### PR TITLE
fix: present the CloudFront domain name as the CFF host header

### DIFF
--- a/docs/services/cloudfront/README.md
+++ b/docs/services/cloudfront/README.md
@@ -385,6 +385,13 @@ The sim CloudFront supports `viewer-request` and `viewer-response` CloudFront Fu
 
 Use `makeCffFunctionCodeInput` to pass a JavaScript handler function to `CreateFunctionCommand`.
 
+The `host` header a function sees is the hostname the request was made to CloudFront with: the
+Distribution domain name, or one of its alternate domain names. Requests served on localhost arrive
+with a Yulin-local host such as `distro123.cloudfront.net.sim-aws.localhost:52341`, and the local
+suffix and port are dropped before the function runs, so a function building a URL from
+`event.request.headers.host.value` behaves as it would on AWS. As on AWS, `host` is read-only: a
+host a function writes is discarded rather than sent on to the Origin.
+
 ```typescript sim-cloudfront-function
 /**
  * Simulated CloudFront Functions.

--- a/src/serve/http/url/sim-aws-request-hostname.iso.test.ts
+++ b/src/serve/http/url/sim-aws-request-hostname.iso.test.ts
@@ -1,0 +1,27 @@
+import { describe, it } from "vitest";
+import { assertIdentical } from "@kensio/smartass";
+import { simAwsRequestHostname } from "./sim-aws-request-hostname.js";
+
+describe("AWS-facing hostname of a request", () => {
+  it("drops the localhost suffix and the local server port", () => {
+    const request = new Request(
+      "http://distro123.cloudfront.net.sim-aws.localhost:52341/index.html",
+    );
+
+    assertIdentical(simAwsRequestHostname(request), "distro123.cloudfront.net");
+  });
+
+  it("keeps a hostname that has no localhost suffix", () => {
+    const request = new Request("https://cdn.example.test/index.html");
+
+    assertIdentical(simAwsRequestHostname(request), "cdn.example.test");
+  });
+
+  it("prefers the Host header over the URL hostname", () => {
+    const request = new Request("http://127.0.0.1:52341/index.html", {
+      headers: { host: "cdn.example.test.sim-aws.localhost:52341" },
+    });
+
+    assertIdentical(simAwsRequestHostname(request), "cdn.example.test");
+  });
+});

--- a/src/serve/http/url/sim-aws-request-hostname.ts
+++ b/src/serve/http/url/sim-aws-request-hostname.ts
@@ -1,0 +1,20 @@
+import { SimAwsLocalUrl } from "./sim-aws-local-url.js";
+
+/**
+ * Get the AWS-facing hostname an incoming request was made to.
+ *
+ * A request served on localhost carries the Yulin-local host, such as
+ * `distro123.cloudfront.net.sim-aws.localhost:52341`, so the local suffix and
+ * the local server port are dropped to leave the hostname the same request
+ * would have used against real AWS.
+ *
+ * The Host header is preferred over the URL hostname, since that is what a
+ * client sends and what AWS itself routes on.
+ */
+export function simAwsRequestHostname(request: Request): string {
+  const requestHost = request.headers.get("host") ?? new URL(request.url).host;
+
+  return new SimAwsLocalUrl({
+    input: `http://${requestHost}/`,
+  }).withoutLocalhostSuffix().hostname;
+}

