### PR TITLE
feat: invoke a subscribed Lambda function

### DIFF
--- a/docs/services/sns/README.md
+++ b/docs/services/sns/README.md
@@ -5,8 +5,8 @@ every operation is authorized by simulated IAM.
 
 Standard topics only. SNS-specific types are imported from the `@kensio/yulin/sns` subpath.
 
-A message published to a topic is delivered to every queue subscribed to it. Other subscription
-protocols are not simulated.
+A message published to a topic is delivered to every queue subscribed to it, and invokes every Lambda
+function subscribed to it. Other subscription protocols are not simulated.
 
 ## Creating a topic and publishing to it
 
@@ -200,9 +200,9 @@ console.log(published.Failed?.[0]?.Code); // "InvalidParameterValueException"
 
 ## Subscriptions
 
-`Subscribe` with the `sqs` protocol and a queue ARN answers with a subscription ARN straight away.
-There is no confirmation step for that protocol, as there is none on real SNS: the subscription is
-confirmed the moment it exists.
+`Subscribe` with the `sqs` protocol and a queue ARN, or the `lambda` protocol and a function ARN,
+answers with a subscription ARN straight away. There is no confirmation step for either protocol, as
+there is none on real SNS: the subscription is confirmed the moment it exists.
 
 ```typescript sim-sns-subscriptions
 /**
@@ -273,7 +273,12 @@ A subscription ARN is the topic's ARN with an opaque id on the end. That is the 
 subscription: `Unsubscribe`, `GetSubscriptionAttributes` and `SetSubscriptionAttributes` all name one
 by it.
 
-Subscribing the same queue to the same topic twice answers with the subscription that is already
+The endpoint has to be an ARN of the kind the protocol implies, and it is checked when the
+subscription is made: a queue ARN over the `lambda` protocol is refused, as it is on real SNS. A
+qualified function ARN naming a version or an alias is refused too, since simulated Lambda has
+neither and subscribing `$LATEST` instead would be a different function from the one asked for.
+
+Subscribing the same endpoint to the same topic twice answers with the subscription that is already
 there rather than making a second one, as real SNS does. The attributes the repeated request carries
 are not applied to it, the same way a repeated `CreateTopic` leaves the existing topic alone. They
 are still validated, so a repeated request naming an attribute this simulation will not take is
@@ -289,11 +294,11 @@ topic recreated under the same name starts with none.
 
 `GetTopicAttributes` counts the topic's subscriptions in `SubscriptionsConfirmed`, and counts the
 ones that have been unsubscribed in `SubscriptionsDeleted`. `SubscriptionsPending` is always zero,
-because the only protocol simulated is the one that needs no confirmation.
+because neither protocol simulated needs a confirmation.
 
-Only the `sqs` protocol is simulated. Every other protocol real SNS has is refused by name at
-`Subscribe` time with the reason it is missing, rather than creating a subscription that would never
-be delivered to.
+Only the `sqs` and `lambda` protocols are simulated. Every other protocol real SNS has is refused by
+name at `Subscribe` time with the reason it is missing, rather than creating a subscription that
+would never be delivered to.
 
 ## Delivering to a queue
 
@@ -439,6 +444,136 @@ attribute travels base64 encoded, since the envelope is JSON.
 With `RawMessageDelivery` set to `true` on the subscription, the body is the published `Message` on
 its own and the published message attributes arrive as SQS message attributes instead. Both matter,
 because a consumer written for one breaks on the other.
+
+## Delivering to a Lambda function
+
+Subscribing a function with the `lambda` protocol invokes it once per published message, with the SNS
+event shape. The function's resource policy has to allow `sns.amazonaws.com` to invoke it for the
+topic, which is what `AddPermission` grants:
+
+```typescript sim-sns-lambda-delivery
+/**
+ * Invoking a simulated Lambda function from a simulated topic.
+ */
+
+import {
+  AddPermissionCommand,
+  CreateFunctionCommand,
+} from "@aws-sdk/client-lambda";
+import {
+  CreateTopicCommand,
+  PublishCommand,
+  SubscribeCommand,
+} from "@aws-sdk/client-sns";
+import { SimAws } from "@kensio/yulin";
+import { makeLambdaZipFileInput } from "@kensio/yulin/lambda";
+
+interface SnsRecord {
+  EventSource: string;
+  Sns: { Subject: string | null; Message: string };
+}
+
+const simAws = new SimAws();
+const sns = simAws.sns();
+const consumerArn = `arn:aws:lambda:${simAws.defaultRegionName}:${simAws.defaultAccountId}:function:order-consumer`;
+
+const { TopicArn } = await sns.createTopic(
+  new CreateTopicCommand({ Name: "orders" }),
+);
+
+await simAws.lambda().createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "order-consumer",
+    Role: `arn:aws:iam::${simAws.defaultAccountId}:role/OrderConsumerRole`,
+    Code: {
+      ZipFile: makeLambdaZipFileInput((event: { Records: [SnsRecord] }) => {
+        const [record] = event.Records;
+
+        console.log(record.EventSource); // "aws:sns"
+        console.log(record.Sns.Subject); // "New order"
+        console.log(record.Sns.Message); // "order-1"
+
+        return "handled";
+      }),
+    },
+  }),
+);
+
+// The function's resource policy is what allows the invocation, and it is
+// checked on every message rather than remembered from subscribe time.
+await simAws.lambda().addPermission(
+  new AddPermissionCommand({
+    FunctionName: "order-consumer",
+    StatementId: "AllowSns",
+    Action: "lambda:InvokeFunction",
+    Principal: "sns.amazonaws.com",
+    SourceArn: TopicArn,
+  }),
+);
+
+// A lambda subscription needs no confirmation either, so the ARN comes back at
+// once.
+await sns.subscribe(
+  new SubscribeCommand({ TopicArn, Protocol: "lambda", Endpoint: consumerArn }),
+);
+
+await sns.publish(
+  new PublishCommand({ TopicArn, Subject: "New order", Message: "order-1" }),
+);
+
+// The invocation happens after the publish is answered, as it does on real SNS.
+await simAws.backgroundTasksComplete();
+```
+
+The permission is checked on every message rather than remembered from subscribe time, so one taken
+away afterwards stops delivery. Nothing checks the function at `Subscribe` time, as nothing checks
+the queue: a subscription to a function that does not exist, or to one whose policy says no, is
+created and fails when a message is delivered to it. Both failures are recorded on
+`simAws.sns().deliveryFailures` the same way a queue's are, and a handler that throws is recorded
+there too without stopping delivery to the topic's other subscriptions.
+
+A function in another account or another region is invoked the same way, on that account's own
+resource policy.
+
+## The event a Lambda function receives
+
+`Records` always holds exactly one entry, even when the message came from a `PublishBatch`. Real SNS
+does not batch to Lambda: each published message is its own invocation, so a handler looping over
+`Records` sees one message per call.
+
+```json
+{
+  "Records": [
+    {
+      "EventSource": "aws:sns",
+      "EventVersion": "1.0",
+      "EventSubscriptionArn": "arn:aws:sns:us-east-1:888888888888:orders:8f1c...",
+      "Sns": {
+        "Type": "Notification",
+        "MessageId": "0f2a0a49-9e3f-4d02-9e5f-2d9f0e5b6d51",
+        "TopicArn": "arn:aws:sns:us-east-1:888888888888:orders",
+        "Subject": "New order",
+        "Message": "order-1",
+        "Timestamp": "2026-01-01T00:00:00.000Z",
+        "SignatureVersion": "1",
+        "Signature": "...",
+        "SigningCertUrl": "https://sns.us-east-1.yulin.invalid/SimulatedNotificationService-....pem",
+        "UnsubscribeUrl": "https://sns.us-east-1.yulin.invalid/?Action=Unsubscribe&SubscriptionArn=...",
+        "MessageAttributes": { "tenant": { "Type": "String", "Value": "acme" } }
+      }
+    }
+  ]
+}
+```
+
+Two fields are spelled differently from the envelope a queue receives, and the difference is real SNS
+behaviour worth writing a consumer against: the envelope has `SigningCertURL` and `UnsubscribeURL`,
+and the Lambda event has `SigningCertUrl` and `UnsubscribeUrl`. `Subject` and `MessageAttributes` are
+always present here as well, carrying `null` and `{}` when the publish had neither, where the
+envelope leaves both out.
+
+`RawMessageDelivery` has no effect on a `lambda` subscription. Real SNS treats it as an SQS and HTTP
+setting, so a function is invoked with the whole event whether it is set or not.
 
 ## Verifying a message signature
 
@@ -793,14 +928,19 @@ Sim SNS currently supports:
 - `GetTopicAttributesCommand` and `SetTopicAttributesCommand`, for `DisplayName` and `Policy`
 - `PublishCommand` and `PublishBatchCommand`, with message attributes, a subject and the 256 KB size
   limit
-- `SubscribeCommand` over the `sqs` protocol, confirmed at once, and `UnsubscribeCommand`
+- `SubscribeCommand` over the `sqs` and `lambda` protocols, confirmed at once, and
+  `UnsubscribeCommand`
 - `ListSubscriptionsCommand` and `ListSubscriptionsByTopicCommand`, paged at a hundred subscriptions
   with a `NextToken`
 - `GetSubscriptionAttributesCommand` and `SetSubscriptionAttributesCommand`, for `RawMessageDelivery`
 - Delivery of a published message to every subscribed queue, including a queue in another account or
   another region, authorized by that queue's own policy on every message
+- Invocation of every subscribed Lambda function, including a function in another account or another
+  region, authorized by that function's own resource policy on every message
 - The SNS envelope, with a real RSA signature a verifier can check against the certificate the
   message names, and `RawMessageDelivery` for the published message on its own
+- The SNS Lambda event, with one `Records` entry per published message and the message attributes in
+  it
 - Authorization of every operation by simulated IAM, against the real IAM action and topic ARN
 - The `Policy` attribute as the topic's resource policy, admitting another account's principal or a
   service principal, with `aws:SourceArn` and `aws:SourceAccount` conditions honoured
@@ -811,9 +951,16 @@ Sim SNS currently supports:
 
 Current documented limitations:
 
-- Only the `sqs` subscription protocol is simulated, so a queue is the only thing a topic can deliver
-  to. `lambda`, `http`, `https`, `email`, `email-json`, `sms`, `application` and `firehose` are
-  refused at `Subscribe` time.
+- Only the `sqs` and `lambda` subscription protocols are simulated, so a queue and a function are the
+  only things a topic can deliver to. `http`, `https`, `email`, `email-json`, `sms`, `application`
+  and `firehose` are refused at `Subscribe` time.
+- A subscribed function is invoked with `Subject: null` and `MessageAttributes: {}` where the publish
+  had neither, which is what real SNS sends. The envelope a queue receives leaves both fields out.
+- `RawMessageDelivery` is accepted on a `lambda` subscription and has no effect on it, as it has none
+  on real SNS.
+- A qualified function ARN naming a version or an alias is refused as a subscription endpoint.
+  Simulated Lambda has no versions or aliases, so subscribing `$LATEST` instead would be a different
+  function from the one named.
 - `SigningCertURL` and `UnsubscribeURL` name `sns.<region>.yulin.invalid` rather than
   `sns.<region>.amazonaws.com`, and neither can be fetched: simulated SNS is not served over HTTP.
   The certificate is handed out in process by `simAws.sns().signingCertificate(url)`. A real SNS
@@ -821,13 +968,13 @@ Current documented limitations:
   fetches the URL itself, so it cannot verify a simulated message as it stands. Verify with
   `node:crypto` against the certificate the simulator hands over instead.
 - A delivery failure is not reported to the publisher, as it is not on real SNS. It is recorded on
-  `simAws.sns().deliveryFailures`, and anything other than a queue policy refusal is also warned
+  `simAws.sns().deliveryFailures`, and anything other than an endpoint policy refusal is also warned
   about once on the console.
 - Delivery retry policies, subscription dead-letter queues and delivery status logging are not
   simulated, so a message an endpoint would not take is delivered once and recorded as a failure
   rather than retried.
-- `ConfirmSubscription` is not supported. The only protocol simulated needs no confirmation, so
-  there is no confirmation token to confirm.
+- `ConfirmSubscription` is not supported. Neither protocol simulated needs a confirmation, so there
+  is no confirmation token to confirm.
 - Subscription filter policies are not simulated, so `FilterPolicy` and `FilterPolicyScope` are
   refused rather than held and never applied.
 - Subscription delivery retry policies, subscription dead-letter queues and message replay are not
@@ -842,7 +989,7 @@ Current documented limitations:
   `FifoThroughputScope` and `ContentBasedDeduplication` attributes, and the `MessageGroupId` and
   `MessageDeduplicationId` publish inputs.
 - `MessageStructure` is refused. A `json` structure picks a different message body per protocol, and
-  none of those protocols is simulated, so it would be a body chosen by a rule that never ran.
+  picking one is not simulated, so it would be a body chosen by a rule that never ran.
 - Publishing to a `TargetArn` or a `PhoneNumber` is refused. Mobile application endpoints and SMS are
   not simulated, so only a `TopicArn` can be published to.
 - Message attributes count against the 256 KB publish limit alongside the message body, as they do on

--- a/docs/services/sns/sim-sns-lambda-delivery.example.ts
+++ b/docs/services/sns/sim-sns-lambda-delivery.example.ts
@@ -1,0 +1,71 @@
+/**
+ * Invoking a simulated Lambda function from a simulated topic.
+ */
+
+import {
+  AddPermissionCommand,
+  CreateFunctionCommand,
+} from "@aws-sdk/client-lambda";
+import {
+  CreateTopicCommand,
+  PublishCommand,
+  SubscribeCommand,
+} from "@aws-sdk/client-sns";
+import { SimAws } from "@kensio/yulin";
+import { makeLambdaZipFileInput } from "@kensio/yulin/lambda";
+
+interface SnsRecord {
+  EventSource: string;
+  Sns: { Subject: string | null; Message: string };
+}
+
+const simAws = new SimAws();
+const sns = simAws.sns();
+const consumerArn = `arn:aws:lambda:${simAws.defaultRegionName}:${simAws.defaultAccountId}:function:order-consumer`;
+
+const { TopicArn } = await sns.createTopic(
+  new CreateTopicCommand({ Name: "orders" }),
+);
+
+await simAws.lambda().createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "order-consumer",
+    Role: `arn:aws:iam::${simAws.defaultAccountId}:role/OrderConsumerRole`,
+    Code: {
+      ZipFile: makeLambdaZipFileInput((event: { Records: [SnsRecord] }) => {
+        const [record] = event.Records;
+
+        console.log(record.EventSource); // "aws:sns"
+        console.log(record.Sns.Subject); // "New order"
+        console.log(record.Sns.Message); // "order-1"
+
+        return "handled";
+      }),
+    },
+  }),
+);
+
+// The function's resource policy is what allows the invocation, and it is
+// checked on every message rather than remembered from subscribe time.
+await simAws.lambda().addPermission(
+  new AddPermissionCommand({
+    FunctionName: "order-consumer",
+    StatementId: "AllowSns",
+    Action: "lambda:InvokeFunction",
+    Principal: "sns.amazonaws.com",
+    SourceArn: TopicArn,
+  }),
+);
+
+// A lambda subscription needs no confirmation either, so the ARN comes back at
+// once.
+await sns.subscribe(
+  new SubscribeCommand({ TopicArn, Protocol: "lambda", Endpoint: consumerArn }),
+);
+
+await sns.publish(
+  new PublishCommand({ TopicArn, Subject: "New order", Message: "order-1" }),
+);
+
+// The invocation happens after the publish is answered, as it does on real SNS.
+await simAws.backgroundTasksComplete();

--- a/src/service/aws/factory/sim-aws-account-region-service-builder.ts
+++ b/src/service/aws/factory/sim-aws-account-region-service-builder.ts
@@ -27,7 +27,7 @@ import { SimS3 } from "../../s3/sim-s3.js";
 import { simAwsS3NotificationDestinations } from "./sim-aws-s3-notification-destinations.js";
 import { SimSecretsManager } from "../../secretsmanager/index.js";
 import { SimSns } from "../../sns/index.js";
-import { SimAwsSnsDeliveryQueues } from "../../sns/delivery/sqs/sim-aws-sns-delivery-queues.js";
+import { SimAwsSnsDeliveryEndpoints } from "../../sns/delivery/sim-aws-sns-delivery-endpoints.js";
 import { SimSqs } from "../../sqs/index.js";
 import { SimSsm } from "../../ssm/index.js";
 import { SimSts } from "../../sts/sim-sts.js";
@@ -239,15 +239,14 @@ export class SimAwsAccountRegionServiceBuilder {
    * Create simulated SNS for an Account Region scope.
    *
    * Topics are Region-scoped on real AWS: a topic ARN names the Region. Where a
-   * subscription delivers is not, since real SNS delivers to a queue in any
-   * Account or Region, so the endpoints come from the whole simulation and are
-   * resolved on delivery rather than here.
+   * subscription delivers is not, since real SNS delivers to a queue or function
+   * in any Account or Region, so the endpoints come from the whole simulation
+   * and are resolved on delivery rather than here.
    */
   createSns(scope: SimAwsAccountRegionContainer): SimSns {
-    return new SimSns({
-      ...this.scoped(scope),
-      deliveryEndpoints: new SimAwsSnsDeliveryQueues({ simAws: this.simAws }),
-    });
+    const endpoints = new SimAwsSnsDeliveryEndpoints({ simAws: this.simAws });
+
+    return new SimSns({ ...this.scoped(scope), deliveryEndpoints: endpoints });
   }
 
   /**

--- a/src/service/sns/README.md
+++ b/src/service/sns/README.md
@@ -59,23 +59,29 @@ Subscription state lives under `subscription/`.
 
 `SimSnsSubscription` is the stored resource: its ARN, the topic it belongs to, its protocol, its
 endpoint, the Account owning it, and its attributes. The endpoint is held as a
-`SimSnsQueueEndpointArn` rather than as a string, because `sqs` is the only protocol accepted and a
-delivery reaches the Account and Region that ARN names rather than the topic's. When another protocol
-arrives, this becomes the endpoint of whichever kind the protocol implies.
+`SimSnsSubscriptionEndpoint` rather than as a string, because a delivery reaches the Account and
+Region that ARN names rather than the topic's. Which kind of ARN it has to be is the protocol's
+question, answered by `requireSimSnsSubscriptionEndpoint`: `SimSnsQueueEndpointArn` for `sqs`, and
+`SimSnsFunctionEndpointArn` for `lambda`. Reading a function ARN is Lambda's own business, so those
+parts come from `parseSimLambdaFunctionArn`; what SNS adds is what an unreadable one means to a
+`Subscribe` request. A qualified function ARN naming a version or an alias is refused, since
+simulated Lambda has neither and delivering to `$LATEST` instead would be the wrong function.
 
-Nothing checks that the endpoint queue exists when a subscription is created, because real SNS does
-not either: a subscription to a queue that is not there is created, and fails when something is
-delivered to it. The queue's policy is not consulted here either, for the same reason. Both are
-delivery-time questions, which is what makes a permission taken away afterwards stop delivery.
+Nothing checks that the endpoint queue or function exists when a subscription is created, because
+real SNS does not either: a subscription to something that is not there is created, and fails when
+something is delivered to it. The endpoint's own policy is not consulted here either, for the same
+reason. Both are delivery-time questions, which is what makes a permission taken away afterwards stop
+delivery.
 
 `SimSnsSubscriptionArn` mints an ARN, which is the topic's with an opaque id added as a seventh part,
 and `parseSnsSubscriptionArn` reads one. Counting the colon separated parts is what tells a
 subscription ARN from a topic ARN, since neither has a resource type separator.
 
-`SimSnsSubscriptionProtocol` holds the one protocol delivery is simulated over. Every other protocol
-real SNS has is refused by name with the reason it is missing, rather than accepted as a subscription
-that would never be delivered to. A protocol real SNS does not have at all is refused the way real
-SNS refuses one.
+`SimSnsSubscriptionProtocol` holds the two protocols delivery is simulated over, `sqs` and `lambda`.
+Neither needs a confirmation, which is why `ConfirmSubscription` is not implemented. Every other
+protocol real SNS has is refused by name with the reason it is missing, rather than accepted as a
+subscription that would never be delivered to. A protocol real SNS does not have at all is refused
+the way real SNS refuses one.
 
 `SimSnsSubscriptionAttributes` holds `RawMessageDelivery` and nothing else, and
 `SimSnsSubscriptionAttributeNames` is where the refusal of the rest is decided. Applying a request
@@ -119,25 +125,56 @@ the background scheduler, because real SNS answers a publish before anything is 
 `simAws.backgroundTasksComplete()` is what waits for it. A failure is recorded on
 `SimSnsDeliveryFailures` rather than thrown, since a background task left rejected would fail an
 unrelated `backgroundTasksComplete()`, and real SNS never reports a delivery failure to the publisher.
-A queue policy refusal is recorded quietly, because that is a modelled outcome a test may be asking
-for; anything else is also warned about once, because it is a fault.
+An endpoint policy refusal is recorded quietly, because that is a modelled outcome a test may be
+asking for; anything else is also warned about once, because it is a fault.
 
-`SimSnsEnvelope` is the JSON document a subscription receives unless it asked for raw delivery. It
-also builds the string real SNS signs, which is the signed fields in alphabetical order, each one its
-name and its value followed by a newline. Message attributes are not signed, here or on real AWS.
+`SimSnsNotification` is one published message as every destination's document carries it, signed
+once. `simSnsCanonicalMessage` builds the string real SNS signs, which is the signed fields in
+alphabetical order, each one its name and its value followed by a newline. That order is the
+declaration order of `SimSnsSignedValues`, since an object keeps the order its keys were written in.
+Message attributes are not signed, here or on real AWS.
 
-`SimSnsDeliveryEndpoints` is where a message goes. There is one implementation, for a queue, because
-`sqs` is the only protocol simulated: a second protocol adds a second implementation rather than a
-branch in this one. `SimAwsSnsDeliveryQueues` resolves the queue when a message is delivered, never
-when it is built, for the same reason S3's notification destinations do it that way. A queue in
-another Account or Region is reachable, since real SNS delivers to both. That is a deliberate
-difference from simulated S3 event notifications, which require the destination queue to be in the
-Bucket's Region because real S3 does.
+The two documents are built from those fields rather than from each other. `SimSnsEnvelope` is what a
+queue receives unless it asked for raw delivery, and `simSnsLambdaEventDocument` is what a function is
+invoked with. They differ in more than nesting: the envelope has `SigningCertURL` and `UnsubscribeURL`
+where the Lambda event has `SigningCertUrl` and `UnsubscribeUrl`, and the envelope leaves out an
+absent subject and an empty attribute set where the Lambda event carries `null` and `{}`. All of that
+is real SNS behaviour rather than an oversight, which is why the fields are held under names that are
+neither document's.
+
+`SimSnsDeliveryEndpoints` is where a message goes. There is one implementation per protocol, because
+what a destination is asked before it takes a message and what it is handed both differ by protocol:
+a second protocol adds a second implementation rather than a branch in an existing one.
+`SimSnsProtocolDeliveryEndpoints` picks between them by the subscription's protocol, holding them in
+a record keyed by the protocol union so that adding a protocol without somewhere to deliver fails to
+compile. `SimAwsSnsDeliveryEndpoints` is that set for one simulated AWS instance.
+
+`SimAwsSnsDeliveryQueues` and `SimAwsSnsDeliveryFunctions` resolve the endpoint when a message is
+delivered, never when they are built, for the same reason S3's notification destinations do it that
+way. A queue or a function in another Account or Region is reachable, since real SNS delivers to
+both. That is a deliberate difference from simulated S3 event notifications, which require the
+destination queue to be in the Bucket's Region because real S3 does.
 
 `SimSnsDeliveryQueue` asks the queue's own Account two questions: whether `sns.amazonaws.com` may
 send to it for this topic, through `SimSqsServiceSendAuthorizer`, and then to send. The send goes
 through the ordinary `SendMessage` path, so a delivered message is the same thing an SDK caller would
-have sent, and is authorized again on the way in.
+have sent, and is authorized again on the way in. `SimSnsQueueMessage` is what it sends, which is the
+envelope unless the subscription asked for raw delivery. That question is asked here rather than in
+the fan-out because `RawMessageDelivery` is an SQS and HTTP protocol setting on real SNS: a function
+subscribed with it on is invoked with the whole event all the same.
+
+`SimSnsDeliveryFunction` asks the function's own Account the same two questions, through
+`SimLambdaServiceInvokeAuthorizer`, which is where whether a service may invoke a function is decided
+for every service that invokes one. The function is then invoked directly rather than through an
+`Invoke` command, because SNS is already inside the background task standing for the asynchronous
+invocation real SNS makes, and because a handler failure has to reach the delivery outcome rather
+than being swallowed as an asynchronous invocation error. A handler that throws is one delivery
+failure and leaves the topic's other subscriptions alone, since each delivery is its own background
+task.
+
+`Records` in a Lambda event always holds exactly one entry, even for a `PublishBatch`. Real SNS does
+not batch to Lambda: each published message is its own asynchronous invocation, and the fan-out
+already schedules one delivery per message per subscription.
 
 `SimSnsMessageSigner` owns the key pair, which belongs to the scope rather than to a topic: real SNS
 signs every message a Region sends with one certificate. It is generated on first use, because
@@ -244,8 +281,14 @@ here, it does not make another Account's topics reachable through this one.
 
 ## Divergences worth knowing
 
-- Only the `sqs` subscription protocol is simulated, so a queue is the only thing a topic delivers
-  to. `ConfirmSubscription` is not implemented, since that protocol needs no confirmation.
+- Only the `sqs` and `lambda` subscription protocols are simulated, so a queue and a function are the
+  only things a topic delivers to. `ConfirmSubscription` is not implemented, since neither protocol
+  needs a confirmation.
+- A Lambda event carries `Subject: null` and `MessageAttributes: {}` where there is nothing to put in
+  either, which is what real SNS sends. The envelope a queue receives leaves both fields out instead.
+- `RawMessageDelivery` is accepted on a `lambda` subscription and has no effect on it, as it has none
+  on real SNS: it is an SQS and HTTP protocol setting, and a function is invoked with the whole event
+  either way.
 - `SigningCertURL` and `UnsubscribeURL` name `sns.<region>.yulin.invalid`, and neither is served.
   The certificate is handed out in process by `SimSns.signingCertificate`. A real verifier such as
   `sns-validator` hard-codes an `amazonaws.com` certificate host and fetches the URL itself, so it
@@ -273,7 +316,7 @@ here, it does not make another Account's topics reachable through this one.
 - Tags, data protection policies and encryption are refused rather than ignored, whether by
   `CreateTopic` or by `SetTopicAttributes`.
 - `MessageStructure` is refused, because a `json` structure picks a different body per protocol and
-  none of those protocols is simulated.
+  picking one is not simulated.
 - Publishing to a `TargetArn` or a `PhoneNumber` is refused. Only topics are simulated.
 - `AddPermission` and `RemovePermission`, which are shorthands for writing one statement of the topic
   policy, are not implemented. The policy is set through the `Policy` attribute only.

--- a/src/service/sns/command/subscription/sim-sns-subscription-commands.ts
+++ b/src/service/sns/command/subscription/sim-sns-subscription-commands.ts
@@ -38,8 +38,8 @@ export class SimSnsSubscriptionCommands {
    *
    * The subscription comes back confirmed, with an ARN rather than the `pending
    * confirmation` a protocol needing a confirmation token answers with. Real
-   * SNS confirms an `sqs` subscription itself, and that is the only protocol
-   * simulated.
+   * SNS confirms an `sqs` and a `lambda` subscription itself, and those are the
+   * protocols simulated.
    */
   subscribe(
     command: SimSubscribeCommand,
@@ -108,11 +108,6 @@ export class SimSnsSubscriptionCommands {
    * however many times it subscribed. The attributes the repeated request
    * carries are not applied, which is how a repeated `CreateTopic` treats its
    * attributes too.
-   *
-   * Only the endpoint is compared. Real SNS matches on the protocol as well,
-   * and there is one protocol here, so two subscriptions of the same endpoint
-   * are necessarily of the same protocol. That comparison goes back in when a
-   * second protocol arrives.
    */
   private existingLike(
     topic: SimSnsTopic,
@@ -120,6 +115,6 @@ export class SimSnsSubscriptionCommands {
   ): SimSnsSubscription | undefined {
     return this.subscriptions
       .forTopic(topic.name.value)
-      .find((held) => held.endpoint.value === subscription.endpoint.value);
+      .find((held) => held.repeats(subscription));
   }
 }

--- a/src/service/sns/delivery/lambda/sim-aws-sns-delivery-functions.ts
+++ b/src/service/sns/delivery/lambda/sim-aws-sns-delivery-functions.ts
@@ -1,0 +1,45 @@
+import type { SimAws } from "../../../aws/sim-aws.js";
+import { SimSnsFunctionEndpointArn } from "../../subscription/sim-sns-function-endpoint-arn.js";
+import type {
+  SimSnsDeliveryEndpoints,
+  SimSnsDeliveryRequest,
+} from "../sim-sns-delivery.js";
+import { SimSnsDeliveryFunction } from "./sim-sns-delivery-function.js";
+
+interface SimAwsSnsDeliveryFunctionsProperties {
+  readonly simAws: SimAws;
+}
+
+/**
+ * The simulated Lambda functions of one simulated AWS instance, as places a
+ * topic delivers to.
+ *
+ * The function is looked up when a message is delivered, never when this is
+ * built, for the same reason the delivery queues do it that way: reaching
+ * another service while this one is being constructed is a cycle with no bottom
+ * to it.
+ *
+ * A function in another Account or another Region is allowed, since real SNS
+ * invokes both.
+ */
+export class SimAwsSnsDeliveryFunctions implements SimSnsDeliveryEndpoints {
+  private readonly simAws: SimAws;
+
+  constructor(properties: SimAwsSnsDeliveryFunctionsProperties) {
+    this.simAws = properties.simAws;
+  }
+
+  /**
+   * Deliver one message to the function its subscription's endpoint names.
+   */
+  async deliver(request: SimSnsDeliveryRequest): Promise<void> {
+    const arn = SimSnsFunctionEndpointArn.parse(
+      request.subscription.endpoint.value,
+    );
+
+    await new SimSnsDeliveryFunction({
+      arn,
+      scope: this.simAws.accountRegionScope(arn.accountId, arn.regionName),
+    }).deliver(request);
+  }
+}

--- a/src/service/sns/delivery/lambda/sim-sns-delivery-function.ts
+++ b/src/service/sns/delivery/lambda/sim-sns-delivery-function.ts
@@ -1,0 +1,83 @@
+import type { SimAwsAccountRegionContainer } from "../../../aws/sim-aws-account-region-scope.js";
+import { SimLambdaServiceInvokeAuthorizer } from "../../../lambda/command/authorize/sim-lambda-service-invoke-authorizer.js";
+import { SimSnsDeliveryNotPermitted } from "../../error/sim-sns-delivery.error.js";
+import { SimSnsNotFoundException } from "../../error/sim-sns.error.js";
+import type { SimSnsFunctionEndpointArn } from "../../subscription/sim-sns-function-endpoint-arn.js";
+import {
+  type SimSnsDeliveryRequest,
+  simSnsDeliverySource,
+  simSnsServicePrincipal,
+} from "../sim-sns-delivery.js";
+import { simSnsLambdaEventDocument } from "./sim-sns-lambda-event.js";
+
+interface SimSnsDeliveryFunctionProperties {
+  readonly arn: SimSnsFunctionEndpointArn;
+  readonly scope: SimAwsAccountRegionContainer;
+}
+
+/**
+ * One function a simulated topic is delivering to, in the Account and Region
+ * its ARN names.
+ *
+ * Everything is asked of the function's own Account, which is what makes a
+ * function in another Account reachable: its resource policy is the grant, and
+ * its Account's IAM is what evaluates it.
+ */
+export class SimSnsDeliveryFunction {
+  private readonly arn: SimSnsFunctionEndpointArn;
+  private readonly scope: SimAwsAccountRegionContainer;
+
+  constructor(properties: SimSnsDeliveryFunctionProperties) {
+    this.arn = properties.arn;
+    this.scope = properties.scope;
+  }
+
+  /**
+   * Invoke the function with the event, if it still admits SNS for this topic.
+   *
+   * The resource policy is consulted on every delivery rather than remembered
+   * from the moment the subscription was made, so a permission taken away
+   * afterwards stops delivery. Real SNS does not check it at `Subscribe` time
+   * at all, which is why this is the only place it is asked.
+   */
+  async deliver(request: SimSnsDeliveryRequest): Promise<void> {
+    const source = simSnsDeliverySource(request);
+    const endpointArn = request.subscription.endpoint.value;
+    const simFunction = this.scope
+      .lambda()
+      .getSimFunctionByName(this.arn.functionName);
+
+    if (simFunction === undefined) {
+      // Not a refusal: the resource policy said nothing, because there is no
+      // function. A subscription pointing at nothing is a mistake worth
+      // warning about, where a policy saying no is a modelled outcome a test
+      // may be asking for on purpose.
+      throw new SimSnsNotFoundException(
+        `${endpointArn} is not a simulated Lambda function.`,
+      );
+    }
+
+    const decision = new SimLambdaServiceInvokeAuthorizer({
+      iam: this.scope.iam(),
+    }).authorize({
+      simFunction,
+      servicePrincipal: simSnsServicePrincipal,
+      ...source,
+    });
+
+    if (decision.isDenied) {
+      throw new SimSnsDeliveryNotPermitted(
+        `The resource policy of ${endpointArn} does not allow ` +
+          `${simSnsServicePrincipal} to invoke it for ${source.sourceArn}. ` +
+          "Grant it with AddPermission.",
+      );
+    }
+
+    // The function is invoked directly rather than through an Invoke command,
+    // because SNS is already inside the background task that stands for the
+    // asynchronous invocation real SNS makes, and because a handler failure
+    // has to reach the delivery outcome rather than being swallowed as an
+    // asynchronous invocation error.
+    await simFunction.invoke(simSnsLambdaEventDocument(request));
+  }
+}

--- a/src/service/sns/delivery/lambda/sim-sns-lambda-event.ts
+++ b/src/service/sns/delivery/lambda/sim-sns-lambda-event.ts
@@ -1,0 +1,60 @@
+import type { SimSnsDeliveryRequest } from "../sim-sns-delivery.js";
+import type { SimSnsNotificationFields } from "../sim-sns-notification.js";
+
+/**
+ * What the `EventSource` of an SNS record says, which is how a handler taking
+ * events from more than one service tells them apart.
+ */
+const eventSource = "aws:sns";
+
+/**
+ * The version of the SNS record shape, which real SNS has never moved off.
+ */
+const eventVersion = "1.0";
+
+/**
+ * The event one subscribed Lambda function is invoked with.
+ *
+ * `Records` always holds exactly one entry, even for a `PublishBatch`. Real SNS
+ * does not batch to Lambda: each published message is its own asynchronous
+ * invocation, so a handler looping over `Records` sees one message per call.
+ */
+export function simSnsLambdaEventDocument(
+  request: SimSnsDeliveryRequest,
+): object {
+  return {
+    Records: [
+      {
+        EventSource: eventSource,
+        EventVersion: eventVersion,
+        EventSubscriptionArn: request.subscription.arn.value,
+        Sns: snsRecord(request.notification.fields()),
+      },
+    ],
+  };
+}
+
+/**
+ * The notification as the `Sns` object of a record spells it.
+ *
+ * Two fields differ from the envelope a queue receives, and the difference is
+ * real SNS behaviour rather than an oversight: the envelope has `SigningCertURL`
+ * and `UnsubscribeURL`, and a Lambda event has `SigningCertUrl` and
+ * `UnsubscribeUrl`. `Subject` and `MessageAttributes` are always present here,
+ * where the envelope leaves each out when there is nothing to put in it.
+ */
+function snsRecord(fields: SimSnsNotificationFields): Record<string, unknown> {
+  return {
+    Type: fields.type,
+    MessageId: fields.messageId,
+    TopicArn: fields.topicArn,
+    Subject: fields.subject ?? null,
+    Message: fields.message,
+    Timestamp: fields.timestamp,
+    SignatureVersion: fields.signature.SignatureVersion,
+    Signature: fields.signature.Signature,
+    SigningCertUrl: fields.signature.SigningCertURL,
+    UnsubscribeUrl: fields.unsubscribeUrl,
+    MessageAttributes: fields.messageAttributes,
+  };
+}

--- a/src/service/sns/delivery/lambda/sim-sns-lambda-fan-out.iso.test.ts
+++ b/src/service/sns/delivery/lambda/sim-sns-lambda-fan-out.iso.test.ts
@@ -1,0 +1,218 @@
+import { PublishBatchCommand, PublishCommand } from "@aws-sdk/client-sns";
+import { ReceiveMessageCommand } from "@aws-sdk/client-sqs";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertObjectEquals,
+  assertObjectMatches,
+  assertTypeString,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import type {
+  SimSnsLambdaEvent,
+  SimSnsLambdaRecord,
+} from "../../../../../test/sns/function-fixture.js";
+import { simSnsSubscribedFunction } from "../../../../../test/sns/function-fixture.js";
+import { simSnsSubscribedQueue } from "../../../../../test/sns/subscription-fixture.js";
+import { simAwsWithTopic } from "../../../../../test/sns/topic-fixture.js";
+
+/**
+ * The one record of the one event a function was invoked with.
+ */
+function onlyRecord(events: readonly SimSnsLambdaEvent[]): SimSnsLambdaRecord {
+  assertArrayLength(events, 1);
+
+  const [event] = events;
+
+  assertNonNullable(event);
+  assertArrayLength(event.Records, 1);
+
+  const [record] = event.Records;
+
+  assertNonNullable(record);
+
+  return record;
+}
+
+describe("SNS fan-out to a Lambda function", () => {
+  it("invokes a subscribed function with one record", async () => {
+    // Given a topic with a function subscribed to it.
+    const { simAws, topicArn } = await simAwsWithTopic();
+    const consumer = await simSnsSubscribedFunction(
+      simAws,
+      "order-consumer",
+      topicArn,
+    );
+
+    // When one message is published.
+    const published = await simAws.sns().publish(
+      new PublishCommand({
+        TopicArn: topicArn,
+        Subject: "New order",
+        Message: "order-1",
+        MessageAttributes: {
+          tenant: { DataType: "String", StringValue: "acme" },
+        },
+      }),
+    );
+
+    await simAws.backgroundTasksComplete();
+
+    // Then the function was invoked with the SNS event shape, carrying the
+    // published message, its subject and its attributes.
+    const record = onlyRecord(consumer.events);
+
+    assertIdentical(record.EventSource, "aws:sns");
+    assertIdentical(record.EventVersion, "1.0");
+    assertObjectMatches(record.Sns, {
+      Type: "Notification",
+      MessageId: published.MessageId,
+      TopicArn: topicArn,
+      Subject: "New order",
+      Message: "order-1",
+      SignatureVersion: "1",
+      MessageAttributes: { tenant: { Type: "String", Value: "acme" } },
+    });
+  });
+
+  it("names the subscription the invocation came from", async () => {
+    // Given a topic with a function subscribed to it.
+    const { simAws, topicArn } = await simAwsWithTopic();
+    const consumer = await simSnsSubscribedFunction(
+      simAws,
+      "order-consumer",
+      topicArn,
+    );
+    const [subscription] = simAws.sns().topicSubscriptions("orders");
+
+    assertNonNullable(subscription);
+
+    // When a message is published.
+    await simAws
+      .sns()
+      .publish(new PublishCommand({ TopicArn: topicArn, Message: "order-1" }));
+
+    await simAws.backgroundTasksComplete();
+
+    // Then the record names the subscription rather than the topic, which is
+    // how a handler tells two subscriptions of one topic apart.
+    assertIdentical(
+      onlyRecord(consumer.events).EventSubscriptionArn,
+      subscription.arn.value,
+    );
+  });
+
+  it("spells the two URLs the way a Lambda event spells them", async () => {
+    // Given a topic with a function subscribed to it.
+    const { simAws, topicArn } = await simAwsWithTopic();
+    const consumer = await simSnsSubscribedFunction(
+      simAws,
+      "order-consumer",
+      topicArn,
+    );
+
+    // When a message is published.
+    await simAws
+      .sns()
+      .publish(new PublishCommand({ TopicArn: topicArn, Message: "order-1" }));
+
+    await simAws.backgroundTasksComplete();
+
+    // Then the event has `SigningCertUrl` and `UnsubscribeUrl`, where the
+    // envelope a queue receives has `SigningCertURL` and `UnsubscribeURL`.
+    const notification = onlyRecord(consumer.events).Sns;
+
+    assertTypeString(notification["SigningCertUrl"]);
+    assertTypeString(notification["UnsubscribeUrl"]);
+    assertUndefined(notification["SigningCertURL"]);
+    assertUndefined(notification["UnsubscribeURL"]);
+  });
+
+  it("carries a null subject and empty attributes when there are none", async () => {
+    // Given a topic with a function subscribed to it.
+    const { simAws, topicArn } = await simAwsWithTopic();
+    const consumer = await simSnsSubscribedFunction(
+      simAws,
+      "order-consumer",
+      topicArn,
+    );
+
+    // When a message with neither a subject nor attributes is published.
+    await simAws
+      .sns()
+      .publish(new PublishCommand({ TopicArn: topicArn, Message: "order-1" }));
+
+    await simAws.backgroundTasksComplete();
+
+    // Then both fields are still there, as they are in a real SNS event. The
+    // envelope a queue receives leaves each out instead.
+    const notification = onlyRecord(consumer.events).Sns;
+
+    assertIdentical(notification["Subject"], null);
+    assertObjectEquals(notification["MessageAttributes"], {});
+  });
+
+  it("invokes once per message of a batch rather than once per batch", async () => {
+    // Given a topic with a function subscribed to it.
+    const { simAws, topicArn } = await simAwsWithTopic();
+    const consumer = await simSnsSubscribedFunction(
+      simAws,
+      "order-consumer",
+      topicArn,
+    );
+
+    // When two messages are published as one batch.
+    await simAws.sns().publishBatch(
+      new PublishBatchCommand({
+        TopicArn: topicArn,
+        PublishBatchRequestEntries: [
+          { Id: "one", Message: "order-1" },
+          { Id: "two", Message: "order-2" },
+        ],
+      }),
+    );
+
+    await simAws.backgroundTasksComplete();
+
+    // Then there are two invocations of one record each. Real SNS does not
+    // batch to Lambda, so `Records` never holds more than one entry.
+    assertArrayLength(consumer.events, 2);
+
+    for (const event of consumer.events) {
+      assertArrayLength(event.Records, 1);
+    }
+  });
+
+  it("delivers to a queue and a function subscribed to one topic", async () => {
+    // Given a topic with one of each subscribed to it.
+    const { simAws, topicArn } = await simAwsWithTopic();
+    const consumer = await simSnsSubscribedFunction(
+      simAws,
+      "order-consumer",
+      topicArn,
+    );
+    const { queueUrl } = await simSnsSubscribedQueue(
+      simAws,
+      "orders-queue",
+      topicArn,
+    );
+
+    // When one message is published.
+    await simAws
+      .sns()
+      .publish(new PublishCommand({ TopicArn: topicArn, Message: "order-1" }));
+
+    await simAws.backgroundTasksComplete();
+
+    // Then both receive their own copy of it, over their own protocol.
+    assertIdentical(onlyRecord(consumer.events).Sns["Message"], "order-1");
+
+    const received = await simAws
+      .sqs()
+      .receiveMessage(new ReceiveMessageCommand({ QueueUrl: queueUrl }));
+
+    assertArrayLength(received.Messages, 1);
+  });
+});

--- a/src/service/sns/delivery/lambda/sim-sns-lambda-permission.iso.test.ts
+++ b/src/service/sns/delivery/lambda/sim-sns-lambda-permission.iso.test.ts
@@ -1,0 +1,227 @@
+import { RemovePermissionCommand } from "@aws-sdk/client-lambda";
+import { PublishCommand } from "@aws-sdk/client-sns";
+import {
+  assertArrayLength,
+  assertFalse,
+  assertNonNullable,
+  assertStringIncludes,
+  assertTrue,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import type { SimAws } from "../../../aws/sim-aws.js";
+import {
+  simSnsAllowInvoke,
+  simSnsFunctionArn,
+  simSnsSubscribedFunction,
+  subscribeFunction,
+} from "../../../../../test/sns/function-fixture.js";
+import { simAwsWithTopic } from "../../../../../test/sns/topic-fixture.js";
+import type { SimSnsDeliveryFailure } from "../sim-sns-delivery-failures.js";
+
+/**
+ * Publish one message and wait for whatever delivery it caused.
+ */
+async function publishOrder(simAws: SimAws, topicArn: string): Promise<void> {
+  await simAws
+    .sns()
+    .publish(new PublishCommand({ TopicArn: topicArn, Message: "order-1" }));
+
+  await simAws.backgroundTasksComplete();
+}
+
+/**
+ * The one delivery a topic could not make.
+ */
+function onlyFailure(simAws: SimAws): SimSnsDeliveryFailure {
+  const failures = simAws.sns().deliveryFailures;
+
+  assertArrayLength(failures, 1);
+
+  const [failure] = failures;
+
+  assertNonNullable(failure);
+
+  return failure;
+}
+
+describe("SNS delivery to a Lambda function it may invoke", () => {
+  it("does not invoke a function that does not admit SNS", async () => {
+    // Given a topic with a function subscribed to it and no invoke permission.
+    const { simAws, topicArn } = await simAwsWithTopic();
+    const consumer = await simSnsSubscribedFunction(
+      simAws,
+      "order-consumer",
+      topicArn,
+      { withoutPermission: true },
+    );
+
+    // When a message is published.
+    await publishOrder(simAws, topicArn);
+
+    // Then nothing was invoked, and the refusal says what to grant.
+    assertArrayLength(consumer.events, 0);
+
+    const failure = onlyFailure(simAws);
+
+    assertTrue(failure.wasRefused);
+    assertStringIncludes(failure.reason, "does not allow sns.amazonaws.com");
+    assertStringIncludes(failure.reason, "AddPermission");
+  });
+
+  it("stops delivering when the permission is taken away", async () => {
+    // Given a topic with a function subscribed to it and allowed to be
+    // invoked, which receives a first message.
+    const { simAws, topicArn } = await simAwsWithTopic();
+    const consumer = await simSnsSubscribedFunction(
+      simAws,
+      "order-consumer",
+      topicArn,
+    );
+
+    await publishOrder(simAws, topicArn);
+    assertArrayLength(consumer.events, 1);
+
+    // When the permission is removed after subscribing.
+    await simAws.lambda().removePermission(
+      new RemovePermissionCommand({
+        FunctionName: "order-consumer",
+        StatementId: "AllowSns",
+      }),
+    );
+
+    await publishOrder(simAws, topicArn);
+
+    // Then the second message is not delivered. The resource policy is
+    // consulted on every delivery rather than remembered from Subscribe time.
+    assertArrayLength(consumer.events, 1);
+    assertTrue(onlyFailure(simAws).wasRefused);
+  });
+
+  it("does not invoke a function granted for another topic", async () => {
+    // Given a function subscribed to a topic, admitting SNS for a different
+    // one.
+    const { simAws, topicArn } = await simAwsWithTopic();
+    const consumer = await simSnsSubscribedFunction(
+      simAws,
+      "order-consumer",
+      topicArn,
+      { withoutPermission: true },
+    );
+
+    await simSnsAllowInvoke(
+      simAws,
+      "order-consumer",
+      "arn:aws:sns:us-east-1:888888888888:invoices",
+    );
+
+    // When a message is published on the topic it is subscribed to.
+    await publishOrder(simAws, topicArn);
+
+    // Then the grant does not reach it, because it names another topic as its
+    // source ARN.
+    assertArrayLength(consumer.events, 0);
+    assertTrue(onlyFailure(simAws).wasRefused);
+  });
+
+  it("invokes a function in another Account that admits the topic", async () => {
+    // Given a topic with a function in another Account subscribed to it.
+    const { simAws, topicArn } = await simAwsWithTopic();
+    const consumer = await simSnsSubscribedFunction(
+      simAws,
+      "order-consumer",
+      topicArn,
+      { accountId: "222222222222" },
+    );
+
+    // When a message is published.
+    await publishOrder(simAws, topicArn);
+
+    // Then it is invoked, because that Account's resource policy admits SNS
+    // for this topic.
+    assertArrayLength(consumer.events, 1);
+    assertStringIncludes(consumer.functionArn, "222222222222");
+  });
+
+  it("invokes a function in another Region", async () => {
+    // Given a topic with a function in another Region subscribed to it.
+    const { simAws, topicArn } = await simAwsWithTopic();
+    const consumer = await simSnsSubscribedFunction(
+      simAws,
+      "order-consumer",
+      topicArn,
+      { regionName: "eu-west-2" },
+    );
+
+    // When a message is published.
+    await publishOrder(simAws, topicArn);
+
+    // Then it is invoked, since real SNS invokes across Regions.
+    assertArrayLength(consumer.events, 1);
+  });
+
+  it("records a subscription pointing at no function at all", async () => {
+    // Given a topic subscribed to a function that was never created.
+    const { simAws, topicArn } = await simAwsWithTopic();
+    const missing = simSnsFunctionArn(simAws, "order-consumer");
+
+    await subscribeFunction(simAws, topicArn, missing);
+
+    // When a message is published.
+    await publishOrder(simAws, topicArn);
+
+    // Then the missing function is reported rather than treated as a refusal,
+    // because no resource policy said no: there was nothing to ask.
+    const failure = onlyFailure(simAws);
+
+    assertFalse(failure.wasRefused);
+    assertStringIncludes(failure.reason, "not a simulated Lambda function");
+  });
+
+  it("keeps delivering to the other subscriptions when a handler throws", async () => {
+    // Given a topic with a failing function and a working one subscribed.
+    const { simAws, topicArn } = await simAwsWithTopic();
+    const failing = await simSnsSubscribedFunction(
+      simAws,
+      "order-failer",
+      topicArn,
+      {
+        onEvent: () => {
+          throw new Error("handler blew up");
+        },
+      },
+    );
+    const working = await simSnsSubscribedFunction(
+      simAws,
+      "order-consumer",
+      topicArn,
+    );
+
+    // When a message is published.
+    await publishOrder(simAws, topicArn);
+
+    // Then both were invoked, and only the failing one is a delivery failure.
+    assertArrayLength(failing.events, 1);
+    assertArrayLength(working.events, 1);
+    assertStringIncludes(onlyFailure(simAws).reason, "handler blew up");
+  });
+
+  it("invokes a function subscribed after its permission was granted", async () => {
+    // Given a function allowed to be invoked before it is subscribed.
+    const { simAws, topicArn } = await simAwsWithTopic();
+    const consumer = await simSnsSubscribedFunction(
+      simAws,
+      "order-consumer",
+      topicArn,
+      { withoutPermission: true },
+    );
+
+    await simSnsAllowInvoke(simAws, "order-consumer", topicArn);
+
+    // When a message is published.
+    await publishOrder(simAws, topicArn);
+
+    // Then it is invoked, since the permission is read at delivery time rather
+    // than at Subscribe time.
+    assertArrayLength(consumer.events, 1);
+  });
+});

--- a/src/service/sns/delivery/sim-aws-sns-delivery-endpoints.ts
+++ b/src/service/sns/delivery/sim-aws-sns-delivery-endpoints.ts
@@ -1,0 +1,26 @@
+import type { SimAws } from "../../aws/sim-aws.js";
+import { SimAwsSnsDeliveryFunctions } from "./lambda/sim-aws-sns-delivery-functions.js";
+import { SimSnsProtocolDeliveryEndpoints } from "./sim-sns-protocol-delivery-endpoints.js";
+import { SimAwsSnsDeliveryQueues } from "./sqs/sim-aws-sns-delivery-queues.js";
+
+interface SimAwsSnsDeliveryEndpointsProperties {
+  readonly simAws: SimAws;
+}
+
+/**
+ * Everywhere the topics of one simulated AWS instance can deliver.
+ *
+ * Which protocols are simulated is a fact about simulated SNS rather than about
+ * the service builder that hands it its endpoints, so the set is assembled
+ * here.
+ */
+export class SimAwsSnsDeliveryEndpoints extends SimSnsProtocolDeliveryEndpoints {
+  constructor(properties: SimAwsSnsDeliveryEndpointsProperties) {
+    super({
+      byProtocol: {
+        sqs: new SimAwsSnsDeliveryQueues(properties),
+        lambda: new SimAwsSnsDeliveryFunctions(properties),
+      },
+    });
+  }
+}

--- a/src/service/sns/delivery/sim-sns-canonical-message.ts
+++ b/src/service/sns/delivery/sim-sns-canonical-message.ts
@@ -18,9 +18,10 @@ export interface SimSnsSignedValues {
  * signature.
  *
  * Each signed field is its name and its value, both followed by a newline, in
- * the alphabetical order of the names. That order is the declaration order of
- * `SimSnsSignedValues`, since an object keeps the order its keys were written
- * in, and rebuilding the string in any other order fails to verify.
+ * the alphabetical order of the names. The names are sorted here rather than
+ * taken in the order they were passed in: an object keeps the order its keys
+ * were written in, so a caller writing the same fields in another order would
+ * otherwise produce a string no verifier could rebuild.
  *
  * A field with no value is left out rather than signed as an empty string,
  * which is what makes a message published without a subject verify.
@@ -31,6 +32,7 @@ export interface SimSnsSignedValues {
 export function simSnsCanonicalMessage(values: SimSnsSignedValues): string {
   return Object.entries(values)
     .filter(([, value]) => value !== undefined)
+    .toSorted(([left], [right]) => left.localeCompare(right))
     .map(([name, value]) => `${name}\n${String(value)}\n`)
     .join("");
 }

--- a/src/service/sns/delivery/sim-sns-canonical-message.ts
+++ b/src/service/sns/delivery/sim-sns-canonical-message.ts
@@ -1,0 +1,36 @@
+/**
+ * The values real SNS signs, under the names it signs them by.
+ *
+ * A verifier rebuilds this from the document it received, so the names are the
+ * document's rather than the simulator's.
+ */
+export interface SimSnsSignedValues {
+  readonly Message: string;
+  readonly MessageId: string;
+  readonly Subject: string | undefined;
+  readonly Timestamp: string;
+  readonly TopicArn: string;
+  readonly Type: string;
+}
+
+/**
+ * The string real SNS signs, which is what a verifier rebuilds to check the
+ * signature.
+ *
+ * Each signed field is its name and its value, both followed by a newline, in
+ * the alphabetical order of the names. That order is the declaration order of
+ * `SimSnsSignedValues`, since an object keeps the order its keys were written
+ * in, and rebuilding the string in any other order fails to verify.
+ *
+ * A field with no value is left out rather than signed as an empty string,
+ * which is what makes a message published without a subject verify.
+ *
+ * The message attributes are not signed, here or on real AWS, so changing one
+ * in flight leaves the signature valid.
+ */
+export function simSnsCanonicalMessage(values: SimSnsSignedValues): string {
+  return Object.entries(values)
+    .filter(([, value]) => value !== undefined)
+    .map(([name, value]) => `${name}\n${String(value)}\n`)
+    .join("");
+}

--- a/src/service/sns/delivery/sim-sns-delivery-request.ts
+++ b/src/service/sns/delivery/sim-sns-delivery-request.ts
@@ -3,7 +3,7 @@ import type { SimSnsPublishedMessage } from "../message/sim-sns-published-messag
 import type { SimSnsMessageSigner } from "../signature/sim-sns-message-signer.js";
 import type { SimSnsSubscription } from "../subscription/sim-sns-subscription.js";
 import type { SimSnsDeliveryRequest } from "./sim-sns-delivery.js";
-import { SimSnsEnvelope } from "./sim-sns-envelope.js";
+import { SimSnsNotification } from "./sim-sns-notification.js";
 
 interface SimSnsDeliveryRequestsProperties {
   readonly signer: SimSnsMessageSigner;
@@ -11,26 +11,12 @@ interface SimSnsDeliveryRequestsProperties {
 }
 
 /**
- * The message on its own, with its attributes alongside it.
- *
- * Raw delivery takes the envelope away, so the message attributes have nowhere
- * to travel but the SQS message itself. A consumer written for raw delivery
- * reads them there.
- */
-function rawBody(
-  message: SimSnsPublishedMessage,
-): Pick<SimSnsDeliveryRequest, "body" | "messageAttributes"> {
-  return {
-    body: message.body.value,
-    messageAttributes: message.attributes.asSqsAttributes(),
-  };
-}
-
-/**
  * Builds what each subscription of one simulated SNS scope is sent.
  *
- * Which form the body takes is the subscription's business rather than the
- * endpoint's, so it is settled here and the endpoint is handed a body.
+ * The notification is built here rather than at the endpoint, because it is
+ * signed with the scope's own key: the signature belongs to the message rather
+ * than to the destination. Which document the endpoint makes of it is the
+ * endpoint's own business.
  */
 export class SimSnsDeliveryRequests {
   private readonly signer: SimSnsMessageSigner;
@@ -48,31 +34,16 @@ export class SimSnsDeliveryRequests {
     subscription: SimSnsSubscription,
     message: SimSnsPublishedMessage,
   ): SimSnsDeliveryRequest {
-    const named = {
-      endpointArn: subscription.endpoint.value,
-      topicArn: subscription.topicArn,
-      topicOwnerAccountId: this.scope.accountId,
-    };
-
-    if (subscription.attributes.rawMessageDelivery) {
-      return { ...named, ...rawBody(message) };
-    }
-
-    return { ...named, body: this.envelope(subscription, message).body };
-  }
-
-  /**
-   * The message wrapped in the SNS envelope, which is the default.
-   */
-  private envelope(
-    subscription: SimSnsSubscription,
-    message: SimSnsPublishedMessage,
-  ): SimSnsEnvelope {
-    return new SimSnsEnvelope({
-      message,
+    return {
       subscription,
-      regionName: this.scope.regionName,
-      signer: this.signer,
-    });
+      message,
+      topicOwnerAccountId: this.scope.accountId,
+      notification: new SimSnsNotification({
+        message,
+        subscription,
+        regionName: this.scope.regionName,
+        signer: this.signer,
+      }),
+    };
   }
 }

--- a/src/service/sns/delivery/sim-sns-delivery.ts
+++ b/src/service/sns/delivery/sim-sns-delivery.ts
@@ -1,39 +1,66 @@
-import type { SimSnsSqsMessageAttribute } from "../message/sim-sns-message-attributes.js";
+import type { SimSnsPublishedMessage } from "../message/sim-sns-published-message.js";
+import type { SimSnsSubscription } from "../subscription/sim-sns-subscription.js";
+import type { SimSnsNotification } from "./sim-sns-notification.js";
 
 /**
  * The service principal simulated SNS reaches another service as.
  *
  * This is the principal a destination's resource policy has to admit, which is
- * why a queue subscribed to a topic needs `sns.amazonaws.com` in its policy.
+ * why a queue subscribed to a topic needs `sns.amazonaws.com` in its policy and
+ * a function needs it in an `AddPermission` grant.
  */
 export const simSnsServicePrincipal = "sns.amazonaws.com";
 
 /**
  * One message on its way from a topic to a subscription's endpoint.
  *
- * The body is already whichever form the subscription asked for, since which
- * one it is is the subscription's business rather than the endpoint's. The
- * attributes are only carried for raw delivery: an envelope has them inside it.
+ * The notification comes along signed, because the signature is over the
+ * message rather than over the destination. What each protocol makes of it is
+ * the endpoint's own business: a queue receives it as an envelope, and a Lambda
+ * function receives it inside an event record.
  */
 export interface SimSnsDeliveryRequest {
-  readonly endpointArn: string;
-  readonly topicArn: string;
+  readonly subscription: SimSnsSubscription;
+  readonly message: SimSnsPublishedMessage;
   readonly topicOwnerAccountId: string;
-  readonly body: string;
-  readonly messageAttributes?:
-    Readonly<Record<string, SimSnsSqsMessageAttribute>> | undefined;
+  readonly notification: SimSnsNotification;
 }
 
 /**
  * Somewhere a simulated topic can deliver a published message.
  *
- * There is one implementation, for a queue, because `sqs` is the only protocol
- * simulated. A second protocol adds a second implementation rather than a
- * branch in this one.
+ * There is one implementation per protocol, because what a destination is asked
+ * and what it is handed differ by protocol: a second protocol adds a second
+ * implementation rather than a branch in an existing one.
+ * `SimSnsProtocolDeliveryEndpoints` is what picks between them.
  */
 export interface SimSnsDeliveryEndpoints {
   /**
    * Deliver one message, refusing if the endpoint does not admit SNS.
    */
   deliver(request: SimSnsDeliveryRequest): Promise<void>;
+}
+
+/**
+ * What a destination's policy is asked about, as IAM condition values.
+ *
+ * A destination is admitting one topic rather than SNS at large, so every
+ * endpoint supplies these two: the topic as `aws:SourceArn`, and the Account
+ * owning it as `aws:SourceAccount`.
+ */
+export interface SimSnsDeliverySource {
+  readonly sourceArn: string;
+  readonly sourceAccount: string;
+}
+
+/**
+ * Which topic a delivery is being made for, and whose it is.
+ */
+export function simSnsDeliverySource(
+  request: SimSnsDeliveryRequest,
+): SimSnsDeliverySource {
+  return {
+    sourceArn: request.subscription.topicArn,
+    sourceAccount: request.topicOwnerAccountId,
+  };
 }

--- a/src/service/sns/delivery/sim-sns-envelope.ts
+++ b/src/service/sns/delivery/sim-sns-envelope.ts
@@ -1,20 +1,8 @@
 import { jsonStringify } from "../../../util/type-guard/json.js";
-import type { SimSnsPublishedMessage } from "../message/sim-sns-published-message.js";
-import { simSnsUnsubscribeUrl } from "../signature/sim-sns-host.js";
-import type { SimSnsMessageSigner } from "../signature/sim-sns-message-signer.js";
-import type { SimSnsSubscription } from "../subscription/sim-sns-subscription.js";
-
-/**
- * What a message published to a topic is, as opposed to a subscription
- * confirmation, which is the only other kind of message real SNS delivers.
- */
-const notificationType = "Notification";
+import type { SimSnsNotification } from "./sim-sns-notification.js";
 
 interface SimSnsEnvelopeProperties {
-  readonly message: SimSnsPublishedMessage;
-  readonly subscription: SimSnsSubscription;
-  readonly regionName: string;
-  readonly signer: SimSnsMessageSigner;
+  readonly notification: SimSnsNotification;
 }
 
 /**
@@ -23,18 +11,16 @@ interface SimSnsEnvelopeProperties {
  * Real SNS wraps the published message in this, which is why a consumer written
  * for it reads `JSON.parse(body).Message` rather than `body`. Everything real
  * SNS puts in it is here, including a signature a verifier can actually check.
+ *
+ * The two URLs are spelled in upper case, which is how real SNS spells them in
+ * an envelope. A Lambda event spells the same two fields `SigningCertUrl` and
+ * `UnsubscribeUrl`.
  */
 export class SimSnsEnvelope {
-  private readonly message: SimSnsPublishedMessage;
-  private readonly subscription: SimSnsSubscription;
-  private readonly regionName: string;
-  private readonly signer: SimSnsMessageSigner;
+  private readonly notification: SimSnsNotification;
 
   constructor(properties: SimSnsEnvelopeProperties) {
-    this.message = properties.message;
-    this.subscription = properties.subscription;
-    this.regionName = properties.regionName;
-    this.signer = properties.signer;
+    this.notification = properties.notification;
   }
 
   /**
@@ -44,63 +30,20 @@ export class SimSnsEnvelope {
     return jsonStringify(this.document());
   }
 
-  /**
-   * The string real SNS signs, which is what a verifier rebuilds to check the
-   * signature.
-   *
-   * Each signed field is its name and its value, both followed by a newline.
-   * The message attributes are not signed, here or on real AWS, so changing one
-   * in flight leaves the signature valid.
-   */
-  canonicalMessage(): string {
-    const parts: string[] = [];
-
-    for (const [name, value] of this.signedFields()) {
-      if (value !== undefined) {
-        parts.push(`${name}\n${value}\n`);
-      }
-    }
-
-    return parts.join("");
-  }
-
-  /**
-   * The fields the signature covers, in the order it covers them.
-   *
-   * They are pairs rather than an object because the order is the signature's
-   * business: it is the alphabetical order of the field names, and rebuilding
-   * the string in any other order fails to verify.
-   */
-  private signedFields(): readonly (readonly [string, string | undefined])[] {
-    return [
-      ["Message", this.message.body.value],
-      ["MessageId", this.message.messageId],
-      ["Subject", this.message.subject?.value],
-      ["Timestamp", this.message.publishedAt.toISOString()],
-      ["TopicArn", this.subscription.topicArn],
-      ["Type", notificationType],
-    ];
-  }
-
   private document(): Record<string, unknown> {
-    const attributes = this.message.attributes;
+    const fields = this.notification.fields();
 
     return {
-      Type: notificationType,
-      MessageId: this.message.messageId,
-      TopicArn: this.subscription.topicArn,
-      ...(this.message.subject !== undefined && {
-        Subject: this.message.subject.value,
-      }),
-      Message: this.message.body.value,
-      Timestamp: this.message.publishedAt.toISOString(),
-      ...this.signer.sign(this.canonicalMessage()),
-      UnsubscribeURL: simSnsUnsubscribeUrl(
-        this.regionName,
-        this.subscription.arn.value,
-      ),
-      ...(!attributes.isEmpty && {
-        MessageAttributes: attributes.inEnvelope(),
+      Type: fields.type,
+      MessageId: fields.messageId,
+      TopicArn: fields.topicArn,
+      ...(fields.subject !== undefined && { Subject: fields.subject }),
+      Message: fields.message,
+      Timestamp: fields.timestamp,
+      ...fields.signature,
+      UnsubscribeURL: fields.unsubscribeUrl,
+      ...(fields.hasMessageAttributes && {
+        MessageAttributes: fields.messageAttributes,
       }),
     };
   }

--- a/src/service/sns/delivery/sim-sns-no-delivery-endpoints.ts
+++ b/src/service/sns/delivery/sim-sns-no-delivery-endpoints.ts
@@ -1,0 +1,29 @@
+import { SimSnsUnsimulatedInputException } from "../error/sim-sns.error.js";
+import type {
+  SimSnsDeliveryEndpoints,
+  SimSnsDeliveryRequest,
+} from "./sim-sns-delivery.js";
+
+/**
+ * The endpoints a simulated SNS built on its own can reach, which is none.
+ *
+ * A standalone SimSns has no other simulated services to reach, and owns its
+ * own background scheduler, so nothing could wait for a delivery it made even
+ * if it could make one. Subscriptions still work, since holding them takes
+ * nothing but SNS: it is delivery that is refused, and the refusal is recorded
+ * as a delivery failure like any other.
+ */
+export class SimSnsNoDeliveryEndpoints implements SimSnsDeliveryEndpoints {
+  /**
+   * Refuse every delivery, explaining how to get one.
+   */
+  deliver(request: SimSnsDeliveryRequest): never {
+    throw new SimSnsUnsimulatedInputException(
+      `Cannot deliver to ${request.subscription.endpoint.value}: this SimSns ` +
+        "was constructed on its own, so it has no other simulated services to " +
+        "deliver to and no shared background scheduler to deliver on. Reach " +
+        "simulated SNS through SimAws to deliver a published message to a " +
+        "queue or a function.",
+    );
+  }
+}

--- a/src/service/sns/delivery/sim-sns-notification.ts
+++ b/src/service/sns/delivery/sim-sns-notification.ts
@@ -1,0 +1,114 @@
+import type { SimSnsEnvelopeMessageAttribute } from "../message/sim-sns-message-attributes.js";
+import type { SimSnsPublishedMessage } from "../message/sim-sns-published-message.js";
+import { simSnsUnsubscribeUrl } from "../signature/sim-sns-host.js";
+import type {
+  SimSnsMessageSigner,
+  SimSnsSignatureFields,
+} from "../signature/sim-sns-message-signer.js";
+import type { SimSnsSubscription } from "../subscription/sim-sns-subscription.js";
+import { simSnsCanonicalMessage } from "./sim-sns-canonical-message.js";
+
+/**
+ * What a message published to a topic is, as opposed to a subscription
+ * confirmation, which is the only other kind of message real SNS delivers.
+ */
+const notificationType = "Notification";
+
+/**
+ * One published message as every destination's document carries it.
+ *
+ * A queue and a Lambda function are handed the same values with the same
+ * signature over them. What differs is how each protocol spells two of the
+ * URLs, and whether an absent subject and an empty attribute set are left out,
+ * so those belong to the documents rather than here.
+ *
+ * The names here are the simulator's own rather than either document's, so that
+ * neither spelling looks like the right one.
+ */
+export interface SimSnsNotificationFields {
+  readonly type: string;
+  readonly messageId: string;
+  readonly topicArn: string;
+  readonly subject: string | undefined;
+  readonly message: string;
+  readonly timestamp: string;
+  readonly signature: SimSnsSignatureFields;
+  readonly unsubscribeUrl: string;
+  readonly messageAttributes: Record<string, SimSnsEnvelopeMessageAttribute>;
+  readonly hasMessageAttributes: boolean;
+}
+
+interface SimSnsNotificationProperties {
+  readonly message: SimSnsPublishedMessage;
+  readonly subscription: SimSnsSubscription;
+  readonly regionName: string;
+  readonly signer: SimSnsMessageSigner;
+}
+
+/**
+ * What one subscription is being told, signed once for whichever document
+ * carries it.
+ *
+ * The fields are kept once they have been built rather than built again per
+ * document, so a message that reaches two documents is signed once. Signing is
+ * the expensive part of a delivery, and a second signature over the same string
+ * would be the same signature anyway.
+ */
+export class SimSnsNotification {
+  private readonly message: SimSnsPublishedMessage;
+  private readonly subscription: SimSnsSubscription;
+  private readonly regionName: string;
+  private readonly signer: SimSnsMessageSigner;
+
+  private held: SimSnsNotificationFields | undefined;
+
+  constructor(properties: SimSnsNotificationProperties) {
+    this.message = properties.message;
+    this.subscription = properties.subscription;
+    this.regionName = properties.regionName;
+    this.signer = properties.signer;
+  }
+
+  /**
+   * The values a delivered document is built out of.
+   */
+  fields(): SimSnsNotificationFields {
+    this.held ??= this.build();
+
+    return this.held;
+  }
+
+  private build(): SimSnsNotificationFields {
+    const attributes = this.message.attributes;
+    const subject = this.message.subject?.value;
+    const timestamp = this.message.publishedAt.toISOString();
+    const topicArn = this.subscription.topicArn;
+    const message = this.message.body.value;
+    const messageId = this.message.messageId;
+
+    return {
+      type: notificationType,
+      messageId,
+      topicArn,
+      subject,
+      message,
+      timestamp,
+      signature: this.signer.sign(
+        simSnsCanonicalMessage({
+          Message: message,
+          MessageId: messageId,
+          Subject: subject,
+          Timestamp: timestamp,
+          TopicArn: topicArn,
+          Type: notificationType,
+        }),
+      ),
+      unsubscribeUrl: simSnsUnsubscribeUrl(
+        this.regionName,
+        this.subscription.arn.value,
+      ),
+      messageAttributes: attributes.inEnvelope(),
+      hasMessageAttributes: !attributes.isEmpty,
+    };
+  }
+}

--- a/src/service/sns/delivery/sim-sns-protocol-delivery-endpoints.ts
+++ b/src/service/sns/delivery/sim-sns-protocol-delivery-endpoints.ts
@@ -1,0 +1,44 @@
+import type { SimSnsSubscriptionProtocol } from "../subscription/sim-sns-subscription-protocol.js";
+import type {
+  SimSnsDeliveryEndpoints,
+  SimSnsDeliveryRequest,
+} from "./sim-sns-delivery.js";
+
+/**
+ * One endpoints implementation per protocol.
+ *
+ * A record rather than a lookup with a fallback, so adding a protocol to
+ * `SimSnsSubscriptionProtocol` without giving it somewhere to deliver fails to
+ * compile.
+ */
+type SimSnsEndpointsByProtocol = Readonly<
+  Record<SimSnsSubscriptionProtocol, SimSnsDeliveryEndpoints>
+>;
+
+interface SimSnsProtocolDeliveryEndpointsProperties {
+  readonly byProtocol: SimSnsEndpointsByProtocol;
+}
+
+/**
+ * Sends each delivery to the endpoints its subscription's protocol implies.
+ *
+ * What a destination is asked before it takes a message, and what it is handed,
+ * both differ by protocol: a queue is asked about its own policy and handed a
+ * body, and a function is asked about its resource policy and handed an event.
+ * So each protocol has its own implementation, and this is what picks between
+ * them.
+ */
+export class SimSnsProtocolDeliveryEndpoints implements SimSnsDeliveryEndpoints {
+  private readonly byProtocol: SimSnsEndpointsByProtocol;
+
+  constructor(properties: SimSnsProtocolDeliveryEndpointsProperties) {
+    this.byProtocol = properties.byProtocol;
+  }
+
+  /**
+   * Deliver one message over its subscription's protocol.
+   */
+  async deliver(request: SimSnsDeliveryRequest): Promise<void> {
+    await this.byProtocol[request.subscription.protocol].deliver(request);
+  }
+}

--- a/src/service/sns/delivery/sqs/sim-aws-sns-delivery-queues.ts
+++ b/src/service/sns/delivery/sqs/sim-aws-sns-delivery-queues.ts
@@ -1,5 +1,4 @@
 import type { SimAws } from "../../../aws/sim-aws.js";
-import { SimSnsUnsimulatedInputException } from "../../error/sim-sns.error.js";
 import { SimSnsQueueEndpointArn } from "../../subscription/sim-sns-queue-endpoint-arn.js";
 import type {
   SimSnsDeliveryEndpoints,
@@ -36,34 +35,13 @@ export class SimAwsSnsDeliveryQueues implements SimSnsDeliveryEndpoints {
    * Deliver one message to the queue its subscription's endpoint names.
    */
   async deliver(request: SimSnsDeliveryRequest): Promise<void> {
-    const arn = SimSnsQueueEndpointArn.parse(request.endpointArn);
+    const arn = SimSnsQueueEndpointArn.parse(
+      request.subscription.endpoint.value,
+    );
 
     await new SimSnsDeliveryQueue({
       arn,
       scope: this.simAws.accountRegionScope(arn.accountId, arn.regionName),
     }).deliver(request);
-  }
-}
-
-/**
- * The endpoints a simulated SNS built on its own can reach, which is none.
- *
- * A standalone SimSns has no other simulated services to reach, and owns its
- * own background scheduler, so nothing could wait for a delivery it made even
- * if it could make one. Subscriptions still work, since holding them takes
- * nothing but SNS: it is delivery that is refused, and the refusal is recorded
- * as a delivery failure like any other.
- */
-export class SimSnsNoDeliveryEndpoints implements SimSnsDeliveryEndpoints {
-  /**
-   * Refuse every delivery, explaining how to get one.
-   */
-  deliver(request: SimSnsDeliveryRequest): never {
-    throw new SimSnsUnsimulatedInputException(
-      `Cannot deliver to ${request.endpointArn}: this SimSns was constructed ` +
-        "on its own, so it has no other simulated services to deliver to and " +
-        "no shared background scheduler to deliver on. Reach simulated SNS " +
-        "through SimAws to deliver a published message to a queue.",
-    );
   }
 }

--- a/src/service/sns/delivery/sqs/sim-sns-delivery-queue.ts
+++ b/src/service/sns/delivery/sqs/sim-sns-delivery-queue.ts
@@ -5,8 +5,10 @@ import { SimSnsNotFoundException } from "../../error/sim-sns.error.js";
 import type { SimSnsQueueEndpointArn } from "../../subscription/sim-sns-queue-endpoint-arn.js";
 import {
   type SimSnsDeliveryRequest,
+  simSnsDeliverySource,
   simSnsServicePrincipal,
 } from "../sim-sns-delivery.js";
+import { SimSnsQueueMessage } from "./sim-sns-queue-message.js";
 
 interface SimSnsDeliveryQueueProperties {
   readonly arn: SimSnsQueueEndpointArn;
@@ -39,6 +41,8 @@ export class SimSnsDeliveryQueue {
    * at all, which is why this is the only place it is asked.
    */
   async deliver(request: SimSnsDeliveryRequest): Promise<void> {
+    const source = simSnsDeliverySource(request);
+    const endpointArn = request.subscription.endpoint.value;
     const queue = this.scope.sqs().findQueue(this.arn.queueName);
 
     if (queue === undefined) {
@@ -47,7 +51,7 @@ export class SimSnsDeliveryQueue {
       // about, where a policy saying no is a modelled outcome a test may be
       // asking for on purpose.
       throw new SimSnsNotFoundException(
-        `${request.endpointArn} is not a simulated SQS queue.`,
+        `${endpointArn} is not a simulated SQS queue.`,
       );
     }
 
@@ -56,42 +60,29 @@ export class SimSnsDeliveryQueue {
     }).authorize({
       queue,
       servicePrincipal: simSnsServicePrincipal,
-      sourceArn: request.topicArn,
-      sourceAccount: request.topicOwnerAccountId,
+      ...source,
     });
 
     if (decision.isDenied) {
       throw new SimSnsDeliveryNotPermitted(
-        `The queue policy of ${request.endpointArn} does not allow ` +
-          `${simSnsServicePrincipal} to send to it for ${request.topicArn}. ` +
+        `The queue policy of ${endpointArn} does not allow ` +
+          `${simSnsServicePrincipal} to send to it for ${source.sourceArn}. ` +
           "Grant sqs:SendMessage with the queue's Policy attribute.",
       );
     }
 
-    await this.send(request);
-  }
-
-  /**
-   * Send the message through the ordinary SendMessage path.
-   *
-   * A delivered message is therefore the same thing an SDK caller would have
-   * sent, and is authorized again on the way in.
-   */
-  private async send(request: SimSnsDeliveryRequest): Promise<void> {
+    // Sent through the ordinary SendMessage path, so a delivered message is
+    // the same thing an SDK caller would have sent, and is authorized again on
+    // the way in.
     await this.scope.sqs().sendMessage(
       {
-        input: {
-          QueueUrl: this.arn.queueUrl,
-          MessageBody: request.body,
-          ...(request.messageAttributes !== undefined && {
-            MessageAttributes: request.messageAttributes,
-          }),
-        },
+        input: new SimSnsQueueMessage(request).sendMessageInput(
+          this.arn.queueUrl,
+        ),
       },
       {
         caller: { kind: "service", service: simSnsServicePrincipal },
-        sourceArn: request.topicArn,
-        sourceAccount: request.topicOwnerAccountId,
+        ...source,
       },
     );
   }

--- a/src/service/sns/delivery/sqs/sim-sns-queue-message.ts
+++ b/src/service/sns/delivery/sqs/sim-sns-queue-message.ts
@@ -1,0 +1,44 @@
+import type { SimSendMessageCommand } from "../../../sqs/command/message/send.command.js";
+import type { SimSnsDeliveryRequest } from "../sim-sns-delivery.js";
+import { SimSnsEnvelope } from "../sim-sns-envelope.js";
+
+/**
+ * What one queue is sent for a published message.
+ *
+ * Which form the body takes is the subscription's business rather than the
+ * queue's. `RawMessageDelivery` is an SQS and HTTP protocol setting on real
+ * SNS, so it is asked here rather than anywhere a Lambda delivery would see it:
+ * a function subscribed with it on is invoked with the whole event all the
+ * same.
+ *
+ * Raw delivery takes the envelope away, so the message attributes have nowhere
+ * to travel but the SQS message itself. A consumer written for raw delivery
+ * reads them there, and one taking the envelope reads them out of it.
+ */
+export class SimSnsQueueMessage {
+  private readonly request: SimSnsDeliveryRequest;
+
+  constructor(request: SimSnsDeliveryRequest) {
+    this.request = request;
+  }
+
+  /**
+   * The SendMessage input this delivery becomes.
+   */
+  sendMessageInput(queueUrl: string): SimSendMessageCommand["input"] {
+    const { subscription, message, notification } = this.request;
+
+    if (subscription.attributes.rawMessageDelivery) {
+      return {
+        QueueUrl: queueUrl,
+        MessageBody: message.body.value,
+        MessageAttributes: message.attributes.asSqsAttributes(),
+      };
+    }
+
+    return {
+      QueueUrl: queueUrl,
+      MessageBody: new SimSnsEnvelope({ notification }).body,
+    };
+  }
+}

--- a/src/service/sns/index.ts
+++ b/src/service/sns/index.ts
@@ -28,10 +28,13 @@ export {
   SimSnsSubscriptionAttributes,
 } from "./subscription/sim-sns-subscription-attributes.js";
 export {
+  simSnsLambdaProtocol,
   simSnsSqsProtocol,
   type SimSnsSubscriptionProtocol,
 } from "./subscription/sim-sns-subscription-protocol.js";
+export { SimSnsFunctionEndpointArn } from "./subscription/sim-sns-function-endpoint-arn.js";
 export { SimSnsQueueEndpointArn } from "./subscription/sim-sns-queue-endpoint-arn.js";
+export type { SimSnsSubscriptionEndpoint } from "./subscription/sim-sns-subscription-endpoint.js";
 export type { SimSnsSubscriptionCounts } from "./subscription/sim-sns-subscription-store.js";
 export { SimSnsMessageAttributes } from "./message/sim-sns-message-attributes.js";
 export type {
@@ -49,6 +52,11 @@ export {
   type SimSnsDeliveryRequest,
   simSnsServicePrincipal,
 } from "./delivery/sim-sns-delivery.js";
+export { SimSnsEnvelope } from "./delivery/sim-sns-envelope.js";
+export {
+  SimSnsNotification,
+  type SimSnsNotificationFields,
+} from "./delivery/sim-sns-notification.js";
 export {
   SimSnsDeliveryFailure,
   SimSnsDeliveryFailures,

--- a/src/service/sns/sim-sns.ts
+++ b/src/service/sns/sim-sns.ts
@@ -11,7 +11,7 @@ import {
 } from "../iam/authorize/sim-iam-inter-service-auth-z.js";
 import type { SimSnsDeliveryEndpoints } from "./delivery/sim-sns-delivery.js";
 import type { SimSnsDeliveryFailure } from "./delivery/sim-sns-delivery-failures.js";
-import { SimSnsNoDeliveryEndpoints } from "./delivery/sqs/sim-aws-sns-delivery-queues.js";
+import { SimSnsNoDeliveryEndpoints } from "./delivery/sim-sns-no-delivery-endpoints.js";
 import type * as simSnsCommands from "./command/sim-sns-command.types.js";
 import { SimSnsCommands } from "./command/sim-sns-commands.js";
 import type { SimSnsRequestOptions } from "./command/sim-sns-request-options.js";
@@ -29,8 +29,8 @@ interface SimSnsProperties {
   /**
    * Where this scope's subscriptions deliver to.
    *
-   * A SimSns built on its own has none, since a queue in another simulated
-   * service is only reachable through SimAws.
+   * A SimSns built on its own has none, since a queue or a function in another
+   * simulated service is only reachable through SimAws.
    */
   readonly deliveryEndpoints?: SimSnsDeliveryEndpoints;
 }

--- a/src/service/sns/subscription/sim-sns-function-endpoint-arn.iso.test.ts
+++ b/src/service/sns/subscription/sim-sns-function-endpoint-arn.iso.test.ts
@@ -1,0 +1,59 @@
+import { assertInstanceOf, assertStringIncludes } from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { subscribeRefusal } from "../../../../test/sns/subscription-fixture.js";
+import { SimSnsInvalidParameterException } from "../error/sim-sns.error.js";
+
+/**
+ * Endpoints that are not a Lambda function ARN, one of each way to not be one.
+ *
+ * The queue ARN is here because the protocol decides what the endpoint has to
+ * be: an SQS queue is a fine endpoint over `sqs` and no endpoint at all over
+ * `lambda`.
+ */
+const endpointsThatAreNotFunctions = [
+  "https://example.com/orders",
+  "arn:aws:lambda:us-east-1:888888888888:layer:shared",
+  "arn:aws:sqs:us-east-1:888888888888:orders-queue",
+  "arn:aws:lambda:us-east-1:888888888888:function:",
+  "",
+];
+
+/**
+ * Subscribe an endpoint over the lambda protocol, answering with what it threw.
+ */
+async function functionEndpointRefusal(
+  endpoint: string | undefined,
+): Promise<Error> {
+  return subscribeRefusal({ Protocol: "lambda", Endpoint: endpoint });
+}
+
+describe("The endpoint of a lambda subscription", () => {
+  it("refuses an endpoint that is not a Lambda function ARN", async () => {
+    // Given a topic.
+    // When each is subscribed over the lambda protocol.
+    const refusals = await Promise.all(
+      [...endpointsThatAreNotFunctions, undefined].map(async (endpoint) =>
+        functionEndpointRefusal(endpoint),
+      ),
+    );
+
+    // Then each is refused, since a lambda subscription invokes a function and
+    // none of these names one.
+    for (const error of refusals) {
+      assertInstanceOf(error, SimSnsInvalidParameterException);
+      assertStringIncludes(error.message, "is not a Lambda function ARN");
+    }
+  });
+
+  it("refuses a qualified function ARN naming a version or an alias", async () => {
+    // Given a topic.
+    // When a function alias is subscribed.
+    const error = await functionEndpointRefusal(
+      "arn:aws:lambda:us-east-1:888888888888:function:orders:PROD",
+    );
+
+    // Then it is refused rather than quietly subscribing the unqualified
+    // function, which would be a different function from the one asked for.
+    assertStringIncludes(error.message, "no function versions or aliases");
+  });
+});

--- a/src/service/sns/subscription/sim-sns-function-endpoint-arn.ts
+++ b/src/service/sns/subscription/sim-sns-function-endpoint-arn.ts
@@ -1,0 +1,75 @@
+import type { SimAwsAccountId } from "../../aws/sim-aws-account-id.js";
+import type { AwsRegionName } from "../../aws/sim-aws-region.js";
+import { parseSimLambdaFunctionArn } from "../../lambda/function/sim-lambda-function-arn-parts.js";
+import {
+  SimSnsInvalidParameterException,
+  SimSnsUnsimulatedInputException,
+} from "../error/sim-sns.error.js";
+
+interface SimSnsFunctionEndpointArnProperties {
+  readonly value: string;
+  readonly regionName: AwsRegionName;
+  readonly accountId: SimAwsAccountId;
+  readonly functionName: string;
+}
+
+/**
+ * The Lambda function ARN a subscription's endpoint names.
+ *
+ * The Region and the Account are read out alongside the name, because a
+ * delivery resolves the function in the scope the ARN gives rather than in the
+ * topic's. Real SNS invokes a function in another Account or Region, so this
+ * does too.
+ */
+export class SimSnsFunctionEndpointArn {
+  public readonly value: string;
+  public readonly regionName: AwsRegionName;
+  public readonly accountId: SimAwsAccountId;
+  public readonly functionName: string;
+
+  private constructor(properties: SimSnsFunctionEndpointArnProperties) {
+    this.value = properties.value;
+    this.regionName = properties.regionName;
+    this.accountId = properties.accountId;
+    this.functionName = properties.functionName;
+  }
+
+  /**
+   * Read a function ARN, refusing anything a function could not be reached by.
+   *
+   * Reading the ARN is Lambda's own business, so the parts come from there.
+   * What SNS adds is what an unreadable one means to a `Subscribe` request,
+   * which is the same `InvalidParameterException` a queue ARN that is not one
+   * gets.
+   *
+   * A qualified ARN naming a version or an alias is refused rather than read as
+   * the unqualified function, because simulated Lambda has neither and
+   * delivering to `$LATEST` instead would be the wrong function.
+   */
+  static parse(endpoint: string): SimSnsFunctionEndpointArn {
+    const parts = parseSimLambdaFunctionArn(endpoint);
+
+    if (parts === undefined) {
+      throw new SimSnsInvalidParameterException(
+        `Invalid parameter: Endpoint Reason: ${endpoint} is not a Lambda ` +
+          "function ARN, which is " +
+          "arn:aws:lambda:<region>:<account-id>:function:<function-name>",
+      );
+    }
+
+    if (parts.qualifier !== undefined) {
+      throw new SimSnsUnsimulatedInputException(
+        `Cannot subscribe ${endpoint}: simulated Lambda has no function ` +
+          "versions or aliases, so a qualified function ARN is refused rather " +
+          "than treated as the unqualified function.",
+      );
+    }
+
+    return new this({
+      value: endpoint,
+      regionName: parts.regionName,
+      accountId: parts.accountId,
+      functionName: parts.functionName,
+    });
+  }
+}

--- a/src/service/sns/subscription/sim-sns-subscription-endpoint.ts
+++ b/src/service/sns/subscription/sim-sns-subscription-endpoint.ts
@@ -1,0 +1,45 @@
+import type { SimAwsAccountId } from "../../aws/sim-aws-account-id.js";
+import type { AwsRegionName } from "../../aws/sim-aws-region.js";
+import { SimSnsFunctionEndpointArn } from "./sim-sns-function-endpoint-arn.js";
+import { SimSnsQueueEndpointArn } from "./sim-sns-queue-endpoint-arn.js";
+import {
+  simSnsLambdaProtocol,
+  simSnsSqsProtocol,
+  type SimSnsSubscriptionProtocol,
+} from "./sim-sns-subscription-protocol.js";
+
+/**
+ * Where a subscription delivers, whichever kind of endpoint its protocol
+ * implies.
+ *
+ * Every protocol simulated names its endpoint by an ARN, and every delivery
+ * needs the same three things from it: the ARN itself, and the Account and
+ * Region to resolve the endpoint in. What kind of resource it is belongs to the
+ * protocol's own endpoint type.
+ */
+export interface SimSnsSubscriptionEndpoint {
+  readonly value: string;
+  readonly regionName: AwsRegionName;
+  readonly accountId: SimAwsAccountId;
+}
+
+/**
+ * Read the endpoint a Subscribe request names, for the protocol it named.
+ *
+ * The protocol decides what the endpoint has to be, so an SQS queue ARN over
+ * the `lambda` protocol is refused here rather than at delivery time. Real SNS
+ * validates the endpoint against the protocol at `Subscribe` time too.
+ */
+export function requireSimSnsSubscriptionEndpoint(
+  protocol: SimSnsSubscriptionProtocol,
+  endpoint: string | undefined,
+): SimSnsSubscriptionEndpoint {
+  switch (protocol) {
+    case simSnsSqsProtocol: {
+      return SimSnsQueueEndpointArn.parse(endpoint ?? "");
+    }
+    case simSnsLambdaProtocol: {
+      return SimSnsFunctionEndpointArn.parse(endpoint ?? "");
+    }
+  }
+}

--- a/src/service/sns/subscription/sim-sns-subscription-protocol.ts
+++ b/src/service/sns/subscription/sim-sns-subscription-protocol.ts
@@ -4,19 +4,29 @@ import {
 } from "../error/sim-sns.error.js";
 
 /**
- * The one delivery protocol this simulation delivers over.
+ * Delivery to an SQS queue.
  *
- * A queue is the protocol SNS is most often put in front of, and it is the one
- * with no confirmation step: real SNS confirms an `sqs` subscription itself, so
+ * A queue is what SNS is most often put in front of, and it is a protocol with
+ * no confirmation step: real SNS confirms an `sqs` subscription itself, so
  * `Subscribe` answers with a subscription ARN rather than `pending
  * confirmation`.
  */
 export const simSnsSqsProtocol = "sqs";
 
 /**
+ * Delivery by invoking a Lambda function.
+ *
+ * Real SNS confirms this one itself too, so a `lambda` subscription is
+ * confirmed as soon as it exists. The function is invoked asynchronously with
+ * an event carrying the published message.
+ */
+export const simSnsLambdaProtocol = "lambda";
+
+/**
  * A protocol a simulated subscription can be created with.
  */
-export type SimSnsSubscriptionProtocol = typeof simSnsSqsProtocol;
+export type SimSnsSubscriptionProtocol =
+  typeof simSnsSqsProtocol | typeof simSnsLambdaProtocol;
 
 /**
  * The protocols real SNS has that this simulation does not deliver over.
@@ -27,7 +37,6 @@ export type SimSnsSubscriptionProtocol = typeof simSnsSqsProtocol;
  * silence.
  */
 const unsimulatedProtocols = new Map<string, string>([
-  ["lambda", "Delivery to a simulated Lambda function is not implemented yet."],
   ["http", "Delivery over HTTP would leave the simulation."],
   ["https", "Delivery over HTTPS would leave the simulation."],
   ["email", "Sending email is not simulated."],
@@ -53,8 +62,8 @@ const unsimulatedProtocols = new Map<string, string>([
 export function requireSimSnsProtocol(
   value: string | undefined,
 ): SimSnsSubscriptionProtocol {
-  if (value === simSnsSqsProtocol) {
-    return simSnsSqsProtocol;
+  if (value === simSnsSqsProtocol || value === simSnsLambdaProtocol) {
+    return value;
   }
 
   const named = value ?? "(none)";
@@ -63,7 +72,8 @@ export function requireSimSnsProtocol(
   if (reason !== undefined) {
     throw new SimSnsUnsimulatedInputException(
       `The ${named} subscription protocol is not simulated. ${reason} ` +
-        `Subscribe with the ${simSnsSqsProtocol} protocol instead.`,
+        `Subscribe with the ${simSnsSqsProtocol} or ` +
+        `${simSnsLambdaProtocol} protocol instead.`,
     );
   }
 

--- a/src/service/sns/subscription/sim-sns-subscription.ts
+++ b/src/service/sns/subscription/sim-sns-subscription.ts
@@ -1,9 +1,12 @@
-import { SimSnsQueueEndpointArn } from "./sim-sns-queue-endpoint-arn.js";
 import { SimSnsSubscriptionArn } from "./sim-sns-subscription-arn.js";
 import type {
   SimSnsSubscriptionAttributeInput,
   SimSnsSubscriptionAttributes,
 } from "./sim-sns-subscription-attributes.js";
+import {
+  requireSimSnsSubscriptionEndpoint,
+  type SimSnsSubscriptionEndpoint,
+} from "./sim-sns-subscription-endpoint.js";
 import type { SimSnsSubscriptionProtocol } from "./sim-sns-subscription-protocol.js";
 
 const subscriptionArnAttributeName = "SubscriptionArn";
@@ -19,9 +22,9 @@ const ownerAttributeName = "Owner";
 /**
  * The two attributes describing a confirmation that never had to happen.
  *
- * Real SNS confirms an `sqs` subscription itself, so one created through the
- * API is confirmed as soon as it exists and the confirmation counts as
- * authenticated. Both are reported as constants because there is no protocol
+ * Real SNS confirms an `sqs` or a `lambda` subscription itself, so one created
+ * through the API is confirmed as soon as it exists and the confirmation counts
+ * as authenticated. Both are reported as constants because there is no protocol
  * here that leaves a subscription pending.
  */
 const confirmationAttributes: readonly (readonly [string, string])[] = [
@@ -34,7 +37,7 @@ interface SimSnsSubscriptionProperties {
   readonly topicArn: string;
   readonly topicName: string;
   readonly protocol: SimSnsSubscriptionProtocol;
-  readonly endpoint: SimSnsQueueEndpointArn;
+  readonly endpoint: SimSnsSubscriptionEndpoint;
   readonly owner: string;
   readonly attributes: SimSnsSubscriptionAttributes;
 }
@@ -51,17 +54,17 @@ interface SimSnsSubscriptionInput {
 /**
  * One simulated subscription to a topic.
  *
- * The endpoint is held as a queue ARN rather than as a string because `sqs` is
- * the only protocol simulated, and a delivery has to reach the Account and
- * Region that ARN names rather than the topic's. When another protocol arrives
- * this becomes the endpoint of whichever kind the protocol implies.
+ * The endpoint is held as the ARN its protocol implies rather than as a string,
+ * because a delivery has to reach the Account and Region that ARN names rather
+ * than the topic's, and because what the ARN has to name is a question the
+ * protocol answers: a queue for `sqs`, a function for `lambda`.
  */
 export class SimSnsSubscription {
   public readonly arn: SimSnsSubscriptionArn;
   public readonly topicArn: string;
   public readonly topicName: string;
   public readonly protocol: SimSnsSubscriptionProtocol;
-  public readonly endpoint: SimSnsQueueEndpointArn;
+  public readonly endpoint: SimSnsSubscriptionEndpoint;
   public readonly owner: string;
 
   private held: SimSnsSubscriptionAttributes;
@@ -79,11 +82,11 @@ export class SimSnsSubscription {
   /**
    * Create a subscription, refusing an endpoint the protocol cannot reach.
    *
-   * Nothing checks that the queue exists, because real SNS does not either: a
-   * subscription to a queue that is not there is created, and fails when
-   * something is delivered to it. That is the moment the queue's own policy is
-   * consulted too, so both failures surface in the same place, and a permission
-   * taken away after subscribing stops delivery.
+   * Nothing checks that the endpoint exists, because real SNS does not either:
+   * a subscription to a queue or a function that is not there is created, and
+   * fails when something is delivered to it. That is the moment the endpoint's
+   * own policy is consulted too, so both failures surface in the same place,
+   * and a permission taken away after subscribing stops delivery.
    */
   static of(input: SimSnsSubscriptionInput): SimSnsSubscription {
     const arn = SimSnsSubscriptionArn.forTopic(input.topicArn);
@@ -93,10 +96,27 @@ export class SimSnsSubscription {
       topicArn: input.topicArn,
       topicName: input.topicName,
       protocol: input.protocol,
-      endpoint: SimSnsQueueEndpointArn.parse(input.endpoint ?? ""),
+      endpoint: requireSimSnsSubscriptionEndpoint(
+        input.protocol,
+        input.endpoint,
+      ),
       owner: input.owner,
       attributes: input.attributes,
     });
+  }
+
+  /**
+   * Whether another subscription would be a repeat of this one.
+   *
+   * Real SNS matches a repeated Subscribe on the topic, the protocol and the
+   * endpoint. Both subscriptions belong to a topic already by the time this is
+   * asked, so it is the other two that are compared here.
+   */
+  repeats(other: SimSnsSubscription): boolean {
+    return (
+      this.protocol === other.protocol &&
+      this.endpoint.value === other.endpoint.value
+    );
   }
 
   /**

--- a/test/sns/function-fixture.ts
+++ b/test/sns/function-fixture.ts
@@ -1,0 +1,176 @@
+/**
+ * A simulated AWS with a Lambda function subscribed to a topic, which every SNS
+ * Lambda delivery test needs before it can say anything about an invocation.
+ *
+ * This lives under `test/` for the same reasons as `test/sns/topic-fixture.ts`:
+ * eslint rejects a test file that exports helpers alongside its own `describe`
+ * calls, and `test/**` is type-checked with everything else, excluded from the
+ * published build, not collected as a suite, and not counted in coverage.
+ */
+
+import {
+  AddPermissionCommand,
+  CreateFunctionCommand,
+} from "@aws-sdk/client-lambda";
+import { SubscribeCommand } from "@aws-sdk/client-sns";
+import { assertNonNullable } from "@kensio/smartass";
+
+import type { SimAws } from "../../src/service/aws/sim-aws.js";
+import { makeLambdaZipFileInput } from "../../src/service/lambda/function/code/lambda-zip-file-input.js";
+import type { SimSnsScope } from "./subscription-fixture.js";
+
+/**
+ * One record of the event a subscribed function is invoked with.
+ *
+ * The `Sns` object is read as a bag of values rather than typed field by field,
+ * because what a test is checking is that the right names carry the right
+ * values, including the two whose spelling differs from the SQS envelope.
+ */
+export interface SimSnsLambdaRecord {
+  readonly EventSource: string;
+  readonly EventVersion: string;
+  readonly EventSubscriptionArn: string;
+  readonly Sns: Record<string, unknown>;
+}
+
+/**
+ * The event document SNS invokes a subscribed function with.
+ */
+export interface SimSnsLambdaEvent {
+  readonly Records: readonly SimSnsLambdaRecord[];
+}
+
+/**
+ * A function subscribed to a topic, and what it has been invoked with.
+ */
+export interface SimSnsFunctionFixture {
+  readonly functionArn: string;
+  readonly events: SimSnsLambdaEvent[];
+}
+
+/**
+ * How a test wants its subscribed function to differ from the usual one.
+ */
+export interface SimSnsFunctionOptions extends SimSnsScope {
+  /**
+   * Left out to grant `sns.amazonaws.com` the invoke action for the topic,
+   * which is what a delivery needs.
+   */
+  readonly withoutPermission?: boolean;
+
+  /**
+   * What the handler does once it has recorded the event it received.
+   */
+  readonly onEvent?: () => void;
+}
+
+/**
+ * The ARN a function of a name has in a scope.
+ */
+export function simSnsFunctionArn(
+  simAws: SimAws,
+  functionName: string,
+  scope: SimSnsScope = {},
+): string {
+  const accountId = scope.accountId ?? simAws.defaultAccountId;
+  const regionName = scope.regionName ?? simAws.defaultRegionName;
+
+  return `arn:aws:lambda:${regionName}:${accountId}:function:${functionName}`;
+}
+
+/**
+ * Grant `sns.amazonaws.com` the invoke action on a function for one topic.
+ *
+ * This is the grant real SNS needs on the function's side, and it is the one
+ * AWS documents: the service principal, the invoke action, and the topic it is
+ * invoking for as the source ARN.
+ */
+export async function simSnsAllowInvoke(
+  simAws: SimAws,
+  functionName: string,
+  topicArn: string,
+  scope: SimSnsScope = {},
+): Promise<void> {
+  await simAws
+    .account(scope.accountId ?? simAws.defaultAccountId)
+    .region(scope.regionName ?? simAws.defaultRegionName)
+    .lambda()
+    .addPermission(
+      new AddPermissionCommand({
+        FunctionName: functionName,
+        StatementId: "AllowSns",
+        Action: "lambda:InvokeFunction",
+        Principal: "sns.amazonaws.com",
+        SourceArn: topicArn,
+      }),
+    );
+}
+
+/**
+ * Subscribe a function ARN to a topic over the `lambda` protocol.
+ */
+export async function subscribeFunction(
+  simAws: SimAws,
+  topicArn: string | undefined,
+  functionArn: string,
+): Promise<string> {
+  const subscribed = await simAws.sns().subscribe(
+    new SubscribeCommand({
+      TopicArn: topicArn,
+      Protocol: "lambda",
+      Endpoint: functionArn,
+    }),
+  );
+
+  assertNonNullable(
+    subscribed.SubscriptionArn,
+    "Subscribe answered with an ARN",
+  );
+
+  return subscribed.SubscriptionArn;
+}
+
+/**
+ * Create a function that records what it is invoked with, and subscribe it.
+ *
+ * The recorded events are the array this answers with, so a test asserts
+ * against the event document itself rather than against something the handler
+ * decided to keep out of it.
+ */
+export async function simSnsSubscribedFunction(
+  simAws: SimAws,
+  functionName: string,
+  topicArn: string,
+  options: SimSnsFunctionOptions = {},
+): Promise<SimSnsFunctionFixture> {
+  const events: SimSnsLambdaEvent[] = [];
+  const lambda = simAws
+    .account(options.accountId ?? simAws.defaultAccountId)
+    .region(options.regionName ?? simAws.defaultRegionName)
+    .lambda();
+
+  await lambda.createFunction(
+    new CreateFunctionCommand({
+      FunctionName: functionName,
+      Role: `arn:aws:iam::${options.accountId ?? simAws.defaultAccountId}:role/${functionName}Role`,
+      Code: {
+        ZipFile: makeLambdaZipFileInput((event: SimSnsLambdaEvent) => {
+          events.push(event);
+          options.onEvent?.();
+
+          return "handled";
+        }),
+      },
+    }),
+  );
+
+  if (options.withoutPermission !== true) {
+    await simSnsAllowInvoke(simAws, functionName, topicArn, options);
+  }
+
+  const functionArn = simSnsFunctionArn(simAws, functionName, options);
+
+  await subscribeFunction(simAws, topicArn, functionArn);
+
+  return { functionArn, events };
+}

