### PR TITLE
feat: serve extra file extensions from a mount

### DIFF
--- a/docs/services/s3/README.md
+++ b/docs/services/s3/README.md
@@ -1564,7 +1564,7 @@ Filesystem storage is somewhat restrictive to make it slightly safer:
 - The directory must not be the user's home directory
 - The path must not contain `..`
 - Object keys must not be absolute paths or contain `..`
-- Unsupported file extensions are rejected or ignored
+- Only files whose extension is on a cautious list are served; see below
 - Symlinks are ignored when listing Objects
 - Deletion is refused rather than unlinking a real file
 
@@ -1576,7 +1576,41 @@ when a test needs deletion to work.
 
 When reading files from filesystem-backed storage, Yulin infers common `content-type` metadata from
 file extensions such as `.html`, `.css`, `.js`, `.json`, `.png`, `.svg`, `.txt`, `.xml`, and common
-font and image formats.
+font and image formats. A served file whose extension is not one of those gets
+`application/octet-stream`, which is what S3 reports for an object whose type it was never told.
+That only comes up for an extension a mount named itself, below: no other file is served at all,
+with or without a type.
+
+### Serving a file extension of your own
+
+A mounted Bucket only serves files whose extension is on a cautious list — the web's own types, and
+nothing else — so that pointing a Bucket at a directory cannot be talked into reading whatever else
+happens to be in it. A file with any other extension is not served, and a `GetObject` for it comes
+back as though the file were not there. That is the right default and the wrong answer for a site
+with a data file of its own, so a mount can name the extensions it needs:
+
+```typescript sim-s3-mount-file-extensions
+/**
+ * Serving a data file whose extension is not one of the web's own.
+ */
+
+import path from "node:path";
+
+import { CreateBucketCommand } from "@aws-sdk/client-s3";
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+await simAws.s3().createBucket(new CreateBucketCommand({ Bucket: "site" }));
+
+simAws.s3().mountBucketFilesystem("site", path.join(process.cwd(), "public"), {
+  // A pinyin dictionary ships a binary frequency table beside its text files.
+  additionalFileExtensions: [".freq"],
+});
+```
+
+These are added to the list rather than replacing it, so naming one cannot cost you `.html`, and a
+leading dot is optional. Everything not named is still refused.
 
 ## Standalone SimS3
 

--- a/docs/services/s3/sim-s3-mount-file-extensions.example.ts
+++ b/docs/services/s3/sim-s3-mount-file-extensions.example.ts
@@ -1,0 +1,17 @@
+/**
+ * Serving a data file whose extension is not one of the web's own.
+ */
+
+import path from "node:path";
+
+import { CreateBucketCommand } from "@aws-sdk/client-s3";
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+await simAws.s3().createBucket(new CreateBucketCommand({ Bucket: "site" }));
+
+simAws.s3().mountBucketFilesystem("site", path.join(process.cwd(), "public"), {
+  // A pinyin dictionary ships a binary frequency table beside its text files.
+  additionalFileExtensions: [".freq"],
+});

--- a/src/service/s3/bucket/sim-s3-bucket-access.ts
+++ b/src/service/s3/bucket/sim-s3-bucket-access.ts
@@ -71,7 +71,12 @@ export class SimS3BucketAccess {
     options: SimS3MountFilesystemOptions = {},
   ): void {
     this.required(bucketName).configureSimStorage(
-      new FilesystemS3BucketStorage({ directoryPath }),
+      new FilesystemS3BucketStorage({
+        directoryPath,
+        ...(options.additionalFileExtensions !== undefined && {
+          additionalFileExtensions: options.additionalFileExtensions,
+        }),
+      }),
     );
     this.mountWatches.register(bucketName, directoryPath, options);
   }

