### PR TITLE
feat: deploy simulated SNS from CloudFormation

### DIFF
--- a/docs/services/cloudformation/README.md
+++ b/docs/services/cloudformation/README.md
@@ -585,34 +585,34 @@ const stack = await simAws.cloudFormation().deployTemplate({
   stackName: "stand-in-stack",
   template: {
     Resources: {
-      AlarmTopic: {
-        Type: "AWS::SNS::Topic",
+      AlarmRule: {
+        Type: "AWS::Events::Rule",
       },
     },
     Outputs: {
-      TopicRef: { Value: { Ref: "AlarmTopic" } },
-      TopicArn: { Value: { "Fn::GetAtt": ["AlarmTopic", "TopicArn"] } },
+      RuleRef: { Value: { Ref: "AlarmRule" } },
+      RuleArn: { Value: { "Fn::GetAtt": ["AlarmRule", "Arn"] } },
     },
   },
 });
 
 await stack.waitForDeployComplete();
 
-console.log(stack.outputs.get("TopicRef")?.value);
-// "AlarmTopic"
+console.log(stack.outputs.get("RuleRef")?.value);
+// "AlarmRule"
 
-console.log(stack.outputs.get("TopicArn")?.value);
-// "AlarmTopic.TopicArn"
+console.log(stack.outputs.get("RuleArn")?.value);
+// "AlarmRule.Arn"
 
 for (const skipped of stack.skippedResources) {
   console.log(skipped.logicalId, skipped.skippedReason);
-  // "AlarmTopic Unsupported sim CloudFormation Resource service SNS"
+  // "AlarmRule Unsupported sim CloudFormation Resource service Events"
 }
 ```
 
 The stand-ins are what lets a template with unsimulated Resources in it deploy at all. Without them,
 every Resource holding a `Ref` or `Fn::GetAtt` to a skipped Resource would fail too, and so would
-every Resource depending on those, until one SNS topic took the whole stack down with it. The skip
+every Resource depending on those, until one EventBridge rule took the whole stack down with it. The skip
 stays where it happened.
 
 A stand-in is deliberately not ARN-shaped, so it fails closed wherever the simulator reads it.
@@ -1729,8 +1729,8 @@ const stack = await simAws.cloudFormation().deployTemplate({
           BucketName: "skipped-site-bucket",
         },
       },
-      AlarmTopic: {
-        Type: "AWS::SNS::Topic",
+      AlarmRule: {
+        Type: "AWS::Events::Rule",
       },
     },
   },
@@ -1739,10 +1739,10 @@ const stack = await simAws.cloudFormation().deployTemplate({
 await stack.waitForDeployComplete();
 
 console.log(stack.skippedResources.map((resource) => resource.logicalId));
-// ["AlarmTopic"]
+// ["AlarmRule"]
 
-console.log(stack.getResource("AlarmTopic")?.skippedReason);
-// "Unsupported sim CloudFormation Resource service SNS"
+console.log(stack.getResource("AlarmRule")?.skippedReason);
+// "Unsupported sim CloudFormation Resource service Events"
 ```
 
 A skipped Resource is still in `stack.resources`, and still answers `Ref` and `Fn::GetAtt` with

--- a/docs/services/cloudformation/sim-cloudformation-inspect-skipped.example.ts
+++ b/docs/services/cloudformation/sim-cloudformation-inspect-skipped.example.ts
@@ -16,8 +16,8 @@ const stack = await simAws.cloudFormation().deployTemplate({
           BucketName: "skipped-site-bucket",
         },
       },
-      AlarmTopic: {
-        Type: "AWS::SNS::Topic",
+      AlarmRule: {
+        Type: "AWS::Events::Rule",
       },
     },
   },
