### PR TITLE
feat: notify a simulated SNS topic of Object events

### DIFF
--- a/docs/services/s3/README.md
+++ b/docs/services/s3/README.md
@@ -825,9 +825,9 @@ reaches, so a configuration is validated the same way whichever it arrives by.
 
 `SqsDestination` and `SnsDestination` write their entry into the same resource, alongside the
 `AWS::SQS::QueuePolicy` or `AWS::SNS::TopicPolicy` that grants S3 access. The queue policy deploys;
-the topic policy does not yet, since the SNS CloudFormation resource types are not implemented, so
-set the topic's `Policy` attribute through the SDK before deploying a stack whose Bucket notifies a
-topic.
+the topic policy does not yet, since the SNS CloudFormation resource types are not implemented. An
+`AWS::SNS::Topic` does not deploy either, so create the topic and set its `Policy` attribute through
+the SDK before deploying a stack whose Bucket notifies one.
 
 Deploy into an Account and Region matching the ones the CDK app synthesized for. The `SourceAccount`
 on the permission CDK writes beside the notification is a synth-time literal, so a stack deployed
@@ -936,9 +936,10 @@ writes do not match it. Without that, the simulation stops after a thousand deli
   and an EventBridge destination in one is refused by name as it is for an SDK caller.
 - A FIFO queue destination is refused by name, as real S3 refuses one. Simulated SQS has no FIFO
   queues either, and neither does simulated SNS, so a FIFO topic destination is refused the same way.
-- The `AWS::SNS::TopicPolicy` CDK's `SnsDestination` writes does not deploy, since the SNS
-  CloudFormation resource types are not implemented. Set the topic's `Policy` attribute through the
-  SDK before deploying a stack whose Bucket notifies a topic, or S3 refuses the destination.
+- Neither the `AWS::SNS::Topic` a CDK app declares nor the `AWS::SNS::TopicPolicy` its
+  `SnsDestination` writes beside it deploys, since the SNS CloudFormation resource types are not
+  implemented. Create the topic and set its `Policy` attribute through the SDK before deploying a
+  stack whose Bucket notifies one, or S3 refuses the destination.
 - The KMS key policy statement CDK's `SqsDestination` writes for an encrypted queue is not acted on.
   Queue encryption is not simulated.
 - A CDK `BucketDeployment` and `mountBucketFilesystem(...)` both replace the whole storage backend

--- a/docs/services/s3/README.md
+++ b/docs/services/s3/README.md
@@ -280,14 +280,14 @@ failures come back.
 
 ## Event notifications
 
-A simulated S3 Bucket can notify a simulated Lambda function or a simulated SQS queue when an Object
-is created or removed. The configuration is applied with
+A simulated S3 Bucket can notify a simulated Lambda function, a simulated SQS queue or a simulated
+SNS topic when an Object is created or removed. The configuration is applied with
 `PutBucketNotificationConfigurationCommand` and read back with
 `GetBucketNotificationConfigurationCommand`.
 
-The destination's own policy decides whether S3 may reach it: the function's resource policy, or the
-queue's `Policy` attribute. That is checked when the configuration is applied, and again for every
-event, as real S3 does.
+The destination's own policy decides whether S3 may reach it: the function's resource policy, the
+queue's `Policy` attribute, or the topic's. That is checked when the configuration is applied, and
+again for every event, as real S3 does.
 
 ```typescript sim-s3-event-notifications
 /**
@@ -553,16 +553,171 @@ await simAws.backgroundTasksComplete();
 The queue has to be in the Bucket's Region, as real S3 requires. It can be in another Account, since
 its own policy and its own Account's IAM are what admit the Bucket. A FIFO queue is refused by name.
 
+### To an SNS topic
+
+A `TopicConfigurations` entry names a topic by ARN. The whole `Records` document is published as the
+SNS `Message`, with a `Subject` of `Amazon S3 Notification`, which is what real S3 publishes. A queue
+subscribed to the topic therefore has two envelopes to reach through: parse the message body for the
+SNS envelope, then parse its `Message` for the S3 event.
+
+The topic's `Policy` attribute has to allow `sns:Publish` for the `s3.amazonaws.com` service
+principal. S3 supplies `aws:SourceArn` and `aws:SourceAccount`, so the `ArnLike` condition CDK's
+`SnsDestination` writes and the `StringEquals aws:SourceAccount` guard AWS documents are both
+satisfied.
+
+```typescript sim-s3-sns-notification
+/**
+ * An Object event reaching a queue through an SNS topic.
+ */
+
+import {
+  CreateBucketCommand,
+  PutBucketNotificationConfigurationCommand,
+  PutObjectCommand,
+} from "@aws-sdk/client-s3";
+import {
+  CreateTopicCommand,
+  SetTopicAttributesCommand,
+  SubscribeCommand,
+} from "@aws-sdk/client-sns";
+import {
+  CreateQueueCommand,
+  ReceiveMessageCommand,
+  SetQueueAttributesCommand,
+} from "@aws-sdk/client-sqs";
+import { SimAws } from "@kensio/yulin";
+
+interface SnsEnvelope {
+  Subject: string;
+  Message: string;
+}
+
+interface S3EventDocument {
+  Records: [{ eventName: string; s3: { object: { key: string } } }];
+}
+
+const simAws = new SimAws();
+const { defaultRegionName: region, defaultAccountId: account } = simAws;
+const bucketArn = "arn:aws:s3:::uploads";
+const topicArn = `arn:aws:sns:${region}:${account}:uploads`;
+const queueArn = `arn:aws:sqs:${region}:${account}:uploads-queue`;
+
+const { TopicArn } = await simAws
+  .sns()
+  .createTopic(new CreateTopicCommand({ Name: "uploads" }));
+
+// The topic policy is the whole decision, because S3 owns no identity
+// policies. S3 supplies aws:SourceArn, so the grant names one Bucket.
+await simAws.sns().setTopicAttributes(
+  new SetTopicAttributesCommand({
+    TopicArn,
+    AttributeName: "Policy",
+    AttributeValue: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: [
+        {
+          Effect: "Allow",
+          Principal: { Service: "s3.amazonaws.com" },
+          Action: "sns:Publish",
+          Resource: topicArn,
+          Condition: { ArnLike: { "aws:SourceArn": bucketArn } },
+        },
+      ],
+    }),
+  }),
+);
+
+const { QueueUrl } = await simAws
+  .sqs()
+  .createQueue(new CreateQueueCommand({ QueueName: "uploads-queue" }));
+
+await simAws.sqs().setQueueAttributes(
+  new SetQueueAttributesCommand({
+    QueueUrl,
+    Attributes: {
+      Policy: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: [
+          {
+            Effect: "Allow",
+            Principal: { Service: "sns.amazonaws.com" },
+            Action: "sqs:SendMessage",
+            Resource: queueArn,
+            Condition: { ArnLike: { "aws:SourceArn": topicArn } },
+          },
+        ],
+      }),
+    },
+  }),
+);
+
+await simAws
+  .sns()
+  .subscribe(
+    new SubscribeCommand({ TopicArn, Protocol: "sqs", Endpoint: queueArn }),
+  );
+
+await simAws.s3().createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+
+await simAws.s3().putBucketNotificationConfiguration(
+  new PutBucketNotificationConfigurationCommand({
+    Bucket: "uploads",
+    NotificationConfiguration: {
+      TopicConfigurations: [
+        {
+          Id: "raw-uploads",
+          Events: ["s3:ObjectCreated:*"],
+          TopicArn,
+          Filter: { Key: { FilterRules: [{ Name: "prefix", Value: "raw/" }] } },
+        },
+      ],
+    },
+  }),
+);
+
+await simAws.s3().putObject(
+  new PutObjectCommand({
+    Bucket: "uploads",
+    Key: "raw/cat.jpg",
+    Body: "cat picture",
+  }),
+);
+
+// One wait covers the publish to the topic and the delivery to the queue.
+await simAws.backgroundTasksComplete();
+
+const received = await simAws
+  .sqs()
+  .receiveMessage(new ReceiveMessageCommand({ QueueUrl }));
+
+// Two envelopes to reach through: the SNS envelope, then the S3 event.
+const envelope = JSON.parse(received.Messages?.[0]?.Body ?? "") as SnsEnvelope;
+
+console.log(envelope.Subject); // "Amazon S3 Notification"
+
+const event = JSON.parse(envelope.Message) as S3EventDocument;
+
+console.log(event.Records[0].s3.object.key); // "raw/cat.jpg"
+```
+
+The topic has to be in the Bucket's Region, as real S3 requires. It can be in another Account, since
+its own policy and its own Account's IAM are what admit the Bucket. A FIFO topic is refused by name.
+
+The publish goes through the ordinary `Publish` path, so the topic's own subscriptions take it from
+there. That means a topic destination reaches everything the topic reaches, and a subscribed queue is
+two hops from the Object that was written. One `backgroundTasksComplete()` covers both.
+
 ### From a CloudFormation template
 
 The `NotificationConfiguration` property of `AWS::S3::Bucket` deploys through the same
 `PutBucketNotificationConfiguration` path, so a template and an SDK caller get identical validation.
 CloudFormation names the same configuration differently in several places: `LambdaConfigurations`
 rather than `LambdaFunctionConfigurations`, a single `Event` string rather than an `Events` list,
-`Function` rather than `LambdaFunctionArn`, `Queue` rather than `QueueArn`, and `Filter.S3Key.Rules`
-rather than `Filter.Key.FilterRules`. `QueueConfigurations` is the one name both spell the same way.
-Yulin reads the CloudFormation names and refuses the others, so a template using the SDK spelling
-fails the stack rather than deploying an unfiltered configuration.
+`Function` rather than `LambdaFunctionArn`, `Queue` rather than `QueueArn`, `Topic` rather than
+`TopicArn`, and `Filter.S3Key.Rules` rather than `Filter.Key.FilterRules`. `QueueConfigurations` and
+`TopicConfigurations` are the names both spell the same way. Yulin reads the CloudFormation names and
+refuses the others, so a template using the SDK spelling fails the stack rather than deploying an
+unfiltered configuration.
 
 ```typescript sim-s3-cfn-event-notification
 /**
@@ -668,6 +823,12 @@ back with `GetBucketNotificationConfigurationCommand` if a test needs it.
 S3 invoke the function. Yulin applies that request through the same command path an SDK caller
 reaches, so a configuration is validated the same way whichever it arrives by.
 
+`SqsDestination` and `SnsDestination` write their entry into the same resource, alongside the
+`AWS::SQS::QueuePolicy` or `AWS::SNS::TopicPolicy` that grants S3 access. The queue policy deploys;
+the topic policy does not yet, since the SNS CloudFormation resource types are not implemented, so
+set the topic's `Policy` attribute through the SDK before deploying a stack whose Bucket notifies a
+topic.
+
 Deploy into an Account and Region matching the ones the CDK app synthesized for. The `SourceAccount`
 on the permission CDK writes beside the notification is a synth-time literal, so a stack deployed
 into another Account leaves S3 unable to validate the destination, and the stack fails.
@@ -713,8 +874,8 @@ get a managed notification configuration.
 
 ### What arrives at the destination
 
-A function is invoked with the `Records` document real S3 sends, and a queue gets the same document
-as one message body. One event produces one record.
+A function is invoked with the `Records` document real S3 sends. A queue gets the same document as
+one message body, and a topic gets it as the published `Message`. One event produces one record.
 
 Creation records carry the Object's `size` and its `eTag`, which is the MD5 of the bytes as it is for
 an Object real S3 stored in one part. Removal records carry neither, because the Object they describe
@@ -746,8 +907,8 @@ writes do not match it. Without that, the simulation stops after a thousand deli
 
 ### Limitations
 
-- A Lambda function and an SQS queue are the destinations. An SNS topic and EventBridge are each
-  refused by name.
+- A Lambda function, an SQS queue and an SNS topic are the destinations. EventBridge is refused by
+  name.
 - A destination goes where the group it was declared in says, not where its ARN says: a queue ARN
   under `LambdaFunctionConfigurations` is refused for not being a function ARN rather than delivered
   to as a queue.
@@ -769,18 +930,23 @@ writes do not match it. Without that, the simulation stops after a thousand deli
 - A notification cannot be configured on a standalone `SimS3`. It has no other simulated services to
   notify, and no shared background scheduler for `backgroundTasksComplete()` to drain. Reach
   simulated S3 through `SimAws` instead.
-- A topic destination in an `AWS::S3::Bucket` `NotificationConfiguration` is refused by name, as it
-  is for an SDK caller, and so is an `EventBridgeConfiguration`.
+- An `EventBridgeConfiguration` in an `AWS::S3::Bucket` `NotificationConfiguration` is refused by
+  name, as it is for an SDK caller.
 - `Managed: false` on a `Custom::S3BucketNotifications` resource is refused rather than approximated,
-  and a topic or EventBridge destination in one is refused by name as it is for an SDK caller.
+  and an EventBridge destination in one is refused by name as it is for an SDK caller.
 - A FIFO queue destination is refused by name, as real S3 refuses one. Simulated SQS has no FIFO
-  queues either.
+  queues either, and neither does simulated SNS, so a FIFO topic destination is refused the same way.
+- The `AWS::SNS::TopicPolicy` CDK's `SnsDestination` writes does not deploy, since the SNS
+  CloudFormation resource types are not implemented. Set the topic's `Policy` attribute through the
+  SDK before deploying a stack whose Bucket notifies a topic, or S3 refuses the destination.
 - The KMS key policy statement CDK's `SqsDestination` writes for an encrypted queue is not acted on.
   Queue encryption is not simulated.
 - A CDK `BucketDeployment` and `mountBucketFilesystem(...)` both replace the whole storage backend
   rather than putting Objects, so neither raises anything, whereas real CDK `BucketDeployment` fires
   one `ObjectCreated:Put` per file.
 - A function ARN naming a version or an alias is refused, since simulated Lambda has neither.
+- A topic destination publishes with no message attributes, since real S3 publishes none. The only
+  thing on the message besides the event document is the `Amazon S3 Notification` subject.
 - `s3:TestEvent` is not sent. Real S3 puts one on a queue or topic when a configuration naming it is
   applied, carrying a flat `{Service, Event, Time, Bucket, RequestId, HostId}` document with no
   `Records` in it. Sending it here would make the simplest test two messages long and hand a
@@ -1652,7 +1818,8 @@ Sim S3 currently supports:
 - `PutObjectCommand`, `GetObjectCommand` and `ListObjectsCommand`
 - `DeleteObjectCommand` and `DeleteObjectsCommand`, authorized per Object by sim IAM
 - `PutBucketNotificationConfigurationCommand` and `GetBucketNotificationConfigurationCommand`, with
-  Object events delivered to a simulated Lambda function or a simulated SQS queue
+  Object events delivered to a simulated Lambda function, a simulated SQS queue or a simulated SNS
+  topic
 - `PutBucketWebsiteCommand`, for static website hosting
 - `PutBucketPolicyCommand`, `GetBucketPolicyCommand` and `DeleteBucketPolicyCommand`, evaluated by
   sim IAM alongside identity policies

--- a/docs/services/s3/sim-s3-sns-notification.example.ts
+++ b/docs/services/s3/sim-s3-sns-notification.example.ts
@@ -1,0 +1,132 @@
+/**
+ * An Object event reaching a queue through an SNS topic.
+ */
+
+import {
+  CreateBucketCommand,
+  PutBucketNotificationConfigurationCommand,
+  PutObjectCommand,
+} from "@aws-sdk/client-s3";
+import {
+  CreateTopicCommand,
+  SetTopicAttributesCommand,
+  SubscribeCommand,
+} from "@aws-sdk/client-sns";
+import {
+  CreateQueueCommand,
+  ReceiveMessageCommand,
+  SetQueueAttributesCommand,
+} from "@aws-sdk/client-sqs";
+import { SimAws } from "@kensio/yulin";
+
+interface SnsEnvelope {
+  Subject: string;
+  Message: string;
+}
+
+interface S3EventDocument {
+  Records: [{ eventName: string; s3: { object: { key: string } } }];
+}
+
+const simAws = new SimAws();
+const { defaultRegionName: region, defaultAccountId: account } = simAws;
+const bucketArn = "arn:aws:s3:::uploads";
+const topicArn = `arn:aws:sns:${region}:${account}:uploads`;
+const queueArn = `arn:aws:sqs:${region}:${account}:uploads-queue`;
+
+const { TopicArn } = await simAws
+  .sns()
+  .createTopic(new CreateTopicCommand({ Name: "uploads" }));
+
+// The topic policy is the whole decision, because S3 owns no identity
+// policies. S3 supplies aws:SourceArn, so the grant names one Bucket.
+await simAws.sns().setTopicAttributes(
+  new SetTopicAttributesCommand({
+    TopicArn,
+    AttributeName: "Policy",
+    AttributeValue: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: [
+        {
+          Effect: "Allow",
+          Principal: { Service: "s3.amazonaws.com" },
+          Action: "sns:Publish",
+          Resource: topicArn,
+          Condition: { ArnLike: { "aws:SourceArn": bucketArn } },
+        },
+      ],
+    }),
+  }),
+);
+
+const { QueueUrl } = await simAws
+  .sqs()
+  .createQueue(new CreateQueueCommand({ QueueName: "uploads-queue" }));
+
+await simAws.sqs().setQueueAttributes(
+  new SetQueueAttributesCommand({
+    QueueUrl,
+    Attributes: {
+      Policy: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: [
+          {
+            Effect: "Allow",
+            Principal: { Service: "sns.amazonaws.com" },
+            Action: "sqs:SendMessage",
+            Resource: queueArn,
+            Condition: { ArnLike: { "aws:SourceArn": topicArn } },
+          },
+        ],
+      }),
+    },
+  }),
+);
+
+await simAws
+  .sns()
+  .subscribe(
+    new SubscribeCommand({ TopicArn, Protocol: "sqs", Endpoint: queueArn }),
+  );
+
+await simAws.s3().createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+
+await simAws.s3().putBucketNotificationConfiguration(
+  new PutBucketNotificationConfigurationCommand({
+    Bucket: "uploads",
+    NotificationConfiguration: {
+      TopicConfigurations: [
+        {
+          Id: "raw-uploads",
+          Events: ["s3:ObjectCreated:*"],
+          TopicArn,
+          Filter: { Key: { FilterRules: [{ Name: "prefix", Value: "raw/" }] } },
+        },
+      ],
+    },
+  }),
+);
+
+await simAws.s3().putObject(
+  new PutObjectCommand({
+    Bucket: "uploads",
+    Key: "raw/cat.jpg",
+    Body: "cat picture",
+  }),
+);
+
+// One wait covers the publish to the topic and the delivery to the queue.
+await simAws.backgroundTasksComplete();
+
+const received = await simAws
+  .sqs()
+  .receiveMessage(new ReceiveMessageCommand({ QueueUrl }));
+
+// Two envelopes to reach through: the SNS envelope, then the S3 event.
+const envelope = JSON.parse(received.Messages?.[0]?.Body ?? "") as SnsEnvelope;
+
+console.log(envelope.Subject); // "Amazon S3 Notification"
+
+const event = JSON.parse(envelope.Message) as S3EventDocument;
+
+console.log(event.Records[0].s3.object.key); // "raw/cat.jpg"