--- a/src/service/s3/mount/sim-s3-mount.type.ts
+++ b/src/service/s3/mount/sim-s3-mount.type.ts
@@ -29,4 +29,17 @@ export interface SimS3MountFilesystemOptions {
    * build one reload. The default suits a generator writing its output.
    */
   readonly settleMs?: number | undefined;
+
+  /**
+   * File extensions to serve in addition to the usual web ones.
+   *
+   * A mounted Bucket only serves files whose extension is on a cautious list —
+   * the web's own types, and nothing else — so that pointing a Bucket at a
+   * directory cannot be talked into reading whatever else is in it. A site
+   * serving a data file of its own needs its extension named here: a pinyin
+   * dictionary's `.freq`, a `.wasm` module, a `.pdf`.
+   *
+   * Added to the list rather than replacing it, and a leading dot is optional.
+   */
+  readonly additionalFileExtensions?: readonly string[] | undefined;
 }

--- a/src/service/s3/storage/filesystem/s3-filesystem-allowed.ts
+++ b/src/service/s3/storage/filesystem/s3-filesystem-allowed.ts
@@ -1,0 +1,81 @@
+/**
+ * What filesystem-backed simulated S3 storage will touch.
+ *
+ * The lists themselves, kept apart from the checks in
+ * `s3-filesystem-safety.ts` that apply them: this file answers "what is
+ * allowed" and that one answers "is this allowed", and only this one changes
+ * when the web grows another file type.
+ */
+
+/**
+ * Default directory names that are safe to use as filesystem storage roots.
+ */
+export const defaultAllowedDirectoryNames = [
+  "assets",
+  "build",
+  "dist",
+  "out",
+  "public",
+  "static",
+  "www",
+] as const;
+
+/**
+ * Write an extension the way `path.extname` reports one.
+ *
+ * A caller thinking about their own files says `.freq` or `freq` without
+ * meaning anything by the difference, and gets the same answer either way.
+ *
+ * An empty one is refused rather than normalised. `path.extname` reports `.`
+ * for a name ending in a dot, so normalising `""` to `.` would quietly turn a
+ * stray entry in a mount's list into permission to serve `secret.` — which is
+ * not something anybody asked for by passing an empty string.
+ */
+export function normaliseExtension(extension: string): string {
+  const lowered = extension.trim().toLowerCase();
+
+  if (lowered === "" || lowered === ".") {
+    throw new Error(
+      `Filesystem S3 storage file extension must not be empty. Got: ${JSON.stringify(
+        extension,
+      )}`,
+    );
+  }
+
+  return lowered.startsWith(".") ? lowered : `.${lowered}`;
+}
+
+/**
+ * Cautious list of allowed file extensions for simulated S3 objects. This is to
+ * try and avoid reading or writing other files that might be unsafe.
+ *
+ * A mount adds to this rather than replacing it — see
+ * `additionalFileExtensions` on the mount options. The list is long, general
+ * and the reason the check is worth having, so a project needing one more
+ * extension should not have to restate the other twenty-odd to get it, nor be
+ * able to drop `.html` by forgetting it.
+ */
+export const defaultAllowedObjectFileExtensions = new Set([
+  ".css",
+  ".eot",
+  ".gif",
+  ".htm",
+  ".html",
+  ".ico",
+  ".jpeg",
+  ".jpg",
+  ".js",
+  ".json",
+  ".map",
+  ".mjs",
+  ".otf",
+  ".png",
+  ".svg",
+  ".ttc",
+  ".ttf",
+  ".txt",
+  ".webp",
+  ".woff",
+  ".woff2",
+  ".xml",
+]);

