### PR TITLE
feat: delete Stack Resources through their services

### DIFF
--- a/src/service/acm/cfn/sim-cfn-acm-resource-factory.ts
+++ b/src/service/acm/cfn/sim-cfn-acm-resource-factory.ts
@@ -5,6 +5,8 @@ import type {
 import type { SimCfnServiceResourceFactory } from "../../cloudformation/resource/factory/sim-cfn-resource-factory.type.js";
 import { SimAcm } from "../sim-acm.js";
 import { SimCfnAcmCertificateCreator } from "./certificate/sim-cfn-acm-cert-creator.js";
+import type { SimAcmCertificate } from "../certificate/sim-acm-certificate.js";
+import { assertDefined } from "../../../util/type-guard/defined.js";
 
 interface SimAcmCfnResourceFactoryProperties {
   readonly acm?: SimAcm | undefined;
@@ -14,11 +16,13 @@ interface SimAcmCfnResourceFactoryProperties {
  * CloudFormation Resource factory for simulated ACM resources.
  */
 export class SimAcmCfnResourceFactory implements SimCfnServiceResourceFactory {
+  private readonly acm: SimAcm;
   private readonly certificateCreator: SimCfnAcmCertificateCreator;
 
   constructor(properties: SimAcmCfnResourceFactoryProperties = {}) {
     const { acm = new SimAcm() } = properties;
 
+    this.acm = acm;
     this.certificateCreator = new SimCfnAcmCertificateCreator({ acm });
   }
 
@@ -40,5 +44,33 @@ export class SimAcmCfnResourceFactory implements SimCfnServiceResourceFactory {
         );
       }
     }
+  }
+
+  /**
+   * Delete a simulated ACM resource created from a CloudFormation Resource.
+   *
+   * DeleteCertificate refuses a certificate that is still in use, so a
+   * certificate a CloudFront Distribution still names comes down after that
+   * Distribution, which the teardown order arranges.
+   */
+  async delete(
+    resourceTypeName: string,
+    resource: SimCfnResource,
+  ): Promise<void> {
+    if (resourceTypeName !== "Certificate") {
+      throw new Error(
+        `Unsupported sim ACM CloudFormation Resource ${resourceTypeName} deletion`,
+      );
+    }
+
+    const certificate = resource.simResource as SimAcmCertificate | undefined;
+    assertDefined(
+      certificate,
+      `sim ACM certificate for CloudFormation Resource ${resource.logicalId}`,
+    );
+
+    await this.acm.deleteCertificate({
+      input: { CertificateArn: certificate.certificateArn },
+    });
   }
 }

--- a/src/service/acm/cfn/sim-cfn-acm-teardown.iso.test.ts
+++ b/src/service/acm/cfn/sim-cfn-acm-teardown.iso.test.ts
@@ -1,0 +1,43 @@
+import { assertArrayLength, assertIdentical } from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { ListCertificatesCommand } from "@aws-sdk/client-acm";
+
+import { SimAws } from "../../aws/sim-aws.js";
+
+describe("ACM CloudFormation Resource teardown", () => {
+  it("deletes the certificate a Stack issued", async () => {
+    // Given a deployed certificate.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "certificate-stack",
+      template: {
+        Resources: {
+          SiteCertificate: {
+            Type: "AWS::CertificateManager::Certificate",
+            Properties: {
+              DomainName: "example.test",
+              ValidationMethod: "DNS",
+            },
+          },
+        },
+      },
+    });
+    await stack.waitForDeployComplete();
+    await simAws.backgroundTasksComplete();
+
+    // When the Stack's Resources are torn down.
+    await stack.teardown();
+    await simAws.backgroundTasksComplete();
+
+    // Then ACM no longer lists it.
+    const listed = await simAws
+      .acm()
+      .listCertificates(new ListCertificatesCommand());
+
+    assertArrayLength(listed.CertificateSummaryList, 0);
+    assertIdentical(
+      stack.resources.get("SiteCertificate")?.status,
+      "DELETE_COMPLETE",
+    );
+  });
+});

--- a/src/service/apigatewayv2/cfn/sim-cfn-api-gateway-v2-resource-deleter.ts
+++ b/src/service/apigatewayv2/cfn/sim-cfn-api-gateway-v2-resource-deleter.ts
@@ -1,0 +1,52 @@
+import type { SimCfnResource } from "../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimApiGatewayV2 } from "../sim-api-gateway-v2.js";
+import type { SimHttpApi } from "../api/sim-http-api.js";
+import { SimCfnHttpApiPartDeleter } from "./sim-cfn-http-api-part-deleter.js";
+import { assertDefined } from "../../../util/type-guard/defined.js";
+
+interface SimCfnApiGatewayV2ResourceDeleterProperties {
+  readonly apiGatewayV2: SimApiGatewayV2;
+}
+
+/**
+ * Deletes the simulated API Gateway v2 resources a CloudFormation Stack
+ * created.
+ *
+ * The API itself is the only Resource type addressed by nothing but its own
+ * object. Everything else is a part of an API, and is deleted by
+ * SimCfnHttpApiPartDeleter, which knows to find the API first.
+ */
+export class SimCfnApiGatewayV2ResourceDeleter {
+  private readonly apiGatewayV2: SimApiGatewayV2;
+  private readonly partDeleter: SimCfnHttpApiPartDeleter;
+
+  constructor(properties: SimCfnApiGatewayV2ResourceDeleterProperties) {
+    this.apiGatewayV2 = properties.apiGatewayV2;
+    this.partDeleter = new SimCfnHttpApiPartDeleter(properties);
+  }
+
+  /**
+   * Delete a simulated API Gateway v2 resource created from a CloudFormation
+   * Resource.
+   */
+  async delete(
+    resourceTypeName: string,
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): Promise<void> {
+    if (resourceTypeName !== "Api") {
+      await this.partDeleter.delete(resourceTypeName, resource, properties);
+
+      return;
+    }
+
+    const api = resource.simResource as SimHttpApi | undefined;
+    assertDefined(
+      api,
+      `sim HTTP API for CloudFormation Resource ${resource.logicalId}`,
+    );
+
+    await this.apiGatewayV2.deleteApi({ input: { ApiId: api.apiId } });
+  }
+}

--- a/src/service/apigatewayv2/cfn/sim-cfn-api-gateway-v2-resource-factory.ts
+++ b/src/service/apigatewayv2/cfn/sim-cfn-api-gateway-v2-resource-factory.ts
@@ -10,6 +10,8 @@ import { SimCfnHttpApiIntegrationCreator } from "./integration/sim-cfn-http-api-
 import { SimCfnHttpApiRouteCreator } from "./route/sim-cfn-http-api-route-creator.js";
 import { SimCfnHttpApiImports } from "./sim-cfn-http-api-imports.js";
 import { SimCfnHttpApiStageCreator } from "./stage/sim-cfn-http-api-stage-creator.js";
+import { SimCfnApiGatewayV2ResourceDeleter } from "./sim-cfn-api-gateway-v2-resource-deleter.js";
+import type { SimCloudFormationResourceDeleteContext } from "../../cloudformation/resource/sim-cfn-resource.type.js";
 
 /**
  * The Resource types belonging to a WebSocket API, which is the half of API
@@ -34,6 +36,7 @@ export class SimApiGatewayV2CfnResourceFactory implements SimCfnServiceResourceF
   private readonly integrationCreator: SimCfnHttpApiIntegrationCreator;
   private readonly routeCreator: SimCfnHttpApiRouteCreator;
   private readonly stageCreator: SimCfnHttpApiStageCreator;
+  private readonly deleter: SimCfnApiGatewayV2ResourceDeleter;
 
   constructor(properties: SimApiGatewayV2CfnResourceFactoryProperties) {
     const { apiGatewayV2 } = properties;
@@ -53,6 +56,7 @@ export class SimApiGatewayV2CfnResourceFactory implements SimCfnServiceResourceF
       imports,
     });
     this.stageCreator = new SimCfnHttpApiStageCreator({ apiGatewayV2 });
+    this.deleter = new SimCfnApiGatewayV2ResourceDeleter({ apiGatewayV2 });
   }
 
   /**
@@ -92,6 +96,22 @@ export class SimApiGatewayV2CfnResourceFactory implements SimCfnServiceResourceF
         );
       }
     }
+  }
+
+  /**
+   * Delete a simulated API Gateway v2 resource created from a CloudFormation
+   * Resource.
+   */
+  async delete(
+    resourceTypeName: string,
+    resource: SimCfnResource,
+    context: SimCloudFormationResourceDeleteContext,
+  ): Promise<void> {
+    await this.deleter.delete(
+      resourceTypeName,
+      resource,
+      context.resolvedProperties ?? resource.properties,
+    );
   }
 
   /**

--- a/src/service/apigatewayv2/cfn/sim-cfn-http-api-part-deleter.ts
+++ b/src/service/apigatewayv2/cfn/sim-cfn-http-api-part-deleter.ts
@@ -1,0 +1,113 @@
+import type { SimCfnResource } from "../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimApiGatewayV2 } from "../sim-api-gateway-v2.js";
+import type { SimHttpApiAuthorizer } from "../api/authorizer/sim-http-api-authorizer.js";
+import type { SimHttpApiIntegration } from "../api/integration/sim-http-api-integration.js";
+import type { SimHttpApiRoute } from "../api/route/sim-http-api-route.js";
+import type { SimHttpApiStage } from "../api/stage/sim-http-api-stage.js";
+import { assertDefined } from "../../../util/type-guard/defined.js";
+
+interface SimCfnHttpApiPartDeleterProperties {
+  readonly apiGatewayV2: SimApiGatewayV2;
+}
+
+/**
+ * Deletes the parts of an HTTP API a CloudFormation Stack declared as their own
+ * Resources.
+ *
+ * Each is addressed by the API it belongs to and its own id. The API id comes
+ * from the Resource's `ApiId` property, which is where creation read it from,
+ * and still resolves because the API outlives everything declared on it.
+ *
+ * Deleting an integration a route still targets is refused, which the teardown
+ * order avoids: a route's `Target` names its integration, so the route goes
+ * first.
+ */
+export class SimCfnHttpApiPartDeleter {
+  private readonly apiGatewayV2: SimApiGatewayV2;
+
+  constructor(properties: SimCfnHttpApiPartDeleterProperties) {
+    this.apiGatewayV2 = properties.apiGatewayV2;
+  }
+
+  /**
+   * Delete one part of an HTTP API, or report a part type nothing deletes.
+   */
+  async delete(
+    resourceTypeName: string,
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): Promise<void> {
+    const apiId = this.apiId(resource, properties);
+
+    switch (resourceTypeName) {
+      case "Authorizer": {
+        const { authorizerId } = this.part<SimHttpApiAuthorizer>(resource);
+
+        await this.apiGatewayV2.deleteAuthorizer({
+          input: { ApiId: apiId, AuthorizerId: authorizerId },
+        });
+
+        return;
+      }
+      case "Integration": {
+        const { integrationId } = this.part<SimHttpApiIntegration>(resource);
+
+        await this.apiGatewayV2.deleteIntegration({
+          input: { ApiId: apiId, IntegrationId: integrationId },
+        });
+
+        return;
+      }
+      case "Route": {
+        const { routeId } = this.part<SimHttpApiRoute>(resource);
+
+        await this.apiGatewayV2.deleteRoute({
+          input: { ApiId: apiId, RouteId: routeId },
+        });
+
+        return;
+      }
+      case "Stage": {
+        const { stageName } = this.part<SimHttpApiStage>(resource);
+
+        await this.apiGatewayV2.deleteStage({
+          input: { ApiId: apiId, StageName: stageName },
+        });
+
+        return;
+      }
+      default: {
+        throw new Error(
+          `Unsupported sim API Gateway v2 CloudFormation Resource ${resourceTypeName} deletion`,
+        );
+      }
+    }
+  }
+
+  private part<T extends object>(resource: SimCfnResource): T {
+    const part = resource.simResource as T | undefined;
+    assertDefined(
+      part,
+      `sim HTTP API part for CloudFormation Resource ${resource.logicalId}`,
+    );
+
+    return part;
+  }
+
+  private apiId(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): string {
+    const apiId = properties["ApiId"];
+
+    /* v8 ignore if -- creation refused the Resource without an ApiId string */
+    if (typeof apiId !== "string") {
+      throw new TypeError(
+        `AWS::ApiGatewayV2 Resource ${resource.logicalId} requires an ApiId string to delete`,
+      );
+    }
+
+    return apiId;
+  }
+}

--- a/src/service/apigatewayv2/cfn/sim-cfn-http-api-teardown.iso.test.ts
+++ b/src/service/apigatewayv2/cfn/sim-cfn-http-api-teardown.iso.test.ts
@@ -1,0 +1,78 @@
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import type { SimHttpApi } from "../api/sim-http-api.js";
+import {
+  simCfnHttpApiRouteLogicalId,
+  simCfnHttpApiTemplateFactory,
+} from "./sim-cfn-http-api-template.factory.js";
+
+describe("HTTP API CloudFormation Resource teardown", () => {
+  it("deletes an API after the routes, integration and stage on it", async () => {
+    // Given a deployed HTTP API in front of a Lambda function, which is the
+    // six-Resource shape CDK synthesises.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: simCfnHttpApiTemplateFactory.make({
+        routeKeys: ["GET /orders"],
+      }),
+    });
+    await stack.waitForDeployComplete();
+
+    const api = stack.resources.get("Api")?.simResource as
+      SimHttpApi | undefined;
+    assertNonNullable(api);
+
+    // When the Stack's Resources are torn down.
+    await stack.teardown();
+
+    // Then the API is gone. Deleting an integration a route still targets is
+    // refused, so this only completes in the order the teardown chose.
+    assertUndefined(simAws.apiGatewayV2().findApi(api.apiId));
+
+    for (const logicalId of [
+      simCfnHttpApiRouteLogicalId(0),
+      "Integration",
+      "Stage",
+      "Api",
+    ]) {
+      assertIdentical(
+        stack.resources.get(logicalId)?.status,
+        "DELETE_COMPLETE",
+        `${logicalId} status`,
+      );
+    }
+  });
+
+  it("deletes the function, its permission and its Role with the API", async () => {
+    // Given the same Stack, whose Lambda half is a function, the permission
+    // API Gateway invokes it under, and the execution Role.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "handler-stack",
+      template: simCfnHttpApiTemplateFactory.make({
+        routeKeys: ["GET /orders"],
+      }),
+    });
+    await stack.waitForDeployComplete();
+
+    assertNonNullable(simAws.lambda().getSimFunctionByName("orders"));
+
+    // When the Stack's Resources are torn down.
+    await stack.teardown();
+
+    // Then the function and the Role it ran as are both gone.
+    assertUndefined(simAws.lambda().getSimFunctionByName("orders"));
+    assertUndefined(simAws.iam().roles.get("orders-role" as never));
+    assertIdentical(
+      stack.resources.get("HandlerPermission")?.status,
+      "DELETE_COMPLETE",
+    );
+  });
+});

--- a/src/service/cloudformation/README.md
+++ b/src/service/cloudformation/README.md
@@ -30,7 +30,8 @@ familiar CloudFormation/CDK outputs.
 - `parameters/` contains parameter input/default handling.
 - `resource/` contains the runtime CloudFormation resource model, resource type parsing, dependency
   extraction, property resolution, and service factory resolution.
-- `stack/` contains the runtime stack model and dependency-ordered deployment lifecycle.
+- `stack/` contains the runtime stack model, the dependency-ordered deployment lifecycle, and the
+  reverse-ordered teardown under `teardown/`.
 - `cdk/` contains CDK-specific integration support, including synthesized output context and custom
   resource implementations.
 - `bind/` contains executable resource binding types used by CDK/custom-resource simulation.
@@ -78,21 +79,24 @@ The implementation is split into several layers:
 - `SimCfnStackPendingResources`
 - `SimCfnStackResourceBatchCreator`
 - Schedule deployment in the background and create resources in dependency-ready batches.
+- `SimCfnStackResourceDeleter`, `SimCfnStackPendingDeletions` and
+  `SimCfnStackResourceBatchDeleter` do the same in reverse for a teardown.
 
 6. **Resource model**
 
-- `SimCfnResource`
-- `SimCfnResourceCreateOperation`
-- `SimCfnResourceCreator`
+- `SimCfnResource` and `SimCfnResourceRecord`
+- `SimCfnResourceCreateOperation` and `SimCfnResourceDeleteOperation`
+- `SimCfnResourceCreator` and `SimCfnResourceDeleter`
 - Track individual resource lifecycle state, dependencies, resolved properties, Ref/GetAtt values,
-  and underlying simulated service resource.
+  and underlying simulated service resource. What a resource is belongs to the record; what has
+  happened to it belongs to the lifecycle half.
 
 7. **Service-specific resource factories**
 
 - `SimCfnCfnResourceFactory`
 - S3 and CloudFront factories exposed by those service simulators
 - CDK/custom factories such as the bucket deployment custom resource
-- Convert a CloudFormation resource into an actual simulated service object.
+- Convert a CloudFormation resource into an actual simulated service object, and remove it again.
 
 This separation is important. CloudFormation owns orchestration and lifecycle; individual services
 own how their own resources are created and represented.
@@ -374,6 +378,88 @@ for a test.
 
 Skipped resources are also recorded on the stack in `skippedResources` for diagnostics.
 
+## Resource teardown loop
+
+`SimCfnStackResourceDeleter` owns the reverse-dependency-ordered deletion loop, and mirrors
+`SimCfnStackResourceCreator` batch for batch:
+
+1. Start with all resources pending.
+2. Ask `SimCfnStackPendingDeletions` for resources nothing still standing depends on.
+3. If no resources are deletable, fail because the teardown cannot make progress.
+4. Delete the ready batch.
+5. Remove resources that reached a terminal delete status.
+6. Repeat until no resources remain pending.
+
+The graph is the one creation already reads, turned round. `simCfnResourceDependents` inverts the
+`dependencies()` each resource reports, so a resource waits for the resources naming it rather than
+for the resources it names.
+
+This ordering is what makes the individual service deleters workable. A bucket policy is taken off
+before its bucket goes, a role's policies before the role, and a route before the integration it
+targets. It also means every `Ref` a resource carries still resolves while that resource is being
+deleted, so deletion can resolve properties the same way creation does rather than remembering what
+creation resolved.
+
+`SimCfnStack.teardown()` is the entry point. It is deliberately only the resource half: stack-level
+delete status, releasing the stack name, and the `DeleteStack` command itself sit on top of it.
+
+## Resource deletion lifecycle
+
+`SimCfnResourceDeleteOperation` owns the asynchronous lifecycle for deleting one resource, and is
+the mirror image of the creation operation.
+
+A resource keeps its creation status until deletion starts, at which point it becomes
+`DELETE_IN_PROGRESS`. The work is scheduled through the background scheduler, and then:
+
+1. background sequencing runs
+2. `SimCfnResourceDeleter` removes the underlying simulated service resource
+3. the resource is marked `DELETE_COMPLETE`
+
+If deletion throws:
+
+- an "unsupported resource" diagnostic marks the deletion skipped, which is `DELETE_COMPLETE` with a
+  reason, exactly as an unsupported resource type is `CREATE_COMPLETE` with one
+- other failures mark the resource `DELETE_FAILED` and reject
+
+A resource that never reached simulated AWS is not passed to its service at all. That covers a
+resource whose type was skipped, and one a failed deployment never got as far as, so a partly
+deployed stack can still be torn down.
+
+Skipped deletions are read off the resources as `stack.skippedResourceDeletions`, the same way
+ignored properties are, so the stack and its resources cannot disagree.
+
+Deletion statuses live on `SimCfnResourceDeletionState`, separate from `SimCfnResourceCreationState`
+rather than sharing one field, because the two answer different questions: what the resource became,
+and what happened when the stack asked for it back.
+
+## Service-specific resource deletion
+
+`SimCfnServiceResourceFactory` has a `delete` alongside `create`, and the engine calls it the same
+way: parse the resource type, resolve the owning service's factory, resolve properties, delegate.
+CloudFormation orchestrates; services delete.
+
+Which command removes a resource type, and what has to be true first, belongs to the service. Real
+CloudFormation does that extra step itself, and so do these deleters:
+
+- a CloudFront distribution is disabled with `UpdateDistribution` before `DeleteDistribution`, which
+  refuses an enabled one
+- an IAM role has its attached and inline policies taken off before `DeleteRole`, which refuses a
+  role that still has any
+- an SQS queue policy is removed by setting the `Policy` attribute to an empty string, because SQS
+  has no `DeleteQueuePolicy`
+- a Route53 record set is removed by a `DELETE` change, because Route53 only takes changes
+
+Two of them stop short on purpose, because AWS does:
+
+- an S3 bucket holding objects fails the teardown with `BucketNotEmpty` rather than being emptied
+  first. That refusal is the reason CDK ships an `autoDeleteObjects` custom resource, and hiding it
+  would hide the difference between a stack that can be deleted and one that cannot.
+- a KMS key is scheduled for deletion and left in `PendingDeletion`, because `ScheduleKeyDeletion` is
+  the only deletion KMS has.
+
+A resource type a service can create but cannot delete throws the same unsupported-resource error an
+unknown type does, so the teardown records it and carries on.
+
 ## Service-specific resource creation
 
 `SimCfnResourceCreator` bridges CloudFormation resources to simulated service resources.
@@ -636,6 +722,9 @@ Useful areas:
 - `stack/deploy/*.iso.test.ts`
   - dependency-ordered resource creation and deployment failure behaviour
 
+- `stack/teardown/*.iso.test.ts`
+  - reverse-dependency-ordered resource deletion and teardown failure behaviour
+
 - `cdk/**/*.loc.test.ts`
   - higher-level CDK synthesized template scenarios
   - local integration of CloudFormation, S3, CloudFront, assets, and custom resources
@@ -656,7 +745,8 @@ When extending simulated CloudFormation:
 - resolve parameters before runtime resource creation
 - resolve resource references only when dependencies are complete
 - keep dependency ordering in the stack/resource orchestration layer
-- add service-specific CloudFormation resource creation to the owning service simulator
+- add service-specific CloudFormation resource creation and deletion to the owning service
+  simulator
 - prefer resource value adapters for `Ref` and `Fn::GetAtt` behaviour
 - do not import real AWS SDK packages from implementation code under `src/`
 - define local structural command/template types that are compatible with SDK-shaped inputs
@@ -665,6 +755,7 @@ When extending simulated CloudFormation:
 - add focused isolated tests for new template/resource behaviour
 - add local integration tests when the full served/CDK/filesystem path matters
 
-The most important design rule is: CloudFormation orchestrates; services create. If a change
+The most important design rule is: CloudFormation orchestrates; services create, and services
+delete. If a change
 requires knowledge of a service's resource schema or runtime object model, it probably belongs in
 that service's CloudFormation resource factory rather than in the generic CloudFormation engine.

--- a/src/service/cloudformation/cdk/s3/bucket-deployment/sim-cdk-bucket-deployment.ts
+++ b/src/service/cloudformation/cdk/s3/bucket-deployment/sim-cdk-bucket-deployment.ts
@@ -36,6 +36,24 @@ export class SimCdkBucketDeploymentResourceFactory implements SimCfnServiceResou
     return undefined;
   }
 
