### PR TITLE
feat: deploy simulated DynamoDB tables from AWS::DynamoDB::GlobalTable

### DIFF
--- a/docs/services/cloudformation/README.md
+++ b/docs/services/cloudformation/README.md
@@ -1366,7 +1366,7 @@ The resource types it creates are:
 - `AWS::CloudFront::Distribution` and `AWS::CloudFront::Function`
 - `AWS::Cognito::UserPool`, `AWS::Cognito::UserPoolClient` and
   `AWS::Cognito::UserPoolGroup`
-- `AWS::DynamoDB::Table`
+- `AWS::DynamoDB::Table` and `AWS::DynamoDB::GlobalTable`
 - `AWS::IAM::Role`, `AWS::IAM::ManagedPolicy` and `AWS::IAM::Policy`
 - `AWS::KMS::Key` and `AWS::KMS::Alias`
 - `AWS::Lambda::Function`, `AWS::Lambda::Url` and `AWS::Lambda::Permission`

--- a/docs/services/dynamodb/README.md
+++ b/docs/services/dynamodb/README.md
@@ -3038,8 +3038,8 @@ property, and the rest of the stack still deploys: `KinesisStreamSpecification`,
 `ResourcePolicy`, `OnDemandThroughput` and `WarmThroughput`. A property `AWS::DynamoDB::Table` does
 not have fails the resource instead, since that is a template real CloudFormation would refuse too.
 
-`AWS::DynamoDB::GlobalTable` is skipped rather than deployed, since replication across regions is
-not simulated.
+`AWS::DynamoDB::GlobalTable` deploys a table as well, under
+[deploying a global table](#deploying-a-global-table-from-cloudformation).
 
 CDK works without hand-editing. A `dynamodb.Table` synthesises a template that deploys here, with
 the table name reaching a function through its environment and a grant policy naming the table by
@@ -3254,6 +3254,104 @@ Changing `StreamViewType` in a deployed template is a different thing here to wh
 CloudFormation, which replaces the table. `UpdateTable` refuses the change in place, so switching the
 stream off and on again is what gives a table a stream with a different view type.
 
+## Deploying a global table from CloudFormation
+
+An `AWS::DynamoDB::GlobalTable` naming one replica deploys an ordinary simulated table in that
+region, because with one replica that is what it is. It is turned into the `AWS::DynamoDB::Table` it
+is and created down the path above, so it is the same table with the same rules behind it.
+
+That is the resource CDK's `TableV2` synthesises for every table it makes, whether or not any
+replica regions were asked for, since it always appends the stack's own region. So a `TableV2` stack
+deploys here without hand-editing, the same way a `dynamodb.Table` one does.
+
+```typescript sim-dynamodb-cloudformation-global-table
+/**
+ * Deploying a global table with one replica from a CloudFormation template.
+ */
+
+import { PutItemCommand } from "@aws-sdk/client-dynamodb";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "orders-stack",
+  template: {
+    Resources: {
+      OrdersTable: {
+        Type: "AWS::DynamoDB::GlobalTable",
+        Properties: {
+          TableName: "orders",
+          KeySchema: [{ AttributeName: "id", KeyType: "HASH" }],
+          AttributeDefinitions: [{ AttributeName: "id", AttributeType: "S" }],
+          BillingMode: "PAY_PER_REQUEST",
+          // The replica carries what an ordinary table says about itself.
+          Replicas: [
+            {
+              Region: "us-east-1",
+              Tags: [{ Key: "Environment", Value: "test" }],
+            },
+          ],
+        },
+      },
+    },
+    Outputs: {
+      OrdersTableName: { Value: { Ref: "OrdersTable" } },
+    },
+  },
+});
+
+await stack.waitForDeployComplete();
+await simAws.backgroundTasksComplete();
+
+const tableName = stack.outputs.get("OrdersTableName")?.value as string;
+
+console.log(tableName);
+// "orders"
+
+await simAws
+  .dynamoDb()
+  .putItem(
+    new PutItemCommand({ TableName: tableName, Item: { id: { S: "1" } } }),
+  );
+```
+
+`Ref` gives the table name, as it does for `AWS::DynamoDB::Table`. `Fn::GetAtt` answers for `Arn`,
+`StreamArn` and `TableId`, which are the attributes the resource type documents. `TableId` is the
+one an ordinary table has no attribute for at all.
+
+The replica carries the settings an ordinary table carries itself: `TableClass`,
+`DeletionProtectionEnabled` and `Tags` are read off it rather than off the table. Everything else a
+global table states the same way an ordinary one does — `TableName`, `KeySchema`,
+`AttributeDefinitions`, `BillingMode`, `LocalSecondaryIndexes`, `StreamSpecification` and
+`TimeToLiveSpecification` — is handed on as it was written.
+
+Capacity is the one thing a global table splits in two. Writes are the table's, in
+`WriteProvisionedThroughputSettings`, since every replica takes the same writes, and reads belong to
+the replica, in `ReadProvisionedThroughputSettings`. With one replica there is one of each, and they
+go back together into the `ProvisionedThroughput` `CreateTable` takes. A global secondary index is
+split the same way: the table declares the index and provisions its writes, and the replica's
+`GlobalSecondaryIndexes` entry names that index and provisions its reads.
+
+A global table naming two or more replica regions is skipped, with a reason naming the regions, and
+the rest of the stack still deploys. Replication genuinely is not simulated, so drawing the line at
+the replica count puts it where the behaviour actually differs.
+
+A global table with no `Replicas` at all fails the resource, since `Replicas` is required and real
+CloudFormation refuses that template too. So does one whose single replica names a region the stack
+is not deploying into, since the replica list has to include the region the table would be created
+in.
+
+A property with behaviour that is not simulated skips the resource, in the same terms an
+`AWS::DynamoDB::Table` one does: `MultiRegionConsistency`, `SSESpecification`, `WarmThroughput` and
+`WriteOnDemandThroughputSettings` on the table, and `PointInTimeRecoverySpecification`,
+`KinesisStreamSpecification`, `ContributorInsightsSpecification`, `ResourcePolicy`,
+`SSESpecification` and `ReadOnDemandThroughputSettings` on the replica. Capacity that scales with
+load — `WriteCapacityAutoScalingSettings` and `ReadCapacityAutoScalingSettings` — skips the resource
+too, since nothing here scales it. A property `AWS::DynamoDB::GlobalTable` does not have fails the
+resource instead.
+
 ## IAM authorization
 
 `CreateTable` authorizes `dynamodb:CreateTable` against the ARN the table is about to have, before
@@ -3342,6 +3440,12 @@ nothing is written.
   expires items, `Tags` deploying a tagged table, `GlobalSecondaryIndexes` and
   `LocalSecondaryIndexes` deploying a table whose indexes are then queried and scanned, and
   `StreamSpecification` deploying a table with a stream that `Fn::GetAtt … StreamArn` names.
+- `AWS::DynamoDB::GlobalTable` in CloudFormation, where one replica deploys the same table the
+  `AWS::DynamoDB::Table` path does, with the replica's `TableClass`, `DeletionProtectionEnabled` and
+  `Tags` read off it, the table's writes and the replica's reads put back together into one
+  provisioned capacity for the table and for each global secondary index, and `Ref`, `Fn::GetAtt …
+Arn`, `Fn::GetAtt … StreamArn` and `Fn::GetAtt … TableId` answering. A CDK `TableV2` stack deploys
+  through it without hand-editing.
 - SDK interception, so an intercepted `DynamoDBClient` or `DynamoDBStreamsClient` reaches the
   simulation.
 - The `@aws-sdk/lib-dynamodb` document client, with `PutCommand`, `GetCommand`, `DeleteCommand`,
@@ -3435,6 +3539,15 @@ nothing is written.
   the outcome does not.
 - Changing a deployed table's `StreamViewType` is not the table replacement real CloudFormation
   performs. The change goes through `UpdateTable`, which refuses a view type change in place.
+- An `AWS::DynamoDB::GlobalTable` naming two or more replica regions is skipped rather than
+  deployed. Replication between regions is not simulated at all, so there is no half of it to give:
+  a table in one of the regions would answer reads the other regions were meant to serve, and
+  nothing would carry a write from one to the other.
+- A global table's per-replica settings cannot differ from the primary's, because there is only ever
+  one replica. Anything a second replica would have said differently is not reachable.
+- `WriteCapacityAutoScalingSettings` and `ReadCapacityAutoScalingSettings` skip the resource rather
+  than being read as the capacity the table would start at. Nothing here scales capacity, and a
+  capacity nothing enforces would still be a number a template asked for and did not get.
 - A shard iterator never expires. Real DynamoDB gives one 15 minutes and then answers
   `ExpiredIteratorException`, which a consumer handles by asking for another from the sequence
   number it last checkpointed. Nothing here refuses an iterator for being old.

--- a/docs/services/dynamodb/sim-dynamodb-cloudformation-global-table.example.ts
+++ b/docs/services/dynamodb/sim-dynamodb-cloudformation-global-table.example.ts
@@ -1,0 +1,50 @@
+/**
+ * Deploying a global table with one replica from a CloudFormation template.
+ */
+
+import { PutItemCommand } from "@aws-sdk/client-dynamodb";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "orders-stack",
+  template: {
+    Resources: {
+      OrdersTable: {
+        Type: "AWS::DynamoDB::GlobalTable",
+        Properties: {
+          TableName: "orders",
+          KeySchema: [{ AttributeName: "id", KeyType: "HASH" }],
+          AttributeDefinitions: [{ AttributeName: "id", AttributeType: "S" }],
+          BillingMode: "PAY_PER_REQUEST",
+          // The replica carries what an ordinary table says about itself.
+          Replicas: [
+            {
+              Region: "us-east-1",
+              Tags: [{ Key: "Environment", Value: "test" }],
+            },
+          ],
+        },
+      },
+    },
+    Outputs: {
+      OrdersTableName: { Value: { Ref: "OrdersTable" } },
+    },
+  },
+});
+
+await stack.waitForDeployComplete();
+await simAws.backgroundTasksComplete();
+
+const tableName = stack.outputs.get("OrdersTableName")?.value as string;
+
+console.log(tableName);
+// "orders"
+
+await simAws
+  .dynamoDb()
+  .putItem(
+    new PutItemCommand({ TableName: tableName, Item: { id: { S: "1" } } }),
+  );

--- a/src/service/cloudformation/cdk/dynamodb/sim-cdk-dynamodb-table-v2.loc.test.ts
+++ b/src/service/cloudformation/cdk/dynamodb/sim-cdk-dynamodb-table-v2.loc.test.ts
@@ -1,0 +1,140 @@
+import {
+  DescribeTableCommand,
+  GetItemCommand,
+  ListTagsOfResourceCommand,
+  PutItemCommand,
+} from "@aws-sdk/client-dynamodb";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertObjectEquals,
+  assertStringStartsWith,
+  assertTypeString,
+} from "@kensio/smartass";
+import path from "node:path";
+import { describe, it } from "vitest";
+
+/**
+ * Slower local integration test. Calls the real CDK CLI to synth the output
+ * template file to pass to sim CloudFormation, so the template under test is
+ * one CDK actually produced rather than one written by hand.
+ */
+import { SimAws } from "../../../aws/sim-aws.js";
+import type { SimAwsAccountId } from "../../../aws/sim-aws-account.js";
+import { TestCdkProject } from "../../../../util/filesystem/test-cdk-project.js";
+
+const accountIdOneOnes = "111111111111" as SimAwsAccountId;
+
+describe("Sim CDK DynamoDB TableV2 deployment local integration", () => {
+  it("deploys a CDK TableV2 an SDK caller then writes to and reads from", async () => {
+    // Given a CDK stack with an unnamed on-demand TableV2 with a partition and
+    // a sort key, no replicas asked for, and a tag applied to everything in
+    // the stack. TableV2 synthesises AWS::DynamoDB::GlobalTable whatever it is
+    // given, with the stack's own region as its one replica.
+    const cdkProject = new TestCdkProject();
+    await cdkProject.writeCdkAppFile(
+      `
+import * as cdk from "aws-cdk-lib/core";
+import * as dynamodb from "aws-cdk-lib/aws-dynamodb";
+
+const app = new cdk.App();
+const stack = new cdk.Stack(app, "TestStack", {
+  env: { account: "111111111111", region: "eu-west-2" },
+});
+
+const ordersTable = new dynamodb.TableV2(stack, "OrdersTable", {
+  partitionKey: { name: "customerId", type: dynamodb.AttributeType.STRING },
+  sortKey: { name: "orderId", type: dynamodb.AttributeType.STRING },
+});
+
+cdk.Tags.of(stack).add("Environment", "test");
+
+new cdk.CfnOutput(stack, "OrdersTableName", {
+  value: ordersTable.tableName,
+});
+
+new cdk.CfnOutput(stack, "OrdersTableArn", {
+  value: ordersTable.tableArn,
+});
+
+app.synth();
+      `,
+    );
+
+    // And we synth the CDK template.
+    const cdkOutDirectory = await cdkProject.synth();
+
+    // When we deploy the synthesized template into the account and region the
+    // CDK app declares, with no hand-editing of the
+    // AWS::DynamoDB::GlobalTable Resource CDK emits.
+    const simAws = new SimAws();
+    const scoped = simAws.account(accountIdOneOnes).region("eu-west-2");
+    const stack = await scoped
+      .cloudFormation()
+      .deployTemplateFile(
+        path.join(cdkOutDirectory, "TestStack.template.json"),
+      );
+    await simAws.backgroundTasksComplete();
+
+    // Then the table name the CDK output carries is the deployed table, named
+    // after the stack and the logical ID because the template did not name it.
+    const tableName = stack.outputs.get("OrdersTableName")?.value;
+    assertTypeString(tableName);
+    assertStringStartsWith(tableName, "TestStack-OrdersTable");
+
+    const described = await scoped
+      .dynamoDb()
+      .describeTable(new DescribeTableCommand({ TableName: tableName }));
+
+    assertNonNullable(described.Table);
+    assertNonNullable(described.Table.KeySchema);
+    assertIdentical(described.Table.TableStatus, "ACTIVE");
+    assertIdentical(
+      described.Table.BillingModeSummary?.BillingMode,
+      "PAY_PER_REQUEST",
+    );
+    assertIdentical(
+      described.Table.KeySchema.at(0)?.AttributeName,
+      "customerId",
+    );
+    assertIdentical(described.Table.KeySchema.at(1)?.AttributeName, "orderId");
+    assertIdentical(
+      stack.outputs.get("OrdersTableArn")?.value,
+      described.Table.TableArn,
+    );
+
+    // And the tag the stack applied is on the table, which CDK puts on the
+    // replica rather than on the table itself for a TableV2.
+    const tags = await scoped.dynamoDb().listTagsOfResource(
+      new ListTagsOfResourceCommand({
+        ResourceArn: described.Table.TableArn,
+      }),
+    );
+    assertArrayLength(tags.Tags, 1);
+    assertObjectEquals(tags.Tags[0], { Key: "Environment", Value: "test" });
+
+    // And an item written to it reads back off it.
+    await scoped.dynamoDb().putItem(
+      new PutItemCommand({
+        TableName: tableName,
+        Item: {
+          customerId: { S: "customer-1" },
+          orderId: { S: "order-1" },
+          total: { N: "42.5" },
+        },
+      }),
+    );
+
+    const read = await scoped.dynamoDb().getItem(
+      new GetItemCommand({
+        TableName: tableName,
+        Key: { customerId: { S: "customer-1" }, orderId: { S: "order-1" } },
+      }),
+    );
+
+    assertIdentical(read.Item?.["total"]?.N, "42.5");
+
+    await simAws.backgroundTasksComplete();
+  });
+});

