### PR TITLE
feat: reload the browser when serving on localhost

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ npm i -D @kensio/yulin
 ## Feature specific docs
 
 - [AWS SDK interception](./docs/sdk "Simulated AWS SDK docs")
+- [Serving on localhost](./docs/serve "Serving simulated AWS on localhost docs")
 - [Simulated time](./docs/time "Simulated time docs")
 
 ## Usage
@@ -207,6 +208,21 @@ process.on("SIGTERM", () => {
 A restart usually overlaps the process it is replacing. `listen` waits a couple of seconds for a
 pinned port that is still held, then throws `SimAwsLocalPortInUse` naming the port, which means
 something other than the outgoing process owns it.
+
+#### Reload the browser on a restart
+
+Yulin is the only thing in the response path of a page it serves, so it can tell the browser to
+reload. Turning `liveReload` on puts a small script into the HTML pages served to browsers, and the
+page reloads itself when the process restarts:
+
+```typescript
+const srv = await serveSimAws({ simAws, port: 4599, liveReload: true });
+```
+
+`srv.reload()` reloads connected browsers for a change that needs no restart. Live reload is off by
+default, since an injected page is not byte for byte what the real service returns. See the
+[serving docs](./docs/serve "Serving simulated AWS on localhost docs") for what gets the script and
+what does not.
 
 ### Control simulated time
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,4 +25,5 @@ behaviour and includes example code that can be copied into tests or local devel
 ## Feature documentation
 
 - [AWS SDK interception](./sdk/ "Simulated AWS SDK usage docs")
+- [Serving on localhost](./serve/ "Serving simulated AWS on localhost usage docs")
 - [Simulated time](./time/ "Simulated time usage docs")

--- a/docs/serve/README.md
+++ b/docs/serve/README.md
@@ -45,7 +45,8 @@ await simAws.s3().createBucket(new CreateBucketCommand({ Bucket: "foo-site" }));
 
 const websiteUrl = simAws.s3().getBucketWebsiteUrl("foo-site");
 console.log(srv.localUrl(websiteUrl).toString());
-// http://foo-site.s3-website.us-east-1.sim-aws.localhost:52413/
+// http://foo-site.s3-website.us-east-1.sim-aws.localhost:<srv.port>/
+// with whatever port this run took, since none was pinned.
 
 srv.close();
 ```
@@ -167,9 +168,10 @@ Yulin's own account of a request goes in headers and never in the body, so a res
 the real service returns. Live reload breaks that rule on purpose, and only for a page a browser is
 about to render. A response gets the script only when all of this holds:
 
-- the response `content-type` is `text/html`
+- the response media type is `text/html` exactly
 - the request `accept` header asks for `text/html`
-- the request carries no SigV4 `authorization` header and no `x-amz-*` header
+- the request carries no SigV4 signature, in either an `authorization` header or
+  the query string of a presigned URL, and no `x-amz-*` header
 - the response has no `content-encoding`
 - the response status is not 206, and the request is not a `HEAD`
 
@@ -178,8 +180,10 @@ looking at the same Object through a website endpoint gets the script.
 
 An injected response carries `x-sim-aws-live-reload: injected`. Its `content-length` is recomputed,
 and `etag` and `last-modified` are dropped, since the bytes are no longer the ones those headers
-describe. The script goes in before `</body>`, or before `</html>` when there is no body element, or
-on the end when the HTML has neither.
+describe. Its `cache-control` is set to `no-store`, replacing whatever the service said, because a
+page held in the browser cache is a page live reload cannot reach. The script goes in before
+`</body>`, or before `</html>` when there is no body element, or on the end when the HTML has
+neither.
 
 ### The reserved path
 
@@ -189,8 +193,9 @@ service can serve anything at that path.
 
 ## Limitations
 
-- An injected page is not byte for byte what the real service would return. That is the point of the
-  feature, and the reason it is off by default and says so on startup.
+- An injected page is not byte for byte what the real service would return, and its `cache-control`
+  is the simulator's rather than the service's. That is the point of the feature, and the reason it
+  is off by default and says so on startup.
 - `/__sim-aws/live-reload` is shadowed on every served hostname while live reload is on.
 - Injection decodes the HTML as UTF-8. A page stored in another encoding would be corrupted, so
   serve HTML as UTF-8.

--- a/docs/serve/README.md
+++ b/docs/serve/README.md
@@ -1,0 +1,200 @@
+# Serving simulated AWS on localhost
+
+Serving puts a simulated AWS environment behind a real port, so a browser, `curl` or an SDK client
+reaches it over HTTP.
+
+## Serving a port
+
+`serveSimAws` starts the server and returns once it is listening:
+
+```typescript sim-serve-localhost
+/**
+ * Serving a simulated environment on a port of your choosing.
+ */
+
+import { SimAws } from "@kensio/yulin";
+import { serveSimAws } from "@kensio/yulin/serve";
+
+const simAws = new SimAws();
+const srv = await serveSimAws({ simAws, port: 8787 });
+
+console.log(srv.port); // "8787"
+
+srv.close();
+```
+
+Without a `port` the server takes whatever port is free, which changes on every run. Pin one when
+the URL needs to stay the same, such as when a browser is pointed at it.
+
+Simulated hostnames do not resolve to the port the server took, so a URL from a simulated service
+needs adapting before it can be fetched. `srv.localUrl(...)` does that:
+
+```typescript sim-serve-local-url
+/**
+ * Turning a simulated AWS URL into one that reaches the local server.
+ */
+
+import { CreateBucketCommand } from "@aws-sdk/client-s3";
+import { SimAws } from "@kensio/yulin";
+import { serveSimAws } from "@kensio/yulin/serve";
+
+const simAws = new SimAws();
+const srv = await serveSimAws({ simAws });
+
+await simAws.s3().createBucket(new CreateBucketCommand({ Bucket: "foo-site" }));
+
+const websiteUrl = simAws.s3().getBucketWebsiteUrl("foo-site");
+console.log(srv.localUrl(websiteUrl).toString());
+// http://foo-site.s3-website.us-east-1.sim-aws.localhost:52413/
+
+srv.close();
+```
+
+## Stopping and restarting
+
+`close()` stops serving and ends the connections the server is holding, so the process can exit.
+Yulin installs no signal handlers, since a library taking over process signals gets in the way of
+whatever else the process is doing. Call `close()` from your own handler:
+
+```typescript sim-serve-shutdown
+/**
+ * Closing a served environment when the process is asked to stop.
+ */
+
+import { serveSimAws } from "@kensio/yulin/serve";
+
+const srv = await serveSimAws({ port: 8787 });
+
+process.on("SIGTERM", () => {
+  srv.close();
+});
+```
+
+A restart usually overlaps the process it replaces. `listen` waits a couple of seconds for a pinned
+port that is still held, then throws `SimAwsLocalPortInUse` naming the port, which means something
+other than the outgoing process owns it.
+
+## Live reload
+
+A page served from a simulated Bucket website, CloudFront distribution, Function URL or HTTP API has
+nothing but Yulin in its response path, so Yulin is the only thing that can tell the browser to
+reload. Turning `liveReload` on serves a reload channel and puts a small script into the HTML pages
+it serves to browsers:
+
+```typescript sim-serve-live-reload
+/**
+ * Serving with live reload, so a browser reloads itself when the process
+ * restarts.
+ */
+
+import { SimAws } from "@kensio/yulin";
+import { serveSimAws } from "@kensio/yulin/serve";
+
+const simAws = new SimAws();
+const srv = await serveSimAws({ simAws, port: 8787, liveReload: true });
+
+// Build the simulated environment the pages are served from here.
+
+process.on("SIGTERM", () => {
+  srv.close();
+});
+```
+
+It is off by default. With it off, no response differs by a byte from what it would otherwise be.
+
+### Reloading on a restart
+
+Local development means restarting the process, because a changed setup script or Lambda handler
+needs a fresh module graph. The script survives that on its own, with no supervisor process and
+nothing shared between the outgoing and incoming process.
+
+The channel is Server-Sent Events rather than a WebSocket, so the browser reconnects by itself. Each
+process has a boot id and sends it to every page that connects. A page that reconnects and finds a
+different boot id knows it is showing output from a process that is no longer running, and reloads.
+A page that reconnects to the same boot id, which is what a blip on a still running process gives,
+does nothing.
+
+`close()` sends a `reloading` event before the connections go, so a page knows the gap it is about to
+see is a restart rather than a server that has died. The page is not drawn over. It gets a
+`data-sim-aws-live-reload="reloading"` attribute on its `<html>` element, which it can style:
+
+```css
+html[data-sim-aws-live-reload="reloading"] {
+  opacity: 0.6;
+}
+```
+
+This works with no supervisor process involved, so a dev script started from an IDE debugger gets
+browser reload with the debugger attached throughout.
+
+### Reloading without a restart
+
+For a change that needs no restart, such as new content in a simulated Bucket, `reload()` reloads
+every connected browser:
+
+```typescript sim-serve-reload
+/**
+ * Reloading connected browsers after changing simulated content in place.
+ */
+
+import { CreateBucketCommand, PutObjectCommand } from "@aws-sdk/client-s3";
+import { SimAws } from "@kensio/yulin";
+import { serveSimAws } from "@kensio/yulin/serve";
+
+const simAws = new SimAws();
+const srv = await serveSimAws({ simAws, liveReload: true });
+
+await simAws.s3().createBucket(new CreateBucketCommand({ Bucket: "foo-site" }));
+await simAws.s3().putObject(
+  new PutObjectCommand({
+    Bucket: "foo-site",
+    Key: "index.html",
+    Body: "<h1>Changed</h1>",
+    ContentType: "text/html; charset=utf-8",
+  }),
+);
+
+srv.reload();
+
+srv.close();
+```
+
+`reload()` throws when live reload is off, rather than quietly doing nothing.
+
+### What gets the script
+
+Yulin's own account of a request goes in headers and never in the body, so a response keeps the shape
+the real service returns. Live reload breaks that rule on purpose, and only for a page a browser is
+about to render. A response gets the script only when all of this holds:
+
+- the response `content-type` is `text/html`
+- the request `accept` header asks for `text/html`
+- the request carries no SigV4 `authorization` header and no `x-amz-*` header
+- the response has no `content-encoding`
+- the response status is not 206, and the request is not a `HEAD`
+
+So an SDK `GetObject` for an HTML Object gets the stored bytes, byte for byte, while a browser
+looking at the same Object through a website endpoint gets the script.
+
+An injected response carries `x-sim-aws-live-reload: injected`. Its `content-length` is recomputed,
+and `etag` and `last-modified` are dropped, since the bytes are no longer the ones those headers
+describe. The script goes in before `</body>`, or before `</html>` when there is no body element, or
+on the end when the HTML has neither.
+
+### The reserved path
+
+The reload channel is served at `/__sim-aws/live-reload` on every hostname the server answers on, so
+a page can ask for it relative to wherever it was served from. While live reload is on, no simulated
+service can serve anything at that path.
+
+## Limitations
+
+- An injected page is not byte for byte what the real service would return. That is the point of the
+  feature, and the reason it is off by default and says so on startup.
+- `/__sim-aws/live-reload` is shadowed on every served hostname while live reload is on.
+- Injection decodes the HTML as UTF-8. A page stored in another encoding would be corrupted, so
+  serve HTML as UTF-8.
+- An open reload connection uses one of the browser's six connections per origin per tab.
+- Nothing is watched. Yulin reloads when the process restarts or when `reload()` is called, and
+  choosing what to watch is left to whatever runs the dev script.
+- There is no overlay for a reload that failed. The terminal has the error.

--- a/docs/serve/sim-serve-live-reload.example.ts
+++ b/docs/serve/sim-serve-live-reload.example.ts
@@ -1,0 +1,16 @@
+/**
+ * Serving with live reload, so a browser reloads itself when the process
+ * restarts.
+ */
+
+import { SimAws } from "@kensio/yulin";
+import { serveSimAws } from "@kensio/yulin/serve";
+
+const simAws = new SimAws();
+const srv = await serveSimAws({ simAws, port: 8787, liveReload: true });
+
+// Build the simulated environment the pages are served from here.
+
+process.on("SIGTERM", () => {
+  srv.close();
+});

--- a/docs/serve/sim-serve-local-url.example.ts
+++ b/docs/serve/sim-serve-local-url.example.ts
@@ -13,6 +13,7 @@ await simAws.s3().createBucket(new CreateBucketCommand({ Bucket: "foo-site" }));
 
 const websiteUrl = simAws.s3().getBucketWebsiteUrl("foo-site");
 console.log(srv.localUrl(websiteUrl).toString());
-// http://foo-site.s3-website.us-east-1.sim-aws.localhost:52413/
+// http://foo-site.s3-website.us-east-1.sim-aws.localhost:<srv.port>/
+// with whatever port this run took, since none was pinned.
 
 srv.close();

--- a/docs/serve/sim-serve-local-url.example.ts
+++ b/docs/serve/sim-serve-local-url.example.ts
@@ -1,0 +1,18 @@
+/**
+ * Turning a simulated AWS URL into one that reaches the local server.
+ */
+
+import { CreateBucketCommand } from "@aws-sdk/client-s3";
+import { SimAws } from "@kensio/yulin";
+import { serveSimAws } from "@kensio/yulin/serve";
+
+const simAws = new SimAws();
+const srv = await serveSimAws({ simAws });
+
+await simAws.s3().createBucket(new CreateBucketCommand({ Bucket: "foo-site" }));
+
+const websiteUrl = simAws.s3().getBucketWebsiteUrl("foo-site");
+console.log(srv.localUrl(websiteUrl).toString());
+// http://foo-site.s3-website.us-east-1.sim-aws.localhost:52413/
+
+srv.close();

--- a/docs/serve/sim-serve-localhost.example.ts
+++ b/docs/serve/sim-serve-localhost.example.ts
@@ -1,0 +1,13 @@
+/**
+ * Serving a simulated environment on a port of your choosing.
+ */
+
+import { SimAws } from "@kensio/yulin";
+import { serveSimAws } from "@kensio/yulin/serve";
+
+const simAws = new SimAws();
+const srv = await serveSimAws({ simAws, port: 8787 });
+
+console.log(srv.port); // "8787"
+
+srv.close();

--- a/docs/serve/sim-serve-reload.example.ts
+++ b/docs/serve/sim-serve-reload.example.ts
@@ -1,0 +1,24 @@
+/**
+ * Reloading connected browsers after changing simulated content in place.
+ */
+
+import { CreateBucketCommand, PutObjectCommand } from "@aws-sdk/client-s3";
+import { SimAws } from "@kensio/yulin";
+import { serveSimAws } from "@kensio/yulin/serve";
+
+const simAws = new SimAws();
+const srv = await serveSimAws({ simAws, liveReload: true });
+
+await simAws.s3().createBucket(new CreateBucketCommand({ Bucket: "foo-site" }));
+await simAws.s3().putObject(
+  new PutObjectCommand({
+    Bucket: "foo-site",
+    Key: "index.html",
+    Body: "<h1>Changed</h1>",
+    ContentType: "text/html; charset=utf-8",
+  }),
+);
+
+srv.reload();
+
+srv.close();

--- a/docs/serve/sim-serve-shutdown.example.ts
+++ b/docs/serve/sim-serve-shutdown.example.ts
@@ -1,0 +1,11 @@
+/**
+ * Closing a served environment when the process is asked to stop.
+ */
+
+import { serveSimAws } from "@kensio/yulin/serve";
+
+const srv = await serveSimAws({ port: 8787 });
+
+process.on("SIGTERM", () => {
+  srv.close();
+});

--- a/src/serve/http/live-reload/sim-live-reload-client.ts
+++ b/src/serve/http/live-reload/sim-live-reload-client.ts
@@ -1,0 +1,64 @@
+import type { ServerResponse } from "node:http";
+import { simLiveReloadConfig } from "./sim-live-reload.config.js";
+
+/**
+ * One browser holding a live reload connection open.
+ *
+ * Server-Sent Events rather than a WebSocket, because the browser reconnects on
+ * its own. That is what lets a reload survive the process restarting: the
+ * outgoing process has nothing to hand over, and the incoming one has nothing
+ * to pick up.
+ */
+export class SimLiveReloadClient {
+  private readonly response: ServerResponse;
+
+  constructor(response: ServerResponse) {
+    this.response = response;
+  }
+
+  /**
+   * Start the event stream, telling the browser how soon to come back.
+   */
+  open(): void {
+    this.response.writeHead(200, {
+      "content-type": "text/event-stream",
+      "cache-control": "no-store",
+      connection: "keep-alive",
+    });
+    this.write(`retry: ${String(simLiveReloadConfig.clientRetryMs)}\n\n`);
+  }
+
+  /**
+   * Send one named event.
+   */
+  send(event: string, data: string): void {
+    this.write(`event: ${event}\ndata: ${data}\n\n`);
+  }
+
+  /**
+   * Finish the stream, so the browser reconnects rather than waiting on a
+   * connection nothing is going to answer on.
+   */
+  end(): void {
+    if (this.response.writableEnded) {
+      return;
+    }
+
+    this.response.end();
+  }
+
+  /**
+   * Run something when the browser goes away.
+   */
+  onClose(listener: () => void): void {
+    this.response.on("close", listener);
+  }
+
+  private write(chunk: string): void {
+    if (this.response.writableEnded) {
+      return;
+    }
+
+    this.response.write(chunk);
+  }
+}

--- a/src/serve/http/live-reload/sim-live-reload-injectable.iso.test.ts
+++ b/src/serve/http/live-reload/sim-live-reload-injectable.iso.test.ts
@@ -1,0 +1,151 @@
+import { assertFalse, assertTrue } from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimLiveReloadInjectable } from "./sim-live-reload-injectable.js";
+
+describe("SimLiveReloadInjectable", () => {
+  it("allows an HTML page a browser asked for", () => {
+    // Given an HTML response to a browser request
+    const injectable = new SimLiveReloadInjectable();
+
+    // When it is considered for the reload script
+    const allowed = injectable.allows(browserRequest(), htmlResponse());
+
+    // Then the script can go in
+    assertTrue(allowed);
+  });
+
+  it("refuses a response that is not HTML", () => {
+    // Given a JSON response
+    const injectable = new SimLiveReloadInjectable();
+    const response = htmlResponse({ "content-type": "application/json" });
+
+    // When it is considered for the reload script
+    const allowed = injectable.allows(browserRequest(), response);
+
+    // Then it is left alone
+    assertFalse(allowed);
+  });
+
+  it("refuses a response that does not say what it is", () => {
+    // Given a response with no content type at all
+    const injectable = new SimLiveReloadInjectable();
+    const response = new Response("<html></html>");
+    response.headers.delete("content-type");
+
+    // When it is considered for the reload script
+    const allowed = injectable.allows(browserRequest(), response);
+
+    // Then it is left alone, rather than guessed at
+    assertFalse(allowed);
+  });
+
+  it("refuses a request that did not ask for HTML", () => {
+    // Given a request from something that will not render a page
+    const injectable = new SimLiveReloadInjectable();
+    const request = browserRequest({ accept: "application/json" });
+
+    // When its response is considered for the reload script
+    const allowed = injectable.allows(request, htmlResponse());
+
+    // Then it is left alone
+    assertFalse(allowed);
+  });
+
+  it("refuses a signed request", () => {
+    // Given a request an AWS client signed
+    const injectable = new SimLiveReloadInjectable();
+    const request = browserRequest({
+      authorization: "AWS4-HMAC-SHA256 Credential=AKIA/20260806/eu-west-2/s3",
+    });
+
+    // When its response is considered for the reload script
+    const allowed = injectable.allows(request, htmlResponse());
+
+    // Then the Object comes back as it was stored
+    assertFalse(allowed);
+  });
+
+  it("refuses a request carrying an AWS header", () => {
+    // Given an unsigned request that is still an AWS client talking
+    const injectable = new SimLiveReloadInjectable();
+    const request = browserRequest({ "x-amz-content-sha256": "UNSIGNED" });
+
+    // When its response is considered for the reload script
+    const allowed = injectable.allows(request, htmlResponse());
+
+    // Then the Object comes back as it was stored
+    assertFalse(allowed);
+  });
+
+  it("refuses an encoded body", () => {
+    // Given an HTML response the simulator would have to decode first
+    const injectable = new SimLiveReloadInjectable();
+    const response = htmlResponse({
+      "content-type": "text/html",
+      "content-encoding": "gzip",
+    });
+
+    // When it is considered for the reload script
+    const allowed = injectable.allows(browserRequest(), response);
+
+    // Then it is left alone
+    assertFalse(allowed);
+  });
+
+  it("refuses a partial response", () => {
+    // Given a range of a page rather than the whole of it
+    const injectable = new SimLiveReloadInjectable();
+    const response = new Response("<html>", {
+      status: 206,
+      headers: { "content-type": "text/html" },
+    });
+
+    // When it is considered for the reload script
+    const allowed = injectable.allows(browserRequest(), response);
+
+    // Then it is left alone
+    assertFalse(allowed);
+  });
+
+  it("refuses a HEAD request", () => {
+    // Given a request asking only for the headers of a page
+    const injectable = new SimLiveReloadInjectable();
+    const request = new Request("http://site.sim-aws.localhost/", {
+      method: "HEAD",
+      headers: { accept: "text/html" },
+    });
+
+    // When its response is considered for the reload script
+    const allowed = injectable.allows(request, htmlResponse());
+
+    // Then it is left alone, since it has no body to put the script in
+    assertFalse(allowed);
+  });
+
+  it("refuses a response with no body", () => {
+    // Given a response that carries no page
+    const injectable = new SimLiveReloadInjectable();
+    const response = new Response(null, {
+      status: 204,
+      headers: { "content-type": "text/html" },
+    });
+
+    // When it is considered for the reload script
+    const allowed = injectable.allows(browserRequest(), response);
+
+    // Then it is left alone
+    assertFalse(allowed);
+  });
+});
+
+function browserRequest(headers: Record<string, string> = {}): Request {
+  return new Request("http://site.sim-aws.localhost/", {
+    headers: { accept: "text/html,application/xhtml+xml", ...headers },
+  });
+}
+
+function htmlResponse(headers: Record<string, string> = {}): Response {
+  return new Response("<html><body></body></html>", {
+    headers: { "content-type": "text/html; charset=utf-8", ...headers },
+  });
+}

--- a/src/serve/http/live-reload/sim-live-reload-injectable.iso.test.ts
+++ b/src/serve/http/live-reload/sim-live-reload-injectable.iso.test.ts
@@ -26,6 +26,34 @@ describe("SimLiveReloadInjectable", () => {
     assertFalse(allowed);
   });
 
+  it("refuses a media type that only starts like HTML", () => {
+    // Given a response whose type begins with the one being looked for
+    const injectable = new SimLiveReloadInjectable();
+    const response = htmlResponse({ "content-type": "text/htmlx" });
+
+    // When it is considered for the reload script
+    const allowed = injectable.allows(browserRequest(), response);
+
+    // Then it is left alone, since it is not HTML
+    assertFalse(allowed);
+  });
+
+  it("refuses a request signed in its query string", () => {
+    // Given a presigned URL opened in a browser, which sends an HTML accept
+    // header and carries its signature in the query string rather than a header
+    const injectable = new SimLiveReloadInjectable();
+    const request = new Request(
+      "http://site.sim-aws.localhost/page.html?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Signature=abc",
+      { headers: { accept: "text/html" } },
+    );
+
+    // When its response is considered for the reload script
+    const allowed = injectable.allows(request, htmlResponse());
+
+    // Then the Object comes back as it was stored
+    assertFalse(allowed);
+  });
+
   it("refuses a response that does not say what it is", () => {
     // Given a response with no content type at all
     const injectable = new SimLiveReloadInjectable();

--- a/src/serve/http/live-reload/sim-live-reload-injectable.ts
+++ b/src/serve/http/live-reload/sim-live-reload-injectable.ts
@@ -1,5 +1,19 @@
 const sigV4AuthorizationPrefix = "AWS4-HMAC-SHA256";
 const htmlContentType = "text/html";
+const awsNamePrefix = "x-amz-";
+
+/**
+ * Whether any of these header or query parameter names is an AWS one.
+ */
+function hasAwsPrefixed(names: IterableIterator<string>): boolean {
+  for (const name of names) {
+    if (name.toLowerCase().startsWith(awsNamePrefix)) {
+      return true;
+    }
+  }
+
+  return false;
+}
 
 /**
  * Decides whether a response can carry the live reload script.
@@ -41,14 +55,17 @@ export class SimLiveReloadInjectable {
   }
 
   /**
-   * An encoded body would have to be decoded, changed and re-encoded, and the
-   * simulator has no reason to be in that business.
+   * The media type has to be `text/html` itself, not merely start with it, so a
+   * type such as `text/htmlx` is left alone. An encoded body would have to be
+   * decoded, changed and re-encoded, and the simulator has no reason to be in
+   * that business.
    */
   private isPlainHtml(response: Response): boolean {
     const contentType = response.headers.get("content-type") ?? "";
+    const [mediaType = ""] = contentType.split(";");
 
     return (
-      contentType.toLowerCase().startsWith(htmlContentType) &&
+      mediaType.trim().toLowerCase() === htmlContentType &&
       !response.headers.has("content-encoding")
     );
   }
@@ -62,22 +79,25 @@ export class SimLiveReloadInjectable {
     return accept.toLowerCase().includes(htmlContentType);
   }
 
+  /**
+   * A signature comes either in a header or, for a presigned URL, in the query
+   * string. A presigned URL is the one signed request a browser makes with an
+   * ordinary HTML `accept` header, which is what an address bar sends, so
+   * missing it would mean handing back an Object with bytes added to it.
+   */
   private isSignedRequest(request: Request): boolean {
     const authorization = request.headers.get("authorization") ?? "";
 
-    return authorization.startsWith(sigV4AuthorizationPrefix);
+    return (
+      authorization.startsWith(sigV4AuthorizationPrefix) ||
+      hasAwsPrefixed(new URL(request.url).searchParams.keys())
+    );
   }
 
   /**
    * An `x-amz-*` header is an AWS client talking, whether it signed or not.
    */
   private isSdkRequest(request: Request): boolean {
-    for (const name of request.headers.keys()) {
-      if (name.toLowerCase().startsWith("x-amz-")) {
-        return true;
-      }
-    }
-
-    return false;
+    return hasAwsPrefixed(request.headers.keys());
   }
 }

--- a/src/serve/http/live-reload/sim-live-reload-injectable.ts
+++ b/src/serve/http/live-reload/sim-live-reload-injectable.ts
@@ -1,0 +1,83 @@
+const sigV4AuthorizationPrefix = "AWS4-HMAC-SHA256";
+const htmlContentType = "text/html";
+
+/**
+ * Decides whether a response can carry the live reload script.
+ *
+ * The simulator's own account of a request goes in headers and never in the
+ * body, so that a response keeps the shape the real service returns. Injecting
+ * a script breaks that rule, and these checks are what keep the breakage to the
+ * one case it is worth it for: an HTML page a browser is about to render.
+ *
+ * Everything else comes back untouched. An SDK reading an HTML Object out of a
+ * Bucket has to get the bytes that were stored, and a range or an encoded body
+ * cannot take an insertion at all.
+ */
+export class SimLiveReloadInjectable {
+  /**
+   * Whether the script belongs in this response.
+   */
+  allows(request: Request, response: Response): boolean {
+    return (
+      this.hasBody(request, response) &&
+      this.isWholeResponse(response) &&
+      this.isPlainHtml(response) &&
+      this.isBrowserRequest(request) &&
+      !this.isSignedRequest(request) &&
+      !this.isSdkRequest(request)
+    );
+  }
+
+  private hasBody(request: Request, response: Response): boolean {
+    return request.method !== "HEAD" && response.body !== null;
+  }
+
+  /**
+   * A partial response is a slice of a body, and a slice cannot take an
+   * insertion without the offsets the client already asked for going wrong.
+   */
+  private isWholeResponse(response: Response): boolean {
+    return response.status !== 206;
+  }
+
+  /**
+   * An encoded body would have to be decoded, changed and re-encoded, and the
+   * simulator has no reason to be in that business.
+   */
+  private isPlainHtml(response: Response): boolean {
+    const contentType = response.headers.get("content-type") ?? "";
+
+    return (
+      contentType.toLowerCase().startsWith(htmlContentType) &&
+      !response.headers.has("content-encoding")
+    );
+  }
+
+  /**
+   * Something asking for HTML is something that will render it.
+   */
+  private isBrowserRequest(request: Request): boolean {
+    const accept = request.headers.get("accept") ?? "";
+
+    return accept.toLowerCase().includes(htmlContentType);
+  }
+
+  private isSignedRequest(request: Request): boolean {
+    const authorization = request.headers.get("authorization") ?? "";
+
+    return authorization.startsWith(sigV4AuthorizationPrefix);
+  }
+
+  /**
+   * An `x-amz-*` header is an AWS client talking, whether it signed or not.
+   */
+  private isSdkRequest(request: Request): boolean {
+    for (const name of request.headers.keys()) {
+      if (name.toLowerCase().startsWith("x-amz-")) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+}

--- a/src/serve/http/live-reload/sim-live-reload-injector.iso.test.ts
+++ b/src/serve/http/live-reload/sim-live-reload-injector.iso.test.ts
@@ -1,0 +1,141 @@
+import {
+  assertIdentical,
+  assertStringEndsWith,
+  assertStringIncludes,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimLiveReloadInjector } from "./sim-live-reload-injector.js";
+import { simLiveReloadHeaderName } from "./sim-live-reload.config.js";
+
+describe("SimLiveReloadInjector", () => {
+  it("puts the script at the end of the body", async () => {
+    // Given an ordinary page
+    const injector = new SimLiveReloadInjector();
+    const response = htmlResponse("<html><body><h1>Hi</h1></body></html>");
+
+    // When it is served to a browser
+    const injected = await injector.injectInto(browserRequest(), response);
+
+    // Then the script is the last thing in the body
+    assertStringEndsWith(await injected.text(), "</script></body></html>");
+    assertIdentical(injected.headers.get(simLiveReloadHeaderName), "injected");
+  });
+
+  it("puts the script before the closing html tag when there is no body", async () => {
+    // Given a page with no body element
+    const injector = new SimLiveReloadInjector();
+    const response = htmlResponse("<html><h1>Hi</h1></html>");
+
+    // When it is served to a browser
+    const injected = await injector.injectInto(browserRequest(), response);
+
+    // Then the script still goes at the end of the document
+    assertStringEndsWith(await injected.text(), "</script></html>");
+  });
+
+  it("appends the script to a fragment with no closing tag", async () => {
+    // Given HTML that is not a whole document
+    const injector = new SimLiveReloadInjector();
+    const response = htmlResponse("<h1>Hi</h1>");
+
+    // When it is served to a browser
+    const injected = await injector.injectInto(browserRequest(), response);
+
+    // Then the script goes on the end, since a browser will render it anyway
+    assertStringIncludes(await injected.text(), "<h1>Hi</h1><script");
+  });
+
+  it("finds a closing tag written in capitals", async () => {
+    // Given a page whose tags are not lower case
+    const injector = new SimLiveReloadInjector();
+    const response = htmlResponse("<HTML><BODY>Hi</BODY></HTML>");
+
+    // When it is served to a browser
+    const injected = await injector.injectInto(browserRequest(), response);
+
+    // Then the script still goes at the end of the body
+    assertStringEndsWith(await injected.text(), "</script></BODY></HTML>");
+  });
+
+  it("puts the script after content that lowercases to a longer string", async () => {
+    // Given a page holding a character that grows when it is lowercased
+    const injector = new SimLiveReloadInjector();
+    const response = htmlResponse("<html><body>İstanbul</body></html>");
+
+    // When it is served to a browser
+    const injected = await injector.injectInto(browserRequest(), response);
+
+    // Then the script lands on the tag rather than a few characters off it
+    assertStringIncludes(
+      await injected.text(),
+      "İstanbul<script data-sim-aws-live-reload>",
+    );
+  });
+
+  it("describes the bytes it actually sends", async () => {
+    // Given a page whose headers describe the stored Object
+    const injector = new SimLiveReloadInjector();
+    const page = "<html><body></body></html>";
+    const response = htmlResponse(page, {
+      "content-length": String(page.length),
+      etag: '"9a0364b9e99bb480dd25e1f0284c8555"',
+      "last-modified": "Wed, 05 Aug 2026 12:00:00 GMT",
+    });
+
+    // When it is served to a browser
+    const injected = await injector.injectInto(browserRequest(), response);
+    const body = await injected.text();
+
+    // Then those headers describe the injected page, or are gone
+    assertIdentical(
+      injected.headers.get("content-length"),
+      String(Buffer.byteLength(body)),
+    );
+    assertIdentical(injected.headers.get("etag"), null);
+    assertIdentical(injected.headers.get("last-modified"), null);
+  });
+
+  it("returns a response it cannot inject untouched", async () => {
+    // Given a response that is not an HTML page
+    const injector = new SimLiveReloadInjector();
+    const response = new Response('{"ok":true}', {
+      headers: { "content-type": "application/json" },
+    });
+
+    // When it is served
+    const served = await injector.injectInto(browserRequest(), response);
+
+    // Then it is the same response, with nothing added
+    assertIdentical(served, response);
+    assertIdentical(served.headers.get(simLiveReloadHeaderName), null);
+  });
+
+  it("keeps the status of the response it injects", async () => {
+    // Given an HTML error page
+    const injector = new SimLiveReloadInjector();
+    const response = htmlResponse("<html><body>Gone</body></html>", {}, 404);
+
+    // When it is served to a browser
+    const injected = await injector.injectInto(browserRequest(), response);
+
+    // Then it is still the same error
+    assertIdentical(injected.status, 404);
+  });
+});
+
+function browserRequest(): Request {
+  return new Request("http://site.sim-aws.localhost/", {
+    headers: { accept: "text/html" },
+  });
+}
+
+function htmlResponse(
+  body: string,
+  headers: Record<string, string> = {},
+  status = 200,
+): Response {
+  return new Response(body, {
+    status,
+    headers: { "content-type": "text/html; charset=utf-8", ...headers },
+  });
+}

--- a/src/serve/http/live-reload/sim-live-reload-injector.iso.test.ts
+++ b/src/serve/http/live-reload/sim-live-reload-injector.iso.test.ts
@@ -95,6 +95,20 @@ describe("SimLiveReloadInjector", () => {
     assertIdentical(injected.headers.get("last-modified"), null);
   });
 
+  it("keeps an injected page out of the browser cache", async () => {
+    // Given a page the service said could be held on to
+    const injector = new SimLiveReloadInjector();
+    const response = htmlResponse("<html><body></body></html>", {
+      "cache-control": "public, max-age=3600",
+    });
+
+    // When it is served to a browser
+    const injected = await injector.injectInto(browserRequest(), response);
+
+    // Then it is not stored, since a cached copy is one live reload cannot reach
+    assertIdentical(injected.headers.get("cache-control"), "no-store");
+  });
+
   it("returns a response it cannot inject untouched", async () => {
     // Given a response that is not an HTML page
     const injector = new SimLiveReloadInjector();

--- a/src/serve/http/live-reload/sim-live-reload-injector.ts
+++ b/src/serve/http/live-reload/sim-live-reload-injector.ts
@@ -1,0 +1,79 @@
+import { SimLiveReloadInjectable } from "./sim-live-reload-injectable.js";
+import { simLiveReloadScriptTag } from "./sim-live-reload-script.js";
+import { simLiveReloadHeaderName } from "./sim-live-reload.config.js";
+
+/**
+ * Puts the live reload script into HTML on its way to a browser.
+ *
+ * The script goes in at the end of the document, so the page has parsed before
+ * a connection is opened. The bytes of the body change, so anything describing
+ * those bytes has to change with them: `content-length` is recomputed, and
+ * `etag` and `last-modified` are dropped rather than left describing the
+ * stored Object the page no longer is.
+ */
+export class SimLiveReloadInjector {
+  private readonly injectable = new SimLiveReloadInjectable();
+
+  /**
+   * Return the response a browser should get, injected if it can take it.
+   */
+  async injectInto(request: Request, response: Response): Promise<Response> {
+    if (!this.injectable.allows(request, response)) {
+      return response;
+    }
+
+    return this.inject(response);
+  }
+
+  private async inject(response: Response): Promise<Response> {
+    const body = insertScriptTag(await response.text());
+    const headers = new Headers(response.headers);
+
+    headers.delete("etag");
+    headers.delete("last-modified");
+    headers.set("content-length", String(Buffer.byteLength(body)));
+    headers.set(simLiveReloadHeaderName, "injected");
+
+    return new Response(body, {
+      status: response.status,
+      statusText: response.statusText,
+      headers,
+    });
+  }
+}
+
+// Matched against the document as written, rather than against a lowercased
+// copy, because lowercasing can change a string's length and move every offset
+// after the character that changed.
+const closingTagPatterns = [/<\/body\s*>/gi, /<\/html\s*>/gi];
+
+/**
+ * Put the script at the end of the document, wherever that turns out to be.
+ *
+ * A closing tag is the ordinary case. HTML without one is still something a
+ * browser will render, so appending is better than declining to reload it.
+ */
+function insertScriptTag(html: string): string {
+  for (const pattern of closingTagPatterns) {
+    const at = lastMatchIndex(html, pattern);
+
+    if (at !== -1) {
+      return html.slice(0, at) + simLiveReloadScriptTag + html.slice(at);
+    }
+  }
+
+  return html + simLiveReloadScriptTag;
+}
+
+/**
+ * Where the document's own closing tag is, rather than one inside it.
+ */
+function lastMatchIndex(html: string, pattern: RegExp): number {
+  let index = -1;
+
+  for (const match of html.matchAll(pattern)) {
+    index = match.index;
+  }
+
+  return index;
+}

--- a/src/serve/http/live-reload/sim-live-reload-injector.ts
+++ b/src/serve/http/live-reload/sim-live-reload-injector.ts
@@ -10,6 +10,10 @@ import { simLiveReloadHeaderName } from "./sim-live-reload.config.js";
  * those bytes has to change with them: `content-length` is recomputed, and
  * `etag` and `last-modified` are dropped rather than left describing the
  * stored Object the page no longer is.
+ *
+ * An injected page is also not stored. A cached copy would outlive the reload
+ * it was injected for, and a page held in the browser cache is a page live
+ * reload cannot reach.
  */
 export class SimLiveReloadInjector {
   private readonly injectable = new SimLiveReloadInjectable();
@@ -32,6 +36,7 @@ export class SimLiveReloadInjector {
     headers.delete("etag");
     headers.delete("last-modified");
     headers.set("content-length", String(Buffer.byteLength(body)));
+    headers.set("cache-control", "no-store");
     headers.set(simLiveReloadHeaderName, "injected");
 
     return new Response(body, {

--- a/src/serve/http/live-reload/sim-live-reload-report.iso.test.ts
+++ b/src/serve/http/live-reload/sim-live-reload-report.iso.test.ts
@@ -1,0 +1,21 @@
+import { assertStringIncludes } from "@kensio/smartass";
+import { describe, it, vi } from "vitest";
+import { SimLiveReloadReport } from "./sim-live-reload-report.js";
+
+describe("SimLiveReloadReport", () => {
+  it("says live reload is on and where the channel is", () => {
+    // Given a server that has started listening with live reload on
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    // When it reports itself
+    new SimLiveReloadReport().announce("8787");
+
+    // Then the divergence is stated, along with the reserved path
+    const reported = String(warn.mock.calls[0]?.[0]);
+    assertStringIncludes(reported, "live reload is on");
+    assertStringIncludes(
+      reported,
+      "http://sim-aws.localhost:8787/__sim-aws/live-reload",
+    );
+  });
+});

--- a/src/serve/http/live-reload/sim-live-reload-report.ts
+++ b/src/serve/http/live-reload/sim-live-reload-report.ts
@@ -1,0 +1,30 @@
+import { simAwsLocalConfig } from "../local-server/sim-aws-local.config.js";
+import { simLiveReloadConfig } from "./sim-live-reload.config.js";
+
+/**
+ * Says on startup that live reload is on.
+ *
+ * Live reload is the one thing the simulator does that changes a response body,
+ * which is otherwise the shape the real service returns. Something a served
+ * page did not ask for is worth being told about, once, at the point it starts
+ * happening, rather than being found later in a page's source.
+ *
+ * It goes to the console because the simulator has no logger of its own, the
+ * same as every other warning it raises.
+ */
+export class SimLiveReloadReport {
+  /**
+   * Report live reload on a server that has just started listening.
+   */
+  announce(port: string): void {
+    const channel = `http://${simAwsLocalConfig.hostname}:${port}${simLiveReloadConfig.channelPath}`;
+
+    // eslint-disable-next-line no-console
+    console.warn(
+      `Simulated AWS live reload is on. HTML responses to browser requests ` +
+        `carry a reload script, so those responses are not byte for byte what ` +
+        `the real service would return. The reload channel is served at ` +
+        `${channel} on every served hostname.`,
+    );
+  }
+}

