### PR TITLE
feat: record simulated Cognito pool messages

### DIFF
--- a/docs/services/cognito/README.md
+++ b/docs/services/cognito/README.md
@@ -1161,7 +1161,7 @@ a message. Each one is given the real event and has to return it, changed or not
 | `CustomMessage`      | `AdminCreateUser`, before the invitation is recorded                   | `CustomMessage_AdminCreateUser`        |
 
 `CustomMessage` is the one whose response is read for more than a flag, and it is covered in
-[Messages a pool would have sent](#the-custommessage-trigger) above. The rest are here.
+[The CustomMessage trigger](#the-custommessage-trigger) above. The rest are here.
 
 The function is a simulated Lambda function anywhere in the simulation, and it has to admit
 `cognito-idp.amazonaws.com` for the pool, which is what `AddPermission` grants and what CDK's
@@ -2167,8 +2167,8 @@ if you mean to.
 
 The two real endpoints are anonymous as they are on real Cognito, so no SigV4 signature is needed to
 fetch them. The real hostname `cognito-idp.<region>.amazonaws.com` maps to
-`cognito-idp.<region>.sim-aws.localhost`, and `srv.localUrl(...)` does that rewriting for you. An unknown pool id gets a 404, as does a pool
-reached through another region's hostname.
+`cognito-idp.<region>.sim-aws.localhost`, and `srv.localUrl(...)` does that rewriting for you. An
+unknown pool id gets a 404, as does a pool reached through another region's hostname.
 
 ```typescript sim-cognito-serve-jwks
 /**

--- a/docs/services/cognito/README.md
+++ b/docs/services/cognito/README.md
@@ -171,6 +171,10 @@ the code is readable from the pool instead, through `confirmationCode` on the po
 deliberate divergence: real Cognito never reports a code back to anyone, and reading one is what
 makes a registration flow testable at all.
 
+The pool also records the message it would have sent, which is where the wording and the code a user
+would have read are. That is in [Messages a pool would have sent](#messages-a-pool-would-have-sent)
+below.
+
 ```typescript sim-cognito-sign-up
 /**
  * Signing a user up and confirming it with the code the pool issued.
@@ -273,6 +277,222 @@ with `NotAuthorizedException`, as a real one does. That value is what a CDK `Use
 `selfSignUpEnabled` emits, so a project testing its registration flow gets the same answer here that
 the deployed pool would give. A pool created without the setting allows sign-up, which is the AWS
 default.
+
+## Messages a pool would have sent
+
+Nothing here delivers an email or a text message. A pool records what it would have sent instead,
+and `sentMessages` on the pool object hands the record over. Each message carries the recipient, the
+medium, the subject, the body and the occasion it was sent on.
+
+A message is recorded on three occasions: a `SignUp`, a `ResendConfirmationCode`, and an
+`AdminCreateUser` that did not ask for `MessageAction: SUPPRESS`. The verification wording is the
+pool's own, and `{####}` is replaced with the code the user was issued.
+
+```typescript sim-cognito-sent-messages
+/**
+ * Reading the verification message a pool would have sent.
+ */
+
+import {
+  CreateUserPoolClientCommand,
+  CreateUserPoolCommand,
+  SignUpCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const cognito = simAws.cognitoIdentityProvider();
+
+const pool = await cognito.createUserPool(
+  new CreateUserPoolCommand({
+    PoolName: "myapp-users",
+    AutoVerifiedAttributes: ["email"],
+    EmailVerificationSubject: "Welcome to Acme",
+    EmailVerificationMessage: "Your Acme code is {####}",
+  }),
+);
+const userPoolId = pool.UserPool!.Id!;
+
+const appClient = await cognito.createUserPoolClient(
+  new CreateUserPoolClientCommand({
+    UserPoolId: userPoolId,
+    ClientName: "web",
+  }),
+);
+
+await cognito.signUp(
+  new SignUpCommand({
+    ClientId: appClient.UserPoolClient!.ClientId!,
+    Username: "alice",
+    Password: "Sup3rSecret!",
+    UserAttributes: [{ Name: "email", Value: "alice@example.com" }],
+  }),
+);
+
+const [message] = cognito.userPool(userPoolId).sentMessages();
+
+console.log(message?.recipient); // "alice@example.com"
+console.log(message?.medium); // "EMAIL"
+console.log(message?.subject); // "Welcome to Acme"
+console.log(message?.occasion); // "SignUp"
+
+// The placeholder carries the code the user was issued.
+const code = cognito.userPool(userPoolId).confirmationCode("alice")!;
+
+console.log(message?.body === `Your Acme code is ${code}`); // true
+```
+
+Where the message goes comes from the user's own attributes, as it does on real Cognito. A
+verification message goes to an attribute the pool verifies automatically, so a pool created with
+`AutoVerifiedAttributes: ["email"]` writes to the user's `email` and a pool that verifies nothing
+records no verification message at all. An invitation goes to the user's `email`, or to its
+`phone_number` where it has no email address. An email is recorded with a subject and a text message
+without one, and a user the pool has no address for is sent nothing.
+
+`AdminCreateUser` records the invitation, carrying the username and the temporary password the
+request named, unless the request asked for `MessageAction: SUPPRESS`.
+
+A pool created with no wording of its own uses the wording real Cognito uses: `Your verification
+code` and `Your verification code is {####}` for a verification message, and `Your temporary
+password` and `Your username is {username} and temporary password is {####}.` for an invitation.
+`EmailVerificationMessage`, `EmailVerificationSubject`, `SmsVerificationMessage` and
+`VerificationMessageTemplate` are all read, at whatever wording a request sets.
+
+This is Cognito's own delivery record rather than a simulated SES. Real Cognito with the default
+`EmailSendingAccount` of `COGNITO_DEFAULT` sends through no other service, and `EmailConfiguration`
+and `SmsConfiguration` are refused here, so no pool is configured for a delivery this record would
+misrepresent.
+
+### The CustomMessage trigger
+
+A pool with a `CustomMessage` Lambda trigger runs it before the message is recorded, and what the
+handler writes into `response.emailSubject`, `response.emailMessage` and `response.smsMessage`
+replaces the pool's own wording. The handler writes `request.codeParameter` into its message where
+the code belongs, as it does on real Cognito, and the code goes in afterwards.
+
+`triggerSource` names the occasion: `CustomMessage_SignUp`, `CustomMessage_ResendCode` or
+`CustomMessage_AdminCreateUser`. The invitation is the one that carries `request.usernameParameter`
+as well.
+
+```typescript sim-cognito-custom-message
+/**
+ * A CustomMessage trigger writing the wording of a verification message.
+ */
+
+import {
+  CreateUserPoolClientCommand,
+  CreateUserPoolCommand,
+  SignUpCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import {
+  AddPermissionCommand,
+  CreateFunctionCommand,
+} from "@aws-sdk/client-lambda";
+
+import { SimAws } from "@kensio/yulin";
+import { makeLambdaZipFileInput } from "@kensio/yulin/lambda";
+
+/**
+ * The part of the CustomMessage event this handler reads and writes.
+ */
+interface CustomMessageEvent {
+  readonly triggerSource: string;
+  readonly request: { readonly codeParameter: string };
+  response: {
+    emailSubject?: string;
+    emailMessage?: string;
+  };
+}
+
+const simAws = new SimAws();
+const lambda = simAws.lambda();
+const cognito = simAws.cognitoIdentityProvider();
+
+await lambda.createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "custom-message",
+    Role: "arn:aws:iam::888888888888:role/CustomMessageRole",
+    Code: {
+      ZipFile: makeLambdaZipFileInput((event: CustomMessageEvent) => {
+        if (event.triggerSource === "CustomMessage_SignUp") {
+          event.response.emailSubject = "Welcome to Acme";
+          event.response.emailMessage =
+            `Your code is ${event.request.codeParameter}. ` +
+            `It is good for one sign-up.`;
+        }
+
+        return event;
+      }),
+    },
+  }),
+);
+
+const pool = await cognito.createUserPool(
+  new CreateUserPoolCommand({
+    PoolName: "myapp-users",
+    AutoVerifiedAttributes: ["email"],
+    LambdaConfig: {
+      CustomMessage:
+        "arn:aws:lambda:us-east-1:888888888888:function:custom-message",
+    },
+  }),
+);
+const userPoolId = pool.UserPool!.Id!;
+
+await lambda.addPermission(
+  new AddPermissionCommand({
+    FunctionName: "custom-message",
+    StatementId: "AllowCognito",
+    Action: "lambda:InvokeFunction",
+    Principal: "cognito-idp.amazonaws.com",
+    SourceArn: pool.UserPool?.Arn,
+  }),
+);
+
+const appClient = await cognito.createUserPoolClient(
+  new CreateUserPoolClientCommand({
+    UserPoolId: userPoolId,
+    ClientName: "web",
+  }),
+);
+
+await cognito.signUp(
+  new SignUpCommand({
+    ClientId: appClient.UserPoolClient!.ClientId!,
+    Username: "alice",
+    Password: "Sup3rSecret!",
+    UserAttributes: [{ Name: "email", Value: "alice@example.com" }],
+  }),
+);
+
+const [message] = cognito.userPool(userPoolId).sentMessages();
+
+console.log(message?.subject); // "Welcome to Acme"
+
+// The code parameter the handler wrote carries the real code.
+const code = cognito.userPool(userPoolId).confirmationCode("alice")!;
+
+console.log(message?.body.startsWith(`Your code is ${code}.`)); // true
+```
+
+A handler that writes nothing leaves the pool's own wording, which is what a handler that only cares
+about one occasion does for the others. A handler that throws fails the request with
+`UserLambdaValidationException` and leaves the pool with no message, because the trigger runs before
+the message is recorded. A `response` that is not an object, or a message in it that is not a
+string, fails with `InvalidLambdaResponseException`.
+
+`ClientMetadata` on `SignUp`, `ResendConfirmationCode` and `AdminCreateUser` reaches the handler as
+`request.clientMetadata`.
+
+### Reading the messages over HTTP
+
+`serveSimAws` lists a pool's recorded messages at `GET /<userPoolId>/messages`, so they can be read
+during local development. Real Cognito serves nothing at that path: it is the serving side of
+`sentMessages`, and a divergence for the same reason that accessor is one.
+
+The response is `{ "messages": [ ... ] }`, each message carrying `username`, `recipient`, `medium`,
+`subject` where it has one, `body`, `occasion` and an ISO `sentDate`.
 
 ## Listing users
 
@@ -919,8 +1139,8 @@ try {
 
 ## Lambda triggers
 
-A pool created with a `LambdaConfig` runs the functions it names as part of a sign-up or a sign-in.
-Each one is given the real event and has to return it, changed or not.
+A pool created with a `LambdaConfig` runs the functions it names as part of a sign-up, a sign-in or
+a message. Each one is given the real event and has to return it, changed or not.
 
 | Trigger              | Fires                                                                  | `triggerSource`                        |
 | -------------------- | ---------------------------------------------------------------------- | -------------------------------------- |
@@ -932,6 +1152,12 @@ Each one is given the real event and has to return it, changed or not.
 | `PreTokenGeneration` | the sign-in that finishes by answering the new password challenge      | `TokenGeneration_NewPasswordChallenge` |
 | `PreTokenGeneration` | a `REFRESH_TOKEN_AUTH` refresh, over the tokens it reissues            | `TokenGeneration_RefreshTokens`        |
 | `PostAuthentication` | a sign-in, once the tokens have been issued                            | `PostAuthentication_Authentication`    |
+| `CustomMessage`      | `SignUp`, before the verification message is recorded                  | `CustomMessage_SignUp`                 |
+| `CustomMessage`      | `ResendConfirmationCode`, before the message is recorded               | `CustomMessage_ResendCode`             |
+| `CustomMessage`      | `AdminCreateUser`, before the invitation is recorded                   | `CustomMessage_AdminCreateUser`        |
+
+`CustomMessage` is the one whose response is read for more than a flag, and it is covered in
+[Messages a pool would have sent](#the-custommessage-trigger) above. The rest are here.
 
 The function is a simulated Lambda function anywhere in the simulation, and it has to admit
 `cognito-idp.amazonaws.com` for the pool, which is what `AddPermission` grants and what CDK's
@@ -1822,12 +2048,12 @@ test can assert it.
 
 A CDK `UserPool` construct emits six properties on `AWS::Cognito::UserPool` before it has been asked
 for anything, and a client created with `disableOAuth` emits two on `AWS::Cognito::UserPoolClient`.
-`AdminCreateUserConfig` is simulated, and decides whether `SignUp` works against the pool. The other
-seven are not: they configure email and SMS delivery, verification message wording and account
-recovery, and none of that happens here.
+Most of them are simulated: `AdminCreateUserConfig` decides whether `SignUp` works against the pool,
+and the four verification wording properties are what a recorded message says.
 
-Those seven are accepted anyway, at one value each and no other, so a CDK stack deploys as it
-stands.
+`AccountRecoverySetting` is the one that is not. There is no `ForgotPassword` here, so no recovery
+mechanism is ever reached, and it is accepted at one value and no other so that a CDK stack deploys
+as it stands. The two app client properties are accepted the same way.
 
 ```typescript sim-cognito-cdk-defaults
 /**
@@ -1899,6 +2125,10 @@ console.log(described.UserPool?.Name); // "app-stack-Pool"
 // what says only an admin creates users in this pool.
 console.log(described.UserPool?.AdminCreateUserConfig);
 // { AllowAdminCreateUserOnly: true }
+
+// So is this one: it is what a verification message the pool records says.
+console.log(described.UserPool?.EmailVerificationSubject);
+// "Verify your new account"
 ```
 
 The accepted value of each is below. A pool or a client created without one of these reports it not
@@ -1907,23 +2137,17 @@ at all, rather than reporting the value it would have had to use.
 | Property                          | Accepted value                                                             |
 | --------------------------------- | -------------------------------------------------------------------------- |
 | `AccountRecoverySetting`          | `verified_phone_number` at priority 1, then `verified_email` at priority 2 |
-| `EmailVerificationMessage`        | `The verification code to your new account is {####}`                      |
-| `EmailVerificationSubject`        | `Verify your new account`                                                  |
-| `SmsVerificationMessage`          | `The verification code to your new account is {####}`                      |
-| `VerificationMessageTemplate`     | `CONFIRM_WITH_CODE`, with the three strings above                          |
 | `AllowedOAuthFlowsUserPoolClient` | `false`                                                                    |
 | `SupportedIdentityProviders`      | `["COGNITO"]`                                                              |
 
-Every key is compared, so an object carrying one the accepted value does not have is refused along
-with everything else that differs. The refusal names the property, the value asked for and the value
-that is simulated.
+Every key of `AccountRecoverySetting` is compared, so an object carrying one the accepted value does
+not have is refused along with everything else that differs. The refusal names the property, the
+value asked for and the value that is simulated.
 
-The verification wording is worth reading twice. It is accepted only at the wording CDK emits,
-because a request writing its own is asking for a message a user would read, and no message is ever
-delivered.
-
-These values are what `aws-cdk-lib` 2.262.1 synthesizes. Whether real Cognito defaults a bare pool
-to the same wording has not been checked against a live account.
+`VerificationMessageTemplate` is read rather than compared, and the one thing refused in it is
+`DefaultEmailOption: CONFIRM_WITH_LINK`, along with `EmailMessageByLink` and `EmailSubjectByLink`.
+Nothing here serves a link, and `ConfirmSignUp` with the code is the only way a user is confirmed, so
+a pool that asked for a link would be tested against a flow it does not have in a deployment.
 
 ## Serving a pool's JWKS on localhost
 
@@ -1931,6 +2155,9 @@ to the same wording has not been checked against a live account.
 
 - `GET /<userPoolId>/.well-known/jwks.json`
 - `GET /<userPoolId>/.well-known/openid-configuration`
+
+It also lists the messages a pool would have sent, at `GET /<userPoolId>/messages`, which real
+Cognito serves nothing at.
 
 Both are anonymous, as they are on real Cognito, so no SigV4 signature is needed to fetch them. The
 real hostname `cognito-idp.<region>.amazonaws.com` maps to `cognito-idp.<region>.sim-aws.localhost`,
@@ -2214,6 +2441,12 @@ Sim Cognito currently supports:
 - The `PreTokenGeneration` Lambda trigger at `V1_0`, whose `claimsOverrideDetails` adds, overrides
   and suppresses the claims of an id token, and whose `groupOverrideDetails` replaces
   `cognito:groups`, on a sign-in and on a refresh alike
+- A record on each pool of the messages it would have sent, read with `sentMessages`, carrying the
+  recipient, the medium, the subject, the body and the occasion, with the pool's own verification
+  wording and the `{####}` placeholder filled in
+- The `CustomMessage` Lambda trigger, invoked before a message is recorded, with the occasion in its
+  `triggerSource` and the wording it writes replacing the pool's
+- The recorded messages listed over HTTP by `serveSimAws`, at `/<userPoolId>/messages`
 - Real RS256 JWTs, signed by a key the pool publishes as a JWKS, so a verifier configured for the
   pool verifies them unchanged
 - A pool's `.well-known/jwks.json` and `.well-known/openid-configuration` served over HTTP by
@@ -2278,19 +2511,53 @@ Current documented limitations:
 - Password reset is not simulated. `ForgotPassword`, `ConfirmForgotPassword` and `ChangePassword`
   are not implemented, so the `RESET_REQUIRED` status cannot be reached.
 - Unsimulated sign-up inputs are refused rather than ignored: `AnalyticsMetadata` and
-  `UserContextData` on the three client-side operations, `ForceAliasCreation` and `Session` on
-  `ConfirmSignUp`, and `ClientMetadata` on `ResendConfirmationCode`. That last one would reach the
-  custom message trigger on real Cognito, which writes the wording of a message, and no message is
-  delivered here.
-- No message is ever delivered. `SignUp` and `ResendConfirmationCode` send no confirmation code, and
-  neither reports `CodeDeliveryDetails`. `AdminCreateUser` sends no invitation, so
-  `MessageAction: SUPPRESS` is accepted and changes nothing, `RESEND` is refused, and
-  `DesiredDeliveryMediums` is refused.
+  `UserContextData` on the three client-side operations, and `ForceAliasCreation` and `Session` on
+  `ConfirmSignUp`. `ClientMetadata` is not among them on any of them: each reaches a trigger that
+  runs here.
+- No message is ever delivered. A pool records what it would have sent and `sentMessages` reads it
+  back, which real Cognito reports to nobody. Nothing leaves the simulation, and no
+  `CodeDeliveryDetails` is reported by `SignUp` or `ResendConfirmationCode`.
+- A message is recorded on three occasions: `SignUp`, `ResendConfirmationCode` and
+  `AdminCreateUser`. Password reset, MFA and the account-taken-over notices are occasions real
+  Cognito sends on and this simulation does not reach.
+- A verification message is recorded only for an attribute the pool verifies automatically, so a
+  pool with no `AutoVerifiedAttributes` records none, and only for a user that has to confirm: one a
+  `PreSignUp` handler auto-confirmed is sent nothing, as it is sent nothing on real Cognito. An invitation is recorded whatever the pool
+  verifies, and both are recorded only where the user has an `email` or a `phone_number` to be
+  reached at.
+- `DesiredDeliveryMediums` is refused. The medium comes from the attribute the message is written
+  to, so a request naming `SMS` for a user with an email address would be recorded as an email.
+  Real Cognito defaults `AdminCreateUser` to `SMS`, and this records an email where the user has an
+  address.
+- An invitation for a user created with no `TemporaryPassword` keeps the `{####}` placeholder,
+  because real Cognito generates a password there and this simulation leaves the user with none at
+  all.
+- `EmailConfiguration` and `SmsConfiguration` stay refused. A pool configured to send through SES or
+  an SNS SMS role would still only record here, and accepting the configuration would say the
+  messages went that way. The record is Cognito's own, which is what the default
+  `EmailSendingAccount` of `COGNITO_DEFAULT` sends by, and there is no simulated SES.
+- Confirming a sign-up by following a link is not simulated. A `VerificationMessageTemplate` with
+  `DefaultEmailOption: CONFIRM_WITH_LINK`, an `EmailMessageByLink` or an `EmailSubjectByLink` is
+  refused, and a `CustomMessage` event carries no `linkParameter`.
+- `VerificationMessageTemplate` wins over `EmailVerificationMessage`, `EmailVerificationSubject` and
+  `SmsVerificationMessage` where a request sets both, and each of those fills in what the template
+  left out. What real Cognito does when the two disagree was not checked against a live account.
+- The default wording, for a pool that set none, is taken from the Cognito API documentation rather
+  than read back from a live account.
+- The recorded messages are listed over HTTP at `GET /<userPoolId>/messages`, which is an endpoint
+  real Cognito does not have. It is the serving side of `sentMessages` and a divergence for the same
+  reason.
+- The `CustomEmailSender` and `CustomSMSSender` triggers are refused. Real Cognito hands those the
+  code as an AWS Encryption SDK ciphertext to decrypt through KMS, that envelope is not simulated
+  anywhere here, and a version handing over a plain code would give a handler that cannot decrypt
+  anything on real AWS.
 - A temporary password never expires. `TemporaryPasswordValidityDays` is stored on the pool and
   nothing acts on it.
 - Unsimulated `AdminCreateUser` inputs are refused rather than ignored: `DesiredDeliveryMediums`,
-  `ForceAliasCreation`, and a `MessageAction` of `RESEND`. `AdminUpdateUserAttributes` refuses
-  `ClientMetadata`, because the only trigger it would reach there is the custom message one.
+  `ForceAliasCreation`, and a `MessageAction` of `RESEND`, which invites a user that already exists.
+  Its `ValidationData` and `ClientMetadata` are read, and reach the `PreSignUp` and `CustomMessage`
+  triggers. `AdminUpdateUserAttributes` refuses `ClientMetadata`, because the message an attribute
+  update would have sent is not one this simulation sends.
 - `ListUsers` refuses `Filter` and `AttributesToGet` rather than ignoring them, and lists users in
   creation order. Real Cognito chooses its own order and does not promise one.
 - `ListUsers`, `ListGroups`, `AdminListGroupsForUser` and `ListUsersInGroup` refuse a `Limit` of
@@ -2315,7 +2582,8 @@ Current documented limitations:
 - `UpdateUserPool` replaces a pool's settings rather than merging into them, as real Cognito does, so
   a setting the request leaves out goes back to the default `CreateUserPool` would have given it. It
   covers the settings this simulation models: `Policies.PasswordPolicy`, `DeletionProtection`,
-  `AdminCreateUserConfig.AllowAdminCreateUserOnly`, `AutoVerifiedAttributes` and `LambdaConfig`.
+  `AdminCreateUserConfig.AllowAdminCreateUserOnly`, `AutoVerifiedAttributes`, `LambdaConfig` and the
+  verification wording.
   `PoolName` is refused, so a pool cannot be renamed, and every input `CreateUserPool` refuses is
   refused here too, in the same words.
 - `UpdateUserPoolClient` replaces an app client's settings the same way, so a setting the request
@@ -2326,12 +2594,12 @@ Current documented limitations:
   on real Cognito, so a client created without a secret never gains one.
 - A redeployed template reaches neither update. Sim CloudFormation replaces a resource whose
   resolved template entry changed rather than updating it in place, whatever the resource type.
-- `PreSignUp`, `PostConfirmation`, `PreAuthentication`, `PostAuthentication` and
-  `PreTokenGeneration` are the only Lambda triggers that run. Every other `LambdaConfig` key is
+- `PreSignUp`, `PostConfirmation`, `PreAuthentication`, `PostAuthentication`, `PreTokenGeneration`
+  and `CustomMessage` are the only Lambda triggers that run. Every other `LambdaConfig` key is
   refused when the pool is created or updated, naming the trigger, because a pool that accepted one
-  would never call the function the template named. The message triggers wait on the messages this
-  simulation does not deliver; the custom challenge triggers would need a challenge loop it does not
-  have; and the migration and federation triggers have no external directory to reach.
+  would never call the function the template named. The custom challenge triggers would need a
+  challenge loop this simulation does not have, and the migration and federation triggers have no
+  external directory to reach.
 - `AdminCreateUser` does not fire `PostConfirmation`, here or on real Cognito. It is the tempting
   place to hang the trigger and the wrong one: a project relying on it would pass here and write
   nothing in production.
@@ -2369,20 +2637,23 @@ Current documented limitations:
 - `ClientMetadata` reaches `PreTokenGeneration` from `RespondToAuthChallenge` and
   `AdminRespondToAuthChallenge` alone, as it does on real Cognito. A refresh accepts one and it
   reaches nothing.
+- A `CustomMessage` event reports `CLIENT_ID_NOT_APPLICABLE` as its `callerContext.clientId` for an
+  `AdminCreateUser`, as real Cognito does for an admin operation, and names the app client for the
+  two occasions that come through one.
 - Unsimulated `CreateUserPool` inputs are refused rather than ignored: `UsernameAttributes`,
   `AliasAttributes`, `Schema`, `UsernameConfiguration`,
   `UserAttributeUpdateSettings`, `DeviceConfiguration`, `UserPoolAddOns`, `KeyConfiguration`,
   `IssuerConfiguration`, `UserPoolTags`, the email and SMS configurations, an
   `SmsAuthenticationMessage`, an `MfaConfiguration` other than `OFF`, a `UserPoolTier` other than
   `ESSENTIALS`, a `SignInPolicy`, and a `PasswordHistorySize`.
-- `AccountRecoverySetting`, `EmailVerificationMessage`, `EmailVerificationSubject`,
-  `SmsVerificationMessage` and `VerificationMessageTemplate` are accepted at one value each and
-  refused at any other. Nothing here reads any of them. They are accepted so a CDK stack deploys,
-  and reported back by `DescribeUserPool` so what the template declared stays visible. The accepted
-  values are in "Properties accepted without being simulated" above.
+- `AccountRecoverySetting` is accepted at one value and refused at any other. Nothing here reads it,
+  because there is no `ForgotPassword`. It is accepted so a CDK stack deploys, and reported back by
+  `DescribeUserPool` so what the template declared stays visible. The accepted value is in
+  "Properties accepted without being simulated" above.
 - `AdminCreateUserConfig.AllowAdminCreateUserOnly` is acted on, and the two keys beside it are
-  refused: `InviteMessageTemplate` and `UnusedAccountValidityDays` are both about the invitation an
-  admin-created user is sent, and no message is delivered here.
+  refused. `InviteMessageTemplate` is the wording of the invitation, and a pool cannot set its own
+  yet, so an invitation is recorded at Cognito's default wording. `UnusedAccountValidityDays`
+  expires a temporary password, and nothing here expires one.
 - `UsernameAttributes` is worth calling out among those. A pool that signs users in by email or phone
   number stores a generated UUID as the username, so a pool created here without that would answer
   with the wrong username and the right one on real AWS.

--- a/docs/services/cognito/README.md
+++ b/docs/services/cognito/README.md
@@ -286,7 +286,9 @@ medium, the subject, the body and the occasion it was sent on.
 
 A message is recorded on three occasions: a `SignUp`, a `ResendConfirmationCode`, and an
 `AdminCreateUser` that did not ask for `MessageAction: SUPPRESS`. The verification wording is the
-pool's own, and `{####}` is replaced with the code the user was issued.
+pool's own, and `{####}` is replaced with the code the user was issued. A sign-up a `PreSignUp`
+handler auto-confirmed records none: that user has no code to answer with, and real Cognito sends it
+nothing.
 
 ```typescript sim-cognito-sent-messages
 /**

--- a/docs/services/cognito/README.md
+++ b/docs/services/cognito/README.md
@@ -357,7 +357,9 @@ A pool created with no wording of its own uses the wording real Cognito uses: `Y
 code` and `Your verification code is {####}` for a verification message, and `Your temporary
 password` and `Your username is {username} and temporary password is {####}.` for an invitation.
 `EmailVerificationMessage`, `EmailVerificationSubject`, `SmsVerificationMessage` and
-`VerificationMessageTemplate` are all read, at whatever wording a request sets.
+`VerificationMessageTemplate` are all read, at whatever wording a request sets, held to the two
+rules real Cognito holds them to: a message carries `{####}`, and runs to 20,000 characters for an
+email and the 140 an SMS carries.
 
 This is Cognito's own delivery record rather than a simulated SES. Real Cognito with the default
 `EmailSendingAccount` of `COGNITO_DEFAULT` sends through no other service, and `EmailConfiguration`
@@ -2157,11 +2159,13 @@ a pool that asked for a link would be tested against a flow it does not have in 
 - `GET /<userPoolId>/.well-known/openid-configuration`
 
 It also lists the messages a pool would have sent, at `GET /<userPoolId>/messages`, which real
-Cognito serves nothing at.
+Cognito serves nothing at. That one is anonymous too, and it hands out confirmation codes and
+temporary passwords to anyone who asks, so serve a simulation on a port other people can reach only
+if you mean to.
 
-Both are anonymous, as they are on real Cognito, so no SigV4 signature is needed to fetch them. The
-real hostname `cognito-idp.<region>.amazonaws.com` maps to `cognito-idp.<region>.sim-aws.localhost`,
-and `srv.localUrl(...)` does that rewriting for you. An unknown pool id gets a 404, as does a pool
+The two real endpoints are anonymous as they are on real Cognito, so no SigV4 signature is needed to
+fetch them. The real hostname `cognito-idp.<region>.amazonaws.com` maps to
+`cognito-idp.<region>.sim-aws.localhost`, and `srv.localUrl(...)` does that rewriting for you. An unknown pool id gets a 404, as does a pool
 reached through another region's hostname.
 
 ```typescript sim-cognito-serve-jwks
@@ -2542,6 +2546,10 @@ Current documented limitations:
 - `VerificationMessageTemplate` wins over `EmailVerificationMessage`, `EmailVerificationSubject` and
   `SmsVerificationMessage` where a request sets both, and each of those fills in what the template
   left out. What real Cognito does when the two disagree was not checked against a live account.
+- Verification wording with no `{####}` in it is refused, as it is on real Cognito, because the
+  message would reach a user with no code in it. So is wording outside the lengths Cognito takes:
+  6 to 20,000 characters for an email, and 6 to 140 for a text message. The subject is not checked
+  against its own length.
 - The default wording, for a pool that set none, is taken from the Cognito API documentation rather
   than read back from a live account.
 - The recorded messages are listed over HTTP at `GET /<userPoolId>/messages`, which is an endpoint

--- a/docs/services/cognito/sim-cognito-cdk-defaults.example.ts
+++ b/docs/services/cognito/sim-cognito-cdk-defaults.example.ts
@@ -67,3 +67,7 @@ console.log(described.UserPool?.Name); // "app-stack-Pool"
 // what says only an admin creates users in this pool.
 console.log(described.UserPool?.AdminCreateUserConfig);
 // { AllowAdminCreateUserOnly: true }
+
+// So is this one: it is what a verification message the pool records says.
+console.log(described.UserPool?.EmailVerificationSubject);
+// "Verify your new account"

--- a/docs/services/cognito/sim-cognito-custom-message.example.ts
+++ b/docs/services/cognito/sim-cognito-custom-message.example.ts
@@ -1,0 +1,98 @@
+/**
+ * A CustomMessage trigger writing the wording of a verification message.
+ */
+
+import {
+  CreateUserPoolClientCommand,
+  CreateUserPoolCommand,
+  SignUpCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import {
+  AddPermissionCommand,
+  CreateFunctionCommand,
+} from "@aws-sdk/client-lambda";
+
+import { SimAws } from "@kensio/yulin";
+import { makeLambdaZipFileInput } from "@kensio/yulin/lambda";
+
+/**
+ * The part of the CustomMessage event this handler reads and writes.
+ */
+interface CustomMessageEvent {
+  readonly triggerSource: string;
+  readonly request: { readonly codeParameter: string };
+  response: {
+    emailSubject?: string;
+    emailMessage?: string;
+  };
+}
+
+const simAws = new SimAws();
+const lambda = simAws.lambda();
+const cognito = simAws.cognitoIdentityProvider();
+
+await lambda.createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "custom-message",
+    Role: "arn:aws:iam::888888888888:role/CustomMessageRole",
+    Code: {
+      ZipFile: makeLambdaZipFileInput((event: CustomMessageEvent) => {
+        if (event.triggerSource === "CustomMessage_SignUp") {
+          event.response.emailSubject = "Welcome to Acme";
+          event.response.emailMessage =
+            `Your code is ${event.request.codeParameter}. ` +
+            `It is good for one sign-up.`;
+        }
+
+        return event;
+      }),
+    },
+  }),
+);
+
+const pool = await cognito.createUserPool(
+  new CreateUserPoolCommand({
+    PoolName: "myapp-users",
+    AutoVerifiedAttributes: ["email"],
+    LambdaConfig: {
+      CustomMessage:
+        "arn:aws:lambda:us-east-1:888888888888:function:custom-message",
+    },
+  }),
+);
+const userPoolId = pool.UserPool!.Id!;
+
+await lambda.addPermission(
+  new AddPermissionCommand({
+    FunctionName: "custom-message",
+    StatementId: "AllowCognito",
+    Action: "lambda:InvokeFunction",
+    Principal: "cognito-idp.amazonaws.com",
+    SourceArn: pool.UserPool?.Arn,
+  }),
+);
+
+const appClient = await cognito.createUserPoolClient(
+  new CreateUserPoolClientCommand({
+    UserPoolId: userPoolId,
+    ClientName: "web",
+  }),
+);
+
+await cognito.signUp(
+  new SignUpCommand({
+    ClientId: appClient.UserPoolClient!.ClientId!,
+    Username: "alice",
+    Password: "Sup3rSecret!",
+    UserAttributes: [{ Name: "email", Value: "alice@example.com" }],
+  }),
+);
+
+const [message] = cognito.userPool(userPoolId).sentMessages();
+
+console.log(message?.subject); // "Welcome to Acme"
+
+// The code parameter the handler wrote carries the real code.
+const code = cognito.userPool(userPoolId).confirmationCode("alice")!;
+
+console.log(message?.body.startsWith(`Your code is ${code}.`)); // true

--- a/docs/services/cognito/sim-cognito-sent-messages.example.ts
+++ b/docs/services/cognito/sim-cognito-sent-messages.example.ts
@@ -1,0 +1,52 @@
+/**
+ * Reading the verification message a pool would have sent.
+ */
+
+import {
+  CreateUserPoolClientCommand,
+  CreateUserPoolCommand,
+  SignUpCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const cognito = simAws.cognitoIdentityProvider();
+
+const pool = await cognito.createUserPool(
+  new CreateUserPoolCommand({
+    PoolName: "myapp-users",
+    AutoVerifiedAttributes: ["email"],
+    EmailVerificationSubject: "Welcome to Acme",
+    EmailVerificationMessage: "Your Acme code is {####}",
+  }),
+);
+const userPoolId = pool.UserPool!.Id!;
+
+const appClient = await cognito.createUserPoolClient(
+  new CreateUserPoolClientCommand({
+    UserPoolId: userPoolId,
+    ClientName: "web",
+  }),
+);
+
+await cognito.signUp(
+  new SignUpCommand({
+    ClientId: appClient.UserPoolClient!.ClientId!,
+    Username: "alice",
+    Password: "Sup3rSecret!",
+    UserAttributes: [{ Name: "email", Value: "alice@example.com" }],
+  }),
+);
+
+const [message] = cognito.userPool(userPoolId).sentMessages();
+
+console.log(message?.recipient); // "alice@example.com"
+console.log(message?.medium); // "EMAIL"
+console.log(message?.subject); // "Welcome to Acme"
+console.log(message?.occasion); // "SignUp"
+
+// The placeholder carries the code the user was issued.
+const code = cognito.userPool(userPoolId).confirmationCode("alice")!;
+
+console.log(message?.body === `Your Acme code is ${code}`); // true

--- a/src/service/cognito/README.md
+++ b/src/service/cognito/README.md
@@ -4,8 +4,8 @@ This directory contains the simulated Cognito user pools implementation. Cognito
 which exchange a token for AWS credentials, are a separate service and are not simulated at all.
 
 The pool, the app client, the users and groups in it, self-service sign-up, the sign-in flows on
-both sides of the API, the tokens it issues and the authorizer are all here. SRP, the hosted UI,
-MFA, password resets and device tracking are not.
+both sides of the API, the messages it would have sent, the tokens it issues and the authorizer are
+all here. SRP, the hosted UI, MFA, password resets and device tracking are not.
 
 ## Entry points
 
@@ -32,11 +32,11 @@ real Cognito: deleting a pool takes its clients with it, and a client id means n
 pool that issued it.
 
 `SimCognitoUserPoolSettings` holds the settings a request can change: the password policy, the
-deletion protection, whether users may sign themselves up, what confirming a sign-up verifies, and
-the Lambda triggers the pool runs. `CreateUserPool` and `UpdateUserPool` both build one out of their
-own request, and an update swaps the pool's for it. That is what makes an update replace rather than
-merge, and it is where the pool's `LastModifiedDate` moves. Each takes the operation name, so a
-refusal from inside the settings names the request it came from.
+deletion protection, whether users may sign themselves up, what confirming a sign-up verifies, the
+Lambda triggers the pool runs, and what its messages say. `CreateUserPool` and `UpdateUserPool` both
+build one out of their own request, and an update swaps the pool's for it. That is what makes an
+update replace rather than merge, and it is where the pool's `LastModifiedDate` moves. Each takes the
+operation name, so a refusal from inside the settings names the request it came from.
 
 `makeSimCognitoUserPoolId` builds the `<region>_<nine characters>` form. The region is part of the id
 rather than decoration: SDK code splits a pool id on the underscore to work out which region to talk
@@ -128,6 +128,37 @@ simulation does not.
 characters, and no whitespace. Cognito gives both the same rule, so it lives in one place and
 `requireSimCognitoUsername` and `requireSimCognitoGroupName` each name their own field in the
 refusal.
+
+## Message model
+
+Message state lives under `user-pool/message/`, and the pool owns the messages it would have sent
+the way it owns its users.
+
+`SimCognitoSentMessage` is one recorded message: who it was for, where it would have gone, by which
+medium, what it said and what the pool was doing when it sent it. `SimCognitoSentMessageStore` holds
+them in order, and `SimCognitoUserPool.sentMessages` is where a test reads them. Nothing is
+delivered, so this record is the whole of what a message is here. It is Cognito's own delivery
+rather than a simulated SES: real Cognito with the default `EmailSendingAccount` of
+`COGNITO_DEFAULT` sends through no other service, and `EmailConfiguration` is refused, so no pool is
+configured for a delivery this would misrepresent.
+
+`SimCognitoPoolMessenger` is what the sign-up and user commands ask to send. It resolves where the
+message goes, runs the pool's `CustomMessage` trigger, and records what is left. The steps are
+separate collaborators because each is a different question: `SimCognitoMessageDelivery` is where
+and by what medium, `simCognitoOccasionWording` is what the pool says, `SimCognitoCustomMessage` is
+what a handler said instead, and `SimCognitoMessagePlaceholders` fills in the code and the username
+last, so that what a handler wrote carries them too.
+
+`SimCognitoVerificationMessages` is the wording a pool was created with. It is a pool setting rather
+than a value accepted and reported, because the recorded message is what it says.
+`VerificationMessageTemplate` wins over the three older inputs, each of which fills in what the
+template left out. Confirming by link is refused in
+`SimCognitoUnsimulatedUserPoolMessaging` instead, so what reaches the settings is always wording for
+a code.
+
+`SimCognitoMessageOccasion` is the three occasions a message is sent on, and it is what a
+`CustomMessage` `triggerSource` is built from. It is a leaf module so that both the trigger and the
+message sides can name an occasion without depending on each other.
 
 ## Group model
 
@@ -234,6 +265,10 @@ authentication: `/<userPoolId>/.well-known/jwks.json` and
 serving layer dispatches to, `SimCognitoOpenIdConfiguration` builds the discovery document, and
 `SimCognitoEndpointResponse` builds the responses. The Cognito API itself is not served: an SDK
 client reaches the simulator through `SimSdk`.
+
+`/<userPoolId>/messages` is served alongside them, and real Cognito has no such endpoint. It is the
+serving side of `SimCognitoUserPool.sentMessages`, so a browser or a curl can read what a pool would
+have sent during local development, and it is a divergence for the same reason that accessor is one.
 
 The request hostname is `cognito-idp.<region>`, which names the regional endpoint rather than one
 pool, so the pool id comes from the path. That id says nothing about the Account that owns the pool,
@@ -436,8 +471,17 @@ resource, here or on real AWS.
   past is what produces a token such a verifier refuses.
 - `UpdateGroup` replaces all three group properties rather than merging an omitted one.
 - A password is held so a user can sign in with it, and nothing reads one back.
-- No message is delivered, so `AdminCreateUser` accepts `MessageAction: SUPPRESS` and refuses
-  `RESEND` and `DesiredDeliveryMediums`.
+- No message is delivered. A pool records what it would have sent, and `SimCognitoUserPool.
+sentMessages` reads it back, which real Cognito reports to nobody. `AdminCreateUser` records an
+  invitation, so `MessageAction: SUPPRESS` records none, and `RESEND` and `DesiredDeliveryMediums`
+  are refused.
+- A verification message is recorded only for an attribute the pool verifies automatically, and only
+  where the user has an `email` or a `phone_number` to be reached at.
+- An invitation for a user created with no `TemporaryPassword` keeps the `{####}` placeholder: real
+  Cognito generates a password there, and this leaves the user with none at all.
+- Confirming a sign-up by following a link is refused, so a `CustomMessage` event carries no
+  `linkParameter`, and the `CustomEmailSender` and `CustomSMSSender` triggers are refused because
+  the AWS Encryption SDK envelope they decrypt is not simulated anywhere here.
 - Listings are in creation order and carry no filtering. `ListUsers` refuses a `Filter` rather than
   dropping it, because a dropped filter answers with the wrong users rather than with an error.
 

--- a/src/service/cognito/README.md
+++ b/src/service/cognito/README.md
@@ -156,9 +156,9 @@ template left out. Confirming by link is refused in
 `SimCognitoUnsimulatedUserPoolMessaging` instead, so what reaches the settings is always wording for
 a code.
 
-`SimCognitoMessageOccasion` is the three occasions a message is sent on, and it is what a
-`CustomMessage` `triggerSource` is built from. It is a leaf module so that both the trigger and the
-message sides can name an occasion without depending on each other.
+`SimCognitoMessageOccasion` is the three occasions a message is sent on, in the vocabulary a
+recorded message reports. `SimCognitoTriggerOccasion.customMessage` turns one into the trigger
+occasion the handler is invoked for, so the record keeps its own names and the event keeps Cognito's.
 
 ## Group model
 
@@ -332,9 +332,12 @@ shape down to the `response` a `PreSignUp` handler is sent with its three flags 
 false. `SimCognitoTriggerContext` is what an operation hands them: the pool, the user, the app
 client where there is one, and the client metadata and validation data the request carried.
 
-`SimCognitoPreSignUpResponse` reads what a `PreSignUp` handler answered. It is the only trigger here
-whose response is read, and the reading is lenient in the same way real Cognito is: anything but
-`true` is no, and a handler that dropped the response has asked for nothing.
+`SimCognitoPreSignUpResponse` reads what a `PreSignUp` handler answered, and
+`SimCognitoCustomMessage` reads what a `CustomMessage` one wrote. Those are the two triggers whose
+response is read at all, and both read a dropped response as a handler having asked for nothing.
+`PreSignUp` is lenient beyond that, in the same way real Cognito is, because anything but `true` is
+no. `CustomMessage` is not: a message that is not a string is refused rather than rendered into what
+the pool records.
 
 `SimAwsCognitoTriggerFunctions` is the bridge to simulated Lambda, and
 `SimCognitoNoTriggerFunctions` is what a standalone `SimCognitoIdentityProvider` gets instead. The

--- a/src/service/cognito/README.md
+++ b/src/service/cognito/README.md
@@ -471,10 +471,10 @@ resource, here or on real AWS.
   past is what produces a token such a verifier refuses.
 - `UpdateGroup` replaces all three group properties rather than merging an omitted one.
 - A password is held so a user can sign in with it, and nothing reads one back.
-- No message is delivered. A pool records what it would have sent, and `SimCognitoUserPool.
-sentMessages` reads it back, which real Cognito reports to nobody. `AdminCreateUser` records an
-  invitation, so `MessageAction: SUPPRESS` records none, and `RESEND` and `DesiredDeliveryMediums`
-  are refused.
+- No message is delivered. A pool records what it would have sent, and
+  `SimCognitoUserPool.sentMessages` reads it back, which real Cognito reports to nobody.
+  `AdminCreateUser` records an invitation, so `MessageAction: SUPPRESS` records none, and `RESEND`
+  and `DesiredDeliveryMediums` are refused.
 - A verification message is recorded only for an attribute the pool verifies automatically, and only
   where the user has an `email` or a `phone_number` to be reached at.
 - An invitation for a user created with no `TemporaryPassword` keeps the `{####}` placeholder: real

--- a/src/service/cognito/cfn/sim-cfn-cognito-lambda-triggers.iso.test.ts
+++ b/src/service/cognito/cfn/sim-cfn-cognito-lambda-triggers.iso.test.ts
@@ -175,14 +175,14 @@ describe("Sim CloudFormation Cognito user pool Lambda triggers", () => {
   });
 
   it("fails a stack asking for a trigger this simulation does not run", async () => {
-    // Given a template naming a custom message trigger.
+    // Given a template naming a user migration trigger.
     const simAws = simAwsInEuWest2();
 
     // When the stack is deployed.
     const error = await deployFailure(
       simAws,
       poolWithTrigger({
-        CustomMessage: { "Fn::GetAtt": ["Trigger", "Arn"] },
+        UserMigration: { "Fn::GetAtt": ["Trigger", "Arn"] },
       }),
     );
 
@@ -190,7 +190,7 @@ describe("Sim CloudFormation Cognito user pool Lambda triggers", () => {
     // the function the template named.
     assertStringIncludes(
       error.message,
-      "CreateUserPool LambdaConfig CustomMessage is not simulated",
+      "CreateUserPool LambdaConfig UserMigration is not simulated",
     );
   });
 });

--- a/src/service/cognito/command/auth/sim-cognito-auth-commands.ts
+++ b/src/service/cognito/command/auth/sim-cognito-auth-commands.ts
@@ -30,7 +30,9 @@ interface SimCognitoAuthCommandsProperties {
  * they run, and the sign-out commands share the pool store with them, so they
  * are built together here rather than among the pool and directory commands.
  * The resolvers arrive from outside because the sign-up commands resolve an
- * app client the same way these do.
+ * app client the same way these do, and the triggers because the sign-up and
+ * user commands run the pool's `CustomMessage` trigger through the same
+ * collaborator.
  */
 export class SimCognitoAuthCommands {
   public readonly adminInitiateAuth: SimCognitoAdminInitiateAuth;

--- a/src/service/cognito/command/sim-cognito-commands.ts
+++ b/src/service/cognito/command/sim-cognito-commands.ts
@@ -5,6 +5,7 @@ import { SimCognitoUserPoolClientFactory } from "../user-pool/client/sim-cognito
 import { SimCognitoGroupFactory } from "../user-pool/group/sim-cognito-group-factory.js";
 import { SimCognitoUserPoolFactory } from "../user-pool/sim-cognito-user-pool-factory.js";
 import type { SimCognitoUserPoolStore } from "../user-pool/sim-cognito-user-pool-store.js";
+import { SimCognitoPoolMessenger } from "../user-pool/message/sim-cognito-pool-messenger.js";
 import type { SimCognitoTriggerFunctions } from "../user-pool/trigger/sim-cognito-trigger-functions.js";
 import { SimCognitoUserPoolTriggers } from "../user-pool/trigger/sim-cognito-user-pool-triggers.js";
 import { SimCognitoUserFactory } from "../user-pool/user/sim-cognito-user-factory.js";
@@ -65,6 +66,9 @@ export class SimCognitoCommands {
     const triggers = new SimCognitoUserPoolTriggers({
       functions: triggerFunctions,
     });
+    // The messages a pool would have sent are recorded by the sign-up and user
+    // commands alike, and both run the pool's CustomMessage trigger first.
+    const messenger = new SimCognitoPoolMessenger({ triggers, clock });
 
     this.userPools = new SimCognitoUserPoolCommands({
       pools,
@@ -86,12 +90,14 @@ export class SimCognitoCommands {
       resolver,
       userFactory,
       triggers,
+      messenger,
     });
     this.signUp = new SimCognitoSignUpCommands({
       authResolver,
       resolver,
       userFactory,
       triggers,
+      messenger,
     });
     this.userUpdates = new SimCognitoUserUpdateCommands({ resolver });
     this.listUsers = new SimCognitoListUsers({ resolver });

--- a/src/service/cognito/command/user-pool/sim-cognito-unsimulated-pool-messaging.ts
+++ b/src/service/cognito/command/user-pool/sim-cognito-unsimulated-pool-messaging.ts
@@ -1,50 +1,37 @@
+import type { SimCognitoVerificationMessageTemplateType } from "../../user-pool/message/sim-cognito-verification-messages.js";
 import { SimCognitoUnsimulatedInput } from "../sim-cognito-unsimulated-input.js";
-import { SimCognitoUnsimulatedStructure } from "../sim-cognito-unsimulated-structure.js";
 import type { SimCognitoUserPoolCommandInput } from "./user-pool.command.js";
 
 /**
- * The verification wording a pool is accepted with.
- *
- * These are the values `aws-cdk-lib` 2.262.1 emits for a `UserPool` construct
- * asking for nothing in particular, so a stack that only wants a pool
- * deploys. Whether real Cognito defaults a bare pool to the same wording was
- * not checked against a live account, so the CDK synth is the source here
- * rather than the AWS default.
+ * What a refusal of the link options says would be lost.
  */
-const verificationMessage =
-  "The verification code to your new account is {####}";
-const verificationSubject = "Verify your new account";
-const verificationMessageTemplate = {
-  DefaultEmailOption: "CONFIRM_WITH_CODE",
-  EmailMessage: verificationMessage,
-  EmailSubject: verificationSubject,
-  SmsMessage: verificationMessage,
-};
-
-/**
- * What a refusal of the verification wording says would be lost.
- */
-const verificationWording = "the wording of a verification message";
+const linkVerification = "confirming a sign-up by following a link";
 
 /**
  * Refuses the message delivery inputs this simulation does not model.
  *
- * Nothing here sends an email or a text message, so a delivery configuration
- * would be stored and never used.
+ * Nothing here delivers an email or a text message. A pool records the message
+ * it would have sent instead, which is Cognito's own delivery rather than
+ * anything a delivery configuration points at: real Cognito with the default
+ * `EmailSendingAccount` of `COGNITO_DEFAULT` sends through no other service.
  *
- * The verification wording is a narrower case. No message is delivered, so
- * the wording is never read either, and refusing the wording CDK emits would
- * refuse every stack that only wanted a pool. It is accepted at that wording
- * and refused at any other, because a request writing its own wording is
- * asking for a message a user would read.
+ * So a pool configured to send through SES or through an SNS SMS role is
+ * refused. Accepting the configuration would say the messages went that way,
+ * and they would not: they would be recorded here exactly as a pool with no
+ * configuration at all records them.
+ *
+ * The wording of the messages is a different matter and is simulated. It is
+ * read by SimCognitoVerificationMessages, which is what a recorded message
+ * says. Verifying by following a link is not: nothing here serves the link,
+ * and `ConfirmSignUp` with the code is the only way a user is confirmed, so a
+ * pool that asked for a link would be tested against a flow it does not have
+ * in a deployment.
  */
 export class SimCognitoUnsimulatedUserPoolMessaging {
   private readonly unsimulated: SimCognitoUnsimulatedInput;
-  private readonly structure: SimCognitoUnsimulatedStructure;
 
   constructor(operation: string) {
     this.unsimulated = new SimCognitoUnsimulatedInput(operation);
-    this.structure = new SimCognitoUnsimulatedStructure(operation);
   }
 
   /**
@@ -68,38 +55,31 @@ export class SimCognitoUnsimulatedUserPoolMessaging {
       "multi-factor authentication messages",
     );
 
-    this.refuseVerificationWording(input);
+    this.refuseLinkVerification(input.VerificationMessageTemplate);
   }
 
   /**
-   * Refuse verification wording other than the one this simulation accepts.
+   * Refuse a pool that verifies by following a link rather than by answering
+   * with a code.
    */
-  private refuseVerificationWording(
-    input: SimCognitoUserPoolCommandInput,
+  private refuseLinkVerification(
+    template: SimCognitoVerificationMessageTemplateType | undefined,
   ): void {
     this.unsimulated.refuseUnless(
-      "EmailVerificationMessage",
-      input.EmailVerificationMessage,
-      verificationMessage,
-      verificationWording,
+      "VerificationMessageTemplate DefaultEmailOption",
+      template?.DefaultEmailOption,
+      "CONFIRM_WITH_CODE",
+      linkVerification,
     );
-    this.unsimulated.refuseUnless(
-      "EmailVerificationSubject",
-      input.EmailVerificationSubject,
-      verificationSubject,
-      verificationWording,
+    this.unsimulated.refuse(
+      "VerificationMessageTemplate EmailMessageByLink",
+      template?.EmailMessageByLink,
+      linkVerification,
     );
-    this.unsimulated.refuseUnless(
-      "SmsVerificationMessage",
-      input.SmsVerificationMessage,
-      verificationMessage,
-      verificationWording,
-    );
-    this.structure.refuseUnless(
-      "VerificationMessageTemplate",
-      input.VerificationMessageTemplate,
-      verificationMessageTemplate,
-      verificationWording,
+    this.unsimulated.refuse(
+      "VerificationMessageTemplate EmailSubjectByLink",
+      template?.EmailSubjectByLink,
+      linkVerification,
     );
   }
 }

--- a/src/service/cognito/command/user-pool/sim-cognito-update-user-pool-validation.iso.test.ts
+++ b/src/service/cognito/command/user-pool/sim-cognito-update-user-pool-validation.iso.test.ts
@@ -58,13 +58,13 @@ const refusedInputs: readonly RefusedInput[] = [
     says: "a password the user has used before",
   },
   {
-    label: "LambdaConfig CustomMessage",
+    label: "LambdaConfig UserMigration",
     input: {
       LambdaConfig: {
-        CustomMessage: "arn:aws:lambda:eu-west-2:1:function:f",
+        UserMigration: "arn:aws:lambda:eu-west-2:1:function:f",
       },
     },
-    says: "writing the wording of a message the pool sends",
+    says: "importing a user from an external directory on first sign-in",
   },
   {
     label: "UserAttributeUpdateSettings",
@@ -134,16 +134,11 @@ const refusedInputs: readonly RefusedInput[] = [
     says: "multi-factor authentication messages",
   },
   {
-    label: "VerificationMessageTemplate",
+    label: "VerificationMessageTemplate DefaultEmailOption",
     input: {
       VerificationMessageTemplate: { DefaultEmailOption: "CONFIRM_WITH_LINK" },
     },
-    says: "the wording of a verification message",
-  },
-  {
-    label: "EmailVerificationMessage",
-    input: { EmailVerificationMessage: "Your code is {####}" },
-    says: "the wording of a verification message",
+    says: "confirming a sign-up by following a link",
   },
 ];
 

--- a/src/service/cognito/command/user-pool/sim-cognito-user-pool-accepted-settings.iso.test.ts
+++ b/src/service/cognito/command/user-pool/sim-cognito-user-pool-accepted-settings.iso.test.ts
@@ -22,11 +22,10 @@ import type { SimCognitoIdentityProvider } from "../../sim-cognito-identity-prov
  * asking for nothing in particular, apart from the `AdminCreateUserConfig`
  * this simulation acts on.
  *
- * Each configures message delivery, verification wording or account recovery.
- * None of those is simulated, and none of these values asks for anything this
- * simulation does not already do, so a pool is created with them rather than
- * refused. They are recorded here as one block because a default CDK stack
- * sends them together.
+ * The verification wording is read: it is what the messages the pool records
+ * say, and any wording is accepted. `AccountRecoverySetting` is not, and this
+ * value asks for nothing this simulation does not already do. They are
+ * recorded here as one block because a default CDK stack sends them together.
  */
 const verificationMessage =
   "The verification code to your new account is {####}";
@@ -50,8 +49,8 @@ const cdkDefaultSettings = {
 } satisfies Partial<CreateUserPoolCommandInput>;
 
 /**
- * A value of each accepted setting that this simulation refuses, with what
- * the refusal has to say about it.
+ * A value this simulation refuses among the settings it otherwise accepts,
+ * with what the refusal has to say about it.
  */
 interface RefusedValue {
   readonly label: string;
@@ -70,26 +69,11 @@ const refusedValues: readonly RefusedValue[] = [
     says: "account recovery",
   },
   {
-    label: "EmailVerificationMessage",
-    input: { EmailVerificationMessage: "Your code is {####}" },
-    says: "the wording of a verification message",
-  },
-  {
-    label: "EmailVerificationSubject",
-    input: { EmailVerificationSubject: "Confirm your address" },
-    says: "the wording of a verification message",
-  },
-  {
-    label: "SmsVerificationMessage",
-    input: { SmsVerificationMessage: "Your code is {####}" },
-    says: "the wording of a verification message",
-  },
-  {
-    label: "VerificationMessageTemplate",
+    label: "VerificationMessageTemplate DefaultEmailOption",
     input: {
       VerificationMessageTemplate: { DefaultEmailOption: "CONFIRM_WITH_LINK" },
     },
-    says: "the wording of a verification message",
+    says: "confirming a sign-up by following a link",
   },
 ];
 
@@ -126,7 +110,7 @@ describe("sim Cognito user pool settings accepted without being simulated", () =
     assertNonNullable(described.UserPool);
 
     // And each setting is reported back as the request set it, so what the
-    // pool was asked for stays visible even though nothing here reads it.
+    // pool was asked for stays visible.
     assertObjectEquals(
       described.UserPool.AccountRecoverySetting,
       cdkDefaultSettings.AccountRecoverySetting,

--- a/src/service/cognito/command/user-pool/sim-cognito-user-pool-validation.iso.test.ts
+++ b/src/service/cognito/command/user-pool/sim-cognito-user-pool-validation.iso.test.ts
@@ -59,10 +59,10 @@ const refusedInputs: readonly RefusedInput[] = [
     label: "LambdaConfig",
     input: {
       LambdaConfig: {
-        CustomMessage: "arn:aws:lambda:eu-west-2:1:function:f",
+        UserMigration: "arn:aws:lambda:eu-west-2:1:function:f",
       },
     },
-    says: "LambdaConfig CustomMessage is not simulated",
+    says: "LambdaConfig UserMigration is not simulated",
   },
   {
     label: "AliasAttributes",
@@ -152,26 +152,25 @@ const refusedInputs: readonly RefusedInput[] = [
     says: "SMS delivery",
   },
   {
-    label: "VerificationMessageTemplate",
+    label: "VerificationMessageTemplate DefaultEmailOption",
     input: {
-      VerificationMessageTemplate: { DefaultEmailOption: "CONFIRM_WITH_CODE" },
+      VerificationMessageTemplate: { DefaultEmailOption: "CONFIRM_WITH_LINK" },
     },
-    says: "the wording of a verification message",
+    says: "confirming a sign-up by following a link",
   },
   {
-    label: "EmailVerificationMessage",
-    input: { EmailVerificationMessage: "Your code is {####}" },
-    says: "the wording of a verification message",
+    label: "VerificationMessageTemplate EmailMessageByLink",
+    input: {
+      VerificationMessageTemplate: { EmailMessageByLink: "Follow {##here##}" },
+    },
+    says: "confirming a sign-up by following a link",
   },
   {
-    label: "EmailVerificationSubject",
-    input: { EmailVerificationSubject: "Verify your email" },
-    says: "the wording of a verification message",
-  },
-  {
-    label: "SmsVerificationMessage",
-    input: { SmsVerificationMessage: "Your code is {####}" },
-    says: "the wording of a verification message",
+    label: "VerificationMessageTemplate EmailSubjectByLink",
+    input: {
+      VerificationMessageTemplate: { EmailSubjectByLink: "Confirm" },
+    },
+    says: "confirming a sign-up by following a link",
   },
   {
     label: "SmsAuthenticationMessage",

--- a/src/service/cognito/command/user-pool/sim-cognito-user-pool-view.ts
+++ b/src/service/cognito/command/user-pool/sim-cognito-user-pool-view.ts
@@ -13,8 +13,9 @@ export class SimCognitoUserPoolView {
    * A pool as `CreateUserPool` and `DescribeUserPool` report it.
    *
    * The settings the pool accepted without acting on are reported back as
-   * the request set them, so a template's declaration stays visible. Nothing
-   * here reads any of them.
+   * the request set them, so a template's declaration stays visible. The
+   * verification wording is reported the same way, and that one the pool does
+   * read: it is what the messages it records say.
    *
    * `LambdaConfig` is reported only by a pool that was created with one, and
    * carries the triggers that pool runs.
@@ -43,6 +44,7 @@ export class SimCognitoUserPoolView {
       CreationDate: pool.creationDate,
       LastModifiedDate: pool.lastModifiedDate,
       ...pool.settings.unsimulated.toOutput(),
+      ...pool.settings.verificationMessages.toOutput(),
     };
   }
 

--- a/src/service/cognito/command/user-pool/user-pool.command.ts
+++ b/src/service/cognito/command/user-pool/user-pool.command.ts
@@ -1,6 +1,7 @@
 import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
 import type { SimCognitoAdminCreateUserConfigType } from "../../user-pool/sim-cognito-admin-create-user-config.js";
 import type { SimCognitoUserPoolPoliciesType } from "../../user-pool/sim-cognito-password-policy.js";
+import type { SimCognitoVerificationMessagesType } from "../../user-pool/message/sim-cognito-verification-messages.js";
 import type { SimCognitoUnsimulatedPoolSettingsType } from "../../user-pool/sim-cognito-unsimulated-pool-settings.js";
 import type { SimCognitoUserPoolSettingsInput } from "../../user-pool/sim-cognito-user-pool-settings.js";
 import type { SimCognitoLambdaConfigType } from "../../user-pool/trigger/sim-cognito-lambda-config.js";
@@ -14,7 +15,10 @@ import type { SimCognitoLambdaConfigType } from "../../user-pool/trigger/sim-cog
  *
  * https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_UserPoolType.html
  */
-export interface SimCognitoUserPoolType extends SimCognitoUnsimulatedPoolSettingsType {
+export interface SimCognitoUserPoolType
+  extends
+    SimCognitoUnsimulatedPoolSettingsType,
+    SimCognitoVerificationMessagesType {
   readonly Id?: string | undefined;
   readonly Name?: string | undefined;
   readonly Arn?: string | undefined;

--- a/src/service/cognito/command/user/sim-cognito-sign-up-commands.ts
+++ b/src/service/cognito/command/user/sim-cognito-sign-up-commands.ts
@@ -1,7 +1,7 @@
 import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
 import { requireSimCognitoSecretHash } from "../../user-pool/auth/sim-cognito-secret-hash.js";
 import type { SimCognitoUserPoolClient } from "../../user-pool/client/sim-cognito-user-pool-client.js";
-import { SimCognitoPasswordCheck } from "../../user-pool/sim-cognito-password-check.js";
+import type { SimCognitoPoolMessenger } from "../../user-pool/message/sim-cognito-pool-messenger.js";
 import type { SimCognitoUserPool } from "../../user-pool/sim-cognito-user-pool.js";
 import { SimCognitoTriggerOccasion } from "../../user-pool/trigger/sim-cognito-trigger-occasion.js";
 import type { SimCognitoUserPoolTriggers } from "../../user-pool/trigger/sim-cognito-user-pool-triggers.js";
@@ -29,6 +29,7 @@ interface SimCognitoSignUpCommandsProperties {
   readonly resolver: SimCognitoRequestResolver;
   readonly userFactory: SimCognitoUserFactory;
   readonly triggers: SimCognitoUserPoolTriggers;
+  readonly messenger: SimCognitoPoolMessenger;
 }
 
 interface SimCognitoCommandOptions {
@@ -46,14 +47,15 @@ interface SimCognitoCommandOptions {
  * operation does.
  *
  * Nothing here delivers the confirmation code. It is issued and held on the
- * user, and `SimCognitoUserPool.confirmationCode` is where a test reads it
- * from.
+ * user, `SimCognitoUserPool.confirmationCode` is where a test reads it from,
+ * and the message the pool would have sent it in is recorded on the pool.
  */
 export class SimCognitoSignUpCommands {
   private readonly authResolver: SimCognitoAuthResolver;
   private readonly resolver: SimCognitoRequestResolver;
   private readonly userFactory: SimCognitoUserFactory;
   private readonly triggers: SimCognitoUserPoolTriggers;
+  private readonly messenger: SimCognitoPoolMessenger;
   private readonly unsimulatedOptions =
     new SimCognitoUnsimulatedSignUpOptions();
 
@@ -62,6 +64,7 @@ export class SimCognitoSignUpCommands {
     this.resolver = properties.resolver;
     this.userFactory = properties.userFactory;
     this.triggers = properties.triggers;
+    this.messenger = properties.messenger;
   }
 
   /**
@@ -79,6 +82,10 @@ export class SimCognitoSignUpCommands {
    * `autoConfirmUser` takes the user straight to `CONFIRMED` and reaches
    * `PostConfirmation` here rather than at a `ConfirmSignUp` that never comes,
    * which is what real Cognito does for a pool whose users never confirm.
+   *
+   * The verification message is recorded for a user that has to confirm, and
+   * for no other: a user the trigger auto-confirmed has nothing to answer with
+   * a code, so real Cognito sends it none.
    */
   async signUp(command: SimSignUpCommand): Promise<SimSignUpCommandOutput> {
     const { input } = command;
@@ -94,9 +101,8 @@ export class SimCognitoSignUpCommands {
     const user = this.userFactory.signUp({
       username,
       attributes: input.UserAttributes,
-      password: new SimCognitoPasswordCheck(
-        pool.settings.passwordPolicy,
-      ).require("Password", input.Password),
+      password: input.Password,
+      passwordPolicy: pool.settings.passwordPolicy,
     });
 
     const preSignUp = await this.triggers.preSignUp(
@@ -122,6 +128,15 @@ export class SimCognitoSignUpCommands {
         pool,
         client,
         user,
+        clientMetadata: input.ClientMetadata,
+      });
+    } else {
+      await this.messenger.send({
+        pool,
+        user,
+        client,
+        occasion: "SignUp",
+        code: user.confirmationCode,
         clientMetadata: input.ClientMetadata,
       });
     }
@@ -168,17 +183,31 @@ export class SimCognitoSignUpCommands {
    * Issue a fresh confirmation code for a user waiting to be confirmed.
    *
    * The code the user had stops working, as it does on real Cognito, so a
-   * test holding the earlier one has to read the new one from the pool.
+   * test holding the earlier one has to read the new one from the pool. The
+   * pool records a second message carrying the fresh code, and a
+   * `CustomMessage` handler tells this occasion from a sign-up by its
+   * `CustomMessage_ResendCode` trigger source.
    */
-  resendConfirmationCode(
+  async resendConfirmationCode(
     command: SimResendConfirmationCodeCommand,
-  ): SimResendConfirmationCodeCommandOutput {
+  ): Promise<SimResendConfirmationCodeCommandOutput> {
     const { input } = command;
     const { pool, client } = this.authResolver.client(input.ClientId);
 
     this.unsimulatedOptions.refuseInResend(input);
 
-    this.signingUpUser(pool, client, input).resendConfirmationCode();
+    const user = this.signingUpUser(pool, client, input);
+
+    user.resendConfirmationCode();
+
+    await this.messenger.send({
+      pool,
+      user,
+      client,
+      occasion: "ResendCode",
+      code: user.confirmationCode,
+      clientMetadata: input.ClientMetadata,
+    });
 
     return { $metadata: {} };
   }

--- a/src/service/cognito/command/user/sim-cognito-unsimulated-sign-up-options.ts
+++ b/src/service/cognito/command/user/sim-cognito-unsimulated-sign-up-options.ts
@@ -53,17 +53,11 @@ export class SimCognitoUnsimulatedSignUpOptions {
   /**
    * Refuse a `ResendConfirmationCode` request this simulation cannot honour.
    *
-   * `ClientMetadata` is still refused here. The only trigger it would reach on
-   * this operation is the custom message one, which writes the wording of a
-   * message, and no message is ever delivered here.
+   * `ClientMetadata` is not among them. It reaches the custom message trigger,
+   * which runs here, so it reaches the handler.
    */
   refuseInResend(input: SimCognitoSignUpCommandInput): void {
     this.refuseAppContext(this.resendInput, input);
-    this.resendInput.refuse(
-      "ClientMetadata",
-      input.ClientMetadata,
-      "passing data to the custom message Lambda trigger",
-    );
   }
 
   /**

--- a/src/service/cognito/command/user/sim-cognito-unsimulated-user-options.ts
+++ b/src/service/cognito/command/user/sim-cognito-unsimulated-user-options.ts
@@ -8,8 +8,10 @@ import type {
 /**
  * Refuses the user operation inputs this simulation does not model.
  *
- * Nothing here delivers a message, verifies an attribute or runs a Lambda
- * trigger, so an input asking for any of those is refused rather than dropped.
+ * Nothing here delivers a message or verifies an attribute, so an input asking
+ * for either is refused rather than dropped. The data a Lambda trigger reads is
+ * refused only where the trigger that would read it is one this simulation does
+ * not run.
  */
 export class SimCognitoUnsimulatedUserOptions {
   private readonly creation = new SimCognitoUnsimulatedInput("AdminCreateUser");
@@ -21,25 +23,29 @@ export class SimCognitoUnsimulatedUserOptions {
   /**
    * Refuse an `AdminCreateUser` request this simulation cannot honour.
    *
-   * `MessageAction: SUPPRESS` is allowed, and does nothing, because no
-   * invitation is ever sent here. `RESEND` is refused: there is no message to
-   * send again.
+   * `MessageAction: SUPPRESS` records no invitation, which is the difference
+   * it makes on real Cognito too. `RESEND` is refused: it invites a user that
+   * already exists, and `AdminCreateUser` refuses to create one twice here.
    *
-   * `ValidationData` and `ClientMetadata` are not refused. Both exist to reach
-   * the pre sign-up trigger, and that trigger runs here, so they reach the
-   * handler.
+   * `DesiredDeliveryMediums` is refused because the pool picks the medium from
+   * the attributes the user has, and a request naming `SMS` for a user with an
+   * email address would be recorded as an email.
+   *
+   * `ValidationData` and `ClientMetadata` are not refused. They exist to reach
+   * the pre sign-up and custom message triggers, and both run here, so they
+   * reach the handler.
    */
   refuseInCreate(input: SimAdminCreateUserCommandInput): void {
     this.creation.refuseUnless(
       "MessageAction",
       input.MessageAction,
       "SUPPRESS",
-      "sending the invitation message again",
+      "inviting a user that already exists",
     );
     this.creation.refuse(
       "DesiredDeliveryMediums",
       input.DesiredDeliveryMediums,
-      "emailing or texting the user their temporary password",
+      "choosing which of a user's attributes the invitation goes to",
     );
     this.creation.refuse(
       "ForceAliasCreation",

--- a/src/service/cognito/command/user/sim-cognito-user-commands.ts
+++ b/src/service/cognito/command/user/sim-cognito-user-commands.ts
@@ -1,6 +1,5 @@
 import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
-import { SimCognitoPasswordCheck } from "../../user-pool/sim-cognito-password-check.js";
-import type { SimCognitoUserPool } from "../../user-pool/sim-cognito-user-pool.js";
+import type { SimCognitoPoolMessenger } from "../../user-pool/message/sim-cognito-pool-messenger.js";
 import { SimCognitoTriggerOccasion } from "../../user-pool/trigger/sim-cognito-trigger-occasion.js";
 import type { SimCognitoUserPoolTriggers } from "../../user-pool/trigger/sim-cognito-user-pool-triggers.js";
 import type { SimCognitoUserFactory } from "../../user-pool/user/sim-cognito-user-factory.js";
@@ -22,6 +21,7 @@ interface SimCognitoUserCommandsProperties {
   readonly resolver: SimCognitoRequestResolver;
   readonly userFactory: SimCognitoUserFactory;
   readonly triggers: SimCognitoUserPoolTriggers;
+  readonly messenger: SimCognitoPoolMessenger;
 }
 
 interface SimCognitoCommandOptions {
@@ -38,6 +38,7 @@ export class SimCognitoUserCommands {
   private readonly resolver: SimCognitoRequestResolver;
   private readonly userFactory: SimCognitoUserFactory;
   private readonly triggers: SimCognitoUserPoolTriggers;
+  private readonly messenger: SimCognitoPoolMessenger;
   private readonly view = new SimCognitoUserView();
   private readonly unsimulatedOptions = new SimCognitoUnsimulatedUserOptions();
 
@@ -45,29 +46,7 @@ export class SimCognitoUserCommands {
     this.resolver = properties.resolver;
     this.userFactory = properties.userFactory;
     this.triggers = properties.triggers;
-  }
-
-  /**
-   * Read the temporary password the request named, or none.
-   *
-   * A request naming none is fine, and leaves the user with no password at
-   * all: real Cognito generates one and sends it to the user, and nothing
-   * here delivers a message for the user to read it from. Such a user reaches
-   * the `NEW_PASSWORD_REQUIRED` challenge with no password to get past it, so
-   * name a `TemporaryPassword` when the test means to sign in.
-   */
-  private static allowedTemporaryPassword(
-    pool: SimCognitoUserPool,
-    temporaryPassword: string | undefined,
-  ): string | undefined {
-    if (temporaryPassword === undefined) {
-      return undefined;
-    }
-
-    return new SimCognitoPasswordCheck(pool.settings.passwordPolicy).require(
-      "TemporaryPassword",
-      temporaryPassword,
-    );
+    this.messenger = properties.messenger;
   }
 
   /**
@@ -76,7 +55,8 @@ export class SimCognitoUserCommands {
    * The user is left in `FORCE_CHANGE_PASSWORD`, as real Cognito leaves an
    * admin-created user: it has a temporary password and cannot sign in until
    * that password is replaced. `AdminSetUserPassword` with `Permanent: true`
-   * is what moves it on.
+   * is what moves it on. A request naming no `TemporaryPassword` leaves the
+   * user with no password at all, so name one when the test means to sign in.
    *
    * The pool's `PreSignUp` trigger runs before the user is added, reporting
    * `PreSignUp_AdminCreateUser`, so a handler that throws leaves the pool
@@ -88,6 +68,11 @@ export class SimCognitoUserCommands {
    * `PostConfirmation` does not run, here or on real Cognito. It fires for
    * users who sign themselves up, and an admin-created user never confirms
    * anything.
+   *
+   * The pool records the invitation it would have sent, carrying the temporary
+   * password, unless the request asked for `MessageAction: SUPPRESS`. That is
+   * what makes suppressing mean something here rather than being accepted and
+   * changing nothing.
    */
   async create(
     command: SimAdminCreateUserCommand,
@@ -106,10 +91,8 @@ export class SimCognitoUserCommands {
     const user = this.userFactory.make({
       username,
       attributes: input.UserAttributes,
-      temporaryPassword: SimCognitoUserCommands.allowedTemporaryPassword(
-        pool,
-        input.TemporaryPassword,
-      ),
+      temporaryPassword: input.TemporaryPassword,
+      passwordPolicy: pool.settings.passwordPolicy,
     });
 
     await this.triggers.preSignUp(SimCognitoTriggerOccasion.adminCreateUser, {
@@ -123,6 +106,16 @@ export class SimCognitoUserCommands {
     });
 
     pool.addUser(user);
+
+    if (input.MessageAction !== "SUPPRESS") {
+      await this.messenger.send({
+        pool,
+        user,
+        occasion: "AdminCreateUser",
+        code: input.TemporaryPassword,
+        clientMetadata: input.ClientMetadata,
+      });
+    }
 
     return { $metadata: {}, User: this.view.entry(user) };
   }

--- a/src/service/cognito/command/user/sim-cognito-user-validation.iso.test.ts
+++ b/src/service/cognito/command/user/sim-cognito-user-validation.iso.test.ts
@@ -210,7 +210,8 @@ describe("sim Cognito user validation", () => {
       );
     });
 
-    // Then it is refused, because Lambda triggers are not simulated.
+    // Then it is refused: the trigger that would have read it is not one this
+    // simulation runs.
     assertInstanceOf(error, SimCognitoInvalidParameterException);
     assertStringIncludes(error.message, "ClientMetadata");
   });

--- a/src/service/cognito/serve/sim-cognito-controller.ts
+++ b/src/service/cognito/serve/sim-cognito-controller.ts
@@ -14,6 +14,21 @@ import { SimCognitoOpenIdConfiguration } from "./sim-cognito-openid-configuratio
 const wellKnownSegment = ".well-known";
 
 /**
+ * The path segment the recorded messages are listed under.
+ *
+ * Real Cognito serves nothing here. It is the serving side of
+ * `SimCognitoUserPool.sentMessages`, so that a browser or a curl can read what
+ * a pool would have sent during local development, and it is a divergence for
+ * the same reason that accessor is one: nothing here delivers a message.
+ */
+const messagesSegment = "messages";
+
+/**
+ * The segments a request can name after the pool id.
+ */
+const servedSegments = new Set([wellKnownSegment, messagesSegment]);
+
+/**
  * The methods a published document is read with.
  */
 const readMethods = new Set(["GET", "HEAD"]);
@@ -23,13 +38,28 @@ interface SimCognitoServiceControllerProperties {
 }
 
 /**
- * Localhost HTTP controller for the public endpoints of a simulated user pool.
+ * The parts of a request that decide which document it is asking for.
+ */
+interface SimCognitoServedRequest {
+  readonly segment: string;
+  readonly document: string | undefined;
+  readonly url: URL;
+  readonly method: string;
+}
+
+/**
+ * Localhost HTTP controller for the public endpoints of a simulated user pool,
+ * and for the messages the pool would have sent.
  *
  * Real Cognito serves a pool's JWKS and its OpenID configuration to anyone,
  * with no SigV4 signature, because a token verifier holding no AWS credentials
  * has to be able to fetch them. Both are anonymous here for the same reason,
  * so a verifier pointed at the local URL fetches keys the way it does against
  * real Cognito rather than being handed them.
+ *
+ * The recorded messages are listed at `/<userPoolId>/messages`, which real
+ * Cognito serves nothing at. Nothing here delivers a message, so this is where
+ * one is read during local development.
  *
  * The Cognito API itself is not served. An SDK client reaches the simulator
  * through `SimSdk` rather than through an endpoint override.
@@ -59,17 +89,18 @@ export class SimCognitoServiceController implements SimAwsServiceController {
       return this.response.notRead(request.method);
     }
 
-    // A path is exactly '<userPoolId>/.well-known/<document>'. Anything
-    // longer is a path real Cognito has nothing at, rather than a prefix of
-    // one it serves.
-    const [userPoolId, wellKnown, document, ...rest] = url.pathname
+    // A path is exactly '<userPoolId>/.well-known/<document>' or
+    // '<userPoolId>/messages'. Anything longer is a path nothing is served at,
+    // rather than a prefix of one that is.
+    const [userPoolId, segment, document, ...rest] = url.pathname
       .slice(1)
       .split("/");
 
     if (
       userPoolId === undefined ||
       userPoolId.length === 0 ||
-      wellKnown !== wellKnownSegment ||
+      segment === undefined ||
+      !servedSegments.has(segment) ||
       rest.length > 0
     ) {
       return this.response.noSuchEndpoint(url.pathname);
@@ -81,14 +112,38 @@ export class SimCognitoServiceController implements SimAwsServiceController {
       return this.response.noSuchUserPool(userPoolId);
     }
 
+    return this.served(pool, {
+      segment,
+      document,
+      url,
+      method: request.method,
+    });
+  }
+
+  /**
+   * The document a request names, or nothing served at that path.
+   */
+  private served(
+    pool: SimCognitoUserPool,
+    request: SimCognitoServedRequest,
+  ): Response {
+    const { segment, document, url, method } = request;
+
+    if (segment === messagesSegment && document === undefined) {
+      return this.response.document(
+        { messages: pool.sentMessages().map((message) => message.toOutput()) },
+        method,
+      );
+    }
+
     if (document === "jwks.json") {
-      return this.response.document(pool.jwks(), request.method);
+      return this.response.document(pool.jwks(), method);
     }
 
     if (document === "openid-configuration") {
       return this.response.document(
         this.openIdConfiguration.document(pool, url.origin),
-        request.method,
+        method,
       );
     }
 

--- a/src/service/cognito/serve/sim-cognito-controller.ts
+++ b/src/service/cognito/serve/sim-cognito-controller.ts
@@ -129,11 +129,18 @@ export class SimCognitoServiceController implements SimAwsServiceController {
   ): Response {
     const { segment, document, url, method } = request;
 
+    // The listing is the whole of what the messages segment serves, and the
+    // two published documents sit under `.well-known` and nowhere else, so a
+    // path that mixes the two reaches neither.
     if (segment === messagesSegment && document === undefined) {
       return this.response.document(
         { messages: pool.sentMessages().map((message) => message.toOutput()) },
         method,
       );
+    }
+
+    if (segment !== wellKnownSegment) {
+      return this.response.noSuchEndpoint(url.pathname);
     }
 
     if (document === "jwks.json") {

--- a/src/service/cognito/serve/sim-cognito-endpoint-response.ts
+++ b/src/service/cognito/serve/sim-cognito-endpoint-response.ts
@@ -38,7 +38,7 @@ export class SimCognitoEndpointResponse {
   /**
    * Refuse a method that does not read a published document.
    *
-   * Both endpoints publish a document, so `GET` and `HEAD` are all they
+   * Every path here publishes a document, so `GET` and `HEAD` are all they
    * answer. The Cognito API is reached through `SimSdk` rather than by posting
    * to this hostname, so a `POST` here is not the API either.
    */
@@ -47,7 +47,8 @@ export class SimCognitoEndpointResponse {
       {
         message:
           `Simulated Cognito answers ${method} at no user pool endpoint. ` +
-          `The JWKS and the OpenID configuration are read with GET.`,
+          `The JWKS, the OpenID configuration and the recorded messages are ` +
+          `read with GET.`,
       },
       { status: 405, headers: { allow: "GET, HEAD" } },
     );

--- a/src/service/cognito/serve/sim-cognito-endpoint-response.ts
+++ b/src/service/cognito/serve/sim-cognito-endpoint-response.ts
@@ -48,7 +48,7 @@ export class SimCognitoEndpointResponse {
         message:
           `Simulated Cognito answers ${method} at no user pool endpoint. ` +
           `The JWKS, the OpenID configuration and the recorded messages are ` +
-          `read with GET.`,
+          `read with GET or HEAD.`,
       },
       { status: 405, headers: { allow: "GET, HEAD" } },
     );

--- a/src/service/cognito/serve/sim-cognito-messages-serve.iso.test.ts
+++ b/src/service/cognito/serve/sim-cognito-messages-serve.iso.test.ts
@@ -151,13 +151,18 @@ describe("Serving the messages a sim Cognito user pool would have sent", () => {
     // Given a pool that has recorded a message.
     const simAws = new SimAws({ defaultRegionName: "eu-west-2" });
     const userPoolId = await poolWithMessageIn(simAws);
+    const simAwsHttp = new SimAwsHttp({ simAws });
 
     // When something below the messages path is requested.
-    const response = await new SimAwsHttp({ simAws }).fetch(
-      `${messagesUrl(userPoolId)}/0`,
-    );
+    const belowListing = await simAwsHttp.fetch(`${messagesUrl(userPoolId)}/0`);
 
-    // Then it is not served: there is no endpoint for one message.
-    assertIdentical(response.status, 404);
+    // And when a published document is asked for under it rather than under
+    // .well-known.
+    const jwks = await simAwsHttp.fetch(`${messagesUrl(userPoolId)}/jwks.json`);
+
+    // Then neither is served: there is no endpoint for one message, and the
+    // two published documents sit under .well-known and nowhere else.
+    assertIdentical(belowListing.status, 404);
+    assertIdentical(jwks.status, 404);
   });
 });

--- a/src/service/cognito/serve/sim-cognito-messages-serve.iso.test.ts
+++ b/src/service/cognito/serve/sim-cognito-messages-serve.iso.test.ts
@@ -1,0 +1,163 @@
+import {
+  CreateUserPoolClientCommand,
+  CreateUserPoolCommand,
+  SignUpCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertObjectEquals,
+  assertObjectMatches,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAwsHttp } from "../../../serve/http/sim-aws-http.js";
+import { SimAwsLocalUrl } from "../../../serve/http/url/sim-aws-local-url.js";
+import { SimAws } from "../../aws/sim-aws.js";
+
+function localUrl(input: string): string {
+  return new SimAwsLocalUrl({ input }).toString();
+}
+
+function messagesUrl(userPoolId: string): string {
+  return localUrl(
+    `https://cognito-idp.eu-west-2.amazonaws.com/${userPoolId}/messages`,
+  );
+}
+
+/**
+ * A pool that has sent one verification message.
+ */
+async function poolWithMessageIn(simAws: SimAws): Promise<string> {
+  const cognito = simAws.cognitoIdentityProvider();
+  const created = await cognito.createUserPool(
+    new CreateUserPoolCommand({
+      PoolName: "myapp-users",
+      AutoVerifiedAttributes: ["email"],
+    }),
+  );
+  assertNonNullable(created.UserPool?.Id);
+
+  const userPoolId = created.UserPool.Id;
+  const client = await cognito.createUserPoolClient(
+    new CreateUserPoolClientCommand({
+      UserPoolId: userPoolId,
+      ClientName: "web",
+    }),
+  );
+  assertNonNullable(client.UserPoolClient?.ClientId);
+
+  await cognito.signUp(
+    new SignUpCommand({
+      ClientId: client.UserPoolClient.ClientId,
+      Username: "alice",
+      Password: "Sup3rSecret!",
+      UserAttributes: [{ Name: "email", Value: "alice@example.com" }],
+    }),
+  );
+
+  return userPoolId;
+}
+
+describe("Serving the messages a sim Cognito user pool would have sent", () => {
+  it("lists the messages a pool has recorded", async () => {
+    // Given a pool that a user has signed itself up to.
+    const simAws = new SimAws({ defaultRegionName: "eu-west-2" });
+    const userPoolId = await poolWithMessageIn(simAws);
+
+    // When the pool's messages are requested.
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      messagesUrl(userPoolId),
+    );
+
+    // Then the verification message is listed, with everything about it a
+    // reader needs during local development.
+    assertIdentical(response.status, 200);
+    assertIdentical(response.headers.get("content-type"), "application/json");
+
+    const code = simAws
+      .cognitoIdentityProvider()
+      .userPool(userPoolId)
+      .confirmationCode("alice");
+    assertNonNullable(code);
+    assertObjectMatches(await response.json(), {
+      messages: [
+        {
+          username: "alice",
+          recipient: "alice@example.com",
+          medium: "EMAIL",
+          subject: "Your verification code",
+          body: `Your verification code is ${code}`,
+          occasion: "SignUp",
+        },
+      ],
+    });
+  });
+
+  it("lists nothing for a pool that has sent nothing", async () => {
+    // Given a pool no user has signed up to.
+    const simAws = new SimAws({ defaultRegionName: "eu-west-2" });
+    const created = await simAws
+      .cognitoIdentityProvider()
+      .createUserPool(new CreateUserPoolCommand({ PoolName: "myapp-users" }));
+    assertNonNullable(created.UserPool?.Id);
+
+    // When its messages are requested.
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      messagesUrl(created.UserPool.Id),
+    );
+
+    // Then the listing is empty rather than missing.
+    assertIdentical(response.status, 200);
+    assertObjectEquals(await response.json(), { messages: [] });
+  });
+
+  it("answers a HEAD with the headers a GET would", async () => {
+    // Given a pool that has recorded a message.
+    const simAws = new SimAws({ defaultRegionName: "eu-west-2" });
+    const userPoolId = await poolWithMessageIn(simAws);
+    const simAwsHttp = new SimAwsHttp({ simAws });
+
+    // When the listing is asked for with HEAD, and with a method that reads
+    // no document at all.
+    const headed = await simAwsHttp.fetch(messagesUrl(userPoolId), {
+      method: "HEAD",
+    });
+    const posted = await simAwsHttp.fetch(messagesUrl(userPoolId), {
+      method: "POST",
+    });
+
+    // Then the HEAD answers the headers with no body, and the write is
+    // refused.
+    assertIdentical(headed.status, 200);
+    assertIdentical(await headed.text(), "");
+    assertIdentical(posted.status, 405);
+  });
+
+  it("reports a pool it does not serve as not found", async () => {
+    // Given a simulated AWS with no user pools.
+    const simAws = new SimAws({ defaultRegionName: "eu-west-2" });
+
+    // When an invented pool's messages are requested.
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      messagesUrl("eu-west-2_aBcDeFgHi"),
+    );
+
+    // Then the endpoint reports it as not found, as it does for the JWKS.
+    assertIdentical(response.status, 404);
+  });
+
+  it("reports a path below the listing as not found", async () => {
+    // Given a pool that has recorded a message.
+    const simAws = new SimAws({ defaultRegionName: "eu-west-2" });
+    const userPoolId = await poolWithMessageIn(simAws);
+
+    // When something below the messages path is requested.
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      `${messagesUrl(userPoolId)}/0`,
+    );
+
+    // Then it is not served: there is no endpoint for one message.
+    assertIdentical(response.status, 404);
+  });
+});

--- a/src/service/cognito/user-pool/message/sim-cognito-invitation-message.iso.test.ts
+++ b/src/service/cognito/user-pool/message/sim-cognito-invitation-message.iso.test.ts
@@ -1,0 +1,155 @@
+import {
+  AdminCreateUserCommand,
+  CreateUserPoolCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import type { AdminCreateUserCommandInput } from "@aws-sdk/client-cognito-identity-provider";
+import {
+  assertArrayEquals,
+  assertIdentical,
+  assertNonNullable,
+  assertTypeString,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import type { SimCognitoIdentityProvider } from "../../sim-cognito-identity-provider.js";
+import type { SimCognitoSentMessage } from "./sim-cognito-sent-message.js";
+
+const temporaryPassword = "Temp0rary!";
+
+interface InvitationPool {
+  readonly cognito: SimCognitoIdentityProvider;
+  readonly userPoolId: string;
+}
+
+async function makePool(): Promise<InvitationPool> {
+  const cognito = new SimAws().cognitoIdentityProvider();
+  const pool = await cognito.createUserPool(
+    new CreateUserPoolCommand({ PoolName: "myapp-users" }),
+  );
+  const userPoolId = pool.UserPool?.Id;
+  assertTypeString(userPoolId);
+
+  return { cognito, userPoolId };
+}
+
+async function createUser(
+  pool: InvitationPool,
+  input: Partial<AdminCreateUserCommandInput> = {},
+): Promise<void> {
+  await pool.cognito.adminCreateUser(
+    new AdminCreateUserCommand({
+      UserPoolId: pool.userPoolId,
+      Username: "alice",
+      TemporaryPassword: temporaryPassword,
+      UserAttributes: [{ Name: "email", Value: "alice@example.com" }],
+      ...input,
+    }),
+  );
+}
+
+function sentBy(pool: InvitationPool): readonly SimCognitoSentMessage[] {
+  return pool.cognito.userPool(pool.userPoolId).sentMessages();
+}
+
+describe("sim Cognito user pool invitation messages", () => {
+  it("records the invitation an admin-created user would have been sent", async () => {
+    // Given a pool with no messages recorded yet.
+    const pool = await makePool();
+
+    // When an administrator creates a user with a temporary password.
+    await createUser(pool);
+
+    // Then the pool recorded the invitation, carrying the username and the
+    // password the user needs to sign in with.
+    const [message] = sentBy(pool);
+    assertNonNullable(message);
+    assertIdentical(message.recipient, "alice@example.com");
+    assertIdentical(message.medium, "EMAIL");
+    assertIdentical(message.occasion, "AdminCreateUser");
+    assertIdentical(message.subject, "Your temporary password");
+    assertIdentical(
+      message.body,
+      `Your username is alice and temporary password is ${temporaryPassword}.`,
+    );
+  });
+
+  it("records nothing where the request suppressed the message", async () => {
+    // Given a pool with no messages recorded yet.
+    const pool = await makePool();
+
+    // When the user is created with the invitation suppressed.
+    await createUser(pool, { MessageAction: "SUPPRESS" });
+
+    // Then no invitation was recorded, which is the difference SUPPRESS makes
+    // on real Cognito too.
+    assertArrayEquals(sentBy(pool), []);
+  });
+
+  it("leaves the placeholder where there is no password to put in it", async () => {
+    // Given a pool, and a user created without a temporary password.
+    const pool = await makePool();
+    await createUser(pool, { TemporaryPassword: undefined });
+
+    // Then the invitation still went, with the placeholder left as it is:
+    // real Cognito generates a password there, and this simulation leaves the
+    // user with none at all, so there is nothing to fill in.
+    const [message] = sentBy(pool);
+    assertNonNullable(message);
+    assertIdentical(
+      message.body,
+      "Your username is alice and temporary password is {####}.",
+    );
+  });
+
+  it("texts a user it has only a phone number for", async () => {
+    // Given a pool with no messages recorded yet.
+    const pool = await makePool();
+
+    // When the user has a phone number rather than an email address.
+    await createUser(pool, {
+      UserAttributes: [{ Name: "phone_number", Value: "+447700900123" }],
+    });
+
+    // Then the invitation is a text message, which has no subject.
+    const [message] = sentBy(pool);
+    assertNonNullable(message);
+    assertIdentical(message.recipient, "+447700900123");
+    assertIdentical(message.medium, "SMS");
+    assertUndefined(message.subject);
+  });
+
+  it("records nothing for a user it has no address for", async () => {
+    // Given a pool with no messages recorded yet.
+    const pool = await makePool();
+
+    // When a user is created with neither attribute the pool could write to.
+    await createUser(pool, { UserAttributes: undefined });
+
+    // Then there was nowhere to send an invitation, and none was recorded.
+    assertArrayEquals(sentBy(pool), []);
+  });
+
+  it("invites a user whatever the pool verifies automatically", async () => {
+    // Given a pool that verifies the phone number rather than the email.
+    const cognito = new SimAws().cognitoIdentityProvider();
+    const created = await cognito.createUserPool(
+      new CreateUserPoolCommand({
+        PoolName: "myapp-users",
+        AutoVerifiedAttributes: ["phone_number"],
+      }),
+    );
+    const userPoolId = created.UserPool?.Id;
+    assertTypeString(userPoolId);
+
+    // When a user with only an email address is created.
+    await createUser({ cognito, userPoolId });
+
+    // Then the invitation went to the email address anyway: what a pool
+    // verifies narrows a verification message, not an invitation.
+    const [message] = sentBy({ cognito, userPoolId });
+    assertNonNullable(message);
+    assertIdentical(message.recipient, "alice@example.com");
+  });
+});

--- a/src/service/cognito/user-pool/message/sim-cognito-message-delivery.ts
+++ b/src/service/cognito/user-pool/message/sim-cognito-message-delivery.ts
@@ -1,0 +1,75 @@
+import type { SimCognitoUserPool } from "../sim-cognito-user-pool.js";
+import type { SimCognitoUser } from "../user/sim-cognito-user.js";
+import type { SimCognitoMessageOccasion } from "./sim-cognito-message-occasion.js";
+import type { SimCognitoMessageMedium } from "./sim-cognito-sent-message.js";
+
+/**
+ * The attributes a pool can write to, and the medium each one is reached by.
+ *
+ * The order is the order Cognito prefers: an email address is written to where
+ * the user has one, and the phone number is what is left.
+ */
+const deliverableAttributes: readonly (readonly [
+  string,
+  SimCognitoMessageMedium,
+])[] = [
+  ["email", "EMAIL"],
+  ["phone_number", "SMS"],
+];
+
+/**
+ * Where a message would go, and how it would get there.
+ *
+ * Cognito picks both from the user's own attributes, so a user with an email
+ * address gets an email and a user with only a phone number gets a text
+ * message.
+ */
+export class SimCognitoMessageDelivery {
+  public readonly recipient: string;
+  public readonly medium: SimCognitoMessageMedium;
+
+  private constructor(recipient: string, medium: SimCognitoMessageMedium) {
+    this.recipient = recipient;
+    this.medium = medium;
+  }
+
+  /**
+   * Where a message for this occasion would go, or nothing where there is
+   * nowhere to send it.
+   *
+   * A user with none of the attributes a pool can write to gets no message
+   * rather than a refusal, because a pool with nowhere to write is not an
+   * error: it is a pool that sends nothing, and the recorded messages say so
+   * by being empty.
+   *
+   * A verification message goes only to an attribute the pool verifies
+   * automatically, because that is the address it is trying to prove belongs
+   * to the user. An invitation goes wherever the user can be reached.
+   */
+  static forOccasion(
+    pool: SimCognitoUserPool,
+    user: SimCognitoUser,
+    occasion: SimCognitoMessageOccasion,
+  ): SimCognitoMessageDelivery | undefined {
+    for (const [name, medium] of deliverableAttributes) {
+      const value = user.attributeValues.get(name);
+
+      if (value !== undefined && this.writable(pool, occasion, name)) {
+        return new SimCognitoMessageDelivery(value, medium);
+      }
+    }
+
+    return undefined;
+  }
+
+  private static writable(
+    pool: SimCognitoUserPool,
+    occasion: SimCognitoMessageOccasion,
+    name: string,
+  ): boolean {
+    return (
+      occasion === "AdminCreateUser" ||
+      pool.settings.autoVerifiedAttributes.names.includes(name)
+    );
+  }
+}

--- a/src/service/cognito/user-pool/message/sim-cognito-message-occasion.ts
+++ b/src/service/cognito/user-pool/message/sim-cognito-message-occasion.ts
@@ -1,0 +1,15 @@
+/**
+ * What made a simulated user pool send a message.
+ *
+ * These are the three occasions this simulation reaches: a user signing itself
+ * up, that user asking for another code, and an administrator creating a user.
+ * Real Cognito sends on more of them, password reset and MFA among them, and
+ * neither of those is simulated here.
+ *
+ * `SimCognitoTriggerOccasion.customMessage` turns one of these into the
+ * occasion the `CustomMessage` trigger fires for.
+ */
+export type SimCognitoMessageOccasion =
+  | "SignUp"
+  | "ResendCode"
+  | "AdminCreateUser";

--- a/src/service/cognito/user-pool/message/sim-cognito-message-occasion.ts
+++ b/src/service/cognito/user-pool/message/sim-cognito-message-occasion.ts
@@ -10,6 +10,4 @@
  * occasion the `CustomMessage` trigger fires for.
  */
 export type SimCognitoMessageOccasion =
-  | "SignUp"
-  | "ResendCode"
-  | "AdminCreateUser";
+  "SignUp" | "ResendCode" | "AdminCreateUser";

--- a/src/service/cognito/user-pool/message/sim-cognito-message-placeholders.ts
+++ b/src/service/cognito/user-pool/message/sim-cognito-message-placeholders.ts
@@ -1,0 +1,79 @@
+/**
+ * The placeholder a pool's wording carries where the code belongs.
+ *
+ * It is `codeParameter` in a `CustomMessage` event, which is what a handler
+ * writes into the message it returns so that Cognito fills the code in
+ * afterwards.
+ */
+export const simCognitoCodeParameter = "{####}";
+
+/**
+ * The placeholder the invitation wording carries where the username belongs,
+ * which is `usernameParameter` in a `CustomMessage` event.
+ */
+export const simCognitoUsernameParameter = "{username}";
+
+interface SimCognitoMessagePlaceholdersProperties {
+  readonly username: string;
+
+  /**
+   * The confirmation code or temporary password the message carries, or
+   * nothing where the pool has none to put in it.
+   */
+  readonly code?: string | undefined;
+}
+
+/**
+ * Fills in the placeholders a message's wording carries.
+ *
+ * The substitution runs after the `CustomMessage` trigger rather than before
+ * it, because that is the order real Cognito runs it in: a handler writes
+ * `codeParameter` into its own wording, and the code replaces it in whatever
+ * wording the message ends up with.
+ *
+ * A placeholder with nothing to put in it is left as it is, so a message that
+ * was never given a code reads as one rather than quietly losing the
+ * placeholder.
+ */
+export class SimCognitoMessagePlaceholders {
+  private readonly username: string;
+  private readonly code: string | undefined;
+
+  constructor(properties: SimCognitoMessagePlaceholdersProperties) {
+    this.username = properties.username;
+    this.code = properties.code;
+  }
+
+  /**
+   * The text with every placeholder this knows a value for filled in.
+   */
+  fill(text: string): string {
+    // The replacement is a function so that a `$` in a username or a code is
+    // put in as it is, rather than being read as a replacement pattern.
+    return this.filledCode(text).replaceAll(
+      simCognitoUsernameParameter,
+      () => this.username,
+    );
+  }
+
+  /**
+   * The same for a subject a medium may not have.
+   */
+  fillOptional(text: string | undefined): string | undefined {
+    if (text === undefined) {
+      return undefined;
+    }
+
+    return this.fill(text);
+  }
+
+  private filledCode(text: string): string {
+    const { code } = this;
+
+    if (code === undefined) {
+      return text;
+    }
+
+    return text.replaceAll(simCognitoCodeParameter, () => code);
+  }
+}

--- a/src/service/cognito/user-pool/message/sim-cognito-message-wording.ts
+++ b/src/service/cognito/user-pool/message/sim-cognito-message-wording.ts
@@ -36,15 +36,10 @@ export class SimCognitoMessageWording {
    * This wording with whatever a `CustomMessage` handler wrote in place of it.
    *
    * A handler that wrote neither leaves the pool's own wording, which is what
-   * a handler returning the event untouched does.
+   * a handler returning the event untouched does, and what a pool with no such
+   * trigger at all gets.
    */
-  replacedBy(
-    written: SimCognitoWrittenWording | undefined,
-  ): SimCognitoMessageWording {
-    if (written === undefined) {
-      return this;
-    }
-
+  replacedBy(written: SimCognitoWrittenWording): SimCognitoMessageWording {
     return new SimCognitoMessageWording({
       subject: written.subject ?? this.subject,
       body: written.body ?? this.body,

--- a/src/service/cognito/user-pool/message/sim-cognito-message-wording.ts
+++ b/src/service/cognito/user-pool/message/sim-cognito-message-wording.ts
@@ -1,0 +1,65 @@
+import type { SimCognitoMessagePlaceholders } from "./sim-cognito-message-placeholders.js";
+
+interface SimCognitoMessageWordingProperties {
+  /** The subject, which a text message does not have. */
+  readonly subject?: string | undefined;
+  readonly body: string;
+}
+
+/**
+ * What a `CustomMessage` handler wrote for one medium, either part of which it
+ * may have left alone.
+ */
+export interface SimCognitoWrittenWording {
+  readonly subject?: string | undefined;
+  readonly body?: string | undefined;
+}
+
+/**
+ * What a message says, before the placeholders in it are filled in.
+ *
+ * A pool has wording for each occasion it sends on, a `CustomMessage` handler
+ * can return wording of its own in place of it, and the code and the username
+ * go in last. Each of those steps hands on a wording rather than a pair of
+ * strings, so the subject and the body cannot drift apart on the way.
+ */
+export class SimCognitoMessageWording {
+  public readonly subject: string | undefined;
+  public readonly body: string;
+
+  constructor(properties: SimCognitoMessageWordingProperties) {
+    this.subject = properties.subject;
+    this.body = properties.body;
+  }
+
+  /**
+   * This wording with whatever a `CustomMessage` handler wrote in place of it.
+   *
+   * A handler that wrote neither leaves the pool's own wording, which is what
+   * a handler returning the event untouched does.
+   */
+  replacedBy(
+    written: SimCognitoWrittenWording | undefined,
+  ): SimCognitoMessageWording {
+    if (written === undefined) {
+      return this;
+    }
+
+    return new SimCognitoMessageWording({
+      subject: written.subject ?? this.subject,
+      body: written.body ?? this.body,
+    });
+  }
+
+  /**
+   * This wording with the code and the username filled in.
+   */
+  filledWith(
+    placeholders: SimCognitoMessagePlaceholders,
+  ): SimCognitoMessageWording {
+    return new SimCognitoMessageWording({
+      subject: placeholders.fillOptional(this.subject),
+      body: placeholders.fill(this.body),
+    });
+  }
+}

--- a/src/service/cognito/user-pool/message/sim-cognito-occasion-wording.ts
+++ b/src/service/cognito/user-pool/message/sim-cognito-occasion-wording.ts
@@ -1,0 +1,43 @@
+import type { SimCognitoUserPool } from "../sim-cognito-user-pool.js";
+import type { SimCognitoMessageOccasion } from "./sim-cognito-message-occasion.js";
+import { SimCognitoMessageWording } from "./sim-cognito-message-wording.js";
+import type { SimCognitoMessageMedium } from "./sim-cognito-sent-message.js";
+
+/**
+ * The wording real Cognito invites an admin-created user with when the pool
+ * asked for none.
+ *
+ * These are the defaults the Cognito API documentation states for
+ * `AdminCreateUserConfig InviteMessageTemplate`, rather than values read back
+ * from a live account. `InviteMessageTemplate` itself is refused, so a pool
+ * cannot ask for anything else here yet.
+ */
+const invitationSubject = "Your temporary password";
+const invitationMessage =
+  "Your username is {username} and temporary password is {####}.";
+
+/**
+ * What a pool says on the occasion it is sending on.
+ *
+ * The invitation an administrator's user is sent is the pool's own wording as
+ * much as the verification message is, and only the verification wording can
+ * be set on a pool here.
+ */
+export function simCognitoOccasionWording(
+  pool: SimCognitoUserPool,
+  occasion: SimCognitoMessageOccasion,
+  medium: SimCognitoMessageMedium,
+): SimCognitoMessageWording {
+  if (occasion !== "AdminCreateUser") {
+    return pool.settings.verificationMessages.wording(medium);
+  }
+
+  if (medium === "SMS") {
+    return new SimCognitoMessageWording({ body: invitationMessage });
+  }
+
+  return new SimCognitoMessageWording({
+    subject: invitationSubject,
+    body: invitationMessage,
+  });
+}

--- a/src/service/cognito/user-pool/message/sim-cognito-pool-messenger.ts
+++ b/src/service/cognito/user-pool/message/sim-cognito-pool-messenger.ts
@@ -1,0 +1,110 @@
+import type { SimClock } from "../../../../util/clock/sim-clock.js";
+import type { SimCognitoUserPoolClient } from "../client/sim-cognito-user-pool-client.js";
+import type { SimCognitoUserPool } from "../sim-cognito-user-pool.js";
+import { SimCognitoTriggerOccasion } from "../trigger/sim-cognito-trigger-occasion.js";
+import type { SimCognitoUserPoolTriggers } from "../trigger/sim-cognito-user-pool-triggers.js";
+import type { SimCognitoUser } from "../user/sim-cognito-user.js";
+import { SimCognitoMessageDelivery } from "./sim-cognito-message-delivery.js";
+import type { SimCognitoMessageOccasion } from "./sim-cognito-message-occasion.js";
+import { SimCognitoMessagePlaceholders } from "./sim-cognito-message-placeholders.js";
+import { simCognitoOccasionWording } from "./sim-cognito-occasion-wording.js";
+import { SimCognitoSentMessage } from "./sim-cognito-sent-message.js";
+
+interface SimCognitoPoolMessengerProperties {
+  readonly triggers: SimCognitoUserPoolTriggers;
+  readonly clock: SimClock;
+}
+
+/**
+ * What a pool is about to send.
+ */
+interface SimCognitoMessageRequest {
+  readonly pool: SimCognitoUserPool;
+  readonly user: SimCognitoUser;
+  readonly occasion: SimCognitoMessageOccasion;
+
+  /**
+   * The confirmation code or temporary password the message carries, where
+   * the pool has one to put in it.
+   */
+  readonly code?: string | undefined;
+
+  /** The app client the request came through, where one did. */
+  readonly client?: SimCognitoUserPoolClient | undefined;
+  readonly clientMetadata?: Readonly<Record<string, string>> | undefined;
+}
+
+/**
+ * Records the messages a simulated user pool would have sent.
+ *
+ * Nothing is delivered. The pool keeps what it would have sent, and a test
+ * reads it back off the pool, which is what makes a verification message
+ * something a test can assert about at all.
+ *
+ * This is Cognito's own delivery, not SES. Real Cognito with the default
+ * `EmailSendingAccount` of `COGNITO_DEFAULT` sends through no other service,
+ * and `EmailConfiguration` is refused here, so no pool is configured for one
+ * that would.
+ */
+export class SimCognitoPoolMessenger {
+  private readonly triggers: SimCognitoUserPoolTriggers;
+  private readonly clock: SimClock;
+
+  constructor(properties: SimCognitoPoolMessengerProperties) {
+    this.triggers = properties.triggers;
+    this.clock = properties.clock;
+  }
+
+  /**
+   * Send the message this occasion produces, running the pool's
+   * `CustomMessage` trigger first so that a handler can write its own.
+   *
+   * A pool with nowhere to write to sends nothing, as one does on real
+   * Cognito, rather than recording a message addressed to no one.
+   */
+  async send(request: SimCognitoMessageRequest): Promise<void> {
+    const delivery = SimCognitoMessageDelivery.forOccasion(
+      request.pool,
+      request.user,
+      request.occasion,
+    );
+
+    if (delivery === undefined) {
+      return;
+    }
+
+    const { medium } = delivery;
+    const custom = await this.triggers.customMessage(
+      SimCognitoTriggerOccasion.customMessage(request.occasion),
+      {
+        pool: request.pool,
+        user: request.user,
+        client: request.client,
+        clientMetadata: request.clientMetadata,
+      },
+    );
+    const pooled = simCognitoOccasionWording(
+      request.pool,
+      request.occasion,
+      medium,
+    );
+    // The code and the username go in last, so that what a handler wrote
+    // carries them too.
+    const placeholders = new SimCognitoMessagePlaceholders({
+      username: request.user.username,
+      code: request.code,
+    });
+    const wording = custom.wordingFor(medium, pooled);
+
+    request.pool.messages.record(
+      new SimCognitoSentMessage({
+        username: request.user.username,
+        recipient: delivery.recipient,
+        medium,
+        wording: wording.filledWith(placeholders),
+        occasion: request.occasion,
+        sentDate: this.clock.now(),
+      }),
+    );
+  }
+}

--- a/src/service/cognito/user-pool/message/sim-cognito-sent-message-store.ts
+++ b/src/service/cognito/user-pool/message/sim-cognito-sent-message-store.ts
@@ -1,0 +1,25 @@
+import type { SimCognitoSentMessage } from "./sim-cognito-sent-message.js";
+
+/**
+ * The messages one simulated user pool would have sent.
+ *
+ * They are kept in the order the pool sent them, so a test that signed a user
+ * up and then asked for another code reads the two in that order.
+ */
+export class SimCognitoSentMessageStore {
+  readonly #messages: SimCognitoSentMessage[] = [];
+
+  /**
+   * Keep a message the pool would have sent.
+   */
+  record(message: SimCognitoSentMessage): void {
+    this.#messages.push(message);
+  }
+
+  /**
+   * Every message, oldest first.
+   */
+  get all(): readonly SimCognitoSentMessage[] {
+    return [...this.#messages];
+  }
+}

--- a/src/service/cognito/user-pool/message/sim-cognito-sent-message.ts
+++ b/src/service/cognito/user-pool/message/sim-cognito-sent-message.ts
@@ -1,0 +1,94 @@
+import type { SimCognitoMessageOccasion } from "./sim-cognito-message-occasion.js";
+import type { SimCognitoMessageWording } from "./sim-cognito-message-wording.js";
+
+/**
+ * How a pool would have delivered a message.
+ *
+ * Cognito picks the medium from the attribute it is writing to, so an email
+ * address gets an email and a phone number gets a text message.
+ */
+export type SimCognitoMessageMedium = "EMAIL" | "SMS";
+
+/**
+ * One recorded message, in the shape the serve layer lists it in.
+ */
+export interface SimCognitoSentMessageOutput {
+  readonly username: string;
+  readonly recipient: string;
+  readonly medium: SimCognitoMessageMedium;
+  readonly subject?: string | undefined;
+  readonly body: string;
+  readonly occasion: SimCognitoMessageOccasion;
+  readonly sentDate: string;
+}
+
+interface SimCognitoSentMessageProperties {
+  readonly username: string;
+  readonly recipient: string;
+  readonly medium: SimCognitoMessageMedium;
+
+  /** What the message says, with its placeholders already filled in. */
+  readonly wording: SimCognitoMessageWording;
+  readonly occasion: SimCognitoMessageOccasion;
+  readonly sentDate: Date;
+}
+
+/**
+ * One message a simulated user pool would have sent.
+ *
+ * Nothing is delivered. The pool keeps what it would have sent instead, which
+ * is what lets a test assert that signing up produces a verification message
+ * carrying the code, and what the wording a pool was created with is finally
+ * read for.
+ *
+ * This is Cognito's own record rather than a simulated SES: real Cognito with
+ * the default `EmailSendingAccount` of `COGNITO_DEFAULT` does not send through
+ * SES at all, so a message here has been through no other service.
+ */
+export class SimCognitoSentMessage {
+  /** The user the message was addressed to. */
+  public readonly username: string;
+
+  /** The email address or phone number it would have gone to. */
+  public readonly recipient: string;
+
+  public readonly medium: SimCognitoMessageMedium;
+
+  /** The subject, which a text message does not have. */
+  public readonly subject: string | undefined;
+
+  public readonly body: string;
+
+  /** What the pool was doing when it sent this. */
+  public readonly occasion: SimCognitoMessageOccasion;
+
+  public readonly sentDate: Date;
+
+  constructor(properties: SimCognitoSentMessageProperties) {
+    this.username = properties.username;
+    this.recipient = properties.recipient;
+    this.medium = properties.medium;
+    this.subject = properties.wording.subject;
+    this.body = properties.wording.body;
+    this.occasion = properties.occasion;
+    this.sentDate = properties.sentDate;
+  }
+
+  /**
+   * This message as the serve layer lists it.
+   *
+   * The date is an ISO string because the listing is JSON, where a `Date` has
+   * no representation of its own.
+   */
+  toOutput(): SimCognitoSentMessageOutput {
+    return {
+      username: this.username,
+      recipient: this.recipient,
+      medium: this.medium,
+      ...(this.subject !== undefined && { subject: this.subject }),
+      body: this.body,
+      occasion: this.occasion,
+      sentDate: this.sentDate.toISOString(),
+    };
+  }
+}

--- a/src/service/cognito/user-pool/message/sim-cognito-verification-messages.iso.test.ts
+++ b/src/service/cognito/user-pool/message/sim-cognito-verification-messages.iso.test.ts
@@ -1,0 +1,230 @@
+import {
+  CreateUserPoolClientCommand,
+  CreateUserPoolCommand,
+  ResendConfirmationCodeCommand,
+  SignUpCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import type { CreateUserPoolCommandInput } from "@aws-sdk/client-cognito-identity-provider";
+import {
+  assertArrayEquals,
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertStringNotIncludes,
+  assertTypeString,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import type { SimCognitoIdentityProvider } from "../../sim-cognito-identity-provider.js";
+import type { SimCognitoSentMessage } from "./sim-cognito-sent-message.js";
+
+/** The password the user in each of these signs up with. */
+const password = "Sup3rSecret!";
+
+interface MessagePool {
+  readonly cognito: SimCognitoIdentityProvider;
+  readonly userPoolId: string;
+  readonly clientId: string;
+}
+
+/**
+ * A pool that verifies an attribute automatically, with an app client to sign
+ * up through.
+ */
+async function makePool(
+  input: Partial<CreateUserPoolCommandInput> = {},
+): Promise<MessagePool> {
+  const cognito = new SimAws().cognitoIdentityProvider();
+  const pool = await cognito.createUserPool(
+    new CreateUserPoolCommand({
+      PoolName: "myapp-users",
+      AutoVerifiedAttributes: ["email"],
+      ...input,
+    }),
+  );
+  const userPoolId = pool.UserPool?.Id;
+  assertTypeString(userPoolId);
+
+  const client = await cognito.createUserPoolClient(
+    new CreateUserPoolClientCommand({
+      UserPoolId: userPoolId,
+      ClientName: "web",
+    }),
+  );
+  const clientId = client.UserPoolClient?.ClientId;
+  assertTypeString(clientId);
+
+  return { cognito, userPoolId, clientId };
+}
+
+async function signUp(
+  pool: MessagePool,
+  attributes: readonly { Name: string; Value: string }[] = [
+    { Name: "email", Value: "alice@example.com" },
+  ],
+): Promise<void> {
+  await pool.cognito.signUp(
+    new SignUpCommand({
+      ClientId: pool.clientId,
+      Username: "alice",
+      Password: password,
+      UserAttributes: [...attributes],
+    }),
+  );
+}
+
+function sentBy(pool: MessagePool): readonly SimCognitoSentMessage[] {
+  return pool.cognito.userPool(pool.userPoolId).sentMessages();
+}
+
+function codeIn(pool: MessagePool): string {
+  const code = pool.cognito.userPool(pool.userPoolId).confirmationCode("alice");
+  assertTypeString(code);
+
+  return code;
+}
+
+describe("sim Cognito user pool verification messages", () => {
+  it("records the message a sign-up would have sent", async () => {
+    // Given a pool that verifies the email attribute automatically.
+    const pool = await makePool();
+
+    // When a user signs itself up.
+    await signUp(pool);
+
+    // Then the pool recorded the verification message it would have sent,
+    // addressed to the user's own email address.
+    const [message] = sentBy(pool);
+    assertNonNullable(message);
+    assertIdentical(message.username, "alice");
+    assertIdentical(message.recipient, "alice@example.com");
+    assertIdentical(message.medium, "EMAIL");
+    assertIdentical(message.occasion, "SignUp");
+    assertIdentical(message.subject, "Your verification code");
+
+    // And the body carries the code the user was issued, in place of the
+    // placeholder the wording has.
+    assertIdentical(message.body, `Your verification code is ${codeIn(pool)}`);
+  });
+
+  it("says what the pool was created with rather than the default", async () => {
+    // Given a pool created with its own verification wording, which used to be
+    // refused at anything but the one string CDK emits.
+    const pool = await makePool({
+      EmailVerificationSubject: "Welcome to Acme",
+      EmailVerificationMessage:
+        "Hello, your Acme code is {####}. Twice: {####}",
+    });
+
+    // When a user signs itself up.
+    await signUp(pool);
+
+    // Then the recorded message says what the pool was asked to say, with
+    // every placeholder in it filled in.
+    const [message] = sentBy(pool);
+    const code = codeIn(pool);
+    assertNonNullable(message);
+    assertIdentical(message.subject, "Welcome to Acme");
+    assertIdentical(
+      message.body,
+      `Hello, your Acme code is ${code}. Twice: ${code}`,
+    );
+  });
+
+  it("prefers the template over the inputs it replaced", async () => {
+    // Given a pool that sets both the older inputs and the template, as a CDK
+    // pool does, with the two disagreeing.
+    const pool = await makePool({
+      EmailVerificationSubject: "The older subject",
+      EmailVerificationMessage: "The older message {####}",
+      VerificationMessageTemplate: {
+        DefaultEmailOption: "CONFIRM_WITH_CODE",
+        EmailSubject: "The template subject",
+      },
+    });
+
+    // When a user signs itself up.
+    await signUp(pool);
+
+    // Then the template wins where it says something, and the older input
+    // fills in what it left out.
+    const [message] = sentBy(pool);
+    assertNonNullable(message);
+    assertIdentical(message.subject, "The template subject");
+    assertIdentical(message.body, `The older message ${codeIn(pool)}`);
+  });
+
+  it("texts a user it has a phone number for", async () => {
+    // Given a pool that verifies the phone number automatically.
+    const pool = await makePool({
+      AutoVerifiedAttributes: ["phone_number"],
+      SmsVerificationMessage: "Acme code: {####}",
+    });
+
+    // When a user with a phone number signs itself up.
+    await signUp(pool, [{ Name: "phone_number", Value: "+447700900123" }]);
+
+    // Then the message went to the number, as a text message with no subject:
+    // Cognito picks the medium from the attribute it is writing to.
+    const [message] = sentBy(pool);
+    assertNonNullable(message);
+    assertIdentical(message.recipient, "+447700900123");
+    assertIdentical(message.medium, "SMS");
+    assertUndefined(message.subject);
+    assertIdentical(message.body, `Acme code: ${codeIn(pool)}`);
+  });
+
+  it("sends nothing for a pool that verifies nothing", async () => {
+    // Given a pool with no AutoVerifiedAttributes, which is the default.
+    const pool = await makePool({ AutoVerifiedAttributes: undefined });
+
+    // When a user signs itself up.
+    await signUp(pool);
+
+    // Then no message was sent: the pool is not trying to prove any address
+    // belongs to the user, so real Cognito leaves it to an administrator to
+    // confirm.
+    assertArrayEquals(sentBy(pool), []);
+  });
+
+  it("sends nothing to a user it has no address for", async () => {
+    // Given a pool that verifies the email attribute.
+    const pool = await makePool();
+
+    // When a user signs up without one.
+    await signUp(pool, []);
+
+    // Then there was nowhere to write to, and no message was recorded.
+    assertArrayEquals(sentBy(pool), []);
+  });
+
+  it("records another message when the code is resent", async () => {
+    // Given a signed-up user waiting to be confirmed.
+    const pool = await makePool();
+    await signUp(pool);
+    const firstCode = codeIn(pool);
+
+    // When it asks for the code again.
+    await pool.cognito.resendConfirmationCode(
+      new ResendConfirmationCodeCommand({
+        ClientId: pool.clientId,
+        Username: "alice",
+      }),
+    );
+
+    // Then a second message was recorded, naming the occasion it was sent on.
+    const messages = sentBy(pool);
+    assertArrayEquals(
+      messages.map((message) => message.occasion),
+      ["SignUp", "ResendCode"],
+    );
+
+    // And it carries the fresh code rather than the one that no longer works.
+    const [, resent] = messages;
+    assertNonNullable(resent);
+    assertStringIncludes(resent.body, codeIn(pool));
+    assertStringNotIncludes(resent.body, firstCode);
+  });
+});

--- a/src/service/cognito/user-pool/message/sim-cognito-verification-messages.iso.test.ts
+++ b/src/service/cognito/user-pool/message/sim-cognito-verification-messages.iso.test.ts
@@ -8,15 +8,18 @@ import type { CreateUserPoolCommandInput } from "@aws-sdk/client-cognito-identit
 import {
   assertArrayEquals,
   assertIdentical,
+  assertInstanceOf,
   assertNonNullable,
   assertStringIncludes,
   assertStringNotIncludes,
+  assertThrowsErrorAsync,
   assertTypeString,
   assertUndefined,
 } from "@kensio/smartass";
 import { describe, it } from "vitest";
 
 import { SimAws } from "../../../aws/sim-aws.js";
+import { SimCognitoInvalidParameterException } from "../../error/sim-cognito.error.js";
 import type { SimCognitoIdentityProvider } from "../../sim-cognito-identity-provider.js";
 import type { SimCognitoSentMessage } from "./sim-cognito-sent-message.js";
 
@@ -226,5 +229,30 @@ describe("sim Cognito user pool verification messages", () => {
     assertNonNullable(resent);
     assertStringIncludes(resent.body, codeIn(pool));
     assertStringNotIncludes(resent.body, firstCode);
+  });
+
+  it("refuses wording with no code placeholder in it", async () => {
+    // When a pool is created with wording that would carry no code.
+    const error = await assertThrowsErrorAsync(async () => {
+      await makePool({ EmailVerificationMessage: "Welcome to Acme" });
+    });
+
+    // Then it is refused as real Cognito refuses it, rather than recording a
+    // message a user could not confirm with.
+    assertInstanceOf(error, SimCognitoInvalidParameterException);
+    assertStringIncludes(error.message, "{####}");
+  });
+
+  it("refuses wording longer than the medium takes", async () => {
+    // When a pool is created with a text message longer than an SMS carries.
+    const error = await assertThrowsErrorAsync(async () => {
+      await makePool({
+        SmsVerificationMessage: `{####} ${"a".repeat(140)}`,
+      });
+    });
+
+    // Then it is refused, naming the length Cognito takes.
+    assertInstanceOf(error, SimCognitoInvalidParameterException);
+    assertStringIncludes(error.message, "140");
   });
 });

--- a/src/service/cognito/user-pool/message/sim-cognito-verification-messages.ts
+++ b/src/service/cognito/user-pool/message/sim-cognito-verification-messages.ts
@@ -1,0 +1,127 @@
+import type { SimCognitoMessageMedium } from "./sim-cognito-sent-message.js";
+import { SimCognitoMessageWording } from "./sim-cognito-message-wording.js";
+
+/**
+ * The wording real Cognito gives a pool that asked for none.
+ *
+ * These are the defaults the Cognito API documentation states for
+ * `VerificationMessageTemplate`, rather than values read back from a live
+ * account. A pool that sets its own wording never reaches them.
+ */
+const defaultEmailSubject = "Your verification code";
+const defaultMessage = "Your verification code is {####}";
+
+/**
+ * The `VerificationMessageTemplate` a pool can be created with.
+ *
+ * https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_VerificationMessageTemplateType.html
+ */
+export interface SimCognitoVerificationMessageTemplateType {
+  readonly DefaultEmailOption?: string | undefined;
+  readonly EmailMessage?: string | undefined;
+  readonly EmailSubject?: string | undefined;
+  readonly EmailMessageByLink?: string | undefined;
+  readonly EmailSubjectByLink?: string | undefined;
+  readonly SmsMessage?: string | undefined;
+}
+
+/**
+ * The verification wording a request can set, in the shape the SDK sends it.
+ */
+export interface SimCognitoVerificationMessagesType {
+  readonly EmailVerificationMessage?: string | undefined;
+  readonly EmailVerificationSubject?: string | undefined;
+  readonly SmsVerificationMessage?: string | undefined;
+  readonly VerificationMessageTemplate?:
+    SimCognitoVerificationMessageTemplateType | undefined;
+}
+
+/**
+ * What a pool says in the message it sends a user signing itself up.
+ *
+ * The wording is read rather than accepted and ignored, because the pool
+ * records the message it would have sent and a test reads it back. A pool that
+ * asked for nothing gets the wording real Cognito gives one.
+ *
+ * `VerificationMessageTemplate` wins over the three older inputs where a
+ * request sets both, and each of them fills in what the template left out.
+ * What real Cognito does when the two disagree was not checked against a live
+ * account, and a request naming one or the other behaves the same either way.
+ *
+ * Only the wording is read here. Confirming by following a link is refused by
+ * SimCognitoUnsimulatedUserPoolMessaging before a pool gets this far, so
+ * whatever wording arrives is wording for a code.
+ */
+export class SimCognitoVerificationMessages {
+  public readonly emailSubject: string;
+  public readonly emailMessage: string;
+  public readonly smsMessage: string;
+
+  private readonly requested: SimCognitoVerificationMessagesType;
+
+  constructor(input: SimCognitoVerificationMessagesType) {
+    const template = input.VerificationMessageTemplate;
+
+    this.emailSubject =
+      template?.EmailSubject ??
+      input.EmailVerificationSubject ??
+      defaultEmailSubject;
+    this.emailMessage =
+      template?.EmailMessage ??
+      input.EmailVerificationMessage ??
+      defaultMessage;
+    this.smsMessage =
+      template?.SmsMessage ?? input.SmsVerificationMessage ?? defaultMessage;
+    this.requested = SimCognitoVerificationMessages.copied(input);
+  }
+
+  /**
+   * The wording copied out of the request rather than kept by reference, so a
+   * described pool reports what the request said at the time it was made even
+   * where the caller edits the object afterwards.
+   *
+   * Each input is kept only where the request set it, so a pool created
+   * without one describes without it rather than describing the default it
+   * fell back to.
+   */
+  private static copied(
+    input: SimCognitoVerificationMessagesType,
+  ): SimCognitoVerificationMessagesType {
+    return structuredClone({
+      ...(input.EmailVerificationMessage !== undefined && {
+        EmailVerificationMessage: input.EmailVerificationMessage,
+      }),
+      ...(input.EmailVerificationSubject !== undefined && {
+        EmailVerificationSubject: input.EmailVerificationSubject,
+      }),
+      ...(input.SmsVerificationMessage !== undefined && {
+        SmsVerificationMessage: input.SmsVerificationMessage,
+      }),
+      ...(input.VerificationMessageTemplate !== undefined && {
+        VerificationMessageTemplate: input.VerificationMessageTemplate,
+      }),
+    });
+  }
+
+  /**
+   * What this pool says in a verification message for one medium.
+   */
+  wording(medium: SimCognitoMessageMedium): SimCognitoMessageWording {
+    if (medium === "SMS") {
+      return new SimCognitoMessageWording({ body: this.smsMessage });
+    }
+
+    return new SimCognitoMessageWording({
+      subject: this.emailSubject,
+      body: this.emailMessage,
+    });
+  }
+
+  /**
+   * This wording as a described pool reports it, which is what the request
+   * set and nothing it did not.
+   */
+  toOutput(): SimCognitoVerificationMessagesType {
+    return structuredClone(this.requested);
+  }
+}

--- a/src/service/cognito/user-pool/message/sim-cognito-verification-messages.ts
+++ b/src/service/cognito/user-pool/message/sim-cognito-verification-messages.ts
@@ -1,5 +1,10 @@
 import type { SimCognitoMessageMedium } from "./sim-cognito-sent-message.js";
 import { SimCognitoMessageWording } from "./sim-cognito-message-wording.js";
+import {
+  requireSimCognitoVerificationWording,
+  simCognitoLongestEmailMessage,
+  simCognitoLongestSmsMessage,
+} from "./sim-cognito-verification-wording.js";
 
 /**
  * The wording real Cognito gives a pool that asked for none.
@@ -50,7 +55,8 @@ export interface SimCognitoVerificationMessagesType {
  *
  * Only the wording is read here. Confirming by following a link is refused by
  * SimCognitoUnsimulatedUserPoolMessaging before a pool gets this far, so
- * whatever wording arrives is wording for a code.
+ * whatever wording arrives is wording for a code, and it is held to the rules
+ * real Cognito holds it to: the code placeholder, and a length.
  */
 export class SimCognitoVerificationMessages {
   public readonly emailSubject: string;
@@ -66,12 +72,18 @@ export class SimCognitoVerificationMessages {
       template?.EmailSubject ??
       input.EmailVerificationSubject ??
       defaultEmailSubject;
-    this.emailMessage =
+    this.emailMessage = requireSimCognitoVerificationWording(
+      "EmailVerificationMessage",
       template?.EmailMessage ??
-      input.EmailVerificationMessage ??
-      defaultMessage;
-    this.smsMessage =
-      template?.SmsMessage ?? input.SmsVerificationMessage ?? defaultMessage;
+        input.EmailVerificationMessage ??
+        defaultMessage,
+      simCognitoLongestEmailMessage,
+    );
+    this.smsMessage = requireSimCognitoVerificationWording(
+      "SmsVerificationMessage",
+      template?.SmsMessage ?? input.SmsVerificationMessage ?? defaultMessage,
+      simCognitoLongestSmsMessage,
+    );
     this.requested = SimCognitoVerificationMessages.copied(input);
   }
 

--- a/src/service/cognito/user-pool/message/sim-cognito-verification-wording.ts
+++ b/src/service/cognito/user-pool/message/sim-cognito-verification-wording.ts
@@ -1,0 +1,43 @@
+import { SimCognitoInvalidParameterException } from "../../error/sim-cognito.error.js";
+import { simCognitoCodeParameter } from "./sim-cognito-message-placeholders.js";
+
+/**
+ * How long each kind of verification message may be.
+ *
+ * These are the lengths real Cognito states for the wording inputs: an email
+ * runs to 20,000 characters and a text message to the 140 an SMS carries.
+ */
+export const simCognitoLongestEmailMessage = 20_000;
+export const simCognitoLongestSmsMessage = 140;
+
+const shortestMessage = 6;
+
+/**
+ * Refuse verification wording real Cognito would refuse.
+ *
+ * Both rules are ones the API applies, so a pool accepted here that a
+ * deployment turns down is the divergence worth refusing. The placeholder is
+ * the one that matters most: the wording is what a recorded message says, and
+ * wording without it is a message that would reach a user with no code in it.
+ */
+export function requireSimCognitoVerificationWording(
+  option: string,
+  message: string,
+  longest: number,
+): string {
+  if (message.length < shortestMessage || message.length > longest) {
+    throw new SimCognitoInvalidParameterException(
+      `${option} is ${String(message.length)} characters, and Cognito takes ` +
+        `${String(shortestMessage)} to ${String(longest)}`,
+    );
+  }
+
+  if (!message.includes(simCognitoCodeParameter)) {
+    throw new SimCognitoInvalidParameterException(
+      `${option} does not carry the ${simCognitoCodeParameter} placeholder, ` +
+        `so the user would be sent a message with no code in it`,
+    );
+  }
+
+  return message;
+}

--- a/src/service/cognito/user-pool/sim-cognito-unsimulated-pool-settings.ts
+++ b/src/service/cognito/user-pool/sim-cognito-unsimulated-pool-settings.ts
@@ -6,20 +6,16 @@
  */
 export interface SimCognitoUnsimulatedPoolSettingsType {
   readonly AccountRecoverySetting?: object | undefined;
-  readonly EmailVerificationMessage?: string | undefined;
-  readonly EmailVerificationSubject?: string | undefined;
-  readonly SmsVerificationMessage?: string | undefined;
-  readonly VerificationMessageTemplate?: object | undefined;
 }
 
 /**
  * The settings a pool was created with and this simulation does not act on.
  *
- * Each one configures message delivery or account recovery, and neither is
- * simulated, so nothing reads any of them back out. They are kept so
- * `DescribeUserPool` reports what the request set, which is how a test can
- * see that a template's declaration reached the pool rather than being
- * dropped on the way.
+ * `AccountRecoverySetting` chooses how a forgotten password is recovered, and
+ * there is no `ForgotPassword` command here, so nothing reads it back out. It
+ * is kept so `DescribeUserPool` reports what the request set, which is how a
+ * test can see that a template's declaration reached the pool rather than
+ * being dropped on the way.
  *
  * Only what the request set is reported. A pool created without one of these
  * describes without it, rather than describing it as the value the request
@@ -44,12 +40,12 @@ export class SimCognitoUnsimulatedPoolSettings {
    * reference.
    *
    * A caller passes its whole `CreateUserPool` input in, and may reuse or
-   * edit that object afterwards. Two of these are nested objects, so the
-   * copy goes all the way down. Copying means a described pool reports what
-   * the request said at the time it was made, as a real one does.
+   * edit that object afterwards. This one is a nested object, so the copy goes
+   * all the way down. Copying means a described pool reports what the request
+   * said at the time it was made, as a real one does.
    *
-   * Each setting is kept only where the request set it, so a pool created
-   * without one describes without it rather than describing it as the value
+   * The setting is kept only where the request set it, so a pool created
+   * without it describes without it rather than describing it as the value
    * the request would have needed to use.
    */
   private accepted(
@@ -58,18 +54,6 @@ export class SimCognitoUnsimulatedPoolSettings {
     return structuredClone({
       ...(settings.AccountRecoverySetting !== undefined && {
         AccountRecoverySetting: settings.AccountRecoverySetting,
-      }),
-      ...(settings.EmailVerificationMessage !== undefined && {
-        EmailVerificationMessage: settings.EmailVerificationMessage,
-      }),
-      ...(settings.EmailVerificationSubject !== undefined && {
-        EmailVerificationSubject: settings.EmailVerificationSubject,
-      }),
-      ...(settings.SmsVerificationMessage !== undefined && {
-        SmsVerificationMessage: settings.SmsVerificationMessage,
-      }),
-      ...(settings.VerificationMessageTemplate !== undefined && {
-        VerificationMessageTemplate: settings.VerificationMessageTemplate,
       }),
     });
   }

--- a/src/service/cognito/user-pool/sim-cognito-user-pool-settings.ts
+++ b/src/service/cognito/user-pool/sim-cognito-user-pool-settings.ts
@@ -9,6 +9,10 @@ import {
   type SimCognitoUserPoolPoliciesType,
 } from "./sim-cognito-password-policy.js";
 import {
+  SimCognitoVerificationMessages,
+  type SimCognitoVerificationMessagesType,
+} from "./message/sim-cognito-verification-messages.js";
+import {
   SimCognitoUnsimulatedPoolSettings,
   type SimCognitoUnsimulatedPoolSettingsType,
 } from "./sim-cognito-unsimulated-pool-settings.js";
@@ -20,7 +24,10 @@ import { SimCognitoLambdaConfig } from "./trigger/sim-cognito-lambda-config.js";
  * `CreateUserPool` and `UpdateUserPool` both carry these, which is what lets
  * an update build a pool's settings the same way a creation does.
  */
-export interface SimCognitoUserPoolSettingsInput extends SimCognitoUnsimulatedPoolSettingsType {
+export interface SimCognitoUserPoolSettingsInput
+  extends
+    SimCognitoUnsimulatedPoolSettingsType,
+    SimCognitoVerificationMessagesType {
   readonly Policies?: SimCognitoUserPoolPoliciesType | undefined;
   readonly DeletionProtection?: string | undefined;
   readonly AdminCreateUserConfig?:
@@ -40,7 +47,10 @@ interface SimCognitoUserPoolSettingsProperties {
 }
 
 /**
- * The settings of one simulated user pool that a request can change.
+ * The settings of one simulated user pool that a request can change: the
+ * password policy, the deletion protection, whether users may sign themselves
+ * up, what confirming a sign-up verifies, the Lambda triggers the pool runs
+ * and what its messages say.
  *
  * The pool's id, ARN and name are not among them. The first two identify the
  * pool, and renaming one is not simulated.
@@ -61,6 +71,11 @@ export class SimCognitoUserPoolSettings {
    * The Lambda triggers the pool runs, by the ARN of the function each names.
    */
   public readonly lambdaConfig: SimCognitoLambdaConfig;
+
+  /**
+   * What the pool says in the message it sends a user signing itself up.
+   */
+  public readonly verificationMessages: SimCognitoVerificationMessages;
 
   /**
    * What the request set that nothing here acts on, kept so a described pool
@@ -87,6 +102,7 @@ export class SimCognitoUserPoolSettings {
       input.LambdaConfig,
       operation,
     );
+    this.verificationMessages = new SimCognitoVerificationMessages(input);
     this.unsimulated = new SimCognitoUnsimulatedPoolSettings(input);
   }
 }

--- a/src/service/cognito/user-pool/sim-cognito-user-pool.ts
+++ b/src/service/cognito/user-pool/sim-cognito-user-pool.ts
@@ -6,6 +6,8 @@ import { SimCognitoUserPoolClientStore } from "./client/sim-cognito-user-pool-cl
 import type { SimCognitoGroup } from "./group/sim-cognito-group.js";
 import type { SimCognitoGroupName } from "./group/sim-cognito-group-name.js";
 import { SimCognitoGroupStore } from "./group/sim-cognito-group-store.js";
+import type { SimCognitoSentMessage } from "./message/sim-cognito-sent-message.js";
+import { SimCognitoSentMessageStore } from "./message/sim-cognito-sent-message-store.js";
 import type { SimCognitoName } from "./sim-cognito-name.js";
 import type { SimCognitoUserPoolArn } from "./sim-cognito-user-pool-arn.js";
 import {
@@ -50,6 +52,13 @@ export class SimCognitoUserPool {
    * The sign-ins part way through this pool, and the tokens it has issued.
    */
   public readonly auth = new SimCognitoPoolAuth();
+
+  /**
+   * The messages this pool would have sent. Nothing here delivers one, and
+   * real Cognito reports its messages to nobody, so this is the simulator's
+   * own record of what a user would have been sent.
+   */
+  public readonly messages = new SimCognitoSentMessageStore();
 
   private readonly clock: SimClock;
   private readonly clientStore = new SimCognitoUserPoolClientStore();
@@ -240,6 +249,11 @@ export class SimCognitoUserPool {
   confirmationCode(username: string): string | undefined {
     return this.requireUser(requireSimCognitoUsername(username))
       .confirmationCode;
+  }
+
+  /** Every message this pool would have sent, oldest first. */
+  sentMessages(): readonly SimCognitoSentMessage[] {
+    return this.messages.all;
   }
 
   /**

--- a/src/service/cognito/user-pool/trigger/sim-cognito-custom-message-failures.iso.test.ts
+++ b/src/service/cognito/user-pool/trigger/sim-cognito-custom-message-failures.iso.test.ts
@@ -1,0 +1,148 @@
+import { SignUpCommand } from "@aws-sdk/client-cognito-identity-provider";
+import {
+  assertArrayEquals,
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import {
+  makeTriggerPool,
+  triggerFunctionArn,
+  type SimCognitoTriggerPool,
+} from "../../../../../test/cognito/trigger-fixture.js";
+import type { SimLambdaHandler } from "../../../lambda/function/sim-lambda-handler.type.js";
+
+const password = "Sup3rSecret!";
+
+/**
+ * A pool that verifies an email address and runs a CustomMessage handler that
+ * answers badly.
+ */
+async function makeMessagePool(
+  handler: SimLambdaHandler,
+): Promise<SimCognitoTriggerPool> {
+  return await makeTriggerPool({
+    triggers: { CustomMessage: triggerFunctionArn },
+    autoVerifiedAttributes: ["email"],
+    handler,
+  });
+}
+
+async function signUp(pool: SimCognitoTriggerPool): Promise<Error> {
+  return await assertThrowsErrorAsync(async () =>
+    pool.cognito.signUp(
+      new SignUpCommand({
+        ClientId: pool.clientId,
+        Username: "alice",
+        Password: password,
+        UserAttributes: [{ Name: "email", Value: "alice@example.com" }],
+      }),
+    ),
+  );
+}
+
+describe("sim Cognito CustomMessage trigger failures", () => {
+  it("fails the sign-up with the message the handler threw", async () => {
+    // Given a pool whose CustomMessage handler cannot write the message.
+    const pool = await makeMessagePool(() => {
+      throw new Error("The wording service is down");
+    });
+
+    // When a user signs itself up.
+    const error = await signUp(pool);
+
+    // Then the request failed on the trigger, carrying the handler's own
+    // words.
+    assertIdentical(error.name, "UserLambdaValidationException");
+    assertStringIncludes(
+      error.message,
+      "CustomMessage failed with error The wording service is down.",
+    );
+
+    // And the pool recorded no message: the trigger runs before the message
+    // is recorded, so there is no wording to fall back to.
+    assertArrayEquals(
+      pool.cognito.userPool(pool.userPoolId).sentMessages(),
+      [],
+    );
+  });
+
+  it("refuses a response that is not an object", async () => {
+    // Given a handler that answers with a response of the wrong shape.
+    const pool = await makeMessagePool((event: unknown) => ({
+      ...(event as object),
+      response: "Welcome to Acme",
+    }));
+
+    // When a user signs itself up.
+    const error = await signUp(pool);
+
+    // Then it is refused rather than the string being read as a message.
+    assertIdentical(error.name, "InvalidLambdaResponseException");
+    assertStringIncludes(error.message, "a response that is not an object");
+  });
+
+  it("refuses a message that is not a string", async () => {
+    // Given a handler that wrote a number where the message belongs.
+    const pool = await makeMessagePool((event: unknown) => ({
+      ...(event as object),
+      response: { emailMessage: 42 },
+    }));
+
+    // When a user signs itself up.
+    const error = await signUp(pool);
+
+    // Then it is refused, naming the field and what it was given, rather than
+    // recording a message the pool could never have sent.
+    assertIdentical(error.name, "InvalidLambdaResponseException");
+    assertStringIncludes(
+      error.message,
+      "whose emailMessage is a number rather than a string",
+    );
+  });
+
+  it("keeps the pool's wording where the handler dropped the response", async () => {
+    // Given a handler that answers with the request half alone, which real
+    // Cognito accepts.
+    const pool = await makeMessagePool((event: unknown) => ({
+      request: (event as { request: object }).request,
+    }));
+
+    // When a user signs itself up.
+    await pool.cognito.signUp(
+      new SignUpCommand({
+        ClientId: pool.clientId,
+        Username: "alice",
+        Password: password,
+        UserAttributes: [{ Name: "email", Value: "alice@example.com" }],
+      }),
+    );
+
+    // Then the pool's own wording is what was recorded: a handler that wrote
+    // nothing has not changed the message.
+    const [message] = pool.cognito.userPool(pool.userPoolId).sentMessages();
+    assertNonNullable(message);
+    assertIdentical(message.subject, "Your verification code");
+  });
+
+  it("fails a sign-up whose trigger function cannot be invoked", async () => {
+    // Given a pool whose trigger function was never granted the invoke
+    // permission a CDK addTrigger emits.
+    const pool = await makeTriggerPool({
+      triggers: { CustomMessage: triggerFunctionArn },
+      autoVerifiedAttributes: ["email"],
+      permitted: false,
+    });
+
+    // When a user signs itself up.
+    const error = await signUp(pool);
+
+    // Then the trigger failed for the permission it is missing, naming the
+    // pool whose resource policy has to admit Cognito.
+    assertIdentical(error.name, "UnexpectedLambdaException");
+    assertStringIncludes(error.message, "CustomMessage trigger of user pool");
+  });
+});

--- a/src/service/cognito/user-pool/trigger/sim-cognito-custom-message-failures.iso.test.ts
+++ b/src/service/cognito/user-pool/trigger/sim-cognito-custom-message-failures.iso.test.ts
@@ -1,4 +1,3 @@
-import { SignUpCommand } from "@aws-sdk/client-cognito-identity-provider";
 import {
   assertArrayEquals,
   assertIdentical,
@@ -10,12 +9,11 @@ import { describe, it } from "vitest";
 
 import {
   makeTriggerPool,
+  signUpTriggerUser,
   triggerFunctionArn,
   type SimCognitoTriggerPool,
 } from "../../../../../test/cognito/trigger-fixture.js";
 import type { SimLambdaHandler } from "../../../lambda/function/sim-lambda-handler.type.js";
-
-const password = "Sup3rSecret!";
 
 /**
  * A pool that verifies an email address and runs a CustomMessage handler that
@@ -31,17 +29,8 @@ async function makeMessagePool(
   });
 }
 
-async function signUp(pool: SimCognitoTriggerPool): Promise<Error> {
-  return await assertThrowsErrorAsync(async () =>
-    pool.cognito.signUp(
-      new SignUpCommand({
-        ClientId: pool.clientId,
-        Username: "alice",
-        Password: password,
-        UserAttributes: [{ Name: "email", Value: "alice@example.com" }],
-      }),
-    ),
-  );
+async function refusedSignUp(pool: SimCognitoTriggerPool): Promise<Error> {
+  return await assertThrowsErrorAsync(async () => signUpTriggerUser(pool));
 }
 
 describe("sim Cognito CustomMessage trigger failures", () => {
@@ -52,7 +41,7 @@ describe("sim Cognito CustomMessage trigger failures", () => {
     });
 
     // When a user signs itself up.
-    const error = await signUp(pool);
+    const error = await refusedSignUp(pool);
 
     // Then the request failed on the trigger, carrying the handler's own
     // words.
@@ -78,7 +67,7 @@ describe("sim Cognito CustomMessage trigger failures", () => {
     }));
 
     // When a user signs itself up.
-    const error = await signUp(pool);
+    const error = await refusedSignUp(pool);
 
     // Then it is refused rather than the string being read as a message.
     assertIdentical(error.name, "InvalidLambdaResponseException");
@@ -93,7 +82,7 @@ describe("sim Cognito CustomMessage trigger failures", () => {
     }));
 
     // When a user signs itself up.
-    const error = await signUp(pool);
+    const error = await refusedSignUp(pool);
 
     // Then it is refused, naming the field and what it was given, rather than
     // recording a message the pool could never have sent.
@@ -112,14 +101,7 @@ describe("sim Cognito CustomMessage trigger failures", () => {
     }));
 
     // When a user signs itself up.
-    await pool.cognito.signUp(
-      new SignUpCommand({
-        ClientId: pool.clientId,
-        Username: "alice",
-        Password: password,
-        UserAttributes: [{ Name: "email", Value: "alice@example.com" }],
-      }),
-    );
+    await signUpTriggerUser(pool);
 
     // Then the pool's own wording is what was recorded: a handler that wrote
     // nothing has not changed the message.
@@ -138,7 +120,7 @@ describe("sim Cognito CustomMessage trigger failures", () => {
     });
 
     // When a user signs itself up.
-    const error = await signUp(pool);
+    const error = await refusedSignUp(pool);
 
     // Then the trigger failed for the permission it is missing, naming the
     // pool whose resource policy has to admit Cognito.

--- a/src/service/cognito/user-pool/trigger/sim-cognito-custom-message.iso.test.ts
+++ b/src/service/cognito/user-pool/trigger/sim-cognito-custom-message.iso.test.ts
@@ -1,0 +1,252 @@
+import {
+  AdminCreateUserCommand,
+  ResendConfirmationCodeCommand,
+  SignUpCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertObjectMatches,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import {
+  makeTriggerPool,
+  triggerFunctionArn,
+  type SimCognitoTriggerPool,
+} from "../../../../../test/cognito/trigger-fixture.js";
+import type { SimCognitoSentMessage } from "../message/sim-cognito-sent-message.js";
+
+/** The password the user in each of these signs up with. */
+const password = "Sup3rSecret!";
+
+/**
+ * The parts of a `CustomMessage` event a handler here reads.
+ */
+interface CustomMessageEvent {
+  readonly request: {
+    readonly codeParameter: string;
+    readonly usernameParameter?: string | undefined;
+  };
+}
+
+/**
+ * Record every event the handler is given, and hand the event back untouched,
+ * which is what a handler with nothing to say has to do.
+ */
+function recordingHandler(events: unknown[]): (event: unknown) => unknown {
+  return (event: unknown) => {
+    events.push(structuredClone(event));
+
+    return event;
+  };
+}
+
+/**
+ * Write a message of the handler's own, with the code placeholder in it where
+ * the code belongs.
+ */
+function writingHandler(event: unknown): unknown {
+  const { request } = event as CustomMessageEvent;
+
+  return {
+    ...(event as object),
+    response: {
+      emailSubject: "Welcome to Acme",
+      emailMessage: `Your Acme code is ${request.codeParameter}`,
+      smsMessage: `Acme: ${request.codeParameter}`,
+    },
+  };
+}
+
+async function signUp(pool: SimCognitoTriggerPool): Promise<void> {
+  await pool.cognito.signUp(
+    new SignUpCommand({
+      ClientId: pool.clientId,
+      Username: "alice",
+      Password: password,
+      UserAttributes: [{ Name: "email", Value: "alice@example.com" }],
+    }),
+  );
+}
+
+function sentBy(pool: SimCognitoTriggerPool): readonly SimCognitoSentMessage[] {
+  return pool.cognito.userPool(pool.userPoolId).sentMessages();
+}
+
+function codeIn(pool: SimCognitoTriggerPool): string {
+  const code = pool.cognito.userPool(pool.userPoolId).confirmationCode("alice");
+  assertNonNullable(code);
+
+  return code;
+}
+
+/**
+ * A pool that verifies an email address and runs a CustomMessage trigger.
+ */
+async function makeMessagePool(
+  handler: (event: unknown) => unknown,
+): Promise<SimCognitoTriggerPool> {
+  return await makeTriggerPool({
+    triggers: { CustomMessage: triggerFunctionArn },
+    autoVerifiedAttributes: ["email"],
+    handler,
+  });
+}
+
+describe("sim Cognito CustomMessage trigger", () => {
+  it("invokes the handler with the sign-up event", async () => {
+    // Given a pool whose CustomMessage trigger records what it is given.
+    const events: unknown[] = [];
+    const pool = await makeMessagePool(recordingHandler(events));
+
+    // When a user signs itself up.
+    await signUp(pool);
+
+    // Then the handler was given the real event, naming the occasion, the
+    // pool, the app client the sign-up came through and the user.
+    assertObjectMatches(events[0], {
+      version: "1",
+      region: pool.simAws.defaultRegionName,
+      userPoolId: pool.userPoolId,
+      userName: "alice",
+      triggerSource: "CustomMessage_SignUp",
+      callerContext: { clientId: pool.clientId },
+      request: {
+        userAttributes: { email: "alice@example.com" },
+        // The placeholder rather than the code, as real Cognito passes it: the
+        // handler writes it into its message and the code goes in afterwards.
+        codeParameter: "{####}",
+      },
+      response: {},
+    });
+  });
+
+  it("records the message the handler wrote", async () => {
+    // Given a pool whose handler writes a message of its own.
+    const pool = await makeMessagePool(writingHandler);
+
+    // When a user signs itself up.
+    await signUp(pool);
+
+    // Then the recorded message says what the handler wrote rather than what
+    // the pool would have said.
+    const [message] = sentBy(pool);
+    assertNonNullable(message);
+    assertIdentical(message.subject, "Welcome to Acme");
+
+    // And the code parameter the handler wrote into it carries the real code.
+    assertIdentical(message.body, `Your Acme code is ${codeIn(pool)}`);
+  });
+
+  it("names the occasion a resent code fired on", async () => {
+    // Given a signed-up user of a pool with the trigger on it.
+    const events: unknown[] = [];
+    const pool = await makeMessagePool(recordingHandler(events));
+    await signUp(pool);
+
+    // When the user asks for its code again.
+    await pool.cognito.resendConfirmationCode(
+      new ResendConfirmationCodeCommand({
+        ClientId: pool.clientId,
+        Username: "alice",
+      }),
+    );
+
+    // Then the handler can tell the two occasions apart by their source.
+    assertObjectMatches(events[1], {
+      triggerSource: "CustomMessage_ResendCode",
+    });
+  });
+
+  it("names the occasion an invitation fired on", async () => {
+    // Given a pool with the trigger on it.
+    const events: unknown[] = [];
+    const pool = await makeMessagePool(recordingHandler(events));
+
+    // When an administrator creates a user.
+    await pool.cognito.adminCreateUser(
+      new AdminCreateUserCommand({
+        UserPoolId: pool.userPoolId,
+        Username: "alice",
+        TemporaryPassword: "Temp0rary!",
+        UserAttributes: [{ Name: "email", Value: "alice@example.com" }],
+      }),
+    );
+
+    // Then the event names the invitation, carries the username placeholder
+    // the invitation wording uses, and reports no app client: an admin
+    // operation comes through none, and real Cognito says so rather than
+    // inventing one.
+    assertObjectMatches(events[0], {
+      triggerSource: "CustomMessage_AdminCreateUser",
+      callerContext: { clientId: "CLIENT_ID_NOT_APPLICABLE" },
+      request: { codeParameter: "{####}", usernameParameter: "{username}" },
+    });
+  });
+
+  it("writes the text message for a user with a phone number", async () => {
+    // Given a pool that verifies a phone number and writes its own messages.
+    const pool = await makeTriggerPool({
+      triggers: { CustomMessage: triggerFunctionArn },
+      autoVerifiedAttributes: ["phone_number"],
+      handler: writingHandler,
+    });
+
+    // When a user with a phone number signs itself up.
+    await pool.cognito.signUp(
+      new SignUpCommand({
+        ClientId: pool.clientId,
+        Username: "alice",
+        Password: password,
+        UserAttributes: [{ Name: "phone_number", Value: "+447700900123" }],
+      }),
+    );
+
+    // Then the message the handler wrote for SMS is the one recorded, and the
+    // subject it wrote for email reaches nothing.
+    const [message] = sentBy(pool);
+    assertNonNullable(message);
+    assertIdentical(message.medium, "SMS");
+    assertIdentical(message.body, `Acme: ${codeIn(pool)}`);
+    assertUndefined(message.subject);
+  });
+
+  it("passes the request's ClientMetadata to the handler", async () => {
+    // Given a pool with the trigger on it.
+    const events: unknown[] = [];
+    const pool = await makeMessagePool(recordingHandler(events));
+
+    // When the sign-up carries ClientMetadata, which used to be refused.
+    await pool.cognito.signUp(
+      new SignUpCommand({
+        ClientId: pool.clientId,
+        Username: "alice",
+        Password: password,
+        UserAttributes: [{ Name: "email", Value: "alice@example.com" }],
+        ClientMetadata: { tenant: "acme" },
+      }),
+    );
+
+    // Then the handler reads it, which is what it is sent for.
+    assertObjectMatches(events[0], {
+      request: { clientMetadata: { tenant: "acme" } },
+    });
+  });
+
+  it("keeps the pool's wording where the handler wrote none", async () => {
+    // Given a pool whose handler returns the event untouched.
+    const pool = await makeMessagePool((event: unknown) => event);
+
+    // When a user signs itself up.
+    await signUp(pool);
+
+    // Then the pool's own wording is what was recorded, as it is for a pool
+    // with no trigger at all.
+    const [message] = sentBy(pool);
+    assertNonNullable(message);
+    assertIdentical(message.subject, "Your verification code");
+    assertIdentical(message.body, `Your verification code is ${codeIn(pool)}`);
+  });
+});

--- a/src/service/cognito/user-pool/trigger/sim-cognito-custom-message.iso.test.ts
+++ b/src/service/cognito/user-pool/trigger/sim-cognito-custom-message.iso.test.ts
@@ -1,10 +1,11 @@
 import {
   AdminCreateUserCommand,
   ResendConfirmationCodeCommand,
-  SignUpCommand,
 } from "@aws-sdk/client-cognito-identity-provider";
 import {
+  assertArrayEquals,
   assertIdentical,
+  assertTrue,
   assertNonNullable,
   assertObjectMatches,
   assertUndefined,
@@ -13,13 +14,13 @@ import { describe, it } from "vitest";
 
 import {
   makeTriggerPool,
+  signUpTriggerUser,
   triggerFunctionArn,
+  triggerUsername,
   type SimCognitoTriggerPool,
 } from "../../../../../test/cognito/trigger-fixture.js";
+import { recordingTriggerHandler } from "../../../../../test/cognito/trigger-handler-fixture.js";
 import type { SimCognitoSentMessage } from "../message/sim-cognito-sent-message.js";
-
-/** The password the user in each of these signs up with. */
-const password = "Sup3rSecret!";
 
 /**
  * The parts of a `CustomMessage` event a handler here reads.
@@ -28,18 +29,6 @@ interface CustomMessageEvent {
   readonly request: {
     readonly codeParameter: string;
     readonly usernameParameter?: string | undefined;
-  };
-}
-
-/**
- * Record every event the handler is given, and hand the event back untouched,
- * which is what a handler with nothing to say has to do.
- */
-function recordingHandler(events: unknown[]): (event: unknown) => unknown {
-  return (event: unknown) => {
-    events.push(structuredClone(event));
-
-    return event;
   };
 }
 
@@ -60,23 +49,14 @@ function writingHandler(event: unknown): unknown {
   };
 }
 
-async function signUp(pool: SimCognitoTriggerPool): Promise<void> {
-  await pool.cognito.signUp(
-    new SignUpCommand({
-      ClientId: pool.clientId,
-      Username: "alice",
-      Password: password,
-      UserAttributes: [{ Name: "email", Value: "alice@example.com" }],
-    }),
-  );
-}
-
 function sentBy(pool: SimCognitoTriggerPool): readonly SimCognitoSentMessage[] {
   return pool.cognito.userPool(pool.userPoolId).sentMessages();
 }
 
 function codeIn(pool: SimCognitoTriggerPool): string {
-  const code = pool.cognito.userPool(pool.userPoolId).confirmationCode("alice");
+  const code = pool.cognito
+    .userPool(pool.userPoolId)
+    .confirmationCode(triggerUsername);
   assertNonNullable(code);
 
   return code;
@@ -99,10 +79,10 @@ describe("sim Cognito CustomMessage trigger", () => {
   it("invokes the handler with the sign-up event", async () => {
     // Given a pool whose CustomMessage trigger records what it is given.
     const events: unknown[] = [];
-    const pool = await makeMessagePool(recordingHandler(events));
+    const pool = await makeMessagePool(recordingTriggerHandler(events));
 
     // When a user signs itself up.
-    await signUp(pool);
+    await signUpTriggerUser(pool);
 
     // Then the handler was given the real event, naming the occasion, the
     // pool, the app client the sign-up came through and the user.
@@ -128,7 +108,7 @@ describe("sim Cognito CustomMessage trigger", () => {
     const pool = await makeMessagePool(writingHandler);
 
     // When a user signs itself up.
-    await signUp(pool);
+    await signUpTriggerUser(pool);
 
     // Then the recorded message says what the handler wrote rather than what
     // the pool would have said.
@@ -143,8 +123,8 @@ describe("sim Cognito CustomMessage trigger", () => {
   it("names the occasion a resent code fired on", async () => {
     // Given a signed-up user of a pool with the trigger on it.
     const events: unknown[] = [];
-    const pool = await makeMessagePool(recordingHandler(events));
-    await signUp(pool);
+    const pool = await makeMessagePool(recordingTriggerHandler(events));
+    await signUpTriggerUser(pool);
 
     // When the user asks for its code again.
     await pool.cognito.resendConfirmationCode(
@@ -163,7 +143,7 @@ describe("sim Cognito CustomMessage trigger", () => {
   it("names the occasion an invitation fired on", async () => {
     // Given a pool with the trigger on it.
     const events: unknown[] = [];
-    const pool = await makeMessagePool(recordingHandler(events));
+    const pool = await makeMessagePool(recordingTriggerHandler(events));
 
     // When an administrator creates a user.
     await pool.cognito.adminCreateUser(
@@ -195,14 +175,9 @@ describe("sim Cognito CustomMessage trigger", () => {
     });
 
     // When a user with a phone number signs itself up.
-    await pool.cognito.signUp(
-      new SignUpCommand({
-        ClientId: pool.clientId,
-        Username: "alice",
-        Password: password,
-        UserAttributes: [{ Name: "phone_number", Value: "+447700900123" }],
-      }),
-    );
+    await signUpTriggerUser(pool, {
+      UserAttributes: [{ Name: "phone_number", Value: "+447700900123" }],
+    });
 
     // Then the message the handler wrote for SMS is the one recorded, and the
     // subject it wrote for email reaches nothing.
@@ -216,18 +191,10 @@ describe("sim Cognito CustomMessage trigger", () => {
   it("passes the request's ClientMetadata to the handler", async () => {
     // Given a pool with the trigger on it.
     const events: unknown[] = [];
-    const pool = await makeMessagePool(recordingHandler(events));
+    const pool = await makeMessagePool(recordingTriggerHandler(events));
 
-    // When the sign-up carries ClientMetadata, which used to be refused.
-    await pool.cognito.signUp(
-      new SignUpCommand({
-        ClientId: pool.clientId,
-        Username: "alice",
-        Password: password,
-        UserAttributes: [{ Name: "email", Value: "alice@example.com" }],
-        ClientMetadata: { tenant: "acme" },
-      }),
-    );
+    // When the sign-up carries ClientMetadata, which reaches the handler.
+    await signUpTriggerUser(pool, { ClientMetadata: { tenant: "acme" } });
 
     // Then the handler reads it, which is what it is sent for.
     assertObjectMatches(events[0], {
@@ -240,7 +207,7 @@ describe("sim Cognito CustomMessage trigger", () => {
     const pool = await makeMessagePool((event: unknown) => event);
 
     // When a user signs itself up.
-    await signUp(pool);
+    await signUpTriggerUser(pool);
 
     // Then the pool's own wording is what was recorded, as it is for a pool
     // with no trigger at all.
@@ -248,5 +215,40 @@ describe("sim Cognito CustomMessage trigger", () => {
     assertNonNullable(message);
     assertIdentical(message.subject, "Your verification code");
     assertIdentical(message.body, `Your verification code is ${codeIn(pool)}`);
+  });
+
+  it("sends nothing for a sign-up PreSignUp confirmed itself", async () => {
+    // Given a pool whose PreSignUp trigger confirms the user, and whose
+    // CustomMessage trigger would write a message if it ran.
+    const events: unknown[] = [];
+    const pool = await makeTriggerPool({
+      triggers: {
+        PreSignUp: triggerFunctionArn,
+        CustomMessage: triggerFunctionArn,
+      },
+      autoVerifiedAttributes: ["email"],
+      handler: (event: unknown) => {
+        events.push(structuredClone(event));
+        Object.assign((event as { response: object }).response, {
+          autoConfirmUser: true,
+        });
+
+        return event;
+      },
+    });
+
+    // When a user signs itself up.
+    const signedUp = await signUpTriggerUser(pool);
+
+    // Then the user is confirmed already, so there is no code to send it and
+    // no message was recorded, which is what real Cognito does here.
+    assertTrue(signedUp.UserConfirmed);
+    assertArrayEquals(sentBy(pool), []);
+
+    // And CustomMessage never fired: only PreSignUp did.
+    assertArrayEquals(
+      events.map((event) => (event as { triggerSource: string }).triggerSource),
+      ["PreSignUp_SignUp"],
+    );
   });
 });

--- a/src/service/cognito/user-pool/trigger/sim-cognito-custom-message.ts
+++ b/src/service/cognito/user-pool/trigger/sim-cognito-custom-message.ts
@@ -1,0 +1,121 @@
+import { SimCognitoInvalidLambdaResponseException } from "../../error/sim-cognito-trigger.error.js";
+import type { SimCognitoMessageMedium } from "../message/sim-cognito-sent-message.js";
+import type {
+  SimCognitoMessageWording,
+  SimCognitoWrittenWording,
+} from "../message/sim-cognito-message-wording.js";
+
+/**
+ * The three fields a `CustomMessage` handler writes its message into.
+ *
+ * They are read as `unknown` because they are whatever the handler put there,
+ * and a value that is not a string is refused rather than rendered into a
+ * message.
+ */
+interface SimCognitoCustomMessageAnswer {
+  readonly emailSubject?: unknown;
+  readonly emailMessage?: unknown;
+  readonly smsMessage?: unknown;
+}
+
+/**
+ * The response half of the event a handler returned, or nothing where it wrote
+ * no message.
+ *
+ * A pool with no `CustomMessage` trigger at all returns nothing, and a handler
+ * that dropped the response wrote nothing. Both leave the pool's own wording in
+ * place. A response that is something other than an object is refused: a
+ * handler that put one there meant to say something, and this cannot read it.
+ */
+function answerOf(returned: unknown): SimCognitoCustomMessageAnswer {
+  if (typeof returned !== "object" || returned === null) {
+    return {};
+  }
+
+  const { response } = returned as { response?: unknown };
+
+  if (response === undefined) {
+    return {};
+  }
+
+  if (typeof response !== "object" || response === null) {
+    throw new SimCognitoInvalidLambdaResponseException(
+      `The CustomMessage trigger returned a response that is not an object, ` +
+        `so there is no message in it. A handler writes its message into the ` +
+        `response of the event it was given.`,
+    );
+  }
+
+  return response;
+}
+
+/**
+ * What a `CustomMessage` handler wrote in place of the pool's own wording.
+ *
+ * A handler writes into `response.emailSubject`, `response.emailMessage` and
+ * `response.smsMessage`, and whichever it left alone leaves the pool's wording
+ * in place. A handler that returned the event untouched has written nothing,
+ * which is the ordinary case for a handler that only cares about one occasion.
+ *
+ * The message is not delivered here, so what the handler wrote is what the
+ * pool records.
+ */
+export class SimCognitoCustomMessage {
+  private readonly emailSubject: string | undefined;
+  private readonly emailMessage: string | undefined;
+  private readonly smsMessage: string | undefined;
+
+  constructor(returned: unknown) {
+    const answer = answerOf(returned);
+
+    this.emailSubject = SimCognitoCustomMessage.text(
+      "emailSubject",
+      answer.emailSubject,
+    );
+    this.emailMessage = SimCognitoCustomMessage.text(
+      "emailMessage",
+      answer.emailMessage,
+    );
+    this.smsMessage = SimCognitoCustomMessage.text(
+      "smsMessage",
+      answer.smsMessage,
+    );
+  }
+
+  private static text(field: string, value: unknown): string | undefined {
+    if (value === undefined || typeof value === "string") {
+      return value;
+    }
+
+    throw new SimCognitoInvalidLambdaResponseException(
+      `The CustomMessage trigger returned a response whose ${field} is a ` +
+        `${typeof value} rather than a string, so it is not a message the ` +
+        `pool can send.`,
+    );
+  }
+
+  /**
+   * The pool's wording with what the handler wrote in place of it.
+   */
+  wordingFor(
+    medium: SimCognitoMessageMedium,
+    wording: SimCognitoMessageWording,
+  ): SimCognitoMessageWording {
+    return wording.replacedBy(this.writtenFor(medium));
+  }
+
+  /**
+   * What the handler wrote for one medium.
+   *
+   * A text message has no subject, so `emailSubject` reaches an email only.
+   */
+  private writtenFor(
+    medium: SimCognitoMessageMedium,
+  ): SimCognitoWrittenWording {
+    if (medium === "SMS") {
+      return { body: this.smsMessage };
+    }
+
+    return { subject: this.emailSubject, body: this.emailMessage };
+  }
+}

--- a/src/service/cognito/user-pool/trigger/sim-cognito-lambda-config.iso.test.ts
+++ b/src/service/cognito/user-pool/trigger/sim-cognito-lambda-config.iso.test.ts
@@ -151,7 +151,7 @@ describe("sim Cognito user pool LambdaConfig", () => {
           PoolName: "myapp-users",
           LambdaConfig: {
             PreAuthentication: triggerFunctionArn,
-            CustomMessage: otherFunctionArn,
+            UserMigration: otherFunctionArn,
           },
         }),
       ),
@@ -162,11 +162,11 @@ describe("sim Cognito user pool LambdaConfig", () => {
     assertIdentical(error.name, "InvalidParameterException");
     assertStringIncludes(
       error.message,
-      "CreateUserPool LambdaConfig CustomMessage is not simulated",
+      "CreateUserPool LambdaConfig UserMigration is not simulated",
     );
     assertStringIncludes(
       error.message,
-      "writing the wording of a message the pool sends",
+      "importing a user from an external directory on first sign-in",
     );
   });
 

--- a/src/service/cognito/user-pool/trigger/sim-cognito-lambda-config.ts
+++ b/src/service/cognito/user-pool/trigger/sim-cognito-lambda-config.ts
@@ -17,6 +17,7 @@ export interface SimCognitoLambdaConfigType {
   readonly PreAuthentication?: string | undefined;
   readonly PostAuthentication?: string | undefined;
   readonly PreTokenGeneration?: string | undefined;
+  readonly CustomMessage?: string | undefined;
 }
 
 /**
@@ -25,7 +26,7 @@ export interface SimCognitoLambdaConfigType {
  * A trigger is held as the function ARN the request named, and nothing is
  * looked up here: the function is resolved when the trigger fires, so a pool
  * can be created before the function it names and a function deleted
- * afterwards fails the sign-in rather than the pool.
+ * afterwards fails the request rather than the pool.
  *
  * Every other `LambdaConfig` key real Cognito has is refused, naming the
  * trigger and saying why, so a pool never quietly drops one. That is the whole

--- a/src/service/cognito/user-pool/trigger/sim-cognito-trigger-event.ts
+++ b/src/service/cognito/user-pool/trigger/sim-cognito-trigger-event.ts
@@ -71,9 +71,7 @@ export class SimCognitoTriggerEvent {
         clientId: this.context.client?.id ?? adminCallerClientId,
       },
       triggerSource: occasion.source,
-      request: new SimCognitoTriggerRequest(this.context).document(
-        occasion.trigger,
-      ),
+      request: new SimCognitoTriggerRequest(this.context).document(occasion),
       response: SimCognitoTriggerEvent.response(occasion.trigger),
     };
   }

--- a/src/service/cognito/user-pool/trigger/sim-cognito-trigger-name.ts
+++ b/src/service/cognito/user-pool/trigger/sim-cognito-trigger-name.ts
@@ -1,11 +1,10 @@
 /**
  * The Lambda triggers a simulated user pool runs.
  *
- * These are the ones that fire around a sign-up, around a sign-in, and over the
- * tokens a sign-in hands out, which is the part of a user's life this
- * simulation has. A pool sends no messages and federates with nobody, so the
- * message and federation triggers would never run whatever a pool named for
- * them.
+ * These are the ones that fire around a sign-up, around a sign-in, around a
+ * message, and over the tokens a sign-in hands out, which is the part of a
+ * user's life this simulation has. A pool federates with nobody, so the
+ * federation triggers would never run whatever a pool named for them.
  */
 export const simCognitoTriggerNames = [
   "PreSignUp",
@@ -13,6 +12,7 @@ export const simCognitoTriggerNames = [
   "PreAuthentication",
   "PostAuthentication",
   "PreTokenGeneration",
+  "CustomMessage",
 ] as const;
 
 export type SimCognitoTriggerName = (typeof simCognitoTriggerNames)[number];
@@ -33,7 +33,6 @@ export const simCognitoUnsimulatedTriggers: ReadonlyMap<string, string> =
         "and scopes. Name the function in PreTokenGeneration for the V1_0 " +
         "trigger, which customises the id token",
     ],
-    ["CustomMessage", "writing the wording of a message the pool sends"],
     ["DefineAuthChallenge", "the custom authentication challenge flow"],
     ["CreateAuthChallenge", "the custom authentication challenge flow"],
     ["VerifyAuthChallengeResponse", "the custom authentication challenge flow"],

--- a/src/service/cognito/user-pool/trigger/sim-cognito-trigger-occasion.ts
+++ b/src/service/cognito/user-pool/trigger/sim-cognito-trigger-occasion.ts
@@ -1,3 +1,4 @@
+import type { SimCognitoMessageOccasion } from "../message/sim-cognito-message-occasion.js";
 import type { SimCognitoTriggerName } from "./sim-cognito-trigger-name.js";
 
 /**
@@ -95,11 +96,57 @@ export class SimCognitoTriggerOccasion {
     "TokenGeneration_RefreshTokens",
   );
 
+  /**
+   * The verification message a user signing itself up is sent.
+   */
+  public static readonly customMessageSignUp = new SimCognitoTriggerOccasion(
+    "CustomMessage",
+    "CustomMessage_SignUp",
+  );
+
+  /**
+   * The verification message a user asking for another code is sent.
+   */
+  public static readonly customMessageResendCode =
+    new SimCognitoTriggerOccasion("CustomMessage", "CustomMessage_ResendCode");
+
+  /**
+   * The invitation an admin-created user is sent.
+   */
+  public static readonly customMessageAdminCreateUser =
+    new SimCognitoTriggerOccasion(
+      "CustomMessage",
+      "CustomMessage_AdminCreateUser",
+    );
+
   public readonly trigger: SimCognitoTriggerName;
   public readonly source: string;
 
   private constructor(trigger: SimCognitoTriggerName, source: string) {
     this.trigger = trigger;
     this.source = source;
+  }
+
+  /**
+   * The `CustomMessage` occasion a message is being sent on.
+   *
+   * One trigger covers all three, and the source is the only thing telling a
+   * handler which it is firing for, so an application customising one message
+   * and not another branches on it.
+   */
+  static customMessage(
+    occasion: SimCognitoMessageOccasion,
+  ): SimCognitoTriggerOccasion {
+    switch (occasion) {
+      case "SignUp": {
+        return SimCognitoTriggerOccasion.customMessageSignUp;
+      }
+      case "ResendCode": {
+        return SimCognitoTriggerOccasion.customMessageResendCode;
+      }
+      case "AdminCreateUser": {
+        return SimCognitoTriggerOccasion.customMessageAdminCreateUser;
+      }
+    }
   }
 }

--- a/src/service/cognito/user-pool/trigger/sim-cognito-trigger-occasion.ts
+++ b/src/service/cognito/user-pool/trigger/sim-cognito-trigger-occasion.ts
@@ -139,13 +139,13 @@ export class SimCognitoTriggerOccasion {
   ): SimCognitoTriggerOccasion {
     switch (occasion) {
       case "SignUp": {
-        return SimCognitoTriggerOccasion.customMessageSignUp;
+        return this.customMessageSignUp;
       }
       case "ResendCode": {
-        return SimCognitoTriggerOccasion.customMessageResendCode;
+        return this.customMessageResendCode;
       }
       case "AdminCreateUser": {
-        return SimCognitoTriggerOccasion.customMessageAdminCreateUser;
+        return this.customMessageAdminCreateUser;
       }
     }
   }

--- a/src/service/cognito/user-pool/trigger/sim-cognito-trigger-request.ts
+++ b/src/service/cognito/user-pool/trigger/sim-cognito-trigger-request.ts
@@ -1,5 +1,9 @@
+import {
+  simCognitoCodeParameter,
+  simCognitoUsernameParameter,
+} from "../message/sim-cognito-message-placeholders.js";
 import type { SimCognitoTriggerContext } from "./sim-cognito-trigger-context.js";
-import type { SimCognitoTriggerName } from "./sim-cognito-trigger-name.js";
+import { SimCognitoTriggerOccasion } from "./sim-cognito-trigger-occasion.js";
 
 /**
  * The `request` half of the event one trigger is given.
@@ -18,10 +22,13 @@ export class SimCognitoTriggerRequest {
   }
 
   /**
-   * The request for one trigger.
+   * The request for one occasion.
+   *
+   * Only `CustomMessage` reads the occasion rather than the trigger: it covers
+   * three of them, and the invitation is the one that names the user.
    */
-  document(trigger: SimCognitoTriggerName): object {
-    switch (trigger) {
+  document(occasion: SimCognitoTriggerOccasion): object {
+    switch (occasion.trigger) {
       case "PreSignUp": {
         return this.preSignUp();
       }
@@ -36,6 +43,9 @@ export class SimCognitoTriggerRequest {
       }
       case "PreTokenGeneration": {
         return this.preTokenGeneration();
+      }
+      case "CustomMessage": {
+        return this.customMessage(occasion);
       }
     }
   }
@@ -89,6 +99,29 @@ export class SimCognitoTriggerRequest {
    */
   private postConfirmation(): object {
     return { userAttributes: this.userAttributes(), ...this.clientMetadata() };
+  }
+
+  /**
+   * What a `CustomMessage` handler is given.
+   *
+   * `codeParameter` is the placeholder rather than the code, as it is on real
+   * Cognito: a handler writes it into the message it returns and the code goes
+   * in afterwards. `usernameParameter` is there for the invitation an
+   * administrator's user is sent, which is the message that names the user.
+   *
+   * There is no `linkParameter`. Real Cognito passes one for a pool verifying
+   * by link, and `CONFIRM_WITH_LINK` is refused here, so a handler given one
+   * would be writing a link into a message no simulation ever follows.
+   */
+  private customMessage(occasion: SimCognitoTriggerOccasion): object {
+    return {
+      userAttributes: this.userAttributes(),
+      codeParameter: simCognitoCodeParameter,
+      ...(occasion === SimCognitoTriggerOccasion.customMessageAdminCreateUser && {
+        usernameParameter: simCognitoUsernameParameter,
+      }),
+      ...this.clientMetadata(),
+    };
   }
 
   private preAuthentication(): object {

--- a/src/service/cognito/user-pool/trigger/sim-cognito-trigger-request.ts
+++ b/src/service/cognito/user-pool/trigger/sim-cognito-trigger-request.ts
@@ -117,7 +117,8 @@ export class SimCognitoTriggerRequest {
     return {
       userAttributes: this.userAttributes(),
       codeParameter: simCognitoCodeParameter,
-      ...(occasion === SimCognitoTriggerOccasion.customMessageAdminCreateUser && {
+      ...(occasion ===
+        SimCognitoTriggerOccasion.customMessageAdminCreateUser && {
         usernameParameter: simCognitoUsernameParameter,
       }),
       ...this.clientMetadata(),

--- a/src/service/cognito/user-pool/trigger/sim-cognito-user-pool-triggers.ts
+++ b/src/service/cognito/user-pool/trigger/sim-cognito-user-pool-triggers.ts
@@ -1,5 +1,6 @@
 import type { SimCognitoClaimsOverride } from "../token/sim-cognito-claims-override.js";
 import { SimCognitoClaimsOverrideReader } from "../token/sim-cognito-claims-override-reader.js";
+import { SimCognitoCustomMessage } from "./sim-cognito-custom-message.js";
 import { SimCognitoPreSignUpResponse } from "./sim-cognito-pre-sign-up-response.js";
 import type { SimCognitoTriggerContext } from "./sim-cognito-trigger-context.js";
 import type { SimCognitoTriggerFunctions } from "./sim-cognito-trigger-functions.js";
@@ -57,6 +58,24 @@ export class SimCognitoUserPoolTriggers {
    */
   async postConfirmation(context: SimCognitoTriggerContext): Promise<void> {
     await this.invocation.run(SimCognitoTriggerOccasion.confirmSignUp, context);
+  }
+
+  /**
+   * Run the `CustomMessage` trigger, if the pool has one, and read what it
+   * wrote.
+   *
+   * This runs before the message is recorded, so a handler that throws leaves
+   * the pool with no message rather than with the wording it was about to use.
+   * A pool without the trigger, and a handler that wrote nothing, both read as
+   * having left the pool's own wording alone.
+   */
+  async customMessage(
+    occasion: SimCognitoTriggerOccasion,
+    context: SimCognitoTriggerContext,
+  ): Promise<SimCognitoCustomMessage> {
+    return new SimCognitoCustomMessage(
+      await this.invocation.run(occasion, context),
+    );
   }
 
   /**

--- a/src/service/cognito/user-pool/user/sim-cognito-user-factory.ts
+++ b/src/service/cognito/user-pool/user/sim-cognito-user-factory.ts
@@ -1,5 +1,7 @@
 import { randomUUID } from "node:crypto";
 import type { SimClock } from "../../../../util/clock/sim-clock.js";
+import { SimCognitoPasswordCheck } from "../sim-cognito-password-check.js";
+import type { SimCognitoPasswordPolicy } from "../sim-cognito-password-policy.js";
 import {
   type SimCognitoAttributeType,
   SimCognitoUserAttributes,
@@ -16,22 +18,30 @@ interface SimCognitoUserFactoryProperties {
 interface SimCognitoMakeUserProperties {
   readonly username: SimCognitoUsername;
   readonly attributes?: readonly SimCognitoAttributeType[] | undefined;
+
   /**
-   * The password the user starts with, already checked against the pool's
-   * policy. A user made without one has no password at all.
+   * The password the user starts with, checked here against the pool's policy.
+   * A user made without one has no password at all.
    */
   readonly temporaryPassword?: string | undefined;
+
+  /** The policy the pool holds its users' passwords to. */
+  readonly passwordPolicy: SimCognitoPasswordPolicy;
 }
 
 interface SimCognitoSignUpUserProperties {
   readonly username: SimCognitoUsername;
   readonly attributes?: readonly SimCognitoAttributeType[] | undefined;
+
   /**
-   * The password the user chose, already checked against the pool's policy.
-   * It is the user's own rather than a temporary one, so the user signs in
-   * with it as soon as it is confirmed.
+   * The password the user chose, checked here against the pool's policy. It is
+   * the user's own rather than a temporary one, so the user signs in with it
+   * as soon as it is confirmed.
    */
-  readonly password: string;
+  readonly password: string | undefined;
+
+  /** The policy the pool holds its users' passwords to. */
+  readonly passwordPolicy: SimCognitoPasswordPolicy;
 }
 
 /**
@@ -44,14 +54,25 @@ export class SimCognitoUserFactory {
     this.clock = properties.clock;
   }
 
+  /**
+   * The password a user starts with, checked against the pool's policy.
+   *
+   * `AdminCreateUser` naming no `TemporaryPassword` leaves the user with no
+   * password at all: real Cognito generates one and sends it to the user, and
+   * the invitation this simulation records carries no password to read.
+   */
   private static passwordFor(
-    temporaryPassword: string | undefined,
+    field: string,
+    given: string | undefined,
+    policy: SimCognitoPasswordPolicy,
   ): SimCognitoUserPassword | undefined {
-    if (temporaryPassword === undefined) {
+    if (given === undefined) {
       return undefined;
     }
 
-    return new SimCognitoUserPassword(temporaryPassword);
+    return new SimCognitoUserPassword(
+      new SimCognitoPasswordCheck(policy).require(field, given),
+    );
   }
 
   /**
@@ -66,7 +87,11 @@ export class SimCognitoUserFactory {
       username: properties.username,
       sub: randomUUID(),
       attributes: new SimCognitoUserAttributes(properties.attributes),
-      password: SimCognitoUserFactory.passwordFor(properties.temporaryPassword),
+      password: SimCognitoUserFactory.passwordFor(
+        "TemporaryPassword",
+        properties.temporaryPassword,
+        properties.passwordPolicy,
+      ),
       clock: this.clock,
     });
   }
@@ -82,7 +107,14 @@ export class SimCognitoUserFactory {
       username: properties.username,
       sub: randomUUID(),
       attributes: new SimCognitoUserAttributes(properties.attributes),
-      password: new SimCognitoUserPassword(properties.password),
+      // The password a user chose is required, where the temporary one an
+      // administrator gives is not.
+      password: new SimCognitoUserPassword(
+        new SimCognitoPasswordCheck(properties.passwordPolicy).require(
+          "Password",
+          properties.password,
+        ),
+      ),
       status: SimCognitoUserStatus.unconfirmed,
       clock: this.clock,
     });


### PR DESCRIPTION
Resolves #429.

Two judgement calls worth a look:

- An invitation for a user created with no `TemporaryPassword` keeps the `{####}` placeholder, because real Cognito generates a password there and this simulation leaves the user with none at all.
- `InviteMessageTemplate` stays refused, so an invitation is recorded at Cognito's default wording. Both are in the Limitations section, along with the note that the default wording comes from the API documentation rather than a live account.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cognito now records email and SMS verification, resend-code, and administrator invitation messages.
  * Added support for customized message content through `CustomMessage` triggers, including placeholder replacement and client metadata.
  * Added a `/messages` endpoint for listing recorded messages.
  * Pool details now display configured verification-message settings.
* **Bug Fixes**
  * Improved delivery selection and handling when recipients or contact methods are unavailable.
* **Documentation**
  * Expanded Cognito documentation, examples, supported functionality, and limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->