### PR TITLE
feat: filter deliveries with a filter policy

### DIFF
--- a/docs/services/sns/README.md
+++ b/docs/services/sns/README.md
@@ -636,6 +636,7 @@ async function subscribeQueue(
               Principal: { Service: "sns.amazonaws.com" },
               Action: "sqs:SendMessage",
               Resource: queueArn,
+              Condition: { ArnEquals: { "aws:SourceArn": TopicArn } },
             },
           ],
         }),
@@ -694,11 +695,16 @@ By default a policy is matched against the message attributes of the publish, wh
 | `{"anything-but": {"prefix": "tmp-"}}`  | every value not starting that way           |
 | `{"numeric": [">", 100]}`               | a number, with `=`, `<`, `<=`, `>` and `>=` |
 | `{"numeric": [">", 0, "<=", 100]}`      | a number inside a range                     |
-| `{"exists": true}`                      | the key being there, whatever it holds      |
-| `{"exists": false}`                     | the key not being there at all              |
+| `{"exists": true}`                      | the key being there, holding something      |
+| `{"exists": false}`                     | the key not being there                     |
 
 Only `{"exists": false}` matches a key the message does not carry. Every other operator needs a value
 to look at, including `anything-but`: there is nothing there to be anything but the excluded value.
+
+`{"exists": false}` also needs the message to carry something else, which is what real SNS states: a
+publish with no message attributes at all matches no filter policy of the default scope, this one
+included. Under the `MessageBody` scope the same goes for a body holding no keys, so a body that is
+not JSON matches nothing whichever operator the policy uses.
 
 Numeric matching applies to the `Number` message attribute data type, as it does on real SNS, so
 digits published as a `String` are text. A `String.Array` attribute matches when any member of it
@@ -709,6 +715,11 @@ does. A `Binary` attribute matches nothing, since filtering is on text.
 ```json
 { "$or": [{ "type": ["order"] }, { "tenant": ["acme"] }] }
 ```
+
+Real SNS reads `$or` as an or only when it holds a list of at least two objects, none of which names
+a reserved keyword such as `numeric` or `prefix`. Anything else is an attribute named `$or` there, so
+the policy quietly stops being an or and matches nothing. Each of those is refused here when the
+policy is set instead.
 
 ### Filtering on the message body
 
@@ -757,6 +768,7 @@ await sqs.setQueueAttributes(
             Principal: { Service: "sns.amazonaws.com" },
             Action: "sqs:SendMessage",
             Resource: queueArn,
+            Condition: { ArnEquals: { "aws:SourceArn": TopicArn } },
           },
         ],
       }),
@@ -799,7 +811,9 @@ console.log(Messages?.length); // 1
 
 A body that is not JSON, or that is JSON without being an object, matches no policy of this scope. It
 is not an error: the body comes from whoever published, and the scope is the subscription's own
-business, so a publisher would otherwise fail on a subscription it knows nothing about.
+business, so a publisher would otherwise fail on a subscription it knows nothing about. A key holding
+`null`, an object or an empty list holds no value to match, so it is a key `{"exists": false}`
+matches, as long as the body holds some other key.
 
 The two attributes can be set on `Subscribe` or afterwards with `SetSubscriptionAttributes`, and
 `GetSubscriptionAttributes` reports both once a policy is set. Setting `FilterPolicy` with no value
@@ -1379,7 +1393,10 @@ Current documented limitations:
   are a flat set of names and such a policy could never match.
 - A message body that is not a JSON object matches no `MessageBody` filter policy, and is not an
   error. A key holding `null`, an object or an empty list holds no value to match, so
-  `{"exists": false}` matches it.
+  `{"exists": false}` matches it, as long as the body holds some other key.
+- An `$or` real SNS would not read as one, because it holds fewer than two objects or names a
+  reserved keyword, is refused when the policy is set. Real SNS treats it as an attribute named
+  `$or` instead, which matches nothing.
 - Subscription delivery retry policies, subscription dead-letter queues and message replay are not
   simulated, so `DeliveryPolicy`, `RedrivePolicy`, `SubscriptionRoleArn` and `ReplayPolicy` are
   refused.

--- a/docs/services/sns/README.md
+++ b/docs/services/sns/README.md
@@ -284,9 +284,11 @@ are not applied to it, the same way a repeated `CreateTopic` leaves the existing
 are still validated, so a repeated request naming an attribute this simulation will not take is
 refused for it.
 
-`RawMessageDelivery` is the one subscription attribute with behaviour behind it. It can be set on the
-`Subscribe` request or afterwards with `SetSubscriptionAttributes`, and its value is `"true"` or
-`"false"`. Anything else is refused, rather than being treated as false.
+`RawMessageDelivery` can be set on the `Subscribe` request or afterwards with
+`SetSubscriptionAttributes`, and its value is `"true"` or `"false"`. Anything else is refused, rather
+than being treated as false. The other two attributes with behaviour behind them are `FilterPolicy`
+and `FilterPolicyScope`, under
+[filtering what a subscription receives](#filtering-what-a-subscription-receives).
 
 `Unsubscribe` of an ARN that names no subscription is `NotFoundException`, so unsubscribing the same
 ARN twice fails the second time. `DeleteTopic` removes the topic's subscriptions along with it, and a
@@ -574,6 +576,239 @@ envelope leaves both out.
 
 `RawMessageDelivery` has no effect on a `lambda` subscription. Real SNS treats it as an SQS and HTTP
 setting, so a function is invoked with the whole event whether it is set or not.
+
+## Filtering what a subscription receives
+
+A subscription with a `FilterPolicy` receives only the messages its policy matches. Every other
+subscription of the topic is unaffected, so one subscriber filtering a message out has nothing to do
+with what another receives.
+
+The policy is a JSON document of keys and the match conditions each one accepts. Separate keys are an
+and, and the list a key holds is an or.
+
+```typescript sim-sns-filter-policy
+/**
+ * Two queues on one topic, each taking the messages its policy names.
+ */
+
+import {
+  CreateTopicCommand,
+  PublishCommand,
+  SubscribeCommand,
+} from "@aws-sdk/client-sns";
+import {
+  CreateQueueCommand,
+  ReceiveMessageCommand,
+  SetQueueAttributesCommand,
+} from "@aws-sdk/client-sqs";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const sns = simAws.sns();
+const sqs = simAws.sqs();
+
+const { TopicArn } = await sns.createTopic(
+  new CreateTopicCommand({ Name: "orders" }),
+);
+
+/**
+ * Subscribe a queue that admits SNS, with a filter policy of its own.
+ */
+async function subscribeQueue(
+  queueName: string,
+  filterPolicy: unknown,
+): Promise<string> {
+  const { QueueUrl } = await sqs.createQueue(
+    new CreateQueueCommand({ QueueName: queueName }),
+  );
+  const queueArn = `arn:aws:sqs:${simAws.defaultRegionName}:${simAws.defaultAccountId}:${queueName}`;
+
+  await sqs.setQueueAttributes(
+    new SetQueueAttributesCommand({
+      QueueUrl,
+      Attributes: {
+        Policy: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: [
+            {
+              Effect: "Allow",
+              Principal: { Service: "sns.amazonaws.com" },
+              Action: "sqs:SendMessage",
+              Resource: queueArn,
+            },
+          ],
+        }),
+      },
+    }),
+  );
+
+  await sns.subscribe(
+    new SubscribeCommand({
+      TopicArn,
+      Protocol: "sqs",
+      Endpoint: queueArn,
+      Attributes: { FilterPolicy: JSON.stringify(filterPolicy) },
+    }),
+  );
+
+  return QueueUrl ?? "";
+}
+
+const orders = await subscribeQueue("order-handling", { type: ["order"] });
+const refunds = await subscribeQueue("refund-handling", { type: ["refund"] });
+
+await sns.publish(
+  new PublishCommand({
+    TopicArn,
+    Message: "order-1",
+    MessageAttributes: { type: { DataType: "String", StringValue: "order" } },
+  }),
+);
+
+await simAws.backgroundTasksComplete();
+
+const delivered = await sqs.receiveMessage(
+  new ReceiveMessageCommand({ QueueUrl: orders }),
+);
+const filtered = await sqs.receiveMessage(
+  new ReceiveMessageCommand({ QueueUrl: refunds }),
+);
+
+console.log(delivered.Messages?.length); // 1
+console.log(filtered.Messages); // undefined
+```
+
+By default a policy is matched against the message attributes of the publish, which is the
+`MessageAttributes` scope. These are the operators:
+
+| Condition                               | Matches                                     |
+| --------------------------------------- | ------------------------------------------- |
+| `"order"`                               | that value exactly, case sensitively        |
+| `["order", "refund"]`                   | either value, since a list is an or         |
+| `{"prefix": "order-"}`                  | the start of the value                      |
+| `{"suffix": ".csv"}`                    | the end of the value                        |
+| `{"equals-ignore-case": "Order"}`       | the value in any case                       |
+| `{"anything-but": "order"}`             | every value but that one                    |
+| `{"anything-but": ["order", "refund"]}` | every value but those                       |
+| `{"anything-but": {"prefix": "tmp-"}}`  | every value not starting that way           |
+| `{"numeric": [">", 100]}`               | a number, with `=`, `<`, `<=`, `>` and `>=` |
+| `{"numeric": [">", 0, "<=", 100]}`      | a number inside a range                     |
+| `{"exists": true}`                      | the key being there, whatever it holds      |
+| `{"exists": false}`                     | the key not being there at all              |
+
+Only `{"exists": false}` matches a key the message does not carry. Every other operator needs a value
+to look at, including `anything-but`: there is nothing there to be anything but the excluded value.
+
+Numeric matching applies to the `Number` message attribute data type, as it does on real SNS, so
+digits published as a `String` are text. A `String.Array` attribute matches when any member of it
+does. A `Binary` attribute matches nothing, since filtering is on text.
+
+`$or` matches when either of two separate keys does, which the rest of a policy cannot say:
+
+```json
+{ "$or": [{ "type": ["order"] }, { "tenant": ["acme"] }] }
+```
+
+### Filtering on the message body
+
+With `FilterPolicyScope` set to `MessageBody`, the policy is matched against the message body read as
+JSON. That is the scope that nests: a policy names a nested key by nesting itself.
+
+```typescript sim-sns-filter-policy-body
+/**
+ * Filtering on a nested key of the published message body.
+ */
+
+import {
+  CreateTopicCommand,
+  PublishCommand,
+  SubscribeCommand,
+} from "@aws-sdk/client-sns";
+import {
+  CreateQueueCommand,
+  ReceiveMessageCommand,
+  SetQueueAttributesCommand,
+} from "@aws-sdk/client-sqs";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const sns = simAws.sns();
+const sqs = simAws.sqs();
+
+const { TopicArn } = await sns.createTopic(
+  new CreateTopicCommand({ Name: "orders" }),
+);
+const { QueueUrl } = await sqs.createQueue(
+  new CreateQueueCommand({ QueueName: "gold-orders" }),
+);
+const queueArn = `arn:aws:sqs:${simAws.defaultRegionName}:${simAws.defaultAccountId}:gold-orders`;
+
+await sqs.setQueueAttributes(
+  new SetQueueAttributesCommand({
+    QueueUrl,
+    Attributes: {
+      Policy: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: [
+          {
+            Effect: "Allow",
+            Principal: { Service: "sns.amazonaws.com" },
+            Action: "sqs:SendMessage",
+            Resource: queueArn,
+          },
+        ],
+      }),
+    },
+  }),
+);
+
+await sns.subscribe(
+  new SubscribeCommand({
+    TopicArn,
+    Protocol: "sqs",
+    Endpoint: queueArn,
+    Attributes: {
+      FilterPolicyScope: "MessageBody",
+      FilterPolicy: JSON.stringify({
+        customer: { tier: ["gold"] },
+        amount: [{ numeric: [">", 100] }],
+      }),
+    },
+  }),
+);
+
+for (const body of [
+  { customer: { tier: "silver" }, amount: 500 },
+  { customer: { tier: "gold" }, amount: 500 },
+]) {
+  await sns.publish(
+    new PublishCommand({ TopicArn, Message: JSON.stringify(body) }),
+  );
+}
+
+await simAws.backgroundTasksComplete();
+
+const { Messages } = await sqs.receiveMessage(
+  new ReceiveMessageCommand({ QueueUrl, MaxNumberOfMessages: 10 }),
+);
+
+console.log(Messages?.length); // 1
+```
+
+A body that is not JSON, or that is JSON without being an object, matches no policy of this scope. It
+is not an error: the body comes from whoever published, and the scope is the subscription's own
+business, so a publisher would otherwise fail on a subscription it knows nothing about.
+
+The two attributes can be set on `Subscribe` or afterwards with `SetSubscriptionAttributes`, and
+`GetSubscriptionAttributes` reports both once a policy is set. Setting `FilterPolicy` with no value
+takes the policy off, so the subscription receives everything again.
+
+A policy is read when it is set rather than when a message arrives. An operator real SNS does not
+have, a match condition naming two operators, a key holding no conditions, and a nested key under the
+`MessageAttributes` scope are all refused there. So is `cidr`, which is the one operator real SNS has
+that this does not.
 
 ## Verifying a message signature
 
@@ -1088,7 +1323,10 @@ Sim SNS currently supports:
   `UnsubscribeCommand`
 - `ListSubscriptionsCommand` and `ListSubscriptionsByTopicCommand`, paged at a hundred subscriptions
   with a `NextToken`
-- `GetSubscriptionAttributesCommand` and `SetSubscriptionAttributesCommand`, for `RawMessageDelivery`
+- `GetSubscriptionAttributesCommand` and `SetSubscriptionAttributesCommand`, for
+  `RawMessageDelivery`, `FilterPolicy` and `FilterPolicyScope`
+- Subscription filter policies over the message attributes or the message body, with the string,
+  numeric, `exists`, `anything-but` and `$or` operators, applied per subscription
 - Delivery of a published message to every subscribed queue, including a queue in another account or
   another region, authorized by that queue's own policy on every message
 - Invocation of every subscribed Lambda function, including a function in another account or another
@@ -1133,14 +1371,22 @@ Current documented limitations:
   rather than retried.
 - `ConfirmSubscription` is not supported. Neither protocol simulated needs a confirmation, so there
   is no confirmation token to confirm.
-- Subscription filter policies are not simulated, so `FilterPolicy` and `FilterPolicyScope` are
-  refused rather than held and never applied.
+- The `cidr` filter policy operator is not simulated. A policy holding one is refused when it is set,
+  naming the operator, rather than accepted and then matching nothing.
+- A filter policy is reported back as the string it was set with. Real SNS re-serialises the
+  document, so what comes back there is not byte for byte what went in.
+- A nested filter policy key is refused under the `MessageAttributes` scope, since message attributes
+  are a flat set of names and such a policy could never match.
+- A message body that is not a JSON object matches no `MessageBody` filter policy, and is not an
+  error. A key holding `null`, an object or an empty list holds no value to match, so
+  `{"exists": false}` matches it.
 - Subscription delivery retry policies, subscription dead-letter queues and message replay are not
   simulated, so `DeliveryPolicy`, `RedrivePolicy`, `SubscriptionRoleArn` and `ReplayPolicy` are
   refused.
 - `GetSubscriptionAttributes` reports `SubscriptionArn`, `TopicArn`, `Protocol`, `Endpoint`, `Owner`,
-  `ConfirmationWasAuthenticated`, `PendingConfirmation` and `RawMessageDelivery`.
-  `EffectiveDeliveryPolicy` is left out, since delivery retry policies are not simulated.
+  `ConfirmationWasAuthenticated`, `PendingConfirmation` and `RawMessageDelivery`, with `FilterPolicy`
+  and `FilterPolicyScope` once a policy is set. `EffectiveDeliveryPolicy` is left out, since delivery
+  retry policies are not simulated.
 - A queue whose name ends in `.fifo` is refused as a subscription endpoint. Only a FIFO topic
   delivers to a FIFO queue, and there are no FIFO topics here.
 - Standard topics only. A topic name ending in `.fifo` is refused, as are the `FifoTopic`,

--- a/docs/services/sns/README.md
+++ b/docs/services/sns/README.md
@@ -581,7 +581,9 @@ setting, so a function is invoked with the whole event whether it is set or not.
 
 A subscription with a `FilterPolicy` receives only the messages its policy matches. Every other
 subscription of the topic is unaffected, so one subscriber filtering a message out has nothing to do
-with what another receives.
+with what another receives. It applies to a subscribed function as it does to a subscribed queue: the
+policy decides whether the message reaches the subscription at all, whatever the subscription
+delivers to.
 
 The policy is a JSON document of keys and the match conditions each one accepts. Separate keys are an
 and, and the list a key holds is an or.

--- a/docs/services/sns/sim-sns-filter-policy-body.example.ts
+++ b/docs/services/sns/sim-sns-filter-policy-body.example.ts
@@ -39,6 +39,7 @@ await sqs.setQueueAttributes(
             Principal: { Service: "sns.amazonaws.com" },
             Action: "sqs:SendMessage",
             Resource: queueArn,
+            Condition: { ArnEquals: { "aws:SourceArn": TopicArn } },
           },
         ],
       }),

--- a/docs/services/sns/sim-sns-filter-policy-body.example.ts
+++ b/docs/services/sns/sim-sns-filter-policy-body.example.ts
@@ -1,0 +1,79 @@
+/**
+ * Filtering on a nested key of the published message body.
+ */
+
+import {
+  CreateTopicCommand,
+  PublishCommand,
+  SubscribeCommand,
+} from "@aws-sdk/client-sns";
+import {
+  CreateQueueCommand,
+  ReceiveMessageCommand,
+  SetQueueAttributesCommand,
+} from "@aws-sdk/client-sqs";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const sns = simAws.sns();
+const sqs = simAws.sqs();
+
+const { TopicArn } = await sns.createTopic(
+  new CreateTopicCommand({ Name: "orders" }),
+);
+const { QueueUrl } = await sqs.createQueue(
+  new CreateQueueCommand({ QueueName: "gold-orders" }),
+);
+const queueArn = `arn:aws:sqs:${simAws.defaultRegionName}:${simAws.defaultAccountId}:gold-orders`;
+
+await sqs.setQueueAttributes(
+  new SetQueueAttributesCommand({
+    QueueUrl,
+    Attributes: {
+      Policy: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: [
+          {
+            Effect: "Allow",
+            Principal: { Service: "sns.amazonaws.com" },
+            Action: "sqs:SendMessage",
+            Resource: queueArn,
+          },
+        ],
+      }),
+    },
+  }),
+);
+
+await sns.subscribe(
+  new SubscribeCommand({
+    TopicArn,
+    Protocol: "sqs",
+    Endpoint: queueArn,
+    Attributes: {
+      FilterPolicyScope: "MessageBody",
+      FilterPolicy: JSON.stringify({
+        customer: { tier: ["gold"] },
+        amount: [{ numeric: [">", 100] }],
+      }),
+    },
+  }),
+);
+
+for (const body of [
+  { customer: { tier: "silver" }, amount: 500 },
+  { customer: { tier: "gold" }, amount: 500 },
+]) {
+  await sns.publish(
+    new PublishCommand({ TopicArn, Message: JSON.stringify(body) }),
+  );
+}
+
+await simAws.backgroundTasksComplete();
+
+const { Messages } = await sqs.receiveMessage(
+  new ReceiveMessageCommand({ QueueUrl, MaxNumberOfMessages: 10 }),
+);
+
+console.log(Messages?.length); // 1

--- a/docs/services/sns/sim-sns-filter-policy.example.ts
+++ b/docs/services/sns/sim-sns-filter-policy.example.ts
@@ -1,0 +1,90 @@
+/**
+ * Two queues on one topic, each taking the messages its policy names.
+ */
+
+import {
+  CreateTopicCommand,
+  PublishCommand,
+  SubscribeCommand,
+} from "@aws-sdk/client-sns";
+import {
+  CreateQueueCommand,
+  ReceiveMessageCommand,
+  SetQueueAttributesCommand,
+} from "@aws-sdk/client-sqs";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const sns = simAws.sns();
+const sqs = simAws.sqs();
+
+const { TopicArn } = await sns.createTopic(
+  new CreateTopicCommand({ Name: "orders" }),
+);
+
+/**
+ * Subscribe a queue that admits SNS, with a filter policy of its own.
+ */
+async function subscribeQueue(
+  queueName: string,
+  filterPolicy: unknown,
+): Promise<string> {
+  const { QueueUrl } = await sqs.createQueue(
+    new CreateQueueCommand({ QueueName: queueName }),
+  );
+  const queueArn = `arn:aws:sqs:${simAws.defaultRegionName}:${simAws.defaultAccountId}:${queueName}`;
+
+  await sqs.setQueueAttributes(
+    new SetQueueAttributesCommand({
+      QueueUrl,
+      Attributes: {
+        Policy: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: [
+            {
+              Effect: "Allow",
+              Principal: { Service: "sns.amazonaws.com" },
+              Action: "sqs:SendMessage",
+              Resource: queueArn,
+            },
+          ],
+        }),
+      },
+    }),
+  );
+
+  await sns.subscribe(
+    new SubscribeCommand({
+      TopicArn,
+      Protocol: "sqs",
+      Endpoint: queueArn,
+      Attributes: { FilterPolicy: JSON.stringify(filterPolicy) },
+    }),
+  );
+
+  return QueueUrl ?? "";
+}
+
+const orders = await subscribeQueue("order-handling", { type: ["order"] });
+const refunds = await subscribeQueue("refund-handling", { type: ["refund"] });
+
+await sns.publish(
+  new PublishCommand({
+    TopicArn,
+    Message: "order-1",
+    MessageAttributes: { type: { DataType: "String", StringValue: "order" } },
+  }),
+);
+
+await simAws.backgroundTasksComplete();
+
+const delivered = await sqs.receiveMessage(
+  new ReceiveMessageCommand({ QueueUrl: orders }),
+);
+const filtered = await sqs.receiveMessage(
+  new ReceiveMessageCommand({ QueueUrl: refunds }),
+);
+
+console.log(delivered.Messages?.length); // 1
+console.log(filtered.Messages); // undefined

