### PR TITLE
feat: reload the browser for a mounted directory

### DIFF
--- a/docs/serve/README.md
+++ b/docs/serve/README.md
@@ -162,6 +162,39 @@ srv.close();
 
 `reload()` throws when live reload is off, rather than quietly doing nothing.
 
+### Reloading when a build changes a mounted directory
+
+A Bucket mounted on a local directory is already reading the files a site generator writes, so a
+rebuild needs nothing copying into it. Hand the mount the server and it watches the directory and
+reloads for you once the writes stop:
+
+```typescript sim-serve-mount-reload
+/**
+ * A built site the process reloads the browser for, rather than restarting for.
+ */
+
+import path from "node:path";
+
+import { CreateBucketCommand } from "@aws-sdk/client-s3";
+import { SimAws } from "@kensio/yulin";
+import { serveSimAws } from "@kensio/yulin/serve";
+
+const simAws = new SimAws();
+const srv = await serveSimAws({ simAws, port: 8787, liveReload: true });
+
+await simAws.s3().createBucket(new CreateBucketCommand({ Bucket: "site" }));
+
+simAws
+  .s3()
+  .mountBucketFilesystem("site", path.join(process.cwd(), "articles/public"), {
+    reload: srv,
+  });
+```
+
+One build is one reload, however many files it wrote. See
+[filesystem-backed Bucket storage](../services/s3/README.md#reloading-the-browser-when-the-directory-changes)
+for the `settleMs` override and for stopping the watch.
+
 ### What gets the script
 
 Yulin's own account of a request goes in headers and never in the body, so a response keeps the shape
@@ -218,10 +251,12 @@ CDK asset directories, and the working files an editor writes around a save.
 On top of that, Yulin names paths it is holding that the module graph never mentions. A directory
 given to `mountBucketFilesystem` and a template given to `deployTemplateFile` are reported to the
 supervisor as they are registered, and watched from then on, without appearing in any list. Editing
-a file in a mounted directory or re-synthing a stack restarts the process. A template deployed with
-the `watch` option is the exception, and is
-[left to the process reading it](#updating-a-stack-instead-of-restarting), as is any path the process
-[says it is holding](#holding-a-path-yourself).
+a file in a mounted directory or re-synthing a stack restarts the process.
+
+A path the process is watching itself is the exception, and is
+[left to the process reading it](#answering-a-change-instead-of-restarting): a template deployed
+with the `watch` option, and a directory mounted with somewhere to reload. So is any other path the
+process [says it is holding](#holding-a-path-yourself).
 
 A burst of writes is one restart. Saving one file is several filesystem events, so changes are held
 until they stop arriving before anything is restarted.
@@ -277,7 +312,12 @@ coming so a page comes back on its own. A hand-written reload channel wants the 
 Both are best effort and need a supervisor. In a process `yulin watch` did not start, such as a test
 run or a script launched from an IDE debugger, they do nothing at all.
 
-### Updating a stack instead of restarting
+This is the general case, for a path nothing else knows about. A mounted directory is the one Yulin
+does know about: `mountBucketFilesystem` takes a reload target, holds the path itself and settles the
+writes, so the example above is written for you. See
+[reloading when a build changes a mounted directory](#reloading-when-a-build-changes-a-mounted-directory).
+
+### Answering a change instead of restarting
 
 A deployment that watches its own template file is left alone by the supervisor:
 
@@ -308,6 +348,12 @@ The process names the template as one it is answering itself, so the supervisor 
 list rather than restarting for it. See
 [watching a template file](../services/cloudformation/README.md#watching-a-template-file) for what
 an update does to the resources.
+
+A directory mounted with somewhere to reload is left alone the same way. The Bucket is reading the
+files either way, so a rebuild has nothing to redo: the browser is reloaded and everything else the
+process is holding stays where it is, rather than the whole simulated environment going for the sake
+of a page that changed. See
+[reloading when a build changes a mounted directory](#reloading-when-a-build-changes-a-mounted-directory).
 
 A template synthesized against a real account sometimes needs adapting before Yulin will take it.
 `transform` is given the parsed template and answers with the one to deploy, on the deployment and
@@ -346,8 +392,8 @@ A transform that throws is reported the way a failed update is, so the process a
 is serving are left where they were. See
 [adapting a synthesized template](../services/cloudformation/README.md#adapting-a-synthesized-template-on-the-way-in).
 
-This works with no supervisor at all, so a dev script started from an IDE debugger picks up a
-re-synth with the debugger attached throughout.
+Both work with no supervisor at all, so a dev script started from an IDE debugger picks up a
+re-synth or a rebuild with the debugger attached throughout.
 
 ### When a run goes wrong
 

--- a/docs/serve/sim-serve-mount-reload.example.ts
+++ b/docs/serve/sim-serve-mount-reload.example.ts
@@ -1,0 +1,20 @@
+/**
+ * A built site the process reloads the browser for, rather than restarting for.
+ */
+
+import path from "node:path";
+
+import { CreateBucketCommand } from "@aws-sdk/client-s3";
+import { SimAws } from "@kensio/yulin";
+import { serveSimAws } from "@kensio/yulin/serve";
+
+const simAws = new SimAws();
+const srv = await serveSimAws({ simAws, port: 8787, liveReload: true });
+
+await simAws.s3().createBucket(new CreateBucketCommand({ Bucket: "site" }));
+
+simAws
+  .s3()
+  .mountBucketFilesystem("site", path.join(process.cwd(), "articles/public"), {
+    reload: srv,
+  });

--- a/docs/services/s3/README.md
+++ b/docs/services/s3/README.md
@@ -1489,6 +1489,71 @@ simS3.mountBucketFilesystem(
 
 After mounting, Object reads and writes for that Bucket use the filesystem directory.
 
+### Reloading the browser when the directory changes
+
+The Bucket is reading the files, so a rebuild needs nothing copying into it. All that is left is
+telling the browser. Give the mount somewhere to reload and it watches the directory for you:
+
+```typescript sim-s3-mount-reload
+/**
+ * Reloading the browser when a build writes into a mounted directory.
+ */
+
+import path from "node:path";
+
+import { CreateBucketCommand } from "@aws-sdk/client-s3";
+import { SimAws } from "@kensio/yulin";
+import { serveSimAws } from "@kensio/yulin/serve";
+
+const simAws = new SimAws();
+const srv = await serveSimAws({ simAws, port: 8787, liveReload: true });
+
+await simAws.s3().createBucket(new CreateBucketCommand({ Bucket: "site" }));
+
+simAws.s3().mountBucketFilesystem("site", path.join(process.cwd(), "public"), {
+  reload: srv,
+});
+```
+
+A build writing a whole tree of files is one reload, not one per file: the writes are held until
+they stop arriving. `settleMs` is how long that wait is, in milliseconds, for a generator that
+pauses part way through a build:
+
+```typescript sim-s3-mount-reload-settle
+/**
+ * Waiting longer for a slow build to finish writing.
+ */
+
+import path from "node:path";
+
+import { CreateBucketCommand } from "@aws-sdk/client-s3";
+import { SimAws } from "@kensio/yulin";
+import { serveSimAws } from "@kensio/yulin/serve";
+
+const simAws = new SimAws();
+const srv = await serveSimAws({ simAws, liveReload: true });
+
+await simAws.s3().createBucket(new CreateBucketCommand({ Bucket: "site" }));
+
+simAws.s3().mountBucketFilesystem("site", path.join(process.cwd(), "dist"), {
+  reload: srv,
+  settleMs: 500,
+});
+```
+
+Anything with a `reload()` method will do, so a test can watch a mount without serving anything.
+
+The watch is recursive, and holds an open filesystem handle, which keeps the process alive. A dev
+process wants exactly that. Anything with an end, such as a test, calls
+`simAws.s3().stopWatchingMountedDirectories()` when it is done.
+`simAws.s3().watchedMountedDirectories()` says which directories are being watched.
+
+Under [`yulin watch`](../../serve/README.md#restarting-on-a-file-change), a mount that reloads for
+itself is left alone by the supervisor: a rebuild reloads the page rather than restarting the
+process and taking every simulated Bucket, Table and Stack with it. A mount without a reload target
+is still reported to the supervisor as a directory to watch, and a change in it restarts the
+process.
+
 Filesystem storage is somewhat restrictive to make it slightly safer:
 
 - The directory path must be absolute
@@ -1564,7 +1629,8 @@ Sim S3 currently supports:
   configuration, and routing-rule redirects
 - Bucket-global uniqueness within a `SimAws` instance across simulated Accounts and Regions
 - In-memory Object storage by default
-- Optional filesystem-backed Bucket storage with `mountBucketFilesystem(...)`
+- Optional filesystem-backed Bucket storage with `mountBucketFilesystem(...)`, watching the mounted
+  directory and reloading connected browsers when it is rebuilt
 
 The simulator focuses on useful behaviour for tests and local development rather than full S3 feature
 parity. Unsupported S3 options may be ignored or may throw errors depending on whether the simulator

--- a/docs/services/s3/sim-s3-mount-reload-settle.example.ts
+++ b/docs/services/s3/sim-s3-mount-reload-settle.example.ts
@@ -1,0 +1,19 @@
+/**
+ * Waiting longer for a slow build to finish writing.
+ */
+
+import path from "node:path";
+
+import { CreateBucketCommand } from "@aws-sdk/client-s3";
+import { SimAws } from "@kensio/yulin";
+import { serveSimAws } from "@kensio/yulin/serve";
+
+const simAws = new SimAws();
+const srv = await serveSimAws({ simAws, liveReload: true });
+
+await simAws.s3().createBucket(new CreateBucketCommand({ Bucket: "site" }));
+
+simAws.s3().mountBucketFilesystem("site", path.join(process.cwd(), "dist"), {
+  reload: srv,
+  settleMs: 500,
+});

--- a/docs/services/s3/sim-s3-mount-reload.example.ts
+++ b/docs/services/s3/sim-s3-mount-reload.example.ts
@@ -1,0 +1,18 @@
+/**
+ * Reloading the browser when a build writes into a mounted directory.
+ */
+
+import path from "node:path";
+
+import { CreateBucketCommand } from "@aws-sdk/client-s3";
+import { SimAws } from "@kensio/yulin";
+import { serveSimAws } from "@kensio/yulin/serve";
+
+const simAws = new SimAws();
+const srv = await serveSimAws({ simAws, port: 8787, liveReload: true });
+
+await simAws.s3().createBucket(new CreateBucketCommand({ Bucket: "site" }));
+
+simAws.s3().mountBucketFilesystem("site", path.join(process.cwd(), "public"), {
+  reload: srv,
+});

--- a/src/cli/watch/sim-watch-reported-paths.loc.test.ts
+++ b/src/cli/watch/sim-watch-reported-paths.loc.test.ts
@@ -46,6 +46,32 @@ describe("paths a supervised process reports", () => {
     await project.untilRuns(2);
   });
 
+  it("leaves a mount that reloads for itself alone", async () => {
+    // Given a dev script that mounts a directory outside the project with
+    // somewhere to reload, so the mount watches it and reloads the browser
+    // when it is rebuilt
+    const project = await WatchProject.of({});
+    const mounted = path.join(project.mountedPath(), "public");
+    await project.writeMounted(path.join("public", "index.html"), "<h1>a</h1>");
+    await project.write(
+      "dev.ts",
+      reloadingMountScript(project.runsLogPath(), mounted),
+    );
+    const supervisor = supervise(project);
+    await project.settled();
+    runSupervisor(supervisor);
+    await project.untilRuns(1);
+    await watchPause(300);
+
+    // When a file in that directory is rebuilt
+    await project.writeMounted(path.join("public", "index.html"), "<h1>b</h1>");
+
+    // Then the browser is reloaded in the process that mounted it, rather than
+    // the process being restarted and everything it holds going with it
+    const recorded = await project.untilRuns(2);
+    assertArrayEquals([...recorded], ["run", "reloaded"]);
+  });
+
   it("watches a template that was deployed", async () => {
     // Given a dev script that deploys a synthesized template from outside the
     // project, as a separate synth step would leave it
@@ -152,6 +178,29 @@ appendFileSync(${JSON.stringify(runsLogPath)}, "run\n");
 const simAws = new SimAws();
 await simAws.s3().createBucket({ input: { Bucket: "site" } });
 simAws.s3().mountBucketFilesystem("site", ${JSON.stringify(mountedPath)});
+
+setInterval(() => {}, 60_000);
+`;
+}
+
+function reloadingMountScript(
+  runsLogPath: string,
+  mountedPath: string,
+): string {
+  return String.raw`import { appendFileSync } from "node:fs";
+import { SimAws } from ${JSON.stringify(yulin)};
+
+appendFileSync(${JSON.stringify(runsLogPath)}, "run\n");
+
+const simAws = new SimAws();
+await simAws.s3().createBucket({ input: { Bucket: "site" } });
+simAws.s3().mountBucketFilesystem("site", ${JSON.stringify(mountedPath)}, {
+  reload: {
+    reload: () => {
+      appendFileSync(${JSON.stringify(runsLogPath)}, "reloaded\n");
+    },
+  },
+});
 
 setInterval(() => {}, 60_000);
 `;

--- a/src/service/s3/README.md
+++ b/src/service/s3/README.md
@@ -250,8 +250,26 @@ This storage is fast, isolated, and appropriate for most tests.
 for local development scenarios such as serving a static site from a real directory through
 simulated S3 and CloudFront.
 
-`SimS3.mountBucketFilesystem(bucketName, directoryPath)` is the high-level API for switching an
-existing Bucket to filesystem-backed storage.
+`SimS3.mountBucketFilesystem(bucketName, directoryPath, options)` is the high-level API for switching
+an existing Bucket to filesystem-backed storage.
+
+### Watching a mounted directory
+
+A mount given somewhere to reload, as `{ reload: srv }`, watches the directory as well as serving it.
+The pieces are in `mount/`:
+
+- `SimS3MountDirectoryEvents` holds the recursive `fs.watch`. It drops an event naming the directory
+  itself, which is macOS replaying the directory's own creation to a watch started moments after it,
+  and would otherwise reload the browser on start-up for a build that never happened.
+- `SimS3MountWatch` puts those events through `SimWatchSettle`, so a build writing a tree of files is
+  one reload, and reloads when they stop.
+- `SimS3MountWatches` is the collection, one watch per Bucket, held by `SimS3BucketAccess`. It also
+  decides what a `yulin watch` supervisor is told: a watched mount is a held path, so a rebuild
+  reloads rather than restarting the process and taking every simulated Bucket, Table and Stack with
+  it, while an unwatched one is a reported path as it always was.
+
+A recursive watch holds an open filesystem handle, so `SimS3.stopWatchingMountedDirectories()` is the
+way to let it go. A dev process never calls it; a test does.
 
 Filesystem storage behaviour:
 

--- a/src/service/s3/bucket/sim-s3-bucket-access.ts
+++ b/src/service/s3/bucket/sim-s3-bucket-access.ts
@@ -3,7 +3,8 @@ import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-
 import { FilesystemS3BucketStorage } from "../storage/filesystem/s3-filesystem-storage.js";
 import { simS3BucketUrl } from "./sim-s3-endpoint-url.js";
 import type { SimS3Bucket, SimS3BucketName } from "./sim-s3-bucket.js";
-import { simWatch } from "../../../watch/sim-watch-runtime.js";
+import { SimS3MountWatches } from "../mount/sim-s3-mount-watches.js";
+import type { SimS3MountFilesystemOptions } from "../mount/sim-s3-mount.type.js";
 
 interface SimS3BucketAccessProperties {
   readonly buckets: ReadonlyMap<SimS3BucketName, SimS3Bucket>;
@@ -21,6 +22,7 @@ interface SimS3BucketAccessProperties {
 export class SimS3BucketAccess {
   private readonly buckets: ReadonlyMap<SimS3BucketName, SimS3Bucket>;
   private readonly accountRegionScope: SimAwsAccountRegionScope;
+  private readonly mountWatches = new SimS3MountWatches();
 
   constructor(properties: SimS3BucketAccessProperties) {
     this.buckets = properties.buckets;
@@ -57,17 +59,34 @@ export class SimS3BucketAccess {
   /**
    * Have a Bucket use a local filesystem directory for storage.
    *
-   * The directory is named to a `yulin watch` supervisor, so editing a file the
-   * Bucket serves restarts the process without the directory having been listed
-   * anywhere. Nothing happens outside watch mode.
+   * Given somewhere to reload, the directory is watched here and a build in it
+   * reloads the connected browsers once the writes stop. Without that the
+   * directory is only named to a `yulin watch` supervisor, so editing a file
+   * the Bucket serves restarts the process without the directory having been
+   * listed anywhere, and nothing happens outside watch mode.
    */
   mountFilesystem(
     bucketName: SimS3BucketName | string,
     directoryPath: string,
+    options: SimS3MountFilesystemOptions = {},
   ): void {
     this.required(bucketName).configureSimStorage(
       new FilesystemS3BucketStorage({ directoryPath }),
     );
-    simWatch.reportPath(directoryPath);
+    this.mountWatches.register(bucketName, directoryPath, options);
+  }
+
+  /**
+   * The mounted directories being watched for changes.
+   */
+  watchedMounts(): readonly string[] {
+    return this.mountWatches.paths();
+  }
+
+  /**
+   * Stop watching mounted directories.
+   */
+  stopWatchingMounts(): void {
+    this.mountWatches.stopAll();
   }
 }

--- a/src/service/s3/index.ts
+++ b/src/service/s3/index.ts
@@ -1,2 +1,6 @@
 export { SimS3 } from "./sim-s3.js";
+export type {
+  SimS3MountFilesystemOptions,
+  SimS3MountReloadTarget,
+} from "./mount/sim-s3-mount.type.js";
 export type { SimS3NotificationDeliveryFailure } from "./notification/sim-s3-notification-failures.js";

--- a/src/service/s3/mount/sim-s3-mount-directory-events.ts
+++ b/src/service/s3/mount/sim-s3-mount-directory-events.ts
@@ -1,0 +1,80 @@
+import fs, { type FSWatcher } from "node:fs";
+import path from "node:path";
+
+interface SimS3MountDirectoryEventsProperties {
+  readonly directoryPath: string;
+  readonly onEvent: () => void;
+}
+
+/**
+ * Filesystem events for everything under a mounted directory.
+ *
+ * The watch is recursive, because a site generator writes into whatever nested
+ * directories its output has and the Bucket serves all of them. Which file
+ * changed does not matter here: any of them is the mounted content changing.
+ */
+export class SimS3MountDirectoryEvents {
+  private readonly directoryPath: string;
+  private readonly directoryName: string;
+  private readonly onEvent: () => void;
+  private watcher: FSWatcher | undefined;
+
+  constructor(properties: SimS3MountDirectoryEventsProperties) {
+    this.directoryPath = path.resolve(properties.directoryPath);
+    this.directoryName = path.basename(this.directoryPath);
+    this.onEvent = properties.onEvent;
+  }
+
+  /**
+   * Start listening for writes under the directory.
+   */
+  start(): void {
+    // eslint-disable-next-line security/detect-non-literal-fs-filename
+    const watcher = fs.watch(
+      this.directoryPath,
+      { recursive: true },
+      (_event, fileName) => {
+        if (this.namesTheDirectoryItself(fileName)) {
+          return;
+        }
+
+        this.onEvent();
+      },
+    );
+
+    // The directory can be deleted or replaced, and a watcher with no error
+    // listener throws. Nothing here can put it back.
+    /* v8 ignore next 4 -- raised where the platform reports a watch going away,
+     * which macOS does not do for a deleted directory, so nothing here can make
+     * it happen on the machine this suite runs on. */
+    watcher.on("error", () => {
+      watcher.close();
+      this.watcher = undefined;
+    });
+
+    this.watcher = watcher;
+  }
+
+  /**
+   * Stop listening.
+   */
+  close(): void {
+    this.watcher?.close();
+    this.watcher = undefined;
+  }
+
+  /**
+   * Whether an event is macOS replaying the directory's own creation.
+   *
+   * A recursive watch started moments after the directory was made is handed a
+   * `change` naming the directory itself, which is the platform catching the
+   * watch up on what it just missed rather than anything having been written.
+   * Reloading for it would reload the browser for nothing every time a process
+   * that builds before it mounts starts up. An established directory never
+   * reports this, and a real event under the mount always names a file inside
+   * it, so dropping it costs nothing.
+   */
+  private namesTheDirectoryItself(fileName: string | null): boolean {
+    return fileName === this.directoryName;
+  }
+}

--- a/src/service/s3/mount/sim-s3-mount-watch.loc.test.ts
+++ b/src/service/s3/mount/sim-s3-mount-watch.loc.test.ts
@@ -1,0 +1,103 @@
+import { assertArrayEquals, assertIdentical } from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { MountedSite, mountPause } from "../../../../test/s3/mounted-site.js";
+
+describe("a directory mounted into a Bucket that changes", () => {
+  it("reloads the connected browsers once the writes stop", async () => {
+    // Given a mounted directory the browser is reloaded for
+    const site = await MountedSite.of();
+
+    try {
+      // When a build writes a page into it
+      await site.write("index.html", "<h1>Rebuilt</h1>");
+      await site.reloaded();
+      await mountPause(200);
+
+      // Then the browser is told once, rather than being told again for
+      // whatever the write did to the directory around it
+      assertIdentical(site.reloadCount(), 1);
+      assertArrayEquals(site.simAws.s3().watchedMountedDirectories(), [
+        site.path(),
+      ]);
+    } finally {
+      site.stop();
+    }
+  });
+
+  it("makes one reload out of a build writing a whole tree", async () => {
+    // Given a mounted directory the browser is reloaded for
+    const site = await MountedSite.of();
+
+    try {
+      // When a build writes the pages it generated, in nested directories as
+      // a site generator lays them out
+      await site.write("index.html", "<h1>Rebuilt</h1>");
+      await site.write("about/index.html", "<h1>About</h1>");
+      await site.write("posts/first/index.html", "<h1>First</h1>");
+      await site.write("assets/site.css", "h1 { color: red }");
+
+      await site.reloaded();
+      await mountPause(300);
+
+      // Then the whole build is one reload, not one per file
+      assertIdentical(site.reloadCount(), 1);
+    } finally {
+      site.stop();
+    }
+  });
+
+  it("watches nothing when the mount was not given somewhere to reload", async () => {
+    // Given a directory mounted the way a test mounts one, with no browser to
+    // tell about it
+    const site = await MountedSite.of({ reload: false });
+
+    try {
+      // When a build writes a page into it
+      await site.write("index.html", "<h1>Rebuilt</h1>");
+      await mountPause(500);
+
+      // Then nothing was watching it, so nothing is holding the process open
+      assertArrayEquals(site.simAws.s3().watchedMountedDirectories(), []);
+      assertIdentical(site.reloadCount(), 0);
+    } finally {
+      site.stop();
+    }
+  });
+
+  it("does not reload for the directory's own creation", async () => {
+    // Given a directory mounted the moment it was made, which is what a
+    // process that builds its site before mounting it does. macOS replays the
+    // directory's own creation to a watch started that soon after it.
+    const site = await MountedSite.of({ fresh: true });
+
+    try {
+      // When the writes that were in flight have had time to arrive
+      await mountPause(500);
+
+      // Then the browser has not been reloaded for a build that never happened
+      assertIdentical(site.reloadCount(), 0);
+
+      // And the watch is live rather than broken: a real build still reloads
+      await site.write("index.html", "<h1>Built</h1>");
+      await site.reloaded();
+      assertIdentical(site.reloadCount(), 1);
+    } finally {
+      site.stop();
+    }
+  });
+
+  it("stops watching when the watch is closed", async () => {
+    // Given a mounted directory whose watch has been stopped, as a test that
+    // is finished with it does
+    const site = await MountedSite.of();
+    site.stop();
+
+    // When a build writes a page into it afterwards
+    await site.write("index.html", "<h1>Rebuilt</h1>");
+    await mountPause(500);
+
+    // Then nothing is left listening for it
+    assertIdentical(site.reloadCount(), 0);
+    assertArrayEquals(site.simAws.s3().watchedMountedDirectories(), []);
+  });
+});

--- a/src/service/s3/mount/sim-s3-mount-watch.ts
+++ b/src/service/s3/mount/sim-s3-mount-watch.ts
@@ -1,0 +1,76 @@
+import path from "node:path";
+import {
+  simWatch,
+  type SimWatchRuntime,
+} from "../../../watch/sim-watch-runtime.js";
+import { SimWatchSettle } from "../../../watch/sim-watch-settle.js";
+import { simWatchConfig } from "../../../watch/sim-watch.config.js";
+import { SimS3MountDirectoryEvents } from "./sim-s3-mount-directory-events.js";
+
+interface SimS3MountWatchProperties {
+  readonly directoryPath: string;
+  readonly onChanged: () => void;
+  readonly settleMs?: number | undefined;
+  readonly watch?: SimWatchRuntime | undefined;
+}
+
+/**
+ * Watches one directory mounted into a Bucket, and answers a build in it.
+ *
+ * Nothing is copied when the directory changes, because the Bucket is already
+ * reading the files. All that is left is telling the browser, once the writes
+ * have stopped, so a build that wrote a hundred files is one reload.
+ */
+export class SimS3MountWatch {
+  readonly directoryPath: string;
+
+  private readonly onChanged: () => void;
+  private readonly settle: SimWatchSettle;
+  private readonly events: SimS3MountDirectoryEvents;
+  private readonly watch: SimWatchRuntime;
+
+  constructor(properties: SimS3MountWatchProperties) {
+    const {
+      directoryPath,
+      onChanged,
+      settleMs = simWatchConfig.settleMs,
+      watch = simWatch,
+    } = properties;
+
+    this.directoryPath = path.resolve(directoryPath);
+    this.onChanged = onChanged;
+    this.watch = watch;
+    this.settle = new SimWatchSettle({
+      settleMs,
+      onSettled: (): void => {
+        this.onChanged();
+      },
+    });
+    this.events = new SimS3MountDirectoryEvents({
+      directoryPath: this.directoryPath,
+      onEvent: (): void => {
+        this.settle.record(this.directoryPath);
+      },
+    });
+  }
+
+  /**
+   * Start watching.
+   *
+   * A `yulin watch` supervisor is told the directory is handled here, so a
+   * rebuild reloads the page instead of restarting the process and taking every
+   * simulated Bucket, Table and Stack with it.
+   */
+  start(): void {
+    this.watch.reportHeldPath(this.directoryPath);
+    this.events.start();
+  }
+
+  /**
+   * Stop watching, and drop a change that was still settling.
+   */
+  close(): void {
+    this.settle.cancel();
+    this.events.close();
+  }
+}

--- a/src/service/s3/mount/sim-s3-mount-watches.loc.test.ts
+++ b/src/service/s3/mount/sim-s3-mount-watches.loc.test.ts
@@ -1,0 +1,86 @@
+import {
+  assertArrayEquals,
+  assertArrayLength,
+  assertIdentical,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimS3MountWatches } from "./sim-s3-mount-watches.js";
+import { SimWatchRuntime } from "../../../watch/sim-watch-runtime.js";
+import { simWatchMessages } from "../../../watch/sim-watch.config.js";
+import { TemporaryDirectory } from "../../../util/filesystem/temporary-directory.js";
+import { FakeProcess } from "../../../../test/watch/fake-process.js";
+
+describe("mounted directories under a watch supervisor", () => {
+  it("holds a directory it reloads for itself, rather than restarting", async () => {
+    // Given a supervised process mounting a directory it reloads the browser
+    // for
+    const host = new FakeProcess();
+    const directory = new TemporaryDirectory();
+    await directory.resolvePath();
+    const mounts = new SimS3MountWatches({
+      watch: new SimWatchRuntime({ host }),
+    });
+
+    try {
+      // When the directory is mounted with somewhere to reload
+      mounts.register("site", directory.path(), {
+        reload: { reload: (): void => undefined },
+      });
+
+      // Then the supervisor is told to leave it alone, so a rebuild reloads
+      // the page instead of restarting the process and taking every simulated
+      // Bucket, Table and Stack with it
+      assertArrayLength(host.sent, 1);
+      const [reported = {}] = host.sent;
+      assertIdentical(reported["type"], simWatchMessages.heldPath);
+      assertIdentical(reported["path"], directory.path());
+    } finally {
+      mounts.stopAll();
+    }
+  });
+
+  it("names a directory nothing is reloading for as one to watch", async () => {
+    // Given a supervised process mounting a directory with no browser to tell
+    const host = new FakeProcess();
+    const directory = new TemporaryDirectory();
+    await directory.resolvePath();
+    const mounts = new SimS3MountWatches({
+      watch: new SimWatchRuntime({ host }),
+    });
+
+    // When the directory is mounted
+    mounts.register("site", directory.path(), {});
+
+    // Then the supervisor watches it and restarts the process for a change,
+    // which is all a mount could do before it watched anything
+    assertArrayLength(host.sent, 1);
+    const [reported = {}] = host.sent;
+    assertIdentical(reported["type"], simWatchMessages.path);
+    assertArrayEquals(mounts.paths(), []);
+  });
+
+  it("watches the directory a re-mounted Bucket is serving now", async () => {
+    // Given a Bucket mounted on one directory and watched
+    const host = new FakeProcess();
+    const first = new TemporaryDirectory();
+    const second = new TemporaryDirectory();
+    await first.resolvePath();
+    await second.resolvePath();
+    const mounts = new SimS3MountWatches({
+      watch: new SimWatchRuntime({ host }),
+    });
+    const reload = { reload: (): void => undefined };
+    mounts.register("site", first.path(), { reload });
+
+    try {
+      // When the same Bucket is mounted somewhere else
+      mounts.register("site", second.path(), { reload });
+
+      // Then the directory it is serving now is the one being watched, rather
+      // than both being held open
+      assertArrayEquals(mounts.paths(), [second.path()]);
+    } finally {
+      mounts.stopAll();
+    }
+  });
+});

--- a/src/service/s3/mount/sim-s3-mount-watches.ts
+++ b/src/service/s3/mount/sim-s3-mount-watches.ts
@@ -1,0 +1,93 @@
+import {
+  simWatch,
+  type SimWatchRuntime,
+} from "../../../watch/sim-watch-runtime.js";
+import type { SimS3BucketName } from "../bucket/sim-s3-bucket.js";
+import { SimS3MountWatch } from "./sim-s3-mount-watch.js";
+import type { SimS3MountFilesystemOptions } from "./sim-s3-mount.type.js";
+
+interface SimS3MountWatchesProperties {
+  readonly watch?: SimWatchRuntime | undefined;
+}
+
+/**
+ * The mounted directories one simulated S3 is watching.
+ *
+ * One watch per Bucket, because a Bucket reads one directory. Mounting a Bucket
+ * again replaces its watch, so the directory being watched is always the one
+ * being served.
+ *
+ * A recursive watch holds an open filesystem handle, which keeps the process
+ * alive, so anything that starts one needs a way to let it go. `stopAll()` is
+ * that way, and a long-running dev process simply never calls it.
+ */
+export class SimS3MountWatches {
+  private readonly watch: SimWatchRuntime;
+  private readonly watches = new Map<SimS3BucketName, SimS3MountWatch>();
+
+  constructor(properties: SimS3MountWatchesProperties = {}) {
+    this.watch = properties.watch ?? simWatch;
+  }
+
+  /**
+   * Take on a directory that has just been mounted into a Bucket.
+   *
+   * A mount that reloads for itself watches the directory, and a `yulin watch`
+   * supervisor is told to leave it alone. A mount that does not is only named
+   * to the supervisor, which then restarts the process for a change in it, and
+   * nothing here holds the event loop open.
+   */
+  register(
+    bucketName: SimS3BucketName | string,
+    directoryPath: string,
+    options: SimS3MountFilesystemOptions,
+  ): void {
+    this.remove(bucketName);
+
+    const { reload } = options;
+
+    if (reload === undefined) {
+      this.watch.reportPath(directoryPath);
+
+      return;
+    }
+
+    const watch = new SimS3MountWatch({
+      directoryPath,
+      onChanged: (): void => {
+        reload.reload();
+      },
+      settleMs: options.settleMs,
+      watch: this.watch,
+    });
+
+    this.watches.set(bucketName as SimS3BucketName, watch);
+    watch.start();
+  }
+
+  /**
+   * The mounted directories being watched, as absolute paths.
+   */
+  paths(): readonly string[] {
+    return [
+      ...new Set(this.watches.values().map((watch) => watch.directoryPath)),
+    ];
+  }
+
+  /**
+   * Stop watching everything, so nothing is left holding the process open.
+   */
+  stopAll(): void {
+    for (const watch of this.watches.values()) {
+      watch.close();
+    }
+
+    this.watches.clear();
+  }
+
+  private remove(bucketName: SimS3BucketName | string): void {
+    const key = bucketName as SimS3BucketName;
+    this.watches.get(key)?.close();
+    this.watches.delete(key);
+  }
+}

--- a/src/service/s3/mount/sim-s3-mount.type.ts
+++ b/src/service/s3/mount/sim-s3-mount.type.ts
@@ -1,0 +1,32 @@
+/**
+ * Somewhere a reload can be sent, which in practice is a local server.
+ *
+ * Named by the shape rather than the class, so mounting a directory does not
+ * drag the serving side of Yulin into a simulated S3 that is only being asked
+ * to read files.
+ */
+export interface SimS3MountReloadTarget {
+  reload(): void;
+}
+
+/**
+ * What to do about a directory mounted into a Bucket, beyond serving it.
+ */
+export interface SimS3MountFilesystemOptions {
+  /**
+   * Reload connected browsers once writes into the directory stop.
+   *
+   * This is the local server, as `{ reload: srv }`. Without it the directory is
+   * not watched at all, and a rebuild is a restart or a manual refresh.
+   */
+  readonly reload?: SimS3MountReloadTarget | undefined;
+
+  /**
+   * How long the writes have to stop for before the directory counts as
+   * changed, in milliseconds.
+   *
+   * A site generator writes a whole tree of files, so a wait is what makes one
+   * build one reload. The default suits a generator writing its output.
+   */
+  readonly settleMs?: number | undefined;
+}

--- a/src/service/s3/sim-s3.ts
+++ b/src/service/s3/sim-s3.ts
@@ -12,6 +12,7 @@ import { SimS3SdkCommandRouter } from "./sdk/sim-s3-sdk-command-router.js";
 import type { SimSdkCommandRouter } from "../../sdk/router/sim-sdk-command-router.type.js";
 import type { SimS3RequestOptions } from "./command/sim-s3-request-options.js";
 import type { SimS3NotificationDeliveryFailure } from "./notification/sim-s3-notification-failures.js";
+import type { SimS3MountFilesystemOptions } from "./mount/sim-s3-mount.type.js";
 
 /**
  * Simulated S3. Handles SDK commands. Emulates AWS behaviour and state.
@@ -48,9 +49,7 @@ export class SimS3 {
     });
   }
 
-  /**
-   * Handle a Create Bucket Command from the SDK.
-   */
+  /** Handle a Create Bucket Command from the SDK. */
   async createBucket(
     command: simS3Commands.SimCreateBucketCommand,
     options?: SimS3RequestOptions,
@@ -58,9 +57,7 @@ export class SimS3 {
     return await this.commands.buckets.create(command, options);
   }
 
-  /**
-   * Handle a Delete Bucket Command from the SDK.
-   */
+  /** Handle a Delete Bucket Command from the SDK. */
   async deleteBucket(
     command: simS3Commands.SimDeleteBucketCommand,
     options?: SimS3RequestOptions,
@@ -68,9 +65,7 @@ export class SimS3 {
     return await this.commands.buckets.delete(command, options);
   }
 
-  /**
-   * Handle a Put Bucket Policy Command from the SDK.
-   */
+  /** Handle a Put Bucket Policy Command from the SDK. */
   async putBucketPolicy(
     command: simS3Commands.SimPutBucketPolicyCommand,
     options?: SimS3RequestOptions,
@@ -78,9 +73,7 @@ export class SimS3 {
     return await this.commands.bucketPolicies.put(command, options);
   }
 
-  /**
-   * Handle a Get Bucket Policy Command from the SDK.
-   */
+  /** Handle a Get Bucket Policy Command from the SDK. */
   async getBucketPolicy(
     command: simS3Commands.SimGetBucketPolicyCommand,
     options?: SimS3RequestOptions,
@@ -88,9 +81,7 @@ export class SimS3 {
     return await this.commands.bucketPolicies.get(command, options);
   }
 
-  /**
-   * Handle a Delete Bucket Policy Command from the SDK.
-   */
+  /** Handle a Delete Bucket Policy Command from the SDK. */
   async deleteBucketPolicy(
     command: simS3Commands.SimDeleteBucketPolicyCommand,
     options?: SimS3RequestOptions,
@@ -98,9 +89,7 @@ export class SimS3 {
     return await this.commands.bucketPolicies.delete(command, options);
   }
 
-  /**
-   * Handle a Put Public Access Block Command from the SDK.
-   */
+  /** Handle a Put Public Access Block Command from the SDK. */
   async putPublicAccessBlock(
     command: simS3Commands.SimPutPublicAccessBlockCommand,
     options?: SimS3RequestOptions,
@@ -108,9 +97,7 @@ export class SimS3 {
     return await this.commands.publicAccessBlocks.put(command, options);
   }
 
-  /**
-   * Handle a Get Public Access Block Command from the SDK.
-   */
+  /** Handle a Get Public Access Block Command from the SDK. */
   async getPublicAccessBlock(
     command: simS3Commands.SimGetPublicAccessBlockCommand,
     options?: SimS3RequestOptions,
@@ -118,9 +105,7 @@ export class SimS3 {
     return await this.commands.publicAccessBlocks.get(command, options);
   }
 
-  /**
-   * Handle a Delete Public Access Block Command from the SDK.
-   */
+  /** Handle a Delete Public Access Block Command from the SDK. */
   async deletePublicAccessBlock(
     command: simS3Commands.SimDeletePublicAccessBlockCommand,
     options?: SimS3RequestOptions,
@@ -128,9 +113,7 @@ export class SimS3 {
     return await this.commands.publicAccessBlocks.delete(command, options);
   }
 
-  /**
-   * Handle a Put Bucket Website Command from the SDK.
-   */
+  /** Handle a Put Bucket Website Command from the SDK. */
   async putBucketWebsite(
     command: simS3Commands.SimPutBucketWebsiteCommand,
     options?: SimS3RequestOptions,
@@ -138,9 +121,7 @@ export class SimS3 {
     return await this.commands.buckets.putWebsite(command, options);
   }
 
-  /**
-   * Handle a Put Bucket Notification Configuration Command from the SDK.
-   */
+  /** Handle a Put Bucket Notification Configuration Command from the SDK. */
   async putBucketNotificationConfiguration(
     command: simS3Commands.SimPutBucketNotificationConfigurationCommand,
     options?: SimS3RequestOptions,
@@ -148,9 +129,7 @@ export class SimS3 {
     return await this.commands.notifications.put(command, options);
   }
 
-  /**
-   * Handle a Get Bucket Notification Configuration Command from the SDK.
-   */
+  /** Handle a Get Bucket Notification Configuration Command from the SDK. */
   async getBucketNotificationConfiguration(
     command: simS3Commands.SimGetBucketNotificationConfigurationCommand,
     options?: SimS3RequestOptions,
@@ -158,9 +137,7 @@ export class SimS3 {
     return await this.commands.notifications.get(command, options);
   }
 
-  /**
-   * Handle a List Buckets Command from the SDK.
-   */
+  /** Handle a List Buckets Command from the SDK. */
   async listBuckets(
     command: simS3Commands.SimListBucketsCommand,
     options?: SimS3RequestOptions,
@@ -168,9 +145,7 @@ export class SimS3 {
     return await this.commands.buckets.list(command, options);
   }
 
-  /**
-   * Handle a Put Object Command from the SDK.
-   */
+  /** Handle a Put Object Command from the SDK. */
   async putObject(
     command: simS3Commands.SimPutObjectCommand,
     options?: SimS3RequestOptions,
@@ -178,9 +153,7 @@ export class SimS3 {
     return await this.commands.objects.put(command, options);
   }
 
-  /**
-   * Handle a Get Object Command from the SDK.
-   */
+  /** Handle a Get Object Command from the SDK. */
   async getObject(
     command: simS3Commands.SimGetObjectCommand,
     options?: SimS3RequestOptions,
@@ -188,9 +161,7 @@ export class SimS3 {
     return await this.commands.objects.get(command, options);
   }
 
-  /**
-   * Handle a Delete Object Command from the SDK.
-   */
+  /** Handle a Delete Object Command from the SDK. */
   async deleteObject(
     command: simS3Commands.SimDeleteObjectCommand,
     options?: SimS3RequestOptions,
@@ -198,9 +169,7 @@ export class SimS3 {
     return await this.commands.objects.delete(command, options);
   }
 
-  /**
-   * Handle a Delete Objects Command from the SDK.
-   */
+  /** Handle a Delete Objects Command from the SDK. */
   async deleteObjects(
     command: simS3Commands.SimDeleteObjectsCommand,
     options?: SimS3RequestOptions,
@@ -208,9 +177,7 @@ export class SimS3 {
     return await this.commands.objects.deleteMany(command, options);
   }
 
-  /**
-   * Handle a List Objects Command from the SDK.
-   */
+  /** Handle a List Objects Command from the SDK. */
   async listObjects(
     command: simS3Commands.SimListObjectsCommand,
     options?: SimS3RequestOptions,
@@ -218,9 +185,7 @@ export class SimS3 {
     return await this.commands.objects.list(command, options);
   }
 
-  /**
-   * Get a simulated S3 Bucket instance by name.
-   */
+  /** Get a simulated S3 Bucket instance by name. */
   getSimBucketByName(
     bucketName: SimS3BucketName | string,
   ): SimS3Bucket | undefined {
@@ -247,16 +212,12 @@ export class SimS3 {
     return simS3ServiceUrl(this.accountRegionScope.regionName);
   }
 
-  /**
-   * Get the simulated S3 REST API endpoint URL for one Bucket.
-   */
+  /** Get the simulated S3 REST API endpoint URL for one Bucket. */
   getBucketUrl(bucketName: SimS3BucketName | string): URL {
     return this.bucketAccess.url(bucketName);
   }
 
-  /**
-   * Get the simulated S3 static website URL for a Bucket.
-   */
+  /** Get the simulated S3 static website URL for a Bucket. */
   getBucketWebsiteUrl(bucketName: SimS3BucketName | string): URL {
     return this.bucketAccess.websiteUrl(bucketName);
   }
@@ -272,24 +233,46 @@ export class SimS3 {
 
   /**
    * Have a simulated S3 Bucket use a local filesystem directory for storage.
+   *
+   * Passing somewhere to reload, as `{ reload: srv }`, also watches the
+   * directory: a build that writes into it reloads the connected browsers once
+   * the writes stop, without the Bucket having to be filled again.
    */
   mountBucketFilesystem(
     bucketName: SimS3BucketName | string,
     directoryPath: string,
+    options: SimS3MountFilesystemOptions = {},
   ): void {
-    this.bucketAccess.mountFilesystem(bucketName, directoryPath);
+    this.bucketAccess.mountFilesystem(bucketName, directoryPath, options);
   }
 
   /**
-   * Get this service's CloudFormation Resource factory.
+   * The mounted directories being watched for changes.
+   *
+   * A directory mounted with somewhere to reload is watched from then on, and
+   * a build in it reloads the browser rather than restarting anything.
    */
+  watchedMountedDirectories(): readonly string[] {
+    return this.bucketAccess.watchedMounts();
+  }
+
+  /**
+   * Stop watching mounted directories.
+   *
+   * A watch holds an open filesystem handle, so a process with one open does
+   * not exit on its own. A dev process wants exactly that and never calls this;
+   * anything with an end, such as a test, calls it when it is done.
+   */
+  stopWatchingMountedDirectories(): void {
+    this.bucketAccess.stopWatchingMounts();
+  }
+
+  /** Get this service's CloudFormation Resource factory. */
   cfnResourceFactory(): SimCfnServiceResourceFactory {
     return this.cfnFactory;
   }
 
-  /**
-   * Get this service's SDK Command router for SDK client interception.
-   */
+  /** Get this service's SDK Command router for SDK client interception. */
   sdkCommandRouter(): SimSdkCommandRouter {
     return this.sdkRouter;
   }

--- a/test/s3/mounted-site.ts
+++ b/test/s3/mounted-site.ts
@@ -1,0 +1,127 @@
+import { mkdir } from "node:fs/promises";
+import { SimAws } from "../../src/index.js";
+import { TemporaryDirectory } from "../../src/util/filesystem/temporary-directory.js";
+
+interface MountedSiteProperties {
+  readonly reload?: boolean;
+  readonly settleMs?: number;
+  readonly fresh?: boolean;
+}
+
+/**
+ * A directory of built files on disk, mounted into a simulated S3 Bucket.
+ *
+ * The tests around watching a mount are about what happens between a build
+ * writing files and a browser being told, so they need the real thing: a real
+ * directory, a real recursive watch on it, and a real wait for the events to
+ * arrive.
+ */
+export class MountedSite {
+  readonly simAws = new SimAws();
+
+  private readonly directory = new TemporaryDirectory();
+  private reloads = 0;
+
+  /**
+   * Mount a directory holding a built page into a Bucket.
+   */
+  static async of(
+    properties: MountedSiteProperties = {},
+  ): Promise<MountedSite> {
+    const { reload = true, settleMs = 200, fresh = false } = properties;
+    const site = new MountedSite();
+    await site.prepare(fresh);
+    await site.simAws.s3().createBucket({ input: { Bucket: "site" } });
+    site.simAws.s3().mountBucketFilesystem("site", site.path(), {
+      settleMs,
+      ...(reload && {
+        reload: {
+          reload: (): void => {
+            site.reloads += 1;
+          },
+        },
+      }),
+    });
+
+    return site;
+  }
+
+  /**
+   * The directory the Bucket is serving, which is a build output directory as
+   * filesystem storage insists on.
+   */
+  path(): string {
+    return this.directory.join("public");
+  }
+
+  /**
+   * Write a built file into the directory, as a site generator would.
+   */
+  async write(name: string, content: string): Promise<void> {
+    await this.directory.writeFile(["public", ...name.split("/")], content);
+  }
+
+  /**
+   * How many times the connected browsers have been told to reload.
+   */
+  reloadCount(): number {
+    return this.reloads;
+  }
+
+  /**
+   * Wait for the mount to have reloaded the given number of times.
+   */
+  async reloaded(count = 1, withinMs = 5000): Promise<void> {
+    const giveUpAt = Date.now() + withinMs;
+
+    while (this.reloads < count) {
+      if (Date.now() >= giveUpAt) {
+        throw new Error(
+          `Mounted site reloaded ${String(this.reloads)} times, expected ${String(count)}`,
+        );
+      }
+
+      // eslint-disable-next-line no-await-in-loop -- polling for a filesystem event
+      await mountPause(20);
+    }
+  }
+
+  /**
+   * Stop watching, so nothing is left holding the test process open.
+   */
+  stop(): void {
+    this.simAws.s3().stopWatchingMountedDirectories();
+  }
+
+  /**
+   * Get the directory into the state the mount is supposed to meet.
+   *
+   * A fresh one is mounted the moment it is made with nothing built into it,
+   * which is what macOS replays the directory's own creation at. Otherwise it
+   * holds a built page and is left to go quiet first, because a watch is also
+   * handed the events that were still in flight when it started, and those are
+   * writes that finished before the Bucket existed.
+   */
+  private async prepare(fresh: boolean): Promise<void> {
+    if (fresh) {
+      await this.directory.resolvePath();
+      // eslint-disable-next-line security/detect-non-literal-fs-filename
+      await mkdir(this.path(), { recursive: true });
+
+      return;
+    }
+
+    await this.write("index.html", "<h1>Hello</h1>");
+    await mountPause(250);
+  }
+}
+
+/**
+ * Give the filesystem events time to arrive and settle, for a test asserting
+ * that nothing happened.
+ */
+export async function mountPause(milliseconds: number): Promise<void> {
+  await new Promise((resolve) => {
+    setTimeout(resolve, milliseconds);
+  });
+}


### PR DESCRIPTION
Mounting a directory into a Bucket can now watch it and reload the connected browsers once the
writes settle, instead of every consumer hand-writing a recursive watch, a debounce and a call to
`srv.reload()`:

```typescript
simAws.s3().mountBucketFilesystem("site", "articles/public", { reload: srv });
```

- A build writing a whole tree of files is one reload, not one per file. `settleMs` lengthens the
  wait for a generator that pauses part way through.
- A mount that reloads for itself names its directory to a `yulin watch` supervisor as a **held**
  path rather than a watched one, so a rebuild reloads instead of restarting the process and taking
  every simulated Bucket, Table and Stack with it. Mounting without the option watches nothing, and
  reports the path for watching as it always did.
- The recursive watch holds the event loop open, so `stopWatchingMountedDirectories()` stops it and
  `watchedMountedDirectories()` says what is being watched. #434 can fold that into a single close
  call.

The reload target is anything with a `reload()` method, so simulated S3 does not have to reach for
the serving side to mount a directory, and a test can watch a mount without serving anything.

### The macOS replay

`fs.watch(directory, { recursive: true })` started moments after the directory was created is handed
a spurious `change` event naming the directory itself; an established directory is quiet. A mount
that reloaded for it would reload the browser for nothing every time a process that builds before it
mounts starts up. That event is dropped, and there is a test that mounts a directory the moment it
is made and then asserts a real write still reloads.

### Tests

- `sim-s3-mount-watch.loc.test.ts`: one reload after a write settles, one reload for a whole tree,
  nothing watched without the option, no reload for the directory's own creation, nothing left
  listening after the watch is closed.
- `sim-s3-mount-watches.loc.test.ts`: held path vs reported path, and a re-mounted Bucket watching
  the directory it is serving now.
- `sim-watch-reported-paths.loc.test.ts`: a real supervised process reloads rather than restarting
  when a file in its mounted directory changes.

### Note on the diff

`sim-s3.ts` was four lines under the 300 line limit, so the new methods would not fit. Its doc
comments are collapsed to single-line blocks, losing no wording, which is most of the churn in that
file.

Resolves #433