--- a/src/service/s3/storage/filesystem/s3-filesystem-object-metadata.ts
+++ b/src/service/s3/storage/filesystem/s3-filesystem-object-metadata.ts
@@ -7,15 +7,13 @@ import { SimS3ObjectMetadata } from "../../object/s3-object.js";
 export function metadataForFilesystemS3ObjectKey(
   key: string,
 ): SimS3ObjectMetadata {
-  const contentType = contentTypeForFilesystemS3ObjectKey(key);
-
-  /* v8 ignore if -- defensive fallback */
-  if (contentType === undefined) {
-    return new SimS3ObjectMetadata();
-  }
-
   return new SimS3ObjectMetadata({
-    "content-type": contentType,
+    // Octet-stream for anything the table below has never heard of, which is
+    // what S3 reports for an object whose type it was never told. That case
+    // arrives by way of `additionalFileExtensions`: the table is the web's own
+    // types, and the option exists for files that are not one of them.
+    "content-type":
+      contentTypeForFilesystemS3ObjectKey(key) ?? "application/octet-stream",
   });
 }
 

--- a/src/service/s3/storage/filesystem/s3-filesystem-safety.iso.test.ts
+++ b/src/service/s3/storage/filesystem/s3-filesystem-safety.iso.test.ts
@@ -2,9 +2,13 @@ import { describe, it } from "vitest";
 import path from "node:path";
 import { homedir } from "node:os";
 import {
+  assertBufferEqual,
+  assertIdentical,
+  assertNonNullable,
   assertStringIncludes,
   assertThrowsError,
   assertThrowsErrorAsync,
+  assertUndefined,
 } from "@kensio/smartass";
 import { FilesystemS3BucketStorage } from "./s3-filesystem-storage.js";
 import { SimS3Object } from "../../object/s3-object.js";
@@ -113,5 +117,112 @@ describe("Filesystem simulated S3 storage safety", () => {
     });
 
     assertStringIncludes(error.message, "unsupported file extension");
+  });
+
+  it("serves an extension the mount named", async () => {
+    const testDirectory = new TemporaryDirectory();
+    await testDirectory.resolvePath();
+    const storage = new FilesystemS3BucketStorage({
+      directoryPath: testDirectory.join("public"),
+      additionalFileExtensions: [".freq"],
+    });
+
+    await storage.putObject(
+      new SimS3Object({
+        key: "data/standard.freq",
+        body: Buffer.from([0, 1, 2]),
+      }),
+    );
+
+    const stored = await storage.getObject("data/standard.freq");
+
+    assertNonNullable(stored);
+    assertBufferEqual(stored.body, Buffer.from([0, 1, 2]));
+    // What S3 reports for an object whose type it was never told, which is
+    // every extension a mount names for itself.
+    assertIdentical(
+      stored.metadata.values["content-type"],
+      "application/octet-stream",
+    );
+  });
+
+  // A caller thinking about their own files says `.freq` or `freq` without
+  // meaning anything by the difference.
+  it("takes an extension written without its dot", async () => {
+    const testDirectory = new TemporaryDirectory();
+    await testDirectory.resolvePath();
+    const storage = new FilesystemS3BucketStorage({
+      directoryPath: testDirectory.join("public"),
+      additionalFileExtensions: ["FREQ"],
+    });
+
+    await storage.putObject(
+      new SimS3Object({ key: "a.freq", body: Buffer.from([7]) }),
+    );
+
+    assertNonNullable(await storage.getObject("a.freq"));
+  });
+
+  // Adding one extension must not be a way to lose the web's own.
+  it("keeps the default extensions when a mount adds one", async () => {
+    const testDirectory = new TemporaryDirectory();
+    await testDirectory.resolvePath();
+    const storage = new FilesystemS3BucketStorage({
+      directoryPath: testDirectory.join("public"),
+      additionalFileExtensions: [".freq"],
+    });
+
+    await storage.putObject(
+      new SimS3Object({ key: "index.html", body: Buffer.from("<p>hi</p>") }),
+    );
+
+    assertNonNullable(await storage.getObject("index.html"));
+  });
+
+  it("still refuses an extension nobody named", async () => {
+    const testDirectory = new TemporaryDirectory();
+    await testDirectory.resolvePath();
+    const storage = new FilesystemS3BucketStorage({
+      directoryPath: testDirectory.join("public"),
+      additionalFileExtensions: [".freq"],
+    });
+
+    const error = await assertThrowsErrorAsync(async () => {
+      await storage.putObject(
+        new SimS3Object({ key: "secret.pem", body: Buffer.from("secret") }),
+      );
+    });
+
+    assertStringIncludes(error.message, "unsupported file extension");
+  });
+
+  // The GET path rather than the PUT one. A file with an unnamed extension can
+  // already be sitting in the mounted directory, and what a browser asking for
+  // it gets is nothing rather than an error.
+  it("does not serve a file whose extension nobody named", async () => {
+    const testDirectory = new TemporaryDirectory();
+    await testDirectory.resolvePath();
+    await testDirectory.writeFile(["public", "secret.pem"], "secret");
+    const storage = new FilesystemS3BucketStorage({
+      directoryPath: testDirectory.join("public"),
+      additionalFileExtensions: [".freq"],
+    });
+
+    assertUndefined(await storage.getObject("secret.pem"));
+  });
+
+  it("refuses an empty extension rather than widening the list", async () => {
+    const testDirectory = new TemporaryDirectory();
+    await testDirectory.resolvePath();
+
+    const error = assertThrowsError(
+      () =>
+        new FilesystemS3BucketStorage({
+          directoryPath: testDirectory.join("public"),
+          additionalFileExtensions: [" "],
+        }),
+    );
+
+    assertStringIncludes(error.message, "must not be empty");
   });
 });

