### PR TITLE
feat: delete simulated Buckets, functions, Roles

### DIFF
--- a/src/service/iam/command/policy/delete-policy/delete-policy.command.ts
+++ b/src/service/iam/command/policy/delete-policy/delete-policy.command.ts
@@ -1,0 +1,9 @@
+export interface SimDeletePolicyCommandInput {
+  readonly PolicyArn?: string | undefined;
+}
+
+export interface SimDeletePolicyCommand {
+  readonly input: SimDeletePolicyCommandInput;
+}
+
+export type SimDeletePolicyCommandOutput = Record<string, never>;

--- a/src/service/iam/command/policy/delete-policy/delete-policy.handler.ts
+++ b/src/service/iam/command/policy/delete-policy/delete-policy.handler.ts
@@ -1,0 +1,99 @@
+import type { CommandHandler } from "../../../../../command/command-handler.js";
+import {
+  type BackgroundScheduler,
+  BackgroundTasks,
+} from "../../../../../util/background/background.js";
+import type { SimArn } from "../../../../aws/arn.js";
+import {
+  SimIamDeleteConflict,
+  SimIamNoSuchEntity,
+} from "../../../error/sim-iam.error.js";
+import type { SimIamManagedPolicy } from "../../../policy/sim-iam-policy.js";
+import type { SimIamRole, SimIamRoleName } from "../../../role/sim-iam-role.js";
+import type { SimIamUser, SimIamUsername } from "../../../user/sim-iam-user.js";
+import type {
+  SimDeletePolicyCommand,
+  SimDeletePolicyCommandOutput,
+} from "./delete-policy.command.js";
+
+interface DeletePolicyCommandHandlerProperties {
+  readonly policies: Map<SimArn, SimIamManagedPolicy>;
+  readonly roles: Map<SimIamRoleName, SimIamRole>;
+  readonly users: Map<SimIamUsername, SimIamUser>;
+  readonly background?: BackgroundScheduler;
+}
+
+/**
+ * IAM DeletePolicyCommand handler.
+ *
+ * Real IAM refuses to delete a managed policy while anything is attached to
+ * it, so this counts the Roles and Users carrying the ARN rather than reading
+ * the policy record's own attachment count: attachment is recorded on the
+ * identity, which is where AttachRolePolicy puts it.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/iam/command/DeletePolicyCommand/
+ */
+export class DeletePolicyCommandHandler implements CommandHandler<
+  SimDeletePolicyCommand,
+  SimDeletePolicyCommandOutput
+> {
+  private readonly policies: Map<SimArn, SimIamManagedPolicy>;
+  private readonly roles: Map<SimIamRoleName, SimIamRole>;
+  private readonly users: Map<SimIamUsername, SimIamUser>;
+  private readonly background: BackgroundScheduler;
+
+  constructor(properties: DeletePolicyCommandHandlerProperties) {
+    const {
+      policies,
+      roles,
+      users,
+      background = new BackgroundTasks(),
+    } = properties;
+
+    this.policies = policies;
+    this.roles = roles;
+    this.users = users;
+    this.background = background;
+  }
+
+  /**
+   * Handle a DeletePolicyCommand from the SDK.
+   */
+  async handle(
+    command: SimDeletePolicyCommand,
+  ): Promise<SimDeletePolicyCommandOutput> {
+    const policyArn = command.input.PolicyArn as SimArn | undefined;
+
+    if (policyArn === undefined || policyArn.length === 0) {
+      throw new Error("PolicyArn is required");
+    }
+
+    // Allow for potential non-deterministic sequencing of async events.
+    await this.background.sequence();
+
+    if (!this.policies.has(policyArn)) {
+      throw new SimIamNoSuchEntity(`No IAM Policy with ARN ${policyArn}`);
+    }
+
+    this.assertNotAttached(policyArn);
+    this.policies.delete(policyArn);
+
+    return {};
+  }
+
+  private assertNotAttached(policyArn: SimArn): void {
+    if (this.attachmentCount(policyArn) > 0) {
+      throw new SimIamDeleteConflict(
+        `Cannot delete a policy attached to entities: IAM Policy ${policyArn}`,
+      );
+    }
+  }
+
+  private attachmentCount(policyArn: SimArn): number {
+    const identities = [...this.roles.values(), ...this.users.values()];
+
+    return identities.filter((identity) =>
+      identity.attachedPolicyArns.has(policyArn),
+    ).length;
+  }
+}

