### PR TITLE
feat: delete aliases, Hosted Zones, certificates

### DIFF
--- a/src/service/acm/command/delete-certificate/delete-certificate-authorizer.ts
+++ b/src/service/acm/command/delete-certificate/delete-certificate-authorizer.ts
@@ -1,0 +1,46 @@
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+
+interface DeleteCertificateAuthorizerProperties {
+  readonly iam: SimIamInterServiceAuthZ;
+}
+
+/**
+ * Applies IAM authorization to an ACM DeleteCertificate request.
+ *
+ * DeleteCertificate authorizes against the requested Certificate ARN, so a
+ * policy can grant deleting one certificate without granting deleting every
+ * certificate in the Account and Region.
+ *
+ * Authorization occurs before ACM looks up the Certificate, so an unauthorized
+ * caller receives AccessDenied whether the requested ARN exists or not.
+ */
+export class DeleteCertificateAuthorizer {
+  private static readonly action = "acm:DeleteCertificate";
+
+  private readonly iam: SimIamInterServiceAuthZ;
+
+  constructor(properties: DeleteCertificateAuthorizerProperties) {
+    this.iam = properties.iam;
+  }
+
+  /**
+   * Ensure the caller may delete the certificate identified by the ARN.
+   */
+  authorize(certificateArn: string, caller?: SimAwsCaller): void {
+    const decision = this.iam.authorize({
+      action: DeleteCertificateAuthorizer.action,
+      resource: certificateArn,
+      caller,
+    });
+
+    if (decision.isDenied) {
+      throw new SimIamAccessDenied({
+        principal: decision.caller.principal,
+        action: DeleteCertificateAuthorizer.action,
+        resource: certificateArn,
+      });
+    }
+  }
+}

--- a/src/service/acm/command/delete-certificate/delete-certificate.command.ts
+++ b/src/service/acm/command/delete-certificate/delete-certificate.command.ts
@@ -1,0 +1,24 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+
+/**
+ * Minimal structural sim ACM DeleteCertificate command.
+ */
+export interface SimDeleteCertificateCommand {
+  readonly input: SimDeleteCertificateCommandInput;
+}
+
+/**
+ * Minimal structural sim ACM DeleteCertificate input.
+ */
+export interface SimDeleteCertificateCommandInput {
+  readonly CertificateArn?: string | undefined;
+}
+
+/**
+ * Minimal structural sim ACM DeleteCertificate output.
+ *
+ * Real ACM answers a successful DeleteCertificate with an empty body.
+ */
+export interface SimDeleteCertificateCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/acm/command/delete-certificate/delete-certificate.handler.ts
+++ b/src/service/acm/command/delete-certificate/delete-certificate.handler.ts
@@ -1,0 +1,90 @@
+import type { CommandHandler } from "../../../../command/command-handler.js";
+import {
+  type BackgroundScheduler,
+  BackgroundTasks,
+} from "../../../../util/background/background.js";
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type { SimArn } from "../../../aws/arn.js";
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import {
+  SimIamAllowAllAuth,
+  type SimIamInterServiceAuthZ,
+} from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import type { SimAcmCertificate } from "../../certificate/sim-acm-certificate.js";
+import { SimAcmResourceNotFoundException } from "../../error/sim-acm.error.js";
+import { DeleteCertificateAuthorizer } from "./delete-certificate-authorizer.js";
+import type {
+  SimDeleteCertificateCommand,
+  SimDeleteCertificateCommandOutput,
+} from "./delete-certificate.command.js";
+
+interface DeleteCertificateCommandHandlerProperties {
+  readonly certificates: Map<SimArn, SimAcmCertificate>;
+  readonly iam?: SimIamInterServiceAuthZ;
+  readonly background?: BackgroundScheduler;
+}
+
+interface DeleteCertificateCommandHandlerOptions {
+  readonly caller?: SimAwsCaller;
+}
+
+/**
+ * Simulated ACM DeleteCertificateCommand handler.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/acm/command/DeleteCertificateCommand/
+ */
+export class DeleteCertificateCommandHandler implements CommandHandler<
+  SimDeleteCertificateCommand,
+  SimDeleteCertificateCommandOutput
+> {
+  private readonly certificates: Map<SimArn, SimAcmCertificate>;
+  private readonly authorizer: DeleteCertificateAuthorizer;
+  private readonly background: BackgroundScheduler;
+
+  constructor(properties: DeleteCertificateCommandHandlerProperties) {
+    const {
+      certificates,
+      iam = new SimIamAllowAllAuth(),
+      background = new BackgroundTasks(),
+    } = properties;
+
+    this.certificates = certificates;
+    this.authorizer = new DeleteCertificateAuthorizer({ iam });
+    this.background = background;
+  }
+
+  /**
+   * Delete a simulated ACM certificate.
+   *
+   * Real ACM refuses with ResourceInUseException while anything is using the
+   * certificate, and reports what through the certificate's InUseBy list. This
+   * simulation does not track use: nothing tells ACM when a CloudFront
+   * distribution or a load balancer takes a certificate up, so InUseBy is
+   * always empty and every certificate here is deletable. A test that expects
+   * the in-use refusal will not get it.
+   */
+  async handle(
+    command: SimDeleteCertificateCommand,
+    options?: DeleteCertificateCommandHandlerOptions,
+  ): Promise<SimDeleteCertificateCommandOutput> {
+    assertDefined(
+      command.input.CertificateArn,
+      "DeleteCertificateCommand.input.CertificateArn required",
+    );
+
+    // Allow for potential non-deterministic sequencing of async events.
+    await this.background.sequence();
+
+    this.authorizer.authorize(command.input.CertificateArn, options?.caller);
+
+    const certificateArn = command.input.CertificateArn as SimArn;
+
+    if (!this.certificates.delete(certificateArn)) {
+      throw new SimAcmResourceNotFoundException(
+        `No sim ACM Certificate with ARN ${certificateArn}`,
+      );
+    }
+
+    return { $metadata: {} };
+  }
+}

--- a/src/service/acm/command/delete-certificate/delete-certificate.iso.test.ts
+++ b/src/service/acm/command/delete-certificate/delete-certificate.iso.test.ts
@@ -1,0 +1,120 @@
+import {
+  DeleteCertificateCommand,
+  DescribeCertificateCommand,
+  ListCertificatesCommand,
+  RequestCertificateCommand,
+} from "@aws-sdk/client-acm";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+import type { SimAcm } from "../../sim-acm.js";
+import { SimAcmResourceNotFoundException } from "../../error/sim-acm.error.js";
+
+async function givenCertificate(
+  simAcm: SimAcm,
+  domainName: string,
+): Promise<string> {
+  const requested = await simAcm.requestCertificate(
+    new RequestCertificateCommand({ DomainName: domainName }),
+  );
+  assertNonNullable(requested.CertificateArn);
+
+  return requested.CertificateArn;
+}
+
+describe("ACM DeleteCertificateCommand", () => {
+  it("deletes a Certificate so it can no longer be described", async () => {
+    // Given a requested Certificate.
+    const simAcm = new SimAws().acm();
+    const certificateArn = await givenCertificate(simAcm, "disposable.test");
+
+    // When the Certificate is deleted.
+    await simAcm.deleteCertificate(
+      new DeleteCertificateCommand({ CertificateArn: certificateArn }),
+    );
+
+    // Then ACM no longer has it.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAcm.describeCertificate(
+        new DescribeCertificateCommand({ CertificateArn: certificateArn }),
+      ),
+    );
+    assertInstanceOf(error, SimAcmResourceNotFoundException);
+
+    const listed = await simAcm.listCertificates(
+      new ListCertificatesCommand({}),
+    );
+    assertArrayLength(listed.CertificateSummaryList, 0);
+  });
+
+  it("rejects a Certificate that does not exist", async () => {
+    // Given a simulated ACM without the requested Certificate.
+    const simAws = new SimAws();
+    const simAcm = simAws.acm();
+
+    // When the missing Certificate is deleted.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAcm.deleteCertificate(
+        new DeleteCertificateCommand({
+          CertificateArn:
+            `arn:aws:acm:${simAws.defaultRegionName}:` +
+            `${simAws.defaultAccountId}:certificate/absent`,
+        }),
+      ),
+    );
+
+    // Then ACM answers with its not-found error.
+    assertInstanceOf(error, SimAcmResourceNotFoundException);
+  });
+
+  it("rejects a missing required CertificateArn input", async () => {
+    // Given a simulated ACM.
+    const simAcm = new SimAws().acm();
+
+    // When DeleteCertificate is called without its required CertificateArn.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAcm.deleteCertificate(
+        // @ts-expect-error -- testing invalid input
+        new DeleteCertificateCommand({}),
+      ),
+    );
+
+    // Then request validation identifies the missing input.
+    assertStringIncludes(
+      error.message,
+      "DeleteCertificateCommand.input.CertificateArn",
+    );
+  });
+
+  it("denies a caller without DeleteCertificate permission", async () => {
+    // Given a Certificate in a simulation with IAM.
+    const simAcm = new SimAws().acm();
+    const certificateArn = await givenCertificate(simAcm, "protected.test");
+
+    // When an anonymous caller deletes it.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAcm.deleteCertificate(
+        new DeleteCertificateCommand({ CertificateArn: certificateArn }),
+        { caller: { kind: "anonymous" } },
+      ),
+    );
+
+    // Then IAM denies the removal action, and the Certificate stays.
+    assertInstanceOf(error, SimIamAccessDenied);
+    assertIdentical(error.action, "acm:DeleteCertificate");
+
+    const stillThere = await simAcm.describeCertificate(
+      new DescribeCertificateCommand({ CertificateArn: certificateArn }),
+    );
+    assertNonNullable(stillThere.Certificate);
+    assertIdentical(stillThere.Certificate.DomainName, "protected.test");
+  });
+});

