### PR TITLE
feat: close a simulated environment in one call

### DIFF
--- a/docs/serve/README.md
+++ b/docs/serve/README.md
@@ -53,9 +53,16 @@ await srv.close();
 
 ## Stopping and restarting
 
-`close()` stops serving and ends the connections the server is holding, so the process can exit. It
-returns a promise that settles once the last thing the server had to say has gone, so a script that
-means to exit rather than let the event loop empty has something to wait for. Yulin installs no
+`close()` stops serving and lets go of everything Yulin was holding, so the process can exit. That
+is the HTTP port, the DNS port and the connections the server is holding, and the simulated
+environment it was serving with them: the template files a deployment is
+[watching](../services/cloudformation/README.md#watching-a-template-file) and the directories a
+[mount](../services/s3/README.md#reloading-the-browser-when-the-directory-changes) is watching,
+in whichever Account and Region each of them lives in. One call, so a script that does not exit is
+not a hunt for the handle you missed.
+
+It returns a promise that settles once the last thing the server had to say has gone, so a script
+that means to exit rather than let the event loop empty has something to wait for. Yulin installs no
 signal handlers, since a library taking over process signals gets in the way of whatever else the
 process is doing. Call `close()` from your own handler:
 
@@ -78,6 +85,68 @@ process.on("SIGTERM", () => {
   void stopServing();
 });
 ```
+
+Closing twice does nothing twice, and closing a server whose environment started nothing is not an
+error. What is closed is the handles that keep the process alive: every simulated Bucket, Table and
+Stack is where it was, and the environment goes on working, so a script that closes and carries on
+can.
+
+An environment that is not being served has the same call on it. `simAws.close()` lets go of its
+template file watches and mounted directory watches, and a test with one of those has one line
+rather than a list:
+
+```typescript sim-serve-close-environment
+/**
+ * Letting go of what an unserved environment is holding.
+ */
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+await simAws.cloudFormation().deployTemplateFile({
+  templatePath: "cdk.out/TestStack.template.json",
+  watch: true,
+});
+
+// The Stack, and everything the template deployed, is still there afterwards.
+await simAws.close();
+```
+
+### Asking for a signal handler
+
+The handler above is yours to write, which is the point: your script decides what a signal means and
+in what order things happen. A script that wants nothing more than the usual can say so instead, and
+gets the same close on `SIGINT` and `SIGTERM`:
+
+```typescript sim-serve-close-on-signal
+/**
+ * Asking for the signal handler rather than writing one.
+ */
+
+import { SimAws } from "@kensio/yulin";
+import { serveSimAws } from "@kensio/yulin/serve";
+
+const simAws = new SimAws();
+const srv = await serveSimAws({ simAws, port: 8787, liveReload: true });
+
+// Build the simulated environment the pages are served from here.
+
+// Asking is the whole of it. The handler closes the server and the environment
+// it serves, and the process then exits on its own.
+const stopListening = srv.closeOnSignal();
+
+// A script that stops wanting the handler before the process ends takes it off
+// again:
+stopListening();
+```
+
+Nothing is installed until that call, so the default stands: a process that never asks keeps its
+signals to itself. `closeOnSignal({ signals: ["SIGHUP"] })` names other signals. The handlers come
+off as the first one arrives, so a second Ctrl-C from someone who has waited long enough lands on
+Node's own default and ends the process. Nothing here exits the process either: closing lets go of
+what Yulin was holding, and a process with nothing else to do then exits on its own. `SimAws` has
+the same method, for an environment that is not served.
 
 A restart usually overlaps the process it replaces. `listen` waits a couple of seconds for a pinned
 port that is still held, then throws `SimAwsLocalPortInUse` naming the port, which means something

--- a/docs/serve/sim-serve-close-environment.example.ts
+++ b/docs/serve/sim-serve-close-environment.example.ts
@@ -1,0 +1,15 @@
+/**
+ * Letting go of what an unserved environment is holding.
+ */
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+await simAws.cloudFormation().deployTemplateFile({
+  templatePath: "cdk.out/TestStack.template.json",
+  watch: true,
+});
+
+// The Stack, and everything the template deployed, is still there afterwards.
+await simAws.close();

--- a/docs/serve/sim-serve-close-on-signal.example.ts
+++ b/docs/serve/sim-serve-close-on-signal.example.ts
@@ -1,0 +1,19 @@
+/**
+ * Asking for the signal handler rather than writing one.
+ */
+
+import { SimAws } from "@kensio/yulin";
+import { serveSimAws } from "@kensio/yulin/serve";
+
+const simAws = new SimAws();
+const srv = await serveSimAws({ simAws, port: 8787, liveReload: true });
+
+// Build the simulated environment the pages are served from here.
+
+// Asking is the whole of it. The handler closes the server and the environment
+// it serves, and the process then exits on its own.
+const stopListening = srv.closeOnSignal();
+
+// A script that stops wanting the handler before the process ends takes it off
+// again:
+stopListening();

--- a/docs/services/cloudformation/README.md
+++ b/docs/services/cloudformation/README.md
@@ -1235,7 +1235,11 @@ writes.
 
 Watching holds a filesystem handle open, so the process does not exit on its own. That is what a dev
 process wants. Anything with an end, such as a test, calls `stopWatchingTemplateFiles()` when it is
-done. `watchedTemplateFiles()` names what is being watched.
+done. `watchedTemplateFiles()` names what is being watched. Both are per Account and Region, so a
+simulation deploying into more than one has one call each.
+[`simAws.close()`](../../serve/README.md#stopping-and-restarting) is the one that is not: it lets go
+of the template watches in every scope, along with everything else the environment is holding, and a
+served environment gets that from `srv.close()`.
 
 Yulin never synthesizes anything. It reads the output template, so run your own `cdk synth` and let
 the watch pick up what it writes.

--- a/docs/services/s3/README.md
+++ b/docs/services/s3/README.md
@@ -1547,6 +1547,9 @@ The watch is recursive, and holds an open filesystem handle, which keeps the pro
 process wants exactly that. Anything with an end, such as a test, calls
 `simAws.s3().stopWatchingMountedDirectories()` when it is done.
 `simAws.s3().watchedMountedDirectories()` says which directories are being watched.
+[`simAws.close()`](../../serve/README.md#stopping-and-restarting) is the one that does not need
+naming a service or a scope: it lets go of the mounted directory watches along with everything else
+the environment is holding, and a served environment gets that from `srv.close()`.
 
 Under [`yulin watch`](../../serve/README.md#restarting-on-a-file-change), a mount that reloads for
 itself is left alone by the supervisor: a rebuild reloads the page rather than restarting the

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,6 @@
 export { SimAws } from "./service/aws/sim-aws.js";
+export type { SimAwsClosing } from "./service/aws/sim-aws-closing.js";
+export type { SimCloseOnSignalOptions } from "./util/process/close-on-signal.js";
 export type { AwsRegionName } from "./service/aws/sim-aws-region.js";
 export {
   isSimAwsAccountId,

--- a/src/serve/http/local-server/sim-aws-local-server-close.loc.test.ts
+++ b/src/serve/http/local-server/sim-aws-local-server-close.loc.test.ts
@@ -1,0 +1,103 @@
+import { assertArrayEquals, assertIdentical } from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { serveSimAws } from "./sim-aws-local-server.js";
+import { SimAws } from "../../../service/aws/sim-aws.js";
+import { heldPause } from "../../../../test/aws/held-environment.js";
+import {
+  closingScript,
+  ServedProject,
+  signalledScript,
+} from "../../../../test/serve/served-project.js";
+
+/**
+ * One call for everything a served environment is holding open.
+ *
+ * The process is the assertion in most of this: a real script serving a real
+ * port, watching a real template file and a real directory, and then exiting on
+ * its own after one awaited close. Nothing else can say whether something was
+ * left holding the event loop.
+ */
+describe("closing a served simulated AWS environment", () => {
+  it("lets go of the watches the environment was holding", async () => {
+    // Given a served environment watching a template file and a mounted
+    // directory
+    const project = await ServedProject.of();
+    const simAws = new SimAws();
+    const srv = await serveSimAws({ simAws, port: 0 });
+    await project.hold(simAws, srv);
+
+    // When the server is closed, and nothing else is
+    await srv.close();
+
+    // Then the environment let go of what it was holding too, rather than
+    // leaving it for a second call
+    assertArrayEquals(simAws.cloudFormation().watchedTemplateFiles(), []);
+    assertArrayEquals(simAws.s3().watchedMountedDirectories(), []);
+  });
+
+  it("installs a signal handler only when it is asked for one", async () => {
+    // Given a served environment nobody has asked for a handler from
+    const project = await ServedProject.of();
+    const listening = process.listenerCount("SIGTERM");
+    const simAws = new SimAws();
+    const srv = await serveSimAws({ simAws, port: 0 });
+    await project.hold(simAws, srv);
+    assertIdentical(process.listenerCount("SIGTERM"), listening);
+
+    // When it is asked for one, and the process is asked to terminate
+    srv.closeOnSignal();
+    process.emit("SIGTERM");
+    await untilClosed(simAws);
+
+    // Then everything the served environment held has gone, and the handler
+    // with it
+    assertArrayEquals(simAws.cloudFormation().watchedTemplateFiles(), []);
+    assertIdentical(process.listenerCount("SIGTERM"), listening);
+  });
+
+  it("exits the process it was serving from", async () => {
+    // Given a script that serves an environment, deploys a watched template
+    // and mounts a watched directory, then awaits one close
+    const project = await ServedProject.of();
+    await project.writeScript(closingScript(project));
+
+    // When it is run as a process of its own
+    const run = await project.run();
+
+    // Then it got everything up, and then exited on its own, with nothing left
+    // holding the event loop open
+    assertIdentical(run.stdout.trim(), "watching 2\nclosed");
+    assertIdentical(run.code, 0);
+  });
+
+  it("exits on a signal it was asked to close for", async () => {
+    // Given the same script, having asked for a signal handler rather than
+    // writing one
+    const project = await ServedProject.of();
+    await project.writeScript(signalledScript(project));
+
+    // When the process is asked to terminate
+    const run = await project.run({ signal: "SIGTERM" });
+
+    // Then it closed what it was holding and exited, without the script having
+    // taken over the signal itself
+    assertIdentical(run.stdout.trim(), "watching 2\nclosed");
+    assertIdentical(run.code, 0);
+  });
+});
+
+/**
+ * Wait for a close nothing handed back a promise for, as a signal handler's is.
+ */
+async function untilClosed(simAws: SimAws, withinMs = 5000): Promise<void> {
+  const giveUpAt = Date.now() + withinMs;
+
+  while (simAws.s3().watchedMountedDirectories().length > 0) {
+    if (Date.now() >= giveUpAt) {
+      throw new Error("The served environment was not closed");
+    }
+
+    // eslint-disable-next-line no-await-in-loop -- polling for a close
+    await heldPause(10);
+  }
+}

--- a/src/serve/http/local-server/sim-aws-local-server.ts
+++ b/src/serve/http/local-server/sim-aws-local-server.ts
@@ -8,6 +8,10 @@ import { nodeServerPort } from "./node-server-port.js";
 import { SimAwsLocalRequestHandler } from "./sim-aws-local-request-handler.js";
 import { SimAwsDnsServer } from "../../dns/sim-aws-dns-server.js";
 import { SimLocalLiveReload } from "../live-reload/sim-local-live-reload.js";
+import {
+  closeOnSignal,
+  type SimCloseOnSignalOptions,
+} from "../../../util/process/close-on-signal.js";
 
 interface SimAwsLocalServerProperties {
   readonly simAws?: SimAws;
@@ -19,6 +23,7 @@ interface SimAwsLocalServerProperties {
  * Useful for local integration testing and local development.
  */
 export class SimAwsLocalServer {
+  private readonly simAws: SimAws;
   private readonly requestHandler: SimAwsLocalRequestHandler;
   private readonly server: Server;
   private readonly portBinder: NodeServerPortBinder;
@@ -27,6 +32,7 @@ export class SimAwsLocalServer {
 
   constructor(properties: SimAwsLocalServerProperties = {}) {
     const { simAws = new SimAws(), liveReload = false } = properties;
+    this.simAws = simAws;
     this.liveReload = new SimLocalLiveReload({ enabled: liveReload });
     const channel = this.liveReload.channel();
     this.requestHandler = new SimAwsLocalRequestHandler({
@@ -101,12 +107,19 @@ export class SimAwsLocalServer {
    * it. Local development restarts on that process exiting, so the connections
    * go.
    *
+   * The environment being served goes with it, so the template file watches
+   * and mounted directory watches it holds are let go of here rather than in a
+   * second call the script has to know to make. Everything Yulin was holding
+   * open is released by this one call, and the simulated state it was serving
+   * is left exactly where it was.
+   *
    * The order is what a browser needs. Both ports are let go first, so a
    * replacement process can have them however long the rest takes. Then the
-   * live reload streams are told a reload is coming and seen out, because a
-   * socket destroyed with bytes still in flight is reset, and a reset costs the
-   * browser the event it was just sent. Only what is left after that is
-   * destroyed.
+   * environment, so a watch cannot answer a change while the server it would
+   * reload is going. Then the live reload streams are told a reload is coming
+   * and seen out, because a socket destroyed with bytes still in flight is
+   * reset, and a reset costs the browser the event it was just sent. Only what
+   * is left after that is destroyed.
    *
    * Await it to know the last event has gone before leaving the process.
    */
@@ -114,9 +127,32 @@ export class SimAwsLocalServer {
     this.server.close();
     this.dnsServer.close();
 
+    await this.simAws.close();
     await this.liveReload.stopping();
 
     this.server.closeAllConnections();
+  }
+
+  /**
+   * Close this server, and the environment it serves, when the process is
+   * signalled.
+   *
+   * Nothing installs a signal handler unless it is asked to, since a library
+   * taking over process signals gets in the way of whatever else the process is
+   * doing. Asking looks like this:
+   *
+   * ```typescript
+   * srv.closeOnSignal();
+   * ```
+   *
+   * `SIGINT` and `SIGTERM` unless other signals are named. What comes back
+   * takes the handlers off again, for a script that stops wanting them before
+   * the process ends.
+   */
+  closeOnSignal(options: SimCloseOnSignalOptions = {}): () => void {
+    return closeOnSignal(async () => {
+      await this.close();
+    }, options);
   }
 
   /**

--- a/src/serve/index.ts
+++ b/src/serve/index.ts
@@ -6,6 +6,7 @@ export {
   SimAwsLocalServer,
 } from "./http/local-server/sim-aws-local-server.js";
 export { SimAwsLocalPortInUse } from "./http/local-server/sim-aws-local-port.error.js";
+export type { SimCloseOnSignalOptions } from "../util/process/close-on-signal.js";
 export { SimLiveReload } from "./http/live-reload/sim-live-reload.js";
 export {
   simLiveReloadConfig,

--- a/src/service/aws/scope/sim-aws-scope-registry.ts
+++ b/src/service/aws/scope/sim-aws-scope-registry.ts
@@ -87,4 +87,20 @@ export class SimAwsScopeRegistry {
 
     return accountRegionScope;
   }
+
+  /**
+   * Let go of everything the scopes in this registry are holding open.
+   *
+   * Every Account Region scope that has been reached for, rather than the
+   * default one alone, because a simulation deploying into a second Account or
+   * Region starts its watches there and they hold the process open just the
+   * same. A registry nothing has been asked of has nothing to close.
+   */
+  async close(): Promise<void> {
+    await Promise.all(
+      this.accountRegionScopes.values().map(async (accountRegionScope) => {
+        await accountRegionScope.close();
+      }),
+    );
+  }
 }

--- a/src/service/aws/sim-aws-account-region-scope.ts
+++ b/src/service/aws/sim-aws-account-region-scope.ts
@@ -1,6 +1,7 @@
 import type { SimAwsAccount, SimAwsAccountId } from "./sim-aws-account.js";
 import type { AwsRegionName, SimAwsRegion } from "./sim-aws-region.js";
 import { Memo } from "../../util/memo/memo.js";
+import { isSimAwsClosing } from "./sim-aws-closing.js";
 import { SimAws } from "./sim-aws.js";
 import type { SimS3 } from "../s3/sim-s3.js";
 import type { SimCloudFront } from "../cloudfront/sim-cloudfront.js";
@@ -211,6 +212,26 @@ export class SimAwsAccountRegionContainer {
   sts(): SimSts {
     return this.memo.getOrCreate("sts", () =>
       this.simAws.serviceFactory.createSts(this),
+    );
+  }
+
+  /**
+   * Let go of everything the services in this scope are holding open.
+   *
+   * Whatever this scope has made that closes is closed, so a service that
+   * starts holding a file or directory watch is let go of here without this
+   * having to be told about it. Services that were never asked for were never
+   * made and have nothing to let go of, so reading them here would only bring
+   * them into being.
+   */
+  async close(): Promise<void> {
+    await Promise.all(
+      this.memo
+        .values()
+        .filter((service) => isSimAwsClosing(service))
+        .map(async (service) => {
+          await service.close();
+        }),
     );
   }
 }

--- a/src/service/aws/sim-aws-close.loc.test.ts
+++ b/src/service/aws/sim-aws-close.loc.test.ts
@@ -1,0 +1,99 @@
+import {
+  assertArrayEquals,
+  assertArrayLength,
+  assertIdentical,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "./sim-aws.js";
+import { HeldEnvironment } from "../../../test/aws/held-environment.js";
+
+/**
+ * Closing a simulated environment, with the real handles that keep a process
+ * alive: a real template file being watched, a real directory being watched,
+ * and both of them in more than one Account and Region.
+ */
+describe("closing a simulated AWS environment", () => {
+  it("lets go of the watches in every scope it has reached", async () => {
+    // Given a simulation watching a template file and a mounted directory in
+    // its default scope and in another Account and Region
+    const held = await HeldEnvironment.of();
+    assertArrayLength(held.watchedPaths(), 4);
+
+    // When the environment is closed, once
+    await held.simAws.close();
+
+    // Then nothing is left holding the process open, in either scope
+    assertArrayEquals(held.watchedPaths(), []);
+  });
+
+  it("closes again without complaining", async () => {
+    // Given a simulation that has already been closed
+    const held = await HeldEnvironment.of();
+    await held.simAws.close();
+
+    // When it is closed again, as a script with two ways out of it does
+    await held.simAws.close();
+
+    // Then there was nothing left to close and nothing to say about it
+    assertArrayEquals(held.watchedPaths(), []);
+  });
+
+  it("closes an environment that started nothing", async () => {
+    // Given a simulation that never watched anything, and never even reached
+    // for the services that could have
+    const simAws = new SimAws();
+
+    // When it is closed
+    await simAws.close();
+
+    // Then it is not an error, and nothing was brought into being to close
+    assertArrayEquals(simAws.s3().watchedMountedDirectories(), []);
+    assertArrayEquals(simAws.cloudFormation().watchedTemplateFiles(), []);
+  });
+
+  it("closes a simulation whose services hold nothing", async () => {
+    // Given a simulation using services that never hold a handle open
+    const simAws = new SimAws();
+    await simAws.sqs().createQueue({ input: { QueueName: "work-to-do" } });
+
+    // When it is closed
+    await simAws.close();
+
+    // Then there was nothing to let go of, and the Queue is still there
+    const queues = await simAws.sqs().listQueues({ input: {} });
+    assertIdentical(queues.QueueUrls?.length, 1);
+  });
+
+  it("closes on a signal, for a script that asked for that", async () => {
+    // Given a simulation holding watches, which asked to be closed when the
+    // process is signalled rather than writing the handler itself
+    const held = await HeldEnvironment.of();
+    const listening = process.listenerCount("SIGTERM");
+    held.simAws.closeOnSignal();
+
+    // When the process is asked to terminate
+    process.emit("SIGTERM");
+    await held.untilClosed();
+
+    // Then everything it was holding has gone, and so has the handler
+    assertArrayEquals(held.watchedPaths(), []);
+    assertIdentical(process.listenerCount("SIGTERM"), listening);
+  });
+
+  it("leaves the simulated state it was serving where it was", async () => {
+    // Given a closed simulation that had deployed a Stack and mounted a Bucket
+    const held = await HeldEnvironment.of();
+    await held.simAws.close();
+
+    // When the environment is used afterwards
+    const stacks = await held.simAws
+      .cloudFormation()
+      .describeStacks({ input: {} });
+    const buckets = await held.simAws.s3().listBuckets({ input: {} });
+
+    // Then everything it holds is still there: closing let go of the handles
+    // that keep the process alive, not of the simulation
+    assertIdentical(stacks.Stacks?.length, 1);
+    assertIdentical(buckets.Buckets?.length, 1);
+  });
+});

--- a/src/service/aws/sim-aws-closing.ts
+++ b/src/service/aws/sim-aws-closing.ts
@@ -1,0 +1,26 @@
+/**
+ * A simulated service that is holding something the process cannot exit with.
+ *
+ * A watch on a file or a directory keeps the event loop alive, so whatever
+ * starts one has to be able to let it go again. Implementing this is what puts
+ * a service in the way of `SimAws.close()`: an Account Region scope closes
+ * whatever it made that closes, so a service that starts holding something
+ * needs nothing added anywhere else to be let go of with the rest.
+ */
+export interface SimAwsClosing {
+  /**
+   * Let go of everything this service is holding open.
+   *
+   * Simulated state is not discarded: this is about the handles that keep the
+   * process alive, not about resetting a simulation, and the service is as
+   * usable afterwards as it was before. Closing again is not an error.
+   */
+  close(): void | Promise<void>;
+}
+
+/**
+ * Whether a simulated service has anything to let go of when it is closed.
+ */
+export function isSimAwsClosing(value: object): value is SimAwsClosing {
+  return "close" in value && typeof value.close === "function";
+}

--- a/src/service/aws/sim-aws.ts
+++ b/src/service/aws/sim-aws.ts
@@ -28,6 +28,10 @@ import type {
 } from "./sim-aws-properties.js";
 import type { SimIamCredentialIdentity } from "../iam/credential/sim-aws-credentials.js";
 import type { SimAwsRequestCaller } from "../iam/request/sim-aws-request-caller.js";
+import {
+  closeOnSignal,
+  type SimCloseOnSignalOptions,
+} from "../../util/process/close-on-signal.js";
 
 /**
  * Top-level container for simulated AWS.
@@ -212,5 +216,46 @@ export class SimAws extends SimAwsServiceAccessors {
    */
   async backgroundTasksComplete(): Promise<void> {
     await this.background.complete();
+  }
+
+  /**
+   * Let go of everything this simulated environment is holding open.
+   *
+   * A watched template file and a watched mounted directory each hold an open
+   * filesystem handle, which keeps the process alive. This is the one call that
+   * releases all of them, in every Account and Region this simulation has
+   * reached, so a script that wants to exit has one thing to wait for rather
+   * than a list to keep up with. A served environment is closed by its server,
+   * so a script with one of those has nothing to call here.
+   *
+   * Simulated state is not discarded. Every Bucket, Table and Stack is where it
+   * was, and the environment goes on working: this is about the handles that
+   * keep the process alive, not about resetting a simulation. Closing an
+   * environment that started nothing is not an error, and closing again does
+   * nothing again.
+   */
+  async close(): Promise<void> {
+    await this.scopes.close();
+  }
+
+  /**
+   * Close this simulated environment when the process is signalled.
+   *
+   * Nothing installs a signal handler unless it is asked to, since a library
+   * taking over process signals gets in the way of whatever else the process is
+   * doing. Asking looks like this:
+   *
+   * ```typescript
+   * simAws.closeOnSignal();
+   * ```
+   *
+   * `SIGINT` and `SIGTERM` unless other signals are named. What comes back
+   * takes the handlers off again, for a script that stops wanting them before
+   * the process ends.
+   */
+  closeOnSignal(options: SimCloseOnSignalOptions = {}): () => void {
+    return closeOnSignal(async () => {
+      await this.close();
+    }, options);
   }
 }

--- a/src/service/cloudformation/README.md
+++ b/src/service/cloudformation/README.md
@@ -173,7 +173,7 @@ the stack was deployed with describes the assembly the previous template came fr
 updates the stack rather than needing the process restarted:
 
 - `SimCfnTemplateFileWatches` holds one watch per deployment, keyed by file and stack, and is what
-  `stopWatchingTemplateFiles()` lets go of. It is also where a deployment's `watch` property is
+  `stopWatchingTemplateFiles()`, and `close()` behind it, lets go of. It is also where a deployment's `watch` property is
   turned into what to do. Keying by deployment is what lets one file deployed as two stacks update
   both, while deploying the same stack again replaces its own watch.
 - `SimCfnTemplateFileWatch` watches the directory the template is in, filtered to the template's own

--- a/src/service/cloudformation/sim-cloudformation.ts
+++ b/src/service/cloudformation/sim-cloudformation.ts
@@ -259,6 +259,18 @@ export class SimCloudFormation {
   }
 
   /**
+   * Let go of everything this simulated CloudFormation is holding open.
+   *
+   * The template file watches, which is what `SimAws.close()` reaches to
+   * release when a simulated environment is closed as a whole. The Stacks and
+   * the resources they deployed are left where they are: this is the open
+   * filesystem handles going, not the deployment.
+   */
+  close(): void {
+    this.stopWatchingTemplateFiles();
+  }
+
+  /**
    * Get this service's SDK Command router for SDK client interception.
    */
   sdkCommandRouter(): SimSdkCommandRouter {

--- a/src/service/s3/README.md
+++ b/src/service/s3/README.md
@@ -269,7 +269,9 @@ The pieces are in `mount/`:
   it, while an unwatched one is a reported path as it always was.
 
 A recursive watch holds an open filesystem handle, so `SimS3.stopWatchingMountedDirectories()` is the
-way to let it go. A dev process never calls it; a test does.
+way to let it go. A dev process never calls it; a test does. `SimS3.close()` is the same thing under
+the name `SimAwsClosing` gives it, which is how `SimAws.close()` reaches these watches without
+knowing that S3 is where they live.
 
 Filesystem storage behaviour:
 

--- a/src/service/s3/sim-s3.ts
+++ b/src/service/s3/sim-s3.ts
@@ -267,6 +267,18 @@ export class SimS3 {
     this.bucketAccess.stopWatchingMounts();
   }
 
+  /**
+   * Let go of everything this simulated S3 is holding open.
+   *
+   * The mounted directory watches, which is what `SimAws.close()` reaches to
+   * release when a simulated environment is closed as a whole. The Buckets and
+   * the Objects in them are left where they are, mounts included: this is the
+   * open filesystem handles going, not the storage behind them.
+   */
+  close(): void {
+    this.stopWatchingMountedDirectories();
+  }
+
   /** Get this service's CloudFormation Resource factory. */
   cfnResourceFactory(): SimCfnServiceResourceFactory {
     return this.cfnFactory;

--- a/src/util/memo/memo.iso.test.ts
+++ b/src/util/memo/memo.iso.test.ts
@@ -1,6 +1,11 @@
 import { describe, it } from "vitest";
 import { Memo } from "./memo.js";
-import { assertFalse, assertIdentical, assertTrue } from "@kensio/smartass";
+import {
+  assertArrayEquals,
+  assertFalse,
+  assertIdentical,
+  assertTrue,
+} from "@kensio/smartass";
 
 describe("Memo", () => {
   it("creates and caches values", () => {
@@ -39,5 +44,15 @@ describe("Memo", () => {
     assertFalse(memo.has("key"));
     memo.getOrCreate("key", () => "value");
     assertTrue(memo.has("key"));
+  });
+
+  it("reads back what was created, without creating anything", () => {
+    const memo = new Memo<string>();
+
+    assertArrayEquals(memo.values(), []);
+    memo.getOrCreate("a", () => "first");
+    memo.getOrCreate("b", () => "second");
+
+    assertArrayEquals(memo.values(), ["first", "second"]);
   });
 });

--- a/src/util/memo/memo.ts
+++ b/src/util/memo/memo.ts
@@ -23,4 +23,15 @@ export class Memo<T> {
   has(key: PropertyKey): boolean {
     return this.cache.has(key);
   }
+
+  /**
+   * Returns what has been created so far, in the order it was created.
+   *
+   * Only what was actually asked for: reading this never makes anything, so a
+   * caller that wants to do something to everything memoized here does it to
+   * the things that exist rather than bringing the rest into being.
+   */
+  values(): readonly T[] {
+    return this.cache.values().toArray();
+  }
 }

--- a/src/util/process/close-on-signal.iso.test.ts
+++ b/src/util/process/close-on-signal.iso.test.ts
@@ -1,0 +1,128 @@
+import { assertArrayEquals, assertIdentical } from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { closeOnSignal } from "./close-on-signal.js";
+
+/**
+ * The signal handler nothing gets unless it asks for one.
+ */
+describe("closing on a signal", () => {
+  it("closes when the process is asked to stop", async () => {
+    // Given something that asked to be closed on a signal
+    const closed = new ClosingRecord();
+    closeOnSignal(closed.close);
+
+    // When the terminal is interrupted
+    process.emit("SIGINT");
+    await settled();
+
+    // Then it was closed
+    assertIdentical(closed.count(), 1);
+  });
+
+  it("closes for a termination signal as well", async () => {
+    // Given something that asked to be closed on a signal
+    const closed = new ClosingRecord();
+    closeOnSignal(closed.close);
+
+    // When the process is asked to terminate, as a supervisor asks
+    process.emit("SIGTERM");
+    await settled();
+
+    // Then it was closed
+    assertIdentical(closed.count(), 1);
+  });
+
+  it("hands the process back after the first signal", async () => {
+    // Given something that asked to be closed on a signal
+    const closed = new ClosingRecord();
+    const listening = signalListeners();
+    closeOnSignal(closed.close);
+
+    // When the same signal arrives twice, as it does from someone who has
+    // waited long enough and pressed Ctrl-C again
+    process.emit("SIGINT");
+    process.emit("SIGINT");
+    await settled();
+
+    // Then closing ran once, and the second signal landed on Node's own
+    // default rather than on a handler that would have held the process here
+    assertIdentical(closed.count(), 1);
+    assertArrayEquals(signalListeners(), listening);
+  });
+
+  it("takes the handlers off when it is asked to", async () => {
+    // Given something that asked to be closed on a signal, and then stopped
+    // wanting that before the process ended
+    const closed = new ClosingRecord();
+    const listening = signalListeners();
+    const stopListening = closeOnSignal(closed.close);
+
+    // When the handlers are taken off, and the signal arrives afterwards
+    stopListening();
+    process.emit("SIGTERM");
+    await settled();
+
+    // Then nothing was closed, and nothing is listening
+    assertIdentical(closed.count(), 0);
+    assertArrayEquals(signalListeners(), listening);
+  });
+
+  it("listens for the signals it was named, and no others", async () => {
+    // Given something that asked to be closed on one signal of its choosing
+    const closed = new ClosingRecord();
+    const stopListening = closeOnSignal(closed.close, { signals: ["SIGHUP"] });
+
+    // When a signal it did not name arrives
+    process.emit("SIGINT");
+    await settled();
+
+    // Then nothing was closed, and the signal it did name still closes it
+    assertIdentical(closed.count(), 0);
+    process.emit("SIGHUP");
+    await settled();
+    assertIdentical(closed.count(), 1);
+
+    stopListening();
+  });
+});
+
+/**
+ * Something to close, that says how many times it was closed.
+ */
+class ClosingRecord {
+  readonly close = async (): Promise<void> => {
+    this.closes += 1;
+    await Promise.resolve();
+  };
+
+  private closes = 0;
+
+  /**
+   * How many times closing has been asked for.
+   */
+  count(): number {
+    return this.closes;
+  }
+}
+
+/**
+ * How many listeners the signals are carrying, so a test can say a handler was
+ * installed and taken off again without assuming it was the only one.
+ */
+function signalListeners(): readonly number[] {
+  return [
+    process.listenerCount("SIGINT"),
+    process.listenerCount("SIGTERM"),
+    process.listenerCount("SIGHUP"),
+  ];
+}
+
+/**
+ * Let the close a signal handler started finish, since a handler cannot be
+ * awaited by whatever raised the signal.
+ */
+async function settled(): Promise<void> {
+  await new Promise((resolve) => {
+    setTimeout(resolve, 0);
+  });
+}

--- a/src/util/process/close-on-signal.ts
+++ b/src/util/process/close-on-signal.ts
@@ -1,0 +1,73 @@
+/**
+ * The signals a process is asked to stop with, when nothing else is said.
+ *
+ * Ctrl-C in a terminal, and the `SIGTERM` a supervisor or a container runtime
+ * sends. Any other signal a script wants handled it names for itself.
+ */
+const defaultSignals: readonly NodeJS.Signals[] = ["SIGINT", "SIGTERM"];
+
+export interface SimCloseOnSignalOptions {
+  /**
+   * The signals to close on, in place of `SIGINT` and `SIGTERM`.
+   */
+  readonly signals?: readonly NodeJS.Signals[];
+}
+
+/**
+ * A handler that closes something once, and then gets out of the way.
+ *
+ * The handlers come off as the first signal arrives, so closing runs once and a
+ * second Ctrl-C from someone who has waited long enough lands on Node's own
+ * default and ends the process. Nothing here exits the process: closing lets go
+ * of what was holding the event loop open, and a process with nothing else to
+ * do then exits on its own.
+ */
+class SimCloseOnSignal {
+  private readonly close: () => Promise<void>;
+  private readonly signals: readonly NodeJS.Signals[];
+
+  private readonly stopListening = (): void => {
+    for (const signal of this.signals) {
+      process.off(signal, this.handle);
+    }
+  };
+
+  private readonly handle = (): void => {
+    this.stopListening();
+    void this.close();
+  };
+
+  constructor(
+    close: () => Promise<void>,
+    options: SimCloseOnSignalOptions = {},
+  ) {
+    this.close = close;
+    this.signals = options.signals ?? defaultSignals;
+  }
+
+  /**
+   * Take the signals on, and hand back the way to give them up again.
+   */
+  listen(): () => void {
+    for (const signal of this.signals) {
+      process.on(signal, this.handle);
+    }
+
+    return this.stopListening;
+  }
+}
+
+/**
+ * Close something when the process is signalled, having been asked to.
+ *
+ * Yulin installs no signal handlers of its own, since a library taking over
+ * process signals gets in the way of whatever else the process is doing. This
+ * is how a script that wants one says so, and what comes back takes the
+ * handlers off again.
+ */
+export function closeOnSignal(
+  close: () => Promise<void>,
+  options: SimCloseOnSignalOptions = {},
+): () => void {
+  return new SimCloseOnSignal(close, options).listen();
+}

--- a/test/aws/held-environment.ts
+++ b/test/aws/held-environment.ts
@@ -1,0 +1,117 @@
+import { mkdir } from "node:fs/promises";
+import { SimAws } from "../../src/index.js";
+import type { SimAwsAccountRegionContainer } from "../../src/service/aws/sim-aws-account-region-scope.js";
+import { TemporaryDirectory } from "../../src/util/filesystem/temporary-directory.js";
+import { jsonStringify } from "../../src/util/type-guard/json.js";
+
+export const otherAccountId = "111111111111";
+export const otherRegionName = "eu-west-1";
+
+/**
+ * A simulation holding every kind of handle it can, in more than one scope.
+ *
+ * Real files and real watches, because the tests around closing are about the
+ * open filesystem handles that keep a process alive. Two Account and Region
+ * scopes, because a simulation that deploys into a second one starts its
+ * watches there too, and a close that only knew about the default scope would
+ * leave those holding the process open.
+ */
+export class HeldEnvironment {
+  readonly simAws = new SimAws();
+
+  private readonly directory = new TemporaryDirectory();
+
+  /**
+   * Deploy a watched template and mount a watched directory in both scopes.
+   */
+  static async of(): Promise<HeldEnvironment> {
+    const held = new HeldEnvironment();
+    await held.directory.writeFile(
+      "Stack.template.json",
+      jsonStringify({ Resources: {} }),
+    );
+
+    await held.hold(held.simAws.accountRegionScope(), "default");
+    await held.hold(held.otherScope(), "other");
+
+    return held;
+  }
+
+  /**
+   * Every path this simulation is watching, in either scope.
+   */
+  watchedPaths(): readonly string[] {
+    return [
+      ...this.scopeWatchedPaths(this.simAws.accountRegionScope()),
+      ...this.scopeWatchedPaths(this.otherScope()),
+    ];
+  }
+
+  /**
+   * Wait for a close nothing handed back a promise for, as a signal handler's
+   * is.
+   */
+  async untilClosed(withinMs = 5000): Promise<void> {
+    const giveUpAt = Date.now() + withinMs;
+
+    while (this.watchedPaths().length > 0) {
+      if (Date.now() >= giveUpAt) {
+        throw new Error(
+          `Still watching ${String(this.watchedPaths().length)} paths`,
+        );
+      }
+
+      // eslint-disable-next-line no-await-in-loop -- polling for a close
+      await heldPause(10);
+    }
+  }
+
+  private otherScope(): SimAwsAccountRegionContainer {
+    return this.simAws.account(otherAccountId).region(otherRegionName);
+  }
+
+  private async hold(
+    scope: SimAwsAccountRegionContainer,
+    name: string,
+  ): Promise<void> {
+    await scope.cloudFormation().deployTemplateFile({
+      templatePath: this.directory.join("Stack.template.json"),
+      stackName: `${name}-stack`,
+      watch: true,
+    });
+
+    const mountPath = await this.mountDirectory(name);
+    await scope.s3().createBucket({ input: { Bucket: `${name}-site` } });
+    scope.s3().mountBucketFilesystem(`${name}-site`, mountPath, {
+      reload: { reload: (): void => undefined },
+    });
+  }
+
+  private scopeWatchedPaths(
+    scope: SimAwsAccountRegionContainer,
+  ): readonly string[] {
+    return [
+      ...scope.cloudFormation().watchedTemplateFiles(),
+      ...scope.s3().watchedMountedDirectories(),
+    ];
+  }
+
+  private async mountDirectory(name: string): Promise<string> {
+    await this.directory.resolvePath();
+    const mountPath = this.directory.join(name, "public");
+
+    // eslint-disable-next-line security/detect-non-literal-fs-filename
+    await mkdir(mountPath, { recursive: true });
+
+    return mountPath;
+  }
+}
+
+/**
+ * Wait, for a test polling for something nothing handed it a promise for.
+ */
+export async function heldPause(milliseconds: number): Promise<void> {
+  await new Promise((resolve) => {
+    setTimeout(resolve, milliseconds);
+  });
+}

--- a/test/serve/served-project.ts
+++ b/test/serve/served-project.ts
@@ -1,0 +1,185 @@
+import { spawn } from "node:child_process";
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
+import type { SimAws } from "../../src/index.js";
+import { repoPath } from "../../src/util/filesystem/path.js";
+import { TemporaryDirectory } from "../../src/util/filesystem/temporary-directory.js";
+import { jsonStringify } from "../../src/util/type-guard/json.js";
+
+const yulin = repoPath("src/index.js");
+const yulinServe = repoPath("src/serve/index.js");
+const tsx = repoPath(path.join("node_modules", ".bin", "tsx"));
+
+/**
+ * How long a dev script is given to serve, hold and then close everything.
+ *
+ * A real process, spawned through `tsx`, importing what a dev script imports.
+ * Reaching it means something was left holding the event loop, so the wait is
+ * generous enough for a loaded CI runner and the failure is the point.
+ */
+const runTimeoutMs = 20_000;
+
+interface RunOptions {
+  readonly signal?: NodeJS.Signals;
+}
+
+export interface ScriptRun {
+  readonly stdout: string;
+  readonly stderr: string;
+  readonly code: number | null;
+}
+
+/**
+ * A throwaway project for a dev script that serves a simulated environment.
+ *
+ * The template and the mounted directory are real files, because what is being
+ * tested is the open filesystem handles a watch on them holds, and the script
+ * is run as a real process, because nothing else can say whether it exits.
+ */
+export class ServedProject {
+  private readonly directory = new TemporaryDirectory();
+
+  /**
+   * Write the files a served environment is built from.
+   */
+  static async of(): Promise<ServedProject> {
+    const project = new ServedProject();
+    await project.directory.writeFile(
+      "Stack.template.json",
+      jsonStringify({ Resources: {} }),
+    );
+    // eslint-disable-next-line security/detect-non-literal-fs-filename
+    await mkdir(project.mountPath(), { recursive: true });
+
+    return project;
+  }
+
+  /**
+   * The synthesized template a Stack is deployed from.
+   */
+  templatePath(): string {
+    return this.directory.join("Stack.template.json");
+  }
+
+  /**
+   * The built directory a Bucket is mounted on.
+   */
+  mountPath(): string {
+    return this.directory.join("public");
+  }
+
+  /**
+   * Deploy the watched template and mount the watched directory.
+   */
+  async hold(simAws: SimAws, reload: { reload: () => void }): Promise<void> {
+    await simAws
+      .cloudFormation()
+      .deployTemplateFile({ templatePath: this.templatePath(), watch: true });
+    await simAws.s3().createBucket({ input: { Bucket: "site" } });
+    simAws.s3().mountBucketFilesystem("site", this.mountPath(), { reload });
+  }
+
+  /**
+   * Write the dev script this project is run as.
+   */
+  async writeScript(source: string): Promise<void> {
+    await this.directory.writeFile("dev.ts", source);
+  }
+
+  /**
+   * Run the dev script as a process of its own, and wait for it to exit.
+   *
+   * A run that has to be killed is a failure rather than a result: the whole
+   * point of it is that the process ended on its own.
+   */
+  async run(options: RunOptions = {}): Promise<ScriptRun> {
+    const child = spawn(tsx, [this.directory.join("dev.ts")], {
+      cwd: this.directory.path(),
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const output = { stdout: "", stderr: "" };
+
+    child.stdout.setEncoding("utf8");
+    child.stdout.on("data", (chunk: string) => {
+      output.stdout += chunk;
+
+      if (options.signal !== undefined && output.stdout.includes("watching ")) {
+        child.kill(options.signal);
+      }
+    });
+
+    child.stderr.setEncoding("utf8");
+    child.stderr.on("data", (chunk: string) => {
+      output.stderr += chunk;
+    });
+
+    const giveUp = setTimeout(() => {
+      child.kill("SIGKILL");
+    }, runTimeoutMs);
+
+    const code = await new Promise<number | null>((resolve) => {
+      child.on("exit", resolve);
+    });
+    clearTimeout(giveUp);
+
+    if (code === null) {
+      throw new Error(
+        `The process did not exit on its own. It said: ${output.stdout} ${output.stderr}`,
+      );
+    }
+
+    return { ...output, code };
+  }
+}
+
+/**
+ * A dev script that closes what it is holding once, and is expected to end.
+ */
+export function closingScript(project: ServedProject): string {
+  return `${servingSource(project)}
+await srv.close();
+console.log("closed");
+`;
+}
+
+/**
+ * The same script, asking for the signal handler rather than writing one.
+ */
+export function signalledScript(project: ServedProject): string {
+  return `${servingSource(project)}
+srv.closeOnSignal();
+process.on("exit", () => {
+  console.log("closed");
+});
+`;
+}
+
+/**
+ * A dev script up to the point where it is holding everything Yulin can hold:
+ * a port, a DNS port, live reload, a watched template and a watched mount.
+ */
+function servingSource(project: ServedProject): string {
+  return `import { SimAws } from ${JSON.stringify(yulin)};
+import { serveSimAws } from ${JSON.stringify(yulinServe)};
+
+const simAws = new SimAws();
+const srv = await serveSimAws({ simAws, port: 0, liveReload: true });
+
+await simAws.cloudFormation().deployTemplateFile({
+  templatePath: ${JSON.stringify(project.templatePath())},
+  watch: true,
+});
+await simAws.s3().createBucket({ input: { Bucket: "site" } });
+simAws.s3().mountBucketFilesystem("site", ${JSON.stringify(project.mountPath())}, {
+  reload: srv,
+});
+
+console.log(
+  "watching " +
+    String(
+      simAws.cloudFormation().watchedTemplateFiles().length +
+        simAws.s3().watchedMountedDirectories().length,
+    ),
+);
+`;
+}


### PR DESCRIPTION
A dev script that serves a simulated environment had three separate things holding the event loop open, reached three different ways: the server, the template file watches on `SimCloudFormation`, and the mounted directory watches on `SimS3`. The last two are per Account and Region scope, and `SimAws` had no `close()` to join them up, so a script that closed the server and then did not exit went looking for the one it missed.

## What this adds

- `SimAws.close()` lets go of everything the environment is holding, in every Account and Region scope it has reached, not just the default one. Scopes are enumerated through `SimAwsScopeRegistry`, which is the only place they are made.
- A service declares that it holds something by implementing `SimAwsClosing`. `SimS3.close()` and `SimCloudFormation.close()` do, so an Account Region scope closes whatever it has made that closes, without a list of services to keep up with when the next holder arrives. Only services that were actually asked for exist to be closed, so closing never brings one into being.
- `SimAwsLocalServer.close()` closes the `SimAws` it was given, after the ports go and before the live reload streams are seen out, so a watch cannot answer a change while the server it would reload is going.
- `closeOnSignal()` on both `SimAws` and `SimAwsLocalServer`, for a script that wants the usual handler rather than writing one. Nothing is installed until that call, so the default of Yulin leaving process signals alone is kept. It returns the way to take the handlers off, and they come off as the first signal arrives so a second Ctrl-C lands on Node's own default.

Closing is idempotent, closing an environment that started nothing is not an error, and no simulated state is discarded: this is the handles that keep the process alive, not a reset.

## Tests

The acceptance test spawns a real process that serves an environment, deploys a watched template and mounts a watched directory, then awaits one close, and asserts the process exits on its own. A second one sends it `SIGTERM` after it asked for the handler. Both fail by hanging until they are killed without the change. Alongside those, in-process tests cover the watches going in two Account and Region scopes, idempotency, an environment that started nothing, and that the Stack and the Bucket are still there afterwards.

## Docs

`docs/serve/README.md` no longer tells consumers that closing the server is only half of stopping, and has a section on asking for the signal handler. The CloudFormation and S3 pages point at the one call from their own stop methods.

Resolves #434