--- a/src/service/s3/storage/filesystem/s3-filesystem-safety.ts
+++ b/src/service/s3/storage/filesystem/s3-filesystem-safety.ts
@@ -1,8 +1,15 @@
 import { homedir } from "node:os";
 import path from "node:path";
 
+import {
+  defaultAllowedDirectoryNames,
+  defaultAllowedObjectFileExtensions,
+  normaliseExtension,
+} from "./s3-filesystem-allowed.js";
+
 interface FilesystemS3StorageSafetyProperties {
   readonly allowedDirectoryNames?: readonly string[] | undefined;
+  readonly additionalFileExtensions?: readonly string[] | undefined;
 }
 
 /**
@@ -13,10 +20,17 @@ interface FilesystemS3StorageSafetyProperties {
  */
 export class FilesystemS3StorageSafety {
   private readonly allowedDirectoryNames: readonly string[];
+  private readonly allowedFileExtensions: ReadonlySet<string>;
 
   constructor(properties: FilesystemS3StorageSafetyProperties = {}) {
     const { allowedDirectoryNames = defaultAllowedDirectoryNames } = properties;
     this.allowedDirectoryNames = allowedDirectoryNames;
+    this.allowedFileExtensions = new Set([
+      ...defaultAllowedObjectFileExtensions,
+      ...(properties.additionalFileExtensions ?? []).map((extension) =>
+        normaliseExtension(extension),
+      ),
+    ]);
   }
 
   /**
@@ -92,52 +106,10 @@ export class FilesystemS3StorageSafety {
    * Check whether a sim S3 Object key has an allowed file extension.
    */
   isAllowedObjectKeyExtension(key: string): boolean {
-    return allowedObjectFileExtensions.has(path.extname(key).toLowerCase());
+    return this.allowedFileExtensions.has(path.extname(key).toLowerCase());
   }
 
   private pathContainsParentDirectorySegment(value: string): boolean {
     return value.split(/[\\/]/u).includes("..");
   }
 }
-
-/**
- * Default directory names that are safe to use as filesystem storage roots.
- */
-const defaultAllowedDirectoryNames = [
-  "assets",
-  "build",
-  "dist",
-  "out",
-  "public",
-  "static",
-  "www",
-] as const;
-
-/**
- * Cautious list of allowed file extensions for simulated S3 objects. This is to
- * try and avoid reading or writing other files that might be unsafe.
- */
-const allowedObjectFileExtensions = new Set([
-  ".css",
-  ".eot",
-  ".gif",
-  ".htm",
-  ".html",
-  ".ico",
-  ".jpeg",
-  ".jpg",
-  ".js",
-  ".json",
-  ".map",
-  ".mjs",
-  ".otf",
-  ".png",
-  ".svg",
-  ".ttc",
-  ".ttf",
-  ".txt",
-  ".webp",
-  ".woff",
-  ".woff2",
-  ".xml",
-]);

