### PR TITLE
feat: ship simulated Rekognition sample images with fixed results

### DIFF
--- a/docs/services/rekognition/README.md
+++ b/docs/services/rekognition/README.md
@@ -354,6 +354,77 @@ A label can be declared as a name on its own, or as a name with what is to be re
 A moderation label declared as a name reports at a confidence of `96.68000030517578`, and a
 detection label at `97.53010559082031`.
 
+## Sample images
+
+Simulated Rekognition ships with five images whose hashes are already declared. A test uploads one
+through its own code and gets a known answer without registering anything, which is what makes an
+application that generates its own object keys testable: nothing in the test has to know the key.
+
+| Image                                              | Format | Detected as                                       |
+| -------------------------------------------------- | ------ | ------------------------------------------------- |
+| `simRekognitionSampleImages.passesModeration()`    | PNG    | no moderation labels                              |
+| `simRekognitionSampleImages.flaggedByModeration()` | JPEG   | `Violence`, `Graphic Violence`, `Weapon Violence` |
+| `simRekognitionSampleImages.noFaces()`             | PNG    | no faces                                          |
+| `simRekognitionSampleImages.oneFace()`             | JPEG   | one face, the built-in default face               |
+| `simRekognitionSampleImages.severalFaces()`        | PNG    | three faces                                       |
+
+```typescript sim-rekognition-sample-images
+/**
+ * A sample image uploaded under a key the application invented.
+ */
+
+import { randomUUID } from "node:crypto";
+
+import { DetectModerationLabelsCommand } from "@aws-sdk/client-rekognition";
+import { CreateBucketCommand, PutObjectCommand } from "@aws-sdk/client-s3";
+
+import { SimAws } from "@kensio/yulin";
+import { simRekognitionSampleImages } from "@kensio/yulin/rekognition";
+
+const simAws = new SimAws();
+await simAws.s3().createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+
+const key = `raw/${randomUUID()}.jpg`;
+
+await simAws.s3().putObject(
+  new PutObjectCommand({
+    Bucket: "uploads",
+    Key: key,
+    Body: simRekognitionSampleImages.flaggedByModeration(),
+  }),
+);
+
+const detected = await simAws.rekognition().detectModerationLabels(
+  new DetectModerationLabelsCommand({
+    Image: { S3Object: { Bucket: "uploads", Name: key } },
+  }),
+);
+
+console.log(detected.ModerationLabels.map((label) => label.Name));
+// [ "Violence", "Graphic Violence", "Weapon Violence" ]
+```
+
+Each image is declared for the one operation it is named for. The moderation images say nothing
+about faces and the face images say nothing about moderation, so those detections answer from their
+own rules as they would for any other image.
+
+The built-in rules are ordinary hash rules registered when the service is made, so declaring a rule
+for the same image replaces it. Note the precedence: a hash rule beats a name rule, so a sample
+image is overridden by hash rather than by the key it was uploaded under.
+
+```typescript
+const sample = simRekognitionSampleImages.flaggedByModeration();
+
+simAws
+  .rekognition()
+  .moderation()
+  .onHash(simRekognitionImageHash(sample), { labels: [] });
+```
+
+The images are real 16 by 16 PNG and JPEG files, 1,909 bytes in total, so the format check reads
+their magic bytes as it does for any other image. What they are pictures of decides nothing, since
+no image is looked at.
+
 ## Moderation labels come back with their parents
 
 A declared label expands to its whole chain in the version 7.0 moderation taxonomy, so handler code
@@ -496,10 +567,16 @@ An upload can moderate itself: a Bucket notification invokes a function, and the
 the object the event names. The function calls Rekognition in the Account and Region it runs in, so
 the rules a test registers on `simAws.rekognition()` are the ones it finds.
 
