### PR TITLE
feat: register a Hosted Zone with a chosen ID

### DIFF
--- a/docs/services/route53/README.md
+++ b/docs/services/route53/README.md
@@ -63,6 +63,66 @@ such as `Z2FDTNDATAQYW2`, can be used in your test setup. An ID with no matching
 `NoSuchHostedZone`, while a malformed one gives `InvalidInput`. Commands also accept the
 `/hostedzone/Z...` form as well as the bare ID.
 
+## Registering a Hosted Zone with a chosen ID
+
+`CreateHostedZoneCommand` allocates its own Hosted Zone ID, as real Route53 does, and takes none
+from you. When something else already decided the ID, register the Hosted Zone as part of your test
+setup instead.
+
+The usual reason is a CDK app that looks its zone up with `HostedZone.fromLookup` rather than
+creating it. That bakes the real Hosted Zone ID into the synthesized template, and every
+`AWS::Route53::RecordSet` in the template names that ID. Registering the zone first means the
+template deploys as it is, with no rewriting.
+
+```typescript sim-route53-register-hosted-zone
+/**
+ * Registering a simulated Route53 Hosted Zone with a chosen Hosted Zone ID.
+ */
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const route53 = simAws.route53();
+
+// The Hosted Zone ID a CDK HostedZone.fromLookup baked into the template.
+route53.registerHostedZone({
+  id: "Z0123456789ABCDEFGHIJ",
+  name: "example.test",
+});
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "site-stack",
+  template: {
+    Resources: {
+      SiteRecord: {
+        Type: "AWS::Route53::RecordSet",
+        Properties: {
+          HostedZoneId: "Z0123456789ABCDEFGHIJ",
+          Name: "www.example.test",
+          Type: "A",
+          TTL: "300",
+          ResourceRecords: ["192.0.2.10"],
+        },
+      },
+    },
+  },
+});
+
+await stack.waitForDeployComplete();
+await simAws.backgroundTasksComplete();
+
+console.log(stack.getResource("SiteRecord")?.status);
+```
+
+A registered Hosted Zone behaves like any other. It answers `GetHostedZoneCommand`,
+`ListHostedZonesByNameCommand` and `ChangeResourceRecordSetsCommand`, its records resolve through
+local hostname routing and simulated DNS, and it is `INSYNC` straight away, having been described as
+already existing rather than created.
+
+`registerHostedZone` takes the same optional `config` as `CreateHostedZoneCommand`, and accepts the
+`/hostedzone/Z...` form of the ID. An ID that another Hosted Zone already holds is refused with
+`HostedZoneAlreadyExists`, and one that is not a Route53 Hosted Zone ID with `InvalidInput`.
+
 ## Creating records
 
 Use `ChangeResourceRecordSetsCommand` to add records to a Hosted Zone.
@@ -878,6 +938,11 @@ try {
 This lets local integration tests use the same CDK infrastructure shape as production while keeping
 the test process local.
 
+A CDK app whose Hosted Zone comes from `HostedZone.fromLookup` names a real Hosted Zone ID
+throughout its template rather than creating the zone. Register that zone before deploying, as in
+[Registering a Hosted Zone with a chosen ID](#registering-a-hosted-zone-with-a-chosen-id), and the
+template's RecordSets find it.
+
 ## Accounts and Regions
 
 Use `SimAws` scopes to create Route53 state in different simulated Accounts and Regions.
@@ -966,6 +1031,8 @@ A standalone `SimRoute53` instance has its own isolated state and is not connect
 Sim Route53 currently supports:
 
 - `CreateHostedZoneCommand`, `GetHostedZoneCommand` and `ListHostedZonesByNameCommand`
+- Registering a Hosted Zone with a chosen Hosted Zone ID, for a zone a template looked up rather
+  than created
 - `ChangeResourceRecordSetsCommand` and `ListResourceRecordSetsCommand`
 - `CREATE`, `UPSERT` and `DELETE` record changes
 - Stored record types: `A`, `AAAA`, `CNAME`, `TXT`, `NS` and `SOA`

--- a/docs/services/route53/sim-route53-register-hosted-zone.example.ts
+++ b/docs/services/route53/sim-route53-register-hosted-zone.example.ts
@@ -1,0 +1,37 @@
+/**
+ * Registering a simulated Route53 Hosted Zone with a chosen Hosted Zone ID.
+ */
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const route53 = simAws.route53();
+
+// The Hosted Zone ID a CDK HostedZone.fromLookup baked into the template.
+route53.registerHostedZone({
+  id: "Z0123456789ABCDEFGHIJ",
+  name: "example.test",
+});
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "site-stack",
+  template: {
+    Resources: {
+      SiteRecord: {
+        Type: "AWS::Route53::RecordSet",
+        Properties: {
+          HostedZoneId: "Z0123456789ABCDEFGHIJ",
+          Name: "www.example.test",
+          Type: "A",
+          TTL: "300",
+          ResourceRecords: ["192.0.2.10"],
+        },
+      },
+    },
+  },
+});
+
+await stack.waitForDeployComplete();
+await simAws.backgroundTasksComplete();
+
+console.log(stack.getResource("SiteRecord")?.status);

