### PR TITLE
feat: delete and update Distributions, delete CFFs

### DIFF
--- a/docs/services/cloudfront/README.md
+++ b/docs/services/cloudfront/README.md
@@ -496,6 +496,107 @@ CDK app works without changes.
 A Distribution using `CloudFrontDefaultCertificate` needs no ACM certificate and is not checked. A
 standalone `new SimCloudFront()` has no sim ACM to check against, so it does not check either.
 
+## Disabling and deleting a Distribution
+
+`DeleteDistributionCommand` removes a Distribution. CloudFront will not delete one that is still
+serving, so the sequence is `UpdateDistributionCommand` with `Enabled: false` first, then the
+deletion. Deleting an enabled Distribution answers `DistributionNotDisabled`, as it does in AWS.
+
+`UpdateDistributionCommand` takes a whole `DistributionConfig` rather than a patch, so the update is
+applied as a replacement. Anything left out of the new config is dropped, including alternate domain
+names and the default root object. Read the Distribution first, change the field you want, and send
+the config back.
+
+Once the Distribution is deleted, a request to its CloudFront domain or any of its alternate domain
+names no longer resolves to it, and those alternate domain names are free for another Distribution.
+
+```typescript sim-cloudfront-delete-distribution
+/**
+ * Disabling a simulated CloudFront Distribution and then deleting it.
+ */
+
+import {
+  CreateDistributionCommand,
+  DeleteDistributionCommand,
+  type DistributionConfig,
+  GetDistributionCommand,
+  UpdateDistributionCommand,
+} from "@aws-sdk/client-cloudfront";
+import { CreateBucketCommand } from "@aws-sdk/client-s3";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const simCloudFront = simAws.cloudFront();
+
+await simAws
+  .s3()
+  .createBucket(new CreateBucketCommand({ Bucket: "site-bucket" }));
+
+const distributionConfig: DistributionConfig = {
+  CallerReference: "site-distribution",
+  Comment: "Site distribution",
+  Enabled: true,
+  Origins: {
+    Quantity: 1,
+    Items: [
+      {
+        Id: "site-origin",
+        DomainName: "site-bucket.s3.amazonaws.com",
+        S3OriginConfig: { OriginAccessIdentity: "" },
+      },
+    ],
+  },
+  DefaultCacheBehavior: {
+    TargetOriginId: "site-origin",
+    ViewerProtocolPolicy: "allow-all",
+  },
+};
+
+const created = await simCloudFront.createDistribution(
+  new CreateDistributionCommand({ DistributionConfig: distributionConfig }),
+);
+await simAws.backgroundTasksComplete();
+
+const distributionId = created.Distribution?.Id;
+
+try {
+  await simCloudFront.deleteDistribution(
+    new DeleteDistributionCommand({ Id: distributionId }),
+  );
+} catch (error) {
+  // DistributionNotDisabled: Sim CloudFront Distribution ... is enabled, so it
+  // cannot be deleted. Disable it with UpdateDistribution first.
+  console.log((error as Error).message);
+}
+
+// Disable the Distribution, then delete it.
+await simCloudFront.updateDistribution(
+  new UpdateDistributionCommand({
+    Id: distributionId,
+    DistributionConfig: { ...distributionConfig, Enabled: false },
+  }),
+);
+await simAws.backgroundTasksComplete();
+
+await simCloudFront.deleteDistribution(
+  new DeleteDistributionCommand({ Id: distributionId }),
+);
+
+try {
+  await simCloudFront.getDistribution(
+    new GetDistributionCommand({ Id: distributionId }),
+  );
+} catch (error) {
+  // NoSuchDistribution: No sim CloudFront Distribution with ID ...
+  console.log((error as Error).message);
+}
+```
+
+`DeleteFunctionCommand` removes a CloudFront Function by name, and answers `NoSuchFunctionExists`
+when the name matches nothing. A cache Behavior still pointing at a deleted Function finds nothing
+and runs no Function code.
+
 ## Simulated CloudFront Functions
 
 The sim CloudFront supports `viewer-request` and `viewer-response` CloudFront Functions.
@@ -682,7 +783,9 @@ export function handler(event) {
 
 Sim CloudFront currently supports:
 
-- `CreateDistributionCommand` and `GetDistributionCommand`
+- `CreateDistributionCommand`, `GetDistributionCommand`, `UpdateDistributionCommand` and
+  `DeleteDistributionCommand`
+- `CreateFunctionCommand` and `DeleteFunctionCommand`
 - S3 Origins backed by sim S3 Buckets
 - Custom Origins reaching sim HTTP APIs and sim Lambda Function URLs in process
 - CloudFront Distribution hostnames such as `distro123.cloudfront.net`
@@ -695,3 +798,19 @@ Sim CloudFront currently supports:
 The simulator focuses on useful behaviour for tests and local development rather than full CloudFront
 feature parity. Unsupported CloudFront options may be ignored or may throw errors depending on
 whether the simulator needs them to model the requested behaviour safely.
+
+## Limitations
+
+Where sim CloudFront knowingly behaves differently from AWS:
+
+- **`IfMatch` ETags are not checked.** `UpdateDistributionCommand`, `DeleteDistributionCommand` and
+  `DeleteFunctionCommand` all accept `IfMatch` and ignore it, so neither `PreconditionFailed` nor
+  `InvalidIfMatchVersion` is ever returned. Nothing else here versions a resource, and a stale ETag
+  is a retry rather than a design mistake. A test expecting the ETag refusal will not get it.
+- **A deletion does not wait for the disable to deploy.** Real CloudFront needs the disabled
+  Distribution to reach `Deployed` before it accepts the deletion. Here, `Enabled: false` is enough.
+- **A disabled Distribution still serves requests.** Real CloudFront answers a disabled Distribution
+  with a 403. Only deleting a Distribution stops it serving here.
+- **`DeleteFunctionCommand` never answers `FunctionInUse`.** Nothing tells a CloudFront Function that
+  a cache Behavior has taken it up, so every Function is deletable. A Behavior left pointing at a
+  deleted Function runs no Function code.

--- a/docs/services/cloudfront/sim-cloudfront-delete-distribution.example.ts
+++ b/docs/services/cloudfront/sim-cloudfront-delete-distribution.example.ts
@@ -1,0 +1,80 @@
+/**
+ * Disabling a simulated CloudFront Distribution and then deleting it.
+ */
+
+import {
+  CreateDistributionCommand,
+  DeleteDistributionCommand,
+  type DistributionConfig,
+  GetDistributionCommand,
+  UpdateDistributionCommand,
+} from "@aws-sdk/client-cloudfront";
+import { CreateBucketCommand } from "@aws-sdk/client-s3";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const simCloudFront = simAws.cloudFront();
+
+await simAws
+  .s3()
+  .createBucket(new CreateBucketCommand({ Bucket: "site-bucket" }));
+
+const distributionConfig: DistributionConfig = {
+  CallerReference: "site-distribution",
+  Comment: "Site distribution",
+  Enabled: true,
+  Origins: {
+    Quantity: 1,
+    Items: [
+      {
+        Id: "site-origin",
+        DomainName: "site-bucket.s3.amazonaws.com",
+        S3OriginConfig: { OriginAccessIdentity: "" },
+      },
+    ],
+  },
+  DefaultCacheBehavior: {
+    TargetOriginId: "site-origin",
+    ViewerProtocolPolicy: "allow-all",
+  },
+};
+
+const created = await simCloudFront.createDistribution(
+  new CreateDistributionCommand({ DistributionConfig: distributionConfig }),
+);
+await simAws.backgroundTasksComplete();
+
+const distributionId = created.Distribution?.Id;
+
+try {
+  await simCloudFront.deleteDistribution(
+    new DeleteDistributionCommand({ Id: distributionId }),
+  );
+} catch (error) {
+  // DistributionNotDisabled: Sim CloudFront Distribution ... is enabled, so it
+  // cannot be deleted. Disable it with UpdateDistribution first.
+  console.log((error as Error).message);
+}
+
+// Disable the Distribution, then delete it.
+await simCloudFront.updateDistribution(
+  new UpdateDistributionCommand({
+    Id: distributionId,
+    DistributionConfig: { ...distributionConfig, Enabled: false },
+  }),
+);
+await simAws.backgroundTasksComplete();
+
+await simCloudFront.deleteDistribution(
+  new DeleteDistributionCommand({ Id: distributionId }),
+);
+
+try {
+  await simCloudFront.getDistribution(
+    new GetDistributionCommand({ Id: distributionId }),
+  );
+} catch (error) {
+  // NoSuchDistribution: No sim CloudFront Distribution with ID ...
+  console.log((error as Error).message);
+}

--- a/src/service/cloudfront/README.md
+++ b/src/service/cloudfront/README.md
@@ -33,12 +33,17 @@ those shapes fit the real AWS SDK types.
 
 Current command areas include:
 
-- `create-Distribution/`
-- `get-Distribution/`
+- `create-distribution/`
+- `get-distribution/`
+- `update-distribution/`
+- `delete-distribution/`
 - `create-function/`
+- `delete-function/`
 
-The main `SimCloudFront` class delegates command execution to these handlers rather than keeping
-command logic inline.
+The main `SimCloudFront` class owns the Distribution and Function maps and nothing else.
+`SimCloudFrontCommands` holds the collaborators every command shares (IAM, the registry, the Origin
+resolvers, the background scheduler) and builds the handlers, so the facade stays state plus
+delegation.
 
 ## Distribution model
 
@@ -54,9 +59,25 @@ time, including:
 - CloudFront Function associations
 - the default root object
 - custom error responses
+- whether the Distribution is enabled
 
 The `Distribution/configurator/` classes translate AWS-style `DistributionConfig` input into the
 internal Distribution model.
+
+### Updating and deleting
+
+CloudFront takes a whole `DistributionConfig` on an update rather than a patch, so
+`UpdateDistribution` applies it as a replacement: `replaceConfiguration` on the Distribution drops
+everything derived from the previous config, and the same configurators then apply the new one from
+scratch. The alternate domain names are resynchronized in the registry around that, so a name the
+update drops is free for another Distribution.
+
+`assertDeletable` on the Distribution holds the rule that CloudFront will not delete a Distribution
+that is still serving. Deleting also deregisters the Distribution from `SimCloudFrontRegistry`,
+which is what actually stops it serving: request routing reads the registry rather than one
+Account's own Distribution map.
+
+The `IfMatch` ETag is accepted and not checked. See the Limitations section of the usage docs.
 
 ### Default root object and custom error responses
 

--- a/src/service/cloudfront/command/create-distribution/create-distribution.command.ts
+++ b/src/service/cloudfront/command/create-distribution/create-distribution.command.ts
@@ -1,4 +1,5 @@
 import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type { SimCloudFrontDistributionView } from "../../distribution/sim-cf-distribution-view.js";
 
 /**
  * Minimal structural sim CloudFront CreateDistribution command.
@@ -18,18 +19,7 @@ export interface SimCreateDistributionCommandInput {
  * Minimal structural sim CloudFront CreateDistribution output.
  */
 export interface SimCreateDistributionCommandOutput {
-  readonly Distribution?:
-    | undefined
-    | {
-        readonly Id?: string | undefined;
-        readonly ARN?: string | undefined;
-        readonly Status?: string | undefined;
-        readonly LastModifiedTime?: Date | undefined;
-        readonly InProgressInvalidationBatches?: number | undefined;
-        readonly DomainName?: string | undefined;
-        readonly DistributionConfig?:
-          SimCloudFrontDistributionConfig | undefined;
-      };
+  readonly Distribution?: SimCloudFrontDistributionView | undefined;
   readonly Location?: string | undefined;
   readonly $metadata: SimResponseMetadata;
 }

--- a/src/service/cloudfront/command/create-distribution/create-distribution.handler.ts
+++ b/src/service/cloudfront/command/create-distribution/create-distribution.handler.ts
@@ -13,10 +13,10 @@ import { assertDefined } from "../../../../util/type-guard/defined.js";
 import type { SimCloudFrontS3OriginResolver } from "../../origin/s3/sim-cloudfront-s3-origin.js";
 import type { SimCfCustomOriginDispatcher } from "../../origin/custom/sim-cf-custom-origin-dispatcher.js";
 import type { BackgroundScheduler } from "../../../../util/background/background.js";
-import { SimCloudFrontOriginConfigurator } from "../../distribution/configurator/sim-cloud-front-origin-configurator.js";
-import { SimCloudFrontBehaviorConfigurator } from "../../distribution/configurator/sim-cloud-front-behavior-configurator.js";
-import { SimCloudFrontDistributionConfigurator } from "../../distribution/configurator/sim-cloud-front-distribution-configurator.js";
+import { makeSimCloudFrontDistributionConfigurator } from "../../distribution/configurator/sim-cf-distribution-configurator.factory.js";
+import type { SimCloudFrontDistributionConfigurator } from "../../distribution/configurator/sim-cloud-front-distribution-configurator.js";
 import { SimCloudFrontDistributionConfigNormalizer } from "./sim-cf-distro-config-normalizer.js";
+import { simCloudFrontDistributionView } from "../../distribution/sim-cf-distribution-view.js";
 import {
   SimIamAllowAllAuth,
   type SimIamInterServiceAuthZ,
@@ -68,13 +68,8 @@ export class CreateDistributionCommandHandler implements CommandHandler<
     this.accountId = properties.accountId;
     this.distributions = properties.distributions;
     this.cloudFrontRegistry = properties.cloudFrontRegistry;
-    this.distributionConfigurator = new SimCloudFrontDistributionConfigurator(
-      new SimCloudFrontOriginConfigurator(
-        properties.s3OriginResolver,
-        properties.customOriginDispatcher,
-      ),
-      new SimCloudFrontBehaviorConfigurator(),
-    );
+    this.distributionConfigurator =
+      makeSimCloudFrontDistributionConfigurator(properties);
     this.authorizer = new CreateDistributionAuthorizer({
       iam: properties.iam ?? new SimIamAllowAllAuth(),
     });
@@ -140,15 +135,7 @@ export class CreateDistributionCommandHandler implements CommandHandler<
     this.background.schedule(() => distribution.completeDeployment());
 
     return {
-      Distribution: {
-        Id: distribution.distributionId,
-        ARN: `arn:aws:cloudfront::${this.accountId}:distribution/${distribution.distributionId}`,
-        Status: distribution.status,
-        LastModifiedTime: distribution.lastModifiedTime,
-        InProgressInvalidationBatches: 0,
-        DomainName: `${distribution.distributionId.toLowerCase()}.cloudfront.net`,
-        DistributionConfig: distribution.distributionConfig,
-      },
+      Distribution: simCloudFrontDistributionView(distribution),
       Location: `https://cloudfront.amazonaws.com/2020-05-31/distribution/${distribution.distributionId}`,
       $metadata: {},
     };

--- a/src/service/cloudfront/command/delete-distribution/delete-distribution-authorizer.ts
+++ b/src/service/cloudfront/command/delete-distribution/delete-distribution-authorizer.ts
@@ -1,0 +1,56 @@
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimAwsAccountId } from "../../../aws/sim-aws-account.js";
+import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+import type { SimCloudFrontDistributionId } from "../../distribution/sim-cloudfront-distribution.js";
+
+interface DeleteDistributionAuthorizerProperties {
+  readonly accountId: SimAwsAccountId;
+  readonly iam: SimIamInterServiceAuthZ;
+}
+
+/**
+ * Applies IAM authorization to a CloudFront DeleteDistribution request.
+ *
+ * DeleteDistribution authorizes against the specific Distribution ARN, so a
+ * policy can grant deleting one Distribution without granting deleting every
+ * Distribution in the Account.
+ *
+ * Authorization happens before the Distribution map is read, so an
+ * unauthorized caller gets AccessDenied whether the Distribution exists or
+ * not.
+ */
+export class DeleteDistributionAuthorizer {
+  private static readonly action = "cloudfront:DeleteDistribution";
+
+  private readonly accountId: SimAwsAccountId;
+  private readonly iam: SimIamInterServiceAuthZ;
+
+  constructor(properties: DeleteDistributionAuthorizerProperties) {
+    this.accountId = properties.accountId;
+    this.iam = properties.iam;
+  }
+
+  /**
+   * Ensure the caller may delete the named CloudFront Distribution.
+   */
+  authorize(
+    distributionId: SimCloudFrontDistributionId | string,
+    caller?: SimAwsCaller,
+  ): void {
+    const resource = `arn:aws:cloudfront::${this.accountId}:distribution/${distributionId}`;
+    const decision = this.iam.authorize({
+      action: DeleteDistributionAuthorizer.action,
+      resource,
+      caller,
+    });
+
+    if (decision.isDenied) {
+      throw new SimIamAccessDenied({
+        principal: decision.caller.principal,
+        action: DeleteDistributionAuthorizer.action,
+        resource,
+      });
+    }
+  }
+}

--- a/src/service/cloudfront/command/delete-distribution/delete-distribution.command.ts
+++ b/src/service/cloudfront/command/delete-distribution/delete-distribution.command.ts
@@ -1,0 +1,29 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+
+/**
+ * Minimal structural sim CloudFront DeleteDistribution command.
+ */
+export interface SimDeleteDistributionCommand {
+  readonly input: SimDeleteDistributionCommandInput;
+}
+
+/**
+ * Minimal structural sim CloudFront DeleteDistribution input.
+ *
+ * `IfMatch` carries the ETag from the preceding GetDistribution. It is
+ * accepted and not checked here, so neither `PreconditionFailed` nor
+ * `InvalidIfMatchVersion` can come back. See the handler for why.
+ */
+export interface SimDeleteDistributionCommandInput {
+  readonly Id?: string | undefined;
+  readonly IfMatch?: string | undefined;
+}
+
+/**
+ * Minimal structural sim CloudFront DeleteDistribution output.
+ *
+ * CloudFront answers a deletion with nothing but the response metadata.
+ */
+export interface SimDeleteDistributionCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/cloudfront/command/delete-distribution/delete-distribution.handler.ts
+++ b/src/service/cloudfront/command/delete-distribution/delete-distribution.handler.ts
@@ -1,0 +1,113 @@
+import type { CommandHandler } from "../../../../command/command-handler.js";
+import {
+  type BackgroundScheduler,
+  BackgroundTasks,
+} from "../../../../util/background/background.js";
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimAwsAccountId } from "../../../aws/sim-aws-account.js";
+import {
+  SimIamAllowAllAuth,
+  type SimIamInterServiceAuthZ,
+} from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import type {
+  SimCloudFrontDistribution,
+  SimCloudFrontDistributionId,
+} from "../../distribution/sim-cloudfront-distribution.js";
+import { SimCloudFrontNoSuchDistribution } from "../../error/sim-cloudfront.error.js";
+import type { SimCloudFrontRegistry } from "../../registry/sim-cloud-front-registry.js";
+import { DeleteDistributionAuthorizer } from "./delete-distribution-authorizer.js";
+import type {
+  SimDeleteDistributionCommand,
+  SimDeleteDistributionCommandOutput,
+} from "./delete-distribution.command.js";
+
+interface DeleteDistributionCommandHandlerProperties {
+  readonly accountId: SimAwsAccountId;
+  readonly distributions: Map<
+    SimCloudFrontDistributionId,
+    SimCloudFrontDistribution
+  >;
+  readonly cloudFrontRegistry: SimCloudFrontRegistry;
+  readonly iam?: SimIamInterServiceAuthZ;
+  readonly background?: BackgroundScheduler;
+}
+
+interface DeleteDistributionCommandHandlerOptions {
+  readonly caller?: SimAwsCaller;
+}
+
+/**
+ * CloudFront DeleteDistributionCommand handler.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/cloudfront/command/DeleteDistributionCommand/
+ */
+export class DeleteDistributionCommandHandler implements CommandHandler<
+  SimDeleteDistributionCommand,
+  SimDeleteDistributionCommandOutput
+> {
+  private readonly distributions: Map<
+    SimCloudFrontDistributionId,
+    SimCloudFrontDistribution
+  >;
+  private readonly cloudFrontRegistry: SimCloudFrontRegistry;
+  private readonly authorizer: DeleteDistributionAuthorizer;
+  private readonly background: BackgroundScheduler;
+
+  constructor(properties: DeleteDistributionCommandHandlerProperties) {
+    const {
+      accountId,
+      distributions,
+      cloudFrontRegistry,
+      iam = new SimIamAllowAllAuth(),
+      background = new BackgroundTasks(),
+    } = properties;
+
+    this.distributions = distributions;
+    this.cloudFrontRegistry = cloudFrontRegistry;
+    this.authorizer = new DeleteDistributionAuthorizer({ accountId, iam });
+    this.background = background;
+  }
+
+  /**
+   * Handle deleting a CloudFront Distribution.
+   *
+   * The Distribution has to be disabled first, as it does in AWS, so a Stack
+   * teardown that forgets fails here the way it fails there.
+   *
+   * Real CloudFront also takes an `IfMatch` ETag from the preceding read and
+   * answers PreconditionFailed or InvalidIfMatchVersion when it is wrong or
+   * missing. That is not modelled: `IfMatch` is accepted and ignored. Nothing
+   * else in this simulator versions a resource, and a stale ETag is a retry
+   * rather than a design mistake, so the concept would cost every CloudFront
+   * command for very little. A test expecting the ETag refusal will not get
+   * it.
+   */
+  async handle(
+    command: SimDeleteDistributionCommand,
+    options?: DeleteDistributionCommandHandlerOptions,
+  ): Promise<SimDeleteDistributionCommandOutput> {
+    assertDefined(command.input.Id, "DeleteDistributionCommand.input.Id");
+    const distributionId = command.input.Id as SimCloudFrontDistributionId;
+
+    // Allow for potential non-deterministic sequencing of async events.
+    await this.background.sequence();
+
+    this.authorizer.authorize(distributionId, options?.caller);
+
+    const distribution = this.distributions.get(distributionId);
+
+    if (distribution === undefined) {
+      throw new SimCloudFrontNoSuchDistribution(
+        `No sim CloudFront Distribution with ID ${distributionId}`,
+      );
+    }
+
+    distribution.assertDeletable();
+
+    this.distributions.delete(distributionId);
+    this.cloudFrontRegistry.deregisterDistribution(distributionId);
+
+    return { $metadata: { httpStatusCode: 204 } };
+  }
+}

