### PR TITLE
feat: fan out a published message to subscribed queues

### DIFF
--- a/docs/services/sns/README.md
+++ b/docs/services/sns/README.md
@@ -5,9 +5,8 @@ every operation is authorized by simulated IAM.
 
 Standard topics only. SNS-specific types are imported from the `@kensio/yulin/sns` subpath.
 
-Subscriptions are held, but delivery is not simulated yet, so a published message still reaches
-nothing. A publish is accepted and answered with a `MessageId`, which is what real SNS does with a
-publish to a topic nothing subscribes to.
+A message published to a topic is delivered to every queue subscribed to it. Other subscription
+protocols are not simulated.
 
 ## Creating a topic and publishing to it
 
@@ -205,10 +204,6 @@ console.log(published.Failed?.[0]?.Code); // "InvalidParameterValueException"
 There is no confirmation step for that protocol, as there is none on real SNS: the subscription is
 confirmed the moment it exists.
 
-Delivery is not simulated yet, so a published message still reaches nothing. What a subscription
-gives a test today is the SNS-side wiring: which queues a topic would reach, and what each would be
-sent.
-
 ```typescript sim-sns-subscriptions
 /**
  * Subscribing a queue to a simulated topic, and reading the subscription back.
@@ -299,6 +294,267 @@ because the only protocol simulated is the one that needs no confirmation.
 Only the `sqs` protocol is simulated. Every other protocol real SNS has is refused by name at
 `Subscribe` time with the reason it is missing, rather than creating a subscription that would never
 be delivered to.
+
+## Delivering to a queue
+
+Publishing to a topic delivers one message to each subscribed queue. That happens after the publish
+has been answered, as it does on real SNS, so a test waits for it with
+`simAws.backgroundTasksComplete()` before receiving.
+
+```typescript sim-sns-fan-out
+/**
+ * Publishing once and having two queues each receive a copy.
+ */
+
+import {
+  CreateTopicCommand,
+  PublishCommand,
+  SubscribeCommand,
+} from "@aws-sdk/client-sns";
+import {
+  CreateQueueCommand,
+  ReceiveMessageCommand,
+  SetQueueAttributesCommand,
+} from "@aws-sdk/client-sqs";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const sns = simAws.sns();
+const sqs = simAws.sqs();
+
+const { TopicArn } = await sns.createTopic(
+  new CreateTopicCommand({ Name: "orders" }),
+);
+
+/**
+ * Create a queue that admits SNS to send to it for this topic, and subscribe
+ * it. The queue policy is what allows the delivery, and it is checked on every
+ * message rather than remembered from subscribe time.
+ */
+async function subscribeQueue(queueName: string): Promise<string> {
+  const { QueueUrl } = await sqs.createQueue(
+    new CreateQueueCommand({ QueueName: queueName }),
+  );
+  const queueArn = `arn:aws:sqs:${simAws.defaultRegionName}:${simAws.defaultAccountId}:${queueName}`;
+
+  await sqs.setQueueAttributes(
+    new SetQueueAttributesCommand({
+      QueueUrl,
+      Attributes: {
+        Policy: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: [
+            {
+              Effect: "Allow",
+              Principal: { Service: "sns.amazonaws.com" },
+              Action: "sqs:SendMessage",
+              Resource: queueArn,
+              Condition: { ArnLike: { "aws:SourceArn": TopicArn } },
+            },
+          ],
+        }),
+      },
+    }),
+  );
+
+  await sns.subscribe(
+    new SubscribeCommand({ TopicArn, Protocol: "sqs", Endpoint: queueArn }),
+  );
+
+  return QueueUrl ?? "";
+}
+
+const fulfilment = await subscribeQueue("fulfilment");
+const audit = await subscribeQueue("audit");
+
+await sns.publish(new PublishCommand({ TopicArn, Message: "order-1" }));
+
+// Delivery happens after the publish is answered, as it does on real SNS.
+await simAws.backgroundTasksComplete();
+
+for (const QueueUrl of [fulfilment, audit]) {
+  const { Messages } = await sqs.receiveMessage(
+    new ReceiveMessageCommand({ QueueUrl }),
+  );
+  const envelope = JSON.parse(Messages?.[0]?.Body ?? "{}") as {
+    Type: string;
+    Message: string;
+  };
+
+  console.log(envelope.Type); // "Notification"
+  console.log(envelope.Message); // "order-1"
+}
+```
+
+The queue's policy is what allows the delivery. It has to admit `sns.amazonaws.com` for
+`sqs:SendMessage`, and the `aws:SourceArn` condition is what keeps one topic's grant from opening the
+queue to another. The policy is checked on every message rather than remembered from subscribe time,
+so a permission taken away afterwards stops delivery.
+
+Nothing checks the queue at `Subscribe` time, because real SNS does not either. A subscription to a
+queue that does not exist, or to one whose policy says no, is created and fails when a message is
+delivered to it.
+
+A delivery that fails is not reported to the publisher, as it is not on real SNS: the publish is
+answered with a `MessageId` before anything is delivered. It is recorded instead, so a queue that is
+unexpectedly empty says why:
+
+```typescript
+const [failure] = simAws.sns().deliveryFailures;
+
+console.log(failure?.endpointArn);
+console.log(failure?.reason);
+console.log(failure?.wasRefused); // true when the queue policy said no
+```
+
+A queue in another account or another region receives a message the same way. Real SNS delivers
+across both, which differs from simulated S3 event notifications: real S3 requires a destination
+queue to be in the bucket's region, and this does not.
+
+## The message a queue receives
+
+By default the body is the SNS envelope, which is the JSON document real SNS wraps a published
+message in. A consumer reads the message out of it with `JSON.parse(body).Message`:
+
+```json
+{
+  "Type": "Notification",
+  "MessageId": "0f2a0a49-9e3f-4d02-9e5f-2d9f0e5b6d51",
+  "TopicArn": "arn:aws:sns:us-east-1:888888888888:orders",
+  "Subject": "New order",
+  "Message": "order-1",
+  "Timestamp": "2026-01-01T00:00:00.000Z",
+  "SignatureVersion": "1",
+  "Signature": "...",
+  "SigningCertURL": "https://sns.us-east-1.yulin.invalid/SimulatedNotificationService-....pem",
+  "UnsubscribeURL": "https://sns.us-east-1.yulin.invalid/?Action=Unsubscribe&SubscriptionArn=...",
+  "MessageAttributes": { "tenant": { "Type": "String", "Value": "acme" } }
+}
+```
+
+`Subject` and `MessageAttributes` are there only when the publish carried them. A binary message
+attribute travels base64 encoded, since the envelope is JSON.
+
+With `RawMessageDelivery` set to `true` on the subscription, the body is the published `Message` on
+its own and the published message attributes arrive as SQS message attributes instead. Both matter,
+because a consumer written for one breaks on the other.
+
+## Verifying a message signature
+
+The `Signature` in the envelope is a real RSA signature over the string real SNS signs: the signed
+fields in alphabetical order, each one its name and its value followed by a newline. Signature
+version `1` is SHA1withRSA, which is what real SNS signs with unless a topic opts into version 2.
+
+The key pair belongs to the simulated SNS scope, as a real signing certificate belongs to a region.
+`SigningCertURL` names its certificate, and `simAws.sns().signingCertificate(url)` hands it over: the
+URL itself cannot be fetched, because simulated SNS is not served over HTTP.
+
+```typescript sim-sns-message-signature
+/**
+ * Verifying the signature on a message a simulated topic delivered.
+ */
+
+import { createVerify } from "node:crypto";
+
+import {
+  CreateTopicCommand,
+  PublishCommand,
+  SubscribeCommand,
+} from "@aws-sdk/client-sns";
+import {
+  CreateQueueCommand,
+  ReceiveMessageCommand,
+  SetQueueAttributesCommand,
+} from "@aws-sdk/client-sqs";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const sns = simAws.sns();
+const sqs = simAws.sqs();
+
+const { TopicArn } = await sns.createTopic(
+  new CreateTopicCommand({ Name: "orders" }),
+);
+const { QueueUrl } = await sqs.createQueue(
+  new CreateQueueCommand({ QueueName: "orders" }),
+);
+const queueArn = `arn:aws:sqs:${simAws.defaultRegionName}:${simAws.defaultAccountId}:orders`;
+
+await sqs.setQueueAttributes(
+  new SetQueueAttributesCommand({
+    QueueUrl,
+    Attributes: {
+      Policy: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: [
+          {
+            Effect: "Allow",
+            Principal: { Service: "sns.amazonaws.com" },
+            Action: "sqs:SendMessage",
+            Resource: queueArn,
+            Condition: { ArnLike: { "aws:SourceArn": TopicArn } },
+          },
+        ],
+      }),
+    },
+  }),
+);
+
+await sns.subscribe(
+  new SubscribeCommand({ TopicArn, Protocol: "sqs", Endpoint: queueArn }),
+);
+
+await sns.publish(new PublishCommand({ TopicArn, Message: "order-1" }));
+await simAws.backgroundTasksComplete();
+
+const { Messages } = await sqs.receiveMessage(
+  new ReceiveMessageCommand({ QueueUrl }),
+);
+const envelope = JSON.parse(Messages?.[0]?.Body ?? "{}") as {
+  Type: string;
+  MessageId: string;
+  Subject?: string;
+  Message: string;
+  Timestamp: string;
+  TopicArn: string;
+  SignatureVersion: string;
+  Signature: string;
+  SigningCertURL: string;
+};
+
+// The string SNS signs is the signed fields in alphabetical order, each one its
+// name and its value followed by a newline. A field the message does not carry,
+// such as Subject, is left out.
+const signed = (
+  [
+    ["Message", envelope.Message],
+    ["MessageId", envelope.MessageId],
+    ["Subject", envelope.Subject],
+    ["Timestamp", envelope.Timestamp],
+    ["TopicArn", envelope.TopicArn],
+    ["Type", envelope.Type],
+  ] as const
+)
+  .filter(([, value]) => value !== undefined)
+  .map(([name, value]) => `${name}\n${value ?? ""}\n`)
+  .join("");
+
+// The certificate comes from the simulator rather than from the network: the
+// SigningCertURL names the simulated host and nothing serves it.
+const certificate = sns.signingCertificate(envelope.SigningCertURL);
+
+const verified = createVerify("RSA-SHA1")
+  .update(signed, "utf8")
+  .verify(certificate ?? "", envelope.Signature, "base64");
+
+console.log(envelope.SignatureVersion); // "1"
+console.log(verified); // true
+```
+
+The message attributes are not signed, here or on real AWS, so changing one in flight leaves the
+signature valid.
 
 ## IAM permissions
 
@@ -541,6 +797,10 @@ Sim SNS currently supports:
 - `ListSubscriptionsCommand` and `ListSubscriptionsByTopicCommand`, paged at a hundred subscriptions
   with a `NextToken`
 - `GetSubscriptionAttributesCommand` and `SetSubscriptionAttributesCommand`, for `RawMessageDelivery`
+- Delivery of a published message to every subscribed queue, including a queue in another account or
+  another region, authorized by that queue's own policy on every message
+- The SNS envelope, with a real RSA signature a verifier can check against the certificate the
+  message names, and `RawMessageDelivery` for the published message on its own
 - Authorization of every operation by simulated IAM, against the real IAM action and topic ARN
 - The `Policy` attribute as the topic's resource policy, admitting another account's principal or a
   service principal, with `aws:SourceArn` and `aws:SourceAccount` conditions honoured
@@ -551,11 +811,21 @@ Sim SNS currently supports:
 
 Current documented limitations:
 
-- Delivery is not simulated. A subscription can be created, listed and removed, but a published
-  message reaches no endpoint. A publish is accepted and answered with a `MessageId`, which is what
-  real SNS does with a publish to a topic nothing subscribes to.
-- Only the `sqs` subscription protocol is simulated. `lambda`, `http`, `https`, `email`,
-  `email-json`, `sms`, `application` and `firehose` are refused at `Subscribe` time.
+- Only the `sqs` subscription protocol is simulated, so a queue is the only thing a topic can deliver
+  to. `lambda`, `http`, `https`, `email`, `email-json`, `sms`, `application` and `firehose` are
+  refused at `Subscribe` time.
+- `SigningCertURL` and `UnsubscribeURL` name `sns.<region>.yulin.invalid` rather than
+  `sns.<region>.amazonaws.com`, and neither can be fetched: simulated SNS is not served over HTTP.
+  The certificate is handed out in process by `simAws.sns().signingCertificate(url)`. A real SNS
+  signature verifier such as `sns-validator` hard-codes an `amazonaws.com` certificate host and
+  fetches the URL itself, so it cannot verify a simulated message as it stands. Verify with
+  `node:crypto` against the certificate the simulator hands over instead.
+- A delivery failure is not reported to the publisher, as it is not on real SNS. It is recorded on
+  `simAws.sns().deliveryFailures`, and anything other than a queue policy refusal is also warned
+  about once on the console.
+- Delivery retry policies, subscription dead-letter queues and delivery status logging are not
+  simulated, so a message an endpoint would not take is delivered once and recorded as a failure
+  rather than retried.
 - `ConfirmSubscription` is not supported. The only protocol simulated needs no confirmation, so
   there is no confirmation token to confirm.
 - Subscription filter policies are not simulated, so `FilterPolicy` and `FilterPolicyScope` are

--- a/docs/services/sns/sim-sns-fan-out.example.ts
+++ b/docs/services/sns/sim-sns-fan-out.example.ts
@@ -1,0 +1,83 @@
+/**
+ * Publishing once and having two queues each receive a copy.
+ */
+
+import {
+  CreateTopicCommand,
+  PublishCommand,
+  SubscribeCommand,
+} from "@aws-sdk/client-sns";
+import {
+  CreateQueueCommand,
+  ReceiveMessageCommand,
+  SetQueueAttributesCommand,
+} from "@aws-sdk/client-sqs";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const sns = simAws.sns();
+const sqs = simAws.sqs();
+
+const { TopicArn } = await sns.createTopic(
+  new CreateTopicCommand({ Name: "orders" }),
+);
+
+/**
+ * Create a queue that admits SNS to send to it for this topic, and subscribe
+ * it. The queue policy is what allows the delivery, and it is checked on every
+ * message rather than remembered from subscribe time.
+ */
+async function subscribeQueue(queueName: string): Promise<string> {
+  const { QueueUrl } = await sqs.createQueue(
+    new CreateQueueCommand({ QueueName: queueName }),
+  );
+  const queueArn = `arn:aws:sqs:${simAws.defaultRegionName}:${simAws.defaultAccountId}:${queueName}`;
+
+  await sqs.setQueueAttributes(
+    new SetQueueAttributesCommand({
+      QueueUrl,
+      Attributes: {
+        Policy: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: [
+            {
+              Effect: "Allow",
+              Principal: { Service: "sns.amazonaws.com" },
+              Action: "sqs:SendMessage",
+              Resource: queueArn,
+              Condition: { ArnLike: { "aws:SourceArn": TopicArn } },
+            },
+          ],
+        }),
+      },
+    }),
+  );
+
+  await sns.subscribe(
+    new SubscribeCommand({ TopicArn, Protocol: "sqs", Endpoint: queueArn }),
+  );
+
+  return QueueUrl ?? "";
+}
+
+const fulfilment = await subscribeQueue("fulfilment");
+const audit = await subscribeQueue("audit");
+
+await sns.publish(new PublishCommand({ TopicArn, Message: "order-1" }));
+
+// Delivery happens after the publish is answered, as it does on real SNS.
+await simAws.backgroundTasksComplete();
+
+for (const QueueUrl of [fulfilment, audit]) {
+  const { Messages } = await sqs.receiveMessage(
+    new ReceiveMessageCommand({ QueueUrl }),
+  );
+  const envelope = JSON.parse(Messages?.[0]?.Body ?? "{}") as {
+    Type: string;
+    Message: string;
+  };
+
+  console.log(envelope.Type); // "Notification"
+  console.log(envelope.Message); // "order-1"
+}

--- a/docs/services/sns/sim-sns-message-signature.example.ts
+++ b/docs/services/sns/sim-sns-message-signature.example.ts
@@ -1,0 +1,100 @@
+/**
+ * Verifying the signature on a message a simulated topic delivered.
+ */
+
+import { createVerify } from "node:crypto";
+
+import {
+  CreateTopicCommand,
+  PublishCommand,
+  SubscribeCommand,
+} from "@aws-sdk/client-sns";
+import {
+  CreateQueueCommand,
+  ReceiveMessageCommand,
+  SetQueueAttributesCommand,
+} from "@aws-sdk/client-sqs";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const sns = simAws.sns();
+const sqs = simAws.sqs();
+
+const { TopicArn } = await sns.createTopic(
+  new CreateTopicCommand({ Name: "orders" }),
+);
+const { QueueUrl } = await sqs.createQueue(
+  new CreateQueueCommand({ QueueName: "orders" }),
+);
+const queueArn = `arn:aws:sqs:${simAws.defaultRegionName}:${simAws.defaultAccountId}:orders`;
+
+await sqs.setQueueAttributes(
+  new SetQueueAttributesCommand({
+    QueueUrl,
+    Attributes: {
+      Policy: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: [
+          {
+            Effect: "Allow",
+            Principal: { Service: "sns.amazonaws.com" },
+            Action: "sqs:SendMessage",
+            Resource: queueArn,
+            Condition: { ArnLike: { "aws:SourceArn": TopicArn } },
+          },
+        ],
+      }),
+    },
+  }),
+);
+
+await sns.subscribe(
+  new SubscribeCommand({ TopicArn, Protocol: "sqs", Endpoint: queueArn }),
+);
+
+await sns.publish(new PublishCommand({ TopicArn, Message: "order-1" }));
+await simAws.backgroundTasksComplete();
+
+const { Messages } = await sqs.receiveMessage(
+  new ReceiveMessageCommand({ QueueUrl }),
+);
+const envelope = JSON.parse(Messages?.[0]?.Body ?? "{}") as {
+  Type: string;
+  MessageId: string;
+  Subject?: string;
+  Message: string;
+  Timestamp: string;
+  TopicArn: string;
+  SignatureVersion: string;
+  Signature: string;
+  SigningCertURL: string;
+};
+
+// The string SNS signs is the signed fields in alphabetical order, each one its
+// name and its value followed by a newline. A field the message does not carry,
+// such as Subject, is left out.
+const signed = (
+  [
+    ["Message", envelope.Message],
+    ["MessageId", envelope.MessageId],
+    ["Subject", envelope.Subject],
+    ["Timestamp", envelope.Timestamp],
+    ["TopicArn", envelope.TopicArn],
+    ["Type", envelope.Type],
+  ] as const
+)
+  .filter(([, value]) => value !== undefined)
+  .map(([name, value]) => `${name}\n${value ?? ""}\n`)
+  .join("");
+
+// The certificate comes from the simulator rather than from the network: the
+// SigningCertURL names the simulated host and nothing serves it.
+const certificate = sns.signingCertificate(envelope.SigningCertURL);
+
+const verified = createVerify("RSA-SHA1")
+  .update(signed, "utf8")
+  .verify(certificate ?? "", envelope.Signature, "base64");
+
+console.log(envelope.SignatureVersion); // "1"
+console.log(verified); // true

--- a/src/service/aws/factory/sim-aws-account-region-service-builder.ts
+++ b/src/service/aws/factory/sim-aws-account-region-service-builder.ts
@@ -27,6 +27,7 @@ import { SimS3 } from "../../s3/sim-s3.js";
 import { simAwsS3NotificationDestinations } from "./sim-aws-s3-notification-destinations.js";
 import { SimSecretsManager } from "../../secretsmanager/index.js";
 import { SimSns } from "../../sns/index.js";
+import { SimAwsSnsDeliveryQueues } from "../../sns/delivery/sqs/sim-aws-sns-delivery-queues.js";
 import { SimSqs } from "../../sqs/index.js";
 import { SimSsm } from "../../ssm/index.js";
 import { SimSts } from "../../sts/sim-sts.js";
@@ -237,11 +238,16 @@ export class SimAwsAccountRegionServiceBuilder {
   /**
    * Create simulated SNS for an Account Region scope.
    *
-   * Topics are Region-scoped on real AWS: a topic ARN names the Region, and a
-   * topic cannot be reached from another one.
+   * Topics are Region-scoped on real AWS: a topic ARN names the Region. Where a
+   * subscription delivers is not, since real SNS delivers to a queue in any
+   * Account or Region, so the endpoints come from the whole simulation and are
+   * resolved on delivery rather than here.
    */
   createSns(scope: SimAwsAccountRegionContainer): SimSns {
-    return new SimSns(this.scoped(scope));
+    return new SimSns({
+      ...this.scoped(scope),
+      deliveryEndpoints: new SimAwsSnsDeliveryQueues({ simAws: this.simAws }),
+    });
   }
 
   /**

--- a/src/service/sns/README.md
+++ b/src/service/sns/README.md
@@ -4,9 +4,8 @@ This directory contains the simulated SNS service implementation. Standard topic
 
 A topic holds almost nothing. Its name, the ARN that name implies, and the attributes a request has
 set are the whole of it, because real SNS keeps no messages: a publish is handed to the topic's
-subscriptions and forgotten. Subscriptions are held here, but delivery is not simulated yet, so a
-publish validates the message, answers with a message id, and the message goes nowhere. That is what
-real SNS does with a publish to a topic nothing subscribes to.
+subscriptions and forgotten. That is what happens here too. A publish validates the message, answers
+with a message id, and hands a copy to each subscription on the background scheduler.
 
 ## Entry points
 
@@ -60,20 +59,20 @@ Subscription state lives under `subscription/`.
 
 `SimSnsSubscription` is the stored resource: its ARN, the topic it belongs to, its protocol, its
 endpoint, the Account owning it, and its attributes. The endpoint is held as a
-`SimSnsQueueEndpointArn` rather than as a string, because `sqs` is the only protocol accepted and the
-Account and Region it names are the ones a delivery will have to reach, rather than the topic's. When
-another protocol arrives, this becomes the endpoint of whichever kind the protocol implies.
+`SimSnsQueueEndpointArn` rather than as a string, because `sqs` is the only protocol accepted and a
+delivery reaches the Account and Region that ARN names rather than the topic's. When another protocol
+arrives, this becomes the endpoint of whichever kind the protocol implies.
 
 Nothing checks that the endpoint queue exists when a subscription is created, because real SNS does
 not either: a subscription to a queue that is not there is created, and fails when something is
-delivered to it. Nothing here consults the queue's policy either, since delivery is not simulated
-yet, and both checks belong with it when it arrives.
+delivered to it. The queue's policy is not consulted here either, for the same reason. Both are
+delivery-time questions, which is what makes a permission taken away afterwards stop delivery.
 
 `SimSnsSubscriptionArn` mints an ARN, which is the topic's with an opaque id added as a seventh part,
 and `parseSnsSubscriptionArn` reads one. Counting the colon separated parts is what tells a
 subscription ARN from a topic ARN, since neither has a resource type separator.
 
-`SimSnsSubscriptionProtocol` holds the one protocol a subscription is accepted for. Every other protocol
+`SimSnsSubscriptionProtocol` holds the one protocol delivery is simulated over. Every other protocol
 real SNS has is refused by name with the reason it is missing, rather than accepted as a subscription
 that would never be delivered to. A protocol real SNS does not have at all is refused the way real
 SNS refuses one.
@@ -110,6 +109,44 @@ validated and carried.
 whichever form it arrived in, because the data type already says which form that was: an attribute of
 a `Binary` type carries bytes and any other carries text. There is no digest here, unlike simulated
 SQS, because a real SNS publish response carries no digest for a caller to check.
+
+## Delivery
+
+Delivery lives under `delivery/`, and the signing that goes with it under `signature/`.
+
+`SimSnsFanOut` is what a publish hands a message to. It schedules one delivery per subscription on
+the background scheduler, because real SNS answers a publish before anything is delivered:
+`simAws.backgroundTasksComplete()` is what waits for it. A failure is recorded on
+`SimSnsDeliveryFailures` rather than thrown, since a background task left rejected would fail an
+unrelated `backgroundTasksComplete()`, and real SNS never reports a delivery failure to the publisher.
+A queue policy refusal is recorded quietly, because that is a modelled outcome a test may be asking
+for; anything else is also warned about once, because it is a fault.
+
+`SimSnsEnvelope` is the JSON document a subscription receives unless it asked for raw delivery. It
+also builds the string real SNS signs, which is the signed fields in alphabetical order, each one its
+name and its value followed by a newline. Message attributes are not signed, here or on real AWS.
+
+`SimSnsDeliveryEndpoints` is where a message goes. There is one implementation, for a queue, because
+`sqs` is the only protocol simulated: a second protocol adds a second implementation rather than a
+branch in this one. `SimAwsSnsDeliveryQueues` resolves the queue when a message is delivered, never
+when it is built, for the same reason S3's notification destinations do it that way. A queue in
+another Account or Region is reachable, since real SNS delivers to both. That is a deliberate
+difference from simulated S3 event notifications, which require the destination queue to be in the
+Bucket's Region because real S3 does.
+
+`SimSnsDeliveryQueue` asks the queue's own Account two questions: whether `sns.amazonaws.com` may
+send to it for this topic, through `SimSqsServiceSendAuthorizer`, and then to send. The send goes
+through the ordinary `SendMessage` path, so a delivered message is the same thing an SDK caller would
+have sent, and is authorized again on the way in.
+
+`SimSnsMessageSigner` owns the key pair, which belongs to the scope rather than to a topic: real SNS
+signs every message a Region sends with one certificate. It is generated on first use, because
+generating RSA takes long enough to notice and most simulated SNS scopes never deliver anything.
+
+`SimSnsSigningKey` signs with SHA1withRSA, which is what signature version 1 means. The certificate
+is assembled by hand in `sim-sns-certificate.ts` out of the DER encoding in `sim-sns-der.ts`, because
+Node reads an X.509 certificate and does not write one, and a `Signature` field with no certificate
+behind it is a field a consumer cannot use.
 
 ## Command handling
 
@@ -207,9 +244,17 @@ here, it does not make another Account's topics reachable through this one.
 
 ## Divergences worth knowing
 
-- Delivery is not simulated, so a publish reaches nothing even when the topic has subscriptions.
-- Only the `sqs` subscription protocol is simulated, and `ConfirmSubscription` is not implemented,
-  since that protocol needs no confirmation.
+- Only the `sqs` subscription protocol is simulated, so a queue is the only thing a topic delivers
+  to. `ConfirmSubscription` is not implemented, since that protocol needs no confirmation.
+- `SigningCertURL` and `UnsubscribeURL` name `sns.<region>.yulin.invalid`, and neither is served.
+  The certificate is handed out in process by `SimSns.signingCertificate`. A real verifier such as
+  `sns-validator` hard-codes an `amazonaws.com` certificate host and fetches the URL itself, so it
+  cannot verify a simulated message as it stands.
+- The certificate is minimal: a version, a serial number derived from the key, one common name as
+  both issuer and subject, a validity window fixed at 2000 to 2049, and the public key. There are no
+  extensions, because nothing verifying an SNS message looks at any.
+- Delivery retry policies, subscription dead-letter queues and delivery status logging are not
+  simulated, so a delivery that fails is recorded once rather than retried.
 - Subscription filter policies, delivery retry policies, dead-letter queues and replay are not
   simulated, so `FilterPolicy`, `FilterPolicyScope`, `DeliveryPolicy`, `RedrivePolicy`,
   `SubscriptionRoleArn` and `ReplayPolicy` are refused.

--- a/src/service/sns/command/publish/sim-sns-batch-entries.ts
+++ b/src/service/sns/command/publish/sim-sns-batch-entries.ts
@@ -1,10 +1,15 @@
 import {
   SimSnsBatchEntryIdsNotDistinctException,
+  SimSnsBatchRequestTooLongException,
   SimSnsEmptyBatchRequestException,
   SimSnsError,
   SimSnsInvalidBatchEntryIdException,
   SimSnsTooManyEntriesInBatchRequestException,
 } from "../../error/sim-sns.error.js";
+import {
+  simSnsMaximumPublishBytes,
+  type SimSnsPublishedMessage,
+} from "../../message/sim-sns-published-message.js";
 import type { SimSnsBatchResultErrorEntry } from "./publish.command.js";
 
 const maximumEntries = 10;
@@ -119,4 +124,29 @@ function requireEntryId(id: string | undefined): string {
   }
 
   return id;
+}
+
+/**
+ * Refuse a batch weighing more than one publish is allowed to.
+ *
+ * Real SNS holds the whole batch to the 256 KB a single publish is held to,
+ * rather than each entry, so ten entries just inside the limit are one batch
+ * far outside it. That is why `SimSnsPublishedMessage` does not check the limit
+ * and this does.
+ */
+export function assertSnsBatchWithinSizeLimit(
+  published: readonly { readonly message: SimSnsPublishedMessage }[],
+): void {
+  const byteSize = published.reduce(
+    (total, { message }) => total + message.byteSize,
+    0,
+  );
+
+  if (byteSize > simSnsMaximumPublishBytes) {
+    throw new SimSnsBatchRequestTooLongException(
+      `The batch request is longer than the permitted size. A batch may be ` +
+        `up to ${String(simSnsMaximumPublishBytes)} bytes, and this one is ` +
+        `${String(byteSize)} bytes.`,
+    );
+  }
 }

--- a/src/service/sns/command/publish/sim-sns-publish-commands.ts
+++ b/src/service/sns/command/publish/sim-sns-publish-commands.ts
@@ -1,13 +1,14 @@
 import type { BackgroundScheduler } from "../../../../util/background/background.js";
-import { SimSnsBatchRequestTooLongException } from "../../error/sim-sns.error.js";
+import type { SimSnsFanOut } from "../../delivery/sim-sns-fan-out.js";
 import {
   assertSimSnsMessageWithinLimit,
-  simSnsMaximumPublishBytes,
   SimSnsPublishedMessage,
 } from "../../message/sim-sns-published-message.js";
+import type { SimSnsTopic } from "../../topic/sim-sns-topic.js";
 import type { SimSnsRequestOptions } from "../sim-sns-request-options.js";
 import type { SimSnsTopicAccess } from "../topic/sim-sns-topic-access.js";
 import {
+  assertSnsBatchWithinSizeLimit,
   requireSnsBatchEntries,
   runSnsBatch,
 } from "./sim-sns-batch-entries.js";
@@ -33,6 +34,7 @@ const publishAction = "sns:Publish";
 interface SimSnsPublishCommandsProperties {
   readonly access: SimSnsTopicAccess;
   readonly clock: BackgroundScheduler;
+  readonly fanOut: SimSnsFanOut;
 }
 
 /**
@@ -41,15 +43,18 @@ interface SimSnsPublishCommandsProperties {
  * A topic keeps nothing a publish sends it. Real SNS hands a message to the
  * topic's subscriptions and forgets it, so a topic with no subscriptions
  * accepts a publish, answers with a message id, and the message goes nowhere.
- * That is what a publish does here, since subscriptions are not simulated yet.
+ * That is what a publish does here too, and a topic with subscriptions hands
+ * each of them a copy on the background scheduler.
  */
 export class SimSnsPublishCommands {
   private readonly access: SimSnsTopicAccess;
   private readonly clock: BackgroundScheduler;
+  private readonly fanOut: SimSnsFanOut;
 
   constructor(properties: SimSnsPublishCommandsProperties) {
     this.access = properties.access;
     this.clock = properties.clock;
+    this.fanOut = properties.fanOut;
   }
 
   /**
@@ -62,12 +67,17 @@ export class SimSnsPublishCommands {
     refuseUnsimulatedPublishTarget(command.input);
 
     // The topic has to be there and the caller has to be allowed to publish to
-    // it, which is all a publish needs of it while nothing subscribes.
-    this.access.requireByArn(publishAction, command.input.TopicArn, options);
-
+    // it before anything is read out of the message.
+    const topic = this.access.requireByArn(
+      publishAction,
+      command.input.TopicArn,
+      options,
+    );
     const message = this.published(command.input);
 
     assertSimSnsMessageWithinLimit(message.byteSize);
+
+    this.fanOut.publish(topic, message);
 
     return { $metadata: {}, MessageId: message.messageId };
   }
@@ -85,8 +95,11 @@ export class SimSnsPublishCommands {
     command: SimPublishBatchCommand,
     options?: SimSnsRequestOptions,
   ): SimPublishBatchCommandOutput {
-    this.access.requireByArn(publishAction, command.input.TopicArn, options);
-
+    const topic = this.access.requireByArn(
+      publishAction,
+      command.input.TopicArn,
+      options,
+    );
     const entries = requireSnsBatchEntries(
       command.input.PublishBatchRequestEntries,
     );
@@ -95,7 +108,8 @@ export class SimSnsPublishCommands {
       message: this.published(entry),
     }));
 
-    this.assertBatchWithinSizeLimit(outcome.successful);
+    assertSnsBatchWithinSizeLimit(outcome.successful);
+    this.fanOutBatch(topic, outcome.successful);
 
     const successful: readonly SimSnsPublishBatchResultEntry[] =
       outcome.successful.map(({ id, message }) => ({
@@ -107,6 +121,22 @@ export class SimSnsPublishCommands {
   }
 
   /**
+   * Hand every message a batch published to the topic's subscriptions.
+   *
+   * The whole batch is checked before any of it is delivered, because a batch
+   * over the size limit fails outright, and a message from a failed request
+   * should reach nothing.
+   */
+  private fanOutBatch(
+    topic: SimSnsTopic,
+    published: readonly { readonly message: SimSnsPublishedMessage }[],
+  ): void {
+    for (const { message } of published) {
+      this.fanOut.publish(topic, message);
+    }
+  }
+
+  /**
    * Read and check one message a request describes.
    */
   private published(published: SimSnsPublishedFields): SimSnsPublishedMessage {
@@ -114,29 +144,5 @@ export class SimSnsPublishCommands {
       simSnsPublishedMessageInput(published),
       this.clock.now(),
     );
-  }
-
-  /**
-   * Refuse a batch weighing more than one publish is allowed to.
-   *
-   * Real SNS holds the whole batch to the 256 KB a single publish is held to,
-   * rather than each entry, so ten entries just inside the limit are one batch
-   * far outside it.
-   */
-  private assertBatchWithinSizeLimit(
-    published: readonly { readonly message: SimSnsPublishedMessage }[],
-  ): void {
-    const byteSize = published.reduce(
-      (total, { message }) => total + message.byteSize,
-      0,
-    );
-
-    if (byteSize > simSnsMaximumPublishBytes) {
-      throw new SimSnsBatchRequestTooLongException(
-        `The batch request is longer than the permitted size. A batch may be ` +
-          `up to ${String(simSnsMaximumPublishBytes)} bytes, and this one is ` +
-          `${String(byteSize)} bytes.`,
-      );
-    }
   }
 }

--- a/src/service/sns/command/sim-sns-commands.ts
+++ b/src/service/sns/command/sim-sns-commands.ts
@@ -1,0 +1,101 @@
+import type { BackgroundScheduler } from "../../../util/background/background.js";
+import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+import type { SimIamInterServiceAuthZ } from "../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import type { SimSnsDeliveryEndpoints } from "../delivery/sim-sns-delivery.js";
+import { SimSnsDeliveryRequests } from "../delivery/sim-sns-delivery-request.js";
+import { SimSnsFanOut } from "../delivery/sim-sns-fan-out.js";
+import { SimSnsMessageSigner } from "../signature/sim-sns-message-signer.js";
+import type { SimSnsSubscriptionStore } from "../subscription/sim-sns-subscription-store.js";
+import type { SimSnsTopicStore } from "../topic/sim-sns-topic-store.js";
+import { SimSnsAuthorizer } from "./authorize/sim-sns-authorizer.js";
+import { SimSnsPublishCommands } from "./publish/sim-sns-publish-commands.js";
+import { SimSnsSubscriptionAccess } from "./subscription/sim-sns-subscription-access.js";
+import { SimSnsSubscriptionAttributeCommands } from "./subscription/sim-sns-subscription-attribute-commands.js";
+import { SimSnsSubscriptionCommands } from "./subscription/sim-sns-subscription-commands.js";
+import { SimSnsSubscriptionListings } from "./subscription/sim-sns-subscription-listings.js";
+import { SimSnsCreateTopic } from "./topic/sim-sns-create-topic.js";
+import { SimSnsTopicAccess } from "./topic/sim-sns-topic-access.js";
+import { SimSnsTopicAttributeCommands } from "./topic/sim-sns-topic-attribute-commands.js";
+import { SimSnsTopicCommands } from "./topic/sim-sns-topic-commands.js";
+
+interface SimSnsCommandsProperties {
+  readonly topics: SimSnsTopicStore;
+  readonly subscriptions: SimSnsSubscriptionStore;
+  readonly iam: SimIamInterServiceAuthZ;
+  readonly background: BackgroundScheduler;
+  readonly deliveryEndpoints: SimSnsDeliveryEndpoints;
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+}
+
+/**
+ * Every command handler one simulated SNS scope delegates to.
+ *
+ * The wiring lives here rather than in the facade so that `SimSns` stays what
+ * it is meant to be: state and delegation. Which handler shares which
+ * collaborator is a fact about the handlers, not about the service object in
+ * front of them.
+ */
+export class SimSnsCommands {
+  public readonly topicCreation: SimSnsCreateTopic;
+  public readonly topics: SimSnsTopicCommands;
+  public readonly topicAttributes: SimSnsTopicAttributeCommands;
+  public readonly subscriptions: SimSnsSubscriptionCommands;
+  public readonly subscriptionListings: SimSnsSubscriptionListings;
+  public readonly subscriptionAttributes: SimSnsSubscriptionAttributeCommands;
+  public readonly publish: SimSnsPublishCommands;
+  public readonly fanOut: SimSnsFanOut;
+  public readonly signer: SimSnsMessageSigner;
+
+  constructor(properties: SimSnsCommandsProperties) {
+    const { topics, subscriptions, accountRegionScope, background } =
+      properties;
+    const access = new SimSnsTopicAccess({
+      topics,
+      authorizer: new SimSnsAuthorizer({ iam: properties.iam }),
+      accountRegionScope,
+    });
+    const subscriptionAccess = new SimSnsSubscriptionAccess({
+      subscriptions,
+      topicAccess: access,
+      accountRegionScope,
+    });
+
+    this.signer = new SimSnsMessageSigner({ accountRegionScope });
+    this.fanOut = new SimSnsFanOut({
+      subscriptions,
+      endpoints: properties.deliveryEndpoints,
+      requests: new SimSnsDeliveryRequests({
+        signer: this.signer,
+        accountRegionScope,
+      }),
+      background,
+    });
+    this.topicCreation = new SimSnsCreateTopic({
+      topics,
+      access,
+      accountRegionScope,
+    });
+    this.topics = new SimSnsTopicCommands({ topics, subscriptions, access });
+    this.topicAttributes = new SimSnsTopicAttributeCommands({
+      access,
+      subscriptions,
+    });
+    this.subscriptions = new SimSnsSubscriptionCommands({
+      subscriptions,
+      topicAccess: access,
+      subscriptionAccess,
+    });
+    this.subscriptionListings = new SimSnsSubscriptionListings({
+      subscriptions,
+      topicAccess: access,
+    });
+    this.subscriptionAttributes = new SimSnsSubscriptionAttributeCommands({
+      access: subscriptionAccess,
+    });
+    this.publish = new SimSnsPublishCommands({
+      access,
+      clock: background,
+      fanOut: this.fanOut,
+    });
+  }
+}

--- a/src/service/sns/delivery/sim-sns-delivery-failures.ts
+++ b/src/service/sns/delivery/sim-sns-delivery-failures.ts
@@ -1,0 +1,110 @@
+import { SimSnsDeliveryNotPermitted } from "../error/sim-sns-delivery.error.js";
+
+/**
+ * What a delivery that failed was trying to do.
+ */
+export interface SimSnsDeliveryFailureProperties {
+  readonly topicArn: string;
+  readonly subscriptionArn: string;
+  readonly endpointArn: string;
+  readonly messageId: string;
+  readonly error: unknown;
+}
+
+/**
+ * One message an endpoint did not take.
+ */
+export class SimSnsDeliveryFailure {
+  public readonly topicArn: string;
+  public readonly subscriptionArn: string;
+  public readonly endpointArn: string;
+  public readonly messageId: string;
+  public readonly error: unknown;
+
+  constructor(properties: SimSnsDeliveryFailureProperties) {
+    this.topicArn = properties.topicArn;
+    this.subscriptionArn = properties.subscriptionArn;
+    this.endpointArn = properties.endpointArn;
+    this.messageId = properties.messageId;
+    this.error = properties.error;
+  }
+
+  /**
+   * Whether the endpoint refused the message rather than failing on it.
+   */
+  get wasRefused(): boolean {
+    return this.error instanceof SimSnsDeliveryNotPermitted;
+  }
+
+  /**
+   * What went wrong, in one line.
+   */
+  get reason(): string {
+    return this.error instanceof Error
+      ? this.error.message
+      : String(this.error);
+  }
+}
+
+/**
+ * What became of the messages a simulated SNS scope could not deliver.
+ *
+ * Real SNS tells the publisher nothing about a failed delivery: the publish is
+ * answered with a message id before anything is delivered, and a delivery that
+ * fails after that is the subscription's problem. Neither does this. Swallowing
+ * the failure entirely would leave a queue mysteriously empty, so every failure
+ * is kept for inspection and anything other than a refusal is warned about
+ * once.
+ */
+export class SimSnsDeliveryFailures {
+  private readonly failures: SimSnsDeliveryFailure[] = [];
+  private readonly warned = new Set<string>();
+
+  /**
+   * Every message this scope could not deliver, oldest first.
+   */
+  get all(): readonly SimSnsDeliveryFailure[] {
+    return this.failures;
+  }
+
+  /**
+   * Record a failed delivery, from what the fan-out knows about it.
+   */
+  record(properties: SimSnsDeliveryFailureProperties): void {
+    const failure = new SimSnsDeliveryFailure(properties);
+
+    this.failures.push(failure);
+
+    if (failure.wasRefused) {
+      // A refusal is a modelled outcome rather than a fault: the queue policy
+      // says no, which is what a test taking a permission away is checking
+      // for. It is recorded, not warned about.
+      return;
+    }
+
+    this.warn(failure);
+  }
+
+  /**
+   * Warn about an endpoint that failed, once per endpoint and cause.
+   *
+   * Warnings go to the console because that is where a test runner surfaces
+   * them next to the failing expectation they explain; the simulator has no
+   * logger of its own to route them through.
+   */
+  private warn(failure: SimSnsDeliveryFailure): void {
+    const key = `${failure.endpointArn}:${failure.reason}`;
+
+    if (this.warned.has(key)) {
+      return;
+    }
+
+    this.warned.add(key);
+
+    // eslint-disable-next-line no-console
+    console.warn(
+      `Simulated SNS topic ${failure.topicArn} could not deliver to ` +
+        `${failure.endpointArn}: ${failure.reason}`,
+    );
+  }
+}

--- a/src/service/sns/delivery/sim-sns-delivery-request.ts
+++ b/src/service/sns/delivery/sim-sns-delivery-request.ts
@@ -1,0 +1,78 @@
+import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+import type { SimSnsPublishedMessage } from "../message/sim-sns-published-message.js";
+import type { SimSnsMessageSigner } from "../signature/sim-sns-message-signer.js";
+import type { SimSnsSubscription } from "../subscription/sim-sns-subscription.js";
+import type { SimSnsDeliveryRequest } from "./sim-sns-delivery.js";
+import { SimSnsEnvelope } from "./sim-sns-envelope.js";
+
+interface SimSnsDeliveryRequestsProperties {
+  readonly signer: SimSnsMessageSigner;
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+}
+
+/**
+ * The message on its own, with its attributes alongside it.
+ *
+ * Raw delivery takes the envelope away, so the message attributes have nowhere
+ * to travel but the SQS message itself. A consumer written for raw delivery
+ * reads them there.
+ */
+function rawBody(
+  message: SimSnsPublishedMessage,
+): Pick<SimSnsDeliveryRequest, "body" | "messageAttributes"> {
+  return {
+    body: message.body.value,
+    messageAttributes: message.attributes.asSqsAttributes(),
+  };
+}
+
+/**
+ * Builds what each subscription of one simulated SNS scope is sent.
+ *
+ * Which form the body takes is the subscription's business rather than the
+ * endpoint's, so it is settled here and the endpoint is handed a body.
+ */
+export class SimSnsDeliveryRequests {
+  private readonly signer: SimSnsMessageSigner;
+  private readonly scope: SimAwsAccountRegionScope;
+
+  constructor(properties: SimSnsDeliveryRequestsProperties) {
+    this.signer = properties.signer;
+    this.scope = properties.accountRegionScope;
+  }
+
+  /**
+   * What one subscription is being sent for one published message.
+   */
+  for(
+    subscription: SimSnsSubscription,
+    message: SimSnsPublishedMessage,
+  ): SimSnsDeliveryRequest {
+    const named = {
+      endpointArn: subscription.endpoint.value,
+      topicArn: subscription.topicArn,
+      topicOwnerAccountId: this.scope.accountId,
+    };
+
+    if (subscription.attributes.rawMessageDelivery) {
+      return { ...named, ...rawBody(message) };
+    }
+
+    return { ...named, body: this.envelope(subscription, message).body };
+  }
+
+  /**
+   * The message wrapped in the SNS envelope, which is the default.
+   */
+  private envelope(
+    subscription: SimSnsSubscription,
+    message: SimSnsPublishedMessage,
+  ): SimSnsEnvelope {
+    return new SimSnsEnvelope({
+      message,
+      subscription,
+      regionName: this.scope.regionName,
+      signer: this.signer,
+    });
+  }
+}

--- a/src/service/sns/delivery/sim-sns-delivery-scope.iso.test.ts
+++ b/src/service/sns/delivery/sim-sns-delivery-scope.iso.test.ts
@@ -1,0 +1,191 @@
+import { PublishCommand } from "@aws-sdk/client-sns";
+import { CreateQueueCommand } from "@aws-sdk/client-sqs";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertStringIncludes,
+  assertTrue,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { BackgroundTasks } from "../../../util/background/background.js";
+import {
+  simSnsDeliveredMessage,
+  simSnsSubscribedQueue,
+} from "../../../../test/sns/subscription-fixture.js";
+import { simAwsWithTopic } from "../../../../test/sns/topic-fixture.js";
+import type { SimAwsAccountId } from "../../aws/sim-aws-account-id.js";
+import { SimSns } from "../sim-sns.js";
+import { SimSnsDeliveryNotPermitted } from "../error/sim-sns-delivery.error.js";
+
+/**
+ * The `Message` a delivered envelope carries.
+ */
+function envelopeMessage(body: string | undefined): unknown {
+  assertNonNullable(body);
+
+  return (JSON.parse(body) as Record<string, unknown>)["Message"];
+}
+
+describe("SNS delivery across Accounts and Regions", () => {
+  it("delivers to a queue in another Region", async () => {
+    // Given a topic with a queue in another Region subscribed to it.
+    const { simAws, topicArn } = await simAwsWithTopic();
+    const scope = { regionName: "eu-west-2" } as const;
+    const { queueUrl } = await simSnsSubscribedQueue(
+      simAws,
+      "orders",
+      topicArn,
+      scope,
+    );
+
+    // When a message is published.
+    await simAws
+      .sns()
+      .publish(new PublishCommand({ TopicArn: topicArn, Message: "order-1" }));
+
+    // Then it reaches the queue. Real SNS delivers across Regions, which is a
+    // deliberate difference from simulated S3 event notifications: real S3
+    // requires the destination queue to be in the Bucket's Region.
+    assertIdentical(
+      envelopeMessage(await simSnsDeliveredMessage(simAws, queueUrl, scope)),
+      "order-1",
+    );
+  });
+
+  it("delivers to a queue in another Account", async () => {
+    // Given a topic with a queue in another Account subscribed to it.
+    const { simAws, topicArn } = await simAwsWithTopic();
+    const scope = { accountId: "222222222222" } as const;
+    const { queueUrl } = await simSnsSubscribedQueue(
+      simAws,
+      "orders",
+      topicArn,
+      scope,
+    );
+
+    // When a message is published.
+    await simAws
+      .sns()
+      .publish(new PublishCommand({ TopicArn: topicArn, Message: "order-1" }));
+
+    // Then it reaches the queue, because that Account's queue policy admits
+    // SNS for this topic.
+    assertIdentical(
+      envelopeMessage(await simSnsDeliveredMessage(simAws, queueUrl, scope)),
+      "order-1",
+    );
+  });
+
+  it("does not deliver to a queue whose policy does not admit SNS", async () => {
+    // Given a topic with a queue subscribed to it that has no policy at all.
+    const { simAws, topicArn } = await simAwsWithTopic();
+    const created = await simAws
+      .sqs()
+      .createQueue(new CreateQueueCommand({ QueueName: "orders" }));
+
+    await simAws.sns().subscribe({
+      input: {
+        TopicArn: topicArn,
+        Protocol: "sqs",
+        Endpoint: "arn:aws:sqs:us-east-1:888888888888:orders",
+      },
+    });
+
+    // When a message is published.
+    await simAws
+      .sns()
+      .publish(new PublishCommand({ TopicArn: topicArn, Message: "order-1" }));
+
+    // Then nothing reaches the queue.
+    assertUndefined(
+      await simSnsDeliveredMessage(simAws, created.QueueUrl ?? ""),
+    );
+
+    // And the refusal is recorded rather than swallowed, so a queue that is
+    // unexpectedly empty says why.
+    const failures = simAws.sns().deliveryFailures;
+
+    assertArrayLength(failures, 1);
+    assertNonNullable(failures[0]);
+    assertInstanceOf(failures[0].error, SimSnsDeliveryNotPermitted);
+    assertTrue(failures[0].wasRefused);
+    assertStringIncludes(
+      failures[0].reason,
+      "does not allow sns.amazonaws.com",
+    );
+  });
+
+  it("records a delivery a simulated SNS on its own cannot make", async () => {
+    // Given a simulated SNS built on its own, with a subscription on it.
+    const background = new BackgroundTasks();
+    const simSns = new SimSns({
+      background,
+      accountRegionScope: {
+        accountId: "333333333333" as SimAwsAccountId,
+        regionName: "eu-west-2",
+      },
+    });
+    const topicArn = "arn:aws:sns:eu-west-2:333333333333:orders";
+
+    await simSns.createTopic({ input: { Name: "orders" } });
+    await simSns.subscribe({
+      input: {
+        TopicArn: topicArn,
+        Protocol: "sqs",
+        Endpoint: "arn:aws:sqs:eu-west-2:333333333333:orders",
+      },
+    });
+
+    // When a message is published.
+    await simSns.publish({ input: { TopicArn: topicArn, Message: "order-1" } });
+    await background.complete();
+
+    // Then the delivery is refused, because there is no other simulated
+    // service to reach, and the reason says how to get one.
+    const failures = simSns.deliveryFailures;
+
+    assertArrayLength(failures, 1);
+    assertNonNullable(failures[0]);
+    assertStringIncludes(
+      failures[0].reason,
+      "Reach simulated SNS through SimAws",
+    );
+  });
+
+  it("does not deliver to a queue that is not there", async () => {
+    // Given a topic subscribed to a queue nothing created.
+    const { simAws, topicArn } = await simAwsWithTopic();
+
+    await simAws.sns().subscribe({
+      input: {
+        TopicArn: topicArn,
+        Protocol: "sqs",
+        Endpoint: "arn:aws:sqs:us-east-1:888888888888:missing",
+      },
+    });
+
+    // When two messages are published.
+    await simAws
+      .sns()
+      .publish(new PublishCommand({ TopicArn: topicArn, Message: "order-1" }));
+    await simAws
+      .sns()
+      .publish(new PublishCommand({ TopicArn: topicArn, Message: "order-2" }));
+
+    await simAws.backgroundTasksComplete();
+
+    // Then both failures are kept and each names the queue, since real SNS
+    // does not check the endpoint exists at Subscribe time either. Only the
+    // first is warned about, so a broken endpoint does not fill the output.
+    const failures = simAws.sns().deliveryFailures;
+
+    assertArrayLength(failures, 2);
+    assertNonNullable(failures[0]);
+    assertNonNullable(failures[1]);
+    assertStringIncludes(failures[0].reason, "is not a simulated SQS queue");
+    assertStringIncludes(failures[1].reason, "is not a simulated SQS queue");
+  });
+});

--- a/src/service/sns/delivery/sim-sns-delivery.ts
+++ b/src/service/sns/delivery/sim-sns-delivery.ts
@@ -1,0 +1,39 @@
+import type { SimSnsSqsMessageAttribute } from "../message/sim-sns-message-attributes.js";
+
+/**
+ * The service principal simulated SNS reaches another service as.
+ *
+ * This is the principal a destination's resource policy has to admit, which is
+ * why a queue subscribed to a topic needs `sns.amazonaws.com` in its policy.
+ */
+export const simSnsServicePrincipal = "sns.amazonaws.com";
+
+/**
+ * One message on its way from a topic to a subscription's endpoint.
+ *
+ * The body is already whichever form the subscription asked for, since which
+ * one it is is the subscription's business rather than the endpoint's. The
+ * attributes are only carried for raw delivery: an envelope has them inside it.
+ */
+export interface SimSnsDeliveryRequest {
+  readonly endpointArn: string;
+  readonly topicArn: string;
+  readonly topicOwnerAccountId: string;
+  readonly body: string;
+  readonly messageAttributes?:
+    Readonly<Record<string, SimSnsSqsMessageAttribute>> | undefined;
+}
+
+/**
+ * Somewhere a simulated topic can deliver a published message.
+ *
+ * There is one implementation, for a queue, because `sqs` is the only protocol
+ * simulated. A second protocol adds a second implementation rather than a
+ * branch in this one.
+ */
+export interface SimSnsDeliveryEndpoints {
+  /**
+   * Deliver one message, refusing if the endpoint does not admit SNS.
+   */
+  deliver(request: SimSnsDeliveryRequest): Promise<void>;
+}

--- a/src/service/sns/delivery/sim-sns-envelope.ts
+++ b/src/service/sns/delivery/sim-sns-envelope.ts
@@ -1,0 +1,107 @@
+import { jsonStringify } from "../../../util/type-guard/json.js";
+import type { SimSnsPublishedMessage } from "../message/sim-sns-published-message.js";
+import { simSnsUnsubscribeUrl } from "../signature/sim-sns-host.js";
+import type { SimSnsMessageSigner } from "../signature/sim-sns-message-signer.js";
+import type { SimSnsSubscription } from "../subscription/sim-sns-subscription.js";
+
+/**
+ * What a message published to a topic is, as opposed to a subscription
+ * confirmation, which is the only other kind of message real SNS delivers.
+ */
+const notificationType = "Notification";
+
+interface SimSnsEnvelopeProperties {
+  readonly message: SimSnsPublishedMessage;
+  readonly subscription: SimSnsSubscription;
+  readonly regionName: string;
+  readonly signer: SimSnsMessageSigner;
+}
+
+/**
+ * The document a subscription receives when it is not asking for raw delivery.
+ *
+ * Real SNS wraps the published message in this, which is why a consumer written
+ * for it reads `JSON.parse(body).Message` rather than `body`. Everything real
+ * SNS puts in it is here, including a signature a verifier can actually check.
+ */
+export class SimSnsEnvelope {
+  private readonly message: SimSnsPublishedMessage;
+  private readonly subscription: SimSnsSubscription;
+  private readonly regionName: string;
+  private readonly signer: SimSnsMessageSigner;
+
+  constructor(properties: SimSnsEnvelopeProperties) {
+    this.message = properties.message;
+    this.subscription = properties.subscription;
+    this.regionName = properties.regionName;
+    this.signer = properties.signer;
+  }
+
+  /**
+   * The envelope as the JSON body a queue receives.
+   */
+  get body(): string {
+    return jsonStringify(this.document());
+  }
+
+  /**
+   * The string real SNS signs, which is what a verifier rebuilds to check the
+   * signature.
+   *
+   * Each signed field is its name and its value, both followed by a newline.
+   * The message attributes are not signed, here or on real AWS, so changing one
+   * in flight leaves the signature valid.
+   */
+  canonicalMessage(): string {
+    const parts: string[] = [];
+
+    for (const [name, value] of this.signedFields()) {
+      if (value !== undefined) {
+        parts.push(`${name}\n${value}\n`);
+      }
+    }
+
+    return parts.join("");
+  }
+
+  /**
+   * The fields the signature covers, in the order it covers them.
+   *
+   * They are pairs rather than an object because the order is the signature's
+   * business: it is the alphabetical order of the field names, and rebuilding
+   * the string in any other order fails to verify.
+   */
+  private signedFields(): readonly (readonly [string, string | undefined])[] {
+    return [
+      ["Message", this.message.body.value],
+      ["MessageId", this.message.messageId],
+      ["Subject", this.message.subject?.value],
+      ["Timestamp", this.message.publishedAt.toISOString()],
+      ["TopicArn", this.subscription.topicArn],
+      ["Type", notificationType],
+    ];
+  }
+
+  private document(): Record<string, unknown> {
+    const attributes = this.message.attributes;
+
+    return {
+      Type: notificationType,
+      MessageId: this.message.messageId,
+      TopicArn: this.subscription.topicArn,
+      ...(this.message.subject !== undefined && {
+        Subject: this.message.subject.value,
+      }),
+      Message: this.message.body.value,
+      Timestamp: this.message.publishedAt.toISOString(),
+      ...this.signer.sign(this.canonicalMessage()),
+      UnsubscribeURL: simSnsUnsubscribeUrl(
+        this.regionName,
+        this.subscription.arn.value,
+      ),
+      ...(!attributes.isEmpty && {
+        MessageAttributes: attributes.inEnvelope(),
+      }),
+    };
+  }
+}

--- a/src/service/sns/delivery/sim-sns-fan-out.iso.test.ts
+++ b/src/service/sns/delivery/sim-sns-fan-out.iso.test.ts
@@ -1,0 +1,267 @@
+import {
+  PublishBatchCommand,
+  PublishCommand,
+  SetSubscriptionAttributesCommand,
+  UnsubscribeCommand,
+} from "@aws-sdk/client-sns";
+import { ReceiveMessageCommand } from "@aws-sdk/client-sqs";
+import {
+  assertArrayLength,
+  assertBufferEqual,
+  assertIdentical,
+  assertNonNullable,
+  assertObjectMatches,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import {
+  simSnsDeliveredMessage,
+  simSnsSubscribedQueue,
+} from "../../../../test/sns/subscription-fixture.js";
+import { simAwsWithTopic } from "../../../../test/sns/topic-fixture.js";
+
+/**
+ * The `Message` a delivered envelope carries.
+ */
+function envelopeMessage(body: string | undefined): unknown {
+  assertNonNullable(body);
+
+  return (JSON.parse(body) as Record<string, unknown>)["Message"];
+}
+
+describe("SNS fan-out to a queue", () => {
+  it("delivers one published message to every subscribed queue", async () => {
+    // Given a topic with two queues subscribed to it.
+    const { simAws, topicArn } = await simAwsWithTopic();
+    const orders = await simSnsSubscribedQueue(simAws, "orders", topicArn);
+    const audit = await simSnsSubscribedQueue(simAws, "audit", topicArn);
+
+    // When one message is published.
+    await simAws
+      .sns()
+      .publish(new PublishCommand({ TopicArn: topicArn, Message: "order-1" }));
+
+    // Then both queues receive a copy of it, which is what a topic is for.
+    assertIdentical(
+      envelopeMessage(await simSnsDeliveredMessage(simAws, orders.queueUrl)),
+      "order-1",
+    );
+    assertIdentical(
+      envelopeMessage(await simSnsDeliveredMessage(simAws, audit.queueUrl)),
+      "order-1",
+    );
+  });
+
+  it("delivers the SNS envelope by default", async () => {
+    // Given a topic with a subscribed queue.
+    const { simAws, topicArn } = await simAwsWithTopic();
+    const { queueUrl } = await simSnsSubscribedQueue(
+      simAws,
+      "orders",
+      topicArn,
+    );
+
+    // When a message with a subject and an attribute is published.
+    const published = await simAws.sns().publish(
+      new PublishCommand({
+        TopicArn: topicArn,
+        Subject: "New order",
+        Message: "order-1",
+        MessageAttributes: {
+          tenant: { DataType: "String", StringValue: "acme" },
+        },
+      }),
+    );
+
+    // Then the body is the envelope real SNS wraps a message in, so a consumer
+    // reads the message out of it rather than off the body.
+    const body = await simSnsDeliveredMessage(simAws, queueUrl);
+
+    assertNonNullable(body);
+    assertObjectMatches(JSON.parse(body), {
+      Type: "Notification",
+      MessageId: published.MessageId,
+      TopicArn: topicArn,
+      Subject: "New order",
+      Message: "order-1",
+      SignatureVersion: "1",
+      MessageAttributes: { tenant: { Type: "String", Value: "acme" } },
+    });
+  });
+
+  it("delivers the raw message with its attributes when asked to", async () => {
+    // Given a topic with a queue subscribed for raw delivery.
+    const { simAws, topicArn } = await simAwsWithTopic();
+    const { queueUrl } = await simSnsSubscribedQueue(
+      simAws,
+      "orders",
+      topicArn,
+    );
+    const [subscription] = simAws.sns().topicSubscriptions("orders");
+
+    assertNonNullable(subscription);
+
+    await simAws.sns().setSubscriptionAttributes(
+      new SetSubscriptionAttributesCommand({
+        SubscriptionArn: subscription.arn.value,
+        AttributeName: "RawMessageDelivery",
+        AttributeValue: "true",
+      }),
+    );
+
+    // When a message with an attribute is published.
+    await simAws.sns().publish(
+      new PublishCommand({
+        TopicArn: topicArn,
+        Message: "order-1",
+        MessageAttributes: {
+          tenant: { DataType: "String", StringValue: "acme" },
+        },
+      }),
+    );
+
+    await simAws.backgroundTasksComplete();
+
+    // Then the body is the message on its own, and the publish's attributes
+    // arrive as SQS message attributes instead of inside an envelope.
+    const received = await simAws.sqs().receiveMessage(
+      new ReceiveMessageCommand({
+        QueueUrl: queueUrl,
+        MessageAttributeNames: ["All"],
+      }),
+    );
+    const message = received.Messages?.[0];
+
+    assertNonNullable(message);
+    assertIdentical(message.Body, "order-1");
+    assertIdentical(message.MessageAttributes?.["tenant"]?.StringValue, "acme");
+  });
+
+  it("carries a binary attribute base64 in the envelope and as bytes raw", async () => {
+    // Given a topic with a queue subscribed for the envelope, and one for the
+    // raw message.
+    const { simAws, topicArn } = await simAwsWithTopic();
+    const wrapped = await simSnsSubscribedQueue(simAws, "wrapped", topicArn);
+    const raw = await simSnsSubscribedQueue(simAws, "raw", topicArn);
+    const rawSubscription = simAws
+      .sns()
+      .topicSubscriptions("orders")
+      .find((held) => held.endpoint.value === raw.queueArn);
+
+    assertNonNullable(rawSubscription);
+
+    await simAws.sns().setSubscriptionAttributes(
+      new SetSubscriptionAttributesCommand({
+        SubscriptionArn: rawSubscription.arn.value,
+        AttributeName: "RawMessageDelivery",
+        AttributeValue: "true",
+      }),
+    );
+
+    // When a message with a binary attribute is published.
+    await simAws.sns().publish(
+      new PublishCommand({
+        TopicArn: topicArn,
+        Message: "order-1",
+        MessageAttributes: {
+          receipt: {
+            DataType: "Binary",
+            BinaryValue: Uint8Array.from([1, 2, 3]),
+          },
+        },
+      }),
+    );
+
+    await simAws.backgroundTasksComplete();
+
+    // Then the envelope carries it base64 encoded, since an envelope is JSON.
+    const body = await simSnsDeliveredMessage(simAws, wrapped.queueUrl);
+
+    assertNonNullable(body);
+    assertObjectMatches(JSON.parse(body), {
+      MessageAttributes: {
+        receipt: {
+          Type: "Binary",
+          Value: Buffer.from([1, 2, 3]).toString("base64"),
+        },
+      },
+    });
+
+    // And raw delivery carries it as the bytes it was published as.
+    const received = await simAws.sqs().receiveMessage(
+      new ReceiveMessageCommand({
+        QueueUrl: raw.queueUrl,
+        MessageAttributeNames: ["All"],
+      }),
+    );
+
+    assertBufferEqual(
+      Buffer.from(
+        received.Messages?.[0]?.MessageAttributes?.["receipt"]?.BinaryValue ??
+          [],
+      ),
+      Buffer.from([1, 2, 3]),
+    );
+  });
+
+  it("delivers every message of a batch", async () => {
+    // Given a topic with a subscribed queue.
+    const { simAws, topicArn } = await simAwsWithTopic();
+    const { queueUrl } = await simSnsSubscribedQueue(
+      simAws,
+      "orders",
+      topicArn,
+    );
+
+    // When two messages are published as one batch.
+    await simAws.sns().publishBatch(
+      new PublishBatchCommand({
+        TopicArn: topicArn,
+        PublishBatchRequestEntries: [
+          { Id: "one", Message: "order-1" },
+          { Id: "two", Message: "order-2" },
+        ],
+      }),
+    );
+
+    await simAws.backgroundTasksComplete();
+
+    // Then both reach the queue.
+    const received = await simAws.sqs().receiveMessage(
+      new ReceiveMessageCommand({
+        QueueUrl: queueUrl,
+        MaxNumberOfMessages: 10,
+      }),
+    );
+
+    assertArrayLength(received.Messages, 2);
+  });
+
+  it("stops delivering once the subscription is gone", async () => {
+    // Given a topic with a subscribed queue that is then unsubscribed.
+    const { simAws, topicArn } = await simAwsWithTopic();
+    const { queueUrl, queueArn } = await simSnsSubscribedQueue(
+      simAws,
+      "orders",
+      topicArn,
+    );
+    const [subscription] = simAws.sns().topicSubscriptions("orders");
+
+    assertNonNullable(subscription);
+    assertIdentical(subscription.endpoint.value, queueArn);
+
+    await simAws
+      .sns()
+      .unsubscribe(
+        new UnsubscribeCommand({ SubscriptionArn: subscription.arn.value }),
+      );
+
+    // When a message is published.
+    await simAws
+      .sns()
+      .publish(new PublishCommand({ TopicArn: topicArn, Message: "order-1" }));
+
+    // Then nothing reaches the queue.
+    assertUndefined(await simSnsDeliveredMessage(simAws, queueUrl));
+  });
+});

--- a/src/service/sns/delivery/sim-sns-fan-out.ts
+++ b/src/service/sns/delivery/sim-sns-fan-out.ts
@@ -1,0 +1,87 @@
+import type { BackgroundScheduler } from "../../../util/background/background.js";
+import type { SimSnsPublishedMessage } from "../message/sim-sns-published-message.js";
+import type { SimSnsSubscription } from "../subscription/sim-sns-subscription.js";
+import type { SimSnsSubscriptionStore } from "../subscription/sim-sns-subscription-store.js";
+import type { SimSnsTopic } from "../topic/sim-sns-topic.js";
+import type { SimSnsDeliveryEndpoints } from "./sim-sns-delivery.js";
+import type { SimSnsDeliveryRequests } from "./sim-sns-delivery-request.js";
+import type { SimSnsDeliveryFailure } from "./sim-sns-delivery-failures.js";
+import { SimSnsDeliveryFailures } from "./sim-sns-delivery-failures.js";
+
+interface SimSnsFanOutProperties {
+  readonly subscriptions: SimSnsSubscriptionStore;
+  readonly endpoints: SimSnsDeliveryEndpoints;
+  readonly requests: SimSnsDeliveryRequests;
+  readonly background: BackgroundScheduler;
+}
+
+/**
+ * Hands a published message to every subscription of its topic.
+ *
+ * Delivery happens on the background scheduler, as real SNS delivers after the
+ * publish has been answered: a publish gets a message id whether or not
+ * anything downstream takes the message.
+ * `simAws.backgroundTasksComplete()` is what waits for it.
+ */
+export class SimSnsFanOut {
+  private readonly subscriptions: SimSnsSubscriptionStore;
+  private readonly endpoints: SimSnsDeliveryEndpoints;
+  private readonly requests: SimSnsDeliveryRequests;
+  private readonly background: BackgroundScheduler;
+  private readonly failures = new SimSnsDeliveryFailures();
+
+  constructor(properties: SimSnsFanOutProperties) {
+    this.subscriptions = properties.subscriptions;
+    this.endpoints = properties.endpoints;
+    this.requests = properties.requests;
+    this.background = properties.background;
+  }
+
+  /**
+   * Every message this scope could not deliver.
+   */
+  get deliveryFailures(): readonly SimSnsDeliveryFailure[] {
+    return this.failures.all;
+  }
+
+  /**
+   * Schedule one message for every subscription of a topic.
+   *
+   * Each subscription gets its own copy, which is the whole point of a topic:
+   * two queues subscribed to one topic both receive what was published once.
+   */
+  publish(topic: SimSnsTopic, message: SimSnsPublishedMessage): void {
+    const subscribed = this.subscriptions.forTopic(topic.name.value);
+
+    for (const subscription of subscribed) {
+      this.background.schedule(async () => {
+        await this.deliver(topic, subscription, message);
+      });
+    }
+  }
+
+  /**
+   * Deliver one message to one subscription, keeping whatever went wrong.
+   *
+   * A failure is recorded rather than thrown, because a background task left
+   * rejected would fail an unrelated `backgroundTasksComplete()`, and real SNS
+   * never reports a delivery failure to the caller who published.
+   */
+  private async deliver(
+    topic: SimSnsTopic,
+    subscription: SimSnsSubscription,
+    message: SimSnsPublishedMessage,
+  ): Promise<void> {
+    try {
+      await this.endpoints.deliver(this.requests.for(subscription, message));
+    } catch (error) {
+      this.failures.record({
+        topicArn: topic.arn.value,
+        subscriptionArn: subscription.arn.value,
+        endpointArn: subscription.endpoint.value,
+        messageId: message.messageId,
+        error,
+      });
+    }
+  }
+}

--- a/src/service/sns/delivery/sim-sns-signature.iso.test.ts
+++ b/src/service/sns/delivery/sim-sns-signature.iso.test.ts
@@ -1,0 +1,157 @@
+import { createVerify, X509Certificate } from "node:crypto";
+import { PublishCommand } from "@aws-sdk/client-sns";
+import {
+  assertFalse,
+  assertIdentical,
+  assertNonNullable,
+  assertStringEndsWith,
+  assertStringIncludes,
+  assertTrue,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import {
+  simSnsDeliveredMessage,
+  simSnsSubscribedQueue,
+} from "../../../../test/sns/subscription-fixture.js";
+import { simAwsWithTopic } from "../../../../test/sns/topic-fixture.js";
+import type { SimAws } from "../../aws/sim-aws.js";
+
+/**
+ * The fields a signed SNS message carries.
+ */
+interface SnsEnvelope {
+  readonly Type: string;
+  readonly MessageId: string;
+  readonly Subject?: string;
+  readonly Message: string;
+  readonly Timestamp: string;
+  readonly TopicArn: string;
+  readonly Signature: string;
+  readonly SigningCertURL: string;
+}
+
+/**
+ * Rebuild the string real SNS signs, the way a real verifier rebuilds it.
+ *
+ * The signed fields are in alphabetical order, each one its name and its value
+ * followed by a newline, and a field the message does not carry is left out.
+ */
+function canonicalMessage(envelope: SnsEnvelope): string {
+  const signed: readonly (readonly [string, string | undefined])[] = [
+    ["Message", envelope.Message],
+    ["MessageId", envelope.MessageId],
+    ["Subject", envelope.Subject],
+    ["Timestamp", envelope.Timestamp],
+    ["TopicArn", envelope.TopicArn],
+    ["Type", envelope.Type],
+  ];
+
+  return signed
+    .filter(([, value]) => value !== undefined)
+    .map(([name, value]) => `${name}\n${value ?? ""}\n`)
+    .join("");
+}
+
+/**
+ * Verify a signature against the certificate the simulation issued.
+ */
+function verifies(
+  simAws: SimAws,
+  envelope: SnsEnvelope,
+  signed: string,
+): boolean {
+  const certificate = simAws.sns().signingCertificate(envelope.SigningCertURL);
+
+  assertNonNullable(certificate, "The SigningCertURL names a certificate");
+
+  return createVerify("RSA-SHA1")
+    .update(signed, "utf8")
+    .verify(certificate, envelope.Signature, "base64");
+}
+
+/**
+ * Publish one message and read the envelope a subscribed queue received.
+ */
+async function deliveredEnvelope(subject?: string): Promise<{
+  simAws: SimAws;
+  envelope: SnsEnvelope;
+}> {
+  const { simAws, topicArn } = await simAwsWithTopic();
+  const { queueUrl } = await simSnsSubscribedQueue(simAws, "orders", topicArn);
+
+  await simAws.sns().publish(
+    new PublishCommand({
+      TopicArn: topicArn,
+      Message: "order-1",
+      ...(subject !== undefined && { Subject: subject }),
+    }),
+  );
+
+  const body = await simSnsDeliveredMessage(simAws, queueUrl);
+
+  assertNonNullable(body);
+
+  return { simAws, envelope: JSON.parse(body) as SnsEnvelope };
+}
+
+describe("SNS message signature", () => {
+  it("signs a delivered message so its signature verifies", async () => {
+    // Given a message delivered to a subscribed queue.
+    const { simAws, envelope } = await deliveredEnvelope("New order");
+
+    // When the signature is checked against the certificate the message names.
+    // Then it verifies, so a consumer can check a simulated message the way it
+    // checks a real one.
+    assertIdentical(envelope.Type, "Notification");
+    assertTrue(verifies(simAws, envelope, canonicalMessage(envelope)));
+  });
+
+  it("fails to verify a message that has been changed", async () => {
+    // Given a message delivered to a subscribed queue.
+    const { simAws, envelope } = await deliveredEnvelope();
+
+    // When the message is changed and the signature is checked again.
+    const tampered = canonicalMessage({ ...envelope, Message: "order-2" });
+
+    // Then it does not verify, which is the whole point of signing it.
+    assertFalse(verifies(simAws, envelope, tampered));
+  });
+
+  it("names a certificate that is a certificate", async () => {
+    // Given a message delivered to a subscribed queue.
+    const { simAws, envelope } = await deliveredEnvelope();
+
+    // When the certificate the message names is read.
+    const pem = simAws.sns().signingCertificate(envelope.SigningCertURL);
+
+    assertNonNullable(pem);
+
+    const certificate = new X509Certificate(pem);
+
+    // Then it is an X.509 certificate naming the simulated SNS host, which is
+    // what the signing certificate URL names too.
+    assertIdentical(certificate.subject, "CN=sns.us-east-1.yulin.invalid");
+    assertStringIncludes(
+      envelope.SigningCertURL,
+      "https://sns.us-east-1.yulin.invalid/SimulatedNotificationService-",
+    );
+    assertStringEndsWith(envelope.SigningCertURL, ".pem");
+  });
+
+  it("hands out no certificate for a URL it did not issue", async () => {
+    // Given a message delivered to a subscribed queue.
+    const { simAws } = await deliveredEnvelope();
+
+    // When a certificate is asked for by another URL.
+    const pem = simAws
+      .sns()
+      .signingCertificate(
+        "https://sns.us-east-1.amazonaws.com/SimpleNotificationService-1.pem",
+      );
+
+    // Then there is none, so a message signed elsewhere is not verified
+    // against this scope's key by accident.
+    assertUndefined(pem);
+  });
+});

--- a/src/service/sns/delivery/sqs/sim-aws-sns-delivery-queues.ts
+++ b/src/service/sns/delivery/sqs/sim-aws-sns-delivery-queues.ts
@@ -1,0 +1,69 @@
+import type { SimAws } from "../../../aws/sim-aws.js";
+import { SimSnsUnsimulatedInputException } from "../../error/sim-sns.error.js";
+import { SimSnsQueueEndpointArn } from "../../subscription/sim-sns-queue-endpoint-arn.js";
+import type {
+  SimSnsDeliveryEndpoints,
+  SimSnsDeliveryRequest,
+} from "../sim-sns-delivery.js";
+import { SimSnsDeliveryQueue } from "./sim-sns-delivery-queue.js";
+
+interface SimAwsSnsDeliveryQueuesProperties {
+  readonly simAws: SimAws;
+}
+
+/**
+ * The simulated SQS queues of one simulated AWS instance, as places a topic
+ * delivers to.
+ *
+ * The queue is looked up when a message is delivered, never when this is
+ * built, for the same reason S3's notification destinations do it that way:
+ * reaching another service while this one is being constructed is a cycle with
+ * no bottom to it.
+ *
+ * A queue in another Account or another Region is allowed. Real SNS delivers to
+ * both, which is a deliberate difference from simulated S3 event notifications:
+ * real S3 requires the destination queue to be in the Bucket's Region, and real
+ * SNS does not.
+ */
+export class SimAwsSnsDeliveryQueues implements SimSnsDeliveryEndpoints {
+  private readonly simAws: SimAws;
+
+  constructor(properties: SimAwsSnsDeliveryQueuesProperties) {
+    this.simAws = properties.simAws;
+  }
+
+  /**
+   * Deliver one message to the queue its subscription's endpoint names.
+   */
+  async deliver(request: SimSnsDeliveryRequest): Promise<void> {
+    const arn = SimSnsQueueEndpointArn.parse(request.endpointArn);
+
+    await new SimSnsDeliveryQueue({
+      arn,
+      scope: this.simAws.accountRegionScope(arn.accountId, arn.regionName),
+    }).deliver(request);
+  }
+}
+
+/**
+ * The endpoints a simulated SNS built on its own can reach, which is none.
+ *
+ * A standalone SimSns has no other simulated services to reach, and owns its
+ * own background scheduler, so nothing could wait for a delivery it made even
+ * if it could make one. Subscriptions still work, since holding them takes
+ * nothing but SNS: it is delivery that is refused, and the refusal is recorded
+ * as a delivery failure like any other.
+ */
+export class SimSnsNoDeliveryEndpoints implements SimSnsDeliveryEndpoints {
+  /**
+   * Refuse every delivery, explaining how to get one.
+   */
+  deliver(request: SimSnsDeliveryRequest): never {
+    throw new SimSnsUnsimulatedInputException(
+      `Cannot deliver to ${request.endpointArn}: this SimSns was constructed ` +
+        "on its own, so it has no other simulated services to deliver to and " +
+        "no shared background scheduler to deliver on. Reach simulated SNS " +
+        "through SimAws to deliver a published message to a queue.",
+    );
+  }
+}

--- a/src/service/sns/delivery/sqs/sim-sns-delivery-queue.ts
+++ b/src/service/sns/delivery/sqs/sim-sns-delivery-queue.ts
@@ -1,0 +1,98 @@
+import type { SimAwsAccountRegionContainer } from "../../../aws/sim-aws-account-region-scope.js";
+import { SimSqsServiceSendAuthorizer } from "../../../sqs/command/authorize/sim-sqs-service-send-authorizer.js";
+import { SimSnsDeliveryNotPermitted } from "../../error/sim-sns-delivery.error.js";
+import { SimSnsNotFoundException } from "../../error/sim-sns.error.js";
+import type { SimSnsQueueEndpointArn } from "../../subscription/sim-sns-queue-endpoint-arn.js";
+import {
+  type SimSnsDeliveryRequest,
+  simSnsServicePrincipal,
+} from "../sim-sns-delivery.js";
+
+interface SimSnsDeliveryQueueProperties {
+  readonly arn: SimSnsQueueEndpointArn;
+  readonly scope: SimAwsAccountRegionContainer;
+}
+
+/**
+ * One queue a simulated topic is delivering to, in the Account and Region its
+ * ARN names.
+ *
+ * Everything is asked of the queue's own Account, which is what makes a queue
+ * in another Account reachable: its policy is the grant, and its Account's IAM
+ * is what evaluates it.
+ */
+export class SimSnsDeliveryQueue {
+  private readonly arn: SimSnsQueueEndpointArn;
+  private readonly scope: SimAwsAccountRegionContainer;
+
+  constructor(properties: SimSnsDeliveryQueueProperties) {
+    this.arn = properties.arn;
+    this.scope = properties.scope;
+  }
+
+  /**
+   * Put one message on the queue, if it admits SNS for this topic.
+   *
+   * The queue policy is consulted on every delivery rather than remembered
+   * from the moment the subscription was made, so a permission taken away
+   * afterwards stops delivery. Real SNS does not check it at `Subscribe` time
+   * at all, which is why this is the only place it is asked.
+   */
+  async deliver(request: SimSnsDeliveryRequest): Promise<void> {
+    const queue = this.scope.sqs().findQueue(this.arn.queueName);
+
+    if (queue === undefined) {
+      // Not a refusal: the queue policy said nothing, because there is no
+      // queue. A subscription pointing at nothing is a mistake worth warning
+      // about, where a policy saying no is a modelled outcome a test may be
+      // asking for on purpose.
+      throw new SimSnsNotFoundException(
+        `${request.endpointArn} is not a simulated SQS queue.`,
+      );
+    }
+
+    const decision = new SimSqsServiceSendAuthorizer({
+      iam: this.scope.iam(),
+    }).authorize({
+      queue,
+      servicePrincipal: simSnsServicePrincipal,
+      sourceArn: request.topicArn,
+      sourceAccount: request.topicOwnerAccountId,
+    });
+
+    if (decision.isDenied) {
+      throw new SimSnsDeliveryNotPermitted(
+        `The queue policy of ${request.endpointArn} does not allow ` +
+          `${simSnsServicePrincipal} to send to it for ${request.topicArn}. ` +
+          "Grant sqs:SendMessage with the queue's Policy attribute.",
+      );
+    }
+
+    await this.send(request);
+  }
+
+  /**
+   * Send the message through the ordinary SendMessage path.
+   *
+   * A delivered message is therefore the same thing an SDK caller would have
+   * sent, and is authorized again on the way in.
+   */
+  private async send(request: SimSnsDeliveryRequest): Promise<void> {
+    await this.scope.sqs().sendMessage(
+      {
+        input: {
+          QueueUrl: this.arn.queueUrl,
+          MessageBody: request.body,
+          ...(request.messageAttributes !== undefined && {
+            MessageAttributes: request.messageAttributes,
+          }),
+        },
+      },
+      {
+        caller: { kind: "service", service: simSnsServicePrincipal },
+        sourceArn: request.topicArn,
+        sourceAccount: request.topicOwnerAccountId,
+      },
+    );
+  }
+}

--- a/src/service/sns/error/sim-sns-delivery.error.ts
+++ b/src/service/sns/error/sim-sns-delivery.error.ts
@@ -1,0 +1,13 @@
+import { SimSnsError } from "./sim-sns.error.js";
+
+/**
+ * Simulated SNS error for an endpoint that would not take a message.
+ *
+ * Real SNS has no error for this, because it never reports a delivery failure
+ * to the caller who published: a publish is answered before anything is
+ * delivered. This is what the failure is recorded as instead, so a test that
+ * wonders why a queue is empty can find out.
+ */
+export class SimSnsDeliveryNotPermitted extends SimSnsError {
+  public override readonly name = "SimSnsDeliveryNotPermitted";
+}

--- a/src/service/sns/index.ts
+++ b/src/service/sns/index.ts
@@ -45,6 +45,21 @@ export {
   SimSnsPublishedMessage,
 } from "./message/sim-sns-published-message.js";
 export {
+  type SimSnsDeliveryEndpoints,
+  type SimSnsDeliveryRequest,
+  simSnsServicePrincipal,
+} from "./delivery/sim-sns-delivery.js";
+export {
+  SimSnsDeliveryFailure,
+  SimSnsDeliveryFailures,
+} from "./delivery/sim-sns-delivery-failures.js";
+export { simSnsHost, simSnsUnsubscribeUrl } from "./signature/sim-sns-host.js";
+export {
+  type SimSnsSignatureFields,
+  simSnsSignatureVersion,
+} from "./signature/sim-sns-message-signer.js";
+export { SimSnsDeliveryNotPermitted } from "./error/sim-sns-delivery.error.js";
+export {
   SimSnsAuthorizationErrorException,
   SimSnsBatchEntryIdsNotDistinctException,
   SimSnsBatchRequestTooLongException,

--- a/src/service/sns/message/sim-sns-message-attribute.ts
+++ b/src/service/sns/message/sim-sns-message-attribute.ts
@@ -40,6 +40,26 @@ export class SimSnsMessageAttribute {
   }
 
   /**
+   * Whether this attribute carries bytes rather than text.
+   *
+   * The data type says which: `Binary` and anything under it carries bytes, and
+   * `String` and `Number` and their custom types carry text.
+   */
+  get isBinary(): boolean {
+    return this.dataType === "Binary" || this.dataType.startsWith("Binary.");
+  }
+
+  /**
+   * This attribute as the SNS envelope reports it.
+   *
+   * The envelope is JSON, so a binary value travels base64 encoded, which is
+   * what real SNS does with one.
+   */
+  get envelopeValue(): string {
+    return this.value.toString(this.isBinary ? "base64" : "utf8");
+  }
+
+  /**
    * What this attribute contributes to the size of a publish.
    *
    * Real SNS counts message attributes against the same 256 KB a message body

--- a/src/service/sns/message/sim-sns-message-attributes.ts
+++ b/src/service/sns/message/sim-sns-message-attributes.ts
@@ -44,4 +44,71 @@ export class SimSnsMessageAttributes {
       0,
     );
   }
+
+  /**
+   * Whether there are any attributes at all.
+   *
+   * A message published without attributes carries no `MessageAttributes` in
+   * its envelope, rather than an empty object, which is what real SNS does.
+   */
+  get isEmpty(): boolean {
+    return this.attributes.length === 0;
+  }
+
+  /**
+   * These attributes as the SNS envelope reports them.
+   *
+   * The envelope names the data type `Type` and the value `Value`, which is not
+   * the shape a publish request carries them in, nor the shape SQS carries
+   * them in.
+   */
+  inEnvelope(): Record<string, SimSnsEnvelopeMessageAttribute> {
+    return Object.fromEntries(
+      this.attributes.map((attribute) => [
+        attribute.name,
+        { Type: attribute.dataType, Value: attribute.envelopeValue },
+      ]),
+    );
+  }
+
+  /**
+   * These attributes as SQS message attributes.
+   *
+   * A subscription with raw message delivery turned on has its attributes moved
+   * onto the SQS message rather than left in an envelope there is no longer
+   * one of.
+   */
+  asSqsAttributes(): Record<string, SimSnsSqsMessageAttribute> {
+    return Object.fromEntries(
+      this.attributes.map((attribute) => [
+        attribute.name,
+        {
+          DataType: attribute.dataType,
+          ...(attribute.isBinary
+            ? { BinaryValue: Uint8Array.from(attribute.value) }
+            : { StringValue: attribute.value.toString("utf8") }),
+        },
+      ]),
+    );
+  }
+}
+
+/**
+ * One message attribute as the SNS envelope reports it.
+ */
+export interface SimSnsEnvelopeMessageAttribute {
+  readonly Type: string;
+  readonly Value: string;
+}
+
+/**
+ * One message attribute as an SQS message carries it.
+ *
+ * This is the SQS shape rather than the SNS one: the data type is `DataType`,
+ * and the value is under the name of the form it takes.
+ */
+export interface SimSnsSqsMessageAttribute {
+  readonly DataType: string;
+  readonly StringValue?: string | undefined;
+  readonly BinaryValue?: Uint8Array | undefined;
 }

--- a/src/service/sns/signature/sim-sns-certificate.ts
+++ b/src/service/sns/signature/sim-sns-certificate.ts
@@ -1,0 +1,180 @@
+import type { KeyObject } from "node:crypto";
+import { createSign } from "node:crypto";
+import {
+  derBitStringTag,
+  derBytes,
+  derExplicitZeroTag,
+  derIntegerTag,
+  derNullTag,
+  derObjectIdentifierTag,
+  derPrintableStringTag,
+  derSequenceTag,
+  derSetTag,
+  derText,
+  derUtcTimeTag,
+  derValue,
+} from "./sim-sns-der.js";
+
+/**
+ * The body bytes of the sha1WithRSAEncryption object identifier,
+ * 1.2.840.113549.1.1.5.
+ *
+ * This is the algorithm signature version 1 names, which is the version real
+ * SNS signs with unless a topic opts into version 2.
+ */
+const sha1WithRsaEncryption = [
+  0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d, 0x01, 0x01, 0x05,
+];
+
+/**
+ * The body bytes of the commonName object identifier, 2.5.4.3.
+ */
+const commonName = [0x55, 0x04, 0x03];
+
+/**
+ * The version number of an X.509 v3 certificate, which counts from zero.
+ */
+const version3 = 2;
+
+/**
+ * When the certificate becomes valid, and when it stops being valid.
+ *
+ * Both are fixed rather than taken from the clock, so the same key always
+ * produces the same certificate and nothing in a test suite depends on when it
+ * ran. The end is before 2050 because a certificate valid past then cannot use
+ * the UTCTime encoding, and nothing here is a real trust anchor that ought to
+ * expire.
+ */
+const notBefore = new Date("2000-01-01T00:00:00.000Z");
+
+const notAfter = new Date("2049-12-31T23:59:59.000Z");
+
+/**
+ * How many bytes of the public key digest become the serial number.
+ */
+const serialNumberBytes = 8;
+
+/**
+ * How many base64 characters a PEM document puts on one line.
+ */
+const pemLineLength = 64;
+
+interface SimSnsCertificateInput {
+  readonly privateKey: KeyObject;
+  readonly publicKey: KeyObject;
+  readonly subjectName: string;
+  readonly serialNumber: Buffer;
+}
+
+/**
+ * A UTCTime, which is the two digit year form certificates date things with.
+ *
+ * Two digits means the year has to be before 2050, which is what X.509 says: a
+ * certificate valid past then carries a GeneralizedTime instead.
+ */
+function utcTime(instant: Date): Buffer {
+  const digits = instant.toISOString().replaceAll(/\D/gu, "");
+
+  return derText(derUtcTimeTag, `${digits.slice(2, 14)}Z`);
+}
+
+/**
+ * Wrap DER bytes as the PEM document a verifier reads.
+ */
+function toPem(der: Buffer): string {
+  const base64 = der.toString("base64");
+  const lines = Array.from(
+    { length: Math.ceil(base64.length / pemLineLength) },
+    (_unused, index) =>
+      base64.slice(index * pemLineLength, (index + 1) * pemLineLength),
+  );
+
+  return `-----BEGIN CERTIFICATE-----\n${lines.join("\n")}\n-----END CERTIFICATE-----\n`;
+}
+
+/**
+ * The algorithm identifier both the certificate body and its signature carry.
+ */
+function signatureAlgorithm(): Buffer {
+  return derValue(
+    derSequenceTag,
+    derBytes(derObjectIdentifierTag, ...sha1WithRsaEncryption),
+    derValue(derNullTag),
+  );
+}
+
+/**
+ * An X.509 Name carrying one common name, which is all this certificate needs.
+ */
+function distinguishedName(name: string): Buffer {
+  const attribute = derValue(
+    derSequenceTag,
+    derBytes(derObjectIdentifierTag, ...commonName),
+    derText(derPrintableStringTag, name),
+  );
+
+  return derValue(derSequenceTag, derValue(derSetTag, attribute));
+}
+
+/**
+ * The part of a certificate that is signed.
+ */
+function certificateBody(input: SimSnsCertificateInput): Buffer {
+  const name = distinguishedName(input.subjectName);
+
+  return derValue(
+    derSequenceTag,
+    derValue(derExplicitZeroTag, derBytes(derIntegerTag, version3)),
+    derValue(derIntegerTag, input.serialNumber),
+    signatureAlgorithm(),
+    name,
+    derValue(derSequenceTag, utcTime(notBefore), utcTime(notAfter)),
+    // Self-signed, so the issuer and the subject are the same Name.
+    name,
+    input.publicKey.export({ type: "spki", format: "der" }),
+  );
+}
+
+/**
+ * Build a self-signed X.509 certificate for a key pair, as PEM.
+ *
+ * It is the smallest certificate that is still a certificate: a version, a
+ * serial number, one common name as both issuer and subject, a validity window,
+ * the public key, and an RSA signature over all of it. There are no extensions,
+ * because nothing verifying an SNS message looks at any.
+ */
+export function simSnsSelfSignedCertificatePem(
+  input: SimSnsCertificateInput,
+): string {
+  const body = certificateBody(input);
+  const signature = createSign("RSA-SHA1").update(body).sign(input.privateKey);
+  const unusedBits = Buffer.from([0]);
+
+  return toPem(
+    derValue(
+      derSequenceTag,
+      body,
+      signatureAlgorithm(),
+      derValue(derBitStringTag, unusedBits, signature),
+    ),
+  );
+}
+
+/**
+ * Read a certificate serial number out of a digest of the public key.
+ *
+ * A real certificate authority allocates serial numbers. Nothing here has one
+ * to allocate, and a serial derived from the key is unique in the only way that
+ * matters: two simulated scopes with different keys have different serials.
+ *
+ * The top bit of the first byte is cleared, because a certificate serial number
+ * has to be positive and a DER integer is signed. Clearing it is one byte of
+ * uniqueness given up for a serial that never needs a leading zero.
+ */
+export function simSnsSerialNumber(digest: Buffer): Buffer {
+  const serial = Buffer.from(digest.subarray(0, serialNumberBytes));
+
+  serial.writeUInt8(serial.readUInt8(0) & 0x7f, 0);
+
+  return serial;
+}

--- a/src/service/sns/signature/sim-sns-der.ts
+++ b/src/service/sns/signature/sim-sns-der.ts
@@ -1,0 +1,81 @@
+/**
+ * The little bit of DER writing a self-signed certificate needs.
+ *
+ * Node's `crypto` reads an X.509 certificate but does not write one, and the
+ * signature a simulated SNS message carries is only useful if a verifier can
+ * check it against a certificate. So the certificate is assembled by hand, and
+ * this is the encoding it is assembled with: every ASN.1 value is a tag, a
+ * length and a body, and that is the whole of what is here.
+ *
+ * The tags are exported alongside it because the shapes X.509 uses are the
+ * caller's business rather than this module's. It is not a general ASN.1
+ * encoder and does not try to be one.
+ */
+
+export const derSequenceTag = 0x30;
+
+export const derSetTag = 0x31;
+
+export const derIntegerTag = 0x02;
+
+export const derBitStringTag = 0x03;
+
+export const derNullTag = 0x05;
+
+export const derObjectIdentifierTag = 0x06;
+
+export const derPrintableStringTag = 0x13;
+
+export const derUtcTimeTag = 0x17;
+
+/**
+ * The tag of an explicitly tagged context specific zero, which is how a
+ * certificate carries its version.
+ */
+export const derExplicitZeroTag = 0xa0;
+
+/**
+ * The largest length DER writes in the length byte itself.
+ */
+const shortFormLimit = 0x80;
+
+/**
+ * Encode a length in DER's short or long form.
+ */
+function derLength(length: number): Buffer {
+  if (length < shortFormLimit) {
+    return Buffer.from([length]);
+  }
+
+  const bytes: number[] = [];
+
+  for (let rest = length; rest > 0; rest = Math.floor(rest / 256)) {
+    bytes.unshift(rest % 256);
+  }
+
+  return Buffer.from([shortFormLimit | bytes.length, ...bytes]);
+}
+
+/**
+ * One ASN.1 value: a tag, the length of what follows, and what follows.
+ */
+export function derValue(tag: number, ...contents: Buffer[]): Buffer {
+  const body = Buffer.concat(contents);
+
+  return Buffer.concat([Buffer.from([tag]), derLength(body.length), body]);
+}
+
+/**
+ * A DER value holding ASCII text, which is what a common name and a UTCTime
+ * both are.
+ */
+export function derText(tag: number, value: string): Buffer {
+  return derValue(tag, Buffer.from(value, "ascii"));
+}
+
+/**
+ * A DER value holding bytes given one at a time.
+ */
+export function derBytes(tag: number, ...bytes: number[]): Buffer {
+  return derValue(tag, Buffer.from(bytes));
+}

--- a/src/service/sns/signature/sim-sns-host.ts
+++ b/src/service/sns/signature/sim-sns-host.ts
@@ -1,0 +1,38 @@
+/**
+ * The hostname the URLs in a delivered message name.
+ *
+ * Real SNS puts `sns.<region>.amazonaws.com` in the `SigningCertURL` and the
+ * `UnsubscribeURL` of every message it delivers. A simulated message names
+ * `sns.<region>.yulin.invalid` instead, because neither URL can be fetched:
+ * simulated SNS is not served over HTTP, and the certificate is handed out
+ * in process by `SimSns.signingCertificate`.
+ *
+ * `.invalid` is the reserved top level domain for exactly this. A consumer that
+ * does try to fetch one of these URLs fails to resolve it, rather than reaching
+ * real AWS and being answered by a certificate that signed nothing here.
+ *
+ * This is a divergence a real signature verifier notices. `sns-validator`
+ * hard-codes an `amazonaws.com` certificate host and fetches the URL itself, so
+ * it cannot verify a simulated message as it stands. Verifying one means
+ * checking the signature against the certificate `SimSns.signingCertificate`
+ * hands over, which is what the docs show.
+ */
+export function simSnsHost(regionName: string): string {
+  return `sns.${regionName}.yulin.invalid`;
+}
+
+/**
+ * The URL a delivered message names to say how to stop receiving them.
+ *
+ * Real SNS carries this in every envelope, and it is the same shape here with
+ * the simulated host in front of it.
+ */
+export function simSnsUnsubscribeUrl(
+  regionName: string,
+  subscriptionArn: string,
+): string {
+  return (
+    `https://${simSnsHost(regionName)}/?Action=Unsubscribe` +
+    `&SubscriptionArn=${encodeURIComponent(subscriptionArn)}`
+  );
+}