@@ -26,7 +26,7 @@ const stack = await simAws.cloudFormation().deployTemplate({
 await stack.waitForDeployComplete();
 
 console.log(stack.skippedResources.map((resource) => resource.logicalId));
-// ["AlarmTopic"]
+// ["AlarmRule"]
 
-console.log(stack.getResource("AlarmTopic")?.skippedReason);
-// "Unsupported sim CloudFormation Resource service SNS"
+console.log(stack.getResource("AlarmRule")?.skippedReason);
+// "Unsupported sim CloudFormation Resource service Events"

--- a/docs/services/cloudformation/sim-cloudformation-skipped-resource-values.example.ts
+++ b/docs/services/cloudformation/sim-cloudformation-skipped-resource-values.example.ts
@@ -10,26 +10,26 @@ const stack = await simAws.cloudFormation().deployTemplate({
   stackName: "stand-in-stack",
   template: {
     Resources: {
-      AlarmTopic: {
-        Type: "AWS::SNS::Topic",
+      AlarmRule: {
+        Type: "AWS::Events::Rule",
       },
     },
     Outputs: {
-      TopicRef: { Value: { Ref: "AlarmTopic" } },
-      TopicArn: { Value: { "Fn::GetAtt": ["AlarmTopic", "TopicArn"] } },
+      RuleRef: { Value: { Ref: "AlarmRule" } },
+      RuleArn: { Value: { "Fn::GetAtt": ["AlarmRule", "Arn"] } },
     },
   },
 });
 
 await stack.waitForDeployComplete();
 
-console.log(stack.outputs.get("TopicRef")?.value);
-// "AlarmTopic"
+console.log(stack.outputs.get("RuleRef")?.value);
+// "AlarmRule"
 
-console.log(stack.outputs.get("TopicArn")?.value);
-// "AlarmTopic.TopicArn"
+console.log(stack.outputs.get("RuleArn")?.value);
+// "AlarmRule.Arn"
 
 for (const skipped of stack.skippedResources) {
   console.log(skipped.logicalId, skipped.skippedReason);
-  // "AlarmTopic Unsupported sim CloudFormation Resource service SNS"
+  // "AlarmRule Unsupported sim CloudFormation Resource service Events"
 }

--- a/docs/services/s3/README.md
+++ b/docs/services/s3/README.md
@@ -824,10 +824,9 @@ S3 invoke the function. Yulin applies that request through the same command path
 reaches, so a configuration is validated the same way whichever it arrives by.
 
 `SqsDestination` and `SnsDestination` write their entry into the same resource, alongside the
-`AWS::SQS::QueuePolicy` or `AWS::SNS::TopicPolicy` that grants S3 access. The queue policy deploys;
-the topic policy does not yet, since the SNS CloudFormation resource types are not implemented. An
-`AWS::SNS::Topic` does not deploy either, so create the topic and set its `Policy` attribute through
-the SDK before deploying a stack whose Bucket notifies one.
+`AWS::SQS::QueuePolicy` or `AWS::SNS::TopicPolicy` that grants S3 access. Both of those deploy, as
+does the `AWS::SNS::Topic` beside them, so a stack whose Bucket notifies a topic needs nothing set
+up by hand.
 
 Deploy into an Account and Region matching the ones the CDK app synthesized for. The `SourceAccount`
 on the permission CDK writes beside the notification is a synth-time literal, so a stack deployed
@@ -936,10 +935,6 @@ writes do not match it. Without that, the simulation stops after a thousand deli
   and an EventBridge destination in one is refused by name as it is for an SDK caller.
 - A FIFO queue destination is refused by name, as real S3 refuses one. Simulated SQS has no FIFO
   queues either, and neither does simulated SNS, so a FIFO topic destination is refused the same way.
-- Neither the `AWS::SNS::Topic` a CDK app declares nor the `AWS::SNS::TopicPolicy` its
-  `SnsDestination` writes beside it deploys, since the SNS CloudFormation resource types are not
-  implemented. Create the topic and set its `Policy` attribute through the SDK before deploying a
-  stack whose Bucket notifies one, or S3 refuses the destination.
 - The KMS key policy statement CDK's `SqsDestination` writes for an encrypted queue is not acted on.
   Queue encryption is not simulated.
 - A CDK `BucketDeployment` and `mountBucketFilesystem(...)` both replace the whole storage backend

--- a/docs/services/sns/README.md
+++ b/docs/services/sns/README.md
@@ -1326,6 +1326,172 @@ The same applies to `SimSdk` interception: intercepting `SNSClient` routes ordin
 simulation with nothing touching the network. See
 [AWS SDK interception](../../sdk/ "Simulated AWS SDK docs").
 
+## Deploying a topic from CloudFormation
+
+Simulated CloudFormation creates a topic from an `AWS::SNS::Topic` resource, in the stack's account
+and region. The topic is created through `CreateTopic`, so a template-created topic is the same thing
+an SDK caller would get: the same name validation, the same attributes, the same ARN.
+
+`Ref` on the resource gives the topic ARN, as it does on real AWS, so it can be handed straight to
+`Publish` or `Subscribe`. `Fn::GetAtt … TopicArn` gives the same string, and `Fn::GetAtt … TopicName`
+gives the name without the account and region around it.
+
+`AWS::SNS::Subscription` subscribes through `Subscribe`, so its `Protocol` has to be one of the two
+simulated and its `Endpoint` has to be an ARN that protocol can reach. `RawMessageDelivery`,
+`FilterPolicy` and `FilterPolicyScope` are carried through as subscription attributes, so a filter
+policy written in a template is read exactly as one set through the SDK. The policy is an object in
+the template where the API takes a JSON string; the conversion happens on the way in. `Ref` on the
+resource gives the subscription ARN.
+
+```typescript sim-sns-cloudformation-topic
+/**
+ * Deploying a topic and a queue subscription from a CloudFormation template.
+ */
+
+import { PublishCommand } from "@aws-sdk/client-sns";
+import { ReceiveMessageCommand } from "@aws-sdk/client-sqs";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "orders-stack",
+  template: {
+    Resources: {
+      OrdersTopic: {
+        Type: "AWS::SNS::Topic",
+        Properties: { TopicName: "orders", DisplayName: "Orders" },
+      },
+      FulfilmentQueue: {
+        Type: "AWS::SQS::Queue",
+        Properties: { QueueName: "fulfilment" },
+      },
+      // The queue policy is what lets SNS deliver to the queue. It is checked
+      // on every message, as it is on real AWS.
+      FulfilmentQueuePolicy: {
+        Type: "AWS::SQS::QueuePolicy",
+        Properties: {
+          Queues: [{ Ref: "FulfilmentQueue" }],
+          PolicyDocument: {
+            Version: "2012-10-17",
+            Statement: [
+              {
+                Effect: "Allow",
+                Principal: { Service: "sns.amazonaws.com" },
+                Action: "sqs:SendMessage",
+                Resource: { "Fn::GetAtt": ["FulfilmentQueue", "Arn"] },
+                Condition: {
+                  ArnEquals: { "aws:SourceArn": { Ref: "OrdersTopic" } },
+                },
+              },
+            ],
+          },
+        },
+      },
+      FulfilmentSubscription: {
+        Type: "AWS::SNS::Subscription",
+        Properties: {
+          TopicArn: { Ref: "OrdersTopic" },
+          Protocol: "sqs",
+          Endpoint: { "Fn::GetAtt": ["FulfilmentQueue", "Arn"] },
+          RawMessageDelivery: true,
+        },
+      },
+    },
+    Outputs: {
+      OrdersTopicArn: { Value: { Ref: "OrdersTopic" } },
+      FulfilmentQueueUrl: { Value: { Ref: "FulfilmentQueue" } },
+    },
+  },
+});
+
+// Ref on a topic resolves to its ARN, so it works as a Publish TopicArn.
+const topicArn = stack.outputs.get("OrdersTopicArn")?.value as string;
+
+await simAws
+  .sns()
+  .publish(new PublishCommand({ TopicArn: topicArn, Message: "order-1" }));
+
+// Delivery happens after the publish is answered, as it does on real SNS.
+await simAws.backgroundTasksComplete();
+
+const QueueUrl = stack.outputs.get("FulfilmentQueueUrl")?.value as string;
+const { Messages } = await simAws
+  .sqs()
+  .receiveMessage(new ReceiveMessageCommand({ QueueUrl }));
+
+console.log(Messages?.[0]?.Body); // "order-1"
+```
+
+A topic with no `TopicName` is named from the stack name and the logical ID, so the topic above with
+its name left out would be `orders-stack-OrdersTopic`. Real CloudFormation adds random characters to
+that, which a template cannot predict either way. The generated name is trimmed to the 256 characters
+a topic name allows, ending in a hash of the untrimmed name so two long names that start the same
+stay apart.
+
+A topic can also declare its subscriptions inside itself, with the `Subscription` property, which is
+how a hand-written template usually writes them. Each entry is a `Protocol` and an `Endpoint`, and
+each goes through `Subscribe` the same way a separate resource does. A subscription written this way
+has no attributes, so a filter policy or raw message delivery needs the separate resource.
+
+```typescript
+{
+  Type: "AWS::SNS::Topic",
+  Properties: {
+    TopicName: "orders",
+    Subscription: [
+      {
+        Protocol: "sqs",
+        Endpoint: { "Fn::GetAtt": ["FulfilmentQueue", "Arn"] },
+      },
+    ],
+  },
+}
+```
+
+`AWS::SNS::TopicPolicy` deploys the policy it names onto each topic in its `Topics` list, through
+`SetTopicAttributes`. A policy declared in a template is therefore validated and enforced exactly as
+one set through the SDK, and a document SNS would refuse fails the resource. `Topics` carries topic
+ARNs, which is what `Ref` on an `AWS::SNS::Topic` gives.
+
+```typescript
+{
+  Type: "AWS::SNS::TopicPolicy",
+  Properties: {
+    Topics: [{ Ref: "OrdersTopic" }],
+    PolicyDocument: {
+      Version: "2012-10-17",
+      Statement: [
+        {
+          Effect: "Allow",
+          Principal: { Service: "s3.amazonaws.com" },
+          Action: "sns:Publish",
+          Resource: { Ref: "OrdersTopic" },
+        },
+      ],
+    },
+  },
+}
+```
+
+A property with no simulated behaviour fails the resource rather than being dropped. That covers
+`FifoTopic`, `ContentBasedDeduplication`, `FifoThroughputScope`, `KmsMasterKeyId`,
+`SignatureVersion`, `TracingConfig`, `ArchivePolicy`, `DeliveryStatusLogging`, `DataProtectionPolicy`
+and `Tags` on a topic, and `DeliveryPolicy`, `RedrivePolicy`, `ReplayPolicy`, `SubscriptionRoleArn`
+and `Region` on a subscription. Most of them are refused by simulated SNS itself, since they are
+topic or subscription attributes of the same name, so the reason is the same one an SDK caller gets.
+A property the resource type does not have at all is refused too. The failure is worded as an invalid
+resource rather than an unsupported one, so the resource fails instead of being
+[skipped](../cloudformation/README.md#values-from-a-skipped-resource): a topic that cannot be created
+as the template asked for it would otherwise leave a stack that looks deployed with nothing
+publishing.
+
+CDK works without hand-editing. `topic.addSubscription(new subscriptions.SqsSubscription(queue))`
+synthesises an `AWS::SNS::Subscription` alongside the `AWS::SQS::QueuePolicy` that authorizes the
+delivery, and both deploy. `new subscriptions.LambdaSubscription(fn)` does the same with the
+`AWS::Lambda::Permission` beside it.
+
 ## Available functionality
 
 Sim SNS currently supports:
@@ -1358,6 +1524,9 @@ Sim SNS currently supports:
   the configuration is applied and again on every event
 - Calls made from inside a simulated Lambda handler, authorized as the function's execution role
 - `SNSClient` interception, routing ordinary SDK code into the simulation
+- `AWS::SNS::Topic`, `AWS::SNS::Subscription` and `AWS::SNS::TopicPolicy` deployed from a
+  CloudFormation template, each through the SDK command an SDK caller would reach, with the inline
+  `Subscription` property on a topic and `Ref` and `Fn::GetAtt` over the deployed resources
 
 ## Limitations
 
@@ -1445,10 +1614,13 @@ Current documented limitations:
   `sms`, `application` and `firehose`, and SMS sandbox and opt-out management are not planned.
 - SNS condition keys such as `sns:Endpoint` and `sns:Protocol` are not derived, so a policy relying on
   them will not match. Ordinary condition operators on values sim IAM does supply work as usual.
-- The CloudFormation resource types are not implemented, so `AWS::SNS::Topic`,
-  `AWS::SNS::Subscription` and `AWS::SNS::TopicPolicy` in a template do not deploy a topic yet. A
-  stack whose Bucket notifies a topic therefore needs the topic and its policy set up through the SDK
-  first.
+- `FifoTopic: false` in a template fails the resource rather than deploying a standard topic. It is
+  passed to `CreateTopic` as the attribute of the same name, which simulated SNS refuses by name
+  whatever the value is. CDK leaves the property out for a standard topic, so this only reaches a
+  hand-written template.
+- `AWS::SNS::Topic` and `AWS::SNS::Subscription` are replaced rather than updated in place when a
+  stack update changes one, as every simulated CloudFormation resource is. A replaced topic is a new
+  topic, so anything the old one held is gone.
 - An S3 event notification published to a topic carries no message attributes, since real S3 publishes
   none. The only thing on the message besides the event document is the `Amazon S3 Notification`
   subject.

--- a/docs/services/sns/README.md
+++ b/docs/services/sns/README.md
@@ -1341,7 +1341,8 @@ simulated and its `Endpoint` has to be an ARN that protocol can reach. `RawMessa
 `FilterPolicy` and `FilterPolicyScope` are carried through as subscription attributes, so a filter
 policy written in a template is read exactly as one set through the SDK. The policy is an object in
 the template where the API takes a JSON string; the conversion happens on the way in. `Ref` on the
-resource gives the subscription ARN.
+resource gives the subscription ARN, and `Fn::GetAtt … Arn` gives the same string, since the ARN is
+the resource's physical id.
 
 ```typescript sim-sns-cloudformation-topic
 /**
@@ -1432,8 +1433,9 @@ stay apart.
 
 A topic can also declare its subscriptions inside itself, with the `Subscription` property, which is
 how a hand-written template usually writes them. Each entry is a `Protocol` and an `Endpoint`, and
-each goes through `Subscribe` the same way a separate resource does. A subscription written this way
-has no attributes, so a filter policy or raw message delivery needs the separate resource.
+each goes through `Subscribe` the same way a separate resource does. A `Protocol` and an `Endpoint`
+are all real CloudFormation lets an entry carry, so an entry carrying anything else fails the
+resource. A filter policy or raw message delivery needs the separate resource.
 
 ```typescript
 {

--- a/docs/services/sns/sim-sns-cloudformation-topic.example.ts
+++ b/docs/services/sns/sim-sns-cloudformation-topic.example.ts
@@ -1,0 +1,78 @@
+/**
+ * Deploying a topic and a queue subscription from a CloudFormation template.
+ */
+
+import { PublishCommand } from "@aws-sdk/client-sns";
+import { ReceiveMessageCommand } from "@aws-sdk/client-sqs";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "orders-stack",
+  template: {
+    Resources: {
+      OrdersTopic: {
+        Type: "AWS::SNS::Topic",
+        Properties: { TopicName: "orders", DisplayName: "Orders" },
+      },
+      FulfilmentQueue: {
+        Type: "AWS::SQS::Queue",
+        Properties: { QueueName: "fulfilment" },
+      },
+      // The queue policy is what lets SNS deliver to the queue. It is checked
+      // on every message, as it is on real AWS.
+      FulfilmentQueuePolicy: {
+        Type: "AWS::SQS::QueuePolicy",
+        Properties: {
+          Queues: [{ Ref: "FulfilmentQueue" }],
+          PolicyDocument: {
+            Version: "2012-10-17",
+            Statement: [
+              {
+                Effect: "Allow",
+                Principal: { Service: "sns.amazonaws.com" },
+                Action: "sqs:SendMessage",
+                Resource: { "Fn::GetAtt": ["FulfilmentQueue", "Arn"] },
+                Condition: {
+                  ArnEquals: { "aws:SourceArn": { Ref: "OrdersTopic" } },
+                },
+              },
+            ],
+          },
+        },
+      },
+      FulfilmentSubscription: {
+        Type: "AWS::SNS::Subscription",
+        Properties: {
+          TopicArn: { Ref: "OrdersTopic" },
+          Protocol: "sqs",
+          Endpoint: { "Fn::GetAtt": ["FulfilmentQueue", "Arn"] },
+          RawMessageDelivery: true,
+        },
+      },
+    },
+    Outputs: {
+      OrdersTopicArn: { Value: { Ref: "OrdersTopic" } },
+      FulfilmentQueueUrl: { Value: { Ref: "FulfilmentQueue" } },
+    },
+  },
+});
+
+// Ref on a topic resolves to its ARN, so it works as a Publish TopicArn.
+const topicArn = stack.outputs.get("OrdersTopicArn")?.value as string;
+
+await simAws
+  .sns()
+  .publish(new PublishCommand({ TopicArn: topicArn, Message: "order-1" }));
+
+// Delivery happens after the publish is answered, as it does on real SNS.
+await simAws.backgroundTasksComplete();
+
+const QueueUrl = stack.outputs.get("FulfilmentQueueUrl")?.value as string;
+const { Messages } = await simAws
+  .sqs()
+  .receiveMessage(new ReceiveMessageCommand({ QueueUrl }));
+
+console.log(Messages?.[0]?.Body); // "order-1"

--- a/src/service/cloudformation/cdk/s3/bucket-notifications/sim-cdk-bucket-notifications-topic.iso.test.ts
+++ b/src/service/cloudformation/cdk/s3/bucket-notifications/sim-cdk-bucket-notifications-topic.iso.test.ts
@@ -21,9 +21,9 @@ import { simCdkBucketNotificationsTemplateFactory } from "./sim-cdk-bucket-notif
 describe("CDK Bucket notifications to an SNS topic", () => {
   it("notifies a topic the way CDK's SnsDestination configures one", async () => {
     // Given a topic whose policy carries the ArnLike source ARN condition
-    // CDK's SnsDestination writes, and a queue subscribed to it. CDK writes
-    // that policy as an AWS::SNS::TopicPolicy, which simulated CloudFormation
-    // does not deploy yet, so the topic is set up through the SDK here.
+    // CDK's SnsDestination writes, and a queue subscribed to it. The topic is
+    // set up through the SDK here, so the test is about the notification
+    // rather than about the AWS::SNS::TopicPolicy CDK writes that policy as.
     const simAws = new SimAws();
     const topicArn = await simS3NotificationTopic(simAws, {
       sourceArn: "arn:aws:s3:::uploads",

--- a/src/service/cloudformation/cdk/sns/sim-cdk-sns-subscriptions.loc.test.ts
+++ b/src/service/cloudformation/cdk/sns/sim-cdk-sns-subscriptions.loc.test.ts
@@ -1,0 +1,147 @@
+import { PublishCommand } from "@aws-sdk/client-sns";
+import { ReceiveMessageCommand } from "@aws-sdk/client-sqs";
+import { assertIdentical, assertTypeString } from "@kensio/smartass";
+import path from "node:path";
+import { describe, it } from "vitest";
+
+/**
+ * Slower local integration test. Calls the real CDK CLI to synth the output
+ * template file to pass to sim CloudFormation, so the template under test is
+ * one CDK actually produced rather than one written by hand.
+ */
+import { SimAws } from "../../../aws/sim-aws.js";
+import { TestCdkProject } from "../../../../util/filesystem/test-cdk-project.js";
+
+const accountIdOneOnes = "111111111111";
+
+/**
+ * A handler forwarding the SNS message it was invoked with to the audit queue,
+ * so the invocation leaves something behind to assert on.
+ */
+const consumerHandlerSource = `
+const { SQSClient, SendMessageCommand } = require("@aws-sdk/client-sqs");
+const client = new SQSClient({});
+exports.handler = async (event) => {
+  await client.send(
+    new SendMessageCommand({
+      QueueUrl: process.env.AUDIT_QUEUE_URL,
+      MessageBody: event.Records[0].Sns.Message,
+    }),
+  );
+  return { handled: true };
+};
+`;
+
+/**
+ * The body of the one message waiting on a queue.
+ */
+async function receivedBody(simAws: SimAws, queueUrl: string): Promise<string> {
+  const received = await simAws
+    .account(accountIdOneOnes)
+    .region("eu-west-2")
+    .sqs()
+    .receiveMessage(new ReceiveMessageCommand({ QueueUrl: queueUrl }));
+
+  const body = received.Messages?.at(0)?.Body;
+  assertTypeString(body);
+
+  return body;
+}
+
+describe("Sim CDK SNS subscription deployment local integration", () => {
+  it("delivers a publish to the queue and the function CDK subscribed", async () => {
+    // Given a CDK stack subscribing a queue and a function to one topic, with
+    // nothing added by hand: the AWS::SQS::QueuePolicy and the
+    // AWS::Lambda::Permission CDK emits alongside them are what authorize the
+    // two deliveries.
+    const cdkProject = new TestCdkProject();
+    await cdkProject.writeCdkAppFile(
+      `
+import * as cdk from "aws-cdk-lib/core";
+import * as lambda from "aws-cdk-lib/aws-lambda";
+import * as sns from "aws-cdk-lib/aws-sns";
+import * as subscriptions from "aws-cdk-lib/aws-sns-subscriptions";
+import * as sqs from "aws-cdk-lib/aws-sqs";
+
+const app = new cdk.App();
+const stack = new cdk.Stack(app, "TestStack", {
+  env: { account: "111111111111", region: "eu-west-2" },
+});
+
+const ordersTopic = new sns.Topic(stack, "OrdersTopic", {
+  displayName: "Orders",
+});
+
+const fulfilmentQueue = new sqs.Queue(stack, "FulfilmentQueue");
+ordersTopic.addSubscription(new subscriptions.SqsSubscription(fulfilmentQueue));
+
+const auditQueue = new sqs.Queue(stack, "AuditQueue");
+
+const consumerFunction = new lambda.Function(stack, "ConsumerFunction", {
+  functionName: "cdk-order-consumer",
+  runtime: lambda.Runtime.NODEJS_20_X,
+  handler: "index.handler",
+  code: lambda.Code.fromInline(${JSON.stringify(consumerHandlerSource)}),
+  environment: {
+    AUDIT_QUEUE_URL: auditQueue.queueUrl,
+  },
+});
+
+auditQueue.grantSendMessages(consumerFunction);
+ordersTopic.addSubscription(
+  new subscriptions.LambdaSubscription(consumerFunction),
+);
+
+new cdk.CfnOutput(stack, "OrdersTopicArn", { value: ordersTopic.topicArn });
+new cdk.CfnOutput(stack, "FulfilmentQueueUrl", {
+  value: fulfilmentQueue.queueUrl,
+});
+new cdk.CfnOutput(stack, "AuditQueueUrl", { value: auditQueue.queueUrl });
+
+app.synth();
+      `,
+    );
+
+    // And we synth the CDK template.
+    const cdkOutDirectory = await cdkProject.synth();
+
+    // When we deploy the synthesized template into the account and region the
+    // CDK app declares.
+    const simAws = new SimAws();
+    const scoped = simAws.account(accountIdOneOnes).region("eu-west-2");
+    const stack = await scoped
+      .cloudFormation()
+      .deployTemplateFile(
+        path.join(cdkOutDirectory, "TestStack.template.json"),
+      );
+    await simAws.backgroundTasksComplete();
+
+    // And a message is published to the topic the CDK output names.
+    const topicArn = stack.outputs.get("OrdersTopicArn")?.value;
+    assertTypeString(topicArn);
+
+    await scoped
+      .sns()
+      .publish(new PublishCommand({ TopicArn: topicArn, Message: "order-1" }));
+    await simAws.backgroundTasksComplete();
+
+    // Then the subscribed queue received it, wrapped in the SNS envelope.
+    const fulfilmentQueueUrl = stack.outputs.get("FulfilmentQueueUrl")?.value;
+    assertTypeString(fulfilmentQueueUrl);
+
+    const envelope = JSON.parse(
+      await receivedBody(simAws, fulfilmentQueueUrl),
+    ) as { Type: string; Message: string };
+    assertIdentical(envelope.Type, "Notification");
+    assertIdentical(envelope.Message, "order-1");
+
+    // And the subscribed function was invoked with it, which it left on the
+    // audit queue.
+    const auditQueueUrl = stack.outputs.get("AuditQueueUrl")?.value;
+    assertTypeString(auditQueueUrl);
+
+    assertIdentical(await receivedBody(simAws, auditQueueUrl), "order-1");
+
+    await simAws.backgroundTasksComplete();
+  });
+});

--- a/src/service/cloudformation/resource/cfn/sim-cfn-default-resource-value-adapter.iso.test.ts
+++ b/src/service/cloudformation/resource/cfn/sim-cfn-default-resource-value-adapter.iso.test.ts
@@ -12,15 +12,15 @@ import type { CfnTemplateBodyRecord } from "../../template/sim-cfn-template.js";
  * A template whose only Resource is one no service claims, referenced both
  * ways, so a test can read what a skipped Resource answers with.
  */
-const skippedTopicTemplate: CfnTemplateBodyRecord = {
+const skippedRuleTemplate: CfnTemplateBodyRecord = {
   Resources: {
-    AlarmTopic: {
-      Type: "AWS::SNS::Topic",
+    AlarmRule: {
+      Type: "AWS::Events::Rule",
     },
   },
   Outputs: {
-    TopicRef: { Value: { Ref: "AlarmTopic" } },
-    TopicArn: { Value: { "Fn::GetAtt": ["AlarmTopic", "TopicArn"] } },
+    RuleRef: { Value: { Ref: "AlarmRule" } },
+    RuleArn: { Value: { "Fn::GetAtt": ["AlarmRule", "Arn"] } },
   },
 };
 
@@ -32,13 +32,13 @@ describe("skipped CloudFormation Resource values", () => {
     // When the template is deployed.
     const stack = await simAws.cloudFormation().deployTemplate({
       stackName: "stand-in-stack",
-      template: skippedTopicTemplate,
+      template: skippedRuleTemplate,
     });
     await stack.waitForDeployComplete();
 
     // Then the Ref resolved to the logical ID rather than failing the
     // Resources that hold it.
-    assertIdentical(stack.outputs.get("TopicRef")?.value, "AlarmTopic");
+    assertIdentical(stack.outputs.get("RuleRef")?.value, "AlarmRule");
   });
 
   it("answers an Fn::GetAtt with the logical ID and attribute name", async () => {
@@ -49,26 +49,23 @@ describe("skipped CloudFormation Resource values", () => {
     // When the template is deployed.
     const stack = await simAws.cloudFormation().deployTemplate({
       stackName: "stand-in-stack",
-      template: skippedTopicTemplate,
+      template: skippedRuleTemplate,
     });
     await stack.waitForDeployComplete();
 
     // Then the attribute resolved to a stand-in that is deliberately not
     // ARN-shaped, so it fails closed wherever it is read as one.
-    assertIdentical(
-      stack.outputs.get("TopicArn")?.value,
-      "AlarmTopic.TopicArn",
-    );
+    assertIdentical(stack.outputs.get("RuleArn")?.value, "AlarmRule.Arn");
   });
 
   it("records the skip the stand-ins came from", async () => {
-    // Given the same template, whose topic is skipped rather than created.
+    // Given the same template, whose rule is skipped rather than created.
     const simAws = new SimAws();
 
     // When the template is deployed.
     const stack = await simAws.cloudFormation().deployTemplate({
       stackName: "stand-in-stack",
-      template: skippedTopicTemplate,
+      template: skippedRuleTemplate,
     });
     await stack.waitForDeployComplete();
 
@@ -76,8 +73,8 @@ describe("skipped CloudFormation Resource values", () => {
     // reader finds out a value they got was a stand-in.
     assertArrayLength(stack.skippedResources, 1);
     assertStringIncludes(
-      stack.getResource("AlarmTopic")?.skippedReason ?? "",
-      "Unsupported sim CloudFormation Resource service SNS",
+      stack.getResource("AlarmRule")?.skippedReason ?? "",
+      "Unsupported sim CloudFormation Resource service Events",
     );
   });
 });

--- a/src/service/cloudformation/resource/cfn/sim-cfn-resource-value-adapter.ts
+++ b/src/service/cloudformation/resource/cfn/sim-cfn-resource-value-adapter.ts
@@ -10,6 +10,7 @@ import { lambdaValueAdapter } from "./lambda/sim-lambda-cfn-value-adapter.js";
 import { route53ValueAdapter } from "./route53/sim-route53-cfn-value-adapter.js";
 import { s3ValueAdapter } from "./s3/sim-s3-cfn-value-adapter.js";
 import { secretsManagerValueAdapter } from "./secretsmanager/sim-secrets-manager-cfn-value-adapter.js";
+import { snsValueAdapter } from "./sns/sim-sns-cfn-value-adapter.js";
 import { sqsValueAdapter } from "./sqs/sim-sqs-cfn-value-adapter.js";
 import { ssmValueAdapter } from "./ssm/sim-ssm-cfn-value-adapter.js";
 import { SimCfnDefaultResourceValueAdapter } from "./sim-cfn-default-resource-value-adapter.js";
@@ -59,6 +60,7 @@ export function simCfnResourceValueAdapter(
     route53ValueAdapter(properties) ??
     s3ValueAdapter(properties) ??
     secretsManagerValueAdapter(properties) ??
+    snsValueAdapter(properties) ??
     sqsValueAdapter(properties) ??
     ssmValueAdapter(properties) ??
     new SimCfnDefaultResourceValueAdapter({

--- a/src/service/cloudformation/resource/cfn/sns/sim-sns-cfn-value-adapter.iso.test.ts
+++ b/src/service/cloudformation/resource/cfn/sns/sim-sns-cfn-value-adapter.iso.test.ts
@@ -1,7 +1,9 @@
 import {
   assertIdentical,
+  assertNonNullable,
   assertStringIncludes,
   assertThrowsErrorAsync,
+  assertTypeString,
 } from "@kensio/smartass";
 import { describe, it } from "vitest";
 
@@ -74,8 +76,49 @@ describe("Sim SNS CloudFormation value adapter", () => {
     );
   });
 
-  it("refuses an AWS::SNS::Subscription attribute, since it has none", async () => {
-    // Given a template asking for an attribute of a subscription.
+  it("answers an AWS::SNS::Subscription Ref and Arn with the subscription ARN", async () => {
+    // Given a template reading a subscription both ways it can. The
+    // subscription ARN is the Resource's physical id, so Ref and the one
+    // Fn::GetAtt attribute it has are the same string.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: {
+        Resources: {
+          ...topicResources,
+          FulfilmentQueue: {
+            Type: "AWS::SQS::Queue",
+            Properties: { QueueName: "fulfilment" },
+          },
+          FulfilmentSubscription: {
+            Type: "AWS::SNS::Subscription",
+            Properties: {
+              TopicArn: { Ref: "OrdersTopic" },
+              Protocol: "sqs",
+              Endpoint: { "Fn::GetAtt": ["FulfilmentQueue", "Arn"] },
+            },
+          },
+        },
+        Outputs: {
+          SubscriptionRef: { Value: { Ref: "FulfilmentSubscription" } },
+          SubscriptionArn: {
+            Value: { "Fn::GetAtt": ["FulfilmentSubscription", "Arn"] },
+          },
+        },
+      },
+    });
+
+    const subscriptionArn = stack.outputs.get("SubscriptionArn")?.value;
+    assertIdentical(
+      stack.outputs.get("SubscriptionRef")?.value,
+      subscriptionArn,
+    );
+    assertTypeString(subscriptionArn);
+    assertNonNullable(simAws.sns().findSubscription(subscriptionArn));
+  });
+
+  it("refuses an AWS::SNS::Subscription attribute that is not Arn", async () => {
+    // Given a template asking for an attribute a subscription does not have.
     const simAws = new SimAws();
 
     const error = await assertThrowsErrorAsync(async () => {
@@ -99,7 +142,7 @@ describe("Sim SNS CloudFormation value adapter", () => {
           },
           Outputs: {
             Nope: {
-              Value: { "Fn::GetAtt": ["FulfilmentSubscription", "Arn"] },
+              Value: { "Fn::GetAtt": ["FulfilmentSubscription", "Endpoint"] },
             },
           },
         },
@@ -108,7 +151,7 @@ describe("Sim SNS CloudFormation value adapter", () => {
 
     assertStringIncludes(
       error.message,
-      "Unsupported AWS::SNS::Subscription attribute Arn",
+      "Unsupported AWS::SNS::Subscription attribute Endpoint",
     );
   });
 

--- a/src/service/cloudformation/resource/cfn/sns/sim-sns-cfn-value-adapter.iso.test.ts
+++ b/src/service/cloudformation/resource/cfn/sns/sim-sns-cfn-value-adapter.iso.test.ts
@@ -1,0 +1,126 @@
+import {
+  assertIdentical,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../../aws/sim-aws.js";
+import type { SimCfnTemplateValue } from "../../../template/value/sim-cfn-template-value.js";
+
+const topicResources = {
+  OrdersTopic: {
+    Type: "AWS::SNS::Topic",
+    Properties: { TopicName: "orders" },
+  },
+};
+
+/**
+ * Deploy a topic and read one Output of the Stack it deployed into.
+ */
+async function outputValue(
+  outputs: Record<string, SimCfnTemplateValue>,
+): Promise<SimCfnTemplateValue | undefined> {
+  const simAws = new SimAws();
+  const stack = await simAws.cloudFormation().deployTemplate({
+    stackName: "orders-stack",
+    template: {
+      Resources: {
+        ...topicResources,
+        OrdersTopicPolicy: {
+          Type: "AWS::SNS::TopicPolicy",
+          Properties: {
+            Topics: [{ Ref: "OrdersTopic" }],
+            PolicyDocument: {
+              Version: "2012-10-17",
+              Statement: [
+                {
+                  Effect: "Allow",
+                  Principal: { Service: "s3.amazonaws.com" },
+                  Action: "sns:Publish",
+                  Resource: "*",
+                },
+              ],
+            },
+          },
+        },
+      },
+      Outputs: Object.fromEntries(
+        Object.entries(outputs).map(([name, value]) => [
+          name,
+          { Value: value },
+        ]),
+      ),
+    },
+  });
+
+  return stack.outputs.get(Object.keys(outputs)[0] ?? "")?.value;
+}
+
+describe("Sim SNS CloudFormation value adapter", () => {
+  it("refuses an AWS::SNS::Topic attribute that is not one", async () => {
+    // Given a template asking for an attribute AWS::SNS::Topic does not have.
+    const error = await assertThrowsErrorAsync(async () => {
+      await outputValue({
+        Nope: { "Fn::GetAtt": ["OrdersTopic", "DisplayName"] },
+      });
+    });
+
+    // Then the deployment fails saying so, rather than answering with a
+    // stand-in value a test would read as the real thing.
+    assertStringIncludes(
+      error.message,
+      "Unsupported AWS::SNS::Topic attribute DisplayName",
+    );
+  });
+
+  it("refuses an AWS::SNS::Subscription attribute, since it has none", async () => {
+    // Given a template asking for an attribute of a subscription.
+    const simAws = new SimAws();
+
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.cloudFormation().deployTemplate({
+        stackName: "orders-stack",
+        template: {
+          Resources: {
+            ...topicResources,
+            FulfilmentQueue: {
+              Type: "AWS::SQS::Queue",
+              Properties: { QueueName: "fulfilment" },
+            },
+            FulfilmentSubscription: {
+              Type: "AWS::SNS::Subscription",
+              Properties: {
+                TopicArn: { Ref: "OrdersTopic" },
+                Protocol: "sqs",
+                Endpoint: { "Fn::GetAtt": ["FulfilmentQueue", "Arn"] },
+              },
+            },
+          },
+          Outputs: {
+            Nope: {
+              Value: { "Fn::GetAtt": ["FulfilmentSubscription", "Arn"] },
+            },
+          },
+        },
+      });
+    });
+
+    assertStringIncludes(
+      error.message,
+      "Unsupported AWS::SNS::Subscription attribute Arn",
+    );
+  });
+
+  it("leaves an AWS::SNS::TopicPolicy Ref to the default adapter", async () => {
+    // Given a template referencing the topic policy Resource. It is backed by
+    // one of the topics it names, since a topic policy is nothing but an
+    // attribute of those topics, so answering the Ref with that topic's ARN
+    // would hand back another Resource's identity.
+    const value = await outputValue({
+      PolicyRef: { Ref: "OrdersTopicPolicy" },
+    });
+
+    assertIdentical(value, "OrdersTopicPolicy");
+  });
+});

--- a/src/service/cloudformation/resource/cfn/sns/sim-sns-cfn-value-adapter.ts
+++ b/src/service/cloudformation/resource/cfn/sns/sim-sns-cfn-value-adapter.ts
@@ -1,0 +1,36 @@
+import { SimSnsSubscription } from "../../../../sns/subscription/sim-sns-subscription.js";
+import { SimSnsTopic } from "../../../../sns/topic/sim-sns-topic.js";
+import type {
+  SimCfnResourceValueAdapterProperties,
+  SimCfnServiceValueAdapter,
+} from "../sim-cfn-resource-value-adapter.js";
+import { SimSnsSubscriptionCfn } from "./sim-sns-subscription-cfn.js";
+import { SimSnsTopicCfn } from "./sim-sns-topic-cfn.js";
+
+/**
+ * The CloudFormation-facing value adapter for a simulated SNS Resource.
+ *
+ * An AWS::SNS::TopicPolicy is backed by one of the topics it names, since a
+ * topic policy is nothing but an attribute of those topics. It is not claimed
+ * here, so it falls through to the default adapter and answers a Ref with its
+ * logical ID rather than with a topic ARN that belongs to another Resource.
+ */
+export function snsValueAdapter(
+  properties: SimCfnResourceValueAdapterProperties,
+): SimCfnServiceValueAdapter {
+  if (
+    properties.type === "AWS::SNS::Topic" &&
+    properties.simResource instanceof SimSnsTopic
+  ) {
+    return new SimSnsTopicCfn({ topic: properties.simResource });
+  }
+
+  if (
+    properties.type === "AWS::SNS::Subscription" &&
+    properties.simResource instanceof SimSnsSubscription
+  ) {
+    return new SimSnsSubscriptionCfn({ subscription: properties.simResource });
+  }
+
+  return undefined;
+}

--- a/src/service/cloudformation/resource/cfn/sns/sim-sns-subscription-cfn.ts
+++ b/src/service/cloudformation/resource/cfn/sns/sim-sns-subscription-cfn.ts
@@ -24,12 +24,17 @@ export class SimSnsSubscriptionCfn implements SimCfnResourceValueAdapter {
   }
 
   /**
-   * AWS::SNS::Subscription has no Fn::GetAtt attributes, on real AWS or here.
+   * AWS::SNS::Subscription attributes.
    *
-   * Everything a template could ask for about a subscription is something it
-   * wrote itself, apart from the ARN the Ref gives.
+   * `Arn` is the only one, and it is the same string the Ref gives, since the
+   * subscription ARN is the Resource's physical id. Everything else a template
+   * could ask for about a subscription is something it wrote itself.
    */
   attributeValue(attributeName: string): SimCfnTemplateValue {
+    if (attributeName === "Arn") {
+      return this.subscription.arn.value;
+    }
+
     throw new Error(
       `Unsupported AWS::SNS::Subscription attribute ${attributeName}`,
     );

--- a/src/service/cloudformation/resource/cfn/sns/sim-sns-subscription-cfn.ts
+++ b/src/service/cloudformation/resource/cfn/sns/sim-sns-subscription-cfn.ts
@@ -1,0 +1,37 @@
+import type { SimSnsSubscription } from "../../../../sns/subscription/sim-sns-subscription.js";
+import type { SimCfnTemplateValue } from "../../../template/value/sim-cfn-template-value.js";
+import type { SimCfnResourceValueAdapter } from "../sim-cfn-resource-value-adapter.js";
+
+interface SimSnsSubscriptionCfnProperties {
+  readonly subscription: SimSnsSubscription;
+}
+
+/**
+ * CloudFormation-facing values for a simulated SNS subscription.
+ */
+export class SimSnsSubscriptionCfn implements SimCfnResourceValueAdapter {
+  private readonly subscription: SimSnsSubscription;
+
+  constructor(properties: SimSnsSubscriptionCfnProperties) {
+    this.subscription = properties.subscription;
+  }
+
+  /**
+   * AWS::SNS::Subscription Ref returns the subscription ARN.
+   */
+  refValue(): SimCfnTemplateValue {
+    return this.subscription.arn.value;
+  }
+
+  /**
+   * AWS::SNS::Subscription has no Fn::GetAtt attributes, on real AWS or here.
+   *
+   * Everything a template could ask for about a subscription is something it
+   * wrote itself, apart from the ARN the Ref gives.
+   */
+  attributeValue(attributeName: string): SimCfnTemplateValue {
+    throw new Error(
+      `Unsupported AWS::SNS::Subscription attribute ${attributeName}`,
+    );
+  }
+}

--- a/src/service/cloudformation/resource/cfn/sns/sim-sns-topic-cfn.ts
+++ b/src/service/cloudformation/resource/cfn/sns/sim-sns-topic-cfn.ts
@@ -1,0 +1,51 @@
+import type { SimSnsTopic } from "../../../../sns/topic/sim-sns-topic.js";
+import type { SimCfnTemplateValue } from "../../../template/value/sim-cfn-template-value.js";
+import type { SimCfnResourceValueAdapter } from "../sim-cfn-resource-value-adapter.js";
+
+interface SimSnsTopicCfnProperties {
+  readonly topic: SimSnsTopic;
+}
+
+/**
+ * CloudFormation-facing values for a simulated SNS topic.
+ */
+export class SimSnsTopicCfn implements SimCfnResourceValueAdapter {
+  private readonly topic: SimSnsTopic;
+
+  constructor(properties: SimSnsTopicCfnProperties) {
+    this.topic = properties.topic;
+  }
+
+  /**
+   * AWS::SNS::Topic Ref returns the topic ARN.
+   *
+   * SNS has no identifier for a topic other than its ARN, so a Ref is directly
+   * usable as the TopicArn of a Publish or a Subscribe.
+   */
+  refValue(): SimCfnTemplateValue {
+    return this.topic.arn.value;
+  }
+
+  /**
+   * AWS::SNS::Topic attributes.
+   *
+   * The ARN is the same string the Ref gives, and is what an IAM policy names
+   * the topic by. The name is what a template reads when it wants the topic
+   * without the Account and Region around it.
+   */
+  attributeValue(attributeName: string): SimCfnTemplateValue {
+    switch (attributeName) {
+      case "TopicArn": {
+        return this.topic.arn.value;
+      }
+      case "TopicName": {
+        return this.topic.name.value;
+      }
+      default: {
+        throw new Error(
+          `Unsupported AWS::SNS::Topic attribute ${attributeName}`,
+        );
+      }
+    }
+  }
+}

--- a/src/service/cloudformation/resource/resolve/service/sim-cfn-service-factories.ts
+++ b/src/service/cloudformation/resource/resolve/service/sim-cfn-service-factories.ts
@@ -90,6 +90,11 @@ export const simCfnServiceResourceFactories: ReadonlyMap<
       scopedAws.secretsManager().cfnResourceFactory(),
   ],
   [
+    "SNS",
+    (scopedAws): SimCfnServiceResourceFactory =>
+      scopedAws.sns().cfnResourceFactory(),
+  ],
+  [
     "SQS",
     (scopedAws): SimCfnServiceResourceFactory =>
       scopedAws.sqs().cfnResourceFactory(),

--- a/src/service/cloudformation/resource/resolve/service/sim-cfn-service-resolver.iso.test.ts
+++ b/src/service/cloudformation/resource/resolve/service/sim-cfn-service-resolver.iso.test.ts
@@ -105,8 +105,8 @@ describe("resolveSimCloudFormationServiceResourceFactory", () => {
         accountRegionScope,
         {
           providerName: "AWS",
-          serviceName: "SNS",
-          resourceTypeName: "Topic",
+          serviceName: "Events",
+          resourceTypeName: "Rule",
         },
       ),
     );
@@ -114,7 +114,7 @@ describe("resolveSimCloudFormationServiceResourceFactory", () => {
     // Then the unsupported service name is included for diagnosis.
     assertIdentical(
       error.message,
-      "Unsupported sim CloudFormation Resource service SNS",
+      "Unsupported sim CloudFormation Resource service Events",
     );
   });
 

--- a/src/service/cloudformation/stack/sim-cfn-stack.iso.test.ts
+++ b/src/service/cloudformation/stack/sim-cfn-stack.iso.test.ts
@@ -228,8 +228,8 @@ describe("SimCfnStack", () => {
       stackName: "TestStack",
       template: {
         Resources: {
-          TestTopic: {
-            Type: "AWS::SNS::Topic",
+          TestRule: {
+            Type: "AWS::Events::Rule",
           },
         },
       },
@@ -240,11 +240,11 @@ describe("SimCfnStack", () => {
     assertIdentical(stack.lifecycle.status, "CREATE_COMPLETE");
     assertArrayLength(stack.skippedResources, 1);
     assertNonNullable(skippedResource);
-    assertIdentical(skippedResource.logicalId, "TestTopic");
+    assertIdentical(skippedResource.logicalId, "TestRule");
     assertTrue(skippedResource.skipped);
     assertIdentical(
       skippedResource.skippedReason,
-      "Unsupported sim CloudFormation Resource service SNS",
+      "Unsupported sim CloudFormation Resource service Events",
     );
   });
 

--- a/src/service/sns/README.md
+++ b/src/service/sns/README.md
@@ -308,6 +308,44 @@ As elsewhere, implementation code under `src/` does not import real AWS SDK pack
 command types in `*.command.ts` match the SDK shapes closely enough for callers to pass real SDK
 command instances.
 
+## CloudFormation resources
+
+`cfn/` holds the `AWS::SNS::*` Resource factory, resolved into the CloudFormation engine through
+`sim-cfn-service-resolver.ts`. Every Resource type goes through the ordinary SNS commands rather than
+reaching into the stores, so a topic a template created is the same thing an SDK caller would have
+got, and a template asking for something this simulation will not do is refused by the same code that
+refuses an SDK caller.
+
+That is why `sim-cfn-sns-topic-property-names.ts` is short. Most AWS::SNS::Topic properties are topic
+attributes of the same name, so they are handed to `CreateTopic` and SNS decides. Only the three that
+have no single attribute behind them are refused in the CloudFormation layer: `Tags` and
+`DataProtectionPolicy` are inputs of their own on a `CreateTopic` request, and `DeliveryStatusLogging`
+is a list that would become fifteen separate attributes. `AWS::SNS::Subscription` works the same way
+against `Subscribe`, with only `Region` refused here.
+
+`sim-cfn-sns-resource-error.ts` is where a refusal gets its wording, and the wording is the point.
+Sim CloudFormation reads an error saying a Resource is unsupported as one to record and step over,
+and stepping over a topic leaves a Stack that looks deployed with nothing publishing. So a refusal
+says the Resource is invalid, and `simCfnSnsResourceCreation` renames SNS's own errors to say which
+Resource asked for it, since an SNS error carries no logical ID.
+
+`SimCfnSnsTopicName` is the name a topic whose template does not name it gets, built on the shared
+`SimCfnGeneratedResourceName`. It leaves out the random characters real CloudFormation adds, so a test
+can predict it.
+
+`AWS::SNS::TopicPolicy` has no existence of its own, in the same way `AWS::SQS::QueuePolicy` has
+none: it is the `Policy` attribute of the topics it names. The Resource is backed by the first of
+those topics, and the deleter reads the `Topics` list again rather than trusting that one, because
+the policy has to come off all of them. Clearing it is `SetTopicAttributes` with an empty value, which
+is how the SDK clears one too.
+
+The `Ref` and `Fn::GetAtt` adapters live with the other value adapters, under
+`cloudformation/resource/cfn/sns/`, since what a Resource type answers an intrinsic with is
+CloudFormation's business rather than the service's. A topic answers `Ref` with its ARN, and a
+subscription with its subscription ARN. A topic policy is not claimed there at all, so it falls
+through to the default adapter rather than answering `Ref` with a topic ARN belonging to another
+Resource.
+
 ## Authorization
 
 `SimSnsAuthorizer` authorizes each operation against the topic's ARN, which carries the topic name
@@ -401,7 +439,8 @@ here, it does not make another Account's topics reachable through this one.
 - Publishing to a `TargetArn` or a `PhoneNumber` is refused. Only topics are simulated.
 - `AddPermission` and `RemovePermission`, which are shorthands for writing one statement of the topic
   policy, are not implemented. The policy is set through the `Policy` attribute only.
-- The CloudFormation resource types are not implemented, so a template with an `AWS::SNS::Topic` in
-  it does not deploy a topic yet.
+- A CloudFormation property with no simulated behaviour fails the Resource rather than being recorded
+  and stepped over, which is what simulated SQS does with most of its own. SNS refuses these to an
+  SDK caller too, and going through the commands is what keeps the two answers the same.
 
 The full list is in [docs/services/sns](../../../docs/services/sns/).

--- a/src/service/sns/cfn/sim-cfn-sns-attribute-value.ts
+++ b/src/service/sns/cfn/sim-cfn-sns-attribute-value.ts
@@ -1,0 +1,26 @@
+import { jsonStringify } from "../../../util/type-guard/json.js";
+import type { SimCfnTemplateValue } from "../../cloudformation/template/value/sim-cfn-template-value.js";
+
+/**
+ * Read a CloudFormation property as the string an SNS attribute carries.
+ *
+ * SNS holds every attribute as a string, and CloudFormation carries the same
+ * settings as booleans, numbers and JSON documents. A `FilterPolicy` is written
+ * as an object in a template and set as a JSON string through the API, which is
+ * the same conversion `RawMessageDelivery: true` needs, so both are done here
+ * rather than one property at a time.
+ *
+ * What each string then has to be is left to simulated SNS, which is what a
+ * request through the SDK is held to.
+ */
+export function simCfnSnsAttributeValue(value: SimCfnTemplateValue): string {
+  if (typeof value === "string") {
+    return value;
+  }
+
+  if (typeof value === "boolean" || typeof value === "number") {
+    return String(value);
+  }
+
+  return jsonStringify(value);
+}

--- a/src/service/sns/cfn/sim-cfn-sns-resource-deleter.ts
+++ b/src/service/sns/cfn/sim-cfn-sns-resource-deleter.ts
@@ -1,0 +1,109 @@
+import { assertDefined } from "../../../util/type-guard/defined.js";
+import type { SimCfnResource } from "../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimSns } from "../sim-sns.js";
+import type { SimSnsSubscription } from "../subscription/sim-sns-subscription.js";
+import type { SimSnsTopic } from "../topic/sim-sns-topic.js";
+import { simSnsPolicyAttributeName } from "../topic/sim-sns-topic-attribute-names.js";
+import { simCfnSnsPolicyTopicArns } from "./topic-policy/sim-cfn-sns-topic-policy-properties.js";
+
+interface SimCfnSnsResourceDeleterProperties {
+  readonly sns: SimSns;
+}
+
+/**
+ * Deletes the simulated SNS resources a CloudFormation Stack created.
+ *
+ * There is no DeleteTopicPolicy in SNS. A topic policy is the `Policy`
+ * attribute of the topics it names, so removing one is SetTopicAttributes
+ * setting that attribute to an empty string, which is how the SDK clears it
+ * too.
+ *
+ * A subscription needs no deleter of its own when its topic goes with it, since
+ * DeleteTopic removes a topic's subscriptions as real SNS does. It has one
+ * because a stack can drop a subscription and keep the topic, and because the
+ * teardown reaches the subscription first either way.
+ */
+export class SimCfnSnsResourceDeleter {
+  private readonly sns: SimSns;
+
+  constructor(properties: SimCfnSnsResourceDeleterProperties) {
+    this.sns = properties.sns;
+  }
+
+  /**
+   * Delete a simulated SNS resource created from a CloudFormation Resource.
+   */
+  async delete(
+    resourceTypeName: string,
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): Promise<void> {
+    switch (resourceTypeName) {
+      case "Topic": {
+        await this.deleteTopic(resource);
+        return;
+      }
+      case "Subscription": {
+        await this.unsubscribe(resource);
+        return;
+      }
+      case "TopicPolicy": {
+        await this.clearTopicPolicy(resource, properties);
+        return;
+      }
+      default: {
+        throw new Error(
+          `Unsupported sim SNS CloudFormation Resource ${resourceTypeName} deletion`,
+        );
+      }
+    }
+  }
+
+  private async deleteTopic(resource: SimCfnResource): Promise<void> {
+    const topic = resource.simResource as SimSnsTopic | undefined;
+    assertDefined(
+      topic,
+      `sim SNS topic for CloudFormation Resource ${resource.logicalId}`,
+    );
+
+    await this.sns.deleteTopic({ input: { TopicArn: topic.arn.value } });
+  }
+
+  private async unsubscribe(resource: SimCfnResource): Promise<void> {
+    const subscription = resource.simResource as SimSnsSubscription | undefined;
+    assertDefined(
+      subscription,
+      `sim SNS subscription for CloudFormation Resource ${resource.logicalId}`,
+    );
+
+    await this.sns.unsubscribe({
+      input: { SubscriptionArn: subscription.arn.value },
+    });
+  }
+
+  /**
+   * Take the policy back off every topic the Resource named.
+   *
+   * The Resource points at only the first of them, so the topics are read from
+   * the template the same way creation read them.
+   */
+  private async clearTopicPolicy(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): Promise<void> {
+    const topicArns = simCfnSnsPolicyTopicArns(resource.logicalId, properties);
+
+    await Promise.all(
+      topicArns.map(async (topicArn) =>
+        this.sns.setTopicAttributes({
+          input: {
+            TopicArn: topicArn,
+            AttributeName: simSnsPolicyAttributeName,
+            AttributeValue: "",
+          },
+        }),
+      ),
+    );
+  }
+}

--- a/src/service/sns/cfn/sim-cfn-sns-resource-error.iso.test.ts
+++ b/src/service/sns/cfn/sim-cfn-sns-resource-error.iso.test.ts
@@ -1,0 +1,59 @@
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimSnsInvalidParameterException } from "../error/sim-sns.error.js";
+import { simCfnSnsResourceCreation } from "./sim-cfn-sns-resource-error.js";
+import { snsTopicResourceType } from "./sim-cfn-sns-resource-types.js";
+
+describe("simCfnSnsResourceCreation", () => {
+  it("names the Resource in what simulated SNS refused", async () => {
+    // Given creation work refused by simulated SNS, whose error carries the
+    // reason and no idea which Resource asked for it.
+    const refused = (): Promise<never> =>
+      Promise.reject(
+        new SimSnsInvalidParameterException("Invalid parameter: Name"),
+      );
+
+    // When it is run as one Resource's creation, then the refusal says which
+    // Resource it was.
+    const error = await assertThrowsErrorAsync(async () =>
+      simCfnSnsResourceCreation(snsTopicResourceType, "OrdersTopic", refused),
+    );
+
+    assertIdentical(
+      error.message,
+      "Invalid AWS::SNS::Topic Resource OrdersTopic: Invalid parameter: Name",
+    );
+    assertInstanceOf(error.cause, SimSnsInvalidParameterException);
+  });
+
+  it("leaves an error that is not SNS's alone", async () => {
+    // Given creation work failing for a reason that is not a refusal, such as
+    // an assertion about the simulator's own state.
+    const broke = (): Promise<never> =>
+      Promise.reject(new TypeError("something else went wrong"));
+
+    // When it is run as one Resource's creation, then the error comes through
+    // as it was, rather than being reworded as a refused Resource.
+    const error = await assertThrowsErrorAsync(async () =>
+      simCfnSnsResourceCreation(snsTopicResourceType, "OrdersTopic", broke),
+    );
+
+    assertIdentical(error.message, "something else went wrong");
+  });
+
+  it("hands back what the creation work answered with", async () => {
+    // Given creation work that succeeds.
+    const created = await simCfnSnsResourceCreation(
+      snsTopicResourceType,
+      "OrdersTopic",
+      () => Promise.resolve("the topic"),
+    );
+
+    assertIdentical(created, "the topic");
+  });
+});

--- a/src/service/sns/cfn/sim-cfn-sns-resource-error.ts
+++ b/src/service/sns/cfn/sim-cfn-sns-resource-error.ts
@@ -1,0 +1,54 @@
+import { SimSnsError } from "../error/sim-sns.error.js";
+
+/**
+ * Build the error a Resource of a simulated SNS type is refused with.
+ *
+ * The wording is deliberate. Sim CloudFormation reads an error saying a
+ * Resource is unsupported as one to record and step over, and stepping over a
+ * topic that cannot be created as the template asked for it is the wrong
+ * answer: the Stack would look deployed while nothing published anywhere. So a
+ * refusal here says the Resource is invalid.
+ */
+export function simCfnSnsResourceError(
+  resourceType: string,
+  logicalId: string,
+  reason: string,
+  cause?: unknown,
+): Error {
+  return new Error(`Invalid ${resourceType} Resource ${logicalId}: ${reason}`, {
+    cause,
+  });
+}
+
+/**
+ * Run the simulated SNS commands one Resource is made of, naming the Resource
+ * in whatever they refuse.
+ *
+ * Every Resource type here goes through the ordinary SNS commands, so what a
+ * template may ask for is decided once, by simulated SNS, rather than again in
+ * the CloudFormation layer. What that leaves out is where the request came
+ * from: a deployment failing with `The topic attribute FifoTopic is not
+ * simulated` says nothing about which Resource asked for it. Only SNS's own
+ * errors are renamed, so a refusal the CloudFormation layer decided keeps the
+ * wording it was written with.
+ */
+export async function simCfnSnsResourceCreation<T>(
+  resourceType: string,
+  logicalId: string,
+  create: () => Promise<T>,
+): Promise<T> {
+  try {
+    return await create();
+  } catch (error) {
+    if (error instanceof SimSnsError) {
+      throw simCfnSnsResourceError(
+        resourceType,
+        logicalId,
+        error.message,
+        error,
+      );
+    }
+
+    throw error;
+  }
+}

--- a/src/service/sns/cfn/sim-cfn-sns-resource-types.ts
+++ b/src/service/sns/cfn/sim-cfn-sns-resource-types.ts
@@ -1,0 +1,12 @@
+/**
+ * The CloudFormation Resource types simulated SNS creates.
+ *
+ * They are named here rather than spelled out where they are used, because each
+ * one is written twice: once by the factory dispatching on it, and once by the
+ * refusals that quote it back to whoever wrote the template.
+ */
+export const snsTopicResourceType = "AWS::SNS::Topic";
+
+export const snsSubscriptionResourceType = "AWS::SNS::Subscription";
+
+export const snsTopicPolicyResourceType = "AWS::SNS::TopicPolicy";

--- a/src/service/sns/cfn/sim-cfn-sns-subscription.iso.test.ts
+++ b/src/service/sns/cfn/sim-cfn-sns-subscription.iso.test.ts
@@ -1,0 +1,312 @@
+import { PublishCommand } from "@aws-sdk/client-sns";
+import { ReceiveMessageCommand } from "@aws-sdk/client-sqs";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertTypeString,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import type { SimCfnTemplateValueRecord } from "../../cloudformation/template/value/sim-cfn-template-value.js";
+
+const accountIdOneOnes = "111111111111";
+
+const ordersQueueUrl =
+  "https://sqs.eu-west-2.amazonaws.com/111111111111/fulfilment";
+
+function simAwsInEuWest2(): SimAws {
+  return new SimAws({
+    defaultAccountId: accountIdOneOnes,
+    defaultRegionName: "eu-west-2",
+  });
+}
+
+/**
+ * The Resources a topic delivering to a queue needs: the topic, the queue, and
+ * the queue policy admitting SNS. The policy is what authorizes the delivery,
+ * and it is the Resource CDK emits alongside an SqsSubscription.
+ */
+function topicAndQueueResources(): SimCfnTemplateValueRecord {
+  return {
+    OrdersTopic: {
+      Type: "AWS::SNS::Topic",
+      Properties: { TopicName: "orders" },
+    },
+    FulfilmentQueue: {
+      Type: "AWS::SQS::Queue",
+      Properties: { QueueName: "fulfilment" },
+    },
+    FulfilmentQueuePolicy: {
+      Type: "AWS::SQS::QueuePolicy",
+      Properties: {
+        Queues: [{ Ref: "FulfilmentQueue" }],
+        PolicyDocument: {
+          Version: "2012-10-17",
+          Statement: [
+            {
+              Effect: "Allow",
+              Principal: { Service: "sns.amazonaws.com" },
+              Action: "sqs:SendMessage",
+              Resource: { "Fn::GetAtt": ["FulfilmentQueue", "Arn"] },
+              Condition: {
+                ArnEquals: { "aws:SourceArn": { Ref: "OrdersTopic" } },
+              },
+            },
+          ],
+        },
+      },
+    },
+  };
+}
+
+/**
+ * The message body of the one message on the fulfilment queue.
+ */
+async function receivedBody(simAws: SimAws): Promise<string> {
+  const received = await simAws
+    .sqs()
+    .receiveMessage(new ReceiveMessageCommand({ QueueUrl: ordersQueueUrl }));
+
+  const body = received.Messages?.at(0)?.Body;
+  assertTypeString(body);
+
+  return body;
+}
+
+describe("SNS CloudFormation Subscription deployment", () => {
+  it("delivers a publish to the queue an AWS::SNS::Subscription names", async () => {
+    // Given a template subscribing a queue to a topic as its own Resource, the
+    // way CDK emits a subscription.
+    const simAws = simAwsInEuWest2();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: {
+        Resources: {
+          ...topicAndQueueResources(),
+          FulfilmentSubscription: {
+            Type: "AWS::SNS::Subscription",
+            Properties: {
+              TopicArn: { Ref: "OrdersTopic" },
+              Protocol: "sqs",
+              Endpoint: { "Fn::GetAtt": ["FulfilmentQueue", "Arn"] },
+            },
+          },
+        },
+        Outputs: {
+          SubscriptionRef: { Value: { Ref: "FulfilmentSubscription" } },
+        },
+      },
+    });
+
+    // When a message is published to the topic the template created.
+    await simAws.sns().publish(
+      new PublishCommand({
+        TopicArn: "arn:aws:sns:eu-west-2:111111111111:orders",
+        Message: "order-1",
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // Then the queue received it, wrapped in the SNS envelope.
+    const envelope = JSON.parse(await receivedBody(simAws)) as {
+      Type: string;
+      Message: string;
+    };
+    assertIdentical(envelope.Type, "Notification");
+    assertIdentical(envelope.Message, "order-1");
+
+    // And Ref on the subscription is its ARN, which is the topic's with the
+    // subscription id added.
+    const subscriptionRef = stack.outputs.get("SubscriptionRef")?.value;
+    assertTypeString(subscriptionRef);
+    assertNonNullable(simAws.sns().findSubscription(subscriptionRef));
+  });
+
+  it("backs the CloudFormation Resource with the simulated subscription", async () => {
+    // Given a deployed subscription.
+    const simAws = simAwsInEuWest2();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: {
+        Resources: {
+          ...topicAndQueueResources(),
+          FulfilmentSubscription: {
+            Type: "AWS::SNS::Subscription",
+            Properties: {
+              TopicArn: { Ref: "OrdersTopic" },
+              Protocol: "sqs",
+              Endpoint: { "Fn::GetAtt": ["FulfilmentQueue", "Arn"] },
+            },
+          },
+        },
+      },
+    });
+
+    // When the Resource is inspected.
+    const resource = stack.getResource("FulfilmentSubscription");
+    assertNonNullable(resource);
+
+    // Then it is backed by the same simulated subscription the topic holds,
+    // rather than some other simulated resource that happens to have an ARN.
+    const subscription = resource.simResource;
+    assertNonNullable(subscription);
+    assertIdentical(simAws.sns().topicSubscriptions("orders")[0], subscription);
+  });
+
+  it("carries RawMessageDelivery through to the delivered message", async () => {
+    // Given a subscription asking for raw delivery, which CloudFormation
+    // carries as a boolean and SNS holds as a string.
+    const simAws = simAwsInEuWest2();
+    await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: {
+        Resources: {
+          ...topicAndQueueResources(),
+          FulfilmentSubscription: {
+            Type: "AWS::SNS::Subscription",
+            Properties: {
+              TopicArn: { Ref: "OrdersTopic" },
+              Protocol: "sqs",
+              Endpoint: { "Fn::GetAtt": ["FulfilmentQueue", "Arn"] },
+              RawMessageDelivery: true,
+            },
+          },
+        },
+      },
+    });
+
+    // When a message is published.
+    await simAws.sns().publish(
+      new PublishCommand({
+        TopicArn: "arn:aws:sns:eu-west-2:111111111111:orders",
+        Message: "order-1",
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // Then the queue received the message on its own rather than the envelope.
+    assertIdentical(await receivedBody(simAws), "order-1");
+  });
+
+  it("filters deliveries with the FilterPolicy the template writes", async () => {
+    // Given a subscription with a filter policy, written as a template object
+    // where the API takes a JSON string.
+    const simAws = simAwsInEuWest2();
+    await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: {
+        Resources: {
+          ...topicAndQueueResources(),
+          FulfilmentSubscription: {
+            Type: "AWS::SNS::Subscription",
+            Properties: {
+              TopicArn: { Ref: "OrdersTopic" },
+              Protocol: "sqs",
+              Endpoint: { "Fn::GetAtt": ["FulfilmentQueue", "Arn"] },
+              FilterPolicy: { region: ["eu"] },
+              FilterPolicyScope: "MessageAttributes",
+              RawMessageDelivery: true,
+            },
+          },
+        },
+      },
+    });
+
+    // When two messages are published, only one of which the policy wants.
+    const topicArn = "arn:aws:sns:eu-west-2:111111111111:orders";
+    await simAws.sns().publish(
+      new PublishCommand({
+        TopicArn: topicArn,
+        Message: "order-us",
+        MessageAttributes: {
+          region: { DataType: "String", StringValue: "us" },
+        },
+      }),
+    );
+    await simAws.sns().publish(
+      new PublishCommand({
+        TopicArn: topicArn,
+        Message: "order-eu",
+        MessageAttributes: {
+          region: { DataType: "String", StringValue: "eu" },
+        },
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // Then only the matching one reached the queue.
+    const received = await simAws.sqs().receiveMessage(
+      new ReceiveMessageCommand({
+        QueueUrl: ordersQueueUrl,
+        MaxNumberOfMessages: 10,
+      }),
+    );
+
+    assertArrayLength(received.Messages ?? [], 1);
+    assertIdentical(received.Messages?.at(0)?.Body, "order-eu");
+  });
+
+  it("creates the subscriptions a topic declares inline", async () => {
+    // Given a hand-written template using the Subscription property of the
+    // topic rather than a Resource of its own.
+    const simAws = simAwsInEuWest2();
+    await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: {
+        Resources: {
+          FulfilmentQueue: {
+            Type: "AWS::SQS::Queue",
+            Properties: { QueueName: "fulfilment" },
+          },
+          FulfilmentQueuePolicy: {
+            Type: "AWS::SQS::QueuePolicy",
+            Properties: {
+              Queues: [{ Ref: "FulfilmentQueue" }],
+              PolicyDocument: {
+                Version: "2012-10-17",
+                Statement: [
+                  {
+                    Effect: "Allow",
+                    Principal: { Service: "sns.amazonaws.com" },
+                    Action: "sqs:SendMessage",
+                    Resource: "*",
+                  },
+                ],
+              },
+            },
+          },
+          OrdersTopic: {
+            Type: "AWS::SNS::Topic",
+            Properties: {
+              TopicName: "orders",
+              Subscription: [
+                {
+                  Protocol: "sqs",
+                  Endpoint: { "Fn::GetAtt": ["FulfilmentQueue", "Arn"] },
+                },
+              ],
+            },
+          },
+        },
+      },
+    });
+
+    // When a message is published.
+    await simAws.sns().publish(
+      new PublishCommand({
+        TopicArn: "arn:aws:sns:eu-west-2:111111111111:orders",
+        Message: "order-1",
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // Then the inline subscription is there and delivered to it.
+    assertArrayLength(simAws.sns().topicSubscriptions("orders"), 1);
+    const envelope = JSON.parse(await receivedBody(simAws)) as {
+      Message: string;
+    };
+    assertIdentical(envelope.Message, "order-1");
+  });
+});

--- a/src/service/sns/cfn/sim-cfn-sns-teardown.iso.test.ts
+++ b/src/service/sns/cfn/sim-cfn-sns-teardown.iso.test.ts
@@ -1,0 +1,219 @@
+import { GetTopicAttributesCommand } from "@aws-sdk/client-sns";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+
+const policyDocument = {
+  Version: "2012-10-17",
+  Statement: [
+    {
+      Effect: "Allow",
+      Principal: { Service: "s3.amazonaws.com" },
+      Action: "sns:Publish",
+      Resource: "*",
+    },
+  ],
+};
+
+describe("SNS CloudFormation Resource teardown", () => {
+  it("deletes a topic after the subscription and policy declared on it", async () => {
+    // Given a deployed topic with a subscription and a topic policy on it.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: {
+        Resources: {
+          OrdersTopic: {
+            Type: "AWS::SNS::Topic",
+            Properties: { TopicName: "orders" },
+          },
+          FulfilmentQueue: {
+            Type: "AWS::SQS::Queue",
+            Properties: { QueueName: "fulfilment" },
+          },
+          FulfilmentSubscription: {
+            Type: "AWS::SNS::Subscription",
+            Properties: {
+              TopicArn: { Ref: "OrdersTopic" },
+              Protocol: "sqs",
+              Endpoint: { "Fn::GetAtt": ["FulfilmentQueue", "Arn"] },
+            },
+          },
+          OrdersTopicPolicy: {
+            Type: "AWS::SNS::TopicPolicy",
+            Properties: {
+              Topics: [{ Ref: "OrdersTopic" }],
+              PolicyDocument: policyDocument,
+            },
+          },
+        },
+      },
+    });
+
+    // When the Stack's Resources are torn down.
+    await stack.teardown();
+
+    // Then the topic is gone, and so is the subscription that named it.
+    assertUndefined(simAws.sns().findTopic("orders"));
+    assertArrayLength(simAws.sns().topicSubscriptions("orders"), 0);
+    assertIdentical(
+      stack.resources.get("OrdersTopic")?.status,
+      "DELETE_COMPLETE",
+    );
+    assertIdentical(
+      stack.resources.get("FulfilmentSubscription")?.status,
+      "DELETE_COMPLETE",
+    );
+  });
+
+  it("clears the policy attribute of a topic that outlives the Stack", async () => {
+    // Given a topic created outside the Stack, so the policy Resource is the
+    // only thing the teardown removes. SNS has no DeleteTopicPolicy: the policy
+    // is an attribute, and clearing it is a SetTopicAttributes.
+    const simAws = new SimAws();
+    const created = await simAws
+      .sns()
+      .createTopic({ input: { Name: "standing" } });
+    assertNonNullable(created.TopicArn);
+
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "topic-policy-stack",
+      template: {
+        Resources: {
+          StandingTopicPolicy: {
+            Type: "AWS::SNS::TopicPolicy",
+            Properties: {
+              Topics: [created.TopicArn],
+              PolicyDocument: policyDocument,
+            },
+          },
+        },
+      },
+    });
+
+    // When the Stack's Resources are torn down.
+    await stack.teardown();
+
+    // Then the topic is still there without a policy on it.
+    const read = await simAws
+      .sns()
+      .getTopicAttributes(
+        new GetTopicAttributesCommand({ TopicArn: created.TopicArn }),
+      );
+
+    assertNonNullable(read.Attributes);
+    assertUndefined(read.Attributes["Policy"]);
+  });
+
+  it("unsubscribes a subscription the Stack drops on its own", async () => {
+    // Given a topic created outside the Stack with the Stack only holding the
+    // subscription to it.
+    const simAws = new SimAws();
+    const created = await simAws
+      .sns()
+      .createTopic({ input: { Name: "standing" } });
+    assertNonNullable(created.TopicArn);
+
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "subscription-stack",
+      template: {
+        Resources: {
+          FulfilmentQueue: {
+            Type: "AWS::SQS::Queue",
+            Properties: { QueueName: "fulfilment" },
+          },
+          FulfilmentSubscription: {
+            Type: "AWS::SNS::Subscription",
+            Properties: {
+              TopicArn: created.TopicArn,
+              Protocol: "sqs",
+              Endpoint: { "Fn::GetAtt": ["FulfilmentQueue", "Arn"] },
+            },
+          },
+        },
+      },
+    });
+    assertArrayLength(simAws.sns().topicSubscriptions("standing"), 1);
+
+    // When the Stack's Resources are torn down.
+    await stack.teardown();
+
+    // Then the subscription is gone and the topic is not.
+    assertArrayLength(simAws.sns().topicSubscriptions("standing"), 0);
+    assertNonNullable(simAws.sns().findTopic("standing"));
+  });
+
+  it("reports an AWS::SNS Resource type it cannot delete", async () => {
+    // Given a deployed topic and the SNS factory asked to delete it as a
+    // Resource type this simulation has no deletion for.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: {
+        Resources: {
+          OrdersTopic: {
+            Type: "AWS::SNS::Topic",
+            Properties: { TopicName: "orders" },
+          },
+        },
+      },
+    });
+    const resource = stack.getResource("OrdersTopic");
+    assertNonNullable(resource);
+
+    // When the deletion is asked for, then it says so as an unsupported
+    // Resource, which is what the teardown records and steps over.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws
+        .sns()
+        .cfnResourceFactory()
+        .delete("PlatformApplication", resource, {
+          simAws,
+          resources: new Map(),
+        }),
+    );
+
+    assertIdentical(
+      error.message,
+      "Unsupported sim SNS CloudFormation Resource PlatformApplication deletion",
+    );
+  });
+
+  it("reports an AWS::SNS Resource type it does not model", async () => {
+    // Given a Stack whose template names an SNS Resource type this simulation
+    // has no implementation for.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: {
+        Resources: {
+          OrdersTopic: {
+            Type: "AWS::SNS::Topic",
+            Properties: { TopicName: "orders" },
+          },
+          OrdersPlatformApplication: {
+            Type: "AWS::SNS::PlatformApplication",
+            Properties: { Platform: "APNS" },
+          },
+        },
+      },
+    });
+
+    // Then the unsupported Resource is stepped over rather than failing the
+    // deployment, and the topic beside it is deployed.
+    assertArrayLength(stack.skippedResources, 1);
+    assertNonNullable(simAws.sns().findTopic("orders"));
+
+    // And the teardown steps over it the same way.
+    await stack.teardown();
+
+    assertUndefined(simAws.sns().findTopic("orders"));
+  });
+});

--- a/src/service/sns/cfn/sim-cfn-sns-topic-policy.iso.test.ts
+++ b/src/service/sns/cfn/sim-cfn-sns-topic-policy.iso.test.ts
@@ -158,7 +158,8 @@ describe("AWS::SNS::TopicPolicy", () => {
 
     assertStringIncludes(
       error.message,
-      "AWS::SNS::TopicPolicy OrdersTopicPolicy requires a Topics list",
+      "Invalid AWS::SNS::TopicPolicy Resource OrdersTopicPolicy: Topics is " +
+        "required and must be a list of topic ARNs",
     );
   });
 
@@ -190,7 +191,8 @@ describe("AWS::SNS::TopicPolicy", () => {
 
     assertStringIncludes(
       error.message,
-      "AWS::SNS::TopicPolicy OrdersTopicPolicy requires a PolicyDocument object",
+      "Invalid AWS::SNS::TopicPolicy Resource OrdersTopicPolicy: " +
+        "PolicyDocument is required and must be an object",
     );
   });
 
@@ -215,7 +217,7 @@ describe("AWS::SNS::TopicPolicy", () => {
 
     assertStringIncludes(
       error.message,
-      "requires each entry of Topics to be a topic ARN string, got number",
+      "each entry of Topics must be a topic ARN string, and one is a number",
     );
   });
 });

--- a/src/service/sns/cfn/sim-cfn-sns-topic-policy.iso.test.ts
+++ b/src/service/sns/cfn/sim-cfn-sns-topic-policy.iso.test.ts
@@ -1,0 +1,221 @@
+import { GetTopicAttributesCommand, PublishCommand } from "@aws-sdk/client-sns";
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import type { CfnTemplateBodyRecord } from "../../cloudformation/template/sim-cfn-template.js";
+import type { SimCfnTemplateValueRecord } from "../../cloudformation/template/value/sim-cfn-template-value.js";
+
+const s3ServicePrincipal = {
+  kind: "service",
+  service: "s3.amazonaws.com",
+} as const;
+
+/**
+ * A template deploying a topic and the topic policy admitting S3 to it, which
+ * is what CDK synthesises for a Bucket notifying a topic.
+ */
+function ordersTemplate(
+  policyStatement: SimCfnTemplateValueRecord,
+): CfnTemplateBodyRecord {
+  return {
+    Resources: {
+      OrdersTopic: {
+        Type: "AWS::SNS::Topic",
+        Properties: { TopicName: "orders" },
+      },
+      OrdersTopicPolicy: {
+        Type: "AWS::SNS::TopicPolicy",
+        Properties: {
+          Topics: [{ Ref: "OrdersTopic" }],
+          PolicyDocument: {
+            Version: "2012-10-17",
+            Statement: [policyStatement],
+          },
+        },
+      },
+    },
+    Outputs: { OrdersTopicArn: { Value: { Ref: "OrdersTopic" } } },
+  };
+}
+
+describe("AWS::SNS::TopicPolicy", () => {
+  it("deploys the policy it names onto the topic", async () => {
+    // Given a template declaring a topic and a policy admitting S3 to it.
+    const simAws = new SimAws();
+    const topicArn = `arn:aws:sns:${simAws.defaultRegionName}:${simAws.defaultAccountId}:orders`;
+
+    // When the template is deployed.
+    await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: ordersTemplate({
+        Effect: "Allow",
+        Principal: { Service: "s3.amazonaws.com" },
+        Action: "sns:Publish",
+        Resource: topicArn,
+      }),
+    });
+
+    // Then the topic carries the policy the template named.
+    const read = await simAws
+      .sns()
+      .getTopicAttributes(
+        new GetTopicAttributesCommand({ TopicArn: topicArn }),
+      );
+
+    assertNonNullable(read.Attributes?.["Policy"]);
+    assertStringIncludes(read.Attributes["Policy"], "s3.amazonaws.com");
+
+    // And the policy takes effect: S3 may publish to the topic.
+    const published = await simAws
+      .sns()
+      .publish(new PublishCommand({ TopicArn: topicArn, Message: "order-1" }), {
+        caller: s3ServicePrincipal,
+      });
+
+    assertNonNullable(published.MessageId);
+  });
+
+  it("deploys a policy that admits nobody it does not name", async () => {
+    // Given a template whose topic policy admits S3 for another topic.
+    const simAws = new SimAws();
+    const topicArn = `arn:aws:sns:${simAws.defaultRegionName}:${simAws.defaultAccountId}:orders`;
+
+    // When the template is deployed.
+    await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: ordersTemplate({
+        Effect: "Allow",
+        Principal: { Service: "s3.amazonaws.com" },
+        Action: "sns:Publish",
+        Resource: `arn:aws:sns:${simAws.defaultRegionName}:${simAws.defaultAccountId}:invoices`,
+      }),
+    });
+
+    // Then S3 is refused, rather than the deployed policy admitting anyone who
+    // asks.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws
+        .sns()
+        .publish(
+          new PublishCommand({ TopicArn: topicArn, Message: "order-1" }),
+          { caller: s3ServicePrincipal },
+        );
+    });
+
+    assertIdentical(error.name, "AuthorizationErrorException");
+  });
+
+  it("fails a policy document SetTopicAttributes would refuse", async () => {
+    // Given a template whose policy statement has no Effect, which is not a
+    // policy document sim IAM will validate.
+    const simAws = new SimAws();
+
+    // When the template is deployed, then the deployment fails.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.cloudFormation().deployTemplate({
+        stackName: "orders-stack",
+        template: ordersTemplate({
+          Principal: { Service: "s3.amazonaws.com" },
+          Action: "sns:Publish",
+          Resource: "*",
+        }),
+      });
+    });
+
+    // And it says which Resource was invalid, with SNS's own reason inside it.
+    assertStringIncludes(
+      error.message,
+      "Invalid AWS::SNS::TopicPolicy Resource OrdersTopicPolicy",
+    );
+    assertStringIncludes(error.message, "Policy Error");
+  });
+
+  it("refuses a Resource naming no topics", async () => {
+    // Given a topic policy with an empty Topics list, which names nothing to
+    // set the policy on.
+    const simAws = new SimAws();
+
+    // When the template is deployed, then the deployment fails.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.cloudFormation().deployTemplate({
+        stackName: "orders-stack",
+        template: {
+          Resources: {
+            OrdersTopicPolicy: {
+              Type: "AWS::SNS::TopicPolicy",
+              Properties: { Topics: [], PolicyDocument: { Statement: [] } },
+            },
+          },
+        },
+      });
+    });
+
+    assertStringIncludes(
+      error.message,
+      "AWS::SNS::TopicPolicy OrdersTopicPolicy requires a Topics list",
+    );
+  });
+
+  it("refuses a Resource with no PolicyDocument object", async () => {
+    // Given a topic policy whose document is a string rather than an object.
+    const simAws = new SimAws();
+
+    // When the template is deployed, then the deployment fails.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.cloudFormation().deployTemplate({
+        stackName: "orders-stack",
+        template: {
+          Resources: {
+            OrdersTopic: {
+              Type: "AWS::SNS::Topic",
+              Properties: { TopicName: "orders" },
+            },
+            OrdersTopicPolicy: {
+              Type: "AWS::SNS::TopicPolicy",
+              Properties: {
+                Topics: [{ Ref: "OrdersTopic" }],
+                PolicyDocument: "{}",
+              },
+            },
+          },
+        },
+      });
+    });
+
+    assertStringIncludes(
+      error.message,
+      "AWS::SNS::TopicPolicy OrdersTopicPolicy requires a PolicyDocument object",
+    );
+  });
+
+  it("refuses a Topics entry that is not a topic ARN string", async () => {
+    // Given a topic policy whose Topics list carries a number.
+    const simAws = new SimAws();
+
+    // When the template is deployed, then the deployment fails.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.cloudFormation().deployTemplate({
+        stackName: "orders-stack",
+        template: {
+          Resources: {
+            OrdersTopicPolicy: {
+              Type: "AWS::SNS::TopicPolicy",
+              Properties: { Topics: [7], PolicyDocument: { Statement: [] } },
+            },
+          },
+        },
+      });
+    });
+
+    assertStringIncludes(
+      error.message,
+      "requires each entry of Topics to be a topic ARN string, got number",
+    );
+  });
+});

