### PR TITLE
feat: export the watch runtime for held paths

### DIFF
--- a/docs/serve/README.md
+++ b/docs/serve/README.md
@@ -220,10 +220,62 @@ given to `mountBucketFilesystem` and a template given to `deployTemplateFile` ar
 supervisor as they are registered, and watched from then on, without appearing in any list. Editing
 a file in a mounted directory or re-synthing a stack restarts the process. A template deployed with
 the `watch` option is the exception, and is
-[left to the process reading it](#updating-a-stack-instead-of-restarting).
+[left to the process reading it](#updating-a-stack-instead-of-restarting), as is any path the process
+[says it is holding](#holding-a-path-yourself).
 
 A burst of writes is one restart. Saving one file is several filesystem events, so changes are held
 until they stop arriving before anything is restarted.
+
+### Holding a path yourself
+
+A process that is already watching a path and answering changes to it in place has nothing to gain
+from a restart, and everything its simulation holds to lose. `simWatch.reportHeldPath(...)` says so,
+and the supervisor leaves that path alone from then on:
+
+```typescript sim-serve-hold-path
+/**
+ * A mounted directory this process watches itself, reloading the browser
+ * rather than being restarted for it.
+ */
+
+import { watch } from "node:fs";
+import path from "node:path";
+
+import { CreateBucketCommand } from "@aws-sdk/client-s3";
+import { SimAws } from "@kensio/yulin";
+import { serveSimAws } from "@kensio/yulin/serve";
+import { simWatch } from "@kensio/yulin/watch";
+
+const built = path.join(process.cwd(), "public");
+
+const simAws = new SimAws();
+await simAws.s3().createBucket(new CreateBucketCommand({ Bucket: "site" }));
+simAws.s3().mountBucketFilesystem("site", built);
+
+const srv = await serveSimAws({ simAws, port: 8787, liveReload: true });
+
+simWatch.reportHeldPath(built);
+
+watch(built, { recursive: true }, () => {
+  srv.reload();
+});
+```
+
+A static site build writing into that directory then reloads the page, where the mount alone would
+have restarted the process and taken every simulated Bucket, Table and Stack with it. Holding a path
+beats having reported it: being told a path is answered in the process is more specific than being
+told it is worth watching, so it wins even though `mountBucketFilesystem` reported the same directory
+first.
+
+A held path stays held only for the run that reported it. A run that exits leaves nothing holding
+the path, and the supervisor watches it again until its replacement says otherwise.
+
+`simWatch.onStopping(...)` is the other half, for a restart this process does not decide: it runs
+just before the supervisor kills the process, which is where live reload tells browsers a reload is
+coming so a page comes back on its own. A hand-written reload channel wants the same warning.
+
+Both are best effort and need a supervisor. In a process `yulin watch` did not start, such as a test
+run or a script launched from an IDE debugger, they do nothing at all.
 
 ### Updating a stack instead of restarting
 

--- a/docs/serve/sim-serve-hold-path.example.ts
+++ b/docs/serve/sim-serve-hold-path.example.ts
@@ -1,0 +1,26 @@
+/**
+ * A mounted directory this process watches itself, reloading the browser
+ * rather than being restarted for it.
+ */
+
+import { watch } from "node:fs";
+import path from "node:path";
+
+import { CreateBucketCommand } from "@aws-sdk/client-s3";
+import { SimAws } from "@kensio/yulin";
+import { serveSimAws } from "@kensio/yulin/serve";
+import { simWatch } from "@kensio/yulin/watch";
+
+const built = path.join(process.cwd(), "public");
+
+const simAws = new SimAws();
+await simAws.s3().createBucket(new CreateBucketCommand({ Bucket: "site" }));
+simAws.s3().mountBucketFilesystem("site", built);
+
+const srv = await serveSimAws({ simAws, port: 8787, liveReload: true });
+
+simWatch.reportHeldPath(built);
+
+watch(built, { recursive: true }, () => {
+  srv.reload();
+});

--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -27,7 +27,8 @@
         "../src/service/secretsmanager/index.ts"
       ],
       "@kensio/yulin/serve": ["../src/serve/index.ts"],
-      "@kensio/yulin/sqs": ["../src/service/sqs/index.ts"]
+      "@kensio/yulin/sqs": ["../src/service/sqs/index.ts"],
+      "@kensio/yulin/watch": ["../src/watch/index.ts"]
     }
   },
   "include": ["**/*.example.ts", "**/*.examples.ts"]