+  /**
+   * Undeploy a CDK BucketDeployment.
+   *
+   * Nothing happens, because nothing happens on AWS either. The provider
+   * function keeps what it deployed unless the construct was given
+   * `retainOnDelete: false`, so the Objects stay in the Bucket, and the
+   * Bucket's own deletion is refused while they do.
+   */
+  async delete(resourceTypeName: string): Promise<void> {
+    await Promise.resolve();
+
+    if (resourceTypeName !== "CDKBucketDeployment") {
+      throw new Error(
+        `Unsupported sim CDK BucketDeployment Resource ${resourceTypeName} deletion`,
+      );
+    }
+  }
+
   private createCdkBucketDeployment(
     resource: SimCfnResource,
     context: SimCloudFormationResourceCreateContext,

--- a/src/service/cloudformation/cdk/s3/bucket-deployment/sim-cdk-bucket-deployment.ts
+++ b/src/service/cloudformation/cdk/s3/bucket-deployment/sim-cdk-bucket-deployment.ts
@@ -49,7 +49,8 @@ export class SimCdkBucketDeploymentResourceFactory implements SimCfnServiceResou
 
     if (resourceTypeName !== "CDKBucketDeployment") {
       throw new Error(
-        `Unsupported sim CDK BucketDeployment Resource ${resourceTypeName} deletion`,
+        `Unsupported sim CDK BucketDeployment CloudFormation Resource ` +
+          `${resourceTypeName} deletion`,
       );
     }
   }

--- a/src/service/cloudformation/cdk/s3/bucket-notifications/sim-cdk-bucket-notifications-remover.ts
+++ b/src/service/cloudformation/cdk/s3/bucket-notifications/sim-cdk-bucket-notifications-remover.ts
@@ -1,0 +1,54 @@
+import type {
+  SimCfnResource,
+  SimCloudFormationResourceDeleteContext,
+} from "../../../resource/sim-cfn-resource.js";
+import { bucketNotificationsError } from "./error/sim-cdk-bucket-notification-error.js";
+import { SimCdkBucketNotificationProperties } from "./property/sim-cdk-bucket-notification-properties.js";
+
+/**
+ * Removes the notification configuration a Custom::S3BucketNotifications
+ * Resource put on a Bucket.
+ *
+ * The CDK provider function empties the configuration on its Delete event, and
+ * an empty PutBucketNotificationConfiguration is how that is said in the SDK,
+ * so that is the call made here.
+ *
+ * The Bucket itself is deleted after this, because the Resource names the
+ * Bucket and so comes down first.
+ */
+export class SimCdkBucketNotificationsRemover {
+  /**
+   * Put an empty notification configuration back on the Resource's Bucket.
+   */
+  async remove(
+    resourceTypeName: string,
+    resource: SimCfnResource,
+    context: SimCloudFormationResourceDeleteContext,
+  ): Promise<void> {
+    /* v8 ignore if -- defensive catch; the resolver routes on this name */
+    if (resourceTypeName !== "S3BucketNotifications") {
+      throw bucketNotificationsError(
+        resource.logicalId,
+        `${resourceTypeName} is not a Resource type this factory deletes`,
+      );
+    }
+
+    const properties = new SimCdkBucketNotificationProperties(
+      resource.logicalId,
+      context.resolvedProperties ?? resource.properties,
+    );
+
+    await context.simAws
+      .accountRegionScope(
+        resource.accountRegionScope.accountId,
+        resource.accountRegionScope.regionName,
+      )
+      .s3()
+      .putBucketNotificationConfiguration({
+        input: {
+          Bucket: properties.bucketName,
+          NotificationConfiguration: {},
+        },
+      });
+  }
+}

--- a/src/service/cloudformation/cdk/s3/bucket-notifications/sim-cdk-bucket-notifications-teardown.iso.test.ts
+++ b/src/service/cloudformation/cdk/s3/bucket-notifications/sim-cdk-bucket-notifications-teardown.iso.test.ts
@@ -1,0 +1,37 @@
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../../aws/sim-aws.js";
+import { simCdkBucketNotificationsTemplateFactory } from "./sim-cdk-bucket-notifications-template.factory.js";
+
+describe("CDK Bucket notifications teardown", () => {
+  it("empties the notification configuration it put on the Bucket", async () => {
+    // Given a deployed Bucket notifying a function, which is what CDK
+    // synthesises for bucket.addEventNotification(...).
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "uploads-stack",
+      template: simCdkBucketNotificationsTemplateFactory.make({}),
+    });
+    await stack.waitForDeployComplete();
+
+    const bucket = simAws.s3().getSimBucketByName("uploads");
+    assertNonNullable(bucket);
+    assertArrayLength(bucket.getNotifications().lambdaNotifications, 1);
+
+    // When the Stack's Resources are torn down.
+    await stack.teardown();
+
+    // Then the configuration is off the Bucket, as the CDK provider function
+    // takes it off on its own Delete event.
+    assertArrayLength(bucket.getNotifications().lambdaNotifications, 0);
+    assertIdentical(
+      stack.resources.get("BucketNotifications")?.status,
+      "DELETE_COMPLETE",
+    );
+  });
+});

--- a/src/service/cloudformation/cdk/s3/bucket-notifications/sim-cdk-bucket-notifications.ts
+++ b/src/service/cloudformation/cdk/s3/bucket-notifications/sim-cdk-bucket-notifications.ts
@@ -2,10 +2,12 @@ import type { SimCfnServiceResourceFactory } from "../../../resource/factory/sim
 import type {
   SimCfnResource,
   SimCloudFormationResourceCreateContext,
+  SimCloudFormationResourceDeleteContext,
 } from "../../../resource/sim-cfn-resource.js";
 import { SimCdkBucketNotificationConfiguration } from "./configuration/sim-cdk-bucket-notification-configuration.js";
 import { bucketNotificationsError } from "./error/sim-cdk-bucket-notification-error.js";
 import { SimCdkBucketNotificationProperties } from "./property/sim-cdk-bucket-notification-properties.js";
+import { SimCdkBucketNotificationsRemover } from "./sim-cdk-bucket-notifications-remover.js";
 
 /**
  * CloudFormation Resource factory for CDK Bucket event notifications.
@@ -67,5 +69,24 @@ export class SimCdkBucketNotificationsResourceFactory implements SimCfnServiceRe
       });
 
     return undefined;
+  }
+
+  /**
+   * Take the Bucket's notification configuration back off again.
+   *
+   * The CDK provider function does the same on its Delete event: the
+   * configuration it put on is the configuration it removes, by putting an
+   * empty one back.
+   */
+  async delete(
+    resourceTypeName: string,
+    resource: SimCfnResource,
+    context: SimCloudFormationResourceDeleteContext,
+  ): Promise<void> {
+    await new SimCdkBucketNotificationsRemover().remove(
+      resourceTypeName,
+      resource,
+      context,
+    );
   }
 }

--- a/src/service/cloudformation/resource/create/sim-cfn-resource-create-operation.ts
+++ b/src/service/cloudformation/resource/create/sim-cfn-resource-create-operation.ts
@@ -5,6 +5,7 @@ import type {
 } from "../sim-cfn-resource.js";
 import type { SimCfnServiceResourceFactory } from "../factory/sim-cfn-resource-factory.type.js";
 import { SimCfnResourceCreator } from "./sim-cfn-resource-creator.js";
+import { isSimCfnUnsupportedResourceError } from "../unsupported/sim-cfn-unsupported-resource.js";
 
 interface SimCfnResourceCreateOperationProperties<T extends object> {
   readonly background: BackgroundScheduler;
@@ -56,7 +57,7 @@ export class SimCfnResourceCreateOperation<T extends object = object> {
           this.resource.markCreateComplete(simResource as T | undefined);
           resolve();
         } catch (error) {
-          if (this.isUnsupportedResourceError(error)) {
+          if (isSimCfnUnsupportedResourceError(error)) {
             const reason =
               error instanceof Error ? error.message : String(error);
 
@@ -73,14 +74,6 @@ export class SimCfnResourceCreateOperation<T extends object = object> {
         }
       });
     });
-  }
-
-  private isUnsupportedResourceError(error: unknown): boolean {
-    return (
-      error instanceof Error &&
-      error.message.includes("Unsupported sim") &&
-      error.message.includes("CloudFormation")
-    );
   }
 
   private resourceCreationError(error: unknown): Error {

--- a/src/service/cloudformation/resource/delete/sim-cfn-resource-delete-operation.ts
+++ b/src/service/cloudformation/resource/delete/sim-cfn-resource-delete-operation.ts
@@ -1,0 +1,88 @@
+import type { BackgroundScheduler } from "../../../../util/background/background.js";
+import type { SimCfnResource } from "../sim-cfn-resource.js";
+import type { SimCloudFormationResourceDeleteContext } from "../sim-cfn-resource.type.js";
+import type { SimCfnServiceResourceFactory } from "../factory/sim-cfn-resource-factory.type.js";
+import { SimCfnResourceDeleter } from "./sim-cfn-resource-deleter.js";
+import { isSimCfnUnsupportedResourceError } from "../unsupported/sim-cfn-unsupported-resource.js";
+
+interface SimCfnResourceDeleteOperationProperties<T extends object> {
+  readonly background: BackgroundScheduler;
+  readonly resource: SimCfnResource<T>;
+  readonly cfnResourceFactory?: SimCfnServiceResourceFactory | undefined;
+}
+
+/**
+ * Runs the asynchronous CloudFormation Resource deletion lifecycle.
+ *
+ * The mirror image of `SimCfnResourceCreateOperation`: it schedules the
+ * delete work in the background, moves the Resource through delete states, and
+ * turns a thrown failure into Resource failure state.
+ *
+ * It does not know how to remove the underlying simulated AWS service Resource.
+ * That responsibility belongs to {@link SimCfnResourceDeleter}.
+ */
+export class SimCfnResourceDeleteOperation<T extends object = object> {
+  private readonly background: BackgroundScheduler;
+  private readonly resource: SimCfnResource<T>;
+  private readonly deleter: SimCfnResourceDeleter<T>;
+
+  constructor(properties: SimCfnResourceDeleteOperationProperties<T>) {
+    this.background = properties.background;
+    this.resource = properties.resource;
+    this.deleter = new SimCfnResourceDeleter({
+      resource: properties.resource,
+      cfnResourceFactory: properties.cfnResourceFactory,
+    });
+  }
+
+  /**
+   * Start Resource deletion as a background operation.
+   *
+   * The returned Promise resolves or rejects with the background delete work,
+   * while the Resource itself is updated through CloudFormation delete states:
+   * in progress before scheduling, complete after the deleter returns, skipped
+   * if nothing can delete the Resource type, or failed if the deleter throws.
+   */
+  run(context: SimCloudFormationResourceDeleteContext): Promise<void> {
+    this.resource.markDeleteInProgress();
+
+    return new Promise<void>((resolve, reject) => {
+      this.background.schedule(async () => {
+        try {
+          await this.background.sequence();
+
+          await this.deleter.delete(context);
+          this.resource.markDeleteComplete();
+          resolve();
+        } catch (error) {
+          if (isSimCfnUnsupportedResourceError(error)) {
+            const reason =
+              error instanceof Error ? error.message : String(error);
+
+            this.resource.markDeleteSkipped(reason);
+            resolve();
+
+            return;
+          }
+
+          const resourceError = this.resourceDeletionError(error);
+
+          this.resource.markDeleteFailed(resourceError);
+          reject(resourceError);
+        }
+      });
+    });
+  }
+
+  private resourceDeletionError(error: unknown): Error {
+    const messagePrefix = `Sim CloudFormation Resource ${this.resource.logicalId} deletion failed`;
+
+    if (error instanceof Error) {
+      error.message = `${messagePrefix}: ${error.message}`;
+
+      return error;
+    }
+
+    return new Error(`${messagePrefix}: ${String(error)}`);
+  }
+}

--- a/src/service/cloudformation/resource/delete/sim-cfn-resource-delete.iso.test.ts
+++ b/src/service/cloudformation/resource/delete/sim-cfn-resource-delete.iso.test.ts
@@ -1,0 +1,184 @@
+import {
+  assertArrayLength,
+  assertFalse,
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertTrue,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimCfnResource } from "../sim-cfn-resource.js";
+import type {
+  SimCloudFormationResourceCreateContext,
+  SimCloudFormationResourceDeleteContext,
+} from "../sim-cfn-resource.js";
+import type { SimCfnServiceResourceFactory } from "../factory/sim-cfn-resource-factory.type.js";
+
+interface DeletingFactory extends SimCfnServiceResourceFactory {
+  readonly deleted: string[];
+}
+
+/**
+ * A factory that records what it was asked to delete, and can be told to
+ * refuse.
+ */
+function deletingFactory(refusal?: Error | string): DeletingFactory {
+  const deleted: string[] = [];
+
+  return {
+    deleted,
+
+    async create(): Promise<object> {
+      await Promise.resolve();
+
+      return { created: true };
+    },
+
+    async delete(resourceTypeName): Promise<void> {
+      await Promise.resolve();
+
+      if (refusal !== undefined) {
+        // eslint-disable-next-line @typescript-eslint/only-throw-error
+        throw refusal;
+      }
+
+      deleted.push(resourceTypeName);
+    },
+  };
+}
+
+describe("SimCfnResource deletion", () => {
+  const resourceFor = (
+    simAws: SimAws,
+    cfnResourceFactory: SimCfnServiceResourceFactory,
+  ): SimCfnResource =>
+    new SimCfnResource({
+      accountRegionScope: simAws.accountRegionScope().accountRegionScope,
+      logicalId: "TestResource",
+      template: { Type: "AWS::S3::Bucket" },
+      cfnResourceFactory,
+    });
+
+  const contextFor = (
+    simAws: SimAws,
+    resource: SimCfnResource,
+  ): SimCloudFormationResourceCreateContext &
+    SimCloudFormationResourceDeleteContext => ({
+    simAws,
+    resources: new Map([["TestResource", resource]]),
+  });
+
+  it("asks the service factory to delete a created Resource", async () => {
+    // Given a created Resource with an isolated factory injected.
+    const simAws = new SimAws();
+    const factory = deletingFactory();
+    const resource = resourceFor(simAws, factory);
+    const context = contextFor(simAws, resource);
+
+    await resource.create(context);
+
+    // When the Resource is deleted.
+    await resource.delete(context);
+
+    // Then the factory was asked for the Resource type, and the Resource
+    // reports a completed deletion.
+    assertArrayLength(factory.deleted, 1);
+    assertIdentical(factory.deleted[0], "Bucket");
+    assertIdentical(resource.status, "DELETE_COMPLETE");
+    assertTrue(resource.deleted);
+    assertTrue(resource.deleteComplete);
+    assertFalse(resource.deletionSkipped);
+    assertUndefined(resource.error);
+  });
+
+  it("leaves a Resource that was never created alone", async () => {
+    // Given a Resource nothing has created.
+    const simAws = new SimAws();
+    const factory = deletingFactory();
+    const resource = resourceFor(simAws, factory);
+
+    // When the Resource is deleted.
+    await resource.delete(contextFor(simAws, resource));
+
+    // Then nothing was asked to delete it, and it is delete-complete anyway,
+    // so a partly deployed Stack can still be torn down.
+    assertArrayLength(factory.deleted, 0);
+    assertIdentical(resource.status, "DELETE_COMPLETE");
+  });
+
+  it("records a Resource type nothing can delete rather than failing", async () => {
+    // Given a created Resource whose factory has no way to delete its type.
+    const simAws = new SimAws();
+    const resource = resourceFor(
+      simAws,
+      deletingFactory(
+        new Error("Unsupported sim Widget CloudFormation Resource Gadget"),
+      ),
+    );
+    const context = contextFor(simAws, resource);
+
+    await resource.create(context);
+
+    // When the Resource is deleted.
+    await resource.delete(context);
+
+    // Then the deletion is recorded as skipped, the same way an unsupported
+    // Resource type is on creation, and the teardown carries on.
+    assertIdentical(resource.status, "DELETE_COMPLETE");
+    assertTrue(resource.deletionSkipped);
+    assertFalse(resource.deleted);
+    assertNonNullable(resource.deletionSkippedReason);
+    assertStringIncludes(resource.deletionSkippedReason, "Gadget");
+  });
+
+  it("fails the Resource when its service refuses the deletion", async () => {
+    // Given a created Resource whose service refuses to delete it.
+    const simAws = new SimAws();
+    const resource = resourceFor(
+      simAws,
+      deletingFactory(new Error("Bucket is not empty")),
+    );
+    const context = contextFor(simAws, resource);
+
+    await resource.create(context);
+
+    // When the Resource is deleted.
+    const error = await assertThrowsErrorAsync(async () =>
+      resource.delete(context),
+    );
+
+    // Then the failure names the Resource and is kept on it.
+    assertStringIncludes(
+      error.message,
+      "Sim CloudFormation Resource TestResource deletion failed: Bucket is not empty",
+    );
+    assertIdentical(resource.status, "DELETE_FAILED");
+    assertTrue(resource.deleteComplete);
+    assertFalse(resource.deleted);
+    assertIdentical(resource.error, error);
+  });
+
+  it("wraps non-Error deletion failures", async () => {
+    // Given a created Resource whose factory rejects with a non-Error value.
+    const simAws = new SimAws();
+    const resource = resourceFor(simAws, deletingFactory("factory failed"));
+    const context = contextFor(simAws, resource);
+
+    await resource.create(context);
+
+    // When the Resource is deleted.
+    const error = await assertThrowsErrorAsync(async () =>
+      resource.delete(context),
+    );
+
+    // Then the thrown value is reported as a Resource deletion failure.
+    assertStringIncludes(
+      error.message,
+      "Sim CloudFormation Resource TestResource deletion failed: factory failed",
+    );
+  });
+});

--- a/src/service/cloudformation/resource/delete/sim-cfn-resource-deleter.ts
+++ b/src/service/cloudformation/resource/delete/sim-cfn-resource-deleter.ts
@@ -1,0 +1,69 @@
+import type { SimCfnResource } from "../sim-cfn-resource.js";
+import type { SimCloudFormationResourceDeleteContext } from "../sim-cfn-resource.type.js";
+import type { SimCfnServiceResourceFactory } from "../factory/sim-cfn-resource-factory.type.js";
+import { parseSimCloudFormationResourceType } from "../parser/sim-cfn-resource-parser.js";
+import { resolveSimCloudFormationServiceResourceFactory } from "../resolve/service/sim-cfn-service-resolver.js";
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+
+interface SimCfnResourceDeleterProperties<T extends object> {
+  readonly resource: SimCfnResource<T>;
+  readonly cfnResourceFactory?: SimCfnServiceResourceFactory | undefined;
+}
+
+/**
+ * Removes the underlying simulated AWS service Resource for a CloudFormation
+ * Resource.
+ *
+ * The mirror image of `SimCfnResourceCreator`: it parses the
+ * CloudFormation Resource type, resolves the owning service's factory, resolves
+ * the Resource's Properties, and asks that factory to delete. Which command
+ * removes a given Resource type, and what has to happen first, is the service's
+ * business rather than the engine's.
+ *
+ * It does not manage the asynchronous CloudFormation operation lifecycle.
+ * Background scheduling, Resource state transitions, and failure handling
+ * belong to SimCfnResourceDeleteOperation.
+ */
+export class SimCfnResourceDeleter<T extends object = object> {
+  private readonly resource: SimCfnResource<T>;
+  private readonly cfnResourceFactory: SimCfnServiceResourceFactory | undefined;
+
+  constructor(properties: SimCfnResourceDeleterProperties<T>) {
+    this.resource = properties.resource;
+    this.cfnResourceFactory = properties.cfnResourceFactory;
+  }
+
+  /**
+   * Delete the underlying simulated AWS service Resource.
+   *
+   * A Resource that never reached simulated AWS has nothing to delete. That
+   * covers a Resource whose type this simulation skipped creating, and one the
+   * Stack never got as far as, so a partly deployed Stack can still be torn
+   * down.
+   */
+  async delete(context: SimCloudFormationResourceDeleteContext): Promise<void> {
+    if (!this.resource.deployed) {
+      return;
+    }
+
+    const { type } = this.resource;
+    assertDefined(
+      type,
+      `Sim CloudFormation Resource ${this.resource.logicalId} is missing a Type`,
+    );
+
+    const resourceType = parseSimCloudFormationResourceType(type);
+    const factory =
+      this.cfnResourceFactory ??
+      resolveSimCloudFormationServiceResourceFactory(
+        context.simAws,
+        this.resource.accountRegionScope,
+        resourceType,
+      );
+
+    await factory.delete(resourceType.resourceTypeName, this.resource, {
+      ...context,
+      resolvedProperties: this.resource.resolvedProperties(context),
+    });
+  }
+}

--- a/src/service/cloudformation/resource/delete/sim-cfn-unsupported-deletion.iso.test.ts
+++ b/src/service/cloudformation/resource/delete/sim-cfn-unsupported-deletion.iso.test.ts
@@ -1,0 +1,110 @@
+import { assertStringIncludes, assertThrowsErrorAsync } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimCfnResource } from "../sim-cfn-resource.js";
+import type { SimCfnServiceResourceFactory } from "../factory/sim-cfn-resource-factory.type.js";
+import { SimCfnCfnResourceFactory } from "../factory/sim-cfn-cfn-resource-factory.js";
+import { SimCdkBucketDeploymentResourceFactory } from "../../cdk/s3/bucket-deployment/sim-cdk-bucket-deployment.js";
+
+interface UnsupportedDeletion {
+  readonly serviceName: string;
+  readonly factory: (simAws: SimAws) => SimCfnServiceResourceFactory;
+}
+
+/**
+ * Every service factory, asked to delete a Resource type it does not have.
+ *
+ * A service is free to create Resource types it cannot delete, and this is how
+ * it says so: the same unsupported-Resource error creation raises, which the
+ * Stack teardown records and steps over rather than failing on.
+ */
+const unsupportedDeletions: readonly UnsupportedDeletion[] = [
+  {
+    serviceName: "ACM",
+    factory: (simAws) => simAws.acm().cfnResourceFactory(),
+  },
+  {
+    serviceName: "API Gateway v2",
+    factory: (simAws) => simAws.apiGatewayV2().cfnResourceFactory(),
+  },
+  {
+    serviceName: "CloudFormation",
+    factory: () => new SimCfnCfnResourceFactory(),
+  },
+  {
+    serviceName: "CDK BucketDeployment",
+    factory: () => new SimCdkBucketDeploymentResourceFactory(),
+  },
+  {
+    serviceName: "CloudFront",
+    factory: (simAws) => simAws.cloudFront().cfnResourceFactory(),
+  },
+  {
+    serviceName: "Cognito",
+    factory: (simAws) => simAws.cognitoIdentityProvider().cfnResourceFactory(),
+  },
+  {
+    serviceName: "DynamoDB",
+    factory: (simAws) => simAws.dynamoDb().cfnResourceFactory(),
+  },
+  {
+    serviceName: "IAM",
+    factory: (simAws) => simAws.iam().cfnResourceFactory(),
+  },
+  {
+    serviceName: "KMS",
+    factory: (simAws) => simAws.kms().cfnResourceFactory(),
+  },
+  {
+    serviceName: "Lambda",
+    factory: (simAws) => simAws.lambda().cfnResourceFactory(),
+  },
+  {
+    serviceName: "Route53",
+    factory: (simAws) => simAws.route53().cfnResourceFactory(),
+  },
+  { serviceName: "S3", factory: (simAws) => simAws.s3().cfnResourceFactory() },
+  {
+    serviceName: "Secrets Manager",
+    factory: (simAws) => simAws.secretsManager().cfnResourceFactory(),
+  },
+  {
+    serviceName: "SQS",
+    factory: (simAws) => simAws.sqs().cfnResourceFactory(),
+  },
+  {
+    serviceName: "SSM",
+    factory: (simAws) => simAws.ssm().cfnResourceFactory(),
+  },
+];
+
+describe("Unsupported sim CloudFormation Resource deletion", () => {
+  it.each(unsupportedDeletions)(
+    "reports a $serviceName Resource type nothing deletes",
+    async ({ serviceName, factory }) => {
+      // Given a Resource of a type its service factory has no deletion for.
+      const simAws = new SimAws();
+      const resource = new SimCfnResource({
+        logicalId: "Unsimulated",
+        template: { Type: `AWS::${serviceName}::Unsimulated` },
+      });
+
+      // When the factory is asked to delete it.
+      const error = await assertThrowsErrorAsync(async () =>
+        factory(simAws).delete("Unsimulated", resource, {
+          simAws,
+          resources: new Map(),
+          // The API Gateway Resource types are addressed by the API they
+          // belong to, which is read before the type is judged.
+          resolvedProperties: { ApiId: "unsimulated-api" },
+        }),
+      );
+
+      // Then the refusal names the Resource type, so a Stack teardown can
+      // record what it could not remove.
+      assertStringIncludes(error.message, "Unsupported sim");
+      assertStringIncludes(error.message, "Unsimulated");
+    },
+  );
+});

