### PR TITLE
feat: restart a dev process when project files change

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,9 +220,19 @@ const srv = await serveSimAws({ simAws, port: 4599, liveReload: true });
 ```
 
 `srv.reload()` reloads connected browsers for a change that needs no restart. Live reload is off by
-default, since an injected page is not byte for byte what the real service returns. See the
-[serving docs](./docs/serve "Serving simulated AWS on localhost docs") for what gets the script and
-what does not.
+default, since an injected page is not byte for byte what the real service returns.
+
+Run the dev script through `yulin watch` and a save is the whole loop, with the process restarted and
+the page refreshed:
+
+```bash
+yulin watch -- tsx dev.ts
+```
+
+It watches the working directory, plus the paths Yulin is holding that a module graph never mentions:
+a directory mounted into a Bucket, and a synthesized template. See the
+[serving docs](./docs/serve "Serving simulated AWS on localhost docs") for what gets the script, what
+is watched, and what is not.
 
 ### Control simulated time
 

--- a/docs/serve/README.md
+++ b/docs/serve/README.md
@@ -191,6 +191,67 @@ The reload channel is served at `/__sim-aws/live-reload` on every hostname the s
 a page can ask for it relative to wherever it was served from. While live reload is on, no simulated
 service can serve anything at that path.
 
+## Restarting on a file change
+
+Live reload gets a page back on its feet after the process restarts. `yulin watch` is what restarts
+it. Run the dev script through it and a save is the whole loop:
+
+```bash
+yulin watch -- tsx dev.ts
+```
+
+Everything after `--` is the command, run as written and restarted when something changes. The CLI
+does not import it, does not look for an exported setup function, and does not care whether the
+simulation was built from SDK commands, a CloudFormation template, or several `SimAws` instances at
+once. The only change to a dev script is turning `liveReload` on.
+
+A restart, rather than swapping code in place, is the deliberate choice. A Lambda handler is a
+function reference out of your own module graph, and a new process re-imports it with no module cache
+to defeat. It also keeps simulated state the same as what a fresh test run sees, since seeding is
+part of the setup script and runs again.
+
+### What is watched
+
+The working directory, minus what nothing edits by hand: `node_modules`, `.git`, `dist`, `coverage`,
+CDK asset directories, and the working files an editor writes around a save.
+
+On top of that, Yulin names paths it is holding that the module graph never mentions. A directory
+given to `mountBucketFilesystem` and a template given to `deployTemplateFile` are reported to the
+supervisor as they are registered, and watched from then on, without appearing in any list. Editing
+a file in a mounted directory or re-synthing a stack restarts the process.
+
+A burst of writes is one restart. Saving one file is several filesystem events, so changes are held
+until they stop arriving before anything is restarted.
+
+### When a run goes wrong
+
+A setup script that throws leaves the watcher up. The error is on the terminal and the next save is
+the retry, with no watch to start over.
+
+Setup that writes into a watched path restarts the process, which writes again, which restarts it.
+That is refused rather than run: after a few restarts caused by the same file changing straight after
+startup, `yulin watch` stops and names the file. Write generated files outside the working directory,
+or into a directory the watch passes over.
+
+### Debugging
+
+A process started by `yulin watch` can be debugged, but the debugger has to attach to that process
+rather than to the supervisor, which does nothing worth stepping through. Pass an inspector flag to
+the watch and it reaches each run through `NODE_OPTIONS`, so it works whether the command is `node`
+or something that spawns it:
+
+```bash
+yulin watch --inspect=9230 -- tsx dev.ts
+```
+
+Each run binds the same inspector port, because the process it replaces has fully exited by the time
+the replacement starts. Attaching to that port with reconnect turned on in your IDE keeps a debugger
+across restarts. The exact run configuration differs between IDEs and is not documented here yet.
+
+Nothing about live reload needs the supervisor. A dev script launched straight from an IDE debugger
+still gets browser reload and still picks up a re-synthed template, and a handler edit is a manual
+restart as it is without watch mode.
+
 ## Limitations
 
 - An injected page is not byte for byte what the real service would return, and its `cache-control`
@@ -200,6 +261,12 @@ service can serve anything at that path.
 - Injection decodes the HTML as UTF-8. A page stored in another encoding would be corrupted, so
   serve HTML as UTF-8.
 - An open reload connection uses one of the browser's six connections per origin per tab.
-- Nothing is watched. Yulin reloads when the process restarts or when `reload()` is called, and
-  choosing what to watch is left to whatever runs the dev script.
 - There is no overlay for a reload that failed. The terminal has the error.
+- `yulin watch` does not re-synth CDK. `cdk watch` is a shortcut for `deploy --watch` against real
+  AWS and there is no synth-only watch, so run your own synth and let the watch pick up its output.
+- Lambda and CloudFront Function code is not swapped without a restart. A fresh process picks up an
+  edited handler correctly, and an in-process swap would have to invalidate an ESM import subgraph
+  that the language does not expose.
+- Simulated state is not carried across a restart. Seeding belongs in the setup script, so it runs
+  again and local state stays the same as what tests and CI see.
+- The IDE run configurations for attaching a debugger to a watched process are not documented yet.

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "bin": {
+    "yulin": "./dist/cli/yulin.js"
+  },
   "scripts": {
     "clean": "rm -rf ./dist/ ./*.tsbuildinfo",
     "build": "pnpm clean && tsc -p tsconfig.build.json",

--- a/src/cli/sim-cli.iso.test.ts
+++ b/src/cli/sim-cli.iso.test.ts
@@ -1,0 +1,71 @@
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it, vi } from "vitest";
+import { SimCli, SimCliUnknownCommand } from "./sim-cli.js";
+
+describe("SimCli", () => {
+  it("shows what it can do when asked", () => {
+    // Given the CLI run with no command
+    const written = captureStdout();
+
+    // When it is asked for help
+    void new SimCli().run(["--help"]);
+
+    // Then the commands are listed
+    assertStringIncludes(written.join(""), "watch [--inspect");
+  });
+
+  it("reports a run with no command as a mistake", async () => {
+    // Given the CLI run with nothing to do
+    captureStdout();
+
+    // When it runs
+    const exitCode = await new SimCli().run([]);
+
+    // Then it says so through its exit code, since a shell may be reading it
+    assertIdentical(exitCode, 1);
+  });
+
+  it("hands a watch over to the watch command", async () => {
+    // Given a watch with no command after the separator
+    const cli = new SimCli();
+
+    // When it is run
+    const error = await assertThrowsErrorAsync(async () => {
+      await cli.run(["watch"]);
+    });
+
+    // Then it is the watch command that read it, and said how to write it
+    assertStringIncludes(error.message, "Usage: yulin watch");
+  });
+
+  it("refuses a command it does not have", async () => {
+    // Given a command that does not exist
+    const cli = new SimCli();
+
+    // When it is run
+    const error = await assertThrowsErrorAsync(async () => {
+      await cli.run(["serve"]);
+    });
+
+    // Then it names the command and says what there is instead
+    assertInstanceOf(error, SimCliUnknownCommand);
+    assertStringIncludes(error.message, "Unknown command serve.");
+    assertStringIncludes(error.message, "watch [--inspect");
+  });
+});
+
+function captureStdout(): string[] {
+  const written: string[] = [];
+
+  vi.spyOn(process.stdout, "write").mockImplementation((chunk): boolean => {
+    written.push(String(chunk));
+    return true;
+  });
+
+  return written;
+}

--- a/src/cli/sim-cli.ts
+++ b/src/cli/sim-cli.ts
@@ -1,0 +1,49 @@
+import { SimWatchCommand } from "./watch/sim-watch-command.js";
+
+const usage = `Usage: yulin <command>
+
+Commands:
+  watch [--inspect[=port]] -- <command>   Run a command, and run it again when project files change
+`;
+
+/**
+ * Thrown for a command the CLI does not have.
+ */
+export class SimCliUnknownCommand extends Error {
+  public override readonly name = "SimCliUnknownCommand";
+
+  constructor(command: string) {
+    super(`Unknown command ${command}.\n\n${usage}`);
+  }
+}
+
+/**
+ * The `yulin` command line.
+ *
+ * One command so far. It exists because a local dev loop needs a process
+ * outside the one being restarted, which is not something a library can be.
+ */
+export class SimCli {
+  /**
+   * Run the CLI, and report the exit code it should leave behind.
+   */
+  async run(argv: readonly string[]): Promise<number> {
+    const [command, ...rest] = argv;
+
+    if (command === undefined) {
+      process.stdout.write(usage);
+      return 1;
+    }
+
+    if (["--help", "-h", "help"].includes(command)) {
+      process.stdout.write(usage);
+      return 0;
+    }
+
+    if (command !== "watch") {
+      throw new SimCliUnknownCommand(command);
+    }
+
+    return await new SimWatchCommand().run(rest);
+  }
+}

--- a/src/cli/watch/sim-watch-arguments.iso.test.ts
+++ b/src/cli/watch/sim-watch-arguments.iso.test.ts
@@ -1,0 +1,88 @@
+import {
+  assertArrayEquals,
+  assertIdentical,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsError,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import {
+  SimWatchArguments,
+  SimWatchUsageError,
+} from "./sim-watch-arguments.js";
+
+describe("SimWatchArguments", () => {
+  it("takes everything after the separator as the command", () => {
+    // Given a command with options of its own
+    const argv = ["--", "tsx", "dev.ts", "--seed", "small"];
+
+    // When the arguments are read
+    const parsed = SimWatchArguments.parse(argv);
+
+    // Then the command keeps its own options, unread by watch
+    assertIdentical(parsed.command, "tsx");
+    assertArrayEquals(parsed.commandArguments, ["dev.ts", "--seed", "small"]);
+    assertUndefined(parsed.inspect);
+  });
+
+  it("passes an inspector flag through", () => {
+    // Given a run that wants a debugger attached
+    const argv = ["--inspect=9230", "--", "tsx", "dev.ts"];
+
+    // When the arguments are read
+    const parsed = SimWatchArguments.parse(argv);
+
+    // Then the flag is kept for the process being run, not for the supervisor
+    assertIdentical(parsed.inspect, "--inspect=9230");
+    assertIdentical(parsed.command, "tsx");
+  });
+
+  it("refuses a run with no separator", () => {
+    // Given a command written without the separator
+    const argv = ["tsx", "dev.ts"];
+
+    // When the arguments are read
+    const error = assertThrowsError(() => SimWatchArguments.parse(argv));
+
+    // Then it says where the command goes and why
+    assertInstanceOf(error, SimWatchUsageError);
+    assertStringIncludes(error.message, "after --");
+    assertStringIncludes(error.message, "Usage: yulin watch");
+  });
+
+  it("refuses a separator with nothing after it", () => {
+    // Given a separator and no command
+    const argv = ["--inspect", "--"];
+
+    // When the arguments are read
+    const error = assertThrowsError(() => SimWatchArguments.parse(argv));
+
+    // Then it says there is nothing to run
+    assertInstanceOf(error, SimWatchUsageError);
+    assertStringIncludes(error.message, "No command given after --.");
+  });
+
+  it("refuses an option it does not have", () => {
+    // Given an option meant for the command, written before the separator
+    const argv = ["--seed", "--", "tsx", "dev.ts"];
+
+    // When the arguments are read
+    const error = assertThrowsError(() => SimWatchArguments.parse(argv));
+
+    // Then it names the option rather than passing it on
+    assertInstanceOf(error, SimWatchUsageError);
+    assertStringIncludes(error.message, "Unknown option --seed.");
+  });
+
+  it("describes the command it was given", () => {
+    // Given a parsed command
+    const parsed = SimWatchArguments.parse(["--", "node", "dev.js", "--quiet"]);
+
+    // When it is described for the terminal
+    const described = parsed.describe();
+
+    // Then it reads as it was written
+    assertIdentical(described, "node dev.js --quiet");
+  });
+});

--- a/src/cli/watch/sim-watch-arguments.ts
+++ b/src/cli/watch/sim-watch-arguments.ts
@@ -1,0 +1,91 @@
+const inspectorFlags = new Set([
+  "--inspect",
+  "--inspect-brk",
+  "--inspect-wait",
+]);
+
+/**
+ * Thrown when `yulin watch` was not given something to run.
+ */
+export class SimWatchUsageError extends Error {
+  public override readonly name = "SimWatchUsageError";
+
+  constructor(message: string) {
+    super(`${message}\n\nUsage: yulin watch [--inspect[=port]] -- <command>`);
+  }
+}
+
+/**
+ * What `yulin watch` was asked to do.
+ *
+ * Everything after `--` is the command, passed through untouched. The CLI does
+ * not import the command, look for an exported setup function, or care whether
+ * the simulation it builds came from SDK commands, a template, or several
+ * `SimAws` instances at once. It runs it and runs it again.
+ */
+export class SimWatchArguments {
+  readonly command: string;
+  readonly commandArguments: readonly string[];
+  readonly inspect: string | undefined;
+
+  private constructor(
+    command: string,
+    commandArguments: readonly string[],
+    inspect: string | undefined,
+  ) {
+    this.command = command;
+    this.commandArguments = commandArguments;
+    this.inspect = inspect;
+  }
+
+  /**
+   * Read the arguments given after `yulin watch`.
+   */
+  static parse(argv: readonly string[]): SimWatchArguments {
+    const separator = argv.indexOf("--");
+
+    if (separator === -1) {
+      throw new SimWatchUsageError(
+        "No command given. Put the command to run after --, so that its own options are not read as options to watch.",
+      );
+    }
+
+    const [command, ...rest] = argv.slice(separator + 1);
+
+    if (command === undefined) {
+      throw new SimWatchUsageError("No command given after --.");
+    }
+
+    return new SimWatchArguments(
+      command,
+      rest,
+      inspectorFlag(argv.slice(0, separator)),
+    );
+  }
+
+  /**
+   * The command as it was written, for reporting.
+   */
+  describe(): string {
+    return [this.command, ...this.commandArguments].join(" ");
+  }
+}
+
+/**
+ * The inspector flag to pass through to each run, if one was asked for.
+ */
+function inspectorFlag(options: readonly string[]): string | undefined {
+  const unknown = options.find((option) => !isInspectorFlag(option));
+
+  if (unknown !== undefined) {
+    throw new SimWatchUsageError(`Unknown option ${unknown}.`);
+  }
+
+  return options.at(-1);
+}
+
+function isInspectorFlag(option: string): boolean {
+  const [flag = ""] = option.split("=");
+
+  return inspectorFlags.has(flag);
+}

--- a/src/cli/watch/sim-watch-child-environment.iso.test.ts
+++ b/src/cli/watch/sim-watch-child-environment.iso.test.ts
@@ -1,0 +1,90 @@
+import path from "node:path";
+import {
+  assertIdentical,
+  assertStringIncludes,
+  assertStringStartsWith,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimWatchChildEnvironment } from "./sim-watch-child-environment.js";
+import { simWatchConfig } from "../../watch/sim-watch.config.js";
+
+const cwd = path.resolve("/projects/media");
+
+describe("SimWatchChildEnvironment", () => {
+  it("puts the project's own binaries on the path", () => {
+    // Given a supervisor started from a shell, with no project bin on PATH
+    const environment = new SimWatchChildEnvironment({
+      cwd,
+      environment: { PATH: "/usr/bin" },
+    });
+
+    // When the environment for a run is built
+    const built = environment.build();
+
+    // Then a command such as tsx resolves from the project it is running in
+    assertStringStartsWith(
+      built["PATH"] ?? "",
+      path.join(cwd, "node_modules", ".bin"),
+    );
+    assertStringIncludes(built["PATH"] ?? "", "/usr/bin");
+  });
+
+  it("leaves a path that already has the project's binaries alone", () => {
+    // Given a run through a package script, which has already done this
+    const localBin = path.join(cwd, "node_modules", ".bin");
+    const environment = new SimWatchChildEnvironment({
+      cwd,
+      environment: { PATH: `${localBin}${path.delimiter}/usr/bin` },
+    });
+
+    // When the environment for a run is built
+    const built = environment.build();
+
+    // Then the same directory is not added twice
+    assertIdentical(built["PATH"], `${localBin}${path.delimiter}/usr/bin`);
+  });
+
+  it("marks the process as supervised", () => {
+    // Given any run
+    const environment = new SimWatchChildEnvironment({ cwd, environment: {} });
+
+    // When the environment for it is built
+    const built = environment.build();
+
+    // Then the runtime in the process knows there is a supervisor to talk to
+    assertIdentical(
+      built[simWatchConfig.environmentVariableName],
+      simWatchConfig.environmentVariableValue,
+    );
+  });
+
+  it("passes an inspector flag through the node options", () => {
+    // Given a run that wants a debugger, of a command that is not node
+    const environment = new SimWatchChildEnvironment({
+      cwd,
+      inspect: "--inspect=9230",
+      environment: { ["NODE_OPTIONS"]: "--enable-source-maps" },
+    });
+
+    // When the environment for it is built
+    const built = environment.build();
+
+    // Then the flag reaches node whatever the command turns out to be
+    assertIdentical(
+      built["NODE_OPTIONS"],
+      "--enable-source-maps --inspect=9230",
+    );
+  });
+
+  it("leaves node options alone when no debugger was asked for", () => {
+    // Given an ordinary run
+    const environment = new SimWatchChildEnvironment({ cwd, environment: {} });
+
+    // When the environment for it is built
+    const built = environment.build();
+
+    // Then nothing is added for a debugger nobody wanted
+    assertUndefined(built["NODE_OPTIONS"]);
+  });
+});

--- a/src/cli/watch/sim-watch-child-environment.ts
+++ b/src/cli/watch/sim-watch-child-environment.ts
@@ -1,0 +1,66 @@
+import path from "node:path";
+import { simWatchConfig } from "../../watch/sim-watch.config.js";
+
+const nodeOptionsName = "NODE_OPTIONS";
+
+interface SimWatchChildEnvironmentProperties {
+  readonly cwd: string;
+  readonly inspect?: string | undefined;
+  readonly environment?: NodeJS.ProcessEnv;
+}
+
+/**
+ * The environment a supervised process runs in.
+ *
+ * Three things are added to the environment the supervisor was given. The
+ * project's own `node_modules/.bin` goes on `PATH`, so `yulin watch -- tsx
+ * dev.ts` works from a plain shell as well as from a package script. A marker
+ * says a supervisor is listening, which is what makes the runtime in the child
+ * report paths at all. An inspector flag goes through `NODE_OPTIONS` rather
+ * than on the command line, because the command being run is often not `node`
+ * itself.
+ */
+export class SimWatchChildEnvironment {
+  private readonly cwd: string;
+  private readonly inspect: string | undefined;
+  private readonly environment: NodeJS.ProcessEnv;
+
+  constructor(properties: SimWatchChildEnvironmentProperties) {
+    const { cwd, inspect, environment = process.env } = properties;
+    this.cwd = cwd;
+    this.inspect = inspect;
+    this.environment = environment;
+  }
+
+  /**
+   * Build the environment for one run of the supervised command.
+   */
+  build(): NodeJS.ProcessEnv {
+    return {
+      ...this.environment,
+      PATH: this.pathWithLocalBin(),
+      [simWatchConfig.environmentVariableName]:
+        simWatchConfig.environmentVariableValue,
+      ...(this.inspect !== undefined && {
+        [nodeOptionsName]: this.nodeOptionsWithInspector(this.inspect),
+      }),
+    };
+  }
+
+  private pathWithLocalBin(): string {
+    const localBin = path.join(this.cwd, "node_modules", ".bin");
+    const existing = this.environment["PATH"] ?? "";
+
+    if (existing.split(path.delimiter).includes(localBin)) {
+      return existing;
+    }
+
+    return `${localBin}${path.delimiter}${existing}`;
+  }
+
+  private nodeOptionsWithInspector(inspect: string): string {
+    const existing = this.environment["NODE_OPTIONS"] ?? "";
+
+    return `${existing} ${inspect}`.trim();
+  }
+}

--- a/src/cli/watch/sim-watch-child-message.iso.test.ts
+++ b/src/cli/watch/sim-watch-child-message.iso.test.ts
@@ -1,0 +1,93 @@
+import { EventEmitter } from "node:events";
+import type { ChildProcess } from "node:child_process";
+import { assertFalse, assertTrue } from "@kensio/smartass";
+import { describe, it } from "vitest";
+import {
+  isWatchPathMessage,
+  waitWatchMessage,
+} from "./sim-watch-child-message.js";
+
+describe("watch child messages", () => {
+  it("recognises a message naming a path", () => {
+    // Given a message from a supervised process
+    const message = { type: "yulin:watch-path", path: "/projects/assets" };
+
+    // When it is read
+    const isPath = isWatchPathMessage(message, "yulin:watch-path");
+
+    // Then the path is there to be watched
+    assertTrue(isPath);
+  });
+
+  it.each([
+    [{ type: "yulin:watch-path" }],
+    [{ type: "yulin:watch-path", path: 7 }],
+    [{ type: "something-else", path: "/projects/assets" }],
+    ["not a message at all"],
+    [null],
+  ])("does not take %s for a path message", (message) => {
+    // Given something that is not a path message
+    // When it is read
+    const isPath = isWatchPathMessage(message, "yulin:watch-path");
+
+    // Then nothing is watched on the strength of it
+    assertFalse(isPath);
+  });
+
+  it("waits for the message it was told to wait for", async () => {
+    // Given a process that is going to answer
+    const childProcess = new FakeChildProcess();
+    const waiting = waitWatchMessage(
+      childProcess.asChildProcess(),
+      "yulin:watch-stopped",
+      5000,
+    );
+
+    // When it answers
+    childProcess.emit("message", { type: "yulin:watch-stopped" });
+    await waiting;
+
+    // Then the wait is over, and nothing is left listening
+    assertFalse(childProcess.listenerCount("message") > 0);
+  });
+
+  it("gives up on a process that never answers", async () => {
+    // Given a process not running Yulin's runtime, which will never answer
+    const childProcess = new FakeChildProcess();
+
+    // When it is waited for
+    await waitWatchMessage(
+      childProcess.asChildProcess(),
+      "yulin:watch-stopped",
+      20,
+    );
+
+    // Then the wait ends anyway, since the answer was never a requirement
+    assertFalse(childProcess.listenerCount("message") > 0);
+  });
+
+  it("keeps waiting through a message of another kind", async () => {
+    // Given a process still reporting paths as it shuts down
+    const childProcess = new FakeChildProcess();
+    const waiting = waitWatchMessage(
+      childProcess.asChildProcess(),
+      "yulin:watch-stopped",
+      5000,
+    );
+
+    // When one of those arrives, and then the answer
+    childProcess.emit("message", { type: "yulin:watch-path", path: "/a" });
+    childProcess.emit("message", { type: "yulin:watch-stopped" });
+    await waiting;
+
+    // Then it was the answer that ended the wait
+    assertFalse(childProcess.listenerCount("message") > 0);
+  });
+});
+
+// eslint-disable-next-line unicorn/prefer-event-target
+class FakeChildProcess extends EventEmitter {
+  asChildProcess(): ChildProcess {
+    return this as unknown as ChildProcess;
+  }
+}

--- a/src/cli/watch/sim-watch-child-message.ts
+++ b/src/cli/watch/sim-watch-child-message.ts
@@ -1,0 +1,59 @@
+import type { ChildProcess } from "node:child_process";
+
+/**
+ * Whether an IPC message is one of the kind named.
+ */
+export function isWatchMessage(message: unknown, type: string): boolean {
+  return (
+    typeof message === "object" &&
+    message !== null &&
+    "type" in message &&
+    message.type === type
+  );
+}
+
+/**
+ * Whether an IPC message names a path to watch.
+ */
+export function isWatchPathMessage(
+  message: unknown,
+  type: string,
+): message is { readonly path: string } {
+  return (
+    isWatchMessage(message, type) &&
+    typeof message === "object" &&
+    message !== null &&
+    "path" in message &&
+    typeof message.path === "string"
+  );
+}
+
+/**
+ * Wait for a process to send a message of one kind, and give up after a while.
+ *
+ * A process not running Yulin's runtime never answers, so this is a short wait
+ * rather than a requirement.
+ */
+export async function waitWatchMessage(
+  childProcess: ChildProcess,
+  type: string,
+  withinMs: number,
+): Promise<void> {
+  await new Promise<void>((resolve) => {
+    const done = (): void => {
+      clearTimeout(timer);
+      childProcess.off("message", onMessage);
+      resolve();
+    };
+
+    const onMessage = (message: unknown): void => {
+      if (isWatchMessage(message, type)) {
+        done();
+      }
+    };
+
+    const timer = setTimeout(done, withinMs);
+
+    childProcess.on("message", onMessage);
+  });
+}

--- a/src/cli/watch/sim-watch-child-process.ts
+++ b/src/cli/watch/sim-watch-child-process.ts
@@ -1,0 +1,44 @@
+import { type ChildProcess, spawn } from "node:child_process";
+
+interface SimWatchChildProcessProperties {
+  readonly command: string;
+  readonly args: readonly string[];
+  readonly cwd: string;
+  readonly env: NodeJS.ProcessEnv;
+}
+
+/**
+ * A spawned command, and the two moments in its life a supervisor waits on.
+ *
+ * Standard input, output and error are the supervisor's own, so the process
+ * being watched prints where it would have printed if it had been started by
+ * hand. The fourth channel is what the runtime inside it reports paths over.
+ */
+export class SimWatchChildProcess {
+  readonly process: ChildProcess;
+  readonly spawned: Promise<void>;
+  readonly finished: Promise<void>;
+
+  constructor(properties: SimWatchChildProcessProperties) {
+    const { command, args, cwd, env } = properties;
+
+    this.process = spawn(command, [...args], {
+      cwd,
+      env,
+      stdio: ["inherit", "inherit", "inherit", "ipc"],
+    });
+
+    this.spawned = new Promise<void>((resolve, reject) => {
+      this.process.once("spawn", resolve);
+      this.process.once("error", (error: Error) => {
+        reject(new Error(`Could not run ${command}: ${error.message}`));
+      });
+    });
+
+    this.finished = new Promise<void>((resolve) => {
+      this.process.once("exit", () => {
+        resolve();
+      });
+    });
+  }
+}

--- a/src/cli/watch/sim-watch-child-shutdown.ts
+++ b/src/cli/watch/sim-watch-child-shutdown.ts
@@ -53,7 +53,14 @@ export class SimWatchChildShutdown {
       ),
     ]);
 
-    this.process.send({ type: simWatchMessages.stopping });
+    // The channel can close between being asked whether it is open and being
+    // written to, because the process is free to exit in between. The callback
+    // is where that failure goes; without one it reaches the process as an
+    // error event, and a warning that could not be delivered is not a reason to
+    // stop taking the process down.
+    this.process.send({ type: simWatchMessages.stopping }, () => {
+      // Nothing to do about a process that has already gone.
+    });
 
     await acknowledged;
   }

--- a/src/cli/watch/sim-watch-child-shutdown.ts
+++ b/src/cli/watch/sim-watch-child-shutdown.ts
@@ -1,0 +1,72 @@
+import type { ChildProcess } from "node:child_process";
+import {
+  simWatchConfig,
+  simWatchMessages,
+} from "../../watch/sim-watch.config.js";
+import { waitWatchMessage } from "./sim-watch-child-message.js";
+
+interface SimWatchChildShutdownProperties {
+  readonly process: ChildProcess;
+  readonly finished: Promise<void>;
+}
+
+/**
+ * Takes a supervised process down, in the order that lets it say goodbye.
+ *
+ * A process running Yulin's runtime is warned first, so a served page hears
+ * that a reload is coming rather than only seeing its connection go, and is
+ * killed as soon as it says it has passed that on. One that does not answer,
+ * because it is serving nothing or is not a Yulin process at all, is killed
+ * when the short wait runs out. Either way it is killed, and killed harder if
+ * it will not go, because the port has to be free for the process replacing it.
+ */
+export class SimWatchChildShutdown {
+  private readonly process: ChildProcess;
+  private readonly finished: Promise<void>;
+
+  constructor(properties: SimWatchChildShutdownProperties) {
+    const { process: childProcess, finished } = properties;
+    this.process = childProcess;
+    this.finished = finished;
+  }
+
+  /**
+   * Stop the process, and wait until it has gone.
+   */
+  async stop(): Promise<void> {
+    await this.warn();
+    this.process.kill("SIGTERM");
+    await this.gone();
+  }
+
+  private async warn(): Promise<void> {
+    if (!this.process.connected) {
+      return;
+    }
+
+    const acknowledged = Promise.race([
+      this.finished,
+      waitWatchMessage(
+        this.process,
+        simWatchMessages.stopped,
+        simWatchConfig.stoppingMs,
+      ),
+    ]);
+
+    this.process.send({ type: simWatchMessages.stopping });
+
+    await acknowledged;
+  }
+
+  private async gone(): Promise<void> {
+    const timer = setTimeout(() => {
+      this.process.kill("SIGKILL");
+    }, simWatchConfig.exitMs);
+
+    try {
+      await this.finished;
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+}

--- a/src/cli/watch/sim-watch-child.loc.test.ts
+++ b/src/cli/watch/sim-watch-child.loc.test.ts
@@ -1,0 +1,112 @@
+import {
+  assertIdentical,
+  assertStringIncludes,
+  assertArrayLength,
+  assertThrowsErrorAsync,
+  assertTrue,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimWatchChild } from "./sim-watch-child.js";
+import { WatchProject, watchPause } from "../../../test/cli/watch-project.js";
+
+describe("SimWatchChild over a real process", () => {
+  it("fails when the command cannot be run", async () => {
+    // Given a command that is not on the path
+    const project = await WatchProject.of({});
+    const child = childOf(project, "definitely-not-a-command", []);
+
+    // When it is started
+    const error = await assertThrowsErrorAsync(async () => {
+      await child.started();
+    });
+
+    // Then it says which command could not be run, rather than looking like a
+    // process that started and stopped
+    assertStringIncludes(error.message, "definitely-not-a-command");
+  });
+
+  it("reports a process that stopped on its own", async () => {
+    // Given a process that runs to the end
+    const project = await WatchProject.of({});
+    const exits: (number | null)[] = [];
+    const child = childOf(
+      project,
+      process.execPath,
+      ["-e", "process.exit(3)"],
+      {
+        onExit: (code) => {
+          exits.push(code);
+        },
+      },
+    );
+    await child.started();
+
+    // When it exits
+    await watchPause(500);
+
+    // Then the supervisor hears about it
+    assertIdentical(exits.at(0), 3);
+  });
+
+  it("says nothing about an exit it asked for", async () => {
+    // Given a process that stays up
+    const project = await WatchProject.of({});
+    const exits: (number | null)[] = [];
+    const child = childOf(
+      project,
+      process.execPath,
+      ["-e", "setInterval(() => {}, 60000)"],
+      {
+        onExit: (code) => {
+          exits.push(code);
+        },
+      },
+    );
+    await child.started();
+
+    // When it is stopped on purpose
+    await child.stop();
+
+    // Then that is not reported as a process that stopped on its own
+    assertArrayLength(exits, 0);
+  });
+
+  it("kills a process that will not go on being asked", async () => {
+    // Given a process that refuses to stop when it is asked
+    const project = await WatchProject.of({});
+    const child = childOf(project, process.execPath, [
+      "-e",
+      "process.on('SIGTERM', () => {}); setInterval(() => {}, 60000)",
+    ]);
+    await child.started();
+
+    // When it is stopped
+    const startedAt = Date.now();
+    await child.stop();
+
+    // Then it goes anyway, so the port is free for the process replacing it
+    assertTrue(Date.now() - startedAt >= 2000);
+  });
+});
+
+interface ChildOfProperties {
+  readonly onExit?: (code: number | null) => void;
+}
+
+function childOf(
+  project: WatchProject,
+  command: string,
+  commandArguments: readonly string[],
+  properties: ChildOfProperties = {},
+): SimWatchChild {
+  return new SimWatchChild({
+    command,
+    args: commandArguments,
+    cwd: project.path(),
+    env: process.env,
+    onPath: () => undefined,
+    onExit: (code) => {
+      properties.onExit?.(code);
+    },
+  });
+}

--- a/src/cli/watch/sim-watch-child.loc.test.ts
+++ b/src/cli/watch/sim-watch-child.loc.test.ts
@@ -7,7 +7,9 @@ import {
 } from "@kensio/smartass";
 import { describe, it } from "vitest";
 import { SimWatchChild } from "./sim-watch-child.js";
-import { WatchProject, watchPause } from "../../../test/cli/watch-project.js";
+import { WatchProject } from "../../../test/cli/watch-project.js";
+import { untilExited } from "../../../test/cli/until-exited.js";
+import { simWatchConfig } from "../../watch/sim-watch.config.js";
 
 describe("SimWatchChild over a real process", () => {
   it("fails when the command cannot be run", async () => {
@@ -42,7 +44,7 @@ describe("SimWatchChild over a real process", () => {
     await child.started();
 
     // When it exits
-    await watchPause(500);
+    await untilExited(exits);
 
     // Then the supervisor hears about it
     assertIdentical(exits.at(0), 3);
@@ -85,7 +87,7 @@ describe("SimWatchChild over a real process", () => {
     await child.stop();
 
     // Then it goes anyway, so the port is free for the process replacing it
-    assertTrue(Date.now() - startedAt >= 2000);
+    assertTrue(Date.now() - startedAt >= simWatchConfig.exitMs);
   });
 });
 

--- a/src/cli/watch/sim-watch-child.ts
+++ b/src/cli/watch/sim-watch-child.ts
@@ -1,0 +1,79 @@
+import { simWatchMessages } from "../../watch/sim-watch.config.js";
+import { isWatchPathMessage } from "./sim-watch-child-message.js";
+import { SimWatchChildProcess } from "./sim-watch-child-process.js";
+import { SimWatchChildShutdown } from "./sim-watch-child-shutdown.js";
+
+interface SimWatchChildProperties {
+  readonly command: string;
+  readonly args: readonly string[];
+  readonly cwd: string;
+  readonly env: NodeJS.ProcessEnv;
+  readonly onPath: (reportedPath: string) => void;
+  readonly onExit: (code: number | null, signal: NodeJS.Signals | null) => void;
+}
+
+/**
+ * One run of the supervised command.
+ *
+ * A restart is a new instance of this rather than anything swapped in place. A
+ * handler is a function reference out of the user's own module graph, and a new
+ * process re-imports it with no module cache to defeat, so a restart is correct
+ * by construction where an in-process swap would have to invalidate an import
+ * graph that ESM does not expose.
+ */
+export class SimWatchChild {
+  private readonly properties: SimWatchChildProperties;
+  private readonly run: SimWatchChildProcess;
+  private readonly startedAt = Date.now();
+  private stopping = false;
+
+  private readonly onMessage = (message: unknown): void => {
+    if (isWatchPathMessage(message, simWatchMessages.path)) {
+      this.properties.onPath(message.path);
+    }
+  };
+
+  private readonly onProcessExit = (
+    code: number | null,
+    signal: NodeJS.Signals | null,
+  ): void => {
+    if (!this.stopping) {
+      this.properties.onExit(code, signal);
+    }
+  };
+
+  constructor(properties: SimWatchChildProperties) {
+    this.properties = properties;
+    this.run = new SimWatchChildProcess(properties);
+
+    this.run.process.on("message", this.onMessage);
+    this.run.process.on("exit", this.onProcessExit);
+  }
+
+  /**
+   * How long this process has been running.
+   */
+  ranForMs(): number {
+    return Date.now() - this.startedAt;
+  }
+
+  /**
+   * Fail if the command could not be run at all, rather than letting it look
+   * like a process that started and stopped.
+   */
+  async started(): Promise<void> {
+    await this.run.spawned;
+  }
+
+  /**
+   * Stop this process, giving it a moment to tell its browsers first.
+   */
+  async stop(): Promise<void> {
+    this.stopping = true;
+
+    await new SimWatchChildShutdown({
+      process: this.run.process,
+      finished: this.run.finished,
+    }).stop();
+  }
+}

--- a/src/cli/watch/sim-watch-command.loc.test.ts
+++ b/src/cli/watch/sim-watch-command.loc.test.ts
@@ -1,0 +1,64 @@
+import {
+  assertArrayEquals,
+  assertIdentical,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimWatchCommand } from "./sim-watch-command.js";
+import { SimWatchUsageError } from "./sim-watch-arguments.js";
+import { SimWatchReporter } from "./sim-watch-reporter.js";
+import {
+  watchChildScript,
+  WatchProject,
+  watchPause,
+} from "../../../test/cli/watch-project.js";
+
+describe("SimWatchCommand", () => {
+  it("refuses a run with nothing to do before starting anything", async () => {
+    // Given a watch with no command after the separator
+    const command = new SimWatchCommand();
+
+    // When it is run
+    const error = await assertThrowsErrorAsync(async () => {
+      await command.run([]);
+    });
+
+    // Then it says how to write it, having started no process
+    assertInstanceOf(error, SimWatchUsageError);
+    assertStringIncludes(error.message, "Usage: yulin watch");
+  });
+
+  it("stops the process it started when it is interrupted", async () => {
+    // Given a watch running a real process
+    const project = await WatchProject.of({
+      "message.mjs": 'export const message = "first";',
+    });
+    await project.write("dev.mjs", watchChildScript(project.runsLogPath()));
+    const lines: string[] = [];
+    const command = new SimWatchCommand({
+      cwd: project.path(),
+      reporter: new SimWatchReporter({
+        cwd: project.path(),
+        write: (line) => {
+          lines.push(line);
+        },
+      }),
+    });
+    await project.settled();
+    const running = command.run(["--", process.execPath, "dev.mjs"]);
+    await project.untilRuns(1);
+
+    // When the terminal is interrupted
+    process.emit("SIGINT");
+    const exitCode = await running;
+
+    // Then it ends cleanly, and nothing is left holding the terminal
+    assertIdentical(exitCode, 0);
+    assertArrayEquals(process.listeners("SIGINT"), []);
+
+    await watchPause(100);
+    assertArrayEquals([...(await project.runs())], ["first"]);
+  });
+});

--- a/src/cli/watch/sim-watch-command.ts
+++ b/src/cli/watch/sim-watch-command.ts
@@ -1,0 +1,51 @@
+import { SimWatchArguments } from "./sim-watch-arguments.js";
+import { SimWatchReporter } from "./sim-watch-reporter.js";
+import { SimWatchSupervisor } from "./sim-watch-supervisor.js";
+
+interface SimWatchCommandProperties {
+  readonly cwd?: string;
+  readonly reporter?: SimWatchReporter;
+}
+
+/**
+ * The `yulin watch` command.
+ *
+ * Ctrl-C is handled here rather than left to the default, because the default
+ * would take the supervisor down and leave the process it started running.
+ */
+export class SimWatchCommand {
+  private readonly cwd: string;
+  private readonly reporter: SimWatchReporter;
+
+  constructor(properties: SimWatchCommandProperties = {}) {
+    const { cwd = process.cwd(), reporter = new SimWatchReporter({ cwd }) } =
+      properties;
+    this.cwd = cwd;
+    this.reporter = reporter;
+  }
+
+  /**
+   * Run the command, and report the exit code it should leave behind.
+   */
+  async run(argv: readonly string[]): Promise<number> {
+    const supervisor = new SimWatchSupervisor({
+      watchArguments: SimWatchArguments.parse(argv),
+      cwd: this.cwd,
+      reporter: this.reporter,
+    });
+
+    const interrupt = (): void => {
+      supervisor.interrupt();
+    };
+
+    process.on("SIGINT", interrupt);
+    process.on("SIGTERM", interrupt);
+
+    try {
+      return await supervisor.run();
+    } finally {
+      process.off("SIGINT", interrupt);
+      process.off("SIGTERM", interrupt);
+    }
+  }
+}

--- a/src/cli/watch/sim-watch-event-path.loc.test.ts
+++ b/src/cli/watch/sim-watch-event-path.loc.test.ts
@@ -1,0 +1,81 @@
+import path from "node:path";
+import { assertIdentical, assertUndefined } from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimWatchEventPath } from "./sim-watch-event-path.js";
+import { repoPath } from "../../util/filesystem/path.js";
+import { TemporaryDirectory } from "../../util/filesystem/temporary-directory.js";
+
+describe("SimWatchEventPath", () => {
+  it("joins a file name onto the directory being watched", () => {
+    // Given a recursive watch on a project
+    const eventPath = new SimWatchEventPath(repoPath(), true);
+
+    // When an event names a file in it
+    const changedPath = eventPath.of(path.join("src", "index.ts"));
+
+    // Then that file is what changed
+    assertIdentical(changedPath, repoPath(path.join("src", "index.ts")));
+  });
+
+  it("takes a nameless event on a directory to be about the directory", () => {
+    // Given a recursive watch on a project
+    const eventPath = new SimWatchEventPath(repoPath(), true);
+
+    // When an event arrives with no file name
+    const changedPath = eventPath.of(null);
+
+    // Then there is nothing to restart for, since an edit names its own file
+    assertUndefined(changedPath);
+  });
+
+  it("takes an empty name on a directory to be about the directory", () => {
+    // Given a recursive watch on a project
+    const eventPath = new SimWatchEventPath(repoPath(), true);
+
+    // When an event arrives with an empty file name
+    const changedPath = eventPath.of("");
+
+    // Then there is nothing to restart for
+    assertUndefined(changedPath);
+  });
+
+  it("takes the directory's own name to be about the directory", () => {
+    // Given a recursive watch on a project, which macOS reports changes to by
+    // the directory's own name rather than with no name at all
+    const eventPath = new SimWatchEventPath(repoPath(), true);
+
+    // When an event names the directory itself
+    const changedPath = eventPath.of(path.basename(repoPath()));
+
+    // Then it is passed over, since no such file is in there
+    assertUndefined(changedPath);
+  });
+
+  it("keeps a real file named after the directory it is in", async () => {
+    // Given a directory holding a file of its own name, which is unusual but
+    // allowed, and a recursive watch on it
+    const directory = new TemporaryDirectory();
+    await directory.resolvePath();
+    const name = path.basename(directory.path());
+    await directory.writeFile(name, "content");
+    const eventPath = new SimWatchEventPath(directory.path(), true);
+
+    // When an event names it
+    const changedPath = eventPath.of(name);
+
+    // Then it is a file that exists, so it is a change like any other
+    assertIdentical(changedPath, directory.join(name));
+  });
+
+  it("takes any event on a watched file to be about that file", () => {
+    // Given a watch on one synthesized template
+    const templatePath = repoPath("cdk.out/Stack.template.json");
+    const eventPath = new SimWatchEventPath(templatePath, false);
+
+    // When an event arrives, however it names the file
+    const changedPath = eventPath.of("Stack.template.json");
+
+    // Then the file being watched is the file that changed
+    assertIdentical(changedPath, templatePath);
+  });
+});

--- a/src/cli/watch/sim-watch-event-path.ts
+++ b/src/cli/watch/sim-watch-event-path.ts
@@ -1,0 +1,60 @@
+import fs from "node:fs";
+import path from "node:path";
+
+/**
+ * Works out which path a filesystem event was about.
+ *
+ * Node reports a watch event as the watched target plus a file name, and both
+ * halves have cases where that is not the whole story. A watch on a single file
+ * reports that file whatever name the event carries. A directory watch reports
+ * a change to the directory itself with no name at all, and on macOS with the
+ * directory's own name, neither of which says anything about a file in it.
+ *
+ * Wrong answers here are restarts nobody asked for, so this is kept apart from
+ * the watching and answered on its own.
+ */
+export class SimWatchEventPath {
+  private readonly target: string;
+  private readonly recursive: boolean;
+
+  constructor(target: string, recursive: boolean) {
+    this.target = target;
+    this.recursive = recursive;
+  }
+
+  /**
+   * The path that changed, or nothing when the event named none.
+   */
+  of(fileName: string | null): string | undefined {
+    if (!this.recursive) {
+      return this.target;
+    }
+
+    if (fileName === null || fileName.length === 0) {
+      return undefined;
+    }
+
+    const changedPath = path.join(this.target, fileName);
+
+    if (this.namesTheDirectoryItself(fileName, changedPath)) {
+      return undefined;
+    }
+
+    return changedPath;
+  }
+
+  /**
+   * A directory holding a file of its own name is unusual but allowed, so the
+   * one that does not exist is the event about the directory.
+   */
+  private namesTheDirectoryItself(
+    fileName: string,
+    changedPath: string,
+  ): boolean {
+    return (
+      fileName === path.basename(this.target) &&
+      // eslint-disable-next-line security/detect-non-literal-fs-filename
+      !fs.existsSync(changedPath)
+    );
+  }
+}

--- a/src/cli/watch/sim-watch-ignore.iso.test.ts
+++ b/src/cli/watch/sim-watch-ignore.iso.test.ts
@@ -25,6 +25,17 @@ describe("SimWatchIgnore", () => {
     assertTrue(!ignored);
   });
 
+  it("watches a source file whose name starts like a CDK asset", () => {
+    // Given a source file that happens to be named after what it configures
+    const ignore = new SimWatchIgnore();
+
+    // When it changes
+    const ignored = ignore.ignores("src/asset.config.ts");
+
+    // Then it is watched, since only CDK's output directory holds CDK assets
+    assertFalse(ignored);
+  });
+
   it("passes over a change that names nothing", () => {
     // Given an event that named no path at all
     const ignore = new SimWatchIgnore();

--- a/src/cli/watch/sim-watch-ignore.iso.test.ts
+++ b/src/cli/watch/sim-watch-ignore.iso.test.ts
@@ -1,0 +1,69 @@
+import { assertFalse, assertTrue } from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimWatchIgnore } from "./sim-watch-ignore.js";
+
+describe("SimWatchIgnore", () => {
+  it("watches project source", () => {
+    // Given a source file in the project
+    const ignore = new SimWatchIgnore();
+
+    // When it changes
+    const ignored = ignore.ignores("src/handler/upload.ts");
+
+    // Then it is worth restarting for
+    assertFalse(ignored);
+  });
+
+  it("watches a synthesized template", () => {
+    // Given the output of a CDK synth
+    const ignore = new SimWatchIgnore();
+
+    // When it changes
+    const ignored = ignore.ignores("cdk.out/MediaStack.template.json");
+
+    // Then it is worth restarting for, since the stack it deploys has changed
+    assertTrue(!ignored);
+  });
+
+  it("passes over a change that names nothing", () => {
+    // Given an event that named no path at all
+    const ignore = new SimWatchIgnore();
+
+    // When it is considered
+    const ignored = ignore.ignores("");
+
+    // Then there is nothing there to restart for
+    assertFalse(ignored);
+  });
+
+  it.each([
+    ["node_modules/@aws-sdk/client-s3/dist/index.js"],
+    [".git/index"],
+    ["dist/index.js"],
+    ["coverage/lcov.info"],
+    ["cdk.out/asset.9f2c/index.js"],
+  ])("passes over %s", (changedPath) => {
+    // Given a path nothing writes by hand
+    const ignore = new SimWatchIgnore();
+
+    // When it changes
+    const ignored = ignore.ignores(changedPath);
+
+    // Then it is not a reason to restart
+    assertTrue(ignored);
+  });
+
+  it.each([["src/dev.ts~"], ["src/.#dev.ts"], ["src/.dev.ts.swp"], ["4913"]])(
+    "passes over the editor working file %s",
+    (changedPath) => {
+      // Given a file an editor wrote on its way to saving
+      const ignore = new SimWatchIgnore();
+
+      // When it changes
+      const ignored = ignore.ignores(changedPath);
+
+      // Then it is not the save, so it is not a restart
+      assertTrue(ignored);
+    },
+  );
+});

--- a/src/cli/watch/sim-watch-ignore.ts
+++ b/src/cli/watch/sim-watch-ignore.ts
@@ -1,0 +1,64 @@
+import path from "node:path";
+
+// Directories nothing worth restarting for is ever written into. `dist` is on
+// the list because a dev script runs from source; a project that runs from its
+// build output is watching the build's inputs anyway.
+const ignoredDirectoryNames = new Set([
+  ".git",
+  ".idea",
+  ".next",
+  ".nyc_output",
+  ".tmp",
+  ".turbo",
+  ".vscode",
+  "coverage",
+  "dist",
+  "node_modules",
+]);
+
+// CDK writes each asset into its own directory beside the template. The
+// template is worth watching and the copies of the handler code beside it are
+// not, since their source is being watched already.
+const ignoredDirectoryPrefixes = ["asset.", ".cache"];
+
+// Editors write, rename and delete around the file being saved. Reacting to the
+// working files means restarting several times for one save, or restarting for
+// a file that is gone by the time anything reads it.
+const editorFilePatterns = [
+  /~$/u,
+  /^\.#/u,
+  /^#.*#$/u,
+  /\.sw[a-p]$/u,
+  /^\.goutputstream/u,
+  /^\d{4}$/u,
+  /^\.DS_Store$/u,
+];
+
+/**
+ * Decides which changed paths are worth restarting for.
+ *
+ * A watch that fires on everything under the working directory fires mostly on
+ * things the project generated, so the ignore list is what makes one save one
+ * restart rather than a stream of them.
+ */
+export class SimWatchIgnore {
+  /**
+   * Whether a changed path should be passed over.
+   */
+  ignores(changedPath: string): boolean {
+    const segments = changedPath.split(path.sep).filter(Boolean);
+    const fileName = segments.at(-1) ?? "";
+
+    return (
+      segments.some((segment) => this.ignoredDirectory(segment)) ||
+      editorFilePatterns.some((pattern) => pattern.test(fileName))
+    );
+  }
+
+  private ignoredDirectory(segment: string): boolean {
+    return (
+      ignoredDirectoryNames.has(segment) ||
+      ignoredDirectoryPrefixes.some((prefix) => segment.startsWith(prefix))
+    );
+  }
+}

--- a/src/cli/watch/sim-watch-ignore.ts
+++ b/src/cli/watch/sim-watch-ignore.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 // the list because a dev script runs from source; a project that runs from its
 // build output is watching the build's inputs anyway.
 const ignoredDirectoryNames = new Set([
+  ".cache",
   ".git",
   ".idea",
   ".next",
@@ -16,10 +17,14 @@ const ignoredDirectoryNames = new Set([
   "node_modules",
 ]);
 
-// CDK writes each asset into its own directory beside the template. The
-// template is worth watching and the copies of the handler code beside it are
-// not, since their source is being watched already.
-const ignoredDirectoryPrefixes = ["asset.", ".cache"];
+// CDK writes each asset into its own directory inside its output directory.
+// The template there is worth watching and the copies of the handler code
+// beside it are not, since their source is being watched already.
+//
+// Only inside that output directory: `asset.` is an ordinary way to start the
+// name of a source file, and `src/asset.config.ts` is a file someone edits.
+const cdkOutputDirectoryName = "cdk.out";
+const cdkAssetPrefix = "asset.";
 
 // Editors write, rename and delete around the file being saved. Reacting to the
 // working files means restarting several times for one save, or restarting for
@@ -50,15 +55,20 @@ export class SimWatchIgnore {
     const fileName = segments.at(-1) ?? "";
 
     return (
-      segments.some((segment) => this.ignoredDirectory(segment)) ||
+      segments.some((segment) => ignoredDirectoryNames.has(segment)) ||
+      this.isCdkAsset(segments) ||
       editorFilePatterns.some((pattern) => pattern.test(fileName))
     );
   }
 
-  private ignoredDirectory(segment: string): boolean {
+  private isCdkAsset(segments: readonly string[]): boolean {
+    const at = segments.indexOf(cdkOutputDirectoryName);
+
     return (
-      ignoredDirectoryNames.has(segment) ||
-      ignoredDirectoryPrefixes.some((prefix) => segment.startsWith(prefix))
+      at !== -1 &&
+      segments
+        .slice(at + 1)
+        .some((segment) => segment.startsWith(cdkAssetPrefix))
     );
   }
 }

--- a/src/cli/watch/sim-watch-loop-guard.iso.test.ts
+++ b/src/cli/watch/sim-watch-loop-guard.iso.test.ts
@@ -1,0 +1,78 @@
+import {
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsError,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import {
+  SimWatchLoopGuard,
+  SimWatchRestartLoop,
+} from "./sim-watch-loop-guard.js";
+
+describe("SimWatchLoopGuard", () => {
+  it("refuses a process that keeps changing the same file on startup", () => {
+    // Given setup that writes a template into a watched path
+    const guard = new SimWatchLoopGuard({
+      selfInflictedMs: 1000,
+      loopRestarts: 3,
+    });
+    guard.check("cdk.out/Stack.template.json", 50);
+    guard.check("cdk.out/Stack.template.json", 50);
+
+    // When it does it again straight after another start
+    const error = assertThrowsError(() => {
+      guard.check("cdk.out/Stack.template.json", 50);
+    });
+
+    // Then it stops, naming the file rather than spinning on it
+    assertInstanceOf(error, SimWatchRestartLoop);
+    assertStringIncludes(error.message, "cdk.out/Stack.template.json");
+    assertStringIncludes(error.message, "writes to a watched path");
+  });
+
+  it("allows a change made after the process has been up a while", () => {
+    // Given a process that has been running long enough for a person to type
+    const guard = new SimWatchLoopGuard({
+      selfInflictedMs: 1000,
+      loopRestarts: 3,
+    });
+
+    // When the same file is saved several times over
+    guard.check("src/handler.ts", 30_000);
+    guard.check("src/handler.ts", 20_000);
+    guard.check("src/handler.ts", 12_000);
+
+    // Then nothing is refused, since none of it was the process itself
+  });
+
+  it("allows fast changes to different files", () => {
+    // Given fast restarts, but each from a different file
+    const guard = new SimWatchLoopGuard({
+      selfInflictedMs: 1000,
+      loopRestarts: 3,
+    });
+
+    // When they arrive straight after startup
+    guard.check("src/one.ts", 40);
+    guard.check("src/two.ts", 40);
+    guard.check("src/three.ts", 40);
+
+    // Then it is someone saving quickly, not a loop
+  });
+
+  it("starts counting again after an unrelated change", () => {
+    // Given a run of self-inflicted restarts that was interrupted
+    const guard = new SimWatchLoopGuard({
+      selfInflictedMs: 1000,
+      loopRestarts: 3,
+    });
+    guard.check("cdk.out/Stack.template.json", 50);
+    guard.check("cdk.out/Stack.template.json", 50);
+    guard.check("src/handler.ts", 50);
+
+    // When the template changes on startup again
+    guard.check("cdk.out/Stack.template.json", 50);
+
+    // Then the count is starting over rather than tripping straight away
+  });
+});

--- a/src/cli/watch/sim-watch-loop-guard.ts
+++ b/src/cli/watch/sim-watch-loop-guard.ts
@@ -1,0 +1,70 @@
+import { simWatchConfig } from "../../watch/sim-watch.config.js";
+
+interface SimWatchLoopGuardProperties {
+  readonly selfInflictedMs?: number;
+  readonly loopRestarts?: number;
+}
+
+/**
+ * Thrown when a process keeps restarting itself.
+ */
+export class SimWatchRestartLoop extends Error {
+  public override readonly name = "SimWatchRestartLoop";
+
+  constructor(changedPath: string, restarts: number) {
+    super(
+      `Restart loop: ${changedPath} changed straight after startup ${String(restarts)} times in a row. ` +
+        `Something in the process writes to a watched path, so watching it restarts the process, which writes to it again. ` +
+        `Write it outside the working directory, or to a directory watch ignores such as .tmp.`,
+    );
+  }
+}
+
+/**
+ * Spots a process that restarts itself.
+ *
+ * Setup that writes into a watched path, such as synthesizing a template or
+ * seeding a mounted Bucket directory, changes a file the supervisor is watching
+ * as a direct result of having started. Left alone that restarts forever, at
+ * whatever rate the setup takes, which looks like the machine being busy rather
+ * than like a mistake. A change arriving before the process has been up long,
+ * from the same path, several times in a row, is that and not a person typing.
+ */
+export class SimWatchLoopGuard {
+  private readonly selfInflictedMs: number;
+  private readonly loopRestarts: number;
+  private lastPath: string | undefined;
+  private consecutive = 0;
+
+  constructor(properties: SimWatchLoopGuardProperties = {}) {
+    const {
+      selfInflictedMs = simWatchConfig.selfInflictedMs,
+      loopRestarts = simWatchConfig.loopRestarts,
+    } = properties;
+    this.selfInflictedMs = selfInflictedMs;
+    this.loopRestarts = loopRestarts;
+  }
+
+  /**
+   * Note a restart, and refuse one that is the process restarting itself.
+   */
+  check(changedPath: string, processRanForMs: number): void {
+    if (!this.selfInflicted(changedPath, processRanForMs)) {
+      this.lastPath = changedPath;
+      this.consecutive = 1;
+      return;
+    }
+
+    this.consecutive += 1;
+
+    if (this.consecutive >= this.loopRestarts) {
+      throw new SimWatchRestartLoop(changedPath, this.consecutive);
+    }
+  }
+
+  private selfInflicted(changedPath: string, processRanForMs: number): boolean {
+    return (
+      changedPath === this.lastPath && processRanForMs < this.selfInflictedMs
+    );
+  }
+}

--- a/src/cli/watch/sim-watch-recovery.loc.test.ts
+++ b/src/cli/watch/sim-watch-recovery.loc.test.ts
@@ -1,0 +1,116 @@
+import {
+  assertArrayEquals,
+  assertIdentical,
+  assertStringIncludes,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimWatchArguments } from "./sim-watch-arguments.js";
+import { SimWatchReporter } from "./sim-watch-reporter.js";
+import { SimWatchSupervisor } from "./sim-watch-supervisor.js";
+import {
+  inspectedChildScript,
+  selfWritingChildScript,
+  throwingChildScript,
+  WatchProject,
+  watchPause,
+} from "../../../test/cli/watch-project.js";
+import { listenOnFreePort, serverPort } from "../../../test/serve/held-port.js";
+
+const message = (value: string): string =>
+  `export const message = ${JSON.stringify(value)};`;
+
+describe("yulin watch when a run goes wrong", () => {
+  it("keeps watching after a setup that threw", async () => {
+    // Given a supervised process whose setup fails on startup
+    const project = await WatchProject.of({ "message.mjs": message("broken") });
+    await project.write("dev.mjs", throwingChildScript(project.runsLogPath()));
+    const reported: string[] = [];
+    const supervisor = supervise(project, reported);
+    await project.settled();
+    const running = supervisor.run();
+    await project.untilRuns(1);
+    await watchPause(300);
+
+    // When the mistake is fixed and saved
+    await project.write("message.mjs", message("fixed"));
+
+    // Then the next save is the retry, with no watch to start over
+    const runs = await project.untilRuns(2);
+    assertArrayEquals([...runs], ["broken", "fixed"]);
+    assertStringIncludes(reported.join(""), "waiting for a change");
+
+    supervisor.interrupt();
+    await running;
+  });
+
+  it("refuses a process that keeps restarting itself", async () => {
+    // Given a supervised process that writes into its own watched directory
+    const project = await WatchProject.of({});
+    await project.write(
+      "dev.mjs",
+      selfWritingChildScript(project.runsLogPath()),
+    );
+    const reported: string[] = [];
+    const supervisor = supervise(project, reported);
+    await project.settled();
+
+    // When it is left to run
+    const exitCode = await supervisor.run();
+
+    // Then it stops, naming the file, rather than restarting forever
+    assertIdentical(exitCode, 1);
+    assertStringIncludes(reported.join(""), "Restart loop");
+    assertStringIncludes(reported.join(""), "generated.json");
+  });
+
+  it("keeps a debugger able to attach across a restart", async () => {
+    // Given a supervised process started with an inspector port
+    const holder = await listenOnFreePort();
+    const inspectorPort = serverPort(holder);
+    holder.close();
+
+    const project = await WatchProject.of({ "message.mjs": message("first") });
+    await project.write("dev.mjs", inspectedChildScript(project.runsLogPath()));
+    const supervisor = supervise(
+      project,
+      [],
+      `--inspect=${String(inspectorPort)}`,
+    );
+    await project.settled();
+    const running = supervisor.run();
+    await project.untilRuns(1);
+
+    // When it restarts
+    await project.write("message.mjs", message("second"));
+
+    // Then the replacement has the inspector too, on the port the last one let
+    // go of
+    const runs = await project.untilRuns(2);
+    assertArrayEquals([...runs], ["first inspector", "second inspector"]);
+
+    supervisor.interrupt();
+    await running;
+  });
+});
+
+function supervise(
+  project: WatchProject,
+  reported: string[],
+  inspect?: string,
+): SimWatchSupervisor {
+  return new SimWatchSupervisor({
+    watchArguments: SimWatchArguments.parse([
+      ...(inspect === undefined ? [] : [inspect]),
+      "--",
+      process.execPath,
+      "dev.mjs",
+    ]),
+    cwd: project.path(),
+    reporter: new SimWatchReporter({
+      cwd: project.path(),
+      write: (line) => {
+        reported.push(line);
+      },
+    }),
+  });
+}

--- a/src/cli/watch/sim-watch-recovery.loc.test.ts
+++ b/src/cli/watch/sim-watch-recovery.loc.test.ts
@@ -3,7 +3,7 @@ import {
   assertIdentical,
   assertStringIncludes,
 } from "@kensio/smartass";
-import { describe, it } from "vitest";
+import { afterEach, describe, it } from "vitest";
 import { SimWatchArguments } from "./sim-watch-arguments.js";
 import { SimWatchReporter } from "./sim-watch-reporter.js";
 import { SimWatchSupervisor } from "./sim-watch-supervisor.js";
@@ -14,12 +14,18 @@ import {
   WatchProject,
   watchPause,
 } from "../../../test/cli/watch-project.js";
+import {
+  runSupervisor,
+  stopSupervisors,
+} from "../../../test/cli/running-supervisors.js";
 import { listenOnFreePort, serverPort } from "../../../test/serve/held-port.js";
 
 const message = (value: string): string =>
   `export const message = ${JSON.stringify(value)};`;
 
 describe("yulin watch when a run goes wrong", () => {
+  afterEach(stopSupervisors);
+
   it("keeps watching after a setup that threw", async () => {
     // Given a supervised process whose setup fails on startup
     const project = await WatchProject.of({ "message.mjs": message("broken") });
@@ -27,7 +33,7 @@ describe("yulin watch when a run goes wrong", () => {
     const reported: string[] = [];
     const supervisor = supervise(project, reported);
     await project.settled();
-    const running = supervisor.run();
+    runSupervisor(supervisor);
     await project.untilRuns(1);
     await watchPause(300);
 
@@ -38,9 +44,6 @@ describe("yulin watch when a run goes wrong", () => {
     const runs = await project.untilRuns(2);
     assertArrayEquals([...runs], ["broken", "fixed"]);
     assertStringIncludes(reported.join(""), "waiting for a change");
-
-    supervisor.interrupt();
-    await running;
   });
 
   it("refuses a process that keeps restarting itself", async () => {
@@ -77,7 +80,7 @@ describe("yulin watch when a run goes wrong", () => {
       `--inspect=${String(inspectorPort)}`,
     );
     await project.settled();
-    const running = supervisor.run();
+    runSupervisor(supervisor);
     await project.untilRuns(1);
 
     // When it restarts
@@ -87,9 +90,6 @@ describe("yulin watch when a run goes wrong", () => {
     // go of
     const runs = await project.untilRuns(2);
     assertArrayEquals([...runs], ["first inspector", "second inspector"]);
-
-    supervisor.interrupt();
-    await running;
   });
 });
 

--- a/src/cli/watch/sim-watch-reported-paths.loc.test.ts
+++ b/src/cli/watch/sim-watch-reported-paths.loc.test.ts
@@ -1,10 +1,14 @@
 import path from "node:path";
-import { describe, it } from "vitest";
+import { afterEach, describe, it } from "vitest";
 import { SimWatchArguments } from "./sim-watch-arguments.js";
 import { SimWatchReporter } from "./sim-watch-reporter.js";
 import { SimWatchSupervisor } from "./sim-watch-supervisor.js";
 import { repoPath } from "../../util/filesystem/path.js";
 import { WatchProject, watchPause } from "../../../test/cli/watch-project.js";
+import {
+  runSupervisor,
+  stopSupervisors,
+} from "../../../test/cli/running-supervisors.js";
 
 const yulin = repoPath("src/index.js");
 const tsx = repoPath(path.join("node_modules", ".bin", "tsx"));
@@ -15,6 +19,8 @@ const tsx = repoPath(path.join("node_modules", ".bin", "tsx"));
  * point is that the reporting happens where the path is registered.
  */
 describe("paths a supervised process reports", () => {
+  afterEach(stopSupervisors);
+
   it("watches a directory mounted into a Bucket", async () => {
     // Given a dev script that mounts a directory outside the project
     const project = await WatchProject.of({});
@@ -26,7 +32,7 @@ describe("paths a supervised process reports", () => {
     );
     const supervisor = supervise(project);
     await project.settled();
-    const running = supervisor.run();
+    runSupervisor(supervisor);
     await project.untilRuns(1);
     await watchPause(300);
 
@@ -36,9 +42,6 @@ describe("paths a supervised process reports", () => {
     // Then the process runs again, without the directory being named anywhere
     // but in the mount itself
     await project.untilRuns(2);
-
-    supervisor.interrupt();
-    await running;
   });
 
   it("watches a template that was deployed", async () => {
@@ -56,7 +59,7 @@ describe("paths a supervised process reports", () => {
     );
     const supervisor = supervise(project);
     await project.settled();
-    const running = supervisor.run();
+    runSupervisor(supervisor);
     await project.untilRuns(1);
     await watchPause(300);
 
@@ -65,9 +68,6 @@ describe("paths a supervised process reports", () => {
 
     // Then the process runs again, rebinding against the new template
     await project.untilRuns(2);
-
-    supervisor.interrupt();
-    await running;
   });
 });
 

--- a/src/cli/watch/sim-watch-reported-paths.loc.test.ts
+++ b/src/cli/watch/sim-watch-reported-paths.loc.test.ts
@@ -1,0 +1,119 @@
+import path from "node:path";
+import { describe, it } from "vitest";
+import { SimWatchArguments } from "./sim-watch-arguments.js";
+import { SimWatchReporter } from "./sim-watch-reporter.js";
+import { SimWatchSupervisor } from "./sim-watch-supervisor.js";
+import { repoPath } from "../../util/filesystem/path.js";
+import { WatchProject, watchPause } from "../../../test/cli/watch-project.js";
+
+const yulin = repoPath("src/index.js");
+const tsx = repoPath(path.join("node_modules", ".bin", "tsx"));
+
+/**
+ * The paths Yulin holds that a module graph never mentions, watched without the
+ * dev script listing them. Real Yulin in a real supervised process, because the
+ * point is that the reporting happens where the path is registered.
+ */
+describe("paths a supervised process reports", () => {
+  it("watches a directory mounted into a Bucket", async () => {
+    // Given a dev script that mounts a directory outside the project
+    const project = await WatchProject.of({});
+    const mounted = path.join(project.mountedPath(), "public");
+    await project.writeMounted(path.join("public", "index.html"), "<h1>a</h1>");
+    await project.write(
+      "dev.ts",
+      mountingScript(project.runsLogPath(), mounted),
+    );
+    const supervisor = supervise(project);
+    await project.settled();
+    const running = supervisor.run();
+    await project.untilRuns(1);
+    await watchPause(300);
+
+    // When a file in that directory is edited
+    await project.writeMounted(path.join("public", "index.html"), "<h1>b</h1>");
+
+    // Then the process runs again, without the directory being named anywhere
+    // but in the mount itself
+    await project.untilRuns(2);
+
+    supervisor.interrupt();
+    await running;
+  });
+
+  it("watches a template that was deployed", async () => {
+    // Given a dev script that deploys a synthesized template from outside the
+    // project, as a separate synth step would leave it
+    const project = await WatchProject.of({});
+    const templatePath = path.join(
+      project.mountedPath(),
+      "Stack.template.json",
+    );
+    await project.writeMounted("Stack.template.json", emptyTemplate);
+    await project.write(
+      "dev.ts",
+      deployingScript(project.runsLogPath(), templatePath),
+    );
+    const supervisor = supervise(project);
+    await project.settled();
+    const running = supervisor.run();
+    await project.untilRuns(1);
+    await watchPause(300);
+
+    // When the stack is synthesized again
+    await project.writeMounted("Stack.template.json", changedTemplate);
+
+    // Then the process runs again, rebinding against the new template
+    await project.untilRuns(2);
+
+    supervisor.interrupt();
+    await running;
+  });
+});
+
+const emptyTemplate = JSON.stringify({ Resources: {} });
+const changedTemplate = JSON.stringify({
+  Resources: {
+    Assets: { Type: "AWS::S3::Bucket", Properties: { BucketName: "assets" } },
+  },
+});
+
+function mountingScript(runsLogPath: string, mountedPath: string): string {
+  return String.raw`import { appendFileSync } from "node:fs";
+import { SimAws } from ${JSON.stringify(yulin)};
+
+appendFileSync(${JSON.stringify(runsLogPath)}, "run\n");
+
+const simAws = new SimAws();
+await simAws.s3().createBucket({ input: { Bucket: "site" } });
+simAws.s3().mountBucketFilesystem("site", ${JSON.stringify(mountedPath)});
+
+setInterval(() => {}, 60_000);
+`;
+}
+
+function deployingScript(runsLogPath: string, templatePath: string): string {
+  return String.raw`import { appendFileSync } from "node:fs";
+import { SimAws } from ${JSON.stringify(yulin)};
+
+appendFileSync(${JSON.stringify(runsLogPath)}, "run\n");
+
+const simAws = new SimAws();
+await simAws
+  .cloudFormation()
+  .deployTemplateFile({ templatePath: ${JSON.stringify(templatePath)} });
+
+setInterval(() => {}, 60_000);
+`;
+}
+
+function supervise(project: WatchProject): SimWatchSupervisor {
+  return new SimWatchSupervisor({
+    watchArguments: SimWatchArguments.parse(["--", tsx, "dev.ts"]),
+    cwd: project.path(),
+    reporter: new SimWatchReporter({
+      cwd: project.path(),
+      write: () => undefined,
+    }),
+  });
+}

--- a/src/cli/watch/sim-watch-reporter.iso.test.ts
+++ b/src/cli/watch/sim-watch-reporter.iso.test.ts
@@ -1,0 +1,105 @@
+import path from "node:path";
+import { assertArrayEquals, assertStringIncludes } from "@kensio/smartass";
+import { describe, it, vi } from "vitest";
+import { SimWatchReporter } from "./sim-watch-reporter.js";
+
+const cwd = path.resolve("/projects/media");
+
+describe("SimWatchReporter", () => {
+  it("says what it is watching and what it is running", () => {
+    // Given a supervisor that has just started
+    const lines: string[] = [];
+    const reporter = new SimWatchReporter({ cwd, write: lineTo(lines) });
+
+    // When it reports itself
+    reporter.started("tsx dev.ts");
+
+    // Then it is clear something is watching, and what it started
+    assertArrayEquals(lines, ["yulin watch: watching ., running tsx dev.ts\n"]);
+  });
+
+  it("reports a restart with what caused it and what it cost", () => {
+    // Given a restart from a file inside the project
+    const lines: string[] = [];
+    const reporter = new SimWatchReporter({ cwd, write: lineTo(lines) });
+
+    // When it is reported
+    reporter.restarted(path.join(cwd, "src", "handler.ts"), 412.6);
+
+    // Then the path is the part that changed, not the part that never does
+    assertArrayEquals(lines, [
+      `yulin watch: restarted in 413ms after ${path.join("src", "handler.ts")}\n`,
+    ]);
+  });
+
+  it("reports a path outside the project in full", () => {
+    // Given a change to a directory mounted from elsewhere
+    const lines: string[] = [];
+    const reporter = new SimWatchReporter({ cwd, write: lineTo(lines) });
+    const outside = path.resolve("/shared/assets/logo.svg");
+
+    // When it is reported
+    reporter.restarted(outside, 10);
+
+    // Then it is named in full, since a relative path to it says less
+    assertStringIncludes(lines[0] ?? "", outside);
+  });
+
+  it("reports a process that stopped on its own", () => {
+    // Given a setup script that threw
+    const lines: string[] = [];
+    const reporter = new SimWatchReporter({ cwd, write: lineTo(lines) });
+
+    // When the process exits
+    reporter.exited(1, null);
+
+    // Then the watching is said to continue, so the next save is the retry
+    assertStringIncludes(lines[0] ?? "", "code 1");
+    assertStringIncludes(lines[0] ?? "", "waiting for a change");
+  });
+
+  it("reports a process that was killed", () => {
+    // Given a process taken down by a signal
+    const lines: string[] = [];
+    const reporter = new SimWatchReporter({ cwd, write: lineTo(lines) });
+
+    // When the exit is reported
+    reporter.exited(null, "SIGKILL");
+
+    // Then the signal is named rather than an exit code that never came
+    assertStringIncludes(lines[0] ?? "", "SIGKILL");
+  });
+
+  it("writes to standard error, leaving standard output to the process", () => {
+    // Given a reporter with nowhere told to write
+    const written: string[] = [];
+    vi.spyOn(process.stderr, "write").mockImplementation((chunk): boolean => {
+      written.push(String(chunk));
+      return true;
+    });
+
+    // When it reports something
+    new SimWatchReporter().started("tsx dev.ts");
+
+    // Then it goes to standard error, so a piped standard output stays clean
+    assertStringIncludes(written.join(""), "running tsx dev.ts");
+  });
+
+  it("reports what stopped the watching", () => {
+    // Given something the watcher cannot carry on through
+    const lines: string[] = [];
+    const reporter = new SimWatchReporter({ cwd, write: lineTo(lines) });
+
+    // When it is reported
+    reporter.failed(new Error("Restart loop: dev.ts changed"));
+
+    // Then the message is what the terminal shows
+    assertStringIncludes(lines[0] ?? "", "Restart loop: dev.ts changed");
+  });
+});
+
+function lineTo(lines: string[]): (line: string) => void {
+  return (line: string): void => {
+    lines.push(line);
+  };
+}

--- a/src/cli/watch/sim-watch-reporter.ts
+++ b/src/cli/watch/sim-watch-reporter.ts
@@ -1,0 +1,92 @@
+import path from "node:path";
+
+interface SimWatchReporterProperties {
+  readonly write?: (line: string) => void;
+  readonly cwd?: string;
+}
+
+/**
+ * What `yulin watch` says in the terminal.
+ *
+ * It writes to standard error so the supervised process keeps standard output
+ * to itself, which matters when that output is being piped somewhere. Paths are
+ * reported relative to the working directory, since an absolute path in a
+ * restart line is mostly the part that has not changed.
+ */
+export class SimWatchReporter {
+  private readonly write: (line: string) => void;
+  private readonly cwd: string;
+
+  constructor(properties: SimWatchReporterProperties = {}) {
+    const {
+      write = (line: string): void => {
+        process.stderr.write(line);
+      },
+      cwd = process.cwd(),
+    } = properties;
+    this.write = write;
+    this.cwd = cwd;
+  }
+
+  /**
+   * Report the first start, so it is clear the supervisor is there.
+   */
+  started(command: string): void {
+    this.line(`watching ${this.relative(this.cwd)}, running ${command}`);
+  }
+
+  /**
+   * Report a restart, and what it cost.
+   */
+  restarted(changedPath: string, tookMs: number): void {
+    this.line(
+      `restarted in ${String(Math.round(tookMs))}ms after ${this.relative(changedPath)}`,
+    );
+  }
+
+  /**
+   * Report a process that stopped on its own, which is a setup error rather
+   * than a reason to stop watching.
+   */
+  exited(code: number | null, signal: NodeJS.Signals | null): void {
+    this.line(
+      `process exited (${describeExit(code, signal)}), waiting for a change`,
+    );
+  }
+
+  /**
+   * Report something that stops the watcher.
+   */
+  failed(error: Error): void {
+    this.line(error.message);
+  }
+
+  private line(message: string): void {
+    this.write(`yulin watch: ${message}\n`);
+  }
+
+  private relative(target: string): string {
+    const relative = path.relative(this.cwd, target);
+
+    if (relative.length === 0) {
+      return ".";
+    }
+
+    if (relative.startsWith("..")) {
+      return target;
+    }
+
+    return relative;
+  }
+}
+
+function describeExit(
+  code: number | null,
+  signal: NodeJS.Signals | null,
+): string {
+  if (signal !== null) {
+    return signal;
+  }
+
+  return `code ${String(code ?? 0)}`;
+}

--- a/src/cli/watch/sim-watch-restarts.iso.test.ts
+++ b/src/cli/watch/sim-watch-restarts.iso.test.ts
@@ -62,6 +62,23 @@ describe("SimWatchRestarts", () => {
     assertIdentical(restarts.failures.at(0), "no port");
   });
 
+  it("drops a change queued behind a restart that failed", async () => {
+    // Given a restart that is going to throw, with another change behind it
+    const restarts = new RecordedRestarts({ failWith: new Error("no port") });
+    restarts.request("src/first.ts");
+    restarts.request("src/second.ts");
+
+    // When the restart fails
+    restarts.release();
+    await restarts.settle();
+    restarts.release();
+    await restarts.settle();
+
+    // Then the queued change does not run anyway. Whatever asked for the
+    // restart decides what happens after one fails.
+    assertArrayEquals(restarts.restarted, ["src/first.ts"]);
+  });
+
   it("restarts again after one that failed", async () => {
     // Given a restart that threw
     const restarts = new RecordedRestarts({ failWith: new Error("no port") });

--- a/src/cli/watch/sim-watch-restarts.iso.test.ts
+++ b/src/cli/watch/sim-watch-restarts.iso.test.ts
@@ -1,0 +1,81 @@
+import { assertArrayEquals, assertIdentical } from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { RecordedRestarts } from "../../../test/cli/recorded-restarts.js";
+
+describe("SimWatchRestarts", () => {
+  it("restarts for a change when nothing else is running", async () => {
+    // Given a watcher with no restart under way
+    const restarts = new RecordedRestarts();
+
+    // When a change arrives
+    restarts.request("src/handler.ts");
+    restarts.release();
+    await restarts.settle();
+
+    // Then it is restarted for
+    assertArrayEquals(restarts.restarted, ["src/handler.ts"]);
+  });
+
+  it("runs a change that arrived during a restart afterwards", async () => {
+    // Given a restart already under way
+    const restarts = new RecordedRestarts();
+    restarts.request("src/first.ts");
+
+    // When another change arrives before it finishes
+    restarts.request("src/second.ts");
+    restarts.release();
+    await restarts.settle();
+    restarts.release();
+    await restarts.settle();
+
+    // Then the edit made during the restart is not lost
+    assertArrayEquals(restarts.restarted, ["src/first.ts", "src/second.ts"]);
+  });
+
+  it("keeps only the latest change made during a restart", async () => {
+    // Given a restart already under way
+    const restarts = new RecordedRestarts();
+    restarts.request("src/first.ts");
+
+    // When several changes arrive before it finishes
+    restarts.request("src/second.ts");
+    restarts.request("src/third.ts");
+    restarts.release();
+    await restarts.settle();
+    restarts.release();
+    await restarts.settle();
+
+    // Then one restart follows, for what is on disk now
+    assertArrayEquals(restarts.restarted, ["src/first.ts", "src/third.ts"]);
+  });
+
+  it("reports a restart that failed", async () => {
+    // Given a restart that is going to throw
+    const restarts = new RecordedRestarts({ failWith: new Error("no port") });
+
+    // When a change arrives
+    restarts.request("src/handler.ts");
+    restarts.release();
+    await restarts.settle();
+
+    // Then the failure is reported rather than swallowed
+    assertIdentical(restarts.failures.at(0), "no port");
+  });
+
+  it("restarts again after one that failed", async () => {
+    // Given a restart that threw
+    const restarts = new RecordedRestarts({ failWith: new Error("no port") });
+    restarts.request("src/first.ts");
+    restarts.release();
+    await restarts.settle();
+
+    // When the next change arrives
+    restarts.stopFailing();
+    restarts.request("src/second.ts");
+    restarts.release();
+    await restarts.settle();
+
+    // Then it is restarted for, rather than the queue being stuck
+    assertArrayEquals(restarts.restarted, ["src/first.ts", "src/second.ts"]);
+  });
+});

--- a/src/cli/watch/sim-watch-restarts.ts
+++ b/src/cli/watch/sim-watch-restarts.ts
@@ -1,0 +1,68 @@
+interface SimWatchRestartsProperties {
+  readonly restart: (changedPath: string) => Promise<void>;
+  readonly onFailure: (error: unknown) => void;
+}
+
+/**
+ * Runs restarts one at a time, and does not lose an edit made during one.
+ *
+ * Changes arrive whenever they arrive, and a restart takes as long as the
+ * project takes to start. Running two at once would leave two processes racing
+ * for the same port, and dropping the second would mean a save silently doing
+ * nothing, so a change that arrives mid-restart waits for its turn.
+ *
+ * Only the latest is kept. A restart takes whatever is on disk at the time, so
+ * two changes queued behind one restart are one restart.
+ */
+export class SimWatchRestarts {
+  private readonly restart: (changedPath: string) => Promise<void>;
+  private readonly onFailure: (error: unknown) => void;
+  private running = false;
+  private queuedPath: string | undefined;
+
+  constructor(properties: SimWatchRestartsProperties) {
+    const { restart, onFailure } = properties;
+    this.restart = restart;
+    this.onFailure = onFailure;
+  }
+
+  /**
+   * Restart for a change, now or as soon as the current restart is done.
+   */
+  request(changedPath: string): void {
+    if (this.running) {
+      this.queuedPath = changedPath;
+      return;
+    }
+
+    this.running = true;
+
+    // eslint-disable-next-line unicorn/prefer-await
+    this.run(changedPath).catch((error: unknown) => {
+      this.onFailure(error);
+    });
+  }
+
+  private async run(changedPath: string): Promise<void> {
+    try {
+      await this.restart(changedPath);
+    } finally {
+      this.running = false;
+    }
+
+    await this.drain();
+  }
+
+  private async drain(): Promise<void> {
+    const queuedPath = this.queuedPath;
+    this.queuedPath = undefined;
+
+    if (queuedPath === undefined) {
+      return;
+    }
+
+    this.running = true;
+
+    await this.run(queuedPath);
+  }
+}

--- a/src/cli/watch/sim-watch-restarts.ts
+++ b/src/cli/watch/sim-watch-restarts.ts
@@ -46,6 +46,12 @@ export class SimWatchRestarts {
   private async run(changedPath: string): Promise<void> {
     try {
       await this.restart(changedPath);
+    } catch (error) {
+      // A restart that failed is the end of this run. Whatever asked for it
+      // decides what happens next, and a change queued behind it would be a
+      // restart nobody is waiting for any more.
+      this.queuedPath = undefined;
+      throw error;
     } finally {
       this.running = false;
     }

--- a/src/cli/watch/sim-watch-settle.iso.test.ts
+++ b/src/cli/watch/sim-watch-settle.iso.test.ts
@@ -1,0 +1,73 @@
+import { assertArrayEquals } from "@kensio/smartass";
+import { afterEach, describe, it, vi } from "vitest";
+import { SimWatchSettle } from "./sim-watch-settle.js";
+
+describe("SimWatchSettle", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("makes one change out of a burst of writes", () => {
+    // Given the several writes one editor save produces
+    vi.useFakeTimers();
+    const settled: string[] = [];
+    const settle = new SimWatchSettle({
+      settleMs: 100,
+      onSettled: (changedPath) => {
+        settled.push(changedPath);
+      },
+    });
+
+    // When they arrive faster than the settle window
+    settle.record("src/handler.ts");
+    vi.advanceTimersByTime(40);
+    settle.record("src/handler.ts~");
+    vi.advanceTimersByTime(40);
+    settle.record("src");
+    vi.advanceTimersByTime(100);
+
+    // Then one change is reported, named after the file that started it
+    assertArrayEquals(settled, ["src/handler.ts"]);
+  });
+
+  it("reports a later change separately", () => {
+    // Given a change that has already settled
+    vi.useFakeTimers();
+    const settled: string[] = [];
+    const settle = new SimWatchSettle({
+      settleMs: 100,
+      onSettled: (changedPath) => {
+        settled.push(changedPath);
+      },
+    });
+    settle.record("src/first.ts");
+    vi.advanceTimersByTime(100);
+
+    // When another arrives afterwards
+    settle.record("src/second.ts");
+    vi.advanceTimersByTime(100);
+
+    // Then it is a change of its own
+    assertArrayEquals(settled, ["src/first.ts", "src/second.ts"]);
+  });
+
+  it("drops a change that was still settling when it was cancelled", () => {
+    // Given a change waiting to see whether more are coming
+    vi.useFakeTimers();
+    const settled: string[] = [];
+    const settle = new SimWatchSettle({
+      settleMs: 100,
+      onSettled: (changedPath) => {
+        settled.push(changedPath);
+      },
+    });
+    settle.record("src/handler.ts");
+
+    // When the watcher shuts down first
+    settle.cancel();
+    vi.advanceTimersByTime(100);
+
+    // Then nothing is restarted for it
+    assertArrayEquals(settled, []);
+  });
+});

--- a/src/cli/watch/sim-watch-settle.ts
+++ b/src/cli/watch/sim-watch-settle.ts
@@ -1,0 +1,51 @@
+interface SimWatchSettleProperties {
+  readonly settleMs: number;
+  readonly onSettled: (changedPath: string) => void;
+}
+
+/**
+ * Turns a burst of writes into one change.
+ *
+ * Saving one file in an editor is several filesystem events: a temporary file
+ * written, renamed over the original, and often the directory touched as well.
+ * Restarting on each of those would be several restarts for one save, so the
+ * changes are held until they stop arriving.
+ *
+ * The path reported is the first of the burst, which is the one that actually
+ * changed rather than whatever the editor did around it.
+ */
+export class SimWatchSettle {
+  private readonly settleMs: number;
+  private readonly onSettled: (changedPath: string) => void;
+  private pendingPath: string | undefined;
+  private timer: NodeJS.Timeout | undefined;
+
+  constructor(properties: SimWatchSettleProperties) {
+    const { settleMs, onSettled } = properties;
+    this.settleMs = settleMs;
+    this.onSettled = onSettled;
+  }
+
+  /**
+   * Note a change, and wait to see whether more are coming.
+   */
+  record(changedPath: string): void {
+    this.pendingPath ??= changedPath;
+    const burstPath = this.pendingPath;
+
+    clearTimeout(this.timer);
+    this.timer = setTimeout(() => {
+      this.pendingPath = undefined;
+      this.onSettled(burstPath);
+    }, this.settleMs);
+  }
+
+  /**
+   * Drop anything waiting, for a watcher that is shutting down.
+   */
+  cancel(): void {
+    clearTimeout(this.timer);
+    this.timer = undefined;
+    this.pendingPath = undefined;
+  }
+}

--- a/src/cli/watch/sim-watch-supervisor.loc.test.ts
+++ b/src/cli/watch/sim-watch-supervisor.loc.test.ts
@@ -1,0 +1,103 @@
+import { assertArrayEquals, assertArrayLength } from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimWatchArguments } from "./sim-watch-arguments.js";
+import { SimWatchReporter } from "./sim-watch-reporter.js";
+import { SimWatchSupervisor } from "./sim-watch-supervisor.js";
+import {
+  reportingChildScript,
+  watchChildScript,
+  WatchProject,
+  watchPause,
+} from "../../../test/cli/watch-project.js";
+
+const message = (value: string): string =>
+  `export const message = ${JSON.stringify(value)};`;
+
+describe("yulin watch over a real process", () => {
+  it("restarts the process when a watched file changes", async () => {
+    // Given a supervised process that has started once
+    const project = await WatchProject.of({
+      "message.mjs": message("first"),
+    });
+    await project.write("dev.mjs", watchChildScript(project.runsLogPath()));
+    const supervisor = supervise(project);
+    await project.settled();
+    const running = supervisor.run();
+    await project.untilRuns(1);
+
+    // When a file it imports is saved
+    await project.write("message.mjs", message("second"));
+
+    // Then it runs again, with the change in it
+    const runs = await project.untilRuns(2);
+    assertArrayEquals([...runs], ["first", "second"]);
+
+    supervisor.interrupt();
+    await running;
+  });
+
+  it("makes one restart out of a burst of saves", async () => {
+    // Given a supervised process that has started once
+    const project = await WatchProject.of({
+      "message.mjs": message("first"),
+    });
+    await project.write("dev.mjs", watchChildScript(project.runsLogPath()));
+    const supervisor = supervise(project);
+    await project.settled();
+    const running = supervisor.run();
+    await project.untilRuns(1);
+
+    // When several writes land in quick succession, as one save does
+    await project.write("message.mjs", message("a"));
+    await project.write("message.mjs", message("b"));
+    await project.write("message.mjs", message("last"));
+
+    // Then there is one more run, not one for each write
+    const runs = await project.untilRuns(2);
+    assertArrayEquals([...runs], ["first", "last"]);
+    await watchPause(400);
+    assertArrayLength(await project.runs(), 2);
+
+    supervisor.interrupt();
+    await running;
+  });
+
+  it("watches a directory the process reported", async () => {
+    // Given a supervised process that named a directory outside the project,
+    // the way a mounted Bucket directory or a deployed template is named
+    const project = await WatchProject.of({});
+    await project.write(
+      "dev.mjs",
+      reportingChildScript(project.runsLogPath(), project.mountedPath()),
+    );
+    const supervisor = supervise(project);
+    await project.settled();
+    const running = supervisor.run();
+    await project.untilRuns(1);
+    await watchPause(200);
+
+    // When a file changes in that directory
+    await project.writeMounted("logo.svg", "<svg></svg>");
+
+    // Then the process runs again, without the directory having been listed
+    await project.untilRuns(2);
+
+    supervisor.interrupt();
+    await running;
+  });
+});
+
+function supervise(project: WatchProject): SimWatchSupervisor {
+  return new SimWatchSupervisor({
+    watchArguments: SimWatchArguments.parse([
+      "--",
+      process.execPath,
+      "dev.mjs",
+    ]),
+    cwd: project.path(),
+    reporter: new SimWatchReporter({
+      cwd: project.path(),
+      write: () => undefined,
+    }),
+  });
+}

--- a/src/cli/watch/sim-watch-supervisor.loc.test.ts
+++ b/src/cli/watch/sim-watch-supervisor.loc.test.ts
@@ -1,5 +1,5 @@
 import { assertArrayEquals, assertArrayLength } from "@kensio/smartass";
-import { describe, it } from "vitest";
+import { afterEach, describe, it } from "vitest";
 import { SimWatchArguments } from "./sim-watch-arguments.js";
 import { SimWatchReporter } from "./sim-watch-reporter.js";
 import { SimWatchSupervisor } from "./sim-watch-supervisor.js";
@@ -9,11 +9,17 @@ import {
   WatchProject,
   watchPause,
 } from "../../../test/cli/watch-project.js";
+import {
+  runSupervisor,
+  stopSupervisors,
+} from "../../../test/cli/running-supervisors.js";
 
 const message = (value: string): string =>
   `export const message = ${JSON.stringify(value)};`;
 
 describe("yulin watch over a real process", () => {
+  afterEach(stopSupervisors);
+
   it("restarts the process when a watched file changes", async () => {
     // Given a supervised process that has started once
     const project = await WatchProject.of({
@@ -22,7 +28,7 @@ describe("yulin watch over a real process", () => {
     await project.write("dev.mjs", watchChildScript(project.runsLogPath()));
     const supervisor = supervise(project);
     await project.settled();
-    const running = supervisor.run();
+    runSupervisor(supervisor);
     await project.untilRuns(1);
 
     // When a file it imports is saved
@@ -31,9 +37,6 @@ describe("yulin watch over a real process", () => {
     // Then it runs again, with the change in it
     const runs = await project.untilRuns(2);
     assertArrayEquals([...runs], ["first", "second"]);
-
-    supervisor.interrupt();
-    await running;
   });
 
   it("makes one restart out of a burst of saves", async () => {
@@ -44,7 +47,7 @@ describe("yulin watch over a real process", () => {
     await project.write("dev.mjs", watchChildScript(project.runsLogPath()));
     const supervisor = supervise(project);
     await project.settled();
-    const running = supervisor.run();
+    runSupervisor(supervisor);
     await project.untilRuns(1);
 
     // When several writes land in quick succession, as one save does
@@ -57,9 +60,6 @@ describe("yulin watch over a real process", () => {
     assertArrayEquals([...runs], ["first", "last"]);
     await watchPause(400);
     assertArrayLength(await project.runs(), 2);
-
-    supervisor.interrupt();
-    await running;
   });
 
   it("watches a directory the process reported", async () => {
@@ -72,7 +72,7 @@ describe("yulin watch over a real process", () => {
     );
     const supervisor = supervise(project);
     await project.settled();
-    const running = supervisor.run();
+    runSupervisor(supervisor);
     await project.untilRuns(1);
     await watchPause(200);
 
@@ -81,9 +81,6 @@ describe("yulin watch over a real process", () => {
 
     // Then the process runs again, without the directory having been listed
     await project.untilRuns(2);
-
-    supervisor.interrupt();
-    await running;
   });
 });
 

--- a/src/cli/watch/sim-watch-supervisor.ts
+++ b/src/cli/watch/sim-watch-supervisor.ts
@@ -1,0 +1,132 @@
+import type { SimWatchArguments } from "./sim-watch-arguments.js";
+import { SimWatchChild } from "./sim-watch-child.js";
+import { SimWatchChildEnvironment } from "./sim-watch-child-environment.js";
+import { SimWatchLoopGuard } from "./sim-watch-loop-guard.js";
+import { SimWatchReporter } from "./sim-watch-reporter.js";
+import { SimWatchRestarts } from "./sim-watch-restarts.js";
+import { SimWatchWatcher } from "./sim-watch-watcher.js";
+
+interface SimWatchSupervisorProperties {
+  readonly watchArguments: SimWatchArguments;
+  readonly cwd?: string;
+  readonly reporter?: SimWatchReporter;
+}
+
+/**
+ * Runs a command, and runs it again when something changes.
+ *
+ * The supervisor is a separate process from the one being restarted, and has to
+ * be. A process that respawned itself would leave the shell's job pointing at
+ * the process that exited, so the prompt would come back while an orphan held
+ * the terminal, and Ctrl-C would stop meaning anything.
+ */
+export class SimWatchSupervisor {
+  private readonly watchArguments: SimWatchArguments;
+  private readonly cwd: string;
+  private readonly reporter: SimWatchReporter;
+  private readonly watcher: SimWatchWatcher;
+  private readonly restarts: SimWatchRestarts;
+  private readonly loopGuard = new SimWatchLoopGuard();
+  private child: SimWatchChild | undefined;
+  private stop: ((exitCode: number) => void) | undefined;
+
+  private readonly onReportedPath = (reportedPath: string): void => {
+    this.watcher.addReported(reportedPath);
+  };
+
+  /**
+   * A process that stopped on its own is a setup that threw, or a script that
+   * ran to the end. Either way the watching goes on, so the next save tries
+   * again without the watch having to be started over.
+   */
+  private readonly onChildExit = (
+    code: number | null,
+    signal: NodeJS.Signals | null,
+  ): void => {
+    this.reporter.exited(code, signal);
+  };
+
+  constructor(properties: SimWatchSupervisorProperties) {
+    const {
+      watchArguments,
+      cwd = process.cwd(),
+      reporter = new SimWatchReporter({ cwd }),
+    } = properties;
+    this.watchArguments = watchArguments;
+    this.cwd = cwd;
+    this.reporter = reporter;
+    this.restarts = new SimWatchRestarts({
+      restart: async (changedPath: string): Promise<void> => {
+        await this.restart(changedPath);
+      },
+      onFailure: (error: unknown): void => {
+        this.fail(error);
+      },
+    });
+    this.watcher = new SimWatchWatcher({
+      cwd,
+      onChange: (changedPath: string): void => {
+        this.restarts.request(changedPath);
+      },
+    });
+  }
+
+  /**
+   * Watch until something stops the watching, and report how it ended.
+   */
+  async run(): Promise<number> {
+    this.reporter.started(this.watchArguments.describe());
+    this.watcher.start();
+    await this.start();
+
+    const exitCode = await new Promise<number>((resolve) => {
+      this.stop = resolve;
+    });
+
+    this.watcher.stop();
+    await this.child?.stop();
+
+    return exitCode;
+  }
+
+  /**
+   * Stop watching, for a supervisor that has been interrupted.
+   */
+  interrupt(): void {
+    this.stop?.(0);
+  }
+
+  private async start(): Promise<void> {
+    const child = new SimWatchChild({
+      command: this.watchArguments.command,
+      args: this.watchArguments.commandArguments,
+      cwd: this.cwd,
+      env: new SimWatchChildEnvironment({
+        cwd: this.cwd,
+        inspect: this.watchArguments.inspect,
+      }).build(),
+      onPath: this.onReportedPath,
+      onExit: this.onChildExit,
+    });
+
+    this.child = child;
+    await child.started();
+  }
+
+  private async restart(changedPath: string): Promise<void> {
+    const startedAt = Date.now();
+    this.loopGuard.check(changedPath, this.child?.ranForMs() ?? 0);
+
+    await this.child?.stop();
+    await this.start();
+
+    this.reporter.restarted(changedPath, Date.now() - startedAt);
+  }
+
+  private fail(error: unknown): void {
+    this.reporter.failed(
+      error instanceof Error ? error : new Error(String(error)),
+    );
+    this.stop?.(1);
+  }
+}

--- a/src/cli/watch/sim-watch-supervisor.ts
+++ b/src/cli/watch/sim-watch-supervisor.ts
@@ -77,16 +77,23 @@ export class SimWatchSupervisor {
   async run(): Promise<number> {
     this.reporter.started(this.watchArguments.describe());
     this.watcher.start();
-    await this.start();
 
-    const exitCode = await new Promise<number>((resolve) => {
+    // Taken before the first start, so an interrupt during startup is heard,
+    // and released in `finally`, so a command that could not be run at all
+    // leaves nothing watching. Open watchers would keep the process alive after
+    // the error had been reported, which reads as a hang rather than a mistake.
+    const stopped = new Promise<number>((resolve) => {
       this.stop = resolve;
     });
 
-    this.watcher.stop();
-    await this.child?.stop();
+    try {
+      await this.start();
 
-    return exitCode;
+      return await stopped;
+    } finally {
+      this.watcher.stop();
+      await this.child?.stop();
+    }
   }
 
   /**
@@ -109,8 +116,11 @@ export class SimWatchSupervisor {
       onExit: this.onChildExit,
     });
 
-    this.child = child;
+    // Kept only once it is running. A command that could not be run has no
+    // process to stop, and waiting for one to exit that never started is a wait
+    // that never ends.
     await child.started();
+    this.child = child;
   }
 
   private async restart(changedPath: string): Promise<void> {

--- a/src/cli/watch/sim-watch-watcher.loc.test.ts
+++ b/src/cli/watch/sim-watch-watcher.loc.test.ts
@@ -1,0 +1,175 @@
+import path from "node:path";
+import {
+  assertArrayEquals,
+  assertStringEndsWith,
+  assertStringStartsWith,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimWatchWatcher } from "./sim-watch-watcher.js";
+import { TemporaryDirectory } from "../../util/filesystem/temporary-directory.js";
+import { watchPause } from "../../../test/cli/watch-project.js";
+
+describe("SimWatchWatcher over a real directory", () => {
+  it("reports a file saved in the working directory", async () => {
+    // Given a watched working directory
+    const { directory, changes, watcher } = await watching();
+
+    try {
+      // When a file in it is saved
+      await directory.writeFile("handler.ts", "export const a = 1;");
+      await watchPause(400);
+
+      // Then the change is reported, by name
+      assertStringEndsWith(changes.at(0) ?? "", "handler.ts");
+    } finally {
+      watcher.stop();
+    }
+  });
+
+  it("passes over a file nothing edits by hand", async () => {
+    // Given a watched working directory
+    const { directory, changes, watcher } = await watching();
+
+    try {
+      // When something writes into a directory the rules skip
+      await directory.writeFile(["node_modules", "left", "index.js"], "1;");
+      await watchPause(400);
+
+      // Then nothing is restarted for it
+      assertArrayEquals(changes, []);
+    } finally {
+      watcher.stop();
+    }
+  });
+
+  it("watches a reported directory outside the working directory", async () => {
+    // Given a directory the supervised process named
+    const { changes, watcher } = await watching();
+    const mounted = new TemporaryDirectory();
+    await mounted.resolvePath();
+    await mounted.writeFile("logo.svg", "<svg></svg>");
+    watcher.addReported(mounted.path());
+    await watchPause(200);
+
+    try {
+      // When a file in it changes
+      await mounted.writeFile("logo.svg", "<svg><g /></svg>");
+      await watchPause(400);
+
+      // Then it is watched, without having been listed anywhere
+      assertStringStartsWith(changes.at(0) ?? "", mounted.path());
+    } finally {
+      watcher.stop();
+    }
+  });
+
+  it("watches a reported file outside the working directory", async () => {
+    // Given a synthesized template the supervised process deployed
+    const { changes, watcher } = await watching();
+    const synth = new TemporaryDirectory();
+    await synth.resolvePath();
+    await synth.writeFile("Stack.template.json", "{}");
+    watcher.addReported(synth.join("Stack.template.json"));
+    await watchPause(200);
+
+    try {
+      // When it is synthesized again
+      await synth.writeFile("Stack.template.json", '{"Resources":{}}');
+      await watchPause(400);
+
+      // Then the stack it deploys is known to have changed
+      assertStringEndsWith(changes.at(0) ?? "", "Stack.template.json");
+    } finally {
+      watcher.stop();
+    }
+  });
+
+  it("watches a reported path the rules would otherwise skip", async () => {
+    // Given a directory inside the working directory that watch normally skips
+    const { directory, changes, watcher } = await watching();
+    const mountedPath = directory.join("dist", "site");
+    await directory.writeFile(["dist", "site", "index.html"], "<h1>a</h1>");
+    watcher.addReported(mountedPath);
+    await watchPause(200);
+
+    try {
+      // When the supervised process reported it and a file in it changes
+      await directory.writeFile(["dist", "site", "index.html"], "<h1>b</h1>");
+      await watchPause(400);
+
+      // Then being told about it beats a default list of directories to skip
+      assertStringStartsWith(changes.at(0) ?? "", mountedPath);
+    } finally {
+      watcher.stop();
+    }
+  });
+
+  it("takes no notice of a path reported twice", async () => {
+    // Given a reported directory
+    const { watcher } = await watching();
+    const mounted = new TemporaryDirectory();
+    await mounted.resolvePath();
+
+    try {
+      // When the same path is reported again, as a second deploy does
+      watcher.addReported(mounted.path());
+      watcher.addReported(mounted.path());
+
+      // Then nothing is watched twice, and nothing throws
+    } finally {
+      watcher.stop();
+    }
+  });
+
+  it("takes no notice of a reported path that is not there", async () => {
+    // Given a path the process named before anything wrote it
+    const { watcher } = await watching();
+
+    try {
+      // When it is reported
+      watcher.addReported(path.resolve("/nowhere/at/all"));
+
+      // Then there is nothing to watch, and nothing throws
+    } finally {
+      watcher.stop();
+    }
+  });
+
+  it("stops reporting once it has been stopped", async () => {
+    // Given a watched working directory
+    const { directory, changes, watcher } = await watching();
+    watcher.stop();
+
+    // When a file changes afterwards
+    await directory.writeFile("handler.ts", "export const a = 1;");
+    await watchPause(400);
+
+    // Then nothing is reported to a supervisor that has finished
+    assertArrayEquals(changes, []);
+  });
+});
+
+interface Watching {
+  readonly directory: TemporaryDirectory;
+  readonly changes: string[];
+  readonly watcher: SimWatchWatcher;
+}
+
+async function watching(): Promise<Watching> {
+  const directory = new TemporaryDirectory();
+  await directory.resolvePath();
+
+  const changes: string[] = [];
+  const watcher = new SimWatchWatcher({
+    cwd: directory.path(),
+    onChange: (changedPath: string): void => {
+      changes.push(changedPath);
+    },
+    settleMs: 30,
+  });
+
+  watcher.start();
+  await watchPause(200);
+
+  return { directory, changes, watcher };
+}

--- a/src/cli/watch/sim-watch-watcher.ts
+++ b/src/cli/watch/sim-watch-watcher.ts
@@ -1,0 +1,146 @@
+import fs, { type FSWatcher } from "node:fs";
+import path from "node:path";
+import { simWatchConfig } from "../../watch/sim-watch.config.js";
+import { SimWatchEventPath } from "./sim-watch-event-path.js";
+import { SimWatchIgnore } from "./sim-watch-ignore.js";
+import { SimWatchSettle } from "./sim-watch-settle.js";
+
+interface SimWatchWatcherProperties {
+  readonly cwd: string;
+  readonly onChange: (changedPath: string) => void;
+  readonly settleMs?: number;
+}
+
+/**
+ * Watches the working directory, and whatever else the process says it is
+ * reading.
+ *
+ * The working directory is watched whole and filtered down, rather than a list
+ * of interesting paths being assembled up front, because the interesting paths
+ * are whatever the project happens to import. What the process reports on top
+ * of that is the paths Yulin holds but Node's module graph never mentions: a
+ * directory mounted into a Bucket, and a synthesized template.
+ *
+ * A reported path is watched whether or not the ignore rules would have passed
+ * over it. Being told about a path is more specific than a default list of
+ * directories worth skipping.
+ */
+export class SimWatchWatcher {
+  private readonly cwd: string;
+  private readonly ignore = new SimWatchIgnore();
+  private readonly settle: SimWatchSettle;
+  private readonly watchers = new Map<string, FSWatcher>();
+  private readonly reportedRoots = new Set<string>();
+
+  constructor(properties: SimWatchWatcherProperties) {
+    const { cwd, onChange, settleMs = simWatchConfig.settleMs } = properties;
+    this.cwd = path.resolve(cwd);
+    this.settle = new SimWatchSettle({ settleMs, onSettled: onChange });
+  }
+
+  /**
+   * Start watching the working directory.
+   */
+  start(): void {
+    this.watch(this.cwd, true);
+  }
+
+  /**
+   * Also watch a path the supervised process reported.
+   *
+   * A path inside the working directory is already covered by the recursive
+   * watch, so it only needs recording as reported. One outside needs a watcher
+   * of its own.
+   */
+  addReported(reportedPath: string): void {
+    const resolved = path.resolve(reportedPath);
+
+    if (this.reportedRoots.has(resolved)) {
+      return;
+    }
+
+    this.reportedRoots.add(resolved);
+
+    if (this.within(this.cwd, resolved)) {
+      return;
+    }
+
+    this.watch(resolved, isDirectory(resolved));
+  }
+
+  /**
+   * Stop watching and drop any change that was still settling.
+   */
+  stop(): void {
+    this.settle.cancel();
+
+    for (const watcher of this.watchers.values()) {
+      watcher.close();
+    }
+
+    this.watchers.clear();
+  }
+
+  private watch(target: string, recursive: boolean): void {
+    // eslint-disable-next-line security/detect-non-literal-fs-filename
+    if (this.watchers.has(target) || !fs.existsSync(target)) {
+      return;
+    }
+
+    const eventPath = new SimWatchEventPath(target, recursive);
+
+    // eslint-disable-next-line security/detect-non-literal-fs-filename
+    const watcher = fs.watch(target, { recursive }, (_event, fileName) => {
+      const changedPath = eventPath.of(fileName);
+
+      if (changedPath !== undefined) {
+        this.changed(changedPath);
+      }
+    });
+
+    // A watched path can be deleted or replaced. Nothing useful can be done
+    // about that from here, and a watcher with no error listener throws.
+    /* v8 ignore next 4 -- raised where the platform reports a watch going away,
+     * which macOS does not do for a deleted directory, so nothing here can make
+     * it happen on the machine this suite runs on. */
+    watcher.on("error", () => {
+      watcher.close();
+      this.watchers.delete(target);
+    });
+
+    this.watchers.set(target, watcher);
+  }
+
+  private changed(changedPath: string): void {
+    if (this.ignored(changedPath)) {
+      return;
+    }
+
+    this.settle.record(changedPath);
+  }
+
+  private ignored(changedPath: string): boolean {
+    for (const root of this.reportedRoots) {
+      if (root === changedPath || this.within(root, changedPath)) {
+        return false;
+      }
+    }
+
+    return this.ignore.ignores(path.relative(this.cwd, changedPath));
+  }
+
+  private within(root: string, target: string): boolean {
+    const relative = path.relative(root, target);
+
+    return (
+      relative.length > 0 &&
+      !relative.startsWith("..") &&
+      !path.isAbsolute(relative)
+    );
+  }
+}
+
+function isDirectory(target: string): boolean {
+  // eslint-disable-next-line security/detect-non-literal-fs-filename
+  return fs.statSync(target, { throwIfNoEntry: false })?.isDirectory() === true;
+}

--- a/src/cli/yulin.loc.test.ts
+++ b/src/cli/yulin.loc.test.ts
@@ -1,0 +1,57 @@
+import { execFile } from "node:child_process";
+import path from "node:path";
+import { promisify } from "node:util";
+import { assertIdentical, assertStringIncludes } from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { repoPath } from "../util/filesystem/path.js";
+
+const runFile = promisify(execFile);
+const binPath = path.join(repoPath(), "src", "cli", "yulin.ts");
+
+/**
+ * The `yulin` command as a command, run the way a shell runs it. Everything it
+ * decides is covered elsewhere; this is that the entry point itself works.
+ */
+describe("yulin command line", () => {
+  it("lists what it can do", async () => {
+    // Given the command run with no arguments
+    // When it is asked for help
+    const { stdout } = await runFile("pnpm", ["tsx", binPath, "--help"], {
+      cwd: repoPath(),
+    });
+
+    // Then the commands are listed
+    assertStringIncludes(stdout, "watch [--inspect");
+  });
+
+  it("reports a command it does not have", async () => {
+    // Given a command that does not exist
+    // When it is run
+    const failure = await commandFailure(["deploy"]);
+
+    // Then it says so on standard error, and exits non-zero
+    assertIdentical(failure.code, 1);
+    assertStringIncludes(failure.stderr, "Unknown command deploy.");
+  });
+});
+
+interface CommandFailure {
+  readonly code: number;
+  readonly stderr: string;
+}
+
+async function commandFailure(
+  commandArguments: readonly string[],
+): Promise<CommandFailure> {
+  try {
+    await runFile("pnpm", ["tsx", binPath, ...commandArguments], {
+      cwd: repoPath(),
+    });
+  } catch (error) {
+    const failed = error as { code?: number; stderr?: string };
+
+    return { code: failed.code ?? 0, stderr: failed.stderr ?? "" };
+  }
+
+  throw new Error("Expected the command to fail");
+}

--- a/src/cli/yulin.loc.test.ts
+++ b/src/cli/yulin.loc.test.ts
@@ -24,6 +24,22 @@ describe("yulin command line", () => {
     assertStringIncludes(stdout, "watch [--inspect");
   });
 
+  it("stops when the command to watch cannot be run", async () => {
+    // Given a watch of a command that is not there, which is what a typo looks
+    // like on the first run
+    // When it is run
+    const failure = await commandFailure([
+      "watch",
+      "--",
+      "definitely-not-a-command",
+    ]);
+
+    // Then it says so and exits, rather than sitting there watching for a
+    // change with nothing to run when one arrives
+    assertIdentical(failure.code, 1);
+    assertStringIncludes(failure.stderr, "definitely-not-a-command");
+  });
+
   it("reports a command it does not have", async () => {
     // Given a command that does not exist
     // When it is run
@@ -44,11 +60,22 @@ async function commandFailure(
   commandArguments: readonly string[],
 ): Promise<CommandFailure> {
   try {
+    // The timeout is what tells a command that reported an error and exited
+    // apart from one that reported it and then sat there.
     await runFile("pnpm", ["tsx", binPath, ...commandArguments], {
       cwd: repoPath(),
+      timeout: 15_000,
     });
   } catch (error) {
-    const failed = error as { code?: number; stderr?: string };
+    const failed = error as {
+      code?: number;
+      stderr?: string;
+      killed?: boolean;
+    };
+
+    if (failed.killed === true) {
+      throw new Error("The command did not exit on its own", { cause: error });
+    }
 
     return { code: failed.code ?? 0, stderr: failed.stderr ?? "" };
   }

--- a/src/cli/yulin.ts
+++ b/src/cli/yulin.ts
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+
+/* v8 ignore start -- the entry point runs as its own process, so coverage of
+ * this repository's test run never sees it. What it does is covered through
+ * `SimCli`, and that it works as a command is covered by running it. */
+
+import { SimCli } from "./sim-cli.js";
+
+try {
+  process.exitCode = await new SimCli().run(process.argv.slice(2));
+} catch (error) {
+  process.stderr.write(
+    `${error instanceof Error ? error.message : String(error)}\n`,
+  );
+  process.exitCode = 1;
+}
+
+/* v8 ignore stop */

--- a/src/serve/http/live-reload/sim-local-live-reload.iso.test.ts
+++ b/src/serve/http/live-reload/sim-local-live-reload.iso.test.ts
@@ -1,0 +1,123 @@
+import type { ServerResponse } from "node:http";
+import {
+  assertStringIncludes,
+  assertThrowsError,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it, vi } from "vitest";
+import { SimLocalLiveReload } from "./sim-local-live-reload.js";
+import { simWatchMessages } from "../../../watch/sim-watch.config.js";
+import { SimWatchRuntime } from "../../../watch/sim-watch-runtime.js";
+import { FakeProcess } from "../../../../test/watch/fake-process.js";
+
+describe("SimLocalLiveReload", () => {
+  it("has no channel when live reload is off", () => {
+    // Given a server serving without live reload
+    const liveReload = new SimLocalLiveReload({ enabled: false });
+
+    // When the request handler asks for the channel
+    const channel = liveReload.channel();
+
+    // Then there is nothing to inject into responses with
+    assertUndefined(channel);
+  });
+
+  it("says nothing on startup when live reload is off", () => {
+    // Given a server serving without live reload
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const liveReload = new SimLocalLiveReload({ enabled: false });
+
+    // When it starts listening
+    liveReload.serving("8787");
+
+    // Then the terminal is left alone, since nothing has changed
+    assertUndefined(warn.mock.calls[0]);
+  });
+
+  it("refuses a reload when live reload is off", () => {
+    // Given a server serving without live reload
+    const liveReload = new SimLocalLiveReload({ enabled: false });
+
+    // When a reload is asked for anyway
+    const error = assertThrowsError(() => {
+      liveReload.reload();
+    });
+
+    // Then it says what to turn on
+    assertStringIncludes(error.message, "{ liveReload: true }");
+  });
+
+  it("warns connected browsers when a supervisor is about to restart", () => {
+    // Given a served page under a `yulin watch` supervisor
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const host = new FakeProcess();
+    const liveReload = new SimLocalLiveReload({
+      enabled: true,
+      watch: new SimWatchRuntime({ host }),
+    });
+    liveReload.serving("8787");
+    const page = new FakeServerResponse();
+    liveReload.channel()?.connect(page.asNodeResponse());
+
+    // When the supervisor says the process is going
+    host.deliver({ type: simWatchMessages.stopping });
+
+    // Then the page hears that a reload is coming, rather than only losing its
+    // connection when the process is killed
+    assertStringIncludes(page.written(), "event: reloading");
+  });
+
+  it("stops listening for a supervisor once the server has closed", () => {
+    // Given a served page under a supervisor, whose server then closed
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const host = new FakeProcess();
+    const liveReload = new SimLocalLiveReload({
+      enabled: true,
+      watch: new SimWatchRuntime({ host }),
+    });
+    liveReload.serving("8787");
+    liveReload.stopping();
+
+    // When the supervisor says the process is going
+    const before = host.sent.length;
+    host.deliver({ type: simWatchMessages.stopping });
+
+    // Then nothing is left holding a reference to a closed server
+    assertUndefined(host.sent.at(before));
+  });
+});
+
+/**
+ * Just enough of a Node response for the channel to write events to.
+ */
+class FakeServerResponse {
+  writableEnded = false;
+
+  private readonly chunks: string[] = [];
+
+  writeHead(): this {
+    return this;
+  }
+
+  write(chunk: string): boolean {
+    this.chunks.push(chunk);
+
+    return true;
+  }
+
+  end(): void {
+    this.writableEnded = true;
+  }
+
+  on(): this {
+    return this;
+  }
+
+  written(): string {
+    return this.chunks.join("");
+  }
+
+  asNodeResponse(): ServerResponse {
+    return this as unknown as ServerResponse;
+  }
+}

--- a/src/serve/http/live-reload/sim-local-live-reload.iso.test.ts
+++ b/src/serve/http/live-reload/sim-local-live-reload.iso.test.ts
@@ -1,5 +1,6 @@
 import type { ServerResponse } from "node:http";
 import {
+  assertIdentical,
   assertStringIncludes,
   assertThrowsError,
   assertUndefined,
@@ -68,7 +69,7 @@ describe("SimLocalLiveReload", () => {
   });
 
   it("stops listening for a supervisor once the server has closed", () => {
-    // Given a served page under a supervisor, whose server then closed
+    // Given a page that was connected to a server which has since closed
     vi.spyOn(console, "warn").mockImplementation(() => undefined);
     const host = new FakeProcess();
     const liveReload = new SimLocalLiveReload({
@@ -76,14 +77,19 @@ describe("SimLocalLiveReload", () => {
       watch: new SimWatchRuntime({ host }),
     });
     liveReload.serving("8787");
+    const page = new FakeServerResponse();
+    liveReload.channel()?.connect(page.asNodeResponse());
     liveReload.stopping();
+    const afterClosing = page.written();
+    const before = host.sent.length;
 
     // When the supervisor says the process is going
-    const before = host.sent.length;
     host.deliver({ type: simWatchMessages.stopping });
 
-    // Then nothing is left holding a reference to a closed server
+    // Then nothing is left holding a reference to a closed server, and the
+    // page it was serving is written to no further
     assertUndefined(host.sent.at(before));
+    assertIdentical(page.written(), afterClosing);
   });
 });
 

--- a/src/serve/http/live-reload/sim-local-live-reload.ts
+++ b/src/serve/http/live-reload/sim-local-live-reload.ts
@@ -1,0 +1,78 @@
+import { SimLiveReload } from "./sim-live-reload.js";
+import { SimLiveReloadReport } from "./sim-live-reload-report.js";
+import {
+  simWatch,
+  type SimWatchRuntime,
+} from "../../../watch/sim-watch-runtime.js";
+
+interface SimLocalLiveReloadProperties {
+  readonly enabled: boolean;
+  readonly watch?: SimWatchRuntime;
+}
+
+/**
+ * Live reload as the local server has to hold it: on or off, and wired into the
+ * server's own lifecycle either way.
+ *
+ * Keeping it here leaves `SimAwsLocalServer` with sockets and ports, which is
+ * enough for one class, and puts the three things that only matter together in
+ * one place: whether it is on, the notice given on startup, and the warning
+ * from a `yulin watch` supervisor that the process is about to be replaced.
+ */
+export class SimLocalLiveReload {
+  private readonly liveReload: SimLiveReload | undefined;
+  private readonly watch: SimWatchRuntime;
+
+  private readonly onSupervisorStopping = (): void => {
+    this.liveReload?.stopping();
+  };
+
+  constructor(properties: SimLocalLiveReloadProperties) {
+    const { enabled, watch = simWatch } = properties;
+    this.liveReload = enabled ? new SimLiveReload() : undefined;
+    this.watch = watch;
+  }
+
+  /**
+   * The channel to hand to the request handler, if there is one.
+   */
+  channel(): SimLiveReload | undefined {
+    return this.liveReload;
+  }
+
+  /**
+   * Say live reload is on, and start listening for a supervised restart.
+   *
+   * Under `yulin watch` the process is killed rather than asked to close, so
+   * this is where a served page finds out a restart is coming.
+   */
+  serving(port: string): void {
+    if (this.liveReload === undefined) {
+      return;
+    }
+
+    new SimLiveReloadReport().announce(port);
+    this.watch.onStopping(this.onSupervisorStopping);
+  }
+
+  /**
+   * Tell connected browsers a reload is coming, and stop listening.
+   */
+  stopping(): void {
+    this.watch.offStopping(this.onSupervisorStopping);
+    this.liveReload?.stopping();
+  }
+
+  /**
+   * Reload connected browsers now.
+   */
+  reload(): void {
+    if (this.liveReload === undefined) {
+      throw new Error(
+        "Live reload is off for this server, serve with { liveReload: true } to use reload()",
+      );
+    }
+
+    this.liveReload.reload();
+  }
+}

--- a/src/serve/http/local-server/node-server-port.ts
+++ b/src/serve/http/local-server/node-server-port.ts
@@ -1,0 +1,23 @@
+import type { Server } from "node:http";
+
+/**
+ * Read the TCP port a Node server took.
+ *
+ * A server that has not started listening has no port, and one listening on a
+ * Unix socket has an address that is not a port at all. Neither is a number to
+ * return, so both are refused rather than guessed at.
+ */
+export function nodeServerPort(server: Server): string {
+  if (!server.listening) {
+    throw new Error("Server is not yet listening, cannot get port number");
+  }
+
+  const address = server.address();
+
+  /* v8 ignore if -- does not happen in practice */
+  if (address === null || typeof address === "string") {
+    throw new Error("Expected local HTTP server to listen on a TCP port");
+  }
+
+  return String(address.port);
+}

--- a/src/serve/http/local-server/sim-aws-local-server.ts
+++ b/src/serve/http/local-server/sim-aws-local-server.ts
@@ -4,10 +4,10 @@ import { simAwsLocalConfig } from "./sim-aws-local.config.js";
 import { SimAwsHttp } from "../sim-aws-http.js";
 import { SimAwsLocalUrl } from "../url/sim-aws-local-url.js";
 import { NodeServerPortBinder } from "./node-server-port-binder.js";
+import { nodeServerPort } from "./node-server-port.js";
 import { SimAwsLocalRequestHandler } from "./sim-aws-local-request-handler.js";
 import { SimAwsDnsServer } from "../../dns/sim-aws-dns-server.js";
-import { SimLiveReload } from "../live-reload/sim-live-reload.js";
-import { SimLiveReloadReport } from "../live-reload/sim-live-reload-report.js";
+import { SimLocalLiveReload } from "../live-reload/sim-local-live-reload.js";
 
 interface SimAwsLocalServerProperties {
   readonly simAws?: SimAws;
@@ -23,14 +23,15 @@ export class SimAwsLocalServer {
   private readonly server: Server;
   private readonly portBinder: NodeServerPortBinder;
   private readonly dnsServer: SimAwsDnsServer;
-  private readonly liveReload: SimLiveReload | undefined;
+  private readonly liveReload: SimLocalLiveReload;
 
   constructor(properties: SimAwsLocalServerProperties = {}) {
     const { simAws = new SimAws(), liveReload = false } = properties;
-    this.liveReload = liveReload ? new SimLiveReload() : undefined;
+    this.liveReload = new SimLocalLiveReload({ enabled: liveReload });
+    const channel = this.liveReload.channel();
     this.requestHandler = new SimAwsLocalRequestHandler({
       simAwsHttp: new SimAwsHttp({ simAws }),
-      ...(this.liveReload !== undefined && { liveReload: this.liveReload }),
+      ...(channel !== undefined && { liveReload: channel }),
     });
     this.dnsServer = new SimAwsDnsServer({ simAws });
     this.server = http.createServer((request, response) => {
@@ -60,9 +61,7 @@ export class SimAwsLocalServer {
     await this.portBinder.bind(port);
     await this.dnsServer.listen(Number(this.port));
 
-    if (this.liveReload !== undefined) {
-      new SimLiveReloadReport().announce(this.port);
-    }
+    this.liveReload.serving(this.port);
 
     return this;
   }
@@ -78,17 +77,7 @@ export class SimAwsLocalServer {
    * Get the TCP port on which this local server is listening.
    */
   get port(): string {
-    if (!this.server.listening) {
-      throw new Error("Server is not yet listening, cannot get port number");
-    }
-
-    const address = this.server.address();
-    /* v8 ignore if -- does not happen in practice */
-    if (address === null || typeof address === "string") {
-      throw new Error("Expected local HTTP server to listen on a TCP port");
-    }
-
-    return String(address.port);
+    return nodeServerPort(this.server);
   }
 
   /**
@@ -114,7 +103,7 @@ export class SimAwsLocalServer {
    * the open ones are being ended.
    */
   close(): void {
-    this.liveReload?.stopping();
+    this.liveReload.stopping();
     this.server.close();
     this.server.closeAllConnections();
     this.dnsServer.close();
@@ -128,12 +117,6 @@ export class SimAwsLocalServer {
    * to restart, and the pages reload themselves when it comes back.
    */
   reload(): void {
-    if (this.liveReload === undefined) {
-      throw new Error(
-        "Live reload is off for this server, serve with { liveReload: true } to use reload()",
-      );
-    }
-
     this.liveReload.reload();
   }
 

--- a/src/service/cloudformation/deploy/sim-cfn-template-file-loader.ts
+++ b/src/service/cloudformation/deploy/sim-cfn-template-file-loader.ts
@@ -8,6 +8,7 @@ import {
   type SimCdkOutContext,
 } from "../cdk/sim-cdk-out-context.js";
 import type { SimCfnExecutableResourceBinding } from "../bind/sim-cfn-exec-binding.type.js";
+import { simWatch } from "../../../watch/sim-watch-runtime.js";
 
 export interface SimCloudFormationDeployTemplateFileProperties {
   readonly templatePath: string;
@@ -46,6 +47,11 @@ export class SimCfnTemplateFileLoader {
       typeof properties === "string"
         ? stackNameFromTemplatePath(templatePath)
         : (properties.stackName ?? stackNameFromTemplatePath(templatePath));
+
+    // The template is named to a `yulin watch` supervisor, so re-synthing a
+    // stack restarts the process that deployed it. Nothing happens outside
+    // watch mode.
+    simWatch.reportPath(templatePath);
 
     // eslint-disable-next-line security/detect-non-literal-fs-filename
     const templateBody = await readFile(templatePath, "utf8");

--- a/src/service/s3/bucket/sim-s3-bucket-access.ts
+++ b/src/service/s3/bucket/sim-s3-bucket-access.ts
@@ -3,6 +3,7 @@ import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-
 import { FilesystemS3BucketStorage } from "../storage/filesystem/s3-filesystem-storage.js";
 import { simS3BucketUrl } from "./sim-s3-endpoint-url.js";
 import type { SimS3Bucket, SimS3BucketName } from "./sim-s3-bucket.js";
+import { simWatch } from "../../../watch/sim-watch-runtime.js";
 
 interface SimS3BucketAccessProperties {
   readonly buckets: ReadonlyMap<SimS3BucketName, SimS3Bucket>;
@@ -55,6 +56,10 @@ export class SimS3BucketAccess {
 
   /**
    * Have a Bucket use a local filesystem directory for storage.
+   *
+   * The directory is named to a `yulin watch` supervisor, so editing a file the
+   * Bucket serves restarts the process without the directory having been listed
+   * anywhere. Nothing happens outside watch mode.
    */
   mountFilesystem(
     bucketName: SimS3BucketName | string,
@@ -63,5 +68,6 @@ export class SimS3BucketAccess {
     this.required(bucketName).configureSimStorage(
       new FilesystemS3BucketStorage({ directoryPath }),
     );
+    simWatch.reportPath(directoryPath);
   }
 }

--- a/src/watch/sim-watch-runtime.iso.test.ts
+++ b/src/watch/sim-watch-runtime.iso.test.ts
@@ -1,0 +1,133 @@
+import {
+  assertArrayEquals,
+  assertArrayLength,
+  assertFalse,
+  assertIdentical,
+  assertStringEndsWith,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimWatchRuntime } from "./sim-watch-runtime.js";
+import { simWatchMessages } from "./sim-watch.config.js";
+import { FakeProcess } from "../../test/watch/fake-process.js";
+
+describe("SimWatchRuntime", () => {
+  it("does nothing in a process no supervisor started", () => {
+    // Given an ordinary process, such as a test run
+    const host = new FakeProcess({ supervised: false });
+    const runtime = new SimWatchRuntime({ host });
+
+    // When a path is reported
+    runtime.reportPath("/projects/media/assets");
+
+    // Then nothing is sent anywhere
+    assertFalse(runtime.supervised());
+    assertArrayEquals(host.sent, []);
+  });
+
+  it("does nothing in a supervised process with no channel", () => {
+    // Given the marker set but no way to answer, as an inherited environment
+    // in an unrelated process would look
+    const host = new FakeProcess({ supervised: true, connected: false });
+    const runtime = new SimWatchRuntime({ host });
+
+    // When a path is reported
+    runtime.reportPath("/projects/media/assets");
+
+    // Then it is dropped rather than assumed to have gone somewhere
+    assertFalse(runtime.supervised());
+  });
+
+  it("names a path to the supervisor that started it", () => {
+    // Given a process `yulin watch` started
+    const host = new FakeProcess();
+    const runtime = new SimWatchRuntime({ host });
+
+    // When a path is reported
+    runtime.reportPath("assets/uploads");
+
+    // Then the supervisor is told, in a form it can watch
+    assertArrayLength(host.sent, 1);
+    const [reported = {}] = host.sent;
+    assertIdentical(reported["type"], simWatchMessages.path);
+    assertStringEndsWith(String(reported["path"]), "assets/uploads");
+  });
+
+  it("passes on the warning that a restart is coming", () => {
+    // Given a supervised process listening for a restart
+    const host = new FakeProcess();
+    const runtime = new SimWatchRuntime({ host });
+    let warned = 0;
+    runtime.onStopping(() => {
+      warned += 1;
+    });
+
+    // When the supervisor says it is about to restart this process
+    host.deliver({ type: simWatchMessages.stopping });
+
+    // Then the listener runs, and the supervisor is told it can go ahead
+    assertIdentical(warned, 1);
+    assertIdentical(host.sent.at(-1)?.["type"], simWatchMessages.stopped);
+  });
+
+  it("ignores a message that is not the warning", () => {
+    // Given a supervised process listening for a restart
+    const host = new FakeProcess();
+    const runtime = new SimWatchRuntime({ host });
+    let warned = 0;
+    runtime.onStopping(() => {
+      warned += 1;
+    });
+
+    // When some other message arrives
+    host.deliver({ type: "something-else" });
+
+    // Then nothing is done about it
+    assertIdentical(warned, 0);
+  });
+
+  it("listens once however many servers are interested", () => {
+    // Given two served environments in the same process
+    const host = new FakeProcess();
+    const runtime = new SimWatchRuntime({ host });
+    const first = (): void => undefined;
+    const second = (): void => undefined;
+
+    // When both ask to hear about a restart
+    runtime.onStopping(first);
+    runtime.onStopping(second);
+
+    // Then the process is listened to once
+    assertArrayLength(host.listeners, 1);
+  });
+
+  it("stops listening once nothing is interested", () => {
+    // Given a listener that has been removed again, as a closed server does
+    const host = new FakeProcess();
+    const runtime = new SimWatchRuntime({ host });
+    let warned = 0;
+    const listener = (): void => {
+      warned += 1;
+    };
+    runtime.onStopping(listener);
+    runtime.offStopping(listener);
+
+    // When the supervisor says it is about to restart this process
+    host.deliver({ type: simWatchMessages.stopping });
+
+    // Then nothing is left holding a reference to a closed server
+    assertIdentical(warned, 0);
+    assertArrayEquals(host.listeners, []);
+  });
+
+  it("does not listen in a process no supervisor started", () => {
+    // Given an ordinary process
+    const host = new FakeProcess({ supervised: false });
+    const runtime = new SimWatchRuntime({ host });
+
+    // When something asks to hear about a restart
+    runtime.onStopping(() => undefined);
+
+    // Then nothing is attached to a process that will never be told
+    assertArrayEquals(host.listeners, []);
+  });
+});

--- a/src/watch/sim-watch-runtime.ts
+++ b/src/watch/sim-watch-runtime.ts
@@ -1,0 +1,143 @@
+import path from "node:path";
+import { simWatchConfig, simWatchMessages } from "./sim-watch.config.js";
+
+type SimWatchStoppingListener = () => void;
+type SimWatchMessageListener = (message: unknown) => void;
+
+/**
+ * The part of the running process this needs, so a test can stand in for it
+ * without touching the process its own test runner is talking over.
+ */
+export interface SimWatchProcess {
+  readonly env: NodeJS.ProcessEnv;
+  readonly send?: ((message: unknown) => boolean) | undefined;
+  on(event: "message", listener: SimWatchMessageListener): unknown;
+  off(event: "message", listener: SimWatchMessageListener): unknown;
+}
+
+interface SimWatchRuntimeProperties {
+  readonly host?: SimWatchProcess;
+}
+
+/**
+ * The half of watch mode that lives in the supervised process.
+ *
+ * It is inert unless `yulin watch` started this process, so nothing here
+ * changes what a test run or an ordinary script does. Under a supervisor it
+ * does two things: it names the paths Yulin is reading, so the supervisor can
+ * watch them without the user listing paths Yulin is already holding, and it
+ * passes on the warning that a restart is coming, so a served page hears about
+ * it before the connection goes.
+ */
+export class SimWatchRuntime {
+  private readonly host: SimWatchProcess;
+  private readonly stoppingListeners = new Set<SimWatchStoppingListener>();
+  private listening = false;
+
+  private readonly onMessage = (message: unknown): void => {
+    if (!isStoppingMessage(message)) {
+      return;
+    }
+
+    for (const listener of this.stoppingListeners) {
+      listener();
+    }
+
+    // The supervisor waits for this before killing the process, so whatever the
+    // listeners wrote has left this end first.
+    this.host.send?.({ type: simWatchMessages.stopped });
+  };
+
+  constructor(properties: SimWatchRuntimeProperties = {}) {
+    const { host = process } = properties;
+    this.host = host;
+  }
+
+  /**
+   * Whether a `yulin watch` supervisor started this process.
+   */
+  supervised(): boolean {
+    return (
+      this.host.env[simWatchConfig.environmentVariableName] ===
+        simWatchConfig.environmentVariableValue &&
+      typeof this.host.send === "function"
+    );
+  }
+
+  /**
+   * Name a path the supervisor should watch, such as a directory mounted into a
+   * Bucket or a synthesized template being deployed.
+   *
+   * Best effort by design. Nothing depends on the message arriving, and a
+   * process with no supervisor drops it.
+   */
+  reportPath(reportedPath: string): void {
+    if (!this.supervised()) {
+      return;
+    }
+
+    this.host.send?.({
+      type: simWatchMessages.path,
+      path: path.resolve(reportedPath),
+    });
+  }
+
+  /**
+   * Run something when the supervisor says this process is about to restart.
+   */
+  onStopping(listener: SimWatchStoppingListener): void {
+    if (!this.supervised()) {
+      return;
+    }
+
+    this.stoppingListeners.add(listener);
+    this.listen();
+  }
+
+  /**
+   * Stop running something on a restart.
+   */
+  offStopping(listener: SimWatchStoppingListener): void {
+    this.stoppingListeners.delete(listener);
+
+    if (this.stoppingListeners.size === 0) {
+      this.unlisten();
+    }
+  }
+
+  private listen(): void {
+    if (this.listening) {
+      return;
+    }
+
+    this.listening = true;
+    this.host.on("message", this.onMessage);
+  }
+
+  private unlisten(): void {
+    if (!this.listening) {
+      return;
+    }
+
+    this.listening = false;
+    this.host.off("message", this.onMessage);
+  }
+}
+
+function isStoppingMessage(message: unknown): boolean {
+  return (
+    typeof message === "object" &&
+    message !== null &&
+    "type" in message &&
+    message.type === simWatchMessages.stopping
+  );
+}
+
+/**
+ * The watch runtime for this process.
+ *
+ * One per process rather than one per `SimAws`, because it is about the process
+ * a supervisor started, not about any one simulated environment. Several
+ * simulations in the same process all report to the same supervisor.
+ */
+export const simWatch = new SimWatchRuntime();

--- a/src/watch/sim-watch.config.ts
+++ b/src/watch/sim-watch.config.ts
@@ -1,0 +1,36 @@
+/**
+ * Configuration shared by `yulin watch` and the process it supervises.
+ */
+export const simWatchConfig = {
+  // Set on a supervised process, so the runtime in it knows there is a
+  // supervisor to talk to. Absent everywhere else, which is what makes watch
+  // mode inert unless it was asked for.
+  environmentVariableName: "YULIN_WATCH",
+  environmentVariableValue: "1",
+  // How long a burst of writes has to go quiet before it counts as one change.
+  // One save from an editor is several writes, and a rename over the original.
+  settleMs: 120,
+  // How long the supervisor waits for a process to say it has told its browsers
+  // a reload is coming. A process not running Yulin's runtime never answers, so
+  // this is a short wait rather than a requirement.
+  stoppingMs: 250,
+  // How long a process gets to exit on its own before it is killed outright.
+  exitMs: 2000,
+  // A change arriving sooner than this after a start is a change the process
+  // itself is likely to have made.
+  selfInflictedMs: 1500,
+  // How many self-inflicted restarts in a row before the loop is called.
+  loopRestarts: 3,
+};
+
+/**
+ * The messages the supervisor and the supervised process send each other.
+ */
+export const simWatchMessages = {
+  // Child to parent: a path Yulin is reading that is worth watching.
+  path: "yulin:watch-path",
+  // Parent to child: this process is about to be restarted.
+  stopping: "yulin:watch-stopping",
+  // Child to parent: the browsers have been told, go ahead.
+  stopped: "yulin:watch-stopped",
+} as const;

--- a/test/cli/recorded-restarts.ts
+++ b/test/cli/recorded-restarts.ts
@@ -1,0 +1,69 @@
+import { SimWatchRestarts } from "../../src/cli/watch/sim-watch-restarts.js";
+
+interface RecordedRestartsProperties {
+  readonly failWith?: Error;
+}
+
+/**
+ * A restart runner whose restarts finish when the test says so, so the queueing
+ * can be driven a step at a time.
+ */
+export class RecordedRestarts {
+  readonly restarted: string[] = [];
+  readonly failures: string[] = [];
+
+  private readonly restarts: SimWatchRestarts;
+  private finishRestart: (() => void) | undefined;
+  private failWith: Error | undefined;
+
+  constructor(properties: RecordedRestartsProperties = {}) {
+    this.failWith = properties.failWith;
+    this.restarts = new SimWatchRestarts({
+      restart: async (changedPath: string): Promise<void> => {
+        await new Promise<void>((resolve) => {
+          this.finishRestart = resolve;
+        });
+
+        this.restarted.push(changedPath);
+
+        if (this.failWith !== undefined) {
+          throw this.failWith;
+        }
+      },
+      onFailure: (error: unknown): void => {
+        this.failures.push(error instanceof Error ? error.message : "");
+      },
+    });
+  }
+
+  /**
+   * Ask for a restart, as a settled change does.
+   */
+  request(changedPath: string): void {
+    this.restarts.request(changedPath);
+  }
+
+  /**
+   * Let the restart that is waiting finish.
+   */
+  release(): void {
+    this.finishRestart?.();
+    this.finishRestart = undefined;
+  }
+
+  /**
+   * Have the next restart succeed.
+   */
+  stopFailing(): void {
+    this.failWith = undefined;
+  }
+
+  /**
+   * Let the promises that were waiting run.
+   */
+  async settle(): Promise<void> {
+    await new Promise((resolve) => {
+      setTimeout(resolve, 0);
+    });
+  }
+}

--- a/test/cli/running-supervisors.ts
+++ b/test/cli/running-supervisors.ts
@@ -1,0 +1,35 @@
+import type { SimWatchSupervisor } from "../../src/cli/watch/sim-watch-supervisor.js";
+
+const running: { supervisor: SimWatchSupervisor; run: Promise<number> }[] = [];
+
+/**
+ * Start a supervisor, and have it stopped when the test ends.
+ *
+ * A supervisor left running holds a real process and a real watch, so a test
+ * that fails part way through would otherwise leave both behind and the test
+ * run would not finish. Stopping it belongs in teardown rather than at the end
+ * of the test body, which an assertion never reaches.
+ */
+export function runSupervisor(supervisor: SimWatchSupervisor): void {
+  running.push({ supervisor, run: supervisor.run() });
+}
+
+/**
+ * Stop every supervisor a test started.
+ */
+export async function stopSupervisors(): Promise<void> {
+  const started = [...running];
+  running.length = 0;
+
+  await Promise.all(
+    started.map(async ({ supervisor, run }) => {
+      supervisor.interrupt();
+
+      try {
+        await run;
+      } catch {
+        // A run that failed is the test's business, not the teardown's.
+      }
+    }),
+  );
+}

--- a/test/cli/until-exited.ts
+++ b/test/cli/until-exited.ts
@@ -1,0 +1,21 @@
+import { watchPause } from "./watch-project.js";
+
+/**
+ * Wait for the exit to be reported, rather than for a length of time chosen in
+ * the hope that it is long enough.
+ */
+export async function untilExited(
+  exits: readonly (number | null)[],
+  withinMs = 5000,
+): Promise<void> {
+  const giveUpAt = Date.now() + withinMs;
+
+  while (exits.length === 0) {
+    if (Date.now() >= giveUpAt) {
+      throw new Error("The process did not report an exit");
+    }
+
+    // eslint-disable-next-line no-await-in-loop
+    await watchPause(25);
+  }
+}

--- a/test/cli/watch-project.ts
+++ b/test/cli/watch-project.ts
@@ -1,0 +1,218 @@
+import { readFile } from "node:fs/promises";
+import { TemporaryDirectory } from "../../src/util/filesystem/temporary-directory.js";
+
+/**
+ * A throwaway project for `yulin watch` to supervise.
+ *
+ * Three directories, because two of them have to be outside the watched one.
+ * The record of what ran cannot live in the project: writing it there would be
+ * the supervised process changing a watched path, which is the restart loop
+ * these tests also check for. Nor can the directory a run reports, which has to
+ * be somewhere the working directory watch would not have reached anyway.
+ */
+export class WatchProject {
+  private readonly project = new TemporaryDirectory();
+  private readonly output = new TemporaryDirectory();
+  private readonly mounted = new TemporaryDirectory();
+
+  /**
+   * Write the project's files and return it ready to be watched.
+   */
+  static async of(files: Record<string, string>): Promise<WatchProject> {
+    const project = new WatchProject();
+
+    await project.project.resolvePath();
+    await project.output.resolvePath();
+    await project.mounted.resolvePath();
+    await project.mounted.writeFile("placeholder.txt", "");
+
+    await Promise.all(
+      Object.entries(files).map(async ([name, content]) =>
+        project.write(name, content),
+      ),
+    );
+
+    return project;
+  }
+
+  /**
+   * The directory `yulin watch` runs in.
+   */
+  path(): string {
+    return this.project.path();
+  }
+
+  /**
+   * Where a run records that it happened, outside anything being watched.
+   */
+  runsLogPath(): string {
+    return this.output.join("runs.log");
+  }
+
+  /**
+   * A directory outside the project, standing in for one a run mounts into a
+   * Bucket and reports.
+   */
+  mountedPath(): string {
+    return this.mounted.path();
+  }
+
+  /**
+   * Write a file in the project, as an editor saving would.
+   */
+  async write(name: string, content: string): Promise<void> {
+    await this.project.writeFile(name, content);
+  }
+
+  /**
+   * Write a file in the reported directory.
+   */
+  async writeMounted(name: string, content: string): Promise<void> {
+    await this.mounted.writeFile(name, content);
+  }
+
+  /**
+   * Wait for the filesystem to go quiet before the watching starts.
+   *
+   * macOS delivers events with a short delay, so a watch started immediately
+   * after these files were written still sees them, and the first run would
+   * restart for writes that happened before it existed.
+   */
+  async settled(): Promise<void> {
+    await watchPause(250);
+  }
+
+  /**
+   * What the supervised process recorded, one line per run.
+   */
+  async runs(): Promise<readonly string[]> {
+    try {
+      // eslint-disable-next-line security/detect-non-literal-fs-filename
+      const recorded = await readFile(this.runsLogPath(), "utf8");
+
+      return recorded.split("\n").filter(Boolean);
+    } catch {
+      return [];
+    }
+  }
+
+  /**
+   * Wait until the supervised process has run a given number of times.
+   */
+  async untilRuns(
+    count: number,
+    withinMs = 10_000,
+  ): Promise<readonly string[]> {
+    return await this.pollRuns(count, Date.now() + withinMs);
+  }
+
+  private async pollRuns(
+    count: number,
+    giveUpAt: number,
+  ): Promise<readonly string[]> {
+    const runs = await this.runs();
+
+    if (runs.length >= count) {
+      return runs;
+    }
+
+    if (Date.now() >= giveUpAt) {
+      throw new Error(
+        `Supervised process ran ${String(runs.length)} times, expected ${String(count)}`,
+      );
+    }
+
+    await watchPause(25);
+
+    return await this.pollRuns(count, giveUpAt);
+  }
+}
+
+/**
+ * A supervised script that records each run and then stays up.
+ */
+export function watchChildScript(runsLogPath: string): string {
+  return String.raw`import { appendFileSync } from "node:fs";
+import { message } from "./message.mjs";
+
+appendFileSync(${JSON.stringify(runsLogPath)}, message + "\n");
+
+setInterval(() => {}, 60_000);
+`;
+}
+
+/**
+ * A supervised script that names a directory to the supervisor over the same
+ * channel Yulin's runtime uses, so it is watched without being listed.
+ */
+export function reportingChildScript(
+  runsLogPath: string,
+  reportedPath: string,
+): string {
+  return String.raw`import { appendFileSync } from "node:fs";
+
+appendFileSync(${JSON.stringify(runsLogPath)}, "run\n");
+process.send?.({ type: "yulin:watch-path", path: ${JSON.stringify(reportedPath)} });
+
+setInterval(() => {}, 60_000);
+`;
+}
+
+/**
+ * A supervised script that writes into its own watched directory, which is the
+ * mistake the restart loop guard is for.
+ */
+export function selfWritingChildScript(runsLogPath: string): string {
+  return String.raw`import { appendFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+appendFileSync(${JSON.stringify(runsLogPath)}, "run\n");
+writeFileSync(path.join(process.cwd(), "generated.json"), JSON.stringify({ at: Date.now() }));
+
+setInterval(() => {}, 60_000);
+`;
+}
+
+/**
+ * A supervised script that throws on startup, as a setup script with a mistake
+ * in it does.
+ */
+export function throwingChildScript(runsLogPath: string): string {
+  return String.raw`import { appendFileSync } from "node:fs";
+import { message } from "./message.mjs";
+
+appendFileSync(${JSON.stringify(runsLogPath)}, message + "\n");
+
+if (message === "broken") {
+  throw new Error("setup failed");
+}
+
+setInterval(() => {}, 60_000);
+`;
+}
+
+/**
+ * A supervised script that records whether a debugger could attach to it.
+ */
+export function inspectedChildScript(runsLogPath: string): string {
+  return String.raw`import { appendFileSync } from "node:fs";
+import inspector from "node:inspector";
+import { message } from "./message.mjs";
+
+appendFileSync(
+  ${JSON.stringify(runsLogPath)},
+  message + " " + (inspector.url() === undefined ? "no-inspector" : "inspector") + "\n",
+);
+
+setInterval(() => {}, 60_000);
+`;
+}
+
+/**
+ * Wait, for a test that has to let something not happen.
+ */
+export async function watchPause(milliseconds: number): Promise<void> {
+  await new Promise((resolve) => {
+    setTimeout(resolve, milliseconds);
+  });
+}

--- a/test/watch/fake-process.ts
+++ b/test/watch/fake-process.ts
@@ -1,0 +1,64 @@
+import type { SimWatchProcess } from "../../src/watch/sim-watch-runtime.js";
+import { simWatchConfig } from "../../src/watch/sim-watch.config.js";
+
+interface FakeProcessProperties {
+  readonly supervised?: boolean;
+  readonly connected?: boolean;
+}
+
+/**
+ * A stand-in for the running process.
+ *
+ * The watch runtime talks over the same channel a test runner uses to reach its
+ * workers, so a test that reached for the real `process` would be writing to
+ * the runner's own IPC.
+ */
+export class FakeProcess implements SimWatchProcess {
+  readonly env: NodeJS.ProcessEnv = {};
+  readonly sent: Record<string, unknown>[] = [];
+  readonly listeners: ((message: unknown) => void)[] = [];
+  readonly send: ((message: unknown) => boolean) | undefined;
+
+  constructor(properties: FakeProcessProperties = {}) {
+    const { supervised = true, connected = true } = properties;
+
+    if (supervised) {
+      this.env[simWatchConfig.environmentVariableName] =
+        simWatchConfig.environmentVariableValue;
+    }
+
+    if (connected) {
+      this.send = (message: unknown): boolean => {
+        this.sent.push(message as Record<string, unknown>);
+        return true;
+      };
+    }
+  }
+
+  /**
+   * Note a listener, as the process would.
+   */
+  on(_event: "message", listener: (message: unknown) => void): void {
+    this.listeners.push(listener);
+  }
+
+  /**
+   * Forget a listener, as the process would.
+   */
+  off(_event: "message", listener: (message: unknown) => void): void {
+    const at = this.listeners.indexOf(listener);
+
+    if (at !== -1) {
+      this.listeners.splice(at, 1);
+    }
+  }
+
+  /**
+   * Hand a message to whatever is listening, as the supervisor would.
+   */
+  deliver(message: unknown): void {
+    for (const listener of this.listeners) {
+      listener(message);
+    }
+  }
+}


### PR DESCRIPTION
Adds `yulin watch -- <command>`, a supervisor that restarts the command on a change and lets live reload refresh the page. It watches the working directory, plus the paths Yulin holds that a module graph never mentions: a directory mounted into a Bucket, and a deployed template, reported over IPC as they are registered.

A burst of writes is one restart, a setup that throws leaves the watcher up, and a process that writes into its own watched path is refused rather than restarted forever.

Resolves https://github.com/KensioSoftware/yulin/issues/418

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `yulin` command-line entry point.
  * Added `yulin watch` to automatically restart development commands when watched files change.
  * Added debounced restarts, graceful shutdown, failure recovery, restart-loop detection, and debugger support.
  * Added watching for project files and registered external paths, including mounted directories and deployed templates.
  * Added local server live reload notifications for watch-mode restarts.

* **Documentation**
  * Documented watch command usage, behavior, supported paths, limitations, and debugger configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->