--- a/src/serve/http/live-reload/sim-live-reload-script.iso.test.ts
+++ b/src/serve/http/live-reload/sim-live-reload-script.iso.test.ts
@@ -1,0 +1,146 @@
+import vm from "node:vm";
+import { assertIdentical } from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { simLiveReloadScript } from "./sim-live-reload-script.js";
+import { simLiveReloadConfig } from "./sim-live-reload.config.js";
+
+describe("simLiveReloadScript", () => {
+  it("connects to the reserved channel path", () => {
+    // Given a page running the script
+    const page = new LiveReloadPage();
+
+    // When it has run
+    page.run();
+
+    // Then it is listening on the reload channel
+    assertIdentical(page.channel, simLiveReloadConfig.channelPath);
+  });
+
+  it("reloads when it reconnects to a different process", () => {
+    // Given a page connected to one process
+    const page = new LiveReloadPage();
+    page.run();
+    page.emit("boot", "first-boot-id");
+
+    // When it reconnects and finds another one
+    page.emit("boot", "second-boot-id");
+
+    // Then it reloads, because a different process built what it is showing
+    assertIdentical(page.reloads, 1);
+  });
+
+  it("does nothing when it reconnects to the same process", () => {
+    // Given a page connected to a process
+    const page = new LiveReloadPage();
+    page.run();
+    page.emit("boot", "first-boot-id");
+
+    // When the connection drops and comes back to the same one
+    page.emit("boot", "first-boot-id");
+
+    // Then nothing happens, since nothing has been rebuilt
+    assertIdentical(page.reloads, 0);
+  });
+
+  it("reloads when the server asks it to", () => {
+    // Given a connected page
+    const page = new LiveReloadPage();
+    page.run();
+    page.emit("boot", "first-boot-id");
+
+    // When the server sends a reload
+    page.emit("reload", "first-boot-id");
+
+    // Then the page reloads
+    assertIdentical(page.reloads, 1);
+  });
+
+  it("marks the document when a reload is on its way", () => {
+    // Given a connected page
+    const page = new LiveReloadPage();
+    page.run();
+
+    // When the server says it is going down for a reload
+    page.emit("reloading", "first-boot-id");
+
+    // Then the page can style that, rather than having anything drawn over it
+    assertIdentical(page.documentState(), "reloading");
+  });
+
+  it("connects once when the script runs twice", () => {
+    // Given a page that somehow got the script twice
+    const page = new LiveReloadPage();
+    page.run();
+
+    // When the second copy runs
+    page.run();
+
+    // Then it is holding one connection, not two
+    assertIdentical(page.connections, 1);
+  });
+});
+
+interface PageEvent {
+  readonly data: string;
+}
+
+type PageEventListener = (event: PageEvent) => void;
+
+/**
+ * A page running the injected script, with just enough browser around it for
+ * the script to do what it does.
+ */
+class LiveReloadPage {
+  reloads = 0;
+  connections = 0;
+  channel = "";
+
+  private readonly listeners = new Map<string, PageEventListener>();
+  private readonly dataset: Record<string, string> = {};
+  private readonly context: vm.Context;
+  private readonly onReload = (): void => {
+    this.reloads += 1;
+  };
+
+  constructor() {
+    this.context = vm.createContext({
+      window: { location: { reload: this.onReload } },
+      document: { documentElement: { dataset: this.dataset } },
+      EventSource: this.eventSourceClass(),
+    });
+  }
+
+  run(): void {
+    vm.runInContext(simLiveReloadScript, this.context);
+  }
+
+  emit(event: string, data: string): void {
+    this.listeners.get(event)?.({ data });
+  }
+
+  documentState(): string | undefined {
+    return this.dataset["simAwsLiveReload"];
+  }
+
+  private eventSourceClass(): new (url: string) => PageEventSource {
+    const { listeners } = this;
+    const onConnect = (url: string): void => {
+      this.channel = url;
+      this.connections += 1;
+    };
+
+    return class {
+      constructor(url: string) {
+        onConnect(url);
+      }
+
+      addEventListener(event: string, listener: PageEventListener): void {
+        listeners.set(event, listener);
+      }
+    };
+  }
+}
+
+interface PageEventSource {
+  addEventListener(event: string, listener: PageEventListener): void;
+}

