### PR TITLE
fix: authorize SQS ListQueues against *

### DIFF
--- a/docs/services/sqs/README.md
+++ b/docs/services/sqs/README.md
@@ -457,8 +457,8 @@ Every operation is authorized against the queue's ARN, which carries the queue n
 type in front of it. Two details are worth knowing, because both are real SQS behaviour that a policy
 can get wrong:
 
-- `ListQueues` has no queue-level permission, so a policy allowing it names
-  `arn:aws:sqs:<region>:<account-id>:*`. A policy naming one queue grants no listing.
+- `ListQueues` has no resource type at all, so a policy allowing it names `*`. A policy naming one
+  queue, or every queue in the Account and Region, grants no listing.
 - The batch operations are authorized as their singular action. There is no `sqs:SendMessageBatch`,
   `sqs:DeleteMessageBatch` or `sqs:ChangeMessageVisibilityBatch` action for a policy to name.
 

--- a/src/service/sns/README.md
+++ b/src/service/sns/README.md
@@ -318,8 +318,7 @@ Two details are real SNS behaviour worth keeping:
 
 - `ListTopics` authorizes against `*`, because real SNS gives it no resource type at all. Only a
   policy whose `Resource` is `*` allows it, and one naming a topic ARN, or every topic ARN in the
-  Account and Region, allows no listing. Simulated SQS authorizes `ListQueues` against
-  `arn:aws:sqs:region:account:*` instead, which admits a policy real SQS would refuse.
+  Account and Region, allows no listing. Simulated SQS authorizes `ListQueues` the same way.
 - `Unsubscribe`, `ListSubscriptions`, `GetSubscriptionAttributes` and `SetSubscriptionAttributes`
   authorize against `*` for the same reason: SNS has one resource type, the topic, and none of these
   four names one. A topic policy therefore cannot grant them. `Subscribe` and

--- a/src/service/sqs/README.md
+++ b/src/service/sqs/README.md
@@ -176,8 +176,8 @@ here, as it matches nothing on real AWS.
 
 Two details are real SQS behaviour worth keeping:
 
-- `ListQueues` authorizes against `arn:aws:sqs:region:account:*`, because real SQS gives it no
-  queue-level permission. A policy naming one queue ARN therefore allows no listing.
+- `ListQueues` authorizes against `*`, because real SQS gives it no resource type at all. A policy
+  naming one queue ARN, or every queue ARN in the Account and Region, therefore allows no listing.
 - The batch operations authorize as their singular action. Real SQS has no `sqs:SendMessageBatch`,
   `sqs:DeleteMessageBatch` or `sqs:ChangeMessageVisibilityBatch` action, so a policy naming one grants
   nothing.

--- a/src/service/sqs/command/authorize/sim-sqs-authorizer.ts
+++ b/src/service/sqs/command/authorize/sim-sqs-authorizer.ts
@@ -1,17 +1,24 @@
 import type { SimAwsResolvedCaller } from "../../../aws/caller/sim-aws-caller-resolver.js";
-import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
 import type { SimIamResourcePolicyInput } from "../../../iam/authorize/context/sim-iam-auth-z-context-builder.js";
 import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
 import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
 import type { SimSqsQueue } from "../../queue/sim-sqs-queue.js";
-import { sqsAnyQueueArn } from "../../queue/sim-sqs-queue-arn.js";
 import type { SimSqsRequestOptions } from "../sim-sqs-request-options.js";
 import { simSqsConditionContext } from "./sim-sqs-condition-context.js";
 import { simSqsQueueResourcePolicies } from "./sim-sqs-queue-resource-policies.js";
 
