### PR TITLE
feat: run Cognito Lambda triggers on sign-in

### DIFF
--- a/docs/services/cognito/README.md
+++ b/docs/services/cognito/README.md
@@ -839,6 +839,156 @@ try {
 }
 ```
 
+## Lambda triggers
+
+A pool created with a `LambdaConfig` runs the functions it names as part of a sign-in.
+`PreAuthentication` runs once the user is known and before its password is checked, and
+`PostAuthentication` runs once the tokens have been issued. Both are given the real event, and both
+have to return it.
+
+The function is a simulated Lambda function anywhere in the simulation, and it has to admit
+`cognito-idp.amazonaws.com` for the pool, which is what `AddPermission` grants and what CDK's
+`addTrigger` emits an `AWS::Lambda::Permission` for.
+
+```typescript sim-cognito-lambda-triggers
+/**
+ * A user pool that runs a PreAuthentication trigger on every sign-in.
+ */
+
+import {
+  AdminCreateUserCommand,
+  AdminInitiateAuthCommand,
+  AdminSetUserPasswordCommand,
+  CreateUserPoolClientCommand,
+  CreateUserPoolCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import {
+  AddPermissionCommand,
+  CreateFunctionCommand,
+} from "@aws-sdk/client-lambda";
+
+import { SimAws } from "@kensio/yulin";
+import { makeLambdaZipFileInput } from "@kensio/yulin/lambda";
+
+/**
+ * The part of the PreAuthentication event this handler reads.
+ */
+interface PreAuthenticationEvent {
+  readonly request: { readonly userAttributes: Record<string, string> };
+}
+
+const simAws = new SimAws();
+const lambda = simAws.lambda();
+const cognito = simAws.cognitoIdentityProvider();
+
+// The trigger turns away anyone who is not on the domain the pool is for, and
+// hands the event back otherwise, as every trigger handler has to.
+await lambda.createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "pre-auth",
+    Role: "arn:aws:iam::888888888888:role/PreAuthRole",
+    Code: {
+      ZipFile: makeLambdaZipFileInput((event: PreAuthenticationEvent) => {
+        const email = event.request.userAttributes["email"] ?? "";
+
+        if (!email.endsWith("@example.com")) {
+          throw new Error("Only example.com may sign in");
+        }
+
+        return event;
+      }),
+    },
+  }),
+);
+
+// The pool names the function by ARN. Nothing is resolved until a sign-in runs
+// the trigger, so the pool can be created before the function exists.
+const pool = await cognito.createUserPool(
+  new CreateUserPoolCommand({
+    PoolName: "myapp-users",
+    LambdaConfig: {
+      PreAuthentication:
+        "arn:aws:lambda:us-east-1:888888888888:function:pre-auth",
+    },
+  }),
+);
+
+// Cognito invokes the function as a service, so the function's resource policy
+// has to admit it for this pool.
+await lambda.addPermission(
+  new AddPermissionCommand({
+    FunctionName: "pre-auth",
+    StatementId: "AllowCognito",
+    Action: "lambda:InvokeFunction",
+    Principal: "cognito-idp.amazonaws.com",
+    SourceArn: pool.UserPool?.Arn,
+  }),
+);
+
+const appClient = await cognito.createUserPoolClient(
+  new CreateUserPoolClientCommand({
+    UserPoolId: pool.UserPool?.Id,
+    ClientName: "web",
+    ExplicitAuthFlows: ["ALLOW_ADMIN_USER_PASSWORD_AUTH"],
+  }),
+);
+
+await cognito.adminCreateUser(
+  new AdminCreateUserCommand({
+    UserPoolId: pool.UserPool?.Id,
+    Username: "mallory",
+    UserAttributes: [{ Name: "email", Value: "mallory@elsewhere.test" }],
+  }),
+);
+await cognito.adminSetUserPassword(
+  new AdminSetUserPasswordCommand({
+    UserPoolId: pool.UserPool?.Id,
+    Username: "mallory",
+    Password: "Sup3rSecretPassw0rd!",
+    Permanent: true,
+  }),
+);
+
+try {
+  await cognito.adminInitiateAuth(
+    new AdminInitiateAuthCommand({
+      UserPoolId: pool.UserPool?.Id,
+      ClientId: appClient.UserPoolClient?.ClientId,
+      AuthFlow: "ADMIN_USER_PASSWORD_AUTH",
+      AuthParameters: {
+        USERNAME: "mallory",
+        PASSWORD: "Sup3rSecretPassw0rd!",
+      },
+    }),
+  );
+} catch (error) {
+  // The handler's own words, in the error real Cognito refuses the sign-in
+  // with.
+  console.log((error as Error).name); // "UserLambdaValidationException"
+  console.log((error as Error).message);
+  // "PreAuthentication failed with error Only example.com may sign in."
+}
+```
+
+The event carries the trigger's own `triggerSource`, which is
+`PreAuthentication_Authentication` or `PostAuthentication_Authentication`, along with `version`,
+`region`, `userPoolId`, `userName`, a `callerContext` naming the app client, and the `request` and
+`response` pair. `ClientMetadata` on the sign-in reaches the handler as `request.validationData` for
+`PreAuthentication` and as `request.clientMetadata` for `PostAuthentication`, as it does on real
+Cognito.
+
+Three failures are reported the way real Cognito reports them:
+
+- A handler that throws refuses the sign-in with `UserLambdaValidationException`, carrying the
+  message it threw.
+- A trigger naming a function that is not there, or one whose resource policy does not admit
+  `cognito-idp.amazonaws.com` for the pool, fails with `UnexpectedLambdaException`.
+- A handler that returns something other than the event it was given fails with
+  `InvalidLambdaResponseException`.
+
+Only these two triggers run. Every other `LambdaConfig` key is refused when the pool is created,
+naming the trigger, so a pool never quietly drops one.
+
 ## Token timestamps and expiry
 
 `iat`, `exp` and `auth_time` come from the simulation's clock rather than the host's, and the tokens
@@ -1160,11 +1310,13 @@ the secret with `DescribeUserPoolClient`, which reports it here as it does on re
 
 The properties each type reads are the ones this simulation models:
 
-- `AWS::Cognito::UserPool`: `UserPoolName`, `Policies`, `DeletionProtection`,
+- `AWS::Cognito::UserPool`: `UserPoolName`, `Policies`, `DeletionProtection`, `LambdaConfig`,
   `AdminCreateUserConfig`, `AutoVerifiedAttributes`, `MfaConfiguration`, `UserPoolTier`,
   `AccountRecoverySetting`, `EmailVerificationMessage`, `EmailVerificationSubject`,
-  `SmsVerificationMessage` and `VerificationMessageTemplate`. The last six are accepted at one value
-  each and refused at any other, as `CreateUserPool` refuses them.
+  `SmsVerificationMessage` and `VerificationMessageTemplate`. `LambdaConfig` is read a trigger at a
+  time, so a template naming a trigger this simulation runs deploys and one naming a trigger it
+  does not fails the stack. The last six are accepted at one value each and refused at any other,
+  as `CreateUserPool` refuses them.
 - `AWS::Cognito::UserPoolClient`: `UserPoolId`, `ClientName`, `GenerateSecret`, `ExplicitAuthFlows`,
   `PreventUserExistenceErrors`, `AccessTokenValidity`, `IdTokenValidity`, `RefreshTokenValidity`,
   `TokenValidityUnits`, `AllowedOAuthFlowsUserPoolClient` and `SupportedIdentityProviders`. The last
@@ -1505,6 +1657,8 @@ Sim Cognito currently supports:
   `USER_PASSWORD_AUTH` and `REFRESH_TOKEN_AUTH` flows, authorized by no IAM policy as they are on
   real Cognito
 - `GlobalSignOutCommand` and `AdminUserGlobalSignOutCommand`, which revoke the tokens a user holds
+- The `PreAuthentication` and `PostAuthentication` Lambda triggers, invoked with the real event
+  around a sign-in, with the pool's own `ClientMetadata` reaching them
 - Real RS256 JWTs, signed by a key the pool publishes as a JWKS, so a verifier configured for the
   pool verifies them unchanged
 - A pool's `.well-known/jwks.json` and `.well-known/openid-configuration` served over HTTP by
@@ -1605,8 +1759,18 @@ Current documented limitations:
   implemented, so `LastModifiedDate` is always the creation date.
 - A pool with `DeletionProtection: ACTIVE` cannot be deleted at all, because deactivating the
   protection needs `UpdateUserPool`.
+- `PreAuthentication` and `PostAuthentication` are the only Lambda triggers that run. Every other
+  `LambdaConfig` key is refused when the pool is created, naming the trigger, because a pool that
+  accepted one would never call the function the template named. The sign-up, token generation and
+  message triggers wait on the features they fire for; the custom challenge triggers would need a
+  challenge loop this simulation does not have; and the migration and federation triggers have no
+  external directory to reach.
+- A `PostAuthentication` handler that throws fails the request, and the sign-in it ran after is not
+  undone: the tokens the pool issued stay issued, as they do on real Cognito.
+- Neither trigger fires for `REFRESH_TOKEN_AUTH`, as neither does on real Cognito. `ClientMetadata`
+  on a refresh is accepted and reaches nothing.
 - Unsimulated `CreateUserPool` inputs are refused rather than ignored: `UsernameAttributes`,
-  `AliasAttributes`, `Schema`, `LambdaConfig`, `UsernameConfiguration`,
+  `AliasAttributes`, `Schema`, `UsernameConfiguration`,
   `UserAttributeUpdateSettings`, `DeviceConfiguration`, `UserPoolAddOns`, `KeyConfiguration`,
   `IssuerConfiguration`, `UserPoolTags`, the email and SMS configurations, an
   `SmsAuthenticationMessage`, an `MfaConfiguration` other than `OFF`, a `UserPoolTier` other than
@@ -1632,10 +1796,9 @@ Current documented limitations:
 - An `AllowedOAuthFlowsUserPoolClient` of `false`, and a `SupportedIdentityProviders` of
   `["COGNITO"]`, are accepted and change nothing, because both say the client wants the pool's own
   users and nothing else, which is all there is here. `DescribeUserPoolClient` reports them back.
-- Unsimulated authentication inputs are refused the same way: `ClientMetadata` and
-  `AnalyticsMetadata` on all four operations, `ContextData` on the admin ones, `UserContextData` on
-  the client ones, and a `Session` on `InitiateAuth` or `AdminInitiateAuth`, which continues a flow
-  neither of them starts.
+- Unsimulated authentication inputs are refused the same way: `AnalyticsMetadata` on all four
+  operations, `ContextData` on the admin ones, `UserContextData` on the client ones, and a `Session`
+  on `InitiateAuth` or `AdminInitiateAuth`, which continues a flow neither of them starts.
 - A pool does not report `SchemaAttributes`. Real Cognito reports the standard attribute schema on
   every pool, and there are no user attributes here to describe.
 - Managed login and the hosted UI are not simulated, and neither are the OAuth endpoints, the

--- a/docs/services/cognito/sim-cognito-lambda-triggers.example.ts
+++ b/docs/services/cognito/sim-cognito-lambda-triggers.example.ts
@@ -1,0 +1,117 @@
+/**
+ * A user pool that runs a PreAuthentication trigger on every sign-in.
+ */
+
+import {
+  AdminCreateUserCommand,
+  AdminInitiateAuthCommand,
+  AdminSetUserPasswordCommand,
+  CreateUserPoolClientCommand,
+  CreateUserPoolCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import {
+  AddPermissionCommand,
+  CreateFunctionCommand,
+} from "@aws-sdk/client-lambda";
+
+import { SimAws } from "@kensio/yulin";
+import { makeLambdaZipFileInput } from "@kensio/yulin/lambda";
+
+/**
+ * The part of the PreAuthentication event this handler reads.
+ */
+interface PreAuthenticationEvent {
+  readonly request: { readonly userAttributes: Record<string, string> };
+}
+
+const simAws = new SimAws();
+const lambda = simAws.lambda();
+const cognito = simAws.cognitoIdentityProvider();
+
+// The trigger turns away anyone who is not on the domain the pool is for, and
+// hands the event back otherwise, as every trigger handler has to.
+await lambda.createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "pre-auth",
+    Role: "arn:aws:iam::888888888888:role/PreAuthRole",
+    Code: {
+      ZipFile: makeLambdaZipFileInput((event: PreAuthenticationEvent) => {
+        const email = event.request.userAttributes["email"] ?? "";
+
+        if (!email.endsWith("@example.com")) {
+          throw new Error("Only example.com may sign in");
+        }
+
+        return event;
+      }),
+    },
+  }),
+);
+
+// The pool names the function by ARN. Nothing is resolved until a sign-in runs
+// the trigger, so the pool can be created before the function exists.
+const pool = await cognito.createUserPool(
+  new CreateUserPoolCommand({
+    PoolName: "myapp-users",
+    LambdaConfig: {
+      PreAuthentication:
+        "arn:aws:lambda:us-east-1:888888888888:function:pre-auth",
+    },
+  }),
+);
+
+// Cognito invokes the function as a service, so the function's resource policy
+// has to admit it for this pool.
+await lambda.addPermission(
+  new AddPermissionCommand({
+    FunctionName: "pre-auth",
+    StatementId: "AllowCognito",
+    Action: "lambda:InvokeFunction",
+    Principal: "cognito-idp.amazonaws.com",
+    SourceArn: pool.UserPool?.Arn,
+  }),
+);
+
+const appClient = await cognito.createUserPoolClient(
+  new CreateUserPoolClientCommand({
+    UserPoolId: pool.UserPool?.Id,
+    ClientName: "web",
+    ExplicitAuthFlows: ["ALLOW_ADMIN_USER_PASSWORD_AUTH"],
+  }),
+);
+
+await cognito.adminCreateUser(
+  new AdminCreateUserCommand({
+    UserPoolId: pool.UserPool?.Id,
+    Username: "mallory",
+    UserAttributes: [{ Name: "email", Value: "mallory@elsewhere.test" }],
+  }),
+);
+await cognito.adminSetUserPassword(
+  new AdminSetUserPasswordCommand({
+    UserPoolId: pool.UserPool?.Id,
+    Username: "mallory",
+    Password: "Sup3rSecretPassw0rd!",
+    Permanent: true,
+  }),
+);
+
+try {
+  await cognito.adminInitiateAuth(
+    new AdminInitiateAuthCommand({
+      UserPoolId: pool.UserPool?.Id,
+      ClientId: appClient.UserPoolClient?.ClientId,
+      AuthFlow: "ADMIN_USER_PASSWORD_AUTH",
+      AuthParameters: {
+        USERNAME: "mallory",
+        PASSWORD: "Sup3rSecretPassw0rd!",
+      },
+    }),
+  );
+} catch (error) {
+  // The handler's own words, in the error real Cognito refuses the sign-in
+  // with.
+  console.log((error as Error).name); // "UserLambdaValidationException"
+  console.log((error as Error).message);
+  // "PreAuthentication failed with error Only example.com may sign in."
+}

--- a/docs/services/lambda/README.md
+++ b/docs/services/lambda/README.md
@@ -1281,10 +1281,13 @@ granted for `AWS_IAM` does not also open a URL later switched to `NONE`.
 
 `SourceArn` becomes an `ArnLike` condition on `AWS:SourceArn`, and `SourceAccount` a `StringEquals`
 condition on `AWS:SourceAccount`. Both are evaluated when another simulated service invokes the
-function, which today means a simulated API Gateway HTTP API invoking it through a Lambda proxy
-integration or as a `REQUEST` authorizer. The source ARN is what the API is invoking the function
-for, and the source Account is the API's own. See
-[Granting the API permission to invoke the function](../apigatewayv2/README.md#granting-the-api-permission-to-invoke-the-function).
+function: a simulated API Gateway HTTP API invoking it through a Lambda proxy integration or as a
+`REQUEST` authorizer, a simulated S3 Bucket delivering an event notification, and a simulated
+Cognito user pool running a Lambda trigger. The source ARN is what that service is invoking the
+function for — the API, the Bucket or the user pool — and the source Account is that service's
+resource's own. See
+[Granting the API permission to invoke the function](../apigatewayv2/README.md#granting-the-api-permission-to-invoke-the-function)
+and [Lambda triggers](../cognito/README.md#lambda-triggers).
 A direct `Invoke`, a Function URL request and an SQS event source mapping supply neither, so a
 statement carrying one does not match them.
 

--- a/src/service/aws/factory/sim-aws-account-region-service-builder.ts
+++ b/src/service/aws/factory/sim-aws-account-region-service-builder.ts
@@ -10,6 +10,7 @@ import { SimCognitoHttpApiJwtIssuerKeys } from "../../apigatewayv2/api/authorize
 import { SimRoute53AcmDnsRecords } from "../../acm/validation/sim-route53-acm-dns-records.js";
 import { SimCloudFormation } from "../../cloudformation/index.js";
 import { SimCognitoIdentityProvider } from "../../cognito/index.js";
+import { simAwsCognitoTriggerFunctions } from "../../cognito/user-pool/trigger/sim-aws-cognito-trigger-functions.js";
 import { SimDynamoDb as SimDynamoDatabase } from "../../dynamodb/index.js";
 import type { SimIamRegistry } from "../../iam/registry/sim-iam-registry.js";
 import { SimKms } from "../../kms/index.js";
@@ -141,9 +142,8 @@ export class SimAwsAccountRegionServiceBuilder {
       accountRegionScope: scope.accountRegionScope,
       iam: this.accountServices.createIam(scope),
       background: this.background,
-      // Pool ids are unique across the simulation, and a pool is reachable by
-      // id alone from the serving layer, whichever scope created it.
       userPoolRegistry: this.registries.cognito,
+      triggerFunctions: simAwsCognitoTriggerFunctions(this.simAws),
     });
   }
 

--- a/src/service/cloudformation/cdk/cognito/sim-cdk-cognito-user-pool-trigger.loc.test.ts
+++ b/src/service/cloudformation/cdk/cognito/sim-cdk-cognito-user-pool-trigger.loc.test.ts
@@ -1,0 +1,202 @@
+import {
+  AdminCreateUserCommand,
+  AdminInitiateAuthCommand,
+  AdminSetUserPasswordCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import { GetObjectCommand } from "@aws-sdk/client-s3";
+import { text } from "node:stream/consumers";
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertTypeString,
+} from "@kensio/smartass";
+import path from "node:path";
+import { describe, it } from "vitest";
+
+/**
+ * Slower local integration test. Calls the real CDK CLI to synth the template
+ * for `userPool.addTrigger(...)`, which CDK writes as a `LambdaConfig` on the
+ * pool plus the `AWS::Lambda::Permission` that lets Cognito invoke the
+ * function.
+ */
+import { SimAws } from "../../../aws/sim-aws.js";
+import { TestCdkProject } from "../../../../util/filesystem/test-cdk-project.js";
+
+const cdkAccountId = "111111111111";
+const cdkRegionName = "eu-west-2";
+const password = "Sup3rSecretPassw0rd!";
+
+/**
+ * A trigger handler that records the sign-in it saw into a Bucket, and turns
+ * away anyone whose email is not on the domain the pool is for.
+ *
+ * Writing the record is what shows the deployed function really ran, and
+ * throwing is what shows its answer reached the sign-in.
+ */
+const preAuthHandlerSource = `
+const { S3Client, PutObjectCommand } = require("@aws-sdk/client-s3");
+const s3Client = new S3Client({});
+exports.handler = async (event) => {
+  await s3Client.send(
+    new PutObjectCommand({
+      Bucket: "cdk-cognito-trigger-audit",
+      Key: event.userName,
+      Body: event.triggerSource,
+    }),
+  );
+
+  const email = event.request.userAttributes.email ?? "";
+  if (!email.endsWith("@example.com")) {
+    throw new Error("Only example.com may sign in");
+  }
+
+  return event;
+};
+`;
+
+describe("Sim CDK Cognito user pool trigger local integration", () => {
+  it("deploys a CDK addTrigger and runs it on a sign-in", async () => {
+    // Given a CDK stack whose user pool has a PreAuthentication trigger, added
+    // the way a CDK app adds one, with no hand-written LambdaConfig or
+    // permission anywhere.
+    const cdkProject = new TestCdkProject();
+    await cdkProject.writeCdkAppFile(
+      `
+import * as cdk from "aws-cdk-lib/core";
+import * as cognito from "aws-cdk-lib/aws-cognito";
+import * as lambda from "aws-cdk-lib/aws-lambda";
+import * as s3 from "aws-cdk-lib/aws-s3";
+
+const app = new cdk.App();
+const stack = new cdk.Stack(app, "TestStack", {
+  env: { account: "${cdkAccountId}", region: "${cdkRegionName}" },
+});
+
+const auditBucket = new s3.Bucket(stack, "AuditBucket", {
+  bucketName: "cdk-cognito-trigger-audit",
+});
+
+const preAuth = new lambda.Function(stack, "PreAuth", {
+  runtime: lambda.Runtime.NODEJS_20_X,
+  handler: "index.handler",
+  code: lambda.Code.fromInline(${JSON.stringify(preAuthHandlerSource)}),
+});
+
+auditBucket.grantPut(preAuth);
+
+const pool = new cognito.UserPool(stack, "Pool");
+pool.addTrigger(cognito.UserPoolOperation.PRE_AUTHENTICATION, preAuth);
+
+const client = pool.addClient("Client", {
+  disableOAuth: true,
+  authFlows: { adminUserPassword: true },
+});
+
+new cdk.CfnOutput(stack, "PoolId", { value: pool.userPoolId });
+new cdk.CfnOutput(stack, "ClientId", { value: client.userPoolClientId });
+
+app.synth();
+      `,
+    );
+
+    const cdkOutDirectory = await cdkProject.synth();
+
+    // When the synthesized template is deployed.
+    const simAws = new SimAws();
+    const scoped = simAws.account(cdkAccountId).region(cdkRegionName);
+    const stack = await scoped
+      .cloudFormation()
+      .deployTemplateFile(
+        path.join(cdkOutDirectory, "TestStack.template.json"),
+      );
+    await stack.waitForDeployComplete();
+
+    const userPoolId = stack.outputs.get("PoolId")?.value;
+    const clientId = stack.outputs.get("ClientId")?.value;
+    assertTypeString(userPoolId);
+    assertTypeString(clientId);
+
+    // And a user on the domain the trigger admits signs in.
+    const cognito = scoped.cognitoIdentityProvider();
+    await cognito.adminCreateUser(
+      new AdminCreateUserCommand({
+        UserPoolId: userPoolId,
+        Username: "alice",
+        UserAttributes: [{ Name: "email", Value: "alice@example.com" }],
+      }),
+    );
+    await cognito.adminSetUserPassword(
+      new AdminSetUserPasswordCommand({
+        UserPoolId: userPoolId,
+        Username: "alice",
+        Password: password,
+        Permanent: true,
+      }),
+    );
+
+    const signedIn = await cognito.adminInitiateAuth(
+      new AdminInitiateAuthCommand({
+        UserPoolId: userPoolId,
+        ClientId: clientId,
+        AuthFlow: "ADMIN_USER_PASSWORD_AUTH",
+        AuthParameters: { USERNAME: "alice", PASSWORD: password },
+      }),
+    );
+
+    // Then the sign-in succeeded, and the deployed function ran as part of it,
+    // reaching the Bucket the same stack granted it.
+    assertNonNullable(signedIn.AuthenticationResult?.AccessToken);
+
+    const audited = await scoped.s3().getObject(
+      new GetObjectCommand({
+        Bucket: "cdk-cognito-trigger-audit",
+        Key: "alice",
+      }),
+    );
+    assertNonNullable(audited.Body);
+    assertIdentical(
+      await text(audited.Body as NodeJS.ReadableStream),
+      "PreAuthentication_Authentication",
+    );
+
+    // And a user the trigger turns away is refused, with the words its handler
+    // threw, so the deployed function decides the sign-in rather than only
+    // watching it.
+    await cognito.adminCreateUser(
+      new AdminCreateUserCommand({
+        UserPoolId: userPoolId,
+        Username: "mallory",
+        UserAttributes: [{ Name: "email", Value: "mallory@elsewhere.test" }],
+      }),
+    );
+    await cognito.adminSetUserPassword(
+      new AdminSetUserPasswordCommand({
+        UserPoolId: userPoolId,
+        Username: "mallory",
+        Password: password,
+        Permanent: true,
+      }),
+    );
+
+    const error = await assertThrowsErrorAsync(async () =>
+      cognito.adminInitiateAuth(
+        new AdminInitiateAuthCommand({
+          UserPoolId: userPoolId,
+          ClientId: clientId,
+          AuthFlow: "ADMIN_USER_PASSWORD_AUTH",
+          AuthParameters: { USERNAME: "mallory", PASSWORD: password },
+        }),
+      ),
+    );
+
+    assertIdentical(error.name, "UserLambdaValidationException");
+    assertStringIncludes(
+      error.message,
+      "PreAuthentication failed with error Only example.com may sign in.",
+    );
+
+    await simAws.backgroundTasksComplete();
+  });
+});

--- a/src/service/cognito/cfn/sim-cfn-cognito-lambda-triggers.iso.test.ts
+++ b/src/service/cognito/cfn/sim-cfn-cognito-lambda-triggers.iso.test.ts
@@ -1,0 +1,194 @@
+import {
+  AdminCreateUserCommand,
+  AdminInitiateAuthCommand,
+  AdminSetUserPasswordCommand,
+  DescribeUserPoolCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertTypeString,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import type { SimAws } from "../../aws/sim-aws.js";
+import type { SimCfnTemplateValueRecord } from "../../cloudformation/template/value/sim-cfn-template-value.js";
+import {
+  deployFailure,
+  deploySuccess,
+  simAwsInEuWest2,
+} from "../../../../test/cognito/cfn-deploy.js";
+
+const password = "Sup3rSecretPassw0rd!";
+
+const triggerRole: SimCfnTemplateValueRecord = {
+  Type: "AWS::IAM::Role",
+  Properties: {
+    RoleName: "trigger-role",
+    AssumeRolePolicyDocument: {
+      Version: "2012-10-17",
+      Statement: [
+        {
+          Effect: "Allow",
+          Principal: { Service: "lambda.amazonaws.com" },
+          Action: "sts:AssumeRole",
+        },
+      ],
+    },
+  },
+};
+
+/**
+ * A trigger handler that turns the sign-in down, so a test can see that the
+ * deployed pool really invoked it rather than signing the user in regardless.
+ */
+const trigger: SimCfnTemplateValueRecord = {
+  Type: "AWS::Lambda::Function",
+  Properties: {
+    FunctionName: "pre-auth",
+    Role: { "Fn::GetAtt": ["TriggerRole", "Arn"] },
+    Code: {
+      ZipFile:
+        "exports.handler = async () => { throw new Error('Not today'); };",
+    },
+    Handler: "index.handler",
+    Runtime: "nodejs20.x",
+  },
+};
+
+/**
+ * The permission CDK emits alongside a `UserPool.addTrigger`, naming the pool
+ * as the source so no other pool may invoke the function.
+ */
+const triggerPermission: SimCfnTemplateValueRecord = {
+  Type: "AWS::Lambda::Permission",
+  Properties: {
+    Action: "lambda:InvokeFunction",
+    FunctionName: { "Fn::GetAtt": ["Trigger", "Arn"] },
+    Principal: "cognito-idp.amazonaws.com",
+    SourceArn: { "Fn::GetAtt": ["AppPool", "Arn"] },
+  },
+};
+
+function poolWithTrigger(
+  lambdaConfig: SimCfnTemplateValueRecord,
+): SimCfnTemplateValueRecord {
+  return {
+    TriggerRole: triggerRole,
+    Trigger: trigger,
+    AppPool: {
+      Type: "AWS::Cognito::UserPool",
+      Properties: { UserPoolName: "myapp-users", LambdaConfig: lambdaConfig },
+    },
+    TriggerPermission: triggerPermission,
+    AppClient: {
+      Type: "AWS::Cognito::UserPoolClient",
+      Properties: {
+        UserPoolId: { Ref: "AppPool" },
+        ClientName: "web",
+        ExplicitAuthFlows: ["ALLOW_ADMIN_USER_PASSWORD_AUTH"],
+      },
+    },
+  };
+}
+
+/**
+ * Add a user that can sign in straight away against the deployed pool.
+ */
+async function addConfirmedUser(
+  simAws: SimAws,
+  userPoolId: string,
+): Promise<void> {
+  const cognito = simAws.cognitoIdentityProvider();
+
+  await cognito.adminCreateUser(
+    new AdminCreateUserCommand({ UserPoolId: userPoolId, Username: "alice" }),
+  );
+  await cognito.adminSetUserPassword(
+    new AdminSetUserPasswordCommand({
+      UserPoolId: userPoolId,
+      Username: "alice",
+      Password: password,
+      Permanent: true,
+    }),
+  );
+}
+
+describe("Sim CloudFormation Cognito user pool Lambda triggers", () => {
+  it("deploys a pool whose trigger fires on a sign-in", async () => {
+    // Given a template with a function, a pool naming it as its
+    // PreAuthentication trigger, and the permission letting Cognito invoke it.
+    const simAws = simAwsInEuWest2();
+
+    // When the stack is deployed.
+    const stack = await deploySuccess(
+      simAws,
+      poolWithTrigger({
+        PreAuthentication: { "Fn::GetAtt": ["Trigger", "Arn"] },
+      }),
+      {
+        PoolId: { Value: { Ref: "AppPool" } },
+        ClientId: { Value: { Ref: "AppClient" } },
+      },
+    );
+
+    const userPoolId = stack.outputs.get("PoolId")?.value;
+    const clientId = stack.outputs.get("ClientId")?.value;
+    assertTypeString(userPoolId);
+    assertTypeString(clientId);
+
+    // Then the deployed pool carries the trigger, rather than having dropped
+    // it on the way to CreateUserPool.
+    const described = await simAws
+      .cognitoIdentityProvider()
+      .describeUserPool(
+        new DescribeUserPoolCommand({ UserPoolId: userPoolId }),
+      );
+    assertNonNullable(described.UserPool?.LambdaConfig?.PreAuthentication);
+    assertStringIncludes(
+      described.UserPool.LambdaConfig.PreAuthentication,
+      ":function:pre-auth",
+    );
+
+    // And a sign-in against the deployed pool runs it: the handler the template
+    // deployed refuses, and the sign-in is refused with its words.
+    await addConfirmedUser(simAws, userPoolId);
+
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.cognitoIdentityProvider().adminInitiateAuth(
+        new AdminInitiateAuthCommand({
+          UserPoolId: userPoolId,
+          ClientId: clientId,
+          AuthFlow: "ADMIN_USER_PASSWORD_AUTH",
+          AuthParameters: { USERNAME: "alice", PASSWORD: password },
+        }),
+      ),
+    );
+
+    assertIdentical(error.name, "UserLambdaValidationException");
+    assertStringIncludes(
+      error.message,
+      "PreAuthentication failed with error Not today.",
+    );
+  });
+
+  it("fails a stack asking for a trigger this simulation does not run", async () => {
+    // Given a template naming a sign-up trigger.
+    const simAws = simAwsInEuWest2();
+
+    // When the stack is deployed.
+    const error = await deployFailure(
+      simAws,
+      poolWithTrigger({ PreSignUp: { "Fn::GetAtt": ["Trigger", "Arn"] } }),
+    );
+
+    // Then the stack fails rather than deploying a pool that would never call
+    // the function the template named.
+    assertStringIncludes(
+      error.message,
+      "CreateUserPool LambdaConfig PreSignUp is not simulated",
+    );
+  });
+});

--- a/src/service/cognito/cfn/user-pool/sim-cfn-cognito-user-pool-properties.ts
+++ b/src/service/cognito/cfn/user-pool/sim-cfn-cognito-user-pool-properties.ts
@@ -22,6 +22,11 @@ import { SimCfnCognitoPolicies } from "./sim-cfn-cognito-policies.js";
  * decides whether `SignUp` is allowed at all, and the second decides which
  * attributes confirming a sign-up marks as verified.
  *
+ * `LambdaConfig` is here because the pool runs the triggers it names.
+ * CreateUserPool reads it a key at a time, so a template asking for a trigger
+ * this simulation fires deploys and one asking for a trigger it does not fails
+ * the stack, rather than the two being decided together.
+ *
  * The five from `AccountRecoverySetting` down are here because a CDK
  * `UserPool` construct emits them when it was asked for nothing in
  * particular. Each configures message delivery, verification wording or
@@ -33,6 +38,7 @@ const simulatedProperties = [
   "UserPoolName",
   "Policies",
   "DeletionProtection",
+  "LambdaConfig",
   "MfaConfiguration",
   "UserPoolTier",
   "AdminCreateUserConfig",
@@ -88,6 +94,10 @@ export class SimCfnCognitoUserPoolProperties {
       DeletionProtection: this.string(
         this.properties["DeletionProtection"],
         "DeletionProtection",
+      ),
+      LambdaConfig: this.record(
+        this.properties["LambdaConfig"],
+        "LambdaConfig",
       ),
       MfaConfiguration: this.string(
         this.properties["MfaConfiguration"],

--- a/src/service/cognito/command/auth/sim-cognito-admin-initiate-auth.ts
+++ b/src/service/cognito/command/auth/sim-cognito-admin-initiate-auth.ts
@@ -40,10 +40,10 @@ export class SimCognitoAdminInitiateAuth {
   /**
    * Start an authentication.
    */
-  handle(
+  async handle(
     command: SimAdminInitiateAuthCommand,
     options?: SimCognitoCommandOptions,
-  ): SimAdminInitiateAuthCommandOutput {
+  ): Promise<SimAdminInitiateAuthCommandOutput> {
     const { input } = command;
     const { pool, client } = this.authResolver.poolClient(
       "cognito-idp:AdminInitiateAuth",
@@ -57,13 +57,14 @@ export class SimCognitoAdminInitiateAuth {
 
     flow.requireEnabledFor(client);
 
-    return this.flowRunner.run(flow, {
+    return await this.flowRunner.run(flow, {
       pool,
       client,
       parameters: new SimCognitoAuthParameters(
         "AuthParameters",
         input.AuthParameters,
       ),
+      clientMetadata: input.ClientMetadata,
     });
   }
 }

--- a/src/service/cognito/command/auth/sim-cognito-admin-respond-to-challenge.ts
+++ b/src/service/cognito/command/auth/sim-cognito-admin-respond-to-challenge.ts
@@ -37,10 +37,10 @@ export class SimCognitoAdminRespondToChallenge {
   /**
    * Answer a challenge.
    */
-  handle(
+  async handle(
     command: SimAdminRespondToAuthChallengeCommand,
     options?: SimCognitoCommandOptions,
-  ): SimAdminRespondToAuthChallengeCommandOutput {
+  ): Promise<SimAdminRespondToAuthChallengeCommandOutput> {
     const { input } = command;
     const { pool, client } = this.authResolver.poolClient(
       "cognito-idp:AdminRespondToAuthChallenge",
@@ -51,7 +51,7 @@ export class SimCognitoAdminRespondToChallenge {
     this.unsimulatedOptions.refuseInAdminResponse(input);
     requireSimCognitoNewPasswordChallenge(input.ChallengeName);
 
-    return this.newPassword.handle({
+    return await this.newPassword.handle({
       pool,
       client,
       parameters: new SimCognitoAuthParameters(
@@ -59,6 +59,7 @@ export class SimCognitoAdminRespondToChallenge {
         input.ChallengeResponses,
       ),
       session: input.Session,
+      clientMetadata: input.ClientMetadata,
     });
   }
 }

--- a/src/service/cognito/command/auth/sim-cognito-auth-commands.ts
+++ b/src/service/cognito/command/auth/sim-cognito-auth-commands.ts
@@ -1,6 +1,8 @@
 import type { SimClock } from "../../../../util/clock/sim-clock.js";
 import type { SimCognitoUserPoolStore } from "../../user-pool/sim-cognito-user-pool-store.js";
 import { SimCognitoTokenIssuer } from "../../user-pool/token/sim-cognito-token-issuer.js";
+import type { SimCognitoTriggerFunctions } from "../../user-pool/trigger/sim-cognito-trigger-functions.js";
+import { SimCognitoUserPoolTriggers } from "../../user-pool/trigger/sim-cognito-user-pool-triggers.js";
 import type { SimCognitoRequestResolver } from "../sim-cognito-request-resolver.js";
 import { SimCognitoAdminInitiateAuth } from "./sim-cognito-admin-initiate-auth.js";
 import { SimCognitoAdminRespondToChallenge } from "./sim-cognito-admin-respond-to-challenge.js";
@@ -19,6 +21,7 @@ interface SimCognitoAuthCommandsProperties {
   readonly authResolver: SimCognitoAuthResolver;
   readonly pools: SimCognitoUserPoolStore;
   readonly clock: SimClock;
+  readonly triggerFunctions: SimCognitoTriggerFunctions;
 }
 
 /**
@@ -38,19 +41,25 @@ export class SimCognitoAuthCommands {
   public readonly signOut: SimCognitoSignOutCommands;
 
   constructor(properties: SimCognitoAuthCommandsProperties) {
-    const { resolver, authResolver, pools, clock } = properties;
+    const { resolver, authResolver, pools, clock, triggerFunctions } =
+      properties;
     const tokenIssuer = new SimCognitoTokenIssuer({ clock });
+    const triggers = new SimCognitoUserPoolTriggers({
+      functions: triggerFunctions,
+    });
     const flowRunner = new SimCognitoAuthFlowRunner({
       passwordSignIn: new SimCognitoPasswordSignIn({
         authResolver,
         tokenIssuer,
         challenge: new SimCognitoNewPasswordChallenge({ clock }),
+        triggers,
       }),
       refreshSignIn: new SimCognitoRefreshSignIn({ tokenIssuer, clock }),
     });
     const newPassword = new SimCognitoNewPasswordResponse({
       authResolver,
       tokenIssuer,
+      triggers,
       clock,
     });
 

--- a/src/service/cognito/command/auth/sim-cognito-auth-flow-runner.ts
+++ b/src/service/cognito/command/auth/sim-cognito-auth-flow-runner.ts
@@ -17,6 +17,10 @@ interface SimCognitoAuthFlowRunnerProperties {
  * `AdminInitiateAuth` and `InitiateAuth` accept different flow names and reach
  * the pool differently, and once a flow is resolved they run the same bodies,
  * so the running of one lives here rather than in either command.
+ *
+ * Running a flow is asynchronous because a password sign-in may have to wait
+ * on the pool's Lambda triggers. A refresh runs no trigger, as it does not on
+ * real Cognito, and answers without waiting on anything.
  */
 export class SimCognitoAuthFlowRunner {
   private readonly passwordSignIn: SimCognitoPasswordSignIn;
@@ -30,14 +34,14 @@ export class SimCognitoAuthFlowRunner {
   /**
    * Run a flow the app client is configured for.
    */
-  run(
+  async run(
     flow: SimCognitoAuthFlow,
     request: SimCognitoAuthRequest,
-  ): SimCognitoAuthenticationOutput {
+  ): Promise<SimCognitoAuthenticationOutput> {
     if (flow.exchangesRefreshToken) {
       return this.refreshSignIn.handle(request);
     }
 
-    return this.passwordSignIn.handle(request);
+    return await this.passwordSignIn.handle(request);
   }
 }

--- a/src/service/cognito/command/auth/sim-cognito-initiate-auth.ts
+++ b/src/service/cognito/command/auth/sim-cognito-initiate-auth.ts
@@ -34,7 +34,9 @@ export class SimCognitoInitiateAuth {
   /**
    * Start an authentication.
    */
-  handle(command: SimInitiateAuthCommand): SimInitiateAuthCommandOutput {
+  async handle(
+    command: SimInitiateAuthCommand,
+  ): Promise<SimInitiateAuthCommandOutput> {
     const { input } = command;
     const { pool, client } = this.authResolver.client(input.ClientId);
 
@@ -44,13 +46,14 @@ export class SimCognitoInitiateAuth {
 
     flow.requireEnabledFor(client);
 
-    return this.flowRunner.run(flow, {
+    return await this.flowRunner.run(flow, {
       pool,
       client,
       parameters: new SimCognitoAuthParameters(
         "AuthParameters",
         input.AuthParameters,
       ),
+      clientMetadata: input.ClientMetadata,
     });
   }
 }

--- a/src/service/cognito/command/auth/sim-cognito-new-password-response.ts
+++ b/src/service/cognito/command/auth/sim-cognito-new-password-response.ts
@@ -5,6 +5,7 @@ import {
 } from "../../user-pool/auth/sim-cognito-sign-in.js";
 import { SimCognitoPasswordCheck } from "../../user-pool/sim-cognito-password-check.js";
 import type { SimCognitoTokenIssuer } from "../../user-pool/token/sim-cognito-token-issuer.js";
+import type { SimCognitoUserPoolTriggers } from "../../user-pool/trigger/sim-cognito-user-pool-triggers.js";
 import { SimCognitoAuthenticationResult } from "./sim-cognito-authentication-result.js";
 import type { SimCognitoAuthResolver } from "./sim-cognito-auth-resolver.js";
 import type { SimCognitoAuthRequest } from "./sim-cognito-password-sign-in.js";
@@ -13,6 +14,7 @@ import type { SimCognitoAuthenticationOutput } from "./auth.command.js";
 interface SimCognitoNewPasswordResponseProperties {
   readonly authResolver: SimCognitoAuthResolver;
   readonly tokenIssuer: SimCognitoTokenIssuer;
+  readonly triggers: SimCognitoUserPoolTriggers;
   readonly clock: SimClock;
 }
 
@@ -36,21 +38,28 @@ export interface SimCognitoChallengeResponseRequest extends SimCognitoAuthReques
 export class SimCognitoNewPasswordResponse {
   private readonly authResolver: SimCognitoAuthResolver;
   private readonly tokenIssuer: SimCognitoTokenIssuer;
+  private readonly triggers: SimCognitoUserPoolTriggers;
   private readonly clock: SimClock;
   private readonly result = new SimCognitoAuthenticationResult();
 
   constructor(properties: SimCognitoNewPasswordResponseProperties) {
     this.authResolver = properties.authResolver;
     this.tokenIssuer = properties.tokenIssuer;
+    this.triggers = properties.triggers;
     this.clock = properties.clock;
   }
 
   /**
    * Complete the challenge, and sign the user in.
+   *
+   * This is where the sign-in the challenge interrupted finishes, so it is
+   * where the pool's `PostAuthentication` trigger runs. `PreAuthentication`
+   * does not run again: it ran when the challenge was issued, and real Cognito
+   * fires it once per sign-in rather than once per request.
    */
-  handle(
+  async handle(
     request: SimCognitoChallengeResponseRequest,
-  ): SimCognitoAuthenticationOutput {
+  ): Promise<SimCognitoAuthenticationOutput> {
     const { pool, client, parameters } = request;
     const username = this.authResolver.username(client, parameters);
     const session = pool.auth.requireSession({
@@ -75,11 +84,20 @@ export class SimCognitoNewPasswordResponse {
 
     pool.auth.removeSession(session);
 
-    return {
+    const authenticated = {
       $metadata: {},
       AuthenticationResult: this.result.of(
         this.tokenIssuer.issue({ pool, client, user }),
       ),
     };
+
+    await this.triggers.postAuthentication({
+      pool,
+      client,
+      user,
+      clientMetadata: request.clientMetadata,
+    });
+
+    return authenticated;
   }
 }

--- a/src/service/cognito/command/auth/sim-cognito-password-sign-in.ts
+++ b/src/service/cognito/command/auth/sim-cognito-password-sign-in.ts
@@ -6,6 +6,7 @@ import {
 import type { SimCognitoUserPoolClient } from "../../user-pool/client/sim-cognito-user-pool-client.js";
 import type { SimCognitoUserPool } from "../../user-pool/sim-cognito-user-pool.js";
 import type { SimCognitoTokenIssuer } from "../../user-pool/token/sim-cognito-token-issuer.js";
+import type { SimCognitoUserPoolTriggers } from "../../user-pool/trigger/sim-cognito-user-pool-triggers.js";
 import { SimCognitoAuthenticationResult } from "./sim-cognito-authentication-result.js";
 import type { SimCognitoAuthParameters } from "./sim-cognito-auth-parameters.js";
 import type { SimCognitoAuthResolver } from "./sim-cognito-auth-resolver.js";
@@ -16,6 +17,7 @@ interface SimCognitoPasswordSignInProperties {
   readonly authResolver: SimCognitoAuthResolver;
   readonly tokenIssuer: SimCognitoTokenIssuer;
   readonly challenge: SimCognitoNewPasswordChallenge;
+  readonly triggers: SimCognitoUserPoolTriggers;
 }
 
 /**
@@ -25,6 +27,12 @@ export interface SimCognitoAuthRequest {
   readonly pool: SimCognitoUserPool;
   readonly client: SimCognitoUserPoolClient;
   readonly parameters: SimCognitoAuthParameters;
+
+  /**
+   * The `ClientMetadata` the request carried, which is what a Lambda trigger
+   * reads as its validation data or its client metadata.
+   */
+  readonly clientMetadata?: Readonly<Record<string, string>> | undefined;
 }
 
 /**
@@ -40,21 +48,41 @@ export class SimCognitoPasswordSignIn {
   private readonly authResolver: SimCognitoAuthResolver;
   private readonly tokenIssuer: SimCognitoTokenIssuer;
   private readonly challenge: SimCognitoNewPasswordChallenge;
+  private readonly triggers: SimCognitoUserPoolTriggers;
   private readonly result = new SimCognitoAuthenticationResult();
 
   constructor(properties: SimCognitoPasswordSignInProperties) {
     this.authResolver = properties.authResolver;
     this.tokenIssuer = properties.tokenIssuer;
     this.challenge = properties.challenge;
+    this.triggers = properties.triggers;
   }
 
   /**
    * Sign the user in, or answer with the challenge it has to get past first.
+   *
+   * The pool's `PreAuthentication` trigger runs once the user is known and
+   * before its password is checked, which is the order real Cognito runs it in:
+   * the trigger is given the user to decide about, and deciding is what it is
+   * for, so a wrong password reaches it too.
+   *
+   * `PostAuthentication` runs only where tokens were issued. A user answered
+   * with the `NEW_PASSWORD_REQUIRED` challenge has not signed in yet, and runs
+   * it when it answers the challenge instead.
    */
-  handle(request: SimCognitoAuthRequest): SimCognitoAuthenticationOutput {
-    const { pool, client, parameters } = request;
+  async handle(
+    request: SimCognitoAuthRequest,
+  ): Promise<SimCognitoAuthenticationOutput> {
+    const { pool, client, parameters, clientMetadata } = request;
     const username = this.authResolver.username(client, parameters);
     const user = requireSimCognitoSignInUser(pool, client, username);
+
+    await this.triggers.preAuthentication({
+      pool,
+      client,
+      user,
+      clientMetadata,
+    });
 
     requireSimCognitoSignIn(user, parameters.require("PASSWORD"));
     requireSimCognitoConfirmed(user);
@@ -63,11 +91,20 @@ export class SimCognitoPasswordSignIn {
       return this.challenge.issue({ pool, clientId: client.id, user });
     }
 
-    return {
+    const authenticated = {
       $metadata: {},
       AuthenticationResult: this.result.of(
         this.tokenIssuer.issue({ pool, client, user }),
       ),
     };
+
+    await this.triggers.postAuthentication({
+      pool,
+      client,
+      user,
+      clientMetadata,
+    });
+
+    return authenticated;
   }
 }

--- a/src/service/cognito/command/auth/sim-cognito-respond-to-challenge.iso.test.ts
+++ b/src/service/cognito/command/auth/sim-cognito-respond-to-challenge.iso.test.ts
@@ -191,7 +191,7 @@ describe("sim Cognito RespondToAuthChallenge", () => {
     // Given a user challenged for a new password.
     const { cognito, clientId, session } = await simCognitoChallenged();
 
-    // When the response carries data for a Lambda trigger.
+    // When the response carries Pinpoint analytics.
     const error = await assertThrowsErrorAsync(async () => {
       await cognito.respondToAuthChallenge(
         new RespondToAuthChallengeCommand({
@@ -199,13 +199,33 @@ describe("sim Cognito RespondToAuthChallenge", () => {
           ChallengeName: "NEW_PASSWORD_REQUIRED",
           Session: session,
           ChallengeResponses: { USERNAME: "alice", NEW_PASSWORD: newPassword },
-          ClientMetadata: { tenant: "acme" },
+          AnalyticsMetadata: { AnalyticsEndpointId: "endpoint" },
         }),
       );
     });
 
     // Then it is refused rather than answered as if nothing had been sent.
     assertInstanceOf(error, SimCognitoInvalidParameterException);
-    assertStringIncludes(error.message, "ClientMetadata is not simulated");
+    assertStringIncludes(error.message, "AnalyticsMetadata is not simulated");
+  });
+
+  it("accepts ClientMetadata, which a pool's triggers read", async () => {
+    // Given a user challenged for a new password.
+    const { cognito, clientId, session } = await simCognitoChallenged();
+
+    // When the response carries data for a Lambda trigger.
+    const signedIn = await cognito.respondToAuthChallenge(
+      new RespondToAuthChallengeCommand({
+        ClientId: clientId,
+        ChallengeName: "NEW_PASSWORD_REQUIRED",
+        Session: session,
+        ChallengeResponses: { USERNAME: "alice", NEW_PASSWORD: newPassword },
+        ClientMetadata: { tenant: "acme" },
+      }),
+    );
+
+    // Then the sign-in completed. A pool with no PostAuthentication trigger has
+    // nowhere to pass the metadata to, and ignores it as real Cognito does.
+    assertNonNullable(signedIn.AuthenticationResult?.AccessToken);
   });
 });

--- a/src/service/cognito/command/auth/sim-cognito-respond-to-challenge.ts
+++ b/src/service/cognito/command/auth/sim-cognito-respond-to-challenge.ts
@@ -33,16 +33,16 @@ export class SimCognitoRespondToChallenge {
   /**
    * Answer a challenge.
    */
-  handle(
+  async handle(
     command: SimRespondToAuthChallengeCommand,
-  ): SimRespondToAuthChallengeCommandOutput {
+  ): Promise<SimRespondToAuthChallengeCommandOutput> {
     const { input } = command;
     const { pool, client } = this.authResolver.client(input.ClientId);
 
     this.unsimulatedOptions.refuseInResponse(input);
     requireSimCognitoNewPasswordChallenge(input.ChallengeName);
 
-    return this.newPassword.handle({
+    return await this.newPassword.handle({
       pool,
       client,
       parameters: new SimCognitoAuthParameters(
@@ -50,6 +50,7 @@ export class SimCognitoRespondToChallenge {
         input.ChallengeResponses,
       ),
       session: input.Session,
+      clientMetadata: input.ClientMetadata,
     });
   }
 }

--- a/src/service/cognito/command/auth/sim-cognito-unsimulated-auth-options.ts
+++ b/src/service/cognito/command/auth/sim-cognito-unsimulated-auth-options.ts
@@ -11,7 +11,6 @@ import type {
  * honour.
  */
 interface SimCognitoUnsimulatedAuthInput {
-  readonly ClientMetadata?: Readonly<Record<string, string>> | undefined;
   readonly AnalyticsMetadata?: object | undefined;
 }
 
@@ -21,6 +20,11 @@ interface SimCognitoUnsimulatedAuthInput {
  * All of them change what real Cognito does with a sign-in, and none of them
  * can be honoured here, so a request carrying one is refused rather than
  * signed in as if it had not.
+ *
+ * `ClientMetadata` is not among them. It is what a sign-in passes to a Lambda
+ * trigger, and the pool's triggers now receive it, so a request carrying it is
+ * honoured rather than refused. A pool with no trigger to hand it to ignores it,
+ * which is what real Cognito does with it too.
  *
  * The admin operations and the client ones name the caller's device and
  * address differently, `ContextData` against `UserContextData`, so each
@@ -42,11 +46,6 @@ export class SimCognitoUnsimulatedAuthOptions {
     unsimulated: SimCognitoUnsimulatedInput,
     input: SimCognitoUnsimulatedAuthInput,
   ): void {
-    unsimulated.refuse(
-      "ClientMetadata",
-      input.ClientMetadata,
-      "passing data to a Lambda trigger",
-    );
     unsimulated.refuse(
       "AnalyticsMetadata",
       input.AnalyticsMetadata,

--- a/src/service/cognito/command/sim-cognito-commands.ts
+++ b/src/service/cognito/command/sim-cognito-commands.ts
@@ -5,6 +5,7 @@ import { SimCognitoUserPoolClientFactory } from "../user-pool/client/sim-cognito
 import { SimCognitoGroupFactory } from "../user-pool/group/sim-cognito-group-factory.js";
 import { SimCognitoUserPoolFactory } from "../user-pool/sim-cognito-user-pool-factory.js";
 import type { SimCognitoUserPoolStore } from "../user-pool/sim-cognito-user-pool-store.js";
+import type { SimCognitoTriggerFunctions } from "../user-pool/trigger/sim-cognito-trigger-functions.js";
 import { SimCognitoUserFactory } from "../user-pool/user/sim-cognito-user-factory.js";
 import { SimCognitoAuthCommands } from "./auth/sim-cognito-auth-commands.js";
 import { SimCognitoAuthResolver } from "./auth/sim-cognito-auth-resolver.js";
@@ -27,6 +28,7 @@ interface SimCognitoCommandsProperties {
   readonly iam: SimIamInterServiceAuthZ;
   readonly clock: SimClock;
   readonly pools: SimCognitoUserPoolStore;
+  readonly triggerFunctions: SimCognitoTriggerFunctions;
 }
 
 /**
@@ -51,7 +53,8 @@ export class SimCognitoCommands {
   public readonly auth: SimCognitoAuthCommands;
 
   constructor(properties: SimCognitoCommandsProperties) {
-    const { accountRegionScope, iam, clock, pools } = properties;
+    const { accountRegionScope, iam, clock, pools, triggerFunctions } =
+      properties;
     const authorizer = new SimCognitoAuthorizer({ iam, accountRegionScope });
     const resolver = new SimCognitoRequestResolver({ pools, authorizer });
     const authResolver = new SimCognitoAuthResolver({ resolver, pools });
@@ -92,6 +95,7 @@ export class SimCognitoCommands {
       authResolver,
       pools,
       clock,
+      triggerFunctions,
     });
   }
 }

--- a/src/service/cognito/command/user-pool/sim-cognito-unsimulated-pool-features.ts
+++ b/src/service/cognito/command/user-pool/sim-cognito-unsimulated-pool-features.ts
@@ -33,6 +33,11 @@ const accountRecoverySetting = {
  * goes, which is what decides whether `SignUp` is allowed. The two keys beside
  * it are about the invitation an admin-created user is sent, and no message is
  * ever delivered here, so those are refused.
+ *
+ * `LambdaConfig` is not here either. The triggers a pool can run are read by
+ * SimCognitoLambdaConfig, which accepts the two this simulation fires and
+ * refuses the rest one key at a time, so a pool can have a trigger without
+ * having every trigger.
  */
 export class SimCognitoUnsimulatedUserPoolFeatures {
   private readonly unsimulated = new SimCognitoUnsimulatedInput(
@@ -46,11 +51,6 @@ export class SimCognitoUnsimulatedUserPoolFeatures {
    * Refuse a request carrying a feature this simulation cannot honour.
    */
   refuseIn(input: SimCreateUserPoolCommandInput): void {
-    this.unsimulated.refuse(
-      "LambdaConfig",
-      input.LambdaConfig,
-      "Lambda triggers",
-    );
     this.unsimulated.refuse(
       "AliasAttributes",
       input.AliasAttributes,

--- a/src/service/cognito/command/user-pool/sim-cognito-user-pool-commands.ts
+++ b/src/service/cognito/command/user-pool/sim-cognito-user-pool-commands.ts
@@ -63,6 +63,7 @@ export class SimCognitoUserPoolCommands {
       deletionProtection: input.DeletionProtection,
       adminCreateUserConfig: input.AdminCreateUserConfig,
       autoVerifiedAttributes: input.AutoVerifiedAttributes,
+      lambdaConfig: input.LambdaConfig,
       unsimulatedSettings: input,
     });
 

--- a/src/service/cognito/command/user-pool/sim-cognito-user-pool-validation.iso.test.ts
+++ b/src/service/cognito/command/user-pool/sim-cognito-user-pool-validation.iso.test.ts
@@ -60,7 +60,7 @@ const refusedInputs: readonly RefusedInput[] = [
     input: {
       LambdaConfig: { PreSignUp: "arn:aws:lambda:eu-west-2:1:function:f" },
     },
-    says: "Lambda triggers",
+    says: "LambdaConfig PreSignUp is not simulated",
   },
   {
     label: "AliasAttributes",

--- a/src/service/cognito/command/user-pool/sim-cognito-user-pool-view.ts
+++ b/src/service/cognito/command/user-pool/sim-cognito-user-pool-view.ts
@@ -16,6 +16,9 @@ export class SimCognitoUserPoolView {
    * the request set them, so a template's declaration stays visible. Nothing
    * here reads any of them.
    *
+   * `LambdaConfig` is reported only by a pool that was created with one, and
+   * carries the triggers that pool runs.
+   *
    * `MfaConfiguration` is always `OFF` because MFA is not simulated.
    * `EstimatedNumberOfUsers` is how many users the pool holds now. Real
    * Cognito refreshes that number periodically rather than on each write, so
@@ -32,6 +35,7 @@ export class SimCognitoUserPoolView {
       Arn: pool.arn.value,
       Policies: { PasswordPolicy: pool.passwordPolicy.toOutput() },
       DeletionProtection: pool.deletionProtection.value,
+      LambdaConfig: pool.lambdaConfig.toOutput(),
       MfaConfiguration: "OFF",
       AdminCreateUserConfig: pool.adminCreateUserConfig.toOutput(),
       AutoVerifiedAttributes: pool.autoVerifiedAttributes.toOutput(),

--- a/src/service/cognito/command/user-pool/user-pool.command.ts
+++ b/src/service/cognito/command/user-pool/user-pool.command.ts
@@ -2,6 +2,7 @@ import type { SimResponseMetadata } from "../../../aws/metadata/response-metadat
 import type { SimCognitoAdminCreateUserConfigType } from "../../user-pool/sim-cognito-admin-create-user-config.js";
 import type { SimCognitoUserPoolPoliciesType } from "../../user-pool/sim-cognito-password-policy.js";
 import type { SimCognitoUnsimulatedPoolSettingsType } from "../../user-pool/sim-cognito-unsimulated-pool-settings.js";
+import type { SimCognitoLambdaConfigType } from "../../user-pool/trigger/sim-cognito-lambda-config.js";
 
 /**
  * A user pool as sim Cognito reports it.
@@ -18,6 +19,7 @@ export interface SimCognitoUserPoolType extends SimCognitoUnsimulatedPoolSetting
   readonly Arn?: string | undefined;
   readonly Policies?: SimCognitoUserPoolPoliciesType | undefined;
   readonly DeletionProtection?: string | undefined;
+  readonly LambdaConfig?: SimCognitoLambdaConfigType | undefined;
   readonly MfaConfiguration?: string | undefined;
   readonly AdminCreateUserConfig?:
     SimCognitoAdminCreateUserConfigType | undefined;

--- a/src/service/cognito/error/sim-cognito-trigger.error.ts
+++ b/src/service/cognito/error/sim-cognito-trigger.error.ts
@@ -1,0 +1,50 @@
+import { SimCognitoError } from "./sim-cognito.error.js";
+
+/**
+ * Simulated Cognito UserLambdaValidationException error.
+ *
+ * Real Cognito reports a Lambda trigger that threw this way, wrapping the
+ * handler's own message in a sentence naming the trigger that ran. That is the
+ * whole point of the error: a `PreAuthentication` handler refusing a sign-in
+ * does it by throwing, and the message it threw is what tells the caller why.
+ */
+export class SimCognitoUserLambdaValidationException extends SimCognitoError {
+  public override readonly name = "UserLambdaValidationException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
+ * Simulated Cognito UnexpectedLambdaException error.
+ *
+ * Real Cognito reports a trigger it could not invoke at all this way: the
+ * function is not there, or its resource policy does not admit
+ * `cognito-idp.amazonaws.com`. The handler never ran, so there is no message of
+ * its own to carry, and this simulation says which of the two happened instead
+ * of the bare "Unexpected exception" real Cognito answers with.
+ */
+export class SimCognitoUnexpectedLambdaException extends SimCognitoError {
+  public override readonly name = "UnexpectedLambdaException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
+ * Simulated Cognito InvalidLambdaResponseException error.
+ *
+ * Real Cognito reports a trigger that returned something it could not read this
+ * way. A trigger handler is given the event and has to return it, so a handler
+ * that returns nothing, or an object without the `request` it was handed, has
+ * dropped the event rather than answered with it.
+ */
+export class SimCognitoInvalidLambdaResponseException extends SimCognitoError {
+  public override readonly name = "InvalidLambdaResponseException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}

--- a/src/service/cognito/sim-cognito-identity-provider.ts
+++ b/src/service/cognito/sim-cognito-identity-provider.ts
@@ -25,6 +25,10 @@ import {
   type SimCognitoUserPoolId,
 } from "./user-pool/sim-cognito-user-pool-id.js";
 import { SimCognitoUserPoolStore } from "./user-pool/sim-cognito-user-pool-store.js";
+import {
+  SimCognitoNoTriggerFunctions,
+  type SimCognitoTriggerFunctions,
+} from "./user-pool/trigger/sim-cognito-trigger-functions.js";
 
 export type { SimCognitoIdentityProviderRequestOptions } from "./sim-cognito-user-directory.js";
 
@@ -32,7 +36,20 @@ interface SimCognitoIdentityProviderProperties {
   readonly accountRegionScope?: SimAwsAccountRegionScope;
   readonly iam?: SimIamInterServiceAuthZ;
   readonly background?: BackgroundScheduler;
+
+  /**
+   * Where every pool in the simulation is indexed by id. Pool ids are unique
+   * across a simulation, and a pool is reachable by id alone from the serving
+   * layer, whichever scope created it.
+   */
   readonly userPoolRegistry?: SimCognitoUserPoolRegistry;
+
+  /**
+   * The Lambda functions a pool's triggers can reach, which is the whole
+   * simulation rather than this scope: a `LambdaConfig` names a function by
+   * ARN, and that ARN can name any Account and Region.
+   */
+  readonly triggerFunctions?: SimCognitoTriggerFunctions;
 }
 
 /**
@@ -64,6 +81,7 @@ export class SimCognitoIdentityProvider extends SimCognitoUserDirectory {
       iam = new SimIamAllowAllAuth(),
       background = new BackgroundTasks(),
       userPoolRegistry = new SimCognitoUserPoolRegistry(),
+      triggerFunctions = new SimCognitoNoTriggerFunctions(),
     } = properties;
     const pools = new SimCognitoUserPoolStore({ registry: userPoolRegistry });
 
@@ -73,6 +91,7 @@ export class SimCognitoIdentityProvider extends SimCognitoUserDirectory {
         iam,
         clock: background,
         pools,
+        triggerFunctions,
       }),
       background,
     });

--- a/src/service/cognito/user-pool/sim-cognito-user-pool-arn.ts
+++ b/src/service/cognito/user-pool/sim-cognito-user-pool-arn.ts
@@ -30,9 +30,19 @@ interface SimCognitoUserPoolArnProperties {
 export class SimCognitoUserPoolArn {
   public readonly value: string;
 
+  /**
+   * The Account that owns the pool.
+   *
+   * This is kept alongside the ARN because it is what another service supplies
+   * as `AWS:SourceAccount` when the pool reaches it, such as a Lambda trigger
+   * invocation.
+   */
+  public readonly accountId: string;
+
   constructor(properties: SimCognitoUserPoolArnProperties) {
     this.value =
       cognitoUserPoolArnPrefix(properties.accountRegionScope) +
       properties.userPoolId;
+    this.accountId = properties.accountRegionScope.accountId;
   }
 }

--- a/src/service/cognito/user-pool/sim-cognito-user-pool-factory.ts
+++ b/src/service/cognito/user-pool/sim-cognito-user-pool-factory.ts
@@ -19,6 +19,7 @@ import {
   type SimCognitoUnsimulatedPoolSettingsType,
 } from "./sim-cognito-unsimulated-pool-settings.js";
 import type { SimCognitoUserPoolStore } from "./sim-cognito-user-pool-store.js";
+import { SimCognitoLambdaConfig } from "./trigger/sim-cognito-lambda-config.js";
 
 interface SimCognitoUserPoolFactoryProperties {
   readonly accountRegionScope: SimAwsAccountRegionScope;
@@ -33,6 +34,11 @@ interface SimCognitoMakeUserPoolProperties {
   readonly adminCreateUserConfig?:
     SimCognitoAdminCreateUserConfigType | undefined;
   readonly autoVerifiedAttributes?: readonly string[] | undefined;
+
+  /**
+   * The Lambda triggers the request asked the pool to run.
+   */
+  readonly lambdaConfig?: object | undefined;
 
   /**
    * The settings the request set that this simulation accepts without acting
@@ -91,6 +97,7 @@ export class SimCognitoUserPoolFactory {
       autoVerifiedAttributes: new SimCognitoAutoVerifiedAttributes(
         properties.autoVerifiedAttributes,
       ),
+      lambdaConfig: new SimCognitoLambdaConfig(properties.lambdaConfig),
       unsimulatedSettings: new SimCognitoUnsimulatedPoolSettings(
         properties.unsimulatedSettings ?? {},
       ),

--- a/src/service/cognito/user-pool/sim-cognito-user-pool-id.ts
+++ b/src/service/cognito/user-pool/sim-cognito-user-pool-id.ts
@@ -67,3 +67,40 @@ export function requireSimCognitoUserPoolId(
 
   return value as SimCognitoUserPoolId;
 }
+
+/**
+ * The Region a pool lives in, which its id names.
+ *
+ * This is where SDK code and token verifiers get it from too: splitting the id
+ * on the underscore is how the region is recovered everywhere, rather than
+ * being carried alongside.
+ */
+export function simCognitoUserPoolRegionName(userPoolId: string): string {
+  const [regionName] = userPoolId.split("_", 1);
+
+  return String(regionName);
+}
+
+/**
+ * The URL a token from a pool names as its issuer.
+ *
+ * This is the `iss` claim of the pool's tokens, the OIDC issuer its
+ * `.well-known` documents are served under, and what a JWT verifier is
+ * configured with.
+ */
+export function simCognitoUserPoolIssuerUrl(userPoolId: string): string {
+  const regionName = simCognitoUserPoolRegionName(userPoolId);
+
+  return `https://cognito-idp.${regionName}.amazonaws.com/${userPoolId}`;
+}
+
+/**
+ * The name a pool is known by where a scheme would be wrong.
+ *
+ * This is the issuer URL without `https://`, and it is what an identity pool
+ * names a user pool provider by, and what `AWS::Cognito::UserPool` answers
+ * `Fn::GetAtt ProviderName` with.
+ */
+export function simCognitoUserPoolProviderName(userPoolId: string): string {
+  return simCognitoUserPoolIssuerUrl(userPoolId).replace("https://", "");
+}

