### PR TITLE
fix: relax Route53 Hosted Zone ID validation

### DIFF
--- a/docs/services/route53/README.md
+++ b/docs/services/route53/README.md
@@ -57,6 +57,12 @@ becomes `example.test.`.
 Hosted Zone creation uses background tasks to move the zone to `INSYNC`. If your test needs final
 state, call `await simAws.backgroundTasksComplete()` before continuing.
 
+Hosted Zone IDs are accepted in any real Route53 shape: a `Z` prefix followed by uppercase
+alphanumerics, up to 32 characters. That means a real Hosted Zone ID copied out of an AWS account,
+such as `Z2FDTNDATAQYW2`, can be used in your test setup. An ID with no matching Hosted Zone gives
+`NoSuchHostedZone`, while a malformed one gives `InvalidInput`. Commands also accept the
+`/hostedzone/Z...` form as well as the bare ID.
+
 ## Creating records
 
 Use `ChangeResourceRecordSetsCommand` to add records to a Hosted Zone.

--- a/src/service/route53/README.md
+++ b/src/service/route53/README.md
@@ -35,6 +35,18 @@ global service while still fitting Yulin's account/region navigation API.
 are normalized and stored on the hosted-zone object, not used as the primary key, because Route53
 supports multiple hosted zones with the same DNS name in some scenarios.
 
+### Hosted-zone IDs
+
+Allocated hosted-zone IDs are a `Z` prefix followed by 21 uppercase alphanumerics. Caller-supplied
+IDs are only checked for that shape, not for that length: real Route53 hosted-zone IDs vary, with a
+documented maximum of 32 characters and IDs in the wild commonly 14 or 21 characters. A real ID
+copied out of an AWS account is therefore usable against the simulator.
+
+`normalizeSimRoute53HostedZoneId` strips an optional `/hostedzone/` prefix and rejects a malformed
+or missing ID with `SimRoute53InvalidInput`. A well-formed ID that no hosted zone owns is left to
+fail later with `SimRoute53NoSuchHostedZone`, so callers can tell a bad ID apart from an unknown
+zone. `assertIsSimRoute53HostedZoneId` applies the same shape check as an internal invariant.
+
 `SimRoute53` is a thin facade. It does not contain command implementation details. Each
 public AWS-style operation constructs the appropriate command handler with the hosted-zone map and
 background scheduler, then delegates to that handler.