--- a/src/service/cloudfront/cff/adapter/sim-cff-request-host.iso.test.ts
+++ b/src/service/cloudfront/cff/adapter/sim-cff-request-host.iso.test.ts
@@ -1,0 +1,96 @@
+import { describe, it } from "vitest";
+import { assertIdentical } from "@kensio/smartass";
+import { SimCffRequestResponseAdapter } from "./sim-cff-request-response-adapter.js";
+import { SimCffEventAdapter } from "./sim-cff-event-adapter.js";
+
+describe("host header seen by a sim CloudFront Function", () => {
+  const adapter = new SimCffRequestResponseAdapter();
+
+  it("presents the Distribution domain name for a request served locally", () => {
+    // Given a request served on the Yulin local server.
+    const request = new Request(
+      "http://distro123.cloudfront.net.sim-aws.localhost:52341/index.html",
+      {
+        headers: { host: "distro123.cloudfront.net.sim-aws.localhost:52341" },
+      },
+    );
+
+    const cffRequest = adapter.toCffRequest(request);
+
+    assertIdentical(
+      cffRequest.headers["host"]?.value,
+      "distro123.cloudfront.net",
+    );
+  });
+
+  it("presents an alternate domain name unchanged", () => {
+    const request = new Request(
+      "http://cdn.example.test.sim-aws.localhost:52341/index.html",
+      { headers: { host: "cdn.example.test.sim-aws.localhost:52341" } },
+    );
+
+    const cffRequest = adapter.toCffRequest(request);
+
+    assertIdentical(cffRequest.headers["host"]?.value, "cdn.example.test");
+  });
+
+  it("leaves a real CloudFront host alone", () => {
+    const request = new Request("https://distro123.cloudfront.net/index.html");
+
+    const cffRequest = adapter.toCffRequest(request);
+
+    assertIdentical(
+      cffRequest.headers["host"]?.value,
+      "distro123.cloudfront.net",
+    );
+  });
+
+  it("presents the same host in a viewer-response event", () => {
+    const eventAdapter = new SimCffEventAdapter();
+    const request = new Request(
+      "http://distro123.cloudfront.net.sim-aws.localhost:52341/index.html",
+      {
+        headers: { host: "distro123.cloudfront.net.sim-aws.localhost:52341" },
+      },
+    );
+
+    const viewerRequestEvent = eventAdapter.toViewerRequestEvent(request);
+    const viewerResponseEvent = eventAdapter.toViewerResponseEvent(
+      request,
+      new Response("<h1>Hello</h1>"),
+    );
+
+    assertIdentical(
+      viewerResponseEvent.request.headers["host"]?.value,
+      viewerRequestEvent.request.headers["host"]?.value,
+    );
+  });
+
+  it("restores the host the request arrived with", () => {
+    // Given a function that rewrites the read-only host header.
+    const request = new Request(
+      "http://distro123.cloudfront.net.sim-aws.localhost:52341/index.html",
+      {
+        headers: { host: "distro123.cloudfront.net.sim-aws.localhost:52341" },
+      },
+    );
+    const cffRequest = adapter.toCffRequest(request);
+    cffRequest.headers["host"] = { value: "somewhere.else.test" };
+
+    const originRequest = adapter.fromCffRequest(cffRequest, request);
+
+    assertIdentical(
+      originRequest.headers.get("host"),
+      "distro123.cloudfront.net.sim-aws.localhost:52341",
+    );
+  });
+
+  it("adds no host header when the request arrived without one", () => {
+    const request = new Request("https://distro123.cloudfront.net/index.html");
+    const cffRequest = adapter.toCffRequest(request);
+
+    const originRequest = adapter.fromCffRequest(cffRequest, request);
+
+    assertIdentical(originRequest.headers.get("host"), null);
+  });
+});

--- a/src/service/cloudfront/cff/adapter/sim-cff-request-response-adapter.ts
+++ b/src/service/cloudfront/cff/adapter/sim-cff-request-response-adapter.ts
@@ -1,4 +1,5 @@
 import type { CloudFrontFunction } from "../../typings/cloudfront-functions.namespace.js";
