### PR TITLE
fix: accept a plain string default Account ID

### DIFF
--- a/src/service/apigatewayv2/command/authorize/sim-api-gateway-v2-iam.iso.test.ts
+++ b/src/service/apigatewayv2/command/authorize/sim-api-gateway-v2-iam.iso.test.ts
@@ -9,13 +9,12 @@ import { assertIdentical } from "@kensio/smartass";
 import { describe, expect, it } from "vitest";
 
 import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
-import type { SimAwsAccountId } from "../../../aws/sim-aws-account.js";
 import { SimAws } from "../../../aws/sim-aws.js";
 import { simIamPolicyDocumentFactory } from "../../../iam/policy/sim-iam-policy-document.factory.js";
 import { simHttpApiOpenApiDocumentFactory } from "../../openapi/sim-http-api-openapi-document.factory.js";
 import { simHttpApiOpenApiIntegrationFactory } from "../../openapi/sim-http-api-openapi-integration.factory.js";
 
-const accountId = "111111111111" as SimAwsAccountId;
+const accountId = "111111111111";
 const regionName = "eu-west-2";
 
 /**

--- a/src/service/aws/sim-aws-properties.ts
+++ b/src/service/aws/sim-aws-properties.ts
@@ -26,7 +26,12 @@ export interface SimAwsRequestCallerOptions {
  * How one simulated AWS environment is set up.
  */
 export interface SimAwsProperties {
-  readonly defaultAccountId?: SimAwsAccountId;
+  /**
+   * AWS Account ID this simulation uses when a call does not name one.
+   * Plain strings are accepted, so callers do not need the internal
+   * SimAwsAccountId brand to set it.
+   */
+  readonly defaultAccountId?: SimAwsAccountId | string;
   readonly defaultRegionName?: AwsRegionName;
   readonly background?: BackgroundScheduler & BackgroundCompleter;
   /**

--- a/src/service/aws/sim-aws.iso.test.ts
+++ b/src/service/aws/sim-aws.iso.test.ts
@@ -2,9 +2,35 @@ import { describe, expect, it } from "vitest";
 import { assertIdentical } from "@kensio/smartass";
 import { CreateUserCommand } from "@aws-sdk/client-iam";
 import { SimAws } from "./sim-aws.js";
+import {
+  makeSimAwsAccountId,
+  type SimAwsAccountId,
+} from "./sim-aws-account.js";
 import { SimFixedClock } from "../../util/clock/sim-clock.js";
 
 describe("SimAws", () => {
+  it("takes a plain string as the default Account ID", () => {
+    const simAws = new SimAws({ defaultAccountId: "207763040965" });
+
+    expect(simAws.defaultAccountId).toBe("207763040965");
+  });
+
+  it("takes an already branded default Account ID", () => {
+    const accountId = makeSimAwsAccountId();
+
+    const simAws = new SimAws({ defaultAccountId: accountId });
+
+    expect(simAws.defaultAccountId).toBe(accountId);
+  });
+
+  it("reads the default Account ID back as a branded Account ID", () => {
+    const simAws = new SimAws({ defaultAccountId: "207763040965" });
+
+    const accountId: SimAwsAccountId = simAws.defaultAccountId;
+
+    expect(accountId).toBe("207763040965");
+  });
+
   it("returns same Account for same Account ID", () => {
     const simAws = new SimAws();
 

--- a/src/service/aws/sim-aws.ts
+++ b/src/service/aws/sim-aws.ts
@@ -73,7 +73,7 @@ export class SimAws extends SimAwsServiceAccessors {
     });
     const background = timekeeping.background;
 
-    this.defaultAccountId = defaultAccountId;
+    this.defaultAccountId = defaultAccountId as SimAwsAccountId;
     this.defaultRegionName = defaultRegionName;
     this.timekeeping = timekeeping;
     this.background = background;

--- a/src/service/cloudformation/cdk/apigatewayv2/sim-cdk-http-api-authorizer.loc.test.ts
+++ b/src/service/cloudformation/cdk/apigatewayv2/sim-cdk-http-api-authorizer.loc.test.ts
@@ -14,7 +14,6 @@ import { describe, it } from "vitest";
  */
 import { serveSimAws } from "../../../../serve/index.js";
 import { SimAws } from "../../../aws/sim-aws.js";
-import type { SimAwsAccountId } from "../../../aws/sim-aws-account.js";
 import { TemporaryDirectory } from "../../../../util/filesystem/temporary-directory.js";
 import { TestCdkProject } from "../../../../util/filesystem/test-cdk-project.js";
 
@@ -88,7 +87,7 @@ describe("Sim CDK HTTP API JWT authorizer local integration", () => {
     // Given a CDK stack with a user pool, an app client, and an HTTP API whose
     // one route goes through an HttpUserPoolAuthorizer trusting that pool.
     const simAws = new SimAws({
-      defaultAccountId: "111111111111" as SimAwsAccountId,
+      defaultAccountId: "111111111111",
       defaultRegionName: "eu-west-2",
     });
     const projectDirectory = new TemporaryDirectory();

--- a/src/service/cloudformation/cdk/apigatewayv2/sim-cdk-http-api-lambda-authorizer.loc.test.ts
+++ b/src/service/cloudformation/cdk/apigatewayv2/sim-cdk-http-api-lambda-authorizer.loc.test.ts
@@ -9,7 +9,6 @@ import { describe, it } from "vitest";
  */
 import { serveSimAws } from "../../../../serve/index.js";
 import { SimAws } from "../../../aws/sim-aws.js";
-import type { SimAwsAccountId } from "../../../aws/sim-aws-account.js";
 import { TemporaryDirectory } from "../../../../util/filesystem/temporary-directory.js";
 import { TestCdkProject } from "../../../../util/filesystem/test-cdk-project.js";
 
@@ -94,7 +93,7 @@ describe("Sim CDK HTTP API Lambda authorizer local integration", () => {
     // Given a CDK stack whose one route goes through an HttpLambdaAuthorizer
     // answering the simple response format.
     const simAws = new SimAws({
-      defaultAccountId: "111111111111" as SimAwsAccountId,
+      defaultAccountId: "111111111111",
       defaultRegionName: "eu-west-2",
     });
     const projectDirectory = new TemporaryDirectory();

--- a/src/service/cloudformation/cdk/apigatewayv2/sim-cdk-http-api.loc.test.ts
+++ b/src/service/cloudformation/cdk/apigatewayv2/sim-cdk-http-api.loc.test.ts
@@ -15,7 +15,6 @@ import { describe, it } from "vitest";
  */
 import { serveSimAws } from "../../../../serve/index.js";
 import { SimAws } from "../../../aws/sim-aws.js";
-import type { SimAwsAccountId } from "../../../aws/sim-aws-account.js";
 import { TemporaryDirectory } from "../../../../util/filesystem/temporary-directory.js";
 import { TestCdkProject } from "../../../../util/filesystem/test-cdk-project.js";
 
@@ -80,7 +79,7 @@ describe("Sim CDK HTTP API deployment local integration", () => {
     // simulated AWS scoped to the Account and Region the stack names, which
     // is what CDK baked into the endpoint it publishes.
     const simAws = new SimAws({
-      defaultAccountId: "111111111111" as SimAwsAccountId,
+      defaultAccountId: "111111111111",
       defaultRegionName: "eu-west-2",
     });
     const projectDirectory = new TemporaryDirectory();

--- a/src/service/cloudformation/cdk/cognito/sim-cdk-cognito-user-pool.loc.test.ts
+++ b/src/service/cloudformation/cdk/cognito/sim-cdk-cognito-user-pool.loc.test.ts
@@ -23,10 +23,9 @@ import { describe, it } from "vitest";
  * one CDK actually produced rather than one written by hand.
  */
 import { SimAws } from "../../../aws/sim-aws.js";
-import type { SimAwsAccountId } from "../../../aws/sim-aws-account.js";
 import { TestCdkProject } from "../../../../util/filesystem/test-cdk-project.js";
 
-const accountIdOneOnes = "111111111111" as SimAwsAccountId;
+const accountIdOneOnes = "111111111111";
 
 const verificationMessage =
   "The verification code to your new account is {####}";

--- a/src/service/cloudformation/cdk/dynamodb/sim-cdk-dynamodb-indexes.loc.test.ts
+++ b/src/service/cloudformation/cdk/dynamodb/sim-cdk-dynamodb-indexes.loc.test.ts
@@ -18,10 +18,9 @@ import { describe, it } from "vitest";
  * one CDK actually produced rather than one written by hand.
  */
 import { SimAws } from "../../../aws/sim-aws.js";
-import type { SimAwsAccountId } from "../../../aws/sim-aws-account.js";
 import { TestCdkProject } from "../../../../util/filesystem/test-cdk-project.js";
 
-const accountIdOneOnes = "111111111111" as SimAwsAccountId;
+const accountIdOneOnes = "111111111111";
 
 describe("Sim CDK DynamoDB secondary index deployment local integration", () => {
   it("deploys a CDK table an SDK caller then queries both indexes of", async () => {

--- a/src/service/cloudformation/cdk/dynamodb/sim-cdk-dynamodb-table-v2.loc.test.ts
+++ b/src/service/cloudformation/cdk/dynamodb/sim-cdk-dynamodb-table-v2.loc.test.ts
@@ -21,10 +21,9 @@ import { describe, it } from "vitest";
  * one CDK actually produced rather than one written by hand.
  */
 import { SimAws } from "../../../aws/sim-aws.js";
-import type { SimAwsAccountId } from "../../../aws/sim-aws-account.js";
 import { TestCdkProject } from "../../../../util/filesystem/test-cdk-project.js";
 
-const accountIdOneOnes = "111111111111" as SimAwsAccountId;
+const accountIdOneOnes = "111111111111";
 
 describe("Sim CDK DynamoDB TableV2 deployment local integration", () => {
   it("deploys a CDK TableV2 an SDK caller then writes to and reads from", async () => {

--- a/src/service/cloudformation/cdk/dynamodb/sim-cdk-dynamodb-table.loc.test.ts
+++ b/src/service/cloudformation/cdk/dynamodb/sim-cdk-dynamodb-table.loc.test.ts
@@ -21,10 +21,9 @@ import { describe, it } from "vitest";
  * one CDK actually produced rather than one written by hand.
  */
 import { SimAws } from "../../../aws/sim-aws.js";
-import type { SimAwsAccountId } from "../../../aws/sim-aws-account.js";
 import { TestCdkProject } from "../../../../util/filesystem/test-cdk-project.js";
 
-const accountIdOneOnes = "111111111111" as SimAwsAccountId;
+const accountIdOneOnes = "111111111111";
 
 describe("Sim CDK DynamoDB Table deployment local integration", () => {
   it("deploys a CDK table an SDK caller then writes to and reads from", async () => {

--- a/src/service/cloudformation/cdk/lambda/sim-cdk-lambda-dynamodb-event-source.loc.test.ts
+++ b/src/service/cloudformation/cdk/lambda/sim-cdk-lambda-dynamodb-event-source.loc.test.ts
@@ -14,10 +14,9 @@ import { describe, it } from "vitest";
  * one CDK actually produced rather than one written by hand.
  */
 import { SimAws } from "../../../aws/sim-aws.js";
-import type { SimAwsAccountId } from "../../../aws/sim-aws-account.js";
 import { TestCdkProject } from "../../../../util/filesystem/test-cdk-project.js";
 
-const accountIdOneOnes = "111111111111" as SimAwsAccountId;
+const accountIdOneOnes = "111111111111";
 
 /**
  * A handler sending each stream record's key on to the queue CDK put in its

--- a/src/service/cloudformation/cdk/sqs/sim-cdk-sqs-queue.loc.test.ts
+++ b/src/service/cloudformation/cdk/sqs/sim-cdk-sqs-queue.loc.test.ts
@@ -19,12 +19,11 @@ import { describe, it } from "vitest";
  * one CDK actually produced rather than one written by hand.
  */
 import { SimAws } from "../../../aws/sim-aws.js";
-import type { SimAwsAccountId } from "../../../aws/sim-aws-account.js";
 import { SimSqsQueueUrl } from "../../../sqs/queue/sim-sqs-queue-url.js";
 import { TestCdkProject } from "../../../../util/filesystem/test-cdk-project.js";
 
 const emptyBytes = new Uint8Array();
-const accountIdOneOnes = "111111111111" as SimAwsAccountId;
+const accountIdOneOnes = "111111111111";
 
 /**
  * A handler sending to the queue whose URL CDK put in its environment.

--- a/src/service/cloudformation/cdk/ssm/sim-cdk-ssm-parameter.loc.test.ts
+++ b/src/service/cloudformation/cdk/ssm/sim-cdk-ssm-parameter.loc.test.ts
@@ -14,11 +14,10 @@ import { describe, it } from "vitest";
  * one CDK actually produced rather than one written by hand.
  */
 import { SimAws } from "../../../aws/sim-aws.js";
-import type { SimAwsAccountId } from "../../../aws/sim-aws-account.js";
 import { TestCdkProject } from "../../../../util/filesystem/test-cdk-project.js";
 
 const emptyBytes = new Uint8Array();
-const accountIdOneOnes = "111111111111" as SimAwsAccountId;
+const accountIdOneOnes = "111111111111";
 
 /**
  * A handler reading the parameter whose name CDK put in its environment.

--- a/src/service/cloudformation/resource/cfn/dynamodb/sim-dynamodb-table-cfn.iso.test.ts
+++ b/src/service/cloudformation/resource/cfn/dynamodb/sim-dynamodb-table-cfn.iso.test.ts
@@ -6,10 +6,9 @@ import {
 import { describe, it } from "vitest";
 
 import { SimAws } from "../../../../aws/sim-aws.js";
-import type { SimAwsAccountId } from "../../../../aws/sim-aws-account.js";
 import type { CfnTemplateBodyRecord } from "../../../template/sim-cfn-template.js";
 
-const accountIdOneOnes = "111111111111" as SimAwsAccountId;
+const accountIdOneOnes = "111111111111";
 
 /**
  * A template referencing its table by one attribute, so a test only has to say

--- a/src/service/cognito/cfn/sim-cfn-cognito-user-pool.iso.test.ts
+++ b/src/service/cognito/cfn/sim-cfn-cognito-user-pool.iso.test.ts
@@ -16,10 +16,9 @@ import {
 import { describe, it } from "vitest";
 
 import { SimAws } from "../../aws/sim-aws.js";
-import type { SimAwsAccountId } from "../../aws/sim-aws-account.js";
 import type { SimCfnStack } from "../../cloudformation/stack/sim-cfn-stack.js";
 
-const accountIdOneOnes = "111111111111" as SimAwsAccountId;
+const accountIdOneOnes = "111111111111";
 
 function simAwsInEuWest2(): SimAws {
   return new SimAws({

--- a/src/service/cognito/command/auth/sim-cognito-token-claims.iso.test.ts
+++ b/src/service/cognito/command/auth/sim-cognito-token-claims.iso.test.ts
@@ -18,7 +18,6 @@ import {
 import { describe, it } from "vitest";
 import type { JSONObject } from "../../../../util/type-guard/json.js";
 import { SimAws } from "../../../aws/sim-aws.js";
-import type { SimAwsAccountId } from "../../../aws/sim-aws-account.js";
 import type { SimCognitoIdentityProvider } from "../../sim-cognito-identity-provider.js";
 
 const password = "Sup3rSecret!";
@@ -57,7 +56,7 @@ function tokenClaims(token: string): JSONObject {
  */
 async function simCognitoTokens(): Promise<SimCognitoTokens> {
   const cognito = new SimAws({
-    defaultAccountId: "111111111111" as SimAwsAccountId,
+    defaultAccountId: "111111111111",
     defaultRegionName: "eu-west-2",
   }).cognitoIdentityProvider();
 

--- a/src/service/cognito/command/auth/sim-cognito-token-verification.iso.test.ts
+++ b/src/service/cognito/command/auth/sim-cognito-token-verification.iso.test.ts
@@ -14,7 +14,6 @@ import {
 import { CognitoJwtVerifier } from "aws-jwt-verify";
 import { describe, it } from "vitest";
 import { SimAws } from "../../../aws/sim-aws.js";
-import type { SimAwsAccountId } from "../../../aws/sim-aws-account.js";
 
 const password = "Sup3rSecret!";
 
@@ -36,7 +35,7 @@ async function simCognitoSignedIn(
   signedInAt?: Date,
 ): Promise<SimCognitoSignedIn> {
   const simAws = new SimAws({
-    defaultAccountId: "111111111111" as SimAwsAccountId,
+    defaultAccountId: "111111111111",
     defaultRegionName: "eu-west-2",
   });
   const cognito = simAws.cognitoIdentityProvider();

--- a/src/service/cognito/command/authorize/sim-cognito-group-iam.iso.test.ts
+++ b/src/service/cognito/command/authorize/sim-cognito-group-iam.iso.test.ts
@@ -15,10 +15,9 @@ import {
 import { describe, it } from "vitest";
 import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
 import { SimAws } from "../../../aws/sim-aws.js";
-import type { SimAwsAccountId } from "../../../aws/sim-aws-account.js";
 import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
 
-const accountId = "111111111111" as SimAwsAccountId;
+const accountId = "111111111111";
 const regionName = "eu-west-2";
 
 interface SimCognitoWithRole {

--- a/src/service/cognito/command/authorize/sim-cognito-iam.iso.test.ts
+++ b/src/service/cognito/command/authorize/sim-cognito-iam.iso.test.ts
@@ -15,10 +15,9 @@ import {
 import { describe, it } from "vitest";
 import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
 import { SimAws } from "../../../aws/sim-aws.js";
-import type { SimAwsAccountId } from "../../../aws/sim-aws-account.js";
 import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
 
-const accountId = "111111111111" as SimAwsAccountId;
+const accountId = "111111111111";
 const regionName = "eu-west-2";
 
 interface SimCognitoWithRole {

--- a/src/service/cognito/command/authorize/sim-cognito-user-iam.iso.test.ts
+++ b/src/service/cognito/command/authorize/sim-cognito-user-iam.iso.test.ts
@@ -16,10 +16,9 @@ import {
 import { describe, it } from "vitest";
 import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
 import { SimAws } from "../../../aws/sim-aws.js";
-import type { SimAwsAccountId } from "../../../aws/sim-aws-account.js";
 import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
 
-const accountId = "111111111111" as SimAwsAccountId;
+const accountId = "111111111111";
 const regionName = "eu-west-2";
 
 interface SimCognitoWithRole {

--- a/src/service/cognito/command/user-pool/sim-cognito-user-pool-commands.iso.test.ts
+++ b/src/service/cognito/command/user-pool/sim-cognito-user-pool-commands.iso.test.ts
@@ -15,12 +15,11 @@ import {
 } from "@kensio/smartass";
 import { describe, it } from "vitest";
 import { SimAws } from "../../../aws/sim-aws.js";
-import type { SimAwsAccountId } from "../../../aws/sim-aws-account.js";
 import { SimCognitoResourceNotFoundException } from "../../error/sim-cognito.error.js";
 
 function simCognitoInEuWest2(): SimAws {
   return new SimAws({
-    defaultAccountId: "111111111111" as SimAwsAccountId,
+    defaultAccountId: "111111111111",
     defaultRegionName: "eu-west-2",
   });
 }

--- a/src/service/cognito/command/user/sim-cognito-user-commands.iso.test.ts
+++ b/src/service/cognito/command/user/sim-cognito-user-commands.iso.test.ts
@@ -19,7 +19,6 @@ import {
 import { describe, it } from "vitest";
 import { SimAws } from "../../../aws/sim-aws.js";
 import type { SimCognitoAttributeType } from "../../user-pool/user/sim-cognito-user-attributes.js";
-import type { SimAwsAccountId } from "../../../aws/sim-aws-account.js";
 import type { SimCognitoIdentityProvider } from "../../sim-cognito-identity-provider.js";
 import { SimCognitoUserNotFoundException } from "../../error/sim-cognito.error.js";
 
@@ -37,7 +36,7 @@ interface SimCognitoWithPool {
 
 async function simCognitoWithPool(): Promise<SimCognitoWithPool> {
   const simAws = new SimAws({
-    defaultAccountId: "111111111111" as SimAwsAccountId,
+    defaultAccountId: "111111111111",
     defaultRegionName: "eu-west-2",
   });
   const cognito = simAws.cognitoIdentityProvider();

--- a/src/service/kms/cfn/sim-cfn-kms-key-properties.iso.test.ts
+++ b/src/service/kms/cfn/sim-cfn-kms-key-properties.iso.test.ts
@@ -3,10 +3,9 @@ import { assertFalse, assertIdentical } from "@kensio/smartass";
 import { describe, it } from "vitest";
 
 import { SimAws } from "../../aws/sim-aws.js";
-import type { SimAwsAccountId } from "../../aws/sim-aws-account.js";
 import { simKmsCfnKey } from "../../../../test/kms/cfn-key-resource.js";
 
-const accountIdOneOnes = "111111111111" as SimAwsAccountId;
+const accountIdOneOnes = "111111111111";
 
 function simAwsInEuWest2(): SimAws {
   return new SimAws({

--- a/src/service/kms/cfn/sim-cfn-kms-key.iso.test.ts
+++ b/src/service/kms/cfn/sim-cfn-kms-key.iso.test.ts
@@ -21,10 +21,9 @@ import {
 import { describe, it } from "vitest";
 
 import { SimAws } from "../../aws/sim-aws.js";
-import type { SimAwsAccountId } from "../../aws/sim-aws-account.js";
 import { simKmsCfnKey } from "../../../../test/kms/cfn-key-resource.js";
 
-const accountIdOneOnes = "111111111111" as SimAwsAccountId;
+const accountIdOneOnes = "111111111111";
 
 function simAwsInEuWest2(): SimAws {
   return new SimAws({

--- a/src/service/s3/serve/sim-s3-presigned-session.iso.test.ts
+++ b/src/service/s3/serve/sim-s3-presigned-session.iso.test.ts
@@ -10,12 +10,11 @@ import { assertIdentical, assertNonNullable } from "@kensio/smartass";
 import { describe, expect, it } from "vitest";
 
 import { SimAws } from "../../aws/sim-aws.js";
-import type { SimAwsAccountId } from "../../aws/sim-aws-account.js";
 import type { AwsRegionName } from "../../aws/sim-aws-region.js";
 import { SimAwsHttp } from "../../../serve/http/sim-aws-http.js";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 
-const accountId = "111111111111" as SimAwsAccountId;
+const accountId = "111111111111";
 const regionName = "eu-west-2" as AwsRegionName;
 const roleArn = `arn:aws:iam::${accountId}:role/ReportPublisher`;
 

--- a/src/service/secretsmanager/cfn/sim-cfn-secrets-manager-secret.iso.test.ts
+++ b/src/service/secretsmanager/cfn/sim-cfn-secrets-manager-secret.iso.test.ts
@@ -15,10 +15,9 @@ import {
 import { describe, it } from "vitest";
 
 import { SimAws } from "../../aws/sim-aws.js";
-import type { SimAwsAccountId } from "../../aws/sim-aws-account.js";
 import type { SimSecretsManagerSecret } from "../secret/sim-secrets-manager-secret.js";
 
-const accountIdOneOnes = "111111111111" as SimAwsAccountId;
+const accountIdOneOnes = "111111111111";
 
 function simAwsInEuWest2(): SimAws {
   return new SimAws({

--- a/src/service/secretsmanager/command/authorize/sim-secrets-manager-iam.iso.test.ts
+++ b/src/service/secretsmanager/command/authorize/sim-secrets-manager-iam.iso.test.ts
@@ -12,11 +12,10 @@ import {
 } from "@kensio/smartass";
 import { describe, it } from "vitest";
 import { SimAws } from "../../../aws/sim-aws.js";
-import type { SimAwsAccountId } from "../../../aws/sim-aws-account.js";
 import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
 import { simIamPolicyDocumentFactory } from "../../../iam/policy/sim-iam-policy-document.factory.js";
 
-const accountIdOneOnes = "111111111111" as SimAwsAccountId;
+const accountIdOneOnes = "111111111111";
 
 describe("Secrets Manager IAM authorization", () => {
   it("allows a read the caller's policy permits", async () => {

--- a/src/service/secretsmanager/command/authorize/sim-secrets-manager-list-iam.iso.test.ts
+++ b/src/service/secretsmanager/command/authorize/sim-secrets-manager-list-iam.iso.test.ts
@@ -11,11 +11,10 @@ import {
 } from "@kensio/smartass";
 import { describe, it } from "vitest";
 import { SimAws } from "../../../aws/sim-aws.js";
-import type { SimAwsAccountId } from "../../../aws/sim-aws-account.js";
 import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
 import { simIamPolicyDocumentFactory } from "../../../iam/policy/sim-iam-policy-document.factory.js";
 
-const accountIdOneOnes = "111111111111" as SimAwsAccountId;
+const accountIdOneOnes = "111111111111";
 
 describe("Secrets Manager ListSecrets authorization", () => {
   it("denies a policy naming individual secret ARNs", async () => {

--- a/src/service/secretsmanager/command/secret/sim-secrets-manager-secret-commands.iso.test.ts
+++ b/src/service/secretsmanager/command/secret/sim-secrets-manager-secret-commands.iso.test.ts
@@ -20,9 +20,8 @@ import {
 } from "@kensio/smartass";
 import { describe, it } from "vitest";
 import { SimAws } from "../../../aws/sim-aws.js";
-import type { SimAwsAccountId } from "../../../aws/sim-aws-account.js";
 
-const accountIdOneOnes = "111111111111" as SimAwsAccountId;
+const accountIdOneOnes = "111111111111";
 
 describe("Secrets Manager CreateSecret", () => {
   it("gives the secret an ARN carrying six random characters", async () => {

--- a/src/service/secretsmanager/secret/sim-secrets-manager-secret-resolution.iso.test.ts
+++ b/src/service/secretsmanager/secret/sim-secrets-manager-secret-resolution.iso.test.ts
@@ -11,10 +11,9 @@ import {
 } from "@kensio/smartass";
 import { describe, it } from "vitest";
 import { SimAws } from "../../aws/sim-aws.js";
-import type { SimAwsAccountId } from "../../aws/sim-aws-account.js";
 import { SimSecretsManagerResourceNotFoundException } from "../error/sim-secrets-manager.error.js";
 
-const accountIdOneOnes = "111111111111" as SimAwsAccountId;
+const accountIdOneOnes = "111111111111";
 
 async function simAwsWithSecret(): Promise<SimAws> {
   const simAws = new SimAws({

--- a/src/service/sqs/cfn/sim-cfn-sqs-queue.iso.test.ts
+++ b/src/service/sqs/cfn/sim-cfn-sqs-queue.iso.test.ts
@@ -13,10 +13,9 @@ import {
 import { describe, it } from "vitest";
 
 import { SimAws } from "../../aws/sim-aws.js";
-import type { SimAwsAccountId } from "../../aws/sim-aws-account.js";
 import { SimSqsQueue } from "../queue/sim-sqs-queue.js";
 
-const accountIdOneOnes = "111111111111" as SimAwsAccountId;
+const accountIdOneOnes = "111111111111";
 
 function simAwsInEuWest2(): SimAws {
   return new SimAws({

--- a/src/service/sqs/command/authorize/sim-sqs-iam.iso.test.ts
+++ b/src/service/sqs/command/authorize/sim-sqs-iam.iso.test.ts
@@ -17,9 +17,8 @@ import {
 import { describe, it } from "vitest";
 import { SimAws } from "../../../aws/sim-aws.js";
 import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
-import type { SimAwsAccountId } from "../../../aws/sim-aws-account.js";
 
-const accountId = "111111111111" as SimAwsAccountId;
+const accountId = "111111111111";
 const regionName = "eu-west-2";
 
 /**

--- a/src/service/sqs/command/message/sim-sqs-send-message-commands.iso.test.ts
+++ b/src/service/sqs/command/message/sim-sqs-send-message-commands.iso.test.ts
@@ -10,7 +10,6 @@ import {
 } from "@kensio/smartass";
 import { describe, it } from "vitest";
 import { SimAws } from "../../../aws/sim-aws.js";
-import type { SimAwsAccountId } from "../../../aws/sim-aws-account.js";
 import {
   SimSqsInvalidMessageContents,
   SimSqsInvalidParameterValue,
@@ -215,7 +214,7 @@ describe("SQS SendMessage", () => {
   it("reaches no queue through a URL naming another Region", async () => {
     // Given a queue in one Region.
     const simAws = new SimAws({
-      defaultAccountId: "111111111111" as SimAwsAccountId,
+      defaultAccountId: "111111111111",
       defaultRegionName: "eu-west-2",
     });
     await simAws

--- a/src/service/sqs/command/queue/sim-sqs-queue-commands.iso.test.ts
+++ b/src/service/sqs/command/queue/sim-sqs-queue-commands.iso.test.ts
@@ -15,7 +15,6 @@ import {
 } from "@kensio/smartass";
 import { describe, it } from "vitest";
 import { SimAws } from "../../../aws/sim-aws.js";
-import type { SimAwsAccountId } from "../../../aws/sim-aws-account.js";
 import {
   SimSqsInvalidParameterValue,
   SimSqsQueueDeletedRecently,
@@ -29,7 +28,7 @@ describe("SQS queue commands", () => {
   it("creates a queue with a URL and ARN naming its Account and Region", async () => {
     // Given a simulated AWS in one Account and Region.
     const simAws = new SimAws({
-      defaultAccountId: "111111111111" as SimAwsAccountId,
+      defaultAccountId: "111111111111",
       defaultRegionName: "eu-west-2",
     });
 
@@ -168,7 +167,7 @@ describe("SQS queue commands", () => {
   it("refuses a request for a queue owned by another Account", async () => {
     // Given an existing queue.
     const simAws = new SimAws({
-      defaultAccountId: "111111111111" as SimAwsAccountId,
+      defaultAccountId: "111111111111",
     });
     await simAws
       .sqs()

--- a/src/service/ssm/cfn/sim-cfn-ssm-parameter.iso.test.ts
+++ b/src/service/ssm/cfn/sim-cfn-ssm-parameter.iso.test.ts
@@ -8,10 +8,9 @@ import {
 import { describe, it } from "vitest";
 
 import { SimAws } from "../../aws/sim-aws.js";
-import type { SimAwsAccountId } from "../../aws/sim-aws-account.js";
 import { SimSsmParameter } from "../parameter/sim-ssm-parameter.js";
 
-const accountIdOneOnes = "111111111111" as SimAwsAccountId;
+const accountIdOneOnes = "111111111111";
 
 function simAwsInEuWest2(): SimAws {
   return new SimAws({

--- a/src/service/ssm/command/authorize/sim-ssm-iam-path.iso.test.ts
+++ b/src/service/ssm/command/authorize/sim-ssm-iam-path.iso.test.ts
@@ -11,11 +11,10 @@ import {
 } from "@kensio/smartass";
 import { describe, it } from "vitest";
 import { SimAws } from "../../../aws/sim-aws.js";
-import type { SimAwsAccountId } from "../../../aws/sim-aws-account.js";
 import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
 import { simIamPolicyDocumentFactory } from "../../../iam/policy/sim-iam-policy-document.factory.js";
 
-const accountIdOneOnes = "111111111111" as SimAwsAccountId;
+const accountIdOneOnes = "111111111111";
 
 describe("SSM path and batch IAM authorization", () => {
   it("authorizes a path listing against the path itself", async () => {

--- a/src/service/ssm/command/authorize/sim-ssm-iam.iso.test.ts
+++ b/src/service/ssm/command/authorize/sim-ssm-iam.iso.test.ts
@@ -12,11 +12,10 @@ import {
 } from "@kensio/smartass";
 import { describe, it } from "vitest";
 import { SimAws } from "../../../aws/sim-aws.js";
-import type { SimAwsAccountId } from "../../../aws/sim-aws-account.js";
 import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
 import { simIamPolicyDocumentFactory } from "../../../iam/policy/sim-iam-policy-document.factory.js";
 
-const accountIdOneOnes = "111111111111" as SimAwsAccountId;
+const accountIdOneOnes = "111111111111";
 
 describe("SSM IAM authorization", () => {
   it("allows a read the caller's policy permits", async () => {


### PR DESCRIPTION
`SimAwsProperties.defaultAccountId` was typed as `SimAwsAccountId`, a brand exported from the package root as a type only, with no constructor, factory or guard. `new SimAws({ defaultAccountId: "207763040965" })` failed with `TS2322`, so every caller had to cast, including this repo's own tests.

Widen the property to `SimAwsAccountId | string` and cast once in the `SimAws` constructor, matching what `SimAws.account()`, `SimAwsRegion.account()` and the `SimS3` bucket accessors already do. `SimAws.defaultAccountId` still reads back as `SimAwsAccountId`, so ARN construction and internal call sites are unchanged.

Removed the `as SimAwsAccountId` casts from the test files that carried them only for this property, along with the imports that became unused. Six files keep the cast, where the same const is also passed to an internal API that genuinely wants the brand: the `*-validation` CloudFormation tests, the CloudFront alternate-domain router test and the Lambda URL registry test. Widening those is the wider brand sweep that #390 put out of scope.

Three tests added to `src/service/aws/sim-aws.iso.test.ts`: plain string, already-branded value, and reading back as `SimAwsAccountId`. The third is the type-level guard, since `const accountId: SimAwsAccountId = simAws.defaultAccountId` fails `build:check` if the property ever widens.

`pnpm run check` passes: 752 test files, 4684 tests, 99.91% statement coverage.

Not addressed here, and noted as an open question on the issue: nothing validates the 12-digit account ID format, and accepting a plain string removes what little compile-time signal there was.

Resolves #390
