### PR TITLE
feat: add custom claims from a Cognito trigger

### DIFF
--- a/docs/services/cognito/README.md
+++ b/docs/services/cognito/README.md
@@ -922,13 +922,16 @@ try {
 A pool created with a `LambdaConfig` runs the functions it names as part of a sign-up or a sign-in.
 Each one is given the real event and has to return it, changed or not.
 
-| Trigger              | Fires                                                                  | `triggerSource`                     |
-| -------------------- | ---------------------------------------------------------------------- | ----------------------------------- |
-| `PreSignUp`          | `SignUp`, before the pool takes the new user                           | `PreSignUp_SignUp`                  |
-| `PreSignUp`          | `AdminCreateUser`, before the pool takes the new user                  | `PreSignUp_AdminCreateUser`         |
-| `PostConfirmation`   | `ConfirmSignUp` and `AdminConfirmSignUp`, once the user is `CONFIRMED` | `PostConfirmation_ConfirmSignUp`    |
-| `PreAuthentication`  | a sign-in, once the user is known and before its password is checked   | `PreAuthentication_Authentication`  |
-| `PostAuthentication` | a sign-in, once the tokens have been issued                            | `PostAuthentication_Authentication` |
+| Trigger              | Fires                                                                  | `triggerSource`                        |
+| -------------------- | ---------------------------------------------------------------------- | -------------------------------------- |
+| `PreSignUp`          | `SignUp`, before the pool takes the new user                           | `PreSignUp_SignUp`                     |
+| `PreSignUp`          | `AdminCreateUser`, before the pool takes the new user                  | `PreSignUp_AdminCreateUser`            |
+| `PostConfirmation`   | `ConfirmSignUp` and `AdminConfirmSignUp`, once the user is `CONFIRMED` | `PostConfirmation_ConfirmSignUp`       |
+| `PreAuthentication`  | a sign-in, once the user is known and before its password is checked   | `PreAuthentication_Authentication`     |
+| `PreTokenGeneration` | a sign-in, where the claims of its tokens are settled                  | `TokenGeneration_Authentication`       |
+| `PreTokenGeneration` | the sign-in that finishes by answering the new password challenge      | `TokenGeneration_NewPasswordChallenge` |
+| `PreTokenGeneration` | a `REFRESH_TOKEN_AUTH` refresh, over the tokens it reissues            | `TokenGeneration_RefreshTokens`        |
+| `PostAuthentication` | a sign-in, once the tokens have been issued                            | `PostAuthentication_Authentication`    |
 
 The function is a simulated Lambda function anywhere in the simulation, and it has to admit
 `cognito-idp.amazonaws.com` for the pool, which is what `AddPermission` grants and what CDK's
@@ -1277,7 +1280,8 @@ try {
 
 `ClientMetadata` on the sign-in reaches the handler as `request.validationData` for
 `PreAuthentication` and as `request.clientMetadata` for `PostAuthentication`, as it does on real
-Cognito. Neither fires for `REFRESH_TOKEN_AUTH`, as neither does on real Cognito.
+Cognito. Neither fires for `REFRESH_TOKEN_AUTH`, as neither does on real Cognito, where
+`PreTokenGeneration` does.
 
 ### The event, and what a failure gets back
 
@@ -1301,6 +1305,160 @@ Three failures are reported the way real Cognito reports them:
 
 Only the triggers in the table above run. Every other `LambdaConfig` key is refused when the pool is
 created or updated, naming the trigger, so a pool never quietly drops one.
+
+## Custom claims from a token trigger
+
+`PreTokenGeneration` decides what the pool puts on a token. The handler writes
+`response.claimsOverrideDetails`, and the id token is signed with what it asked for.
+`claimsToAddOrOverride` adds or replaces a claim, `claimsToSuppress` removes one, and
+`groupOverrideDetails.groupsToOverride` replaces the `cognito:groups` claim. The group override
+reaches the access token too, which is the one change a `V1_0` trigger makes to one.
+
+```typescript sim-cognito-pre-token-generation
+/**
+ * A user pool whose token trigger puts a tenant on every id token.
+ */
+
+import {
+  AdminCreateUserCommand,
+  AdminInitiateAuthCommand,
+  AdminSetUserPasswordCommand,
+  CreateUserPoolClientCommand,
+  CreateUserPoolCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import {
+  AddPermissionCommand,
+  CreateFunctionCommand,
+} from "@aws-sdk/client-lambda";
+
+import { SimAws } from "@kensio/yulin";
+import { makeLambdaZipFileInput } from "@kensio/yulin/lambda";
+
+/**
+ * The part of the PreTokenGeneration event this handler reads and writes.
+ */
+interface PreTokenGenerationEvent {
+  readonly request: { readonly userAttributes: Record<string, string> };
+  readonly response: object;
+}
+
+const simAws = new SimAws();
+const lambda = simAws.lambda();
+const cognito = simAws.cognitoIdentityProvider();
+
+// The trigger reads the user's email and puts the tenant it belongs to on the
+// token, along with the groups that tenant's users get.
+await lambda.createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "pre-token",
+    Role: "arn:aws:iam::888888888888:role/PreTokenRole",
+    Code: {
+      ZipFile: makeLambdaZipFileInput((event: PreTokenGenerationEvent) => {
+        const email = event.request.userAttributes["email"] ?? "";
+
+        return {
+          ...event,
+          response: {
+            claimsOverrideDetails: {
+              claimsToAddOrOverride: { tenantId: email.split("@", 2)[1] ?? "" },
+              claimsToSuppress: ["email"],
+              groupOverrideDetails: { groupsToOverride: ["tenant-admin"] },
+            },
+          },
+        };
+      }),
+    },
+  }),
+);
+
+const pool = await cognito.createUserPool(
+  new CreateUserPoolCommand({
+    PoolName: "myapp-users",
+    LambdaConfig: {
+      PreTokenGeneration:
+        "arn:aws:lambda:us-east-1:888888888888:function:pre-token",
+    },
+  }),
+);
+
+await lambda.addPermission(
+  new AddPermissionCommand({
+    FunctionName: "pre-token",
+    StatementId: "AllowCognito",
+    Action: "lambda:InvokeFunction",
+    Principal: "cognito-idp.amazonaws.com",
+    SourceArn: pool.UserPool?.Arn,
+  }),
+);
+
+const appClient = await cognito.createUserPoolClient(
+  new CreateUserPoolClientCommand({
+    UserPoolId: pool.UserPool?.Id,
+    ClientName: "web",
+    ExplicitAuthFlows: ["ALLOW_ADMIN_USER_PASSWORD_AUTH"],
+  }),
+);
+
+await cognito.adminCreateUser(
+  new AdminCreateUserCommand({
+    UserPoolId: pool.UserPool?.Id,
+    Username: "alice",
+    UserAttributes: [{ Name: "email", Value: "alice@acme.example" }],
+  }),
+);
+await cognito.adminSetUserPassword(
+  new AdminSetUserPasswordCommand({
+    UserPoolId: pool.UserPool?.Id,
+    Username: "alice",
+    Password: "Sup3rSecretPassw0rd!",
+    Permanent: true,
+  }),
+);
+
+const signedIn = await cognito.adminInitiateAuth(
+  new AdminInitiateAuthCommand({
+    UserPoolId: pool.UserPool?.Id,
+    ClientId: appClient.UserPoolClient?.ClientId,
+    AuthFlow: "ADMIN_USER_PASSWORD_AUTH",
+    AuthParameters: { USERNAME: "alice", PASSWORD: "Sup3rSecretPassw0rd!" },
+  }),
+);
+
+// The id token carries the claim the handler added, and not the one it
+// suppressed. It verifies against the pool's JWKS unchanged.
+const [, claims] = (signedIn.AuthenticationResult?.IdToken ?? "").split(".");
+const payload = JSON.parse(
+  Buffer.from(claims ?? "", "base64url").toString("utf8"),
+) as Record<string, unknown>;
+
+console.log(payload["tenantId"]); // "acme.example"
+console.log(payload["email"]); // undefined
+console.log(payload["cognito:groups"]); // ["tenant-admin"]
+```
+
+The trigger runs wherever the pool issues tokens, and names the occasion in `triggerSource`:
+`TokenGeneration_Authentication` for a sign-in, `TokenGeneration_NewPasswordChallenge` for the
+sign-in that finishes by answering the new password challenge, and `TokenGeneration_RefreshTokens`
+for `REFRESH_TOKEN_AUTH`. A refresh runs the handler again, so a claim that changed since the
+sign-in is on the reissued token rather than being stale for the life of the session.
+
+The request the handler is given carries `userAttributes`, a `groupConfiguration.groupsToOverride`
+holding the groups the user is in, and, from a challenge response, `clientMetadata`. Real Cognito
+passes `ClientMetadata` to this trigger from `RespondToAuthChallenge` and
+`AdminRespondToAuthChallenge` only, and not from `InitiateAuth` or `AdminInitiateAuth`.
+
+A response naming something this simulation would have to drop is refused with
+`InvalidLambdaResponseException` rather than applied in part:
+
+- A reserved claim in `claimsToAddOrOverride` or `claimsToSuppress`, such as `sub`, `aud`, `iss`,
+  `token_use`, `exp`, `iat` or `auth_time`. Real Cognito ignores an override of one, so a handler
+  that appeared to work here would do nothing deployed.
+- Any `cognito:` claim in `claimsToAddOrOverride`. `cognito:groups` is changed through
+  `groupOverrideDetails` instead, and the refusal says so.
+- `groupOverrideDetails.iamRolesToOverride` or `preferredRole`, because the `cognito:roles` and
+  `cognito:preferred_role` claims they feed are not issued here at all.
+- A claim value that is not a string. Complex claim values arrived with the `V2_0` event, which is
+  not simulated.
 
 ## Token timestamps and expiry
 
@@ -2044,6 +2202,9 @@ Sim Cognito currently supports:
 - `GlobalSignOutCommand` and `AdminUserGlobalSignOutCommand`, which revoke the tokens a user holds
 - The `PreAuthentication` and `PostAuthentication` Lambda triggers, invoked with the real event
   around a sign-in, with the sign-in's own `ClientMetadata` reaching them
+- The `PreTokenGeneration` Lambda trigger at `V1_0`, whose `claimsOverrideDetails` adds, overrides
+  and suppresses the claims of an id token, and whose `groupOverrideDetails` replaces
+  `cognito:groups`, on a sign-in and on a refresh alike
 - Real RS256 JWTs, signed by a key the pool publishes as a JWKS, so a verifier configured for the
   pool verifies them unchanged
 - A pool's `.well-known/jwks.json` and `.well-known/openid-configuration` served over HTTP by
@@ -2082,7 +2243,8 @@ Current documented limitations:
   caller's own verifier, which asks this simulation nothing, so nothing here can tell it the token
   was revoked. Real Cognito is the same for a verifier reading only the JWKS.
 - The `cognito:preferred_role` and `cognito:roles` claims are not on the tokens. A group's `RoleArn`
-  is stored and reported, and nothing assumes that role.
+  is stored and reported, and nothing assumes that role. A `PreTokenGeneration` handler naming
+  either claim is refused rather than half-applied.
 - A pool publishes one signing key where real Cognito publishes two and rotates between them, so
   code assuming a single JWKS entry passes here and is still wrong against real AWS. The key is
   generated with `node:crypto` the first time the pool signs or publishes one, and kept in memory
@@ -2155,12 +2317,12 @@ Current documented limitations:
   on real Cognito, so a client created without a secret never gains one.
 - A redeployed template reaches neither update. Sim CloudFormation replaces a resource whose
   resolved template entry changed rather than updating it in place, whatever the resource type.
-- `PreSignUp`, `PostConfirmation`, `PreAuthentication` and `PostAuthentication` are the only Lambda
-  triggers that run. Every other `LambdaConfig` key is refused when the pool is created or updated,
-  naming the trigger, because a pool that accepted one would never call the function the template
-  named. The token generation and message triggers wait on the features they fire for; the custom
-  challenge triggers would need a challenge loop this simulation does not have; and the migration
-  and federation triggers have no external directory to reach.
+- `PreSignUp`, `PostConfirmation`, `PreAuthentication`, `PostAuthentication` and
+  `PreTokenGeneration` are the only Lambda triggers that run. Every other `LambdaConfig` key is
+  refused when the pool is created or updated, naming the trigger, because a pool that accepted one
+  would never call the function the template named. The message triggers wait on the messages this
+  simulation does not deliver; the custom challenge triggers would need a challenge loop it does not
+  have; and the migration and federation triggers have no external directory to reach.
 - `AdminCreateUser` does not fire `PostConfirmation`, here or on real Cognito. It is the tempting
   place to hang the trigger and the wrong one: a project relying on it would pass here and write
   nothing in production.
@@ -2175,7 +2337,24 @@ Current documented limitations:
   ran after is not undone: a confirmed user stays confirmed and the tokens a pool issued stay
   issued, as they do on real Cognito.
 - Neither sign-in trigger fires for `REFRESH_TOKEN_AUTH`, as neither does on real Cognito.
-  `ClientMetadata` on a refresh is accepted and reaches nothing.
+  `PreTokenGeneration` does fire there, because the pool is issuing tokens.
+- `PreTokenGenerationConfig` is refused, so the trigger runs at `V1_0` and nothing else. The `V2_0`
+  and `V3_0` events customise access token claims and carry `scopesToAdd` and `scopesToSuppress`,
+  none of which is simulated. The one change a `V1_0` event makes to an access token, replacing its
+  `cognito:groups`, is applied.
+- A `V1_0` claim value is a string, and a handler returning anything else is refused. The complex
+  claim values arrived with the `V2_0` event.
+- A `PreTokenGeneration` response naming a claim real Cognito reserves is refused rather than
+  ignored, which is what real Cognito does with one. That is a deliberate divergence: a claim that
+  silently does not arrive in production is the failure a test with a trigger in it is there to
+  catch.
+- `groupOverrideDetails.iamRolesToOverride` and `preferredRole` are refused, and the request's
+  `groupConfiguration` carries neither, because the `cognito:roles` and `cognito:preferred_role`
+  claims they feed are not issued here. A handler copying the request's `groupConfiguration` back
+  into its response, which is how real Cognito says to leave the groups alone, works unchanged.
+- `ClientMetadata` reaches `PreTokenGeneration` from `RespondToAuthChallenge` and
+  `AdminRespondToAuthChallenge` alone, as it does on real Cognito. A refresh accepts one and it
+  reaches nothing.
 - Unsimulated `CreateUserPool` inputs are refused rather than ignored: `UsernameAttributes`,
   `AliasAttributes`, `Schema`, `UsernameConfiguration`,
   `UserAttributeUpdateSettings`, `DeviceConfiguration`, `UserPoolAddOns`, `KeyConfiguration`,

--- a/docs/services/cognito/README.md
+++ b/docs/services/cognito/README.md
@@ -1330,6 +1330,7 @@ import {
   AddPermissionCommand,
   CreateFunctionCommand,
 } from "@aws-sdk/client-lambda";
+import { CognitoJwtVerifier } from "aws-jwt-verify";
 
 import { SimAws } from "@kensio/yulin";
 import { makeLambdaZipFileInput } from "@kensio/yulin/lambda";
@@ -1380,6 +1381,7 @@ const pool = await cognito.createUserPool(
     },
   }),
 );
