### PR TITLE
feat: run the Cognito sign-up Lambda triggers

### DIFF
--- a/docs/services/cognito/README.md
+++ b/docs/services/cognito/README.md
@@ -258,6 +258,10 @@ for a user that has already confirmed is refused with `InvalidParameterException
 `AdminConfirmSignUp` confirms a user with no code at all. It names the pool and the user, and is
 authorized by IAM the way the other admin operations are.
 
+A pool with a `PreSignUp` trigger can confirm a user at sign-up instead, and one with a
+`PostConfirmation` trigger runs it whichever way the user got confirmed. See
+"[Lambda triggers](#lambda-triggers)" below.
+
 The pool's `AutoVerifiedAttributes` decide what confirming verifies. A pool created with
 `["email"]` has `email_verified` set to `true` on the user when it confirms, because answering with
 the code shows the address is the user's. `AdminConfirmSignUp` sets nothing, as it sets nothing on
@@ -915,14 +919,241 @@ try {
 
 ## Lambda triggers
 
-A pool created with a `LambdaConfig` runs the functions it names as part of a sign-in.
-`PreAuthentication` runs once the user is known and before its password is checked, and
-`PostAuthentication` runs once the tokens have been issued. Both are given the real event, and both
-have to return it.
+A pool created with a `LambdaConfig` runs the functions it names as part of a sign-up or a sign-in.
+Each one is given the real event and has to return it, changed or not.
+
+| Trigger              | Fires                                                                  | `triggerSource`                     |
+| -------------------- | ---------------------------------------------------------------------- | ----------------------------------- |
+| `PreSignUp`          | `SignUp`, before the pool takes the new user                           | `PreSignUp_SignUp`                  |
+| `PreSignUp`          | `AdminCreateUser`, before the pool takes the new user                  | `PreSignUp_AdminCreateUser`         |
+| `PostConfirmation`   | `ConfirmSignUp` and `AdminConfirmSignUp`, once the user is `CONFIRMED` | `PostConfirmation_ConfirmSignUp`    |
+| `PreAuthentication`  | a sign-in, once the user is known and before its password is checked   | `PreAuthentication_Authentication`  |
+| `PostAuthentication` | a sign-in, once the tokens have been issued                            | `PostAuthentication_Authentication` |
 
 The function is a simulated Lambda function anywhere in the simulation, and it has to admit
 `cognito-idp.amazonaws.com` for the pool, which is what `AddPermission` grants and what CDK's
 `addTrigger` emits an `AWS::Lambda::Permission` for.
+
+### Sign-up triggers
+
+`PreSignUp` runs before the pool takes the new user, so a handler that throws refuses the sign-up
+with `UserLambdaValidationException` and leaves no user behind. `PostConfirmation` runs once the
+user has reached `CONFIRMED`, and is given its attributes with the `sub` the pool allocated among
+them, which is what a handler keys an external record on.
+
+The handler runs as its function's execution role, so a call it makes to another simulated service
+is authorized by simulated IAM the way the deployed function's would be.
+
+```typescript sim-cognito-sign-up-triggers
+/**
+ * A user pool that auto-confirms its users and writes each one to DynamoDB.
+ */
+
+import {
+  CreateUserPoolClientCommand,
+  CreateUserPoolCommand,
+  SignUpCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import {
+  CreateTableCommand,
+  GetItemCommand,
+  PutItemCommand,
+} from "@aws-sdk/client-dynamodb";
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import {
+  AddPermissionCommand,
+  CreateFunctionCommand,
+} from "@aws-sdk/client-lambda";
+
+import { SimAws } from "@kensio/yulin";
+import { makeLambdaZipFileInput } from "@kensio/yulin/lambda";
+
+/**
+ * The parts of the two sign-up events these handlers read.
+ */
+interface SignUpTriggerEvent {
+  readonly userName: string;
+  readonly request: { readonly userAttributes: Record<string, string> };
+  readonly response: {
+    autoConfirmUser?: boolean;
+    autoVerifyEmail?: boolean;
+  };
+}
+
+const simAws = new SimAws();
+const lambda = simAws.lambda();
+const cognito = simAws.cognitoIdentityProvider();
+
+await simAws.dynamoDb().createTable(
+  new CreateTableCommand({
+    TableName: "users",
+    KeySchema: [{ AttributeName: "sub", KeyType: "HASH" }],
+    AttributeDefinitions: [{ AttributeName: "sub", AttributeType: "S" }],
+    BillingMode: "PAY_PER_REQUEST",
+  }),
+);
+
+// The execution role is what the handler's own writes are authorized as, so a
+// missing grant fails the confirmation rather than writing nothing.
+const role = await simAws.iam().createRole(
+  new CreateRoleCommand({
+    RoleName: "SignUpTriggerRole",
+    AssumeRolePolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Principal: { Service: "lambda.amazonaws.com" },
+        Action: "sts:AssumeRole",
+      },
+    }),
+  }),
+);
+
+await simAws.iam().putRolePolicy(
+  new PutRolePolicyCommand({
+    RoleName: "SignUpTriggerRole",
+    PolicyName: "WriteUsers",
+    PolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Action: "dynamodb:PutItem",
+        Resource: `arn:aws:dynamodb:${simAws.defaultRegionName}:${simAws.defaultAccountId}:table/users`,
+      },
+    }),
+  }),
+);
+
+// Anyone on the domain the pool is for skips confirmation, and their address
+// counts as verified without a code ever being answered.
+await lambda.createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "pre-sign-up",
+    Role: role.Role.Arn,
+    Code: {
+      ZipFile: makeLambdaZipFileInput((event: SignUpTriggerEvent) => {
+        const email = event.request.userAttributes["email"] ?? "";
+
+        if (email.endsWith("@example.com")) {
+          event.response.autoConfirmUser = true;
+          event.response.autoVerifyEmail = true;
+        }
+
+        return event;
+      }),
+    },
+  }),
+);
+
+// The confirmed user gets a row of its own, keyed on the sub Cognito
+// allocated rather than on the username.
+await lambda.createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "post-confirmation",
+    Role: role.Role.Arn,
+    Code: {
+      ZipFile: makeLambdaZipFileInput(async (event: SignUpTriggerEvent) => {
+        await simAws.dynamoDb().putItem(
+          new PutItemCommand({
+            TableName: "users",
+            Item: {
+              sub: { S: event.request.userAttributes["sub"] ?? "" },
+              email: { S: event.request.userAttributes["email"] ?? "" },
+              username: { S: event.userName },
+            },
+          }),
+        );
+
+        return event;
+      }),
+    },
+  }),
+);
+
+const pool = await cognito.createUserPool(
+  new CreateUserPoolCommand({
+    PoolName: "myapp-users",
+    LambdaConfig: {
+      PreSignUp: `arn:aws:lambda:${simAws.defaultRegionName}:${simAws.defaultAccountId}:function:pre-sign-up`,
+      PostConfirmation: `arn:aws:lambda:${simAws.defaultRegionName}:${simAws.defaultAccountId}:function:post-confirmation`,
+    },
+  }),
+);
+
+for (const functionName of ["pre-sign-up", "post-confirmation"]) {
+  await lambda.addPermission(
+    new AddPermissionCommand({
+      FunctionName: functionName,
+      StatementId: "AllowCognito",
+      Action: "lambda:InvokeFunction",
+      Principal: "cognito-idp.amazonaws.com",
+      SourceArn: pool.UserPool?.Arn,
+    }),
+  );
+}
+
+const appClient = await cognito.createUserPoolClient(
+  new CreateUserPoolClientCommand({
+    UserPoolId: pool.UserPool?.Id,
+    ClientName: "web",
+    ExplicitAuthFlows: ["ALLOW_USER_PASSWORD_AUTH"],
+  }),
+);
+
+const signedUp = await cognito.signUp(
+  new SignUpCommand({
+    ClientId: appClient.UserPoolClient?.ClientId,
+    Username: "alice",
+    Password: "Sup3rSecret!",
+    UserAttributes: [{ Name: "email", Value: "alice@example.com" }],
+  }),
+);
+
+// The pre sign-up handler confirmed the user, so no ConfirmSignUp call is
+// needed and the post confirmation handler has already run.
+console.log(signedUp.UserConfirmed); // true
+
+const written = await simAws.dynamoDb().getItem(
+  new GetItemCommand({
+    TableName: "users",
+    Key: { sub: { S: signedUp.UserSub ?? "" } },
+  }),
+);
+
+console.log(written.Item?.["email"]?.S); // "alice@example.com"
+```
+
+A `PreSignUp` handler answers in the `response` it is given, which arrives with `autoConfirmUser`,
+`autoVerifyEmail` and `autoVerifyPhone` all set to `false`. Setting `autoConfirmUser` takes the new
+user straight to `CONFIRMED`, and `SignUp` reports `UserConfirmed: true`. The two verify flags set
+`email_verified` and `phone_number_verified` without a code being answered, and work whether or not
+the user was confirmed. Asking to verify an attribute the sign-up did not carry refuses the sign-up,
+as it does on real Cognito, rather than creating a user with the flag quietly unset.
+
+A user confirmed that way still reaches `PostConfirmation`, at sign-up rather than at a
+`ConfirmSignUp` that never comes. A project whose users never confirm is covered by that, here as on
+real Cognito.
+
+`AdminCreateUser` reaches `PreSignUp` and never reaches `PostConfirmation`. That matters more than
+it looks: `AdminCreateUser` is the obvious place to hang the trigger and the wrong one, and a
+project relying on it would pass here and write nothing in production. What the handler wrote into
+the response is ignored on that occasion too, because an admin-created user is already past
+confirmation. Real Cognito ignores all three flags there.
+
+The `ValidationData` and `ClientMetadata` a request carries reach the handler. `SignUp` and
+`AdminCreateUser` pass both to `PreSignUp`, as `request.validationData` and
+`request.clientMetadata`. `ConfirmSignUp` and `AdminConfirmSignUp` pass their `ClientMetadata` to
+`PostConfirmation`. Neither is stored on the user, as neither is on real Cognito.
+
+The admin operations have no app client to name, so a handler fired by `AdminCreateUser` or
+`AdminConfirmSignUp` reads `callerContext.clientId` as `CLIENT_ID_NOT_APPLICABLE`, which is what
+real Cognito sends.
+
+### Sign-in triggers
+
+`PreAuthentication` runs once the user is known and before its password is checked, so a wrong
+password reaches it too: the trigger is given the user to decide about, and deciding is what it is
+for. `PostAuthentication` runs once the tokens have been issued.
 
 ```typescript sim-cognito-lambda-triggers
 /**
@@ -1044,24 +1275,32 @@ try {
 }
 ```
 
-The event carries the trigger's own `triggerSource`, which is
-`PreAuthentication_Authentication` or `PostAuthentication_Authentication`, along with `version`,
-`region`, `userPoolId`, `userName`, a `callerContext` naming the app client, and the `request` and
-`response` pair. `ClientMetadata` on the sign-in reaches the handler as `request.validationData` for
+`ClientMetadata` on the sign-in reaches the handler as `request.validationData` for
 `PreAuthentication` and as `request.clientMetadata` for `PostAuthentication`, as it does on real
-Cognito.
+Cognito. Neither fires for `REFRESH_TOKEN_AUTH`, as neither does on real Cognito.
+
+### The event, and what a failure gets back
+
+Every event carries `version`, `region`, `userPoolId`, `userName`, the `triggerSource` naming the
+occasion, a `callerContext` naming the app client, and the `request` and `response` pair. The
+`request` holds `userAttributes` as a plain object of strings rather than the `Name`/`Value` pairs
+the API answers with.
+
+`sub` is among those attributes everywhere except `PreSignUp`, where the user does not exist yet: on
+real Cognito the sub is allocated once the sign-up has got past that handler. A handler keying an
+external record on `sub` has to be a `PostConfirmation` one, here as there.
 
 Three failures are reported the way real Cognito reports them:
 
-- A handler that throws refuses the sign-in with `UserLambdaValidationException`, carrying the
-  message it threw.
+- A handler that throws fails the request with `UserLambdaValidationException`, carrying the message
+  it threw. For `PreSignUp` and `PreAuthentication` that is how the trigger turns the request down.
 - A trigger naming a function that is not there, or one whose resource policy does not admit
   `cognito-idp.amazonaws.com` for the pool, fails with `UnexpectedLambdaException`.
 - A handler that returns something other than the event it was given fails with
   `InvalidLambdaResponseException`.
 
-Only these two triggers run. Every other `LambdaConfig` key is refused when the pool is created or
-updated, naming the trigger, so a pool never quietly drops one.
+Only the triggers in the table above run. Every other `LambdaConfig` key is refused when the pool is
+created or updated, naming the trigger, so a pool never quietly drops one.
 
 ## Token timestamps and expiry
 
@@ -1787,6 +2026,9 @@ Sim Cognito currently supports:
 - `SignUpCommand`, `ConfirmSignUpCommand` and `ResendConfirmationCodeCommand`, authorized by no IAM
   policy as they are on real Cognito, and `AdminConfirmSignUpCommand`, which is authorized like the
   other admin operations
+- The `PreSignUp` and `PostConfirmation` Lambda triggers, with `autoConfirmUser`, `autoVerifyEmail`
+  and `autoVerifyPhone` applied, and with the `ValidationData` and `ClientMetadata` a request
+  carries reaching the handler
 - `AutoVerifiedAttributes`, so confirming a sign-up sets `email_verified` or
   `phone_number_verified`, and `AdminCreateUserConfig.AllowAdminCreateUserOnly`, which refuses
   `SignUp` against a pool created with it
@@ -1801,7 +2043,7 @@ Sim Cognito currently supports:
   real Cognito
 - `GlobalSignOutCommand` and `AdminUserGlobalSignOutCommand`, which revoke the tokens a user holds
 - The `PreAuthentication` and `PostAuthentication` Lambda triggers, invoked with the real event
-  around a sign-in, with the pool's own `ClientMetadata` reaching them
+  around a sign-in, with the sign-in's own `ClientMetadata` reaching them
 - Real RS256 JWTs, signed by a key the pool publishes as a JWKS, so a verifier configured for the
   pool verifies them unchanged
 - A pool's `.well-known/jwks.json` and `.well-known/openid-configuration` served over HTTP by
@@ -1855,8 +2097,9 @@ Current documented limitations:
 - A confirmation code never expires, where a real one lasts 24 hours. `ResendConfirmationCode` is
   what replaces one.
 - `AdminConfirmSignUp` verifies nothing, whatever the pool's `AutoVerifiedAttributes` say, as it
-  verifies nothing on real Cognito. Only `ConfirmSignUp` sets `email_verified` and
-  `phone_number_verified`, and only where the user has the attribute to verify.
+  verifies nothing on real Cognito. `ConfirmSignUp` sets `email_verified` and
+  `phone_number_verified`, and only where the user has the attribute to verify, and a `PreSignUp`
+  trigger sets them by asking for `autoVerifyEmail` or `autoVerifyPhone`.
 - `AutoVerifiedAttributes` is accepted at `email` and `phone_number`, and anything else is refused.
   Those are the two Cognito can send a code to.
 - `SignUp`, `ConfirmSignUp` and `ResendConfirmationCode` report a user the pool does not hold
@@ -1864,10 +2107,11 @@ Current documented limitations:
   only.
 - Password reset is not simulated. `ForgotPassword`, `ConfirmForgotPassword` and `ChangePassword`
   are not implemented, so the `RESET_REQUIRED` status cannot be reached.
-- Unsimulated sign-up inputs are refused rather than ignored: `ClientMetadata`, `AnalyticsMetadata`
-  and `UserContextData` on the three client-side operations, `ValidationData` on `SignUp`,
-  `ForceAliasCreation` and `Session` on `ConfirmSignUp`, and `ClientMetadata` on
-  `AdminConfirmSignUp`.
+- Unsimulated sign-up inputs are refused rather than ignored: `AnalyticsMetadata` and
+  `UserContextData` on the three client-side operations, `ForceAliasCreation` and `Session` on
+  `ConfirmSignUp`, and `ClientMetadata` on `ResendConfirmationCode`. That last one would reach the
+  custom message trigger on real Cognito, which writes the wording of a message, and no message is
+  delivered here.
 - No message is ever delivered. `SignUp` and `ResendConfirmationCode` send no confirmation code, and
   neither reports `CodeDeliveryDetails`. `AdminCreateUser` sends no invitation, so
   `MessageAction: SUPPRESS` is accepted and changes nothing, `RESEND` is refused, and
@@ -1875,8 +2119,8 @@ Current documented limitations:
 - A temporary password never expires. `TemporaryPasswordValidityDays` is stored on the pool and
   nothing acts on it.
 - Unsimulated `AdminCreateUser` inputs are refused rather than ignored: `DesiredDeliveryMediums`,
-  `ForceAliasCreation`, `ValidationData`, `ClientMetadata`, and a `MessageAction` of `RESEND`.
-  `AdminUpdateUserAttributes` refuses `ClientMetadata` the same way.
+  `ForceAliasCreation`, and a `MessageAction` of `RESEND`. `AdminUpdateUserAttributes` refuses
+  `ClientMetadata`, because the only trigger it would reach there is the custom message one.
 - `ListUsers` refuses `Filter` and `AttributesToGet` rather than ignoring them, and lists users in
   creation order. Real Cognito chooses its own order and does not promise one.
 - `ListUsers`, `ListGroups`, `AdminListGroupsForUser` and `ListUsersInGroup` refuse a `Limit` of
@@ -1912,16 +2156,27 @@ Current documented limitations:
   on real Cognito, so a client created without a secret never gains one.
 - A redeployed template reaches neither update. Sim CloudFormation replaces a resource whose
   resolved template entry changed rather than updating it in place, whatever the resource type.
-- `PreAuthentication` and `PostAuthentication` are the only Lambda triggers that run. Every other
-  `LambdaConfig` key is refused when the pool is created or updated, naming the trigger, because a
-  pool that accepted one would never call the function the template named. The sign-up, token
-  generation and message triggers wait on the features they fire for; the custom challenge triggers
-  would need a challenge loop this simulation does not have; and the migration and federation
-  triggers have no external directory to reach.
-- A `PostAuthentication` handler that throws fails the request, and the sign-in it ran after is not
-  undone: the tokens the pool issued stay issued, as they do on real Cognito.
-- Neither trigger fires for `REFRESH_TOKEN_AUTH`, as neither does on real Cognito. `ClientMetadata`
-  on a refresh is accepted and reaches nothing.
+- `PreSignUp`, `PostConfirmation`, `PreAuthentication` and `PostAuthentication` are the only Lambda
+  triggers that run. Every other `LambdaConfig` key is refused when the pool is created or updated,
+  naming the trigger, because a pool that accepted one would never call the function the template
+  named. The token generation and message triggers wait on the features they fire for; the custom
+  challenge triggers would need a challenge loop this simulation does not have; and the migration
+  and federation triggers have no external directory to reach.
+- `AdminCreateUser` does not fire `PostConfirmation`, here or on real Cognito. It is the tempting
+  place to hang the trigger and the wrong one: a project relying on it would pass here and write
+  nothing in production.
+- `PostConfirmation_ConfirmForgotPassword` is not reached, because password reset is not simulated.
+  `PostConfirmation_ConfirmSignUp` is the only source the trigger reports.
+- A `PreSignUp` handler asking to verify an attribute the sign-up did not carry refuses the sign-up
+  with `InvalidParameterException`. Real Cognito refuses it too, and what it names the error has not
+  been checked against a live account.
+- `PreSignUp_ExternalProvider` is not reached either. Federated sign-in is not simulated, so no user
+  ever arrives from an identity provider.
+- A `PostConfirmation` or `PostAuthentication` handler that throws fails the request, and what it
+  ran after is not undone: a confirmed user stays confirmed and the tokens a pool issued stay
+  issued, as they do on real Cognito.
+- Neither sign-in trigger fires for `REFRESH_TOKEN_AUTH`, as neither does on real Cognito.
+  `ClientMetadata` on a refresh is accepted and reaches nothing.
 - Unsimulated `CreateUserPool` inputs are refused rather than ignored: `UsernameAttributes`,
   `AliasAttributes`, `Schema`, `UsernameConfiguration`,
   `UserAttributeUpdateSettings`, `DeviceConfiguration`, `UserPoolAddOns`, `KeyConfiguration`,
@@ -1963,8 +2218,8 @@ Current documented limitations:
   can fetch the keys they point at. A token's `iss` claim still names the real
   `https://cognito-idp.<region>.amazonaws.com/<userPoolId>`, so the two disagree here and agree on
   real Cognito.
-- Identity providers, resource servers, user pool domains, MFA configuration, risk configuration and
-  Lambda triggers are not simulated.
+- Identity providers, resource servers, user pool domains, MFA configuration and risk configuration
+  are not simulated.
 - Tags are not simulated. `UserPoolTags` is refused, and `TagResource`, `UntagResource` and
   `ListTagsForResource` are not implemented.
 - Listings carry no filtering, and are in creation order rather than any order real Cognito chooses.

--- a/docs/services/cognito/README.md
+++ b/docs/services/cognito/README.md
@@ -2102,9 +2102,8 @@ Current documented limitations:
   trigger sets them by asking for `autoVerifyEmail` or `autoVerifyPhone`.
 - `AutoVerifiedAttributes` is accepted at `email` and `phone_number`, and anything else is refused.
   Those are the two Cognito can send a code to.
-- `SignUp`, `ConfirmSignUp` and `ResendConfirmationCode` report a user the pool does not hold
-  whatever the app client's `PreventUserExistenceErrors` says. That setting is honoured for sign-in
-  only.
+- `ConfirmSignUp` and `ResendConfirmationCode` report a user the pool does not hold whatever the app
+  client's `PreventUserExistenceErrors` says. That setting is honoured for sign-in only.
 - Password reset is not simulated. `ForgotPassword`, `ConfirmForgotPassword` and `ChangePassword`
   are not implemented, so the `RESET_REQUIRED` status cannot be reached.
 - Unsimulated sign-up inputs are refused rather than ignored: `AnalyticsMetadata` and

--- a/docs/services/cognito/sim-cognito-sign-up-triggers.example.ts
+++ b/docs/services/cognito/sim-cognito-sign-up-triggers.example.ts
@@ -1,0 +1,176 @@
+/**
+ * A user pool that auto-confirms its users and writes each one to DynamoDB.
+ */
+
+import {
+  CreateUserPoolClientCommand,
+  CreateUserPoolCommand,
+  SignUpCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import {
+  CreateTableCommand,
+  GetItemCommand,
+  PutItemCommand,
+} from "@aws-sdk/client-dynamodb";
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import {
+  AddPermissionCommand,
+  CreateFunctionCommand,
+} from "@aws-sdk/client-lambda";
+
+import { SimAws } from "@kensio/yulin";
+import { makeLambdaZipFileInput } from "@kensio/yulin/lambda";
+
+/**
+ * The parts of the two sign-up events these handlers read.
+ */
+interface SignUpTriggerEvent {
+  readonly userName: string;
+  readonly request: { readonly userAttributes: Record<string, string> };
+  readonly response: {
+    autoConfirmUser?: boolean;
+    autoVerifyEmail?: boolean;
+  };
+}
+
+const simAws = new SimAws();
+const lambda = simAws.lambda();
+const cognito = simAws.cognitoIdentityProvider();
+
+await simAws.dynamoDb().createTable(
+  new CreateTableCommand({
+    TableName: "users",
+    KeySchema: [{ AttributeName: "sub", KeyType: "HASH" }],
+    AttributeDefinitions: [{ AttributeName: "sub", AttributeType: "S" }],
+    BillingMode: "PAY_PER_REQUEST",
+  }),
+);
+
+// The execution role is what the handler's own writes are authorized as, so a
+// missing grant fails the confirmation rather than writing nothing.
+const role = await simAws.iam().createRole(
+  new CreateRoleCommand({
+    RoleName: "SignUpTriggerRole",
+    AssumeRolePolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Principal: { Service: "lambda.amazonaws.com" },
+        Action: "sts:AssumeRole",
+      },
+    }),
+  }),
+);
+
+await simAws.iam().putRolePolicy(
+  new PutRolePolicyCommand({
+    RoleName: "SignUpTriggerRole",
+    PolicyName: "WriteUsers",
+    PolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Action: "dynamodb:PutItem",
+        Resource: `arn:aws:dynamodb:${simAws.defaultRegionName}:${simAws.defaultAccountId}:table/users`,
+      },
+    }),
+  }),
+);
+
+// Anyone on the domain the pool is for skips confirmation, and their address
+// counts as verified without a code ever being answered.
+await lambda.createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "pre-sign-up",
+    Role: role.Role.Arn,
+    Code: {
+      ZipFile: makeLambdaZipFileInput((event: SignUpTriggerEvent) => {
+        const email = event.request.userAttributes["email"] ?? "";
+
+        if (email.endsWith("@example.com")) {
+          event.response.autoConfirmUser = true;
+          event.response.autoVerifyEmail = true;
+        }
+
+        return event;
+      }),
+    },
+  }),
+);
+
+// The confirmed user gets a row of its own, keyed on the sub Cognito
+// allocated rather than on the username.
+await lambda.createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "post-confirmation",
+    Role: role.Role.Arn,
+    Code: {
+      ZipFile: makeLambdaZipFileInput(async (event: SignUpTriggerEvent) => {
+        await simAws.dynamoDb().putItem(
+          new PutItemCommand({
+            TableName: "users",
+            Item: {
+              sub: { S: event.request.userAttributes["sub"] ?? "" },
+              email: { S: event.request.userAttributes["email"] ?? "" },
+              username: { S: event.userName },
+            },
+          }),
+        );
+
+        return event;
+      }),
+    },
+  }),
+);
+
+const pool = await cognito.createUserPool(
+  new CreateUserPoolCommand({
+    PoolName: "myapp-users",
+    LambdaConfig: {
+      PreSignUp: `arn:aws:lambda:${simAws.defaultRegionName}:${simAws.defaultAccountId}:function:pre-sign-up`,
+      PostConfirmation: `arn:aws:lambda:${simAws.defaultRegionName}:${simAws.defaultAccountId}:function:post-confirmation`,
+    },
+  }),
+);
+
+for (const functionName of ["pre-sign-up", "post-confirmation"]) {
+  await lambda.addPermission(
+    new AddPermissionCommand({
+      FunctionName: functionName,
+      StatementId: "AllowCognito",
+      Action: "lambda:InvokeFunction",
+      Principal: "cognito-idp.amazonaws.com",
+      SourceArn: pool.UserPool?.Arn,
+    }),
+  );
+}
+
+const appClient = await cognito.createUserPoolClient(
+  new CreateUserPoolClientCommand({
+    UserPoolId: pool.UserPool?.Id,
+    ClientName: "web",
+    ExplicitAuthFlows: ["ALLOW_USER_PASSWORD_AUTH"],
+  }),
+);
+
+const signedUp = await cognito.signUp(
+  new SignUpCommand({
+    ClientId: appClient.UserPoolClient?.ClientId,
+    Username: "alice",
+    Password: "Sup3rSecret!",
+    UserAttributes: [{ Name: "email", Value: "alice@example.com" }],
+  }),
+);
+
+// The pre sign-up handler confirmed the user, so no ConfirmSignUp call is
+// needed and the post confirmation handler has already run.
+console.log(signedUp.UserConfirmed); // true
+
+const written = await simAws.dynamoDb().getItem(
+  new GetItemCommand({
+    TableName: "users",
+    Key: { sub: { S: signedUp.UserSub ?? "" } },
+  }),
+);
+
+console.log(written.Item?.["email"]?.S); // "alice@example.com"