--- a/src/service/cloudformation/resource/delete/sim-cfn-unsupported-deletion.iso.test.ts
+++ b/src/service/cloudformation/resource/delete/sim-cfn-unsupported-deletion.iso.test.ts
@@ -1,4 +1,8 @@
-import { assertStringIncludes, assertThrowsErrorAsync } from "@kensio/smartass";
+import {
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertTrue,
+} from "@kensio/smartass";
 import { describe, it } from "vitest";
 
 import { SimAws } from "../../../aws/sim-aws.js";
@@ -6,6 +10,7 @@ import { SimCfnResource } from "../sim-cfn-resource.js";
 import type { SimCfnServiceResourceFactory } from "../factory/sim-cfn-resource-factory.type.js";
 import { SimCfnCfnResourceFactory } from "../factory/sim-cfn-cfn-resource-factory.js";
 import { SimCdkBucketDeploymentResourceFactory } from "../../cdk/s3/bucket-deployment/sim-cdk-bucket-deployment.js";
+import { isSimCfnUnsupportedResourceError } from "../unsupported/sim-cfn-unsupported-resource.js";
 
 interface UnsupportedDeletion {
   readonly serviceName: string;
@@ -101,9 +106,10 @@ describe("Unsupported sim CloudFormation Resource deletion", () => {
         }),
       );
 
-      // Then the refusal names the Resource type, so a Stack teardown can
-      // record what it could not remove.
-      assertStringIncludes(error.message, "Unsupported sim");
+      // Then the refusal is one a Stack teardown records and steps over,
+      // rather than one that fails the teardown, and it names the Resource
+      // type so the record says what could not be removed.
+      assertTrue(isSimCfnUnsupportedResourceError(error));
       assertStringIncludes(error.message, "Unsimulated");
     },
   );

--- a/src/service/cloudformation/resource/dependency/sim-cfn-resource-dependents.ts
+++ b/src/service/cloudformation/resource/dependency/sim-cfn-resource-dependents.ts
@@ -1,0 +1,32 @@
+import type { SimCfnResource } from "../sim-cfn-resource.js";
+
+/**
+ * The Resources depending on each Resource of a Stack, keyed by logical ID.
+ *
+ * Creation reads the dependency graph forwards: a Resource waits for the
+ * Resources it names. Deletion reads the same graph backwards: a Resource waits
+ * for the Resources naming it, so a Bucket policy goes before its Bucket and a
+ * Role's policies go before the Role.
+ *
+ * The graph is the one each Resource already reports, rather than a second one
+ * built for deletion. A Resource nothing depends on has no entry.
+ */
+export function simCfnResourceDependents(
+  resources: ReadonlyMap<string, SimCfnResource>,
+): ReadonlyMap<string, readonly SimCfnResource[]> {
+  const dependents = new Map<string, SimCfnResource[]>();
+
+  for (const resource of resources.values()) {
+    for (const dependency of resource.dependencies()) {
+      const existing = dependents.get(dependency);
+
+      if (existing === undefined) {
+        dependents.set(dependency, [resource]);
+      } else {
+        existing.push(resource);
+      }
+    }
+  }
+
+  return dependents;
+}

--- a/src/service/cloudformation/resource/factory/sim-cfn-cfn-resource-factory.ts
+++ b/src/service/cloudformation/resource/factory/sim-cfn-cfn-resource-factory.ts
@@ -42,4 +42,21 @@ export class SimCfnCfnResourceFactory implements SimCfnServiceResourceFactory {
       }
     }
   }
+
+  /**
+   * Delete a simulated CloudFormation resource.
+   *
+   * A WaitConditionHandle is a pre-signed URL and nothing else. There is
+   * nothing behind it to remove, so deleting one is the Stack forgetting about
+   * it, which the Stack does whether this is called or not.
+   */
+  async delete(resourceTypeName: string): Promise<void> {
+    await Promise.resolve();
+
+    if (resourceTypeName !== "WaitConditionHandle") {
+      throw new Error(
+        `Unsupported sim CloudFormation CloudFormation Resource ${resourceTypeName} deletion`,
+      );
+    }
+  }
 }

