### PR TITLE
feat: update a simulated Cognito user pool

### DIFF
--- a/docs/services/cognito/README.md
+++ b/docs/services/cognito/README.md
@@ -1060,8 +1060,8 @@ Three failures are reported the way real Cognito reports them:
 - A handler that returns something other than the event it was given fails with
   `InvalidLambdaResponseException`.
 
-Only these two triggers run. Every other `LambdaConfig` key is refused when the pool is created,
-naming the trigger, so a pool never quietly drops one.
+Only these two triggers run. Every other `LambdaConfig` key is refused when the pool is created or
+updated, naming the trigger, so a pool never quietly drops one.
 
 ## Token timestamps and expiry
 
@@ -1694,22 +1694,90 @@ console.log(pool.UserPool?.Arn);
 // "arn:aws:cognito-idp:eu-west-2:111111111111:userpool/eu-west-2_aBcDeFgHi"
 ```
 
+## Updating a pool
+
+`UpdateUserPool` changes a pool's password policy, deletion protection, auto-verified attributes,
+Lambda triggers and `AdminCreateUserConfig.AllowAdminCreateUserOnly`.
+
+It replaces those settings rather than merging into them, as real Cognito does. A setting the
+request leaves out goes back to the default `CreateUserPool` would have given it, so a request that
+names only the one setting it wants to change resets the others. Name every setting the pool should
+keep. That is the sharp edge on real Cognito too, and a request written that way behaves the same
+here and in a deployment.
+
+A pool's `LambdaConfig` is replaced the same way, so an update that says nothing about it stops the
+pool running the triggers it was created with, as real Cognito would.
+
+The pool's name is not among the settings an update carries. Real `UpdateUserPool` renames a pool
+with `PoolName`, and a rename is not simulated, so a request carrying one is refused. Every other
+input `CreateUserPool` refuses is refused here too, in the same words, saying `UpdateUserPool`.
+
+`UpdateUserPool` answers with nothing but the response metadata, as the real operation does, so
+`DescribeUserPool` is what reads the change back.
+
+```typescript sim-cognito-update-user-pool
+/**
+ * Changing a simulated user pool's settings.
+ */
+
+import {
+  CreateUserPoolCommand,
+  DeleteUserPoolCommand,
+  DescribeUserPoolCommand,
+  UpdateUserPoolCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+
+import { SimAws } from "@kensio/yulin";
+
+const cognito = new SimAws().cognitoIdentityProvider();
+
+const created = await cognito.createUserPool(
+  new CreateUserPoolCommand({
+    PoolName: "myapp-users",
+    DeletionProtection: "ACTIVE",
+    Policies: { PasswordPolicy: { MinimumLength: 12 } },
+  }),
+);
+
+const UserPoolId = created.UserPool?.Id;
+
+await cognito.updateUserPool(
+  new UpdateUserPoolCommand({ UserPoolId, DeletionProtection: "INACTIVE" }),
+);
+
+const described = await cognito.describeUserPool(
+  new DescribeUserPoolCommand({ UserPoolId }),
+);
+
+console.log(described.UserPool?.DeletionProtection); // "INACTIVE"
+
+// The update said nothing about the password policy, so it is back at the
+// default rather than the twelve characters the pool was created with.
+console.log(described.UserPool?.Policies?.PasswordPolicy?.MinimumLength); // 8
+
+// The pool can be deleted now its protection is off.
+await cognito.deleteUserPool(new DeleteUserPoolCommand({ UserPoolId }));
+```
+
+A pool reports the time of its last update as its `LastModifiedDate`, in `DescribeUserPool` and in
+`ListUserPools`. A pool no update has reached reports its creation date there.
+
 ## Deletion protection
 
 A pool created through the API is unprotected unless the request asks for protection, which is the
 opposite of what the console does. A pool created with `DeletionProtection: "ACTIVE"` refuses
 `DeleteUserPool` with `InvalidParameterException`.
 
-Real Cognito wants an `UpdateUserPool` request deactivating the protection before the pool can go.
-`UpdateUserPool` is not simulated, so a protected pool cannot be deleted here at all. Create the pool
-without `DeletionProtection` if the test needs to delete it.
+Real Cognito wants an `UpdateUserPool` request deactivating the protection before the pool can go,
+and so does this. Send an `UpdateUserPool` with `DeletionProtection: "INACTIVE"` first, then delete
+the pool.
 
 ## Available functionality
 
 Sim Cognito currently supports:
 
-- `CreateUserPoolCommand`, `DescribeUserPoolCommand`, `DeleteUserPoolCommand` and
-  `ListUserPoolsCommand`
+- `CreateUserPoolCommand`, `DescribeUserPoolCommand`, `UpdateUserPoolCommand`,
+  `DeleteUserPoolCommand` and `ListUserPoolsCommand`
 - `CreateUserPoolClientCommand`, `DescribeUserPoolClientCommand`, `UpdateUserPoolClientCommand`,
   `DeleteUserPoolClientCommand` and `ListUserPoolClientsCommand`
 - `AdminCreateUserCommand`, `AdminGetUserCommand`, `AdminDeleteUserCommand`,
@@ -1829,25 +1897,26 @@ Current documented limitations:
   periodically rather than on each write, so it can lag there in a way it never does here.
 - MFA is not simulated, so `AdminGetUser` reports no `UserMFASettingList`, `PreferredMfaSetting` or
   `MFAOptions`.
-- Nothing updates a pool. `UpdateUserPool` is not implemented, so a pool's `LastModifiedDate` is
-  always its creation date.
-- `UpdateUserPoolClient` replaces an app client's settings rather than merging into them, as real
-  Cognito does, so a setting the request leaves out goes back to the default `CreateUserPoolClient`
-  would have given it. `ClientName` is the exception: a client has to have a name and there is no
-  default to reset to, so an update that names none keeps the one the client has.
+- `UpdateUserPool` replaces a pool's settings rather than merging into them, as real Cognito does, so
+  a setting the request leaves out goes back to the default `CreateUserPool` would have given it. It
+  covers the settings this simulation models: `Policies.PasswordPolicy`, `DeletionProtection`,
+  `AdminCreateUserConfig.AllowAdminCreateUserOnly`, `AutoVerifiedAttributes` and `LambdaConfig`.
+  `PoolName` is refused, so a pool cannot be renamed, and every input `CreateUserPool` refuses is
+  refused here too, in the same words.
+- `UpdateUserPoolClient` replaces an app client's settings the same way, so a setting the request
+  leaves out goes back to the default `CreateUserPoolClient` would have given it. `ClientName` is
+  the exception: a client has to have a name and there is no default to reset to, so an update that
+  names none keeps the one the client has.
 - An update leaves the client's secret alone. `UpdateUserPoolClient` has no `GenerateSecret` input
   on real Cognito, so a client created without a secret never gains one.
-- Redeploying a template that changed an `AWS::Cognito::UserPoolClient` does not run
-  `UpdateUserPoolClient`. Sim CloudFormation replaces a resource whose resolved template entry
-  changed rather than updating it in place.
-- A pool with `DeletionProtection: ACTIVE` cannot be deleted at all, because deactivating the
-  protection needs `UpdateUserPool`.
+- A redeployed template reaches neither update. Sim CloudFormation replaces a resource whose
+  resolved template entry changed rather than updating it in place, whatever the resource type.
 - `PreAuthentication` and `PostAuthentication` are the only Lambda triggers that run. Every other
-  `LambdaConfig` key is refused when the pool is created, naming the trigger, because a pool that
-  accepted one would never call the function the template named. The sign-up, token generation and
-  message triggers wait on the features they fire for; the custom challenge triggers would need a
-  challenge loop this simulation does not have; and the migration and federation triggers have no
-  external directory to reach.
+  `LambdaConfig` key is refused when the pool is created or updated, naming the trigger, because a
+  pool that accepted one would never call the function the template named. The sign-up, token
+  generation and message triggers wait on the features they fire for; the custom challenge triggers
+  would need a challenge loop this simulation does not have; and the migration and federation
+  triggers have no external directory to reach.
 - A `PostAuthentication` handler that throws fails the request, and the sign-in it ran after is not
   undone: the tokens the pool issued stay issued, as they do on real Cognito.
 - Neither trigger fires for `REFRESH_TOKEN_AUTH`, as neither does on real Cognito. `ClientMetadata`

--- a/docs/services/cognito/sim-cognito-update-user-pool.example.ts
+++ b/docs/services/cognito/sim-cognito-update-user-pool.example.ts
@@ -1,0 +1,41 @@
+/**
+ * Changing a simulated user pool's settings.
+ */
+
+import {
+  CreateUserPoolCommand,
+  DeleteUserPoolCommand,
+  DescribeUserPoolCommand,
+  UpdateUserPoolCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+
+import { SimAws } from "@kensio/yulin";
+
+const cognito = new SimAws().cognitoIdentityProvider();
+
+const created = await cognito.createUserPool(
+  new CreateUserPoolCommand({
+    PoolName: "myapp-users",
+    DeletionProtection: "ACTIVE",
+    Policies: { PasswordPolicy: { MinimumLength: 12 } },
+  }),
+);
+
+const UserPoolId = created.UserPool?.Id;
+
+await cognito.updateUserPool(
+  new UpdateUserPoolCommand({ UserPoolId, DeletionProtection: "INACTIVE" }),
+);
+
+const described = await cognito.describeUserPool(
+  new DescribeUserPoolCommand({ UserPoolId }),
+);
+
+console.log(described.UserPool?.DeletionProtection); // "INACTIVE"
+
+// The update said nothing about the password policy, so it is back at the
+// default rather than the twelve characters the pool was created with.
+console.log(described.UserPool?.Policies?.PasswordPolicy?.MinimumLength); // 8
+
+// The pool can be deleted now its protection is off.
+await cognito.deleteUserPool(new DeleteUserPoolCommand({ UserPoolId }));

--- a/src/service/cognito/README.md
+++ b/src/service/cognito/README.md
@@ -26,10 +26,17 @@ a pool in one region cannot be reached from another.
 
 Pool state lives under `user-pool/`, and app client state under `user-pool/client/`.
 
-`SimCognitoUserPool` is the stored resource: its id, its ARN, its password policy, its deletion
-protection, and its app clients. The pool owns the clients rather than a separate store owning them,
-because that is where they live on real Cognito: deleting a pool takes its clients with it, and a
-client id means nothing outside the pool that issued it.
+`SimCognitoUserPool` is the stored resource: its id, its ARN, its settings, and its app clients. The
+pool owns the clients rather than a separate store owning them, because that is where they live on
+real Cognito: deleting a pool takes its clients with it, and a client id means nothing outside the
+pool that issued it.
+
+`SimCognitoUserPoolSettings` holds the settings a request can change: the password policy, the
+deletion protection, whether users may sign themselves up, what confirming a sign-up verifies, and
+the Lambda triggers the pool runs. `CreateUserPool` and `UpdateUserPool` both build one out of their
+own request, and an update swaps the pool's for it. That is what makes an update replace rather than
+merge, and it is where the pool's `LastModifiedDate` moves. Each takes the operation name, so a
+refusal from inside the settings names the request it came from.
 
 `makeSimCognitoUserPoolId` builds the `<region>_<nine characters>` form. The region is part of the id
 rather than decoration: SDK code splits a pool id on the underscore to work out which region to talk
@@ -329,19 +336,21 @@ resource, here or on real AWS.
   `RESET_REQUIRED` is a status no user here reaches.
 - A client-side sign-up operation naming a user the pool does not hold reports it, whatever the app
   client's `PreventUserExistenceErrors` says. That setting is honoured for sign-in only.
-- Every unsimulated `CreateUserPool`, `CreateUserPoolClient` and `UpdateUserPoolClient` input is
-  refused rather than ignored.
+- Every unsimulated `CreateUserPool`, `UpdateUserPool`, `CreateUserPoolClient` and
+  `UpdateUserPoolClient` input is refused rather than ignored.
   `UsernameAttributes` is the one that matters most: a pool signing users in by email stores a
   generated UUID as the username, so a pool quietly created without it would answer with the wrong
   username here and the right one on real AWS.
-- A pool created with `DeletionProtection: ACTIVE` cannot be deleted at all, because `UpdateUserPool`
-  is not simulated and that is the only way to deactivate the protection.
-- Nothing changes a pool after creation, so its `LastModifiedDate` is always its creation date. An
-  app client is different: `UpdateUserPoolClient` moves its `LastModifiedDate` on, as every
-  operation that changes a user moves that user's `UserLastModifiedDate` on.
-- `UpdateUserPoolClient` replaces an app client's settings rather than merging into them, so a
-  setting the request leaves out goes back to its `CreateUserPoolClient` default. The client's
-  secret is not a setting and is left alone.
+- A pool created with `DeletionProtection: ACTIVE` refuses `DeleteUserPool` until an `UpdateUserPool`
+  request deactivates the protection, as real Cognito refuses it.
+- `UpdateUserPool` replaces a pool's settings rather than merging into them, so a setting the request
+  leaves out goes back to its `CreateUserPool` default, its `LambdaConfig` included. `PoolName` is
+  refused, so a pool cannot be renamed here.
+- `UpdateUserPoolClient` replaces an app client's settings the same way, so a setting the request
+  leaves out goes back to its `CreateUserPoolClient` default. The client's secret is not a setting
+  and is left alone.
+- An update moves a pool's or an app client's `LastModifiedDate` on, as every operation that changes
+  a user moves that user's `UserLastModifiedDate` on.
 - `SchemaAttributes` is not reported on a pool, though every pool holds the standard schema and
   validates user attributes against it.
 - Users are resolved by username only, and real Cognito also accepts a `sub` there.

--- a/src/service/cognito/cfn/sim-cfn-cognito-properties.iso.test.ts
+++ b/src/service/cognito/cfn/sim-cfn-cognito-properties.iso.test.ts
@@ -73,8 +73,8 @@ describe("Cognito CloudFormation property shapes", () => {
     assertTypeString(userPoolId);
 
     const pool = simAws.cognitoIdentityProvider().userPool(userPoolId);
-    assertIdentical(pool.passwordPolicy.minimumLength, 12);
-    assertFalse(pool.passwordPolicy.requiresSymbols);
+    assertIdentical(pool.settings.passwordPolicy.minimumLength, 12);
+    assertFalse(pool.settings.passwordPolicy.requiresSymbols);
 
     const client = pool.clients[0];
     assertNonNullable(client);

--- a/src/service/cognito/cfn/sim-cfn-cognito-validation.iso.test.ts
+++ b/src/service/cognito/cfn/sim-cfn-cognito-validation.iso.test.ts
@@ -184,8 +184,7 @@ describe("Cognito CloudFormation validation", () => {
     assertStringIncludes(error.message, "AppPool");
     assertStringIncludes(
       error.message,
-      "CreateUserPool AutoVerifiedAttributes 'profile' is not an attribute " +
-        "Cognito can verify",
+      "AutoVerifiedAttributes 'profile' is not an attribute Cognito can verify",
     );
     assertStringIncludes(error.message, "email and phone_number");
   });

--- a/src/service/cognito/command/auth/sim-cognito-new-password-response.ts
+++ b/src/service/cognito/command/auth/sim-cognito-new-password-response.ts
@@ -75,7 +75,7 @@ export class SimCognitoNewPasswordResponse {
     requireSimCognitoEnabled(user);
 
     user.setPassword(
-      new SimCognitoPasswordCheck(pool.passwordPolicy).require(
+      new SimCognitoPasswordCheck(pool.settings.passwordPolicy).require(
         "NEW_PASSWORD",
         parameters.find("NEW_PASSWORD"),
       ),

--- a/src/service/cognito/command/authorize/sim-cognito-iam.iso.test.ts
+++ b/src/service/cognito/command/authorize/sim-cognito-iam.iso.test.ts
@@ -5,6 +5,7 @@ import {
   DescribeUserPoolClientCommand,
   ListUserPoolsCommand,
   UpdateUserPoolClientCommand,
+  UpdateUserPoolCommand,
 } from "@aws-sdk/client-cognito-identity-provider";
 import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
 import {
@@ -122,6 +123,57 @@ describe("sim Cognito IAM authorization", () => {
     });
 
     // Then it is denied.
+    assertInstanceOf(error, SimIamAccessDenied);
+  });
+
+  it("allows an update to a pool the caller's policy names", async () => {
+    // Given a Role allowed to update one pool by its ARN.
+    const { simAws, caller, userPoolId } = await simCognitoWithRole({
+      Effect: "Allow",
+      Action: ["cognito-idp:UpdateUserPool", "cognito-idp:DescribeUserPool"],
+      Resource: userPoolArn("*"),
+    });
+
+    // When that Role updates the pool.
+    await simAws.cognitoIdentityProvider().updateUserPool(
+      new UpdateUserPoolCommand({
+        UserPoolId: userPoolId,
+        DeletionProtection: "ACTIVE",
+      }),
+      { caller },
+    );
+
+    // Then the request is allowed, and the change is there.
+    const described = await simAws
+      .cognitoIdentityProvider()
+      .describeUserPool(
+        new DescribeUserPoolCommand({ UserPoolId: userPoolId }),
+        { caller },
+      );
+
+    assertIdentical(described.UserPool?.DeletionProtection, "ACTIVE");
+  });
+
+  it("denies an update to a pool the caller may only read", async () => {
+    // Given a Role allowed to describe pools and nothing else.
+    const { simAws, caller, userPoolId } = await simCognitoWithRole({
+      Effect: "Allow",
+      Action: "cognito-idp:DescribeUserPool",
+      Resource: userPoolArn("*"),
+    });
+
+    // When that Role updates the pool.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.cognitoIdentityProvider().updateUserPool(
+        new UpdateUserPoolCommand({
+          UserPoolId: userPoolId,
+          DeletionProtection: "ACTIVE",
+        }),
+        { caller },
+      );
+    });
+
+    // Then it is denied, because UpdateUserPool is its own IAM action.
     assertInstanceOf(error, SimIamAccessDenied);
   });
 

--- a/src/service/cognito/command/sim-cognito-command.types.ts
+++ b/src/service/cognito/command/sim-cognito-command.types.ts
@@ -12,6 +12,9 @@ export type {
   SimDescribeUserPoolCommand,
   SimDescribeUserPoolCommandInput,
   SimDescribeUserPoolCommandOutput,
+  SimUpdateUserPoolCommand,
+  SimUpdateUserPoolCommandInput,
+  SimUpdateUserPoolCommandOutput,
 } from "./user-pool/user-pool.command.js";
 export type {
   SimCognitoUserPoolDescriptionType,

--- a/src/service/cognito/command/user-pool/sim-cognito-unsimulated-pool-features.ts
+++ b/src/service/cognito/command/user-pool/sim-cognito-unsimulated-pool-features.ts
@@ -1,6 +1,6 @@
 import { SimCognitoUnsimulatedInput } from "../sim-cognito-unsimulated-input.js";
 import { SimCognitoUnsimulatedStructure } from "../sim-cognito-unsimulated-structure.js";
-import type { SimCreateUserPoolCommandInput } from "./user-pool.command.js";
+import type { SimCognitoUserPoolCommandInput } from "./user-pool.command.js";
 
 /**
  * The account recovery a pool is accepted with, which is what `aws-cdk-lib`
@@ -34,34 +34,24 @@ const accountRecoverySetting = {
  * it are about the invitation an admin-created user is sent, and no message is
  * ever delivered here, so those are refused.
  *
- * `LambdaConfig` is not here either. The triggers a pool can run are read by
+ * `LambdaConfig` is not here. The triggers a pool can run are read by
  * SimCognitoLambdaConfig, which accepts the two this simulation fires and
  * refuses the rest one key at a time, so a pool can have a trigger without
  * having every trigger.
  */
 export class SimCognitoUnsimulatedUserPoolFeatures {
-  private readonly unsimulated = new SimCognitoUnsimulatedInput(
-    "CreateUserPool",
-  );
-  private readonly structure = new SimCognitoUnsimulatedStructure(
-    "CreateUserPool",
-  );
+  private readonly unsimulated: SimCognitoUnsimulatedInput;
+  private readonly structure: SimCognitoUnsimulatedStructure;
+
+  constructor(operation: string) {
+    this.unsimulated = new SimCognitoUnsimulatedInput(operation);
+    this.structure = new SimCognitoUnsimulatedStructure(operation);
+  }
 
   /**
    * Refuse a request carrying a feature this simulation cannot honour.
    */
-  refuseIn(input: SimCreateUserPoolCommandInput): void {
-    this.unsimulated.refuse(
-      "AliasAttributes",
-      input.AliasAttributes,
-      "sign-in aliases",
-    );
-    this.unsimulated.refuse("Schema", input.Schema, "custom attributes");
-    this.unsimulated.refuse(
-      "UsernameConfiguration",
-      input.UsernameConfiguration,
-      "case-insensitive usernames",
-    );
+  refuseIn(input: SimCognitoUserPoolCommandInput): void {
     this.unsimulated.refuse(
       "UserAttributeUpdateSettings",
       input.UserAttributeUpdateSettings,

--- a/src/service/cognito/command/user-pool/sim-cognito-unsimulated-pool-identity.ts
+++ b/src/service/cognito/command/user-pool/sim-cognito-unsimulated-pool-identity.ts
@@ -1,0 +1,61 @@
+import { SimCognitoInvalidParameterException } from "../../error/sim-cognito.error.js";
+import { SimCognitoUnsimulatedInput } from "../sim-cognito-unsimulated-input.js";
+import type { SimCreateUserPoolCommandInput } from "./user-pool.command.js";
+
+/**
+ * Refuses the inputs deciding how a pool identifies its users.
+ *
+ * These four are `CreateUserPool` inputs only. Real Cognito fixes each of
+ * them when the pool is made and has no `UpdateUserPool` input for any of
+ * them, so the refusals only ever name creation.
+ *
+ * `UsernameAttributes` is the one that would hurt most, and it gets its own
+ * refusal saying why.
+ */
+export class SimCognitoUnsimulatedUserPoolIdentity {
+  private readonly unsimulated = new SimCognitoUnsimulatedInput(
+    "CreateUserPool",
+  );
+
+  /**
+   * Refuse a request choosing how its users are identified.
+   */
+  refuseIn(input: SimCreateUserPoolCommandInput): void {
+    this.refuseUsernameAttributes(input.UsernameAttributes);
+
+    this.unsimulated.refuse(
+      "AliasAttributes",
+      input.AliasAttributes,
+      "sign-in aliases",
+    );
+    this.unsimulated.refuse("Schema", input.Schema, "custom attributes");
+    this.unsimulated.refuse(
+      "UsernameConfiguration",
+      input.UsernameConfiguration,
+      "case-insensitive usernames",
+    );
+  }
+
+  /**
+   * Refuse a pool that signs users in by an attribute rather than by
+   * username.
+   *
+   * Such a pool stores a generated UUID as the username, so code written
+   * against it looks users up by something this simulation would not have
+   * given them.
+   */
+  private refuseUsernameAttributes(
+    attributes: readonly string[] | undefined,
+  ): void {
+    if (attributes === undefined) {
+      return;
+    }
+
+    throw new SimCognitoInvalidParameterException(
+      "CreateUserPool UsernameAttributes is not simulated: a pool that signs " +
+        "users in by email or phone number stores a generated UUID as the " +
+        "username, so simulating the pool without that would answer with the " +
+        "wrong username here and the right one on real AWS",
+    );
+  }
+}

--- a/src/service/cognito/command/user-pool/sim-cognito-unsimulated-pool-messaging.ts
+++ b/src/service/cognito/command/user-pool/sim-cognito-unsimulated-pool-messaging.ts
@@ -1,6 +1,6 @@
 import { SimCognitoUnsimulatedInput } from "../sim-cognito-unsimulated-input.js";
 import { SimCognitoUnsimulatedStructure } from "../sim-cognito-unsimulated-structure.js";
-import type { SimCreateUserPoolCommandInput } from "./user-pool.command.js";
+import type { SimCognitoUserPoolCommandInput } from "./user-pool.command.js";
 
 /**
  * The verification wording a pool is accepted with.
@@ -39,18 +39,19 @@ const verificationWording = "the wording of a verification message";
  * asking for a message a user would read.
  */
 export class SimCognitoUnsimulatedUserPoolMessaging {
-  private readonly unsimulated = new SimCognitoUnsimulatedInput(
-    "CreateUserPool",
-  );
-  private readonly structure = new SimCognitoUnsimulatedStructure(
-    "CreateUserPool",
-  );
+  private readonly unsimulated: SimCognitoUnsimulatedInput;
+  private readonly structure: SimCognitoUnsimulatedStructure;
+
+  constructor(operation: string) {
+    this.unsimulated = new SimCognitoUnsimulatedInput(operation);
+    this.structure = new SimCognitoUnsimulatedStructure(operation);
+  }
 
   /**
    * Refuse a request carrying a message setting this simulation cannot
    * honour.
    */
-  refuseIn(input: SimCreateUserPoolCommandInput): void {
+  refuseIn(input: SimCognitoUserPoolCommandInput): void {
     this.unsimulated.refuse(
       "EmailConfiguration",
       input.EmailConfiguration,
@@ -74,7 +75,7 @@ export class SimCognitoUnsimulatedUserPoolMessaging {
    * Refuse verification wording other than the one this simulation accepts.
    */
   private refuseVerificationWording(
-    input: SimCreateUserPoolCommandInput,
+    input: SimCognitoUserPoolCommandInput,
   ): void {
     this.unsimulated.refuseUnless(
       "EmailVerificationMessage",

--- a/src/service/cognito/command/user-pool/sim-cognito-unsimulated-pool-options.ts
+++ b/src/service/cognito/command/user-pool/sim-cognito-unsimulated-pool-options.ts
@@ -1,30 +1,33 @@
-import { SimCognitoInvalidParameterException } from "../../error/sim-cognito.error.js";
 import { SimCognitoUnsimulatedInput } from "../sim-cognito-unsimulated-input.js";
 import { SimCognitoUnsimulatedUserPoolFeatures } from "./sim-cognito-unsimulated-pool-features.js";
 import { SimCognitoUnsimulatedUserPoolMessaging } from "./sim-cognito-unsimulated-pool-messaging.js";
-import type { SimCreateUserPoolCommandInput } from "./user-pool.command.js";
+import type { SimCognitoUserPoolCommandInput } from "./user-pool.command.js";
 
 /**
- * Refuses the CreateUserPool inputs this simulation does not model.
+ * Refuses the pool inputs this simulation does not model.
  *
  * Every one of these changes what the pool does on real AWS, so ignoring any
  * of them would let a request succeed here and behave differently in a
- * deployment. `UsernameAttributes` is the one that would hurt most, and it
- * gets its own refusal saying why.
+ * deployment.
+ *
+ * `CreateUserPool` and `UpdateUserPool` both carry them, so both refuse them,
+ * each naming itself in the refusal.
  */
 export class SimCognitoUnsimulatedUserPoolOptions {
-  private readonly unsimulated = new SimCognitoUnsimulatedInput(
-    "CreateUserPool",
-  );
-  private readonly features = new SimCognitoUnsimulatedUserPoolFeatures();
-  private readonly messaging = new SimCognitoUnsimulatedUserPoolMessaging();
+  private readonly unsimulated: SimCognitoUnsimulatedInput;
+  private readonly features: SimCognitoUnsimulatedUserPoolFeatures;
+  private readonly messaging: SimCognitoUnsimulatedUserPoolMessaging;
+
+  constructor(operation: string) {
+    this.unsimulated = new SimCognitoUnsimulatedInput(operation);
+    this.features = new SimCognitoUnsimulatedUserPoolFeatures(operation);
+    this.messaging = new SimCognitoUnsimulatedUserPoolMessaging(operation);
+  }
 
   /**
    * Refuse a request carrying an input this simulation cannot honour.
    */
-  refuseIn(input: SimCreateUserPoolCommandInput): void {
-    this.refuseUsernameAttributes(input.UsernameAttributes);
-
+  refuseIn(input: SimCognitoUserPoolCommandInput): void {
     this.unsimulated.refuseUnless(
       "MfaConfiguration",
       input.MfaConfiguration,
@@ -50,28 +53,5 @@ export class SimCognitoUnsimulatedUserPoolOptions {
 
     this.features.refuseIn(input);
     this.messaging.refuseIn(input);
-  }
-
-  /**
-   * Refuse a pool that signs users in by an attribute rather than by
-   * username.
-   *
-   * Such a pool stores a generated UUID as the username, so code written
-   * against it looks users up by something this simulation would not have
-   * given them.
-   */
-  private refuseUsernameAttributes(
-    attributes: readonly string[] | undefined,
-  ): void {
-    if (attributes === undefined) {
-      return;
-    }
-
-    throw new SimCognitoInvalidParameterException(
-      "CreateUserPool UsernameAttributes is not simulated: a pool that signs " +
-        "users in by email or phone number stores a generated UUID as the " +
-        "username, so simulating the pool without that would answer with the " +
-        "wrong username here and the right one on real AWS",
-    );
   }
 }

--- a/src/service/cognito/command/user-pool/sim-cognito-unsimulated-pool-updates.ts
+++ b/src/service/cognito/command/user-pool/sim-cognito-unsimulated-pool-updates.ts
@@ -1,0 +1,32 @@
+import { SimCognitoUnsimulatedInput } from "../sim-cognito-unsimulated-input.js";
+import { SimCognitoUnsimulatedUserPoolOptions } from "./sim-cognito-unsimulated-pool-options.js";
+import type { SimUpdateUserPoolCommandInput } from "./user-pool.command.js";
+
+/**
+ * Refuses the UpdateUserPool inputs this simulation does not model.
+ *
+ * An update carries the same settings a creation does, and they are refused
+ * in the same words, saying `UpdateUserPool`.
+ *
+ * `PoolName` is the one input only an update refuses. Real `UpdateUserPool`
+ * renames the pool with it, and a rename is not simulated, so a request
+ * carrying one is refused rather than answered with a pool still under its
+ * old name.
+ */
+export class SimCognitoUnsimulatedUserPoolUpdates {
+  private readonly unsimulated = new SimCognitoUnsimulatedInput(
+    "UpdateUserPool",
+  );
+  private readonly options = new SimCognitoUnsimulatedUserPoolOptions(
+    "UpdateUserPool",
+  );
+
+  /**
+   * Refuse an update carrying an input this simulation cannot honour.
+   */
+  refuseIn(input: SimUpdateUserPoolCommandInput): void {
+    this.unsimulated.refuse("PoolName", input.PoolName, "renaming a pool");
+
+    this.options.refuseIn(input);
+  }
+}

--- a/src/service/cognito/command/user-pool/sim-cognito-update-user-pool-validation.iso.test.ts
+++ b/src/service/cognito/command/user-pool/sim-cognito-update-user-pool-validation.iso.test.ts
@@ -1,0 +1,261 @@
+import {
+  type UpdateUserPoolCommandInput,
+  CreateUserPoolCommand,
+  UpdateUserPoolCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import {
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertTrue,
+  assertTypeString,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import {
+  SimCognitoInvalidParameterException,
+  SimCognitoResourceNotFoundException,
+} from "../../error/sim-cognito.error.js";
+import type { SimCognitoIdentityProvider } from "../../sim-cognito-identity-provider.js";
+
+interface RefusedInput {
+  readonly label: string;
+  readonly input: Partial<UpdateUserPoolCommandInput>;
+  readonly says: string;
+}
+
+/**
+ * The inputs an update carries that this simulation does not model. They are
+ * the same ones `CreateUserPool` refuses, apart from `PoolName`, which only
+ * an update can carry as a change.
+ */
+const refusedInputs: readonly RefusedInput[] = [
+  {
+    label: "PoolName",
+    input: { PoolName: "myapp-members" },
+    says: "renaming a pool",
+  },
+  {
+    label: "MfaConfiguration",
+    input: { MfaConfiguration: "OPTIONAL" },
+    says: "multi-factor authentication",
+  },
+  {
+    label: "UserPoolTier",
+    input: { UserPoolTier: "PLUS" },
+    says: "the Lite and Plus feature plans",
+  },
+  {
+    label: "SignInPolicy",
+    input: {
+      Policies: { SignInPolicy: { AllowedFirstAuthFactors: ["EMAIL_OTP"] } },
+    },
+    says: "which factors a user may sign in with first",
+  },
+  {
+    label: "PasswordHistorySize",
+    input: { Policies: { PasswordPolicy: { PasswordHistorySize: 3 } } },
+    says: "a password the user has used before",
+  },
+  {
+    label: "LambdaConfig PreSignUp",
+    input: {
+      LambdaConfig: { PreSignUp: "arn:aws:lambda:eu-west-2:1:function:f" },
+    },
+    says: "validating a self-service sign-up",
+  },
+  {
+    label: "UserAttributeUpdateSettings",
+    input: {
+      UserAttributeUpdateSettings: {
+        AttributesRequireVerificationBeforeUpdate: ["email"],
+      },
+    },
+    says: "verification before an attribute changes",
+  },
+  {
+    label: "DeviceConfiguration",
+    input: { DeviceConfiguration: { ChallengeRequiredOnNewDevice: true } },
+    says: "device remembering",
+  },
+  {
+    label: "AccountRecoverySetting",
+    input: {
+      AccountRecoverySetting: {
+        RecoveryMechanisms: [{ Name: "admin_only", Priority: 1 }],
+      },
+    },
+    says: "account recovery",
+  },
+  {
+    label: "AdminCreateUserConfig InviteMessageTemplate",
+    input: {
+      AdminCreateUserConfig: {
+        InviteMessageTemplate: { EmailSubject: "Welcome" },
+      },
+    },
+    says: "the wording of the invitation an admin-created user is sent",
+  },
+  {
+    label: "UserPoolAddOns",
+    input: { UserPoolAddOns: { AdvancedSecurityMode: "ENFORCED" } },
+    says: "threat protection",
+  },
+  {
+    label: "KeyConfiguration",
+    input: { KeyConfiguration: { KeyType: "CUSTOMER_MANAGED_KEY" } },
+    says: "encryption under a customer managed key",
+  },
+  {
+    label: "IssuerConfiguration",
+    input: { IssuerConfiguration: { Type: "UPDATED" } },
+    says: "a custom token issuer",
+  },
+  {
+    label: "UserPoolTags",
+    input: { UserPoolTags: { team: "platform" } },
+    says: "tags",
+  },
+  {
+    label: "EmailConfiguration",
+    input: { EmailConfiguration: { EmailSendingAccount: "DEVELOPER" } },
+    says: "email delivery",
+  },
+  {
+    label: "SmsConfiguration",
+    input: { SmsConfiguration: { SnsCallerArn: "arn:aws:iam::1:role/sms" } },
+    says: "SMS delivery",
+  },
+  {
+    label: "SmsAuthenticationMessage",
+    input: { SmsAuthenticationMessage: "Your code is {####}" },
+    says: "multi-factor authentication messages",
+  },
+  {
+    label: "VerificationMessageTemplate",
+    input: {
+      VerificationMessageTemplate: { DefaultEmailOption: "CONFIRM_WITH_LINK" },
+    },
+    says: "the wording of a verification message",
+  },
+  {
+    label: "EmailVerificationMessage",
+    input: { EmailVerificationMessage: "Your code is {####}" },
+    says: "the wording of a verification message",
+  },
+];
+
+async function createdPoolId(
+  cognito: SimCognitoIdentityProvider,
+): Promise<string> {
+  const created = await cognito.createUserPool(
+    new CreateUserPoolCommand({ PoolName: "myapp-users" }),
+  );
+  const userPoolId = created.UserPool?.Id;
+  assertTypeString(userPoolId);
+
+  return userPoolId;
+}
+
+describe("sim Cognito UpdateUserPool validation", () => {
+  it("refuses every UpdateUserPool input it does not simulate", async () => {
+    // Given a created pool.
+    const cognito = new SimAws().cognitoIdentityProvider();
+    const userPoolId = await createdPoolId(cognito);
+
+    // When each unsimulated input is used in an update.
+    const outcomes = await Promise.all(
+      refusedInputs.map(async (refused) => ({
+        refused,
+        error: await assertThrowsErrorAsync(async () => {
+          await cognito.updateUserPool(
+            new UpdateUserPoolCommand({
+              UserPoolId: userPoolId,
+              ...refused.input,
+            }),
+          );
+        }, refused.label),
+      })),
+    );
+
+    // Then each request is refused in the same words CreateUserPool uses,
+    // naming UpdateUserPool as the operation that could not honour it.
+    for (const { refused, error } of outcomes) {
+      assertInstanceOf(error, SimCognitoInvalidParameterException);
+      assertStringIncludes(error.message, "UpdateUserPool");
+      assertStringIncludes(error.message, refused.says);
+      assertStringIncludes(error.message, "is not simulated");
+    }
+  });
+
+  it("accepts the inputs whose only simulated value is their default", async () => {
+    // Given a created pool.
+    const cognito = new SimAws().cognitoIdentityProvider();
+    const userPoolId = await createdPoolId(cognito);
+
+    // When an update carries them at the values this simulation does model.
+    await cognito.updateUserPool(
+      new UpdateUserPoolCommand({
+        UserPoolId: userPoolId,
+        MfaConfiguration: "OFF",
+        UserPoolTier: "ESSENTIALS",
+        AdminCreateUserConfig: { AllowAdminCreateUserOnly: true },
+      }),
+    );
+
+    // Then the update is applied rather than refused.
+    const described = await cognito.describeUserPool({
+      input: { UserPoolId: userPoolId },
+    });
+
+    assertTrue(
+      described.UserPool?.AdminCreateUserConfig?.AllowAdminCreateUserOnly,
+    );
+  });
+
+  it("refuses an attribute Cognito cannot verify", async () => {
+    // Given a created pool.
+    const cognito = new SimAws().cognitoIdentityProvider();
+    const userPoolId = await createdPoolId(cognito);
+
+    // When an update asks to auto-verify an attribute no code is sent to. The
+    // SDK's own types allow only the attributes Cognito can verify, so this is
+    // the request as it reaches the simulator.
+    const error = await assertThrowsErrorAsync(async () => {
+      await cognito.updateUserPool({
+        input: {
+          UserPoolId: userPoolId,
+          AutoVerifiedAttributes: ["profile"],
+        },
+      });
+    });
+
+    // Then it is refused, as it is on creation.
+    assertInstanceOf(error, SimCognitoInvalidParameterException);
+    assertStringIncludes(error.message, "email and phone_number");
+  });
+
+  it("refuses an update naming no pool, or one that does not exist", async () => {
+    // Given simulated Cognito with no pools.
+    const cognito = new SimAws().cognitoIdentityProvider();
+
+    // When an update names no pool, and when it names one never created. The
+    // SDK's own types insist on an id, so the first is the request as it
+    // reaches the simulator.
+    const missingId = await assertThrowsErrorAsync(async () => {
+      await cognito.updateUserPool({ input: {} });
+    });
+    const missingPool = await assertThrowsErrorAsync(async () => {
+      await cognito.updateUserPool(
+        new UpdateUserPoolCommand({ UserPoolId: "eu-west-2_aBcDeFgHi" }),
+      );
+    });
+
+    // Then the first fails validation and the second reports the pool
+    // missing.
+    assertInstanceOf(missingId, SimCognitoInvalidParameterException);
+    assertStringIncludes(missingId.message, "UserPoolId is required");
+    assertInstanceOf(missingPool, SimCognitoResourceNotFoundException);
+    assertStringIncludes(missingPool.message, "does not exist");
+  });
+});

--- a/src/service/cognito/command/user-pool/sim-cognito-update-user-pool.iso.test.ts
+++ b/src/service/cognito/command/user-pool/sim-cognito-update-user-pool.iso.test.ts
@@ -1,0 +1,268 @@
+import {
+  type UpdateUserPoolCommandInput,
+  CreateUserPoolCommand,
+  DeleteUserPoolCommand,
+  DescribeUserPoolCommand,
+  ListUserPoolsCommand,
+  UpdateUserPoolCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertObjectEquals,
+  assertObjectMatches,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertTypeString,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+
+/**
+ * The settings a pool is created with in the tests that then change them,
+ * each one at something other than its default.
+ */
+const createdSettings = {
+  Policies: { PasswordPolicy: { MinimumLength: 12, RequireSymbols: false } },
+  DeletionProtection: "ACTIVE",
+  AdminCreateUserConfig: { AllowAdminCreateUserOnly: true },
+  AutoVerifiedAttributes: ["email"],
+} satisfies Partial<UpdateUserPoolCommandInput>;
+
+describe("sim Cognito UpdateUserPool", () => {
+  it("applies the settings an update names", async () => {
+    // Given a pool created with nothing but a name.
+    const cognito = new SimAws().cognitoIdentityProvider();
+    const created = await cognito.createUserPool(
+      new CreateUserPoolCommand({ PoolName: "myapp-users" }),
+    );
+    const userPoolId = created.UserPool?.Id;
+
+    // When it is updated with each of the settings this simulation models.
+    await cognito.updateUserPool(
+      new UpdateUserPoolCommand({ UserPoolId: userPoolId, ...createdSettings }),
+    );
+
+    // Then the described pool reports every one of them.
+    const described = await cognito.describeUserPool(
+      new DescribeUserPoolCommand({ UserPoolId: userPoolId }),
+    );
+
+    assertNonNullable(described.UserPool);
+    assertObjectMatches(described.UserPool, {
+      Policies: {
+        PasswordPolicy: {
+          MinimumLength: 12,
+          RequireSymbols: false,
+          RequireUppercase: true,
+        },
+      },
+      DeletionProtection: "ACTIVE",
+      AdminCreateUserConfig: { AllowAdminCreateUserOnly: true },
+      AutoVerifiedAttributes: ["email"],
+    });
+  });
+
+  it("resets the settings an update leaves out", async () => {
+    // Given a pool created with all of those settings, and one of the
+    // settings this simulation accepts without acting on.
+    const cognito = new SimAws().cognitoIdentityProvider();
+    const created = await cognito.createUserPool(
+      new CreateUserPoolCommand({
+        PoolName: "myapp-users",
+        ...createdSettings,
+        EmailVerificationSubject: "Verify your new account",
+      }),
+    );
+    const userPoolId = created.UserPool?.Id;
+
+    // When an update names only the deletion protection.
+    await cognito.updateUserPool(
+      new UpdateUserPoolCommand({
+        UserPoolId: userPoolId,
+        DeletionProtection: "INACTIVE",
+      }),
+    );
+
+    // Then the settings it left out are back at the defaults CreateUserPool
+    // would have given them, because an update replaces rather than merges.
+    const described = await cognito.describeUserPool(
+      new DescribeUserPoolCommand({ UserPoolId: userPoolId }),
+    );
+
+    assertNonNullable(described.UserPool);
+    assertObjectMatches(described.UserPool, {
+      Policies: { PasswordPolicy: { MinimumLength: 8, RequireSymbols: true } },
+      DeletionProtection: "INACTIVE",
+      AdminCreateUserConfig: { AllowAdminCreateUserOnly: false },
+    });
+    assertUndefined(described.UserPool.AutoVerifiedAttributes);
+    assertUndefined(described.UserPool.EmailVerificationSubject);
+
+    // And the pool keeps the name it was created with, which is not a setting
+    // an update carries.
+    assertIdentical(described.UserPool.Name, "myapp-users");
+  });
+
+  it("replaces the Lambda triggers a pool runs", async () => {
+    // Given a pool created with a PreAuthentication trigger.
+    const cognito = new SimAws().cognitoIdentityProvider();
+    const created = await cognito.createUserPool(
+      new CreateUserPoolCommand({
+        PoolName: "myapp-users",
+        LambdaConfig: {
+          PreAuthentication: "arn:aws:lambda:us-east-1:111111111111:function:a",
+        },
+      }),
+    );
+    const userPoolId = created.UserPool?.Id;
+
+    // When an update names a PostAuthentication trigger and nothing else.
+    await cognito.updateUserPool(
+      new UpdateUserPoolCommand({
+        UserPoolId: userPoolId,
+        LambdaConfig: {
+          PostAuthentication:
+            "arn:aws:lambda:us-east-1:111111111111:function:b",
+        },
+      }),
+    );
+
+    // Then the pool runs that trigger and no longer runs the first, because
+    // the whole LambdaConfig is replaced.
+    const described = await cognito.describeUserPool(
+      new DescribeUserPoolCommand({ UserPoolId: userPoolId }),
+    );
+
+    assertNonNullable(described.UserPool);
+    assertObjectEquals(described.UserPool.LambdaConfig, {
+      PostAuthentication: "arn:aws:lambda:us-east-1:111111111111:function:b",
+    });
+  });
+
+  it("reports when the pool was last updated", async () => {
+    // Given a pool created twenty minutes ago, on a clock held still so the
+    // dates are exactly the twenty minutes apart.
+    const simAws = new SimAws();
+    const cognito = simAws.cognitoIdentityProvider();
+
+    simAws.clock().freeze();
+
+    const created = await cognito.createUserPool(
+      new CreateUserPoolCommand({ PoolName: "myapp-users" }),
+    );
+    const userPoolId = created.UserPool?.Id;
+
+    await simAws.clock().advanceBy({ minutes: 20 });
+
+    // When it is updated.
+    await cognito.updateUserPool(
+      new UpdateUserPoolCommand({
+        UserPoolId: userPoolId,
+        DeletionProtection: "ACTIVE",
+      }),
+    );
+
+    // Then it reports the update as its LastModifiedDate, and its creation
+    // date is unchanged.
+    const described = await cognito.describeUserPool(
+      new DescribeUserPoolCommand({ UserPoolId: userPoolId }),
+    );
+    const creationTime = created.UserPool?.CreationDate?.getTime();
+
+    assertNonNullable(creationTime);
+    assertIdentical(described.UserPool?.CreationDate?.getTime(), creationTime);
+    assertIdentical(
+      described.UserPool.LastModifiedDate?.getTime(),
+      creationTime + 20 * 60 * 1000,
+    );
+
+    // And a listed pool reports the same, as ListUserPools reports both dates.
+    const listed = await cognito.listUserPools(
+      new ListUserPoolsCommand({ MaxResults: 10 }),
+    );
+
+    assertIdentical(
+      listed.UserPools?.[0]?.LastModifiedDate?.getTime(),
+      creationTime + 20 * 60 * 1000,
+    );
+  });
+
+  it("reports the creation date for a pool never updated", async () => {
+    // Given a pool nothing has changed since it was created.
+    const simAws = new SimAws();
+    const cognito = simAws.cognitoIdentityProvider();
+
+    simAws.clock().freeze();
+
+    const created = await cognito.createUserPool(
+      new CreateUserPoolCommand({ PoolName: "myapp-users" }),
+    );
+
+    await simAws.clock().advanceBy({ minutes: 20 });
+
+    // When it is described and listed.
+    const described = await cognito.describeUserPool(
+      new DescribeUserPoolCommand({ UserPoolId: created.UserPool?.Id }),
+    );
+    const listed = await cognito.listUserPools(
+      new ListUserPoolsCommand({ MaxResults: 10 }),
+    );
+
+    // Then both report its creation date as the last modified date, rather
+    // than the time they were asked.
+    const creationTime = created.UserPool?.CreationDate?.getTime();
+
+    assertNonNullable(creationTime);
+    assertIdentical(
+      described.UserPool?.LastModifiedDate?.getTime(),
+      creationTime,
+    );
+    assertIdentical(
+      listed.UserPools?.[0]?.LastModifiedDate?.getTime(),
+      creationTime,
+    );
+  });
+
+  it("deletes a pool an update has unprotected", async () => {
+    // Given a pool created with deletion protection active.
+    const cognito = new SimAws().cognitoIdentityProvider();
+    const created = await cognito.createUserPool(
+      new CreateUserPoolCommand({
+        PoolName: "myapp-users",
+        DeletionProtection: "ACTIVE",
+      }),
+    );
+    const userPoolId = created.UserPool?.Id;
+
+    assertTypeString(userPoolId);
+
+    // And deleting it refused, saying to deactivate the protection first.
+    const protectedError = await assertThrowsErrorAsync(async () => {
+      await cognito.deleteUserPool(
+        new DeleteUserPoolCommand({ UserPoolId: userPoolId }),
+      );
+    });
+
+    assertStringIncludes(protectedError.message, "UpdateUserPool");
+
+    // When the protection is deactivated and the pool deleted.
+    await cognito.updateUserPool(
+      new UpdateUserPoolCommand({
+        UserPoolId: userPoolId,
+        DeletionProtection: "INACTIVE",
+      }),
+    );
+    await cognito.deleteUserPool(
+      new DeleteUserPoolCommand({ UserPoolId: userPoolId }),
+    );
+
+    // Then it is gone.
+    const listed = await cognito.listUserPools(
+      new ListUserPoolsCommand({ MaxResults: 10 }),
+    );
+
+    assertIdentical(listed.UserPools?.length, 0);
+  });
+});

--- a/src/service/cognito/command/user-pool/sim-cognito-user-pool-commands.iso.test.ts
+++ b/src/service/cognito/command/user-pool/sim-cognito-user-pool-commands.iso.test.ts
@@ -167,9 +167,14 @@ describe("sim Cognito user pool commands", () => {
       );
     });
 
-    // Then it is refused, as real Cognito refuses it.
+    // Then it is refused, as real Cognito refuses it, and the refusal says to
+    // deactivate the protection with UpdateUserPool first.
     assertIdentical(error.name, "InvalidParameterException");
     assertStringIncludes(error.message, "protected against deletion");
+    assertStringIncludes(
+      error.message,
+      "UpdateUserPool request with a DeletionProtection of INACTIVE",
+    );
   });
 
   it("keeps pools in one account and region out of another", async () => {

--- a/src/service/cognito/command/user-pool/sim-cognito-user-pool-commands.ts
+++ b/src/service/cognito/command/user-pool/sim-cognito-user-pool-commands.ts
@@ -2,9 +2,12 @@ import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
 import { SimCognitoInvalidParameterException } from "../../error/sim-cognito.error.js";
 import type { SimCognitoUserPoolFactory } from "../../user-pool/sim-cognito-user-pool-factory.js";
 import { requireSimCognitoUserPoolId } from "../../user-pool/sim-cognito-user-pool-id.js";
+import { SimCognitoUserPoolSettings } from "../../user-pool/sim-cognito-user-pool-settings.js";
 import type { SimCognitoUserPoolStore } from "../../user-pool/sim-cognito-user-pool-store.js";
 import type { SimCognitoAuthorizer } from "../authorize/sim-cognito-authorizer.js";
+import { SimCognitoUnsimulatedUserPoolIdentity } from "./sim-cognito-unsimulated-pool-identity.js";
 import { SimCognitoUnsimulatedUserPoolOptions } from "./sim-cognito-unsimulated-pool-options.js";
+import { SimCognitoUnsimulatedUserPoolUpdates } from "./sim-cognito-unsimulated-pool-updates.js";
 import { SimCognitoUserPoolView } from "./sim-cognito-user-pool-view.js";
 import type {
   SimCreateUserPoolCommand,
@@ -13,6 +16,8 @@ import type {
   SimDeleteUserPoolCommandOutput,
   SimDescribeUserPoolCommand,
   SimDescribeUserPoolCommandOutput,
+  SimUpdateUserPoolCommand,
+  SimUpdateUserPoolCommandOutput,
 } from "./user-pool.command.js";
 
 interface SimCognitoUserPoolCommandsProperties {
@@ -26,7 +31,8 @@ interface SimCognitoCommandOptions {
 }
 
 /**
- * The commands that create, describe and delete a simulated user pool.
+ * The commands that create, describe, change and delete a simulated user
+ * pool.
  */
 export class SimCognitoUserPoolCommands {
   private readonly pools: SimCognitoUserPoolStore;
@@ -34,7 +40,11 @@ export class SimCognitoUserPoolCommands {
   private readonly authorizer: SimCognitoAuthorizer;
   private readonly view = new SimCognitoUserPoolView();
   private readonly unsimulatedOptions =
-    new SimCognitoUnsimulatedUserPoolOptions();
+    new SimCognitoUnsimulatedUserPoolOptions("CreateUserPool");
+  private readonly unsimulatedIdentity =
+    new SimCognitoUnsimulatedUserPoolIdentity();
+  private readonly unsimulatedUpdates =
+    new SimCognitoUnsimulatedUserPoolUpdates();
 
   constructor(properties: SimCognitoUserPoolCommandsProperties) {
     this.pools = properties.pools;
@@ -55,21 +65,51 @@ export class SimCognitoUserPoolCommands {
     const { input } = command;
 
     this.authorizer.authorizeAny("cognito-idp:CreateUserPool", options?.caller);
+    this.unsimulatedIdentity.refuseIn(input);
     this.unsimulatedOptions.refuseIn(input);
 
     const pool = this.poolFactory.make({
       name: input.PoolName,
-      policies: input.Policies,
-      deletionProtection: input.DeletionProtection,
-      adminCreateUserConfig: input.AdminCreateUserConfig,
-      autoVerifiedAttributes: input.AutoVerifiedAttributes,
-      lambdaConfig: input.LambdaConfig,
-      unsimulatedSettings: input,
+      settings: input,
     });
 
     this.pools.add(pool);
 
     return { $metadata: {}, UserPool: this.view.describe(pool) };
+  }
+
+  /**
+   * Change a user pool's settings.
+   *
+   * The settings are replaced rather than merged, as real Cognito replaces
+   * them: a setting the request leaves out goes back to the default
+   * `CreateUserPool` would have given it. A request naming every setting it
+   * wants is the one that behaves the same here and on real AWS.
+   *
+   * Real `UpdateUserPool` answers with nothing, so `DescribeUserPool` is what
+   * reads the change back.
+   */
+  update(
+    command: SimUpdateUserPoolCommand,
+    options?: SimCognitoCommandOptions,
+  ): SimUpdateUserPoolCommandOutput {
+    const { input } = command;
+    const userPoolId = requireSimCognitoUserPoolId(input.UserPoolId);
+
+    this.authorizer.authorizeUserPool(
+      "cognito-idp:UpdateUserPool",
+      userPoolId,
+      options?.caller,
+    );
+    this.unsimulatedUpdates.refuseIn(input);
+
+    this.pools
+      .require(userPoolId)
+      .update(
+        new SimCognitoUserPoolSettings({ input, operation: "UpdateUserPool" }),
+      );
+
+    return { $metadata: {} };
   }
 
   /**
@@ -110,12 +150,11 @@ export class SimCognitoUserPoolCommands {
 
     const pool = this.pools.require(userPoolId);
 
-    if (pool.deletionProtection.isActive) {
+    if (pool.settings.deletionProtection.isActive) {
       throw new SimCognitoInvalidParameterException(
-        `User pool ${userPoolId} is protected against deletion. Real ` +
-          `Cognito wants an UpdateUserPool request deactivating the ` +
-          `protection first, which this simulation does not support, so ` +
-          `create the pool without DeletionProtection instead.`,
+        `User pool ${userPoolId} is protected against deletion. Send an ` +
+          `UpdateUserPool request with a DeletionProtection of INACTIVE ` +
+          `first, as real Cognito wants.`,
       );
     }
 

--- a/src/service/cognito/command/user-pool/sim-cognito-user-pool-view.ts
+++ b/src/service/cognito/command/user-pool/sim-cognito-user-pool-view.ts
@@ -33,16 +33,16 @@ export class SimCognitoUserPoolView {
       Id: pool.id,
       Name: pool.name,
       Arn: pool.arn.value,
-      Policies: { PasswordPolicy: pool.passwordPolicy.toOutput() },
-      DeletionProtection: pool.deletionProtection.value,
-      LambdaConfig: pool.lambdaConfig.toOutput(),
+      Policies: { PasswordPolicy: pool.settings.passwordPolicy.toOutput() },
+      DeletionProtection: pool.settings.deletionProtection.value,
+      LambdaConfig: pool.settings.lambdaConfig.toOutput(),
       MfaConfiguration: "OFF",
-      AdminCreateUserConfig: pool.adminCreateUserConfig.toOutput(),
-      AutoVerifiedAttributes: pool.autoVerifiedAttributes.toOutput(),
+      AdminCreateUserConfig: pool.settings.adminCreateUserConfig.toOutput(),
+      AutoVerifiedAttributes: pool.settings.autoVerifiedAttributes.toOutput(),
       EstimatedNumberOfUsers: pool.userCount,
       CreationDate: pool.creationDate,
       LastModifiedDate: pool.lastModifiedDate,
-      ...pool.unsimulatedSettings.toOutput(),
+      ...pool.settings.unsimulated.toOutput(),
     };
   }
 

--- a/src/service/cognito/command/user-pool/user-pool.command.ts
+++ b/src/service/cognito/command/user-pool/user-pool.command.ts
@@ -2,6 +2,7 @@ import type { SimResponseMetadata } from "../../../aws/metadata/response-metadat
 import type { SimCognitoAdminCreateUserConfigType } from "../../user-pool/sim-cognito-admin-create-user-config.js";
 import type { SimCognitoUserPoolPoliciesType } from "../../user-pool/sim-cognito-password-policy.js";
 import type { SimCognitoUnsimulatedPoolSettingsType } from "../../user-pool/sim-cognito-unsimulated-pool-settings.js";
+import type { SimCognitoUserPoolSettingsInput } from "../../user-pool/sim-cognito-user-pool-settings.js";
 import type { SimCognitoLambdaConfigType } from "../../user-pool/trigger/sim-cognito-lambda-config.js";
 
 /**
@@ -30,42 +31,41 @@ export interface SimCognitoUserPoolType extends SimCognitoUnsimulatedPoolSetting
 }
 
 /**
+ * The pool inputs `CreateUserPool` and `UpdateUserPool` both carry.
+ *
+ * Every input real Cognito accepts on both is named here, whether or not it
+ * is simulated, so a request carrying one this simulation does not model can
+ * be refused rather than silently ignored.
+ */
+export interface SimCognitoUserPoolCommandInput extends SimCognitoUserPoolSettingsInput {
+  readonly MfaConfiguration?: string | undefined;
+  readonly UserPoolTier?: string | undefined;
+  readonly DeviceConfiguration?: object | undefined;
+  readonly EmailConfiguration?: object | undefined;
+  readonly IssuerConfiguration?: object | undefined;
+  readonly KeyConfiguration?: object | undefined;
+  readonly SmsAuthenticationMessage?: string | undefined;
+  readonly SmsConfiguration?: object | undefined;
+  readonly UserAttributeUpdateSettings?: object | undefined;
+  readonly UserPoolAddOns?: object | undefined;
+  readonly UserPoolTags?: Readonly<Record<string, string>> | undefined;
+}
+
+/**
  * The CreateUserPool inputs this simulation reads, and the ones it refuses.
  *
- * Every input real Cognito accepts is named here, whether or not it is
- * simulated, so a request carrying one this simulation does not model can be
- * refused rather than silently ignored.
+ * The four beside the shared ones are the inputs only a creation carries.
+ * They decide how a pool identifies its users, and none of them can be
+ * changed afterwards on real Cognito either.
  *
  * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/cognito-identity-provider/command/CreateUserPoolCommand/
  */
-export interface SimCreateUserPoolCommandInput {
+export interface SimCreateUserPoolCommandInput extends SimCognitoUserPoolCommandInput {
   readonly PoolName?: string | undefined;
-  readonly Policies?: SimCognitoUserPoolPoliciesType | undefined;
-  readonly DeletionProtection?: string | undefined;
-  readonly MfaConfiguration?: string | undefined;
-  readonly UserPoolTier?: string | undefined;
-  readonly AccountRecoverySetting?: object | undefined;
-  readonly AdminCreateUserConfig?:
-    SimCognitoAdminCreateUserConfigType | undefined;
   readonly AliasAttributes?: readonly string[] | undefined;
-  readonly AutoVerifiedAttributes?: readonly string[] | undefined;
-  readonly DeviceConfiguration?: object | undefined;
-  readonly EmailConfiguration?: object | undefined;
-  readonly EmailVerificationMessage?: string | undefined;
-  readonly EmailVerificationSubject?: string | undefined;
-  readonly IssuerConfiguration?: object | undefined;
-  readonly KeyConfiguration?: object | undefined;
-  readonly LambdaConfig?: object | undefined;
   readonly Schema?: readonly object[] | undefined;
-  readonly SmsAuthenticationMessage?: string | undefined;
-  readonly SmsConfiguration?: object | undefined;
-  readonly SmsVerificationMessage?: string | undefined;
-  readonly UserAttributeUpdateSettings?: object | undefined;
   readonly UsernameAttributes?: readonly string[] | undefined;
   readonly UsernameConfiguration?: object | undefined;
-  readonly UserPoolAddOns?: object | undefined;
-  readonly UserPoolTags?: Readonly<Record<string, string>> | undefined;
-  readonly VerificationMessageTemplate?: object | undefined;
 }
 
 /**
@@ -93,6 +93,36 @@ export interface SimDescribeUserPoolCommandInput {
 
 export interface SimDescribeUserPoolCommandOutput {
   readonly UserPool?: SimCognitoUserPoolType | undefined;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * The UpdateUserPool inputs this simulation reads, and the ones it refuses.
+ *
+ * `PoolName` is among the refused ones. Real `UpdateUserPool` renames a pool
+ * with it, and nothing here does, so a request carrying it is refused rather
+ * than answered with a pool still under its old name.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/cognito-identity-provider/command/UpdateUserPoolCommand/
+ */
+export interface SimUpdateUserPoolCommandInput extends SimCognitoUserPoolCommandInput {
+  readonly UserPoolId?: string | undefined;
+  readonly PoolName?: string | undefined;
+}
+
+/**
+ * Minimal structural sim Cognito UpdateUserPool command.
+ */
+export interface SimUpdateUserPoolCommand {
+  readonly input: SimUpdateUserPoolCommandInput;
+}
+
+/**
+ * What `UpdateUserPool` answers with, which is nothing but the metadata: real
+ * Cognito reports no pool back, so a caller reads the change with
+ * `DescribeUserPool`.
+ */
+export interface SimUpdateUserPoolCommandOutput {
   readonly $metadata: SimResponseMetadata;
 }
 

--- a/src/service/cognito/command/user/sim-cognito-sign-up-commands.ts
+++ b/src/service/cognito/command/user/sim-cognito-sign-up-commands.ts
@@ -73,7 +73,7 @@ export class SimCognitoSignUpCommands {
     const { pool, client } = this.authResolver.client(input.ClientId);
 
     this.unsimulatedOptions.refuseInSignUp(input);
-    pool.adminCreateUserConfig.requireSelfServiceSignUp();
+    pool.settings.adminCreateUserConfig.requireSelfServiceSignUp();
 
     const username = requireSimCognitoUsername(input.Username);
 
@@ -82,10 +82,9 @@ export class SimCognitoSignUpCommands {
     const user = this.userFactory.signUp({
       username,
       attributes: input.UserAttributes,
-      password: new SimCognitoPasswordCheck(pool.passwordPolicy).require(
-        "Password",
-        input.Password,
-      ),
+      password: new SimCognitoPasswordCheck(
+        pool.settings.passwordPolicy,
+      ).require("Password", input.Password),
     });
 
     pool.addUser(user);
@@ -111,7 +110,7 @@ export class SimCognitoSignUpCommands {
     const user = this.signingUpUser(pool, client, input);
 
     user.confirmSignUp(input.ConfirmationCode);
-    user.verifyAttributes(pool.autoVerifiedAttributes.names);
+    user.verifyAttributes(pool.settings.autoVerifiedAttributes.names);
 
     return { $metadata: {} };
   }

--- a/src/service/cognito/command/user/sim-cognito-user-commands.ts
+++ b/src/service/cognito/command/user/sim-cognito-user-commands.ts
@@ -58,7 +58,7 @@ export class SimCognitoUserCommands {
       return undefined;
     }
 
-    return new SimCognitoPasswordCheck(pool.passwordPolicy).require(
+    return new SimCognitoPasswordCheck(pool.settings.passwordPolicy).require(
       "TemporaryPassword",
       temporaryPassword,
     );

--- a/src/service/cognito/command/user/sim-cognito-user-update-commands.ts
+++ b/src/service/cognito/command/user/sim-cognito-user-update-commands.ts
@@ -55,10 +55,9 @@ export class SimCognitoUserUpdateCommands {
       options,
     );
 
-    const password = new SimCognitoPasswordCheck(pool.passwordPolicy).require(
-      "Password",
-      input.Password,
-    );
+    const password = new SimCognitoPasswordCheck(
+      pool.settings.passwordPolicy,
+    ).require("Password", input.Password);
 
     user.setPassword(password, input.Permanent);
 

--- a/src/service/cognito/sdk/sim-cognito-sdk-command-router.iso.test.ts
+++ b/src/service/cognito/sdk/sim-cognito-sdk-command-router.iso.test.ts
@@ -17,6 +17,7 @@ describe("SimCognitoSdkCommandRouter", () => {
     assertArrayIncludesAll(names, [
       "CreateUserPoolCommand",
       "DescribeUserPoolCommand",
+      "UpdateUserPoolCommand",
       "DeleteUserPoolCommand",
       "ListUserPoolsCommand",
       "CreateUserPoolClientCommand",

--- a/src/service/cognito/sdk/sim-cognito-sdk-pool-routes.ts
+++ b/src/service/cognito/sdk/sim-cognito-sdk-pool-routes.ts
@@ -14,6 +14,7 @@ import type {
   SimCreateUserPoolCommand,
   SimDeleteUserPoolCommand,
   SimDescribeUserPoolCommand,
+  SimUpdateUserPoolCommand,
 } from "../command/user-pool/user-pool.command.js";
 import type { SimCognitoIdentityProvider } from "../sim-cognito-identity-provider.js";
 
@@ -37,6 +38,14 @@ export function simCognitoSdkPoolRoutes(
       async (command, context): Promise<unknown> =>
         await simCognito.describeUserPool(
           command as SimDescribeUserPoolCommand,
+          simSdkCallerOptions(context),
+        ),
+    ],
+    [
+      "UpdateUserPoolCommand",
+      async (command, context): Promise<unknown> =>
+        await simCognito.updateUserPool(
+          command as SimUpdateUserPoolCommand,
           simSdkCallerOptions(context),
         ),
     ],

--- a/src/service/cognito/sdk/sim-cognito-sdk-routing.iso.test.ts
+++ b/src/service/cognito/sdk/sim-cognito-sdk-routing.iso.test.ts
@@ -9,6 +9,7 @@ import {
   ListUserPoolClientsCommand,
   ListUserPoolsCommand,
   UpdateUserPoolClientCommand,
+  UpdateUserPoolCommand,
 } from "@aws-sdk/client-cognito-identity-provider";
 import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
 import { CreateFunctionCommand, InvokeCommand } from "@aws-sdk/client-lambda";
@@ -175,6 +176,16 @@ describe("Cognito SDK interception", () => {
         ClientId: clientId,
       }),
     );
+    await client.send(
+      new UpdateUserPoolCommand({
+        UserPoolId: userPoolId,
+        AutoVerifiedAttributes: ["email"],
+      }),
+    );
+
+    const describedPool = await client.send(
+      new DescribeUserPoolCommand({ UserPoolId: userPoolId }),
+    );
     const listedPools = await client.send(
       new ListUserPoolsCommand({ MaxResults: 10 }),
     );
@@ -198,6 +209,9 @@ describe("Cognito SDK interception", () => {
     assertIdentical(updatedClient.UserPoolClient?.AccessTokenValidity, 30);
     assertIdentical(describedClient.UserPoolClient?.ClientName, "web");
     assertIdentical(describedClient.UserPoolClient.AccessTokenValidity, 30);
+    assertArrayEquals(describedPool.UserPool?.AutoVerifiedAttributes, [
+      "email",
+    ]);
     assertArrayEquals(
       listedPools.UserPools?.map((listed) => listed.Name),
       ["myapp-users"],

--- a/src/service/cognito/sim-cognito-identity-provider.ts
+++ b/src/service/cognito/sim-cognito-identity-provider.ts
@@ -155,6 +155,17 @@ export class SimCognitoIdentityProvider extends SimCognitoUserDirectory {
   }
 
   /**
+   * Handle an UpdateUserPool Command from the SDK.
+   */
+  async updateUserPool(
+    command: simCognitoCommands.SimUpdateUserPoolCommand,
+    options?: SimCognitoIdentityProviderRequestOptions,
+  ): Promise<simCognitoCommands.SimUpdateUserPoolCommandOutput> {
+    await this.background.sequence();
+    return this.commands.userPools.update(command, options);
+  }
+
+  /**
    * Handle a DeleteUserPool Command from the SDK.
    */
   async deleteUserPool(

--- a/src/service/cognito/user-pool/sim-cognito-auto-verified-attributes.ts
+++ b/src/service/cognito/user-pool/sim-cognito-auto-verified-attributes.ts
@@ -32,9 +32,8 @@ export class SimCognitoAutoVerifiedAttributes {
   private static requireVerifiable(name: string): string {
     if (!verifiableAttributeNames.includes(name)) {
       throw new SimCognitoInvalidParameterException(
-        `CreateUserPool AutoVerifiedAttributes '${name}' is not an attribute ` +
-          `Cognito can verify. Only ${verifiableAttributeNames.join(" and ")} ` +
-          `can be`,
+        `AutoVerifiedAttributes '${name}' is not an attribute Cognito can ` +
+          `verify. Only ${verifiableAttributeNames.join(" and ")} can be`,
       );
     }
 

--- a/src/service/cognito/user-pool/sim-cognito-user-pool-factory.ts
+++ b/src/service/cognito/user-pool/sim-cognito-user-pool-factory.ts
@@ -1,25 +1,14 @@
 import type { SimClock } from "../../../util/clock/sim-clock.js";
 import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
-import {
-  SimCognitoAdminCreateUserConfig,
-  type SimCognitoAdminCreateUserConfigType,
-} from "./sim-cognito-admin-create-user-config.js";
-import { SimCognitoAutoVerifiedAttributes } from "./sim-cognito-auto-verified-attributes.js";
-import { SimCognitoDeletionProtection } from "./sim-cognito-deletion-protection.js";
 import { SimCognitoName } from "./sim-cognito-name.js";
-import {
-  SimCognitoPasswordPolicy,
-  type SimCognitoUserPoolPoliciesType,
-} from "./sim-cognito-password-policy.js";
 import { SimCognitoUserPool } from "./sim-cognito-user-pool.js";
 import { SimCognitoUserPoolArn } from "./sim-cognito-user-pool-arn.js";
 import { makeSimCognitoUserPoolId } from "./sim-cognito-user-pool-id.js";
 import {
-  SimCognitoUnsimulatedPoolSettings,
-  type SimCognitoUnsimulatedPoolSettingsType,
-} from "./sim-cognito-unsimulated-pool-settings.js";
+  SimCognitoUserPoolSettings,
+  type SimCognitoUserPoolSettingsInput,
+} from "./sim-cognito-user-pool-settings.js";
 import type { SimCognitoUserPoolStore } from "./sim-cognito-user-pool-store.js";
-import { SimCognitoLambdaConfig } from "./trigger/sim-cognito-lambda-config.js";
 
 interface SimCognitoUserPoolFactoryProperties {
   readonly accountRegionScope: SimAwsAccountRegionScope;
@@ -29,23 +18,11 @@ interface SimCognitoUserPoolFactoryProperties {
 
 interface SimCognitoMakeUserPoolProperties {
   readonly name: string | undefined;
-  readonly policies?: SimCognitoUserPoolPoliciesType | undefined;
-  readonly deletionProtection?: string | undefined;
-  readonly adminCreateUserConfig?:
-    SimCognitoAdminCreateUserConfigType | undefined;
-  readonly autoVerifiedAttributes?: readonly string[] | undefined;
 
   /**
-   * The Lambda triggers the request asked the pool to run.
+   * The `CreateUserPool` request the pool's settings are read out of.
    */
-  readonly lambdaConfig?: object | undefined;
-
-  /**
-   * The settings the request set that this simulation accepts without acting
-   * on, which a described pool reports back.
-   */
-  readonly unsimulatedSettings?:
-    SimCognitoUnsimulatedPoolSettingsType | undefined;
+  readonly settings: SimCognitoUserPoolSettingsInput;
 }
 
 /**
@@ -85,23 +62,11 @@ export class SimCognitoUserPoolFactory {
         field: "PoolName",
         value: properties.name,
       }),
-      passwordPolicy: new SimCognitoPasswordPolicy(
-        properties.policies?.PasswordPolicy,
-      ),
-      deletionProtection: new SimCognitoDeletionProtection(
-        properties.deletionProtection,
-      ),
-      adminCreateUserConfig: new SimCognitoAdminCreateUserConfig(
-        properties.adminCreateUserConfig,
-      ),
-      autoVerifiedAttributes: new SimCognitoAutoVerifiedAttributes(
-        properties.autoVerifiedAttributes,
-      ),
-      lambdaConfig: new SimCognitoLambdaConfig(properties.lambdaConfig),
-      unsimulatedSettings: new SimCognitoUnsimulatedPoolSettings(
-        properties.unsimulatedSettings ?? {},
-      ),
-      createdDate: this.clock.now(),
+      settings: new SimCognitoUserPoolSettings({
+        input: properties.settings,
+        operation: "CreateUserPool",
+      }),
+      clock: this.clock,
     });
   }
 }

--- a/src/service/cognito/user-pool/sim-cognito-user-pool-settings.ts
+++ b/src/service/cognito/user-pool/sim-cognito-user-pool-settings.ts
@@ -1,0 +1,92 @@
+import {
+  SimCognitoAdminCreateUserConfig,
+  type SimCognitoAdminCreateUserConfigType,
+} from "./sim-cognito-admin-create-user-config.js";
+import { SimCognitoAutoVerifiedAttributes } from "./sim-cognito-auto-verified-attributes.js";
+import { SimCognitoDeletionProtection } from "./sim-cognito-deletion-protection.js";
+import {
+  SimCognitoPasswordPolicy,
+  type SimCognitoUserPoolPoliciesType,
+} from "./sim-cognito-password-policy.js";
+import {
+  SimCognitoUnsimulatedPoolSettings,
+  type SimCognitoUnsimulatedPoolSettingsType,
+} from "./sim-cognito-unsimulated-pool-settings.js";
+import { SimCognitoLambdaConfig } from "./trigger/sim-cognito-lambda-config.js";
+
+/**
+ * The pool settings a request can set, in the shape the SDK sends them.
+ *
+ * `CreateUserPool` and `UpdateUserPool` both carry these, which is what lets
+ * an update build a pool's settings the same way a creation does.
+ */
+export interface SimCognitoUserPoolSettingsInput extends SimCognitoUnsimulatedPoolSettingsType {
+  readonly Policies?: SimCognitoUserPoolPoliciesType | undefined;
+  readonly DeletionProtection?: string | undefined;
+  readonly AdminCreateUserConfig?:
+    SimCognitoAdminCreateUserConfigType | undefined;
+  readonly AutoVerifiedAttributes?: readonly string[] | undefined;
+  readonly LambdaConfig?: object | undefined;
+}
+
+interface SimCognitoUserPoolSettingsProperties {
+  readonly input: SimCognitoUserPoolSettingsInput;
+
+  /**
+   * The operation reading these settings, which its refusals name:
+   * `CreateUserPool` or `UpdateUserPool`.
+   */
+  readonly operation: string;
+}
+
+/**
+ * The settings of one simulated user pool that a request can change.
+ *
+ * The pool's id, ARN and name are not among them. The first two identify the
+ * pool, and renaming one is not simulated.
+ *
+ * A setting the request leaves out takes the default real Cognito applies to
+ * a pool that never asked for it. That is what makes `UpdateUserPool` replace
+ * rather than merge: an update builds a whole configuration out of its own
+ * request, and the pool swaps to it, so a setting the update is silent about
+ * goes back to its default rather than staying as it was.
+ */
+export class SimCognitoUserPoolSettings {
+  public readonly passwordPolicy: SimCognitoPasswordPolicy;
+  public readonly deletionProtection: SimCognitoDeletionProtection;
+  public readonly adminCreateUserConfig: SimCognitoAdminCreateUserConfig;
+  public readonly autoVerifiedAttributes: SimCognitoAutoVerifiedAttributes;
+
+  /**
+   * The Lambda triggers the pool runs, by the ARN of the function each names.
+   */
+  public readonly lambdaConfig: SimCognitoLambdaConfig;
+
+  /**
+   * What the request set that nothing here acts on, kept so a described pool
+   * reports it.
+   */
+  public readonly unsimulated: SimCognitoUnsimulatedPoolSettings;
+
+  constructor(properties: SimCognitoUserPoolSettingsProperties) {
+    const { input, operation } = properties;
+
+    this.passwordPolicy = new SimCognitoPasswordPolicy(
+      input.Policies?.PasswordPolicy,
+    );
+    this.deletionProtection = new SimCognitoDeletionProtection(
+      input.DeletionProtection,
+    );
+    this.adminCreateUserConfig = new SimCognitoAdminCreateUserConfig(
+      input.AdminCreateUserConfig,
+    );
+    this.autoVerifiedAttributes = new SimCognitoAutoVerifiedAttributes(
+      input.AutoVerifiedAttributes,
+    );
+    this.lambdaConfig = new SimCognitoLambdaConfig(
+      input.LambdaConfig,
+      operation,
+    );
+    this.unsimulated = new SimCognitoUnsimulatedPoolSettings(input);
+  }
+}

--- a/src/service/cognito/user-pool/sim-cognito-user-pool.ts
+++ b/src/service/cognito/user-pool/sim-cognito-user-pool.ts
@@ -1,3 +1,4 @@
+import type { SimClock } from "../../../util/clock/sim-clock.js";
 import { SimCognitoPoolAuth } from "./auth/sim-cognito-pool-auth.js";
 import type { SimCognitoUserPoolClient } from "./client/sim-cognito-user-pool-client.js";
 import type { SimCognitoUserPoolClientId } from "./client/sim-cognito-user-pool-client-id.js";
@@ -5,19 +6,14 @@ import { SimCognitoUserPoolClientStore } from "./client/sim-cognito-user-pool-cl
 import type { SimCognitoGroup } from "./group/sim-cognito-group.js";
 import type { SimCognitoGroupName } from "./group/sim-cognito-group-name.js";
 import { SimCognitoGroupStore } from "./group/sim-cognito-group-store.js";
-import type { SimCognitoAdminCreateUserConfig } from "./sim-cognito-admin-create-user-config.js";
-import type { SimCognitoAutoVerifiedAttributes } from "./sim-cognito-auto-verified-attributes.js";
-import type { SimCognitoDeletionProtection } from "./sim-cognito-deletion-protection.js";
 import type { SimCognitoName } from "./sim-cognito-name.js";
-import type { SimCognitoPasswordPolicy } from "./sim-cognito-password-policy.js";
 import type { SimCognitoUserPoolArn } from "./sim-cognito-user-pool-arn.js";
 import {
   simCognitoUserPoolIssuerUrl,
   simCognitoUserPoolProviderName,
   type SimCognitoUserPoolId,
 } from "./sim-cognito-user-pool-id.js";
-import type { SimCognitoUnsimulatedPoolSettings } from "./sim-cognito-unsimulated-pool-settings.js";
-import type { SimCognitoLambdaConfig } from "./trigger/sim-cognito-lambda-config.js";
+import type { SimCognitoUserPoolSettings } from "./sim-cognito-user-pool-settings.js";
 import {
   SimCognitoSigningKey,
   type SimCognitoJwks,
@@ -33,13 +29,8 @@ interface SimCognitoUserPoolProperties {
   readonly id: SimCognitoUserPoolId;
   readonly arn: SimCognitoUserPoolArn;
   readonly name: SimCognitoName;
-  readonly passwordPolicy: SimCognitoPasswordPolicy;
-  readonly deletionProtection: SimCognitoDeletionProtection;
-  readonly adminCreateUserConfig: SimCognitoAdminCreateUserConfig;
-  readonly autoVerifiedAttributes: SimCognitoAutoVerifiedAttributes;
-  readonly lambdaConfig: SimCognitoLambdaConfig;
-  readonly unsimulatedSettings: SimCognitoUnsimulatedPoolSettings;
-  readonly createdDate: Date;
+  readonly settings: SimCognitoUserPoolSettings;
+  readonly clock: SimClock;
 }
 
 /**
@@ -53,30 +44,6 @@ export class SimCognitoUserPool {
   public readonly id: SimCognitoUserPoolId;
   public readonly arn: SimCognitoUserPoolArn;
   public readonly name: string;
-  public readonly passwordPolicy: SimCognitoPasswordPolicy;
-  public readonly deletionProtection: SimCognitoDeletionProtection;
-
-  /**
-   * Whether users may sign themselves up in this pool.
-   */
-  public readonly adminCreateUserConfig: SimCognitoAdminCreateUserConfig;
-
-  /**
-   * The attributes confirming a sign-up marks as verified.
-   */
-  public readonly autoVerifiedAttributes: SimCognitoAutoVerifiedAttributes;
-
-  /**
-   * The Lambda triggers this pool runs, by the ARN of the function each names.
-   */
-  public readonly lambdaConfig: SimCognitoLambdaConfig;
-
-  /**
-   * What the pool was created with and nothing here acts on, kept so a
-   * described pool reports it.
-   */
-  public readonly unsimulatedSettings: SimCognitoUnsimulatedPoolSettings;
-
   public readonly creationDate: Date;
 
   /**
@@ -84,23 +51,45 @@ export class SimCognitoUserPool {
    */
   public readonly auth = new SimCognitoPoolAuth();
 
+  private readonly clock: SimClock;
   private readonly clientStore = new SimCognitoUserPoolClientStore();
   private readonly userStore = new SimCognitoUserStore();
   private readonly groupStore = new SimCognitoGroupStore();
 
+  #settings: SimCognitoUserPoolSettings;
+  #modifiedDate: Date;
   #signingKey: SimCognitoSigningKey | undefined;
 
   constructor(properties: SimCognitoUserPoolProperties) {
     this.id = properties.id;
     this.arn = properties.arn;
     this.name = properties.name.value;
-    this.passwordPolicy = properties.passwordPolicy;
-    this.deletionProtection = properties.deletionProtection;
-    this.adminCreateUserConfig = properties.adminCreateUserConfig;
-    this.autoVerifiedAttributes = properties.autoVerifiedAttributes;
-    this.lambdaConfig = properties.lambdaConfig;
-    this.unsimulatedSettings = properties.unsimulatedSettings;
-    this.creationDate = properties.createdDate;
+    this.#settings = properties.settings;
+    this.clock = properties.clock;
+    this.creationDate = this.clock.now();
+    this.#modifiedDate = this.creationDate;
+  }
+
+  /**
+   * The settings this pool applies: its password policy, its deletion
+   * protection, whether users may sign themselves up, and what confirming a
+   * sign-up verifies.
+   */
+  get settings(): SimCognitoUserPoolSettings {
+    return this.#settings;
+  }
+
+  /**
+   * Replace this pool's settings with the ones an update asked for.
+   *
+   * `UpdateUserPool` replaces rather than merges, as real Cognito does: the
+   * settings object is built from the update's own request, so a setting the
+   * request left out goes back to the default `CreateUserPool` would have
+   * given it rather than staying as it was.
+   */
+  update(settings: SimCognitoUserPoolSettings): void {
+    this.#settings = settings;
+    this.#modifiedDate = this.clock.now();
   }
 
   /** The URL a token from this pool names as its issuer. */
@@ -139,13 +128,13 @@ export class SimCognitoUserPool {
   }
 
   /**
-   * When the pool last changed.
+   * When the pool's settings last changed.
    *
-   * Nothing can change a pool here, as `UpdateUserPool` is not simulated, so
-   * this is its creation date.
+   * A pool no `UpdateUserPool` request has reached reports its creation date,
+   * as a real one does.
    */
   get lastModifiedDate(): Date {
-    return this.creationDate;
+    return this.#modifiedDate;
   }
 
   /**

--- a/src/service/cognito/user-pool/trigger/sim-cognito-lambda-config.ts
+++ b/src/service/cognito/user-pool/trigger/sim-cognito-lambda-config.ts
@@ -31,31 +31,21 @@ export interface SimCognitoLambdaConfigType {
  * and on real AWS.
  */
 export class SimCognitoLambdaConfig {
-  private readonly unsimulated = new SimCognitoUnsimulatedInput(
-    "CreateUserPool",
-  );
+  private readonly operation: string;
+  private readonly unsimulated: SimCognitoUnsimulatedInput;
   private readonly triggers = new Map<SimCognitoTriggerName, string>();
   private readonly configured: boolean;
 
-  constructor(config: object | undefined) {
+  constructor(config: object | undefined, operation: string) {
     const entries = Object.entries(config ?? {});
 
+    this.operation = operation;
+    this.unsimulated = new SimCognitoUnsimulatedInput(operation);
     this.configured = config !== undefined;
 
     for (const [key, value] of entries) {
       this.read(key, value);
     }
-  }
-
-  private static requireFunctionArn(key: string, value: unknown): string {
-    if (typeof value !== "string" || value === "") {
-      throw new SimCognitoInvalidParameterException(
-        `CreateUserPool LambdaConfig ${key} must be the ARN of the function ` +
-          `the trigger invokes`,
-      );
-    }
-
-    return value;
   }
 
   /**
@@ -104,7 +94,18 @@ export class SimCognitoLambdaConfig {
 
     this.triggers.set(
       key as SimCognitoTriggerName,
-      SimCognitoLambdaConfig.requireFunctionArn(key, value),
+      this.requireFunctionArn(key, value),
     );
+  }
+
+  private requireFunctionArn(key: string, value: unknown): string {
+    if (typeof value !== "string" || value === "") {
+      throw new SimCognitoInvalidParameterException(
+        `${this.operation} LambdaConfig ${key} must be the ARN of the ` +
+          `function the trigger invokes`,
+      );
+    }
+
+    return value;
   }
 }

--- a/src/service/cognito/user-pool/trigger/sim-cognito-user-pool-triggers.ts
+++ b/src/service/cognito/user-pool/trigger/sim-cognito-user-pool-triggers.ts
@@ -62,7 +62,7 @@ export class SimCognitoUserPoolTriggers {
     trigger: SimCognitoTriggerName,
     context: SimCognitoTriggerContext,
   ): Promise<void> {
-    const functionArn = context.pool.lambdaConfig.find(trigger);
+    const functionArn = context.pool.settings.lambdaConfig.find(trigger);
 
     if (functionArn === undefined) {
       return;


### PR DESCRIPTION
Resolves #451.

Two decisions worth a look:

- `PoolName` is refused on an update, so a pool cannot be renamed. Real `UpdateUserPool` accepts it, and the issue did not list it among the settings to cover, so it fails closed rather than being ignored.
- `LambdaConfig` is part of what an update replaces, which #451 put out of scope for #425. Once #450 landed, leaving it out would have meant an update omitting it kept the triggers here and cleared them on real AWS, which is the silent divergence the replace rule exists to avoid.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for updating simulated Cognito user pools.
  * Pool settings, password policies, deletion protection, verification options, and Lambda triggers can now be replaced through updates.
  * Updates refresh modification timestamps while preserving creation timestamps.
  * Deletion protection can be disabled before deleting a pool.
  * Added SDK routing, authorization checks, validation, and usage examples for pool updates.

* **Documentation**
  * Expanded guidance on supported update behavior, limitations, validation, and deletion protection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->