### PR TITLE
feat: skip an unmodelled Route53 record type

### DIFF
--- a/docs/services/cloudformation/README.md
+++ b/docs/services/cloudformation/README.md
@@ -1736,6 +1736,16 @@ console.log(stack.getResource("AlarmTopic")?.skippedReason);
 A skipped Resource is still in `stack.resources`, and still answers `Ref` and `Fn::GetAtt` with
 [stand-in values](#values-from-a-skipped-resource).
 
+A skip is not always a whole Resource type nothing simulates. A service can decline one Resource of a
+type it does create, when that Resource asks for something the service cannot model, and the
+`skippedReason` says which part it was. An `AWS::Route53::RecordSet` declaring a record type sim
+Route53 does not store is skipped with the record type named, so a DNS stack carrying a record the
+test is not about still deploys. See [record types](../route53/README.md#record-types).
+
+A Resource that was skipped on create is stepped over by a teardown rather than deleted, because
+nothing reached simulated AWS to delete. It reaches `DELETE_COMPLETE` and stays out of
+`stack.skippedResourceDeletions`, which is for Resources that were created and could not be removed.
+
 ## Properties a Resource was created without
 
 Deployment is best effort. A Resource type that is not simulated is skipped and the rest of the

--- a/docs/services/route53/README.md
+++ b/docs/services/route53/README.md
@@ -316,8 +316,12 @@ The stored alias value is normalized without the trailing dot.
 Sim Route53 stores ten record types: `A`, `AAAA`, `CAA`, `CNAME`, `MX`, `NS`, `PTR`, `SOA`, `SRV` and
 `TXT`. All ten can be created through `ChangeResourceRecordSetsCommand`, read back through
 `ListResourceRecordSetsCommand`, and declared as an `AWS::Route53::RecordSet`, so a zone that models
-a real one — mail records, certificate pinning, a service record — deploys as it stands. A type
-outside that list is rejected rather than stored.
+a real one — mail records, certificate pinning, a service record — deploys as it stands.
+
+A type outside that list is not stored. `ChangeResourceRecordSetsCommand` rejects it, because the
+call asked for a record the simulator cannot keep. A template declaring one is treated more gently:
+the `AWS::Route53::RecordSet` is skipped and the rest of the stack deploys. See
+[unsupported record types in a template](#unsupported-record-types-in-a-template).
 
 Simulated DNS answers queries for six of them: `A`, `AAAA`, `CNAME`, `TXT`, `NS` and `SOA`. `MX`,
 `SRV`, `CAA` and `PTR` are stored for a test to assert the presence and value of, not for a resolver
@@ -982,6 +986,80 @@ await simAws.backgroundTasksComplete();
 Record sets can use either `HostedZoneId` or `HostedZoneName`. `HostedZoneId` is usually the
 clearest option in templates because it can reference the zone resource directly.
 
+### Unsupported record types in a template
+
+A real DNS stack usually holds a few records that have nothing to do with what is being tested. When
+one of them declares a [record type](#record-types) sim Route53 does not store, the RecordSet is
+skipped and the rest of the stack deploys, the same way an unsupported resource type is. The skipped
+RecordSet is in `stack.skippedResources` with a `skippedReason` naming the record type.
+
+```typescript sim-route53-skipped-record-type
+/**
+ * Deploying a template that carries a record type sim Route53 does not store.
+ */
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "signed-dns-stack",
+  template: {
+    Resources: {
+      SiteZone: {
+        Type: "AWS::Route53::HostedZone",
+        Properties: {
+          Name: "example.test",
+        },
+      },
+      SiteRecord: {
+        Type: "AWS::Route53::RecordSet",
+        Properties: {
+          HostedZoneId: { Ref: "SiteZone" },
+          Name: "www.example.test",
+          Type: "A",
+          TTL: "300",
+          ResourceRecords: ["192.0.2.1"],
+        },
+      },
+      DelegationSigner: {
+        Type: "AWS::Route53::RecordSet",
+        Properties: {
+          HostedZoneId: { Ref: "SiteZone" },
+          Name: "example.test",
+          Type: "DS",
+          TTL: "3600",
+          ResourceRecords: ["12345 13 2 49FD46E6C4B45C55D4AC"],
+        },
+      },
+    },
+  },
+});
+
+await stack.waitForDeployComplete();
+await simAws.backgroundTasksComplete();
+
+// The A record the test is about was created.
+console.log(stack.getResource("SiteRecord")?.status);
+// "CREATE_COMPLETE"
+
+console.log(stack.skippedResources.map((resource) => resource.logicalId));
+// ["DelegationSigner"]
+
+console.log(stack.getResource("DelegationSigner")?.skippedReason);
+// "Unsupported sim Route53 CloudFormation Resource DelegationSigner: sim Route53
+//  does not model the DS record type, and stores A, AAAA, CAA, CNAME, MX, NS,
+//  PTR, SOA, SRV, TXT."
+```
+
+Only the record type is treated this way. A RecordSet that makes no sense as a RecordSet still fails
+the stack, so a `Name` that is not a string, a `Type` that is not a string, or a negative `TTL` is
+refused. An unmodelled record type is a gap in the simulation; a malformed RecordSet is a broken
+template.
+
+Tearing the stack down works with the skipped RecordSet in it. Nothing was created for it, so the
+teardown steps over it rather than asking Route53 to remove a record it never stored.
+
 ## CDK integration
 
 You can synthesize a CDK app and deploy the generated template with sim CloudFormation. CDK Route53
@@ -1138,7 +1216,8 @@ Sim Route53 currently supports:
 - A browser-viewable hosted zone and record summary at `dns.sim-aws.localhost`
 - DNS answers over UDP for `A`, `AAAA`, `CNAME`, `TXT`, `NS` and `SOA`, so those records can be
   queried with `dig` or any DNS client
-- The `AWS::Route53::HostedZone` and `AWS::Route53::RecordSet` CloudFormation resources
+- The `AWS::Route53::HostedZone` and `AWS::Route53::RecordSet` CloudFormation resources, with a
+  RecordSet declaring an unstored record type skipped rather than failing the stack
 - CDK-created Route53 Hosted Zones and records in synthesized templates
 
 The simulator focuses on useful behaviour for tests and local development rather than full Route53

--- a/docs/services/route53/sim-route53-skipped-record-type.example.ts
+++ b/docs/services/route53/sim-route53-skipped-record-type.example.ts
@@ -1,0 +1,56 @@
+/**
+ * Deploying a template that carries a record type sim Route53 does not store.
+ */
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "signed-dns-stack",
+  template: {
+    Resources: {
+      SiteZone: {
+        Type: "AWS::Route53::HostedZone",
+        Properties: {
+          Name: "example.test",
+        },
+      },
+      SiteRecord: {
+        Type: "AWS::Route53::RecordSet",
+        Properties: {
+          HostedZoneId: { Ref: "SiteZone" },
+          Name: "www.example.test",
+          Type: "A",
+          TTL: "300",
+          ResourceRecords: ["192.0.2.1"],
+        },
+      },
+      DelegationSigner: {
+        Type: "AWS::Route53::RecordSet",
+        Properties: {
+          HostedZoneId: { Ref: "SiteZone" },
+          Name: "example.test",
+          Type: "DS",
+          TTL: "3600",
+          ResourceRecords: ["12345 13 2 49FD46E6C4B45C55D4AC"],
+        },
+      },
+    },
+  },
+});
+
+await stack.waitForDeployComplete();
+await simAws.backgroundTasksComplete();
+
+// The A record the test is about was created.
+console.log(stack.getResource("SiteRecord")?.status);
+// "CREATE_COMPLETE"
+
+console.log(stack.skippedResources.map((resource) => resource.logicalId));
+// ["DelegationSigner"]
+
+console.log(stack.getResource("DelegationSigner")?.skippedReason);
+// "Unsupported sim Route53 CloudFormation Resource DelegationSigner: sim Route53
+//  does not model the DS record type, and stores A, AAAA, CAA, CNAME, MX, NS,
+//  PTR, SOA, SRV, TXT."

--- a/src/service/route53/cfn/record-set/build/sim-cfn-r53-record-set-builder.iso.test.ts
+++ b/src/service/route53/cfn/record-set/build/sim-cfn-r53-record-set-builder.iso.test.ts
@@ -1,14 +1,17 @@
 import {
+  assertFalse,
   assertIdentical,
   assertInstanceOf,
   assertObjectMatches,
   assertStringIncludes,
   assertThrowsError,
+  assertTrue,
   assertUndefined,
 } from "@kensio/smartass";
 import { describe, it } from "vitest";
 import { SimCfnResource } from "../../../../cloudformation/resource/sim-cfn-resource.js";
 import type { SimCfnTemplateValueRecord } from "../../../../cloudformation/template/value/sim-cfn-template-value.js";
+import { isSimCfnUnsupportedResourceError } from "../../../../cloudformation/resource/unsupported/sim-cfn-unsupported-resource.js";
 import { simRoute53RecordTypes } from "../../../record/sim-route53-record.js";
 import { SimCfnRoute53RecordSetBuilder } from "./sim-cfn-r53-record-set-builder.js";
 
@@ -114,10 +117,9 @@ describe("SimCfnRoute53RecordSetBuilder", () => {
     );
   });
 
-  it("throws when Type is not a supported Route53 record type", () => {
-    // Given RecordSets with invalid Type values, including a real Route53 type
-    // the simulator does not model.
-    const invalidTypes = [undefined, "DS", "a", 123, null];
+  it("throws when Type is not a declared record type", () => {
+    // Given RecordSets whose Type says nothing about which record was wanted.
+    const invalidTypes = [undefined, "", "  ", 123, null];
 
     for (const type of invalidTypes) {
       // When the RecordSet is built.
@@ -129,11 +131,37 @@ describe("SimCfnRoute53RecordSetBuilder", () => {
         }),
       );
 
-      // Then a clear validation error is thrown.
+      // Then a clear validation error is thrown, rather than the skip a
+      // declared but unmodelled type gets.
       assertInstanceOf(error, TypeError);
       assertStringIncludes(
         error.message,
-        "Invalid AWS::Route53::RecordSet TestRecordSet: Type must be a supported Route53 record type",
+        "Invalid AWS::Route53::RecordSet TestRecordSet: Type must be a non-empty string",
+      );
+      assertFalse(isSimCfnUnsupportedResourceError(error));
+    }
+  });
+
+  it("raises the unsupported-resource diagnostic for a record type the simulator does not store", () => {
+    // Given RecordSets declaring record types sim Route53 does not store: real
+    // Route53 types, and a string that is no record type at all.
+    const unmodelledTypes = ["DS", "NAPTR", "HTTPS", "a"];
+
+    for (const type of unmodelledTypes) {
+      // When the RecordSet is built.
+      const error = assertThrowsError(() =>
+        buildRecordSet({
+          Name: "www.example.com",
+          Type: type,
+        }),
+      );
+
+      // Then the error is the one the Stack lifecycle skips over rather than
+      // fails on, and it names the record type that was left out.
+      assertTrue(isSimCfnUnsupportedResourceError(error));
+      assertStringIncludes(
+        error.message,
+        `Unsupported sim Route53 CloudFormation Resource TestRecordSet: sim Route53 does not model the ${type} record type`,
       );
     }
   });

--- a/src/service/route53/cfn/record-set/build/sim-cfn-r53-record-set-builder.ts
+++ b/src/service/route53/cfn/record-set/build/sim-cfn-r53-record-set-builder.ts
@@ -6,11 +6,17 @@ import type {
 } from "../../../command/change-resource-record-sets/change-resource-record-sets.command.js";
 import type { SimRoute53RecordType } from "../../../record/sim-route53-record.js";
 import { SimCfnRoute53AliasTargetParser } from "../parse/sim-cfn-r53-alias-target-parser.js";
+import { SimCfnRoute53RecordTypeSkip } from "./sim-cfn-r53-record-type-skip.js";
 import { isSimRoute53RecordType } from "../../../record/sim-route53-record-type.js";
 
 /**
  * Builds Route53 ResourceRecordSet command input from CloudFormation
  * AWS::Route53::RecordSet properties.
+ *
+ * A property that makes no sense as a RecordSet is refused, which fails the
+ * Resource. A record type sim Route53 does not store is a different thing: that
+ * raises the unsupported-resource diagnostic the Stack lifecycle skips over,
+ * through {@link SimCfnRoute53RecordTypeSkip}.
  */
 export class SimCfnRoute53RecordSetBuilder {
   constructor(
@@ -50,13 +56,22 @@ export class SimCfnRoute53RecordSetBuilder {
   private type(): SimRoute53RecordType {
     const type = this.properties["Type"];
 
-    if (!isSimRoute53RecordType(type)) {
-      throw new TypeError(
-        `Invalid AWS::Route53::RecordSet ${this.resource.logicalId}: Type must be a supported Route53 record type`,
-      );
+    if (isSimRoute53RecordType(type)) {
+      return type;
     }
 
-    return type;
+    const skipError = new SimCfnRoute53RecordTypeSkip().findSkipError(
+      this.resource,
+      type,
+    );
+
+    if (skipError !== undefined) {
+      throw skipError;
+    }
+
+    throw new TypeError(
+      `Invalid AWS::Route53::RecordSet ${this.resource.logicalId}: Type must be a non-empty string`,
+    );
   }
 
   private ttl(): number | undefined {

--- a/src/service/route53/cfn/record-set/build/sim-cfn-r53-record-type-skip.ts
+++ b/src/service/route53/cfn/record-set/build/sim-cfn-r53-record-type-skip.ts
@@ -1,0 +1,41 @@
+import type { SimCfnResource } from "../../../../cloudformation/resource/sim-cfn-resource.js";
+import { isSimRoute53RecordType } from "../../../record/sim-route53-record-type.js";
+import { simRoute53RecordTypes } from "../../../record/sim-route53-record.js";
+
+/**
+ * Skips template RecordSets declaring a record type sim Route53 does not store.
+ *
+ * Route53 has more record types than a simulator is going to model, and a zone
+ * modelling a real one carries records that have nothing to do with what is
+ * being tested. Failing the whole Stack over one of them leaves an otherwise
+ * supported DNS stack undeployable until the record is edited out.
+ *
+ * The "Unsupported sim ... CloudFormation" wording marks the Resource as
+ * skipped rather than failing the Stack, so the rest of the Stack deploys and
+ * `stack.skippedResources` says which record type was left out.
+ *
+ * Only a declared type is skipped. A `Type` that is not a string at all says
+ * nothing about which record was wanted, so that stays a refusal: an unmodelled
+ * type is a gap in the simulation, a malformed one is a broken template.
+ */
+export class SimCfnRoute53RecordTypeSkip {
+  /**
+   * A skip error when this RecordSet declares a record type sim Route53 does
+   * not store, otherwise undefined.
+   */
+  findSkipError(resource: SimCfnResource, type: unknown): Error | undefined {
+    if (isSimRoute53RecordType(type) || !this.isDeclaredType(type)) {
+      return undefined;
+    }
+
+    return new Error(
+      `Unsupported sim Route53 CloudFormation Resource ${resource.logicalId}: ` +
+        `sim Route53 does not model the ${type} record type, and stores ` +
+        `${simRoute53RecordTypes.join(", ")}.`,
+    );
+  }
+
+  private isDeclaredType(type: unknown): type is string {
+    return typeof type === "string" && type.trim().length > 0;
+  }
+}

--- a/src/service/route53/cfn/record-set/sim-cfn-r53-skipped-record-type.iso.test.ts
+++ b/src/service/route53/cfn/record-set/sim-cfn-r53-skipped-record-type.iso.test.ts
@@ -1,0 +1,190 @@
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertMapSize,
+  assertNonNullable,
+  assertObjectMatches,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimRoute53HostedZone } from "../../hosted-zone/sim-route53-hosted-zone.js";
+
+describe("Route53 CloudFormation RecordSets with an unmodelled record type", () => {
+  it("skips the RecordSet and deploys the rest of the Stack", async () => {
+    // Given a zone carrying a DS record, which is a real Route53 record type
+    // sim Route53 does not store, alongside the records a test is about.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "dns-stack",
+      template: {
+        Resources: {
+          SiteZone: {
+            Type: "AWS::Route53::HostedZone",
+            Properties: { Name: "example.test" },
+          },
+          SiteRecord: {
+            Type: "AWS::Route53::RecordSet",
+            Properties: {
+              HostedZoneId: { Ref: "SiteZone" },
+              Name: "www.example.test",
+              Type: "A",
+              TTL: "300",
+              ResourceRecords: ["192.0.2.1"],
+            },
+          },
+          MailRecord: {
+            Type: "AWS::Route53::RecordSet",
+            Properties: {
+              HostedZoneId: { Ref: "SiteZone" },
+              Name: "example.test",
+              Type: "MX",
+              TTL: "3600",
+              ResourceRecords: ["10 in1-smtp.example.net."],
+            },
+          },
+          DelegationSigner: {
+            Type: "AWS::Route53::RecordSet",
+            Properties: {
+              HostedZoneId: { Ref: "SiteZone" },
+              Name: "example.test",
+              Type: "DS",
+              TTL: "3600",
+              ResourceRecords: ["12345 13 2 49FD46E6C4B45C55D4AC"],
+            },
+          },
+        },
+      },
+    });
+
+    // When the Stack finishes deploying.
+    await stack.waitForDeployComplete();
+    await simAws.backgroundTasksComplete();
+
+    // Then the unmodelled record is recorded as skipped, with a reason naming
+    // the record type that was left out.
+    assertArrayLength(stack.skippedResources, 1);
+    const skipped = stack.skippedResources[0];
+    assertNonNullable(skipped);
+    assertIdentical(skipped.logicalId, "DelegationSigner");
+    assertStringIncludes(
+      skipped.skippedReason ?? "",
+      "sim Route53 does not model the DS record type",
+    );
+
+    // And the records the test is about were created.
+    assertIdentical(
+      stack.resources.get("SiteRecord")?.status,
+      "CREATE_COMPLETE",
+    );
+    const hostedZone = stack.getResource("SiteZone")?.simResource;
+    assertInstanceOf(hostedZone, SimRoute53HostedZone);
+    assertObjectMatches(hostedZone.records.get("www.example.test", "A"), {
+      type: "A",
+      values: ["192.0.2.1"],
+    });
+    assertObjectMatches(hostedZone.records.get("example.test", "MX"), {
+      type: "MX",
+      values: ["10 in1-smtp.example.net."],
+    });
+  });
+
+  it("tears down a Stack holding a skipped RecordSet", async () => {
+    // Given a deployed Stack whose DS record was skipped rather than created.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "signed-dns-stack",
+      template: {
+        Resources: {
+          SiteZone: {
+            Type: "AWS::Route53::HostedZone",
+            Properties: { Name: "example.test" },
+          },
+          SiteRecord: {
+            Type: "AWS::Route53::RecordSet",
+            Properties: {
+              HostedZoneId: { Ref: "SiteZone" },
+              Name: "www.example.test",
+              Type: "A",
+              TTL: "300",
+              ResourceRecords: ["192.0.2.1"],
+            },
+          },
+          DelegationSigner: {
+            Type: "AWS::Route53::RecordSet",
+            Properties: {
+              HostedZoneId: { Ref: "SiteZone" },
+              Name: "example.test",
+              Type: "DS",
+              TTL: "3600",
+              ResourceRecords: ["12345 13 2 49FD46E6C4B45C55D4AC"],
+            },
+          },
+        },
+      },
+    });
+    await stack.waitForDeployComplete();
+    await simAws.backgroundTasksComplete();
+
+    // When the Stack is torn down.
+    await stack.teardown();
+    await simAws.backgroundTasksComplete();
+
+    // Then the teardown ran to the end, taking the created record and its zone
+    // with it. The zone only goes if its records went first, because
+    // DeleteHostedZone refuses a zone that still holds records.
+    assertIdentical(
+      stack.resources.get("SiteRecord")?.status,
+      "DELETE_COMPLETE",
+    );
+    assertIdentical(stack.resources.get("SiteZone")?.status, "DELETE_COMPLETE");
+    assertMapSize(simAws.route53().hostedZones, 0);
+
+    // And the skipped record is delete-complete without a service being asked
+    // to remove a record it never stored, so nothing was left behind. The skip
+    // is still on the Stack to be read after the teardown.
+    assertIdentical(
+      stack.resources.get("DelegationSigner")?.status,
+      "DELETE_COMPLETE",
+    );
+    assertArrayLength(stack.skippedResourceDeletions, 0);
+    assertArrayLength(stack.skippedResources, 1);
+  });
+
+  it("still fails a Stack whose RecordSet is malformed", async () => {
+    // Given a RecordSet whose Type says nothing about which record was wanted,
+    // which is a broken template rather than a gap in the simulation.
+    const simAws = new SimAws();
+
+    // When the Stack is deployed.
+    const error = await assertThrowsErrorAsync(async () => {
+      const stack = await simAws.cloudFormation().deployTemplate({
+        stackName: "broken-dns-stack",
+        template: {
+          Resources: {
+            SiteZone: {
+              Type: "AWS::Route53::HostedZone",
+              Properties: { Name: "example.test" },
+            },
+            SiteRecord: {
+              Type: "AWS::Route53::RecordSet",
+              Properties: {
+                HostedZoneId: { Ref: "SiteZone" },
+                Name: "www.example.test",
+                TTL: "300",
+                ResourceRecords: ["192.0.2.1"],
+              },
+            },
+          },
+        },
+      });
+      await stack.waitForDeployComplete();
+    });
+
+    // Then the deployment is refused rather than skipped.
+    assertStringIncludes(error.message, "Type must be a non-empty string");
+  });
+});


### PR DESCRIPTION
One `AWS::Route53::RecordSet` with a record type sim Route53 does not store failed the whole
deployment, so an otherwise fully supported DNS stack could not be deployed until the record was
edited out. That was out of step with the rest of simulated CloudFormation, where an unsupported
resource type is recorded and stepped over, and where #408 pushed the same answer down to
properties.

`SimCfnRoute53RecordSetBuilder.type()` threw a `TypeError`, which is not the diagnostic
`isSimCfnUnsupportedResourceError` recognises, so the resource went to `CREATE_FAILED` and took the
Stack with it. It now consults `SimCfnRoute53RecordTypeSkip`, which raises the
`Unsupported sim Route53 CloudFormation Resource ...` error the Stack lifecycle already knows how to
skip. The RecordSet lands in `stack.skippedResources` with a `skippedReason` naming the record type,
and the rest of the Stack deploys.

## Skip or refusal

The line is between a gap in the simulation and a broken template.

- A declared record type sim Route53 does not store is a **skip**. That covers a real Route53 type
  such as `DS`, and a string that is no record type at all. Adding `MX`, `SRV`, `CAA` and `PTR` in
  #444 shrank how often this is reached but did not remove it: Route53 has more types than a
  simulator is going to model.
- A `Type` that says nothing about which record was wanted — absent, not a string, empty or blank —
  is a **refusal**, as `Name` that is not a string and a negative `TTL` still are. Its message
  changed from "Type must be a supported Route53 record type" to "Type must be a non-empty string",
  which is what it now actually checks.

`ChangeResourceRecordSetsCommand` is unchanged: a call asking for a record the simulator cannot keep
is still rejected. Only the template path is treated gently.

## Teardown

Tearing down a Stack holding a skipped RecordSet works. The skipped Resource never reached simulated
AWS, so the teardown steps over it and it reaches `DELETE_COMPLETE`; it stays out of
`stack.skippedResourceDeletions`, which is for Resources that were created and could not be removed.
That is the existing engine behaviour for any skipped Resource, and this change does not carve out
an exception to it. The skip itself is still readable on the Stack after the teardown.

## Behaviour change

A template that fails today will deploy. That is the intended direction, but a consumer relying on
the failure to catch an unsupported record now has to read `stack.skippedResources` instead.

## Documentation

`docs/services/route53/README.md` gains an "Unsupported record types in a template" section with a
compiled example showing the skip and the reason string, and the "Record types" section now
separates the command's rejection from the template's skip.
`docs/services/cloudformation/README.md` notes in its skipped-resource section that a service can
decline one Resource of a type it does create, and what a teardown does with a skipped Resource.

## Verification

`pnpm run check` passes: format, lint, FTA, type check, docs examples, and 5186 tests with the
coverage threshold met.

Resolves #437
