### PR TITLE
feat: update a simulated Cognito app client

### DIFF
--- a/docs/services/cognito/README.md
+++ b/docs/services/cognito/README.md
@@ -477,6 +477,80 @@ is refused, as real Cognito refuses it. A client holding `ADMIN_NO_SRP_AUTH` can
 `ADMIN_USER_PASSWORD_AUTH` and one holding `USER_PASSWORD_AUTH` can run `USER_PASSWORD_AUTH`, which
 is what those settings meant before the `ALLOW_` prefixed ones replaced them.
 
+## Updating an app client
+
+`UpdateUserPoolClient` changes a client's settings, and `DescribeUserPoolClient` reports them along
+with a `LastModifiedDate` from when the update happened. A client nothing has updated reports its
+creation date there.
+
+```typescript sim-cognito-update-app-client
+/**
+ * Changing a simulated app client's settings, which replaces them rather than
+ * merging into them.
+ */
+
+import {
+  CreateUserPoolClientCommand,
+  CreateUserPoolCommand,
+  UpdateUserPoolClientCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const cognito = simAws.cognitoIdentityProvider();
+
+const pool = await cognito.createUserPool(
+  new CreateUserPoolCommand({ PoolName: "myapp-users" }),
+);
+
+const appClient = await cognito.createUserPoolClient(
+  new CreateUserPoolClientCommand({
+    UserPoolId: pool.UserPool?.Id,
+    ClientName: "web",
+    ExplicitAuthFlows: ["ALLOW_USER_PASSWORD_AUTH", "ALLOW_REFRESH_TOKEN_AUTH"],
+  }),
+);
+
+const updated = await cognito.updateUserPoolClient(
+  new UpdateUserPoolClientCommand({
+    UserPoolId: pool.UserPool?.Id,
+    ClientId: appClient.UserPoolClient?.ClientId,
+    ClientName: "web",
+    ExplicitAuthFlows: ["ALLOW_USER_PASSWORD_AUTH", "ALLOW_REFRESH_TOKEN_AUTH"],
+    AccessTokenValidity: 5,
+    TokenValidityUnits: { AccessToken: "minutes" },
+  }),
+);
+
+// The next sign-in gets an access token lasting five minutes.
+console.log(updated.UserPoolClient?.AccessTokenValidity); // 5
+console.log(updated.UserPoolClient?.LastModifiedDate); // when the update ran
+```
+
+An update replaces the client's configuration rather than merging into it, which is what real
+Cognito does. A setting the request leaves out goes back to the default `CreateUserPoolClient` would
+have given it, so the example above repeats `ExplicitAuthFlows` to keep them. A request carrying
+only `ClientName` sends the authentication flows back to `ALLOW_REFRESH_TOKEN_AUTH`,
+`ALLOW_USER_SRP_AUTH` and `ALLOW_CUSTOM_AUTH`, the token validities back to an hour and thirty days,
+and `PreventUserExistenceErrors` back to `LEGACY`.
+
+`ClientName` is the one setting an omitted request keeps rather than resets. A client has to have a
+name, and `CreateUserPoolClient` requires one, so there is no default to go back to.
+
+The client's secret is untouched by an update. `UpdateUserPoolClient` has no `GenerateSecret` input
+on real Cognito, so a client created without a secret never gains one and a client with one keeps the
+same value.
+
+A token already issued keeps the expiry it was issued with, because that expiry was stamped when the
+token was handed out. Shortening `AccessTokenValidity` therefore applies to the next sign-in rather
+than to a token a test is already holding, as it does on real Cognito. A changed `ExplicitAuthFlows`
+takes effect for the next `InitiateAuth`, so removing `ALLOW_USER_PASSWORD_AUTH` starts refusing that
+flow.
+
+The inputs `CreateUserPoolClient` refuses are refused here too, in the same words, saying
+`UpdateUserPoolClient`.
+
 ## Signing in and verifying tokens
 
 `AdminInitiateAuth` runs the `ADMIN_USER_PASSWORD_AUTH` flow and answers with real signed tokens. The
@@ -1636,8 +1710,8 @@ Sim Cognito currently supports:
 
 - `CreateUserPoolCommand`, `DescribeUserPoolCommand`, `DeleteUserPoolCommand` and
   `ListUserPoolsCommand`
-- `CreateUserPoolClientCommand`, `DescribeUserPoolClientCommand`, `DeleteUserPoolClientCommand` and
-  `ListUserPoolClientsCommand`
+- `CreateUserPoolClientCommand`, `DescribeUserPoolClientCommand`, `UpdateUserPoolClientCommand`,
+  `DeleteUserPoolClientCommand` and `ListUserPoolClientsCommand`
 - `AdminCreateUserCommand`, `AdminGetUserCommand`, `AdminDeleteUserCommand`,
   `AdminSetUserPasswordCommand`, `AdminUpdateUserAttributesCommand`, `AdminDisableUserCommand`,
   `AdminEnableUserCommand` and `ListUsersCommand`
@@ -1755,8 +1829,17 @@ Current documented limitations:
   periodically rather than on each write, so it can lag there in a way it never does here.
 - MFA is not simulated, so `AdminGetUser` reports no `UserMFASettingList`, `PreferredMfaSetting` or
   `MFAOptions`.
-- Nothing updates a pool or an app client. `UpdateUserPool` and `UpdateUserPoolClient` are not
-  implemented, so `LastModifiedDate` is always the creation date.
+- Nothing updates a pool. `UpdateUserPool` is not implemented, so a pool's `LastModifiedDate` is
+  always its creation date.
+- `UpdateUserPoolClient` replaces an app client's settings rather than merging into them, as real
+  Cognito does, so a setting the request leaves out goes back to the default `CreateUserPoolClient`
+  would have given it. `ClientName` is the exception: a client has to have a name and there is no
+  default to reset to, so an update that names none keeps the one the client has.
+- An update leaves the client's secret alone. `UpdateUserPoolClient` has no `GenerateSecret` input
+  on real Cognito, so a client created without a secret never gains one.
+- Redeploying a template that changed an `AWS::Cognito::UserPoolClient` does not run
+  `UpdateUserPoolClient`. Sim CloudFormation replaces a resource whose resolved template entry
+  changed rather than updating it in place.
 - A pool with `DeletionProtection: ACTIVE` cannot be deleted at all, because deactivating the
   protection needs `UpdateUserPool`.
 - `PreAuthentication` and `PostAuthentication` are the only Lambda triggers that run. Every other
@@ -1792,7 +1875,7 @@ Current documented limitations:
   `SupportedIdentityProviders` naming anything but `COGNITO`, a `ClientSecret` of your own,
   `AnalyticsConfiguration`, `AuthSessionValidity`, `EnablePropagateAdditionalUserContextData`,
   `RefreshTokenRotation`, `ReadAttributes`, `WriteAttributes`, and an `EnableTokenRevocation` of
-  `false`.
+  `false`. `UpdateUserPoolClient` refuses the same inputs, in the same words.
 - An `AllowedOAuthFlowsUserPoolClient` of `false`, and a `SupportedIdentityProviders` of
   `["COGNITO"]`, are accepted and change nothing, because both say the client wants the pool's own
   users and nothing else, which is all there is here. `DescribeUserPoolClient` reports them back.