--- a/src/service/sns/signature/sim-sns-message-signer.ts
+++ b/src/service/sns/signature/sim-sns-message-signer.ts
@@ -1,0 +1,84 @@
+import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+import { simSnsHost } from "./sim-sns-host.js";
+import { SimSnsSigningKey } from "./sim-sns-signing-key.js";
+
+/**
+ * The signature version real SNS signs with unless a topic opts into version 2.
+ *
+ * Version 1 is SHA1withRSA. The `SignatureVersion` topic attribute, which is
+ * how a real topic asks for version 2, is refused here, so every message
+ * carries this.
+ */
+export const simSnsSignatureVersion = "1";
+
+/**
+ * What a signature adds to a delivered message.
+ */
+export interface SimSnsSignatureFields {
+  readonly SignatureVersion: string;
+  readonly Signature: string;
+  readonly SigningCertURL: string;
+}
+
+interface SimSnsMessageSignerProperties {
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+}
+
+/**
+ * Signs the messages one simulated SNS scope delivers.
+ *
+ * The key belongs to the scope rather than to a topic, which is how real SNS
+ * works: one certificate per Region signs every message that Region sends. It
+ * is generated on first use, because generating RSA takes long enough to
+ * notice and a scope that never delivers anything never needs one.
+ */
+export class SimSnsMessageSigner {
+  private readonly host: string;
+  private held: SimSnsSigningKey | undefined;
+
+  constructor(properties: SimSnsMessageSignerProperties) {
+    this.host = simSnsHost(properties.accountRegionScope.regionName);
+  }
+
+  /**
+   * Sign the canonical form of one message.
+   */
+  sign(canonicalMessage: string): SimSnsSignatureFields {
+    const key = this.key();
+
+    return {
+      SignatureVersion: simSnsSignatureVersion,
+      Signature: key.sign(canonicalMessage),
+      SigningCertURL: this.certificateUrl(key),
+    };
+  }
+
+  /**
+   * The certificate a `SigningCertURL` names, or nothing when it names another.
+   *
+   * This is how a verifier gets at the certificate, because the URL cannot be
+   * fetched: simulated SNS is not served over HTTP. A URL this scope did not
+   * issue answers with nothing rather than with the certificate it has, so a
+   * message signed by another scope is not accidentally verified against the
+   * wrong key.
+   */
+  certificateFor(signingCertUrl: string): string | undefined {
+    const key = this.held;
+
+    if (key === undefined || this.certificateUrl(key) !== signingCertUrl) {
+      return undefined;
+    }
+
+    return key.certificatePem;
+  }
+
+  private certificateUrl(key: SimSnsSigningKey): string {
+    return `https://${this.host}/SimulatedNotificationService-${key.fingerprint}.pem`;
+  }
+
+  private key(): SimSnsSigningKey {
+    this.held ??= SimSnsSigningKey.generate(this.host);
+
+    return this.held;
+  }
+}