--- a/src/service/sns/cfn/sim-cfn-sns-topic.iso.test.ts
+++ b/src/service/sns/cfn/sim-cfn-sns-topic.iso.test.ts
@@ -1,0 +1,204 @@
+import { GetTopicAttributesCommand } from "@aws-sdk/client-sns";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import { SimSnsTopic } from "../topic/sim-sns-topic.js";
+
+const accountIdOneOnes = "111111111111";
+
+const ordersTopicArn = "arn:aws:sns:eu-west-2:111111111111:orders";
+
+function simAwsInEuWest2(): SimAws {
+  return new SimAws({
+    defaultAccountId: accountIdOneOnes,
+    defaultRegionName: "eu-west-2",
+  });
+}
+
+describe("SNS CloudFormation Topic deployment", () => {
+  it("creates a topic with the attributes the template sets", async () => {
+    // Given a template declaring a topic with a name and a display name.
+    const simAws = simAwsInEuWest2();
+
+    // When the template is deployed.
+    await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: {
+        Resources: {
+          OrdersTopic: {
+            Type: "AWS::SNS::Topic",
+            Properties: { TopicName: "orders", DisplayName: "Orders" },
+          },
+        },
+      },
+    });
+
+    // Then the attributes read back as an SDK caller would read them, so a
+    // wrong value in the template is a wrong value in the test.
+    const read = await simAws
+      .sns()
+      .getTopicAttributes(
+        new GetTopicAttributesCommand({ TopicArn: ordersTopicArn }),
+      );
+
+    assertNonNullable(read.Attributes);
+    assertIdentical(read.Attributes["TopicArn"], ordersTopicArn);
+    assertIdentical(read.Attributes["DisplayName"], "Orders");
+    assertIdentical(read.Attributes["Owner"], accountIdOneOnes);
+  });
+
+  it("applies a display name a template Parameter supplies", async () => {
+    // Given a template taking its display name from a Parameter.
+    const simAws = simAwsInEuWest2();
+
+    // When the template is deployed with a value for it.
+    await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      parameters: { TopicDisplayName: "Customer orders" },
+      template: {
+        Parameters: { TopicDisplayName: { Type: "String" } },
+        Resources: {
+          OrdersTopic: {
+            Type: "AWS::SNS::Topic",
+            Properties: {
+              TopicName: "orders",
+              DisplayName: { Ref: "TopicDisplayName" },
+            },
+          },
+        },
+      },
+    });
+
+    // Then the topic has the value the Parameter carried.
+    const read = await simAws
+      .sns()
+      .getTopicAttributes(
+        new GetTopicAttributesCommand({ TopicArn: ordersTopicArn }),
+      );
+
+    assertIdentical(read.Attributes?.["DisplayName"], "Customer orders");
+  });
+
+  it("resolves Ref to the topic ARN and Fn::GetAtt to its ARN and name", async () => {
+    // Given a template referencing its topic every way it can.
+    const simAws = simAwsInEuWest2();
+
+    // When the template is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: {
+        Resources: {
+          OrdersTopic: {
+            Type: "AWS::SNS::Topic",
+            Properties: { TopicName: "orders" },
+          },
+        },
+        Outputs: {
+          TopicRef: { Value: { Ref: "OrdersTopic" } },
+          TopicArn: { Value: { "Fn::GetAtt": ["OrdersTopic", "TopicArn"] } },
+          TopicName: { Value: { "Fn::GetAtt": ["OrdersTopic", "TopicName"] } },
+        },
+      },
+    });
+
+    // Then Ref is the topic ARN, as AWS::SNS::Topic Ref is, so it can be
+    // handed straight to Publish.
+    assertIdentical(stack.outputs.get("TopicRef")?.value, ordersTopicArn);
+    assertIdentical(stack.outputs.get("TopicArn")?.value, ordersTopicArn);
+    assertIdentical(stack.outputs.get("TopicName")?.value, "orders");
+  });
+
+  it("names an unnamed topic after the stack and its logical ID", async () => {
+    // Given a template leaving TopicName out, as CDK does for a topic with no
+    // explicit name.
+    const simAws = simAwsInEuWest2();
+
+    // When the template is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: {
+        Resources: { OrdersTopic: { Type: "AWS::SNS::Topic" } },
+        Outputs: {
+          TopicName: { Value: { "Fn::GetAtt": ["OrdersTopic", "TopicName"] } },
+        },
+      },
+    });
+
+    // Then the topic is named from the stack name and the logical ID, as real
+    // CloudFormation names one, without the random characters a template could
+    // not predict anyway.
+    assertIdentical(
+      stack.outputs.get("TopicName")?.value,
+      "orders-stack-OrdersTopic",
+    );
+    assertNonNullable(simAws.sns().findTopic("orders-stack-OrdersTopic"));
+  });
+
+  it("backs the CloudFormation Resource with the simulated topic", async () => {
+    // Given a deployed topic.
+    const simAws = simAwsInEuWest2();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: {
+        Resources: {
+          OrdersTopic: {
+            Type: "AWS::SNS::Topic",
+            Properties: { TopicName: "orders" },
+          },
+        },
+      },
+    });
+
+    // When the Resource is inspected.
+    const resource = stack.getResource("OrdersTopic");
+    assertNonNullable(resource);
+
+    // Then it is backed by the same simulated topic the service holds, rather
+    // than some other simulated resource that happens to have an ARN.
+    const topic = resource.simResource;
+    assertInstanceOf(topic, SimSnsTopic);
+    assertIdentical(simAws.sns().findTopic("orders"), topic);
+  });
+
+  it("creates the topic in the stack's account and region", async () => {
+    // Given a simulated AWS whose default scope is not the stack's.
+    const simAws = new SimAws();
+
+    // When a template is deployed into another account and region.
+    await simAws
+      .account(accountIdOneOnes)
+      .region("us-east-1")
+      .cloudFormation()
+      .deployTemplate({
+        stackName: "orders-stack",
+        template: {
+          Resources: {
+            OrdersTopic: {
+              Type: "AWS::SNS::Topic",
+              Properties: { TopicName: "orders" },
+            },
+          },
+        },
+      });
+
+    // Then the topic exists in that account and region, and nowhere else.
+    const scoped = simAws
+      .account(accountIdOneOnes)
+      .region("us-east-1")
+      .sns()
+      .findTopic("orders");
+
+    assertNonNullable(scoped);
+    assertIdentical(
+      scoped.arn.value,
+      "arn:aws:sns:us-east-1:111111111111:orders",
+    );
+    assertUndefined(simAws.sns().findTopic("orders"));
+  });
+});