--- a/src/service/cloudfront/command/delete-distribution/delete-distribution.iso.test.ts
+++ b/src/service/cloudfront/command/delete-distribution/delete-distribution.iso.test.ts
@@ -1,0 +1,266 @@
+import {
+  CreateDistributionCommand,
+  DeleteDistributionCommand,
+  type DistributionConfig,
+  GetDistributionCommand,
+  UpdateDistributionCommand,
+} from "@aws-sdk/client-cloudfront";
+import { CreateBucketCommand, PutObjectCommand } from "@aws-sdk/client-s3";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertResponseStatus,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAwsServiceRequest } from "../../../../serve/controller/sim-service-controller.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+import { SimCloudFrontServiceController } from "../../controller/sim-cloudfront-controller.js";
+import {
+  SimCloudFrontDistributionNotDisabled,
+  SimCloudFrontNoSuchDistribution,
+} from "../../error/sim-cloudfront.error.js";
+import type { SimCloudFront } from "../../sim-cloudfront.js";
+
+interface Distro {
+  readonly simAws: SimAws;
+  readonly simCloudFront: SimCloudFront;
+  readonly distributionId: string;
+  readonly aliases: string[];
+}
+
+function distributionConfig(
+  overrides: Partial<DistributionConfig> = {},
+): DistributionConfig {
+  return {
+    CallerReference: "deletable-distribution",
+    Comment: "Deletable distribution",
+    Enabled: true,
+    Origins: {
+      Quantity: 1,
+      Items: [
+        {
+          Id: "SiteOrigin",
+          DomainName: "example-bucket.s3.amazonaws.com",
+          S3OriginConfig: { OriginAccessIdentity: "" },
+        },
+      ],
+    },
+    DefaultCacheBehavior: {
+      TargetOriginId: "SiteOrigin",
+      ViewerProtocolPolicy: "allow-all",
+    },
+    ...overrides,
+  };
+}
+
+/**
+ * Create a Distribution over an S3 Origin holding one object, so a request to
+ * it has something to answer with.
+ */
+async function givenDistribution(aliases: string[] = []): Promise<Distro> {
+  const simAws = new SimAws();
+  await simAws
+    .s3()
+    .createBucket(new CreateBucketCommand({ Bucket: "example-bucket" }));
+  await simAws.s3().putObject(
+    new PutObjectCommand({
+      Bucket: "example-bucket",
+      Key: "index.html",
+      ContentType: "text/html",
+      Body: "<h1>Served</h1>",
+    }),
+  );
+
+  const simCloudFront = simAws.cloudFront();
+  const created = await simCloudFront.createDistribution(
+    new CreateDistributionCommand({
+      DistributionConfig: distributionConfig({
+        Aliases: { Quantity: aliases.length, Items: aliases },
+      }),
+    }),
+  );
+  await simAws.backgroundTasksComplete();
+  assertNonNullable(created.Distribution?.Id);
+
+  return {
+    simAws,
+    simCloudFront,
+    distributionId: created.Distribution.Id,
+    aliases,
+  };
+}
+
+async function disable(distro: Distro): Promise<void> {
+  await distro.simCloudFront.updateDistribution(
+    new UpdateDistributionCommand({
+      Id: distro.distributionId,
+      IfMatch: "E2QWRUHAPOMQZL",
+      DistributionConfig: distributionConfig({
+        Enabled: false,
+        Aliases: { Quantity: distro.aliases.length, Items: distro.aliases },
+      }),
+    }),
+  );
+  await distro.simAws.backgroundTasksComplete();
+}
+
+async function requestDistribution(
+  distro: Distro,
+  hostname: string,
+): Promise<Response> {
+  return await new SimCloudFrontServiceController({
+    simAws: distro.simAws,
+  }).handleRequest(
+    new SimAwsServiceRequest({
+      target: { service: "cloudFront", resourceName: "" },
+      request: new Request(`http://${hostname}.sim-aws.localhost/index.html`),
+    }),
+  );
+}
+
+describe("CloudFront DeleteDistributionCommand", () => {
+  it("deletes a disabled Distribution", async () => {
+    // Given a Distribution that has been disabled.
+    const distro = await givenDistribution();
+    await disable(distro);
+
+    // When the Distribution is deleted.
+    const output = await distro.simCloudFront.deleteDistribution(
+      new DeleteDistributionCommand({ Id: distro.distributionId }),
+    );
+
+    // Then CloudFront accepts it, and the Distribution is gone.
+    assertIdentical(output.$metadata.httpStatusCode, 204);
+
+    await assertThrowsErrorAsync(async () =>
+      distro.simCloudFront.getDistribution(
+        new GetDistributionCommand({ Id: distro.distributionId }),
+      ),
+    );
+  });
+
+  it("refuses a Distribution that is still enabled", async () => {
+    // Given a Distribution left enabled.
+    const distro = await givenDistribution();
+
+    // When the Distribution is deleted.
+    const error = await assertThrowsErrorAsync(async () =>
+      distro.simCloudFront.deleteDistribution(
+        new DeleteDistributionCommand({ Id: distro.distributionId }),
+      ),
+    );
+
+    // Then CloudFront refuses, leaving the caller to disable it first.
+    assertInstanceOf(error, SimCloudFrontDistributionNotDisabled);
+    assertIdentical(error.$metadata.httpStatusCode, 409);
+    assertNonNullable(
+      distro.simCloudFront.getSimDistributionById(distro.distributionId),
+    );
+  });
+
+  it("stops a request to the Distribution domain resolving to it", async () => {
+    // Given a disabled Distribution still answering on its CloudFront domain.
+    const distro = await givenDistribution();
+    await disable(distro);
+    const cloudFrontDomain = `${distro.distributionId.toLowerCase()}.cloudfront.net`;
+
+    assertResponseStatus(
+      await requestDistribution(distro, cloudFrontDomain),
+      200,
+    );
+
+    // When the Distribution is deleted.
+    await distro.simCloudFront.deleteDistribution(
+      new DeleteDistributionCommand({ Id: distro.distributionId }),
+    );
+
+    // Then a request to its domain no longer resolves to it.
+    assertResponseStatus(
+      await requestDistribution(distro, cloudFrontDomain),
+      404,
+    );
+  });
+
+  it("frees the alternate domain names the Distribution answered on", async () => {
+    // Given a disabled Distribution with an alternate domain name.
+    const distro = await givenDistribution(["cdn.deletable.test"]);
+    await disable(distro);
+
+    assertResponseStatus(
+      await requestDistribution(distro, "cdn.deletable.test"),
+      200,
+    );
+
+    // When the Distribution is deleted.
+    await distro.simCloudFront.deleteDistribution(
+      new DeleteDistributionCommand({ Id: distro.distributionId }),
+    );
+
+    // Then the alternate domain name routes to nothing, and is free again.
+    assertResponseStatus(
+      await requestDistribution(distro, "cdn.deletable.test"),
+      404,
+    );
+    assertUndefined(
+      distro.simAws.serviceFactory.cloudFrontRegistry.distributionIdForAlternateDomainName(
+        "cdn.deletable.test",
+      ),
+    );
+  });
+
+  it("rejects a Distribution that does not exist", async () => {
+    // Given a simulated CloudFront without the requested Distribution.
+    const simCloudFront = new SimAws().cloudFront();
+
+    // When the missing Distribution is deleted.
+    const error = await assertThrowsErrorAsync(async () =>
+      simCloudFront.deleteDistribution(
+        new DeleteDistributionCommand({ Id: "EMISSINGDISTRIB" }),
+      ),
+    );
+
+    // Then CloudFront answers with its missing-Distribution error.
+    assertInstanceOf(error, SimCloudFrontNoSuchDistribution);
+    assertIdentical(error.$metadata.httpStatusCode, 404);
+  });
+
+  it("requires a Distribution ID", async () => {
+    // Given a simulated CloudFront.
+    const simCloudFront = new SimAws().cloudFront();
+
+    // When a deletion arrives without an ID.
+    const error = await assertThrowsErrorAsync(async () =>
+      simCloudFront.deleteDistribution(
+        new DeleteDistributionCommand({ Id: undefined }),
+      ),
+    );
+
+    // Then it is refused before anything is deleted.
+    assertInstanceOf(error, Error);
+  });
+
+  it("denies a caller without DeleteDistribution permission", async () => {
+    // Given a disabled Distribution in a simulation with IAM.
+    const distro = await givenDistribution();
+    await disable(distro);
+
+    // When an anonymous caller deletes it.
+    const error = await assertThrowsErrorAsync(async () =>
+      distro.simCloudFront.deleteDistribution(
+        new DeleteDistributionCommand({ Id: distro.distributionId }),
+        { caller: { kind: "anonymous" } },
+      ),
+    );
+
+    // Then IAM denies the removal action, and the Distribution stays.
+    assertInstanceOf(error, SimIamAccessDenied);
+    assertIdentical(error.action, "cloudfront:DeleteDistribution");
+    assertNonNullable(
+      distro.simCloudFront.getSimDistributionById(distro.distributionId),
+    );
+  });
+});