--- a/src/service/iam/command/policy/delete-policy/delete-policy.iso.test.ts
+++ b/src/service/iam/command/policy/delete-policy/delete-policy.iso.test.ts
@@ -1,0 +1,166 @@
+import {
+  AttachRolePolicyCommand,
+  CreatePolicyCommand,
+  CreateRoleCommand,
+  DeletePolicyCommand,
+  DetachRolePolicyCommand,
+  GetPolicyCommand,
+} from "@aws-sdk/client-iam";
+import {
+  assertFalse,
+  assertIdentical,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import {
+  SimIamDeleteConflict,
+  SimIamNoSuchEntity,
+} from "../../../error/sim-iam.error.js";
+import { SimIam } from "../../../sim-iam.js";
+
+const policyDocument = JSON.stringify({
+  Version: "2012-10-17",
+  Statement: { Effect: "Allow", Action: "s3:ListBucket", Resource: "*" },
+});
+
+const trustPolicy = JSON.stringify({
+  Version: "2012-10-17",
+  Statement: {
+    Effect: "Allow",
+    Principal: { Service: "lambda.amazonaws.com" },
+    Action: "sts:AssumeRole",
+  },
+});
+
+describe("IAM DeletePolicyCommand", () => {
+  it("deletes a managed policy nothing is attached to", async () => {
+    // Given a managed policy with no attachments.
+    const simIam = new SimIam();
+    const policy = await simIam.createPolicy(
+      new CreatePolicyCommand({
+        PolicyName: "Unused",
+        PolicyDocument: policyDocument,
+      }),
+    );
+
+    // When the policy is deleted.
+    await simIam.deletePolicy(
+      new DeletePolicyCommand({ PolicyArn: policy.Policy.Arn }),
+    );
+
+    // Then IAM no longer has it.
+    assertFalse(simIam.policies.has(policy.Policy.Arn));
+
+    const error = await assertThrowsErrorAsync(async () =>
+      simIam.getPolicy(new GetPolicyCommand({ PolicyArn: policy.Policy.Arn })),
+    );
+    assertInstanceOf(error, SimIamNoSuchEntity);
+  });
+
+  it("refuses a policy that is still attached to a Role", async () => {
+    // Given a managed policy attached to a Role.
+    const simIam = new SimIam();
+    await simIam.createRole(
+      new CreateRoleCommand({
+        RoleName: "HolderRole",
+        AssumeRolePolicyDocument: trustPolicy,
+      }),
+    );
+    const policy = await simIam.createPolicy(
+      new CreatePolicyCommand({
+        PolicyName: "StillAttached",
+        PolicyDocument: policyDocument,
+      }),
+    );
+    await simIam.attachRolePolicy(
+      new AttachRolePolicyCommand({
+        RoleName: "HolderRole",
+        PolicyArn: policy.Policy.Arn,
+      }),
+    );
+
+    // When the policy is deleted.
+    const error = await assertThrowsErrorAsync(async () =>
+      simIam.deletePolicy(
+        new DeletePolicyCommand({ PolicyArn: policy.Policy.Arn }),
+      ),
+    );
+
+    // Then IAM refuses while an identity still carries it.
+    assertInstanceOf(error, SimIamDeleteConflict);
+    assertIdentical(error.$metadata.httpStatusCode, 409);
+    assertStringIncludes(error.message, "attached to entities");
+  });
+
+  it("deletes a policy once it has been detached", async () => {
+    // Given a managed policy that has been detached from its Role.
+    const simIam = new SimIam();
+    await simIam.createRole(
+      new CreateRoleCommand({
+        RoleName: "FormerHolder",
+        AssumeRolePolicyDocument: trustPolicy,
+      }),
+    );
+    const policy = await simIam.createPolicy(
+      new CreatePolicyCommand({
+        PolicyName: "Detached",
+        PolicyDocument: policyDocument,
+      }),
+    );
+    await simIam.attachRolePolicy(
+      new AttachRolePolicyCommand({
+        RoleName: "FormerHolder",
+        PolicyArn: policy.Policy.Arn,
+      }),
+    );
+    await simIam.detachRolePolicy(
+      new DetachRolePolicyCommand({
+        RoleName: "FormerHolder",
+        PolicyArn: policy.Policy.Arn,
+      }),
+    );
+
+    // When the policy is deleted.
+    await simIam.deletePolicy(
+      new DeletePolicyCommand({ PolicyArn: policy.Policy.Arn }),
+    );
+
+    // Then it goes, because nothing carries it any more.
+    assertFalse(simIam.policies.has(policy.Policy.Arn));
+  });
+
+  it("rejects a policy that does not exist", async () => {
+    // Given an IAM Account without the requested policy.
+    const simIam = new SimIam();
+
+    // When the missing policy is deleted.
+    const error = await assertThrowsErrorAsync(async () =>
+      simIam.deletePolicy(
+        new DeletePolicyCommand({
+          PolicyArn: "arn:aws:iam::111111111111:policy/Absent",
+        }),
+      ),
+    );
+
+    // Then IAM answers with its missing-entity error.
+    assertInstanceOf(error, SimIamNoSuchEntity);
+  });
+
+  it("rejects a missing required PolicyArn input", async () => {
+    // Given an IAM Account.
+    const simIam = new SimIam();
+
+    // When DeletePolicy is called without its required PolicyArn.
+    const error = await assertThrowsErrorAsync(async () =>
+      simIam.deletePolicy(
+        // @ts-expect-error -- testing invalid input
+        new DeletePolicyCommand({}),
+      ),
+    );
+
+    // Then request validation identifies the missing input.
+    assertStringIncludes(error.message, "PolicyArn is required");
+  });
+});

--- a/src/service/iam/command/policy/delete-role-policy/delete-role-policy.command.ts
+++ b/src/service/iam/command/policy/delete-role-policy/delete-role-policy.command.ts
@@ -1,0 +1,10 @@
+export interface SimDeleteRolePolicyCommandInput {
+  readonly RoleName?: string | undefined;
+  readonly PolicyName?: string | undefined;
+}
+
+export interface SimDeleteRolePolicyCommand {
+  readonly input: SimDeleteRolePolicyCommandInput;
+}
+
+export type SimDeleteRolePolicyCommandOutput = Record<string, never>;

--- a/src/service/iam/command/policy/delete-role-policy/delete-role-policy.handler.ts
+++ b/src/service/iam/command/policy/delete-role-policy/delete-role-policy.handler.ts
@@ -1,0 +1,76 @@
+import type { CommandHandler } from "../../../../../command/command-handler.js";
+import {
+  type BackgroundScheduler,
+  BackgroundTasks,
+} from "../../../../../util/background/background.js";
+import { SimIamNoSuchEntity } from "../../../error/sim-iam.error.js";
+import type { SimIamRole, SimIamRoleName } from "../../../role/sim-iam-role.js";
+import type {
+  SimDeleteRolePolicyCommand,
+  SimDeleteRolePolicyCommandOutput,
+} from "./delete-role-policy.command.js";
+
+interface DeleteRolePolicyCommandHandlerProperties {
+  readonly roles: Map<SimIamRoleName, SimIamRole>;
+  readonly background?: BackgroundScheduler;
+}
+
+/**
+ * IAM DeleteRolePolicyCommand handler.
+ *
+ * This removes an inline policy stored on the Role, which is what
+ * PutRolePolicy put there. A policy name the Role does not carry is refused,
+ * as real IAM has nothing to remove.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/iam/command/DeleteRolePolicyCommand/
+ */
+export class DeleteRolePolicyCommandHandler implements CommandHandler<
+  SimDeleteRolePolicyCommand,
+  SimDeleteRolePolicyCommandOutput
+> {
+  private readonly roles: Map<SimIamRoleName, SimIamRole>;
+  private readonly background: BackgroundScheduler;
+
+  constructor(properties: DeleteRolePolicyCommandHandlerProperties) {
+    const { roles, background = new BackgroundTasks() } = properties;
+
+    this.roles = roles;
+    this.background = background;
+  }
+
+  /**
+   * Handle a DeleteRolePolicyCommand from the SDK.
+   */
+  async handle(
+    command: SimDeleteRolePolicyCommand,
+  ): Promise<SimDeleteRolePolicyCommandOutput> {
+    const roleName = command.input.RoleName as SimIamRoleName | undefined;
+
+    if (roleName === undefined || roleName.length === 0) {
+      throw new Error("RoleName is required");
+    }
+
+    const { PolicyName: policyName } = command.input;
+
+    if (policyName === undefined || policyName.length === 0) {
+      throw new Error("PolicyName is required");
+    }
+
+    // Allow for potential non-deterministic sequencing of async events.
+    await this.background.sequence();
+
+    const role = this.roles.get(roleName);
+
+    if (role === undefined) {
+      throw new SimIamNoSuchEntity(`No IAM Role with name ${roleName}`);
+    }
+
+    if (!role.inlinePolicies.delete(policyName)) {
+      throw new SimIamNoSuchEntity(
+        `No inline IAM Policy named ${policyName} on Role ${roleName}`,
+      );
+    }
+
+    return {};
+  }
+}

--- a/src/service/iam/command/policy/delete-role-policy/delete-role-policy.iso.test.ts
+++ b/src/service/iam/command/policy/delete-role-policy/delete-role-policy.iso.test.ts
@@ -1,0 +1,132 @@
+import {
+  CreateRoleCommand,
+  DeleteRolePolicyCommand,
+  PutRolePolicyCommand,
+} from "@aws-sdk/client-iam";
+import {
+  assertFalse,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertTrue,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimIamNoSuchEntity } from "../../../error/sim-iam.error.js";
+import type { SimIamRoleName } from "../../../role/sim-iam-role.js";
+import { SimIam } from "../../../sim-iam.js";
+
+const trustPolicy = JSON.stringify({
+  Version: "2012-10-17",
+  Statement: {
+    Effect: "Allow",
+    Principal: { Service: "lambda.amazonaws.com" },
+    Action: "sts:AssumeRole",
+  },
+});
+
+const policyDocument = JSON.stringify({
+  Version: "2012-10-17",
+  Statement: { Effect: "Allow", Action: "s3:ListBucket", Resource: "*" },
+});
+
+describe("IAM DeleteRolePolicyCommand", () => {
+  it("removes the inline policy PutRolePolicy stored", async () => {
+    // Given a Role carrying an inline policy.
+    const simIam = new SimIam();
+    await simIam.createRole(
+      new CreateRoleCommand({
+        RoleName: "InlineRole",
+        AssumeRolePolicyDocument: trustPolicy,
+      }),
+    );
+    await simIam.putRolePolicy(
+      new PutRolePolicyCommand({
+        RoleName: "InlineRole",
+        PolicyName: "Removable",
+        PolicyDocument: policyDocument,
+      }),
+    );
+
+    const role = simIam.roles.get("InlineRole" as SimIamRoleName);
+    assertTrue(role?.inlinePolicies.has("Removable"));
+
+    // When the inline policy is deleted.
+    await simIam.deleteRolePolicy(
+      new DeleteRolePolicyCommand({
+        RoleName: "InlineRole",
+        PolicyName: "Removable",
+      }),
+    );
+
+    // Then the Role no longer carries it.
+    assertFalse(role.inlinePolicies.has("Removable"));
+  });
+
+  it("rejects a policy name the Role does not carry", async () => {
+    // Given a Role with no inline policies.
+    const simIam = new SimIam();
+    await simIam.createRole(
+      new CreateRoleCommand({
+        RoleName: "PlainRole",
+        AssumeRolePolicyDocument: trustPolicy,
+      }),
+    );
+
+    // When a policy name it does not have is deleted.
+    const error = await assertThrowsErrorAsync(async () =>
+      simIam.deleteRolePolicy(
+        new DeleteRolePolicyCommand({
+          RoleName: "PlainRole",
+          PolicyName: "NeverPut",
+        }),
+      ),
+    );
+
+    // Then IAM answers with its missing-entity error.
+    assertInstanceOf(error, SimIamNoSuchEntity);
+    assertStringIncludes(error.message, "No inline IAM Policy named NeverPut");
+  });
+
+  it("rejects a Role that does not exist", async () => {
+    // Given an IAM Account without the requested Role.
+    const simIam = new SimIam();
+
+    // When an inline policy is deleted from the missing Role.
+    const error = await assertThrowsErrorAsync(async () =>
+      simIam.deleteRolePolicy(
+        new DeleteRolePolicyCommand({
+          RoleName: "Absent",
+          PolicyName: "Whatever",
+        }),
+      ),
+    );
+
+    // Then IAM answers with its missing-entity error.
+    assertInstanceOf(error, SimIamNoSuchEntity);
+  });
+
+  it("rejects missing required inputs", async () => {
+    // Given an IAM Account.
+    const simIam = new SimIam();
+
+    // When DeleteRolePolicy is called without a RoleName.
+    const roleError = await assertThrowsErrorAsync(async () =>
+      simIam.deleteRolePolicy(
+        // @ts-expect-error -- testing invalid input
+        new DeleteRolePolicyCommand({ PolicyName: "Some" }),
+      ),
+    );
+
+    // And without a PolicyName.
+    const policyError = await assertThrowsErrorAsync(async () =>
+      simIam.deleteRolePolicy(
+        // @ts-expect-error -- testing invalid input
+        new DeleteRolePolicyCommand({ RoleName: "SomeRole" }),
+      ),
+    );
+
+    // Then request validation identifies each missing input.
+    assertStringIncludes(roleError.message, "RoleName is required");
+    assertStringIncludes(policyError.message, "PolicyName is required");
+  });
+});

--- a/src/service/iam/command/policy/sim-iam-policy-command-handlers.ts
+++ b/src/service/iam/command/policy/sim-iam-policy-command-handlers.ts
@@ -3,6 +3,7 @@ import type { BackgroundScheduler } from "../../../../util/background/background
 import type { SimArn } from "../../../aws/arn.js";
 import type { SimIamActionAuthorizer } from "../../authorize/sim-iam-action-authorizer.js";
 import type { SimIamManagedPolicy } from "../../policy/sim-iam-policy.js";
+import type { SimIamRole, SimIamRoleName } from "../../role/sim-iam-role.js";
 import type { SimIamUser, SimIamUsername } from "../../user/sim-iam-user.js";
 import type { SimIamRequestOptions } from "../sim-iam-request-options.js";
 import { CreatePolicyCommandHandler } from "./create-policy/create-policy.handler.js";
@@ -20,6 +21,11 @@ import type {
   SimListPoliciesCommand,
   SimListPoliciesCommandOutput,
 } from "./list-policies/list-policies.command.js";
+import { DeletePolicyCommandHandler } from "./delete-policy/delete-policy.handler.js";
+import type {
+  SimDeletePolicyCommand,
+  SimDeletePolicyCommandOutput,
+} from "./delete-policy/delete-policy.command.js";
 import { PutUserPolicyCommandHandler } from "./put-user-policy/put-user-policy.handler.js";
 import type {
   SimPutUserPolicyCommand,
@@ -29,6 +35,7 @@ import type {
 interface SimIamPolicyCommandHandlersProperties {
   readonly accountId: SimAwsAccountId;
   readonly policies: Map<SimArn, SimIamManagedPolicy>;
+  readonly roles: Map<SimIamRoleName, SimIamRole>;
   readonly users: Map<SimIamUsername, SimIamUser>;
   readonly background: BackgroundScheduler;
   readonly authorizer: SimIamActionAuthorizer;
@@ -44,18 +51,42 @@ interface SimIamPolicyCommandHandlersProperties {
 export class SimIamPolicyCommandHandlers {
   private readonly accountId: SimAwsAccountId;
   private readonly policies: Map<SimArn, SimIamManagedPolicy>;
+  private readonly roles: Map<SimIamRoleName, SimIamRole>;
   private readonly users: Map<SimIamUsername, SimIamUser>;
   private readonly background: BackgroundScheduler;
   private readonly authorizer: SimIamActionAuthorizer;
 
   constructor(properties: SimIamPolicyCommandHandlersProperties) {
-    const { accountId, policies, users, background, authorizer } = properties;
+    const { accountId, policies, roles, users, background, authorizer } =
+      properties;
 
     this.accountId = accountId;
     this.policies = policies;
+    this.roles = roles;
     this.users = users;
     this.background = background;
     this.authorizer = authorizer;
+  }
+
+  /**
+   * Handle a DeletePolicy command from the SDK.
+   */
+  async deletePolicy(
+    command: SimDeletePolicyCommand,
+    options?: SimIamRequestOptions,
+  ): Promise<SimDeletePolicyCommandOutput> {
+    this.authorizer.authorize(
+      "iam:DeletePolicy",
+      command.input.PolicyArn ?? "*",
+      options?.caller,
+    );
+    const handler = new DeletePolicyCommandHandler({
+      policies: this.policies,
+      roles: this.roles,
+      users: this.users,
+      background: this.background,
+    });
+    return await handler.handle(command);
   }
 
   /**

--- a/src/service/iam/command/role/delete-role/delete-role.command.ts
+++ b/src/service/iam/command/role/delete-role/delete-role.command.ts
@@ -1,0 +1,20 @@
+/**
+ * Minimal structural sim IAM DeleteRole command.
+ */
+export interface SimDeleteRoleCommand {
+  readonly input: SimDeleteRoleCommandInput;
+}
+
+/**
+ * Minimal structural sim IAM DeleteRole input.
+ */
+export interface SimDeleteRoleCommandInput {
+  readonly RoleName?: string | undefined;
+}
+
+/**
+ * Minimal structural sim IAM DeleteRole output.
+ *
+ * Real IAM answers a successful DeleteRole with an empty response body.
+ */
+export type SimDeleteRoleCommandOutput = Record<string, never>;

--- a/src/service/iam/command/role/delete-role/delete-role.handler.ts
+++ b/src/service/iam/command/role/delete-role/delete-role.handler.ts
@@ -1,0 +1,82 @@
+import type { CommandHandler } from "../../../../../command/command-handler.js";
+import {
+  type BackgroundScheduler,
+  BackgroundTasks,
+} from "../../../../../util/background/background.js";
+import {
+  SimIamDeleteConflict,
+  SimIamNoSuchEntity,
+} from "../../../error/sim-iam.error.js";
+import type { SimIamRole, SimIamRoleName } from "../../../role/sim-iam-role.js";
+import type {
+  SimDeleteRoleCommand,
+  SimDeleteRoleCommandOutput,
+} from "./delete-role.command.js";
+
+interface DeleteRoleCommandHandlerProperties {
+  readonly roles: Map<SimIamRoleName, SimIamRole>;
+  readonly background?: BackgroundScheduler;
+}
+
+/**
+ * IAM DeleteRoleCommand handler.
+ *
+ * Real IAM only deletes a Role nothing is hanging off. A Role with inline
+ * policies or attached managed policies is refused, leaving the caller to
+ * remove them first with DeleteRolePolicy and DetachRolePolicy. That refusal
+ * is why a CloudFormation Stack deletes a Role's policies before the Role.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/iam/command/DeleteRoleCommand/
+ */
+export class DeleteRoleCommandHandler implements CommandHandler<
+  SimDeleteRoleCommand,
+  SimDeleteRoleCommandOutput
+> {
+  private readonly roles: Map<SimIamRoleName, SimIamRole>;
+  private readonly background: BackgroundScheduler;
+
+  constructor(properties: DeleteRoleCommandHandlerProperties) {
+    const { roles, background = new BackgroundTasks() } = properties;
+
+    this.roles = roles;
+    this.background = background;
+  }
+
+  /**
+   * Handle a DeleteRoleCommand from the SDK.
+   */
+  async handle(
+    command: SimDeleteRoleCommand,
+  ): Promise<SimDeleteRoleCommandOutput> {
+    const roleName = command.input.RoleName as SimIamRoleName | undefined;
+
+    if (roleName === undefined || roleName.length === 0) {
+      throw new Error("RoleName is required");
+    }
+
+    // Allow for potential non-deterministic sequencing of async events.
+    await this.background.sequence();
+
+    const role = this.roles.get(roleName);
+
+    if (role === undefined) {
+      throw new SimIamNoSuchEntity(`No IAM Role with name ${roleName}`);
+    }
+
+    this.assertNothingAttached(role);
+    this.roles.delete(roleName);
+
+    return {};
+  }
+
+  private assertNothingAttached(role: SimIamRole): void {
+    const attached = role.inlinePolicies.size + role.attachedPolicyArns.size;
+
+    if (attached > 0) {
+      throw new SimIamDeleteConflict(
+        `Cannot delete entity, must detach all policies first: ` +
+          `IAM Role ${role.roleName}`,
+      );
+    }
+  }
+}

--- a/src/service/iam/command/role/delete-role/delete-role.iso.test.ts
+++ b/src/service/iam/command/role/delete-role/delete-role.iso.test.ts
@@ -1,0 +1,214 @@
+import {
+  AttachRolePolicyCommand,
+  CreatePolicyCommand,
+  CreateRoleCommand,
+  DeleteRoleCommand,
+  DeleteRolePolicyCommand,
+  DetachRolePolicyCommand,
+  GetRoleCommand,
+  PutRolePolicyCommand,
+} from "@aws-sdk/client-iam";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimIam } from "../../../sim-iam.js";
+import {
+  SimIamDeleteConflict,
+  SimIamNoSuchEntity,
+} from "../../../error/sim-iam.error.js";
+import type { SimIamRoleName } from "../../../role/sim-iam-role.js";
+
+const trustPolicy = JSON.stringify({
+  Version: "2012-10-17",
+  Statement: {
+    Effect: "Allow",
+    Principal: { Service: "lambda.amazonaws.com" },
+    Action: "sts:AssumeRole",
+  },
+});
+
+async function givenRole(simIam: SimIam, roleName: string): Promise<void> {
+  await simIam.createRole(
+    new CreateRoleCommand({
+      RoleName: roleName,
+      AssumeRolePolicyDocument: trustPolicy,
+    }),
+  );
+}
+
+describe("IAM DeleteRoleCommand", () => {
+  it("deletes a Role that has no policies on it", async () => {
+    // Given a Role with nothing attached to it.
+    const simIam = new SimIam();
+    await givenRole(simIam, "BareRole");
+
+    // When the Role is deleted.
+    await simIam.deleteRole(new DeleteRoleCommand({ RoleName: "BareRole" }));
+
+    // Then IAM no longer has it.
+    assertUndefined(simIam.roles.get("BareRole" as SimIamRoleName));
+
+    const error = await assertThrowsErrorAsync(async () =>
+      simIam.getRole(new GetRoleCommand({ RoleName: "BareRole" })),
+    );
+    assertInstanceOf(error, SimIamNoSuchEntity);
+  });
+
+  it("refuses a Role that still has an inline policy", async () => {
+    // Given a Role carrying an inline policy.
+    const simIam = new SimIam();
+    await givenRole(simIam, "InlinePolicyRole");
+    await simIam.putRolePolicy(
+      new PutRolePolicyCommand({
+        RoleName: "InlinePolicyRole",
+        PolicyName: "ReadBuckets",
+        PolicyDocument: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: {
+            Effect: "Allow",
+            Action: "s3:ListBucket",
+            Resource: "*",
+          },
+        }),
+      }),
+    );
+
+    // When the Role is deleted.
+    const error = await assertThrowsErrorAsync(async () =>
+      simIam.deleteRole(
+        new DeleteRoleCommand({ RoleName: "InlinePolicyRole" }),
+      ),
+    );
+
+    // Then IAM refuses, as it does until the policies are removed.
+    assertInstanceOf(error, SimIamDeleteConflict);
+    assertIdentical(error.$metadata.httpStatusCode, 409);
+    assertStringIncludes(error.message, "must detach all policies first");
+  });
+
+  it("refuses a Role that still has a managed policy attached", async () => {
+    // Given a Role with a managed policy attached to it.
+    const simIam = new SimIam();
+    await givenRole(simIam, "AttachedPolicyRole");
+    const policy = await simIam.createPolicy(
+      new CreatePolicyCommand({
+        PolicyName: "ListBuckets",
+        PolicyDocument: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: {
+            Effect: "Allow",
+            Action: "s3:ListBucket",
+            Resource: "*",
+          },
+        }),
+      }),
+    );
+    await simIam.attachRolePolicy(
+      new AttachRolePolicyCommand({
+        RoleName: "AttachedPolicyRole",
+        PolicyArn: policy.Policy.Arn,
+      }),
+    );
+
+    // When the Role is deleted.
+    const error = await assertThrowsErrorAsync(async () =>
+      simIam.deleteRole(
+        new DeleteRoleCommand({ RoleName: "AttachedPolicyRole" }),
+      ),
+    );
+
+    // Then IAM refuses.
+    assertInstanceOf(error, SimIamDeleteConflict);
+  });
+
+  it("deletes a Role once its policies have been removed", async () => {
+    // Given a Role whose inline and managed policies have both been removed.
+    const simIam = new SimIam();
+    await givenRole(simIam, "EmptiedRole");
+    const policy = await simIam.createPolicy(
+      new CreatePolicyCommand({
+        PolicyName: "Emptied",
+        PolicyDocument: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: {
+            Effect: "Allow",
+            Action: "s3:ListBucket",
+            Resource: "*",
+          },
+        }),
+      }),
+    );
+    await simIam.attachRolePolicy(
+      new AttachRolePolicyCommand({
+        RoleName: "EmptiedRole",
+        PolicyArn: policy.Policy.Arn,
+      }),
+    );
+    await simIam.putRolePolicy(
+      new PutRolePolicyCommand({
+        RoleName: "EmptiedRole",
+        PolicyName: "Inline",
+        PolicyDocument: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: {
+            Effect: "Allow",
+            Action: "s3:ListBucket",
+            Resource: "*",
+          },
+        }),
+      }),
+    );
+
+    // When both are removed and the Role is deleted.
+    await simIam.detachRolePolicy(
+      new DetachRolePolicyCommand({
+        RoleName: "EmptiedRole",
+        PolicyArn: policy.Policy.Arn,
+      }),
+    );
+    await simIam.deleteRolePolicy(
+      new DeleteRolePolicyCommand({
+        RoleName: "EmptiedRole",
+        PolicyName: "Inline",
+      }),
+    );
+    await simIam.deleteRole(new DeleteRoleCommand({ RoleName: "EmptiedRole" }));
+
+    // Then the Role is gone.
+    assertUndefined(simIam.roles.get("EmptiedRole" as SimIamRoleName));
+  });
+
+  it("rejects a Role that does not exist", async () => {
+    // Given an IAM Account without the requested Role.
+    const simIam = new SimIam();
+
+    // When the missing Role is deleted.
+    const error = await assertThrowsErrorAsync(async () =>
+      simIam.deleteRole(new DeleteRoleCommand({ RoleName: "Absent" })),
+    );
+
+    // Then IAM answers with its missing-entity error.
+    assertInstanceOf(error, SimIamNoSuchEntity);
+  });
+
+  it("rejects a missing required RoleName input", async () => {
+    // Given an IAM Account.
+    const simIam = new SimIam();
+
+    // When DeleteRole is called without its required RoleName.
+    const error = await assertThrowsErrorAsync(async () =>
+      simIam.deleteRole(
+        // @ts-expect-error -- testing invalid input
+        new DeleteRoleCommand({}),
+      ),
+    );
+
+    // Then request validation identifies the missing input.
+    assertStringIncludes(error.message, "RoleName is required");
+  });
+});