--- a/src/service/sns/cfn/sim-cfn-sns-validation.iso.test.ts
+++ b/src/service/sns/cfn/sim-cfn-sns-validation.iso.test.ts
@@ -174,6 +174,27 @@ describe("AWS::SNS::Topic validation", () => {
     );
   });
 
+  it("fails an inline Subscription entry asking for a filter policy", async () => {
+    // Given an inline entry carrying something an inline entry cannot carry.
+    // Real CloudFormation gives one a Protocol and an Endpoint and nothing
+    // else, so the separate Resource is the only place a filter policy goes.
+    const error = await deployTopic({
+      TopicName: "orders",
+      Subscription: [
+        {
+          Protocol: "sqs",
+          Endpoint: "arn:aws:sqs:us-east-1:888888888888:fulfilment",
+          FilterPolicy: { region: ["eu"] },
+        },
+      ],
+    });
+
+    assertStringIncludes(
+      error.message,
+      "an entry of Subscription carries FilterPolicy",
+    );
+  });
+
   it("fails an inline Subscription entry with no Endpoint", async () => {
     const error = await deployTopic({
       TopicName: "orders",

--- a/src/service/sns/cfn/sim-cfn-sns-validation.iso.test.ts
+++ b/src/service/sns/cfn/sim-cfn-sns-validation.iso.test.ts
@@ -1,0 +1,277 @@
+import { assertStringIncludes, assertThrowsErrorAsync } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import type { SimCfnTemplateValueRecord } from "../../cloudformation/template/value/sim-cfn-template-value.js";
+
+/**
+ * Deploy one AWS::SNS::Topic and hand back whatever the deployment failed
+ * with.
+ *
+ * A refusal has to fail the Resource rather than skip it. Sim CloudFormation
+ * steps over a Resource whose error reads as unsupported, and stepping over a
+ * topic leaves a stack that looks deployed with nothing publishing anywhere.
+ */
+async function deployTopic(
+  properties: SimCfnTemplateValueRecord,
+): Promise<Error> {
+  const simAws = new SimAws();
+
+  return await assertThrowsErrorAsync(async () => {
+    await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: {
+        Resources: {
+          OrdersTopic: { Type: "AWS::SNS::Topic", Properties: properties },
+        },
+      },
+    });
+  });
+}
+
+/**
+ * Deploy one AWS::SNS::Subscription against a deployed topic and hand back
+ * whatever the deployment failed with.
+ */
+async function deploySubscription(
+  properties: SimCfnTemplateValueRecord,
+): Promise<Error> {
+  const simAws = new SimAws();
+
+  return await assertThrowsErrorAsync(async () => {
+    await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: {
+        Resources: {
+          OrdersTopic: {
+            Type: "AWS::SNS::Topic",
+            Properties: { TopicName: "orders" },
+          },
+          FulfilmentSubscription: {
+            Type: "AWS::SNS::Subscription",
+            Properties: { TopicArn: { Ref: "OrdersTopic" }, ...properties },
+          },
+        },
+      },
+    });
+  });
+}
+
+describe("AWS::SNS::Topic validation", () => {
+  it("fails a FIFO topic rather than creating a standard one", async () => {
+    // Given a template asking for a FIFO topic, which is not simulated.
+    const error = await deployTopic({ TopicName: "orders", FifoTopic: true });
+
+    // Then the Resource is invalid, with SNS's own reason inside it, rather
+    // than unsupported and stepped over.
+    assertStringIncludes(
+      error.message,
+      "Invalid AWS::SNS::Topic Resource OrdersTopic",
+    );
+    assertStringIncludes(
+      error.message,
+      "The topic attribute FifoTopic is not simulated",
+    );
+  });
+
+  it("fails a topic asking for server-side encryption", async () => {
+    // Given a template naming a KMS key for the topic.
+    const error = await deployTopic({
+      TopicName: "orders",
+      KmsMasterKeyId: "alias/aws/sns",
+    });
+
+    // Then it fails rather than deploying a topic that is not encrypted.
+    assertStringIncludes(
+      error.message,
+      "The topic attribute KmsMasterKeyId is not simulated",
+    );
+  });
+
+  it("fails a topic carrying tags", async () => {
+    // Given a template tagging the topic.
+    const error = await deployTopic({
+      TopicName: "orders",
+      Tags: [{ Key: "team", Value: "orders" }],
+    });
+
+    // Then it fails, since a dropped tag would leave the topic looking tagged
+    // to the template that wrote it.
+    assertStringIncludes(
+      error.message,
+      "Tags is a real AWS::SNS::Topic property simulated SNS does not act on",
+    );
+  });
+
+  it("fails a topic asking for delivery status logging", async () => {
+    // Given a template configuring delivery status logging, which would become
+    // fifteen separate attributes.
+    const error = await deployTopic({
+      TopicName: "orders",
+      DeliveryStatusLogging: [
+        { Protocol: "sqs", SuccessFeedbackSampleRate: 100 },
+      ],
+    });
+
+    assertStringIncludes(
+      error.message,
+      "DeliveryStatusLogging is a real AWS::SNS::Topic property simulated SNS does not act on",
+    );
+  });
+
+  it("fails a topic carrying a property AWS::SNS::Topic does not have", async () => {
+    // Given a template with a misspelled property.
+    const error = await deployTopic({
+      TopicName: "orders",
+      DisplayNam: "Orders",
+    });
+
+    // Then the topic is not deployed silently missing the setting.
+    assertStringIncludes(
+      error.message,
+      "DisplayNam is not a property of AWS::SNS::Topic",
+    );
+  });
+
+  it("fails a TopicName that is not a string", async () => {
+    const error = await deployTopic({ TopicName: 7 });
+
+    assertStringIncludes(error.message, "TopicName must be a string");
+  });
+
+  it("fails a topic name simulated SNS refuses", async () => {
+    // Given a name ending in .fifo, which names a FIFO topic.
+    const error = await deployTopic({ TopicName: "orders.fifo" });
+
+    assertStringIncludes(
+      error.message,
+      "Invalid AWS::SNS::Topic Resource OrdersTopic",
+    );
+    assertStringIncludes(error.message, "names a FIFO topic");
+  });
+
+  it("fails an inline Subscription list that is not a list", async () => {
+    const error = await deployTopic({
+      TopicName: "orders",
+      Subscription: { Protocol: "sqs", Endpoint: "x" },
+    });
+
+    assertStringIncludes(
+      error.message,
+      "Subscription must be a list of subscriptions",
+    );
+  });
+
+  it("fails an inline Subscription entry that is not an object", async () => {
+    const error = await deployTopic({
+      TopicName: "orders",
+      Subscription: ["sqs"],
+    });
+
+    assertStringIncludes(
+      error.message,
+      "each entry of Subscription must be an object",
+    );
+  });
+
+  it("fails an inline Subscription entry with no Endpoint", async () => {
+    const error = await deployTopic({
+      TopicName: "orders",
+      Subscription: [{ Protocol: "sqs" }],
+    });
+
+    assertStringIncludes(
+      error.message,
+      "each entry of Subscription requires Endpoint to be a string",
+    );
+  });
+});
+
+describe("AWS::SNS::Subscription validation", () => {
+  it("fails a subscription with no Protocol", async () => {
+    const error = await deploySubscription({ Endpoint: "x" });
+
+    assertStringIncludes(
+      error.message,
+      "Protocol is required and must be a string",
+    );
+  });
+
+  it("leaves an absent Endpoint to Subscribe to refuse", async () => {
+    // Given a subscription with no Endpoint. Real CloudFormation leaves the
+    // property optional, because a protocol such as sms carries the
+    // destination elsewhere, so the refusal belongs to the protocol.
+    const error = await deploySubscription({ Protocol: "sqs" });
+
+    assertStringIncludes(
+      error.message,
+      "Invalid AWS::SNS::Subscription Resource FulfilmentSubscription",
+    );
+    assertStringIncludes(error.message, "Endpoint");
+  });
+
+  it("fails a subscription whose Endpoint is not a string", async () => {
+    const error = await deploySubscription({ Protocol: "sqs", Endpoint: 7 });
+
+    assertStringIncludes(error.message, "Endpoint must be a string");
+  });
+
+  it("fails a subscription naming a Region of its own", async () => {
+    // Given a cross-region subscription, which simulated SNS has nothing to do
+    // with: the topic ARN already says where the topic is.
+    const error = await deploySubscription({
+      Protocol: "sqs",
+      Endpoint: "arn:aws:sqs:us-east-1:123456789012:fulfilment",
+      Region: "us-east-1",
+    });
+
+    assertStringIncludes(
+      error.message,
+      "Region is a real AWS::SNS::Subscription property simulated SNS does not act on",
+    );
+  });
+
+  it("fails a subscription asking for a dead-letter queue", async () => {
+    // Given a redrive policy, which is a real subscription attribute this
+    // simulation gives no behaviour to.
+    const error = await deploySubscription({
+      Protocol: "sqs",
+      Endpoint: "arn:aws:sqs:us-east-1:123456789012:fulfilment",
+      RedrivePolicy: { deadLetterTargetArn: "arn:aws:sqs:x:y:dlq" },
+    });
+
+    assertStringIncludes(
+      error.message,
+      "The subscription attribute RedrivePolicy is not simulated",
+    );
+  });
+
+  it("fails a subscription carrying a property AWS::SNS::Subscription does not have", async () => {
+    const error = await deploySubscription({
+      Protocol: "sqs",
+      Endpoint: "arn:aws:sqs:us-east-1:123456789012:fulfilment",
+      RawMessageDeliver: true,
+    });
+
+    assertStringIncludes(
+      error.message,
+      "RawMessageDeliver is not a property of AWS::SNS::Subscription",
+    );
+  });
+
+  it("fails a filter policy simulated SNS refuses", async () => {
+    // Given a policy using the cidr operator, which is the one operator real
+    // SNS has that this does not.
+    const error = await deploySubscription({
+      Protocol: "sqs",
+      Endpoint: "arn:aws:sqs:eu-west-2:123456789012:fulfilment",
+      FilterPolicy: { source: [{ cidr: "10.0.0.0/24" }] },
+    });
+
+    assertStringIncludes(
+      error.message,
+      "Invalid AWS::SNS::Subscription Resource FulfilmentSubscription",
+    );
+    assertStringIncludes(error.message, "cidr");
+  });
+});

