### PR TITLE
feat: store MX, SRV, CAA and PTR Route53 records

### DIFF
--- a/docs/services/route53/README.md
+++ b/docs/services/route53/README.md
@@ -251,6 +251,98 @@ await simAws.backgroundTasksComplete();
 
 The stored alias value is normalized without the trailing dot.
 
+## Record types
+
+Sim Route53 stores ten record types: `A`, `AAAA`, `CAA`, `CNAME`, `MX`, `NS`, `PTR`, `SOA`, `SRV` and
+`TXT`. All ten can be created through `ChangeResourceRecordSetsCommand`, read back through
+`ListResourceRecordSetsCommand`, and declared as an `AWS::Route53::RecordSet`, so a zone that models
+a real one — mail records, certificate pinning, a service record — deploys as it stands. A type
+outside that list is rejected rather than stored.
+
+Simulated DNS answers queries for six of them: `A`, `AAAA`, `CNAME`, `TXT`, `NS` and `SOA`. `MX`,
+`SRV`, `CAA` and `PTR` are stored for a test to assert the presence and value of, not for a resolver
+to act on, so a DNS query for one is answered as no data. See
+[What is answered](#what-is-answered).
+
+Values of those four are stored exactly as written, along with `TXT`. Nothing takes an `MX`
+preference number or an `SRV` priority apart, so what you assert on is the string your stack
+declared. Values of the other types are hostnames or addresses, and are normalized like DNS names so
+they compare consistently.
+
+```typescript sim-route53-mail-records
+/**
+ * Creating simulated Route53 records a resolver never answers for.
+ */
+
+import {
+  ChangeResourceRecordSetsCommand,
+  CreateHostedZoneCommand,
+  ListResourceRecordSetsCommand,
+} from "@aws-sdk/client-route-53";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const route53 = simAws.route53();
+
+const hostedZoneCreation = await route53.createHostedZone(
+  new CreateHostedZoneCommand({
+    Name: "example.test",
+    CallerReference: "mail-zone",
+  }),
+);
+
+const hostedZoneId = hostedZoneCreation.HostedZone!.Id!;
+
+await simAws.backgroundTasksComplete();
+
+await route53.changeResourceRecordSets(
+  new ChangeResourceRecordSetsCommand({
+    HostedZoneId: hostedZoneId,
+    ChangeBatch: {
+      Changes: [
+        {
+          Action: "CREATE",
+          ResourceRecordSet: {
+            Name: "example.test",
+            Type: "MX",
+            TTL: 3600,
+            ResourceRecords: [
+              { Value: "10 in1-smtp.messagingengine.com." },
+              { Value: "20 in2-smtp.messagingengine.com." },
+            ],
+          },
+        },
+        {
+          Action: "CREATE",
+          ResourceRecordSet: {
+            Name: "example.test",
+            Type: "CAA",
+            TTL: 300,
+            ResourceRecords: [{ Value: '0 issue "letsencrypt.org"' }],
+          },
+        },
+      ],
+    },
+  }),
+);
+
+await simAws.backgroundTasksComplete();
+
+const listOutput = await route53.listResourceRecordSets(
+  new ListResourceRecordSetsCommand({
+    HostedZoneId: hostedZoneId,
+  }),
+);
+
+const mailRecord = listOutput.ResourceRecordSets?.find(
+  (recordSet) => recordSet.Type === "MX",
+);
+
+// [ '10 in1-smtp.messagingengine.com.', '20 in2-smtp.messagingengine.com.' ]
+console.log(mailRecord?.ResourceRecords?.map((record) => record.Value));
+```
+
 ## Listing Hosted Zones by name
 
 Use `ListHostedZonesByNameCommand` to inspect zones in sorted Route53 order.
@@ -572,7 +664,11 @@ server answers for those names too: see [Local hostname resolution](#local-hostn
 
 ### What is answered
 
-- The record types sim Route53 stores: `A`, `AAAA`, `CNAME`, `TXT`, `NS` and `SOA`.
+- Six of the ten record types sim Route53 stores: `A`, `AAAA`, `CNAME`, `TXT`, `NS` and `SOA`. A
+  query for a stored type outside that list — `MX`, `SRV`, `CAA` or `PTR` — is answered as no data,
+  the same as a query type the simulator does not recognise at all. Those records exist to be
+  asserted on rather than resolved; what a browser reaching a simulated site needs is an address or
+  a CNAME. See [Record types](#record-types).
 - CNAME chains are followed, so an `A` query on a name holding a CNAME returns the CNAME and the
   address it leads to together. Chains are bounded, and a cycle stops immediately.
 - Alias records are resolved to the address of whatever they point at, answered under the name that
@@ -968,12 +1064,13 @@ Sim Route53 currently supports:
 - `CreateHostedZoneCommand`, `GetHostedZoneCommand` and `ListHostedZonesByNameCommand`
 - `ChangeResourceRecordSetsCommand` and `ListResourceRecordSetsCommand`
 - `CREATE`, `UPSERT` and `DELETE` record changes
-- Stored record types: `A`, `AAAA`, `CNAME`, `TXT`, `NS` and `SOA`
+- Stored record types: `A`, `AAAA`, `CAA`, `CNAME`, `MX`, `NS`, `PTR`, `SOA`, `SRV` and `TXT`
 - Local HTTP hostname routing through `CNAME` records that point to simulated service hostnames
 - Alias records, with `AliasTarget.DNSName` stored as the record value
 - Local hostname resolution, with or without the `sim-aws.localhost` suffix on the requested hostname
 - A browser-viewable hosted zone and record summary at `dns.sim-aws.localhost`
-- DNS answers over UDP, so records can be queried with `dig` or any DNS client
+- DNS answers over UDP for `A`, `AAAA`, `CNAME`, `TXT`, `NS` and `SOA`, so those records can be
+  queried with `dig` or any DNS client
 - The `AWS::Route53::HostedZone` and `AWS::Route53::RecordSet` CloudFormation resources
 - CDK-created Route53 Hosted Zones and records in synthesized templates
 

--- a/docs/services/route53/sim-route53-mail-records.example.ts
+++ b/docs/services/route53/sim-route53-mail-records.example.ts
@@ -1,0 +1,71 @@
+/**
+ * Creating simulated Route53 records a resolver never answers for.
+ */
+
+import {
+  ChangeResourceRecordSetsCommand,
+  CreateHostedZoneCommand,
+  ListResourceRecordSetsCommand,
+} from "@aws-sdk/client-route-53";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const route53 = simAws.route53();
+
+const hostedZoneCreation = await route53.createHostedZone(
+  new CreateHostedZoneCommand({
+    Name: "example.test",
+    CallerReference: "mail-zone",
+  }),
+);
+
+const hostedZoneId = hostedZoneCreation.HostedZone!.Id!;
+
+await simAws.backgroundTasksComplete();
+
+await route53.changeResourceRecordSets(
+  new ChangeResourceRecordSetsCommand({
+    HostedZoneId: hostedZoneId,
+    ChangeBatch: {
+      Changes: [
+        {
+          Action: "CREATE",
+          ResourceRecordSet: {
+            Name: "example.test",
+            Type: "MX",
+            TTL: 3600,
+            ResourceRecords: [
+              { Value: "10 in1-smtp.messagingengine.com." },
+              { Value: "20 in2-smtp.messagingengine.com." },
+            ],
+          },
+        },
+        {
+          Action: "CREATE",
+          ResourceRecordSet: {
+            Name: "example.test",
+            Type: "CAA",
+            TTL: 300,
+            ResourceRecords: [{ Value: '0 issue "letsencrypt.org"' }],
+          },
+        },
+      ],
+    },
+  }),
+);
+
+await simAws.backgroundTasksComplete();
+
+const listOutput = await route53.listResourceRecordSets(
+  new ListResourceRecordSetsCommand({
+    HostedZoneId: hostedZoneId,
+  }),
+);
+
+const mailRecord = listOutput.ResourceRecordSets?.find(
+  (recordSet) => recordSet.Type === "MX",
+);
+
+// [ '10 in1-smtp.messagingengine.com.', '20 in2-smtp.messagingengine.com.' ]
+console.log(mailRecord?.ResourceRecords?.map((record) => record.Value));

--- a/src/service/route53/README.md
+++ b/src/service/route53/README.md
@@ -147,14 +147,24 @@ contain distinct records such as:
 - `CNAME www.example.test`
 - `TXT example.test`
 
+`simRoute53RecordTypes` in `record/sim-route53-record.ts` is the list, and the union is derived from
+it so the guard in `sim-route53-record-type.ts` cannot drift from the type. It is wider than the set
+simulated DNS answers queries for: `MX`, `SRV`, `CAA` and `PTR` are stored, listed and deployable
+from a template so a zone can model a real one, but nothing resolves them. See
+[DNS wire format](#dns-wire-format).
+
 Record normalization is simple:
 
 - record names are normalized with Route53 local-name helpers
-- non-`TXT` record values are normalized like DNS names
-- `TXT` values are preserved as text values
+- record values go through `normaliseSimRoute53RecordValue` in
+  `record/sim-route53-record-value.ts`, which normalizes them like DNS names
+- `TXT`, `MX`, `SRV`, `CAA` and `PTR` values are preserved exactly as given
 
-DNS-like target values need consistent comparison and resolution, while TXT record values should not
-be transformed as hostnames.
+DNS-like target values need consistent comparison and resolution. A TXT value is arbitrary text, and
+the other four hold a structured string — a preference and a host, a priority, weight, port and
+target, a CAA flag, tag and value — that nothing in the simulator resolves against, so it is stored
+as written rather than taken apart or folded to a hostname. A test asserting on an `MX` record gets
+back the string its stack declared.
 
 The record store supports three mutation modes:
 
@@ -390,10 +400,15 @@ localhost test against a real client.
 
 The scope is narrow, which is what keeps the codec small:
 
-- Only the record types sim Route53 stores are encodable: `A`, `AAAA`, `CNAME`,
-  `TXT`, `NS`, `SOA`. `dns-record-type.ts` maps those to and from wire type
-  numbers, and returns `undefined` for any other query type so a caller answers
-  with no records rather than guessing at an encoding it does not have.
+- Only six of the ten stored record types are encodable: `A`, `AAAA`, `CNAME`,
+  `TXT`, `NS`, `SOA`. `dns-record-type.ts` names that subset as
+  `SimRoute53DnsRecordType`, maps it to and from wire type numbers, and returns
+  `undefined` for any other query type so a caller answers with no records rather
+  than guessing at an encoding it does not have. A stored type with no encoder,
+  such as `MX`, arrives as a wire number the map does not hold and is treated the
+  same way. Narrowing the type rather than widening the map is what keeps the
+  encoders exhaustive: adding a stored type cannot silently leave `encodeDnsRdata`
+  with a case it cannot handle.
 - **`ANY` (QTYPE 255) is a query type, not a record type**, so it
   does not map to a stored record type. `dnsAnyQueryType` is exported for a
   caller that wants to recognise it, but what to _answer_ for `ANY` is answer

--- a/src/service/route53/cfn/record-set/build/sim-cfn-r53-record-set-builder.iso.test.ts
+++ b/src/service/route53/cfn/record-set/build/sim-cfn-r53-record-set-builder.iso.test.ts
@@ -9,6 +9,7 @@ import {
 import { describe, it } from "vitest";
 import { SimCfnResource } from "../../../../cloudformation/resource/sim-cfn-resource.js";
 import type { SimCfnTemplateValueRecord } from "../../../../cloudformation/template/value/sim-cfn-template-value.js";
+import { simRoute53RecordTypes } from "../../../record/sim-route53-record.js";
 import { SimCfnRoute53RecordSetBuilder } from "./sim-cfn-r53-record-set-builder.js";
 
 describe("SimCfnRoute53RecordSetBuilder", () => {
@@ -83,10 +84,8 @@ describe("SimCfnRoute53RecordSetBuilder", () => {
   });
 
   it("accepts all supported Route53 record types", () => {
-    // Given every record type supported by the builder.
-    const supportedTypes = ["A", "AAAA", "CNAME", "TXT", "NS", "SOA"] as const;
-
-    for (const type of supportedTypes) {
+    // Given every record type the simulator stores.
+    for (const type of simRoute53RecordTypes) {
       // When the RecordSet is built.
       const recordSet = buildRecordSet({
         Name: `${type.toLowerCase()}.example.com`,
@@ -116,8 +115,9 @@ describe("SimCfnRoute53RecordSetBuilder", () => {
   });
 
   it("throws when Type is not a supported Route53 record type", () => {
-    // Given RecordSets with invalid Type values.
-    const invalidTypes = [undefined, "MX", "a", 123, null];
+    // Given RecordSets with invalid Type values, including a real Route53 type
+    // the simulator does not model.
+    const invalidTypes = [undefined, "DS", "a", 123, null];
 
     for (const type of invalidTypes) {
       // When the RecordSet is built.

--- a/src/service/route53/cfn/record-set/sim-cfn-r53-mail-record-set.iso.test.ts
+++ b/src/service/route53/cfn/record-set/sim-cfn-r53-mail-record-set.iso.test.ts
@@ -1,0 +1,63 @@
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertObjectMatches,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimRoute53HostedZone } from "../../hosted-zone/sim-route53-hosted-zone.js";
+
+describe("Route53 CloudFormation RecordSets for stored-only record types", () => {
+  it("deploys an MX RecordSet and leaves it readable on the Hosted Zone", async () => {
+    // Given a template pointing a zone's mail at a provider, which is a record
+    // simulated DNS never answers a query for but a stack still carries.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "mail-stack",
+      template: {
+        Resources: {
+          MailZone: {
+            Type: "AWS::Route53::HostedZone",
+            Properties: { Name: "example.test" },
+          },
+          MailRecord: {
+            Type: "AWS::Route53::RecordSet",
+            Properties: {
+              HostedZoneId: { Ref: "MailZone" },
+              Name: "example.test",
+              Type: "MX",
+              TTL: "3600",
+              ResourceRecords: [
+                "10 in1-smtp.messagingengine.com.",
+                "20 in2-smtp.messagingengine.com.",
+              ],
+            },
+          },
+        },
+      },
+    });
+
+    // When the Stack finishes deploying.
+    await stack.waitForDeployComplete();
+    await simAws.backgroundTasksComplete();
+
+    // Then the RecordSet deployed rather than failing the Stack, and the record
+    // is on the Hosted Zone with its preference numbers intact.
+    assertIdentical(
+      stack.resources.get("MailRecord")?.status,
+      "CREATE_COMPLETE",
+    );
+    const hostedZone = stack.getResource("MailZone")?.simResource;
+    assertInstanceOf(hostedZone, SimRoute53HostedZone);
+    assertObjectMatches(hostedZone.records.get("example.test", "MX"), {
+      name: "example.test",
+      type: "MX",
+      ttl: 3600,
+      values: [
+        "10 in1-smtp.messagingengine.com.",
+        "20 in2-smtp.messagingengine.com.",
+      ],
+    });
+  });
+});

--- a/src/service/route53/command/change-resource-record-sets/change-resource-rec-sets-error.iso.test.ts
+++ b/src/service/route53/command/change-resource-record-sets/change-resource-rec-sets-error.iso.test.ts
@@ -40,11 +40,14 @@ describe("Route53 ChangeResourceRecordSetsCommand errors", () => {
               {
                 Action: "CREATE",
                 ResourceRecordSet: {
-                  Name: "mail.unsupported-type.example.com",
-                  Type: "MX",
+                  Name: "sip.unsupported-type.example.com",
+                  Type: "NAPTR",
                   TTL: 300,
                   ResourceRecords: [
-                    { Value: "10 mail.unsupported-type.example.com" },
+                    {
+                      Value:
+                        '10 100 "S" "SIP+D2U" "" _sip._udp.unsupported-type.example.com.',
+                    },
                   ],
                 },
               },
@@ -57,7 +60,7 @@ describe("Route53 ChangeResourceRecordSetsCommand errors", () => {
     // Then validation reaches ResourceRecordSet conversion and rejects the type.
     assertIdentical(
       error.message,
-      "Unsupported ChangeResourceRecordSetsCommand.ResourceRecordSet.Type MX",
+      "Unsupported ChangeResourceRecordSetsCommand.ResourceRecordSet.Type NAPTR",
     );
     assertStringIncludes(
       error.message,

--- a/src/service/route53/dns/answer/dns-answerer-test-query.ts
+++ b/src/service/route53/dns/answer/dns-answerer-test-query.ts
@@ -1,6 +1,9 @@
 import type { SimAws } from "../../../aws/sim-aws.js";
-import type { SimRoute53RecordType } from "../../record/sim-route53-record.js";
-import { dnsInternetClass, dnsRecordTypeNumber } from "../dns-record-type.js";
+import {
+  dnsInternetClass,
+  dnsRecordTypeNumber,
+  type SimRoute53DnsRecordType,
+} from "../dns-record-type.js";
 import type { DnsQuestion } from "../wire/dns-question.js";
 import { SimRoute53DnsAnswerer } from "./sim-route53-dns-answerer.js";
 
@@ -16,12 +19,15 @@ export function testAnswerer(simAws: SimAws): SimRoute53DnsAnswerer {
 }
 
 /**
- * Build a question for a name and record type.
+ * Build a question for a name and a record type simulated DNS answers.
+ *
+ * A question about a stored type with no wire number here, such as `MX`, is
+ * built by naming the number, as a real resolver's query carries it.
  * @internal
  */
 export function testQuestion(
   name: string,
-  type: SimRoute53RecordType,
+  type: SimRoute53DnsRecordType,
 ): DnsQuestion {
   return {
     name,

--- a/src/service/route53/dns/answer/sim-route53-dns-negative.iso.test.ts
+++ b/src/service/route53/dns/answer/sim-route53-dns-negative.iso.test.ts
@@ -2,9 +2,21 @@ import { assertArrayLength, assertIdentical } from "@kensio/smartass";
 import { describe, it } from "vitest";
 import { SimAws } from "../../../aws/sim-aws.js";
 import { dnsRcodes } from "../dns-rcode.js";
-import { dnsAnyQueryType, dnsRecordTypeNumber } from "../dns-record-type.js";
+import {
+  dnsAnyQueryType,
+  dnsInternetClass,
+  dnsRecordTypeNumber,
+} from "../dns-record-type.js";
 import { testAnswerer, testQuestion } from "./dns-answerer-test-query.js";
 import { createTestZone } from "./dns-answerer-test-zone.js";
+
+/**
+ * The MX wire type number, which the codec has no encoder for and so does not
+ * name.
+ *
+ * https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml
+ */
+const mxQueryType = 15;
 
 describe("Simulated Route53 DNS negative answers", () => {
   it("reports no data for a name holding no record of the queried type", async () => {
@@ -101,6 +113,34 @@ describe("Simulated Route53 DNS negative answers", () => {
     assertIdentical(answer.rcode, dnsRcodes.noError);
     assertArrayLength(answer.answers, 0);
     assertArrayLength(answer.authority, 1);
+  });
+
+  it("reports no data for a stored record type it does not answer, such as MX", async () => {
+    // Given a zone holding an MX record, which the simulator stores for a test
+    // to assert on rather than for a resolver to act on.
+    const simAws = new SimAws();
+    await createTestZone(simAws, "example.test", [
+      {
+        name: "example.test",
+        type: "MX",
+        values: ["10 in1-smtp.messagingengine.com."],
+      },
+    ]);
+
+    // When the name is queried for MX.
+    const answer = testAnswerer(simAws).answer({
+      name: "example.test",
+      type: mxQueryType,
+      class: dnsInternetClass,
+    });
+
+    // Then the record is left out of the answer rather than encoded, and the
+    // query is answered as no data, with the zone SOA a resolver caches that
+    // against.
+    assertIdentical(answer.rcode, dnsRcodes.noError);
+    assertArrayLength(answer.answers, 0);
+    assertArrayLength(answer.authority, 1);
+    assertIdentical(answer.authority[0].type, dnsRecordTypeNumber("SOA"));
   });
 
   it("stops a CNAME cycle instead of following it forever", async () => {

--- a/src/service/route53/dns/answer/sim-route53-dns-record-answer.ts
+++ b/src/service/route53/dns/answer/sim-route53-dns-record-answer.ts
@@ -1,5 +1,9 @@
 import type { SimRoute53Record } from "../../record/sim-route53-record.js";
-import { dnsInternetClass, dnsRecordTypeNumber } from "../dns-record-type.js";
+import {
+  dnsInternetClass,
+  dnsRecordTypeNumber,
+  isSimRoute53DnsRecordType,
+} from "../dns-record-type.js";
 import { encodeDnsRdata } from "../rdata/dns-rdata.js";
 import type { DnsResourceRecord } from "../wire/dns-resource-record.js";
 
@@ -20,11 +24,19 @@ const defaultRecordTtl = 60;
 export function simRoute53DnsAnswerRecords(
   record: SimRoute53Record,
 ): readonly DnsResourceRecord[] {
+  const recordType = record.type;
+
+  /* v8 ignore if -- a query only reaches records of a type it asked for by
+     wire number, and only answered types have one */
+  if (!isSimRoute53DnsRecordType(recordType)) {
+    return [];
+  }
+
   return record.values.map((value) => ({
     name: record.name,
-    type: dnsRecordTypeNumber(record.type),
+    type: dnsRecordTypeNumber(recordType),
     class: dnsInternetClass,
     ttl: record.ttl ?? defaultRecordTtl,
-    rdata: encodeDnsRdata(record.type, value),
+    rdata: encodeDnsRdata(recordType, value),
   }));
 }

--- a/src/service/route53/dns/dns-codec.loc.test.ts
+++ b/src/service/route53/dns/dns-codec.loc.test.ts
@@ -7,20 +7,20 @@ import {
   assertThrowsErrorAsync,
 } from "@kensio/smartass";
 import { afterAll, beforeAll, describe, it } from "vitest";
-import type { SimRoute53RecordType } from "../record/sim-route53-record.js";
 import { decodeDnsQuery } from "./dns-query.js";
 import { dnsRcodes } from "./dns-rcode.js";
 import {
   dnsInternetClass,
   dnsRecordTypeNumber,
   simRoute53RecordTypeFromNumber,
+  type SimRoute53DnsRecordType,
 } from "./dns-record-type.js";
 import { encodeDnsResponse } from "./dns-response.js";
 import { encodeDnsRdata } from "./rdata/dns-rdata.js";
 
 interface FixtureRecord {
   readonly name: string;
-  readonly type: SimRoute53RecordType;
+  readonly type: SimRoute53DnsRecordType;
   readonly value: string;
 }
 

--- a/src/service/route53/dns/dns-record-type.ts
+++ b/src/service/route53/dns/dns-record-type.ts
@@ -1,11 +1,26 @@
 import type { SimRoute53RecordType } from "../record/sim-route53-record.js";
 
 /**
- * DNS resource record type numbers, limited to the types sim Route53 stores.
+ * The stored record types simulated DNS answers queries for.
+ *
+ * Sim Route53 stores more types than this. `MX`, `SRV`, `CAA` and `PTR` are
+ * stored, listed and deployed from a template so a zone can model a real one,
+ * but a browser reaching a simulated site needs an address or a CNAME, and a
+ * mail record is there to be asserted on rather than resolved. Encoding a type
+ * means an RDATA encoder for its wire shape, so the codec carries only the ones
+ * an answer actually uses.
+ */
+export type SimRoute53DnsRecordType = Extract<
+  SimRoute53RecordType,
+  "A" | "AAAA" | "CNAME" | "TXT" | "NS" | "SOA"
+>;
+
+/**
+ * DNS resource record type numbers, limited to the types simulated DNS answers.
  *
  * https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml
  */
-const typeNumbersByRecordType = new Map<SimRoute53RecordType, number>([
+const typeNumbersByRecordType = new Map<SimRoute53DnsRecordType, number>([
   ["A", 1],
   ["NS", 2],
   ["CNAME", 5],
@@ -14,10 +29,14 @@ const typeNumbersByRecordType = new Map<SimRoute53RecordType, number>([
   ["AAAA", 28],
 ]);
 
-const recordTypesByTypeNumber = new Map<number, SimRoute53RecordType>(
+const recordTypesByTypeNumber = new Map<number, SimRoute53DnsRecordType>(
   typeNumbersByRecordType
     .entries()
     .map(([recordType, typeNumber]) => [typeNumber, recordType]),
+);
+
+const dnsRecordTypes: ReadonlySet<string> = new Set(
+  typeNumbersByRecordType.keys(),
 );
 
 /**
@@ -32,12 +51,23 @@ export const dnsAnyQueryType = 255;
 export const dnsInternetClass = 1;
 
 /**
- * Get the wire type number for a sim Route53 record type.
+ * Check whether a stored record type is one simulated DNS answers queries for.
  */
-export function dnsRecordTypeNumber(recordType: SimRoute53RecordType): number {
+export function isSimRoute53DnsRecordType(
+  recordType: SimRoute53RecordType,
+): recordType is SimRoute53DnsRecordType {
+  return dnsRecordTypes.has(recordType);
+}
+
+/**
+ * Get the wire type number for a record type simulated DNS answers.
+ */
+export function dnsRecordTypeNumber(
+  recordType: SimRoute53DnsRecordType,
+): number {
   const typeNumber = typeNumbersByRecordType.get(recordType);
 
-  /* v8 ignore if -- the map covers every sim Route53 record type */
+  /* v8 ignore if -- the map covers every type simulated DNS answers */
   if (typeNumber === undefined) {
     throw new Error(`No DNS type number for record type ${recordType}`);
   }
@@ -46,14 +76,16 @@ export function dnsRecordTypeNumber(recordType: SimRoute53RecordType): number {
 }
 
 /**
- * Get the sim Route53 record type for a wire type number, if it is one the
- * simulator stores.
+ * Get the record type for a wire type number, if it is one simulated DNS
+ * answers queries for.
  *
- * Unknown and unsupported query types resolve to `undefined` so the caller can
- * answer with no records rather than guessing at a type it cannot encode.
+ * Unknown and unanswered query types resolve to `undefined` so the caller can
+ * answer with no records rather than guessing at a type it cannot encode. A
+ * stored type the codec has no RDATA encoder for, such as `MX`, arrives here as
+ * a number it does not know and is treated the same way.
  */
 export function simRoute53RecordTypeFromNumber(
   typeNumber: number,
-): SimRoute53RecordType | undefined {
+): SimRoute53DnsRecordType | undefined {
   return recordTypesByTypeNumber.get(typeNumber);
 }

--- a/src/service/route53/dns/rdata/dns-rdata.ts
+++ b/src/service/route53/dns/rdata/dns-rdata.ts
@@ -1,4 +1,4 @@
-import type { SimRoute53RecordType } from "../../record/sim-route53-record.js";
+import type { SimRoute53DnsRecordType } from "../dns-record-type.js";
 import { encodeDnsName } from "../wire/dns-name.js";
 import { encodeDnsAaaaRdata, encodeDnsARdata } from "./dns-address-rdata.js";
 import { encodeDnsSoaRdata } from "./dns-soa-rdata.js";
@@ -11,7 +11,7 @@ import { encodeDnsTxtRdata } from "./dns-text-rdata.js";
  * name encoder rather than having wrappers of their own.
  */
 export function encodeDnsRdata(
-  recordType: SimRoute53RecordType,
+  recordType: SimRoute53DnsRecordType,
   value: string,
 ): Uint8Array {
   switch (recordType) {

--- a/src/service/route53/hosted-zone/sim-route53-hosted-zone-records.ts
+++ b/src/service/route53/hosted-zone/sim-route53-hosted-zone-records.ts
@@ -3,6 +3,7 @@ import type {
   SimRoute53Record,
   SimRoute53RecordType,
 } from "../record/sim-route53-record.js";
+import { normaliseSimRoute53RecordValue } from "../record/sim-route53-record-value.js";
 
 export type SimRoute53RecordChangeListener = () => void;
 
@@ -128,18 +129,11 @@ function normaliseRecord(record: SimRoute53Record): SimRoute53Record {
     ...record,
     name: normaliseSimRoute53Name(record.name),
     values: record.values.map((value) =>
-      normaliseRecordValue(record.type, value),
+      normaliseSimRoute53RecordValue(record.type, value),
     ),
   };
 }
 
 function recordKey(name: string, type: SimRoute53RecordType): string {
   return `${type}:${name}`;
-}
-
-function normaliseRecordValue(
-  type: SimRoute53RecordType,
-  value: string,
-): string {
-  return type === "TXT" ? value : normaliseSimRoute53Name(value);
 }

--- a/src/service/route53/record/sim-route53-record-type.iso.test.ts
+++ b/src/service/route53/record/sim-route53-record-type.iso.test.ts
@@ -1,0 +1,113 @@
+import { assertArrayLength, assertObjectMatches } from "@kensio/smartass";
+import {
+  ChangeResourceRecordSetsCommand,
+  CreateHostedZoneCommand,
+  ListResourceRecordSetsCommand,
+  type ResourceRecordSet,
+} from "@aws-sdk/client-route-53";
+import { describe, it } from "vitest";
+import { SimAws } from "../../aws/sim-aws.js";
+import { assertIsSimRoute53HostedZoneId } from "../command/create-hosted-zone/sim-route53-zone-id.js";
+
+interface ZoneRecord {
+  readonly type: string;
+  readonly zoneName: string;
+  readonly recordSet: ResourceRecordSet;
+}
+
+/**
+ * Records a zone modelling a real one carries, each holding a value in the
+ * shape the record really takes: a preference and a mail host, a service
+ * priority, weight, port and target, a CAA flag, tag and value, and a name.
+ */
+const zoneRecords: readonly ZoneRecord[] = [
+  {
+    type: "MX",
+    zoneName: "example.test",
+    recordSet: {
+      Name: "example.test",
+      Type: "MX",
+      TTL: 3600,
+      ResourceRecords: [
+        { Value: "10 in1-smtp.messagingengine.com." },
+        { Value: "20 in2-smtp.messagingengine.com." },
+      ],
+    },
+  },
+  {
+    type: "SRV",
+    zoneName: "example.test",
+    recordSet: {
+      Name: "_sip._tcp.example.test",
+      Type: "SRV",
+      TTL: 300,
+      ResourceRecords: [{ Value: "10 60 5060 sipserver.Example.test." }],
+    },
+  },
+  {
+    type: "CAA",
+    zoneName: "example.test",
+    recordSet: {
+      Name: "example.test",
+      Type: "CAA",
+      TTL: 300,
+      ResourceRecords: [{ Value: '0 issue "letsencrypt.org"' }],
+    },
+  },
+  {
+    type: "PTR",
+    zoneName: "2.0.192.in-addr.arpa",
+    recordSet: {
+      Name: "1.2.0.192.in-addr.arpa",
+      Type: "PTR",
+      TTL: 300,
+      ResourceRecords: [{ Value: "www.Example.test." }],
+    },
+  },
+];
+
+describe("Simulated Route53 record types", () => {
+  it.each(zoneRecords)(
+    "round-trips a $type record through change and list",
+    async ({ type, zoneName, recordSet }) => {
+      // Given a Hosted Zone holding a record of the type.
+      const simAws = new SimAws();
+      const simRoute53 = simAws.route53();
+
+      const hostedZoneCreation = await simRoute53.createHostedZone(
+        new CreateHostedZoneCommand({
+          Name: zoneName,
+          CallerReference: `${type}-record-type-test`,
+        }),
+      );
+      const hostedZoneId = hostedZoneCreation.HostedZone?.Id;
+      assertIsSimRoute53HostedZoneId(hostedZoneId);
+
+      await simRoute53.changeResourceRecordSets(
+        new ChangeResourceRecordSetsCommand({
+          HostedZoneId: hostedZoneId,
+          ChangeBatch: {
+            Changes: [{ Action: "CREATE", ResourceRecordSet: recordSet }],
+          },
+        }),
+      );
+      await simAws.backgroundTasksComplete();
+
+      // When the Hosted Zone's records are listed.
+      const listOutput = await simRoute53.listResourceRecordSets(
+        new ListResourceRecordSetsCommand({ HostedZoneId: hostedZoneId }),
+      );
+
+      // Then the record comes back holding the values it was given, each stored
+      // as written rather than taken apart into the parts of the record or
+      // folded to a DNS name.
+      assertArrayLength(listOutput.ResourceRecordSets, 1);
+      assertObjectMatches(listOutput.ResourceRecordSets[0], {
+        Name: `${recordSet.Name ?? ""}.`,
+        Type: recordSet.Type,
+        TTL: recordSet.TTL,
+        ResourceRecords: recordSet.ResourceRecords,
+      });
+    },
+  );
+});

--- a/src/service/route53/record/sim-route53-record-type.ts
+++ b/src/service/route53/record/sim-route53-record-type.ts
@@ -1,4 +1,9 @@
-import type { SimRoute53RecordType } from "./sim-route53-record.js";
+import {
+  simRoute53RecordTypes,
+  type SimRoute53RecordType,
+} from "./sim-route53-record.js";
+
+const recordTypes: ReadonlySet<string> = new Set(simRoute53RecordTypes);
 
 /**
  * Check whether a value is a sim Route53 record type.
@@ -6,8 +11,5 @@ import type { SimRoute53RecordType } from "./sim-route53-record.js";
 export function isSimRoute53RecordType(
   value: unknown,
 ): value is SimRoute53RecordType {
-  return (
-    typeof value === "string" &&
-    ["A", "AAAA", "CNAME", "TXT", "NS", "SOA"].includes(value)
-  );
+  return typeof value === "string" && recordTypes.has(value);
 }

--- a/src/service/route53/record/sim-route53-record-value.ts
+++ b/src/service/route53/record/sim-route53-record-value.ts
@@ -1,0 +1,31 @@
+import { normaliseSimRoute53Name } from "../local-name/sim-route53-local-name.js";
+import type { SimRoute53RecordType } from "./sim-route53-record.js";
+
+/**
+ * Record types whose values are stored exactly as they were given.
+ *
+ * A `TXT` value is arbitrary text. The rest hold a structured string — a
+ * preference and a host, a priority, weight, port and target, a CAA flag, tag
+ * and value — that nothing in the simulator resolves against, so it is kept as
+ * written rather than being taken apart or folded to a DNS name.
+ */
+const verbatimValueTypes: ReadonlySet<SimRoute53RecordType> = new Set([
+  "CAA",
+  "MX",
+  "PTR",
+  "SRV",
+  "TXT",
+]);
+
+/**
+ * Normalise one stored record value for its record type.
+ *
+ * Values that are hostnames or addresses need consistent comparison, so they go
+ * through DNS name normalisation. The rest are kept verbatim.
+ */
+export function normaliseSimRoute53RecordValue(
+  type: SimRoute53RecordType,
+  value: string,
+): string {
+  return verbatimValueTypes.has(type) ? value : normaliseSimRoute53Name(value);
+}

--- a/src/service/route53/record/sim-route53-record.ts
+++ b/src/service/route53/record/sim-route53-record.ts
@@ -1,5 +1,30 @@
-export type SimRoute53RecordType =
-  "A" | "AAAA" | "CNAME" | "TXT" | "NS" | "SOA";
+/**
+ * Every record type a simulated Hosted Zone stores.
+ *
+ * The list is wider than the types simulated DNS answers queries for. A zone
+ * modelling a real one carries mail and certificate records, and those are there
+ * for a test to assert the presence and value of rather than for a resolver to
+ * act on, so storing them costs nothing beyond this list. See
+ * `SimRoute53DnsRecordType` for the narrower set the DNS server encodes.
+ */
+export const simRoute53RecordTypes = [
+  "A",
+  "AAAA",
+  "CAA",
+  "CNAME",
+  "MX",
+  "NS",
+  "PTR",
+  "SOA",
+  "SRV",
+  "TXT",
+] as const;
+
+/**
+ * A record type a simulated Hosted Zone stores, derived from the list so the
+ * two cannot drift apart.
+ */
+export type SimRoute53RecordType = (typeof simRoute53RecordTypes)[number];
 
 export interface SimRoute53Record {
   readonly name: string;


### PR DESCRIPTION
Simulated Route53 modelled six record types: `A`, `AAAA`, `CNAME`, `TXT`, `NS` and `SOA`. A zone
that models a real one carries more than that — mail records pointing at a provider, a `CAA` record
pinning a certificate authority, a `SRV` record for a service — and none of those could be created,
through the SDK or through `AWS::Route53::RecordSet`, so a stack holding one had to have the record
edited out before it would deploy into a simulation.

`MX`, `SRV`, `CAA` and `PTR` are now stored. Each round-trips through `ChangeResourceRecordSets` and
`ListResourceRecordSets`, and deploys from `AWS::Route53::RecordSet`.

## Values are stored as written

Those four join `TXT` in `normaliseSimRoute53RecordValue`, which leaves a value alone rather than
folding it to a DNS name. Nothing takes an `MX` preference number or an `SRV` priority apart, so a
test asserts on the string its stack declared, trailing dot and letter case included. The remaining
types hold a hostname or an address, which still needs consistent comparison, so those are
normalised as before.

## Simulated DNS is unchanged

DNS still answers queries for `A`, `AAAA`, `CNAME`, `TXT`, `NS` and `SOA` only. That is what a
browser reaching a simulated site needs; a mail record is there to be asserted on, not resolved,
and encoding a type means writing an RDATA encoder for its wire shape.

That subset is now its own type, `SimRoute53DnsRecordType`, which `dnsRecordTypeNumber` and
`encodeDnsRdata` take. Narrowing rather than widening the type-number map is what keeps the encoders
exhaustive: adding a stored type cannot silently leave `encodeDnsRdata` with a case it has no
encoder for. A query for `MX` arrives as a wire number the map does not hold and is answered as no
data with the zone `SOA`, the same as any query type the simulator does not recognise.

## Also

- `SimRoute53RecordType` is derived from `simRoute53RecordTypes`, so the guard cannot drift from the
  union the way the previous literal array could.
- `SimCfnRoute53RecordSetBuilder.type()` still throws for a type outside the list — #437 changes
  that to a skip and is queued to follow.

Resolves #436