--- a/src/service/cloudfront/command/delete-function/delete-function-authorizer.ts
+++ b/src/service/cloudfront/command/delete-function/delete-function-authorizer.ts
@@ -1,0 +1,52 @@
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimAwsAccountId } from "../../../aws/sim-aws-account.js";
+import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+import type { SimCloudFrontFunctionName } from "../../cff/sim-cloudfront-function.js";
+
+interface DeleteFunctionAuthorizerProperties {
+  readonly accountId: SimAwsAccountId;
+  readonly iam: SimIamInterServiceAuthZ;
+}
+
+/**
+ * Applies IAM authorization to a CloudFront DeleteFunction request.
+ *
+ * Authorization is against the Function ARN, and happens before the Function
+ * map is read, so an unauthorized caller gets AccessDenied whether the
+ * Function exists or not.
+ */
+export class DeleteFunctionAuthorizer {
+  private static readonly action = "cloudfront:DeleteFunction";
+
+  private readonly accountId: SimAwsAccountId;
+  private readonly iam: SimIamInterServiceAuthZ;
+
+  constructor(properties: DeleteFunctionAuthorizerProperties) {
+    this.accountId = properties.accountId;
+    this.iam = properties.iam;
+  }
+
+  /**
+   * Ensure the caller may delete the named CloudFront Function.
+   */
+  authorize(
+    functionName: SimCloudFrontFunctionName | string,
+    caller?: SimAwsCaller,
+  ): void {
+    const resource = `arn:aws:cloudfront::${this.accountId}:function/${functionName}`;
+    const decision = this.iam.authorize({
+      action: DeleteFunctionAuthorizer.action,
+      resource,
+      caller,
+    });
+
+    if (decision.isDenied) {
+      throw new SimIamAccessDenied({
+        principal: decision.caller.principal,
+        action: DeleteFunctionAuthorizer.action,
+        resource,
+      });
+    }
+  }
+}

--- a/src/service/cloudfront/command/delete-function/delete-function.command.ts
+++ b/src/service/cloudfront/command/delete-function/delete-function.command.ts
@@ -1,0 +1,29 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+
+/**
+ * Minimal structural sim CloudFront DeleteFunction command.
+ */
+export interface SimDeleteFunctionCommand {
+  readonly input: SimDeleteFunctionCommandInput;
+}
+
+/**
+ * Minimal structural sim CloudFront DeleteFunction input.
+ *
+ * `IfMatch` carries the ETag from the preceding DescribeFunction. It is
+ * accepted and not checked here, so neither `PreconditionFailed` nor
+ * `InvalidIfMatchVersion` can come back. See the handler for why.
+ */
+export interface SimDeleteFunctionCommandInput {
+  readonly Name?: string | undefined;
+  readonly IfMatch?: string | undefined;
+}
+
+/**
+ * Minimal structural sim CloudFront DeleteFunction output.
+ *
+ * CloudFront answers a deletion with nothing but the response metadata.
+ */
+export interface SimDeleteFunctionCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/cloudfront/command/delete-function/delete-function.handler.ts
+++ b/src/service/cloudfront/command/delete-function/delete-function.handler.ts
@@ -1,0 +1,92 @@
+import type { CommandHandler } from "../../../../command/command-handler.js";
+import {
+  type BackgroundScheduler,
+  BackgroundTasks,
+} from "../../../../util/background/background.js";
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimAwsAccountId } from "../../../aws/sim-aws-account.js";
+import {
+  SimIamAllowAllAuth,
+  type SimIamInterServiceAuthZ,
+} from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import type { SimCloudFrontFunctionName } from "../../cff/sim-cloudfront-function.js";
+import { SimCloudFrontNoSuchFunctionExists } from "../../error/sim-cloudfront.error.js";
+import type { SimCloudFrontFunctionMap } from "../create-function/create-function.handler.js";
+import { DeleteFunctionAuthorizer } from "./delete-function-authorizer.js";
+import type {
+  SimDeleteFunctionCommand,
+  SimDeleteFunctionCommandOutput,
+} from "./delete-function.command.js";
+
+interface DeleteFunctionCommandHandlerProperties {
+  readonly accountId: SimAwsAccountId;
+  readonly cloudFrontFunctions: SimCloudFrontFunctionMap;
+  readonly iam?: SimIamInterServiceAuthZ;
+  readonly background?: BackgroundScheduler;
+}
+
+interface DeleteFunctionCommandHandlerOptions {
+  readonly caller?: SimAwsCaller;
+}
+
+/**
+ * CloudFront DeleteFunctionCommand handler.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/cloudfront/command/DeleteFunctionCommand/
+ */
+export class DeleteFunctionCommandHandler implements CommandHandler<
+  SimDeleteFunctionCommand,
+  SimDeleteFunctionCommandOutput
+> {
+  private readonly cloudFrontFunctions: SimCloudFrontFunctionMap;
+  private readonly authorizer: DeleteFunctionAuthorizer;
+  private readonly background: BackgroundScheduler;
+
+  constructor(properties: DeleteFunctionCommandHandlerProperties) {
+    const {
+      accountId,
+      cloudFrontFunctions,
+      iam = new SimIamAllowAllAuth(),
+      background = new BackgroundTasks(),
+    } = properties;
+
+    this.cloudFrontFunctions = cloudFrontFunctions;
+    this.authorizer = new DeleteFunctionAuthorizer({ accountId, iam });
+    this.background = background;
+  }
+
+  /**
+   * Handle deleting a CloudFront Function.
+   *
+   * Real CloudFront refuses with FunctionInUse while the Function is
+   * associated with a Distribution, and only deletes an unassociated one. This
+   * simulation does not track association: a cache Behavior holds the Function
+   * ARN it runs, and nothing tells the Function it has been taken up, so every
+   * Function here is deletable. A Behavior still pointing at a deleted
+   * Function finds nothing and runs no Function code.
+   *
+   * The `IfMatch` ETag is accepted and not checked, for the same reason as
+   * DeleteDistribution: nothing else here versions a resource.
+   */
+  async handle(
+    command: SimDeleteFunctionCommand,
+    options?: DeleteFunctionCommandHandlerOptions,
+  ): Promise<SimDeleteFunctionCommandOutput> {
+    assertDefined(command.input.Name, "DeleteFunctionCommand.input.Name");
+    const functionName = command.input.Name as SimCloudFrontFunctionName;
+
+    // Allow for potential non-deterministic sequencing of async events.
+    await this.background.sequence();
+
+    this.authorizer.authorize(functionName, options?.caller);
+
+    if (!this.cloudFrontFunctions.delete(functionName)) {
+      throw new SimCloudFrontNoSuchFunctionExists(
+        `No sim CloudFront Function named ${functionName}`,
+      );
+    }
+
+    return { $metadata: { httpStatusCode: 204 } };
+  }
+}

--- a/src/service/cloudfront/command/delete-function/delete-function.iso.test.ts
+++ b/src/service/cloudfront/command/delete-function/delete-function.iso.test.ts
@@ -1,0 +1,132 @@
+import {
+  CreateFunctionCommand,
+  DeleteFunctionCommand,
+} from "@aws-sdk/client-cloudfront";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+import type { SimCloudFrontFunctionName } from "../../cff/sim-cloudfront-function.js";
+import { SimCloudFrontNoSuchFunctionExists } from "../../error/sim-cloudfront.error.js";
+import type { SimCloudFront } from "../../sim-cloudfront.js";
+
+const functionCode = Buffer.from(`
+  function handler(event) {
+    return event.request;
+  }
+`);
+
+async function givenFunction(name: string): Promise<{
+  readonly simAws: SimAws;
+  readonly simCloudFront: SimCloudFront;
+}> {
+  const simAws = new SimAws();
+  const simCloudFront = simAws.cloudFront();
+
+  await simCloudFront.createFunction(
+    new CreateFunctionCommand({
+      Name: name,
+      FunctionConfig: { Comment: name, Runtime: "cloudfront-js-2.0" },
+      FunctionCode: functionCode,
+    }),
+  );
+  await simAws.backgroundTasksComplete();
+
+  return { simAws, simCloudFront };
+}
+
+describe("CloudFront DeleteFunctionCommand", () => {
+  it("deletes a CloudFront Function", async () => {
+    // Given a published CloudFront Function.
+    const { simCloudFront } = await givenFunction("deletable-cff");
+    assertNonNullable(
+      simCloudFront.getCloudFrontFunctionByName(
+        "deletable-cff" as SimCloudFrontFunctionName,
+      ),
+    );
+
+    // When the Function is deleted.
+    const output = await simCloudFront.deleteFunction(
+      new DeleteFunctionCommand({
+        Name: "deletable-cff",
+        IfMatch: "E2QWRUHAPOMQZL",
+      }),
+    );
+
+    // Then CloudFront accepts it, and the Function is gone.
+    assertIdentical(output.$metadata.httpStatusCode, 204);
+    assertUndefined(
+      simCloudFront.getCloudFrontFunctionByName(
+        "deletable-cff" as SimCloudFrontFunctionName,
+      ),
+    );
+  });
+
+  it("rejects a Function that does not exist", async () => {
+    // Given a simulated CloudFront without the requested Function.
+    const simCloudFront = new SimAws().cloudFront();
+
+    // When the missing Function is deleted.
+    const error = await assertThrowsErrorAsync(async () =>
+      simCloudFront.deleteFunction(
+        new DeleteFunctionCommand({
+          Name: "no-such-cff",
+          IfMatch: "E2QWRUHAPOMQZL",
+        }),
+      ),
+    );
+
+    // Then CloudFront answers with its missing-Function error.
+    assertInstanceOf(error, SimCloudFrontNoSuchFunctionExists);
+    assertIdentical(error.$metadata.httpStatusCode, 404);
+  });
+
+  it("requires a Function name", async () => {
+    // Given a simulated CloudFront.
+    const simCloudFront = new SimAws().cloudFront();
+
+    // When a deletion arrives without a name.
+    const error = await assertThrowsErrorAsync(async () =>
+      simCloudFront.deleteFunction(
+        new DeleteFunctionCommand({
+          Name: undefined,
+          IfMatch: "E2QWRUHAPOMQZL",
+        }),
+      ),
+    );
+
+    // Then it is refused before anything is deleted.
+    assertInstanceOf(error, Error);
+  });
+
+  it("denies a caller without DeleteFunction permission", async () => {
+    // Given a CloudFront Function in a simulation with IAM.
+    const { simCloudFront } = await givenFunction("protected-cff");
+
+    // When an anonymous caller deletes it.
+    const error = await assertThrowsErrorAsync(async () =>
+      simCloudFront.deleteFunction(
+        new DeleteFunctionCommand({
+          Name: "protected-cff",
+          IfMatch: "E2QWRUHAPOMQZL",
+        }),
+        { caller: { kind: "anonymous" } },
+      ),
+    );
+
+    // Then IAM denies the removal action, and the Function stays.
+    assertInstanceOf(error, SimIamAccessDenied);
+    assertIdentical(error.action, "cloudfront:DeleteFunction");
+    assertNonNullable(
+      simCloudFront.getCloudFrontFunctionByName(
+        "protected-cff" as SimCloudFrontFunctionName,
+      ),
+    );
+  });
+});

--- a/src/service/cloudfront/command/get-distribution/get-distribution.command.ts
+++ b/src/service/cloudfront/command/get-distribution/get-distribution.command.ts
@@ -1,5 +1,5 @@
-import type { SimCloudFrontDistributionConfig } from "../create-distribution/create-distribution.command.js";
 import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type { SimCloudFrontDistributionView } from "../../distribution/sim-cf-distribution-view.js";
 
 /**
  * Minimal structural sim CloudFront GetDistribution command.
@@ -19,17 +19,6 @@ export interface SimGetDistributionCommandInput {
  * Minimal structural sim CloudFront GetDistribution output.
  */
 export interface SimGetDistributionCommandOutput {
-  readonly Distribution?:
-    | undefined
-    | {
-        readonly Id?: string | undefined;
-        readonly ARN?: string | undefined;
-        readonly Status?: string | undefined;
-        readonly LastModifiedTime?: Date | undefined;
-        readonly InProgressInvalidationBatches?: number | undefined;
-        readonly DomainName?: string | undefined;
-        readonly DistributionConfig?:
-          SimCloudFrontDistributionConfig | undefined;
-      };
+  readonly Distribution?: SimCloudFrontDistributionView | undefined;
   readonly $metadata: SimResponseMetadata;
 }