--- a/src/service/sns/cfn/sim-sns-cfn-resource-factory.ts
+++ b/src/service/sns/cfn/sim-sns-cfn-resource-factory.ts
@@ -1,0 +1,83 @@
+import type { SimCfnServiceResourceFactory } from "../../cloudformation/resource/factory/sim-cfn-resource-factory.type.js";
+import type {
+  SimCfnResource,
+  SimCloudFormationResourceCreateContext,
+} from "../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCloudFormationResourceDeleteContext } from "../../cloudformation/resource/sim-cfn-resource.type.js";
+import type { SimSns } from "../sim-sns.js";
+import { SimCfnSnsResourceDeleter } from "./sim-cfn-sns-resource-deleter.js";
+import { SimCfnSnsSubscriptionCreator } from "./subscription/sim-cfn-sns-subscription-creator.js";
+import { SimCfnSnsTopicCreator } from "./topic/sim-cfn-sns-topic-creator.js";
+import { SimCfnSnsTopicPolicyCreator } from "./topic-policy/sim-cfn-sns-topic-policy-creator.js";
+
+interface SimSnsCfnResourceFactoryProperties {
+  readonly sns: SimSns;
+}
+
+/**
+ * CloudFormation Resource factory for simulated SNS resources.
+ */
+export class SimSnsCfnResourceFactory implements SimCfnServiceResourceFactory {
+  private readonly topicCreator: SimCfnSnsTopicCreator;
+  private readonly subscriptionCreator: SimCfnSnsSubscriptionCreator;
+  private readonly topicPolicyCreator: SimCfnSnsTopicPolicyCreator;
+  private readonly deleter: SimCfnSnsResourceDeleter;
+
+  constructor(properties: SimSnsCfnResourceFactoryProperties) {
+    this.topicCreator = new SimCfnSnsTopicCreator({ sns: properties.sns });
+    this.subscriptionCreator = new SimCfnSnsSubscriptionCreator({
+      sns: properties.sns,
+    });
+    this.topicPolicyCreator = new SimCfnSnsTopicPolicyCreator({
+      sns: properties.sns,
+    });
+    this.deleter = new SimCfnSnsResourceDeleter({ sns: properties.sns });
+  }
+
+  /**
+   * Create a simulated SNS resource from a CloudFormation Resource.
+   *
+   * The topic, its subscriptions and its policy are the AWS::SNS::* Resource
+   * types this simulation models. Anything else is reported as unsupported and
+   * skipped rather than quietly treated as deployed.
+   */
+  async create(
+    resourceTypeName: string,
+    resource: SimCfnResource,
+    context: SimCloudFormationResourceCreateContext,
+  ): Promise<object | undefined> {
+    const properties = context.resolvedProperties ?? resource.properties;
+
+    switch (resourceTypeName) {
+      case "Topic": {
+        return await this.topicCreator.create(resource, properties);
+      }
+      case "Subscription": {
+        return await this.subscriptionCreator.create(resource, properties);
+      }
+      case "TopicPolicy": {
+        return await this.topicPolicyCreator.create(resource, properties);
+      }
+      default: {
+        throw new Error(
+          `Unsupported sim SNS CloudFormation Resource ${resourceTypeName}`,
+        );
+      }
+    }
+  }
+
+  /**
+   * Delete a simulated SNS resource created from a CloudFormation Resource.
+   */
+  async delete(
+    resourceTypeName: string,
+    resource: SimCfnResource,
+    context: SimCloudFormationResourceDeleteContext,
+  ): Promise<void> {
+    await this.deleter.delete(
+      resourceTypeName,
+      resource,
+      context.resolvedProperties ?? resource.properties,
+    );
+  }
+}

