### PR TITLE
feat: query and scan simulated DynamoDB with the document client

### DIFF
--- a/docs/services/dynamodb/README.md
+++ b/docs/services/dynamodb/README.md
@@ -2850,14 +2850,99 @@ const tags = read.Item?.["tags"] as Set<string>;
 console.log(tags.has("priority")); // true
 ```
 
-`PutCommand`, `GetCommand`, `DeleteCommand`, `UpdateCommand`, `BatchWriteCommand` and
-`BatchGetCommand` are converted. A document Command with no route here, such as
-`TransactWriteCommand`, is refused by name before anything tries to convert its values.
+`PutCommand`, `GetCommand`, `DeleteCommand`, `UpdateCommand`, `QueryCommand`, `ScanCommand`,
+`BatchWriteCommand` and `BatchGetCommand` are converted. A document Command with no route here, such
+as `TransactWriteCommand`, is refused by name before anything tries to convert its values.
 
 Intercept the document client itself. `DynamoDBDocumentClient.from(client)` builds a separate object
 that is not an instance of `DynamoDBClient`, so intercepting the base client does nothing for
 Commands sent through the document one. See
 [the SDK docs](../../sdk/README.md#the-dynamodb-document-client).
+
+### Querying and scanning through the document client
+
+`@aws-sdk/lib-dynamodb` names its `QueryCommand` and `ScanCommand` exactly as
+`@aws-sdk/client-dynamodb` does. Both are routed, and which one a request gets is decided by the
+Command it was sent with rather than by the name, so the two can be used on the same intercepted
+client.
+
+Expression values and `ExclusiveStartKey` are converted on the way in, and `Items` and
+`LastEvaluatedKey` on the way out. A key from one page goes straight back in as the start of the
+next, so `paginateQuery` and `paginateScan` work as they are.
+
+```typescript sim-dynamodb-document-read
+/**
+ * Querying a simulated table through the document client, a page at a time.
+ */
+
+import { CreateTableCommand, DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import {
+  DynamoDBDocumentClient,
+  paginateQuery,
+  PutCommand,
+  QueryCommand,
+} from "@aws-sdk/lib-dynamodb";
+
+import { SimSdk } from "@kensio/yulin/sdk";
+
+using simSdk = new SimSdk();
+
+const documents = DynamoDBDocumentClient.from(
+  new DynamoDBClient({ region: "eu-west-2" }),
+);
+simSdk.intercept(documents);
+
+await documents.send(
+  new CreateTableCommand({
+    TableName: "OrdersTable",
+    KeySchema: [
+      { AttributeName: "customerId", KeyType: "HASH" },
+      { AttributeName: "orderId", KeyType: "RANGE" },
+    ],
+    AttributeDefinitions: [
+      { AttributeName: "customerId", AttributeType: "S" },
+      { AttributeName: "orderId", AttributeType: "S" },
+    ],
+    BillingMode: "PAY_PER_REQUEST",
+  }),
+);
+await simSdk.simAws.backgroundTasksComplete();
+
+for (const orderId of ["order-1", "order-2"]) {
+  await documents.send(
+    new PutCommand({
+      TableName: "OrdersTable",
+      Item: { customerId: "cust-1", orderId, total: 42 },
+    }),
+  );
+}
+
+const query = {
+  TableName: "OrdersTable",
+  KeyConditionExpression: "customerId = :customer",
+  ExpressionAttributeValues: { ":customer": "cust-1" },
+  Limit: 1,
+};
+
+const first = await documents.send(new QueryCommand(query));
+
+console.log(first.Items?.[0]?.["total"]); // 42
+
+// The key comes back as plain JavaScript, and goes back in as it is.
+const second = await documents.send(
+  new QueryCommand({ ...query, ExclusiveStartKey: first.LastEvaluatedKey }),
+);
+
+console.log(second.Items?.[0]?.["orderId"]); // order-2
+
+// The paginators send the same Commands, so they need nothing extra. Each one
+// writes the next start key into the input it was given, so it gets a copy.
+const pages = paginateQuery({ client: documents, pageSize: 1 }, { ...query });
+
+for await (const page of pages) {
+  console.log(page.Items?.length); // 1
+}
+```
 
 ### Which native types map to which descriptors
 
@@ -3449,22 +3534,20 @@ Arn`, `Fn::GetAtt … StreamArn` and `Fn::GetAtt … TableId` answering. A CDK `
 - SDK interception, so an intercepted `DynamoDBClient` or `DynamoDBStreamsClient` reaches the
   simulation.
 - The `@aws-sdk/lib-dynamodb` document client, with `PutCommand`, `GetCommand`, `DeleteCommand`,
-  `UpdateCommand`, `BatchWriteCommand` and `BatchGetCommand` converting native JavaScript values on
-  the way in and out.
+  `UpdateCommand`, `QueryCommand`, `ScanCommand`, `BatchWriteCommand` and `BatchGetCommand`
+  converting native JavaScript values on the way in and out, and `paginateQuery` and `paginateScan`
+  paging through a simulated table.
 
 ## Limitations
 
-- The document client's `Query`, `Scan`, transaction and PartiQL Commands are not converted. PartiQL
-  is an operation this simulation does not have yet. The rest are simulated as operations, so only
-  the document form is missing: for the transaction Commands that is simply not written yet, and for
-  `Query` and `Scan` it is because `@aws-sdk/lib-dynamodb` and `@aws-sdk/client-dynamodb` both name
-  their Commands `QueryCommand` and `ScanCommand`, which the interception routes by. All of them are
-  refused by name rather than half converted.
+- The document client's transaction and PartiQL Commands are not converted. PartiQL is an operation
+  this simulation does not have yet. The transactions are simulated as operations, so only the
+  document form of them is missing. Both are refused by name rather than half converted.
 - A document client's translate config is not read, so the marshalling options it was built with do
   not apply. See [the SDK docs](../../sdk/README.md#limitations).
-- `Expected`, `ConditionalOperator` and `AttributeUpdates` are not converted for the document
-  client, because simulated DynamoDB refuses all three anyway. A request carrying one is refused by
-  the operation rather than by the conversion.
+- `Expected`, `ConditionalOperator`, `AttributeUpdates`, `KeyConditions`, `QueryFilter` and
+  `ScanFilter` are not converted for the document client, because simulated DynamoDB refuses all six
+  anyway. A request carrying one is refused by the operation rather than by the conversion.
 - A read of a global secondary index answers with the attributes the index projects, and nothing
   fills in the rest. Real DynamoDB does not either: it never reads the base table for an attribute a
   global secondary index does not project, which is why `Select: ALL_ATTRIBUTES` against a partial

--- a/docs/services/dynamodb/sim-dynamodb-document-read.example.ts
+++ b/docs/services/dynamodb/sim-dynamodb-document-read.example.ts
@@ -1,0 +1,71 @@
+/**
+ * Querying a simulated table through the document client, a page at a time.
+ */
+
+import { CreateTableCommand, DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import {
+  DynamoDBDocumentClient,
+  paginateQuery,
+  PutCommand,
+  QueryCommand,
+} from "@aws-sdk/lib-dynamodb";
+
+import { SimSdk } from "@kensio/yulin/sdk";
+
+using simSdk = new SimSdk();
+
+const documents = DynamoDBDocumentClient.from(
+  new DynamoDBClient({ region: "eu-west-2" }),
+);
+simSdk.intercept(documents);
+
+await documents.send(
+  new CreateTableCommand({
+    TableName: "OrdersTable",
+    KeySchema: [
+      { AttributeName: "customerId", KeyType: "HASH" },
+      { AttributeName: "orderId", KeyType: "RANGE" },
+    ],
+    AttributeDefinitions: [
+      { AttributeName: "customerId", AttributeType: "S" },
+      { AttributeName: "orderId", AttributeType: "S" },
+    ],
+    BillingMode: "PAY_PER_REQUEST",
+  }),
+);
+await simSdk.simAws.backgroundTasksComplete();
+
+for (const orderId of ["order-1", "order-2"]) {
+  await documents.send(
+    new PutCommand({
+      TableName: "OrdersTable",
+      Item: { customerId: "cust-1", orderId, total: 42 },
+    }),
+  );
+}
+
+const query = {
+  TableName: "OrdersTable",
+  KeyConditionExpression: "customerId = :customer",
+  ExpressionAttributeValues: { ":customer": "cust-1" },
+  Limit: 1,
+};
+
+const first = await documents.send(new QueryCommand(query));
+
+console.log(first.Items?.[0]?.["total"]); // 42
+
+// The key comes back as plain JavaScript, and goes back in as it is.
+const second = await documents.send(
+  new QueryCommand({ ...query, ExclusiveStartKey: first.LastEvaluatedKey }),
+);
+
+console.log(second.Items?.[0]?.["orderId"]); // order-2
+
+// The paginators send the same Commands, so they need nothing extra. Each one
+// writes the next start key into the input it was given, so it gets a copy.
+const pages = paginateQuery({ client: documents, pageSize: 1 }, { ...query });
+
+for await (const page of pages) {
+  console.log(page.Items?.length); // 1
+}

--- a/src/service/dynamodb/README.md
+++ b/src/service/dynamodb/README.md
@@ -1103,9 +1103,16 @@ intercepted send never runs it and the conversion happens at the interception bo
 - `sim-dynamodb-document-route.ts` converts, sends to the ordinary facade method, and converts back.
   `-routes.ts` builds one per Command for the SDK router to merge in.
 
-A document Command is named differently to the Command it stands for, so `PutCommand` and
+Most document Commands are named differently to the Command they stand for, so `PutCommand` and
 `PutItemCommand` route separately. One with no route, such as `TransactWriteCommand`, is refused by
 name before anything tries to convert its values.
+
+`QueryCommand` and `ScanCommand` are named the same in both packages, so the SDK router cannot key on
+the name alone. `sim-dynamodb-document-shared-name-route.ts` holds the document route and the client
+route for one name and picks between them by asking the Command which client built it:
+`@aws-sdk/lib-dynamodb` declares `inputKeyNodes`, `outputKeyNodes` and `clientCommand` on its own
+Commands, which are `protected` and so present at runtime where a client Command has nothing.
+`sim-dynamodb-document-command.ts` is that check.
 
 Which object a user intercepts is settled: the document client itself.
 `DynamoDBDocumentClient.from(client)` builds a separate object that extends the same `Client` base as

--- a/src/service/dynamodb/document/sim-dynamodb-document-command-paths.ts
+++ b/src/service/dynamodb/document/sim-dynamodb-document-command-paths.ts
@@ -31,6 +31,24 @@ const writtenAttributes = simDynamoDbDocumentFields({
 const valueRecords = simDynamoDbDocumentEach(simDynamoDbDocumentValues());
 
 /**
+ * What a read is given: where to carry on from, and the values its expressions
+ * compare against. A Query and a Scan take the same ones.
+ */
+const readInput = simDynamoDbDocumentFields({
+  ExclusiveStartKey: simDynamoDbDocumentValues(),
+  ExpressionAttributeValues: simDynamoDbDocumentValues(),
+});
+
+/**
+ * What a read answers with: the items it found, and where the page after it
+ * carries on from.
+ */
+const readPage = simDynamoDbDocumentFields({
+  Items: valueRecords,
+  LastEvaluatedKey: simDynamoDbDocumentValues(),
+});
+
+/**
  * One put or delete in a batch write.
  */
 const batchWriteRequest = simDynamoDbDocumentFields({
@@ -64,9 +82,10 @@ const batchGetKeys = simDynamoDbDocumentEach(
  *
  * They stop short of the real ones in one place. `Expected`,
  * `ConditionalOperator` and `AttributeUpdates` are the conditional write and
- * the update that expressions replaced, and simulated DynamoDB refuses all
- * three, so a request carrying one never reaches a conversion. Converting input
- * that is about to be refused would only move the refusal.
+ * the update that expressions replaced, and `KeyConditions`, `QueryFilter` and
+ * `ScanFilter` are the read the same expressions replaced. Simulated DynamoDB
+ * refuses all six, so a request carrying one never reaches a conversion.
+ * Converting input that is about to be refused would only move the refusal.
  */
 export const simDynamoDbDocumentCommandPaths = {
   put: {
@@ -93,6 +112,14 @@ export const simDynamoDbDocumentCommandPaths = {
       ExpressionAttributeValues: simDynamoDbDocumentValues(),
     }),
     output: writtenAttributes,
+  },
+  query: {
+    input: readInput,
+    output: readPage,
+  },
+  scan: {
+    input: readInput,
+    output: readPage,
   },
   batchWrite: {
     input: simDynamoDbDocumentFields({ RequestItems: batchWriteRequests }),

--- a/src/service/dynamodb/document/sim-dynamodb-document-command.ts
+++ b/src/service/dynamodb/document/sim-dynamodb-document-command.ts
@@ -1,11 +1,10 @@
-import { SimDynamoDbUnsupportedOperation } from "../error/dynamodb.error.js";
-
 /**
  * The properties `@aws-sdk/lib-dynamodb` declares on every one of its Commands.
  *
  * They are TypeScript `protected`, which means nothing at runtime, so a
  * document Command carries them where the client Command of the same name does
- * not.
+ * not. That is what tells a document `QueryCommand` from a client one, since
+ * the two share a class name.
  */
 const documentCommandProperties: readonly string[] = [
   "inputKeyNodes",
@@ -16,32 +15,8 @@ const documentCommandProperties: readonly string[] = [
 /**
  * Whether an intercepted Command came from the document client.
  */
-function isSimDynamoDbDocumentCommand(command: object): boolean {
+export function isSimDynamoDbDocumentCommand(command: object): boolean {
   return documentCommandProperties.every((property) =>
     Object.hasOwn(command, property),
-  );
-}
-
-/**
- * Refuse a document Command that shares its name with a client Command.
- *
- * The SDK router keys on the Command's class name, and `QueryCommand` and
- * `ScanCommand` are named the same in `@aws-sdk/client-dynamodb` and in
- * `@aws-sdk/lib-dynamodb`, unlike `PutCommand` and `PutItemCommand`. A document
- * Command reaching the client operation would have its native JavaScript values
- * read as AttributeValues, so it is refused by name instead.
- */
-export function refuseSimDynamoDbDocumentCommand(
-  command: object,
-  commandName: string,
-): void {
-  if (!isSimDynamoDbDocumentCommand(command)) {
-    return;
-  }
-
-  throw new SimDynamoDbUnsupportedOperation(
-    `The document client's ${commandName} is not simulated. It shares its ` +
-      `name with the ${commandName} of @aws-sdk/client-dynamodb, which is, so ` +
-      `it is refused rather than read as though it carried AttributeValues.`,
   );
 }