+This is the flow the sample images exist for. The object goes in under a key the application
+generated, and the sample image's own hash rule decides the result, so nothing in the test names the
+key.
+
 ```typescript sim-rekognition-upload-pipeline
 /**
  * An upload moderated by the Lambda function its Bucket notifies.
  */
+
+import { randomUUID } from "node:crypto";
 
 import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
 import {
@@ -514,6 +591,7 @@ import {
 
 import { SimAws } from "@kensio/yulin";
 import { makeLambdaCodeZip } from "@kensio/yulin/lambda";
+import { simRekognitionSampleImages } from "@kensio/yulin/rekognition";
 
 const simAws = new SimAws();
 const moderatorArn = `arn:aws:lambda:${simAws.defaultRegionName}:${simAws.defaultAccountId}:function:moderator`;
@@ -618,19 +696,13 @@ await simAws.s3().putBucketNotificationConfiguration(
   }),
 );
 
-simAws
-  .rekognition()
-  .moderation()
-  .onName("raw/nsfw.png", { labels: ["Explicit Nudity"] });
-
+// The sample image is already declared as failing moderation, so the key it
+// goes in under is the application's business rather than the test's.
 await simAws.s3().putObject(
   new PutObjectCommand({
     Bucket: "uploads",
-    Key: "raw/nsfw.png",
-    Body: Buffer.from(
-      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGO4I2IDAAL8AS3VzMq8AAAAAElFTkSuQmCC",
-      "base64",
-    ),
+    Key: `raw/${randomUUID()}.jpg`,
+    Body: simRekognitionSampleImages.flaggedByModeration(),
   }),
 );
 
@@ -702,6 +774,8 @@ Simulated Rekognition currently supports:
 - `Attributes` handling for face detection, with the default subset always returned, `ALL` adding
   the rest, and five landmarks reported unless `ALL` was asked for
 - `simRekognitionNoFaces` and `simRekognitionSeveralFaces`, for a test that counts faces
+- Five built-in sample images, real PNG and JPEG files with their hashes already declared, for a
+  clean and a flagged moderation result and for zero, one and three faces
 - `simRekognitionImageHash`, for hashing a fixture to declare a rule against
 - PNG and JPEG format detection from the image bytes
 - IAM authorization on `rekognition:DetectModerationLabels`, `rekognition:DetectLabels` and
@@ -740,6 +814,8 @@ Simulated Rekognition currently supports:
   content it identifies as such, which needs an image to look at.
 - Nothing looks at the image beyond its first few bytes. A PNG of a kitten declared as `Violence`
   comes back as `Violence`, and an image no rule matches gets the built-in `Mobile Phone` result.
+- The sample images are 16 by 16 pictures of coloured shapes, small enough to ship in the package.
+  They are not photographs of the things they are named for, because nothing decodes them.
 - The format comes from the image bytes and never from a stored content type. Simulated S3 keeps a
   `ContentType` given to `PutObject` as a metadata key, and has none at all when the uploader did
   not set one, so trusting it would make the same bytes detectable or not depending on how they were

--- a/docs/services/rekognition/sim-rekognition-sample-images.example.ts
+++ b/docs/services/rekognition/sim-rekognition-sample-images.example.ts
@@ -1,0 +1,33 @@
+/**
+ * A sample image uploaded under a key the application invented.
+ */
+
+import { randomUUID } from "node:crypto";
+
+import { DetectModerationLabelsCommand } from "@aws-sdk/client-rekognition";
+import { CreateBucketCommand, PutObjectCommand } from "@aws-sdk/client-s3";
+
+import { SimAws } from "@kensio/yulin";
+import { simRekognitionSampleImages } from "@kensio/yulin/rekognition";
+
+const simAws = new SimAws();
+await simAws.s3().createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+
+const key = `raw/${randomUUID()}.jpg`;
+
+await simAws.s3().putObject(
+  new PutObjectCommand({
+    Bucket: "uploads",
+    Key: key,
+    Body: simRekognitionSampleImages.flaggedByModeration(),
+  }),
+);
+
+const detected = await simAws.rekognition().detectModerationLabels(
+  new DetectModerationLabelsCommand({
+    Image: { S3Object: { Bucket: "uploads", Name: key } },
+  }),
+);
+
+console.log(detected.ModerationLabels.map((label) => label.Name));
+// [ "Violence", "Graphic Violence", "Weapon Violence" ]

--- a/docs/services/rekognition/sim-rekognition-upload-pipeline.example.ts
+++ b/docs/services/rekognition/sim-rekognition-upload-pipeline.example.ts
@@ -2,6 +2,8 @@
  * An upload moderated by the Lambda function its Bucket notifies.
  */
 
+import { randomUUID } from "node:crypto";
+
 import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
 import {
   AddPermissionCommand,
@@ -15,6 +17,7 @@ import {
 
 import { SimAws } from "@kensio/yulin";
 import { makeLambdaCodeZip } from "@kensio/yulin/lambda";
+import { simRekognitionSampleImages } from "@kensio/yulin/rekognition";
 
 const simAws = new SimAws();
 const moderatorArn = `arn:aws:lambda:${simAws.defaultRegionName}:${simAws.defaultAccountId}:function:moderator`;
@@ -119,19 +122,13 @@ await simAws.s3().putBucketNotificationConfiguration(
   }),
 );
 
-simAws
-  .rekognition()
-  .moderation()
-  .onName("raw/nsfw.png", { labels: ["Explicit Nudity"] });
-
+// The sample image is already declared as failing moderation, so the key it
+// goes in under is the application's business rather than the test's.
 await simAws.s3().putObject(
   new PutObjectCommand({
     Bucket: "uploads",
-    Key: "raw/nsfw.png",
-    Body: Buffer.from(
-      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGO4I2IDAAL8AS3VzMq8AAAAAElFTkSuQmCC",
-      "base64",
-    ),
+    Key: `raw/${randomUUID()}.jpg`,
+    Body: simRekognitionSampleImages.flaggedByModeration(),
   }),
 );
 

--- a/src/service/rekognition/README.md
+++ b/src/service/rekognition/README.md
@@ -140,6 +140,29 @@ routinely excludes the chin. Landmark pairs that run across the face, such as `e
 `eyeRight`, are required to be in the order Rekognition reports them in, so a declaration with the
 two swapped is refused where it was written.
 