--- a/src/service/sns/cfn/subscription/sim-cfn-sns-subscription-creator.ts
+++ b/src/service/sns/cfn/subscription/sim-cfn-sns-subscription-creator.ts
@@ -1,0 +1,61 @@
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimSns } from "../../sim-sns.js";
+import type { SimSnsSubscription } from "../../subscription/sim-sns-subscription.js";
+import { simCfnSnsResourceCreation } from "../sim-cfn-sns-resource-error.js";
+import { snsSubscriptionResourceType } from "../sim-cfn-sns-resource-types.js";
+import { SimCfnSnsSubscriptionProperties } from "./sim-cfn-sns-subscription-properties.js";
+
+interface SimCfnSnsSubscriptionCreatorProperties {
+  readonly sns: SimSns;
+}
+
+/**
+ * Creates simulated subscriptions from AWS::SNS::Subscription Resources.
+ *
+ * This is what CDK emits for `topic.addSubscription(...)`, alongside whatever
+ * lets the delivery through: an AWS::SQS::QueuePolicy for a queue, an
+ * AWS::Lambda::Permission for a function. The subscription goes through the
+ * ordinary Subscribe command, so the endpoint has to be one the protocol can
+ * reach and the filter policy is read exactly as one set through the SDK is.
+ */
+export class SimCfnSnsSubscriptionCreator {
+  private readonly sns: SimSns;
+
+  constructor(properties: SimCfnSnsSubscriptionCreatorProperties) {
+    this.sns = properties.sns;
+  }
+
+  /**
+   * Create a subscription from an AWS::SNS::Subscription Resource.
+   */
+  async create(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): Promise<SimSnsSubscription> {
+    const input = new SimCfnSnsSubscriptionProperties({
+      resource,
+      properties,
+    }).input();
+
+    return simCfnSnsResourceCreation(
+      snsSubscriptionResourceType,
+      resource.logicalId,
+      async () => {
+        const subscribed = await this.sns.subscribe({ input });
+
+        const arn = subscribed.SubscriptionArn;
+        assertDefined(
+          arn,
+          `sim SNS subscription ARN after CloudFormation creation of ${resource.logicalId}`,
+        );
+
+        const subscription = this.sns.findSubscription(arn);
+        assertDefined(subscription, `sim SNS subscription ${arn}`);
+
+        return subscription;
+      },
+    );
+  }
+}

--- a/src/service/sns/cfn/subscription/sim-cfn-sns-subscription-properties.ts
+++ b/src/service/sns/cfn/subscription/sim-cfn-sns-subscription-properties.ts
@@ -1,0 +1,135 @@
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type {
+  SimCfnTemplateValue,
+  SimCfnTemplateValueRecord,
+} from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimSubscribeCommandInput } from "../../command/subscription/subscription.command.js";
+import type { SimSnsSubscriptionAttributeInput } from "../../subscription/sim-sns-subscription-attributes.js";
+import { simCfnSnsAttributeValue } from "../sim-cfn-sns-attribute-value.js";
+import { simCfnSnsResourceError } from "../sim-cfn-sns-resource-error.js";
+import { snsSubscriptionResourceType } from "../sim-cfn-sns-resource-types.js";
+import {
+  attributePropertyNames,
+  subscriptionEndpointPropertyName,
+  subscriptionPropertyNames,
+  subscriptionProtocolPropertyName,
+  subscriptionTopicArnPropertyName,
+  unsimulatedPropertyReasons,
+} from "./sim-cfn-sns-subscription-property-names.js";
+
+interface SimCfnSnsSubscriptionPropertiesProperties {
+  readonly resource: SimCfnResource;
+  readonly properties: SimCfnTemplateValueRecord;
+}
+
+/**
+ * Reads AWS::SNS::Subscription CloudFormation properties into the shape
+ * Subscribe takes.
+ *
+ * The three settings this simulation acts on, `RawMessageDelivery`, the filter
+ * policy and its scope, are attributes of the same name, so they go through as
+ * attributes and are validated exactly as an SDK caller's are. A filter policy
+ * is written as an object in a template and set as a JSON string through the
+ * API, which is the only conversion needed on the way.
+ */
+export class SimCfnSnsSubscriptionProperties {
+  private readonly resource: SimCfnResource;
+  private readonly properties: ReadonlyMap<string, SimCfnTemplateValue>;
+
+  constructor(properties: SimCfnSnsSubscriptionPropertiesProperties) {
+    this.resource = properties.resource;
+    this.properties = new Map(Object.entries(properties.properties));
+  }
+
+  /**
+   * The Subscribe request the Resource describes.
+   */
+  input(): SimSubscribeCommandInput {
+    return {
+      TopicArn: this.requiredString(subscriptionTopicArnPropertyName),
+      Protocol: this.requiredString(subscriptionProtocolPropertyName),
+      Endpoint: this.endpoint(),
+      Attributes: this.attributes(),
+    };
+  }
+
+  /**
+   * What the subscription delivers to.
+   *
+   * Real CloudFormation leaves it optional, because a protocol such as `sms`
+   * carries the destination elsewhere. Neither protocol simulated here is one
+   * of those, so an absent endpoint is refused by Subscribe rather than here.
+   */
+  private endpoint(): string | undefined {
+    const endpoint = this.properties.get(subscriptionEndpointPropertyName);
+
+    if (endpoint === undefined) {
+      return undefined;
+    }
+
+    if (typeof endpoint !== "string") {
+      throw this.propertyError(
+        `${subscriptionEndpointPropertyName} must be a string`,
+      );
+    }
+
+    return endpoint;
+  }
+
+  private attributes(): SimSnsSubscriptionAttributeInput {
+    return Object.fromEntries(
+      this.properties
+        .entries()
+        .filter(([name]) => this.isAttributeProperty(name))
+        .map(([name, value]) => [name, simCfnSnsAttributeValue(value)]),
+    );
+  }
+
+  /**
+   * Whether a property is handed to Subscribe as an attribute.
+   *
+   * The properties naming the subscription itself are not. Anything else with
+   * no attribute behind it is refused, rather than deployed as a subscription
+   * quietly missing whatever it asked for.
+   */
+  private isAttributeProperty(name: string): boolean {
+    if (subscriptionPropertyNames.has(name)) {
+      return false;
+    }
+
+    if (attributePropertyNames.has(name)) {
+      return true;
+    }
+
+    const unsimulatedReason = unsimulatedPropertyReasons.get(name);
+
+    if (unsimulatedReason !== undefined) {
+      throw this.propertyError(
+        `${name} is a real ${snsSubscriptionResourceType} property simulated ` +
+          `SNS does not act on: ${unsimulatedReason}`,
+      );
+    }
+
+    throw this.propertyError(
+      `${name} is not a property of ${snsSubscriptionResourceType}`,
+    );
+  }
+
+  private requiredString(name: string): string {
+    const value = this.properties.get(name);
+
+    if (typeof value !== "string") {
+      throw this.propertyError(`${name} is required and must be a string`);
+    }
+
+    return value;
+  }
+
+  private propertyError(reason: string): Error {
+    return simCfnSnsResourceError(
+      snsSubscriptionResourceType,
+      this.resource.logicalId,
+      reason,
+    );
+  }
+}