+const userPoolId = pool.UserPool!.Id!;
 
 await lambda.addPermission(
   new AddPermissionCommand({
@@ -1387,28 +1389,29 @@ await lambda.addPermission(
     StatementId: "AllowCognito",
     Action: "lambda:InvokeFunction",
     Principal: "cognito-idp.amazonaws.com",
-    SourceArn: pool.UserPool?.Arn,
+    SourceArn: pool.UserPool!.Arn!,
   }),
 );
 
 const appClient = await cognito.createUserPoolClient(
   new CreateUserPoolClientCommand({
-    UserPoolId: pool.UserPool?.Id,
+    UserPoolId: userPoolId,
     ClientName: "web",
     ExplicitAuthFlows: ["ALLOW_ADMIN_USER_PASSWORD_AUTH"],
   }),
 );
+const clientId = appClient.UserPoolClient!.ClientId!;
 
 await cognito.adminCreateUser(
   new AdminCreateUserCommand({
-    UserPoolId: pool.UserPool?.Id,
+    UserPoolId: userPoolId,
     Username: "alice",
     UserAttributes: [{ Name: "email", Value: "alice@acme.example" }],
   }),
 );
 await cognito.adminSetUserPassword(
   new AdminSetUserPasswordCommand({
-    UserPoolId: pool.UserPool?.Id,
+    UserPoolId: userPoolId,
     Username: "alice",
     Password: "Sup3rSecretPassw0rd!",
     Permanent: true,
@@ -1417,20 +1420,26 @@ await cognito.adminSetUserPassword(
 
 const signedIn = await cognito.adminInitiateAuth(
   new AdminInitiateAuthCommand({
-    UserPoolId: pool.UserPool?.Id,
-    ClientId: appClient.UserPoolClient?.ClientId,
+    UserPoolId: userPoolId,
+    ClientId: clientId,
     AuthFlow: "ADMIN_USER_PASSWORD_AUTH",
     AuthParameters: { USERNAME: "alice", PASSWORD: "Sup3rSecretPassw0rd!" },
   }),
 );
 
-// The id token carries the claim the handler added, and not the one it
-// suppressed. It verifies against the pool's JWKS unchanged.
-const [, claims] = (signedIn.AuthenticationResult?.IdToken ?? "").split(".");
-const payload = JSON.parse(
-  Buffer.from(claims ?? "", "base64url").toString("utf8"),
-) as Record<string, unknown>;
+// The overridden token is signed like any other, so the application's own
+// verifier is what reads the claims off it.
+const verifier = CognitoJwtVerifier.create({
+  userPoolId,
+  tokenUse: "id",
+  clientId,
+});
 
+verifier.cacheJwks(cognito.userPool(userPoolId).jwks());
+
+const payload = await verifier.verify(signedIn.AuthenticationResult!.IdToken!);
+
+// The claim the handler added is there, and the one it suppressed is not.
 console.log(payload["tenantId"]); // "acme.example"
 console.log(payload["email"]); // undefined
 console.log(payload["cognito:groups"]); // ["tenant-admin"]
@@ -2344,6 +2353,11 @@ Current documented limitations:
   `cognito:groups`, is applied.
 - A `V1_0` claim value is a string, and a handler returning anything else is refused. The complex
   claim values arrived with the `V2_0` event.
+- `claimsToAddOrOverride` and `claimsToSuppress` reach the id token alone, because a `V1_0` event
+  customises that token. `cognito:groups` on an access token is changed through
+  `groupOverrideDetails`, which is what real Cognito calls the only change a `V1_0` event makes to
+  an access token. `claimsToSuppress` naming a `cognito:` claim other than `cognito:groups` is
+  refused, since real Cognito suppresses none of the others.
 - A `PreTokenGeneration` response naming a claim real Cognito reserves is refused rather than
   ignored, which is what real Cognito does with one. That is a deliberate divergence: a claim that
   silently does not arrive in production is the failure a test with a trigger in it is there to

--- a/docs/services/cognito/sim-cognito-pre-token-generation.example.ts
+++ b/docs/services/cognito/sim-cognito-pre-token-generation.example.ts
@@ -13,6 +13,7 @@ import {
   AddPermissionCommand,
   CreateFunctionCommand,
 } from "@aws-sdk/client-lambda";
+import { CognitoJwtVerifier } from "aws-jwt-verify";
 
 import { SimAws } from "@kensio/yulin";
 import { makeLambdaZipFileInput } from "@kensio/yulin/lambda";
@@ -63,6 +64,7 @@ const pool = await cognito.createUserPool(
     },
   }),
 );
+const userPoolId = pool.UserPool!.Id!;
 
 await lambda.addPermission(
   new AddPermissionCommand({
@@ -70,28 +72,29 @@ await lambda.addPermission(
     StatementId: "AllowCognito",
     Action: "lambda:InvokeFunction",
     Principal: "cognito-idp.amazonaws.com",
-    SourceArn: pool.UserPool?.Arn,
+    SourceArn: pool.UserPool!.Arn!,
   }),
 );
 
 const appClient = await cognito.createUserPoolClient(
   new CreateUserPoolClientCommand({
-    UserPoolId: pool.UserPool?.Id,
+    UserPoolId: userPoolId,
     ClientName: "web",
     ExplicitAuthFlows: ["ALLOW_ADMIN_USER_PASSWORD_AUTH"],
   }),
 );
+const clientId = appClient.UserPoolClient!.ClientId!;
 
 await cognito.adminCreateUser(
   new AdminCreateUserCommand({
-    UserPoolId: pool.UserPool?.Id,
+    UserPoolId: userPoolId,
     Username: "alice",
     UserAttributes: [{ Name: "email", Value: "alice@acme.example" }],
   }),
 );
 await cognito.adminSetUserPassword(
   new AdminSetUserPasswordCommand({
-    UserPoolId: pool.UserPool?.Id,
+    UserPoolId: userPoolId,
     Username: "alice",
     Password: "Sup3rSecretPassw0rd!",
     Permanent: true,
@@ -100,20 +103,26 @@ await cognito.adminSetUserPassword(
 
 const signedIn = await cognito.adminInitiateAuth(
   new AdminInitiateAuthCommand({
-    UserPoolId: pool.UserPool?.Id,
-    ClientId: appClient.UserPoolClient?.ClientId,
+    UserPoolId: userPoolId,
+    ClientId: clientId,
     AuthFlow: "ADMIN_USER_PASSWORD_AUTH",
     AuthParameters: { USERNAME: "alice", PASSWORD: "Sup3rSecretPassw0rd!" },
   }),
 );
 
-// The id token carries the claim the handler added, and not the one it
-// suppressed. It verifies against the pool's JWKS unchanged.
-const [, claims] = (signedIn.AuthenticationResult?.IdToken ?? "").split(".");
-const payload = JSON.parse(
-  Buffer.from(claims ?? "", "base64url").toString("utf8"),
-) as Record<string, unknown>;
+// The overridden token is signed like any other, so the application's own
+// verifier is what reads the claims off it.
+const verifier = CognitoJwtVerifier.create({
+  userPoolId,
+  tokenUse: "id",
+  clientId,
+});
 
+verifier.cacheJwks(cognito.userPool(userPoolId).jwks());
+
+const payload = await verifier.verify(signedIn.AuthenticationResult!.IdToken!);
+
+// The claim the handler added is there, and the one it suppressed is not.
 console.log(payload["tenantId"]); // "acme.example"
 console.log(payload["email"]); // undefined
 console.log(payload["cognito:groups"]); // ["tenant-admin"]

--- a/docs/services/cognito/sim-cognito-pre-token-generation.example.ts
+++ b/docs/services/cognito/sim-cognito-pre-token-generation.example.ts
@@ -1,0 +1,119 @@
+/**
+ * A user pool whose token trigger puts a tenant on every id token.
+ */
+
+import {
+  AdminCreateUserCommand,
+  AdminInitiateAuthCommand,
+  AdminSetUserPasswordCommand,
+  CreateUserPoolClientCommand,
+  CreateUserPoolCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import {
+  AddPermissionCommand,
+  CreateFunctionCommand,
+} from "@aws-sdk/client-lambda";
+
+import { SimAws } from "@kensio/yulin";
+import { makeLambdaZipFileInput } from "@kensio/yulin/lambda";
+
+/**
+ * The part of the PreTokenGeneration event this handler reads and writes.
+ */
+interface PreTokenGenerationEvent {
+  readonly request: { readonly userAttributes: Record<string, string> };
+  readonly response: object;
+}
+
+const simAws = new SimAws();
+const lambda = simAws.lambda();
+const cognito = simAws.cognitoIdentityProvider();
+
+// The trigger reads the user's email and puts the tenant it belongs to on the
+// token, along with the groups that tenant's users get.
+await lambda.createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "pre-token",
+    Role: "arn:aws:iam::888888888888:role/PreTokenRole",
+    Code: {
+      ZipFile: makeLambdaZipFileInput((event: PreTokenGenerationEvent) => {
+        const email = event.request.userAttributes["email"] ?? "";
+
+        return {
+          ...event,
+          response: {
+            claimsOverrideDetails: {
+              claimsToAddOrOverride: { tenantId: email.split("@", 2)[1] ?? "" },
+              claimsToSuppress: ["email"],
+              groupOverrideDetails: { groupsToOverride: ["tenant-admin"] },
+            },
+          },
+        };
+      }),
+    },
+  }),
+);
+
+const pool = await cognito.createUserPool(
+  new CreateUserPoolCommand({
+    PoolName: "myapp-users",
+    LambdaConfig: {
+      PreTokenGeneration:
+        "arn:aws:lambda:us-east-1:888888888888:function:pre-token",
+    },
+  }),
+);
+
+await lambda.addPermission(
+  new AddPermissionCommand({
+    FunctionName: "pre-token",
+    StatementId: "AllowCognito",
+    Action: "lambda:InvokeFunction",
+    Principal: "cognito-idp.amazonaws.com",
+    SourceArn: pool.UserPool?.Arn,
+  }),
+);
+
+const appClient = await cognito.createUserPoolClient(
+  new CreateUserPoolClientCommand({
+    UserPoolId: pool.UserPool?.Id,
+    ClientName: "web",
+    ExplicitAuthFlows: ["ALLOW_ADMIN_USER_PASSWORD_AUTH"],
+  }),
+);
+
+await cognito.adminCreateUser(
+  new AdminCreateUserCommand({
+    UserPoolId: pool.UserPool?.Id,
+    Username: "alice",
+    UserAttributes: [{ Name: "email", Value: "alice@acme.example" }],
+  }),
+);
+await cognito.adminSetUserPassword(
+  new AdminSetUserPasswordCommand({
+    UserPoolId: pool.UserPool?.Id,
+    Username: "alice",
+    Password: "Sup3rSecretPassw0rd!",
+    Permanent: true,
+  }),
+);
+
+const signedIn = await cognito.adminInitiateAuth(
+  new AdminInitiateAuthCommand({
+    UserPoolId: pool.UserPool?.Id,
+    ClientId: appClient.UserPoolClient?.ClientId,
+    AuthFlow: "ADMIN_USER_PASSWORD_AUTH",
+    AuthParameters: { USERNAME: "alice", PASSWORD: "Sup3rSecretPassw0rd!" },
+  }),
+);
+
+// The id token carries the claim the handler added, and not the one it
+// suppressed. It verifies against the pool's JWKS unchanged.
+const [, claims] = (signedIn.AuthenticationResult?.IdToken ?? "").split(".");
+const payload = JSON.parse(
+  Buffer.from(claims ?? "", "base64url").toString("utf8"),
+) as Record<string, unknown>;
+
+console.log(payload["tenantId"]); // "acme.example"
+console.log(payload["email"]); // undefined
+console.log(payload["cognito:groups"]); // ["tenant-admin"]

--- a/src/service/cognito/README.md
+++ b/src/service/cognito/README.md
@@ -422,7 +422,9 @@ resource, here or on real AWS.
 - A `PreTokenGeneration` response is refused where real Cognito would quietly drop part of it: a
   reserved claim, any `cognito:` claim in `claimsToAddOrOverride`, a claim value that is not a
   string, and a group override naming IAM roles. The trigger runs at `V1_0` only, so
-  `PreTokenGenerationConfig` is refused and no access token claim or scope is customised.
+  `PreTokenGenerationConfig` is refused, and the group override replacing `cognito:groups` is the
+  only change that reaches an access token. The `V2_0` and `V3_0` access token claims and scopes are
+  not customised.
 - A refresh answers with no new refresh token, as real Cognito does with refresh token rotation off.
   `RefreshTokenRotation` is refused on an app client, and `GetTokensFromRefreshToken` and
   `RevokeToken` are not implemented.

--- a/src/service/cognito/README.md
+++ b/src/service/cognito/README.md
@@ -173,6 +173,21 @@ hands out all three tokens and `reissue` signs a new access and id token for a r
 difference `REFRESH_TOKEN_AUTH` answers with. Everything it issues is recorded on the pool, because
 the pool is what a refresh or a sign-out presents a token back to.
 
+The pool's `PreTokenGeneration` trigger runs from the issuer, because that is where a token's claims
+are settled, and it runs from `reissue` as well as from `issue`: real Cognito fires it on a refresh
+too, and a simulation that only fired it on a first sign-in would let a claim the handler has since
+changed survive one. Each caller says which occasion it is issuing for, which is what becomes the
+handler's `triggerSource`.
+
+`SimCognitoClaimsOverrideReader` reads what the handler wrote into `response.claimsOverrideDetails`
+and answers with a `SimCognitoClaimsOverride`, which is what applies the changes to a claim set. A
+pool with no such trigger produces an empty override rather than nothing, so the issuer applies one
+either way. `sim-cognito-reserved-claims.ts` holds the claims a handler may not name. Refusing those is a
+deliberate divergence: real Cognito drops the override without saying so, and a handler that appears
+to work here and does nothing deployed is the failure worth catching. The claim changes reach the id
+token, and the group override reaches the access token as well, which is the one change a `V1_0`
+event makes to one.
+
 ## CloudFormation resources
 
 `cfn/` creates `AWS::Cognito::UserPool`, `AWS::Cognito::UserPoolClient` and
@@ -404,6 +419,10 @@ resource, here or on real AWS.
 - The password and refresh flows run on both sides of the API, and only `NEW_PASSWORD_REQUIRED` is
   issued. SRP, `USER_AUTH`, custom authentication, MFA challenges and device tracking are refused
   rather than treated as a flow or challenge that is simulated.
+- A `PreTokenGeneration` response is refused where real Cognito would quietly drop part of it: a
+  reserved claim, any `cognito:` claim in `claimsToAddOrOverride`, a claim value that is not a
+  string, and a group override naming IAM roles. The trigger runs at `V1_0` only, so
+  `PreTokenGenerationConfig` is refused and no access token claim or scope is customised.
 - A refresh answers with no new refresh token, as real Cognito does with refresh token rotation off.
   `RefreshTokenRotation` is refused on an app client, and `GetTokensFromRefreshToken` and
   `RevokeToken` are not implemented.

--- a/src/service/cognito/cfn/sim-cfn-cognito-lambda-triggers.iso.test.ts
+++ b/src/service/cognito/cfn/sim-cfn-cognito-lambda-triggers.iso.test.ts
@@ -175,14 +175,14 @@ describe("Sim CloudFormation Cognito user pool Lambda triggers", () => {
   });
 
   it("fails a stack asking for a trigger this simulation does not run", async () => {
-    // Given a template naming a token generation trigger.
+    // Given a template naming a custom message trigger.
     const simAws = simAwsInEuWest2();
 
     // When the stack is deployed.
     const error = await deployFailure(
       simAws,
       poolWithTrigger({
-        PreTokenGeneration: { "Fn::GetAtt": ["Trigger", "Arn"] },
+        CustomMessage: { "Fn::GetAtt": ["Trigger", "Arn"] },
       }),
     );
 
@@ -190,7 +190,7 @@ describe("Sim CloudFormation Cognito user pool Lambda triggers", () => {
     // the function the template named.
     assertStringIncludes(
       error.message,
-      "CreateUserPool LambdaConfig PreTokenGeneration is not simulated",
+      "CreateUserPool LambdaConfig CustomMessage is not simulated",
     );
   });
 });

--- a/src/service/cognito/command/auth/sim-cognito-auth-commands.ts
+++ b/src/service/cognito/command/auth/sim-cognito-auth-commands.ts
@@ -41,7 +41,7 @@ export class SimCognitoAuthCommands {
 
   constructor(properties: SimCognitoAuthCommandsProperties) {
     const { resolver, authResolver, pools, clock, triggers } = properties;
-    const tokenIssuer = new SimCognitoTokenIssuer({ clock });
+    const tokenIssuer = new SimCognitoTokenIssuer({ clock, triggers });
     const flowRunner = new SimCognitoAuthFlowRunner({
       passwordSignIn: new SimCognitoPasswordSignIn({
         authResolver,

--- a/src/service/cognito/command/auth/sim-cognito-auth-flow-runner.ts
+++ b/src/service/cognito/command/auth/sim-cognito-auth-flow-runner.ts
@@ -18,9 +18,9 @@ interface SimCognitoAuthFlowRunnerProperties {
  * the pool differently, and once a flow is resolved they run the same bodies,
  * so the running of one lives here rather than in either command.
  *
- * Running a flow is asynchronous because a password sign-in may have to wait
- * on the pool's Lambda triggers. A refresh runs no trigger, as it does not on
- * real Cognito, and answers without waiting on anything.
+ * Running a flow is asynchronous because either flow may have to wait on the
+ * pool's Lambda triggers. A password sign-in runs the authentication triggers,
+ * and both flows run `PreTokenGeneration` where they issue tokens.
  */
 export class SimCognitoAuthFlowRunner {
   private readonly passwordSignIn: SimCognitoPasswordSignIn;
@@ -39,7 +39,7 @@ export class SimCognitoAuthFlowRunner {
     request: SimCognitoAuthRequest,
   ): Promise<SimCognitoAuthenticationOutput> {
     if (flow.exchangesRefreshToken) {
-      return this.refreshSignIn.handle(request);
+      return await this.refreshSignIn.handle(request);
     }
 
     return await this.passwordSignIn.handle(request);

--- a/src/service/cognito/command/auth/sim-cognito-new-password-response.ts
+++ b/src/service/cognito/command/auth/sim-cognito-new-password-response.ts
@@ -5,6 +5,7 @@ import {
 } from "../../user-pool/auth/sim-cognito-sign-in.js";
 import { SimCognitoPasswordCheck } from "../../user-pool/sim-cognito-password-check.js";
 import type { SimCognitoTokenIssuer } from "../../user-pool/token/sim-cognito-token-issuer.js";
+import { SimCognitoTriggerOccasion } from "../../user-pool/trigger/sim-cognito-trigger-occasion.js";
 import type { SimCognitoUserPoolTriggers } from "../../user-pool/trigger/sim-cognito-user-pool-triggers.js";
 import { SimCognitoAuthenticationResult } from "./sim-cognito-authentication-result.js";
 import type { SimCognitoAuthResolver } from "./sim-cognito-auth-resolver.js";
@@ -53,9 +54,11 @@ export class SimCognitoNewPasswordResponse {
    * Complete the challenge, and sign the user in.
    *
    * This is where the sign-in the challenge interrupted finishes, so it is
-   * where the pool's `PostAuthentication` trigger runs. `PreAuthentication`
-   * does not run again: it ran when the challenge was issued, and real Cognito
-   * fires it once per sign-in rather than once per request.
+   * where the pool's `PostAuthentication` trigger runs, and where its
+   * `PreTokenGeneration` trigger runs with a `triggerSource` of
+   * `TokenGeneration_NewPasswordChallenge`. `PreAuthentication` does not run
+   * again: it ran when the challenge was issued, and real Cognito fires it once
+   * per sign-in rather than once per request.
    */
   async handle(
     request: SimCognitoChallengeResponseRequest,
@@ -84,10 +87,19 @@ export class SimCognitoNewPasswordResponse {
 
     pool.auth.removeSession(session);
 
+    // This is the one occasion real Cognito passes a request's `ClientMetadata`
+    // to the token trigger, so it travels with the tokens here and nowhere
+    // else.
     const authenticated = {
       $metadata: {},
       AuthenticationResult: this.result.of(
-        this.tokenIssuer.issue({ pool, client, user }),
+        await this.tokenIssuer.issue({
+          pool,
+          client,
+          user,
+          occasion: SimCognitoTriggerOccasion.newPasswordTokenGeneration,
+          clientMetadata: request.clientMetadata,
+        }),
       ),
     };
 

--- a/src/service/cognito/command/auth/sim-cognito-password-sign-in.ts
+++ b/src/service/cognito/command/auth/sim-cognito-password-sign-in.ts
@@ -6,6 +6,7 @@ import {
 import type { SimCognitoUserPoolClient } from "../../user-pool/client/sim-cognito-user-pool-client.js";
 import type { SimCognitoUserPool } from "../../user-pool/sim-cognito-user-pool.js";
 import type { SimCognitoTokenIssuer } from "../../user-pool/token/sim-cognito-token-issuer.js";
+import { SimCognitoTriggerOccasion } from "../../user-pool/trigger/sim-cognito-trigger-occasion.js";
 import type { SimCognitoUserPoolTriggers } from "../../user-pool/trigger/sim-cognito-user-pool-triggers.js";
 import { SimCognitoAuthenticationResult } from "./sim-cognito-authentication-result.js";
 import type { SimCognitoAuthParameters } from "./sim-cognito-auth-parameters.js";
@@ -68,7 +69,8 @@ export class SimCognitoPasswordSignIn {
    *
    * `PostAuthentication` runs only where tokens were issued. A user answered
    * with the `NEW_PASSWORD_REQUIRED` challenge has not signed in yet, and runs
-   * it when it answers the challenge instead.
+   * it when it answers the challenge instead. `PreTokenGeneration` runs between
+   * the two, where the token issuer settles the claims.
    */
   async handle(
     request: SimCognitoAuthRequest,
@@ -91,10 +93,18 @@ export class SimCognitoPasswordSignIn {
       return this.challenge.issue({ pool, clientId: client.id, user });
     }
 
+    // `ClientMetadata` reaches PreAuthentication and PostAuthentication, and
+    // not the token trigger: real Cognito does not pass an InitiateAuth or
+    // AdminInitiateAuth request's on to that one.
     const authenticated = {
       $metadata: {},
       AuthenticationResult: this.result.of(
-        this.tokenIssuer.issue({ pool, client, user }),
+        await this.tokenIssuer.issue({
+          pool,
+          client,
+          user,
+          occasion: SimCognitoTriggerOccasion.tokenGeneration,
+        }),
       ),
     };
 

--- a/src/service/cognito/command/auth/sim-cognito-refresh-sign-in.ts
+++ b/src/service/cognito/command/auth/sim-cognito-refresh-sign-in.ts
@@ -2,6 +2,7 @@ import type { SimClock } from "../../../../util/clock/sim-clock.js";
 import { requireSimCognitoSecretHash } from "../../user-pool/auth/sim-cognito-secret-hash.js";
 import { requireSimCognitoEnabled } from "../../user-pool/auth/sim-cognito-sign-in.js";
 import type { SimCognitoTokenIssuer } from "../../user-pool/token/sim-cognito-token-issuer.js";
+import { SimCognitoTriggerOccasion } from "../../user-pool/trigger/sim-cognito-trigger-occasion.js";
 import { requireSimCognitoUsername } from "../../user-pool/user/sim-cognito-username.js";
 import { SimCognitoAuthenticationResult } from "./sim-cognito-authentication-result.js";
 import type { SimCognitoAuthRequest } from "./sim-cognito-password-sign-in.js";
@@ -19,6 +20,10 @@ interface SimCognitoRefreshSignInProperties {
  * it is, which is why one presented to another app client is refused. Nothing
  * new comes back with the tokens, because real Cognito issues no new refresh
  * token here, so a client keeps the one it has until that expires.
+ *
+ * The pool's `PreTokenGeneration` trigger runs for the reissued tokens, as it
+ * does on real Cognito, so a claim it changed since the sign-in is on the token
+ * a refresh answers with rather than being stale for the life of the session.
  */
 export class SimCognitoRefreshSignIn {
   private readonly tokenIssuer: SimCognitoTokenIssuer;
@@ -33,7 +38,9 @@ export class SimCognitoRefreshSignIn {
   /**
    * Refresh a session, or refuse the token it was asked for with.
    */
-  handle(request: SimCognitoAuthRequest): SimCognitoAuthenticationOutput {
+  async handle(
+    request: SimCognitoAuthRequest,
+  ): Promise<SimCognitoAuthenticationOutput> {
     const { pool, client, parameters } = request;
     const refreshToken = pool.auth.requireRefreshToken({
       value: parameters.require("REFRESH_TOKEN"),
@@ -55,10 +62,18 @@ export class SimCognitoRefreshSignIn {
 
     requireSimCognitoEnabled(user);
 
+    // A refresh runs through `InitiateAuth`, whose `ClientMetadata` real
+    // Cognito does not pass to the token trigger, so none travels with these
+    // tokens.
     return {
       $metadata: {},
       AuthenticationResult: this.result.of(
-        this.tokenIssuer.reissue({ pool, client, user }),
+        await this.tokenIssuer.reissue({
+          pool,
+          client,
+          user,
+          occasion: SimCognitoTriggerOccasion.refreshTokenGeneration,
+        }),
       ),
     };
   }

--- a/src/service/cognito/command/user-pool/sim-cognito-update-user-pool-validation.iso.test.ts
+++ b/src/service/cognito/command/user-pool/sim-cognito-update-user-pool-validation.iso.test.ts
@@ -58,13 +58,13 @@ const refusedInputs: readonly RefusedInput[] = [
     says: "a password the user has used before",
   },
   {
-    label: "LambdaConfig PreTokenGeneration",
+    label: "LambdaConfig CustomMessage",
     input: {
       LambdaConfig: {
-        PreTokenGeneration: "arn:aws:lambda:eu-west-2:1:function:f",
+        CustomMessage: "arn:aws:lambda:eu-west-2:1:function:f",
       },
     },
-    says: "changing the claims a pool puts in its tokens",
+    says: "writing the wording of a message the pool sends",
   },
   {
     label: "UserAttributeUpdateSettings",

--- a/src/service/cognito/command/user-pool/sim-cognito-user-pool-validation.iso.test.ts
+++ b/src/service/cognito/command/user-pool/sim-cognito-user-pool-validation.iso.test.ts
@@ -59,10 +59,10 @@ const refusedInputs: readonly RefusedInput[] = [
     label: "LambdaConfig",
     input: {
       LambdaConfig: {
-        PreTokenGeneration: "arn:aws:lambda:eu-west-2:1:function:f",
+        CustomMessage: "arn:aws:lambda:eu-west-2:1:function:f",
       },
     },
-    says: "LambdaConfig PreTokenGeneration is not simulated",
+    says: "LambdaConfig CustomMessage is not simulated",
   },
   {
     label: "AliasAttributes",

--- a/src/service/cognito/index.ts
+++ b/src/service/cognito/index.ts
@@ -64,6 +64,13 @@ export {
   SimCognitoTokenIssuer,
   type SimCognitoIssuedTokens,
 } from "./user-pool/token/sim-cognito-token-issuer.js";
+export { SimCognitoUserPoolTriggers } from "./user-pool/trigger/sim-cognito-user-pool-triggers.js";
+export {
+  SimCognitoNoTriggerFunctions,
+  type SimCognitoTriggerFunctions,
+} from "./user-pool/trigger/sim-cognito-trigger-functions.js";
+export type { SimCognitoTriggerName } from "./user-pool/trigger/sim-cognito-trigger-name.js";
+export { SimCognitoTriggerOccasion } from "./user-pool/trigger/sim-cognito-trigger-occasion.js";
 export { SimCognitoAuthSession } from "./user-pool/auth/sim-cognito-auth-session.js";
 export { SimCognitoIssuedToken } from "./user-pool/auth/sim-cognito-issued-token.js";
 export { SimCognitoPoolAuth } from "./user-pool/auth/sim-cognito-pool-auth.js";

--- a/src/service/cognito/user-pool/token/sim-cognito-claims-override-reader.ts
+++ b/src/service/cognito/user-pool/token/sim-cognito-claims-override-reader.ts
@@ -1,0 +1,109 @@
+import { isRecord } from "../../../../util/type-guard/record.js";
+import { SimCognitoClaimsOverride } from "./sim-cognito-claims-override.js";
+import {
+  refuseSimCognitoResponse,
+  requireSimCognitoResponseObject,
+  requireSimCognitoResponseStrings,
+} from "./sim-cognito-claims-override-values.js";
+import { readSimCognitoGroupOverride } from "./sim-cognito-group-override.js";
+import {
+  requireSimCognitoOverridableClaim,
+  requireSimCognitoSuppressibleClaim,
+} from "./sim-cognito-reserved-claims.js";
+
+/**
+ * Reads what a `PreTokenGeneration` handler wrote into its response.
+ *
+ * A V1_0 response carries `claimsOverrideDetails`, and everything this reads is
+ * inside it. Anything a handler could write that this simulation would not act
+ * on is refused rather than dropped, because a claim that quietly does not
+ * arrive is the failure a test with a trigger in it is there to catch.
+ */
+export class SimCognitoClaimsOverrideReader {
+  /**
+   * The override the event a handler returned asks for.
+   *
+   * A handler that wrote nothing, and one that was never invoked because the
+   * pool has no such trigger, both give an empty override.
+   */
+  read(returned: unknown): SimCognitoClaimsOverride {
+    const details = this.details(returned);
+
+    if (details === undefined) {
+      return SimCognitoClaimsOverride.none();
+    }
+
+    return new SimCognitoClaimsOverride({
+      added: this.added(details["claimsToAddOrOverride"]),
+      suppressed: this.suppressed(details["claimsToSuppress"]),
+      groups: readSimCognitoGroupOverride(details),
+    });
+  }
+
+  private details(returned: unknown): Record<string, unknown> | undefined {
+    if (!isRecord(returned)) {
+      return undefined;
+    }
+
+    const response: unknown = returned["response"];
+
+    if (!isRecord(response)) {
+      return undefined;
+    }
+
+    const details: unknown = response["claimsOverrideDetails"];
+
+    if (details === undefined || details === null) {
+      return undefined;
+    }
+
+    return requireSimCognitoResponseObject(details, "claimsOverrideDetails");
+  }
+
+  /**
+   * The claims to add or override, which a V1_0 response carries as strings.
+   *
+   * A value of any other type is refused. Complex claim values arrived with the
+   * V2_0 event, which this simulation does not run, so accepting one here would
+   * put a claim on a token that a deployed V1_0 trigger would not.
+   */
+  private added(value: unknown): ReadonlyMap<string, string> {
+    const added = new Map<string, string>();
+
+    if (value === undefined || value === null) {
+      return added;
+    }
+
+    const claims = Object.entries(
+      requireSimCognitoResponseObject(value, "claimsToAddOrOverride"),
+    );
+
+    for (const [claim, claimValue] of claims) {
+      requireSimCognitoOverridableClaim(claim);
+
+      if (typeof claimValue !== "string") {
+        refuseSimCognitoResponse(
+          `a claimsToAddOrOverride value for ${claim} that is not a string. ` +
+            `A V1_0 trigger event carries claim values as strings, and the ` +
+            `complex values arrived with the V2_0 event.`,
+        );
+      }
+
+      added.set(claim, claimValue);
+    }
+
+    return added;
+  }
+
+  private suppressed(value: unknown): ReadonlySet<string> {
+    const suppressed = new Set<string>();
+    const claims = requireSimCognitoResponseStrings(value, "claimsToSuppress");
+
+    for (const claim of claims) {
+      requireSimCognitoSuppressibleClaim(claim);
+      suppressed.add(claim);
+    }
+
+    return suppressed;
+  }
+}

--- a/src/service/cognito/user-pool/token/sim-cognito-claims-override-values.ts
+++ b/src/service/cognito/user-pool/token/sim-cognito-claims-override-values.ts
@@ -1,0 +1,63 @@
+import { isRecord } from "../../../../util/type-guard/record.js";
+import { SimCognitoInvalidLambdaResponseException } from "../../error/sim-cognito-trigger.error.js";
+
+/**
+ * Refuse what a `PreTokenGeneration` handler wrote into its response.
+ *
+ * Every refusal reads as one sentence about the trigger, because that is what
+ * the reader of the failure has to go and change: the handler, rather than
+ * anything about the pool or the sign-in.
+ */
+export function refuseSimCognitoResponse(message: string): never {
+  throw new SimCognitoInvalidLambdaResponseException(
+    `The PreTokenGeneration trigger returned ${message}`,
+  );
+}
+
+/**
+ * One field of the response, which has to be an object.
+ */
+export function requireSimCognitoResponseObject(
+  value: unknown,
+  field: string,
+): Record<string, unknown> {
+  if (!isRecord(value)) {
+    refuseSimCognitoResponse(`a ${field} that is not an object.`);
+  }
+
+  return value;
+}
+
+/**
+ * One field of the response, which has to be a list of strings.
+ *
+ * A field that is not there at all asks for nothing, and answers with an empty
+ * list rather than being refused: a handler naming only the claims it adds has
+ * written a complete response.
+ */
+export function requireSimCognitoResponseStrings(
+  value: unknown,
+  field: string,
+): readonly string[] {
+  if (value === undefined || value === null) {
+    return [];
+  }
+
+  if (!Array.isArray(value)) {
+    refuseSimCognitoResponse(`a ${field} that is not a list.`);
+  }
+
+  const entries: string[] = [];
+
+  for (const entry of value) {
+    if (typeof entry !== "string") {
+      refuseSimCognitoResponse(
+        `a ${field} holding something that is not a string.`,
+      );
+    }
+
+    entries.push(entry);
+  }
+
+  return entries;
+}

--- a/src/service/cognito/user-pool/token/sim-cognito-claims-override.iso.test.ts
+++ b/src/service/cognito/user-pool/token/sim-cognito-claims-override.iso.test.ts
@@ -1,0 +1,239 @@
+import {
+  assertArrayEquals,
+  assertIdentical,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import {
+  makeTriggerPool,
+  makeTriggerUser,
+  triggerFunctionArn,
+} from "../../../../../test/cognito/trigger-fixture.js";
+import { claimsOverrideHandler } from "../../../../../test/cognito/trigger-handler-fixture.js";
+import {
+  signInToTriggerPool,
+  triggerTokenClaims,
+} from "../../../../../test/cognito/trigger-token-fixture.js";
+
+/**
+ * Sign in against a pool whose token trigger answers with these override
+ * details, and answer with the refusal the sign-in failed with.
+ */
+async function refusalOf(details: unknown): Promise<Error> {
+  const pool = await makeTriggerPool({
+    triggers: { PreTokenGeneration: triggerFunctionArn },
+    handler: claimsOverrideHandler(details),
+  });
+
+  await makeTriggerUser(pool);
+
+  const error = await assertThrowsErrorAsync(async () =>
+    signInToTriggerPool(pool),
+  );
+
+  // Every refusal here is the one real Cognito reports for a response it could
+  // not act on.
+  assertIdentical(error.name, "InvalidLambdaResponseException");
+
+  return error;
+}
+
+describe("sim Cognito PreTokenGeneration claims override refusals", () => {
+  it("refuses an override of a reserved claim, naming it", async () => {
+    // Given a handler trying to put its own value in `sub`, which real Cognito
+    // drops without saying so.
+    // When the user signs in.
+    const error = await refusalOf({
+      claimsToAddOrOverride: { sub: "00000000-0000-0000-0000-000000000000" },
+    });
+
+    // Then the sign-in is refused, naming the claim, rather than answering with
+    // a token that does not carry what the handler asked for.
+    assertStringIncludes(error.message, "claimsToAddOrOverride");
+    assertStringIncludes(error.message, "the reserved claim sub");
+  });
+
+  it("refuses suppressing a claim a token has to carry", async () => {
+    // Given a handler suppressing the expiry.
+    // When the user signs in.
+    const error = await refusalOf({ claimsToSuppress: ["exp"] });
+
+    // Then it is refused, because real Cognito issues that claim whatever a
+    // handler says about it.
+    assertStringIncludes(error.message, "claimsToSuppress");
+    assertStringIncludes(error.message, "the reserved claim exp");
+  });
+
+  it("points a groups override at the field that changes it", async () => {
+    // Given a handler adding the groups claim as an ordinary claim.
+    // When the user signs in.
+    const error = await refusalOf({
+      claimsToAddOrOverride: { "cognito:groups": "tenant-admin" },
+    });
+
+    // Then it says where a group change belongs, because real Cognito ignores
+    // the claim there.
+    assertStringIncludes(error.message, "cognito:groups");
+    assertStringIncludes(
+      error.message,
+      "groupOverrideDetails.groupsToOverride",
+    );
+  });
+
+  it("refuses an override of any other cognito claim", async () => {
+    // Given a handler renaming the user.
+    // When the user signs in.
+    const error = await refusalOf({
+      claimsToAddOrOverride: { "cognito:username": "bob" },
+    });
+
+    // Then it is refused: Cognito reserves the whole prefix.
+    assertStringIncludes(error.message, "cognito:username");
+    assertStringIncludes(error.message, "reserves the cognito: claims");
+  });
+
+  it("refuses a claim value that is not a string", async () => {
+    // Given a handler adding a number, which arrived with the V2_0 event.
+    // When the user signs in.
+    const error = await refusalOf({
+      claimsToAddOrOverride: { seats: 12 },
+    });
+
+    // Then it is refused rather than put on a token a V1_0 trigger would not
+    // have produced.
+    assertStringIncludes(error.message, "value for seats that is not a string");
+    assertStringIncludes(error.message, "V2_0");
+  });
+
+  it("refuses a group override naming IAM roles", async () => {
+    // Given a handler that overrides the roles alongside the groups.
+    // When the user signs in.
+    const error = await refusalOf({
+      groupOverrideDetails: {
+        groupsToOverride: ["tenant-admin"],
+        iamRolesToOverride: ["arn:aws:iam::111111111111:role/TenantAdmin"],
+      },
+    });
+
+    // Then it is refused rather than applying the groups and dropping the
+    // roles, since the claims they feed are not issued here.
+    assertStringIncludes(error.message, "iamRolesToOverride");
+    assertStringIncludes(error.message, "cognito:roles");
+  });
+
+  it("refuses a group override naming a preferred role", async () => {
+    // Given a handler naming the role a member of the group prefers.
+    // When the user signs in.
+    const error = await refusalOf({
+      groupOverrideDetails: {
+        groupsToOverride: ["tenant-admin"],
+        preferredRole: "arn:aws:iam::111111111111:role/TenantAdmin",
+      },
+    });
+
+    // Then it is refused for the same reason.
+    assertStringIncludes(error.message, "preferredRole");
+    assertStringIncludes(error.message, "cognito:preferred_role");
+  });
+
+  it("refuses override details that are not an object", async () => {
+    // Given a handler answering with a string where the details belong.
+    // When the user signs in.
+    const error = await refusalOf("everything");
+
+    // Then it is refused, rather than read as asking for nothing.
+    assertStringIncludes(
+      error.message,
+      "a claimsOverrideDetails that is not an object",
+    );
+  });
+
+  it("refuses claims to suppress that are not a list", async () => {
+    // Given a handler naming one claim to suppress without the list around it.
+    // When the user signs in.
+    const error = await refusalOf({ claimsToSuppress: "email" });
+
+    // Then it is refused rather than read a character at a time.
+    assertStringIncludes(
+      error.message,
+      "a claimsToSuppress that is not a list",
+    );
+  });
+
+  it("refuses a group in a group override that is not a string", async () => {
+    // Given a handler naming a group by something other than its name.
+    // When the user signs in.
+    const error = await refusalOf({
+      groupOverrideDetails: { groupsToOverride: [7] },
+    });
+
+    // Then it is refused, because a group is named by its name.
+    assertStringIncludes(
+      error.message,
+      "a groupsToOverride holding something that is not a string",
+    );
+  });
+
+  it("refuses claims to add that are not an object", async () => {
+    // Given a handler answering with a list of claims rather than a map.
+    // When the user signs in.
+    const error = await refusalOf({ claimsToAddOrOverride: ["tenantId"] });
+
+    // Then it is refused: the field is a map of claim to value.
+    assertStringIncludes(
+      error.message,
+      "a claimsToAddOrOverride that is not an object",
+    );
+  });
+
+  it("accepts a group override whose role fields name nothing", async () => {
+    // Given a handler that carries the role fields empty, as one copying the
+    // request's group configuration back produces.
+    const pool = await makeTriggerPool({
+      triggers: { PreTokenGeneration: triggerFunctionArn },
+      handler: claimsOverrideHandler({
+        groupOverrideDetails: {
+          groupsToOverride: ["tenant-admin"],
+          iamRolesToOverride: [],
+          preferredRole: null,
+        },
+      }),
+    });
+
+    await makeTriggerUser(pool);
+
+    // When the user signs in.
+    const { idToken } = await signInToTriggerPool(pool);
+
+    // Then the groups are applied: naming no role asks for nothing this
+    // simulation would have had to drop.
+    assertArrayEquals(triggerTokenClaims(idToken)["cognito:groups"], [
+      "tenant-admin",
+    ]);
+  });
+
+  it("ignores a response that is not an object at all", async () => {
+    // Given a handler that replaced the response with a string, which real
+    // Cognito reads nothing out of.
+    const pool = await makeTriggerPool({
+      triggers: { PreTokenGeneration: triggerFunctionArn },
+      handler: (event: unknown) => ({
+        ...(event as object),
+        response: "done",
+      }),
+    });
+
+    await makeTriggerUser(pool);
+
+    // When the user signs in.
+    const { idToken } = await signInToTriggerPool(pool);
+
+    // Then the tokens are the ones the pool was going to issue, rather than the
+    // sign-in failing over a response that asked for nothing.
+    assertIdentical(triggerTokenClaims(idToken)["cognito:username"], "alice");
+    assertUndefined(triggerTokenClaims(idToken)["cognito:groups"]);
+  });
+});

--- a/src/service/cognito/user-pool/token/sim-cognito-claims-override.iso.test.ts
+++ b/src/service/cognito/user-pool/token/sim-cognito-claims-override.iso.test.ts
@@ -95,6 +95,20 @@ describe("sim Cognito PreTokenGeneration claims override refusals", () => {
     assertStringIncludes(error.message, "reserves the cognito: claims");
   });
 
+  it("refuses suppressing a cognito claim other than the groups", async () => {
+    // Given a handler suppressing the roles claim directly, which real Cognito
+    // takes off a token by suppressing cognito:groups instead.
+    // When the user signs in.
+    const error = await refusalOf({ claimsToSuppress: ["cognito:roles"] });
+
+    // Then it is refused, and told which claim to name.
+    assertStringIncludes(error.message, "cognito:roles");
+    assertStringIncludes(
+      error.message,
+      "cognito:groups is the only cognito: claim",
+    );
+  });
+
   it("refuses a claim value that is not a string", async () => {
     // Given a handler adding a number, which arrived with the V2_0 event.
     // When the user signs in.

--- a/src/service/cognito/user-pool/token/sim-cognito-claims-override.ts
+++ b/src/service/cognito/user-pool/token/sim-cognito-claims-override.ts
@@ -1,0 +1,108 @@
+import { simCognitoGroupsClaim } from "./sim-cognito-reserved-claims.js";
+import type {
+  SimCognitoClaimValue,
+  SimCognitoTokenClaims,
+} from "./sim-cognito-token-claims.js";
+
+interface SimCognitoClaimsOverrideProperties {
+  readonly added: ReadonlyMap<string, string>;
+  readonly suppressed: ReadonlySet<string>;
+
+  /**
+   * The groups the `cognito:groups` claim is to carry, or nothing when the
+   * handler said nothing about groups and the user's own are to stand.
+   */
+  readonly groups: readonly string[] | undefined;
+}
+
+function withoutClaims(
+  claims: SimCognitoTokenClaims,
+  dropped: ReadonlySet<string>,
+): SimCognitoTokenClaims {
+  return Object.fromEntries(
+    Object.entries(claims).filter(([name]) => !dropped.has(name)),
+  );
+}
+
+/**
+ * What a `PreTokenGeneration` handler asked to change about a token's claims.
+ *
+ * A pool with no such trigger, and a handler that returned the event without
+ * writing a response, both produce an empty one of these, so the token layer
+ * applies an override either way rather than branching on whether there is one.
+ *
+ * The claim changes reach the id token, which is what a V1_0 trigger customises.
+ * The group override reaches the access token as well, because that is the one
+ * change real Cognito lets a V1_0 event make to an access token.
+ */
+export class SimCognitoClaimsOverride {
+  private readonly added: ReadonlyMap<string, string>;
+  private readonly suppressed: ReadonlySet<string>;
+  private readonly groups: readonly string[] | undefined;
+
+  constructor(properties: SimCognitoClaimsOverrideProperties) {
+    this.added = properties.added;
+    this.suppressed = properties.suppressed;
+    this.groups = properties.groups;
+  }
+
+  /**
+   * The override a token is issued under when no handler asked for one.
+   */
+  static none(): SimCognitoClaimsOverride {
+    return new SimCognitoClaimsOverride({
+      added: new Map(),
+      suppressed: new Set(),
+      groups: undefined,
+    });
+  }
+
+  /**
+   * The id token's claims, with the handler's changes applied.
+   *
+   * Suppression runs last, so a claim named in both `claimsToAddOrOverride` and
+   * `claimsToSuppress` is suppressed. Real Cognito resolves the pair the same
+   * way round.
+   */
+  applyTo(claims: SimCognitoTokenClaims): SimCognitoTokenClaims {
+    return withoutClaims(
+      { ...this.withGroups(claims), ...this.addedClaims() },
+      this.suppressed,
+    );
+  }
+
+  /**
+   * The access token's claims, with the group override applied and nothing
+   * else.
+   */
+  applyGroupsTo(claims: SimCognitoTokenClaims): SimCognitoTokenClaims {
+    return this.withGroups(claims);
+  }
+
+  private addedClaims(): Record<string, SimCognitoClaimValue> {
+    return Object.fromEntries(this.added);
+  }
+
+  /**
+   * The claims with `cognito:groups` replaced by the groups the handler named.
+   *
+   * A handler that named no group at all suppresses the claim rather than
+   * carrying an empty list, which is what a pool does for a user in no groups.
+   */
+  private withGroups(claims: SimCognitoTokenClaims): SimCognitoTokenClaims {
+    if (this.groups === undefined) {
+      return claims;
+    }
+
+    const withoutGroups = withoutClaims(
+      claims,
+      new Set([simCognitoGroupsClaim]),
+    );
+
+    if (this.groups.length === 0) {
+      return withoutGroups;
+    }
+
+    return { ...withoutGroups, [simCognitoGroupsClaim]: [...this.groups] };
+  }
+}

--- a/src/service/cognito/user-pool/token/sim-cognito-group-override.ts
+++ b/src/service/cognito/user-pool/token/sim-cognito-group-override.ts
@@ -1,0 +1,78 @@
+/* eslint-disable security/detect-object-injection -- every lookup here is a
+   field name this simulation asks for, such as `groupsToOverride`, read out of
+   the plain object a trigger handler returned. */
+import {
+  refuseSimCognitoResponse,
+  requireSimCognitoResponseObject,
+  requireSimCognitoResponseStrings,
+} from "./sim-cognito-claims-override-values.js";
+
+/**
+ * The fields of `groupOverrideDetails` that name IAM roles.
+ *
+ * Both feed claims this simulation does not issue, so a handler naming one is
+ * refused rather than half-applied: the groups would change and the roles the
+ * handler asked for would silently not be there.
+ */
+const roleOverrideFields = ["iamRolesToOverride", "preferredRole"] as const;
+
+/**
+ * The groups a handler asked the `cognito:groups` claim to carry, or nothing
+ * when it said nothing about groups and the user's own are to stand.
+ *
+ * A `groupOverrideDetails` that is there but empty, or null, suppresses the
+ * claim, as it does on real Cognito. That is why the key being present is what
+ * matters rather than what it holds.
+ */
+export function readSimCognitoGroupOverride(
+  details: Record<string, unknown>,
+): readonly string[] | undefined {
+  if (!("groupOverrideDetails" in details)) {
+    return undefined;
+  }
+
+  const overrideDetails: unknown = details["groupOverrideDetails"];
+
+  if (overrideDetails === undefined || overrideDetails === null) {
+    return [];
+  }
+
+  const group = requireSimCognitoResponseObject(
+    overrideDetails,
+    "groupOverrideDetails",
+  );
+
+  refuseRoleOverrides(group);
+
+  return requireSimCognitoResponseStrings(
+    group["groupsToOverride"],
+    "groupsToOverride",
+  );
+}
+
+/**
+ * Refuse a group override naming IAM roles.
+ *
+ * A field that is there and names no role is left alone, so a handler copying
+ * the request's group configuration back into its response, which is how real
+ * Cognito says to leave the groups as they are, is accepted.
+ */
+function refuseRoleOverrides(group: Record<string, unknown>): void {
+  for (const field of roleOverrideFields) {
+    const value: unknown = group[field];
+
+    if (value === undefined || value === null) {
+      continue;
+    }
+
+    if (Array.isArray(value) && value.length === 0) {
+      continue;
+    }
+
+    refuseSimCognitoResponse(
+      `a groupOverrideDetails naming ${field}. The cognito:roles and ` +
+        `cognito:preferred_role claims are not issued on a token here, so ` +
+        `the roles it names would go nowhere while its groups were applied.`,
+    );
+  }
+}

--- a/src/service/cognito/user-pool/token/sim-cognito-reserved-claims.ts
+++ b/src/service/cognito/user-pool/token/sim-cognito-reserved-claims.ts
@@ -67,9 +67,20 @@ export function requireSimCognitoOverridableClaim(claim: string): void {
  * Refuse a claim a handler asked to suppress that it may not.
  *
  * `cognito:groups` is suppressible, as it is on real Cognito, and it is the one
- * `cognito:` claim that is.
+ * `cognito:` claim that is. Suppressing it is also how real Cognito takes the
+ * role claims off a token, so a handler naming one of those directly is refused
+ * and told which claim to name instead.
  */
 export function requireSimCognitoSuppressibleClaim(claim: string): void {
+  if (claim !== simCognitoGroupsClaim && claim.startsWith("cognito:")) {
+    throw new SimCognitoInvalidLambdaResponseException(
+      `The PreTokenGeneration trigger returned claimsToSuppress naming ` +
+        `${claim}. ${simCognitoGroupsClaim} is the only cognito: claim real ` +
+        `Cognito suppresses, and suppressing that one is what takes the ` +
+        `cognito:roles and cognito:preferred_role claims with it.`,
+    );
+  }
+
   requireUnreservedClaim(claim, "claimsToSuppress");
 }
 

--- a/src/service/cognito/user-pool/token/sim-cognito-reserved-claims.ts
+++ b/src/service/cognito/user-pool/token/sim-cognito-reserved-claims.ts
@@ -1,0 +1,87 @@
+import { SimCognitoInvalidLambdaResponseException } from "../../error/sim-cognito-trigger.error.js";
+
+/**
+ * The claims a `PreTokenGeneration` handler may not add, override or suppress.
+ *
+ * These are the ones real Cognito reserves: the JWT registered claims that say
+ * when a token was issued and who by, and the Cognito claims that identify the
+ * user and the token. A handler naming one of them changes nothing on real
+ * Cognito, which drops the override without saying so.
+ */
+const reservedClaims: ReadonlySet<string> = new Set([
+  "acr",
+  "amr",
+  "at_hash",
+  "aud",
+  "auth_time",
+  "azp",
+  "cognito:username",
+  "exp",
+  "iat",
+  "identities",
+  "iss",
+  "jti",
+  "nbf",
+  "nonce",
+  "origin_jti",
+  "sub",
+  "token_use",
+]);
+
+/**
+ * The claim a group override is written against, which is the one `cognito:`
+ * claim a handler may name in `claimsToSuppress`.
+ */
+export const simCognitoGroupsClaim = "cognito:groups";
+
+/**
+ * Refuse a claim a handler asked to add or override that it may not.
+ *
+ * Refusing is the divergence worth having. Real Cognito silently ignores an
+ * override of a reserved claim, so a handler that appears to work here and does
+ * nothing in production is exactly the failure this simulation exists to catch.
+ */
+export function requireSimCognitoOverridableClaim(claim: string): void {
+  if (claim === simCognitoGroupsClaim) {
+    throw new SimCognitoInvalidLambdaResponseException(
+      `The PreTokenGeneration trigger returned claimsToAddOrOverride naming ` +
+        `${simCognitoGroupsClaim}, which real Cognito ignores there. Use ` +
+        `groupOverrideDetails.groupsToOverride to change the groups on a ` +
+        `token.`,
+    );
+  }
+
+  if (claim.startsWith("cognito:")) {
+    throw new SimCognitoInvalidLambdaResponseException(
+      `The PreTokenGeneration trigger returned claimsToAddOrOverride naming ` +
+        `${claim}. Real Cognito reserves the cognito: claims and ignores an ` +
+        `override of one, so the token would carry the value it was going to ` +
+        `carry anyway.`,
+    );
+  }
+
+  requireUnreservedClaim(claim, "claimsToAddOrOverride");
+}
+
+/**
+ * Refuse a claim a handler asked to suppress that it may not.
+ *
+ * `cognito:groups` is suppressible, as it is on real Cognito, and it is the one
+ * `cognito:` claim that is.
+ */
+export function requireSimCognitoSuppressibleClaim(claim: string): void {
+  requireUnreservedClaim(claim, "claimsToSuppress");
+}
+
+function requireUnreservedClaim(claim: string, field: string): void {
+  if (!reservedClaims.has(claim)) {
+    return;
+  }
+
+  throw new SimCognitoInvalidLambdaResponseException(
+    `The PreTokenGeneration trigger returned ${field} naming the reserved ` +
+      `claim ${claim}. Real Cognito issues that claim itself and ignores a ` +
+      `handler that names it, so a token here would not carry what the ` +
+      `handler asked for either.`,
+  );
+}

--- a/src/service/cognito/user-pool/token/sim-cognito-token-issuer.ts
+++ b/src/service/cognito/user-pool/token/sim-cognito-token-issuer.ts
@@ -3,8 +3,11 @@ import type { SimClock } from "../../../../util/clock/sim-clock.js";
 import { SimCognitoIssuedToken } from "../auth/sim-cognito-issued-token.js";
 import type { SimCognitoUserPoolClient } from "../client/sim-cognito-user-pool-client.js";
 import type { SimCognitoUserPool } from "../sim-cognito-user-pool.js";
+import type { SimCognitoTriggerOccasion } from "../trigger/sim-cognito-trigger-occasion.js";
+import type { SimCognitoUserPoolTriggers } from "../trigger/sim-cognito-user-pool-triggers.js";
 import type { SimCognitoUser } from "../user/sim-cognito-user.js";
 import { SimCognitoAccessToken } from "./sim-cognito-access-token.js";
+import type { SimCognitoClaimsOverride } from "./sim-cognito-claims-override.js";
 import { SimCognitoIdToken } from "./sim-cognito-id-token.js";
 
 /**
@@ -32,12 +35,25 @@ export interface SimCognitoIssuedTokens {
 
 interface SimCognitoTokenIssuerProperties {
   readonly clock: SimClock;
+  readonly triggers: SimCognitoUserPoolTriggers;
 }
 
 interface SimCognitoIssueTokensProperties {
   readonly pool: SimCognitoUserPool;
   readonly client: SimCognitoUserPoolClient;
   readonly user: SimCognitoUser;
+
+  /**
+   * What the pool is issuing tokens for, which is what a `PreTokenGeneration`
+   * handler reads as its `triggerSource`.
+   */
+  readonly occasion: SimCognitoTriggerOccasion;
+
+  /**
+   * The `ClientMetadata` the request carried, which reaches the token trigger
+   * from a challenge response and from nowhere else, as on real Cognito.
+   */
+  readonly clientMetadata?: Readonly<Record<string, string>> | undefined;
 }
 
 /**
@@ -50,12 +66,19 @@ interface SimCognitoIssueTokensProperties {
  *
  * What it issues is remembered on the pool, because the pool is what a refresh
  * or a sign-out presents a token back to.
+ *
+ * The pool's `PreTokenGeneration` trigger runs here, because this is where the
+ * claims of a token are settled. It runs on a refresh as well as on a sign-in,
+ * so a claim a handler changed between the two is not stale on the reissued
+ * token.
  */
 export class SimCognitoTokenIssuer {
   private readonly clock: SimClock;
+  private readonly triggers: SimCognitoUserPoolTriggers;
 
   constructor(properties: SimCognitoTokenIssuerProperties) {
     this.clock = properties.clock;
+    this.triggers = properties.triggers;
   }
 
   private static expiryOf(issuedAt: Date, seconds: number): Date {
@@ -69,10 +92,17 @@ export class SimCognitoTokenIssuer {
    * The two JWTs last as long as the app client says, which is an hour each
    * unless the client was created with its own validity, and the refresh token
    * lasts the thirty days real Cognito gives one by default.
+   *
+   * The refresh token is minted after the JWTs are signed, so a
+   * `PreTokenGeneration` handler that refuses the request leaves the pool
+   * holding no token from a sign-in that never answered with one.
    */
-  issue(properties: SimCognitoIssueTokensProperties): SimCognitoIssuedTokens {
+  async issue(
+    properties: SimCognitoIssueTokensProperties,
+  ): Promise<SimCognitoIssuedTokens> {
     const { pool, client, user } = properties;
     const issuedAt = this.clock.now();
+    const signed = await this.signTokens(properties, issuedAt);
     const refreshToken = randomBytes(refreshTokenBytes).toString("base64url");
 
     pool.auth.addRefreshToken(
@@ -88,7 +118,7 @@ export class SimCognitoTokenIssuer {
       }),
     );
 
-    return { ...this.signTokens(properties, issuedAt), refreshToken };
+    return { ...signed, refreshToken };
   }
 
   /**
@@ -99,15 +129,18 @@ export class SimCognitoTokenIssuer {
    * refresh token rotation off, so the caller keeps using the one it has until
    * that expires.
    */
-  reissue(properties: SimCognitoIssueTokensProperties): SimCognitoIssuedTokens {
-    return this.signTokens(properties, this.clock.now());
+  async reissue(
+    properties: SimCognitoIssueTokensProperties,
+  ): Promise<SimCognitoIssuedTokens> {
+    return await this.signTokens(properties, this.clock.now());
   }
 
-  private signTokens(
+  private async signTokens(
     properties: SimCognitoIssueTokensProperties,
     issuedAt: Date,
-  ): SimCognitoIssuedTokens {
+  ): Promise<SimCognitoIssuedTokens> {
     const { pool, client, user } = properties;
+    const claimsOverride = await this.claimsOverride(properties);
     const accessTokenSeconds = client.tokenValidity.accessToken.seconds;
     const accessTokenExpiresAt = SimCognitoTokenIssuer.expiryOf(
       issuedAt,
@@ -131,7 +164,12 @@ export class SimCognitoTokenIssuer {
       tokenId: randomUUID(),
     });
 
-    const signedAccessToken = pool.signingKey.sign(accessToken.claims());
+    // A V1_0 trigger customises the id token, and the one change it makes to an
+    // access token is the group override, which is why the access token is
+    // signed with that alone applied.
+    const signedAccessToken = pool.signingKey.sign(
+      claimsOverride.applyGroupsTo(accessToken.claims()),
+    );
 
     pool.auth.addAccessToken(
       new SimCognitoIssuedToken({
@@ -144,9 +182,22 @@ export class SimCognitoTokenIssuer {
     );
 
     return {
-      idToken: pool.signingKey.sign(idToken.claims()),
+      idToken: pool.signingKey.sign(claimsOverride.applyTo(idToken.claims())),
       accessToken: signedAccessToken,
       expiresIn: accessTokenSeconds,
     };
+  }
+
+  private async claimsOverride(
+    properties: SimCognitoIssueTokensProperties,
+  ): Promise<SimCognitoClaimsOverride> {
+    const { pool, client, user, occasion, clientMetadata } = properties;
+
+    return await this.triggers.preTokenGeneration(occasion, {
+      pool,
+      client,
+      user,
+      clientMetadata,
+    });
   }
 }

--- a/src/service/cognito/user-pool/trigger/sim-cognito-lambda-config.iso.test.ts
+++ b/src/service/cognito/user-pool/trigger/sim-cognito-lambda-config.iso.test.ts
@@ -47,6 +47,61 @@ describe("sim Cognito user pool LambdaConfig", () => {
     });
   });
 
+  it("creates a pool with the token trigger and reports it", async () => {
+    // Given a simulation.
+    const cognito = new SimAws().cognitoIdentityProvider();
+
+    // When a pool is created with a PreTokenGeneration trigger, which is the
+    // V1_0 token trigger this simulation runs.
+    const created = await cognito.createUserPool(
+      new CreateUserPoolCommand({
+        PoolName: "myapp-users",
+        LambdaConfig: { PreTokenGeneration: triggerFunctionArn },
+      }),
+    );
+
+    assertNonNullable(created.UserPool?.Id);
+
+    // Then a described pool reports it.
+    const described = await cognito.describeUserPool(
+      new DescribeUserPoolCommand({ UserPoolId: created.UserPool.Id }),
+    );
+    assertObjectEquals(described.UserPool?.LambdaConfig, {
+      PreTokenGeneration: triggerFunctionArn,
+    });
+  });
+
+  it("refuses the token trigger versions that customise an access token", async () => {
+    // Given a simulation.
+    const cognito = new SimAws().cognitoIdentityProvider();
+
+    // When a pool asks for the V2_0 or V3_0 token trigger.
+    const error = await assertThrowsErrorAsync(async () =>
+      cognito.createUserPool(
+        new CreateUserPoolCommand({
+          PoolName: "myapp-users",
+          LambdaConfig: {
+            PreTokenGenerationConfig: {
+              LambdaArn: triggerFunctionArn,
+              LambdaVersion: "V2_0",
+            },
+          },
+        }),
+      ),
+    );
+
+    // Then it is refused, and pointed at the trigger that does run here.
+    assertIdentical(error.name, "InvalidParameterException");
+    assertStringIncludes(
+      error.message,
+      "CreateUserPool LambdaConfig PreTokenGenerationConfig is not simulated",
+    );
+    assertStringIncludes(
+      error.message,
+      "Name the function in PreTokenGeneration",
+    );
+  });
+
   it("reports no LambdaConfig for a pool created without one", async () => {
     // Given a simulation.
     const cognito = new SimAws().cognitoIdentityProvider();
@@ -89,15 +144,14 @@ describe("sim Cognito user pool LambdaConfig", () => {
     // Given a simulation.
     const cognito = new SimAws().cognitoIdentityProvider();
 
-    // When a pool asks for a token generation trigger alongside one that is
-    // simulated.
+    // When a pool asks for a message trigger alongside one that is simulated.
     const error = await assertThrowsErrorAsync(async () =>
       cognito.createUserPool(
         new CreateUserPoolCommand({
           PoolName: "myapp-users",
           LambdaConfig: {
             PreAuthentication: triggerFunctionArn,
-            PreTokenGeneration: otherFunctionArn,
+            CustomMessage: otherFunctionArn,
           },
         }),
       ),
@@ -108,11 +162,11 @@ describe("sim Cognito user pool LambdaConfig", () => {
     assertIdentical(error.name, "InvalidParameterException");
     assertStringIncludes(
       error.message,
-      "CreateUserPool LambdaConfig PreTokenGeneration is not simulated",
+      "CreateUserPool LambdaConfig CustomMessage is not simulated",
     );
     assertStringIncludes(
       error.message,
-      "changing the claims a pool puts in its tokens",
+      "writing the wording of a message the pool sends",
     );
   });
 

--- a/src/service/cognito/user-pool/trigger/sim-cognito-lambda-config.ts
+++ b/src/service/cognito/user-pool/trigger/sim-cognito-lambda-config.ts
@@ -16,6 +16,7 @@ export interface SimCognitoLambdaConfigType {
   readonly PostConfirmation?: string | undefined;
   readonly PreAuthentication?: string | undefined;
   readonly PostAuthentication?: string | undefined;
+  readonly PreTokenGeneration?: string | undefined;
 }
 
 /**

--- a/src/service/cognito/user-pool/trigger/sim-cognito-pre-token-generation-occasions.iso.test.ts
+++ b/src/service/cognito/user-pool/trigger/sim-cognito-pre-token-generation-occasions.iso.test.ts
@@ -1,0 +1,195 @@
+/* eslint-disable @typescript-eslint/naming-convention -- the authentication
+   parameter names are Cognito's own, rather than identifier names. */
+import {
+  AdminInitiateAuthCommand,
+  AdminRespondToAuthChallengeCommand,
+  InitiateAuthCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertObjectMatches,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import {
+  makeTriggerPool,
+  makeTriggerUser,
+  triggerFunctionArn,
+} from "../../../../../test/cognito/trigger-fixture.js";
+import { recordingTriggerHandler } from "../../../../../test/cognito/trigger-handler-fixture.js";
+import {
+  signInToTriggerPool,
+  triggerTokenClaims,
+} from "../../../../../test/cognito/trigger-token-fixture.js";
+import type { SimCognitoTriggerPool } from "../../../../../test/cognito/trigger-fixture.js";
+
+const newPassword = "Rep1acementPassw0rd!";
+
+/**
+ * Answer the `NEW_PASSWORD_REQUIRED` challenge a user with a temporary
+ * password is given, which is where its sign-in finishes.
+ */
+async function answerChallenge(
+  pool: SimCognitoTriggerPool,
+  clientMetadata: Readonly<Record<string, string>>,
+): Promise<string> {
+  const challenged = await pool.cognito.adminInitiateAuth(
+    new AdminInitiateAuthCommand({
+      UserPoolId: pool.userPoolId,
+      ClientId: pool.clientId,
+      AuthFlow: "ADMIN_USER_PASSWORD_AUTH",
+      AuthParameters: { USERNAME: "alice", PASSWORD: "Temp0rary!" },
+    }),
+  );
+
+  assertNonNullable(challenged.Session);
+
+  const signedIn = await pool.cognito.adminRespondToAuthChallenge(
+    new AdminRespondToAuthChallengeCommand({
+      UserPoolId: pool.userPoolId,
+      ClientId: pool.clientId,
+      ChallengeName: "NEW_PASSWORD_REQUIRED",
+      ChallengeResponses: { USERNAME: "alice", NEW_PASSWORD: newPassword },
+      Session: challenged.Session,
+      ClientMetadata: clientMetadata,
+    }),
+  );
+
+  assertNonNullable(signedIn.AuthenticationResult?.IdToken);
+
+  return signedIn.AuthenticationResult.IdToken;
+}
+
+describe("sim Cognito PreTokenGeneration trigger occasions", () => {
+  it("runs the trigger again on a refresh, with the claim it now returns", async () => {
+    // Given a pool whose token trigger names a different tenant the second
+    // time it runs.
+    const tenants = ["acme", "acme-holdings"];
+    const pool = await makeTriggerPool({
+      triggers: { PreTokenGeneration: triggerFunctionArn },
+      handler: (event: unknown) => ({
+        ...(event as object),
+        response: {
+          claimsOverrideDetails: {
+            claimsToAddOrOverride: { tenantId: tenants.shift() ?? "none" },
+          },
+        },
+      }),
+    });
+
+    await makeTriggerUser(pool);
+
+    const { idToken, refreshToken } = await signInToTriggerPool(pool);
+
+    assertIdentical(triggerTokenClaims(idToken)["tenantId"], "acme");
+
+    // When the session is renewed with the refresh token.
+    const refreshed = await pool.cognito.initiateAuth(
+      new InitiateAuthCommand({
+        ClientId: pool.clientId,
+        AuthFlow: "REFRESH_TOKEN_AUTH",
+        AuthParameters: { REFRESH_TOKEN: refreshToken },
+      }),
+    );
+
+    assertNonNullable(refreshed.AuthenticationResult?.IdToken);
+
+    // Then the reissued token carries what the handler returns now, rather
+    // than the claim the first sign-in put on it.
+    assertIdentical(
+      triggerTokenClaims(refreshed.AuthenticationResult.IdToken)["tenantId"],
+      "acme-holdings",
+    );
+  });
+
+  it("names the refresh as the occasion the trigger fired on", async () => {
+    // Given a pool recording every event its token trigger is given.
+    const events: unknown[] = [];
+    const pool = await makeTriggerPool({
+      triggers: { PreTokenGeneration: triggerFunctionArn },
+      handler: recordingTriggerHandler(events),
+    });
+
+    await makeTriggerUser(pool);
+
+    const { refreshToken } = await signInToTriggerPool(pool);
+
+    // When the session is renewed.
+    await pool.cognito.initiateAuth(
+      new InitiateAuthCommand({
+        ClientId: pool.clientId,
+        AuthFlow: "REFRESH_TOKEN_AUTH",
+        AuthParameters: { REFRESH_TOKEN: refreshToken },
+      }),
+    );
+
+    // Then the second event names the refresh, so a handler can tell it from
+    // the sign-in that came before it.
+    assertObjectMatches(events[1], {
+      triggerSource: "TokenGeneration_RefreshTokens",
+      userName: "alice",
+    });
+  });
+
+  it("runs the trigger where the new password challenge is answered", async () => {
+    // Given a pool with a token trigger, and a user that has to replace its
+    // temporary password before it can sign in.
+    const events: unknown[] = [];
+    const pool = await makeTriggerPool({
+      triggers: { PreTokenGeneration: triggerFunctionArn },
+      handler: (event: unknown) => {
+        events.push(structuredClone(event));
+
+        return {
+          ...(event as object),
+          response: {
+            claimsOverrideDetails: {
+              claimsToAddOrOverride: { tenantId: "acme" },
+            },
+          },
+        };
+      },
+    });
+
+    await makeTriggerUser(pool, false);
+
+    // When the user answers the challenge, carrying metadata with it.
+    const idToken = await answerChallenge(pool, { tenant: "acme" });
+
+    // Then the trigger fired for the occasion real Cognito names it for, and
+    // the token it issued carries the claim.
+    assertObjectMatches(events[0], {
+      triggerSource: "TokenGeneration_NewPasswordChallenge",
+      request: { clientMetadata: { tenant: "acme" } },
+    });
+    assertIdentical(triggerTokenClaims(idToken)["tenantId"], "acme");
+  });
+
+  it("refuses the sign-in with the message the handler threw", async () => {
+    // Given a token trigger that cannot work out what to put on the token.
+    const pool = await makeTriggerPool({
+      triggers: { PreTokenGeneration: triggerFunctionArn },
+      handler: () => {
+        throw new Error("The tenant directory is unreachable");
+      },
+    });
+
+    await makeTriggerUser(pool);
+
+    // When the user signs in.
+    const error = await assertThrowsErrorAsync(async () =>
+      signInToTriggerPool(pool),
+    );
+
+    // Then the sign-in was refused, carrying the handler's own words, as a
+    // failing trigger refuses one on real Cognito.
+    assertIdentical(error.name, "UserLambdaValidationException");
+    assertStringIncludes(
+      error.message,
+      "PreTokenGeneration failed with error The tenant directory is unreachable.",
+    );
+  });
+});

--- a/src/service/cognito/user-pool/trigger/sim-cognito-pre-token-generation.iso.test.ts
+++ b/src/service/cognito/user-pool/trigger/sim-cognito-pre-token-generation.iso.test.ts
@@ -1,0 +1,261 @@
+import {
+  AdminAddUserToGroupCommand,
+  CreateGroupCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import {
+  assertArrayEquals,
+  assertIdentical,
+  assertNonNullable,
+  assertObjectMatches,
+  assertUndefined,
+} from "@kensio/smartass";
+import { CognitoJwtVerifier } from "aws-jwt-verify";
+import { describe, it } from "vitest";
+
+import {
+  makeTriggerPool,
+  makeTriggerUser,
+  triggerFunctionArn,
+} from "../../../../../test/cognito/trigger-fixture.js";
+import { recordingTriggerHandler } from "../../../../../test/cognito/trigger-handler-fixture.js";
+import { claimsOverrideHandler } from "../../../../../test/cognito/trigger-handler-fixture.js";
+import {
+  signInToTriggerPool,
+  triggerTokenClaims,
+} from "../../../../../test/cognito/trigger-token-fixture.js";
+import type { SimCognitoTriggerPool } from "../../../../../test/cognito/trigger-fixture.js";
+
+/**
+ * A pool whose PreTokenGeneration handler answers with these override details,
+ * and a user ready to sign in.
+ */
+async function poolOverriding(
+  details: unknown,
+): Promise<SimCognitoTriggerPool> {
+  const pool = await makeTriggerPool({
+    triggers: { PreTokenGeneration: triggerFunctionArn },
+    handler: claimsOverrideHandler(details),
+  });
+
+  await makeTriggerUser(pool);
+
+  return pool;
+}
+
+/**
+ * Put the user in a group, so the tokens it signs in for carry a
+ * `cognito:groups` claim for a handler to replace.
+ */
+async function addToGroup(
+  pool: SimCognitoTriggerPool,
+  groupName: string,
+): Promise<void> {
+  await pool.cognito.createGroup(
+    new CreateGroupCommand({
+      UserPoolId: pool.userPoolId,
+      GroupName: groupName,
+    }),
+  );
+  await pool.cognito.adminAddUserToGroup(
+    new AdminAddUserToGroupCommand({
+      UserPoolId: pool.userPoolId,
+      Username: "alice",
+      GroupName: groupName,
+    }),
+  );
+}
+
+describe("sim Cognito PreTokenGeneration trigger", () => {
+  it("puts a claim the handler added on the id token", async () => {
+    // Given a pool whose token trigger adds a tenant to every id token.
+    const pool = await poolOverriding({
+      claimsToAddOrOverride: { tenantId: "acme" },
+    });
+
+    // When the user signs in.
+    const { idToken, accessToken } = await signInToTriggerPool(pool);
+
+    // Then the id token carries the claim the handler asked for.
+    assertIdentical(triggerTokenClaims(idToken)["tenantId"], "acme");
+
+    // And the access token does not: a V1_0 trigger customises the id token.
+    assertUndefined(triggerTokenClaims(accessToken)["tenantId"]);
+  });
+
+  it("signs the overridden id token so it still verifies", async () => {
+    // Given a signed-in user of a pool that adds a claim, and a verifier
+    // configured for the pool rather than told what to expect.
+    const pool = await poolOverriding({
+      claimsToAddOrOverride: { tenantId: "acme" },
+    });
+    const { idToken } = await signInToTriggerPool(pool);
+    const verifier = CognitoJwtVerifier.create({
+      userPoolId: pool.userPoolId,
+      tokenUse: "id",
+      clientId: pool.clientId,
+    });
+
+    verifier.cacheJwks(pool.cognito.userPool(pool.userPoolId).jwks());
+
+    // When the verifier verifies the token.
+    const payload = await verifier.verify(idToken);
+
+    // Then it passes with the added claim on it, so the trigger changed the
+    // claims before the pool signed them rather than after.
+    assertIdentical(payload["tenantId"], "acme");
+    assertIdentical(payload.token_use, "id");
+  });
+
+  it("overrides a claim the token would otherwise carry", async () => {
+    // Given a handler that replaces the user's email.
+    const pool = await poolOverriding({
+      claimsToAddOrOverride: { email: "alice@acme.example" },
+    });
+
+    // When the user signs in.
+    const { idToken } = await signInToTriggerPool(pool);
+
+    // Then the token carries the handler's value rather than the attribute's.
+    assertIdentical(triggerTokenClaims(idToken)["email"], "alice@acme.example");
+  });
+
+  it("removes a claim the handler suppressed", async () => {
+    // Given a handler that keeps the user's email off the token.
+    const pool = await poolOverriding({ claimsToSuppress: ["email"] });
+
+    // When the user signs in.
+    const { idToken } = await signInToTriggerPool(pool);
+
+    // Then the claim is gone rather than empty.
+    assertUndefined(triggerTokenClaims(idToken)["email"]);
+  });
+
+  it("suppresses a claim it was asked to override as well", async () => {
+    // Given a handler that names the same claim in both fields, which real
+    // Cognito resolves by suppressing it.
+    const pool = await poolOverriding({
+      claimsToAddOrOverride: { email: "alice@acme.example" },
+      claimsToSuppress: ["email"],
+    });
+
+    // When the user signs in.
+    const { idToken } = await signInToTriggerPool(pool);
+
+    // Then the claim is suppressed, rather than carrying the value the same
+    // response asked for.
+    assertUndefined(triggerTokenClaims(idToken)["email"]);
+  });
+
+  it("replaces the groups claim rather than adding to it", async () => {
+    // Given a user in a group of the pool, and a handler that names another.
+    const pool = await poolOverriding({
+      groupOverrideDetails: { groupsToOverride: ["tenant-admin"] },
+    });
+
+    await addToGroup(pool, "staff");
+
+    // When the user signs in.
+    const { idToken, accessToken } = await signInToTriggerPool(pool);
+
+    // Then the claim holds the handler's groups alone, on both tokens: the
+    // group override is the one change a V1_0 event makes to an access token.
+    assertArrayEquals(triggerTokenClaims(idToken)["cognito:groups"], [
+      "tenant-admin",
+    ]);
+    assertArrayEquals(triggerTokenClaims(accessToken)["cognito:groups"], [
+      "tenant-admin",
+    ]);
+  });
+
+  it("suppresses the groups for a group override naming none", async () => {
+    // Given a user in a group, and a handler answering with an empty group
+    // override, which real Cognito reads as suppressing the groups.
+    const pool = await poolOverriding({ groupOverrideDetails: {} });
+
+    await addToGroup(pool, "staff");
+
+    // When the user signs in.
+    const { idToken } = await signInToTriggerPool(pool);
+
+    // Then the token carries no groups claim at all, rather than an empty list.
+    assertUndefined(triggerTokenClaims(idToken)["cognito:groups"]);
+  });
+
+  it("reads a response of nulls as asking for nothing but the groups", async () => {
+    // Given a handler whose response carries the fields at null, as a handler
+    // building its response from optional values produces.
+    const pool = await poolOverriding({
+      claimsToAddOrOverride: null,
+      claimsToSuppress: null,
+      groupOverrideDetails: null,
+    });
+
+    await addToGroup(pool, "staff");
+
+    // When the user signs in.
+    const { idToken } = await signInToTriggerPool(pool);
+
+    // Then the claims stand, and the null group override suppresses the groups
+    // as an empty one does.
+    assertIdentical(triggerTokenClaims(idToken)["email"], "alice@example.com");
+    assertUndefined(triggerTokenClaims(idToken)["cognito:groups"]);
+  });
+
+  it("gives the handler the user's groups and the occasion it fired on", async () => {
+    // Given a pool recording the event its token trigger is given.
+    const events: unknown[] = [];
+    const pool = await makeTriggerPool({
+      triggers: { PreTokenGeneration: triggerFunctionArn },
+      handler: recordingTriggerHandler(events),
+    });
+
+    await makeTriggerUser(pool);
+    await addToGroup(pool, "staff");
+
+    // When the user signs in, with metadata on the request.
+    await signInToTriggerPool(pool, { tenant: "acme" });
+
+    // Then the handler was given the real event, naming the occasion and the
+    // groups the user is in.
+    assertObjectMatches(events[0], {
+      triggerSource: "TokenGeneration_Authentication",
+      userName: "alice",
+      request: {
+        userAttributes: { email: "alice@example.com" },
+        groupConfiguration: { groupsToOverride: ["staff"] },
+      },
+      response: {},
+    });
+
+    // And no client metadata: real Cognito passes an InitiateAuth request's on
+    // to the authentication triggers and not to this one.
+    assertUndefined(
+      (events[0] as { request: { clientMetadata?: object } }).request
+        .clientMetadata,
+    );
+  });
+
+  it("issues the ordinary claims for a handler that wrote no response", async () => {
+    // Given a token trigger that hands the event straight back, which is what a
+    // handler with nothing to say does.
+    const pool = await makeTriggerPool({
+      triggers: { PreTokenGeneration: triggerFunctionArn },
+      handler: (event: unknown) => {
+        const { response, ...rest } = event as { response: unknown };
+
+        assertNonNullable(response);
+
+        return rest;
+      },
+    });
+
+    await makeTriggerUser(pool);
+
+    // When the user signs in.
+    const { idToken } = await signInToTriggerPool(pool);
+
+    // Then the token carries what the pool was going to issue anyway.
+    assertIdentical(triggerTokenClaims(idToken)["email"], "alice@example.com");
+    assertIdentical(triggerTokenClaims(idToken)["cognito:username"], "alice");
+  });
+});

--- a/src/service/cognito/user-pool/trigger/sim-cognito-trigger-invocation.ts
+++ b/src/service/cognito/user-pool/trigger/sim-cognito-trigger-invocation.ts
@@ -1,0 +1,94 @@
+import {
+  SimCognitoUnexpectedLambdaException,
+  SimCognitoUserLambdaValidationException,
+} from "../../error/sim-cognito-trigger.error.js";
+import type { SimCognitoTriggerContext } from "./sim-cognito-trigger-context.js";
+import { SimCognitoTriggerEvent } from "./sim-cognito-trigger-event.js";
+import type {
+  SimCognitoTriggerFunctionRequest,
+  SimCognitoTriggerFunctions,
+} from "./sim-cognito-trigger-functions.js";
+import type { SimCognitoTriggerOccasion } from "./sim-cognito-trigger-occasion.js";
+import { requireSimCognitoTriggerResponse } from "./sim-cognito-trigger-response.js";
+
+/**
+ * Reaching the function a pool's trigger names.
+ *
+ * A pool with no trigger for the occasion runs nothing, which is the ordinary
+ * case and costs a map lookup. A pool with one invokes it and waits: these
+ * triggers are synchronous, so the request is held up until the handler
+ * answers, as it is on real Cognito.
+ *
+ * The function's resource policy is checked on every invocation rather than
+ * remembered from the first, because a permission revoked afterwards stops the
+ * trigger on real Cognito too.
+ */
+export class SimCognitoTriggerInvocation {
+  private readonly functions: SimCognitoTriggerFunctions;
+
+  constructor(functions: SimCognitoTriggerFunctions) {
+    this.functions = functions;
+  }
+
+  /**
+   * Invoke the trigger for one occasion, answering with what the handler
+   * returned, or with nothing where the pool has no such trigger.
+   */
+  async run(
+    occasion: SimCognitoTriggerOccasion,
+    context: SimCognitoTriggerContext,
+  ): Promise<unknown> {
+    const { trigger } = occasion;
+    const functionArn = context.pool.settings.lambdaConfig.find(trigger);
+
+    if (functionArn === undefined) {
+      return undefined;
+    }
+
+    const request: SimCognitoTriggerFunctionRequest = {
+      functionArn,
+      userPoolArn: context.pool.arn.value,
+      userPoolAccountId: context.pool.arn.accountId,
+    };
+    const refusal = this.functions.invokeRefusal(request);
+
+    if (refusal !== undefined) {
+      throw new SimCognitoUnexpectedLambdaException(
+        `The ${trigger} trigger of user pool ${context.pool.id} could not be ` +
+          `invoked. ${refusal}`,
+      );
+    }
+
+    const returned = await this.invoke(occasion, request, context);
+
+    requireSimCognitoTriggerResponse(trigger, returned);
+
+    return returned;
+  }
+
+  /**
+   * Invoke the handler, reporting a failure the way real Cognito reports one.
+   *
+   * The handler's own message is repeated because that is the whole mechanism a
+   * `PreSignUp` or `PreAuthentication` trigger refuses a request with: it
+   * throws, and the words it threw are what the caller is told.
+   */
+  private async invoke(
+    occasion: SimCognitoTriggerOccasion,
+    request: SimCognitoTriggerFunctionRequest,
+    context: SimCognitoTriggerContext,
+  ): Promise<unknown> {
+    try {
+      return await this.functions.invoke(
+        request,
+        new SimCognitoTriggerEvent(context).document(occasion),
+      );
+    } catch (error) {
+      throw new SimCognitoUserLambdaValidationException(
+        `${occasion.trigger} failed with error ${
+          error instanceof Error ? error.message : String(error)
+        }.`,
+      );
+    }
+  }
+}

--- a/src/service/cognito/user-pool/trigger/sim-cognito-trigger-name.ts
+++ b/src/service/cognito/user-pool/trigger/sim-cognito-trigger-name.ts
@@ -1,16 +1,18 @@
 /**
  * The Lambda triggers a simulated user pool runs.
  *
- * These are the ones that fire around a sign-up and around a sign-in, which is
- * the part of a user's life this simulation has. A pool sends no messages and
- * federates with nobody, so the message and federation triggers would never run
- * whatever a pool named for them.
+ * These are the ones that fire around a sign-up, around a sign-in, and over the
+ * tokens a sign-in hands out, which is the part of a user's life this
+ * simulation has. A pool sends no messages and federates with nobody, so the
+ * message and federation triggers would never run whatever a pool named for
+ * them.
  */
 export const simCognitoTriggerNames = [
   "PreSignUp",
   "PostConfirmation",
   "PreAuthentication",
   "PostAuthentication",
+  "PreTokenGeneration",
 ] as const;
 
 export type SimCognitoTriggerName = (typeof simCognitoTriggerNames)[number];
@@ -25,10 +27,11 @@ export type SimCognitoTriggerName = (typeof simCognitoTriggerNames)[number];
  */
 export const simCognitoUnsimulatedTriggers: ReadonlyMap<string, string> =
   new Map([
-    ["PreTokenGeneration", "changing the claims a pool puts in its tokens"],
     [
       "PreTokenGenerationConfig",
-      "changing the claims a pool puts in its tokens",
+      "the V2_0 and V3_0 token triggers, which customise access token claims " +
+        "and scopes. Name the function in PreTokenGeneration for the V1_0 " +
+        "trigger, which customises the id token",
     ],
     ["CustomMessage", "writing the wording of a message the pool sends"],
     ["DefineAuthChallenge", "the custom authentication challenge flow"],

--- a/src/service/cognito/user-pool/trigger/sim-cognito-trigger-occasion.ts
+++ b/src/service/cognito/user-pool/trigger/sim-cognito-trigger-occasion.ts
@@ -90,11 +90,10 @@ export class SimCognitoTriggerOccasion {
    * changed since the sign-in reaches the reissued token rather than being
    * stale for the life of the session.
    */
-  public static readonly refreshTokenGeneration =
-    new SimCognitoTriggerOccasion(
-      "PreTokenGeneration",
-      "TokenGeneration_RefreshTokens",
-    );
+  public static readonly refreshTokenGeneration = new SimCognitoTriggerOccasion(
+    "PreTokenGeneration",
+    "TokenGeneration_RefreshTokens",
+  );
 
   public readonly trigger: SimCognitoTriggerName;
   public readonly source: string;

--- a/src/service/cognito/user-pool/trigger/sim-cognito-trigger-occasion.ts
+++ b/src/service/cognito/user-pool/trigger/sim-cognito-trigger-occasion.ts
@@ -61,6 +61,41 @@ export class SimCognitoTriggerOccasion {
     "PostAuthentication_Authentication",
   );
 
+  /**
+   * The tokens a sign-in hands out.
+   */
+  public static readonly tokenGeneration = new SimCognitoTriggerOccasion(
+    "PreTokenGeneration",
+    "TokenGeneration_Authentication",
+  );
+
+  /**
+   * The tokens handed out where a sign-in finishes by answering the new
+   * password challenge.
+   *
+   * This is also the one occasion a request's `ClientMetadata` reaches the
+   * token trigger, because real Cognito passes it on from
+   * `RespondToAuthChallenge` and `AdminRespondToAuthChallenge` alone.
+   */
+  public static readonly newPasswordTokenGeneration =
+    new SimCognitoTriggerOccasion(
+      "PreTokenGeneration",
+      "TokenGeneration_NewPasswordChallenge",
+    );
+
+  /**
+   * The tokens a `REFRESH_TOKEN_AUTH` refresh hands out.
+   *
+   * Real Cognito runs the token trigger again here, so a claim a handler has
+   * changed since the sign-in reaches the reissued token rather than being
+   * stale for the life of the session.
+   */
+  public static readonly refreshTokenGeneration =
+    new SimCognitoTriggerOccasion(
+      "PreTokenGeneration",
+      "TokenGeneration_RefreshTokens",
+    );
+
   public readonly trigger: SimCognitoTriggerName;
   public readonly source: string;
 

--- a/src/service/cognito/user-pool/trigger/sim-cognito-trigger-request.ts
+++ b/src/service/cognito/user-pool/trigger/sim-cognito-trigger-request.ts
@@ -34,7 +34,37 @@ export class SimCognitoTriggerRequest {
       case "PostAuthentication": {
         return this.postAuthentication();
       }
+      case "PreTokenGeneration": {
+        return this.preTokenGeneration();
+      }
     }
+  }
+
+  /**
+   * What a `PreTokenGeneration` handler is given.
+   *
+   * `groupConfiguration.groupsToOverride` is the user's groups in precedence
+   * order, which is what a handler copies back into `groupOverrideDetails` to
+   * leave the `cognito:groups` claim alone. The `iamRolesToOverride` and
+   * `preferredRole` real Cognito sends beside it are left out, because the
+   * claims they feed are not issued here and a response naming them is refused.
+   *
+   * The client metadata is there only where the occasion carried it, which is a
+   * challenge response and nothing else: real Cognito does not pass an
+   * `InitiateAuth` request's `ClientMetadata` on to this trigger.
+   */
+  private preTokenGeneration(): object {
+    const { pool, user } = this.context;
+
+    return {
+      userAttributes: this.userAttributes(),
+      groupConfiguration: {
+        groupsToOverride: pool
+          .groupsOf(user.username)
+          .map((group) => group.name),
+      },
+      ...this.clientMetadata(),
+    };
   }
 
   /**

--- a/src/service/cognito/user-pool/trigger/sim-cognito-user-pool-triggers.ts
+++ b/src/service/cognito/user-pool/trigger/sim-cognito-user-pool-triggers.ts
@@ -1,18 +1,10 @@
-import {
-  SimCognitoUnexpectedLambdaException,
-  SimCognitoUserLambdaValidationException,
-} from "../../error/sim-cognito-trigger.error.js";
 import type { SimCognitoClaimsOverride } from "../token/sim-cognito-claims-override.js";
 import { SimCognitoClaimsOverrideReader } from "../token/sim-cognito-claims-override-reader.js";
 import { SimCognitoPreSignUpResponse } from "./sim-cognito-pre-sign-up-response.js";
 import type { SimCognitoTriggerContext } from "./sim-cognito-trigger-context.js";
-import { SimCognitoTriggerEvent } from "./sim-cognito-trigger-event.js";
-import type {
-  SimCognitoTriggerFunctionRequest,
-  SimCognitoTriggerFunctions,
-} from "./sim-cognito-trigger-functions.js";
+import type { SimCognitoTriggerFunctions } from "./sim-cognito-trigger-functions.js";
+import { SimCognitoTriggerInvocation } from "./sim-cognito-trigger-invocation.js";
 import { SimCognitoTriggerOccasion } from "./sim-cognito-trigger-occasion.js";
-import { requireSimCognitoTriggerResponse } from "./sim-cognito-trigger-response.js";
 
 interface SimCognitoUserPoolTriggersProperties {
   readonly functions: SimCognitoTriggerFunctions;
@@ -21,21 +13,17 @@ interface SimCognitoUserPoolTriggersProperties {
 /**
  * Runs the Lambda triggers a simulated user pool names.
  *
- * A pool with no trigger for the occasion runs nothing, which is the ordinary
- * case and costs a map lookup. A pool with one invokes it and waits: these
- * triggers are synchronous, so the request is held up until the handler
- * answers, as it is on real Cognito.
- *
- * The function's resource policy is checked on every invocation rather than
- * remembered from the first, because a permission revoked afterwards stops the
- * trigger on real Cognito too.
+ * One method per trigger, because each says something different about when it
+ * fires and what the pool does with what the handler answered. Reaching the
+ * function is the same for all of them, and lives in
+ * `SimCognitoTriggerInvocation`.
  */
 export class SimCognitoUserPoolTriggers {
-  private readonly functions: SimCognitoTriggerFunctions;
+  private readonly invocation: SimCognitoTriggerInvocation;
   private readonly claimsOverrides = new SimCognitoClaimsOverrideReader();
 
   constructor(properties: SimCognitoUserPoolTriggersProperties) {
-    this.functions = properties.functions;
+    this.invocation = new SimCognitoTriggerInvocation(properties.functions);
   }
 
   /**
@@ -54,7 +42,9 @@ export class SimCognitoUserPoolTriggers {
     occasion: SimCognitoTriggerOccasion,
     context: SimCognitoTriggerContext,
   ): Promise<SimCognitoPreSignUpResponse> {
-    return new SimCognitoPreSignUpResponse(await this.run(occasion, context));
+    return new SimCognitoPreSignUpResponse(
+      await this.invocation.run(occasion, context),
+    );
   }
 
   /**
@@ -66,7 +56,7 @@ export class SimCognitoUserPoolTriggers {
    * reaches it on real Cognito.
    */
   async postConfirmation(context: SimCognitoTriggerContext): Promise<void> {
-    await this.run(SimCognitoTriggerOccasion.confirmSignUp, context);
+    await this.invocation.run(SimCognitoTriggerOccasion.confirmSignUp, context);
   }
 
   /**
@@ -77,7 +67,10 @@ export class SimCognitoUserPoolTriggers {
    * `UserLambdaValidationException` the caller sees.
    */
   async preAuthentication(context: SimCognitoTriggerContext): Promise<void> {
-    await this.run(SimCognitoTriggerOccasion.preAuthentication, context);
+    await this.invocation.run(
+      SimCognitoTriggerOccasion.preAuthentication,
+      context,
+    );
   }
 
   /**
@@ -88,7 +81,10 @@ export class SimCognitoUserPoolTriggers {
    * tokens the pool issued stay issued, exactly as on real Cognito.
    */
   async postAuthentication(context: SimCognitoTriggerContext): Promise<void> {
-    await this.run(SimCognitoTriggerOccasion.postAuthentication, context);
+    await this.invocation.run(
+      SimCognitoTriggerOccasion.postAuthentication,
+      context,
+    );
   }
 
   /**
@@ -103,68 +99,8 @@ export class SimCognitoUserPoolTriggers {
     occasion: SimCognitoTriggerOccasion,
     context: SimCognitoTriggerContext,
   ): Promise<SimCognitoClaimsOverride> {
-    return this.claimsOverrides.read(await this.run(occasion, context));
-  }
-
-  /**
-   * Invoke the trigger for one occasion, answering with what the handler
-   * returned, or with nothing where the pool has no such trigger.
-   */
-  private async run(
-    occasion: SimCognitoTriggerOccasion,
-    context: SimCognitoTriggerContext,
-  ): Promise<unknown> {
-    const { trigger } = occasion;
-    const functionArn = context.pool.settings.lambdaConfig.find(trigger);
-
-    if (functionArn === undefined) {
-      return undefined;
-    }
-
-    const request: SimCognitoTriggerFunctionRequest = {
-      functionArn,
-      userPoolArn: context.pool.arn.value,
-      userPoolAccountId: context.pool.arn.accountId,
-    };
-    const refusal = this.functions.invokeRefusal(request);
-
-    if (refusal !== undefined) {
-      throw new SimCognitoUnexpectedLambdaException(
-        `The ${trigger} trigger of user pool ${context.pool.id} could not be ` +
-          `invoked. ${refusal}`,
-      );
-    }
-
-    const returned = await this.invoke(occasion, request, context);
-
-    requireSimCognitoTriggerResponse(trigger, returned);
-
-    return returned;
-  }
-
-  /**
-   * Invoke the handler, reporting a failure the way real Cognito reports one.
-   *
-   * The handler's own message is repeated because that is the whole mechanism a
-   * `PreSignUp` or `PreAuthentication` trigger refuses a request with: it
-   * throws, and the words it threw are what the caller is told.
-   */
-  private async invoke(
-    occasion: SimCognitoTriggerOccasion,
-    request: SimCognitoTriggerFunctionRequest,
-    context: SimCognitoTriggerContext,
-  ): Promise<unknown> {
-    try {
-      return await this.functions.invoke(
-        request,
-        new SimCognitoTriggerEvent(context).document(occasion),
-      );
-    } catch (error) {
-      throw new SimCognitoUserLambdaValidationException(
-        `${occasion.trigger} failed with error ${
-          error instanceof Error ? error.message : String(error)
-        }.`,
-      );
-    }
+    return this.claimsOverrides.read(
+      await this.invocation.run(occasion, context),
+    );
   }
 }

--- a/src/service/cognito/user-pool/trigger/sim-cognito-user-pool-triggers.ts
+++ b/src/service/cognito/user-pool/trigger/sim-cognito-user-pool-triggers.ts
@@ -2,6 +2,8 @@ import {
   SimCognitoUnexpectedLambdaException,
   SimCognitoUserLambdaValidationException,
 } from "../../error/sim-cognito-trigger.error.js";
+import type { SimCognitoClaimsOverride } from "../token/sim-cognito-claims-override.js";
+import { SimCognitoClaimsOverrideReader } from "../token/sim-cognito-claims-override-reader.js";
 import { SimCognitoPreSignUpResponse } from "./sim-cognito-pre-sign-up-response.js";
 import type { SimCognitoTriggerContext } from "./sim-cognito-trigger-context.js";
 import { SimCognitoTriggerEvent } from "./sim-cognito-trigger-event.js";
@@ -30,6 +32,7 @@ interface SimCognitoUserPoolTriggersProperties {
  */
 export class SimCognitoUserPoolTriggers {
   private readonly functions: SimCognitoTriggerFunctions;
+  private readonly claimsOverrides = new SimCognitoClaimsOverrideReader();
 
   constructor(properties: SimCognitoUserPoolTriggersProperties) {
     this.functions = properties.functions;
@@ -86,6 +89,21 @@ export class SimCognitoUserPoolTriggers {
    */
   async postAuthentication(context: SimCognitoTriggerContext): Promise<void> {
     await this.run(SimCognitoTriggerOccasion.postAuthentication, context);
+  }
+
+  /**
+   * Run the `PreTokenGeneration` trigger, if the pool has one, and answer with
+   * what its handler asked to change about the claims.
+   *
+   * A pool without the trigger, and a handler that returned the event without
+   * writing a response, both answer with an override that changes nothing, so
+   * the token layer applies one either way.
+   */
+  async preTokenGeneration(
+    occasion: SimCognitoTriggerOccasion,
+    context: SimCognitoTriggerContext,
+  ): Promise<SimCognitoClaimsOverride> {
+    return this.claimsOverrides.read(await this.run(occasion, context));
   }
 
   /**

--- a/test/cognito/trigger-handler-fixture.ts
+++ b/test/cognito/trigger-handler-fixture.ts
@@ -35,3 +35,16 @@ export function answeringTriggerHandler(
     return event;
   };
 }
+
+/**
+ * Answer with one `claimsOverrideDetails`, which is how a `PreTokenGeneration`
+ * handler says what a token is to carry.
+ */
+export function claimsOverrideHandler(
+  details: unknown,
+): (event: unknown) => unknown {
+  return (event: unknown) => ({
+    ...(event as object),
+    response: { claimsOverrideDetails: details },
+  });
+}

--- a/test/cognito/trigger-token-fixture.ts
+++ b/test/cognito/trigger-token-fixture.ts
@@ -1,0 +1,63 @@
+/**
+ * Signing the fixture's user in, and reading the tokens back.
+ *
+ * The `PreTokenGeneration` suites assert on what a token carries rather than on
+ * what a handler was given, so the sign-in and the claim reading live here
+ * rather than in `trigger-fixture.ts`, which owns the pool and the user.
+ */
+
+import { InitiateAuthCommand } from "@aws-sdk/client-cognito-identity-provider";
+import { assertNonNullable } from "@kensio/smartass";
+
+import {
+  triggerPassword,
+  triggerUsername,
+  type SimCognitoTriggerPool,
+} from "./trigger-fixture.js";
+
+/**
+ * The tokens a sign-in through the fixture's app client answered with.
+ */
+export interface SimCognitoTriggerTokens {
+  readonly idToken: string;
+  readonly accessToken: string;
+  readonly refreshToken: string;
+}
+
+/**
+ * Sign the fixture's user in through the client-side flow.
+ */
+export async function signInToTriggerPool(
+  pool: SimCognitoTriggerPool,
+  clientMetadata?: Readonly<Record<string, string>>,
+): Promise<SimCognitoTriggerTokens> {
+  const signedIn = await pool.cognito.initiateAuth(
+    new InitiateAuthCommand({
+      ClientId: pool.clientId,
+      AuthFlow: "USER_PASSWORD_AUTH",
+      AuthParameters: { USERNAME: triggerUsername, PASSWORD: triggerPassword },
+      ...(clientMetadata !== undefined && { ClientMetadata: clientMetadata }),
+    }),
+  );
+
+  assertNonNullable(signedIn.AuthenticationResult?.IdToken);
+  assertNonNullable(signedIn.AuthenticationResult.AccessToken);
+  assertNonNullable(signedIn.AuthenticationResult.RefreshToken);
+
+  return {
+    idToken: signedIn.AuthenticationResult.IdToken,
+    accessToken: signedIn.AuthenticationResult.AccessToken,
+    refreshToken: signedIn.AuthenticationResult.RefreshToken,
+  };
+}
+
+/**
+ * The claims one signed token carries, which is the middle part of the JWT.
+ */
+export function triggerTokenClaims(token: string): Record<string, unknown> {
+  const [, claims] = token.split(".");
+
+  return JSON.parse(
+    Buffer.from(claims ?? "", "base64url").toString("utf8"),
+  ) as Record<string, unknown>;
+}


### PR DESCRIPTION
Resolves #427.

Two decisions a reviewer may want to weigh:

- The group override is applied to the access token's `cognito:groups` as well as the id token's. AWS documents that as the one change a V1_0 event makes to an access token, so it is more realistic than the id-token-only scope the issue names.
- The request's `groupConfiguration` carries `groupsToOverride` alone. Sending `iamRolesToOverride` and `preferredRole` and then refusing them back would break the copy-the-request-back pattern AWS documents for leaving groups alone.

`SimCognitoTokenIssuer` now requires the pool's triggers, which is breaking for anyone constructing one directly. `SimCognitoUserPoolTriggers` and the trigger function types are exported so it stays constructible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Cognito `PreTokenGeneration` triggers.
  * Customize, suppress, and override token claims and groups during sign-in, password challenges, and token refresh.
  * Added support for client metadata during new-password token generation.
  * Added public exports and simulation examples for configuring and using token-generation triggers.

* **Documentation**
  * Expanded Cognito trigger documentation with supported versions, events, limitations, validation, and refresh behavior.

* **Bug Fixes**
  * Improved validation and error handling for invalid trigger responses and unsupported claims.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->