### PR TITLE
test: scope UpdateUserPool IAM tests to one pool

### DIFF
--- a/docs/services/cognito/README.md
+++ b/docs/services/cognito/README.md
@@ -1760,7 +1760,8 @@ await cognito.deleteUserPool(new DeleteUserPoolCommand({ UserPoolId }));
 ```
 
 A pool reports the time of its last update as its `LastModifiedDate`, in `DescribeUserPool` and in
-`ListUserPools`. A pool no update has reached reports its creation date there.
+`ListUserPools`. A pool that has never been updated reports its creation date as its
+`LastModifiedDate`.
 
 ## Deletion protection
 

--- a/src/service/cognito/command/authorize/sim-cognito-iam.iso.test.ts
+++ b/src/service/cognito/command/authorize/sim-cognito-iam.iso.test.ts
@@ -5,7 +5,6 @@ import {
   DescribeUserPoolClientCommand,
   ListUserPoolsCommand,
   UpdateUserPoolClientCommand,
-  UpdateUserPoolCommand,
 } from "@aws-sdk/client-cognito-identity-provider";
 import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
 import {
@@ -123,57 +122,6 @@ describe("sim Cognito IAM authorization", () => {
     });
 
     // Then it is denied.
-    assertInstanceOf(error, SimIamAccessDenied);
-  });
-
-  it("allows an update to a pool the caller's policy names", async () => {
-    // Given a Role allowed to update one pool by its ARN.
-    const { simAws, caller, userPoolId } = await simCognitoWithRole({
-      Effect: "Allow",
-      Action: ["cognito-idp:UpdateUserPool", "cognito-idp:DescribeUserPool"],
-      Resource: userPoolArn("*"),
-    });
-
-    // When that Role updates the pool.
-    await simAws.cognitoIdentityProvider().updateUserPool(
-      new UpdateUserPoolCommand({
-        UserPoolId: userPoolId,
-        DeletionProtection: "ACTIVE",
-      }),
-      { caller },
-    );
-
-    // Then the request is allowed, and the change is there.
-    const described = await simAws
-      .cognitoIdentityProvider()
-      .describeUserPool(
-        new DescribeUserPoolCommand({ UserPoolId: userPoolId }),
-        { caller },
-      );
-
-    assertIdentical(described.UserPool?.DeletionProtection, "ACTIVE");
-  });
-
-  it("denies an update to a pool the caller may only read", async () => {
-    // Given a Role allowed to describe pools and nothing else.
-    const { simAws, caller, userPoolId } = await simCognitoWithRole({
-      Effect: "Allow",
-      Action: "cognito-idp:DescribeUserPool",
-      Resource: userPoolArn("*"),
-    });
-
-    // When that Role updates the pool.
-    const error = await assertThrowsErrorAsync(async () => {
-      await simAws.cognitoIdentityProvider().updateUserPool(
-        new UpdateUserPoolCommand({
-          UserPoolId: userPoolId,
-          DeletionProtection: "ACTIVE",
-        }),
-        { caller },
-      );
-    });
-
-    // Then it is denied, because UpdateUserPool is its own IAM action.
     assertInstanceOf(error, SimIamAccessDenied);
   });
 

--- a/src/service/cognito/command/authorize/sim-cognito-user-pool-update-iam.iso.test.ts
+++ b/src/service/cognito/command/authorize/sim-cognito-user-pool-update-iam.iso.test.ts
@@ -1,0 +1,135 @@
+import {
+  CreateUserPoolCommand,
+  DescribeUserPoolCommand,
+  UpdateUserPoolCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertThrowsErrorAsync,
+  assertTypeString,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+import { simIamRoleWithPolicyFactory } from "../../../iam/role/sim-iam-role-with-policy.factory.js";
+
+const accountId = "111111111111";
+const regionName = "eu-west-2";
+
+function userPoolArn(userPoolId: string): string {
+  return `arn:aws:cognito-idp:${regionName}:${accountId}:userpool/${userPoolId}`;
+}
+
+/**
+ * A simulated AWS with a pool in it, and the pool's id.
+ */
+async function simAwsWithPool(): Promise<{
+  readonly simAws: SimAws;
+  readonly userPoolId: string;
+}> {
+  const simAws = new SimAws({
+    defaultAccountId: accountId,
+    defaultRegionName: regionName,
+  });
+  const created = await simAws
+    .cognitoIdentityProvider()
+    .createUserPool(new CreateUserPoolCommand({ PoolName: "myapp-users" }));
+  const userPoolId = created.UserPool?.Id;
+
+  assertTypeString(userPoolId);
+
+  return { simAws, userPoolId };
+}
+
+describe("sim Cognito UpdateUserPool authorization", () => {
+  it("allows an update to the pool the caller's policy names", async () => {
+    // Given a Role allowed to update that pool alone, by its own ARN rather
+    // than by a wildcard, so the ARN this simulation authorizes against has to
+    // be the one a policy would really be written with.
+    const { simAws, userPoolId } = await simAwsWithPool();
+    const role = await simIamRoleWithPolicyFactory.make(
+      {
+        roleName: "PoolAdministrator",
+        actions: ["cognito-idp:UpdateUserPool", "cognito-idp:DescribeUserPool"],
+        resource: userPoolArn(userPoolId),
+      },
+      simAws,
+    );
+    const caller = { caller: { kind: "arn", arn: role.Arn } } as const;
+
+    // When that Role updates the pool.
+    await simAws.cognitoIdentityProvider().updateUserPool(
+      new UpdateUserPoolCommand({
+        UserPoolId: userPoolId,
+        DeletionProtection: "ACTIVE",
+      }),
+      caller,
+    );
+
+    // Then it is allowed, and the change is there.
+    const described = await simAws
+      .cognitoIdentityProvider()
+      .describeUserPool(
+        new DescribeUserPoolCommand({ UserPoolId: userPoolId }),
+        caller,
+      );
+
+    assertIdentical(described.UserPool?.DeletionProtection, "ACTIVE");
+  });
+
+  it("denies an update to a pool the policy names another of", async () => {
+    // Given a Role allowed everything on a different pool's ARN.
+    const { simAws, userPoolId } = await simAwsWithPool();
+    const role = await simIamRoleWithPolicyFactory.make(
+      {
+        roleName: "OtherPoolAdministrator",
+        actions: ["cognito-idp:*"],
+        resource: userPoolArn("eu-west-2_zZzZzZzZz"),
+      },
+      simAws,
+    );
+
+    // When that Role updates this one.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.cognitoIdentityProvider().updateUserPool(
+        new UpdateUserPoolCommand({
+          UserPoolId: userPoolId,
+          DeletionProtection: "ACTIVE",
+        }),
+        { caller: { kind: "arn", arn: role.Arn } },
+      );
+    });
+
+    // Then it is denied, because an update authorizes against the ARN of the
+    // pool it names.
+    assertInstanceOf(error, SimIamAccessDenied);
+  });
+
+  it("denies an update to a pool the caller may only read", async () => {
+    // Given a Role allowed to describe any pool and nothing else.
+    const { simAws, userPoolId } = await simAwsWithPool();
+    const role = await simIamRoleWithPolicyFactory.make(
+      {
+        roleName: "PoolReader",
+        actions: ["cognito-idp:DescribeUserPool"],
+        resource: userPoolArn("*"),
+      },
+      simAws,
+    );
+
+    // When that Role updates the pool.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.cognitoIdentityProvider().updateUserPool(
+        new UpdateUserPoolCommand({
+          UserPoolId: userPoolId,
+          DeletionProtection: "ACTIVE",
+        }),
+        { caller: { kind: "arn", arn: role.Arn } },
+      );
+    });
+
+    // Then it is denied, because UpdateUserPool is its own IAM action.
+    assertInstanceOf(error, SimIamAccessDenied);
+  });
+});

--- a/src/service/cognito/user-pool/sim-cognito-user-pool.ts
+++ b/src/service/cognito/user-pool/sim-cognito-user-pool.ts
@@ -130,8 +130,8 @@ export class SimCognitoUserPool {
   /**
    * When the pool's settings last changed.
    *
-   * A pool no `UpdateUserPool` request has reached reports its creation date,
-   * as a real one does.
+   * A pool that no `UpdateUserPool` request has reached reports its creation
+   * date, as a real one does.
    */
   get lastModifiedDate(): Date {
     return this.#modifiedDate;


### PR DESCRIPTION
Follow-ups from the review of #457, which merged before they were applied.

The UpdateUserPool authorization tests move into their own file so `sim-cognito-iam.iso.test.ts` stays under the 400 line limit, and they use `simIamRoleWithPolicyFactory` rather than that file's local role helper. The allowed case names the pool's own ARN instead of a wildcard, which is what makes it check that the ARN the simulator authorizes against is the one a policy would be written with.

Plus a plainer sentence for what `LastModifiedDate` reports on a pool no update has reached.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that user pools with no updates report their creation date as the last modified date in user pool details and listings.

* **Bug Fixes**
  * Improved authorization handling for user pool updates, including resource-specific permissions and required access levels.

* **Tests**
  * Added coverage for permitted and denied user pool update scenarios, including validation through user pool details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->