--- a/package.json
+++ b/package.json
@@ -117,6 +117,10 @@
     "./serve": {
       "import": "./dist/serve/index.js",
       "types": "./dist/serve/index.d.ts"
+    },
+    "./watch": {
+      "import": "./dist/watch/index.js",
+      "types": "./dist/watch/index.d.ts"
     }
   },
   "files": [

--- a/src/cli/watch/sim-watch-reported-paths.loc.test.ts
+++ b/src/cli/watch/sim-watch-reported-paths.loc.test.ts
@@ -12,6 +12,7 @@ import {
 } from "../../../test/cli/running-supervisors.js";
 
 const yulin = repoPath("src/index.js");
+const yulinWatch = repoPath("src/watch/index.js");
 const tsx = repoPath(path.join("node_modules", ".bin", "tsx"));
 
 /**
@@ -98,6 +99,41 @@ describe("paths a supervised process reports", () => {
     const recorded = await project.untilRuns(2);
     assertArrayEquals([...recorded], ["run", "updated"]);
   });
+
+  it("leaves a mounted directory the process holds alone", async () => {
+    // Given a dev script that mounts a directory and then says it is watching
+    // that directory itself, as a project with its own build and reload does
+    const project = await WatchProject.of({});
+    const mounted = path.join(project.mountedPath(), "public");
+    await project.writeMounted(path.join("public", "index.html"), "<h1>a</h1>");
+    await project.write(
+      "dev.ts",
+      holdingScript(project.runsLogPath(), mounted),
+    );
+    const supervisor = supervise(project);
+    await project.settled();
+    runSupervisor(supervisor);
+    await project.untilRuns(1);
+    await watchPause(300);
+
+    // When the site is built into that directory again
+    await project.writeMounted(path.join("public", "index.html"), "<h1>b</h1>");
+
+    // Then the run that mounted it answers the change itself, keeping every
+    // simulated Bucket, Table and Stack a restart would have taken, even though
+    // mounting reported the same directory for watching first
+    const recorded = await project.untilRuns(2);
+    assertArrayEquals([...recorded].slice(0, 2), ["run", "answered"]);
+
+    // Long enough for a restart to have been recorded, since what is being
+    // waited for here is a run that should never happen
+    await watchPause(3000);
+    const settled = await project.runs();
+    assertArrayEquals(
+      settled.filter((line) => line === "run"),
+      ["run"],
+    );
+  });
 });
 
 const emptyTemplate = JSON.stringify({ Resources: {} });
@@ -150,6 +186,26 @@ await simAws.cloudFormation().deployTemplateFile({
       appendFileSync(${JSON.stringify(runsLogPath)}, "updated\n");
     },
   },
+});
+
+setInterval(() => {}, 60_000);
+`;
+}
+
+function holdingScript(runsLogPath: string, mountedPath: string): string {
+  return String.raw`import { appendFileSync, watch } from "node:fs";
+import { SimAws } from ${JSON.stringify(yulin)};
+import { simWatch } from ${JSON.stringify(yulinWatch)};
+
+appendFileSync(${JSON.stringify(runsLogPath)}, "run\n");
+
+const simAws = new SimAws();
+await simAws.s3().createBucket({ input: { Bucket: "site" } });
+simAws.s3().mountBucketFilesystem("site", ${JSON.stringify(mountedPath)});
+
+simWatch.reportHeldPath(${JSON.stringify(mountedPath)});
+watch(${JSON.stringify(mountedPath)}, { recursive: true }, () => {
+  appendFileSync(${JSON.stringify(runsLogPath)}, "answered\n");
 });
 
 setInterval(() => {}, 60_000);

--- a/src/watch/index.ts
+++ b/src/watch/index.ts
@@ -1,0 +1,2 @@
+export { simWatch } from "./sim-watch-runtime.js";
+export type { SimWatchRuntime } from "./sim-watch-runtime.js";

--- a/src/watch/sim-watch-runtime.iso.test.ts
+++ b/src/watch/sim-watch-runtime.iso.test.ts
@@ -3,9 +3,11 @@ import {
   assertArrayLength,
   assertFalse,
   assertIdentical,
+  assertInstanceOf,
   assertStringEndsWith,
 } from "@kensio/smartass";
 import { describe, it } from "vitest";
+import { simWatch } from "./index.js";
 import { SimWatchRuntime } from "./sim-watch-runtime.js";
 import { simWatchMessages } from "./sim-watch.config.js";
 import { FakeProcess } from "../../test/watch/fake-process.js";
@@ -157,5 +159,25 @@ describe("SimWatchRuntime", () => {
 
     // Then nothing is attached to a process that will never be told
     assertArrayEquals(host.listeners, []);
+  });
+});
+
+describe("the exported watch runtime", () => {
+  it("is the runtime for the process it was imported into", () => {
+    // Given the export a consumer reaches for, from `@kensio/yulin/watch`
+    // Then it is the one runtime talking to whatever started this process
+    assertInstanceOf(simWatch, SimWatchRuntime);
+  });
+
+  it("does nothing in a process no supervisor started", () => {
+    // Given an ordinary process, such as this test run
+
+    // When it is told about paths and asked about a restart
+    simWatch.reportPath("assets/uploads");
+    simWatch.reportHeldPath("articles/public");
+    simWatch.onStopping(() => undefined);
+
+    // Then it says there is nobody to tell, and nothing was sent
+    assertFalse(simWatch.supervised());
   });
 });


### PR DESCRIPTION
`reportHeldPath` is how a supervised process tells `yulin watch` that it is watching a path itself
and answers changes to it in place, so a change there is not something to restart for. It was the
documented mechanism with no way for a consumer to call it: `src/watch/sim-watch-runtime.ts` was not
reachable from any package export.

A `./watch` export now carries `simWatch` and the `SimWatchRuntime` type, so a dev script can hold a
directory it builds into and reload the browser rather than losing every simulated Bucket, Table and
Stack to a restart. `onStopping` comes with the object, which is what a hand-written live reload
needs to warn browsers before a supervised restart.

- `src/watch/index.ts` exports `simWatch` and the `SimWatchRuntime` type
- `./watch` in `package.json` and in the docs example path mapping, so `verify:pack` covers it as it
  covers the other subpaths: 20 of 20 import from the tarball with declarations
- a supervised run that mounts a directory and then holds it answers a write into it itself, with no
  restart, even though mounting reported the same directory for watching first
- the export is inert in a process no supervisor started, as it is now
- the serve docs say how to hold a path, next to what was already written about which paths are
  watched

Resolves #439