--- a/src/service/sns/signature/sim-sns-signing-key.ts
+++ b/src/service/sns/signature/sim-sns-signing-key.ts
@@ -1,0 +1,84 @@
+import {
+  createHash,
+  createSign,
+  generateKeyPairSync,
+  type KeyObject,
+} from "node:crypto";
+import {
+  simSnsSelfSignedCertificatePem,
+  simSnsSerialNumber,
+} from "./sim-sns-certificate.js";
+
+/**
+ * The RSA modulus size real SNS signs with.
+ */
+const modulusLength = 2048;
+
+/**
+ * How many characters of the key's digest name the certificate.
+ *
+ * Real SNS puts an opaque hash in the certificate's file name. This is the
+ * same idea, and it means the URL names the key it actually belongs to.
+ */
+const fingerprintLength = 32;
+
+/**
+ * The key one simulated SNS scope signs its messages with.
+ *
+ * The key material is real, generated with `node:crypto`, and the signature is
+ * a real SHA1withRSA signature over the string real SNS signs. A verifier can
+ * therefore check a delivered message against the certificate, rather than
+ * being handed a `Signature` field it has no way to use.
+ */
+export class SimSnsSigningKey {
+  public readonly fingerprint: string;
+  public readonly certificatePem: string;
+
+  private readonly privateKey: KeyObject;
+
+  private constructor(subjectName: string) {
+    const { privateKey, publicKey } = generateKeyPairSync("rsa", {
+      modulusLength,
+    });
+    const digest = createHash("sha256")
+      .update(publicKey.export({ type: "spki", format: "der" }))
+      .digest();
+
+    this.privateKey = privateKey;
+    this.fingerprint = digest.toString("hex").slice(0, fingerprintLength);
+    this.certificatePem = simSnsSelfSignedCertificatePem({
+      privateKey,
+      publicKey,
+      subjectName,
+      serialNumber: simSnsSerialNumber(digest),
+    });
+  }
+
+  /**
+   * Generate a key pair for a simulated SNS scope.
+   *
+   * A scope generates its own on first use rather than at construction,
+   * because generating 2048-bit RSA takes long enough to notice and most
+   * simulated SNS scopes in a test suite never deliver anything. Nothing is
+   * written to disk, and no key material is committed: a private key in the
+   * repository would set off secret scanners for no gain.
+   */
+  static generate(subjectName: string): SimSnsSigningKey {
+    return new SimSnsSigningKey(subjectName);
+  }
+
+  /**
+   * Sign the canonical form of a message, as real SNS signs it.
+   *
+   * Signature version 1 is SHA1withRSA, and the signature travels base64
+   * encoded in the envelope. SHA-1 is weak, and it is what real SNS uses for
+   * version 1: a simulation signing with something else would produce a
+   * signature a real verifier could not check.
+   */
+  sign(canonicalMessage: string): string {
+    return createSign("RSA-SHA1")
+      .update(canonicalMessage, "utf8")
+      .sign(this.privateKey)
+      .toString("base64");
+  }
+}

