### PR TITLE
fix: let the reloading event out before closing

### DIFF
--- a/docs/serve/README.md
+++ b/docs/serve/README.md
@@ -20,7 +20,7 @@ const srv = await serveSimAws({ simAws, port: 8787 });
 
 console.log(srv.port); // "8787"
 
-srv.close();
+await srv.close();
 ```
 
 Without a `port` the server takes whatever port is free, which changes on every run. Pin one when
@@ -48,14 +48,16 @@ console.log(srv.localUrl(websiteUrl).toString());
 // http://foo-site.s3-website.us-east-1.sim-aws.localhost:<srv.port>/
 // with whatever port this run took, since none was pinned.
 
-srv.close();
+await srv.close();
 ```
 
 ## Stopping and restarting
 
-`close()` stops serving and ends the connections the server is holding, so the process can exit.
-Yulin installs no signal handlers, since a library taking over process signals gets in the way of
-whatever else the process is doing. Call `close()` from your own handler:
+`close()` stops serving and ends the connections the server is holding, so the process can exit. It
+returns a promise that settles once the last thing the server had to say has gone, so a script that
+means to exit rather than let the event loop empty has something to wait for. Yulin installs no
+signal handlers, since a library taking over process signals gets in the way of whatever else the
+process is doing. Call `close()` from your own handler:
 
 ```typescript sim-serve-shutdown
 /**
@@ -66,8 +68,14 @@ import { serveSimAws } from "@kensio/yulin/serve";
 
 const srv = await serveSimAws({ port: 8787 });
 
+async function stopServing(): Promise<void> {
+  // Waiting means anything the server still had to say has gone before the
+  // process does.
+  await srv.close();
+}
+
 process.on("SIGTERM", () => {
-  srv.close();
+  void stopServing();
 });
 ```
 
@@ -96,8 +104,13 @@ const srv = await serveSimAws({ simAws, port: 8787, liveReload: true });
 
 // Build the simulated environment the pages are served from here.
 
+async function stopServing(): Promise<void> {
+  // Waiting means the browsers hear about the restart before the process goes.
+  await srv.close();
+}
+
 process.on("SIGTERM", () => {
-  srv.close();
+  void stopServing();
 });
 ```
 
@@ -124,6 +137,12 @@ html[data-sim-aws-live-reload="reloading"] {
   opacity: 0.6;
 }
 ```
+
+The event has to reach the browser before the connection does, so `close()` sees the reload streams
+out before it destroys anything else the server was holding, and its promise settles once they have
+gone. A browser that has stopped answering is waited on for half a second and then dropped, so a page
+nobody is looking at cannot hold up a restart. Both ports are released before any of that waiting, so
+a replacement process can take them straight away either way.
 
 This works with no supervisor process involved, so a dev script started from an IDE debugger gets
 browser reload with the debugger attached throughout.