--- a/src/service/cloudformation/resource/cfn/dynamodb/sim-dynamodb-cfn-value-adapter.ts
+++ b/src/service/cloudformation/resource/cfn/dynamodb/sim-dynamodb-cfn-value-adapter.ts
@@ -1,3 +1,7 @@
+import {
+  dynamoDbGlobalTableResourceTypeName,
+  dynamoDbTableResourceTypeName,
+} from "../../../../dynamodb/cfn/sim-cfn-dynamodb-resource-type.js";
 import { SimDynamoDbTable } from "../../../../dynamodb/table/sim-dynamodb-table.js";
 import type {
   SimCfnResourceValueAdapterProperties,
@@ -6,16 +10,34 @@ import type {
 import { SimDynamoDbTableCfn } from "./sim-dynamodb-table-cfn.js";
 
 /**
+ * The Resource types that deploy a simulated table.
+ */
+const tableResourceTypeNames: ReadonlySet<string> = new Set([
+  dynamoDbTableResourceTypeName,
+  dynamoDbGlobalTableResourceTypeName,
+]);
+
+/**
  * The CloudFormation-facing value adapter for a simulated DynamoDB Resource.
+ *
+ * A global table with one replica deploys the same simulated table an ordinary
+ * one does, so both Resource types answer through the same adapter, which is
+ * told which of them it is speaking for.
  */
 export function dynamoDbValueAdapter(
   properties: SimCfnResourceValueAdapterProperties,
 ): SimCfnServiceValueAdapter {
+  const { type } = properties;
+
   if (
-    properties.type === "AWS::DynamoDB::Table" &&
+    type !== undefined &&
+    tableResourceTypeNames.has(type) &&
     properties.simResource instanceof SimDynamoDbTable
   ) {
-    return new SimDynamoDbTableCfn({ table: properties.simResource });
+    return new SimDynamoDbTableCfn({
+      table: properties.simResource,
+      resourceTypeName: type,
+    });
   }
 
   return undefined;

--- a/src/service/cloudformation/resource/cfn/dynamodb/sim-dynamodb-table-cfn.iso.test.ts
+++ b/src/service/cloudformation/resource/cfn/dynamodb/sim-dynamodb-table-cfn.iso.test.ts
@@ -88,6 +88,31 @@ describe("AWS::DynamoDB::Table CloudFormation values", () => {
     );
   });
 
+  it("refuses Fn::GetAtt TableId, which only a global table has", async () => {
+    // Given a template asking an ordinary table for the attribute
+    // AWS::DynamoDB::GlobalTable documents and AWS::DynamoDB::Table does not.
+    const simAws = new SimAws({
+      defaultAccountId: accountIdOneOnes,
+      defaultRegionName: "eu-west-2",
+    });
+
+    // When the template is deployed, then it is refused as the unknown
+    // attribute it is on this Resource type.
+    const error = await assertThrowsErrorAsync(async () => {
+      const stack = await simAws.cloudFormation().deployTemplate({
+        stackName: "orders-stack",
+        template: tableAttributeTemplate("TableId"),
+      });
+
+      await stack.waitForDeployComplete();
+    });
+
+    assertStringIncludes(
+      error.message,
+      "Unsupported AWS::DynamoDB::Table attribute TableId",
+    );
+  });
+
   it("answers a Ref for a table another Resource depends on", async () => {
     // Given a template handing the table name to a Lambda function through its
     // environment, which is what a Ref is for.

--- a/src/service/cloudformation/resource/cfn/dynamodb/sim-dynamodb-table-cfn.ts
+++ b/src/service/cloudformation/resource/cfn/dynamodb/sim-dynamodb-table-cfn.ts
@@ -1,9 +1,17 @@
+import { dynamoDbGlobalTableResourceTypeName } from "../../../../dynamodb/cfn/sim-cfn-dynamodb-resource-type.js";
 import type { SimDynamoDbTable } from "../../../../dynamodb/table/sim-dynamodb-table.js";
 import type { SimCfnTemplateValue } from "../../../template/value/sim-cfn-template-value.js";
 import type { SimCfnResourceValueAdapter } from "../sim-cfn-resource-value-adapter.js";
 
 interface SimDynamoDbTableCfnProperties {
   readonly table: SimDynamoDbTable;
+
+  /**
+   * Which of the two Resource types that make a table this is answering for,
+   * since they document different attributes and a refusal names the type the
+   * template asked through.
+   */
+  readonly resourceTypeName: string;
 }
 
 /**
@@ -11,14 +19,16 @@ interface SimDynamoDbTableCfnProperties {
  */
 export class SimDynamoDbTableCfn implements SimCfnResourceValueAdapter {
   private readonly table: SimDynamoDbTable;
+  private readonly resourceTypeName: string;
 
   constructor(properties: SimDynamoDbTableCfnProperties) {
     this.table = properties.table;
+    this.resourceTypeName = properties.resourceTypeName;
   }
 
   /**
-   * AWS::DynamoDB::Table Ref returns the table name rather than its ARN, which
-   * is what makes a Ref usable as a PutItem TableName. It is also what a
+   * Both Resource types answer a Ref with the table name rather than its ARN,
+   * which is what makes a Ref usable as a PutItem TableName. It is also what a
    * template hands a function through its environment.
    */
   refValue(): SimCfnTemplateValue {
@@ -26,10 +36,12 @@ export class SimDynamoDbTableCfn implements SimCfnResourceValueAdapter {
   }
 
   /**
-   * AWS::DynamoDB::Table attributes.
+   * The attributes a table Resource documents.
    *
    * `Arn` is what an IAM policy names the table by. `StreamArn` is the ARN of
-   * the stream the table's `StreamSpecification` gave it.
+   * the stream the table's `StreamSpecification` gave it. `TableId` is the
+   * table's unique ID, which only AWS::DynamoDB::GlobalTable has an attribute
+   * for.
    */
   attributeValue(attributeName: string): SimCfnTemplateValue {
     switch (attributeName) {
@@ -39,10 +51,11 @@ export class SimDynamoDbTableCfn implements SimCfnResourceValueAdapter {
       case "StreamArn": {
         return this.streamArn();
       }
+      case "TableId": {
+        return this.tableId();
+      }
       default: {
-        throw new Error(
-          `Unsupported AWS::DynamoDB::Table attribute ${attributeName}`,
-        );
+        throw this.unsupported(attributeName);
       }
     }
   }
@@ -60,12 +73,31 @@ export class SimDynamoDbTableCfn implements SimCfnResourceValueAdapter {
 
     if (arn === undefined) {
       throw new Error(
-        `Unsupported AWS::DynamoDB::Table attribute StreamArn: table ` +
+        `Unsupported ${this.resourceTypeName} attribute StreamArn: table ` +
           `${this.table.tableName} has no StreamSpecification, so it has no ` +
           `stream and no stream ARN`,
       );
     }
 
     return arn;
+  }
+
+  /**
+   * The table's unique ID, which AWS::DynamoDB::Table has no attribute for at
+   * all, so asking an ordinary table for one is refused as the unknown
+   * attribute it is.
+   */
+  private tableId(): SimCfnTemplateValue {
+    if (this.resourceTypeName !== dynamoDbGlobalTableResourceTypeName) {
+      throw this.unsupported("TableId");
+    }
+
+    return this.table.tableId;
+  }
+
+  private unsupported(attributeName: string): Error {
+    return new Error(
+      `Unsupported ${this.resourceTypeName} attribute ${attributeName}`,
+    );
   }
 }

--- a/src/service/dynamodb/README.md
+++ b/src/service/dynamodb/README.md
@@ -932,24 +932,30 @@ answers with a one element list.
 orchestrates and services create.
 
 `SimDynamoDbCfnResourceFactory` is the entry point, resolved into the CloudFormation engine by
-`sim-cfn-service-resolver.ts`. `Table` is the only resource type it creates. Anything else, including
-`GlobalTable`, throws an `Unsupported sim DynamoDB CloudFormation Resource` error, which is the
-wording that marks a resource as skipped rather than failing the stack.
+`sim-cfn-service-resolver.ts`. `Table` and `GlobalTable` are the resource types it creates, and both
+make a table. Anything else throws an `Unsupported sim DynamoDB CloudFormation Resource` error,
+which is the wording that marks a resource as skipped rather than failing the stack.
+
+The parts under `cfn/property/` are what the two resource types share:
+
+- `SimCfnDynamoDbPropertyValues` reads the plain shapes a property can hold, naming the property path
+  in each refusal. It takes a number from the string a template Parameter carries one as. It carries
+  the resource type it is reading for, since the two types name the same table differently and a
+  refusal that named the wrong one would send whoever reads it to the wrong documentation.
+- `SimCfnDynamoDbPropertyRules` decides what a property means, at whatever level a template nests. A
+  simulated property is passed on, a real property that is not simulated skips the resource with a
+  reason naming it, and anything that is not a property of that object at all fails the resource,
+  because that is a template real CloudFormation would refuse too. Each level differs only in which
+  names belong to it, so a level is a pair of name sets rather than a rule of its own.
 
 The parts under `cfn/table/` split by responsibility:
 
-- `SimCfnDynamoDbTablePropertyRules` decides what a property means. A simulated property is passed
-  on, a real property that is not simulated skips the resource with a reason naming it, and anything
-  that is not an `AWS::DynamoDB::Table` property at all fails the resource, because that is a
-  template real CloudFormation would refuse too.
-- `SimCfnDynamoDbTableIndexRules` applies the same rule a level down, to the entries of
-  `GlobalSecondaryIndexes` and `LocalSecondaryIndexes`. The two kinds have different property sets:
-  a local secondary index has no throughput or insights settings on AWS either, so anything of the
-  sort on one fails the resource rather than skipping it.
-- `SimCfnDynamoDbTableStreamRules` applies the same rule to the `StreamSpecification`, whose nested
+- `SimCfnDynamoDbTablePropertyRules` holds the `AWS::DynamoDB::Table` name sets, and applies them to
+  the resource's own properties and then a level down to the entries of `GlobalSecondaryIndexes` and
+  `LocalSecondaryIndexes` and to the `StreamSpecification`. The two index kinds have different
+  property sets: a local secondary index has no throughput or insights settings on AWS either, so
+  anything of the sort on one fails the resource rather than skipping it. The stream's nested
   `ResourcePolicy` is a policy on the stream rather than the table's own.
-- `SimCfnDynamoDbTableValues` reads the plain shapes a property can hold, naming the property path in
-  each refusal. It takes a number from the string a template Parameter carries one as.
 - `SimCfnDynamoDbTableProperties` turns the template properties into `CreateTable` input, and
   generates a name for a table the template did not name, through the shared
   `SimCfnGeneratedResourceName`. The parts several properties share are read by
@@ -972,11 +978,34 @@ dependency-ready batch of resources at once, so a template with two indexed tabl
 than serialised, since serialising would hold up stack timing over a template shape a test is
 unlikely to be about.
 
+The parts under `cfn/global-table/` are the difference between the two resource types, and nothing
+else. `SimCfnDynamoDbGlobalTableProperties` reads an `AWS::DynamoDB::GlobalTable` into the
+`AWS::DynamoDB::Table` properties it is, and `SimCfnDynamoDbGlobalTableCreator` hands those to
+`SimCfnDynamoDbTableCreator`, so a global table is created by the path an ordinary table already
+takes rather than by a second one:
+
+- `SimCfnDynamoDbGlobalTableReplicas` settles the replica before anything else is read. One replica
+  is an ordinary table in that region, which is what CDK's `TableV2` synthesises for every table it
+  makes. Two or more is a table that replicates, which is not simulated, so it skips the resource
+  with a reason naming the regions. None fails it, as does one naming a region the stack is not
+  deploying into, since real CloudFormation refuses both templates too. The line is at the replica
+  count rather than at the resource type because that is where the behaviour actually differs.
+- The property name sets are in `sim-cfn-dynamodb-global-table-property-rules.ts` and
+  `sim-cfn-dynamodb-global-table-replica-rules.ts`, one pair per level a global table nests.
+- `simCfnDynamoDbGlobalTableProperty` hands on the properties a global table states exactly as an
+  ordinary table does, in the shape the template wrote them, which is what keeps the rules deciding
+  what they are allowed to be in one place.
+- `simCfnDynamoDbGlobalTableCapacity` puts back together the capacity a global table splits between
+  the table's writes and the replica's reads. `simCfnDynamoDbGlobalTableIndexes` does the same for
+  each global secondary index, matching the replica's per-index entry to the index it names.
+
 `Ref` and `Fn::GetAtt` behaviour lives with the CloudFormation engine rather than on the table, in
-`SimDynamoDbTableCfn` under `cloudformation/resource/cfn/dynamodb/`. `Ref` answers with the table
-name and `Fn::GetAtt Arn` with the table ARN. `StreamArn` answers with the ARN of the stream the
-table's `StreamSpecification` gave it, and is refused by name on a table with no stream, since an
-invented stream ARN would read as a working stream.
+`SimDynamoDbTableCfn` under `cloudformation/resource/cfn/dynamodb/`, which answers for both resource
+types and is told which of them it is speaking for. `Ref` answers with the table name and
+`Fn::GetAtt Arn` with the table ARN. `StreamArn` answers with the ARN of the stream the table's
+`StreamSpecification` gave it, and is refused by name on a table with no stream, since an invented
+stream ARN would read as a working stream. `TableId` answers only for a global table, since that is
+the only one of the two with an attribute for it.
 
 ## Error model
 

--- a/src/service/dynamodb/cfn/global-table/sim-cfn-dynamodb-global-table-capacity.ts
+++ b/src/service/dynamodb/cfn/global-table/sim-cfn-dynamodb-global-table-capacity.ts
@@ -1,0 +1,44 @@
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimCfnDynamoDbPropertyValues } from "../property/sim-cfn-dynamodb-property-values.js";
+import { simCfnDynamoDbGlobalTableEntry } from "./sim-cfn-dynamodb-global-table-property.js";
+
+interface SimCfnDynamoDbGlobalTableCapacitySources {
+  readonly read: SimCfnDynamoDbPropertyValues | undefined;
+  readonly write: SimCfnDynamoDbPropertyValues | undefined;
+}
+
+/**
+ * The `ProvisionedThroughput` a global table's two capacity settings add up to.
+ *
+ * A global table splits the capacity an ordinary table states in one place:
+ * writes are the table's, since every replica takes the same writes, and reads
+ * belong to the replica doing them. One replica is one of each, so the two go
+ * back together into the property CreateTable takes.
+ *
+ * Each half is read here rather than passed through, so a capacity the template
+ * wrote as something other than a number is refused at the path a global table
+ * puts it at rather than at the one an ordinary table would have.
+ *
+ * A table that states neither half has no `ProvisionedThroughput` at all, which
+ * is what an on-demand table looks like. A table stating one of them keeps the
+ * gap, so CreateTable refuses it in its own words rather than being handed a
+ * capacity nothing asked for.
+ */
+export function simCfnDynamoDbGlobalTableCapacity(
+  sources: SimCfnDynamoDbGlobalTableCapacitySources,
+): SimCfnTemplateValueRecord | undefined {
+  if (sources.read === undefined && sources.write === undefined) {
+    return undefined;
+  }
+
+  return Object.fromEntries([
+    ...simCfnDynamoDbGlobalTableEntry(
+      "ReadCapacityUnits",
+      sources.read?.number("ReadCapacityUnits"),
+    ),
+    ...simCfnDynamoDbGlobalTableEntry(
+      "WriteCapacityUnits",
+      sources.write?.number("WriteCapacityUnits"),
+    ),
+  ]);
+}

--- a/src/service/dynamodb/cfn/global-table/sim-cfn-dynamodb-global-table-creator.ts
+++ b/src/service/dynamodb/cfn/global-table/sim-cfn-dynamodb-global-table-creator.ts
@@ -1,0 +1,44 @@
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimDynamoDbTable } from "../../table/sim-dynamodb-table.js";
+import type { SimCfnDynamoDbTableCreator } from "../table/sim-cfn-dynamodb-table-creator.js";
+import { SimCfnDynamoDbGlobalTableProperties } from "./sim-cfn-dynamodb-global-table-properties.js";
+
+interface SimCfnDynamoDbGlobalTableCreatorProperties {
+  readonly tableCreator: SimCfnDynamoDbTableCreator;
+}
+
+/**
+ * Creates simulated tables from AWS::DynamoDB::GlobalTable Resources.
+ *
+ * A global table naming one replica is turned into the AWS::DynamoDB::Table it
+ * is and created down the path an ordinary table already takes, so the table a
+ * `TableV2` stack deployed is the same thing a `Table` stack would have got:
+ * the same name generation, the same CreateTable rules, the same refusals for
+ * what this simulation does not model.
+ */
+export class SimCfnDynamoDbGlobalTableCreator {
+  private readonly tableCreator: SimCfnDynamoDbTableCreator;
+
+  constructor(properties: SimCfnDynamoDbGlobalTableCreatorProperties) {
+    this.tableCreator = properties.tableCreator;
+  }
+
+  /**
+   * Create a table from an AWS::DynamoDB::GlobalTable Resource.
+   */
+  async create(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): Promise<SimDynamoDbTable> {
+    const globalTable = new SimCfnDynamoDbGlobalTableProperties({
+      resource,
+      properties,
+    });
+
+    return await this.tableCreator.create(
+      resource,
+      globalTable.tableProperties(),
+    );
+  }
+}

--- a/src/service/dynamodb/cfn/global-table/sim-cfn-dynamodb-global-table-indexes.ts
+++ b/src/service/dynamodb/cfn/global-table/sim-cfn-dynamodb-global-table-indexes.ts
@@ -1,0 +1,97 @@
+import type {
+  SimCfnTemplateValue,
+  SimCfnTemplateValueRecord,
+} from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimCfnDynamoDbPropertyValues } from "../property/sim-cfn-dynamodb-property-values.js";
+import { simCfnDynamoDbGlobalTableCapacity } from "./sim-cfn-dynamodb-global-table-capacity.js";
+import {
+  type SimCfnDynamoDbGlobalTableEntry,
+  simCfnDynamoDbGlobalTableEntry,
+  simCfnDynamoDbGlobalTableProperty,
+} from "./sim-cfn-dynamodb-global-table-property.js";
+
+/**
+ * The `GlobalSecondaryIndexes` an AWS::DynamoDB::Table would carry, built from
+ * the two halves a global table splits each index into.
+ *
+ * The table names the index and what it projects, and provisions its writes.
+ * The replica provisions its reads, naming the index it is talking about rather
+ * than restating it. Putting them back together is what makes an index on a
+ * global table the index an ordinary table's template would have declared.
+ *
+ * A table declaring the property at all keeps it, even holding no indexes, so
+ * an empty list stays an empty list rather than becoming a table that never
+ * mentioned indexes.
+ */
+export function simCfnDynamoDbGlobalTableIndexes(
+  values: SimCfnDynamoDbPropertyValues,
+  replica: SimCfnDynamoDbPropertyValues,
+): SimCfnTemplateValue | undefined {
+  if (values.value("GlobalSecondaryIndexes") === undefined) {
+    return undefined;
+  }
+
+  const readSettings = replicaReadSettings(replica);
+
+  return values.list("GlobalSecondaryIndexes").map((index) => {
+    const indexName = index.string("IndexName");
+
+    return tableIndex(
+      index,
+      indexName === undefined ? undefined : readSettings.get(indexName),
+    );
+  });
+}
+
+/**
+ * One index, as the table declared it and the replica provisioned it.
+ */
+function tableIndex(
+  index: SimCfnDynamoDbPropertyValues,
+  replicaIndex: SimCfnDynamoDbPropertyValues | undefined,
+): SimCfnTemplateValueRecord {
+  return Object.fromEntries([
+    ...simCfnDynamoDbGlobalTableProperty(index, [
+      "IndexName",
+      "KeySchema",
+      "Projection",
+    ]),
+    ...namedCapacity(index, replicaIndex),
+  ]);
+}
+
+/**
+ * The `ProvisionedThroughput` entry an index gets, where either half of its
+ * capacity was stated.
+ */
+function namedCapacity(
+  index: SimCfnDynamoDbPropertyValues,
+  replicaIndex: SimCfnDynamoDbPropertyValues | undefined,
+): readonly SimCfnDynamoDbGlobalTableEntry[] {
+  return simCfnDynamoDbGlobalTableEntry(
+    "ProvisionedThroughput",
+    simCfnDynamoDbGlobalTableCapacity({
+      read: replicaIndex?.object("ReadProvisionedThroughputSettings"),
+      write: index.object("WriteProvisionedThroughputSettings"),
+    }),
+  );
+}
+
+/**
+ * The replica's per-index read settings, by the index they name.
+ *
+ * An entry naming no index is left out rather than matched to something, since
+ * there is nothing it could be about. CreateTable is where an index with no
+ * name is refused.
+ */
+function replicaReadSettings(
+  replica: SimCfnDynamoDbPropertyValues,
+): ReadonlyMap<string, SimCfnDynamoDbPropertyValues> {
+  return new Map(
+    replica.list("GlobalSecondaryIndexes").flatMap((index) => {
+      const indexName = index.string("IndexName");
+
+      return indexName === undefined ? [] : [[indexName, index] as const];
+    }),
+  );
+}

--- a/src/service/dynamodb/cfn/global-table/sim-cfn-dynamodb-global-table-properties.ts
+++ b/src/service/dynamodb/cfn/global-table/sim-cfn-dynamodb-global-table-properties.ts
@@ -1,0 +1,108 @@
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import { SimCfnDynamoDbPropertyValues } from "../property/sim-cfn-dynamodb-property-values.js";
+import { dynamoDbGlobalTableResourceTypeName } from "../sim-cfn-dynamodb-resource-type.js";
+import { simCfnDynamoDbGlobalTableCapacity } from "./sim-cfn-dynamodb-global-table-capacity.js";
+import { simCfnDynamoDbGlobalTableIndexes } from "./sim-cfn-dynamodb-global-table-indexes.js";
+import {
+  simCfnDynamoDbGlobalTableEntry,
+  simCfnDynamoDbGlobalTableProperty,
+} from "./sim-cfn-dynamodb-global-table-property.js";
+import { SimCfnDynamoDbGlobalTableReplicas } from "./sim-cfn-dynamodb-global-table-replicas.js";
+import { assertSimCfnDynamoDbGlobalTableSimulated } from "./sim-cfn-dynamodb-global-table-simulated.js";
+
+/**
+ * The properties a global table states the same way an ordinary table does.
+ */
+const tableWordedPropertyNames: readonly string[] = [
+  "AttributeDefinitions",
+  "BillingMode",
+  "KeySchema",
+  "LocalSecondaryIndexes",
+  "StreamSpecification",
+  "TableName",
+  "TimeToLiveSpecification",
+];
+
+/**
+ * The properties a global table puts on its replica and an ordinary table puts
+ * on itself.
+ */
+const replicaWordedPropertyNames: readonly string[] = [
+  "DeletionProtectionEnabled",
+  "TableClass",
+  "Tags",
+];
+
+interface SimCfnDynamoDbGlobalTablePropertiesProperties {
+  readonly resource: SimCfnResource;
+  readonly properties: SimCfnTemplateValueRecord;
+}
+
+/**
+ * Reads an AWS::DynamoDB::GlobalTable Resource into the AWS::DynamoDB::Table
+ * Resource it is.
+ *
+ * A global table with one replica is an ordinary table in that region, so it is
+ * turned into one and deployed down the path an ordinary table already takes.
+ * Nothing about what a key schema, a projection or a billing mode is allowed to
+ * be is decided here: most properties are handed on in the shape the template
+ * wrote them, and CreateTable is where they are checked.
+ *
+ * What is decided here is what a global table says differently. The replica
+ * carries the settings an ordinary table carries itself, capacity is split
+ * between the table's writes and the replica's reads, and there are properties
+ * about replication that have nothing to be true of on one table in one region.
+ */
+export class SimCfnDynamoDbGlobalTableProperties {
+  private readonly logicalId: string;
+  private readonly values: SimCfnDynamoDbPropertyValues;
+  private readonly replicas: SimCfnDynamoDbGlobalTableReplicas;
+
+  constructor(properties: SimCfnDynamoDbGlobalTablePropertiesProperties) {
+    this.logicalId = properties.resource.logicalId;
+    this.values = new SimCfnDynamoDbPropertyValues({
+      resourceTypeName: dynamoDbGlobalTableResourceTypeName,
+      logicalId: this.logicalId,
+      properties: properties.properties,
+    });
+    this.replicas = new SimCfnDynamoDbGlobalTableReplicas({
+      logicalId: this.logicalId,
+      regionName: properties.resource.accountRegionScope.regionName,
+      values: this.values,
+    });
+  }
+
+  /**
+   * The AWS::DynamoDB::Table properties this global table is, refusing
+   * everything about it that is not simulated on the way.
+   *
+   * The replica is settled first, since a table replicating across regions is
+   * skipped whatever else it asks for.
+   */
+  tableProperties(): SimCfnTemplateValueRecord {
+    const replica = this.replicas.single();
+
+    assertSimCfnDynamoDbGlobalTableSimulated({
+      logicalId: this.logicalId,
+      values: this.values,
+      replica,
+    });
+
+    const indexes = simCfnDynamoDbGlobalTableIndexes(this.values, replica);
+    const capacity = simCfnDynamoDbGlobalTableCapacity({
+      read: replica.object("ReadProvisionedThroughputSettings"),
+      write: this.values.object("WriteProvisionedThroughputSettings"),
+    });
+
+    return Object.fromEntries([
+      ...simCfnDynamoDbGlobalTableProperty(
+        this.values,
+        tableWordedPropertyNames,
+      ),
+      ...simCfnDynamoDbGlobalTableProperty(replica, replicaWordedPropertyNames),
+      ...simCfnDynamoDbGlobalTableEntry("GlobalSecondaryIndexes", indexes),
+      ...simCfnDynamoDbGlobalTableEntry("ProvisionedThroughput", capacity),
+    ]);
+  }
+}

--- a/src/service/dynamodb/cfn/global-table/sim-cfn-dynamodb-global-table-property-rules.ts
+++ b/src/service/dynamodb/cfn/global-table/sim-cfn-dynamodb-global-table-property-rules.ts
@@ -1,0 +1,173 @@
+import { SimCfnDynamoDbPropertyRules } from "../property/sim-cfn-dynamodb-property-rules.js";
+import { dynamoDbGlobalTableResourceTypeName } from "../sim-cfn-dynamodb-resource-type.js";
+
+/**
+ * The AWS::DynamoDB::GlobalTable properties this simulation acts on.
+ *
+ * Everything but `Replicas` is the table itself, and is handed on to the
+ * AWS::DynamoDB::Table path in the shape it already reads. `Replicas` is what
+ * decides whether there is a table here to create at all.
+ */
+const simulatedPropertyNames: ReadonlySet<string> = new Set([
+  "AttributeDefinitions",
+  "BillingMode",
+  "GlobalSecondaryIndexes",
+  "KeySchema",
+  "LocalSecondaryIndexes",
+  "Replicas",
+  "StreamSpecification",
+  "TableName",
+  "TimeToLiveSpecification",
+  "WriteProvisionedThroughputSettings",
+]);
+
+/**
+ * Real AWS::DynamoDB::GlobalTable properties this simulation does not model.
+ *
+ * These are the ones the AWS::DynamoDB::Table path already skips, under the
+ * names a global table gives them, plus `MultiRegionConsistency`, which is a
+ * statement about replication and so has nothing to be true of here.
+ */
+const unsimulatedPropertyNames: ReadonlySet<string> = new Set([
+  "MultiRegionConsistency",
+  "SSESpecification",
+  "WarmThroughput",
+  "WriteOnDemandThroughputSettings",
+]);
+
+/**
+ * The GlobalSecondaryIndex properties a global table's own index carries.
+ *
+ * A global table splits an index's capacity in two: the write capacity is the
+ * table's, since every replica takes the same writes, and the read capacity
+ * belongs to each replica. This is the writing half.
+ */
+const simulatedIndexPropertyNames: ReadonlySet<string> = new Set([
+  "IndexName",
+  "KeySchema",
+  "Projection",
+  "WriteProvisionedThroughputSettings",
+]);
+
+/**
+ * Real GlobalSecondaryIndex properties of a global table this simulation does
+ * not model.
+ */
+const unsimulatedIndexPropertyNames: ReadonlySet<string> = new Set([
+  "WarmThroughput",
+  "WriteOnDemandThroughputSettings",
+]);
+
+/**
+ * The LocalSecondaryIndex properties, which this simulation models all of.
+ *
+ * A local secondary index reads out of its table's capacity rather than having
+ * any of its own, on a global table as on an ordinary one, so there is nothing
+ * here that is real and unmodelled.
+ */
+const simulatedLocalIndexPropertyNames: ReadonlySet<string> = new Set([
+  "IndexName",
+  "KeySchema",
+  "Projection",
+]);
+
+/**
+ * The StreamSpecification properties of a global table.
+ *
+ * A global table's stream is what replication reads from, so AWS gives it no
+ * `ResourcePolicy` and no choice of view type worth the name. `StreamViewType`
+ * is the whole of it.
+ */
+const simulatedStreamPropertyNames: ReadonlySet<string> = new Set([
+  "StreamViewType",
+]);
+
+/**
+ * The write capacity settings this simulation acts on.
+ *
+ * A fixed `WriteCapacityUnits` is the capacity an ordinary table's
+ * `ProvisionedThroughput` states, so it is carried across.
+ * `WriteCapacityAutoScalingSettings` asks for capacity that changes with load,
+ * which nothing here changes, so it skips the table rather than being read as
+ * the capacity it starts at.
+ */
+const simulatedWriteCapacityPropertyNames: ReadonlySet<string> = new Set([
+  "WriteCapacityUnits",
+]);
+
+const unsimulatedWriteCapacityPropertyNames: ReadonlySet<string> = new Set([
+  "WriteCapacityAutoScalingSettings",
+]);
+
+/**
+ * The rules the Resource's own properties are read under.
+ */
+export function simCfnDynamoDbGlobalTableRules(
+  logicalId: string,
+): SimCfnDynamoDbPropertyRules {
+  return new SimCfnDynamoDbPropertyRules({
+    resourceTypeName: dynamoDbGlobalTableResourceTypeName,
+    logicalId,
+    simulated: simulatedPropertyNames,
+    unsimulated: unsimulatedPropertyNames,
+  });
+}
+
+/**
+ * The rules a `GlobalSecondaryIndexes` entry on the table itself is read under.
+ */
+export function simCfnDynamoDbGlobalTableIndexRules(
+  logicalId: string,
+): SimCfnDynamoDbPropertyRules {
+  return new SimCfnDynamoDbPropertyRules({
+    resourceTypeName: dynamoDbGlobalTableResourceTypeName,
+    logicalId,
+    kind: "GlobalSecondaryIndex",
+    simulated: simulatedIndexPropertyNames,
+    unsimulated: unsimulatedIndexPropertyNames,
+  });
+}
+
+/**
+ * The rules a `LocalSecondaryIndexes` entry is read under.
+ */
+export function simCfnDynamoDbGlobalTableLocalIndexRules(
+  logicalId: string,
+): SimCfnDynamoDbPropertyRules {
+  return new SimCfnDynamoDbPropertyRules({
+    resourceTypeName: dynamoDbGlobalTableResourceTypeName,
+    logicalId,
+    kind: "LocalSecondaryIndex",
+    simulated: simulatedLocalIndexPropertyNames,
+  });
+}
+
+/**
+ * The rules the `StreamSpecification` is read under.
+ */
+export function simCfnDynamoDbGlobalTableStreamRules(
+  logicalId: string,
+): SimCfnDynamoDbPropertyRules {
+  return new SimCfnDynamoDbPropertyRules({
+    resourceTypeName: dynamoDbGlobalTableResourceTypeName,
+    logicalId,
+    kind: "StreamSpecification",
+    simulated: simulatedStreamPropertyNames,
+  });
+}
+
+/**
+ * The rules a `WriteProvisionedThroughputSettings` is read under, on the table
+ * or on one of its global secondary indexes.
+ */
+export function simCfnDynamoDbGlobalTableWriteCapacityRules(
+  logicalId: string,
+): SimCfnDynamoDbPropertyRules {
+  return new SimCfnDynamoDbPropertyRules({
+    resourceTypeName: dynamoDbGlobalTableResourceTypeName,
+    logicalId,
+    kind: "WriteProvisionedThroughputSettings",
+    simulated: simulatedWriteCapacityPropertyNames,
+    unsimulated: unsimulatedWriteCapacityPropertyNames,
+  });
+}

--- a/src/service/dynamodb/cfn/global-table/sim-cfn-dynamodb-global-table-property.ts
+++ b/src/service/dynamodb/cfn/global-table/sim-cfn-dynamodb-global-table-property.ts
@@ -1,0 +1,43 @@
+import type { SimCfnTemplateValue } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimCfnDynamoDbPropertyValues } from "../property/sim-cfn-dynamodb-property-values.js";
+
+/**
+ * One entry of the AWS::DynamoDB::Table properties a global table becomes.
+ */
+export type SimCfnDynamoDbGlobalTableEntry = readonly [
+  string,
+  SimCfnTemplateValue,
+];
+
+/**
+ * The named properties a global table states exactly as an ordinary table
+ * does, in the shape the template wrote them.
+ *
+ * Passing these through untouched is what keeps the rules deciding what a key
+ * schema, a projection or a view type is allowed to be in one place: the
+ * AWS::DynamoDB::Table path they are handed to, and CreateTable beneath it.
+ *
+ * A property the template left out is left out here too, rather than carried
+ * across as nothing, since the two are read differently further down.
+ */
+export function simCfnDynamoDbGlobalTableProperty(
+  values: SimCfnDynamoDbPropertyValues,
+  names: readonly string[],
+): readonly SimCfnDynamoDbGlobalTableEntry[] {
+  return names.flatMap((name) => {
+    return simCfnDynamoDbGlobalTableEntry(name, values.value(name));
+  });
+}
+
+/**
+ * One property of the table being built, where there is one to add.
+ *
+ * A property built from what a global table splits in two is only there when
+ * either half was stated, so the entry it makes comes and goes with it.
+ */
+export function simCfnDynamoDbGlobalTableEntry(
+  name: string,
+  value: SimCfnTemplateValue | undefined,
+): readonly SimCfnDynamoDbGlobalTableEntry[] {
+  return value === undefined ? [] : [[name, value] as const];
+}

--- a/src/service/dynamodb/cfn/global-table/sim-cfn-dynamodb-global-table-replica-rules.ts
+++ b/src/service/dynamodb/cfn/global-table/sim-cfn-dynamodb-global-table-replica-rules.ts
@@ -1,0 +1,112 @@
+import { SimCfnDynamoDbPropertyRules } from "../property/sim-cfn-dynamodb-property-rules.js";
+import { dynamoDbGlobalTableResourceTypeName } from "../sim-cfn-dynamodb-resource-type.js";
+
+/**
+ * The replica properties this simulation acts on.
+ *
+ * A replica is where a global table says the things an ordinary table says
+ * about itself: what it is protected from, what class it is stored in, what it
+ * is tagged with, and what it is provisioned to read.
+ */
+const simulatedReplicaPropertyNames: ReadonlySet<string> = new Set([
+  "DeletionProtectionEnabled",
+  "GlobalSecondaryIndexes",
+  "ReadProvisionedThroughputSettings",
+  "Region",
+  "TableClass",
+  "Tags",
+]);
+
+/**
+ * Real replica properties this simulation does not model.
+ *
+ * These are the same settings the AWS::DynamoDB::Table path skips, in the place
+ * a global table puts them, so a template asking for point in time recovery is
+ * skipped whichever Resource type it asked through.
+ */
+const unsimulatedReplicaPropertyNames: ReadonlySet<string> = new Set([
+  "ContributorInsightsSpecification",
+  "KinesisStreamSpecification",
+  "PointInTimeRecoverySpecification",
+  "ReadOnDemandThroughputSettings",
+  "ResourcePolicy",
+  "SSESpecification",
+]);
+
+/**
+ * The per-replica global secondary index properties this simulation acts on.
+ *
+ * A replica does not restate what an index is, only what it is provisioned to
+ * read, so the entry names the index and its read capacity and nothing else.
+ */
+const simulatedReplicaIndexPropertyNames: ReadonlySet<string> = new Set([
+  "IndexName",
+  "ReadProvisionedThroughputSettings",
+]);
+
+const unsimulatedReplicaIndexPropertyNames: ReadonlySet<string> = new Set([
+  "ContributorInsightsSpecification",
+  "ReadOnDemandThroughputSettings",
+]);
+
+/**
+ * The read capacity settings this simulation acts on.
+ *
+ * A fixed `ReadCapacityUnits` is half of the capacity an ordinary table's
+ * `ProvisionedThroughput` states. `ReadCapacityAutoScalingSettings` asks for
+ * capacity that changes with load, which nothing here changes, so it skips the
+ * table rather than being read as the capacity it starts at.
+ */
+const simulatedReadCapacityPropertyNames: ReadonlySet<string> = new Set([
+  "ReadCapacityUnits",
+]);
+
+const unsimulatedReadCapacityPropertyNames: ReadonlySet<string> = new Set([
+  "ReadCapacityAutoScalingSettings",
+]);
+
+/**
+ * The rules a `Replicas` entry is read under.
+ */
+export function simCfnDynamoDbGlobalTableReplicaRules(
+  logicalId: string,
+): SimCfnDynamoDbPropertyRules {
+  return new SimCfnDynamoDbPropertyRules({
+    resourceTypeName: dynamoDbGlobalTableResourceTypeName,
+    logicalId,
+    kind: "Replica",
+    simulated: simulatedReplicaPropertyNames,
+    unsimulated: unsimulatedReplicaPropertyNames,
+  });
+}
+
+/**
+ * The rules a replica's `GlobalSecondaryIndexes` entry is read under.
+ */
+export function simCfnDynamoDbGlobalTableReplicaIndexRules(
+  logicalId: string,
+): SimCfnDynamoDbPropertyRules {
+  return new SimCfnDynamoDbPropertyRules({
+    resourceTypeName: dynamoDbGlobalTableResourceTypeName,
+    logicalId,
+    kind: "Replica GlobalSecondaryIndex",
+    simulated: simulatedReplicaIndexPropertyNames,
+    unsimulated: unsimulatedReplicaIndexPropertyNames,
+  });
+}
+
+/**
+ * The rules a `ReadProvisionedThroughputSettings` is read under, on the replica
+ * or on one of its global secondary indexes.
+ */
+export function simCfnDynamoDbGlobalTableReadCapacityRules(
+  logicalId: string,
+): SimCfnDynamoDbPropertyRules {
+  return new SimCfnDynamoDbPropertyRules({
+    resourceTypeName: dynamoDbGlobalTableResourceTypeName,
+    logicalId,
+    kind: "ReadProvisionedThroughputSettings",
+    simulated: simulatedReadCapacityPropertyNames,
+    unsimulated: unsimulatedReadCapacityPropertyNames,
+  });
+}

--- a/src/service/dynamodb/cfn/global-table/sim-cfn-dynamodb-global-table-replicas.ts
+++ b/src/service/dynamodb/cfn/global-table/sim-cfn-dynamodb-global-table-replicas.ts
@@ -1,0 +1,105 @@
+import type { SimCfnDynamoDbPropertyValues } from "../property/sim-cfn-dynamodb-property-values.js";
+
+interface SimCfnDynamoDbGlobalTableReplicasProperties {
+  readonly logicalId: string;
+  readonly regionName: string;
+  readonly values: SimCfnDynamoDbPropertyValues;
+}
+
+/**
+ * The one replica a global table this simulation can create is made of.
+ *
+ * A global table naming one replica is an ordinary table in that region,
+ * because with one replica that is what it is. CDK's `TableV2` synthesises one
+ * for every table it makes, since `renderReplicaTables` always appends the
+ * stack's own region, so a table with no `replicas` prop at all arrives here.
+ *
+ * Two or more replicas is a table that replicates, which is not simulated. That
+ * skips the Resource with a reason naming the regions, so the rest of the stack
+ * still deploys and the report says which table was left out and why. The line
+ * is drawn at the replica count rather than at the Resource type because that
+ * is where the behaviour actually differs.
+ */
+export class SimCfnDynamoDbGlobalTableReplicas {
+  private readonly logicalId: string;
+  private readonly regionName: string;
+  private readonly values: SimCfnDynamoDbPropertyValues;
+
+  constructor(properties: SimCfnDynamoDbGlobalTableReplicasProperties) {
+    this.logicalId = properties.logicalId;
+    this.regionName = properties.regionName;
+    this.values = properties.values;
+  }
+
+  /**
+   * The single replica this global table is, refusing every other count.
+   */
+  single(): SimCfnDynamoDbPropertyValues {
+    const replicas = this.values.list("Replicas");
+
+    if (replicas.length > 1) {
+      throw this.replicatedError(replicas);
+    }
+
+    const replica = replicas.at(0);
+
+    if (replica === undefined) {
+      throw this.values.error(
+        "Replicas must name at least one region, since a global table with " +
+          "no replica is a table in no region, and real CloudFormation " +
+          "refuses that template too",
+      );
+    }
+
+    this.assertOwnRegion(replica);
+
+    return replica;
+  }
+
+  /**
+   * Refuse a replica somewhere other than where the stack is deploying.
+   *
+   * The Resource is created in the Account and Region the stack deploys into,
+   * which is the only place a simulated table can appear. Real CloudFormation
+   * requires the replica list to include the stack's own region, so a template
+   * naming one region and deploying into another is one it refuses as well.
+   */
+  private assertOwnRegion(replica: SimCfnDynamoDbPropertyValues): void {
+    const region = replica.string("Region");
+
+    if (region === undefined) {
+      throw this.values.error("Replicas.0.Region is required");
+    }
+
+    if (region !== this.regionName) {
+      throw this.values.error(
+        `Replicas.0.Region is ${region}, and the stack is deploying into ` +
+          `${this.regionName}, so the replica list does not include the ` +
+          `region the table would be created in`,
+      );
+    }
+  }
+
+  /**
+   * The refusal that skips a global table which genuinely replicates.
+   *
+   * The "Unsupported sim ... CloudFormation" wording is what marks the Resource
+   * as skipped rather than failing the stack.
+   */
+  private replicatedError(
+    replicas: readonly SimCfnDynamoDbPropertyValues[],
+  ): Error {
+    const regions = replicas
+      .map((replica, index) => {
+        return replica.string("Region") ?? `Replicas.${index.toString()}`;
+      })
+      .join(", ");
+
+    return new Error(
+      `Unsupported sim DynamoDB CloudFormation Resource ${this.logicalId}: ` +
+        `Replicas names ${regions}, and replicating a table between regions ` +
+        `is not simulated, so the global table is skipped rather than ` +
+        `created as an ordinary table in one of them`,
+    );
+  }
+}

--- a/src/service/dynamodb/cfn/global-table/sim-cfn-dynamodb-global-table-resource.factory.ts
+++ b/src/service/dynamodb/cfn/global-table/sim-cfn-dynamodb-global-table-resource.factory.ts
@@ -1,0 +1,87 @@
+import { MappedFactory } from "@kensio/part-factory";
+import { DEFAULT_SIM_AWS_REGION_NAME } from "../../../aws/sim-aws-region.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import { simCfnDynamoDbTableKeyProperties } from "../table/sim-cfn-dynamodb-table-key-properties.js";
+import { simCfnDynamoDbTableNameProperty } from "../table/sim-cfn-dynamodb-table-resource.factory.js";
+
+/**
+ * What a test asks for when it wants an `AWS::DynamoDB::GlobalTable` Resource.
+ *
+ * A global table is an ordinary table plus the regions it replicates to, so
+ * this takes what the table Resource builder takes and adds the replicas.
+ * `properties` and `replicaProperties` are what the template says beyond that,
+ * and each is applied last where it belongs, so a test that needs one property
+ * states that one property rather than the whole Resource.
+ */
+export interface SimCfnDynamoDbGlobalTableResourceInput {
+  /**
+   * The name the template gives the table, where nothing leaves `TableName`
+   * out, as CDK does for a table it lets CloudFormation name.
+   */
+  readonly tableName: string | undefined;
+  readonly partitionKeyName: string;
+  readonly partitionKeyType: string;
+
+  /**
+   * The sort key the table has, where nothing gives it a partition key alone.
+   */
+  readonly sortKeyName: string | undefined;
+  readonly sortKeyType: string;
+  readonly billingMode: string;
+
+  /**
+   * The regions the table replicates to, which is the region the stack is in
+   * for a `TableV2` that asked for no replicas at all.
+   */
+  readonly replicaRegions: readonly string[];
+  readonly replicaProperties: SimCfnTemplateValueRecord;
+  readonly properties: SimCfnTemplateValueRecord;
+}
+
+/**
+ * Builds the `AWS::DynamoDB::GlobalTable` Resource a template carries.
+ *
+ * ```typescript
+ * template: {
+ *   Resources: {
+ *     OrdersTable: simCfnDynamoDbGlobalTableResourceFactory.make({
+ *       tableName: "orders",
+ *       replicaProperties: { TableClass: "STANDARD_INFREQUENT_ACCESS" },
+ *     }),
+ *   },
+ * }
+ * ```
+ *
+ * Nothing here decides what a property is allowed to be. The Resource is
+ * deployed through the ordinary CloudFormation path, so a value this builds is
+ * checked by the same CreateTable rules an SDK caller's table is.
+ */
+export const simCfnDynamoDbGlobalTableResourceFactory = new MappedFactory<
+  SimCfnDynamoDbGlobalTableResourceInput,
+  SimCfnTemplateValueRecord
+>(
+  () => ({
+    tableName: undefined,
+    partitionKeyName: "id",
+    partitionKeyType: "S",
+    sortKeyName: undefined,
+    sortKeyType: "S",
+    billingMode: "PAY_PER_REQUEST",
+    replicaRegions: [DEFAULT_SIM_AWS_REGION_NAME],
+    replicaProperties: {},
+    properties: {},
+  }),
+  (input) => ({
+    Type: "AWS::DynamoDB::GlobalTable",
+    Properties: {
+      ...simCfnDynamoDbTableNameProperty(input.tableName),
+      ...simCfnDynamoDbTableKeyProperties(input),
+      BillingMode: input.billingMode,
+      Replicas: input.replicaRegions.map((region) => ({
+        Region: region,
+        ...input.replicaProperties,
+      })),
+      ...input.properties,
+    },
+  }),
+);

--- a/src/service/dynamodb/cfn/global-table/sim-cfn-dynamodb-global-table-simulated.ts
+++ b/src/service/dynamodb/cfn/global-table/sim-cfn-dynamodb-global-table-simulated.ts
@@ -1,0 +1,83 @@
+import type { SimCfnDynamoDbPropertyValues } from "../property/sim-cfn-dynamodb-property-values.js";
+import {
+  simCfnDynamoDbGlobalTableIndexRules,
+  simCfnDynamoDbGlobalTableLocalIndexRules,
+  simCfnDynamoDbGlobalTableRules,
+  simCfnDynamoDbGlobalTableStreamRules,
+  simCfnDynamoDbGlobalTableWriteCapacityRules,
+} from "./sim-cfn-dynamodb-global-table-property-rules.js";
+import {
+  simCfnDynamoDbGlobalTableReadCapacityRules,
+  simCfnDynamoDbGlobalTableReplicaIndexRules,
+  simCfnDynamoDbGlobalTableReplicaRules,
+} from "./sim-cfn-dynamodb-global-table-replica-rules.js";
+
+interface SimCfnDynamoDbGlobalTableSimulatedProperties {
+  readonly logicalId: string;
+  readonly values: SimCfnDynamoDbPropertyValues;
+  readonly replica: SimCfnDynamoDbPropertyValues;
+}
+
+/**
+ * Refuse everything an AWS::DynamoDB::GlobalTable asks for and cannot get, at
+ * every level a global table nests: the table, its indexes, its stream, the
+ * replica, the replica's per-index settings, and the two halves of its
+ * capacity.
+ *
+ * Each level is a set of property names rather than a rule of its own, so what
+ * differs between them is which names belong where.
+ */
+export function assertSimCfnDynamoDbGlobalTableSimulated(
+  properties: SimCfnDynamoDbGlobalTableSimulatedProperties,
+): void {
+  const { logicalId, values, replica } = properties;
+  const indexes = values.list("GlobalSecondaryIndexes");
+  const replicaIndexes = replica.list("GlobalSecondaryIndexes");
+
+  simCfnDynamoDbGlobalTableRules(logicalId).assertSimulated(values);
+  simCfnDynamoDbGlobalTableIndexRules(logicalId).assertEachSimulated(indexes);
+  simCfnDynamoDbGlobalTableLocalIndexRules(logicalId).assertEachSimulated(
+    values.list("LocalSecondaryIndexes"),
+  );
+  simCfnDynamoDbGlobalTableStreamRules(logicalId).assertSimulated(
+    values.object("StreamSpecification"),
+  );
+  simCfnDynamoDbGlobalTableReplicaRules(logicalId).assertSimulated(replica);
+  simCfnDynamoDbGlobalTableReplicaIndexRules(logicalId).assertEachSimulated(
+    replicaIndexes,
+  );
+
+  assertSimulatedCapacity(
+    logicalId,
+    [values, ...indexes],
+    [replica, ...replicaIndexes],
+  );
+}
+
+/**
+ * Refuse a capacity that changes with load, wherever it was asked for.
+ *
+ * The table and each of its indexes state the writing half, and the replica and
+ * its per-index entries state the reading half, so both sets are held to the
+ * same rule.
+ */
+function assertSimulatedCapacity(
+  logicalId: string,
+  writing: readonly SimCfnDynamoDbPropertyValues[],
+  reading: readonly SimCfnDynamoDbPropertyValues[],
+): void {
+  const writeRules = simCfnDynamoDbGlobalTableWriteCapacityRules(logicalId);
+  const readRules = simCfnDynamoDbGlobalTableReadCapacityRules(logicalId);
+
+  for (const values of writing) {
+    writeRules.assertSimulated(
+      values.object("WriteProvisionedThroughputSettings"),
+    );
+  }
+
+  for (const values of reading) {
+    readRules.assertSimulated(
+      values.object("ReadProvisionedThroughputSettings"),
+    );
+  }
+}

--- a/src/service/dynamodb/cfn/property/sim-cfn-dynamodb-property-error.ts
+++ b/src/service/dynamodb/cfn/property/sim-cfn-dynamodb-property-error.ts
@@ -1,19 +1,24 @@
 /**
- * Build the error a property of an AWS::DynamoDB::Table Resource is refused
- * with.
+ * Build the error a property of a simulated DynamoDB Resource is refused with.
  *
  * The wording matters. Sim CloudFormation skips a Resource whose error reads as
  * an unsupported Resource type, and skipping is the wrong answer for a table
  * the template described in a way it cannot be created: nothing is missing from
  * the simulation, the template is wrong, and the same template would fail on
  * real CloudFormation.
+ *
+ * The Resource type is named rather than assumed, since `AWS::DynamoDB::Table`
+ * and `AWS::DynamoDB::GlobalTable` describe the same table in different
+ * property names, and a refusal naming the wrong one sends whoever reads it to
+ * the wrong page of the documentation.
  */
-export function dynamoDbTablePropertyError(
+export function dynamoDbPropertyError(
+  resourceTypeName: string,
   logicalId: string,
   reason: string,
 ): Error {
   return new Error(
-    `Invalid AWS::DynamoDB::Table Resource ${logicalId}: ${reason}`,
+    `Invalid ${resourceTypeName} Resource ${logicalId}: ${reason}`,
   );
 }
 
@@ -25,13 +30,14 @@ export function dynamoDbTablePropertyError(
  * deploys and the skip reason names the property. The path is the whole way to
  * the property, so a setting on one index of several says which one it was on.
  */
-export function dynamoDbTableUnsimulatedPropertyError(
+export function dynamoDbUnsimulatedPropertyError(
+  resourceTypeName: string,
   logicalId: string,
   path: string,
 ): Error {
   return new Error(
     `Unsupported sim DynamoDB CloudFormation Resource ${logicalId}: ` +
-      `${path} is a real AWS::DynamoDB::Table property that simulated ` +
+      `${path} is a real ${resourceTypeName} property that simulated ` +
       `DynamoDB does not simulate, so the table is skipped rather than ` +
       `created without it`,
   );

--- a/src/service/dynamodb/cfn/property/sim-cfn-dynamodb-property-rules.ts
+++ b/src/service/dynamodb/cfn/property/sim-cfn-dynamodb-property-rules.ts
@@ -1,0 +1,109 @@
+import {
+  dynamoDbPropertyError,
+  dynamoDbUnsimulatedPropertyError,
+} from "./sim-cfn-dynamodb-property-error.js";
+import type { SimCfnDynamoDbPropertyValues } from "./sim-cfn-dynamodb-property-values.js";
+
+interface SimCfnDynamoDbPropertyRulesProperties {
+  readonly resourceTypeName: string;
+  readonly logicalId: string;
+
+  /**
+   * What the properties belong to, where they are not the Resource's own: a
+   * `GlobalSecondaryIndex`, a `StreamSpecification`, a replica. A refusal names
+   * it, so an unrecognised property says which shape it was not part of.
+   */
+  readonly kind?: string | undefined;
+  readonly simulated: ReadonlySet<string>;
+  readonly unsimulated?: ReadonlySet<string> | undefined;
+}
+
+/**
+ * Which properties of one object in a DynamoDB Resource template simulated
+ * DynamoDB can act on.
+ *
+ * A real property that is not simulated skips the Resource, with a reason
+ * naming it, so the rest of the stack still deploys and the report says what
+ * was left out. Anything that is not a property of that object at all fails the
+ * Resource instead, because that is a template real CloudFormation would refuse
+ * too.
+ *
+ * The same rule applies at every level a template nests: the Resource's own
+ * properties, the entries of an index list, a stream specification, a replica.
+ * Each level differs only in which names belong to it, so each is a set of
+ * names handed to this rather than a rule of its own.
+ */
+export class SimCfnDynamoDbPropertyRules {
+  private readonly resourceTypeName: string;
+  private readonly logicalId: string;
+  private readonly kind: string | undefined;
+  private readonly simulated: ReadonlySet<string>;
+  private readonly unsimulated: ReadonlySet<string>;
+
+  constructor(properties: SimCfnDynamoDbPropertyRulesProperties) {
+    this.resourceTypeName = properties.resourceTypeName;
+    this.logicalId = properties.logicalId;
+    this.kind = properties.kind;
+    this.simulated = properties.simulated;
+    this.unsimulated = properties.unsimulated ?? new Set<string>();
+  }
+
+  /**
+   * Refuse everything about this object that is not simulated.
+   *
+   * An object the template left out has nothing here to refuse.
+   */
+  assertSimulated(values: SimCfnDynamoDbPropertyValues | undefined): void {
+    if (values === undefined) {
+      return;
+    }
+
+    for (const name of values.names) {
+      this.assertSimulatedProperty(values, name);
+    }
+  }
+
+  /**
+   * Apply the same rule to every entry of a list, such as the indexes or the
+   * replicas a template declares.
+   */
+  assertEachSimulated(entries: readonly SimCfnDynamoDbPropertyValues[]): void {
+    for (const entry of entries) {
+      this.assertSimulated(entry);
+    }
+  }
+
+  private assertSimulatedProperty(
+    values: SimCfnDynamoDbPropertyValues,
+    name: string,
+  ): void {
+    if (this.simulated.has(name)) {
+      return;
+    }
+
+    if (this.unsimulated.has(name)) {
+      throw dynamoDbUnsimulatedPropertyError(
+        this.resourceTypeName,
+        this.logicalId,
+        values.pathTo(name),
+      );
+    }
+
+    throw dynamoDbPropertyError(
+      this.resourceTypeName,
+      this.logicalId,
+      `${values.pathTo(name)} is not ${this.description()} property`,
+    );
+  }
+
+  /**
+   * What an unrecognised property was not part of, as a refusal names it.
+   */
+  private description(): string {
+    if (this.kind === undefined) {
+      return `an ${this.resourceTypeName}`;
+    }
+
+    return `an ${this.resourceTypeName} ${this.kind}`;
+  }
+}

--- a/src/service/dynamodb/cfn/property/sim-cfn-dynamodb-property-scalars.ts
+++ b/src/service/dynamodb/cfn/property/sim-cfn-dynamodb-property-scalars.ts
@@ -1,0 +1,46 @@
+import type { SimCfnTemplateValue } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+
+/**
+ * Read a template value as a number, or as nothing when it is not one.
+ *
+ * CloudFormation carries a number as a string when it came from a template
+ * Parameter, so both are read.
+ */
+export function readSimCfnDynamoDbNumber(
+  value: SimCfnTemplateValue,
+): number | undefined {
+  if (typeof value === "number") {
+    return value;
+  }
+
+  if (typeof value === "string" && value.trim() !== "") {
+    const parsed = Number(value);
+
+    if (!Number.isNaN(parsed)) {
+      return parsed;
+    }
+  }
+
+  return undefined;
+}
+
+/**
+ * Read a template value as a boolean, or as nothing when it is not one.
+ *
+ * CloudFormation carries a boolean as a string when it came from a template
+ * Parameter, so both are read. Anything else is nothing rather than false,
+ * since what the template asked for is not knowable.
+ */
+export function readSimCfnDynamoDbBoolean(
+  value: SimCfnTemplateValue,
+): boolean | undefined {
+  if (value === true || value === "true") {
+    return true;
+  }
+
+  if (value === false || value === "false") {
+    return false;
+  }
+
+  return undefined;
+}

--- a/src/service/dynamodb/cfn/property/sim-cfn-dynamodb-property-values.ts
+++ b/src/service/dynamodb/cfn/property/sim-cfn-dynamodb-property-values.ts
@@ -2,16 +2,21 @@ import type {
   SimCfnTemplateValue,
   SimCfnTemplateValueRecord,
 } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
-import { dynamoDbTablePropertyError } from "./sim-cfn-dynamodb-table-property-error.js";
+import { dynamoDbPropertyError } from "./sim-cfn-dynamodb-property-error.js";
+import {
+  readSimCfnDynamoDbBoolean,
+  readSimCfnDynamoDbNumber,
+} from "./sim-cfn-dynamodb-property-scalars.js";
 
-interface SimCfnDynamoDbTableValuesProperties {
+interface SimCfnDynamoDbPropertyValuesProperties {
+  readonly resourceTypeName: string;
   readonly logicalId: string;
   readonly properties: SimCfnTemplateValueRecord;
   readonly path?: string;
 }
 
 /**
- * Reads the plain shapes an AWS::DynamoDB::Table property can hold.
+ * Reads the plain shapes a simulated DynamoDB Resource property can hold.
  *
  * Only the template's own shape is checked here: a list where a list belongs, a
  * number where a number belongs. What a value is allowed to mean is left to
@@ -21,12 +26,14 @@ interface SimCfnDynamoDbTableValuesProperties {
  * the path it sits at, so a refusal names the whole property path it came from
  * rather than just the field.
  */
-export class SimCfnDynamoDbTableValues {
+export class SimCfnDynamoDbPropertyValues {
+  private readonly resourceTypeName: string;
   private readonly logicalId: string;
   private readonly entries: ReadonlyMap<string, SimCfnTemplateValue>;
   private readonly path: string;
 
-  constructor(properties: SimCfnDynamoDbTableValuesProperties) {
+  constructor(properties: SimCfnDynamoDbPropertyValuesProperties) {
+    this.resourceTypeName = properties.resourceTypeName;
     this.logicalId = properties.logicalId;
     this.entries = new Map(Object.entries(properties.properties));
     this.path = properties.path ?? "";
@@ -40,12 +47,24 @@ export class SimCfnDynamoDbTableValues {
   }
 
   /**
+   * A property as the template wrote it, for one that is handed on rather than
+   * read.
+   *
+   * A global table carries several properties an ordinary table states the same
+   * way, and passing those through untouched is what keeps the rules that
+   * decide what they are allowed to be in one place.
+   */
+  value(name: string): SimCfnTemplateValue | undefined {
+    return this.entries.get(name);
+  }
+
+  /**
    * Read a property holding a list of objects, such as a key schema.
    *
    * A property the template leaves out reads as no entries, which is what
    * CreateTable then refuses in its own words.
    */
-  list(name: string): readonly SimCfnDynamoDbTableValues[] {
+  list(name: string): readonly SimCfnDynamoDbPropertyValues[] {
     const value = this.entries.get(name);
 
     if (value === undefined) {
@@ -94,7 +113,7 @@ export class SimCfnDynamoDbTableValues {
   /**
    * Read a property holding an object, where the template may leave it out.
    */
-  object(name: string): SimCfnDynamoDbTableValues | undefined {
+  object(name: string): SimCfnDynamoDbPropertyValues | undefined {
     const value = this.entries.get(name);
 
     if (value === undefined) {
@@ -122,10 +141,8 @@ export class SimCfnDynamoDbTableValues {
   }
 
   /**
-   * Read a property holding a number.
-   *
-   * CloudFormation carries a number as a string when it came from a template
-   * Parameter, so both are read.
+   * Read a property holding a number, including one a template Parameter
+   * carried as a string.
    */
   number(name: string): number | undefined {
     const value = this.entries.get(name);
@@ -134,27 +151,18 @@ export class SimCfnDynamoDbTableValues {
       return undefined;
     }
 
-    if (typeof value === "number") {
-      return value;
+    const parsed = readSimCfnDynamoDbNumber(value);
+
+    if (parsed === undefined) {
+      throw this.error(`${this.pathTo(name)} must be a number`);
     }
 
-    if (typeof value === "string" && value.trim() !== "") {
-      const parsed = Number(value);
-
-      if (!Number.isNaN(parsed)) {
-        return parsed;
-      }
-    }
-
-    throw this.error(`${this.pathTo(name)} must be a number`);
+    return parsed;
   }
 
   /**
-   * Read a property holding a boolean.
-   *
-   * CloudFormation carries a boolean as a string when it came from a template
-   * Parameter, so both are read. Anything else is refused rather than read as
-   * false, since what the template asked for is not knowable.
+   * Read a property holding a boolean, including one a template Parameter
+   * carried as a string.
    */
   boolean(name: string): boolean | undefined {
     const value = this.entries.get(name);
@@ -163,22 +171,20 @@ export class SimCfnDynamoDbTableValues {
       return undefined;
     }
 
-    if (value === true || value === "true") {
-      return true;
+    const parsed = readSimCfnDynamoDbBoolean(value);
+
+    if (parsed === undefined) {
+      throw this.error(`${this.pathTo(name)} must be true or false`);
     }
 
-    if (value === false || value === "false") {
-      return false;
-    }
-
-    throw this.error(`${this.pathTo(name)} must be true or false`);
+    return parsed;
   }
 
   /**
    * Build the error this Resource is refused with.
    */
   error(reason: string): Error {
-    return dynamoDbTablePropertyError(this.logicalId, reason);
+    return dynamoDbPropertyError(this.resourceTypeName, this.logicalId, reason);
   }
 
   /**
@@ -198,12 +204,13 @@ export class SimCfnDynamoDbTableValues {
   private reader(
     value: SimCfnTemplateValue,
     path: string,
-  ): SimCfnDynamoDbTableValues {
+  ): SimCfnDynamoDbPropertyValues {
     if (typeof value !== "object" || value === null || Array.isArray(value)) {
       throw this.error(`${path} must be an object`);
     }
 
-    return new SimCfnDynamoDbTableValues({
+    return new SimCfnDynamoDbPropertyValues({
+      resourceTypeName: this.resourceTypeName,
       logicalId: this.logicalId,
       properties: value,
       path,

--- a/src/service/dynamodb/cfn/sim-cfn-dynamodb-global-table-validation.iso.test.ts
+++ b/src/service/dynamodb/cfn/sim-cfn-dynamodb-global-table-validation.iso.test.ts
@@ -1,0 +1,318 @@
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertTrue,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import { simCfnDynamoDbGlobalTableResourceFactory } from "./global-table/sim-cfn-dynamodb-global-table-resource.factory.js";
+
+describe("DynamoDB CloudFormation GlobalTable validation", () => {
+  it("skips a global table replicating between regions", async () => {
+    // Given a template naming two replica regions, which genuinely replicates,
+    // in a stack with another Resource in it.
+    const simAws = new SimAws();
+
+    // When the template is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: {
+        Resources: {
+          OrdersTable: simCfnDynamoDbGlobalTableResourceFactory.make({
+            tableName: "orders",
+            replicaRegions: ["us-east-1", "eu-west-2"],
+          }),
+          OrdersBucket: { Type: "AWS::S3::Bucket" },
+        },
+      },
+    });
+    await stack.waitForDeployComplete();
+
+    // Then the table is skipped, with a reason naming the regions, rather than
+    // created as an ordinary table in one of them.
+    const resource = stack.getResource("OrdersTable");
+    assertNonNullable(resource);
+    assertTrue(resource.skipped);
+    assertStringIncludes(
+      resource.skippedReason ?? "",
+      "Replicas names us-east-1, eu-west-2, and replicating a table between " +
+        "regions is not simulated",
+    );
+    assertUndefined(simAws.dynamoDb().findTable("orders"));
+
+    // And the rest of the stack still deploys.
+    assertTrue(stack.getResource("OrdersBucket")?.deployed);
+  });
+
+  it("fails a global table with no replicas at all", async () => {
+    // Given a template leaving Replicas out, which real CloudFormation refuses
+    // too since the property is required. Written out rather than built, since
+    // this is the one global table here that has no replica to build.
+    const simAws = new SimAws();
+
+    // When the template is deployed, then the deployment fails.
+    const error = await assertThrowsErrorAsync(async () => {
+      return await simAws.cloudFormation().deployTemplate({
+        stackName: "orders-stack",
+        template: {
+          Resources: {
+            OrdersTable: {
+              Type: "AWS::DynamoDB::GlobalTable",
+              Properties: {
+                TableName: "orders",
+                KeySchema: [{ AttributeName: "id", KeyType: "HASH" }],
+                AttributeDefinitions: [
+                  { AttributeName: "id", AttributeType: "S" },
+                ],
+                BillingMode: "PAY_PER_REQUEST",
+              },
+            },
+          },
+        },
+      });
+    });
+
+    assertStringIncludes(
+      error.message,
+      "Invalid AWS::DynamoDB::GlobalTable Resource OrdersTable: Replicas " +
+        "must name at least one region",
+    );
+
+    const stack = simAws.cloudFormation().getStackByName("orders-stack");
+    assertNonNullable(stack);
+    assertIdentical(stack.getResource("OrdersTable")?.status, "CREATE_FAILED");
+    assertUndefined(simAws.dynamoDb().findTable("orders"));
+  });
+
+  it("fails a global table whose one replica is somewhere else", async () => {
+    // Given a template whose only replica names a region the stack is not
+    // deploying into, which real CloudFormation refuses too.
+    const simAws = new SimAws();
+
+    // When the template is deployed, then the deployment fails.
+    const error = await assertThrowsErrorAsync(async () => {
+      return await simAws.cloudFormation().deployTemplate({
+        stackName: "orders-stack",
+        template: {
+          Resources: {
+            OrdersTable: simCfnDynamoDbGlobalTableResourceFactory.make({
+              tableName: "orders",
+              replicaRegions: ["eu-west-2"],
+            }),
+          },
+        },
+      });
+    });
+
+    // And the failure names both regions, since either one of them could be
+    // the one the template got wrong.
+    assertStringIncludes(
+      error.message,
+      "Replicas.0.Region is eu-west-2, and the stack is deploying into " +
+        "us-east-1",
+    );
+    assertUndefined(simAws.dynamoDb().findTable("orders"));
+  });
+
+  it("skips a global table asking for a replica setting that is not simulated", async () => {
+    // Given a template asking for point in time recovery, which a global table
+    // asks for on its replica and which is not simulated either way.
+    const simAws = new SimAws();
+
+    // When the template is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: {
+        Resources: {
+          OrdersTable: simCfnDynamoDbGlobalTableResourceFactory.make({
+            tableName: "orders",
+            replicaProperties: {
+              PointInTimeRecoverySpecification: {
+                PointInTimeRecoveryEnabled: true,
+              },
+            },
+          }),
+        },
+      },
+    });
+    await stack.waitForDeployComplete();
+
+    // Then the table is skipped, with a reason naming the whole path to the
+    // property, so it says which replica asked for it.
+    const resource = stack.getResource("OrdersTable");
+    assertNonNullable(resource);
+    assertTrue(resource.skipped);
+    assertStringIncludes(
+      resource.skippedReason ?? "",
+      "Replicas.0.PointInTimeRecoverySpecification is a real " +
+        "AWS::DynamoDB::GlobalTable property that simulated DynamoDB does " +
+        "not simulate",
+    );
+    assertUndefined(simAws.dynamoDb().findTable("orders"));
+  });
+
+  it("skips a global table asking for capacity that scales with load", async () => {
+    // Given a template asking for autoscaled write capacity, which is what
+    // CDK's Capacity.autoscaled synthesises and which nothing here scales.
+    const simAws = new SimAws();
+
+    // When the template is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: {
+        Resources: {
+          OrdersTable: simCfnDynamoDbGlobalTableResourceFactory.make({
+            tableName: "orders",
+            billingMode: "PROVISIONED",
+            properties: {
+              WriteProvisionedThroughputSettings: {
+                WriteCapacityAutoScalingSettings: {
+                  MinCapacity: 1,
+                  MaxCapacity: 10,
+                },
+              },
+            },
+          }),
+        },
+      },
+    });
+    await stack.waitForDeployComplete();
+
+    // Then the table is skipped rather than created at the capacity it would
+    // have started at.
+    const resource = stack.getResource("OrdersTable");
+    assertNonNullable(resource);
+    assertTrue(resource.skipped);
+    assertStringIncludes(
+      resource.skippedReason ?? "",
+      "WriteProvisionedThroughputSettings.WriteCapacityAutoScalingSettings " +
+        "is a real AWS::DynamoDB::GlobalTable property",
+    );
+    assertUndefined(simAws.dynamoDb().findTable("orders"));
+  });
+
+  it("fails a global table with a property the Resource type does not have", async () => {
+    // Given a template putting an AWS::DynamoDB::Table property on a global
+    // table, which states that one on its replica instead.
+    const simAws = new SimAws();
+
+    // When the template is deployed, then the deployment fails, because that
+    // is a template real CloudFormation would refuse too.
+    const error = await assertThrowsErrorAsync(async () => {
+      return await simAws.cloudFormation().deployTemplate({
+        stackName: "orders-stack",
+        template: {
+          Resources: {
+            OrdersTable: simCfnDynamoDbGlobalTableResourceFactory.make({
+              tableName: "orders",
+              properties: { TableClass: "STANDARD_INFREQUENT_ACCESS" },
+            }),
+          },
+        },
+      });
+    });
+
+    assertStringIncludes(
+      error.message,
+      "TableClass is not an AWS::DynamoDB::GlobalTable property",
+    );
+    assertUndefined(simAws.dynamoDb().findTable("orders"));
+  });
+
+  it("fails a global table whose one replica names no region", async () => {
+    // Given a template whose replica says nothing about where it is, which
+    // real CloudFormation refuses too since Region is required.
+    const simAws = new SimAws();
+
+    // When the template is deployed, then the deployment fails.
+    const error = await assertThrowsErrorAsync(async () => {
+      return await simAws.cloudFormation().deployTemplate({
+        stackName: "orders-stack",
+        template: {
+          Resources: {
+            OrdersTable: simCfnDynamoDbGlobalTableResourceFactory.make({
+              tableName: "orders",
+              properties: { Replicas: [{}] },
+            }),
+          },
+        },
+      });
+    });
+
+    assertStringIncludes(error.message, "Replicas.0.Region is required");
+    assertUndefined(simAws.dynamoDb().findTable("orders"));
+  });
+
+  it("fails a global table whose index names itself nowhere", async () => {
+    // Given a template declaring an index with no IndexName, and a replica
+    // provisioning the reads of an index it does not name either, so there is
+    // nothing to match the two by.
+    const simAws = new SimAws();
+
+    // When the template is deployed, then the deployment fails.
+    const error = await assertThrowsErrorAsync(async () => {
+      return await simAws.cloudFormation().deployTemplate({
+        stackName: "orders-stack",
+        template: {
+          Resources: {
+            OrdersTable: simCfnDynamoDbGlobalTableResourceFactory.make({
+              tableName: "orders",
+              properties: {
+                GlobalSecondaryIndexes: [
+                  {
+                    KeySchema: [{ AttributeName: "id", KeyType: "HASH" }],
+                    Projection: { ProjectionType: "ALL" },
+                  },
+                ],
+              },
+              replicaProperties: {
+                GlobalSecondaryIndexes: [
+                  { ReadProvisionedThroughputSettings: {} },
+                ],
+              },
+            }),
+          },
+        },
+      });
+    });
+
+    // And the failure is the one CreateTable gives an unnamed index.
+    assertStringIncludes(error.message, "A secondary index has no IndexName");
+  });
+
+  it("fails a global table the CreateTable rules refuse", async () => {
+    // Given a template naming a key attribute it never defines, which
+    // CreateTable refuses for an SDK caller too.
+    const simAws = new SimAws();
+
+    // When the template is deployed, then the deployment fails.
+    const error = await assertThrowsErrorAsync(async () => {
+      return await simAws.cloudFormation().deployTemplate({
+        stackName: "orders-stack",
+        template: {
+          Resources: {
+            OrdersTable: simCfnDynamoDbGlobalTableResourceFactory.make({
+              tableName: "orders",
+              properties: {
+                AttributeDefinitions: [
+                  { AttributeName: "customerId", AttributeType: "S" },
+                ],
+              },
+            }),
+          },
+        },
+      });
+    });
+
+    // And the failure is the one CreateTable gives, because a global table is
+    // created by calling it, as an ordinary table is.
+    assertStringIncludes(
+      error.message,
+      "The KeySchema names the attribute id, which has no AttributeDefinition",
+    );
+  });
+});

--- a/src/service/dynamodb/cfn/sim-cfn-dynamodb-global-table.iso.test.ts
+++ b/src/service/dynamodb/cfn/sim-cfn-dynamodb-global-table.iso.test.ts
@@ -1,0 +1,376 @@
+import {
+  DescribeTableCommand,
+  GetItemCommand,
+  ListTagsOfResourceCommand,
+  PutItemCommand,
+} from "@aws-sdk/client-dynamodb";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertObjectEquals,
+  assertTrue,
+  assertTypeString,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import { simCfnDynamoDbGlobalTableResourceFactory } from "./global-table/sim-cfn-dynamodb-global-table-resource.factory.js";
+
+/**
+ * A template holding one unnamed on-demand global table with a partition and a
+ * sort key, replicated nowhere but the region the stack is in.
+ */
+const ordersTableTemplate = {
+  Resources: {
+    OrdersTable: simCfnDynamoDbGlobalTableResourceFactory.make({
+      partitionKeyName: "customerId",
+      sortKeyName: "orderId",
+    }),
+  },
+  Outputs: {
+    OrdersTableName: { Value: { Ref: "OrdersTable" } },
+  },
+};
+
+describe("DynamoDB CloudFormation GlobalTable deployment", () => {
+  it("creates a table from a global table naming one replica", async () => {
+    // Given a template declaring a named global table replicated to the one
+    // region the stack is in, which is what CDK's TableV2 synthesises for a
+    // table that asked for no replicas at all.
+    const simAws = new SimAws();
+
+    // When the template is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: {
+        Resources: {
+          OrdersTable: simCfnDynamoDbGlobalTableResourceFactory.make({
+            tableName: "orders",
+            partitionKeyName: "customerId",
+            sortKeyName: "orderId",
+          }),
+        },
+      },
+    });
+    await stack.waitForDeployComplete();
+    await simAws.backgroundTasksComplete();
+
+    // Then DescribeTable finds an ordinary table, because with one replica
+    // that is what a global table is.
+    const described = await simAws
+      .dynamoDb()
+      .describeTable(new DescribeTableCommand({ TableName: "orders" }));
+
+    assertNonNullable(described.Table);
+    assertNonNullable(described.Table.KeySchema);
+    assertIdentical(described.Table.TableStatus, "ACTIVE");
+    assertIdentical(
+      described.Table.TableArn,
+      `arn:aws:dynamodb:${simAws.defaultRegionName}:` +
+        `${simAws.defaultAccountId}:table/orders`,
+    );
+    assertIdentical(
+      described.Table.KeySchema.at(0)?.AttributeName,
+      "customerId",
+    );
+    assertIdentical(described.Table.KeySchema.at(1)?.AttributeName, "orderId");
+    assertIdentical(
+      described.Table.BillingModeSummary?.BillingMode,
+      "PAY_PER_REQUEST",
+    );
+  });
+
+  it("takes the settings a global table puts on its replica", async () => {
+    // Given a template stating on the replica what an ordinary table states
+    // about itself: its class, its protection and its tags.
+    const simAws = new SimAws();
+
+    // When the template is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: {
+        Resources: {
+          OrdersTable: simCfnDynamoDbGlobalTableResourceFactory.make({
+            tableName: "orders",
+            replicaProperties: {
+              TableClass: "STANDARD_INFREQUENT_ACCESS",
+              DeletionProtectionEnabled: true,
+              Tags: [{ Key: "Environment", Value: "test" }],
+            },
+          }),
+        },
+      },
+    });
+    await stack.waitForDeployComplete();
+
+    // Then they are on the table, since the replica is the table.
+    const described = await simAws
+      .dynamoDb()
+      .describeTable(new DescribeTableCommand({ TableName: "orders" }));
+
+    assertNonNullable(described.Table);
+    assertIdentical(
+      described.Table.TableClassSummary?.TableClass,
+      "STANDARD_INFREQUENT_ACCESS",
+    );
+    assertTrue(described.Table.DeletionProtectionEnabled);
+
+    const tags = await simAws.dynamoDb().listTagsOfResource(
+      new ListTagsOfResourceCommand({
+        ResourceArn: described.Table.TableArn,
+      }),
+    );
+    assertArrayLength(tags.Tags, 1);
+    assertObjectEquals(tags.Tags[0], { Key: "Environment", Value: "test" });
+  });
+
+  it("provisions a table from the two halves its capacity is split into", async () => {
+    // Given a template provisioning writes on the table and reads on the
+    // replica, which is how a global table states the capacity an ordinary
+    // table states in one place.
+    const simAws = new SimAws();
+
+    // When the template is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: {
+        Resources: {
+          OrdersTable: simCfnDynamoDbGlobalTableResourceFactory.make({
+            tableName: "orders",
+            billingMode: "PROVISIONED",
+            properties: {
+              WriteProvisionedThroughputSettings: { WriteCapacityUnits: 3 },
+            },
+            replicaProperties: {
+              ReadProvisionedThroughputSettings: { ReadCapacityUnits: 5 },
+            },
+          }),
+        },
+      },
+    });
+    await stack.waitForDeployComplete();
+
+    // Then the two halves are the one capacity reported back off the table.
+    const described = await simAws
+      .dynamoDb()
+      .describeTable(new DescribeTableCommand({ TableName: "orders" }));
+
+    assertNonNullable(described.Table?.ProvisionedThroughput);
+    assertIdentical(described.Table.ProvisionedThroughput.ReadCapacityUnits, 5);
+    assertIdentical(
+      described.Table.ProvisionedThroughput.WriteCapacityUnits,
+      3,
+    );
+  });
+
+  it("provisions a secondary index from the two halves of its capacity", async () => {
+    // Given a template declaring an index on the table and provisioning its
+    // reads on the replica, which names the index rather than restating it.
+    const simAws = new SimAws();
+
+    // When the template is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: {
+        Resources: {
+          OrdersTable: simCfnDynamoDbGlobalTableResourceFactory.make({
+            tableName: "orders",
+            partitionKeyName: "customerId",
+            billingMode: "PROVISIONED",
+            properties: {
+              AttributeDefinitions: [
+                { AttributeName: "customerId", AttributeType: "S" },
+                { AttributeName: "status", AttributeType: "S" },
+              ],
+              WriteProvisionedThroughputSettings: { WriteCapacityUnits: 2 },
+              GlobalSecondaryIndexes: [
+                {
+                  IndexName: "byStatus",
+                  KeySchema: [{ AttributeName: "status", KeyType: "HASH" }],
+                  Projection: { ProjectionType: "ALL" },
+                  WriteProvisionedThroughputSettings: {
+                    WriteCapacityUnits: 4,
+                  },
+                },
+              ],
+            },
+            replicaProperties: {
+              ReadProvisionedThroughputSettings: { ReadCapacityUnits: 1 },
+              GlobalSecondaryIndexes: [
+                {
+                  IndexName: "byStatus",
+                  ReadProvisionedThroughputSettings: { ReadCapacityUnits: 7 },
+                },
+              ],
+            },
+          }),
+        },
+      },
+    });
+    await stack.waitForDeployComplete();
+    await simAws.backgroundTasksComplete();
+
+    // Then the index carries the capacity both halves named.
+    const described = await simAws
+      .dynamoDb()
+      .describeTable(new DescribeTableCommand({ TableName: "orders" }));
+
+    const index = described.Table?.GlobalSecondaryIndexes?.at(0);
+    assertNonNullable(index?.ProvisionedThroughput);
+    assertIdentical(index.IndexName, "byStatus");
+    assertIdentical(index.ProvisionedThroughput.ReadCapacityUnits, 7);
+    assertIdentical(index.ProvisionedThroughput.WriteCapacityUnits, 4);
+  });
+
+  it("gives the table the stream its global table asked for", async () => {
+    // Given a template asking for a stream, which a global table states the
+    // way an ordinary table does.
+    const simAws = new SimAws();
+
+    // When the template is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: {
+        Resources: {
+          OrdersTable: simCfnDynamoDbGlobalTableResourceFactory.make({
+            tableName: "orders",
+            properties: {
+              StreamSpecification: { StreamViewType: "NEW_AND_OLD_IMAGES" },
+            },
+          }),
+        },
+        Outputs: {
+          TableStreamArn: {
+            Value: { "Fn::GetAtt": ["OrdersTable", "StreamArn"] },
+          },
+        },
+      },
+    });
+    await stack.waitForDeployComplete();
+    await simAws.backgroundTasksComplete();
+
+    // Then the table has a stream, and Fn::GetAtt answers with its ARN.
+    const described = await simAws
+      .dynamoDb()
+      .describeTable(new DescribeTableCommand({ TableName: "orders" }));
+
+    assertNonNullable(described.Table);
+    assertIdentical(
+      described.Table.StreamSpecification?.StreamViewType,
+      "NEW_AND_OLD_IMAGES",
+    );
+    assertIdentical(
+      stack.outputs.get("TableStreamArn")?.value,
+      described.Table.LatestStreamArn,
+    );
+  });
+
+  it("resolves Ref to the table name and Fn::GetAtt to its ARN and ID", async () => {
+    // Given a template referencing its global table every way the Resource
+    // type documents.
+    const simAws = new SimAws();
+
+    // When the template is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: {
+        Resources: {
+          OrdersTable: simCfnDynamoDbGlobalTableResourceFactory.make({
+            tableName: "orders",
+          }),
+        },
+        Outputs: {
+          TableRef: { Value: { Ref: "OrdersTable" } },
+          TableArn: { Value: { "Fn::GetAtt": ["OrdersTable", "Arn"] } },
+          TableId: { Value: { "Fn::GetAtt": ["OrdersTable", "TableId"] } },
+        },
+      },
+    });
+    await stack.waitForDeployComplete();
+
+    // Then Ref is the table name, as AWS::DynamoDB::GlobalTable Ref is, so it
+    // can be handed straight to PutItem.
+    assertIdentical(stack.outputs.get("TableRef")?.value, "orders");
+
+    const described = await simAws
+      .dynamoDb()
+      .describeTable(new DescribeTableCommand({ TableName: "orders" }));
+    assertIdentical(
+      stack.outputs.get("TableArn")?.value,
+      described.Table?.TableArn,
+    );
+    assertIdentical(
+      stack.outputs.get("TableId")?.value,
+      described.Table?.TableId,
+    );
+  });
+
+  it("writes and reads an item through the table a Ref names", async () => {
+    // Given a deployed global table whose name the stack outputs, left unnamed
+    // as CDK leaves one it lets CloudFormation name.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: ordersTableTemplate,
+    });
+    await stack.waitForDeployComplete();
+
+    const tableName = stack.outputs.get("OrdersTableName")?.value;
+    assertTypeString(tableName);
+    assertIdentical(tableName, "orders-stack-OrdersTable");
+
+    // When an item is written to the table the Ref named.
+    await simAws.dynamoDb().putItem(
+      new PutItemCommand({
+        TableName: tableName,
+        Item: {
+          customerId: { S: "customer-1" },
+          orderId: { S: "order-1" },
+          total: { N: "42.5" },
+        },
+      }),
+    );
+
+    // Then it reads back off the deployed table.
+    const read = await simAws.dynamoDb().getItem(
+      new GetItemCommand({
+        TableName: tableName,
+        Key: { customerId: { S: "customer-1" }, orderId: { S: "order-1" } },
+      }),
+    );
+
+    assertIdentical(read.Item?.["total"]?.N, "42.5");
+  });
+
+  it("creates the table in the Region its one replica names", async () => {
+    // Given a template deployed through a scoped simulated CloudFormation,
+    // with the replica naming the region the stack is deploying into.
+    const simAws = new SimAws();
+    const scoped = simAws.account("222222222222").region("eu-west-2");
+
+    // When the template is deployed.
+    const stack = await scoped.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: {
+        Resources: {
+          OrdersTable: simCfnDynamoDbGlobalTableResourceFactory.make({
+            tableName: "orders",
+            replicaRegions: ["eu-west-2"],
+          }),
+        },
+        Outputs: {
+          TableArn: { Value: { "Fn::GetAtt": ["OrdersTable", "Arn"] } },
+        },
+      },
+    });
+    await stack.waitForDeployComplete();
+
+    // Then the table is in that scope.
+    assertIdentical(
+      stack.outputs.get("TableArn")?.value,
+      "arn:aws:dynamodb:eu-west-2:222222222222:table/orders",
+    );
+    assertNonNullable(scoped.dynamoDb().findTable("orders"));
+  });
+});