--- a/docs/services/sns/README.md
+++ b/docs/services/sns/README.md
@@ -733,6 +733,162 @@ Anything else fails with `InvalidParameterException`.
 `GetTopicAttributes` reports `Policy` back as the string it was set with. Setting the attribute with
 no value takes the policy off the topic, which is the only way back to a topic without one.
 
+## Taking S3 Object events
+
+A simulated S3 Bucket can publish its event notifications to a topic. The topic then fans them out to
+its own subscribers, so one Bucket configuration reaches every queue subscribed to the topic.
+
+Set up the topic policy first. S3 asks the topic whether it may publish when the notification
+configuration is applied, and asks again for every event, so a policy that does not admit
+`s3.amazonaws.com` for that Bucket refuses the configuration outright.
+
+```typescript sim-sns-s3-events
+/**
+ * A topic taking S3 Object events and fanning them out to two queues.
+ */
+
+import {
+  CreateBucketCommand,
+  PutBucketNotificationConfigurationCommand,
+  PutObjectCommand,
+} from "@aws-sdk/client-s3";
+import {
+  CreateTopicCommand,
+  SetTopicAttributesCommand,
+  SubscribeCommand,
+} from "@aws-sdk/client-sns";
+import {
+  CreateQueueCommand,
+  ReceiveMessageCommand,
+  SetQueueAttributesCommand,
+} from "@aws-sdk/client-sqs";
+import { SimAws } from "@kensio/yulin";
+
+interface SnsEnvelope {
+  Message: string;
+}
+
+interface S3EventDocument {
+  Records: [{ s3: { object: { key: string } } }];
+}
+
+const simAws = new SimAws();
+const { defaultRegionName: region, defaultAccountId: account } = simAws;
+const topicArn = `arn:aws:sns:${region}:${account}:uploads`;
+
+const { TopicArn } = await simAws
+  .sns()
+  .createTopic(new CreateTopicCommand({ Name: "uploads" }));
+
+// S3 owns no identity policies, so the topic policy is the whole decision.
+// The Bucket it is publishing for arrives as aws:SourceArn.
+await simAws.sns().setTopicAttributes(
+  new SetTopicAttributesCommand({
+    TopicArn,
+    AttributeName: "Policy",
+    AttributeValue: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: [
+        {
+          Effect: "Allow",
+          Principal: { Service: "s3.amazonaws.com" },
+          Action: "sns:Publish",
+          Resource: topicArn,
+          Condition: { ArnLike: { "aws:SourceArn": "arn:aws:s3:::uploads" } },
+        },
+      ],
+    }),
+  }),
+);
+
+/**
+ * Subscribe a queue that admits SNS to send to it for this topic.
+ */
+async function subscribeQueue(queueName: string): Promise<string> {
+  const { QueueUrl } = await simAws
+    .sqs()
+    .createQueue(new CreateQueueCommand({ QueueName: queueName }));
+  const queueArn = `arn:aws:sqs:${region}:${account}:${queueName}`;
+
+  await simAws.sqs().setQueueAttributes(
+    new SetQueueAttributesCommand({
+      QueueUrl,
+      Attributes: {
+        Policy: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: [
+            {
+              Effect: "Allow",
+              Principal: { Service: "sns.amazonaws.com" },
+              Action: "sqs:SendMessage",
+              Resource: queueArn,
+              Condition: { ArnLike: { "aws:SourceArn": topicArn } },
+            },
+          ],
+        }),
+      },
+    }),
+  );
+
+  await simAws
+    .sns()
+    .subscribe(
+      new SubscribeCommand({ TopicArn, Protocol: "sqs", Endpoint: queueArn }),
+    );
+
+  return QueueUrl ?? "";
+}
+
+const thumbnails = await subscribeQueue("thumbnails");
+const audit = await subscribeQueue("audit");
+
+await simAws.s3().createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+
+await simAws.s3().putBucketNotificationConfiguration(
+  new PutBucketNotificationConfigurationCommand({
+    Bucket: "uploads",
+    NotificationConfiguration: {
+      TopicConfigurations: [
+        { Id: "uploads", Events: ["s3:ObjectCreated:*"], TopicArn },
+      ],
+    },
+  }),
+);
+
+await simAws.s3().putObject(
+  new PutObjectCommand({
+    Bucket: "uploads",
+    Key: "raw/cat.jpg",
+    Body: "cat picture",
+  }),
+);
+
+await simAws.backgroundTasksComplete();
+
+for (const QueueUrl of [thumbnails, audit]) {
+  const received = await simAws
+    .sqs()
+    .receiveMessage(new ReceiveMessageCommand({ QueueUrl }));
+  const envelope = JSON.parse(
+    received.Messages?.[0]?.Body ?? "",
+  ) as SnsEnvelope;
+  const event = JSON.parse(envelope.Message) as S3EventDocument;
+
+  console.log(event.Records[0].s3.object.key); // "raw/cat.jpg"
+}
+```
+
+The published `Message` is the S3 `Records` document as text, and the `Subject` is
+`Amazon S3 Notification`, which is what real S3 publishes. A subscribed queue receiving the SNS
+envelope therefore has two layers to parse. `RawMessageDelivery` on the subscription takes one of
+them away, leaving the S3 event document as the message body.
+
+The topic has to be in the Bucket's Region, as real S3 requires, which is stricter than a
+subscription: a topic delivers to a queue in any Region. The Accounts can differ on both hops.
+
+See [simulated S3](../s3/README.md#event-notifications "Simulated S3 event notification docs") for the
+rest of the Bucket side, including the object key filters and what a record carries.
+
 ## Scoping
 
 Topics belong to an account and a region, as they do on real AWS. A topic name is unique within one
@@ -804,6 +960,8 @@ Sim SNS currently supports:
 - Authorization of every operation by simulated IAM, against the real IAM action and topic ARN
 - The `Policy` attribute as the topic's resource policy, admitting another account's principal or a
   service principal, with `aws:SourceArn` and `aws:SourceAccount` conditions honoured
+- Simulated S3 Bucket event notifications published to a topic, authorized by the topic policy when
+  the configuration is applied and again on every event
 - Calls made from inside a simulated Lambda handler, authorized as the function's execution role
 - `SNSClient` interception, routing ordinary SDK code into the simulation
 
@@ -876,7 +1034,10 @@ Current documented limitations:
 - SNS condition keys such as `sns:Endpoint` and `sns:Protocol` are not derived, so a policy relying on
   them will not match. Ordinary condition operators on values sim IAM does supply work as usual.
 - The CloudFormation resource types are not implemented, so `AWS::SNS::Topic`,
-  `AWS::SNS::Subscription` and `AWS::SNS::TopicPolicy` in a template do not deploy a topic yet.
-- Simulated S3 still refuses `TopicConfigurations` on a bucket notification configuration, since
-  delivery to a topic is not simulated.
+  `AWS::SNS::Subscription` and `AWS::SNS::TopicPolicy` in a template do not deploy a topic yet. A
+  stack whose Bucket notifies a topic therefore needs the topic and its policy set up through the SDK
+  first.
+- An S3 event notification published to a topic carries no message attributes, since real S3 publishes
+  none. The only thing on the message besides the event document is the `Amazon S3 Notification`
+  subject.
 - SNS is not served as an HTTP API by `serveSimAws`.

--- a/docs/services/sns/sim-sns-s3-events.example.ts
+++ b/docs/services/sns/sim-sns-s3-events.example.ts
@@ -1,0 +1,133 @@
+/**
+ * A topic taking S3 Object events and fanning them out to two queues.
+ */
+
+import {
+  CreateBucketCommand,
+  PutBucketNotificationConfigurationCommand,
+  PutObjectCommand,
+} from "@aws-sdk/client-s3";
+import {
+  CreateTopicCommand,
+  SetTopicAttributesCommand,
+  SubscribeCommand,
+} from "@aws-sdk/client-sns";
+import {
+  CreateQueueCommand,
+  ReceiveMessageCommand,
+  SetQueueAttributesCommand,
+} from "@aws-sdk/client-sqs";
+import { SimAws } from "@kensio/yulin";
+
+interface SnsEnvelope {
+  Message: string;
+}
+
+interface S3EventDocument {
+  Records: [{ s3: { object: { key: string } } }];
+}
+
+const simAws = new SimAws();
+const { defaultRegionName: region, defaultAccountId: account } = simAws;
+const topicArn = `arn:aws:sns:${region}:${account}:uploads`;
+
+const { TopicArn } = await simAws
+  .sns()
+  .createTopic(new CreateTopicCommand({ Name: "uploads" }));
+
+// S3 owns no identity policies, so the topic policy is the whole decision.
+// The Bucket it is publishing for arrives as aws:SourceArn.
+await simAws.sns().setTopicAttributes(
+  new SetTopicAttributesCommand({
+    TopicArn,
+    AttributeName: "Policy",
+    AttributeValue: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: [
+        {
+          Effect: "Allow",
+          Principal: { Service: "s3.amazonaws.com" },
+          Action: "sns:Publish",
+          Resource: topicArn,
+          Condition: { ArnLike: { "aws:SourceArn": "arn:aws:s3:::uploads" } },
+        },
+      ],
+    }),
+  }),
+);
+
+/**
+ * Subscribe a queue that admits SNS to send to it for this topic.
+ */
+async function subscribeQueue(queueName: string): Promise<string> {
+  const { QueueUrl } = await simAws
+    .sqs()
+    .createQueue(new CreateQueueCommand({ QueueName: queueName }));
+  const queueArn = `arn:aws:sqs:${region}:${account}:${queueName}`;
+
+  await simAws.sqs().setQueueAttributes(
+    new SetQueueAttributesCommand({
+      QueueUrl,
+      Attributes: {
+        Policy: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: [
+            {
+              Effect: "Allow",
+              Principal: { Service: "sns.amazonaws.com" },
+              Action: "sqs:SendMessage",
+              Resource: queueArn,
+              Condition: { ArnLike: { "aws:SourceArn": topicArn } },
+            },
+          ],
+        }),
+      },
+    }),
+  );
+
+  await simAws
+    .sns()
+    .subscribe(
+      new SubscribeCommand({ TopicArn, Protocol: "sqs", Endpoint: queueArn }),
+    );
+
+  return QueueUrl ?? "";
+}
+
+const thumbnails = await subscribeQueue("thumbnails");
+const audit = await subscribeQueue("audit");
+
+await simAws.s3().createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+
+await simAws.s3().putBucketNotificationConfiguration(
+  new PutBucketNotificationConfigurationCommand({
+    Bucket: "uploads",
+    NotificationConfiguration: {
+      TopicConfigurations: [
+        { Id: "uploads", Events: ["s3:ObjectCreated:*"], TopicArn },
+      ],
+    },
+  }),
+);
+
+await simAws.s3().putObject(
+  new PutObjectCommand({
+    Bucket: "uploads",
+    Key: "raw/cat.jpg",
+    Body: "cat picture",
+  }),
+);
+
+await simAws.backgroundTasksComplete();
+
+for (const QueueUrl of [thumbnails, audit]) {
+  const received = await simAws
+    .sqs()
+    .receiveMessage(new ReceiveMessageCommand({ QueueUrl }));
+  const envelope = JSON.parse(
+    received.Messages?.[0]?.Body ?? "",
+  ) as SnsEnvelope;
+  const event = JSON.parse(envelope.Message) as S3EventDocument;
+
+  console.log(event.Records[0].s3.object.key); // "raw/cat.jpg"
+}