--- a/test/sns/subscription-fixture.ts
+++ b/test/sns/subscription-fixture.ts
@@ -100,7 +100,6 @@ export async function subscribeRefusal(
  * The protocols real SNS has that nothing in the simulation delivers over.
  */
 export const simSnsUnsimulatedProtocols = [
-  "lambda",
   "http",
   "https",
   "email",


### PR DESCRIPTION
Subscribe with the `lambda` protocol and a function ARN, and a publish invokes that function with the SNS event shape: one `Records` entry carrying the subscription ARN and the published message, its subject and its message attributes. `Records` always holds exactly one entry, even for a `PublishBatch`, because real SNS does not batch to Lambda. The function's resource policy has to allow `sns.amazonaws.com` to invoke it for the topic, and it is read on every delivery rather than remembered from subscribe time, so a permission taken away afterwards stops delivery. Delivery endpoints are now one implementation per protocol, picked by the subscription's protocol, and the signed notification is built once for whichever document carries it: the envelope a queue receives spells two of the URLs `SigningCertURL` and `UnsubscribeURL` where the Lambda event spells them `SigningCertUrl` and `UnsubscribeUrl`.

Resolves https://github.com/KensioSoftware/yulin/issues/470

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added SNS subscriptions using Lambda endpoints alongside SQS.
  - Added Lambda invocation with SNS-formatted events, message metadata, and subscription details.
  - Added support for cross-account and cross-region Lambda delivery.
  - Added authorization checks through Lambda resource policies.
  - Added delivery failure reporting for missing functions, denied permissions, and handler failures.
  - Added endpoint validation for Lambda function ARNs and improved SNS delivery documentation.

- **Bug Fixes**
  - Improved duplicate subscription detection and protocol-specific endpoint handling.
  - Preserved SNS message attributes and envelope behavior for SQS delivery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->