--- a/src/service/route53/cfn/record-set/apply/sim-cfn-r53-record-set-applicator.iso.test.ts
+++ b/src/service/route53/cfn/record-set/apply/sim-cfn-r53-record-set-applicator.iso.test.ts
@@ -7,6 +7,7 @@ import {
 import { describe, it } from "vitest";
 import { SimAws } from "../../../../aws/sim-aws.js";
 import { SimCfnResource } from "../../../../cloudformation/resource/sim-cfn-resource.js";
+import { SimRoute53NoSuchHostedZone } from "../../../error/sim-route53.error.js";
 import { SimCfnRoute53RecordSetApplicator } from "./sim-cfn-r53-record-set-applicator.js";
 
 describe("SimCfnRoute53RecordSetApplicator", () => {
@@ -70,6 +71,28 @@ describe("SimCfnRoute53RecordSetApplicator", () => {
       error.message,
       "Invalid AWS::Route53::RecordSet TestRecordSet: HostedZoneId must be a string",
     );
+  });
+
+  it("reports an unknown real world HostedZoneId as NoSuchHostedZone", async () => {
+    // Given a RecordSet applicator.
+    const simAws = new SimAws();
+    const applicator = new SimCfnRoute53RecordSetApplicator({
+      route53: simAws.route53(),
+    });
+
+    // When a CloudFormation RecordSet uses a real 14 character HostedZoneId.
+    const error = await assertThrowsErrorAsync(async () =>
+      applicator.create(resource(), {
+        HostedZoneId: "Z2FDTNDATAQYW2",
+        Name: "www.example.com",
+        Type: "A",
+        ResourceRecords: ["192.0.2.1"],
+      }),
+    );
+
+    // Then the ID passes validation and the missing zone is reported.
+    assertInstanceOf(error, SimRoute53NoSuchHostedZone);
+    assertStringIncludes(error.message, "Z2FDTNDATAQYW2");
   });
 
   it("throws when HostedZoneName is invalid or cannot be found", async () => {

--- a/src/service/route53/command/change-resource-record-sets/change-resource-rec-sets-valid.iso.test.ts
+++ b/src/service/route53/command/change-resource-record-sets/change-resource-rec-sets-valid.iso.test.ts
@@ -7,7 +7,10 @@ import {
 } from "@kensio/smartass";
 import { describe, it } from "vitest";
 import { SimAws } from "../../../aws/sim-aws.js";
-import { SimRoute53NoSuchHostedZone } from "../../error/sim-route53.error.js";
+import {
+  SimRoute53InvalidInput,
+  SimRoute53NoSuchHostedZone,
+} from "../../error/sim-route53.error.js";
 import {
   assertIsSimRoute53HostedZoneId,
   makeSimRoute53HostedZoneId,
@@ -183,9 +186,10 @@ describe("ChangeResourceRecordSetsCommand validation", () => {
     );
 
     // Then HostedZoneId validation fails.
+    assertInstanceOf(missingHostedZoneIdError, SimRoute53InvalidInput);
     assertIdentical(
       missingHostedZoneIdError.message,
-      "Not a SimRoute53HostedZoneId",
+      "Invalid Route53 Hosted Zone ID: (missing)",
     );
 
     // When ChangeBatch.Changes is missing.
@@ -203,6 +207,27 @@ describe("ChangeResourceRecordSetsCommand validation", () => {
       missingChangesError.message,
       "ChangeResourceRecordSetsCommand.ChangeBatch.Changes",
     );
+  });
+
+  it("reports an unknown real world HostedZoneId as NoSuchHostedZone", async () => {
+    // Given a simulated Route53 service with one Hosted Zone.
+    const { simRoute53 } = await createHostedZone("real-world.example.com");
+
+    // When a change is submitted for a real 14 character Hosted Zone ID.
+    const error = await assertThrowsErrorAsync(async () =>
+      simRoute53.changeResourceRecordSets({
+        input: {
+          HostedZoneId: "Z2FDTNDATAQYW2",
+          ChangeBatch: {
+            Changes: [],
+          },
+        },
+      }),
+    );
+
+    // Then the ID passes validation and the missing zone is reported.
+    assertInstanceOf(error, SimRoute53NoSuchHostedZone);
+    assertStringIncludes(error.message, "Z2FDTNDATAQYW2");
   });
 
   it("accepts a /hostedzone/ prefixed HostedZoneId", async () => {

--- a/src/service/route53/command/create-hosted-zone/sim-route53-zone-id.iso.test.ts
+++ b/src/service/route53/command/create-hosted-zone/sim-route53-zone-id.iso.test.ts
@@ -1,0 +1,135 @@
+import { describe, it } from "vitest";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertThrowsError,
+} from "@kensio/smartass";
+import { SimRoute53InvalidInput } from "../../error/sim-route53.error.js";
+import {
+  assertIsSimRoute53HostedZoneId,
+  makeSimRoute53HostedZoneId,
+  normalizeSimRoute53HostedZoneId,
+} from "./sim-route53-zone-id.js";
+
+describe("sim Route53 Hosted Zone ID", () => {
+  describe("normalizeSimRoute53HostedZoneId", () => {
+    it("accepts a real 14 character Hosted Zone ID", () => {
+      // Given a real Route53 Hosted Zone ID copied from AWS.
+      const value = "Z2FDTNDATAQYW2";
+
+      // When the Hosted Zone ID is normalized.
+      const hostedZoneId = normalizeSimRoute53HostedZoneId(value);
+
+      // Then the Hosted Zone ID is accepted unchanged.
+      assertIdentical(hostedZoneId, value);
+    });
+
+    it("accepts a real 20 character Hosted Zone ID", () => {
+      // Given a real Route53 Hosted Zone ID copied from AWS.
+      const value = "Z04589353OZQGDQ0X1RG";
+
+      // When the Hosted Zone ID is normalized.
+      const hostedZoneId = normalizeSimRoute53HostedZoneId(value);
+
+      // Then the Hosted Zone ID is accepted unchanged.
+      assertIdentical(hostedZoneId, value);
+    });
+
+    it("accepts an allocated simulated Hosted Zone ID", () => {
+      // Given a Hosted Zone ID allocated by the simulator.
+      const value = makeSimRoute53HostedZoneId();
+
+      // When the Hosted Zone ID is normalized.
+      const hostedZoneId = normalizeSimRoute53HostedZoneId(value);
+
+      // Then the Hosted Zone ID is accepted unchanged.
+      assertIdentical(hostedZoneId, value);
+    });
+
+    it("strips a leading /hostedzone/ prefix", () => {
+      // Given a Hosted Zone ID in its resource path form.
+      const value = "/hostedzone/Z2FDTNDATAQYW2";
+
+      // When the Hosted Zone ID is normalized.
+      const hostedZoneId = normalizeSimRoute53HostedZoneId(value);
+
+      // Then the bare Hosted Zone ID is returned.
+      assertIdentical(hostedZoneId, "Z2FDTNDATAQYW2");
+    });
+
+    it("rejects a Hosted Zone ID longer than 32 characters", () => {
+      // Given a Hosted Zone ID over the documented maximum length.
+      const value = `Z${"A".repeat(32)}`;
+
+      // When the Hosted Zone ID is normalized.
+      const error = assertThrowsError(() =>
+        normalizeSimRoute53HostedZoneId(value),
+      );
+
+      // Then InvalidInput is reported.
+      assertInstanceOf(error, SimRoute53InvalidInput);
+      assertIdentical(
+        error.message,
+        `Invalid Route53 Hosted Zone ID: ${value}`,
+      );
+    });
+
+    it("rejects a Hosted Zone ID without the Z prefix", () => {
+      // Given a Hosted Zone ID that does not start with Z.
+      const value = "A2FDTNDATAQYW2";
+
+      // When the Hosted Zone ID is normalized.
+      const error = assertThrowsError(() =>
+        normalizeSimRoute53HostedZoneId(value),
+      );
+
+      // Then InvalidInput is reported.
+      assertInstanceOf(error, SimRoute53InvalidInput);
+    });
+
+    it("rejects a lowercase Hosted Zone ID", () => {
+      // Given a Hosted Zone ID in lowercase.
+      const value = "z2fdtndataqyw2";
+
+      // When the Hosted Zone ID is normalized.
+      const error = assertThrowsError(() =>
+        normalizeSimRoute53HostedZoneId(value),
+      );
+
+      // Then InvalidInput is reported.
+      assertInstanceOf(error, SimRoute53InvalidInput);
+    });
+
+    it("rejects a missing Hosted Zone ID", () => {
+      // Given no Hosted Zone ID at all.
+      const value = undefined;
+
+      // When the Hosted Zone ID is normalized.
+      const error = assertThrowsError(() =>
+        normalizeSimRoute53HostedZoneId(value),
+      );
+
+      // Then InvalidInput reports the missing ID.
+      assertInstanceOf(error, SimRoute53InvalidInput);
+      assertIdentical(
+        error.message,
+        "Invalid Route53 Hosted Zone ID: (missing)",
+      );
+    });
+  });
+
+  describe("assertIsSimRoute53HostedZoneId", () => {
+    it("throws for a value that is not a Hosted Zone ID", () => {
+      // Given a value that is not a Hosted Zone ID.
+      const value = 123;
+
+      // When the value is asserted to be a Hosted Zone ID.
+      const error = assertThrowsError(() => {
+        assertIsSimRoute53HostedZoneId(value);
+      });
+
+      // Then the invariant failure is reported.
+      assertIdentical(error.message, "Not a SimRoute53HostedZoneId");
+    });
+  });
+});

--- a/src/service/route53/command/create-hosted-zone/sim-route53-zone-id.ts
+++ b/src/service/route53/command/create-hosted-zone/sim-route53-zone-id.ts
@@ -1,7 +1,18 @@
 import { faker } from "@faker-js/faker";
 import type { Brand } from "../../../../util/brand.type.js";
+import { SimRoute53InvalidInput } from "../../error/sim-route53.error.js";
 
 export type SimRoute53HostedZoneId = Brand<string, "SimRoute53HostedZoneId">;
+
+/**
+ * Route53 Hosted Zone IDs are a `Z` prefix followed by uppercase alphanumerics.
+ * Real IDs are not a fixed length: the API documents a maximum of 32
+ * characters, and IDs in the wild are commonly 14 or 21 characters. Only the
+ * shape is checked so real IDs copied from an AWS account are accepted.
+ *
+ * https://docs.aws.amazon.com/Route53/latest/APIReference/API_HostedZone.html
+ */
+const simRoute53HostedZoneIdPattern = /^Z[\dA-Z]{1,31}$/u;
 
 /**
  * Allocate a unique simulated Route53 Hosted Zone ID.
@@ -24,15 +35,33 @@ export function makeSimRoute53HostedZoneId(
 }
 
 /**
- * Normalize a Route53 Hosted Zone ID from either a bare zone ID or /hostedzone/
- * prefixed ID.
+ * Normalize a caller-supplied Route53 Hosted Zone ID from either a bare zone ID
+ * or /hostedzone/ prefixed ID.
+ *
+ * A malformed ID is rejected here with InvalidInput. A well-formed ID that no
+ * simulated hosted zone owns is left to fail later with NoSuchHostedZone.
  */
 export function normalizeSimRoute53HostedZoneId(
   value: string | undefined,
 ): SimRoute53HostedZoneId {
   const hostedZoneId = value?.replace(/^\/?hostedzone\//u, "");
-  assertIsSimRoute53HostedZoneId(hostedZoneId);
+
+  if (!isSimRoute53HostedZoneId(hostedZoneId)) {
+    throw new SimRoute53InvalidInput(
+      `Invalid Route53 Hosted Zone ID: ${value ?? "(missing)"}`,
+    );
+  }
+
   return hostedZoneId;
+}
+
+/**
+ * Whether a value has the shape of a Route53 Hosted Zone ID.
+ */
+export function isSimRoute53HostedZoneId(
+  value: unknown,
+): value is SimRoute53HostedZoneId {
+  return typeof value === "string" && simRoute53HostedZoneIdPattern.test(value);
 }
 
 /**
@@ -41,11 +70,7 @@ export function normalizeSimRoute53HostedZoneId(
 export function assertIsSimRoute53HostedZoneId(
   value: unknown,
 ): asserts value is SimRoute53HostedZoneId {
-  if (
-    typeof value !== "string" ||
-    !value.startsWith("Z") ||
-    value.length !== 22
-  ) {
+  if (!isSimRoute53HostedZoneId(value)) {
     throw new Error("Not a SimRoute53HostedZoneId");
   }
 }

--- a/src/service/route53/error/sim-route53.error.ts
+++ b/src/service/route53/error/sim-route53.error.ts
@@ -29,6 +29,17 @@ export class SimRoute53NoSuchHostedZone extends SimRoute53Error {
 }
 
 /**
+ * Simulated Route53 InvalidInput error.
+ */
+export class SimRoute53InvalidInput extends SimRoute53Error {
+  public override readonly name = "InvalidInput";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
  * Simulated Route53 HostedZoneAlreadyExists error.
  */
 export class SimRoute53HostedZoneAlreadyExists extends SimRoute53Error {


### PR DESCRIPTION
Resolves #384

Two things a reviewer has to decide on:

- The missing-`HostedZoneId` path now throws the new `SimRoute53InvalidInput` instead of `Error: Not a SimRoute53HostedZoneId`, so it is a breaking change to that error.
- Whether real Route53 returns `InvalidInput` or `NoSuchHostedZone` for an over-length ID is unverified; `InvalidInput` is the assumption here.