--- a/src/service/cognito/README.md
+++ b/src/service/cognito/README.md
@@ -256,6 +256,41 @@ use.
 `SimCognitoUserPassword` holds what a user signs in with. It answers whether a candidate matches and
 nothing exposes it, the same modelling choice simulated KMS key material makes.
 
+## Lambda trigger model
+
+Trigger state and the running of a trigger live under `user-pool/trigger/`.
+
+`SimCognitoLambdaConfig` is the `LambdaConfig` a pool was created or updated with. It holds the
+function ARN each trigger names and resolves nothing, so a pool can be created before the function
+it names, and a function deleted afterwards fails the request rather than having silently broken the
+pool. Every `LambdaConfig` key this simulation does not run is refused there, naming the trigger,
+because a pool that accepted one would never call the function the template named.
+
+`SimCognitoTriggerOccasion` is a trigger paired with the `triggerSource` of one occasion it fires
+on. The two are not the same thing: `PreSignUp` fires both on `SignUp` and on `AdminCreateUser`, and
+a handler tells them apart by the source. Pairing them in a value object is what stops a source
+being derived from a trigger name, which would only work while every trigger had one.
+
+`SimCognitoUserPoolTriggers` runs them. A pool with no trigger for the occasion runs nothing and
+costs a map lookup. A pool with one checks the function's resource policy, invokes it, waits, and
+refuses what came back unless it is the event the handler was given. The policy is checked on every
+invocation rather than remembered, because a permission revoked afterwards stops the trigger on real
+Cognito too.
+
+`SimCognitoTriggerEvent` and `SimCognitoTriggerRequest` build the event document, which is the real
+shape down to the `response` a `PreSignUp` handler is sent with its three flags already set to
+false. `SimCognitoTriggerContext` is what an operation hands them: the pool, the user, the app
+client where there is one, and the client metadata and validation data the request carried.
+
+`SimCognitoPreSignUpResponse` reads what a `PreSignUp` handler answered. It is the only trigger here
+whose response is read, and the reading is lenient in the same way real Cognito is: anything but
+`true` is no, and a handler that dropped the response has asked for nothing.
+
+`SimAwsCognitoTriggerFunctions` is the bridge to simulated Lambda, and
+`SimCognitoNoTriggerFunctions` is what a standalone `SimCognitoIdentityProvider` gets instead. The
+functions come from the whole simulation rather than from the pool's own scope, because a
+`LambdaConfig` names a function by ARN and that ARN can name any Account and Region.
+
 ## Command handling
 
 AWS SDK-style operations are implemented under `command/`, grouped by the collaborators they share
@@ -328,8 +363,12 @@ resource, here or on real AWS.
   `SimCognitoUserPool.confirmationCode`. Real Cognito sends it and never reports it to anyone.
   Nothing here delivers a message, so this is what makes a sign-up flow testable at all.
 - `AdminConfirmSignUp` verifies nothing, whatever the pool's `AutoVerifiedAttributes` say, as it
-  verifies nothing on real Cognito. Only `ConfirmSignUp` sets `email_verified` and
-  `phone_number_verified`, and only where the user has the attribute to verify.
+  verifies nothing on real Cognito. `ConfirmSignUp` sets `email_verified` and
+  `phone_number_verified` where the user has the attribute to verify, and a `PreSignUp` trigger sets
+  them by answering `autoVerifyEmail` or `autoVerifyPhone`.
+- `AdminCreateUser` fires `PreSignUp` and never fires `PostConfirmation`, as on real Cognito, and
+  what a handler answered is ignored on that occasion. It is the tempting place to hang a user
+  record and the wrong one.
 - A confirmation code never expires, where a real one lasts 24 hours. `ResendConfirmationCode` is
   what replaces one.
 - `ForgotPassword`, `ConfirmForgotPassword` and `ChangePassword` are not implemented, so

--- a/src/service/cognito/cfn/sim-cfn-cognito-lambda-triggers.iso.test.ts
+++ b/src/service/cognito/cfn/sim-cfn-cognito-lambda-triggers.iso.test.ts
@@ -175,20 +175,22 @@ describe("Sim CloudFormation Cognito user pool Lambda triggers", () => {
   });
 
   it("fails a stack asking for a trigger this simulation does not run", async () => {
-    // Given a template naming a sign-up trigger.
+    // Given a template naming a token generation trigger.
     const simAws = simAwsInEuWest2();
 
     // When the stack is deployed.
     const error = await deployFailure(
       simAws,
-      poolWithTrigger({ PreSignUp: { "Fn::GetAtt": ["Trigger", "Arn"] } }),
+      poolWithTrigger({
+        PreTokenGeneration: { "Fn::GetAtt": ["Trigger", "Arn"] },
+      }),
     );
 
     // Then the stack fails rather than deploying a pool that would never call
     // the function the template named.
     assertStringIncludes(
       error.message,
-      "CreateUserPool LambdaConfig PreSignUp is not simulated",
+      "CreateUserPool LambdaConfig PreTokenGeneration is not simulated",
     );
   });
 });

--- a/src/service/cognito/command/auth/sim-cognito-auth-commands.ts
+++ b/src/service/cognito/command/auth/sim-cognito-auth-commands.ts
@@ -1,8 +1,7 @@
 import type { SimClock } from "../../../../util/clock/sim-clock.js";
 import type { SimCognitoUserPoolStore } from "../../user-pool/sim-cognito-user-pool-store.js";
 import { SimCognitoTokenIssuer } from "../../user-pool/token/sim-cognito-token-issuer.js";
-import type { SimCognitoTriggerFunctions } from "../../user-pool/trigger/sim-cognito-trigger-functions.js";
-import { SimCognitoUserPoolTriggers } from "../../user-pool/trigger/sim-cognito-user-pool-triggers.js";
+import type { SimCognitoUserPoolTriggers } from "../../user-pool/trigger/sim-cognito-user-pool-triggers.js";
 import type { SimCognitoRequestResolver } from "../sim-cognito-request-resolver.js";
 import { SimCognitoAdminInitiateAuth } from "./sim-cognito-admin-initiate-auth.js";
 import { SimCognitoAdminRespondToChallenge } from "./sim-cognito-admin-respond-to-challenge.js";