+/**
+ * The resource an action with no resource type authorizes against.
+ *
+ * Real SQS gives ListQueues no resource type at all, so IAM evaluates it
+ * against `*` and only a policy whose Resource is `*` allows it. A policy
+ * naming a queue ARN, or every queue ARN in the Account and Region, allows no
+ * listing, here as on AWS.
+ */
+const noResource = "*";
+
 interface SimSqsAuthorizerProperties {
   readonly iam: SimIamInterServiceAuthZ;
-  readonly accountRegionScope: SimAwsAccountRegionScope;
 }
 
 interface SimSqsQueueAuthorizationInput {
@@ -46,17 +53,15 @@ interface SimSqsResourceAuthorizationInput {
  * what admits a caller from another Account or a service principal, since
  * neither is covered by an identity policy in the Account owning the queue.
  *
- * ListQueues is the exception: real SQS gives it no queue-level permission, so
- * it authorizes against every queue in the account and region rather than one of
- * them, and no queue policy applies to it.
+ * ListQueues is the exception: real SQS gives it no resource type, so it
+ * authorizes against `*` rather than against a queue, and no queue policy
+ * applies to it.
  */
 export class SimSqsAuthorizer {
   private readonly iam: SimIamInterServiceAuthZ;
-  private readonly accountRegionScope: SimAwsAccountRegionScope;
 
   constructor(properties: SimSqsAuthorizerProperties) {
     this.iam = properties.iam;
-    this.accountRegionScope = properties.accountRegionScope;
   }
 
   /**
@@ -85,7 +90,7 @@ export class SimSqsAuthorizer {
   ): SimAwsResolvedCaller {
     return this.authorizeResource({
       action,
-      resource: sqsAnyQueueArn(this.accountRegionScope),
+      resource: noResource,
       resourcePolicies: [],
       options,
     });

--- a/src/service/sqs/command/authorize/sim-sqs-iam.iso.test.ts
+++ b/src/service/sqs/command/authorize/sim-sqs-iam.iso.test.ts
@@ -205,12 +205,12 @@ describe("SQS IAM authorization", () => {
     );
   });
 
-  it("authorizes listing against every queue in the Account and Region", async () => {
-    // Given a Role allowed to list with the resource real SQS documents for it.
+  it("allows listing to a policy whose resource is a bare wildcard", async () => {
+    // Given a Role allowed to list queues the only way real SQS allows it.
     const { simAws, caller } = await simAwsWithRole({
       Effect: "Allow",
       Action: "sqs:ListQueues",
-      Resource: `arn:aws:sqs:${regionName}:${accountId}:*`,
+      Resource: "*",
     });
 
     // When it lists the queues.
@@ -222,22 +222,36 @@ describe("SQS IAM authorization", () => {
     assertIdentical(listed.QueueUrls?.length, 1);
   });
 
-  it("denies listing to a policy naming one queue ARN", async () => {
-    // Given a Role allowed to list only the one queue by name, which real SQS
-    // gives no queue-level permission for.
-    const { simAws, caller } = await simAwsWithRole({
+  it("gives listing no queue-level permission", async () => {
+    // Given Roles allowed to list queues by naming one queue ARN, and by
+    // naming every queue ARN in the Account and Region.
+    const oneQueue = await simAwsWithRole({
       Effect: "Allow",
       Action: "sqs:ListQueues",
       Resource: `arn:aws:sqs:${regionName}:${accountId}:orders`,
     });
-
-    // When it lists the queues.
-    const error = await assertThrowsErrorAsync(async () => {
-      await simAws.sqs().listQueues(new ListQueuesCommand({}), { caller });
+    const everyQueue = await simAwsWithRole({
+      Effect: "Allow",
+      Action: "sqs:ListQueues",
+      Resource: `arn:aws:sqs:${regionName}:${accountId}:*`,
     });
 
-    // Then it is denied, as it would be on real AWS.
-    assertIdentical(error.name, "AccessDenied");
+    // When each lists the queues.
+    const refusals = await Promise.all(
+      [oneQueue, everyQueue].map(async ({ simAws, caller }) =>
+        assertThrowsErrorAsync(async () => {
+          await simAws.sqs().listQueues(new ListQueuesCommand({}), { caller });
+        }),
+      ),
+    );
+
+    // Then neither allows it. Real SQS gives ListQueues no resource type at
+    // all, so it is authorized against `*` and only a policy naming `*`
+    // reaches it.
+    for (const error of refusals) {
+      assertIdentical(error.name, "AccessDenied");
+      assertStringIncludes(error.message, "resource: *");
+    }
   });
 
   it("denies a create the Role has no permission for", async () => {

--- a/src/service/sqs/index.ts
+++ b/src/service/sqs/index.ts
@@ -10,7 +10,6 @@ export {
   type SimSqsQueueWatcher,
 } from "./queue/sim-sqs-queue-activity.js";
 export {
-  sqsAnyQueueArn,
   SimSqsQueueArn,
   type SimSqsQueueLocation,
   sqsQueueArnPrefix,

--- a/src/service/sqs/queue/sim-sqs-queue-arn.ts
+++ b/src/service/sqs/queue/sim-sqs-queue-arn.ts
@@ -18,18 +18,6 @@ export function sqsQueueArnPrefix(
 }
 
 /**
- * The resource an operation naming no particular queue authorizes against.
- *
- * Real SQS gives ListQueues no queue-level permission, so a policy allowing it
- * names every queue in the account and region rather than one of them.
- */
-export function sqsAnyQueueArn(
-  accountRegionScope: SimAwsAccountRegionScope,
-): string {
-  return `${sqsQueueArnPrefix(accountRegionScope)}*`;
-}
-
-/**
  * Where one queue is, in the three facts both its ARN and its URL carry.
  *
  * The strings are unbranded because the callers that have only read an ARN,

--- a/src/service/sqs/sim-sqs.ts
+++ b/src/service/sqs/sim-sqs.ts
@@ -66,7 +66,7 @@ export class SimSqs {
 
     const access = new SimSqsQueueAccess({
       queues: this.queues,
-      authorizer: new SimSqsAuthorizer({ iam, accountRegionScope }),
+      authorizer: new SimSqsAuthorizer({ iam }),
       accountRegionScope,
       clock: background,
     });


### PR DESCRIPTION
Simulated SQS authorized `ListQueues` against the queue ARN wildcard for the Account and Region, so an identity policy naming that ARN allowed a listing here and was denied on AWS. Real SQS gives `ListQueues` no resource type at all, so IAM evaluates it against `*` and only a policy whose `Resource` is `*` allows it. The authorizer now uses `*`, as every other simulated service with a resourceless action already does, and `sqsAnyQueueArn` goes with its export from `@kensio/yulin/sqs` since nothing else called it. The test asserting the old behaviour inverts rather than being added to, and the SQS READMEs stop describing the queue ARN wildcard as real SQS behaviour.

Resolves https://github.com/KensioSoftware/yulin/issues/475

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that SQS `ListQueues` requires the `*` resource.
  * Clarified that SNS `ListTopics` authorizes against `*`.

* **Bug Fixes**
  * Corrected SQS listing authorization behavior.
  * Queue-specific and account/region-scoped ARN policies no longer incorrectly grant permission to list queues.

* **Tests**
  * Added coverage confirming valid and invalid SQS `ListQueues` authorization scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->