### PR TITLE
fix: settle a burst of writes during a build

### DIFF
--- a/docs/serve/README.md
+++ b/docs/serve/README.md
@@ -222,8 +222,29 @@ a file in a mounted directory or re-synthing a stack restarts the process. A tem
 the `watch` option is the exception, and is
 [left to the process reading it](#updating-a-stack-instead-of-restarting).
 
+### One restart for a burst of writes
+
 A burst of writes is one restart. Saving one file is several filesystem events, so changes are held
-until they stop arriving before anything is restarted.
+until they stop arriving before anything is restarted. The wait is 250ms by default, and a build
+writing hundreds of files is one restart rather than one per file.
+
+The number is what a build needs rather than what a save needs. macOS hands a recursive watch its
+events in waves rather than one at a time: a build writing several thousand files was measured
+arriving as tens of waves up to 49ms apart, so a window anywhere near that turns one build into
+several restarts. A build that pauses between its own phases, as a tool that resolves before it
+writes does, pauses for longer than that again. 250ms clears the waves several times over and covers
+the shorter of those pauses, at the cost of 250ms before a plain save is acted on.
+
+A project whose build is unusual can say so, rather than moving the default:
+
+```bash
+yulin watch --settle=600 -- tsx dev.ts
+```
+
+Writes that keep arriving push the wait back, so a build that never goes quiet would otherwise hold
+the restart off for as long as it ran. A burst is acted on after five seconds however much is still
+arriving, and the writes after that are a burst of their own. That is a backstop for a build that
+writes continuously for minutes, not something an ordinary build reaches.
 
 ### Updating a stack instead of restarting
 

--- a/docs/services/cloudformation/README.md
+++ b/docs/services/cloudformation/README.md
@@ -1130,7 +1130,9 @@ template that no longer deploys leaves a working environment where a restart on 
 none.
 
 A burst of writes is one update. Saving a file is several filesystem events, so changes are held
-until they stop arriving. `settleMs` is how long that wait is.
+until they stop arriving. `settleMs` is how long that wait is, and it defaults to the 250ms
+[`yulin watch` settles at](../../serve/README.md#one-restart-for-a-burst-of-writes). A synth that
+keeps writing is updated from after five seconds of it, rather than being held off until it stops.
 
 Watching holds a filesystem handle open, so the process does not exit on its own. That is what a dev
 process wants. Anything with an end, such as a test, calls `stopWatchingTemplateFiles()` when it is

--- a/src/cli/sim-cli.iso.test.ts
+++ b/src/cli/sim-cli.iso.test.ts
@@ -15,8 +15,9 @@ describe("SimCli", () => {
     // When it is asked for help
     void new SimCli().run(["--help"]);
 
-    // Then the commands are listed
-    assertStringIncludes(written.join(""), "watch [--inspect");
+    // Then the commands are listed, with the options they take
+    assertStringIncludes(written.join(""), "watch [options]");
+    assertStringIncludes(written.join(""), "--settle=ms");
   });
 
   it("reports a run with no command as a mistake", async () => {
@@ -55,7 +56,7 @@ describe("SimCli", () => {
     // Then it names the command and says what there is instead
     assertInstanceOf(error, SimCliUnknownCommand);
     assertStringIncludes(error.message, "Unknown command serve.");
-    assertStringIncludes(error.message, "watch [--inspect");
+    assertStringIncludes(error.message, "watch [options]");
   });
 });
 

--- a/src/cli/sim-cli.ts
+++ b/src/cli/sim-cli.ts
@@ -3,7 +3,11 @@ import { SimWatchCommand } from "./watch/sim-watch-command.js";
 const usage = `Usage: yulin <command>
 
 Commands:
-  watch [--inspect[=port]] -- <command>   Run a command, and run it again when project files change
+  watch [options] -- <command>   Run a command, and run it again when project files change
+
+Watch options:
+  --inspect[=port]              Run the command with an inspector, for a debugger to attach to
+  --settle=ms                   How long writes have to stop for before they count as one change
 `;
 
 /**

--- a/src/cli/watch/sim-watch-arguments.iso.test.ts
+++ b/src/cli/watch/sim-watch-arguments.iso.test.ts
@@ -38,6 +38,68 @@ describe("SimWatchArguments", () => {
     assertIdentical(parsed.command, "tsx");
   });
 
+  it("takes a settle window for a project the default does not suit", () => {
+    // Given a build whose writes come in further apart than most
+    const argv = ["--settle=800", "--inspect", "--", "tsx", "dev.ts"];
+
+    // When the arguments are read
+    const parsed = SimWatchArguments.parse(argv);
+
+    // Then the window is watch's own option, alongside one for the command
+    assertIdentical(parsed.settleMs, 800);
+    assertIdentical(parsed.inspect, "--inspect");
+    assertIdentical(parsed.command, "tsx");
+  });
+
+  it("leaves the settle window alone when it was not asked about", () => {
+    // Given a watch written without the option
+    const argv = ["--", "tsx", "dev.ts"];
+
+    // When the arguments are read
+    const parsed = SimWatchArguments.parse(argv);
+
+    // Then the default window is what the watcher will use
+    assertUndefined(parsed.settleMs);
+  });
+
+  it("refuses a settle window that is not a number of milliseconds", () => {
+    // Given a window written as a word
+    const argv = ["--settle=slowly", "--", "tsx", "dev.ts"];
+
+    // When the arguments are read
+    const error = assertThrowsError(() => SimWatchArguments.parse(argv));
+
+    // Then it says how the option is written
+    assertInstanceOf(error, SimWatchUsageError);
+    assertStringIncludes(error.message, "--settle takes a number");
+    assertStringIncludes(error.message, "--settle=250");
+  });
+
+  it("refuses a settle window with no value", () => {
+    // Given the option written as though it took the next word
+    const argv = ["--settle", "250", "--", "tsx", "dev.ts"];
+
+    // When the arguments are read
+    const error = assertThrowsError(() => SimWatchArguments.parse(argv));
+
+    // Then it says how the option is written, rather than reading 250 as an
+    // option of its own
+    assertInstanceOf(error, SimWatchUsageError);
+    assertStringIncludes(error.message, "--settle takes a number");
+  });
+
+  it("refuses a settle window of nothing at all", () => {
+    // Given a window that would act on every event separately
+    const argv = ["--settle=0", "--", "tsx", "dev.ts"];
+
+    // When the arguments are read
+    const error = assertThrowsError(() => SimWatchArguments.parse(argv));
+
+    // Then it is refused rather than turning one save into several restarts
+    assertInstanceOf(error, SimWatchUsageError);
+    assertStringIncludes(error.message, "--settle takes a number");
+  });
+
   it("refuses a run with no separator", () => {
     // Given a command written without the separator
     const argv = ["tsx", "dev.ts"];

--- a/src/cli/watch/sim-watch-arguments.ts
+++ b/src/cli/watch/sim-watch-arguments.ts
@@ -3,6 +3,7 @@ const inspectorFlags = new Set([
   "--inspect-brk",
   "--inspect-wait",
 ]);
+const settleFlag = "--settle";
 
 /**
  * Thrown when `yulin watch` was not given something to run.
@@ -11,7 +12,9 @@ export class SimWatchUsageError extends Error {
   public override readonly name = "SimWatchUsageError";
 
   constructor(message: string) {
-    super(`${message}\n\nUsage: yulin watch [--inspect[=port]] -- <command>`);
+    super(
+      `${message}\n\nUsage: yulin watch [--inspect[=port]] [--settle=ms] -- <command>`,
+    );
   }
 }
 
@@ -27,15 +30,17 @@ export class SimWatchArguments {
   readonly command: string;
   readonly commandArguments: readonly string[];
   readonly inspect: string | undefined;
+  readonly settleMs: number | undefined;
 
   private constructor(
     command: string,
     commandArguments: readonly string[],
-    inspect: string | undefined,
+    options: SimWatchOptions,
   ) {
     this.command = command;
     this.commandArguments = commandArguments;
-    this.inspect = inspect;
+    this.inspect = options.inspect;
+    this.settleMs = options.settleMs;
   }
 
   /**
@@ -59,7 +64,7 @@ export class SimWatchArguments {
     return new SimWatchArguments(
       command,
       rest,
-      inspectorFlag(argv.slice(0, separator)),
+      optionsIn(argv.slice(0, separator)),
     );
   }
 
@@ -71,21 +76,57 @@ export class SimWatchArguments {
   }
 }
 
-/**
- * The inspector flag to pass through to each run, if one was asked for.
- */
-function inspectorFlag(options: readonly string[]): string | undefined {
-  const unknown = options.find((option) => !isInspectorFlag(option));
-
-  if (unknown !== undefined) {
-    throw new SimWatchUsageError(`Unknown option ${unknown}.`);
-  }
-
-  return options.at(-1);
+interface SimWatchOptions {
+  readonly inspect: string | undefined;
+  readonly settleMs: number | undefined;
 }
 
-function isInspectorFlag(option: string): boolean {
+/**
+ * The options written before the separator, which are the only ones watch reads
+ * itself.
+ */
+function optionsIn(given: readonly string[]): SimWatchOptions {
+  let inspect: string | undefined;
+  let settleMs: number | undefined;
+
+  for (const option of given) {
+    const flag = flagOf(option);
+
+    if (inspectorFlags.has(flag)) {
+      inspect = option;
+    } else if (flag === settleFlag) {
+      settleMs = settleValue(option);
+    } else {
+      throw new SimWatchUsageError(`Unknown option ${option}.`);
+    }
+  }
+
+  return { inspect, settleMs };
+}
+
+/**
+ * How long a burst of writes has to go quiet, for a project whose build the
+ * default window does not suit.
+ */
+function settleValue(option: string): number {
+  const [, value] = option.split("=");
+  const milliseconds = Number(value);
+
+  if (
+    value === undefined ||
+    !Number.isSafeInteger(milliseconds) ||
+    milliseconds < 1
+  ) {
+    throw new SimWatchUsageError(
+      `${settleFlag} takes a number of milliseconds, written as ${settleFlag}=250.`,
+    );
+  }
+
+  return milliseconds;
+}
+
+function flagOf(option: string): string {
   const [flag = ""] = option.split("=");
 
-  return inspectorFlags.has(flag);
+  return flag;
 }

--- a/src/cli/watch/sim-watch-supervisor.ts
+++ b/src/cli/watch/sim-watch-supervisor.ts
@@ -75,6 +75,7 @@ export class SimWatchSupervisor {
     });
     this.watcher = new SimWatchWatcher({
       cwd,
+      settleMs: watchArguments.settleMs,
       onChange: (changedPath: string): void => {
         this.restarts.request(changedPath);
       },

--- a/src/cli/watch/sim-watch-watcher.loc.test.ts
+++ b/src/cli/watch/sim-watch-watcher.loc.test.ts
@@ -1,11 +1,14 @@
 import path from "node:path";
 import {
   assertArrayEquals,
+  assertArrayLength,
+  assertNumberBetween,
   assertStringEndsWith,
   assertStringStartsWith,
 } from "@kensio/smartass";
 import { describe, it } from "vitest";
 import { SimWatchWatcher } from "./sim-watch-watcher.js";
+import { simWatchConfig } from "../../watch/sim-watch.config.js";
 import { TemporaryDirectory } from "../../util/filesystem/temporary-directory.js";
 import { watchPause } from "../../../test/cli/watch-project.js";
 
@@ -21,6 +24,40 @@ describe("SimWatchWatcher over a real directory", () => {
 
       // Then the change is reported, by name
       assertStringEndsWith(changes.at(0) ?? "", "handler.ts");
+    } finally {
+      watcher.stop();
+    }
+  });
+
+  it("makes one change out of a build writing several hundred files", async () => {
+    // Given a watched working directory settling at the window a project gets
+    // by default
+    const { directory, changes, changedAt, watcher } = await watching({
+      settleMs: simWatchConfig.settleMs,
+    });
+
+    try {
+      // When a build writes a few hundred files into it, which the platform
+      // delivers in waves rather than all at once
+      await Promise.all(
+        Array.from({ length: 500 }, async (_, at) =>
+          directory.writeFile(
+            ["site", `page-${String(at)}.html`],
+            `<h1>page ${String(at)}</h1>`,
+          ),
+        ),
+      );
+      const writtenAt = Date.now();
+      await watchPause(simWatchConfig.settleMs * 6);
+
+      // Then the build is one restart, taken shortly after its last write
+      // rather than once per wave
+      assertArrayLength(changes, 1);
+      assertNumberBetween(
+        (changedAt.at(0) ?? 0) - writtenAt,
+        0,
+        simWatchConfig.settleMs * 4,
+      );
     } finally {
       watcher.stop();
     }
@@ -200,24 +237,34 @@ describe("SimWatchWatcher over a real directory", () => {
 interface Watching {
   readonly directory: TemporaryDirectory;
   readonly changes: string[];
+  readonly changedAt: number[];
   readonly watcher: SimWatchWatcher;
 }
 
-async function watching(): Promise<Watching> {
+interface WatchingProperties {
+  readonly settleMs?: number;
+}
+
+async function watching(
+  properties: WatchingProperties = {},
+): Promise<Watching> {
+  const { settleMs = 30 } = properties;
   const directory = new TemporaryDirectory();
   await directory.resolvePath();
 
   const changes: string[] = [];
+  const changedAt: number[] = [];
   const watcher = new SimWatchWatcher({
     cwd: directory.path(),
     onChange: (changedPath: string): void => {
       changes.push(changedPath);
+      changedAt.push(Date.now());
     },
-    settleMs: 30,
+    settleMs,
   });
 
   watcher.start();
   await watchPause(200);
 
-  return { directory, changes, watcher };
+  return { directory, changes, changedAt, watcher };
 }

--- a/src/cli/watch/sim-watch-watcher.loc.test.ts
+++ b/src/cli/watch/sim-watch-watcher.loc.test.ts
@@ -39,10 +39,14 @@ describe("SimWatchWatcher over a real directory", () => {
     try {
       // When a build writes a few hundred files into it, which the platform
       // delivers in waves rather than all at once
+      //
+      // Into the directory already being watched rather than a new one of its
+      // own: a directory arriving is a change in its own right, and one a
+      // recursive watch only sees inside once it has caught up with it.
       await Promise.all(
         Array.from({ length: 500 }, async (_, at) =>
           directory.writeFile(
-            ["site", `page-${String(at)}.html`],
+            `page-${String(at)}.html`,
             `<h1>page ${String(at)}</h1>`,
           ),
         ),

--- a/src/cli/watch/sim-watch-watcher.ts
+++ b/src/cli/watch/sim-watch-watcher.ts
@@ -8,7 +8,7 @@ import { SimWatchSettle } from "../../watch/sim-watch-settle.js";
 interface SimWatchWatcherProperties {
   readonly cwd: string;
   readonly onChange: (changedPath: string) => void;
-  readonly settleMs?: number;
+  readonly settleMs?: number | undefined;
 }
 
 /**
@@ -36,7 +36,11 @@ export class SimWatchWatcher {
   constructor(properties: SimWatchWatcherProperties) {
     const { cwd, onChange, settleMs = simWatchConfig.settleMs } = properties;
     this.cwd = path.resolve(cwd);
-    this.settle = new SimWatchSettle({ settleMs, onSettled: onChange });
+    this.settle = new SimWatchSettle({
+      settleMs,
+      maxWaitMs: simWatchConfig.settleMaxWaitMs,
+      onSettled: onChange,
+    });
   }
 
   /**

--- a/src/cli/yulin.loc.test.ts
+++ b/src/cli/yulin.loc.test.ts
@@ -21,7 +21,7 @@ describe("yulin command line", () => {
     });
 
     // Then the commands are listed
-    assertStringIncludes(stdout, "watch [--inspect");
+    assertStringIncludes(stdout, "watch [options]");
   });
 
   it("stops when the command to watch cannot be run", async () => {

--- a/src/service/cloudformation/watch/sim-cfn-template-file-watch.ts
+++ b/src/service/cloudformation/watch/sim-cfn-template-file-watch.ts
@@ -42,6 +42,7 @@ export class SimCfnTemplateFileWatch {
     this.watch = watch;
     this.settle = new SimWatchSettle({
       settleMs,
+      maxWaitMs: simWatchConfig.settleMaxWaitMs,
       onSettled: (): void => {
         this.apply();
       },

--- a/src/watch/sim-watch-settle.iso.test.ts
+++ b/src/watch/sim-watch-settle.iso.test.ts
@@ -9,14 +9,7 @@ describe("SimWatchSettle", () => {
 
   it("makes one change out of a burst of writes", () => {
     // Given the several writes one editor save produces
-    vi.useFakeTimers();
-    const settled: string[] = [];
-    const settle = new SimWatchSettle({
-      settleMs: 100,
-      onSettled: (changedPath) => {
-        settled.push(changedPath);
-      },
-    });
+    const { settled, settle } = settling();
 
     // When they arrive faster than the settle window
     settle.record("src/handler.ts");
@@ -32,14 +25,7 @@ describe("SimWatchSettle", () => {
 
   it("reports a later change separately", () => {
     // Given a change that has already settled
-    vi.useFakeTimers();
-    const settled: string[] = [];
-    const settle = new SimWatchSettle({
-      settleMs: 100,
-      onSettled: (changedPath) => {
-        settled.push(changedPath);
-      },
-    });
+    const { settled, settle } = settling();
     settle.record("src/first.ts");
     vi.advanceTimersByTime(100);
 
@@ -51,16 +37,39 @@ describe("SimWatchSettle", () => {
     assertArrayEquals(settled, ["src/first.ts", "src/second.ts"]);
   });
 
+  it("acts on a burst that never goes quiet", () => {
+    // Given a build writing files without a pause long enough to settle in
+    const { settled, settle } = settling(100, 500);
+
+    // When the writes go on for more than twice the longest wait allowed
+    for (let elapsed = 0; elapsed < 1400; elapsed += 50) {
+      settle.record("dist/page.html");
+      vi.advanceTimersByTime(50);
+    }
+
+    // Then each stretch of the build is one change, taken while it was still
+    // writing rather than held until the end of it
+    assertArrayEquals(settled, ["dist/page.html", "dist/page.html"]);
+  });
+
+  it("waits the settle window out when the longest wait is shorter", () => {
+    // Given a window longer than the wait meant to cap it
+    const { settled, settle } = settling(100, 10);
+
+    // When one save arrives
+    settle.record("src/handler.ts");
+    vi.advanceTimersByTime(50);
+
+    // Then the window is still what a save is held for, since ending a burst
+    // sooner than the window is what the window is there to stop
+    assertArrayEquals(settled, []);
+    vi.advanceTimersByTime(50);
+    assertArrayEquals(settled, ["src/handler.ts"]);
+  });
+
   it("drops a change that was still settling when it was cancelled", () => {
     // Given a change waiting to see whether more are coming
-    vi.useFakeTimers();
-    const settled: string[] = [];
-    const settle = new SimWatchSettle({
-      settleMs: 100,
-      onSettled: (changedPath) => {
-        settled.push(changedPath);
-      },
-    });
+    const { settled, settle } = settling();
     settle.record("src/handler.ts");
 
     // When the watcher shuts down first
@@ -71,3 +80,24 @@ describe("SimWatchSettle", () => {
     assertArrayEquals(settled, []);
   });
 });
+
+interface Settling {
+  readonly settled: string[];
+  readonly settle: SimWatchSettle;
+}
+
+function settling(settleMs = 100, maxWaitMs = 5000): Settling {
+  vi.useFakeTimers();
+  const settled: string[] = [];
+
+  return {
+    settled,
+    settle: new SimWatchSettle({
+      settleMs,
+      maxWaitMs,
+      onSettled: (changedPath) => {
+        settled.push(changedPath);
+      },
+    }),
+  };
+}

--- a/src/watch/sim-watch-settle.ts
+++ b/src/watch/sim-watch-settle.ts
@@ -1,5 +1,6 @@
 interface SimWatchSettleProperties {
   readonly settleMs: number;
+  readonly maxWaitMs: number;
   readonly onSettled: (changedPath: string) => void;
 }
 
@@ -11,18 +12,29 @@ interface SimWatchSettleProperties {
  * Acting on each of those would be several restarts, or several Stack updates,
  * for one save, so the changes are held until they stop arriving.
  *
+ * A burst that never stops arriving would otherwise be held for as long as it
+ * went on, since every event pushes the wait back. `maxWaitMs` is how long that
+ * pushing back is allowed to last: a build that writes without a pause is acted
+ * on during it rather than only once it finishes.
+ *
  * The path reported is the first of the burst, which is the one that actually
  * changed rather than whatever the editor did around it.
  */
 export class SimWatchSettle {
   private readonly settleMs: number;
+  private readonly maxWaitMs: number;
   private readonly onSettled: (changedPath: string) => void;
   private pendingPath: string | undefined;
+  private settleBy: number | undefined;
   private timer: NodeJS.Timeout | undefined;
 
   constructor(properties: SimWatchSettleProperties) {
-    const { settleMs, onSettled } = properties;
+    const { settleMs, maxWaitMs, onSettled } = properties;
     this.settleMs = settleMs;
+    // A maximum shorter than the window it caps would end every burst early,
+    // including the one editor save the window is there for, so an unusually
+    // long window is its own maximum.
+    this.maxWaitMs = Math.max(maxWaitMs, settleMs);
     this.onSettled = onSettled;
   }
 
@@ -31,13 +43,15 @@ export class SimWatchSettle {
    */
   record(changedPath: string): void {
     this.pendingPath ??= changedPath;
+    this.settleBy ??= Date.now() + this.maxWaitMs;
     const burstPath = this.pendingPath;
 
     clearTimeout(this.timer);
     this.timer = setTimeout(() => {
       this.pendingPath = undefined;
+      this.settleBy = undefined;
       this.onSettled(burstPath);
-    }, this.settleMs);
+    }, this.waitMs());
   }
 
   /**
@@ -47,5 +61,16 @@ export class SimWatchSettle {
     clearTimeout(this.timer);
     this.timer = undefined;
     this.pendingPath = undefined;
+    this.settleBy = undefined;
+  }
+
+  /**
+   * How long to wait for the next event: the settle window, or whatever is left
+   * of the maximum, whichever runs out first.
+   */
+  private waitMs(): number {
+    const left = (this.settleBy ?? 0) - Date.now();
+
+    return Math.max(0, Math.min(this.settleMs, left));
   }
 }

--- a/src/watch/sim-watch.config.ts
+++ b/src/watch/sim-watch.config.ts
@@ -9,7 +9,27 @@ export const simWatchConfig = {
   environmentVariableValue: "1",
   // How long a burst of writes has to go quiet before it counts as one change.
   // One save from an editor is several writes, and a rename over the original.
-  settleMs: 120,
+  //
+  // The number is what a real build needs rather than what one save needs.
+  // macOS hands a recursive watch its events in waves rather than one at a
+  // time: a build writing several thousand files was measured arriving as tens
+  // of waves up to 49ms apart, so a window near that turns one build into
+  // several restarts, and 120 was close enough to it to be split by a build
+  // that pauses between its own phases. 250 clears the waves several times
+  // over, and covers the short pauses a multi-stage build takes. It is also
+  // well inside `selfInflictedMs`, so a file the process wrote on startup is
+  // still recognised as one it wrote itself.
+  settleMs: 250,
+  // How long a burst is allowed to defer the change that started it. Every
+  // event pushes the settle window back, so without this a build that writes
+  // for a minute is acted on a minute late, having held everything off for the
+  // whole of it.
+  //
+  // Longer than `selfInflictedMs`, so a change taken during a burst is never
+  // mistaken for one the process made itself, and longer than an ordinary build
+  // takes, so it is a backstop for a stream that will not stop rather than
+  // something a build runs into.
+  settleMaxWaitMs: 5000,
   // How long the supervisor waits for a process to say it has told its browsers
   // a reload is coming. A process not running Yulin's runtime never answers, so
   // this is a short wait rather than a requirement.


### PR DESCRIPTION
## What changed

- The default settle window goes from 120ms to 250ms.
- A burst can no longer defer its change indefinitely: whatever is still arriving, it is acted on after five seconds, and the writes after that are a burst of its own.
- `yulin watch --settle=<ms>` sets the window for a project the default does not suit.

## Measurement

Method: a recursive `fs.watch` over a temporary directory on macOS 25.5 with Node 24, a real build writing into it, every event timestamped, then the recorded stream replayed through candidate windows. Three runs of each build.

`tsc -p tsconfig.build.json` into the watched directory, 7,340 files in 0.8–1.8s:

| | run 1 | run 2 | run 3 |
| --- | --- | --- | --- |
| waves | 57 | 66 | 72 |
| gap between waves, p50 | 17.9ms | 16.7ms | 11.1ms |
| gap between waves, max | 49.2ms | 49.0ms | 49.1ms |
| smallest window making one change | 60ms | 60ms | 60ms |

`pnpm add aws-cdk-lib --node-linker=hoisted` into the watched directory, ~7,400 files, which is a build that resolves before it links rather than writing straight through:

| | run 1 | run 2 | run 3 |
| --- | --- | --- | --- |
| waves | 72 | 77 | 92 |
| gap between waves, max | 233ms | 352ms | 314ms |
| smallest window making one change | 250ms | 400ms | 400ms |

Two separate things set the floor. The platform coalesces: a build writing continuously arrives as tens of waves, never more than 49ms apart in any run, so a window near that turns one build into several restarts, which is what 40ms did every time. Above that it is the build's own think time between its phases, which was 233–352ms here and is not bounded by anything.

250ms clears the delivery waves five times over and covers the shorter phase pauses, which is also where the 250ms reported on the Hugo build lands. Going further buys little against pauses that have no upper bound and costs the same latency on every ordinary save, so the rest is the `--settle` option rather than the default.

The maximum wait is a backstop rather than a second window: nothing measured here reaches five seconds, and a build that writes continuously for a minute no longer holds everything off for the minute. It has to stay above `selfInflictedMs`, since a change taken during a burst restarts a process that has been running that long, and one taken sooner than 1500ms after a start is what the restart loop guard reads as a process writing to its own watched path.

The longer window eats into that same 1500ms budget from the other end: a file the process writes on startup is now acted on 250ms rather than 120ms after the write, which still leaves the loop guard most of its budget.

## Tests

- A burst of 500 files written into a watched directory is one change, timed against the last write.
- A stream of events longer than the maximum wait settles during the stream, and the stretch after it settles once too.
- A maximum wait shorter than the window it caps does not cut a single save short.
- `--settle` parsing, including a value that is not a number, no value at all, and zero.

Resolves #438