--- a/src/service/acm/sdk/sim-acm-sdk-command-router.iso.test.ts
+++ b/src/service/acm/sdk/sim-acm-sdk-command-router.iso.test.ts
@@ -1,6 +1,7 @@
 import { describe, it } from "vitest";
 import {
   ACMClient,
+  AddTagsToCertificateCommand,
   DeleteCertificateCommand,
   DescribeCertificateCommand,
   ListCertificatesCommand,
@@ -48,6 +49,14 @@ describe("simulated ACM SDK Command routing", () => {
     assertNonNullable(describeOutput.Certificate);
     assertIdentical(describeOutput.Certificate.DomainName, "example.com");
     assertIdentical(describeOutput.Certificate.Status, "PENDING_VALIDATION");
+
+    await client.send(
+      new DeleteCertificateCommand({
+        CertificateArn: requestOutput.CertificateArn,
+      }),
+    );
+    const listAfterDelete = await client.send(new ListCertificatesCommand({}));
+    assertArrayLength(listAfterDelete.CertificateSummaryList, 0);
   });
 
   it("shares certificate state with direct sim ACM use", async () => {
@@ -76,14 +85,15 @@ describe("simulated ACM SDK Command routing", () => {
 
     const error = await assertThrowsErrorAsync(async () => {
       await client.send(
-        new DeleteCertificateCommand({
+        new AddTagsToCertificateCommand({
           CertificateArn:
             "arn:aws:acm:eu-west-1:888888888888:certificate/00000001",
+          Tags: [{ Key: "team", Value: "platform" }],
         }),
       );
     });
 
-    assertStringIncludes(error.message, "DeleteCertificateCommand");
+    assertStringIncludes(error.message, "AddTagsToCertificateCommand");
     assertStringIncludes(error.message, "RequestCertificateCommand");
   });
 });

--- a/src/service/acm/sdk/sim-acm-sdk-command-router.ts
+++ b/src/service/acm/sdk/sim-acm-sdk-command-router.ts
@@ -3,6 +3,7 @@ import {
   type SimSdkCommandRoute,
   type SimSdkCommandRouter,
 } from "../../../sdk/index.js";
+import type { SimDeleteCertificateCommand } from "../command/delete-certificate/delete-certificate.command.js";
 import type { SimDescribeCertificateCommand } from "../command/describe-certificate/describe-certificate.command.js";
 import type { SimListCertificatesCommand } from "../command/list-certificates/list-certificates.command.js";
 import type { SimRequestCertificateCommand } from "../command/request-certificate/request-certificate.command.js";
@@ -21,6 +22,14 @@ export class SimAcmSdkCommandRouter implements SimSdkCommandRouter {
         async (command, context): Promise<unknown> =>
           await simAcm.describeCertificate(
             command as SimDescribeCertificateCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "DeleteCertificateCommand",
+        async (command, context): Promise<unknown> =>
+          await simAcm.deleteCertificate(
+            command as SimDeleteCertificateCommand,
             simSdkCallerOptions(context),
           ),
       ],

--- a/src/service/acm/sim-acm.ts
+++ b/src/service/acm/sim-acm.ts
@@ -16,6 +16,11 @@ import type {
 } from "./command/describe-certificate/describe-certificate.command.js";
 import { DescribeCertificateCommandHandler } from "./command/describe-certificate/describe-certificate.handler.js";
 import type {
+  SimDeleteCertificateCommand,
+  SimDeleteCertificateCommandOutput,
+} from "./command/delete-certificate/delete-certificate.command.js";
+import { DeleteCertificateCommandHandler } from "./command/delete-certificate/delete-certificate.handler.js";
+import type {
   SimListCertificatesCommand,
   SimListCertificatesCommandOutput,
 } from "./command/list-certificates/list-certificates.command.js";
@@ -134,6 +139,21 @@ export class SimAcm {
     options?: SimAcmRequestOptions,
   ): Promise<SimDescribeCertificateCommandOutput> {
     const handler = new DescribeCertificateCommandHandler({
+      certificates: this.certificates,
+      iam: this.iam,
+      background: this.background,
+    });
+    return await handler.handle(command, options);
+  }
+
+  /**
+   * Handle a Delete Certificate Command from the SDK.
+   */
+  async deleteCertificate(
+    command: SimDeleteCertificateCommand,
+    options?: SimAcmRequestOptions,
+  ): Promise<SimDeleteCertificateCommandOutput> {
+    const handler = new DeleteCertificateCommandHandler({
       certificates: this.certificates,
       iam: this.iam,
       background: this.background,

--- a/src/service/kms/command/alias/alias.command.ts
+++ b/src/service/kms/command/alias/alias.command.ts
@@ -19,6 +19,23 @@ export interface SimCreateAliasCommandOutput {
 }
 
 /**
+ * Minimal structural sim KMS DeleteAlias command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/kms/command/DeleteAliasCommand/
+ */
+export interface SimDeleteAliasCommand {
+  readonly input: SimDeleteAliasCommandInput;
+}
+
+export interface SimDeleteAliasCommandInput {
+  readonly AliasName?: string | undefined;
+}
+
+export interface SimDeleteAliasCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
  * Minimal structural sim KMS ListAliases command.
  *
  * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/kms/command/ListAliasesCommand/

--- a/src/service/kms/command/alias/sim-kms-alias-commands.ts
+++ b/src/service/kms/command/alias/sim-kms-alias-commands.ts
@@ -1,11 +1,19 @@
 import type { SimKmsRequestOptions } from "../sim-kms-request-options.js";
-import { SimKmsValidationException } from "../../error/sim-kms.error.js";
-import { SimKmsAliasName } from "../../key/sim-kms-alias.js";
+import {
+  SimKmsNotFoundException,
+  SimKmsValidationException,
+} from "../../error/sim-kms.error.js";
+import {
+  SimKmsAliasName,
+  simKmsAwsAliasPrefix,
+} from "../../key/sim-kms-alias.js";
 import type { SimKmsKeyStore } from "../../key/sim-kms-key-store.js";
 import type { SimKmsAuthorizer } from "../authorize/sim-kms-authorizer.js";
 import type {
   SimCreateAliasCommand,
   SimCreateAliasCommandOutput,
+  SimDeleteAliasCommand,
+  SimDeleteAliasCommandOutput,
   SimListAliasesCommand,
   SimListAliasesCommandOutput,
 } from "./alias.command.js";
@@ -50,6 +58,43 @@ export class SimKmsAliasCommands {
     const key = this.keys.require(command.input.TargetKeyId);
     this.authorizer.authorizeKey("kms:CreateAlias", key, options);
     this.keys.addAlias(aliasName, key);
+
+    return { $metadata: {} };
+  }
+
+  /**
+   * Remove an alias, leaving the key it pointed at alone.
+   *
+   * Real KMS authorizes this against the alias and the target key, and the
+   * key is the half checked here for the same reason CreateAlias checks it.
+   * An alias reserved for an AWS managed key is refused rather than removed,
+   * as real KMS does not let a customer delete one.
+   */
+  delete(
+    command: SimDeleteAliasCommand,
+    options?: SimKmsRequestOptions,
+  ): SimDeleteAliasCommandOutput {
+    const aliasName = command.input.AliasName;
+
+    if (aliasName === undefined) {
+      throw new SimKmsValidationException("AliasName is required");
+    }
+
+    if (aliasName.startsWith(simKmsAwsAliasPrefix)) {
+      throw new SimKmsValidationException(
+        `Alias '${aliasName}' is reserved for AWS managed keys`,
+      );
+    }
+
+    const alias = this.keys.findAlias(aliasName);
+
+    if (alias === undefined) {
+      throw new SimKmsNotFoundException(`Alias '${aliasName}' does not exist`);
+    }
+
+    const key = this.keys.require(alias.targetKeyId);
+    this.authorizer.authorizeKey("kms:DeleteAlias", key, options);
+    this.keys.removeAlias(aliasName);
 
     return { $metadata: {} };
   }

--- a/src/service/kms/command/alias/sim-kms-delete-alias.iso.test.ts
+++ b/src/service/kms/command/alias/sim-kms-delete-alias.iso.test.ts
@@ -1,0 +1,152 @@
+import {
+  CreateAliasCommand,
+  CreateKeyCommand,
+  DeleteAliasCommand,
+  DescribeKeyCommand,
+  ListAliasesCommand,
+} from "@aws-sdk/client-kms";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+import {
+  SimKmsNotFoundException,
+  SimKmsValidationException,
+} from "../../error/sim-kms.error.js";
+import { SimKms } from "../../sim-kms.js";
+
+async function givenAliasedKey(
+  simKms: SimKms,
+  aliasName: string,
+): Promise<string> {
+  const key = await simKms.createKey(new CreateKeyCommand({}));
+  assertNonNullable(key.KeyMetadata?.KeyId);
+  const keyId = key.KeyMetadata.KeyId;
+
+  await simKms.createAlias(
+    new CreateAliasCommand({ AliasName: aliasName, TargetKeyId: keyId }),
+  );
+
+  return keyId;
+}
+
+describe("KMS DeleteAliasCommand", () => {
+  it("removes the alias and leaves the key alone", async () => {
+    // Given a key with an alias pointing at it.
+    const simKms = new SimKms();
+    const keyId = await givenAliasedKey(simKms, "alias/removable");
+
+    // When the alias is deleted.
+    await simKms.deleteAlias(
+      new DeleteAliasCommand({ AliasName: "alias/removable" }),
+    );
+
+    // Then the alias is gone and the key is untouched.
+    assertUndefined(simKms.findAlias("alias/removable"));
+
+    const described = await simKms.describeKey(
+      new DescribeKeyCommand({ KeyId: keyId }),
+    );
+    assertNonNullable(described.KeyMetadata);
+    assertIdentical(described.KeyMetadata.KeyState, "Enabled");
+
+    const listed = await simKms.listAliases(new ListAliasesCommand({}));
+    assertArrayLength(listed.Aliases, 0);
+  });
+
+  it("frees the alias name for another key", async () => {
+    // Given an alias that has been deleted.
+    const simKms = new SimKms();
+    await givenAliasedKey(simKms, "alias/reusable");
+    await simKms.deleteAlias(
+      new DeleteAliasCommand({ AliasName: "alias/reusable" }),
+    );
+
+    // When a second key claims the same alias name.
+    const second = await simKms.createKey(new CreateKeyCommand({}));
+    assertNonNullable(second.KeyMetadata?.KeyId);
+    await simKms.createAlias(
+      new CreateAliasCommand({
+        AliasName: "alias/reusable",
+        TargetKeyId: second.KeyMetadata.KeyId,
+      }),
+    );
+
+    // Then it points at the second key.
+    assertIdentical(
+      simKms.findAlias("alias/reusable")?.targetKeyId,
+      second.KeyMetadata.KeyId,
+    );
+  });
+
+  it("rejects an alias that does not exist", async () => {
+    // Given a simulated KMS without the requested alias.
+    const simKms = new SimKms();
+
+    // When the missing alias is deleted.
+    const error = await assertThrowsErrorAsync(async () =>
+      simKms.deleteAlias(new DeleteAliasCommand({ AliasName: "alias/absent" })),
+    );
+
+    // Then KMS answers with its not-found error.
+    assertInstanceOf(error, SimKmsNotFoundException);
+  });
+
+  it("refuses an alias reserved for an AWS managed key", async () => {
+    // Given a simulated KMS.
+    const simKms = new SimKms();
+
+    // When a reserved alias is deleted.
+    const error = await assertThrowsErrorAsync(async () =>
+      simKms.deleteAlias(new DeleteAliasCommand({ AliasName: "alias/aws/s3" })),
+    );
+
+    // Then KMS refuses, as a customer cannot remove an AWS managed alias.
+    assertInstanceOf(error, SimKmsValidationException);
+    assertStringIncludes(error.message, "reserved for AWS managed keys");
+  });
+
+  it("rejects a missing required AliasName input", async () => {
+    // Given a simulated KMS.
+    const simKms = new SimKms();
+
+    // When DeleteAlias is called without its required AliasName.
+    const error = await assertThrowsErrorAsync(async () =>
+      simKms.deleteAlias(
+        // @ts-expect-error -- testing invalid input
+        new DeleteAliasCommand({}),
+      ),
+    );
+
+    // Then request validation identifies the missing input.
+    assertStringIncludes(error.message, "AliasName is required");
+  });
+
+  it("denies a caller without DeleteAlias permission on the key", async () => {
+    // Given a key in a simulation with IAM, whose policy grants the Account
+    // root and nobody else.
+    const simKms = new SimAws().kms();
+    await givenAliasedKey(simKms, "alias/protected");
+
+    // When an anonymous caller deletes the alias.
+    const error = await assertThrowsErrorAsync(async () =>
+      simKms.deleteAlias(
+        new DeleteAliasCommand({ AliasName: "alias/protected" }),
+        { caller: { kind: "anonymous" } },
+      ),
+    );
+
+    // Then IAM denies it, and the alias stays.
+    assertInstanceOf(error, SimIamAccessDenied);
+    assertIdentical(error.action, "kms:DeleteAlias");
+    assertInstanceOf(simKms.findAlias("alias/protected"), Object);
+  });
+});

--- a/src/service/kms/command/sim-kms-command.types.ts
+++ b/src/service/kms/command/sim-kms-command.types.ts
@@ -7,6 +7,8 @@
 export type {
   SimCreateAliasCommand,
   SimCreateAliasCommandOutput,
+  SimDeleteAliasCommand,
+  SimDeleteAliasCommandOutput,
   SimListAliasesCommand,
   SimListAliasesCommandOutput,
 } from "./alias/alias.command.js";

--- a/src/service/kms/key/sim-kms-key-store.ts
+++ b/src/service/kms/key/sim-kms-key-store.ts
@@ -117,6 +117,16 @@ export class SimKmsKeyStore {
   }
 
   /**
+   * Remove an alias, leaving the key it pointed at alone.
+   *
+   * An alias is a name for a key rather than part of it, so this is the one
+   * KMS removal that destroys nothing.
+   */
+  removeAlias(aliasName: string): void {
+    this.aliases.delete(aliasName);
+  }
+
+  /**
    * The aliases pointing at one key, or all of them.
    */
   aliasesFor(keyId: SimKmsKeyId | undefined): readonly SimKmsAlias[] {

--- a/src/service/kms/sdk/sim-kms-sdk-command-router.iso.test.ts
+++ b/src/service/kms/sdk/sim-kms-sdk-command-router.iso.test.ts
@@ -1,6 +1,7 @@
 import {
   CancelKeyDeletionCommand,
   CreateAliasCommand,
+  DeleteAliasCommand,
   CreateKeyCommand,
   DecryptCommand,
   DescribeKeyCommand,
@@ -49,6 +50,7 @@ describe("SimKmsSdkCommandRouter", () => {
       "ScheduleKeyDeletionCommand",
       "CancelKeyDeletionCommand",
       "CreateAliasCommand",
+      "DeleteAliasCommand",
       "ListAliasesCommand",
       "EncryptCommand",
       "DecryptCommand",
@@ -113,6 +115,9 @@ describe("SimKmsSdkCommandRouter", () => {
       }),
     );
 
+    await kms.send(new DeleteAliasCommand({ AliasName: "alias/router" }));
+    const aliasesAfterDelete = await kms.send(new ListAliasesCommand({}));
+
     await kms.send(new DisableKeyCommand({ KeyId: keyArn }));
     await kms.send(new EnableKeyCommand({ KeyId: keyArn }));
     await kms.send(new ScheduleKeyDeletionCommand({ KeyId: keyArn }));
@@ -127,6 +132,7 @@ describe("SimKmsSdkCommandRouter", () => {
     assertIdentical(described.KeyMetadata?.Description, "Router key");
     assertArrayLength(keys.Keys ?? [], 1);
     assertArrayLength(aliases.Aliases ?? [], 1);
+    assertArrayLength(aliasesAfterDelete.Aliases ?? [], 0);
     assertIdentical(cancelled.KeyId, keyArn);
 
     simSdk.restoreAll();

--- a/src/service/kms/sdk/sim-kms-sdk-command-router.ts
+++ b/src/service/kms/sdk/sim-kms-sdk-command-router.ts
@@ -5,6 +5,7 @@ import {
 } from "../../../sdk/index.js";
 import type {
   SimCreateAliasCommand,
+  SimDeleteAliasCommand,
   SimListAliasesCommand,
 } from "../command/alias/alias.command.js";
 import type {
@@ -110,6 +111,14 @@ export class SimKmsSdkCommandRouter implements SimSdkCommandRouter {
         async (command, context): Promise<unknown> =>
           await simKms.createAlias(
             command as SimCreateAliasCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "DeleteAliasCommand",
+        async (command, context): Promise<unknown> =>
+          await simKms.deleteAlias(
+            command as SimDeleteAliasCommand,
             simSdkCallerOptions(context),
           ),
       ],

--- a/src/service/kms/sim-kms-commands.ts
+++ b/src/service/kms/sim-kms-commands.ts
@@ -1,0 +1,89 @@
+import {
+  type BackgroundScheduler,
+  BackgroundTasks,
+} from "../../util/background/background.js";
+import type { SimAwsAccountRegionScope } from "../aws/sim-aws-account-region-scope.js";
+import { simAwsAccountRegionScopeFactory } from "../aws/sim-aws-account-region-scope.factory.js";
+import {
+  SimIamAllowAllAuth,
+  type SimIamInterServiceAuthZ,
+} from "../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { SimKmsAliasCommands } from "./command/alias/sim-kms-alias-commands.js";
+import { SimKmsAuthorizer } from "./command/authorize/sim-kms-authorizer.js";
+import { SimKmsCryptoCommands } from "./command/crypto/sim-kms-crypto-commands.js";
+import { SimKmsGenerateDataKey } from "./command/crypto/sim-kms-generate-data-key.js";
+import { SimKmsKeyCommands } from "./command/key/sim-kms-key-commands.js";
+import { SimKmsKeyLifecycleCommands } from "./command/key/sim-kms-key-lifecycle-commands.js";
+import { SimKmsKeyPolicyCommands } from "./command/key/sim-kms-key-policy-commands.js";
+import { SimKmsListKeys } from "./command/key/sim-kms-list-keys.js";
+import { SimKmsKeyFactory } from "./key/sim-kms-key-factory.js";
+import { SimKmsKeyMetadataView } from "./key/sim-kms-key-metadata.js";
+import { SimKmsKeyStore } from "./key/sim-kms-key-store.js";
+
+/**
+ * How one simulated KMS is put together.
+ */
+export interface SimKmsProperties {
+  readonly accountRegionScope?: SimAwsAccountRegionScope;
+  readonly iam?: SimIamInterServiceAuthZ;
+  readonly background?: BackgroundScheduler;
+}
+
+/**
+ * The command areas of one simulated KMS, and the state they share.
+ *
+ * Every command authorizes against the same IAM and works on the same key
+ * store, so the wiring lives here rather than being repeated once per command
+ * in the service facade. That keeps SimKms what it should be: state plus
+ * delegation.
+ */
+export class SimKmsCommands {
+  public readonly keys: SimKmsKeyStore;
+  public readonly key: SimKmsKeyCommands;
+  public readonly listKeys: SimKmsListKeys;
+  public readonly lifecycle: SimKmsKeyLifecycleCommands;
+  public readonly policies: SimKmsKeyPolicyCommands;
+  public readonly aliases: SimKmsAliasCommands;
+  public readonly crypto: SimKmsCryptoCommands;
+  public readonly generateDataKey: SimKmsGenerateDataKey;
+  public readonly background: BackgroundScheduler;
+
+  constructor(properties: SimKmsProperties = {}) {
+    const {
+      accountRegionScope = simAwsAccountRegionScopeFactory.make(),
+      iam = new SimIamAllowAllAuth(),
+      background = new BackgroundTasks(),
+    } = properties;
+
+    const keyFactory = new SimKmsKeyFactory({
+      accountRegionScope,
+      clock: background,
+    });
+    const authorizer = new SimKmsAuthorizer({ iam, accountRegionScope });
+
+    this.background = background;
+    this.keys = new SimKmsKeyStore({ accountRegionScope, keyFactory });
+    this.key = new SimKmsKeyCommands({
+      keys: this.keys,
+      keyFactory,
+      authorizer,
+      metadata: new SimKmsKeyMetadataView(accountRegionScope.accountId),
+    });
+    this.listKeys = new SimKmsListKeys({ keys: this.keys, authorizer });
+    this.lifecycle = new SimKmsKeyLifecycleCommands({
+      keys: this.keys,
+      authorizer,
+      clock: background,
+    });
+    this.policies = new SimKmsKeyPolicyCommands({
+      keys: this.keys,
+      authorizer,
+    });
+    this.aliases = new SimKmsAliasCommands({ keys: this.keys, authorizer });
+    this.crypto = new SimKmsCryptoCommands({ keys: this.keys, authorizer });
+    this.generateDataKey = new SimKmsGenerateDataKey({
+      keys: this.keys,
+      authorizer,
+    });
+  }
+}

--- a/src/service/kms/sim-kms.ts
+++ b/src/service/kms/sim-kms.ts
@@ -1,37 +1,11 @@
-import {
-  type BackgroundScheduler,
-  BackgroundTasks,
-} from "../../util/background/background.js";
-import type { SimAwsAccountRegionScope } from "../aws/sim-aws-account-region-scope.js";
-import { simAwsAccountRegionScopeFactory } from "../aws/sim-aws-account-region-scope.factory.js";
-import {
-  SimIamAllowAllAuth,
-  type SimIamInterServiceAuthZ,
-} from "../iam/authorize/sim-iam-inter-service-auth-z.js";
 import type { SimSdkCommandRouter } from "../../sdk/router/sim-sdk-command-router.type.js";
-import { SimKmsAliasCommands } from "./command/alias/sim-kms-alias-commands.js";
 import type * as simKmsCommands from "./command/sim-kms-command.types.js";
 import type { SimKmsRequestOptions } from "./command/sim-kms-request-options.js";
-import { SimKmsAuthorizer } from "./command/authorize/sim-kms-authorizer.js";
-import { SimKmsCryptoCommands } from "./command/crypto/sim-kms-crypto-commands.js";
-import { SimKmsGenerateDataKey } from "./command/crypto/sim-kms-generate-data-key.js";
-import { SimKmsKeyCommands } from "./command/key/sim-kms-key-commands.js";
-import { SimKmsListKeys } from "./command/key/sim-kms-list-keys.js";
-import { SimKmsKeyLifecycleCommands } from "./command/key/sim-kms-key-lifecycle-commands.js";
-import { SimKmsKeyPolicyCommands } from "./command/key/sim-kms-key-policy-commands.js";
 import { SimKmsCfnResourceFactory } from "./cfn/sim-cfn-kms-resource-factory.js";
 import type { SimKmsAlias } from "./key/sim-kms-alias.js";
 import type { SimKmsKey } from "./key/sim-kms-key.js";
-import { SimKmsKeyFactory } from "./key/sim-kms-key-factory.js";
-import { SimKmsKeyMetadataView } from "./key/sim-kms-key-metadata.js";
-import { SimKmsKeyStore } from "./key/sim-kms-key-store.js";
 import { SimKmsSdkCommandRouter } from "./sdk/sim-kms-sdk-command-router.js";
-
-interface SimKmsProperties {
-  readonly accountRegionScope?: SimAwsAccountRegionScope;
-  readonly iam?: SimIamInterServiceAuthZ;
-  readonly background?: BackgroundScheduler;
-}
+import { SimKmsCommands, type SimKmsProperties } from "./sim-kms-commands.js";
 
 /**
  * Simulated KMS. Handles SDK commands. Emulates AWS behaviour and state.
@@ -42,61 +16,12 @@ interface SimKmsProperties {
  * the wrong encryption context genuinely fails.
  */
 export class SimKms {
-  private readonly keys: SimKmsKeyStore;
-  private readonly keyCommands: SimKmsKeyCommands;
-  private readonly listKeysCommand: SimKmsListKeys;
-  private readonly lifecycleCommands: SimKmsKeyLifecycleCommands;
-  private readonly policyCommands: SimKmsKeyPolicyCommands;
-  private readonly aliasCommands: SimKmsAliasCommands;
-  private readonly cryptoCommands: SimKmsCryptoCommands;
-  private readonly generateDataKeyCommand: SimKmsGenerateDataKey;
-  private readonly background: BackgroundScheduler;
+  private readonly commands: SimKmsCommands;
   private readonly sdkRouter = new SimKmsSdkCommandRouter(this);
   private readonly cfnFactory = new SimKmsCfnResourceFactory({ kms: this });
 
   constructor(properties: SimKmsProperties = {}) {
-    const {
-      accountRegionScope = simAwsAccountRegionScopeFactory.make(),
-      iam = new SimIamAllowAllAuth(),
-      background = new BackgroundTasks(),
-    } = properties;
-
-    const keyFactory = new SimKmsKeyFactory({
-      accountRegionScope,
-      clock: background,
-    });
-    const authorizer = new SimKmsAuthorizer({ iam, accountRegionScope });
-
-    this.background = background;
-    this.keys = new SimKmsKeyStore({ accountRegionScope, keyFactory });
-    this.keyCommands = new SimKmsKeyCommands({
-      keys: this.keys,
-      keyFactory,
-      authorizer,
-      metadata: new SimKmsKeyMetadataView(accountRegionScope.accountId),
-    });
-    this.listKeysCommand = new SimKmsListKeys({ keys: this.keys, authorizer });
-    this.lifecycleCommands = new SimKmsKeyLifecycleCommands({
-      keys: this.keys,
-      authorizer,
-      clock: background,
-    });
-    this.policyCommands = new SimKmsKeyPolicyCommands({
-      keys: this.keys,
-      authorizer,
-    });
-    this.aliasCommands = new SimKmsAliasCommands({
-      keys: this.keys,
-      authorizer,
-    });
-    this.cryptoCommands = new SimKmsCryptoCommands({
-      keys: this.keys,
-      authorizer,
-    });
-    this.generateDataKeyCommand = new SimKmsGenerateDataKey({
-      keys: this.keys,
-      authorizer,
-    });
+    this.commands = new SimKmsCommands(properties);
   }
 
   /**
@@ -106,7 +31,7 @@ export class SimKms {
    * state without going through a Command and its authorization.
    */
   findKey(keyId: string): SimKmsKey | undefined {
-    return this.keys.find(keyId);
+    return this.commands.keys.find(keyId);
   }
 
   /**
@@ -116,7 +41,7 @@ export class SimKms {
    * for CloudFormation Resource creation to get at the alias it just made.
    */
   findAlias(aliasName: string): SimKmsAlias | undefined {
-    return this.keys.findAlias(aliasName);
+    return this.commands.keys.findAlias(aliasName);
   }
 
   /**
@@ -126,8 +51,8 @@ export class SimKms {
     command: simKmsCommands.SimCreateKeyCommand,
     options?: SimKmsRequestOptions,
   ): Promise<simKmsCommands.SimCreateKeyCommandOutput> {
-    await this.background.sequence();
-    return this.keyCommands.create(command, options);
+    await this.commands.background.sequence();
+    return this.commands.key.create(command, options);
   }
 
   /**
@@ -137,8 +62,8 @@ export class SimKms {
     command: simKmsCommands.SimDescribeKeyCommand,
     options?: SimKmsRequestOptions,
   ): Promise<simKmsCommands.SimDescribeKeyCommandOutput> {
-    await this.background.sequence();
-    return this.keyCommands.describe(command, options);
+    await this.commands.background.sequence();
+    return this.commands.key.describe(command, options);
   }
 
   /**
@@ -148,8 +73,8 @@ export class SimKms {
     command: simKmsCommands.SimListKeysCommand,
     options?: SimKmsRequestOptions,
   ): Promise<simKmsCommands.SimListKeysCommandOutput> {
-    await this.background.sequence();
-    return this.listKeysCommand.handle(command, options);
+    await this.commands.background.sequence();
+    return this.commands.listKeys.handle(command, options);
   }
 
   /**
@@ -159,8 +84,8 @@ export class SimKms {
     command: simKmsCommands.SimGetKeyPolicyCommand,
     options?: SimKmsRequestOptions,
   ): Promise<simKmsCommands.SimGetKeyPolicyCommandOutput> {
-    await this.background.sequence();
-    return this.policyCommands.get(command, options);
+    await this.commands.background.sequence();
+    return this.commands.policies.get(command, options);
   }
 
   /**
@@ -170,8 +95,8 @@ export class SimKms {
     command: simKmsCommands.SimPutKeyPolicyCommand,
     options?: SimKmsRequestOptions,
   ): Promise<simKmsCommands.SimPutKeyPolicyCommandOutput> {
-    await this.background.sequence();
-    return this.policyCommands.put(command, options);
+    await this.commands.background.sequence();
+    return this.commands.policies.put(command, options);
   }
 
   /**
@@ -181,8 +106,8 @@ export class SimKms {
     command: simKmsCommands.SimEnableKeyCommand,
     options?: SimKmsRequestOptions,
   ): Promise<simKmsCommands.SimEnableKeyCommandOutput> {
-    await this.background.sequence();
-    return this.lifecycleCommands.enable(command, options);
+    await this.commands.background.sequence();
+    return this.commands.lifecycle.enable(command, options);
   }
 
   /**
@@ -192,8 +117,8 @@ export class SimKms {
     command: simKmsCommands.SimDisableKeyCommand,
     options?: SimKmsRequestOptions,
   ): Promise<simKmsCommands.SimDisableKeyCommandOutput> {
-    await this.background.sequence();
-    return this.lifecycleCommands.disable(command, options);
+    await this.commands.background.sequence();
+    return this.commands.lifecycle.disable(command, options);
   }
 
   /**
@@ -203,8 +128,8 @@ export class SimKms {
     command: simKmsCommands.SimScheduleKeyDeletionCommand,
     options?: SimKmsRequestOptions,
   ): Promise<simKmsCommands.SimScheduleKeyDeletionCommandOutput> {
-    await this.background.sequence();
-    return this.lifecycleCommands.scheduleDeletion(command, options);
+    await this.commands.background.sequence();
+    return this.commands.lifecycle.scheduleDeletion(command, options);
   }
 
   /**
@@ -214,8 +139,8 @@ export class SimKms {
     command: simKmsCommands.SimCancelKeyDeletionCommand,
     options?: SimKmsRequestOptions,
   ): Promise<simKmsCommands.SimCancelKeyDeletionCommandOutput> {
-    await this.background.sequence();
-    return this.lifecycleCommands.cancelDeletion(command, options);
+    await this.commands.background.sequence();
+    return this.commands.lifecycle.cancelDeletion(command, options);
   }
 
   /**
@@ -225,8 +150,19 @@ export class SimKms {
     command: simKmsCommands.SimCreateAliasCommand,
     options?: SimKmsRequestOptions,
   ): Promise<simKmsCommands.SimCreateAliasCommandOutput> {
-    await this.background.sequence();
-    return this.aliasCommands.create(command, options);
+    await this.commands.background.sequence();
+    return this.commands.aliases.create(command, options);
+  }
+
+  /**
+   * Handle a DeleteAlias Command from the SDK.
+   */
+  async deleteAlias(
+    command: simKmsCommands.SimDeleteAliasCommand,
+    options?: SimKmsRequestOptions,
+  ): Promise<simKmsCommands.SimDeleteAliasCommandOutput> {
+    await this.commands.background.sequence();
+    return this.commands.aliases.delete(command, options);
   }
 
   /**
@@ -236,8 +172,8 @@ export class SimKms {
     command: simKmsCommands.SimListAliasesCommand,
     options?: SimKmsRequestOptions,
   ): Promise<simKmsCommands.SimListAliasesCommandOutput> {
-    await this.background.sequence();
-    return this.aliasCommands.list(command, options);
+    await this.commands.background.sequence();
+    return this.commands.aliases.list(command, options);
   }
 
   /**
@@ -247,8 +183,8 @@ export class SimKms {
     command: simKmsCommands.SimEncryptCommand,
     options?: SimKmsRequestOptions,
   ): Promise<simKmsCommands.SimEncryptCommandOutput> {
-    await this.background.sequence();
-    return this.cryptoCommands.encrypt(command, options);
+    await this.commands.background.sequence();
+    return this.commands.crypto.encrypt(command, options);
   }
 
   /**
@@ -258,8 +194,8 @@ export class SimKms {
     command: simKmsCommands.SimDecryptCommand,
     options?: SimKmsRequestOptions,
   ): Promise<simKmsCommands.SimDecryptCommandOutput> {
-    await this.background.sequence();
-    return this.cryptoCommands.decrypt(command, options);
+    await this.commands.background.sequence();
+    return this.commands.crypto.decrypt(command, options);
   }
 
   /**
@@ -269,8 +205,8 @@ export class SimKms {
     command: simKmsCommands.SimGenerateDataKeyCommand,
     options?: SimKmsRequestOptions,
   ): Promise<simKmsCommands.SimGenerateDataKeyCommandOutput> {
-    await this.background.sequence();
-    return this.generateDataKeyCommand.handle(command, options);
+    await this.commands.background.sequence();
+    return this.commands.generateDataKey.handle(command, options);
   }
 
   /**

--- a/src/service/route53/command/delete-hosted-zone/delete-hosted-zone-authorizer.ts
+++ b/src/service/route53/command/delete-hosted-zone/delete-hosted-zone-authorizer.ts
@@ -1,0 +1,46 @@
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+
+interface DeleteHostedZoneAuthorizerProperties {
+  readonly iam: SimIamInterServiceAuthZ;
+}
+
+/**
+ * Applies IAM authorization to a Route53 DeleteHostedZone request.
+ *
+ * DeleteHostedZone authorizes against the specific hosted zone ARN, so a
+ * policy can grant deleting one zone without granting deleting every zone in
+ * the Account.
+ *
+ * Authorization happens before the hosted zone store is read, so an
+ * unauthorized caller gets AccessDenied whether the zone exists or not.
+ */
+export class DeleteHostedZoneAuthorizer {
+  private static readonly action = "route53:DeleteHostedZone";
+
+  private readonly iam: SimIamInterServiceAuthZ;
+
+  constructor(properties: DeleteHostedZoneAuthorizerProperties) {
+    this.iam = properties.iam;
+  }
+
+  /**
+   * Ensure the caller may delete the hosted zone identified by the ARN.
+   */
+  authorize(hostedZoneArn: string, caller?: SimAwsCaller): void {
+    const decision = this.iam.authorize({
+      action: DeleteHostedZoneAuthorizer.action,
+      resource: hostedZoneArn,
+      caller,
+    });
+
+    if (decision.isDenied) {
+      throw new SimIamAccessDenied({
+        principal: decision.caller.principal,
+        action: DeleteHostedZoneAuthorizer.action,
+        resource: hostedZoneArn,
+      });
+    }
+  }
+}

--- a/src/service/route53/command/delete-hosted-zone/delete-hosted-zone.command.ts
+++ b/src/service/route53/command/delete-hosted-zone/delete-hosted-zone.command.ts
@@ -1,0 +1,28 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type { SimRoute53ChangeInfo } from "../create-hosted-zone/create-hosted-zone.command.js";
+
+/**
+ * Minimal structural sim Route53 DeleteHostedZone command.
+ */
+export interface SimDeleteHostedZoneCommand {
+  readonly input: SimDeleteHostedZoneCommandInput;
+}
+
+/**
+ * Minimal structural sim Route53 DeleteHostedZone input.
+ */
+export interface SimDeleteHostedZoneCommandInput {
+  readonly Id?: string | undefined;
+}
+
+/**
+ * Minimal structural sim Route53 DeleteHostedZone output.
+ *
+ * Real Route53 answers with the change it made, the same shape
+ * ChangeResourceRecordSets returns, because deleting a zone is a change that
+ * propagates.
+ */
+export interface SimDeleteHostedZoneCommandOutput {
+  readonly ChangeInfo: SimRoute53ChangeInfo;
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/route53/command/delete-hosted-zone/delete-hosted-zone.handler.ts
+++ b/src/service/route53/command/delete-hosted-zone/delete-hosted-zone.handler.ts
@@ -1,0 +1,113 @@
+import type { CommandHandler } from "../../../../command/command-handler.js";
+import {
+  type BackgroundScheduler,
+  BackgroundTasks,
+} from "../../../../util/background/background.js";
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import {
+  SimIamAllowAllAuth,
+  type SimIamInterServiceAuthZ,
+} from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { SimRoute53NoSuchHostedZone } from "../../error/sim-route53.error.js";
+import { simRoute53HostedZoneArn } from "../../hosted-zone/sim-route53-hosted-zone-arn.js";
+import type { SimRoute53HostedZone } from "../../hosted-zone/sim-route53-hosted-zone.js";
+import type { SimRoute53Registry } from "../../registry/sim-route53-registry.js";
+import {
+  normalizeSimRoute53HostedZoneId,
+  type SimRoute53HostedZoneId,
+} from "../create-hosted-zone/sim-route53-zone-id.js";
+import { DeleteHostedZoneAuthorizer } from "./delete-hosted-zone-authorizer.js";
+import type {
+  SimDeleteHostedZoneCommand,
+  SimDeleteHostedZoneCommandOutput,
+} from "./delete-hosted-zone.command.js";
+
+interface DeleteHostedZoneCommandHandlerProperties {
+  readonly hostedZones: Map<SimRoute53HostedZoneId, SimRoute53HostedZone>;
+  readonly route53Registry: SimRoute53Registry;
+  readonly iam?: SimIamInterServiceAuthZ;
+  readonly background?: BackgroundScheduler;
+}
+
+interface DeleteHostedZoneCommandHandlerOptions {
+  readonly caller?: SimAwsCaller;
+}
+
+/**
+ * Route53 DeleteHostedZoneCommand handler.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/route-53/command/DeleteHostedZoneCommand/
+ */
+export class DeleteHostedZoneCommandHandler implements CommandHandler<
+  SimDeleteHostedZoneCommand,
+  SimDeleteHostedZoneCommandOutput
+> {
+  private readonly hostedZones: Map<
+    SimRoute53HostedZoneId,
+    SimRoute53HostedZone
+  >;
+  private readonly route53Registry: SimRoute53Registry;
+  private readonly authorizer: DeleteHostedZoneAuthorizer;
+  private readonly background: BackgroundScheduler;
+
+  constructor(properties: DeleteHostedZoneCommandHandlerProperties) {
+    const {
+      hostedZones,
+      route53Registry,
+      iam = new SimIamAllowAllAuth(),
+      background = new BackgroundTasks(),
+    } = properties;
+
+    this.hostedZones = hostedZones;
+    this.route53Registry = route53Registry;
+    this.authorizer = new DeleteHostedZoneAuthorizer({ iam });
+    this.background = background;
+  }
+
+  /**
+   * Handle deleting a Route53 Hosted Zone.
+   *
+   * Real Route53 only deletes an empty zone, and answers HostedZoneNotEmpty
+   * while any record other than the zone's own NS and SOA is left in it. A
+   * simulated zone is created without those two, so any record at all counts
+   * here, and the caller removes them with ChangeResourceRecordSets first.
+   *
+   * Deregistering the zone is what stops its names resolving, because DNS
+   * resolution reads the cross-Account registry rather than this Account's
+   * own hosted zone map.
+   */
+  async handle(
+    command: SimDeleteHostedZoneCommand,
+    options?: DeleteHostedZoneCommandHandlerOptions,
+  ): Promise<SimDeleteHostedZoneCommandOutput> {
+    const hostedZoneId = normalizeSimRoute53HostedZoneId(command.input.Id);
+    const hostedZoneArn = simRoute53HostedZoneArn(hostedZoneId);
+
+    // Allow for potential non-deterministic sequencing of async events.
+    await this.background.sequence();
+
+    this.authorizer.authorize(hostedZoneArn, options?.caller);
+
+    const hostedZone = this.hostedZones.get(hostedZoneId);
+
+    if (hostedZone === undefined) {
+      throw new SimRoute53NoSuchHostedZone(
+        `No sim Route53 Hosted Zone with ID ${hostedZoneId}`,
+      );
+    }
+
+    hostedZone.assertDeletable();
+
+    this.hostedZones.delete(hostedZoneId);
+    this.route53Registry.deregisterHostedZone(hostedZoneId);
+
+    return {
+      ChangeInfo: {
+        Id: `/change/${hostedZoneId}`,
+        Status: "INSYNC",
+        SubmittedAt: this.background.now(),
+      },
+      $metadata: {},
+    };
+  }
+}

--- a/src/service/route53/command/delete-hosted-zone/delete-hosted-zone.iso.test.ts
+++ b/src/service/route53/command/delete-hosted-zone/delete-hosted-zone.iso.test.ts
@@ -1,0 +1,175 @@
+import {
+  ChangeResourceRecordSetsCommand,
+  CreateHostedZoneCommand,
+  DeleteHostedZoneCommand,
+  GetHostedZoneCommand,
+} from "@aws-sdk/client-route-53";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+import {
+  SimRoute53HostedZoneNotEmpty,
+  SimRoute53NoSuchHostedZone,
+} from "../../error/sim-route53.error.js";
+import type { SimRoute53 } from "../../sim-route53.js";
+
+interface Zone {
+  readonly simAws: SimAws;
+  readonly simRoute53: SimRoute53;
+  readonly zoneId: string;
+}
+
+async function givenHostedZone(name: string): Promise<Zone> {
+  const simAws = new SimAws();
+  const simRoute53 = simAws.route53();
+  const created = await simRoute53.createHostedZone(
+    new CreateHostedZoneCommand({ Name: name, CallerReference: name }),
+  );
+  await simAws.backgroundTasksComplete();
+  assertNonNullable(created.HostedZone?.Id);
+
+  return { simAws, simRoute53, zoneId: created.HostedZone.Id };
+}
+
+async function changeRecord(
+  zone: Zone,
+  action: "CREATE" | "DELETE",
+  recordName: string,
+): Promise<void> {
+  await zone.simRoute53.changeResourceRecordSets(
+    new ChangeResourceRecordSetsCommand({
+      HostedZoneId: zone.zoneId,
+      ChangeBatch: {
+        Changes: [
+          {
+            Action: action,
+            ResourceRecordSet: {
+              Name: recordName,
+              Type: "A",
+              TTL: 60,
+              ResourceRecords: [{ Value: "127.0.0.1" }],
+            },
+          },
+        ],
+      },
+    }),
+  );
+  await zone.simAws.backgroundTasksComplete();
+}
+
+describe("Route53 DeleteHostedZoneCommand", () => {
+  it("deletes an empty Hosted Zone", async () => {
+    // Given a Hosted Zone with no records in it.
+    const zone = await givenHostedZone("disposable.test");
+
+    // When the Hosted Zone is deleted.
+    const output = await zone.simRoute53.deleteHostedZone(
+      new DeleteHostedZoneCommand({ Id: zone.zoneId }),
+    );
+
+    // Then Route53 reports the change, and the zone is gone.
+    assertIdentical(output.ChangeInfo.Status, "INSYNC");
+
+    const error = await assertThrowsErrorAsync(async () =>
+      zone.simRoute53.getHostedZone(
+        new GetHostedZoneCommand({ Id: zone.zoneId }),
+      ),
+    );
+    assertInstanceOf(error, SimRoute53NoSuchHostedZone);
+  });
+
+  it("refuses a Hosted Zone that still holds records", async () => {
+    // Given a Hosted Zone with a record in it.
+    const zone = await givenHostedZone("occupied.test");
+    await changeRecord(zone, "CREATE", "www.occupied.test");
+
+    // When the Hosted Zone is deleted.
+    const error = await assertThrowsErrorAsync(async () =>
+      zone.simRoute53.deleteHostedZone(
+        new DeleteHostedZoneCommand({ Id: zone.zoneId }),
+      ),
+    );
+
+    // Then Route53 refuses, leaving the caller to remove the records first.
+    assertInstanceOf(error, SimRoute53HostedZoneNotEmpty);
+    assertIdentical(error.$metadata.httpStatusCode, 400);
+  });
+
+  it("deletes a Hosted Zone once its records have been removed", async () => {
+    // Given a Hosted Zone whose only record has been deleted again.
+    const zone = await givenHostedZone("emptied.test");
+    await changeRecord(zone, "CREATE", "www.emptied.test");
+    await changeRecord(zone, "DELETE", "www.emptied.test");
+
+    // When the Hosted Zone is deleted.
+    await zone.simRoute53.deleteHostedZone(
+      new DeleteHostedZoneCommand({ Id: zone.zoneId }),
+    );
+
+    // Then it goes, because there is nothing left in it.
+    const error = await assertThrowsErrorAsync(async () =>
+      zone.simRoute53.getHostedZone(
+        new GetHostedZoneCommand({ Id: zone.zoneId }),
+      ),
+    );
+    assertInstanceOf(error, SimRoute53NoSuchHostedZone);
+  });
+
+  it("stops the Hosted Zone taking part in name resolution", async () => {
+    // Given a Hosted Zone registered for resolution.
+    const zone = await givenHostedZone("resolved.test");
+    assertIdentical(zone.simRoute53.resolvableHostedZones().size, 1);
+
+    // When the Hosted Zone is deleted.
+    await zone.simRoute53.deleteHostedZone(
+      new DeleteHostedZoneCommand({ Id: zone.zoneId }),
+    );
+
+    // Then it is out of the registry DNS resolution reads.
+    assertIdentical(zone.simRoute53.resolvableHostedZones().size, 0);
+  });
+
+  it("rejects a Hosted Zone that does not exist", async () => {
+    // Given a simulated Route53 without the requested Hosted Zone.
+    const simRoute53 = new SimAws().route53();
+
+    // When the missing Hosted Zone is deleted.
+    const error = await assertThrowsErrorAsync(async () =>
+      simRoute53.deleteHostedZone(
+        new DeleteHostedZoneCommand({ Id: "Z0000000000000000000A" }),
+      ),
+    );
+
+    // Then Route53 answers with its missing-zone error.
+    assertInstanceOf(error, SimRoute53NoSuchHostedZone);
+  });
+
+  it("denies a caller without DeleteHostedZone permission", async () => {
+    // Given a Hosted Zone in a simulation with IAM.
+    const zone = await givenHostedZone("protected.test");
+
+    // When an anonymous caller deletes it.
+    const error = await assertThrowsErrorAsync(async () =>
+      zone.simRoute53.deleteHostedZone(
+        new DeleteHostedZoneCommand({ Id: zone.zoneId }),
+        { caller: { kind: "anonymous" } },
+      ),
+    );
+
+    // Then IAM denies the removal action, and the zone stays.
+    assertInstanceOf(error, SimIamAccessDenied);
+    assertIdentical(error.action, "route53:DeleteHostedZone");
+
+    const stillThere = await zone.simRoute53.getHostedZone(
+      new GetHostedZoneCommand({ Id: zone.zoneId }),
+    );
+    assertNonNullable(stillThere.HostedZone);
+    assertIdentical(stillThere.HostedZone.Name, "protected.test.");
+  });
+});

--- a/src/service/route53/error/sim-route53.error.ts
+++ b/src/service/route53/error/sim-route53.error.ts
@@ -29,6 +29,22 @@ export class SimRoute53NoSuchHostedZone extends SimRoute53Error {
 }
 
 /**
+ * Simulated Route53 HostedZoneNotEmpty error.
+ *
+ * Real Route53 refuses to delete a Hosted Zone that still holds records,
+ * counting everything except the NS and SOA records it created with the zone.
+ * Simulated zones are created without those two, so here every remaining
+ * record counts.
+ */
+export class SimRoute53HostedZoneNotEmpty extends SimRoute53Error {
+  public override readonly name = "HostedZoneNotEmpty";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
  * Simulated Route53 InvalidInput error.
  */
 export class SimRoute53InvalidInput extends SimRoute53Error {

--- a/src/service/route53/hosted-zone/sim-route53-hosted-zone.ts
+++ b/src/service/route53/hosted-zone/sim-route53-hosted-zone.ts
@@ -6,6 +6,7 @@ import {
   type SimRoute53HostedZoneId,
 } from "../command/create-hosted-zone/sim-route53-zone-id.js";
 import type { BackgroundScheduler } from "../../../util/background/background.js";
+import { SimRoute53HostedZoneNotEmpty } from "../error/sim-route53.error.js";
 
 export type SimRoute53HostedZoneStatus = "PENDING" | "INSYNC";
 
@@ -126,6 +127,22 @@ export class SimRoute53HostedZone {
   async waitForSynchronizationComplete(): Promise<void> {
     if (this.synchronizationComplete !== undefined) {
       await this.synchronizationComplete;
+    }
+  }
+
+  /**
+   * Refuse deletion while this Hosted Zone still holds records.
+   *
+   * Real Route53 counts everything except the NS and SOA records it creates
+   * with the zone. A simulated zone is created without those two, so every
+   * record left here counts.
+   */
+  assertDeletable(): void {
+    if (this.records.count > 0) {
+      throw new SimRoute53HostedZoneNotEmpty(
+        `Sim Route53 Hosted Zone ${this.id} still holds ` +
+          `${String(this.records.count)} records`,
+      );
     }
   }
 

--- a/src/service/route53/registry/sim-route53-registry.ts
+++ b/src/service/route53/registry/sim-route53-registry.ts
@@ -33,6 +33,18 @@ export class SimRoute53Registry {
   }
 
   /**
+   * Stop resolving a Hosted Zone, because it has been deleted.
+   *
+   * Anything watching for record changes stays subscribed: zones come and go
+   * while other simulated services are already watching, which is why the
+   * listeners are held here rather than on one zone.
+   */
+  deregisterHostedZone(hostedZoneId: SimRoute53HostedZoneId): void {
+    this.hostedZonesById.delete(hostedZoneId);
+    this.notifyRecordChange();
+  }
+
+  /**
    * Register a listener called whenever a record changes in any registered
    * Hosted Zone.
    *

--- a/src/service/route53/sdk/sim-route53-sdk-command-router.iso.test.ts
+++ b/src/service/route53/sdk/sim-route53-sdk-command-router.iso.test.ts
@@ -3,12 +3,14 @@ import {
   ChangeResourceRecordSetsCommand,
   CreateHostedZoneCommand,
   DeleteHostedZoneCommand,
+  GetChangeCommand,
   GetHostedZoneCommand,
   ListHostedZonesByNameCommand,
   ListResourceRecordSetsCommand,
   Route53Client,
 } from "@aws-sdk/client-route-53";
 import {
+  assertArrayLength,
   assertIdentical,
   assertNonNullable,
   assertStringIncludes,
@@ -41,6 +43,12 @@ describe("simulated Route53 SDK Command routing", () => {
       new ListHostedZonesByNameCommand({ DNSName: "example.com" }),
     );
     assertIdentical(listOutput.HostedZones?.[0]?.Id, hostedZoneId);
+
+    await client.send(new DeleteHostedZoneCommand({ Id: hostedZoneId }));
+    const listAfterDelete = await client.send(
+      new ListHostedZonesByNameCommand({ DNSName: "example.com" }),
+    );
+    assertArrayLength(listAfterDelete.HostedZones ?? [], 0);
   });
 
   it("routes ChangeResourceRecordSetsCommand through an intercepted client", async () => {
@@ -137,10 +145,10 @@ describe("simulated Route53 SDK Command routing", () => {
     simSdk.intercept(client);
 
     const error = await assertThrowsErrorAsync(async () => {
-      await client.send(new DeleteHostedZoneCommand({ Id: "Z123" }));
+      await client.send(new GetChangeCommand({ Id: "C123" }));
     });
 
-    assertStringIncludes(error.message, "DeleteHostedZoneCommand");
+    assertStringIncludes(error.message, "GetChangeCommand");
     assertStringIncludes(error.message, "CreateHostedZoneCommand");
   });
 });

--- a/src/service/route53/sdk/sim-route53-sdk-command-router.ts
+++ b/src/service/route53/sdk/sim-route53-sdk-command-router.ts
@@ -5,6 +5,7 @@ import {
 } from "../../../sdk/index.js";
 import type { SimChangeResourceRecordSetsCommand } from "../command/change-resource-record-sets/change-resource-record-sets.command.js";
 import type { SimCreateHostedZoneCommand } from "../command/create-hosted-zone/create-hosted-zone.command.js";
+import type { SimDeleteHostedZoneCommand } from "../command/delete-hosted-zone/delete-hosted-zone.command.js";
 import type { SimGetHostedZoneCommand } from "../command/get-hosted-zone/get-hosted-zone.command.js";
 import type { SimListHostedZonesByNameCommand } from "../command/list-hosted-zones-by-name/list-hosted-zones-by-name.command.js";
 import type { SimListResourceRecordSetsCommand } from "../command/list-resource-record-sets/list-resource-record-sets.command.js";
@@ -39,6 +40,14 @@ export class SimRoute53SdkCommandRouter implements SimSdkCommandRouter {
         async (command, context): Promise<unknown> =>
           await simRoute53.getHostedZone(
             command as SimGetHostedZoneCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "DeleteHostedZoneCommand",
+        async (command, context): Promise<unknown> =>
+          await simRoute53.deleteHostedZone(
+            command as SimDeleteHostedZoneCommand,
             simSdkCallerOptions(context),
           ),
       ],

--- a/src/service/route53/sim-route53.ts
+++ b/src/service/route53/sim-route53.ts
@@ -13,6 +13,11 @@ import type {
 } from "./command/get-hosted-zone/get-hosted-zone.command.js";
 import { GetHostedZoneCommandHandler } from "./command/get-hosted-zone/get-hosted-zone.handler.js";
 import type {
+  SimDeleteHostedZoneCommand,
+  SimDeleteHostedZoneCommandOutput,
+} from "./command/delete-hosted-zone/delete-hosted-zone.command.js";
+import { DeleteHostedZoneCommandHandler } from "./command/delete-hosted-zone/delete-hosted-zone.handler.js";
+import type {
   SimListHostedZonesByNameCommand,
   SimListHostedZonesByNameCommandOutput,
 } from "./command/list-hosted-zones-by-name/list-hosted-zones-by-name.command.js";
@@ -110,6 +115,22 @@ export class SimRoute53 {
   ): Promise<SimGetHostedZoneCommandOutput> {
     const handler = new GetHostedZoneCommandHandler({
       hostedZones: this.hostedZones,
+      iam: this.iam,
+      background: this.background,
+    });
+    return await handler.handle(command, options);
+  }
+
+  /**
+   * Handle a Delete Hosted Zone command from the SDK.
+   */
+  async deleteHostedZone(
+    command: SimDeleteHostedZoneCommand,
+    options?: SimRoute53RequestOptions,
+  ): Promise<SimDeleteHostedZoneCommandOutput> {
+    const handler = new DeleteHostedZoneCommandHandler({
+      hostedZones: this.hostedZones,
+      route53Registry: this.route53Registry,
       iam: this.iam,
       background: this.background,
     });


### PR DESCRIPTION
Continues the delete operations from #402, covering the three services whose deletions are a single small command each.

## What is here

| Command | Behaviour |
| --- | --- |
| `KMS DeleteAlias` | Removes the alias and leaves the key it pointed at alone, refusing an `alias/aws/` name reserved for an AWS managed key |
| `Route53 DeleteHostedZone` | Refuses a zone that still holds records with `HostedZoneNotEmpty`, and deregisters it so its names stop resolving |
| `ACM DeleteCertificate` | Removes the certificate, answering `ResourceNotFoundException` for one that is not there |

Each is authorized as its own IAM action, routed for SDK client interception, and covered by isolated tests including the routing path.

## Two things worth knowing

**KMS key deletion already existed.** #403 asked for `ScheduleKeyDeletion` and `CancelKeyDeletion`, but both are already implemented, and `SimKmsKeyLifecycle` already models `PendingDeletion` with its recovery window and refuses cryptographic operations on a key on its way out. The earlier inventory missed them because they do not start with "delete". Only `DeleteAlias` was actually missing, so that is all this adds.

**ACM cannot tell whether a certificate is in use.** Real ACM refuses with `ResourceInUseException` while something holds the certificate, and reports what through `InUseBy`. Nothing tells simulated ACM when a CloudFront distribution or a load balancer takes a certificate up, so `InUseBy` is always empty and every certificate here is deletable. That is a divergence in the looser direction, so it is stated in the handler rather than left to be discovered. Closing that gap means tracking certificate use across services, which is its own piece of work.

The `HostedZoneNotEmpty` rule is a closer match than it looks. Real Route53 counts everything except the NS and SOA records it creates with a zone, and simulated zones are created without those two, so every remaining record counts here.

## Refactor

KMS gained the `SimKmsCommands` parts class that S3, Lambda and IAM already have, because `SimKms` went over the 300 line limit. The facade is now state plus delegation, and the wiring lives with the commands.

Resolves https://github.com/KensioSoftware/yulin/issues/403