--- a/src/serve/http/live-reload/sim-live-reload-script.ts
+++ b/src/serve/http/live-reload/sim-live-reload-script.ts
@@ -1,0 +1,46 @@
+import { simLiveReloadConfig } from "./sim-live-reload.config.js";
+
+/**
+ * The script a served page runs to reload itself.
+ *
+ * It reloads on two signals. An explicit `reload` event is a reload the
+ * simulator asked for. A `boot` event carrying an id other than the one this
+ * page first saw means it is talking to a process that has restarted, which is
+ * how a restart reaches a page without the outgoing and incoming processes
+ * having to agree on anything. Reconnecting to the same id, which is what a
+ * dropped connection to a still running process gives, does nothing.
+ *
+ * A `reloading` event says a reload is on its way. The page is left to decide
+ * what to make of that, through an attribute it can style, rather than having
+ * anything drawn over it.
+ */
+export const simLiveReloadScript = `(() => {
+  if (window.simAwsLiveReload) {
+    return;
+  }
+  window.simAwsLiveReload = true;
+
+  let bootId = null;
+  const source = new EventSource("${simLiveReloadConfig.channelPath}");
+
+  source.addEventListener("boot", (event) => {
+    if (bootId !== null && bootId !== event.data) {
+      window.location.reload();
+      return;
+    }
+    bootId = event.data;
+  });
+
+  source.addEventListener("reload", () => {
+    window.location.reload();
+  });
+
+  source.addEventListener("reloading", () => {
+    document.documentElement.dataset.simAwsLiveReload = "reloading";
+  });
+})();`;
+
+/**
+ * The script as it goes into a page.
+ */
+export const simLiveReloadScriptTag = `<script data-sim-aws-live-reload>${simLiveReloadScript}</script>`;