--- a/src/service/dynamodb/document/sim-dynamodb-document-interception.iso.test.ts
+++ b/src/service/dynamodb/document/sim-dynamodb-document-interception.iso.test.ts
@@ -22,7 +22,6 @@ import {
 } from "@kensio/smartass";
 import { describe, it } from "vitest";
 import { SimSdk, SimSdkUnsupportedCommandError } from "../../../sdk/index.js";
-import { SimDynamoDbUnsupportedOperation } from "../error/dynamodb.error.js";
 import { SimIamAccessDenied } from "../../iam/error/sim-iam.error.js";
 
 /**
@@ -139,8 +138,8 @@ describe("simulated DynamoDB document client interception", () => {
     assertStringIncludes(error.message, "PutCommand");
   });
 
-  it("refuses a document Command sharing its name with a client Command", async () => {
-    // Given an intercepted document client.
+  it("routes a Command sharing its name with a client Command by which client sent it", async () => {
+    // Given an intercepted document client holding one item.
     using simSdk = new SimSdk();
     const documents = DynamoDBDocumentClient.from(
       new DynamoDBClient({ region: "eu-west-2" }),
@@ -148,23 +147,26 @@ describe("simulated DynamoDB document client interception", () => {
     simSdk.intercept(documents);
     await createTable(simSdk, documents);
 
-    // When a document Query is sent, which is named the same as the client
-    // Query the simulator does route.
-    const error = await assertThrowsErrorAsync(async () => {
-      await documents.send(
-        new QueryCommand({
-          TableName: "OrdersTable",
-          KeyConditionExpression: "orderId = :order",
-          ExpressionAttributeValues: { ":order": "order-1" },
-        }),
-      );
-    });
+    await documents.send(
+      new PutCommand({
+        TableName: "OrdersTable",
+        Item: { orderId: "order-1", total: 42 },
+      }),
+    );
 
-    // Then it is refused rather than read as though it carried
-    // AttributeValues, which is what the client Query would have done with its
-    // native values.
-    assertInstanceOf(error, SimDynamoDbUnsupportedOperation);
-    assertStringIncludes(error.message, "document client's QueryCommand");
+    // When a document Query is sent, which is named the same as the client
+    // Query the simulator also routes.
+    const read = await documents.send(
+      new QueryCommand({
+        TableName: "OrdersTable",
+        KeyConditionExpression: "orderId = :order",
+        ExpressionAttributeValues: { ":order": "order-1" },
+      }),
+    );
+
+    // Then it is read as the document Command it is, rather than as though its
+    // native values were AttributeValues.
+    assertObjectEquals(read.Items?.[0], { orderId: "order-1", total: 42 });
   });
 
   it("authorizes a document Command as the caller sending it", async () => {

--- a/src/service/dynamodb/document/sim-dynamodb-document-query.iso.test.ts
+++ b/src/service/dynamodb/document/sim-dynamodb-document-query.iso.test.ts
@@ -1,0 +1,197 @@
+import {
+  CreateTableCommand,
+  DynamoDBClient,
+  QueryCommand as ClientQueryCommand,
+} from "@aws-sdk/client-dynamodb";
+import {
+  DynamoDBDocumentClient,
+  paginateQuery,
+  PutCommand,
+  QueryCommand,
+} from "@aws-sdk/lib-dynamodb";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertObjectEquals,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimSdk } from "../../../sdk/index.js";
+
+/**
+ * The orders these tests read, one customer having more than one.
+ */
+const orders: readonly Record<string, unknown>[] = [
+  { customerId: "cust-1", orderId: "order-1", total: 42, paid: true },
+  { customerId: "cust-1", orderId: "order-2", total: 7, paid: false },
+  { customerId: "cust-2", orderId: "order-3", total: 19, paid: true },
+];
+
+/**
+ * An intercepted document client, and a table holding the orders above.
+ *
+ * The table is created and filled through the same document client, which is
+ * what a test using the document client would do.
+ */
+async function interceptedOrders(
+  simSdk: SimSdk,
+): Promise<DynamoDBDocumentClient> {
+  const documents = DynamoDBDocumentClient.from(
+    new DynamoDBClient({ region: "eu-west-2" }),
+  );
+  simSdk.intercept(documents);
+
+  await documents.send(
+    new CreateTableCommand({
+      TableName: "OrdersTable",
+      KeySchema: [
+        { AttributeName: "customerId", KeyType: "HASH" },
+        { AttributeName: "orderId", KeyType: "RANGE" },
+      ],
+      AttributeDefinitions: [
+        { AttributeName: "customerId", AttributeType: "S" },
+        { AttributeName: "orderId", AttributeType: "S" },
+      ],
+      BillingMode: "PAY_PER_REQUEST",
+    }),
+  );
+  await simSdk.simAws.backgroundTasksComplete();
+
+  await Promise.all(
+    orders.map(
+      async (order) =>
+        await documents.send(
+          new PutCommand({ TableName: "OrdersTable", Item: order }),
+        ),
+    ),
+  );
+
+  return documents;
+}
+
+/**
+ * The Query every test here reads one customer's orders with.
+ */
+const oneCustomer = {
+  TableName: "OrdersTable",
+  KeyConditionExpression: "customerId = :customer",
+  ExpressionAttributeValues: { ":customer": "cust-1" },
+};
+
+describe("simulated DynamoDB document client Query", () => {
+  it("round-trips native values through a Query", async () => {
+    // Given an intercepted document client with orders to read.
+    using simSdk = new SimSdk();
+    const documents = await interceptedOrders(simSdk);
+
+    // When one customer's orders are queried with plain JavaScript values.
+    const read = await documents.send(
+      new QueryCommand({
+        ...oneCustomer,
+        KeyConditionExpression: "customerId = :customer AND orderId > :after",
+        ExpressionAttributeValues: {
+          ":customer": "cust-1",
+          ":after": "order-1",
+        },
+      }),
+    );
+
+    // Then the items come back as plain JavaScript, with no AttributeValues
+    // either way.
+    assertArrayLength(read.Items ?? [], 1);
+    assertObjectEquals(read.Items?.[0], {
+      customerId: "cust-1",
+      orderId: "order-2",
+      total: 7,
+      paid: false,
+    });
+
+    // And the counts the operation reports come through untouched, since they
+    // were never attribute values.
+    assertIdentical(read.Count, 1);
+  });
+
+  it("carries a Query on from where the page before it stopped", async () => {
+    // Given an intercepted document client with orders to read.
+    using simSdk = new SimSdk();
+    const documents = await interceptedOrders(simSdk);
+    const page = { ...oneCustomer, Limit: 1 };
+
+    // When a page of one is read.
+    const first = await documents.send(new QueryCommand(page));
+
+    // Then it says where to carry on from, as a plain JavaScript key.
+    assertObjectEquals(first.LastEvaluatedKey, {
+      customerId: "cust-1",
+      orderId: "order-1",
+    });
+
+    // And that key goes straight back in as the start of the next page, with
+    // nothing converted by hand.
+    const second = await documents.send(
+      new QueryCommand({ ...page, ExclusiveStartKey: first.LastEvaluatedKey }),
+    );
+
+    assertIdentical(second.Items?.[0]?.["orderId"], "order-2");
+
+    // The second page fills its Limit as well, so it too says where a third
+    // would carry on from, the way AWS does. There is nothing left to read
+    // from there.
+    const third = await documents.send(
+      new QueryCommand({ ...page, ExclusiveStartKey: second.LastEvaluatedKey }),
+    );
+
+    assertArrayLength(third.Items ?? [], 0);
+    assertUndefined(third.LastEvaluatedKey);
+  });
+
+  it("pages a Query through the document client paginator", async () => {
+    // Given an intercepted document client with orders to read.
+    using simSdk = new SimSdk();
+    const documents = await interceptedOrders(simSdk);
+
+    // When paginateQuery reads a page at a time. It sends the same document
+    // Command through the intercepted send, so nothing else is needed.
+    // The paginator writes the next start key into the input it was given, so
+    // it gets a copy of its own.
+    const pages = paginateQuery(
+      { client: documents, pageSize: 1 },
+      { ...oneCustomer },
+    );
+    const found: unknown[] = [];
+    for await (const page of pages) {
+      found.push(...(page.Items ?? []));
+    }
+
+    // Then every page carried native values, and the key it fed back was the
+    // one it had been given.
+    assertArrayLength(found, 2);
+    assertObjectEquals(found[0], {
+      customerId: "cust-1",
+      orderId: "order-1",
+      total: 42,
+      paid: true,
+    });
+  });
+
+  it("leaves a client Query on the same client unconverted", async () => {
+    // Given a document client that has been intercepted.
+    using simSdk = new SimSdk();
+    const documents = await interceptedOrders(simSdk);
+
+    // When the Query of @aws-sdk/client-dynamodb is sent through it, which is
+    // named the same as the document one.
+    const read = await documents.send(
+      new ClientQueryCommand({
+        ...oneCustomer,
+        ExpressionAttributeValues: { ":customer": { S: "cust-1" } },
+      }),
+    );
+
+    // Then it takes and answers with AttributeValues, as it would through a
+    // base client. Sharing a name with a document Command changes nothing
+    // about what it does.
+    assertArrayLength(read.Items ?? [], 2);
+    assertObjectEquals(read.Items?.[0]?.["total"], { N: "42" });
+  });
+});