--- a/src/service/aws/factory/sim-aws-s3-notification-destinations.ts
+++ b/src/service/aws/factory/sim-aws-s3-notification-destinations.ts
@@ -2,6 +2,8 @@ import type { SimAws } from "../sim-aws.js";
 import { SimAwsS3NotificationFunctions } from "../../s3/notification/destination/lambda/sim-aws-s3-notification-functions.js";
 import { SimS3LambdaNotificationDestination } from "../../s3/notification/destination/lambda/sim-s3-lambda-notification-destination.js";
 import { SimS3ServiceNotificationDestinations } from "../../s3/notification/destination/sim-s3-service-notification-destinations.js";
+import { SimAwsS3NotificationTopics } from "../../s3/notification/destination/sns/sim-aws-s3-notification-topics.js";
+import { SimS3SnsNotificationDestination } from "../../s3/notification/destination/sns/sim-s3-sns-notification-destination.js";
 import { SimAwsS3NotificationQueues } from "../../s3/notification/destination/sqs/sim-aws-s3-notification-queues.js";
 import { SimS3SqsNotificationDestination } from "../../s3/notification/destination/sqs/sim-s3-sqs-notification-destination.js";
 
@@ -18,6 +20,9 @@ export function simAwsS3NotificationDestinations(
   return new SimS3ServiceNotificationDestinations({
     lambda: new SimS3LambdaNotificationDestination({
       functions: new SimAwsS3NotificationFunctions({ simAws }),
+    }),
+    sns: new SimS3SnsNotificationDestination({
+      topics: new SimAwsS3NotificationTopics({ simAws }),
     }),
     sqs: new SimS3SqsNotificationDestination({
       queues: new SimAwsS3NotificationQueues({ simAws }),

--- a/src/service/cloudformation/cdk/s3/bucket-notifications/configuration/sim-cdk-bucket-notification-configuration.ts
+++ b/src/service/cloudformation/cdk/s3/bucket-notifications/configuration/sim-cdk-bucket-notification-configuration.ts
@@ -2,6 +2,7 @@ import type {
   SimS3LambdaFunctionConfigurationInput,
   SimS3NotificationConfigurationInput,
   SimS3QueueConfigurationInput,
+  SimS3TopicConfigurationInput,
 } from "../../../../../s3/command/put-bucket-notification-configuration/put-bucket-notification-configuration.command.js";
 import type { SimCfnTemplateValue } from "../../../../template/value/sim-cfn-template-value.js";
 import { SimCfnValueShape } from "../../../../template/value/sim-cfn-value-shape.js";
@@ -52,8 +53,7 @@ export class SimCdkBucketNotificationConfiguration {
       ),
       TopicConfigurations: this.shape.present(
         record["TopicConfigurations"],
-        (configurations) =>
-          this.shape.list(configurations, "TopicConfigurations"),
+        (configurations) => this.topicConfigurations(configurations),
       ),
       EventBridgeConfiguration: this.shape.present(
         record["EventBridgeConfiguration"],
@@ -111,6 +111,33 @@ export class SimCdkBucketNotificationConfiguration {
       Id: this.shape.present(record["Id"], (id) => this.shape.string(id, "Id")),
       QueueArn: this.shape.present(record["QueueArn"], (arn) =>
         this.shape.string(arn, "QueueArn"),
+      ),
+      Events: this.shape.present(record["Events"], (events) =>
+        this.events(events),
+      ),
+      Filter: this.shape.present(record["Filter"], (filter) =>
+        this.filter.read(filter),
+      ),
+    };
+  }
+
+  private topicConfigurations(
+    value: SimCfnTemplateValue,
+  ): readonly SimS3TopicConfigurationInput[] {
+    return this.shape
+      .list(value, "TopicConfigurations")
+      .map((configuration) => this.topicConfiguration(configuration));
+  }
+
+  private topicConfiguration(
+    value: SimCfnTemplateValue,
+  ): SimS3TopicConfigurationInput {
+    const record = this.shape.record(value, "TopicConfigurations entry");
+
+    return {
+      Id: this.shape.present(record["Id"], (id) => this.shape.string(id, "Id")),
+      TopicArn: this.shape.present(record["TopicArn"], (arn) =>
+        this.shape.string(arn, "TopicArn"),
       ),
       Events: this.shape.present(record["Events"], (events) =>
         this.events(events),

--- a/src/service/cloudformation/cdk/s3/bucket-notifications/sim-cdk-bucket-notifications-shape.iso.test.ts
+++ b/src/service/cloudformation/cdk/s3/bucket-notifications/sim-cdk-bucket-notifications-shape.iso.test.ts
@@ -181,23 +181,22 @@ describe("CDK Bucket notifications configuration shape", () => {
     assertStringIncludes(error.message, "is not a simulated SQS queue");
   });
 
-  it("refuses a topic destination by name", async () => {
-    // Given a configuration naming an SNS topic.
+  it("refuses a topic destination that is not there", async () => {
+    // Given the configuration CDK synthesizes for an SnsDestination, naming a
+    // topic no stack ever created.
     // When the template is deployed.
     const error = await deployConfiguration({
       TopicConfigurations: [
         {
-          Events: ["s3:ObjectCreated:*"],
+          Events: ["s3:ObjectRemoved:*"],
           TopicArn: "arn:aws:sns:us-east-1:888888888888:uploads",
         },
       ],
     });
 
-    // Then the Stack fails naming the destination.
-    assertStringIncludes(
-      error.message,
-      "Simulated S3 cannot notify a SNS topic",
-    );
+    // Then the Stack fails, because a configuration that is accepted and never
+    // delivered is worse than one that is refused.
+    assertStringIncludes(error.message, "is not a simulated SNS topic");
   });
 
   it("refuses an EventBridge destination by name", async () => {

--- a/src/service/cloudformation/cdk/s3/bucket-notifications/sim-cdk-bucket-notifications-topic.iso.test.ts
+++ b/src/service/cloudformation/cdk/s3/bucket-notifications/sim-cdk-bucket-notifications-topic.iso.test.ts
@@ -1,0 +1,92 @@
+import {
+  DeleteObjectCommand,
+  GetBucketNotificationConfigurationCommand,
+  PutObjectCommand,
+} from "@aws-sdk/client-s3";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../../aws/sim-aws.js";
+import {
+  simSnsDeliveredMessage,
+  simSnsSubscribedQueue,
+} from "../../../../../../test/sns/subscription-fixture.js";
+import { simS3NotificationTopic } from "../../../../../../test/s3/notification-topic-fixture.js";
+import { simCdkBucketNotificationsTemplateFactory } from "./sim-cdk-bucket-notifications-template.factory.js";
+
+describe("CDK Bucket notifications to an SNS topic", () => {
+  it("notifies a topic the way CDK's SnsDestination configures one", async () => {
+    // Given a topic whose policy carries the ArnLike source ARN condition
+    // CDK's SnsDestination writes, and a queue subscribed to it. CDK writes
+    // that policy as an AWS::SNS::TopicPolicy, which simulated CloudFormation
+    // does not deploy yet, so the topic is set up through the SDK here.
+    const simAws = new SimAws();
+    const topicArn = await simS3NotificationTopic(simAws, {
+      sourceArn: "arn:aws:s3:::uploads",
+    });
+    const { queueUrl } = await simSnsSubscribedQueue(
+      simAws,
+      "uploads-queue",
+      topicArn,
+    );
+
+    // When a template naming that topic alongside the function is deployed,
+    // which is what a CDK app adding two destinations for two event types
+    // synthesizes.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "uploads-stack",
+      template: simCdkBucketNotificationsTemplateFactory.make({
+        notificationConfiguration: {
+          TopicConfigurations: [
+            {
+              Id: "removals",
+              Events: ["s3:ObjectRemoved:*"],
+              TopicArn: topicArn,
+              Filter: {
+                Key: { FilterRules: [{ Name: "prefix", Value: "raw/" }] },
+              },
+            },
+          ],
+        },
+      }),
+    });
+    await stack.waitForDeployComplete();
+
+    // Then an Object removed from under the filtered prefix reaches the queue
+    // two hops away.
+    await simAws.s3().putObject(
+      new PutObjectCommand({
+        Bucket: "uploads",
+        Key: "raw/cat.jpg",
+        Body: "cat picture",
+      }),
+    );
+    await simAws
+      .s3()
+      .deleteObject(
+        new DeleteObjectCommand({ Bucket: "uploads", Key: "raw/cat.jpg" }),
+      );
+
+    assertNonNullable(await simSnsDeliveredMessage(simAws, queueUrl));
+
+    // And the Bucket reports the configuration back under TopicConfigurations.
+    const output = await simAws
+      .s3()
+      .getBucketNotificationConfiguration(
+        new GetBucketNotificationConfigurationCommand({ Bucket: "uploads" }),
+      );
+    const configurations = output.TopicConfigurations;
+    assertNonNullable(configurations);
+    assertArrayLength(configurations, 1);
+    assertIdentical(configurations[0].Id, "removals");
+    assertIdentical(configurations[0].TopicArn, topicArn);
+    assertIdentical(
+      configurations[0].Filter?.Key?.FilterRules?.[0]?.Value,
+      "raw/",
+    );
+  });
+});

--- a/src/service/s3/README.md
+++ b/src/service/s3/README.md
@@ -373,7 +373,8 @@ Notifications are split between the configuration, which is Bucket state, and de
 
 `bucket/notification/` holds the configuration. `SimS3NotificationConfiguration` is what a Bucket
 stores, and `SimS3NotificationFilter` is the object key filter. `SimS3Notification` is one
-destination in it, with `SimS3LambdaNotification` and `SimS3QueueNotification` as the two kinds.
+destination in it, with `SimS3LambdaNotification`, `SimS3QueueNotification` and
+`SimS3TopicNotification` as the three kinds.
 Everything a configuration is asked, which events reach a destination and whether two of them
 conflict, is the same question whatever the destination is, so only the ARN's property name and the
 kind of destination it wants differ between the subclasses. Each reads its own entries through
@@ -424,7 +425,7 @@ then reaches the Lambda destination and is refused for not being a function, ins
 being delivered to as a queue. Each destination refuses an ARN that does not name what it delivers
 to. `SimS3NoNotificationDestinations` is what a standalone `SimS3` gets, and it refuses by name.
 
-Both destinations resolve lazily from the `SimAws` they were built with, never at construction time:
+Every destination resolves lazily from the `SimAws` it was built with, never at construction time:
 `createLambda` already reaches `scope.s3()` for function code, so an eager `scope.lambda()` in
 `createS3` would recurse, because the scope memo records a service only once its factory has
 returned.
@@ -441,6 +442,18 @@ grant and its own IAM evaluates it, through `SimSqsServiceSendAuthorizer`. Deliv
 ordinary `SendMessage` path, so the message is the same thing an SDK caller would have sent and is
 authorized again on the way in. The refusal is asked for first all the same, so a queue policy saying
 no is recorded as a refusal rather than as a fault.
+
+`SimAwsS3NotificationTopics` is the same shape again for a topic, splitting into the Region rule and
+`SimS3NotificationTopic`, which is one topic in the Account and Region its ARN names. The decision
+comes from `SimSnsServicePublishAuthorizer`, and delivery goes through the ordinary `Publish` path,
+so the topic's own subscriptions take the event from there and an S3 event reaches everything the
+topic reaches. `SimS3NotificationTopicArn` borrows `parseSnsTopicArn` rather than reading the ARN
+itself, since a topic ARN has no resource type segment and a subscription ARN is one with a seventh
+part added: reading a subscription ARN as a topic ARN would find a topic nobody named.
+
+The message is the `Records` document a queue destination gets, published with the
+`Amazon S3 Notification` subject real S3 publishes and no message attributes, since real S3 sends
+none.
 
 The raise point is one call in `PutObjectCommandHandler` and one in each of the two deletion
 handlers, after the write and with the caller the authorizer resolved. Every write path funnels

--- a/src/service/s3/bucket/notification/sim-s3-notification-configuration-reader.ts
+++ b/src/service/s3/bucket/notification/sim-s3-notification-configuration-reader.ts
@@ -4,6 +4,7 @@ import { SimS3NotificationConfiguration } from "./sim-s3-notification-configurat
 import { simS3AssertNotificationIdsAreUnique } from "./sim-s3-notification-ids.js";
 import { simS3AssertNoNotificationOverlap } from "./sim-s3-notification-overlap.js";
 import { SimS3QueueNotification } from "./sim-s3-queue-notification.js";
+import { SimS3TopicNotification } from "./sim-s3-topic-notification.js";
 import { simS3RefuseUnsimulatedDestinations } from "./sim-s3-unsimulated-notification-destinations.js";
 
 /**
@@ -35,6 +36,9 @@ export class SimS3NotificationConfigurationReader {
       ),
       queueNotifications: (input.QueueConfigurations ?? []).map((entry) =>
         SimS3QueueNotification.fromInput(entry),
+      ),
+      topicNotifications: (input.TopicConfigurations ?? []).map((entry) =>
+        SimS3TopicNotification.fromInput(entry),
       ),
     });
 

--- a/src/service/s3/bucket/notification/sim-s3-notification-configuration.ts
+++ b/src/service/s3/bucket/notification/sim-s3-notification-configuration.ts
@@ -3,10 +3,12 @@ import type { SimS3LambdaNotification } from "./sim-s3-lambda-notification.js";
 import type { SimS3Notification } from "./sim-s3-notification.js";
 import type { SimS3NotificationEvent } from "./sim-s3-notification-event.js";
 import type { SimS3QueueNotification } from "./sim-s3-queue-notification.js";
+import type { SimS3TopicNotification } from "./sim-s3-topic-notification.js";
 
 interface SimS3NotificationConfigurationProperties {
   readonly lambdaNotifications?: readonly SimS3LambdaNotification[];
   readonly queueNotifications?: readonly SimS3QueueNotification[];
+  readonly topicNotifications?: readonly SimS3TopicNotification[];
 }
 
 /**
@@ -24,10 +26,12 @@ interface SimS3NotificationConfigurationProperties {
 export class SimS3NotificationConfiguration {
   public readonly lambdaNotifications: readonly SimS3LambdaNotification[];
   public readonly queueNotifications: readonly SimS3QueueNotification[];
+  public readonly topicNotifications: readonly SimS3TopicNotification[];
 
   constructor(properties: SimS3NotificationConfigurationProperties = {}) {
     this.lambdaNotifications = properties.lambdaNotifications ?? [];
     this.queueNotifications = properties.queueNotifications ?? [];
+    this.topicNotifications = properties.topicNotifications ?? [];
   }
 
   /**
@@ -41,7 +45,11 @@ export class SimS3NotificationConfiguration {
    * Every configured destination, whatever kind it is.
    */
   get all(): readonly SimS3Notification[] {
-    return [...this.lambdaNotifications, ...this.queueNotifications];
+    return [
+      ...this.lambdaNotifications,
+      ...this.queueNotifications,
+      ...this.topicNotifications,
+    ];
   }
 
   /**
@@ -69,6 +77,11 @@ export class SimS3NotificationConfiguration {
       }),
       ...(this.queueNotifications.length > 0 && {
         QueueConfigurations: this.queueNotifications.map((notification) =>
+          notification.toOutput(),
+        ),
+      }),
+      ...(this.topicNotifications.length > 0 && {
+        TopicConfigurations: this.topicNotifications.map((notification) =>
           notification.toOutput(),
         ),
       }),

--- a/src/service/s3/bucket/notification/sim-s3-topic-notification.ts
+++ b/src/service/s3/bucket/notification/sim-s3-topic-notification.ts
@@ -1,0 +1,37 @@
+import type { SimS3TopicConfigurationInput } from "../../command/put-bucket-notification-configuration/put-bucket-notification-configuration.command.js";
+import type { SimS3NotificationDestinationService } from "../../notification/destination/sim-s3-notification-destination.js";
+import { SimS3Notification } from "./sim-s3-notification.js";
+import { simS3NotificationProperties } from "./sim-s3-notification-properties.js";
+
+/**
+ * One SNS topic destination in a Bucket's notification configuration.
+ */
+export class SimS3TopicNotification extends SimS3Notification {
+  /**
+   * The kind of destination this configuration was declared for.
+   */
+  public readonly destinationService: SimS3NotificationDestinationService =
+    "sns";
+
+  /**
+   * Read one TopicConfigurations entry.
+   */
+  static fromInput(
+    configuration: SimS3TopicConfigurationInput,
+  ): SimS3TopicNotification {
+    return new SimS3TopicNotification(
+      simS3NotificationProperties(
+        configuration,
+        configuration.TopicArn,
+        "A topic notification configuration must name a TopicArn.",
+      ),
+    );
+  }
+
+  /**
+   * This configuration as GetBucketNotificationConfiguration reports it.
+   */
+  toOutput(): SimS3TopicConfigurationInput {
+    return { ...this.reported(), TopicArn: this.destinationArn };
+  }
+}

--- a/src/service/s3/bucket/notification/sim-s3-unsimulated-notification-destinations.ts
+++ b/src/service/s3/bucket/notification/sim-s3-unsimulated-notification-destinations.ts
@@ -6,7 +6,6 @@ import { SimS3NotImplemented } from "../../error/sim-s3.error.js";
  * deliver to, and what to say about each.
  */
 const unsimulatedDestinations = new Map<string, string>([
-  ["TopicConfigurations", "SNS topic"],
   ["EventBridgeConfiguration", "EventBridge"],
 ]);
 
@@ -15,7 +14,7 @@ const unsimulatedDestinations = new Map<string, string>([
  *
  * Naming the destination matters more than the refusal: a configuration quietly
  * accepted and never delivered is the failure this feature exists to remove, so
- * an SNS topic destination says so rather than being dropped.
+ * an EventBridge destination says so rather than being dropped.
  */
 export function simS3RefuseUnsimulatedDestinations(
   input: SimS3NotificationConfigurationInput,
@@ -35,7 +34,8 @@ export function simS3RefuseUnsimulatedDestinations(
 
     throw new SimS3NotImplemented(
       `Simulated S3 cannot notify a ${destination}. ${property} is not ` +
-        "simulated; use LambdaFunctionConfigurations or QueueConfigurations.",
+        "simulated; use LambdaFunctionConfigurations, QueueConfigurations or " +
+        "TopicConfigurations.",
     );
   }
 }

--- a/src/service/s3/cfn/bucket/notification/sim-cfn-s3-bucket-notification-configuration.ts
+++ b/src/service/s3/cfn/bucket/notification/sim-cfn-s3-bucket-notification-configuration.ts
@@ -5,6 +5,7 @@ import type {
   SimS3NotificationConfigurationInput,
   SimS3NotificationFilterInput,
   SimS3QueueConfigurationInput,
+  SimS3TopicConfigurationInput,
 } from "../../../command/put-bucket-notification-configuration/put-bucket-notification-configuration.command.js";
 import { s3BucketNotificationError } from "../error/sim-cfn-s3-bucket-error.js";
 import { SimCfnS3BucketNotificationFilter } from "./sim-cfn-s3-bucket-notification-filter.js";
@@ -44,6 +45,18 @@ const queueConfigurationNames: ReadonlySet<string> = new Set([
 ]);
 
 /**
+ * The names one CloudFormation TopicConfiguration carries.
+ *
+ * `Topic` is the topic's ARN, the same shortening CloudFormation applies to a
+ * queue destination.
+ */
+const topicConfigurationNames: ReadonlySet<string> = new Set([
+  "Event",
+  "Filter",
+  "Topic",
+]);
+
+/**
  * The parts of one CloudFormation destination configuration that are the same
  * whichever destination it names.
  */
@@ -56,11 +69,12 @@ interface SimCfnS3BucketNotificationParts {
  * Reads the `NotificationConfiguration` property of an AWS::S3::Bucket Resource
  * into a PutBucketNotificationConfiguration request.
  *
- * CloudFormation and the SDK name the same configuration differently in four
+ * CloudFormation and the SDK name the same configuration differently in several
  * places, and each of them is a silent failure if read at the wrong name:
  * `LambdaConfigurations` against `LambdaFunctionConfigurations`, a single
  * `Event` string against an `Events` list, `Function` against
- * `LambdaFunctionArn`, and `Filter.S3Key.Rules` against `Filter.Key.FilterRules`.
+ * `LambdaFunctionArn`, `Queue` against `QueueArn`, `Topic` against `TopicArn`,
+ * and `Filter.S3Key.Rules` against `Filter.Key.FilterRules`.
  *
  * Only the shape is read here. Whether the configuration is one simulated S3
  * accepts is the command's question, so a template and an SDK caller are
@@ -80,10 +94,10 @@ export class SimCfnS3BucketNotificationConfiguration {
   /**
    * Read a whole notification configuration.
    *
-   * A destination group this simulator cannot deliver to is carried through
-   * untouched, so the command refuses it by name rather than dropping it. The
-   * names happen to match: CloudFormation and the SDK both call them
-   * `QueueConfigurations`, `TopicConfigurations` and `EventBridgeConfiguration`.
+   * `EventBridgeConfiguration` is carried through untouched, so the command
+   * refuses it by name rather than dropping it. The name happens to match:
+   * CloudFormation and the SDK both spell it that way, as they do
+   * `QueueConfigurations` and `TopicConfigurations`.
    */
   read(value: SimCfnTemplateValue): SimS3NotificationConfigurationInput {
     const record = this.shape.record(value, "NotificationConfiguration");
@@ -104,8 +118,7 @@ export class SimCfnS3BucketNotificationConfiguration {
       ),
       TopicConfigurations: this.shape.present(
         record["TopicConfigurations"],
-        (configurations) =>
-          this.shape.list(configurations, "TopicConfigurations"),
+        (configurations) => this.topicConfigurations(configurations),
       ),
       EventBridgeConfiguration: this.shape.present(
         record["EventBridgeConfiguration"],
@@ -163,6 +176,32 @@ export class SimCfnS3BucketNotificationConfiguration {
       ...this.notificationParts(record),
       QueueArn: this.shape.present(record["Queue"], (arn) =>
         this.shape.string(arn, "Queue"),
+      ),
+    };
+  }
+
+  private topicConfigurations(
+    value: SimCfnTemplateValue,
+  ): readonly SimS3TopicConfigurationInput[] {
+    return this.shape
+      .list(value, "TopicConfigurations")
+      .map((configuration) => this.topicConfiguration(configuration));
+  }
+
+  private topicConfiguration(
+    value: SimCfnTemplateValue,
+  ): SimS3TopicConfigurationInput {
+    const record = this.shape.record(value, "TopicConfigurations entry");
+    this.shape.knownKeys(
+      record,
+      topicConfigurationNames,
+      "TopicConfigurations entry",
+    );
+
+    return {
+      ...this.notificationParts(record),
+      TopicArn: this.shape.present(record["Topic"], (arn) =>
+        this.shape.string(arn, "Topic"),
       ),
     };
   }

--- a/src/service/s3/cfn/bucket/notification/sim-cfn-s3-bucket-notification-refusals.iso.test.ts
+++ b/src/service/s3/cfn/bucket/notification/sim-cfn-s3-bucket-notification-refusals.iso.test.ts
@@ -204,8 +204,8 @@ describe("AWS::S3::Bucket NotificationConfiguration refusals", () => {
     );
   });
 
-  it("refuses a topic destination", async () => {
-    // Given a template naming an SNS topic destination.
+  it("refuses a topic destination that is not a topic ARN", async () => {
+    // Given a template whose topic destination names no Region or Account.
     const simAws = new SimAws();
 
     // When the template is deployed.
@@ -216,9 +216,29 @@ describe("AWS::S3::Bucket NotificationConfiguration refusals", () => {
     });
 
     // Then the Stack fails with the command's own refusal.
+    assertStringIncludes(error.message, "is not an SNS topic ARN");
+  });
+
+  it("refuses a topic destination naming the SDK property", async () => {
+    // Given a template using the SDK's TopicArn rather than CloudFormation's
+    // Topic, which would otherwise deploy a Bucket notifying nothing.
+    const simAws = new SimAws();
+
+    // When the template is deployed.
+    const error = await deployFailing(simAws, {
+      TopicConfigurations: [
+        {
+          Event: "s3:ObjectCreated:*",
+          TopicArn: "arn:aws:sns:us-east-1:888888888888:uploads",
+        },
+      ],
+    });
+
+    // Then the Stack fails on the name CloudFormation does not have.
     assertStringIncludes(
       error.message,
-      "Simulated S3 cannot notify a SNS topic",
+      "TopicArn is not a TopicConfigurations entry property this simulation " +
+        "reads",
     );
   });
 

--- a/src/service/s3/cfn/bucket/notification/sim-cfn-s3-bucket-notification.iso.test.ts
+++ b/src/service/s3/cfn/bucket/notification/sim-cfn-s3-bucket-notification.iso.test.ts
@@ -16,6 +16,11 @@ import { describe, it } from "vitest";
 
 import { SimAws } from "../../../../aws/sim-aws.js";
 import { simIamPolicyDocumentFactory } from "../../../../iam/policy/sim-iam-policy-document.factory.js";
+import {
+  simSnsDeliveredMessage,
+  simSnsSubscribedQueue,
+} from "../../../../../../test/sns/subscription-fixture.js";
+import { simS3NotificationTopic } from "../../../../../../test/s3/notification-topic-fixture.js";
 import { simCfnS3BucketNotificationTemplateFactory } from "./sim-cfn-s3-bucket-notification-template.factory.js";
 
 /**
@@ -250,6 +255,58 @@ describe("AWS::S3::Bucket NotificationConfiguration", () => {
     const configurations = output.QueueConfigurations ?? [];
     assertArrayLength(configurations, 1);
     assertIdentical(configurations[0].QueueArn, queueArn);
+    assertIdentical(configurations[0].Events?.[0], "s3:ObjectCreated:*");
+  });
+
+  it("notifies a topic a TopicConfigurations entry names", async () => {
+    // Given a topic admitting the Bucket the template deploys, with a queue
+    // subscribed to it.
+    const simAws = new SimAws();
+    const topicArn = await simS3NotificationTopic(simAws, {
+      sourceArn: "arn:aws:s3:::uploads",
+    });
+    const { queueUrl } = await simSnsSubscribedQueue(
+      simAws,
+      "uploads-queue",
+      topicArn,
+    );
+
+    // When a template naming it under CloudFormation's own property names is
+    // deployed: `Topic` rather than `TopicArn`, and one `Event` rather than an
+    // `Events` list.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "uploads-stack",
+      template: simCfnS3BucketNotificationTemplateFactory.make({
+        notificationConfiguration: {
+          TopicConfigurations: [
+            { Event: "s3:ObjectCreated:*", Topic: topicArn },
+          ],
+        },
+      }),
+    });
+    await stack.waitForDeployComplete();
+
+    // Then an Object put into the deployed Bucket reaches the queue two hops
+    // away.
+    await simAws.s3().putObject(
+      new PutObjectCommand({
+        Bucket: "uploads",
+        Key: "cat.jpg",
+        Body: "cat picture",
+      }),
+    );
+
+    assertNonNullable(await simSnsDeliveredMessage(simAws, queueUrl));
+
+    // And the Bucket reports it back in the SDK's names.
+    const output = await simAws
+      .s3()
+      .getBucketNotificationConfiguration(
+        new GetBucketNotificationConfigurationCommand({ Bucket: "uploads" }),
+      );
+    const configurations = output.TopicConfigurations ?? [];
+    assertArrayLength(configurations, 1);
+    assertIdentical(configurations[0].TopicArn, topicArn);
     assertIdentical(configurations[0].Events?.[0], "s3:ObjectCreated:*");
   });
 

--- a/src/service/s3/command/get-bucket-notification-configuration/get-bucket-notification-configuration.command.ts
+++ b/src/service/s3/command/get-bucket-notification-configuration/get-bucket-notification-configuration.command.ts
@@ -2,6 +2,7 @@ import type { SimResponseMetadata } from "../../../aws/metadata/response-metadat
 import type {
   SimS3LambdaFunctionConfigurationInput,
   SimS3QueueConfigurationInput,
+  SimS3TopicConfigurationInput,
 } from "../put-bucket-notification-configuration/put-bucket-notification-configuration.command.js";
 
 /**
@@ -33,6 +34,8 @@ export interface SimS3NotificationConfigurationOutput {
     readonly SimS3LambdaFunctionConfigurationInput[] | undefined;
   readonly QueueConfigurations?:
     readonly SimS3QueueConfigurationInput[] | undefined;
+  readonly TopicConfigurations?:
+    readonly SimS3TopicConfigurationInput[] | undefined;
 }
 
 /**

--- a/src/service/s3/command/put-bucket-notification-configuration/put-bucket-notification-configuration.command.ts
+++ b/src/service/s3/command/put-bucket-notification-configuration/put-bucket-notification-configuration.command.ts
@@ -37,7 +37,8 @@ export interface SimS3NotificationConfigurationInput {
     readonly SimS3LambdaFunctionConfigurationInput[] | undefined;
   readonly QueueConfigurations?:
     readonly SimS3QueueConfigurationInput[] | undefined;
-  readonly TopicConfigurations?: readonly unknown[] | undefined;
+  readonly TopicConfigurations?:
+    readonly SimS3TopicConfigurationInput[] | undefined;
   readonly EventBridgeConfiguration?: object | undefined;
 }
 
@@ -57,6 +58,16 @@ export interface SimS3LambdaFunctionConfigurationInput {
 export interface SimS3QueueConfigurationInput {
   readonly Id?: string | undefined;
   readonly QueueArn?: string | undefined;
+  readonly Events?: readonly string[] | undefined;
+  readonly Filter?: SimS3NotificationFilterInput | undefined;
+}
+
+/**
+ * Minimal structural sim S3 SNS topic notification configuration.
+ */
+export interface SimS3TopicConfigurationInput {
+  readonly Id?: string | undefined;
+  readonly TopicArn?: string | undefined;
   readonly Events?: readonly string[] | undefined;
   readonly Filter?: SimS3NotificationFilterInput | undefined;
 }

--- a/src/service/s3/command/put-bucket-notification-configuration/put-bucket-notification-destination-refusals.iso.test.ts
+++ b/src/service/s3/command/put-bucket-notification-configuration/put-bucket-notification-destination-refusals.iso.test.ts
@@ -46,14 +46,14 @@ describe("What a simulated S3 notification destination refuses", () => {
     assertStringIncludes(error.message, "FIFO queue");
   });
 
-  it("refuses an SNS topic destination by name", async () => {
+  it("refuses a FIFO topic destination by name", async () => {
     // Given a Bucket
     const simAws = new SimAws();
     await simAws
       .s3()
       .createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
 
-    // When a configuration names a topic
+    // When a configuration names a FIFO topic
     const error = await assertThrowsErrorAsync(async () =>
       simAws.s3().putBucketNotificationConfiguration(
         new PutBucketNotificationConfigurationCommand({
@@ -62,7 +62,7 @@ describe("What a simulated S3 notification destination refuses", () => {
             TopicConfigurations: [
               {
                 Events: ["s3:ObjectCreated:*"],
-                TopicArn: "arn:aws:sns:us-east-1:888888888888:uploads",
+                TopicArn: "arn:aws:sns:us-east-1:888888888888:uploads.fifo",
               },
             ],
           },
@@ -70,8 +70,10 @@ describe("What a simulated S3 notification destination refuses", () => {
       ),
     );
 
-    // Then the destination it cannot deliver to is named
-    assertStringIncludes(error.message, "SNS topic");
+    // Then the topic real S3 will not deliver to is named for what it is,
+    // rather than being reported as a topic that is not there.
+    assertIdentical(error.name, "NotImplemented");
+    assertStringIncludes(error.message, "FIFO topic");
   });
 
   it("refuses an EventBridge destination by name", async () => {

--- a/src/service/s3/command/put-bucket-notification-configuration/put-bucket-notification-overlap.iso.test.ts
+++ b/src/service/s3/command/put-bucket-notification-configuration/put-bucket-notification-overlap.iso.test.ts
@@ -3,9 +3,10 @@
  *
  * https://docs.aws.amazon.com/AmazonS3/latest/userguide/notification-how-to-filtering.html
  *
- * AWS states the rule with SNS topic and SQS queue destinations, which this
- * simulator does not deliver to. The prefixes, suffixes and event types are
- * ported as they are written there; only the destination is a Lambda function.
+ * AWS states the rule with SNS topic and SQS queue destinations. The prefixes,
+ * suffixes and event types are ported as they are written there; the
+ * destination is a Lambda function, since the rule is the same whatever the
+ * destination is, and the last case here proves that by mixing two groups.
  */
 
 import {
@@ -345,5 +346,43 @@ describe("Overlapping S3 notification configurations", () => {
         new GetBucketNotificationConfigurationCommand({ Bucket: "uploads" }),
       );
     assertArrayLength(read.LambdaFunctionConfigurations ?? [], 2);
+  });
+
+  it("refuses a topic and a queue that want the same event", async () => {
+    // Given a Bucket
+    const simAws = new SimAws();
+    await simAws
+      .s3()
+      .createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+
+    // When a topic destination and a queue destination take the same event
+    // with filters that could both match a key
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.s3().putBucketNotificationConfiguration(
+        new PutBucketNotificationConfigurationCommand({
+          Bucket: "uploads",
+          NotificationConfiguration: {
+            TopicConfigurations: [
+              {
+                Id: "topic",
+                Events: ["s3:ObjectCreated:*"],
+                TopicArn: "arn:aws:sns:us-east-1:888888888888:uploads",
+              },
+            ],
+            QueueConfigurations: [
+              {
+                Id: "queue",
+                Events: ["s3:ObjectCreated:Put"],
+                QueueArn: "arn:aws:sqs:us-east-1:888888888888:uploads",
+              },
+            ],
+          },
+        }),
+      ),
+    );
+
+    // Then it is refused, as it would be for two of the same kind: the rule is
+    // about event sets and filters rather than about destination groups
+    assertStringIncludes(error.message, "overlap");
   });
 });

--- a/src/service/s3/command/put-bucket-notification-configuration/put-bucket-notification-refusals.iso.test.ts
+++ b/src/service/s3/command/put-bucket-notification-configuration/put-bucket-notification-refusals.iso.test.ts
@@ -289,4 +289,31 @@ describe("What a simulated S3 notification configuration refuses", () => {
     assertStringIncludes(error.message, "constructed on its own");
     assertStringIncludes(error.message, "SimAws");
   });
+
+  it("refuses a topic destination on a simulated S3 built on its own", async () => {
+    // Given a SimS3 constructed outside SimAws, which has no simulated SNS to
+    // publish to
+    const simS3 = new SimS3();
+    await simS3.createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+
+    // When a topic notification configuration is applied to one of its Buckets
+    const error = await assertThrowsErrorAsync(async () =>
+      simS3.putBucketNotificationConfiguration(
+        new PutBucketNotificationConfigurationCommand({
+          Bucket: "uploads",
+          NotificationConfiguration: {
+            TopicConfigurations: [
+              {
+                Events: ["s3:ObjectCreated:*"],
+                TopicArn: "arn:aws:sns:us-east-1:888888888888:uploads",
+              },
+            ],
+          },
+        }),
+      ),
+    );
+
+    // Then it says so, as it does for every other kind of destination
+    assertStringIncludes(error.message, "constructed on its own");
+  });
 });

--- a/src/service/s3/notification/destination/sim-s3-notification-destination.ts
+++ b/src/service/s3/notification/destination/sim-s3-notification-destination.ts
@@ -59,7 +59,7 @@ export interface SimS3NotificationDestination {
  * under `LambdaFunctionConfigurations` is refused for not being a function
  * rather than quietly delivered to as a queue.
  */
-export type SimS3NotificationDestinationService = "lambda" | "sqs";
+export type SimS3NotificationDestinationService = "lambda" | "sns" | "sqs";
 
 /**
  * The destinations one simulated S3 scope can reach.

--- a/src/service/s3/notification/destination/sim-s3-service-notification-destinations.ts
+++ b/src/service/s3/notification/destination/sim-s3-service-notification-destinations.ts
@@ -7,6 +7,7 @@ import type {
 
 interface SimS3ServiceNotificationDestinationsProperties {
   readonly lambda: SimS3NotificationDestination;
+  readonly sns: SimS3NotificationDestination;
   readonly sqs: SimS3NotificationDestination;
 }
 
@@ -20,10 +21,12 @@ interface SimS3ServiceNotificationDestinationsProperties {
  */
 export class SimS3ServiceNotificationDestinations implements SimS3NotificationDestinations {
   private readonly lambda: SimS3NotificationDestination;
+  private readonly sns: SimS3NotificationDestination;
   private readonly sqs: SimS3NotificationDestination;
 
   constructor(properties: SimS3ServiceNotificationDestinationsProperties) {
     this.lambda = properties.lambda;
+    this.sns = properties.sns;
     this.sqs = properties.sqs;
   }
 
@@ -36,6 +39,9 @@ export class SimS3ServiceNotificationDestinations implements SimS3NotificationDe
     switch (service) {
       case "lambda": {
         return this.lambda;
+      }
+      case "sns": {
+        return this.sns;
       }
       case "sqs": {
         return this.sqs;

--- a/src/service/s3/notification/destination/sns/sim-aws-s3-notification-topics.ts
+++ b/src/service/s3/notification/destination/sns/sim-aws-s3-notification-topics.ts
@@ -1,0 +1,72 @@
+import type { SimAws } from "../../../../aws/sim-aws.js";
+import type { SimS3NotificationDestinationRequest } from "../sim-s3-notification-destination.js";
+import { SimS3NotificationTopic } from "./sim-s3-notification-topic.js";
+import { SimS3NotificationTopicArn } from "./sim-s3-notification-topic-arn.js";
+import type { SimS3NotificationTopics } from "./sim-s3-notification-topics.js";
+
+interface SimAwsS3NotificationTopicsProperties {
+  readonly simAws: SimAws;
+}
+
+/**
+ * The simulated SNS topics of one simulated AWS instance, as S3 notification
+ * destinations.
+ *
+ * Topics are looked up when a configuration is applied or an event is
+ * delivered, never when this is built, for the same reason the other
+ * destinations do it that way: reaching another service while this one is being
+ * constructed is a cycle with no bottom to it.
+ *
+ * A topic in another Account is allowed, and evaluated against the IAM of the
+ * Account owning it. Real S3 asks only that the topic is in the Bucket's
+ * Region, the same rule it applies to a destination queue.
+ */
+export class SimAwsS3NotificationTopics implements SimS3NotificationTopics {
+  private readonly simAws: SimAws;
+
+  constructor(properties: SimAwsS3NotificationTopicsProperties) {
+    this.simAws = properties.simAws;
+  }
+
+  /**
+   * Why S3 may not publish to the topic, or nothing when it may.
+   *
+   * The Region is this side's rule and the rest is the topic's own. What S3
+   * adds to the topic's decision is which Bucket is sending, so a policy
+   * granting one Bucket does not open the topic to another.
+   */
+  publishRefusal(
+    request: SimS3NotificationDestinationRequest,
+  ): string | undefined {
+    const arn = SimS3NotificationTopicArn.parse(request.destinationArn);
+
+    if (!arn.isIn(request.bucketRegionName)) {
+      return (
+        `${request.destinationArn} is in ${arn.regionName}, and an S3 event ` +
+        "notification destination topic must be in the Bucket's Region, " +
+        `${request.bucketRegionName}.`
+      );
+    }
+
+    return this.topic(arn).publishRefusal(request);
+  }
+
+  /**
+   * Publish the event document to the topic.
+   */
+  async publish(
+    request: SimS3NotificationDestinationRequest,
+    body: string,
+  ): Promise<void> {
+    await this.topic(
+      SimS3NotificationTopicArn.parse(request.destinationArn),
+    ).publish(request, body);
+  }
+
+  private topic(arn: SimS3NotificationTopicArn): SimS3NotificationTopic {
+    return new SimS3NotificationTopic({
+      arn,
+      scope: this.simAws.accountRegionScope(arn.accountId, arn.regionName),
+    });
+  }
+}

--- a/src/service/s3/notification/destination/sns/sim-s3-notification-topic-arn.ts
+++ b/src/service/s3/notification/destination/sns/sim-s3-notification-topic-arn.ts
@@ -1,0 +1,71 @@
+import type { SimAwsAccountId } from "../../../../aws/sim-aws-account.js";
+import type { AwsRegionName } from "../../../../aws/sim-aws-region.js";
+import { parseSnsTopicArn } from "../../../../sns/topic/sim-sns-topic-arn.js";
+import {
+  SimS3InvalidArgument,
+  SimS3NotImplemented,
+} from "../../../error/sim-s3.error.js";
+
+/**
+ * The SNS topic ARN a notification configuration names.
+ *
+ * A topic ARN has no resource type segment, so the topic name follows the
+ * Account id directly, which is why the shared ARN reader cannot read one and
+ * SNS's own reader is borrowed here instead.
+ */
+export class SimS3NotificationTopicArn {
+  public readonly regionName: AwsRegionName;
+  public readonly accountId: SimAwsAccountId;
+  public readonly topicName: string;
+  public readonly value: string;
+
+  private constructor(
+    regionName: AwsRegionName,
+    accountId: SimAwsAccountId,
+    topicName: string,
+    value: string,
+  ) {
+    this.regionName = regionName;
+    this.accountId = accountId;
+    this.topicName = topicName;
+    this.value = value;
+  }
+
+  /**
+   * Read an SNS topic ARN, refusing anything else.
+   *
+   * A FIFO topic is refused by its name, as real S3 refuses one as an event
+   * notification destination. Simulated SNS has no FIFO topics either, so
+   * without this the refusal would be that the topic does not exist, which
+   * points at the wrong thing to fix.
+   */
+  static parse(arn: string): SimS3NotificationTopicArn {
+    const location = parseSnsTopicArn(arn);
+
+    if (location === undefined) {
+      throw new SimS3InvalidArgument(`${arn} is not an SNS topic ARN.`);
+    }
+
+    if (location.name.endsWith(".fifo")) {
+      throw new SimS3NotImplemented(
+        `Cannot notify ${arn}: a FIFO topic is not a valid S3 event ` +
+          "notification destination, and simulated SNS has no FIFO topics.",
+      );
+    }
+
+    return new SimS3NotificationTopicArn(
+      location.regionName as AwsRegionName,
+      location.accountId as SimAwsAccountId,
+      location.name,
+      arn,
+    );
+  }
+
+  /**
+   * Whether this topic is in a Region, which a destination topic has to share
+   * with the Bucket notifying it.
+   */
+  isIn(regionName: string): boolean {
+    return this.regionName === regionName;
+  }
+}

--- a/src/service/s3/notification/destination/sns/sim-s3-notification-topic.ts
+++ b/src/service/s3/notification/destination/sns/sim-s3-notification-topic.ts
@@ -1,0 +1,97 @@
+import type { SimAwsAccountRegionContainer } from "../../../../aws/sim-aws-account-region-scope.js";
+import { SimSnsServicePublishAuthorizer } from "../../../../sns/command/authorize/sim-sns-service-publish-authorizer.js";
+import type { SimS3NotificationDestinationRequest } from "../sim-s3-notification-destination.js";
+import { simS3ServicePrincipal } from "../sim-s3-service-principal.js";
+import type { SimS3NotificationTopicArn } from "./sim-s3-notification-topic-arn.js";
+
+/**
+ * The subject real S3 publishes every event notification with.
+ *
+ * It is the same string for every Bucket and every event, so a subscriber
+ * cannot tell one notification from another by it. It is carried because the
+ * SNS envelope a queue receives has a `Subject` field in it, and leaving it out
+ * would make a simulated envelope differ from a real one for no reason.
+ */
+export const simS3NotificationSubject = "Amazon S3 Notification";
+
+interface SimS3NotificationTopicProperties {
+  readonly arn: SimS3NotificationTopicArn;
+  readonly scope: SimAwsAccountRegionContainer;
+}
+
+/**
+ * One topic an S3 Bucket is notifying, in the Account and Region its ARN names.
+ *
+ * Everything here is asked of the topic's own Account, which is what makes a
+ * topic in another Account reachable: its policy is the grant, and its
+ * Account's IAM is what evaluates it.
+ */
+export class SimS3NotificationTopic {
+  private readonly arn: SimS3NotificationTopicArn;
+  private readonly scope: SimAwsAccountRegionContainer;
+
+  constructor(properties: SimS3NotificationTopicProperties) {
+    this.arn = properties.arn;
+    this.scope = properties.scope;
+  }
+
+  /**
+   * Why S3 may not publish to this topic, or nothing when it may.
+   */
+  publishRefusal(
+    request: SimS3NotificationDestinationRequest,
+  ): string | undefined {
+    const topic = this.scope.sns().findTopic(this.arn.topicName);
+
+    if (topic === undefined) {
+      return `${request.destinationArn} is not a simulated SNS topic.`;
+    }
+
+    const decision = new SimSnsServicePublishAuthorizer({
+      iam: this.scope.iam(),
+    }).authorize({
+      topic,
+      servicePrincipal: simS3ServicePrincipal,
+      sourceArn: request.bucketArn,
+      sourceAccount: request.bucketOwnerAccountId,
+    });
+
+    if (decision.isDenied) {
+      return (
+        `The topic policy of ${request.destinationArn} does not allow ` +
+        `${simS3ServicePrincipal} to publish to it for ${request.bucketArn}. ` +
+        "Grant sns:Publish with the topic's Policy attribute."
+      );
+    }
+
+    return undefined;
+  }
+
+  /**
+   * Publish one message body to this topic as the S3 service principal.
+   *
+   * This goes through the ordinary Publish path rather than handing the message
+   * to the topic's subscriptions directly, so a delivered event is the same
+   * thing an SDK caller would have published, and is authorized again on the
+   * way in.
+   */
+  async publish(
+    request: SimS3NotificationDestinationRequest,
+    body: string,
+  ): Promise<void> {
+    await this.scope.sns().publish(
+      {
+        input: {
+          TopicArn: this.arn.value,
+          Subject: simS3NotificationSubject,
+          Message: body,
+        },
+      },
+      {
+        caller: { kind: "service", service: simS3ServicePrincipal },
+        sourceArn: request.bucketArn,
+        sourceAccount: request.bucketOwnerAccountId,
+      },
+    );
+  }
+}

--- a/src/service/s3/notification/destination/sns/sim-s3-notification-topics.ts
+++ b/src/service/s3/notification/destination/sns/sim-s3-notification-topics.ts
@@ -1,0 +1,28 @@
+import type { SimS3NotificationDestinationRequest } from "../sim-s3-notification-destination.js";
+
+/**
+ * The narrow slice of simulated SNS that S3 event notification needs.
+ *
+ * S3 asks two questions of a topic: whether it may publish to it, and then to
+ * publish to it. Both are asked by ARN, because a notification configuration
+ * names a topic by ARN and that ARN can name another Account.
+ */
+export interface SimS3NotificationTopics {
+  /**
+   * Why S3 may not publish to the topic, or nothing when it may.
+   *
+   * A reason rather than a boolean, because both the configuration-time refusal
+   * and the delivery-time record repeat it back to whoever has to fix it.
+   */
+  publishRefusal(
+    request: SimS3NotificationDestinationRequest,
+  ): string | undefined;
+
+  /**
+   * Publish one message body to the topic.
+   */
+  publish(
+    request: SimS3NotificationDestinationRequest,
+    body: string,
+  ): Promise<void>;
+}

--- a/src/service/s3/notification/destination/sns/sim-s3-sns-notification-destination.ts
+++ b/src/service/s3/notification/destination/sns/sim-s3-sns-notification-destination.ts
@@ -1,0 +1,74 @@
+import { jsonStringify } from "../../../../../util/type-guard/json.js";
+import { SimS3InvalidArgument } from "../../../error/sim-s3.error.js";
+import { SimS3NotificationNotPermitted } from "../../../error/sim-s3-notification.error.js";
+import { simS3EventRecordsDocument } from "../../event/sim-s3-event-records.js";
+import type {
+  SimS3NotificationDeliveryRequest,
+  SimS3NotificationDestination,
+  SimS3NotificationDestinationRequest,
+} from "../sim-s3-notification-destination.js";
+import type { SimS3NotificationTopics } from "./sim-s3-notification-topics.js";
+
+interface SimS3SnsNotificationDestinationProperties {
+  readonly topics: SimS3NotificationTopics;
+}
+
+/**
+ * A simulated SNS topic as somewhere S3 sends Object events.
+ *
+ * The whole `Records` document is published as the message, which is the same
+ * text a queue destination receives as its message body. A subscriber reaching
+ * it through an SNS envelope therefore has two layers to parse rather than one:
+ * the envelope's `Message` is the S3 event document as text.
+ *
+ * The same question is asked twice on purpose, as it is for the other
+ * destinations. Real S3 checks the topic policy when the configuration is
+ * applied and checks it again for every event, so a permission removed
+ * afterwards stops delivery.
+ */
+export class SimS3SnsNotificationDestination implements SimS3NotificationDestination {
+  private readonly topics: SimS3NotificationTopics;
+
+  constructor(properties: SimS3SnsNotificationDestinationProperties) {
+    this.topics = properties.topics;
+  }
+
+  /**
+   * Refuse a topic the Bucket may not publish to.
+   *
+   * Real S3 answers InvalidArgument for a destination it could not validate,
+   * which is what a topic policy that does not admit `s3.amazonaws.com`
+   * produces.
+   */
+  validate(request: SimS3NotificationDestinationRequest): void {
+    const refusal = this.topics.publishRefusal(request);
+
+    if (refusal !== undefined) {
+      throw new SimS3InvalidArgument(
+        `Unable to validate the following destination configurations: ${refusal}`,
+      );
+    }
+  }
+
+  /**
+   * Publish the event document to the topic, if it still admits this Bucket.
+   *
+   * The refusal is asked for before publishing rather than left to the publish,
+   * which authorizes the same way, so that a topic policy saying no is recorded
+   * as a refusal rather than as a fault in the simulation.
+   */
+  async deliver(request: SimS3NotificationDeliveryRequest): Promise<void> {
+    const refusal = this.topics.publishRefusal(request);
+
+    if (refusal !== undefined) {
+      throw new SimS3NotificationNotPermitted(refusal);
+    }
+
+    await this.topics.publish(
+      request,
+      jsonStringify(
+        simS3EventRecordsDocument(request.event, request.configurationId),
+      ),
+    );
+  }
+}

--- a/src/service/s3/notification/destination/sns/sim-s3-topic-notification-refusals.iso.test.ts
+++ b/src/service/s3/notification/destination/sns/sim-s3-topic-notification-refusals.iso.test.ts
@@ -1,0 +1,208 @@
+import {
+  CreateBucketCommand,
+  GetBucketNotificationConfigurationCommand,
+  PutBucketNotificationConfigurationCommand,
+  PutObjectCommand,
+} from "@aws-sdk/client-s3";
+import { SetTopicAttributesCommand } from "@aws-sdk/client-sns";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertTrue,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../../aws/sim-aws.js";
+import {
+  simSnsDeliveredMessage,
+  simSnsSubscribedQueue,
+} from "../../../../../../test/sns/subscription-fixture.js";
+import {
+  simS3NotificationTopic,
+  simS3TopicPolicy,
+} from "../../../../../../test/s3/notification-topic-fixture.js";
+
+const bucketArn = "arn:aws:s3:::uploads";
+
+/**
+ * Configure a Bucket to notify a topic, answering with whatever it threw.
+ */
+async function notifyTopicRefusal(
+  simAws: SimAws,
+  topicArn: string,
+): Promise<Error> {
+  await simAws
+    .s3()
+    .createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+
+  return assertThrowsErrorAsync(async () =>
+    simAws.s3().putBucketNotificationConfiguration(
+      new PutBucketNotificationConfigurationCommand({
+        Bucket: "uploads",
+        NotificationConfiguration: {
+          TopicConfigurations: [
+            { Events: ["s3:ObjectCreated:*"], TopicArn: topicArn },
+          ],
+        },
+      }),
+    ),
+  );
+}
+
+describe("What a simulated SNS notification destination refuses", () => {
+  it("refuses a topic whose policy admits nothing", async () => {
+    // Given a topic with no policy at all
+    const simAws = new SimAws();
+    const topicArn = await simS3NotificationTopic(simAws);
+
+    // When a Bucket is configured to notify it
+    const error = await notifyTopicRefusal(simAws, topicArn);
+
+    // Then it is refused, since a service principal owns no identity policies
+    // and the topic policy is the whole decision
+    assertIdentical(error.name, "InvalidArgument");
+    assertStringIncludes(error.message, "does not allow s3.amazonaws.com");
+
+    // And nothing was stored
+    const stored = await simAws
+      .s3()
+      .getBucketNotificationConfiguration(
+        new GetBucketNotificationConfigurationCommand({ Bucket: "uploads" }),
+      );
+    assertUndefined(stored.TopicConfigurations);
+  });
+
+  it("refuses a topic whose policy admits another Bucket", async () => {
+    // Given a topic admitting S3 for a different Bucket
+    const simAws = new SimAws();
+    const topicArn = await simS3NotificationTopic(simAws, {
+      sourceArn: "arn:aws:s3:::reports",
+    });
+
+    // When this Bucket is configured to notify it
+    const error = await notifyTopicRefusal(simAws, topicArn);
+
+    // Then the source ARN condition keeps it out, so a grant written for one
+    // Bucket does not open the topic to another
+    assertStringIncludes(error.message, bucketArn);
+  });
+
+  it("refuses a topic in another Region", async () => {
+    // Given a topic in another Region, admitting the Bucket
+    const simAws = new SimAws();
+    const topicArn = await simS3NotificationTopic(simAws, {
+      regionName: "eu-west-2",
+      sourceArn: bucketArn,
+    });
+
+    // When the Bucket is configured to notify it
+    const error = await notifyTopicRefusal(simAws, topicArn);
+
+    // Then it is refused: real S3 requires the destination topic to be in the
+    // Bucket's own Region, whatever either side's policies say
+    assertStringIncludes(error.message, "must be in the Bucket's Region");
+  });
+
+  it("refuses a topic that is not there", async () => {
+    // Given a Bucket and no topic
+    const simAws = new SimAws();
+
+    // When the Bucket is configured to notify one
+    const error = await notifyTopicRefusal(
+      simAws,
+      `arn:aws:sns:${simAws.defaultRegionName}:${simAws.defaultAccountId}:uploads`,
+    );
+
+    // Then the missing topic is named rather than the configuration being
+    // stored and never delivered on
+    assertStringIncludes(error.message, "is not a simulated SNS topic");
+  });
+
+  it("refuses a destination ARN that is not a topic", async () => {
+    // Given a Bucket
+    const simAws = new SimAws();
+
+    // When the topic destination carries an SQS queue ARN
+    const error = await notifyTopicRefusal(
+      simAws,
+      "arn:aws:sqs:us-east-1:888888888888:uploads",
+    );
+
+    // Then it is refused for what it is, since the destination group says what
+    // kind of resource is wanted rather than the ARN doing so
+    assertStringIncludes(error.message, "is not an SNS topic ARN");
+  });
+
+  it("refuses a subscription ARN as a topic destination", async () => {
+    // Given a Bucket
+    const simAws = new SimAws();
+
+    // When the topic destination carries a subscription ARN, which is a topic
+    // ARN with one more part on the end
+    const error = await notifyTopicRefusal(
+      simAws,
+      "arn:aws:sns:us-east-1:888888888888:uploads:8b26d0f2",
+    );
+
+    // Then it is refused rather than read as the topic it is a subscription to
+    assertStringIncludes(error.message, "is not an SNS topic ARN");
+  });
+
+  it("stops delivering when the topic policy stops admitting the Bucket", async () => {
+    // Given a Bucket notifying a topic that admits it, with a subscribed queue
+    const simAws = new SimAws();
+    const topicArn = await simS3NotificationTopic(simAws, {
+      sourceArn: bucketArn,
+    });
+    const { queueUrl } = await simSnsSubscribedQueue(
+      simAws,
+      "uploads-queue",
+      topicArn,
+    );
+    await simAws
+      .s3()
+      .createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+    await simAws.s3().putBucketNotificationConfiguration(
+      new PutBucketNotificationConfigurationCommand({
+        Bucket: "uploads",
+        NotificationConfiguration: {
+          TopicConfigurations: [
+            {
+              Id: "uploads",
+              Events: ["s3:ObjectCreated:*"],
+              TopicArn: topicArn,
+            },
+          ],
+        },
+      }),
+    );
+
+    // When the topic policy is narrowed to another Bucket and an Object is put
+    await simAws.sns().setTopicAttributes(
+      new SetTopicAttributesCommand({
+        TopicArn: topicArn,
+        AttributeName: "Policy",
+        AttributeValue: simS3TopicPolicy(topicArn, "arn:aws:s3:::reports"),
+      }),
+    );
+    await simAws.s3().putObject(
+      new PutObjectCommand({
+        Bucket: "uploads",
+        Key: "raw/cat.jpg",
+        Body: "cat picture",
+      }),
+    );
+
+    // Then nothing is delivered, and the refusal is recorded rather than the
+    // earlier check being remembered
+    assertUndefined(await simSnsDeliveredMessage(simAws, queueUrl));
+
+    const failures = simAws.s3().getNotificationDeliveryFailures();
+    assertArrayLength(failures, 1);
+    assertTrue(failures[0].wasRefused);
+    assertIdentical(failures[0].destinationArn, topicArn);
+  });
+});

--- a/src/service/s3/notification/sim-s3-topic-notification.iso.test.ts
+++ b/src/service/s3/notification/sim-s3-topic-notification.iso.test.ts
@@ -268,6 +268,10 @@ describe("Notifying a simulated SNS topic of an Object event", () => {
     const created = await otherScope
       .sqs()
       .createQueue(new CreateQueueCommand({ QueueName: "uploads-queue" }));
+    assertNonNullable(
+      created.QueueUrl,
+      "CreateQueue answered with a queue URL",
+    );
     await otherScope.sqs().setQueueAttributes(
       new SetQueueAttributesCommand({
         QueueUrl: created.QueueUrl,
@@ -281,7 +285,7 @@ describe("Notifying a simulated SNS topic of an Object event", () => {
         Endpoint: queueArn,
       }),
     );
-    const queueUrl = created.QueueUrl ?? "";
+    const queueUrl = created.QueueUrl;
 
     // And a Bucket in this Account configured to notify it
     await simAws

--- a/src/service/s3/notification/sim-s3-topic-notification.iso.test.ts
+++ b/src/service/s3/notification/sim-s3-topic-notification.iso.test.ts
@@ -1,0 +1,309 @@
+import {
+  CreateBucketCommand,
+  DeleteObjectCommand,
+  GetBucketNotificationConfigurationCommand,
+  PutBucketNotificationConfigurationCommand,
+  PutObjectCommand,
+} from "@aws-sdk/client-s3";
+import { SubscribeCommand } from "@aws-sdk/client-sns";
+import {
+  CreateQueueCommand,
+  SetQueueAttributesCommand,
+} from "@aws-sdk/client-sqs";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import {
+  simSnsDeliveredMessage,
+  simSnsQueuePolicy,
+  simSnsSubscribedQueue,
+} from "../../../../test/sns/subscription-fixture.js";
+import { simS3NotificationTopic } from "../../../../test/s3/notification-topic-fixture.js";
+
+const bucketArn = "arn:aws:s3:::uploads";
+
+/**
+ * The SNS envelope a subscribed queue receives, and the S3 event document
+ * inside it.
+ */
+interface SnsEnvelope {
+  readonly Subject?: string;
+  readonly Message: string;
+}
+
+interface S3EventDocument {
+  readonly Records: readonly [
+    {
+      readonly eventName: string;
+      readonly s3: {
+        readonly configurationId: string;
+        readonly bucket: { readonly name: string };
+        readonly object: { readonly key: string; readonly size?: number };
+      };
+    },
+  ];
+}
+
+/**
+ * Read the S3 event document out of the envelope a queue received.
+ */
+function envelope(body: string | undefined): SnsEnvelope {
+  assertNonNullable(body);
+
+  return JSON.parse(body) as SnsEnvelope;
+}
+
+function eventDocument(received: SnsEnvelope): S3EventDocument {
+  return JSON.parse(received.Message) as S3EventDocument;
+}
+
+/**
+ * Configure a Bucket to notify a topic of created Objects.
+ */
+async function notifyTopic(
+  simAws: SimAws,
+  topicArn: string,
+  id: string,
+): Promise<void> {
+  await simAws.s3().putBucketNotificationConfiguration(
+    new PutBucketNotificationConfigurationCommand({
+      Bucket: "uploads",
+      NotificationConfiguration: {
+        TopicConfigurations: [
+          { Id: id, Events: ["s3:ObjectCreated:*"], TopicArn: topicArn },
+        ],
+      },
+    }),
+  );
+}
+
+describe("Notifying a simulated SNS topic of an Object event", () => {
+  it("reaches a queue subscribed to the topic", async () => {
+    // Given a topic admitting one Bucket, with a queue subscribed to it
+    const simAws = new SimAws();
+    const topicArn = await simS3NotificationTopic(simAws, {
+      sourceArn: bucketArn,
+    });
+    const { queueUrl } = await simSnsSubscribedQueue(
+      simAws,
+      "uploads-queue",
+      topicArn,
+    );
+
+    // And a Bucket configured to notify the topic
+    await simAws
+      .s3()
+      .createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+    await notifyTopic(simAws, topicArn, "raw-uploads");
+
+    // When an Object is put into it
+    await simAws.s3().putObject(
+      new PutObjectCommand({
+        Bucket: "uploads",
+        Key: "raw/cat.jpg",
+        Body: "cat picture",
+      }),
+    );
+
+    // Then the event travelled both hops, arriving as the S3 event document
+    // inside the SNS envelope the queue's subscription wraps it in
+    const received = envelope(await simSnsDeliveredMessage(simAws, queueUrl));
+    assertIdentical(received.Subject, "Amazon S3 Notification");
+    const document = eventDocument(received);
+    assertArrayLength(document.Records, 1);
+    assertIdentical(document.Records[0].eventName, "ObjectCreated:Put");
+    assertIdentical(document.Records[0].s3.configurationId, "raw-uploads");
+    assertIdentical(document.Records[0].s3.bucket.name, "uploads");
+    const { key, size } = document.Records[0].s3.object;
+    assertIdentical(key, "raw/cat.jpg");
+    assertIdentical(size, 11);
+  });
+
+  it("publishes the document a removal produces", async () => {
+    // Given a Bucket holding an Object, notifying a topic of removals
+    const simAws = new SimAws();
+    const topicArn = await simS3NotificationTopic(simAws, {
+      sourceArn: bucketArn,
+    });
+    const { queueUrl } = await simSnsSubscribedQueue(
+      simAws,
+      "removals-queue",
+      topicArn,
+    );
+    await simAws
+      .s3()
+      .createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+    await simAws.s3().putObject(
+      new PutObjectCommand({
+        Bucket: "uploads",
+        Key: "raw/cat.jpg",
+        Body: "cat picture",
+      }),
+    );
+    await simAws.s3().putBucketNotificationConfiguration(
+      new PutBucketNotificationConfigurationCommand({
+        Bucket: "uploads",
+        NotificationConfiguration: {
+          TopicConfigurations: [
+            {
+              Id: "removals",
+              Events: ["s3:ObjectRemoved:*"],
+              TopicArn: topicArn,
+            },
+          ],
+        },
+      }),
+    );
+
+    // When the Object is deleted
+    await simAws
+      .s3()
+      .deleteObject(
+        new DeleteObjectCommand({ Bucket: "uploads", Key: "raw/cat.jpg" }),
+      );
+
+    // Then the removal record arrives, carrying no size, as a real removal
+    // record carries none
+    const document = eventDocument(
+      envelope(await simSnsDeliveredMessage(simAws, queueUrl)),
+    );
+    assertIdentical(document.Records[0].eventName, "ObjectRemoved:Delete");
+    assertUndefined(document.Records[0].s3.object.size);
+  });
+
+  it("applies the object key filter to a topic destination", async () => {
+    // Given a Bucket notifying a topic only about the raw/ prefix
+    const simAws = new SimAws();
+    const topicArn = await simS3NotificationTopic(simAws, {
+      sourceArn: bucketArn,
+    });
+    const { queueUrl } = await simSnsSubscribedQueue(
+      simAws,
+      "uploads-queue",
+      topicArn,
+    );
+    await simAws
+      .s3()
+      .createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+    await simAws.s3().putBucketNotificationConfiguration(
+      new PutBucketNotificationConfigurationCommand({
+        Bucket: "uploads",
+        NotificationConfiguration: {
+          TopicConfigurations: [
+            {
+              Id: "raw-uploads",
+              Events: ["s3:ObjectCreated:*"],
+              TopicArn: topicArn,
+              Filter: {
+                Key: { FilterRules: [{ Name: "prefix", Value: "raw/" }] },
+              },
+            },
+          ],
+        },
+      }),
+    );
+
+    // When an Object outside the prefix is put into it
+    await simAws.s3().putObject(
+      new PutObjectCommand({
+        Bucket: "uploads",
+        Key: "thumbnails/cat.jpg",
+        Body: "thumbnail",
+      }),
+    );
+
+    // Then nothing is published, since the filter rules are the same whatever
+    // the destination is
+    assertUndefined(await simSnsDeliveredMessage(simAws, queueUrl));
+  });
+
+  it("reports a topic configuration back", async () => {
+    // Given a Bucket notifying a topic
+    const simAws = new SimAws();
+    const topicArn = await simS3NotificationTopic(simAws, {
+      sourceArn: bucketArn,
+    });
+    await simAws
+      .s3()
+      .createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+    await notifyTopic(simAws, topicArn, "raw-uploads");
+
+    // When the configuration is read back
+    const stored = await simAws
+      .s3()
+      .getBucketNotificationConfiguration(
+        new GetBucketNotificationConfigurationCommand({ Bucket: "uploads" }),
+      );
+
+    // Then the topic group is reported alongside the others, at the top level
+    // of the response rather than under NotificationConfiguration
+    const configurations = stored.TopicConfigurations;
+    assertNonNullable(configurations);
+    assertArrayLength(configurations, 1);
+    assertIdentical(configurations[0].Id, "raw-uploads");
+    assertIdentical(configurations[0].TopicArn, topicArn);
+    assertUndefined(stored.QueueConfigurations);
+  });
+
+  it("notifies a topic in another Account that admits the Bucket", async () => {
+    // Given a topic in another Account, admitting this Bucket
+    const simAws = new SimAws();
+    const otherAccountId = "222222222222";
+    const topicArn = await simS3NotificationTopic(simAws, {
+      accountId: otherAccountId,
+      sourceArn: bucketArn,
+    });
+
+    // And a queue in that Account subscribed to it
+    const otherScope = simAws
+      .account(otherAccountId)
+      .region(simAws.defaultRegionName);
+    const queueArn = `arn:aws:sqs:${simAws.defaultRegionName}:${otherAccountId}:uploads-queue`;
+    const created = await otherScope
+      .sqs()
+      .createQueue(new CreateQueueCommand({ QueueName: "uploads-queue" }));
+    await otherScope.sqs().setQueueAttributes(
+      new SetQueueAttributesCommand({
+        QueueUrl: created.QueueUrl,
+        Attributes: { Policy: simSnsQueuePolicy(queueArn, topicArn) },
+      }),
+    );
+    await otherScope.sns().subscribe(
+      new SubscribeCommand({
+        TopicArn: topicArn,
+        Protocol: "sqs",
+        Endpoint: queueArn,
+      }),
+    );
+    const queueUrl = created.QueueUrl ?? "";
+
+    // And a Bucket in this Account configured to notify it
+    await simAws
+      .s3()
+      .createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+    await notifyTopic(simAws, topicArn, "uploads");
+
+    // When an Object is put into it
+    await simAws.s3().putObject(
+      new PutObjectCommand({
+        Bucket: "uploads",
+        Key: "raw/cat.jpg",
+        Body: "cat picture",
+      }),
+    );
+
+    // Then the event reached the other Account, since its own topic policy is
+    // the grant and its own IAM evaluated it
+    assertNonNullable(
+      await simSnsDeliveredMessage(simAws, queueUrl, {
+        accountId: otherAccountId,
+      }),
+    );
+  });
+});

--- a/src/service/sns/README.md
+++ b/src/service/sns/README.md
@@ -232,6 +232,13 @@ principal from another Account, or a service principal such as `s3.amazonaws.com
 identity policies anywhere. A topic with no policy contributes nothing and the decision is left to
 the caller's identity policies, as it is on real AWS.
 
+`SimSnsServicePublishAuthorizer` is the same decision offered to another simulated service, as a
+decision rather than a thrown error. Simulated S3 needs it: it validates a notification destination
+when the configuration is applied, before it has an event to publish, and has to report the refusal
+as part of refusing the configuration. Nothing is remembered from that question, so the ordinary
+`Publish` the event later goes through authorizes again and a topic policy changed in between stops
+the delivery. `SimSqsServiceSendAuthorizer` is the same idea on the queue's side.
+
 `SimSnsRequestOptions` carries a `sourceArn` and a `sourceAccount` alongside the caller, supplied to
 IAM as `aws:SourceArn` and `aws:SourceAccount`. A simulated service reaching a topic on a resource's
 behalf sets both, which is how a topic policy granting a service principal tells one Bucket from

--- a/src/service/sns/command/authorize/sim-sns-service-publish-authorizer.ts
+++ b/src/service/sns/command/authorize/sim-sns-service-publish-authorizer.ts
@@ -1,0 +1,70 @@
+import type {
+  SimIamAuthorizationDecision,
+  SimIamInterServiceAuthZ,
+} from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import type { SimSnsTopic } from "../../topic/sim-sns-topic.js";
+import { simSnsConditionContext } from "./sim-sns-condition-context.js";
+import { simSnsTopicResourcePolicies } from "./sim-sns-topic-resource-policies.js";
+
+interface SimSnsServicePublishAuthorizerProperties {
+  readonly iam: SimIamInterServiceAuthZ;
+}
+
+interface SimSnsServicePublishAuthorizationInput {
+  readonly topic: SimSnsTopic;
+
+  /** The service principal the publishing service calls SNS as. */
+  readonly servicePrincipal: string;
+
+  /**
+   * What the service is publishing for, such as the S3 Bucket an event came
+   * from.
+   */
+  readonly sourceArn?: string | undefined;
+
+  /** The Account the publishing service's own resource belongs to. */
+  readonly sourceAccount?: string | undefined;
+}
+
+/**
+ * Decides whether a simulated AWS service may publish a message to a topic.
+ *
+ * A service principal owns no identity policies anywhere, so the topic's own
+ * policy is the whole decision. The answer is a decision rather than a thrown
+ * error because a service asks this before it has a message to publish: S3
+ * validates the destination when a notification configuration is applied, and
+ * has to report the refusal as part of refusing the configuration.
+ *
+ * A service with a message in hand publishes it through `Publish` as usual,
+ * which authorizes the same way. Nothing is remembered from the earlier
+ * question, so a topic policy changed in between stops the delivery.
+ */
+export class SimSnsServicePublishAuthorizer {
+  private static readonly action = "sns:Publish";
+
+  private readonly iam: SimIamInterServiceAuthZ;
+
+  constructor(properties: SimSnsServicePublishAuthorizerProperties) {
+    this.iam = properties.iam;
+  }
+
+  /**
+   * Evaluate `sns:Publish` for a service against the topic.
+   */
+  authorize(
+    input: SimSnsServicePublishAuthorizationInput,
+  ): SimIamAuthorizationDecision {
+    return this.iam.authorize({
+      action: SimSnsServicePublishAuthorizer.action,
+      resource: input.topic.arn.value,
+      caller: { kind: "service", service: input.servicePrincipal },
+      resourcePolicies: simSnsTopicResourcePolicies(input.topic),
+      conditionContext: simSnsConditionContext({
+        ...(input.sourceArn !== undefined && { sourceArn: input.sourceArn }),
+        ...(input.sourceAccount !== undefined && {
+          sourceAccount: input.sourceAccount,
+        }),
+      }),
+    });
+  }
+}

--- a/test/s3/notification-topic-fixture.ts
+++ b/test/s3/notification-topic-fixture.ts
@@ -1,0 +1,78 @@
+/**
+ * A simulated SNS topic an S3 Bucket can notify, which every test about the
+ * topic destination needs before it can say anything about delivery.
+ *
+ * This lives under `test/` for the same reasons as `test/sns/topic-fixture.ts`:
+ * eslint rejects a test file that exports helpers alongside its own `describe`
+ * calls, and `test/**` is type-checked with everything else, excluded from the
+ * published build, not collected as a suite, and not counted in coverage.
+ */
+
+import { CreateTopicCommand } from "@aws-sdk/client-sns";
+import { assertNonNullable } from "@kensio/smartass";
+
+import type { SimAws } from "../../src/service/aws/sim-aws.js";
+import type { AwsRegionName } from "../../src/service/aws/sim-aws-region.js";
+import { simIamPolicyDocumentFactory } from "../../src/service/iam/policy/sim-iam-policy-document.factory.js";
+
+/**
+ * The policy statement AWS documents for an S3 event notification destination
+ * topic, which is what a Bucket has to be admitted by.
+ */
+export function simS3TopicPolicy(topicArn: string, sourceArn: string): string {
+  return simIamPolicyDocumentFactory.make({
+    Statement: {
+      Principal: { Service: "s3.amazonaws.com" },
+      Action: "sns:Publish",
+      Resource: topicArn,
+      Condition: { ArnLike: { "aws:SourceArn": sourceArn } },
+    },
+  });
+}
+
+/**
+ * Where a topic lives and which Bucket its policy admits.
+ */
+export interface SimS3TopicOptions {
+  readonly topicName?: string;
+  readonly accountId?: string;
+  readonly regionName?: AwsRegionName;
+
+  /**
+   * The Bucket ARN the topic policy admits. A topic asked for without one gets
+   * no policy at all, which is what refuses every publish.
+   */
+  readonly sourceArn?: string;
+}
+
+/**
+ * Create a topic, with a policy admitting S3 for one Bucket.
+ */
+export async function simS3NotificationTopic(
+  simAws: SimAws,
+  options: SimS3TopicOptions = {},
+): Promise<string> {
+  const {
+    topicName = "uploads",
+    accountId = simAws.defaultAccountId,
+    regionName = simAws.defaultRegionName,
+    sourceArn,
+  } = options;
+  const topicArn = `arn:aws:sns:${regionName}:${accountId}:${topicName}`;
+  const created = await simAws
+    .account(accountId)
+    .region(regionName)
+    .sns()
+    .createTopic(
+      new CreateTopicCommand({
+        Name: topicName,
+        ...(sourceArn !== undefined && {
+          Attributes: { Policy: simS3TopicPolicy(topicArn, sourceArn) },
+        }),
+      }),
+    );
+
+  assertNonNullable(created.TopicArn, "CreateTopic answered with a topic ARN");
+
+  return created.TopicArn;
+}


### PR DESCRIPTION
A Bucket configured with a `TopicConfigurations` entry publishes the S3 event document to the topic when a matching Object event happens, and the topic fans it out to its own subscriptions, so an upload reaches a queue two hops away. Delivery is authorized by the topic's own policy, checked when the configuration is applied and again on every event, so a policy removed afterwards stops delivery rather than the earlier check being remembered. The destination is reachable from the SDK, from the `AWS::S3::Bucket` `TopicConfiguration` property, and from the `Custom::S3BucketNotifications` resource CDK's `SnsDestination` writes into.

The one part of the issue's scope left out is `AWS::SNS::TopicPolicy`, which https://github.com/KensioSoftware/yulin/issues/472 owns along with `AWS::SNS::Topic` and `AWS::SNS::Subscription`. A CDK `SnsDestination` stack needs the topic resource as well as the policy, so adding the policy here on its own would not have made such a stack deploy. The CDK test sets the topic and its policy up through the SDK and deploys the notification resource, and the gap is recorded in both docs pages.

Resolves https://github.com/KensioSoftware/yulin/issues/473

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added SNS topics as supported destinations for simulated S3 event notifications.
  * S3 object-created and object-removed events can now be delivered through SNS to subscribed queues.
  * Added support for topic notification configurations in SDK, CloudFormation, and CDK workflows.
  * Added validation for topic existence, permissions, regions, accounts, ARN formats, and FIFO restrictions.
* **Documentation**
  * Expanded S3 and SNS guidance with setup examples, delivery behavior, policies, envelopes, and limitations.
* **Tests**
  * Added comprehensive coverage for successful delivery, filtering, cross-account scenarios, and authorization failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->