--- a/src/service/cloudfront/command/get-distribution/get-distribution.handler.ts
+++ b/src/service/cloudfront/command/get-distribution/get-distribution.handler.ts
@@ -7,6 +7,7 @@ import type {
   SimCloudFrontDistribution,
   SimCloudFrontDistributionId,
 } from "../../distribution/sim-cloudfront-distribution.js";
+import { simCloudFrontDistributionView } from "../../distribution/sim-cf-distribution-view.js";
 import { SimCloudFrontResourceNotFoundException } from "../../error/sim-cloudfront.error.js";
 import {
   type BackgroundScheduler,
@@ -89,15 +90,7 @@ export class GetDistributionCommandHandler implements CommandHandler<
     }
 
     return {
-      Distribution: {
-        Id: distribution.distributionId,
-        ARN: `arn:aws:cloudfront::${distribution.accountId}:distribution/${distribution.distributionId}`,
-        Status: distribution.status,
-        LastModifiedTime: distribution.lastModifiedTime,
-        InProgressInvalidationBatches: 0,
-        DomainName: `${distribution.distributionId.toLowerCase()}.cloudfront.net`,
-        DistributionConfig: distribution.distributionConfig,
-      },
+      Distribution: simCloudFrontDistributionView(distribution),
       $metadata: {},
     };
   }

--- a/src/service/cloudfront/command/update-distribution/update-distribution-authorizer.ts
+++ b/src/service/cloudfront/command/update-distribution/update-distribution-authorizer.ts
@@ -1,0 +1,52 @@
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimAwsAccountId } from "../../../aws/sim-aws-account.js";
+import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+import type { SimCloudFrontDistributionId } from "../../distribution/sim-cloudfront-distribution.js";
+
+interface UpdateDistributionAuthorizerProperties {
+  readonly accountId: SimAwsAccountId;
+  readonly iam: SimIamInterServiceAuthZ;
+}
+
+/**
+ * Applies IAM authorization to a CloudFront UpdateDistribution request.
+ *
+ * Authorization is against the specific Distribution ARN, and happens before
+ * the Distribution map is read, so an unauthorized caller gets AccessDenied
+ * whether the Distribution exists or not.
+ */
+export class UpdateDistributionAuthorizer {
+  private static readonly action = "cloudfront:UpdateDistribution";
+
+  private readonly accountId: SimAwsAccountId;
+  private readonly iam: SimIamInterServiceAuthZ;
+
+  constructor(properties: UpdateDistributionAuthorizerProperties) {
+    this.accountId = properties.accountId;
+    this.iam = properties.iam;
+  }
+
+  /**
+   * Ensure the caller may update the named CloudFront Distribution.
+   */
+  authorize(
+    distributionId: SimCloudFrontDistributionId | string,
+    caller?: SimAwsCaller,
+  ): void {
+    const resource = `arn:aws:cloudfront::${this.accountId}:distribution/${distributionId}`;
+    const decision = this.iam.authorize({
+      action: UpdateDistributionAuthorizer.action,
+      resource,
+      caller,
+    });
+
+    if (decision.isDenied) {
+      throw new SimIamAccessDenied({
+        principal: decision.caller.principal,
+        action: UpdateDistributionAuthorizer.action,
+        resource,
+      });
+    }
+  }
+}

--- a/src/service/cloudfront/command/update-distribution/update-distribution.command.ts
+++ b/src/service/cloudfront/command/update-distribution/update-distribution.command.ts
@@ -1,0 +1,34 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type { SimCloudFrontDistributionView } from "../../distribution/sim-cf-distribution-view.js";
+import type { SimCloudFrontDistributionConfig } from "../create-distribution/create-distribution.command.js";
+
+/**
+ * Minimal structural sim CloudFront UpdateDistribution command.
+ */
+export interface SimUpdateDistributionCommand {
+  readonly input: SimUpdateDistributionCommandInput;
+}
+
+/**
+ * Minimal structural sim CloudFront UpdateDistribution input.
+ *
+ * CloudFront takes the whole DistributionConfig rather than a patch, so the
+ * usual sequence is GetDistribution, change a field, then UpdateDistribution.
+ *
+ * `IfMatch` carries the ETag from that read. It is accepted and not checked
+ * here, so neither `PreconditionFailed` nor `InvalidIfMatchVersion` can come
+ * back. See the handler for why.
+ */
+export interface SimUpdateDistributionCommandInput {
+  readonly Id?: string | undefined;
+  readonly IfMatch?: string | undefined;
+  readonly DistributionConfig?: SimCloudFrontDistributionConfig | undefined;
+}
+
+/**
+ * Minimal structural sim CloudFront UpdateDistribution output.
+ */
+export interface SimUpdateDistributionCommandOutput {
+  readonly Distribution?: SimCloudFrontDistributionView | undefined;
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/cloudfront/command/update-distribution/update-distribution.handler.ts
+++ b/src/service/cloudfront/command/update-distribution/update-distribution.handler.ts
@@ -1,0 +1,131 @@
+import type { CommandHandler } from "../../../../command/command-handler.js";
+import {
+  type BackgroundScheduler,
+  BackgroundTasks,
+} from "../../../../util/background/background.js";
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type { SimAcmRegistry } from "../../../acm/registry/sim-acm-registry.js";
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimAwsAccountId } from "../../../aws/sim-aws-account.js";
+import {
+  SimIamAllowAllAuth,
+  type SimIamInterServiceAuthZ,
+} from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { SimCloudFrontDistributionReconfigurer } from "../../distribution/sim-cf-distribution-reconfigurer.js";
+import { simCloudFrontDistributionView } from "../../distribution/sim-cf-distribution-view.js";
+import type {
+  SimCloudFrontDistribution,
+  SimCloudFrontDistributionId,
+} from "../../distribution/sim-cloudfront-distribution.js";
+import { SimCloudFrontViewerCertificateValidator } from "../../distribution/viewer-certificate/sim-cf-viewer-certificate-validator.js";
+import { SimCloudFrontNoSuchDistribution } from "../../error/sim-cloudfront.error.js";
+import type { SimCfCustomOriginDispatcher } from "../../origin/custom/sim-cf-custom-origin-dispatcher.js";
+import type { SimCloudFrontS3OriginResolver } from "../../origin/s3/sim-cloudfront-s3-origin.js";
+import type { SimCloudFrontRegistry } from "../../registry/sim-cloud-front-registry.js";
+import { SimCloudFrontDistributionConfigNormalizer } from "../create-distribution/sim-cf-distro-config-normalizer.js";
+import { UpdateDistributionAuthorizer } from "./update-distribution-authorizer.js";
+import type {
+  SimUpdateDistributionCommand,
+  SimUpdateDistributionCommandOutput,
+} from "./update-distribution.command.js";
+
+interface UpdateDistributionCommandHandlerProperties {
+  readonly accountId: SimAwsAccountId;
+  readonly distributions: Map<
+    SimCloudFrontDistributionId,
+    SimCloudFrontDistribution
+  >;
+  readonly cloudFrontRegistry: SimCloudFrontRegistry;
+  readonly s3OriginResolver: SimCloudFrontS3OriginResolver;
+  readonly customOriginDispatcher?: SimCfCustomOriginDispatcher | undefined;
+  readonly iam?: SimIamInterServiceAuthZ;
+  readonly acmRegistry?: SimAcmRegistry | undefined;
+  readonly background?: BackgroundScheduler;
+}
+
+interface UpdateDistributionCommandHandlerOptions {
+  readonly caller?: SimAwsCaller;
+}
+
+/**
+ * CloudFront UpdateDistributionCommand handler.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/cloudfront/command/UpdateDistributionCommand/
+ */
+export class UpdateDistributionCommandHandler implements CommandHandler<
+  SimUpdateDistributionCommand,
+  SimUpdateDistributionCommandOutput
+> {
+  private readonly distributions: Map<
+    SimCloudFrontDistributionId,
+    SimCloudFrontDistribution
+  >;
+  private readonly reconfigurer: SimCloudFrontDistributionReconfigurer;
+  private readonly viewerCertificateValidator: SimCloudFrontViewerCertificateValidator;
+  private readonly authorizer: UpdateDistributionAuthorizer;
+  private readonly background: BackgroundScheduler;
+
+  constructor(properties: UpdateDistributionCommandHandlerProperties) {
+    const {
+      accountId,
+      iam = new SimIamAllowAllAuth(),
+      background = new BackgroundTasks(),
+    } = properties;
+
+    this.distributions = properties.distributions;
+    this.reconfigurer = new SimCloudFrontDistributionReconfigurer(properties);
+    this.viewerCertificateValidator =
+      new SimCloudFrontViewerCertificateValidator(properties);
+    this.authorizer = new UpdateDistributionAuthorizer({ accountId, iam });
+    this.background = background;
+  }
+
+  /**
+   * Handle updating a CloudFront Distribution.
+   *
+   * The `IfMatch` ETag is accepted and not checked. Nothing else in this
+   * simulator versions a resource, and a stale ETag is a retry rather than a
+   * design mistake, so the concept would cost every CloudFront command for
+   * very little. A test expecting PreconditionFailed will not get it.
+   */
+  async handle(
+    command: SimUpdateDistributionCommand,
+    options?: UpdateDistributionCommandHandlerOptions,
+  ): Promise<SimUpdateDistributionCommandOutput> {
+    const { Id: id, DistributionConfig: config } = command.input;
+    assertDefined(id, "UpdateDistributionCommand.input.Id");
+    assertDefined(config, "UpdateDistributionCommand.input.DistributionConfig");
+
+    const distributionId = id as SimCloudFrontDistributionId;
+    const distributionConfig = new SimCloudFrontDistributionConfigNormalizer(
+      config,
+    ).normalize();
+
+    // Allow for potential non-deterministic sequencing of async events.
+    await this.background.sequence();
+
+    this.authorizer.authorize(distributionId, options?.caller);
+
+    const distribution = this.distributions.get(distributionId);
+
+    if (distribution === undefined) {
+      throw new SimCloudFrontNoSuchDistribution(
+        `No sim CloudFront Distribution with ID ${distributionId}`,
+      );
+    }
+
+    // Reject an unusable viewer certificate before the Distribution is
+    // touched, as CloudFront rejects the whole request.
+    this.viewerCertificateValidator.validate(distributionConfig);
+
+    this.reconfigurer.reconfigure(distribution, distributionConfig);
+
+    // Schedule background task to complete deployment of the sim Distribution.
+    this.background.schedule(() => distribution.completeDeployment());
+
+    return {
+      Distribution: simCloudFrontDistributionView(distribution),
+      $metadata: {},
+    };
+  }
+}