--- a/src/service/dynamodb/document/sim-dynamodb-document-routes.ts
+++ b/src/service/dynamodb/document/sim-dynamodb-document-routes.ts
@@ -17,32 +17,69 @@ type SimDynamoDbDocumentSend = (
 ) => Promise<object>;
 
 /**
- * Build the routed entry for one document Command.
+ * Build the route for one document Command.
  */
 function documentRoute(
+  commandPaths: SimDynamoDbDocumentCommandPaths,
+  send: SimDynamoDbDocumentSend,
+): SimSdkCommandRoute {
+  return new SimDynamoDbDocumentRoute({
+    input: commandPaths.input,
+    output: commandPaths.output,
+    send: async (input, options) => await send(input as never, options),
+  }).route();
+}
+
+/**
+ * Build the routed entry for one document Command with a name of its own.
+ */
+function namedDocumentRoute(
   name: string,
   commandPaths: SimDynamoDbDocumentCommandPaths,
   send: SimDynamoDbDocumentSend,
 ): readonly [string, SimSdkCommandRoute] {
-  return [
-    name,
-    new SimDynamoDbDocumentRoute({
-      input: commandPaths.input,
-      output: commandPaths.output,
-      send: async (input, options) => await send(input as never, options),
-    }).route(),
-  ];
+  return [name, documentRoute(commandPaths, send)];
 }
 
 /**
- * The routes that handle `@aws-sdk/lib-dynamodb` document client Commands.
+ * The document routes for the two Commands `@aws-sdk/lib-dynamodb` names
+ * exactly as `@aws-sdk/client-dynamodb` does.
  *
- * A document Command is named differently to the Command it stands for, so
- * `PutCommand` and `PutItemCommand` route separately and only the document one
- * converts. Everything after the conversion is the ordinary operation: the same
- * validation, the same authorization, the same simulated table.
+ * These cannot be routed by name on their own. Each is paired with the client
+ * route of the same name by `SimDynamoDbSharedNameRoute`, which asks the
+ * Command which client it came from.
+ */
+export function simDynamoDbDocumentSharedNameRoutes(dynamoDb: SimDynamoDb): {
+  readonly query: SimSdkCommandRoute;
+  readonly scan: SimSdkCommandRoute;
+} {
+  return {
+    query: documentRoute(
+      paths.query,
+      async (input: simDynamoDbCommands.SimQueryCommandInput, options) =>
+        await dynamoDb.query({ input }, options),
+    ),
+    scan: documentRoute(
+      paths.scan,
+      async (input: simDynamoDbCommands.SimScanCommandInput, options) =>
+        await dynamoDb.scan({ input }, options),
+    ),
+  };
+}
+
+/**
+ * The routes that handle the `@aws-sdk/lib-dynamodb` document client Commands
+ * with a name of their own.
  *
- * An operation with no document route here, such as a document
+ * Most document Commands are named differently to the Command they stand for,
+ * so `PutCommand` and `PutItemCommand` route separately and only the document
+ * one converts. Everything after the conversion is the ordinary operation: the
+ * same validation, the same authorization, the same simulated table.
+ *
+ * `QueryCommand` and `ScanCommand` share their names with client Commands and
+ * so are routed by `simDynamoDbDocumentSharedNameRoutes` instead.
+ *
+ * An operation with no document route at all, such as a document
  * `TransactWriteCommand`, is refused by name like any other unsupported
  * Command, rather than failing part way through a conversion.
  */