--- a/src/service/dynamodb/cfn/sim-cfn-dynamodb-resource-factory.ts
+++ b/src/service/dynamodb/cfn/sim-cfn-dynamodb-resource-factory.ts
@@ -4,6 +4,7 @@ import type {
   SimCloudFormationResourceCreateContext,
 } from "../../cloudformation/resource/sim-cfn-resource.js";
 import type { SimDynamoDb } from "../sim-dynamodb.js";
+import { SimCfnDynamoDbGlobalTableCreator } from "./global-table/sim-cfn-dynamodb-global-table-creator.js";
 import { SimCfnDynamoDbTableCreator } from "./table/sim-cfn-dynamodb-table-creator.js";
 
 interface SimDynamoDbCfnResourceFactoryProperties {
@@ -15,32 +16,39 @@ interface SimDynamoDbCfnResourceFactoryProperties {
  */
 export class SimDynamoDbCfnResourceFactory implements SimCfnServiceResourceFactory {
   private readonly tableCreator: SimCfnDynamoDbTableCreator;
+  private readonly globalTableCreator: SimCfnDynamoDbGlobalTableCreator;
 
   constructor(properties: SimDynamoDbCfnResourceFactoryProperties) {
     this.tableCreator = new SimCfnDynamoDbTableCreator({
       dynamoDb: properties.dynamoDb,
+    });
+    this.globalTableCreator = new SimCfnDynamoDbGlobalTableCreator({
+      tableCreator: this.tableCreator,
     });
   }
 
   /**
    * Create a simulated DynamoDB resource from a CloudFormation Resource.
    *
-   * The table is the only AWS::DynamoDB::* Resource type this simulation
-   * models. A global table replicates across regions, which is not simulated,
-   * so AWS::DynamoDB::GlobalTable is reported as unsupported and skipped rather
-   * than quietly created as an ordinary table in one region.
+   * Both Resource types make a table. A global table naming one replica is an
+   * ordinary table in that region, which is what CDK's `TableV2` synthesises
+   * for every table it makes, so it is created rather than skipped. One naming
+   * two or more regions genuinely replicates, which is not simulated, and is
+   * skipped where it is read rather than here.
    */
   async create(
     resourceTypeName: string,
     resource: SimCfnResource,
     context: SimCloudFormationResourceCreateContext,
   ): Promise<object | undefined> {
+    const properties = context.resolvedProperties ?? resource.properties;
+
     switch (resourceTypeName) {
       case "Table": {
-        return await this.tableCreator.create(
-          resource,
-          context.resolvedProperties ?? resource.properties,
-        );
+        return await this.tableCreator.create(resource, properties);
+      }
+      case "GlobalTable": {
+        return await this.globalTableCreator.create(resource, properties);
       }
       default: {
         throw new Error(

--- a/src/service/dynamodb/cfn/sim-cfn-dynamodb-resource-type.ts
+++ b/src/service/dynamodb/cfn/sim-cfn-dynamodb-resource-type.ts
@@ -1,0 +1,14 @@
+/**
+ * The CloudFormation Resource type of an ordinary table.
+ */
+export const dynamoDbTableResourceTypeName = "AWS::DynamoDB::Table";
+
+/**
+ * The CloudFormation Resource type CDK's `TableV2` synthesises, whether or not
+ * any replica regions were asked for.
+ *
+ * A global table naming one replica is an ordinary table in that region, which
+ * is why the two type names sit together rather than one of them standing for
+ * something this simulation has no answer for.
+ */
+export const dynamoDbGlobalTableResourceTypeName = "AWS::DynamoDB::GlobalTable";

--- a/src/service/dynamodb/cfn/sim-cfn-dynamodb-table-validation.iso.test.ts
+++ b/src/service/dynamodb/cfn/sim-cfn-dynamodb-table-validation.iso.test.ts
@@ -90,9 +90,9 @@ describe("DynamoDB CloudFormation Table validation", () => {
     assertTrue(stack.getResource("OrdersBucket")?.deployed);
   });
 
-  it("skips a global table rather than creating an ordinary one", async () => {
-    // Given a template with an AWS::DynamoDB::GlobalTable in it, which
-    // replicates across regions.
+  it("skips a DynamoDB Resource type this simulation does not create", async () => {
+    // Given a template with an AWS::DynamoDB:: Resource that is neither of the
+    // two that make a table.
     const simAws = new SimAws();
 
     // When the template is deployed.
@@ -100,26 +100,23 @@ describe("DynamoDB CloudFormation Table validation", () => {
       stackName: "orders-stack",
       template: {
         Resources: {
-          OrdersTable: {
-            ...simCfnDynamoDbTableResourceFactory.make({
-              tableName: "orders",
-            }),
-            Type: "AWS::DynamoDB::GlobalTable",
-          },
+          OrdersBackup: { Type: "AWS::DynamoDB::Backup" },
+          OrdersBucket: { Type: "AWS::S3::Bucket" },
         },
       },
     });
     await stack.waitForDeployComplete();
 
-    // Then it is skipped, naming the Resource type, and no table is created.
-    const resource = stack.getResource("OrdersTable");
+    // Then it is skipped, naming the Resource type, and the rest of the stack
+    // still deploys.
+    const resource = stack.getResource("OrdersBackup");
     assertNonNullable(resource);
     assertTrue(resource.skipped);
     assertStringIncludes(
       resource.skippedReason ?? "",
-      "Unsupported sim DynamoDB CloudFormation Resource GlobalTable",
+      "Unsupported sim DynamoDB CloudFormation Resource Backup",
     );
-    assertUndefined(simAws.dynamoDb().findTable("orders"));
+    assertTrue(stack.getResource("OrdersBucket")?.deployed);
   });
 
   it("leaves a table unprotected when a Parameter says so", async () => {

--- a/src/service/dynamodb/cfn/table/sim-cfn-dynamodb-table-index-rules.ts
+++ b/src/service/dynamodb/cfn/table/sim-cfn-dynamodb-table-index-rules.ts
@@ -1,8 +1,5 @@
-import {
-  dynamoDbTablePropertyError,
-  dynamoDbTableUnsimulatedPropertyError,
-} from "./sim-cfn-dynamodb-table-property-error.js";
-import type { SimCfnDynamoDbTableValues } from "./sim-cfn-dynamodb-table-values.js";
+import { SimCfnDynamoDbPropertyRules } from "../property/sim-cfn-dynamodb-property-rules.js";
+import { dynamoDbTableResourceTypeName } from "../sim-cfn-dynamodb-resource-type.js";
 
 /**
  * The GlobalSecondaryIndex properties this simulation acts on.
@@ -41,90 +38,35 @@ const simulatedLocalIndexPropertyNames: ReadonlySet<string> = new Set([
   "Projection",
 ]);
 
-interface SimCfnDynamoDbTableIndexRulesProperties {
-  readonly logicalId: string;
-  readonly kind: string;
-  readonly simulated: ReadonlySet<string>;
-  readonly unsimulated: ReadonlySet<string>;
-}
-
 /**
- * Which properties of one secondary index a template declares simulated
- * DynamoDB can act on.
+ * The rules a `GlobalSecondaryIndexes` entry is read under.
  *
  * This is the table's own property rule applied a level down. A real index
  * property that is not simulated skips the whole table, since a table deployed
- * without a setting its index asked for answers reads differently. Anything
- * that is not an index property at all fails the Resource, because that is a
- * template real CloudFormation would refuse too.
+ * without a setting its index asked for answers reads differently.
  */
-export class SimCfnDynamoDbTableIndexRules {
-  private readonly logicalId: string;
-  private readonly kind: string;
-  private readonly simulated: ReadonlySet<string>;
-  private readonly unsimulated: ReadonlySet<string>;
+export function simCfnDynamoDbTableGlobalIndexRules(
+  logicalId: string,
+): SimCfnDynamoDbPropertyRules {
+  return new SimCfnDynamoDbPropertyRules({
+    resourceTypeName: dynamoDbTableResourceTypeName,
+    logicalId,
+    kind: "GlobalSecondaryIndex",
+    simulated: simulatedGlobalIndexPropertyNames,
+    unsimulated: unsimulatedGlobalIndexPropertyNames,
+  });
+}
 
-  private constructor(properties: SimCfnDynamoDbTableIndexRulesProperties) {
-    this.logicalId = properties.logicalId;
-    this.kind = properties.kind;
-    this.simulated = properties.simulated;
-    this.unsimulated = properties.unsimulated;
-  }
-
-  /**
-   * The rules a `GlobalSecondaryIndexes` entry is read under.
-   */
-  static global(logicalId: string): SimCfnDynamoDbTableIndexRules {
-    return new this({
-      logicalId,
-      kind: "GlobalSecondaryIndex",
-      simulated: simulatedGlobalIndexPropertyNames,
-      unsimulated: unsimulatedGlobalIndexPropertyNames,
-    });
-  }
-
-  /**
-   * The rules a `LocalSecondaryIndexes` entry is read under.
-   */
-  static local(logicalId: string): SimCfnDynamoDbTableIndexRules {
-    return new this({
-      logicalId,
-      kind: "LocalSecondaryIndex",
-      simulated: simulatedLocalIndexPropertyNames,
-      unsimulated: new Set<string>(),
-    });
-  }
-
-  /**
-   * Refuse everything about these index entries that is not simulated.
-   */
-  assertSimulated(entries: readonly SimCfnDynamoDbTableValues[]): void {
-    for (const entry of entries) {
-      for (const name of entry.names) {
-        this.assertSimulatedProperty(entry, name);
-      }
-    }
-  }
-
-  private assertSimulatedProperty(
-    entry: SimCfnDynamoDbTableValues,
-    name: string,
-  ): void {
-    if (this.simulated.has(name)) {
-      return;
-    }
-
-    if (this.unsimulated.has(name)) {
-      throw dynamoDbTableUnsimulatedPropertyError(
-        this.logicalId,
-        entry.pathTo(name),
-      );
-    }
-
-    throw dynamoDbTablePropertyError(
-      this.logicalId,
-      `${entry.pathTo(name)} is not an AWS::DynamoDB::Table ${this.kind} ` +
-        `property`,
-    );
-  }
+/**
+ * The rules a `LocalSecondaryIndexes` entry is read under.
+ */
+export function simCfnDynamoDbTableLocalIndexRules(
+  logicalId: string,
+): SimCfnDynamoDbPropertyRules {
+  return new SimCfnDynamoDbPropertyRules({
+    resourceTypeName: dynamoDbTableResourceTypeName,
+    logicalId,
+    kind: "LocalSecondaryIndex",
+    simulated: simulatedLocalIndexPropertyNames,
+  });
 }

--- a/src/service/dynamodb/cfn/table/sim-cfn-dynamodb-table-indexes.ts
+++ b/src/service/dynamodb/cfn/table/sim-cfn-dynamodb-table-indexes.ts
@@ -4,7 +4,7 @@ import type {
 } from "../../command/table/table.types.js";
 import { readSimCfnDynamoDbKeySchema } from "./sim-cfn-dynamodb-table-key-schema.js";
 import { readSimCfnDynamoDbThroughput } from "./sim-cfn-dynamodb-table-throughput.js";
-import type { SimCfnDynamoDbTableValues } from "./sim-cfn-dynamodb-table-values.js";
+import type { SimCfnDynamoDbPropertyValues } from "../property/sim-cfn-dynamodb-property-values.js";
 
 /**
  * Read the `GlobalSecondaryIndexes` or `LocalSecondaryIndexes` an
@@ -25,7 +25,7 @@ import type { SimCfnDynamoDbTableValues } from "./sim-cfn-dynamodb-table-values.
  * be about, so the divergence is documented under Limitations instead.
  */
 export function readSimCfnDynamoDbTableIndexes(
-  values: SimCfnDynamoDbTableValues,
+  values: SimCfnDynamoDbPropertyValues,
   propertyName: string,
 ): readonly SimDynamoDbSecondaryIndexInput[] {
   return values.list(propertyName).map((index) => readIndex(index));
@@ -38,7 +38,7 @@ export function readSimCfnDynamoDbTableIndexes(
  * so reading one that is not there leaves it out rather than inventing it.
  */
 function readIndex(
-  index: SimCfnDynamoDbTableValues,
+  index: SimCfnDynamoDbPropertyValues,
 ): SimDynamoDbSecondaryIndexInput {
   return {
     IndexName: index.string("IndexName"),
@@ -56,7 +56,7 @@ function readIndex(
  * one that does not.
  */
 function readProjection(
-  index: SimCfnDynamoDbTableValues,
+  index: SimCfnDynamoDbPropertyValues,
 ): SimDynamoDbProjectionInput | undefined {
   const projection = index.object("Projection");
 

--- a/src/service/dynamodb/cfn/table/sim-cfn-dynamodb-table-key-schema.ts
+++ b/src/service/dynamodb/cfn/table/sim-cfn-dynamodb-table-key-schema.ts
@@ -1,5 +1,5 @@
 import type { SimDynamoDbKeySchemaElementInput } from "../../command/table/table.types.js";
-import type { SimCfnDynamoDbTableValues } from "./sim-cfn-dynamodb-table-values.js";
+import type { SimCfnDynamoDbPropertyValues } from "../property/sim-cfn-dynamodb-property-values.js";
 
 /**
  * Read the `KeySchema` property of a table or one of its secondary indexes.
@@ -9,7 +9,7 @@ import type { SimCfnDynamoDbTableValues } from "./sim-cfn-dynamodb-table-values.
  * what says which is the partition key.
  */
 export function readSimCfnDynamoDbKeySchema(
-  values: SimCfnDynamoDbTableValues,
+  values: SimCfnDynamoDbPropertyValues,
 ): readonly SimDynamoDbKeySchemaElementInput[] {
   return values.list("KeySchema").map((element) => {
     return {

--- a/src/service/dynamodb/cfn/table/sim-cfn-dynamodb-table-properties.ts
+++ b/src/service/dynamodb/cfn/table/sim-cfn-dynamodb-table-properties.ts
@@ -10,13 +10,14 @@ import type {
 } from "../../command/table/table.types.js";
 import type { SimDynamoDbTimeToLiveSpecificationInput } from "../../command/time-to-live/time-to-live.types.js";
 import type { SimDynamoDbStreamSpecification } from "../../stream/sim-dynamodb-stream.types.js";
+import { dynamoDbTableResourceTypeName } from "../sim-cfn-dynamodb-resource-type.js";
 import { readSimCfnDynamoDbTableIndexes } from "./sim-cfn-dynamodb-table-indexes.js";
 import { readSimCfnDynamoDbKeySchema } from "./sim-cfn-dynamodb-table-key-schema.js";
 import { SimCfnDynamoDbTablePropertyRules } from "./sim-cfn-dynamodb-table-property-rules.js";
 import { readSimCfnDynamoDbTableStream } from "./sim-cfn-dynamodb-table-stream.js";
 import { readSimCfnDynamoDbThroughput } from "./sim-cfn-dynamodb-table-throughput.js";
 import { readSimCfnDynamoDbTableTimeToLive } from "./sim-cfn-dynamodb-table-time-to-live.js";
-import { SimCfnDynamoDbTableValues } from "./sim-cfn-dynamodb-table-values.js";
+import { SimCfnDynamoDbPropertyValues } from "../property/sim-cfn-dynamodb-property-values.js";
 
 /**
  * A table name is at most 255 characters, so a generated one is trimmed to fit.
@@ -40,11 +41,12 @@ interface SimCfnDynamoDbTablePropertiesProperties {
 export class SimCfnDynamoDbTableProperties {
   private readonly resource: SimCfnResource;
   private readonly rules: SimCfnDynamoDbTablePropertyRules;
-  private readonly values: SimCfnDynamoDbTableValues;
+  private readonly values: SimCfnDynamoDbPropertyValues;
 
   constructor(properties: SimCfnDynamoDbTablePropertiesProperties) {
     this.resource = properties.resource;
-    this.values = new SimCfnDynamoDbTableValues({
+    this.values = new SimCfnDynamoDbPropertyValues({
+      resourceTypeName: dynamoDbTableResourceTypeName,
       logicalId: properties.resource.logicalId,
       properties: properties.properties,
     });

--- a/src/service/dynamodb/cfn/table/sim-cfn-dynamodb-table-property-rules.ts
+++ b/src/service/dynamodb/cfn/table/sim-cfn-dynamodb-table-property-rules.ts
@@ -1,10 +1,11 @@
-import { SimCfnDynamoDbTableIndexRules } from "./sim-cfn-dynamodb-table-index-rules.js";
+import { SimCfnDynamoDbPropertyRules } from "../property/sim-cfn-dynamodb-property-rules.js";
+import type { SimCfnDynamoDbPropertyValues } from "../property/sim-cfn-dynamodb-property-values.js";
+import { dynamoDbTableResourceTypeName } from "../sim-cfn-dynamodb-resource-type.js";
 import {
-  dynamoDbTablePropertyError,
-  dynamoDbTableUnsimulatedPropertyError,
-} from "./sim-cfn-dynamodb-table-property-error.js";
-import { SimCfnDynamoDbTableStreamRules } from "./sim-cfn-dynamodb-table-stream-rules.js";
-import type { SimCfnDynamoDbTableValues } from "./sim-cfn-dynamodb-table-values.js";
+  simCfnDynamoDbTableGlobalIndexRules,
+  simCfnDynamoDbTableLocalIndexRules,
+} from "./sim-cfn-dynamodb-table-index-rules.js";
+import { simCfnDynamoDbTableStreamRules } from "./sim-cfn-dynamodb-table-stream-rules.js";
 
 /**
  * The AWS::DynamoDB::Table properties this simulation acts on.
@@ -49,7 +50,7 @@ const unsimulatedPropertyNames: ReadonlySet<string> = new Set([
 
 interface SimCfnDynamoDbTablePropertyRulesProperties {
   readonly logicalId: string;
-  readonly values: SimCfnDynamoDbTableValues;
+  readonly values: SimCfnDynamoDbPropertyValues;
 }
 
 /**
@@ -66,7 +67,7 @@ interface SimCfnDynamoDbTablePropertyRulesProperties {
  */
 export class SimCfnDynamoDbTablePropertyRules {
   private readonly logicalId: string;
-  private readonly values: SimCfnDynamoDbTableValues;
+  private readonly values: SimCfnDynamoDbPropertyValues;
 
   constructor(properties: SimCfnDynamoDbTablePropertyRulesProperties) {
     this.logicalId = properties.logicalId;
@@ -77,26 +78,14 @@ export class SimCfnDynamoDbTablePropertyRules {
    * Refuse everything about this Resource that is not simulated.
    */
   assertSimulated(): void {
-    for (const name of this.values.names) {
-      this.assertSimulatedProperty(name);
-    }
+    new SimCfnDynamoDbPropertyRules({
+      resourceTypeName: dynamoDbTableResourceTypeName,
+      logicalId: this.logicalId,
+      simulated: simulatedPropertyNames,
+      unsimulated: unsimulatedPropertyNames,
+    }).assertSimulated(this.values);
 
     this.assertSimulatedMembers();
-  }
-
-  private assertSimulatedProperty(name: string): void {
-    if (simulatedPropertyNames.has(name)) {
-      return;
-    }
-
-    if (unsimulatedPropertyNames.has(name)) {
-      throw dynamoDbTableUnsimulatedPropertyError(this.logicalId, name);
-    }
-
-    throw dynamoDbTablePropertyError(
-      this.logicalId,
-      `${name} is not an AWS::DynamoDB::Table property`,
-    );
   }
 
   /**
@@ -106,12 +95,14 @@ export class SimCfnDynamoDbTablePropertyRules {
   private assertSimulatedMembers(): void {
     const logicalId = this.logicalId;
 
-    SimCfnDynamoDbTableIndexRules.global(logicalId).assertSimulated(
+    simCfnDynamoDbTableGlobalIndexRules(logicalId).assertEachSimulated(
       this.values.list("GlobalSecondaryIndexes"),
     );
-    SimCfnDynamoDbTableIndexRules.local(logicalId).assertSimulated(
+    simCfnDynamoDbTableLocalIndexRules(logicalId).assertEachSimulated(
       this.values.list("LocalSecondaryIndexes"),
     );
-    new SimCfnDynamoDbTableStreamRules(logicalId).assertSimulated(this.values);
+    simCfnDynamoDbTableStreamRules(logicalId).assertSimulated(
+      this.values.object("StreamSpecification"),
+    );
   }
 }

--- a/src/service/dynamodb/cfn/table/sim-cfn-dynamodb-table-resource.factory.ts
+++ b/src/service/dynamodb/cfn/table/sim-cfn-dynamodb-table-resource.factory.ts
@@ -62,7 +62,7 @@ export const simCfnDynamoDbTableResourceFactory = new MappedFactory<
   (input) => ({
     Type: "AWS::DynamoDB::Table",
     Properties: {
-      ...namedBy(input.tableName),
+      ...simCfnDynamoDbTableNameProperty(input.tableName),
       ...simCfnDynamoDbTableKeyProperties(input),
       BillingMode: input.billingMode,
       ...input.properties,
@@ -72,8 +72,13 @@ export const simCfnDynamoDbTableResourceFactory = new MappedFactory<
 
 /**
  * The `TableName` property, for a template that names its table.
+ *
+ * Both Resource types that make a table name it the same way, so both build
+ * the property here.
  */
-function namedBy(tableName: string | undefined): SimCfnTemplateValueRecord {
+export function simCfnDynamoDbTableNameProperty(
+  tableName: string | undefined,
+): SimCfnTemplateValueRecord {
   if (tableName === undefined) {
     return {};
   }

--- a/src/service/dynamodb/cfn/table/sim-cfn-dynamodb-table-stream-rules.ts
+++ b/src/service/dynamodb/cfn/table/sim-cfn-dynamodb-table-stream-rules.ts
@@ -1,8 +1,5 @@
-import {
-  dynamoDbTablePropertyError,
-  dynamoDbTableUnsimulatedPropertyError,
-} from "./sim-cfn-dynamodb-table-property-error.js";
-import type { SimCfnDynamoDbTableValues } from "./sim-cfn-dynamodb-table-values.js";
+import { SimCfnDynamoDbPropertyRules } from "../property/sim-cfn-dynamodb-property-rules.js";
+import { dynamoDbTableResourceTypeName } from "../sim-cfn-dynamodb-resource-type.js";
 
 /**
  * The StreamSpecification properties this simulation acts on.
@@ -27,58 +24,21 @@ const unsimulatedStreamPropertyNames: ReadonlySet<string> = new Set([
 ]);
 
 /**
- * Which properties of a table's StreamSpecification simulated DynamoDB can act
- * on.
+ * The rules a table's `StreamSpecification` is read under.
  *
  * This is the table's own property rule applied a level down, as the index
  * rules are. A real property that is not simulated skips the table, since a
  * stream deployed without a policy the template asked for would be read by
  * whatever that policy was meant to keep out.
  */
-export class SimCfnDynamoDbTableStreamRules {
-  private readonly logicalId: string;
-
-  constructor(logicalId: string) {
-    this.logicalId = logicalId;
-  }
-
-  /**
-   * Refuse everything about the table's StreamSpecification that is not
-   * simulated.
-   *
-   * A table declaring no stream has nothing here to refuse.
-   */
-  assertSimulated(values: SimCfnDynamoDbTableValues): void {
-    const specification = values.object("StreamSpecification");
-
-    if (specification === undefined) {
-      return;
-    }
-
-    for (const name of specification.names) {
-      this.assertSimulatedProperty(specification, name);
-    }
-  }
-
-  private assertSimulatedProperty(
-    specification: SimCfnDynamoDbTableValues,
-    name: string,
-  ): void {
-    if (simulatedStreamPropertyNames.has(name)) {
-      return;
-    }
-
-    if (unsimulatedStreamPropertyNames.has(name)) {
-      throw dynamoDbTableUnsimulatedPropertyError(
-        this.logicalId,
-        specification.pathTo(name),
-      );
-    }
-
-    throw dynamoDbTablePropertyError(
-      this.logicalId,
-      `${specification.pathTo(name)} is not an AWS::DynamoDB::Table ` +
-        `StreamSpecification property`,
-    );
-  }
+export function simCfnDynamoDbTableStreamRules(
+  logicalId: string,
+): SimCfnDynamoDbPropertyRules {
+  return new SimCfnDynamoDbPropertyRules({
+    resourceTypeName: dynamoDbTableResourceTypeName,
+    logicalId,
+    kind: "StreamSpecification",
+    simulated: simulatedStreamPropertyNames,
+    unsimulated: unsimulatedStreamPropertyNames,
+  });
 }

--- a/src/service/dynamodb/cfn/table/sim-cfn-dynamodb-table-stream.ts
+++ b/src/service/dynamodb/cfn/table/sim-cfn-dynamodb-table-stream.ts
@@ -1,5 +1,5 @@
 import type { SimDynamoDbStreamSpecification } from "../../stream/sim-dynamodb-stream.types.js";
-import type { SimCfnDynamoDbTableValues } from "./sim-cfn-dynamodb-table-values.js";
+import type { SimCfnDynamoDbPropertyValues } from "../property/sim-cfn-dynamodb-property-values.js";
 
 /**
  * Read the stream an AWS::DynamoDB::Table Resource asks for.
@@ -15,7 +15,7 @@ import type { SimCfnDynamoDbTableValues } from "./sim-cfn-dynamodb-table-values.
  * in.
  */
 export function readSimCfnDynamoDbTableStream(
-  values: SimCfnDynamoDbTableValues,
+  values: SimCfnDynamoDbPropertyValues,
 ): SimDynamoDbStreamSpecification | undefined {
   const specification = values.object("StreamSpecification");
 

--- a/src/service/dynamodb/cfn/table/sim-cfn-dynamodb-table-throughput.ts
+++ b/src/service/dynamodb/cfn/table/sim-cfn-dynamodb-table-throughput.ts
@@ -1,5 +1,5 @@
 import type { SimDynamoDbProvisionedThroughput } from "../../command/table/table.types.js";
-import type { SimCfnDynamoDbTableValues } from "./sim-cfn-dynamodb-table-values.js";
+import type { SimCfnDynamoDbPropertyValues } from "../property/sim-cfn-dynamodb-property-values.js";
 
 /**
  * Read the capacity a `ProvisionedThroughput` property asks for.
@@ -9,7 +9,7 @@ import type { SimCfnDynamoDbTableValues } from "./sim-cfn-dynamodb-table-values.
  * copy of the shape.
  */
 export function readSimCfnDynamoDbThroughput(
-  values: SimCfnDynamoDbTableValues,
+  values: SimCfnDynamoDbPropertyValues,
 ): SimDynamoDbProvisionedThroughput | undefined {
   const throughput = values.object("ProvisionedThroughput");
 

--- a/src/service/dynamodb/cfn/table/sim-cfn-dynamodb-table-time-to-live.ts
+++ b/src/service/dynamodb/cfn/table/sim-cfn-dynamodb-table-time-to-live.ts
@@ -1,5 +1,5 @@
 import type { SimDynamoDbTimeToLiveSpecificationInput } from "../../command/time-to-live/time-to-live.types.js";
-import type { SimCfnDynamoDbTableValues } from "./sim-cfn-dynamodb-table-values.js";
+import type { SimCfnDynamoDbPropertyValues } from "../property/sim-cfn-dynamodb-property-values.js";
 
 /**
  * Read the time to live an AWS::DynamoDB::Table Resource asks for.
@@ -10,7 +10,7 @@ import type { SimCfnDynamoDbTableValues } from "./sim-cfn-dynamodb-table-values.
  * attribute is refused in the same words an SDK caller would get.
  */
 export function readSimCfnDynamoDbTableTimeToLive(
-  values: SimCfnDynamoDbTableValues,
+  values: SimCfnDynamoDbPropertyValues,
 ): SimDynamoDbTimeToLiveSpecificationInput | undefined {
   const specification = values.object("TimeToLiveSpecification");
 


### PR DESCRIPTION
A global table naming one replica is an ordinary table in that region, so it is read into the AWS::DynamoDB::Table it is and created down the path an ordinary table already takes. Two or more replicas skips the resource, naming the regions, since replication is not simulated.

Collapses the three near-identical table property rule classes into one shared SimCfnDynamoDbPropertyRules under cfn/property/, which now carries the resource type its refusals name.

Resolves #377