--- a/src/serve/http/live-reload/sim-live-reload.config.ts
+++ b/src/serve/http/live-reload/sim-live-reload.config.ts
@@ -1,0 +1,19 @@
+/**
+ * Configuration for the live reload channel served on localhost.
+ */
+export const simLiveReloadConfig = {
+  // Reserved on every served hostname, so the injected script can ask for it
+  // with a relative path whatever host the page was served from. The cost is
+  // that a simulated distribution cannot serve anything at this path while live
+  // reload is on.
+  channelPath: "/__sim-aws/live-reload",
+  // How soon a browser reconnects after the connection drops. The default is
+  // several seconds, which is the gap between a restarted process being ready
+  // and the page noticing.
+  clientRetryMs: 500,
+};
+
+/**
+ * Reports that a response carries the injected live reload script.
+ */
+export const simLiveReloadHeaderName = "x-sim-aws-live-reload";

--- a/src/serve/http/live-reload/sim-live-reload.iso.test.ts
+++ b/src/serve/http/live-reload/sim-live-reload.iso.test.ts
@@ -1,0 +1,202 @@
+import { EventEmitter } from "node:events";
+import type { IncomingMessage, ServerResponse } from "node:http";
+import {
+  assertFalse,
+  assertIdentical,
+  assertStringIncludes,
+  assertTrue,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimLiveReload } from "./sim-live-reload.js";
+import { simLiveReloadConfig } from "./sim-live-reload.config.js";
+
+const bootId = "boot-id-for-this-process";
+
+describe("SimLiveReload", () => {
+  it("recognises a request for the reload channel", () => {
+    // Given a live reload channel
+    const liveReload = new SimLiveReload({ bootId });
+
+    // When a browser asks for the reserved path
+    const channelRequest = liveReload.isChannelRequest(
+      browserRequest(simLiveReloadConfig.channelPath),
+    );
+
+    // Then it is answered here rather than by a simulated service
+    assertTrue(channelRequest);
+  });
+
+  it("recognises the reload channel with a trailing slash", () => {
+    // Given a live reload channel
+    const liveReload = new SimLiveReload({ bootId });
+
+    // When a browser asks for the reserved path with a slash on the end
+    const channelRequest = liveReload.isChannelRequest(
+      browserRequest(`${simLiveReloadConfig.channelPath}/?v=1`),
+    );
+
+    // Then it is still the channel
+    assertTrue(channelRequest);
+  });
+
+  it("leaves any other path to the simulated services", () => {
+    // Given a live reload channel
+    const liveReload = new SimLiveReload({ bootId });
+
+    // When a browser asks for an ordinary page
+    const channelRequest = liveReload.isChannelRequest(
+      browserRequest("/index.html"),
+    );
+
+    // Then live reload has nothing to do with it
+    assertFalse(channelRequest);
+  });
+
+  it("leaves a write to the reserved path to the simulated services", () => {
+    // Given a live reload channel
+    const liveReload = new SimLiveReload({ bootId });
+
+    // When something posts to the reserved path
+    const channelRequest = liveReload.isChannelRequest(
+      browserRequest(simLiveReloadConfig.channelPath, "POST"),
+    );
+
+    // Then it is not a request to read the channel
+    assertFalse(channelRequest);
+  });
+
+  it("tells a connecting browser which process it reached", () => {
+    // Given a live reload channel
+    const liveReload = new SimLiveReload({ bootId });
+    const response = new FakeServerResponse();
+
+    // When a browser connects
+    liveReload.connect(response.asNodeResponse());
+
+    // Then it is told how soon to come back, and what it has reached
+    assertIdentical(response.status, 200);
+    assertIdentical(response.headers["content-type"], "text/event-stream");
+    assertStringIncludes(
+      response.written(),
+      `retry: ${String(simLiveReloadConfig.clientRetryMs)}`,
+    );
+    assertStringIncludes(response.written(), `event: boot\ndata: ${bootId}`);
+  });
+
+  it("reloads every connected browser", () => {
+    // Given two connected browsers
+    const liveReload = new SimLiveReload({ bootId });
+    const first = new FakeServerResponse();
+    const second = new FakeServerResponse();
+    liveReload.connect(first.asNodeResponse());
+    liveReload.connect(second.asNodeResponse());
+
+    // When a reload is asked for
+    liveReload.reload();
+
+    // Then both are told to reload
+    assertStringIncludes(first.written(), "event: reload");
+    assertStringIncludes(second.written(), "event: reload");
+  });
+
+  it("says a reload is coming, then ends the connection", () => {
+    // Given a connected browser
+    const liveReload = new SimLiveReload({ bootId });
+    const response = new FakeServerResponse();
+    liveReload.connect(response.asNodeResponse());
+
+    // When the server is stopping
+    liveReload.stopping();
+
+    // Then the browser hears about it and is let go, so it reconnects
+    assertStringIncludes(response.written(), "event: reloading");
+    assertTrue(response.writableEnded);
+  });
+
+  it("forgets a browser that has gone away", () => {
+    // Given a browser that connected and then closed the connection
+    const liveReload = new SimLiveReload({ bootId });
+    const response = new FakeServerResponse();
+    liveReload.connect(response.asNodeResponse());
+    const onConnect = response.written();
+    response.emit("close");
+
+    // When a reload is asked for
+    liveReload.reload();
+
+    // Then nothing more is written to it
+    assertIdentical(response.written(), onConnect);
+  });
+
+  it("writes nothing to a connection that has already finished", () => {
+    // Given a connected browser whose response has been ended
+    const liveReload = new SimLiveReload({ bootId });
+    const response = new FakeServerResponse();
+    liveReload.connect(response.asNodeResponse());
+    liveReload.connect(response.asNodeResponse());
+    response.end();
+    const onConnect = response.written();
+
+    // When a reload is asked for
+    liveReload.reload();
+
+    // Then the finished response is left alone rather than written to
+    assertIdentical(response.written(), onConnect);
+  });
+
+  it("leaves a finished connection alone when stopping", () => {
+    // Given a connected browser whose response has already finished
+    const liveReload = new SimLiveReload({ bootId });
+    const response = new FakeServerResponse();
+    liveReload.connect(response.asNodeResponse());
+    response.end();
+    const onConnect = response.written();
+
+    // When the server stops
+    liveReload.stopping();
+
+    // Then there is nothing to say to it and nothing to end
+    assertIdentical(response.written(), onConnect);
+  });
+});
+
+function browserRequest(url: string, method = "GET"): IncomingMessage {
+  return { method, url } as IncomingMessage;
+}
+
+/**
+ * Just enough of a Node response for the channel to write events to.
+ */
+// eslint-disable-next-line unicorn/prefer-event-target
+class FakeServerResponse extends EventEmitter {
+  status = 0;
+  headers: Record<string, string> = {};
+  writableEnded = false;
+
+  private readonly chunks: string[] = [];
+
+  writeHead(status: number, headers: Record<string, string>): this {
+    this.status = status;
+    this.headers = headers;
+
+    return this;
+  }
+
+  write(chunk: string): boolean {
+    this.chunks.push(chunk);
+
+    return true;
+  }
+
+  end(): void {
+    this.writableEnded = true;
+  }
+
+  written(): string {
+    return this.chunks.join("");
+  }
+
+  asNodeResponse(): ServerResponse {
+    return this as unknown as ServerResponse;
+  }
+}