--- a/src/service/sns/cfn/subscription/sim-cfn-sns-subscription-property-names.ts
+++ b/src/service/sns/cfn/subscription/sim-cfn-sns-subscription-property-names.ts
@@ -1,0 +1,59 @@
+/**
+ * The topic the subscription belongs to, as an ARN.
+ */
+export const subscriptionTopicArnPropertyName = "TopicArn";
+
+/**
+ * How the subscription is delivered to.
+ */
+export const subscriptionProtocolPropertyName = "Protocol";
+
+/**
+ * What the subscription is delivered to, which is a queue ARN or a function
+ * ARN for the two protocols simulated.
+ */
+export const subscriptionEndpointPropertyName = "Endpoint";
+
+/**
+ * The three properties naming the subscription itself, which the
+ * CloudFormation layer reads rather than handing on as attributes.
+ */
+export const subscriptionPropertyNames: ReadonlySet<string> = new Set([
+  subscriptionTopicArnPropertyName,
+  subscriptionProtocolPropertyName,
+  subscriptionEndpointPropertyName,
+]);
+
+/**
+ * The AWS::SNS::Subscription properties carrying a subscription attribute of
+ * the same name.
+ *
+ * CloudFormation names these exactly as the SNS API names the attributes, so
+ * they are handed to Subscribe rather than read here. `RawMessageDelivery`, the
+ * filter policy and the scope it is read under are the three simulated SNS
+ * acts on, and a template setting them gets the same validation an SDK caller
+ * setting them gets. The rest are refused by SNS with the reason each one is
+ * missing.
+ */
+export const attributePropertyNames: ReadonlySet<string> = new Set([
+  "DeliveryPolicy",
+  "FilterPolicy",
+  "FilterPolicyScope",
+  "RawMessageDelivery",
+  "RedrivePolicy",
+  "ReplayPolicy",
+  "SubscriptionRoleArn",
+]);
+
+/**
+ * The real AWS::SNS::Subscription properties this simulation has no behaviour
+ * for and no subscription attribute to hand them to.
+ */
+export const unsimulatedPropertyReasons: ReadonlyMap<string, string> = new Map([
+  [
+    "Region",
+    "a subscription is created in the Region its topic ARN names, and " +
+      "simulated SNS refuses a topic ARN naming another Region, so there is " +
+      "nothing for this to change",
+  ],
+]);

--- a/src/service/sns/cfn/topic-policy/sim-cfn-sns-topic-policy-creator.ts
+++ b/src/service/sns/cfn/topic-policy/sim-cfn-sns-topic-policy-creator.ts
@@ -8,7 +8,10 @@ import { simSnsPolicyAttributeName } from "../../topic/sim-sns-topic-attribute-n
 import { parseSnsTopicArn } from "../../topic/sim-sns-topic-arn.js";
 import { simCfnSnsResourceCreation } from "../sim-cfn-sns-resource-error.js";
 import { snsTopicPolicyResourceType } from "../sim-cfn-sns-resource-types.js";