--- a/src/service/cloudfront/command/update-distribution/update-distribution.iso.test.ts
+++ b/src/service/cloudfront/command/update-distribution/update-distribution.iso.test.ts
@@ -1,0 +1,268 @@
+import {
+  CreateDistributionCommand,
+  type DistributionConfig,
+  GetDistributionCommand,
+  UpdateDistributionCommand,
+} from "@aws-sdk/client-cloudfront";
+import { CreateBucketCommand } from "@aws-sdk/client-s3";
+import {
+  assertFalse,
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertSetSize,
+  assertThrowsErrorAsync,
+  assertTrue,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+import {
+  SimCloudFrontInvalidViewerCertificate,
+  SimCloudFrontNoSuchDistribution,
+} from "../../error/sim-cloudfront.error.js";
+import type { SimCloudFront } from "../../sim-cloudfront.js";
+
+interface Distro {
+  readonly simAws: SimAws;
+  readonly simCloudFront: SimCloudFront;
+  readonly distributionId: string;
+}
+
+function distributionConfig(
+  overrides: Partial<DistributionConfig> = {},
+): DistributionConfig {
+  return {
+    CallerReference: "updatable-distribution",
+    Comment: "Updatable distribution",
+    Enabled: true,
+    Origins: {
+      Quantity: 1,
+      Items: [
+        {
+          Id: "SiteOrigin",
+          DomainName: "example-bucket.s3.amazonaws.com",
+          S3OriginConfig: { OriginAccessIdentity: "" },
+        },
+      ],
+    },
+    DefaultCacheBehavior: {
+      TargetOriginId: "SiteOrigin",
+      ViewerProtocolPolicy: "allow-all",
+    },
+    ...overrides,
+  };
+}
+
+async function givenDistribution(aliases: string[] = []): Promise<Distro> {
+  const simAws = new SimAws();
+  await simAws
+    .s3()
+    .createBucket(new CreateBucketCommand({ Bucket: "example-bucket" }));
+
+  const simCloudFront = simAws.cloudFront();
+  const created = await simCloudFront.createDistribution(
+    new CreateDistributionCommand({
+      DistributionConfig: distributionConfig({
+        Aliases: { Quantity: aliases.length, Items: aliases },
+      }),
+    }),
+  );
+  await simAws.backgroundTasksComplete();
+  assertNonNullable(created.Distribution?.Id);
+
+  return { simAws, simCloudFront, distributionId: created.Distribution.Id };
+}
+
+describe("CloudFront UpdateDistributionCommand", () => {
+  it("disables a Distribution", async () => {
+    // Given an enabled Distribution.
+    const distro = await givenDistribution();
+    assertTrue(
+      distro.simCloudFront.getSimDistributionById(distro.distributionId)
+        ?.enabled,
+    );
+
+    // When it is updated with Enabled false.
+    const output = await distro.simCloudFront.updateDistribution(
+      new UpdateDistributionCommand({
+        Id: distro.distributionId,
+        IfMatch: "E2QWRUHAPOMQZL",
+        DistributionConfig: distributionConfig({ Enabled: false }),
+      }),
+    );
+
+    // Then CloudFront redeploys the Distribution as disabled.
+    assertIdentical(output.Distribution?.Status, "Deploying");
+    assertFalse(output.Distribution.DistributionConfig?.Enabled);
+    assertFalse(
+      distro.simCloudFront.getSimDistributionById(distro.distributionId)
+        ?.enabled,
+    );
+
+    await distro.simAws.backgroundTasksComplete();
+    const read = await distro.simCloudFront.getDistribution(
+      new GetDistributionCommand({ Id: distro.distributionId }),
+    );
+    assertIdentical(read.Distribution?.Status, "Deployed");
+  });
+
+  it("applies a replacement configuration rather than merging it", async () => {
+    // Given a Distribution with a default root object and an alternate domain.
+    const distro = await givenDistribution(["cdn.updatable.test"]);
+    await distro.simCloudFront.updateDistribution(
+      new UpdateDistributionCommand({
+        Id: distro.distributionId,
+        DistributionConfig: distributionConfig({
+          DefaultRootObject: "index.html",
+          Aliases: { Quantity: 1, Items: ["cdn.updatable.test"] },
+        }),
+      }),
+    );
+    const configured = distro.simCloudFront.getSimDistributionById(
+      distro.distributionId,
+    );
+    assertIdentical(configured?.defaultRootObject, "index.html");
+
+    // When the Distribution is updated with neither of them.
+    await distro.simCloudFront.updateDistribution(
+      new UpdateDistributionCommand({
+        Id: distro.distributionId,
+        DistributionConfig: distributionConfig(),
+      }),
+    );
+
+    // Then both are gone, as CloudFront takes the whole config.
+    const updated = distro.simCloudFront.getSimDistributionById(
+      distro.distributionId,
+    );
+    assertNonNullable(updated);
+    assertUndefined(updated.defaultRootObject);
+    assertSetSize(updated.getAlternateDomainNames(), 0);
+    assertUndefined(
+      distro.simAws.serviceFactory.cloudFrontRegistry.distributionIdForAlternateDomainName(
+        "cdn.updatable.test",
+      ),
+    );
+  });
+
+  it("moves an alternate domain name to the Distribution now holding it", async () => {
+    // Given a Distribution answering on an alternate domain name.
+    const distro = await givenDistribution(["moved.updatable.test"]);
+    const registry = distro.simAws.serviceFactory.cloudFrontRegistry;
+    assertIdentical(
+      registry.distributionIdForAlternateDomainName("moved.updatable.test"),
+      distro.distributionId,
+    );
+
+    // When the name is replaced with another one.
+    await distro.simCloudFront.updateDistribution(
+      new UpdateDistributionCommand({
+        Id: distro.distributionId,
+        DistributionConfig: distributionConfig({
+          Aliases: { Quantity: 1, Items: ["renamed.updatable.test"] },
+        }),
+      }),
+    );
+
+    // Then the old registration goes and the new one takes its place, so the
+    // old name is free for another Distribution.
+    assertUndefined(
+      registry.distributionIdForAlternateDomainName("moved.updatable.test"),
+    );
+    assertIdentical(
+      registry.distributionIdForAlternateDomainName("renamed.updatable.test"),
+      distro.distributionId,
+    );
+  });
+
+  it("refuses an unusable viewer certificate, leaving the Distribution alone", async () => {
+    // Given an enabled Distribution.
+    const distro = await givenDistribution();
+
+    // When it is updated with a certificate ARN that resolves to nothing.
+    const error = await assertThrowsErrorAsync(async () =>
+      distro.simCloudFront.updateDistribution(
+        new UpdateDistributionCommand({
+          Id: distro.distributionId,
+          DistributionConfig: distributionConfig({
+            Enabled: false,
+            ViewerCertificate: {
+              ACMCertificateArn:
+                "arn:aws:acm:us-east-1:123456789012:certificate/missing",
+              SSLSupportMethod: "sni-only",
+            },
+          }),
+        }),
+      ),
+    );
+
+    // Then CloudFront rejects the whole request and nothing is applied.
+    assertInstanceOf(error, SimCloudFrontInvalidViewerCertificate);
+    assertTrue(
+      distro.simCloudFront.getSimDistributionById(distro.distributionId)
+        ?.enabled,
+    );
+  });
+
+  it("rejects a Distribution that does not exist", async () => {
+    // Given a simulated CloudFront without the requested Distribution.
+    const simCloudFront = new SimAws().cloudFront();
+
+    // When the missing Distribution is updated.
+    const error = await assertThrowsErrorAsync(async () =>
+      simCloudFront.updateDistribution(
+        new UpdateDistributionCommand({
+          Id: "EMISSINGDISTRIB",
+          DistributionConfig: distributionConfig(),
+        }),
+      ),
+    );
+
+    // Then CloudFront answers with its missing-Distribution error.
+    assertInstanceOf(error, SimCloudFrontNoSuchDistribution);
+  });
+
+  it("requires a DistributionConfig", async () => {
+    // Given an existing Distribution.
+    const distro = await givenDistribution();
+
+    // When an update arrives without a config.
+    const error = await assertThrowsErrorAsync(async () =>
+      distro.simCloudFront.updateDistribution(
+        new UpdateDistributionCommand({
+          Id: distro.distributionId,
+          DistributionConfig: undefined,
+        }),
+      ),
+    );
+
+    // Then it is refused rather than emptying the Distribution.
+    assertInstanceOf(error, Error);
+  });
+
+  it("denies a caller without UpdateDistribution permission", async () => {
+    // Given a Distribution in a simulation with IAM.
+    const distro = await givenDistribution();
+
+    // When an anonymous caller updates it.
+    const error = await assertThrowsErrorAsync(async () =>
+      distro.simCloudFront.updateDistribution(
+        new UpdateDistributionCommand({
+          Id: distro.distributionId,
+          DistributionConfig: distributionConfig({ Enabled: false }),
+        }),
+        { caller: { kind: "anonymous" } },
+      ),
+    );
+
+    // Then IAM denies the action, and the Distribution stays enabled.
+    assertInstanceOf(error, SimIamAccessDenied);
+    assertIdentical(error.action, "cloudfront:UpdateDistribution");
+    assertTrue(
+      distro.simCloudFront.getSimDistributionById(distro.distributionId)
+        ?.enabled,
+    );
+  });
+});

--- a/src/service/cloudfront/command/update-distribution/update-distribution.iso.test.ts
+++ b/src/service/cloudfront/command/update-distribution/update-distribution.iso.test.ts
@@ -177,6 +177,48 @@ describe("CloudFront UpdateDistributionCommand", () => {
     );
   });
 