--- a/src/service/route53/README.md
+++ b/src/service/route53/README.md
@@ -129,6 +129,28 @@ The creation flow is:
 
 Duplicate caller references throw `SimRoute53HostedZoneAlreadyExists`.
 
+## Registering a pre-existing Hosted Zone
+
+`SimRoute53.registerHostedZone()` stands up a Hosted Zone with a caller-chosen ID. It is a setup
+method rather than a command, in the way `SimS3.mountBucketFilesystem` is: it arranges the world in
+a way the real API has no operation for, so it stays off the command surface and `CreateHostedZone`
+keeps allocating its own ID as AWS does.
+
+It exists because a CDK app using `HostedZone.fromLookup` bakes the looked-up zone's real ID into
+the synthesized template, and every `AWS::Route53::RecordSet` names that ID. Nothing rewrites IDs as
+a template deploys, so the simulation has to be able to own the ID the template already names.
+
+`registerSimRoute53HostedZone` in `hosted-zone/` does the work. It normalizes the ID the same way
+commands do, so a malformed one is `SimRoute53InvalidInput` before any state changes, and refuses an
+ID already held with `SimRoute53HostedZoneAlreadyExists`. The zone goes into both the Account's
+hosted-zone map and `SimRoute53Registry`, which is what a created zone does and what makes DNS
+resolution work for it.
+
+A registered zone is `INSYNC` from the start through `markSynchronized()`, because there is nothing
+to synchronize: the zone is described as already existing rather than created here. Its caller
+reference is derived from its ID, since the creation that would have supplied one happened outside
+the simulation.
+
 The simulator does not currently try to emulate all AWS edge cases around duplicate zone names,
 delegation sets, private-zone VPC associations, or caller-reference replay output. The caller
 reference is mainly used to prevent accidental duplicate CloudFormation-created zones and to match

--- a/src/service/route53/cfn/record-set/sim-cfn-r53-registered-zone.iso.test.ts
+++ b/src/service/route53/cfn/record-set/sim-cfn-r53-registered-zone.iso.test.ts
@@ -1,0 +1,64 @@
+import {
+  assertArrayEquals,
+  assertArrayLength,
+  assertIdentical,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import {
+  testAnswerer,
+  testQuestion,
+} from "../../dns/answer/dns-answerer-test-query.js";
+import { dnsRcodes } from "../../dns/dns-rcode.js";
+
+// The Hosted Zone ID a CDK app using HostedZone.fromLookup bakes into every
+// RecordSet of its synthesized template.
+const lookedUpHostedZoneId = "Z0123456789ABCDEFGHIJ";
+
+describe("Route53 CloudFormation RecordSet in a registered Hosted Zone", () => {
+  it("deploys a RecordSet naming a Hosted Zone the simulation registered", async () => {
+    // Given a simulated Route53 Hosted Zone registered with a looked-up ID.
+    const simAws = new SimAws();
+
+    simAws.route53().registerHostedZone({
+      id: lookedUpHostedZoneId,
+      name: "example.com",
+    });
+
+    // When a template whose RecordSet names that Hosted Zone ID is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "route53-registered-zone-stack",
+      template: {
+        Resources: {
+          SiteRecord: {
+            Type: "AWS::Route53::RecordSet",
+            Properties: {
+              HostedZoneId: lookedUpHostedZoneId,
+              Name: "www.example.com",
+              Type: "A",
+              TTL: "300",
+              ResourceRecords: ["192.0.2.10"],
+            },
+          },
+        },
+      },
+    });
+
+    await stack.waitForDeployComplete();
+    await simAws.backgroundTasksComplete();
+
+    // Then the Stack deploys, and the record resolves through simulated DNS the
+    // same as one in a Hosted Zone the template created.
+    assertIdentical(stack.status, "CREATE_COMPLETE");
+    assertIdentical(stack.getResource("SiteRecord")?.status, "CREATE_COMPLETE");
+
+    const answer = testAnswerer(simAws).answer(
+      testQuestion("www.example.com", "A"),
+    );
+
+    assertIdentical(answer.rcode, dnsRcodes.noError);
+    assertArrayLength(answer.answers, 1);
+    assertArrayEquals([...answer.answers[0].rdata], [192, 0, 2, 10]);
+  });
+});