-import { simCfnSnsPolicyTopicArns } from "./sim-cfn-sns-topic-policy-properties.js";
+import {
+  simCfnSnsPolicyDocument,
+  simCfnSnsPolicyTopicArns,
+} from "./sim-cfn-sns-topic-policy-properties.js";
 
 interface SimCfnSnsTopicPolicyCreatorProperties {
   readonly sns: SimSns;
@@ -41,14 +44,15 @@ export class SimCfnSnsTopicPolicyCreator {
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
   ): Promise<SimSnsTopic> {
-    const topicArns = simCfnSnsPolicyTopicArns(resource.logicalId, properties);
+    const { logicalId } = resource;
+    const topicArns = simCfnSnsPolicyTopicArns(logicalId, properties);
     const policy = jsonStringify(
-      this.policyDocumentForResource(resource, properties),
+      simCfnSnsPolicyDocument(logicalId, properties),
     );
 
     return simCfnSnsResourceCreation(
       snsTopicPolicyResourceType,
-      resource.logicalId,
+      logicalId,
       async () => {
         const topics = await Promise.all(
           topicArns.map(async (topicArn) =>
@@ -59,7 +63,7 @@ export class SimCfnSnsTopicPolicyCreator {
         const first = topics[0];
         assertDefined(
           first,
-          `sim SNS topic after CloudFormation topic policy creation for ${resource.logicalId}`,
+          `sim SNS topic after CloudFormation topic policy creation for ${logicalId}`,
         );
 
         return first;
@@ -89,25 +93,5 @@ export class SimCfnSnsTopicPolicyCreator {
     assertDefined(topic, `sim SNS topic at ${topicArn}`);
 
     return topic;
-  }
-
-  private policyDocumentForResource(
-    resource: SimCfnResource,
-    properties: SimCfnTemplateValueRecord,
-  ): object {
-    const policyDocument = properties["PolicyDocument"];
-
-    if (
-      policyDocument === undefined ||
-      policyDocument === null ||
-      typeof policyDocument !== "object" ||
-      Array.isArray(policyDocument)
-    ) {
-      throw new TypeError(
-        `${snsTopicPolicyResourceType} ${resource.logicalId} requires a PolicyDocument object`,
-      );
-    }
-
-    return policyDocument;
   }
 }

--- a/src/service/sns/cfn/topic-policy/sim-cfn-sns-topic-policy-creator.ts
+++ b/src/service/sns/cfn/topic-policy/sim-cfn-sns-topic-policy-creator.ts
@@ -1,0 +1,113 @@
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import { jsonStringify } from "../../../../util/type-guard/json.js";
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimSns } from "../../sim-sns.js";
+import type { SimSnsTopic } from "../../topic/sim-sns-topic.js";
+import { simSnsPolicyAttributeName } from "../../topic/sim-sns-topic-attribute-names.js";
+import { parseSnsTopicArn } from "../../topic/sim-sns-topic-arn.js";
+import { simCfnSnsResourceCreation } from "../sim-cfn-sns-resource-error.js";
+import { snsTopicPolicyResourceType } from "../sim-cfn-sns-resource-types.js";
+import { simCfnSnsPolicyTopicArns } from "./sim-cfn-sns-topic-policy-properties.js";
+
+interface SimCfnSnsTopicPolicyCreatorProperties {
+  readonly sns: SimSns;
+}
+
+/**
+ * Creates simulated topic policies from AWS::SNS::TopicPolicy Resources.
+ *
+ * This is what CDK emits for `grantPublish` to a service principal and for
+ * every `addToResourcePolicy`, so a synthesized template reaches it whether or
+ * not the app mentions a topic policy itself. The policy is set through the
+ * ordinary SetTopicAttributes command, so one declared in a template is
+ * validated and enforced exactly as one set through the SDK.
+ */
+export class SimCfnSnsTopicPolicyCreator {
+  private readonly sns: SimSns;
+
+  constructor(properties: SimCfnSnsTopicPolicyCreatorProperties) {
+    this.sns = properties.sns;
+  }
+
+  /**
+   * Attach a policy to each topic the Resource names.
+   *
+   * The first topic is returned as the Resource's simulated object, because a
+   * topic policy has no existence of its own in SNS: it is the `Policy`
+   * attribute of the topics it names.
+   */
+  async create(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): Promise<SimSnsTopic> {
+    const topicArns = simCfnSnsPolicyTopicArns(resource.logicalId, properties);
+    const policy = jsonStringify(
+      this.policyDocumentForResource(resource, properties),
+    );
+
+    return simCfnSnsResourceCreation(
+      snsTopicPolicyResourceType,
+      resource.logicalId,
+      async () => {
+        const topics = await Promise.all(
+          topicArns.map(async (topicArn) =>
+            this.policyApplied(topicArn, policy),
+          ),
+        );
+
+        const first = topics[0];
+        assertDefined(
+          first,
+          `sim SNS topic after CloudFormation topic policy creation for ${resource.logicalId}`,
+        );
+
+        return first;
+      },
+    );
+  }
+
+  /**
+   * Set the policy on one topic and hand back the topic it was set on.
+   */
+  private async policyApplied(
+    topicArn: string,
+    policy: string,
+  ): Promise<SimSnsTopic> {
+    await this.sns.setTopicAttributes({
+      input: {
+        TopicArn: topicArn,
+        AttributeName: simSnsPolicyAttributeName,
+        AttributeValue: policy,
+      },
+    });
+
+    const parts = parseSnsTopicArn(topicArn);
+    assertDefined(parts, `topic ARN ${topicArn} SetTopicAttributes accepted`);
+
+    const topic = this.sns.findTopic(parts.name);
+    assertDefined(topic, `sim SNS topic at ${topicArn}`);
+
+    return topic;
+  }
+
+  private policyDocumentForResource(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): object {
+    const policyDocument = properties["PolicyDocument"];
+
+    if (
+      policyDocument === undefined ||
+      policyDocument === null ||
+      typeof policyDocument !== "object" ||
+      Array.isArray(policyDocument)
+    ) {
+      throw new TypeError(
+        `${snsTopicPolicyResourceType} ${resource.logicalId} requires a PolicyDocument object`,
+      );
+    }
+
+    return policyDocument;
+  }
+}

--- a/src/service/sns/cfn/topic-policy/sim-cfn-sns-topic-policy-properties.ts
+++ b/src/service/sns/cfn/topic-policy/sim-cfn-sns-topic-policy-properties.ts
@@ -1,4 +1,5 @@
 import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import { simCfnSnsResourceError } from "../sim-cfn-sns-resource-error.js";
 import { snsTopicPolicyResourceType } from "../sim-cfn-sns-resource-types.js";
 
 /**
@@ -18,18 +19,51 @@ export function simCfnSnsPolicyTopicArns(
   const topics = properties["Topics"];
 
   if (!Array.isArray(topics) || topics.length === 0) {
-    throw new TypeError(
-      `${snsTopicPolicyResourceType} ${logicalId} requires a Topics list of topic ARNs`,
+    throw topicPolicyError(
+      logicalId,
+      "Topics is required and must be a list of topic ARNs",
     );
   }
 
   return topics.map((topic) => {
     if (typeof topic !== "string") {
-      throw new TypeError(
-        `${snsTopicPolicyResourceType} ${logicalId} requires each entry of Topics to be a topic ARN string, got ${typeof topic}`,
+      throw topicPolicyError(
+        logicalId,
+        `each entry of Topics must be a topic ARN string, and one is a ${typeof topic}`,
       );
     }
 
     return topic;
   });
+}
+
+/**
+ * The policy document an AWS::SNS::TopicPolicy Resource carries.
+ *
+ * A template writes it as an object where SetTopicAttributes takes a JSON
+ * string, so what comes back here is what is serialised on the way in.
+ */
+export function simCfnSnsPolicyDocument(
+  logicalId: string,
+  properties: SimCfnTemplateValueRecord,
+): object {
+  const policyDocument = properties["PolicyDocument"];
+
+  if (
+    policyDocument === undefined ||
+    policyDocument === null ||
+    typeof policyDocument !== "object" ||
+    Array.isArray(policyDocument)
+  ) {
+    throw topicPolicyError(
+      logicalId,
+      "PolicyDocument is required and must be an object",
+    );
+  }
+
+  return policyDocument;
+}
+
+function topicPolicyError(logicalId: string, reason: string): Error {
+  return simCfnSnsResourceError(snsTopicPolicyResourceType, logicalId, reason);
 }

--- a/src/service/sns/cfn/topic-policy/sim-cfn-sns-topic-policy-properties.ts
+++ b/src/service/sns/cfn/topic-policy/sim-cfn-sns-topic-policy-properties.ts
@@ -1,0 +1,35 @@
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import { snsTopicPolicyResourceType } from "../sim-cfn-sns-resource-types.js";
+
+/**
+ * The topic ARNs an AWS::SNS::TopicPolicy Resource names.
+ *
+ * `Ref` on an AWS::SNS::Topic gives its ARN, so a template naming its topics
+ * the way CDK does arrives here as the ARNs SetTopicAttributes takes.
+ *
+ * Creation and deletion both read them, because the Resource points at only the
+ * first of the topics it named and taking the policy back off needs all of
+ * them.
+ */
+export function simCfnSnsPolicyTopicArns(
+  logicalId: string,
+  properties: SimCfnTemplateValueRecord,
+): readonly string[] {
+  const topics = properties["Topics"];
+
+  if (!Array.isArray(topics) || topics.length === 0) {
+    throw new TypeError(
+      `${snsTopicPolicyResourceType} ${logicalId} requires a Topics list of topic ARNs`,
+    );
+  }
+
+  return topics.map((topic) => {
+    if (typeof topic !== "string") {
+      throw new TypeError(
+        `${snsTopicPolicyResourceType} ${logicalId} requires each entry of Topics to be a topic ARN string, got ${typeof topic}`,
+      );
+    }
+
+    return topic;
+  });
+}

--- a/src/service/sns/cfn/topic/sim-cfn-sns-inline-subscriptions.ts
+++ b/src/service/sns/cfn/topic/sim-cfn-sns-inline-subscriptions.ts
@@ -3,12 +3,18 @@ import { simCfnSnsResourceError } from "../sim-cfn-sns-resource-error.js";
 import { snsTopicResourceType } from "../sim-cfn-sns-resource-types.js";
 import { topicSubscriptionPropertyName } from "./sim-cfn-sns-topic-property-names.js";
 
+const protocolKey = "Protocol";
+
+const endpointKey = "Endpoint";
+
 /**
  * One entry of the `Subscription` list on an AWS::SNS::Topic.
  *
- * It carries the protocol and the endpoint and nothing else. A subscription
- * declared this way cannot have a filter policy or raw message delivery, which
- * is what the separate AWS::SNS::Subscription Resource is for.
+ * It carries the protocol and the endpoint and nothing else, which is all real
+ * CloudFormation lets one carry. A subscription declared this way therefore
+ * cannot have a filter policy or raw message delivery, and an entry asking for
+ * either is refused rather than deployed without it. That is what the separate
+ * AWS::SNS::Subscription Resource is for.
  */
 export interface SimCfnSnsInlineSubscription {
   readonly protocol: string;
@@ -52,9 +58,21 @@ function inlineSubscription(
     );
   }
 
+  const fields = new Map(Object.entries(entry));
+
+  for (const name of fields.keys()) {
+    if (name !== protocolKey && name !== endpointKey) {
+      throw topicPropertyError(
+        logicalId,
+        `an entry of ${topicSubscriptionPropertyName} carries ${name}, and ` +
+          `the only things one can carry are ${protocolKey} and ${endpointKey}`,
+      );
+    }
+  }
+
   return {
-    protocol: requiredString(logicalId, entry["Protocol"], "Protocol"),
-    endpoint: requiredString(logicalId, entry["Endpoint"], "Endpoint"),
+    protocol: requiredString(logicalId, fields.get(protocolKey), protocolKey),
+    endpoint: requiredString(logicalId, fields.get(endpointKey), endpointKey),
   };
 }
 

--- a/src/service/sns/cfn/topic/sim-cfn-sns-inline-subscriptions.ts
+++ b/src/service/sns/cfn/topic/sim-cfn-sns-inline-subscriptions.ts
@@ -1,0 +1,79 @@
+import type { SimCfnTemplateValue } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import { simCfnSnsResourceError } from "../sim-cfn-sns-resource-error.js";
+import { snsTopicResourceType } from "../sim-cfn-sns-resource-types.js";
+import { topicSubscriptionPropertyName } from "./sim-cfn-sns-topic-property-names.js";
+
+/**
+ * One entry of the `Subscription` list on an AWS::SNS::Topic.
+ *
+ * It carries the protocol and the endpoint and nothing else. A subscription
+ * declared this way cannot have a filter policy or raw message delivery, which
+ * is what the separate AWS::SNS::Subscription Resource is for.
+ */
+export interface SimCfnSnsInlineSubscription {
+  readonly protocol: string;
+  readonly endpoint: string;
+}
+
+/**
+ * Read the `Subscription` property of an AWS::SNS::Topic.
+ *
+ * CDK emits a separate AWS::SNS::Subscription Resource for every subscription,
+ * so this list is the hand-written template's way of writing the same thing.
+ * Both end up going through Subscribe.
+ */
+export function simCfnSnsInlineSubscriptions(
+  logicalId: string,
+  value: SimCfnTemplateValue | undefined,
+): readonly SimCfnSnsInlineSubscription[] {
+  if (value === undefined) {
+    return [];
+  }
+
+  if (!Array.isArray(value)) {
+    throw topicPropertyError(
+      logicalId,
+      `${topicSubscriptionPropertyName} must be a list of subscriptions`,
+    );
+  }
+
+  return value.map((entry) => inlineSubscription(logicalId, entry));
+}
+
+function inlineSubscription(
+  logicalId: string,
+  entry: SimCfnTemplateValue,
+): SimCfnSnsInlineSubscription {
+  if (entry === null || typeof entry !== "object" || Array.isArray(entry)) {
+    throw topicPropertyError(
+      logicalId,
+      `each entry of ${topicSubscriptionPropertyName} must be an object with ` +
+        `a Protocol and an Endpoint`,
+    );
+  }
+
+  return {
+    protocol: requiredString(logicalId, entry["Protocol"], "Protocol"),
+    endpoint: requiredString(logicalId, entry["Endpoint"], "Endpoint"),
+  };
+}
+
+function requiredString(
+  logicalId: string,
+  value: SimCfnTemplateValue | undefined,
+  name: string,
+): string {
+  if (typeof value !== "string") {
+    throw topicPropertyError(
+      logicalId,
+      `each entry of ${topicSubscriptionPropertyName} requires ${name} to be a ` +
+        `string`,
+    );
+  }
+
+  return value;
+}
+
+function topicPropertyError(logicalId: string, reason: string): Error {
+  return simCfnSnsResourceError(snsTopicResourceType, logicalId, reason);
+}

--- a/src/service/sns/cfn/topic/sim-cfn-sns-topic-creator.ts
+++ b/src/service/sns/cfn/topic/sim-cfn-sns-topic-creator.ts
@@ -1,0 +1,89 @@
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimSns } from "../../sim-sns.js";
+import type { SimSnsTopic } from "../../topic/sim-sns-topic.js";
+import { simCfnSnsResourceCreation } from "../sim-cfn-sns-resource-error.js";
+import { snsTopicResourceType } from "../sim-cfn-sns-resource-types.js";
+import type { SimCfnSnsInlineSubscription } from "./sim-cfn-sns-inline-subscriptions.js";
+import { SimCfnSnsTopicProperties } from "./sim-cfn-sns-topic-properties.js";
+
+interface SimCfnSnsTopicCreatorProperties {
+  readonly sns: SimSns;
+}
+
+/**
+ * Creates simulated topics from AWS::SNS::Topic Resources.
+ *
+ * The topic is created through the ordinary CreateTopic command rather than
+ * constructed directly, so a topic a template deployed is the same thing an SDK
+ * caller would have got: the same name validation, the same attributes, the
+ * same refusals for what this simulation does not model.
+ */
+export class SimCfnSnsTopicCreator {
+  private readonly sns: SimSns;
+
+  constructor(properties: SimCfnSnsTopicCreatorProperties) {
+    this.sns = properties.sns;
+  }
+
+  /**
+   * Create a topic from an AWS::SNS::Topic Resource.
+   */
+  async create(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): Promise<SimSnsTopic> {
+    const topicProperties = new SimCfnSnsTopicProperties({
+      resource,
+      properties,
+    });
+    const name = topicProperties.name();
+    const attributes = topicProperties.attributes();
+    const inline = topicProperties.inlineSubscriptions();
+
+    return simCfnSnsResourceCreation(
+      snsTopicResourceType,
+      resource.logicalId,
+      async () => {
+        await this.sns.createTopic({
+          input: { Name: name, Attributes: attributes },
+        });
+
+        const topic = this.sns.findTopic(name);
+        assertDefined(
+          topic,
+          `sim SNS topic ${name} after CloudFormation creation`,
+        );
+
+        await this.subscribeInline(topic, inline);
+
+        return topic;
+      },
+    );
+  }
+
+  /**
+   * Subscribe everything the topic's own `Subscription` list declares.
+   *
+   * They go through Subscribe one after another rather than together, so a
+   * later entry naming an endpoint its protocol cannot reach fails the Resource
+   * with the earlier ones already subscribed, which is what a template asking
+   * for two subscriptions and getting one has to look like.
+   */
+  private async subscribeInline(
+    topic: SimSnsTopic,
+    subscriptions: readonly SimCfnSnsInlineSubscription[],
+  ): Promise<void> {
+    for (const subscription of subscriptions) {
+      // eslint-disable-next-line no-await-in-loop -- one entry at a time, so a refused entry leaves the earlier ones subscribed
+      await this.sns.subscribe({
+        input: {
+          TopicArn: topic.arn.value,
+          Protocol: subscription.protocol,
+          Endpoint: subscription.endpoint,
+        },
+      });
+    }
+  }
+}

--- a/src/service/sns/cfn/topic/sim-cfn-sns-topic-name.iso.test.ts
+++ b/src/service/sns/cfn/topic/sim-cfn-sns-topic-name.iso.test.ts
@@ -1,0 +1,87 @@
+import {
+  assertFalse,
+  assertIdentical,
+  assertStringLength,
+  assertStringStartsWith,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimCfnSnsTopicName } from "./sim-cfn-sns-topic-name.js";
+
+describe("SimCfnSnsTopicName", () => {
+  it("names a topic after the stack and the logical ID", () => {
+    // Given a Resource in a stack.
+    const name = new SimCfnSnsTopicName({
+      stackName: "orders-stack",
+      logicalId: "OrdersTopic",
+    });
+
+    // When the generated name is read, then it carries both, as a real
+    // CloudFormation generated name does.
+    assertIdentical(name.value, "orders-stack-OrdersTopic");
+  });
+
+  it("falls back to the logical ID with no stack name", () => {
+    // Given a Resource created outside a stack, which has no stack name to
+    // derive a name from.
+    const noStack = new SimCfnSnsTopicName({
+      stackName: undefined,
+      logicalId: "OrdersTopic",
+    });
+    const emptyStackName = new SimCfnSnsTopicName({
+      stackName: "",
+      logicalId: "OrdersTopic",
+    });
+
+    // When the generated name is read, then it is the logical ID on its own
+    // rather than a name with an empty part in it.
+    assertIdentical(noStack.value, "OrdersTopic");
+    assertIdentical(emptyStackName.value, "OrdersTopic");
+  });
+
+  it("trims a generated name to the 256 characters SNS allows", () => {
+    // Given a stack name and logical ID that are too long together for a topic
+    // name, which real SNS refuses at 257 characters.
+    const name = new SimCfnSnsTopicName({
+      stackName: "a".repeat(200),
+      logicalId: "OrdersTopicWithARatherLongLogicalIdIndeed".repeat(2),
+    });
+
+    // When the generated name is read, then it is trimmed to fit, keeping the
+    // start, so the stack name is still in it.
+    assertStringLength(name.value, 256);
+    assertStringStartsWith(name.value, `${"a".repeat(200)}-OrdersTopic`);
+
+    // And the same template generates the same name again, rather than a new
+    // one each deployment.
+    assertIdentical(
+      name.value,
+      new SimCfnSnsTopicName({
+        stackName: "a".repeat(200),
+        logicalId: "OrdersTopicWithARatherLongLogicalIdIndeed".repeat(2),
+      }).value,
+    );
+  });
+
+  it("keeps two trimmed names apart where only the trimmed-off part differs", () => {
+    // Given two logical IDs that are the same up to the point a generated name
+    // is trimmed at. CDK puts its disambiguating hash at the end of a logical
+    // ID, which is the part trimming takes off.
+    const stackName = "a".repeat(200);
+    const sharedPrefix = "OrdersTopic".repeat(6);
+    const first = new SimCfnSnsTopicName({
+      stackName,
+      logicalId: `${sharedPrefix}E6CA6235`,
+    });
+    const second = new SimCfnSnsTopicName({
+      stackName,
+      logicalId: `${sharedPrefix}1B3D8A07`,
+    });
+
+    // When both names are read, then they are different names, so the two
+    // topics do not collide on one name.
+    assertStringLength(first.value, 256);
+    assertStringLength(second.value, 256);
+    assertFalse(first.value === second.value);
+  });
+});

--- a/src/service/sns/cfn/topic/sim-cfn-sns-topic-name.ts
+++ b/src/service/sns/cfn/topic/sim-cfn-sns-topic-name.ts
@@ -1,0 +1,35 @@
+import { SimCfnGeneratedResourceName } from "../../../cloudformation/resource/name/sim-cfn-generated-resource-name.js";
+
+const maximumNameLength = 256;
+
+interface SimCfnSnsTopicNameProperties {
+  readonly stackName: string | undefined;
+  readonly logicalId: string;
+}
+
+/**
+ * The name CloudFormation gives a topic whose template does not name it.
+ *
+ * A topic name is at most 256 characters, so a long stack name and logical ID
+ * together are trimmed to fit. How a generated name is put together and trimmed
+ * is the same for every service, and lives in
+ * {@link SimCfnGeneratedResourceName}.
+ */
+export class SimCfnSnsTopicName {
+  private readonly generated: SimCfnGeneratedResourceName;
+
+  constructor(properties: SimCfnSnsTopicNameProperties) {
+    this.generated = new SimCfnGeneratedResourceName({
+      stackName: properties.stackName,
+      logicalId: properties.logicalId,
+      maximumLength: maximumNameLength,
+    });
+  }
+
+  /**
+   * The generated topic name.
+   */
+  get value(): string {
+    return this.generated.value;
+  }
+}

--- a/src/service/sns/cfn/topic/sim-cfn-sns-topic-properties.ts
+++ b/src/service/sns/cfn/topic/sim-cfn-sns-topic-properties.ts
@@ -1,0 +1,140 @@
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type {
+  SimCfnTemplateValue,
+  SimCfnTemplateValueRecord,
+} from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimSnsTopicAttributeInput } from "../../topic/sim-sns-topic-attributes.js";
+import { simCfnSnsAttributeValue } from "../sim-cfn-sns-attribute-value.js";
+import { simCfnSnsResourceError } from "../sim-cfn-sns-resource-error.js";
+import { snsTopicResourceType } from "../sim-cfn-sns-resource-types.js";
+import {
+  simCfnSnsInlineSubscriptions,
+  type SimCfnSnsInlineSubscription,
+} from "./sim-cfn-sns-inline-subscriptions.js";
+import { SimCfnSnsTopicName } from "./sim-cfn-sns-topic-name.js";
+import {
+  attributePropertyNames,
+  topicNamePropertyName,
+  topicSubscriptionPropertyName,
+  unsimulatedPropertyReasons,
+} from "./sim-cfn-sns-topic-property-names.js";
+
+interface SimCfnSnsTopicPropertiesProperties {
+  readonly resource: SimCfnResource;
+  readonly properties: SimCfnTemplateValueRecord;
+}
+
+/**
+ * Reads AWS::SNS::Topic CloudFormation properties into the shape CreateTopic
+ * takes.
+ *
+ * Most of what a template can say about a topic is a topic attribute of the
+ * same name, so those are passed straight through and simulated SNS decides
+ * what it will take. A property that is not an attribute, and that this
+ * simulation gives no behaviour to, is refused here instead. Refusing rather
+ * than dropping is the point: a topic deployed without its data protection
+ * policy looks protected to the template that wrote it and redacts nothing.
+ */
+export class SimCfnSnsTopicProperties {
+  private readonly resource: SimCfnResource;
+  private readonly properties: ReadonlyMap<string, SimCfnTemplateValue>;
+
+  constructor(properties: SimCfnSnsTopicPropertiesProperties) {
+    this.resource = properties.resource;
+    this.properties = new Map(Object.entries(properties.properties));
+  }
+
+  /**
+   * The topic name.
+   *
+   * An unnamed topic is named after the stack and the logical ID, as real
+   * CloudFormation names one.
+   */
+  name(): string {
+    const name = this.properties.get(topicNamePropertyName);
+
+    if (name === undefined) {
+      return new SimCfnSnsTopicName({
+        stackName: this.resource.stackName,
+        logicalId: this.resource.logicalId,
+      }).value;
+    }
+
+    if (typeof name !== "string") {
+      throw this.propertyError(`${topicNamePropertyName} must be a string`);
+    }
+
+    return name;
+  }
+
+  /**
+   * The topic attributes the template sets, in the string form CreateTopic
+   * takes them in.
+   *
+   * The ones simulated SNS gives no behaviour to are passed on with the rest,
+   * because refusing them is SNS's own answer and it already carries the reason
+   * each one is missing. `FifoTopic` is the one that matters most: only
+   * standard topics are simulated, and a topic that appeared to accept the
+   * property would be a standard topic a test believed was ordered.
+   */
+  attributes(): SimSnsTopicAttributeInput {
+    return Object.fromEntries(
+      this.properties
+        .entries()
+        .filter(([name]) => this.isAttributeProperty(name))
+        .map(([name, value]) => [name, simCfnSnsAttributeValue(value)]),
+    );
+  }
+
+  /**
+   * The subscriptions the topic declares inside itself.
+   */
+  inlineSubscriptions(): readonly SimCfnSnsInlineSubscription[] {
+    return simCfnSnsInlineSubscriptions(
+      this.resource.logicalId,
+      this.properties.get(topicSubscriptionPropertyName),
+    );
+  }
+
+  /**
+   * Whether a property is handed to CreateTopic as an attribute.
+   *
+   * The two properties the CloudFormation layer reads itself are not. The rest
+   * are refused as they are reached: the ones with a reason of their own with
+   * that reason, and anything else as a property AWS::SNS::Topic does not have,
+   * which is how real CloudFormation answers one too.
+   */
+  private isAttributeProperty(name: string): boolean {
+    if (
+      name === topicNamePropertyName ||
+      name === topicSubscriptionPropertyName
+    ) {
+      return false;
+    }
+
+    if (attributePropertyNames.has(name)) {
+      return true;
+    }
+
+    const unsimulatedReason = unsimulatedPropertyReasons.get(name);
+
+    if (unsimulatedReason !== undefined) {
+      throw this.propertyError(
+        `${name} is a real ${snsTopicResourceType} property simulated SNS ` +
+          `does not act on: ${unsimulatedReason}`,
+      );
+    }
+
+    throw this.propertyError(
+      `${name} is not a property of ${snsTopicResourceType}`,
+    );
+  }
+
+  private propertyError(reason: string): Error {
+    return simCfnSnsResourceError(
+      snsTopicResourceType,
+      this.resource.logicalId,
+      reason,
+    );
+  }
+}

--- a/src/service/sns/cfn/topic/sim-cfn-sns-topic-property-names.ts
+++ b/src/service/sns/cfn/topic/sim-cfn-sns-topic-property-names.ts
@@ -1,0 +1,54 @@
+/**
+ * The name the template gives the topic.
+ */
+export const topicNamePropertyName = "TopicName";
+
+/**
+ * The subscriptions declared inside the topic rather than as Resources of their
+ * own.
+ */
+export const topicSubscriptionPropertyName = "Subscription";
+
+/**
+ * The AWS::SNS::Topic properties carrying a topic attribute of the same name.
+ *
+ * CloudFormation names these exactly as the SNS API names the attributes, so
+ * they are handed to CreateTopic rather than read here. Simulated SNS takes
+ * `DisplayName` and refuses the rest by name with the reason each one is
+ * missing, which is the same refusal an SDK caller setting the attribute gets.
+ * Keeping that decision in one place is what stops a template quietly accepting
+ * something the SDK path would not.
+ */
+export const attributePropertyNames: ReadonlySet<string> = new Set([
+  "ArchivePolicy",
+  "ContentBasedDeduplication",
+  "DisplayName",
+  "FifoThroughputScope",
+  "FifoTopic",
+  "KmsMasterKeyId",
+  "SignatureVersion",
+  "TracingConfig",
+]);
+
+/**
+ * The real AWS::SNS::Topic properties this simulation has no behaviour for and
+ * no single topic attribute to hand them to.
+ *
+ * The rest of the unsimulated properties are attributes of the same name, so
+ * SNS refuses those itself. These three are not: two are inputs of their own on
+ * a CreateTopic request, and `DeliveryStatusLogging` is a list that would
+ * become fifteen separate attributes.
+ */
+export const unsimulatedPropertyReasons: ReadonlyMap<string, string> = new Map([
+  [
+    "DataProtectionPolicy",
+    "data protection policies are not simulated, so a topic deployed with one " +
+      "would redact nothing while a test believed it was protecting the " +
+      "messages going through the topic",
+  ],
+  [
+    "DeliveryStatusLogging",
+    "delivery status logging writes to CloudWatch Logs, which is not simulated",
+  ],
+  ["Tags", "no simulated service reads a topic tag"],
+]);

--- a/src/service/sns/sim-sns.ts
+++ b/src/service/sns/sim-sns.ts
@@ -15,6 +15,7 @@ import { SimSnsNoDeliveryEndpoints } from "./delivery/sim-sns-no-delivery-endpoi
 import type * as simSnsCommands from "./command/sim-sns-command.types.js";
 import { SimSnsCommands } from "./command/sim-sns-commands.js";
 import type { SimSnsRequestOptions } from "./command/sim-sns-request-options.js";
+import { SimSnsCfnResourceFactory } from "./cfn/sim-sns-cfn-resource-factory.js";
 import { SimSnsSdkCommandRouter } from "./sdk/sim-sns-sdk-command-router.js";
 import type { SimSnsSubscription } from "./subscription/sim-sns-subscription.js";
 import { SimSnsSubscriptionStore } from "./subscription/sim-sns-subscription-store.js";
@@ -50,6 +51,7 @@ export class SimSns {
   private readonly commands: SimSnsCommands;
   private readonly background: BackgroundScheduler;
   private readonly sdkRouter = new SimSnsSdkCommandRouter(this);
+  private readonly cfnFactory = new SimSnsCfnResourceFactory({ sns: this });
 
   constructor(properties: SimSnsProperties = {}) {
     const {
@@ -109,6 +111,16 @@ export class SimSns {
    */
   topicSubscriptions(topicName: string): readonly SimSnsSubscription[] {
     return this.subscriptions.forTopic(topicName);
+  }
+
+  /**
+   * Find a subscription by ARN.
+   *
+   * This is the simulator's own accessor, for a test or a CloudFormation
+   * Resource holding the ARN a Subscribe answered with.
+   */
+  findSubscription(arn: string): SimSnsSubscription | undefined {
+    return this.subscriptions.find(arn);
   }
 
   /**
@@ -264,6 +276,13 @@ export class SimSns {
   ): Promise<simSnsCommands.SimPublishBatchCommandOutput> {
     await this.background.sequence();
     return this.commands.publish.publishBatch(command, options);
+  }
+
+  /**
+   * Get this service's CloudFormation Resource factory.
+   */
+  cfnResourceFactory(): SimSnsCfnResourceFactory {
+    return this.cfnFactory;
   }
 
   /**


### PR DESCRIPTION
Adds the AWS::SNS::Topic, AWS::SNS::Subscription and AWS::SNS::TopicPolicy Resource types to simulated CloudFormation, each going through the ordinary SNS commands so a topic a template created is the same thing an SDK caller would have got. Ref on a topic gives its ARN and Fn::GetAtt gives TopicArn and TopicName, Ref on a subscription gives the subscription ARN, and a topic the template does not name gets a predictable name from the stack name and logical ID. The inline Subscription property on a topic works alongside the separate Resource type, and a subscription carries RawMessageDelivery, FilterPolicy and FilterPolicyScope through to the validation the SDK path applies. A property with no simulated behaviour fails the Resource as an invalid one rather than an unsupported one, so it is not skipped.

Resolves https://github.com/KensioSoftware/yulin/issues/472

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CloudFormation support for SNS topics, subscriptions, and topic policies.
  * Added support for inline topic subscriptions, policy enforcement, intrinsic references, generated topic names, and SNS/SQS message delivery.
  * Added clear validation errors for unsupported or invalid properties.
* **Documentation**
  * Expanded SNS CloudFormation guidance and updated S3 notification documentation to reflect successful SNS-backed deployments.
  * Updated skipped-resource examples to use unsupported EventBridge rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->