--- a/src/service/cognito/user-pool/sim-cognito-user-pool.ts
+++ b/src/service/cognito/user-pool/sim-cognito-user-pool.ts
@@ -11,8 +11,13 @@ import type { SimCognitoDeletionProtection } from "./sim-cognito-deletion-protec
 import type { SimCognitoName } from "./sim-cognito-name.js";
 import type { SimCognitoPasswordPolicy } from "./sim-cognito-password-policy.js";
 import type { SimCognitoUserPoolArn } from "./sim-cognito-user-pool-arn.js";
-import type { SimCognitoUserPoolId } from "./sim-cognito-user-pool-id.js";
+import {
+  simCognitoUserPoolIssuerUrl,
+  simCognitoUserPoolProviderName,
+  type SimCognitoUserPoolId,
+} from "./sim-cognito-user-pool-id.js";
 import type { SimCognitoUnsimulatedPoolSettings } from "./sim-cognito-unsimulated-pool-settings.js";
+import type { SimCognitoLambdaConfig } from "./trigger/sim-cognito-lambda-config.js";
 import {
   SimCognitoSigningKey,
   type SimCognitoJwks,
@@ -32,6 +37,7 @@ interface SimCognitoUserPoolProperties {
   readonly deletionProtection: SimCognitoDeletionProtection;
   readonly adminCreateUserConfig: SimCognitoAdminCreateUserConfig;
   readonly autoVerifiedAttributes: SimCognitoAutoVerifiedAttributes;
+  readonly lambdaConfig: SimCognitoLambdaConfig;
   readonly unsimulatedSettings: SimCognitoUnsimulatedPoolSettings;
   readonly createdDate: Date;
 }
@@ -61,6 +67,11 @@ export class SimCognitoUserPool {
   public readonly autoVerifiedAttributes: SimCognitoAutoVerifiedAttributes;
 
   /**
+   * The Lambda triggers this pool runs, by the ARN of the function each names.
+   */
+  public readonly lambdaConfig: SimCognitoLambdaConfig;
+
+  /**
    * What the pool was created with and nothing here acts on, kept so a
    * described pool reports it.
    */
@@ -87,31 +98,19 @@ export class SimCognitoUserPool {
     this.deletionProtection = properties.deletionProtection;
     this.adminCreateUserConfig = properties.adminCreateUserConfig;
     this.autoVerifiedAttributes = properties.autoVerifiedAttributes;
+    this.lambdaConfig = properties.lambdaConfig;
     this.unsimulatedSettings = properties.unsimulatedSettings;
     this.creationDate = properties.createdDate;
   }
 
-  /**
-   * The URL a token from this pool names as its issuer.
-   *
-   * The region comes out of the pool id, which is where SDK code and token
-   * verifiers get it from too.
-   */
+  /** The URL a token from this pool names as its issuer. */
   get issuerUrl(): string {
-    const [regionName] = this.id.split("_", 1);
-
-    return `https://cognito-idp.${String(regionName)}.amazonaws.com/${this.id}`;
+    return simCognitoUserPoolIssuerUrl(this.id);
   }
 
-  /**
-   * The name this pool is known by where a scheme would be wrong.
-   *
-   * This is the issuer URL without `https://`, and it is what an identity pool
-   * names a user pool provider by, and what `AWS::Cognito::UserPool` answers
-   * `Fn::GetAtt ProviderName` with.
-   */
+  /** The name this pool is known by where a scheme would be wrong. */
   get providerName(): string {
-    return this.issuerUrl.replace("https://", "");
+    return simCognitoUserPoolProviderName(this.id);
   }
 
   /**

--- a/src/service/cognito/user-pool/trigger/sim-aws-cognito-trigger-functions.iso.test.ts
+++ b/src/service/cognito/user-pool/trigger/sim-aws-cognito-trigger-functions.iso.test.ts
@@ -1,0 +1,195 @@
+import {
+  AdminCreateUserCommand,
+  AdminSetUserPasswordCommand,
+  CreateUserPoolClientCommand,
+  CreateUserPoolCommand,
+  InitiateAuthCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import { makeLambdaZipFileInput } from "../../../lambda/function/code/lambda-zip-file-input.js";
+import { SimCognitoIdentityProvider } from "../../sim-cognito-identity-provider.js";
+import {
+  simAwsCognitoTriggerFunctions,
+  SimAwsCognitoTriggerFunctions,
+} from "./sim-aws-cognito-trigger-functions.js";
+import { SimCognitoNoTriggerFunctions } from "./sim-cognito-trigger-functions.js";
+
+const userPoolArn =
+  "arn:aws:cognito-idp:us-east-1:888888888888:userpool/us-east-1_aBcDeFgHi";
+
+function request(functionArn: string): {
+  functionArn: string;
+  userPoolArn: string;
+  userPoolAccountId: string;
+} {
+  return { functionArn, userPoolArn, userPoolAccountId: "888888888888" };
+}
+
+describe("Simulated Lambda functions as Cognito user pool triggers", () => {
+  it("refuses an ARN that is not a Lambda function", () => {
+    // Given a simulation.
+    const functions = simAwsCognitoTriggerFunctions(new SimAws());
+
+    // When a trigger names a Lambda layer rather than a function.
+    const refusal = functions.invokeRefusal(
+      request("arn:aws:lambda:us-east-1:888888888888:layer:shared"),
+    );
+
+    // Then it is refused for what it is.
+    assertNonNullable(refusal);
+    assertStringIncludes(refusal, "is not a Lambda function ARN");
+  });
+
+  it("refuses a function version or alias", () => {
+    // Given a simulation.
+    const functions = new SimAwsCognitoTriggerFunctions({
+      simAws: new SimAws(),
+    });
+
+    // When a trigger names a published version rather than the function.
+    const refusal = functions.invokeRefusal(
+      request("arn:aws:lambda:us-east-1:888888888888:function:pre-auth:PROD"),
+    );
+
+    // Then it is refused rather than run against `$LATEST`, which is a
+    // different function to the one the pool named.
+    assertNonNullable(refusal);
+    assertStringIncludes(refusal, "names a function version or alias");
+  });
+
+  it("refuses to invoke a function that is not there", async () => {
+    // Given a simulation with no functions in it.
+    const functions = simAwsCognitoTriggerFunctions(new SimAws());
+
+    // When one is invoked anyway, which a trigger only reaches if the function
+    // went away between the check and the invocation.
+    const error = await assertThrowsErrorAsync(async () =>
+      functions.invoke(
+        request("arn:aws:lambda:us-east-1:888888888888:function:pre-auth"),
+        { request: {} },
+      ),
+    );
+
+    // Then the missing function is reported rather than silently skipped.
+    assertStringIncludes(error.message, "not a simulated Lambda function");
+  });
+
+  it("says a standalone Cognito has no Lambda to reach", async () => {
+    // Given a Cognito built on its own rather than through SimAws, with a pool
+    // naming a trigger. The pool is created without complaint, because nothing
+    // is resolved until the trigger fires.
+    const cognito = new SimCognitoIdentityProvider();
+    const pool = await cognito.createUserPool(
+      new CreateUserPoolCommand({
+        PoolName: "myapp-users",
+        LambdaConfig: {
+          PreAuthentication:
+            "arn:aws:lambda:us-east-1:888888888888:function:pre-auth",
+        },
+      }),
+    );
+
+    assertNonNullable(pool.UserPool?.Id);
+
+    const client = await cognito.createUserPoolClient(
+      new CreateUserPoolClientCommand({
+        UserPoolId: pool.UserPool.Id,
+        ClientName: "web",
+        ExplicitAuthFlows: ["ALLOW_USER_PASSWORD_AUTH"],
+      }),
+    );
+
+    const clientId = client.UserPoolClient?.ClientId;
+
+    assertNonNullable(clientId);
+
+    await cognito.adminCreateUser(
+      new AdminCreateUserCommand({
+        UserPoolId: pool.UserPool.Id,
+        Username: "alice",
+      }),
+    );
+    await cognito.adminSetUserPassword(
+      new AdminSetUserPasswordCommand({
+        UserPoolId: pool.UserPool.Id,
+        Username: "alice",
+        Password: "Sup3rSecret!",
+        Permanent: true,
+      }),
+    );
+
+    // When the user signs in.
+    const error = await assertThrowsErrorAsync(async () =>
+      cognito.initiateAuth(
+        new InitiateAuthCommand({
+          ClientId: clientId,
+          AuthFlow: "USER_PASSWORD_AUTH",
+          AuthParameters: { USERNAME: "alice", PASSWORD: "Sup3rSecret!" },
+        }),
+      ),
+    );
+
+    // Then the sign-in says why the trigger could not run, and how to make it
+    // able to.
+    assertIdentical(error.name, "UnexpectedLambdaException");
+    assertStringIncludes(error.message, "without simulated Lambda");
+    assertStringIncludes(error.message, "Reach Cognito through SimAws");
+  });
+
+  it("refuses to invoke from a standalone Cognito too", async () => {
+    // Given the trigger functions a standalone Cognito is built with.
+    const functions = new SimCognitoNoTriggerFunctions();
+
+    // When one is invoked, which nothing reaches while the refusal is checked
+    // first, and which has to refuse rather than resolve if anything ever does.
+    const error = await assertThrowsErrorAsync(async () =>
+      functions.invoke(
+        request("arn:aws:lambda:us-east-1:888888888888:function:pre-auth"),
+      ),
+    );
+
+    assertStringIncludes(error.message, "without simulated Lambda");
+  });
+
+  it("has no refusal for a function in another Region that admits the pool", async () => {
+    // Given a function in a Region the pool does not live in, granting Cognito
+    // the invoke action for that pool.
+    const simAws = new SimAws({ defaultAccountId: "888888888888" });
+    const lambda = simAws.account("888888888888").region("eu-west-2").lambda();
+
+    await lambda.createFunction({
+      input: {
+        FunctionName: "pre-auth",
+        Role: "arn:aws:iam::888888888888:role/PreAuthRole",
+        Code: { ZipFile: makeLambdaZipFileInput((event: unknown) => event) },
+      },
+    });
+    await lambda.addPermission({
+      input: {
+        FunctionName: "pre-auth",
+        StatementId: "AllowCognito",
+        Action: "lambda:InvokeFunction",
+        Principal: "cognito-idp.amazonaws.com",
+        SourceArn: userPoolArn,
+      },
+    });
+
+    // When the pool asks whether it may invoke it.
+    const refusal = simAwsCognitoTriggerFunctions(simAws).invokeRefusal(
+      request("arn:aws:lambda:eu-west-2:888888888888:function:pre-auth"),
+    );
+
+    // Then there is nothing to say: the lookup follows the ARN across Regions,
+    // as a real LambdaConfig may name one.
+    assertUndefined(refusal);
+  });
+});

--- a/src/service/cognito/user-pool/trigger/sim-aws-cognito-trigger-functions.ts
+++ b/src/service/cognito/user-pool/trigger/sim-aws-cognito-trigger-functions.ts
@@ -1,0 +1,149 @@
+import type { SimAws } from "../../../aws/sim-aws.js";
+import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { SimLambdaServiceInvokeAuthorizer } from "../../../lambda/command/authorize/sim-lambda-service-invoke-authorizer.js";
+import type { SimLambdaFunction } from "../../../lambda/function/sim-lambda-function.js";
+import {
+  parseSimLambdaFunctionArn,
+  type SimLambdaFunctionArnParts,
+} from "../../../lambda/function/sim-lambda-function-arn-parts.js";
+import type {
+  SimCognitoTriggerFunctionRequest,
+  SimCognitoTriggerFunctions,
+} from "./sim-cognito-trigger-functions.js";
+
+/**
+ * The service principal real Cognito invokes a user pool trigger as.
+ */
+export const simCognitoServicePrincipal = "cognito-idp.amazonaws.com";
+
+interface SimAwsCognitoTriggerFunctionsProperties {
+  readonly simAws: SimAws;
+}
+
+/**
+ * The Lambda functions a simulated user pool's triggers can reach.
+ *
+ * A `LambdaConfig` names a function by ARN, and that ARN can name any Account
+ * and Region, so the functions come from the whole simulation rather than from
+ * the scope the pool belongs to.
+ */
+export function simAwsCognitoTriggerFunctions(
+  simAws: SimAws,
+): SimCognitoTriggerFunctions {
+  return new SimAwsCognitoTriggerFunctions({ simAws });
+}
+
+/**
+ * The simulated Lambda functions of one simulated AWS instance, as user pool
+ * trigger targets.
+ *
+ * Functions are looked up when a trigger fires, never when a pool is created,
+ * so a pool can be created before the function it names and one deleted
+ * afterwards refuses the sign-in rather than having silently broken the pool.
+ * That also keeps CloudFormation free to deploy the two in either order.
+ */
+export class SimAwsCognitoTriggerFunctions implements SimCognitoTriggerFunctions {
+  private readonly simAws: SimAws;
+
+  constructor(properties: SimAwsCognitoTriggerFunctionsProperties) {
+    this.simAws = properties.simAws;
+  }
+
+  /**
+   * Why the pool may not invoke the function, or nothing when it may.
+   *
+   * Whether a service may invoke a function is Lambda's own rule, so the
+   * decision is made there. What Cognito adds is which pool is calling, supplied
+   * as the source ARN and source Account, so a permission granted for one pool
+   * does not open the function to another.
+   */
+  invokeRefusal(request: SimCognitoTriggerFunctionRequest): string | undefined {
+    const arn = parseSimLambdaFunctionArn(request.functionArn);
+
+    if (arn === undefined) {
+      return `${request.functionArn} is not a Lambda function ARN.`;
+    }
+
+    if (arn.qualifier !== undefined) {
+      return (
+        `${request.functionArn} names a function version or alias, and ` +
+        "simulated Lambda has neither, so it is refused rather than treated " +
+        "as the unqualified function."
+      );
+    }
+
+    const simFunction = this.findFunction(arn);
+
+    if (simFunction === undefined) {
+      return `${request.functionArn} is not a simulated Lambda function.`;
+    }
+
+    return this.policyRefusal(simFunction, request);
+  }
+
+  /**
+   * Invoke the function with the trigger event, answering with what the
+   * handler returned.
+   *
+   * The function is invoked directly rather than through an Invoke command,
+   * because real Cognito invokes it as the service rather than as the caller
+   * signing in, and because the handler's return value and its failure both
+   * have to reach the sign-in rather than being reported as an invocation
+   * result.
+   */
+  async invoke(
+    request: SimCognitoTriggerFunctionRequest,
+    event: object,
+  ): Promise<unknown> {
+    const arn = parseSimLambdaFunctionArn(request.functionArn);
+    const simFunction = arn === undefined ? undefined : this.findFunction(arn);
+
+    if (simFunction === undefined) {
+      throw new Error(
+        `${request.functionArn} is not a simulated Lambda function.`,
+      );
+    }
+
+    return await simFunction.invoke(event);
+  }
+
+  private policyRefusal(
+    simFunction: SimLambdaFunction,
+    request: SimCognitoTriggerFunctionRequest,
+  ): string | undefined {
+    const decision = new SimLambdaServiceInvokeAuthorizer({
+      iam: this.iam(simFunction),
+    }).authorize({
+      simFunction,
+      servicePrincipal: simCognitoServicePrincipal,
+      sourceArn: request.userPoolArn,
+      sourceAccount: request.userPoolAccountId,
+    });
+
+    if (decision.isDenied) {
+      return (
+        `The resource policy of ${request.functionArn} does not allow ` +
+        `${simCognitoServicePrincipal} to invoke it for ` +
+        `${request.userPoolArn}. Grant it with AddPermission, or with the ` +
+        "AWS::Lambda::Permission a CDK addTrigger emits."
+      );
+    }
+
+    return undefined;
+  }
+
+  private findFunction(
+    arn: SimLambdaFunctionArnParts,
+  ): SimLambdaFunction | undefined {
+    return this.simAws
+      .accountRegionScope(arn.accountId, arn.regionName)
+      .lambda()
+      .getSimFunctionByName(arn.functionName);
+  }
+
+  private iam(simFunction: SimLambdaFunction): SimIamInterServiceAuthZ {
+    const { accountId, regionName } = simFunction.accountRegionScope;
+
+    return this.simAws.accountRegionScope(accountId, regionName).iam();
+  }
+}

--- a/src/service/cognito/user-pool/trigger/sim-cognito-auth-triggers.iso.test.ts
+++ b/src/service/cognito/user-pool/trigger/sim-cognito-auth-triggers.iso.test.ts
@@ -1,0 +1,200 @@
+/* eslint-disable @typescript-eslint/naming-convention -- the authentication
+   parameter names are Cognito's own, rather than identifier names. */
+import {
+  AdminInitiateAuthCommand,
+  InitiateAuthCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import {
+  assertArrayEquals,
+  assertNonNullable,
+  assertObjectMatches,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import {
+  makeTriggerPool,
+  makeTriggerUser,
+  triggerFunctionArn,
+  triggerPassword,
+} from "../../../../../test/cognito/trigger-fixture.js";
+
+/**
+ * Record every event a trigger handler is given, and hand the event back so
+ * the sign-in carries on.
+ */
+function recordingHandler(events: unknown[]): (event: unknown) => unknown {
+  return (event: unknown) => {
+    events.push(structuredClone(event));
+
+    return event;
+  };
+}
+
+function signIn(clientId: string): InitiateAuthCommand {
+  return new InitiateAuthCommand({
+    ClientId: clientId,
+    AuthFlow: "USER_PASSWORD_AUTH",
+    AuthParameters: { USERNAME: "alice", PASSWORD: triggerPassword },
+  });
+}
+
+describe("sim Cognito user pool authentication triggers", () => {
+  it("invokes the PreAuthentication trigger on InitiateAuth", async () => {
+    // Given a pool whose PreAuthentication trigger records what it is given.
+    const events: unknown[] = [];
+    const pool = await makeTriggerPool({
+      triggers: { PreAuthentication: triggerFunctionArn },
+      handler: recordingHandler(events),
+    });
+
+    await makeTriggerUser(pool);
+
+    // When a user signs in through the app client.
+    const signedIn = await pool.cognito.initiateAuth(signIn(pool.clientId));
+
+    // Then the sign-in answered with tokens.
+    assertNonNullable(signedIn.AuthenticationResult?.AccessToken);
+
+    // And the handler was given the real event, naming the occasion it fired
+    // on, the pool, the app client and the user it fired for.
+    assertObjectMatches(events[0], {
+      version: "1",
+      region: pool.simAws.defaultRegionName,
+      userPoolId: pool.userPoolId,
+      userName: "alice",
+      triggerSource: "PreAuthentication_Authentication",
+      callerContext: { clientId: pool.clientId },
+      request: {
+        userAttributes: { email: "alice@example.com" },
+        userNotFound: false,
+      },
+      response: {},
+    });
+  });
+
+  it("runs PostAuthentication after the tokens have been issued", async () => {
+    // Given a pool with both triggers pointing at the one function.
+    const events: unknown[] = [];
+    const pool = await makeTriggerPool({
+      triggers: {
+        PreAuthentication: triggerFunctionArn,
+        PostAuthentication: triggerFunctionArn,
+      },
+      handler: recordingHandler(events),
+    });
+
+    await makeTriggerUser(pool);
+
+    // When a user signs in.
+    const signedIn = await pool.cognito.initiateAuth(signIn(pool.clientId));
+
+    // Then both triggers fired, in the order a sign-in reaches them.
+    assertArrayEquals(
+      events.map((event) => (event as { triggerSource: string }).triggerSource),
+      ["PreAuthentication_Authentication", "PostAuthentication_Authentication"],
+    );
+
+    // And the sign-in still answered with the tokens it issued before the
+    // second one ran.
+    assertNonNullable(signedIn.AuthenticationResult?.IdToken);
+  });
+
+  it("passes ClientMetadata to each trigger under the name it reads", async () => {
+    // Given a pool with both triggers on it.
+    const events: unknown[] = [];
+    const pool = await makeTriggerPool({
+      triggers: {
+        PreAuthentication: triggerFunctionArn,
+        PostAuthentication: triggerFunctionArn,
+      },
+      handler: recordingHandler(events),
+    });
+
+    await makeTriggerUser(pool);
+
+    // When the sign-in carries ClientMetadata, which used to be refused.
+    await pool.cognito.initiateAuth(
+      new InitiateAuthCommand({
+        ClientId: pool.clientId,
+        AuthFlow: "USER_PASSWORD_AUTH",
+        AuthParameters: { USERNAME: "alice", PASSWORD: triggerPassword },
+        ClientMetadata: { tenant: "acme" },
+      }),
+    );
+
+    // Then PreAuthentication reads it as validation data, which is the name
+    // real Cognito gives it there.
+    assertObjectMatches(events[0], {
+      request: { validationData: { tenant: "acme" } },
+    });
+
+    // And PostAuthentication reads it as client metadata, which is the name it
+    // has there instead.
+    assertObjectMatches(events[1], {
+      request: { clientMetadata: { tenant: "acme" }, newDeviceUsed: false },
+    });
+  });
+
+  it("invokes the triggers on AdminInitiateAuth as well", async () => {
+    // Given a pool with a PostAuthentication trigger.
+    const events: unknown[] = [];
+    const pool = await makeTriggerPool({
+      triggers: { PostAuthentication: triggerFunctionArn },
+      handler: recordingHandler(events),
+    });
+
+    await makeTriggerUser(pool);
+
+    // When the server-side flow signs the same user in.
+    await pool.cognito.adminInitiateAuth(
+      new AdminInitiateAuthCommand({
+        UserPoolId: pool.userPoolId,
+        ClientId: pool.clientId,
+        AuthFlow: "ADMIN_USER_PASSWORD_AUTH",
+        AuthParameters: { USERNAME: "alice", PASSWORD: triggerPassword },
+      }),
+    );
+
+    // Then the trigger fired for it, because it is the same sign-in as far as
+    // real Cognito is concerned.
+    assertObjectMatches(events[0], {
+      triggerSource: "PostAuthentication_Authentication",
+      userName: "alice",
+    });
+  });
+
+  it("runs no trigger for a refresh, as real Cognito runs none", async () => {
+    // Given a signed-in user of a pool with both triggers on it.
+    const events: unknown[] = [];
+    const pool = await makeTriggerPool({
+      triggers: {
+        PreAuthentication: triggerFunctionArn,
+        PostAuthentication: triggerFunctionArn,
+      },
+      handler: recordingHandler(events),
+    });
+
+    await makeTriggerUser(pool);
+
+    const signedIn = await pool.cognito.initiateAuth(signIn(pool.clientId));
+    const refreshToken = signedIn.AuthenticationResult?.RefreshToken;
+
+    assertNonNullable(refreshToken);
+    events.length = 0;
+
+    // When the session is renewed with the refresh token.
+    const refreshed = await pool.cognito.initiateAuth(
+      new InitiateAuthCommand({
+        ClientId: pool.clientId,
+        AuthFlow: "REFRESH_TOKEN_AUTH",
+        AuthParameters: { REFRESH_TOKEN: refreshToken },
+      }),
+    );
+
+    // Then it renewed without firing either trigger: the authentication
+    // triggers fire around a sign-in, and a refresh is not one.
+    assertNonNullable(refreshed.AuthenticationResult?.AccessToken);
+    assertUndefined(events[0]);
+  });
+});

--- a/src/service/cognito/user-pool/trigger/sim-cognito-lambda-config.iso.test.ts
+++ b/src/service/cognito/user-pool/trigger/sim-cognito-lambda-config.iso.test.ts
@@ -1,0 +1,162 @@
+import {
+  CreateUserPoolCommand,
+  DescribeUserPoolCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertObjectEquals,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { triggerFunctionArn } from "../../../../../test/cognito/trigger-fixture.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+
+const otherFunctionArn =
+  "arn:aws:lambda:eu-west-2:111111111111:function:on-sign-up";
+
+describe("sim Cognito user pool LambdaConfig", () => {
+  it("creates a pool with the triggers it simulates and reports them", async () => {
+    // Given a simulation.
+    const cognito = new SimAws().cognitoIdentityProvider();
+
+    // When a pool is created with both authentication triggers.
+    const created = await cognito.createUserPool(
+      new CreateUserPoolCommand({
+        PoolName: "myapp-users",
+        LambdaConfig: {
+          PreAuthentication: triggerFunctionArn,
+          PostAuthentication: triggerFunctionArn,
+        },
+      }),
+    );
+
+    assertNonNullable(created.UserPool?.Id);
+
+    // Then a described pool reports the config it was created with, so a
+    // template's declaration stays visible.
+    const described = await cognito.describeUserPool(
+      new DescribeUserPoolCommand({ UserPoolId: created.UserPool.Id }),
+    );
+    assertObjectEquals(described.UserPool?.LambdaConfig, {
+      PreAuthentication: triggerFunctionArn,
+      PostAuthentication: triggerFunctionArn,
+    });
+  });
+
+  it("reports no LambdaConfig for a pool created without one", async () => {
+    // Given a simulation.
+    const cognito = new SimAws().cognitoIdentityProvider();
+
+    // When a pool is created without naming any trigger.
+    const created = await cognito.createUserPool(
+      new CreateUserPoolCommand({ PoolName: "myapp-users" }),
+    );
+
+    // Then it describes without one, rather than with an empty object it never
+    // asked for.
+    assertUndefined(created.UserPool?.LambdaConfig);
+  });
+
+  it("ignores a trigger key the request left undefined", async () => {
+    // Given a simulation.
+    const cognito = new SimAws().cognitoIdentityProvider();
+
+    // When the config carries a key for a trigger this simulation does not
+    // run, with nothing set against it, as a caller spreading an optional
+    // value produces.
+    const created = await cognito.createUserPool(
+      new CreateUserPoolCommand({
+        PoolName: "myapp-users",
+        LambdaConfig: {
+          PreAuthentication: triggerFunctionArn,
+          PreSignUp: undefined,
+        },
+      }),
+    );
+
+    // Then the key that names no function is not refused, and not reported:
+    // the request asked for nothing there.
+    assertObjectEquals(created.UserPool?.LambdaConfig, {
+      PreAuthentication: triggerFunctionArn,
+    });
+  });
+
+  it("refuses a trigger this simulation does not run, naming it", async () => {
+    // Given a simulation.
+    const cognito = new SimAws().cognitoIdentityProvider();
+
+    // When a pool asks for a sign-up trigger alongside one that is simulated.
+    const error = await assertThrowsErrorAsync(async () =>
+      cognito.createUserPool(
+        new CreateUserPoolCommand({
+          PoolName: "myapp-users",
+          LambdaConfig: {
+            PreAuthentication: triggerFunctionArn,
+            PostConfirmation: otherFunctionArn,
+          },
+        }),
+      ),
+    );
+
+    // Then the pool is refused rather than created without the trigger it
+    // would never have run.
+    assertIdentical(error.name, "InvalidParameterException");
+    assertStringIncludes(
+      error.message,
+      "CreateUserPool LambdaConfig PostConfirmation is not simulated",
+    );
+    assertStringIncludes(
+      error.message,
+      "acting on a user confirming its own account",
+    );
+  });
+
+  it("refuses a LambdaConfig key real Cognito does not have either", async () => {
+    // Given a simulation.
+    const cognito = new SimAws().cognitoIdentityProvider();
+
+    // When a pool asks for a trigger by a name nothing recognises.
+    const error = await assertThrowsErrorAsync(async () =>
+      cognito.createUserPool(
+        new CreateUserPoolCommand({
+          PoolName: "myapp-users",
+          LambdaConfig: { PreAuthentications: triggerFunctionArn } as object,
+        }),
+      ),
+    );
+
+    // Then it is refused in the same words, because a pool accepting it would
+    // behave the same way as one accepting a real trigger it never runs.
+    assertIdentical(error.name, "InvalidParameterException");
+    assertStringIncludes(
+      error.message,
+      "CreateUserPool LambdaConfig PreAuthentications is not simulated",
+    );
+  });
+
+  it("refuses a trigger that is not a function ARN", async () => {
+    // Given a simulation.
+    const cognito = new SimAws().cognitoIdentityProvider();
+
+    // When a pool names its trigger with something that is not an ARN string.
+    const error = await assertThrowsErrorAsync(async () =>
+      cognito.createUserPool(
+        new CreateUserPoolCommand({
+          PoolName: "myapp-users",
+          LambdaConfig: { PreAuthentication: 42 } as object,
+        }),
+      ),
+    );
+
+    // Then it says what the value has to be.
+    assertIdentical(error.name, "InvalidParameterException");
+    assertStringIncludes(
+      error.message,
+      "LambdaConfig PreAuthentication must be the ARN of the function",
+    );
+  });
+});

--- a/src/service/cognito/user-pool/trigger/sim-cognito-lambda-config.ts
+++ b/src/service/cognito/user-pool/trigger/sim-cognito-lambda-config.ts
@@ -1,0 +1,110 @@
+import { SimCognitoInvalidParameterException } from "../../error/sim-cognito.error.js";
+import { SimCognitoUnsimulatedInput } from "../../command/sim-cognito-unsimulated-input.js";
+import {
+  simCognitoTriggerNames,
+  simCognitoUnsimulatedTriggers,
+  type SimCognitoTriggerName,
+} from "./sim-cognito-trigger-name.js";
+
+/**
+ * The `LambdaConfig` a pool was created with, as a described pool reports it.
+ *
+ * https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_LambdaConfigType.html
+ */
+export interface SimCognitoLambdaConfigType {
+  readonly PreAuthentication?: string | undefined;
+  readonly PostAuthentication?: string | undefined;
+}
+
+/**
+ * The Lambda triggers one simulated user pool runs.
+ *
+ * A trigger is held as the function ARN the request named, and nothing is
+ * looked up here: the function is resolved when the trigger fires, so a pool
+ * can be created before the function it names and a function deleted
+ * afterwards fails the sign-in rather than the pool.
+ *
+ * Every other `LambdaConfig` key real Cognito has is refused, naming the
+ * trigger and saying why, so a pool never quietly drops one. That is the whole
+ * reason this reads the config rather than storing it: a pool that accepted a
+ * `PreSignUp` trigger and never called it would sign users up differently here
+ * and on real AWS.
+ */
+export class SimCognitoLambdaConfig {
+  private readonly unsimulated = new SimCognitoUnsimulatedInput(
+    "CreateUserPool",
+  );
+  private readonly triggers = new Map<SimCognitoTriggerName, string>();
+  private readonly configured: boolean;
+
+  constructor(config: object | undefined) {
+    const entries = Object.entries(config ?? {});
+
+    this.configured = config !== undefined;
+
+    for (const [key, value] of entries) {
+      this.read(key, value);
+    }
+  }
+
+  private static requireFunctionArn(key: string, value: unknown): string {
+    if (typeof value !== "string" || value === "") {
+      throw new SimCognitoInvalidParameterException(
+        `CreateUserPool LambdaConfig ${key} must be the ARN of the function ` +
+          `the trigger invokes`,
+      );
+    }
+
+    return value;
+  }
+
+  /**
+   * The function ARN a trigger names, or nothing when the pool has no such
+   * trigger.
+   */
+  find(trigger: SimCognitoTriggerName): string | undefined {
+    return this.triggers.get(trigger);
+  }
+
+  /**
+   * This config as a described pool reports it.
+   *
+   * A pool created without a `LambdaConfig` at all reports none, rather than
+   * reporting an empty one, so a describe answers what the request said.
+   */
+  toOutput(): SimCognitoLambdaConfigType | undefined {
+    if (!this.configured) {
+      return undefined;
+    }
+
+    return Object.fromEntries(this.triggers);
+  }
+
+  /**
+   * Read one `LambdaConfig` entry, refusing a trigger this simulation does not
+   * run.
+   *
+   * A key real Cognito does not have at all is refused too, in the same words
+   * as one it has: either way the pool would behave differently for having
+   * accepted it.
+   */
+  private read(key: string, value: unknown): void {
+    if (value === undefined) {
+      return;
+    }
+
+    if (!simCognitoTriggerNames.includes(key as SimCognitoTriggerName)) {
+      this.unsimulated.refuse(
+        `LambdaConfig ${key}`,
+        value,
+        simCognitoUnsimulatedTriggers.get(key) ??
+          "a Lambda trigger this simulation does not know",
+      );
+    }
+
+    this.triggers.set(
+      key as SimCognitoTriggerName,
+      SimCognitoLambdaConfig.requireFunctionArn(key, value),
+    );
+  }
+}

--- a/src/service/cognito/user-pool/trigger/sim-cognito-trigger-event.ts
+++ b/src/service/cognito/user-pool/trigger/sim-cognito-trigger-event.ts
@@ -1,0 +1,108 @@
+import type { SimCognitoUserPoolClient } from "../client/sim-cognito-user-pool-client.js";
+import type { SimCognitoUserPool } from "../sim-cognito-user-pool.js";
+import { simCognitoUserPoolRegionName } from "../sim-cognito-user-pool-id.js";
+import type { SimCognitoUser } from "../user/sim-cognito-user.js";
+import {
+  simCognitoTriggerSource,
+  type SimCognitoTriggerName,
+} from "./sim-cognito-trigger-name.js";
+
+/**
+ * The SDK version real Cognito reports for a caller it could not identify,
+ * which is what an SDK v3 client gets.
+ *
+ * Every invocation here reports this, because nothing in a simulated request
+ * says which SDK made it. A handler branching on it would branch the same way
+ * against a real pool called from the JavaScript SDK, and differently from one
+ * called by an older SDK that does announce itself.
+ */
+const awsSdkVersion = "aws-sdk-unknown-unknown";
+
+/**
+ * The sign-in a trigger is firing for.
+ */
+export interface SimCognitoTriggerContext {
+  readonly pool: SimCognitoUserPool;
+  readonly client: SimCognitoUserPoolClient;
+  readonly user: SimCognitoUser;
+  readonly clientMetadata?: Readonly<Record<string, string>> | undefined;
+}
+
+/**
+ * The event document a simulated Cognito Lambda trigger is invoked with.
+ *
+ * The shape is the real one, down to the empty `response` a handler is
+ * expected to hand back untouched. Neither of these two triggers reads anything
+ * out of `response`, so what a handler writes there is ignored, exactly as real
+ * Cognito ignores it.
+ */
+export class SimCognitoTriggerEvent {
+  private readonly context: SimCognitoTriggerContext;
+
+  constructor(context: SimCognitoTriggerContext) {
+    this.context = context;
+  }
+
+  /**
+   * The event for one trigger.
+   *
+   * The two triggers name the same data differently, which is not a detail to
+   * smooth over: a `PreAuthentication` handler reads `request.validationData`
+   * and a `PostAuthentication` one reads `request.clientMetadata`, and both
+   * come from the `ClientMetadata` the sign-in request carried.
+   */
+  document(trigger: SimCognitoTriggerName): object {
+    return {
+      version: "1",
+      region: simCognitoUserPoolRegionName(this.context.pool.id),
+      userPoolId: this.context.pool.id,
+      userName: this.context.user.username,
+      callerContext: {
+        awsSdkVersion,
+        clientId: this.context.client.id,
+      },
+      triggerSource: simCognitoTriggerSource(trigger),
+      request: this.request(trigger),
+      response: {},
+    };
+  }
+
+  private request(trigger: SimCognitoTriggerName): object {
+    if (trigger === "PreAuthentication") {
+      return {
+        userAttributes: this.userAttributes(),
+        ...(this.context.clientMetadata !== undefined && {
+          validationData: { ...this.context.clientMetadata },
+        }),
+        // A sign-in naming a user the pool does not hold is refused before any
+        // trigger runs here, so the trigger only ever sees a user that exists.
+        // Real Cognito fires it with `userNotFound: true` for an app client
+        // that hides user existence, which this simulation does not do.
+        userNotFound: false,
+      };
+    }
+
+    return {
+      userAttributes: this.userAttributes(),
+      // Devices are not remembered here: `CreateUserPool` refuses a
+      // `DeviceConfiguration`, so no sign-in is ever made from a new device.
+      newDeviceUsed: false,
+      ...(this.context.clientMetadata !== undefined && {
+        clientMetadata: { ...this.context.clientMetadata },
+      }),
+    };
+  }
+
+  /**
+   * The user's attributes by name, as a trigger event carries them.
+   *
+   * The event is a plain object of strings rather than the `Name`/`Value` pairs
+   * the API answers with, and `sub` is among them.
+   */
+  private userAttributes(): Record<string, string> {
+    return {
+      sub: this.context.user.sub,
+      ...Object.fromEntries(this.context.user.attributeValues),
+    };
+  }
+}

--- a/src/service/cognito/user-pool/trigger/sim-cognito-trigger-failures.iso.test.ts
+++ b/src/service/cognito/user-pool/trigger/sim-cognito-trigger-failures.iso.test.ts
@@ -1,0 +1,263 @@
+/* eslint-disable @typescript-eslint/naming-convention -- the authentication
+   parameter names are Cognito's own, rather than identifier names. */
+import {
+  AdminGetUserCommand,
+  AdminInitiateAuthCommand,
+  AdminRespondToAuthChallengeCommand,
+  InitiateAuthCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import { DeleteFunctionCommand } from "@aws-sdk/client-lambda";
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import {
+  makeTriggerPool,
+  makeTriggerUser,
+  triggerFunctionArn,
+  triggerFunctionName,
+  triggerPassword,
+} from "../../../../../test/cognito/trigger-fixture.js";
+import type { SimCognitoTriggerPool } from "../../../../../test/cognito/trigger-fixture.js";
+
+const newPassword = "Rep1acementPassw0rd!";
+
+function signIn(clientId: string): InitiateAuthCommand {
+  return new InitiateAuthCommand({
+    ClientId: clientId,
+    AuthFlow: "USER_PASSWORD_AUTH",
+    AuthParameters: { USERNAME: "alice", PASSWORD: triggerPassword },
+  });
+}
+
+/**
+ * Start the sign-in a user with a temporary password gets, which is the
+ * `NEW_PASSWORD_REQUIRED` challenge and the session to answer it with.
+ */
+async function challengeSession(pool: SimCognitoTriggerPool): Promise<string> {
+  const challenged = await pool.cognito.adminInitiateAuth(
+    new AdminInitiateAuthCommand({
+      UserPoolId: pool.userPoolId,
+      ClientId: pool.clientId,
+      AuthFlow: "ADMIN_USER_PASSWORD_AUTH",
+      AuthParameters: { USERNAME: "alice", PASSWORD: "Temp0rary!" },
+    }),
+  );
+
+  assertIdentical(challenged.ChallengeName, "NEW_PASSWORD_REQUIRED");
+  assertNonNullable(challenged.Session);
+
+  return challenged.Session;
+}
+
+describe("sim Cognito user pool trigger failures", () => {
+  it("refuses the sign-in with the message a PreAuthentication handler threw", async () => {
+    // Given a pool whose PreAuthentication trigger turns the sign-in down.
+    const pool = await makeTriggerPool({
+      triggers: { PreAuthentication: triggerFunctionArn },
+      handler: () => {
+        throw new Error("Sign-in is closed for maintenance");
+      },
+    });
+
+    await makeTriggerUser(pool);
+
+    // When the user signs in with the right password.
+    const error = await assertThrowsErrorAsync(async () =>
+      pool.cognito.initiateAuth(signIn(pool.clientId)),
+    );
+
+    // Then the sign-in was refused as real Cognito refuses it, carrying the
+    // handler's own words so the caller knows why.
+    assertIdentical(error.name, "UserLambdaValidationException");
+    assertStringIncludes(
+      error.message,
+      "PreAuthentication failed with error Sign-in is closed for maintenance.",
+    );
+  });
+
+  it("fails a trigger the pool has no permission to invoke", async () => {
+    // Given a pool whose trigger function was never granted the invoke
+    // permission a CDK addTrigger emits.
+    const pool = await makeTriggerPool({
+      triggers: { PreAuthentication: triggerFunctionArn },
+      permitted: false,
+    });
+
+    await makeTriggerUser(pool);
+
+    // When a user signs in.
+    const error = await assertThrowsErrorAsync(async () =>
+      pool.cognito.initiateAuth(signIn(pool.clientId)),
+    );
+
+    // Then the trigger failed for the permission it is missing, naming the
+    // principal and the pool the resource policy has to admit.
+    assertIdentical(error.name, "UnexpectedLambdaException");
+    assertStringIncludes(error.message, "cognito-idp.amazonaws.com");
+    assertStringIncludes(error.message, pool.userPoolArn);
+    assertStringIncludes(error.message, "AddPermission");
+  });
+
+  it("fails a trigger whose function is not there", async () => {
+    // Given a pool whose trigger function has since been deleted, which a pool
+    // only finds out about when the trigger fires.
+    const pool = await makeTriggerPool({
+      triggers: { PreAuthentication: triggerFunctionArn },
+    });
+
+    await makeTriggerUser(pool);
+    await pool.simAws
+      .lambda()
+      .deleteFunction(
+        new DeleteFunctionCommand({ FunctionName: triggerFunctionName }),
+      );
+
+    // When a user signs in.
+    const error = await assertThrowsErrorAsync(async () =>
+      pool.cognito.initiateAuth(signIn(pool.clientId)),
+    );
+
+    // Then the missing function is reported rather than the sign-in going
+    // ahead as though the pool had no trigger.
+    assertIdentical(error.name, "UnexpectedLambdaException");
+    assertStringIncludes(error.message, "is not a simulated Lambda function");
+  });
+
+  it("refuses a handler that returned something other than the event", async () => {
+    // Given a trigger handler that answers with a string.
+    const pool = await makeTriggerPool({
+      triggers: { PreAuthentication: triggerFunctionArn },
+      handler: () => "ok",
+    });
+
+    await makeTriggerUser(pool);
+
+    // When a user signs in.
+    const error = await assertThrowsErrorAsync(async () =>
+      pool.cognito.initiateAuth(signIn(pool.clientId)),
+    );
+
+    // Then the response is refused, because Cognito reads the returned event
+    // rather than the one it sent.
+    assertIdentical(error.name, "InvalidLambdaResponseException");
+    assertStringIncludes(error.message, "rather than the event it was given");
+  });
+
+  it("carries what a handler threw when it was not an Error", async () => {
+    // Given a trigger handler that throws a string rather than an Error, which
+    // JavaScript allows and a hand-written handler sometimes does.
+    const pool = await makeTriggerPool({
+      triggers: { PreAuthentication: triggerFunctionArn },
+      handler: () => {
+        // eslint-disable-next-line @typescript-eslint/only-throw-error -- a handler may throw anything, and that is the case under test
+        throw "Sign-in is closed";
+      },
+    });
+
+    await makeTriggerUser(pool);
+
+    // When a user signs in.
+    const error = await assertThrowsErrorAsync(async () =>
+      pool.cognito.initiateAuth(signIn(pool.clientId)),
+    );
+
+    // Then what it threw still reaches the caller, rather than the refusal
+    // saying nothing about why.
+    assertIdentical(error.name, "UserLambdaValidationException");
+    assertStringIncludes(
+      error.message,
+      "PreAuthentication failed with error Sign-in is closed.",
+    );
+  });
+
+  it("refuses a handler that returned an array", async () => {
+    // Given a trigger handler that answers with a list.
+    const pool = await makeTriggerPool({
+      triggers: { PreAuthentication: triggerFunctionArn },
+      handler: () => [],
+    });
+
+    await makeTriggerUser(pool);
+
+    // When a user signs in.
+    const error = await assertThrowsErrorAsync(async () =>
+      pool.cognito.initiateAuth(signIn(pool.clientId)),
+    );
+
+    // Then it is refused, and named for what it was: an array is an object,
+    // and it is still not the event.
+    assertIdentical(error.name, "InvalidLambdaResponseException");
+    assertStringIncludes(error.message, "returned an array rather than");
+  });
+
+  it("refuses a handler that returned an object without the request", async () => {
+    // Given a trigger handler that answers with the response half alone.
+    const pool = await makeTriggerPool({
+      triggers: { PreAuthentication: triggerFunctionArn },
+      handler: () => ({ response: {} }),
+    });
+
+    await makeTriggerUser(pool);
+
+    // When a user signs in.
+    const error = await assertThrowsErrorAsync(async () =>
+      pool.cognito.initiateAuth(signIn(pool.clientId)),
+    );
+
+    // Then it is refused too: an event without its request is a different
+    // event, not the one the handler was given.
+    assertIdentical(error.name, "InvalidLambdaResponseException");
+    assertStringIncludes(error.message, "without a request");
+  });
+
+  it("does not undo the sign-in when PostAuthentication fails", async () => {
+    // Given a pool whose PostAuthentication trigger throws, and a user that
+    // has to replace its temporary password before it can sign in.
+    const pool = await makeTriggerPool({
+      triggers: { PostAuthentication: triggerFunctionArn },
+      handler: () => {
+        throw new Error("The audit log is unreachable");
+      },
+    });
+
+    await makeTriggerUser(pool, false);
+
+    const session = await challengeSession(pool);
+
+    // When the user answers the challenge, which is where its sign-in
+    // completes.
+    const error = await assertThrowsErrorAsync(async () =>
+      pool.cognito.adminRespondToAuthChallenge(
+        new AdminRespondToAuthChallengeCommand({
+          UserPoolId: pool.userPoolId,
+          ClientId: pool.clientId,
+          ChallengeName: "NEW_PASSWORD_REQUIRED",
+          ChallengeResponses: {
+            USERNAME: "alice",
+            NEW_PASSWORD: newPassword,
+          },
+          Session: session,
+        }),
+      ),
+    );
+
+    // Then the request failed on the trigger.
+    assertIdentical(error.name, "UserLambdaValidationException");
+    assertStringIncludes(error.message, "PostAuthentication failed with error");
+
+    // And the sign-in that had already happened stands: the user took its new
+    // password and is confirmed, rather than being left with the temporary one.
+    const described = await pool.cognito.adminGetUser(
+      new AdminGetUserCommand({
+        UserPoolId: pool.userPoolId,
+        Username: "alice",
+      }),
+    );
+    assertIdentical(described.UserStatus, "CONFIRMED");
+  });
+});

--- a/src/service/cognito/user-pool/trigger/sim-cognito-trigger-functions.ts
+++ b/src/service/cognito/user-pool/trigger/sim-cognito-trigger-functions.ts
@@ -1,0 +1,73 @@
+/**
+ * A pool asking to reach the function one of its triggers names.
+ *
+ * The pool ARN and the Account that owns it travel with every request because
+ * they are what the function's resource policy is written against: real Cognito
+ * invokes with the pool as the source ARN, so a permission granted for one pool
+ * does not open the function to another.
+ */
+export interface SimCognitoTriggerFunctionRequest {
+  readonly functionArn: string;
+  readonly userPoolArn: string;
+  readonly userPoolAccountId: string;
+}
+
+/**
+ * The narrow slice of simulated Lambda that a Cognito user pool trigger needs.
+ *
+ * A pool asks two things of a function: whether it may invoke it, and then to
+ * invoke it and hand back what the handler returned. Both are asked by ARN,
+ * because a `LambdaConfig` names a function by ARN and that ARN can name
+ * another Account or Region.
+ *
+ * The invocation is synchronous and its result is read, which is what makes
+ * these triggers different from an event notification: the handler's return
+ * value is the event the pool goes on with, and a handler that throws refuses
+ * the sign-in.
+ */
+export interface SimCognitoTriggerFunctions {
+  /**
+   * Why the pool may not invoke the function, or nothing when it may.
+   *
+   * A reason rather than a boolean, because it is repeated back in the
+   * `UnexpectedLambdaException` whoever has to grant the permission reads.
+   */
+  invokeRefusal(request: SimCognitoTriggerFunctionRequest): string | undefined;
+
+  /**
+   * Invoke the function with the trigger event, answering with whatever the
+   * handler returned.
+   */
+  invoke(
+    request: SimCognitoTriggerFunctionRequest,
+    event: object,
+  ): Promise<unknown>;
+}
+
+/**
+ * The trigger functions of a simulated Cognito built without simulated Lambda,
+ * such as a standalone SimCognitoIdentityProvider constructed outside SimAws.
+ *
+ * A pool can still be created with a `LambdaConfig`, because the function is
+ * only resolved when a trigger fires. It is the sign-in that says there is no
+ * Lambda to reach, rather than the pool creation that would have to guess.
+ */
+export class SimCognitoNoTriggerFunctions implements SimCognitoTriggerFunctions {
+  /**
+   * Refuse the invocation, explaining how to reach a function.
+   */
+  invokeRefusal(request: SimCognitoTriggerFunctionRequest): string {
+    return (
+      `${request.functionArn} cannot be reached: this ` +
+      `SimCognitoIdentityProvider was built without simulated Lambda. Reach ` +
+      `Cognito through SimAws to run a user pool trigger.`
+    );
+  }
+
+  /**
+   * Refuse to invoke, for the same reason.
+   */
+  invoke(request: SimCognitoTriggerFunctionRequest): Promise<unknown> {
+    return Promise.reject(new Error(this.invokeRefusal(request)));
+  }
+}

--- a/src/service/cognito/user-pool/trigger/sim-cognito-trigger-name.ts
+++ b/src/service/cognito/user-pool/trigger/sim-cognito-trigger-name.ts
@@ -1,0 +1,63 @@
+/**
+ * The Lambda triggers a simulated user pool runs.
+ *
+ * These two are the ones that fire around a sign-in, which is the only part of
+ * a user's life this simulation has: `AdminCreateUser` is how a user comes to
+ * exist here, and a pool sends no messages, so the sign-up and message triggers
+ * would never run whatever a pool named for them.
+ */
+export const simCognitoTriggerNames = [
+  "PreAuthentication",
+  "PostAuthentication",
+] as const;
+
+export type SimCognitoTriggerName = (typeof simCognitoTriggerNames)[number];
+
+/**
+ * What real Cognito calls a trigger when it invokes it.
+ *
+ * A handler reads `triggerSource` to tell apart the several occasions one
+ * trigger fires on, so the value has to be the real one rather than the
+ * trigger's own name. Each of these two has a single source here, because the
+ * other sources name flows this simulation does not run.
+ */
+export function simCognitoTriggerSource(
+  trigger: SimCognitoTriggerName,
+): string {
+  return trigger === "PreAuthentication"
+    ? "PreAuthentication_Authentication"
+    : "PostAuthentication_Authentication";
+}
+
+/**
+ * The `LambdaConfig` keys real Cognito has that this simulation does not run,
+ * and why each one is refused rather than accepted and ignored.
+ *
+ * A pool that accepted one of these would sign users in without ever calling
+ * the function the template named, which is the difference between a stack
+ * that works here and one that works deployed.
+ */
+export const simCognitoUnsimulatedTriggers: ReadonlyMap<string, string> =
+  new Map([
+    ["PreSignUp", "validating a self-service sign-up"],
+    ["PostConfirmation", "acting on a user confirming its own account"],
+    ["PreTokenGeneration", "changing the claims a pool puts in its tokens"],
+    [
+      "PreTokenGenerationConfig",
+      "changing the claims a pool puts in its tokens",
+    ],
+    ["CustomMessage", "writing the wording of a message the pool sends"],
+    ["DefineAuthChallenge", "the custom authentication challenge flow"],
+    ["CreateAuthChallenge", "the custom authentication challenge flow"],
+    ["VerifyAuthChallengeResponse", "the custom authentication challenge flow"],
+    [
+      "UserMigration",
+      "importing a user from an external directory on first sign-in",
+    ],
+    ["CustomEmailSender", "sending the pool's email through a function"],
+    ["CustomSMSSender", "sending the pool's SMS through a function"],
+    [
+      "KMSKeyID",
+      "the key the custom sender triggers encrypt their codes under",
+    ],
+  ]);

--- a/src/service/cognito/user-pool/trigger/sim-cognito-trigger-response.ts
+++ b/src/service/cognito/user-pool/trigger/sim-cognito-trigger-response.ts
@@ -1,0 +1,49 @@
+import { SimCognitoInvalidLambdaResponseException } from "../../error/sim-cognito-trigger.error.js";
+import type { SimCognitoTriggerName } from "./sim-cognito-trigger-name.js";
+
+/**
+ * Refuse what a Lambda trigger handler returned, unless it is the event it was
+ * given.
+ *
+ * A trigger handler is handed the event and has to return it, changed or not.
+ * Real Cognito reads the returned object rather than the one it sent, so a
+ * handler that returns nothing has dropped the event, and one that returns
+ * something without the `request` it was given has returned a different event.
+ * Both are `InvalidLambdaResponseException` there and here.
+ *
+ * `response` is not checked. Neither of the triggers this simulation runs reads
+ * anything out of it, so a handler that dropped it has not changed what happens
+ * next, and refusing it here would refuse handlers real Cognito accepts.
+ */
+export function requireSimCognitoTriggerResponse(
+  trigger: SimCognitoTriggerName,
+  returned: unknown,
+): void {
+  if (
+    typeof returned !== "object" ||
+    returned === null ||
+    Array.isArray(returned)
+  ) {
+    throw new SimCognitoInvalidLambdaResponseException(
+      `The ${trigger} trigger returned ${describeReturned(returned)} rather ` +
+        `than the event it was given. A trigger handler has to return the ` +
+        `event, changed or not.`,
+    );
+  }
+
+  if (!("request" in returned)) {
+    throw new SimCognitoInvalidLambdaResponseException(
+      `The ${trigger} trigger returned an object without a request, so it is ` +
+        `not the event it was given. A trigger handler has to return the ` +
+        `event, changed or not.`,
+    );
+  }
+}
+
+function describeReturned(returned: unknown): string {
+  if (Array.isArray(returned)) {
+    return "an array";
+  }
+
+  return returned === null ? "null" : typeof returned;
+}

--- a/src/service/cognito/user-pool/trigger/sim-cognito-user-pool-triggers.ts
+++ b/src/service/cognito/user-pool/trigger/sim-cognito-user-pool-triggers.ts
@@ -1,0 +1,116 @@
+import {
+  SimCognitoUnexpectedLambdaException,
+  SimCognitoUserLambdaValidationException,
+} from "../../error/sim-cognito-trigger.error.js";
+import {
+  SimCognitoTriggerEvent,
+  type SimCognitoTriggerContext,
+} from "./sim-cognito-trigger-event.js";
+import type {
+  SimCognitoTriggerFunctionRequest,
+  SimCognitoTriggerFunctions,
+} from "./sim-cognito-trigger-functions.js";
+import type { SimCognitoTriggerName } from "./sim-cognito-trigger-name.js";
+import { requireSimCognitoTriggerResponse } from "./sim-cognito-trigger-response.js";
+
+interface SimCognitoUserPoolTriggersProperties {
+  readonly functions: SimCognitoTriggerFunctions;
+}
+
+/**
+ * Runs the Lambda triggers a simulated user pool names.
+ *
+ * A pool with no trigger for the occasion runs nothing, which is the ordinary
+ * case and costs a map lookup. A pool with one invokes it and waits: these
+ * triggers are synchronous, so the sign-in is held up until the handler
+ * answers, as it is on real Cognito.
+ *
+ * The function's resource policy is checked on every invocation rather than
+ * remembered from the first, because a permission revoked afterwards stops the
+ * trigger on real Cognito too.
+ */
+export class SimCognitoUserPoolTriggers {
+  private readonly functions: SimCognitoTriggerFunctions;
+
+  constructor(properties: SimCognitoUserPoolTriggersProperties) {
+    this.functions = properties.functions;
+  }
+
+  /**
+   * Run the `PreAuthentication` trigger, if the pool has one.
+   *
+   * A handler that throws refuses the sign-in, which is what the trigger is
+   * for: the message it threw is carried into the
+   * `UserLambdaValidationException` the caller sees.
+   */
+  async preAuthentication(context: SimCognitoTriggerContext): Promise<void> {
+    await this.run("PreAuthentication", context);
+  }
+
+  /**
+   * Run the `PostAuthentication` trigger, if the pool has one.
+   *
+   * This runs once the tokens have been issued, so a handler that throws fails
+   * the request without undoing the sign-in: the user is signed in, and the
+   * tokens the pool issued stay issued, exactly as on real Cognito.
+   */
+  async postAuthentication(context: SimCognitoTriggerContext): Promise<void> {
+    await this.run("PostAuthentication", context);
+  }
+
+  private async run(
+    trigger: SimCognitoTriggerName,
+    context: SimCognitoTriggerContext,
+  ): Promise<void> {
+    const functionArn = context.pool.lambdaConfig.find(trigger);
+
+    if (functionArn === undefined) {
+      return;
+    }
+
+    const request: SimCognitoTriggerFunctionRequest = {
+      functionArn,
+      userPoolArn: context.pool.arn.value,
+      userPoolAccountId: context.pool.arn.accountId,
+    };
+    const refusal = this.functions.invokeRefusal(request);
+
+    if (refusal !== undefined) {
+      throw new SimCognitoUnexpectedLambdaException(
+        `The ${trigger} trigger of user pool ${context.pool.id} could not be ` +
+          `invoked. ${refusal}`,
+      );
+    }
+
+    requireSimCognitoTriggerResponse(
+      trigger,
+      await this.invoke(trigger, request, context),
+    );
+  }
+
+  /**
+   * Invoke the handler, reporting a failure the way real Cognito reports one.
+   *
+   * The handler's own message is repeated because that is the whole mechanism a
+   * `PreAuthentication` trigger refuses a sign-in with: it throws, and the
+   * words it threw are what the caller is told.
+   */
+  private async invoke(
+    trigger: SimCognitoTriggerName,
+    request: SimCognitoTriggerFunctionRequest,
+    context: SimCognitoTriggerContext,
+  ): Promise<unknown> {
+    try {
+      return await this.functions.invoke(
+        request,
+        new SimCognitoTriggerEvent(context).document(trigger),
+      );
+    } catch (error) {
+      throw new SimCognitoUserLambdaValidationException(
+        `${trigger} failed with error ${
+          error instanceof Error ? error.message : String(error)
+        }.`,
+      );
+    }
+  }
+}

--- a/src/service/lambda/function/invoke/sim-lambda-handler-runner.ts
+++ b/src/service/lambda/function/invoke/sim-lambda-handler-runner.ts
@@ -17,6 +17,32 @@ function toHandlerError(error: Error | string): Error {
 }
 
 /**
+ * The Error a rejected handler rejected with.
+ *
+ * Zip code runs in a vm sandbox with its own realm, so the Error it throws is
+ * not an instance of this realm's Error, and stringifying it into the message
+ * of a new one would give whoever reads it `Error: Boom` where the handler said
+ * `Boom`. A thrown value carrying a string message is rebuilt as an Error of
+ * this realm instead, saying what the handler said and keeping the value it
+ * threw as the cause.
+ */
+function toRejectedError(error: unknown): Error {
+  if (error instanceof Error) {
+    return error;
+  }
+
+  if (
+    typeof error !== "object" ||
+    error === null ||
+    typeof (error as Error).message !== "string"
+  ) {
+    return new Error(String(error));
+  }
+
+  return new Error((error as Error).message, { cause: error });
+}
+
+/**
  * Runs a sim Lambda handler function to completion.
  *
  * Mirrors the completion styles of the real Node.js Lambda runtime: a handler
@@ -51,7 +77,7 @@ export class SimLambdaHandlerRunner {
         // this cannot await; the callback path may still settle first.
         // eslint-disable-next-line unicorn/prefer-await
         returned.then(resolve, (error: unknown) => {
-          reject(error instanceof Error ? error : new Error(String(error)));
+          reject(toRejectedError(error));
         });
         return;
       }

--- a/src/service/lambda/function/sim-lambda-function-arn-parts.ts
+++ b/src/service/lambda/function/sim-lambda-function-arn-parts.ts
@@ -1,0 +1,64 @@
+import type { SimAwsAccountId } from "../../aws/sim-aws-account.js";
+import type { AwsRegionName } from "../../aws/sim-aws-region.js";
+
+/**
+ * The parts of a Lambda function ARN.
+ *
+ * The qualifier is the version or alias a qualified ARN names, and it is
+ * reported rather than ignored: simulated Lambda has neither, so a service
+ * pointed at `:PROD` would otherwise reach `$LATEST` and think it had done as
+ * it was told.
+ */
+export interface SimLambdaFunctionArnParts {
+  readonly regionName: AwsRegionName;
+  readonly accountId: SimAwsAccountId;
+  readonly functionName: string;
+  readonly qualifier: string | undefined;
+}
+
+/**
+ * Read the parts of a Lambda function ARN, or nothing when the value is not
+ * one.
+ *
+ * Lambda addresses a function with colons rather than a slash, so this reads
+ * the ARN itself rather than going through the shared ARN parser, which is
+ * built for the slash form.
+ *
+ * Nothing is thrown here. A function ARN reaches the simulator from another
+ * service's configuration, where a value that is not one at all is an ordinary
+ * case that service reports in its own words.
+ */
+export function parseSimLambdaFunctionArn(
+  arn: string,
+): SimLambdaFunctionArnParts | undefined {
+  const [
+    prefix,
+    partition,
+    service,
+    region,
+    accountId,
+    resourceType,
+    name,
+    qualifier,
+  ] = arn.split(":");
+
+  if (
+    prefix !== "arn" ||
+    partition !== "aws" ||
+    service !== "lambda" ||
+    resourceType !== "function" ||
+    region === undefined ||
+    accountId === undefined ||
+    name === undefined ||
+    name === ""
+  ) {
+    return undefined;
+  }
+
+  return {
+    regionName: region as AwsRegionName,
+    accountId: accountId as SimAwsAccountId,
+    functionName: name,
+    qualifier,
+  };
+}

--- a/src/service/s3/notification/destination/lambda/sim-s3-notification-function-arn.ts
+++ b/src/service/s3/notification/destination/lambda/sim-s3-notification-function-arn.ts
@@ -1,5 +1,6 @@
 import type { SimAwsAccountId } from "../../../../aws/sim-aws-account.js";
 import type { AwsRegionName } from "../../../../aws/sim-aws-region.js";
+import { parseSimLambdaFunctionArn } from "../../../../lambda/function/sim-lambda-function-arn-parts.js";
 import {
   SimS3InvalidArgument,
   SimS3NotImplemented,
@@ -8,9 +9,9 @@ import {
 /**
  * The Lambda function ARN a notification configuration names.
  *
- * Lambda addresses a function with colons rather than a slash, so this reads
- * the ARN itself rather than going through the shared ARN parser, which is
- * built for the slash form.
+ * Reading the ARN is Lambda's own business, so the parts come from there. What
+ * S3 adds is what an unreadable one means to a Bucket, which is an
+ * `InvalidArgument` against the configuration that named it.
  */
 export class SimS3NotificationFunctionArn {
   public readonly regionName: AwsRegionName;
@@ -35,31 +36,13 @@ export class SimS3NotificationFunctionArn {
    * silently notifying `$LATEST` instead would be the wrong function.
    */
   static parse(arn: string): SimS3NotificationFunctionArn {
-    const [
-      prefix,
-      partition,
-      service,
-      region,
-      accountId,
-      resourceType,
-      name,
-      qualifier,
-    ] = arn.split(":");
+    const parts = parseSimLambdaFunctionArn(arn);
 
-    if (
-      prefix !== "arn" ||
-      partition !== "aws" ||
-      service !== "lambda" ||
-      resourceType !== "function" ||
-      region === undefined ||
-      accountId === undefined ||
-      name === undefined ||
-      name === ""
-    ) {
+    if (parts === undefined) {
       throw new SimS3InvalidArgument(`${arn} is not a Lambda function ARN.`);
     }
 
-    if (qualifier !== undefined) {
+    if (parts.qualifier !== undefined) {
       throw new SimS3NotImplemented(
         `Cannot notify ${arn}: simulated Lambda has no function versions or ` +
           "aliases, so a qualified function ARN is refused rather than " +
@@ -68,9 +51,9 @@ export class SimS3NotificationFunctionArn {
     }
 
     return new SimS3NotificationFunctionArn(
-      region as AwsRegionName,
-      accountId as SimAwsAccountId,
-      name,
+      parts.regionName,
+      parts.accountId,
+      parts.functionName,
     );
   }
 }

--- a/test/cognito/cfn-deploy.ts
+++ b/test/cognito/cfn-deploy.ts
@@ -52,10 +52,14 @@ export async function deployFailure(
 export async function deploySuccess(
   simAws: SimAws,
   resources: SimCfnTemplateValueRecord,
+  outputs?: SimCfnTemplateValueRecord,
 ): Promise<SimCfnStack> {
   const stack = await simAws.cloudFormation().deployTemplate({
     stackName: "app-stack",
-    template: { Resources: resources },
+    template: {
+      Resources: resources,
+      ...(outputs !== undefined && { Outputs: outputs }),
+    },
   });
   await stack.waitForDeployComplete();
 

--- a/test/cognito/trigger-fixture.ts
+++ b/test/cognito/trigger-fixture.ts
@@ -1,0 +1,195 @@
+/**
+ * The parts a user pool trigger test needs before it can say anything about a
+ * trigger firing: a function to invoke, the permission that lets Cognito invoke
+ * it, a pool naming it, an app client to sign in through, and a user to sign
+ * in.
+ *
+ * These live under `test/` because eslint rejects a test file exporting helpers
+ * alongside its own `describe` calls, and several suites need the same pool.
+ */
+
+import {
+  AdminCreateUserCommand,
+  AdminSetUserPasswordCommand,
+  CreateUserPoolClientCommand,
+  CreateUserPoolCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import {
+  AddPermissionCommand,
+  CreateFunctionCommand,
+} from "@aws-sdk/client-lambda";
+import { assertNonNullable } from "@kensio/smartass";
+
+import { SimAws } from "../../src/service/aws/sim-aws.js";
+import { DEFAULT_SIM_AWS_ACCOUNT_ID } from "../../src/service/aws/sim-aws-account.js";
+import { DEFAULT_SIM_AWS_REGION_NAME } from "../../src/service/aws/sim-aws-region.js";
+import type { SimCognitoIdentityProvider } from "../../src/service/cognito/index.js";
+import { makeLambdaZipFileInput } from "../../src/service/lambda/function/code/lambda-zip-file-input.js";
+import type { SimLambdaHandler } from "../../src/service/lambda/function/sim-lambda-handler.type.js";
+
+/**
+ * A trigger handler that hands the event back untouched, which is what a
+ * handler with nothing to say has to do.
+ */
+const passThroughHandler: SimLambdaHandler = (event: unknown) => event;
+
+/** The password the fixture's user signs in with. */
+export const triggerPassword = "Sup3rSecret!";
+
+/** The name of the function every trigger in the fixture points at. */
+export const triggerFunctionName = "auth-trigger";
+
+/**
+ * What a test asks for when it wants a pool with a Lambda trigger on it.
+ */
+export interface SimCognitoTriggerPoolInput {
+  /** The `LambdaConfig` the pool is created with. */
+  readonly triggers: Readonly<Record<string, string>>;
+
+  /** What the function does when a trigger invokes it. */
+  readonly handler?: SimLambdaHandler | undefined;
+
+  /**
+   * Whether the function's resource policy admits `cognito-idp.amazonaws.com`
+   * for this pool, which is what a CDK `addTrigger` emits an
+   * `AWS::Lambda::Permission` for.
+   */
+  readonly permitted?: boolean | undefined;
+}
+
+/**
+ * A pool whose triggers point at a function, and a user ready to sign in.
+ */
+export interface SimCognitoTriggerPool {
+  readonly simAws: SimAws;
+  readonly cognito: SimCognitoIdentityProvider;
+  readonly userPoolId: string;
+  readonly userPoolArn: string;
+  readonly clientId: string;
+  readonly functionArn: string;
+}
+
+/**
+ * The ARN the fixture's trigger function has.
+ *
+ * A `LambdaConfig` names the function before the pool exists, so the ARN has to
+ * be known before anything is created, which is why it is stated rather than
+ * read back off the created function.
+ */
+export const triggerFunctionArn =
+  `arn:aws:lambda:${DEFAULT_SIM_AWS_REGION_NAME}:${DEFAULT_SIM_AWS_ACCOUNT_ID}` +
+  `:function:${triggerFunctionName}`;
+
+/**
+ * Build a pool running the triggers a test named.
+ *
+ * The order is the one a real deployment has to use: the function first,
+ * because the pool names it by ARN, then the pool, then the permission, because
+ * that names the pool by ARN in turn.
+ */
+export async function makeTriggerPool(
+  input: SimCognitoTriggerPoolInput,
+): Promise<SimCognitoTriggerPool> {
+  const simAws = new SimAws();
+
+  await simAws.lambda().createFunction(
+    new CreateFunctionCommand({
+      FunctionName: triggerFunctionName,
+      Role: `arn:aws:iam::${simAws.defaultAccountId}:role/TriggerRole`,
+      Code: {
+        ZipFile: makeLambdaZipFileInput(input.handler ?? passThroughHandler),
+      },
+    }),
+  );
+
+  const cognito = simAws.cognitoIdentityProvider();
+  const pool = await cognito.createUserPool(
+    new CreateUserPoolCommand({
+      PoolName: "myapp-users",
+      LambdaConfig: input.triggers,
+    }),
+  );
+
+  assertNonNullable(pool.UserPool?.Id, "CreateUserPool answered with a pool");
+  assertNonNullable(pool.UserPool.Arn, "The created pool has an ARN");
+
+  const userPoolId = pool.UserPool.Id;
+  const userPoolArn = pool.UserPool.Arn;
+
+  if (input.permitted ?? true) {
+    await simAws.lambda().addPermission(
+      new AddPermissionCommand({
+        FunctionName: triggerFunctionName,
+        StatementId: "AllowCognito",
+        Action: "lambda:InvokeFunction",
+        Principal: "cognito-idp.amazonaws.com",
+        SourceArn: userPoolArn,
+      }),
+    );
+  }
+
+  return {
+    simAws,
+    cognito,
+    userPoolId,
+    userPoolArn,
+    clientId: await makeTriggerClient(cognito, userPoolId),
+    functionArn: triggerFunctionArn,
+  };
+}
+
+/**
+ * Add the user the fixture signs in as, with `email` set so a trigger event has
+ * an attribute to carry beyond the `sub` every user has.
+ *
+ * A user left unconfirmed keeps only its temporary password, so its sign-in is
+ * answered with the `NEW_PASSWORD_REQUIRED` challenge rather than with tokens.
+ */
+export async function makeTriggerUser(
+  pool: SimCognitoTriggerPool,
+  confirmed = true,
+): Promise<void> {
+  await pool.cognito.adminCreateUser(
+    new AdminCreateUserCommand({
+      UserPoolId: pool.userPoolId,
+      Username: "alice",
+      TemporaryPassword: "Temp0rary!",
+      UserAttributes: [{ Name: "email", Value: "alice@example.com" }],
+    }),
+  );
+
+  if (confirmed) {
+    await pool.cognito.adminSetUserPassword(
+      new AdminSetUserPasswordCommand({
+        UserPoolId: pool.userPoolId,
+        Username: "alice",
+        Password: triggerPassword,
+        Permanent: true,
+      }),
+    );
+  }
+}
+
+async function makeTriggerClient(
+  cognito: SimCognitoIdentityProvider,
+  userPoolId: string,
+): Promise<string> {
+  const client = await cognito.createUserPoolClient(
+    new CreateUserPoolClientCommand({
+      UserPoolId: userPoolId,
+      ClientName: "web",
+      ExplicitAuthFlows: [
+        "ALLOW_USER_PASSWORD_AUTH",
+        "ALLOW_ADMIN_USER_PASSWORD_AUTH",
+        "ALLOW_REFRESH_TOKEN_AUTH",
+      ],
+    }),
+  );
+
+  assertNonNullable(
+    client.UserPoolClient?.ClientId,
+    "CreateUserPoolClient answered with a client id",
+  );
+
+  return client.UserPoolClient.ClientId;
+}


### PR DESCRIPTION
Resolves #425

A simulated Cognito user pool could not have Lambda triggers at all: `CreateUserPool` refused `LambdaConfig` outright, so a CDK stack calling `userPool.addTrigger(...)` would not deploy.

## What it does

A pool accepts `LambdaConfig`, and `PreAuthentication` and `PostAuthentication` fire around a successful sign-in. `PreAuthentication` runs once the user is known and before its password is checked, which is the order AWS documents; `PostAuthentication` runs once the tokens have been issued.

The handler receives the real event: `version`, `region`, `userPoolId`, `userName`, `callerContext`, `triggerSource` and a `request`/`response` pair. Three failures are reported the way real Cognito reports them:

- a handler that throws refuses the sign-in with `UserLambdaValidationException`, carrying the message it threw;
- a trigger naming a function that is not there, or one whose resource policy does not admit `cognito-idp.amazonaws.com` for the pool, fails with `UnexpectedLambdaException`;
- a handler that returns something other than the event it was given fails with `InvalidLambdaResponseException`.

Every other `LambdaConfig` key is refused when the pool is created, one key at a time and naming the trigger, so a pool never silently drops one.

`ClientMetadata` stops being refused on `InitiateAuth`, `AdminInitiateAuth`, `RespondToAuthChallenge` and `AdminRespondToAuthChallenge`, and reaches the handler as `request.validationData` or `request.clientMetadata`.

## Notes on scope

- **`PostAuthentication` also fires on the challenge response.** A user answering `NEW_PASSWORD_REQUIRED` completes its sign-in there, and AWS documents `RespondToAuthChallenge`'s `ClientMetadata` as reaching the post authentication trigger. Without this, accepting `ClientMetadata` on those two commands would have been a silent ignore.
- **Neither trigger fires for `REFRESH_TOKEN_AUTH`**, as neither does on real Cognito.
- **`UpdateUserPool` is not part of this.** The issue asked for `LambdaConfig` on `UpdateUserPool` too, but that command is not simulated at all, so there is no handler to add it to. A separate issue is worth raising for it.
- **One Lambda fix came along.** `SimLambdaHandlerRunner` was turning an error thrown inside the vm sandbox into `new Error(String(error))`, so a zip handler that threw `Boom` surfaced as `Error: Boom`. It now rebuilds a host `Error` from the message with the thrown value as the cause, which also improves S3 notification and direct-invoke failures.
- **Lambda function ARN parsing is now shared.** `parseSimLambdaFunctionArn` lives in Lambda, and `SimS3NotificationFunctionArn` delegates to it rather than keeping a second copy.

## Tests

- Unit and behaviour suites for the trigger event shape, the config refusals, and each of the three failures.
- A CloudFormation suite deploying a pool, a function and an `AWS::Lambda::Permission` together.
- A local integration test that synths a real CDK app using `pool.addTrigger(UserPoolOperation.PRE_AUTHENTICATION, fn)`, deploys the synthesized template, and shows the deployed function both recording a sign-in into a Bucket and turning one away.

`pnpm check` passes. One pre-existing failure shows up locally, `src/cli/watch/sim-watch-reported-paths.loc.test.ts` from #441: `repoPath` requires the repo directory to be named `yulin`, so from a git worktree it resolves out to the main checkout. It fails the same way on a clean `main` in a worktree and is unrelated to this change.

## Docs

A **Lambda triggers** section in the Cognito README with a compiling example, updated functionality and limitations lists, and a correction to the Lambda README's list of services that supply `AWS:SourceArn`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added simulated Cognito `PreAuthentication` and `PostAuthentication` Lambda trigger support.
  - Added CloudFormation `LambdaConfig` handling, trigger validation, permission checks, and trigger event generation.
  - Authentication now passes `ClientMetadata` to configured triggers.
  - User-pool descriptions report configured supported triggers.
- **Bug Fixes**
  - Improved Cognito error reporting for trigger failures and invalid responses.
  - Authentication with `ClientMetadata` is now supported; unsupported `AnalyticsMetadata` remains rejected.
- **Documentation**
  - Documented trigger behavior, deployment requirements, limitations, failures, and refresh-token handling.
  - Added usage examples for authentication trigger configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->