@@ -157,7 +176,7 @@ await simAws.s3().putObject(
 
 srv.reload();
 
-srv.close();
+await srv.close();
 ```
 
 `reload()` throws when live reload is off, rather than quietly doing nothing.

--- a/docs/serve/sim-serve-live-reload.example.ts
+++ b/docs/serve/sim-serve-live-reload.example.ts
@@ -11,6 +11,11 @@ const srv = await serveSimAws({ simAws, port: 8787, liveReload: true });
 
 // Build the simulated environment the pages are served from here.
 
+async function stopServing(): Promise<void> {
+  // Waiting means the browsers hear about the restart before the process goes.
+  await srv.close();
+}
+
 process.on("SIGTERM", () => {
-  srv.close();
+  void stopServing();
 });

--- a/docs/serve/sim-serve-local-url.example.ts
+++ b/docs/serve/sim-serve-local-url.example.ts
@@ -16,4 +16,4 @@ console.log(srv.localUrl(websiteUrl).toString());
 // http://foo-site.s3-website.us-east-1.sim-aws.localhost:<srv.port>/
 // with whatever port this run took, since none was pinned.
 
-srv.close();
+await srv.close();

--- a/docs/serve/sim-serve-localhost.example.ts
+++ b/docs/serve/sim-serve-localhost.example.ts
@@ -10,4 +10,4 @@ const srv = await serveSimAws({ simAws, port: 8787 });
 
 console.log(srv.port); // "8787"
 
-srv.close();
+await srv.close();

--- a/docs/serve/sim-serve-reload.example.ts
+++ b/docs/serve/sim-serve-reload.example.ts
@@ -21,4 +21,4 @@ await simAws.s3().putObject(
 
 srv.reload();
 
-srv.close();
+await srv.close();

--- a/docs/serve/sim-serve-shutdown.example.ts
+++ b/docs/serve/sim-serve-shutdown.example.ts
@@ -6,6 +6,12 @@ import { serveSimAws } from "@kensio/yulin/serve";
 
 const srv = await serveSimAws({ port: 8787 });
 
+async function stopServing(): Promise<void> {
+  // Waiting means anything the server still had to say has gone before the
+  // process does.
+  await srv.close();
+}
+
 process.on("SIGTERM", () => {
-  srv.close();
+  void stopServing();
 });

--- a/docs/services/apigatewayv2/README.md
+++ b/docs/services/apigatewayv2/README.md
@@ -143,7 +143,7 @@ const response = await fetch(srv.localUrl(`${ApiEndpoint}/orders?limit=10`));
 console.log(response.status);
 console.log(await response.text());
 
-srv.close();
+await srv.close();
 ```
 
 The `$default` route matches any method and path, so every request to the endpoint reaches the
@@ -358,7 +358,7 @@ const response = await fetch(srv.localUrl(`${ApiEndpoint}/dev/pets/6`));
 
 console.log(await response.json());
 
-srv.close();
+await srv.close();
 ```
 
 That handler reports four fields of its event, so the response body it produces is:
@@ -557,7 +557,7 @@ const expired = await fetch(url, {
 
 console.log(expired.status); // 401
 
-srv.close();
+await srv.close();
 ```
 
 The verification is real. The token is parsed, its `alg` has to be `RS256`, its `kid` has to name a
@@ -797,7 +797,7 @@ const reporter = await fetch(url, {
 
 console.log(await reporter.text()); // "orders for arn:aws:iam::888888888888:role/Reporter"
 
-srv.close();
+await srv.close();
 ```
 
 ### What a refused request gets back
@@ -983,7 +983,7 @@ const admitted = await fetch(url, { headers: { cookie: "session=valid" } });
 
 console.log(await admitted.text()); // '{"tenant":"acme"}'
 
-srv.close();
+await srv.close();
 ```
 
 The authorizer function is invoked once per request reaching the route. Nothing is cached between
@@ -1208,7 +1208,7 @@ await simAws.clock().advanceBy({ minutes: 6 });
 
 console.log(await call()); // { invocations: 2 }
 
-srv.close();
+await srv.close();
 ```
 
 A refusal is held the same way an admission is, so a session the authorizer rejected stays rejected
@@ -1518,7 +1518,7 @@ const response = await fetch(srv.localUrl(`${ApiEndpoint}/orders/42`));
 
 console.log(await response.text()); // "order 42"
 
-srv.close();
+await srv.close();
 ```
 
 The API is named by `info.title`. `uri` is read as either the long
@@ -1754,7 +1754,7 @@ const response = await fetch(srv.localUrl(`${apiEndpoint}/orders`));
 console.log(response.status);
 console.log(await response.text());
 
-srv.close();
+await srv.close();
 ```
 
 Every property outside the simulated set is left out of what is created and recorded in

--- a/docs/services/apigatewayv2/sim-apigatewayv2-cloudformation.example.ts
+++ b/docs/services/apigatewayv2/sim-apigatewayv2-cloudformation.example.ts
@@ -109,4 +109,4 @@ const response = await fetch(srv.localUrl(`${apiEndpoint}/orders`));
 console.log(response.status);
 console.log(await response.text());
 
-srv.close();
+await srv.close();

--- a/docs/services/apigatewayv2/sim-apigatewayv2-iam-authorizer.example.ts
+++ b/docs/services/apigatewayv2/sim-apigatewayv2-iam-authorizer.example.ts
@@ -124,4 +124,4 @@ const reporter = await fetch(url, {
 
 console.log(await reporter.text()); // "orders for arn:aws:iam::888888888888:role/Reporter"
 
-srv.close();
+await srv.close();

--- a/docs/services/apigatewayv2/sim-apigatewayv2-jwt-authorizer.example.ts
+++ b/docs/services/apigatewayv2/sim-apigatewayv2-jwt-authorizer.example.ts
@@ -157,4 +157,4 @@ const expired = await fetch(url, {
 
 console.log(expired.status); // 401
 
-srv.close();
+await srv.close();

--- a/docs/services/apigatewayv2/sim-apigatewayv2-lambda-authorizer-cache.example.ts
+++ b/docs/services/apigatewayv2/sim-apigatewayv2-lambda-authorizer-cache.example.ts
@@ -130,4 +130,4 @@ await simAws.clock().advanceBy({ minutes: 6 });
 
 console.log(await call()); // { invocations: 2 }
 
-srv.close();
+await srv.close();

--- a/docs/services/apigatewayv2/sim-apigatewayv2-lambda-authorizer.example.ts
+++ b/docs/services/apigatewayv2/sim-apigatewayv2-lambda-authorizer.example.ts
@@ -126,4 +126,4 @@ const admitted = await fetch(url, { headers: { cookie: "session=valid" } });
 
 console.log(await admitted.text()); // '{"tenant":"acme"}'
 
-srv.close();
+await srv.close();

--- a/docs/services/apigatewayv2/sim-apigatewayv2-lambda-proxy.example.ts
+++ b/docs/services/apigatewayv2/sim-apigatewayv2-lambda-proxy.example.ts
@@ -78,4 +78,4 @@ const response = await fetch(srv.localUrl(`${ApiEndpoint}/orders?limit=10`));
 console.log(response.status);
 console.log(await response.text());
 
-srv.close();
+await srv.close();

--- a/docs/services/apigatewayv2/sim-apigatewayv2-openapi.example.ts
+++ b/docs/services/apigatewayv2/sim-apigatewayv2-openapi.example.ts
@@ -85,4 +85,4 @@ const response = await fetch(srv.localUrl(`${ApiEndpoint}/orders/42`));
 
 console.log(await response.text()); // "order 42"
 
-srv.close();
+await srv.close();

--- a/docs/services/apigatewayv2/sim-apigatewayv2-routes.example.ts
+++ b/docs/services/apigatewayv2/sim-apigatewayv2-routes.example.ts
@@ -89,4 +89,4 @@ const response = await fetch(srv.localUrl(`${ApiEndpoint}/dev/pets/6`));
 
 console.log(await response.json());
 
-srv.close();
+await srv.close();

--- a/docs/services/cloudformation/README.md
+++ b/docs/services/cloudformation/README.md
@@ -1174,7 +1174,7 @@ try {
   console.log(response.status);
   console.log(await response.text());
 } finally {
-  srv.close();
+  await srv.close();
 }
 ```
 
@@ -1339,7 +1339,7 @@ try {
   console.log(response.status);
   console.log(response.headers.get("location"));
 } finally {
-  srv.close();
+  await srv.close();
 }
 ```
 
@@ -1475,7 +1475,7 @@ try {
   console.log(response.status);
   console.log(await response.text());
 } finally {
-  srv.close();
+  await srv.close();
 }
 ```
 

--- a/docs/services/cloudformation/sim-cloudformation-cdk-bucket-deployment.example.ts
+++ b/docs/services/cloudformation/sim-cloudformation-cdk-bucket-deployment.example.ts
@@ -20,5 +20,5 @@ try {
   console.log(response.status);
   console.log(await response.text());
 } finally {
-  srv.close();
+  await srv.close();
 }

--- a/docs/services/cloudformation/sim-cloudformation-cloudfront-function-binding.example.ts
+++ b/docs/services/cloudformation/sim-cloudformation-cloudfront-function-binding.example.ts
@@ -60,5 +60,5 @@ try {
   console.log(response.status);
   console.log(response.headers.get("location"));
 } finally {
-  srv.close();
+  await srv.close();
 }

--- a/docs/services/cloudformation/sim-cloudformation-serve-localhost.example.ts
+++ b/docs/services/cloudformation/sim-cloudformation-serve-localhost.example.ts
@@ -66,5 +66,5 @@ try {
   console.log(response.status);
   console.log(await response.text());
 } finally {
-  srv.close();
+  await srv.close();
 }

--- a/docs/services/cloudfront/README.md
+++ b/docs/services/cloudfront/README.md
@@ -154,7 +154,7 @@ try {
   console.log(missing.status); // 404
   console.log(await missing.text()); // <h1>Page not found</h1>
 } finally {
-  srv.close();
+  await srv.close();
 }
 ```
 
@@ -250,7 +250,7 @@ try {
   console.log(response.status);
   console.log(await response.text());
 } finally {
-  srv.close();
+  await srv.close();
 }
 ```
 
@@ -405,7 +405,7 @@ try {
   console.log(await page.text());
   console.log(await things.text());
 } finally {
-  srv.close();
+  await srv.close();
 }
 ```
 
@@ -713,7 +713,7 @@ try {
   console.log(response.status);
   console.log(response.headers.get("location"));
 } finally {
-  srv.close();
+  await srv.close();
 }
 ```
 

--- a/docs/services/cloudfront/serve-sim-cloudfront-localhost.example.ts
+++ b/docs/services/cloudfront/serve-sim-cloudfront-localhost.example.ts
@@ -63,5 +63,5 @@ try {
   console.log(response.status);
   console.log(await response.text());
 } finally {
-  srv.close();
+  await srv.close();
 }

--- a/docs/services/cloudfront/sim-cloudfront-distribution-custom-origin.example.ts
+++ b/docs/services/cloudfront/sim-cloudfront-distribution-custom-origin.example.ts
@@ -133,5 +133,5 @@ try {
   console.log(await page.text());
   console.log(await things.text());
 } finally {
-  srv.close();
+  await srv.close();
 }

--- a/docs/services/cloudfront/sim-cloudfront-function.example.ts
+++ b/docs/services/cloudfront/sim-cloudfront-function.example.ts
@@ -100,5 +100,5 @@ try {
   console.log(response.status);
   console.log(response.headers.get("location"));
 } finally {
-  srv.close();
+  await srv.close();
 }

--- a/docs/services/cloudfront/sim-cloudfront-static-site.example.ts
+++ b/docs/services/cloudfront/sim-cloudfront-static-site.example.ts
@@ -81,5 +81,5 @@ try {
   console.log(missing.status); // 404
   console.log(await missing.text()); // <h1>Page not found</h1>
 } finally {
-  srv.close();
+  await srv.close();
 }

--- a/docs/services/cognito/README.md
+++ b/docs/services/cognito/README.md
@@ -1277,7 +1277,7 @@ try {
 
   console.log(payload.username); // "alice"
 } finally {
-  srv.close();
+  await srv.close();
 }
 ```
 

--- a/docs/services/cognito/sim-cognito-serve-jwks.example.ts
+++ b/docs/services/cognito/sim-cognito-serve-jwks.example.ts
@@ -77,5 +77,5 @@ try {
 
   console.log(payload.username); // "alice"
 } finally {
-  srv.close();
+  await srv.close();
 }

--- a/docs/services/iam/README.md
+++ b/docs/services/iam/README.md
@@ -520,7 +520,7 @@ try {
   // caller-header
   console.log(response.headers.get("x-sim-aws-auth"));
 } finally {
-  srv.close();
+  await srv.close();
 }
 ```
 

--- a/docs/services/iam/sim-iam-served-request-caller.example.ts
+++ b/docs/services/iam/sim-iam-served-request-caller.example.ts
@@ -40,5 +40,5 @@ try {
   // caller-header
   console.log(response.headers.get("x-sim-aws-auth"));
 } finally {
-  srv.close();
+  await srv.close();
 }

--- a/docs/services/lambda/README.md
+++ b/docs/services/lambda/README.md
@@ -1050,7 +1050,7 @@ try {
   console.log(response.status);
   console.log(await response.text());
 } finally {
-  srv.close();
+  await srv.close();
 }
 ```
 
@@ -1210,7 +1210,7 @@ try {
   console.log(allowed.status); // 200
   console.log(await allowed.text()); // called by arn:aws:iam::888888888888:role/Reporter
 } finally {
-  srv.close();
+  await srv.close();
 }
 ```
 
@@ -1637,7 +1637,7 @@ try {
 
   console.log(await response.text());
 } finally {
-  srv.close();
+  await srv.close();
 }
 ```
 

--- a/docs/services/lambda/sim-lambda-cloudformation-function-url.example.ts
+++ b/docs/services/lambda/sim-lambda-cloudformation-function-url.example.ts
@@ -66,5 +66,5 @@ try {
 
   console.log(await response.text());
 } finally {
-  srv.close();
+  await srv.close();
 }

--- a/docs/services/lambda/sim-lambda-function-url-iam-auth.example.ts
+++ b/docs/services/lambda/sim-lambda-function-url-iam-auth.example.ts
@@ -85,5 +85,5 @@ try {
   console.log(allowed.status); // 200
   console.log(await allowed.text()); // called by arn:aws:iam::888888888888:role/Reporter
 } finally {
-  srv.close();
+  await srv.close();
 }

--- a/docs/services/lambda/sim-lambda-function-url.example.ts
+++ b/docs/services/lambda/sim-lambda-function-url.example.ts
@@ -51,5 +51,5 @@ try {
   console.log(response.status);
   console.log(await response.text());
 } finally {
-  srv.close();
+  await srv.close();
 }

--- a/docs/services/route53/README.md
+++ b/docs/services/route53/README.md
@@ -551,7 +551,7 @@ try {
 
   console.log(addresses); // [ '192.0.2.10' ]
 } finally {
-  srv.close();
+  await srv.close();
 }
 ```
 
@@ -722,7 +722,7 @@ try {
   console.log(response.status);
   console.log(await response.text());
 } finally {
-  srv.close();
+  await srv.close();
 }
 ```
 
@@ -871,7 +871,7 @@ try {
   console.log(response.status);
   console.log(await response.text());
 } finally {
-  srv.close();
+  await srv.close();
 }
 ```
 

--- a/docs/services/route53/sim-route53-cdk-template-file.example.ts
+++ b/docs/services/route53/sim-route53-cdk-template-file.example.ts
@@ -27,5 +27,5 @@ try {
   console.log(response.status);
   console.log(await response.text());
 } finally {
-  srv.close();
+  await srv.close();
 }

--- a/docs/services/route53/sim-route53-cloudfront-localhost.example.ts
+++ b/docs/services/route53/sim-route53-cloudfront-localhost.example.ts
@@ -100,5 +100,5 @@ try {
   console.log(response.status);
   console.log(await response.text());
 } finally {
-  srv.close();
+  await srv.close();
 }

--- a/docs/services/route53/sim-route53-dns-resolver.example.ts
+++ b/docs/services/route53/sim-route53-dns-resolver.example.ts
@@ -53,5 +53,5 @@ try {
 
   console.log(addresses); // [ '192.0.2.10' ]
 } finally {
-  srv.close();
+  await srv.close();
 }

--- a/docs/services/s3/README.md
+++ b/docs/services/s3/README.md
@@ -1148,7 +1148,7 @@ try {
   console.log(response.headers.get("content-type"));
   console.log(await response.text());
 } finally {
-  srv.close();
+  await srv.close();
 }
 ```
 
@@ -1253,7 +1253,7 @@ try {
   console.log(response.status);
   console.log(await response.text());
 } finally {
-  srv.close();
+  await srv.close();
 }
 ```
 

--- a/docs/services/s3/sim-s3-presigned-url.example.ts
+++ b/docs/services/s3/sim-s3-presigned-url.example.ts
@@ -76,5 +76,5 @@ try {
   console.log(response.status);
   console.log(await response.text());
 } finally {
-  srv.close();
+  await srv.close();
 }

--- a/docs/services/s3/sim-s3-serve-localhost.example.ts
+++ b/docs/services/s3/sim-s3-serve-localhost.example.ts
@@ -79,5 +79,5 @@ try {
   console.log(response.headers.get("content-type"));
   console.log(await response.text());
 } finally {
-  srv.close();
+  await srv.close();
 }

--- a/src/serve/dns/sim-aws-dns-server.loc.test.ts
+++ b/src/serve/dns/sim-aws-dns-server.loc.test.ts
@@ -124,8 +124,8 @@ describe("Simulated AWS DNS server", () => {
     resolver.setServers([`127.0.0.1:${server.dnsPort}`]);
   });
 
-  afterAll(() => {
-    server.close();
+  afterAll(async () => {
+    await server.close();
   });
 
   it("resolves a simulated Route53 name with a real DNS client", async () => {

--- a/src/serve/http/live-reload/sim-live-reload-client.ts
+++ b/src/serve/http/live-reload/sim-live-reload-client.ts
@@ -1,4 +1,6 @@
+import { once } from "node:events";
 import type { ServerResponse } from "node:http";
+import type { Socket } from "node:net";
 import { simLiveReloadConfig } from "./sim-live-reload.config.js";
 
 /**
@@ -36,15 +38,32 @@ export class SimLiveReloadClient {
   }
 
   /**
-   * Finish the stream, so the browser reconnects rather than waiting on a
-   * connection nothing is going to answer on.
+   * Finish the stream and see its connection out, so the browser reconnects
+   * rather than waiting on a connection nothing is going to answer on.
+   *
+   * Waiting is what makes the last event readable. A socket destroyed with
+   * bytes still in flight is reset rather than closed, and a reset tells the
+   * peer to throw away what it has received but not yet handed to the page,
+   * which is the event that was just written. Ending the socket puts a normal
+   * close after the bytes instead, and resolving once it has gone leaves the
+   * server nothing left to destroy.
    */
-  end(): void {
-    if (this.response.writableEnded) {
+  async end(): Promise<void> {
+    const { socket } = this.response;
+
+    if (!this.response.writableEnded) {
+      await new Promise<void>((resolve) => {
+        this.response.end(resolve);
+      });
+    }
+
+    if (socket === null || socket.destroyed) {
       return;
     }
 
-    this.response.end();
+    socket.end();
+
+    await this.closed(socket);
   }
 
   /**
@@ -52,6 +71,22 @@ export class SimLiveReloadClient {
    */
   onClose(listener: () => void): void {
     this.response.on("close", listener);
+  }
+
+  /**
+   * Wait for a connection to go, giving up on a browser that is no longer
+   * answering rather than holding the process open for it.
+   */
+  private async closed(socket: Socket): Promise<void> {
+    try {
+      await once(socket, "close", {
+        signal: AbortSignal.timeout(simLiveReloadConfig.stoppingCloseMs),
+      });
+    } catch {
+      // Either the connection failed on its way out or the browser never
+      // answered. Nothing is owed to a page that is not there, and the server
+      // destroys whatever is left of the connection anyway.
+    }
   }
 
   private write(chunk: string): void {

--- a/src/serve/http/live-reload/sim-live-reload.config.ts
+++ b/src/serve/http/live-reload/sim-live-reload.config.ts
@@ -11,6 +11,12 @@ export const simLiveReloadConfig = {
   // several seconds, which is the gap between a restarted process being ready
   // and the page noticing.
   clientRetryMs: 500,
+  // How long a stopping server gives a reload connection to go of its own
+  // accord before the socket is destroyed. Loopback needs a fraction of this,
+  // so it is only reached by a browser that has stopped answering, and reaching
+  // it costs nothing beyond the wait: the ports are already released and the
+  // socket is destroyed either way.
+  stoppingCloseMs: 500,
 };
 
 /**

--- a/src/serve/http/live-reload/sim-live-reload.iso.test.ts
+++ b/src/serve/http/live-reload/sim-live-reload.iso.test.ts
@@ -99,14 +99,14 @@ describe("SimLiveReload", () => {
     assertStringIncludes(second.written(), "event: reload");
   });
 
-  it("says a reload is coming, then ends the connection", () => {
+  it("says a reload is coming, then ends the connection", async () => {
     // Given a connected browser
     const liveReload = new SimLiveReload({ bootId });
     const response = new FakeServerResponse();
     liveReload.connect(response.asNodeResponse());
 
     // When the server is stopping
-    liveReload.stopping();
+    await liveReload.stopping();
 
     // Then the browser hears about it and is let go, so it reconnects
     assertStringIncludes(response.written(), "event: reloading");
@@ -144,7 +144,7 @@ describe("SimLiveReload", () => {
     assertIdentical(response.written(), onConnect);
   });
 
-  it("leaves a finished connection alone when stopping", () => {
+  it("leaves a finished connection alone when stopping", async () => {
     // Given a connected browser whose response has already finished
     const liveReload = new SimLiveReload({ bootId });
     const response = new FakeServerResponse();
@@ -153,7 +153,7 @@ describe("SimLiveReload", () => {
     const onConnect = response.written();
 
     // When the server stops
-    liveReload.stopping();
+    await liveReload.stopping();
 
     // Then there is nothing to say to it and nothing to end
     assertIdentical(response.written(), onConnect);
@@ -172,6 +172,9 @@ class FakeServerResponse extends EventEmitter {
   status = 0;
   headers: Record<string, string> = {};
   writableEnded = false;
+  // No socket, as a response that never went over one has none, which is what
+  // tells the channel there is no connection to see out.
+  readonly socket = null;
 
   private readonly chunks: string[] = [];
 
@@ -188,8 +191,9 @@ class FakeServerResponse extends EventEmitter {
     return true;
   }
 
-  end(): void {
+  end(onFinished?: () => void): void {
     this.writableEnded = true;
+    onFinished?.();
   }
 
   written(): string {

--- a/src/serve/http/live-reload/sim-live-reload.loc.test.ts
+++ b/src/serve/http/live-reload/sim-live-reload.loc.test.ts
@@ -1,6 +1,7 @@
 import { GetObjectCommand } from "@aws-sdk/client-s3";
 import {
   assertIdentical,
+  assertStringEndsWith,
   assertStringIncludes,
   assertStringLength,
   assertThrowsError,
@@ -10,6 +11,7 @@ import { SimAws } from "../../../service/aws/sim-aws.js";
 import { serveSimAws } from "../local-server/sim-aws-local-server.js";
 import { simLiveReloadHeaderName } from "./sim-live-reload.config.js";
 import { SimLiveReloadChannel } from "../../../../test/serve/live-reload-channel.js";
+import { SimLiveReloadSocket } from "../../../../test/serve/live-reload-socket.js";
 import {
   simBrowserFetch,
   simServedSite,
@@ -37,7 +39,7 @@ describe("Live reload over a local server", () => {
       assertIdentical(await response.text(), page);
       assertIdentical(response.headers.get(simLiveReloadHeaderName), null);
     } finally {
-      server.close();
+      await server.close();
     }
   });
 
@@ -69,7 +71,7 @@ describe("Live reload over a local server", () => {
         String(Buffer.byteLength(body)),
       );
     } finally {
-      server.close();
+      await server.close();
     }
   });
 
@@ -90,7 +92,7 @@ describe("Live reload over a local server", () => {
       // Then it gets what was stored, with nothing injected
       assertIdentical(await output.Body?.transformToString(), page);
     } finally {
-      server.close();
+      await server.close();
     }
   });
 
@@ -109,7 +111,7 @@ describe("Live reload over a local server", () => {
       assertStringLength(event.data, 36);
       channel.close();
     } finally {
-      server.close();
+      await server.close();
     }
   });
 
@@ -129,7 +131,7 @@ describe("Live reload over a local server", () => {
       assertIdentical(event.event, "reload");
       channel.close();
     } finally {
-      server.close();
+      await server.close();
     }
   });
 
@@ -140,12 +142,60 @@ describe("Live reload over a local server", () => {
     await channel.nextEvent();
 
     // When the server closes, as it does on the way to a restart
-    server.close();
+    await server.close();
 
     // Then the browser hears that rather than only losing the connection
     const event = await channel.nextEvent();
     assertIdentical(event.event, "reloading");
     channel.close();
+  });
+
+  it("says a reload is coming to a browser reading over a socket", async () => {
+    // Given a browser on a real socket, holding bytes it has not read yet, the
+    // way one does between the server sending an event and the page seeing it
+    const server = await serveSimAws({ liveReload: true });
+    const channel = await SimLiveReloadSocket.open(server);
+    channel.stopReading();
+
+    // When the server closes, as it does on the way to a restart
+    await server.close();
+
+    // Then the event survives the connection going, and the stream is finished
+    // rather than cut off, so the browser reconnects
+    const stream = await channel.readToEnd();
+    assertStringIncludes(stream, "event: reloading");
+    assertStringEndsWith(stream, "0\r\n\r\n");
+  });
+
+  it("has the event out of the process by the time closing settles", async () => {
+    // Given a browser connected to the reload channel over a real socket
+    const server = await serveSimAws({ liveReload: true });
+    const channel = await SimLiveReloadSocket.open(server);
+
+    // When the server closes and the caller waits for it, as a script that
+    // means to exit rather than let the event loop empty has to
+    await server.close();
+
+    // Then the browser already has the event, so exiting now costs it nothing
+    assertStringIncludes(channel.read(), "event: reloading");
+    channel.close();
+  });
+
+  it("closes twice with no browser connected", async () => {
+    // Given a server with live reload on, on a pinned port, and nothing
+    // connected to it
+    const server = await serveSimAws({ liveReload: true });
+    const pinnedPort = Number(server.port);
+
+    // When it is closed, and closed again, as a handler that fires twice does
+    await server.close();
+    await server.close();
+
+    // Then both completed and the port went with the first, so waiting on the
+    // reload streams costs nothing when there are none
+    const replacement = await serveSimAws({ port: pinnedPort });
+    assertIdentical(replacement.port, String(pinnedPort));
+    await replacement.close();
   });
 
   it("refuses reload() when live reload is off", async () => {
@@ -161,7 +211,7 @@ describe("Live reload over a local server", () => {
       // Then it says what to turn on
       assertStringIncludes(error.message, "{ liveReload: true }");
     } finally {
-      server.close();
+      await server.close();
     }
   });
 });

--- a/src/serve/http/live-reload/sim-live-reload.ts
+++ b/src/serve/http/live-reload/sim-live-reload.ts
@@ -84,15 +84,17 @@ export class SimLiveReload {
    * The page learns that the gap it is about to see is a restart rather than a
    * server that has died. Ending the connections rather than leaving them for
    * the browser to notice is what makes the reconnection prompt.
+   *
+   * Resolves once the connections have gone, so a caller closing a server has
+   * something to wait for before destroying sockets or leaving the process.
    */
-  stopping(): void {
+  async stopping(): Promise<void> {
     this.send("reloading");
 
-    for (const client of this.clients) {
-      client.end();
-    }
-
+    const leaving = [...this.clients];
     this.clients.clear();
+
+    await Promise.all(leaving.map((client) => client.end()));
   }
 
   private send(event: string): void {

--- a/src/serve/http/live-reload/sim-local-live-reload.iso.test.ts
+++ b/src/serve/http/live-reload/sim-local-live-reload.iso.test.ts
@@ -68,7 +68,7 @@ describe("SimLocalLiveReload", () => {
     assertStringIncludes(page.written(), "event: reloading");
   });
 
-  it("stops listening for a supervisor once the server has closed", () => {
+  it("stops listening for a supervisor once the server has closed", async () => {
     // Given a page that was connected to a server which has since closed
     vi.spyOn(console, "warn").mockImplementation(() => undefined);
     const host = new FakeProcess();
@@ -79,7 +79,7 @@ describe("SimLocalLiveReload", () => {
     liveReload.serving("8787");
     const page = new FakeServerResponse();
     liveReload.channel()?.connect(page.asNodeResponse());
-    liveReload.stopping();
+    await liveReload.stopping();
     const afterClosing = page.written();
     const before = host.sent.length;
 
@@ -98,6 +98,9 @@ describe("SimLocalLiveReload", () => {
  */
 class FakeServerResponse {
   writableEnded = false;
+  // No socket, as a response that never went over one has none, which is what
+  // tells the channel there is no connection to see out.
+  readonly socket = null;
 
   private readonly chunks: string[] = [];
 
@@ -111,8 +114,9 @@ class FakeServerResponse {
     return true;
   }
 
-  end(): void {
+  end(onFinished?: () => void): void {
     this.writableEnded = true;
+    onFinished?.();
   }
 
   on(): this {

--- a/src/serve/http/live-reload/sim-local-live-reload.ts
+++ b/src/serve/http/live-reload/sim-local-live-reload.ts
@@ -23,8 +23,11 @@ export class SimLocalLiveReload {
   private readonly liveReload: SimLiveReload | undefined;
   private readonly watch: SimWatchRuntime;
 
+  // The supervisor has its own handshake for waiting: it holds off killing the
+  // process until this one says it has stopped, which it does once the
+  // listeners have run. So the writes go out here and nothing waits on them.
   private readonly onSupervisorStopping = (): void => {
-    this.liveReload?.stopping();
+    void this.liveReload?.stopping();
   };
 
   constructor(properties: SimLocalLiveReloadProperties) {
@@ -57,10 +60,13 @@ export class SimLocalLiveReload {
 
   /**
    * Tell connected browsers a reload is coming, and stop listening.
+   *
+   * Resolves once those browsers have had it, so the server can go on to
+   * destroy what is left of its connections.
    */
-  stopping(): void {
+  async stopping(): Promise<void> {
     this.watch.offStopping(this.onSupervisorStopping);
-    this.liveReload?.stopping();
+    await this.liveReload?.stopping();
   }
 
   /**

--- a/src/serve/http/local-server/sim-aws-local-server-restart.loc.test.ts
+++ b/src/serve/http/local-server/sim-aws-local-server-restart.loc.test.ts
@@ -18,7 +18,7 @@ describe("Simulated AWS local HTTP server restart", () => {
     const connection = await keepAliveConnection(Number(server.port));
 
     // When the server is closed
-    server.close();
+    await server.close();
 
     // Then the connection ends without the client having done anything
     await assertConnectionEnds(connection);
@@ -31,7 +31,7 @@ describe("Simulated AWS local HTTP server restart", () => {
     await startAnotherRequest(connection);
 
     // When the server is closed
-    server.close();
+    await server.close();
 
     // Then that connection ends too, rather than being left to finish
     await assertConnectionEnds(connection);
@@ -50,7 +50,7 @@ describe("Simulated AWS local HTTP server restart", () => {
 
     // Then it took the port rather than failing on it being busy
     assertIdentical(server.port, String(pinnedPort));
-    server.close();
+    await server.close();
   });
 
   it("binds a pinned port again immediately after closing", async () => {
@@ -60,11 +60,11 @@ describe("Simulated AWS local HTTP server restart", () => {
     await keepAliveConnection(pinnedPort);
 
     // When it closes and a replacement asks for the same port
-    first.close();
+    await first.close();
     const second = await new SimAwsLocalServer().listen(pinnedPort);
 
     // Then the replacement serves on the port the first one had
     assertIdentical(second.port, String(pinnedPort));
-    second.close();
+    await second.close();
   });
 });

--- a/src/serve/http/local-server/sim-aws-local-server.iso.test.ts
+++ b/src/serve/http/local-server/sim-aws-local-server.iso.test.ts
@@ -20,7 +20,7 @@ describe("SimAwsLocalServer", () => {
         "local sim server nodeRequest.headers.host required",
       );
     } finally {
-      server.close();
+      await server.close();
     }
   });
 
@@ -43,7 +43,7 @@ describe("SimAwsLocalServer", () => {
         "local sim server nodeRequest.headers.host required",
       );
     } finally {
-      server.close();
+      await server.close();
     }
   });
 });

--- a/src/serve/http/local-server/sim-aws-local-server.loc.test.ts
+++ b/src/serve/http/local-server/sim-aws-local-server.loc.test.ts
@@ -15,8 +15,8 @@ describe("Simulated AWS local HTTP server", () => {
     await srv.listen();
   });
 
-  afterAll(() => {
-    srv.close();
+  afterAll(async () => {
+    await srv.close();
   });
 
   it("responds HTTP 400 for missing Host header", async () => {
@@ -99,7 +99,7 @@ describe("Simulated AWS local HTTP server", () => {
     const responseBody = await response.text();
     assertStringIncludes(responseBody, "S3 bucket named my-site not found");
 
-    server.close();
+    await server.close();
   });
 
   it("throws on trying to get port before listening", () => {

--- a/src/serve/http/local-server/sim-aws-local-server.ts
+++ b/src/serve/http/local-server/sim-aws-local-server.ts
@@ -99,14 +99,24 @@ export class SimAwsLocalServer {
    * but one that is in use, which is what a browser part way through a request
    * or a live reload stream holds, keeps its socket open and the process with
    * it. Local development restarts on that process exiting, so the connections
-   * go. Closing the listening socket first means nothing new is accepted while
-   * the open ones are being ended.
+   * go.
+   *
+   * The order is what a browser needs. Both ports are let go first, so a
+   * replacement process can have them however long the rest takes. Then the
+   * live reload streams are told a reload is coming and seen out, because a
+   * socket destroyed with bytes still in flight is reset, and a reset costs the
+   * browser the event it was just sent. Only what is left after that is
+   * destroyed.
+   *
+   * Await it to know the last event has gone before leaving the process.
    */
-  close(): void {
-    this.liveReload.stopping();
+  async close(): Promise<void> {
     this.server.close();
-    this.server.closeAllConnections();
     this.dnsServer.close();
+
+    await this.liveReload.stopping();
+
+    this.server.closeAllConnections();
   }
 
   /**

--- a/src/service/apigatewayv2/serve/sim-http-api-serve.loc.test.ts
+++ b/src/service/apigatewayv2/serve/sim-http-api-serve.loc.test.ts
@@ -91,7 +91,7 @@ describe("Serving a sim HTTP API on localhost", () => {
       assertIdentical(response.headers.get("content-type"), "text/plain");
       assertIdentical(await response.text(), "orders limit 10");
     } finally {
-      srv.close();
+      await srv.close();
     }
   });
 });

--- a/src/service/cloudformation/cdk/apigatewayv2/sim-cdk-http-api-authorizer.loc.test.ts
+++ b/src/service/cloudformation/cdk/apigatewayv2/sim-cdk-http-api-authorizer.loc.test.ts
@@ -166,7 +166,7 @@ describe("Sim CDK HTTP API JWT authorizer local integration", () => {
       });
       assertIdentical(expired.status, 401);
     } finally {
-      srv.close();
+      await srv.close();
     }
 
     await simAws.backgroundTasksComplete();

--- a/src/service/cloudformation/cdk/apigatewayv2/sim-cdk-http-api-iam-authorizer.loc.test.ts
+++ b/src/service/cloudformation/cdk/apigatewayv2/sim-cdk-http-api-iam-authorizer.loc.test.ts
@@ -143,7 +143,7 @@ describe("Sim CDK HTTP API IAM authorizer local integration", () => {
       assertIdentical(reporter.status, 200);
       assertIdentical(await reporter.text(), reporterArn);
     } finally {
-      srv.close();
+      await srv.close();
     }
 
     await simAws.backgroundTasksComplete();

--- a/src/service/cloudformation/cdk/apigatewayv2/sim-cdk-http-api-lambda-authorizer.loc.test.ts
+++ b/src/service/cloudformation/cdk/apigatewayv2/sim-cdk-http-api-lambda-authorizer.loc.test.ts
@@ -137,7 +137,7 @@ describe("Sim CDK HTTP API Lambda authorizer local integration", () => {
       assertIdentical(admitted.status, 200);
       assertIdentical(await admitted.text(), "acme");
     } finally {
-      srv.close();
+      await srv.close();
     }
 
     await simAws.backgroundTasksComplete();

--- a/src/service/cloudformation/cdk/apigatewayv2/sim-cdk-http-api.loc.test.ts
+++ b/src/service/cloudformation/cdk/apigatewayv2/sim-cdk-http-api.loc.test.ts
@@ -123,7 +123,7 @@ describe("Sim CDK HTTP API deployment local integration", () => {
       assertIdentical(fromApiEndpoint.status, 200);
       assertIdentical(await fromApiEndpoint.text(), "order YL-2");
     } finally {
-      srv.close();
+      await srv.close();
     }
 
     // And the invocation was gated by the AWS::Lambda::Permission CDK pairs

--- a/src/service/cloudformation/cdk/cloudfront/sim-cdk-cff-binding.loc.test.ts
+++ b/src/service/cloudformation/cdk/cloudfront/sim-cdk-cff-binding.loc.test.ts
@@ -29,8 +29,8 @@ describe("Sim CDK CloudFront Function binding local integration", () => {
     await srv.listen();
   });
 
-  afterAll(() => {
-    srv.close();
+  afterAll(async () => {
+    await srv.close();
   });
 
   it("deploys a CloudFront Function association using a binding", async () => {

--- a/src/service/cloudformation/cdk/cloudfront/sim-cdk-cff-source.loc.test.ts
+++ b/src/service/cloudformation/cdk/cloudfront/sim-cdk-cff-source.loc.test.ts
@@ -27,8 +27,8 @@ describe("Sim CDK CloudFront Function embedded source local integration", () => 
     await srv.listen();
   });
 
-  afterAll(() => {
-    srv.close();
+  afterAll(async () => {
+    await srv.close();
   });
 
   it("deploys a CloudFront Function association using embedded source code", async () => {

--- a/src/service/cloudformation/cdk/demo-proj/sim-cdk-website-alias.loc.test.ts
+++ b/src/service/cloudformation/cdk/demo-proj/sim-cdk-website-alias.loc.test.ts
@@ -24,8 +24,8 @@ describe("Sim CDK website deployment local integration", () => {
     await srv.listen();
   });
 
-  afterAll(() => {
-    srv.close();
+  afterAll(async () => {
+    await srv.close();
   });
 
   it("deploys test demo project into sim AWS", async () => {

--- a/src/service/cloudformation/cdk/demo-proj/sim-cdk-website-cff.loc.test.ts
+++ b/src/service/cloudformation/cdk/demo-proj/sim-cdk-website-cff.loc.test.ts
@@ -26,8 +26,8 @@ describe("Sim CDK website deployment local integration", () => {
     await srv.listen();
   });
 
-  afterAll(() => {
-    srv.close();
+  afterAll(async () => {
+    await srv.close();
   });
 
   it("deploys test demo project into sim AWS", async () => {

--- a/src/service/cloudformation/cdk/lambda/sim-cdk-lambda-function-url.loc.test.ts
+++ b/src/service/cloudformation/cdk/lambda/sim-cdk-lambda-function-url.loc.test.ts
@@ -98,7 +98,7 @@ app.synth();
       assertIdentical(response.headers.get("content-type"), "text/plain");
       assertIdentical(await response.text(), "Hello CDK");
     } finally {
-      srv.close();
+      await srv.close();
     }
 
     await simAws.backgroundTasksComplete();

--- a/src/service/cloudformation/cdk/lambda/sim-cdk-lambda-grant-invoke-url.loc.test.ts
+++ b/src/service/cloudformation/cdk/lambda/sim-cdk-lambda-grant-invoke-url.loc.test.ts
@@ -141,7 +141,7 @@ app.synth();
       );
       assertIdentical(ungranted.status, 403);
     } finally {
-      srv.close();
+      await srv.close();
     }
 
     await simAws.backgroundTasksComplete();

--- a/src/service/cloudformation/cdk/s3/bucket-deployment/sim-cdk-bucket-deployment.loc.test.ts
+++ b/src/service/cloudformation/cdk/s3/bucket-deployment/sim-cdk-bucket-deployment.loc.test.ts
@@ -19,8 +19,8 @@ describe("Sim CDK BucketDeployment local integration", () => {
     await srv.listen();
   });
 
-  afterAll(() => {
-    srv.close();
+  afterAll(async () => {
+    await srv.close();
   });
 
   it("sets up sim S3 bucket deployment on local filesystem", async () => {

--- a/src/service/cloudfront/cff/sim-cloudfront-functions.loc.test.ts
+++ b/src/service/cloudfront/cff/sim-cloudfront-functions.loc.test.ts
@@ -19,8 +19,8 @@ describe("Serve sim CloudFront Functions on localhost", () => {
     await srv.listen();
   });
 
-  afterAll(() => {
-    srv.close();
+  afterAll(async () => {
+    await srv.close();
   });
 
   it("applies viewer-request CFF", async () => {

--- a/src/service/cloudfront/controller/sim-cloudfront-controller.loc.test.ts
+++ b/src/service/cloudfront/controller/sim-cloudfront-controller.loc.test.ts
@@ -21,8 +21,8 @@ describe("sim CloudFront local server", () => {
     await srv.listen();
   });
 
-  afterAll(() => {
-    srv.close();
+  afterAll(async () => {
+    await srv.close();
   });
 
   it("serves from multiple sim S3 Origins", async () => {

--- a/src/service/cloudfront/origin/custom/sim-cloudfront-custom-origin.loc.test.ts
+++ b/src/service/cloudfront/origin/custom/sim-cloudfront-custom-origin.loc.test.ts
@@ -88,7 +88,7 @@ describe("Serving a sim CloudFront custom Origin on localhost", () => {
       assertIdentical(response.status, 200);
       assertIdentical(await response.text(), "/greet Yulin");
     } finally {
-      srv.close();
+      await srv.close();
     }
   });
 });

--- a/src/service/cognito/serve/sim-cognito-jwks-serve.loc.test.ts
+++ b/src/service/cognito/serve/sim-cognito-jwks-serve.loc.test.ts
@@ -100,7 +100,7 @@ describe("Serving a sim Cognito JWKS on localhost", () => {
       const payload = await verifier.verify(accessToken);
       assertIdentical(payload.username, "alice");
     } finally {
-      srv.close();
+      await srv.close();
     }
   });
 
@@ -133,7 +133,7 @@ describe("Serving a sim Cognito JWKS on localhost", () => {
       const payload = await verifier.verify(accessToken);
       assertIdentical(payload.username, "alice");
     } finally {
-      srv.close();
+      await srv.close();
     }
   });
 
@@ -164,7 +164,7 @@ describe("Serving a sim Cognito JWKS on localhost", () => {
       const jwks = await fetch(document.jwks_uri);
       assertIdentical(jwks.status, 200);
     } finally {
-      srv.close();
+      await srv.close();
     }
   });
 });

--- a/src/service/lambda/serve/sim-lambda-url-serve.loc.test.ts
+++ b/src/service/lambda/serve/sim-lambda-url-serve.loc.test.ts
@@ -50,7 +50,7 @@ describe("Serving a sim Lambda Function URL on localhost", () => {
       assertIdentical(response.headers.get("content-type"), "text/plain");
       assertIdentical(await response.text(), "Hello Yulin");
     } finally {
-      srv.close();
+      await srv.close();
     }
   });
 });

--- a/src/service/route53/serve/sim-route53-controller.loc.test.ts
+++ b/src/service/route53/serve/sim-route53-controller.loc.test.ts
@@ -51,8 +51,8 @@ describe("Simulated Route53 hosted zone summary over localhost", () => {
     server = await serveSimAws({ simAws });
   });
 
-  afterAll(() => {
-    server.close();
+  afterAll(async () => {
+    await server.close();
   });
 
   it("serves the hosted zone summary in a browser-viewable page", async () => {

--- a/src/service/s3/bucket/website/redirect/s3-bucket-website-redirects.loc.test.ts
+++ b/src/service/s3/bucket/website/redirect/s3-bucket-website-redirects.loc.test.ts
@@ -18,8 +18,8 @@ describe("Serve simulated S3 Bucket static website on localhost", () => {
     await srv.listen();
   });
 
-  afterAll(() => {
-    srv.close();
+  afterAll(async () => {
+    await srv.close();
   });
 
   it("redirects to a slash-terminated folder URL when a folder index document exists", async () => {

--- a/src/service/s3/bucket/website/s3-bucket-website.loc.test.ts
+++ b/src/service/s3/bucket/website/s3-bucket-website.loc.test.ts
@@ -18,8 +18,8 @@ describe("Serve simulated S3 Bucket static website on localhost", () => {
     await srv.listen();
   });
 
-  afterAll(() => {
-    srv.close();
+  afterAll(async () => {
+    await srv.close();
   });
 
   it("does not serve objects before static website hosting is configured", async () => {

--- a/src/service/s3/serve/sim-s3-controller.loc.test.ts
+++ b/src/service/s3/serve/sim-s3-controller.loc.test.ts
@@ -23,8 +23,8 @@ describe("Simulated S3 local HTTP controller", () => {
     await srv.listen();
   });
 
-  afterAll(() => {
-    srv.close();
+  afterAll(async () => {
+    await srv.close();
   });
 
   it("serves an S3 Object body and content type over HTTP GET", async () => {

--- a/src/service/s3/serve/sim-s3-presigned-url.loc.test.ts
+++ b/src/service/s3/serve/sim-s3-presigned-url.loc.test.ts
@@ -38,8 +38,8 @@ describe("Presigned simulated S3 URLs over a local server", () => {
     });
   });
 
-  afterAll(() => {
-    srv.close();
+  afterAll(async () => {
+    await srv.close();
   });
 
   it("downloads an Object through a presigned URL", async () => {

--- a/src/service/s3/storage/filesystem/s3-filesystem-storage.loc.test.ts
+++ b/src/service/s3/storage/filesystem/s3-filesystem-storage.loc.test.ts
@@ -25,8 +25,8 @@ describe("Serve sim S3 Bucket on localhost with filesystem storage", () => {
     await srv.listen();
   });
 
-  afterAll(() => {
-    srv.close();
+  afterAll(async () => {
+    await srv.close();
   });
 
   it("reads files from filesystem and serves on localhost", async () => {

--- a/test/serve/live-reload-socket.ts
+++ b/test/serve/live-reload-socket.ts
@@ -1,0 +1,97 @@
+import { once } from "node:events";
+import net from "node:net";
+import { simLiveReloadConfig } from "../../src/serve/http/live-reload/sim-live-reload.config.js";
+import { simAwsLocalConfig } from "../../src/serve/http/local-server/sim-aws-local.config.js";
+import type { SimAwsLocalServer } from "../../src/serve/http/local-server/sim-aws-local-server.js";
+
+/**
+ * Reads the live reload channel over a plain TCP socket, the way a browser
+ * does, rather than with the same-process `fetch` the other tests here use.
+ *
+ * The difference is what the connection going costs. `fetch` is handed bytes as
+ * it decodes them, on the same event loop as the server that sent them, so it
+ * is a forgiving reader of a stream that is closing. A browser is at the other
+ * end of a socket, and what it has been sent is only what actually left this
+ * end before the socket went. That is the reader worth testing against.
+ */
+export class SimLiveReloadSocket {
+  private readonly socket: net.Socket;
+  private received = "";
+
+  private constructor(socket: net.Socket) {
+    this.socket = socket;
+
+    // A connection that is reset rather than closed reaches this end as an
+    // error, which an unwatched socket throws on. It is one of the things being
+    // measured, so it is left to the events to report rather than allowed to
+    // end the test run.
+    socket.on("error", () => {
+      // Whatever arrived before it is what a browser would have had.
+    });
+    socket.on("data", (chunk: Buffer) => {
+      this.received += chunk.toString("utf8");
+    });
+  }
+
+  /**
+   * Connect to the channel a local server is serving, and wait for the stream
+   * to open, so the server has this browser on its list.
+   */
+  static async open(server: SimAwsLocalServer): Promise<SimLiveReloadSocket> {
+    const socket = net.createConnection({
+      host: simAwsLocalConfig.loopbackAddress,
+      port: Number(server.port),
+    });
+
+    await once(socket, "connect");
+
+    const channel = new SimLiveReloadSocket(socket);
+    socket.write(
+      `GET ${simLiveReloadConfig.channelPath} HTTP/1.1\r\n` +
+        `Host: ${simAwsLocalConfig.hostname}\r\n` +
+        "Accept: text/event-stream\r\n\r\n",
+    );
+    await once(socket, "data");
+
+    return channel;
+  }
+
+  /**
+   * Everything the server has sent so far.
+   */
+  read(): string {
+    return this.received;
+  }
+
+  /**
+   * Stop taking bytes off the connection, leaving anything sent from now on
+   * where a browser that has not read it yet would be holding it.
+   */
+  stopReading(): void {
+    this.socket.pause();
+  }
+
+  /**
+   * Read everything the server sent, up to the connection going.
+   */
+  async readToEnd(): Promise<string> {
+    this.socket.resume();
+
+    try {
+      await once(this.socket, "close");
+    } catch {
+      // The connection was reset rather than closed. What arrived before that
+      // is all a browser would have to work with, which is the point of reading
+      // it over a socket.
+    }
+
+    return this.received;
+  }
+
+  /**
+   * Let the connection go without waiting for the server to end it.
+   */
+  close(): void {
+    this.socket.destroy();
+  }
+}


### PR DESCRIPTION
## Problem

`SimAwsLocalServer.close()` wrote `event: reloading` to every live reload stream and then called
`closeAllConnections()` in the same synchronous tick. A socket destroyed with bytes still in flight
is reset rather than closed, and a reset tells the peer to discard data it received but has not yet
handed to the application, so the event that was written is the event the browser throws away.
`close()` also returned `void`, so a dev script had nothing to wait for before calling
`process.exit()`.

## Change

`close()` now:

1. closes the listening socket and the DNS socket, so both ports are free straight away;
2. tells the reload streams a reload is coming, ends each response, ends its socket so a normal
   close follows the bytes rather than a reset, and waits for the connection to go;
3. destroys whatever connections are left.

A connection that does not go within 500ms is given up on, so a browser that has stopped answering
cannot hold up a restart, and the ports were already released before any of that waiting.

`close()` returns `Promise<void>`, so a script can wait for the last event to leave before exiting.
That is a breaking change to the return type; the issue sanctions it and nothing depends on it yet.
`SimLiveReload.stopping()`, `SimLocalLiveReload.stopping()` and `SimLiveReloadClient.end()` are
async for the same reason. The supervised-restart path is unchanged: it has its own handshake and
does not wait on the writes.

## Tests

`test/serve/live-reload-socket.ts` reads the channel over a plain TCP socket rather than with
same-process `fetch`, which is the forgiving reader the existing test used. Three new cases in
`sim-live-reload.loc.test.ts`:

- a browser holding unread bytes on a real socket still finds `event: reloading` in the stream, and
  the stream is finished rather than cut off;
- the event has already reached the browser by the time `close()` settles, which is what lets a
  script exit straight afterwards — this one fails on `main`;
- closing twice with nothing connected completes, and the pinned port is free for a replacement.

## Verification

`pnpm run check` passes. Also checked by hand against a real Chrome on a served Bucket website: with
a handler that awaits `close()` and then calls `process.exit(0)`, the page ends up with
`data-sim-aws-live-reload="reloading"` on its `<html>` element.

Worth noting: on macOS loopback the old code happened to survive, both under a paused raw socket and
under a real browser, because the data was delivered ahead of the reset. The fix removes the
dependence on that rather than on any platform's reset behaviour.

## Docs

`docs/serve/README.md` covers the new return type, what the ordering buys a browser, and the
half-second give-up. Both shutdown examples now await `close()` from an async handler. Every other
call site across the docs and tests gained an `await`.

Resolves #430