+## Sample images
+
+`sample/` is the five images that ship with the service, for the case the hash rules exist for: an
+application that generates its own object keys, where the name a detection sees is not something a
+test can match on.
+
+`sample/sim-rekognition-sample-image-files.ts` holds them as base64, so a sample image is the same
+bytes in the published package as it is here and reading one needs no filesystem. They are real 16
+by 16 PNG and JPEG files, 1,909 bytes in total, which is what keeps the format check applying to
+them as it does to any other image. Re-encoding one would change its hash and leave its rule
+matching nothing, so they are checked in rather than generated.
+
+`sample/sim-rekognition-sample-rules.ts` is what each one is declared as.
+`SimRekognitionModeration` and `SimRekognitionFaces` register those as ordinary hash rules in their
+constructors, which is the whole of the mechanism: a rule a test registers for the same image
+replaces the built-in one through the usual precedence, and nothing anywhere special-cases a sample
+image. It also means a sample image beats a name rule for the key it was uploaded under, since a
+hash rule wins.
+
+Each image is declared for the one operation it is named for. Declaring the face images as clean for
+moderation as well would decide something the image is not named for, and the moderation default
+already reports a clean image.
+
 ## Images
 
 `image/` is the path from a request to the bytes a rule is matched against.

--- a/src/service/rekognition/face/sim-rekognition-faces.ts
+++ b/src/service/rekognition/face/sim-rekognition-faces.ts
@@ -1,5 +1,6 @@
 import type { SimRekognitionImage } from "../image/sim-rekognition-image.js";
 import { SimRekognitionResultRules } from "../rule/sim-rekognition-result-rules.js";
+import { simRekognitionSampleFaceRules } from "../sample/sim-rekognition-sample-rules.js";
 import type { SimRekognitionFacesResult } from "./sim-rekognition-face-declaration.js";
 import { SimRekognitionFaceDetection } from "./sim-rekognition-face-detection.js";
 import { simRekognitionDefaultFaces } from "./sim-rekognition-face-defaults.js";