--- a/src/service/iam/command/role/detach-role-policy/detach-role-policy.command.ts
+++ b/src/service/iam/command/role/detach-role-policy/detach-role-policy.command.ts
@@ -1,0 +1,21 @@
+/**
+ * Minimal structural sim IAM DetachRolePolicy command.
+ */
+export interface SimDetachRolePolicyCommand {
+  readonly input: SimDetachRolePolicyCommandInput;
+}
+
+/**
+ * Minimal structural sim IAM DetachRolePolicy input.
+ */
+export interface SimDetachRolePolicyCommandInput {
+  readonly RoleName?: string | undefined;
+  readonly PolicyArn?: string | undefined;
+}
+
+/**
+ * Minimal structural sim IAM DetachRolePolicy output.
+ *
+ * Real IAM answers a successful DetachRolePolicy with an empty response body.
+ */
+export type SimDetachRolePolicyCommandOutput = Record<string, never>;

--- a/src/service/iam/command/role/detach-role-policy/detach-role-policy.handler.ts
+++ b/src/service/iam/command/role/detach-role-policy/detach-role-policy.handler.ts
@@ -1,0 +1,77 @@
+import type { CommandHandler } from "../../../../../command/command-handler.js";
+import {
+  type BackgroundScheduler,
+  BackgroundTasks,
+} from "../../../../../util/background/background.js";
+import type { SimArn } from "../../../../aws/arn.js";
+import { SimIamNoSuchEntity } from "../../../error/sim-iam.error.js";
+import type { SimIamRole, SimIamRoleName } from "../../../role/sim-iam-role.js";
+import type {
+  SimDetachRolePolicyCommand,
+  SimDetachRolePolicyCommandOutput,
+} from "./detach-role-policy.command.js";
+
+interface DetachRolePolicyCommandHandlerProperties {
+  readonly roles: Map<SimIamRoleName, SimIamRole>;
+  readonly background?: BackgroundScheduler;
+}
+
+/**
+ * IAM DetachRolePolicyCommand handler.
+ *
+ * Detaching removes the attachment record rather than the managed policy
+ * itself, which is the other half of what AttachRolePolicy records. A policy
+ * that is not attached is refused, as real IAM has nothing to detach.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/iam/command/DetachRolePolicyCommand/
+ */
+export class DetachRolePolicyCommandHandler implements CommandHandler<
+  SimDetachRolePolicyCommand,
+  SimDetachRolePolicyCommandOutput
+> {
+  private readonly roles: Map<SimIamRoleName, SimIamRole>;
+  private readonly background: BackgroundScheduler;
+
+  constructor(properties: DetachRolePolicyCommandHandlerProperties) {
+    const { roles, background = new BackgroundTasks() } = properties;
+
+    this.roles = roles;
+    this.background = background;
+  }
+
+  /**
+   * Handle a DetachRolePolicyCommand from the SDK.
+   */
+  async handle(
+    command: SimDetachRolePolicyCommand,
+  ): Promise<SimDetachRolePolicyCommandOutput> {
+    const roleName = command.input.RoleName as SimIamRoleName | undefined;
+
+    if (roleName === undefined || roleName.length === 0) {
+      throw new Error("RoleName is required");
+    }
+
+    const policyArn = command.input.PolicyArn as SimArn | undefined;
+
+    if (policyArn === undefined || policyArn.length === 0) {
+      throw new Error("PolicyArn is required");
+    }
+
+    // Allow for potential non-deterministic sequencing of async events.
+    await this.background.sequence();
+
+    const role = this.roles.get(roleName);
+
+    if (role === undefined) {
+      throw new SimIamNoSuchEntity(`No IAM Role with name ${roleName}`);
+    }
+
+    if (!role.attachedPolicyArns.delete(policyArn)) {
+      throw new SimIamNoSuchEntity(
+        `IAM Policy ${policyArn} is not attached to Role ${roleName}`,
+      );
+    }
+
+    return {};
+  }
+}

--- a/src/service/iam/command/role/detach-role-policy/detach-role-policy.iso.test.ts
+++ b/src/service/iam/command/role/detach-role-policy/detach-role-policy.iso.test.ts
@@ -1,0 +1,139 @@
+import {
+  AttachRolePolicyCommand,
+  CreatePolicyCommand,
+  CreateRoleCommand,
+  DetachRolePolicyCommand,
+} from "@aws-sdk/client-iam";
+import {
+  assertFalse,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertTrue,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimIamNoSuchEntity } from "../../../error/sim-iam.error.js";
+import type { SimIamRoleName } from "../../../role/sim-iam-role.js";
+import { SimIam } from "../../../sim-iam.js";
+
+const trustPolicy = JSON.stringify({
+  Version: "2012-10-17",
+  Statement: {
+    Effect: "Allow",
+    Principal: { Service: "lambda.amazonaws.com" },
+    Action: "sts:AssumeRole",
+  },
+});
+
+const policyDocument = JSON.stringify({
+  Version: "2012-10-17",
+  Statement: { Effect: "Allow", Action: "s3:ListBucket", Resource: "*" },
+});
+
+describe("IAM DetachRolePolicyCommand", () => {
+  it("removes the attachment the Role carried", async () => {
+    // Given a Role with a managed policy attached.
+    const simIam = new SimIam();
+    await simIam.createRole(
+      new CreateRoleCommand({
+        RoleName: "AttachedRole",
+        AssumeRolePolicyDocument: trustPolicy,
+      }),
+    );
+    const policy = await simIam.createPolicy(
+      new CreatePolicyCommand({
+        PolicyName: "Detachable",
+        PolicyDocument: policyDocument,
+      }),
+    );
+    await simIam.attachRolePolicy(
+      new AttachRolePolicyCommand({
+        RoleName: "AttachedRole",
+        PolicyArn: policy.Policy.Arn,
+      }),
+    );
+
+    const role = simIam.roles.get("AttachedRole" as SimIamRoleName);
+    assertTrue(role?.attachedPolicyArns.has(policy.Policy.Arn));
+
+    // When the policy is detached.
+    await simIam.detachRolePolicy(
+      new DetachRolePolicyCommand({
+        RoleName: "AttachedRole",
+        PolicyArn: policy.Policy.Arn,
+      }),
+    );
+
+    // Then the attachment is gone, and the managed policy itself remains.
+    assertFalse(role.attachedPolicyArns.has(policy.Policy.Arn));
+    assertTrue(simIam.policies.has(policy.Policy.Arn));
+  });
+
+  it("rejects a policy the Role does not carry", async () => {
+    // Given a Role with nothing attached.
+    const simIam = new SimIam();
+    await simIam.createRole(
+      new CreateRoleCommand({
+        RoleName: "UnattachedRole",
+        AssumeRolePolicyDocument: trustPolicy,
+      }),
+    );
+
+    // When a policy that is not attached is detached.
+    const error = await assertThrowsErrorAsync(async () =>
+      simIam.detachRolePolicy(
+        new DetachRolePolicyCommand({
+          RoleName: "UnattachedRole",
+          PolicyArn: "arn:aws:iam::111111111111:policy/NeverAttached",
+        }),
+      ),
+    );
+
+    // Then IAM answers with its missing-entity error.
+    assertInstanceOf(error, SimIamNoSuchEntity);
+    assertStringIncludes(error.message, "is not attached to Role");
+  });
+
+  it("rejects a Role that does not exist", async () => {
+    // Given an IAM Account without the requested Role.
+    const simIam = new SimIam();
+
+    // When a policy is detached from the missing Role.
+    const error = await assertThrowsErrorAsync(async () =>
+      simIam.detachRolePolicy(
+        new DetachRolePolicyCommand({
+          RoleName: "Absent",
+          PolicyArn: "arn:aws:iam::111111111111:policy/Whatever",
+        }),
+      ),
+    );
+
+    // Then IAM answers with its missing-entity error.
+    assertInstanceOf(error, SimIamNoSuchEntity);
+  });
+
+  it("rejects missing required inputs", async () => {
+    // Given an IAM Account.
+    const simIam = new SimIam();
+
+    // When DetachRolePolicy is called without a RoleName.
+    const roleError = await assertThrowsErrorAsync(async () =>
+      simIam.detachRolePolicy(
+        // @ts-expect-error -- testing invalid input
+        new DetachRolePolicyCommand({ PolicyArn: "arn:aws:iam::1:policy/P" }),
+      ),
+    );
+
+    // And without a PolicyArn.
+    const policyError = await assertThrowsErrorAsync(async () =>
+      simIam.detachRolePolicy(
+        // @ts-expect-error -- testing invalid input
+        new DetachRolePolicyCommand({ RoleName: "SomeRole" }),
+      ),
+    );
+
+    // Then request validation identifies each missing input.
+    assertStringIncludes(roleError.message, "RoleName is required");
+    assertStringIncludes(policyError.message, "PolicyArn is required");
+  });
+});

--- a/src/service/iam/command/role/sim-iam-role-command-handlers.ts
+++ b/src/service/iam/command/role/sim-iam-role-command-handlers.ts
@@ -28,6 +28,21 @@ import type {
   SimAttachRolePolicyCommand,
   SimAttachRolePolicyCommandOutput,
 } from "./attach-role-policy/attach-role-policy.command.js";