--- a/src/service/cloudformation/resource/factory/sim-cfn-resource-factory.type.ts
+++ b/src/service/cloudformation/resource/factory/sim-cfn-resource-factory.type.ts
@@ -1,6 +1,7 @@
 import type {
   SimCfnResource,
   SimCloudFormationResourceCreateContext,
+  SimCloudFormationResourceDeleteContext,
 } from "../sim-cfn-resource.js";
 
 export interface SimCfnServiceResourceFactory {
@@ -9,6 +10,25 @@ export interface SimCfnServiceResourceFactory {
     resource: SimCfnResource,
     context: SimCloudFormationResourceCreateContext,
   ): Promise<object | undefined>;
+
+  /**
+   * Remove a Resource this factory created.
+   *
+   * The service owning a Resource type is the one that knows which command
+   * removes it, and what has to be true before that command will work: a
+   * CloudFront distribution has to be disabled first, an IAM role has to have
+   * its policies taken off it. CloudFormation orchestrates the order Resources
+   * come down in and nothing more.
+   *
+   * A Resource type this factory can create but has no way to remove should
+   * throw an unsupported-Resource error, the same as an unknown type does, so
+   * the teardown records it and carries on.
+   */
+  delete(
+    resourceTypeName: string,
+    resource: SimCfnResource,
+    context: SimCloudFormationResourceDeleteContext,
+  ): Promise<void>;
 }
 
 export interface SimCloudFormationParsedResourceType {

--- a/src/service/cloudformation/resource/resolve/property/sim-cfn-resource-property-resolver.ts
+++ b/src/service/cloudformation/resource/resolve/property/sim-cfn-resource-property-resolver.ts
@@ -4,7 +4,7 @@ import type {
   SimCfnTemplateValue,
   SimCfnTemplateValueRecord,
 } from "../../../template/value/sim-cfn-template-value.js";
-import type { SimCloudFormationResourceCreateContext } from "../../sim-cfn-resource.js";
+import type { SimCfnResourceResolveContext } from "../../sim-cfn-resource.type.js";
 import type { SimCfnPseudoParameters } from "../../../parameters/pseudo/sim-cfn-pseudo-parameters.js";
 
 interface SimCfnResourcePropertyResolverProperties {
@@ -47,7 +47,7 @@ export class SimCfnResourcePropertyResolver {
    */
   resolve(
     properties: SimCfnTemplateValueRecord,
-    context: SimCloudFormationResourceCreateContext,
+    context: SimCfnResourceResolveContext,
   ): SimCfnTemplateValueRecord {
     const resolver = new SimCfnTemplateValueResolver({
       parameters: this.parameters ?? new SimCfnParameters(),

--- a/src/service/cloudformation/resource/sim-cfn-resource-record.ts
+++ b/src/service/cloudformation/resource/sim-cfn-resource-record.ts
@@ -1,0 +1,171 @@
+import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+import { SimCfnIgnoredProperties } from "./ignore/sim-cfn-ignored-properties.js";
+import type {
+  SimCfnIgnoredProperty,
+  SimCfnPropertyIgnorer,
+} from "./ignore/sim-cfn-ignored-property.type.js";
+import { SimCfnResourceTemplateReader } from "./template/sim-cfn-resource-template-reader.js";
+import type {
+  SimCfnTemplateValue,
+  SimCfnTemplateValueRecord,
+} from "../template/value/sim-cfn-template-value.js";
+import { SimCfnResourcePropertyResolver } from "./resolve/property/sim-cfn-resource-property-resolver.js";
+import {
+  type SimCfnResourceValueAdapter,
+  simCfnResourceValueAdapter,
+} from "./cfn/sim-cfn-resource-value-adapter.js";
+import { simAwsAccountRegionScopeFactory } from "../../aws/sim-aws-account-region-scope.factory.js";
+import type {
+  SimCfnResourceResolveContext,
+  SimCloudFormationResourceProperties,
+} from "./sim-cfn-resource.type.js";
+
+/**
+ * What one CloudFormation Resource entry is, apart from what has happened to
+ * it.
+ *
+ * This half of `SimCfnResource` is fixed when the Stack reads its
+ * template: which Resource this is, what the template says about it, which
+ * other Resources it names, and how it answers Ref and Fn::GetAtt. None of it
+ * changes as the Stack deploys or tears down.
+ *
+ * The lifecycle half lives on SimCfnResource, which extends this. Keeping the
+ * two apart is what lets the record stay readable while creation and deletion
+ * each carry a full set of states, and it puts the Resource's identity where a
+ * service factory can read it without seeing lifecycle controls it should not
+ * be calling.
+ */
+export abstract class SimCfnResourceRecord implements SimCfnPropertyIgnorer {
+  public readonly accountRegionScope: SimAwsAccountRegionScope;
+  public readonly logicalId: string;
+  /** The Stack this Resource belongs to, where a generated name comes from. */
+  public readonly stackName: string | undefined;
+  public readonly template: SimCfnTemplateValueRecord;
+
+  private readonly ignoredPropertyList = new SimCfnIgnoredProperties();
+  private readonly resourceTemplateReader: SimCfnResourceTemplateReader;
+  private readonly propertyResolver: SimCfnResourcePropertyResolver;
+  private readonly resourceLogicalIds: ReadonlySet<string>;
+
+  constructor(properties: SimCloudFormationResourceProperties = {}) {
+    const {
+      accountRegionScope = simAwsAccountRegionScopeFactory.make(),
+      logicalId = "Resource",
+      stackName,
+      template = {},
+      parameters,
+      resourceLogicalIds = new Set(),
+    } = properties;
+
+    this.accountRegionScope = accountRegionScope;
+    this.logicalId = logicalId;
+    this.stackName = stackName;
+    this.template = template;
+    this.resourceTemplateReader = new SimCfnResourceTemplateReader(template);
+    this.propertyResolver = new SimCfnResourcePropertyResolver({ parameters });
+    this.resourceLogicalIds = resourceLogicalIds;
+  }
+
+  /**
+   * The simulated AWS object created for this CloudFormation Resource.
+   */
+  public abstract get simResource(): object | undefined;
+
+  /**
+   * The properties this Resource was created without acting on.
+   */
+  public get ignoredProperties(): readonly SimCfnIgnoredProperty[] {
+    return this.ignoredPropertyList.all;
+  }
+
+  /**
+   * The CloudFormation Resource type from the Resource template.
+   *
+   * E.g. AWS::S3::Bucket
+   */
+  public get type(): string | undefined {
+    return this.resourceTemplateReader.type();
+  }
+
+  /**
+   * The CloudFormation Resource properties object from the Resource template.
+   *
+   * Missing or non-object Properties are treated as an empty object by the
+   * Resource template reader.
+   */
+  public get properties(): SimCfnTemplateValueRecord {
+    return this.resourceTemplateReader.properties();
+  }
+
+  /**
+   * The value returned when this Resource is referenced via { "Ref": logicalId }.
+   *
+   * Mirroring CloudFormation, Resource Ref behavior is Resource-type specific.
+   * CloudFormation-specific value behavior is delegated to a Resource adapter so
+   * simulated service objects do not need to know about CloudFormation.
+   */
+  public get refValue(): SimCfnTemplateValue {
+    return this.cfnValueAdapter().refValue();
+  }
+
+  /**
+   * Record that this Resource is being created without acting on a property.
+   * Called by the service parsing this Resource's properties, which is the
+   * only thing that knows whether a property changes behaviour it simulates.
+   */
+  ignoreProperty(path: string, reason: string): void {
+    this.ignoredPropertyList.record(this, path, reason);
+  }
+
+  /**
+   * The value returned when this Resource is referenced via Fn::GetAtt.
+   *
+   * Mirroring CloudFormation, Resource attributes are Resource-type specific.
+   * CloudFormation-specific value behavior is delegated to a Resource adapter so
+   * simulated service objects do not need to know about CloudFormation.
+   */
+  attributeValue(attributeName: string): SimCfnTemplateValue {
+    return this.cfnValueAdapter().attributeValue(attributeName);
+  }
+
+  /**
+   * Logical IDs of Resources that must complete before this Resource can
+   * create.
+   *
+   * Includes both explicit DependsOn entries and implicit dependencies from Ref
+   * expressions that target other Resources.
+   */
+  dependencies(): string[] {
+    return this.resourceTemplateReader.dependencies(this.resourceLogicalIds);
+  }
+
+  /**
+   * Resolve this Resource's Properties, including Refs to other Resources.
+   *
+   * Called by the creation operation once every dependency has reached
+   * CREATE_COMPLETE, and by the deletion operation while everything this
+   * Resource names is still there, so referenced Resources have valid Ref
+   * values either way.
+   */
+  resolvedProperties(
+    context: SimCfnResourceResolveContext,
+  ): SimCfnTemplateValueRecord {
+    return this.propertyResolver.resolve(this.properties, context);
+  }
+
+  /**
+   * Forget the properties recorded as ignored, for a Resource being created
+   * again.
+   */
+  protected clearIgnoredProperties(): void {
+    this.ignoredPropertyList.clear();
+  }
+
+  private cfnValueAdapter(): SimCfnResourceValueAdapter {
+    return simCfnResourceValueAdapter({
+      logicalId: this.logicalId,
+      type: this.type,
+      simResource: this.simResource,
+    });
+  }
+}

--- a/src/service/cloudformation/resource/sim-cfn-resource.iso.test.ts
+++ b/src/service/cloudformation/resource/sim-cfn-resource.iso.test.ts
@@ -195,6 +195,10 @@ describe("SimCfnResource", () => {
 
         return createdSimResource;
       },
+
+      async delete(): Promise<void> {
+        await Promise.resolve();
+      },
     };
 
     const resource = new SimCfnResource({
@@ -270,6 +274,10 @@ describe("SimCfnResource", () => {
 
           // eslint-disable-next-line @typescript-eslint/only-throw-error
           throw "factory failed";
+        },
+
+        async delete() {
+          await Promise.resolve();
         },
       },
     });

--- a/src/service/cloudformation/resource/sim-cfn-resource.ts
+++ b/src/service/cloudformation/resource/sim-cfn-resource.ts
@@ -1,29 +1,16 @@
-import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
 import {
   type BackgroundScheduler,
   BackgroundTasks,
 } from "../../../util/background/background.js";
 import type { SimCfnServiceResourceFactory } from "./factory/sim-cfn-resource-factory.type.js";
 import { SimCfnResourceCreateOperation } from "./create/sim-cfn-resource-create-operation.js";
+import { SimCfnResourceDeleteOperation } from "./delete/sim-cfn-resource-delete-operation.js";
 import { SimCfnResourceCreationState } from "./state/sim-cfn-resource-creation-state.js";
-import { SimCfnIgnoredProperties } from "./ignore/sim-cfn-ignored-properties.js";
-import type {
-  SimCfnIgnoredProperty,
-  SimCfnPropertyIgnorer,
-} from "./ignore/sim-cfn-ignored-property.type.js";
-import { SimCfnResourceTemplateReader } from "./template/sim-cfn-resource-template-reader.js";
-import type {
-  SimCfnTemplateValue,
-  SimCfnTemplateValueRecord,
-} from "../template/value/sim-cfn-template-value.js";
-import { SimCfnResourcePropertyResolver } from "./resolve/property/sim-cfn-resource-property-resolver.js";
-import {
-  type SimCfnResourceValueAdapter,
-  simCfnResourceValueAdapter,
-} from "./cfn/sim-cfn-resource-value-adapter.js";
-import { simAwsAccountRegionScopeFactory } from "../../aws/sim-aws-account-region-scope.factory.js";
+import { SimCfnResourceDeletionState } from "./state/sim-cfn-resource-deletion-state.js";
+import { SimCfnResourceRecord } from "./sim-cfn-resource-record.js";
 import type {
   SimCloudFormationResourceCreateContext,
+  SimCloudFormationResourceDeleteContext,
   SimCloudFormationResourceProperties,
   SimCloudFormationResourceStatus,
 } from "./sim-cfn-resource.type.js";
@@ -33,61 +20,47 @@ import type {
  *
  * A SimCfnResource is created from one item in a stack template's Resources map.
  * It keeps the Resource logical ID, account/region scope, original Resource
- * template object, CloudFormation creation state, and the simulated AWS object
+ * template object, CloudFormation lifecycle state, and the simulated AWS object
  * produced by Resource creation.
  *
  * This class stays small:
+ * - what the Resource is, rather than what has happened to it, belongs to
+ *   SimCfnResourceRecord, which this extends;
  * - whole-template validation and Parameter resolution belong to SimCfnTemplate;
- * - Resource-field reading belongs to SimCfnResourceTemplateReader;
- * - asynchronous creation orchestration belongs to SimCfnResourceCreateOperation;
- * - service-specific object construction belongs to SimCfnServiceResourceFactory.
+ * - asynchronous creation and deletion orchestration belong to
+ *   SimCfnResourceCreateOperation and SimCfnResourceDeleteOperation;
+ * - service-specific object construction and removal belong to
+ *   SimCfnServiceResourceFactory.
  * As a result, SimCfnResource acts as the stable Resource record passed between
- * stack creation, dependency resolution, and service-specific factories.
+ * stack deployment, dependency resolution, and service-specific factories.
  */
 export class SimCfnResource<
   T extends object = object,
-> implements SimCfnPropertyIgnorer {
-  public readonly accountRegionScope: SimAwsAccountRegionScope;
-  public readonly logicalId: string;
-  /** The Stack this Resource belongs to, where a generated name comes from. */
-  public readonly stackName: string | undefined;
-  public readonly template: SimCfnTemplateValueRecord;
+> extends SimCfnResourceRecord {
   private readonly creationState = new SimCfnResourceCreationState<T>();
-  private readonly ignoredPropertyList = new SimCfnIgnoredProperties();
-  private readonly resourceTemplateReader: SimCfnResourceTemplateReader;
-  private readonly propertyResolver: SimCfnResourcePropertyResolver;
+  private readonly deletionState = new SimCfnResourceDeletionState();
   private readonly background: BackgroundScheduler;
   private readonly cfnResourceFactory: SimCfnServiceResourceFactory | undefined;
-  private readonly resourceLogicalIds: ReadonlySet<string>;
 
   constructor(properties: SimCloudFormationResourceProperties = {}) {
-    const {
-      accountRegionScope = simAwsAccountRegionScopeFactory.make(),
-      background = new BackgroundTasks(),
-      logicalId = "Resource",
-      stackName,
-      template = {},
-      cfnResourceFactory,
-      parameters,
-      resourceLogicalIds = new Set(),
-    } = properties;
+    super(properties);
 
-    this.accountRegionScope = accountRegionScope;
+    const { background = new BackgroundTasks(), cfnResourceFactory } =
+      properties;
+
     this.background = background;
-    this.logicalId = logicalId;
-    this.stackName = stackName;
-    this.template = template;
-    this.resourceTemplateReader = new SimCfnResourceTemplateReader(template);
-    this.propertyResolver = new SimCfnResourcePropertyResolver({ parameters });
     this.cfnResourceFactory = cfnResourceFactory;
-    this.resourceLogicalIds = resourceLogicalIds;
   }
 
   /**
-   * Get the current CloudFormation creation status for this Resource.
+   * Get the current CloudFormation status for this Resource.
+   *
+   * A Resource keeps the status its creation left it with until the Stack asks
+   * for it to be deleted, so the status reads as the last thing CloudFormation
+   * did to the Resource.
    */
   public get status(): SimCloudFormationResourceStatus {
-    return this.creationState.status;
+    return this.deletionState.status ?? this.creationState.status;
   }
 
   /**
@@ -113,22 +86,6 @@ export class SimCfnResource<
   }
 
   /**
-   * The properties this Resource was created without acting on.
-   */
-  public get ignoredProperties(): readonly SimCfnIgnoredProperty[] {
-    return this.ignoredPropertyList.all;
-  }
-
-  /**
-   * Record that this Resource is being created without acting on a property.
-   * Called by the service parsing this Resource's properties, which is the
-   * only thing that knows whether a property changes behaviour it simulates.
-   */
-  ignoreProperty(path: string, reason: string): void {
-    this.ignoredPropertyList.record(this, path, reason);
-  }
-
-  /**
    * Whether this Resource has reached a terminal successful creation status.
    */
   public get createComplete(): boolean {
@@ -136,44 +93,32 @@ export class SimCfnResource<
   }
 
   /**
-   * The CloudFormation Resource type from the Resource template.
-   *
-   * E.g. AWS::S3::Bucket
+   * Whether this Resource has reached a terminal deletion status.
    */
-  public get type(): string | undefined {
-    return this.resourceTemplateReader.type();
+  public get deleteComplete(): boolean {
+    return this.deletionState.deleteComplete;
   }
 
   /**
-   * The CloudFormation Resource properties object from the Resource template.
-   *
-   * Missing or non-object Properties are treated as an empty object by the
-   * Resource template reader.
+   * Whether this Resource was removed from simulated AWS.
    */
-  public get properties(): SimCfnTemplateValueRecord {
-    return this.resourceTemplateReader.properties();
+  public get deleted(): boolean {
+    return this.deletionState.deleted;
   }
 
   /**
-   * The value returned when this Resource is referenced via { "Ref": logicalId }.
-   *
-   * Mirroring CloudFormation, Resource Ref behavior is Resource-type specific.
-   * CloudFormation-specific value behavior is delegated to a Resource adapter so
-   * simulated service objects do not need to know about CloudFormation.
+   * Whether this Resource's deletion was recorded rather than carried out,
+   * because sim CloudFormation has no way to delete its Resource type.
    */
-  public get refValue(): SimCfnTemplateValue {
-    return this.cfnValueAdapter().refValue();
+  public get deletionSkipped(): boolean {
+    return this.deletionState.skipped;
   }
 
   /**
-   * The value returned when this Resource is referenced via Fn::GetAtt.
-   *
-   * Mirroring CloudFormation, Resource attributes are Resource-type specific.
-   * CloudFormation-specific value behavior is delegated to a Resource adapter so
-   * simulated service objects do not need to know about CloudFormation.
+   * The reason this Resource's deletion was skipped, if it was skipped.
    */
-  public attributeValue(attributeName: string): SimCfnTemplateValue {
-    return this.cfnValueAdapter().attributeValue(attributeName);
+  public get deletionSkippedReason(): string | undefined {
+    return this.deletionState.skippedReason;
   }
 
   /**
@@ -183,38 +128,15 @@ export class SimCfnResource<
    * after creation completes. Resources that do not produce a concrete service
    * object may leave this undefined.
    */
-  public get simResource(): T | undefined {
+  public override get simResource(): T | undefined {
     return this.creationState.simResource;
   }
 
   /**
-   * The creation failure captured for this Resource, if creation failed.
+   * The failure captured for this Resource, if creation or deletion failed.
    */
   public get error(): Error | undefined {
-    return this.creationState.error;
-  }
-
-  /**
-   * Logical IDs of Resources that must complete before this Resource can
-   * create.
-   *
-   * Includes both explicit DependsOn entries and implicit dependencies from Ref
-   * expressions that target other Resources.
-   */
-  dependencies(): string[] {
-    return this.resourceTemplateReader.dependencies(this.resourceLogicalIds);
-  }
-
-  /**
-   * Resolve this Resource's Properties, including Refs to other Resources.
-   *
-   * Called by the creation operation once every dependency has reached
-   * CREATE_COMPLETE, so referenced Resources have valid Ref values.
-   */
-  resolvedProperties(
-    context: SimCloudFormationResourceCreateContext,
-  ): SimCfnTemplateValueRecord {
-    return this.propertyResolver.resolve(this.properties, context);
+    return this.deletionState.error ?? this.creationState.error;
   }
 
   /**
@@ -236,12 +158,25 @@ export class SimCfnResource<
    * remains a lifecycle record rather than an async workflow implementation.
    */
   create(context: SimCloudFormationResourceCreateContext): Promise<void> {
-    const creationOperation = new SimCfnResourceCreateOperation({
+    return new SimCfnResourceCreateOperation({
       background: this.background,
       resource: this,
       cfnResourceFactory: this.cfnResourceFactory,
-    });
-    return creationOperation.run(context);
+    }).run(context);
+  }
+
+  /**
+   * Start deleting this Resource from simulated AWS.
+   *
+   * The actual work is delegated to SimCfnResourceDeleteOperation, for the same
+   * reason creation is.
+   */
+  delete(context: SimCloudFormationResourceDeleteContext): Promise<void> {
+    return new SimCfnResourceDeleteOperation({
+      background: this.background,
+      resource: this,
+      cfnResourceFactory: this.cfnResourceFactory,
+    }).run(context);
   }
 
   /**
@@ -251,7 +186,7 @@ export class SimCfnResource<
    * CloudFormation lifecycle.
    */
   markCreateInProgress(): void {
-    this.ignoredPropertyList.clear();
+    this.clearIgnoredProperties();
     this.creationState.markCreateInProgress();
   }
 
@@ -284,17 +219,39 @@ export class SimCfnResource<
     this.creationState.markCreateFailed(error);
   }
 
-  private cfnValueAdapter(): SimCfnResourceValueAdapter {
-    return simCfnResourceValueAdapter({
-      logicalId: this.logicalId,
-      type: this.type,
-      simResource: this.simResource,
-    });
+  /**
+   * Mark this Resource as deletion in progress.
+   */
+  markDeleteInProgress(): void {
+    this.deletionState.markDeleteInProgress();
+  }
+
+  /**
+   * Mark this Resource as successfully deleted.
+   */
+  markDeleteComplete(): void {
+    this.deletionState.markDeleteComplete();
+  }
+
+  /**
+   * Mark this Resource's deletion as skipped because sim CloudFormation has no
+   * way to delete its service or Resource type.
+   */
+  markDeleteSkipped(reason: string): void {
+    this.deletionState.markDeleteSkipped(reason);
+  }
+
+  /**
+   * Mark this Resource as failed to delete and store the failure reason.
+   */
+  markDeleteFailed(error?: Error): void {
+    this.deletionState.markDeleteFailed(error);
   }
 }
 
 export {
   type SimCloudFormationResourceCreateContext,
+  type SimCloudFormationResourceDeleteContext,
   type SimCloudFormationResourceProperties,
   type SimCloudFormationResourceStatus,
 } from "./sim-cfn-resource.type.js";

--- a/src/service/cloudformation/resource/sim-cfn-resource.type.ts
+++ b/src/service/cloudformation/resource/sim-cfn-resource.type.ts
@@ -22,11 +22,31 @@ export interface SimCloudFormationResourceProperties {
 /**
  * Simulated CloudFormation Resource status.
  *
- * These states model the CloudFormation creation lifecycle for one Resource
- * entry, not the lifecycle of the underlying simulated AWS service object.
+ * These states model the CloudFormation creation and deletion lifecycle for one
+ * Resource entry, not the lifecycle of the underlying simulated AWS service
+ * object.
+ *
+ * A Resource keeps its creation status until it is asked to delete, so a status
+ * reads as the last thing CloudFormation did to the Resource.
  */
 export type SimCloudFormationResourceStatus =
-  "CREATE_PENDING" | "CREATE_IN_PROGRESS" | "CREATE_COMPLETE" | "CREATE_FAILED";
+  | "CREATE_PENDING"
+  | "CREATE_IN_PROGRESS"
+  | "CREATE_COMPLETE"
+  | "CREATE_FAILED"
+  | "DELETE_IN_PROGRESS"
+  | "DELETE_COMPLETE"
+  | "DELETE_FAILED";
+
+/**
+ * What resolving one Resource's Properties needs from the operation running.
+ *
+ * Creation and deletion both resolve Properties against the Stack's other
+ * Resources, and neither needs anything else of the operation to do it.
+ */
+export interface SimCfnResourceResolveContext {
+  readonly resources: ReadonlyMap<string, SimCfnResource>;
+}
 
 export interface SimCloudFormationResourceCreateContext {
   readonly simAws: SimAws;
@@ -34,4 +54,19 @@ export interface SimCloudFormationResourceCreateContext {
   readonly resolvedProperties?: SimCfnTemplateValueRecord | undefined;
   readonly cdkOutContext?: SimCdkOutContext | undefined;
   readonly bindings?: readonly SimCfnExecutableResourceBinding[] | undefined;
+}
+
+/**
+ * What a service is given to delete a Resource it created.
+ *
+ * The same shape as the creation context, minus the parts only creation has an
+ * answer for. Properties are resolved again at deletion time rather than
+ * remembered from creation, which works because a Stack tears down in reverse
+ * dependency order: everything a Resource refers to is still there when the
+ * Resource itself is deleted.
+ */
+export interface SimCloudFormationResourceDeleteContext {
+  readonly simAws: SimAws;
+  readonly resources: ReadonlyMap<string, SimCfnResource>;
+  readonly resolvedProperties?: SimCfnTemplateValueRecord | undefined;
 }

--- a/src/service/cloudformation/resource/state/sim-cfn-resource-deletion-state.ts
+++ b/src/service/cloudformation/resource/state/sim-cfn-resource-deletion-state.ts
@@ -1,0 +1,107 @@
+import type { SimCloudFormationResourceStatus } from "../sim-cfn-resource.type.js";
+
+/**
+ * Tracks CloudFormation Resource deletion status and failure.
+ *
+ * Deletion state is separate from creation state rather than sharing one status
+ * field, because the two answer different questions. Creation state says what
+ * the Resource became; deletion state says what happened when the Stack asked
+ * for it to be taken away again. A Resource that was never asked to delete has
+ * no deletion status at all, which is what `undefined` means here.
+ */
+export class SimCfnResourceDeletionState {
+  #status: SimCloudFormationResourceStatus | undefined;
+  #skippedReason: string | undefined;
+  #failure: Error | undefined;
+
+  /**
+   * The current deletion status, or undefined if deletion has not started.
+   */
+  public get status(): SimCloudFormationResourceStatus | undefined {
+    return this.#status;
+  }
+
+  /**
+   * Whether this Resource has reached a terminal deletion status.
+   */
+  public get deleteComplete(): boolean {
+    return (
+      this.#status === "DELETE_COMPLETE" || this.#status === "DELETE_FAILED"
+    );
+  }
+
+  /**
+   * Whether this Resource was removed from simulated AWS.
+   *
+   * A skipped deletion is delete-complete without this being true, mirroring a
+   * skipped creation, which is create-complete without being deployed.
+   */
+  public get deleted(): boolean {
+    return (
+      this.#status === "DELETE_COMPLETE" && this.#skippedReason === undefined
+    );
+  }
+
+  /**
+   * Whether deletion was recorded rather than carried out, because sim
+   * CloudFormation has no way to delete this Resource type.
+   */
+  public get skipped(): boolean {
+    return this.#skippedReason !== undefined;
+  }
+
+  /**
+   * The reason this Resource's deletion was skipped, if it was skipped.
+   */
+  public get skippedReason(): string | undefined {
+    return this.#skippedReason;
+  }
+
+  /**
+   * The failure captured for this Resource, if deletion failed.
+   */
+  public get error(): Error | undefined {
+    return this.#failure;
+  }
+
+  /**
+   * Mark this Resource as deletion in progress.
+   */
+  markDeleteInProgress(): void {
+    this.#failure = undefined;
+    this.#skippedReason = undefined;
+    this.#status = "DELETE_IN_PROGRESS";
+  }
+
+  /**
+   * Mark this Resource as successfully deleted.
+   */
+  markDeleteComplete(): void {
+    this.#failure = undefined;
+    this.#skippedReason = undefined;
+    this.#status = "DELETE_COMPLETE";
+  }
+
+  /**
+   * Mark this Resource's deletion as skipped because sim CloudFormation cannot
+   * delete its service or Resource type.
+   *
+   * Skipped deletions are treated as DELETE_COMPLETE, the same way an
+   * unsupported Resource type is treated as CREATE_COMPLETE, so one Resource
+   * nothing can remove does not hold up the rest of the teardown.
+   */
+  markDeleteSkipped(reason: string): void {
+    this.#failure = undefined;
+    this.#skippedReason = reason;
+    this.#status = "DELETE_COMPLETE";
+  }
+
+  /**
+   * Mark this Resource as failed to delete.
+   */
+  markDeleteFailed(error?: Error): void {
+    this.#failure = error;
+    this.#skippedReason = undefined;
+    this.#status = "DELETE_FAILED";
+  }
+}

--- a/src/service/cloudformation/resource/unsupported/sim-cfn-unsupported-resource.ts
+++ b/src/service/cloudformation/resource/unsupported/sim-cfn-unsupported-resource.ts
@@ -1,0 +1,17 @@
+/**
+ * Whether an error says sim CloudFormation has no implementation for a
+ * Resource, rather than that an implementation ran and failed.
+ *
+ * Service factories raise this as an ordinary error, because from the service's
+ * point of view being asked for a Resource type it does not model is a refusal
+ * like any other. The Stack lifecycle reads it differently: an unsupported
+ * Resource is recorded and stepped over, so the rest of the Stack still
+ * deploys, and still tears down.
+ */
+export function isSimCfnUnsupportedResourceError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    error.message.includes("Unsupported sim") &&
+    error.message.includes("CloudFormation")
+  );
+}

--- a/src/service/cloudformation/stack/sim-cfn-stack.ts
+++ b/src/service/cloudformation/stack/sim-cfn-stack.ts
@@ -9,6 +9,7 @@ import type {
   SimCfnTemplate,
 } from "../template/sim-cfn-template.js";
 import { SimCfnStackResourceCreator } from "./deploy/sim-cfn-stack-resource-creator.js";
+import { SimCfnStackResourceDeleter } from "./teardown/sim-cfn-stack-resource-deleter.js";
 import { makeSimCfnStackResourceMap } from "./resource-map/sim-cfn-stack-resource-map.js";
 import { SimCfnStackDeploymentLifecycle } from "./deploy/sim-cfn-stack-deployment-lifecycle.js";
 import type { SimCdkOutContext } from "../cdk/sim-cdk-out-context.js";
@@ -119,6 +120,22 @@ export class SimCfnStack {
   }
 
   /**
+   * Delete this Stack's Resources from simulated AWS, in reverse dependency
+   * order.
+   *
+   * The Resource half of deleting a Stack. Stack deletion status, releasing the
+   * Stack name and the DeleteStack command itself sit on top of this rather
+   * than inside it, so the Resource teardown can be exercised on its own.
+   */
+  async teardown(): Promise<void> {
+    await new SimCfnStackResourceDeleter({
+      simAws: this.simAws,
+      resources: this.resources,
+      stackName: this.stackName,
+    }).deleteAll();
+  }
+
+  /**
    * Get a Stack Resource by logical ID.
    */
   getResource(logicalId: string): SimCfnResource | undefined {
@@ -131,6 +148,20 @@ export class SimCfnStack {
    */
   public get skippedResources(): readonly SimCfnResource[] {
     return this.skippedResourceList;
+  }
+
+  /**
+   * Resources the teardown recorded rather than deleted, because sim
+   * CloudFormation has no way to delete their Resource type.
+   *
+   * Read from the Resources rather than collected during teardown, the same way
+   * ignored properties are, so the Stack and its Resources cannot disagree.
+   */
+  public get skippedResourceDeletions(): readonly SimCfnResource[] {
+    return this.resources
+      .values()
+      .filter((resource) => resource.deletionSkipped)
+      .toArray();
   }
 
   /**

--- a/src/service/cloudformation/stack/teardown/sim-cfn-stack-pending-deletions.ts
+++ b/src/service/cloudformation/stack/teardown/sim-cfn-stack-pending-deletions.ts
@@ -1,0 +1,70 @@
+import type { SimCfnResource } from "../../resource/sim-cfn-resource.js";
+import { simCfnResourceDependents } from "../../resource/dependency/sim-cfn-resource-dependents.js";
+
+/**
+ * Immutable view of the Resources still pending in the Stack teardown loop.
+ *
+ * The deletion counterpart of SimCfnStackPendingResources, and the place the
+ * dependency graph is read backwards:
+ *
+ * - expose whether any Resources are still pending
+ * - select pending Resources nothing left in the Stack still depends on
+ * - return the next pending-set view after a batch has run
+ *
+ * It does not mutate Resources, delete Resources, or report dependency
+ * deadlocks. SimCfnStackResourceDeleter owns the orchestration loop.
+ */
+export class SimCfnStackPendingDeletions {
+  private readonly resources: ReadonlyMap<string, SimCfnResource>;
+  private readonly pendingResources: ReadonlySet<SimCfnResource>;
+  private readonly dependents: ReadonlyMap<string, readonly SimCfnResource[]>;
+
+  constructor(
+    resources: ReadonlyMap<string, SimCfnResource>,
+    pendingResources: ReadonlySet<SimCfnResource> = new Set(resources.values()),
+  ) {
+    this.resources = resources;
+    this.pendingResources = pendingResources;
+    this.dependents = simCfnResourceDependents(resources);
+  }
+
+  /**
+   * Whether the teardown loop still has Resources to consider.
+   */
+  get hasResources(): boolean {
+    return this.pendingResources.size > 0;
+  }
+
+  /**
+   * Pending Resources that nothing still standing depends on.
+   *
+   * A Resource is deletable once every Resource naming it has finished
+   * deleting, which is the creation rule with the arrow turned round.
+   */
+  deletableResources(): SimCfnResource[] {
+    return [...this.pendingResources].filter((resource) => {
+      const dependents = this.dependents.get(resource.logicalId) ?? [];
+
+      return dependents.every((dependent) => dependent.deleteComplete);
+    });
+  }
+
+  /**
+   * Return the pending-set view for the next loop iteration.
+   *
+   * Resources that are delete-complete are removed. Resources that failed or
+   * are still waiting for their dependents remain pending, so the orchestrator
+   * can either make progress in a later batch or detect that no progress is
+   * possible.
+   */
+  incompleteResources(): SimCfnStackPendingDeletions {
+    return new SimCfnStackPendingDeletions(
+      this.resources,
+      new Set(
+        [...this.pendingResources].filter((resource) => {
+          return !resource.deleteComplete;
+        }),
+      ),
+    );
+  }
+}

--- a/src/service/cloudformation/stack/teardown/sim-cfn-stack-pending-deletions.ts
+++ b/src/service/cloudformation/stack/teardown/sim-cfn-stack-pending-deletions.ts
@@ -52,10 +52,10 @@ export class SimCfnStackPendingDeletions {
   /**
    * Return the pending-set view for the next loop iteration.
    *
-   * Resources that are delete-complete are removed. Resources that failed or
-   * are still waiting for their dependents remain pending, so the orchestrator
-   * can either make progress in a later batch or detect that no progress is
-   * possible.
+   * Resources that reached a terminal delete status are removed, whether they
+   * were deleted or failed to delete. Only Resources still waiting for their
+   * dependents remain pending, so the orchestrator can either make progress in
+   * a later batch or detect that no progress is possible.
    */
   incompleteResources(): SimCfnStackPendingDeletions {
     return new SimCfnStackPendingDeletions(

--- a/src/service/cloudformation/stack/teardown/sim-cfn-stack-resource-batch-deleter.ts
+++ b/src/service/cloudformation/stack/teardown/sim-cfn-stack-resource-batch-deleter.ts
@@ -1,0 +1,43 @@
+import type { SimAws } from "../../../aws/sim-aws.js";
+import type { SimCfnResource } from "../../resource/sim-cfn-resource.js";
+
+interface SimCfnStackResourceBatchDeleterProperties {
+  readonly simAws: SimAws;
+  readonly resources: ReadonlyMap<string, SimCfnResource>;
+}
+
+/**
+ * Deletes one batch of Stack Resources nothing still depends on.
+ *
+ * The caller guarantees that every supplied Resource is ready to delete. This
+ * class owns only the batch execution details: delete them in parallel, passing
+ * each the shared Stack context.
+ *
+ * It does not choose which Resources are ready, retry incomplete Resources, or
+ * update Stack lifecycle state.
+ */
+export class SimCfnStackResourceBatchDeleter {
+  private readonly simAws: SimAws;
+  private readonly resources: ReadonlyMap<string, SimCfnResource>;
+
+  constructor(properties: SimCfnStackResourceBatchDeleterProperties) {
+    this.simAws = properties.simAws;
+    this.resources = properties.resources;
+  }
+
+  /**
+   * Delete the supplied Resources concurrently.
+   *
+   * Each Resource still owns its own delete lifecycle and status transitions.
+   */
+  async delete(resources: readonly SimCfnResource[]): Promise<void> {
+    await Promise.all(
+      resources.map(async (resource) => {
+        await resource.delete({
+          simAws: this.simAws,
+          resources: this.resources,
+        });
+      }),
+    );
+  }
+}

--- a/src/service/cloudformation/stack/teardown/sim-cfn-stack-resource-deleter.ts
+++ b/src/service/cloudformation/stack/teardown/sim-cfn-stack-resource-deleter.ts
@@ -1,0 +1,71 @@
+import type { SimAws } from "../../../aws/sim-aws.js";
+import type { SimCfnResource } from "../../resource/sim-cfn-resource.js";
+import { SimCfnStackPendingDeletions } from "./sim-cfn-stack-pending-deletions.js";
+import { SimCfnStackResourceBatchDeleter } from "./sim-cfn-stack-resource-batch-deleter.js";
+
+interface SimCfnStackResourceDeleterProperties {
+  readonly simAws: SimAws;
+  readonly resources: ReadonlyMap<string, SimCfnResource>;
+  readonly stackName: string;
+}
+
+/**
+ * Orchestrates reverse-dependency-ordered deletion of a Stack's Resources.
+ *
+ * The mirror image of SimCfnStackResourceCreator:
+ *
+ * - ask SimCfnStackPendingDeletions which pending Resources nothing depends on
+ * - fail if no pending Resource can make progress
+ * - ask SimCfnStackResourceBatchDeleter to delete the ready batch
+ * - repeat with the Resources that are still not delete-complete
+ *
+ * Deleting in this order is what makes the individual service deleters
+ * workable: a Bucket policy is gone before its Bucket, a Role's policies before
+ * the Role, and every Ref a Resource carries still resolves while that Resource
+ * is being deleted.
+ */
+export class SimCfnStackResourceDeleter {
+  private readonly resources: ReadonlyMap<string, SimCfnResource>;
+  private readonly stackName: string;
+  private readonly batchDeleter: SimCfnStackResourceBatchDeleter;
+
+  constructor(properties: SimCfnStackResourceDeleterProperties) {
+    const { simAws, resources, stackName } = properties;
+
+    this.resources = resources;
+    this.stackName = stackName;
+    this.batchDeleter = new SimCfnStackResourceBatchDeleter({
+      simAws,
+      resources,
+    });
+  }
+
+  /**
+   * Delete every Stack Resource once nothing depends on it any more.
+   *
+   * The loop is sequential between batches because a Resource can only go once
+   * the Resources naming it have gone. Deletion inside a batch is parallel and
+   * delegated to SimCfnStackResourceBatchDeleter.
+   *
+   * If a loop iteration finds pending Resources but none are deletable, the
+   * template's dependencies are cyclic, the same condition creation reports.
+   */
+  async deleteAll(): Promise<void> {
+    let pendingDeletions = new SimCfnStackPendingDeletions(this.resources);
+
+    while (pendingDeletions.hasResources) {
+      const deletableResources = pendingDeletions.deletableResources();
+
+      if (deletableResources.length === 0) {
+        throw new Error(
+          `Could not resolve simulated CloudFormation Resource dependencies to delete Stack ${this.stackName}`,
+        );
+      }
+
+      // eslint-disable-next-line no-await-in-loop
+      await this.batchDeleter.delete(deletableResources);
+
+      pendingDeletions = pendingDeletions.incompleteResources();
+    }
+  }
+}

--- a/src/service/cloudformation/stack/teardown/sim-cfn-stack-teardown.iso.test.ts
+++ b/src/service/cloudformation/stack/teardown/sim-cfn-stack-teardown.iso.test.ts
@@ -1,0 +1,184 @@
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimCfnResource } from "../../resource/sim-cfn-resource.js";
+import { SimCfnStackResourceDeleter } from "./sim-cfn-stack-resource-deleter.js";
+
+describe("SimCfnStack teardown", () => {
+  it("deletes Resources in reverse dependency order", async () => {
+    // Given a Stack whose Resources depend on each other in a line, deployed
+    // so every one of them exists.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "chain-stack",
+      template: {
+        Resources: {
+          First: { Type: "AWS::CloudFormation::WaitConditionHandle" },
+          Second: {
+            Type: "AWS::CloudFormation::WaitConditionHandle",
+            DependsOn: "First",
+          },
+          Third: {
+            Type: "AWS::CloudFormation::WaitConditionHandle",
+            DependsOn: "Second",
+          },
+        },
+      },
+    });
+    await stack.waitForDeployComplete();
+
+    // When the Stack's Resources are torn down.
+    await stack.teardown();
+
+    // Then every Resource reports a completed deletion.
+    for (const logicalId of ["First", "Second", "Third"]) {
+      assertIdentical(
+        stack.resources.get(logicalId)?.status,
+        "DELETE_COMPLETE",
+        `${logicalId} status`,
+      );
+    }
+
+    // And nothing was recorded as undeletable.
+    assertArrayLength(stack.skippedResourceDeletions, 0);
+  });
+
+  it("leaves a Resource standing until its dependents have gone", async () => {
+    // Given a Bucket policy that names its Bucket, so deleting the Bucket
+    // first would leave the policy nothing to be taken off.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "ordered-stack",
+      template: {
+        Resources: {
+          DataBucket: {
+            Type: "AWS::S3::Bucket",
+            Properties: { BucketName: "data" },
+          },
+          DataBucketPolicy: {
+            Type: "AWS::S3::BucketPolicy",
+            Properties: {
+              Bucket: { Ref: "DataBucket" },
+              PolicyDocument: {
+                Version: "2012-10-17",
+                Statement: [
+                  {
+                    Effect: "Allow",
+                    Principal: { AWS: "arn:aws:iam::111111111111:root" },
+                    Action: "s3:GetObject",
+                    Resource: "arn:aws:s3:::data/*",
+                  },
+                ],
+              },
+            },
+          },
+        },
+      },
+    });
+
+    // When the Stack's Resources are torn down.
+    await stack.teardown();
+
+    // Then both are gone, which only happens if the policy went first: taking
+    // a policy off a Bucket that is not there is refused by S3.
+    assertIdentical(
+      stack.resources.get("DataBucketPolicy")?.status,
+      "DELETE_COMPLETE",
+    );
+    assertIdentical(
+      stack.resources.get("DataBucket")?.status,
+      "DELETE_COMPLETE",
+    );
+  });
+
+  it("steps over a Resource whose type was never created", async () => {
+    // Given a Stack carrying a Resource type this simulation does not create.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "skipped-stack",
+      template: {
+        Resources: {
+          Handle: { Type: "AWS::CloudFormation::WaitConditionHandle" },
+          Cluster: { Type: "AWS::ECS::Cluster" },
+        },
+      },
+    });
+    await stack.waitForDeployComplete();
+
+    assertArrayLength(stack.skippedResources, 1);
+
+    // When the Stack's Resources are torn down.
+    await stack.teardown();
+
+    // Then the skipped Resource is delete-complete without any service being
+    // asked to delete something it never made.
+    assertIdentical(stack.resources.get("Cluster")?.status, "DELETE_COMPLETE");
+    assertArrayLength(stack.skippedResourceDeletions, 0);
+  });
+
+  it("reports Resources whose deletion nothing could carry out", async () => {
+    // Given a deployed Stack where a Resource's deletion was recorded rather
+    // than carried out, as an unsupported Resource type's creation is.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "unremovable-stack",
+      template: {
+        Resources: {
+          Handle: { Type: "AWS::CloudFormation::WaitConditionHandle" },
+        },
+      },
+    });
+    await stack.waitForDeployComplete();
+
+    const resource = stack.resources.get("Handle");
+    assertNonNullable(resource);
+
+    // When that Resource records a skipped deletion.
+    resource.markDeleteSkipped("nothing deletes a WaitConditionHandle");
+
+    // Then the Stack reports it, so a teardown says what it left behind.
+    assertArrayLength(stack.skippedResourceDeletions, 1);
+    assertIdentical(stack.skippedResourceDeletions[0], resource);
+  });
+
+  it("fails a teardown whose Resources cannot make progress", async () => {
+    // Given Resources that depend on each other in a circle, so no Resource is
+    // ever the last one standing.
+    const simAws = new SimAws();
+    const resourceLogicalIds = new Set(["Left", "Right"]);
+    const resourceOf = (logicalId: string, dependsOn: string): SimCfnResource =>
+      new SimCfnResource({
+        logicalId,
+        template: {
+          Type: "AWS::CloudFormation::WaitConditionHandle",
+          DependsOn: dependsOn,
+        },
+        resourceLogicalIds,
+      });
+    const resources = new Map([
+      ["Left", resourceOf("Left", "Right")],
+      ["Right", resourceOf("Right", "Left")],
+    ]);
+
+    // When the Resources are torn down.
+    const error = await assertThrowsErrorAsync(async () =>
+      new SimCfnStackResourceDeleter({
+        simAws,
+        resources,
+        stackName: "cyclic-stack",
+      }).deleteAll(),
+    );
+
+    // Then the teardown reports the deadlock, naming the Stack, as deployment
+    // reports the same template.
+    assertStringIncludes(error.message, "cyclic-stack");
+    assertStringIncludes(error.message, "Could not resolve");
+  });
+});

--- a/src/service/cloudfront/cfn/distro/sim-cfn-cf-distro-deleter.ts
+++ b/src/service/cloudfront/cfn/distro/sim-cfn-cf-distro-deleter.ts
@@ -1,0 +1,64 @@
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCloudFront } from "../../sim-cloudfront.js";
+import type { SimCloudFrontDistribution } from "../../distribution/sim-cloudfront-distribution.js";
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+
+interface SimCfnCfDistroDeleterProperties {
+  readonly cloudFront: SimCloudFront;
+}
+
+/**
+ * Deletes simulated Distributions created from AWS::CloudFront::Distribution
+ * Resources.
+ *
+ * CloudFront refuses to delete a Distribution that is still serving, so this
+ * disables it first, which is what makes deleting one a two-command sequence
+ * everywhere: UpdateDistribution with `Enabled: false`, then
+ * DeleteDistribution. CloudFormation does the disable itself rather than asking
+ * the template to declare a disabled Distribution before it can be removed.
+ *
+ * The Distribution is updated with the configuration it already has, so nothing
+ * but `Enabled` changes on the way out.
+ */
+export class SimCfnCfDistroDeleter {
+  private readonly cloudFront: SimCloudFront;
+
+  constructor(properties: SimCfnCfDistroDeleterProperties) {
+    this.cloudFront = properties.cloudFront;
+  }
+
+  /**
+   * Disable and then delete the Distribution a Resource created.
+   */
+  async delete(resource: SimCfnResource): Promise<void> {
+    const distribution = resource.simResource as
+      SimCloudFrontDistribution | undefined;
+    assertDefined(
+      distribution,
+      `sim CloudFront Distribution for CloudFormation Resource ${resource.logicalId}`,
+    );
+
+    await this.disable(distribution);
+
+    await this.cloudFront.deleteDistribution({
+      input: { Id: distribution.distributionId },
+    });
+  }
+
+  private async disable(
+    distribution: SimCloudFrontDistribution,
+  ): Promise<void> {
+    const { distributionConfig } = distribution;
+    assertDefined(
+      distributionConfig,
+      `sim CloudFront Distribution ${distribution.distributionId} configuration to disable`,
+    );
+
+    await this.cloudFront.updateDistribution({
+      input: {
+        Id: distribution.distributionId,
+        DistributionConfig: { ...distributionConfig, Enabled: false },
+      },
+    });
+  }
+}

--- a/src/service/cloudfront/cfn/distro/sim-cfn-cf-distro.iso.test.ts
+++ b/src/service/cloudfront/cfn/distro/sim-cfn-cf-distro.iso.test.ts
@@ -146,7 +146,6 @@ describe("CloudFront CloudFormation Distribution", () => {
     assertTypeString(distributionId);
 
     const resolvedWaitHandleProperties = waitHandleResource.resolvedProperties({
-      simAws,
       resources: stack.resources,
     });
 

--- a/src/service/cloudfront/cfn/sim-cfn-cloudfront-resource-factory.ts
+++ b/src/service/cloudfront/cfn/sim-cfn-cloudfront-resource-factory.ts
@@ -6,17 +6,24 @@ import type {
 } from "../../cloudformation/resource/sim-cfn-resource.js";
 import { SimCfnCfDistroCreator } from "./distro/sim-cfn-cf-distro-creator.js";
 import { SimCfnCffCreator } from "./cff/sim-cfn-cff-creator.js";
+import { SimCfnCfDistroDeleter } from "./distro/sim-cfn-cf-distro-deleter.js";
+import type { SimCloudFrontFunction } from "../cff/sim-cloudfront-function.js";
+import { assertDefined } from "../../../util/type-guard/defined.js";
 
 /**
  * CloudFormation Resource factory for simulated CloudFront resources.
  */
 export class SimCloudFrontCloudFormationResourceFactory implements SimCfnServiceResourceFactory {
+  private readonly cloudFront: SimCloudFront;
   private readonly distroCreator: SimCfnCfDistroCreator;
   private readonly functionCreator: SimCfnCffCreator;
+  private readonly distroDeleter: SimCfnCfDistroDeleter;
 
   constructor(cloudFront: SimCloudFront) {
+    this.cloudFront = cloudFront;
     this.distroCreator = new SimCfnCfDistroCreator({ cloudFront });
     this.functionCreator = new SimCfnCffCreator({ cloudFront });
+    this.distroDeleter = new SimCfnCfDistroDeleter({ cloudFront });
   }
 
   /**
@@ -47,5 +54,43 @@ export class SimCloudFrontCloudFormationResourceFactory implements SimCfnService
         );
       }
     }
+  }
+
+  /**
+   * Delete a simulated CloudFront resource created from a CloudFormation
+   * Resource.
+   */
+  async delete(
+    resourceTypeName: string,
+    resource: SimCfnResource,
+  ): Promise<void> {
+    switch (resourceTypeName) {
+      case "Distribution": {
+        await this.distroDeleter.delete(resource);
+        return;
+      }
+      case "Function": {
+        await this.deleteFunction(resource);
+        return;
+      }
+      default: {
+        throw new Error(
+          `Unsupported sim CloudFront CloudFormation Resource ${resourceTypeName} deletion`,
+        );
+      }
+    }
+  }
+
+  private async deleteFunction(resource: SimCfnResource): Promise<void> {
+    const cloudFrontFunction = resource.simResource as
+      SimCloudFrontFunction | undefined;
+    assertDefined(
+      cloudFrontFunction,
+      `sim CloudFront Function for CloudFormation Resource ${resource.logicalId}`,
+    );
+
+    await this.cloudFront.deleteFunction({
+      input: { Name: cloudFrontFunction.name },
+    });
   }
 }

--- a/src/service/cloudfront/cfn/sim-cfn-cloudfront-teardown.iso.test.ts
+++ b/src/service/cloudfront/cfn/sim-cfn-cloudfront-teardown.iso.test.ts
@@ -1,0 +1,117 @@
+import {
+  assertFalse,
+  assertIdentical,
+  assertNonNullable,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import type { SimCloudFrontDistribution } from "../distribution/sim-cloudfront-distribution.js";
+import type { SimCloudFrontFunctionName } from "../cff/sim-cloudfront-function.js";
+
+const template = {
+  Resources: {
+    SiteBucket: {
+      Type: "AWS::S3::Bucket",
+      Properties: { BucketName: "site-bucket" },
+    },
+    SiteFunction: {
+      Type: "AWS::CloudFront::Function",
+      Properties: {
+        Name: "site-function",
+        FunctionCode: "function handler(event) { return event.request; }",
+      },
+    },
+    SiteDistribution: {
+      Type: "AWS::CloudFront::Distribution",
+      DependsOn: "SiteBucket",
+      Properties: {
+        DistributionConfig: {
+          Enabled: true,
+          Origins: {
+            Items: [
+              {
+                Id: "SiteOrigin",
+                DomainName: "site-bucket.s3.amazonaws.com",
+                S3OriginConfig: {},
+              },
+            ],
+          },
+          DefaultCacheBehavior: {
+            TargetOriginId: "SiteOrigin",
+            ViewerProtocolPolicy: "redirect-to-https",
+            FunctionAssociations: {
+              Items: [
+                {
+                  EventType: "viewer-request",
+                  FunctionARN: {
+                    "Fn::GetAtt": ["SiteFunction", "FunctionARN"],
+                  },
+                },
+              ],
+            },
+          },
+        },
+      },
+    },
+  },
+};
+
+describe("CloudFront CloudFormation Resource teardown", () => {
+  it("disables a Distribution before deleting it", async () => {
+    // Given a deployed Distribution, which CloudFront only accepts a deletion
+    // for once it has been disabled.
+    const simAws = new SimAws();
+    const stack = await simAws
+      .cloudFormation()
+      .deployTemplate({ stackName: "site-stack", template });
+    await stack.waitForDeployComplete();
+
+    const distribution = stack.resources.get("SiteDistribution")
+      ?.simResource as SimCloudFrontDistribution | undefined;
+    assertNonNullable(distribution);
+    // The template asked for an enabled Distribution, so a teardown that only
+    // called DeleteDistribution would be refused.
+
+    // When the Stack's Resources are torn down.
+    await stack.teardown();
+
+    // Then the Distribution was disabled on its way out and is gone.
+    assertFalse(distribution.enabled);
+    assertUndefined(
+      simAws.cloudFront().getSimDistributionById(distribution.distributionId),
+    );
+    assertIdentical(
+      stack.resources.get("SiteDistribution")?.status,
+      "DELETE_COMPLETE",
+    );
+  });
+
+  it("deletes a CloudFront Function after the Distribution using it", async () => {
+    // Given a deployed Distribution with a Function associated to a behaviour.
+    const simAws = new SimAws();
+    const stack = await simAws
+      .cloudFormation()
+      .deployTemplate({ stackName: "function-stack", template });
+    await stack.waitForDeployComplete();
+
+    const functionName = "site-function" as SimCloudFrontFunctionName;
+    assertNonNullable(
+      simAws.cloudFront().getCloudFrontFunctionByName(functionName),
+    );
+
+    // When the Stack's Resources are torn down.
+    await stack.teardown();
+
+    // Then the Function is gone too, which only works because the Distribution
+    // associating it went first.
+    assertUndefined(
+      simAws.cloudFront().getCloudFrontFunctionByName(functionName),
+    );
+    assertIdentical(
+      stack.resources.get("SiteFunction")?.status,
+      "DELETE_COMPLETE",
+    );
+  });
+});

--- a/src/service/cognito/cfn/sim-cfn-cognito-resource-deleter.ts
+++ b/src/service/cognito/cfn/sim-cfn-cognito-resource-deleter.ts
@@ -1,0 +1,86 @@
+import type { SimCfnResource } from "../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCognitoIdentityProvider } from "../sim-cognito-identity-provider.js";
+import type { SimCognitoUserPool } from "../user-pool/sim-cognito-user-pool.js";
+import type { SimCognitoUserPoolClient } from "../user-pool/client/sim-cognito-user-pool-client.js";
+import type { SimCognitoGroup } from "../user-pool/group/sim-cognito-group.js";
+import { assertDefined } from "../../../util/type-guard/defined.js";
+
+interface SimCfnCognitoResourceDeleterProperties {
+  readonly cognito: SimCognitoIdentityProvider;
+}
+
+/**
+ * Deletes the simulated Cognito resources a CloudFormation Stack created.
+ *
+ * An app client and a group both belong to a pool, and each carries the pool it
+ * belongs to, so neither has to be found from the template again.
+ */
+export class SimCfnCognitoResourceDeleter {
+  private readonly cognito: SimCognitoIdentityProvider;
+
+  constructor(properties: SimCfnCognitoResourceDeleterProperties) {
+    this.cognito = properties.cognito;
+  }
+
+  /**
+   * Delete a simulated Cognito resource created from a CloudFormation Resource.
+   */
+  async delete(
+    resourceTypeName: string,
+    resource: SimCfnResource,
+  ): Promise<void> {
+    switch (resourceTypeName) {
+      case "UserPool": {
+        await this.deleteUserPool(resource);
+        return;
+      }
+      case "UserPoolClient": {
+        await this.deleteClient(resource);
+        return;
+      }
+      case "UserPoolGroup": {
+        await this.deleteGroup(resource);
+        return;
+      }
+      default: {
+        throw new Error(
+          `Unsupported sim Cognito CloudFormation Resource ${resourceTypeName} deletion`,
+        );
+      }
+    }
+  }
+
+  private async deleteUserPool(resource: SimCfnResource): Promise<void> {
+    const userPool = resource.simResource as SimCognitoUserPool | undefined;
+    assertDefined(
+      userPool,
+      `sim Cognito user pool for CloudFormation Resource ${resource.logicalId}`,
+    );
+
+    await this.cognito.deleteUserPool({ input: { UserPoolId: userPool.id } });
+  }
+
+  private async deleteClient(resource: SimCfnResource): Promise<void> {
+    const client = resource.simResource as SimCognitoUserPoolClient | undefined;
+    assertDefined(
+      client,
+      `sim Cognito app client for CloudFormation Resource ${resource.logicalId}`,
+    );
+
+    await this.cognito.deleteUserPoolClient({
+      input: { UserPoolId: client.userPoolId, ClientId: client.id },
+    });
+  }
+
+  private async deleteGroup(resource: SimCfnResource): Promise<void> {
+    const group = resource.simResource as SimCognitoGroup | undefined;
+    assertDefined(
+      group,
+      `sim Cognito group for CloudFormation Resource ${resource.logicalId}`,
+    );
+
+    await this.cognito.deleteGroup({
+      input: { UserPoolId: group.userPoolId, GroupName: group.name },
+    });
+  }
+}

--- a/src/service/cognito/cfn/sim-cfn-cognito-resource-factory.ts
+++ b/src/service/cognito/cfn/sim-cfn-cognito-resource-factory.ts
@@ -7,6 +7,7 @@ import type { SimCognitoIdentityProvider } from "../sim-cognito-identity-provide
 import { SimCfnCognitoClientCreator } from "./client/sim-cfn-cognito-client-creator.js";
 import { SimCfnCognitoGroupCreator } from "./group/sim-cfn-cognito-group-creator.js";
 import { SimCfnCognitoUserPoolCreator } from "./user-pool/sim-cfn-cognito-user-pool-creator.js";
+import { SimCfnCognitoResourceDeleter } from "./sim-cfn-cognito-resource-deleter.js";
 
 interface SimCognitoCfnResourceFactoryProperties {
   readonly cognito: SimCognitoIdentityProvider;
@@ -19,6 +20,7 @@ export class SimCognitoCfnResourceFactory implements SimCfnServiceResourceFactor
   private readonly userPoolCreator: SimCfnCognitoUserPoolCreator;
   private readonly clientCreator: SimCfnCognitoClientCreator;
   private readonly groupCreator: SimCfnCognitoGroupCreator;
+  private readonly deleter: SimCfnCognitoResourceDeleter;
 
   constructor(properties: SimCognitoCfnResourceFactoryProperties) {
     const { cognito } = properties;
@@ -26,6 +28,7 @@ export class SimCognitoCfnResourceFactory implements SimCfnServiceResourceFactor
     this.userPoolCreator = new SimCfnCognitoUserPoolCreator({ cognito });
     this.clientCreator = new SimCfnCognitoClientCreator({ cognito });
     this.groupCreator = new SimCfnCognitoGroupCreator({ cognito });
+    this.deleter = new SimCfnCognitoResourceDeleter({ cognito });
   }
 
   /**
@@ -58,5 +61,15 @@ export class SimCognitoCfnResourceFactory implements SimCfnServiceResourceFactor
         );
       }
     }
+  }
+
+  /**
+   * Delete a simulated Cognito resource created from a CloudFormation Resource.
+   */
+  async delete(
+    resourceTypeName: string,
+    resource: SimCfnResource,
+  ): Promise<void> {
+    await this.deleter.delete(resourceTypeName, resource);
   }
 }

--- a/src/service/cognito/cfn/sim-cfn-cognito-teardown.iso.test.ts
+++ b/src/service/cognito/cfn/sim-cfn-cognito-teardown.iso.test.ts
@@ -1,0 +1,64 @@
+import {
+  assertIdentical,
+  assertThrowsErrorAsync,
+  assertTypeString,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { DescribeUserPoolCommand } from "@aws-sdk/client-cognito-identity-provider";
+
+import { SimAws } from "../../aws/sim-aws.js";
+
+describe("Cognito CloudFormation Resource teardown", () => {
+  it("deletes a user pool after the client and group in it", async () => {
+    // Given a deployed user pool with an app client and a group.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "app-stack",
+      template: {
+        Resources: {
+          AppPool: {
+            Type: "AWS::Cognito::UserPool",
+            Properties: { UserPoolName: "myapp-users" },
+          },
+          AppClient: {
+            Type: "AWS::Cognito::UserPoolClient",
+            Properties: {
+              UserPoolId: { Ref: "AppPool" },
+              ClientName: "web",
+            },
+          },
+          AdminsGroup: {
+            Type: "AWS::Cognito::UserPoolGroup",
+            Properties: {
+              UserPoolId: { Ref: "AppPool" },
+              GroupName: "admins",
+            },
+          },
+        },
+      },
+    });
+    await stack.waitForDeployComplete();
+
+    const userPoolId = stack.resources.get("AppPool")?.refValue;
+    assertTypeString(userPoolId);
+
+    // When the Stack's Resources are torn down.
+    await stack.teardown();
+
+    // Then the pool is gone, and so is everything that was in it.
+    await assertThrowsErrorAsync(async () =>
+      simAws
+        .cognitoIdentityProvider()
+        .describeUserPool(
+          new DescribeUserPoolCommand({ UserPoolId: userPoolId }),
+        ),
+    );
+    for (const logicalId of ["AdminsGroup", "AppClient", "AppPool"]) {
+      assertIdentical(
+        stack.resources.get(logicalId)?.status,
+        "DELETE_COMPLETE",
+        `${logicalId} status`,
+      );
+    }
+  });
+});

--- a/src/service/dynamodb/cfn/sim-cfn-dynamodb-resource-deleter.ts
+++ b/src/service/dynamodb/cfn/sim-cfn-dynamodb-resource-deleter.ts
@@ -1,0 +1,48 @@
+import type { SimCfnResource } from "../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimDynamoDb } from "../sim-dynamodb.js";
+import type { SimDynamoDbTable } from "../table/sim-dynamodb-table.js";
+import { assertDefined } from "../../../util/type-guard/defined.js";
+
+interface SimCfnDynamoDbResourceDeleterProperties {
+  readonly dynamoDb: SimDynamoDb;
+}
+
+/**
+ * Deletes the simulated DynamoDB tables a CloudFormation Stack created.
+ *
+ * Both Resource types made a table, so both are deleted as one. A table with
+ * deletion protection turned on is refused by the ordinary command, as it is on
+ * AWS, where it is the whole point of the setting.
+ */
+export class SimCfnDynamoDbResourceDeleter {
+  private readonly dynamoDb: SimDynamoDb;
+
+  constructor(properties: SimCfnDynamoDbResourceDeleterProperties) {
+    this.dynamoDb = properties.dynamoDb;
+  }
+
+  /**
+   * Delete a simulated DynamoDB resource created from a CloudFormation
+   * Resource.
+   */
+  async delete(
+    resourceTypeName: string,
+    resource: SimCfnResource,
+  ): Promise<void> {
+    if (resourceTypeName !== "Table" && resourceTypeName !== "GlobalTable") {
+      throw new Error(
+        `Unsupported sim DynamoDB CloudFormation Resource ${resourceTypeName} deletion`,
+      );
+    }
+
+    const table = resource.simResource as SimDynamoDbTable | undefined;
+    assertDefined(
+      table,
+      `sim DynamoDB table for CloudFormation Resource ${resource.logicalId}`,
+    );
+
+    await this.dynamoDb.deleteTable({
+      input: { TableName: table.tableName },
+    });
+  }
+}

--- a/src/service/dynamodb/cfn/sim-cfn-dynamodb-resource-factory.ts
+++ b/src/service/dynamodb/cfn/sim-cfn-dynamodb-resource-factory.ts
@@ -6,6 +6,7 @@ import type {
 import type { SimDynamoDb } from "../sim-dynamodb.js";
 import { SimCfnDynamoDbGlobalTableCreator } from "./global-table/sim-cfn-dynamodb-global-table-creator.js";
 import { SimCfnDynamoDbTableCreator } from "./table/sim-cfn-dynamodb-table-creator.js";
+import { SimCfnDynamoDbResourceDeleter } from "./sim-cfn-dynamodb-resource-deleter.js";
 
 interface SimDynamoDbCfnResourceFactoryProperties {
   readonly dynamoDb: SimDynamoDb;
@@ -17,6 +18,7 @@ interface SimDynamoDbCfnResourceFactoryProperties {
 export class SimDynamoDbCfnResourceFactory implements SimCfnServiceResourceFactory {
   private readonly tableCreator: SimCfnDynamoDbTableCreator;
   private readonly globalTableCreator: SimCfnDynamoDbGlobalTableCreator;
+  private readonly deleter: SimCfnDynamoDbResourceDeleter;
 
   constructor(properties: SimDynamoDbCfnResourceFactoryProperties) {
     this.tableCreator = new SimCfnDynamoDbTableCreator({
@@ -24,6 +26,9 @@ export class SimDynamoDbCfnResourceFactory implements SimCfnServiceResourceFacto
     });
     this.globalTableCreator = new SimCfnDynamoDbGlobalTableCreator({
       tableCreator: this.tableCreator,
+    });
+    this.deleter = new SimCfnDynamoDbResourceDeleter({
+      dynamoDb: properties.dynamoDb,
     });
   }
 
@@ -56,5 +61,15 @@ export class SimDynamoDbCfnResourceFactory implements SimCfnServiceResourceFacto
         );
       }
     }
+  }
+
+  /**
+   * Delete a simulated DynamoDB resource created from a CloudFormation Resource.
+   */
+  async delete(
+    resourceTypeName: string,
+    resource: SimCfnResource,
+  ): Promise<void> {
+    await this.deleter.delete(resourceTypeName, resource);
   }
 }

--- a/src/service/dynamodb/cfn/sim-cfn-dynamodb-teardown.iso.test.ts
+++ b/src/service/dynamodb/cfn/sim-cfn-dynamodb-teardown.iso.test.ts
@@ -1,0 +1,41 @@
+import { assertIdentical, assertThrowsErrorAsync } from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { DescribeTableCommand } from "@aws-sdk/client-dynamodb";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import { simCfnDynamoDbTableResourceFactory } from "./table/sim-cfn-dynamodb-table-resource.factory.js";
+
+describe("DynamoDB CloudFormation Resource teardown", () => {
+  it("deletes the table a Stack created", async () => {
+    // Given a deployed table.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: {
+        Resources: {
+          OrdersTable: simCfnDynamoDbTableResourceFactory.make({
+            tableName: "orders",
+            partitionKeyName: "customerId",
+          }),
+        },
+      },
+    });
+    await stack.waitForDeployComplete();
+    await simAws.backgroundTasksComplete();
+
+    // When the Stack's Resources are torn down.
+    await stack.teardown();
+    await simAws.backgroundTasksComplete();
+
+    // Then DescribeTable no longer finds it.
+    await assertThrowsErrorAsync(async () =>
+      simAws
+        .dynamoDb()
+        .describeTable(new DescribeTableCommand({ TableName: "orders" })),
+    );
+    assertIdentical(
+      stack.resources.get("OrdersTable")?.status,
+      "DELETE_COMPLETE",
+    );
+  });
+});

--- a/src/service/iam/cfn/managed-policy/sim-cfn-iam-managed-policy.iso.test.ts
+++ b/src/service/iam/cfn/managed-policy/sim-cfn-iam-managed-policy.iso.test.ts
@@ -222,7 +222,6 @@ describe("IAM CloudFormation ManagedPolicy", () => {
     );
 
     const resolvedWaitHandleProperties = waitHandleResource.resolvedProperties({
-      simAws,
       resources: stack.resources,
     });
 

--- a/src/service/iam/cfn/role/sim-cfn-iam-role-deleter.ts
+++ b/src/service/iam/cfn/role/sim-cfn-iam-role-deleter.ts
@@ -1,0 +1,65 @@
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimIam } from "../../sim-iam.js";
+import type { SimIamRole } from "../../role/sim-iam-role.js";
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+
+interface SimCfnIamRoleDeleterProperties {
+  readonly iam: SimIam;
+}
+
+/**
+ * Deletes simulated Roles created from AWS::IAM::Role Resources.
+ *
+ * DeleteRole refuses a Role that still has policies on it, so the Role's
+ * policies come off first. Real CloudFormation does the same for the policies
+ * it put there itself: a `ManagedPolicyArns` entry is detached and a `Policies`
+ * entry removed as part of deleting the Role, rather than being left for the
+ * caller to clear up.
+ *
+ * An AWS::IAM::Policy Resource naming this Role is a separate Resource, and the
+ * teardown order takes it off before reaching the Role. Removing whatever is
+ * left here covers the policies the Role Resource declared inline.
+ */
+export class SimCfnIamRoleDeleter {
+  private readonly iam: SimIam;
+
+  constructor(properties: SimCfnIamRoleDeleterProperties) {
+    this.iam = properties.iam;
+  }
+
+  /**
+   * Delete the Role a CloudFormation Resource created.
+   */
+  async delete(resource: SimCfnResource): Promise<void> {
+    const role = resource.simResource as SimIamRole | undefined;
+    assertDefined(
+      role,
+      `sim IAM Role for CloudFormation Resource ${resource.logicalId}`,
+    );
+
+    await this.detachPolicies(role);
+    await this.deleteInlinePolicies(role);
+
+    await this.iam.deleteRole({ input: { RoleName: role.roleName } });
+  }
+
+  private async detachPolicies(role: SimIamRole): Promise<void> {
+    await Promise.all(
+      [...role.attachedPolicyArns].map(async (policyArn) =>
+        this.iam.detachRolePolicy({
+          input: { RoleName: role.roleName, PolicyArn: policyArn },
+        }),
+      ),
+    );
+  }
+
+  private async deleteInlinePolicies(role: SimIamRole): Promise<void> {
+    await Promise.all(
+      role.inlinePolicies.keys().map(async (policyName) =>
+        this.iam.deleteRolePolicy({
+          input: { RoleName: role.roleName, PolicyName: policyName },
+        }),
+      ),
+    );
+  }
+}

--- a/src/service/iam/cfn/role/sim-cfn-iam-role.iso.test.ts
+++ b/src/service/iam/cfn/role/sim-cfn-iam-role.iso.test.ts
@@ -278,7 +278,6 @@ describe("IAM CloudFormation Role", () => {
     assertIdentical(roleResource.refValue, "OutputRole");
 
     const resolvedWaitHandleProperties = waitHandleResource.resolvedProperties({
-      simAws,
       resources: stack.resources,
     });
 

--- a/src/service/iam/cfn/sim-cfn-iam-resource-deleter.ts
+++ b/src/service/iam/cfn/sim-cfn-iam-resource-deleter.ts
@@ -1,0 +1,91 @@
+import type { SimCfnResource } from "../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimIam } from "../sim-iam.js";
+import type { SimIamManagedPolicy } from "../policy/sim-iam-policy.js";
+import { SimCfnIamRoleDeleter } from "./role/sim-cfn-iam-role-deleter.js";
+import { assertDefined } from "../../../util/type-guard/defined.js";
+
+interface SimCfnIamResourceDeleterProperties {
+  readonly iam: SimIam;
+}
+
+/**
+ * Deletes the simulated IAM resources a CloudFormation Stack created.
+ */
+export class SimCfnIamResourceDeleter {
+  private readonly iam: SimIam;
+  private readonly roleDeleter: SimCfnIamRoleDeleter;
+
+  constructor(properties: SimCfnIamResourceDeleterProperties) {
+    this.iam = properties.iam;
+    this.roleDeleter = new SimCfnIamRoleDeleter({ iam: properties.iam });
+  }
+
+  /**
+   * Delete a simulated IAM resource created from a CloudFormation Resource.
+   */
+  async delete(
+    resourceTypeName: string,
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): Promise<void> {
+    switch (resourceTypeName) {
+      case "ManagedPolicy": {
+        await this.deleteManagedPolicy(resource);
+        return;
+      }
+      case "Policy": {
+        await this.deleteInlinePolicy(properties);
+        return;
+      }
+      case "Role": {
+        await this.roleDeleter.delete(resource);
+        return;
+      }
+      default: {
+        throw new Error(
+          `Unsupported sim IAM CloudFormation Resource ${resourceTypeName} deletion`,
+        );
+      }
+    }
+  }
+
+  private async deleteManagedPolicy(resource: SimCfnResource): Promise<void> {
+    const policy = resource.simResource as SimIamManagedPolicy | undefined;
+    assertDefined(
+      policy,
+      `sim IAM Managed Policy for CloudFormation Resource ${resource.logicalId}`,
+    );
+
+    await this.iam.deletePolicy({ input: { PolicyArn: policy.arn } });
+  }
+
+  /**
+   * Take an AWS::IAM::Policy back off the Roles it was put on.
+   *
+   * The Resource has no stored object of its own, so the Roles are read from
+   * the template the same way creation read them. Their Refs still resolve,
+   * because a Role is deleted after the policies naming it.
+   */
+  private async deleteInlinePolicy(
+    properties: SimCfnTemplateValueRecord,
+  ): Promise<void> {
+    const policyName = properties["PolicyName"];
+    const roles = properties["Roles"];
+
+    /* v8 ignore if -- creation refused the Resource if either was missing */
+    if (typeof policyName !== "string" || !Array.isArray(roles)) {
+      return;
+    }
+
+    await Promise.all(
+      roles
+        .filter((roleName): roleName is string => typeof roleName === "string")
+        .map(async (roleName) =>
+          this.iam.deleteRolePolicy({
+            input: { RoleName: roleName, PolicyName: policyName },
+          }),
+        ),
+    );
+  }
+}

--- a/src/service/iam/cfn/sim-cfn-iam-resource-factory.ts
+++ b/src/service/iam/cfn/sim-cfn-iam-resource-factory.ts
@@ -7,6 +7,8 @@ import type { SimIam } from "../sim-iam.js";
 import { SimCfnIamManagedPolicyCreator } from "./managed-policy/sim-cfn-iam-managed-policy-creator.js";
 import { SimCfnIamPolicyCreator } from "./policy/sim-cfn-iam-policy-creator.js";
 import { SimCfnIamRoleCreator } from "./role/sim-cfn-iam-role-creator.js";
+import { SimCfnIamResourceDeleter } from "./sim-cfn-iam-resource-deleter.js";
+import type { SimCloudFormationResourceDeleteContext } from "../../cloudformation/resource/sim-cfn-resource.type.js";
 
 /**
  * CloudFormation Resource factory for simulated IAM resources.
@@ -15,11 +17,13 @@ export class SimIamCloudFormationResourceFactory implements SimCfnServiceResourc
   private readonly managedPolicyCreator: SimCfnIamManagedPolicyCreator;
   private readonly policyCreator: SimCfnIamPolicyCreator;
   private readonly roleCreator: SimCfnIamRoleCreator;
+  private readonly deleter: SimCfnIamResourceDeleter;
 
   constructor(iam: SimIam) {
     this.managedPolicyCreator = new SimCfnIamManagedPolicyCreator({ iam });
     this.policyCreator = new SimCfnIamPolicyCreator({ iam });
     this.roleCreator = new SimCfnIamRoleCreator({ iam });
+    this.deleter = new SimCfnIamResourceDeleter({ iam });
   }
 
   /**
@@ -56,5 +60,20 @@ export class SimIamCloudFormationResourceFactory implements SimCfnServiceResourc
         );
       }
     }
+  }
+
+  /**
+   * Delete a simulated IAM resource created from a CloudFormation Resource.
+   */
+  async delete(
+    resourceTypeName: string,
+    resource: SimCfnResource,
+    context: SimCloudFormationResourceDeleteContext,
+  ): Promise<void> {
+    await this.deleter.delete(
+      resourceTypeName,
+      resource,
+      context.resolvedProperties ?? resource.properties,
+    );
   }
 }

--- a/src/service/iam/cfn/sim-cfn-iam-teardown.iso.test.ts
+++ b/src/service/iam/cfn/sim-cfn-iam-teardown.iso.test.ts
@@ -1,0 +1,135 @@
+import {
+  assertIdentical,
+  assertMapSize,
+  assertSetSize,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import type { SimIamRole } from "../role/sim-iam-role.js";
+
+const assumeRolePolicyDocument = {
+  Version: "2012-10-17",
+  Statement: [
+    {
+      Effect: "Allow",
+      Principal: { Service: "lambda.amazonaws.com" },
+      Action: "sts:AssumeRole",
+    },
+  ],
+};
+
+const readObjectsDocument = {
+  Version: "2012-10-17",
+  Statement: [
+    { Effect: "Allow", Action: "s3:GetObject", Resource: "arn:aws:s3:::*/*" },
+  ],
+};
+
+const template = {
+  Resources: {
+    ReadPolicy: {
+      Type: "AWS::IAM::ManagedPolicy",
+      Properties: {
+        ManagedPolicyName: "read-objects",
+        PolicyDocument: readObjectsDocument,
+      },
+    },
+    HandlerRole: {
+      Type: "AWS::IAM::Role",
+      Properties: {
+        RoleName: "handler-role",
+        AssumeRolePolicyDocument: assumeRolePolicyDocument,
+        ManagedPolicyArns: [{ Ref: "ReadPolicy" }],
+        Policies: [
+          {
+            PolicyName: "inline-read",
+            PolicyDocument: readObjectsDocument,
+          },
+        ],
+      },
+    },
+    HandlerDefaultPolicy: {
+      Type: "AWS::IAM::Policy",
+      Properties: {
+        PolicyName: "handler-default",
+        Roles: [{ Ref: "HandlerRole" }],
+        PolicyDocument: readObjectsDocument,
+      },
+    },
+  },
+};
+
+describe("IAM CloudFormation Resource teardown", () => {
+  it("takes a Role's policies off it before deleting the Role", async () => {
+    // Given a deployed Role carrying an attached managed policy and two inline
+    // policies, one declared on the Role and one as its own Resource. IAM
+    // refuses DeleteRole while any of them are still on it.
+    const simAws = new SimAws();
+    const stack = await simAws
+      .cloudFormation()
+      .deployTemplate({ stackName: "handler-stack", template });
+
+    const role = stack.resources.get("HandlerRole")?.simResource as
+      SimIamRole | undefined;
+    assertIdentical(role?.roleName, "handler-role");
+    assertSetSize(role.attachedPolicyArns, 1);
+    assertMapSize(role.inlinePolicies, 2);
+
+    // When the Stack's Resources are torn down.
+    await stack.teardown();
+
+    // Then the Role is gone, along with the managed policy it used.
+    await assertThrowsErrorAsync(async () =>
+      simAws.iam().getRole({ input: { RoleName: "handler-role" } }),
+    );
+    assertUndefined(simAws.iam().roles.get(role.roleName));
+    assertIdentical(
+      stack.resources.get("ReadPolicy")?.status,
+      "DELETE_COMPLETE",
+    );
+  });
+
+  it("removes an AWS::IAM::Policy from the Roles it names", async () => {
+    // Given a Role declared outside the Stack, so it outlives the teardown and
+    // can be asked what is still on it.
+    const simAws = new SimAws();
+    await simAws.iam().createRole({
+      input: {
+        RoleName: "standing-role",
+        AssumeRolePolicyDocument: JSON.stringify(assumeRolePolicyDocument),
+      },
+    });
+
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "policy-only-stack",
+      template: {
+        Resources: {
+          StandingPolicy: {
+            Type: "AWS::IAM::Policy",
+            Properties: {
+              PolicyName: "standing-default",
+              Roles: ["standing-role"],
+              PolicyDocument: readObjectsDocument,
+            },
+          },
+        },
+      },
+    });
+
+    const role = simAws.iam().roles.get("standing-role" as never);
+    assertMapSize(role?.inlinePolicies, 1);
+
+    // When the Stack's Resources are torn down.
+    await stack.teardown();
+
+    // Then the inline policy is off the Role, which is still there.
+    assertMapSize(role.inlinePolicies, 0);
+    assertIdentical(
+      stack.resources.get("StandingPolicy")?.status,
+      "DELETE_COMPLETE",
+    );
+  });
+});

--- a/src/service/kms/cfn/sim-cfn-kms-resource-deleter.ts
+++ b/src/service/kms/cfn/sim-cfn-kms-resource-deleter.ts
@@ -1,0 +1,65 @@
+import type { SimCfnResource } from "../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimKms } from "../sim-kms.js";
+import type { SimKmsKey } from "../key/sim-kms-key.js";
+import type { SimKmsAlias } from "../key/sim-kms-alias.js";
+import { assertDefined } from "../../../util/type-guard/defined.js";
+
+interface SimCfnKmsResourceDeleterProperties {
+  readonly kms: SimKms;
+}
+
+/**
+ * Deletes the simulated KMS resources a CloudFormation Stack created.
+ *
+ * KMS has no DeleteKey. A key is scheduled for deletion and sits in
+ * `PendingDeletion` until the window runs out, so that is what a Stack deletion
+ * leaves behind: a key that is still there and can no longer be used. Anything
+ * expecting the key to be gone is expecting something KMS does not do.
+ */
+export class SimCfnKmsResourceDeleter {
+  private readonly kms: SimKms;
+
+  constructor(properties: SimCfnKmsResourceDeleterProperties) {
+    this.kms = properties.kms;
+  }
+
+  /**
+   * Delete a simulated KMS resource created from a CloudFormation Resource.
+   */
+  async delete(
+    resourceTypeName: string,
+    resource: SimCfnResource,
+  ): Promise<void> {
+    switch (resourceTypeName) {
+      case "Key": {
+        const key = resource.simResource as SimKmsKey | undefined;
+        assertDefined(
+          key,
+          `sim KMS Key for CloudFormation Resource ${resource.logicalId}`,
+        );
+
+        await this.kms.scheduleKeyDeletion({ input: { KeyId: key.keyId } });
+
+        return;
+      }
+      case "Alias": {
+        const alias = resource.simResource as SimKmsAlias | undefined;
+        assertDefined(
+          alias,
+          `sim KMS Alias for CloudFormation Resource ${resource.logicalId}`,
+        );
+
+        await this.kms.deleteAlias({
+          input: { AliasName: alias.aliasName },
+        });
+
+        return;
+      }
+      default: {
+        throw new Error(
+          `Unsupported sim KMS CloudFormation Resource ${resourceTypeName} deletion`,
+        );
+      }
+    }
+  }
+}

--- a/src/service/kms/cfn/sim-cfn-kms-resource-factory.ts
+++ b/src/service/kms/cfn/sim-cfn-kms-resource-factory.ts
@@ -6,6 +6,7 @@ import type {
 import type { SimKms } from "../sim-kms.js";
 import { SimCfnKmsAliasCreator } from "./alias/sim-cfn-kms-alias-creator.js";
 import { SimCfnKmsKeyCreator } from "./key/sim-cfn-kms-key-creator.js";
+import { SimCfnKmsResourceDeleter } from "./sim-cfn-kms-resource-deleter.js";
 
 interface SimKmsCfnResourceFactoryProperties {
   readonly kms: SimKms;
@@ -17,10 +18,12 @@ interface SimKmsCfnResourceFactoryProperties {
 export class SimKmsCfnResourceFactory implements SimCfnServiceResourceFactory {
   private readonly keyCreator: SimCfnKmsKeyCreator;
   private readonly aliasCreator: SimCfnKmsAliasCreator;
+  private readonly deleter: SimCfnKmsResourceDeleter;
 
   constructor(properties: SimKmsCfnResourceFactoryProperties) {
     this.keyCreator = new SimCfnKmsKeyCreator({ kms: properties.kms });
     this.aliasCreator = new SimCfnKmsAliasCreator({ kms: properties.kms });
+    this.deleter = new SimCfnKmsResourceDeleter({ kms: properties.kms });
   }
 
   /**
@@ -49,5 +52,15 @@ export class SimKmsCfnResourceFactory implements SimCfnServiceResourceFactory {
         );
       }
     }
+  }
+
+  /**
+   * Delete a simulated KMS resource created from a CloudFormation Resource.
+   */
+  async delete(
+    resourceTypeName: string,
+    resource: SimCfnResource,
+  ): Promise<void> {
+    await this.deleter.delete(resourceTypeName, resource);
   }
 }

--- a/src/service/kms/cfn/sim-cfn-kms-teardown.iso.test.ts
+++ b/src/service/kms/cfn/sim-cfn-kms-teardown.iso.test.ts
@@ -1,0 +1,47 @@
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import type { SimKmsKey } from "../key/sim-kms-key.js";
+
+describe("KMS CloudFormation Resource teardown", () => {
+  it("schedules the key for deletion and removes its alias", async () => {
+    // Given a deployed key with an alias. KMS has no DeleteKey, so the most a
+    // Stack deletion can do is schedule the key's deletion.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "key-stack",
+      template: {
+        Resources: {
+          AppKey: { Type: "AWS::KMS::Key" },
+          AppKeyAlias: {
+            Type: "AWS::KMS::Alias",
+            Properties: {
+              AliasName: "alias/app-key",
+              TargetKeyId: { Ref: "AppKey" },
+            },
+          },
+        },
+      },
+    });
+    await stack.waitForDeployComplete();
+
+    const key = stack.resources.get("AppKey")?.simResource as
+      SimKmsKey | undefined;
+    assertNonNullable(key);
+
+    // When the Stack's Resources are torn down.
+    await stack.teardown();
+
+    // Then the alias is gone, and the key is still there in PendingDeletion,
+    // which is as far as KMS ever takes a key.
+    assertUndefined(simAws.kms().findAlias("alias/app-key"));
+    assertIdentical(simAws.kms().findKey(key.keyId), key);
+    assertIdentical(key.keyState, "PendingDeletion");
+    assertIdentical(stack.resources.get("AppKey")?.status, "DELETE_COMPLETE");
+  });
+});

--- a/src/service/lambda/cfn/sim-cfn-lambda-deploy.iso.test.ts
+++ b/src/service/lambda/cfn/sim-cfn-lambda-deploy.iso.test.ts
@@ -225,7 +225,6 @@ describe("Lambda CloudFormation Function deployment", () => {
     assertIdentical(functionResource.refValue, "output-function");
 
     const resolvedWaitHandleProperties = waitHandleResource.resolvedProperties({
-      simAws,
       resources: stack.resources,
     });
 

--- a/src/service/lambda/cfn/sim-cfn-lambda-resource-deleter.ts
+++ b/src/service/lambda/cfn/sim-cfn-lambda-resource-deleter.ts
@@ -1,0 +1,121 @@
+import type { SimCfnResource } from "../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimLambda } from "../sim-lambda.js";
+import type { SimLambdaFunction } from "../function/sim-lambda-function.js";
+import type { SimLambdaFunctionUrl } from "../function/url/sim-lambda-function-url.js";
+import type { SimLambdaEventSourceMapping } from "../event-source/sim-lambda-event-source-mapping.js";
+import type { SimLambdaPermission } from "../function/policy/sim-lambda-permission.js";
+import { assertDefined } from "../../../util/type-guard/defined.js";
+import { simCfnLambdaTargetFunctionName } from "./function/sim-cfn-lambda-target-function.js";
+
+interface SimCfnLambdaResourceDeleterProperties {
+  readonly lambda: SimLambda;
+}
+
+/**
+ * Deletes the simulated Lambda resources a CloudFormation Stack created.
+ *
+ * Each Resource type is addressed by what its creation produced, so a URL and a
+ * permission are removed from the function they were put on rather than from
+ * the function name the template happened to write.
+ */
+export class SimCfnLambdaResourceDeleter {
+  private readonly lambda: SimLambda;
+
+  constructor(properties: SimCfnLambdaResourceDeleterProperties) {
+    this.lambda = properties.lambda;
+  }
+
+  /**
+   * Delete a simulated Lambda resource created from a CloudFormation Resource.
+   */
+  async delete(
+    resourceTypeName: string,
+    resource: SimCfnResource,
+  ): Promise<void> {
+    switch (resourceTypeName) {
+      case "Function": {
+        await this.deleteFunction(resource);
+        return;
+      }
+      case "Url": {
+        await this.deleteFunctionUrl(resource);
+        return;
+      }
+      case "EventSourceMapping": {
+        await this.deleteEventSourceMapping(resource);
+        return;
+      }
+      case "Permission": {
+        await this.removePermission(resource);
+        return;
+      }
+      default: {
+        throw new Error(
+          `Unsupported sim Lambda CloudFormation Resource ${resourceTypeName} deletion`,
+        );
+      }
+    }
+  }
+
+  private async deleteFunction(resource: SimCfnResource): Promise<void> {
+    const simFunction = resource.simResource as SimLambdaFunction | undefined;
+    assertDefined(
+      simFunction,
+      `sim Lambda Function for CloudFormation Resource ${resource.logicalId}`,
+    );
+
+    await this.lambda.deleteFunction({
+      input: { FunctionName: simFunction.name },
+    });
+  }
+
+  private async deleteFunctionUrl(resource: SimCfnResource): Promise<void> {
+    const functionUrl = resource.simResource as
+      SimLambdaFunctionUrl | undefined;
+    assertDefined(
+      functionUrl,
+      `sim Lambda Function URL for CloudFormation Resource ${resource.logicalId}`,
+    );
+
+    await this.lambda.deleteFunctionUrlConfig({
+      input: { FunctionName: functionUrl.functionName },
+    });
+  }
+
+  private async deleteEventSourceMapping(
+    resource: SimCfnResource,
+  ): Promise<void> {
+    const mapping = resource.simResource as
+      SimLambdaEventSourceMapping | undefined;
+    assertDefined(
+      mapping,
+      `sim Lambda event source mapping for CloudFormation Resource ${resource.logicalId}`,
+    );
+
+    await this.lambda.deleteEventSourceMapping({
+      input: { UUID: mapping.uuid },
+    });
+  }
+
+  /**
+   * Take a permission back off the function it was added to.
+   *
+   * The statement is named after the Resource's logical ID when it is added,
+   * because AWS::Lambda::Permission has no StatementId property, so that is
+   * what addresses it again here.
+   */
+  private async removePermission(resource: SimCfnResource): Promise<void> {
+    const permission = resource.simResource as SimLambdaPermission | undefined;
+    assertDefined(
+      permission,
+      `sim Lambda permission for CloudFormation Resource ${resource.logicalId}`,
+    );
+
+    await this.lambda.removePermission({
+      input: {
+        FunctionName: simCfnLambdaTargetFunctionName(permission.resourceArn),
+        StatementId: permission.statementId,
+      },
+    });
+  }
+}

--- a/src/service/lambda/cfn/sim-cfn-lambda-resource-factory.ts
+++ b/src/service/lambda/cfn/sim-cfn-lambda-resource-factory.ts
@@ -8,6 +8,7 @@ import { SimCfnLambdaEventSourceMappingCreator } from "./event-source-mapping/si
 import { SimCfnLambdaFunctionCreator } from "./function/sim-cfn-lambda-function-creator.js";
 import { SimCfnLambdaPermissionCreator } from "./permission/sim-cfn-lambda-permission-creator.js";
 import { SimCfnLambdaUrlCreator } from "./url/sim-cfn-lambda-url-creator.js";
+import { SimCfnLambdaResourceDeleter } from "./sim-cfn-lambda-resource-deleter.js";
 
 /**
  * CloudFormation Resource factory for simulated Lambda resources.
@@ -17,8 +18,10 @@ export class SimLambdaCloudFormationResourceFactory implements SimCfnServiceReso
   private readonly urlCreator: SimCfnLambdaUrlCreator;
   private readonly permissionCreator: SimCfnLambdaPermissionCreator;
   private readonly eventSourceMappingCreator: SimCfnLambdaEventSourceMappingCreator;
+  private readonly deleter: SimCfnLambdaResourceDeleter;
 
   constructor(lambda: SimLambda) {
+    this.deleter = new SimCfnLambdaResourceDeleter({ lambda });
     this.functionCreator = new SimCfnLambdaFunctionCreator({ lambda });
     this.urlCreator = new SimCfnLambdaUrlCreator({ lambda });
     this.permissionCreator = new SimCfnLambdaPermissionCreator({ lambda });
@@ -67,5 +70,15 @@ export class SimLambdaCloudFormationResourceFactory implements SimCfnServiceReso
         );
       }
     }
+  }
+
+  /**
+   * Delete a simulated Lambda resource created from a CloudFormation Resource.
+   */
+  async delete(
+    resourceTypeName: string,
+    resource: SimCfnResource,
+  ): Promise<void> {
+    await this.deleter.delete(resourceTypeName, resource);
   }
 }

--- a/src/service/lambda/cfn/sim-cfn-lambda-teardown.iso.test.ts
+++ b/src/service/lambda/cfn/sim-cfn-lambda-teardown.iso.test.ts
@@ -59,10 +59,10 @@ const consumerFunction = {
 };
 
 describe("Lambda CloudFormation Resource teardown", () => {
-  it("deletes a Function URL without deleting its function", async () => {
+  it("deletes a Function URL before the function it is on", async () => {
     // Given a deployed function with a Function URL on it. The URL is state on
-    // the function rather than a resource of its own, so removing it leaves
-    // the function alone.
+    // the function rather than a resource of its own, so its Resource has to
+    // be taken off before the function it names goes.
     const simAws = new SimAws();
     const stack = await simAws.cloudFormation().deployTemplate({
       stackName: "greeter-stack",
@@ -99,7 +99,8 @@ describe("Lambda CloudFormation Resource teardown", () => {
     // When the Stack's Resources are torn down.
     await stack.teardown();
 
-    // Then the URL configuration is gone, and so is the function it was on.
+    // Then the URL configuration is gone, and the function it was on has
+    // followed it out with the rest of the Stack.
     assertUndefined(simAws.lambda().getSimFunctionUrl("greeter"));
     assertUndefined(simAws.lambda().getSimFunctionByName("greeter"));
   });

--- a/src/service/lambda/cfn/sim-cfn-lambda-teardown.iso.test.ts
+++ b/src/service/lambda/cfn/sim-cfn-lambda-teardown.iso.test.ts
@@ -1,0 +1,151 @@
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import type { SimLambdaEventSourceMapping } from "../event-source/sim-lambda-event-source-mapping.js";
+
+const assumeRolePolicyDocument = {
+  Version: "2012-10-17",
+  Statement: [
+    {
+      Effect: "Allow",
+      Principal: { Service: "lambda.amazonaws.com" },
+      Action: "sts:AssumeRole",
+    },
+  ],
+};
+
+const consumerRole = {
+  Type: "AWS::IAM::Role",
+  Properties: {
+    RoleName: "consumer-role",
+    AssumeRolePolicyDocument: assumeRolePolicyDocument,
+    Policies: [
+      {
+        PolicyName: "ConsumeOrders",
+        PolicyDocument: {
+          Version: "2012-10-17",
+          Statement: [
+            {
+              Effect: "Allow",
+              Action: [
+                "sqs:ReceiveMessage",
+                "sqs:DeleteMessage",
+                "sqs:GetQueueAttributes",
+              ],
+              Resource: { "Fn::GetAtt": ["OrderQueue", "Arn"] },
+            },
+          ],
+        },
+      },
+    ],
+  },
+};
+
+const consumerFunction = {
+  Type: "AWS::Lambda::Function",
+  Properties: {
+    FunctionName: "order-consumer",
+    Role: { "Fn::GetAtt": ["ConsumerRole", "Arn"] },
+    Code: { ZipFile: "exports.handler = async () => 'consumed';" },
+    Handler: "index.handler",
+    Runtime: "nodejs22.x",
+  },
+};
+
+describe("Lambda CloudFormation Resource teardown", () => {
+  it("deletes a Function URL without deleting its function", async () => {
+    // Given a deployed function with a Function URL on it. The URL is state on
+    // the function rather than a resource of its own, so removing it leaves
+    // the function alone.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "greeter-stack",
+      template: {
+        Resources: {
+          ConsumerRole: {
+            Type: "AWS::IAM::Role",
+            Properties: {
+              RoleName: "greeter-role",
+              AssumeRolePolicyDocument: assumeRolePolicyDocument,
+            },
+          },
+          GreeterFunction: {
+            ...consumerFunction,
+            Properties: {
+              ...consumerFunction.Properties,
+              FunctionName: "greeter",
+            },
+          },
+          GreeterUrl: {
+            Type: "AWS::Lambda::Url",
+            Properties: {
+              TargetFunctionArn: { "Fn::GetAtt": ["GreeterFunction", "Arn"] },
+              AuthType: "NONE",
+            },
+          },
+        },
+      },
+    });
+    await stack.waitForDeployComplete();
+
+    assertNonNullable(simAws.lambda().getSimFunctionUrl("greeter"));
+
+    // When the Stack's Resources are torn down.
+    await stack.teardown();
+
+    // Then the URL configuration is gone, and so is the function it was on.
+    assertUndefined(simAws.lambda().getSimFunctionUrl("greeter"));
+    assertUndefined(simAws.lambda().getSimFunctionByName("greeter"));
+  });
+
+  it("deletes an event source mapping before its queue and function", async () => {
+    // Given a deployed queue, a consumer function, and a mapping between them,
+    // as CDK's fn.addEventSource(new SqsEventSource(queue)) synthesises.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "consumer-stack",
+      template: {
+        Resources: {
+          OrderQueue: {
+            Type: "AWS::SQS::Queue",
+            Properties: { QueueName: "orders" },
+          },
+          ConsumerRole: consumerRole,
+          ConsumerFunction: consumerFunction,
+          OrderConsumerMapping: {
+            Type: "AWS::Lambda::EventSourceMapping",
+            Properties: {
+              EventSourceArn: { "Fn::GetAtt": ["OrderQueue", "Arn"] },
+              FunctionName: { Ref: "ConsumerFunction" },
+              BatchSize: 5,
+            },
+          },
+        },
+      },
+    });
+    await stack.waitForDeployComplete();
+
+    const mapping = stack.resources.get("OrderConsumerMapping")?.simResource as
+      SimLambdaEventSourceMapping | undefined;
+    assertNonNullable(mapping);
+
+    // When the Stack's Resources are torn down.
+    await stack.teardown();
+
+    // Then the mapping, the queue and the function have all gone.
+    assertUndefined(simAws.lambda().getSimEventSourceMapping(mapping.uuid));
+    assertUndefined(simAws.sqs().findQueue("orders"));
+    assertUndefined(simAws.lambda().getSimFunctionByName("order-consumer"));
+    assertArrayLength(stack.skippedResourceDeletions, 0);
+    assertIdentical(
+      stack.resources.get("OrderConsumerMapping")?.status,
+      "DELETE_COMPLETE",
+    );
+  });
+});

--- a/src/service/route53/cfn/hosted-zone/sim-cfn-route53-zone.iso.test.ts
+++ b/src/service/route53/cfn/hosted-zone/sim-cfn-route53-zone.iso.test.ts
@@ -219,7 +219,6 @@ describe("Route53 CloudFormation HostedZone", () => {
     assertTypeString(hostedZoneId);
 
     const resolvedWaitHandleProperties = waitHandleResource.resolvedProperties({
-      simAws,
       resources: stack.resources,
     });
 

--- a/src/service/route53/cfn/sim-cfn-route53-resource-deleter.ts
+++ b/src/service/route53/cfn/sim-cfn-route53-resource-deleter.ts
@@ -1,0 +1,96 @@
+import type { SimCfnResource } from "../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimRoute53 } from "../sim-route53.js";
+import type { SimRoute53HostedZone } from "../hosted-zone/sim-route53-hosted-zone.js";
+import { SimCfnRoute53RecordSetBuilder } from "./record-set/build/sim-cfn-r53-record-set-builder.js";
+import { SimCfnRoute53RecordSetHostedZoneResolver } from "./record-set/resolve/sim-cfn-r53-rec-set-zone-resolver.js";
+import { assertDefined } from "../../../util/type-guard/defined.js";
+
+interface SimCfnRoute53ResourceDeleterProperties {
+  readonly route53: SimRoute53;
+}
+
+/**
+ * Deletes the simulated Route53 resources a CloudFormation Stack created.
+ *
+ * A record set has no delete command of its own. Route53 only takes changes, so
+ * removing one is a ChangeResourceRecordSets carrying a DELETE change built
+ * from the same template properties that created it.
+ *
+ * The Hosted Zone goes last, and only works because it does: DeleteHostedZone
+ * refuses a zone that still holds records, and the record set Resources naming
+ * the zone have already been taken off it by then.
+ */
+export class SimCfnRoute53ResourceDeleter {
+  private readonly route53: SimRoute53;
+  private readonly hostedZoneResolver: SimCfnRoute53RecordSetHostedZoneResolver;
+
+  constructor(properties: SimCfnRoute53ResourceDeleterProperties) {
+    this.route53 = properties.route53;
+    this.hostedZoneResolver = new SimCfnRoute53RecordSetHostedZoneResolver({
+      route53: this.route53,
+    });
+  }
+
+  /**
+   * Delete a simulated Route53 resource created from a CloudFormation Resource.
+   */
+  async delete(
+    resourceTypeName: string,
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): Promise<void> {
+    switch (resourceTypeName) {
+      case "HostedZone": {
+        await this.deleteHostedZone(resource);
+        return;
+      }
+      case "RecordSet": {
+        await this.deleteRecordSet(resource, properties);
+        return;
+      }
+      default: {
+        throw new Error(
+          `Unsupported sim Route53 CloudFormation Resource ${resourceTypeName} deletion`,
+        );
+      }
+    }
+  }
+
+  private async deleteHostedZone(resource: SimCfnResource): Promise<void> {
+    const hostedZone = resource.simResource as SimRoute53HostedZone | undefined;
+    assertDefined(
+      hostedZone,
+      `sim Route53 Hosted Zone for CloudFormation Resource ${resource.logicalId}`,
+    );
+
+    await this.route53.deleteHostedZone({ input: { Id: hostedZone.id } });
+  }
+
+  private async deleteRecordSet(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): Promise<void> {
+    const hostedZoneId = this.hostedZoneResolver.hostedZoneId(
+      resource,
+      properties,
+    );
+    const recordSet = new SimCfnRoute53RecordSetBuilder(
+      resource,
+      properties,
+    ).build();
+
+    await this.route53.changeResourceRecordSets({
+      input: {
+        HostedZoneId: hostedZoneId,
+        ChangeBatch: {
+          Changes: [{ Action: "DELETE", ResourceRecordSet: recordSet }],
+        },
+      },
+    });
+
+    await this.route53.hostedZones
+      .get(hostedZoneId)
+      ?.waitForSynchronizationComplete();
+  }
+}

--- a/src/service/route53/cfn/sim-cfn-route53-resource-factory.ts
+++ b/src/service/route53/cfn/sim-cfn-route53-resource-factory.ts
@@ -6,6 +6,8 @@ import type { SimCfnServiceResourceFactory } from "../../cloudformation/resource
 import { SimRoute53 } from "../sim-route53.js";
 import { SimCfnRoute53HostedZoneCreator } from "./hosted-zone/sim-cfn-r53-zone-creator.js";
 import { SimCfnRoute53RecordSetApplicator } from "./record-set/apply/sim-cfn-r53-record-set-applicator.js";
+import { SimCfnRoute53ResourceDeleter } from "./sim-cfn-route53-resource-deleter.js";
+import type { SimCloudFormationResourceDeleteContext } from "../../cloudformation/resource/sim-cfn-resource.type.js";
 
 interface SimRoute53CloudFormationResourceFactoryProperties {
   readonly route53?: SimRoute53 | undefined;
@@ -17,6 +19,7 @@ interface SimRoute53CloudFormationResourceFactoryProperties {
 export class SimRoute53CloudFormationResourceFactory implements SimCfnServiceResourceFactory {
   private readonly hostedZoneCreator: SimCfnRoute53HostedZoneCreator;
   private readonly recordSetCreator: SimCfnRoute53RecordSetApplicator;
+  private readonly deleter: SimCfnRoute53ResourceDeleter;
 
   constructor(
     properties: SimRoute53CloudFormationResourceFactoryProperties = {},
@@ -25,6 +28,7 @@ export class SimRoute53CloudFormationResourceFactory implements SimCfnServiceRes
 
     this.hostedZoneCreator = new SimCfnRoute53HostedZoneCreator({ route53 });
     this.recordSetCreator = new SimCfnRoute53RecordSetApplicator({ route53 });
+    this.deleter = new SimCfnRoute53ResourceDeleter({ route53 });
   }
 
   /**
@@ -54,5 +58,20 @@ export class SimRoute53CloudFormationResourceFactory implements SimCfnServiceRes
         );
       }
     }
+  }
+
+  /**
+   * Delete a simulated Route53 resource created from a CloudFormation Resource.
+   */
+  async delete(
+    resourceTypeName: string,
+    resource: SimCfnResource,
+    context: SimCloudFormationResourceDeleteContext,
+  ): Promise<void> {
+    await this.deleter.delete(
+      resourceTypeName,
+      resource,
+      context.resolvedProperties ?? resource.properties,
+    );
   }
 }

--- a/src/service/route53/cfn/sim-cfn-route53-teardown.iso.test.ts
+++ b/src/service/route53/cfn/sim-cfn-route53-teardown.iso.test.ts
@@ -1,0 +1,48 @@
+import { assertIdentical, assertMapSize } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+
+describe("Route53 CloudFormation Resource teardown", () => {
+  it("removes the records before deleting the Hosted Zone", async () => {
+    // Given a deployed Hosted Zone holding a record set. Route53 refuses to
+    // delete a zone that still holds records, and has no delete command for a
+    // record: it takes a DELETE change instead.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "dns-stack",
+      template: {
+        Resources: {
+          SiteZone: {
+            Type: "AWS::Route53::HostedZone",
+            Properties: { Name: "example.test" },
+          },
+          SiteRecord: {
+            Type: "AWS::Route53::RecordSet",
+            Properties: {
+              HostedZoneId: { Ref: "SiteZone" },
+              Name: "www.example.test",
+              Type: "A",
+              TTL: "300",
+              ResourceRecords: ["203.0.113.1"],
+            },
+          },
+        },
+      },
+    });
+    await stack.waitForDeployComplete();
+
+    assertMapSize(simAws.route53().hostedZones, 1);
+
+    // When the Stack's Resources are torn down.
+    await stack.teardown();
+
+    // Then the zone is gone, which only happens once its record went first.
+    assertMapSize(simAws.route53().hostedZones, 0);
+    assertIdentical(
+      stack.resources.get("SiteRecord")?.status,
+      "DELETE_COMPLETE",
+    );
+    assertIdentical(stack.resources.get("SiteZone")?.status, "DELETE_COMPLETE");
+  });
+});

--- a/src/service/s3/cfn/sim-cfn-s3-resource-deleter.ts
+++ b/src/service/s3/cfn/sim-cfn-s3-resource-deleter.ts
@@ -1,0 +1,72 @@
+import type { SimCfnResource } from "../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimS3Bucket } from "../bucket/sim-s3-bucket.js";
+import type { SimS3 } from "../sim-s3.js";
+import { assertDefined } from "../../../util/type-guard/defined.js";
+
+interface SimCfnS3ResourceDeleterProperties {
+  readonly simS3: SimS3;
+}
+
+/**
+ * Deletes the simulated S3 resources a CloudFormation Stack created.
+ *
+ * Both Resource types are deleted through the ordinary command path, so a
+ * teardown is refused for the same reasons an SDK caller would be. The one that
+ * matters is a Bucket still holding Objects: DeleteBucket answers BucketNotEmpty
+ * and the Stack deletion fails, exactly as it does on AWS. Emptying the Bucket
+ * first would be a kindness that hides the reason CDK ships an
+ * `autoDeleteObjects` custom resource at all.
+ */
+export class SimCfnS3ResourceDeleter {
+  private readonly simS3: SimS3;
+
+  constructor(properties: SimCfnS3ResourceDeleterProperties) {
+    this.simS3 = properties.simS3;
+  }
+
+  /**
+   * Delete a simulated S3 resource created from a CloudFormation Resource.
+   */
+  async delete(
+    resourceTypeName: string,
+    resource: SimCfnResource,
+  ): Promise<void> {
+    switch (resourceTypeName) {
+      case "Bucket": {
+        await this.simS3.deleteBucket({
+          input: { Bucket: this.bucketName(resource) },
+        });
+
+        return;
+      }
+      case "BucketPolicy": {
+        await this.simS3.deleteBucketPolicy({
+          input: { Bucket: this.bucketName(resource) },
+        });
+
+        return;
+      }
+      default: {
+        throw new Error(
+          `Unsupported sim S3 CloudFormation Resource ${resourceTypeName} deletion`,
+        );
+      }
+    }
+  }
+
+  /**
+   * The Bucket a Resource was created against.
+   *
+   * A Bucket policy has no existence of its own in S3, so its Resource carries
+   * the Bucket it was put on, which is the Bucket to take it off again.
+   */
+  private bucketName(resource: SimCfnResource): string {
+    const bucket = resource.simResource as SimS3Bucket | undefined;
+    assertDefined(
+      bucket,
+      `sim S3 Bucket for CloudFormation Resource ${resource.logicalId}`,
+    );
+
+    return bucket.bucketName;
+  }
+}

--- a/src/service/s3/cfn/sim-cfn-s3-resource-factory.ts
+++ b/src/service/s3/cfn/sim-cfn-s3-resource-factory.ts
@@ -6,6 +6,7 @@ import type { SimS3 } from "../sim-s3.js";
 import type { SimCfnServiceResourceFactory } from "../../cloudformation/resource/factory/sim-cfn-resource-factory.type.js";
 import { SimCfnS3BucketCreator } from "./bucket/sim-cfn-s3-bucket-creator.js";
 import { SimCfnS3BucketPolicyCreator } from "./bucket-policy/sim-cfn-s3-bucket-policy-creator.js";
+import { SimCfnS3ResourceDeleter } from "./sim-cfn-s3-resource-deleter.js";
 
 /**
  * CloudFormation Resource factory for simulated S3 resources.
@@ -13,10 +14,12 @@ import { SimCfnS3BucketPolicyCreator } from "./bucket-policy/sim-cfn-s3-bucket-p
 export class SimS3CloudFormationResourceFactory implements SimCfnServiceResourceFactory {
   private readonly bucketCreator: SimCfnS3BucketCreator;
   private readonly bucketPolicyCreator: SimCfnS3BucketPolicyCreator;
+  private readonly deleter: SimCfnS3ResourceDeleter;
 
   constructor(simS3: SimS3) {
     this.bucketCreator = new SimCfnS3BucketCreator({ simS3 });
     this.bucketPolicyCreator = new SimCfnS3BucketPolicyCreator({ simS3 });
+    this.deleter = new SimCfnS3ResourceDeleter({ simS3 });
   }
 
   /**
@@ -46,5 +49,15 @@ export class SimS3CloudFormationResourceFactory implements SimCfnServiceResource
         );
       }
     }
+  }
+
+  /**
+   * Delete a simulated S3 resource created from a CloudFormation Resource.
+   */
+  async delete(
+    resourceTypeName: string,
+    resource: SimCfnResource,
+  ): Promise<void> {
+    await this.deleter.delete(resourceTypeName, resource);
   }
 }

--- a/src/service/s3/cfn/sim-cfn-s3-teardown.iso.test.ts
+++ b/src/service/s3/cfn/sim-cfn-s3-teardown.iso.test.ts
@@ -1,0 +1,141 @@
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { PutObjectCommand } from "@aws-sdk/client-s3";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import {
+  SimS3BucketNotEmpty,
+  SimS3NoSuchBucketPolicy,
+} from "../error/sim-s3.error.js";
+
+describe("S3 CloudFormation Resource teardown", () => {
+  const policyStatement = {
+    Effect: "Allow",
+    Principal: "*",
+    Action: "s3:GetObject",
+    Resource: "arn:aws:s3:::reports/*",
+  };
+
+  const template = {
+    Resources: {
+      ReportsBucket: {
+        Type: "AWS::S3::Bucket",
+        Properties: {
+          BucketName: "reports",
+          PublicAccessBlockConfiguration: { BlockPublicPolicy: false },
+        },
+      },
+      ReportsBucketPolicy: {
+        Type: "AWS::S3::BucketPolicy",
+        Properties: {
+          Bucket: { Ref: "ReportsBucket" },
+          PolicyDocument: {
+            Version: "2012-10-17",
+            Statement: [policyStatement],
+          },
+        },
+      },
+    },
+  };
+
+  it("deletes a Bucket after the policy declared on it", async () => {
+    // Given a deployed Bucket carrying a Bucket policy.
+    const simAws = new SimAws();
+    const stack = await simAws
+      .cloudFormation()
+      .deployTemplate({ stackName: "reports-stack", template });
+
+    // When the Stack's Resources are torn down.
+    await stack.teardown();
+
+    // Then the Bucket is gone from simulated S3.
+    assertUndefined(simAws.s3().getSimBucketByName("reports"));
+
+    // And both Resources report a completed deletion.
+    assertIdentical(
+      stack.resources.get("ReportsBucketPolicy")?.status,
+      "DELETE_COMPLETE",
+    );
+    assertIdentical(
+      stack.resources.get("ReportsBucket")?.status,
+      "DELETE_COMPLETE",
+    );
+  });
+
+  it("takes the policy off the Bucket before the Bucket goes", async () => {
+    // Given a deployed Bucket policy, on a Bucket declared outside the Stack
+    // so the Bucket outlives the teardown and can be asked about the policy.
+    const simAws = new SimAws();
+    await simAws.s3().createBucket({ input: { Bucket: "reports" } });
+
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "policy-only-stack",
+      template: {
+        Resources: {
+          ReportsBucketPolicy: {
+            Type: "AWS::S3::BucketPolicy",
+            Properties: {
+              Bucket: "reports",
+              PolicyDocument: {
+                Version: "2012-10-17",
+                Statement: [
+                  {
+                    ...policyStatement,
+                    Principal: { AWS: "arn:aws:iam::111111111111:root" },
+                  },
+                ],
+              },
+            },
+          },
+        },
+      },
+    });
+
+    // When the Stack's Resources are torn down.
+    await stack.teardown();
+
+    // Then the policy is no longer on the Bucket, which is still there.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.s3().getBucketPolicy({ input: { Bucket: "reports" } }),
+    );
+    assertInstanceOf(error, SimS3NoSuchBucketPolicy);
+    assertNonNullable(simAws.s3().getSimBucketByName("reports"));
+  });
+
+  it("fails the teardown of a Bucket that still holds Objects", async () => {
+    // Given a deployed Bucket someone has put an Object in. A CDK app asks for
+    // an autoDeleteObjects custom resource to get past this; a template that
+    // does not is refused by S3, and the Stack deletion fails with it.
+    const simAws = new SimAws();
+    const stack = await simAws
+      .cloudFormation()
+      .deployTemplate({ stackName: "held-stack", template });
+
+    await simAws.s3().putObject(
+      new PutObjectCommand({
+        Bucket: "reports",
+        Key: "q3.txt",
+        Body: "quarterly numbers",
+      }),
+    );
+
+    // When the Stack's Resources are torn down.
+    const error = await assertThrowsErrorAsync(async () => stack.teardown());
+
+    // Then the Bucket is still there, with the reason it could not go.
+    assertInstanceOf(error, SimS3BucketNotEmpty);
+    assertStringIncludes(error.message, "ReportsBucket");
+    assertNonNullable(simAws.s3().getSimBucketByName("reports"));
+    assertIdentical(
+      stack.resources.get("ReportsBucket")?.status,
+      "DELETE_FAILED",
+    );
+  });
+});

--- a/src/service/secretsmanager/cfn/sim-cfn-secrets-manager-resource-factory.ts
+++ b/src/service/secretsmanager/cfn/sim-cfn-secrets-manager-resource-factory.ts
@@ -5,6 +5,8 @@ import type {
 } from "../../cloudformation/resource/sim-cfn-resource.js";
 import type { SimSecretsManager } from "../sim-secrets-manager.js";
 import { SimCfnSecretsManagerSecretCreator } from "./secret/sim-cfn-secrets-manager-secret-creator.js";
+import type { SimSecretsManagerSecret } from "../secret/sim-secrets-manager-secret.js";
+import { assertDefined } from "../../../util/type-guard/defined.js";
 
 interface SimSecretsManagerCfnResourceFactoryProperties {
   readonly secretsManager: SimSecretsManager;
@@ -14,9 +16,11 @@ interface SimSecretsManagerCfnResourceFactoryProperties {
  * CloudFormation Resource factory for simulated Secrets Manager resources.
  */
 export class SimSecretsManagerCfnResourceFactory implements SimCfnServiceResourceFactory {
+  private readonly secretsManager: SimSecretsManager;
   private readonly secretCreator: SimCfnSecretsManagerSecretCreator;
 
   constructor(properties: SimSecretsManagerCfnResourceFactoryProperties) {
+    this.secretsManager = properties.secretsManager;
     this.secretCreator = new SimCfnSecretsManagerSecretCreator({
       secretsManager: properties.secretsManager,
     });
@@ -48,5 +52,35 @@ export class SimSecretsManagerCfnResourceFactory implements SimCfnServiceResourc
         );
       }
     }
+  }
+
+  /**
+   * Delete a simulated Secrets Manager resource created from a CloudFormation
+   * Resource.
+   *
+   * DeleteSecret schedules the deletion rather than carrying it out, so a torn
+   * down Stack leaves a secret waiting out its recovery window. That is what
+   * CloudFormation does: the secret is recoverable afterwards, which is the
+   * point of the window.
+   */
+  async delete(
+    resourceTypeName: string,
+    resource: SimCfnResource,
+  ): Promise<void> {
+    if (resourceTypeName !== "Secret") {
+      throw new Error(
+        `Unsupported sim Secrets Manager CloudFormation Resource ${resourceTypeName} deletion`,
+      );
+    }
+
+    const secret = resource.simResource as SimSecretsManagerSecret | undefined;
+    assertDefined(
+      secret,
+      `sim Secrets Manager secret for CloudFormation Resource ${resource.logicalId}`,
+    );
+
+    await this.secretsManager.deleteSecret({
+      input: { SecretId: secret.arn.value },
+    });
   }
 }

--- a/src/service/secretsmanager/cfn/sim-cfn-secrets-manager-teardown.iso.test.ts
+++ b/src/service/secretsmanager/cfn/sim-cfn-secrets-manager-teardown.iso.test.ts
@@ -1,0 +1,46 @@
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertTrue,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import type { SimSecretsManagerSecret } from "../secret/sim-secrets-manager-secret.js";
+
+describe("Secrets Manager CloudFormation Resource teardown", () => {
+  it("schedules the secret for deletion rather than removing it", async () => {
+    // Given a deployed secret. DeleteSecret starts a recovery window rather
+    // than taking the secret away, which is what CloudFormation leaves behind.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "secret-stack",
+      template: {
+        Resources: {
+          ApiSecret: {
+            Type: "AWS::SecretsManager::Secret",
+            Properties: {
+              Name: "api-key",
+              SecretString: "s3cret",
+            },
+          },
+        },
+      },
+    });
+    await stack.waitForDeployComplete();
+
+    const secret = stack.resources.get("ApiSecret")?.simResource as
+      SimSecretsManagerSecret | undefined;
+    assertNonNullable(secret);
+
+    // When the Stack's Resources are torn down.
+    await stack.teardown();
+
+    // Then the secret is waiting out its recovery window.
+    assertTrue(secret.isScheduledForDeletion);
+    assertIdentical(
+      stack.resources.get("ApiSecret")?.status,
+      "DELETE_COMPLETE",
+    );
+  });
+});

--- a/src/service/sqs/cfn/sim-cfn-sqs-resource-deleter.ts
+++ b/src/service/sqs/cfn/sim-cfn-sqs-resource-deleter.ts
@@ -1,0 +1,91 @@
+import type { SimCfnResource } from "../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimSqs } from "../sim-sqs.js";
+import type { SimSqsQueue } from "../queue/sim-sqs-queue.js";
+import { simSqsQueuePolicyAttributeName } from "../queue/sim-sqs-queue-attribute-specs.js";
+import { assertDefined } from "../../../util/type-guard/defined.js";
+
+interface SimCfnSqsResourceDeleterProperties {
+  readonly sqs: SimSqs;
+}
+
+/**
+ * Deletes the simulated SQS resources a CloudFormation Stack created.
+ *
+ * There is no DeleteQueuePolicy in SQS. A queue policy is the `Policy`
+ * attribute of the queues it names, so removing one is SetQueueAttributes
+ * setting that attribute to an empty string, which is how the SDK clears it
+ * too.
+ */
+export class SimCfnSqsResourceDeleter {
+  private readonly sqs: SimSqs;
+
+  constructor(properties: SimCfnSqsResourceDeleterProperties) {
+    this.sqs = properties.sqs;
+  }
+
+  /**
+   * Delete a simulated SQS resource created from a CloudFormation Resource.
+   */
+  async delete(
+    resourceTypeName: string,
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): Promise<void> {
+    switch (resourceTypeName) {
+      case "Queue": {
+        await this.deleteQueue(resource);
+        return;
+      }
+      case "QueuePolicy": {
+        await this.clearQueuePolicy(properties);
+        return;
+      }
+      default: {
+        throw new Error(
+          `Unsupported sim SQS CloudFormation Resource ${resourceTypeName} deletion`,
+        );
+      }
+    }
+  }
+
+  private async deleteQueue(resource: SimCfnResource): Promise<void> {
+    const queue = resource.simResource as SimSqsQueue | undefined;
+    assertDefined(
+      queue,
+      `sim SQS queue for CloudFormation Resource ${resource.logicalId}`,
+    );
+
+    await this.sqs.deleteQueue({ input: { QueueUrl: queue.url } });
+  }
+
+  /**
+   * Take the policy back off every queue the Resource named.
+   *
+   * The Resource points at only the first of them, so the queues are read from
+   * the template the same way creation read them.
+   */
+  private async clearQueuePolicy(
+    properties: SimCfnTemplateValueRecord,
+  ): Promise<void> {
+    const queues = properties["Queues"];
+
+    /* v8 ignore if -- creation refused the Resource without a Queues list */
+    if (!Array.isArray(queues)) {
+      return;
+    }
+
+    await Promise.all(
+      queues
+        .filter((queueUrl): queueUrl is string => typeof queueUrl === "string")
+        .map(async (queueUrl) =>
+          this.sqs.setQueueAttributes({
+            input: {
+              QueueUrl: queueUrl,
+              Attributes: { [simSqsQueuePolicyAttributeName]: "" },
+            },
+          }),
+        ),
+    );
+  }
+}

--- a/src/service/sqs/cfn/sim-cfn-sqs-teardown.iso.test.ts
+++ b/src/service/sqs/cfn/sim-cfn-sqs-teardown.iso.test.ts
@@ -1,0 +1,94 @@
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+
+const policyDocument = {
+  Version: "2012-10-17",
+  Statement: [
+    {
+      Effect: "Allow",
+      Principal: { Service: "s3.amazonaws.com" },
+      Action: "sqs:SendMessage",
+      Resource: "*",
+    },
+  ],
+};
+
+describe("SQS CloudFormation Resource teardown", () => {
+  it("deletes a queue after the policy declared on it", async () => {
+    // Given a deployed queue carrying a queue policy.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: {
+        Resources: {
+          OrdersQueue: {
+            Type: "AWS::SQS::Queue",
+            Properties: { QueueName: "orders" },
+          },
+          OrdersQueuePolicy: {
+            Type: "AWS::SQS::QueuePolicy",
+            Properties: {
+              Queues: [{ Ref: "OrdersQueue" }],
+              PolicyDocument: policyDocument,
+            },
+          },
+        },
+      },
+    });
+    await stack.waitForDeployComplete();
+
+    // When the Stack's Resources are torn down.
+    await stack.teardown();
+
+    // Then the queue is gone.
+    assertUndefined(simAws.sqs().findQueue("orders"));
+    assertIdentical(
+      stack.resources.get("OrdersQueue")?.status,
+      "DELETE_COMPLETE",
+    );
+  });
+
+  it("clears the policy attribute of a queue that outlives the Stack", async () => {
+    // Given a queue created outside the Stack, so the policy Resource is the
+    // only thing the teardown removes. SQS has no DeleteQueuePolicy: the policy
+    // is an attribute, and clearing it is a SetQueueAttributes.
+    const simAws = new SimAws();
+    const created = await simAws
+      .sqs()
+      .createQueue({ input: { QueueName: "standing" } });
+    assertNonNullable(created.QueueUrl);
+
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "queue-policy-stack",
+      template: {
+        Resources: {
+          StandingQueuePolicy: {
+            Type: "AWS::SQS::QueuePolicy",
+            Properties: {
+              Queues: [created.QueueUrl],
+              PolicyDocument: policyDocument,
+            },
+          },
+        },
+      },
+    });
+    await stack.waitForDeployComplete();
+
+    const queue = simAws.sqs().findQueue("standing");
+    assertNonNullable(queue);
+    assertNonNullable(queue.attributes.queuePolicy);
+
+    // When the Stack's Resources are torn down.
+    await stack.teardown();
+
+    // Then the queue still exists with no policy on it.
+    assertNonNullable(simAws.sqs().findQueue("standing"));
+    assertUndefined(queue.attributes.queuePolicy);
+  });
+});

--- a/src/service/sqs/cfn/sim-sqs-cfn-resource-factory.ts
+++ b/src/service/sqs/cfn/sim-sqs-cfn-resource-factory.ts
@@ -6,6 +6,8 @@ import type {
 import type { SimSqs } from "../sim-sqs.js";
 import { SimCfnSqsQueueCreator } from "./queue/sim-cfn-sqs-queue-creator.js";
 import { SimCfnSqsQueuePolicyCreator } from "./queue-policy/sim-cfn-sqs-queue-policy-creator.js";
+import { SimCfnSqsResourceDeleter } from "./sim-cfn-sqs-resource-deleter.js";
+import type { SimCloudFormationResourceDeleteContext } from "../../cloudformation/resource/sim-cfn-resource.type.js";
 
 interface SimSqsCfnResourceFactoryProperties {
   readonly sqs: SimSqs;
@@ -17,12 +19,14 @@ interface SimSqsCfnResourceFactoryProperties {
 export class SimSqsCfnResourceFactory implements SimCfnServiceResourceFactory {
   private readonly queueCreator: SimCfnSqsQueueCreator;
   private readonly queuePolicyCreator: SimCfnSqsQueuePolicyCreator;
+  private readonly deleter: SimCfnSqsResourceDeleter;
 
   constructor(properties: SimSqsCfnResourceFactoryProperties) {
     this.queueCreator = new SimCfnSqsQueueCreator({ sqs: properties.sqs });
     this.queuePolicyCreator = new SimCfnSqsQueuePolicyCreator({
       sqs: properties.sqs,
     });
+    this.deleter = new SimCfnSqsResourceDeleter({ sqs: properties.sqs });
   }
 
   /**
@@ -56,5 +60,20 @@ export class SimSqsCfnResourceFactory implements SimCfnServiceResourceFactory {
         );
       }
     }
+  }
+
+  /**
+   * Delete a simulated SQS resource created from a CloudFormation Resource.
+   */
+  async delete(
+    resourceTypeName: string,
+    resource: SimCfnResource,
+    context: SimCloudFormationResourceDeleteContext,
+  ): Promise<void> {
+    await this.deleter.delete(
+      resourceTypeName,
+      resource,
+      context.resolvedProperties ?? resource.properties,
+    );
   }
 }

--- a/src/service/sqs/command/queue/sim-sqs-queue-attribute-commands.iso.test.ts
+++ b/src/service/sqs/command/queue/sim-sqs-queue-attribute-commands.iso.test.ts
@@ -206,6 +206,49 @@ describe("SQS queue attribute commands", () => {
     assertIdentical(read.Attributes["VisibilityTimeout"], "120");
   });
 
+  it("removes a queue policy set to an empty string", async () => {
+    // Given a queue carrying a policy. SQS has no DeleteQueuePolicy, so an
+    // empty value is the only way back to a queue without one.
+    const { simAws, queueUrl } = await simAwsWithQueue();
+    const policy = JSON.stringify({
+      Version: "2012-10-17",
+      Statement: [
+        {
+          Effect: "Allow",
+          Principal: { Service: "s3.amazonaws.com" },
+          Action: "sqs:SendMessage",
+          Resource: "*",
+        },
+      ],
+    });
+
+    await simAws.sqs().setQueueAttributes(
+      new SetQueueAttributesCommand({
+        QueueUrl: queueUrl,
+        Attributes: { Policy: policy },
+      }),
+    );
+
+    // When the policy attribute is set to nothing.
+    await simAws.sqs().setQueueAttributes(
+      new SetQueueAttributesCommand({
+        QueueUrl: queueUrl,
+        Attributes: { Policy: "" },
+      }),
+    );
+
+    // Then the queue reports no policy at all, rather than an empty one.
+    const read = await simAws.sqs().getQueueAttributes(
+      new GetQueueAttributesCommand({
+        QueueUrl: queueUrl,
+        AttributeNames: ["All"],
+      }),
+    );
+
+    assertNonNullable(read.Attributes);
+    assertUndefined(read.Attributes["Policy"]);
+  });
+
   it("refuses an attribute value outside the range real SQS accepts", async () => {
     // Given a queue.
     const { simAws, queueUrl } = await simAwsWithQueue();

--- a/src/service/sqs/queue/sim-sqs-queue-json-attribute.ts
+++ b/src/service/sqs/queue/sim-sqs-queue-json-attribute.ts
@@ -46,6 +46,10 @@ export class SimSqsQueueJsonAttribute<
   /**
    * This attribute after a request, which holds the document the request sets
    * or the one already there.
+   *
+   * An empty string takes the document off the queue, which is how SQS is told
+   * to remove one: there is no DeleteQueuePolicy, so setting the attribute to
+   * nothing is the only way back to a queue without one.
    */
   with(requested: SimSqsQueueAttributeInput): SimSqsQueueJsonAttribute<T> {
     const value = this.valueIn(requested);
@@ -57,7 +61,7 @@ export class SimSqsQueueJsonAttribute<
     return new SimSqsQueueJsonAttribute({
       name: this.name,
       parse: this.parse,
-      held: this.parse(value),
+      held: value === "" ? undefined : this.parse(value),
     });
   }
 

--- a/src/service/ssm/cfn/sim-cfn-ssm-resource-factory.ts
+++ b/src/service/ssm/cfn/sim-cfn-ssm-resource-factory.ts
@@ -5,6 +5,8 @@ import type {
 } from "../../cloudformation/resource/sim-cfn-resource.js";
 import type { SimSsm } from "../sim-ssm.js";
 import { SimCfnSsmParameterCreator } from "./parameter/sim-cfn-ssm-parameter-creator.js";
+import type { SimSsmParameter } from "../parameter/sim-ssm-parameter.js";
+import { assertDefined } from "../../../util/type-guard/defined.js";
 
 interface SimSsmCfnResourceFactoryProperties {
   readonly ssm: SimSsm;
@@ -14,9 +16,11 @@ interface SimSsmCfnResourceFactoryProperties {
  * CloudFormation Resource factory for simulated SSM resources.
  */
 export class SimSsmCfnResourceFactory implements SimCfnServiceResourceFactory {
+  private readonly ssm: SimSsm;
   private readonly parameterCreator: SimCfnSsmParameterCreator;
 
   constructor(properties: SimSsmCfnResourceFactoryProperties) {
+    this.ssm = properties.ssm;
     this.parameterCreator = new SimCfnSsmParameterCreator({
       ssm: properties.ssm,
     });
@@ -47,5 +51,27 @@ export class SimSsmCfnResourceFactory implements SimCfnServiceResourceFactory {
         );
       }
     }
+  }
+
+  /**
+   * Delete a simulated SSM resource created from a CloudFormation Resource.
+   */
+  async delete(
+    resourceTypeName: string,
+    resource: SimCfnResource,
+  ): Promise<void> {
+    if (resourceTypeName !== "Parameter") {
+      throw new Error(
+        `Unsupported sim SSM CloudFormation Resource ${resourceTypeName} deletion`,
+      );
+    }
+
+    const parameter = resource.simResource as SimSsmParameter | undefined;
+    assertDefined(
+      parameter,
+      `sim SSM Parameter for CloudFormation Resource ${resource.logicalId}`,
+    );
+
+    await this.ssm.deleteParameter({ input: { Name: parameter.name.value } });
   }
 }

--- a/src/service/ssm/cfn/sim-cfn-ssm-teardown.iso.test.ts
+++ b/src/service/ssm/cfn/sim-cfn-ssm-teardown.iso.test.ts
@@ -1,0 +1,42 @@
+import { assertIdentical, assertThrowsErrorAsync } from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { GetParameterCommand } from "@aws-sdk/client-ssm";
+
+import { SimAws } from "../../aws/sim-aws.js";
+
+describe("SSM CloudFormation Resource teardown", () => {
+  it("deletes the Parameter a Stack created", async () => {
+    // Given a deployed Parameter.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "config-stack",
+      template: {
+        Resources: {
+          ApiUrlParameter: {
+            Type: "AWS::SSM::Parameter",
+            Properties: {
+              Name: "/app/api-url",
+              Type: "String",
+              Value: "https://api.example.test",
+            },
+          },
+        },
+      },
+    });
+    await stack.waitForDeployComplete();
+
+    // When the Stack's Resources are torn down.
+    await stack.teardown();
+
+    // Then Parameter Store no longer holds it.
+    await assertThrowsErrorAsync(async () =>
+      simAws
+        .ssm()
+        .getParameter(new GetParameterCommand({ Name: "/app/api-url" })),
+    );
+    assertIdentical(
+      stack.resources.get("ApiUrlParameter")?.status,
+      "DELETE_COMPLETE",
+    );
+  });
+});


### PR DESCRIPTION
The CloudFormation side of Resource deletion, which unblocks #397.

## Acceptance criteria

- **`SimCfnServiceResourceFactory` gains `delete`, implemented by every service for the Resource types it can create.** Met. ACM, API Gateway v2, CloudFormation, CloudFront, Cognito, DynamoDB, IAM, KMS, Lambda, Route53, S3, Secrets Manager, SQS and SSM, plus the two CDK custom Resources. Each calls its own SDK-shaped command; the engine never reaches into a service's state.
- **A delete lifecycle on `SimCfnResource` mirroring the create one.** Met. `SimCloudFormationResourceStatus` gains `DELETE_IN_PROGRESS`, `DELETE_COMPLETE` and `DELETE_FAILED`, held in a `SimCfnResourceDeletionState` beside the creation state, driven by `SimCfnResourceDeleteOperation` and `SimCfnResourceDeleter`.
- **Deletion in reverse dependency order.** Met. `simCfnResourceDependents` inverts the graph `dependencies()` already exposes, and `SimCfnStackResourceDeleter` / `SimCfnStackPendingDeletions` / `SimCfnStackResourceBatchDeleter` mirror the creation trio batch for batch.
- **A Resource type with no delete path is recorded rather than failing.** Met. A service raises the same unsupported-Resource error creation raises; the operation marks the deletion skipped (`DELETE_COMPLETE` with a reason) and the Stack reports it on `stack.skippedResourceDeletions`, read off the Resources the way `ignoredProperties` is.
- **Stack-level statuses and `DeleteStack` left to #397.** Met. `SimCfnStack.teardown()` is the internal entry point this PR tests through; nothing stack-level was added.

## Per-Resource behaviour

Where calling the delete command blindly would give the wrong answer, the deleter does what real CloudFormation does:

- **CloudFront Distribution** is disabled with `UpdateDistribution` before `DeleteDistribution`, which refuses an enabled one.
- **IAM Role** has its attached and inline policies removed before `DeleteRole`.
- **SQS QueuePolicy** is removed by `SetQueueAttributes` with an empty `Policy`, since there is no `DeleteQueuePolicy`.
- **Route53 RecordSet** is removed by a `DELETE` change.
- **S3 Bucket** holding Objects fails the teardown with `BucketNotEmpty`, deliberately not emptied first.
- **KMS Key** is scheduled for deletion and left in `PendingDeletion`.
- **WaitConditionHandle** and `Custom::CDKBucketDeployment` have nothing to delete. `Custom::S3BucketNotifications` puts an empty configuration back, as the CDK provider does on its Delete event.

## Divergences worth flagging

- **`SimCfnResource` was split.** It was at the 300-line limit, so what a Resource *is* moved to a new `SimCfnResourceRecord` base class and what has *happened* to it stayed on `SimCfnResource`. No public member moved or changed name.
- **Sim SQS now accepts an empty `Policy` attribute as a removal.** `SetQueueAttributes` rejected `Policy: ""`, so the queue policy had no removal path at all. Real SQS treats an empty value as clearing the attribute, which is the only way back to a queue without a policy. One line in `SimSqsQueueJsonAttribute`, with an SDK-level test beside the other attribute commands.
- **User-facing docs are unchanged.** `docs/services/cloudformation/README.md` still says stack deletes are not supported, which stays true until #397 puts a command on top of this. The implementation README carries the design.
- **The PR is larger than the usual steer**, at roughly 3,900 lines. It is 14 services plus the engine, and a little over half is tests.

## Testing

`pnpm run check` passes. Each service has a teardown test that deploys a template and asserts through that service's own API that the resources are gone, including the CloudFront disable-first and S3 `BucketNotEmpty` cases, which a naive implementation gets wrong while looking right.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added CloudFormation stack teardown with reverse dependency-order deletion.
  - Added deletion lifecycle statuses, skip reporting, failure handling, and cyclic-dependency detection.
  - Added teardown support across ACM, API Gateway, CloudFront, Cognito, DynamoDB, IAM, KMS, Lambda, Route 53, S3, Secrets Manager, SQS, SSM, and custom resources.
  - Added cleanup for policies, notifications, integrations, routes, stages, and related dependencies.

- **Tests**
  - Added comprehensive teardown integration tests covering ordering, skipped resources, failures, and service-specific cleanup.

- **Documentation**
  - Expanded CloudFormation lifecycle and teardown documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->