@@ -21,7 +20,7 @@ interface SimCognitoAuthCommandsProperties {
   readonly authResolver: SimCognitoAuthResolver;
   readonly pools: SimCognitoUserPoolStore;
   readonly clock: SimClock;
-  readonly triggerFunctions: SimCognitoTriggerFunctions;
+  readonly triggers: SimCognitoUserPoolTriggers;
 }
 
 /**
@@ -41,12 +40,8 @@ export class SimCognitoAuthCommands {
   public readonly signOut: SimCognitoSignOutCommands;
 
   constructor(properties: SimCognitoAuthCommandsProperties) {
-    const { resolver, authResolver, pools, clock, triggerFunctions } =
-      properties;
+    const { resolver, authResolver, pools, clock, triggers } = properties;
     const tokenIssuer = new SimCognitoTokenIssuer({ clock });
-    const triggers = new SimCognitoUserPoolTriggers({
-      functions: triggerFunctions,
-    });
     const flowRunner = new SimCognitoAuthFlowRunner({
       passwordSignIn: new SimCognitoPasswordSignIn({
         authResolver,

--- a/src/service/cognito/command/sim-cognito-commands.ts
+++ b/src/service/cognito/command/sim-cognito-commands.ts
@@ -6,6 +6,7 @@ import { SimCognitoGroupFactory } from "../user-pool/group/sim-cognito-group-fac
 import { SimCognitoUserPoolFactory } from "../user-pool/sim-cognito-user-pool-factory.js";
 import type { SimCognitoUserPoolStore } from "../user-pool/sim-cognito-user-pool-store.js";
 import type { SimCognitoTriggerFunctions } from "../user-pool/trigger/sim-cognito-trigger-functions.js";
+import { SimCognitoUserPoolTriggers } from "../user-pool/trigger/sim-cognito-user-pool-triggers.js";
 import { SimCognitoUserFactory } from "../user-pool/user/sim-cognito-user-factory.js";
 import { SimCognitoAuthCommands } from "./auth/sim-cognito-auth-commands.js";
 import { SimCognitoAuthResolver } from "./auth/sim-cognito-auth-resolver.js";
@@ -59,6 +60,11 @@ export class SimCognitoCommands {
     const resolver = new SimCognitoRequestResolver({ pools, authorizer });
     const authResolver = new SimCognitoAuthResolver({ resolver, pools });
     const userFactory = new SimCognitoUserFactory({ clock });
+    // One trigger runner serves every command, because a pool's LambdaConfig
+    // is one set of functions whichever operation reaches it.
+    const triggers = new SimCognitoUserPoolTriggers({
+      functions: triggerFunctions,
+    });
 
     this.userPools = new SimCognitoUserPoolCommands({
       pools,
@@ -76,11 +82,16 @@ export class SimCognitoCommands {
       authorizer,
     });
     this.listClients = new SimCognitoListUserPoolClients({ pools, authorizer });
-    this.users = new SimCognitoUserCommands({ resolver, userFactory });
+    this.users = new SimCognitoUserCommands({
+      resolver,
+      userFactory,
+      triggers,
+    });
     this.signUp = new SimCognitoSignUpCommands({
       authResolver,
       resolver,
       userFactory,
+      triggers,
     });
     this.userUpdates = new SimCognitoUserUpdateCommands({ resolver });
     this.listUsers = new SimCognitoListUsers({ resolver });
@@ -95,7 +106,7 @@ export class SimCognitoCommands {
       authResolver,
       pools,
       clock,
-      triggerFunctions,
+      triggers,
     });
   }
 }

--- a/src/service/cognito/command/sim-cognito-validation-data.ts
+++ b/src/service/cognito/command/sim-cognito-validation-data.ts
@@ -1,0 +1,43 @@
+import { SimCognitoInvalidParameterException } from "../error/sim-cognito.error.js";
+import type { SimCognitoAttributeType } from "../user-pool/user/sim-cognito-user-attributes.js";
+
+/**
+ * Read the `ValidationData` a sign-up or a user creation carried.
+ *
+ * The request sends `Name`/`Value` pairs and a `PreSignUp` handler reads a
+ * plain object of strings, so the two shapes are not the same. The names are
+ * not checked against the pool's schema, because this is never stored on the
+ * user: real Cognito passes it to the trigger and forgets it.
+ *
+ * A request that sent none reaches the handler with no `validationData` at all,
+ * rather than with an empty object.
+ */
+export function simCognitoValidationData(
+  requested: readonly SimCognitoAttributeType[] | undefined,
+  operation: string,
+): Readonly<Record<string, string>> | undefined {
+  if (requested === undefined) {
+    return undefined;
+  }
+
+  return Object.fromEntries(
+    requested.map((entry) => [
+      requireValidationDataName(entry.Name, operation),
+      entry.Value ?? "",
+    ]),
+  );
+}
+
+function requireValidationDataName(
+  name: string | undefined,
+  operation: string,
+): string {
+  if (name === undefined || name === "") {
+    throw new SimCognitoInvalidParameterException(
+      `${operation} ValidationData needs a Name on every entry, saying what ` +
+        `the pre sign-up trigger reads it as`,
+    );
+  }
+
+  return name;
+}