--- a/src/serve/http/live-reload/sim-live-reload.loc.test.ts
+++ b/src/serve/http/live-reload/sim-live-reload.loc.test.ts
@@ -1,0 +1,167 @@
+import { GetObjectCommand } from "@aws-sdk/client-s3";
+import {
+  assertIdentical,
+  assertStringIncludes,
+  assertStringLength,
+  assertThrowsError,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../service/aws/sim-aws.js";
+import { serveSimAws } from "../local-server/sim-aws-local-server.js";
+import { simLiveReloadHeaderName } from "./sim-live-reload.config.js";
+import { SimLiveReloadChannel } from "../../../../test/serve/live-reload-channel.js";
+import {
+  simBrowserFetch,
+  simServedSite,
+  simServedSiteS3Client,
+  simServedSiteUrl,
+} from "../../../../test/serve/served-site.js";
+
+const page = "<html><body><h1>Hello</h1></body></html>";
+
+describe("Live reload over a local server", () => {
+  it("leaves responses alone when it is off", async () => {
+    // Given a served site with live reload not asked for
+    const simAws = new SimAws();
+    const server = await serveSimAws({ simAws });
+
+    try {
+      await simServedSite(simAws, "quiet-site", page);
+
+      // When a browser asks for the page
+      const response = await simBrowserFetch(
+        simServedSiteUrl(simAws, server, "quiet-site"),
+      );
+
+      // Then it gets the page as it was stored, and no sign of live reload
+      assertIdentical(await response.text(), page);
+      assertIdentical(response.headers.get(simLiveReloadHeaderName), null);
+    } finally {
+      server.close();
+    }
+  });
+
+  it("injects the reload script into a page a browser asked for", async () => {
+    // Given a served site with live reload on
+    const simAws = new SimAws();
+    const server = await serveSimAws({ simAws, liveReload: true });
+
+    try {
+      await simServedSite(simAws, "reload-site", page);
+
+      // When a browser asks for the page
+      const response = await simBrowserFetch(
+        simServedSiteUrl(simAws, server, "reload-site"),
+      );
+      const body = await response.text();
+
+      // Then the script is in it, at the end of the document
+      assertIdentical(
+        response.headers.get(simLiveReloadHeaderName),
+        "injected",
+      );
+      assertStringIncludes(body, "<script data-sim-aws-live-reload>");
+      assertStringIncludes(body, "</script></body></html>");
+
+      // And the headers describe the bytes that were actually sent
+      assertIdentical(
+        response.headers.get("content-length"),
+        String(Buffer.byteLength(body)),
+      );
+    } finally {
+      server.close();
+    }
+  });
+
+  it("gives an SDK the stored Object bytes", async () => {
+    // Given a served site whose page is also readable as an S3 Object
+    const simAws = new SimAws();
+    const server = await serveSimAws({ simAws, liveReload: true });
+
+    try {
+      await simServedSite(simAws, "sdk-site", page);
+      const s3Client = await simServedSiteS3Client(simAws, server, "sdk-site");
+
+      // When an SDK client reads that Object
+      const output = await s3Client.send(
+        new GetObjectCommand({ Bucket: "sdk-site", Key: "index.html" }),
+      );
+
+      // Then it gets what was stored, with nothing injected
+      assertIdentical(await output.Body?.transformToString(), page);
+    } finally {
+      server.close();
+    }
+  });
+
+  it("tells a connected browser which process it reached", async () => {
+    // Given a browser connected to the reload channel
+    const server = await serveSimAws({ liveReload: true });
+
+    try {
+      const channel = await SimLiveReloadChannel.open(server);
+
+      // When it reads the first event
+      const event = await channel.nextEvent();
+
+      // Then it is the boot id of this process
+      assertIdentical(event.event, "boot");
+      assertStringLength(event.data, 36);
+      channel.close();
+    } finally {
+      server.close();
+    }
+  });
+
+  it("reloads a connected browser on reload()", async () => {
+    // Given a browser connected to the reload channel
+    const server = await serveSimAws({ liveReload: true });
+
+    try {
+      const channel = await SimLiveReloadChannel.open(server);
+      await channel.nextEvent();
+
+      // When the server is told to reload
+      server.reload();
+
+      // Then the browser is told to reload
+      const event = await channel.nextEvent();
+      assertIdentical(event.event, "reload");
+      channel.close();
+    } finally {
+      server.close();
+    }
+  });
+
+  it("says a reload is coming before it stops serving", async () => {
+    // Given a browser connected to the reload channel
+    const server = await serveSimAws({ liveReload: true });
+    const channel = await SimLiveReloadChannel.open(server);
+    await channel.nextEvent();
+
+    // When the server closes, as it does on the way to a restart
+    server.close();
+
+    // Then the browser hears that rather than only losing the connection
+    const event = await channel.nextEvent();
+    assertIdentical(event.event, "reloading");
+    channel.close();
+  });
+
+  it("refuses reload() when live reload is off", async () => {
+    // Given a served environment with live reload not asked for
+    const server = await serveSimAws();
+
+    try {
+      // When a reload is asked for anyway
+      const error = assertThrowsError(() => {
+        server.reload();
+      });
+
+      // Then it says what to turn on
+      assertStringIncludes(error.message, "{ liveReload: true }");
+    } finally {
+      server.close();
+    }
+  });
+});

--- a/src/serve/http/live-reload/sim-live-reload.ts
+++ b/src/serve/http/live-reload/sim-live-reload.ts
@@ -1,0 +1,103 @@
+import { randomUUID } from "node:crypto";
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { SimLiveReloadClient } from "./sim-live-reload-client.js";
+import { SimLiveReloadInjector } from "./sim-live-reload-injector.js";
+import { simLiveReloadConfig } from "./sim-live-reload.config.js";
+
+interface SimLiveReloadProperties {
+  readonly bootId?: string;
+}
+
+/**
+ * Reloads a browser looking at a page the simulator served.
+ *
+ * Yulin is the only thing in the response path for a page served from a
+ * simulated distribution, Function URL or Bucket website, so it is the only
+ * thing that can tell the browser to reload. Pages get a script, the script
+ * holds a connection open, and this is the end that decides what to say on it.
+ *
+ * The boot id is what makes a restart work. It identifies this process to the
+ * pages connected to it, and a page that reconnects to a different one knows
+ * it is looking at output from a process that is no longer running.
+ */
+export class SimLiveReload {
+  private readonly bootId: string;
+  private readonly clients = new Set<SimLiveReloadClient>();
+  private readonly injector = new SimLiveReloadInjector();
+
+  constructor(properties: SimLiveReloadProperties = {}) {
+    const { bootId = randomUUID() } = properties;
+    this.bootId = bootId;
+  }
+
+  /**
+   * Whether this request is for the reload channel rather than for a simulated
+   * service. The path is reserved on every served hostname, so a page can ask
+   * for it relative to wherever it was served from.
+   */
+  isChannelRequest(request: IncomingMessage): boolean {
+    if (request.method !== "GET") {
+      return false;
+    }
+
+    const path = new URL(
+      request.url ?? "/",
+      "http://sim-aws.invalid",
+    ).pathname.replace(/\/$/, "");
+
+    return path === simLiveReloadConfig.channelPath;
+  }
+
+  /**
+   * Open the reload channel for a browser, and tell it which process it has
+   * reached.
+   */
+  connect(response: ServerResponse): void {
+    const client = new SimLiveReloadClient(response);
+
+    this.clients.add(client);
+    client.onClose(() => {
+      this.clients.delete(client);
+    });
+
+    client.open();
+    client.send("boot", this.bootId);
+  }
+
+  /**
+   * Put the reload script into a response, if that response can take it.
+   */
+  async injectInto(request: Request, response: Response): Promise<Response> {
+    return this.injector.injectInto(request, response);
+  }
+
+  /**
+   * Reload every connected browser now.
+   */
+  reload(): void {
+    this.send("reload");
+  }
+
+  /**
+   * Say a reload is coming, then let the connections go.
+   *
+   * The page learns that the gap it is about to see is a restart rather than a
+   * server that has died. Ending the connections rather than leaving them for
+   * the browser to notice is what makes the reconnection prompt.
+   */
+  stopping(): void {
+    this.send("reloading");
+
+    for (const client of this.clients) {
+      client.end();
+    }
+
+    this.clients.clear();
+  }
+
+  private send(event: string): void {
+    for (const client of this.clients) {
+      client.send(event, this.bootId);
+    }
+  }
+}

--- a/src/serve/http/local-server/sim-aws-local-request-handler.ts
+++ b/src/serve/http/local-server/sim-aws-local-request-handler.ts
@@ -1,6 +1,12 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { NodeFetchHttpAdapter } from "../node-fetch-http-adapter.js";
 import type { SimAwsHttp } from "../sim-aws-http.js";
+import type { SimLiveReload } from "../live-reload/sim-live-reload.js";
+
+interface SimAwsLocalRequestHandlerProperties {
+  readonly simAwsHttp: SimAwsHttp;
+  readonly liveReload?: SimLiveReload;
+}
 
 /**
  * Bridges Node's HTTP server callbacks to the Fetch-shaped simulated AWS HTTP
@@ -9,13 +15,21 @@ import type { SimAwsHttp } from "../sim-aws-http.js";
  * Node hands over a request and a response object and expects nothing back,
  * while `SimAwsHttp` takes a `Request` and returns a `Response`. Keeping that
  * adaptation here leaves the local server owning only the socket lifecycle.
+ *
+ * Live reload sits either side of `SimAwsHttp` rather than inside it. That
+ * interface is also the SDK interception path and the in-process test path, so
+ * keeping the reload channel and the injected script out here means only a real
+ * browser talking to the local server ever sees either of them.
  */
 export class SimAwsLocalRequestHandler {
   private readonly simAwsHttp: SimAwsHttp;
+  private readonly liveReload: SimLiveReload | undefined;
   private readonly nodeFetchHttpAdapter = new NodeFetchHttpAdapter();
 
-  constructor(simAwsHttp: SimAwsHttp) {
+  constructor(properties: SimAwsLocalRequestHandlerProperties) {
+    const { simAwsHttp, liveReload } = properties;
     this.simAwsHttp = simAwsHttp;
+    this.liveReload = liveReload;
   }
 
   /**
@@ -23,6 +37,11 @@ export class SimAwsLocalRequestHandler {
    * than letting it escape into an unhandled rejection.
    */
   handle(nodeRequest: IncomingMessage, nodeResponse: ServerResponse): void {
+    if (this.liveReload?.isChannelRequest(nodeRequest) === true) {
+      this.liveReload.connect(nodeResponse);
+      return;
+    }
+
     // eslint-disable-next-line unicorn/prefer-await
     this.respond(nodeRequest, nodeResponse).catch((error: unknown) => {
       this.respondWithError(error, nodeResponse);
@@ -37,7 +56,21 @@ export class SimAwsLocalRequestHandler {
       this.nodeFetchHttpAdapter.nodeRequestToFetchRequest(nodeRequest);
     const response = await this.simAwsHttp.handleRequest(request);
 
-    await this.nodeFetchHttpAdapter.sendFetchResponse(nodeResponse, response);
+    await this.nodeFetchHttpAdapter.sendFetchResponse(
+      nodeResponse,
+      await this.served(request, response),
+    );
+  }
+
+  private async served(
+    request: Request,
+    response: Response,
+  ): Promise<Response> {
+    if (this.liveReload === undefined) {
+      return response;
+    }
+
+    return this.liveReload.injectInto(request, response);
   }
 
   private respondWithError(error: unknown, nodeResponse: ServerResponse): void {

--- a/src/serve/http/local-server/sim-aws-local-server.ts
+++ b/src/serve/http/local-server/sim-aws-local-server.ts
@@ -6,9 +6,12 @@ import { SimAwsLocalUrl } from "../url/sim-aws-local-url.js";
 import { NodeServerPortBinder } from "./node-server-port-binder.js";
 import { SimAwsLocalRequestHandler } from "./sim-aws-local-request-handler.js";
 import { SimAwsDnsServer } from "../../dns/sim-aws-dns-server.js";
+import { SimLiveReload } from "../live-reload/sim-live-reload.js";
+import { SimLiveReloadReport } from "../live-reload/sim-live-reload-report.js";
 
 interface SimAwsLocalServerProperties {
   readonly simAws?: SimAws;
+  readonly liveReload?: boolean;
 }
 
 /**
@@ -20,12 +23,15 @@ export class SimAwsLocalServer {
   private readonly server: Server;
   private readonly portBinder: NodeServerPortBinder;
   private readonly dnsServer: SimAwsDnsServer;
+  private readonly liveReload: SimLiveReload | undefined;
 
   constructor(properties: SimAwsLocalServerProperties = {}) {
-    const { simAws = new SimAws() } = properties;
-    this.requestHandler = new SimAwsLocalRequestHandler(
-      new SimAwsHttp({ simAws }),
-    );
+    const { simAws = new SimAws(), liveReload = false } = properties;
+    this.liveReload = liveReload ? new SimLiveReload() : undefined;
+    this.requestHandler = new SimAwsLocalRequestHandler({
+      simAwsHttp: new SimAwsHttp({ simAws }),
+      ...(this.liveReload !== undefined && { liveReload: this.liveReload }),
+    });
     this.dnsServer = new SimAwsDnsServer({ simAws });
     this.server = http.createServer((request, response) => {
       this.requestHandler.handle(request, response);
@@ -53,6 +59,11 @@ export class SimAwsLocalServer {
   async listen(port: number = simAwsLocalConfig.defaultPort): Promise<this> {
     await this.portBinder.bind(port);
     await this.dnsServer.listen(Number(this.port));
+
+    if (this.liveReload !== undefined) {
+      new SimLiveReloadReport().announce(this.port);
+    }
+
     return this;
   }
 
@@ -103,9 +114,27 @@ export class SimAwsLocalServer {
    * the open ones are being ended.
    */
   close(): void {
+    this.liveReload?.stopping();
     this.server.close();
     this.server.closeAllConnections();
     this.dnsServer.close();
+  }
+
+  /**
+   * Reload every browser connected to this server.
+   *
+   * For a change that needs no restart, such as new content in a simulated
+   * Bucket. A change to the code that built the environment needs the process
+   * to restart, and the pages reload themselves when it comes back.
+   */
+  reload(): void {
+    if (this.liveReload === undefined) {
+      throw new Error(
+        "Live reload is off for this server, serve with { liveReload: true } to use reload()",
+      );
+    }
+
+    this.liveReload.reload();
   }
 
   /**
@@ -120,6 +149,7 @@ export class SimAwsLocalServer {
 interface ServeSimAwsProperties {
   readonly simAws?: SimAws;
   readonly port?: number;
+  readonly liveReload?: boolean;
 }
 
 /**
@@ -128,8 +158,11 @@ interface ServeSimAwsProperties {
 export async function serveSimAws(
   properties: ServeSimAwsProperties = {},
 ): Promise<SimAwsLocalServer> {
-  const { simAws = new SimAws(), port = simAwsLocalConfig.defaultPort } =
-    properties;
-  const server = new SimAwsLocalServer({ simAws });
+  const {
+    simAws = new SimAws(),
+    port = simAwsLocalConfig.defaultPort,
+    liveReload = false,
+  } = properties;
+  const server = new SimAwsLocalServer({ simAws, liveReload });
   return server.listen(port);
 }

--- a/src/serve/index.ts
+++ b/src/serve/index.ts
@@ -6,6 +6,11 @@ export {
   SimAwsLocalServer,
 } from "./http/local-server/sim-aws-local-server.js";
 export { SimAwsLocalPortInUse } from "./http/local-server/sim-aws-local-port.error.js";
+export { SimLiveReload } from "./http/live-reload/sim-live-reload.js";
+export {
+  simLiveReloadConfig,
+  simLiveReloadHeaderName,
+} from "./http/live-reload/sim-live-reload.config.js";
 export {
   type SimAwsServiceController,
   SimAwsServiceRequest,

--- a/test/serve/live-reload-channel.ts
+++ b/test/serve/live-reload-channel.ts
@@ -1,0 +1,110 @@
+import { assertNonNullable } from "@kensio/smartass";
+import { simLiveReloadConfig } from "../../src/serve/http/live-reload/sim-live-reload.config.js";
+import type { SimAwsLocalServer } from "../../src/serve/http/local-server/sim-aws-local-server.js";
+
+/**
+ * One named event read off the live reload channel.
+ */
+export interface SimLiveReloadEvent {
+  readonly event: string;
+  readonly data: string;
+}
+
+/**
+ * Reads the live reload channel the way the injected script does, without a
+ * browser. Node has no `EventSource`, and the wire format is small enough that
+ * reading it directly says more about what the server sent than a client
+ * library would.
+ */
+export class SimLiveReloadChannel {
+  private readonly abort: AbortController;
+  private readonly reader: ReadableStreamDefaultReader<Uint8Array>;
+  private readonly decoder = new TextDecoder();
+  private buffered = "";
+
+  private constructor(
+    abort: AbortController,
+    reader: ReadableStreamDefaultReader<Uint8Array>,
+  ) {
+    this.abort = abort;
+    this.reader = reader;
+  }
+
+  /**
+   * Connect to the channel a local server is serving.
+   */
+  static async open(server: SimAwsLocalServer): Promise<SimLiveReloadChannel> {
+    const abort = new AbortController();
+    const response = await fetch(
+      `http://${server.hostname}:${server.port}${simLiveReloadConfig.channelPath}`,
+      { signal: abort.signal },
+    );
+
+    assertNonNullable(response.body);
+
+    return new SimLiveReloadChannel(abort, response.body.getReader());
+  }
+
+  /**
+   * Read the next named event, passing over the stream's own bookkeeping lines.
+   */
+  async nextEvent(): Promise<SimLiveReloadEvent> {
+    const event = parseEvent(await this.nextBlock());
+
+    if (event === undefined) {
+      return this.nextEvent();
+    }
+
+    return event;
+  }
+
+  /**
+   * Stop reading and let the connection go.
+   */
+  close(): void {
+    this.abort.abort();
+  }
+
+  private async nextBlock(): Promise<string> {
+    const end = this.buffered.indexOf("\n\n");
+
+    if (end !== -1) {
+      const block = this.buffered.slice(0, end);
+      this.buffered = this.buffered.slice(end + 2);
+
+      return block;
+    }
+
+    const { value, done } = await this.reader.read();
+
+    if (done) {
+      throw new Error("Live reload channel ended before the expected event");
+    }
+
+    this.buffered += this.decoder.decode(value, { stream: true });
+
+    return this.nextBlock();
+  }
+}
+
+function parseEvent(block: string): SimLiveReloadEvent | undefined {
+  const lines = block.split("\n");
+  const event = fieldValue(lines, "event");
+
+  if (event === undefined) {
+    return undefined;
+  }
+
+  return { event, data: fieldValue(lines, "data") ?? "" };
+}
+
+function fieldValue(lines: string[], field: string): string | undefined {
+  const prefix = `${field}: `;
+  const line = lines.find((candidate) => candidate.startsWith(prefix));
+
+  if (line === undefined) {
+    return undefined;
+  }
+
+  return line.slice(prefix.length);
+}

--- a/test/serve/served-site.ts
+++ b/test/serve/served-site.ts
@@ -1,0 +1,105 @@
+import {
+  CreateAccessKeyCommand,
+  CreateUserCommand,
+  PutUserPolicyCommand,
+} from "@aws-sdk/client-iam";
+import {
+  CreateBucketCommand,
+  PutBucketWebsiteCommand,
+  PutObjectCommand,
+  S3Client,
+} from "@aws-sdk/client-s3";
+
+import type { SimAws } from "../../src/service/aws/sim-aws.js";
+import type { SimAwsLocalServer } from "../../src/serve/http/local-server/sim-aws-local-server.js";
+import { grantPublicWebsiteRead } from "../../src/service/s3/bucket/website/sim-s3-public-website.fixture.js";
+
+/**
+ * A Bucket website holding one HTML page, which is the smallest thing a browser
+ * can be pointed at through the local server.
+ */
+export async function simServedSite(
+  simAws: SimAws,
+  bucketName: string,
+  html: string,
+): Promise<void> {
+  const simS3 = simAws.s3();
+
+  await simS3.createBucket(new CreateBucketCommand({ Bucket: bucketName }));
+  await simS3.putObject(
+    new PutObjectCommand({
+      Bucket: bucketName,
+      Key: "index.html",
+      Body: html,
+      ContentType: "text/html; charset=utf-8",
+    }),
+  );
+  await simS3.putBucketWebsite(
+    new PutBucketWebsiteCommand({
+      Bucket: bucketName,
+      WebsiteConfiguration: { IndexDocument: { Suffix: "index.html" } },
+    }),
+  );
+  await grantPublicWebsiteRead(simS3, bucketName);
+}
+
+/**
+ * The local URL of a served Bucket website page.
+ */
+export function simServedSiteUrl(
+  simAws: SimAws,
+  server: SimAwsLocalServer,
+  bucketName: string,
+): URL {
+  return server.localUrl(simAws.s3().getBucketWebsiteUrl(bucketName));
+}
+
+/**
+ * Ask for a page the way a browser asks for one.
+ */
+export async function simBrowserFetch(url: URL | string): Promise<Response> {
+  return fetch(url, {
+    headers: { accept: "text/html,application/xhtml+xml,*/*;q=0.8" },
+  });
+}
+
+/**
+ * A real S3 client signing for the local server, for the other kind of caller a
+ * served environment gets: an SDK reading the same Object as an Object.
+ */
+export async function simServedSiteS3Client(
+  simAws: SimAws,
+  server: SimAwsLocalServer,
+  bucketName: string,
+): Promise<S3Client> {
+  const simIam = simAws.iam();
+
+  await simIam.createUser(new CreateUserCommand({ UserName: "SiteReader" }));
+  await simIam.putUserPolicy(
+    new PutUserPolicyCommand({
+      UserName: "SiteReader",
+      PolicyName: "ReadSiteObjects",
+      PolicyDocument: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: {
+          Effect: "Allow",
+          Action: "s3:GetObject",
+          Resource: `arn:aws:s3:::${bucketName}/*`,
+        },
+      }),
+    }),
+  );
+  const accessKey = await simIam.createAccessKey(
+    new CreateAccessKeyCommand({ UserName: "SiteReader" }),
+  );
+
+  return new S3Client({
+    region: simAws.defaultRegionName,
+    endpoint: server.localUrl(simAws.s3().getServiceUrl()).toString(),
+    requestChecksumCalculation: "WHEN_REQUIRED",
+    credentials: {
+      accessKeyId: accessKey.AccessKey.AccessKeyId,
+      secretAccessKey: accessKey.AccessKey.SecretAccessKey,
+    },
+  });
+}


### PR DESCRIPTION
Opt in with serveSimAws({ liveReload: true }). The local server serves an SSE reload channel on a reserved path and injects a small script into HTML responses to browser requests. A page reloads when it reconnects to a different boot id, so a process restart reaches it with nothing shared between the outgoing and incoming process, and reload() covers a change that needs no restart.

Injection is off by default, reported on startup and in a response header, and never applied to a response an SDK client will parse.

Resolves https://github.com/KensioSoftware/yulin/issues/417

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for serving simulated AWS environments on localhost.
  * Added optional browser live reload for HTML pages, including automatic reloads after server restarts and manual reload triggers.
  * Added local URL conversion and server lifecycle support, including graceful shutdown.
* **Documentation**
  * Added comprehensive serving and live-reload documentation with practical TypeScript examples.
* **Tests**
  * Added extensive coverage for local serving, live-reload behavior, browser integration, response handling, and shutdown scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->