+import { simAwsRequestHostname } from "../../../../serve/http/url/sim-aws-request-hostname.js";
 import { SimCffRequestMetadataAdapter } from "./sim-cff-request-metadata-adapter.js";
 
 /**
@@ -17,7 +18,7 @@ export class SimCffRequestResponseAdapter {
     return {
       method: request.method,
       uri: url.pathname,
-      headers: this.metadataAdapter.toCffHeaders(request.headers),
+      headers: this.viewerCffHeaders(request),
       querystring: this.metadataAdapter.toCffQueryString(url.searchParams),
       cookies: this.metadataAdapter.toCffCookies(request.headers),
     };
@@ -48,12 +49,15 @@ export class SimCffRequestResponseAdapter {
     );
     const isAllowsBody = !/^(get|head)$/i.test(cffRequest.method);
 
+    const headers = this.metadataAdapter.fromCffHeaders(
+      cffRequest.headers,
+      cffRequest.cookies,
+    );
+    this.restoreViewerHost(headers, originalRequest);
+
     return new Request(url, {
       method: cffRequest.method,
-      headers: this.metadataAdapter.fromCffHeaders(
-        cffRequest.headers,
-        cffRequest.cookies,
-      ),
+      headers,
       body: isAllowsBody ? originalRequest.clone().body : null,
       duplex: "half",
       redirect: originalRequest.redirect,
@@ -91,6 +95,41 @@ export class SimCffRequestResponseAdapter {
       statusText: cffResponse.statusDescription ?? "",
       headers: this.metadataAdapter.fromCffHeaders(cffResponse.headers, {}),
     });
+  }
+
+  /**
+   * Convert request headers to CFF Headers, with the host CloudFront presents.
+   *
+   * A CloudFront Function sees the hostname the viewer used to reach
+   * CloudFront: the Distribution domain name or one of its alternate domain
+   * names. A request served on localhost arrives with the Yulin-local host
+   * instead, which is the same hostname the Distribution router already
+   * resolves the request by, so it is normalised here as well.
+   */
+  private viewerCffHeaders(request: Request): CloudFrontFunction.Headers {
+    const cffHeaders = this.metadataAdapter.toCffHeaders(request.headers);
+    cffHeaders["host"] = { value: simAwsRequestHostname(request) };
+
+    return cffHeaders;
+  }
+
+  /**
+   * Restore the host the request arrived with.
+   *
+   * The host header is read-only for CloudFront Functions, so a host a
+   * function returns is discarded rather than sent on. That also keeps the
+   * Yulin-local host on the request continuing to the Origin, which is what
+   * the rest of the simulated environment resolves.
+   */
+  private restoreViewerHost(headers: Headers, originalRequest: Request): void {
+    const viewerHost = originalRequest.headers.get("host");
+
+    if (viewerHost === null) {
+      headers.delete("host");
+      return;
+    }
+
+    headers.set("host", viewerHost);
   }
 
   private cffResponseBody(

--- a/src/service/cloudfront/cff/sim-cloudfront-functions.loc.test.ts
+++ b/src/service/cloudfront/cff/sim-cloudfront-functions.loc.test.ts
@@ -105,6 +105,82 @@ describe("Serve sim CloudFront Functions on localhost", () => {
     );
   });
 