--- a/src/service/cognito/command/user-pool/sim-cognito-update-user-pool-validation.iso.test.ts
+++ b/src/service/cognito/command/user-pool/sim-cognito-update-user-pool-validation.iso.test.ts
@@ -58,11 +58,13 @@ const refusedInputs: readonly RefusedInput[] = [
     says: "a password the user has used before",
   },
   {
-    label: "LambdaConfig PreSignUp",
+    label: "LambdaConfig PreTokenGeneration",
     input: {
-      LambdaConfig: { PreSignUp: "arn:aws:lambda:eu-west-2:1:function:f" },
+      LambdaConfig: {
+        PreTokenGeneration: "arn:aws:lambda:eu-west-2:1:function:f",
+      },
     },
-    says: "validating a self-service sign-up",
+    says: "changing the claims a pool puts in its tokens",
   },
   {
     label: "UserAttributeUpdateSettings",

--- a/src/service/cognito/command/user-pool/sim-cognito-user-pool-validation.iso.test.ts
+++ b/src/service/cognito/command/user-pool/sim-cognito-user-pool-validation.iso.test.ts
@@ -58,9 +58,11 @@ const refusedInputs: readonly RefusedInput[] = [
   {
     label: "LambdaConfig",
     input: {
-      LambdaConfig: { PreSignUp: "arn:aws:lambda:eu-west-2:1:function:f" },
+      LambdaConfig: {
+        PreTokenGeneration: "arn:aws:lambda:eu-west-2:1:function:f",
+      },
     },
-    says: "LambdaConfig PreSignUp is not simulated",
+    says: "LambdaConfig PreTokenGeneration is not simulated",
   },
   {
     label: "AliasAttributes",

--- a/src/service/cognito/command/user/sign-up.command.ts
+++ b/src/service/cognito/command/user/sign-up.command.ts
@@ -39,10 +39,10 @@ export interface SimSignUpCommand {
 /**
  * What a sign-up answers with.
  *
- * `UserConfirmed` is always false here, because a pool confirming a user at
- * sign-up is one with a pre sign-up Lambda trigger doing it, and triggers are
- * not simulated. There is no `CodeDeliveryDetails`: real Cognito reports where
- * it sent the confirmation code, and nothing here sends one anywhere.
+ * `UserConfirmed` is true only where the pool's pre sign-up Lambda trigger
+ * answered `autoConfirmUser`, which is the one way a user is confirmed at
+ * sign-up. There is no `CodeDeliveryDetails`: real Cognito reports where it
+ * sent the confirmation code, and nothing here sends one anywhere.
  */
 export interface SimSignUpCommandOutput {
   readonly UserConfirmed?: boolean | undefined;
@@ -90,7 +90,7 @@ export interface SimResendConfirmationCodeCommandOutput {
 }
 
 /**
- * The AdminConfirmSignUp inputs this simulation reads, and the one it refuses.
+ * The AdminConfirmSignUp inputs, which are all simulated.
  *
  * This is the admin side of confirming, so it names the pool and the user
  * rather than an app client, and no confirmation code is involved at all.

--- a/src/service/cognito/command/user/sim-cognito-sign-up-commands.ts
+++ b/src/service/cognito/command/user/sim-cognito-sign-up-commands.ts
@@ -3,11 +3,14 @@ import { requireSimCognitoSecretHash } from "../../user-pool/auth/sim-cognito-se
 import type { SimCognitoUserPoolClient } from "../../user-pool/client/sim-cognito-user-pool-client.js";
 import { SimCognitoPasswordCheck } from "../../user-pool/sim-cognito-password-check.js";
 import type { SimCognitoUserPool } from "../../user-pool/sim-cognito-user-pool.js";
+import { SimCognitoTriggerOccasion } from "../../user-pool/trigger/sim-cognito-trigger-occasion.js";
+import type { SimCognitoUserPoolTriggers } from "../../user-pool/trigger/sim-cognito-user-pool-triggers.js";
 import type { SimCognitoUser } from "../../user-pool/user/sim-cognito-user.js";
 import type { SimCognitoUserFactory } from "../../user-pool/user/sim-cognito-user-factory.js";
 import { requireSimCognitoUsername } from "../../user-pool/user/sim-cognito-username.js";
 import type { SimCognitoAuthResolver } from "../auth/sim-cognito-auth-resolver.js";
 import type { SimCognitoRequestResolver } from "../sim-cognito-request-resolver.js";
+import { simCognitoValidationData } from "../sim-cognito-validation-data.js";
 import { SimCognitoUnsimulatedSignUpOptions } from "./sim-cognito-unsimulated-sign-up-options.js";
 import type {
   SimAdminConfirmSignUpCommand,
@@ -25,6 +28,7 @@ interface SimCognitoSignUpCommandsProperties {
   readonly authResolver: SimCognitoAuthResolver;
   readonly resolver: SimCognitoRequestResolver;
   readonly userFactory: SimCognitoUserFactory;
+  readonly triggers: SimCognitoUserPoolTriggers;
 }
 
 interface SimCognitoCommandOptions {
@@ -49,6 +53,7 @@ export class SimCognitoSignUpCommands {
   private readonly authResolver: SimCognitoAuthResolver;
   private readonly resolver: SimCognitoRequestResolver;
   private readonly userFactory: SimCognitoUserFactory;
+  private readonly triggers: SimCognitoUserPoolTriggers;
   private readonly unsimulatedOptions =
     new SimCognitoUnsimulatedSignUpOptions();
 
@@ -56,6 +61,7 @@ export class SimCognitoSignUpCommands {
     this.authResolver = properties.authResolver;
     this.resolver = properties.resolver;
     this.userFactory = properties.userFactory;
+    this.triggers = properties.triggers;
   }
 
   /**
@@ -67,8 +73,14 @@ export class SimCognitoSignUpCommands {
    * against the pool's policy first, as `AdminCreateUser` checks a temporary
    * one, and a username the pool already holds is refused whether that user
    * signed itself up or an admin created it.
+   *
+   * The pool's `PreSignUp` trigger runs before the user is added, so a handler
+   * that throws leaves the pool without it. A handler answering
+   * `autoConfirmUser` takes the user straight to `CONFIRMED` and reaches
+   * `PostConfirmation` here rather than at a `ConfirmSignUp` that never comes,
+   * which is what real Cognito does for a pool whose users never confirm.
    */
-  signUp(command: SimSignUpCommand): SimSignUpCommandOutput {
+  async signUp(command: SimSignUpCommand): Promise<SimSignUpCommandOutput> {
     const { input } = command;
     const { pool, client } = this.authResolver.client(input.ClientId);
 
@@ -87,9 +99,38 @@ export class SimCognitoSignUpCommands {
       ).require("Password", input.Password),
     });
 
+    const preSignUp = await this.triggers.preSignUp(
+      SimCognitoTriggerOccasion.signUp,
+      {
+        pool,
+        client,
+        user,
+        clientMetadata: input.ClientMetadata,
+        validationData: simCognitoValidationData(
+          input.ValidationData,
+          "SignUp",
+        ),
+      },
+    );
+
+    preSignUp.verifyAttributesOf(user);
     pool.addUser(user);
 
-    return { $metadata: {}, UserConfirmed: false, UserSub: user.sub };
+    if (preSignUp.autoConfirmUser) {
+      user.confirm();
+      await this.triggers.postConfirmation({
+        pool,
+        client,
+        user,
+        clientMetadata: input.ClientMetadata,
+      });
+    }
+
+    return {
+      $metadata: {},
+      UserConfirmed: preSignUp.autoConfirmUser,
+      UserSub: user.sub,
+    };
   }
 
   /**
@@ -97,11 +138,12 @@ export class SimCognitoSignUpCommands {
    *
    * The user reaches `CONFIRMED` and can sign in from then on. The pool's
    * `AutoVerifiedAttributes` are marked verified here, because answering with
-   * the code is what shows the address the code went to is the user's.
+   * the code is what shows the address the code went to is the user's. The
+   * pool's `PostConfirmation` trigger runs last, on the confirmed user.
    */
-  confirmSignUp(
+  async confirmSignUp(
     command: SimConfirmSignUpCommand,
-  ): SimConfirmSignUpCommandOutput {
+  ): Promise<SimConfirmSignUpCommandOutput> {
     const { input } = command;
     const { pool, client } = this.authResolver.client(input.ClientId);
 
@@ -111,6 +153,13 @@ export class SimCognitoSignUpCommands {
 
     user.confirmSignUp(input.ConfirmationCode);
     user.verifyAttributes(pool.settings.autoVerifiedAttributes.names);
+
+    await this.triggers.postConfirmation({
+      pool,
+      client,
+      user,
+      clientMetadata: input.ClientMetadata,
+    });
 
     return { $metadata: {} };
   }
@@ -141,22 +190,31 @@ export class SimCognitoSignUpCommands {
    * `phone_number_verified` alone here even on a pool with
    * `AutoVerifiedAttributes`, because an admin confirming a user says nothing
    * about whether the address is really theirs.
+   *
+   * The `PostConfirmation` trigger still runs, and reports the same
+   * `PostConfirmation_ConfirmSignUp` source `ConfirmSignUp` does, because the
+   * user being confirmed signed itself up either way. There is no app client
+   * in the request, so the handler reads `CLIENT_ID_NOT_APPLICABLE`.
    */
-  adminConfirmSignUp(
+  async adminConfirmSignUp(
     command: SimAdminConfirmSignUpCommand,
     options?: SimCognitoCommandOptions,
-  ): SimAdminConfirmSignUpCommandOutput {
+  ): Promise<SimAdminConfirmSignUpCommandOutput> {
     const { input } = command;
 
-    const user = this.resolver.user(
+    const { pool, user } = this.resolver.poolUser(
       "cognito-idp:AdminConfirmSignUp",
       input,
       options,
     );
 
-    this.unsimulatedOptions.refuseInAdminConfirm(input);
-
     user.confirm();
+
+    await this.triggers.postConfirmation({
+      pool,
+      user,
+      clientMetadata: input.ClientMetadata,
+    });
 
     return { $metadata: {} };
   }

--- a/src/service/cognito/command/user/sim-cognito-sign-up.iso.test.ts
+++ b/src/service/cognito/command/user/sim-cognito-sign-up.iso.test.ts
@@ -14,6 +14,7 @@ import {
   assertStringIncludes,
   assertStringLength,
   assertThrowsErrorAsync,
+  assertUndefined,
   assertUuidV4,
 } from "@kensio/smartass";
 import { describe, it } from "vitest";
@@ -238,25 +239,53 @@ describe("sim Cognito sign-up", () => {
     assertStringIncludes(error.message, "AllowAdminCreateUserOnly");
   });
 
-  it("refuses an input that only a Lambda trigger would read", async () => {
+  it("refuses an input about the device a request came from", async () => {
     // Given a pool with an app client.
     const { cognito, clientId } = await simCognitoWithClient();
 
-    // When a sign-up carries validation data for a pre sign-up trigger.
+    // When a sign-up carries the device context threat protection reads.
     const error = await assertThrowsErrorAsync(async () => {
       await cognito.signUp(
         new SignUpCommand({
           ClientId: clientId,
           Username: "alice",
           Password: password,
-          ValidationData: [{ Name: "tenant", Value: "acme" }],
+          UserContextData: { IpAddress: "192.0.2.1" },
         }),
       );
     });
 
-    // Then it is refused rather than dropped, because the trigger that would
-    // have read it does not run here.
-    assertStringIncludes(error.message, "SignUp ValidationData");
+    // Then it is refused rather than dropped, because nothing here judges a
+    // request by the device it came from.
+    assertStringIncludes(error.message, "SignUp UserContextData");
     assertStringIncludes(error.message, "is not simulated");
+  });
+
+  it("takes the validation data a pre sign-up trigger would read", async () => {
+    // Given a pool with an app client and no pre sign-up trigger.
+    const { cognito, userPoolId, clientId } = await simCognitoWithClient();
+
+    // When a sign-up carries validation data.
+    await cognito.signUp(
+      new SignUpCommand({
+        ClientId: clientId,
+        Username: "alice",
+        Password: password,
+        ValidationData: [{ Name: "tenant", Value: "acme" }],
+      }),
+    );
+
+    // Then the sign-up went ahead, and the data reached nothing: real Cognito
+    // passes it to the pre sign-up trigger and never stores it on the user.
+    const read = await cognito.adminGetUser(
+      new AdminGetUserCommand({ UserPoolId: userPoolId, Username: "alice" }),
+    );
+
+    assertIdentical(read.UserStatus, "UNCONFIRMED");
+    assertUndefined(
+      read.UserAttributes?.find(
+        (attribute) => attribute.Name === "custom:tenant",
+      ),
+    );
   });
 });

--- a/src/service/cognito/command/user/sim-cognito-unsimulated-sign-up-options.ts
+++ b/src/service/cognito/command/user/sim-cognito-unsimulated-sign-up-options.ts
@@ -1,6 +1,5 @@
 import { SimCognitoUnsimulatedInput } from "../sim-cognito-unsimulated-input.js";
 import type {
-  SimAdminConfirmSignUpCommandInput,
   SimCognitoSignUpCommandInput,
   SimConfirmSignUpCommandInput,
   SimSignUpCommandInput,
@@ -9,10 +8,14 @@ import type {
 /**
  * Refuses the sign-up inputs this simulation does not model.
  *
- * The four operations share most of them: every one can carry data for a
- * Lambda trigger, and the two client-side ones can carry the analytics and
- * device context a real app sends. None of that is simulated, so an input
- * asking for any of it is refused rather than dropped.
+ * The three client-side operations share the analytics and device context a
+ * real app sends, and none of that is simulated, so an input asking for any of
+ * it is refused rather than dropped.
+ *
+ * `ClientMetadata` and `ValidationData` are not among them on the operations
+ * that run a trigger. They exist to reach a Lambda trigger, and the pre sign-up
+ * and post confirmation triggers run here, so the data reaches the handler
+ * instead of being refused.
  */
 export class SimCognitoUnsimulatedSignUpOptions {
   private readonly signUpInput = new SimCognitoUnsimulatedInput("SignUp");
@@ -22,31 +25,19 @@ export class SimCognitoUnsimulatedSignUpOptions {
   private readonly resendInput = new SimCognitoUnsimulatedInput(
     "ResendConfirmationCode",
   );
-  private readonly adminConfirmInput = new SimCognitoUnsimulatedInput(
-    "AdminConfirmSignUp",
-  );
 
   /**
    * Refuse a `SignUp` request this simulation cannot honour.
-   *
-   * `ValidationData` gets its own refusal because it exists only to be read by
-   * a pre sign-up trigger: a request sending it is written against a trigger
-   * that would not run here.
    */
   refuseInSignUp(input: SimSignUpCommandInput): void {
-    this.refuseClientContext(this.signUpInput, input);
-    this.signUpInput.refuse(
-      "ValidationData",
-      input.ValidationData,
-      "passing data to a pre sign-up Lambda trigger",
-    );
+    this.refuseAppContext(this.signUpInput, input);
   }
 
   /**
    * Refuse a `ConfirmSignUp` request this simulation cannot honour.
    */
   refuseInConfirm(input: SimConfirmSignUpCommandInput): void {
-    this.refuseClientContext(this.confirmInput, input);
+    this.refuseAppContext(this.confirmInput, input);
     this.confirmInput.refuse(
       "ForceAliasCreation",
       input.ForceAliasCreation,
@@ -61,34 +52,27 @@ export class SimCognitoUnsimulatedSignUpOptions {
 
   /**
    * Refuse a `ResendConfirmationCode` request this simulation cannot honour.
+   *
+   * `ClientMetadata` is still refused here. The only trigger it would reach on
+   * this operation is the custom message one, which writes the wording of a
+   * message, and no message is ever delivered here.
    */
   refuseInResend(input: SimCognitoSignUpCommandInput): void {
-    this.refuseClientContext(this.resendInput, input);
-  }
-
-  /**
-   * Refuse an `AdminConfirmSignUp` request this simulation cannot honour.
-   */
-  refuseInAdminConfirm(input: SimAdminConfirmSignUpCommandInput): void {
-    this.adminConfirmInput.refuse(
+    this.refuseAppContext(this.resendInput, input);
+    this.resendInput.refuse(
       "ClientMetadata",
       input.ClientMetadata,
-      "passing data to a Lambda trigger",
+      "passing data to the custom message Lambda trigger",
     );
   }
 
   /**
-   * Refuse the three inputs every client-side sign-up operation shares.
+   * Refuse the two inputs every client-side sign-up operation shares.
    */
-  private refuseClientContext(
+  private refuseAppContext(
     unsimulated: SimCognitoUnsimulatedInput,
     input: SimCognitoSignUpCommandInput,
   ): void {
-    unsimulated.refuse(
-      "ClientMetadata",
-      input.ClientMetadata,
-      "passing data to a Lambda trigger",
-    );
     unsimulated.refuse(
       "AnalyticsMetadata",
       input.AnalyticsMetadata,

--- a/src/service/cognito/command/user/sim-cognito-unsimulated-user-options.ts
+++ b/src/service/cognito/command/user/sim-cognito-unsimulated-user-options.ts
@@ -24,6 +24,10 @@ export class SimCognitoUnsimulatedUserOptions {
    * `MessageAction: SUPPRESS` is allowed, and does nothing, because no
    * invitation is ever sent here. `RESEND` is refused: there is no message to
    * send again.
+   *
+   * `ValidationData` and `ClientMetadata` are not refused. Both exist to reach
+   * the pre sign-up trigger, and that trigger runs here, so they reach the
+   * handler.
    */
   refuseInCreate(input: SimAdminCreateUserCommandInput): void {
     this.creation.refuseUnless(
@@ -41,16 +45,6 @@ export class SimCognitoUnsimulatedUserOptions {
       "ForceAliasCreation",
       input.ForceAliasCreation,
       "moving an email or phone number alias to the new user",
-    );
-    this.creation.refuse(
-      "ValidationData",
-      input.ValidationData,
-      "passing data to a pre sign-up Lambda trigger",
-    );
-    this.creation.refuse(
-      "ClientMetadata",
-      input.ClientMetadata,
-      "passing data to a Lambda trigger",
     );
   }
 

--- a/src/service/cognito/command/user/sim-cognito-user-commands.ts
+++ b/src/service/cognito/command/user/sim-cognito-user-commands.ts
@@ -1,10 +1,13 @@
 import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
 import { SimCognitoPasswordCheck } from "../../user-pool/sim-cognito-password-check.js";
 import type { SimCognitoUserPool } from "../../user-pool/sim-cognito-user-pool.js";
+import { SimCognitoTriggerOccasion } from "../../user-pool/trigger/sim-cognito-trigger-occasion.js";
+import type { SimCognitoUserPoolTriggers } from "../../user-pool/trigger/sim-cognito-user-pool-triggers.js";
 import type { SimCognitoUserFactory } from "../../user-pool/user/sim-cognito-user-factory.js";
 import { requireSimCognitoUsername } from "../../user-pool/user/sim-cognito-username.js";
 import { SimCognitoUnsimulatedUserOptions } from "./sim-cognito-unsimulated-user-options.js";
 import type { SimCognitoRequestResolver } from "../sim-cognito-request-resolver.js";
+import { simCognitoValidationData } from "../sim-cognito-validation-data.js";
 import { SimCognitoUserView } from "./sim-cognito-user-view.js";
 import type {
   SimAdminCreateUserCommand,
@@ -18,6 +21,7 @@ import type {
 interface SimCognitoUserCommandsProperties {
   readonly resolver: SimCognitoRequestResolver;
   readonly userFactory: SimCognitoUserFactory;
+  readonly triggers: SimCognitoUserPoolTriggers;
 }
 
 interface SimCognitoCommandOptions {
@@ -33,12 +37,14 @@ interface SimCognitoCommandOptions {
 export class SimCognitoUserCommands {
   private readonly resolver: SimCognitoRequestResolver;
   private readonly userFactory: SimCognitoUserFactory;
+  private readonly triggers: SimCognitoUserPoolTriggers;
   private readonly view = new SimCognitoUserView();
   private readonly unsimulatedOptions = new SimCognitoUnsimulatedUserOptions();
 
   constructor(properties: SimCognitoUserCommandsProperties) {
     this.resolver = properties.resolver;
     this.userFactory = properties.userFactory;
+    this.triggers = properties.triggers;
   }
 
   /**
@@ -71,11 +77,22 @@ export class SimCognitoUserCommands {
    * admin-created user: it has a temporary password and cannot sign in until
    * that password is replaced. `AdminSetUserPassword` with `Permanent: true`
    * is what moves it on.
+   *
+   * The pool's `PreSignUp` trigger runs before the user is added, reporting
+   * `PreSignUp_AdminCreateUser`, so a handler that throws leaves the pool
+   * without the user. What the handler wrote into the response is read and not
+   * acted on, because real Cognito ignores `autoConfirmUser`, `autoVerifyEmail`
+   * and `autoVerifyPhone` on this occasion: the user is already past
+   * confirmation.
+   *
+   * `PostConfirmation` does not run, here or on real Cognito. It fires for
+   * users who sign themselves up, and an admin-created user never confirms
+   * anything.
    */
-  create(
+  async create(
     command: SimAdminCreateUserCommand,
     options?: SimCognitoCommandOptions,
-  ): SimAdminCreateUserCommandOutput {
+  ): Promise<SimAdminCreateUserCommandOutput> {
     const { input } = command;
     const pool = this.resolver.pool(
       "cognito-idp:AdminCreateUser",
@@ -92,6 +109,16 @@ export class SimCognitoUserCommands {
       temporaryPassword: SimCognitoUserCommands.allowedTemporaryPassword(
         pool,
         input.TemporaryPassword,
+      ),
+    });
+
+    await this.triggers.preSignUp(SimCognitoTriggerOccasion.adminCreateUser, {
+      pool,
+      user,
+      clientMetadata: input.ClientMetadata,
+      validationData: simCognitoValidationData(
+        input.ValidationData,
+        "AdminCreateUser",
       ),
     });
 

--- a/src/service/cognito/user-pool/trigger/sim-cognito-auth-triggers.iso.test.ts
+++ b/src/service/cognito/user-pool/trigger/sim-cognito-auth-triggers.iso.test.ts
@@ -18,18 +18,7 @@ import {
   triggerFunctionArn,
   triggerPassword,
 } from "../../../../../test/cognito/trigger-fixture.js";
-
-/**
- * Record every event a trigger handler is given, and hand the event back so
- * the sign-in carries on.
- */
-function recordingHandler(events: unknown[]): (event: unknown) => unknown {
-  return (event: unknown) => {
-    events.push(structuredClone(event));
-
-    return event;
-  };
-}
+import { recordingTriggerHandler } from "../../../../../test/cognito/trigger-handler-fixture.js";
 
 function signIn(clientId: string): InitiateAuthCommand {
   return new InitiateAuthCommand({
@@ -45,7 +34,7 @@ describe("sim Cognito user pool authentication triggers", () => {
     const events: unknown[] = [];
     const pool = await makeTriggerPool({
       triggers: { PreAuthentication: triggerFunctionArn },
-      handler: recordingHandler(events),
+      handler: recordingTriggerHandler(events),
     });
 
     await makeTriggerUser(pool);
@@ -81,7 +70,7 @@ describe("sim Cognito user pool authentication triggers", () => {
         PreAuthentication: triggerFunctionArn,
         PostAuthentication: triggerFunctionArn,
       },
-      handler: recordingHandler(events),
+      handler: recordingTriggerHandler(events),
     });
 
     await makeTriggerUser(pool);
@@ -108,7 +97,7 @@ describe("sim Cognito user pool authentication triggers", () => {
         PreAuthentication: triggerFunctionArn,
         PostAuthentication: triggerFunctionArn,
       },
-      handler: recordingHandler(events),
+      handler: recordingTriggerHandler(events),
     });
 
     await makeTriggerUser(pool);
@@ -141,7 +130,7 @@ describe("sim Cognito user pool authentication triggers", () => {
     const events: unknown[] = [];
     const pool = await makeTriggerPool({
       triggers: { PostAuthentication: triggerFunctionArn },
-      handler: recordingHandler(events),
+      handler: recordingTriggerHandler(events),
     });
 
     await makeTriggerUser(pool);
@@ -172,7 +161,7 @@ describe("sim Cognito user pool authentication triggers", () => {
         PreAuthentication: triggerFunctionArn,
         PostAuthentication: triggerFunctionArn,
       },
-      handler: recordingHandler(events),
+      handler: recordingTriggerHandler(events),
     });
 
     await makeTriggerUser(pool);

--- a/src/service/cognito/user-pool/trigger/sim-cognito-lambda-config.iso.test.ts
+++ b/src/service/cognito/user-pool/trigger/sim-cognito-lambda-config.iso.test.ts
@@ -73,7 +73,7 @@ describe("sim Cognito user pool LambdaConfig", () => {
         PoolName: "myapp-users",
         LambdaConfig: {
           PreAuthentication: triggerFunctionArn,
-          PreSignUp: undefined,
+          PreTokenGeneration: undefined,
         },
       }),
     );
@@ -89,14 +89,15 @@ describe("sim Cognito user pool LambdaConfig", () => {
     // Given a simulation.
     const cognito = new SimAws().cognitoIdentityProvider();
 
-    // When a pool asks for a sign-up trigger alongside one that is simulated.
+    // When a pool asks for a token generation trigger alongside one that is
+    // simulated.
     const error = await assertThrowsErrorAsync(async () =>
       cognito.createUserPool(
         new CreateUserPoolCommand({
           PoolName: "myapp-users",
           LambdaConfig: {
             PreAuthentication: triggerFunctionArn,
-            PostConfirmation: otherFunctionArn,
+            PreTokenGeneration: otherFunctionArn,
           },
         }),
       ),
@@ -107,11 +108,11 @@ describe("sim Cognito user pool LambdaConfig", () => {
     assertIdentical(error.name, "InvalidParameterException");
     assertStringIncludes(
       error.message,
-      "CreateUserPool LambdaConfig PostConfirmation is not simulated",
+      "CreateUserPool LambdaConfig PreTokenGeneration is not simulated",
     );
     assertStringIncludes(
       error.message,
-      "acting on a user confirming its own account",
+      "changing the claims a pool puts in its tokens",
     );
   });
 

--- a/src/service/cognito/user-pool/trigger/sim-cognito-lambda-config.ts
+++ b/src/service/cognito/user-pool/trigger/sim-cognito-lambda-config.ts
@@ -12,6 +12,8 @@ import {
  * https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_LambdaConfigType.html
  */
 export interface SimCognitoLambdaConfigType {
+  readonly PreSignUp?: string | undefined;
+  readonly PostConfirmation?: string | undefined;
   readonly PreAuthentication?: string | undefined;
   readonly PostAuthentication?: string | undefined;
 }
@@ -27,8 +29,8 @@ export interface SimCognitoLambdaConfigType {
  * Every other `LambdaConfig` key real Cognito has is refused, naming the
  * trigger and saying why, so a pool never quietly drops one. That is the whole
  * reason this reads the config rather than storing it: a pool that accepted a
- * `PreSignUp` trigger and never called it would sign users up differently here
- * and on real AWS.
+ * `PreTokenGeneration` trigger and never called it would issue different tokens
+ * here and on real AWS.
  */
 export class SimCognitoLambdaConfig {
   private readonly operation: string;

--- a/src/service/cognito/user-pool/trigger/sim-cognito-post-confirmation-dynamodb.iso.test.ts
+++ b/src/service/cognito/user-pool/trigger/sim-cognito-post-confirmation-dynamodb.iso.test.ts
@@ -1,0 +1,62 @@
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import {
+  makeUserWritingPool,
+  readUserItem,
+} from "../../../../../test/cognito/post-confirmation-table-fixture.js";
+import {
+  confirmTriggerSignUp,
+  signUpTriggerUser,
+} from "../../../../../test/cognito/trigger-fixture.js";
+
+describe("sim Cognito PostConfirmation trigger writing to DynamoDB", () => {
+  it("writes the confirmed user to a simulated table", async () => {
+    // Given a pool whose PostConfirmation trigger puts a user item, and an
+    // execution role allowed to write it.
+    const pool = await makeUserWritingPool(true);
+    const signedUp = await signUpTriggerUser(pool);
+
+    assertNonNullable(signedUp.UserSub);
+
+    // When the user confirms with the code the pool issued.
+    await confirmTriggerSignUp(pool);
+
+    // Then the handler wrote the item, keyed on the sub the pool allocated
+    // rather than on the username.
+    const item = await readUserItem(pool, signedUp.UserSub);
+
+    assertNonNullable(item);
+    assertIdentical(item["email"]?.S, "alice@example.com");
+    assertIdentical(item["username"]?.S, "alice");
+  });
+
+  it("fails the confirmation when the execution role cannot write", async () => {
+    // Given the same pool, with an execution role holding no dynamodb:PutItem
+    // grant.
+    const pool = await makeUserWritingPool(false);
+    const signedUp = await signUpTriggerUser(pool);
+
+    assertNonNullable(signedUp.UserSub);
+
+    // When the user confirms.
+    const error = await assertThrowsErrorAsync(async () =>
+      confirmTriggerSignUp(pool),
+    );
+
+    // Then the denial reaches the caller rather than the handler silently
+    // writing nothing.
+    assertIdentical(error.name, "UserLambdaValidationException");
+    assertStringIncludes(error.message, "PostConfirmation failed with error");
+    assertStringIncludes(error.message, "dynamodb:PutItem");
+
+    // And the table is still empty.
+    assertUndefined(await readUserItem(pool, signedUp.UserSub));
+  });
+});

--- a/src/service/cognito/user-pool/trigger/sim-cognito-post-confirmation-trigger.iso.test.ts
+++ b/src/service/cognito/user-pool/trigger/sim-cognito-post-confirmation-trigger.iso.test.ts
@@ -20,18 +20,7 @@ import {
   signUpTriggerUser,
   triggerFunctionArn,
 } from "../../../../../test/cognito/trigger-fixture.js";
-
-/**
- * Record every event a trigger handler is given, and hand the event back so
- * the confirmation carries on.
- */
-function recordingHandler(events: unknown[]): (event: unknown) => unknown {
-  return (event: unknown) => {
-    events.push(structuredClone(event));
-
-    return event;
-  };
-}
+import { recordingTriggerHandler } from "../../../../../test/cognito/trigger-handler-fixture.js";
 
 /**
  * The `triggerSource` of every event a handler recorded.
@@ -49,7 +38,7 @@ describe("sim Cognito PostConfirmation trigger", () => {
     const events: unknown[] = [];
     const pool = await makeTriggerPool({
       triggers: { PostConfirmation: triggerFunctionArn },
-      handler: recordingHandler(events),
+      handler: recordingTriggerHandler(events),
       autoVerifiedAttributes: ["email"],
     });
 
@@ -81,7 +70,7 @@ describe("sim Cognito PostConfirmation trigger", () => {
     const events: unknown[] = [];
     const pool = await makeTriggerPool({
       triggers: { PostConfirmation: triggerFunctionArn },
-      handler: recordingHandler(events),
+      handler: recordingTriggerHandler(events),
     });
 
     const signedUp = await signUpTriggerUser(pool);
@@ -131,7 +120,7 @@ describe("sim Cognito PostConfirmation trigger", () => {
     const events: unknown[] = [];
     const pool = await makeTriggerPool({
       triggers: { PostConfirmation: triggerFunctionArn },
-      handler: recordingHandler(events),
+      handler: recordingTriggerHandler(events),
     });
 
     await signUpTriggerUser(pool);
@@ -160,7 +149,7 @@ describe("sim Cognito PostConfirmation trigger", () => {
     const events: unknown[] = [];
     const pool = await makeTriggerPool({
       triggers: { PostConfirmation: triggerFunctionArn },
-      handler: recordingHandler(events),
+      handler: recordingTriggerHandler(events),
     });
 
     // When an admin creates a user and gives it a permanent password, which is

--- a/src/service/cognito/user-pool/trigger/sim-cognito-post-confirmation-trigger.iso.test.ts
+++ b/src/service/cognito/user-pool/trigger/sim-cognito-post-confirmation-trigger.iso.test.ts
@@ -1,0 +1,190 @@
+/* eslint-disable @typescript-eslint/naming-convention -- the user attribute
+   names are Cognito's own, rather than identifier names. */
+import {
+  AdminConfirmSignUpCommand,
+  AdminCreateUserCommand,
+  AdminSetUserPasswordCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import {
+  assertArrayEquals,
+  assertIdentical,
+  assertObjectMatches,
+  assertUndefined,
+  assertUuidV4,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import {
+  confirmTriggerSignUp,
+  makeTriggerPool,
+  signUpTriggerUser,
+  triggerFunctionArn,
+} from "../../../../../test/cognito/trigger-fixture.js";
+
+/**
+ * Record every event a trigger handler is given, and hand the event back so
+ * the confirmation carries on.
+ */
+function recordingHandler(events: unknown[]): (event: unknown) => unknown {
+  return (event: unknown) => {
+    events.push(structuredClone(event));
+
+    return event;
+  };
+}
+
+/**
+ * The `triggerSource` of every event a handler recorded.
+ */
+function sourcesOf(events: readonly unknown[]): readonly string[] {
+  return events.map(
+    (event) => (event as { triggerSource: string }).triggerSource,
+  );
+}
+
+describe("sim Cognito PostConfirmation trigger", () => {
+  it("invokes the trigger after ConfirmSignUp with the confirmed user", async () => {
+    // Given a pool that verifies an email on confirmation and records what its
+    // PostConfirmation trigger is given.
+    const events: unknown[] = [];
+    const pool = await makeTriggerPool({
+      triggers: { PostConfirmation: triggerFunctionArn },
+      handler: recordingHandler(events),
+      autoVerifiedAttributes: ["email"],
+    });
+
+    await signUpTriggerUser(pool);
+
+    // When the user confirms with the code the pool issued.
+    await confirmTriggerSignUp(pool, { source: "web" });
+
+    // Then the handler was given the confirmed user's attributes, including
+    // the verification the confirmation had just applied.
+    assertObjectMatches(events[0], {
+      userPoolId: pool.userPoolId,
+      userName: "alice",
+      triggerSource: "PostConfirmation_ConfirmSignUp",
+      callerContext: { clientId: pool.clientId },
+      request: {
+        userAttributes: {
+          email: "alice@example.com",
+          email_verified: "true",
+        },
+        clientMetadata: { source: "web" },
+      },
+      response: {},
+    });
+  });
+
+  it("gives the handler the sub the pool allocated", async () => {
+    // Given a pool whose PostConfirmation trigger records what it is given.
+    const events: unknown[] = [];
+    const pool = await makeTriggerPool({
+      triggers: { PostConfirmation: triggerFunctionArn },
+      handler: recordingHandler(events),
+    });
+
+    const signedUp = await signUpTriggerUser(pool);
+
+    // When the user confirms.
+    await confirmTriggerSignUp(pool);
+
+    // Then the sub is among the attributes, which is what a handler keys an
+    // external record on.
+    const { request } = events[0] as {
+      request: { userAttributes: Record<string, string> };
+    };
+
+    assertUuidV4(request.userAttributes["sub"]);
+    assertIdentical(request.userAttributes["sub"], signedUp.UserSub);
+  });
+
+  it("reaches a user the PreSignUp trigger confirmed outright", async () => {
+    // Given a pool with both triggers, where the first auto-confirms.
+    const events: unknown[] = [];
+    const pool = await makeTriggerPool({
+      triggers: {
+        PreSignUp: triggerFunctionArn,
+        PostConfirmation: triggerFunctionArn,
+      },
+      handler: (event: { response: Record<string, boolean> }) => {
+        events.push(structuredClone(event));
+        event.response["autoConfirmUser"] = true;
+
+        return event;
+      },
+    });
+
+    // When a user signs itself up and never calls ConfirmSignUp.
+    await signUpTriggerUser(pool);
+
+    // Then both fired, in the order the sign-up reaches them, so a project
+    // whose users never confirm still runs its post confirmation handler.
+    assertArrayEquals(sourcesOf(events), [
+      "PreSignUp_SignUp",
+      "PostConfirmation_ConfirmSignUp",
+    ]);
+  });
+
+  it("invokes the trigger after AdminConfirmSignUp", async () => {
+    // Given a signed-up user waiting to be confirmed.
+    const events: unknown[] = [];
+    const pool = await makeTriggerPool({
+      triggers: { PostConfirmation: triggerFunctionArn },
+      handler: recordingHandler(events),
+    });
+
+    await signUpTriggerUser(pool);
+
+    // When an admin confirms it with no code at all.
+    await pool.cognito.adminConfirmSignUp(
+      new AdminConfirmSignUpCommand({
+        UserPoolId: pool.userPoolId,
+        Username: "alice",
+        ClientMetadata: { source: "console" },
+      }),
+    );
+
+    // Then the trigger fired under the same source, because the user being
+    // confirmed signed itself up either way, and with no app client to name.
+    assertObjectMatches(events[0], {
+      triggerSource: "PostConfirmation_ConfirmSignUp",
+      userName: "alice",
+      callerContext: { clientId: "CLIENT_ID_NOT_APPLICABLE" },
+      request: { clientMetadata: { source: "console" } },
+    });
+  });
+
+  it("does not invoke the trigger for AdminCreateUser", async () => {
+    // Given a pool with a PostConfirmation trigger.
+    const events: unknown[] = [];
+    const pool = await makeTriggerPool({
+      triggers: { PostConfirmation: triggerFunctionArn },
+      handler: recordingHandler(events),
+    });
+
+    // When an admin creates a user and gives it a permanent password, which is
+    // what takes an admin-created user to CONFIRMED.
+    await pool.cognito.adminCreateUser(
+      new AdminCreateUserCommand({
+        UserPoolId: pool.userPoolId,
+        Username: "alice",
+        TemporaryPassword: "Temp0rary!",
+      }),
+    );
+    await pool.cognito.adminSetUserPassword(
+      new AdminSetUserPasswordCommand({
+        UserPoolId: pool.userPoolId,
+        Username: "alice",
+        Password: "Sup3rSecret!",
+        Permanent: true,
+      }),
+    );
+
+    // Then nothing fired, as nothing fires on real Cognito: the trigger is for
+    // users who sign themselves up. A project hanging its user record on this
+    // would pass here and write nothing in production, so it has to fail here
+    // too.
+    assertUndefined(events[0]);
+  });
+});

--- a/src/service/cognito/user-pool/trigger/sim-cognito-pre-sign-up-response.ts
+++ b/src/service/cognito/user-pool/trigger/sim-cognito-pre-sign-up-response.ts
@@ -1,0 +1,96 @@
+import { SimCognitoInvalidParameterException } from "../../error/sim-cognito.error.js";
+import type { SimCognitoUser } from "../user/sim-cognito-user.js";
+
+/**
+ * The three flags a `PreSignUp` handler can write into the event's response.
+ *
+ * They are read as `unknown` because a handler writes whatever it likes there.
+ * Real Cognito treats anything but `true` as false rather than refusing the
+ * response, and so does this.
+ */
+interface SimCognitoPreSignUpAnswer {
+  readonly autoConfirmUser?: unknown;
+  readonly autoVerifyEmail?: unknown;
+  readonly autoVerifyPhone?: unknown;
+}
+
+/**
+ * The response half of the event a handler returned, or nothing where it
+ * returned no usable response.
+ *
+ * A handler that dropped the response, and a pool with no `PreSignUp` trigger
+ * at all, both read as having asked for nothing.
+ */
+function answerOf(returned: unknown): SimCognitoPreSignUpAnswer {
+  if (typeof returned !== "object" || returned === null) {
+    return {};
+  }
+
+  const { response } = returned as { response?: unknown };
+
+  if (typeof response !== "object" || response === null) {
+    return {};
+  }
+
+  return response;
+}
+
+/**
+ * What a `PreSignUp` handler asked for in the event it returned.
+ *
+ * These three are the whole of what the trigger can change: whether the new
+ * user skips confirmation, and whether its email and phone number count as
+ * verified without a code ever being answered.
+ */
+export class SimCognitoPreSignUpResponse {
+  public readonly autoConfirmUser: boolean;
+  public readonly autoVerifyEmail: boolean;
+  public readonly autoVerifyPhone: boolean;
+
+  constructor(returned: unknown) {
+    const answer = answerOf(returned);
+
+    this.autoConfirmUser = answer.autoConfirmUser === true;
+    this.autoVerifyEmail = answer.autoVerifyEmail === true;
+    this.autoVerifyPhone = answer.autoVerifyPhone === true;
+  }
+
+  /**
+   * The attributes the handler asked to have marked verified.
+   */
+  get verifiedAttributeNames(): readonly string[] {
+    const names: string[] = [];
+
+    if (this.autoVerifyEmail) {
+      names.push("email");
+    }
+
+    if (this.autoVerifyPhone) {
+      names.push("phone_number");
+    }
+
+    return names;
+  }
+
+  /**
+   * Mark the attributes the handler asked to verify on the new user.
+   *
+   * An attribute the sign-up did not carry is refused rather than skipped.
+   * Real Cognito fails the sign-up in the same case, because there is no
+   * address to call verified, and a user created here with the flag quietly
+   * unset would be a user the deployed pool refused to create at all.
+   */
+  verifyAttributesOf(user: SimCognitoUser): void {
+    for (const name of this.verifiedAttributeNames) {
+      if (!user.attributeValues.has(name)) {
+        throw new SimCognitoInvalidParameterException(
+          `The PreSignUp trigger asked to verify '${name}', and the sign-up ` +
+            `carried no '${name}' attribute to verify. Real Cognito refuses ` +
+            `the sign-up in the same case.`,
+        );
+      }
+    }
+
+    user.verifyAttributes(this.verifiedAttributeNames);
+  }
+}

--- a/src/service/cognito/user-pool/trigger/sim-cognito-pre-sign-up-trigger.iso.test.ts
+++ b/src/service/cognito/user-pool/trigger/sim-cognito-pre-sign-up-trigger.iso.test.ts
@@ -16,30 +16,11 @@ import {
   signUpTriggerUser,
   triggerFunctionArn,
 } from "../../../../../test/cognito/trigger-fixture.js";
+import {
+  answeringTriggerHandler,
+  recordingTriggerHandler,
+} from "../../../../../test/cognito/trigger-handler-fixture.js";
 import type { SimCognitoTriggerPool } from "../../../../../test/cognito/trigger-fixture.js";
-
-/**
- * Record every event a trigger handler is given, and hand the event back so
- * the sign-up carries on.
- */
-function recordingHandler(events: unknown[]): (event: unknown) => unknown {
-  return (event: unknown) => {
-    events.push(structuredClone(event));
-
-    return event;
-  };
-}
-
-/**
- * A handler that answers the pre sign-up flags a test named.
- */
-function answeringHandler(answer: Record<string, boolean>) {
-  return (event: { response: Record<string, boolean> }) => {
-    Object.assign(event.response, answer);
-
-    return event;
-  };
-}
 
 /**
  * The status the pool holds a user at.
@@ -83,7 +64,7 @@ describe("sim Cognito PreSignUp trigger", () => {
     const events: unknown[] = [];
     const pool = await makeTriggerPool({
       triggers: { PreSignUp: triggerFunctionArn },
-      handler: recordingHandler(events),
+      handler: recordingTriggerHandler(events),
     });
 
     // When a user signs itself up, carrying data for the trigger to read.
@@ -119,7 +100,7 @@ describe("sim Cognito PreSignUp trigger", () => {
     const events: unknown[] = [];
     const pool = await makeTriggerPool({
       triggers: { PreSignUp: triggerFunctionArn },
-      handler: recordingHandler(events),
+      handler: recordingTriggerHandler(events),
     });
 
     // When a sign-up carries a validation data entry with no value.
@@ -139,7 +120,7 @@ describe("sim Cognito PreSignUp trigger", () => {
     const events: unknown[] = [];
     const pool = await makeTriggerPool({
       triggers: { PreSignUp: triggerFunctionArn },
-      handler: recordingHandler(events),
+      handler: recordingTriggerHandler(events),
     });
 
     // When a user signs itself up.
@@ -158,7 +139,7 @@ describe("sim Cognito PreSignUp trigger", () => {
     // Given a pool whose PreSignUp trigger auto-confirms every user.
     const pool = await makeTriggerPool({
       triggers: { PreSignUp: triggerFunctionArn },
-      handler: answeringHandler({ autoConfirmUser: true }),
+      handler: answeringTriggerHandler({ autoConfirmUser: true }),
     });
 
     // When a user signs itself up.
@@ -175,7 +156,7 @@ describe("sim Cognito PreSignUp trigger", () => {
     // given.
     const pool = await makeTriggerPool({
       triggers: { PreSignUp: triggerFunctionArn },
-      handler: answeringHandler({
+      handler: answeringTriggerHandler({
         autoVerifyEmail: true,
         autoVerifyPhone: true,
       }),
@@ -199,7 +180,7 @@ describe("sim Cognito PreSignUp trigger", () => {
     // about confirming, which real Cognito treats as two separate answers.
     const pool = await makeTriggerPool({
       triggers: { PreSignUp: triggerFunctionArn },
-      handler: answeringHandler({ autoVerifyEmail: true }),
+      handler: answeringTriggerHandler({ autoVerifyEmail: true }),
     });
 
     // When a user signs itself up.
@@ -216,7 +197,7 @@ describe("sim Cognito PreSignUp trigger", () => {
     const events: unknown[] = [];
     const pool = await makeTriggerPool({
       triggers: { PreSignUp: triggerFunctionArn },
-      handler: recordingHandler(events),
+      handler: recordingTriggerHandler(events),
     });
 
     // When an admin creates a user instead.
@@ -249,7 +230,7 @@ describe("sim Cognito PreSignUp trigger", () => {
     // Given a pool whose PreSignUp trigger answers every flag it has.
     const pool = await makeTriggerPool({
       triggers: { PreSignUp: triggerFunctionArn },
-      handler: answeringHandler({
+      handler: answeringTriggerHandler({
         autoConfirmUser: true,
         autoVerifyEmail: true,
         autoVerifyPhone: true,
@@ -277,7 +258,7 @@ describe("sim Cognito PreSignUp trigger", () => {
     const events: unknown[] = [];
     const pool = await makeTriggerPool({
       triggers: { PostConfirmation: triggerFunctionArn },
-      handler: recordingHandler(events),
+      handler: recordingTriggerHandler(events),
     });
 
     // When a user signs itself up.

--- a/src/service/cognito/user-pool/trigger/sim-cognito-pre-sign-up-trigger.iso.test.ts
+++ b/src/service/cognito/user-pool/trigger/sim-cognito-pre-sign-up-trigger.iso.test.ts
@@ -1,0 +1,291 @@
+import {
+  AdminCreateUserCommand,
+  AdminGetUserCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import {
+  assertFalse,
+  assertIdentical,
+  assertObjectMatches,
+  assertTrue,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import {
+  makeTriggerPool,
+  signUpTriggerUser,
+  triggerFunctionArn,
+} from "../../../../../test/cognito/trigger-fixture.js";
+import type { SimCognitoTriggerPool } from "../../../../../test/cognito/trigger-fixture.js";
+
+/**
+ * Record every event a trigger handler is given, and hand the event back so
+ * the sign-up carries on.
+ */
+function recordingHandler(events: unknown[]): (event: unknown) => unknown {
+  return (event: unknown) => {
+    events.push(structuredClone(event));
+
+    return event;
+  };
+}
+
+/**
+ * A handler that answers the pre sign-up flags a test named.
+ */
+function answeringHandler(answer: Record<string, boolean>) {
+  return (event: { response: Record<string, boolean> }) => {
+    Object.assign(event.response, answer);
+
+    return event;
+  };
+}
+
+/**
+ * The status the pool holds a user at.
+ */
+async function statusOf(pool: SimCognitoTriggerPool): Promise<string> {
+  const read = await pool.cognito.adminGetUser(
+    new AdminGetUserCommand({ UserPoolId: pool.userPoolId, Username: "alice" }),
+  );
+
+  return read.UserStatus ?? "";
+}
+
+/**
+ * The value of one attribute of the pool's user.
+ */
+async function attributeOf(
+  pool: SimCognitoTriggerPool,
+  name: string,
+): Promise<string | undefined> {
+  const read = await pool.cognito.adminGetUser(
+    new AdminGetUserCommand({ UserPoolId: pool.userPoolId, Username: "alice" }),
+  );
+
+  return read.UserAttributes?.find((attribute) => attribute.Name === name)
+    ?.Value;
+}
+
+/**
+ * Whether the pool's user has an attribute marked verified.
+ */
+async function isVerified(
+  pool: SimCognitoTriggerPool,
+  name: string,
+): Promise<boolean> {
+  return (await attributeOf(pool, `${name}_verified`)) === "true";
+}
+
+describe("sim Cognito PreSignUp trigger", () => {
+  it("invokes the trigger on SignUp with the real event", async () => {
+    // Given a pool whose PreSignUp trigger records what it is given.
+    const events: unknown[] = [];
+    const pool = await makeTriggerPool({
+      triggers: { PreSignUp: triggerFunctionArn },
+      handler: recordingHandler(events),
+    });
+
+    // When a user signs itself up, carrying data for the trigger to read.
+    await signUpTriggerUser(pool, {
+      ValidationData: [{ Name: "tenant", Value: "acme" }],
+      ClientMetadata: { source: "web" },
+    });
+
+    // Then the handler was given the real event, naming the occasion it fired
+    // on and carrying the response flags it can answer with.
+    assertObjectMatches(events[0], {
+      version: "1",
+      region: pool.simAws.defaultRegionName,
+      userPoolId: pool.userPoolId,
+      userName: "alice",
+      triggerSource: "PreSignUp_SignUp",
+      callerContext: { clientId: pool.clientId },
+      request: {
+        userAttributes: { email: "alice@example.com" },
+        validationData: { tenant: "acme" },
+        clientMetadata: { source: "web" },
+      },
+      response: {
+        autoConfirmUser: false,
+        autoVerifyEmail: false,
+        autoVerifyPhone: false,
+      },
+    });
+  });
+
+  it("reads validation data that names a key and no value", async () => {
+    // Given a pool whose PreSignUp trigger records what it is given.
+    const events: unknown[] = [];
+    const pool = await makeTriggerPool({
+      triggers: { PreSignUp: triggerFunctionArn },
+      handler: recordingHandler(events),
+    });
+
+    // When a sign-up carries a validation data entry with no value.
+    await signUpTriggerUser(pool, {
+      ValidationData: [{ Name: "tenant" }],
+    });
+
+    // Then the handler reads it as the empty string, because a trigger event
+    // carries strings rather than the Name/Value pairs the request sent.
+    assertObjectMatches(events[0], {
+      request: { validationData: { tenant: "" } },
+    });
+  });
+
+  it("gives the handler no sub, because the user does not exist yet", async () => {
+    // Given a pool whose PreSignUp trigger records what it is given.
+    const events: unknown[] = [];
+    const pool = await makeTriggerPool({
+      triggers: { PreSignUp: triggerFunctionArn },
+      handler: recordingHandler(events),
+    });
+
+    // When a user signs itself up.
+    await signUpTriggerUser(pool);
+
+    // Then the attributes carry no sub: real Cognito allocates one only once
+    // the sign-up has got past this handler.
+    const { request } = events[0] as {
+      request: { userAttributes: Record<string, string> };
+    };
+
+    assertUndefined(request.userAttributes["sub"]);
+  });
+
+  it("confirms the user outright when the handler asks it to", async () => {
+    // Given a pool whose PreSignUp trigger auto-confirms every user.
+    const pool = await makeTriggerPool({
+      triggers: { PreSignUp: triggerFunctionArn },
+      handler: answeringHandler({ autoConfirmUser: true }),
+    });
+
+    // When a user signs itself up.
+    const signedUp = await signUpTriggerUser(pool);
+
+    // Then the sign-up reported the user confirmed, and the pool holds it that
+    // way with no ConfirmSignUp call ever made.
+    assertTrue(signedUp.UserConfirmed);
+    assertIdentical(await statusOf(pool), "CONFIRMED");
+  });
+
+  it("verifies the attributes the handler asks it to", async () => {
+    // Given a pool whose PreSignUp trigger vouches for the addresses it is
+    // given.
+    const pool = await makeTriggerPool({
+      triggers: { PreSignUp: triggerFunctionArn },
+      handler: answeringHandler({
+        autoVerifyEmail: true,
+        autoVerifyPhone: true,
+      }),
+    });
+
+    // When a user signs itself up with both addresses.
+    await signUpTriggerUser(pool, {
+      UserAttributes: [
+        { Name: "email", Value: "alice@example.com" },
+        { Name: "phone_number", Value: "+12065550100" },
+      ],
+    });
+
+    // Then both are marked verified without a code ever being answered.
+    assertTrue(await isVerified(pool, "email"));
+    assertTrue(await isVerified(pool, "phone_number"));
+  });
+
+  it("leaves an auto-verified user unconfirmed unless it was told otherwise", async () => {
+    // Given a pool whose PreSignUp trigger verifies the email and says nothing
+    // about confirming, which real Cognito treats as two separate answers.
+    const pool = await makeTriggerPool({
+      triggers: { PreSignUp: triggerFunctionArn },
+      handler: answeringHandler({ autoVerifyEmail: true }),
+    });
+
+    // When a user signs itself up.
+    const signedUp = await signUpTriggerUser(pool);
+
+    // Then the address is verified and the user still has to confirm.
+    assertTrue(await isVerified(pool, "email"));
+    assertFalse(signedUp.UserConfirmed);
+    assertIdentical(await statusOf(pool), "UNCONFIRMED");
+  });
+
+  it("invokes the trigger on AdminCreateUser, naming that occasion", async () => {
+    // Given a pool whose PreSignUp trigger records what it is given.
+    const events: unknown[] = [];
+    const pool = await makeTriggerPool({
+      triggers: { PreSignUp: triggerFunctionArn },
+      handler: recordingHandler(events),
+    });
+
+    // When an admin creates a user instead.
+    await pool.cognito.adminCreateUser(
+      new AdminCreateUserCommand({
+        UserPoolId: pool.userPoolId,
+        Username: "alice",
+        UserAttributes: [{ Name: "email", Value: "alice@example.com" }],
+        ValidationData: [{ Name: "tenant", Value: "acme" }],
+        ClientMetadata: { source: "console" },
+      }),
+    );
+
+    // Then the trigger fired for the occasion real Cognito names it, with no
+    // app client to report because an admin operation is made with AWS
+    // credentials rather than through one.
+    assertObjectMatches(events[0], {
+      triggerSource: "PreSignUp_AdminCreateUser",
+      userName: "alice",
+      callerContext: { clientId: "CLIENT_ID_NOT_APPLICABLE" },
+      request: {
+        userAttributes: { email: "alice@example.com" },
+        validationData: { tenant: "acme" },
+        clientMetadata: { source: "console" },
+      },
+    });
+  });
+
+  it("ignores what the handler answers on the AdminCreateUser occasion", async () => {
+    // Given a pool whose PreSignUp trigger answers every flag it has.
+    const pool = await makeTriggerPool({
+      triggers: { PreSignUp: triggerFunctionArn },
+      handler: answeringHandler({
+        autoConfirmUser: true,
+        autoVerifyEmail: true,
+        autoVerifyPhone: true,
+      }),
+    });
+
+    // When an admin creates a user.
+    await pool.cognito.adminCreateUser(
+      new AdminCreateUserCommand({
+        UserPoolId: pool.userPoolId,
+        Username: "alice",
+        UserAttributes: [{ Name: "email", Value: "alice@example.com" }],
+      }),
+    );
+
+    // Then none of it was acted on, as real Cognito ignores all three here:
+    // the user is already past confirmation, so it waits on its temporary
+    // password with nothing vouched for.
+    assertIdentical(await statusOf(pool), "FORCE_CHANGE_PASSWORD");
+    assertUndefined(await attributeOf(pool, "email_verified"));
+  });
+
+  it("runs no trigger for a pool that names none", async () => {
+    // Given a pool with a PostConfirmation trigger and no PreSignUp one.
+    const events: unknown[] = [];
+    const pool = await makeTriggerPool({
+      triggers: { PostConfirmation: triggerFunctionArn },
+      handler: recordingHandler(events),
+    });
+
+    // When a user signs itself up.
+    const signedUp = await signUpTriggerUser(pool);
+
+    // Then nothing was invoked and the sign-up went ahead unconfirmed, which
+    // is where a pool with no trigger leaves one.
+    assertUndefined(events[0]);
+    assertFalse(signedUp.UserConfirmed);
+  });
+});

--- a/src/service/cognito/user-pool/trigger/sim-cognito-sign-up-trigger-failures.iso.test.ts
+++ b/src/service/cognito/user-pool/trigger/sim-cognito-sign-up-trigger-failures.iso.test.ts
@@ -1,0 +1,222 @@
+import {
+  AdminCreateUserCommand,
+  AdminGetUserCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import {
+  assertFalse,
+  assertIdentical,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import {
+  confirmTriggerSignUp,
+  makeTriggerPool,
+  signUpTriggerUser,
+  triggerFunctionArn,
+  triggerPassword,
+} from "../../../../../test/cognito/trigger-fixture.js";
+import type { SimCognitoTriggerPool } from "../../../../../test/cognito/trigger-fixture.js";
+
+/**
+ * A handler that turns the request down the way a trigger handler does, by
+ * throwing.
+ */
+function refusingHandler(message: string): () => never {
+  return () => {
+    throw new Error(message);
+  };
+}
+
+/**
+ * How many users the pool holds.
+ */
+function userCount(pool: SimCognitoTriggerPool): number {
+  return pool.cognito.userPool(pool.userPoolId).userCount;
+}
+
+describe("sim Cognito sign-up trigger failures", () => {
+  it("refuses the sign-up with the message a PreSignUp handler threw", async () => {
+    // Given a pool whose PreSignUp trigger turns sign-ups down.
+    const pool = await makeTriggerPool({
+      triggers: { PreSignUp: triggerFunctionArn },
+      handler: refusingHandler("Only example.com may sign up"),
+    });
+
+    // When a user tries to sign itself up.
+    const error = await assertThrowsErrorAsync(async () =>
+      signUpTriggerUser(pool),
+    );
+
+    // Then it is refused the way real Cognito refuses it, carrying the
+    // handler's own words.
+    assertIdentical(error.name, "UserLambdaValidationException");
+    assertStringIncludes(
+      error.message,
+      "PreSignUp failed with error Only example.com may sign up.",
+    );
+
+    // And no user was created, because the trigger ran before the pool took
+    // one.
+    assertIdentical(userCount(pool), 0);
+  });
+
+  it("creates no user when a PreSignUp handler refuses an AdminCreateUser", async () => {
+    // Given a pool whose PreSignUp trigger turns every new user down.
+    const pool = await makeTriggerPool({
+      triggers: { PreSignUp: triggerFunctionArn },
+      handler: refusingHandler("Nobody new today"),
+    });
+
+    // When an admin tries to create one.
+    const error = await assertThrowsErrorAsync(async () =>
+      pool.cognito.adminCreateUser(
+        new AdminCreateUserCommand({
+          UserPoolId: pool.userPoolId,
+          Username: "alice",
+        }),
+      ),
+    );
+
+    // Then the creation was refused and the pool is still empty.
+    assertIdentical(error.name, "UserLambdaValidationException");
+    assertStringIncludes(error.message, "PreSignUp failed with error");
+    assertIdentical(userCount(pool), 0);
+  });
+
+  it("refuses a sign-up whose PreSignUp trigger cannot be invoked", async () => {
+    // Given a pool whose trigger function was never granted the invoke
+    // permission a CDK addTrigger emits.
+    const pool = await makeTriggerPool({
+      triggers: { PreSignUp: triggerFunctionArn },
+      permitted: false,
+    });
+
+    // When a user tries to sign itself up.
+    const error = await assertThrowsErrorAsync(async () =>
+      signUpTriggerUser(pool),
+    );
+
+    // Then the missing permission is reported rather than the sign-up going
+    // ahead as though the pool had no trigger.
+    assertIdentical(error.name, "UnexpectedLambdaException");
+    assertStringIncludes(error.message, "cognito-idp.amazonaws.com");
+    assertIdentical(userCount(pool), 0);
+  });
+
+  it("refuses a sign-up whose PreSignUp handler verified an attribute it has not got", async () => {
+    // Given a pool whose PreSignUp trigger vouches for a phone number.
+    const pool = await makeTriggerPool({
+      triggers: { PreSignUp: triggerFunctionArn },
+      handler: (event: { response: Record<string, boolean> }) => {
+        event.response["autoVerifyPhone"] = true;
+
+        return event;
+      },
+    });
+
+    // When a user signs up with an email and no phone number.
+    const error = await assertThrowsErrorAsync(async () =>
+      signUpTriggerUser(pool),
+    );
+
+    // Then the sign-up is refused, as real Cognito refuses one whose
+    // auto-verified attribute is not there, rather than creating a user with
+    // the flag quietly unset.
+    assertIdentical(error.name, "InvalidParameterException");
+    assertStringIncludes(error.message, "asked to verify 'phone_number'");
+    assertIdentical(userCount(pool), 0);
+  });
+
+  it("leaves the user confirmed when PostConfirmation fails", async () => {
+    // Given a pool whose PostConfirmation trigger throws.
+    const pool = await makeTriggerPool({
+      triggers: { PostConfirmation: triggerFunctionArn },
+      handler: refusingHandler("The user table is unreachable"),
+    });
+
+    await signUpTriggerUser(pool);
+
+    // When the user confirms.
+    const error = await assertThrowsErrorAsync(async () =>
+      confirmTriggerSignUp(pool),
+    );
+
+    // Then the request failed on the trigger.
+    assertIdentical(error.name, "UserLambdaValidationException");
+    assertStringIncludes(error.message, "PostConfirmation failed with error");
+
+    // And the confirmation that had already happened stands, as it does on
+    // real Cognito: the trigger runs after it, not as part of it.
+    const read = await pool.cognito.adminGetUser(
+      new AdminGetUserCommand({
+        UserPoolId: pool.userPoolId,
+        Username: "alice",
+      }),
+    );
+
+    assertIdentical(read.UserStatus, "CONFIRMED");
+  });
+
+  it("refuses a PreSignUp handler that returned something else", async () => {
+    // Given a PreSignUp handler that answers with a string.
+    const pool = await makeTriggerPool({
+      triggers: { PreSignUp: triggerFunctionArn },
+      handler: () => "ok",
+    });
+
+    // When a user signs itself up.
+    const error = await assertThrowsErrorAsync(async () =>
+      signUpTriggerUser(pool),
+    );
+
+    // Then the response is refused, because Cognito reads the returned event
+    // rather than the one it sent.
+    assertIdentical(error.name, "InvalidLambdaResponseException");
+    assertStringIncludes(error.message, "rather than the event it was given");
+    assertIdentical(userCount(pool), 0);
+  });
+
+  it("reads a dropped response as a handler asking for nothing", async () => {
+    // Given a PreSignUp handler that hands back the request half alone, which
+    // is an event without the response Cognito sent.
+    const pool = await makeTriggerPool({
+      triggers: { PreSignUp: triggerFunctionArn },
+      handler: (event: { request: object }) => ({ request: event.request }),
+    });
+
+    // When a user signs itself up.
+    const signedUp = await signUpTriggerUser(pool);
+
+    // Then the sign-up went ahead unconfirmed: a handler with no response has
+    // asked for none of the three things it could have.
+    assertFalse(signedUp.UserConfirmed);
+    assertIdentical(userCount(pool), 1);
+  });
+
+  it("refuses ValidationData that names nothing", async () => {
+    // Given a pool with a PreSignUp trigger.
+    const pool = await makeTriggerPool({
+      triggers: { PreSignUp: triggerFunctionArn },
+    });
+
+    // When a sign-up carries a validation data entry with no Name, which the
+    // SDK's own types would not let a caller build.
+    const error = await assertThrowsErrorAsync(async () =>
+      pool.cognito.signUp({
+        input: {
+          ClientId: pool.clientId,
+          Username: "alice",
+          Password: triggerPassword,
+          ValidationData: [{ Value: "acme" }],
+        },
+      }),
+    );
+
+    // Then it is refused: a handler reads validation data by name, so an entry
+    // without one reaches nothing.
+    assertIdentical(error.name, "InvalidParameterException");
+    assertStringIncludes(error.message, "SignUp ValidationData needs a Name");
+  });
+});

--- a/src/service/cognito/user-pool/trigger/sim-cognito-trigger-context.ts
+++ b/src/service/cognito/user-pool/trigger/sim-cognito-trigger-context.ts
@@ -1,0 +1,38 @@
+import type { SimCognitoUserPoolClient } from "../client/sim-cognito-user-pool-client.js";
+import type { SimCognitoUserPool } from "../sim-cognito-user-pool.js";
+import type { SimCognitoUser } from "../user/sim-cognito-user.js";
+
+/**
+ * The request a trigger is firing for.
+ *
+ * The app client is optional because the admin operations have none. Real
+ * Cognito reports `CLIENT_ID_NOT_APPLICABLE` as the caller context's client id
+ * for those, which is what a handler branching on the client sees.
+ *
+ * The user is the one the trigger is about. On the `PreSignUp` occasions it has
+ * not been added to the pool yet, which is the point: a handler that throws
+ * leaves the pool without it.
+ */
+export interface SimCognitoTriggerContext {
+  readonly pool: SimCognitoUserPool;
+  readonly user: SimCognitoUser;
+  readonly client?: SimCognitoUserPoolClient | undefined;
+
+  /**
+   * The `ClientMetadata` the request carried.
+   *
+   * A sign-in's reaches `PreAuthentication` as its validation data and
+   * `PostAuthentication` as its client metadata. A sign-up's reaches
+   * `PreSignUp` and `PostConfirmation` as client metadata, alongside the
+   * validation data below.
+   */
+  readonly clientMetadata?: Readonly<Record<string, string>> | undefined;
+
+  /**
+   * The `ValidationData` a sign-up or a user creation carried.
+   *
+   * Real Cognito never stores this on the user. It exists to be read by a
+   * `PreSignUp` handler and goes no further.
+   */
+  readonly validationData?: Readonly<Record<string, string>> | undefined;
+}

--- a/src/service/cognito/user-pool/trigger/sim-cognito-trigger-event.ts
+++ b/src/service/cognito/user-pool/trigger/sim-cognito-trigger-event.ts
@@ -1,11 +1,8 @@
-import type { SimCognitoUserPoolClient } from "../client/sim-cognito-user-pool-client.js";
-import type { SimCognitoUserPool } from "../sim-cognito-user-pool.js";
 import { simCognitoUserPoolRegionName } from "../sim-cognito-user-pool-id.js";
-import type { SimCognitoUser } from "../user/sim-cognito-user.js";
-import {
-  simCognitoTriggerSource,
-  type SimCognitoTriggerName,
-} from "./sim-cognito-trigger-name.js";
+import type { SimCognitoTriggerContext } from "./sim-cognito-trigger-context.js";
+import type { SimCognitoTriggerName } from "./sim-cognito-trigger-name.js";
+import type { SimCognitoTriggerOccasion } from "./sim-cognito-trigger-occasion.js";
+import { SimCognitoTriggerRequest } from "./sim-cognito-trigger-request.js";
 
 /**
  * The SDK version real Cognito reports for a caller it could not identify,
@@ -19,22 +16,20 @@ import {
 const awsSdkVersion = "aws-sdk-unknown-unknown";
 
 /**
- * The sign-in a trigger is firing for.
+ * The client id real Cognito reports for an operation no app client made.
+ *
+ * `AdminCreateUser` and `AdminConfirmSignUp` are called with AWS credentials
+ * rather than through an app client, so there is no client id to report.
  */
-export interface SimCognitoTriggerContext {
-  readonly pool: SimCognitoUserPool;
-  readonly client: SimCognitoUserPoolClient;
-  readonly user: SimCognitoUser;
-  readonly clientMetadata?: Readonly<Record<string, string>> | undefined;
-}
+const adminCallerClientId = "CLIENT_ID_NOT_APPLICABLE";
 
 /**
  * The event document a simulated Cognito Lambda trigger is invoked with.
  *
- * The shape is the real one, down to the empty `response` a handler is
- * expected to hand back untouched. Neither of these two triggers reads anything
- * out of `response`, so what a handler writes there is ignored, exactly as real
- * Cognito ignores it.
+ * The shape is the real one, down to the `response` a handler is expected to
+ * hand back with its answer written into it. Only `PreSignUp` is asked
+ * anything, so it is the only one whose response arrives with fields already
+ * in it, which is how real Cognito sends it.
  */
 export class SimCognitoTriggerEvent {
   private readonly context: SimCognitoTriggerContext;
@@ -44,14 +39,28 @@ export class SimCognitoTriggerEvent {
   }
 
   /**
-   * The event for one trigger.
+   * The response half of the event, as real Cognito sends it.
    *
-   * The two triggers name the same data differently, which is not a detail to
-   * smooth over: a `PreAuthentication` handler reads `request.validationData`
-   * and a `PostAuthentication` one reads `request.clientMetadata`, and both
-   * come from the `ClientMetadata` the sign-in request carried.
+   * A `PreSignUp` handler is sent the three flags it can answer with, already
+   * set to false, so a handler reading one before writing it finds what it
+   * would find against a real pool.
    */
-  document(trigger: SimCognitoTriggerName): object {
+  private static response(trigger: SimCognitoTriggerName): object {
+    if (trigger !== "PreSignUp") {
+      return {};
+    }
+
+    return {
+      autoConfirmUser: false,
+      autoVerifyEmail: false,
+      autoVerifyPhone: false,
+    };
+  }
+
+  /**
+   * The event for one occasion.
+   */
+  document(occasion: SimCognitoTriggerOccasion): object {
     return {
       version: "1",
       region: simCognitoUserPoolRegionName(this.context.pool.id),
@@ -59,50 +68,13 @@ export class SimCognitoTriggerEvent {
       userName: this.context.user.username,
       callerContext: {
         awsSdkVersion,
-        clientId: this.context.client.id,
+        clientId: this.context.client?.id ?? adminCallerClientId,
       },
-      triggerSource: simCognitoTriggerSource(trigger),
-      request: this.request(trigger),
-      response: {},
-    };
-  }
-
-  private request(trigger: SimCognitoTriggerName): object {
-    if (trigger === "PreAuthentication") {
-      return {
-        userAttributes: this.userAttributes(),
-        ...(this.context.clientMetadata !== undefined && {
-          validationData: { ...this.context.clientMetadata },
-        }),
-        // A sign-in naming a user the pool does not hold is refused before any
-        // trigger runs here, so the trigger only ever sees a user that exists.
-        // Real Cognito fires it with `userNotFound: true` for an app client
-        // that hides user existence, which this simulation does not do.
-        userNotFound: false,
-      };
-    }
-
-    return {
-      userAttributes: this.userAttributes(),
-      // Devices are not remembered here: `CreateUserPool` refuses a
-      // `DeviceConfiguration`, so no sign-in is ever made from a new device.
-      newDeviceUsed: false,
-      ...(this.context.clientMetadata !== undefined && {
-        clientMetadata: { ...this.context.clientMetadata },
-      }),
-    };
-  }
-
-  /**
-   * The user's attributes by name, as a trigger event carries them.
-   *
-   * The event is a plain object of strings rather than the `Name`/`Value` pairs
-   * the API answers with, and `sub` is among them.
-   */
-  private userAttributes(): Record<string, string> {
-    return {
-      sub: this.context.user.sub,
-      ...Object.fromEntries(this.context.user.attributeValues),
+      triggerSource: occasion.source,
+      request: new SimCognitoTriggerRequest(this.context).document(
+        occasion.trigger,
+      ),
+      response: SimCognitoTriggerEvent.response(occasion.trigger),
     };
   }
 }

--- a/src/service/cognito/user-pool/trigger/sim-cognito-trigger-name.ts
+++ b/src/service/cognito/user-pool/trigger/sim-cognito-trigger-name.ts
@@ -1,12 +1,14 @@
 /**
  * The Lambda triggers a simulated user pool runs.
  *
- * These two are the ones that fire around a sign-in, which is the only part of
- * a user's life this simulation has: `AdminCreateUser` is how a user comes to
- * exist here, and a pool sends no messages, so the sign-up and message triggers
- * would never run whatever a pool named for them.
+ * These are the ones that fire around a sign-up and around a sign-in, which is
+ * the part of a user's life this simulation has. A pool sends no messages and
+ * federates with nobody, so the message and federation triggers would never run
+ * whatever a pool named for them.
  */
 export const simCognitoTriggerNames = [
+  "PreSignUp",
+  "PostConfirmation",
   "PreAuthentication",
   "PostAuthentication",
 ] as const;
@@ -14,33 +16,15 @@ export const simCognitoTriggerNames = [
 export type SimCognitoTriggerName = (typeof simCognitoTriggerNames)[number];
 
 /**
- * What real Cognito calls a trigger when it invokes it.
- *
- * A handler reads `triggerSource` to tell apart the several occasions one
- * trigger fires on, so the value has to be the real one rather than the
- * trigger's own name. Each of these two has a single source here, because the
- * other sources name flows this simulation does not run.
- */
-export function simCognitoTriggerSource(
-  trigger: SimCognitoTriggerName,
-): string {
-  return trigger === "PreAuthentication"
-    ? "PreAuthentication_Authentication"
-    : "PostAuthentication_Authentication";
-}
-
-/**
  * The `LambdaConfig` keys real Cognito has that this simulation does not run,
  * and why each one is refused rather than accepted and ignored.
  *
- * A pool that accepted one of these would sign users in without ever calling
- * the function the template named, which is the difference between a stack
- * that works here and one that works deployed.
+ * A pool that accepted one of these would sign users up or in without ever
+ * calling the function the template named, which is the difference between a
+ * stack that works here and one that works deployed.
  */
 export const simCognitoUnsimulatedTriggers: ReadonlyMap<string, string> =
   new Map([
-    ["PreSignUp", "validating a self-service sign-up"],
-    ["PostConfirmation", "acting on a user confirming its own account"],
     ["PreTokenGeneration", "changing the claims a pool puts in its tokens"],
     [
       "PreTokenGenerationConfig",

--- a/src/service/cognito/user-pool/trigger/sim-cognito-trigger-occasion.ts
+++ b/src/service/cognito/user-pool/trigger/sim-cognito-trigger-occasion.ts
@@ -1,0 +1,71 @@
+import type { SimCognitoTriggerName } from "./sim-cognito-trigger-name.js";
+
+/**
+ * One occasion a simulated user pool fires a trigger on.
+ *
+ * A trigger and the occasion it fired on are not the same thing. `PreSignUp`
+ * runs both when a user signs itself up and when an admin creates one, and a
+ * handler tells the two apart by the `triggerSource` on the event. The pair
+ * travels together so a source is never derived from a trigger name, which
+ * would only work while every trigger had one.
+ *
+ * The source is the real string real Cognito sends, because that is what a
+ * handler written against a deployed pool branches on.
+ */
+export class SimCognitoTriggerOccasion {
+  /**
+   * A user signing itself up with `SignUp`.
+   */
+  public static readonly signUp = new SimCognitoTriggerOccasion(
+    "PreSignUp",
+    "PreSignUp_SignUp",
+  );
+
+  /**
+   * An admin creating a user with `AdminCreateUser`.
+   *
+   * Real Cognito ignores everything a handler writes into the response on this
+   * occasion, because the user it is about to create is already past
+   * confirmation.
+   */
+  public static readonly adminCreateUser = new SimCognitoTriggerOccasion(
+    "PreSignUp",
+    "PreSignUp_AdminCreateUser",
+  );
+
+  /**
+   * A signed-up user reaching `CONFIRMED`.
+   *
+   * `ConfirmSignUp`, `AdminConfirmSignUp` and a `PreSignUp` handler that
+   * auto-confirmed the user all report this one source, as they do on real
+   * Cognito.
+   */
+  public static readonly confirmSignUp = new SimCognitoTriggerOccasion(
+    "PostConfirmation",
+    "PostConfirmation_ConfirmSignUp",
+  );
+
+  /**
+   * A sign-in, before the user's password is checked.
+   */
+  public static readonly preAuthentication = new SimCognitoTriggerOccasion(
+    "PreAuthentication",
+    "PreAuthentication_Authentication",
+  );
+
+  /**
+   * A sign-in, once the tokens have been issued.
+   */
+  public static readonly postAuthentication = new SimCognitoTriggerOccasion(
+    "PostAuthentication",
+    "PostAuthentication_Authentication",
+  );
+
+  public readonly trigger: SimCognitoTriggerName;
+  public readonly source: string;
+
+  private constructor(trigger: SimCognitoTriggerName, source: string) {
+    this.trigger = trigger;
+    this.source = source;
+  }
+}

--- a/src/service/cognito/user-pool/trigger/sim-cognito-trigger-request.ts
+++ b/src/service/cognito/user-pool/trigger/sim-cognito-trigger-request.ts
@@ -1,0 +1,116 @@
+import type { SimCognitoTriggerContext } from "./sim-cognito-trigger-context.js";
+import type { SimCognitoTriggerName } from "./sim-cognito-trigger-name.js";
+
+/**
+ * The `request` half of the event one trigger is given.
+ *
+ * Each trigger reads its own set of fields, and two of them name the same data
+ * differently, which is not a detail to smooth over: a `PreAuthentication`
+ * handler reads `request.validationData` where a `PostAuthentication` one reads
+ * `request.clientMetadata`, and both come from the `ClientMetadata` the sign-in
+ * carried.
+ */
+export class SimCognitoTriggerRequest {
+  private readonly context: SimCognitoTriggerContext;
+
+  constructor(context: SimCognitoTriggerContext) {
+    this.context = context;
+  }
+
+  /**
+   * The request for one trigger.
+   */
+  document(trigger: SimCognitoTriggerName): object {
+    switch (trigger) {
+      case "PreSignUp": {
+        return this.preSignUp();
+      }
+      case "PostConfirmation": {
+        return this.postConfirmation();
+      }
+      case "PreAuthentication": {
+        return this.preAuthentication();
+      }
+      case "PostAuthentication": {
+        return this.postAuthentication();
+      }
+    }
+  }
+
+  /**
+   * What a `PreSignUp` handler is given.
+   *
+   * The attributes carry no `sub`, because the user does not exist yet: real
+   * Cognito allocates one only once the sign-up has got past this handler. A
+   * handler keying an external record on `sub` has to do it in
+   * `PostConfirmation` instead, here as there.
+   */
+  private preSignUp(): object {
+    return {
+      userAttributes: Object.fromEntries(this.context.user.attributeValues),
+      ...this.validationData(),
+      ...this.clientMetadata(),
+    };
+  }
+
+  /**
+   * What a `PostConfirmation` handler is given, which is the confirmed user's
+   * attributes with the `sub` Cognito allocated among them.
+   */
+  private postConfirmation(): object {
+    return { userAttributes: this.userAttributes(), ...this.clientMetadata() };
+  }
+
+  private preAuthentication(): object {
+    return {
+      userAttributes: this.userAttributes(),
+      ...(this.context.clientMetadata !== undefined && {
+        validationData: { ...this.context.clientMetadata },
+      }),
+      // A sign-in naming a user the pool does not hold is refused before any
+      // trigger runs here, so the trigger only ever sees a user that exists.
+      // Real Cognito fires it with `userNotFound: true` for an app client
+      // that hides user existence, which this simulation does not do.
+      userNotFound: false,
+    };
+  }
+
+  private postAuthentication(): object {
+    return {
+      userAttributes: this.userAttributes(),
+      // Devices are not remembered here: `CreateUserPool` refuses a
+      // `DeviceConfiguration`, so no sign-in is ever made from a new device.
+      newDeviceUsed: false,
+      ...this.clientMetadata(),
+    };
+  }
+
+  /**
+   * The user's attributes by name, as a trigger event carries them.
+   *
+   * The event is a plain object of strings rather than the `Name`/`Value` pairs
+   * the API answers with, and `sub` is among them.
+   */
+  private userAttributes(): Record<string, string> {
+    return {
+      sub: this.context.user.sub,
+      ...Object.fromEntries(this.context.user.attributeValues),
+    };
+  }
+
+  private clientMetadata(): object {
+    if (this.context.clientMetadata === undefined) {
+      return {};
+    }
+
+    return { clientMetadata: { ...this.context.clientMetadata } };
+  }
+
+  private validationData(): object {
+    if (this.context.validationData === undefined) {
+      return {};
+    }
+
+    return { validationData: { ...this.context.validationData } };
+  }
+}

--- a/src/service/cognito/user-pool/trigger/sim-cognito-trigger-response.ts
+++ b/src/service/cognito/user-pool/trigger/sim-cognito-trigger-response.ts
@@ -11,9 +11,11 @@ import type { SimCognitoTriggerName } from "./sim-cognito-trigger-name.js";
  * something without the `request` it was given has returned a different event.
  * Both are `InvalidLambdaResponseException` there and here.
  *
- * `response` is not checked. Neither of the triggers this simulation runs reads
- * anything out of it, so a handler that dropped it has not changed what happens
- * next, and refusing it here would refuse handlers real Cognito accepts.
+ * `response` is not checked. `PreSignUp` is the only trigger here that reads
+ * anything out of it, and a handler that dropped it is read as having answered
+ * no to all three of its flags, which is what a handler with nothing to ask for
+ * means. Refusing a missing `response` would refuse handlers real Cognito
+ * accepts.
  */
 export function requireSimCognitoTriggerResponse(
   trigger: SimCognitoTriggerName,

--- a/src/service/cognito/user-pool/trigger/sim-cognito-user-pool-triggers.ts
+++ b/src/service/cognito/user-pool/trigger/sim-cognito-user-pool-triggers.ts
@@ -2,15 +2,14 @@ import {
   SimCognitoUnexpectedLambdaException,
   SimCognitoUserLambdaValidationException,
 } from "../../error/sim-cognito-trigger.error.js";
-import {
-  SimCognitoTriggerEvent,
-  type SimCognitoTriggerContext,
-} from "./sim-cognito-trigger-event.js";
+import { SimCognitoPreSignUpResponse } from "./sim-cognito-pre-sign-up-response.js";
+import type { SimCognitoTriggerContext } from "./sim-cognito-trigger-context.js";
+import { SimCognitoTriggerEvent } from "./sim-cognito-trigger-event.js";
 import type {
   SimCognitoTriggerFunctionRequest,
   SimCognitoTriggerFunctions,
 } from "./sim-cognito-trigger-functions.js";
-import type { SimCognitoTriggerName } from "./sim-cognito-trigger-name.js";
+import { SimCognitoTriggerOccasion } from "./sim-cognito-trigger-occasion.js";
 import { requireSimCognitoTriggerResponse } from "./sim-cognito-trigger-response.js";
 
 interface SimCognitoUserPoolTriggersProperties {
@@ -22,7 +21,7 @@ interface SimCognitoUserPoolTriggersProperties {
  *
  * A pool with no trigger for the occasion runs nothing, which is the ordinary
  * case and costs a map lookup. A pool with one invokes it and waits: these
- * triggers are synchronous, so the sign-in is held up until the handler
+ * triggers are synchronous, so the request is held up until the handler
  * answers, as it is on real Cognito.
  *
  * The function's resource policy is checked on every invocation rather than
@@ -37,6 +36,37 @@ export class SimCognitoUserPoolTriggers {
   }
 
   /**
+   * Run the `PreSignUp` trigger, if the pool has one, and read its answer.
+   *
+   * This runs before the user is added to the pool, so a handler that throws
+   * refuses the sign-up and leaves the pool without it, which is what the
+   * trigger is for.
+   *
+   * The answer is read on every occasion and acted on by the caller. Real
+   * Cognito ignores all three flags when the occasion is `AdminCreateUser`,
+   * because that user is already past confirmation, so that caller reads the
+   * answer and does nothing with it.
+   */
+  async preSignUp(
+    occasion: SimCognitoTriggerOccasion,
+    context: SimCognitoTriggerContext,
+  ): Promise<SimCognitoPreSignUpResponse> {
+    return new SimCognitoPreSignUpResponse(await this.run(occasion, context));
+  }
+
+  /**
+   * Run the `PostConfirmation` trigger, if the pool has one.
+   *
+   * This runs once the user is `CONFIRMED`, so a handler that throws fails the
+   * request without undoing the confirmation: the user stays confirmed, exactly
+   * as on real Cognito. `AdminCreateUser` never reaches here, as it never
+   * reaches it on real Cognito.
+   */
+  async postConfirmation(context: SimCognitoTriggerContext): Promise<void> {
+    await this.run(SimCognitoTriggerOccasion.confirmSignUp, context);
+  }
+
+  /**
    * Run the `PreAuthentication` trigger, if the pool has one.
    *
    * A handler that throws refuses the sign-in, which is what the trigger is
@@ -44,7 +74,7 @@ export class SimCognitoUserPoolTriggers {
    * `UserLambdaValidationException` the caller sees.
    */
   async preAuthentication(context: SimCognitoTriggerContext): Promise<void> {
-    await this.run("PreAuthentication", context);
+    await this.run(SimCognitoTriggerOccasion.preAuthentication, context);
   }
 
   /**
@@ -55,17 +85,22 @@ export class SimCognitoUserPoolTriggers {
    * tokens the pool issued stay issued, exactly as on real Cognito.
    */
   async postAuthentication(context: SimCognitoTriggerContext): Promise<void> {
-    await this.run("PostAuthentication", context);
+    await this.run(SimCognitoTriggerOccasion.postAuthentication, context);
   }
 
+  /**
+   * Invoke the trigger for one occasion, answering with what the handler
+   * returned, or with nothing where the pool has no such trigger.
+   */
   private async run(
-    trigger: SimCognitoTriggerName,
+    occasion: SimCognitoTriggerOccasion,
     context: SimCognitoTriggerContext,
-  ): Promise<void> {
+  ): Promise<unknown> {
+    const { trigger } = occasion;
     const functionArn = context.pool.settings.lambdaConfig.find(trigger);
 
     if (functionArn === undefined) {
-      return;
+      return undefined;
     }
 
     const request: SimCognitoTriggerFunctionRequest = {
@@ -82,32 +117,33 @@ export class SimCognitoUserPoolTriggers {
       );
     }
 
-    requireSimCognitoTriggerResponse(
-      trigger,
-      await this.invoke(trigger, request, context),
-    );
+    const returned = await this.invoke(occasion, request, context);
+
+    requireSimCognitoTriggerResponse(trigger, returned);
+
+    return returned;
   }
 
   /**
    * Invoke the handler, reporting a failure the way real Cognito reports one.
    *
    * The handler's own message is repeated because that is the whole mechanism a
-   * `PreAuthentication` trigger refuses a sign-in with: it throws, and the
-   * words it threw are what the caller is told.
+   * `PreSignUp` or `PreAuthentication` trigger refuses a request with: it
+   * throws, and the words it threw are what the caller is told.
    */
   private async invoke(
-    trigger: SimCognitoTriggerName,
+    occasion: SimCognitoTriggerOccasion,
     request: SimCognitoTriggerFunctionRequest,
     context: SimCognitoTriggerContext,
   ): Promise<unknown> {
     try {
       return await this.functions.invoke(
         request,
-        new SimCognitoTriggerEvent(context).document(trigger),
+        new SimCognitoTriggerEvent(context).document(occasion),
       );
     } catch (error) {
       throw new SimCognitoUserLambdaValidationException(
-        `${trigger} failed with error ${
+        `${occasion.trigger} failed with error ${
           error instanceof Error ? error.message : String(error)
         }.`,
       );

--- a/test/cognito/post-confirmation-table-fixture.ts
+++ b/test/cognito/post-confirmation-table-fixture.ts
@@ -1,0 +1,132 @@
+/**
+ * The parts a test needs to watch a `PostConfirmation` trigger write a user
+ * item to a simulated DynamoDB table: the table, an execution Role with or
+ * without the grant the write needs, and a pool whose trigger runs that code.
+ *
+ * The function code here is a real archive rather than a stowed handler
+ * function, so it runs in the Lambda vm with the runtime's own AWS SDK provided
+ * to it. Its calls are made as the function's execution Role, which is what
+ * makes the missing-grant case mean anything.
+ */
+
+import {
+  CreateTableCommand,
+  GetItemCommand,
+  type AttributeValue,
+} from "@aws-sdk/client-dynamodb";
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+
+import { SimAws } from "../../src/service/aws/sim-aws.js";
+import { simIamPolicyDocumentFactory } from "../../src/service/iam/policy/sim-iam-policy-document.factory.js";
+import { makeLambdaCodeZip } from "../../src/service/lambda/function/code/make-lambda-code-zip.js";
+import {
+  makeTriggerPool,
+  triggerFunctionArn,
+  type SimCognitoTriggerPool,
+} from "./trigger-fixture.js";
+
+/** The table the trigger writes each confirmed user to. */
+export const usersTableName = "users";
+
+const writeUserItemCode = `
+const { DynamoDBClient, PutItemCommand } = require("@aws-sdk/client-dynamodb");
+
+const dynamoDb = new DynamoDBClient({});
+
+exports.handler = async (event) => {
+  await dynamoDb.send(
+    new PutItemCommand({
+      TableName: "${usersTableName}",
+      Item: {
+        sub: { S: event.request.userAttributes.sub },
+        email: { S: event.request.userAttributes.email },
+        username: { S: event.userName },
+      },
+    }),
+  );
+
+  return event;
+};
+`;
+
+/**
+ * Build a pool whose `PostConfirmation` trigger writes the new user to the
+ * table, running as a Role that may or may not write it.
+ */
+export async function makeUserWritingPool(
+  granted: boolean,
+): Promise<SimCognitoTriggerPool> {
+  const simAws = new SimAws();
+
+  await makeUsersTable(simAws);
+
+  return await makeTriggerPool({
+    simAws,
+    triggers: { PostConfirmation: triggerFunctionArn },
+    code: makeLambdaCodeZip(writeUserItemCode),
+    roleArn: await makeWriterRole(simAws, granted),
+  });
+}
+
+/**
+ * Read the item the trigger would have written for a user.
+ */
+export async function readUserItem(
+  pool: SimCognitoTriggerPool,
+  sub: string,
+): Promise<Record<string, AttributeValue> | undefined> {
+  const read = await pool.simAws.dynamoDb().getItem(
+    new GetItemCommand({
+      TableName: usersTableName,
+      Key: { sub: { S: sub } },
+    }),
+  );
+
+  return read.Item;
+}
+
+async function makeUsersTable(simAws: SimAws): Promise<void> {
+  await simAws.dynamoDb().createTable(
+    new CreateTableCommand({
+      TableName: usersTableName,
+      AttributeDefinitions: [{ AttributeName: "sub", AttributeType: "S" }],
+      KeySchema: [{ AttributeName: "sub", KeyType: "HASH" }],
+      BillingMode: "PAY_PER_REQUEST",
+    }),
+  );
+}
+
+async function makeWriterRole(
+  simAws: SimAws,
+  granted: boolean,
+): Promise<string> {
+  const roleName = "PostConfirmationRole";
+  const created = await simAws.iam().createRole(
+    new CreateRoleCommand({
+      RoleName: roleName,
+      AssumeRolePolicyDocument: simIamPolicyDocumentFactory.make({
+        Statement: {
+          Principal: { Service: "lambda.amazonaws.com" },
+          Action: "sts:AssumeRole",
+        },
+      }),
+    }),
+  );
+
+  if (granted) {
+    await simAws.iam().putRolePolicy(
+      new PutRolePolicyCommand({
+        RoleName: roleName,
+        PolicyName: "WriteUsers",
+        PolicyDocument: simIamPolicyDocumentFactory.make({
+          Statement: {
+            Action: "dynamodb:PutItem",
+            Resource: `arn:aws:dynamodb:*:*:table/${usersTableName}`,
+          },
+        }),
+      }),
+    );
+  }
+
+  return created.Role.Arn;
+}

--- a/test/cognito/trigger-fixture.ts
+++ b/test/cognito/trigger-fixture.ts
@@ -38,6 +38,9 @@ import type { SimLambdaHandler } from "../../src/service/lambda/function/sim-lam
  */
 const passThroughHandler: SimLambdaHandler = (event: unknown) => event;
 
+/** The user every suite in the fixture signs up, creates or signs in. */
+export const triggerUsername = "alice";
+
 /** The password the fixture's user signs in with. */
 export const triggerPassword = "Sup3rSecret!";
 
@@ -60,15 +63,19 @@ export interface SimCognitoTriggerPoolInput {
    */
   readonly simAws?: SimAws | undefined;
 
-  /** What the function does when a trigger invokes it. */
+  /**
+   * What the function does when a trigger invokes it, as a handler function.
+   *
+   * This is the quick way to say what a trigger does, and it is ignored when
+   * `code` is given as well: the two are alternatives, and the archive wins.
+   */
   readonly handler?: SimLambdaHandler | undefined;
 
   /**
    * A real code archive to run instead of a handler function.
    *
-   * A handler function is the quick way to say what a trigger does. Function
-   * code that calls another simulated service has to be an archive, because
-   * that is what runs in the Lambda vm with the runtime's own AWS SDK
+   * Function code that calls another simulated service has to be an archive,
+   * because that is what runs in the Lambda vm with the runtime's own AWS SDK
    * provided to it.
    */
   readonly code?: Uint8Array | undefined;
@@ -213,20 +220,26 @@ export async function makeTriggerUser(
 }
 
 /**
- * Sign a user up through the fixture's app client.
+ * Sign the fixture's user up through its app client.
  *
  * This is the self-service path rather than the admin one, so it is what
  * reaches `PreSignUp_SignUp` and, once confirmed, `PostConfirmation`.
+ *
+ * The app client, the username and the password are the fixture's own, so a
+ * caller names only what the trigger under test reads: the attributes, the
+ * validation data and the client metadata.
  */
 export async function signUpTriggerUser(
   pool: SimCognitoTriggerPool,
-  input: Partial<SignUpCommandInput> = {},
+  input: Partial<
+    Omit<SignUpCommandInput, "ClientId" | "Password" | "Username">
+  > = {},
 ): Promise<SimSignUpCommandOutput> {
   return await pool.cognito.signUp(
     new SignUpCommand({
       UserAttributes: [{ Name: "email", Value: "alice@example.com" }],
       ...input,
-      Username: input.Username ?? "alice",
+      Username: triggerUsername,
       ClientId: pool.clientId,
       Password: triggerPassword,
     }),
@@ -243,10 +256,10 @@ export async function confirmTriggerSignUp(
   await pool.cognito.confirmSignUp(
     new ConfirmSignUpCommand({
       ClientId: pool.clientId,
-      Username: "alice",
+      Username: triggerUsername,
       ConfirmationCode: pool.cognito
         .userPool(pool.userPoolId)
-        .confirmationCode("alice"),
+        .confirmationCode(triggerUsername),
       ...(clientMetadata !== undefined && { ClientMetadata: clientMetadata }),
     }),
   );

--- a/test/cognito/trigger-fixture.ts
+++ b/test/cognito/trigger-fixture.ts
@@ -11,8 +11,12 @@
 import {
   AdminCreateUserCommand,
   AdminSetUserPasswordCommand,
+  ConfirmSignUpCommand,
   CreateUserPoolClientCommand,
   CreateUserPoolCommand,
+  SignUpCommand,
+  type SignUpCommandInput,
+  type VerifiedAttributeType,
 } from "@aws-sdk/client-cognito-identity-provider";
 import {
   AddPermissionCommand,
@@ -23,6 +27,7 @@ import { assertNonNullable } from "@kensio/smartass";
 import { SimAws } from "../../src/service/aws/sim-aws.js";
 import { DEFAULT_SIM_AWS_ACCOUNT_ID } from "../../src/service/aws/sim-aws-account.js";
 import { DEFAULT_SIM_AWS_REGION_NAME } from "../../src/service/aws/sim-aws-region.js";
+import type { SimSignUpCommandOutput } from "../../src/service/cognito/command/user/sign-up.command.js";
 import type { SimCognitoIdentityProvider } from "../../src/service/cognito/index.js";
 import { makeLambdaZipFileInput } from "../../src/service/lambda/function/code/lambda-zip-file-input.js";
 import type { SimLambdaHandler } from "../../src/service/lambda/function/sim-lambda-handler.type.js";
@@ -46,8 +51,30 @@ export interface SimCognitoTriggerPoolInput {
   /** The `LambdaConfig` the pool is created with. */
   readonly triggers: Readonly<Record<string, string>>;
 
+  /**
+   * The simulation to build the pool in.
+   *
+   * A test whose trigger reaches another service creates the table or the
+   * Bucket first, so it has to make the simulation itself. Everything else
+   * takes a fresh one.
+   */
+  readonly simAws?: SimAws | undefined;
+
   /** What the function does when a trigger invokes it. */
   readonly handler?: SimLambdaHandler | undefined;
+
+  /**
+   * A real code archive to run instead of a handler function.
+   *
+   * A handler function is the quick way to say what a trigger does. Function
+   * code that calls another simulated service has to be an archive, because
+   * that is what runs in the Lambda vm with the runtime's own AWS SDK
+   * provided to it.
+   */
+  readonly code?: Uint8Array | undefined;
+
+  /** The execution Role the function runs as, and its SDK calls are made as. */
+  readonly roleArn?: string | undefined;
 
   /**
    * Whether the function's resource policy admits `cognito-idp.amazonaws.com`
@@ -55,6 +82,10 @@ export interface SimCognitoTriggerPoolInput {
    * `AWS::Lambda::Permission` for.
    */
   readonly permitted?: boolean | undefined;
+
+  /** The `AutoVerifiedAttributes` the pool is created with. */
+  readonly autoVerifiedAttributes?:
+    readonly VerifiedAttributeType[] | undefined;
 }
 
 /**
@@ -90,14 +121,22 @@ export const triggerFunctionArn =
 export async function makeTriggerPool(
   input: SimCognitoTriggerPoolInput,
 ): Promise<SimCognitoTriggerPool> {
-  const simAws = new SimAws();
+  const simAws = input.simAws ?? new SimAws();
 
   await simAws.lambda().createFunction(
     new CreateFunctionCommand({
       FunctionName: triggerFunctionName,
-      Role: `arn:aws:iam::${simAws.defaultAccountId}:role/TriggerRole`,
+      Role:
+        input.roleArn ??
+        `arn:aws:iam::${simAws.defaultAccountId}:role/TriggerRole`,
+      // A real archive needs the handler naming the module and export the way
+      // a deployed function does. A stowed handler function is its own entry
+      // point and needs none.
+      ...(input.code !== undefined && { Handler: "index.handler" }),
       Code: {
-        ZipFile: makeLambdaZipFileInput(input.handler ?? passThroughHandler),
+        ZipFile:
+          input.code ??
+          makeLambdaZipFileInput(input.handler ?? passThroughHandler),
       },
     }),
   );
@@ -107,6 +146,9 @@ export async function makeTriggerPool(
     new CreateUserPoolCommand({
       PoolName: "myapp-users",
       LambdaConfig: input.triggers,
+      ...(input.autoVerifiedAttributes !== undefined && {
+        AutoVerifiedAttributes: [...input.autoVerifiedAttributes],
+      }),
     }),
   );
 
@@ -168,6 +210,46 @@ export async function makeTriggerUser(
       }),
     );
   }
+}
+
+/**
+ * Sign a user up through the fixture's app client.
+ *
+ * This is the self-service path rather than the admin one, so it is what
+ * reaches `PreSignUp_SignUp` and, once confirmed, `PostConfirmation`.
+ */
+export async function signUpTriggerUser(
+  pool: SimCognitoTriggerPool,
+  input: Partial<SignUpCommandInput> = {},
+): Promise<SimSignUpCommandOutput> {
+  return await pool.cognito.signUp(
+    new SignUpCommand({
+      UserAttributes: [{ Name: "email", Value: "alice@example.com" }],
+      ...input,
+      Username: input.Username ?? "alice",
+      ClientId: pool.clientId,
+      Password: triggerPassword,
+    }),
+  );
+}
+
+/**
+ * Confirm the signed-up user with the code the pool issued.
+ */
+export async function confirmTriggerSignUp(
+  pool: SimCognitoTriggerPool,
+  clientMetadata?: Record<string, string>,
+): Promise<void> {
+  await pool.cognito.confirmSignUp(
+    new ConfirmSignUpCommand({
+      ClientId: pool.clientId,
+      Username: "alice",
+      ConfirmationCode: pool.cognito
+        .userPool(pool.userPoolId)
+        .confirmationCode("alice"),
+      ...(clientMetadata !== undefined && { ClientMetadata: clientMetadata }),
+    }),
+  );
 }
 
 async function makeTriggerClient(

--- a/test/cognito/trigger-handler-fixture.ts
+++ b/test/cognito/trigger-handler-fixture.ts
@@ -1,0 +1,37 @@
+/**
+ * What the function behind a user pool trigger does in a test.
+ *
+ * These are the handler bodies, kept apart from the pool that runs them in
+ * `trigger-fixture.ts`, because a suite usually varies one without touching the
+ * other. They live under `test/` for the same reason everything else there
+ * does: eslint rejects a test file exporting helpers alongside its own
+ * `describe` calls.
+ */
+
+/**
+ * Record every event the handler is given, and hand the event back so the
+ * request it fired for carries on.
+ */
+export function recordingTriggerHandler(
+  events: unknown[],
+): (event: unknown) => unknown {
+  return (event: unknown) => {
+    events.push(structuredClone(event));
+
+    return event;
+  };
+}
+
+/**
+ * Answer the pre sign-up flags a test named, leaving the rest of the event as
+ * it arrived.
+ */
+export function answeringTriggerHandler(
+  answer: Readonly<Record<string, boolean>>,
+): (event: { response: Record<string, boolean> }) => unknown {
+  return (event: { response: Record<string, boolean> }) => {
+    Object.assign(event.response, answer);
+
+    return event;
+  };
+}


### PR DESCRIPTION
Resolves #428.

Three decisions worth a reviewer's attention:

- `AdminConfirmSignUp` fires `PostConfirmation` too, which the issue did not
  mention. The AWS trigger source table lists it alongside `ConfirmSignUp`
  under `PostConfirmation_ConfirmSignUp`, and the command already exists here,
  so leaving it out would have been a silent divergence.
- `ValidationData` and `ClientMetadata` were refused on `SignUp`,
  `AdminCreateUser`, `ConfirmSignUp` and `AdminConfirmSignUp` with the reason
  "passing data to a Lambda trigger". That reason no longer holds, so they are
  read and passed to the handler instead. `ResendConfirmationCode` and
  `AdminUpdateUserAttributes` still refuse `ClientMetadata`: the only trigger
  it reaches there is the unsimulated custom message one.
- `simCognitoTriggerSource(trigger)` is gone, replaced by
  `SimCognitoTriggerOccasion`, because `PreSignUp` has two sources. #427 and
  #429 will conflict with more than a line in that file if they are in flight.

Two AWS behaviours were checked against the documentation rather than assumed,
and both changed the design: `AdminCreateUser` ignores all three `PreSignUp`
response flags, not just `autoConfirmUser`; and an auto-confirmed user does
reach `PostConfirmation`, at sign-up time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for Cognito `PreSignUp` and `PostConfirmation` Lambda triggers.
  - Sign-up triggers can auto-confirm users and verify email or phone attributes.
  - Confirmation and admin user-creation flows now invoke supported triggers.
  - Client metadata and validation data are passed to trigger events.
  - Trigger-driven workflows can persist confirmed-user data in DynamoDB.
- **Bug Fixes**
  - Improved handling and reporting of trigger failures, invalid responses, permissions, and validation data.
- **Documentation**
  - Expanded Cognito trigger behavior, limitations, event shapes, permissions, and failure scenarios.
  - Added a complete sign-up trigger example.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->