### PR TITLE
feat: transform a template file as it is read

### DIFF
--- a/docs/serve/README.md
+++ b/docs/serve/README.md
@@ -257,6 +257,43 @@ list rather than restarting for it. See
 [watching a template file](../services/cloudformation/README.md#watching-a-template-file) for what
 an update does to the resources.
 
+A template synthesized against a real account sometimes needs adapting before Yulin will take it.
+`transform` is given the parsed template and answers with the one to deploy, on the deployment and
+again on every change, so the file the supervisor leaves alone is still the one in `cdk.out`:
+
+```typescript sim-serve-transform-template
+/**
+ * Adapting a watched template, so the file being watched is the real one.
+ */
+
+import { SimAws } from "@kensio/yulin";
+import { serveSimAws } from "@kensio/yulin/serve";
+
+const simAws = new SimAws();
+const srv = await serveSimAws({ simAws, port: 8787, liveReload: true });
+
+await simAws.cloudFormation().deployTemplateFile({
+  templatePath: "cdk.out/TestStack.template.json",
+  transform: (template) => ({
+    ...template,
+    Resources: Object.fromEntries(
+      Object.entries(template.Resources).filter(
+        ([logicalId]) => logicalId !== "SiteAliasRecord",
+      ),
+    ),
+  }),
+  watch: {
+    onUpdated: () => {
+      srv.reload();
+    },
+  },
+});
+```
+
+A transform that throws is reported the way a failed update is, so the process and the resources it
+is serving are left where they were. See
+[adapting a synthesized template](../services/cloudformation/README.md#adapting-a-synthesized-template-on-the-way-in).
+
 This works with no supervisor at all, so a dev script started from an IDE debugger picks up a
 re-synth with the debugger attached throughout.
 

--- a/docs/serve/sim-serve-transform-template.example.ts
+++ b/docs/serve/sim-serve-transform-template.example.ts
@@ -1,0 +1,26 @@
+/**
+ * Adapting a watched template, so the file being watched is the real one.
+ */
+
+import { SimAws } from "@kensio/yulin";
+import { serveSimAws } from "@kensio/yulin/serve";
+
+const simAws = new SimAws();
+const srv = await serveSimAws({ simAws, port: 8787, liveReload: true });
+
+await simAws.cloudFormation().deployTemplateFile({
+  templatePath: "cdk.out/TestStack.template.json",
+  transform: (template) => ({
+    ...template,
+    Resources: Object.fromEntries(
+      Object.entries(template.Resources).filter(
+        ([logicalId]) => logicalId !== "SiteAliasRecord",
+      ),
+    ),
+  }),
+  watch: {
+    onUpdated: () => {
+      srv.reload();
+    },
+  },
+});

--- a/docs/services/cloudformation/README.md
+++ b/docs/services/cloudformation/README.md
@@ -1049,6 +1049,63 @@ sibling `TestStack.assets.json` manifest and the staged asset directories beside
 anything that needs a CDK asset, such as a `Custom::CDKBucketDeployment` or a Lambda function
 bundled with `Code.fromAsset`, fails with `No CDK assets manifest is available.`
 
+## Adapting a synthesized template on the way in
+
+Editing the parsed object works for a template you deploy once. A template you keep reading, because
+it is [watched](#watching-a-template-file) or applied again as an update, needs the same change made
+every time it is read. `transform` is that: it is given the parsed template and answers with the one
+to deploy, on the deployment and again on every change:
+
+```typescript sim-cloudformation-transform-template-file
+/**
+ * Adapting a synthesized template every time it is read.
+ */
+
+import { SimAws } from "@kensio/yulin";
+import type { CfnTemplateBodyRecord } from "@kensio/yulin/cloudformation";
+
+const simAws = new SimAws();
+
+/**
+ * Drop the records pointing at a hosted zone that only exists in the real
+ * account.
+ */
+function withoutDnsRecords(
+  template: CfnTemplateBodyRecord,
+): CfnTemplateBodyRecord {
+  const resources = Object.fromEntries(
+    Object.entries(template.Resources).filter(
+      ([, resource]) =>
+        (resource as { Type?: string }).Type !== "AWS::Route53::RecordSet",
+    ),
+  );
+
+  return { ...template, Resources: resources };
+}
+
+await simAws.cloudFormation().deployTemplateFile({
+  templatePath: "cdk.out/TestStack.template.json",
+  transform: withoutDnsRecords,
+  watch: true,
+});
+```
+
+This is for what a simulation cannot resolve at all, such as an ARN carrying a real account or a
+hosted zone ID that came from `HostedZone.fromLookup`. A property Yulin does not model is usually not
+one you need this for: S3, DynamoDB, Cognito, API Gateway v2, SQS and KMS
+[record it and carry on](#properties-a-resource-was-created-without).
+
+The template file is still the real one, so there is no derived `.local.template.json` in `cdk.out`
+to keep in step with it. Staged assets resolve as they always did, from the assets manifest beside
+`templatePath`, since the cloud assembly is found by path rather than read out of the template.
+
+`updateTemplateFile(...)` takes it too, for a consumer driving updates itself. Give it the same
+deployment object, so the difference applied is the difference in the file.
+
+A transform that throws fails the deployment, with what it threw as the cause. On a watched change it
+is reported the way a failed update is: the stack keeps the resources it had, and the watch carries
+on to the next save.
+
 ## Applying a changed template file
 
 `updateTemplateFile(...)` reads a deployed template file again and applies it to its stack, the same
@@ -1131,6 +1188,10 @@ none.
 
 A burst of writes is one update. Saving a file is several filesystem events, so changes are held
 until they stop arriving. `settleMs` is how long that wait is.
+
+[`transform`](#adapting-a-synthesized-template-on-the-way-in) runs again on every change, so a
+template that needs adapting before Yulin will take it can still be watched as the file synthesis
+writes.
 
 Watching holds a filesystem handle open, so the process does not exit on its own. That is what a dev
 process wants. Anything with an end, such as a test, calls `stopWatchingTemplateFiles()` when it is

--- a/docs/services/cloudformation/sim-cloudformation-transform-template-file.example.ts
+++ b/docs/services/cloudformation/sim-cloudformation-transform-template-file.example.ts
@@ -1,0 +1,31 @@
+/**
+ * Adapting a synthesized template every time it is read.
+ */
+
+import { SimAws } from "@kensio/yulin";
+import type { CfnTemplateBodyRecord } from "@kensio/yulin/cloudformation";
+
+const simAws = new SimAws();
+
+/**
+ * Drop the records pointing at a hosted zone that only exists in the real
+ * account.
+ */
+function withoutDnsRecords(
+  template: CfnTemplateBodyRecord,
+): CfnTemplateBodyRecord {
+  const resources = Object.fromEntries(
+    Object.entries(template.Resources).filter(
+      ([, resource]) =>
+        (resource as { Type?: string }).Type !== "AWS::Route53::RecordSet",
+    ),
+  );
+
+  return { ...template, Resources: resources };
+}
+
+await simAws.cloudFormation().deployTemplateFile({
+  templatePath: "cdk.out/TestStack.template.json",
+  transform: withoutDnsRecords,
+  watch: true,
+});

--- a/src/service/cloudformation/deploy/sim-cfn-template-file-loader.iso.test.ts
+++ b/src/service/cloudformation/deploy/sim-cfn-template-file-loader.iso.test.ts
@@ -1,7 +1,10 @@
 import path from "node:path";
 import {
+  assertArrayEquals,
   assertIdentical,
   assertObjectMatches,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
   assertUndefined,
 } from "@kensio/smartass";
 import { describe, it } from "vitest";
@@ -162,6 +165,82 @@ describe("SimCfnTemplateFileLoader", () => {
         },
       },
     });
+  });
+
+  it("loads the template a transform returned, with the assets manifest beside the file", async () => {
+    // Given a synthesized template naming a Hosted Zone the simulation cannot
+    // look up, and its sibling CDK assets manifest.
+    const temporaryDirectory = new TemporaryDirectory();
+    const templatePath = "SiteStack.template.json";
+
+    await temporaryDirectory.writeFile(
+      templatePath,
+      jsonStringify({
+        Resources: {
+          SiteRecord: {
+            Type: "AWS::Route53::RecordSet",
+            Properties: { HostedZoneId: "Z0123456789ABCDEFGHIJ" },
+          },
+        },
+      }),
+    );
+    await temporaryDirectory.writeFile(
+      "SiteStack.assets.json",
+      jsonStringify({ files: {} }),
+    );
+
+    // When it is loaded through a transform that drops the record.
+    const fileLoader = new SimCfnTemplateFileLoader();
+    const loadedTemplate = await fileLoader.load({
+      templatePath: temporaryDirectory.join(templatePath),
+      transform: (template) => ({ ...template, Resources: {} }),
+    });
+
+    // Then the template to deploy is the one the transform returned.
+    assertArrayEquals(Object.keys(loadedTemplate.template.Resources), []);
+
+    // And the cloud assembly is still the one the file came from, since it is
+    // found beside the path rather than read out of the template.
+    assertObjectMatches(loadedTemplate.cdkOutContext, {
+      templateDirectoryPath: temporaryDirectory.path(),
+      assetsManifest: { files: {} },
+    });
+  });
+
+  it("says a transform threw rather than letting it read as a bad template", async () => {
+    // Given a template file and a transform that fails on it.
+    const temporaryDirectory = new TemporaryDirectory();
+    const templatePath = "SiteStack.template.json";
+
+    await temporaryDirectory.writeFile(
+      templatePath,
+      jsonStringify({ Resources: {} }),
+    );
+
+    // When the template file is loaded through it.
+    const fileLoader = new SimCfnTemplateFileLoader();
+    const error = await assertThrowsErrorAsync(async () => {
+      await fileLoader.load({
+        templatePath: temporaryDirectory.join(templatePath),
+        transform: () => {
+          throw new Error("no Hosted Zone ID for the review environment");
+        },
+      });
+    });
+
+    // Then loading fails, saying what threw and keeping the reason it gave.
+    assertStringIncludes(
+      error.message,
+      "Sim CloudFormation template transform",
+    );
+    assertStringIncludes(
+      error.message,
+      "no Hosted Zone ID for the review environment",
+    );
+    assertIdentical(
+      (error.cause as Error).message,
+      "no Hosted Zone ID for the review environment",
+    );
   });
 
   it("loads a non-CDK template filename without requiring an assets manifest", async () => {

--- a/src/service/cloudformation/deploy/sim-cfn-template-file-loader.ts
+++ b/src/service/cloudformation/deploy/sim-cfn-template-file-loader.ts
@@ -10,12 +10,35 @@ import {
 import type { SimCfnExecutableResourceBinding } from "../bind/sim-cfn-exec-binding.type.js";
 import { simWatch } from "../../../watch/sim-watch-runtime.js";
 import type { SimCfnTemplateFileWatchOptions } from "../watch/sim-cfn-template-watch.type.js";
+import { simCfnTemplateFileDeployment } from "./sim-cfn-template-file-deployment.js";
+import {
+  transformedTemplate,
+  type SimCfnTemplateFileTransform,
+} from "./sim-cfn-template-file-transform.js";
 
 export interface SimCloudFormationDeployTemplateFileProperties {
   readonly templatePath: string;
   readonly stackName?: SimCloudFormationStackName | string | undefined;
   readonly parameters?: Record<string, string> | undefined;
   readonly bindings?: readonly SimCfnExecutableResourceBinding[] | undefined;
+
+  /**
+   * Adapt the parsed template before it is deployed, and again every time a
+   * watched file changes.
+   *
+   * A synthesized template can carry something a simulation cannot resolve at
+   * all, such as an ARN holding a real account or a Hosted Zone ID that came
+   * from a lookup. This is where that gets rewritten, so the template being
+   * deployed and watched is the one the cloud assembly holds rather than a
+   * derived copy of it living somewhere on disk.
+   *
+   * What it returns is what gets deployed. Staged assets still resolve, since
+   * the cloud assembly is found beside `templatePath` rather than read out of
+   * the template. A transform that throws fails the deployment, and on a
+   * watched change is reported the way a failed update is, leaving the watch
+   * to carry on to the next save.
+   */
+  readonly transform?: SimCfnTemplateFileTransform | undefined;
 
   /**
    * Keep watching the template file, and apply it to the Stack again whenever
@@ -49,16 +72,10 @@ export class SimCfnTemplateFileLoader {
   async load(
     properties: SimCloudFormationDeployTemplateFileProperties | string,
   ): Promise<SimCfnLoadedTemplateFile> {
-    const templatePath =
-      typeof properties === "string" ? properties : properties.templatePath;
-    const parameters =
-      typeof properties === "string" ? undefined : properties.parameters;
-    const bindings =
-      typeof properties === "string" ? undefined : properties.bindings;
+    const deployment = simCfnTemplateFileDeployment(properties);
+    const { templatePath, parameters, bindings } = deployment;
     const stackName =
-      typeof properties === "string"
-        ? stackNameFromTemplatePath(templatePath)
-        : (properties.stackName ?? stackNameFromTemplatePath(templatePath));
+      deployment.stackName ?? stackNameFromTemplatePath(templatePath);
 
     // The template is named to a `yulin watch` supervisor, so re-synthing a
     // stack restarts the process that deployed it. Nothing happens outside
@@ -67,9 +84,12 @@ export class SimCfnTemplateFileLoader {
 
     // eslint-disable-next-line security/detect-non-literal-fs-filename
     const templateBody = await readFile(templatePath, "utf8");
-    const template = jsonParse(
-      templateBody as JSONString<CfnTemplateBodyRecord>,
+    const template = transformedTemplate(
+      jsonParse(templateBody as JSONString<CfnTemplateBodyRecord>),
+      deployment.transform,
     );
+    // Read from the path rather than the template, so what a transform did to
+    // the body leaves the staged assets beside it where they were.
     const cdkOutContext = await loadSiblingCdkAssetsManifest(templatePath);
 
     return {

--- a/src/service/cloudformation/deploy/sim-cfn-template-file-transform.ts
+++ b/src/service/cloudformation/deploy/sim-cfn-template-file-transform.ts
@@ -1,0 +1,41 @@
+import type { CfnTemplateBodyRecord } from "../template/sim-cfn-template.js";
+
+/**
+ * Adapts a parsed template file into the template to deploy.
+ *
+ * Given the body as it was synthesized, and answering with the body simulated
+ * AWS should be holding, so the file on disk stays the real one.
+ */
+export type SimCfnTemplateFileTransform = (
+  template: CfnTemplateBodyRecord,
+) => CfnTemplateBodyRecord;
+
+/**
+ * Adapt the parsed template, if the deployment brought something to adapt it
+ * with.
+ *
+ * A transform that throws is said to have thrown, because the file it was given
+ * is the synthesized one and the reason it could not be deployed is not in
+ * there. On a watched change this reads as the failed update it is.
+ */
+export function transformedTemplate(
+  template: CfnTemplateBodyRecord,
+  transform: SimCfnTemplateFileTransform | undefined,
+): CfnTemplateBodyRecord {
+  if (transform === undefined) {
+    return template;
+  }
+
+  try {
+    return transform(template);
+  } catch (error) {
+    throw new Error(
+      `Sim CloudFormation template transform threw: ${transformFailure(error)}`,
+      { cause: error },
+    );
+  }
+}
+
+function transformFailure(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/src/service/cloudformation/deploy/sim-cfn-template-transform.iso.test.ts
+++ b/src/service/cloudformation/deploy/sim-cfn-template-transform.iso.test.ts
@@ -1,0 +1,147 @@
+import { buffer } from "node:stream/consumers";
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../aws/sim-aws.js";
+import { TemporaryDirectory } from "../../../util/filesystem/temporary-directory.js";
+import { jsonStringify } from "../../../util/type-guard/json.js";
+import {
+  accountScopedName,
+  accountScopedTemplate,
+  withoutSynthesizedAccount,
+} from "../../../../test/cloudformation/account-scoped-template.js";
+
+describe("deploying a template file through a transform", () => {
+  it("deploys what the transform returned rather than what the file holds", async () => {
+    // Given a synthesized template naming Buckets the real account owns
+    const directory = new TemporaryDirectory();
+    await directory.writeFile(
+      "Site.template.json",
+      jsonStringify(accountScopedTemplate()),
+    );
+
+    // When it is deployed through a transform that takes the account off it
+    const simAws = new SimAws();
+    await simAws.cloudFormation().deployTemplateFile({
+      templatePath: directory.join("Site.template.json"),
+      transform: withoutSynthesizedAccount,
+    });
+
+    // Then the Bucket the transform asked for is the one simulated S3 holds
+    assertNonNullable(simAws.s3().getSimBucketByName("site-content"));
+    assertUndefined(
+      simAws.s3().getSimBucketByName(accountScopedName("site-content")),
+    );
+  });
+
+  it("resolves the staged assets beside the template it transformed", async () => {
+    // Given a cloud assembly with a staged asset in it
+    const directory = new TemporaryDirectory();
+    await directory.writeFile("asset.page.txt", "hello");
+    await directory.writeFile(
+      "Site.assets.json",
+      jsonStringify(stagedAsset("asset.page.txt", "page.txt")),
+    );
+    await directory.writeFile(
+      "Site.template.json",
+      jsonStringify(accountScopedTemplate()),
+    );
+
+    // When its template is deployed through a transform
+    const simAws = new SimAws();
+    await simAws.cloudFormation().deployTemplateFile({
+      templatePath: directory.join("Site.template.json"),
+      transform: withoutSynthesizedAccount,
+    });
+
+    // Then the asset synthesis staged is published, since the cloud assembly
+    // is found beside the path rather than read out of the template
+    const output = await simAws
+      .s3()
+      .getObject({ input: { Bucket: "cdk-staging", Key: "page.txt" } });
+    assertNonNullable(output.Body);
+    const bytes = await buffer(output.Body);
+    assertIdentical(bytes.toString("utf8"), "hello");
+  });
+
+  it("fails the deployment when the transform throws", async () => {
+    // Given a template file whose transform cannot adapt it
+    const directory = new TemporaryDirectory();
+    await directory.writeFile(
+      "Site.template.json",
+      jsonStringify(accountScopedTemplate()),
+    );
+
+    // When it is deployed
+    const simAws = new SimAws();
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.cloudFormation().deployTemplateFile({
+        templatePath: directory.join("Site.template.json"),
+        transform: () => {
+          throw new Error("no Hosted Zone ID for the review environment");
+        },
+      });
+    });
+
+    // Then nothing is deployed, and the reason is the one the transform gave
+    assertStringIncludes(
+      error.message,
+      "no Hosted Zone ID for the review environment",
+    );
+    assertUndefined(
+      simAws.s3().getSimBucketByName(accountScopedName("site-content")),
+    );
+  });
+
+  it("applies the transform again when the file is applied as an update", async () => {
+    // Given a Stack deployed from a template file through a transform
+    const directory = new TemporaryDirectory();
+    await directory.writeFile(
+      "Site.template.json",
+      jsonStringify(accountScopedTemplate()),
+    );
+
+    const simAws = new SimAws();
+    const deployment = {
+      templatePath: directory.join("Site.template.json"),
+      transform: withoutSynthesizedAccount,
+    };
+    await simAws.cloudFormation().deployTemplateFile(deployment);
+
+    // When the stack is synthesized again with another Bucket in it
+    await directory.writeFile(
+      "Site.template.json",
+      jsonStringify(accountScopedTemplate({ withUploads: true })),
+    );
+
+    await simAws.cloudFormation().updateTemplateFile(deployment);
+
+    // Then the update applied the transformed template too, rather than the
+    // names the file on disk still holds
+    assertNonNullable(simAws.s3().getSimBucketByName("site-uploads"));
+    assertUndefined(
+      simAws.s3().getSimBucketByName(accountScopedName("site-uploads")),
+    );
+  });
+});
+
+function stagedAsset(sourcePath: string, objectKey: string): object {
+  return {
+    files: {
+      [objectKey]: {
+        source: { path: sourcePath },
+        destinations: {
+          "current_account-current_region": {
+            bucketName: "cdk-staging",
+            objectKey,
+          },
+        },
+      },
+    },
+  };
+}

--- a/src/service/cloudformation/index.ts
+++ b/src/service/cloudformation/index.ts
@@ -1,2 +1,4 @@
 export { SimCloudFormation } from "./sim-cloudformation.js";
+export type { SimCfnTemplateFileTransform } from "./deploy/sim-cfn-template-file-transform.js";
+export type { CfnTemplateBodyRecord } from "./template/sim-cfn-template.js";
 export type { SimCfnTemplateFileWatchOptions } from "./watch/sim-cfn-template-watch.type.js";

--- a/src/service/cloudformation/watch/sim-cfn-template-transform-watch.loc.test.ts
+++ b/src/service/cloudformation/watch/sim-cfn-template-transform-watch.loc.test.ts
@@ -1,0 +1,107 @@
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import {
+  accountScopedName,
+  accountScopedTemplate,
+  withoutSynthesizedAccount,
+} from "../../../../test/cloudformation/account-scoped-template.js";
+import {
+  putSitePage,
+  sitePage,
+  WatchedTemplate,
+} from "../../../../test/cloudformation/watched-template.js";
+
+describe("a watched template file with a transform", () => {
+  it("transforms the changed file again on every save", async () => {
+    // Given a Stack deployed from a watched template file through a transform
+    // that takes the real account off the names in it
+    const watched = await WatchedTemplate.of(
+      accountScopedTemplate(),
+      {},
+      withoutSynthesizedAccount,
+    );
+    assertNonNullable(watched.simAws.s3().getSimBucketByName("site-content"));
+
+    try {
+      // When the stack is synthesized again with another Bucket in it
+      await watched.write(accountScopedTemplate({ withUploads: true }));
+      await watched.updated();
+
+      // Then the update applied the transformed template, so the file being
+      // watched stays the synthesized one with no derived copy of it on disk
+      assertNonNullable(watched.simAws.s3().getSimBucketByName("site-uploads"));
+      assertUndefined(
+        watched.simAws
+          .s3()
+          .getSimBucketByName(accountScopedName("site-uploads")),
+      );
+    } finally {
+      watched.stop();
+    }
+  });
+
+  it("reports a transform that throws, and goes on watching", async () => {
+    // Given a Stack deployed from a watched template file, holding an Object,
+    // and a transform that fails on anything with an Uploads Bucket in it
+    const watched = await WatchedTemplate.of(
+      accountScopedTemplate(),
+      {},
+      (template) => {
+        if ("Uploads" in template.Resources) {
+          throw new Error("no Hosted Zone ID for the uploads domain");
+        }
+
+        return withoutSynthesizedAccount(template);
+      },
+    );
+    await putSitePage(watched.simAws);
+
+    try {
+      // When a save the transform cannot adapt arrives
+      await watched.write(accountScopedTemplate({ withUploads: true }));
+      await watched.failedUpdates();
+
+      // Then it is reported the way a failed update is, and the Resources
+      // serving are the ones from before the change
+      assertStringIncludes(
+        watched.failed().at(0)?.message ?? "",
+        "no Hosted Zone ID for the uploads domain",
+      );
+      assertIdentical(await sitePage(watched.simAws), "<h1>Hello</h1>");
+
+      // And the next save the transform can adapt is applied, since what
+      // failed was the update rather than the watch
+      await watched.write(accountScopedTemplate({ withCache: true }));
+      await watched.updated();
+
+      assertNonNullable(watched.simAws.s3().getSimBucketByName("site-cache"));
+    } finally {
+      watched.stop();
+    }
+  });
+
+  it("reads the file as it is when the deployment brought no transform", async () => {
+    // Given a Stack deployed from a watched template file with no transform
+    const watched = await WatchedTemplate.of(accountScopedTemplate());
+
+    try {
+      // When it is synthesized again
+      await watched.write(accountScopedTemplate({ withUploads: true }));
+      await watched.updated();
+
+      // Then what the file holds is what was applied, names and all
+      assertNonNullable(
+        watched.simAws
+          .s3()
+          .getSimBucketByName(accountScopedName("site-uploads")),
+      );
+    } finally {
+      watched.stop();
+    }
+  });
+});

--- a/test/cloudformation/account-scoped-template.ts
+++ b/test/cloudformation/account-scoped-template.ts
@@ -1,0 +1,69 @@
+import {
+  jsonParse,
+  jsonStringify,
+  type JSONString,
+} from "../../src/util/type-guard/json.js";
+import type { CfnTemplateBodyRecord } from "../../src/service/cloudformation/template/sim-cfn-template.js";
+
+/**
+ * The account a template was synthesized against, carried in the names it
+ * holds.
+ */
+const synthesizedAccount = "-123456789012";
+
+interface AccountScopedTemplateProperties {
+  readonly withUploads?: boolean;
+  readonly withCache?: boolean;
+}
+
+/**
+ * A synthesized template whose Bucket names carry the account it was
+ * synthesized against.
+ *
+ * This stands in for whatever a real template holds that a simulation cannot
+ * resolve, such as an ARN naming a real account or a Hosted Zone ID that came
+ * from a lookup: a value the simulator has no way to reach, and the reason for
+ * adapting the template on the way in rather than editing the file.
+ */
+export function accountScopedTemplate(
+  properties: AccountScopedTemplateProperties = {},
+): object {
+  const { withUploads = false, withCache = false } = properties;
+
+  return {
+    Resources: {
+      Site: accountScopedBucket("site-content"),
+      ...(withUploads && { Uploads: accountScopedBucket("site-uploads") }),
+      ...(withCache && { Cache: accountScopedBucket("site-cache") }),
+    },
+  };
+}
+
+/**
+ * Take the account off every name in the template, as adapting a real template
+ * to a simulated environment does.
+ */
+export function withoutSynthesizedAccount(
+  template: CfnTemplateBodyRecord,
+): CfnTemplateBodyRecord {
+  return jsonParse(
+    jsonStringify(template).replaceAll(
+      synthesizedAccount,
+      "",
+    ) as JSONString<CfnTemplateBodyRecord>,
+  );
+}
+
+/**
+ * The name a Bucket has in the synthesized template, before anything adapts it.
+ */
+export function accountScopedName(bucketName: string): string {
+  return `${bucketName}${synthesizedAccount}`;
+}
+
+function accountScopedBucket(bucketName: string): object {
+  return {
+    Type: "AWS::S3::Bucket",
+    Properties: { BucketName: accountScopedName(bucketName) },
+  };
+}

--- a/test/cloudformation/watched-template.ts
+++ b/test/cloudformation/watched-template.ts
@@ -4,6 +4,7 @@ import { SimAws } from "../../src/index.js";
 import { TemporaryDirectory } from "../../src/util/filesystem/temporary-directory.js";
 import { jsonStringify } from "../../src/util/type-guard/json.js";
 import type { SimCfnTemplateFileWatchOptions } from "../../src/service/cloudformation/watch/sim-cfn-template-watch.type.js";
+import type { SimCfnTemplateFileTransform } from "../../src/service/cloudformation/deploy/sim-cfn-template-file-transform.js";
 
 /**
  * A synthesized template file on disk, deployed and watched.
@@ -24,10 +25,15 @@ export class WatchedTemplate {
 
   /**
    * Deploy a template file and watch it.
+   *
+   * A transform is given to the deployment rather than applied to the template
+   * written here, so what the file holds stays the synthesized template and
+   * the adapting is the simulator's to do again on every change.
    */
   static async of(
     template: object,
     watching: boolean | SimCfnTemplateFileWatchOptions = {},
+    transform?: SimCfnTemplateFileTransform,
   ): Promise<WatchedTemplate> {
     const watched = new WatchedTemplate();
     await watched.write(template);
@@ -40,6 +46,7 @@ export class WatchedTemplate {
 
     await watched.simAws.cloudFormation().deployTemplateFile({
       templatePath: watched.path(),
+      transform,
       watch: watched.watchProperty(watching),
     });
 


### PR DESCRIPTION
A synthesized template from a real CDK app can carry something a simulation cannot resolve at all: an ARN holding a real account, a Hosted Zone ID that came from `HostedZone.fromLookup`. `deployTemplate({ template, templatePath })` already covered deploying an object you had edited yourself, while still resolving staged assets from the cloud assembly beside `templatePath`. The watch path had no equivalent, so keeping an adapted template up to date meant writing a second `.local.template.json` into `cdk.out`, copying the assets manifest next to it, and watching the real template yourself to regenerate it.

`transform` is a single hook that takes the parsed body and answers with the one to deploy.

```typescript
await simAws.cloudFormation().deployTemplateFile({
  templatePath: "cdk.out/SiteStack.template.json",
  transform: withoutDnsRecords,
  watch: true,
});
```

## How

It is applied in `SimCfnTemplateFileLoader`, which is the one place a template file is read. That is what makes the deployment, `updateTemplateFile` and every watched change go through the same hook, rather than each growing its own. `load()` also stopped asking `typeof properties === "string"` four times over and normalizes through `simCfnTemplateFileDeployment()` instead, so the new option did not need a fifth ternary.

Staged assets resolve as they always did: the cloud assembly is found beside `templatePath`, so what a transform did to the body leaves the manifest and the staged directories where they were.

A transform that throws fails the deployment, with what it threw as the cause. On a watched change it rejects the update before the Stack is touched, so the existing failed-update path reports it and the apply queue is left able to take the next save.

## Notes

`SimCfnTemplateFileTransform` and `CfnTemplateBodyRecord` are exported from `@kensio/yulin/cloudformation`, so a named transform function can type its parameter.

An in-memory `updateTemplate(template)` and watching something other than a template file are the alternative shape for the same need, and stay out of scope.

Documented under [adapting a synthesized template on the way in](docs/services/cloudformation/README.md), with the watch flow in `docs/serve/README.md` pointing at it.

Resolves #431