--- a/src/service/sns/sim-sns.ts
+++ b/src/service/sns/sim-sns.ts
@@ -9,18 +9,12 @@ import {
   SimIamAllowAllAuth,
   type SimIamInterServiceAuthZ,
 } from "../iam/authorize/sim-iam-inter-service-auth-z.js";
-import { SimSnsAuthorizer } from "./command/authorize/sim-sns-authorizer.js";
-import { SimSnsPublishCommands } from "./command/publish/sim-sns-publish-commands.js";
+import type { SimSnsDeliveryEndpoints } from "./delivery/sim-sns-delivery.js";
+import type { SimSnsDeliveryFailure } from "./delivery/sim-sns-delivery-failures.js";
+import { SimSnsNoDeliveryEndpoints } from "./delivery/sqs/sim-aws-sns-delivery-queues.js";
 import type * as simSnsCommands from "./command/sim-sns-command.types.js";
+import { SimSnsCommands } from "./command/sim-sns-commands.js";
 import type { SimSnsRequestOptions } from "./command/sim-sns-request-options.js";
-import { SimSnsSubscriptionAccess } from "./command/subscription/sim-sns-subscription-access.js";
-import { SimSnsSubscriptionAttributeCommands } from "./command/subscription/sim-sns-subscription-attribute-commands.js";
-import { SimSnsSubscriptionCommands } from "./command/subscription/sim-sns-subscription-commands.js";
-import { SimSnsSubscriptionListings } from "./command/subscription/sim-sns-subscription-listings.js";
-import { SimSnsCreateTopic } from "./command/topic/sim-sns-create-topic.js";
-import { SimSnsTopicAccess } from "./command/topic/sim-sns-topic-access.js";
-import { SimSnsTopicAttributeCommands } from "./command/topic/sim-sns-topic-attribute-commands.js";
-import { SimSnsTopicCommands } from "./command/topic/sim-sns-topic-commands.js";
 import { SimSnsSdkCommandRouter } from "./sdk/sim-sns-sdk-command-router.js";
 import type { SimSnsSubscription } from "./subscription/sim-sns-subscription.js";
 import { SimSnsSubscriptionStore } from "./subscription/sim-sns-subscription-store.js";