--- a/docs/services/sns/sim-sns-filter-policy.example.ts
+++ b/docs/services/sns/sim-sns-filter-policy.example.ts
@@ -47,6 +47,7 @@ async function subscribeQueue(
               Principal: { Service: "sns.amazonaws.com" },
               Action: "sqs:SendMessage",
               Resource: queueArn,
+              Condition: { ArnEquals: { "aws:SourceArn": TopicArn } },
             },
           ],
         }),

--- a/src/service/sns/README.md
+++ b/src/service/sns/README.md
@@ -185,9 +185,9 @@ Delivery lives under `delivery/`, and the signing that goes with it under `signa
 
 `SimSnsFanOut` is what a publish hands a message to. It asks each subscription whether it wants the
 message before scheduling anything, which is where a filter policy is applied: filtering sits above
-the delivery endpoint rather than inside the queue one, so a second protocol picks it up for free.
-Each subscription is asked on its own, so one subscriber filtering a message out has nothing to do
-with what another receives. It schedules one delivery per subscription that wants it on the
+the delivery endpoint rather than inside any one of them, so a `lambda` subscription is filtered the
+same way an `sqs` one is, and a third protocol would be too. Each subscription is asked on its own,
+so one subscriber filtering a message out has nothing to do with what another receives. It schedules one delivery per subscription that wants it on the
 background scheduler, because real SNS answers a publish before anything is delivered:
 `simAws.backgroundTasksComplete()` is what waits for it. A failure is recorded on
 `SimSnsDeliveryFailures` rather than thrown, since a background task left rejected would fail an

--- a/src/service/sns/README.md
+++ b/src/service/sns/README.md
@@ -123,6 +123,11 @@ answer what a key path holds, so no operator has to know which of them it is loo
 is not a JSON object holds nothing at any key rather than failing to be read, because the body comes
 from whoever published and the scope is the subscription's own business.
 
+A subject also says whether it holds anything at all, which `{"exists": false}` needs: real SNS
+states that an empty set of message attributes matches no filter policy, so a key missing from a
+message carrying other keys is not the same thing as a message carrying none. That is why the answer
+belongs to the subject rather than to the key being asked about.
+
 `SimSnsFilterValue` is one value a policy can be matched against. It holds the forms it has rather
 than one form, because a `Number` message attribute has two: the digits it was published as, and the
 number they spell. A form a value does not have matches nothing of that form, which is what keeps
@@ -132,6 +137,12 @@ number they spell. A form a value does not have matches nothing of that form, wh
 a list is a `SimSnsFilterKeyRule`, a key holding an object is another level of rules, and `$or` is
 alternatives. A nested key is refused under the `MessageAttributes` scope, since message attributes
 are flat and such a policy could never match.
+
+`sim-sns-filter-or-eligibility.ts` holds the rules deciding whether an `$or` is one. Real SNS asks for
+a list of at least two objects, none of which names a reserved keyword, and reads anything else as an
+attribute named `$or`. That is the divergence worth knowing here: real SNS makes such a policy match
+nothing, and this refuses it when it is set, because a policy that quietly stopped being an or is
+what filtering is meant to protect a test from.
 
 `match/` holds one class per operator, each holding what it was written with and answering one
 question about a value. `SimSnsFilterMatch` is what they share, including the answer to whether they
@@ -362,6 +373,9 @@ here, it does not make another Account's topics reachable through this one.
 - Delivery retry policies, subscription dead-letter queues and delivery status logging are not
   simulated, so a delivery that fails is recorded once rather than retried.
 - The `cidr` filter policy operator is not simulated, and is refused when the policy is set.
+- An `$or` real SNS would read as an ordinary attribute name, because it holds fewer than two objects
+  or names a reserved keyword, is refused when the policy is set rather than matched as that
+  attribute.
 - A filter policy is reported back as the string it was set with, rather than the re-serialised
   document real SNS answers with.
 - Delivery retry policies, dead-letter queues and replay are not simulated, so `DeliveryPolicy`,

--- a/src/service/sns/README.md
+++ b/src/service/sns/README.md
@@ -83,14 +83,66 @@ protocol real SNS has is refused by name with the reason it is missing, rather t
 subscription that would never be delivered to. A protocol real SNS does not have at all is refused
 the way real SNS refuses one.
 
-`SimSnsSubscriptionAttributes` holds `RawMessageDelivery` and nothing else, and
-`SimSnsSubscriptionAttributeNames` is where the refusal of the rest is decided. Applying a request
-makes a new set rather than changing the one the subscription holds, as it does for a topic.
+`SimSnsSubscriptionAttributes` holds `RawMessageDelivery`, the subscription's filter policy and the
+scope that policy is read under, and `SimSnsSubscriptionAttributeNames` is where the refusal of the
+rest is decided. Applying a request makes a new set rather than changing the one the subscription
+holds, as it does for a topic, and `sim-sns-subscription-attribute-changes.ts` is where a request is
+read as the attributes it leaves behind. The two filter policy attributes are read together, because
+a policy of the `MessageBody` scope may say things a policy of the default scope may not: setting
+either one on its own still reads the policy under whichever scope ends up in force.
+
+`SimSnsRequestedSubscriptionAttributes` is one request's attributes with the ones it left out left
+out. Every name is checked as it is read, so a request naming one attribute this simulation will not
+take changes none of them.
 
 `SimSnsSubscriptionStore` holds subscriptions rather than the topic holding its own, because an
 `Unsubscribe` request carries a subscription ARN and nothing else: the subscription has to be
 reachable without knowing which topic it belongs to first. It also keeps a per-topic count of the
 subscriptions that have been removed, which is what `SubscriptionsDeleted` reports.
+
+## Filter policies
+
+Subscription filtering lives under `filter/`. It is its own area rather than part of the fan-out,
+because a policy is read when it is set and applied when a message is published, and those happen at
+opposite ends of the service.
+
+`SimSnsFilterPolicy` is one subscription's policy. It keeps the string it was set with, so
+`GetSubscriptionAttributes` reports back what was set rather than a re-serialised version of it, and
+it holds the scope it was read under: reading it is what refuses an operator this simulation cannot
+apply, and the scope decides what the document may say. `forScope` reads it again when the scope
+changes, so a policy that cannot be written under the new scope is refused there rather than left in
+place matching nothing.
+
+`SimSnsFilterPolicyScope` is the two scopes, each of which knows what part of a published message a
+policy of that scope matches against and whether that part can nest. That is the whole difference
+between them, which is why the scope builds the subject rather than something else branching on it.
+
+`SimSnsFilterSubject` is what a policy is matched against, and there are two: `SimSnsAttributeSubject`
+over the message attributes of the publish, and `SimSnsBodySubject` over the parsed message body. Both
+answer what a key path holds, so no operator has to know which of them it is looking at. A body that
+is not a JSON object holds nothing at any key rather than failing to be read, because the body comes
+from whoever published and the scope is the subscription's own business.
+
+`SimSnsFilterValue` is one value a policy can be matched against. It holds the forms it has rather
+than one form, because a `Number` message attribute has two: the digits it was published as, and the
+number they spell. A form a value does not have matches nothing of that form, which is what keeps
+`numeric` from matching a `String` attribute holding digits, as real SNS keeps it.
+
+`SimSnsFilterRules` is one level of a policy document, and every rule in it has to hold. A key holding
+a list is a `SimSnsFilterKeyRule`, a key holding an object is another level of rules, and `$or` is
+alternatives. A nested key is refused under the `MessageAttributes` scope, since message attributes
+are flat and such a policy could never match.
+
+`match/` holds one class per operator, each holding what it was written with and answering one
+question about a value. `SimSnsFilterMatch` is what they share, including the answer to whether they
+match a key the message does not carry: only `exists` says yes to that. `SimSnsAnythingButMatch` is
+the negation of the matches inside it rather than an operator of its own, which is what makes
+`anything-but` with a `prefix` in it work without a second implementation of `prefix`.
+
+`sim-sns-filter-matches.ts` reads one match condition, and `sim-sns-filter-operators.ts` is the
+operator table it reads with. `cidr` is refused there by name: it is the one operator real SNS has
+that this does not, and a policy holding it would otherwise be accepted and then match nothing, which
+looks exactly like filtering that worked.
 
 ## Message model
 
@@ -120,8 +172,12 @@ SQS, because a real SNS publish response carries no digest for a caller to check
 
 Delivery lives under `delivery/`, and the signing that goes with it under `signature/`.
 
-`SimSnsFanOut` is what a publish hands a message to. It schedules one delivery per subscription on
-the background scheduler, because real SNS answers a publish before anything is delivered:
+`SimSnsFanOut` is what a publish hands a message to. It asks each subscription whether it wants the
+message before scheduling anything, which is where a filter policy is applied: filtering sits above
+the delivery endpoint rather than inside the queue one, so a second protocol picks it up for free.
+Each subscription is asked on its own, so one subscriber filtering a message out has nothing to do
+with what another receives. It schedules one delivery per subscription that wants it on the
+background scheduler, because real SNS answers a publish before anything is delivered:
 `simAws.backgroundTasksComplete()` is what waits for it. A failure is recorded on
 `SimSnsDeliveryFailures` rather than thrown, since a background task left rejected would fail an
 unrelated `backgroundTasksComplete()`, and real SNS never reports a delivery failure to the publisher.
@@ -305,9 +361,11 @@ here, it does not make another Account's topics reachable through this one.
   extensions, because nothing verifying an SNS message looks at any.
 - Delivery retry policies, subscription dead-letter queues and delivery status logging are not
   simulated, so a delivery that fails is recorded once rather than retried.
-- Subscription filter policies, delivery retry policies, dead-letter queues and replay are not
-  simulated, so `FilterPolicy`, `FilterPolicyScope`, `DeliveryPolicy`, `RedrivePolicy`,
-  `SubscriptionRoleArn` and `ReplayPolicy` are refused.
+- The `cidr` filter policy operator is not simulated, and is refused when the policy is set.
+- A filter policy is reported back as the string it was set with, rather than the re-serialised
+  document real SNS answers with.
+- Delivery retry policies, dead-letter queues and replay are not simulated, so `DeliveryPolicy`,
+  `RedrivePolicy`, `SubscriptionRoleArn` and `ReplayPolicy` are refused.
 - `Unsubscribe` of an ARN naming no subscription is a `NotFoundException`, which is the error real
   SNS documents for it.
 - A topic name ending in `.fifo` is refused, as are `FifoTopic` and the other FIFO attributes.
@@ -316,6 +374,8 @@ here, it does not make another Account's topics reachable through this one.
   bytes of the name, the data type and the value.
 - A subject beginning with a space is accepted. Older AWS documentation described a subject as ASCII
   text beginning with a letter, number or punctuation mark, and the current contract does not.
+- `GetSubscriptionAttributes` reports `FilterPolicy` and `FilterPolicyScope` only once a policy is
+  set, since the scope only says how a policy is read.
 - `GetTopicAttributes` reports `TopicArn`, `Owner`, `DisplayName`, the three subscription counts and
   `Policy` when one is set. `EffectiveDeliveryPolicy` and `DeliveryPolicy` are left out, since
   delivery retry policies are not simulated. `SubscriptionsPending` is always zero, because the one

--- a/src/service/sns/command/subscription/sim-sns-subscription-attribute-commands.iso.test.ts
+++ b/src/service/sns/command/subscription/sim-sns-subscription-attribute-commands.iso.test.ts
@@ -8,6 +8,7 @@ import {
   assertObjectMatches,
   assertStringIncludes,
   assertThrowsErrorAsync,
+  assertUndefined,
 } from "@kensio/smartass";
 import { describe, it } from "vitest";
 import { simAwsWithSubscription } from "../../../../../test/sns/subscription-fixture.js";
@@ -78,21 +79,92 @@ describe("SNS subscription attribute commands", () => {
       }),
     );
 
-    // When a filter policy is set on it.
+    // When a dead-letter queue is set on it.
     const error = await assertThrowsErrorAsync(async () => {
       await simAws.sns().setSubscriptionAttributes(
         new SetSubscriptionAttributesCommand({
           SubscriptionArn: subscriptionArn,
-          AttributeName: "FilterPolicy",
-          AttributeValue: JSON.stringify({ kind: ["order"] }),
+          AttributeName: "RedrivePolicy",
+          AttributeValue: JSON.stringify({
+            deadLetterTargetArn: "arn:aws:sqs:us-east-1:888888888888:dead",
+          }),
         }),
       );
     });
 
     // Then it is refused with its reason, and what was already set stands.
     assertInstanceOf(error, SimSnsUnsimulatedInputException);
-    assertStringIncludes(error.message, "filter policies are not simulated");
+    assertStringIncludes(error.message, "dead-letter queues are not simulated");
     await assertRawMessageDelivery(simAws, subscriptionArn, "true");
+  });
+
+  it("reports the filter policy it was set with", async () => {
+    // Given a subscription with no filter policy.
+    const { simAws, subscriptionArn } = await simAwsWithSubscription();
+    const before = await simAws.sns().getSubscriptionAttributes(
+      new GetSubscriptionAttributesCommand({
+        SubscriptionArn: subscriptionArn,
+      }),
+    );
+
+    assertUndefined(before.Attributes?.["FilterPolicy"]);
+
+    // When a policy is set on it.
+    const policy = JSON.stringify({ type: ["order"] });
+
+    await simAws.sns().setSubscriptionAttributes(
+      new SetSubscriptionAttributesCommand({
+        SubscriptionArn: subscriptionArn,
+        AttributeName: "FilterPolicy",
+        AttributeValue: policy,
+      }),
+    );
+
+    // Then it comes back as the document it was set with, with the scope it is
+    // read under alongside it.
+    const read = await simAws.sns().getSubscriptionAttributes(
+      new GetSubscriptionAttributesCommand({
+        SubscriptionArn: subscriptionArn,
+      }),
+    );
+
+    assertNonNullable(read.Attributes);
+    assertObjectMatches(read.Attributes, {
+      FilterPolicy: policy,
+      FilterPolicyScope: "MessageAttributes",
+    });
+  });
+
+  it("reports the scope a filter policy is read under", async () => {
+    // Given a subscription filtering on the message body.
+    const { simAws, subscriptionArn } = await simAwsWithSubscription();
+
+    await simAws.sns().setSubscriptionAttributes(
+      new SetSubscriptionAttributesCommand({
+        SubscriptionArn: subscriptionArn,
+        AttributeName: "FilterPolicyScope",
+        AttributeValue: "MessageBody",
+      }),
+    );
+
+    await simAws.sns().setSubscriptionAttributes(
+      new SetSubscriptionAttributesCommand({
+        SubscriptionArn: subscriptionArn,
+        AttributeName: "FilterPolicy",
+        AttributeValue: JSON.stringify({ customer: { tier: ["gold"] } }),
+      }),
+    );
+
+    // When the subscription is read back.
+    const read = await simAws.sns().getSubscriptionAttributes(
+      new GetSubscriptionAttributesCommand({
+        SubscriptionArn: subscriptionArn,
+      }),
+    );
+
+    // Then the scope is reported with the policy it applies to.
+    assertNonNullable(read.Attributes);
+    assertObjectMatches(read.Attributes, { FilterPolicyScope: "MessageBody" });
   });
 
   it("requires an attribute name", async () => {

--- a/src/service/sns/command/subscription/sim-sns-subscription-attribute-validation.iso.test.ts
+++ b/src/service/sns/command/subscription/sim-sns-subscription-attribute-validation.iso.test.ts
@@ -26,8 +26,6 @@ describe("SNS subscription attribute validation", () => {
     // subscribe time.
     const refusals = await Promise.all(
       [
-        { FilterPolicy: JSON.stringify({ kind: ["order"] }) },
-        { FilterPolicyScope: "MessageBody" },
         { DeliveryPolicy: JSON.stringify({ healthyRetryPolicy: {} }) },
         { RedrivePolicy: JSON.stringify({ deadLetterTargetArn: queueArn }) },
         { SubscriptionRoleArn: "arn:aws:iam::888888888888:role/Firehose" },

--- a/src/service/sns/delivery/sim-sns-fan-out.ts
+++ b/src/service/sns/delivery/sim-sns-fan-out.ts
@@ -45,13 +45,18 @@ export class SimSnsFanOut {
   }
 
   /**
-   * Schedule one message for every subscription of a topic.
+   * Schedule one message for every subscription of a topic that wants it.
    *
-   * Each subscription gets its own copy, which is the whole point of a topic:
-   * two queues subscribed to one topic both receive what was published once.
+   * Each subscription gets its own copy, which is what a topic is for: two
+   * queues subscribed to one topic both receive what was published once. A
+   * subscription whose filter policy does not match the message is left out,
+   * and asking each one separately is what keeps one subscriber's policy from
+   * having anything to do with what another receives.
    */
   publish(topic: SimSnsTopic, message: SimSnsPublishedMessage): void {
-    const subscribed = this.subscriptions.forTopic(topic.name.value);
+    const subscribed = this.subscriptions
+      .forTopic(topic.name.value)
+      .filter((subscription) => subscription.accepts(message));
 
     for (const subscription of subscribed) {
       this.background.schedule(async () => {

--- a/src/service/sns/delivery/sim-sns-filtered-fan-out.iso.test.ts
+++ b/src/service/sns/delivery/sim-sns-filtered-fan-out.iso.test.ts
@@ -14,6 +14,7 @@ import {
   assertUndefined,
 } from "@kensio/smartass";
 import { describe, it } from "vitest";
+import { simSnsSubscribedFunction } from "../../../../test/sns/function-fixture.js";
 import {
   simSnsDeliveredMessage,
   simSnsQueuePolicy,
@@ -182,5 +183,54 @@ describe("SNS fan-out with subscription filter policies", () => {
       envelopeMessage(await simSnsDeliveredMessage(simAws, queueUrl)),
       "order-1",
     );
+  });
+
+  it("filters a subscribed function the same way as a queue", async () => {
+    // Given a topic with a function subscribed to it, filtering on the kind of
+    // message it wants.
+    const { simAws, topicArn } = await simAwsWithTopic();
+    const consumer = await simSnsSubscribedFunction(
+      simAws,
+      "order-consumer",
+      topicArn,
+    );
+    const [subscription] = simAws.sns().topicSubscriptions("orders");
+
+    assertNonNullable(subscription);
+
+    await simAws.sns().setSubscriptionAttributes(
+      new SetSubscriptionAttributesCommand({
+        SubscriptionArn: subscription.arn.value,
+        AttributeName: "FilterPolicy",
+        AttributeValue: JSON.stringify({ type: ["order"] }),
+      }),
+    );
+
+    // When a refund is published, and then an order.
+    await Promise.all(
+      ["refund", "order"].map(async (type) =>
+        simAws.sns().publish(
+          new PublishCommand({
+            TopicArn: topicArn,
+            Message: `${type}-1`,
+            MessageAttributes: {
+              type: { DataType: "String", StringValue: type },
+            },
+          }),
+        ),
+      ),
+    );
+
+    await simAws.backgroundTasksComplete();
+
+    // Then only the order invoked it. Filtering sits above the endpoint a
+    // subscription delivers to, so it applies to a function as it does to a
+    // queue.
+    assertArrayLength(consumer.events, 1);
+
+    const [event] = consumer.events;
+
+    assertNonNullable(event);
+    assertIdentical(event.Records[0]?.Sns["Message"], "order-1");
   });
 });

--- a/src/service/sns/delivery/sim-sns-filtered-fan-out.iso.test.ts
+++ b/src/service/sns/delivery/sim-sns-filtered-fan-out.iso.test.ts
@@ -1,0 +1,186 @@
+import {
+  PublishCommand,
+  SetSubscriptionAttributesCommand,
+  SubscribeCommand,
+} from "@aws-sdk/client-sns";
+import {
+  CreateQueueCommand,
+  SetQueueAttributesCommand,
+} from "@aws-sdk/client-sqs";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import {
+  simSnsDeliveredMessage,
+  simSnsQueuePolicy,
+} from "../../../../test/sns/subscription-fixture.js";
+import { simAwsWithTopic } from "../../../../test/sns/topic-fixture.js";
+import type { SimAws } from "../../aws/sim-aws.js";
+
+/**
+ * Subscribe a queue to the topic with a filter policy of its own.
+ */
+async function subscribeFiltering(
+  simAws: SimAws,
+  queueName: string,
+  topicArn: string,
+  attributes: Record<string, string>,
+): Promise<string> {
+  const sqs = simAws.sqs();
+  const created = await sqs.createQueue(
+    new CreateQueueCommand({ QueueName: queueName }),
+  );
+  const queueArn = `arn:aws:sqs:us-east-1:888888888888:${queueName}`;
+
+  await sqs.setQueueAttributes(
+    new SetQueueAttributesCommand({
+      QueueUrl: created.QueueUrl,
+      Attributes: { Policy: simSnsQueuePolicy(queueArn, topicArn) },
+    }),
+  );
+
+  await simAws.sns().subscribe(
+    new SubscribeCommand({
+      TopicArn: topicArn,
+      Protocol: "sqs",
+      Endpoint: queueArn,
+      Attributes: attributes,
+    }),
+  );
+
+  assertNonNullable(created.QueueUrl);
+
+  return created.QueueUrl;
+}
+
+/**
+ * The `Message` a delivered envelope carries.
+ */
+function envelopeMessage(body: string | undefined): unknown {
+  assertNonNullable(body);
+
+  return (JSON.parse(body) as Record<string, unknown>)["Message"];
+}
+
+describe("SNS fan-out with subscription filter policies", () => {
+  it("delivers to the subscriptions whose policy matches", async () => {
+    // Given a topic with three queues subscribed to it: one taking orders, one
+    // taking refunds, and one with no policy at all.
+    const { simAws, topicArn } = await simAwsWithTopic();
+    const orders = await subscribeFiltering(simAws, "orders-q", topicArn, {
+      FilterPolicy: JSON.stringify({ type: ["order"] }),
+    });
+    const refunds = await subscribeFiltering(simAws, "refunds-q", topicArn, {
+      FilterPolicy: JSON.stringify({ type: ["refund"] }),
+    });
+    const audit = await subscribeFiltering(simAws, "audit-q", topicArn, {});
+
+    // When an order is published.
+    await simAws.sns().publish(
+      new PublishCommand({
+        TopicArn: topicArn,
+        Message: "order-1",
+        MessageAttributes: {
+          type: { DataType: "String", StringValue: "order" },
+        },
+      }),
+    );
+
+    // Then it reaches the queue whose policy matches and the one filtering
+    // nothing, and the other subscription's policy has nothing to do with it.
+    assertIdentical(
+      envelopeMessage(await simSnsDeliveredMessage(simAws, orders)),
+      "order-1",
+    );
+    assertIdentical(
+      envelopeMessage(await simSnsDeliveredMessage(simAws, audit)),
+      "order-1",
+    );
+    assertUndefined(await simSnsDeliveredMessage(simAws, refunds));
+  });
+
+  it("filters on the message body when the scope says to", async () => {
+    // Given a queue subscribed with a policy about the body.
+    const { simAws, topicArn } = await simAwsWithTopic();
+    const gold = await subscribeFiltering(simAws, "gold-q", topicArn, {
+      FilterPolicy: JSON.stringify({ customer: { tier: ["gold"] } }),
+      FilterPolicyScope: "MessageBody",
+    });
+
+    // When a body naming another tier is published, and then one naming gold.
+    await simAws.sns().publish(
+      new PublishCommand({
+        TopicArn: topicArn,
+        Message: JSON.stringify({ customer: { tier: "silver" } }),
+      }),
+    );
+
+    assertUndefined(await simSnsDeliveredMessage(simAws, gold));
+
+    await simAws.sns().publish(
+      new PublishCommand({
+        TopicArn: topicArn,
+        Message: JSON.stringify({ customer: { tier: "gold" } }),
+      }),
+    );
+
+    // Then only the second one is delivered.
+    assertIdentical(
+      envelopeMessage(await simSnsDeliveredMessage(simAws, gold)),
+      JSON.stringify({ customer: { tier: "gold" } }),
+    );
+  });
+
+  it("delivers a body that is not JSON to nothing filtering on one", async () => {
+    // Given a queue filtering on the message body.
+    const { simAws, topicArn } = await simAwsWithTopic();
+    const queueUrl = await subscribeFiltering(simAws, "body-q", topicArn, {
+      FilterPolicy: JSON.stringify({ type: ["order"] }),
+      FilterPolicyScope: "MessageBody",
+    });
+
+    // When a message that is not JSON at all is published.
+    await simAws
+      .sns()
+      .publish(new PublishCommand({ TopicArn: topicArn, Message: "order-1" }));
+
+    // Then nothing is delivered and nothing failed: a body with no keys in it
+    // matches no policy.
+    assertUndefined(await simSnsDeliveredMessage(simAws, queueUrl));
+    assertArrayLength(simAws.sns().deliveryFailures, 0);
+  });
+
+  it("stops filtering when the policy is taken off again", async () => {
+    // Given a queue subscribed with a policy nothing published matches.
+    const { simAws, topicArn } = await simAwsWithTopic();
+    const queueUrl = await subscribeFiltering(simAws, "orders-q", topicArn, {
+      FilterPolicy: JSON.stringify({ type: ["refund"] }),
+    });
+    const [subscription] = simAws.sns().topicSubscriptions("orders");
+
+    assertNonNullable(subscription);
+
+    // When the policy is cleared by setting it with no value.
+    await simAws.sns().setSubscriptionAttributes(
+      new SetSubscriptionAttributesCommand({
+        SubscriptionArn: subscription.arn.value,
+        AttributeName: "FilterPolicy",
+        AttributeValue: undefined,
+      }),
+    );
+
+    await simAws
+      .sns()
+      .publish(new PublishCommand({ TopicArn: topicArn, Message: "order-1" }));
+
+    // Then the subscription is back to receiving everything.
+    assertIdentical(
+      envelopeMessage(await simSnsDeliveredMessage(simAws, queueUrl)),
+      "order-1",
+    );
+  });
+});

--- a/src/service/sns/filter/match/sim-sns-anything-but-match.ts
+++ b/src/service/sns/filter/match/sim-sns-anything-but-match.ts
@@ -1,0 +1,109 @@
+import type { JSONValue } from "../../../../util/type-guard/json.js";
+import {
+  filterPolicyOperator,
+  isFilterPolicyObject,
+  simSnsFilterPolicyRefusal,
+} from "../sim-sns-filter-refusals.js";
+import type { SimSnsFilterValue } from "../sim-sns-filter-value.js";
+import {
+  SimSnsEqualsIgnoreCaseMatch,
+  simSnsEqualsIgnoreCaseOperator,
+} from "./sim-sns-equals-ignore-case-match.js";
+import { SimSnsExactMatch } from "./sim-sns-exact-match.js";
+import { SimSnsFilterMatch } from "./sim-sns-filter-match.js";
+import {
+  SimSnsPrefixMatch,
+  simSnsPrefixOperator,
+} from "./sim-sns-prefix-match.js";
+import {
+  SimSnsSuffixMatch,
+  simSnsSuffixOperator,
+} from "./sim-sns-suffix-match.js";
+
+/**
+ * The operator name real SNS gives this match.
+ */
+export const simSnsAnythingButOperator = "anything-but";
+
+/**
+ * The operators real SNS lets a policy write inside `anything-but`.
+ *
+ * These are the string matches, which is what excluding by shape rather than by
+ * value needs. `numeric` and `exists` are not among them, and neither is a
+ * second `anything-but`.
+ */
+const excludable = new Map<string, (operand: JSONValue) => SimSnsFilterMatch>([
+  [
+    simSnsPrefixOperator,
+    (operand): SimSnsFilterMatch => SimSnsPrefixMatch.of(operand),
+  ],
+  [
+    simSnsSuffixOperator,
+    (operand): SimSnsFilterMatch => SimSnsSuffixMatch.of(operand),
+  ],
+  [
+    simSnsEqualsIgnoreCaseOperator,
+    (operand): SimSnsFilterMatch => SimSnsEqualsIgnoreCaseMatch.of(operand),
+  ],
+]);
+
+/**
+ * Read what an `anything-but` excludes, whichever form it was written in.
+ *
+ * A scalar excludes one value, a list excludes each of them, and an object
+ * excludes whatever the operator inside it would have matched.
+ */
+function excluded(operand: JSONValue): readonly SimSnsFilterMatch[] {
+  if (Array.isArray(operand)) {
+    return operand.map((written) => SimSnsExactMatch.of(written));
+  }
+
+  if (!isFilterPolicyObject(operand)) {
+    return [SimSnsExactMatch.of(operand)];
+  }
+
+  const { name, operand: excludes } = filterPolicyOperator(operand);
+  const inner = excludable.get(name);
+
+  if (inner === undefined) {
+    throw simSnsFilterPolicyRefusal(
+      `anything-but takes a value, a list of values, or a prefix, suffix or ` +
+        `equals-ignore-case match, and this one takes ${name}`,
+    );
+  }
+
+  return [inner(excludes)];
+}
+
+/**
+ * `{"anything-but": "order"}`, which matches every value but the ones it names.
+ *
+ * It is the negation of whatever it holds rather than an operator of its own,
+ * so `{"anything-but": {"prefix": "order-"}}` excludes on the start of the
+ * value the way `prefix` includes on it.
+ *
+ * A key the message does not carry still matches nothing. Real SNS asks about a
+ * value it has, and there is no value here to be anything but the excluded one.
+ */
+export class SimSnsAnythingButMatch extends SimSnsFilterMatch {
+  private readonly excluded: readonly SimSnsFilterMatch[];
+
+  constructor(excludedMatches: readonly SimSnsFilterMatch[]) {
+    super();
+    this.excluded = excludedMatches;
+  }
+
+  /**
+   * Read what an `anything-but` excludes.
+   */
+  static of(operand: JSONValue): SimSnsAnythingButMatch {
+    return new this(excluded(operand));
+  }
+
+  /**
+   * Whether the value is none of the excluded ones.
+   */
+  matchesValue(value: SimSnsFilterValue): boolean {
+    return this.excluded.every((match) => !match.matchesValue(value));
+  }
+}

--- a/src/service/sns/filter/match/sim-sns-equals-ignore-case-match.ts
+++ b/src/service/sns/filter/match/sim-sns-equals-ignore-case-match.ts
@@ -1,0 +1,36 @@
+import type { JSONValue } from "../../../../util/type-guard/json.js";
+import { filterPolicyText } from "../sim-sns-filter-refusals.js";
+import type { SimSnsFilterValue } from "../sim-sns-filter-value.js";
+import { SimSnsFilterMatch } from "./sim-sns-filter-match.js";
+
+/**
+ * The operator name real SNS gives this match.
+ */
+export const simSnsEqualsIgnoreCaseOperator = "equals-ignore-case";
+
+/**
+ * `{"equals-ignore-case": "Order"}`, which is the one string match that is not
+ * case sensitive.
+ */
+export class SimSnsEqualsIgnoreCaseMatch extends SimSnsFilterMatch {
+  private readonly lowerCased: string;
+
+  constructor(expected: string) {
+    super();
+    this.lowerCased = expected.toLowerCase();
+  }
+
+  /**
+   * Read the text this match is written with.
+   */
+  static of(operand: JSONValue): SimSnsEqualsIgnoreCaseMatch {
+    return new this(filterPolicyText(operand, simSnsEqualsIgnoreCaseOperator));
+  }
+
+  /**
+   * Whether the value is the text the policy named, in any case.
+   */
+  matchesValue(value: SimSnsFilterValue): boolean {
+    return value.text?.toLowerCase() === this.lowerCased;
+  }
+}

--- a/src/service/sns/filter/match/sim-sns-exact-match.ts
+++ b/src/service/sns/filter/match/sim-sns-exact-match.ts
@@ -1,0 +1,59 @@
+import type { JSONValue } from "../../../../util/type-guard/json.js";
+import { simSnsFilterPolicyRefusal } from "../sim-sns-filter-refusals.js";
+import { SimSnsFilterValue } from "../sim-sns-filter-value.js";
+import { SimSnsFilterMatch } from "./sim-sns-filter-match.js";
+
+/**
+ * Read a scalar a policy was written with as the value it means.
+ *
+ * A list or an object is not a value: a list at this position would be a list
+ * of match conditions inside a list of match conditions, which real SNS has no
+ * meaning for, and an object is an operator handled elsewhere.
+ */
+function exactValue(written: JSONValue): SimSnsFilterValue {
+  if (typeof written === "string") {
+    return SimSnsFilterValue.ofText(written);
+  }
+
+  if (typeof written === "number") {
+    return SimSnsFilterValue.ofNumber(written);
+  }
+
+  if (typeof written === "boolean") {
+    return SimSnsFilterValue.ofBoolean(written);
+  }
+
+  throw simSnsFilterPolicyRefusal(
+    `a match condition is a string, a number, a boolean or an operator, and ` +
+      `this one is ${JSON.stringify(written)}`,
+  );
+}
+
+/**
+ * The value a policy names on its own, with no operator around it.
+ *
+ * This is the plain form: `{"type": ["order"]}` matches a `type` of `order` and
+ * nothing else. String matching is case sensitive, as it is on real SNS.
+ */
+export class SimSnsExactMatch extends SimSnsFilterMatch {
+  private readonly expected: SimSnsFilterValue;
+
+  constructor(expected: SimSnsFilterValue) {
+    super();
+    this.expected = expected;
+  }
+
+  /**
+   * Read one scalar of a policy as the value it has to equal.
+   */
+  static of(written: JSONValue): SimSnsExactMatch {
+    return new this(exactValue(written));
+  }
+
+  /**
+   * Whether the value is the one the policy named.
+   */
+  matchesValue(value: SimSnsFilterValue): boolean {
+    return this.expected.equals(value);
+  }
+}

--- a/src/service/sns/filter/match/sim-sns-exists-match.ts
+++ b/src/service/sns/filter/match/sim-sns-exists-match.ts
@@ -1,0 +1,49 @@
+import type { JSONValue } from "../../../../util/type-guard/json.js";
+import { simSnsFilterPolicyRefusal } from "../sim-sns-filter-refusals.js";
+import { SimSnsFilterMatch } from "./sim-sns-filter-match.js";
+
+/**
+ * The operator name real SNS gives this match.
+ */
+export const simSnsExistsOperator = "exists";
+
+/**
+ * `{"exists": true}`, which asks about the key rather than the value.
+ *
+ * This is the one operator with anything to say about a key the message does
+ * not carry: `{"exists": false}` matches exactly that, and every other operator
+ * matches nothing when there is no value to look at.
+ */
+export class SimSnsExistsMatch extends SimSnsFilterMatch {
+  public override readonly matchesAbsence: boolean;
+
+  private readonly required: boolean;
+
+  constructor(required: boolean) {
+    super();
+    this.required = required;
+    this.matchesAbsence = !required;
+  }
+
+  /**
+   * Read whether the policy asks for the key to be there or to be missing.
+   */
+  static of(operand: JSONValue): SimSnsExistsMatch {
+    if (typeof operand !== "boolean") {
+      throw simSnsFilterPolicyRefusal(
+        `exists match is true or false, and this one is ${JSON.stringify(
+          operand,
+        )}`,
+      );
+    }
+
+    return new this(operand);
+  }
+
+  /**
+   * Whether a value being there is what the policy asked for.
+   */
+  matchesValue(): boolean {
+    return this.required;
+  }
+}

--- a/src/service/sns/filter/match/sim-sns-filter-match.ts
+++ b/src/service/sns/filter/match/sim-sns-filter-match.ts
@@ -1,0 +1,25 @@
+import type { SimSnsFilterValue } from "../sim-sns-filter-value.js";
+
+/**
+ * One match condition of a filter policy, which is one entry of the list a
+ * policy key holds.
+ *
+ * There is one of these per operator rather than one evaluator branching on the
+ * operator name, so an operator is a small class holding what it was written
+ * with and answering one question about a value.
+ */
+export abstract class SimSnsFilterMatch {
+  /**
+   * Whether this matches a key the message does not carry at all.
+   *
+   * Every operator but `exists` answers no, which is real SNS behaviour: a
+   * message with no `type` attribute matches no rule about `type` except the
+   * one asking for it to be missing.
+   */
+  public readonly matchesAbsence: boolean = false;
+
+  /**
+   * Whether one value the message carries at the key matches.
+   */
+  abstract matchesValue(value: SimSnsFilterValue): boolean;
+}

--- a/src/service/sns/filter/match/sim-sns-numeric-match.ts
+++ b/src/service/sns/filter/match/sim-sns-numeric-match.ts
@@ -1,0 +1,153 @@
+import type { JSONValue } from "../../../../util/type-guard/json.js";
+import {
+  filterPolicyList,
+  simSnsFilterPolicyRefusal,
+} from "../sim-sns-filter-refusals.js";
+import type { SimSnsFilterValue } from "../sim-sns-filter-value.js";
+import { SimSnsFilterMatch } from "./sim-sns-filter-match.js";
+
+/**
+ * The operator name real SNS gives this match.
+ */
+export const simSnsNumericOperator = "numeric";
+
+/**
+ * The comparators real SNS writes a numeric condition with.
+ */
+const comparators = new Map<
+  string,
+  (value: number, operand: number) => boolean
+>([
+  ["=", (value, operand): boolean => value === operand],
+  ["<", (value, operand): boolean => value < operand],
+  ["<=", (value, operand): boolean => value <= operand],
+  [">", (value, operand): boolean => value > operand],
+  [">=", (value, operand): boolean => value >= operand],
+]);
+
+/**
+ * The comparison one comparator makes, if it is one real SNS has.
+ */
+function comparatorFor(
+  comparator: JSONValue | undefined,
+): ((value: number, operand: number) => boolean) | undefined {
+  if (typeof comparator !== "string") {
+    return undefined;
+  }
+
+  return comparators.get(comparator);
+}
+
+/**
+ * One half of a numeric condition, such as `">", 100`.
+ *
+ * A range is two of these rather than a form of its own, which is how it is
+ * written: `[">", 0, "<=", 100]` is the same two comparisons a policy could
+ * have made one at a time, and both have to hold.
+ */
+class SimSnsNumericComparison {
+  private readonly compare: (value: number, operand: number) => boolean;
+  private readonly operand: number;
+
+  private constructor(
+    compare: (value: number, operand: number) => boolean,
+    operand: number,
+  ) {
+    this.compare = compare;
+    this.operand = operand;
+  }
+
+  /**
+   * Read one comparator and the number it compares against.
+   */
+  static of(
+    comparator: JSONValue | undefined,
+    operand: JSONValue | undefined,
+  ): SimSnsNumericComparison {
+    const compare = comparatorFor(comparator);
+
+    if (compare === undefined) {
+      throw simSnsFilterPolicyRefusal(
+        `numeric match takes one of =, <, <=, > or >=, and this one takes ${JSON.stringify(
+          comparator,
+        )}`,
+      );
+    }
+
+    if (typeof operand !== "number") {
+      throw simSnsFilterPolicyRefusal(
+        `numeric match compares against a number, and this one compares ` +
+          `against ${JSON.stringify(operand)}`,
+      );
+    }
+
+    return new this(compare, operand);
+  }
+
+  /**
+   * Whether a number the message carries satisfies this comparison.
+   */
+  holds(value: number): boolean {
+    return this.compare(value, this.operand);
+  }
+}
+
+/**
+ * Read the comparator and operand pairs a numeric condition is written as.
+ */
+function comparisonsIn(operand: JSONValue): readonly SimSnsNumericComparison[] {
+  const written = filterPolicyList(operand, simSnsNumericOperator);
+
+  if (written.length === 0 || written.length % 2 !== 0) {
+    throw simSnsFilterPolicyRefusal(
+      `numeric match is a comparator and a number, optionally twice for a ` +
+        `range, and this one is ${JSON.stringify(operand)}`,
+    );
+  }
+
+  const comparisons: SimSnsNumericComparison[] = [];
+
+  for (let index = 0; index < written.length; index += 2) {
+    const [comparator, against] = written.slice(index, index + 2);
+
+    comparisons.push(SimSnsNumericComparison.of(comparator, against));
+  }
+
+  return comparisons;
+}
+
+/**
+ * `{"numeric": [">", 100]}`, and `{"numeric": [">", 0, "<=", 100]}` for a range.
+ *
+ * Only a number is compared numerically, so this matches a `Number` message
+ * attribute and a JSON number in a message body. A `String` attribute holding
+ * digits is text as far as real SNS is concerned, and matches nothing here.
+ */
+export class SimSnsNumericMatch extends SimSnsFilterMatch {
+  private readonly comparisons: readonly SimSnsNumericComparison[];
+
+  constructor(comparisons: readonly SimSnsNumericComparison[]) {
+    super();
+    this.comparisons = comparisons;
+  }
+
+  /**
+   * Read the comparisons a numeric condition is written as.
+   */
+  static of(operand: JSONValue): SimSnsNumericMatch {
+    return new this(comparisonsIn(operand));
+  }
+
+  /**
+   * Whether the value is a number every comparison holds for.
+   */
+  matchesValue(value: SimSnsFilterValue): boolean {
+    const numeric = value.numeric;
+
+    if (numeric === undefined) {
+      return false;
+    }
+
+    return this.comparisons.every((comparison) => comparison.holds(numeric));
+  }
+}

--- a/src/service/sns/filter/match/sim-sns-prefix-match.ts
+++ b/src/service/sns/filter/match/sim-sns-prefix-match.ts
@@ -1,0 +1,38 @@
+import type { JSONValue } from "../../../../util/type-guard/json.js";
+import { filterPolicyText } from "../sim-sns-filter-refusals.js";
+import type { SimSnsFilterValue } from "../sim-sns-filter-value.js";
+import { SimSnsFilterMatch } from "./sim-sns-filter-match.js";
+
+/**
+ * The operator name real SNS gives this match.
+ */
+export const simSnsPrefixOperator = "prefix";
+
+/**
+ * `{"prefix": "order-"}`, which matches on the start of the value.
+ *
+ * Only text has a start, so a numeric value matches no prefix. That is what a
+ * message body holding a JSON number rather than a string runs into.
+ */
+export class SimSnsPrefixMatch extends SimSnsFilterMatch {
+  private readonly prefix: string;
+
+  constructor(prefix: string) {
+    super();
+    this.prefix = prefix;
+  }
+
+  /**
+   * Read the text a prefix match is written with.
+   */
+  static of(operand: JSONValue): SimSnsPrefixMatch {
+    return new this(filterPolicyText(operand, simSnsPrefixOperator));
+  }
+
+  /**
+   * Whether the value starts with the text the policy named.
+   */
+  matchesValue(value: SimSnsFilterValue): boolean {
+    return value.text?.startsWith(this.prefix) === true;
+  }
+}

--- a/src/service/sns/filter/match/sim-sns-suffix-match.ts
+++ b/src/service/sns/filter/match/sim-sns-suffix-match.ts
@@ -1,0 +1,35 @@
+import type { JSONValue } from "../../../../util/type-guard/json.js";
+import { filterPolicyText } from "../sim-sns-filter-refusals.js";
+import type { SimSnsFilterValue } from "../sim-sns-filter-value.js";
+import { SimSnsFilterMatch } from "./sim-sns-filter-match.js";
+
+/**
+ * The operator name real SNS gives this match.
+ */
+export const simSnsSuffixOperator = "suffix";
+
+/**
+ * `{"suffix": ".csv"}`, which matches on the end of the value.
+ */
+export class SimSnsSuffixMatch extends SimSnsFilterMatch {
+  private readonly suffix: string;
+
+  constructor(suffix: string) {
+    super();
+    this.suffix = suffix;
+  }
+
+  /**
+   * Read the text a suffix match is written with.
+   */
+  static of(operand: JSONValue): SimSnsSuffixMatch {
+    return new this(filterPolicyText(operand, simSnsSuffixOperator));
+  }
+
+  /**
+   * Whether the value ends with the text the policy named.
+   */
+  matchesValue(value: SimSnsFilterValue): boolean {
+    return value.text?.endsWith(this.suffix) === true;
+  }
+}

--- a/src/service/sns/filter/sim-sns-attribute-subject.ts
+++ b/src/service/sns/filter/sim-sns-attribute-subject.ts
@@ -85,6 +85,17 @@ export class SimSnsAttributeSubject implements SimSnsFilterSubject {
   }
 
   /**
+   * Whether the publish carried no message attributes at all.
+   *
+   * An attribute carrying bytes counts as one, even though a filter policy can
+   * match nothing against it: real SNS asks whether the message has attributes
+   * rather than whether it has ones worth matching.
+   */
+  get isEmpty(): boolean {
+    return this.byName.size === 0;
+  }
+
+  /**
    * The values the attribute of a name holds, if there is one.
    */
   valuesAt(path: readonly string[]): readonly SimSnsFilterValue[] {

--- a/src/service/sns/filter/sim-sns-attribute-subject.ts
+++ b/src/service/sns/filter/sim-sns-attribute-subject.ts
@@ -1,0 +1,99 @@
+import type { JSONValue } from "../../../util/type-guard/json.js";
+import type { SimSnsMessageAttribute } from "../message/sim-sns-message-attribute.js";
+import type { SimSnsMessageAttributes } from "../message/sim-sns-message-attributes.js";
+import type { SimSnsFilterSubject } from "./sim-sns-filter-subject.js";
+import { SimSnsFilterValue } from "./sim-sns-filter-value.js";
+import { simSnsJsonFilterValues } from "./sim-sns-json-filter-values.js";
+
+/**
+ * Read the members of a `String.Array` attribute.
+ *
+ * The text is a JSON array, and a policy matches any member of it. Text that is
+ * not one is matched as the text it is, rather than the publish being failed
+ * here: a message attribute's value is not validated as JSON when it is
+ * published, so a filter policy is not the place to start.
+ */
+function arrayValues(text: string): readonly SimSnsFilterValue[] {
+  try {
+    const parsed = JSON.parse(text) as JSONValue;
+
+    if (Array.isArray(parsed)) {
+      return simSnsJsonFilterValues(parsed);
+    }
+  } catch {
+    // Not JSON, so there are no members to read.
+  }
+
+  return [SimSnsFilterValue.ofText(text)];
+}
+
+/**
+ * Read one message attribute as the values a policy can match against it.
+ *
+ * A binary attribute has none. Real SNS filters on the text of an attribute,
+ * and bytes are not text, so a policy naming a binary attribute matches nothing
+ * rather than matching its base64.
+ */
+function valuesOf(
+  attribute: SimSnsMessageAttribute,
+): readonly SimSnsFilterValue[] {
+  if (attribute.isBinary) {
+    return [];
+  }
+
+  const text = attribute.value.toString("utf8");
+
+  if (attribute.isNumber) {
+    return [SimSnsFilterValue.ofNumericText(text)];
+  }
+
+  if (attribute.isStringArray) {
+    return arrayValues(text);
+  }
+
+  return [SimSnsFilterValue.ofText(text)];
+}
+
+/**
+ * The message attributes of a publish, as a filter policy sees them.
+ *
+ * This is the default scope, and the flat one: an attribute has a name and no
+ * structure under it, so a policy nesting keys under this scope is refused when
+ * it is set.
+ */
+export class SimSnsAttributeSubject implements SimSnsFilterSubject {
+  private readonly byName: ReadonlyMap<string, readonly SimSnsFilterValue[]>;
+
+  private constructor(
+    byName: ReadonlyMap<string, readonly SimSnsFilterValue[]>,
+  ) {
+    this.byName = byName;
+  }
+
+  /**
+   * Read the message attributes of one publish.
+   */
+  static of(attributes: SimSnsMessageAttributes): SimSnsAttributeSubject {
+    return new this(
+      new Map(
+        attributes.all.map((attribute) => [
+          attribute.name,
+          valuesOf(attribute),
+        ]),
+      ),
+    );
+  }
+
+  /**
+   * The values the attribute of a name holds, if there is one.
+   */
+  valuesAt(path: readonly string[]): readonly SimSnsFilterValue[] {
+    const [name] = path;
+
+    if (path.length !== 1 || name === undefined) {
+      return [];
+    }
+
+    return this.byName.get(name) ?? [];
+  }
+}

--- a/src/service/sns/filter/sim-sns-body-subject.ts
+++ b/src/service/sns/filter/sim-sns-body-subject.ts
@@ -1,0 +1,68 @@
+import type { JSONObject, JSONValue } from "../../../util/type-guard/json.js";
+import { isFilterPolicyObject } from "./sim-sns-filter-refusals.js";
+import type { SimSnsFilterSubject } from "./sim-sns-filter-subject.js";
+import type { SimSnsFilterValue } from "./sim-sns-filter-value.js";
+import { simSnsJsonFilterValues } from "./sim-sns-json-filter-values.js";
+
+/**
+ * Read a published message body as the JSON document a policy matches against.
+ *
+ * A body that is not JSON, or that is JSON without being an object, holds no
+ * keys at all. It is not an error: `MessageBody` filtering is set on the
+ * subscription and the body comes from whoever published, so a publisher
+ * sending text to a topic one subscription filters on this way would otherwise
+ * fail a delivery it knows nothing about. The message simply does not match.
+ */
+function documentIn(body: string): JSONObject | undefined {
+  try {
+    const parsed = JSON.parse(body) as JSONValue;
+
+    if (isFilterPolicyObject(parsed)) {
+      return parsed;
+    }
+  } catch {
+    // Not JSON, so there is nothing to match against.
+  }
+
+  return undefined;
+}
+
+/**
+ * The parsed message body, as a filter policy of the `MessageBody` scope sees
+ * it.
+ *
+ * This is the scope that nests: a policy names a nested key by nesting itself,
+ * and the path is what it nested through.
+ */
+export class SimSnsBodySubject implements SimSnsFilterSubject {
+  private readonly document: JSONObject | undefined;
+
+  private constructor(document: JSONObject | undefined) {
+    this.document = document;
+  }
+
+  /**
+   * Read the body of one published message.
+   */
+  static of(body: string): SimSnsBodySubject {
+    return new this(documentIn(body));
+  }
+
+  /**
+   * The values held at a key path, after going through what nests it.
+   */
+  valuesAt(path: readonly string[]): readonly SimSnsFilterValue[] {
+    let held: JSONValue = this.document ?? null;
+
+    for (const key of path) {
+      if (!isFilterPolicyObject(held)) {
+        return [];
+      }
+
+      // eslint-disable-next-line security/detect-object-injection -- a key the filter policy named, read out of parsed JSON.
+      held = held[key] ?? null;
+    }
+
+    return simSnsJsonFilterValues(held);
+  }
+}

--- a/src/service/sns/filter/sim-sns-body-subject.ts
+++ b/src/service/sns/filter/sim-sns-body-subject.ts
@@ -49,6 +49,19 @@ export class SimSnsBodySubject implements SimSnsFilterSubject {
   }
 
   /**
+   * Whether the body holds no keys at all.
+   *
+   * A body that is not a JSON object holds none, which is what keeps
+   * `{"exists": false}` from matching a message that was never JSON in the
+   * first place.
+   */
+  get isEmpty(): boolean {
+    return (
+      this.document === undefined || Object.keys(this.document).length === 0
+    );
+  }
+
+  /**
    * The values held at a key path, after going through what nests it.
    */
   valuesAt(path: readonly string[]): readonly SimSnsFilterValue[] {

--- a/src/service/sns/filter/sim-sns-filter-any-rule.ts
+++ b/src/service/sns/filter/sim-sns-filter-any-rule.ts
@@ -1,0 +1,29 @@
+import type { SimSnsFilterRule } from "./sim-sns-filter-rule.js";
+import type { SimSnsFilterSubject } from "./sim-sns-filter-subject.js";
+
+/**
+ * An `$or` across separate keys, which matches when any of its sides does.
+ *
+ * Each side is a policy of its own, so `{"$or": [{"type": ["order"]}, {"kind":
+ * ["refund"]}]}` matches a message carrying either key. Everything else in a
+ * policy is an and, which is why this needs a key of its own to express.
+ *
+ * Whether an `$or` is one at all is decided before this is built, in
+ * `sim-sns-filter-or-eligibility.ts`.
+ */
+export class SimSnsFilterAnyRule implements SimSnsFilterRule {
+  private readonly alternatives: readonly SimSnsFilterRule[];
+
+  constructor(alternatives: readonly SimSnsFilterRule[]) {
+    this.alternatives = alternatives;
+  }
+
+  /**
+   * Whether the message satisfies any one of the alternatives.
+   */
+  matches(subject: SimSnsFilterSubject): boolean {
+    return this.alternatives.some((alternative) =>
+      alternative.matches(subject),
+    );
+  }
+}

--- a/src/service/sns/filter/sim-sns-filter-body-matching.iso.test.ts
+++ b/src/service/sns/filter/sim-sns-filter-body-matching.iso.test.ts
@@ -1,0 +1,191 @@
+import { assertFalse, assertTrue } from "@kensio/smartass";
+import { describe, it } from "vitest";
+import {
+  simSnsFilterMatchesBody,
+  simSnsFilteringSubscription,
+  simSnsPublishedMessage,
+  simSnsStringAttribute,
+} from "../../../../test/sns/filter-fixture.js";
+
+describe("SNS filter policy message body matching", () => {
+  it("matches a key of the published body", () => {
+    // Given a policy about the body rather than the attributes.
+    const policy = { type: ["order"] };
+
+    // When bodies carrying each kind are matched.
+    // Then the policy reads the body it was given.
+    assertTrue(
+      simSnsFilterMatchesBody(policy, JSON.stringify({ type: "order" })),
+    );
+    assertFalse(
+      simSnsFilterMatchesBody(policy, JSON.stringify({ type: "refund" })),
+    );
+  });
+
+  it("matches a nested key", () => {
+    // Given a policy nesting the way the body does.
+    const policy = { customer: { tier: ["gold"] } };
+
+    // When bodies with each tier are matched.
+    // Then the nesting is the path into the body.
+    assertTrue(
+      simSnsFilterMatchesBody(
+        policy,
+        JSON.stringify({ customer: { tier: "gold", id: "c-1" } }),
+      ),
+    );
+    assertFalse(
+      simSnsFilterMatchesBody(
+        policy,
+        JSON.stringify({ customer: { tier: "silver" } }),
+      ),
+    );
+    assertFalse(
+      simSnsFilterMatchesBody(policy, JSON.stringify({ customer: 1 })),
+    );
+  });
+
+  it("matches the numbers and booleans a body holds", () => {
+    // Given policies about a JSON number and a JSON boolean.
+    const numeric = { amount: [{ numeric: [">", 100] }] };
+    const logical = { paid: [true] };
+
+    // When bodies holding each are matched.
+    // Then a body needs no data types for either: JSON has them.
+    assertTrue(
+      simSnsFilterMatchesBody(numeric, JSON.stringify({ amount: 150 })),
+    );
+    assertFalse(
+      simSnsFilterMatchesBody(numeric, JSON.stringify({ amount: 50 })),
+    );
+    assertTrue(
+      simSnsFilterMatchesBody(logical, JSON.stringify({ paid: true })),
+    );
+    assertFalse(
+      simSnsFilterMatchesBody(logical, JSON.stringify({ paid: false })),
+    );
+  });
+
+  it("matches any member of a list the body holds", () => {
+    // Given a policy naming one region.
+    const policy = { regions: ["eu-west-2"] };
+
+    // When a body holding a list of them is matched.
+    // Then any member matching is the key matching.
+    assertTrue(
+      simSnsFilterMatchesBody(
+        policy,
+        JSON.stringify({ regions: ["us-east-1", "eu-west-2"] }),
+      ),
+    );
+    assertFalse(
+      simSnsFilterMatchesBody(
+        policy,
+        JSON.stringify({ regions: ["us-east-1"] }),
+      ),
+    );
+  });
+
+  it("finds nothing at a key holding null or an object", () => {
+    // Given a policy asking for a key to be missing.
+    const policy = { customer: [{ exists: false }] };
+
+    // When bodies holding null and an object at that key are matched.
+    // Then neither holds a value to match, so the key counts as missing.
+    assertTrue(
+      simSnsFilterMatchesBody(policy, JSON.stringify({ customer: null })),
+    );
+    assertTrue(
+      simSnsFilterMatchesBody(policy, JSON.stringify({ customer: { id: 1 } })),
+    );
+    assertFalse(
+      simSnsFilterMatchesBody(policy, JSON.stringify({ customer: "c-1" })),
+    );
+  });
+
+  it("fails to match a body that is not a JSON object", () => {
+    // Given a policy about the body.
+    const policy = { type: ["order"] };
+
+    // When bodies that are not a JSON object are matched.
+    // Then none of them matches, and none of them throws: the body comes from
+    // whoever published, and the scope is the subscription's own business.
+    assertFalse(simSnsFilterMatchesBody(policy, "order-1"));
+    assertFalse(simSnsFilterMatchesBody(policy, "{ not json"));
+    assertFalse(simSnsFilterMatchesBody(policy, JSON.stringify(["order"])));
+    assertFalse(simSnsFilterMatchesBody(policy, JSON.stringify("order")));
+  });
+
+  it("ignores the message attributes under this scope", () => {
+    // Given a policy of the MessageBody scope.
+    const policy = { type: ["order"] };
+
+    // When a message carrying the value as an attribute is matched.
+    const message = simSnsPublishedMessage("order-1", {
+      type: simSnsStringAttribute("order"),
+    });
+    const matched = simSnsFilteringSubscription(policy, "MessageBody").accepts(
+      message,
+    );
+
+    // Then it does not match, since the scope says where to look.
+    assertFalse(matched);
+  });
+
+  it("keeps its policy when another attribute is set", () => {
+    // Given a subscription filtering on the body.
+    const held = simSnsFilteringSubscription(
+      { type: ["order"] },
+      "MessageBody",
+    );
+
+    // When an unrelated attribute is set on it.
+    const raw = held.with({ RawMessageDelivery: "true" });
+
+    // Then the policy is the one it already had, still read under its own
+    // scope.
+    const order = simSnsPublishedMessage(JSON.stringify({ type: "order" }));
+
+    assertTrue(raw.rawMessageDelivery);
+    assertTrue(raw.accepts(order));
+  });
+
+  it("goes back to the default scope when the scope is cleared", () => {
+    // Given a subscription filtering on the body.
+    const held = simSnsFilteringSubscription(
+      { type: ["order"] },
+      "MessageBody",
+    );
+
+    // When the scope is set with no value, which is how SNS is told to clear
+    // an attribute.
+    const cleared = held.with({ FilterPolicyScope: "" });
+
+    // Then the policy is read against the message attributes again.
+    const order = simSnsPublishedMessage("order-1", {
+      type: simSnsStringAttribute("order"),
+    });
+
+    assertTrue(cleared.accepts(order));
+  });
+
+  it("reads the policy again when the scope changes", () => {
+    // Given a subscription filtering on the body.
+    const held = simSnsFilteringSubscription(
+      { type: ["order"] },
+      "MessageBody",
+    );
+
+    // When the scope is moved to the message attributes.
+    const moved = held.with({ FilterPolicyScope: "MessageAttributes" });
+
+    // Then the same policy now matches the attribute instead of the body.
+    const asBody = simSnsPublishedMessage(JSON.stringify({ type: "order" }));
+    const asAttribute = simSnsPublishedMessage("order-1", {
+      type: simSnsStringAttribute("order"),
+    });
+
+    assertFalse(moved.accepts(asBody));
+    assertTrue(moved.accepts(asAttribute));
+  });
+});

--- a/src/service/sns/filter/sim-sns-filter-body-matching.iso.test.ts
+++ b/src/service/sns/filter/sim-sns-filter-body-matching.iso.test.ts
@@ -116,6 +116,23 @@ describe("SNS filter policy message body matching", () => {
     assertFalse(simSnsFilterMatchesBody(policy, JSON.stringify("order")));
   });
 
+  it("matches no body holding nothing, even asking for a missing key", () => {
+    // Given a policy asking for a key to be missing.
+    const policy = { type: [{ exists: false }] };
+
+    // When a body with no keys in it, and one that is not JSON at all, are
+    // matched.
+    // Then neither matches. A body holding nothing matches no policy, the way
+    // an empty set of message attributes matches none.
+    assertFalse(simSnsFilterMatchesBody(policy, JSON.stringify({})));
+    assertFalse(simSnsFilterMatchesBody(policy, "order-1"));
+
+    // And a body holding some other key does match it.
+    assertTrue(
+      simSnsFilterMatchesBody(policy, JSON.stringify({ tenant: "acme" })),
+    );
+  });
+
   it("ignores the message attributes under this scope", () => {
     // Given a policy of the MessageBody scope.
     const policy = { type: ["order"] };

--- a/src/service/sns/filter/sim-sns-filter-key-rule.ts
+++ b/src/service/sns/filter/sim-sns-filter-key-rule.ts
@@ -1,0 +1,67 @@
+import type { JSONValue } from "../../../util/type-guard/json.js";
+import type { SimSnsFilterMatch } from "./match/sim-sns-filter-match.js";
+import { simSnsFilterMatchOf } from "./sim-sns-filter-matches.js";
+import { simSnsFilterPolicyRefusal } from "./sim-sns-filter-refusals.js";
+import type { SimSnsFilterRule } from "./sim-sns-filter-rule.js";
+import type { SimSnsFilterSubject } from "./sim-sns-filter-subject.js";
+
+/**
+ * One key of a filter policy and the match conditions it holds.
+ *
+ * The list is read as an OR, which is what makes `{"type": ["order",
+ * "refund"]}` a rule about two kinds of message rather than a message that is
+ * somehow both.
+ */
+export class SimSnsFilterKeyRule implements SimSnsFilterRule {
+  private readonly path: readonly string[];
+  private readonly conditions: readonly SimSnsFilterMatch[];
+
+  private constructor(
+    path: readonly string[],
+    conditions: readonly SimSnsFilterMatch[],
+  ) {
+    this.path = path;
+    this.conditions = conditions;
+  }
+
+  /**
+   * Read the list of match conditions a key holds.
+   *
+   * An empty list is refused rather than taken as a rule nothing satisfies. A
+   * policy that matched no message at all would be indistinguishable from one
+   * whose messages never turned up.
+   */
+  static of(
+    path: readonly string[],
+    written: readonly JSONValue[],
+  ): SimSnsFilterKeyRule {
+    if (written.length === 0) {
+      throw simSnsFilterPolicyRefusal(
+        `${path.join(".")} holds no match conditions, so nothing could match it`,
+      );
+    }
+
+    return new this(
+      path,
+      written.map((condition) => simSnsFilterMatchOf(condition)),
+    );
+  }
+
+  /**
+   * Whether any of this key's match conditions holds for the message.
+   */
+  matches(subject: SimSnsFilterSubject): boolean {
+    const values = subject.valuesAt(this.path);
+
+    // A key the message does not carry is only matched by the operator that
+    // asks for it to be missing. A key holding several values, as a
+    // String.Array attribute or a JSON array does, is matched by any of them.
+    if (values.length === 0) {
+      return this.conditions.some((condition) => condition.matchesAbsence);
+    }
+
+    return this.conditions.some((condition) =>
+      values.some((value) => condition.matchesValue(value)),
+    );
+  }
+}

--- a/src/service/sns/filter/sim-sns-filter-key-rule.ts
+++ b/src/service/sns/filter/sim-sns-filter-key-rule.ts
@@ -54,10 +54,16 @@ export class SimSnsFilterKeyRule implements SimSnsFilterRule {
     const values = subject.valuesAt(this.path);
 
     // A key the message does not carry is only matched by the operator that
-    // asks for it to be missing. A key holding several values, as a
-    // String.Array attribute or a JSON array does, is matched by any of them.
+    // asks for it to be missing, and only when the message carries something
+    // else: real SNS states that `{"exists": false}` needs at least one
+    // attribute present, so a message carrying none matches no policy at all.
+    // A key holding several values, as a String.Array attribute or a JSON array
+    // does, is matched by any of them.
     if (values.length === 0) {
-      return this.conditions.some((condition) => condition.matchesAbsence);
+      return (
+        !subject.isEmpty &&
+        this.conditions.some((condition) => condition.matchesAbsence)
+      );
     }
 
     return this.conditions.some((condition) =>

--- a/src/service/sns/filter/sim-sns-filter-matches.ts
+++ b/src/service/sns/filter/sim-sns-filter-matches.ts
@@ -1,0 +1,54 @@
+import type { JSONValue } from "../../../util/type-guard/json.js";
+import { SimSnsUnsimulatedInputException } from "../error/sim-sns.error.js";
+import { SimSnsExactMatch } from "./match/sim-sns-exact-match.js";
+import type { SimSnsFilterMatch } from "./match/sim-sns-filter-match.js";
+import { simSnsFilterOperators } from "./sim-sns-filter-operators.js";
+import {
+  filterPolicyOperator,
+  isFilterPolicyObject,
+  simSnsFilterPolicyRefusal,
+} from "./sim-sns-filter-refusals.js";
+
+/**
+ * The one operator real SNS has that this simulation does not.
+ *
+ * IP range matching is refused when the policy is set rather than accepted and
+ * then matching nothing, because a subscription that filtered everything out
+ * would look like a policy nothing happened to match.
+ */
+const simSnsCidrOperator = "cidr";
+
+/**
+ * Refuse an operator this simulation cannot apply, naming it.
+ */
+function unknownOperator(name: string): Error {
+  if (name === simSnsCidrOperator) {
+    return new SimSnsUnsimulatedInputException(
+      `The filter policy operator ${simSnsCidrOperator} is not simulated. IP ` +
+        `range matching is refused when the policy is set, because a policy ` +
+        `holding it would match nothing and look like filtering that worked.`,
+    );
+  }
+
+  return simSnsFilterPolicyRefusal(`${name} is not a match operator`);
+}
+
+/**
+ * Read one entry of the list a policy key holds.
+ *
+ * An object is an operator, and anything else is a value to match exactly.
+ */
+export function simSnsFilterMatchOf(written: JSONValue): SimSnsFilterMatch {
+  if (!isFilterPolicyObject(written)) {
+    return SimSnsExactMatch.of(written);
+  }
+
+  const { name, operand } = filterPolicyOperator(written);
+  const operator = simSnsFilterOperators.get(name);
+
+  if (operator === undefined) {
+    throw unknownOperator(name);
+  }
+
+  return operator(operand);
+}

--- a/src/service/sns/filter/sim-sns-filter-numeric-matching.iso.test.ts
+++ b/src/service/sns/filter/sim-sns-filter-numeric-matching.iso.test.ts
@@ -1,0 +1,173 @@
+import { assertFalse, assertTrue } from "@kensio/smartass";
+import { describe, it } from "vitest";
+import {
+  simSnsFilterMatchesAttributes,
+  simSnsNumberAttribute,
+  simSnsStringAttribute,
+} from "../../../../test/sns/filter-fixture.js";
+import type { JSONObject } from "../../../util/type-guard/json.js";
+
+/**
+ * Whether a policy matches a message carrying one `amount` number.
+ */
+function matchesAmount(policy: JSONObject, amount: string): boolean {
+  return simSnsFilterMatchesAttributes(policy, {
+    amount: simSnsNumberAttribute(amount),
+  });
+}
+
+describe("SNS filter policy numeric matching", () => {
+  it("compares a number with each comparator", () => {
+    // Given a policy for each numeric comparator.
+    const cases = [
+      { policy: { amount: [{ numeric: ["=", 100] }] }, yes: "100", no: "101" },
+      { policy: { amount: [{ numeric: [">", 100] }] }, yes: "150", no: "100" },
+      { policy: { amount: [{ numeric: [">=", 100] }] }, yes: "100", no: "99" },
+      { policy: { amount: [{ numeric: ["<", 100] }] }, yes: "50", no: "100" },
+      { policy: { amount: [{ numeric: ["<=", 100] }] }, yes: "100", no: "101" },
+    ];
+
+    // When an amount on each side of the comparison is matched against it.
+    // Then each holds only for the side it names.
+    for (const { policy, yes, no } of cases) {
+      assertTrue(matchesAmount(policy, yes));
+      assertFalse(matchesAmount(policy, no));
+    }
+  });
+
+  it("matches only inside a range", () => {
+    // Given a policy for an amount over 0 and up to 100.
+    const policy = { amount: [{ numeric: [">", 0, "<=", 100] }] };
+
+    // When amounts on either side of it are matched.
+    // Then only the ones inside it match, and the upper end is included.
+    assertFalse(matchesAmount(policy, "0"));
+    assertTrue(matchesAmount(policy, "50"));
+    assertTrue(matchesAmount(policy, "100"));
+    assertFalse(matchesAmount(policy, "101"));
+  });
+
+  it("matches a number written differently", () => {
+    // Given a policy about an exact amount.
+    const policy = { amount: [{ numeric: ["=", 100] }] };
+
+    // When the same number is published in other spellings.
+    // Then each matches, since the attribute is compared as the number it
+    // means rather than as the digits it carries.
+    assertTrue(matchesAmount(policy, "100.0"));
+    assertTrue(matchesAmount(policy, "1e2"));
+  });
+
+  it("compares numerically only what is a number", () => {
+    // Given a numeric policy.
+    const policy = { amount: [{ numeric: [">", 100] }] };
+
+    // When a String attribute holding digits, and a Number attribute holding
+    // something else, are matched.
+    const asString = simSnsFilterMatchesAttributes(policy, {
+      amount: simSnsStringAttribute("150"),
+    });
+
+    // Then neither matches. Real SNS matches numerically on the Number data
+    // type, so digits published as a String are text.
+    assertFalse(asString);
+    assertFalse(matchesAmount(policy, "a lot"));
+  });
+
+  it("matches a number the policy names on its own", () => {
+    // Given a policy naming a number rather than an operator.
+    const policy = { amount: [100] };
+
+    // When the number and its text are matched.
+    // Then the Number attribute matches and the String one does not.
+    assertTrue(matchesAmount(policy, "100"));
+    assertFalse(
+      simSnsFilterMatchesAttributes(policy, {
+        amount: simSnsStringAttribute("100"),
+      }),
+    );
+  });
+
+  it("matches either side of an or across separate keys", () => {
+    // Given a policy matching one key or another.
+    const policy = {
+      $or: [{ type: ["order"] }, { tenant: ["acme"] }],
+    };
+
+    // When messages carrying one, the other and neither are matched.
+    // Then either side is enough, which separate keys of a policy are not.
+    assertTrue(
+      simSnsFilterMatchesAttributes(policy, {
+        type: simSnsStringAttribute("order"),
+      }),
+    );
+    assertTrue(
+      simSnsFilterMatchesAttributes(policy, {
+        tenant: simSnsStringAttribute("acme"),
+      }),
+    );
+    assertFalse(
+      simSnsFilterMatchesAttributes(policy, {
+        type: simSnsStringAttribute("refund"),
+      }),
+    );
+  });
+
+  it("matches any member of a String.Array attribute", () => {
+    // Given a policy naming one region.
+    const policy = { regions: ["eu-west-2"] };
+
+    // When an attribute holding a list of regions is matched.
+    const listed = simSnsFilterMatchesAttributes(policy, {
+      regions: {
+        DataType: "String.Array",
+        StringValue: JSON.stringify(["us-east-1", "eu-west-2"]),
+      },
+    });
+    const other = simSnsFilterMatchesAttributes(policy, {
+      regions: {
+        DataType: "String.Array",
+        StringValue: JSON.stringify(["us-east-1"]),
+      },
+    });
+
+    // Then any member matching is the attribute matching.
+    assertTrue(listed);
+    assertFalse(other);
+  });
+
+  it("matches the text of a String.Array that is not a list", () => {
+    // Given a policy naming a value.
+    const policy = { regions: ["eu-west-2"] };
+
+    // When a String.Array attribute carrying something other than a JSON list
+    // is matched.
+    const plain = simSnsFilterMatchesAttributes(policy, {
+      regions: { DataType: "String.Array", StringValue: "eu-west-2" },
+    });
+    const number = simSnsFilterMatchesAttributes(policy, {
+      regions: { DataType: "String.Array", StringValue: "2" },
+    });
+
+    // Then it is matched as the text it is. A publish does not check that the
+    // value is a JSON list, so a filter policy is not the place to start.
+    assertTrue(plain);
+    assertFalse(number);
+  });
+
+  it("matches nothing against a binary attribute", () => {
+    // Given a policy about an attribute carrying bytes.
+    const receipt = {
+      receipt: { DataType: "Binary", BinaryValue: Uint8Array.from([1, 2, 3]) },
+    };
+
+    // When policies about it are matched.
+    // Then it is a key with no value to match, since real SNS filters on text.
+    assertFalse(
+      simSnsFilterMatchesAttributes({ receipt: [{ prefix: "" }] }, receipt),
+    );
+    assertTrue(
+      simSnsFilterMatchesAttributes({ receipt: [{ exists: false }] }, receipt),
+    );
+  });
+});

--- a/src/service/sns/filter/sim-sns-filter-numeric-matching.iso.test.ts
+++ b/src/service/sns/filter/sim-sns-filter-numeric-matching.iso.test.ts
@@ -163,6 +163,8 @@ describe("SNS filter policy numeric matching", () => {
 
     // When policies about it are matched.
     // Then it is a key with no value to match, since real SNS filters on text.
+    // The message still carries an attribute, so a policy about a key that is
+    // missing has something to be missing from.
     assertFalse(
       simSnsFilterMatchesAttributes({ receipt: [{ prefix: "" }] }, receipt),
     );

--- a/src/service/sns/filter/sim-sns-filter-operators.ts
+++ b/src/service/sns/filter/sim-sns-filter-operators.ts
@@ -38,10 +38,10 @@ export type SimSnsFilterOperatorReader = (
  * The one real SNS has that is missing here is `cidr`, which is refused by name
  * rather than left out quietly.
  */
-export const simSnsFilterOperators = new Map<
+export const simSnsFilterOperators: ReadonlyMap<
   string,
   SimSnsFilterOperatorReader
->([
+> = new Map<string, SimSnsFilterOperatorReader>([
   [
     simSnsPrefixOperator,
     (operand): SimSnsFilterMatch => SimSnsPrefixMatch.of(operand),
@@ -66,4 +66,16 @@ export const simSnsFilterOperators = new Map<
     simSnsAnythingButOperator,
     (operand): SimSnsFilterMatch => SimSnsAnythingButMatch.of(operand),
   ],
+]);
+
+/**
+ * The names real SNS reserves, which a policy cannot use as a key.
+ *
+ * These are the operator names. An `$or` alternative naming one of them is not
+ * read as an alternative by real SNS, which is the rule that decides whether a
+ * policy is an or at all.
+ */
+export const simSnsFilterReservedNames: ReadonlySet<string> = new Set([
+  ...simSnsFilterOperators.keys(),
+  "cidr",
 ]);

--- a/src/service/sns/filter/sim-sns-filter-operators.ts
+++ b/src/service/sns/filter/sim-sns-filter-operators.ts
@@ -1,0 +1,69 @@
+import type { JSONValue } from "../../../util/type-guard/json.js";
+import {
+  SimSnsAnythingButMatch,
+  simSnsAnythingButOperator,
+} from "./match/sim-sns-anything-but-match.js";
+import {
+  SimSnsEqualsIgnoreCaseMatch,
+  simSnsEqualsIgnoreCaseOperator,
+} from "./match/sim-sns-equals-ignore-case-match.js";
+import {
+  SimSnsExistsMatch,
+  simSnsExistsOperator,
+} from "./match/sim-sns-exists-match.js";
+import type { SimSnsFilterMatch } from "./match/sim-sns-filter-match.js";
+import {
+  SimSnsNumericMatch,
+  simSnsNumericOperator,
+} from "./match/sim-sns-numeric-match.js";
+import {
+  SimSnsPrefixMatch,
+  simSnsPrefixOperator,
+} from "./match/sim-sns-prefix-match.js";
+import {
+  SimSnsSuffixMatch,
+  simSnsSuffixOperator,
+} from "./match/sim-sns-suffix-match.js";
+
+/**
+ * How each operator reads the operand it was written with.
+ */
+export type SimSnsFilterOperatorReader = (
+  operand: JSONValue,
+) => SimSnsFilterMatch;
+
+/**
+ * Every operator a match condition can be written with.
+ *
+ * The one real SNS has that is missing here is `cidr`, which is refused by name
+ * rather than left out quietly.
+ */
+export const simSnsFilterOperators = new Map<
+  string,
+  SimSnsFilterOperatorReader
+>([
+  [
+    simSnsPrefixOperator,
+    (operand): SimSnsFilterMatch => SimSnsPrefixMatch.of(operand),
+  ],
+  [
+    simSnsSuffixOperator,
+    (operand): SimSnsFilterMatch => SimSnsSuffixMatch.of(operand),
+  ],
+  [
+    simSnsEqualsIgnoreCaseOperator,
+    (operand): SimSnsFilterMatch => SimSnsEqualsIgnoreCaseMatch.of(operand),
+  ],
+  [
+    simSnsNumericOperator,
+    (operand): SimSnsFilterMatch => SimSnsNumericMatch.of(operand),
+  ],
+  [
+    simSnsExistsOperator,
+    (operand): SimSnsFilterMatch => SimSnsExistsMatch.of(operand),
+  ],
+  [
+    simSnsAnythingButOperator,
+    (operand): SimSnsFilterMatch => SimSnsAnythingButMatch.of(operand),
+  ],
+]);

--- a/src/service/sns/filter/sim-sns-filter-or-eligibility.ts
+++ b/src/service/sns/filter/sim-sns-filter-or-eligibility.ts
@@ -1,0 +1,71 @@
+import type { JSONObject, JSONValue } from "../../../util/type-guard/json.js";
+import { simSnsFilterReservedNames } from "./sim-sns-filter-operators.js";
+import {
+  filterPolicyList,
+  isFilterPolicyObject,
+  simSnsFilterPolicyRefusal,
+} from "./sim-sns-filter-refusals.js";
+
+/**
+ * The key real SNS reads as an OR across separate keys.
+ */
+export const simSnsOrKey = "$or";
+
+/**
+ * Refuse an alternative real SNS would not read as one.
+ *
+ * Real SNS asks that no field name inside an `$or` be a reserved keyword, which
+ * is what the operators are named. A policy breaking that rule is not an error
+ * there: `$or` becomes an ordinary attribute name, so the policy asks about an
+ * attribute called `$or` and matches nothing. It is refused here instead,
+ * because a policy that quietly stopped being an or is the failure this feature
+ * exists to prevent.
+ */
+function assertAlternative(written: JSONValue): JSONObject {
+  if (!isFilterPolicyObject(written)) {
+    throw simSnsFilterPolicyRefusal(
+      `each alternative of ${simSnsOrKey} is a policy of its own, and this one ` +
+        `is ${JSON.stringify(written)}`,
+    );
+  }
+
+  const reserved = Object.keys(written).find((name) =>
+    simSnsFilterReservedNames.has(name),
+  );
+
+  if (reserved !== undefined) {
+    throw simSnsFilterPolicyRefusal(
+      `an alternative of ${simSnsOrKey} names keys of the message, and this ` +
+        `one names the reserved ${reserved}, which real SNS reads as an ` +
+        `attribute called ${simSnsOrKey} rather than as an or`,
+    );
+  }
+
+  return written;
+}
+
+/**
+ * Read the alternatives of an `$or`, refusing what real SNS would not read as
+ * one.
+ *
+ * Real SNS recognises an `$or` only when it holds an array of at least two
+ * objects, none of which names a reserved keyword. Anything else is an ordinary
+ * attribute name there rather than an error, which makes a policy that looks
+ * like an or and is not one: it asks about an attribute called `$or`, so it
+ * matches nothing. Each of those is refused here when the policy is set.
+ */
+export function simSnsOrAlternatives(
+  written: JSONValue,
+): readonly JSONObject[] {
+  const alternatives = filterPolicyList(written, simSnsOrKey);
+
+  if (alternatives.length < 2) {
+    throw simSnsFilterPolicyRefusal(
+      `${simSnsOrKey} holds at least two alternatives, and this one holds ${String(
+        alternatives.length,
+      )}`,
+    );
+  }
+
+  return alternatives.map((alternative) => assertAlternative(alternative));
+}

--- a/src/service/sns/filter/sim-sns-filter-policy-scope.ts
+++ b/src/service/sns/filter/sim-sns-filter-policy-scope.ts
@@ -1,0 +1,100 @@
+import { SimSnsInvalidParameterException } from "../error/sim-sns.error.js";
+import type { SimSnsPublishedMessage } from "../message/sim-sns-published-message.js";
+import { SimSnsAttributeSubject } from "./sim-sns-attribute-subject.js";
+import { SimSnsBodySubject } from "./sim-sns-body-subject.js";
+import type { SimSnsFilterSubject } from "./sim-sns-filter-subject.js";
+
+/**
+ * What part of a published message a filter policy is matched against.
+ *
+ * There are two, and which one a subscription uses decides what its policy can
+ * say: message attributes are a flat set of names, and a message body is a JSON
+ * document a policy can nest into.
+ */
+export abstract class SimSnsFilterPolicyScope {
+  /**
+   * The name real SNS gives this scope, which is what the attribute is set to.
+   */
+  abstract get value(): string;
+
+  /**
+   * Whether a policy of this scope can name a key nested under another.
+   */
+  abstract get allowsNestedKeys(): boolean;
+
+  /**
+   * The part of a published message a policy of this scope matches against.
+   */
+  abstract subjectOf(message: SimSnsPublishedMessage): SimSnsFilterSubject;
+}
+
+/**
+ * The default scope, which matches the message attributes of the publish.
+ */
+class SimSnsMessageAttributesScope extends SimSnsFilterPolicyScope {
+  override get value(): string {
+    return "MessageAttributes";
+  }
+
+  override get allowsNestedKeys(): boolean {
+    return false;
+  }
+
+  override subjectOf(message: SimSnsPublishedMessage): SimSnsFilterSubject {
+    return SimSnsAttributeSubject.of(message.attributes);
+  }
+}
+
+/**
+ * The scope that matches the message body, read as a JSON document.
+ */
+class SimSnsMessageBodyScope extends SimSnsFilterPolicyScope {
+  override get value(): string {
+    return "MessageBody";
+  }
+
+  override get allowsNestedKeys(): boolean {
+    return true;
+  }
+
+  override subjectOf(message: SimSnsPublishedMessage): SimSnsFilterSubject {
+    return SimSnsBodySubject.of(message.body.value);
+  }
+}
+
+/**
+ * The scope a subscription filters with unless it says otherwise, which is the
+ * one real SNS defaults to.
+ */
+export const simSnsDefaultFilterPolicyScope: SimSnsFilterPolicyScope =
+  new SimSnsMessageAttributesScope();
+
+const scopes: readonly SimSnsFilterPolicyScope[] = [
+  simSnsDefaultFilterPolicyScope,
+  new SimSnsMessageBodyScope(),
+];
+
+/**
+ * Read the `FilterPolicyScope` attribute of a request.
+ *
+ * An empty value is how an attribute is cleared, which puts the subscription
+ * back on the default scope. Anything real SNS does not have is refused.
+ */
+export function simSnsFilterPolicyScopeOf(
+  value: string,
+): SimSnsFilterPolicyScope {
+  if (value === "") {
+    return simSnsDefaultFilterPolicyScope;
+  }
+
+  const scope = scopes.find((held) => held.value === value);
+
+  if (scope === undefined) {
+    throw new SimSnsInvalidParameterException(
+      `Invalid parameter: FilterPolicyScope: ${value} is not a filter policy ` +
+        `scope, which is ${scopes.map((held) => held.value).join(" or ")}`,
+    );
+  }
+
+  return scope;
+}

--- a/src/service/sns/filter/sim-sns-filter-policy-validation.iso.test.ts
+++ b/src/service/sns/filter/sim-sns-filter-policy-validation.iso.test.ts
@@ -1,0 +1,187 @@
+import { assertInstanceOf, assertStringIncludes } from "@kensio/smartass";
+import { describe, it } from "vitest";
+import {
+  simSnsFilterPolicyRefusal,
+  simSnsFilteringSubscription,
+  simSnsSubscriptionAttributeRefusal,
+} from "../../../../test/sns/filter-fixture.js";
+import {
+  SimSnsInvalidParameterException,
+  SimSnsUnsimulatedInputException,
+} from "../error/sim-sns.error.js";
+
+describe("SNS filter policy validation", () => {
+  it("refuses a cidr match, naming the operator", () => {
+    // Given a policy matching an IP range.
+    const policy = { ip: [{ cidr: "10.0.0.0/24" }] };
+
+    // When it is set on a subscription.
+    const error = simSnsFilterPolicyRefusal(policy);
+
+    // Then it is refused when it is set rather than accepted and then matching
+    // nothing, which would look like filtering that worked.
+    assertInstanceOf(error, SimSnsUnsimulatedInputException);
+    assertStringIncludes(error.message, "cidr is not simulated");
+  });
+
+  it("refuses an operator real SNS does not have", () => {
+    // Given a policy naming an operator that does not exist.
+    const error = simSnsFilterPolicyRefusal({ type: [{ contains: "order" }] });
+
+    // Then it is refused rather than matching nothing.
+    assertInstanceOf(error, SimSnsInvalidParameterException);
+    assertStringIncludes(error.message, "contains is not a match operator");
+  });
+
+  it("refuses a match condition naming two operators", () => {
+    // Given a match condition holding a prefix and a suffix at once.
+    const error = simSnsFilterPolicyRefusal({
+      name: [{ prefix: "order-", suffix: ".csv" }],
+    });
+
+    // Then it is refused, since real SNS takes one operator per condition and
+    // nothing says how two would be combined.
+    assertInstanceOf(error, SimSnsInvalidParameterException);
+    assertStringIncludes(error.message, "names one operator");
+  });
+
+  it("refuses a policy that is not a JSON object", () => {
+    // Given values that are not a policy document.
+    const notJson = simSnsSubscriptionAttributeRefusal({
+      FilterPolicy: "{ nope",
+    });
+    const notAnObject = simSnsSubscriptionAttributeRefusal({
+      FilterPolicy: JSON.stringify(["order"]),
+    });
+
+    // Then each is refused when it is set.
+    assertStringIncludes(notJson.message, "is not a JSON document");
+    assertStringIncludes(
+      notAnObject.message,
+      "keys and their match conditions",
+    );
+  });
+
+  it("refuses a key holding something other than match conditions", () => {
+    // Given a key holding a value rather than a list of conditions.
+    const error = simSnsFilterPolicyRefusal({ type: "order" });
+
+    // Then it is refused, rather than guessed at.
+    assertStringIncludes(error.message, "holds a list of match conditions");
+  });
+
+  it("refuses a key holding no match conditions", () => {
+    // Given a key holding an empty list.
+    const error = simSnsFilterPolicyRefusal({ type: [] });
+
+    // Then it is refused, since nothing could ever match it.
+    assertStringIncludes(error.message, "holds no match conditions");
+  });
+
+  it("refuses a match condition that is neither a value nor an operator", () => {
+    // Given a condition holding a list and one holding null.
+    const listed = simSnsFilterPolicyRefusal({ type: [["order"]] });
+    const nothing = simSnsFilterPolicyRefusal({ type: [null] });
+
+    // Then each is refused.
+    assertStringIncludes(listed.message, "a match condition is a string");
+    assertStringIncludes(nothing.message, "a match condition is a string");
+  });
+
+  it("refuses a numeric match that is not a comparator and a number", () => {
+    // Given numeric conditions written the wrong way round.
+    const refusals = [
+      simSnsFilterPolicyRefusal({ amount: [{ numeric: ">" }] }),
+      simSnsFilterPolicyRefusal({ amount: [{ numeric: [] }] }),
+      simSnsFilterPolicyRefusal({ amount: [{ numeric: [">"] }] }),
+      simSnsFilterPolicyRefusal({ amount: [{ numeric: ["~", 1] }] }),
+      simSnsFilterPolicyRefusal({ amount: [{ numeric: [1, 2] }] }),
+      simSnsFilterPolicyRefusal({ amount: [{ numeric: [">", "1"] }] }),
+    ];
+
+    // Then each is refused when the policy is set.
+    for (const error of refusals) {
+      assertInstanceOf(error, SimSnsInvalidParameterException);
+      assertStringIncludes(error.message, "numeric ");
+    }
+  });
+
+  it("refuses a string operator written without a string", () => {
+    // Given operators given the wrong kind of operand.
+    const prefixed = simSnsFilterPolicyRefusal({ name: [{ prefix: 1 }] });
+    const cased = simSnsFilterPolicyRefusal({
+      name: [{ "equals-ignore-case": ["a"] }],
+    });
+    const existing = simSnsFilterPolicyRefusal({ name: [{ exists: "true" }] });
+
+    // Then each is refused with what it wanted.
+    assertStringIncludes(prefixed.message, "prefix takes a string");
+    assertStringIncludes(cased.message, "equals-ignore-case takes a string");
+    assertStringIncludes(existing.message, "exists match is true or false");
+  });
+
+  it("refuses an anything-but holding an operator it cannot exclude", () => {
+    // Given an anything-but around a numeric match.
+    const error = simSnsFilterPolicyRefusal({
+      amount: [{ "anything-but": { numeric: [">", 1] } }],
+    });
+
+    // Then it is refused: real SNS excludes by value, prefix, suffix or case.
+    assertStringIncludes(error.message, "anything-but takes a value");
+  });
+
+  it("refuses an or that is not a list of policies", () => {
+    // Given an $or written as something else.
+    const notAList = simSnsFilterPolicyRefusal({ $or: { type: ["order"] } });
+    const empty = simSnsFilterPolicyRefusal({ $or: [] });
+    const notAPolicy = simSnsFilterPolicyRefusal({ $or: ["order"] });
+
+    // Then each is refused.
+    assertStringIncludes(notAList.message, "$or takes a list");
+    assertStringIncludes(empty.message, "$or holds no alternatives");
+    assertStringIncludes(notAPolicy.message, "a policy of its own");
+  });
+
+  it("refuses a nested key under the message attributes scope", () => {
+    // Given a policy nesting one key under another.
+    const policy = { customer: { tier: ["gold"] } };
+
+    // When it is set for each scope.
+    const refused = simSnsFilterPolicyRefusal(policy);
+    const accepted = simSnsFilteringSubscription(policy, "MessageBody");
+
+    // Then the body scope takes it and the attribute scope does not: message
+    // attributes are a flat set of names, so it could never match there.
+    assertStringIncludes(refused.message, "is a nested key");
+    assertStringIncludes(refused.message, "MessageAttributes scope");
+    assertStringIncludes(accepted.filterPolicyScope.value, "MessageBody");
+  });
+
+  it("refuses a filter policy scope real SNS does not have", () => {
+    // Given a scope of some other name.
+    const error = simSnsSubscriptionAttributeRefusal({
+      FilterPolicyScope: "MessageSubject",
+    });
+
+    // Then it is refused rather than treated as the default.
+    assertInstanceOf(error, SimSnsInvalidParameterException);
+    assertStringIncludes(error.message, "is not a filter policy scope");
+  });
+
+  it("refuses a policy the new scope cannot take", () => {
+    // Given a subscription holding a nested policy of the body scope.
+    const held = simSnsFilteringSubscription(
+      { customer: { tier: ["gold"] } },
+      "MessageBody",
+    );
+
+    // When the scope is moved to the message attributes.
+    const error = simSnsSubscriptionAttributeRefusal(
+      { FilterPolicyScope: "MessageAttributes" },
+      held,
+    );
+
+    // Then it is refused there, rather than left in place matching nothing.
+    assertStringIncludes(error.message, "is a nested key");
+  });
+});

--- a/src/service/sns/filter/sim-sns-filter-policy-validation.iso.test.ts
+++ b/src/service/sns/filter/sim-sns-filter-policy-validation.iso.test.ts
@@ -130,16 +130,24 @@ describe("SNS filter policy validation", () => {
     assertStringIncludes(error.message, "anything-but takes a value");
   });
 
-  it("refuses an or that is not a list of policies", () => {
-    // Given an $or written as something else.
+  it("refuses an or real SNS would not read as one", () => {
+    // Given the ways an $or falls short of what real SNS recognises: something
+    // other than a list, fewer than two alternatives, an alternative that is
+    // not a policy, and one naming a reserved operator.
     const notAList = simSnsFilterPolicyRefusal({ $or: { type: ["order"] } });
-    const empty = simSnsFilterPolicyRefusal({ $or: [] });
-    const notAPolicy = simSnsFilterPolicyRefusal({ $or: ["order"] });
+    const one = simSnsFilterPolicyRefusal({ $or: [{ type: ["order"] }] });
+    const notAPolicy = simSnsFilterPolicyRefusal({ $or: ["order", "refund"] });
+    const reserved = simSnsFilterPolicyRefusal({
+      $or: [{ numeric: 123 }, { prefix: "abc" }],
+    });
 
-    // Then each is refused.
+    // Then each is refused. Real SNS treats each of these as an attribute
+    // named $or instead, so the policy would quietly stop being an or and
+    // match nothing.
     assertStringIncludes(notAList.message, "$or takes a list");
-    assertStringIncludes(empty.message, "$or holds no alternatives");
+    assertStringIncludes(one.message, "$or holds at least two alternatives");
     assertStringIncludes(notAPolicy.message, "a policy of its own");
+    assertStringIncludes(reserved.message, "reserved numeric");
   });
 
   it("refuses a nested key under the message attributes scope", () => {

--- a/src/service/sns/filter/sim-sns-filter-policy.ts
+++ b/src/service/sns/filter/sim-sns-filter-policy.ts
@@ -1,0 +1,112 @@
+import type { JSONObject, JSONValue } from "../../../util/type-guard/json.js";
+import type { SimSnsPublishedMessage } from "../message/sim-sns-published-message.js";
+import type { SimSnsFilterPolicyScope } from "./sim-sns-filter-policy-scope.js";
+import {
+  isFilterPolicyObject,
+  simSnsFilterPolicyRefusal,
+} from "./sim-sns-filter-refusals.js";
+import { SimSnsFilterRules } from "./sim-sns-filter-rules.js";
+
+/**
+ * Read the `FilterPolicy` attribute of a request as the document it has to be.
+ */
+function documentIn(value: string): JSONObject {
+  const parsed = parsedJson(value);
+
+  if (!isFilterPolicyObject(parsed)) {
+    throw simSnsFilterPolicyRefusal(
+      `a filter policy is a JSON object of keys and their match conditions, ` +
+        `and this one is ${JSON.stringify(parsed)}`,
+    );
+  }
+
+  return parsed;
+}
+
+function parsedJson(value: string): JSONValue {
+  try {
+    return JSON.parse(value) as JSONValue;
+  } catch {
+    throw simSnsFilterPolicyRefusal(
+      `${JSON.stringify(value)} is not a JSON document`,
+    );
+  }
+}
+
+interface SimSnsFilterPolicyProperties {
+  readonly value: string;
+  readonly scope: SimSnsFilterPolicyScope;
+  readonly rules: SimSnsFilterRules;
+}
+
+/**
+ * The filter policy of one simulated subscription.
+ *
+ * A published message reaches the subscription only when the policy matches, so
+ * this is what makes a topic with several subscribers something a test can say
+ * anything about: a subscriber receiving nothing is a policy that did not
+ * match, rather than a delivery that went missing.
+ *
+ * The whole policy is read when it is set. An operator this simulation cannot
+ * apply is refused there rather than when a message arrives, because a policy
+ * accepted and then matching nothing looks exactly like filtering that worked.
+ *
+ * The string the policy was set with is kept, so `GetSubscriptionAttributes`
+ * reports back what was set rather than a re-serialised version of it.
+ */
+export class SimSnsFilterPolicy {
+  public readonly value: string;
+  public readonly scope: SimSnsFilterPolicyScope;
+
+  private readonly rules: SimSnsFilterRules;
+
+  private constructor(properties: SimSnsFilterPolicyProperties) {
+    this.value = properties.value;
+    this.scope = properties.scope;
+    this.rules = properties.rules;
+  }
+
+  /**
+   * Read a filter policy for the scope it will be matched under.
+   *
+   * The scope is part of reading it rather than part of matching with it,
+   * because it decides what the document may say: only a policy of the
+   * `MessageBody` scope can nest.
+   */
+  static parse(
+    value: string,
+    scope: SimSnsFilterPolicyScope,
+  ): SimSnsFilterPolicy {
+    return new this({
+      value,
+      scope,
+      rules: SimSnsFilterRules.of(documentIn(value), [], scope),
+    });
+  }
+
+  /**
+   * Whether a published message satisfies this policy.
+   *
+   * Every key of the policy has to match, and each key matches when any of its
+   * match conditions does.
+   */
+  matches(message: SimSnsPublishedMessage): boolean {
+    return this.rules.matches(this.scope.subjectOf(message));
+  }
+
+  /**
+   * This policy read again for another scope.
+   *
+   * Setting `FilterPolicyScope` on a subscription that already holds a policy
+   * changes what that policy is matched against, so it is read again under the
+   * new scope. A policy that cannot be written under the new scope is refused
+   * then, rather than left in place matching nothing.
+   */
+  forScope(scope: SimSnsFilterPolicyScope): SimSnsFilterPolicy {
+    if (scope === this.scope) {
+      return this;
+    }
+
+    return SimSnsFilterPolicy.parse(this.value, scope);
+  }
+}

--- a/src/service/sns/filter/sim-sns-filter-refusals.ts
+++ b/src/service/sns/filter/sim-sns-filter-refusals.ts
@@ -1,0 +1,85 @@
+import { isRecord } from "../../../util/type-guard/record.js";
+import type { JSONObject, JSONValue } from "../../../util/type-guard/json.js";
+import { SimSnsInvalidParameterException } from "../error/sim-sns.error.js";
+
+/**
+ * Refuse a filter policy real SNS would refuse.
+ *
+ * Every refusal here happens when the policy is set rather than when a message
+ * is matched, because a policy accepted and then never matching looks exactly
+ * like correct filtering.
+ */
+export function simSnsFilterPolicyRefusal(
+  reason: string,
+): SimSnsInvalidParameterException {
+  return new SimSnsInvalidParameterException(
+    `Invalid parameter: FilterPolicy: ${reason}`,
+  );
+}
+
+/**
+ * Read an operator's operand as the text it has to be.
+ */
+export function filterPolicyText(operand: JSONValue, operator: string): string {
+  if (typeof operand !== "string") {
+    throw simSnsFilterPolicyRefusal(
+      `${operator} takes a string, and this one takes ${JSON.stringify(
+        operand,
+      )}`,
+    );
+  }
+
+  return operand;
+}
+
+/**
+ * Read an operator's operand as the list it has to be.
+ */
+export function filterPolicyList(
+  operand: JSONValue,
+  operator: string,
+): readonly JSONValue[] {
+  if (!Array.isArray(operand)) {
+    throw simSnsFilterPolicyRefusal(
+      `${operator} takes a list, and this one takes ${JSON.stringify(operand)}`,
+    );
+  }
+
+  return operand;
+}
+
+/**
+ * One operator of a match condition, and what it was written against.
+ */
+export interface SimSnsFilterOperator {
+  readonly name: string;
+  readonly operand: JSONValue;
+}
+
+/**
+ * Read a policy value as the object of one operator it has to be.
+ *
+ * Real SNS takes one operator per match condition. Two in one object would be
+ * two rules with no stated relationship between them, so it is refused rather
+ * than resolved by picking the first.
+ */
+export function filterPolicyOperator(value: JSONObject): SimSnsFilterOperator {
+  const entries = Object.entries(value);
+  const [entry] = entries;
+
+  if (entries.length !== 1 || entry === undefined) {
+    throw simSnsFilterPolicyRefusal(
+      `a match condition names one operator, and this one names ` +
+        `${String(entries.length)}: ${JSON.stringify(value)}`,
+    );
+  }
+
+  return { name: entry[0], operand: entry[1] };
+}
+
+/**
+ * Whether a policy value is an object rather than a list or a scalar.
+ */
+export function isFilterPolicyObject(value: JSONValue): value is JSONObject {
+  return isRecord(value);
+}

--- a/src/service/sns/filter/sim-sns-filter-rule.ts
+++ b/src/service/sns/filter/sim-sns-filter-rule.ts
@@ -1,0 +1,15 @@
+import type { SimSnsFilterSubject } from "./sim-sns-filter-subject.js";
+
+/**
+ * One thing a filter policy requires of a message.
+ *
+ * A policy is a set of these, all of which have to hold. There are three: a key
+ * with its match conditions, a nested set of rules under a key of a message
+ * body, and an `$or` of alternatives.
+ */
+export interface SimSnsFilterRule {
+  /**
+   * Whether the message satisfies this rule.
+   */
+  matches(subject: SimSnsFilterSubject): boolean;
+}

--- a/src/service/sns/filter/sim-sns-filter-rules.ts
+++ b/src/service/sns/filter/sim-sns-filter-rules.ts
@@ -1,18 +1,17 @@
 import type { JSONObject, JSONValue } from "../../../util/type-guard/json.js";
+import { SimSnsFilterAnyRule } from "./sim-sns-filter-any-rule.js";
 import { SimSnsFilterKeyRule } from "./sim-sns-filter-key-rule.js";
+import {
+  simSnsOrAlternatives,
+  simSnsOrKey,
+} from "./sim-sns-filter-or-eligibility.js";
 import type { SimSnsFilterPolicyScope } from "./sim-sns-filter-policy-scope.js";
 import {
-  filterPolicyList,
   isFilterPolicyObject,
   simSnsFilterPolicyRefusal,
 } from "./sim-sns-filter-refusals.js";
 import type { SimSnsFilterRule } from "./sim-sns-filter-rule.js";
 import type { SimSnsFilterSubject } from "./sim-sns-filter-subject.js";
-
-/**
- * The key real SNS reads as an OR across separate keys.
- */
-const simSnsOrKey = "$or";
 
 /**
  * Every key of a filter policy, all of which have to match.
@@ -55,58 +54,6 @@ export class SimSnsFilterRules implements SimSnsFilterRule {
 }
 
 /**
- * An `$or` across separate keys, which matches when any of its sides does.
- *
- * Each side is a policy of its own, so `{"$or": [{"type": ["order"]}, {"kind":
- * ["refund"]}]}` matches a message carrying either key. Everything else in a
- * policy is an AND, which is why this needs a key of its own to express.
- */
-class SimSnsFilterAnyRule implements SimSnsFilterRule {
-  private readonly alternatives: readonly SimSnsFilterRules[];
-
-  private constructor(alternatives: readonly SimSnsFilterRules[]) {
-    this.alternatives = alternatives;
-  }
-
-  /**
-   * Read the list of policies an `$or` holds.
-   */
-  static of(
-    written: JSONValue,
-    path: readonly string[],
-    scope: SimSnsFilterPolicyScope,
-  ): SimSnsFilterAnyRule {
-    const alternatives = filterPolicyList(written, simSnsOrKey);
-
-    if (alternatives.length === 0) {
-      throw simSnsFilterPolicyRefusal(`${simSnsOrKey} holds no alternatives`);
-    }
-
-    return new this(
-      alternatives.map((alternative) => {
-        if (!isFilterPolicyObject(alternative)) {
-          throw simSnsFilterPolicyRefusal(
-            `each alternative of ${simSnsOrKey} is a policy of its own, and ` +
-              `this one is ${JSON.stringify(alternative)}`,
-          );
-        }
-
-        return SimSnsFilterRules.of(alternative, path, scope);
-      }),
-    );
-  }
-
-  /**
-   * Whether the message satisfies any one of the alternatives.
-   */
-  matches(subject: SimSnsFilterSubject): boolean {
-    return this.alternatives.some((alternative) =>
-      alternative.matches(subject),
-    );
-  }
-}
-
-/**
  * Read one key of a policy as the rule it states.
  *
  * A list is the match conditions for that key, an object is a nested key, and
@@ -119,7 +66,11 @@ function ruleOf(
   scope: SimSnsFilterPolicyScope,
 ): SimSnsFilterRule {
   if (key === simSnsOrKey) {
-    return SimSnsFilterAnyRule.of(written, path, scope);
+    return new SimSnsFilterAnyRule(
+      simSnsOrAlternatives(written).map((alternative) =>
+        SimSnsFilterRules.of(alternative, path, scope),
+      ),
+    );
   }
 
   if (Array.isArray(written)) {

--- a/src/service/sns/filter/sim-sns-filter-rules.ts
+++ b/src/service/sns/filter/sim-sns-filter-rules.ts
@@ -1,0 +1,160 @@
+import type { JSONObject, JSONValue } from "../../../util/type-guard/json.js";
+import { SimSnsFilterKeyRule } from "./sim-sns-filter-key-rule.js";
+import type { SimSnsFilterPolicyScope } from "./sim-sns-filter-policy-scope.js";
+import {
+  filterPolicyList,
+  isFilterPolicyObject,
+  simSnsFilterPolicyRefusal,
+} from "./sim-sns-filter-refusals.js";
+import type { SimSnsFilterRule } from "./sim-sns-filter-rule.js";
+import type { SimSnsFilterSubject } from "./sim-sns-filter-subject.js";
+
+/**
+ * The key real SNS reads as an OR across separate keys.
+ */
+const simSnsOrKey = "$or";
+
+/**
+ * Every key of a filter policy, all of which have to match.
+ *
+ * This is a rule itself as well as a set of them, because a nested key of a
+ * message body holds another set: `{"customer": {"tier": ["gold"]}}` is a rule
+ * about `customer` whose content is the same thing one level down.
+ */
+export class SimSnsFilterRules implements SimSnsFilterRule {
+  private readonly rules: readonly SimSnsFilterRule[];
+
+  private constructor(rules: readonly SimSnsFilterRule[]) {
+    this.rules = rules;
+  }
+
+  /**
+   * Read one level of a filter policy document.
+   *
+   * The path is where this level sits in the document, which is what a nested
+   * policy is: the key it was nested under, then the key it names.
+   */
+  static of(
+    document: JSONObject,
+    path: readonly string[],
+    scope: SimSnsFilterPolicyScope,
+  ): SimSnsFilterRules {
+    return new this(
+      Object.entries(document).map(([key, value]) =>
+        ruleOf(key, value, path, scope),
+      ),
+    );
+  }
+
+  /**
+   * Whether the message satisfies every key of this level.
+   */
+  matches(subject: SimSnsFilterSubject): boolean {
+    return this.rules.every((rule) => rule.matches(subject));
+  }
+}
+
+/**
+ * An `$or` across separate keys, which matches when any of its sides does.
+ *
+ * Each side is a policy of its own, so `{"$or": [{"type": ["order"]}, {"kind":
+ * ["refund"]}]}` matches a message carrying either key. Everything else in a
+ * policy is an AND, which is why this needs a key of its own to express.
+ */
+class SimSnsFilterAnyRule implements SimSnsFilterRule {
+  private readonly alternatives: readonly SimSnsFilterRules[];
+
+  private constructor(alternatives: readonly SimSnsFilterRules[]) {
+    this.alternatives = alternatives;
+  }
+
+  /**
+   * Read the list of policies an `$or` holds.
+   */
+  static of(
+    written: JSONValue,
+    path: readonly string[],
+    scope: SimSnsFilterPolicyScope,
+  ): SimSnsFilterAnyRule {
+    const alternatives = filterPolicyList(written, simSnsOrKey);
+
+    if (alternatives.length === 0) {
+      throw simSnsFilterPolicyRefusal(`${simSnsOrKey} holds no alternatives`);
+    }
+
+    return new this(
+      alternatives.map((alternative) => {
+        if (!isFilterPolicyObject(alternative)) {
+          throw simSnsFilterPolicyRefusal(
+            `each alternative of ${simSnsOrKey} is a policy of its own, and ` +
+              `this one is ${JSON.stringify(alternative)}`,
+          );
+        }
+
+        return SimSnsFilterRules.of(alternative, path, scope);
+      }),
+    );
+  }
+
+  /**
+   * Whether the message satisfies any one of the alternatives.
+   */
+  matches(subject: SimSnsFilterSubject): boolean {
+    return this.alternatives.some((alternative) =>
+      alternative.matches(subject),
+    );
+  }
+}
+
+/**
+ * Read one key of a policy as the rule it states.
+ *
+ * A list is the match conditions for that key, an object is a nested key, and
+ * `$or` is neither: it names alternatives rather than a key of the message.
+ */
+function ruleOf(
+  key: string,
+  written: JSONValue,
+  path: readonly string[],
+  scope: SimSnsFilterPolicyScope,
+): SimSnsFilterRule {
+  if (key === simSnsOrKey) {
+    return SimSnsFilterAnyRule.of(written, path, scope);
+  }
+
+  if (Array.isArray(written)) {
+    return SimSnsFilterKeyRule.of([...path, key], written);
+  }
+
+  if (isFilterPolicyObject(written)) {
+    return nestedRules(key, written, path, scope);
+  }
+
+  throw simSnsFilterPolicyRefusal(
+    `${[...path, key].join(".")} holds a list of match conditions, and this ` +
+      `one holds ${JSON.stringify(written)}`,
+  );
+}
+
+/**
+ * Read a nested key, which only a message body has.
+ *
+ * Message attributes are a flat set of names, so a policy nesting under that
+ * scope names a key no message could carry. It is refused when the policy is
+ * set rather than left to match nothing.
+ */
+function nestedRules(
+  key: string,
+  written: JSONObject,
+  path: readonly string[],
+  scope: SimSnsFilterPolicyScope,
+): SimSnsFilterRules {
+  if (!scope.allowsNestedKeys) {
+    throw simSnsFilterPolicyRefusal(
+      `${[...path, key].join(".")} is a nested key, and a policy of the ` +
+        `${scope.value} scope matches a flat set of message attributes`,
+    );
+  }
+
+  return SimSnsFilterRules.of(written, [...path, key], scope);
+}

--- a/src/service/sns/filter/sim-sns-filter-string-matching.iso.test.ts
+++ b/src/service/sns/filter/sim-sns-filter-string-matching.iso.test.ts
@@ -1,0 +1,187 @@
+import { assertFalse, assertTrue } from "@kensio/smartass";
+import { describe, it } from "vitest";
+import {
+  simSnsFilterMatchesAttributes,
+  simSnsStringAttribute,
+} from "../../../../test/sns/filter-fixture.js";
+import type { JSONObject } from "../../../util/type-guard/json.js";
+
+/**
+ * Whether a policy matches a message carrying one `type` attribute.
+ */
+function matchesType(policy: JSONObject, type: string): boolean {
+  return simSnsFilterMatchesAttributes(policy, {
+    type: simSnsStringAttribute(type),
+  });
+}
+
+describe("SNS filter policy string matching", () => {
+  it("matches a value the policy names and nothing else", () => {
+    // Given a policy naming one kind of message.
+    const policy = { type: ["order"] };
+
+    // When messages of each kind are matched against it.
+    // Then only the one it names matches, and matching is case sensitive.
+    assertTrue(matchesType(policy, "order"));
+    assertFalse(matchesType(policy, "refund"));
+    assertFalse(matchesType(policy, "Order"));
+  });
+
+  it("reads a list of values as an or", () => {
+    // Given a policy naming two kinds of message.
+    const policy = { type: ["order", "refund"] };
+
+    // When messages of each kind are matched against it.
+    // Then either one matches, since the list is an or.
+    assertTrue(matchesType(policy, "order"));
+    assertTrue(matchesType(policy, "refund"));
+    assertFalse(matchesType(policy, "invoice"));
+  });
+
+  it("requires every key of the policy to match", () => {
+    // Given a policy about two attributes.
+    const policy = { type: ["order"], tenant: ["acme"] };
+
+    // When a message carrying only one of them is matched.
+    const one = simSnsFilterMatchesAttributes(policy, {
+      type: simSnsStringAttribute("order"),
+    });
+    const both = simSnsFilterMatchesAttributes(policy, {
+      type: simSnsStringAttribute("order"),
+      tenant: simSnsStringAttribute("acme"),
+    });
+
+    // Then both keys have to match, since separate keys are an and.
+    assertFalse(one);
+    assertTrue(both);
+  });
+
+  it("matches on the start and the end of a value", () => {
+    // Given a policy about the start of one value and the end of another.
+    const prefixed = { name: [{ prefix: "order-" }] };
+    const suffixed = { name: [{ suffix: ".csv" }] };
+
+    // When names are matched against each.
+    // Then each matches on its own end of the value.
+    assertTrue(
+      simSnsFilterMatchesAttributes(prefixed, {
+        name: simSnsStringAttribute("order-1.csv"),
+      }),
+    );
+    assertFalse(
+      simSnsFilterMatchesAttributes(prefixed, {
+        name: simSnsStringAttribute("refund-1.csv"),
+      }),
+    );
+    assertTrue(
+      simSnsFilterMatchesAttributes(suffixed, {
+        name: simSnsStringAttribute("order-1.csv"),
+      }),
+    );
+    assertFalse(
+      simSnsFilterMatchesAttributes(suffixed, {
+        name: simSnsStringAttribute("order-1.json"),
+      }),
+    );
+  });
+
+  it("matches a value in any case when asked to", () => {
+    // Given a policy matching without regard to case.
+    const policy = { type: [{ "equals-ignore-case": "Order" }] };
+
+    // When values differing only in case are matched.
+    // Then each matches, and a different value still does not.
+    assertTrue(matchesType(policy, "ORDER"));
+    assertTrue(matchesType(policy, "order"));
+    assertFalse(matchesType(policy, "refund"));
+  });
+
+  it("excludes the values an anything-but names", () => {
+    // Given a policy excluding one value and one excluding two.
+    const one = { type: [{ "anything-but": "order" }] };
+    const two = { type: [{ "anything-but": ["order", "refund"] }] };
+
+    // When values are matched against each.
+    // Then everything but the named ones matches.
+    assertFalse(matchesType(one, "order"));
+    assertTrue(matchesType(one, "refund"));
+    assertFalse(matchesType(two, "refund"));
+    assertTrue(matchesType(two, "invoice"));
+  });
+
+  it("excludes on the start, the end and the case of a value", () => {
+    // Given policies excluding by shape rather than by value.
+    const prefixed = { name: [{ "anything-but": { prefix: "order-" } }] };
+    const suffixed = { name: [{ "anything-but": { suffix: ".csv" } }] };
+    const cased = {
+      name: [{ "anything-but": { "equals-ignore-case": "Order" } }],
+    };
+
+    // When names are matched against each.
+    // Then each excludes what the operator inside it would have matched.
+    assertFalse(
+      simSnsFilterMatchesAttributes(prefixed, {
+        name: simSnsStringAttribute("order-1"),
+      }),
+    );
+    assertTrue(
+      simSnsFilterMatchesAttributes(prefixed, {
+        name: simSnsStringAttribute("refund-1"),
+      }),
+    );
+    assertFalse(
+      simSnsFilterMatchesAttributes(suffixed, {
+        name: simSnsStringAttribute("order-1.csv"),
+      }),
+    );
+    assertTrue(
+      simSnsFilterMatchesAttributes(suffixed, {
+        name: simSnsStringAttribute("order-1.json"),
+      }),
+    );
+    assertFalse(
+      simSnsFilterMatchesAttributes(cased, {
+        name: simSnsStringAttribute("ORDER"),
+      }),
+    );
+    assertTrue(
+      simSnsFilterMatchesAttributes(cased, {
+        name: simSnsStringAttribute("orders"),
+      }),
+    );
+  });
+
+  it("asks whether an attribute is there at all", () => {
+    // Given a policy about an attribute being there, and one about it not
+    // being there.
+    const present = { type: [{ exists: true }] };
+    const absent = { type: [{ exists: false }] };
+    const carried = { type: simSnsStringAttribute("order") };
+
+    // When a message carrying the attribute and one without it are matched.
+    // Then each policy matches the one it asks for.
+    assertTrue(simSnsFilterMatchesAttributes(present, carried));
+    assertFalse(simSnsFilterMatchesAttributes(present, {}));
+    assertFalse(simSnsFilterMatchesAttributes(absent, carried));
+    assertTrue(simSnsFilterMatchesAttributes(absent, {}));
+  });
+
+  it("matches nothing at all when the attribute is missing", () => {
+    // Given policies of every other operator.
+    const policies = [
+      { type: ["order"] },
+      { type: [{ prefix: "order" }] },
+      { type: [{ suffix: "order" }] },
+      { type: [{ "equals-ignore-case": "order" }] },
+      { type: [{ "anything-but": "order" }] },
+      { type: [{ numeric: [">", 0] }] },
+    ];
+
+    // When a message carrying no such attribute is matched against each.
+    // Then none of them matches, including the one excluding a value: there is
+    // no value there to be anything but the excluded one.
+    for (const policy of policies) {
+      assertFalse(simSnsFilterMatchesAttributes(policy, {}));
+    }
+  });
+});

--- a/src/service/sns/filter/sim-sns-filter-string-matching.iso.test.ts
+++ b/src/service/sns/filter/sim-sns-filter-string-matching.iso.test.ts
@@ -157,13 +157,25 @@ describe("SNS filter policy string matching", () => {
     const present = { type: [{ exists: true }] };
     const absent = { type: [{ exists: false }] };
     const carried = { type: simSnsStringAttribute("order") };
+    const other = { tenant: simSnsStringAttribute("acme") };
 
-    // When a message carrying the attribute and one without it are matched.
+    // When a message carrying the attribute and one carrying another are
+    // matched.
     // Then each policy matches the one it asks for.
     assertTrue(simSnsFilterMatchesAttributes(present, carried));
-    assertFalse(simSnsFilterMatchesAttributes(present, {}));
+    assertFalse(simSnsFilterMatchesAttributes(present, other));
     assertFalse(simSnsFilterMatchesAttributes(absent, carried));
-    assertTrue(simSnsFilterMatchesAttributes(absent, {}));
+    assertTrue(simSnsFilterMatchesAttributes(absent, other));
+  });
+
+  it("matches nothing at all against a message with no attributes", () => {
+    // Given a policy asking for an attribute to be missing.
+    const absent = { type: [{ exists: false }] };
+
+    // When a message carrying no attributes at all is matched.
+    // Then it does not match, which is what real SNS states: an empty set of
+    // attributes matches no filter policy, including this one.
+    assertFalse(simSnsFilterMatchesAttributes(absent, {}));
   });
 
   it("matches nothing at all when the attribute is missing", () => {

--- a/src/service/sns/filter/sim-sns-filter-subject.ts
+++ b/src/service/sns/filter/sim-sns-filter-subject.ts
@@ -14,6 +14,15 @@ import type { SimSnsFilterValue } from "./sim-sns-filter-value.js";
  */
 export interface SimSnsFilterSubject {
   /**
+   * Whether the message carries nothing at all at this scope.
+   *
+   * A key missing from a message that carries other keys is not the same thing
+   * as a message carrying none, and `{"exists": false}` is the operator that
+   * tells them apart: real SNS matches the first and not the second.
+   */
+  readonly isEmpty: boolean;
+
+  /**
    * Every value held at a key path, which is empty when nothing is held there.
    *
    * A key can hold more than one value: a `String.Array` attribute and a JSON

--- a/src/service/sns/filter/sim-sns-filter-subject.ts
+++ b/src/service/sns/filter/sim-sns-filter-subject.ts
@@ -1,0 +1,23 @@
+import type { SimSnsFilterValue } from "./sim-sns-filter-value.js";
+
+/**
+ * Whatever a filter policy is matched against.
+ *
+ * There are two, because there are two filter policy scopes: the message
+ * attributes of a publish, and the parsed message body. Both answer the same
+ * question, which is what a key holds, so an operator never has to know which
+ * of them it is looking at.
+ *
+ * A key path is a list because a message body nests and a policy under the
+ * `MessageBody` scope names a nested key by nesting itself. Message attributes
+ * are flat, so a path of more than one part finds nothing there.
+ */
+export interface SimSnsFilterSubject {
+  /**
+   * Every value held at a key path, which is empty when nothing is held there.
+   *
+   * A key can hold more than one value: a `String.Array` attribute and a JSON
+   * array both do, and a policy matching any member of one matches the key.
+   */
+  valuesAt(path: readonly string[]): readonly SimSnsFilterValue[];
+}

--- a/src/service/sns/filter/sim-sns-filter-subjects.iso.test.ts
+++ b/src/service/sns/filter/sim-sns-filter-subjects.iso.test.ts
@@ -1,0 +1,56 @@
+import { assertArrayLength, assertIdentical } from "@kensio/smartass";
+import { describe, it } from "vitest";
+import {
+  simSnsStringAttribute,
+  simSnsNumberAttribute,
+} from "../../../../test/sns/filter-fixture.js";
+import { SimSnsMessageAttributes } from "../message/sim-sns-message-attributes.js";
+import { SimSnsAttributeSubject } from "./sim-sns-attribute-subject.js";
+import { SimSnsBodySubject } from "./sim-sns-body-subject.js";
+
+describe("SNS filter policy subjects", () => {
+  it("holds message attributes under their own names and no deeper", () => {
+    // Given the attributes of one publish.
+    const subject = SimSnsAttributeSubject.of(
+      SimSnsMessageAttributes.of({
+        type: simSnsStringAttribute("order"),
+        amount: simSnsNumberAttribute("150"),
+      }),
+    );
+
+    // When they are asked for by name, by nothing, and by a nested path.
+    // Then a name finds its value, and nothing else finds anything: message
+    // attributes are flat, so there is nothing under one.
+    assertIdentical(subject.valuesAt(["type"])[0]?.text, "order");
+    assertIdentical(subject.valuesAt(["amount"])[0]?.numeric, 150);
+    assertArrayLength(subject.valuesAt(["tenant"]), 0);
+    assertArrayLength(subject.valuesAt([]), 0);
+    assertArrayLength(subject.valuesAt(["type", "kind"]), 0);
+  });
+
+  it("holds a message body at the paths it nests", () => {
+    // Given a body with a nested key in it.
+    const subject = SimSnsBodySubject.of(
+      JSON.stringify({ customer: { tier: "gold" }, amount: 150 }),
+    );
+
+    // When paths into it are asked for.
+    // Then each finds what the body holds there, and a path through something
+    // that is not an object finds nothing.
+    assertIdentical(subject.valuesAt(["customer", "tier"])[0]?.text, "gold");
+    assertIdentical(subject.valuesAt(["amount"])[0]?.numeric, 150);
+    assertArrayLength(subject.valuesAt(["customer"]), 0);
+    assertArrayLength(subject.valuesAt(["amount", "currency"]), 0);
+    assertArrayLength(subject.valuesAt(["missing"]), 0);
+  });
+
+  it("holds nothing for a body that is not a JSON object", () => {
+    // Given bodies that are not a JSON object.
+    const text = SimSnsBodySubject.of("order-1");
+    const listed = SimSnsBodySubject.of(JSON.stringify(["order"]));
+
+    // Then neither holds anything at any key, rather than failing to be read.
+    assertArrayLength(text.valuesAt(["type"]), 0);
+    assertArrayLength(listed.valuesAt(["type"]), 0);
+  });
+});

--- a/src/service/sns/filter/sim-sns-filter-subjects.iso.test.ts
+++ b/src/service/sns/filter/sim-sns-filter-subjects.iso.test.ts
@@ -1,4 +1,9 @@
-import { assertArrayLength, assertIdentical } from "@kensio/smartass";
+import {
+  assertArrayLength,
+  assertFalse,
+  assertIdentical,
+  assertTrue,
+} from "@kensio/smartass";
 import { describe, it } from "vitest";
 import {
   simSnsStringAttribute,
@@ -26,6 +31,24 @@ describe("SNS filter policy subjects", () => {
     assertArrayLength(subject.valuesAt(["tenant"]), 0);
     assertArrayLength(subject.valuesAt([]), 0);
     assertArrayLength(subject.valuesAt(["type", "kind"]), 0);
+    assertFalse(subject.isEmpty);
+  });
+
+  it("knows when the message carries nothing at this scope", () => {
+    // Given the attributes of a publish that carried none, and bodies holding
+    // nothing.
+    const noAttributes = SimSnsAttributeSubject.of(
+      SimSnsMessageAttributes.of({}),
+    );
+
+    // Then each says so, which is what `{"exists": false}` needs before it can
+    // match a key that is missing.
+    assertTrue(noAttributes.isEmpty);
+    assertTrue(SimSnsBodySubject.of(JSON.stringify({})).isEmpty);
+    assertTrue(SimSnsBodySubject.of("order-1").isEmpty);
+    assertFalse(
+      SimSnsBodySubject.of(JSON.stringify({ type: "order" })).isEmpty,
+    );
   });
 
   it("holds a message body at the paths it nests", () => {

--- a/src/service/sns/filter/sim-sns-filter-value.ts
+++ b/src/service/sns/filter/sim-sns-filter-value.ts
@@ -1,0 +1,99 @@
+interface SimSnsFilterValueProperties {
+  readonly text: string | undefined;
+  readonly numeric: number | undefined;
+  readonly logical: boolean | undefined;
+}
+
+/**
+ * Read text as the number it spells, if it spells one.
+ *
+ * A message attribute always arrives as text, so a `Number` attribute carries
+ * its digits rather than a number, and something has to turn one into the
+ * other before `numeric` can be asked about it.
+ */
+function numberIn(text: string): number | undefined {
+  const parsed = Number(text);
+
+  if (text.trim() === "" || Number.isNaN(parsed)) {
+    return undefined;
+  }
+
+  return parsed;
+}
+
+/**
+ * One value a subscription filter policy is matched against.
+ *
+ * A value knows which forms it has rather than which form it is, because a
+ * `Number` message attribute has two: the digits it was published as, and the
+ * number those digits spell. A `numeric` operator needs the second and a
+ * `prefix` operator needs the first.
+ *
+ * A form a value does not have matches nothing of that form. That is what keeps
+ * `numeric` from matching a `String` attribute that happens to hold digits,
+ * which is real SNS behaviour: numeric matching is for the `Number` data type.
+ */
+export class SimSnsFilterValue {
+  public readonly text: string | undefined;
+  public readonly numeric: number | undefined;
+  public readonly logical: boolean | undefined;
+
+  private constructor(properties: SimSnsFilterValueProperties) {
+    this.text = properties.text;
+    this.numeric = properties.numeric;
+    this.logical = properties.logical;
+  }
+
+  /**
+   * Text, which is what a `String` attribute and a JSON string both are.
+   */
+  static ofText(value: string): SimSnsFilterValue {
+    return new this({ text: value, numeric: undefined, logical: undefined });
+  }
+
+  /**
+   * A `Number` message attribute, which is text that also means a number.
+   */
+  static ofNumericText(value: string): SimSnsFilterValue {
+    return new this({
+      text: value,
+      numeric: numberIn(value),
+      logical: undefined,
+    });
+  }
+
+  /**
+   * A number, which is what a JSON number in a message body is.
+   */
+  static ofNumber(value: number): SimSnsFilterValue {
+    return new this({ text: undefined, numeric: value, logical: undefined });
+  }
+
+  /**
+   * A boolean, which only a message body can hold: a message attribute has no
+   * boolean data type.
+   */
+  static ofBoolean(value: boolean): SimSnsFilterValue {
+    return new this({ text: undefined, numeric: undefined, logical: value });
+  }
+
+  /**
+   * Whether this value is the one another value holds.
+   *
+   * The form the policy wrote decides how the comparison is made, so a policy
+   * value of `100` matches the number and a policy value of `"100"` matches the
+   * digits. That is what stops a policy naming a number from matching a
+   * `String` attribute spelling the same one.
+   */
+  equals(other: SimSnsFilterValue): boolean {
+    if (this.numeric !== undefined) {
+      return this.numeric === other.numeric;
+    }
+
+    if (this.logical !== undefined) {
+      return this.logical === other.logical;
+    }
+
+    return this.text !== undefined && this.text === other.text;
+  }
+}

--- a/src/service/sns/filter/sim-sns-json-filter-values.ts
+++ b/src/service/sns/filter/sim-sns-json-filter-values.ts
@@ -1,0 +1,32 @@
+import type { JSONValue } from "../../../util/type-guard/json.js";
+import { SimSnsFilterValue } from "./sim-sns-filter-value.js";
+
+/**
+ * Read a piece of JSON as the values a filter policy can match against.
+ *
+ * A scalar is one value, a list is each of its members, and anything else is
+ * nothing to match: an object is a level to go through rather than a value, and
+ * a null holds nothing. A key holding null is therefore a key the policy finds
+ * nothing at, which `{"exists": false}` matches.
+ */
+export function simSnsJsonFilterValues(
+  json: JSONValue,
+): readonly SimSnsFilterValue[] {
+  if (typeof json === "string") {
+    return [SimSnsFilterValue.ofText(json)];
+  }
+
+  if (typeof json === "number") {
+    return [SimSnsFilterValue.ofNumber(json)];
+  }
+
+  if (typeof json === "boolean") {
+    return [SimSnsFilterValue.ofBoolean(json)];
+  }
+
+  if (Array.isArray(json)) {
+    return json.flatMap((member) => simSnsJsonFilterValues(member));
+  }
+
+  return [];
+}

--- a/src/service/sns/index.ts
+++ b/src/service/sns/index.ts
@@ -36,6 +36,14 @@ export { SimSnsFunctionEndpointArn } from "./subscription/sim-sns-function-endpo
 export { SimSnsQueueEndpointArn } from "./subscription/sim-sns-queue-endpoint-arn.js";
 export type { SimSnsSubscriptionEndpoint } from "./subscription/sim-sns-subscription-endpoint.js";
 export type { SimSnsSubscriptionCounts } from "./subscription/sim-sns-subscription-store.js";
+export { SimSnsFilterPolicy } from "./filter/sim-sns-filter-policy.js";
+export {
+  simSnsDefaultFilterPolicyScope,
+  SimSnsFilterPolicyScope,
+  simSnsFilterPolicyScopeOf,
+} from "./filter/sim-sns-filter-policy-scope.js";
+export type { SimSnsFilterSubject } from "./filter/sim-sns-filter-subject.js";
+export { SimSnsFilterValue } from "./filter/sim-sns-filter-value.js";
 export { SimSnsMessageAttributes } from "./message/sim-sns-message-attributes.js";
 export type {
   SimSnsMessageAttributeInput,

--- a/src/service/sns/message/sim-sns-message-attribute.ts
+++ b/src/service/sns/message/sim-sns-message-attribute.ts
@@ -46,7 +46,28 @@ export class SimSnsMessageAttribute {
    * `String` and `Number` and their custom types carry text.
    */
   get isBinary(): boolean {
-    return this.dataType === "Binary" || this.dataType.startsWith("Binary.");
+    return this.hasDataType("Binary");
+  }
+
+  /**
+   * Whether this attribute carries a number.
+   *
+   * A number still arrives as text, since that is all a message attribute
+   * carries. The data type is what says the text means a number, which is what
+   * a filter policy needs before it can compare one numerically.
+   */
+  get isNumber(): boolean {
+    return this.hasDataType("Number");
+  }
+
+  /**
+   * Whether this attribute carries a JSON array of values in its text.
+   *
+   * A filter policy matches any member of one, which is what the data type is
+   * for: `String.Array` is a list rather than a string that looks like one.
+   */
+  get isStringArray(): boolean {
+    return this.hasDataType("String.Array");
   }
 
   /**
@@ -71,5 +92,12 @@ export class SimSnsMessageAttribute {
       Buffer.byteLength(this.dataType, "utf8") +
       this.value.length
     );
+  }
+
+  /**
+   * Whether the data type is one of the four, with or without a custom label.
+   */
+  private hasDataType(base: string): boolean {
+    return this.dataType === base || this.dataType.startsWith(`${base}.`);
   }
 }

--- a/src/service/sns/message/sim-sns-message-attributes.ts
+++ b/src/service/sns/message/sim-sns-message-attributes.ts
@@ -36,6 +36,16 @@ export class SimSnsMessageAttributes {
   }
 
   /**
+   * Each attribute on its own.
+   *
+   * A subscription filter policy reads them one at a time, because what a
+   * policy can match depends on the data type each one declares.
+   */
+  get all(): readonly SimSnsMessageAttribute[] {
+    return this.attributes;
+  }
+
+  /**
    * What these attributes contribute to the size of a publish.
    */
   get byteSize(): number {

--- a/src/service/sns/subscription/sim-sns-requested-subscription-attributes.ts
+++ b/src/service/sns/subscription/sim-sns-requested-subscription-attributes.ts
@@ -1,0 +1,63 @@
+import { SimSnsInvalidParameterException } from "../error/sim-sns.error.js";
+import { assertSimSnsSettableSubscriptionAttribute } from "./sim-sns-subscription-attribute-names.js";
+
+/**
+ * Subscription attributes as a request carries them, which is always as
+ * strings.
+ */
+export type SimSnsSubscriptionAttributeInput = Readonly<
+  Record<string, string | undefined>
+>;
+
+/**
+ * The attributes one request names, with the ones it left out left out.
+ *
+ * Every name is checked as this is read, so a request naming one attribute this
+ * simulation will not take changes none of them.
+ */
+export class SimSnsRequestedSubscriptionAttributes {
+  private readonly named: ReadonlyMap<string, string>;
+
+  constructor(requested: SimSnsSubscriptionAttributeInput) {
+    const named = Object.entries(requested).filter(
+      (entry): entry is [string, string] => entry[1] !== undefined,
+    );
+
+    for (const [name] of named) {
+      assertSimSnsSettableSubscriptionAttribute(name);
+    }
+
+    this.named = new Map(named);
+  }
+
+  /**
+   * What the request set an attribute to, if it named it at all.
+   */
+  value(name: string): string | undefined {
+    return this.named.get(name);
+  }
+
+  /**
+   * Read an attribute the request set to a boolean.
+   *
+   * Real SNS takes the two lower case spellings and refuses everything else, so
+   * a request setting `RawMessageDelivery` to `True` or to `1` is refused
+   * rather than quietly treated as false.
+   */
+  booleanValue(name: string): boolean | undefined {
+    const value = this.value(name);
+
+    if (value === undefined) {
+      return undefined;
+    }
+
+    if (value === "true" || value === "false") {
+      return value === "true";
+    }
+
+    throw new SimSnsInvalidParameterException(
+      `Invalid parameter: AttributeValue: ${name} must be true or false, and ` +
+        `this one is ${value}`,
+    );
+  }
+}

--- a/src/service/sns/subscription/sim-sns-subscription-attribute-changes.ts
+++ b/src/service/sns/subscription/sim-sns-subscription-attribute-changes.ts
@@ -1,0 +1,90 @@
+import { SimSnsFilterPolicy } from "../filter/sim-sns-filter-policy.js";
+import {
+  type SimSnsFilterPolicyScope,
+  simSnsFilterPolicyScopeOf,
+} from "../filter/sim-sns-filter-policy-scope.js";
+import {
+  SimSnsRequestedSubscriptionAttributes,
+  type SimSnsSubscriptionAttributeInput,
+} from "./sim-sns-requested-subscription-attributes.js";
+import {
+  simSnsFilterPolicyAttributeName,
+  simSnsFilterPolicyScopeAttributeName,
+  simSnsRawMessageDeliveryAttributeName,
+} from "./sim-sns-subscription-attribute-names.js";
+
+/**
+ * What one subscription's settable attributes are set to.
+ */
+export interface SimSnsSubscriptionAttributeValues {
+  readonly rawMessageDelivery: boolean;
+  readonly filterPolicy: SimSnsFilterPolicy | undefined;
+  readonly filterPolicyScope: SimSnsFilterPolicyScope;
+}
+
+/**
+ * The scope the subscription ends up with.
+ *
+ * An empty value is how an attribute is cleared, which puts the subscription
+ * back on the default scope.
+ */
+function changedScope(
+  held: SimSnsSubscriptionAttributeValues,
+  named: SimSnsRequestedSubscriptionAttributes,
+): SimSnsFilterPolicyScope {
+  const value = named.value(simSnsFilterPolicyScopeAttributeName);
+
+  if (value === undefined) {
+    return held.filterPolicyScope;
+  }
+
+  return simSnsFilterPolicyScopeOf(value);
+}
+
+/**
+ * The policy the subscription ends up with.
+ *
+ * An empty value takes the policy off the subscription, which puts it back to
+ * receiving everything its topic publishes. A policy already held is read again
+ * when the scope changes, since the scope decides what a policy may say.
+ */
+function changedPolicy(
+  held: SimSnsSubscriptionAttributeValues,
+  named: SimSnsRequestedSubscriptionAttributes,
+  scope: SimSnsFilterPolicyScope,
+): SimSnsFilterPolicy | undefined {
+  const value = named.value(simSnsFilterPolicyAttributeName);
+
+  if (value === undefined) {
+    return held.filterPolicy?.forScope(scope);
+  }
+
+  if (value === "") {
+    return undefined;
+  }
+
+  return SimSnsFilterPolicy.parse(value, scope);
+}
+
+/**
+ * Read a request as the attributes it leaves the subscription with.
+ *
+ * Every attribute the request left out keeps the value it had, and every name
+ * is checked before any value is read, so a request naming one attribute this
+ * simulation will not take changes none of them.
+ */
+export function simSnsChangedSubscriptionAttributes(
+  held: SimSnsSubscriptionAttributeValues,
+  requested: SimSnsSubscriptionAttributeInput,
+): SimSnsSubscriptionAttributeValues {
+  const named = new SimSnsRequestedSubscriptionAttributes(requested);
+  const scope = changedScope(held, named);
+
+  return {
+    rawMessageDelivery:
+      named.booleanValue(simSnsRawMessageDeliveryAttributeName) ??
+      held.rawMessageDelivery,
+    filterPolicy: changedPolicy(held, named, scope),
+    filterPolicyScope: scope,
+  };
+}

--- a/src/service/sns/subscription/sim-sns-subscription-attribute-names.ts
+++ b/src/service/sns/subscription/sim-sns-subscription-attribute-names.ts
@@ -7,25 +7,37 @@ import {
  * Whether the subscription receives the published message on its own rather
  * than wrapped in the SNS envelope.
  *
- * This is the only subscription attribute with behaviour behind it here, and it
- * is the one a consumer breaks on: code written for the envelope reads
- * `JSON.parse(body).Message`, and code written for raw delivery reads `body`.
+ * This is the subscription attribute a consumer breaks on: code written for the
+ * envelope reads `JSON.parse(body).Message`, and code written for raw delivery
+ * reads `body`.
  */
 export const simSnsRawMessageDeliveryAttributeName = "RawMessageDelivery";
 
-const settableAttributeNames = new Set([simSnsRawMessageDeliveryAttributeName]);
+/**
+ * The JSON document saying which messages the subscription wants.
+ */
+export const simSnsFilterPolicyAttributeName = "FilterPolicy";
+
+/**
+ * What part of a published message the filter policy is matched against.
+ */
+export const simSnsFilterPolicyScopeAttributeName = "FilterPolicyScope";
+
+const settableAttributeNames = new Set([
+  simSnsRawMessageDeliveryAttributeName,
+  simSnsFilterPolicyAttributeName,
+  simSnsFilterPolicyScopeAttributeName,
+]);
 
 /**
  * The other attributes real SNS lets a request set on a subscription.
  *
  * Each is refused by name with the reason rather than taken and ignored. A
- * subscription that appeared to accept a `FilterPolicy` would receive every
- * message while a test believed it was filtering, which is exactly the kind of
- * pass that means nothing.
+ * subscription that appeared to accept a `RedrivePolicy` would drop a failed
+ * delivery while a test believed it was keeping it, which is exactly the kind
+ * of pass that means nothing.
  */
 const unsimulatedAttributeNames = new Map<string, string>([
-  ["FilterPolicy", "Subscription filter policies are not simulated."],
-  ["FilterPolicyScope", "Subscription filter policies are not simulated."],
   ["DeliveryPolicy", "Delivery retry policies are not simulated."],
   [
     "RedrivePolicy",

--- a/src/service/sns/subscription/sim-sns-subscription-attributes.ts
+++ b/src/service/sns/subscription/sim-sns-subscription-attributes.ts
@@ -1,38 +1,19 @@
-import { SimSnsInvalidParameterException } from "../error/sim-sns.error.js";
+import type { SimSnsFilterPolicy } from "../filter/sim-sns-filter-policy.js";
 import {
-  assertSimSnsSettableSubscriptionAttribute,
+  simSnsDefaultFilterPolicyScope,
+  type SimSnsFilterPolicyScope,
+} from "../filter/sim-sns-filter-policy-scope.js";
+import type { SimSnsPublishedMessage } from "../message/sim-sns-published-message.js";
+import type { SimSnsSubscriptionAttributeInput } from "./sim-sns-requested-subscription-attributes.js";
+import {
+  simSnsChangedSubscriptionAttributes,
+  type SimSnsSubscriptionAttributeValues,
+} from "./sim-sns-subscription-attribute-changes.js";
+import {
+  simSnsFilterPolicyAttributeName,
+  simSnsFilterPolicyScopeAttributeName,
   simSnsRawMessageDeliveryAttributeName,
 } from "./sim-sns-subscription-attribute-names.js";
-
-/**
- * Subscription attributes as a request carries them, which is always as
- * strings.
- */
-export type SimSnsSubscriptionAttributeInput = Readonly<
-  Record<string, string | undefined>
->;
-
-/**
- * Read the one boolean attribute this simulation holds.
- *
- * Real SNS takes the two lower case spellings and refuses everything else, so a
- * request setting `RawMessageDelivery` to `True` or to `1` is refused rather
- * than quietly treated as false.
- */
-function booleanValue(value: string): boolean {
-  if (value === "true") {
-    return true;
-  }
-
-  if (value === "false") {
-    return false;
-  }
-
-  throw new SimSnsInvalidParameterException(
-    `Invalid parameter: AttributeValue: ${simSnsRawMessageDeliveryAttributeName}` +
-      ` must be true or false, and this one is ${value}`,
-  );
-}
 
 /**
  * The attributes of one simulated subscription that a request can set.
@@ -43,9 +24,13 @@ function booleanValue(value: string): boolean {
  */
 export class SimSnsSubscriptionAttributes {
   public readonly rawMessageDelivery: boolean;
+  public readonly filterPolicy: SimSnsFilterPolicy | undefined;
+  public readonly filterPolicyScope: SimSnsFilterPolicyScope;
 
-  private constructor(rawMessageDelivery: boolean) {
-    this.rawMessageDelivery = rawMessageDelivery;
+  private constructor(values: SimSnsSubscriptionAttributeValues) {
+    this.rawMessageDelivery = values.rawMessageDelivery;
+    this.filterPolicy = values.filterPolicy;
+    this.filterPolicyScope = values.filterPolicyScope;
   }
 
   /**
@@ -53,47 +38,61 @@ export class SimSnsSubscriptionAttributes {
    *
    * Real SNS reports `RawMessageDelivery` as false for a subscription created
    * without it, rather than leaving the attribute out, which is why it is held
-   * rather than being absent until set.
+   * rather than being absent until set. A subscription holds no filter policy
+   * until one is set, and receives everything its topic publishes.
    */
   static defaults(): SimSnsSubscriptionAttributes {
-    return new this(false);
+    return new this({
+      rawMessageDelivery: false,
+      filterPolicy: undefined,
+      filterPolicyScope: simSnsDefaultFilterPolicyScope,
+    });
   }
 
   /**
    * These attributes with a request's changes applied.
-   *
-   * Every name is checked before any value is read, so a request naming one
-   * attribute this simulation will not take changes none of them.
    */
   with(
     requested: SimSnsSubscriptionAttributeInput,
   ): SimSnsSubscriptionAttributes {
-    const named = Object.entries(requested).filter(
-      (entry): entry is [string, string] => entry[1] !== undefined,
+    return new SimSnsSubscriptionAttributes(
+      simSnsChangedSubscriptionAttributes(this, requested),
     );
+  }
 
-    for (const [name] of named) {
-      assertSimSnsSettableSubscriptionAttribute(name);
-    }
-
-    const raw = named.find(
-      ([name]) => name === simSnsRawMessageDeliveryAttributeName,
-    )?.[1];
-
-    if (raw === undefined) {
-      return this;
-    }
-
-    return new SimSnsSubscriptionAttributes(booleanValue(raw));
+  /**
+   * Whether this subscription's filter policy admits a published message.
+   *
+   * A subscription with no policy takes everything its topic publishes, which
+   * is what a subscription without one does on real SNS.
+   */
+  accepts(message: SimSnsPublishedMessage): boolean {
+    return this.filterPolicy?.matches(message) ?? true;
   }
 
   /**
    * Add these attributes to what SNS reports about the subscription.
+   *
+   * The two filter policy attributes are reported only when there is a policy,
+   * as real SNS reports them. A subscription that filters nothing has no scope
+   * to report either, since the scope only says how a policy is read.
    */
   reportInto(reported: Map<string, string>): void {
     reported.set(
       simSnsRawMessageDeliveryAttributeName,
       String(this.rawMessageDelivery),
     );
+
+    if (this.filterPolicy === undefined) {
+      return;
+    }
+
+    reported.set(simSnsFilterPolicyAttributeName, this.filterPolicy.value);
+    reported.set(
+      simSnsFilterPolicyScopeAttributeName,
+      this.filterPolicyScope.value,
+    );
   }
 }
+
+export { type SimSnsSubscriptionAttributeInput } from "./sim-sns-requested-subscription-attributes.js";

--- a/src/service/sns/subscription/sim-sns-subscription.ts
+++ b/src/service/sns/subscription/sim-sns-subscription.ts
@@ -1,3 +1,4 @@
+import type { SimSnsPublishedMessage } from "../message/sim-sns-published-message.js";
 import { SimSnsSubscriptionArn } from "./sim-sns-subscription-arn.js";
 import type {
   SimSnsSubscriptionAttributeInput,
@@ -132,6 +133,17 @@ export class SimSnsSubscription {
    */
   applyAttributes(requested: SimSnsSubscriptionAttributeInput): void {
     this.held = this.held.with(requested);
+  }
+
+  /**
+   * Whether this subscription wants a published message.
+   *
+   * The subscription's filter policy is what decides, so this is asked once per
+   * subscription rather than once per publish: one subscriber filtering a
+   * message out has nothing to do with what another receives.
+   */
+  accepts(message: SimSnsPublishedMessage): boolean {
+    return this.held.accepts(message);
   }
 
   /**

--- a/test/sns/filter-fixture.ts
+++ b/test/sns/filter-fixture.ts
@@ -1,0 +1,113 @@
+/**
+ * One published message and one subscription filter policy, which is all a
+ * question about matching needs.
+ *
+ * This lives under `test/` for the same reasons as `test/sns/topic-fixture.ts`:
+ * eslint rejects a test file that exports helpers alongside its own `describe`
+ * calls, and `test/**` is type-checked with everything else, excluded from the
+ * published build, not collected as a suite, and not counted in coverage.
+ */
+
+import { assertThrowsError } from "@kensio/smartass";
+
+import type { JSONObject } from "../../src/util/type-guard/json.js";
+import type {
+  SimSnsMessageAttributeInput,
+  SimSnsMessageAttributeValue,
+} from "../../src/service/sns/message/sim-sns-message-attribute-value.js";
+import { SimSnsMessageAttributes } from "../../src/service/sns/message/sim-sns-message-attributes.js";
+import { SimSnsPublishedMessage } from "../../src/service/sns/message/sim-sns-published-message.js";
+import { SimSnsSubscriptionAttributes } from "../../src/service/sns/subscription/sim-sns-subscription-attributes.js";
+
+/**
+ * One published message, with whatever a test is asking about on it.
+ */
+export function simSnsPublishedMessage(
+  body: string,
+  attributes: SimSnsMessageAttributeInput = {},
+): SimSnsPublishedMessage {
+  return SimSnsPublishedMessage.of(
+    {
+      message: body,
+      subject: undefined,
+      attributes: SimSnsMessageAttributes.of(attributes),
+    },
+    new Date(),
+  );
+}
+
+/**
+ * A subscription holding one filter policy, of either scope.
+ */
+export function simSnsFilteringSubscription(
+  policy: JSONObject,
+  scope?: string,
+): SimSnsSubscriptionAttributes {
+  return SimSnsSubscriptionAttributes.defaults().with({
+    FilterPolicy: JSON.stringify(policy),
+    ...(scope !== undefined && { FilterPolicyScope: scope }),
+  });
+}
+
+/**
+ * Whether a policy of the default scope matches a message's attributes.
+ */
+export function simSnsFilterMatchesAttributes(
+  policy: JSONObject,
+  attributes: SimSnsMessageAttributeInput,
+): boolean {
+  return simSnsFilteringSubscription(policy).accepts(
+    simSnsPublishedMessage("order-1", attributes),
+  );
+}
+
+/**
+ * Whether a policy of the `MessageBody` scope matches a message body.
+ */
+export function simSnsFilterMatchesBody(
+  policy: JSONObject,
+  body: string,
+): boolean {
+  return simSnsFilteringSubscription(policy, "MessageBody").accepts(
+    simSnsPublishedMessage(body),
+  );
+}
+
+/**
+ * Set a filter policy that will not be taken, answering with what it threw.
+ */
+export function simSnsFilterPolicyRefusal(
+  policy: JSONObject,
+  scope?: string,
+): Error {
+  return assertThrowsError(() => simSnsFilteringSubscription(policy, scope));
+}
+
+/**
+ * Set subscription attributes that will not be taken, answering with what they
+ * threw.
+ */
+export function simSnsSubscriptionAttributeRefusal(
+  requested: Record<string, string>,
+  held = SimSnsSubscriptionAttributes.defaults(),
+): Error {
+  return assertThrowsError(() => held.with(requested));
+}
+
+/**
+ * A `String` message attribute of a value, which is the ordinary case.
+ */
+export function simSnsStringAttribute(
+  value: string,
+): SimSnsMessageAttributeValue {
+  return { DataType: "String", StringValue: value };
+}
+
+/**
+ * A `Number` message attribute, which is the one a numeric match applies to.
+ */
+export function simSnsNumberAttribute(
+  value: string,
+): SimSnsMessageAttributeValue {
+  return { DataType: "Number", StringValue: value };
+}


### PR DESCRIPTION
A subscription with a `FilterPolicy` now receives only the messages its policy matches, over the message attributes of the publish or over the message body read as JSON. The policy is read when it is set, so an operator this simulation cannot apply is refused there rather than accepted and then matching nothing: `cidr` is the one real SNS has that this does not. Filtering is asked of each subscription on its own, above the delivery endpoint, so one subscriber filtering a message out has nothing to do with what another receives, and a second protocol picks it up without another implementation.

Resolves https://github.com/KensioSoftware/yulin/issues/471

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added SNS subscription filter policies for message attributes and JSON message bodies.
  * Added support for exact, numeric, prefix, suffix, case-insensitive, existence, and exclusion matching.
  * Added nested body filtering and configurable filter-policy scopes.
  * SNS fan-out now delivers messages only to subscriptions whose policies match.
  * Added examples demonstrating filtered message delivery.

* **Documentation**
  * Expanded SNS documentation with supported operators, validation rules, limitations, scopes, and examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->