--- a/docs/services/cognito/sim-cognito-update-app-client.example.ts
+++ b/docs/services/cognito/sim-cognito-update-app-client.example.ts
@@ -1,0 +1,42 @@
+/**
+ * Changing a simulated app client's settings, which replaces them rather than
+ * merging into them.
+ */
+
+import {
+  CreateUserPoolClientCommand,
+  CreateUserPoolCommand,
+  UpdateUserPoolClientCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const cognito = simAws.cognitoIdentityProvider();
+
+const pool = await cognito.createUserPool(
+  new CreateUserPoolCommand({ PoolName: "myapp-users" }),
+);
+
+const appClient = await cognito.createUserPoolClient(
+  new CreateUserPoolClientCommand({
+    UserPoolId: pool.UserPool?.Id,
+    ClientName: "web",
+    ExplicitAuthFlows: ["ALLOW_USER_PASSWORD_AUTH", "ALLOW_REFRESH_TOKEN_AUTH"],
+  }),
+);
+
+const updated = await cognito.updateUserPoolClient(
+  new UpdateUserPoolClientCommand({
+    UserPoolId: pool.UserPool?.Id,
+    ClientId: appClient.UserPoolClient?.ClientId,
+    ClientName: "web",
+    ExplicitAuthFlows: ["ALLOW_USER_PASSWORD_AUTH", "ALLOW_REFRESH_TOKEN_AUTH"],
+    AccessTokenValidity: 5,
+    TokenValidityUnits: { AccessToken: "minutes" },
+  }),
+);
+
+// The next sign-in gets an access token lasting five minutes.
+console.log(updated.UserPoolClient?.AccessTokenValidity); // 5
+console.log(updated.UserPoolClient?.LastModifiedDate); // when the update ran

--- a/src/service/cognito/README.md
+++ b/src/service/cognito/README.md
@@ -61,9 +61,20 @@ is a number in a unit, and the two arrive in separate request inputs, so the sam
 for an access token and a day for a refresh token. Resolving both into seconds in one place is what
 stops the pairing being got wrong when tokens are actually issued.
 
+`SimCognitoUserPoolClientSettings` holds the properties a request can set: the name, the
+authentication flows, `PreventUserExistenceErrors`, the token validities, and the two managed login
+settings that are reported back without being acted on. `CreateUserPoolClient` builds one from its
+request and `UpdateUserPoolClient` builds a fresh one and replaces what the client had, so a setting
+an update leaves out goes back to the default a create would have given it. That is what real
+Cognito does. `ClientName` is the exception the command applies: a client has to have a name and
+`CreateUserPoolClient` requires one, so there is no default to reset to and an update naming none
+keeps the name the client has.
+
 `makeSimCognitoClientSecret` generates a client secret, and only a client created with
 `GenerateSecret` gets one. A public client has no secret at all rather than an empty one, which is
-what makes code computing a `SECRET_HASH` fail on the client it should fail on.
+what makes code computing a `SECRET_HASH` fail on the client it should fail on. The secret is not
+one of the settings, so an update leaves it alone, as real Cognito does with no `GenerateSecret`
+input on `UpdateUserPoolClient`.
 
 ## User model
 
@@ -318,15 +329,19 @@ resource, here or on real AWS.
   `RESET_REQUIRED` is a status no user here reaches.
 - A client-side sign-up operation naming a user the pool does not hold reports it, whatever the app
   client's `PreventUserExistenceErrors` says. That setting is honoured for sign-in only.
-- Every unsimulated `CreateUserPool` and `CreateUserPoolClient` input is refused rather than ignored.
+- Every unsimulated `CreateUserPool`, `CreateUserPoolClient` and `UpdateUserPoolClient` input is
+  refused rather than ignored.
   `UsernameAttributes` is the one that matters most: a pool signing users in by email stores a
   generated UUID as the username, so a pool quietly created without it would answer with the wrong
   username here and the right one on real AWS.
 - A pool created with `DeletionProtection: ACTIVE` cannot be deleted at all, because `UpdateUserPool`
   is not simulated and that is the only way to deactivate the protection.
-- Nothing changes a pool or an app client after creation, so `LastModifiedDate` is always the
-  creation date. A user is different: every operation that changes one moves its
-  `UserLastModifiedDate` on.
+- Nothing changes a pool after creation, so its `LastModifiedDate` is always its creation date. An
+  app client is different: `UpdateUserPoolClient` moves its `LastModifiedDate` on, as every
+  operation that changes a user moves that user's `UserLastModifiedDate` on.
+- `UpdateUserPoolClient` replaces an app client's settings rather than merging into them, so a
+  setting the request leaves out goes back to its `CreateUserPoolClient` default. The client's
+  secret is not a setting and is left alone.
 - `SchemaAttributes` is not reported on a pool, though every pool holds the standard schema and
   validates user attributes against it.
 - Users are resolved by username only, and real Cognito also accepts a `sub` there.

--- a/src/service/cognito/command/authorize/sim-cognito-iam.iso.test.ts
+++ b/src/service/cognito/command/authorize/sim-cognito-iam.iso.test.ts
@@ -4,6 +4,7 @@ import {
   DescribeUserPoolCommand,
   DescribeUserPoolClientCommand,
   ListUserPoolsCommand,
+  UpdateUserPoolClientCommand,
 } from "@aws-sdk/client-cognito-identity-provider";
 import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
 import {
@@ -175,6 +176,73 @@ describe("sim Cognito IAM authorization", () => {
 
     // Then it is allowed.
     assertIdentical(described.UserPoolClient?.ClientName, "web");
+  });
+
+  it("authorizes updating an app client against the pool's ARN", async () => {
+    // Given a Role allowed to describe and create app clients in a pool, but
+    // not to update one.
+    const { simAws, caller, userPoolId } = await simCognitoWithRole({
+      Effect: "Allow",
+      Action: [
+        "cognito-idp:CreateUserPoolClient",
+        "cognito-idp:DescribeUserPoolClient",
+      ],
+      Resource: userPoolArn("*"),
+    });
+    const cognito = simAws.cognitoIdentityProvider();
+    const created = await cognito.createUserPoolClient(
+      new CreateUserPoolClientCommand({
+        UserPoolId: userPoolId,
+        ClientName: "web",
+      }),
+      { caller },
+    );
+
+    // When that Role updates the client it made.
+    const error = await assertThrowsErrorAsync(async () => {
+      await cognito.updateUserPoolClient(
+        new UpdateUserPoolClientCommand({
+          UserPoolId: userPoolId,
+          ClientId: created.UserPoolClient?.ClientId,
+          ClientName: "web-app",
+        }),
+        { caller },
+      );
+    });
+
+    // Then it is denied, because the policy grants no
+    // cognito-idp:UpdateUserPoolClient on the pool.
+    assertInstanceOf(error, SimIamAccessDenied);
+  });
+
+  it("allows updating an app client to a policy granting the action", async () => {
+    // Given a Role allowed everything on one pool.
+    const { simAws, caller, userPoolId } = await simCognitoWithRole({
+      Effect: "Allow",
+      Action: "cognito-idp:*",
+      Resource: userPoolArn("*"),
+    });
+    const cognito = simAws.cognitoIdentityProvider();
+    const created = await cognito.createUserPoolClient(
+      new CreateUserPoolClientCommand({
+        UserPoolId: userPoolId,
+        ClientName: "web",
+      }),
+      { caller },
+    );
+
+    // When that Role renames the client.
+    const updated = await cognito.updateUserPoolClient(
+      new UpdateUserPoolClientCommand({
+        UserPoolId: userPoolId,
+        ClientId: created.UserPoolClient?.ClientId,
+        ClientName: "web-app",
+      }),
+      { caller },
+    );
+
+    // Then it is allowed.
+    assertIdentical(updated.UserPoolClient?.ClientName, "web-app");
   });
 
   it("denies creating a pool to a policy naming pool ARNs", async () => {

--- a/src/service/cognito/command/client/sim-cognito-unsimulated-client-options.ts
+++ b/src/service/cognito/command/client/sim-cognito-unsimulated-client-options.ts
@@ -1,23 +1,27 @@
 import { SimCognitoUnsimulatedInput } from "../sim-cognito-unsimulated-input.js";
 import { SimCognitoUnsimulatedManagedLogin } from "./sim-cognito-unsimulated-managed-login.js";
-import type { SimCreateUserPoolClientCommandInput } from "./user-pool-client.command.js";
+import type { SimCognitoUserPoolClientSettingsInput } from "./user-pool-client.command.js";
 
 /**
- * Refuses the CreateUserPoolClient inputs this simulation does not model.
+ * Refuses the app client inputs this simulation does not model.
  *
  * Storing any of them would suggest an app client that works here would work
- * there.
+ * there. `CreateUserPoolClient` and `UpdateUserPoolClient` take the same
+ * settings, so both refuse the same ones and each says its own name.
  */
 export class SimCognitoUnsimulatedUserPoolClientOptions {
-  private readonly unsimulated = new SimCognitoUnsimulatedInput(
-    "CreateUserPoolClient",
-  );
-  private readonly managedLogin = new SimCognitoUnsimulatedManagedLogin();
+  private readonly unsimulated: SimCognitoUnsimulatedInput;
+  private readonly managedLogin: SimCognitoUnsimulatedManagedLogin;
+
+  constructor(operation: string) {
+    this.unsimulated = new SimCognitoUnsimulatedInput(operation);
+    this.managedLogin = new SimCognitoUnsimulatedManagedLogin(operation);
+  }
 
   /**
    * Refuse a request carrying an input this simulation cannot honour.
    */
-  refuseIn(input: SimCreateUserPoolClientCommandInput): void {
+  refuseIn(input: SimCognitoUserPoolClientSettingsInput): void {
     this.managedLogin.refuseIn(input);
 
     this.unsimulated.refuseUnless(

--- a/src/service/cognito/command/client/sim-cognito-unsimulated-managed-login.ts
+++ b/src/service/cognito/command/client/sim-cognito-unsimulated-managed-login.ts
@@ -1,6 +1,6 @@
 import { SimCognitoInvalidParameterException } from "../../error/sim-cognito.error.js";
 import { SimCognitoUnsimulatedInput } from "../sim-cognito-unsimulated-input.js";
-import type { SimCreateUserPoolClientCommandInput } from "./user-pool-client.command.js";
+import type { SimCognitoUserPoolClientSettingsInput } from "./user-pool-client.command.js";
 
 /**
  * The only identity provider a simulated app client can support.
@@ -18,14 +18,16 @@ const cognitoIdentityProvider = "COGNITO";
  * settings mean anything here.
  */
 export class SimCognitoUnsimulatedManagedLogin {
-  private readonly unsimulated = new SimCognitoUnsimulatedInput(
-    "CreateUserPoolClient",
-  );
+  private readonly unsimulated: SimCognitoUnsimulatedInput;
+
+  constructor(operation: string) {
+    this.unsimulated = new SimCognitoUnsimulatedInput(operation);
+  }
 
   /**
    * Refuse a request carrying a managed login setting.
    */
-  refuseIn(input: SimCreateUserPoolClientCommandInput): void {
+  refuseIn(input: SimCognitoUserPoolClientSettingsInput): void {
     this.refuseSupportedIdentityProviders(input.SupportedIdentityProviders);
 
     this.unsimulated.refuseUnless(
@@ -68,12 +70,8 @@ export class SimCognitoUnsimulatedManagedLogin {
    * which is what this simulation has, so that one is allowed through.
    */
   private refuseSupportedIdentityProviders(
-    providers: readonly string[] | undefined,
+    providers: readonly string[] = [],
   ): void {
-    if (providers === undefined) {
-      return;
-    }
-
     const federated = providers.filter(
       (provider) => provider !== cognitoIdentityProvider,
     );
@@ -83,7 +81,7 @@ export class SimCognitoUnsimulatedManagedLogin {
     }
 
     throw new SimCognitoInvalidParameterException(
-      `CreateUserPoolClient SupportedIdentityProviders ` +
+      `${this.unsimulated.operation} SupportedIdentityProviders ` +
         `'${federated.join(", ")}' is not simulated: federated sign-in ` +
         `happens at the provider rather than in this simulation. Only ` +
         `'${cognitoIdentityProvider}' is supported.`,

--- a/src/service/cognito/command/client/sim-cognito-update-client-unsimulated-options.iso.test.ts
+++ b/src/service/cognito/command/client/sim-cognito-update-client-unsimulated-options.iso.test.ts
@@ -1,0 +1,231 @@
+import {
+  type ExplicitAuthFlowsType,
+  type UpdateUserPoolClientCommandInput,
+  CreateUserPoolClientCommand,
+  CreateUserPoolCommand,
+  UpdateUserPoolClientCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import {
+  assertArrayEquals,
+  assertFalse,
+  assertInstanceOf,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimCognitoInvalidParameterException } from "../../error/sim-cognito.error.js";
+import type { SimCognitoIdentityProvider } from "../../sim-cognito-identity-provider.js";
+
+interface RefusedInput {
+  readonly label: string;
+  readonly input: Partial<UpdateUserPoolClientCommandInput>;
+  readonly says: string;
+}
+
+const refusedInputs: readonly RefusedInput[] = [
+  {
+    label: "SupportedIdentityProviders",
+    input: { SupportedIdentityProviders: ["COGNITO", "Google"] },
+    says: "federated sign-in happens at the provider",
+  },
+  {
+    label: "AllowedOAuthFlowsUserPoolClient",
+    input: { AllowedOAuthFlowsUserPoolClient: true },
+    says: "the OAuth 2.0 authorization server endpoints",
+  },
+  {
+    label: "EnableTokenRevocation",
+    input: { EnableTokenRevocation: false },
+    says: "token revocation",
+  },
+  {
+    label: "AllowedOAuthFlows",
+    input: { AllowedOAuthFlows: ["code"] },
+    says: "OAuth grants through managed login",
+  },
+  {
+    label: "AllowedOAuthScopes",
+    input: { AllowedOAuthScopes: ["openid"] },
+    says: "OAuth scopes",
+  },
+  {
+    label: "CallbackURLs",
+    input: { CallbackURLs: ["https://example.com"] },
+    says: "managed login redirects",
+  },
+  {
+    label: "LogoutURLs",
+    input: { LogoutURLs: ["https://example.com/out"] },
+    says: "managed login redirects",
+  },
+  {
+    label: "DefaultRedirectURI",
+    input: { DefaultRedirectURI: "https://example.com" },
+    says: "managed login redirects",
+  },
+  {
+    label: "AnalyticsConfiguration",
+    input: { AnalyticsConfiguration: { ApplicationId: "app" } },
+    says: "Amazon Pinpoint analytics",
+  },
+  {
+    label: "AuthSessionValidity",
+    input: { AuthSessionValidity: 5 },
+    says: "the authentication session lifetime",
+  },
+  {
+    label: "EnablePropagateAdditionalUserContextData",
+    input: { EnablePropagateAdditionalUserContextData: true },
+    says: "threat protection context data",
+  },
+  {
+    label: "RefreshTokenRotation",
+    input: { RefreshTokenRotation: { Feature: "ENABLED" } },
+    says: "refresh token rotation",
+  },
+  {
+    label: "ReadAttributes",
+    input: { ReadAttributes: ["email"] },
+    says: "per-client attribute permissions",
+  },
+  {
+    label: "WriteAttributes",
+    input: { WriteAttributes: ["email"] },
+    says: "per-client attribute permissions",
+  },
+];
+
+interface SimCognitoWithClient {
+  readonly cognito: SimCognitoIdentityProvider;
+  readonly userPoolId: string;
+  readonly clientId: string;
+}
+
+async function simCognitoWithClient(): Promise<SimCognitoWithClient> {
+  const cognito = new SimAws().cognitoIdentityProvider();
+  const pool = await cognito.createUserPool(
+    new CreateUserPoolCommand({ PoolName: "myapp-users" }),
+  );
+
+  assertNonNullable(pool.UserPool?.Id);
+
+  const appClient = await cognito.createUserPoolClient(
+    new CreateUserPoolClientCommand({
+      UserPoolId: pool.UserPool.Id,
+      ClientName: "web",
+    }),
+  );
+
+  assertNonNullable(appClient.UserPoolClient?.ClientId);
+
+  return {
+    cognito,
+    userPoolId: pool.UserPool.Id,
+    clientId: appClient.UserPoolClient.ClientId,
+  };
+}
+
+async function refusedUpdate(
+  withClient: SimCognitoWithClient,
+  input: Partial<UpdateUserPoolClientCommandInput>,
+  label: string,
+): Promise<Error> {
+  return await assertThrowsErrorAsync(async () => {
+    await withClient.cognito.updateUserPoolClient(
+      new UpdateUserPoolClientCommand({
+        UserPoolId: withClient.userPoolId,
+        ClientId: withClient.clientId,
+        ClientName: "web",
+        ...input,
+      }),
+    );
+  }, label);
+}
+
+describe("sim Cognito UpdateUserPoolClient unsimulated options", () => {
+  it("refuses every UpdateUserPoolClient input it does not simulate", async () => {
+    // Given a pool with an app client.
+    const withClient = await simCognitoWithClient();
+
+    // When each unsimulated input is used on an update.
+    const outcomes = await Promise.all(
+      refusedInputs.map(async (refused) => ({
+        refused,
+        error: await refusedUpdate(withClient, refused.input, refused.label),
+      })),
+    );
+
+    // Then each request is refused, saying what it was that could not be
+    // honoured, and naming the operation that was asked for.
+    for (const { refused, error } of outcomes) {
+      assertInstanceOf(error, SimCognitoInvalidParameterException);
+      assertStringIncludes(error.message, refused.says);
+      assertStringIncludes(error.message, "UpdateUserPoolClient");
+    }
+  });
+
+  it("takes the two managed login settings it accepts on creation", async () => {
+    // Given a pool with an app client.
+    const withClient = await simCognitoWithClient();
+
+    // When an update names the settings accepted at one value each.
+    const updated = await withClient.cognito.updateUserPoolClient(
+      new UpdateUserPoolClientCommand({
+        UserPoolId: withClient.userPoolId,
+        ClientId: withClient.clientId,
+        ClientName: "web",
+        SupportedIdentityProviders: ["COGNITO"],
+        AllowedOAuthFlowsUserPoolClient: false,
+        EnableTokenRevocation: true,
+      }),
+    );
+
+    // Then the update is applied, and the two settings it reports back are
+    // what this request set rather than what the creating one did.
+    assertFalse(updated.UserPoolClient?.AllowedOAuthFlowsUserPoolClient);
+    assertArrayEquals(updated.UserPoolClient.SupportedIdentityProviders, [
+      "COGNITO",
+    ]);
+  });
+
+  it("refuses a client name Cognito would not accept", async () => {
+    // Given a pool with an app client.
+    const withClient = await simCognitoWithClient();
+
+    // When an update renames it to something with a character Cognito
+    // rejects.
+    const error = await refusedUpdate(
+      withClient,
+      { ClientName: "web/app" },
+      "ClientName",
+    );
+
+    // Then it is refused, as the creating request would have been.
+    assertInstanceOf(error, SimCognitoInvalidParameterException);
+    assertStringIncludes(error.message, "characters Cognito does not allow");
+  });
+
+  it("refuses an authentication flow that is not a Cognito flow", async () => {
+    // Given a pool with an app client.
+    const withClient = await simCognitoWithClient();
+
+    // When an update names a flow that does not exist.
+    const error = await refusedUpdate(
+      withClient,
+      // The SDK types name the flows Cognito has, and the wire format takes
+      // any string, so this is what reaches a real pool from code that built
+      // the request itself.
+      {
+        ExplicitAuthFlows: ["ALLOW_MAGIC_LINK_AUTH" as ExplicitAuthFlowsType],
+      },
+      "ExplicitAuthFlows",
+    );
+
+    // Then it is refused rather than stored, because a typo in a flow name
+    // would otherwise turn into a puzzling sign-in failure much later.
+    assertInstanceOf(error, SimCognitoInvalidParameterException);
+    assertStringIncludes(error.message, "is not a Cognito authentication flow");
+  });
+});

--- a/src/service/cognito/command/client/sim-cognito-update-user-pool-client.iso.test.ts
+++ b/src/service/cognito/command/client/sim-cognito-update-user-pool-client.iso.test.ts
@@ -1,0 +1,282 @@
+import {
+  CreateUserPoolClientCommand,
+  CreateUserPoolCommand,
+  DescribeUserPoolClientCommand,
+  UpdateUserPoolClientCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import {
+  assertArrayEquals,
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimCognitoResourceNotFoundException } from "../../error/sim-cognito.error.js";
+
+describe("sim Cognito UpdateUserPoolClient", () => {
+  it("applies the settings the request names", async () => {
+    // Given a pool with an app client created with nothing but a name.
+    const cognito = new SimAws().cognitoIdentityProvider();
+    const pool = await cognito.createUserPool(
+      new CreateUserPoolCommand({ PoolName: "myapp-users" }),
+    );
+    const userPoolId = pool.UserPool?.Id;
+    const created = await cognito.createUserPoolClient(
+      new CreateUserPoolClientCommand({
+        UserPoolId: userPoolId,
+        ClientName: "web",
+      }),
+    );
+    const clientId = created.UserPoolClient?.ClientId;
+
+    // When the client is updated with new settings.
+    const updated = await cognito.updateUserPoolClient(
+      new UpdateUserPoolClientCommand({
+        UserPoolId: userPoolId,
+        ClientId: clientId,
+        ClientName: "web-app",
+        ExplicitAuthFlows: [
+          "ALLOW_USER_PASSWORD_AUTH",
+          "ALLOW_REFRESH_TOKEN_AUTH",
+        ],
+        PreventUserExistenceErrors: "ENABLED",
+        AccessTokenValidity: 5,
+        TokenValidityUnits: { AccessToken: "minutes" },
+      }),
+    );
+
+    // Then the update reports them, and so does the client from then on.
+    assertIdentical(updated.UserPoolClient?.ClientName, "web-app");
+    assertArrayEquals(updated.UserPoolClient.ExplicitAuthFlows, [
+      "ALLOW_USER_PASSWORD_AUTH",
+      "ALLOW_REFRESH_TOKEN_AUTH",
+    ]);
+    assertIdentical(
+      updated.UserPoolClient.PreventUserExistenceErrors,
+      "ENABLED",
+    );
+    assertIdentical(updated.UserPoolClient.AccessTokenValidity, 5);
+
+    const described = await cognito.describeUserPoolClient(
+      new DescribeUserPoolClientCommand({
+        UserPoolId: userPoolId,
+        ClientId: clientId,
+      }),
+    );
+
+    assertIdentical(described.UserPoolClient?.ClientName, "web-app");
+    assertIdentical(
+      described.UserPoolClient.TokenValidityUnits?.AccessToken,
+      "minutes",
+    );
+
+    const client = cognito
+      .findUserPool(userPoolId ?? "")
+      ?.findClient(clientId ?? "");
+
+    assertNonNullable(client);
+    assertIdentical(client.tokenValidity.accessToken.seconds, 5 * 60);
+  });
+
+  it("resets the settings the request leaves out to their defaults", async () => {
+    // Given a client created with flows, token lifetimes and a
+    // PreventUserExistenceErrors of its own.
+    const cognito = new SimAws().cognitoIdentityProvider();
+    const pool = await cognito.createUserPool(
+      new CreateUserPoolCommand({ PoolName: "myapp-users" }),
+    );
+    const userPoolId = pool.UserPool?.Id;
+    const created = await cognito.createUserPoolClient(
+      new CreateUserPoolClientCommand({
+        UserPoolId: userPoolId,
+        ClientName: "web",
+        ExplicitAuthFlows: ["ALLOW_USER_PASSWORD_AUTH"],
+        PreventUserExistenceErrors: "ENABLED",
+        AccessTokenValidity: 5,
+        IdTokenValidity: 5,
+        RefreshTokenValidity: 1,
+        TokenValidityUnits: {
+          AccessToken: "minutes",
+          IdToken: "minutes",
+          RefreshToken: "days",
+        },
+      }),
+    );
+
+    // When an update names only the client's name.
+    const updated = await cognito.updateUserPoolClient(
+      new UpdateUserPoolClientCommand({
+        UserPoolId: userPoolId,
+        ClientId: created.UserPoolClient?.ClientId,
+        ClientName: "web",
+      }),
+    );
+
+    // Then everything the request left out is back to the default
+    // CreateUserPoolClient would have applied, as real Cognito replaces a
+    // client's configuration rather than merging into it.
+    assertArrayEquals(updated.UserPoolClient?.ExplicitAuthFlows, [
+      "ALLOW_REFRESH_TOKEN_AUTH",
+      "ALLOW_USER_SRP_AUTH",
+      "ALLOW_CUSTOM_AUTH",
+    ]);
+    assertIdentical(
+      updated.UserPoolClient.PreventUserExistenceErrors,
+      "LEGACY",
+    );
+    assertUndefined(updated.UserPoolClient.AccessTokenValidity);
+    assertUndefined(updated.UserPoolClient.IdTokenValidity);
+    assertUndefined(updated.UserPoolClient.TokenValidityUnits);
+    assertIdentical(updated.UserPoolClient.RefreshTokenValidity, 30);
+  });
+
+  it("keeps the client's name when the request names no other", async () => {
+    // Given a client called web.
+    const cognito = new SimAws().cognitoIdentityProvider();
+    const pool = await cognito.createUserPool(
+      new CreateUserPoolCommand({ PoolName: "myapp-users" }),
+    );
+    const userPoolId = pool.UserPool?.Id;
+    const created = await cognito.createUserPoolClient(
+      new CreateUserPoolClientCommand({
+        UserPoolId: userPoolId,
+        ClientName: "web",
+      }),
+    );
+
+    // When an update says nothing about the name.
+    const updated = await cognito.updateUserPoolClient(
+      new UpdateUserPoolClientCommand({
+        UserPoolId: userPoolId,
+        ClientId: created.UserPoolClient?.ClientId,
+        AccessTokenValidity: 30,
+        TokenValidityUnits: { AccessToken: "minutes" },
+      }),
+    );
+
+    // Then it is still called web. A client has to have a name, and
+    // CreateUserPoolClient requires one, so there is no default to reset to.
+    assertIdentical(updated.UserPoolClient?.ClientName, "web");
+    assertIdentical(updated.UserPoolClient.AccessTokenValidity, 30);
+  });
+
+  it("leaves the client's secret untouched", async () => {
+    // Given one client with a secret and one without.
+    const cognito = new SimAws().cognitoIdentityProvider();
+    const pool = await cognito.createUserPool(
+      new CreateUserPoolCommand({ PoolName: "myapp-users" }),
+    );
+    const userPoolId = pool.UserPool?.Id;
+    const withSecret = await cognito.createUserPoolClient(
+      new CreateUserPoolClientCommand({
+        UserPoolId: userPoolId,
+        ClientName: "server",
+        GenerateSecret: true,
+      }),
+    );
+    const withoutSecret = await cognito.createUserPoolClient(
+      new CreateUserPoolClientCommand({
+        UserPoolId: userPoolId,
+        ClientName: "web",
+      }),
+    );
+
+    // When both are updated.
+    const updatedWithSecret = await cognito.updateUserPoolClient(
+      new UpdateUserPoolClientCommand({
+        UserPoolId: userPoolId,
+        ClientId: withSecret.UserPoolClient?.ClientId,
+        ClientName: "server",
+      }),
+    );
+    const updatedWithoutSecret = await cognito.updateUserPoolClient(
+      new UpdateUserPoolClientCommand({
+        UserPoolId: userPoolId,
+        ClientId: withoutSecret.UserPoolClient?.ClientId,
+        ClientName: "web",
+      }),
+    );
+
+    // Then the first keeps the same secret and the second still has none.
+    // UpdateUserPoolClient has no GenerateSecret input on real Cognito.
+    assertNonNullable(withSecret.UserPoolClient?.ClientSecret);
+    assertIdentical(
+      updatedWithSecret.UserPoolClient?.ClientSecret,
+      withSecret.UserPoolClient.ClientSecret,
+    );
+    assertUndefined(updatedWithoutSecret.UserPoolClient?.ClientSecret);
+  });
+
+  it("reports when the client was last updated", async () => {
+    // Given a simulation whose clock is stopped, and a client created on it.
+    const simAws = new SimAws();
+    const cognito = simAws.cognitoIdentityProvider();
+    const createdAt = new Date("2026-03-01T09:00:00.000Z");
+
+    await simAws.clock().setTo(createdAt);
+
+    const pool = await cognito.createUserPool(
+      new CreateUserPoolCommand({ PoolName: "myapp-users" }),
+    );
+    const userPoolId = pool.UserPool?.Id;
+    const created = await cognito.createUserPoolClient(
+      new CreateUserPoolClientCommand({
+        UserPoolId: userPoolId,
+        ClientName: "web",
+      }),
+    );
+
+    // Then a client nothing has changed reports its creation date.
+    assertIdentical(
+      created.UserPoolClient?.LastModifiedDate?.getTime(),
+      createdAt.getTime(),
+    );
+
+    // When an hour passes and the client is updated.
+    await simAws.clock().advanceBy({ hours: 1 });
+
+    const updated = await cognito.updateUserPoolClient(
+      new UpdateUserPoolClientCommand({
+        UserPoolId: userPoolId,
+        ClientId: created.UserPoolClient.ClientId,
+        ClientName: "web-app",
+      }),
+    );
+
+    // Then it reports when the update happened, and its creation date is
+    // where it was.
+    assertIdentical(
+      updated.UserPoolClient?.LastModifiedDate?.getTime(),
+      createdAt.getTime() + 60 * 60 * 1000,
+    );
+    assertIdentical(
+      updated.UserPoolClient.CreationDate?.getTime(),
+      createdAt.getTime(),
+    );
+  });
+
+  it("refuses an update naming a client the pool does not hold", async () => {
+    // Given a pool with no app clients.
+    const cognito = new SimAws().cognitoIdentityProvider();
+    const pool = await cognito.createUserPool(
+      new CreateUserPoolCommand({ PoolName: "myapp-users" }),
+    );
+
+    // When a client that was never created is updated.
+    const error = await assertThrowsErrorAsync(async () => {
+      await cognito.updateUserPoolClient(
+        new UpdateUserPoolClientCommand({
+          UserPoolId: pool.UserPool?.Id,
+          ClientId: "1example23456789abcdefghij",
+          ClientName: "web",
+        }),
+      );
+    });
+
+    // Then it is reported missing.
+    assertInstanceOf(error, SimCognitoResourceNotFoundException);
+  });
+});

--- a/src/service/cognito/command/client/sim-cognito-updated-client-sign-in.iso.test.ts
+++ b/src/service/cognito/command/client/sim-cognito-updated-client-sign-in.iso.test.ts
@@ -1,0 +1,97 @@
+import {
+  AdminInitiateAuthCommand,
+  GlobalSignOutCommand,
+  UpdateUserPoolClientCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimCognitoInvalidParameterException } from "../../error/sim-cognito.error.js";
+import { simCognitoSignedInFactory } from "../../user-pool/auth/sim-cognito-signed-in.factory.js";
+
+const password = "Correct-horse-1";
+
+describe("signing in against an updated app client", () => {
+  it("refuses an authentication flow the update took away", async () => {
+    // Given a pool whose app client allows ADMIN_USER_PASSWORD_AUTH, and a
+    // user who has signed in with it.
+    const simAws = new SimAws();
+    const cognito = simAws.cognitoIdentityProvider();
+    const signedIn = await simCognitoSignedInFactory.make({ password }, simAws);
+
+    // When an update leaves ALLOW_ADMIN_USER_PASSWORD_AUTH out, so the client
+    // goes back to the flows CreateUserPoolClient defaults to.
+    await cognito.updateUserPoolClient(
+      new UpdateUserPoolClientCommand({
+        UserPoolId: signedIn.userPoolId,
+        ClientId: signedIn.clientId,
+        ClientName: "web",
+      }),
+    );
+
+    const error = await assertThrowsErrorAsync(async () => {
+      await cognito.adminInitiateAuth(
+        new AdminInitiateAuthCommand({
+          UserPoolId: signedIn.userPoolId,
+          ClientId: signedIn.clientId,
+          AuthFlow: "ADMIN_USER_PASSWORD_AUTH",
+          AuthParameters: { USERNAME: signedIn.username, PASSWORD: password },
+        }),
+      );
+    });
+
+    // Then the next sign-in with that flow is refused.
+    assertInstanceOf(error, SimCognitoInvalidParameterException);
+    assertStringIncludes(error.message, "ADMIN_USER_PASSWORD_AUTH");
+  });
+
+  it("leaves a token already issued with the expiry it was issued with", async () => {
+    // Given a user signed in on a stopped clock, against a client whose
+    // access tokens last the default hour.
+    const simAws = new SimAws();
+    const cognito = simAws.cognitoIdentityProvider();
+
+    await simAws.clock().setTo(new Date("2026-03-01T09:00:00.000Z"));
+
+    const signedIn = await simCognitoSignedInFactory.make({ password }, simAws);
+
+    // When the client's access tokens are shortened to five minutes.
+    await cognito.updateUserPoolClient(
+      new UpdateUserPoolClientCommand({
+        UserPoolId: signedIn.userPoolId,
+        ClientId: signedIn.clientId,
+        ClientName: "web",
+        ExplicitAuthFlows: ["ALLOW_ADMIN_USER_PASSWORD_AUTH"],
+        AccessTokenValidity: 5,
+        TokenValidityUnits: { AccessToken: "minutes" },
+      }),
+    );
+
+    // And ten minutes pass, which is longer than the new lifetime.
+    await simAws.clock().advanceBy({ minutes: 10 });
+
+    // Then the token issued before the update is still honoured, because its
+    // expiry was stamped when it was handed out rather than read from the
+    // client later.
+    await cognito.globalSignOut(
+      new GlobalSignOutCommand({ AccessToken: signedIn.accessToken }),
+    );
+
+    // And the next sign-in gets the shorter lifetime.
+    const signedInAgain = await cognito.adminInitiateAuth(
+      new AdminInitiateAuthCommand({
+        UserPoolId: signedIn.userPoolId,
+        ClientId: signedIn.clientId,
+        AuthFlow: "ADMIN_USER_PASSWORD_AUTH",
+        AuthParameters: { USERNAME: signedIn.username, PASSWORD: password },
+      }),
+    );
+
+    assertIdentical(signedInAgain.AuthenticationResult?.ExpiresIn, 5 * 60);
+  });
+});

--- a/src/service/cognito/command/client/sim-cognito-user-pool-client-commands.ts
+++ b/src/service/cognito/command/client/sim-cognito-user-pool-client-commands.ts
@@ -1,6 +1,7 @@
 import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
 import type { SimCognitoUserPoolClientFactory } from "../../user-pool/client/sim-cognito-user-pool-client-factory.js";
 import { requireSimCognitoUserPoolClientId } from "../../user-pool/client/sim-cognito-user-pool-client-id.js";
+import { SimCognitoUserPoolClientSettings } from "../../user-pool/client/sim-cognito-user-pool-client-settings.js";
 import { requireSimCognitoUserPoolId } from "../../user-pool/sim-cognito-user-pool-id.js";
 import type { SimCognitoUserPool } from "../../user-pool/sim-cognito-user-pool.js";
 import type { SimCognitoUserPoolStore } from "../../user-pool/sim-cognito-user-pool-store.js";
@@ -14,6 +15,8 @@ import type {
   SimDeleteUserPoolClientCommandOutput,
   SimDescribeUserPoolClientCommand,
   SimDescribeUserPoolClientCommandOutput,
+  SimUpdateUserPoolClientCommand,
+  SimUpdateUserPoolClientCommandOutput,
 } from "./user-pool-client.command.js";
 
 interface SimCognitoUserPoolClientCommandsProperties {
@@ -27,7 +30,8 @@ interface SimCognitoCommandOptions {
 }
 
 /**
- * The commands that create, describe and delete a simulated app client.
+ * The commands that create, describe, change and delete a simulated app
+ * client.
  *
  * Each one authorizes against the pool's ARN, because an app client has no
  * ARN of its own.
@@ -37,8 +41,10 @@ export class SimCognitoUserPoolClientCommands {
   private readonly clientFactory: SimCognitoUserPoolClientFactory;
   private readonly authorizer: SimCognitoAuthorizer;
   private readonly view = new SimCognitoUserPoolClientView();
-  private readonly unsimulatedOptions =
-    new SimCognitoUnsimulatedUserPoolClientOptions();
+  private readonly unsimulatedCreateOptions =
+    new SimCognitoUnsimulatedUserPoolClientOptions("CreateUserPoolClient");
+  private readonly unsimulatedUpdateOptions =
+    new SimCognitoUnsimulatedUserPoolClientOptions("UpdateUserPoolClient");
 
   constructor(properties: SimCognitoUserPoolClientCommandsProperties) {
     this.pools = properties.pools;
@@ -60,19 +66,59 @@ export class SimCognitoUserPoolClientCommands {
       options,
     );
 
-    this.unsimulatedOptions.refuseIn(input);
+    this.unsimulatedCreateOptions.refuseIn(input);
 
     const client = this.clientFactory.make({
       pool,
-      name: input.ClientName,
       generateSecret: input.GenerateSecret,
-      explicitAuthFlows: input.ExplicitAuthFlows,
-      preventUserExistenceErrors: input.PreventUserExistenceErrors,
-      tokenValidity: input,
-      unsimulatedSettings: input,
+      settings: new SimCognitoUserPoolClientSettings(input),
     });
 
     pool.addClient(client);
+
+    return { $metadata: {}, UserPoolClient: this.view.describe(client) };
+  }
+
+  /**
+   * Change an app client's settings.
+   *
+   * The settings are replaced by what the request holds, as real Cognito
+   * replaces them, so one the request leaves out goes back to the default
+   * `CreateUserPoolClient` would have given it. A request naming only
+   * `ClientName` therefore sends the authentication flows and the token
+   * lifetimes back to their defaults.
+   *
+   * The client's secret is not a setting and survives untouched.
+   * `UpdateUserPoolClient` has no `GenerateSecret` input on real Cognito, so
+   * a client created without a secret never gains one.
+   *
+   * `ClientName` is the one setting an omitted request keeps rather than
+   * resets. A client has to have a name, and `CreateUserPoolClient` requires
+   * one, so there is no default for an update to go back to.
+   */
+  update(
+    command: SimUpdateUserPoolClientCommand,
+    options?: SimCognitoCommandOptions,
+  ): SimUpdateUserPoolClientCommandOutput {
+    const { input } = command;
+    const pool = this.authorizedPool(
+      "cognito-idp:UpdateUserPoolClient",
+      input.UserPoolId,
+      options,
+    );
+
+    this.unsimulatedUpdateOptions.refuseIn(input);
+
+    const client = pool.requireClient(
+      requireSimCognitoUserPoolClientId(input.ClientId),
+    );
+
+    client.update(
+      new SimCognitoUserPoolClientSettings({
+        ...input,
+        ClientName: input.ClientName ?? client.name,
+      }),
+    );
 
     return { $metadata: {}, UserPoolClient: this.view.describe(client) };
   }

--- a/src/service/cognito/command/client/sim-cognito-user-pool-client-view.ts
+++ b/src/service/cognito/command/client/sim-cognito-user-pool-client-view.ts
@@ -7,8 +7,8 @@ import type { SimCognitoUserPoolClientType } from "./user-pool-client.command.js
  */
 export class SimCognitoUserPoolClientView {
   /**
-   * A client as `CreateUserPoolClient` and `DescribeUserPoolClient` report
-   * it.
+   * A client as `CreateUserPoolClient`, `DescribeUserPoolClient` and
+   * `UpdateUserPoolClient` report it.
    *
    * The secret is included, as real Cognito includes it: `ClientSecret` on
    * `DescribeUserPoolClient` is how an application reads the secret it was

--- a/src/service/cognito/command/client/user-pool-client.command.ts
+++ b/src/service/cognito/command/client/user-pool-client.command.ts
@@ -28,19 +28,20 @@ export interface SimCognitoUserPoolClientType extends SimCognitoUnsimulatedClien
 }
 
 /**
- * The CreateUserPoolClient inputs this simulation reads, and the ones it
- * refuses.
+ * The app client settings `CreateUserPoolClient` and `UpdateUserPoolClient`
+ * both take, which is every one of them apart from the client's secret.
  *
  * Every input real Cognito accepts is named here, whether or not it is
  * simulated, so a request carrying one this simulation does not model can be
  * refused rather than silently ignored.
  *
- * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/cognito-identity-provider/command/CreateUserPoolClientCommand/
+ * `ClientSecret` is among them although only `CreateUserPoolClient` has it on
+ * real Cognito. It is refused either way, so a request that reached this
+ * simulation with one is told why rather than ignored.
  */
-export interface SimCreateUserPoolClientCommandInput {
+export interface SimCognitoUserPoolClientSettingsInput {
   readonly UserPoolId?: string | undefined;
   readonly ClientName?: string | undefined;
-  readonly GenerateSecret?: boolean | undefined;
   readonly ExplicitAuthFlows?: readonly string[] | undefined;
   readonly AccessTokenValidity?: number | undefined;
   readonly IdTokenValidity?: number | undefined;
@@ -65,6 +66,16 @@ export interface SimCreateUserPoolClientCommandInput {
 }
 
 /**
+ * The CreateUserPoolClient inputs this simulation reads, and the ones it
+ * refuses.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/cognito-identity-provider/command/CreateUserPoolClientCommand/
+ */
+export interface SimCreateUserPoolClientCommandInput extends SimCognitoUserPoolClientSettingsInput {
+  readonly GenerateSecret?: boolean | undefined;
+}
+
+/**
  * Minimal structural sim Cognito CreateUserPoolClient command.
  */
 export interface SimCreateUserPoolClientCommand {
@@ -72,6 +83,31 @@ export interface SimCreateUserPoolClientCommand {
 }
 
 export interface SimCreateUserPoolClientCommandOutput {
+  readonly UserPoolClient?: SimCognitoUserPoolClientType | undefined;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * The UpdateUserPoolClient inputs, which are the settings
+ * `CreateUserPoolClient` takes against a client that already exists.
+ *
+ * There is no `GenerateSecret` here, as there is none on real Cognito: an
+ * update cannot give a client a secret or take one away.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/cognito-identity-provider/command/UpdateUserPoolClientCommand/
+ */
+export interface SimUpdateUserPoolClientCommandInput extends SimCognitoUserPoolClientSettingsInput {
+  readonly ClientId?: string | undefined;
+}
+
+/**
+ * Minimal structural sim Cognito UpdateUserPoolClient command.
+ */
+export interface SimUpdateUserPoolClientCommand {
+  readonly input: SimUpdateUserPoolClientCommandInput;
+}
+
+export interface SimUpdateUserPoolClientCommandOutput {
   readonly UserPoolClient?: SimCognitoUserPoolClientType | undefined;
   readonly $metadata: SimResponseMetadata;
 }

--- a/src/service/cognito/command/sim-cognito-command.types.ts
+++ b/src/service/cognito/command/sim-cognito-command.types.ts
@@ -20,6 +20,7 @@ export type {
   SimListUserPoolsCommandOutput,
 } from "./user-pool/list-user-pools.command.js";
 export type {
+  SimCognitoUserPoolClientSettingsInput,
   SimCognitoUserPoolClientType,
   SimCreateUserPoolClientCommand,
   SimCreateUserPoolClientCommandInput,
@@ -30,6 +31,9 @@ export type {
   SimDescribeUserPoolClientCommand,
   SimDescribeUserPoolClientCommandInput,
   SimDescribeUserPoolClientCommandOutput,
+  SimUpdateUserPoolClientCommand,
+  SimUpdateUserPoolClientCommandInput,
+  SimUpdateUserPoolClientCommandOutput,
 } from "./client/user-pool-client.command.js";
 export type {
   SimCognitoUserPoolClientDescription,

--- a/src/service/cognito/command/sim-cognito-unsimulated-input.ts
+++ b/src/service/cognito/command/sim-cognito-unsimulated-input.ts
@@ -9,7 +9,11 @@ import { SimCognitoInvalidParameterException } from "../error/sim-cognito.error.
  * every refusal say why it happened rather than only that it did.
  */
 export class SimCognitoUnsimulatedInput {
-  private readonly operation: string;
+  /**
+   * The operation a refusal names, which is also what a caller building its
+   * own message about an input needs.
+   */
+  public readonly operation: string;
 
   constructor(operation: string) {
     this.operation = operation;

--- a/src/service/cognito/sdk/sim-cognito-sdk-command-router.iso.test.ts
+++ b/src/service/cognito/sdk/sim-cognito-sdk-command-router.iso.test.ts
@@ -21,6 +21,7 @@ describe("SimCognitoSdkCommandRouter", () => {
       "ListUserPoolsCommand",
       "CreateUserPoolClientCommand",
       "DescribeUserPoolClientCommand",
+      "UpdateUserPoolClientCommand",
       "DeleteUserPoolClientCommand",
       "ListUserPoolClientsCommand",
       "AdminCreateUserCommand",

--- a/src/service/cognito/sdk/sim-cognito-sdk-pool-routes.ts
+++ b/src/service/cognito/sdk/sim-cognito-sdk-pool-routes.ts
@@ -7,6 +7,7 @@ import type {
   SimCreateUserPoolClientCommand,
   SimDeleteUserPoolClientCommand,
   SimDescribeUserPoolClientCommand,
+  SimUpdateUserPoolClientCommand,
 } from "../command/client/user-pool-client.command.js";
 import type { SimListUserPoolsCommand } from "../command/user-pool/list-user-pools.command.js";
 import type {
@@ -68,6 +69,14 @@ export function simCognitoSdkPoolRoutes(
       async (command, context): Promise<unknown> =>
         await simCognito.describeUserPoolClient(
           command as SimDescribeUserPoolClientCommand,
+          simSdkCallerOptions(context),
+        ),
+    ],
+    [
+      "UpdateUserPoolClientCommand",
+      async (command, context): Promise<unknown> =>
+        await simCognito.updateUserPoolClient(
+          command as SimUpdateUserPoolClientCommand,
           simSdkCallerOptions(context),
         ),
     ],

--- a/src/service/cognito/sdk/sim-cognito-sdk-routing.iso.test.ts
+++ b/src/service/cognito/sdk/sim-cognito-sdk-routing.iso.test.ts
@@ -8,6 +8,7 @@ import {
   DescribeUserPoolCommand,
   ListUserPoolClientsCommand,
   ListUserPoolsCommand,
+  UpdateUserPoolClientCommand,
 } from "@aws-sdk/client-cognito-identity-provider";
 import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
 import { CreateFunctionCommand, InvokeCommand } from "@aws-sdk/client-lambda";
@@ -159,6 +160,15 @@ describe("Cognito SDK interception", () => {
     const clientId = appClient.UserPoolClient?.ClientId;
 
     // When each of the remaining operations is used.
+    const updatedClient = await client.send(
+      new UpdateUserPoolClientCommand({
+        UserPoolId: userPoolId,
+        ClientId: clientId,
+        ClientName: "web",
+        AccessTokenValidity: 30,
+        TokenValidityUnits: { AccessToken: "minutes" },
+      }),
+    );
     const describedClient = await client.send(
       new DescribeUserPoolClientCommand({
         UserPoolId: userPoolId,
@@ -185,7 +195,9 @@ describe("Cognito SDK interception", () => {
     );
 
     // Then each one reached simulated Cognito.
+    assertIdentical(updatedClient.UserPoolClient?.AccessTokenValidity, 30);
     assertIdentical(describedClient.UserPoolClient?.ClientName, "web");
+    assertIdentical(describedClient.UserPoolClient.AccessTokenValidity, 30);
     assertArrayEquals(
       listedPools.UserPools?.map((listed) => listed.Name),
       ["myapp-users"],

--- a/src/service/cognito/sim-cognito-identity-provider.ts
+++ b/src/service/cognito/sim-cognito-identity-provider.ts
@@ -199,6 +199,17 @@ export class SimCognitoIdentityProvider extends SimCognitoUserDirectory {
   }
 
   /**
+   * Handle an UpdateUserPoolClient Command from the SDK.
+   */
+  async updateUserPoolClient(
+    command: simCognitoCommands.SimUpdateUserPoolClientCommand,
+    options?: SimCognitoIdentityProviderRequestOptions,
+  ): Promise<simCognitoCommands.SimUpdateUserPoolClientCommandOutput> {
+    await this.background.sequence();
+    return this.commands.clients.update(command, options);
+  }
+
+  /**
    * Handle a DeleteUserPoolClient Command from the SDK.
    */
   async deleteUserPoolClient(

--- a/src/service/cognito/user-pool/client/sim-cognito-user-pool-client-factory.ts
+++ b/src/service/cognito/user-pool/client/sim-cognito-user-pool-client-factory.ts
@@ -1,19 +1,9 @@
 import type { SimClock } from "../../../../util/clock/sim-clock.js";
-import { SimCognitoName } from "../sim-cognito-name.js";
 import type { SimCognitoUserPool } from "../sim-cognito-user-pool.js";
 import { makeSimCognitoClientSecret } from "./sim-cognito-client-secret.js";
-import { SimCognitoExplicitAuthFlows } from "./sim-cognito-explicit-auth-flows.js";
-import { SimCognitoPreventUserExistenceErrors } from "./sim-cognito-prevent-user-existence-errors.js";
-import {
-  SimCognitoTokenValidity,
-  type SimCognitoTokenValidityInput,
-} from "./sim-cognito-token-validity.js";
-import {
-  SimCognitoUnsimulatedClientSettings,
-  type SimCognitoUnsimulatedClientSettingsType,
-} from "./sim-cognito-unsimulated-client-settings.js";
 import { SimCognitoUserPoolClient } from "./sim-cognito-user-pool-client.js";
 import { makeSimCognitoUserPoolClientId } from "./sim-cognito-user-pool-client-id.js";
+import type { SimCognitoUserPoolClientSettings } from "./sim-cognito-user-pool-client-settings.js";
 
 interface SimCognitoUserPoolClientFactoryProperties {
   readonly clock: SimClock;
@@ -21,18 +11,8 @@ interface SimCognitoUserPoolClientFactoryProperties {
 
 interface SimCognitoMakeUserPoolClientProperties {
   readonly pool: SimCognitoUserPool;
-  readonly name: string | undefined;
   readonly generateSecret?: boolean | undefined;
-  readonly explicitAuthFlows?: readonly string[] | undefined;
-  readonly preventUserExistenceErrors?: string | undefined;
-  readonly tokenValidity: SimCognitoTokenValidityInput;
-
-  /**
-   * The settings the request set that this simulation accepts without acting
-   * on, which a described client reports back.
-   */
-  readonly unsimulatedSettings?:
-    SimCognitoUnsimulatedClientSettingsType | undefined;
+  readonly settings: SimCognitoUserPoolClientSettings;
 }
 
 /**
@@ -60,22 +40,9 @@ export class SimCognitoUserPoolClientFactory {
     return new SimCognitoUserPoolClient({
       id: makeSimCognitoUserPoolClientId(pool.clientIds),
       userPoolId: pool.id,
-      name: new SimCognitoName({
-        field: "ClientName",
-        value: properties.name,
-      }),
       secret: this.secretFor(properties.generateSecret),
-      explicitAuthFlows: new SimCognitoExplicitAuthFlows(
-        properties.explicitAuthFlows,
-      ),
-      preventUserExistenceErrors: new SimCognitoPreventUserExistenceErrors(
-        properties.preventUserExistenceErrors,
-      ),
-      tokenValidity: new SimCognitoTokenValidity(properties.tokenValidity),
-      unsimulatedSettings: new SimCognitoUnsimulatedClientSettings(
-        properties.unsimulatedSettings ?? {},
-      ),
-      createdDate: this.clock.now(),
+      settings: properties.settings,
+      clock: this.clock,
     });
   }
 

--- a/src/service/cognito/user-pool/client/sim-cognito-user-pool-client-settings.ts
+++ b/src/service/cognito/user-pool/client/sim-cognito-user-pool-client-settings.ts
@@ -1,0 +1,64 @@
+import { SimCognitoName } from "../sim-cognito-name.js";
+import { SimCognitoExplicitAuthFlows } from "./sim-cognito-explicit-auth-flows.js";
+import { SimCognitoPreventUserExistenceErrors } from "./sim-cognito-prevent-user-existence-errors.js";
+import {
+  SimCognitoTokenValidity,
+  type SimCognitoTokenValidityInput,
+} from "./sim-cognito-token-validity.js";
+import {
+  SimCognitoUnsimulatedClientSettings,
+  type SimCognitoUnsimulatedClientSettingsType,
+} from "./sim-cognito-unsimulated-client-settings.js";
+
+/**
+ * The app client properties a request can set.
+ *
+ * `ClientId` is not among them: it identifies the client, and
+ * `UpdateUserPoolClient` cannot change it. Nor is the secret, which an update
+ * cannot touch either.
+ */
+export interface SimCognitoUserPoolClientSettingsProperties
+  extends
+    SimCognitoTokenValidityInput,
+    SimCognitoUnsimulatedClientSettingsType {
+  readonly ClientName?: string | undefined;
+  readonly ExplicitAuthFlows?: readonly string[] | undefined;
+  readonly PreventUserExistenceErrors?: string | undefined;
+}
+
+/**
+ * The settable properties of one simulated app client.
+ *
+ * `CreateUserPoolClient` builds one of these from its request, and
+ * `UpdateUserPoolClient` builds a fresh one and replaces what the client had.
+ * That is why the defaults live here rather than in the create command: a
+ * property an update leaves out goes back to the value a create would have
+ * given it, which is what real Cognito does.
+ */
+export class SimCognitoUserPoolClientSettings {
+  public readonly name: string;
+  public readonly explicitAuthFlows: SimCognitoExplicitAuthFlows;
+  public readonly preventUserExistenceErrors: SimCognitoPreventUserExistenceErrors;
+  public readonly tokenValidity: SimCognitoTokenValidity;
+
+  /**
+   * What the request set and nothing here acts on, kept so a described client
+   * reports it.
+   */
+  public readonly unsimulated: SimCognitoUnsimulatedClientSettings;
+
+  constructor(properties: SimCognitoUserPoolClientSettingsProperties) {
+    this.name = new SimCognitoName({
+      field: "ClientName",
+      value: properties.ClientName,
+    }).value;
+    this.explicitAuthFlows = new SimCognitoExplicitAuthFlows(
+      properties.ExplicitAuthFlows,
+    );
+    this.preventUserExistenceErrors = new SimCognitoPreventUserExistenceErrors(
+      properties.PreventUserExistenceErrors,
+    );
+    this.tokenValidity = new SimCognitoTokenValidity(properties);
+    this.unsimulated = new SimCognitoUnsimulatedClientSettings(properties);
+  }
+}

--- a/src/service/cognito/user-pool/client/sim-cognito-user-pool-client.ts
+++ b/src/service/cognito/user-pool/client/sim-cognito-user-pool-client.ts
@@ -1,21 +1,18 @@
-import type { SimCognitoName } from "../sim-cognito-name.js";
+import type { SimClock } from "../../../../util/clock/sim-clock.js";
 import type { SimCognitoUserPoolId } from "../sim-cognito-user-pool-id.js";
 import type { SimCognitoExplicitAuthFlows } from "./sim-cognito-explicit-auth-flows.js";
 import type { SimCognitoPreventUserExistenceErrors } from "./sim-cognito-prevent-user-existence-errors.js";
 import type { SimCognitoTokenValidity } from "./sim-cognito-token-validity.js";
 import type { SimCognitoUnsimulatedClientSettings } from "./sim-cognito-unsimulated-client-settings.js";
+import type { SimCognitoUserPoolClientSettings } from "./sim-cognito-user-pool-client-settings.js";
 import type { SimCognitoUserPoolClientId } from "./sim-cognito-user-pool-client-id.js";
 
 interface SimCognitoUserPoolClientProperties {
   readonly id: SimCognitoUserPoolClientId;
   readonly userPoolId: SimCognitoUserPoolId;
-  readonly name: SimCognitoName;
   readonly secret: string | undefined;
-  readonly explicitAuthFlows: SimCognitoExplicitAuthFlows;
-  readonly preventUserExistenceErrors: SimCognitoPreventUserExistenceErrors;
-  readonly tokenValidity: SimCognitoTokenValidity;
-  readonly unsimulatedSettings: SimCognitoUnsimulatedClientSettings;
-  readonly createdDate: Date;
+  readonly settings: SimCognitoUserPoolClientSettings;
+  readonly clock: SimClock;
 }
 
 /**
@@ -29,17 +26,6 @@ interface SimCognitoUserPoolClientProperties {
 export class SimCognitoUserPoolClient {
   public readonly id: SimCognitoUserPoolClientId;
   public readonly userPoolId: SimCognitoUserPoolId;
-  public readonly name: string;
-  public readonly explicitAuthFlows: SimCognitoExplicitAuthFlows;
-  public readonly preventUserExistenceErrors: SimCognitoPreventUserExistenceErrors;
-  public readonly tokenValidity: SimCognitoTokenValidity;
-
-  /**
-   * What the client was created with and nothing here acts on, kept so a
-   * described client reports it.
-   */
-  public readonly unsimulatedSettings: SimCognitoUnsimulatedClientSettings;
-
   public readonly creationDate: Date;
 
   /**
@@ -48,26 +34,62 @@ export class SimCognitoUserPoolClient {
    */
   public readonly secret: string | undefined;
 
+  private readonly clock: SimClock;
+  private clientSettings: SimCognitoUserPoolClientSettings;
+  private modifiedDate: Date;
+
   constructor(properties: SimCognitoUserPoolClientProperties) {
     this.id = properties.id;
     this.userPoolId = properties.userPoolId;
-    this.name = properties.name.value;
     this.secret = properties.secret;
-    this.explicitAuthFlows = properties.explicitAuthFlows;
-    this.preventUserExistenceErrors = properties.preventUserExistenceErrors;
-    this.tokenValidity = properties.tokenValidity;
-    this.unsimulatedSettings = properties.unsimulatedSettings;
-    this.creationDate = properties.createdDate;
+    this.clientSettings = properties.settings;
+    this.clock = properties.clock;
+    this.creationDate = this.clock.now();
+    this.modifiedDate = this.creationDate;
   }
 
   /**
-   * When the client last changed.
-   *
-   * Nothing can change an app client here, as `UpdateUserPoolClient` is not
-   * simulated, so this is its creation date.
+   * The client's friendly name.
+   */
+  get name(): string {
+    return this.clientSettings.name;
+  }
+
+  /**
+   * The authentication flows this client allows.
+   */
+  get explicitAuthFlows(): SimCognitoExplicitAuthFlows {
+    return this.clientSettings.explicitAuthFlows;
+  }
+
+  /**
+   * Whether a sign-in naming an unknown user says so.
+   */
+  get preventUserExistenceErrors(): SimCognitoPreventUserExistenceErrors {
+    return this.clientSettings.preventUserExistenceErrors;
+  }
+
+  /**
+   * How long each kind of token this client is given lasts.
+   */
+  get tokenValidity(): SimCognitoTokenValidity {
+    return this.clientSettings.tokenValidity;
+  }
+
+  /**
+   * What the client was given and nothing here acts on, kept so a described
+   * client reports it.
+   */
+  get unsimulatedSettings(): SimCognitoUnsimulatedClientSettings {
+    return this.clientSettings.unsimulated;
+  }
+
+  /**
+   * When the client's settings last changed, which is its creation date until
+   * something updates it.
    */
   get lastModifiedDate(): Date {
-    return this.creationDate;
+    return this.modifiedDate;
   }
 
   /**
@@ -76,5 +98,19 @@ export class SimCognitoUserPoolClient {
    */
   get hasSecret(): boolean {
     return this.secret !== undefined;
+  }
+
+  /**
+   * Replace the client's settings.
+   *
+   * `UpdateUserPoolClient` replaces rather than merges, as real Cognito does,
+   * so a setting the request left out goes back to the default a
+   * `CreateUserPoolClient` request leaving it out would have got. The secret
+   * is not among the settings and survives an update untouched, because real
+   * Cognito has no way to change it either.
+   */
+  update(settings: SimCognitoUserPoolClientSettings): void {
+    this.clientSettings = settings;
+    this.modifiedDate = this.clock.now();
   }
 }


### PR DESCRIPTION
Resolves #452.

An update replaces the client's settings rather than merging into them, as real Cognito does. `ClientName` is the one exception: a client has to have a name and `CreateUserPoolClient` requires one, so an update naming none keeps the name the client has rather than resetting to a default that does not exist.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for updating Cognito user pool app clients.
  - App-client settings can be replaced, with omitted settings reset to defaults.
  - Client names and secrets remain unchanged during updates.
  - Modification timestamps update while creation timestamps remain unchanged.
  - Updated settings affect newly issued tokens and subsequent sign-in behavior.

- **Documentation**
  - Documented supported update behavior, limitations, token validity, and CloudFormation considerations.
  - Added a usage example for updating app-client settings.

- **Bug Fixes**
  - Added authorization and validation for unsupported options, invalid clients, names, and authentication flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->