### PR TITLE
feat: export template type and Account ID ctor

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,11 @@
+# yaml-language-server: $schema=https://docs.coderabbit.ai/schemas/coderabbit-schema.json
+---
+# Repository level CodeRabbit settings, which override the organisation ones for
+# this repository only.
+reviews:
+  auto_review:
+    # Review a pull request once, when it is opened.
+    enabled: true
+    # Do not review again on every push after that. Ask for another review with
+    # an `@coderabbitai review` comment on the pull request.
+    auto_incremental_review: false

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ AWS state is simulated internally, so you can test realistic interactions with m
 services.
 
 An Account ID is a plain string wherever one is accepted. Code that wants to name the type can get a
-`SimAwsAccountId` from `simAwsAccountId(...)`, which refuses anything that is not a 12 digit AWS
+`SimAwsAccountId` from `simAwsAccountId(...)`, which refuses anything that is not a 12-digit AWS
 Account ID, or from `makeSimAwsAccountId()` when a test just needs an arbitrary one.
 
 ```typescript

--- a/README.md
+++ b/README.md
@@ -124,6 +124,17 @@ await simAws.account("111111111111").region("eu-west-2").dynamoDb().createTable(
 AWS state is simulated internally, so you can test realistic interactions with multiple AWS
 services.
 
+An Account ID is a plain string wherever one is accepted. Code that wants to name the type can get a
+`SimAwsAccountId` from `simAwsAccountId(...)`, which refuses anything that is not a 12 digit AWS
+Account ID, or from `makeSimAwsAccountId()` when a test just needs an arbitrary one.
+
+```typescript
+import { makeSimAwsAccountId, simAwsAccountId } from "@kensio/yulin";
+
+const accountId = simAwsAccountId("111111111111");
+const someOtherAccountId = makeSimAwsAccountId();
+```
+
 Each instance of `SimAws` is cheap and encapsulated so you can create them wherever you need them.
 It's fine to create a new instance of `SimAws` in every test case or in shared test setup.
 

--- a/docs/services/cloudformation/README.md
+++ b/docs/services/cloudformation/README.md
@@ -45,6 +45,44 @@ console.log(bucket?.bucketName);
 `deployTemplate(...)` returns the simulated stack object. If your test needs the created resources
 to be available, wait for deployment to complete before asserting final state.
 
+### Naming the template type
+
+A template written inline is typed by `deployTemplate(...)` itself. A test that builds a template up
+somewhere else can name that type as `CfnTemplateBodyRecord`.
+
+```typescript sim-cloudformation-template-type
+/**
+ * Naming the type of a template a test builds somewhere other than the call.
+ */
+
+import { SimAws } from "@kensio/yulin";
+import type { CfnTemplateBodyRecord } from "@kensio/yulin/cloudformation";
+
+function siteTemplate(bucketName: string): CfnTemplateBodyRecord {
+  return {
+    Resources: {
+      SiteBucket: {
+        Type: "AWS::S3::Bucket",
+        Properties: {
+          BucketName: bucketName,
+        },
+      },
+    },
+  };
+}
+
+const simAws = new SimAws();
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "typed-site-stack",
+  template: siteTemplate("typed-site-bucket"),
+});
+
+await stack.waitForDeployComplete();
+
+console.log(simAws.s3().getSimBucketByName("typed-site-bucket")?.bucketName);
+```
+
 ## Creating stacks with AWS SDK command shapes
 
 You can also use AWS SDK-style CloudFormation commands.
@@ -1612,6 +1650,10 @@ await scopedCfn.deployTemplate({
 Stacks are scoped to the selected simulated account and region. Resources created by a stack are
 created through that same simulated account/region scope unless the underlying simulated service has
 different AWS-like scoping behaviour.
+
+An Account ID can always be written as a plain string, as above. Code that wants to name the type
+can get a `SimAwsAccountId` from `simAwsAccountId("111111111111")`, which refuses anything that is
+not a 12 digit AWS Account ID.
 
 ## Inspecting stacks and resources
 

--- a/docs/services/cloudformation/README.md
+++ b/docs/services/cloudformation/README.md
@@ -1653,7 +1653,7 @@ different AWS-like scoping behaviour.
 
 An Account ID can always be written as a plain string, as above. Code that wants to name the type
 can get a `SimAwsAccountId` from `simAwsAccountId("111111111111")`, which refuses anything that is
-not a 12 digit AWS Account ID.
+not a 12-digit AWS Account ID.
 
 ## Inspecting stacks and resources
 

--- a/docs/services/cloudformation/sim-cloudformation-template-type.example.ts
+++ b/docs/services/cloudformation/sim-cloudformation-template-type.example.ts
@@ -1,0 +1,30 @@
+/**
+ * Naming the type of a template a test builds somewhere other than the call.
+ */
+
+import { SimAws } from "@kensio/yulin";
+import type { CfnTemplateBodyRecord } from "@kensio/yulin/cloudformation";
+
+function siteTemplate(bucketName: string): CfnTemplateBodyRecord {
+  return {
+    Resources: {
+      SiteBucket: {
+        Type: "AWS::S3::Bucket",
+        Properties: {
+          BucketName: bucketName,
+        },
+      },
+    },
+  };
+}
+
+const simAws = new SimAws();
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "typed-site-stack",
+  template: siteTemplate("typed-site-bucket"),
+});
+
+await stack.waitForDeployComplete();
+
+console.log(simAws.s3().getSimBucketByName("typed-site-bucket")?.bucketName);

--- a/scripts/mts/verify-pack-consumer.mts
+++ b/scripts/mts/verify-pack-consumer.mts
@@ -1,0 +1,209 @@
+/**
+ * The throwaway project the packed tarball is installed into, and the checks
+ * that run inside it.
+ *
+ * Everything here works the way a package consumer does: through the installed
+ * package's own export subpaths, with no path back into this repository's
+ * source tree.
+ */
+
+import { execa } from "execa";
+import { mkdir, stat, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+import type {
+  ImportResult,
+  PackageManifest,
+  Subpath,
+} from "./verify-pack.type.mjs";
+
+const projectRoot = path.resolve(import.meta.dirname, "../..");
+
+/** Consumer file whose only job is to name types the package must export. */
+const typeUsageFileName = "use-types.ts";
+
+/**
+ * What a consumer writes when it names the types Yulin's own API asks for.
+ *
+ * This is compiled rather than run, because a type that is missing from the
+ * package leaves nothing behind at runtime for the import check to miss.
+ */
+const typeUsageSource = `import {
+  SimAws,
+  simAwsAccountId,
+  type SimAwsAccountId,
+} from "@kensio/yulin";
+import type { CfnTemplateBodyRecord } from "@kensio/yulin/cloudformation";
+
+const accountId: SimAwsAccountId = simAwsAccountId("111111111111");
+
+const template: CfnTemplateBodyRecord = {
+  Resources: {
+    Handle: { Type: "AWS::CloudFormation::WaitConditionHandle" },
+  },
+};
+
+export function deployStack(): Promise<unknown> {
+  return new SimAws()
+    .account(accountId)
+    .cloudFormation()
+    .deployTemplate({ stackName: "packed-stack", template });
+}
+`;
+
+/**
+ * A bare ESM project outside the repository, so module resolution cannot fall
+ * back to the repository's own `node_modules` or source tree.
+ */
+export async function createConsumer(
+  consumerDirectory: string,
+  tarballPath: string,
+  manifest: PackageManifest,
+): Promise<void> {
+  await mkdir(consumerDirectory, { recursive: true });
+
+  await writeFile(
+    path.join(consumerDirectory, "package.json"),
+    `${JSON.stringify({ name: "yulin-verify-pack", version: "0.0.0", private: true, type: "module" }, undefined, 2)}\n`,
+    "utf8",
+  );
+
+  // Optional peers are installed so that subpaths depending on them are
+  // exercised rather than skipped.
+  const peers = Object.keys(manifest.peerDependencies ?? {});
+
+  await execa("npm", ["install", "--silent", tarballPath, ...peers], {
+    cwd: consumerDirectory,
+  });
+
+  console.log(`Installed tarball into ${consumerDirectory}.`);
+}
+
+/** Declaration files an export target points at but the tarball does not have. */
+export async function findMissingTypes(
+  consumerDirectory: string,
+  manifest: PackageManifest,
+  subpaths: readonly Subpath[],
+): Promise<readonly string[]> {
+  const packageDirectory = path.join(
+    consumerDirectory,
+    "node_modules",
+    manifest.name,
+  );
+  const missing: string[] = [];
+
+  for (const subpath of subpaths) {
+    if (!(await isFile(path.join(packageDirectory, subpath.types)))) {
+      missing.push(`${subpath.specifier} -> ${subpath.types}`);
+    }
+  }
+
+  return missing;
+}
+
+async function isFile(filePath: string): Promise<boolean> {
+  try {
+    const entry = await stat(filePath);
+
+    return entry.isFile();
+  } catch {
+    return false;
+  }
+}
+
+/** Imports each subpath in a child process running inside the consumer. */
+export async function importSubpaths(
+  consumerDirectory: string,
+  subpaths: readonly Subpath[],
+): Promise<readonly ImportResult[]> {
+  const runnerPath = path.join(consumerDirectory, "import-subpaths.mjs");
+
+  await writeFile(runnerPath, importRunnerSource(subpaths), "utf8");
+
+  const { stdout } = await execa("node", [runnerPath], {
+    cwd: consumerDirectory,
+  });
+
+  return JSON.parse(stdout) as readonly ImportResult[];
+}
+
+function importRunnerSource(subpaths: readonly Subpath[]): string {
+  const imports = subpaths.map((subpath) => ({
+    specifier: subpath.specifier,
+    requiredExports: subpath.requiredExports,
+  }));
+
+  return `const imports = ${JSON.stringify(imports, undefined, 2)};
+const results = [];
+
+for (const { specifier, requiredExports } of imports) {
+  try {
+    const module = await import(specifier);
+    const missing = requiredExports.filter((name) => !(name in module));
+
+    results.push({
+      specifier,
+      ok: missing.length === 0,
+      exportCount: Object.keys(module).length,
+      error:
+        missing.length === 0
+          ? undefined
+          : \`missing export(s): \${missing.join(", ")}\`,
+    });
+  } catch (error) {
+    results.push({
+      specifier,
+      ok: false,
+      exportCount: 0,
+      error: \`\${error.code ?? ""} \${error.message}\`.trim().split("\\n")[0],
+    });
+  }
+}
+
+process.stdout.write(JSON.stringify(results));
+`;
+}
+
+/**
+ * Compiles a consumer file that names the package's types, using this
+ * repository's own tsc against the tarball installed in the consumer.
+ *
+ * Module resolution follows the consumer's `node_modules`, so this fails on a
+ * type the package does not export even though the repository's own source
+ * tree has it.
+ */
+export async function assertTypesUsable(
+  consumerDirectory: string,
+): Promise<void> {
+  await writeFile(
+    path.join(consumerDirectory, typeUsageFileName),
+    typeUsageSource,
+    "utf8",
+  );
+
+  try {
+    await execa(
+      path.join(projectRoot, "node_modules", ".bin", "tsc"),
+      [
+        "--noEmit",
+        "--strict",
+        "--skipLibCheck",
+        "--module",
+        "nodenext",
+        "--target",
+        "es2023",
+        typeUsageFileName,
+      ],
+      { cwd: consumerDirectory },
+    );
+  } catch (error) {
+    const { stdout } = error as { readonly stdout?: string };
+
+    throw new Error(
+      `A consumer cannot name the package's types:\n${stdout ?? String(error)}`,
+      { cause: error },
+    );
+  }
+
+  console.log("Consumer type usage compiles against the tarball.");
+}

--- a/scripts/mts/verify-pack.mts
+++ b/scripts/mts/verify-pack.mts
@@ -8,19 +8,28 @@
  * This catches publishes where `dist/` is stale or incomplete, which a local
  * build alone cannot detect because the repository working tree still has the
  * files that the tarball is missing.
+ *
+ * It also compiles a consumer file that names the types Yulin's own API asks
+ * for, which catches a type a consumer cannot name because the package never
+ * exports it.
  */
 
 import { execa } from "execa";
-import {
-  mkdir,
-  mkdtemp,
-  readFile,
-  rm,
-  stat,
-  writeFile,
-} from "node:fs/promises";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+
+import {
+  assertTypesUsable,
+  createConsumer,
+  findMissingTypes,
+  importSubpaths,
+} from "./verify-pack-consumer.mjs";
+import type {
+  ImportResult,
+  PackageManifest,
+  Subpath,
+} from "./verify-pack.type.mjs";
 
 const projectRoot = path.resolve(import.meta.dirname, "../..");
 
@@ -31,28 +40,25 @@ const forbiddenTarballEntries = [
   "/node_modules/",
 ];
 
-interface PackageManifest {
-  readonly name: string;
-  readonly exports: Readonly<Record<string, ExportTarget>>;
-  readonly peerDependencies?: Readonly<Record<string, string>>;
-}
-
-type ExportTarget =
-  string | { readonly import: string; readonly types: string };
-
-interface Subpath {
-  /** Specifier a consumer would import, e.g. `@kensio/yulin/s3`. */
-  readonly specifier: string;
-  /** Package-relative path to the declaration file. */
-  readonly types: string;
-}
-
-interface ImportResult {
-  readonly specifier: string;
-  readonly ok: boolean;
-  readonly exportCount: number;
-  readonly error?: string;
-}
+/**
+ * Exports a consumer imports by name, keyed by export subpath.
+ *
+ * A subpath resolving does not mean the export a consumer reaches for is in it,
+ * so the names an ordinary consumer uses are named here.
+ */
+const requiredExports = new Map<string, readonly string[]>([
+  [
+    ".",
+    [
+      "SimAws",
+      "isSimAwsAccountId",
+      "makeSimAwsAccountId",
+      "simAwsAccountId",
+      "SimInvalidAwsAccountId",
+    ],
+  ],
+  ["./cloudformation", ["SimCloudFormation"]],
+]);
 
 async function main(): Promise<void> {
   const manifest = await readManifest();
@@ -79,6 +85,8 @@ async function main(): Promise<void> {
     );
 
     report(results, missingTypes);
+
+    await assertTypesUsable(consumerDirectory);
   } finally {
     await rm(workDirectory, { recursive: true, force: true });
   }
@@ -104,6 +112,7 @@ function collectSubpaths(manifest: PackageManifest): readonly Subpath[] {
     subpaths.push({
       specifier: `${manifest.name}${suffix}`,
       types: target.types,
+      requiredExports: requiredExports.get(key) ?? [],
     });
   }
 
@@ -147,109 +156,6 @@ async function assertTarballHygiene(tarballPath: string): Promise<void> {
   }
 
   console.log(`Tarball is clean (${String(entries.length)} entries).`);
-}
-
-/**
- * A bare ESM project outside the repository, so module resolution cannot fall
- * back to the repository's own `node_modules` or source tree.
- */
-async function createConsumer(
-  consumerDirectory: string,
-  tarballPath: string,
-  manifest: PackageManifest,
-): Promise<void> {
-  await mkdir(consumerDirectory, { recursive: true });
-
-  await writeFile(
-    path.join(consumerDirectory, "package.json"),
-    `${JSON.stringify({ name: "yulin-verify-pack", version: "0.0.0", private: true, type: "module" }, undefined, 2)}\n`,
-    "utf8",
-  );
-
-  // Optional peers are installed so that subpaths depending on them are
-  // exercised rather than skipped.
-  const peers = Object.keys(manifest.peerDependencies ?? {});
-
-  await execa("npm", ["install", "--silent", tarballPath, ...peers], {
-    cwd: consumerDirectory,
-  });
-
-  console.log(`Installed tarball into ${consumerDirectory}.`);
-}
-
-/** Declaration files an export target points at but the tarball does not have. */
-async function findMissingTypes(
-  consumerDirectory: string,
-  manifest: PackageManifest,
-  subpaths: readonly Subpath[],
-): Promise<readonly string[]> {
-  const packageDirectory = path.join(
-    consumerDirectory,
-    "node_modules",
-    manifest.name,
-  );
-  const missing: string[] = [];
-
-  for (const subpath of subpaths) {
-    if (!(await isFile(path.join(packageDirectory, subpath.types)))) {
-      missing.push(`${subpath.specifier} -> ${subpath.types}`);
-    }
-  }
-
-  return missing;
-}
-
-async function isFile(filePath: string): Promise<boolean> {
-  try {
-    const entry = await stat(filePath);
-
-    return entry.isFile();
-  } catch {
-    return false;
-  }
-}
-
-/** Imports each subpath in a child process running inside the consumer. */
-async function importSubpaths(
-  consumerDirectory: string,
-  subpaths: readonly Subpath[],
-): Promise<readonly ImportResult[]> {
-  const specifiers = subpaths.map((subpath) => subpath.specifier);
-  const runnerPath = path.join(consumerDirectory, "import-subpaths.mjs");
-
-  await writeFile(runnerPath, importRunnerSource(specifiers), "utf8");
-
-  const { stdout } = await execa("node", [runnerPath], {
-    cwd: consumerDirectory,
-  });
-
-  return JSON.parse(stdout) as readonly ImportResult[];
-}
-
-function importRunnerSource(specifiers: readonly string[]): string {
-  return `const specifiers = ${JSON.stringify(specifiers, undefined, 2)};
-const results = [];
-
-for (const specifier of specifiers) {
-  try {
-    const module = await import(specifier);
-    results.push({
-      specifier,
-      ok: true,
-      exportCount: Object.keys(module).length,
-    });
-  } catch (error) {
-    results.push({
-      specifier,
-      ok: false,
-      exportCount: 0,
-      error: \`\${error.code ?? ""} \${error.message}\`.trim().split("\\n")[0],
-    });
-  }
-}
-
-process.stdout.write(JSON.stringify(results));
-`;
 }
 
 function report(

--- a/scripts/mts/verify-pack.type.mts
+++ b/scripts/mts/verify-pack.type.mts
@@ -1,0 +1,29 @@
+/**
+ * Shapes shared by the pack verification script and the throwaway consumer
+ * project it installs the packed tarball into.
+ */
+
+export interface PackageManifest {
+  readonly name: string;
+  readonly exports: Readonly<Record<string, ExportTarget>>;
+  readonly peerDependencies?: Readonly<Record<string, string>>;
+}
+
+export type ExportTarget =
+  string | { readonly import: string; readonly types: string };
+
+export interface Subpath {
+  /** Specifier a consumer would import, e.g. `@kensio/yulin/s3`. */
+  readonly specifier: string;
+  /** Package-relative path to the declaration file. */
+  readonly types: string;
+  /** Export names this subpath must have, if any are named for it. */
+  readonly requiredExports: readonly string[];
+}
+
+export interface ImportResult {
+  readonly specifier: string;
+  readonly ok: boolean;
+  readonly exportCount: number;
+  readonly error?: string;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,12 @@
 export { SimAws } from "./service/aws/sim-aws.js";
 export type { AwsRegionName } from "./service/aws/sim-aws-region.js";
-export type { SimAwsAccountId } from "./service/aws/sim-aws-account.js";
+export {
+  isSimAwsAccountId,
+  makeSimAwsAccountId,
+  type SimAwsAccountId,
+  simAwsAccountId,
+  SimInvalidAwsAccountId,
+} from "./service/aws/sim-aws-account-id.js";
 export {
   type SimClock,
   SimFixedClock,

--- a/src/service/aws/sim-aws-account-id.iso.test.ts
+++ b/src/service/aws/sim-aws-account-id.iso.test.ts
@@ -1,0 +1,110 @@
+import { CreateBucketCommand } from "@aws-sdk/client-s3";
+import { describe, expect, it } from "vitest";
+
+import { DEFAULT_SIM_AWS_ACCOUNT_ID } from "./sim-aws-account.js";
+import {
+  isSimAwsAccountId,
+  makeSimAwsAccountId,
+  simAwsAccountId,
+  SimInvalidAwsAccountId,
+} from "./sim-aws-account-id.js";
+import { SimAws } from "./sim-aws.js";
+
+describe("simAwsAccountId", () => {
+  it("names a twelve digit Account ID", () => {
+    // Given a twelve digit AWS Account ID written as a plain string
+    const written = "111111111111";
+
+    // When it is named
+    // Then it comes back as the same ID, now typed as one
+    expect(simAwsAccountId(written)).toBe(written);
+  });
+
+  it("keeps leading zeroes", () => {
+    // Given an AWS Account ID that starts with a zero
+    // When it is named
+    // Then the zero is still there: an Account ID is digits, not a number
+    expect(simAwsAccountId("000123456789")).toBe("000123456789");
+  });
+
+  it("refuses a value that is not twelve digits", () => {
+    // Given values that no AWS Account ID looks like
+    // When they are named
+    // Then each is refused, with the value in the message
+    expect(() => simAwsAccountId("12345")).toThrow(SimInvalidAwsAccountId);
+    expect(() => simAwsAccountId("12345")).toThrow(/"12345"/);
+    expect(() => simAwsAccountId("1111111111111")).toThrow(
+      SimInvalidAwsAccountId,
+    );
+    expect(() => simAwsAccountId("not-an-account")).toThrow(/"not-an-account"/);
+    expect(() => simAwsAccountId("11111111111 ")).toThrow(
+      SimInvalidAwsAccountId,
+    );
+  });
+
+  it("refuses a value that is not a string at all", () => {
+    // Given a caller without types passing something else entirely
+    const notAnId = 111_111_111_111 as unknown as string;
+
+    // When it is named
+    // Then it is refused rather than branded
+    expect(() => simAwsAccountId(notAnId)).toThrow(SimInvalidAwsAccountId);
+  });
+
+  it("names an Account a simulated AWS then accepts", async () => {
+    // Given a named Account ID
+    const accountId = simAwsAccountId("222222222222");
+
+    // When it is used to scope a simulated service
+    const simAws = new SimAws();
+    await simAws
+      .account(accountId)
+      .s3()
+      .createBucket(new CreateBucketCommand({ Bucket: "id-bucket" }));
+
+    // Then the resources are in that Account
+    expect(
+      simAws.account(accountId).s3().getSimBucketByName("id-bucket"),
+    ).toBeDefined();
+  });
+});
+
+describe("isSimAwsAccountId", () => {
+  it("narrows a string that is an Account ID", () => {
+    // Given a value that could be anything
+    const value: unknown = "333333333333";
+
+    // When it is checked
+    // Then it is an Account ID, and narrowed to one
+    expect(isSimAwsAccountId(value)).toBe(true);
+  });
+
+  it("rejects anything that is not an Account ID", () => {
+    // Given values that are not AWS Account IDs
+    // When they are checked
+    // Then none of them narrows
+    expect(isSimAwsAccountId("nope")).toBe(false);
+    expect(isSimAwsAccountId(333_333_333_333)).toBe(false);
+    expect(isSimAwsAccountId(undefined)).toBe(false);
+  });
+});
+
+describe("makeSimAwsAccountId", () => {
+  it("generates an arbitrary Account ID", () => {
+    // Given a test that wants an Account ID but does not care which
+    const accountId = makeSimAwsAccountId();
+
+    // When it is checked
+    // Then it is a usable AWS Account ID
+    expect(isSimAwsAccountId(accountId)).toBe(true);
+  });
+});
+
+describe("DEFAULT_SIM_AWS_ACCOUNT_ID", () => {
+  it("is an AWS Account ID", () => {
+    // Given the Account ID a simulated AWS uses when none is given
+    // When it is checked
+    // Then it is a usable AWS Account ID
+    expect(isSimAwsAccountId(DEFAULT_SIM_AWS_ACCOUNT_ID)).toBe(true);
+  });
+});

--- a/src/service/aws/sim-aws-account-id.ts
+++ b/src/service/aws/sim-aws-account-id.ts
@@ -1,0 +1,50 @@
+import type { Brand } from "../../util/brand.type.js";
+import { faker } from "@faker-js/faker";
+
+/**
+ * The ID of a simulated AWS Account.
+ *
+ * Everything that takes an Account ID also takes a plain string, so this is a
+ * name for the type rather than a requirement to use it.
+ */
+export type SimAwsAccountId = Brand<string, "SimAwsAccountId">;
+
+/** An AWS Account ID is twelve digits, with leading zeroes kept. */
+const accountIdPattern = /^\d{12}$/u;
+
+/**
+ * Thrown for a value that cannot be an AWS Account ID.
+ */
+export class SimInvalidAwsAccountId extends Error {
+  constructor(value: unknown) {
+    super(
+      `Invalid simulated AWS Account ID "${String(value)}": an AWS Account ID is 12 digits`,
+    );
+    this.name = "SimInvalidAwsAccountId";
+  }
+}
+
+/**
+ * Narrow a value to an AWS Account ID.
+ */
+export function isSimAwsAccountId(value: unknown): value is SimAwsAccountId {
+  return typeof value === "string" && accountIdPattern.test(value);
+}
+
+/**
+ * Name an AWS Account ID, refusing anything that is not one.
+ */
+export function simAwsAccountId(value: string): SimAwsAccountId {
+  if (!isSimAwsAccountId(value)) {
+    throw new SimInvalidAwsAccountId(value);
+  }
+
+  return value;
+}
+
+/**
+ * Generate a fake AWS Account ID, for a test that wants an arbitrary one.
+ */
+export function makeSimAwsAccountId(): SimAwsAccountId {
+  return simAwsAccountId(faker.string.numeric({ length: 12 }));
+}

--- a/src/service/aws/sim-aws-account.ts
+++ b/src/service/aws/sim-aws-account.ts
@@ -1,7 +1,6 @@
 import type { AwsRegionName } from "./sim-aws-region.js";
-import type { Brand } from "../../util/brand.type.js";
 import type { SimAwsAccountRegionContainer } from "./sim-aws-account-region-scope.js";
-import { faker } from "@faker-js/faker";
+import { simAwsAccountId, type SimAwsAccountId } from "./sim-aws-account-id.js";
 import type { SimS3 } from "../s3/sim-s3.js";
 import type { SimCloudFront } from "../cloudfront/sim-cloudfront.js";
 import type {
@@ -19,9 +18,21 @@ import type { SimAwsPrincipal } from "./caller/sim-aws-caller.js";
 import { makeSimAwsAccountRootPrincipal } from "./caller/sim-aws-account-root-principal.js";
 import type { SimSts } from "../sts/sim-sts.js";
 
-export type SimAwsAccountId = Brand<string, "SimAwsAccountId">;
+// An Account ID is its own small thing and is defined in its own module. It is
+// re-exported here because this is where the rest of the simulator already
+// reaches for it, alongside the Account it identifies.
+export {
+  isSimAwsAccountId,
+  makeSimAwsAccountId,
+  type SimAwsAccountId,
+  simAwsAccountId,
+  SimInvalidAwsAccountId,
+} from "./sim-aws-account-id.js";
 
-export const DEFAULT_SIM_AWS_ACCOUNT_ID = "888888888888" as SimAwsAccountId;
+/**
+ * The AWS Account a simulated AWS uses when it is not told which one.
+ */
+export const DEFAULT_SIM_AWS_ACCOUNT_ID = simAwsAccountId("888888888888");
 
 interface SimAwsAccountProperties {
   readonly simAws?: Pick<SimAws, "accountRegionScope">;
@@ -137,11 +148,4 @@ export class SimAwsAccount {
   sts(): SimSts {
     return this.region().sts();
   }
-}
-
-/**
- * Generate a fake AWS Account ID.
- */
-export function makeSimAwsAccountId(): SimAwsAccountId {
-  return faker.string.numeric({ length: 12 }) as SimAwsAccountId;
 }

--- a/src/service/cloudformation/index.ts
+++ b/src/service/cloudformation/index.ts
@@ -1,4 +1,4 @@
 export { SimCloudFormation } from "./sim-cloudformation.js";
-export type { SimCfnTemplateFileTransform } from "./deploy/sim-cfn-template-file-transform.js";
 export type { CfnTemplateBodyRecord } from "./template/sim-cfn-template.js";
+export type { SimCfnTemplateFileTransform } from "./deploy/sim-cfn-template-file-transform.js";
 export type { SimCfnTemplateFileWatchOptions } from "./watch/sim-cfn-template-watch.type.js";


### PR DESCRIPTION
Two types a consumer needs in ordinary use could not be named without a workaround.

## `CfnTemplateBodyRecord`

This is what `deployTemplate({ template })` takes, and it was exported from neither the root nor `./cloudformation`, so naming it meant `Parameters<ReturnType<SimAws["cloudFormation"]>["deployTemplate"]>[0]["template"]`. It is now exported from `./cloudformation`, and the CloudFormation docs show a test building a template somewhere other than the call.

## `SimAwsAccountId`

The branded type was exported from the root as a type only, so every consumer wrote `as SimAwsAccountId`. Now exported from the root:

- `simAwsAccountId(value)` returns the branded type, and throws `SimInvalidAwsAccountId` naming the value it was given for anything that is not a 12 digit AWS Account ID.
- `isSimAwsAccountId(value)` narrows.
- `makeSimAwsAccountId()` for a test that wants an arbitrary Account ID.

Nothing that took a plain Account ID string stops taking one. `SimAws.defaultAccountId` and the `SimAwsAccountId | string` entry points are unchanged; the constructor is how to get the branded type, not a new requirement.

The Account ID identity moved into `sim-aws-account-id.ts` so it is not mixed in with the Account navigation container, and is re-exported from `sim-aws-account.js` so the ~170 places that already name it are untouched.

## `verify:pack`

Both are covered from the installed tarball, so a package consumer can actually import them:

- The subpath import check now also asserts the export names a consumer imports, not just that the subpath resolves.
- A consumer file naming both types is compiled with `tsc` against the installed tarball. A type-only export gap leaves nothing behind at runtime, so compiling is the only way to catch it.

Both checks were confirmed to fail when the export is removed. The consumer side of the script moved into `verify-pack-consumer.mts` to stay under the file size limit.

## Out of scope

Auditing every other branded type for the same gap. There are several; this covers the two a consumer has hit.

Resolves #440

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added simulated AWS account ID helpers with validation, generation, and a dedicated error type.
  * Added CloudFormation template typing support and related exports.
  * Improved package verification to check consumer installs, imports, and type usability.

* **Documentation**
  * Expanded README and CloudFormation docs with usage examples for account IDs and typed templates.

* **Tests**
  * Added coverage for account ID validation, generation, and resource scoping.

* **Chores**
  * Updated repository review settings for automated PR checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->