### PR TITLE
feat: sign up to a simulated Cognito user pool

### DIFF
--- a/docs/services/cognito/README.md
+++ b/docs/services/cognito/README.md
@@ -161,6 +161,115 @@ Attributes come back under `Attributes` from `AdminCreateUser` and `ListUsers`, 
 Only the standard attributes exist. A pool here is created without a `Schema` of its own, so a
 `custom:` attribute is refused, as it would be on a real pool created the same way.
 
+## Signing up
+
+`SignUp` is the other way a user gets into a pool. It names an app client rather than a pool, is
+authorized by no IAM policy, and leaves the user in `UNCONFIRMED` with the password it chose.
+
+Real Cognito emails or texts a confirmation code at that point. Nothing here delivers a message, so
+the code is readable from the pool instead, through `confirmationCode` on the pool object. That is a
+deliberate divergence: real Cognito never reports a code back to anyone, and reading one is what
+makes a registration flow testable at all.
+
+```typescript sim-cognito-sign-up
+/**
+ * Signing a user up and confirming it with the code the pool issued.
+ */
+
+import {
+  ConfirmSignUpCommand,
+  CreateUserPoolClientCommand,
+  CreateUserPoolCommand,
+  InitiateAuthCommand,
+  SignUpCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const cognito = simAws.cognitoIdentityProvider();
+
+const pool = await cognito.createUserPool(
+  new CreateUserPoolCommand({
+    PoolName: "myapp-users",
+    AutoVerifiedAttributes: ["email"],
+  }),
+);
+const userPoolId = pool.UserPool!.Id!;
+
+const appClient = await cognito.createUserPoolClient(
+  new CreateUserPoolClientCommand({
+    UserPoolId: userPoolId,
+    ClientName: "web",
+    ExplicitAuthFlows: ["ALLOW_USER_PASSWORD_AUTH"],
+  }),
+);
+const clientId = appClient.UserPoolClient!.ClientId!;
+
+const signedUp = await cognito.signUp(
+  new SignUpCommand({
+    ClientId: clientId,
+    Username: "alice",
+    Password: "Sup3rSecret!",
+    UserAttributes: [{ Name: "email", Value: "alice@example.com" }],
+  }),
+);
+
+console.log(signedUp.UserConfirmed); // false
+console.log(signedUp.UserSub); // A UUID, and not "alice"
+
+// Real Cognito sends this to the user and never reports it. Nothing here
+// delivers a message, so the pool hands it over instead.
+const code = cognito.userPool(userPoolId).confirmationCode("alice");
+
+await cognito.confirmSignUp(
+  new ConfirmSignUpCommand({
+    ClientId: clientId,
+    Username: "alice",
+    ConfirmationCode: code,
+  }),
+);
+
+// The user is CONFIRMED now, and signs in with the password it chose.
+const signedIn = await cognito.initiateAuth(
+  new InitiateAuthCommand({
+    ClientId: clientId,
+    AuthFlow: "USER_PASSWORD_AUTH",
+    AuthParameters: { USERNAME: "alice", PASSWORD: "Sup3rSecret!" },
+  }),
+);
+
+console.log(signedIn.AuthenticationResult?.AccessToken !== undefined); // true
+```
+
+Signing in before confirming is refused with `UserNotConfirmedException`, which real Cognito answers
+with even when the password was right, so an application can tell the two apart and send the user to
+`ConfirmSignUp`. A wrong password is still refused as any wrong password is, and says nothing about
+the account being unconfirmed.
+
+A wrong code is refused with `CodeMismatchException`, and leaves the user unconfirmed holding the
+code it was issued, so a second attempt with the right one works. A code is single use, and
+confirming spends it.
+
+`ResendConfirmationCode` issues a fresh code and the earlier one stops working, as it does on real
+Cognito. A test holding the earlier code has to read the new one from the pool. Asking for a code
+for a user that has already confirmed is refused with `InvalidParameterException`.
+
+`AdminConfirmSignUp` confirms a user with no code at all. It names the pool and the user, and is
+authorized by IAM the way the other admin operations are.
+
+The pool's `AutoVerifiedAttributes` decide what confirming verifies. A pool created with
+`["email"]` has `email_verified` set to `true` on the user when it confirms, because answering with
+the code shows the address is the user's. `AdminConfirmSignUp` sets nothing, as it sets nothing on
+real Cognito: an admin confirming a user says nothing about whose address it is. Only `email` and
+`phone_number` can be verified, and an attribute the user does not have is left alone.
+
+A pool created with `AdminCreateUserConfig: { AllowAdminCreateUserOnly: true }` refuses `SignUp`
+with `NotAuthorizedException`, as a real one does. That value is what a CDK `UserPool` without
+`selfSignUpEnabled` emits, so a project testing its registration flow gets the same answer here that
+the deployed pool would give. A pool created without the setting allows sign-up, which is the AWS
+default.
+
 ## Listing users
 
 `ListUsers` pages by `Limit` and `PaginationToken`, which is what the real operation calls them.
@@ -1051,11 +1160,11 @@ the secret with `DescribeUserPoolClient`, which reports it here as it does on re
 
 The properties each type reads are the ones this simulation models:
 
-- `AWS::Cognito::UserPool`: `UserPoolName`, `Policies`, `DeletionProtection`, `MfaConfiguration`,
-  `UserPoolTier`, `AccountRecoverySetting`, `AdminCreateUserConfig`, `EmailVerificationMessage`,
-  `EmailVerificationSubject`, `SmsVerificationMessage` and `VerificationMessageTemplate`. All but
-  the first three are accepted at one value each and refused at any other, as `CreateUserPool`
-  refuses them.
+- `AWS::Cognito::UserPool`: `UserPoolName`, `Policies`, `DeletionProtection`,
+  `AdminCreateUserConfig`, `AutoVerifiedAttributes`, `MfaConfiguration`, `UserPoolTier`,
+  `AccountRecoverySetting`, `EmailVerificationMessage`, `EmailVerificationSubject`,
+  `SmsVerificationMessage` and `VerificationMessageTemplate`. The last six are accepted at one value
+  each and refused at any other, as `CreateUserPool` refuses them.
 - `AWS::Cognito::UserPoolClient`: `UserPoolId`, `ClientName`, `GenerateSecret`, `ExplicitAuthFlows`,
   `PreventUserExistenceErrors`, `AccessTokenValidity`, `IdTokenValidity`, `RefreshTokenValidity`,
   `TokenValidityUnits`, `AllowedOAuthFlowsUserPoolClient` and `SupportedIdentityProviders`. The last
@@ -1081,10 +1190,12 @@ test can assert it.
 
 A CDK `UserPool` construct emits six properties on `AWS::Cognito::UserPool` before it has been asked
 for anything, and a client created with `disableOAuth` emits two on `AWS::Cognito::UserPoolClient`.
-None of the eight is simulated. They configure email and SMS delivery, verification message wording,
-account recovery, and whether users may sign themselves up, and none of those happens here.
+`AdminCreateUserConfig` is simulated, and decides whether `SignUp` works against the pool. The other
+seven are not: they configure email and SMS delivery, verification message wording and account
+recovery, and none of that happens here.
 
-They are accepted anyway, at one value each and no other, so a CDK stack deploys as it stands.
+Those seven are accepted anyway, at one value each and no other, so a CDK stack deploys as it
+stands.
 
 ```typescript sim-cognito-cdk-defaults
 /**
@@ -1152,7 +1263,8 @@ const described = await simAws
 
 console.log(described.UserPool?.Name); // "app-stack-Pool"
 
-// What the template declared is reported back, though nothing here reads it.
+// What the template declared is reported back. This one is acted on: it is
+// what says only an admin creates users in this pool.
 console.log(described.UserPool?.AdminCreateUserConfig);
 // { AllowAdminCreateUserOnly: true }
 ```
@@ -1163,7 +1275,6 @@ at all, rather than reporting the value it would have had to use.
 | Property                          | Accepted value                                                             |
 | --------------------------------- | -------------------------------------------------------------------------- |
 | `AccountRecoverySetting`          | `verified_phone_number` at priority 1, then `verified_email` at priority 2 |
-| `AdminCreateUserConfig`           | `{ AllowAdminCreateUserOnly: true }`                                       |
 | `EmailVerificationMessage`        | `The verification code to your new account is {####}`                      |
 | `EmailVerificationSubject`        | `Verify your new account`                                                  |
 | `SmsVerificationMessage`          | `The verification code to your new account is {####}`                      |
@@ -1175,12 +1286,9 @@ Every key is compared, so an object carrying one the accepted value does not hav
 with everything else that differs. The refusal names the property, the value asked for and the value
 that is simulated.
 
-Two of these are worth reading twice. `AllowAdminCreateUserOnly` is accepted at `true` and refused
-at `false`, which is the opposite way round from the AWS default: `false` says users may sign
-themselves up, and there is no `SignUp` command here to do that with, so accepting it would promise
-something this simulation cannot do. And the verification wording is accepted only at the wording
-CDK emits, because a request writing its own is asking for a message a user would read, and no
-message is ever delivered.
+The verification wording is worth reading twice. It is accepted only at the wording CDK emits,
+because a request writing its own is asking for a message a user would read, and no message is ever
+delivered.
 
 These values are what `aws-cdk-lib` 2.262.1 synthesizes. Whether real Cognito defaults a bare pool
 to the same wording has not been checked against a live account.
@@ -1381,6 +1489,12 @@ Sim Cognito currently supports:
 - `AdminCreateUserCommand`, `AdminGetUserCommand`, `AdminDeleteUserCommand`,
   `AdminSetUserPasswordCommand`, `AdminUpdateUserAttributesCommand`, `AdminDisableUserCommand`,
   `AdminEnableUserCommand` and `ListUsersCommand`
+- `SignUpCommand`, `ConfirmSignUpCommand` and `ResendConfirmationCodeCommand`, authorized by no IAM
+  policy as they are on real Cognito, and `AdminConfirmSignUpCommand`, which is authorized like the
+  other admin operations
+- `AutoVerifiedAttributes`, so confirming a sign-up sets `email_verified` or
+  `phone_number_verified`, and `AdminCreateUserConfig.AllowAdminCreateUserOnly`, which refuses
+  `SignUp` against a pool created with it
 - `CreateGroupCommand`, `GetGroupCommand`, `UpdateGroupCommand`, `DeleteGroupCommand`,
   `ListGroupsCommand`, `AdminAddUserToGroupCommand`, `AdminRemoveUserFromGroupCommand`,
   `AdminListGroupsForUserCommand` and `ListUsersInGroupCommand`
@@ -1401,7 +1515,7 @@ Sim Cognito currently supports:
 - Pool ids in the real `<region>_<nine characters>` form, and pool ARNs built from them
 - The real default password policy, applied to the passwords users are given
 - The real user status lifecycle, so an admin-created user stays in `FORCE_CHANGE_PASSWORD` until it
-  has a permanent password
+  has a permanent password, and a signed-up user stays in `UNCONFIRMED` until it confirms
 - Group membership, and the precedence order the `cognito:groups` claim uses
 - App client authentication flows, token lifetimes, generated client secrets and
   `PreventUserExistenceErrors`
@@ -1437,11 +1551,30 @@ Current documented limitations:
 - A password is kept so a user can sign in with it, and nothing reads one back.
 - Users are resolved by username only. Real Cognito also accepts a user's `sub` where an admin
   operation asks for a username, and that fails here with `UserNotFoundException`.
-- Self-service sign-up is not simulated. `SignUp`, `ConfirmSignUp`, `ForgotPassword`,
-  `ChangePassword` and `ResendConfirmationCode` are not implemented, so the `UNCONFIRMED` and
-  `RESET_REQUIRED` statuses cannot be reached. `AdminCreateUser` is the only way to make a user.
-- No message is ever delivered. `AdminCreateUser` sends no invitation, so `MessageAction: SUPPRESS`
-  is accepted and changes nothing, `RESEND` is refused, and `DesiredDeliveryMediums` is refused.
+- A pool reports the confirmation code a signed-up user is waiting to answer with, through
+  `confirmationCode` on the pool object. Real Cognito sends the code and never reports it to anyone.
+  Nothing here delivers a message, so this is what makes a registration flow testable, and it is a
+  deliberate divergence rather than an operation to write application code against.
+- A confirmation code never expires, where a real one lasts 24 hours. `ResendConfirmationCode` is
+  what replaces one.
+- `AdminConfirmSignUp` verifies nothing, whatever the pool's `AutoVerifiedAttributes` say, as it
+  verifies nothing on real Cognito. Only `ConfirmSignUp` sets `email_verified` and
+  `phone_number_verified`, and only where the user has the attribute to verify.
+- `AutoVerifiedAttributes` is accepted at `email` and `phone_number`, and anything else is refused.
+  Those are the two Cognito can send a code to.
+- `SignUp`, `ConfirmSignUp` and `ResendConfirmationCode` report a user the pool does not hold
+  whatever the app client's `PreventUserExistenceErrors` says. That setting is honoured for sign-in
+  only.
+- Password reset is not simulated. `ForgotPassword`, `ConfirmForgotPassword` and `ChangePassword`
+  are not implemented, so the `RESET_REQUIRED` status cannot be reached.
+- Unsimulated sign-up inputs are refused rather than ignored: `ClientMetadata`, `AnalyticsMetadata`
+  and `UserContextData` on the three client-side operations, `ValidationData` on `SignUp`,
+  `ForceAliasCreation` and `Session` on `ConfirmSignUp`, and `ClientMetadata` on
+  `AdminConfirmSignUp`.
+- No message is ever delivered. `SignUp` and `ResendConfirmationCode` send no confirmation code, and
+  neither reports `CodeDeliveryDetails`. `AdminCreateUser` sends no invitation, so
+  `MessageAction: SUPPRESS` is accepted and changes nothing, `RESEND` is refused, and
+  `DesiredDeliveryMediums` is refused.
 - A temporary password never expires. `TemporaryPasswordValidityDays` is stored on the pool and
   nothing acts on it.
 - Unsimulated `AdminCreateUser` inputs are refused rather than ignored: `DesiredDeliveryMediums`,
@@ -1473,21 +1606,19 @@ Current documented limitations:
 - A pool with `DeletionProtection: ACTIVE` cannot be deleted at all, because deactivating the
   protection needs `UpdateUserPool`.
 - Unsimulated `CreateUserPool` inputs are refused rather than ignored: `UsernameAttributes`,
-  `AliasAttributes`, `AutoVerifiedAttributes`, `Schema`, `LambdaConfig`, `UsernameConfiguration`,
+  `AliasAttributes`, `Schema`, `LambdaConfig`, `UsernameConfiguration`,
   `UserAttributeUpdateSettings`, `DeviceConfiguration`, `UserPoolAddOns`, `KeyConfiguration`,
   `IssuerConfiguration`, `UserPoolTags`, the email and SMS configurations, an
   `SmsAuthenticationMessage`, an `MfaConfiguration` other than `OFF`, a `UserPoolTier` other than
   `ESSENTIALS`, a `SignInPolicy`, and a `PasswordHistorySize`.
-- `AccountRecoverySetting`, `AdminCreateUserConfig`, `EmailVerificationMessage`,
-  `EmailVerificationSubject`, `SmsVerificationMessage` and `VerificationMessageTemplate` are
-  accepted at one value each and refused at any other. Nothing here reads any of them. They are
-  accepted so a CDK stack deploys, and reported back by `DescribeUserPool` so what the template
-  declared stays visible. The accepted values are in "Properties accepted without being simulated"
-  above.
-- `AdminCreateUserConfig` is accepted at `{ AllowAdminCreateUserOnly: true }` and refused at
-  `AllowAdminCreateUserOnly: false`, though `false` is what AWS itself defaults to. `false` says
-  users may sign themselves up, and there is no `SignUp` command here, so accepting it would let a
-  pool be created that claims something this simulation cannot do. This is stricter than AWS.
+- `AccountRecoverySetting`, `EmailVerificationMessage`, `EmailVerificationSubject`,
+  `SmsVerificationMessage` and `VerificationMessageTemplate` are accepted at one value each and
+  refused at any other. Nothing here reads any of them. They are accepted so a CDK stack deploys,
+  and reported back by `DescribeUserPool` so what the template declared stays visible. The accepted
+  values are in "Properties accepted without being simulated" above.
+- `AdminCreateUserConfig.AllowAdminCreateUserOnly` is acted on, and the two keys beside it are
+  refused: `InviteMessageTemplate` and `UnusedAccountValidityDays` are both about the invitation an
+  admin-created user is sent, and no message is delivered here.
 - `UsernameAttributes` is worth calling out among those. A pool that signs users in by email or phone
   number stores a generated UUID as the username, so a pool created here without that would answer
   with the wrong username and the right one on real AWS.

--- a/docs/services/cognito/sim-cognito-cdk-defaults.example.ts
+++ b/docs/services/cognito/sim-cognito-cdk-defaults.example.ts
@@ -63,6 +63,7 @@ const described = await simAws
 
 console.log(described.UserPool?.Name); // "app-stack-Pool"
 
-// What the template declared is reported back, though nothing here reads it.
+// What the template declared is reported back. This one is acted on: it is
+// what says only an admin creates users in this pool.
 console.log(described.UserPool?.AdminCreateUserConfig);
 // { AllowAdminCreateUserOnly: true }

