### PR TITLE
feat: create Resources without unsupported props

### DIFF
--- a/docs/services/apigatewayv2/README.md
+++ b/docs/services/apigatewayv2/README.md
@@ -1890,10 +1890,10 @@ Current documented limitations:
 - An authorizer function that throws is a 500 rather than a 401. Real Lambda turns a thrown error
   into a payload carrying `errorMessage`, and simulated Lambda rejects with the error itself, so
   returning `{ "errorMessage": "Unauthorized" }` is how an authorizer asks for a 401 here.
-- `AuthorizerCredentialsArn` is refused, as is `AuthorizerCredentialsArn` on an
-  `AWS::ApiGatewayV2::Authorizer` and `authorizerCredentials` in an imported document. It names a
-  Role API Gateway assumes to invoke the authorizer, and the function's own resource policy is the
-  whole decision here.
+- `AuthorizerCredentialsArn` is refused on `CreateAuthorizer`, as is `authorizerCredentials` in an
+  imported document. On an `AWS::ApiGatewayV2::Authorizer` it is recorded instead, and the authorizer
+  is created without it. It names a Role API Gateway assumes to invoke the authorizer, and the
+  function's own resource policy is the whole decision here.
 - `AuthorizerResultTtlInSeconds` is accepted between 0 and 3600, which is the range AWS accepts, and
   is refused on an authorizer with no `IdentitySource`, since there would be nothing to key the held
   decision on.
@@ -1987,8 +1987,9 @@ Current documented limitations:
   only the name `GetApi` reports.
 - A terminal `{proxy+}` in an imported path reaches `CreateRoute` unchanged. Greedy segments are
   established for route keys rather than for OpenAPI path templating.
-- `AWS::ApiGatewayV2::Api` refuses `BodyS3Location` by name. Reading a document out of a simulated S3
-  bucket adds a fetch path and nothing about OpenAPI.
+- `AWS::ApiGatewayV2::Api` records `BodyS3Location` rather than reading it, so the API is created
+  with no routes at all. Reading a document out of a simulated S3 bucket adds a fetch path and
+  nothing about OpenAPI.
 - `AWS::ApiGatewayV2::Api` refuses `Policy` with a message of its own saying an HTTP API has no
   resource policy. There is no such property on the real Resource type, so a template carrying one
   was written for a REST API rather than hitting a gap here.

--- a/docs/services/apigatewayv2/README.md
+++ b/docs/services/apigatewayv2/README.md
@@ -1675,8 +1675,11 @@ console.log(await response.text());
 srv.close();
 ```
 
-Every property outside the simulated set is refused by name, and the refusal fails the stack. The
-simulated properties are:
+Every property outside the simulated set is left out of what is created and recorded in
+[`stack.ignoredProperties`](../cloudformation/README.md#properties-a-resource-was-created-without),
+naming the Resource type, the logical id and the ones this can act on instead. The API, authorizer,
+integration, route or stage is created either way, so the stack deploys and the record says which of
+its parts behaves differently to the template. The simulated properties are:
 
 - `Api`: `Name`, `ProtocolType`, `Description`, `DisableExecuteApiEndpoint`, `Body`,
   `FailOnWarnings`
@@ -1756,6 +1759,7 @@ Api:
 `ProtocolType` that is present has to be `HTTP`, and a `Name` that is present names the API instead
 of the document's `info.title`. `Description` and `DisableExecuteApiEndpoint` are refused alongside a
 `Body`, because `ImportApi` does not take them and nothing here changes an API after it is created.
+Each is recorded rather than applied, so the API is created from the document without them.
 
 A template combining an `Api` with a `Body` and a separate `Route`, `Integration` or `Authorizer`
 Resource for that same API fails the stack, naming both logical IDs. The document already declares
@@ -1947,10 +1951,9 @@ Current documented limitations:
 - `CorsConfiguration` and `Tags` are refused, as is the `RouteKey`/`Target` quick-create shorthand on
   `CreateApi`. Anything else the real commands accept and this one does not is refused by name rather
   than dropped.
-- `AWS::ApiGatewayV2::Api` refuses `CorsConfiguration` by name rather than accepting it with no
-  effect. CORS request handling is not simulated, and a template that configured it would otherwise
-  get an API that answered preflight requests here differently from AWS. A CDK stack using
-  `corsPreflight` does not deploy.
+- `AWS::ApiGatewayV2::Api` records `CorsConfiguration` rather than applying it. CORS request handling
+  is not simulated, so a CDK stack using `corsPreflight` deploys and its API answers preflight
+  requests here differently from AWS. The record is where a test checks that.
 - Only OpenAPI 3.0.x is imported. A `swagger: "2.0"` document and an `openapi: "3.1.0"` one are both
   refused by version, and only JSON is parsed, not YAML.
 - `FailOnWarnings` is honoured only in its strict sense. Everything an import cannot apply is refused

--- a/docs/services/cloudformation/README.md
+++ b/docs/services/cloudformation/README.md
@@ -318,8 +318,8 @@ simulated CloudFront hostname, such as `e123example.cloudfront.net`.
 
 #### Values from a skipped Resource
 
-A Resource that was skipped, because its type is not simulated or because it sets a property whose
-behaviour is not simulated, still answers both intrinsics. `Ref` returns the logical ID, and
+A Resource that was skipped, because its type is not simulated or because there is no simulated
+Resource to create at all, still answers both intrinsics. `Ref` returns the logical ID, and
 `Fn::GetAtt` returns the string `<logical ID>.<attribute name>`.
 
 ```typescript sim-cloudformation-skipped-resource-values
@@ -1281,8 +1281,8 @@ This is useful in tests when you want to assert that a specific template resourc
 expected simulated service resource.
 
 `stack.skippedResources` lists the Resources the deployment did not create. Each one carries a
-`skippedReason` naming the type or the property that is not simulated, so a test that expected a
-resource to exist can find out why it does not.
+`skippedReason` naming the type that is not simulated, so a test that expected a resource to exist
+can find out why it does not.
 
 ```typescript sim-cloudformation-inspect-skipped
 /**
@@ -1321,6 +1321,81 @@ console.log(stack.getResource("AlarmTopic")?.skippedReason);
 
 A skipped Resource is still in `stack.resources`, and still answers `Ref` and `Fn::GetAtt` with
 [stand-in values](#values-from-a-skipped-resource).
+
+## Properties a Resource was created without
+
+Deployment is best effort. A Resource type that is not simulated is skipped and the rest of the
+stack still deploys, and the same goes one level down: a property the Resource's own service cannot
+act on does not stop the Resource being created. It is left out, and the omission is recorded in
+`stack.ignoredProperties`.
+
+```typescript sim-cloudformation-ignored-properties
+/**
+ * Finding out which properties a Stack created its Resources without.
+ */
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "uploads-stack",
+  template: {
+    Resources: {
+      UploadsBucket: {
+        Type: "AWS::S3::Bucket",
+        Properties: {
+          BucketName: "uploads",
+          VersioningConfiguration: { Status: "Enabled" },
+        },
+      },
+    },
+  },
+});
+
+await stack.waitForDeployComplete();
+
+// The Bucket exists and is usable, unversioned.
+console.log(stack.getResource("UploadsBucket")?.deployed);
+// true
+
+for (const ignored of stack.ignoredProperties) {
+  console.log(ignored.logicalId, ignored.path, ignored.reason);
+  // "UploadsBucket VersioningConfiguration VersioningConfiguration is a real
+  //  AWS::S3::Bucket property simulated S3 does not act on: Object versions
+  //  are not simulated, ..."
+}
+```
+
+Each entry names the `logicalId` and `resourceType` of the Resource, the `path` to the property, and
+a `reason`. The path is the whole way down, so a setting on one entry of a list says which entry it
+was on, such as `GlobalSecondaryIndexes.1.WarmThroughput`. The same list is on each Resource as
+`resource.ignoredProperties`.
+
+**An ignored property means the simulated Resource behaves differently to the one the template
+describes.** That is the trade this makes: a template deploys as far as it can, and the record is
+where to check whether what it could not do matters to the test you are writing. A test asserting on
+object versions, on a dead-letter queue, or on a rotated key needs to look here before trusting the
+result.
+
+A property name that is not one AWS has is recorded the same way rather than failing the stack. A
+typo and a property AWS added after this simulator read the docs look identical from here, and a
+Resource that deploys with the unread name reported is more useful than a stack that fails over
+either.
+
+Two things are still refused outright, and fail the Resource:
+
+- A property that leaves nothing coherent to create, such as an `AWS::S3::Bucket` whose `BucketName`
+  is not a string, or an `AWS::DynamoDB::GlobalTable` whose replica list does not include the region
+  the stack is deploying into. Real CloudFormation refuses these templates too.
+- A value the simulated service itself refuses, which is refused in the same words an SDK caller
+  gets. An `AWS::SQS::Queue` with `FifoQueue: true` is one: a FIFO queue is named `<name>.fifo`,
+  which simulated SQS refuses, so there is no queue to create under the name the template gave it.
+
+Properties nothing simulated could tell apart are not listed. There is no simulated KMS and Object
+bytes are stored as they arrive, so an `AWS::S3::Bucket` carrying `BucketEncryption` and `Tags`, as
+almost every Bucket CDK synthesizes does, records nothing: a report of differences that make no
+difference is one nobody can read.
 
 ## Handling deployment failures
 
@@ -1438,7 +1513,11 @@ Each service's own docs describe what its resource types support.
   resource answers `Ref` and `Fn::GetAtt` with
   [stand-in values](#values-from-a-skipped-resource) rather than the value a created resource would
   have given.
-- Unsupported resource properties may be ignored or rejected depending on the resource simulator.
+- A resource property that is not simulated is left out and recorded in `stack.ignoredProperties`
+  rather than failing the stack, so the resource is created behaving differently to the one the
+  template describes. See
+  [properties a Resource was created without](#properties-a-resource-was-created-without) for what
+  is still refused outright.
 - Stack updates and deletes are not supported.
 - `Fn::FindInMap` accepts only the three-argument form. The four-argument form, where the fourth
   argument is `{ "DefaultValue": ... }`, is rejected.

--- a/docs/services/cloudformation/sim-cloudformation-ignored-properties.example.ts
+++ b/docs/services/cloudformation/sim-cloudformation-ignored-properties.example.ts
@@ -1,0 +1,35 @@
+/**
+ * Finding out which properties a Stack created its Resources without.
+ */
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "uploads-stack",
+  template: {
+    Resources: {
+      UploadsBucket: {
+        Type: "AWS::S3::Bucket",
+        Properties: {
+          BucketName: "uploads",
+          VersioningConfiguration: { Status: "Enabled" },
+        },
+      },
+    },
+  },
+});
+
+await stack.waitForDeployComplete();
+
+// The Bucket exists and is usable, unversioned.
+console.log(stack.getResource("UploadsBucket")?.deployed);
+// true
+
+for (const ignored of stack.ignoredProperties) {
+  console.log(ignored.logicalId, ignored.path, ignored.reason);
+  // "UploadsBucket VersioningConfiguration VersioningConfiguration is a real
+  //  AWS::S3::Bucket property simulated S3 does not act on: Object versions
+  //  are not simulated, ..."
+}

--- a/docs/services/cognito/README.md
+++ b/docs/services/cognito/README.md
@@ -1063,10 +1063,13 @@ The properties each type reads are the ones this simulation models:
 - `AWS::Cognito::UserPoolGroup`: `UserPoolId`, `GroupName`, `Description`, `Precedence` and
   `RoleArn`.
 
-Any other property is refused at deploy time, naming the logical id and the property, rather than
-deploying a resource that would behave differently on AWS. A stack that forgets
-`ALLOW_ADMIN_USER_PASSWORD_AUTH` therefore fails at the sign-in here as it would in a deployment,
-which is the point of deploying the template rather than restating it.
+Any other property is left out of what is created and recorded in
+[`stack.ignoredProperties`](../cloudformation/README.md#properties-a-resource-was-created-without),
+naming the logical id, the property and the ones this can act on instead. The pool or client is
+created either way, so a stack full of Cognito resources deploys and the record says which of them
+behaves differently to the template. A stack that forgets `ALLOW_ADMIN_USER_PASSWORD_AUTH` still
+fails at the sign-in here as it would in a deployment, which is the point of deploying the template
+rather than restating it.
 
 `UserPoolName` and `ClientName` are optional. A template that sets neither gets
 `<stack name>-<logical id>`, as real CloudFormation generates a name, trimmed to the 128 characters

--- a/docs/services/dynamodb/README.md
+++ b/docs/services/dynamodb/README.md
@@ -3333,7 +3333,8 @@ that does not exist, or naming none at all, is refused in the words `CreateTable
 caller in.
 
 `StreamSpecification.ResourcePolicy` is a policy on the stream rather than on the table. It is not