--- a/src/service/s3/storage/filesystem/s3-filesystem-storage.ts
+++ b/src/service/s3/storage/filesystem/s3-filesystem-storage.ts
@@ -11,6 +11,7 @@ import { SimS3NotImplemented } from "../../error/sim-s3.error.js";
 interface FilesystemS3BucketStorageProperties {
   readonly directoryPath: string;
   readonly allowedDirectoryNames?: readonly string[];
+  readonly additionalFileExtensions?: readonly string[];
 }
 
 /**
@@ -29,6 +30,7 @@ export class FilesystemS3BucketStorage implements SimS3BucketStorage {
   constructor(properties: FilesystemS3BucketStorageProperties) {
     this.safety = new FilesystemS3StorageSafety({
       allowedDirectoryNames: properties.allowedDirectoryNames,
+      additionalFileExtensions: properties.additionalFileExtensions,
     });
     this.safety.assertSafeDirectoryPath(properties.directoryPath);
     this.directoryPath = path.resolve(properties.directoryPath);


### PR DESCRIPTION
A mounted Bucket serves files whose extension is on a cautious list of the web's
own types, so that pointing a Bucket at a directory cannot be talked into
reading whatever else is in it. Anything else is not served, and a `GetObject`
for it comes back as though the file were not there.

That is the right default and the wrong answer for a site with a data file of
its own. ChineseBoost serves a pinyin dictionary as three static files — two of
text, one a binary frequency table named `.freq` — and the frequency table was
the single thing the simulated site could not load, so the page came up and then
reported that its dictionary had failed.

## What changes

A mount can name the extensions it needs:

```typescript
simAws.s3().mountBucketFilesystem("site", directory, {
  additionalFileExtensions: [".freq"],
});
```

**Added to the default list rather than replacing it**, which is the one place
this departs from `allowedDirectoryNames` sitting beside it. That list is short
and worth replacing wholesale. This one is long, general, and the reason the
check earns its keep — so a project wanting one more extension should not have
to restate the other twenty-odd, nor be able to drop `.html` by forgetting it.
A leading dot is optional, since nobody means anything by the difference.

Two things follow:

- An extension the content-type table has never heard of is now reachable, and
  is served as `application/octet-stream` rather than with no type at all. That
  is what S3 reports for an object whose type it was never told, and it retires
  a fallback that was previously marked unreachable.
- The lists move to `s3-filesystem-allowed.ts`, leaving the checks that apply
  them in `s3-filesystem-safety.ts`. One file answers "what is allowed" and the
  other "is this allowed" — which also brings the latter back under the FTA
  threshold it had crossed.

## Why not just add `.freq` to the default set

It is a pinyin dictionary's file extension. Baking that into a general AWS
simulator's default allowlist would be the wrong home for it, and the next
project would arrive with a different extension and the same problem.

## Checks

`pnpm check` passes: format, FTA, build, doc examples and coverage at 99.9%
statements / 97.9% branches. Four tests cover the new option — that a named
extension is served, that a dot is optional, that the defaults survive naming
one, and that everything unnamed is still refused.

The docs page gains a section on it, and its example is extracted and
type-checked by `examples:check` like the rest.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring additional file extensions when mounting filesystem-backed S3 storage.
  * Extension entries are case-insensitive and may include or omit a leading dot.
  * Default web file types remain supported, while custom types can now be served.

* **Bug Fixes**
  * Unsupported file types remain hidden as nonexistent.
  * Unrecognized served file types now receive `application/octet-stream` content metadata.

* **Documentation**
  * Added configuration guidance and an example for serving custom binary files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->