--- a/src/service/route53/hosted-zone/register-sim-route53-hosted-zone.iso.test.ts
+++ b/src/service/route53/hosted-zone/register-sim-route53-hosted-zone.iso.test.ts
@@ -1,0 +1,254 @@
+import {
+  assertArrayEquals,
+  assertArrayLength,
+  assertFalse,
+  assertIdentical,
+  assertInstanceOf,
+  assertMapSize,
+  assertNonNullable,
+  assertObjectMatches,
+  assertStringIncludes,
+  assertStringStartsWith,
+  assertThrowsError,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import {
+  ChangeResourceRecordSetsCommand,
+  CreateHostedZoneCommand,
+  GetHostedZoneCommand,
+  ListHostedZonesByNameCommand,
+} from "@aws-sdk/client-route-53";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import { assertIsSimRoute53HostedZoneId } from "../command/create-hosted-zone/sim-route53-zone-id.js";
+import {
+  testAnswerer,
+  testQuestion,
+} from "../dns/answer/dns-answerer-test-query.js";
+import { dnsRcodes } from "../dns/dns-rcode.js";
+import {
+  SimRoute53HostedZoneAlreadyExists,
+  SimRoute53InvalidInput,
+} from "../error/sim-route53.error.js";
+
+// A real Hosted Zone ID, of the length AWS allocates, as a CDK app that looked
+// its zone up would carry into its template.
+const lookedUpHostedZoneId = "Z0123456789ABCDEFGHIJ";
+
+describe("Registering a simulated Route53 Hosted Zone", () => {
+  it("answers GetHostedZone under the registered ID", async () => {
+    // Given a simulated Route53 service.
+    const simAws = new SimAws();
+    const simRoute53 = simAws.route53();
+
+    // When a Hosted Zone is registered with a chosen ID.
+    simRoute53.registerHostedZone({
+      id: lookedUpHostedZoneId,
+      name: "example.com",
+      config: { Comment: "Looked-up zone", PrivateZone: false },
+    });
+
+    // Then the zone is read back under that ID.
+    const hostedZoneOut = await simRoute53.getHostedZone(
+      new GetHostedZoneCommand({ Id: lookedUpHostedZoneId }),
+    );
+
+    assertObjectMatches(hostedZoneOut.HostedZone, {
+      Id: lookedUpHostedZoneId,
+      Name: "example.com.",
+      Config: { Comment: "Looked-up zone", PrivateZone: false },
+      ResourceRecordSetCount: 0,
+    });
+
+    // And it needs no background work to be synchronized, having been
+    // described as already existing rather than created here.
+    assertIsSimRoute53HostedZoneId(lookedUpHostedZoneId);
+    const hostedZone = simRoute53.hostedZones.get(lookedUpHostedZoneId);
+    assertNonNullable(hostedZone, "Registered Hosted Zone");
+    assertIdentical(hostedZone.status, "INSYNC");
+  });
+
+  it("lists the registered Hosted Zone by name", async () => {
+    // Given a simulated Route53 service.
+    const simAws = new SimAws();
+    const simRoute53 = simAws.route53();
+
+    // When a Hosted Zone is registered.
+    simRoute53.registerHostedZone({
+      id: lookedUpHostedZoneId,
+      name: "example.com",
+    });
+
+    // Then it is listed like any other Hosted Zone.
+    const listOutput = await simRoute53.listHostedZonesByName(
+      new ListHostedZonesByNameCommand({ DNSName: "example.com" }),
+    );
+
+    assertArrayLength(listOutput.HostedZones, 1);
+    assertObjectMatches(listOutput.HostedZones[0], {
+      Id: lookedUpHostedZoneId,
+      Name: "example.com.",
+    });
+  });
+
+  it("takes record-set changes and resolves them through simulated DNS", async () => {
+    // Given a registered Hosted Zone.
+    const simAws = new SimAws();
+    const simRoute53 = simAws.route53();
+
+    simRoute53.registerHostedZone({
+      id: lookedUpHostedZoneId,
+      name: "example.com",
+    });
+
+    // When a record is created in it.
+    await simRoute53.changeResourceRecordSets(
+      new ChangeResourceRecordSetsCommand({
+        HostedZoneId: lookedUpHostedZoneId,
+        ChangeBatch: {
+          Changes: [
+            {
+              Action: "CREATE",
+              ResourceRecordSet: {
+                Name: "www.example.com",
+                Type: "A",
+                TTL: 300,
+                ResourceRecords: [{ Value: "192.0.2.10" }],
+              },
+            },
+          ],
+        },
+      }),
+    );
+
+    await simAws.backgroundTasksComplete();
+
+    // Then simulated DNS answers for the record, as it would for a zone the
+    // simulation created.
+    const answer = testAnswerer(simAws).answer(
+      testQuestion("www.example.com", "A"),
+    );
+
+    assertIdentical(answer.rcode, dnsRcodes.noError);
+    assertArrayLength(answer.answers, 1);
+    assertArrayEquals([...answer.answers[0].rdata], [192, 0, 2, 10]);
+  });
+
+  it("accepts the /hostedzone/ form of the ID", async () => {
+    // Given a simulated Route53 service.
+    const simAws = new SimAws();
+    const simRoute53 = simAws.route53();
+
+    // When a Hosted Zone is registered by its prefixed ID, as a Route53
+    // response carries it.
+    simRoute53.registerHostedZone({
+      id: `/hostedzone/${lookedUpHostedZoneId}`,
+      name: "example.com",
+    });
+
+    // Then the bare ID is what the zone holds.
+    const hostedZoneOut = await simRoute53.getHostedZone(
+      new GetHostedZoneCommand({ Id: lookedUpHostedZoneId }),
+    );
+
+    assertIdentical(hostedZoneOut.HostedZone?.Id, lookedUpHostedZoneId);
+  });
+
+  it("refuses an ID another registered Hosted Zone holds", () => {
+    // Given a registered Hosted Zone.
+    const simAws = new SimAws();
+    const simRoute53 = simAws.route53();
+
+    simRoute53.registerHostedZone({
+      id: lookedUpHostedZoneId,
+      name: "example.com",
+    });
+
+    // When the same ID is registered again.
+    const error = assertThrowsError(() => {
+      simRoute53.registerHostedZone({
+        id: lookedUpHostedZoneId,
+        name: "other.example.com",
+      });
+    });
+
+    // Then the duplicate ID is refused.
+    assertInstanceOf(error, SimRoute53HostedZoneAlreadyExists);
+    assertStringIncludes(error.message, lookedUpHostedZoneId);
+  });
+
+  it("refuses an ID a created Hosted Zone already allocated", async () => {
+    // Given a Hosted Zone created through the Route53 API.
+    const simAws = new SimAws();
+    const simRoute53 = simAws.route53();
+
+    const hostedZoneCreation = await simRoute53.createHostedZone(
+      new CreateHostedZoneCommand({
+        Name: "created.example.com",
+        CallerReference: "created-zone",
+      }),
+    );
+
+    const createdHostedZoneId = hostedZoneCreation.HostedZone?.Id;
+    assertNonNullable(createdHostedZoneId, "Created Hosted Zone ID");
+
+    // When its allocated ID is registered.
+    const error = assertThrowsError(() => {
+      simRoute53.registerHostedZone({
+        id: createdHostedZoneId,
+        name: "registered.example.com",
+      });
+    });
+
+    // Then the taken ID is refused.
+    assertInstanceOf(error, SimRoute53HostedZoneAlreadyExists);
+    assertStringIncludes(error.message, createdHostedZoneId);
+  });
+
+  it("refuses an ID that is not a Route53 Hosted Zone ID", () => {
+    // Given a simulated Route53 service.
+    const simAws = new SimAws();
+    const simRoute53 = simAws.route53();
+
+    // When a malformed ID is registered.
+    const error = assertThrowsError(() => {
+      simRoute53.registerHostedZone({
+        id: "not-a-hosted-zone-id",
+        name: "example.com",
+      });
+    });
+
+    // Then the ID is refused before any zone exists to answer for it.
+    assertInstanceOf(error, SimRoute53InvalidInput);
+    assertStringIncludes(error.message, "not-a-hosted-zone-id");
+    assertMapSize(simRoute53.hostedZones, 0);
+  });
+
+  it("still allocates its own ID for a Hosted Zone CreateHostedZone makes", async () => {
+    // Given a registered Hosted Zone.
+    const simAws = new SimAws();
+    const simRoute53 = simAws.route53();
+
+    simRoute53.registerHostedZone({
+      id: lookedUpHostedZoneId,
+      name: "example.com",
+    });
+
+    // When another Hosted Zone is created through the Route53 API.
+    const hostedZoneCreation = await simRoute53.createHostedZone(
+      new CreateHostedZoneCommand({
+        Name: "created.example.com",
+        CallerReference: "created-zone",
+      }),
+    );
+
+    // Then its ID is allocated by the simulator, as real Route53 allocates it.
+    const createdHostedZoneId = hostedZoneCreation.HostedZone?.Id;
+    assertNonNullable(createdHostedZoneId, "Created Hosted Zone ID");
+    assertStringStartsWith(createdHostedZoneId, "Z");
+    assertFalse(
+      createdHostedZoneId === lookedUpHostedZoneId,
+      "Created Hosted Zone ID should not be the registered one",
+    );
+  });
+});

--- a/src/service/route53/hosted-zone/register-sim-route53-hosted-zone.ts
+++ b/src/service/route53/hosted-zone/register-sim-route53-hosted-zone.ts
@@ -1,0 +1,69 @@
+import type { SimRoute53HostedZoneConfig } from "../command/create-hosted-zone/create-hosted-zone.command.js";
+import {
+  normalizeSimRoute53HostedZoneId,
+  type SimRoute53HostedZoneId,
+} from "../command/create-hosted-zone/sim-route53-zone-id.js";
+import { SimRoute53HostedZoneAlreadyExists } from "../error/sim-route53.error.js";
+import type { SimRoute53Registry } from "../registry/sim-route53-registry.js";
+import { SimRoute53HostedZone } from "./sim-route53-hosted-zone.js";
+
+/**
+ * What a simulation says about a Hosted Zone it registers as already existing.
+ */
+export interface SimRoute53HostedZoneRegistration {
+  /**
+   * The Hosted Zone ID the simulated zone takes, in either the bare `Z...`
+   * form or the `/hostedzone/Z...` form.
+   */
+  readonly id: SimRoute53HostedZoneId | string;
+  readonly name: string;
+  readonly config?: SimRoute53HostedZoneConfig | undefined;
+}
+
+interface RegisterSimRoute53HostedZoneProperties {
+  readonly hostedZones: Map<SimRoute53HostedZoneId, SimRoute53HostedZone>;
+  readonly route53Registry: SimRoute53Registry;
+}
+
+/**
+ * Register a Hosted Zone the simulation is told already exists.
+ *
+ * Real Route53 allocates a Hosted Zone ID, so nothing on the command surface
+ * takes one. A zone a CDK app looked up rather than created is named by its
+ * real ID throughout the synthesized template, and this is how a simulation
+ * comes to own that ID before the template deploys.
+ *
+ * The zone is INSYNC from the start. There is nothing to synchronize: it is
+ * described as already existing rather than created here.
+ */
+export function registerSimRoute53HostedZone(
+  registration: SimRoute53HostedZoneRegistration,
+  properties: RegisterSimRoute53HostedZoneProperties,
+): SimRoute53HostedZone {
+  const { hostedZones, route53Registry } = properties;
+  const hostedZoneId = normalizeSimRoute53HostedZoneId(registration.id);
+
+  if (
+    hostedZones.has(hostedZoneId) ||
+    route53Registry.hostedZones.has(hostedZoneId)
+  ) {
+    throw new SimRoute53HostedZoneAlreadyExists(
+      `A sim Route53 Hosted Zone with ID ${hostedZoneId} already exists`,
+    );
+  }
+
+  const hostedZone = new SimRoute53HostedZone({
+    id: hostedZoneId,
+    name: registration.name,
+    // A registered zone has no caller reference of its own, its creation
+    // having happened elsewhere, so its ID stands in as the unique one.
+    callerReference: `registered-${hostedZoneId}`,
+    config: registration.config,
+  });
+  hostedZone.markSynchronized();
+
+  hostedZones.set(hostedZoneId, hostedZone);
+  route53Registry.registerHostedZone(hostedZoneId, hostedZone);
+
+  return hostedZone;
+}

--- a/src/service/route53/hosted-zone/sim-route53-hosted-zone.ts
+++ b/src/service/route53/hosted-zone/sim-route53-hosted-zone.ts
@@ -150,7 +150,17 @@ export class SimRoute53HostedZone {
    * Move the sim Hosted Zone into INSYNC status.
    */
   completeSynchronization(): Promise<void> {
-    this.#status = "INSYNC";
+    this.markSynchronized();
     return Promise.resolve();
+  }
+
+  /**
+   * Put the sim Hosted Zone into INSYNC status without awaiting anything.
+   *
+   * A zone registered as already existing has no synchronization to wait for,
+   * and setup methods are not asynchronous.
+   */
+  markSynchronized(): void {
+    this.#status = "INSYNC";
   }
 }

--- a/src/service/route53/index.ts
+++ b/src/service/route53/index.ts
@@ -1,1 +1,2 @@
 export { SimRoute53 } from "./sim-route53.js";
+export { type SimRoute53HostedZoneRegistration } from "./hosted-zone/register-sim-route53-hosted-zone.js";

--- a/src/service/route53/sim-route53.ts
+++ b/src/service/route53/sim-route53.ts
@@ -6,6 +6,10 @@ import type {
   SimCreateHostedZoneCommandOutput,
 } from "./command/create-hosted-zone/create-hosted-zone.command.js";
 import type { SimRoute53HostedZone } from "./hosted-zone/sim-route53-hosted-zone.js";
+import {
+  registerSimRoute53HostedZone,
+  type SimRoute53HostedZoneRegistration,
+} from "./hosted-zone/register-sim-route53-hosted-zone.js";
 import type { SimRoute53HostedZoneId } from "./command/create-hosted-zone/sim-route53-zone-id.js";
 import type {
   SimGetHostedZoneCommand,
@@ -104,6 +108,25 @@ export class SimRoute53 {
       route53Registry: this.route53Registry,
     });
     return await handler.handle(command, options);
+  }
+
+  /**
+   * Register a Hosted Zone that already exists, with an ID of your choosing.
+   *
+   * `CreateHostedZone` allocates its own ID, as real Route53 does, so this is
+   * the way to stand up a zone a template already names: a CDK app using
+   * `HostedZone.fromLookup` bakes that zone's real ID into every RecordSet it
+   * synthesizes. A registered zone answers Route53 commands and resolves
+   * through simulated DNS the same as one the simulation created.
+   *
+   * An ID another Hosted Zone holds, or one that is not a Route53 Hosted Zone
+   * ID, is refused.
+   */
+  registerHostedZone(registration: SimRoute53HostedZoneRegistration): void {
+    registerSimRoute53HostedZone(registration, {
+      hostedZones: this.hostedZones,
+      route53Registry: this.route53Registry,
+    });
   }
 
   /**


### PR DESCRIPTION
A CDK app using `HostedZone.fromLookup` bakes the looked-up zone's real Hosted Zone ID into its
synthesized template, and every `AWS::Route53::RecordSet` names that ID. The shape was already
accepted, but nothing owned the ID: `changeResourceRecordSets` found no zone, the RecordSet went
`CREATE_FAILED`, and the Stack failed with it.

`SimRoute53.registerHostedZone({ id, name })` stands a Hosted Zone up with a caller-chosen ID. It is
a setup method rather than a command, in the way `SimS3.mountBucketFilesystem` is: it arranges the
world in a way the real API has no operation for, so `CreateHostedZone` keeps allocating its own ID
and taking none from the caller, as AWS does.

`registerSimRoute53HostedZone` normalizes the ID the way commands do, so the `/hostedzone/Z...` form
works and a malformed one is `InvalidInput` before any state changes, and refuses an ID already held
with `HostedZoneAlreadyExists`. The zone goes into both the Account's hosted-zone map and
`SimRoute53Registry`, which is what makes it answer `GetHostedZone`, `ListHostedZonesByName` and
`ChangeResourceRecordSets` and resolve through simulated DNS the same as a zone a template created.
It is `INSYNC` from the start, having been described as already existing rather than created here.

Tested through the Route53 commands, through simulated DNS, and by deploying a template whose
RecordSet names the registered ID. Docs and both READMEs updated.

Resolves #435