### PR TITLE
fix: resolve HTTP hosts without the local suffix

### DIFF
--- a/docs/services/route53/README.md
+++ b/docs/services/route53/README.md
@@ -567,7 +567,8 @@ number is already held on UDP by something else, DNS binds an ephemeral port ins
 Nothing binds port 53, which would need root. To resolve simulated names system-wide without naming a
 port, point your resolver at the simulator yourself. On macOS, a file such as `/etc/resolver/test`
 containing `nameserver 127.0.0.1` and `port <dnsPort>` makes the whole `.test` TLD resolve through
-it. That is a change to your machine, so Yulin does not make it for you.
+it. That is a change to your machine, so Yulin does not make it for you. With that in place, the HTTP
+server answers for those names too: see [Local hostname resolution](#local-hostname-resolution).
 
 ### What is answered
 
@@ -600,6 +601,20 @@ http://www.example.test.sim-aws.localhost:<port>/
 
 The local server resolves the logical hostname `www.example.test` through sim Route53 and routes the
 request to the simulated target named by the record.
+
+The suffix is optional. It exists so a client can reach the local server without the hostname
+resolving on the public internet, so it is only needed while nothing is resolving the name to the
+simulator. Once a resolver is pointed at the served DNS server, as under [Ports](#ports) above, the
+name resolves on its own and the request can be made under the hostname your application really
+uses:
+
+```text
+http://www.example.test:<port>/
+```
+
+Both forms reach the same simulated target. The suffix-free form is what makes an exact apex `Host`
+possible, so a CloudFront Function redirecting `example.test` to `www.example.test` can be exercised
+in a browser.
 
 This is most useful with CloudFront aliases. You can create a CloudFront distribution, create a
 Route53 record pointing at the distribution hostname, then fetch through your application hostname.
@@ -956,7 +971,7 @@ Sim Route53 currently supports:
 - Stored record types: `A`, `AAAA`, `CNAME`, `TXT`, `NS` and `SOA`
 - Local HTTP hostname routing through `CNAME` records that point to simulated service hostnames
 - Alias records, with `AliasTarget.DNSName` stored as the record value
-- Local hostname resolution through `*.sim-aws.localhost`
+- Local hostname resolution, with or without the `sim-aws.localhost` suffix on the requested hostname
 - A browser-viewable hosted zone and record summary at `dns.sim-aws.localhost`
 - DNS answers over UDP, so records can be queried with `dig` or any DNS client
 - The `AWS::Route53::HostedZone` and `AWS::Route53::RecordSet` CloudFormation resources

--- a/src/serve/dns/sim-aws-dns-server.loc.test.ts
+++ b/src/serve/dns/sim-aws-dns-server.loc.test.ts
@@ -138,23 +138,40 @@ describe("Simulated AWS DNS server", () => {
     assertArrayEquals(addresses, ["127.0.0.1"]);
   });
 
-  it("serves over HTTP what DNS pointed at, for the same name", async () => {
+  it("serves over HTTP what DNS pointed at, under the same name", async () => {
     // Given the address DNS just answered with.
     const addresses = await resolver.resolve4("www.example.test");
     assertIdentical(addresses[0], "127.0.0.1");
 
-    // When the site is requested at exactly the address DNS gave, rather than by
-    // resolving the hostname again. `sim-aws.localhost` resolves to both ::1 and
+    // When the site is requested at exactly the address DNS gave, under the name
+    // that was resolved. The address is used literally rather than by resolving
+    // the hostname again, because `sim-aws.localhost` resolves to both ::1 and
     // 127.0.0.1, so going by name could reach a different socket than the one
     // the DNS answer named, and hide a disagreement between the two.
     const { statusCode, body } = await requestAt(
       addresses[0],
       server.port,
+      "www.example.test",
+    );
+
+    // Then the simulated S3 website answers, so a resolver pointed at the
+    // simulator sends a browser somewhere that serves the name it asked for.
+    assertIdentical(statusCode, 200);
+    assertStringIncludes(body, "Hello from Yulin");
+  });
+
+  it("serves the same name carrying the Yulin-local suffix", async () => {
+    // Given a client that reaches the local server without a resolver pointed at
+    // it, and so asks for the name with the local suffix on it.
+    // When the site is requested under that hostname.
+    const { statusCode, body } = await requestAt(
+      "127.0.0.1",
+      server.port,
       "www.example.test.sim-aws.localhost",
     );
 
-    // Then the simulated S3 website answers, so the address in the DNS answer is
-    // one that really serves the name.
+    // Then the same simulated S3 website answers, because the suffix only says
+    // where the request is going, not which name is being asked for.
     assertIdentical(statusCode, 200);
     assertStringIncludes(body, "Hello from Yulin");
   });

--- a/src/serve/http/sim-aws-http.iso.test.ts
+++ b/src/serve/http/sim-aws-http.iso.test.ts
@@ -100,6 +100,51 @@ describe("Simulated AWS HTTP", () => {
     );
   });
 
+  it("routes custom domains without the Yulin-local suffix", async () => {
+    // Given a hosted zone with a CNAME pointing at a CloudFront hostname.
+    const simAws = new SimAws();
+    const hostedZoneCreation = await simAws.route53().createHostedZone({
+      input: {
+        Name: "bar.com",
+        CallerReference: "bar-com-test",
+      },
+    });
+
+    await simAws.route53().changeResourceRecordSets({
+      input: {
+        HostedZoneId: hostedZoneCreation.HostedZone?.Id,
+        ChangeBatch: {
+          Changes: [
+            {
+              Action: "UPSERT",
+              ResourceRecordSet: {
+                Name: "www.bar.com",
+                Type: "CNAME",
+                ResourceRecords: [{ Value: "d123.cloudfront.net" }],
+              },
+            },
+          ],
+        },
+      },
+    });
+    await simAws.backgroundTasksComplete();
+
+    const simAwsHttp = new SimAwsHttp({ simAws });
+
+    // When the request names the hostname as a browser would, with no suffix,
+    // which is what the simulated DNS server answers for.
+    const response = await simAwsHttp.fetch(new Request("http://www.bar.com/"));
+
+    // Then it reaches CloudFront routing rather than being refused as an
+    // unknown host.
+    assertResponseStatus(response, 404);
+    const responseBody = await response.text();
+    assertStringIncludes(
+      responseBody,
+      "Suitable sim CloudFront Distribution not found",
+    );
+  });
+
   it("serves an S3 Object over simulated HTTP when static website hosting is configured", async () => {
     const simAws = new SimAws();
 

--- a/src/service/route53/local-name/sim-route53-local-name.iso.test.ts
+++ b/src/service/route53/local-name/sim-route53-local-name.iso.test.ts
@@ -2,6 +2,7 @@ import { describe, it } from "vitest";
 import { assertIdentical, assertUndefined } from "@kensio/smartass";
 import {
   simRoute53LocalName,
+  simRoute53LogicalHostname,
   simRoute53LogicalName,
 } from "./sim-route53-local-name.js";
 
@@ -46,6 +47,53 @@ describe("sim Route53 local name utils", () => {
 
       // When converting the local name to a logical DNS name.
       const logicalName = simRoute53LogicalName(localName);
+
+      // Then no logical DNS name is returned.
+      assertUndefined(logicalName);
+    });
+  });
+
+  describe("simRoute53LogicalHostname", () => {
+    it("strips the local suffix when a hostname carries one", () => {
+      // Given a requested hostname carrying the simulated local suffix.
+      const hostname = "WWW.FOO.COM.sim-aws.localhost.";
+
+      // When converting it to a logical DNS name.
+      const logicalName = simRoute53LogicalHostname(hostname);
+
+      // Then the logical name is returned in normalised form.
+      assertIdentical(logicalName, "www.foo.com");
+    });
+
+    it("returns a hostname with no local suffix as the logical name", () => {
+      // Given a requested hostname with no simulated local suffix, as a browser
+      // sends after the simulated DNS server has answered for the name.
+      const hostname = "WWW.FOO.COM.";
+
+      // When converting it to a logical DNS name.
+      const logicalName = simRoute53LogicalHostname(hostname);
+
+      // Then it is already the logical name, in normalised form.
+      assertIdentical(logicalName, "www.foo.com");
+    });
+
+    it("returns undefined for hostnames containing empty labels", () => {
+      // Given a malformed hostname with an empty label and no local suffix.
+      const hostname = "www..foo.com";
+
+      // When converting it to a logical DNS name.
+      const logicalName = simRoute53LogicalHostname(hostname);
+
+      // Then no logical DNS name is returned.
+      assertUndefined(logicalName);
+    });
+
+    it("returns undefined for a bare local suffix", () => {
+      // Given a hostname that is the local suffix with nothing before it.
+      const hostname = ".sim-aws.localhost";
+
+      // When converting it to a logical DNS name.
+      const logicalName = simRoute53LogicalHostname(hostname);
 
       // Then no logical DNS name is returned.
       assertUndefined(logicalName);

--- a/src/service/route53/local-name/sim-route53-local-name.ts
+++ b/src/service/route53/local-name/sim-route53-local-name.ts
@@ -30,11 +30,30 @@ export function simRoute53LogicalName(localName: string): string | undefined {
     return undefined;
   }
 
-  const logicalName = normalisedName.slice(0, -simRoute53LocalSuffix.length);
-  const logicalNameLabels = logicalName.split(".");
+  return simRoute53LogicalHostname(normalisedName);
+}
+
+/**
+ * Convert a hostname a client requested to a logical DNS name.
+ *
+ * The Yulin-local suffix is optional here, unlike in `simRoute53LogicalName`.
+ * A hostname arriving over HTTP may carry it, because that is how a client
+ * reaches the local server without the name resolving on the public internet,
+ * or it may be the logical name itself, because the simulator's own DNS server
+ * answers for logical names and can point a resolver straight at the local
+ * server.
+ */
+export function simRoute53LogicalHostname(
+  hostname: string,
+): string | undefined {
+  const normalisedName = normaliseSimRoute53Name(hostname);
+
+  const logicalName = normalisedName.endsWith(simRoute53LocalSuffix)
+    ? normalisedName.slice(0, -simRoute53LocalSuffix.length)
+    : normalisedName;
 
   // Reject empty labels before normalization can hide malformed hostnames.
-  if (logicalNameLabels.some((label) => label.length === 0)) {
+  if (logicalName.split(".").some((label) => label.length === 0)) {
     return undefined;
   }
 

--- a/src/service/route53/resolve/sim-route53-resolve-cname.iso.test.ts
+++ b/src/service/route53/resolve/sim-route53-resolve-cname.iso.test.ts
@@ -53,11 +53,11 @@ describe("SimRoute53 hostname resolution", () => {
     await properties.simAws.backgroundTasksComplete();
   }
 
-  it("returns undefined when the hostname is not a local Route53 name", () => {
-    // Given simulated AWS.
+  it("returns undefined when no hosted zone holds the hostname", () => {
+    // Given simulated AWS holding no hosted zones.
     const simAws = new SimAws();
 
-    // When a non-local hostname is resolved.
+    // When a hostname is resolved.
     const target = simAws.route53().resolveHttpHost("example.com");
 
     // Then no target is resolved.

--- a/src/service/route53/resolve/sim-route53-resolve-host-suffix.iso.test.ts
+++ b/src/service/route53/resolve/sim-route53-resolve-host-suffix.iso.test.ts
@@ -1,0 +1,133 @@
+import { assertObjectMatches, assertUndefined } from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../aws/sim-aws.js";
+
+/**
+ * The Yulin-local suffix is optional on a hostname arriving over HTTP, because
+ * the simulated DNS server answers for logical zone names. A resolver pointed at
+ * the simulator therefore sends a client here under the hostname the application
+ * really uses, with no suffix on it.
+ */
+describe("SimRoute53 hostname resolution without the local suffix", () => {
+  it("resolves a CNAME under the logical hostname", async () => {
+    // Given a hosted zone with a CNAME pointing at a simulated S3 website.
+    const simAws = new SimAws();
+    const simRoute53 = simAws.route53();
+    const hostedZoneCreation = await simRoute53.createHostedZone({
+      input: { Name: "example.test", CallerReference: "example-test" },
+    });
+    await simRoute53.changeResourceRecordSets({
+      input: {
+        HostedZoneId: hostedZoneCreation.HostedZone?.Id,
+        ChangeBatch: {
+          Changes: [
+            {
+              Action: "CREATE",
+              ResourceRecordSet: {
+                Name: "www.example.test",
+                Type: "CNAME",
+                ResourceRecords: [
+                  { Value: "site-bucket.s3-website.eu-west-1" },
+                ],
+              },
+            },
+          ],
+        },
+      },
+    });
+    await simAws.backgroundTasksComplete();
+
+    // When the hostname is resolved without the local suffix.
+    const target = simRoute53.resolveHttpHost("www.example.test");
+
+    // Then it reaches the same S3 website the suffixed hostname reaches.
+    assertObjectMatches(target, {
+      service: "s3",
+      resourceName: "site-bucket",
+      regionName: "eu-west-1",
+    });
+  });
+
+  it("resolves a zone apex under the logical hostname", async () => {
+    // Given a hosted zone with an apex A alias pointing at a CloudFront hostname.
+    const simAws = new SimAws();
+    const simRoute53 = simAws.route53();
+    const hostedZoneCreation = await simRoute53.createHostedZone({
+      input: { Name: "apex.test", CallerReference: "apex-test" },
+    });
+    await simRoute53.changeResourceRecordSets({
+      input: {
+        HostedZoneId: hostedZoneCreation.HostedZone?.Id,
+        ChangeBatch: {
+          Changes: [
+            {
+              Action: "CREATE",
+              ResourceRecordSet: {
+                Name: "apex.test",
+                Type: "A",
+                AliasTarget: {
+                  DNSName: "EDFDVBD6EXAMPLE.cloudfront.net",
+                  HostedZoneId: "Z2FDTNDATAQYW2",
+                  EvaluateTargetHealth: false,
+                },
+              },
+            },
+          ],
+        },
+      },
+    });
+    await simAws.backgroundTasksComplete();
+
+    // When the apex is resolved as a browser would present it in a Host header.
+    const target = simRoute53.resolveHttpHost("apex.test");
+
+    // Then it routes to the CloudFront Distribution, so an exact apex Host can
+    // reach a Distribution for the first time.
+    assertObjectMatches(target, {
+      service: "cloudFront",
+      resourceName: "edfdvbd6example",
+    });
+  });
+
+  it("resolves a built-in service hostname without the local suffix", () => {
+    // Given simulated AWS.
+    const simAws = new SimAws();
+
+    // When a simulated S3 website hostname is resolved with no suffix on it.
+    const target = simAws
+      .route53()
+      .resolveHttpHost("site-bucket.s3-website.eu-west-1");
+
+    // Then the service target is recognised by its shape, as it is with the
+    // suffix, because the suffix never carried any of that meaning.
+    assertObjectMatches(target, {
+      service: "s3",
+      resourceName: "site-bucket",
+      regionName: "eu-west-1",
+    });
+  });
+
+  it("returns undefined for a hostname held by no hosted zone", () => {
+    // Given simulated AWS holding no hosted zones.
+    const simAws = new SimAws();
+
+    // When a hostname nothing answers for is resolved.
+    const target = simAws.route53().resolveHttpHost("nothing.example.test");
+
+    // Then no target is resolved, so the request is still refused rather than
+    // dropping through to some default service.
+    assertUndefined(target);
+  });
+
+  it("returns undefined for a hostname containing an empty label", () => {
+    // Given simulated AWS.
+    const simAws = new SimAws();
+
+    // When a malformed hostname is resolved.
+    const target = simAws.route53().resolveHttpHost("www..example.test");
+
+    // Then no target is resolved, rather than the empty label being normalised
+    // away into a hostname that does resolve.
+    assertUndefined(target);
+  });
+});

--- a/src/service/route53/resolve/sim-route53-resolver.ts
+++ b/src/service/route53/resolve/sim-route53-resolver.ts
@@ -1,6 +1,7 @@
 import type { SimAwsServiceTarget } from "../../../serve/controller/sim-service-controller.js";
 import {
   simRoute53LocalName,
+  simRoute53LogicalHostname,
   simRoute53LogicalName,
 } from "../local-name/sim-route53-local-name.js";
 import type { SimRoute53HostedZone } from "../hosted-zone/sim-route53-hosted-zone.js";
@@ -29,18 +30,24 @@ export class SimRoute53Resolver {
   }
 
   /**
-   * Resolve a Yulin-local HTTP hostname to a simulated AWS service target.
+   * Resolve an HTTP hostname to a simulated AWS service target.
    *
    * Resolution follows the same shape used by local integration tests:
    *
-   * 1. Strip the Yulin localhost suffix to get the logical Route53 name.
+   * 1. Strip the Yulin localhost suffix, if the hostname carries one, to get the
+   *    logical Route53 name.
    * 2. Check whether that name already points at a built-in simulated service.
    * 3. If not, follow CNAME or alias records to the next hostname.
    * 4. Stop when a service target is found, a chain breaks, a cycle appears, or
    *    the maximum CNAME depth is reached.
+   *
+   * The suffix is optional because the simulated DNS server answers for logical
+   * zone names, so a resolver pointed at the simulator sends a browser here with
+   * the hostname the application really uses. Refusing that name would leave the
+   * DNS server pointing at a server that will not answer for it.
    */
   resolveHttpHost(hostname: string): SimAwsServiceTarget | undefined {
-    const initialLogicalName = simRoute53LogicalName(hostname);
+    const initialLogicalName = simRoute53LogicalHostname(hostname);
     if (initialLogicalName === undefined) {
       return undefined;
     }


### PR DESCRIPTION
Resolves #395

Simulated DNS answered for the logical names held in the hosted zones, while `SimAwsHttp` went through `SimRoute53Resolver.resolveHttpHost`, whose first step refused any hostname not ending in `.sim-aws.localhost`. Pointing a resolver at the served DNS server, as `docs/services/route53/README.md` recommends, therefore sent a browser to an HTTP server that answered 501 for the name it had just been pointed at.

`resolveHttpHost` now treats an unsuffixed hostname as already being the logical name, through a new `simRoute53LogicalHostname`. The suffix stays optional rather than going away: it is what lets a client reach the local server without the name resolving on the public internet, and every existing suffixed hostname routes exactly as before. Empty-label validation is unchanged, so a malformed hostname is still refused rather than normalised into one that resolves.

The practical gain is an exact apex `Host`: `http://example.test:<port>/` now reaches a simulated service, which is what a CloudFront Function doing an apex to `www` redirect needs to see. #385 is the other half of that.

Worth a look in review: `sim-aws-dns-server.loc.test.ts` had a test named "serves over HTTP what DNS pointed at, for the same name" that was quietly working around this bug, requesting the suffixed hostname after resolving the bare one. It now uses the name it resolved, with a separate case covering the suffixed form.