+  it("refuses an alternate domain name another Distribution holds", async () => {
+    // Given two Distributions, one of them answering on an alternate domain
+    // name.
+    const distro = await givenDistribution(["taken.updatable.test"]);
+    const other = await distro.simCloudFront.createDistribution(
+      new CreateDistributionCommand({
+        DistributionConfig: distributionConfig({
+          CallerReference: "other-distribution",
+          Aliases: { Quantity: 1, Items: ["own.updatable.test"] },
+        }),
+      }),
+    );
+    await distro.simAws.backgroundTasksComplete();
+    assertNonNullable(other.Distribution?.Id);
+
+    // When the second Distribution is updated to claim the first one's name.
+    await assertThrowsErrorAsync(async () =>
+      distro.simCloudFront.updateDistribution(
+        new UpdateDistributionCommand({
+          Id: other.Distribution?.Id,
+          DistributionConfig: distributionConfig({
+            CallerReference: "other-distribution",
+            Aliases: { Quantity: 1, Items: ["taken.updatable.test"] },
+          }),
+        }),
+      ),
+    );
+
+    // Then it is left as it was, rather than half updated: it still answers on
+    // its own name, and the name it tried to take still routes to the first
+    // Distribution.
+    const registry = distro.simAws.serviceFactory.cloudFrontRegistry;
+    assertIdentical(
+      registry.distributionIdForAlternateDomainName("own.updatable.test"),
+      other.Distribution.Id,
+    );
+    assertIdentical(
+      registry.distributionIdForAlternateDomainName("taken.updatable.test"),
+      distro.distributionId,
+    );
+  });
+
   it("refuses an unusable viewer certificate, leaving the Distribution alone", async () => {
     // Given an enabled Distribution.
     const distro = await givenDistribution();

--- a/src/service/cloudfront/distribution/configurator/sim-cf-distribution-configurator.factory.ts
+++ b/src/service/cloudfront/distribution/configurator/sim-cf-distribution-configurator.factory.ts
@@ -1,0 +1,28 @@
+import type { SimCfCustomOriginDispatcher } from "../../origin/custom/sim-cf-custom-origin-dispatcher.js";
+import type { SimCloudFrontS3OriginResolver } from "../../origin/s3/sim-cloudfront-s3-origin.js";
+import { SimCloudFrontBehaviorConfigurator } from "./sim-cloud-front-behavior-configurator.js";
+import { SimCloudFrontDistributionConfigurator } from "./sim-cloud-front-distribution-configurator.js";
+import { SimCloudFrontOriginConfigurator } from "./sim-cloud-front-origin-configurator.js";
+
+interface SimCloudFrontConfiguratorOrigins {
+  readonly s3OriginResolver: SimCloudFrontS3OriginResolver;
+  readonly customOriginDispatcher?: SimCfCustomOriginDispatcher | undefined;
+}
+
+/**
+ * Build the configurator that applies a DistributionConfig to a Distribution.
+ *
+ * Creation and update apply the same config the same way, so they build the
+ * same set of configurators.
+ */
+export function makeSimCloudFrontDistributionConfigurator(
+  origins: SimCloudFrontConfiguratorOrigins,
+): SimCloudFrontDistributionConfigurator {
+  return new SimCloudFrontDistributionConfigurator(
+    new SimCloudFrontOriginConfigurator(
+      origins.s3OriginResolver,
+      origins.customOriginDispatcher,
+    ),
+    new SimCloudFrontBehaviorConfigurator(),
+  );
+}

--- a/src/service/cloudfront/distribution/sim-cf-distribution-reconfigurer.ts
+++ b/src/service/cloudfront/distribution/sim-cf-distribution-reconfigurer.ts
@@ -1,0 +1,55 @@
+import type { SimCloudFrontDistributionConfig } from "../command/create-distribution/create-distribution.command.js";
+import type { SimCfCustomOriginDispatcher } from "../origin/custom/sim-cf-custom-origin-dispatcher.js";
+import type { SimCloudFrontS3OriginResolver } from "../origin/s3/sim-cloudfront-s3-origin.js";
+import type { SimCloudFrontRegistry } from "../registry/sim-cloud-front-registry.js";
+import { makeSimCloudFrontDistributionConfigurator } from "./configurator/sim-cf-distribution-configurator.factory.js";
+import type { SimCloudFrontDistributionConfigurator } from "./configurator/sim-cloud-front-distribution-configurator.js";
+import type { SimCloudFrontDistribution } from "./sim-cloudfront-distribution.js";
+
+interface SimCloudFrontDistributionReconfigurerProperties {
+  readonly cloudFrontRegistry: SimCloudFrontRegistry;
+  readonly s3OriginResolver: SimCloudFrontS3OriginResolver;
+  readonly customOriginDispatcher?: SimCfCustomOriginDispatcher | undefined;
+}
+
+/**
+ * Applies a replacement DistributionConfig to a Distribution already in place.
+ *
+ * CloudFront takes a whole DistributionConfig on an update rather than a
+ * patch, so an update is a replacement: everything derived from the previous
+ * config is dropped, and the new one is applied by the same configurators that
+ * apply it at creation.
+ */
+export class SimCloudFrontDistributionReconfigurer {
+  private readonly cloudFrontRegistry: SimCloudFrontRegistry;
+  private readonly configurator: SimCloudFrontDistributionConfigurator;
+
+  constructor(properties: SimCloudFrontDistributionReconfigurerProperties) {
+    this.cloudFrontRegistry = properties.cloudFrontRegistry;
+    this.configurator = makeSimCloudFrontDistributionConfigurator(properties);
+  }
+
+  /**
+   * Apply a replacement DistributionConfig, resynchronizing the alternate
+   * domain names the Distribution answers on so a name the update drops is
+   * free for another Distribution.
+   */
+  reconfigure(
+    distribution: SimCloudFrontDistribution,
+    distributionConfig: SimCloudFrontDistributionConfig,
+  ): void {
+    const { distributionId } = distribution;
+
+    this.cloudFrontRegistry.deregisterAlternateDomainNames(distributionId);
+
+    distribution.replaceConfiguration(distributionConfig);
+    this.configurator.configure(distribution, distributionConfig);
+
+    for (const alternateDomainName of distribution.getAlternateDomainNames()) {
+      this.cloudFrontRegistry.registerAlternateDomainName(
+        alternateDomainName,
+        distributionId,
+      );
+    }
+  }
+}

--- a/src/service/cloudfront/distribution/sim-cf-distribution-reconfigurer.ts
+++ b/src/service/cloudfront/distribution/sim-cf-distribution-reconfigurer.ts
@@ -33,12 +33,21 @@ export class SimCloudFrontDistributionReconfigurer {
    * Apply a replacement DistributionConfig, resynchronizing the alternate
    * domain names the Distribution answers on so a name the update drops is
    * free for another Distribution.
+   *
+   * A name another Distribution already holds is refused before anything is
+   * changed, so a rejected update leaves the Distribution as it was rather
+   * than half replaced.
    */
   reconfigure(
     distribution: SimCloudFrontDistribution,
     distributionConfig: SimCloudFrontDistributionConfig,
   ): void {
     const { distributionId } = distribution;
+
+    this.cloudFrontRegistry.assertAlternateDomainNamesAvailable(
+      distributionConfig.Aliases?.Items ?? [],
+      distributionId,
+    );
 
     this.cloudFrontRegistry.deregisterAlternateDomainNames(distributionId);
 

--- a/src/service/cloudfront/distribution/sim-cf-distribution-view.ts
+++ b/src/service/cloudfront/distribution/sim-cf-distribution-view.ts
@@ -1,0 +1,45 @@
+import type { SimCloudFrontDistributionConfig } from "../command/create-distribution/create-distribution.command.js";
+import type { SimCloudFrontDistribution } from "./sim-cloudfront-distribution.js";
+
+/**
+ * Minimal structural sim CloudFront Distribution, as the API returns it.
+ *
+ * CreateDistribution, GetDistribution and UpdateDistribution all answer with
+ * this same shape, so they all build it here.
+ */
+export interface SimCloudFrontDistributionView {
+  readonly Id?: string | undefined;
+  readonly ARN?: string | undefined;
+  readonly Status?: string | undefined;
+  readonly LastModifiedTime?: Date | undefined;
+  readonly InProgressInvalidationBatches?: number | undefined;
+  readonly DomainName?: string | undefined;
+  readonly DistributionConfig?: SimCloudFrontDistributionConfig | undefined;
+}
+
+/**
+ * Build the API view of a sim CloudFront Distribution.
+ */
+export function simCloudFrontDistributionView(
+  distribution: SimCloudFrontDistribution,
+): SimCloudFrontDistributionView {
+  return {
+    Id: distribution.distributionId,
+    ARN: simCloudFrontDistributionArn(distribution),
+    Status: distribution.status,
+    LastModifiedTime: distribution.lastModifiedTime,
+    InProgressInvalidationBatches: 0,
+    DomainName: `${distribution.distributionId.toLowerCase()}.cloudfront.net`,
+    DistributionConfig: distribution.distributionConfig,
+  };
+}
+
+/**
+ * Build the ARN of a sim CloudFront Distribution. CloudFront is not
+ * region-scoped, so the Region segment of the ARN is always empty.
+ */
+export function simCloudFrontDistributionArn(
+  distribution: SimCloudFrontDistribution,
+): string {
+  return `arn:aws:cloudfront::${distribution.accountId}:distribution/${distribution.distributionId}`;
+}

--- a/src/service/cloudfront/distribution/sim-cf-distro-config.factory.ts
+++ b/src/service/cloudfront/distribution/sim-cf-distro-config.factory.ts
@@ -8,6 +8,7 @@ import type { SimCfnTemplateValue } from "../../cloudformation/template/value/si
 export const simCfDistroConfigFactory = new DynamicFactory<
   SimCloudFrontDistributionConfig & SimCfnTemplateValue
 >(() => ({
+  Enabled: true,
   Origins: {
     Items: [
       {

--- a/src/service/cloudfront/distribution/sim-cloudfront-distribution.ts
+++ b/src/service/cloudfront/distribution/sim-cloudfront-distribution.ts
@@ -9,6 +9,7 @@ import {
 } from "../../aws/sim-aws-account.js";
 import type { SimCloudFrontDistributionConfig } from "../command/create-distribution/create-distribution.command.js";
 import { type SimClock, SimRealClock } from "../../../util/clock/sim-clock.js";
+import { SimCloudFrontDistributionNotDisabled } from "../error/sim-cloudfront.error.js";
 
 export type SimCloudFrontDistributionId = Brand<
   string,
@@ -35,13 +36,13 @@ interface SimCloudFrontDistributionProperties {
 export class SimCloudFrontDistribution {
   public readonly distributionId: SimCloudFrontDistributionId;
   public readonly accountId: SimAwsAccountId;
-  public readonly distributionConfig:
-    SimCloudFrontDistributionConfig | undefined;
   public readonly behaviors: SimCloudFrontBehavior[] = [];
   public readonly customErrorResponses: SimCloudFrontCustomErrorResponse[] = [];
   public readonly lastModifiedTime: Date;
 
   #status: SimCloudFrontDistributionStatus;
+  #distributionConfig: SimCloudFrontDistributionConfig | undefined;
+  #enabled: boolean;
   #defaultRootObject: string | undefined;
   private readonly alternateDomainNames = new Set<string>();
 
@@ -60,7 +61,8 @@ export class SimCloudFrontDistribution {
     this.distributionId = distributionId;
     this.#status = status;
     this.accountId = accountId;
-    this.distributionConfig = distributionConfig;
+    this.#distributionConfig = distributionConfig;
+    this.#enabled = distributionConfig?.Enabled ?? true;
   }
 
   /**
@@ -68,6 +70,20 @@ export class SimCloudFrontDistribution {
    */
   get status(): SimCloudFrontDistributionStatus {
     return this.#status;
+  }
+
+  /**
+   * Get the DistributionConfig this sim Distribution was configured from.
+   */
+  get distributionConfig(): SimCloudFrontDistributionConfig | undefined {
+    return this.#distributionConfig;
+  }
+
+  /**
+   * Whether this sim Distribution is enabled, and so serving requests.
+   */
+  get enabled(): boolean {
+    return this.#enabled;
   }
 
   /**
@@ -90,6 +106,44 @@ export class SimCloudFrontDistribution {
   completeDeployment(): Promise<void> {
     this.#status = "Deployed";
     return Promise.resolve();
+  }
+
+  /**
+   * Replace this sim Distribution's configuration, clearing everything derived
+   * from the previous one.
+   *
+   * CloudFront takes a whole DistributionConfig on an update rather than a
+   * patch, so an update is a replacement here too: the caller applies the new
+   * config from scratch, the same way creation does. The Distribution goes
+   * back into Deploying while that happens, as it does in AWS.
+   */
+  replaceConfiguration(
+    distributionConfig: SimCloudFrontDistributionConfig,
+  ): void {
+    this.#distributionConfig = distributionConfig;
+    this.#enabled = distributionConfig.Enabled ?? true;
+    this.#status = "Deploying";
+    this.#defaultRootObject = undefined;
+    this.behaviors.length = 0;
+    this.customErrorResponses.length = 0;
+    this.alternateDomainNames.clear();
+    this.origins.clear();
+  }
+
+  /**
+   * Refuse deletion while this sim Distribution is still enabled.
+   *
+   * CloudFront will not delete a Distribution that is still serving, so the
+   * real sequence is UpdateDistribution with `Enabled: false` and then
+   * DeleteDistribution. Nothing here waits for the disable to deploy, which
+   * real CloudFront does before it accepts the deletion.
+   */
+  assertDeletable(): void {
+    if (this.#enabled) {
+      throw new SimCloudFrontDistributionNotDisabled(
+        `Sim CloudFront Distribution ${this.distributionId} is enabled, so it cannot be deleted. Disable it with UpdateDistribution first.`,
+      );
+    }
   }
 
   /**

--- a/src/service/cloudfront/error/sim-cloudfront.error.ts
+++ b/src/service/cloudfront/error/sim-cloudfront.error.ts
@@ -89,3 +89,43 @@ export class SimCloudFrontResourceNotFoundException extends SimCloudFrontError {
     super(message, { httpStatusCode: 404 });
   }
 }
+
+/**
+ * Simulated CloudFront NoSuchDistribution error.
+ *
+ * What CloudFront answers when a Distribution ID names nothing.
+ */
+export class SimCloudFrontNoSuchDistribution extends SimCloudFrontError {
+  public override readonly name = "NoSuchDistribution";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 404 });
+  }
+}
+
+/**
+ * Simulated CloudFront NoSuchFunctionExists error.
+ *
+ * What CloudFront answers when a Function name names nothing.
+ */
+export class SimCloudFrontNoSuchFunctionExists extends SimCloudFrontError {
+  public override readonly name = "NoSuchFunctionExists";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 404 });
+  }
+}
+
+/**
+ * Simulated CloudFront DistributionNotDisabled error.
+ *
+ * CloudFront will not delete a Distribution that is still serving. The caller
+ * disables it with UpdateDistribution first.
+ */
+export class SimCloudFrontDistributionNotDisabled extends SimCloudFrontError {
+  public override readonly name = "DistributionNotDisabled";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 409 });
+  }
+}

--- a/src/service/cloudfront/registry/sim-cloud-front-registry.iso.test.ts
+++ b/src/service/cloudfront/registry/sim-cloud-front-registry.iso.test.ts
@@ -1,7 +1,13 @@
-import { assertStringIncludes, assertThrowsError } from "@kensio/smartass";
+import {
+  assertIdentical,
+  assertStringIncludes,
+  assertThrowsError,
+  assertUndefined,
+} from "@kensio/smartass";
 import { describe, it } from "vitest";
 import { SimCloudFrontRegistry } from "./sim-cloud-front-registry.js";
 import type { SimCloudFrontDistributionId } from "../distribution/sim-cloudfront-distribution.js";
+import type { SimAwsAccountId } from "../../aws/sim-aws-account.js";
 
 describe("SimCloudFrontRegistry", () => {
   it("throws when an alternate domain name is registered to a different Distribution", () => {
@@ -22,6 +28,54 @@ describe("SimCloudFrontRegistry", () => {
     assertStringIncludes(
       error.message,
       "Sim CloudFront alternate domain name cdn.example.test is already registered to Distribution EDISTRIBUTION01",
+    );
+  });
+
+  it("releases an alternate domain name once its Distribution is deregistered", () => {
+    // Given a Distribution registered with an alternate domain name.
+    const registry = new SimCloudFrontRegistry();
+    const distributionId = "EDISTRIBUTION01" as SimCloudFrontDistributionId;
+
+    registry.registerDistribution(
+      distributionId,
+      "111111111111" as SimAwsAccountId,
+    );
+    registry.registerAlternateDomainName("cdn.example.test", distributionId);
+
+    // When the Distribution is deregistered.
+    registry.deregisterDistribution(distributionId);
+
+    // Then nothing is left pointing at it, and another Distribution can take
+    // the alternate domain name.
+    assertUndefined(registry.accountIdForDistribution(distributionId));
+    assertUndefined(
+      registry.distributionIdForAlternateDomainName("cdn.example.test"),
+    );
+
+    registry.registerAlternateDomainName(
+      "cdn.example.test",
+      "EDISTRIBUTION02" as SimCloudFrontDistributionId,
+    );
+    assertIdentical(
+      registry.distributionIdForAlternateDomainName("cdn.example.test"),
+      "EDISTRIBUTION02",
+    );
+  });
+
+  it("ignores a Distribution ID that was never registered", () => {
+    // Given a registry that has never seen the Distribution ID.
+    const registry = new SimCloudFrontRegistry();
+
+    // When it is deregistered anyway.
+    registry.deregisterDistribution(
+      "EDISTRIBUTION03" as SimCloudFrontDistributionId,
+    );
+
+    // Then nothing happens, rather than a failure part way through a deletion.
+    assertUndefined(
+      registry.accountIdForDistribution(
+        "EDISTRIBUTION03" as SimCloudFrontDistributionId,
+      ),
     );
   });
 });

--- a/src/service/cloudfront/registry/sim-cloud-front-registry.ts
+++ b/src/service/cloudfront/registry/sim-cloud-front-registry.ts
@@ -61,6 +61,43 @@ export class SimCloudFrontRegistry {
   }
 
   /**
+   * Deregister a simulated CloudFront Distribution ID.
+   *
+   * Request routing reads this registry rather than one Account's own
+   * Distribution map, so deregistering is what stops a deleted Distribution
+   * serving. The alternate domain names it answered on go with it, leaving
+   * them free for another Distribution.
+   */
+  deregisterDistribution(distributionId: SimCloudFrontDistributionId): void {
+    const accountId = this.distributionAccountIds.get(distributionId);
+
+    this.distributionAccountIds.delete(distributionId);
+
+    if (accountId !== undefined) {
+      this.accountDistributionIds.get(accountId)?.delete(distributionId);
+    }
+
+    this.deregisterAlternateDomainNames(distributionId);
+  }
+
+  /**
+   * Deregister every alternate domain name held by a Distribution ID.
+   *
+   * An update replaces a Distribution's Aliases wholesale, so the old names
+   * are dropped before the new ones are registered.
+   */
+  deregisterAlternateDomainNames(
+    distributionId: SimCloudFrontDistributionId,
+  ): void {
+    for (const [alternateDomainName, registeredDistributionId] of this
+      .alternateDomainDistributionIds) {
+      if (registeredDistributionId === distributionId) {
+        this.alternateDomainDistributionIds.delete(alternateDomainName);
+      }
+    }
+  }
+
+  /**
    * Register an alternate domain name to a simulated CloudFront Distribution ID.
    */
   registerAlternateDomainName(

--- a/src/service/cloudfront/registry/sim-cloud-front-registry.ts
+++ b/src/service/cloudfront/registry/sim-cloud-front-registry.ts
@@ -104,22 +104,42 @@ export class SimCloudFrontRegistry {
     alternateDomainName: string,
     distributionId: SimCloudFrontDistributionId,
   ): void {
-    const existingDistributionId =
-      this.alternateDomainDistributionIds.get(alternateDomainName);
-
-    if (
-      existingDistributionId !== undefined &&
-      existingDistributionId !== distributionId
-    ) {
-      throw new Error(
-        `Sim CloudFront alternate domain name ${alternateDomainName} is already registered to Distribution ${existingDistributionId}`,
-      );
-    }
+    this.assertAlternateDomainNamesAvailable(
+      [alternateDomainName],
+      distributionId,
+    );
 
     this.alternateDomainDistributionIds.set(
       alternateDomainName,
       distributionId,
     );
+  }
+
+  /**
+   * Check that a Distribution can take every one of a set of alternate domain
+   * names, without registering any of them.
+   *
+   * An update applies its Aliases wholesale, so it asks this first: a name
+   * another Distribution already holds is refused while the Distribution being
+   * updated is still intact, rather than half way through being replaced.
+   */
+  assertAlternateDomainNamesAvailable(
+    alternateDomainNames: Iterable<string>,
+    distributionId: SimCloudFrontDistributionId,
+  ): void {
+    for (const alternateDomainName of alternateDomainNames) {
+      const existingDistributionId =
+        this.alternateDomainDistributionIds.get(alternateDomainName);
+
+      if (
+        existingDistributionId !== undefined &&
+        existingDistributionId !== distributionId
+      ) {
+        throw new Error(
+          `Sim CloudFront alternate domain name ${alternateDomainName} is already registered to Distribution ${existingDistributionId}`,
+        );
+      }
+    }
   }
 
   /**

--- a/src/service/cloudfront/sdk/sim-cloudfront-sdk-command-router.iso.test.ts
+++ b/src/service/cloudfront/sdk/sim-cloudfront-sdk-command-router.iso.test.ts
@@ -3,8 +3,11 @@ import {
   CloudFrontClient,
   CreateDistributionCommand,
   CreateFunctionCommand,
+  CreateInvalidationCommand,
   DeleteDistributionCommand,
+  DeleteFunctionCommand,
   GetDistributionCommand,
+  UpdateDistributionCommand,
 } from "@aws-sdk/client-cloudfront";
 import { CreateBucketCommand } from "@aws-sdk/client-s3";
 import {
@@ -12,6 +15,7 @@ import {
   assertNonNullable,
   assertStringIncludes,
   assertThrowsErrorAsync,
+  assertUndefined,
 } from "@kensio/smartass";
 import { SimSdk } from "../../../sdk/index.js";
 import type { SimCloudFrontFunctionName } from "../cff/sim-cloudfront-function.js";
@@ -53,11 +57,46 @@ describe("simulated CloudFront SDK Command routing", () => {
     );
 
     assertNonNullable(distroCreation.Distribution?.Id);
+    const distributionId = distroCreation.Distribution.Id;
     const distroOut = await client.send(
-      new GetDistributionCommand({ Id: distroCreation.Distribution.Id }),
+      new GetDistributionCommand({ Id: distributionId }),
     );
 
-    assertIdentical(distroOut.Distribution?.Id, distroCreation.Distribution.Id);
+    assertIdentical(distroOut.Distribution?.Id, distributionId);
+
+    // Disabling and then deleting goes through the router the same way.
+    await client.send(
+      new UpdateDistributionCommand({
+        Id: distributionId,
+        IfMatch: "E2QWRUHAPOMQZL",
+        DistributionConfig: {
+          CallerReference: "sdk-intercept-ref-1",
+          DefaultRootObject: "index.html",
+          Origins: {
+            Items: [
+              {
+                Id: "origin1",
+                DomainName: "origin-bucket.s3.amazonaws.com",
+                S3OriginConfig: { OriginAccessIdentity: "" },
+              },
+            ],
+            Quantity: 1,
+          },
+          DefaultCacheBehavior: {
+            TargetOriginId: "origin1",
+            ViewerProtocolPolicy: "redirect-to-https",
+            AllowedMethods: { Items: ["GET", "HEAD"], Quantity: 2 },
+          },
+          Comment: "SDK intercepted distribution",
+          Enabled: false,
+        },
+      }),
+    );
+    await client.send(new DeleteDistributionCommand({ Id: distributionId }));
+
+    assertUndefined(
+      simSdk.simAws.cloudFront().getSimDistributionById(distributionId),
+    );
   });
 
   it("routes CreateFunctionCommand through an intercepted client", async () => {
@@ -88,6 +127,22 @@ describe("simulated CloudFront SDK Command routing", () => {
           "intercepted-cff" as SimCloudFrontFunctionName,
         ),
     );
+
+    // Deleting it again goes through the router the same way.
+    await client.send(
+      new DeleteFunctionCommand({
+        Name: "intercepted-cff",
+        IfMatch: "E2QWRUHAPOMQZL",
+      }),
+    );
+
+    assertUndefined(
+      simSdk.simAws
+        .cloudFront()
+        .getCloudFrontFunctionByName(
+          "intercepted-cff" as SimCloudFrontFunctionName,
+        ),
+    );
   });
 
   it("rejects a Command simulated CloudFront does not support", async () => {
@@ -96,10 +151,18 @@ describe("simulated CloudFront SDK Command routing", () => {
     simSdk.intercept(client);
 
     const error = await assertThrowsErrorAsync(async () => {
-      await client.send(new DeleteDistributionCommand({ Id: "D123" }));
+      await client.send(
+        new CreateInvalidationCommand({
+          DistributionId: "D123",
+          InvalidationBatch: {
+            CallerReference: "unsupported",
+            Paths: { Quantity: 1, Items: ["/*"] },
+          },
+        }),
+      );
     });
 
-    assertStringIncludes(error.message, "DeleteDistributionCommand");
+    assertStringIncludes(error.message, "CreateInvalidationCommand");
     assertStringIncludes(error.message, "CreateDistributionCommand");
   });
 });

--- a/src/service/cloudfront/sdk/sim-cloudfront-sdk-command-router.ts
+++ b/src/service/cloudfront/sdk/sim-cloudfront-sdk-command-router.ts
@@ -5,7 +5,10 @@ import {
 } from "../../../sdk/index.js";
 import type { SimCreateDistributionCommand } from "../command/create-distribution/create-distribution.command.js";
 import type { SimCreateFunctionCommand } from "../command/create-function/create-function.command.js";
+import type { SimDeleteDistributionCommand } from "../command/delete-distribution/delete-distribution.command.js";
+import type { SimDeleteFunctionCommand } from "../command/delete-function/delete-function.command.js";
 import type { SimGetDistributionCommand } from "../command/get-distribution/get-distribution.command.js";
+import type { SimUpdateDistributionCommand } from "../command/update-distribution/update-distribution.command.js";
 import type { SimCloudFront } from "../sim-cloudfront.js";
 
 /**
@@ -34,10 +37,34 @@ export class SimCloudFrontSdkCommandRouter implements SimSdkCommandRouter {
           ),
       ],
       [
+        "DeleteDistributionCommand",
+        async (command, context): Promise<unknown> =>
+          await simCloudFront.deleteDistribution(
+            command as SimDeleteDistributionCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "DeleteFunctionCommand",
+        async (command, context): Promise<unknown> =>
+          await simCloudFront.deleteFunction(
+            command as SimDeleteFunctionCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
         "GetDistributionCommand",
         async (command, context): Promise<unknown> =>
           await simCloudFront.getDistribution(
             command as SimGetDistributionCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "UpdateDistributionCommand",
+        async (command, context): Promise<unknown> =>
+          await simCloudFront.updateDistribution(
+            command as SimUpdateDistributionCommand,
             simSdkCallerOptions(context),
           ),
       ],

--- a/src/service/cloudfront/sim-cloudfront-commands.ts
+++ b/src/service/cloudfront/sim-cloudfront-commands.ts
@@ -1,0 +1,246 @@
+import {
+  type BackgroundScheduler,
+  BackgroundTasks,
+} from "../../util/background/background.js";
+import type { SimAcmRegistry } from "../acm/registry/sim-acm-registry.js";
+import type { SimAwsCaller } from "../aws/caller/sim-aws-caller.js";
+import type { SimAwsAccountRegionScope } from "../aws/sim-aws-account-region-scope.js";
+import type { SimAwsAccountId } from "../aws/sim-aws-account.js";
+import {
+  SimIamAllowAllAuth,
+  type SimIamInterServiceAuthZ,
+} from "../iam/authorize/sim-iam-inter-service-auth-z.js";
+import type {
+  SimCreateDistributionCommand,
+  SimCreateDistributionCommandOutput,
+} from "./command/create-distribution/create-distribution.command.js";
+import { CreateDistributionCommandHandler } from "./command/create-distribution/create-distribution.handler.js";
+import type {
+  SimCreateFunctionCommand,
+  SimCreateFunctionCommandOutput,
+} from "./command/create-function/create-function.command.js";
+import {
+  CreateFunctionCommandHandler,
+  type SimCloudFrontFunctionMap,
+} from "./command/create-function/create-function.handler.js";
+import type {
+  SimDeleteDistributionCommand,
+  SimDeleteDistributionCommandOutput,
+} from "./command/delete-distribution/delete-distribution.command.js";
+import { DeleteDistributionCommandHandler } from "./command/delete-distribution/delete-distribution.handler.js";
+import type {
+  SimDeleteFunctionCommand,
+  SimDeleteFunctionCommandOutput,
+} from "./command/delete-function/delete-function.command.js";
+import { DeleteFunctionCommandHandler } from "./command/delete-function/delete-function.handler.js";
+import type {
+  SimGetDistributionCommand,
+  SimGetDistributionCommandOutput,
+} from "./command/get-distribution/get-distribution.command.js";
+import { GetDistributionCommandHandler } from "./command/get-distribution/get-distribution.handler.js";
+import type {
+  SimUpdateDistributionCommand,
+  SimUpdateDistributionCommandOutput,
+} from "./command/update-distribution/update-distribution.command.js";
+import { UpdateDistributionCommandHandler } from "./command/update-distribution/update-distribution.handler.js";
+import type {
+  SimCloudFrontDistribution,
+  SimCloudFrontDistributionId,
+} from "./distribution/sim-cloudfront-distribution.js";
+import type { SimCfCustomOriginDispatcher } from "./origin/custom/sim-cf-custom-origin-dispatcher.js";
+import {
+  emptyCloudFrontS3OriginResolver,
+  type SimCloudFrontS3OriginResolver,
+} from "./origin/s3/sim-cloudfront-s3-origin.js";
+import { SimCloudFrontRegistry } from "./registry/sim-cloud-front-registry.js";
+
+/**
+ * How one simulated CloudFront is put together.
+ */
+export interface SimCloudFrontProperties {
+  readonly accountRegionScope?: SimAwsAccountRegionScope;
+  readonly cloudFrontRegistry?: SimCloudFrontRegistry;
+  readonly s3OriginResolver?: SimCloudFrontS3OriginResolver;
+  readonly customOriginDispatcher?: SimCfCustomOriginDispatcher | undefined;
+  readonly iam?: SimIamInterServiceAuthZ;
+  readonly acmRegistry?: SimAcmRegistry | undefined;
+  readonly background?: BackgroundScheduler;
+}
+
+interface SimCloudFrontCommandsProperties extends SimCloudFrontProperties {
+  readonly accountId: SimAwsAccountId;
+  readonly distributions: SimCloudFrontDistributionMap;
+  readonly cloudFrontFunctions: SimCloudFrontFunctionMap;
+}
+
+/**
+ * Options carried by any simulated CloudFront request.
+ */
+export interface SimCloudFrontRequestOptions {
+  readonly caller?: SimAwsCaller;
+}
+
+export type SimCloudFrontDistributionMap = Map<
+  SimCloudFrontDistributionId,
+  SimCloudFrontDistribution
+>;
+
+/**
+ * The state every Distribution command works on.
+ */
+interface SimCloudFrontDistributionState {
+  readonly accountId: SimAwsAccountId;
+  readonly distributions: SimCloudFrontDistributionMap;
+  readonly cloudFrontRegistry: SimCloudFrontRegistry;
+  readonly iam: SimIamInterServiceAuthZ;
+  readonly background: BackgroundScheduler;
+}
+
+/**
+ * The state every CloudFront Function command works on.
+ */
+interface SimCloudFrontFunctionState {
+  readonly accountId: SimAwsAccountId;
+  readonly cloudFrontFunctions: SimCloudFrontFunctionMap;
+  readonly iam: SimIamInterServiceAuthZ;
+  readonly background: BackgroundScheduler;
+}
+
+/**
+ * The commands of one simulated CloudFront, and the state they share.
+ *
+ * Every command authorizes against the same IAM and works on the same
+ * Distribution and Function maps, so the wiring lives here rather than being
+ * repeated once per command in the service facade. That keeps SimCloudFront
+ * what it should be: state plus delegation.
+ */
+export class SimCloudFrontCommands {
+  private readonly distributionState: SimCloudFrontDistributionState;
+  private readonly functionState: SimCloudFrontFunctionState;
+  private readonly s3OriginResolver: SimCloudFrontS3OriginResolver;
+  private readonly customOriginDispatcher:
+    SimCfCustomOriginDispatcher | undefined;
+  private readonly acmRegistry: SimAcmRegistry | undefined;
+
+  constructor(properties: SimCloudFrontCommandsProperties) {
+    const {
+      accountId,
+      distributions,
+      cloudFrontFunctions,
+      cloudFrontRegistry = new SimCloudFrontRegistry(),
+      s3OriginResolver = emptyCloudFrontS3OriginResolver,
+      customOriginDispatcher,
+      iam = new SimIamAllowAllAuth(),
+      acmRegistry,
+      background = new BackgroundTasks(),
+    } = properties;
+
+    this.distributionState = {
+      accountId,
+      distributions,
+      cloudFrontRegistry,
+      iam,
+      background,
+    };
+    this.functionState = {
+      accountId,
+      cloudFrontFunctions,
+      iam,
+      background,
+    };
+    this.s3OriginResolver = s3OriginResolver;
+    this.customOriginDispatcher = customOriginDispatcher;
+    this.acmRegistry = acmRegistry;
+  }
+
+  /**
+   * Handle a Create Distribution Command from the SDK.
+   */
+  async createDistribution(
+    command: SimCreateDistributionCommand,
+    options?: SimCloudFrontRequestOptions,
+  ): Promise<SimCreateDistributionCommandOutput> {
+    return await new CreateDistributionCommandHandler({
+      ...this.distributionState,
+      ...this.originState(),
+    }).handle(command, options);
+  }
+
+  /**
+   * Handle a Get Distribution Command from the SDK.
+   */
+  async getDistribution(
+    command: SimGetDistributionCommand,
+    options?: SimCloudFrontRequestOptions,
+  ): Promise<SimGetDistributionCommandOutput> {
+    return await new GetDistributionCommandHandler(
+      this.distributionState,
+    ).handle(command, options);
+  }
+
+  /**
+   * Handle an Update Distribution Command from the SDK.
+   */
+  async updateDistribution(
+    command: SimUpdateDistributionCommand,
+    options?: SimCloudFrontRequestOptions,
+  ): Promise<SimUpdateDistributionCommandOutput> {
+    return await new UpdateDistributionCommandHandler({
+      ...this.distributionState,
+      ...this.originState(),
+    }).handle(command, options);
+  }
+
+  /**
+   * Handle a Delete Distribution Command from the SDK.
+   */
+  async deleteDistribution(
+    command: SimDeleteDistributionCommand,
+    options?: SimCloudFrontRequestOptions,
+  ): Promise<SimDeleteDistributionCommandOutput> {
+    return await new DeleteDistributionCommandHandler(
+      this.distributionState,
+    ).handle(command, options);
+  }
+
+  /**
+   * Handle a Create Function Command from the SDK.
+   */
+  async createFunction(
+    command: SimCreateFunctionCommand,
+    options?: SimCloudFrontRequestOptions,
+  ): Promise<SimCreateFunctionCommandOutput> {
+    return await new CreateFunctionCommandHandler(this.functionState).handle(
+      command,
+      options,
+    );
+  }
+
+  /**
+   * Handle a Delete Function Command from the SDK.
+   */
+  async deleteFunction(
+    command: SimDeleteFunctionCommand,
+    options?: SimCloudFrontRequestOptions,
+  ): Promise<SimDeleteFunctionCommandOutput> {
+    return await new DeleteFunctionCommandHandler(this.functionState).handle(
+      command,
+      options,
+    );
+  }
+
+  /**
+   * How the commands that configure a Distribution reach its Origins.
+   */
+  private originState(): {
+    readonly s3OriginResolver: SimCloudFrontS3OriginResolver;
+    readonly customOriginDispatcher: SimCfCustomOriginDispatcher | undefined;
+    readonly acmRegistry: SimAcmRegistry | undefined;
+  } {
+    return {
+      s3OriginResolver: this.s3OriginResolver,
+      customOriginDispatcher: this.customOriginDispatcher,
+      acmRegistry: this.acmRegistry,
+    };
+  }
+}

--- a/src/service/cloudfront/sim-cloudfront.ts
+++ b/src/service/cloudfront/sim-cloudfront.ts
@@ -1,109 +1,79 @@
-import { SimCloudFrontRegistry } from "./registry/sim-cloud-front-registry.js";
-import { CreateDistributionCommandHandler } from "./command/create-distribution/create-distribution.handler.js";
-import type {
-  SimCloudFrontDistribution,
-  SimCloudFrontDistributionId,
-} from "./distribution/sim-cloudfront-distribution.js";
 import type { SimAwsAccountRegionScope } from "../aws/sim-aws-account-region-scope.js";
-import type {
-  SimCreateDistributionCommand,
-  SimCreateDistributionCommandOutput,
-} from "./command/create-distribution/create-distribution.command.js";
-import {
-  emptyCloudFrontS3OriginResolver,
-  type SimCloudFrontS3OriginResolver,
-} from "./origin/s3/sim-cloudfront-s3-origin.js";
-import type { SimCfCustomOriginDispatcher } from "./origin/custom/sim-cf-custom-origin-dispatcher.js";
-import {
-  type BackgroundScheduler,
-  BackgroundTasks,
-} from "../../util/background/background.js";
-import type {
-  SimGetDistributionCommand,
-  SimGetDistributionCommandOutput,
-} from "./command/get-distribution/get-distribution.command.js";
-import { GetDistributionCommandHandler } from "./command/get-distribution/get-distribution.handler.js";
-import type {
-  SimCreateFunctionCommand,
-  SimCreateFunctionCommandOutput,
-} from "./command/create-function/create-function.command.js";
-import { CreateFunctionCommandHandler } from "./command/create-function/create-function.handler.js";
+import { simAwsAccountRegionScopeFactory } from "../aws/sim-aws-account-region-scope.factory.js";
+import type { SimArn } from "../aws/arn.js";
+import { assertDefined } from "../../util/type-guard/defined.js";
+import type { SimCfnServiceResourceFactory } from "../cloudformation/resource/factory/sim-cfn-resource-factory.type.js";
+import type { SimSdkCommandRouter } from "../../sdk/router/sim-sdk-command-router.type.js";
 import type {
   SimCloudFrontFunction,
   SimCloudFrontFunctionName,
 } from "./cff/sim-cloudfront-function.js";
-import type { SimArn } from "../aws/arn.js";
-import { assertDefined } from "../../util/type-guard/defined.js";
 import { SimCloudFrontCloudFormationResourceFactory } from "./cfn/sim-cfn-cloudfront-resource-factory.js";
-import type { SimCfnServiceResourceFactory } from "../cloudformation/resource/factory/sim-cfn-resource-factory.type.js";
-import { simAwsAccountRegionScopeFactory } from "../aws/sim-aws-account-region-scope.factory.js";
-import type { SimAwsCaller } from "../aws/caller/sim-aws-caller.js";
-import {
-  SimIamAllowAllAuth,
-  type SimIamInterServiceAuthZ,
-} from "../iam/authorize/sim-iam-inter-service-auth-z.js";
+import type {
+  SimCreateDistributionCommand,
+  SimCreateDistributionCommandOutput,
+} from "./command/create-distribution/create-distribution.command.js";
+import type {
+  SimCreateFunctionCommand,
+  SimCreateFunctionCommandOutput,
+} from "./command/create-function/create-function.command.js";
+import type { SimCloudFrontFunctionMap } from "./command/create-function/create-function.handler.js";
+import type {
+  SimDeleteDistributionCommand,
+  SimDeleteDistributionCommandOutput,
+} from "./command/delete-distribution/delete-distribution.command.js";
+import type {
+  SimDeleteFunctionCommand,
+  SimDeleteFunctionCommandOutput,
+} from "./command/delete-function/delete-function.command.js";
+import type {
+  SimGetDistributionCommand,
+  SimGetDistributionCommandOutput,
+} from "./command/get-distribution/get-distribution.command.js";
+import type {
+  SimUpdateDistributionCommand,
+  SimUpdateDistributionCommandOutput,
+} from "./command/update-distribution/update-distribution.command.js";
+import type {
+  SimCloudFrontDistribution,
+  SimCloudFrontDistributionId,
+} from "./distribution/sim-cloudfront-distribution.js";
 import { SimCloudFrontSdkCommandRouter } from "./sdk/sim-cloudfront-sdk-command-router.js";
-import type { SimSdkCommandRouter } from "../../sdk/router/sim-sdk-command-router.type.js";
-import type { SimAcmRegistry } from "../acm/registry/sim-acm-registry.js";
+import {
+  SimCloudFrontCommands,
+  type SimCloudFrontDistributionMap,
+  type SimCloudFrontProperties,
+  type SimCloudFrontRequestOptions,
+} from "./sim-cloudfront-commands.js";
 
-export interface SimCloudFrontRequestOptions {
-  readonly caller?: SimAwsCaller;
-}
-
-interface SimCloudFrontProperties {
-  readonly accountRegionScope?: SimAwsAccountRegionScope;
-  readonly cloudFrontRegistry?: SimCloudFrontRegistry;
-  readonly s3OriginResolver?: SimCloudFrontS3OriginResolver;
-  readonly customOriginDispatcher?: SimCfCustomOriginDispatcher | undefined;
-  readonly iam?: SimIamInterServiceAuthZ;
-  readonly acmRegistry?: SimAcmRegistry | undefined;
-  readonly background?: BackgroundScheduler;
-}
+export type {
+  SimCloudFrontProperties,
+  SimCloudFrontRequestOptions,
+} from "./sim-cloudfront-commands.js";
 
 /**
  * Simulated CloudFront. Handles SDK commands. Emulates AWS behaviour and state.
  */
 export class SimCloudFront {
-  private readonly distributions = new Map<
-    SimCloudFrontDistributionId,
-    SimCloudFrontDistribution
-  >();
-  private readonly cloudFrontFunctions = new Map<
-    SimCloudFrontFunctionName,
-    SimCloudFrontFunction
-  >();
+  private readonly distributions: SimCloudFrontDistributionMap = new Map();
+  private readonly cloudFrontFunctions: SimCloudFrontFunctionMap = new Map();
 
   private readonly accountRegionScope: SimAwsAccountRegionScope;
-  private readonly cloudFrontRegistry: SimCloudFrontRegistry;
-  private readonly s3OriginResolver: SimCloudFrontS3OriginResolver;
-  private readonly customOriginDispatcher:
-    SimCfCustomOriginDispatcher | undefined;
-  private readonly iam: SimIamInterServiceAuthZ;
-  private readonly acmRegistry: SimAcmRegistry | undefined;
-  private readonly background: BackgroundScheduler;
+  private readonly commands: SimCloudFrontCommands;
   private readonly cfnFactory = new SimCloudFrontCloudFormationResourceFactory(
     this,
   );
   private readonly sdkRouter = new SimCloudFrontSdkCommandRouter(this);
 
   constructor(properties: SimCloudFrontProperties = {}) {
-    const {
-      accountRegionScope = simAwsAccountRegionScopeFactory.make(),
-      cloudFrontRegistry = new SimCloudFrontRegistry(),
-      s3OriginResolver = emptyCloudFrontS3OriginResolver,
-      customOriginDispatcher,
-      iam = new SimIamAllowAllAuth(),
-      acmRegistry,
-      background = new BackgroundTasks(),
-    } = properties;
-
-    this.accountRegionScope = accountRegionScope;
-    this.cloudFrontRegistry = cloudFrontRegistry;
-    this.s3OriginResolver = s3OriginResolver;
-    this.customOriginDispatcher = customOriginDispatcher;
-    this.iam = iam;
-    this.acmRegistry = acmRegistry;
-    this.background = background;
+    this.accountRegionScope =
+      properties.accountRegionScope ?? simAwsAccountRegionScopeFactory.make();
+    this.commands = new SimCloudFrontCommands({
+      ...properties,
+      accountId: this.accountRegionScope.accountId,
+      distributions: this.distributions,
+      cloudFrontFunctions: this.cloudFrontFunctions,
+    });
   }
 
   /**
@@ -134,17 +104,7 @@ export class SimCloudFront {
     command: SimCreateDistributionCommand,
     options?: SimCloudFrontRequestOptions,
   ): Promise<SimCreateDistributionCommandOutput> {
-    const handler = new CreateDistributionCommandHandler({
-      accountId: this.accountRegionScope.accountId,
-      distributions: this.distributions,
-      cloudFrontRegistry: this.cloudFrontRegistry,
-      s3OriginResolver: this.s3OriginResolver,
-      customOriginDispatcher: this.customOriginDispatcher,
-      iam: this.iam,
-      acmRegistry: this.acmRegistry,
-      background: this.background,
-    });
-    return await handler.handle(command, options);
+    return await this.commands.createDistribution(command, options);
   }
 
   /**
@@ -154,13 +114,27 @@ export class SimCloudFront {
     command: SimGetDistributionCommand,
     options?: SimCloudFrontRequestOptions,
   ): Promise<SimGetDistributionCommandOutput> {
-    const handler = new GetDistributionCommandHandler({
-      accountId: this.accountRegionScope.accountId,
-      distributions: this.distributions,
-      iam: this.iam,
-      background: this.background,
-    });
-    return await handler.handle(command, options);
+    return await this.commands.getDistribution(command, options);
+  }
+
+  /**
+   * Handle an Update Distribution Command from the SDK.
+   */
+  async updateDistribution(
+    command: SimUpdateDistributionCommand,
+    options?: SimCloudFrontRequestOptions,
+  ): Promise<SimUpdateDistributionCommandOutput> {
+    return await this.commands.updateDistribution(command, options);
+  }
+
+  /**
+   * Handle a Delete Distribution Command from the SDK.
+   */
+  async deleteDistribution(
+    command: SimDeleteDistributionCommand,
+    options?: SimCloudFrontRequestOptions,
+  ): Promise<SimDeleteDistributionCommandOutput> {
+    return await this.commands.deleteDistribution(command, options);
   }
 
   /**
@@ -170,17 +144,21 @@ export class SimCloudFront {
     command: SimCreateFunctionCommand,
     options?: SimCloudFrontRequestOptions,
   ): Promise<SimCreateFunctionCommandOutput> {
-    const handler = new CreateFunctionCommandHandler({
-      accountId: this.accountRegionScope.accountId,
-      cloudFrontFunctions: this.cloudFrontFunctions,
-      iam: this.iam,
-      background: this.background,
-    });
-    return await handler.handle(command, options);
+    return await this.commands.createFunction(command, options);
   }
 
   /**
-   * Get a sim CloudFront Function by name.
+   * Handle a Delete Function Command from the SDK.
+   */
+  async deleteFunction(
+    command: SimDeleteFunctionCommand,
+    options?: SimCloudFrontRequestOptions,
+  ): Promise<SimDeleteFunctionCommandOutput> {
+    return await this.commands.deleteFunction(command, options);
+  }
+
+  /**
+   * Get a sim CloudFront Function by ARN.
    */
   getCloudFrontFunctionByArn(
     cloudFrontFunctionArn: SimArn,


### PR DESCRIPTION
Adds CloudFront `DeleteDistribution`, `UpdateDistribution` and `DeleteFunction`, the third of the delete-operation PRs a simulated Stack teardown needs. Resolves #404.

## Acceptance criteria

- [x] `DeleteDistributionCommand` and `DeleteFunctionCommand` are routed and authorized as `cloudfront:DeleteDistribution` and `cloudfront:DeleteFunction`. Both have a dedicated authorizer running before the state map is read, so an unauthorized caller cannot learn whether the resource exists.
- [x] A deleted Distribution stops serving. Deletion deregisters it from `SimCloudFrontRegistry`, which is what request routing reads, and the alternate domain names it answered on go with it. Covered by tests that serve a request to the CloudFront domain and to an alternate domain before and after the deletion.
- [x] Deleting something that is not there answers `NoSuchDistribution` and `NoSuchFunctionExists`.
- [x] A Distribution carries Enabled state, `UpdateDistribution` can change it, and deleting an enabled Distribution answers `DistributionNotDisabled`. The rule lives on the resource model as `assertDeletable`, alongside `SimRoute53HostedZone`.
- [x] A disabled Distribution deletes.
- [x] The unchecked `IfMatch` is documented as a divergence, in a new Limitations section on the CloudFront docs page.

## UpdateDistribution

The issue asks for enough of `UpdateDistribution` to flip Enabled. It is implemented as a real update rather than an Enabled-only special case, because CloudFront takes a whole `DistributionConfig` rather than a patch: `replaceConfiguration` on the Distribution drops everything derived from the previous config, and the same configurators creation uses then apply the new one. Anything left out of the new config is therefore dropped, which is what AWS does. The alternate domain names are resynchronized in the registry around that, so a name an update drops is free for another Distribution.

## Divergences

All four are recorded in the new Limitations section of `docs/services/cloudfront/README.md`:

- `IfMatch` is accepted and not checked on all three commands, so neither `PreconditionFailed` nor `InvalidIfMatchVersion` is ever returned. This is the decision recorded on the issue.
- A deletion does not wait for the disable to deploy. Real CloudFront needs the disabled Distribution to reach `Deployed` first; here `Enabled: false` is enough.
- A disabled Distribution still serves requests. Real CloudFront answers a disabled Distribution with a 403. Only deleting one stops it serving here.
- `DeleteFunction` never answers `FunctionInUse`, because nothing tells a CloudFront Function that a cache Behavior has taken it up.

## Also in here

- `SimCloudFront` gained the command parts class S3, Lambda, IAM and KMS already have. The facade was at 224 lines and three more commands would not fit under the 300 line limit.
- `simCloudFrontDistributionView` replaces the Distribution output shape that create, get and update would otherwise each build.
- The update handler tripped the FTA threshold at 58, so the reconfiguration moved onto `SimCloudFrontDistributionReconfigurer` and the configurator wiring onto a shared factory.
- The SDK router test's "rejects a Command simulated CloudFront does not support" case used `DeleteDistributionCommand`, which is now supported, so it uses `CreateInvalidationCommand` instead.

One thing left alone: `GetDistribution` still answers a missing Distribution with `ResourceNotFoundException` rather than `NoSuchDistribution`, which is what real CloudFront returns. Changing it is out of scope here but worth a follow-up.

`pnpm run check` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for updating and deleting CloudFront distributions.
  * Added support for deleting CloudFront functions.
  * Enforced disabling distributions before deletion.
  * Distribution updates now replace the complete configuration and refresh alternate-domain mappings.
  * Added IAM authorization for update and delete operations.

* **Documentation**
  * Expanded CloudFront documentation with usage examples, deletion guidance, and service limitations.

* **Bug Fixes**
  * Improved cleanup of distribution and alternate-domain registrations after deletion or reconfiguration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->