@@ -16,6 +17,17 @@ export class SimRekognitionFaces {
     new SimRekognitionResultRules<SimRekognitionFaceDetection>(
       new SimRekognitionFaceDetection(simRekognitionDefaultFaces),
     );
+
+  /**
+   * The sample images are declared as ordinary hash rules, so a rule a test
+   * registers for the same image replaces the built-in one through the usual
+   * precedence rather than through anything special-cased here.
+   */
+  constructor() {
+    for (const sample of simRekognitionSampleFaceRules) {
+      this.onHash(sample.image.hash, sample.result);
+    }
+  }
 
   /**
    * Answer with this result for any image no other rule matches.

--- a/src/service/rekognition/index.ts
+++ b/src/service/rekognition/index.ts
@@ -52,6 +52,10 @@ export {
 } from "./moderation/sim-rekognition-moderation-taxonomy.js";
 export { simRekognitionImageHash } from "./image/sim-rekognition-image-hash.js";
 export {
+  simRekognitionSampleImages,
+  SimRekognitionSampleImages,
+} from "./sample/sim-rekognition-sample-images.js";
+export {
   SimRekognitionAccessDeniedException,
   SimRekognitionDeclarationError,
   SimRekognitionError,

--- a/src/service/rekognition/moderation/sim-rekognition-moderation.ts
+++ b/src/service/rekognition/moderation/sim-rekognition-moderation.ts
@@ -1,5 +1,6 @@
 import type { SimRekognitionImage } from "../image/sim-rekognition-image.js";
 import { SimRekognitionResultRules } from "../rule/sim-rekognition-result-rules.js";
+import { simRekognitionSampleModerationRules } from "../sample/sim-rekognition-sample-rules.js";
 import {
   SimRekognitionModerationDetection,
   type SimRekognitionModerationResult,
@@ -27,6 +28,17 @@ export class SimRekognitionModeration {
     new SimRekognitionResultRules<SimRekognitionModerationDetection>(
       new SimRekognitionModerationDetection(cleanImage),
     );
+
+  /**
+   * The sample images are declared as ordinary hash rules, so a rule a test
+   * registers for the same image replaces the built-in one through the usual
+   * precedence rather than through anything special-cased here.
+   */
+  constructor() {
+    for (const sample of simRekognitionSampleModerationRules) {
+      this.onHash(sample.image.hash, sample.result);
+    }
+  }
 
   /**
    * Answer with this result for any image no other rule matches.

--- a/src/service/rekognition/sample/sim-rekognition-sample-image-files.ts
+++ b/src/service/rekognition/sample/sim-rekognition-sample-image-files.ts
@@ -1,0 +1,72 @@
+/* eslint-disable no-secrets/no-secrets -- base64 image files, not secrets. */
+import { SimRekognitionSampleImage } from "./sim-rekognition-sample-image.js";
+
+/**
+ * The images that ship with simulated Rekognition.
+ *
+ * Each is a real 16 by 16 PNG or JPEG, so the format check reads the same
+ * magic bytes from a sample image as from any other image and there is no
+ * path around it. Three are PNG and two are JPEG, which is the pair of formats
+ * Rekognition accepts.
+ *
+ * They are 1,909 bytes in total, held here as base64. What they are pictures
+ * of decides nothing: no image is looked at, and each one answers from the
+ * rule registered against its hash. They are pictures of something anyway,
+ * because an image that reads as a photograph of a landscape is easier to
+ * follow in a test than a rectangle of one colour.
+ *
+ * The bytes are fixed. Re-encoding one would change its hash and leave the
+ * built-in rule matching nothing, so they are checked in as they are rather
+ * than generated at build time.
+ */
+export const simRekognitionSampleImageFiles = {
+  passesModeration: new SimRekognitionSampleImage(
+    "iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAAAHklEQVR42mMwTp" +
+      "tJEmKgo4ZPz07iQaMaho+GQZP4ABIcwWyZg5lwAAAAAElFTkSuQmCC",
+  ),
+  flaggedByModeration: new SimRekognitionSampleImage(
+    "/9j/4AAQSkZJRgABAQAASABIAAD/wAARCAAQABADASIAAhEBAxEB/8QAHwAAAQ" +
+      "UBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9" +
+      "AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJi" +
+      "coKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWG" +
+      "h4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19" +
+      "jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEAAwEBAQEBAQEBAQAAAAAAAAEC" +
+      "AwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSExBhJBUQdhcR" +
+      "MiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZH" +
+      "SElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoq" +
+      "OkpaanqKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP0" +
+      "9fb3+Pn6/9sAQwAEBAQEBAQGBAQGCQYGBgkMCQkJCQwPDAwMDAwPEg8PDw8PDx" +
+      "ISEhISEhISFRUVFRUVGRkZGRkcHBwcHBwcHBwc/9sAQwEEBQUHBwcMBwcMHRQQ" +
+      "FB0dHR0dHR0dHR0dHR0dHR0dHR0dHR0dHR0dHR0dHR0dHR0dHR0dHR0dHR0dHR" +
+      "0dHR0d/90ABAAB/9oADAMBAAIRAxEAPwDwL7//AE08z95+848zH/LWX+7Ev8K9" +
+      "6Pv/APTTzP3n7zjzMf8ALWX+7Ev8K96Pv/8ATTzP3n7zjzMf8tZf7sS/wr3o+/" +
+      "8A9NPM/efvOPMx/wAtZf7sS/wr3rxv6/r+vutp+l7/ANf8P387363/AHn/2Q==",
+  ),
+  noFaces: new SimRekognitionSampleImage(
+    "iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAAAG0lEQVR42mNo3/" +
+      "uCJMQwqmGIavDvsicJjUgNAOxJxJC8NL++AAAAAElFTkSuQmCC",
+  ),
+  oneFace: new SimRekognitionSampleImage(
+    "/9j/4AAQSkZJRgABAQAASABIAAD/wAARCAAQABADASIAAhEBAxEB/8QAHwAAAQ" +
+      "UBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9" +
+      "AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJi" +
+      "coKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWG" +
+      "h4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19" +
+      "jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEAAwEBAQEBAQEBAQAAAAAAAAEC" +
+      "AwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSExBhJBUQdhcR" +
+      "MiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZH" +
+      "SElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoq" +
+      "OkpaanqKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP0" +
+      "9fb3+Pn6/9sAQwAEBAQEBAQGBAQGCQYGBgkMCQkJCQwPDAwMDAwPEg8PDw8PDx" +
+      "ISEhISEhISFRUVFRUVGRkZGRkcHBwcHBwcHBwc/9sAQwEEBQUHBwcMBwcMHRQQ" +
+      "FB0dHR0dHR0dHR0dHR0dHR0dHR0dHR0dHR0dHR0dHR0dHR0dHR0dHR0dHR0dHR" +
+      "0dHR0d/90ABAAB/9oADAMBAAIRAxEAPwD2ZF3sF6ZoddjFeuK8bHivXwci6x/w" +
+      "BP8A4mg+K9fJybrP/AE/+Jrp/wBZaPtub3uS21lvfe9+x8jy0/YcvL799/K21v" +
+      "U//9k=",
+  ),
+  severalFaces: new SimRekognitionSampleImage(
+    "iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAAAMElEQVR42mNo3/" +
+      "uCJMQwJDQ82DAJgnBqQFNBqQY0LjU04PcS4VBC1+DfZU8SGpEaAJaDwyjublVb" +
+      "AAAAAElFTkSuQmCC",
+  ),
+};

--- a/src/service/rekognition/sample/sim-rekognition-sample-image.ts
+++ b/src/service/rekognition/sample/sim-rekognition-sample-image.ts
@@ -1,0 +1,35 @@
+import { simRekognitionImageHash } from "../image/sim-rekognition-image-hash.js";
+
+/**
+ * One image that ships with simulated Rekognition.
+ *
+ * The bytes are held as base64 in the source rather than as a file beside it,
+ * so a sample image is the same bytes in the published package as in this
+ * repository, and reading one needs no filesystem.
+ *
+ * The hash is taken once, when the image is made, because it is what the
+ * built-in rules are registered against.
+ */
+export class SimRekognitionSampleImage {
+  /**
+   * The content hash of this image, which is the hash a rule matches it by.
+   */
+  public readonly hash: string;
+
+  private readonly image: Uint8Array;
+
+  constructor(base64: string) {
+    this.image = Uint8Array.from(Buffer.from(base64, "base64"));
+    this.hash = simRekognitionImageHash(this.image);
+  }
+
+  /**
+   * The bytes of this image.
+   *
+   * A copy, so a caller that writes into what it uploaded cannot change what
+   * the next caller gets and leave the built-in rule matching nothing.
+   */
+  bytes(): Uint8Array {
+    return Uint8Array.from(this.image);
+  }
+}

--- a/src/service/rekognition/sample/sim-rekognition-sample-images.iso.test.ts
+++ b/src/service/rekognition/sample/sim-rekognition-sample-images.iso.test.ts
@@ -1,0 +1,88 @@
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNumberBetween,
+  assertSetSize,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { simRekognitionImageFormat } from "../image/sim-rekognition-image-format.js";
+import { simRekognitionImageHash } from "../image/sim-rekognition-image-hash.js";
+import { simRekognitionSampleImageFiles } from "./sim-rekognition-sample-image-files.js";
+import { simRekognitionSampleImages } from "./sim-rekognition-sample-images.js";
+
+const everySample = [
+  simRekognitionSampleImages.passesModeration(),
+  simRekognitionSampleImages.flaggedByModeration(),
+  simRekognitionSampleImages.noFaces(),
+  simRekognitionSampleImages.oneFace(),
+  simRekognitionSampleImages.severalFaces(),
+];
+
+describe("The simulated Rekognition sample images", () => {
+  it("are images in the two formats Rekognition reads", () => {
+    // Given the sample images.
+    // When each one's format is identified from its own bytes.
+    const formats = everySample.map((bytes) =>
+      simRekognitionImageFormat(bytes),
+    );
+
+    // Then each is a real PNG or JPEG, so the format check applies to a
+    // sample image as it does to any other image, with no path around it.
+    assertArrayLength(formats, 5);
+    assertIdentical(formats[1], "JPEG");
+    assertIdentical(formats[3], "JPEG");
+    assertIdentical(formats[0], "PNG");
+  });
+
+  it("are five different images", () => {
+    // Given the sample images.
+    // When their content hashes are taken.
+    const hashes = new Set(
+      everySample.map((bytes) => simRekognitionImageHash(bytes)),
+    );
+
+    // Then no two share a hash, so no two share a rule.
+    assertSetSize(hashes, 5);
+  });
+
+  it("hash to what their built-in rules were registered against", () => {
+    // Given one sample image.
+    const bytes = simRekognitionSampleImages.oneFace();
+
+    // When it is hashed the way a test would hash a fixture.
+    const hash = simRekognitionImageHash(bytes);
+
+    // Then it is the hash the image itself reports, which is what the
+    // built-in rule was registered against.
+    assertIdentical(hash, simRekognitionSampleImageFiles.oneFace.hash);
+  });
+
+  it("answer with a copy, so one caller cannot spoil another's", () => {
+    // Given the bytes of a sample image.
+    const first = simRekognitionSampleImages.noFaces();
+
+    // When a caller writes into them.
+    first.set([0x00, 0x00, 0x00, 0x00]);
+
+    // Then the next caller still gets the image, and its hash still matches
+    // the rule registered for it.
+    const second = simRekognitionSampleImages.noFaces();
+    assertIdentical(simRekognitionImageFormat(second), "PNG");
+    assertIdentical(
+      simRekognitionImageHash(second),
+      simRekognitionSampleImageFiles.noFaces.hash,
+    );
+  });
+
+  it("stay small enough to ship in the package", () => {
+    // Given the sample images.
+    // When their sizes are added up.
+    const bytes = everySample.reduce((total, image) => total + image.length, 0);
+
+    // Then they are the couple of kilobytes they were meant to be. They ship
+    // in the published package, so this is a size budget rather than a fact
+    // about the pictures.
+    assertNumberBetween(bytes, 1, 4096);
+  });
+});

--- a/src/service/rekognition/sample/sim-rekognition-sample-images.ts
+++ b/src/service/rekognition/sample/sim-rekognition-sample-images.ts
@@ -1,0 +1,68 @@
+import { simRekognitionSampleImageFiles as files } from "./sim-rekognition-sample-image-files.js";
+
+/**
+ * The images simulated Rekognition ships with, each already declared as a
+ * rule.
+ *
+ * They are for the case the hash rules exist for: a system that generates its
+ * own object keys, where the name a detection sees is not something a test can
+ * match on. A test uploads one of these through its own code and gets a known
+ * answer without configuring anything.
+ *
+ * ```typescript
+ * await simAws.s3().putObject(
+ *   new PutObjectCommand({
+ *     Bucket: "uploads",
+ *     Key: randomUUID(),
+ *     Body: simRekognitionSampleImages.flaggedByModeration(),
+ *   }),
+ * );
+ * ```
+ *
+ * Each image is declared for the one operation it is named for. The
+ * moderation images say nothing about faces, and the face images say nothing
+ * about moderation, so those detections answer from their own rules as they
+ * would for any other image.
+ */
+export class SimRekognitionSampleImages {
+  /**
+   * A PNG that content moderation finds nothing in.
+   */
+  passesModeration(): Uint8Array {
+    return files.passesModeration.bytes();
+  }
+
+  /**
+   * A JPEG that content moderation flags, as `Weapon Violence` and the two
+   * labels above it in the taxonomy.
+   */
+  flaggedByModeration(): Uint8Array {
+    return files.flaggedByModeration.bytes();
+  }
+
+  /**
+   * A PNG with nobody in it.
+   */
+  noFaces(): Uint8Array {
+    return files.noFaces.bytes();
+  }
+
+  /**
+   * A JPEG with one face in it, reported as the built-in default face.
+   */
+  oneFace(): Uint8Array {
+    return files.oneFace.bytes();
+  }
+
+  /**
+   * A PNG with three faces in it.
+   */
+  severalFaces(): Uint8Array {
+    return files.severalFaces.bytes();
+  }
+}
+
+/**
+ * The sample images simulated Rekognition ships with.
+ */
+export const simRekognitionSampleImages = new SimRekognitionSampleImages();

--- a/src/service/rekognition/sample/sim-rekognition-sample-rules.iso.test.ts
+++ b/src/service/rekognition/sample/sim-rekognition-sample-rules.iso.test.ts
@@ -1,0 +1,176 @@
+import { randomUUID } from "node:crypto";
+
+import {
+  DetectFacesCommand,
+  DetectModerationLabelsCommand,
+} from "@aws-sdk/client-rekognition";
+import { CreateBucketCommand, PutObjectCommand } from "@aws-sdk/client-s3";
+import {
+  assertArrayEquals,
+  assertArrayLength,
+  assertIdentical,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import { simRekognitionImageHash } from "../image/sim-rekognition-image-hash.js";
+import { simRekognitionSampleImages } from "./sim-rekognition-sample-images.js";
+
+/**
+ * Upload a sample image under a key the application invented, which is the
+ * case the sample images exist for.
+ */
+async function upload(simAws: SimAws, body: Uint8Array): Promise<string> {
+  const key = randomUUID();
+
+  await simAws
+    .s3()
+    .putObject(
+      new PutObjectCommand({ Bucket: "uploads", Key: key, Body: body }),
+    );
+
+  return key;
+}
+
+async function simAwsWithBucket(): Promise<SimAws> {
+  const simAws = new SimAws();
+  await simAws
+    .s3()
+    .createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+
+  return simAws;
+}
+
+async function moderate(
+  simAws: SimAws,
+  key: string,
+): Promise<readonly string[]> {
+  const detected = await simAws.rekognition().detectModerationLabels(
+    new DetectModerationLabelsCommand({
+      Image: { S3Object: { Bucket: "uploads", Name: key } },
+    }),
+  );
+
+  return detected.ModerationLabels.map((label) => label.Name);
+}
+
+async function faceCount(simAws: SimAws, key: string): Promise<number> {
+  const detected = await simAws.rekognition().detectFaces(
+    new DetectFacesCommand({
+      Image: { S3Object: { Bucket: "uploads", Name: key } },
+    }),
+  );
+
+  return detected.FaceDetails.length;
+}
+
+describe("Detecting on a simulated Rekognition sample image", () => {
+  it("flags the flagged image under a key nothing was declared for", async () => {
+    // Given the flagged sample image, uploaded under a generated key.
+    const simAws = await simAwsWithBucket();
+    const key = await upload(
+      simAws,
+      simRekognitionSampleImages.flaggedByModeration(),
+    );
+
+    // When it is moderated.
+    const labels = await moderate(simAws, key);
+
+    // Then it fails, with the chain above the label it was declared as, and
+    // the test never had to name the key or hash anything.
+    assertArrayEquals(labels, [
+      "Violence",
+      "Graphic Violence",
+      "Weapon Violence",
+    ]);
+  });
+
+  it("keeps the clean image clean when the default says otherwise", async () => {
+    // Given a test that declared every other image as failing moderation.
+    const simAws = await simAwsWithBucket();
+    simAws
+      .rekognition()
+      .moderation()
+      .byDefault({ labels: ["Weapon Violence"] });
+    const key = await upload(
+      simAws,
+      simRekognitionSampleImages.passesModeration(),
+    );
+
+    // When the clean sample image is moderated.
+    const labels = await moderate(simAws, key);
+
+    // Then it is still clean: it has a hash rule of its own, and a hash rule
+    // wins over the default.
+    assertArrayLength(labels, 0);
+  });
+
+  it("answers with the faces each face sample was declared to hold", async () => {
+    // Given the three face sample images, uploaded under generated keys.
+    const simAws = await simAwsWithBucket();
+    const empty = await upload(simAws, simRekognitionSampleImages.noFaces());
+    const one = await upload(simAws, simRekognitionSampleImages.oneFace());
+    const several = await upload(
+      simAws,
+      simRekognitionSampleImages.severalFaces(),
+    );
+
+    // When faces are detected in each.
+    // Then each answers with what it is named for.
+    assertIdentical(await faceCount(simAws, empty), 0);
+    assertIdentical(await faceCount(simAws, one), 1);
+    assertIdentical(await faceCount(simAws, several), 3);
+  });
+
+  it("leaves the operations a sample says nothing about to their own rules", async () => {
+    // Given a face sample image uploaded under a generated key.
+    const simAws = await simAwsWithBucket();
+    const key = await upload(simAws, simRekognitionSampleImages.severalFaces());
+
+    // When it is moderated rather than detected for faces.
+    const labels = await moderate(simAws, key);
+
+    // Then moderation answers from its own rules, which report a clean image
+    // until a test says otherwise.
+    assertArrayLength(labels, 0);
+  });
+
+  it("is overridden by a rule registered for the same image", async () => {
+    // Given a test that declared the flagged sample image as clean.
+    const simAws = await simAwsWithBucket();
+    const bytes = simRekognitionSampleImages.flaggedByModeration();
+    simAws
+      .rekognition()
+      .moderation()
+      .onHash(simRekognitionImageHash(bytes), { labels: [] });
+    const key = await upload(simAws, bytes);
+
+    // When it is moderated.
+    const labels = await moderate(simAws, key);
+
+    // Then the test's rule answers. The built-in rules are ordinary hash
+    // rules, so registering one for the same image replaces it.
+    assertArrayLength(labels, 0);
+  });
+
+  it("ships the built-in rules with every Account and Region", async () => {
+    // Given a Rekognition in another Region, which nothing was declared
+    // against.
+    const simAws = new SimAws();
+
+    // When the flagged sample image is moderated there, as bytes.
+    const detected = await simAws
+      .account("111111111111")
+      .region("eu-west-2")
+      .rekognition()
+      .detectModerationLabels(
+        new DetectModerationLabelsCommand({
+          Image: { Bytes: simRekognitionSampleImages.flaggedByModeration() },
+        }),
+      );
+
+    // Then it fails there too, since each scope registers the built-in rules
+    // for itself.
+    assertArrayLength(detected.ModerationLabels, 3);
+  });
+});

--- a/src/service/rekognition/sample/sim-rekognition-sample-rules.ts
+++ b/src/service/rekognition/sample/sim-rekognition-sample-rules.ts
@@ -1,0 +1,49 @@
+import type { SimRekognitionFacesResult } from "../face/sim-rekognition-face-declaration.js";
+import {
+  simRekognitionDefaultFaces,
+  simRekognitionNoFaces,
+  simRekognitionSeveralFaces,
+} from "../face/sim-rekognition-face-defaults.js";
+import type { SimRekognitionModerationResult } from "../moderation/sim-rekognition-moderation-result.js";
+import { simRekognitionSampleImageFiles as files } from "./sim-rekognition-sample-image-files.js";
+import type { SimRekognitionSampleImage } from "./sim-rekognition-sample-image.js";
+
+/**
+ * What one sample image is declared to hold.
+ */
+export interface SimRekognitionSampleRule<TResult> {
+  readonly image: SimRekognitionSampleImage;
+  readonly result: TResult;
+}
+
+/**
+ * What the sample images are declared as for content moderation.
+ *
+ * The clean image is declared rather than left to the default, so it stays
+ * clean in a test that declared everything else as failing.
+ *
+ * `Weapon Violence` is a third level label, so the flagged image arrives with
+ * `Violence` and `Graphic Violence` above it and exercises the chain a real
+ * moderation handler reads.
+ */
+export const simRekognitionSampleModerationRules: readonly SimRekognitionSampleRule<SimRekognitionModerationResult>[] =
+  [
+    { image: files.passesModeration, result: { labels: [] } },
+    {
+      image: files.flaggedByModeration,
+      result: { labels: ["Weapon Violence"] },
+    },
+  ];
+
+/**
+ * What the sample images are declared as for face detection.
+ *
+ * The one face image answers with the built-in default face, which is the
+ * face from the AWS DetectFaces example response and carries every attribute.
+ */
+export const simRekognitionSampleFaceRules: readonly SimRekognitionSampleRule<SimRekognitionFacesResult>[] =
+  [
+    { image: files.noFaces, result: simRekognitionNoFaces },
+    { image: files.oneFace, result: simRekognitionDefaultFaces },
+    { image: files.severalFaces, result: simRekognitionSeveralFaces },
+  ];

--- a/src/service/rekognition/sim-rekognition-moderation-pipeline.iso.test.ts
+++ b/src/service/rekognition/sim-rekognition-moderation-pipeline.iso.test.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { text } from "node:stream/consumers";
 import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
 import {
@@ -23,6 +24,7 @@ import {
 } from "../../../test/rekognition/image-fixture.js";
 import { SimAws } from "../aws/sim-aws.js";
 import { makeLambdaCodeZip } from "../lambda/function/code/make-lambda-code-zip.js";
+import { simRekognitionSampleImages } from "./sample/sim-rekognition-sample-images.js";
 
 /**
  * A moderation handler as an application would write one: it reads the object
@@ -175,6 +177,36 @@ describe("Moderating an uploaded image through a simulated pipeline", () => {
     );
     assertNonNullable(flagged.Body);
     assertStringIncludes(await text(flagged.Body), "Explicit,Explicit Nudity");
+  });
+
+  it("flags a sample image uploaded under a key nothing was declared for", async () => {
+    // Given the same pipeline, with no rules registered by this test, and a
+    // key the application generated rather than the test.
+    const simAws = await simAwsWithModerationPipeline();
+    const key = `raw/${randomUUID()}.jpg`;
+
+    // When the flagged sample image is uploaded under it.
+    await simAws.s3().putObject(
+      new PutObjectCommand({
+        Bucket: "uploads",
+        Key: key,
+        Body: simRekognitionSampleImages.flaggedByModeration(),
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // Then the sample image's own hash rule decided the result, so a test of
+    // an application that names its own objects needs no rule of its own.
+    const flagged = await simAws
+      .s3()
+      .getObject(
+        new GetObjectCommand({ Bucket: "uploads", Key: `flagged/${key}` }),
+      );
+    assertNonNullable(flagged.Body);
+    assertStringIncludes(
+      await text(flagged.Body),
+      "Violence,Graphic Violence,Weapon Violence",
+    );
   });
 
   it("leaves a clean upload alone", async () => {


### PR DESCRIPTION
simRekognitionSampleImages gives five real PNG and JPEG images, 1,909 bytes in total, whose hashes are declared when the service is made: a clean and a flagged moderation result, and zero, one and three faces. A test uploads one through its own code, under a key the application generated, and gets a known answer without registering anything.

They are registered as ordinary hash rules, so a rule declared for the same image replaces one through the usual precedence.

Resolves https://github.com/KensioSoftware/yulin/issues/320