@@ -50,31 +87,31 @@ export function simDynamoDbDocumentRoutes(
   dynamoDb: SimDynamoDb,
 ): readonly (readonly [string, SimSdkCommandRoute])[] {
   return [
-    documentRoute(
+    namedDocumentRoute(
       "PutCommand",
       paths.put,
       async (input: simDynamoDbCommands.SimPutItemCommandInput, options) =>
         await dynamoDb.putItem({ input }, options),
     ),
-    documentRoute(
+    namedDocumentRoute(
       "GetCommand",
       paths.get,
       async (input: simDynamoDbCommands.SimGetItemCommandInput, options) =>
         await dynamoDb.getItem({ input }, options),
     ),
-    documentRoute(
+    namedDocumentRoute(
       "DeleteCommand",
       paths.remove,
       async (input: simDynamoDbCommands.SimDeleteItemCommandInput, options) =>
         await dynamoDb.deleteItem({ input }, options),
     ),
-    documentRoute(
+    namedDocumentRoute(
       "UpdateCommand",
       paths.update,
       async (input: simDynamoDbCommands.SimUpdateItemCommandInput, options) =>
         await dynamoDb.updateItem({ input }, options),
     ),
-    documentRoute(
+    namedDocumentRoute(
       "BatchWriteCommand",
       paths.batchWrite,
       async (
@@ -82,7 +119,7 @@ export function simDynamoDbDocumentRoutes(
         options,
       ) => await dynamoDb.batchWriteItem({ input }, options),
     ),
-    documentRoute(
+    namedDocumentRoute(
       "BatchGetCommand",
       paths.batchGet,
       async (input: simDynamoDbCommands.SimBatchGetItemCommandInput, options) =>

--- a/src/service/dynamodb/document/sim-dynamodb-document-scan.iso.test.ts
+++ b/src/service/dynamodb/document/sim-dynamodb-document-scan.iso.test.ts
@@ -1,0 +1,147 @@
+import { CreateTableCommand, DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import {
+  DynamoDBDocumentClient,
+  paginateScan,
+  PutCommand,
+  ScanCommand,
+} from "@aws-sdk/lib-dynamodb";
+import {
+  assertArrayEquals,
+  assertArrayLength,
+  assertObjectEquals,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimSdk } from "../../../sdk/index.js";
+
+/**
+ * The orders these tests read, one customer having more than one.
+ */
+const orders: readonly Record<string, unknown>[] = [
+  { customerId: "cust-1", orderId: "order-1", total: 42, paid: true },
+  { customerId: "cust-1", orderId: "order-2", total: 7, paid: false },
+  { customerId: "cust-2", orderId: "order-3", total: 19, paid: true },
+];
+
+/**
+ * An intercepted document client, and a table holding the orders above.
+ *
+ * The table is created and filled through the same document client, which is
+ * what a test using the document client would do.
+ */
+async function interceptedOrders(
+  simSdk: SimSdk,
+): Promise<DynamoDBDocumentClient> {
+  const documents = DynamoDBDocumentClient.from(
+    new DynamoDBClient({ region: "eu-west-2" }),
+  );
+  simSdk.intercept(documents);
+
+  await documents.send(
+    new CreateTableCommand({
+      TableName: "OrdersTable",
+      KeySchema: [
+        { AttributeName: "customerId", KeyType: "HASH" },
+        { AttributeName: "orderId", KeyType: "RANGE" },
+      ],
+      AttributeDefinitions: [
+        { AttributeName: "customerId", AttributeType: "S" },
+        { AttributeName: "orderId", AttributeType: "S" },
+      ],
+      BillingMode: "PAY_PER_REQUEST",
+    }),
+  );
+  await simSdk.simAws.backgroundTasksComplete();
+
+  await Promise.all(
+    orders.map(
+      async (order) =>
+        await documents.send(
+          new PutCommand({ TableName: "OrdersTable", Item: order }),
+        ),
+    ),
+  );
+
+  return documents;
+}
+
+/**
+ * The order identifiers a page answered with, in a settled order.
+ */
+function orderIds(items: readonly Record<string, unknown>[]): string[] {
+  return items
+    .map((item): string => String(item["orderId"]))
+    .toSorted((left, right) => left.localeCompare(right));
+}
+
+describe("simulated DynamoDB document client Scan", () => {
+  it("round-trips native values through a Scan", async () => {
+    // Given an intercepted document client with orders to read.
+    using simSdk = new SimSdk();
+    const documents = await interceptedOrders(simSdk);
+
+    // When the table is scanned with a filter comparing against a native
+    // value.
+    const read = await documents.send(
+      new ScanCommand({
+        TableName: "OrdersTable",
+        FilterExpression: "paid = :paid",
+        ExpressionAttributeValues: { ":paid": true },
+      }),
+    );
+
+    // Then the items that matched come back as plain JavaScript, with no
+    // AttributeValues either way.
+    assertArrayEquals(orderIds(read.Items ?? []), ["order-1", "order-3"]);
+    assertObjectEquals(
+      (read.Items ?? []).find((item) => item["orderId"] === "order-1"),
+      { customerId: "cust-1", orderId: "order-1", total: 42, paid: true },
+    );
+  });
+
+  it("carries a Scan on through its segments", async () => {
+    // Given an intercepted document client with orders to read.
+    using simSdk = new SimSdk();
+    const documents = await interceptedOrders(simSdk);
+
+    // When the table is scanned in two segments.
+    const segments = await Promise.all(
+      [0, 1].map(
+        async (segment) =>
+          await documents.send(
+            new ScanCommand({
+              TableName: "OrdersTable",
+              TotalSegments: 2,
+              Segment: segment,
+            }),
+          ),
+      ),
+    );
+
+    // Then the segments between them answer with every item, each as plain
+    // JavaScript.
+    const found = segments.flatMap((page) => page.Items ?? []);
+    assertArrayEquals(orderIds(found), ["order-1", "order-2", "order-3"]);
+  });
+
+  it("pages a Scan through the document client paginator", async () => {
+    // Given an intercepted document client with orders to read.
+    using simSdk = new SimSdk();
+    const documents = await interceptedOrders(simSdk);
+
+    // When paginateScan reads a page at a time. It sends the same document
+    // Command through the intercepted send, so nothing else is needed.
+    const pages = paginateScan(
+      { client: documents, pageSize: 1 },
+      { TableName: "OrdersTable" },
+    );
+    const found: Record<string, unknown>[] = [];
+    for await (const page of pages) {
+      found.push(...(page.Items ?? []));
+    }
+
+    // Then the key each page fed the next was the plain JavaScript one it had
+    // been given, and every item was read once.
+    assertArrayLength(found, orders.length);
+    assertArrayEquals(orderIds(found), ["order-1", "order-2", "order-3"]);
+  });
+});

--- a/src/service/dynamodb/document/sim-dynamodb-document-shared-name-route.ts
+++ b/src/service/dynamodb/document/sim-dynamodb-document-shared-name-route.ts
@@ -1,0 +1,40 @@
+import type { SimSdkCommandRoute } from "../../../sdk/index.js";
+import { isSimDynamoDbDocumentCommand } from "./sim-dynamodb-document-command.js";
+
+interface SimDynamoDbSharedNameRouteProperties {
+  readonly document: SimSdkCommandRoute;
+  readonly client: SimSdkCommandRoute;
+}
+
+/**
+ * One Command name both DynamoDB clients use, routed by the client it came
+ * from.
+ *
+ * The SDK router keys on the Command's class name, and `@aws-sdk/lib-dynamodb`
+ * names its `QueryCommand` and `ScanCommand` exactly as
+ * `@aws-sdk/client-dynamodb` does, unlike `PutCommand` and `PutItemCommand`. So
+ * the name alone cannot say whether the request carries native JavaScript
+ * values or AttributeValues, and the Command is asked instead.
+ */
+export class SimDynamoDbSharedNameRoute {
+  private readonly document: SimSdkCommandRoute;
+  private readonly client: SimSdkCommandRoute;
+
+  constructor(properties: SimDynamoDbSharedNameRouteProperties) {
+    this.document = properties.document;
+    this.client = properties.client;
+  }
+
+  /**
+   * The route the SDK interception engine calls.
+   */
+  route(): SimSdkCommandRoute {
+    return async (command, context): Promise<unknown> => {
+      if (isSimDynamoDbDocumentCommand(command)) {
+        return await this.document(command, context);
+      }
+
+      return await this.client(command, context);
+    };
+  }
+}

--- a/src/service/dynamodb/sdk/sim-dynamodb-sdk-command-router.ts
+++ b/src/service/dynamodb/sdk/sim-dynamodb-sdk-command-router.ts
@@ -35,8 +35,11 @@ import type {
   SimDescribeTimeToLiveCommand,
   SimUpdateTimeToLiveCommand,
 } from "../command/time-to-live/time-to-live.command.js";
-import { refuseSimDynamoDbDocumentCommand } from "../document/sim-dynamodb-document-command.js";
-import { simDynamoDbDocumentRoutes } from "../document/sim-dynamodb-document-routes.js";
+import {
+  simDynamoDbDocumentRoutes,
+  simDynamoDbDocumentSharedNameRoutes,
+} from "../document/sim-dynamodb-document-routes.js";
+import { SimDynamoDbSharedNameRoute } from "../document/sim-dynamodb-document-shared-name-route.js";
 import type { SimDynamoDb as SimDynamoDatabase } from "../sim-dynamodb.js";
 
 /**
@@ -46,6 +49,11 @@ export class SimDynamoDatabaseSdkCommandRouter implements SimSdkCommandRouter {
   private readonly routes: ReadonlyMap<string, SimSdkCommandRoute>;
 
   constructor(simDynamoDatabase: SimDynamoDatabase) {
+    // The document Commands named the same as a client Command, each paired
+    // below with the client route it shares its name with.
+    const documentShared =
+      simDynamoDbDocumentSharedNameRoutes(simDynamoDatabase);
+
     this.routes = new Map<string, SimSdkCommandRoute>([
       [
         "CreateTableCommand",
@@ -121,29 +129,25 @@ export class SimDynamoDatabaseSdkCommandRouter implements SimSdkCommandRouter {
       ],
       [
         "QueryCommand",
-        async (command, context): Promise<unknown> => {
-          // The document client names its Query the same as this one, so the
-          // Command name alone cannot tell them apart.
-          refuseSimDynamoDbDocumentCommand(command, "QueryCommand");
-
-          return await simDynamoDatabase.query(
-            command as SimQueryCommand,
-            simSdkCallerOptions(context),
-          );
-        },
+        new SimDynamoDbSharedNameRoute({
+          document: documentShared.query,
+          client: async (command, context): Promise<unknown> =>
+            await simDynamoDatabase.query(
+              command as SimQueryCommand,
+              simSdkCallerOptions(context),
+            ),
+        }).route(),
       ],
       [
         "ScanCommand",
-        async (command, context): Promise<unknown> => {
-          // The document client names its Scan the same as this one, so the
-          // Command name alone cannot tell them apart.
-          refuseSimDynamoDbDocumentCommand(command, "ScanCommand");
-
-          return await simDynamoDatabase.scan(
-            command as SimScanCommand,
-            simSdkCallerOptions(context),
-          );
-        },
+        new SimDynamoDbSharedNameRoute({
+          document: documentShared.scan,
+          client: async (command, context): Promise<unknown> =>
+            await simDynamoDatabase.scan(
+              command as SimScanCommand,
+              simSdkCallerOptions(context),
+            ),
+        }).route(),
       ],
       [
         "BatchWriteItemCommand",

--- a/src/service/dynamodb/sdk/sim-dynamodb-sdk-scan-routing.iso.test.ts
+++ b/src/service/dynamodb/sdk/sim-dynamodb-sdk-scan-routing.iso.test.ts
@@ -8,16 +8,9 @@ import {
   DynamoDBDocumentClient,
   ScanCommand as DocumentScanCommand,
 } from "@aws-sdk/lib-dynamodb";
-import {
-  assertArrayLength,
-  assertIdentical,
-  assertInstanceOf,
-  assertStringIncludes,
-  assertThrowsErrorAsync,
-} from "@kensio/smartass";
+import { assertArrayLength, assertIdentical } from "@kensio/smartass";
 import { describe, it } from "vitest";
 import { SimSdk } from "../../../sdk/index.js";
-import { SimDynamoDbUnsupportedOperation } from "../error/dynamodb.error.js";
 
 /**
  * An intercepted client with two items written to a table.
@@ -73,7 +66,7 @@ describe("simulated DynamoDB Scan SDK Command routing", () => {
     assertIdentical(output.ScannedCount, 2);
   });
 
-  it("refuses the document client's Scan, which shares its name", async () => {
+  it("routes the document client's Scan, which shares its name", async () => {
     // Given an intercepted document client. It is the document client that is
     // intercepted, since it has a send of its own.
     using simSdk = new SimSdk();
@@ -82,16 +75,14 @@ describe("simulated DynamoDB Scan SDK Command routing", () => {
     simSdk.intercept(documentClient);
 
     // When a document Scan is sent through it.
-    const error = await assertThrowsErrorAsync(async () =>
-      documentClient.send(
-        new DocumentScanCommand({ TableName: "CollectionTable" }),
-      ),
+    const output = await documentClient.send(
+      new DocumentScanCommand({ TableName: "CollectionTable" }),
     );
 
-    // Then it is refused by name rather than read as though it carried
-    // AttributeValues, since @aws-sdk/lib-dynamodb names its Command the same
-    // as @aws-sdk/client-dynamodb does.
-    assertInstanceOf(error, SimDynamoDbUnsupportedOperation);
-    assertStringIncludes(error.message, "ScanCommand");
+    // Then it reads the same table, answering with native values rather than
+    // AttributeValues, even though @aws-sdk/lib-dynamodb names its Command the
+    // same as @aws-sdk/client-dynamodb does.
+    assertArrayLength(output.Items ?? [], 2);
+    assertIdentical(output.Items?.[0]?.["customerId"], "c-1");
   });
 });


### PR DESCRIPTION
The document client's QueryCommand and ScanCommand share their names with the client Commands, so the SDK router refused them rather than risk reading native JavaScript values as AttributeValues. It now pairs the two routes for each name and picks by what the Command carries, converting expression values and ExclusiveStartKey in, Items and LastEvaluatedKey out. paginateQuery and paginateScan work as they are.

Resolves https://github.com/KensioSoftware/yulin/issues/383