--- a/docs/services/cognito/sim-cognito-sign-up.example.ts
+++ b/docs/services/cognito/sim-cognito-sign-up.example.ts
@@ -1,0 +1,68 @@
+/**
+ * Signing a user up and confirming it with the code the pool issued.
+ */
+
+import {
+  ConfirmSignUpCommand,
+  CreateUserPoolClientCommand,
+  CreateUserPoolCommand,
+  InitiateAuthCommand,
+  SignUpCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const cognito = simAws.cognitoIdentityProvider();
+
+const pool = await cognito.createUserPool(
+  new CreateUserPoolCommand({
+    PoolName: "myapp-users",
+    AutoVerifiedAttributes: ["email"],
+  }),
+);
+const userPoolId = pool.UserPool!.Id!;
+
+const appClient = await cognito.createUserPoolClient(
+  new CreateUserPoolClientCommand({
+    UserPoolId: userPoolId,
+    ClientName: "web",
+    ExplicitAuthFlows: ["ALLOW_USER_PASSWORD_AUTH"],
+  }),
+);
+const clientId = appClient.UserPoolClient!.ClientId!;
+
+const signedUp = await cognito.signUp(
+  new SignUpCommand({
+    ClientId: clientId,
+    Username: "alice",
+    Password: "Sup3rSecret!",
+    UserAttributes: [{ Name: "email", Value: "alice@example.com" }],
+  }),
+);
+
+console.log(signedUp.UserConfirmed); // false
+console.log(signedUp.UserSub); // A UUID, and not "alice"
+
+// Real Cognito sends this to the user and never reports it. Nothing here
+// delivers a message, so the pool hands it over instead.
+const code = cognito.userPool(userPoolId).confirmationCode("alice");
+
+await cognito.confirmSignUp(
+  new ConfirmSignUpCommand({
+    ClientId: clientId,
+    Username: "alice",
+    ConfirmationCode: code,
+  }),
+);
+
+// The user is CONFIRMED now, and signs in with the password it chose.
+const signedIn = await cognito.initiateAuth(
+  new InitiateAuthCommand({
+    ClientId: clientId,
+    AuthFlow: "USER_PASSWORD_AUTH",
+    AuthParameters: { USERNAME: "alice", PASSWORD: "Sup3rSecret!" },
+  }),
+);
+
+console.log(signedIn.AuthenticationResult?.AccessToken !== undefined); // true

--- a/src/service/cloudformation/cdk/cognito/sim-cdk-cognito-user-pool.loc.test.ts
+++ b/src/service/cloudformation/cdk/cognito/sim-cdk-cognito-user-pool.loc.test.ts
@@ -1,9 +1,13 @@
 import {
   AdminCreateUserCommand,
+  AdminGetUserCommand,
   AdminInitiateAuthCommand,
   AdminSetUserPasswordCommand,
+  ConfirmSignUpCommand,
   DescribeUserPoolClientCommand,
   DescribeUserPoolCommand,
+  InitiateAuthCommand,
+  SignUpCommand,
 } from "@aws-sdk/client-cognito-identity-provider";
 import {
   assertArrayEquals,
@@ -12,6 +16,7 @@ import {
   assertNonNullable,
   assertObjectEquals,
   assertStringStartsWith,
+  assertTrue,
   assertTypeString,
 } from "@kensio/smartass";
 import path from "node:path";
@@ -155,6 +160,105 @@ app.synth();
     );
 
     assertNonNullable(signedIn.AuthenticationResult?.AccessToken);
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("deploys a CDK user pool a user signs itself up in", async () => {
+    // Given a CDK stack with a user pool that lets users sign themselves up
+    // and verifies the email address they sign up with.
+    const cdkProject = new TestCdkProject();
+    await cdkProject.writeCdkAppFile(
+      `
+import * as cdk from "aws-cdk-lib/core";
+import * as cognito from "aws-cdk-lib/aws-cognito";
+
+const app = new cdk.App();
+const stack = new cdk.Stack(app, "TestStack", {
+  env: { account: "111111111111", region: "eu-west-2" },
+});
+
+const pool = new cognito.UserPool(stack, "Pool", {
+  selfSignUpEnabled: true,
+  autoVerify: { email: true },
+});
+const client = pool.addClient("Client", {
+  disableOAuth: true,
+  authFlows: { userPassword: true },
+});
+
+new cdk.CfnOutput(stack, "PoolId", { value: pool.userPoolId });
+new cdk.CfnOutput(stack, "ClientId", { value: client.userPoolClientId });
+
+app.synth();
+      `,
+    );
+
+    // And we synth the CDK template.
+    const cdkOutDirectory = await cdkProject.synth();
+
+    // When we deploy it, and someone signs themselves up through the deployed
+    // app client.
+    const simAws = new SimAws();
+    const scoped = simAws.account(accountIdOneOnes).region("eu-west-2");
+    const stack = await scoped
+      .cloudFormation()
+      .deployTemplateFile(
+        path.join(cdkOutDirectory, "TestStack.template.json"),
+      );
+    await stack.waitForDeployComplete();
+
+    const userPoolId = stack.outputs.get("PoolId")?.value;
+    const clientId = stack.outputs.get("ClientId")?.value;
+    assertTypeString(userPoolId);
+    assertTypeString(clientId);
+
+    const cognito = scoped.cognitoIdentityProvider();
+
+    await cognito.signUp(
+      new SignUpCommand({
+        ClientId: clientId,
+        Username: "alice",
+        Password: "Sup3rSecretPassw0rd!",
+        UserAttributes: [{ Name: "email", Value: "alice@example.com" }],
+      }),
+    );
+    await cognito.confirmSignUp(
+      new ConfirmSignUpCommand({
+        ClientId: clientId,
+        Username: "alice",
+        ConfirmationCode: cognito
+          .userPool(userPoolId)
+          .confirmationCode("alice"),
+      }),
+    );
+
+    // Then the user signs in against the deployed pool, and the email address
+    // it signed up with is verified, because the template asked for that.
+    const signedIn = await cognito.initiateAuth(
+      new InitiateAuthCommand({
+        ClientId: clientId,
+        AuthFlow: "USER_PASSWORD_AUTH",
+        AuthParameters: {
+          USERNAME: "alice",
+          PASSWORD: "Sup3rSecretPassw0rd!",
+        },
+      }),
+    );
+
+    assertNonNullable(signedIn.AuthenticationResult?.AccessToken);
+
+    const described = await cognito.adminGetUser(
+      new AdminGetUserCommand({ UserPoolId: userPoolId, Username: "alice" }),
+    );
+
+    assertIdentical(described.UserStatus, "CONFIRMED");
+    assertTrue(
+      (described.UserAttributes ?? []).some(
+        (attribute) =>
+          attribute.Name === "email_verified" && attribute.Value === "true",
+      ),
+    );
 
     await simAws.backgroundTasksComplete();
   });

--- a/src/service/cognito/README.md
+++ b/src/service/cognito/README.md
@@ -3,9 +3,9 @@
 This directory contains the simulated Cognito user pools implementation. Cognito identity pools,
 which exchange a token for AWS credentials, are a separate service and are not simulated at all.
 
-The pool, the app client, the users and groups in it, the sign-in flows on both sides of the API,
-the tokens it issues and the authorizer are all here. SRP, the hosted UI, MFA and device tracking
-are not.
+The pool, the app client, the users and groups in it, self-service sign-up, the sign-in flows on
+both sides of the API, the tokens it issues and the authorizer are all here. SRP, the hosted UI,
+MFA, password resets and device tracking are not.
 
 ## Entry points
 
@@ -78,10 +78,24 @@ against the pool's policy when it is set, and held as a `SimCognitoUserPassword`
 whether a candidate matches and exposes nothing, the same modelling choice simulated KMS key
 material makes.
 
-`SimCognitoUserStatus` holds the two statuses this simulation can reach, and the transition between
-them. `AdminCreateUser` leaves a user in `FORCE_CHANGE_PASSWORD`, and only a permanent password
-reaches `CONFIRMED`. The rest of the real statuses belong to sign-up, resets and federation, none of
-which are simulated.
+`SimCognitoUserStatus` holds the three statuses this simulation can reach, and the transitions
+between them. `AdminCreateUser` leaves a user in `FORCE_CHANGE_PASSWORD`, and only a permanent
+password reaches `CONFIRMED`. `SignUp` leaves a user in `UNCONFIRMED`, and `ConfirmSignUp`,
+`AdminConfirmSignUp` or a permanent password reaches `CONFIRMED` from there. The rest of the real
+statuses belong to password resets and federation, neither of which is simulated.
+
+`SimCognitoConfirmationCode` is the six-digit code a signed-up user is issued. A user gets one when
+it is constructed `UNCONFIRMED`, spends it when it leaves that status, and `ResendConfirmationCode`
+replaces it with another rather than sending the same one again. The code is readable, through
+`SimCognitoUserPool.confirmationCode`, which real Cognito never allows: nothing here delivers a
+message, so a test would otherwise have nowhere to read it from. That accessor is the one place this
+simulation knowingly tells a caller something real Cognito would not.
+
+`SimCognitoAdminCreateUserConfig` is whether users may sign themselves up, and
+`SimCognitoAutoVerifiedAttributes` is what confirming a sign-up marks verified. Both are pool state
+rather than settings accepted and ignored: `AllowAdminCreateUserOnly: true` is what a CDK `UserPool`
+without `selfSignUpEnabled` emits, and a simulation that took `SignUp` against such a pool would
+pass code that a deployment refuses.
 
 `SimCognitoUserAttributes` validates attribute names against the pool's schema. Only the standard
 attributes exist, because `CreateUserPool` refuses a `Schema`, so a `custom:` attribute is refused
@@ -232,8 +246,10 @@ rather than one class per command, so the `SimCognitoIdentityProvider` facade st
 - `command/user-pool/`: the pool commands, their structural input/output types and their output
   views
 - `command/client/`: the same for app clients
-- `command/user/`: the same for users, split between the commands that create, read and delete one
-  and the commands that change one afterwards
+- `command/user/`: the same for users, split between the commands that create, read and delete one,
+  the commands that change one afterwards, and the commands a user signs itself up with. The
+  sign-up ones resolve their pool through an app client id the way the client-side sign-in commands
+  do, so they share `SimCognitoAuthResolver` with them
 - `command/group/`: the same for groups, split between the commands that act on a group and the
   commands that move users in and out of one
 - `command/auth/`: the four sign-in operations and the two sign-out ones, the flow and challenge
@@ -279,9 +295,9 @@ command instances.
 - `CreateUserPool` and `ListUserPools` authorize against `*`, because real Cognito gives those two
   actions no resource-level permissions, so a policy naming individual pool ARNs grants nothing.
 
-`InitiateAuth`, `RespondToAuthChallenge` and `GlobalSignOut` authorize nothing, and read no caller.
-Real Cognito evaluates no IAM policy for them: they are what an application calls on behalf of a
-user, holding no AWS credentials at all. Authorizing them here would pass code that a real
+`InitiateAuth`, `RespondToAuthChallenge`, `GlobalSignOut`, `SignUp`, `ConfirmSignUp` and
+`ResendConfirmationCode` authorize nothing, and read no caller. Real Cognito evaluates no IAM policy
+for them: they are what an application calls on behalf of a user, holding no AWS credentials at all. Authorizing them here would pass code that a real
 deployment refuses, and refuse code that really works.
 
 A policy granting an app client action on a pool therefore reaches every client in that pool, and a
@@ -290,6 +306,18 @@ resource, here or on real AWS.
 
 ## Divergences worth knowing
 
+- A user pool reports the confirmation code a signed-up user was issued, through
+  `SimCognitoUserPool.confirmationCode`. Real Cognito sends it and never reports it to anyone.
+  Nothing here delivers a message, so this is what makes a sign-up flow testable at all.
+- `AdminConfirmSignUp` verifies nothing, whatever the pool's `AutoVerifiedAttributes` say, as it
+  verifies nothing on real Cognito. Only `ConfirmSignUp` sets `email_verified` and
+  `phone_number_verified`, and only where the user has the attribute to verify.
+- A confirmation code never expires, where a real one lasts 24 hours. `ResendConfirmationCode` is
+  what replaces one.
+- `ForgotPassword`, `ConfirmForgotPassword` and `ChangePassword` are not implemented, so
+  `RESET_REQUIRED` is a status no user here reaches.
+- A client-side sign-up operation naming a user the pool does not hold reports it, whatever the app
+  client's `PreventUserExistenceErrors` says. That setting is honoured for sign-in only.
 - Every unsimulated `CreateUserPool` and `CreateUserPoolClient` input is refused rather than ignored.
   `UsernameAttributes` is the one that matters most: a pool signing users in by email stores a
   generated UUID as the username, so a pool quietly created without it would answer with the wrong

--- a/src/service/cognito/cfn/sim-cfn-cognito-cdk-defaults.iso.test.ts
+++ b/src/service/cognito/cfn/sim-cfn-cognito-cdk-defaults.iso.test.ts
@@ -138,8 +138,8 @@ describe("Cognito CloudFormation defaults a CDK stack emits", () => {
   });
 
   it("refuses a pool property at a value other than the one it accepts", async () => {
-    // Given a template asking for self-service sign-up, which no command here
-    // implements.
+    // Given a template writing its own account recovery, which nothing here
+    // reaches whichever mechanisms are listed.
     const simAws = simAwsInEuWest2();
 
     // When it is deployed.
@@ -148,7 +148,9 @@ describe("Cognito CloudFormation defaults a CDK stack emits", () => {
         Type: "AWS::Cognito::UserPool",
         Properties: {
           UserPoolName: "myapp-users",
-          AdminCreateUserConfig: { AllowAdminCreateUserOnly: false },
+          AccountRecoverySetting: {
+            RecoveryMechanisms: [{ Name: "admin_only", Priority: 1 }],
+          },
         },
       },
     });
@@ -156,13 +158,54 @@ describe("Cognito CloudFormation defaults a CDK stack emits", () => {
     // Then the failure names the logical ID, the property, the value asked
     // for and the one that is simulated.
     assertStringIncludes(error.message, "AppPool");
-    assertStringIncludes(error.message, "CreateUserPool AdminCreateUserConfig");
-    assertStringIncludes(error.message, '{"AllowAdminCreateUserOnly":false}');
-    assertStringIncludes(error.message, "self-service sign-up");
     assertStringIncludes(
       error.message,
-      'Only {"AllowAdminCreateUserOnly":true} is supported',
+      "CreateUserPool AccountRecoverySetting",
     );
+    assertStringIncludes(error.message, '"Name":"admin_only"');
+    assertStringIncludes(error.message, "account recovery");
+    assertStringIncludes(error.message, "Only");
+  });
+
+  it("deploys a pool a CDK stack asked for self-service sign-up on", async () => {
+    // Given the AdminCreateUserConfig and AutoVerifiedAttributes CDK emits for
+    // a UserPool with selfSignUpEnabled and autoVerify of the email address.
+    const simAws = simAwsInEuWest2();
+
+    // When it is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "app-stack",
+      template: {
+        Resources: {
+          Pool: {
+            Type: "AWS::Cognito::UserPool",
+            Properties: {
+              ...cdkPoolProperties,
+              AdminCreateUserConfig: { AllowAdminCreateUserOnly: false },
+              AutoVerifiedAttributes: ["email"],
+            },
+          },
+        },
+        Outputs: { PoolId: { Value: { Ref: "Pool" } } },
+      },
+    });
+    await stack.waitForDeployComplete();
+
+    // Then the pool deployed with both, so a user can sign itself up in it.
+    const userPoolId = stack.outputs.get("PoolId")?.value;
+    assertTypeString(userPoolId);
+
+    const described = await simAws
+      .cognitoIdentityProvider()
+      .describeUserPool(
+        new DescribeUserPoolCommand({ UserPoolId: userPoolId }),
+      );
+
+    assertNonNullable(described.UserPool);
+    assertObjectEquals(described.UserPool.AdminCreateUserConfig, {
+      AllowAdminCreateUserOnly: false,
+    });
+    assertArrayEquals(described.UserPool.AutoVerifiedAttributes, ["email"]);
   });
 
   it("refuses a client asking for the hosted UI flows", async () => {

--- a/src/service/cognito/cfn/sim-cfn-cognito-validation.iso.test.ts
+++ b/src/service/cognito/cfn/sim-cfn-cognito-validation.iso.test.ts
@@ -164,6 +164,32 @@ describe("Cognito CloudFormation validation", () => {
     );
   });
 
+  it("refuses an attribute Cognito cannot verify", async () => {
+    // Given a template auto-verifying an attribute no confirmation code is
+    // ever sent to.
+    const simAws = simAwsInEuWest2();
+
+    // When it is deployed.
+    const error = await deployFailure(simAws, {
+      AppPool: {
+        Type: "AWS::Cognito::UserPool",
+        Properties: {
+          UserPoolName: "myapp-users",
+          AutoVerifiedAttributes: ["profile"],
+        },
+      },
+    });
+
+    // Then the refusal names the attribute and the two that can be verified.
+    assertStringIncludes(error.message, "AppPool");
+    assertStringIncludes(
+      error.message,
+      "CreateUserPool AutoVerifiedAttributes 'profile' is not an attribute " +
+        "Cognito can verify",
+    );
+    assertStringIncludes(error.message, "email and phone_number");
+  });
+
   it("refuses a property value of the wrong shape", async () => {
     // Given a template whose GroupName is a number rather than a string.
     const simAws = simAwsInEuWest2();

--- a/src/service/cognito/cfn/user-pool/sim-cfn-cognito-admin-create-user-config.ts
+++ b/src/service/cognito/cfn/user-pool/sim-cfn-cognito-admin-create-user-config.ts
@@ -1,0 +1,85 @@
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValue } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimCognitoAdminCreateUserConfigType } from "../../user-pool/sim-cognito-admin-create-user-config.js";
+import type { SimCfnCognitoPropertyParser } from "../sim-cfn-cognito-property-parser.js";
+
+/**
+ * The `AdminCreateUserConfig` fields this simulation reads, which are all of
+ * them.
+ *
+ * The two beside `AllowAdminCreateUserOnly` are read so that CreateUserPool
+ * can refuse them in words that say why, rather than having them dropped
+ * silently on the way.
+ */
+const modelledFields = [
+  "AllowAdminCreateUserOnly",
+  "InviteMessageTemplate",
+  "UnusedAccountValidityDays",
+];
+
+interface SimCfnCognitoAdminCreateUserConfigProperties {
+  readonly resource: SimCfnResource;
+  readonly propertyParser: SimCfnCognitoPropertyParser;
+}
+
+/**
+ * Reads the `AdminCreateUserConfig` property of an AWS::Cognito::UserPool
+ * Resource into the shape CreateUserPool takes.
+ *
+ * `AllowAdminCreateUserOnly` is what a CDK `UserPool` sets from
+ * `selfSignUpEnabled`, and is the property that decides whether `SignUp` works
+ * against the deployed pool at all, so it is parsed as a boolean rather than
+ * passed through as whatever the template carried.
+ */
+export class SimCfnCognitoAdminCreateUserConfig {
+  private readonly resource: SimCfnResource;
+  private readonly propertyParser: SimCfnCognitoPropertyParser;
+
+  constructor(properties: SimCfnCognitoAdminCreateUserConfigProperties) {
+    this.resource = properties.resource;
+    this.propertyParser = properties.propertyParser;
+  }
+
+  /**
+   * The pool's admin creation configuration, or undefined when the template
+   * names none.
+   */
+  parse(
+    value: SimCfnTemplateValue | undefined,
+  ): SimCognitoAdminCreateUserConfigType | undefined {
+    const config = this.propertyParser.optionalRecord(
+      this.resource,
+      value,
+      "AdminCreateUserConfig",
+    );
+
+    if (config === undefined) {
+      return undefined;
+    }
+
+    this.propertyParser.ignoreUnmodelledKeys(
+      this.resource,
+      config,
+      modelledFields,
+      "AdminCreateUserConfig ",
+    );
+
+    return {
+      AllowAdminCreateUserOnly: this.propertyParser.optionalBoolean(
+        this.resource,
+        config["AllowAdminCreateUserOnly"],
+        "AdminCreateUserConfig AllowAdminCreateUserOnly",
+      ),
+      InviteMessageTemplate: this.propertyParser.optionalRecord(
+        this.resource,
+        config["InviteMessageTemplate"],
+        "AdminCreateUserConfig InviteMessageTemplate",
+      ),
+      UnusedAccountValidityDays: this.propertyParser.optionalNumber(
+        this.resource,
+        config["UnusedAccountValidityDays"],
+        "AdminCreateUserConfig UnusedAccountValidityDays",
+      ),
+    };
+  }
+}

--- a/src/service/cognito/cfn/user-pool/sim-cfn-cognito-user-pool-properties.ts
+++ b/src/service/cognito/cfn/user-pool/sim-cfn-cognito-user-pool-properties.ts
@@ -6,6 +6,7 @@ import type {
 import type { SimCreateUserPoolCommandInput } from "../../command/user-pool/user-pool.command.js";
 import { SimCfnCognitoGeneratedName } from "../sim-cfn-cognito-generated-name.js";
 import { SimCfnCognitoPropertyParser } from "../sim-cfn-cognito-property-parser.js";
+import { SimCfnCognitoAdminCreateUserConfig } from "./sim-cfn-cognito-admin-create-user-config.js";
 import { SimCfnCognitoPolicies } from "./sim-cfn-cognito-policies.js";
 
 /**
@@ -16,12 +17,17 @@ import { SimCfnCognitoPolicies } from "./sim-cfn-cognito-policies.js";
  * why. A CDK stack states both routinely, and a pool created without either
  * would be reported as behaving differently when it does not.
  *
- * The six from `AccountRecoverySetting` down are here for the same reason,
- * and are the six a CDK `UserPool` construct emits when it was asked for
- * nothing in particular. Each configures message delivery, verification
- * wording or account recovery, none of which is simulated, so CreateUserPool
- * accepts each at the one value that asks for nothing this simulation does
- * not already do and refuses it at every other.
+ * `AdminCreateUserConfig` and `AutoVerifiedAttributes` are the two a
+ * `selfSignUpEnabled` CDK pool turns on, and both are acted on: the first
+ * decides whether `SignUp` is allowed at all, and the second decides which
+ * attributes confirming a sign-up marks as verified.
+ *
+ * The five from `AccountRecoverySetting` down are here because a CDK
+ * `UserPool` construct emits them when it was asked for nothing in
+ * particular. Each configures message delivery, verification wording or
+ * account recovery, none of which is simulated, so CreateUserPool accepts each
+ * at the one value that asks for nothing this simulation does not already do
+ * and refuses it at every other.
  */
 const simulatedProperties = [
   "UserPoolName",
@@ -29,8 +35,9 @@ const simulatedProperties = [
   "DeletionProtection",
   "MfaConfiguration",
   "UserPoolTier",
-  "AccountRecoverySetting",
   "AdminCreateUserConfig",
+  "AutoVerifiedAttributes",
+  "AccountRecoverySetting",
   "EmailVerificationMessage",
   "EmailVerificationSubject",
   "SmsVerificationMessage",
@@ -94,9 +101,14 @@ export class SimCfnCognitoUserPoolProperties {
         this.properties["AccountRecoverySetting"],
         "AccountRecoverySetting",
       ),
-      AdminCreateUserConfig: this.record(
-        this.properties["AdminCreateUserConfig"],
-        "AdminCreateUserConfig",
+      AdminCreateUserConfig: new SimCfnCognitoAdminCreateUserConfig({
+        resource: this.resource,
+        propertyParser: this.propertyParser,
+      }).parse(this.properties["AdminCreateUserConfig"]),
+      AutoVerifiedAttributes: this.propertyParser.optionalStringArray(
+        this.resource,
+        this.properties["AutoVerifiedAttributes"],
+        "AutoVerifiedAttributes",
       ),
       VerificationMessageTemplate: this.record(
         this.properties["VerificationMessageTemplate"],

--- a/src/service/cognito/command/auth/sim-cognito-auth-commands.ts
+++ b/src/service/cognito/command/auth/sim-cognito-auth-commands.ts
@@ -5,7 +5,7 @@ import type { SimCognitoRequestResolver } from "../sim-cognito-request-resolver.
 import { SimCognitoAdminInitiateAuth } from "./sim-cognito-admin-initiate-auth.js";
 import { SimCognitoAdminRespondToChallenge } from "./sim-cognito-admin-respond-to-challenge.js";
 import { SimCognitoAuthFlowRunner } from "./sim-cognito-auth-flow-runner.js";
-import { SimCognitoAuthResolver } from "./sim-cognito-auth-resolver.js";
+import type { SimCognitoAuthResolver } from "./sim-cognito-auth-resolver.js";
 import { SimCognitoInitiateAuth } from "./sim-cognito-initiate-auth.js";
 import { SimCognitoNewPasswordChallenge } from "./sim-cognito-new-password-challenge.js";
 import { SimCognitoNewPasswordResponse } from "./sim-cognito-new-password-response.js";
@@ -16,6 +16,7 @@ import { SimCognitoSignOutCommands } from "./sim-cognito-sign-out.js";
 
 interface SimCognitoAuthCommandsProperties {
   readonly resolver: SimCognitoRequestResolver;
+  readonly authResolver: SimCognitoAuthResolver;
   readonly pools: SimCognitoUserPoolStore;
   readonly clock: SimClock;
 }
@@ -23,10 +24,11 @@ interface SimCognitoAuthCommandsProperties {
 /**
  * The authentication command handlers of one simulated Cognito scope.
  *
- * The four sign-in commands share a resolver, a token issuer and the bodies of
- * the flows they run, and the sign-out commands share the pool store with
- * them, so they are built together here rather than among the pool and
- * directory commands.
+ * The four sign-in commands share a token issuer and the bodies of the flows
+ * they run, and the sign-out commands share the pool store with them, so they
+ * are built together here rather than among the pool and directory commands.
+ * The resolvers arrive from outside because the sign-up commands resolve an
+ * app client the same way these do.
  */
 export class SimCognitoAuthCommands {
   public readonly adminInitiateAuth: SimCognitoAdminInitiateAuth;
@@ -36,8 +38,7 @@ export class SimCognitoAuthCommands {
   public readonly signOut: SimCognitoSignOutCommands;
 
   constructor(properties: SimCognitoAuthCommandsProperties) {
-    const { resolver, pools, clock } = properties;
-    const authResolver = new SimCognitoAuthResolver({ resolver, pools });
+    const { resolver, authResolver, pools, clock } = properties;
     const tokenIssuer = new SimCognitoTokenIssuer({ clock });
     const flowRunner = new SimCognitoAuthFlowRunner({
       passwordSignIn: new SimCognitoPasswordSignIn({

--- a/src/service/cognito/command/auth/sim-cognito-password-sign-in.ts
+++ b/src/service/cognito/command/auth/sim-cognito-password-sign-in.ts
@@ -1,4 +1,5 @@
 import {
+  requireSimCognitoConfirmed,
   requireSimCognitoSignIn,
   requireSimCognitoSignInUser,
 } from "../../user-pool/auth/sim-cognito-sign-in.js";
@@ -56,6 +57,7 @@ export class SimCognitoPasswordSignIn {
     const user = requireSimCognitoSignInUser(pool, client, username);
 
     requireSimCognitoSignIn(user, parameters.require("PASSWORD"));
+    requireSimCognitoConfirmed(user);
 
     if (user.status.mustChangePassword) {
       return this.challenge.issue({ pool, clientId: client.id, user });

--- a/src/service/cognito/command/sim-cognito-command.types.ts
+++ b/src/service/cognito/command/sim-cognito-command.types.ts
@@ -65,6 +65,20 @@ export type {
   SimListUsersCommandOutput,
 } from "./user/list-users.command.js";
 export type {
+  SimAdminConfirmSignUpCommand,
+  SimAdminConfirmSignUpCommandInput,
+  SimAdminConfirmSignUpCommandOutput,
+  SimCognitoSignUpCommandInput,
+  SimConfirmSignUpCommand,
+  SimConfirmSignUpCommandInput,
+  SimConfirmSignUpCommandOutput,
+  SimResendConfirmationCodeCommand,
+  SimResendConfirmationCodeCommandOutput,
+  SimSignUpCommand,
+  SimSignUpCommandInput,
+  SimSignUpCommandOutput,
+} from "./user/sign-up.command.js";
+export type {
   SimCognitoGroupCommandInput,
   SimCognitoGroupType,
   SimCreateGroupCommand,

--- a/src/service/cognito/command/sim-cognito-commands.ts
+++ b/src/service/cognito/command/sim-cognito-commands.ts
@@ -7,6 +7,7 @@ import { SimCognitoUserPoolFactory } from "../user-pool/sim-cognito-user-pool-fa
 import type { SimCognitoUserPoolStore } from "../user-pool/sim-cognito-user-pool-store.js";
 import { SimCognitoUserFactory } from "../user-pool/user/sim-cognito-user-factory.js";
 import { SimCognitoAuthCommands } from "./auth/sim-cognito-auth-commands.js";
+import { SimCognitoAuthResolver } from "./auth/sim-cognito-auth-resolver.js";
 import { SimCognitoAuthorizer } from "./authorize/sim-cognito-authorizer.js";
 import { SimCognitoListUserPoolClients } from "./client/sim-cognito-list-user-pool-clients.js";
 import { SimCognitoGroupCommands } from "./group/sim-cognito-group-commands.js";
@@ -14,6 +15,7 @@ import { SimCognitoGroupMembershipCommands } from "./group/sim-cognito-group-mem
 import { SimCognitoListGroups } from "./group/sim-cognito-list-groups.js";
 import { SimCognitoUserPoolClientCommands } from "./client/sim-cognito-user-pool-client-commands.js";
 import { SimCognitoListUsers } from "./user/sim-cognito-list-users.js";
+import { SimCognitoSignUpCommands } from "./user/sim-cognito-sign-up-commands.js";
 import { SimCognitoUserCommands } from "./user/sim-cognito-user-commands.js";
 import { SimCognitoRequestResolver } from "./sim-cognito-request-resolver.js";
 import { SimCognitoUserUpdateCommands } from "./user/sim-cognito-user-update-commands.js";
@@ -40,6 +42,7 @@ export class SimCognitoCommands {
   public readonly clients: SimCognitoUserPoolClientCommands;
   public readonly listClients: SimCognitoListUserPoolClients;
   public readonly users: SimCognitoUserCommands;
+  public readonly signUp: SimCognitoSignUpCommands;
   public readonly userUpdates: SimCognitoUserUpdateCommands;
   public readonly listUsers: SimCognitoListUsers;
   public readonly groups: SimCognitoGroupCommands;
@@ -51,6 +54,8 @@ export class SimCognitoCommands {
     const { accountRegionScope, iam, clock, pools } = properties;
     const authorizer = new SimCognitoAuthorizer({ iam, accountRegionScope });
     const resolver = new SimCognitoRequestResolver({ pools, authorizer });
+    const authResolver = new SimCognitoAuthResolver({ resolver, pools });
+    const userFactory = new SimCognitoUserFactory({ clock });
 
     this.userPools = new SimCognitoUserPoolCommands({
       pools,
@@ -68,9 +73,11 @@ export class SimCognitoCommands {
       authorizer,
     });
     this.listClients = new SimCognitoListUserPoolClients({ pools, authorizer });
-    this.users = new SimCognitoUserCommands({
+    this.users = new SimCognitoUserCommands({ resolver, userFactory });
+    this.signUp = new SimCognitoSignUpCommands({
+      authResolver,
       resolver,
-      userFactory: new SimCognitoUserFactory({ clock }),
+      userFactory,
     });
     this.userUpdates = new SimCognitoUserUpdateCommands({ resolver });
     this.listUsers = new SimCognitoListUsers({ resolver });
@@ -80,6 +87,11 @@ export class SimCognitoCommands {
     });
     this.groupMembership = new SimCognitoGroupMembershipCommands({ resolver });
     this.listGroups = new SimCognitoListGroups({ resolver });
-    this.auth = new SimCognitoAuthCommands({ resolver, pools, clock });
+    this.auth = new SimCognitoAuthCommands({
+      resolver,
+      authResolver,
+      pools,
+      clock,
+    });
   }
 }

--- a/src/service/cognito/command/user-pool/sim-cognito-unsimulated-pool-features.ts
+++ b/src/service/cognito/command/user-pool/sim-cognito-unsimulated-pool-features.ts
@@ -19,29 +19,20 @@ const accountRecoverySetting = {
 };
 
 /**
- * The AdminCreateUser configuration a pool is accepted with.
- *
- * `AllowAdminCreateUserOnly: true` says only an administrator creates users,
- * which is all `AdminCreateUser` does here, so accepting it promises nothing
- * this simulation does not already do. `false` says users may sign themselves
- * up, and there is no `SignUp` command to do that with, so it is refused.
- *
- * That asymmetry is deliberately stricter than AWS, whose own default for the
- * field is `false`. CDK emits `true`, which is why the accepted value is the
- * one that is safe rather than the one AWS defaults to.
- */
-const adminCreateUserConfig = { AllowAdminCreateUserOnly: true };
-
-/**
  * Refuses the user pool features this simulation does not model.
  *
  * These are the settings that decide what a pool does with its users. Most of
  * them cannot be honoured here at all, and a pool created as if they had been
  * would behave differently in a deployment.
  *
- * Two are accepted at one value each, and refused at every other. Neither
- * value asks for anything this simulation does not do, and both are what CDK
- * emits, so a stack that only wanted a pool deploys.
+ * `AccountRecoverySetting` is accepted at one value and refused at every
+ * other. That value asks for nothing this simulation does not do, and it is
+ * what CDK emits, so a stack that only wanted a pool deploys.
+ *
+ * `AdminCreateUserConfig` is simulated as far as `AllowAdminCreateUserOnly`
+ * goes, which is what decides whether `SignUp` is allowed. The two keys beside
+ * it are about the invitation an admin-created user is sent, and no message is
+ * ever delivered here, so those are refused.
  */
 export class SimCognitoUnsimulatedUserPoolFeatures {
   private readonly unsimulated = new SimCognitoUnsimulatedInput(
@@ -65,11 +56,6 @@ export class SimCognitoUnsimulatedUserPoolFeatures {
       input.AliasAttributes,
       "sign-in aliases",
     );
-    this.unsimulated.refuse(
-      "AutoVerifiedAttributes",
-      input.AutoVerifiedAttributes,
-      "automatic attribute verification",
-    );
     this.unsimulated.refuse("Schema", input.Schema, "custom attributes");
     this.unsimulated.refuse(
       "UsernameConfiguration",
@@ -92,11 +78,15 @@ export class SimCognitoUnsimulatedUserPoolFeatures {
       accountRecoverySetting,
       "account recovery",
     );
-    this.structure.refuseUnless(
-      "AdminCreateUserConfig",
-      input.AdminCreateUserConfig,
-      adminCreateUserConfig,
-      "self-service sign-up and the invitation an admin-created user is sent",
+    this.unsimulated.refuse(
+      "AdminCreateUserConfig InviteMessageTemplate",
+      input.AdminCreateUserConfig?.InviteMessageTemplate,
+      "the wording of the invitation an admin-created user is sent",
+    );
+    this.unsimulated.refuse(
+      "AdminCreateUserConfig UnusedAccountValidityDays",
+      input.AdminCreateUserConfig?.UnusedAccountValidityDays,
+      "expiring the temporary password an admin-created user was sent",
     );
     this.unsimulated.refuse(
       "UserPoolAddOns",

--- a/src/service/cognito/command/user-pool/sim-cognito-user-pool-accepted-settings.iso.test.ts
+++ b/src/service/cognito/command/user-pool/sim-cognito-user-pool-accepted-settings.iso.test.ts
@@ -19,13 +19,14 @@ import type { SimCognitoIdentityProvider } from "../../sim-cognito-identity-prov
 
 /**
  * The pool settings `aws-cdk-lib` 2.262.1 emits for a `UserPool` construct
- * asking for nothing in particular.
+ * asking for nothing in particular, apart from the `AdminCreateUserConfig`
+ * this simulation acts on.
  *
  * Each configures message delivery, verification wording or account recovery.
  * None of those is simulated, and none of these values asks for anything this
  * simulation does not already do, so a pool is created with them rather than
  * refused. They are recorded here as one block because a default CDK stack
- * sends all six together.
+ * sends them together.
  */
 const verificationMessage =
   "The verification code to your new account is {####}";
@@ -37,7 +38,6 @@ const cdkDefaultSettings = {
       { Name: "verified_email", Priority: 2 },
     ],
   },
-  AdminCreateUserConfig: { AllowAdminCreateUserOnly: true },
   EmailVerificationMessage: verificationMessage,
   EmailVerificationSubject: "Verify your new account",
   SmsVerificationMessage: verificationMessage,
@@ -68,21 +68,6 @@ const refusedValues: readonly RefusedValue[] = [
       },
     },
     says: "account recovery",
-  },
-  {
-    label: "AdminCreateUserConfig self sign-up",
-    input: { AdminCreateUserConfig: { AllowAdminCreateUserOnly: false } },
-    says: "self-service sign-up",
-  },
-  {
-    label: "AdminCreateUserConfig extra key",
-    input: {
-      AdminCreateUserConfig: {
-        AllowAdminCreateUserOnly: true,
-        InviteMessageTemplate: { EmailSubject: "Welcome" },
-      },
-    },
-    says: "self-service sign-up",
   },
   {
     label: "EmailVerificationMessage",
@@ -147,10 +132,6 @@ describe("sim Cognito user pool settings accepted without being simulated", () =
       cdkDefaultSettings.AccountRecoverySetting,
     );
     assertObjectEquals(
-      described.UserPool.AdminCreateUserConfig,
-      cdkDefaultSettings.AdminCreateUserConfig,
-    );
-    assertObjectEquals(
       described.UserPool.VerificationMessageTemplate,
       cdkDefaultSettings.VerificationMessageTemplate,
     );
@@ -182,7 +163,6 @@ describe("sim Cognito user pool settings accepted without being simulated", () =
     // value a request would have had to use to be accepted.
     assertNonNullable(described.UserPool);
     assertUndefined(described.UserPool.AccountRecoverySetting);
-    assertUndefined(described.UserPool.AdminCreateUserConfig);
     assertUndefined(described.UserPool.VerificationMessageTemplate);
     assertUndefined(described.UserPool.EmailVerificationMessage);
     assertUndefined(described.UserPool.EmailVerificationSubject);
@@ -195,11 +175,11 @@ describe("sim Cognito user pool settings accepted without being simulated", () =
     const input: Partial<CreateUserPoolCommandInput> =
       structuredClone(cdkDefaultSettings);
     const userPoolId = await createdPoolId(cognito, input);
-    assertNonNullable(input.AdminCreateUserConfig);
+    assertNonNullable(input.VerificationMessageTemplate);
 
     // When the caller edits that object afterwards, as it would to create a
     // second pool from the same starting point.
-    input.AdminCreateUserConfig.AllowAdminCreateUserOnly = false;
+    input.VerificationMessageTemplate.EmailSubject = "Something else";
     input.EmailVerificationSubject = "Something else";
 
     // Then the pool still reports what the request said when it was made,
@@ -208,9 +188,10 @@ describe("sim Cognito user pool settings accepted without being simulated", () =
       new DescribeUserPoolCommand({ UserPoolId: userPoolId }),
     );
     assertNonNullable(described.UserPool);
-    assertObjectEquals(described.UserPool.AdminCreateUserConfig, {
-      AllowAdminCreateUserOnly: true,
-    });
+    assertObjectEquals(
+      described.UserPool.VerificationMessageTemplate,
+      cdkDefaultSettings.VerificationMessageTemplate,
+    );
     assertIdentical(
       described.UserPool.EmailVerificationSubject,
       "Verify your new account",

--- a/src/service/cognito/command/user-pool/sim-cognito-user-pool-commands.ts
+++ b/src/service/cognito/command/user-pool/sim-cognito-user-pool-commands.ts
@@ -61,6 +61,8 @@ export class SimCognitoUserPoolCommands {
       name: input.PoolName,
       policies: input.Policies,
       deletionProtection: input.DeletionProtection,
+      adminCreateUserConfig: input.AdminCreateUserConfig,
+      autoVerifiedAttributes: input.AutoVerifiedAttributes,
       unsimulatedSettings: input,
     });
 

--- a/src/service/cognito/command/user-pool/sim-cognito-user-pool-validation.iso.test.ts
+++ b/src/service/cognito/command/user-pool/sim-cognito-user-pool-validation.iso.test.ts
@@ -68,11 +68,6 @@ const refusedInputs: readonly RefusedInput[] = [
     says: "sign-in aliases",
   },
   {
-    label: "AutoVerifiedAttributes",
-    input: { AutoVerifiedAttributes: ["email"] },
-    says: "automatic attribute verification",
-  },
-  {
     label: "Schema",
     input: { Schema: [{ Name: "tenant", AttributeDataType: "String" }] },
     says: "custom attributes",
@@ -106,9 +101,21 @@ const refusedInputs: readonly RefusedInput[] = [
     says: "account recovery",
   },
   {
-    label: "AdminCreateUserConfig",
-    input: { AdminCreateUserConfig: { AllowAdminCreateUserOnly: false } },
-    says: "self-service sign-up",
+    label: "AdminCreateUserConfig InviteMessageTemplate",
+    input: {
+      AdminCreateUserConfig: {
+        AllowAdminCreateUserOnly: true,
+        InviteMessageTemplate: { EmailSubject: "Welcome" },
+      },
+    },
+    says: "the wording of the invitation an admin-created user is sent",
+  },
+  {
+    label: "AdminCreateUserConfig UnusedAccountValidityDays",
+    input: {
+      AdminCreateUserConfig: { UnusedAccountValidityDays: 3 },
+    },
+    says: "expiring the temporary password an admin-created user was sent",
   },
   {
     label: "UserPoolAddOns",

--- a/src/service/cognito/command/user-pool/sim-cognito-user-pool-view.ts
+++ b/src/service/cognito/command/user-pool/sim-cognito-user-pool-view.ts
@@ -20,6 +20,10 @@ export class SimCognitoUserPoolView {
    * `EstimatedNumberOfUsers` is how many users the pool holds now. Real
    * Cognito refreshes that number periodically rather than on each write, so
    * it can lag there in a way it never does here.
+   *
+   * `AdminCreateUserConfig` is reported whether or not the request named it,
+   * as real Cognito reports it, because the pool acts on it either way:
+   * it is what decides whether `SignUp` is allowed at all.
    */
   describe(pool: SimCognitoUserPool): SimCognitoUserPoolType {
     return {
@@ -29,6 +33,8 @@ export class SimCognitoUserPoolView {
       Policies: { PasswordPolicy: pool.passwordPolicy.toOutput() },
       DeletionProtection: pool.deletionProtection.value,
       MfaConfiguration: "OFF",
+      AdminCreateUserConfig: pool.adminCreateUserConfig.toOutput(),
+      AutoVerifiedAttributes: pool.autoVerifiedAttributes.toOutput(),
       EstimatedNumberOfUsers: pool.userCount,
       CreationDate: pool.creationDate,
       LastModifiedDate: pool.lastModifiedDate,

--- a/src/service/cognito/command/user-pool/user-pool.command.ts
+++ b/src/service/cognito/command/user-pool/user-pool.command.ts
@@ -1,4 +1,5 @@
 import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type { SimCognitoAdminCreateUserConfigType } from "../../user-pool/sim-cognito-admin-create-user-config.js";
 import type { SimCognitoUserPoolPoliciesType } from "../../user-pool/sim-cognito-password-policy.js";
 import type { SimCognitoUnsimulatedPoolSettingsType } from "../../user-pool/sim-cognito-unsimulated-pool-settings.js";
 
@@ -18,6 +19,9 @@ export interface SimCognitoUserPoolType extends SimCognitoUnsimulatedPoolSetting
   readonly Policies?: SimCognitoUserPoolPoliciesType | undefined;
   readonly DeletionProtection?: string | undefined;
   readonly MfaConfiguration?: string | undefined;
+  readonly AdminCreateUserConfig?:
+    SimCognitoAdminCreateUserConfigType | undefined;
+  readonly AutoVerifiedAttributes?: readonly string[] | undefined;
   readonly EstimatedNumberOfUsers?: number | undefined;
   readonly CreationDate?: Date | undefined;
   readonly LastModifiedDate?: Date | undefined;
@@ -39,7 +43,8 @@ export interface SimCreateUserPoolCommandInput {
   readonly MfaConfiguration?: string | undefined;
   readonly UserPoolTier?: string | undefined;
   readonly AccountRecoverySetting?: object | undefined;
-  readonly AdminCreateUserConfig?: object | undefined;
+  readonly AdminCreateUserConfig?:
+    SimCognitoAdminCreateUserConfigType | undefined;
   readonly AliasAttributes?: readonly string[] | undefined;
   readonly AutoVerifiedAttributes?: readonly string[] | undefined;
   readonly DeviceConfiguration?: object | undefined;

--- a/src/service/cognito/command/user/sign-up.command.ts
+++ b/src/service/cognito/command/user/sign-up.command.ts
@@ -1,0 +1,115 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type { SimCognitoAttributeType } from "../../user-pool/user/sim-cognito-user-attributes.js";
+
+/**
+ * What every client-side sign-up operation names: the app client, and the user
+ * signing up.
+ *
+ * There is no `UserPoolId` in any of them. These are what a browser or mobile
+ * app calls, and an app client id is enough to find the pool, as it is on real
+ * Cognito. `SecretHash` is what a client created with a secret has to send.
+ */
+export interface SimCognitoSignUpCommandInput {
+  readonly ClientId?: string | undefined;
+  readonly Username?: string | undefined;
+  readonly SecretHash?: string | undefined;
+  readonly ClientMetadata?: Readonly<Record<string, string>> | undefined;
+  readonly AnalyticsMetadata?: object | undefined;
+  readonly UserContextData?: object | undefined;
+}
+
+/**
+ * The SignUp inputs this simulation reads, and the ones it refuses.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/cognito-identity-provider/command/SignUpCommand/
+ */
+export interface SimSignUpCommandInput extends SimCognitoSignUpCommandInput {
+  readonly Password?: string | undefined;
+  readonly UserAttributes?: readonly SimCognitoAttributeType[] | undefined;
+  readonly ValidationData?: readonly SimCognitoAttributeType[] | undefined;
+}
+
+/**
+ * Minimal structural sim Cognito SignUp command.
+ */
+export interface SimSignUpCommand {
+  readonly input: SimSignUpCommandInput;
+}
+
+/**
+ * What a sign-up answers with.
+ *
+ * `UserConfirmed` is always false here, because a pool confirming a user at
+ * sign-up is one with a pre sign-up Lambda trigger doing it, and triggers are
+ * not simulated. There is no `CodeDeliveryDetails`: real Cognito reports where
+ * it sent the confirmation code, and nothing here sends one anywhere.
+ */
+export interface SimSignUpCommandOutput {
+  readonly UserConfirmed?: boolean | undefined;
+  readonly UserSub?: string | undefined;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * The ConfirmSignUp inputs this simulation reads, and the ones it refuses.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/cognito-identity-provider/command/ConfirmSignUpCommand/
+ */
+export interface SimConfirmSignUpCommandInput extends SimCognitoSignUpCommandInput {
+  readonly ConfirmationCode?: string | undefined;
+  readonly ForceAliasCreation?: boolean | undefined;
+  readonly Session?: string | undefined;
+}
+
+/**
+ * Minimal structural sim Cognito ConfirmSignUp command.
+ */
+export interface SimConfirmSignUpCommand {
+  readonly input: SimConfirmSignUpCommandInput;
+}
+
+export interface SimConfirmSignUpCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim Cognito ResendConfirmationCode command.
+ */
+export interface SimResendConfirmationCodeCommand {
+  readonly input: SimCognitoSignUpCommandInput;
+}
+
+/**
+ * What resending answers with, which is nothing beyond the metadata.
+ *
+ * Real Cognito reports the `CodeDeliveryDetails` of the message it sent. No
+ * message is sent here, so the fresh code is read from the pool instead.
+ */
+export interface SimResendConfirmationCodeCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * The AdminConfirmSignUp inputs this simulation reads, and the one it refuses.
+ *
+ * This is the admin side of confirming, so it names the pool and the user
+ * rather than an app client, and no confirmation code is involved at all.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/cognito-identity-provider/command/AdminConfirmSignUpCommand/
+ */
+export interface SimAdminConfirmSignUpCommandInput {
+  readonly UserPoolId?: string | undefined;
+  readonly Username?: string | undefined;
+  readonly ClientMetadata?: Readonly<Record<string, string>> | undefined;
+}
+
+/**
+ * Minimal structural sim Cognito AdminConfirmSignUp command.
+ */
+export interface SimAdminConfirmSignUpCommand {
+  readonly input: SimAdminConfirmSignUpCommandInput;
+}
+
+export interface SimAdminConfirmSignUpCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/cognito/command/user/sim-cognito-confirm-sign-up.iso.test.ts
+++ b/src/service/cognito/command/user/sim-cognito-confirm-sign-up.iso.test.ts
@@ -1,0 +1,328 @@
+import {
+  AdminConfirmSignUpCommand,
+  AdminGetUserCommand,
+  ConfirmSignUpCommand,
+  CreateUserPoolClientCommand,
+  CreateUserPoolCommand,
+  InitiateAuthCommand,
+  ResendConfirmationCodeCommand,
+  SignUpCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import type { VerifiedAttributeType } from "@aws-sdk/client-cognito-identity-provider";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import type { SimCognitoAttributeType } from "../../user-pool/user/sim-cognito-user-attributes.js";
+import {
+  SimCognitoCodeMismatchException,
+  SimCognitoInvalidParameterException,
+  SimCognitoNotAuthorizedException,
+} from "../../error/sim-cognito.error.js";
+import type { SimCognitoIdentityProvider } from "../../sim-cognito-identity-provider.js";
+
+const password = "Sup3rSecret!";
+
+/**
+ * What Cognito sets a `_verified` attribute to, which is the string rather
+ * than a boolean.
+ */
+const verified = "true";
+
+interface SimCognitoWithSignUp {
+  readonly cognito: SimCognitoIdentityProvider;
+  readonly userPoolId: string;
+  readonly clientId: string;
+  readonly confirmationCode: string;
+}
+
+function attributeValue(
+  attributes: readonly SimCognitoAttributeType[] | undefined,
+  name: string,
+): string | undefined {
+  return (attributes ?? []).find((attribute) => attribute.Name === name)?.Value;
+}
+
+/**
+ * A pool holding one user that has signed itself up and not confirmed.
+ */
+async function simCognitoWithSignUp(
+  autoVerifiedAttributes?: VerifiedAttributeType[],
+): Promise<SimCognitoWithSignUp> {
+  const cognito = new SimAws().cognitoIdentityProvider();
+  const pool = await cognito.createUserPool(
+    new CreateUserPoolCommand({
+      PoolName: "myapp-users",
+      AutoVerifiedAttributes: autoVerifiedAttributes,
+    }),
+  );
+
+  assertNonNullable(pool.UserPool?.Id);
+
+  const userPoolId = pool.UserPool.Id;
+  const client = await cognito.createUserPoolClient(
+    new CreateUserPoolClientCommand({
+      UserPoolId: userPoolId,
+      ClientName: "web",
+      ExplicitAuthFlows: ["ALLOW_USER_PASSWORD_AUTH"],
+    }),
+  );
+
+  assertNonNullable(client.UserPoolClient?.ClientId);
+
+  const clientId = client.UserPoolClient.ClientId;
+
+  await cognito.signUp(
+    new SignUpCommand({
+      ClientId: clientId,
+      Username: "alice",
+      Password: password,
+      UserAttributes: [{ Name: "email", Value: "alice@example.com" }],
+    }),
+  );
+
+  const confirmationCode = cognito
+    .userPool(userPoolId)
+    .confirmationCode("alice");
+
+  assertNonNullable(confirmationCode);
+
+  return { cognito, userPoolId, clientId, confirmationCode };
+}
+
+async function userStatus(
+  cognito: SimCognitoIdentityProvider,
+  userPoolId: string,
+): Promise<string | undefined> {
+  const read = await cognito.adminGetUser(
+    new AdminGetUserCommand({ UserPoolId: userPoolId, Username: "alice" }),
+  );
+
+  return read.UserStatus;
+}
+
+describe("sim Cognito sign-up confirmation", () => {
+  it("confirms a sign-up and lets the user sign in", async () => {
+    // Given a user waiting to confirm.
+    const { cognito, userPoolId, clientId, confirmationCode } =
+      await simCognitoWithSignUp();
+
+    // When it answers with the code it was issued.
+    await cognito.confirmSignUp(
+      new ConfirmSignUpCommand({
+        ClientId: clientId,
+        Username: "alice",
+        ConfirmationCode: confirmationCode,
+      }),
+    );
+
+    // Then it is confirmed, and signs in with the password it chose at
+    // sign-up rather than being sent a challenge.
+    assertIdentical(await userStatus(cognito, userPoolId), "CONFIRMED");
+
+    const signedIn = await cognito.initiateAuth(
+      new InitiateAuthCommand({
+        ClientId: clientId,
+        AuthFlow: "USER_PASSWORD_AUTH",
+        AuthParameters: { USERNAME: "alice", PASSWORD: password },
+      }),
+    );
+
+    assertNonNullable(signedIn.AuthenticationResult?.AccessToken);
+  });
+
+  it("spends the code, so it confirms nothing twice", async () => {
+    // Given a confirmed user.
+    const { cognito, userPoolId, clientId, confirmationCode } =
+      await simCognitoWithSignUp();
+    await cognito.confirmSignUp(
+      new ConfirmSignUpCommand({
+        ClientId: clientId,
+        Username: "alice",
+        ConfirmationCode: confirmationCode,
+      }),
+    );
+
+    // When the same code is presented again.
+    const error = await assertThrowsErrorAsync(async () => {
+      await cognito.confirmSignUp(
+        new ConfirmSignUpCommand({
+          ClientId: clientId,
+          Username: "alice",
+          ConfirmationCode: confirmationCode,
+        }),
+      );
+    });
+
+    // Then it is refused, and the pool no longer holds a code at all.
+    assertInstanceOf(error, SimCognitoNotAuthorizedException);
+    assertStringIncludes(error.message, "Current status is CONFIRMED");
+    assertUndefined(cognito.userPool(userPoolId).confirmationCode("alice"));
+  });
+
+  it("refuses a wrong code and leaves the user where it was", async () => {
+    // Given a user waiting to confirm.
+    const { cognito, userPoolId, clientId } = await simCognitoWithSignUp();
+
+    // When it answers with a code that is not the one it was issued.
+    const error = await assertThrowsErrorAsync(async () => {
+      await cognito.confirmSignUp(
+        new ConfirmSignUpCommand({
+          ClientId: clientId,
+          Username: "alice",
+          ConfirmationCode: "000000-not-it",
+        }),
+      );
+    });
+
+    // Then it is refused, and the user is still waiting with the code it had,
+    // so a second attempt with the right one works.
+    assertInstanceOf(error, SimCognitoCodeMismatchException);
+    assertIdentical(await userStatus(cognito, userPoolId), "UNCONFIRMED");
+    assertNonNullable(cognito.userPool(userPoolId).confirmationCode("alice"));
+  });
+
+  it("verifies the pool's auto-verified attributes on confirmation", async () => {
+    // Given a pool that verifies email addresses, and a user waiting to
+    // confirm.
+    const { cognito, userPoolId, clientId, confirmationCode } =
+      await simCognitoWithSignUp(["email"]);
+
+    // When the sign-up is confirmed.
+    await cognito.confirmSignUp(
+      new ConfirmSignUpCommand({
+        ClientId: clientId,
+        Username: "alice",
+        ConfirmationCode: confirmationCode,
+      }),
+    );
+
+    // Then the address the code went to is marked verified.
+    const read = await cognito.adminGetUser(
+      new AdminGetUserCommand({ UserPoolId: userPoolId, Username: "alice" }),
+    );
+
+    assertIdentical(
+      attributeValue(read.UserAttributes, "email_verified"),
+      verified,
+    );
+  });
+
+  it("verifies nothing on a pool that verifies nothing", async () => {
+    // Given a pool with no AutoVerifiedAttributes.
+    const { cognito, userPoolId, clientId, confirmationCode } =
+      await simCognitoWithSignUp();
+
+    // When the sign-up is confirmed.
+    await cognito.confirmSignUp(
+      new ConfirmSignUpCommand({
+        ClientId: clientId,
+        Username: "alice",
+        ConfirmationCode: confirmationCode,
+      }),
+    );
+
+    // Then the email is left unverified, as it is on such a pool.
+    const read = await cognito.adminGetUser(
+      new AdminGetUserCommand({ UserPoolId: userPoolId, Username: "alice" }),
+    );
+
+    assertUndefined(attributeValue(read.UserAttributes, "email_verified"));
+  });
+
+  it("issues a fresh code, and the earlier one stops working", async () => {
+    // Given a user waiting to confirm, holding the code it was issued.
+    const { cognito, userPoolId, clientId, confirmationCode } =
+      await simCognitoWithSignUp();
+
+    // When it asks for the code again.
+    await cognito.resendConfirmationCode(
+      new ResendConfirmationCodeCommand({
+        ClientId: clientId,
+        Username: "alice",
+      }),
+    );
+
+    // Then the earlier code confirms nothing, as it does not on real Cognito.
+    const error = await assertThrowsErrorAsync(async () => {
+      await cognito.confirmSignUp(
+        new ConfirmSignUpCommand({
+          ClientId: clientId,
+          Username: "alice",
+          ConfirmationCode: confirmationCode,
+        }),
+      );
+    });
+
+    assertInstanceOf(error, SimCognitoCodeMismatchException);
+
+    // And the code the pool holds now is the one that does.
+    const resent = cognito.userPool(userPoolId).confirmationCode("alice");
+
+    await cognito.confirmSignUp(
+      new ConfirmSignUpCommand({
+        ClientId: clientId,
+        Username: "alice",
+        ConfirmationCode: resent,
+      }),
+    );
+
+    assertIdentical(await userStatus(cognito, userPoolId), "CONFIRMED");
+  });
+
+  it("refuses another code for a user that has confirmed", async () => {
+    // Given a confirmed user.
+    const { cognito, userPoolId, clientId, confirmationCode } =
+      await simCognitoWithSignUp();
+    await cognito.confirmSignUp(
+      new ConfirmSignUpCommand({
+        ClientId: clientId,
+        Username: "alice",
+        ConfirmationCode: confirmationCode,
+      }),
+    );
+
+    // When another code is asked for.
+    const error = await assertThrowsErrorAsync(async () => {
+      await cognito.resendConfirmationCode(
+        new ResendConfirmationCodeCommand({
+          ClientId: clientId,
+          Username: "alice",
+        }),
+      );
+    });
+
+    // Then it is refused, and the user still holds no code.
+    assertInstanceOf(error, SimCognitoInvalidParameterException);
+    assertStringIncludes(error.message, "already confirmed");
+    assertUndefined(cognito.userPool(userPoolId).confirmationCode("alice"));
+  });
+
+  it("confirms a user as an admin with no code at all", async () => {
+    // Given a user waiting to confirm, on a pool that verifies emails.
+    const { cognito, userPoolId } = await simCognitoWithSignUp(["email"]);
+
+    // When an admin confirms it.
+    await cognito.adminConfirmSignUp(
+      new AdminConfirmSignUpCommand({
+        UserPoolId: userPoolId,
+        Username: "alice",
+      }),
+    );
+
+    // Then the user is confirmed, and its email is still unverified: an admin
+    // confirming a user says nothing about whose address that is.
+    const read = await cognito.adminGetUser(
+      new AdminGetUserCommand({ UserPoolId: userPoolId, Username: "alice" }),
+    );
+
+    assertIdentical(read.UserStatus, "CONFIRMED");
+    assertUndefined(attributeValue(read.UserAttributes, "email_verified"));
+  });
+});

--- a/src/service/cognito/command/user/sim-cognito-sign-up-commands.ts
+++ b/src/service/cognito/command/user/sim-cognito-sign-up-commands.ts
@@ -1,0 +1,183 @@
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import { requireSimCognitoSecretHash } from "../../user-pool/auth/sim-cognito-secret-hash.js";
+import type { SimCognitoUserPoolClient } from "../../user-pool/client/sim-cognito-user-pool-client.js";
+import { SimCognitoPasswordCheck } from "../../user-pool/sim-cognito-password-check.js";
+import type { SimCognitoUserPool } from "../../user-pool/sim-cognito-user-pool.js";
+import type { SimCognitoUser } from "../../user-pool/user/sim-cognito-user.js";
+import type { SimCognitoUserFactory } from "../../user-pool/user/sim-cognito-user-factory.js";
+import { requireSimCognitoUsername } from "../../user-pool/user/sim-cognito-username.js";
+import type { SimCognitoAuthResolver } from "../auth/sim-cognito-auth-resolver.js";
+import type { SimCognitoRequestResolver } from "../sim-cognito-request-resolver.js";
+import { SimCognitoUnsimulatedSignUpOptions } from "./sim-cognito-unsimulated-sign-up-options.js";
+import type {
+  SimAdminConfirmSignUpCommand,
+  SimAdminConfirmSignUpCommandOutput,
+  SimCognitoSignUpCommandInput,
+  SimConfirmSignUpCommand,
+  SimConfirmSignUpCommandOutput,
+  SimResendConfirmationCodeCommand,
+  SimResendConfirmationCodeCommandOutput,
+  SimSignUpCommand,
+  SimSignUpCommandOutput,
+} from "./sign-up.command.js";
+
+interface SimCognitoSignUpCommandsProperties {
+  readonly authResolver: SimCognitoAuthResolver;
+  readonly resolver: SimCognitoRequestResolver;
+  readonly userFactory: SimCognitoUserFactory;
+}
+
+interface SimCognitoCommandOptions {
+  readonly caller?: SimAwsCaller;
+}
+
+/**
+ * The commands a user signs itself up with, and the one an admin confirms it
+ * with.
+ *
+ * The first three are what a browser or mobile app calls, so no IAM permission
+ * is involved and no caller is read, as with the client-side sign-in commands:
+ * the app client id is what finds the pool. `AdminConfirmSignUp` is the
+ * exception, and authorizes against the pool's ARN the way every other admin
+ * operation does.
+ *
+ * Nothing here delivers the confirmation code. It is issued and held on the
+ * user, and `SimCognitoUserPool.confirmationCode` is where a test reads it
+ * from.
+ */
+export class SimCognitoSignUpCommands {
+  private readonly authResolver: SimCognitoAuthResolver;
+  private readonly resolver: SimCognitoRequestResolver;
+  private readonly userFactory: SimCognitoUserFactory;
+  private readonly unsimulatedOptions =
+    new SimCognitoUnsimulatedSignUpOptions();
+
+  constructor(properties: SimCognitoSignUpCommandsProperties) {
+    this.authResolver = properties.authResolver;
+    this.resolver = properties.resolver;
+    this.userFactory = properties.userFactory;
+  }
+
+  /**
+   * Sign a new user up.
+   *
+   * The user is left in `UNCONFIRMED` holding a confirmation code, which is
+   * where real Cognito leaves one: it has the password it chose and cannot
+   * sign in with it until the sign-up is confirmed. The password is checked
+   * against the pool's policy first, as `AdminCreateUser` checks a temporary
+   * one, and a username the pool already holds is refused whether that user
+   * signed itself up or an admin created it.
+   */
+  signUp(command: SimSignUpCommand): SimSignUpCommandOutput {
+    const { input } = command;
+    const { pool, client } = this.authResolver.client(input.ClientId);
+
+    this.unsimulatedOptions.refuseInSignUp(input);
+    pool.adminCreateUserConfig.requireSelfServiceSignUp();
+
+    const username = requireSimCognitoUsername(input.Username);
+
+    requireSimCognitoSecretHash(username, client, input.SecretHash);
+
+    const user = this.userFactory.signUp({
+      username,
+      attributes: input.UserAttributes,
+      password: new SimCognitoPasswordCheck(pool.passwordPolicy).require(
+        "Password",
+        input.Password,
+      ),
+    });
+
+    pool.addUser(user);
+
+    return { $metadata: {}, UserConfirmed: false, UserSub: user.sub };
+  }
+
+  /**
+   * Confirm a sign-up with the code the pool issued.
+   *
+   * The user reaches `CONFIRMED` and can sign in from then on. The pool's
+   * `AutoVerifiedAttributes` are marked verified here, because answering with
+   * the code is what shows the address the code went to is the user's.
+   */
+  confirmSignUp(
+    command: SimConfirmSignUpCommand,
+  ): SimConfirmSignUpCommandOutput {
+    const { input } = command;
+    const { pool, client } = this.authResolver.client(input.ClientId);
+
+    this.unsimulatedOptions.refuseInConfirm(input);
+
+    const user = this.signingUpUser(pool, client, input);
+
+    user.confirmSignUp(input.ConfirmationCode);
+    user.verifyAttributes(pool.autoVerifiedAttributes.names);
+
+    return { $metadata: {} };
+  }
+
+  /**
+   * Issue a fresh confirmation code for a user waiting to be confirmed.
+   *
+   * The code the user had stops working, as it does on real Cognito, so a
+   * test holding the earlier one has to read the new one from the pool.
+   */
+  resendConfirmationCode(
+    command: SimResendConfirmationCodeCommand,
+  ): SimResendConfirmationCodeCommandOutput {
+    const { input } = command;
+    const { pool, client } = this.authResolver.client(input.ClientId);
+
+    this.unsimulatedOptions.refuseInResend(input);
+
+    this.signingUpUser(pool, client, input).resendConfirmationCode();
+
+    return { $metadata: {} };
+  }
+
+  /**
+   * Confirm a sign-up as an administrator, with no code involved.
+   *
+   * Nothing is verified by this. Real Cognito leaves `email_verified` and
+   * `phone_number_verified` alone here even on a pool with
+   * `AutoVerifiedAttributes`, because an admin confirming a user says nothing
+   * about whether the address is really theirs.
+   */
+  adminConfirmSignUp(
+    command: SimAdminConfirmSignUpCommand,
+    options?: SimCognitoCommandOptions,
+  ): SimAdminConfirmSignUpCommandOutput {
+    const { input } = command;
+
+    const user = this.resolver.user(
+      "cognito-idp:AdminConfirmSignUp",
+      input,
+      options,
+    );
+
+    this.unsimulatedOptions.refuseInAdminConfirm(input);
+
+    user.confirm();
+
+    return { $metadata: {} };
+  }
+
+  /**
+   * Resolve the user a client-side sign-up operation names.
+   *
+   * The `SECRET_HASH` covers the username, so it is checked as soon as the
+   * username is known and before anything looks the user up, which is the
+   * order the sign-in commands check it in too.
+   */
+  private signingUpUser(
+    pool: SimCognitoUserPool,
+    client: SimCognitoUserPoolClient,
+    input: SimCognitoSignUpCommandInput,
+  ): SimCognitoUser {
+    const username = requireSimCognitoUsername(input.Username);
+
+    requireSimCognitoSecretHash(username, client, input.SecretHash);
+
+    return pool.requireUser(username);
+  }
+}

--- a/src/service/cognito/command/user/sim-cognito-sign-up.iso.test.ts
+++ b/src/service/cognito/command/user/sim-cognito-sign-up.iso.test.ts
@@ -1,0 +1,262 @@
+import {
+  AdminCreateUserCommand,
+  AdminGetUserCommand,
+  CreateUserPoolClientCommand,
+  CreateUserPoolCommand,
+  InitiateAuthCommand,
+  SignUpCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import {
+  assertFalse,
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertStringIncludes,
+  assertStringLength,
+  assertThrowsErrorAsync,
+  assertUuidV4,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import {
+  SimCognitoInvalidPasswordException,
+  SimCognitoNotAuthorizedException,
+  SimCognitoUsernameExistsException,
+  SimCognitoUserNotConfirmedException,
+} from "../../error/sim-cognito.error.js";
+import type { SimCognitoIdentityProvider } from "../../sim-cognito-identity-provider.js";
+
+const password = "Sup3rSecret!";
+
+interface SimCognitoWithClient {
+  readonly cognito: SimCognitoIdentityProvider;
+  readonly userPoolId: string;
+  readonly clientId: string;
+}
+
+/**
+ * A pool users may sign themselves up in, with a client-side app client.
+ */
+async function simCognitoWithClient(adminCreateUserConfig?: {
+  AllowAdminCreateUserOnly: boolean;
+}): Promise<SimCognitoWithClient> {
+  const cognito = new SimAws().cognitoIdentityProvider();
+  const pool = await cognito.createUserPool(
+    new CreateUserPoolCommand({
+      PoolName: "myapp-users",
+      AdminCreateUserConfig: adminCreateUserConfig,
+    }),
+  );
+
+  assertNonNullable(pool.UserPool?.Id);
+
+  const client = await cognito.createUserPoolClient(
+    new CreateUserPoolClientCommand({
+      UserPoolId: pool.UserPool.Id,
+      ClientName: "web",
+      ExplicitAuthFlows: ["ALLOW_USER_PASSWORD_AUTH"],
+    }),
+  );
+
+  assertNonNullable(client.UserPoolClient?.ClientId);
+
+  return {
+    cognito,
+    userPoolId: pool.UserPool.Id,
+    clientId: client.UserPoolClient.ClientId,
+  };
+}
+
+describe("sim Cognito sign-up", () => {
+  it("signs a user up unconfirmed with a sub of its own", async () => {
+    // Given a pool with an app client.
+    const { cognito, userPoolId, clientId } = await simCognitoWithClient();
+
+    // When someone signs themselves up through it.
+    const signedUp = await cognito.signUp(
+      new SignUpCommand({
+        ClientId: clientId,
+        Username: "alice",
+        Password: password,
+        UserAttributes: [{ Name: "email", Value: "alice@example.com" }],
+      }),
+    );
+
+    // Then the user exists unconfirmed, with the sub Cognito allocated it
+    // reported back rather than the username.
+    assertFalse(signedUp.UserConfirmed);
+    assertNonNullable(signedUp.UserSub);
+    assertUuidV4(signedUp.UserSub);
+
+    const read = await cognito.adminGetUser(
+      new AdminGetUserCommand({ UserPoolId: userPoolId, Username: "alice" }),
+    );
+
+    assertIdentical(read.UserStatus, "UNCONFIRMED");
+  });
+
+  it("issues a confirmation code a test can read from the pool", async () => {
+    // Given a pool with an app client.
+    const { cognito, userPoolId, clientId } = await simCognitoWithClient();
+
+    // When someone signs themselves up.
+    await cognito.signUp(
+      new SignUpCommand({
+        ClientId: clientId,
+        Username: "alice",
+        Password: password,
+      }),
+    );
+
+    // Then the code the user would have been sent is readable from the pool,
+    // because nothing here delivers a message to read it from.
+    const code = cognito.userPool(userPoolId).confirmationCode("alice");
+
+    assertNonNullable(code);
+    assertStringLength(code, 6);
+  });
+
+  it("refuses signing in as a user that has not confirmed", async () => {
+    // Given a user that signed itself up and has not confirmed.
+    const { cognito, clientId } = await simCognitoWithClient();
+    await cognito.signUp(
+      new SignUpCommand({
+        ClientId: clientId,
+        Username: "alice",
+        Password: password,
+      }),
+    );
+
+    // When it signs in with the password it chose.
+    const error = await assertThrowsErrorAsync(async () => {
+      await cognito.initiateAuth(
+        new InitiateAuthCommand({
+          ClientId: clientId,
+          AuthFlow: "USER_PASSWORD_AUTH",
+          AuthParameters: { USERNAME: "alice", PASSWORD: password },
+        }),
+      );
+    });
+
+    // Then the refusal says the sign-up is what is missing, rather than the
+    // password, which is what sends an application to ConfirmSignUp.
+    assertInstanceOf(error, SimCognitoUserNotConfirmedException);
+    assertIdentical(error.name, "UserNotConfirmedException");
+  });
+
+  it("refuses a wrong password before it mentions confirmation", async () => {
+    // Given a user that signed itself up and has not confirmed.
+    const { cognito, clientId } = await simCognitoWithClient();
+    await cognito.signUp(
+      new SignUpCommand({
+        ClientId: clientId,
+        Username: "alice",
+        Password: password,
+      }),
+    );
+
+    // When it signs in with the wrong password.
+    const error = await assertThrowsErrorAsync(async () => {
+      await cognito.initiateAuth(
+        new InitiateAuthCommand({
+          ClientId: clientId,
+          AuthFlow: "USER_PASSWORD_AUTH",
+          AuthParameters: { USERNAME: "alice", PASSWORD: "Wr0ngOne!" },
+        }),
+      );
+    });
+
+    // Then it is refused the way any wrong password is, saying nothing about
+    // the account being unconfirmed.
+    assertInstanceOf(error, SimCognitoNotAuthorizedException);
+  });
+
+  it("refuses a username the pool already holds", async () => {
+    // Given a user an admin created.
+    const { cognito, userPoolId, clientId } = await simCognitoWithClient();
+    await cognito.adminCreateUser(
+      new AdminCreateUserCommand({ UserPoolId: userPoolId, Username: "alice" }),
+    );
+
+    // When someone signs up with the same username.
+    const error = await assertThrowsErrorAsync(async () => {
+      await cognito.signUp(
+        new SignUpCommand({
+          ClientId: clientId,
+          Username: "alice",
+          Password: password,
+        }),
+      );
+    });
+
+    // Then it is refused, as real Cognito refuses it, whichever way the first
+    // user got there.
+    assertInstanceOf(error, SimCognitoUsernameExistsException);
+  });
+
+  it("checks the chosen password against the pool's policy", async () => {
+    // Given a pool with an app client.
+    const { cognito, clientId } = await simCognitoWithClient();
+
+    // When someone signs up with a password the policy does not allow.
+    const error = await assertThrowsErrorAsync(async () => {
+      await cognito.signUp(
+        new SignUpCommand({
+          ClientId: clientId,
+          Username: "alice",
+          Password: "short",
+        }),
+      );
+    });
+
+    // Then it is refused in the same words AdminCreateUser refuses one in.
+    assertInstanceOf(error, SimCognitoInvalidPasswordException);
+    assertStringIncludes(error.message, "Password not long enough");
+  });
+
+  it("refuses a sign-up on a pool only an admin may create users in", async () => {
+    // Given a pool created the way a CDK UserPool without selfSignUpEnabled
+    // creates one.
+    const { cognito, clientId } = await simCognitoWithClient({
+      AllowAdminCreateUserOnly: true,
+    });
+
+    // When someone tries to sign themselves up.
+    const error = await assertThrowsErrorAsync(async () => {
+      await cognito.signUp(
+        new SignUpCommand({
+          ClientId: clientId,
+          Username: "alice",
+          Password: password,
+        }),
+      );
+    });
+
+    // Then it is refused as real Cognito refuses it, rather than making a user
+    // the deployed pool would not have.
+    assertInstanceOf(error, SimCognitoNotAuthorizedException);
+    assertStringIncludes(error.message, "AllowAdminCreateUserOnly");
+  });
+
+  it("refuses an input that only a Lambda trigger would read", async () => {
+    // Given a pool with an app client.
+    const { cognito, clientId } = await simCognitoWithClient();
+
+    // When a sign-up carries validation data for a pre sign-up trigger.
+    const error = await assertThrowsErrorAsync(async () => {
+      await cognito.signUp(
+        new SignUpCommand({
+          ClientId: clientId,
+          Username: "alice",
+          Password: password,
+          ValidationData: [{ Name: "tenant", Value: "acme" }],
+        }),
+      );
+    });
+
+    // Then it is refused rather than dropped, because the trigger that would
+    // have read it does not run here.
+    assertStringIncludes(error.message, "SignUp ValidationData");
+    assertStringIncludes(error.message, "is not simulated");
+  });
+});

--- a/src/service/cognito/command/user/sim-cognito-unsimulated-sign-up-options.ts
+++ b/src/service/cognito/command/user/sim-cognito-unsimulated-sign-up-options.ts
@@ -1,0 +1,103 @@
+import { SimCognitoUnsimulatedInput } from "../sim-cognito-unsimulated-input.js";
+import type {
+  SimAdminConfirmSignUpCommandInput,
+  SimCognitoSignUpCommandInput,
+  SimConfirmSignUpCommandInput,
+  SimSignUpCommandInput,
+} from "./sign-up.command.js";
+
+/**
+ * Refuses the sign-up inputs this simulation does not model.
+ *
+ * The four operations share most of them: every one can carry data for a
+ * Lambda trigger, and the two client-side ones can carry the analytics and
+ * device context a real app sends. None of that is simulated, so an input
+ * asking for any of it is refused rather than dropped.
+ */
+export class SimCognitoUnsimulatedSignUpOptions {
+  private readonly signUpInput = new SimCognitoUnsimulatedInput("SignUp");
+  private readonly confirmInput = new SimCognitoUnsimulatedInput(
+    "ConfirmSignUp",
+  );
+  private readonly resendInput = new SimCognitoUnsimulatedInput(
+    "ResendConfirmationCode",
+  );
+  private readonly adminConfirmInput = new SimCognitoUnsimulatedInput(
+    "AdminConfirmSignUp",
+  );
+
+  /**
+   * Refuse a `SignUp` request this simulation cannot honour.
+   *
+   * `ValidationData` gets its own refusal because it exists only to be read by
+   * a pre sign-up trigger: a request sending it is written against a trigger
+   * that would not run here.
+   */
+  refuseInSignUp(input: SimSignUpCommandInput): void {
+    this.refuseClientContext(this.signUpInput, input);
+    this.signUpInput.refuse(
+      "ValidationData",
+      input.ValidationData,
+      "passing data to a pre sign-up Lambda trigger",
+    );
+  }
+
+  /**
+   * Refuse a `ConfirmSignUp` request this simulation cannot honour.
+   */
+  refuseInConfirm(input: SimConfirmSignUpCommandInput): void {
+    this.refuseClientContext(this.confirmInput, input);
+    this.confirmInput.refuse(
+      "ForceAliasCreation",
+      input.ForceAliasCreation,
+      "moving an email or phone number alias to the confirmed user",
+    );
+    this.confirmInput.refuse(
+      "Session",
+      input.Session,
+      "continuing to a passwordless sign-in after confirming",
+    );
+  }
+
+  /**
+   * Refuse a `ResendConfirmationCode` request this simulation cannot honour.
+   */
+  refuseInResend(input: SimCognitoSignUpCommandInput): void {
+    this.refuseClientContext(this.resendInput, input);
+  }
+
+  /**
+   * Refuse an `AdminConfirmSignUp` request this simulation cannot honour.
+   */
+  refuseInAdminConfirm(input: SimAdminConfirmSignUpCommandInput): void {
+    this.adminConfirmInput.refuse(
+      "ClientMetadata",
+      input.ClientMetadata,
+      "passing data to a Lambda trigger",
+    );
+  }
+
+  /**
+   * Refuse the three inputs every client-side sign-up operation shares.
+   */
+  private refuseClientContext(
+    unsimulated: SimCognitoUnsimulatedInput,
+    input: SimCognitoSignUpCommandInput,
+  ): void {
+    unsimulated.refuse(
+      "ClientMetadata",
+      input.ClientMetadata,
+      "passing data to a Lambda trigger",
+    );
+    unsimulated.refuse(
+      "AnalyticsMetadata",
+      input.AnalyticsMetadata,
+      "recording the request against a Pinpoint analytics endpoint",
+    );
+    unsimulated.refuse(
+      "UserContextData",
+      input.UserContextData,
+      "the device data threat protection judges a request by",
+    );
+  }
+}

--- a/src/service/cognito/error/sim-cognito.error.ts
+++ b/src/service/cognito/error/sim-cognito.error.ts
@@ -103,6 +103,36 @@ export class SimCognitoNotAuthorizedException extends SimCognitoError {
 }
 
 /**
+ * Simulated Cognito UserNotConfirmedException error.
+ *
+ * Real Cognito reports a sign-in by a user that signed itself up and never
+ * confirmed this way. The password was right: what is missing is the
+ * confirmation, so an application knows to send the user to `ConfirmSignUp`
+ * rather than back to the password field.
+ */
+export class SimCognitoUserNotConfirmedException extends SimCognitoError {
+  public override readonly name = "UserNotConfirmedException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
+ * Simulated Cognito CodeMismatchException error.
+ *
+ * Real Cognito reports a confirmation code that is not the one it issued this
+ * way, and leaves the user where it was.
+ */
+export class SimCognitoCodeMismatchException extends SimCognitoError {
+  public override readonly name = "CodeMismatchException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
  * Simulated Cognito InvalidPasswordException error.
  *
  * Real Cognito reports a password its pool's password policy does not allow

--- a/src/service/cognito/index.ts
+++ b/src/service/cognito/index.ts
@@ -13,6 +13,11 @@ export {
   type SimCognitoDeletionProtectionValue,
 } from "./user-pool/sim-cognito-deletion-protection.js";
 export {
+  SimCognitoAdminCreateUserConfig,
+  type SimCognitoAdminCreateUserConfigType,
+} from "./user-pool/sim-cognito-admin-create-user-config.js";
+export { SimCognitoAutoVerifiedAttributes } from "./user-pool/sim-cognito-auto-verified-attributes.js";
+export {
   SimCognitoPasswordPolicy,
   type SimCognitoPasswordPolicyType,
   type SimCognitoSignInPolicyType,
@@ -34,6 +39,7 @@ export {
 export { SimCognitoUserDirectory } from "./sim-cognito-user-directory.js";
 export { SimCognitoAuthentication } from "./sim-cognito-authentication.js";
 export { SimCognitoUser } from "./user-pool/user/sim-cognito-user.js";
+export { SimCognitoConfirmationCode } from "./user-pool/user/sim-cognito-confirmation-code.js";
 export type { SimCognitoUsername } from "./user-pool/user/sim-cognito-username.js";
 export {
   SimCognitoUserStatus,
@@ -62,6 +68,7 @@ export { SimCognitoAuthSession } from "./user-pool/auth/sim-cognito-auth-session
 export { SimCognitoIssuedToken } from "./user-pool/auth/sim-cognito-issued-token.js";
 export { SimCognitoPoolAuth } from "./user-pool/auth/sim-cognito-pool-auth.js";
 export {
+  SimCognitoCodeMismatchException,
   SimCognitoError,
   SimCognitoGroupExistsException,
   SimCognitoInvalidParameterException,
@@ -69,5 +76,6 @@ export {
   SimCognitoNotAuthorizedException,
   SimCognitoResourceNotFoundException,
   SimCognitoUsernameExistsException,
+  SimCognitoUserNotConfirmedException,
   SimCognitoUserNotFoundException,
 } from "./error/sim-cognito.error.js";

--- a/src/service/cognito/sdk/sim-cognito-sdk-directory-routes.ts
+++ b/src/service/cognito/sdk/sim-cognito-sdk-directory-routes.ts
@@ -17,6 +17,12 @@ import type {
 } from "../command/group/group.command.js";
 import type { SimListUsersCommand } from "../command/user/list-users.command.js";
 import type {
+  SimAdminConfirmSignUpCommand,
+  SimConfirmSignUpCommand,
+  SimResendConfirmationCodeCommand,
+  SimSignUpCommand,
+} from "../command/user/sign-up.command.js";
+import type {
   SimAdminCreateUserCommand,
   SimAdminDeleteUserCommand,
   SimAdminDisableUserCommand,
@@ -29,11 +35,42 @@ import type { SimCognitoIdentityProvider } from "../sim-cognito-identity-provide
 
 /**
  * The SDK Command routes for the users and groups in a pool.
+ *
+ * The three sign-up routes read no caller from the SDK context, because real
+ * Cognito authorizes them with no IAM policy: they are what an application
+ * calls on behalf of someone signing themselves up, holding no AWS credentials
+ * at all. `AdminConfirmSignUp` is the admin side of the same thing, and does
+ * read one.
  */
 export function simCognitoSdkDirectoryRoutes(
   simCognito: SimCognitoIdentityProvider,
 ): readonly (readonly [string, SimSdkCommandRoute])[] {
   return [
+    [
+      "SignUpCommand",
+      async (command): Promise<unknown> =>
+        await simCognito.signUp(command as SimSignUpCommand),
+    ],
+    [
+      "ConfirmSignUpCommand",
+      async (command): Promise<unknown> =>
+        await simCognito.confirmSignUp(command as SimConfirmSignUpCommand),
+    ],
+    [
+      "ResendConfirmationCodeCommand",
+      async (command): Promise<unknown> =>
+        await simCognito.resendConfirmationCode(
+          command as SimResendConfirmationCodeCommand,
+        ),
+    ],
+    [
+      "AdminConfirmSignUpCommand",
+      async (command, context): Promise<unknown> =>
+        await simCognito.adminConfirmSignUp(
+          command as SimAdminConfirmSignUpCommand,
+          simSdkCallerOptions(context),
+        ),
+    ],
     [
       "AdminCreateUserCommand",
       async (command, context): Promise<unknown> =>

--- a/src/service/cognito/sdk/sim-cognito-sdk-user-routing.iso.test.ts
+++ b/src/service/cognito/sdk/sim-cognito-sdk-user-routing.iso.test.ts
@@ -1,4 +1,5 @@
 import {
+  AdminConfirmSignUpCommand,
   AdminCreateUserCommand,
   AdminDeleteUserCommand,
   AdminDisableUserCommand,
@@ -7,17 +8,23 @@ import {
   AdminSetUserPasswordCommand,
   AdminUpdateUserAttributesCommand,
   CognitoIdentityProviderClient,
+  ConfirmSignUpCommand,
+  CreateUserPoolClientCommand,
   CreateUserPoolCommand,
   ListUsersCommand,
+  ResendConfirmationCodeCommand,
+  SignUpCommand,
 } from "@aws-sdk/client-cognito-identity-provider";
 import {
   assertArrayEquals,
   assertFalse,
   assertIdentical,
   assertTrue,
+  assertTypeString,
 } from "@kensio/smartass";
 import { describe, it } from "vitest";
 import { SimSdk } from "../../../sdk/index.js";
+import { SimAws } from "../../aws/sim-aws.js";
 
 describe("Cognito user SDK interception", () => {
   it("routes every user Command through the intercepted client", async () => {
@@ -92,5 +99,113 @@ describe("Cognito user SDK interception", () => {
       ["alice"],
     );
     assertArrayEquals(listedAfterDelete.Users, []);
+  });
+
+  it("routes every sign-up Command through the intercepted client", async () => {
+    // Given an intercepted Cognito SDK client with a pool and an app client.
+    const simAws = new SimAws({ defaultRegionName: "eu-west-2" });
+    using simSdk = new SimSdk({ simAws });
+    simSdk.intercept(CognitoIdentityProviderClient);
+
+    const client = new CognitoIdentityProviderClient({ region: "eu-west-2" });
+    const pool = await client.send(
+      new CreateUserPoolCommand({
+        PoolName: "myapp-users",
+        AutoVerifiedAttributes: ["email"],
+      }),
+    );
+    const userPoolId = pool.UserPool?.Id;
+    assertTypeString(userPoolId);
+
+    const appClient = await client.send(
+      new CreateUserPoolClientCommand({
+        UserPoolId: userPoolId,
+        ClientName: "web",
+      }),
+    );
+
+    // When ordinary SDK code signs a user up and confirms it.
+    const signedUp = await client.send(
+      new SignUpCommand({
+        ClientId: appClient.UserPoolClient?.ClientId,
+        Username: "alice",
+        Password: "Sup3rSecret!",
+        UserAttributes: [{ Name: "email", Value: "alice@example.com" }],
+      }),
+    );
+
+    await client.send(
+      new ResendConfirmationCodeCommand({
+        ClientId: appClient.UserPoolClient?.ClientId,
+        Username: "alice",
+      }),
+    );
+
+    await client.send(
+      new ConfirmSignUpCommand({
+        ClientId: appClient.UserPoolClient?.ClientId,
+        Username: "alice",
+        ConfirmationCode: simAws
+          .cognitoIdentityProvider()
+          .userPool(userPoolId)
+          .confirmationCode("alice"),
+      }),
+    );
+
+    const confirmed = await client.send(
+      new AdminGetUserCommand({ UserPoolId: userPoolId, Username: "alice" }),
+    );
+
+    // Then each Command reached simulated Cognito.
+    assertFalse(signedUp.UserConfirmed);
+    assertIdentical(confirmed.UserStatus, "CONFIRMED");
+    assertTrue(
+      (confirmed.UserAttributes ?? []).some(
+        (attribute) =>
+          attribute.Name === "email_verified" && attribute.Value === "true",
+      ),
+    );
+  });
+
+  it("routes AdminConfirmSignUp through the intercepted client", async () => {
+    // Given an intercepted Cognito SDK client with an unconfirmed user.
+    const simAws = new SimAws({ defaultRegionName: "eu-west-2" });
+    using simSdk = new SimSdk({ simAws });
+    simSdk.intercept(CognitoIdentityProviderClient);
+
+    const client = new CognitoIdentityProviderClient({ region: "eu-west-2" });
+    const pool = await client.send(
+      new CreateUserPoolCommand({ PoolName: "myapp-users" }),
+    );
+    const userPoolId = pool.UserPool?.Id;
+    const appClient = await client.send(
+      new CreateUserPoolClientCommand({
+        UserPoolId: userPoolId,
+        ClientName: "web",
+      }),
+    );
+
+    await client.send(
+      new SignUpCommand({
+        ClientId: appClient.UserPoolClient?.ClientId,
+        Username: "alice",
+        Password: "Sup3rSecret!",
+      }),
+    );
+
+    // When an admin confirms the user rather than the user confirming itself.
+    await client.send(
+      new AdminConfirmSignUpCommand({
+        UserPoolId: userPoolId,
+        Username: "alice",
+      }),
+    );
+
+    // Then the Command reached simulated Cognito.
+    const confirmed = await client.send(
+      new AdminGetUserCommand({ UserPoolId: userPoolId, Username: "alice" }),
+    );
+
+    assertIdentical(confirmed.UserStatus, "CONFIRMED");
   });
 });

--- a/src/service/cognito/sim-cognito-user-directory.ts
+++ b/src/service/cognito/sim-cognito-user-directory.ts
@@ -40,6 +40,47 @@ export abstract class SimCognitoUserDirectory extends SimCognitoAuthentication {
   }
 
   /**
+   * Handle a SignUp Command from the SDK.
+   */
+  async signUp(
+    command: simCognitoCommands.SimSignUpCommand,
+  ): Promise<simCognitoCommands.SimSignUpCommandOutput> {
+    await this.background.sequence();
+    return this.commands.signUp.signUp(command);
+  }
+
+  /**
+   * Handle a ConfirmSignUp Command from the SDK.
+   */
+  async confirmSignUp(
+    command: simCognitoCommands.SimConfirmSignUpCommand,
+  ): Promise<simCognitoCommands.SimConfirmSignUpCommandOutput> {
+    await this.background.sequence();
+    return this.commands.signUp.confirmSignUp(command);
+  }
+
+  /**
+   * Handle a ResendConfirmationCode Command from the SDK.
+   */
+  async resendConfirmationCode(
+    command: simCognitoCommands.SimResendConfirmationCodeCommand,
+  ): Promise<simCognitoCommands.SimResendConfirmationCodeCommandOutput> {
+    await this.background.sequence();
+    return this.commands.signUp.resendConfirmationCode(command);
+  }
+
+  /**
+   * Handle an AdminConfirmSignUp Command from the SDK.
+   */
+  async adminConfirmSignUp(
+    command: simCognitoCommands.SimAdminConfirmSignUpCommand,
+    options?: SimCognitoIdentityProviderRequestOptions,
+  ): Promise<simCognitoCommands.SimAdminConfirmSignUpCommandOutput> {
+    await this.background.sequence();
+    return this.commands.signUp.adminConfirmSignUp(command, options);
+  }
+
+  /**
    * Handle an AdminGetUser Command from the SDK.
    */
   async adminGetUser(

--- a/src/service/cognito/user-pool/auth/sim-cognito-sign-in.ts
+++ b/src/service/cognito/user-pool/auth/sim-cognito-sign-in.ts
@@ -1,4 +1,7 @@
-import { SimCognitoNotAuthorizedException } from "../../error/sim-cognito.error.js";
+import {
+  SimCognitoNotAuthorizedException,
+  SimCognitoUserNotConfirmedException,
+} from "../../error/sim-cognito.error.js";
 import type { SimCognitoUserPoolClient } from "../client/sim-cognito-user-pool-client.js";
 import type { SimCognitoUserPool } from "../sim-cognito-user-pool.js";
 import type { SimCognitoUser } from "../user/sim-cognito-user.js";
@@ -44,6 +47,20 @@ export function requireSimCognitoSignInUser(
 export function requireSimCognitoEnabled(user: SimCognitoUser): void {
   if (!user.enabled) {
     throw new SimCognitoNotAuthorizedException("User is disabled.");
+  }
+}
+
+/**
+ * Refuse a sign-in by a user that has not confirmed its sign-up.
+ *
+ * This is checked after the password, because that is the order real Cognito
+ * answers in: an unconfirmed user with the wrong password is refused as any
+ * other wrong password is, and one with the right password is told what is
+ * actually missing, so an application can send it to `ConfirmSignUp`.
+ */
+export function requireSimCognitoConfirmed(user: SimCognitoUser): void {
+  if (user.status.isUnconfirmed) {
+    throw new SimCognitoUserNotConfirmedException("User is not confirmed.");
   }
 }
 

--- a/src/service/cognito/user-pool/sim-cognito-admin-create-user-config.ts
+++ b/src/service/cognito/user-pool/sim-cognito-admin-create-user-config.ts
@@ -1,0 +1,59 @@
+import { SimCognitoNotAuthorizedException } from "../error/sim-cognito.error.js";
+
+/**
+ * The `AdminCreateUserConfig` a request can set on a pool.
+ *
+ * `InviteMessageTemplate` and `UnusedAccountValidityDays` are named so that
+ * `CreateUserPool` can refuse them: both are about the invitation an
+ * admin-created user is sent, and nothing here delivers a message.
+ */
+export interface SimCognitoAdminCreateUserConfigType {
+  readonly AllowAdminCreateUserOnly?: boolean | undefined;
+  readonly InviteMessageTemplate?: object | undefined;
+  readonly UnusedAccountValidityDays?: number | undefined;
+}
+
+/**
+ * Whether a pool lets users sign themselves up.
+ *
+ * `AllowAdminCreateUserOnly: true` says only an administrator creates users,
+ * and real Cognito refuses `SignUp` against such a pool. That refusal is
+ * simulated rather than the setting being accepted and ignored, because a CDK
+ * `UserPool` without `selfSignUpEnabled` emits exactly that value: a project
+ * testing its registration flow against a pool created that way would pass
+ * here and fail in a deployment.
+ *
+ * A pool created without the setting allows sign-up, which is the AWS default
+ * for the field.
+ */
+export class SimCognitoAdminCreateUserConfig {
+  public readonly allowAdminCreateUserOnly: boolean;
+
+  constructor(requested?: SimCognitoAdminCreateUserConfigType) {
+    this.allowAdminCreateUserOnly =
+      requested?.AllowAdminCreateUserOnly ?? false;
+  }
+
+  /**
+   * Refuse a sign-up against a pool only an administrator may create users in.
+   */
+  requireSelfServiceSignUp(): void {
+    if (this.allowAdminCreateUserOnly) {
+      throw new SimCognitoNotAuthorizedException(
+        "SignUp is not permitted for this user pool: it was created with " +
+          "AdminCreateUserConfig AllowAdminCreateUserOnly true, so only " +
+          "AdminCreateUser makes a user in it.",
+      );
+    }
+  }
+
+  /**
+   * This configuration as a described pool reports it.
+   *
+   * Real Cognito reports the setting whether or not the request named it, so
+   * a pool that allows sign-up says so rather than saying nothing.
+   */
+  toOutput(): SimCognitoAdminCreateUserConfigType {
+    return { AllowAdminCreateUserOnly: this.allowAdminCreateUserOnly };
+  }
+}

--- a/src/service/cognito/user-pool/sim-cognito-auto-verified-attributes.ts
+++ b/src/service/cognito/user-pool/sim-cognito-auto-verified-attributes.ts
@@ -1,0 +1,73 @@
+import { SimCognitoInvalidParameterException } from "../error/sim-cognito.error.js";
+
+/**
+ * The attributes a pool can verify automatically.
+ *
+ * These are the two Cognito can send a confirmation code to, and the only two
+ * with a `_verified` flag in the standard schema.
+ */
+const verifiableAttributeNames: readonly string[] = ["email", "phone_number"];
+
+/**
+ * The attributes a pool verifies when a user confirms its sign-up.
+ *
+ * Real Cognito sends the confirmation code to each of these, and marks the
+ * matching `_verified` flag once the user answers with the code. Nothing here
+ * sends anything, so what is simulated is the second half: confirming a
+ * sign-up sets `email_verified` or `phone_number_verified` on the user, which
+ * is what an application reads to decide whether it can trust the address.
+ *
+ * `AdminConfirmSignUp` sets neither, as it does not on real Cognito: an admin
+ * confirming a user says nothing about whether the address is really theirs.
+ */
+export class SimCognitoAutoVerifiedAttributes {
+  private readonly attributeNames: readonly string[];
+
+  constructor(requested?: readonly string[]) {
+    this.attributeNames = (requested ?? []).map((name) =>
+      SimCognitoAutoVerifiedAttributes.requireVerifiable(name),
+    );
+  }
+
+  private static requireVerifiable(name: string): string {
+    if (!verifiableAttributeNames.includes(name)) {
+      throw new SimCognitoInvalidParameterException(
+        `CreateUserPool AutoVerifiedAttributes '${name}' is not an attribute ` +
+          `Cognito can verify. Only ${verifiableAttributeNames.join(" and ")} ` +
+          `can be`,
+      );
+    }
+
+    return name;
+  }
+
+  /**
+   * The attribute names, as the request gave them.
+   */
+  get names(): readonly string[] {
+    return this.attributeNames;
+  }
+
+  /**
+   * Whether the pool verifies nothing automatically.
+   */
+  get isEmpty(): boolean {
+    return this.attributeNames.length === 0;
+  }
+
+  /**
+   * These attributes as a described pool reports them, or nothing where the
+   * pool has none.
+   *
+   * A pool created without any reports the property not at all rather than as
+   * an empty list, which is how the settings a pool accepts without acting on
+   * are reported too.
+   */
+  toOutput(): readonly string[] | undefined {
+    if (this.isEmpty) {
+      return undefined;
+    }
+
+    return [...this.attributeNames];
+  }
+}

--- a/src/service/cognito/user-pool/sim-cognito-unsimulated-pool-settings.ts
+++ b/src/service/cognito/user-pool/sim-cognito-unsimulated-pool-settings.ts
@@ -6,7 +6,6 @@
  */
 export interface SimCognitoUnsimulatedPoolSettingsType {
   readonly AccountRecoverySetting?: object | undefined;
-  readonly AdminCreateUserConfig?: object | undefined;
   readonly EmailVerificationMessage?: string | undefined;
   readonly EmailVerificationSubject?: string | undefined;
   readonly SmsVerificationMessage?: string | undefined;
@@ -45,7 +44,7 @@ export class SimCognitoUnsimulatedPoolSettings {
    * reference.
    *
    * A caller passes its whole `CreateUserPool` input in, and may reuse or
-   * edit that object afterwards. Three of these are nested objects, so the
+   * edit that object afterwards. Two of these are nested objects, so the
    * copy goes all the way down. Copying means a described pool reports what
    * the request said at the time it was made, as a real one does.
    *
@@ -59,9 +58,6 @@ export class SimCognitoUnsimulatedPoolSettings {
     return structuredClone({
       ...(settings.AccountRecoverySetting !== undefined && {
         AccountRecoverySetting: settings.AccountRecoverySetting,
-      }),
-      ...(settings.AdminCreateUserConfig !== undefined && {
-        AdminCreateUserConfig: settings.AdminCreateUserConfig,
       }),
       ...(settings.EmailVerificationMessage !== undefined && {
         EmailVerificationMessage: settings.EmailVerificationMessage,

--- a/src/service/cognito/user-pool/sim-cognito-user-pool-factory.ts
+++ b/src/service/cognito/user-pool/sim-cognito-user-pool-factory.ts
@@ -1,5 +1,10 @@
 import type { SimClock } from "../../../util/clock/sim-clock.js";
 import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+import {
+  SimCognitoAdminCreateUserConfig,
+  type SimCognitoAdminCreateUserConfigType,
+} from "./sim-cognito-admin-create-user-config.js";
+import { SimCognitoAutoVerifiedAttributes } from "./sim-cognito-auto-verified-attributes.js";
 import { SimCognitoDeletionProtection } from "./sim-cognito-deletion-protection.js";
 import { SimCognitoName } from "./sim-cognito-name.js";
 import {
@@ -25,6 +30,9 @@ interface SimCognitoMakeUserPoolProperties {
   readonly name: string | undefined;
   readonly policies?: SimCognitoUserPoolPoliciesType | undefined;
   readonly deletionProtection?: string | undefined;
+  readonly adminCreateUserConfig?:
+    SimCognitoAdminCreateUserConfigType | undefined;
+  readonly autoVerifiedAttributes?: readonly string[] | undefined;
 
   /**
    * The settings the request set that this simulation accepts without acting
@@ -76,6 +84,12 @@ export class SimCognitoUserPoolFactory {
       ),
       deletionProtection: new SimCognitoDeletionProtection(
         properties.deletionProtection,
+      ),
+      adminCreateUserConfig: new SimCognitoAdminCreateUserConfig(
+        properties.adminCreateUserConfig,
+      ),
+      autoVerifiedAttributes: new SimCognitoAutoVerifiedAttributes(
+        properties.autoVerifiedAttributes,
       ),
       unsimulatedSettings: new SimCognitoUnsimulatedPoolSettings(
         properties.unsimulatedSettings ?? {},

--- a/src/service/cognito/user-pool/sim-cognito-user-pool.ts
+++ b/src/service/cognito/user-pool/sim-cognito-user-pool.ts
@@ -5,6 +5,8 @@ import { SimCognitoUserPoolClientStore } from "./client/sim-cognito-user-pool-cl
 import type { SimCognitoGroup } from "./group/sim-cognito-group.js";
 import type { SimCognitoGroupName } from "./group/sim-cognito-group-name.js";
 import { SimCognitoGroupStore } from "./group/sim-cognito-group-store.js";
+import type { SimCognitoAdminCreateUserConfig } from "./sim-cognito-admin-create-user-config.js";
+import type { SimCognitoAutoVerifiedAttributes } from "./sim-cognito-auto-verified-attributes.js";
 import type { SimCognitoDeletionProtection } from "./sim-cognito-deletion-protection.js";
 import type { SimCognitoName } from "./sim-cognito-name.js";
 import type { SimCognitoPasswordPolicy } from "./sim-cognito-password-policy.js";
@@ -17,7 +19,10 @@ import {
 } from "./token/sim-cognito-signing-key.js";
 import type { SimCognitoUser } from "./user/sim-cognito-user.js";
 import { SimCognitoUserStore } from "./user/sim-cognito-user-store.js";
-import type { SimCognitoUsername } from "./user/sim-cognito-username.js";
+import {
+  requireSimCognitoUsername,
+  type SimCognitoUsername,
+} from "./user/sim-cognito-username.js";
 
 interface SimCognitoUserPoolProperties {
   readonly id: SimCognitoUserPoolId;
@@ -25,6 +30,8 @@ interface SimCognitoUserPoolProperties {
   readonly name: SimCognitoName;
   readonly passwordPolicy: SimCognitoPasswordPolicy;
   readonly deletionProtection: SimCognitoDeletionProtection;
+  readonly adminCreateUserConfig: SimCognitoAdminCreateUserConfig;
+  readonly autoVerifiedAttributes: SimCognitoAutoVerifiedAttributes;
   readonly unsimulatedSettings: SimCognitoUnsimulatedPoolSettings;
   readonly createdDate: Date;
 }
@@ -42,6 +49,16 @@ export class SimCognitoUserPool {
   public readonly name: string;
   public readonly passwordPolicy: SimCognitoPasswordPolicy;
   public readonly deletionProtection: SimCognitoDeletionProtection;
+
+  /**
+   * Whether users may sign themselves up in this pool.
+   */
+  public readonly adminCreateUserConfig: SimCognitoAdminCreateUserConfig;
+
+  /**
+   * The attributes confirming a sign-up marks as verified.
+   */
+  public readonly autoVerifiedAttributes: SimCognitoAutoVerifiedAttributes;
 
   /**
    * What the pool was created with and nothing here acts on, kept so a
@@ -68,6 +85,8 @@ export class SimCognitoUserPool {
     this.name = properties.name.value;
     this.passwordPolicy = properties.passwordPolicy;
     this.deletionProtection = properties.deletionProtection;
+    this.adminCreateUserConfig = properties.adminCreateUserConfig;
+    this.autoVerifiedAttributes = properties.autoVerifiedAttributes;
     this.unsimulatedSettings = properties.unsimulatedSettings;
     this.creationDate = properties.createdDate;
   }
@@ -221,6 +240,18 @@ export class SimCognitoUserPool {
    */
   requireUser(username: SimCognitoUsername): SimCognitoUser {
     return this.userStore.require(username);
+  }
+
+  /**
+   * The confirmation code a user of this pool has outstanding, if it has one.
+   *
+   * This is the simulator's own accessor, for a test that signed a user up:
+   * nothing here delivers a message for one to read the code from. Real
+   * Cognito reports a code to nobody, so this is a deliberate divergence.
+   */
+  confirmationCode(username: string): string | undefined {
+    return this.requireUser(requireSimCognitoUsername(username))
+      .confirmationCode;
   }
 
   /**

--- a/src/service/cognito/user-pool/user/sim-cognito-confirmation-code.ts
+++ b/src/service/cognito/user-pool/user/sim-cognito-confirmation-code.ts
@@ -1,0 +1,46 @@
+import { randomInt } from "node:crypto";
+
+/**
+ * How many digits a Cognito confirmation code has.
+ */
+const codeDigits = 6;
+
+/**
+ * The confirmation code a pool issues to a user that signed itself up.
+ *
+ * Real Cognito emails or texts the code and never reports it back, so a value
+ * object here would be write-only if it exposed nothing. It exposes its value,
+ * and a pool hands that value to a test through
+ * `SimCognitoUserPool.confirmationCode`, because nothing here delivers a
+ * message for a test to read the code from. That is the one place this
+ * simulation knowingly tells a caller something real Cognito would not.
+ *
+ * The code is six digits, as a real one is, so code parsing or validating it
+ * gets the shape it would get in a deployment.
+ */
+export class SimCognitoConfirmationCode {
+  public readonly value: string;
+
+  private constructor(value: string) {
+    this.value = value;
+  }
+
+  /**
+   * Issue a fresh code.
+   *
+   * Leading zeros are kept, because a real code has them and a test treating
+   * the value as a number would lose them.
+   */
+  static issue(): SimCognitoConfirmationCode {
+    return new SimCognitoConfirmationCode(
+      String(randomInt(0, 10 ** codeDigits)).padStart(codeDigits, "0"),
+    );
+  }
+
+  /**
+   * Whether a candidate is this code.
+   */
+  matches(candidate: string | undefined): boolean {
+    return candidate === this.value;
+  }
+}

--- a/src/service/cognito/user-pool/user/sim-cognito-user-attributes.ts
+++ b/src/service/cognito/user-pool/user/sim-cognito-user-attributes.ts
@@ -120,6 +120,21 @@ export class SimCognitoUserAttributes {
   }
 
   /**
+   * Mark the named attributes verified, where they are held.
+   *
+   * This is what a pool's `AutoVerifiedAttributes` reaches when a user
+   * confirms its sign-up. An attribute the user does not have is left alone
+   * rather than flagged as verified, because there was nothing to verify.
+   */
+  verify(names: readonly string[]): void {
+    this.update(
+      names
+        .filter((name) => this.byName.has(name))
+        .map((name) => ({ Name: `${name}_verified`, Value: "true" })),
+    );
+  }
+
+  /**
    * Apply requested attributes over the ones already held.
    *
    * An update names only the attributes it changes, as `AdminUpdateUserAttributes`

--- a/src/service/cognito/user-pool/user/sim-cognito-user-confirmation.ts
+++ b/src/service/cognito/user-pool/user/sim-cognito-user-confirmation.ts
@@ -1,0 +1,59 @@
+import { SimCognitoCodeMismatchException } from "../../error/sim-cognito.error.js";
+import { SimCognitoConfirmationCode } from "./sim-cognito-confirmation-code.js";
+import type { SimCognitoUserStatus } from "./sim-cognito-user-status.js";
+
+/**
+ * The confirmation one user has outstanding.
+ *
+ * A user that signed itself up holds a code until it confirms, and a user that
+ * did not holds none. Keeping the code and what it answers together is the
+ * same modelling choice `SimCognitoUserPassword` makes: the user asks whether
+ * a candidate is right, rather than reading the value out to compare it.
+ *
+ * The value is readable, unlike a password, because nothing here delivers the
+ * message that would carry it.
+ */
+export class SimCognitoUserConfirmation {
+  #code: SimCognitoConfirmationCode | undefined;
+
+  constructor(status: SimCognitoUserStatus) {
+    this.settle(status);
+  }
+
+  /**
+   * The code outstanding, if there is one.
+   */
+  get code(): string | undefined {
+    return this.#code?.value;
+  }
+
+  /**
+   * Issue a fresh code, forgetting any outstanding one.
+   */
+  issue(): void {
+    this.#code = SimCognitoConfirmationCode.issue();
+  }
+
+  /**
+   * Follow the user to a status.
+   *
+   * A user waiting to be confirmed holds a code, and one that has left
+   * `UNCONFIRMED` has spent it: a code confirms one sign-up and no more.
+   */
+  settle(status: SimCognitoUserStatus): void {
+    this.#code = status.isUnconfirmed
+      ? SimCognitoConfirmationCode.issue()
+      : undefined;
+  }
+
+  /**
+   * Refuse a candidate that is not the code outstanding.
+   */
+  require(candidate: string | undefined): void {
+    if (this.#code?.matches(candidate) !== true) {
+      throw new SimCognitoCodeMismatchException(
+        "Invalid verification code provided, please try again.",
+      );
+    }
+  }
+}

--- a/src/service/cognito/user-pool/user/sim-cognito-user-factory.ts
+++ b/src/service/cognito/user-pool/user/sim-cognito-user-factory.ts
@@ -6,6 +6,7 @@ import {
 } from "./sim-cognito-user-attributes.js";
 import { SimCognitoUser } from "./sim-cognito-user.js";
 import { SimCognitoUserPassword } from "./sim-cognito-user-password.js";
+import { SimCognitoUserStatus } from "./sim-cognito-user-status.js";
 import type { SimCognitoUsername } from "./sim-cognito-username.js";
 
 interface SimCognitoUserFactoryProperties {
@@ -20,6 +21,17 @@ interface SimCognitoMakeUserProperties {
    * policy. A user made without one has no password at all.
    */
   readonly temporaryPassword?: string | undefined;
+}
+
+interface SimCognitoSignUpUserProperties {
+  readonly username: SimCognitoUsername;
+  readonly attributes?: readonly SimCognitoAttributeType[] | undefined;
+  /**
+   * The password the user chose, already checked against the pool's policy.
+   * It is the user's own rather than a temporary one, so the user signs in
+   * with it as soon as it is confirmed.
+   */
+  readonly password: string;
 }
 
 /**
@@ -55,6 +67,23 @@ export class SimCognitoUserFactory {
       sub: randomUUID(),
       attributes: new SimCognitoUserAttributes(properties.attributes),
       password: SimCognitoUserFactory.passwordFor(properties.temporaryPassword),
+      clock: this.clock,
+    });
+  }
+
+  /**
+   * Make a user that signed itself up, waiting to be confirmed.
+   *
+   * The user starts in `UNCONFIRMED` holding the confirmation code it gets
+   * with that status, which is where real Cognito leaves a `SignUp`.
+   */
+  signUp(properties: SimCognitoSignUpUserProperties): SimCognitoUser {
+    return new SimCognitoUser({
+      username: properties.username,
+      sub: randomUUID(),
+      attributes: new SimCognitoUserAttributes(properties.attributes),
+      password: new SimCognitoUserPassword(properties.password),
+      status: SimCognitoUserStatus.unconfirmed,
       clock: this.clock,
     });
   }

--- a/src/service/cognito/user-pool/user/sim-cognito-user-status.ts
+++ b/src/service/cognito/user-pool/user/sim-cognito-user-status.ts
@@ -1,16 +1,29 @@
-export type SimCognitoUserStatusValue = "FORCE_CHANGE_PASSWORD" | "CONFIRMED";
+import {
+  SimCognitoInvalidParameterException,
+  SimCognitoNotAuthorizedException,
+} from "../../error/sim-cognito.error.js";
+
+export type SimCognitoUserStatusValue =
+  "UNCONFIRMED" | "FORCE_CHANGE_PASSWORD" | "CONFIRMED";
 
 /**
  * The status of one simulated user.
  *
- * Only the two statuses this simulation can reach are modelled. A user created
- * by `AdminCreateUser` starts in `FORCE_CHANGE_PASSWORD`, which is what stops
- * it signing in normally on real Cognito, and reaches `CONFIRMED` when an
- * admin sets a permanent password on it. The other real statuses
- * (`UNCONFIRMED`, `RESET_REQUIRED`, `EXTERNAL_PROVIDER` and the rest) belong
- * to sign-up, password resets and federation, none of which are simulated.
+ * Only the three statuses this simulation can reach are modelled. A user
+ * created by `AdminCreateUser` starts in `FORCE_CHANGE_PASSWORD`, which is what
+ * stops it signing in normally on real Cognito, and reaches `CONFIRMED` when an
+ * admin sets a permanent password on it. A user that signed itself up with
+ * `SignUp` starts in `UNCONFIRMED`, which is what stops that one signing in,
+ * and reaches `CONFIRMED` through `ConfirmSignUp` or `AdminConfirmSignUp`. The
+ * other real statuses (`RESET_REQUIRED`, `EXTERNAL_PROVIDER` and the rest)
+ * belong to password resets and federation, neither of which is simulated.
  */
 export class SimCognitoUserStatus {
+  /**
+   * The status a user that signed itself up starts in.
+   */
+  public static readonly unconfirmed = new SimCognitoUserStatus("UNCONFIRMED");
+
   /**
    * The status a user created by an admin starts in.
    */
@@ -34,7 +47,9 @@ export class SimCognitoUserStatus {
    *
    * A permanent password is the user's own, so the user is confirmed and can
    * sign in with it. A temporary one leaves the user having to replace it,
-   * which is the same place `AdminCreateUser` leaves a new user.
+   * which is the same place `AdminCreateUser` leaves a new user. An
+   * `UNCONFIRMED` user reaches the same two, as it does on real Cognito:
+   * setting a permanent password on one confirms it without a code.
    */
   static afterPasswordSet(
     permanent: boolean | undefined,
@@ -54,5 +69,46 @@ export class SimCognitoUserStatus {
    */
   get mustChangePassword(): boolean {
     return this.value === "FORCE_CHANGE_PASSWORD";
+  }
+
+  /**
+   * Whether the user has still to confirm the sign-up it made.
+   *
+   * This is what turns an authentication into `UserNotConfirmedException`,
+   * which real Cognito answers with even when the password was right.
+   */
+  get isUnconfirmed(): boolean {
+    return this.value === "UNCONFIRMED";
+  }
+
+  /**
+   * Refuse to confirm a user that is not waiting to be confirmed.
+   *
+   * Real Cognito says which status stopped it, because the answer to a user
+   * already `CONFIRMED` is to sign it in and the answer to one in
+   * `FORCE_CHANGE_PASSWORD` is the new password challenge.
+   */
+  requireConfirmable(): void {
+    if (!this.isUnconfirmed) {
+      throw new SimCognitoNotAuthorizedException(
+        `User cannot be confirmed. Current status is ${this.value}`,
+      );
+    }
+  }
+
+  /**
+   * Refuse to issue another confirmation code to a user that needs none.
+   *
+   * Real Cognito reports this as a bad request rather than as a refusal to
+   * confirm, because nothing was wrong with the user: there is simply no
+   * sign-up left to confirm.
+   */
+  requireResendable(): void {
+    if (!this.isUnconfirmed) {
+      throw new SimCognitoInvalidParameterException(
+        `User is already confirmed: its status is ${this.value}, so there ` +
+          `is no sign-up left to confirm.`,
+      );
+    }
   }
 }

--- a/src/service/cognito/user-pool/user/sim-cognito-user.ts
+++ b/src/service/cognito/user-pool/user/sim-cognito-user.ts
@@ -1,4 +1,5 @@
 import type { SimClock } from "../../../../util/clock/sim-clock.js";
+import { SimCognitoUserConfirmation } from "./sim-cognito-user-confirmation.js";
 import type {
   SimCognitoAttributeType,
   SimCognitoUserAttributes,
@@ -12,6 +13,13 @@ interface SimCognitoUserProperties {
   readonly sub: string;
   readonly attributes: SimCognitoUserAttributes;
   readonly password?: SimCognitoUserPassword | undefined;
+
+  /**
+   * Where the user starts. `AdminCreateUser` leaves one in
+   * `FORCE_CHANGE_PASSWORD`, which is the default, and `SignUp` leaves one in
+   * `UNCONFIRMED`.
+   */
+  readonly status?: SimCognitoUserStatus | undefined;
   readonly clock: SimClock;
 }
 
@@ -22,9 +30,10 @@ interface SimCognitoUserProperties {
  * that keys on the wrong one works only while the two happen to match, which
  * they never do on a real pool.
  *
- * A user starts in `FORCE_CHANGE_PASSWORD`, because `AdminCreateUser` is the
- * only way to make one here. That is the status that stops a user signing in
- * with the temporary password it was given.
+ * Where a user starts depends on how it was made. `AdminCreateUser` leaves one
+ * in `FORCE_CHANGE_PASSWORD`, which is the status that stops it signing in
+ * with the temporary password it was given, and `SignUp` leaves one in
+ * `UNCONFIRMED` holding the confirmation code its pool issued.
  */
 export class SimCognitoUser {
   public readonly username: SimCognitoUsername;
@@ -33,7 +42,8 @@ export class SimCognitoUser {
 
   private readonly clock: SimClock;
   private readonly userAttributes: SimCognitoUserAttributes;
-  private userStatus = SimCognitoUserStatus.forceChangePassword;
+  private readonly confirmation: SimCognitoUserConfirmation;
+  private userStatus: SimCognitoUserStatus;
   private userPassword: SimCognitoUserPassword | undefined;
   private isEnabled = true;
   private modifiedDate: Date;
@@ -43,6 +53,9 @@ export class SimCognitoUser {
     this.sub = properties.sub;
     this.userAttributes = properties.attributes;
     this.userPassword = properties.password;
+    this.userStatus =
+      properties.status ?? SimCognitoUserStatus.forceChangePassword;
+    this.confirmation = new SimCognitoUserConfirmation(this.userStatus);
     this.clock = properties.clock;
     this.creationDate = this.clock.now();
     this.modifiedDate = this.creationDate;
@@ -95,6 +108,18 @@ export class SimCognitoUser {
   }
 
   /**
+   * The confirmation code this user has outstanding, if it has one.
+   *
+   * Real Cognito sends the code to the user and never reports it back. Nothing
+   * here delivers a message, so a test reads the code from the pool instead,
+   * which is the divergence that makes a sign-up flow testable at all. A
+   * confirmed user has none: a code is single use, and confirming spends it.
+   */
+  get confirmationCode(): string | undefined {
+    return this.confirmation.code;
+  }
+
+  /**
    * Set the password an admin gave this user.
    *
    * A permanent password is the user's own, and confirms it. A temporary one
@@ -103,7 +128,51 @@ export class SimCognitoUser {
    */
   setPassword(password: string, permanent: boolean | undefined): void {
     this.userPassword = new SimCognitoUserPassword(password);
-    this.userStatus = SimCognitoUserStatus.afterPasswordSet(permanent);
+    this.moveTo(SimCognitoUserStatus.afterPasswordSet(permanent));
+  }
+
+  /**
+   * Issue a fresh confirmation code, forgetting the one this user had.
+   *
+   * `ResendConfirmationCode` issues another one rather than sending the same
+   * one again, as real Cognito does, so a code read before the resend no
+   * longer confirms anything.
+   */
+  resendConfirmationCode(): void {
+    this.userStatus.requireResendable();
+    this.confirmation.issue();
+    this.touch();
+  }
+
+  /**
+   * Confirm the sign-up this user made, given the code it was issued.
+   *
+   * A wrong code leaves the user where it was, still holding the code it was
+   * issued, so a caller can try again with the right one.
+   */
+  confirmSignUp(code: string | undefined): void {
+    this.userStatus.requireConfirmable();
+    this.confirmation.require(code);
+    this.moveTo(SimCognitoUserStatus.confirmed);
+  }
+
+  /**
+   * Confirm the sign-up without a code, as `AdminConfirmSignUp` does.
+   */
+  confirm(): void {
+    this.userStatus.requireConfirmable();
+    this.moveTo(SimCognitoUserStatus.confirmed);
+  }
+
+  /**
+   * Mark the named attributes verified, where this user has them.
+   *
+   * This is what a pool's `AutoVerifiedAttributes` reaches when a user
+   * confirms its sign-up: the address the code was sent to has been shown to
+   * be the user's.
+   */
+  verifyAttributes(names: readonly string[]): void {
+    this.userAttributes.verify(names);
     this.touch();
   }
 
@@ -142,6 +211,19 @@ export class SimCognitoUser {
    */
   disable(): void {
     this.isEnabled = false;
+    this.touch();
+  }
+
+  /**
+   * Move the user to a status, and let its confirmation follow.
+   *
+   * A code confirms one sign-up and no more, so it goes as soon as the user
+   * leaves `UNCONFIRMED`, whether it was `ConfirmSignUp` or an admin setting a
+   * permanent password that took it there.
+   */
+  private moveTo(status: SimCognitoUserStatus): void {
+    this.userStatus = status;
+    this.confirmation.settle(status);
     this.touch();
   }
 


### PR DESCRIPTION
Resolves #426.

One decision worth a reviewer's eye: `AdminCreateUserConfig.AllowAdminCreateUserOnly` is now simulated rather than accepted and ignored, so `true` refuses `SignUp` as a real pool does. A CDK `UserPool` without `selfSignUpEnabled` emits exactly that value, so accepting it and allowing sign-up anyway would pass a registration test here that the deployed pool refuses. It moves out of the "accepted without being simulated" set, and `DescribeUserPool` now always reports it.