+import { DetachRolePolicyCommandHandler } from "./detach-role-policy/detach-role-policy.handler.js";
+import type {
+  SimDetachRolePolicyCommand,
+  SimDetachRolePolicyCommandOutput,
+} from "./detach-role-policy/detach-role-policy.command.js";
+import { DeleteRoleCommandHandler } from "./delete-role/delete-role.handler.js";
+import type {
+  SimDeleteRoleCommand,
+  SimDeleteRoleCommandOutput,
+} from "./delete-role/delete-role.command.js";
+import { DeleteRolePolicyCommandHandler } from "../policy/delete-role-policy/delete-role-policy.handler.js";
+import type {
+  SimDeleteRolePolicyCommand,
+  SimDeleteRolePolicyCommandOutput,
+} from "../policy/delete-role-policy/delete-role-policy.command.js";
 
 interface SimIamRoleCommandHandlersProperties {
   readonly accountId: SimAwsAccountId;
@@ -146,6 +161,63 @@ export class SimIamRoleCommandHandlers {
       options?.caller,
     );
     const handler = new AttachRolePolicyCommandHandler({
+      roles: this.roles,
+      background: this.background,
+    });
+    return await handler.handle(command);
+  }
+
+  /**
+   * Handle a DetachRolePolicy command from the SDK.
+   */
+  async detachRolePolicy(
+    command: SimDetachRolePolicyCommand,
+    options?: SimIamRequestOptions,
+  ): Promise<SimDetachRolePolicyCommandOutput> {
+    this.authorizer.authorize(
+      "iam:DetachRolePolicy",
+      this.roleArn(command.input.RoleName),
+      options?.caller,
+    );
+    const handler = new DetachRolePolicyCommandHandler({
+      roles: this.roles,
+      background: this.background,
+    });
+    return await handler.handle(command);
+  }
+
+  /**
+   * Handle a DeleteRolePolicy command from the SDK.
+   */
+  async deleteRolePolicy(
+    command: SimDeleteRolePolicyCommand,
+    options?: SimIamRequestOptions,
+  ): Promise<SimDeleteRolePolicyCommandOutput> {
+    this.authorizer.authorize(
+      "iam:DeleteRolePolicy",
+      this.roleArn(command.input.RoleName),
+      options?.caller,
+    );
+    const handler = new DeleteRolePolicyCommandHandler({
+      roles: this.roles,
+      background: this.background,
+    });
+    return await handler.handle(command);
+  }
+
+  /**
+   * Handle a DeleteRole command from the SDK.
+   */
+  async deleteRole(
+    command: SimDeleteRoleCommand,
+    options?: SimIamRequestOptions,
+  ): Promise<SimDeleteRoleCommandOutput> {
+    this.authorizer.authorize(
+      "iam:DeleteRole",
+      this.roleArn(command.input.RoleName),
+      options?.caller,
+    );
+    const handler = new DeleteRoleCommandHandler({
       roles: this.roles,
       background: this.background,
     });

--- a/src/service/iam/command/sim-iam-command-handlers.ts
+++ b/src/service/iam/command/sim-iam-command-handlers.ts
@@ -60,6 +60,7 @@ export class SimIamCommandHandlers {
     this.policies = new SimIamPolicyCommandHandlers({
       accountId: properties.accountId,
       policies: properties.policies,
+      roles: properties.roles,
       users: properties.users,
       background: properties.background,
       authorizer,

--- a/src/service/iam/command/sim-iam-command.types.ts
+++ b/src/service/iam/command/sim-iam-command.types.ts
@@ -1,0 +1,67 @@
+/**
+ * The structural command and output types of every simulated IAM operation.
+ *
+ * Collected here so the service facade can name them in one import, rather
+ * than repeating a per-command import list.
+ */
+
+export type {
+  SimCreatePolicyCommand,
+  SimCreatePolicyCommandOutput,
+} from "./policy/create-policy/create-policy.command.js";
+export type {
+  SimDeletePolicyCommand,
+  SimDeletePolicyCommandOutput,
+} from "./policy/delete-policy/delete-policy.command.js";
+export type {
+  SimDeleteRolePolicyCommand,
+  SimDeleteRolePolicyCommandOutput,
+} from "./policy/delete-role-policy/delete-role-policy.command.js";
+export type {
+  SimGetPolicyCommand,
+  SimGetPolicyCommandOutput,
+} from "./policy/get-policy/get-policy.command.js";
+export type {
+  SimListPoliciesCommand,
+  SimListPoliciesCommandOutput,
+} from "./policy/list-policies/list-policies.command.js";
+export type {
+  SimPutRolePolicyCommand,
+  SimPutRolePolicyCommandOutput,
+} from "./policy/put-role-policy/put-role-policy.command.js";
+export type {
+  SimPutUserPolicyCommand,
+  SimPutUserPolicyCommandOutput,
+} from "./policy/put-user-policy/put-user-policy.command.js";
+export type {
+  SimAttachRolePolicyCommand,
+  SimAttachRolePolicyCommandOutput,
+} from "./role/attach-role-policy/attach-role-policy.command.js";
+export type {
+  SimCreateRoleCommand,
+  SimCreateRoleCommandOutput,
+} from "./role/create-role/create-role.command.js";
+export type {
+  SimDeleteRoleCommand,
+  SimDeleteRoleCommandOutput,
+} from "./role/delete-role/delete-role.command.js";
+export type {
+  SimDetachRolePolicyCommand,
+  SimDetachRolePolicyCommandOutput,
+} from "./role/detach-role-policy/detach-role-policy.command.js";
+export type {
+  SimGetRoleCommand,
+  SimGetRoleCommandOutput,
+} from "./role/get-role/get-role.command.js";
+export type {
+  SimListRolesCommand,
+  SimListRolesCommandOutput,
+} from "./role/list-roles/list-roles.command.js";
+export type {
+  SimCreateAccessKeyCommand,
+  SimCreateAccessKeyCommandOutput,
+} from "./user/create-access-key/create-access-key.command.js";
+export type {
+  SimCreateUserCommand,
+  SimCreateUserCommandOutput,
+} from "./user/create-user/create-user.command.js";

--- a/src/service/iam/error/sim-iam.error.ts
+++ b/src/service/iam/error/sim-iam.error.ts
@@ -84,6 +84,21 @@ export class SimIamEntityAlreadyExists extends SimIamError {
 }
 
 /**
+ * Simulated IAM DeleteConflict error.
+ *
+ * Real IAM refuses to delete an entity something still depends on, which is
+ * how a Role with policies on it and a managed policy that is still attached
+ * are both refused. The caller detaches first and deletes after.
+ */
+export class SimIamDeleteConflict extends SimIamError {
+  public override readonly name = "DeleteConflict";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 409 });
+  }
+}
+
+/**
  * Simulated IAM InvalidMarker error.
  */
 export class SimIamInvalidMarkerException extends SimIamError {

--- a/src/service/iam/sdk/sim-iam-sdk-command-router.iso.test.ts
+++ b/src/service/iam/sdk/sim-iam-sdk-command-router.iso.test.ts
@@ -5,7 +5,11 @@ import {
   CreatePolicyCommand,
   CreateRoleCommand,
   CreateUserCommand,
+  DeletePolicyCommand,
   DeleteRoleCommand,
+  DeleteRolePolicyCommand,
+  DeleteUserCommand,
+  DetachRolePolicyCommand,
   GetPolicyCommand,
   GetRoleCommand,
   IAMClient,
@@ -65,6 +69,69 @@ describe("simulated IAM SDK Command routing", () => {
         PolicyDocument: allowAllPolicyDocument,
       }),
     );
+  });
+
+  it("round-trips the removal Commands through an intercepted client", async () => {
+    using simSdk = new SimSdk();
+    const client = new IAMClient({ region: "us-east-1" });
+    simSdk.intercept(client);
+
+    await client.send(
+      new CreateRoleCommand({
+        RoleName: "RemovableRole",
+        AssumeRolePolicyDocument: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: {
+            Effect: "Allow",
+            Principal: { Service: "lambda.amazonaws.com" },
+            Action: "sts:AssumeRole",
+          },
+        }),
+      }),
+    );
+    const policyCreation = await client.send(
+      new CreatePolicyCommand({
+        PolicyName: "RemovablePolicy",
+        PolicyDocument: allowAllPolicyDocument,
+      }),
+    );
+    assertNonNullable(policyCreation.Policy?.Arn);
+    await client.send(
+      new AttachRolePolicyCommand({
+        RoleName: "RemovableRole",
+        PolicyArn: policyCreation.Policy.Arn,
+      }),
+    );
+    await client.send(
+      new PutRolePolicyCommand({
+        RoleName: "RemovableRole",
+        PolicyName: "inline-policy",
+        PolicyDocument: allowAllPolicyDocument,
+      }),
+    );
+
+    // The Role's policies come off first, as real IAM requires.
+    await client.send(
+      new DetachRolePolicyCommand({
+        RoleName: "RemovableRole",
+        PolicyArn: policyCreation.Policy.Arn,
+      }),
+    );
+    await client.send(
+      new DeleteRolePolicyCommand({
+        RoleName: "RemovableRole",
+        PolicyName: "inline-policy",
+      }),
+    );
+    await client.send(new DeleteRoleCommand({ RoleName: "RemovableRole" }));
+    await client.send(
+      new DeletePolicyCommand({ PolicyArn: policyCreation.Policy.Arn }),
+    );
+
+    const error = await assertThrowsErrorAsync(async () =>
+      client.send(new GetRoleCommand({ RoleName: "RemovableRole" })),
+    );
+    assertStringIncludes(error.message, "No IAM Role named RemovableRole");
   });
 
   it("round-trips managed Policy Commands through an intercepted client", async () => {
@@ -166,10 +233,10 @@ describe("simulated IAM SDK Command routing", () => {
     simSdk.intercept(client);
 
     const error = await assertThrowsErrorAsync(async () => {
-      await client.send(new DeleteRoleCommand({ RoleName: "InterceptRole" }));
+      await client.send(new DeleteUserCommand({ UserName: "InterceptUser" }));
     });
 
-    assertStringIncludes(error.message, "DeleteRoleCommand");
+    assertStringIncludes(error.message, "DeleteUserCommand");
     assertStringIncludes(error.message, "CreateRoleCommand");
   });
 });

--- a/src/service/iam/sdk/sim-iam-sdk-command-router.ts
+++ b/src/service/iam/sdk/sim-iam-sdk-command-router.ts
@@ -4,6 +4,10 @@ import {
   type SimSdkCommandRouter,
 } from "../../../sdk/index.js";
 import type { SimCreatePolicyCommand } from "../command/policy/create-policy/create-policy.command.js";
+import type { SimDeletePolicyCommand } from "../command/policy/delete-policy/delete-policy.command.js";
+import type { SimDeleteRolePolicyCommand } from "../command/policy/delete-role-policy/delete-role-policy.command.js";
+import type { SimDeleteRoleCommand } from "../command/role/delete-role/delete-role.command.js";
+import type { SimDetachRolePolicyCommand } from "../command/role/detach-role-policy/detach-role-policy.command.js";
 import type { SimGetPolicyCommand } from "../command/policy/get-policy/get-policy.command.js";
 import type { SimListPoliciesCommand } from "../command/policy/list-policies/list-policies.command.js";
 import type { SimPutRolePolicyCommand } from "../command/policy/put-role-policy/put-role-policy.command.js";
