### PR TITLE
fix: resolve repo root inside a worktree

### DIFF
--- a/src/service/s3/mount/sim-s3-mount-watch.ts
+++ b/src/service/s3/mount/sim-s3-mount-watch.ts
@@ -42,6 +42,7 @@ export class SimS3MountWatch {
     this.watch = watch;
     this.settle = new SimWatchSettle({
       settleMs,
+      maxWaitMs: simWatchConfig.settleMaxWaitMs,
       onSettled: (): void => {
         this.onChanged();
       },

--- a/src/util/filesystem/path.iso.test.ts
+++ b/src/util/filesystem/path.iso.test.ts
@@ -1,0 +1,52 @@
+import path from "node:path";
+import { assertIdentical } from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { findRepoRootFrom, repoPath } from "./path.js";
+import { TemporaryDirectory } from "./temporary-directory.js";
+
+describe("Repository root resolution", () => {
+  it("stops at a checkout whose directory is not named after the repo", async () => {
+    // Given a checkout nested inside another one, in a directory named after a
+    // branch rather than after the repository, as a git worktree is
+    const worktree = await checkoutIn(["worktrees", "some-branch"]);
+
+    // When the root is resolved from a directory inside it
+    const foundRoot = findRepoRootFrom(path.join(worktree, "src", "util"));
+
+    // Then it is the worktree, not the checkout the worktree sits inside
+    assertIdentical(foundRoot, worktree);
+  });
+
+  it("walks past a package that is not the workspace root", async () => {
+    // Given a nested package carrying its own manifest and TypeScript config
+    const temporaryDirectory = new TemporaryDirectory();
+    await temporaryDirectory.writeFile(["nested", "package.json"], "{}");
+    await temporaryDirectory.writeFile(["nested", "tsconfig.json"], "{}");
+
+    // When the root is resolved from inside that package
+    const foundRoot = findRepoRootFrom(temporaryDirectory.join("nested"));
+
+    // Then the walk continues past it, up to the checkout it belongs to
+    assertIdentical(foundRoot, repoPath());
+  });
+});
+
+/**
+ * Writes the marker files of a checkout into a temporary directory, returning
+ * the path they were written to.
+ */
+async function checkoutIn(directoryParts: string[]): Promise<string> {
+  const temporaryDirectory = new TemporaryDirectory();
+
+  await temporaryDirectory.writeFile([...directoryParts, "package.json"], "{}");
+  await temporaryDirectory.writeFile(
+    [...directoryParts, "tsconfig.json"],
+    "{}",
+  );
+  await temporaryDirectory.writeFile(
+    [...directoryParts, "pnpm-workspace.yaml"],
+    "",
+  );
+
+  return temporaryDirectory.join(...directoryParts);
+}

--- a/src/util/filesystem/path.ts
+++ b/src/util/filesystem/path.ts
@@ -37,7 +37,7 @@ function findRepoRoot(startDirectories: readonly string[]): string {
 /**
  * Finds the repository root by walking upward from one directory.
  */
-function findRepoRootFrom(startDirectory: string): string | undefined {
+export function findRepoRootFrom(startDirectory: string): string | undefined {
   let currentDirectory = path.resolve(startDirectory);
 
   for (let level = 0; level < 100; level++) {
@@ -61,10 +61,15 @@ function findRepoRootFrom(startDirectory: string): string | undefined {
 
 /**
  * Checks whether a directory looks like this repository's root.
+ *
+ * Marker files only, deliberately: a git worktree is a checkout in a directory
+ * named after the branch rather than after the repository, so matching on the
+ * directory name walks straight past it and lands in whichever checkout is
+ * further up. The three markers together are specific enough on their own,
+ * with the workspace file ruling out a nested package.
  */
 function isRepoRoot(directory: string): boolean {
   return (
-    path.basename(directory) === "yulin" &&
     fs.existsSync(path.join(directory, "package.json")) &&
     fs.existsSync(path.join(directory, "tsconfig.json")) &&
     fs.existsSync(path.join(directory, "pnpm-workspace.yaml"))


### PR DESCRIPTION
Two fixes, both about code that was green in isolation and wrong once combined.

## Resolving the repo root inside a worktree

`repoPath` resolved out of a git worktree and into the main checkout, silently.

`isRepoRoot` required `path.basename(directory) === "yulin"` alongside `package.json`, `tsconfig.json` and `pnpm-workspace.yaml`. A worktree under `.claude/worktrees/<name>` has a basename named after the branch, so `findRepoRootFrom` walked straight past a perfectly good root and kept going up until it reached the checkout the worktree was nested inside — usually on a different commit.

The visible failure was `src/cli/watch/sim-watch-reported-paths.loc.test.ts`, which supervises a real process at `repoPath("src/watch/index.js")`. Run from a worktree that resolved to the other checkout, which does not have the file unless it happens to be on a commit containing it, and the supervised process died with `ERR_MODULE_NOT_FOUND`. The wider risk is worse than one failing test: any code reading through `repoPath` from a worktree read the wrong checkout without saying so.

Match on the marker files alone and drop the name check. There is exactly one `pnpm-workspace.yaml` in the tree, and that is what rules out stopping at a nested package — `docs/` has a `tsconfig.json` but no manifest and no workspace file. The name check was not carrying the specificity on its own.

A `.git` entry is deliberately *not* used as a signal. The three markers are already unique, so adding it would only introduce a way for resolution to fail on a checkout without one.

`findRepoRootFrom` is now exported so the walk is testable from an arbitrary start directory.

Tests cover both directions:

- Resolution stops at a checkout whose directory is named after a branch and is nested inside another checkout.
- Resolution still walks past a package carrying its own manifest and TypeScript config but no workspace file, so the specificity the name check stood in for is genuinely retained.

`sim-watch-reported-paths.loc.test.ts` now passes from a worktree, where it failed on a clean `main` before.

Neither `temporary-directory.ts` nor `test-cdk-project.ts` makes an independent assumption — both go through `repoPath` and follow the fix. Nothing else in `src/`, `test/` or `scripts/` walks up looking for the root.

## Capping a burst of writes to a mount

`main` was broken at a00e4d4, independently of the above. #449 made `maxWaitMs` required on `SimWatchSettle`; #446 merged after it and added a call site in `sim-s3-mount-watch.ts` without one. Each was green on its own, and they only conflict once both are on `main`, so `tsc` failed there with:

```
error TS2741: Property 'maxWaitMs' is missing in type
'{ settleMs: number; onSettled: () => void; }'
but required in type 'SimWatchSettleProperties'.
```

Fixed here rather than separately, so merging this unblocks `main`.

The backstop comes from config, matching what `SimWatchWatcher` and `SimCfnTemplateFileWatch` already do — both expose `settleMs` as an override and take `maxWaitMs` from `simWatchConfig`. `settleMaxWaitMs` is also the right value on its own terms: the mount watch exists so that a build writing a hundred files is one reload, and 5000ms is the documented backstop for a burst that will not stop, so a long build reloads the browser during it rather than only once it finishes.

## Verification

`pnpm run check` passes on this branch: 846 test files, 5182 tests. The two remaining lint warnings are pre-existing, in `delete-hosted-zone.iso.test.ts`, untouched here.