### PR TITLE
fix: apply CloudFront DefaultRootObject and CustomErrorResponses

### DIFF
--- a/docs/services/cloudfront/README.md
+++ b/docs/services/cloudfront/README.md
@@ -63,6 +63,122 @@ const distributionCreation = await simCloudFront.createDistribution(
 console.log(distributionCreation.Distribution?.DomainName);
 ```
 
+## Static sites: default root object and error pages
+
+A static site behind CloudFront usually leans on two Distribution settings: `DefaultRootObject`, so
+a request for the site root returns the home page, and `CustomErrorResponses`, so a URL that matches
+no object returns the site's own error page rather than the Origin's. Sim CloudFront applies both,
+so a test can assert what a visitor would actually see.
+
+```typescript sim-cloudfront-static-site
+/**
+ * Serving a static site with a default root object and a custom error page.
+ */
+
+import { CreateDistributionCommand } from "@aws-sdk/client-cloudfront";
+import { CreateBucketCommand, PutObjectCommand } from "@aws-sdk/client-s3";
+
+import { SimAws } from "@kensio/yulin";
+import { serveSimAws } from "@kensio/yulin/serve";
+
+const simAws = new SimAws();
+const srv = await serveSimAws({ simAws });
+
+try {
+  const simS3 = simAws.s3();
+
+  await simS3.createBucket(new CreateBucketCommand({ Bucket: "site-bucket" }));
+
+  const pages = {
+    "index.html": "<h1>Home</h1>",
+    "404.html": "<h1>Page not found</h1>",
+  };
+
+  for (const [key, body] of Object.entries(pages)) {
+    await simS3.putObject(
+      new PutObjectCommand({
+        Bucket: "site-bucket",
+        Key: key,
+        ContentType: "text/html",
+        Body: body,
+      }),
+    );
+  }
+
+  const distributionCreation = await simAws.cloudFront().createDistribution(
+    new CreateDistributionCommand({
+      DistributionConfig: {
+        CallerReference: "static-site",
+        Comment: "Static site",
+        Enabled: true,
+        DefaultRootObject: "index.html",
+        CustomErrorResponses: {
+          Quantity: 2,
+          Items: [
+            {
+              ErrorCode: 404,
+              ResponsePagePath: "/404.html",
+              ResponseCode: "404",
+            },
+            {
+              ErrorCode: 403,
+              ResponsePagePath: "/404.html",
+              ResponseCode: "404",
+            },
+          ],
+        },
+        Origins: {
+          Quantity: 1,
+          Items: [
+            {
+              Id: "site-origin",
+              DomainName: "site-bucket.s3.amazonaws.com",
+              S3OriginConfig: { OriginAccessIdentity: "" },
+            },
+          ],
+        },
+        DefaultCacheBehavior: {
+          TargetOriginId: "site-origin",
+          ViewerProtocolPolicy: "allow-all",
+        },
+      },
+    }),
+  );
+
+  const distroHostname = distributionCreation.Distribution!.DomainName!;
+
+  const home = await fetch(srv.localUrl(`http://${distroHostname}/`));
+  console.log(await home.text()); // <h1>Home</h1>
+
+  const missing = await fetch(srv.localUrl(`http://${distroHostname}/nowhere`));
+  console.log(missing.status); // 404
+  console.log(await missing.text()); // <h1>Page not found</h1>
+} finally {
+  srv.close();
+}
+```
+
+The default root object stands in for a request to the root of the Distribution and nothing else. A
+request for `/blog/` is passed to the Origin as it arrived, even where that folder holds its own
+`index.html`, which is where CloudFront differs from an S3 website index document. The substituted
+path is what the rest of request handling sees, so a Cache Behavior pattern and a `viewer-request`
+CloudFront Function both act on the object being served rather than on the root. The value names an
+object at the Origin, so it may be a path such as `public/index.html` but must not begin with a
+forward slash: sim CloudFront refuses one that does with `InvalidDefaultRootObject`, rather than
+creating a Distribution that answers its own root with a 403.
+
+A custom error response replaces the Origin's response when its status matches `ErrorCode`, which is
+one of the codes CloudFront supports: 400, 403, 404, 405, 414, 416, 500, 501, 502, 503 and 504. The
+response page is fetched as a request in its own right, so the Cache Behavior matching
+`ResponsePagePath` chooses which Origin it comes from, and error pages can live somewhere other than
+the content that failed. `ResponseCode` is the status the viewer sees, which is how a single page
+app serves its shell with a 200 for a URL the Bucket has no object for. Where the response page is
+itself missing, the viewer gets the status from fetching it, as in CloudFront.
+
+Custom error responses are applied before a `viewer-response` CloudFront Function runs, so the
+function sees the response the viewer is about to get. `ErrorCachingMinTTL` is accepted and ignored,
+along with a rule that sets nothing else, because sim CloudFront has no cache to apply it to.
+
 ## Serve simulated CloudFront on localhost
 
 Use `serveSimAws` when you want to make real HTTP requests to the simulated system on localhost.
@@ -563,6 +679,7 @@ Sim CloudFront currently supports:
 - Custom Origins reaching sim HTTP APIs and sim Lambda Function URLs in process
 - CloudFront Distribution hostnames such as `distro123.cloudfront.net`
 - Default cache Behavior and path-based cache Behaviors
+- `DefaultRootObject` and `CustomErrorResponses`, for static sites and single page apps
 - `viewer-request` and `viewer-response` CloudFront Functions
 - Viewer certificates from sim ACM, including CloudFront's `us-east-1` requirement
 - Serving simulated CloudFront traffic on localhost with `serveSimAws`

--- a/docs/services/cloudfront/README.md
+++ b/docs/services/cloudfront/README.md
@@ -171,9 +171,10 @@ A custom error response replaces the Origin's response when its status matches `
 one of the codes CloudFront supports: 400, 403, 404, 405, 414, 416, 500, 501, 502, 503 and 504. The
 response page is fetched as a request in its own right, so the Cache Behavior matching
 `ResponsePagePath` chooses which Origin it comes from, and error pages can live somewhere other than
-the content that failed. `ResponseCode` is the status the viewer sees, which is how a single page
-app serves its shell with a 200 for a URL the Bucket has no object for. Where the response page is
-itself missing, the viewer gets the status from fetching it, as in CloudFront.
+the content that failed. `ResponseCode` is the status the viewer sees, which is how a single-page
+app serves its shell with a 200 for a URL the Bucket has no object for. It is one of the same error
+codes or 200, the set CloudFront allows. Where the response page is itself missing, the viewer gets
+the status from fetching it, as in CloudFront.
 
 Custom error responses are applied before a `viewer-response` CloudFront Function runs, so the
 function sees the response the viewer is about to get. `ErrorCachingMinTTL` is accepted and ignored,
@@ -679,7 +680,7 @@ Sim CloudFront currently supports:
 - Custom Origins reaching sim HTTP APIs and sim Lambda Function URLs in process
 - CloudFront Distribution hostnames such as `distro123.cloudfront.net`
 - Default cache Behavior and path-based cache Behaviors
-- `DefaultRootObject` and `CustomErrorResponses`, for static sites and single page apps
+- `DefaultRootObject` and `CustomErrorResponses`, for static sites and single-page apps
 - `viewer-request` and `viewer-response` CloudFront Functions
 - Viewer certificates from sim ACM, including CloudFront's `us-east-1` requirement
 - Serving simulated CloudFront traffic on localhost with `serveSimAws`

--- a/docs/services/cloudfront/sim-cloudfront-static-site.example.ts
+++ b/docs/services/cloudfront/sim-cloudfront-static-site.example.ts
@@ -1,0 +1,85 @@
+/**
+ * Serving a static site with a default root object and a custom error page.
+ */
+
+import { CreateDistributionCommand } from "@aws-sdk/client-cloudfront";
+import { CreateBucketCommand, PutObjectCommand } from "@aws-sdk/client-s3";
+
+import { SimAws } from "@kensio/yulin";
+import { serveSimAws } from "@kensio/yulin/serve";
+
+const simAws = new SimAws();
+const srv = await serveSimAws({ simAws });
+
+try {
+  const simS3 = simAws.s3();
+
+  await simS3.createBucket(new CreateBucketCommand({ Bucket: "site-bucket" }));
+
+  const pages = {
+    "index.html": "<h1>Home</h1>",
+    "404.html": "<h1>Page not found</h1>",
+  };
+
+  for (const [key, body] of Object.entries(pages)) {
+    await simS3.putObject(
+      new PutObjectCommand({
+        Bucket: "site-bucket",
+        Key: key,
+        ContentType: "text/html",
+        Body: body,
+      }),
+    );
+  }
+
+  const distributionCreation = await simAws.cloudFront().createDistribution(
+    new CreateDistributionCommand({
+      DistributionConfig: {
+        CallerReference: "static-site",
+        Comment: "Static site",
+        Enabled: true,
+        DefaultRootObject: "index.html",
+        CustomErrorResponses: {
+          Quantity: 2,
+          Items: [
+            {
+              ErrorCode: 404,
+              ResponsePagePath: "/404.html",
+              ResponseCode: "404",
+            },
+            {
+              ErrorCode: 403,
+              ResponsePagePath: "/404.html",
+              ResponseCode: "404",
+            },
+          ],
+        },
+        Origins: {
+          Quantity: 1,
+          Items: [
+            {
+              Id: "site-origin",
+              DomainName: "site-bucket.s3.amazonaws.com",
+              S3OriginConfig: { OriginAccessIdentity: "" },
+            },
+          ],
+        },
+        DefaultCacheBehavior: {
+          TargetOriginId: "site-origin",
+          ViewerProtocolPolicy: "allow-all",
+        },
+      },
+    }),
+  );
+
+  const distroHostname = distributionCreation.Distribution!.DomainName!;
+
+  const home = await fetch(srv.localUrl(`http://${distroHostname}/`));
+  console.log(await home.text()); // <h1>Home</h1>
+
+  const missing = await fetch(srv.localUrl(`http://${distroHostname}/nowhere`));
+  console.log(missing.status); // 404
+  console.log(await missing.text()); // <h1>Page not found</h1>
+} finally {
+  srv.close();
+}

--- a/src/service/cloudfront/README.md
+++ b/src/service/cloudfront/README.md
@@ -52,9 +52,20 @@ time, including:
 - Origins
 - Cache Behaviors
 - CloudFront Function associations
+- the default root object
+- custom error responses
 
 The `Distribution/configurator/` classes translate AWS-style `DistributionConfig` input into the
 internal Distribution model.
+
+### Default root object and custom error responses
+
+`SimCloudFrontCustomErrorConfigurator` refuses configuration CloudFront refuses: an `ErrorCode`
+outside the set CloudFront supports, and a `ResponsePagePath` or `ResponseCode` given without the
+other. A rule with neither only configures error caching, which nothing here caches, so it is
+accepted and left out of the internal model. `DefaultRootObject` beginning with a forward slash is
+refused for the same reason: in real CloudFront it answers the Distribution root with a 403, so a
+Distribution carrying one is not worth creating.
 
 ### Viewer certificates
 
@@ -85,6 +96,12 @@ registry checks nothing.
 HTTP request behaviour is split across a few directories:
 
 - `controller/` coordinates request handling for served CloudFront traffic.
+  `controller/root-object/` substitutes the default root object for a request to the Distribution
+  root, before Behavior resolution so that everything downstream sees the object being served.
+  `controller/error/` replaces an Origin error with the Distribution's response page, after the
+  Origin fetch and before the viewer-response CloudFront Function. The response page is fetched
+  through the same Behavior resolution and Origin fetching as any other request, so it can come from
+  an Origin of its own.
 - `router/` resolves an incoming `Request` to a simulated Distribution by CloudFront hostname or
   alternate domain name.
 - `resolver/` chooses the matching Cache Behavior for a request path.

--- a/src/service/cloudfront/cfn/distro/sim-cfn-cf-distro-error-pages.iso.test.ts
+++ b/src/service/cloudfront/cfn/distro/sim-cfn-cf-distro-error-pages.iso.test.ts
@@ -1,0 +1,151 @@
+import { describe, it } from "vitest";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertResponseStatus,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  describeResponse,
+} from "@kensio/smartass";
+import { PutObjectCommand } from "@aws-sdk/client-s3";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimCloudFrontDistribution } from "../../distribution/sim-cloudfront-distribution.js";
+import { simCfSiteRequest } from "../../../../../test/cloudfront/site-fixture.js";
+
+describe("CloudFormation Distribution error pages and root object", () => {
+  it("serves a static site declared in a CloudFormation template", async () => {
+    // Given a template declaring a static site the way CDK synthesizes one,
+    // with the list properties as arrays and ResponseCode as an integer.
+    const simAws = new SimAws();
+
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "static-site-stack",
+      template: {
+        Resources: {
+          SiteBucket: {
+            Type: "AWS::S3::Bucket",
+            Properties: { BucketName: "cfn-site-bucket" },
+          },
+          SiteDistribution: {
+            Type: "AWS::CloudFront::Distribution",
+            DependsOn: "SiteBucket",
+            Properties: {
+              DistributionConfig: {
+                DefaultRootObject: "index.html",
+                CustomErrorResponses: [
+                  {
+                    ErrorCode: 404,
+                    ResponsePagePath: "/404.html",
+                    ResponseCode: 404,
+                  },
+                  {
+                    ErrorCode: 403,
+                    ResponsePagePath: "/404.html",
+                    ResponseCode: 404,
+                  },
+                ],
+                Origins: [
+                  {
+                    Id: "SiteOrigin",
+                    DomainName: "cfn-site-bucket.s3.amazonaws.com",
+                    S3OriginConfig: {},
+                  },
+                ],
+                DefaultCacheBehavior: {
+                  TargetOriginId: "SiteOrigin",
+                  ViewerProtocolPolicy: "redirect-to-https",
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    const resource = stack.getResource("SiteDistribution");
+    assertNonNullable(resource);
+    assertInstanceOf(resource.simResource, SimCloudFrontDistribution);
+    const distributionId = resource.simResource.distributionId;
+
+    // And the site's pages in the Bucket the template created.
+    const simS3 = simAws.s3();
+    await simS3.putObject(
+      new PutObjectCommand({
+        Bucket: "cfn-site-bucket",
+        Key: "index.html",
+        ContentType: "text/html",
+        Body: "<h1>Home</h1>",
+      }),
+    );
+    await simS3.putObject(
+      new PutObjectCommand({
+        Bucket: "cfn-site-bucket",
+        Key: "404.html",
+        ContentType: "text/html",
+        Body: "<h1>Not found</h1>",
+      }),
+    );
+
+    // When the root of the Distribution is requested.
+    const home = await simCfSiteRequest(simAws, distributionId, "/");
+
+    // Then the default root object is served.
+    assertResponseStatus(home, 200, await describeResponse(home));
+    assertIdentical(await home.text(), "<h1>Home</h1>");
+
+    // And when a page that does not exist is requested.
+    const missing = await simCfSiteRequest(simAws, distributionId, "/missing");
+
+    // Then the error page is served with the status the template asked for.
+    assertResponseStatus(missing, 404, await describeResponse(missing));
+    assertIdentical(await missing.text(), "<h1>Not found</h1>");
+  });
+
+  it("fails the stack for an unusable default root object", async () => {
+    // Given a template whose default root object begins with a forward slash.
+    const simAws = new SimAws();
+
+    // When the template is deployed.
+    const error = await assertThrowsErrorAsync(async () => {
+      const stack = await simAws.cloudFormation().deployTemplate({
+        stackName: "bad-root-object-stack",
+        template: {
+          Resources: {
+            SiteBucket: {
+              Type: "AWS::S3::Bucket",
+              Properties: { BucketName: "bad-root-object-bucket" },
+            },
+            SiteDistribution: {
+              Type: "AWS::CloudFront::Distribution",
+              DependsOn: "SiteBucket",
+              Properties: {
+                DistributionConfig: {
+                  DefaultRootObject: "/index.html",
+                  Origins: [
+                    {
+                      Id: "SiteOrigin",
+                      DomainName: "bad-root-object-bucket.s3.amazonaws.com",
+                      S3OriginConfig: {},
+                    },
+                  ],
+                  DefaultCacheBehavior: {
+                    TargetOriginId: "SiteOrigin",
+                    ViewerProtocolPolicy: "redirect-to-https",
+                  },
+                },
+              },
+            },
+          },
+        },
+      });
+      await stack.waitForDeployComplete();
+    });
+
+    // Then the stack fails rather than deploying a Distribution that would
+    // answer its own root with a 403, naming the resource and the value.
+    assertStringIncludes(error.message, "SiteDistribution");
+    assertStringIncludes(error.message, "/index.html");
+  });
+});

--- a/src/service/cloudfront/command/create-distribution/create-distribution.command.ts
+++ b/src/service/cloudfront/command/create-distribution/create-distribution.command.ts
@@ -41,6 +41,13 @@ export interface SimCloudFrontDistributionConfig {
   readonly CallerReference?: string | undefined;
   readonly Comment?: string | undefined;
   readonly Enabled?: boolean | undefined;
+  readonly DefaultRootObject?: string | undefined;
+  readonly CustomErrorResponses?:
+    | undefined
+    | {
+        readonly Items?:
+          readonly SimCloudFrontCustomErrorResponseConfig[] | undefined;
+      };
   readonly Aliases?:
     | undefined
     | {
@@ -60,6 +67,19 @@ export interface SimCloudFrontDistributionConfig {
           readonly SimCloudFrontCacheBehaviorConfig[] | undefined;
       };
   readonly ViewerCertificate?: SimCloudFrontViewerCertificate | undefined;
+}
+
+/**
+ * Minimal structural sim CloudFront CustomErrorResponse.
+ *
+ * The CloudFront API types `ResponseCode` as a string, while
+ * `AWS::CloudFront::Distribution` types it as an integer, so both arrive here.
+ */
+export interface SimCloudFrontCustomErrorResponseConfig {
+  readonly ErrorCode?: number | undefined;
+  readonly ResponsePagePath?: string | undefined;
+  readonly ResponseCode?: string | number | undefined;
+  readonly ErrorCachingMinTTL?: number | undefined;
 }
 
 /**

--- a/src/service/cloudfront/command/create-distribution/sim-cf-distro-config-normalizer.ts
+++ b/src/service/cloudfront/command/create-distribution/sim-cf-distro-config-normalizer.ts
@@ -1,5 +1,6 @@
 import type {
   SimCloudFrontCacheBehaviorConfig,
+  SimCloudFrontCustomErrorResponseConfig,
   SimCloudFrontDefaultCacheBehaviorConfig,
   SimCloudFrontDistributionConfig,
   SimCloudFrontFunctionAssociation,
@@ -45,6 +46,10 @@ export class SimCloudFrontDistributionConfigNormalizer {
       Origins: this.normalizeList<SimCloudFrontOriginConfig>(
         distributionConfig["Origins"],
       ),
+      CustomErrorResponses:
+        this.normalizeList<SimCloudFrontCustomErrorResponseConfig>(
+          distributionConfig["CustomErrorResponses"],
+        ),
       DefaultCacheBehavior:
         this.distributionConfig.DefaultCacheBehavior === undefined
           ? undefined

--- a/src/service/cloudfront/controller/dependency/sim-cf-controller-dependency.ts
+++ b/src/service/cloudfront/controller/dependency/sim-cf-controller-dependency.ts
@@ -6,6 +6,7 @@ import type { SimCloudFrontBehaviorResolver } from "../../resolver/sim-cloud-fro
 import { SimCloudFrontBehaviorResolver as DefaultSimCloudFrontBehaviorResolver } from "../../resolver/sim-cloud-front-behavior-resolver.js";
 import { SimCffApplicator } from "../cff/sim-cff-applicator.js";
 import { SimCloudFrontOriginFetcher } from "../origin/sim-cloudfront-origin-fetcher.js";
+import { SimCfCustomErrorResponder } from "../error/sim-cf-custom-error-responder.js";
 
 export interface SimCloudFrontServiceControllerProperties {
   readonly simAws?: SimAws;
@@ -14,6 +15,7 @@ export interface SimCloudFrontServiceControllerProperties {
   readonly behaviourResolver?: SimCloudFrontBehaviorResolver;
   readonly cffApplicator?: SimCffApplicator;
   readonly originFetcher?: SimCloudFrontOriginFetcher;
+  readonly customErrorResponder?: SimCfCustomErrorResponder;
 }
 
 export interface SimCloudFrontControllerDependencies {
@@ -21,6 +23,7 @@ export interface SimCloudFrontControllerDependencies {
   readonly behaviourResolver: SimCloudFrontBehaviorResolver;
   readonly cffApplicator: SimCffApplicator;
   readonly originFetcher: SimCloudFrontOriginFetcher;
+  readonly customErrorResponder: SimCfCustomErrorResponder;
 }
 
 /**
@@ -37,6 +40,15 @@ export class SimCloudFrontControllerDependenciesFactory {
     const cloudFrontRegistry =
       properties.cloudFrontRegistry ?? simAws.serviceFactory.cloudFrontRegistry;
 
+    // The custom error responder fetches its response page through the same
+    // Behavior resolution and Origin fetching as any other request, so it is
+    // built from whichever of those the caller supplied.
+    const behaviourResolver =
+      properties.behaviourResolver ??
+      new DefaultSimCloudFrontBehaviorResolver();
+    const originFetcher =
+      properties.originFetcher ?? new SimCloudFrontOriginFetcher();
+
     return {
       distroRouter:
         properties.distroRouter ??
@@ -44,12 +56,12 @@ export class SimCloudFrontControllerDependenciesFactory {
           simAws,
           cloudFrontRegistry,
         }),
-      behaviourResolver:
-        properties.behaviourResolver ??
-        new DefaultSimCloudFrontBehaviorResolver(),
+      behaviourResolver,
       cffApplicator: properties.cffApplicator ?? new SimCffApplicator(),
-      originFetcher:
-        properties.originFetcher ?? new SimCloudFrontOriginFetcher(),
+      originFetcher,
+      customErrorResponder:
+        properties.customErrorResponder ??
+        new SimCfCustomErrorResponder({ behaviourResolver, originFetcher }),
     };
   }
 }

--- a/src/service/cloudfront/controller/error/sim-cf-custom-error-responder.ts
+++ b/src/service/cloudfront/controller/error/sim-cf-custom-error-responder.ts
@@ -78,9 +78,15 @@ export class SimCfCustomErrorResponder {
     url.pathname = customErrorResponse.responsePagePath;
     url.search = "";
 
+    // The response page is fetched without a body, whatever the viewer sent,
+    // so headers describing the viewer's body would describe nothing.
+    const headers = new Headers(request.headers);
+    headers.delete("content-type");
+    headers.delete("content-length");
+
     return new Request(url, {
       method: request.method === "HEAD" ? "HEAD" : "GET",
-      headers: request.headers,
+      headers,
       redirect: request.redirect,
       signal: request.signal,
     });

--- a/src/service/cloudfront/controller/error/sim-cf-custom-error-responder.ts
+++ b/src/service/cloudfront/controller/error/sim-cf-custom-error-responder.ts
@@ -1,0 +1,88 @@
+import type { SimCloudFrontBehaviorResolver } from "../../resolver/sim-cloud-front-behavior-resolver.js";
+import type { SimCloudFrontOriginFetcher } from "../origin/sim-cloudfront-origin-fetcher.js";
+import type { SimCloudFrontDistribution } from "../../distribution/sim-cloudfront-distribution.js";
+import type { SimCloudFrontCustomErrorResponse } from "../../custom-error/sim-cloudfront-custom-error-response.js";
+
+interface SimCfCustomErrorResponderProperties {
+  readonly behaviourResolver: SimCloudFrontBehaviorResolver;
+  readonly originFetcher: SimCloudFrontOriginFetcher;
+}
+
+/**
+ * Replaces an Origin error response with a Distribution's custom error page.
+ *
+ * The response page is fetched as a request of its own, so the Cache Behavior
+ * matching the response page path decides which Origin it comes from. That is
+ * what lets a Distribution keep its error pages somewhere other than the
+ * content that failed, as CloudFront does.
+ */
+export class SimCfCustomErrorResponder {
+  private readonly behaviourResolver: SimCloudFrontBehaviorResolver;
+  private readonly originFetcher: SimCloudFrontOriginFetcher;
+
+  constructor(properties: SimCfCustomErrorResponderProperties) {
+    this.behaviourResolver = properties.behaviourResolver;
+    this.originFetcher = properties.originFetcher;
+  }
+
+  /**
+   * Return the custom error response for an Origin response, where the
+   * Distribution configures one for its status.
+   */
+  async apply(
+    request: Request,
+    distribution: SimCloudFrontDistribution,
+    response: Response,
+  ): Promise<Response> {
+    const customErrorResponse = distribution.customErrorResponses.find(
+      (candidate) => candidate.errorCode === response.status,
+    );
+
+    if (customErrorResponse === undefined) {
+      return response;
+    }
+
+    return await this.responsePage(request, distribution, customErrorResponse);
+  }
+
+  private async responsePage(
+    request: Request,
+    distribution: SimCloudFrontDistribution,
+    customErrorResponse: SimCloudFrontCustomErrorResponse,
+  ): Promise<Response> {
+    const pageRequest = this.pageRequest(request, customErrorResponse);
+    const behaviour = this.behaviourResolver.resolve(pageRequest, distribution);
+    const pageResponse = await this.originFetcher.fetch(
+      pageRequest,
+      distribution,
+      behaviour,
+    );
+
+    // A response page that is itself unavailable leaves the viewer with the
+    // status from fetching it, as it does in CloudFront.
+    if (!pageResponse.ok) {
+      return pageResponse;
+    }
+
+    return new Response(pageResponse.body, {
+      status: customErrorResponse.responseCode,
+      headers: pageResponse.headers,
+    });
+  }
+
+  private pageRequest(
+    request: Request,
+    customErrorResponse: SimCloudFrontCustomErrorResponse,
+  ): Request {
+    const url = new URL(request.url);
+    url.pathname = customErrorResponse.responsePagePath;
+    url.search = "";
+
+    return new Request(url, {
+      method: request.method === "HEAD" ? "HEAD" : "GET",
+      headers: request.headers,
+      redirect: request.redirect,
+      signal: request.signal,
+    });
+  }
+}

--- a/src/service/cloudfront/controller/error/sim-cf-custom-error-response.iso.test.ts
+++ b/src/service/cloudfront/controller/error/sim-cf-custom-error-response.iso.test.ts
@@ -1,0 +1,298 @@
+import { describe, it } from "vitest";
+import {
+  assertIdentical,
+  assertResponseStatus,
+  assertStringIncludes,
+  describeResponse,
+} from "@kensio/smartass";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import {
+  simCfSiteBucket,
+  simCfSiteDistributionConfig,
+  simCfSiteDistributionId,
+  simCfSiteRequest,
+} from "../../../../../test/cloudfront/site-fixture.js";
+
+describe("Sim CloudFront custom error responses", () => {
+  it("serves the response page when the Origin has no such object", async () => {
+    // Given a site mapping 403 and 404 to one error page, as a static site
+    // behind CloudFront usually does.
+    const simAws = new SimAws();
+    await simCfSiteBucket(simAws, "error-page-site", {
+      "404.html": "<h1>Not found here</h1>",
+    });
+    const distributionId = await simCfSiteDistributionId(
+      simAws,
+      simCfSiteDistributionConfig("error-page-site", {
+        CustomErrorResponses: {
+          Quantity: 2,
+          Items: [
+            {
+              ErrorCode: 404,
+              ResponsePagePath: "/404.html",
+              ResponseCode: "404",
+            },
+            {
+              ErrorCode: 403,
+              ResponsePagePath: "/404.html",
+              ResponseCode: "404",
+            },
+          ],
+        },
+      }),
+    );
+
+    // When a page that does not exist is requested.
+    const response = await simCfSiteRequest(simAws, distributionId, "/missing");
+
+    // Then the error page is served in place of the Origin's own 404.
+    assertResponseStatus(response, 404, await describeResponse(response));
+    assertIdentical(await response.text(), "<h1>Not found here</h1>");
+  });
+
+  it("returns the ResponseCode rather than the Origin's status", async () => {
+    // Given a site answering a missing page with 200, as a single page app
+    // handing routing to the browser does.
+    const simAws = new SimAws();
+    await simCfSiteBucket(simAws, "spa-site", {
+      "index.html": "<div id=app></div>",
+    });
+    const distributionId = await simCfSiteDistributionId(
+      simAws,
+      simCfSiteDistributionConfig("spa-site", {
+        CustomErrorResponses: {
+          Quantity: 1,
+          Items: [
+            {
+              ErrorCode: 404,
+              ResponsePagePath: "/index.html",
+              ResponseCode: "200",
+            },
+          ],
+        },
+      }),
+    );
+
+    // When a client-side route is requested.
+    const response = await simCfSiteRequest(
+      simAws,
+      distributionId,
+      "/orders/17",
+    );
+
+    // Then the app is served as a success.
+    assertResponseStatus(response, 200, await describeResponse(response));
+    assertIdentical(await response.text(), "<div id=app></div>");
+  });
+
+  it("leaves a status with no matching rule alone", async () => {
+    // Given a rule for 403 only.
+    const simAws = new SimAws();
+    await simCfSiteBucket(simAws, "unmatched-status-site", {
+      "403.html": "<h1>Forbidden</h1>",
+    });
+    const distributionId = await simCfSiteDistributionId(
+      simAws,
+      simCfSiteDistributionConfig("unmatched-status-site", {
+        CustomErrorResponses: {
+          Quantity: 1,
+          Items: [
+            {
+              ErrorCode: 403,
+              ResponsePagePath: "/403.html",
+              ResponseCode: "403",
+            },
+          ],
+        },
+      }),
+    );
+
+    // When a request produces a 404 instead.
+    const response = await simCfSiteRequest(simAws, distributionId, "/missing");
+
+    // Then the Origin's own response reaches the viewer untouched.
+    assertResponseStatus(response, 404, await describeResponse(response));
+    assertStringIncludes(await response.text(), "not found in sim S3 Bucket");
+  });
+
+  it("leaves a successful response alone", async () => {
+    // Given a site with a custom error response configured.
+    const simAws = new SimAws();
+    await simCfSiteBucket(simAws, "success-site", {
+      "index.html": "<h1>Home</h1>",
+      "404.html": "<h1>Not found</h1>",
+    });
+    const distributionId = await simCfSiteDistributionId(
+      simAws,
+      simCfSiteDistributionConfig("success-site", {
+        CustomErrorResponses: {
+          Quantity: 1,
+          Items: [
+            {
+              ErrorCode: 404,
+              ResponsePagePath: "/404.html",
+              ResponseCode: "404",
+            },
+          ],
+        },
+      }),
+    );
+
+    // When an object that exists is requested.
+    const response = await simCfSiteRequest(
+      simAws,
+      distributionId,
+      "/index.html",
+    );
+
+    // Then it is served as it is.
+    assertResponseStatus(response, 200, await describeResponse(response));
+    assertIdentical(await response.text(), "<h1>Home</h1>");
+  });
+
+  it("falls back to the response page's own status when it is missing", async () => {
+    // Given a rule naming an error page that was never uploaded.
+    const simAws = new SimAws();
+    await simCfSiteBucket(simAws, "missing-error-page-site", {});
+    const distributionId = await simCfSiteDistributionId(
+      simAws,
+      simCfSiteDistributionConfig("missing-error-page-site", {
+        CustomErrorResponses: {
+          Quantity: 1,
+          Items: [
+            {
+              ErrorCode: 404,
+              ResponsePagePath: "/404.html",
+              ResponseCode: "200",
+            },
+          ],
+        },
+      }),
+    );
+
+    // When a page that does not exist is requested.
+    const response = await simCfSiteRequest(simAws, distributionId, "/missing");
+
+    // Then the viewer gets the status from fetching the error page, not the
+    // 200 the rule asks for, as in CloudFront.
+    assertResponseStatus(response, 404, await describeResponse(response));
+    assertStringIncludes(await response.text(), "404.html");
+  });
+
+  it("fetches the response page through the Behavior matching its path", async () => {
+    // Given error pages kept in a Bucket of their own, reached by a Cache
+    // Behavior for their path.
+    const simAws = new SimAws();
+    await simCfSiteBucket(simAws, "content-site", {});
+    await simCfSiteBucket(simAws, "error-pages", {
+      "errors/404.html": "<h1>From the error Bucket</h1>",
+    });
+    const distributionId = await simCfSiteDistributionId(
+      simAws,
+      simCfSiteDistributionConfig("content-site", {
+        Origins: {
+          Quantity: 2,
+          Items: [
+            {
+              Id: "site-origin",
+              DomainName: "content-site.s3.amazonaws.com",
+              S3OriginConfig: { OriginAccessIdentity: "" },
+            },
+            {
+              Id: "errors-origin",
+              DomainName: "error-pages.s3.amazonaws.com",
+              S3OriginConfig: { OriginAccessIdentity: "" },
+            },
+          ],
+        },
+        CacheBehaviors: {
+          Quantity: 1,
+          Items: [
+            {
+              PathPattern: "/errors/*",
+              TargetOriginId: "errors-origin",
+              ViewerProtocolPolicy: "allow-all",
+            },
+          ],
+        },
+        CustomErrorResponses: {
+          Quantity: 1,
+          Items: [
+            {
+              ErrorCode: 404,
+              ResponsePagePath: "/errors/404.html",
+              ResponseCode: "404",
+            },
+          ],
+        },
+      }),
+    );
+
+    // When a page that does not exist is requested.
+    const response = await simCfSiteRequest(simAws, distributionId, "/missing");
+
+    // Then the error page came from the Origin its own Behavior names, not
+    // from the Origin that failed.
+    assertResponseStatus(response, 404, await describeResponse(response));
+    assertIdentical(await response.text(), "<h1>From the error Bucket</h1>");
+  });
+
+  it("serves the response page for a HEAD request without a body", async () => {
+    // Given a site with an error page.
+    const simAws = new SimAws();
+    await simCfSiteBucket(simAws, "head-error-site", {
+      "404.html": "<h1>Not found</h1>",
+    });
+    const distributionId = await simCfSiteDistributionId(
+      simAws,
+      simCfSiteDistributionConfig("head-error-site", {
+        CustomErrorResponses: {
+          Quantity: 1,
+          Items: [
+            {
+              ErrorCode: 404,
+              ResponsePagePath: "/404.html",
+              ResponseCode: "404",
+            },
+          ],
+        },
+      }),
+    );
+
+    // When a missing page is requested with HEAD.
+    const response = await simCfSiteRequest(
+      simAws,
+      distributionId,
+      "/missing",
+      { method: "HEAD" },
+    );
+
+    // Then the status is the custom one and no body comes with it.
+    assertResponseStatus(response, 404, await describeResponse(response));
+    assertIdentical(await response.text(), "");
+  });
+
+  it("accepts a rule that only configures error caching", async () => {
+    // Given a rule with no response page, which in CloudFront only sets how
+    // long the error is cached. There is no simulated cache to apply it to.
+    const simAws = new SimAws();
+    await simCfSiteBucket(simAws, "caching-only-site", {});
+    const distributionId = await simCfSiteDistributionId(
+      simAws,
+      simCfSiteDistributionConfig("caching-only-site", {
+        CustomErrorResponses: {
+          Quantity: 1,
+          Items: [{ ErrorCode: 404, ErrorCachingMinTTL: 30 }],
+        },
+      }),
+    );
+
+    // When a page that does not exist is requested.
+    const response = await simCfSiteRequest(simAws, distributionId, "/missing");
+
+    // Then the Origin's own response is what the viewer sees.
+    assertResponseStatus(response, 404, await describeResponse(response));
+    assertStringIncludes(await response.text(), "not found in sim S3 Bucket");
+  });
+});

--- a/src/service/cloudfront/controller/root-object/sim-cf-default-root-object-request.ts
+++ b/src/service/cloudfront/controller/root-object/sim-cf-default-root-object-request.ts
@@ -1,0 +1,43 @@
+import type { SimCloudFrontDistribution } from "../../distribution/sim-cloudfront-distribution.js";
+
+/**
+ * Apply a Distribution's default root object to a request for its root.
+ *
+ * CloudFront substitutes the default root object for a request to the root of
+ * the Distribution and nothing else: a request for a subdirectory such as
+ * `/install/` is passed to the Origin as it arrived, even where that directory
+ * holds a copy of the object. The substituted path is the one the rest of
+ * request handling sees, so a Cache Behavior pattern and a CloudFront Function
+ * both act on the object being served rather than on the root.
+ *
+ * The default root object applies to every method the Distribution allows, so
+ * the request is rebuilt around the new path rather than being narrowed to a
+ * GET.
+ */
+export function simCfDefaultRootObjectRequest(
+  request: Request,
+  distribution: SimCloudFrontDistribution,
+): Request {
+  const { defaultRootObject } = distribution;
+  if (defaultRootObject === undefined) {
+    return request;
+  }
+
+  const url = new URL(request.url);
+  if (url.pathname !== "/") {
+    return request;
+  }
+
+  url.pathname = `/${defaultRootObject}`;
+
+  const isBodyAllowed = !/^(?:get|head)$/iu.test(request.method);
+
+  return new Request(url, {
+    method: request.method,
+    headers: request.headers,
+    body: isBodyAllowed ? request.clone().body : null,
+    duplex: "half",
+    redirect: request.redirect,
+    signal: request.signal,
+  });
+}

--- a/src/service/cloudfront/controller/root-object/sim-cf-default-root-object.iso.test.ts
+++ b/src/service/cloudfront/controller/root-object/sim-cf-default-root-object.iso.test.ts
@@ -1,0 +1,264 @@
+import { describe, it } from "vitest";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertResponseStatus,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  describeResponse,
+} from "@kensio/smartass";
+import { CreateDistributionCommand } from "@aws-sdk/client-cloudfront";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import type { SimPayload2Event } from "../../../../serve/payload-2/sim-payload-2-event.type.js";
+import { simHttpApiLambdaProxyFactory } from "../../../apigatewayv2/api/sim-http-api-lambda-proxy.factory.js";
+import { SimCloudFrontInvalidDefaultRootObject } from "../../error/sim-cloudfront.error.js";
+import {
+  simCfSiteBucket,
+  simCfSiteDistributionConfig,
+  simCfSiteDistributionId,
+  simCfSiteRequest,
+} from "../../../../../test/cloudfront/site-fixture.js";
+
+describe("Sim CloudFront default root object", () => {
+  it("serves the default root object for a request to the Distribution root", async () => {
+    // Given a site with a home page and a Distribution naming it as the
+    // default root object.
+    const simAws = new SimAws();
+    await simCfSiteBucket(simAws, "root-object-site", {
+      "index.html": "<h1>Home</h1>",
+    });
+    const distributionId = await simCfSiteDistributionId(
+      simAws,
+      simCfSiteDistributionConfig("root-object-site", {
+        DefaultRootObject: "index.html",
+      }),
+    );
+
+    // When the root of the Distribution is requested.
+    const response = await simCfSiteRequest(simAws, distributionId, "/");
+
+    // Then the home page is served.
+    assertResponseStatus(response, 200, await describeResponse(response));
+    assertIdentical(await response.text(), "<h1>Home</h1>");
+  });
+
+  it("serves an object in a folder as the default root object", async () => {
+    // Given a default root object naming a path rather than a bare object,
+    // which CloudFront also allows.
+    const simAws = new SimAws();
+    await simCfSiteBucket(simAws, "folder-root-object-site", {
+      "public/index.html": "<h1>Public home</h1>",
+    });
+    const distributionId = await simCfSiteDistributionId(
+      simAws,
+      simCfSiteDistributionConfig("folder-root-object-site", {
+        DefaultRootObject: "public/index.html",
+      }),
+    );
+
+    // When the root of the Distribution is requested.
+    const response = await simCfSiteRequest(simAws, distributionId, "/");
+
+    // Then the object at that path is served.
+    assertResponseStatus(response, 200, await describeResponse(response));
+    assertIdentical(await response.text(), "<h1>Public home</h1>");
+  });
+
+  it("does not apply the default root object to a subdirectory", async () => {
+    // Given a subdirectory holding its own copy of the default root object,
+    // which CloudFront does not substitute, unlike an S3 website index
+    // document.
+    const simAws = new SimAws();
+    await simCfSiteBucket(simAws, "subdirectory-site", {
+      "index.html": "<h1>Home</h1>",
+      "blog/index.html": "<h1>Blog</h1>",
+    });
+    const distributionId = await simCfSiteDistributionId(
+      simAws,
+      simCfSiteDistributionConfig("subdirectory-site", {
+        DefaultRootObject: "index.html",
+      }),
+    );
+
+    // When the subdirectory is requested.
+    const response = await simCfSiteRequest(simAws, distributionId, "/blog/");
+
+    // Then the request reaches the Origin as it arrived and finds nothing.
+    assertResponseStatus(response, 404, await describeResponse(response));
+  });
+
+  it("keeps the request path when no default root object is configured", async () => {
+    // Given a Distribution with no default root object.
+    const simAws = new SimAws();
+    await simCfSiteBucket(simAws, "no-root-object-site", {
+      "index.html": "<h1>Home</h1>",
+    });
+    const distributionId = await simCfSiteDistributionId(
+      simAws,
+      simCfSiteDistributionConfig("no-root-object-site"),
+    );
+
+    // When the root of the Distribution is requested.
+    const response = await simCfSiteRequest(simAws, distributionId, "/");
+
+    // Then the Origin is asked for the root itself, which holds no object.
+    assertResponseStatus(response, 404, await describeResponse(response));
+  });
+
+  it("serves the default root object over a custom Origin", async () => {
+    // Given an HTTP API serving the path the default root object names.
+    const simAws = new SimAws();
+    const api = await simHttpApiLambdaProxyFactory.make(
+      {
+        handler: (event: SimPayload2Event): unknown => ({
+          rawPath: event.rawPath,
+        }),
+        routeKeys: ["GET /index.html"],
+      },
+      simAws,
+    );
+
+    // And a Distribution with that API as a custom Origin.
+    const distributionId = await simCfSiteDistributionId(simAws, {
+      CallerReference: "custom-origin-root-object",
+      Comment: "Custom Origin root object",
+      Enabled: true,
+      DefaultRootObject: "index.html",
+      Origins: {
+        Quantity: 1,
+        Items: [
+          {
+            Id: "api-origin",
+            DomainName: new URL(api.apiEndpoint).hostname,
+            CustomOriginConfig: {
+              HTTPPort: 80,
+              HTTPSPort: 443,
+              OriginProtocolPolicy: "https-only",
+            },
+          },
+        ],
+      },
+      DefaultCacheBehavior: {
+        TargetOriginId: "api-origin",
+        ViewerProtocolPolicy: "allow-all",
+      },
+    });
+
+    // When the root of the Distribution is requested.
+    const response = await simCfSiteRequest(simAws, distributionId, "/");
+
+    // Then the Origin saw the default root object rather than the root, so
+    // the substitution is not specific to an S3 Origin.
+    assertResponseStatus(response, 200, await describeResponse(response));
+    assertIdentical(await response.text(), '{"rawPath":"/index.html"}');
+  });
+
+  it("applies the default root object to a POST to the root", async () => {
+    // Given an API taking a POST at the path the default root object names.
+    // CloudFront substitutes the default root object for every method the
+    // Distribution allows, not only for a GET.
+    const simAws = new SimAws();
+    const api = await simHttpApiLambdaProxyFactory.make(
+      {
+        handler: (event: SimPayload2Event): unknown => ({
+          rawPath: event.rawPath,
+          body: event.body,
+        }),
+        routeKeys: ["POST /index.html"],
+      },
+      simAws,
+    );
+
+    const distributionId = await simCfSiteDistributionId(simAws, {
+      CallerReference: "post-root-object",
+      Comment: "POST root object",
+      Enabled: true,
+      DefaultRootObject: "index.html",
+      Origins: {
+        Quantity: 1,
+        Items: [
+          {
+            Id: "api-origin",
+            DomainName: new URL(api.apiEndpoint).hostname,
+            CustomOriginConfig: {
+              HTTPPort: 80,
+              HTTPSPort: 443,
+              OriginProtocolPolicy: "https-only",
+            },
+          },
+        ],
+      },
+      DefaultCacheBehavior: {
+        TargetOriginId: "api-origin",
+        ViewerProtocolPolicy: "allow-all",
+        AllowedMethods: {
+          Quantity: 3,
+          Items: ["GET", "HEAD", "POST"],
+          CachedMethods: { Quantity: 2, Items: ["GET", "HEAD"] },
+        },
+      },
+    });
+
+    // When the root of the Distribution is posted to.
+    const response = await simCfSiteRequest(simAws, distributionId, "/", {
+      method: "POST",
+      body: "order=17",
+    });
+
+    // Then the Origin saw the substituted path, with the body still on it.
+    assertResponseStatus(response, 200, await describeResponse(response));
+    assertIdentical(
+      await response.text(),
+      '{"rawPath":"/index.html","body":"order=17"}',
+    );
+  });
+
+  it("refuses a default root object beginning with a forward slash", async () => {
+    // Given a default root object written as a path from the root, which real
+    // CloudFront answers with a 403 on every request to the Distribution root.
+    const simAws = new SimAws();
+    await simCfSiteBucket(simAws, "slash-root-object-site", {
+      "index.html": "<h1>Home</h1>",
+    });
+
+    // When the Distribution is created.
+    const creation = assertThrowsErrorAsync(
+      async () =>
+        await simAws.cloudFront().createDistribution(
+          new CreateDistributionCommand({
+            DistributionConfig: simCfSiteDistributionConfig(
+              "slash-root-object-site",
+              { DefaultRootObject: "/index.html" },
+            ),
+          }),
+        ),
+    );
+
+    // Then it is refused as InvalidDefaultRootObject, as an unusable value.
+    const error = await creation;
+    assertInstanceOf(error, SimCloudFrontInvalidDefaultRootObject);
+    assertStringIncludes(error.message, "/index.html");
+  });
+
+  it("treats an empty default root object as none", async () => {
+    // Given an empty DefaultRootObject, which is how CloudFront expresses
+    // having none.
+    const simAws = new SimAws();
+    await simCfSiteBucket(simAws, "empty-root-object-site", {
+      "index.html": "<h1>Home</h1>",
+    });
+    const distributionId = await simCfSiteDistributionId(
+      simAws,
+      simCfSiteDistributionConfig("empty-root-object-site", {
+        DefaultRootObject: "",
+      }),
+    );
+
+    // When the root of the Distribution is requested.
+    const response = await simCfSiteRequest(simAws, distributionId, "/");
+
+    // Then nothing is substituted.
+    assertResponseStatus(response, 404, await describeResponse(response));
+  });
+});

--- a/src/service/cloudfront/controller/sim-cf-controller-viewer-response-cff.iso.test.ts
+++ b/src/service/cloudfront/controller/sim-cf-controller-viewer-response-cff.iso.test.ts
@@ -15,6 +15,12 @@ import { SimAwsServiceRequest } from "../../../serve/controller/sim-service-cont
 import { makeCffFunctionCodeInput } from "../cff/function-code-input/cff-function-code-input.js";
 import type { CloudFrontFunction } from "../typings/cloudfront-functions.namespace.js";
 import { CreateBucketCommand, PutObjectCommand } from "@aws-sdk/client-s3";
+import {
+  simCfSiteBucket,
+  simCfSiteDistributionConfig,
+  simCfSiteDistributionId,
+  simCfSiteRequest,
+} from "../../../../test/cloudfront/site-fixture.js";
 
 describe("Simulated CloudFront local HTTP controller CFF", () => {
   it("preserves the Origin response body when a viewer-response CFF only changes headers", async () => {
@@ -119,5 +125,70 @@ describe("Simulated CloudFront local HTTP controller CFF", () => {
       String(Buffer.byteLength(body)),
     );
     assertFalse(response.headers.has("transfer-encoding"));
+  });
+
+  it("runs the viewer-response CFF on a custom error response", async () => {
+    // Given a site whose 404s are answered with its own error page.
+    const simAws = new SimAws();
+    await simCfSiteBucket(simAws, "cff-error-page-site", {
+      "404.html": "<h1>Not found</h1>",
+    });
+
+    // And a viewer-response CFF marking whatever the viewer is about to get.
+    const cffOutput = await simAws.cloudFront().createFunction(
+      new CreateFunctionCommand({
+        Name: "error-page-marker-cff",
+        FunctionConfig: {
+          Comment: "Error page marker CFF",
+          Runtime: "cloudfront-js-2.0",
+        },
+        FunctionCode: makeCffFunctionCodeInput(
+          (event: CloudFrontFunction.ViewerResponseEvent) => {
+            event.response.headers["x-served-status"] = {
+              value: String(event.response.statusCode),
+            };
+            return event.response;
+          },
+        ),
+      }),
+    );
+
+    const distributionId = await simCfSiteDistributionId(
+      simAws,
+      simCfSiteDistributionConfig("cff-error-page-site", {
+        DefaultCacheBehavior: {
+          TargetOriginId: "site-origin",
+          ViewerProtocolPolicy: "allow-all",
+          FunctionAssociations: {
+            Quantity: 1,
+            Items: [
+              {
+                EventType: "viewer-response",
+                FunctionARN: cffOutput.FunctionMetadata.FunctionARN,
+              },
+            ],
+          },
+        },
+        CustomErrorResponses: {
+          Quantity: 1,
+          Items: [
+            {
+              ErrorCode: 404,
+              ResponsePagePath: "/404.html",
+              ResponseCode: "404",
+            },
+          ],
+        },
+      }),
+    );
+
+    // When a page that does not exist is requested.
+    const response = await simCfSiteRequest(simAws, distributionId, "/missing");
+
+    // Then the function saw the custom error response rather than the Origin's
+    // own, so the error page is what the CFF gets to act on.
+    assertResponseStatus(response, 404);
+    assertIdentical(await response.text(), "<h1>Not found</h1>");
+    assertIdentical(response.headers.get("x-served-status"), "404");
   });
 });

--- a/src/service/cloudfront/controller/sim-cloudfront-controller.loc.test.ts
+++ b/src/service/cloudfront/controller/sim-cloudfront-controller.loc.test.ts
@@ -117,6 +117,88 @@ describe("sim CloudFront local server", () => {
     assertIdentical(missingResponse.status, 404);
   });
 
+  it("serves a static site with a root object and an error page", async () => {
+    // Given a site with a home page and an error page in a Bucket.
+    const simS3 = simAws.s3();
+    await simS3.createBucket(
+      new CreateBucketCommand({ Bucket: "site-bucket" }),
+    );
+    await simS3.putObject(
+      new PutObjectCommand({
+        Bucket: "site-bucket",
+        Key: "index.html",
+        ContentType: "text/html",
+        Body: "<h1>Home</h1>",
+      }),
+    );
+    await simS3.putObject(
+      new PutObjectCommand({
+        Bucket: "site-bucket",
+        Key: "404.html",
+        ContentType: "text/html",
+        Body: "<h1>Not found</h1>",
+      }),
+    );
+
+    // And a Distribution serving it the way a static site is usually set up.
+    const distributionCreation = await simAws.cloudFront().createDistribution(
+      new CreateDistributionCommand({
+        DistributionConfig: {
+          CallerReference: "static-site",
+          Comment: "Static site CDN",
+          Enabled: true,
+          DefaultRootObject: "index.html",
+          CustomErrorResponses: {
+            Quantity: 2,
+            Items: [
+              {
+                ErrorCode: 404,
+                ResponsePagePath: "/404.html",
+                ResponseCode: "404",
+              },
+              {
+                ErrorCode: 403,
+                ResponsePagePath: "/404.html",
+                ResponseCode: "404",
+              },
+            ],
+          },
+          Origins: {
+            Quantity: 1,
+            Items: [
+              {
+                Id: "site-origin",
+                DomainName: "site-bucket.s3.amazonaws.com",
+                S3OriginConfig: { OriginAccessIdentity: "" },
+              },
+            ],
+          },
+          DefaultCacheBehavior: {
+            TargetOriginId: "site-origin",
+            ViewerProtocolPolicy: "allow-all",
+          },
+        },
+      }),
+    );
+    const distroId = distributionCreation.Distribution?.Id;
+    assertNonNullable(distroId);
+    const siteUrl = `http://${distroId.toLowerCase()}.cloudfront.net.sim-aws.localhost:${srv.port}`;
+
+    // When the site root is requested over localhost.
+    const homeResponse = await fetch(`${siteUrl}/`);
+
+    // Then the home page is served.
+    assertIdentical(homeResponse.status, 200);
+    assertIdentical(await homeResponse.text(), "<h1>Home</h1>");
+
+    // And when a page that does not exist is requested.
+    const missingResponse = await fetch(`${siteUrl}/nowhere`);
+
+    // Then the site's own error page is served, not the simulator's.
+    assertIdentical(missingResponse.status, 404);
+    assertIdentical(await missingResponse.text(), "<h1>Not found</h1>");
+  });
+
   it("can use S3 Origin in any Region", async () => {
     const regionA = makeAwsRegionName();
     const regionB = makeAwsRegionName();

--- a/src/service/cloudfront/controller/sim-cloudfront-request-pipeline.ts
+++ b/src/service/cloudfront/controller/sim-cloudfront-request-pipeline.ts
@@ -3,11 +3,15 @@ import type { SimCloudFrontBehaviorResolver } from "../resolver/sim-cloud-front-
 import type { SimCffApplicator } from "./cff/sim-cff-applicator.js";
 import type { SimCloudFrontOriginFetcher } from "./origin/sim-cloudfront-origin-fetcher.js";
 import type { SimCloudFrontControllerDependencies } from "./dependency/sim-cf-controller-dependency.js";
+import type { SimCfCustomErrorResponder } from "./error/sim-cf-custom-error-responder.js";
+import { simCfDefaultRootObjectRequest } from "./root-object/sim-cf-default-root-object-request.js";
 
 /**
  * Runs a single simulated CloudFront request through its lifecycle:
- * route to a Distribution, resolve the matching Behavior, run viewer-request
- * hooks, fetch from the Origin, then run viewer-response hooks.
+ * route to a Distribution, apply the default root object, resolve the matching
+ * Behavior, run viewer-request hooks, fetch from the Origin, replace an error
+ * response with the Distribution's custom error page, then run viewer-response
+ * hooks.
  *
  * This is the request-processing core, kept separate from the service
  * controller so the controller stays a thin adapter to the shared
@@ -19,12 +23,14 @@ export class SimCloudFrontRequestPipeline {
   private readonly behaviourResolver: SimCloudFrontBehaviorResolver;
   private readonly cffApplicator: SimCffApplicator;
   private readonly originFetcher: SimCloudFrontOriginFetcher;
+  private readonly customErrorResponder: SimCfCustomErrorResponder;
 
   constructor(dependencies: SimCloudFrontControllerDependencies) {
     this.distroRouter = dependencies.distroRouter;
     this.behaviourResolver = dependencies.behaviourResolver;
     this.cffApplicator = dependencies.cffApplicator;
     this.originFetcher = dependencies.originFetcher;
+    this.customErrorResponder = dependencies.customErrorResponder;
   }
 
   /**
@@ -43,6 +49,8 @@ export class SimCloudFrontRequestPipeline {
 
     const { cloudFront, distribution: distro } = route;
 
+    requestReference = simCfDefaultRootObjectRequest(requestReference, distro);
+
     const behaviour = this.behaviourResolver.resolve(requestReference, distro);
 
     // Handle viewer-request CFF, if any.
@@ -58,10 +66,19 @@ export class SimCloudFrontRequestPipeline {
     }
     requestReference = cffResult;
 
-    const response = await this.originFetcher.fetch(
+    const originResponse = await this.originFetcher.fetch(
       requestReference,
       distro,
       behaviour,
+    );
+
+    // Replace an Origin error with the Distribution's custom error page, if it
+    // configures one for that status. This happens before the viewer-response
+    // CFF so that a function sees the response the viewer is about to get.
+    const response = await this.customErrorResponder.apply(
+      requestReference,
+      distro,
+      originResponse,
     );
 
     // Handle viewer-response CFF, if any.

--- a/src/service/cloudfront/custom-error/sim-cloudfront-custom-error-response.ts
+++ b/src/service/cloudfront/custom-error/sim-cloudfront-custom-error-response.ts
@@ -6,6 +6,15 @@ export const simCloudFrontCustomErrorCodes: ReadonlySet<number> = new Set([
 ]);
 
 /**
+ * The HTTP status codes CloudFront can return alongside a custom error page.
+ *
+ * These are the error codes plus 200, which is how a Distribution serves a
+ * page for an error without telling the viewer anything went wrong.
+ */
+export const simCloudFrontCustomErrorResponseCodes: ReadonlySet<number> =
+  new Set([200, ...simCloudFrontCustomErrorCodes]);
+
+/**
  * A custom error response of a sim CloudFront Distribution.
  *
  * Only a rule with a response page reaches this model. A rule carrying nothing

--- a/src/service/cloudfront/custom-error/sim-cloudfront-custom-error-response.ts
+++ b/src/service/cloudfront/custom-error/sim-cloudfront-custom-error-response.ts
@@ -1,0 +1,19 @@
+/**
+ * The HTTP status codes CloudFront can return a custom error page for.
+ */
+export const simCloudFrontCustomErrorCodes: ReadonlySet<number> = new Set([
+  400, 403, 404, 405, 414, 416, 500, 501, 502, 503, 504,
+]);
+
+/**
+ * A custom error response of a sim CloudFront Distribution.
+ *
+ * Only a rule with a response page reaches this model. A rule carrying nothing
+ * but `ErrorCode` and `ErrorCachingMinTTL` configures error caching, which the
+ * simulator has nothing to cache with.
+ */
+export interface SimCloudFrontCustomErrorResponse {
+  readonly errorCode: number;
+  readonly responsePagePath: string;
+  readonly responseCode: number;
+}

--- a/src/service/cloudfront/distribution/configurator/sim-cf-custom-error-config.iso.test.ts
+++ b/src/service/cloudfront/distribution/configurator/sim-cf-custom-error-config.iso.test.ts
@@ -111,4 +111,32 @@ describe("Sim CloudFront custom error response configuration", () => {
     assertInstanceOf(error, SimCloudFrontInvalidResponseCode);
     assertStringIncludes(error.message, "not-a-status");
   });
+
+  it("refuses a response code outside the set CloudFront returns", async () => {
+    // Given a status CloudFront does not return with a custom error page. It
+    // allows 200 and the error codes, and nothing else.
+    const error = await refusedCustomErrorResponse({
+      ErrorCode: 404,
+      ResponsePagePath: "/404.html",
+      ResponseCode: "201",
+    });
+
+    // Then it is refused as InvalidResponseCode.
+    assertInstanceOf(error, SimCloudFrontInvalidResponseCode);
+    assertStringIncludes(error.message, "201");
+  });
+
+  it("refuses a response code that cannot carry the response page", async () => {
+    // Given 204, which has no body to put the page in.
+    const error = await refusedCustomErrorResponse({
+      ErrorCode: 404,
+      ResponsePagePath: "/404.html",
+      ResponseCode: "204",
+    });
+
+    // Then it is refused when the Distribution is created, rather than
+    // failing on the request that would serve the page.
+    assertInstanceOf(error, SimCloudFrontInvalidResponseCode);
+    assertStringIncludes(error.message, "204");
+  });
 });

--- a/src/service/cloudfront/distribution/configurator/sim-cf-custom-error-config.iso.test.ts
+++ b/src/service/cloudfront/distribution/configurator/sim-cf-custom-error-config.iso.test.ts
@@ -1,0 +1,114 @@
+import { describe, it } from "vitest";
+import {
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import {
+  CreateDistributionCommand,
+  type CustomErrorResponse,
+} from "@aws-sdk/client-cloudfront";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import {
+  SimCloudFrontInvalidArgument,
+  SimCloudFrontInvalidErrorCode,
+  SimCloudFrontInvalidResponseCode,
+} from "../../error/sim-cloudfront.error.js";
+
+/**
+ * Create a Distribution carrying one custom error response, returning whatever
+ * error refuses it.
+ */
+async function refusedCustomErrorResponse(
+  customErrorResponse: CustomErrorResponse,
+): Promise<Error> {
+  return await assertThrowsErrorAsync(
+    async () =>
+      await new SimAws().cloudFront().createDistribution(
+        new CreateDistributionCommand({
+          DistributionConfig: {
+            CallerReference: "custom-error-config",
+            Comment: "Custom error response config",
+            Enabled: true,
+            Origins: { Quantity: 0, Items: [] },
+            DefaultCacheBehavior: {
+              TargetOriginId: "site-origin",
+              ViewerProtocolPolicy: "allow-all",
+            },
+            CustomErrorResponses: {
+              Quantity: 1,
+              Items: [customErrorResponse],
+            },
+          },
+        }),
+      ),
+  );
+}
+
+describe("Sim CloudFront custom error response configuration", () => {
+  it("refuses a status code CloudFront has no custom error page for", async () => {
+    // Given a rule for a status outside the set CloudFront supports.
+    const error = await refusedCustomErrorResponse({
+      ErrorCode: 418,
+      ResponsePagePath: "/418.html",
+      ResponseCode: "418",
+    });
+
+    // Then it is refused as InvalidErrorCode.
+    assertInstanceOf(error, SimCloudFrontInvalidErrorCode);
+    assertStringIncludes(error.message, "418");
+  });
+
+  it("refuses a response page with no response code", async () => {
+    // Given a rule naming a page but not the status to serve it with, which
+    // CloudFront requires together.
+    const error = await refusedCustomErrorResponse({
+      ErrorCode: 404,
+      ResponsePagePath: "/404.html",
+    });
+
+    // Then it is refused rather than half applied.
+    assertInstanceOf(error, SimCloudFrontInvalidArgument);
+    assertStringIncludes(error.message, "ResponseCode");
+  });
+
+  it("refuses a response code with no response page", async () => {
+    // Given a rule naming a status but no page to serve.
+    const error = await refusedCustomErrorResponse({
+      ErrorCode: 404,
+      ResponseCode: "200",
+    });
+
+    // Then it is refused, as the pairing goes both ways in CloudFront.
+    assertInstanceOf(error, SimCloudFrontInvalidArgument);
+    assertStringIncludes(error.message, "ResponsePagePath");
+  });
+
+  it("refuses a response page path that is not a path from the root", async () => {
+    // Given a response page written as an object key rather than a path, which
+    // CloudFront cannot resolve against the Distribution.
+    const error = await refusedCustomErrorResponse({
+      ErrorCode: 404,
+      ResponsePagePath: "404.html",
+      ResponseCode: "404",
+    });
+
+    // Then it is refused.
+    assertInstanceOf(error, SimCloudFrontInvalidArgument);
+    assertStringIncludes(error.message, "forward slash");
+  });
+
+  it("refuses a response code that is not an HTTP status code", async () => {
+    // Given a response code that is not a status.
+    const error = await refusedCustomErrorResponse({
+      ErrorCode: 404,
+      ResponsePagePath: "/404.html",
+      ResponseCode: "not-a-status",
+    });
+
+    // Then it is refused as InvalidResponseCode.
+    assertInstanceOf(error, SimCloudFrontInvalidResponseCode);
+    assertStringIncludes(error.message, "not-a-status");
+  });
+});

--- a/src/service/cloudfront/distribution/configurator/sim-cloud-front-custom-error-configurator.ts
+++ b/src/service/cloudfront/distribution/configurator/sim-cloud-front-custom-error-configurator.ts
@@ -1,0 +1,85 @@
+import type { SimCloudFrontCustomErrorResponseConfig } from "../../command/create-distribution/create-distribution.command.js";
+import type { SimCloudFrontDistribution } from "../sim-cloudfront-distribution.js";
+import { simCloudFrontCustomErrorCodes } from "../../custom-error/sim-cloudfront-custom-error-response.js";
+import {
+  SimCloudFrontInvalidArgument,
+  SimCloudFrontInvalidErrorCode,
+  SimCloudFrontInvalidResponseCode,
+} from "../../error/sim-cloudfront.error.js";
+
+/**
+ * Applies custom error response configuration to a sim CloudFront
+ * Distribution.
+ *
+ * CloudFront pairs `ResponsePagePath` and `ResponseCode`: a rule carrying one
+ * without the other is refused rather than half applied. A rule carrying
+ * neither only configures error caching, which this simulator does not model,
+ * so it is accepted and left out of the Distribution's request handling.
+ */
+export class SimCloudFrontCustomErrorConfigurator {
+  /**
+   * Configure one custom error response on a Distribution.
+   */
+  configure(
+    distribution: SimCloudFrontDistribution,
+    customErrorResponse: SimCloudFrontCustomErrorResponseConfig,
+  ): void {
+    const errorCode = customErrorResponse.ErrorCode;
+    if (
+      errorCode === undefined ||
+      !simCloudFrontCustomErrorCodes.has(errorCode)
+    ) {
+      throw new SimCloudFrontInvalidErrorCode(
+        `CloudFront CustomErrorResponse ErrorCode ${String(errorCode)} is not one of ${[...simCloudFrontCustomErrorCodes].join(", ")}`,
+      );
+    }
+
+    const responsePagePath = customErrorResponse.ResponsePagePath;
+    const responseCode = this.responseCode(customErrorResponse.ResponseCode);
+
+    if (responsePagePath === undefined || responsePagePath === "") {
+      if (responseCode !== undefined) {
+        throw new SimCloudFrontInvalidArgument(
+          `CloudFront CustomErrorResponse for ${String(errorCode)} has a ResponseCode without a ResponsePagePath`,
+        );
+      }
+
+      return;
+    }
+
+    if (responseCode === undefined) {
+      throw new SimCloudFrontInvalidArgument(
+        `CloudFront CustomErrorResponse for ${String(errorCode)} has a ResponsePagePath without a ResponseCode`,
+      );
+    }
+
+    if (!responsePagePath.startsWith("/")) {
+      throw new SimCloudFrontInvalidArgument(
+        `CloudFront CustomErrorResponse ResponsePagePath ${responsePagePath} must begin with a forward slash`,
+      );
+    }
+
+    distribution.addCustomErrorResponse({
+      errorCode,
+      responsePagePath,
+      responseCode,
+    });
+  }
+
+  private responseCode(
+    responseCode: string | number | undefined,
+  ): number | undefined {
+    if (responseCode === undefined || responseCode === "") {
+      return undefined;
+    }
+
+    const parsed = Number(responseCode);
+    if (!Number.isSafeInteger(parsed) || parsed < 100 || parsed > 599) {
+      throw new SimCloudFrontInvalidResponseCode(
+        `CloudFront CustomErrorResponse ResponseCode ${String(responseCode)} is not an HTTP status code`,
+      );
+    }
+
+    return parsed;
+  }
+}

--- a/src/service/cloudfront/distribution/configurator/sim-cloud-front-custom-error-configurator.ts
+++ b/src/service/cloudfront/distribution/configurator/sim-cloud-front-custom-error-configurator.ts
@@ -1,6 +1,9 @@
 import type { SimCloudFrontCustomErrorResponseConfig } from "../../command/create-distribution/create-distribution.command.js";
 import type { SimCloudFrontDistribution } from "../sim-cloudfront-distribution.js";
-import { simCloudFrontCustomErrorCodes } from "../../custom-error/sim-cloudfront-custom-error-response.js";
+import {
+  simCloudFrontCustomErrorCodes,
+  simCloudFrontCustomErrorResponseCodes,
+} from "../../custom-error/sim-cloudfront-custom-error-response.js";
 import {
   SimCloudFrontInvalidArgument,
   SimCloudFrontInvalidErrorCode,
@@ -74,9 +77,9 @@ export class SimCloudFrontCustomErrorConfigurator {
     }
 
     const parsed = Number(responseCode);
-    if (!Number.isSafeInteger(parsed) || parsed < 100 || parsed > 599) {
+    if (!simCloudFrontCustomErrorResponseCodes.has(parsed)) {
       throw new SimCloudFrontInvalidResponseCode(
-        `CloudFront CustomErrorResponse ResponseCode ${String(responseCode)} is not an HTTP status code`,
+        `CloudFront CustomErrorResponse ResponseCode ${String(responseCode)} is not one of ${[...simCloudFrontCustomErrorResponseCodes].join(", ")}`,
       );
     }
 

--- a/src/service/cloudfront/distribution/configurator/sim-cloud-front-distribution-configurator.ts
+++ b/src/service/cloudfront/distribution/configurator/sim-cloud-front-distribution-configurator.ts
@@ -2,19 +2,26 @@ import type { SimCloudFrontDistributionConfig } from "../../command/create-distr
 import type { SimCloudFrontDistribution } from "../sim-cloudfront-distribution.js";
 import type { SimCloudFrontOriginConfigurator } from "./sim-cloud-front-origin-configurator.js";
 import type { SimCloudFrontBehaviorConfigurator } from "./sim-cloud-front-behavior-configurator.js";
+import { SimCloudFrontCustomErrorConfigurator } from "./sim-cloud-front-custom-error-configurator.js";
+import { SimCloudFrontInvalidDefaultRootObject } from "../../error/sim-cloudfront.error.js";
 
 /**
  * Applies top-level Distribution configuration to a sim CloudFront Distribution.
  *
- * Orchestrates the three configuration steps in the order CloudFront requires:
+ * Orchestrates the configuration steps in the order CloudFront requires:
  * 1. Alternate domain names (Aliases)
  * 2. Origins
  * 3. Cache Behaviors (default first, then named patterns)
+ * 4. The default root object and custom error responses, which are request
+ *    handling rather than routing and so depend on nothing above them
  *
  * Named Cache Behaviors must be added after the default so that the default
  * always acts as the fallback when no path pattern matches.
  */
 export class SimCloudFrontDistributionConfigurator {
+  private readonly customErrorConfigurator =
+    new SimCloudFrontCustomErrorConfigurator();
+
   constructor(
     private readonly originConfigurator: SimCloudFrontOriginConfigurator,
     private readonly behaviorConfigurator: SimCloudFrontBehaviorConfigurator,
@@ -49,5 +56,37 @@ export class SimCloudFrontDistributionConfigurator {
         cacheBehavior,
       );
     }
+
+    distribution.defaultRootObject = this.defaultRootObject(
+      distributionConfig.DefaultRootObject,
+    );
+
+    const customErrorItems =
+      distributionConfig.CustomErrorResponses?.Items ?? [];
+    for (const customErrorResponse of customErrorItems) {
+      this.customErrorConfigurator.configure(distribution, customErrorResponse);
+    }
+  }
+
+  /**
+   * CloudFront takes the default root object as an Origin object name, so a
+   * leading forward slash is refused rather than quietly stripped: in real
+   * CloudFront it produces a 403 on every request to the Distribution root.
+   * An empty value means no default root object, as it does in AWS.
+   */
+  private defaultRootObject(
+    defaultRootObject: string | undefined,
+  ): string | undefined {
+    if (defaultRootObject === undefined || defaultRootObject === "") {
+      return undefined;
+    }
+
+    if (defaultRootObject.startsWith("/")) {
+      throw new SimCloudFrontInvalidDefaultRootObject(
+        `CloudFront DefaultRootObject ${defaultRootObject} must not begin with a forward slash`,
+      );
+    }
+
+    return defaultRootObject;
   }
 }

--- a/src/service/cloudfront/distribution/sim-cloudfront-distribution.ts
+++ b/src/service/cloudfront/distribution/sim-cloudfront-distribution.ts
@@ -1,6 +1,7 @@
 import type { Brand } from "../../../util/brand.type.js";
 import type { SimCloudFrontOrigin } from "../origin/sim-cloudfront-origin.js";
 import type { SimCloudFrontBehavior } from "../behaviour/sim-cloud-front-behavior.js";
+import type { SimCloudFrontCustomErrorResponse } from "../custom-error/sim-cloudfront-custom-error-response.js";
 import { faker } from "@faker-js/faker";
 import {
   makeSimAwsAccountId,
@@ -37,9 +38,11 @@ export class SimCloudFrontDistribution {
   public readonly distributionConfig:
     SimCloudFrontDistributionConfig | undefined;
   public readonly behaviors: SimCloudFrontBehavior[] = [];
+  public readonly customErrorResponses: SimCloudFrontCustomErrorResponse[] = [];
   public readonly lastModifiedTime: Date;
 
   #status: SimCloudFrontDistributionStatus;
+  #defaultRootObject: string | undefined;
   private readonly alternateDomainNames = new Set<string>();
 
   private readonly origins = new Map<string, SimCloudFrontOrigin>();
@@ -65,6 +68,20 @@ export class SimCloudFrontDistribution {
    */
   get status(): SimCloudFrontDistributionStatus {
     return this.#status;
+  }
+
+  /**
+   * Get the object this sim Distribution serves for a request to its root.
+   */
+  get defaultRootObject(): string | undefined {
+    return this.#defaultRootObject;
+  }
+
+  /**
+   * Set the object this sim Distribution serves for a request to its root.
+   */
+  set defaultRootObject(defaultRootObject: string | undefined) {
+    this.#defaultRootObject = defaultRootObject;
   }
 
   /**
@@ -101,6 +118,15 @@ export class SimCloudFrontDistribution {
    */
   addBehavior(behavior: SimCloudFrontBehavior): void {
     this.behaviors.push(behavior);
+  }
+
+  /**
+   * Add a custom error response to this sim Distribution.
+   */
+  addCustomErrorResponse(
+    customErrorResponse: SimCloudFrontCustomErrorResponse,
+  ): void {
+    this.customErrorResponses.push(customErrorResponse);
   }
 
   /**

--- a/src/service/cloudfront/error/sim-cloudfront.error.ts
+++ b/src/service/cloudfront/error/sim-cloudfront.error.ts
@@ -33,6 +33,53 @@ export class SimCloudFrontInvalidViewerCertificate extends SimCloudFrontError {
 }
 
 /**
+ * Simulated CloudFront InvalidDefaultRootObject error.
+ *
+ * CloudFront requires the default root object to name an object at the Origin,
+ * so a value starting with a forward slash is refused.
+ */
+export class SimCloudFrontInvalidDefaultRootObject extends SimCloudFrontError {
+  public override readonly name = "InvalidDefaultRootObject";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
+ * Simulated CloudFront InvalidErrorCode error.
+ */
+export class SimCloudFrontInvalidErrorCode extends SimCloudFrontError {
+  public override readonly name = "InvalidErrorCode";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
+ * Simulated CloudFront InvalidResponseCode error.
+ */
+export class SimCloudFrontInvalidResponseCode extends SimCloudFrontError {
+  public override readonly name = "InvalidResponseCode";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
+ * Simulated CloudFront InvalidArgument error.
+ */
+export class SimCloudFrontInvalidArgument extends SimCloudFrontError {
+  public override readonly name = "InvalidArgument";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
  * Simulated CloudFront ResourceNotFoundException error.
  */
 export class SimCloudFrontResourceNotFoundException extends SimCloudFrontError {

--- a/test/cloudfront/site-fixture.ts
+++ b/test/cloudfront/site-fixture.ts
@@ -1,0 +1,116 @@
+/**
+ * A simulated static site behind a CloudFront Distribution, which every test
+ * about serving one needs before it can say anything about the response.
+ *
+ * This lives under `test/` for the same reasons as `test/sqs/`: eslint rejects
+ * an AWS SDK import from `src/` outside a test file, and `test/**` is
+ * type-checked with everything else, excluded from the published build, not
+ * collected as a suite, and not counted in coverage.
+ */
+
+import { assertNonNullable } from "@kensio/smartass";
+import { CreateBucketCommand, PutObjectCommand } from "@aws-sdk/client-s3";
+import {
+  CreateDistributionCommand,
+  type DistributionConfig,
+} from "@aws-sdk/client-cloudfront";
+
+import type { SimAws } from "../../src/service/aws/sim-aws.js";
+import { SimCloudFrontServiceController } from "../../src/service/cloudfront/controller/sim-cloudfront-controller.js";
+import { SimAwsServiceRequest } from "../../src/serve/controller/sim-service-controller.js";
+
+/**
+ * Create a Bucket holding the given objects, keyed by object key.
+ */
+export async function simCfSiteBucket(
+  simAws: SimAws,
+  bucketName: string,
+  objects: Record<string, string>,
+): Promise<void> {
+  const simS3 = simAws.s3();
+  await simS3.createBucket(new CreateBucketCommand({ Bucket: bucketName }));
+
+  await Promise.all(
+    Object.entries(objects).map(
+      async ([key, body]) =>
+        await simS3.putObject(
+          new PutObjectCommand({
+            Bucket: bucketName,
+            Key: key,
+            ContentType: "text/html",
+            Body: body,
+          }),
+        ),
+    ),
+  );
+}
+
+/**
+ * A DistributionConfig serving one S3 Origin, with the given config merged on
+ * top so a test only states the part it is about.
+ */
+export function simCfSiteDistributionConfig(
+  bucketName: string,
+  distributionConfig: Partial<DistributionConfig> = {},
+): DistributionConfig {
+  return {
+    CallerReference: `site-${bucketName}`,
+    Comment: "Static site distribution",
+    Enabled: true,
+    Origins: {
+      Quantity: 1,
+      Items: [
+        {
+          Id: "site-origin",
+          DomainName: `${bucketName}.s3.amazonaws.com`,
+          S3OriginConfig: { OriginAccessIdentity: "" },
+        },
+      ],
+    },
+    DefaultCacheBehavior: {
+      TargetOriginId: "site-origin",
+      ViewerProtocolPolicy: "allow-all",
+    },
+    ...distributionConfig,
+  };
+}
+
+/**
+ * Create the Distribution and return its ID.
+ */
+export async function simCfSiteDistributionId(
+  simAws: SimAws,
+  distributionConfig: DistributionConfig,
+): Promise<string> {
+  const creation = await simAws
+    .cloudFront()
+    .createDistribution(
+      new CreateDistributionCommand({ DistributionConfig: distributionConfig }),
+    );
+
+  assertNonNullable(creation.Distribution?.Id);
+
+  return creation.Distribution.Id;
+}
+
+/**
+ * Serve one request to a Distribution through the CloudFront controller.
+ */
+export async function simCfSiteRequest(
+  simAws: SimAws,
+  distributionId: string,
+  path: string,
+  requestInit: RequestInit = {},
+): Promise<Response> {
+  const controller = new SimCloudFrontServiceController({ simAws });
+
+  return await controller.handleRequest(
+    new SimAwsServiceRequest({
+      target: { service: "cloudFront", resourceName: "" },
+      request: new Request(
+        `http://${distributionId}.cloudfront.net.sim-aws.localhost${path}`,
+        requestInit,
+      ),
+    }),
+  );
+}

--- a/test/cloudfront/site-fixture.ts
+++ b/test/cloudfront/site-fixture.ts
@@ -48,6 +48,10 @@ export async function simCfSiteBucket(
 /**
  * A DistributionConfig serving one S3 Origin, with the given config merged on
  * top so a test only states the part it is about.
+ *
+ * The merge is shallow, so overriding `DefaultCacheBehavior` or `Origins`
+ * replaces the whole value rather than adding to it, and the caller has to
+ * restate what it still needs, such as `TargetOriginId`.
  */
 export function simCfSiteDistributionConfig(
   bucketName: string,


### PR DESCRIPTION
Resolves #388 and #389.

`DefaultRootObject` and `CustomErrorResponses` were accepted from `CreateDistributionCommand` and from `AWS::CloudFront::Distribution`, stored on the Distribution and read back by `GetDistributionCommand`, while nothing in request handling looked at either. A Distribution therefore looked configured through the API and behaved as though it were not, which is what simulated S3's docs say a resource should never do.

## Default root object

A request for the Distribution root is rewritten to the named object before Behavior resolution, so a Cache Behavior path pattern and a `viewer-request` CloudFront Function both act on the object being served. Only the exact root is substituted, never a subdirectory, which is where CloudFront differs from an S3 website index document. It applies to every method the Distribution allows, and to a custom Origin as well as an S3 one.

A value beginning with a forward slash is refused at create time as `InvalidDefaultRootObject`, since in real CloudFront it answers every root request with a 403. An empty value means none, as it does in AWS.

## Custom error responses

An Origin response whose status matches an `ErrorCode` is replaced by fetching `ResponsePagePath` as a request in its own right, so the Behavior matching that path decides which Origin the page comes from and error pages can live somewhere other than the content that failed. `ResponseCode` is the status the viewer sees, which covers a single page app serving its shell with a 200. Where the response page is itself missing, the viewer gets the status from fetching it, as CloudFront documents. This runs before the `viewer-response` CloudFront Function, so a function sees the response the viewer is about to get.

Configuration CloudFront refuses is refused here: an `ErrorCode` outside the eleven codes it supports (`InvalidErrorCode`), `ResponsePagePath` and `ResponseCode` given without each other (`InvalidArgument`), and a `ResponseCode` that is not an HTTP status (`InvalidResponseCode`). A rule carrying only `ErrorCode` and `ErrorCachingMinTTL` configures error caching, which nothing here caches, so it is accepted and ignored.

## Notes

- Both properties arrive through CloudFormation as well, in CDK's bare-array form with an integer `ResponseCode` as well as the SDK's `{Quantity, Items}` with a string.
- The shared test fixture sits under `test/cloudfront/` rather than beside the tests, for the reason given in `test/sqs/queue-fixture.ts`: eslint refuses an AWS SDK import from `src/` outside a test file.
- Refusing a `ResponsePagePath` without a leading slash is a judgement call rather than a documented API constraint. CDK rejects one, and the value cannot resolve as a Distribution path, so it looked more like a mistake worth catching than a value to accept.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for CloudFront default root objects for serving homepage content.
  * Added custom error responses with configurable error pages and response status codes.
  * Added support for static-site routing, including custom 403 and 404 pages.
  * Added validation for supported error codes, response codes, and page paths.
  * Viewer-response functions now run on custom error responses.

* **Documentation**
  * Added configuration guidance and a static-site usage example, including local serving behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->