@@ -29,6 +33,38 @@ export class SimIamSdkCommandRouter implements SimSdkCommandRouter {
         async (command, context): Promise<unknown> =>
           await simIam.attachRolePolicy(
             command as SimAttachRolePolicyCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "DetachRolePolicyCommand",
+        async (command, context): Promise<unknown> =>
+          await simIam.detachRolePolicy(
+            command as SimDetachRolePolicyCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "DeleteRoleCommand",
+        async (command, context): Promise<unknown> =>
+          await simIam.deleteRole(
+            command as SimDeleteRoleCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "DeleteRolePolicyCommand",
+        async (command, context): Promise<unknown> =>
+          await simIam.deleteRolePolicy(
+            command as SimDeleteRolePolicyCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "DeletePolicyCommand",
+        async (command, context): Promise<unknown> =>
+          await simIam.deletePolicy(
+            command as SimDeletePolicyCommand,
             simSdkCallerOptions(context),
           ),
       ],

--- a/src/service/iam/sim-iam.ts
+++ b/src/service/iam/sim-iam.ts
@@ -1,54 +1,11 @@
 import type { SimArn } from "../aws/arn.js";
 import type { SimAwsAccountId } from "../aws/sim-aws-account.js";
-import type {
-  SimCreatePolicyCommand,
-  SimCreatePolicyCommandOutput,
-} from "./command/policy/create-policy/create-policy.command.js";
 import type { SimIamManagedPolicy } from "./policy/sim-iam-policy.js";
-import type {
-  SimGetPolicyCommand,
-  SimGetPolicyCommandOutput,
-} from "./command/policy/get-policy/get-policy.command.js";
-import type {
-  SimListPoliciesCommand,
-  SimListPoliciesCommandOutput,
-} from "./command/policy/list-policies/list-policies.command.js";
-import type {
-  SimCreateRoleCommand,
-  SimCreateRoleCommandOutput,
-} from "./command/role/create-role/create-role.command.js";
-import type {
-  SimGetRoleCommand,
-  SimGetRoleCommandOutput,
-} from "./command/role/get-role/get-role.command.js";
 import type { SimIamRole, SimIamRoleName } from "./role/sim-iam-role.js";
-import type {
-  SimListRolesCommand,
-  SimListRolesCommandOutput,
-} from "./command/role/list-roles/list-roles.command.js";
 import type { SimIamAuthorizationInput } from "./authorize/context/sim-iam-auth-z-context-builder.js";
 import type { SimIamPolicyDecision } from "./authorize/sim-iam-decision.js";
-import type {
-  SimPutRolePolicyCommand,
-  SimPutRolePolicyCommandOutput,
-} from "./command/policy/put-role-policy/put-role-policy.command.js";
-import type {
-  SimAttachRolePolicyCommand,
-  SimAttachRolePolicyCommandOutput,
-} from "./command/role/attach-role-policy/attach-role-policy.command.js";
-import type {
-  SimCreateUserCommand,
-  SimCreateUserCommandOutput,
-} from "./command/user/create-user/create-user.command.js";
-import type {
-  SimCreateAccessKeyCommand,
-  SimCreateAccessKeyCommandOutput,
-} from "./command/user/create-access-key/create-access-key.command.js";
+import type * as simIamCommands from "./command/sim-iam-command.types.js";
 import type { SimIamRequestOptions } from "./command/sim-iam-request-options.js";
-import type {
-  SimPutUserPolicyCommand,
-  SimPutUserPolicyCommandOutput,
-} from "./command/policy/put-user-policy/put-user-policy.command.js";
 import { SimIamCloudFormationResourceFactory } from "./cfn/sim-cfn-iam-resource-factory.js";
 import type { SimCfnServiceResourceFactory } from "../cloudformation/resource/factory/sim-cfn-resource-factory.type.js";
 import type { SimIamInterServiceAuthZ } from "./authorize/sim-iam-inter-service-auth-z.js";
@@ -140,9 +97,9 @@ export class SimIam
    * Handle a Create Policy Command from the SDK.
    */
   async createPolicy(
-    command: SimCreatePolicyCommand,
+    command: simIamCommands.SimCreatePolicyCommand,
     options?: SimIamRequestOptions,
-  ): Promise<SimCreatePolicyCommandOutput> {
+  ): Promise<simIamCommands.SimCreatePolicyCommandOutput> {
     return await this.commands.policies.createPolicy(command, options);
   }
 
@@ -150,9 +107,9 @@ export class SimIam
    * Handle a Get Policy Command from the SDK.
    */
   async getPolicy(
-    command: SimGetPolicyCommand,
+    command: simIamCommands.SimGetPolicyCommand,
     options?: SimIamRequestOptions,
-  ): Promise<SimGetPolicyCommandOutput> {
+  ): Promise<simIamCommands.SimGetPolicyCommandOutput> {
     return await this.commands.policies.getPolicy(command, options);
   }
 
@@ -160,9 +117,9 @@ export class SimIam
    * Handle a List Policies Command from the SDK.
    */
   async listPolicies(
-    command: SimListPoliciesCommand,
+    command: simIamCommands.SimListPoliciesCommand,
     options?: SimIamRequestOptions,
-  ): Promise<SimListPoliciesCommandOutput> {
+  ): Promise<simIamCommands.SimListPoliciesCommandOutput> {
     return await this.commands.policies.listPolicies(command, options);
   }
 
@@ -170,9 +127,9 @@ export class SimIam
    * Handle a Put Role Policy Command from the SDK.
    */
   async putRolePolicy(
-    command: SimPutRolePolicyCommand,
+    command: simIamCommands.SimPutRolePolicyCommand,
     options?: SimIamRequestOptions,
-  ): Promise<SimPutRolePolicyCommandOutput> {
+  ): Promise<simIamCommands.SimPutRolePolicyCommandOutput> {
     return await this.commands.roles.putRolePolicy(command, options);
   }
 
@@ -180,9 +137,9 @@ export class SimIam
    * Handle an IAM PutUserPolicy command.
    */
   async putUserPolicy(
-    command: SimPutUserPolicyCommand,
+    command: simIamCommands.SimPutUserPolicyCommand,
     options?: SimIamRequestOptions,
-  ): Promise<SimPutUserPolicyCommandOutput> {
+  ): Promise<simIamCommands.SimPutUserPolicyCommandOutput> {
     return await this.commands.policies.putUserPolicy(command, options);
   }
 
@@ -190,9 +147,9 @@ export class SimIam
    * Handle a Create Role Command from the SDK.
    */
   async createRole(
-    command: SimCreateRoleCommand,
+    command: simIamCommands.SimCreateRoleCommand,
     options?: SimIamRequestOptions,
-  ): Promise<SimCreateRoleCommandOutput> {
+  ): Promise<simIamCommands.SimCreateRoleCommandOutput> {
     return await this.commands.roles.createRole(command, options);
   }
 
@@ -200,19 +157,59 @@ export class SimIam
    * Handle an Attach Role Policy Command from the SDK.
    */
   async attachRolePolicy(
-    command: SimAttachRolePolicyCommand,
+    command: simIamCommands.SimAttachRolePolicyCommand,
     options?: SimIamRequestOptions,
-  ): Promise<SimAttachRolePolicyCommandOutput> {
+  ): Promise<simIamCommands.SimAttachRolePolicyCommandOutput> {
     return await this.commands.roles.attachRolePolicy(command, options);
+  }
+
+  /**
+   * Handle a Detach Role Policy Command from the SDK.
+   */
+  async detachRolePolicy(
+    command: simIamCommands.SimDetachRolePolicyCommand,
+    options?: SimIamRequestOptions,
+  ): Promise<simIamCommands.SimDetachRolePolicyCommandOutput> {
+    return await this.commands.roles.detachRolePolicy(command, options);
+  }
+
+  /**
+   * Handle a Delete Role Policy Command from the SDK.
+   */
+  async deleteRolePolicy(
+    command: simIamCommands.SimDeleteRolePolicyCommand,
+    options?: SimIamRequestOptions,
+  ): Promise<simIamCommands.SimDeleteRolePolicyCommandOutput> {
+    return await this.commands.roles.deleteRolePolicy(command, options);
+  }
+
+  /**
+   * Handle a Delete Role Command from the SDK.
+   */
+  async deleteRole(
+    command: simIamCommands.SimDeleteRoleCommand,
+    options?: SimIamRequestOptions,
+  ): Promise<simIamCommands.SimDeleteRoleCommandOutput> {
+    return await this.commands.roles.deleteRole(command, options);
+  }
+
+  /**
+   * Handle a Delete Policy Command from the SDK.
+   */
+  async deletePolicy(
+    command: simIamCommands.SimDeletePolicyCommand,
+    options?: SimIamRequestOptions,
+  ): Promise<simIamCommands.SimDeletePolicyCommandOutput> {
+    return await this.commands.policies.deletePolicy(command, options);
   }
 
   /**
    * Handle a Get Role Command from the SDK.
    */
   async getRole(
-    command: SimGetRoleCommand,
+    command: simIamCommands.SimGetRoleCommand,
     options?: SimIamRequestOptions,
-  ): Promise<SimGetRoleCommandOutput> {
+  ): Promise<simIamCommands.SimGetRoleCommandOutput> {
     return await this.commands.roles.getRole(command, options);
   }
 
@@ -220,9 +217,9 @@ export class SimIam
    * Handle a List Roles Command from the SDK.
    */
   async listRoles(
-    command: SimListRolesCommand,
+    command: simIamCommands.SimListRolesCommand,
     options?: SimIamRequestOptions,
-  ): Promise<SimListRolesCommandOutput> {
+  ): Promise<simIamCommands.SimListRolesCommandOutput> {
     return await this.commands.roles.listRoles(command, options);
   }
 
@@ -230,9 +227,9 @@ export class SimIam
    * Handle an IAM CreateUser command.
    */
   async createUser(
-    command: SimCreateUserCommand,
+    command: simIamCommands.SimCreateUserCommand,
     options?: SimIamRequestOptions,
-  ): Promise<SimCreateUserCommandOutput> {
+  ): Promise<simIamCommands.SimCreateUserCommandOutput> {
     return await this.commands.users.createUser(command, options);
   }
 
@@ -240,9 +237,9 @@ export class SimIam
    * Handle an IAM CreateAccessKey command.
    */
   async createAccessKey(
-    command: SimCreateAccessKeyCommand,
+    command: simIamCommands.SimCreateAccessKeyCommand,
     options?: SimIamRequestOptions,
-  ): Promise<SimCreateAccessKeyCommandOutput> {
+  ): Promise<simIamCommands.SimCreateAccessKeyCommandOutput> {
     return await this.commands.users.createAccessKey(command, options);
   }
 

--- a/src/service/lambda/command/delete-function/delete-function-authorizer.ts
+++ b/src/service/lambda/command/delete-function/delete-function-authorizer.ts
@@ -1,0 +1,42 @@
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+
+interface DeleteFunctionAuthorizerProperties {
+  readonly iam: SimIamInterServiceAuthZ;
+}
+
+/**
+ * Applies IAM authorization to a Lambda DeleteFunction request.
+ *
+ * AWS maps the DeleteFunction API operation to the lambda:DeleteFunction IAM
+ * action. The resource is the function ARN being deleted.
+ */
+export class DeleteFunctionAuthorizer {
+  private static readonly action = "lambda:DeleteFunction";
+
+  private readonly iam: SimIamInterServiceAuthZ;
+
+  constructor(properties: DeleteFunctionAuthorizerProperties) {
+    this.iam = properties.iam;
+  }
+
+  /**
+   * Ensure the caller may delete the Lambda function with the given ARN.
+   */
+  authorize(functionArn: string, caller?: SimAwsCaller): void {
+    const decision = this.iam.authorize({
+      action: DeleteFunctionAuthorizer.action,
+      resource: functionArn,
+      caller,
+    });
+
+    if (decision.isDenied) {
+      throw new SimIamAccessDenied({
+        principal: decision.caller.principal,
+        action: DeleteFunctionAuthorizer.action,
+        resource: functionArn,
+      });
+    }
+  }
+}

--- a/src/service/lambda/command/delete-function/delete-function.command.ts
+++ b/src/service/lambda/command/delete-function/delete-function.command.ts
@@ -1,0 +1,25 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+
+/**
+ * Minimal structural sim Lambda DeleteFunction command.
+ */
+export interface SimDeleteFunctionCommand {
+  readonly input: SimDeleteFunctionCommandInput;
+}
+
+/**
+ * Minimal structural sim Lambda DeleteFunction input.
+ */
+export interface SimDeleteFunctionCommandInput {
+  readonly FunctionName?: string | undefined;
+}
+
+/**
+ * Minimal structural sim Lambda DeleteFunction output.
+ *
+ * Real Lambda answers a successful DeleteFunction with 204 No Content, so
+ * there is nothing in the body to model.
+ */
+export interface SimDeleteFunctionCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/lambda/command/delete-function/delete-function.handler.ts
+++ b/src/service/lambda/command/delete-function/delete-function.handler.ts
@@ -1,0 +1,112 @@
+import type { CommandHandler } from "../../../../command/command-handler.js";
+import {
+  type BackgroundScheduler,
+  BackgroundTasks,
+} from "../../../../util/background/background.js";
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
+import {
+  SimIamAllowAllAuth,
+  type SimIamInterServiceAuthZ,
+} from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { SimLambdaResourceNotFoundException } from "../../error/sim-lambda.error.js";
+import {
+  type SimLambdaFunctionMap,
+  type SimLambdaFunctionName,
+  simLambdaFunctionArn,
+} from "../../function/sim-lambda-function.js";
+import type { SimLambdaFunctionUrlStore } from "../../function/url/sim-lambda-function-url-store.js";
+import { DeleteFunctionAuthorizer } from "./delete-function-authorizer.js";
+import type {
+  SimDeleteFunctionCommand,
+  SimDeleteFunctionCommandOutput,
+} from "./delete-function.command.js";
+
+interface DeleteFunctionCommandHandlerProperties {
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+  readonly functions: SimLambdaFunctionMap;
+  readonly functionUrls: SimLambdaFunctionUrlStore;
+  readonly iam?: SimIamInterServiceAuthZ;
+  readonly background?: BackgroundScheduler;
+}
+
+interface DeleteFunctionCommandHandlerOptions {
+  readonly caller?: SimAwsCaller;
+}
+
+/**
+ * Simulated Lambda DeleteFunctionCommand handler.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/lambda/command/DeleteFunctionCommand/
+ */
+export class DeleteFunctionCommandHandler implements CommandHandler<
+  SimDeleteFunctionCommand,
+  SimDeleteFunctionCommandOutput
+> {
+  private readonly accountRegionScope: SimAwsAccountRegionScope;
+  private readonly functions: SimLambdaFunctionMap;
+  private readonly functionUrls: SimLambdaFunctionUrlStore;
+  private readonly authorizer: DeleteFunctionAuthorizer;
+  private readonly background: BackgroundScheduler;
+
+  constructor(properties: DeleteFunctionCommandHandlerProperties) {
+    const {
+      accountRegionScope,
+      functions,
+      functionUrls,
+      iam = new SimIamAllowAllAuth(),
+      background = new BackgroundTasks(),
+    } = properties;
+
+    this.accountRegionScope = accountRegionScope;
+    this.functions = functions;
+    this.functionUrls = functionUrls;
+    this.authorizer = new DeleteFunctionAuthorizer({ iam });
+    this.background = background;
+  }
+
+  /**
+   * Delete a function, and the Function URL that belongs to it.
+   *
+   * A function's URL is part of the function on real Lambda, so it goes with
+   * it. Event source mappings are not: real Lambda leaves a mapping in place
+   * pointing at a function that is gone, and simulated polling treats a missing
+   * function as nothing to deliver to.
+   *
+   * The resource policy the Add Permission command builds is held on the
+   * function itself, so it goes at the same time.
+   */
+  async handle(
+    command: SimDeleteFunctionCommand,
+    options?: DeleteFunctionCommandHandlerOptions,
+  ): Promise<SimDeleteFunctionCommandOutput> {
+    assertDefined(
+      command.input.FunctionName,
+      "DeleteFunctionCommand.input.FunctionName required",
+    );
+
+    // Allow for potential non-deterministic sequencing of async events.
+    await this.background.sequence();
+
+    const functionName = command.input.FunctionName as SimLambdaFunctionName;
+    const functionArn = simLambdaFunctionArn(
+      this.accountRegionScope,
+      functionName,
+    );
+    this.authorizer.authorize(functionArn, options?.caller);
+
+    const simFunction = this.functions.get(functionName);
+
+    if (simFunction === undefined) {
+      throw new SimLambdaResourceNotFoundException(
+        `Function not found: ${functionArn}`,
+      );
+    }
+
+    this.functionUrls.deleteIfPresent(simFunction);
+    this.functions.delete(functionName);
+
+    return { $metadata: {} };
+  }
+}

--- a/src/service/lambda/command/delete-function/delete-function.iso.test.ts
+++ b/src/service/lambda/command/delete-function/delete-function.iso.test.ts
@@ -1,0 +1,184 @@
+import { CreateRoleCommand } from "@aws-sdk/client-iam";
+import {
+  CreateFunctionCommand,
+  CreateFunctionUrlConfigCommand,
+  DeleteFunctionCommand,
+  GetFunctionCommand,
+  GetFunctionUrlConfigCommand,
+} from "@aws-sdk/client-lambda";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { makeSimAwsAccountId } from "../../../aws/sim-aws-account.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+import { SimLambdaResourceNotFoundException } from "../../error/sim-lambda.error.js";
+import { makeLambdaZipFileInput } from "../../function/code/lambda-zip-file-input.js";
+import { SimLambda } from "../../sim-lambda.js";
+
+const roleArn = "arn:aws:iam::111111111111:role/FunctionRole";
+
+async function givenFunction(
+  simLambda: SimLambda,
+  functionName: string,
+): Promise<void> {
+  await simLambda.createFunction(
+    new CreateFunctionCommand({
+      FunctionName: functionName,
+      Role: roleArn,
+      Handler: "index.handler",
+      Runtime: "nodejs22.x",
+      Code: { ZipFile: makeLambdaZipFileInput(() => null) },
+    }),
+  );
+}
+
+describe("Lambda DeleteFunctionCommand", () => {
+  it("deletes a function so it can no longer be read", async () => {
+    // Given an existing function.
+    const simLambda = new SimLambda();
+    await givenFunction(simLambda, "disposable");
+
+    // When the function is deleted.
+    await simLambda.deleteFunction(
+      new DeleteFunctionCommand({ FunctionName: "disposable" }),
+    );
+
+    // Then Lambda no longer has it.
+    assertUndefined(simLambda.getSimFunctionByName("disposable"));
+
+    const error = await assertThrowsErrorAsync(async () =>
+      simLambda.getFunction(
+        new GetFunctionCommand({ FunctionName: "disposable" }),
+      ),
+    );
+    assertInstanceOf(error, SimLambdaResourceNotFoundException);
+  });
+
+  it("deletes the Function URL that belongs to the function", async () => {
+    // Given a function with a Function URL.
+    const simLambda = new SimLambda();
+    await givenFunction(simLambda, "urled");
+    await simLambda.createFunctionUrlConfig(
+      new CreateFunctionUrlConfigCommand({
+        FunctionName: "urled",
+        AuthType: "NONE",
+      }),
+    );
+
+    // When the function is deleted.
+    await simLambda.deleteFunction(
+      new DeleteFunctionCommand({ FunctionName: "urled" }),
+    );
+
+    // Then the URL goes with it, as a Function URL is part of the function.
+    assertUndefined(simLambda.getSimFunctionUrl("urled"));
+
+    const error = await assertThrowsErrorAsync(async () =>
+      simLambda.getFunctionUrlConfig(
+        new GetFunctionUrlConfigCommand({ FunctionName: "urled" }),
+      ),
+    );
+    assertInstanceOf(error, SimLambdaResourceNotFoundException);
+  });
+
+  it("frees the function name for a new function", async () => {
+    // Given a function that has been deleted.
+    const simLambda = new SimLambda();
+    await givenFunction(simLambda, "recreated");
+    await simLambda.deleteFunction(
+      new DeleteFunctionCommand({ FunctionName: "recreated" }),
+    );
+
+    // When a new function is created under the same name.
+    await givenFunction(simLambda, "recreated");
+
+    // Then it is there, because the name was released.
+    const output = await simLambda.getFunction(
+      new GetFunctionCommand({ FunctionName: "recreated" }),
+    );
+    assertIdentical(output.Configuration.FunctionName, "recreated");
+  });
+
+  it("throws on a function that does not exist", async () => {
+    // Given a simulated Lambda without the requested function.
+    const simAws = new SimAws();
+
+    // When the missing function is deleted.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws
+        .lambda()
+        .deleteFunction(new DeleteFunctionCommand({ FunctionName: "missing" })),
+    );
+
+    // Then Lambda answers with its not-found error, naming the function ARN.
+    assertInstanceOf(error, SimLambdaResourceNotFoundException);
+    assertStringIncludes(
+      error.message,
+      `arn:aws:lambda:${simAws.defaultRegionName}:` +
+        `${simAws.defaultAccountId}:function:missing`,
+    );
+  });
+
+  it("rejects a missing required FunctionName input", async () => {
+    // Given a simulated Lambda.
+    const simLambda = new SimLambda();
+
+    // When DeleteFunction is called without its required FunctionName.
+    const error = await assertThrowsErrorAsync(async () =>
+      simLambda.deleteFunction(
+        // @ts-expect-error -- testing invalid input
+        new DeleteFunctionCommand({}),
+      ),
+    );
+
+    // Then request validation identifies the missing input.
+    assertStringIncludes(
+      error.message,
+      "DeleteFunctionCommand.input.FunctionName",
+    );
+  });
+
+  it("denies a caller without DeleteFunction permission", async () => {
+    // Given a function and a Role with no Lambda grant.
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws({ defaultAccountId: accountId });
+    const simLambda = simAws.lambda();
+
+    await givenFunction(simLambda, "protected-function");
+    const roleCreation = await simAws.iam().createRole(
+      new CreateRoleCommand({
+        RoleName: "UnprivilegedFunctionRemover",
+        AssumeRolePolicyDocument: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: {
+            Effect: "Allow",
+            Principal: { AWS: `arn:aws:iam::${accountId}:root` },
+            Action: "sts:AssumeRole",
+          },
+        }),
+      }),
+    );
+
+    // When the unprivileged Role deletes the function.
+    const error = await assertThrowsErrorAsync(async () =>
+      simLambda.deleteFunction(
+        new DeleteFunctionCommand({ FunctionName: "protected-function" }),
+        { caller: { kind: "arn", arn: roleCreation.Role.Arn } },
+      ),
+    );
+
+    // Then IAM denies the removal action, and the function stays.
+    assertInstanceOf(error, SimIamAccessDenied);
+    assertIdentical(error.action, "lambda:DeleteFunction");
+    assertInstanceOf(
+      simLambda.getSimFunctionByName("protected-function"),
+      Object,
+    );
+  });
+});

--- a/src/service/lambda/command/function/sim-lambda-function-commands.ts
+++ b/src/service/lambda/command/function/sim-lambda-function-commands.ts
@@ -7,11 +7,17 @@ import type { SimLambdaCodeStore } from "../../function/code/store/sim-lambda-co
 import type { SimLambdaVmSdkModuleProvider } from "../../function/code/vm/sdk/sim-lambda-vm-sdk-module-provider.js";
 import type { SimLambdaEnvironmentConflicts } from "../../function/environment/sim-lambda-environment-conflicts.js";
 import type { SimLambdaFunctionMap } from "../../function/sim-lambda-function.js";
+import type { SimLambdaFunctionUrlStore } from "../../function/url/sim-lambda-function-url-store.js";
 import { CreateFunctionCommandHandler } from "../create-function/create-function.handler.js";
 import type {
   SimCreateFunctionCommand,
   SimCreateFunctionCommandOutput,
 } from "../create-function/create-function.command.js";
+import { DeleteFunctionCommandHandler } from "../delete-function/delete-function.handler.js";
+import type {
+  SimDeleteFunctionCommand,
+  SimDeleteFunctionCommandOutput,
+} from "../delete-function/delete-function.command.js";
 import { GetFunctionCommandHandler } from "../get-function/get-function.handler.js";
 import type {
   SimGetFunctionCommand,
@@ -29,6 +35,7 @@ interface SimLambdaFunctionCommandsProperties {
   readonly iam: SimIamInterServiceAuthZ;
   readonly background: BackgroundScheduler;
   readonly runAsOwner: SimAwsRunAsOwner;
+  readonly functionUrls: SimLambdaFunctionUrlStore;
   readonly environmentConflicts: SimLambdaEnvironmentConflicts;
   readonly codeStore?: SimLambdaCodeStore | undefined;
   readonly vmSdkModuleProvider?: SimLambdaVmSdkModuleProvider | undefined;
@@ -73,6 +80,19 @@ export class SimLambdaFunctionCommands {
     options?: SimLambdaFunctionCommandOptions,
   ): Promise<SimGetFunctionCommandOutput> {
     return await new GetFunctionCommandHandler(this.properties).handle(
+      command,
+      options,
+    );
+  }
+
+  /**
+   * Delete a function, and the Function URL that belongs to it.
+   */
+  async delete(
+    command: SimDeleteFunctionCommand,
+    options?: SimLambdaFunctionCommandOptions,
+  ): Promise<SimDeleteFunctionCommandOutput> {
+    return await new DeleteFunctionCommandHandler(this.properties).handle(
       command,
       options,
     );

--- a/src/service/lambda/command/sim-lambda-command.types.ts
+++ b/src/service/lambda/command/sim-lambda-command.types.ts
@@ -34,6 +34,10 @@ export type {
   SimCreateFunctionUrlConfigCommandOutput,
 } from "./create-function-url-config/create-function-url-config.command.js";
 export type {
+  SimDeleteFunctionCommand,
+  SimDeleteFunctionCommandOutput,
+} from "./delete-function/delete-function.command.js";
+export type {
   SimDeleteFunctionUrlConfigCommand,
   SimDeleteFunctionUrlConfigCommandOutput,
 } from "./delete-function-url-config/delete-function-url-config.command.js";

--- a/src/service/lambda/function/url/sim-lambda-function-url-store.ts
+++ b/src/service/lambda/function/url/sim-lambda-function-url-store.ts
@@ -104,6 +104,18 @@ export class SimLambdaFunctionUrlStore {
   }
 
   /**
+   * Delete a function's Function URL when it has one.
+   *
+   * Deleting a function takes its URL with it, and a function without one is
+   * not an error there the way a DeleteFunctionUrlConfig request is.
+   */
+  deleteIfPresent(simFunction: SimLambdaFunction): void {
+    if (this.get(simFunction.name) !== undefined) {
+      this.delete(simFunction);
+    }
+  }
+
+  /**
    * Delete a function's Function URL, so its hostname stops resolving.
    */
   delete(simFunction: SimLambdaFunction): void {

--- a/src/service/lambda/sdk/sim-lambda-sdk-command-router.iso.test.ts
+++ b/src/service/lambda/sdk/sim-lambda-sdk-command-router.iso.test.ts
@@ -1,5 +1,6 @@
 import {
   CreateFunctionCommand,
+  DeleteFunctionCommand,
   GetFunctionCommand,
   InvokeCommand,
   LambdaClient,
@@ -62,6 +63,15 @@ describe("simulated Lambda SDK Command routing", () => {
       .lambda()
       .getFunction(new GetFunctionCommand({ FunctionName: "intercepted" }));
     assertIdentical(directGetOutput.Configuration.FunctionName, "intercepted");
+
+    // And deleting it through the client takes it out of that scope.
+    await client.send(
+      new DeleteFunctionCommand({ FunctionName: "intercepted" }),
+    );
+    const deletedError = await assertThrowsErrorAsync(async () =>
+      client.send(new GetFunctionCommand({ FunctionName: "intercepted" })),
+    );
+    assertStringIncludes(deletedError.message, "Function not found");
   });
 
   it("attributes handler execution to the function's execution Role", async () => {

--- a/src/service/lambda/sdk/sim-lambda-sdk-command-router.ts
+++ b/src/service/lambda/sdk/sim-lambda-sdk-command-router.ts
@@ -12,6 +12,7 @@ import type {
   SimListEventSourceMappingsCommand,
 } from "../command/event-source-mapping/event-source-mapping.command.js";
 import type { SimCreateFunctionUrlConfigCommand } from "../command/create-function-url-config/create-function-url-config.command.js";
+import type { SimDeleteFunctionCommand } from "../command/delete-function/delete-function.command.js";
 import type { SimDeleteFunctionUrlConfigCommand } from "../command/delete-function-url-config/delete-function-url-config.command.js";
 import type { SimGetFunctionCommand } from "../command/get-function/get-function.command.js";
 import type { SimGetFunctionUrlConfigCommand } from "../command/get-function-url-config/get-function-url-config.command.js";
@@ -75,6 +76,14 @@ export class SimLambdaSdkCommandRouter implements SimSdkCommandRouter {
         async (command, context): Promise<unknown> =>
           await simLambda.updateFunctionUrlConfig(
             command as SimUpdateFunctionUrlConfigCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "DeleteFunctionCommand",
+        async (command, context): Promise<unknown> =>
+          await simLambda.deleteFunction(
+            command as SimDeleteFunctionCommand,
             simSdkCallerOptions(context),
           ),
       ],

--- a/src/service/lambda/sim-lambda-commands.ts
+++ b/src/service/lambda/sim-lambda-commands.ts
@@ -121,6 +121,7 @@ export class SimLambdaCommands {
     this.functions = new SimLambdaFunctionCommands({
       accountRegionScope,
       functions: properties.functions,
+      functionUrls: this.functionUrlStore,
       iam,
       background,
       runAsOwner: properties.runAsOwner,

--- a/src/service/lambda/sim-lambda.ts
+++ b/src/service/lambda/sim-lambda.ts
@@ -67,6 +67,16 @@ export class SimLambda {
   }
 
   /**
+   * Handle a Delete Function Command from the SDK.
+   */
+  async deleteFunction(
+    command: simLambdaCommands.SimDeleteFunctionCommand,
+    options?: SimLambdaRequestOptions,
+  ): Promise<simLambdaCommands.SimDeleteFunctionCommandOutput> {
+    return await this.commands.functions.delete(command, options);
+  }
+
+  /**
    * Handle an Invoke Command from the SDK.
    */
   async invoke(

--- a/src/service/s3/bucket/sim-s3-bucket-access.ts
+++ b/src/service/s3/bucket/sim-s3-bucket-access.ts
@@ -1,0 +1,67 @@
+import { assertDefined } from "../../../util/type-guard/defined.js";
+import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+import { FilesystemS3BucketStorage } from "../storage/filesystem/s3-filesystem-storage.js";
+import { simS3BucketUrl } from "./sim-s3-endpoint-url.js";
+import type { SimS3Bucket, SimS3BucketName } from "./sim-s3-bucket.js";
+
+interface SimS3BucketAccessProperties {
+  readonly buckets: ReadonlyMap<SimS3BucketName, SimS3Bucket>;
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+}
+
+/**
+ * Reaching a Bucket in one simulated S3 scope by name.
+ *
+ * These are the conveniences a test or a local development setup uses rather
+ * than S3 operations an SDK caller would send, so they live here instead of
+ * alongside the command delegations on the service facade. Each of them starts
+ * by finding the Bucket, and says which name was missing when it is not there.
+ */
+export class SimS3BucketAccess {
+  private readonly buckets: ReadonlyMap<SimS3BucketName, SimS3Bucket>;
+  private readonly accountRegionScope: SimAwsAccountRegionScope;
+
+  constructor(properties: SimS3BucketAccessProperties) {
+    this.buckets = properties.buckets;
+    this.accountRegionScope = properties.accountRegionScope;
+  }
+
+  /**
+   * Get a Bucket by name, or fail naming the Bucket that is not there.
+   */
+  required(bucketName: SimS3BucketName | string): SimS3Bucket {
+    const bucket = this.buckets.get(bucketName as SimS3BucketName);
+    assertDefined(bucket, `Sim S3 Bucket named ${bucketName}`);
+
+    return bucket;
+  }
+
+  /**
+   * The simulated S3 REST API endpoint URL for one Bucket.
+   */
+  url(bucketName: SimS3BucketName | string): URL {
+    return simS3BucketUrl(
+      this.required(bucketName).bucketName,
+      this.accountRegionScope.regionName,
+    );
+  }
+
+  /**
+   * The simulated S3 static website URL for one Bucket.
+   */
+  websiteUrl(bucketName: SimS3BucketName | string): URL {
+    return this.required(bucketName).getWebsiteUrl();
+  }
+
+  /**
+   * Have a Bucket use a local filesystem directory for storage.
+   */
+  mountFilesystem(
+    bucketName: SimS3BucketName | string,
+    directoryPath: string,
+  ): void {
+    this.required(bucketName).configureSimStorage(
+      new FilesystemS3BucketStorage({ directoryPath }),
+    );
+  }
+}

--- a/src/service/s3/command/bucket/sim-s3-bucket-commands.ts
+++ b/src/service/s3/command/bucket/sim-s3-bucket-commands.ts
@@ -1,6 +1,7 @@
 import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
 import type { SimS3GlobalRegistry } from "../../sim-s3-global-registry.js";
 import { CreateBucketCommandHandler } from "../create-bucket/create-bucket.handler.js";
+import { DeleteBucketCommandHandler } from "../delete-bucket/delete-bucket.handler.js";
 import { ListBucketsCommandHandler } from "../list-buckets/list-buckets.handler.js";
 import { PutBucketWebsiteCommandHandler } from "../put-bucket-website/put-bucket-website.handler.js";
 import type { SimS3BucketCommandState } from "../sim-s3-bucket-command-state.js";
@@ -34,6 +35,19 @@ export class SimS3BucketCommands {
     options?: SimS3RequestOptions,
   ): Promise<simS3Commands.SimCreateBucketCommandOutput> {
     return await new CreateBucketCommandHandler(this.properties).handle(
+      command,
+      options,
+    );
+  }
+
+  /**
+   * Delete a Bucket from this scope and release its name globally.
+   */
+  async delete(
+    command: simS3Commands.SimDeleteBucketCommand,
+    options?: SimS3RequestOptions,
+  ): Promise<simS3Commands.SimDeleteBucketCommandOutput> {
+    return await new DeleteBucketCommandHandler(this.properties).handle(
       command,
       options,
     );

--- a/src/service/s3/command/delete-bucket/delete-bucket-authorizer.ts
+++ b/src/service/s3/command/delete-bucket/delete-bucket-authorizer.ts
@@ -1,0 +1,48 @@
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+import { simS3BucketArn } from "../../bucket/sim-s3-bucket-arn.js";
+import type { SimS3Bucket } from "../../bucket/sim-s3-bucket.js";
+import { simS3BucketResourcePolicies } from "../authorize/sim-s3-bucket-resource-policies.js";
+
+interface DeleteBucketAuthorizerProperties {
+  readonly iam: SimIamInterServiceAuthZ;
+}
+
+/**
+ * Applies IAM authorization to an S3 DeleteBucket request.
+ *
+ * Real S3 governs removing a Bucket with s3:DeleteBucket, which is a distinct
+ * action from the s3:CreateBucket that made it. The Bucket policy is consulted
+ * as well, because a Bucket policy can grant Bucket administration actions.
+ */
+export class DeleteBucketAuthorizer {
+  private static readonly action = "s3:DeleteBucket";
+
+  private readonly iam: SimIamInterServiceAuthZ;
+
+  constructor(properties: DeleteBucketAuthorizerProperties) {
+    this.iam = properties.iam;
+  }
+
+  /**
+   * Ensure the caller may delete the Bucket.
+   */
+  authorize(bucket: SimS3Bucket, caller?: SimAwsCaller): void {
+    const resource = simS3BucketArn(bucket.bucketName);
+    const decision = this.iam.authorize({
+      action: DeleteBucketAuthorizer.action,
+      resource,
+      caller,
+      resourcePolicies: simS3BucketResourcePolicies(bucket),
+    });
+
+    if (decision.isDenied) {
+      throw new SimIamAccessDenied({
+        principal: decision.caller.principal,
+        action: DeleteBucketAuthorizer.action,
+        resource,
+      });
+    }
+  }
+}

--- a/src/service/s3/command/delete-bucket/delete-bucket.command.ts
+++ b/src/service/s3/command/delete-bucket/delete-bucket.command.ts
@@ -1,0 +1,25 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+
+/**
+ * Minimal structural sim S3 DeleteBucket command.
+ */
+export interface SimDeleteBucketCommand {
+  readonly input: SimDeleteBucketCommandInput;
+}
+
+/**
+ * Minimal structural sim S3 DeleteBucket input.
+ */
+export interface SimDeleteBucketCommandInput {
+  readonly Bucket?: string | undefined;
+}
+
+/**
+ * Minimal structural sim S3 DeleteBucket output.
+ *
+ * Real S3 answers a successful DeleteBucket with 204 No Content, so there is
+ * nothing in the body to model.
+ */
+export interface SimDeleteBucketCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/s3/command/delete-bucket/delete-bucket.handler.ts
+++ b/src/service/s3/command/delete-bucket/delete-bucket.handler.ts
@@ -1,0 +1,106 @@
+import type { CommandHandler } from "../../../../command/command-handler.js";
+import {
+  type BackgroundScheduler,
+  BackgroundTasks,
+} from "../../../../util/background/background.js";
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import {
+  SimIamAllowAllAuth,
+  type SimIamInterServiceAuthZ,
+} from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import type {
+  SimS3Bucket,
+  SimS3BucketName,
+} from "../../bucket/sim-s3-bucket.js";
+import { SimS3BucketNotEmpty } from "../../error/sim-s3.error.js";
+import type { SimS3GlobalRegistry } from "../../sim-s3-global-registry.js";
+import { requireSimS3Bucket } from "../require-sim-s3-bucket.js";
+import { DeleteBucketAuthorizer } from "./delete-bucket-authorizer.js";
+import type {
+  SimDeleteBucketCommand,
+  SimDeleteBucketCommandOutput,
+} from "./delete-bucket.command.js";
+
+interface DeleteBucketCommandHandlerProperties {
+  readonly buckets: Map<SimS3BucketName, SimS3Bucket>;
+  readonly s3GlobalRegistry: SimS3GlobalRegistry;
+  readonly iam?: SimIamInterServiceAuthZ;
+  readonly background?: BackgroundScheduler;
+}
+
+interface DeleteBucketCommandHandlerOptions {
+  readonly caller?: SimAwsCaller;
+}
+
+/**
+ * Simulated S3 DeleteBucketCommand handler.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/s3/command/DeleteBucketCommand/
+ */
+export class DeleteBucketCommandHandler implements CommandHandler<
+  SimDeleteBucketCommand,
+  SimDeleteBucketCommandOutput
+> {
+  private readonly buckets: Map<SimS3BucketName, SimS3Bucket>;
+  private readonly s3GlobalRegistry: SimS3GlobalRegistry;
+  private readonly authorizer: DeleteBucketAuthorizer;
+  private readonly background: BackgroundScheduler;
+
+  constructor(properties: DeleteBucketCommandHandlerProperties) {
+    const {
+      buckets,
+      s3GlobalRegistry,
+      iam = new SimIamAllowAllAuth(),
+      background = new BackgroundTasks(),
+    } = properties;
+
+    this.buckets = buckets;
+    this.s3GlobalRegistry = s3GlobalRegistry;
+    this.authorizer = new DeleteBucketAuthorizer({ iam });
+    this.background = background;
+  }
+
+  /**
+   * Authorize and delete a Bucket.
+   *
+   * Real S3 only deletes an empty Bucket, and answers BucketNotEmpty otherwise
+   * rather than removing the Objects for the caller. That refusal is the reason
+   * a CloudFormation Stack holding a Bucket with Objects in it fails to delete,
+   * so it is worth keeping here.
+   *
+   * The Bucket name is released globally as well as in this scope, because S3
+   * Bucket names are globally unique and a deleted name can be claimed again.
+   */
+  async handle(
+    command: SimDeleteBucketCommand,
+    options?: DeleteBucketCommandHandlerOptions,
+  ): Promise<SimDeleteBucketCommandOutput> {
+    assertDefined(command.input.Bucket, "DeleteBucketCommand.input.Bucket");
+
+    const bucketName = command.input.Bucket as SimS3BucketName;
+    const bucket = requireSimS3Bucket(this.buckets, bucketName);
+
+    await this.background.sequence();
+
+    this.authorizer.authorize(bucket, options?.caller);
+    await this.assertEmpty(bucket);
+
+    this.buckets.delete(bucketName);
+    this.s3GlobalRegistry.deregisterBucket(bucketName);
+
+    return {
+      $metadata: {},
+    };
+  }
+
+  private async assertEmpty(bucket: SimS3Bucket): Promise<void> {
+    const objects = await bucket.listObjects();
+
+    if (objects.length > 0) {
+      throw new SimS3BucketNotEmpty(
+        `S3 Bucket ${bucket.bucketName} holds ${String(objects.length)} Objects`,
+      );
+    }
+  }
+}

--- a/src/service/s3/command/delete-bucket/delete-bucket.iso.test.ts
+++ b/src/service/s3/command/delete-bucket/delete-bucket.iso.test.ts
@@ -1,0 +1,191 @@
+import { CreateRoleCommand } from "@aws-sdk/client-iam";
+import {
+  CreateBucketCommand,
+  DeleteBucketCommand,
+  DeleteObjectCommand,
+  PutObjectCommand,
+} from "@aws-sdk/client-s3";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { makeSimAwsAccountId } from "../../../aws/sim-aws-account.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+import {
+  SimS3BucketNotEmpty,
+  SimS3NoSuchBucket,
+} from "../../error/sim-s3.error.js";
+
+describe("S3 DeleteBucketCommand", () => {
+  const simAws = new SimAws();
+
+  it("deletes an empty Bucket", async () => {
+    // Given an empty Bucket.
+    const simS3 = simAws.s3();
+
+    await simS3.createBucket(
+      new CreateBucketCommand({ Bucket: "disposable-bucket" }),
+    );
+
+    // When the Bucket is deleted.
+    await simS3.deleteBucket(
+      new DeleteBucketCommand({ Bucket: "disposable-bucket" }),
+    );
+
+    // Then the Bucket is gone from the scope.
+    assertUndefined(simS3.getSimBucketByName("disposable-bucket"));
+  });
+
+  it("releases the Bucket name for another Region to claim", async () => {
+    // Given a Bucket in one Region, whose name no other Region can take.
+    const crossRegionSimAws = new SimAws();
+    const euS3 = crossRegionSimAws.region("eu-west-2").s3();
+    const usS3 = crossRegionSimAws.region("us-east-1").s3();
+
+    await euS3.createBucket(new CreateBucketCommand({ Bucket: "moving-home" }));
+    const takenError = await assertThrowsErrorAsync(async () =>
+      usS3.createBucket(new CreateBucketCommand({ Bucket: "moving-home" })),
+    );
+    assertStringIncludes(takenError.name, "BucketAlreadyOwnedByYou");
+
+    // When the Bucket is deleted in the Region that holds it.
+    await euS3.deleteBucket(new DeleteBucketCommand({ Bucket: "moving-home" }));
+
+    // Then the other Region can claim the name, as S3 names are only unique
+    // for as long as the Bucket exists.
+    await usS3.createBucket(new CreateBucketCommand({ Bucket: "moving-home" }));
+    assertUndefined(euS3.getSimBucketByName("moving-home"));
+  });
+
+  it("refuses to delete a Bucket that still holds Objects", async () => {
+    // Given a Bucket with an Object in it.
+    const simS3 = simAws.s3();
+
+    await simS3.createBucket(
+      new CreateBucketCommand({ Bucket: "occupied-bucket" }),
+    );
+    await simS3.putObject(
+      new PutObjectCommand({
+        Bucket: "occupied-bucket",
+        Key: "left-behind.txt",
+        Body: "still here",
+      }),
+    );
+
+    // When the Bucket is deleted.
+    const error = await assertThrowsErrorAsync(async () =>
+      simS3.deleteBucket(
+        new DeleteBucketCommand({ Bucket: "occupied-bucket" }),
+      ),
+    );
+
+    // Then S3 refuses, rather than emptying the Bucket for the caller.
+    assertInstanceOf(error, SimS3BucketNotEmpty);
+    assertIdentical(error.$metadata.httpStatusCode, 409);
+    assertInstanceOf(simS3.getSimBucketByName("occupied-bucket"), Object);
+  });
+
+  it("deletes a Bucket once its Objects have been removed", async () => {
+    // Given a Bucket that has been emptied.
+    const simS3 = simAws.s3();
+
+    await simS3.createBucket(
+      new CreateBucketCommand({ Bucket: "emptied-bucket" }),
+    );
+    await simS3.putObject(
+      new PutObjectCommand({
+        Bucket: "emptied-bucket",
+        Key: "temporary.txt",
+        Body: "for now",
+      }),
+    );
+    await simS3.deleteObject(
+      new DeleteObjectCommand({
+        Bucket: "emptied-bucket",
+        Key: "temporary.txt",
+      }),
+    );
+
+    // When the Bucket is deleted.
+    await simS3.deleteBucket(
+      new DeleteBucketCommand({ Bucket: "emptied-bucket" }),
+    );
+
+    // Then it goes, because there is nothing left in it.
+    assertUndefined(simS3.getSimBucketByName("emptied-bucket"));
+  });
+
+  it("rejects a non-existent Bucket", async () => {
+    // Given the top-level simulated S3 service without the requested Bucket.
+    const simS3 = simAws.s3();
+
+    // When DeleteBucket targets the missing Bucket.
+    const error = await assertThrowsErrorAsync(async () =>
+      simS3.deleteBucket(new DeleteBucketCommand({ Bucket: "never-made" })),
+    );
+
+    // Then S3 returns its missing-Bucket error.
+    assertInstanceOf(error, SimS3NoSuchBucket);
+    assertIdentical(error.$metadata.httpStatusCode, 404);
+  });
+
+  it("rejects a missing required Bucket input", async () => {
+    // Given the top-level simulated S3 service.
+    const simS3 = simAws.s3();
+
+    // When DeleteBucket is called without its required Bucket.
+    const error = await assertThrowsErrorAsync(async () =>
+      simS3.deleteBucket(
+        // @ts-expect-error -- testing invalid input
+        new DeleteBucketCommand({}),
+      ),
+    );
+
+    // Then request validation identifies the missing Bucket input.
+    assertStringIncludes(error.message, "DeleteBucketCommand.input.Bucket");
+  });
+
+  it("denies a caller without DeleteBucket permission", async () => {
+    // Given a Bucket and a Role with no S3 grant.
+    const accountId = makeSimAwsAccountId();
+    const scopedSimAws = new SimAws({ defaultAccountId: accountId });
+    const simIam = scopedSimAws.iam();
+    const simS3 = scopedSimAws.s3();
+
+    await simS3.createBucket(
+      new CreateBucketCommand({ Bucket: "protected-bucket" }),
+    );
+    const roleCreation = await simIam.createRole(
+      new CreateRoleCommand({
+        RoleName: "UnprivilegedBucketRemover",
+        AssumeRolePolicyDocument: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: {
+            Effect: "Allow",
+            Principal: { AWS: `arn:aws:iam::${accountId}:root` },
+            Action: "sts:AssumeRole",
+          },
+        }),
+      }),
+    );
+
+    // When the unprivileged Role deletes the Bucket.
+    const error = await assertThrowsErrorAsync(async () =>
+      simS3.deleteBucket(
+        new DeleteBucketCommand({ Bucket: "protected-bucket" }),
+        { caller: { kind: "arn", arn: roleCreation.Role.Arn } },
+      ),
+    );
+
+    // Then IAM denies the removal action, and the Bucket stays.
+    assertInstanceOf(error, SimIamAccessDenied);
+    assertIdentical(error.action, "s3:DeleteBucket");
+    assertIdentical(error.resource, "arn:aws:s3:::protected-bucket");
+    assertInstanceOf(simS3.getSimBucketByName("protected-bucket"), Object);
+  });
+});

--- a/src/service/s3/command/sim-s3-command.types.ts
+++ b/src/service/s3/command/sim-s3-command.types.ts
@@ -10,6 +10,10 @@ export type {
   SimCreateBucketCommandOutput,
 } from "./create-bucket/create-bucket.command.js";
 export type {
+  SimDeleteBucketCommand,
+  SimDeleteBucketCommandOutput,
+} from "./delete-bucket/delete-bucket.command.js";
+export type {
   SimDeleteBucketPolicyCommand,
   SimDeleteBucketPolicyCommandOutput,
 } from "./delete-bucket-policy/delete-bucket-policy.command.js";

--- a/src/service/s3/error/sim-s3.error.ts
+++ b/src/service/s3/error/sim-s3.error.ts
@@ -90,6 +90,20 @@ export class SimS3BucketAlreadyOwnedByYou extends SimS3Error {
 }
 
 /**
+ * Simulated S3 BucketNotEmpty error.
+ *
+ * Real S3 refuses to delete a Bucket that still holds Objects, leaving it to
+ * the caller to empty it first.
+ */
+export class SimS3BucketNotEmpty extends SimS3Error {
+  public override readonly name = "BucketNotEmpty";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 409 });
+  }
+}
+
+/**
  * Simulated S3 MalformedXML error.
  *
  * Real S3 answers this when the request document is not one it accepts, which

--- a/src/service/s3/sdk/sim-s3-sdk-command-router.iso.test.ts
+++ b/src/service/s3/sdk/sim-s3-sdk-command-router.iso.test.ts
@@ -1,6 +1,7 @@
 import { describe, it } from "vitest";
 import {
   CreateBucketCommand,
+  DeleteBucketCommand,
   DeleteBucketPolicyCommand,
   DeleteObjectCommand,
   DeleteObjectsCommand,
@@ -51,6 +52,20 @@ describe("simulated S3 SDK Command routing", () => {
     );
 
     assertIdentical(output.Contents?.length, 2);
+  });
+
+  it("routes DeleteBucketCommand through an intercepted client", async () => {
+    using simSdk = new SimSdk();
+    const client = new S3Client({ region: "us-east-1" });
+    simSdk.intercept(client);
+
+    await client.send(new CreateBucketCommand({ Bucket: "bucket-to-go" }));
+
+    await client.send(new DeleteBucketCommand({ Bucket: "bucket-to-go" }));
+
+    assertUndefined(
+      simSdk.simAws.region("us-east-1").s3().getSimBucketByName("bucket-to-go"),
+    );
   });
 
   it("routes PutBucketWebsiteCommand through an intercepted client", async () => {
@@ -236,8 +251,9 @@ describe("simulated S3 SDK Command routing", () => {
 
     const supported = router.supportedCommandNames();
 
-    assertArrayLength(supported, 16);
+    assertArrayLength(supported, 17);
     assertArrayIncludes(supported, "GetObjectCommand");
+    assertArrayIncludes(supported, "DeleteBucketCommand");
     assertArrayIncludes(supported, "PutBucketNotificationConfigurationCommand");
     assertArrayIncludes(supported, "GetBucketNotificationConfigurationCommand");
     assertArrayIncludes(supported, "DeleteObjectCommand");

--- a/src/service/s3/sdk/sim-s3-sdk-command-router.ts
+++ b/src/service/s3/sdk/sim-s3-sdk-command-router.ts
@@ -11,6 +11,7 @@ import type {
 } from "../command/get-object/get-object.command.js";
 import type { SimListBucketsCommand } from "../command/list-buckets/list-buckets.command.js";
 import type { SimListObjectsCommand } from "../command/list-objects/list-objects.command.js";
+import type { SimDeleteBucketCommand } from "../command/delete-bucket/delete-bucket.command.js";
 import type { SimDeleteBucketPolicyCommand } from "../command/delete-bucket-policy/delete-bucket-policy.command.js";
 import type { SimDeleteObjectCommand } from "../command/delete-object/delete-object.command.js";
 import type { SimDeleteObjectsCommand } from "../command/delete-objects/delete-objects.command.js";
@@ -38,6 +39,14 @@ export class SimS3SdkCommandRouter implements SimSdkCommandRouter {
         async (command, context): Promise<unknown> =>
           await simS3.createBucket(
             command as SimCreateBucketCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "DeleteBucketCommand",
+        async (command, context): Promise<unknown> =>
+          await simS3.deleteBucket(
+            command as SimDeleteBucketCommand,
             simSdkCallerOptions(context),
           ),
       ],

--- a/src/service/s3/sim-s3-global-registry.ts
+++ b/src/service/s3/sim-s3-global-registry.ts
@@ -26,6 +26,16 @@ export class SimS3GlobalRegistry {
   }
 
   /**
+   * Release a Bucket name, so it can be claimed again.
+   *
+   * S3 Bucket names are globally unique while the Bucket exists and no longer
+   * than that, so deleting a Bucket has to give the name back.
+   */
+  deregisterBucket(bucketName: SimS3BucketName): void {
+    this.bucketScopes.delete(bucketName);
+  }
+
+  /**
    * Look up the Account Region scope for a Bucket by Bucket name.
    */
   findBucketScope(

--- a/src/service/s3/sim-s3.ts
+++ b/src/service/s3/sim-s3.ts
@@ -2,12 +2,8 @@ import type { SimS3Bucket, SimS3BucketName } from "./bucket/sim-s3-bucket.js";
 import type * as simS3Commands from "./command/sim-s3-command.types.js";
 import { SimS3GlobalRegistry } from "./sim-s3-global-registry.js";
 import type { SimAwsAccountRegionScope } from "../aws/sim-aws-account-region-scope.js";
-import { assertDefined } from "../../util/type-guard/defined.js";
-import { FilesystemS3BucketStorage } from "./storage/filesystem/s3-filesystem-storage.js";
-import {
-  simS3BucketUrl,
-  simS3ServiceUrl,
-} from "./bucket/sim-s3-endpoint-url.js";
+import { SimS3BucketAccess } from "./bucket/sim-s3-bucket-access.js";
+import { simS3ServiceUrl } from "./bucket/sim-s3-endpoint-url.js";
 import { SimS3CloudFormationResourceFactory } from "./cfn/sim-cfn-s3-resource-factory.js";
 import type { SimCfnServiceResourceFactory } from "../cloudformation/resource/factory/sim-cfn-resource-factory.type.js";
 import { simAwsAccountRegionScopeFactory } from "../aws/sim-aws-account-region-scope.factory.js";
@@ -28,6 +24,7 @@ export class SimS3 {
   private readonly accountRegionScope: SimAwsAccountRegionScope;
   private readonly s3GlobalRegistry: SimS3GlobalRegistry;
   private readonly commands: SimS3Commands;
+  private readonly bucketAccess: SimS3BucketAccess;
   private readonly cfnFactory = new SimS3CloudFormationResourceFactory(this);
   private readonly sdkRouter = new SimS3SdkCommandRouter(this);
 
@@ -45,6 +42,10 @@ export class SimS3 {
       s3GlobalRegistry,
       buckets: this.buckets,
     });
+    this.bucketAccess = new SimS3BucketAccess({
+      buckets: this.buckets,
+      accountRegionScope,
+    });
   }
 
   /**
@@ -55,6 +56,16 @@ export class SimS3 {
     options?: SimS3RequestOptions,
   ): Promise<simS3Commands.SimCreateBucketCommandOutput> {
     return await this.commands.buckets.create(command, options);
+  }
+
+  /**
+   * Handle a Delete Bucket Command from the SDK.
+   */
+  async deleteBucket(
+    command: simS3Commands.SimDeleteBucketCommand,
+    options?: SimS3RequestOptions,
+  ): Promise<simS3Commands.SimDeleteBucketCommandOutput> {
+    return await this.commands.buckets.delete(command, options);
   }
 
   /**
@@ -240,23 +251,14 @@ export class SimS3 {
    * Get the simulated S3 REST API endpoint URL for one Bucket.
    */
   getBucketUrl(bucketName: SimS3BucketName | string): URL {
-    const bucket = this.getSimBucketByName(bucketName);
-    assertDefined(bucket, `Sim S3 Bucket named ${bucketName}`);
-
-    return simS3BucketUrl(
-      bucket.bucketName,
-      this.accountRegionScope.regionName,
-    );
+    return this.bucketAccess.url(bucketName);
   }
 
   /**
    * Get the simulated S3 static website URL for a Bucket.
    */
   getBucketWebsiteUrl(bucketName: SimS3BucketName | string): URL {
-    const bucket = this.getSimBucketByName(bucketName);
-    assertDefined(bucket, `Sim S3 Bucket named ${bucketName}`);
-
-    return bucket.getWebsiteUrl();
+    return this.bucketAccess.websiteUrl(bucketName);
   }
 
   /**
@@ -275,11 +277,7 @@ export class SimS3 {
     bucketName: SimS3BucketName | string,
     directoryPath: string,
   ): void {
-    const bucket = this.getSimBucketByName(bucketName);
-    assertDefined(bucket, `Sim S3 Bucket named ${bucketName}`);
-    bucket.configureSimStorage(
-      new FilesystemS3BucketStorage({ directoryPath }),
-    );
+    this.bucketAccess.mountFilesystem(bucketName, directoryPath);
   }
 
   /**


### PR DESCRIPTION
Adds the AWS delete operations for simulated S3 Buckets, Lambda functions, and IAM Roles and policies. These are the first of the delete commands stack deletion needs, and are useful on their own: until now most services could create their main resource and never remove it.

## What is here

| Command | Behaviour |
| --- | --- |
| `S3 DeleteBucket` | Refuses a Bucket that still holds Objects with `BucketNotEmpty`, and releases the Bucket name globally so another Account or Region can claim it |
| `Lambda DeleteFunction` | Takes the function's Function URL with it, and leaves event source mappings alone as real Lambda does |
| `IAM DeleteRole` | Refuses with `DeleteConflict` while the Role carries inline or attached policies |
| `IAM DetachRolePolicy` | Removes the attachment `AttachRolePolicy` recorded, leaving the managed policy itself |
| `IAM DeleteRolePolicy` | Removes the inline policy `PutRolePolicy` stored |
| `IAM DeletePolicy` | Refuses with `DeleteConflict` while any Role or User still carries the ARN |

Each is authorized as its own IAM action, routed for SDK client interception, and covered by colocated isolated tests including the routing path.

The refusals matter as much as the deletions. Real AWS will not delete a Bucket with Objects in it or a Role that still has policies on it, and those refusals are exactly why a CloudFormation Stack deletion fails partway. Simulating only the success would make a passing test mean less than it should.

## Refactors

Two collaborators were extracted because the service facades sat exactly on the 300 line limit:

- `SimS3BucketAccess` takes the Bucket lookup, endpoint URL and filesystem mount conveniences off `SimS3`. They are test and local development conveniences rather than S3 operations, so they read better together and away from the command delegations.
- IAM gained the `command/sim-iam-command.types.ts` barrel that S3 and Lambda already had, which replaced 60 lines of per-command imports in `SimIam` with one.

## Not here

Docs. They are held back until the rest of the delete commands land, so the S3, Lambda and IAM pages can be updated once rather than three times.

The delete operations for the other services are #403, #404 and #405. The CloudFormation side is #406, which unblocks #397 and then #398.

Resolves https://github.com/KensioSoftware/yulin/issues/402