+  it("gives a viewer-request CFF the Distribution domain name as its host", async () => {
+    const simCloudFront = simAws.cloudFront();
+
+    // Given a CFF that redirects to the host it was given.
+    function hostRedirectHandlerFunction(
+      event: CloudFrontFunction.ViewerRequestEvent,
+    ) {
+      const host = event.request.headers["host"]?.value ?? "no-host";
+      return {
+        statusCode: 302,
+        statusDescription: "Found",
+        headers: {
+          location: { value: `https://${host}/redirected.html` },
+        },
+      };
+    }
+    const hostCffCreation = await simCloudFront.createFunction(
+      new CreateFunctionCommand({
+        Name: "host-viewer-request-cff",
+        FunctionConfig: {
+          Comment: "Host Viewer Request CloudFront Function",
+          Runtime: "cloudfront-js-2.0",
+        },
+        FunctionCode: makeCffFunctionCodeInput(hostRedirectHandlerFunction),
+      }),
+    );
+
+    const distributionCreation = await simCloudFront.createDistribution(
+      new CreateDistributionCommand({
+        DistributionConfig: {
+          CallerReference: "host-header-cff",
+          Comment: "Host header CDN",
+          Enabled: true,
+          Origins: {
+            Quantity: 1,
+            Items: [
+              {
+                Id: "foo-origin",
+                DomainName: "foo-bucket.s3.amazonaws.com",
+                S3OriginConfig: { OriginAccessIdentity: "" },
+              },
+            ],
+          },
+          DefaultCacheBehavior: {
+            TargetOriginId: "foo-origin",
+            ViewerProtocolPolicy: "allow-all",
+            FunctionAssociations: {
+              Quantity: 1,
+              Items: [
+                {
+                  EventType: "viewer-request",
+                  FunctionARN: hostCffCreation.FunctionMetadata.FunctionARN,
+                },
+              ],
+            },
+          },
+        },
+      }),
+    );
+    const distroId = distributionCreation.Distribution?.Id;
+    assertNonNullable(distroId);
+
+    // When the Distribution is requested by its CloudFront domain name.
+    const distroHostResponse = await fetch(
+      `http://${distroId.toLowerCase()}.cloudfront.net.sim-aws.localhost:${srv.port}/index.html`,
+      { redirect: "manual" },
+    );
+
+    // Then the CFF saw the CloudFront domain name, without the local suffix
+    // and without the local server port.
+    assertIdentical(
+      distroHostResponse.headers.get("location"),
+      `https://${distroId.toLowerCase()}.cloudfront.net/redirected.html`,
+    );
+  });
+
   it("applies viewer-response CFF", async () => {
     const simS3 = simAws.s3();
     const simCloudFront = simAws.cloudFront();

--- a/src/service/cloudfront/controller/sim-cf-controller-cff-host.iso.test.ts
+++ b/src/service/cloudfront/controller/sim-cf-controller-cff-host.iso.test.ts
@@ -1,0 +1,207 @@
+import { assertIdentical, assertNonNullable } from "@kensio/smartass";
+import {
+  CreateDistributionCommand,
+  CreateFunctionCommand,
+  type FunctionAssociation,
+} from "@aws-sdk/client-cloudfront";
+import { CreateBucketCommand, PutObjectCommand } from "@aws-sdk/client-s3";
+import { describe, it } from "vitest";
+import { SimAws } from "../../aws/sim-aws.js";
+import { SimCloudFrontServiceController } from "./sim-cloudfront-controller.js";
+import { SimAwsServiceRequest } from "../../../serve/controller/sim-service-controller.js";
+import { makeCffFunctionCodeInput } from "../cff/function-code-input/cff-function-code-input.js";
+import type { CloudFrontFunction } from "../typings/cloudfront-functions.namespace.js";
+
+interface HostCffHandlers {
+  readonly viewerRequest: CloudFrontFunction.Handler;
+  readonly viewerResponse?: CloudFrontFunction.Handler;
+}
+
+/**
+ * Make a Distribution serving a Bucket through the given CFF handlers.
+ */
+async function makeHostCffDistribution(
+  simAws: SimAws,
+  handlers: HostCffHandlers,
+): Promise<string> {
+  const simCloudFront = simAws.cloudFront();
+
+  await simAws.s3().createBucket(
+    new CreateBucketCommand({
+      Bucket: "cff-host-bucket",
+    }),
+  );
+  await simAws.s3().putObject(
+    new PutObjectCommand({
+      Bucket: "cff-host-bucket",
+      Key: "index.html",
+      Body: "<h1>From the Origin</h1>",
+    }),
+  );
+
+  const cffOutput = await simCloudFront.createFunction(
+    new CreateFunctionCommand({
+      Name: "cff-host-viewer-request",
+      FunctionConfig: {
+        Comment: "Host header viewer-request CFF",
+        Runtime: "cloudfront-js-2.0",
+      },
+      FunctionCode: makeCffFunctionCodeInput(handlers.viewerRequest),
+    }),
+  );
+
+  const functionAssociations: FunctionAssociation[] = [
+    {
+      EventType: "viewer-request",
+      FunctionARN: cffOutput.FunctionMetadata.FunctionARN,
+    },
+  ];
+
+  if (handlers.viewerResponse !== undefined) {
+    const viewerResponseOutput = await simCloudFront.createFunction(
+      new CreateFunctionCommand({
+        Name: "cff-host-viewer-response",
+        FunctionConfig: {
+          Comment: "Host header viewer-response CFF",
+          Runtime: "cloudfront-js-2.0",
+        },
+        FunctionCode: makeCffFunctionCodeInput(handlers.viewerResponse),
+      }),
+    );
+    functionAssociations.push({
+      EventType: "viewer-response",
+      FunctionARN: viewerResponseOutput.FunctionMetadata.FunctionARN,
+    });
+  }
+
+  const distributionOutput = await simCloudFront.createDistribution(
+    new CreateDistributionCommand({
+      DistributionConfig: {
+        CallerReference: "cff-host",
+        Comment: "CFF host Distribution",
+        Enabled: true,
+        Aliases: {
+          Quantity: 1,
+          Items: ["cdn.example.test"],
+        },
+        Origins: {
+          Quantity: 1,
+          Items: [
+            {
+              Id: "host-origin",
+              DomainName: "cff-host-bucket.s3.amazonaws.com",
+              S3OriginConfig: { OriginAccessIdentity: "" },
+            },
+          ],
+        },
+        DefaultCacheBehavior: {
+          TargetOriginId: "host-origin",
+          ViewerProtocolPolicy: "allow-all",
+          FunctionAssociations: {
+            Quantity: functionAssociations.length,
+            Items: functionAssociations,
+          },
+        },
+      },
+    }),
+  );
+
+  const distributionId = distributionOutput.Distribution?.Id;
+  assertNonNullable(distributionId);
+
+  return distributionId;
+}
+
+/**
+ * Handle a request through the simulated CloudFront controller.
+ */
+async function handleCloudFrontRequest(
+  simAws: SimAws,
+  request: Request,
+): Promise<Response> {
+  return new SimCloudFrontServiceController({ simAws }).handleRequest(
+    new SimAwsServiceRequest({
+      target: { service: "cloudFront", resourceName: "" },
+      request,
+    }),
+  );
+}
+
+describe("Simulated CloudFront controller CFF host header", () => {
+  it("gives a CFF the alternate domain name the request was made to", async () => {
+    const simAws = new SimAws();
+
+    // Given a CFF echoing its host back in a response header.
+    const distributionId = await makeHostCffDistribution(simAws, {
+      viewerRequest: (event: CloudFrontFunction.ViewerRequestEvent) => ({
+        statusCode: 204,
+        headers: {
+          "x-cff-host": {
+            value: event.request.headers["host"]?.value ?? "no-host",
+          },
+        },
+      }),
+    });
+
+    // When the Distribution is requested by its alternate domain name.
+    const aliasResponse = await handleCloudFrontRequest(
+      simAws,
+      new Request("http://cdn.example.test.sim-aws.localhost/index.html", {
+        headers: { host: "cdn.example.test.sim-aws.localhost" },
+      }),
+    );
+
+    // Then the CFF saw the alternate domain name.
+    assertIdentical(
+      aliasResponse.headers.get("x-cff-host"),
+      "cdn.example.test",
+    );
+
+    // And a request by CloudFront domain name sees that instead.
+    const distroResponse = await handleCloudFrontRequest(
+      simAws,
+      new Request(
+        `http://${distributionId}.cloudfront.net.sim-aws.localhost/index.html`,
+      ),
+    );
+
+    assertIdentical(
+      distroResponse.headers.get("x-cff-host"),
+      `${distributionId.toLowerCase()}.cloudfront.net`,
+    );
+  });
+
+  it("discards a host a CFF writes, as CloudFront does for a read-only header", async () => {
+    const simAws = new SimAws();
+
+    // Given a viewer-request CFF that rewrites the read-only host header.
+    const distributionId = await makeHostCffDistribution(simAws, {
+      viewerRequest: (event: CloudFrontFunction.ViewerRequestEvent) => {
+        event.request.headers["host"] = { value: "somewhere.else.test" };
+        return event.request;
+      },
+      viewerResponse: (event: CloudFrontFunction.ViewerResponseEvent) => {
+        event.response.headers["x-cff-host"] = {
+          value: event.request.headers["host"]?.value ?? "no-host",
+        };
+        return event.response;
+      },
+    });
+
+    const response = await handleCloudFrontRequest(
+      simAws,
+      new Request(
+        `http://${distributionId}.cloudfront.net.sim-aws.localhost/index.html`,
+      ),
+    );
+
+    // Then the viewer-response CFF still saw the host the viewer requested.
+    assertIdentical(
+      response.headers.get("x-cff-host"),
+      `${distributionId.toLowerCase()}.cloudfront.net`,
+    );
+
+    // And the request was still served from the Distribution's Origin.
+    assertIdentical(await response.text(), "<h1>From the Origin</h1>");
+  });
+});

--- a/src/service/cloudfront/router/sim-cloud-front-distro-router.ts
+++ b/src/service/cloudfront/router/sim-cloud-front-distro-router.ts
@@ -2,8 +2,7 @@ import type {
   SimCloudFrontDistribution,
   SimCloudFrontDistributionId,
 } from "../distribution/sim-cloudfront-distribution.js";
-import { assertNotNull } from "../../../util/type-guard/defined.js";
-import { SimAwsLocalUrl } from "../../../serve/http/url/sim-aws-local-url.js";
+import { simAwsRequestHostname } from "../../../serve/http/url/sim-aws-request-hostname.js";
 import type { SimCloudFront } from "../sim-cloudfront.js";
 import type { SimCloudFrontRegistry } from "../registry/sim-cloud-front-registry.js";
 import { SimAws } from "../../aws/sim-aws.js";
@@ -80,11 +79,7 @@ export class SimCloudFrontDistroRouter {
    * are handled identically.
    */
   routeForRequest(request: Request): SimCloudFrontDistroRoute | undefined {
-    const url = new URL(request.url);
-    const hostname = request.headers.get("host") ?? url.hostname;
-    assertNotNull(hostname, "distroForRequest.req.headers.host");
-    const simUrl = new SimAwsLocalUrl({ input: `http://${hostname}/` });
-    const baseHostname = simUrl.withoutLocalhostSuffix().hostname;
+    const baseHostname = simAwsRequestHostname(request);
 
     const distributionId = extractCloudFrontHostDistroId(baseHostname);
     if (distributionId !== undefined) {


### PR DESCRIPTION
A CloudFront Function reading `event.request.headers.host.value` was given the Yulin-local host the request arrived with, such as `distro123.cloudfront.net.sim-aws.localhost:52341`, rather than the hostname AWS would present. Nothing errored, so a function building a redirect target from `host` silently produced a URL that would be wrong against real CloudFront.

The Distribution router already stripped the local suffix to route the request, so that normalisation is now shared and applied before a function runs, for both `viewer-request` and `viewer-response` events. A request served by an alternate domain name sees that domain, matching what routing resolved it by.

Host is read-only for CloudFront Functions on AWS, so a host a function writes is discarded and the request continuing to the Origin keeps the host it arrived with.

## Changes

- `simAwsRequestHostname` in `src/serve/http/url/`, returning the AWS-facing hostname for a request: Host header preferred over the URL, local suffix and local server port dropped.
- `SimCffRequestResponseAdapter` sets `host` from that helper instead of copying request headers verbatim, and restores the arriving host on the way back out.
- `SimCloudFrontDistroRouter` calls the same helper rather than repeating the stripping logic, so the two cannot drift.
- A paragraph in the CloudFront Functions docs on which host a function sees and that it is read-only.

## Tests

Each new test was checked to fail without the change.

- Adapter-level cases for the local suffix and port, an alternate domain name, a real `cloudfront.net` host left alone, and the host restore.
- Controller-level cases for a Distribution reached by both its alternate domain name and its CloudFront domain name, and for a viewer-request function overwriting `host` while the viewer-response function still sees the viewer's host.
- A localhost test over `SimAwsLocalServer`, which is where the port actually appears on the wire.

Two scope notes. The alternate domain case cannot be exercised over `serveSimAws` without a Route53 Hosted Zone, since HTTP host dispatch goes through `resolveHttpHost`, so it is covered at controller level instead. The "still reaches the Origin" criterion in the issue passes with or without the host restore, because no Origin type reads that header today and custom Origins set their own, so the regression test is anchored on the viewer-response host, which does depend on it.

Resolves #385