-simulated, so a template declaring one skips the table, naming the whole property path.
+simulated, so the table is created without it and the whole property path is recorded in
+[`stack.ignoredProperties`](../cloudformation/README.md#properties-a-resource-was-created-without).
 
 Changing `StreamViewType` in a deployed template is a different thing here to what it is on real
 CloudFormation, which replaces the table. `UpdateTable` refuses the change in place, so switching the
@@ -3622,15 +3623,16 @@ Arn`, `Fn::GetAtt … StreamArn` and `Fn::GetAtt … TableId` answering. A CDK `
   the outcome does not.
 - Changing a deployed table's `StreamViewType` is not the table replacement real CloudFormation
   performs. The change goes through `UpdateTable`, which refuses a view type change in place.
-- An `AWS::DynamoDB::GlobalTable` naming two or more replica regions is skipped rather than
-  deployed. Replication between regions is not simulated at all, so there is no half of it to give:
-  a table in one of the regions would answer reads the other regions were meant to serve, and
-  nothing would carry a write from one to the other.
+- An `AWS::DynamoDB::GlobalTable` naming two or more replica regions is created as an ordinary table
+  in the region the stack is deploying into, with `Replicas` recorded in `stack.ignoredProperties`.
+  Replication between regions is not simulated at all, so everything the table does within one region
+  behaves as the template describes and nothing is copied to the others. A replica list that does not
+  include the stack's own region is refused, as real CloudFormation refuses it.
 - A global table's per-replica settings cannot differ from the primary's, because there is only ever
   one replica. Anything a second replica would have said differently is not reachable.
-- `WriteCapacityAutoScalingSettings` and `ReadCapacityAutoScalingSettings` skip the resource rather
-  than being read as the capacity the table would start at. Nothing here scales capacity, and a
-  capacity nothing enforces would still be a number a template asked for and did not get.
+- `WriteCapacityAutoScalingSettings` and `ReadCapacityAutoScalingSettings` are recorded rather than
+  applied, and the table is created at the `MinCapacity` each of them names, which is where
+  autoscaling starts it on AWS. Nothing here scales capacity afterwards.
 - A shard iterator never expires. Real DynamoDB gives one 15 minutes and then answers
   `ExpiredIteratorException`, which a consumer handles by asking for another from the sequence
   number it last checkpointed. Nothing here refuses an iterator for being old.
@@ -3658,13 +3660,13 @@ Arn`, `Fn::GetAtt … StreamArn` and `Fn::GetAtt … TableId` answering. A CDK `
   the record carries. That is the rule AWS's own published sample records follow, and it is not the
   rule the 400 KB item limit uses, where a number costs about half its digits.
 - `KinesisStreamSpecification` is not simulated. A table's changes go to its own stream or nowhere.
-- Encryption at rest is not simulated. An `SSESpecification` with `Enabled` set is refused rather
-  than reported back against items held in the clear. `Enabled: false` asks for the AWS owned key
-  real DynamoDB uses by default, so it is accepted.
-- Table resource policies are not simulated. `ResourcePolicy` is refused, since a table left open to
-  callers the policy would have kept out is the wrong way to fail.
-- `OnDemandThroughput` and `WarmThroughput` are refused. Nothing here applies a request-unit maximum
-  or pre-warms capacity.
+- Encryption at rest is not simulated. An `SSESpecification` with `Enabled` set on a
+  CloudFormation Resource is recorded rather than reported back against items held in the clear.
+  `Enabled: false` asks for the AWS owned key real DynamoDB uses by default, so it is accepted.
+- Table resource policies are not simulated. `ResourcePolicy` on a CloudFormation Resource is
+  recorded, so a table a policy was meant to keep callers out of is open here and closed on AWS.
+- `OnDemandThroughput` and `WarmThroughput` are recorded rather than applied. Nothing here applies a
+  request-unit maximum or pre-warms capacity.
 - `BillingModeSummary` and `TableClassSummary` are reported only when the request named a
   `BillingMode` or a `TableClass`. Real DynamoDB reports the effective values whichever way the table
   was created.

--- a/docs/services/dynamodb/README.md
+++ b/docs/services/dynamodb/README.md
@@ -3117,11 +3117,13 @@ table with no `StreamSpecification` it is refused by name, naming the table, sin
 ARN would read as a working stream to whatever the template handed it to. Real CloudFormation refuses
 the same template while validating it, where this refuses when the attribute is asked for.
 
-A property with behaviour that is not simulated skips the resource, with a reason naming the
-property, and the rest of the stack still deploys: `KinesisStreamSpecification`, `SSESpecification`,
-`PointInTimeRecoverySpecification`, `ContributorInsightsSpecification`, `ImportSourceSpecification`,
-`ResourcePolicy`, `OnDemandThroughput` and `WarmThroughput`. A property `AWS::DynamoDB::Table` does
-not have fails the resource instead, since that is a template real CloudFormation would refuse too.
+A property with behaviour that is not simulated is left out and recorded in
+[`stack.ignoredProperties`](../cloudformation/README.md#properties-a-resource-was-created-without),
+so the table is created and the rest of the stack still deploys: `KinesisStreamSpecification`,
+`SSESpecification`, `PointInTimeRecoverySpecification`, `ContributorInsightsSpecification`,
+`ImportSourceSpecification`, `ResourcePolicy`, `OnDemandThroughput` and `WarmThroughput`. A property
+`AWS::DynamoDB::Table` does not have is recorded the same way, rather than a stack failing over a
+typo or a property AWS added since this list was written.
 
 `AWS::DynamoDB::GlobalTable` deploys a table as well, under
 [deploying a global table](#deploying-a-global-table-from-cloudformation).
@@ -3237,9 +3239,11 @@ per-index throughput a provisioned table needs, and the rule that a local second
 table's partition key.
 
 `ContributorInsightsSpecification`, `OnDemandThroughput` and `WarmThroughput` on a global secondary
-index are not simulated, so a table declaring one is skipped with a reason naming the index it was
-on. `LocalSecondaryIndexes` entries have `IndexName`, `KeySchema` and `Projection` and nothing else,
-so anything further on one fails the resource, as it would on real CloudFormation.
+index are not simulated, so the index is created without them and the record names the index it was
+on, such as `GlobalSecondaryIndexes.0.WarmThroughput`. `LocalSecondaryIndexes` entries have
+`IndexName`, `KeySchema` and `Projection` and nothing else, so anything further on one is recorded
+the same way. A `ProvisionedThroughput` there still fails the resource, because an index entry goes
+to `CreateTable` as the template wrote it and real DynamoDB refuses capacity on a local index.
 
 A CDK `Table` with `addGlobalSecondaryIndex` and `addLocalSecondaryIndex` synthesises a template that
 deploys here without hand-editing.
@@ -3420,9 +3424,11 @@ go back together into the `ProvisionedThroughput` `CreateTable` takes. A global 
 split the same way: the table declares the index and provisions its writes, and the replica's
 `GlobalSecondaryIndexes` entry names that index and provisions its reads.
 
-A global table naming two or more replica regions is skipped, with a reason naming the regions, and
-the rest of the stack still deploys. Replication genuinely is not simulated, so drawing the line at
-the replica count puts it where the behaviour actually differs.
+A global table naming two or more replica regions is created as an ordinary table in the region the
+stack is deploying into, with `Replicas` recorded in
+[`stack.ignoredProperties`](../cloudformation/README.md#properties-a-resource-was-created-without)
+naming the regions. Replication genuinely is not simulated, so everything the table does within one
+region behaves as the template describes and nothing is copied to the others.
 
 A global table with no `Replicas` at all fails the resource, since `Replicas` is required and real
 CloudFormation refuses that template too. So does one whose single replica names a region the stack

--- a/docs/services/kms/README.md
+++ b/docs/services/kms/README.md
@@ -452,12 +452,15 @@ console.log(Buffer.from(decrypted.Plaintext ?? []).toString("utf8")); // "hunter
 console.log(stack.outputs.get("KeyArn")?.value); // "arn:aws:kms:...:key/..."
 ```
 
-Properties asking for behaviour that is not simulated refuse the deployment rather than being
-ignored, so a template does not quietly deploy a key that would behave differently on AWS.
-`EnableKeyRotation`, `RotationPeriodInDays`, `MultiRegion` and `Tags` are all refused. An asymmetric
-or HMAC `KeySpec` or `KeyUsage`, or an `Origin` other than `AWS_KMS`, is refused by `CreateKey` in
-the same terms it refuses an SDK caller. `Enabled: false` is supported, and deploys a key that is
-disabled from the moment it exists.
+Properties asking for behaviour that is not simulated do not stop the key being created. The key is
+created without them and each one is recorded in
+[`stack.ignoredProperties`](../cloudformation/README.md#properties-a-resource-was-created-without),
+so a template deploys and the record says what the key does not do. `EnableKeyRotation`,
+`RotationPeriodInDays`, `MultiRegion` and `Tags` are all recorded that way: the key encrypts and
+decrypts, its material never rotates, it exists in one region, and nothing reads its tags. An
+asymmetric or HMAC `KeySpec` or `KeyUsage`, or an `Origin` other than `AWS_KMS`, is still refused by
+`CreateKey` in the same terms it refuses an SDK caller, because there is no key to create at all.
+`Enabled: false` is supported, and deploys a key that is disabled from the moment it exists.
 
 ## Inside a simulated Lambda handler
 
@@ -492,8 +495,10 @@ Current documented limitations:
   refused.
 - Grants (`CreateGrant` and friends) are not simulated.
 - Automatic key rotation is not simulated. An `AWS::KMS::Key` declaring `EnableKeyRotation` or
-  `RotationPeriodInDays` is refused.
-- Multi-Region keys are not simulated. An `AWS::KMS::Key` declaring `MultiRegion: true` is refused.
+  `RotationPeriodInDays` is created without it, and the property is recorded in
+  `stack.ignoredProperties`.
+- Multi-Region keys are not simulated. An `AWS::KMS::Key` declaring `MultiRegion: true` is created as
+  a key in one region, and the property is recorded.
 - `AWS::KMS::Key` accepts but ignores `PendingWindowInDays` and `BypassPolicyLockoutSafetyCheck`.
   Neither has anything to act on: simulated CloudFormation does not delete stacks, and simulated KMS
   applies no policy lockout safety check to bypass.
@@ -505,7 +510,8 @@ Current documented limitations:
   recovery window does not delete it, so the key ID stays taken.
 - Aliases cannot be updated or deleted; `UpdateAlias` and `DeleteAlias` are not supported.
 - Tags, `ListResourceTags` and the `aws:ResourceTag` condition key are not simulated. An
-  `AWS::KMS::Key` declaring `Tags` is refused rather than deploying with the tags dropped.
+  `AWS::KMS::Key` declaring `Tags` deploys with the tags dropped and the property recorded, so a
+  policy condition written around one matches nothing here and matches on AWS.
 - `kms:EncryptionContext:*` and other KMS-specific condition keys beyond `kms:ViaService` and
   `kms:CallerAccount` are not derived, so a policy relying on them will not match. Ordinary condition
   operators on values sim IAM does supply work as usual.

--- a/docs/services/s3/README.md
+++ b/docs/services/s3/README.md
@@ -794,16 +794,22 @@ An `AWS::S3::Bucket` resource carries four properties simulated S3 acts on: `Buc
 `BucketName` the Bucket is named after the resource's logical id, lowercased, rather than the
 generated name real CloudFormation invents.
 
-Any other property fails the stack by name. A Bucket deployed without the lifecycle rules,
-versioning or CORS configuration its template asked for would look configured and behave as though it
-were not, and the failure that causes turns up somewhere else entirely. One of the four that is there
-but is not the shape it should be fails the stack too, rather than being read as absent.
+Any other property is left out and recorded in
+[`stack.ignoredProperties`](../cloudformation/README.md#properties-a-resource-was-created-without),
+so the Bucket is created and the stack carries on. That matters because a Bucket deployed without the
+lifecycle rules, versioning or CORS configuration its template asked for looks configured and behaves
+as though it were not, and the failure that causes turns up somewhere else entirely. The record is
+where a test checks which of those it is standing on. A property name `AWS::S3::Bucket` does not have
+is recorded the same way, rather than a stack failing over a typo.
 
-`BucketEncryption` and `Tags` are the two exceptions. They are read and ignored, because nothing this
-simulator models can tell the difference: there is no simulated KMS, Object bytes are stored as they
-arrive, and no simulated service reads a Bucket tag. CDK puts both on almost every Bucket it
-synthesizes, so refusing them would leave a CDK app unable to deploy over a difference no test could
-observe.
+One of the four that is there but is not the shape it should be still fails the stack, rather than
+being read as absent, and so does a `BucketName` that is not a string: there is no Bucket to create
+under a name nothing else in the template refers to.
+
+`BucketEncryption` and `Tags` are read, ignored and not recorded, because nothing this simulator
+models can tell the difference: there is no simulated KMS, Object bytes are stored as they arrive,
+and no simulated service reads a Bucket tag. CDK puts both on almost every Bucket it synthesizes, and
+listing a difference no test could observe would only bury the ones that matter.
 
 ## Bucket policies
 

--- a/docs/services/sqs/README.md
+++ b/docs/services/sqs/README.md
@@ -1144,8 +1144,9 @@ Current documented limitations:
   over either. The 60 second hold on a deleted queue's name is simulated, so recreating a queue
   straight after deleting it fails with `QueueDeletedRecently` until the clock moves on.
 - Dead-letter queues are simulated for standard queues only, and only the `RedrivePolicy` half of
-  them. `RedriveAllowPolicy` is refused, so a dead-letter queue cannot restrict which queues may
-  redrive to it. `ListDeadLetterSourceQueues` and the `StartMessageMoveTask` family for draining a
+  them. Setting `RedriveAllowPolicy` through the SQS API is refused, and on an `AWS::SQS::Queue` it
+  is recorded and the queue created without it, so a dead-letter queue cannot restrict which queues
+  may redrive to it either way. `ListDeadLetterSourceQueues` and the `StartMessageMoveTask` family for draining a
   dead-letter queue back to its source are not supported, so a redriven message is moved back by a
   test sending it again.
 - `ApproximateReceiveCount` starting again from one on a dead-letter queue is this simulation's

--- a/docs/services/sqs/README.md
+++ b/docs/services/sqs/README.md
@@ -1059,12 +1059,17 @@ that, which a template cannot predict either way. The generated name is trimmed 
 a queue name allows, ending in a hash of the untrimmed name so two long names that start the same
 stay apart.
 
-`FifoQueue: true` fails the resource, because only standard queues are simulated and a FIFO queue
-created as a standard one would take messages in an order the deployment does not promise. The
-properties with behaviour that is not simulated fail the resource in the same way rather than being
-dropped: `RedrivePolicy`, `RedriveAllowPolicy`, `KmsMasterKeyId`, `KmsDataKeyReusePeriodSeconds`,
-`SqsManagedSseEnabled`, `ContentBasedDeduplication`, `DeduplicationScope`, `FifoThroughputLimit` and
-`Tags`. So does a property `AWS::SQS::Queue` does not have.
+`FifoQueue: true` fails the resource. Only standard queues are simulated, and a FIFO queue is named
+`<name>.fifo`, which simulated SQS refuses to an SDK caller as well, so there is no queue to create
+under the name the template gave it.
+
+The properties with behaviour that is not simulated are a different case: the queue is created
+without them and each one is recorded in
+[`stack.ignoredProperties`](../cloudformation/README.md#properties-a-resource-was-created-without),
+so a stack full of queues still deploys. Those are `RedrivePolicy`, `RedriveAllowPolicy`,
+`KmsMasterKeyId`, `KmsDataKeyReusePeriodSeconds`, `SqsManagedSseEnabled`,
+`ContentBasedDeduplication`, `DeduplicationScope`, `FifoThroughputLimit` and `Tags`. A property
+`AWS::SQS::Queue` does not have is recorded the same way.
 
 `AWS::SQS::QueuePolicy` deploys the policy it names onto each queue in its `Queues` list, through
 `SetQueueAttributes`. A policy declared in a template is therefore validated and enforced exactly as
@@ -1148,8 +1153,8 @@ Current documented limitations:
   and the moved message has not been received from the dead-letter queue yet. `SentTimestamp` being
   unchanged by the move is documented AWS behaviour, and is simulated as such.
 - The `RedrivePolicy` property on `AWS::SQS::Queue` is not simulated, so a dead-letter queue is
-  configured by an SDK call rather than by a template. The property fails the resource rather than
-  being dropped.
+  configured by an SDK call rather than by a template. The queue is created without the property and
+  the omission is recorded in `stack.ignoredProperties`.
 - A queue policy is set through the `Policy` attribute only. `AddPermission` and `RemovePermission`,
   which are shorthands for writing one statement of it, are not supported.
 - `GetQueueAttributes` reports the `Policy` string that was set. Real SQS re-serialises the document
@@ -1158,8 +1163,8 @@ Current documented limitations:
   policy admits another account's principal to a queue here; it does not make another account's
   queues reachable through this one.
 - Encryption is not simulated. `KmsMasterKeyId`, `KmsDataKeyReusePeriodSeconds` and
-  `SqsManagedSseEnabled` are refused, and message bodies are held in process memory as they were
-  sent. That is not a security boundary: anything sharing the process can reach them.
+  `SqsManagedSseEnabled` are recorded rather than applied on an `AWS::SQS::Queue`, and message bodies
+  are held in process memory as they were sent. That is not a security boundary: anything sharing the process can reach them.
 - Tags are not simulated. `TagQueue`, `UntagQueue` and `ListQueueTags` are not supported, and
   `CreateQueue` refuses a `tags` parameter rather than dropping it.
 - `SenderId` is not reported, because a simulated caller has no user or role id to report it as.

--- a/src/service/apigatewayv2/cfn/api/sim-cfn-http-api-import-properties.ts
+++ b/src/service/apigatewayv2/cfn/api/sim-cfn-http-api-import-properties.ts
@@ -36,7 +36,7 @@ export class SimCfnHttpApiImportProperties {
    * what AWS documents, and a `ProtocolType` that is present has to be `HTTP`.
    */
   importApiInput(): SimImportApiCommandInput {
-    this.rules.refuseUnimportableProperties();
+    this.rules.ignoreUnimportableProperties();
     this.rules.requireHttpProtocolType(
       this.propertyParser.optionalString(
         this.resource,

--- a/src/service/apigatewayv2/cfn/api/sim-cfn-http-api-properties.ts
+++ b/src/service/apigatewayv2/cfn/api/sim-cfn-http-api-properties.ts
@@ -56,7 +56,7 @@ export class SimCfnHttpApiProperties {
     });
 
     this.rules.requireNoResourcePolicy();
-    this.propertyParser.requireOnlySimulated(this.resource, this.properties);
+    this.propertyParser.ignoreUnsimulated(this.resource, this.properties);
   }
 
   /**
@@ -85,7 +85,7 @@ export class SimCfnHttpApiProperties {
    * WebSocket API is refused by CreateApi with the reason it is refused.
    */
   createApiInput(): SimCreateApiCommandInput {
-    this.rules.requireBodyForFailOnWarnings();
+    this.rules.ignoreFailOnWarningsWithoutBody();
 
     return {
       Name: this.propertyParser.requiredString(

--- a/src/service/apigatewayv2/cfn/api/sim-cfn-http-api-property-rules.ts
+++ b/src/service/apigatewayv2/cfn/api/sim-cfn-http-api-property-rules.ts
@@ -5,10 +5,10 @@ import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template
  * The properties an imported API cannot also carry.
  *
  * `ImportApi` takes neither, and nothing here changes an API after it is
- * created, so a template asking for one alongside a `Body` would get an API
- * that ignored it. AWS applies both by updating the imported API afterwards.
+ * created, so a template asking for one alongside a `Body` gets an API without
+ * it. AWS applies both by updating the imported API afterwards.
  */
-const refusedAlongsideBody = new Set([
+const droppedAlongsideBody = new Set([
   "Description",
   "DisableExecuteApiEndpoint",
 ]);
@@ -19,9 +19,15 @@ interface SimCfnHttpApiPropertyRulesProperties {
 }
 
 /**
- * The AWS::ApiGatewayV2::Api rules about which properties may appear together,
- * each refused with the reason it cannot be deployed rather than with the
- * generic "not simulated" message.
+ * The AWS::ApiGatewayV2::Api rules about which properties may appear together.
+ *
+ * Each one says why that combination cannot be deployed as written, rather
+ * than falling back on the generic "not simulated" wording. Which of them
+ * refuses the Resource and which records it and carries on turns on what real
+ * CloudFormation does with the same template: a property AWS has no such thing
+ * as, or one asking for a WebSocket API, is a template AWS refuses too, and one
+ * AWS quietly applies in a second step is one to create the API without and
+ * report.
  */
 export class SimCfnHttpApiPropertyRules {
   private readonly resource: SimCfnResource;
@@ -51,10 +57,14 @@ export class SimCfnHttpApiPropertyRules {
   }
 
   /**
-   * Refuse a `FailOnWarnings` on an API that imports nothing.
+   * Record a `FailOnWarnings` on an API that imports nothing.
+   *
+   * There are no import warnings without an import, so the property says
+   * nothing about this API either way, and real CloudFormation accepts the
+   * same template.
    */
-  requireBodyForFailOnWarnings(): void {
-    this.refuse(
+  ignoreFailOnWarningsWithoutBody(): void {
+    this.ignore(
       "FailOnWarnings",
       "it says what to do with the warnings an OpenAPI import finds, and " +
         "this Resource has no Body to import",
@@ -62,22 +72,19 @@ export class SimCfnHttpApiPropertyRules {
   }
 
   /**
-   * Refuse the properties an imported API would silently drop.
+   * Record the properties an imported API cannot be created with.
    */
-  refuseUnimportableProperties(): void {
-    const refused = Object.keys(this.properties).find((name) =>
-      refusedAlongsideBody.has(name),
-    );
-
-    if (refused === undefined) {
-      return;
+  ignoreUnimportableProperties(): void {
+    for (const name of Object.keys(this.properties)) {
+      if (droppedAlongsideBody.has(name)) {
+        this.ignore(
+          name,
+          "ImportApi does not take it, and nothing here changes an API after " +
+            "it is created, so the API is created without it where real AWS " +
+            "would apply it in a second step",
+        );
+      }
     }
-
-    throw this.error(
-      refused,
-      "ImportApi does not take it, and nothing here changes an API after it " +
-        "is created, so it would be ignored here and applied on real AWS",
-    );
   }
 
   /**
@@ -104,6 +111,21 @@ export class SimCfnHttpApiPropertyRules {
     }
 
     throw this.error(name, reason);
+  }
+
+  /**
+   * Record a property this Resource carries and is created without, if it
+   * carries it.
+   */
+  private ignore(name: string, reason: string): void {
+    if (!Object.keys(this.properties).includes(name)) {
+      return;
+    }
+
+    this.resource.ignoreProperty(
+      name,
+      `AWS::ApiGatewayV2::Api property ${name} is not applied: ${reason}`,
+    );
   }
 
   /**

--- a/src/service/apigatewayv2/cfn/authorizer/sim-cfn-http-api-authorizer-properties.ts
+++ b/src/service/apigatewayv2/cfn/authorizer/sim-cfn-http-api-authorizer-properties.ts
@@ -47,7 +47,7 @@ export class SimCfnHttpApiAuthorizerProperties {
     this.resource = properties.resource;
     this.properties = properties.properties;
 
-    this.propertyParser.requireOnlySimulated(this.resource, this.properties);
+    this.propertyParser.ignoreUnsimulated(this.resource, this.properties);
   }
 
   /**

--- a/src/service/apigatewayv2/cfn/integration/sim-cfn-http-api-integration-properties.ts
+++ b/src/service/apigatewayv2/cfn/integration/sim-cfn-http-api-integration-properties.ts
@@ -40,7 +40,7 @@ export class SimCfnHttpApiIntegrationProperties {
     this.resource = properties.resource;
     this.properties = properties.properties;
 
-    this.propertyParser.requireOnlySimulated(this.resource, this.properties);
+    this.propertyParser.ignoreUnsimulated(this.resource, this.properties);
   }
 
   /**

--- a/src/service/apigatewayv2/cfn/route/sim-cfn-http-api-route-properties.ts
+++ b/src/service/apigatewayv2/cfn/route/sim-cfn-http-api-route-properties.ts
@@ -36,7 +36,7 @@ export class SimCfnHttpApiRouteProperties {
     this.resource = properties.resource;
     this.properties = properties.properties;
 
-    this.propertyParser.requireOnlySimulated(this.resource, this.properties);
+    this.propertyParser.ignoreUnsimulated(this.resource, this.properties);
   }
 
   /**

--- a/src/service/apigatewayv2/cfn/sim-cfn-api-gateway-v2-property-parser.ts
+++ b/src/service/apigatewayv2/cfn/sim-cfn-api-gateway-v2-property-parser.ts
@@ -8,18 +8,19 @@ interface SimCfnApiGatewayV2PropertyParserProperties {
 }
 
 /**
- * Validates the AWS::ApiGatewayV2::* CloudFormation properties of one Resource
- * type: which of them may appear, and, through the value parsing it inherits,
- * what shape each has to be.
+ * Reads the AWS::ApiGatewayV2::* CloudFormation properties of one Resource
+ * type: which of them are acted on, and, through the value parsing it inherits,
+ * what shape each of those has to be.
  *
  * Each Resource type states the properties it simulates, and every other
- * property is refused. An allow-list rather than a list of known-unsimulated
- * properties is what keeps a template from quietly deploying an API that looks
- * configured to the template that configured it and unconfigured to every
- * request it serves.
+ * property is recorded against the Resource and left out of what is created.
+ * An allow-list rather than a list of known-unsimulated properties is what
+ * keeps a template from quietly deploying an API that looks configured to the
+ * template that configured it and unconfigured to every request it serves: the
+ * API is created either way, and the record says which of the two it is.
  *
  * The Resource type is carried here because five of them are created, and a
- * message naming the wrong one would send a reader to the wrong template entry.
+ * record naming the wrong one would send a reader to the wrong template entry.
  */
 export class SimCfnApiGatewayV2PropertyParser extends SimCfnApiGatewayV2PropertyValues {
   private readonly simulated: readonly string[];
@@ -30,36 +31,36 @@ export class SimCfnApiGatewayV2PropertyParser extends SimCfnApiGatewayV2Property
   }
 
   /**
-   * Refuse every property this Resource type does not simulate.
+   * Record every property this Resource type does not simulate.
    *
    * A property whose only simulated value is one of the values it can take,
    * such as `ProtocolType`, counts as simulated here and is refused further
    * down by the API Gateway command that receives it, which is where the
    * reason lives.
    */
-  requireOnlySimulated(
+  ignoreUnsimulated(
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
   ): void {
     for (const name of Object.keys(properties)) {
       if (!this.simulated.includes(name)) {
-        throw this.unsimulatedPropertyError(resource, name);
+        resource.ignoreProperty(name, this.unsimulatedPropertyReason(name));
       }
     }
   }
 
   /**
-   * Build the diagnostic error for a property this simulator does not model.
+   * Say why a property this simulator does not model was left out.
+   *
+   * The simulated names are listed because an API Gateway Resource type has
+   * many more properties than this creates the API from, so what it can act on
+   * is the shorter and more useful half to read.
    */
-  private unsimulatedPropertyError(
-    resource: SimCfnResource,
-    label: string,
-  ): Error {
-    return new Error(
-      `${this.resourceType} ${resource.logicalId} property ${label} is not ` +
-        `simulated, and a deployed Resource ignoring it would behave ` +
-        `differently here than on AWS. The simulated properties are ` +
-        `${this.simulated.join(", ")}.`,
+  private unsimulatedPropertyReason(label: string): string {
+    return (
+      `${this.resourceType} property ${label} is not simulated, so the ` +
+      `Resource is created without it and behaves differently here than on ` +
+      `AWS. The simulated properties are ${this.simulated.join(", ")}.`
     );
   }
 }

--- a/src/service/apigatewayv2/cfn/sim-cfn-http-api-authorization.iso.test.ts
+++ b/src/service/apigatewayv2/cfn/sim-cfn-http-api-authorization.iso.test.ts
@@ -1,8 +1,14 @@
-import { assertStringIncludes } from "@kensio/smartass";
+import {
+  assertNonNullable,
+  assertStringIncludes,
+  assertTrue,
+} from "@kensio/smartass";
 import { describe, it } from "vitest";
 
 import {
+  deployHttpApi,
   deployHttpApiFailure,
+  ignoredReasons,
   simAwsInEuWest2,
 } from "../../../../test/apigatewayv2/cfn-deploy.js";
 import { simCfnHttpApiTemplateFactory } from "./sim-cfn-http-api-template.factory.js";
@@ -156,13 +162,13 @@ describe("API Gateway v2 CloudFormation authorization validation", () => {
     );
   });
 
-  it("refuses an authorizer Resource naming a Role to assume", async () => {
-    // Given a template whose Lambda authorizer names credentials for API
-    // Gateway to assume rather than relying on the function's own policy
+  it("creates an authorizer Resource without the Role it names to assume", async () => {
+    // Given a template whose authorizer names credentials for API Gateway to
+    // assume rather than relying on the invoked function's own policy
     const simAws = simAwsInEuWest2();
 
     // When the template is deployed
-    const error = await deployHttpApiFailure(
+    const stack = await deployHttpApi(
       simAws,
       simCfnHttpApiTemplateFactory.make({
         resources: {
@@ -170,8 +176,13 @@ describe("API Gateway v2 CloudFormation authorization validation", () => {
             Type: "AWS::ApiGatewayV2::Authorizer",
             Properties: {
               ApiId: { Ref: "Api" },
-              AuthorizerType: "REQUEST",
-              Name: "lambda",
+              AuthorizerType: "JWT",
+              Name: "pool",
+              IdentitySource: ["$request.header.Authorization"],
+              JwtConfiguration: {
+                Issuer: "https://issuer.test",
+                Audience: ["client01"],
+              },
               AuthorizerCredentialsArn: "arn:aws:iam::111111111111:role/Auth",
             },
           },
@@ -179,9 +190,14 @@ describe("API Gateway v2 CloudFormation authorization validation", () => {
       }),
     );
 
-    // Then it is refused by name, since nothing here assumes that Role
+    // Then the authorizer is created, with the Role nothing here assumes
+    // recorded against the Resource
+    assertTrue(stack.getResource("Authorizer")?.deployed);
+
+    const [reason] = ignoredReasons(stack);
+    assertNonNullable(reason);
     assertStringIncludes(
-      error.message,
+      reason,
       "property AuthorizerCredentialsArn is not simulated",
     );
   });

--- a/src/service/apigatewayv2/cfn/sim-cfn-http-api-body.iso.test.ts
+++ b/src/service/apigatewayv2/cfn/sim-cfn-http-api-body.iso.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from "vitest";
 import {
   deployHttpApi,
   deployHttpApiFailure,
+  ignoredReasons,
   simAwsInEuWest2,
 } from "../../../../test/apigatewayv2/cfn-deploy.js";
 import { SimAwsHttp } from "../../../serve/http/sim-aws-http.js";
@@ -118,12 +119,12 @@ describe("Deploying a sim HTTP API from an AWS::ApiGatewayV2::Api Body", () => {
     );
   });
 
-  it("refuses a property an imported API would drop", async () => {
+  it("creates an imported API without a property it would drop", async () => {
     // Given a template describing the API it imports
     const simAws = simAwsInEuWest2();
 
     // When it is deployed
-    const error = await deployHttpApiFailure(
+    const stack = await deployHttpApi(
       simAws,
       simCfnImportedHttpApiTemplateFactory.make({
         paths: ordersPaths,
@@ -131,28 +132,31 @@ describe("Deploying a sim HTTP API from an AWS::ApiGatewayV2::Api Body", () => {
       }),
     );
 
-    // Then the stack fails rather than deploying an API that ignored it,
-    // since ImportApi does not take it and nothing here updates an API
-    expect(error.message).toContain(
-      "property Description cannot be deployed: ImportApi does not take it",
+    // Then the API is created from the document without the description, since
+    // ImportApi does not take it and nothing here updates an API afterwards
+    const [reason] = ignoredReasons(stack);
+    expect(reason).toContain(
+      "property Description is not applied: ImportApi does not take it",
     );
   });
 
-  it("refuses FailOnWarnings on an Api that imports nothing", async () => {
+  it("creates an Api that imports nothing without its FailOnWarnings", async () => {
     // Given a Resource-declared API asking what to do with import warnings
     const simAws = simAwsInEuWest2();
 
     // When it is deployed
-    const error = await deployHttpApiFailure(
+    const stack = await deployHttpApi(
       simAws,
       simCfnHttpApiTemplateFactory.make({
         apiProperties: { FailOnWarnings: true },
       }),
     );
 
-    // Then the stack fails, since there is no document for it to be about
-    expect(error.message).toContain(
-      "property FailOnWarnings cannot be deployed: it says what to do with " +
+    // Then the API is created and the property is recorded, since there is no
+    // document for it to be about and real CloudFormation accepts this too
+    const [reason] = ignoredReasons(stack);
+    expect(reason).toContain(
+      "property FailOnWarnings is not applied: it says what to do with " +
         "the warnings an OpenAPI import finds",
     );
   });
@@ -193,12 +197,12 @@ describe("Deploying a sim HTTP API from an AWS::ApiGatewayV2::Api Body", () => {
     expect(error.message).toContain("Body must be an inline OpenAPI document");
   });
 
-  it("refuses a BodyS3Location, which is still not read", async () => {
+  it("creates an API without a BodyS3Location, which is still not read", async () => {
     // Given a template keeping its document in a bucket
     const simAws = simAwsInEuWest2();
 
     // When it is deployed
-    const error = await deployHttpApiFailure(
+    const stack = await deployHttpApi(
       simAws,
       simCfnHttpApiTemplateFactory.make({
         apiProperties: {
@@ -207,10 +211,11 @@ describe("Deploying a sim HTTP API from an AWS::ApiGatewayV2::Api Body", () => {
       }),
     );
 
-    // Then the stack fails, since reading a document out of a bucket adds a
-    // fetch path and nothing about OpenAPI
-    expect(error.message).toContain(
-      "AWS::ApiGatewayV2::Api Api property BodyS3Location is not simulated",
+    // Then the API is created with no routes at all, since reading a document
+    // out of a bucket adds a fetch path and nothing about OpenAPI
+    const [reason] = ignoredReasons(stack);
+    expect(reason).toContain(
+      "AWS::ApiGatewayV2::Api property BodyS3Location is not simulated",
     );
   });
 

--- a/src/service/apigatewayv2/cfn/sim-cfn-http-api-validation.iso.test.ts
+++ b/src/service/apigatewayv2/cfn/sim-cfn-http-api-validation.iso.test.ts
@@ -9,17 +9,18 @@ import { describe, it } from "vitest";
 import {
   deployHttpApi,
   deployHttpApiFailure,
+  ignoredReasons,
   simAwsInEuWest2,
 } from "../../../../test/apigatewayv2/cfn-deploy.js";
 import { simCfnHttpApiTemplateFactory } from "./sim-cfn-http-api-template.factory.js";
 
 describe("API Gateway v2 CloudFormation validation", () => {
-  it("refuses an API property outside the simulated set", async () => {
+  it("creates an API without a property outside the simulated set", async () => {
     // Given an API asking for CORS, which is not simulated
     const simAws = simAwsInEuWest2();
 
     // When the template is deployed
-    const error = await deployHttpApiFailure(
+    const stack = await deployHttpApi(
       simAws,
       simCfnHttpApiTemplateFactory.make({
         apiProperties: {
@@ -28,15 +29,19 @@ describe("API Gateway v2 CloudFormation validation", () => {
       }),
     );
 
-    // Then the stack fails, naming the Resource type, the logical ID, the
-    // property and what is simulated
-    assertStringIncludes(error.message, "Api");
+    // Then the API is created without answering preflight requests, and the
+    // record names the logical ID, the property and what is simulated
+    assertTrue(stack.getResource("Api")?.deployed);
+
+    const [reason] = ignoredReasons(stack);
+    assertNonNullable(reason);
+    assertStringIncludes(reason, "Api");
     assertStringIncludes(
-      error.message,
-      "AWS::ApiGatewayV2::Api Api property CorsConfiguration is not simulated",
+      reason,
+      "AWS::ApiGatewayV2::Api property CorsConfiguration is not simulated",
     );
     assertStringIncludes(
-      error.message,
+      reason,
       "The simulated properties are Name, ProtocolType, Description, " +
         "DisableExecuteApiEndpoint, Body, FailOnWarnings.",
     );
@@ -58,27 +63,32 @@ describe("API Gateway v2 CloudFormation validation", () => {
     assertStringIncludes(error.message, "WebSocket APIs are not simulated");
   });
 
-  it("refuses an integration property outside the simulated set", async () => {
+  it("creates an integration without a property outside the simulated set", async () => {
     // Given an integration asking for a request timeout
     const simAws = simAwsInEuWest2();
 
     // When the template is deployed
-    const error = await deployHttpApiFailure(
+    const stack = await deployHttpApi(
       simAws,
       simCfnHttpApiTemplateFactory.make({
         integrationProperties: { TimeoutInMillis: 5000 },
       }),
     );
 
-    // Then the stack fails, naming the Resource type, the logical ID, the
-    // property and what is simulated
+    // Then the integration is created without a timeout, and the record names
+    // the Resource type, the logical ID, the property and what is simulated
+    assertTrue(stack.getResource("Integration")?.deployed);
+
+    const [reason] = ignoredReasons(stack);
+    assertNonNullable(reason);
+    assertStringIncludes(reason, "Integration");
     assertStringIncludes(
-      error.message,
-      "AWS::ApiGatewayV2::Integration Integration property TimeoutInMillis " +
-        "is not simulated",
+      reason,
+      "AWS::ApiGatewayV2::Integration property TimeoutInMillis is not " +
+        "simulated",
     );
     assertStringIncludes(
-      error.message,
+      reason,
       "The simulated properties are ApiId, IntegrationType, IntegrationUri, " +
         "PayloadFormatVersion, Description.",
     );
@@ -150,12 +160,12 @@ describe("API Gateway v2 CloudFormation validation", () => {
     );
   });
 
-  it("refuses a stage property outside the simulated set", async () => {
+  it("creates a stage without a property outside the simulated set", async () => {
     // Given a stage asking for throttling settings
     const simAws = simAwsInEuWest2();
 
     // When the template is deployed
-    const error = await deployHttpApiFailure(
+    const stack = await deployHttpApi(
       simAws,
       simCfnHttpApiTemplateFactory.make({
         stageProperties: {
@@ -164,15 +174,20 @@ describe("API Gateway v2 CloudFormation validation", () => {
       }),
     );
 
-    // Then the stack fails, naming the Resource type, the logical ID, the
-    // property and what is simulated
+    // Then the stage is created throttling nothing, and the record names the
+    // Resource type, the logical ID, the property and what is simulated
+    assertTrue(stack.getResource("Stage")?.deployed);
+
+    const [reason] = ignoredReasons(stack);
+    assertNonNullable(reason);
+    assertStringIncludes(reason, "Stage");
     assertStringIncludes(
-      error.message,
-      "AWS::ApiGatewayV2::Stage Stage property DefaultRouteSettings is not " +
+      reason,
+      "AWS::ApiGatewayV2::Stage property DefaultRouteSettings is not " +
         "simulated",
     );
     assertStringIncludes(
-      error.message,
+      reason,
       "The simulated properties are ApiId, StageName, AutoDeploy, " +
         "StageVariables, Description.",
     );

--- a/src/service/apigatewayv2/cfn/stage/sim-cfn-http-api-stage-properties.ts
+++ b/src/service/apigatewayv2/cfn/stage/sim-cfn-http-api-stage-properties.ts
@@ -40,7 +40,7 @@ export class SimCfnHttpApiStageProperties {
     this.resource = properties.resource;
     this.properties = properties.properties;
 
-    this.propertyParser.requireOnlySimulated(this.resource, this.properties);
+    this.propertyParser.ignoreUnsimulated(this.resource, this.properties);
   }
 
   /**

--- a/src/service/cloudformation/resource/ignore/sim-cfn-ignored-properties.iso.test.ts
+++ b/src/service/cloudformation/resource/ignore/sim-cfn-ignored-properties.iso.test.ts
@@ -1,0 +1,84 @@
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimCfnResource } from "../sim-cfn-resource.js";
+
+/**
+ * A Resource of the given type, with nothing else on it.
+ */
+function makeResource(logicalId: string, type?: string): SimCfnResource {
+  const simAws = new SimAws();
+
+  return new SimCfnResource({
+    accountRegionScope: simAws.accountRegionScope().accountRegionScope,
+    logicalId,
+    template: type === undefined ? {} : { Type: type },
+  });
+}
+
+describe("SimCfnResource ignored properties", () => {
+  it("records an ignored property against the Resource that declared it", () => {
+    // Given a Bucket Resource.
+    const resource = makeResource("SiteBucket", "AWS::S3::Bucket");
+
+    // When its service reports creating it without a property.
+    resource.ignoreProperty(
+      "VersioningConfiguration",
+      "Object versions are not simulated",
+    );
+
+    // Then the record names the Resource, its type, the property and why.
+    assertArrayLength(resource.ignoredProperties, 1);
+    const ignored = resource.ignoredProperties[0];
+    assertNonNullable(ignored);
+    assertIdentical(ignored.logicalId, "SiteBucket");
+    assertIdentical(ignored.resourceType, "AWS::S3::Bucket");
+    assertIdentical(ignored.path, "VersioningConfiguration");
+    assertIdentical(ignored.reason, "Object versions are not simulated");
+  });
+
+  it("keeps one record of a property two levels of a parse both noticed", () => {
+    // Given a Resource whose property is reported twice with the same reason,
+    // as a nested shape read through two rules would.
+    const resource = makeResource("Orders", "AWS::DynamoDB::Table");
+
+    // When the same omission is recorded twice, and a different one once.
+    resource.ignoreProperty("Replicas.0.Region", "replication not simulated");
+    resource.ignoreProperty("Replicas.0.Region", "replication not simulated");
+    resource.ignoreProperty("Replicas.0.Region", "and for another reason");
+
+    // Then the repeat is dropped and the genuinely different one is kept.
+    assertArrayLength(resource.ignoredProperties, 2);
+  });
+
+  it("forgets what an earlier creation attempt ignored", () => {
+    // Given a Resource that recorded an ignored property while creating.
+    const resource = makeResource("SiteBucket", "AWS::S3::Bucket");
+    resource.ignoreProperty("Tags", "tags are not simulated");
+
+    // When the Resource starts creating again.
+    resource.markCreateInProgress();
+
+    // Then the record is of this attempt only, rather than every attempt so
+    // far.
+    assertArrayLength(resource.ignoredProperties, 0);
+  });
+
+  it("records an empty type for a Resource that declares none", () => {
+    // Given a Resource template with no Type at all.
+    const resource = makeResource("Untyped");
+
+    // When a property is ignored on it.
+    resource.ignoreProperty("Anything", "nothing reads this");
+
+    // Then the record still names the property, with no type to name.
+    const ignored = resource.ignoredProperties[0];
+    assertNonNullable(ignored);
+    assertIdentical(ignored.resourceType, "");
+  });
+});

--- a/src/service/cloudformation/resource/ignore/sim-cfn-ignored-properties.ts
+++ b/src/service/cloudformation/resource/ignore/sim-cfn-ignored-properties.ts
@@ -1,0 +1,73 @@
+import type { SimCfnIgnoredProperty } from "./sim-cfn-ignored-property.type.js";
+
+/**
+ * What a recorded property names as the Resource it was declared on.
+ */
+interface SimCfnIgnoredPropertyResource {
+  readonly logicalId: string;
+  readonly type: string | undefined;
+}
+
+/**
+ * The properties one CloudFormation Resource was created without acting on.
+ *
+ * Simulated CloudFormation deploys what it can. A Resource type it does not
+ * simulate is skipped and the rest of the stack still deploys; this is the
+ * same answer one level down, for a property the Resource's own service cannot
+ * act on. The Resource is created without it and the omission is recorded
+ * here, rather than the property taking the Resource, or the stack, down with
+ * it.
+ *
+ * The record is the point. An ignored property means the simulated Resource
+ * behaves differently to the one the template describes, so a test asserting
+ * on that behaviour needs somewhere to find out that it was never configured.
+ *
+ * Properties nothing simulated could tell apart are not recorded here, since a
+ * list of differences that make no difference is a list nobody can read. Each
+ * service decides which of its own properties those are.
+ */
+export class SimCfnIgnoredProperties {
+  #ignored: SimCfnIgnoredProperty[] = [];
+
+  /**
+   * Every property ignored on the current creation attempt.
+   */
+  public get all(): readonly SimCfnIgnoredProperty[] {
+    return this.#ignored;
+  }
+
+  /**
+   * Record a property the Resource was created without.
+   *
+   * A property recorded twice on one attempt is kept once, since two levels of
+   * the same parse noticing the same omission is a detail of how the template
+   * was read rather than something a reader needs told twice.
+   */
+  record(
+    resource: SimCfnIgnoredPropertyResource,
+    path: string,
+    reason: string,
+  ): void {
+    const already = this.#ignored.some((entry) => {
+      return entry.path === path && entry.reason === reason;
+    });
+
+    if (already) {
+      return;
+    }
+
+    this.#ignored.push({
+      logicalId: resource.logicalId,
+      resourceType: resource.type ?? "",
+      path,
+      reason,
+    });
+  }
+
+  /**
+   * Forget everything recorded, for a Resource starting creation again.
+   */
+  clear(): void {
+    this.#ignored = [];
+  }
+}

--- a/src/service/cloudformation/resource/ignore/sim-cfn-ignored-property.type.ts
+++ b/src/service/cloudformation/resource/ignore/sim-cfn-ignored-property.type.ts
@@ -1,0 +1,36 @@
+/**
+ * One property of a CloudFormation Resource that was deployed unread.
+ *
+ * The Resource exists and is usable. The property named here was left out of
+ * it, so the simulated Resource behaves as though the template had never
+ * declared that property at all.
+ */
+export interface SimCfnIgnoredProperty {
+  /** The logical ID of the Resource the property was declared on. */
+  readonly logicalId: string;
+
+  /** The Resource type, e.g. `AWS::S3::Bucket`. */
+  readonly resourceType: string;
+
+  /**
+   * The whole way to the property, so a setting on one entry of a list says
+   * which entry it was on, e.g. `GlobalSecondaryIndexes.1.OnDemandThroughput`.
+   */
+  readonly path: string;
+
+  /** Why the property was ignored rather than acted on. */
+  readonly reason: string;
+}
+
+/**
+ * What a service property parser records an ignored property against.
+ *
+ * Narrow on purpose: a property parser needs to say that it ignored something,
+ * and nothing else about the Resource holding it.
+ */
+export interface SimCfnPropertyIgnorer {
+  /**
+   * Record that this Resource is being created without acting on a property.
+   */
+  ignoreProperty(path: string, reason: string): void;
+}

--- a/src/service/cloudformation/resource/sim-cfn-resource.ts
+++ b/src/service/cloudformation/resource/sim-cfn-resource.ts
@@ -1,4 +1,3 @@
-import type { SimAws } from "../../aws/sim-aws.js";
 import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
 import {
   type BackgroundScheduler,
@@ -7,48 +6,27 @@ import {
 import type { SimCfnServiceResourceFactory } from "./factory/sim-cfn-resource-factory.type.js";
 import { SimCfnResourceCreateOperation } from "./create/sim-cfn-resource-create-operation.js";
 import { SimCfnResourceCreationState } from "./state/sim-cfn-resource-creation-state.js";
+import { SimCfnIgnoredProperties } from "./ignore/sim-cfn-ignored-properties.js";
+import type {
+  SimCfnIgnoredProperty,
+  SimCfnPropertyIgnorer,
+} from "./ignore/sim-cfn-ignored-property.type.js";
 import { SimCfnResourceTemplateReader } from "./template/sim-cfn-resource-template-reader.js";
 import type {
   SimCfnTemplateValue,
   SimCfnTemplateValueRecord,
 } from "../template/value/sim-cfn-template-value.js";
-import type { SimCfnParameters } from "../parameters/sim-cfn-parameters.js";
 import { SimCfnResourcePropertyResolver } from "./resolve/property/sim-cfn-resource-property-resolver.js";
 import {
   type SimCfnResourceValueAdapter,
   simCfnResourceValueAdapter,
 } from "./cfn/sim-cfn-resource-value-adapter.js";
-import type { SimCdkOutContext } from "../cdk/sim-cdk-out-context.js";
-import type { SimCfnExecutableResourceBinding } from "../bind/sim-cfn-exec-binding.type.js";
 import { simAwsAccountRegionScopeFactory } from "../../aws/sim-aws-account-region-scope.factory.js";
-
-export interface SimCloudFormationResourceProperties {
-  readonly accountRegionScope?: SimAwsAccountRegionScope;
-  readonly background?: BackgroundScheduler;
-  readonly logicalId?: string;
-  readonly stackName?: string | undefined;
-  readonly template?: SimCfnTemplateValueRecord;
-  readonly cfnResourceFactory?: SimCfnServiceResourceFactory | undefined;
-  readonly parameters?: SimCfnParameters | undefined;
-  readonly resourceLogicalIds?: ReadonlySet<string> | undefined;
-}
-
-/**
- * Simulated CloudFormation Resource status.
- *
- * These states model the CloudFormation creation lifecycle for one Resource
- * entry, not the lifecycle of the underlying simulated AWS service object.
- */
-export type SimCloudFormationResourceStatus =
-  "CREATE_PENDING" | "CREATE_IN_PROGRESS" | "CREATE_COMPLETE" | "CREATE_FAILED";
-
-export interface SimCloudFormationResourceCreateContext {
-  readonly simAws: SimAws;
-  readonly resources: ReadonlyMap<string, SimCfnResource>;
-  readonly resolvedProperties?: SimCfnTemplateValueRecord | undefined;
-  readonly cdkOutContext?: SimCdkOutContext | undefined;
-  readonly bindings?: readonly SimCfnExecutableResourceBinding[] | undefined;
-}
+import type {
+  SimCloudFormationResourceCreateContext,
+  SimCloudFormationResourceProperties,
+  SimCloudFormationResourceStatus,
+} from "./sim-cfn-resource.type.js";
 
 /**
  * Runtime representation of one CloudFormation Resource entry.
@@ -63,17 +41,19 @@ export interface SimCloudFormationResourceCreateContext {
  * - Resource-field reading belongs to SimCfnResourceTemplateReader;
  * - asynchronous creation orchestration belongs to SimCfnResourceCreateOperation;
  * - service-specific object construction belongs to SimCfnServiceResourceFactory.
- *
  * As a result, SimCfnResource acts as the stable Resource record passed between
  * stack creation, dependency resolution, and service-specific factories.
  */
-export class SimCfnResource<T extends object = object> {
+export class SimCfnResource<
+  T extends object = object,
+> implements SimCfnPropertyIgnorer {
   public readonly accountRegionScope: SimAwsAccountRegionScope;
   public readonly logicalId: string;
   /** The Stack this Resource belongs to, where a generated name comes from. */
   public readonly stackName: string | undefined;
   public readonly template: SimCfnTemplateValueRecord;
   private readonly creationState = new SimCfnResourceCreationState<T>();
+  private readonly ignoredPropertyList = new SimCfnIgnoredProperties();
   private readonly resourceTemplateReader: SimCfnResourceTemplateReader;
   private readonly propertyResolver: SimCfnResourcePropertyResolver;
   private readonly background: BackgroundScheduler;
@@ -130,6 +110,22 @@ export class SimCfnResource<T extends object = object> {
    */
   public get skippedReason(): string | undefined {
     return this.creationState.skippedReason;
+  }
+
+  /**
+   * The properties this Resource was created without acting on.
+   */
+  public get ignoredProperties(): readonly SimCfnIgnoredProperty[] {
+    return this.ignoredPropertyList.all;
+  }
+
+  /**
+   * Record that this Resource is being created without acting on a property.
+   * Called by the service parsing this Resource's properties, which is the
+   * only thing that knows whether a property changes behaviour it simulates.
+   */
+  ignoreProperty(path: string, reason: string): void {
+    this.ignoredPropertyList.record(this, path, reason);
   }
 
   /**
@@ -255,13 +251,13 @@ export class SimCfnResource<T extends object = object> {
    * CloudFormation lifecycle.
    */
   markCreateInProgress(): void {
+    this.ignoredPropertyList.clear();
     this.creationState.markCreateInProgress();
   }
 
   /**
-   * Mark this Resource as successfully created and store its simulated AWS object.
-   *
-   * Intended for use by the creation operation after the appropriate
+   * Mark this Resource as successfully created and store its simulated AWS
+   * object. Intended for use by the creation operation after the appropriate
    * service-specific factory has created the simulated resource.
    */
   markCreateComplete(simResource?: T): void {
@@ -281,7 +277,6 @@ export class SimCfnResource<T extends object = object> {
 
   /**
    * Mark this Resource as failed to create and store the failure reason.
-   *
    * Intended for use by the creation operation when service-specific creation
    * throws or rejects.
    */
@@ -297,3 +292,9 @@ export class SimCfnResource<T extends object = object> {
     });
   }
 }
+
+export {
+  type SimCloudFormationResourceCreateContext,
+  type SimCloudFormationResourceProperties,
+  type SimCloudFormationResourceStatus,
+} from "./sim-cfn-resource.type.js";

--- a/src/service/cloudformation/resource/sim-cfn-resource.type.ts
+++ b/src/service/cloudformation/resource/sim-cfn-resource.type.ts
@@ -1,0 +1,37 @@
+import type { SimAws } from "../../aws/sim-aws.js";
+import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+import type { BackgroundScheduler } from "../../../util/background/background.js";
+import type { SimCfnServiceResourceFactory } from "./factory/sim-cfn-resource-factory.type.js";
+import type { SimCfnTemplateValueRecord } from "../template/value/sim-cfn-template-value.js";
+import type { SimCfnParameters } from "../parameters/sim-cfn-parameters.js";
+import type { SimCdkOutContext } from "../cdk/sim-cdk-out-context.js";
+import type { SimCfnExecutableResourceBinding } from "../bind/sim-cfn-exec-binding.type.js";
+import type { SimCfnResource } from "./sim-cfn-resource.js";
+
+export interface SimCloudFormationResourceProperties {
+  readonly accountRegionScope?: SimAwsAccountRegionScope;
+  readonly background?: BackgroundScheduler;
+  readonly logicalId?: string;
+  readonly stackName?: string | undefined;
+  readonly template?: SimCfnTemplateValueRecord;
+  readonly cfnResourceFactory?: SimCfnServiceResourceFactory | undefined;
+  readonly parameters?: SimCfnParameters | undefined;
+  readonly resourceLogicalIds?: ReadonlySet<string> | undefined;
+}
+
+/**
+ * Simulated CloudFormation Resource status.
+ *
+ * These states model the CloudFormation creation lifecycle for one Resource
+ * entry, not the lifecycle of the underlying simulated AWS service object.
+ */
+export type SimCloudFormationResourceStatus =
+  "CREATE_PENDING" | "CREATE_IN_PROGRESS" | "CREATE_COMPLETE" | "CREATE_FAILED";
+
+export interface SimCloudFormationResourceCreateContext {
+  readonly simAws: SimAws;
+  readonly resources: ReadonlyMap<string, SimCfnResource>;
+  readonly resolvedProperties?: SimCfnTemplateValueRecord | undefined;
+  readonly cdkOutContext?: SimCdkOutContext | undefined;
+  readonly bindings?: readonly SimCfnExecutableResourceBinding[] | undefined;
+}

--- a/src/service/cloudformation/stack/sim-cfn-stack.ts
+++ b/src/service/cloudformation/stack/sim-cfn-stack.ts
@@ -3,6 +3,7 @@ import type { Brand } from "../../../util/brand.type.js";
 import type { BackgroundScheduler } from "../../../util/background/background.js";
 import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
 import type { SimCfnResource } from "../resource/sim-cfn-resource.js";
+import type { SimCfnIgnoredProperty } from "../resource/ignore/sim-cfn-ignored-property.type.js";
 import type {
   CfnTemplateBodyRecord,
   SimCfnTemplate,
@@ -130,6 +131,20 @@ export class SimCfnStack {
    */
   public get skippedResources(): readonly SimCfnResource[] {
     return this.skippedResourceList;
+  }
+
+  /**
+   * Every property the deployment created a Resource without acting on.
+   *
+   * Read from the Resources rather than collected during deployment, so a
+   * Resource created outside a stack deployment still reports its own, and the
+   * two never disagree.
+   */
+  public get ignoredProperties(): readonly SimCfnIgnoredProperty[] {
+    return this.resources
+      .values()
+      .flatMap((resource) => resource.ignoredProperties)
+      .toArray();
   }
 
   /**

--- a/src/service/cognito/cfn/client/sim-cfn-cognito-client-properties.ts
+++ b/src/service/cognito/cfn/client/sim-cfn-cognito-client-properties.ts
@@ -56,7 +56,7 @@ export class SimCfnCognitoClientProperties {
     this.resource = properties.resource;
     this.properties = properties.properties;
 
-    this.propertyParser.requireOnlySimulated(this.resource, this.properties);
+    this.propertyParser.ignoreUnsimulated(this.resource, this.properties);
   }
 
   /**

--- a/src/service/cognito/cfn/client/sim-cfn-cognito-token-validity-units.ts
+++ b/src/service/cognito/cfn/client/sim-cfn-cognito-token-validity-units.ts
@@ -46,7 +46,7 @@ export class SimCfnCognitoTokenValidityUnits {
       return undefined;
     }
 
-    this.propertyParser.requireOnlyKeys(
+    this.propertyParser.ignoreUnmodelledKeys(
       this.resource,
       units,
       modelledFields,

--- a/src/service/cognito/cfn/group/sim-cfn-cognito-group-properties.ts
+++ b/src/service/cognito/cfn/group/sim-cfn-cognito-group-properties.ts
@@ -36,7 +36,7 @@ export class SimCfnCognitoGroupProperties {
     this.resource = properties.resource;
     this.properties = properties.properties;
 
-    this.propertyParser.requireOnlySimulated(this.resource, this.properties);
+    this.propertyParser.ignoreUnsimulated(this.resource, this.properties);
   }
 
   /**

--- a/src/service/cognito/cfn/sim-cfn-cognito-properties.iso.test.ts
+++ b/src/service/cognito/cfn/sim-cfn-cognito-properties.iso.test.ts
@@ -11,6 +11,8 @@ import { describe, it } from "vitest";
 import type { SimCfnTemplateValueRecord } from "../../cloudformation/template/value/sim-cfn-template-value.js";
 import {
   deployFailure,
+  deploySuccess,
+  ignoredReasons,
   simAwsInEuWest2,
 } from "../../../../test/cognito/cfn-deploy.js";
 
@@ -107,10 +109,10 @@ describe("Cognito CloudFormation property shapes", () => {
     );
   });
 
-  it("refuses a nested property key it does not model", async () => {
+  it("records a nested property key it does not model", async () => {
     // Given templates carrying a key nothing reads inside each of the nested
     // objects.
-    const passwordPolicyError = await deployFailure(simAwsInEuWest2(), {
+    const passwordPolicyStack = await deploySuccess(simAwsInEuWest2(), {
       AppPool: {
         Type: "AWS::Cognito::UserPool",
         Properties: {
@@ -119,7 +121,7 @@ describe("Cognito CloudFormation property shapes", () => {
         },
       },
     });
-    const unitsError = await deployFailure(simAwsInEuWest2(), {
+    const unitsStack = await deploySuccess(simAwsInEuWest2(), {
       AppPool: appPool,
       AppClient: {
         Type: "AWS::Cognito::UserPoolClient",
@@ -130,14 +132,19 @@ describe("Cognito CloudFormation property shapes", () => {
       },
     });
 
-    // Then each is refused where it sits, rather than dropped on the way to
-    // the Command as the top-level properties would not be.
+    // Then each is recorded at the level it sits at, rather than dropped on
+    // the way to the Command with nothing said about it.
+    const [passwordPolicyReason] = ignoredReasons(passwordPolicyStack);
+    assertNonNullable(passwordPolicyReason);
     assertStringIncludes(
-      passwordPolicyError.message,
+      passwordPolicyReason,
       "property Policies PasswordPolicy RequireEmoji is not simulated",
     );
+
+    const [unitsReason] = ignoredReasons(unitsStack);
+    assertNonNullable(unitsReason);
     assertStringIncludes(
-      unitsError.message,
+      unitsReason,
       "property TokenValidityUnits SessionToken is not simulated",
     );
   });

--- a/src/service/cognito/cfn/sim-cfn-cognito-property-parser.ts
+++ b/src/service/cognito/cfn/sim-cfn-cognito-property-parser.ts
@@ -11,14 +11,18 @@ interface SimCfnCognitoPropertyParserProperties {
 }
 
 /**
- * Validates the AWS::Cognito::* CloudFormation properties of one Resource
- * type, both which of them may appear and what shape each has to be.
+ * Reads the AWS::Cognito::* CloudFormation properties of one Resource type,
+ * deciding which of them are acted on and checking the shape of those that are.
  *
  * Each Resource type states the properties it simulates, and every other
- * property is refused. An allow-list rather than a list of known-unsimulated
- * properties is what keeps a template from quietly deploying something this
- * simulation would ignore, including properties CloudFormation has that the
- * Cognito API does not.
+ * property is recorded against the Resource and left out of what is created.
+ * An allow-list rather than a list of known-unsimulated properties is what
+ * keeps the record honest: a property CloudFormation has that the Cognito API
+ * does not still shows up in it, without this having to name every one.
+ *
+ * Nothing is deployed quietly. What is not simulated is not silently dropped;
+ * it is created without and reported, so a user pool that behaves differently
+ * to the template says so.
  */
 export class SimCfnCognitoPropertyParser extends SimCfnCognitoValueParser {
   private readonly simulated: readonly string[];
@@ -29,28 +33,28 @@ export class SimCfnCognitoPropertyParser extends SimCfnCognitoValueParser {
   }
 
   /**
-   * Refuse every property this Resource type does not simulate.
+   * Record every property this Resource type does not simulate.
    *
    * A property whose only simulated value is its AWS default, such as
    * `MfaConfiguration`, counts as simulated here and is refused further down
    * by the Cognito command that receives it.
    */
-  requireOnlySimulated(
+  ignoreUnsimulated(
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
   ): void {
-    this.requireOnlyKeys(resource, properties, this.simulated);
+    this.ignoreUnmodelledKeys(resource, properties, this.simulated);
   }
 
   /**
-   * Refuse every key of a nested property object that is not modelled.
+   * Record every key of a nested property object that is not modelled.
    *
    * A nested object is held to the same rule as the properties around it. A
    * `Policies` or a `TokenValidityUnits` carrying a key nothing here reads
-   * would otherwise be dropped on the way to the Command, which is the quiet
-   * ignoring the top-level allow-list exists to prevent.
+   * would otherwise be dropped on the way to the Command without a word about
+   * it, which is the quiet ignoring the top-level allow-list exists to prevent.
    */
-  requireOnlyKeys(
+  ignoreUnmodelledKeys(
     resource: SimCfnResource,
     record: SimCfnTemplateValueRecord,
     modelled: readonly string[],
@@ -58,10 +62,9 @@ export class SimCfnCognitoPropertyParser extends SimCfnCognitoValueParser {
   ): void {
     for (const name of Object.keys(record)) {
       if (!modelled.includes(name)) {
-        throw this.unsimulatedPropertyError(
-          resource,
+        resource.ignoreProperty(
           `${path}${name}`,
-          modelled,
+          this.unsimulatedPropertyReason(`${path}${name}`, modelled),
         );
       }
     }
@@ -108,18 +111,20 @@ export class SimCfnCognitoPropertyParser extends SimCfnCognitoValueParser {
   }
 
   /**
-   * Build the diagnostic error for a property this simulator does not model.
+   * Say why a property this simulator does not model was left out.
+   *
+   * The modelled names are listed because a Cognito Resource type has a lot of
+   * properties and few of them are simulated, so what this can act on is
+   * shorter and more useful to read than what it cannot.
    */
-  private unsimulatedPropertyError(
-    resource: SimCfnResource,
+  private unsimulatedPropertyReason(
     label: string,
     modelled: readonly string[],
-  ): Error {
-    return new Error(
-      `${this.resourceType} ${resource.logicalId} property ${label} is not ` +
-        `simulated, and a deployed Resource ignoring it would behave ` +
-        `differently here than on AWS. The simulated properties are ` +
-        `${modelled.join(", ")}.`,
+  ): string {
+    return (
+      `${this.resourceType} property ${label} is not simulated, so the ` +
+      `Resource is created without it and behaves differently here than on ` +
+      `AWS. The simulated properties are ${modelled.join(", ")}.`
     );
   }
 }

--- a/src/service/cognito/cfn/sim-cfn-cognito-validation.iso.test.ts
+++ b/src/service/cognito/cfn/sim-cfn-cognito-validation.iso.test.ts
@@ -5,6 +5,7 @@ import {
   assertNonNullable,
   assertStringIncludes,
   assertStringLength,
+  assertTrue,
   assertTypeString,
   assertUndefined,
 } from "@kensio/smartass";
@@ -14,6 +15,8 @@ import { describe, it } from "vitest";
 import { SimCognitoUserPool } from "../../cognito/user-pool/sim-cognito-user-pool.js";
 import {
   deployFailure,
+  deploySuccess,
+  ignoredReasons,
   simAwsInEuWest2,
 } from "../../../../test/cognito/cfn-deploy.js";
 
@@ -81,12 +84,12 @@ describe("Cognito CloudFormation validation", () => {
     assertUndefined(browserClient.secret);
   });
 
-  it("refuses a user pool property it does not simulate", async () => {
+  it("creates a user pool without a property it does not simulate", async () => {
     // Given a template asking for a pool that signs users in by email.
     const simAws = simAwsInEuWest2();
 
     // When it is deployed.
-    const error = await deployFailure(simAws, {
+    const stack = await deploySuccess(simAws, {
       AppPool: {
         Type: "AWS::Cognito::UserPool",
         Properties: {
@@ -96,19 +99,24 @@ describe("Cognito CloudFormation validation", () => {
       },
     });
 
-    // Then the failure names the logical ID and the property, rather than the
-    // pool being deployed without it.
-    assertStringIncludes(error.message, "AppPool");
-    assertStringIncludes(error.message, "UsernameAttributes is not simulated");
-    assertStringIncludes(error.message, "The simulated properties are");
+    // Then the pool exists, and the record names the logical ID, the property
+    // and what this simulation can act on instead.
+    assertTrue(stack.getResource("AppPool")?.deployed);
+    assertArrayLength(stack.ignoredProperties, 1);
+
+    const [reason] = ignoredReasons(stack);
+    assertNonNullable(reason);
+    assertStringIncludes(reason, "AppPool");
+    assertStringIncludes(reason, "UsernameAttributes is not simulated");
+    assertStringIncludes(reason, "The simulated properties are");
   });
 
-  it("refuses an app client property it does not simulate", async () => {
+  it("creates an app client without a property it does not simulate", async () => {
     // Given a template asking for a client with the hosted UI OAuth flows.
     const simAws = simAwsInEuWest2();
 
     // When it is deployed.
-    const error = await deployFailure(simAws, {
+    const stack = await deploySuccess(simAws, {
       AppPool: {
         Type: "AWS::Cognito::UserPool",
         Properties: { UserPoolName: "myapp-users" },
@@ -122,9 +130,14 @@ describe("Cognito CloudFormation validation", () => {
       },
     });
 
-    // Then the failure names that client and that property.
-    assertStringIncludes(error.message, "AppClient");
-    assertStringIncludes(error.message, "AllowedOAuthFlows is not simulated");
+    // Then the client exists, with a record naming that client and that
+    // property.
+    assertTrue(stack.getResource("AppClient")?.deployed);
+
+    const [reason] = ignoredReasons(stack);
+    assertNonNullable(reason);
+    assertStringIncludes(reason, "AppClient");
+    assertStringIncludes(reason, "AllowedOAuthFlows is not simulated");
   });
 
   it("refuses a pool feature the Cognito API refuses", async () => {

--- a/src/service/cognito/cfn/user-pool/sim-cfn-cognito-password-policy.ts
+++ b/src/service/cognito/cfn/user-pool/sim-cfn-cognito-password-policy.ts
@@ -53,7 +53,7 @@ export class SimCfnCognitoPasswordPolicy {
       return undefined;
     }
 
-    this.propertyParser.requireOnlyKeys(
+    this.propertyParser.ignoreUnmodelledKeys(
       this.resource,
       policy,
       modelledFields,

--- a/src/service/cognito/cfn/user-pool/sim-cfn-cognito-policies.ts
+++ b/src/service/cognito/cfn/user-pool/sim-cfn-cognito-policies.ts
@@ -48,7 +48,7 @@ export class SimCfnCognitoPolicies {
       return undefined;
     }
 
-    this.propertyParser.requireOnlyKeys(
+    this.propertyParser.ignoreUnmodelledKeys(
       this.resource,
       policies,
       modelledFields,

--- a/src/service/cognito/cfn/user-pool/sim-cfn-cognito-sign-in-policy.ts
+++ b/src/service/cognito/cfn/user-pool/sim-cfn-cognito-sign-in-policy.ts
@@ -44,7 +44,7 @@ export class SimCfnCognitoSignInPolicy {
       return undefined;
     }
 
-    this.propertyParser.requireOnlyKeys(
+    this.propertyParser.ignoreUnmodelledKeys(
       this.resource,
       policy,
       modelledFields,

--- a/src/service/cognito/cfn/user-pool/sim-cfn-cognito-user-pool-properties.ts
+++ b/src/service/cognito/cfn/user-pool/sim-cfn-cognito-user-pool-properties.ts
@@ -13,8 +13,8 @@ import { SimCfnCognitoPolicies } from "./sim-cfn-cognito-policies.js";
  *
  * `MfaConfiguration` and `UserPoolTier` are here because CreateUserPool
  * accepts each at its AWS default and refuses it otherwise, in words that say
- * why. A CDK stack states both routinely, so refusing them outright would
- * refuse templates that ask for nothing unsimulated.
+ * why. A CDK stack states both routinely, and a pool created without either
+ * would be reported as behaving differently when it does not.
  *
  * The six from `AccountRecoverySetting` down are here for the same reason,
  * and are the six a CDK `UserPool` construct emits when it was asked for
@@ -46,9 +46,9 @@ interface SimCfnCognitoUserPoolPropertiesProperties {
  * Reads AWS::Cognito::UserPool CloudFormation properties into the CreateUserPool
  * input the pool creator needs.
  *
- * The refusal of unsimulated properties runs on construction rather than when
- * a property is read, so a Resource asking for something unmodelled cannot get
- * as far as creating a pool that would then be wrong.
+ * The recording of unsimulated properties runs on construction rather than
+ * when a property is read, so the report of what the pool was created without
+ * is complete whichever properties the creator goes on to ask for.
  */
 export class SimCfnCognitoUserPoolProperties {
   private readonly resource: SimCfnResource;
@@ -62,7 +62,7 @@ export class SimCfnCognitoUserPoolProperties {
     this.resource = properties.resource;
     this.properties = properties.properties;
 
-    this.propertyParser.requireOnlySimulated(this.resource, this.properties);
+    this.propertyParser.ignoreUnsimulated(this.resource, this.properties);
   }
 
   /**

--- a/src/service/dynamodb/cfn/global-table/sim-cfn-dynamodb-global-table-capacity.ts
+++ b/src/service/dynamodb/cfn/global-table/sim-cfn-dynamodb-global-table-capacity.ts
@@ -34,11 +34,37 @@ export function simCfnDynamoDbGlobalTableCapacity(
   return Object.fromEntries([
     ...simCfnDynamoDbGlobalTableEntry(
       "ReadCapacityUnits",
-      sources.read?.number("ReadCapacityUnits"),
+      capacityUnits(sources.read, "Read"),
     ),
     ...simCfnDynamoDbGlobalTableEntry(
       "WriteCapacityUnits",
-      sources.write?.number("WriteCapacityUnits"),
+      capacityUnits(sources.write, "Write"),
     ),
   ]);
+}
+
+/**
+ * The fixed capacity one half states, falling back to where autoscaling would
+ * have started it.
+ *
+ * Nothing here scales a table with load, so the autoscaling settings themselves
+ * are recorded as unsimulated a level up. Their `MinCapacity` is still the
+ * capacity the table is created at on AWS, though, so it is the honest fixed
+ * capacity to create the table with: the table exists and takes the load a
+ * newly created one takes, rather than the deployment failing because the only
+ * capacity the template stated was one this simulation cannot act on.
+ */
+function capacityUnits(
+  values: SimCfnDynamoDbPropertyValues | undefined,
+  half: string,
+): number | undefined {
+  const fixed = values?.number(`${half}CapacityUnits`);
+
+  if (fixed !== undefined) {
+    return fixed;
+  }
+
+  return values
+    ?.object(`${half}CapacityAutoScalingSettings`)
+    ?.number("MinCapacity");
 }

--- a/src/service/dynamodb/cfn/global-table/sim-cfn-dynamodb-global-table-properties.ts
+++ b/src/service/dynamodb/cfn/global-table/sim-cfn-dynamodb-global-table-properties.ts
@@ -9,7 +9,8 @@ import {
   simCfnDynamoDbGlobalTableProperty,
 } from "./sim-cfn-dynamodb-global-table-property.js";
 import { SimCfnDynamoDbGlobalTableReplicas } from "./sim-cfn-dynamodb-global-table-replicas.js";
-import { assertSimCfnDynamoDbGlobalTableSimulated } from "./sim-cfn-dynamodb-global-table-simulated.js";
+import { applySimCfnDynamoDbGlobalTableRules } from "./sim-cfn-dynamodb-global-table-simulated.js";
+import type { SimCfnDynamoDbResourceScope } from "../property/sim-cfn-dynamodb-resource-scope.js";
 
 /**
  * The properties a global table states the same way an ordinary table does.
@@ -55,36 +56,39 @@ interface SimCfnDynamoDbGlobalTablePropertiesProperties {
  * about replication that have nothing to be true of on one table in one region.
  */
 export class SimCfnDynamoDbGlobalTableProperties {
-  private readonly logicalId: string;
+  private readonly scope: SimCfnDynamoDbResourceScope;
   private readonly values: SimCfnDynamoDbPropertyValues;
   private readonly replicas: SimCfnDynamoDbGlobalTableReplicas;
 
   constructor(properties: SimCfnDynamoDbGlobalTablePropertiesProperties) {
-    this.logicalId = properties.resource.logicalId;
+    this.scope = {
+      logicalId: properties.resource.logicalId,
+      ignorer: properties.resource,
+    };
     this.values = new SimCfnDynamoDbPropertyValues({
       resourceTypeName: dynamoDbGlobalTableResourceTypeName,
-      logicalId: this.logicalId,
+      logicalId: this.scope.logicalId,
       properties: properties.properties,
     });
     this.replicas = new SimCfnDynamoDbGlobalTableReplicas({
-      logicalId: this.logicalId,
+      scope: this.scope,
       regionName: properties.resource.accountRegionScope.regionName,
       values: this.values,
     });
   }
 
   /**
-   * The AWS::DynamoDB::Table properties this global table is, refusing
+   * The AWS::DynamoDB::Table properties this global table is, recording
    * everything about it that is not simulated on the way.
    *
-   * The replica is settled first, since a table replicating across regions is
-   * skipped whatever else it asks for.
+   * The replica is settled first, since which region the table is created in
+   * decides which replica's settings the rest of the read comes from.
    */
   tableProperties(): SimCfnTemplateValueRecord {
     const replica = this.replicas.single();
 
-    assertSimCfnDynamoDbGlobalTableSimulated({
-      logicalId: this.logicalId,
+    applySimCfnDynamoDbGlobalTableRules({
+      scope: this.scope,
       values: this.values,
       replica,
     });

--- a/src/service/dynamodb/cfn/global-table/sim-cfn-dynamodb-global-table-property-rules.ts
+++ b/src/service/dynamodb/cfn/global-table/sim-cfn-dynamodb-global-table-property-rules.ts
@@ -1,4 +1,5 @@
 import { SimCfnDynamoDbPropertyRules } from "../property/sim-cfn-dynamodb-property-rules.js";
+import type { SimCfnDynamoDbResourceScope } from "../property/sim-cfn-dynamodb-resource-scope.js";
 import { dynamoDbGlobalTableResourceTypeName } from "../sim-cfn-dynamodb-resource-type.js";
 
 /**
@@ -88,8 +89,8 @@ const simulatedStreamPropertyNames: ReadonlySet<string> = new Set([
  * A fixed `WriteCapacityUnits` is the capacity an ordinary table's
  * `ProvisionedThroughput` states, so it is carried across.
  * `WriteCapacityAutoScalingSettings` asks for capacity that changes with load,
- * which nothing here changes, so it skips the table rather than being read as
- * the capacity it starts at.
+ * which nothing here changes, so it is recorded and the table is created at the
+ * `MinCapacity` it names.
  */
 const simulatedWriteCapacityPropertyNames: ReadonlySet<string> = new Set([
   "WriteCapacityUnits",
@@ -103,11 +104,11 @@ const unsimulatedWriteCapacityPropertyNames: ReadonlySet<string> = new Set([
  * The rules the Resource's own properties are read under.
  */
 export function simCfnDynamoDbGlobalTableRules(
-  logicalId: string,
+  scope: SimCfnDynamoDbResourceScope,
 ): SimCfnDynamoDbPropertyRules {
   return new SimCfnDynamoDbPropertyRules({
     resourceTypeName: dynamoDbGlobalTableResourceTypeName,
-    logicalId,
+    scope,
     simulated: simulatedPropertyNames,
     unsimulated: unsimulatedPropertyNames,
   });
@@ -117,11 +118,11 @@ export function simCfnDynamoDbGlobalTableRules(
  * The rules a `GlobalSecondaryIndexes` entry on the table itself is read under.
  */
 export function simCfnDynamoDbGlobalTableIndexRules(
-  logicalId: string,
+  scope: SimCfnDynamoDbResourceScope,
 ): SimCfnDynamoDbPropertyRules {
   return new SimCfnDynamoDbPropertyRules({
     resourceTypeName: dynamoDbGlobalTableResourceTypeName,
-    logicalId,
+    scope,
     kind: "GlobalSecondaryIndex",
     simulated: simulatedIndexPropertyNames,
     unsimulated: unsimulatedIndexPropertyNames,
@@ -132,11 +133,11 @@ export function simCfnDynamoDbGlobalTableIndexRules(
  * The rules a `LocalSecondaryIndexes` entry is read under.
  */
 export function simCfnDynamoDbGlobalTableLocalIndexRules(
-  logicalId: string,
+  scope: SimCfnDynamoDbResourceScope,
 ): SimCfnDynamoDbPropertyRules {
   return new SimCfnDynamoDbPropertyRules({
     resourceTypeName: dynamoDbGlobalTableResourceTypeName,
-    logicalId,
+    scope,
     kind: "LocalSecondaryIndex",
     simulated: simulatedLocalIndexPropertyNames,
   });
@@ -146,11 +147,11 @@ export function simCfnDynamoDbGlobalTableLocalIndexRules(
  * The rules the `StreamSpecification` is read under.
  */
 export function simCfnDynamoDbGlobalTableStreamRules(
-  logicalId: string,
+  scope: SimCfnDynamoDbResourceScope,
 ): SimCfnDynamoDbPropertyRules {
   return new SimCfnDynamoDbPropertyRules({
     resourceTypeName: dynamoDbGlobalTableResourceTypeName,
-    logicalId,
+    scope,
     kind: "StreamSpecification",
     simulated: simulatedStreamPropertyNames,
   });
@@ -161,11 +162,11 @@ export function simCfnDynamoDbGlobalTableStreamRules(
  * or on one of its global secondary indexes.
  */
 export function simCfnDynamoDbGlobalTableWriteCapacityRules(
-  logicalId: string,
+  scope: SimCfnDynamoDbResourceScope,
 ): SimCfnDynamoDbPropertyRules {
   return new SimCfnDynamoDbPropertyRules({
     resourceTypeName: dynamoDbGlobalTableResourceTypeName,
-    logicalId,
+    scope,
     kind: "WriteProvisionedThroughputSettings",
     simulated: simulatedWriteCapacityPropertyNames,
     unsimulated: unsimulatedWriteCapacityPropertyNames,

--- a/src/service/dynamodb/cfn/global-table/sim-cfn-dynamodb-global-table-replica-rules.ts
+++ b/src/service/dynamodb/cfn/global-table/sim-cfn-dynamodb-global-table-replica-rules.ts
@@ -1,4 +1,5 @@
 import { SimCfnDynamoDbPropertyRules } from "../property/sim-cfn-dynamodb-property-rules.js";
+import type { SimCfnDynamoDbResourceScope } from "../property/sim-cfn-dynamodb-resource-scope.js";
 import { dynamoDbGlobalTableResourceTypeName } from "../sim-cfn-dynamodb-resource-type.js";
 
 /**
@@ -54,8 +55,8 @@ const unsimulatedReplicaIndexPropertyNames: ReadonlySet<string> = new Set([
  *
  * A fixed `ReadCapacityUnits` is half of the capacity an ordinary table's
  * `ProvisionedThroughput` states. `ReadCapacityAutoScalingSettings` asks for
- * capacity that changes with load, which nothing here changes, so it skips the
- * table rather than being read as the capacity it starts at.
+ * capacity that changes with load, which nothing here changes, so it is
+ * recorded and the table is created at the `MinCapacity` it names.
  */
 const simulatedReadCapacityPropertyNames: ReadonlySet<string> = new Set([
   "ReadCapacityUnits",
@@ -69,11 +70,11 @@ const unsimulatedReadCapacityPropertyNames: ReadonlySet<string> = new Set([
  * The rules a `Replicas` entry is read under.
  */
 export function simCfnDynamoDbGlobalTableReplicaRules(
-  logicalId: string,
+  scope: SimCfnDynamoDbResourceScope,
 ): SimCfnDynamoDbPropertyRules {
   return new SimCfnDynamoDbPropertyRules({
     resourceTypeName: dynamoDbGlobalTableResourceTypeName,
-    logicalId,
+    scope,
     kind: "Replica",
     simulated: simulatedReplicaPropertyNames,
     unsimulated: unsimulatedReplicaPropertyNames,
@@ -84,11 +85,11 @@ export function simCfnDynamoDbGlobalTableReplicaRules(
  * The rules a replica's `GlobalSecondaryIndexes` entry is read under.
  */
 export function simCfnDynamoDbGlobalTableReplicaIndexRules(
-  logicalId: string,
+  scope: SimCfnDynamoDbResourceScope,
 ): SimCfnDynamoDbPropertyRules {
   return new SimCfnDynamoDbPropertyRules({
     resourceTypeName: dynamoDbGlobalTableResourceTypeName,
-    logicalId,
+    scope,
     kind: "Replica GlobalSecondaryIndex",
     simulated: simulatedReplicaIndexPropertyNames,
     unsimulated: unsimulatedReplicaIndexPropertyNames,
@@ -100,11 +101,11 @@ export function simCfnDynamoDbGlobalTableReplicaIndexRules(
  * or on one of its global secondary indexes.
  */
 export function simCfnDynamoDbGlobalTableReadCapacityRules(
-  logicalId: string,
+  scope: SimCfnDynamoDbResourceScope,
 ): SimCfnDynamoDbPropertyRules {
   return new SimCfnDynamoDbPropertyRules({
     resourceTypeName: dynamoDbGlobalTableResourceTypeName,
-    logicalId,
+    scope,
     kind: "ReadProvisionedThroughputSettings",
     simulated: simulatedReadCapacityPropertyNames,
     unsimulated: unsimulatedReadCapacityPropertyNames,

--- a/src/service/dynamodb/cfn/global-table/sim-cfn-dynamodb-global-table-replicas.ts
+++ b/src/service/dynamodb/cfn/global-table/sim-cfn-dynamodb-global-table-replicas.ts
@@ -1,49 +1,50 @@
 import type { SimCfnDynamoDbPropertyValues } from "../property/sim-cfn-dynamodb-property-values.js";
+import type { SimCfnDynamoDbResourceScope } from "../property/sim-cfn-dynamodb-resource-scope.js";
 
 interface SimCfnDynamoDbGlobalTableReplicasProperties {
-  readonly logicalId: string;
+  readonly scope: SimCfnDynamoDbResourceScope;
   readonly regionName: string;
   readonly values: SimCfnDynamoDbPropertyValues;
 }
 
 /**
- * The one replica a global table this simulation can create is made of.
+ * The one replica a global table this simulation creates is made of.
  *
  * A global table naming one replica is an ordinary table in that region,
  * because with one replica that is what it is. CDK's `TableV2` synthesises one
  * for every table it makes, since `renderReplicaTables` always appends the
  * stack's own region, so a table with no `replicas` prop at all arrives here.
  *
- * Two or more replicas is a table that replicates, which is not simulated. That
- * skips the Resource with a reason naming the regions, so the rest of the stack
- * still deploys and the report says which table was left out and why. The line
- * is drawn at the replica count rather than at the Resource type because that
- * is where the behaviour actually differs.
+ * Two or more replicas is a table that replicates, which is not simulated. The
+ * table is still created, as the one in the region the stack is deploying
+ * into, and the replication nothing here performs is recorded against the
+ * Resource. That is more useful than no table at all: everything the table does
+ * within one region behaves as the template describes, and only the copying
+ * between regions is missing.
+ *
+ * A replica list with nothing in it, or with nothing in the stack's own region,
+ * is refused rather than recorded. Real CloudFormation refuses both, so there
+ * is no gap in this simulation to be best effort about.
  */
 export class SimCfnDynamoDbGlobalTableReplicas {
-  private readonly logicalId: string;
+  private readonly scope: SimCfnDynamoDbResourceScope;
   private readonly regionName: string;
   private readonly values: SimCfnDynamoDbPropertyValues;
 
   constructor(properties: SimCfnDynamoDbGlobalTableReplicasProperties) {
-    this.logicalId = properties.logicalId;
+    this.scope = properties.scope;
     this.regionName = properties.regionName;
     this.values = properties.values;
   }
 
   /**
-   * The single replica this global table is, refusing every other count.
+   * The replica this global table is created as, recording the rest.
    */
   single(): SimCfnDynamoDbPropertyValues {
     const replicas = this.values.list("Replicas");
+    const [only] = replicas;
 
-    if (replicas.length > 1) {
-      throw this.replicatedError(replicas);
-    }
-
-    const replica = replicas.at(0);
-
-    if (replica === undefined) {
+    if (only === undefined) {
       throw this.values.error(
         "Replicas must name at least one region, since a global table with " +
           "no replica is a table in no region, and real CloudFormation " +
@@ -51,20 +52,24 @@ export class SimCfnDynamoDbGlobalTableReplicas {
       );
     }
 
-    this.assertOwnRegion(replica);
+    if (replicas.length === 1) {
+      return this.onlyReplica(only);
+    }
 
-    return replica;
+    return this.ownRegionReplica(replicas);
   }
 
   /**
-   * Refuse a replica somewhere other than where the stack is deploying.
+   * The single replica a template declared, which has to name the region the
+   * stack is deploying into.
    *
-   * The Resource is created in the Account and Region the stack deploys into,
-   * which is the only place a simulated table can appear. Real CloudFormation
-   * requires the replica list to include the stack's own region, so a template
-   * naming one region and deploying into another is one it refuses as well.
+   * Real CloudFormation requires the replica list to include the stack's own
+   * region, so a template naming one region and deploying into another is one
+   * it refuses as well.
    */
-  private assertOwnRegion(replica: SimCfnDynamoDbPropertyValues): void {
+  private onlyReplica(
+    replica: SimCfnDynamoDbPropertyValues,
+  ): SimCfnDynamoDbPropertyValues {
     const region = replica.string("Region");
 
     if (region === undefined) {
@@ -78,28 +83,50 @@ export class SimCfnDynamoDbGlobalTableReplicas {
           `region the table would be created in`,
       );
     }
+
+    return replica;
   }
 
   /**
-   * The refusal that skips a global table which genuinely replicates.
-   *
-   * The "Unsupported sim ... CloudFormation" wording is what marks the Resource
-   * as skipped rather than failing the stack.
+   * The replica in the stack's own region, out of the several a replicating
+   * table declares, recording the replication that will not happen.
    */
-  private replicatedError(
+  private ownRegionReplica(
     replicas: readonly SimCfnDynamoDbPropertyValues[],
-  ): Error {
-    const regions = replicas
+  ): SimCfnDynamoDbPropertyValues {
+    const own = replicas.find((replica) => {
+      return replica.string("Region") === this.regionName;
+    });
+
+    if (own === undefined) {
+      throw this.values.error(
+        `Replicas names ${this.regionNames(replicas)}, and the stack is ` +
+          `deploying into ${this.regionName}, so the replica list does not ` +
+          `include the region the table would be created in`,
+      );
+    }
+
+    this.scope.ignorer.ignoreProperty(
+      "Replicas",
+      `Replicas names ${this.regionNames(replicas)}, and replicating a table ` +
+        `between regions is not simulated, so the table is created as an ` +
+        `ordinary table in ${this.regionName} and nothing is copied to the ` +
+        `others`,
+    );
+
+    return own;
+  }
+
+  /**
+   * The regions a replica list names, for a message that says which they were.
+   */
+  private regionNames(
+    replicas: readonly SimCfnDynamoDbPropertyValues[],
+  ): string {
+    return replicas
       .map((replica, index) => {
         return replica.string("Region") ?? `Replicas.${index.toString()}`;
       })
       .join(", ");
-
-    return new Error(
-      `Unsupported sim DynamoDB CloudFormation Resource ${this.logicalId}: ` +
-        `Replicas names ${regions}, and replicating a table between regions ` +
-        `is not simulated, so the global table is skipped rather than ` +
-        `created as an ordinary table in one of them`,
-    );
   }
 }

--- a/src/service/dynamodb/cfn/global-table/sim-cfn-dynamodb-global-table-simulated.ts
+++ b/src/service/dynamodb/cfn/global-table/sim-cfn-dynamodb-global-table-simulated.ts
@@ -1,4 +1,5 @@
 import type { SimCfnDynamoDbPropertyValues } from "../property/sim-cfn-dynamodb-property-values.js";
+import type { SimCfnDynamoDbResourceScope } from "../property/sim-cfn-dynamodb-resource-scope.js";
 import {
   simCfnDynamoDbGlobalTableIndexRules,
   simCfnDynamoDbGlobalTableLocalIndexRules,
@@ -13,71 +14,62 @@ import {
 } from "./sim-cfn-dynamodb-global-table-replica-rules.js";
 
 interface SimCfnDynamoDbGlobalTableSimulatedProperties {
-  readonly logicalId: string;
+  readonly scope: SimCfnDynamoDbResourceScope;
   readonly values: SimCfnDynamoDbPropertyValues;
   readonly replica: SimCfnDynamoDbPropertyValues;
 }
 
 /**
- * Refuse everything an AWS::DynamoDB::GlobalTable asks for and cannot get, at
+ * Record everything an AWS::DynamoDB::GlobalTable asks for and cannot get, at
  * every level a global table nests: the table, its indexes, its stream, the
  * replica, the replica's per-index settings, and the two halves of its
  * capacity.
  *
  * Each level is a set of property names rather than a rule of its own, so what
- * differs between them is which names belong where.
+ * differs between them is which names belong where. The table is created
+ * either way; the record is what says which of those levels was read past.
  */
-export function assertSimCfnDynamoDbGlobalTableSimulated(
+export function applySimCfnDynamoDbGlobalTableRules(
   properties: SimCfnDynamoDbGlobalTableSimulatedProperties,
 ): void {
-  const { logicalId, values, replica } = properties;
+  const { scope, values, replica } = properties;
   const indexes = values.list("GlobalSecondaryIndexes");
   const replicaIndexes = replica.list("GlobalSecondaryIndexes");
 
-  simCfnDynamoDbGlobalTableRules(logicalId).assertSimulated(values);
-  simCfnDynamoDbGlobalTableIndexRules(logicalId).assertEachSimulated(indexes);
-  simCfnDynamoDbGlobalTableLocalIndexRules(logicalId).assertEachSimulated(
+  simCfnDynamoDbGlobalTableRules(scope).apply(values);
+  simCfnDynamoDbGlobalTableIndexRules(scope).applyToEach(indexes);
+  simCfnDynamoDbGlobalTableLocalIndexRules(scope).applyToEach(
     values.list("LocalSecondaryIndexes"),
   );
-  simCfnDynamoDbGlobalTableStreamRules(logicalId).assertSimulated(
+  simCfnDynamoDbGlobalTableStreamRules(scope).apply(
     values.object("StreamSpecification"),
   );
-  simCfnDynamoDbGlobalTableReplicaRules(logicalId).assertSimulated(replica);
-  simCfnDynamoDbGlobalTableReplicaIndexRules(logicalId).assertEachSimulated(
-    replicaIndexes,
-  );
+  simCfnDynamoDbGlobalTableReplicaRules(scope).apply(replica);
+  simCfnDynamoDbGlobalTableReplicaIndexRules(scope).applyToEach(replicaIndexes);
 
-  assertSimulatedCapacity(
-    logicalId,
-    [values, ...indexes],
-    [replica, ...replicaIndexes],
-  );
+  applyCapacityRules(scope, [values, ...indexes], [replica, ...replicaIndexes]);
 }
 
 /**
- * Refuse a capacity that changes with load, wherever it was asked for.
+ * Record a capacity that changes with load, wherever it was asked for.
  *
  * The table and each of its indexes state the writing half, and the replica and
  * its per-index entries state the reading half, so both sets are held to the
  * same rule.
  */
-function assertSimulatedCapacity(
-  logicalId: string,
+function applyCapacityRules(
+  scope: SimCfnDynamoDbResourceScope,
   writing: readonly SimCfnDynamoDbPropertyValues[],
   reading: readonly SimCfnDynamoDbPropertyValues[],
 ): void {
-  const writeRules = simCfnDynamoDbGlobalTableWriteCapacityRules(logicalId);
-  const readRules = simCfnDynamoDbGlobalTableReadCapacityRules(logicalId);
+  const writeRules = simCfnDynamoDbGlobalTableWriteCapacityRules(scope);
+  const readRules = simCfnDynamoDbGlobalTableReadCapacityRules(scope);
 
   for (const values of writing) {
-    writeRules.assertSimulated(
-      values.object("WriteProvisionedThroughputSettings"),
-    );
+    writeRules.apply(values.object("WriteProvisionedThroughputSettings"));
   }
 
   for (const values of reading) {
-    readRules.assertSimulated(
-      values.object("ReadProvisionedThroughputSettings"),
-    );
+    readRules.apply(values.object("ReadProvisionedThroughputSettings"));
   }
 }

--- a/src/service/dynamodb/cfn/property/sim-cfn-dynamodb-property-error.ts
+++ b/src/service/dynamodb/cfn/property/sim-cfn-dynamodb-property-error.ts
@@ -1,11 +1,12 @@
 /**
  * Build the error a property of a simulated DynamoDB Resource is refused with.
  *
- * The wording matters. Sim CloudFormation skips a Resource whose error reads as
- * an unsupported Resource type, and skipping is the wrong answer for a table
- * the template described in a way it cannot be created: nothing is missing from
- * the simulation, the template is wrong, and the same template would fail on
- * real CloudFormation.
+ * Refusing is now the rarer answer. A property simulated DynamoDB cannot act on
+ * is recorded against the Resource and the table is created without it, so what
+ * is left here is the template that describes no table at all: a global table
+ * with no replica, a key schema that is not a list. Nothing is missing from
+ * this simulation in those cases, the template is wrong, and the same template
+ * would fail on real CloudFormation.
  *
  * The Resource type is named rather than assumed, since `AWS::DynamoDB::Table`
  * and `AWS::DynamoDB::GlobalTable` describe the same table in different
@@ -19,26 +20,5 @@ export function dynamoDbPropertyError(
 ): Error {
   return new Error(
     `Invalid ${resourceTypeName} Resource ${logicalId}: ${reason}`,
-  );
-}
-
-/**
- * Build the error that skips a Resource over a property that is not simulated.
- *
- * The "Unsupported sim ... CloudFormation" wording is what marks the Resource
- * as skipped rather than failing the stack, so the rest of the template still
- * deploys and the skip reason names the property. The path is the whole way to
- * the property, so a setting on one index of several says which one it was on.
- */
-export function dynamoDbUnsimulatedPropertyError(
-  resourceTypeName: string,
-  logicalId: string,
-  path: string,
-): Error {
-  return new Error(
-    `Unsupported sim DynamoDB CloudFormation Resource ${logicalId}: ` +
-      `${path} is a real ${resourceTypeName} property that simulated ` +
-      `DynamoDB does not simulate, so the table is skipped rather than ` +
-      `created without it`,
   );
 }

--- a/src/service/dynamodb/cfn/property/sim-cfn-dynamodb-property-rules.ts
+++ b/src/service/dynamodb/cfn/property/sim-cfn-dynamodb-property-rules.ts
@@ -1,16 +1,13 @@
-import {
-  dynamoDbPropertyError,
-  dynamoDbUnsimulatedPropertyError,
-} from "./sim-cfn-dynamodb-property-error.js";
 import type { SimCfnDynamoDbPropertyValues } from "./sim-cfn-dynamodb-property-values.js";
+import type { SimCfnDynamoDbResourceScope } from "./sim-cfn-dynamodb-resource-scope.js";
 
 interface SimCfnDynamoDbPropertyRulesProperties {
   readonly resourceTypeName: string;
-  readonly logicalId: string;
+  readonly scope: SimCfnDynamoDbResourceScope;
 
   /**
    * What the properties belong to, where they are not the Resource's own: a
-   * `GlobalSecondaryIndex`, a `StreamSpecification`, a replica. A refusal names
+   * `GlobalSecondaryIndex`, a `StreamSpecification`, a replica. A record names
    * it, so an unrecognised property says which shape it was not part of.
    */
   readonly kind?: string | undefined;
@@ -19,14 +16,16 @@ interface SimCfnDynamoDbPropertyRulesProperties {
 }
 
 /**
- * Which properties of one object in a DynamoDB Resource template simulated
- * DynamoDB can act on.
+ * What simulated DynamoDB does with each property of one object in a table
+ * template.
  *
- * A real property that is not simulated skips the Resource, with a reason
- * naming it, so the rest of the stack still deploys and the report says what
- * was left out. Anything that is not a property of that object at all fails the
- * Resource instead, because that is a template real CloudFormation would refuse
- * too.
+ * A property this simulation cannot act on does not stop the table being
+ * created. The table is created without it and the omission is recorded
+ * against the Resource, where a test that expected the setting to do something
+ * can find out that it never did. Anything that is not a property of that
+ * object at all is recorded the same way, since a typo and a property AWS added
+ * after this list was written look identical from here, and a table that
+ * deploys is more useful than a stack that fails over either.
  *
  * The same rule applies at every level a template nests: the Resource's own
  * properties, the entries of an index list, a stream specification, a replica.
@@ -35,31 +34,31 @@ interface SimCfnDynamoDbPropertyRulesProperties {
  */
 export class SimCfnDynamoDbPropertyRules {
   private readonly resourceTypeName: string;
-  private readonly logicalId: string;
+  private readonly scope: SimCfnDynamoDbResourceScope;
   private readonly kind: string | undefined;
   private readonly simulated: ReadonlySet<string>;
   private readonly unsimulated: ReadonlySet<string>;
 
   constructor(properties: SimCfnDynamoDbPropertyRulesProperties) {
     this.resourceTypeName = properties.resourceTypeName;
-    this.logicalId = properties.logicalId;
+    this.scope = properties.scope;
     this.kind = properties.kind;
     this.simulated = properties.simulated;
     this.unsimulated = properties.unsimulated ?? new Set<string>();
   }
 
   /**
-   * Refuse everything about this object that is not simulated.
+   * Record everything about this object the table is created without.
    *
-   * An object the template left out has nothing here to refuse.
+   * An object the template left out has nothing here to record.
    */
-  assertSimulated(values: SimCfnDynamoDbPropertyValues | undefined): void {
+  apply(values: SimCfnDynamoDbPropertyValues | undefined): void {
     if (values === undefined) {
       return;
     }
 
     for (const name of values.names) {
-      this.assertSimulatedProperty(values, name);
+      this.applyToProperty(values, name);
     }
   }
 
@@ -67,13 +66,13 @@ export class SimCfnDynamoDbPropertyRules {
    * Apply the same rule to every entry of a list, such as the indexes or the
    * replicas a template declares.
    */
-  assertEachSimulated(entries: readonly SimCfnDynamoDbPropertyValues[]): void {
+  applyToEach(entries: readonly SimCfnDynamoDbPropertyValues[]): void {
     for (const entry of entries) {
-      this.assertSimulated(entry);
+      this.apply(entry);
     }
   }
 
-  private assertSimulatedProperty(
+  private applyToProperty(
     values: SimCfnDynamoDbPropertyValues,
     name: string,
   ): void {
@@ -81,23 +80,27 @@ export class SimCfnDynamoDbPropertyRules {
       return;
     }
 
+    const path = values.pathTo(name);
+
     if (this.unsimulated.has(name)) {
-      throw dynamoDbUnsimulatedPropertyError(
-        this.resourceTypeName,
-        this.logicalId,
-        values.pathTo(name),
+      this.scope.ignorer.ignoreProperty(
+        path,
+        `${path} is a real ${this.resourceTypeName} property that simulated ` +
+          `DynamoDB does not simulate, so the table is created without it`,
       );
+
+      return;
     }
 
-    throw dynamoDbPropertyError(
-      this.resourceTypeName,
-      this.logicalId,
-      `${values.pathTo(name)} is not ${this.description()} property`,
+    this.scope.ignorer.ignoreProperty(
+      path,
+      `${path} is not ${this.description()} property simulated DynamoDB ` +
+        `knows about, so the table is created without it`,
     );
   }
 
   /**
-   * What an unrecognised property was not part of, as a refusal names it.
+   * What an unrecognised property was not part of, as a record names it.
    */
   private description(): string {
     if (this.kind === undefined) {

--- a/src/service/dynamodb/cfn/property/sim-cfn-dynamodb-resource-scope.ts
+++ b/src/service/dynamodb/cfn/property/sim-cfn-dynamodb-resource-scope.ts
@@ -1,0 +1,14 @@
+import type { SimCfnPropertyIgnorer } from "../../../cloudformation/resource/ignore/sim-cfn-ignored-property.type.js";
+
+/**
+ * The Resource one level of a DynamoDB template read belongs to.
+ *
+ * A global table nests six levels deep, and every one of them needs to say
+ * which Resource it is reading and where to record what it could not act on.
+ * Carrying both together keeps a rule a level down from having to be handed
+ * two arguments that must not be mixed up.
+ */
+export interface SimCfnDynamoDbResourceScope {
+  readonly logicalId: string;
+  readonly ignorer: SimCfnPropertyIgnorer;
+}

--- a/src/service/dynamodb/cfn/sim-cfn-dynamodb-global-table-validation.iso.test.ts
+++ b/src/service/dynamodb/cfn/sim-cfn-dynamodb-global-table-validation.iso.test.ts
@@ -12,7 +12,7 @@ import { SimAws } from "../../aws/sim-aws.js";
 import { simCfnDynamoDbGlobalTableResourceFactory } from "./global-table/sim-cfn-dynamodb-global-table-resource.factory.js";
 
 describe("DynamoDB CloudFormation GlobalTable validation", () => {
-  it("skips a global table replicating between regions", async () => {
+  it("creates a global table replicating between regions in its own region", async () => {
     // Given a template naming two replica regions, which genuinely replicates,
     // in a stack with another Resource in it.
     const simAws = new SimAws();
@@ -32,20 +32,54 @@ describe("DynamoDB CloudFormation GlobalTable validation", () => {
     });
     await stack.waitForDeployComplete();
 
-    // Then the table is skipped, with a reason naming the regions, rather than
-    // created as an ordinary table in one of them.
+    // Then the table is created as an ordinary table in the region the stack
+    // is deploying into, and the replication nothing performs is recorded with
+    // the regions it named.
     const resource = stack.getResource("OrdersTable");
     assertNonNullable(resource);
-    assertTrue(resource.skipped);
+    assertTrue(resource.deployed);
+    assertNonNullable(simAws.dynamoDb().findTable("orders"));
+
+    const ignored = resource.ignoredProperties[0];
+    assertNonNullable(ignored);
+    assertIdentical(ignored.path, "Replicas");
     assertStringIncludes(
-      resource.skippedReason ?? "",
+      ignored.reason,
       "Replicas names us-east-1, eu-west-2, and replicating a table between " +
         "regions is not simulated",
     );
-    assertUndefined(simAws.dynamoDb().findTable("orders"));
 
     // And the rest of the stack still deploys.
     assertTrue(stack.getResource("OrdersBucket")?.deployed);
+  });
+
+  it("fails a global table replicating nowhere near the stack's own region", async () => {
+    // Given a template naming two replica regions, neither of which is where
+    // the stack is deploying. Real CloudFormation refuses that template too.
+    const simAws = new SimAws();
+
+    // When the template is deployed, then the deployment fails rather than
+    // creating a table in a region no replica asked for.
+    const error = await assertThrowsErrorAsync(async () => {
+      return await simAws.cloudFormation().deployTemplate({
+        stackName: "orders-stack",
+        template: {
+          Resources: {
+            OrdersTable: simCfnDynamoDbGlobalTableResourceFactory.make({
+              tableName: "orders",
+              replicaRegions: ["eu-west-2", "eu-west-1"],
+            }),
+          },
+        },
+      });
+    });
+
+    assertStringIncludes(
+      error.message,
+      "Replicas names eu-west-2, eu-west-1, and the stack is deploying into " +
+        "us-east-1",
+    );
+    assertUndefined(simAws.dynamoDb().findTable("orders"));
   });
 
   it("fails a global table with no replicas at all", async () => {
@@ -118,7 +152,7 @@ describe("DynamoDB CloudFormation GlobalTable validation", () => {
     assertUndefined(simAws.dynamoDb().findTable("orders"));
   });
 
-  it("skips a global table asking for a replica setting that is not simulated", async () => {
+  it("creates a global table without a replica setting that is not simulated", async () => {
     // Given a template asking for point in time recovery, which a global table
     // asks for on its replica and which is not simulated either way.
     const simAws = new SimAws();
@@ -141,23 +175,30 @@ describe("DynamoDB CloudFormation GlobalTable validation", () => {
     });
     await stack.waitForDeployComplete();
 
-    // Then the table is skipped, with a reason naming the whole path to the
+    // Then the table exists, and the record names the whole path to the
     // property, so it says which replica asked for it.
     const resource = stack.getResource("OrdersTable");
     assertNonNullable(resource);
-    assertTrue(resource.skipped);
+    assertTrue(resource.deployed);
+    assertNonNullable(simAws.dynamoDb().findTable("orders"));
+
+    const ignored = resource.ignoredProperties[0];
+    assertNonNullable(ignored);
+    assertIdentical(
+      ignored.path,
+      "Replicas.0.PointInTimeRecoverySpecification",
+    );
     assertStringIncludes(
-      resource.skippedReason ?? "",
+      ignored.reason,
       "Replicas.0.PointInTimeRecoverySpecification is a real " +
         "AWS::DynamoDB::GlobalTable property that simulated DynamoDB does " +
         "not simulate",
     );
-    assertUndefined(simAws.dynamoDb().findTable("orders"));
   });
 
-  it("skips a global table asking for capacity that scales with load", async () => {
-    // Given a template asking for autoscaled write capacity, which is what
-    // CDK's Capacity.autoscaled synthesises and which nothing here scales.
+  it("creates a global table asking for capacity that scales with load", async () => {
+    // Given a template asking for autoscaled capacity on both halves, which is
+    // what CDK's Capacity.autoscaled synthesises and which nothing here scales.
     const simAws = new SimAws();
 
     // When the template is deployed.
@@ -171,8 +212,16 @@ describe("DynamoDB CloudFormation GlobalTable validation", () => {
             properties: {
               WriteProvisionedThroughputSettings: {
                 WriteCapacityAutoScalingSettings: {
-                  MinCapacity: 1,
+                  MinCapacity: 2,
                   MaxCapacity: 10,
+                },
+              },
+            },
+            replicaProperties: {
+              ReadProvisionedThroughputSettings: {
+                ReadCapacityAutoScalingSettings: {
+                  MinCapacity: 3,
+                  MaxCapacity: 30,
                 },
               },
             },
@@ -182,45 +231,63 @@ describe("DynamoDB CloudFormation GlobalTable validation", () => {
     });
     await stack.waitForDeployComplete();
 
-    // Then the table is skipped rather than created at the capacity it would
-    // have started at.
+    // Then the table exists at the capacity autoscaling would have started it
+    // at, rather than the deployment failing for want of a capacity, and the
+    // scaling nothing performs is recorded on both halves.
     const resource = stack.getResource("OrdersTable");
     assertNonNullable(resource);
-    assertTrue(resource.skipped);
-    assertStringIncludes(
-      resource.skippedReason ?? "",
-      "WriteProvisionedThroughputSettings.WriteCapacityAutoScalingSettings " +
-        "is a real AWS::DynamoDB::GlobalTable property",
+    assertTrue(resource.deployed);
+
+    const table = simAws.dynamoDb().findTable("orders");
+    assertNonNullable(table);
+    const throughput = table.billing.throughputDescription();
+    assertIdentical(throughput.WriteCapacityUnits, 2);
+    assertIdentical(throughput.ReadCapacityUnits, 3);
+
+    assertIdentical(
+      resource.ignoredProperties
+        .map((entry) => entry.path)
+        .toSorted((first, second) => first.localeCompare(second))
+        .join(", "),
+      "Replicas.0.ReadProvisionedThroughputSettings." +
+        "ReadCapacityAutoScalingSettings, " +
+        "WriteProvisionedThroughputSettings.WriteCapacityAutoScalingSettings",
     );
-    assertUndefined(simAws.dynamoDb().findTable("orders"));
   });
 
-  it("fails a global table with a property the Resource type does not have", async () => {
+  it("creates a global table with a property the Resource type does not have", async () => {
     // Given a template putting an AWS::DynamoDB::Table property on a global
     // table, which states that one on its replica instead.
     const simAws = new SimAws();
 
-    // When the template is deployed, then the deployment fails, because that
-    // is a template real CloudFormation would refuse too.
-    const error = await assertThrowsErrorAsync(async () => {
-      return await simAws.cloudFormation().deployTemplate({
-        stackName: "orders-stack",
-        template: {
-          Resources: {
-            OrdersTable: simCfnDynamoDbGlobalTableResourceFactory.make({
-              tableName: "orders",
-              properties: { TableClass: "STANDARD_INFREQUENT_ACCESS" },
-            }),
-          },
+    // When the template is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: {
+        Resources: {
+          OrdersTable: simCfnDynamoDbGlobalTableResourceFactory.make({
+            tableName: "orders",
+            properties: { TableClass: "STANDARD_INFREQUENT_ACCESS" },
+          }),
         },
-      });
+      },
     });
+    await stack.waitForDeployComplete();
 
+    // Then the table is created in the default class, with the property that
+    // belongs on the replica recorded where it was written instead.
+    const resource = stack.getResource("OrdersTable");
+    assertNonNullable(resource);
+    assertTrue(resource.deployed);
+    assertNonNullable(simAws.dynamoDb().findTable("orders"));
+
+    const ignored = resource.ignoredProperties[0];
+    assertNonNullable(ignored);
     assertStringIncludes(
-      error.message,
-      "TableClass is not an AWS::DynamoDB::GlobalTable property",
+      ignored.reason,
+      "TableClass is not an AWS::DynamoDB::GlobalTable property simulated " +
+        "DynamoDB knows about",
     );
-    assertUndefined(simAws.dynamoDb().findTable("orders"));
   });
 
   it("fails a global table whose one replica names no region", async () => {

--- a/src/service/dynamodb/cfn/sim-cfn-dynamodb-table-index-validation.iso.test.ts
+++ b/src/service/dynamodb/cfn/sim-cfn-dynamodb-table-index-validation.iso.test.ts
@@ -112,7 +112,7 @@ describe("DynamoDB CloudFormation Table secondary index validation", () => {
     assertStringIncludes(error.message, "Index byStatus has no Projection");
   });
 
-  it("skips a table whose index asks for something not simulated", async () => {
+  it("creates a table whose index asks for something not simulated", async () => {
     // Given a template asking for warm throughput on one index, which is not
     // simulated, in a stack with another Resource in it.
     const simAws = new SimAws();
@@ -129,48 +129,58 @@ describe("DynamoDB CloudFormation Table secondary index validation", () => {
       ],
     });
 
-    // Then the whole table is skipped, with a reason naming the index the
-    // setting was on, rather than deployed with an index that ignores it.
+    // Then the table and its index exist, and the record names the index the
+    // setting was on rather than only the property.
     const stack = simAws.cloudFormation().getStackByName("orders-stack");
     const resource = stack?.getResource("OrdersTable");
     assertNonNullable(resource);
-    assertTrue(resource.skipped);
+    assertTrue(resource.deployed);
+    assertNonNullable(simAws.dynamoDb().findTable("orders"));
+
+    const ignored = resource.ignoredProperties[0];
+    assertNonNullable(ignored);
+    assertIdentical(ignored.path, "GlobalSecondaryIndexes.0.WarmThroughput");
     assertStringIncludes(
-      resource.skippedReason ?? "",
+      ignored.reason,
       "GlobalSecondaryIndexes.0.WarmThroughput is a real " +
         "AWS::DynamoDB::Table property that simulated DynamoDB does not " +
         "simulate",
     );
-    assertUndefined(simAws.dynamoDb().findTable("orders"));
 
     // And the rest of the stack still deploys.
     assertTrue(stack?.getResource("OrdersBucket")?.deployed);
   });
 
-  it("fails an index carrying something that is not an index property", async () => {
+  it("creates a table whose index carries something that is not an index property", async () => {
     // Given a template naming something on its index that AWS::DynamoDB::Table
     // has no such property for.
     const simAws = new SimAws();
 
-    // When the template is deployed, then the deployment fails rather than
-    // skipping, since real CloudFormation would refuse this template too.
-    const error = await assertThrowsErrorAsync(async () => {
-      await deployIndexedTable(simAws, {
-        GlobalSecondaryIndexes: [
-          {
-            IndexName: "byStatus",
-            KeySchema: [{ AttributeName: "status", KeyType: "HASH" }],
-            Projection: { ProjectionType: "ALL" },
-            Sorted: true,
-          },
-        ],
-      });
+    // When the template is deployed.
+    await deployIndexedTable(simAws, {
+      GlobalSecondaryIndexes: [
+        {
+          IndexName: "byStatus",
+          KeySchema: [{ AttributeName: "status", KeyType: "HASH" }],
+          Projection: { ProjectionType: "ALL" },
+          Sorted: true,
+        },
+      ],
     });
 
+    // Then the table is created, and the name nothing read is recorded rather
+    // than failing a stack over a typo or a property AWS added since.
+    const stack = simAws.cloudFormation().getStackByName("orders-stack");
+    const resource = stack?.getResource("OrdersTable");
+    assertNonNullable(resource);
+    assertTrue(resource.deployed);
+
+    const ignored = resource.ignoredProperties[0];
+    assertNonNullable(ignored);
     assertStringIncludes(
-      error.message,
+      ignored.reason,
       "GlobalSecondaryIndexes.0.Sorted is not an AWS::DynamoDB::Table " +
-        "GlobalSecondaryIndex property",
+        "GlobalSecondaryIndex property simulated DynamoDB knows about",
     );
   });
 
@@ -179,8 +189,10 @@ describe("DynamoDB CloudFormation Table secondary index validation", () => {
     // which has no such property: it reads out of the table's own capacity.
     const simAws = new SimAws();
 
-    // When the template is deployed, then the deployment fails naming the
-    // property.
+    // When the template is deployed, then the deployment fails rather than
+    // recording the property and carrying on. An index entry is handed to
+    // CreateTable as the template wrote it, so this is refused where an SDK
+    // caller's identical index is, and real DynamoDB refuses it too.
     const error = await assertThrowsErrorAsync(async () => {
       await deployIndexedTable(simAws, {
         LocalSecondaryIndexes: [
@@ -202,8 +214,8 @@ describe("DynamoDB CloudFormation Table secondary index validation", () => {
 
     assertStringIncludes(
       error.message,
-      "LocalSecondaryIndexes.0.ProvisionedThroughput is not an " +
-        "AWS::DynamoDB::Table LocalSecondaryIndex property",
+      "ProvisionedThroughput cannot be specified for index: byTotal because " +
+        "it is a local secondary index",
     );
   });
 

--- a/src/service/dynamodb/cfn/sim-cfn-dynamodb-table-stream.iso.test.ts
+++ b/src/service/dynamodb/cfn/sim-cfn-dynamodb-table-stream.iso.test.ts
@@ -171,7 +171,7 @@ describe("DynamoDB CloudFormation Table stream", () => {
     assertUndefined(simAws.dynamoDb().findTable("orders"));
   });
 
-  it("skips a table publishing its changes to a Kinesis stream", async () => {
+  it("creates a table publishing its changes to a Kinesis stream", async () => {
     // Given a template asking for a Kinesis stream, which is a different thing
     // from the table's own stream and is not simulated.
     const simAws = new SimAws();
@@ -183,20 +183,23 @@ describe("DynamoDB CloudFormation Table stream", () => {
       },
     });
 
-    // Then the table is skipped, naming the property, rather than deployed
-    // publishing its changes nowhere.
+    // Then the table exists, publishing its changes nowhere, and the property
+    // it was created without is recorded against the Resource.
     const resource = stack.getResource("OrdersTable");
     assertNonNullable(resource);
-    assertTrue(resource.skipped);
+    assertTrue(resource.deployed);
+    assertNonNullable(simAws.dynamoDb().findTable("orders"));
+
+    const ignored = resource.ignoredProperties[0];
+    assertNonNullable(ignored);
     assertStringIncludes(
-      resource.skippedReason ?? "",
+      ignored.reason,
       "KinesisStreamSpecification is a real AWS::DynamoDB::Table property " +
         "that simulated DynamoDB does not simulate",
     );
-    assertUndefined(simAws.dynamoDb().findTable("orders"));
   });
 
-  it("skips a table asking for a policy on its stream", async () => {
+  it("creates a table asking for a policy on its stream", async () => {
     // Given a template putting a resource policy on the stream, which is a
     // different property from the table's own ResourcePolicy.
     const simAws = new SimAws();
@@ -209,38 +212,48 @@ describe("DynamoDB CloudFormation Table stream", () => {
       },
     });
 
-    // Then the table is skipped, naming the whole path to the property, rather
-    // than deployed with a stream anything could read.
+    // Then the table exists with a stream anything can read, and the record
+    // names the whole path to the property it was created without.
     const resource = stack.getResource("OrdersTable");
     assertNonNullable(resource);
-    assertTrue(resource.skipped);
+    assertTrue(resource.deployed);
+    assertNonNullable(simAws.dynamoDb().findTable("orders"));
+
+    const ignored = resource.ignoredProperties[0];
+    assertNonNullable(ignored);
+    assertIdentical(ignored.path, "StreamSpecification.ResourcePolicy");
     assertStringIncludes(
-      resource.skippedReason ?? "",
+      ignored.reason,
       "StreamSpecification.ResourcePolicy is a real AWS::DynamoDB::Table " +
         "property that simulated DynamoDB does not simulate",
     );
-    assertUndefined(simAws.dynamoDb().findTable("orders"));
   });
 
-  it("fails a table whose StreamSpecification has a made up property", async () => {
+  it("creates a table whose StreamSpecification has a made up property", async () => {
     // Given a template stating something StreamSpecification has no such thing
-    // as, which real CloudFormation would refuse too.
+    // as, which real CloudFormation would refuse.
     const simAws = new SimAws();
 
-    // When the template is deployed, then the failure names the property path.
-    const error = await assertThrowsErrorAsync(async () => {
-      await deployTable(simAws, {
-        StreamSpecification: {
-          StreamViewType: "NEW_IMAGE",
-          StreamEnabled: true,
-        },
-      });
+    // When the template is deployed.
+    const stack = await deployTable(simAws, {
+      StreamSpecification: {
+        StreamViewType: "NEW_IMAGE",
+        StreamEnabled: true,
+      },
     });
 
+    // Then the table is created, with the property path recorded rather than
+    // the stack failing over a name this simulation does not read.
+    const resource = stack.getResource("OrdersTable");
+    assertNonNullable(resource);
+    assertTrue(resource.deployed);
+
+    const ignored = resource.ignoredProperties[0];
+    assertNonNullable(ignored);
     assertStringIncludes(
-      error.message,
+      ignored.reason,
       "StreamSpecification.StreamEnabled is not an AWS::DynamoDB::Table " +
-        "StreamSpecification property",
+        "StreamSpecification property simulated DynamoDB knows about",
     );
   });
 });

--- a/src/service/dynamodb/cfn/sim-cfn-dynamodb-table-validation.iso.test.ts
+++ b/src/service/dynamodb/cfn/sim-cfn-dynamodb-table-validation.iso.test.ts
@@ -50,7 +50,7 @@ describe("DynamoDB CloudFormation Table validation", () => {
     assertUndefined(simAws.dynamoDb().findTable("orders"));
   });
 
-  it("skips a table with a property that is not simulated", async () => {
+  it("creates a table without a property that is not simulated", async () => {
     // Given a template asking for point in time recovery, which is not
     // simulated, in a stack with another Resource in it.
     const simAws = new SimAws();
@@ -74,17 +74,22 @@ describe("DynamoDB CloudFormation Table validation", () => {
     });
     await stack.waitForDeployComplete();
 
-    // Then the table is skipped, with a reason naming the property, rather
-    // than created without the behaviour the template asked for.
+    // Then the table exists, without the behaviour the template asked for, and
+    // the property it was created without is recorded against the Resource.
     const resource = stack.getResource("OrdersTable");
     assertNonNullable(resource);
-    assertTrue(resource.skipped);
+    assertFalse(resource.skipped);
+    assertTrue(resource.deployed);
+    assertNonNullable(simAws.dynamoDb().findTable("orders"));
+
+    const ignored = resource.ignoredProperties[0];
+    assertNonNullable(ignored);
+    assertIdentical(ignored.path, "PointInTimeRecoverySpecification");
     assertStringIncludes(
-      resource.skippedReason ?? "",
+      ignored.reason,
       "PointInTimeRecoverySpecification is a real AWS::DynamoDB::Table " +
         "property that simulated DynamoDB does not simulate",
     );
-    assertUndefined(simAws.dynamoDb().findTable("orders"));
 
     // And the rest of the stack still deploys.
     assertTrue(stack.getResource("OrdersBucket")?.deployed);

--- a/src/service/dynamodb/cfn/table/sim-cfn-dynamodb-table-creator.ts
+++ b/src/service/dynamodb/cfn/table/sim-cfn-dynamodb-table-creator.ts
@@ -36,7 +36,7 @@ export class SimCfnDynamoDbTableCreator {
       resource,
       properties,
     });
-    tableProperties.assertSimulated();
+    tableProperties.applyPropertyRules();
 
     const name = tableProperties.name();
 

--- a/src/service/dynamodb/cfn/table/sim-cfn-dynamodb-table-index-rules.ts
+++ b/src/service/dynamodb/cfn/table/sim-cfn-dynamodb-table-index-rules.ts
@@ -1,4 +1,5 @@
 import { SimCfnDynamoDbPropertyRules } from "../property/sim-cfn-dynamodb-property-rules.js";
+import type { SimCfnDynamoDbResourceScope } from "../property/sim-cfn-dynamodb-resource-scope.js";
 import { dynamoDbTableResourceTypeName } from "../sim-cfn-dynamodb-resource-type.js";
 
 /**
@@ -42,15 +43,16 @@ const simulatedLocalIndexPropertyNames: ReadonlySet<string> = new Set([
  * The rules a `GlobalSecondaryIndexes` entry is read under.
  *
  * This is the table's own property rule applied a level down. A real index
- * property that is not simulated skips the whole table, since a table deployed
- * without a setting its index asked for answers reads differently.
+ * property that is not simulated is recorded and the index is created without
+ * it, since a table deployed without a setting its index asked for answers reads
+ * differently.
  */
 export function simCfnDynamoDbTableGlobalIndexRules(
-  logicalId: string,
+  scope: SimCfnDynamoDbResourceScope,
 ): SimCfnDynamoDbPropertyRules {
   return new SimCfnDynamoDbPropertyRules({
     resourceTypeName: dynamoDbTableResourceTypeName,
-    logicalId,
+    scope,
     kind: "GlobalSecondaryIndex",
     simulated: simulatedGlobalIndexPropertyNames,
     unsimulated: unsimulatedGlobalIndexPropertyNames,
@@ -61,11 +63,11 @@ export function simCfnDynamoDbTableGlobalIndexRules(
  * The rules a `LocalSecondaryIndexes` entry is read under.
  */
 export function simCfnDynamoDbTableLocalIndexRules(
-  logicalId: string,
+  scope: SimCfnDynamoDbResourceScope,
 ): SimCfnDynamoDbPropertyRules {
   return new SimCfnDynamoDbPropertyRules({
     resourceTypeName: dynamoDbTableResourceTypeName,
-    logicalId,
+    scope,
     kind: "LocalSecondaryIndex",
     simulated: simulatedLocalIndexPropertyNames,
   });

--- a/src/service/dynamodb/cfn/table/sim-cfn-dynamodb-table-properties.iso.test.ts
+++ b/src/service/dynamodb/cfn/table/sim-cfn-dynamodb-table-properties.iso.test.ts
@@ -1,5 +1,7 @@
 import {
+  assertArrayLength,
   assertIdentical,
+  assertNonNullable,
   assertStringIncludes,
   assertThrowsErrorAsync,
 } from "@kensio/smartass";
@@ -250,19 +252,29 @@ describe("AWS::DynamoDB::Table property reading", () => {
     );
   });
 
-  it("refuses a property AWS::DynamoDB::Table does not have", async () => {
-    // Given a template carrying a property that is not on the Resource type,
-    // which real CloudFormation refuses too.
-    // When the Resource is created, then it is refused rather than skipped:
-    // nothing is missing from the simulation, the template is wrong.
-    const error = await createTableResource(
-      tableBreaking({ ReadCapacityUnits: 5 }),
-    );
+  it("creates a table carrying a property AWS::DynamoDB::Table does not have", async () => {
+    // Given a template carrying a property that is not on the Resource type.
+    const simAws = new SimAws();
+    const factory = new SimDynamoDbCfnResourceFactory({
+      dynamoDb: simAws.dynamoDb(),
+    });
+    const resource = simCfnResourceFactory.make({
+      logicalId: "OddTable",
+      template: tableBreaking({ ReadCapacityUnits: 5 }),
+    });
 
-    assertIdentical(
-      error.message,
-      "Invalid AWS::DynamoDB::Table Resource BadTable: ReadCapacityUnits is " +
-        "not an AWS::DynamoDB::Table property",
+    // When the Resource is created.
+    await factory.create("Table", resource, { simAws, resources: new Map() });
+
+    // Then the table exists, with the property nothing read recorded against
+    // it rather than the Resource being refused over it.
+    assertArrayLength(resource.ignoredProperties, 1);
+    const [ignored] = resource.ignoredProperties;
+    assertNonNullable(ignored);
+    assertStringIncludes(
+      ignored.reason,
+      "ReadCapacityUnits is not an AWS::DynamoDB::Table property simulated " +
+        "DynamoDB knows about",
     );
   });
 });

--- a/src/service/dynamodb/cfn/table/sim-cfn-dynamodb-table-properties.ts
+++ b/src/service/dynamodb/cfn/table/sim-cfn-dynamodb-table-properties.ts
@@ -51,17 +51,20 @@ export class SimCfnDynamoDbTableProperties {
       properties: properties.properties,
     });
     this.rules = new SimCfnDynamoDbTablePropertyRules({
-      logicalId: properties.resource.logicalId,
+      scope: {
+        logicalId: properties.resource.logicalId,
+        ignorer: properties.resource,
+      },
       values: this.values,
     });
   }
 
   /**
-   * Refuse everything about this Resource that is not simulated, before
+   * Record everything about this Resource the table is created without, before
    * anything is read off it.
    */
-  assertSimulated(): void {
-    this.rules.assertSimulated();
+  applyPropertyRules(): void {
+    this.rules.apply();
   }
 
   /**

--- a/src/service/dynamodb/cfn/table/sim-cfn-dynamodb-table-property-rules.ts
+++ b/src/service/dynamodb/cfn/table/sim-cfn-dynamodb-table-property-rules.ts
@@ -1,5 +1,6 @@
 import { SimCfnDynamoDbPropertyRules } from "../property/sim-cfn-dynamodb-property-rules.js";
 import type { SimCfnDynamoDbPropertyValues } from "../property/sim-cfn-dynamodb-property-values.js";
+import type { SimCfnDynamoDbResourceScope } from "../property/sim-cfn-dynamodb-resource-scope.js";
 import { dynamoDbTableResourceTypeName } from "../sim-cfn-dynamodb-resource-type.js";
 import {
   simCfnDynamoDbTableGlobalIndexRules,
@@ -33,9 +34,9 @@ const simulatedPropertyNames: ReadonlySet<string> = new Set([
  * Real AWS::DynamoDB::Table properties this simulation does not model.
  *
  * Each one changes what the table does. A table deployed without the Kinesis
- * stream its changes were meant to be published to would leave whatever reads
- * that stream waiting, so the Resource is skipped rather than deployed as
- * something else.
+ * stream its changes were meant to be published to leaves whatever reads that
+ * stream waiting, so the table is created without the property and the
+ * omission is recorded where a test can find it.
  */
 const unsimulatedPropertyNames: ReadonlySet<string> = new Set([
   "ContributorInsightsSpecification",
@@ -49,59 +50,58 @@ const unsimulatedPropertyNames: ReadonlySet<string> = new Set([
 ]);
 
 interface SimCfnDynamoDbTablePropertyRulesProperties {
-  readonly logicalId: string;
+  readonly scope: SimCfnDynamoDbResourceScope;
   readonly values: SimCfnDynamoDbPropertyValues;
 }
 
 /**
- * Which AWS::DynamoDB::Table properties simulated DynamoDB can act on.
+ * What simulated DynamoDB does with each AWS::DynamoDB::Table property.
  *
- * A real property that is not simulated skips the Resource, with a reason
- * naming it, so the rest of the stack still deploys and the report says what
- * was left out. Anything that is not an AWS::DynamoDB::Table property at all
- * fails the Resource instead, because that is a template real CloudFormation
- * would refuse too.
+ * A property this simulation cannot act on is recorded against the Resource
+ * and the table is created without it, rather than the table going missing
+ * from the stack over one setting. Anything that is not an
+ * AWS::DynamoDB::Table property at all is recorded the same way.
  *
  * The two index properties and the stream specification carry properties of
  * their own, which are held to the same rule a level down.
  */
 export class SimCfnDynamoDbTablePropertyRules {
-  private readonly logicalId: string;
+  private readonly scope: SimCfnDynamoDbResourceScope;
   private readonly values: SimCfnDynamoDbPropertyValues;
 
   constructor(properties: SimCfnDynamoDbTablePropertyRulesProperties) {
-    this.logicalId = properties.logicalId;
+    this.scope = properties.scope;
     this.values = properties.values;
   }
 
   /**
-   * Refuse everything about this Resource that is not simulated.
+   * Record everything about this Resource the table is created without.
    */
-  assertSimulated(): void {
+  apply(): void {
     new SimCfnDynamoDbPropertyRules({
       resourceTypeName: dynamoDbTableResourceTypeName,
-      logicalId: this.logicalId,
+      scope: this.scope,
       simulated: simulatedPropertyNames,
       unsimulated: unsimulatedPropertyNames,
-    }).assertSimulated(this.values);
+    }).apply(this.values);
 
-    this.assertSimulatedMembers();
+    this.applyToMembers();
   }
 
   /**
-   * Refuse what the properties carrying properties of their own ask for and
-   * cannot get: the two index lists, and the stream specification.
+   * Apply the same rule to the properties carrying properties of their own:
+   * the two index lists, and the stream specification.
    */
-  private assertSimulatedMembers(): void {
-    const logicalId = this.logicalId;
+  private applyToMembers(): void {
+    const scope = this.scope;
 
-    simCfnDynamoDbTableGlobalIndexRules(logicalId).assertEachSimulated(
+    simCfnDynamoDbTableGlobalIndexRules(scope).applyToEach(
       this.values.list("GlobalSecondaryIndexes"),
     );
-    simCfnDynamoDbTableLocalIndexRules(logicalId).assertEachSimulated(
+    simCfnDynamoDbTableLocalIndexRules(scope).applyToEach(
       this.values.list("LocalSecondaryIndexes"),
     );
-    simCfnDynamoDbTableStreamRules(logicalId).assertSimulated(
+    simCfnDynamoDbTableStreamRules(scope).apply(
       this.values.object("StreamSpecification"),
     );
   }

--- a/src/service/dynamodb/cfn/table/sim-cfn-dynamodb-table-stream-rules.ts
+++ b/src/service/dynamodb/cfn/table/sim-cfn-dynamodb-table-stream-rules.ts
@@ -1,4 +1,5 @@
 import { SimCfnDynamoDbPropertyRules } from "../property/sim-cfn-dynamodb-property-rules.js";
+import type { SimCfnDynamoDbResourceScope } from "../property/sim-cfn-dynamodb-resource-scope.js";
 import { dynamoDbTableResourceTypeName } from "../sim-cfn-dynamodb-resource-type.js";
 
 /**
@@ -27,16 +28,17 @@ const unsimulatedStreamPropertyNames: ReadonlySet<string> = new Set([
  * The rules a table's `StreamSpecification` is read under.
  *
  * This is the table's own property rule applied a level down, as the index
- * rules are. A real property that is not simulated skips the table, since a
- * stream deployed without a policy the template asked for would be read by
- * whatever that policy was meant to keep out.
+ * rules are. A real property that is not simulated is recorded and the table is
+ * created without it, since a stream deployed without a policy the template
+ * asked for is read by whatever that policy was meant to keep out, and a test
+ * needs to be able to find that out.
  */
 export function simCfnDynamoDbTableStreamRules(
-  logicalId: string,
+  scope: SimCfnDynamoDbResourceScope,
 ): SimCfnDynamoDbPropertyRules {
   return new SimCfnDynamoDbPropertyRules({
     resourceTypeName: dynamoDbTableResourceTypeName,
-    logicalId,
+    scope,
     kind: "StreamSpecification",
     simulated: simulatedStreamPropertyNames,
     unsimulated: unsimulatedStreamPropertyNames,

--- a/src/service/kms/cfn/key/sim-cfn-kms-key-properties.ts
+++ b/src/service/kms/cfn/key/sim-cfn-kms-key-properties.ts
@@ -36,7 +36,7 @@ export class SimCfnKmsKeyProperties {
 
     new SimCfnKmsUnsimulatedKeyProperties({
       propertyParser: this.propertyParser,
-    }).require(this.resource, this.properties);
+    }).apply(this.resource, this.properties);
   }
 
   /**

--- a/src/service/kms/cfn/key/sim-cfn-kms-unsimulated-key-properties.ts
+++ b/src/service/kms/cfn/key/sim-cfn-kms-unsimulated-key-properties.ts
@@ -10,14 +10,16 @@ interface SimCfnKmsUnsimulatedKeyPropertiesProperties {
 }
 
 /**
- * Refuses AWS::KMS::Key properties that ask for behaviour simulated KMS does
- * not model.
+ * Records the AWS::KMS::Key properties that ask for behaviour simulated KMS
+ * does not model.
  *
  * Each of these changes what the key is, not merely how it is described, so
- * quietly ignoring one would leave a template deploying a key that behaves
- * differently here than it would on AWS: rotation that never happens, a
- * multi-Region key whose replica cannot exist, or tags no policy can match.
- * Refusing at deploy time makes that visible where it was declared.
+ * dropping one without a word would leave a template deploying a key that
+ * behaves differently here than it would on AWS: rotation that never happens,
+ * a multi-Region key whose replica cannot exist, or tags no policy can match.
+ * None of them stops a key existing and encrypting, though, so the key is
+ * created without them and each one is recorded against the Resource, where a
+ * test written against the behaviour can find out it was never configured.
  */
 export class SimCfnKmsUnsimulatedKeyProperties {
   private readonly propertyParser: SimCfnKmsPropertyParser;
@@ -27,28 +29,25 @@ export class SimCfnKmsUnsimulatedKeyProperties {
   }
 
   /**
-   * Refuse the Resource if it asks for something unmodelled.
+   * Record everything unmodelled the Resource asks for.
    *
    * KeySpec, KeyUsage and Origin are not checked here: they go through to
    * CreateKey, which already refuses the types this simulation does not
    * create.
    */
-  require(
-    resource: SimCfnResource,
-    properties: SimCfnTemplateValueRecord,
-  ): void {
-    this.requireNoRotation(resource, properties);
-    this.requireSingleRegion(resource, properties);
-    this.requireNoTags(resource, properties);
+  apply(resource: SimCfnResource, properties: SimCfnTemplateValueRecord): void {
+    this.applyToRotation(resource, properties);
+    this.applyToRegion(resource, properties);
+    this.applyToTags(resource, properties);
   }
 
   /**
    * Automatic key rotation is not simulated.
    *
-   * `EnableKeyRotation: false` is the AWS default and says nothing, so it is
-   * accepted.
+   * `EnableKeyRotation: false` is the AWS default and says nothing, so there
+   * is nothing to record for it.
    */
-  private requireNoRotation(
+  private applyToRotation(
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
   ): void {
@@ -59,17 +58,17 @@ export class SimCfnKmsUnsimulatedKeyProperties {
     );
 
     if (enabled === true) {
-      throw this.propertyParser.propertyError(
-        resource,
+      resource.ignoreProperty(
+        "EnableKeyRotation",
         "EnableKeyRotation is not simulated: simulated KMS keys keep the " +
-          "same key material for their lifetime, so a rotated ciphertext " +
-          "would not be modelled",
+          "same key material for their lifetime, so the key is created " +
+          "without rotation and a rotated ciphertext is not modelled",
       );
     }
 
     if (properties["RotationPeriodInDays"] !== undefined) {
-      throw this.propertyParser.propertyError(
-        resource,
+      resource.ignoreProperty(
+        "RotationPeriodInDays",
         "RotationPeriodInDays is not simulated: simulated KMS does not " +
           "rotate key material",
       );
@@ -81,7 +80,7 @@ export class SimCfnKmsUnsimulatedKeyProperties {
    * account and region, and a ciphertext produced under it cannot be decrypted
    * elsewhere.
    */
-  private requireSingleRegion(
+  private applyToRegion(
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
   ): void {
@@ -92,31 +91,31 @@ export class SimCfnKmsUnsimulatedKeyProperties {
     );
 
     if (multiRegion === true) {
-      throw this.propertyParser.propertyError(
-        resource,
-        "MultiRegion is not simulated: a simulated key belongs to one " +
-          "account and region, and its ciphertext cannot be decrypted in " +
-          "another",
+      resource.ignoreProperty(
+        "MultiRegion",
+        "MultiRegion is not simulated: the key is created in one account and " +
+          "region, and its ciphertext cannot be decrypted in another",
       );
     }
   }
 
   /**
-   * Tags are not simulated on KMS keys, so a template declaring them is
-   * refused rather than deploying a key whose tags nothing can read and no
-   * `aws:ResourceTag` condition can match.
+   * Tags are not simulated on KMS keys, so a template declaring them deploys a
+   * key whose tags nothing can read and no `aws:ResourceTag` condition can
+   * match. That is worth recording, since a policy written around one would
+   * match nothing here and match on AWS.
    */
-  private requireNoTags(
+  private applyToTags(
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
   ): void {
     const tags: SimCfnTemplateValue | undefined = properties["Tags"];
 
     if (tags !== undefined) {
-      throw this.propertyParser.propertyError(
-        resource,
+      resource.ignoreProperty(
+        "Tags",
         "Tags are not simulated on KMS keys: ListResourceTags and the " +
-          "aws:ResourceTag condition key would not see them",
+          "aws:ResourceTag condition key do not see them",
       );
     }
   }

--- a/src/service/kms/cfn/sim-cfn-kms-validation.iso.test.ts
+++ b/src/service/kms/cfn/sim-cfn-kms-validation.iso.test.ts
@@ -1,5 +1,7 @@
 import {
+  assertIdentical,
   assertInstanceOf,
+  assertNonNullable,
   assertStringIncludes,
   assertThrowsError,
 } from "@kensio/smartass";
@@ -8,6 +10,7 @@ import { describe, it } from "vitest";
 import { SimAws } from "../../aws/sim-aws.js";
 import type { SimAwsAccountId } from "../../aws/sim-aws-account.js";
 import { SimCfnResource } from "../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnIgnoredProperty } from "../../cloudformation/resource/ignore/sim-cfn-ignored-property.type.js";
 import type { SimCfnTemplateValueRecord } from "../../cloudformation/template/value/sim-cfn-template-value.js";
 import { SimKmsKey } from "../key/sim-kms-key.js";
 import { SimKmsCfnResourceFactory } from "./sim-cfn-kms-resource-factory.js";
@@ -26,6 +29,22 @@ function kmsResource(
     logicalId: "BadKey",
     template: { Type: resourceType, Properties: properties },
   });
+}
+
+/**
+ * Create a KMS Resource straight through the Resource factory, returning what
+ * it recorded creating the Resource without.
+ */
+async function createdKmsResource(
+  properties: SimCfnTemplateValueRecord,
+): Promise<readonly SimCfnIgnoredProperty[]> {
+  const simAws = new SimAws({ defaultAccountId: accountIdOneOnes });
+  const factory = new SimKmsCfnResourceFactory({ kms: simAws.kms() });
+  const resource = kmsResource("AWS::KMS::Key", properties);
+
+  await factory.create("Key", resource, { simAws, resources: new Map() });
+
+  return resource.ignoredProperties;
 }
 
 /**
@@ -56,15 +75,18 @@ async function createKmsResource(
 }
 
 describe("KMS CloudFormation Resource validation", () => {
-  it("refuses EnableKeyRotation", async () => {
+  it("records EnableKeyRotation", async () => {
     // Given a template asking for automatic key rotation, which simulated KMS
     // does not model.
-    // When the Resource is created, then it is refused rather than deploying a
-    // key whose material never actually rotates.
-    const error = await createKmsResource("Key", { EnableKeyRotation: true });
+    // When the Resource is created, then the key exists and the rotation that
+    // never happens is recorded against it.
+    const ignored = await createdKmsResource({ EnableKeyRotation: true });
 
-    assertStringIncludes(error.message, "AWS::KMS::Key Resource BadKey");
-    assertStringIncludes(error.message, "EnableKeyRotation is not simulated");
+    const [rotation] = ignored;
+    assertNonNullable(rotation);
+    assertIdentical(rotation.logicalId, "BadKey");
+    assertIdentical(rotation.resourceType, "AWS::KMS::Key");
+    assertStringIncludes(rotation.reason, "EnableKeyRotation is not simulated");
   });
 
   it("accepts EnableKeyRotation false, which is the AWS default", async () => {
@@ -83,38 +105,43 @@ describe("KMS CloudFormation Resource validation", () => {
     assertInstanceOf(created, SimKmsKey);
   });
 
-  it("refuses RotationPeriodInDays", async () => {
+  it("records RotationPeriodInDays", async () => {
     // Given a template setting a rotation period.
-    // When the Resource is created, then it is refused.
-    const error = await createKmsResource("Key", {
-      RotationPeriodInDays: 180,
-    });
+    // When the Resource is created, then it is recorded.
+    const ignored = await createdKmsResource({ RotationPeriodInDays: 180 });
 
     assertStringIncludes(
-      error.message,
+      ignored[0]?.reason ?? "",
       "RotationPeriodInDays is not simulated",
     );
   });
 
-  it("refuses MultiRegion", async () => {
+  it("records MultiRegion", async () => {
     // Given a template asking for a multi-Region key, whose whole point is a
     // replica in another region that simulated KMS cannot produce.
-    // When the Resource is created, then it is refused.
-    const error = await createKmsResource("Key", { MultiRegion: true });
+    // When the Resource is created, then the key exists in this region alone
+    // and the replica that cannot be is recorded.
+    const ignored = await createdKmsResource({ MultiRegion: true });
 
-    assertStringIncludes(error.message, "MultiRegion is not simulated");
+    assertStringIncludes(
+      ignored[0]?.reason ?? "",
+      "MultiRegion is not simulated",
+    );
   });
 
-  it("refuses Tags", async () => {
+  it("records Tags", async () => {
     // Given a template tagging the key, which simulated KMS neither stores nor
     // matches in a policy condition.
-    // When the Resource is created, then it is refused rather than dropping
-    // the tags silently.
-    const error = await createKmsResource("Key", {
+    // When the Resource is created, then the tags are recorded rather than
+    // dropped with nothing said about them.
+    const ignored = await createdKmsResource({
       Tags: [{ Key: "component", Value: "database" }],
     });
 
-    assertStringIncludes(error.message, "Tags are not simulated on KMS keys");
+    assertStringIncludes(
+      ignored[0]?.reason ?? "",
+      "Tags are not simulated on KMS keys",
+    );
   });
 
   it("refuses an asymmetric KeySpec", async () => {

--- a/src/service/s3/cfn/bucket/sim-cfn-s3-bucket-creator.ts
+++ b/src/service/s3/cfn/bucket/sim-cfn-s3-bucket-creator.ts
@@ -24,11 +24,10 @@ export class SimCfnS3BucketCreator {
   /**
    * Create a simulated Bucket, with the configurations it declares.
    *
-   * Which properties the Resource carries is checked before anything is
-   * created, so a Resource asking for something this simulation does not model
-   * fails the Stack rather than leaving a Bucket behind that is configured
-   * differently from the template. What each of them says is then checked as it
-   * is applied.
+   * Which properties the Resource carries is settled before anything is
+   * created. A property this simulation does not model is recorded against the
+   * Resource and the Bucket is created without it. What each of the remaining
+   * ones says is then checked as it is applied.
    */
   async create(
     resource: SimCfnResource,
@@ -37,7 +36,8 @@ export class SimCfnS3BucketCreator {
     new SimCfnS3BucketPropertyRules({
       logicalId: resource.logicalId,
       properties,
-    }).assertSimulated();
+      ignorer: resource,
+    }).apply();
 
     const bucketName = this.bucketNameForResource(resource, properties);
     validateS3BucketName(bucketName);

--- a/src/service/s3/cfn/bucket/sim-cfn-s3-bucket-property-names.ts
+++ b/src/service/s3/cfn/bucket/sim-cfn-s3-bucket-property-names.ts
@@ -1,0 +1,78 @@
+/**
+ * The AWS::S3::Bucket properties this simulation acts on.
+ */
+export const simulatedPropertyNames: ReadonlySet<string> = new Set([
+  "BucketName",
+  "NotificationConfiguration",
+  "PublicAccessBlockConfiguration",
+  "WebsiteConfiguration",
+]);
+
+/**
+ * Real AWS::S3::Bucket properties this simulation reads and does nothing with.
+ *
+ * Nothing this simulator models can tell the difference. There is no simulated
+ * KMS and Object bytes are stored as they arrive, so an encrypted Bucket and an
+ * unencrypted one answer every simulated command identically, and no simulated
+ * service reads a Bucket tag. So these are not recorded as ignored either: a
+ * report of differences that make no difference is one nobody can read.
+ */
+export const inertPropertyNames: ReadonlySet<string> = new Set([
+  "BucketEncryption",
+  "Tags",
+]);
+
+/**
+ * Real AWS::S3::Bucket properties this simulation does not model, with what
+ * each of them would have changed.
+ *
+ * The Bucket is created without them and each one is recorded against the
+ * Resource. A versioned Bucket, for instance, answers a delete with a delete
+ * marker and an `ObjectRemoved:DeleteMarkerCreated` event, where this simulator
+ * removes the Object and raises `ObjectRemoved:Delete`, so a test written
+ * against versioning needs to find out that it was never configured.
+ */
+export const unsimulatedPropertyReasons: ReadonlyMap<string, string> = new Map([
+  ["AbacStatus", "attribute-based access control is not simulated"],
+  ["AccelerateConfiguration", "transfer acceleration is not simulated"],
+  [
+    "AccessControl",
+    "canned Bucket ACLs are not simulated, and simulated S3 authorizes " +
+      "through IAM and the Bucket policy instead",
+  ],
+  ["AnalyticsConfigurations", "storage class analytics is not simulated"],
+  ["BucketNamePrefix", "generated Bucket names are not simulated"],
+  ["BucketNamespace", "Bucket namespaces are not simulated"],
+  [
+    "CorsConfiguration",
+    "simulated S3 does not answer preflight requests or return CORS headers",
+  ],
+  [
+    "IntelligentTieringConfigurations",
+    "storage classes are not simulated, so nothing transitions between them",
+  ],
+  ["InventoryConfigurations", "Bucket inventory reports are not simulated"],
+  [
+    "LifecycleConfiguration",
+    "simulated S3 does not expire or transition Objects on a schedule",
+  ],
+  ["LoggingConfiguration", "server access logging is not simulated"],
+  ["MetadataConfiguration", "Bucket metadata tables are not simulated"],
+  ["MetadataTableConfiguration", "Bucket metadata tables are not simulated"],
+  ["MetricsConfigurations", "CloudWatch request metrics are not simulated"],
+  [
+    "ObjectLockConfiguration",
+    "Object Lock is not simulated, so a retained Object can still be deleted",
+  ],
+  [
+    "ObjectLockEnabled",
+    "Object Lock is not simulated, so a retained Object can still be deleted",
+  ],
+  ["OwnershipControls", "Object ownership and ACLs are not simulated"],
+  ["ReplicationConfiguration", "Bucket replication is not simulated"],
+  [
+    "VersioningConfiguration",
+    "Object versions are not simulated, so a delete removes the Object and " +
+      "raises ObjectRemoved:Delete rather than creating a delete marker",
+  ],
+]);

--- a/src/service/s3/cfn/bucket/sim-cfn-s3-bucket-property-rules.iso.test.ts
+++ b/src/service/s3/cfn/bucket/sim-cfn-s3-bucket-property-rules.iso.test.ts
@@ -1,12 +1,15 @@
 import { ListBucketsCommand } from "@aws-sdk/client-s3";
 import {
   assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
   assertStringIncludes,
   assertThrowsErrorAsync,
 } from "@kensio/smartass";
 import { describe, it } from "vitest";
 
 import { SimAws } from "../../../aws/sim-aws.js";
+import type { SimCfnStack } from "../../../cloudformation/stack/sim-cfn-stack.js";
 import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
 
 /**
@@ -32,37 +35,96 @@ async function deployFailing(
   });
 }
 
+/**
+ * Deploy a Bucket carrying the given properties and wait for it to settle.
+ */
+async function deployBucket(
+  simAws: SimAws,
+  properties: SimCfnTemplateValueRecord,
+): Promise<SimCfnStack> {
+  const stack = await simAws.cloudFormation().deployTemplate({
+    stackName: "uploads-stack",
+    template: {
+      Resources: {
+        Bucket: {
+          Type: "AWS::S3::Bucket",
+          Properties: { BucketName: "uploads", ...properties },
+        },
+      },
+    },
+  });
+  await stack.waitForDeployComplete();
+
+  return stack;
+}
+
+/**
+ * How many Buckets simulated S3 holds.
+ */
+async function bucketCount(simAws: SimAws): Promise<number> {
+  const output = await simAws.s3().listBuckets(new ListBucketsCommand());
+
+  return (output.Buckets ?? []).length;
+}
+
 describe("AWS::S3::Bucket property rules", () => {
-  it("refuses a real Bucket property simulated S3 does not simulate", async () => {
+  it("deploys a Bucket without a real property simulated S3 cannot act on", async () => {
     // Given a template asking for Bucket versioning.
     const simAws = new SimAws();
 
     // When the template is deployed.
-    const error = await deployFailing(simAws, {
+    const stack = await deployBucket(simAws, {
       VersioningConfiguration: { Status: "Enabled" },
     });
 
-    // Then the Stack fails naming the property, rather than deploying a Bucket
-    // that looks versioned to the template and is not.
-    assertStringIncludes(
-      error.message,
-      "Invalid AWS::S3::Bucket Resource Bucket: VersioningConfiguration is a " +
-        "real AWS::S3::Bucket property that simulated S3 does not simulate",
-    );
+    // Then the Bucket is created, unversioned, and the property it was created
+    // without is recorded against the Resource.
+    assertIdentical(await bucketCount(simAws), 1);
+    assertArrayLength(stack.ignoredProperties, 1);
+    const ignored = stack.ignoredProperties[0];
+    assertNonNullable(ignored);
+    assertIdentical(ignored.logicalId, "Bucket");
+    assertIdentical(ignored.resourceType, "AWS::S3::Bucket");
+    assertIdentical(ignored.path, "VersioningConfiguration");
+    assertStringIncludes(ignored.reason, "Object versions are not simulated");
   });
 
-  it("refuses a name that is not a Bucket property at all", async () => {
+  it("deploys a Bucket without a name it has never heard of", async () => {
     // Given a template carrying a misspelled property.
     const simAws = new SimAws();
 
     // When the template is deployed.
-    const error = await deployFailing(simAws, { BucketNam: "uploads" });
+    const stack = await deployBucket(simAws, { BucketNam: "uploads" });
 
-    // Then the Stack fails naming it.
+    // Then the Bucket is still created, and the name nothing read is recorded
+    // rather than failing a stack over a typo or a property AWS added since.
+    assertIdentical(await bucketCount(simAws), 1);
+    assertArrayLength(stack.ignoredProperties, 1);
+    const ignored = stack.ignoredProperties[0];
+    assertNonNullable(ignored);
+    assertIdentical(ignored.path, "BucketNam");
     assertStringIncludes(
-      error.message,
-      "Invalid AWS::S3::Bucket Resource Bucket: BucketNam is not an " +
-        "AWS::S3::Bucket property",
+      ignored.reason,
+      "BucketNam is not a property simulated S3 knows about",
+    );
+  });
+
+  it("records every unsimulated property, not only the first", async () => {
+    // Given a template asking for object locking as well as versioning.
+    const simAws = new SimAws();
+
+    // When the template is deployed.
+    const stack = await deployBucket(simAws, {
+      ObjectLockEnabled: true,
+      VersioningConfiguration: { Status: "Enabled" },
+    });
+
+    // Then the Bucket exists and both omissions are reported.
+    assertIdentical(await bucketCount(simAws), 1);
+    assertArrayLength(stack.ignoredProperties, 2);
+    assertIdentical(
+      stack.ignoredProperties.map((entry) => entry.path).join(", "),
+      "ObjectLockEnabled, VersioningConfiguration",
     );
   });
 
@@ -136,52 +198,25 @@ describe("AWS::S3::Bucket property rules", () => {
     );
   });
 
-  it("refuses the property before creating the Bucket", async () => {
-    // Given a template asking for object locking alongside a valid Bucket name.
-    const simAws = new SimAws();
-
-    // When the template is deployed.
-    await deployFailing(simAws, { ObjectLockEnabled: true });
-
-    // Then no Bucket is left behind for a later deployment to collide with.
-    const output = await simAws.s3().listBuckets(new ListBucketsCommand());
-
-    assertArrayLength(output.Buckets ?? [], 0);
-  });
-
   it("deploys a Bucket carrying properties nothing simulated can tell apart", async () => {
     // Given a template with the encryption and tags CDK puts on almost every
     // Bucket it synthesizes.
     const simAws = new SimAws();
 
     // When the template is deployed.
-    const stack = await simAws.cloudFormation().deployTemplate({
-      stackName: "uploads-stack",
-      template: {
-        Resources: {
-          Bucket: {
-            Type: "AWS::S3::Bucket",
-            Properties: {
-              BucketName: "uploads",
-              BucketEncryption: {
-                ServerSideEncryptionConfiguration: [
-                  {
-                    ServerSideEncryptionByDefault: { SSEAlgorithm: "AES256" },
-                  },
-                ],
-              },
-              Tags: [{ Key: "app", Value: "uploads" }],
-            },
-          },
-        },
+    const stack = await deployBucket(simAws, {
+      BucketEncryption: {
+        ServerSideEncryptionConfiguration: [
+          { ServerSideEncryptionByDefault: { SSEAlgorithm: "AES256" } },
+        ],
       },
+      Tags: [{ Key: "app", Value: "uploads" }],
     });
-    await stack.waitForDeployComplete();
 
-    // Then the Bucket is created, and the properties are read and ignored.
-    const output = await simAws.s3().listBuckets(new ListBucketsCommand());
-
-    assertArrayLength(output.Buckets ?? [], 1);
+    // Then the Bucket is created, and nothing is reported: no simulated
+    // command could tell either property was left out.
+    assertIdentical(await bucketCount(simAws), 1);
+    assertArrayLength(stack.ignoredProperties, 0);
   });
 
   it("accepts the four properties simulated S3 acts on", async () => {
@@ -190,27 +225,14 @@ describe("AWS::S3::Bucket property rules", () => {
     const simAws = new SimAws();
 
     // When the template is deployed.
-    const stack = await simAws.cloudFormation().deployTemplate({
-      stackName: "uploads-stack",
-      template: {
-        Resources: {
-          Bucket: {
-            Type: "AWS::S3::Bucket",
-            Properties: {
-              BucketName: "uploads",
-              NotificationConfiguration: { LambdaConfigurations: [] },
-              PublicAccessBlockConfiguration: { BlockPublicPolicy: false },
-              WebsiteConfiguration: { IndexDocument: "index.html" },
-            },
-          },
-        },
-      },
+    const stack = await deployBucket(simAws, {
+      NotificationConfiguration: { LambdaConfigurations: [] },
+      PublicAccessBlockConfiguration: { BlockPublicPolicy: false },
+      WebsiteConfiguration: { IndexDocument: "index.html" },
     });
-    await stack.waitForDeployComplete();
 
-    // Then the Bucket is created.
-    const output = await simAws.s3().listBuckets(new ListBucketsCommand());
-
-    assertArrayLength(output.Buckets ?? [], 1);
+    // Then the Bucket is created with nothing left out.
+    assertIdentical(await bucketCount(simAws), 1);
+    assertArrayLength(stack.ignoredProperties, 0);
   });
 });

--- a/src/service/s3/cfn/bucket/sim-cfn-s3-bucket-property-rules.ts
+++ b/src/service/s3/cfn/bucket/sim-cfn-s3-bucket-property-rules.ts
@@ -1,92 +1,52 @@
 import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimCfnPropertyIgnorer } from "../../../cloudformation/resource/ignore/sim-cfn-ignored-property.type.js";
 import { s3BucketResourceError } from "./error/sim-cfn-s3-bucket-error.js";
-
-/**
- * The AWS::S3::Bucket properties this simulation acts on.
- */
-const simulatedPropertyNames: ReadonlySet<string> = new Set([
-  "BucketName",
-  "NotificationConfiguration",
-  "PublicAccessBlockConfiguration",
-  "WebsiteConfiguration",
-]);
-
-/**
- * Real AWS::S3::Bucket properties this simulation reads and does nothing with.
- *
- * Nothing this simulator models can tell the difference. There is no simulated
- * KMS and Object bytes are stored as they arrive, so an encrypted Bucket and an
- * unencrypted one answer every simulated command identically, and no simulated
- * service reads a Bucket tag. Both are on almost every Bucket CDK synthesizes,
- * so refusing them would leave a CDK app unable to deploy over a difference no
- * test could observe.
- */
-const inertPropertyNames: ReadonlySet<string> = new Set([
-  "BucketEncryption",
-  "Tags",
-]);
-
-/**
- * Real AWS::S3::Bucket properties this simulation does not model.
- *
- * Each of these changes what a simulated command answers on real AWS. A
- * versioned Bucket answers a delete with a delete marker and an
- * `ObjectRemoved:DeleteMarkerCreated` event, where this simulator removes the
- * Object and raises `ObjectRemoved:Delete`. So they fail the Resource rather
- * than being dropped on the way through, which would leave a Bucket that looks
- * configured to the template and behaves as though it were not.
- */
-const unsimulatedPropertyNames: ReadonlySet<string> = new Set([
-  "AbacStatus",
-  "AccelerateConfiguration",
-  "AccessControl",
-  "AnalyticsConfigurations",
-  "BucketNamePrefix",
-  "BucketNamespace",
-  "CorsConfiguration",
-  "IntelligentTieringConfigurations",
-  "InventoryConfigurations",
-  "LifecycleConfiguration",
-  "LoggingConfiguration",
-  "MetadataConfiguration",
-  "MetadataTableConfiguration",
-  "MetricsConfigurations",
-  "ObjectLockConfiguration",
-  "ObjectLockEnabled",
-  "OwnershipControls",
-  "ReplicationConfiguration",
-  "VersioningConfiguration",
-]);
+import {
+  inertPropertyNames,
+  simulatedPropertyNames,
+  unsimulatedPropertyReasons,
+} from "./sim-cfn-s3-bucket-property-names.js";
 
 interface SimCfnS3BucketPropertyRulesProperties {
   readonly logicalId: string;
   readonly properties: SimCfnTemplateValueRecord;
+  readonly ignorer: SimCfnPropertyIgnorer;
 }
 
 /**
- * Which AWS::S3::Bucket properties simulated S3 can act on.
+ * What simulated S3 does with each AWS::S3::Bucket property it is handed.
  *
- * Anything else fails the Resource. Being stricter than CloudFormation shows up
- * as a puzzling deployment failure here; being looser shows up as a Bucket
- * behaving one way in a test and another way on AWS.
+ * Simulated CloudFormation deploys what it can, so a property this simulation
+ * cannot act on does not stop the Bucket being created. It is left out and
+ * recorded against the Resource, where a test can find it. Refusing is kept for
+ * the one case where there is nothing coherent to create: a BucketName that is
+ * not a name.
+ *
+ * A property this simulation has never heard of is treated the same way. It may
+ * be a typo, or a property AWS added since this list was written, and a Bucket
+ * that deploys with the unknown name recorded is more useful than a stack that
+ * fails over either.
  */
 export class SimCfnS3BucketPropertyRules {
   private readonly logicalId: string;
   private readonly properties: SimCfnTemplateValueRecord;
+  private readonly ignorer: SimCfnPropertyIgnorer;
 
   constructor(properties: SimCfnS3BucketPropertyRulesProperties) {
     this.logicalId = properties.logicalId;
     this.properties = properties.properties;
+    this.ignorer = properties.ignorer;
   }
 
   /**
-   * Refuse everything about this Resource that is not simulated.
+   * Record everything about this Resource that is not simulated, refusing only
+   * what leaves nothing to create.
    */
-  assertSimulated(): void {
+  apply(): void {
     this.refuseUnusableBucketName();
 
     for (const name of Object.keys(this.properties)) {
-      this.assertSimulatedProperty(name);
+      this.applyToProperty(name);
     }
   }
 
@@ -111,22 +71,27 @@ export class SimCfnS3BucketPropertyRules {
     );
   }
 
-  private assertSimulatedProperty(name: string): void {
+  private applyToProperty(name: string): void {
     if (simulatedPropertyNames.has(name) || inertPropertyNames.has(name)) {
       return;
     }
 
-    if (unsimulatedPropertyNames.has(name)) {
-      throw s3BucketResourceError(
-        this.logicalId,
-        `${name} is a real AWS::S3::Bucket property that simulated S3 does ` +
-          `not simulate, so it is refused rather than ignored`,
+    const unsimulatedReason = unsimulatedPropertyReasons.get(name);
+
+    if (unsimulatedReason !== undefined) {
+      this.ignorer.ignoreProperty(
+        name,
+        `${name} is a real AWS::S3::Bucket property simulated S3 does not ` +
+          `act on: ${unsimulatedReason}`,
       );
+
+      return;
     }
 
-    throw s3BucketResourceError(
-      this.logicalId,
-      `${name} is not an AWS::S3::Bucket property`,
+    this.ignorer.ignoreProperty(
+      name,
+      `${name} is not a property simulated S3 knows about, so the Bucket is ` +
+        `created without it`,
     );
   }
 }

--- a/src/service/sqs/cfn/queue/sim-cfn-sqs-queue-properties.ts
+++ b/src/service/sqs/cfn/queue/sim-cfn-sqs-queue-properties.ts
@@ -34,6 +34,7 @@ export class SimCfnSqsQueueProperties {
     this.rules = new SimCfnSqsQueuePropertyRules({
       logicalId: properties.resource.logicalId,
       properties: properties.properties,
+      ignorer: properties.resource,
     });
   }
 
@@ -65,7 +66,7 @@ export class SimCfnSqsQueueProperties {
    * takes them in.
    */
   attributes(): SimSqsQueueAttributeInput {
-    this.rules.assertSimulated();
+    this.rules.apply();
 
     return Object.fromEntries(
       Object.entries(this.properties)

--- a/src/service/sqs/cfn/queue/sim-cfn-sqs-queue-property-names.ts
+++ b/src/service/sqs/cfn/queue/sim-cfn-sqs-queue-property-names.ts
@@ -1,0 +1,67 @@
+import type { SimCfnTemplateValue } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+
+/**
+ * The AWS::SQS::Queue properties carrying a queue attribute of the same name.
+ *
+ * CloudFormation names these exactly as the SQS API names the attributes, so
+ * they are handed to CreateQueue rather than applied here. That leaves the
+ * ranges and defaults in one place: the ones simulated SQS already validates.
+ */
+export const attributePropertyNames: ReadonlySet<string> = new Set([
+  "DelaySeconds",
+  "MaximumMessageSize",
+  "MessageRetentionPeriod",
+  "ReceiveMessageWaitTimeSeconds",
+  "VisibilityTimeout",
+]);
+
+/**
+ * Real AWS::SQS::Queue properties this simulation does not model, with what
+ * each of them would have changed.
+ *
+ * The queue is created without them and each one is recorded against the
+ * Resource. A queue deployed without its redrive policy looks like a queue with
+ * a dead-letter queue to the template that wrote it and has none, so a test
+ * expecting a failed message to end up somewhere needs to find out that it
+ * never will.
+ */
+export const unsimulatedPropertyReasons: ReadonlyMap<string, string> = new Map([
+  ["ContentBasedDeduplication", "only standard queues are simulated"],
+  ["DeduplicationScope", "only standard queues are simulated"],
+  ["FifoThroughputLimit", "only standard queues are simulated"],
+  [
+    "KmsDataKeyReusePeriodSeconds",
+    "simulated SQS does not encrypt message bodies",
+  ],
+  ["KmsMasterKeyId", "simulated SQS does not encrypt message bodies"],
+  [
+    "RedriveAllowPolicy",
+    "dead-letter queues are not simulated, so nothing enforces which queues " +
+      "may name this one as theirs",
+  ],
+  [
+    "RedrivePolicy",
+    "dead-letter queues are not simulated, so a message that is received " +
+      "past maxReceiveCount stays on this queue rather than moving",
+  ],
+  ["SqsManagedSseEnabled", "simulated SQS does not encrypt message bodies"],
+  ["Tags", "no simulated service reads a queue tag"],
+]);
+
+/**
+ * The FifoQueue values that ask for a FIFO queue. CloudFormation carries a
+ * boolean property as either, depending on where the value came from.
+ */
+export const fifoQueueValues: ReadonlySet<SimCfnTemplateValue> = new Set([
+  true,
+  "true",
+]);
+
+/**
+ * The FifoQueue values that ask for a standard queue, which is the only kind
+ * this simulation creates.
+ */
+export const standardQueueValues: ReadonlySet<SimCfnTemplateValue> = new Set([
+  false,
+  "false",
+]);

--- a/src/service/sqs/cfn/queue/sim-cfn-sqs-queue-property-rules.ts
+++ b/src/service/sqs/cfn/queue/sim-cfn-sqs-queue-property-rules.ts
@@ -1,67 +1,19 @@
-import type {
-  SimCfnTemplateValue,
-  SimCfnTemplateValueRecord,
-} from "../../../cloudformation/template/value/sim-cfn-template-value.js";
-
-/**
- * The AWS::SQS::Queue properties carrying a queue attribute of the same name.
- *
- * CloudFormation names these exactly as the SQS API names the attributes, so
- * they are handed to CreateQueue rather than applied here. That leaves the
- * ranges and defaults in one place: the ones simulated SQS already validates.
- */
-const attributePropertyNames: ReadonlySet<string> = new Set([
-  "DelaySeconds",
-  "MaximumMessageSize",
-  "MessageRetentionPeriod",
-  "ReceiveMessageWaitTimeSeconds",
-  "VisibilityTimeout",
-]);
-
-/**
- * Real AWS::SQS::Queue properties this simulation does not model.
- *
- * A queue deployed without its redrive policy would look like a queue with a
- * dead-letter queue to the template and have none, so these fail the Resource
- * rather than being dropped on the way through.
- */
-const unsimulatedPropertyNames: ReadonlySet<string> = new Set([
-  "ContentBasedDeduplication",
-  "DeduplicationScope",
-  "FifoThroughputLimit",
-  "KmsDataKeyReusePeriodSeconds",
-  "KmsMasterKeyId",
-  "RedriveAllowPolicy",
-  "RedrivePolicy",
-  "SqsManagedSseEnabled",
-  "Tags",
-]);
-
-/**
- * The FifoQueue values that ask for a FIFO queue. CloudFormation carries a
- * boolean property as either, depending on where the value came from.
- */
-const fifoQueueValues: ReadonlySet<SimCfnTemplateValue> = new Set([
-  true,
-  "true",
-]);
-
-/**
- * The FifoQueue values that ask for a standard queue, which is the only kind
- * this simulation creates.
- */
-const standardQueueValues: ReadonlySet<SimCfnTemplateValue> = new Set([
-  false,
-  "false",
-]);
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimCfnPropertyIgnorer } from "../../../cloudformation/resource/ignore/sim-cfn-ignored-property.type.js";
+import {
+  attributePropertyNames,
+  fifoQueueValues,
+  standardQueueValues,
+  unsimulatedPropertyReasons,
+} from "./sim-cfn-sqs-queue-property-names.js";
 
 /**
  * Build the error a property of an AWS::SQS::Queue Resource is refused with.
  *
- * The wording matters. Sim CloudFormation skips a Resource whose error reads as
- * an unsupported Resource type, and skipping is the wrong answer for a queue
- * that cannot be created as the template asks: the stack would deploy without
- * it.
+ * Refusing is the rarer answer now. A property simulated SQS cannot act on is
+ * recorded against the Resource and the queue is created without it, so what
+ * is left here is the template that describes no queue at all: a QueueName
+ * that is not a name, a FifoQueue that is neither true nor false.
  */
 export function sqsQueuePropertyError(
   logicalId: string,
@@ -73,22 +25,27 @@ export function sqsQueuePropertyError(
 interface SimCfnSqsQueuePropertyRulesProperties {
   readonly logicalId: string;
   readonly properties: SimCfnTemplateValueRecord;
+  readonly ignorer: SimCfnPropertyIgnorer;
 }
 
 /**
- * Which AWS::SQS::Queue properties simulated SQS can act on.
+ * What simulated SQS does with each AWS::SQS::Queue property it is handed.
  *
- * Anything else fails the Resource. Being stricter than CloudFormation shows up
- * as a puzzling deployment failure here; being looser shows up as a queue
- * behaving one way in a test and another way on AWS.
+ * A property this simulation cannot act on does not stop the queue being
+ * created. It is left out and recorded against the Resource, where a test can
+ * find it, so a stack full of queues still deploys around the settings this
+ * models nothing for. Refusing is kept for the template that describes no
+ * queue at all.
  */
 export class SimCfnSqsQueuePropertyRules {
   private readonly logicalId: string;
   private readonly properties: SimCfnTemplateValueRecord;
+  private readonly ignorer: SimCfnPropertyIgnorer;
 
   constructor(properties: SimCfnSqsQueuePropertyRulesProperties) {
     this.logicalId = properties.logicalId;
     this.properties = properties.properties;
+    this.ignorer = properties.ignorer;
   }
 
   /**
@@ -99,26 +56,31 @@ export class SimCfnSqsQueuePropertyRules {
   }
 
   /**
-   * Refuse everything about this Resource that is not simulated.
+   * Record everything about this Resource the queue is created without.
    */
-  assertSimulated(): void {
-    this.refuseFifoQueue();
+  apply(): void {
+    this.applyToFifoQueue();
 
     for (const name of Object.keys(this.properties)) {
-      this.assertSimulatedProperty(name);
+      this.applyToProperty(name);
     }
   }
 
   /**
    * Refuse a FIFO queue.
    *
-   * Only standard queues are simulated, and a FIFO queue quietly created as a
-   * standard one would take messages in an order the deployment does not
-   * promise, so the Resource fails instead. A value that is neither true nor
-   * false is refused as well, rather than read as false: CloudFormation would
-   * refuse it too, and the queue it asked for is not knowable.
+   * This is one of the few properties still worth refusing over. A FIFO queue
+   * is named `<name>.fifo`, and simulated SQS refuses that name to an SDK
+   * caller as well, so there is no queue to create the Resource without the
+   * property as: the only queue that could exist would answer to a different
+   * name from the one the template gave it, and everything referring to it
+   * would be referring to nothing.
+   *
+   * A value that is neither true nor false is refused as well, rather than
+   * read as false: CloudFormation refuses it too, and the queue it asked for
+   * is not knowable.
    */
-  private refuseFifoQueue(): void {
+  private applyToFifoQueue(): void {
     const fifo = this.properties["FifoQueue"];
 
     if (fifo === undefined || standardQueueValues.has(fifo)) {
@@ -129,8 +91,9 @@ export class SimCfnSqsQueuePropertyRules {
       throw sqsQueuePropertyError(
         this.logicalId,
         "FifoQueue names a FIFO queue, which simulated SQS does not " +
-          "simulate. Only standard queues are simulated, so the queue is not " +
-          "created rather than created as a standard queue",
+          "simulate. Only standard queues are simulated, and a FIFO queue " +
+          "is named <name>.fifo, which simulated SQS refuses, so there is no " +
+          "queue to create under the name the template gave it",
       );
     }
 
@@ -140,13 +103,17 @@ export class SimCfnSqsQueuePropertyRules {
     );
   }
 
-  private assertSimulatedProperty(name: string): void {
-    if (unsimulatedPropertyNames.has(name)) {
-      throw sqsQueuePropertyError(
-        this.logicalId,
-        `${name} is a real AWS::SQS::Queue property that simulated SQS does ` +
-          `not simulate, so it is refused rather than ignored`,
+  private applyToProperty(name: string): void {
+    const unsimulatedReason = unsimulatedPropertyReasons.get(name);
+
+    if (unsimulatedReason !== undefined) {
+      this.ignorer.ignoreProperty(
+        name,
+        `${name} is a real AWS::SQS::Queue property simulated SQS does not ` +
+          `act on: ${unsimulatedReason}`,
       );
+
+      return;
     }
 
     if (
@@ -154,9 +121,10 @@ export class SimCfnSqsQueuePropertyRules {
       name !== "FifoQueue" &&
       !this.isAttributeProperty(name)
     ) {
-      throw sqsQueuePropertyError(
-        this.logicalId,
-        `${name} is not an AWS::SQS::Queue property`,
+      this.ignorer.ignoreProperty(
+        name,
+        `${name} is not a property simulated SQS knows about, so the queue ` +
+          `is created without it`,
       );
     }
   }

--- a/src/service/sqs/cfn/sim-cfn-sqs-queue-validation.iso.test.ts
+++ b/src/service/sqs/cfn/sim-cfn-sqs-queue-validation.iso.test.ts
@@ -13,6 +13,7 @@ import { describe, it } from "vitest";
 import { SimAws } from "../../aws/sim-aws.js";
 import type { SimAwsAccountId } from "../../aws/sim-aws-account.js";
 import { SimCfnResource } from "../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnIgnoredProperty } from "../../cloudformation/resource/ignore/sim-cfn-ignored-property.type.js";
 import type { SimCfnTemplateValueRecord } from "../../cloudformation/template/value/sim-cfn-template-value.js";
 import { SimSqsCfnResourceFactory } from "./sim-sqs-cfn-resource-factory.js";
 
@@ -27,6 +28,23 @@ function queueResource(properties: SimCfnTemplateValueRecord): SimCfnResource {
     logicalId: "BadQueue",
     template: { Type: "AWS::SQS::Queue", Properties: properties },
   });
+}
+
+/**
+ * Create a queue straight through the Resource factory, returning what it
+ * recorded creating the queue without. Keeps the property rules under test
+ * without a whole stack.
+ */
+async function createdQueueResource(
+  properties: SimCfnTemplateValueRecord,
+): Promise<readonly SimCfnIgnoredProperty[]> {
+  const simAws = new SimAws();
+  const factory = new SimSqsCfnResourceFactory({ sqs: simAws.sqs() });
+  const resource = queueResource(properties);
+
+  await factory.create("Queue", resource, { simAws, resources: new Map() });
+
+  return resource.ignoredProperties;
 }
 
 /**
@@ -67,8 +85,9 @@ describe("SQS CloudFormation Queue validation", () => {
       });
     });
 
-    // And the failure names FIFO, rather than the Resource being skipped or
-    // quietly deployed as a standard queue.
+    // And the failure names FIFO, rather than the property being recorded and
+    // the queue created: a FIFO queue is named <name>.fifo, which simulated
+    // SQS refuses, so there is no queue to create under that name.
     assertStringIncludes(
       error.message,
       "FifoQueue names a FIFO queue, which simulated SQS does not simulate",
@@ -119,54 +138,55 @@ describe("SQS CloudFormation Queue validation", () => {
     );
   });
 
-  it("refuses the properties this simulation does not model", async () => {
+  it("records the properties this simulation does not model", async () => {
     // Given templates declaring properties with behaviour that is not
     // simulated.
-    // When each Resource is created, then each is refused by name rather than
-    // deploying a queue that behaves differently here than on AWS.
-    const redrive = await createQueueResource({
+    // When each Resource is created, then each queue exists with the property
+    // it behaves differently to AWS without recorded by name.
+    const redrive = await createdQueueResource({
       QueueName: "orders",
       RedrivePolicy: { maxReceiveCount: 3 },
     });
     assertIdentical(
-      redrive.message,
-      "Invalid AWS::SQS::Queue Resource BadQueue: RedrivePolicy is a real " +
-        "AWS::SQS::Queue property that simulated SQS does not simulate, so " +
-        "it is refused rather than ignored",
+      redrive[0]?.reason,
+      "RedrivePolicy is a real AWS::SQS::Queue property simulated SQS does " +
+        "not act on: dead-letter queues are not simulated, so a message that " +
+        "is received past maxReceiveCount stays on this queue rather than " +
+        "moving",
     );
 
-    const encryption = await createQueueResource({
+    const encryption = await createdQueueResource({
       QueueName: "orders",
       KmsMasterKeyId: "alias/aws/sqs",
     });
     assertStringIncludes(
-      encryption.message,
+      encryption[0]?.reason ?? "",
       "KmsMasterKeyId is a real AWS::SQS::Queue property",
     );
 
-    const tags = await createQueueResource({
+    const tags = await createdQueueResource({
       QueueName: "orders",
       Tags: [{ Key: "component", Value: "orders" }],
     });
     assertStringIncludes(
-      tags.message,
+      tags[0]?.reason ?? "",
       "Tags is a real AWS::SQS::Queue property",
     );
   });
 
-  it("refuses a property AWS::SQS::Queue does not have", async () => {
+  it("records a property AWS::SQS::Queue does not have", async () => {
     // Given a template naming a property that is not on this Resource type.
-    // When the Resource is created, then it is refused rather than ignored, so
-    // a misspelled property does not pass here and fail the deployment.
-    const error = await createQueueResource({
+    // When the Resource is created, then the queue exists with the misspelling
+    // recorded, rather than a stack failing over a name nothing reads.
+    const ignored = await createdQueueResource({
       QueueName: "orders",
       VisibilityTimeoutSeconds: 30,
     });
 
     assertIdentical(
-      error.message,
-      "Invalid AWS::SQS::Queue Resource BadQueue: VisibilityTimeoutSeconds " +
-        "is not an AWS::SQS::Queue property",
+      ignored[0]?.reason,
+      "VisibilityTimeoutSeconds is not a property simulated SQS knows " +
+        "about, so the queue is created without it",
     );
   });
 

--- a/test/apigatewayv2/cfn-deploy.ts
+++ b/test/apigatewayv2/cfn-deploy.ts
@@ -54,3 +54,13 @@ export async function deployHttpApiFailure(
 
   return error;
 }
+
+/**
+ * The reasons a deployed stack gave for the properties it created Resources
+ * without, as one string per ignored property.
+ */
+export function ignoredReasons(stack: SimCfnStack): string[] {
+  return stack.ignoredProperties.map((ignored) => {
+    return `${ignored.logicalId} ${ignored.reason}`;
+  });
+}

--- a/test/cognito/cfn-deploy.ts
+++ b/test/cognito/cfn-deploy.ts
@@ -12,6 +12,7 @@
 import { assertInstanceOf, assertThrowsErrorAsync } from "@kensio/smartass";
 
 import { SimAws } from "../../src/service/aws/sim-aws.js";
+import type { SimCfnStack } from "../../src/service/cloudformation/stack/sim-cfn-stack.js";
 import type { SimCfnTemplateValueRecord } from "../../src/service/cloudformation/template/value/sim-cfn-template-value.js";
 
 /**
@@ -43,4 +44,30 @@ export async function deployFailure(
   assertInstanceOf(error, Error);
 
   return error;
+}
+
+/**
+ * Deploy a template that is expected to succeed, and give back the stack.
+ */
+export async function deploySuccess(
+  simAws: SimAws,
+  resources: SimCfnTemplateValueRecord,
+): Promise<SimCfnStack> {
+  const stack = await simAws.cloudFormation().deployTemplate({
+    stackName: "app-stack",
+    template: { Resources: resources },
+  });
+  await stack.waitForDeployComplete();
+
+  return stack;
+}
+
+/**
+ * The reasons a deployed stack gave for the properties it created Resources
+ * without, as one string per ignored property.
+ */
+export function ignoredReasons(stack: SimCfnStack): string[] {
+  return stack.ignoredProperties.map((ignored) => {
+    return `${ignored.logicalId} ${ignored.reason}`;
+  });
 }


### PR DESCRIPTION
Simulated CloudFormation already skipped a Resource type it could not create and carried on with the rest of the stack. A *property* it could not act on got one of two harsher answers: a hard failure that took the whole stack to `CREATE_FAILED` (S3, Cognito), or a skip that removed the Resource entirely over one setting (DynamoDB, SQS, API Gateway v2). This applies the same best-effort answer one level down.

Resolves #391
Resolves #392

## The mechanism

A service property parser calls `resource.ignoreProperty(path, reason)` instead of throwing. The Resource is created without the property, and the omission is on `resource.ignoredProperties` and on `stack.ignoredProperties`:

```typescript
const stack = await simAws.cloudFormation().deployTemplate({
  stackName: "uploads-stack",
  template: {
    Resources: {
      UploadsBucket: {
        Type: "AWS::S3::Bucket",
        Properties: {
          BucketName: "uploads",
          VersioningConfiguration: { Status: "Enabled" },
        },
      },
    },
  },
});
await stack.waitForDeployComplete();

// The Bucket exists and is usable, unversioned.
for (const ignored of stack.ignoredProperties) {
  console.log(ignored.logicalId, ignored.path, ignored.reason);
}
```

The path is the whole way down, so a setting on one entry of a list says which entry it was on, such as `GlobalSecondaryIndexes.1.WarmThroughput`. The stack getter reads from the Resources rather than collecting during deployment, so the two can never disagree.

This trades safety for reach, and the docs say so plainly: an ignored property means the simulated Resource behaves differently to the one the template describes, and the record is where a test checks whether that matters.

## Services

S3, DynamoDB (table and global table, at all six levels a global table nests), Cognito, API Gateway v2, SQS and KMS now record rather than refuse or skip. A property name AWS has no such thing as is recorded too, rather than a stack failing over a typo or a property AWS added since the list was written.

Properties nothing simulated could tell apart stay unrecorded. `BucketEncryption` and `Tags` on an S3 Bucket are on almost every Bucket CDK synthesizes, and listing a difference no test could observe would only bury the ones that matter.

## What is still refused

Three cases, each because the code disagreed with the plan in the issues:

- **A template that leaves nothing coherent to create.** A `BucketName` that is not a string, or a global table whose replica list omits the region the stack is deploying into. Real CloudFormation refuses these too.
- **A value the simulated service itself refuses an SDK caller.** `AWS::SQS::Queue` with `FifoQueue: true` is the one: a FIFO queue is named `<name>.fifo`, which simulated SQS refuses, so there is no queue to create under the name the template gave it. Issue #392 assumed this could be recorded; it cannot.
- **A Resource that cannot exist at all**, such as a Lambda function declaring a Python runtime. These stay whole-Resource skips.

## Two fallbacks

- A `AWS::DynamoDB::GlobalTable` naming several replicas is now created as an ordinary table in the stack's own region, with `Replicas` recorded, rather than skipped.
- Autoscaled capacity needed a fallback rather than only a record. Once `WriteCapacityAutoScalingSettings` was ignored, a `PROVISIONED` table had no capacity at all and `CreateTable` refused it. It now falls back to the `MinCapacity` those settings name, which is where autoscaling starts the table on AWS.

## Notes for review

- One API Gateway test was only passing because the allow-list refused it before `CreateAuthorizer` saw it; its authorizer template was incomplete and now needs a valid one.
- An LSI carrying `ProvisionedThroughput` still fails the stack. The index entry is handed to `CreateTable` as the template wrote it, and real DynamoDB refuses it, so that is the AWS-matching outcome rather than a gap.
- `docs/services/cloudformation/README.md` gains a section on the new behaviour, and the S3, DynamoDB, SQS, KMS, Cognito and API Gateway READMEs are updated where they described the old refusals.

`pnpm check` passes: 753 test files, 4686 tests, 99.9% statements.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CloudFormation stacks can now deploy resources when they contain unsupported or unknown properties.
  * Omitted properties are reported through `stack.ignoredProperties`, including resource, property path, and reason.
  * API Gateway, Cognito, DynamoDB, KMS, S3, and SQS simulations now support this behavior.
  * DynamoDB global tables can deploy locally when replication is unsupported; replication settings are recorded as ignored.
* **Bug Fixes**
  * Unsupported properties no longer incorrectly cause resources to be skipped or deployments to fail.
  * Existing validation errors remain for invalid resource configurations and unsupported resource types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->