### PR TITLE
fix: release the localhost server port on close

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,29 @@ console.log(bucketWebsiteUrl.toString());
 const res = await fetch(new URL("/foo/", bucketWebsiteUrl));
 ```
 
+#### Restarting a served environment
+
+A served environment takes an available port by default, so the URL changes every time the process
+starts. Pin a port to keep the URL the same across restarts:
+
+```typescript
+const srv = await serveSimAws({ simAws, port: 4599 });
+```
+
+Closing the server ends the connections it is holding, so the process can exit rather than being
+kept alive by a browser tab. Yulin does not install signal handlers, so call `close()` from your
+own:
+
+```typescript
+process.on("SIGTERM", () => {
+  srv.close();
+});
+```
+
+A restart usually overlaps the process it is replacing. `listen` waits a couple of seconds for a
+pinned port that is still held, then throws `SimAwsLocalPortInUse` naming the port, which means
+something other than the outgoing process owns it.
+
 ### Control simulated time
 
 Each simulated AWS has its own clock, which you can freeze, set, or advance. This lets a test

--- a/src/serve/http/local-server/node-server-port-binder.iso.test.ts
+++ b/src/serve/http/local-server/node-server-port-binder.iso.test.ts
@@ -1,0 +1,84 @@
+import http from "node:http";
+import { describe, it } from "vitest";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertTrue,
+} from "@kensio/smartass";
+import { NodeServerPortBinder } from "./node-server-port-binder.js";
+import { SimAwsLocalPortInUse } from "./sim-aws-local-port.error.js";
+import {
+  listenOnFreePort,
+  serverPort,
+} from "../../../../test/serve/held-port.js";
+import { promiseError } from "../../../../test/promise-error.js";
+
+describe("NodeServerPortBinder", () => {
+  it("binds a free port", async () => {
+    // Given a server that is not listening yet
+    const server = http.createServer();
+    const binder = new NodeServerPortBinder({ server });
+
+    // When it binds an operating system chosen port
+    await binder.bind(0);
+
+    // Then it is listening
+    assertTrue(server.listening);
+    server.close();
+  });
+
+  it("waits for a held port to be released", async () => {
+    // Given another listener still holding a port
+    const holder = await listenOnFreePort();
+    const port = serverPort(holder);
+    const server = http.createServer();
+    const binder = new NodeServerPortBinder({
+      server,
+      waitMs: 2000,
+      waitIntervalMs: 10,
+    });
+
+    // When the holder lets go shortly after binding starts
+    setTimeout(() => {
+      holder.close();
+    }, 50);
+    await binder.bind(port);
+
+    // Then the same port was bound rather than the bind failing
+    assertIdentical(serverPort(server), port);
+    server.close();
+  });
+
+  it("throws naming the port when it stays held", async () => {
+    // Given another listener that keeps hold of a port
+    const holder = await listenOnFreePort();
+    const port = serverPort(holder);
+    const binder = new NodeServerPortBinder({
+      server: http.createServer(),
+      waitMs: 40,
+      waitIntervalMs: 10,
+    });
+
+    // When the wait for that port runs out
+    const error = await promiseError(binder.bind(port));
+
+    // Then it says which port is held and for how long it waited
+    assertInstanceOf(error, SimAwsLocalPortInUse);
+    assertStringIncludes(error.message, `Port ${String(port)} is held`);
+    assertStringIncludes(error.message, "after waiting 40ms");
+    holder.close();
+  });
+
+  it("throws a listen failure that is not a held port", async () => {
+    // Given a binder asked for a port number that cannot exist
+    const binder = new NodeServerPortBinder({ server: http.createServer() });
+
+    // When it tries to bind that port
+    const error = await promiseError(binder.bind(70_000));
+
+    // Then the underlying failure is reported rather than waited out
+    assertInstanceOf(error, RangeError);
+    assertStringIncludes(error.message, "70000");
+  });
+});

--- a/src/serve/http/local-server/node-server-port-binder.ts
+++ b/src/serve/http/local-server/node-server-port-binder.ts
@@ -1,0 +1,92 @@
+import type { Server } from "node:http";
+import { simAwsLocalConfig } from "./sim-aws-local.config.js";
+import { SimAwsLocalPortInUse } from "./sim-aws-local-port.error.js";
+import { waitNodeServerListen } from "./wait-node-server-listen.js";
+
+interface NodeServerPortBinderProperties {
+  readonly server: Server;
+  readonly address?: string;
+  readonly waitMs?: number;
+  readonly waitIntervalMs?: number;
+}
+
+/**
+ * Binds a Node HTTP server to a port, waiting out a port that is still held.
+ *
+ * Restarting local development overlaps the process being replaced: the
+ * outgoing one is still letting go of its listening socket while the incoming
+ * one asks for the same number. Giving up on the first `EADDRINUSE` makes that
+ * overlap fatal and loses the pinned port, so the bind is retried for a short
+ * bounded period first. The bound is finite because a port held by an unrelated
+ * process is never going to come free, and waiting forever would hide that.
+ */
+export class NodeServerPortBinder {
+  private readonly server: Server;
+  private readonly address: string;
+  private readonly waitMs: number;
+  private readonly waitIntervalMs: number;
+
+  constructor(properties: NodeServerPortBinderProperties) {
+    const {
+      server,
+      address = simAwsLocalConfig.loopbackAddress,
+      waitMs = simAwsLocalConfig.portWaitMs,
+      waitIntervalMs = simAwsLocalConfig.portWaitIntervalMs,
+    } = properties;
+    this.server = server;
+    this.address = address;
+    this.waitMs = waitMs;
+    this.waitIntervalMs = waitIntervalMs;
+  }
+
+  /**
+   * Start listening on the given port, waiting briefly for another listener to
+   * release it. Port zero asks the operating system for a free port, so it
+   * never waits.
+   */
+  async bind(port: number): Promise<void> {
+    await this.attempt(port, Date.now() + this.waitMs);
+  }
+
+  /**
+   * Try to bind once, and try again later if the port is only busy for now.
+   *
+   * A listen that failed leaves the server without a handle, so a later attempt
+   * is an ordinary fresh listen on the same server rather than a reopening.
+   */
+  private async attempt(port: number, giveUpAt: number): Promise<void> {
+    try {
+      this.server.listen(port, this.address);
+      await waitNodeServerListen(this.server);
+    } catch (error) {
+      if (!isPortInUse(error)) {
+        throw error;
+      }
+
+      if (Date.now() >= giveUpAt) {
+        throw new SimAwsLocalPortInUse(port, this.waitMs);
+      }
+
+      await pause(this.waitIntervalMs);
+      await this.attempt(port, giveUpAt);
+    }
+  }
+}
+
+/**
+ * Recognise the one listen failure that is worth waiting out.
+ */
+function isPortInUse(error: unknown): boolean {
+  return (
+    error instanceof Error && "code" in error && error.code === "EADDRINUSE"
+  );
+}
+
+/**
+ * Wait before the next attempt.
+ */
+async function pause(milliseconds: number): Promise<void> {
+  await new Promise((resolve) => {
+    setTimeout(resolve, milliseconds);
+  });
+}

--- a/src/serve/http/local-server/sim-aws-local-port.error.ts
+++ b/src/serve/http/local-server/sim-aws-local-port.error.ts
@@ -1,0 +1,18 @@
+/**
+ * Thrown when a port stays held by another listener for the whole wait.
+ *
+ * A local development restart usually overlaps the process it replaces, so a
+ * pinned port being busy for a moment is expected and is waited out. Still
+ * being busy at the end of that wait means something else owns the port, which
+ * no amount of further waiting will fix.
+ */
+export class SimAwsLocalPortInUse extends Error {
+  public override readonly name = "SimAwsLocalPortInUse";
+
+  constructor(port: number, waitedMs: number) {
+    super(
+      `Port ${String(port)} is held by another listener. ` +
+        `It was still held after waiting ${String(waitedMs)}ms for it to be released.`,
+    );
+  }
+}

--- a/src/serve/http/local-server/sim-aws-local-server-restart.loc.test.ts
+++ b/src/serve/http/local-server/sim-aws-local-server-restart.loc.test.ts
@@ -1,0 +1,70 @@
+import { describe, it } from "vitest";
+import { assertIdentical } from "@kensio/smartass";
+import { SimAwsLocalServer } from "./sim-aws-local-server.js";
+import {
+  listenOnFreePort,
+  serverPort,
+} from "../../../../test/serve/held-port.js";
+import {
+  assertConnectionEnds,
+  keepAliveConnection,
+  startAnotherRequest,
+} from "../../../../test/serve/local-server-connection.js";
+
+describe("Simulated AWS local HTTP server restart", () => {
+  it("ends an idle keep-alive connection when closed", async () => {
+    // Given a served simulated AWS with a client holding a keep-alive connection
+    const server = await new SimAwsLocalServer().listen(0);
+    const connection = await keepAliveConnection(Number(server.port));
+
+    // When the server is closed
+    server.close();
+
+    // Then the connection ends without the client having done anything
+    await assertConnectionEnds(connection);
+  });
+
+  it("ends a connection part way through a request when closed", async () => {
+    // Given a client that has started another request on its open connection
+    const server = await new SimAwsLocalServer().listen(0);
+    const connection = await keepAliveConnection(Number(server.port));
+    await startAnotherRequest(connection);
+
+    // When the server is closed
+    server.close();
+
+    // Then that connection ends too, rather than being left to finish
+    await assertConnectionEnds(connection);
+  });
+
+  it("waits for a pinned port that is still held", async () => {
+    // Given a pinned port another listener has not let go of yet
+    const holder = await listenOnFreePort();
+    const pinnedPort = serverPort(holder);
+
+    // When a server asks for that port and the holder lets go shortly after
+    setTimeout(() => {
+      holder.close();
+    }, 50);
+    const server = await new SimAwsLocalServer().listen(pinnedPort);
+
+    // Then it took the port rather than failing on it being busy
+    assertIdentical(server.port, String(pinnedPort));
+    server.close();
+  });
+
+  it("binds a pinned port again immediately after closing", async () => {
+    // Given a served simulated AWS on a pinned port, with an open connection
+    const first = await new SimAwsLocalServer().listen(0);
+    const pinnedPort = Number(first.port);
+    await keepAliveConnection(pinnedPort);
+
+    // When it closes and a replacement asks for the same port
+    first.close();
+    const second = await new SimAwsLocalServer().listen(pinnedPort);
+
+    // Then the replacement serves on the port the first one had
+    assertIdentical(second.port, String(pinnedPort));
+    second.close();
+  });
+});

--- a/src/serve/http/local-server/sim-aws-local-server.ts
+++ b/src/serve/http/local-server/sim-aws-local-server.ts
@@ -3,7 +3,7 @@ import { SimAws } from "../../../service/aws/sim-aws.js";
 import { simAwsLocalConfig } from "./sim-aws-local.config.js";
 import { SimAwsHttp } from "../sim-aws-http.js";
 import { SimAwsLocalUrl } from "../url/sim-aws-local-url.js";
-import { waitNodeServerListen } from "./wait-node-server-listen.js";
+import { NodeServerPortBinder } from "./node-server-port-binder.js";
 import { SimAwsLocalRequestHandler } from "./sim-aws-local-request-handler.js";
 import { SimAwsDnsServer } from "../../dns/sim-aws-dns-server.js";
 
@@ -18,6 +18,7 @@ interface SimAwsLocalServerProperties {
 export class SimAwsLocalServer {
   private readonly requestHandler: SimAwsLocalRequestHandler;
   private readonly server: Server;
+  private readonly portBinder: NodeServerPortBinder;
   private readonly dnsServer: SimAwsDnsServer;
 
   constructor(properties: SimAwsLocalServerProperties = {}) {
@@ -29,6 +30,7 @@ export class SimAwsLocalServer {
     this.server = http.createServer((request, response) => {
       this.requestHandler.handle(request, response);
     });
+    this.portBinder = new NodeServerPortBinder({ server: this.server });
   }
 
   /**
@@ -44,10 +46,12 @@ export class SimAwsLocalServer {
    * the resolver returns first, which is commonly `::1`. DNS answers with the
    * IPv4 loopback address, so binding it explicitly is what makes the address in
    * a DNS answer one that actually serves HTTP.
+   *
+   * A pinned port that is still held is waited for rather than refused, so a
+   * restart that overlaps the process it replaces still gets its port back.
    */
   async listen(port: number = simAwsLocalConfig.defaultPort): Promise<this> {
-    this.server.listen(port, simAwsLocalConfig.loopbackAddress);
-    await waitNodeServerListen(this.server);
+    await this.portBinder.bind(port);
     await this.dnsServer.listen(Number(this.port));
     return this;
   }
@@ -89,9 +93,18 @@ export class SimAwsLocalServer {
 
   /**
    * Stop serving simulated AWS services.
+   *
+   * Open connections are ended rather than left to finish. Node's own close
+   * stops the server accepting and lets go of the connections that are idle,
+   * but one that is in use, which is what a browser part way through a request
+   * or a live reload stream holds, keeps its socket open and the process with
+   * it. Local development restarts on that process exiting, so the connections
+   * go. Closing the listening socket first means nothing new is accepted while
+   * the open ones are being ended.
    */
   close(): void {
     this.server.close();
+    this.server.closeAllConnections();
     this.dnsServer.close();
   }
 

--- a/src/serve/http/local-server/sim-aws-local.config.ts
+++ b/src/serve/http/local-server/sim-aws-local.config.ts
@@ -8,4 +8,10 @@ export const simAwsLocalConfig = {
   // names that resolve to a simulated service, so a lookup and an HTTP request
   // for the same name reach the same place.
   loopbackAddress: "127.0.0.1",
+  // How long a pinned port is waited for when something else still holds it.
+  // A restart overlaps the process it replaces for a moment, and long enough to
+  // outlast that is the whole requirement. Anything still holding the port after
+  // this is not going to let go.
+  portWaitMs: 2000,
+  portWaitIntervalMs: 25,
 };

--- a/src/serve/http/local-server/wait-node-server-listen.iso.test.ts
+++ b/src/serve/http/local-server/wait-node-server-listen.iso.test.ts
@@ -4,6 +4,7 @@ import http from "node:http";
 import { describe, it } from "vitest";
 import { assertIdentical, assertTrue } from "@kensio/smartass";
 import { waitNodeServerListen } from "./wait-node-server-listen.js";
+import { promiseError } from "../../../../test/promise-error.js";
 
 describe("waitNodeServerListen", () => {
   it("resolves immediately when server is already listening", async () => {
@@ -41,7 +42,6 @@ describe("waitNodeServerListen", () => {
 
     server.emit("error", cause);
 
-    // @ts-expect-error -- testing error
     const error = await promiseError(wait);
 
     assertIdentical(error, cause);
@@ -58,20 +58,4 @@ class TestServer extends EventEmitter {
     // @ts-expect-error -- test mock
     return this;
   }
-}
-
-async function promiseError(promise: Promise<never>): Promise<Error> {
-  try {
-    await promise;
-  } catch (error) {
-    if (error instanceof Error) {
-      return error;
-    }
-
-    throw new TypeError("Expected promise to reject with an Error", {
-      cause: error,
-    });
-  }
-
-  throw new Error("Expected promise to reject");
 }

--- a/src/serve/index.ts
+++ b/src/serve/index.ts
@@ -5,6 +5,7 @@ export {
   serveSimAws,
   SimAwsLocalServer,
 } from "./http/local-server/sim-aws-local-server.js";
+export { SimAwsLocalPortInUse } from "./http/local-server/sim-aws-local-port.error.js";
 export {
   type SimAwsServiceController,
   SimAwsServiceRequest,

--- a/test/promise-error.ts
+++ b/test/promise-error.ts
@@ -1,0 +1,18 @@
+/**
+ * Take the Error a promise rejected with, for asserting on.
+ */
+export async function promiseError(promise: Promise<void>): Promise<Error> {
+  try {
+    await promise;
+  } catch (error) {
+    if (error instanceof Error) {
+      return error;
+    }
+
+    throw new TypeError("Expected promise to reject with an Error", {
+      cause: error,
+    });
+  }
+
+  throw new Error("Expected promise to reject");
+}

--- a/test/serve/held-port.ts
+++ b/test/serve/held-port.ts
@@ -1,0 +1,29 @@
+import http from "node:http";
+import { simAwsLocalConfig } from "../../src/serve/http/local-server/sim-aws-local.config.js";
+
+/**
+ * Start a plain HTTP server on a free port, so a test has a port that something
+ * else is holding.
+ */
+export async function listenOnFreePort(): Promise<http.Server> {
+  const holder = http.createServer();
+
+  await new Promise<void>((resolve) => {
+    holder.listen(0, simAwsLocalConfig.loopbackAddress, resolve);
+  });
+
+  return holder;
+}
+
+/**
+ * Read the TCP port a server took.
+ */
+export function serverPort(server: http.Server): number {
+  const address = server.address();
+
+  if (address === null || typeof address === "string") {
+    throw new TypeError("Expected the server to listen on a TCP port");
+  }
+
+  return address.port;
+}

--- a/test/serve/local-server-connection.ts
+++ b/test/serve/local-server-connection.ts
@@ -1,0 +1,70 @@
+import { once } from "node:events";
+import net from "node:net";
+import { simAwsLocalConfig } from "../../src/serve/http/local-server/sim-aws-local.config.js";
+
+// Node leaves an idle keep-alive connection open for five seconds by default,
+// so anything shorter than that proves the server ended the connection itself
+// rather than a timeout getting there first.
+const connectionEndWaitMs = 1000;
+
+const requestStart = `GET / HTTP/1.1\r\nHost: ${simAwsLocalConfig.hostname}\r\n`;
+
+/**
+ * Connect, make one request, and leave the connection open afterwards, the way
+ * a browser holds on to a connection between page loads.
+ */
+export async function keepAliveConnection(port: number): Promise<net.Socket> {
+  const socket = net.createConnection({
+    host: simAwsLocalConfig.loopbackAddress,
+    port,
+  });
+  await once(socket, "connect");
+
+  await write(socket, `${requestStart}Connection: keep-alive\r\n\r\n`);
+  await once(socket, "data");
+
+  return socket;
+}
+
+/**
+ * Send the start of a request without finishing it, leaving the server holding
+ * a connection that is in use rather than idle.
+ */
+export async function startAnotherRequest(socket: net.Socket): Promise<void> {
+  await write(socket, requestStart);
+
+  // Flushing the write only means the bytes left this end. Give the server a
+  // moment to read them, so the connection is in use by the time it closes.
+  await new Promise((resolve) => {
+    setTimeout(resolve, 50);
+  });
+}
+
+/**
+ * Require that an open connection ends promptly, rather than being left for the
+ * client or a timeout to deal with.
+ */
+export async function assertConnectionEnds(socket: net.Socket): Promise<void> {
+  try {
+    await once(socket, "close", {
+      signal: AbortSignal.timeout(connectionEndWaitMs),
+    });
+  } catch {
+    throw new Error(
+      `Connection was still open ${String(connectionEndWaitMs)}ms after the server closed`,
+    );
+  }
+}
+
+async function write(socket: net.Socket, text: string): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    socket.write(text, (error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+
+      resolve();
+    });
+  });
+}


### PR DESCRIPTION
close() ends connections that are in use, not only the idle ones Node lets go of, so the process can exit for a restart. listen() waits a bounded couple of seconds for a pinned port another listener still holds, then throws SimAwsLocalPortInUse naming it.

Resolves https://github.com/KensioSoftware/yulin/issues/416