@@ -31,6 +25,14 @@ interface SimSnsProperties {
   readonly accountRegionScope?: SimAwsAccountRegionScope;
   readonly iam?: SimIamInterServiceAuthZ;
   readonly background?: BackgroundScheduler;
+
+  /**
+   * Where this scope's subscriptions deliver to.
+   *
+   * A SimSns built on its own has none, since a queue in another simulated
+   * service is only reachable through SimAws.
+   */
+  readonly deliveryEndpoints?: SimSnsDeliveryEndpoints;
 }
 
 /**
@@ -45,13 +47,7 @@ interface SimSnsProperties {
 export class SimSns {
   private readonly topics = new SimSnsTopicStore();
   private readonly subscriptions = new SimSnsSubscriptionStore();
-  private readonly topicCreation: SimSnsCreateTopic;
-  private readonly topicCommands: SimSnsTopicCommands;
-  private readonly attributeCommands: SimSnsTopicAttributeCommands;
-  private readonly subscriptionCommands: SimSnsSubscriptionCommands;
-  private readonly subscriptionListings: SimSnsSubscriptionListings;
-  private readonly subscriptionAttributeCommands: SimSnsSubscriptionAttributeCommands;
-  private readonly publishCommands: SimSnsPublishCommands;
+  private readonly commands: SimSnsCommands;
   private readonly background: BackgroundScheduler;
   private readonly sdkRouter = new SimSnsSdkCommandRouter(this);
 
@@ -60,49 +56,39 @@ export class SimSns {
       accountRegionScope = simAwsAccountRegionScopeFactory.make(),
       iam = new SimIamAllowAllAuth(),
       background = new BackgroundTasks(),
+      deliveryEndpoints = new SimSnsNoDeliveryEndpoints(),
     } = properties;
 
-    const access = new SimSnsTopicAccess({
-      topics: this.topics,
-      authorizer: new SimSnsAuthorizer({ iam }),
-      accountRegionScope,
-    });
-    const subscriptionAccess = new SimSnsSubscriptionAccess({
-      subscriptions: this.subscriptions,
-      topicAccess: access,
-      accountRegionScope,
-    });
-
     this.background = background;
-    this.topicCreation = new SimSnsCreateTopic({
+    this.commands = new SimSnsCommands({
       topics: this.topics,
-      access,
+      subscriptions: this.subscriptions,
+      iam,
+      background,
+      deliveryEndpoints,
       accountRegionScope,
     });
-    this.topicCommands = new SimSnsTopicCommands({
-      topics: this.topics,
-      subscriptions: this.subscriptions,
-      access,
-    });
-    this.attributeCommands = new SimSnsTopicAttributeCommands({
-      access,
-      subscriptions: this.subscriptions,
-    });
-    this.subscriptionCommands = new SimSnsSubscriptionCommands({
-      subscriptions: this.subscriptions,
-      topicAccess: access,
-      subscriptionAccess,
-    });
-    this.subscriptionListings = new SimSnsSubscriptionListings({
-      subscriptions: this.subscriptions,
-      topicAccess: access,
-    });
-    this.subscriptionAttributeCommands =
-      new SimSnsSubscriptionAttributeCommands({ access: subscriptionAccess });
-    this.publishCommands = new SimSnsPublishCommands({
-      access,
-      clock: background,
-    });
+  }
+
+  /**
+   * Every message this simulated SNS could not deliver.
+   *
+   * Real SNS tells the publisher nothing about a failed delivery, and neither
+   * does this. A queue that is unexpectedly empty is explained here.
+   */
+  get deliveryFailures(): readonly SimSnsDeliveryFailure[] {
+    return this.commands.fanOut.deliveryFailures;
+  }
+
+  /**
+   * The certificate a delivered message's `SigningCertURL` names.
+   *
+   * The URL cannot be fetched, because simulated SNS is not served over HTTP,
+   * so this is how a verifier gets at the certificate to check a signature
+   * with. A URL this scope did not issue answers with nothing.
+   */
+  signingCertificate(signingCertUrl: string): string | undefined {
+    return this.commands.signer.certificateFor(signingCertUrl);
   }
 
   /**
@@ -133,7 +119,7 @@ export class SimSns {
     options?: SimSnsRequestOptions,
   ): Promise<simSnsCommands.SimCreateTopicCommandOutput> {
     await this.background.sequence();
-    return this.topicCreation.handle(command, options);
+    return this.commands.topicCreation.handle(command, options);
   }
 
   /**
@@ -144,7 +130,7 @@ export class SimSns {
     options?: SimSnsRequestOptions,
   ): Promise<simSnsCommands.SimListTopicsCommandOutput> {
     await this.background.sequence();
-    return this.topicCommands.listTopics(command, options);
+    return this.commands.topics.listTopics(command, options);
   }
 
   /**
@@ -155,7 +141,7 @@ export class SimSns {
     options?: SimSnsRequestOptions,
   ): Promise<simSnsCommands.SimDeleteTopicCommandOutput> {
     await this.background.sequence();
-    return this.topicCommands.deleteTopic(command, options);
+    return this.commands.topics.deleteTopic(command, options);
   }
 
   /**
@@ -166,7 +152,7 @@ export class SimSns {
     options?: SimSnsRequestOptions,
   ): Promise<simSnsCommands.SimGetTopicAttributesCommandOutput> {
     await this.background.sequence();
-    return this.attributeCommands.getTopicAttributes(command, options);
+    return this.commands.topicAttributes.getTopicAttributes(command, options);
   }
 
   /**
@@ -177,7 +163,7 @@ export class SimSns {
     options?: SimSnsRequestOptions,
   ): Promise<simSnsCommands.SimSetTopicAttributesCommandOutput> {
     await this.background.sequence();
-    return this.attributeCommands.setTopicAttributes(command, options);
+    return this.commands.topicAttributes.setTopicAttributes(command, options);
   }
 
   /**
@@ -188,7 +174,7 @@ export class SimSns {
     options?: SimSnsRequestOptions,
   ): Promise<simSnsCommands.SimSubscribeCommandOutput> {
     await this.background.sequence();
-    return this.subscriptionCommands.subscribe(command, options);
+    return this.commands.subscriptions.subscribe(command, options);
   }
 
   /**
@@ -199,7 +185,7 @@ export class SimSns {
     options?: SimSnsRequestOptions,
   ): Promise<simSnsCommands.SimUnsubscribeCommandOutput> {
     await this.background.sequence();
-    return this.subscriptionCommands.unsubscribe(command, options);
+    return this.commands.subscriptions.unsubscribe(command, options);
   }
 
   /**
@@ -210,7 +196,10 @@ export class SimSns {
     options?: SimSnsRequestOptions,
   ): Promise<simSnsCommands.SimListSubscriptionsCommandOutput> {
     await this.background.sequence();
-    return this.subscriptionListings.listSubscriptions(command, options);
+    return this.commands.subscriptionListings.listSubscriptions(
+      command,
+      options,
+    );
   }
 
   /**
@@ -221,7 +210,10 @@ export class SimSns {
     options?: SimSnsRequestOptions,
   ): Promise<simSnsCommands.SimListSubscriptionsByTopicCommandOutput> {
     await this.background.sequence();
-    return this.subscriptionListings.listSubscriptionsByTopic(command, options);
+    return this.commands.subscriptionListings.listSubscriptionsByTopic(
+      command,
+      options,
+    );
   }
 
   /**
@@ -232,7 +224,7 @@ export class SimSns {
     options?: SimSnsRequestOptions,
   ): Promise<simSnsCommands.SimGetSubscriptionAttributesCommandOutput> {
     await this.background.sequence();
-    return this.subscriptionAttributeCommands.getSubscriptionAttributes(
+    return this.commands.subscriptionAttributes.getSubscriptionAttributes(
       command,
       options,
     );
@@ -246,7 +238,7 @@ export class SimSns {
     options?: SimSnsRequestOptions,
   ): Promise<simSnsCommands.SimSetSubscriptionAttributesCommandOutput> {
     await this.background.sequence();
-    return this.subscriptionAttributeCommands.setSubscriptionAttributes(
+    return this.commands.subscriptionAttributes.setSubscriptionAttributes(
       command,
       options,
     );
@@ -260,7 +252,7 @@ export class SimSns {
     options?: SimSnsRequestOptions,
   ): Promise<simSnsCommands.SimPublishCommandOutput> {
     await this.background.sequence();
-    return this.publishCommands.publish(command, options);
+    return this.commands.publish.publish(command, options);
   }
 
   /**
@@ -271,7 +263,7 @@ export class SimSns {
     options?: SimSnsRequestOptions,
   ): Promise<simSnsCommands.SimPublishBatchCommandOutput> {
     await this.background.sequence();
-    return this.publishCommands.publishBatch(command, options);
+    return this.commands.publish.publishBatch(command, options);
   }
 
   /**

--- a/src/service/sns/subscription/sim-sns-queue-endpoint-arn.ts
+++ b/src/service/sns/subscription/sim-sns-queue-endpoint-arn.ts
@@ -1,3 +1,6 @@
+import type { SimAwsAccountId } from "../../aws/sim-aws-account-id.js";
+import type { AwsRegionName } from "../../aws/sim-aws-region.js";
+import { sqsQueueUrl } from "../../sqs/queue/sim-sqs-queue-arn.js";
 import {
   SimSnsInvalidParameterException,
   SimSnsUnsimulatedInputException,
@@ -13,8 +16,8 @@ const queueArnParts = 6;
 
 interface SimSnsQueueEndpointArnProperties {
   readonly value: string;
-  readonly regionName: string;
-  readonly accountId: string;
+  readonly regionName: AwsRegionName;
+  readonly accountId: SimAwsAccountId;
   readonly queueName: string;
 }
 
@@ -27,8 +30,8 @@ interface SimSnsQueueEndpointArnProperties {
  */
 export class SimSnsQueueEndpointArn {
   public readonly value: string;
-  public readonly regionName: string;
-  public readonly accountId: string;
+  public readonly regionName: AwsRegionName;
+  public readonly accountId: SimAwsAccountId;
   public readonly queueName: string;
 
   private constructor(properties: SimSnsQueueEndpointArnProperties) {
@@ -78,9 +81,24 @@ export class SimSnsQueueEndpointArn {
 
     return new this({
       value: endpoint,
-      regionName,
-      accountId,
+      // The Region and the Account come out of an ARN as plain strings. They
+      // are the branded types everywhere else, and an ARN naming a scope the
+      // simulation has never seen resolves to an empty one rather than being
+      // refused here, the same as any other ARN a request carries.
+      regionName: regionName as AwsRegionName,
+      accountId: accountId as SimAwsAccountId,
       queueName,
+    });
+  }
+
+  /**
+   * The URL an SQS request names this queue by.
+   */
+  get queueUrl(): string {
+    return sqsQueueUrl({
+      regionName: this.regionName,
+      accountId: this.accountId,
+      name: this.queueName,
     });
   }
 }

--- a/src/service/sns/subscription/sim-sns-subscription.ts
+++ b/src/service/sns/subscription/sim-sns-subscription.ts
@@ -81,9 +81,9 @@ export class SimSnsSubscription {
    *
    * Nothing checks that the queue exists, because real SNS does not either: a
    * subscription to a queue that is not there is created, and fails when
-   * something is delivered to it. The queue's own policy is not consulted here
-   * either, since delivery is not simulated yet, and both checks belong with it
-   * when it arrives.
+   * something is delivered to it. That is the moment the queue's own policy is
+   * consulted too, so both failures surface in the same place, and a permission
+   * taken away after subscribing stops delivery.
    */
   static of(input: SimSnsSubscriptionInput): SimSnsSubscription {
     const arn = SimSnsSubscriptionArn.forTopic(input.topicArn);
@@ -97,6 +97,13 @@ export class SimSnsSubscription {
       owner: input.owner,
       attributes: input.attributes,
     });
+  }
+
+  /**
+   * The attributes this subscription currently holds.
+   */
+  get attributes(): SimSnsSubscriptionAttributes {
+    return this.held;
   }
 
   /**

--- a/test/sns/subscription-fixture.ts
+++ b/test/sns/subscription-fixture.ts
@@ -9,9 +9,15 @@
  */
 
 import { SubscribeCommand } from "@aws-sdk/client-sns";
+import {
+  CreateQueueCommand,
+  ReceiveMessageCommand,
+  SetQueueAttributesCommand,
+} from "@aws-sdk/client-sqs";
 import { assertNonNullable, assertThrowsErrorAsync } from "@kensio/smartass";
 
 import type { SimAws } from "../../src/service/aws/sim-aws.js";
+import type { AwsRegionName } from "../../src/service/aws/sim-aws-region.js";
 import { simAwsWithTopic } from "./topic-fixture.js";
 
 /**
@@ -113,6 +119,100 @@ export const simSnsEndpointsThatAreNotQueues = [
   "arn:aws:sns:us-east-1:888888888888:orders",
   "",
 ];
+
+/**
+ * An Account and Region a queue lives in, when it is not the default one.
+ */
+export interface SimSnsScope {
+  readonly accountId?: string;
+  readonly regionName?: AwsRegionName;
+}
+
+/**
+ * A queue policy admitting SNS to send to a queue for one topic.
+ *
+ * This is the grant real SNS needs on the queue's side, and it is the one AWS
+ * documents: the service principal, the send action, and the topic it is
+ * sending for as `aws:SourceArn`.
+ */
+export function simSnsQueuePolicy(queueArn: string, topicArn: string): string {
+  return JSON.stringify({
+    Version: "2012-10-17",
+    Statement: [
+      {
+        Effect: "Allow",
+        Principal: { Service: "sns.amazonaws.com" },
+        Action: "sqs:SendMessage",
+        Resource: queueArn,
+        Condition: { ArnLike: { "aws:SourceArn": topicArn } },
+      },
+    ],
+  });
+}
+
+/**
+ * Create a queue in a scope, with a policy admitting SNS for a topic.
+ *
+ * The queue ARN is built rather than read back, because a queue's ARN is the
+ * one thing CreateQueue does not answer with.
+ */
+export async function simSnsSubscribedQueue(
+  simAws: SimAws,
+  queueName: string,
+  topicArn: string,
+  scope: SimSnsScope = {},
+): Promise<{ queueUrl: string; queueArn: string }> {
+  const accountId = scope.accountId ?? simAws.defaultAccountId;
+  const regionName = scope.regionName ?? simAws.defaultRegionName;
+  const sqs = simAws.account(accountId).region(regionName).sqs();
+  const created = await sqs.createQueue(
+    new CreateQueueCommand({ QueueName: queueName }),
+  );
+
+  assertNonNullable(created.QueueUrl, "CreateQueue answered with a queue URL");
+
+  const queueArn = `arn:aws:sqs:${regionName}:${accountId}:${queueName}`;
+
+  await sqs.setQueueAttributes(
+    new SetQueueAttributesCommand({
+      QueueUrl: created.QueueUrl,
+      Attributes: { Policy: simSnsQueuePolicy(queueArn, topicArn) },
+    }),
+  );
+
+  await simAws.sns().subscribe(
+    new SubscribeCommand({
+      TopicArn: topicArn,
+      Protocol: "sqs",
+      Endpoint: queueArn,
+    }),
+  );
+
+  return { queueUrl: created.QueueUrl, queueArn };
+}
+
+/**
+ * Wait for delivery, then take the one message a queue received.
+ *
+ * Delivery happens on the background scheduler, as it does on real SNS after
+ * the publish has been answered, so nothing has arrived until that work is
+ * done.
+ */
+export async function simSnsDeliveredMessage(
+  simAws: SimAws,
+  queueUrl: string,
+  scope: SimSnsScope = {},
+): Promise<string | undefined> {
+  await simAws.backgroundTasksComplete();
+
+  const received = await simAws
+    .account(scope.accountId ?? simAws.defaultAccountId)
+    .region(scope.regionName ?? simAws.defaultRegionName)
+    .sqs()
+    .receiveMessage(new ReceiveMessageCommand({ QueueUrl: queueUrl }));
+
+  return received.Messages?.[0]?.Body;
+}
 
 /**
  * Subscribe a queue over a protocol, answering with whatever it threw.


### PR DESCRIPTION
Stacked on https://github.com/KensioSoftware/yulin/pull/476, which adds the subscription model this builds on. Review that one first, and this one merges into it.

A publish now delivers one message to each subscribed queue, on the background scheduler as real SNS delivers after answering the publish. The body is the SNS envelope by default, carrying a real SHA1withRSA signature over the string real SNS signs and a `SigningCertURL` naming a certificate the scope hands out through `simAws.sns().signingCertificate(url)`. With `RawMessageDelivery` on the subscription, the body is the published message on its own and its attributes arrive as SQS message attributes.

The queue's own policy authorizes every delivery through `SimSqsServiceSendAuthorizer`, checked on each message rather than remembered from subscribe time, so a queue in another account or another region receives a message when its policy admits the topic and a permission taken away afterwards stops delivery. Real SNS delivers across regions, which is a deliberate difference from simulated S3 event notifications. A delivery that fails is recorded on `simAws.sns().deliveryFailures` rather than reported to the publisher, as real SNS reports nothing.

Node reads an X.509 certificate but does not write one, so the certificate is assembled from DER by hand in `signature/`. It is the smallest thing that is still a certificate, and `new X509Certificate(pem)` parses it and `createVerify("RSA-SHA1")` verifies against it. The `sns-validator` divergence is recorded in a code comment and in the docs Limitations section: it hard-codes an `amazonaws.com` certificate host and fetches the URL itself, and neither URL in a simulated envelope is served.

Resolves https://github.com/KensioSoftware/yulin/issues/469

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * SNS messages now fan out asynchronously to subscribed SQS queues.
  * Supports raw delivery, SNS notification envelopes, message attributes, and signed messages.
  * Queue delivery works across accounts and Regions when authorized by queue policies.
  * Added delivery-failure reporting and RSA signature verification support.
  * Enforced publish batch size limits.
* **Documentation**
  * Expanded SNS documentation with delivery behavior, authorization, signatures, limitations, and examples.
* **Bug Fixes**
  * Delivery failures are now recorded with diagnostic reasons instead of being silently ignored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->