### PR TITLE
fix: GetDistribution throws NoSuchDistribution

### DIFF
--- a/src/service/cloudfront/command/get-distribution/get-distribution.handler.ts
+++ b/src/service/cloudfront/command/get-distribution/get-distribution.handler.ts
@@ -8,7 +8,7 @@ import type {
   SimCloudFrontDistributionId,
 } from "../../distribution/sim-cloudfront-distribution.js";
 import { simCloudFrontDistributionView } from "../../distribution/sim-cf-distribution-view.js";
-import { SimCloudFrontResourceNotFoundException } from "../../error/sim-cloudfront.error.js";
+import { SimCloudFrontNoSuchDistribution } from "../../error/sim-cloudfront.error.js";
 import {
   type BackgroundScheduler,
   BackgroundTasks,
@@ -84,7 +84,7 @@ export class GetDistributionCommandHandler implements CommandHandler<
 
     const distribution = this.distributions.get(distributionId);
     if (distribution === undefined) {
-      throw new SimCloudFrontResourceNotFoundException(
+      throw new SimCloudFrontNoSuchDistribution(
         `No sim CloudFront Distribution with ID ${distributionId}`,
       );
     }

--- a/src/service/cloudfront/command/get-distribution/get-distribution.iso.test.ts
+++ b/src/service/cloudfront/command/get-distribution/get-distribution.iso.test.ts
@@ -11,7 +11,7 @@ import {
   assertThrowsErrorAsync,
 } from "@kensio/smartass";
 import { SimAws } from "../../../aws/sim-aws.js";
-import { SimCloudFrontResourceNotFoundException } from "../../error/sim-cloudfront.error.js";
+import { SimCloudFrontNoSuchDistribution } from "../../error/sim-cloudfront.error.js";
 import { CreateBucketCommand } from "@aws-sdk/client-s3";
 
 describe("CloudFront GetDistributionCommand", () => {
@@ -107,6 +107,6 @@ describe("CloudFront GetDistributionCommand", () => {
         new GetDistributionCommand({ Id: "NonExistentDistribution" }),
       ),
     );
-    assertInstanceOf(error, SimCloudFrontResourceNotFoundException);
+    assertInstanceOf(error, SimCloudFrontNoSuchDistribution);
   });
 });

--- a/src/service/cloudfront/error/sim-cloudfront.error.ts
+++ b/src/service/cloudfront/error/sim-cloudfront.error.ts
@@ -80,17 +80,6 @@ export class SimCloudFrontInvalidArgument extends SimCloudFrontError {
 }
 
 /**
- * Simulated CloudFront ResourceNotFoundException error.
- */
-export class SimCloudFrontResourceNotFoundException extends SimCloudFrontError {
-  public override readonly name = "ResourceNotFoundException";
-
-  constructor(message: string) {
-    super(message, { httpStatusCode: 404 });
-  }
-}
-
-/**
  * Simulated CloudFront NoSuchDistribution error.
  *
  * What CloudFront answers when a Distribution ID names nothing.


### PR DESCRIPTION
Real CloudFront answers a request for a missing Distribution with `NoSuchDistribution`. The simulated `GetDistributionCommand` threw `SimCloudFrontResourceNotFoundException` instead, so it disagreed both with real CloudFront and with the `DeleteDistribution` and `UpdateDistribution` handlers added in #411.

- `GetDistributionCommandHandler` now throws `SimCloudFrontNoSuchDistribution`.
- The colocated iso test asserts the new type.
- `SimCloudFrontResourceNotFoundException` is removed: the handler and that test were its only two users, and no references remain.

`pnpm run check` passes: 780 test files, 4844 tests, coverage threshold met.