### PR TITLE
feat: deploy a CDK docs site stack into the simulator

### DIFF
--- a/docs/services/cloudformation/README.md
+++ b/docs/services/cloudformation/README.md
@@ -1291,9 +1291,37 @@ try {
 }
 ```
 
-A CDK BucketDeployment can copy files from synthesized asset output into the simulated Bucket. When
-the Bucket is configured for website hosting, those files can be served through Yulin's local
-server.
+The files in the staged asset directory become Objects in the destination Bucket, keyed by their path
+relative to the asset root. When the Bucket is configured for website hosting, or sits behind a
+CloudFront Distribution, those Objects are what gets served.
+
+This is the `aws s3 sync` the real provider function shells out to, so the properties CDK synthesizes
+around it are read the same way:
+
+- `DestinationBucketKeyPrefix` puts the Objects under a key prefix.
+- `Exclude` and `Include` choose which files are copied. Every `Exclude` pattern is applied first and
+  then every `Include` one, and the last pattern to match a path decides, which is what makes
+  `exclude: ["*"], include: ["*.txt"]` mean "only the text files". A file no pattern matches is
+  copied. `*` matches across `/`, so `data/*` covers everything under a `data` directory.
+- `SystemMetadata` sets content headers on every Object the deployment copies, such as
+  `content-encoding` or `cache-control`. Without it, the content type is guessed from the file
+  extension. See [Object system metadata](../s3/README.md#object-system-metadata) for what comes back
+  on a read.
+- `Prune` removes the Objects the deployment covers and its source no longer holds. It is on unless
+  the deployment turns it off, as the construct is. Pruning only considers what the filters and the
+  key prefix select, so a deployment does not delete Objects it would never have copied.
+
+Several deployments can share one Bucket, which is the usual arrangement when the headers differ by
+file type: a `BucketDeployment` sets them for all of its files at once, so a second deployment is how
+the rest of the site gets different ones. Give the second one `prune: false`, or filters that do not
+overlap the first, the same as you would in AWS.
+
+A deployment with more than one entry in `SourceObjectKeys` copies each source in turn, and a path
+two of them share ends up with the later one's content.
+
+Filter patterns take `*` and `?`. The CLI also takes character classes such as `[abc]`, and a pattern
+using one is refused by name rather than matched as written, since a pattern that quietly means
+something else would copy the wrong files.
 
 ## S3 Bucket notifications
 
@@ -1927,7 +1955,8 @@ The resource types it creates are:
   `AWS::ApiGatewayV2::Stage`
 - `AWS::CertificateManager::Certificate`
 - `AWS::CloudFormation::WaitConditionHandle`
-- `AWS::CloudFront::Distribution` and `AWS::CloudFront::Function`
+- `AWS::CloudFront::Distribution`, `AWS::CloudFront::Function` and
+  `AWS::CloudFront::ResponseHeadersPolicy`
 - `AWS::Cognito::UserPool`, `AWS::Cognito::UserPoolClient` and
   `AWS::Cognito::UserPoolGroup`
 - `AWS::DynamoDB::Table` and `AWS::DynamoDB::GlobalTable`

--- a/docs/services/cloudfront/README.md
+++ b/docs/services/cloudfront/README.md
@@ -779,6 +779,112 @@ export function handler(event) {
 }
 ```
 
+## Response headers policies
+
+A response headers policy sets headers on everything a cache Behavior serves. Declare one as
+`AWS::CloudFront::ResponseHeadersPolicy` and point a Behavior's `ResponseHeadersPolicyId` at it with
+a `Ref`, which is what CDK's `ResponseHeadersPolicy` construct synthesizes.
+
+```typescript sim-cloudfront-response-headers-policy
+/**
+ * Setting response headers on what a cache Behavior serves.
+ */
+
+import { PutObjectCommand } from "@aws-sdk/client-s3";
+import { SimAws } from "@kensio/yulin";
+import { serveSimAws } from "@kensio/yulin/serve";
+
+const simAws = new SimAws();
+const srv = await serveSimAws({ simAws });
+
+try {
+  const stack = await simAws.cloudFormation().deployTemplate({
+    stackName: "site-stack",
+    template: {
+      Resources: {
+        SiteBucket: {
+          Type: "AWS::S3::Bucket",
+          Properties: { BucketName: "site-bucket" },
+        },
+        CacheHeaders: {
+          Type: "AWS::CloudFront::ResponseHeadersPolicy",
+          Properties: {
+            ResponseHeadersPolicyConfig: {
+              Name: "CacheHeaders",
+              CustomHeadersConfig: {
+                Items: [
+                  {
+                    Header: "Cache-Control",
+                    Override: true,
+                    Value: "public, max-age=0, must-revalidate",
+                  },
+                ],
+              },
+            },
+          },
+        },
+        SiteDistribution: {
+          Type: "AWS::CloudFront::Distribution",
+          DependsOn: ["SiteBucket", "CacheHeaders"],
+          Properties: {
+            DistributionConfig: {
+              DefaultRootObject: "index.html",
+              Origins: [
+                {
+                  Id: "SiteOrigin",
+                  DomainName: "site-bucket.s3.amazonaws.com",
+                  S3OriginConfig: {},
+                },
+              ],
+              DefaultCacheBehavior: {
+                TargetOriginId: "SiteOrigin",
+                ViewerProtocolPolicy: "allow-all",
+                ResponseHeadersPolicyId: { Ref: "CacheHeaders" },
+              },
+            },
+          },
+        },
+      },
+      Outputs: {
+        DistributionDomainName: {
+          Value: { "Fn::GetAtt": ["SiteDistribution", "DomainName"] },
+        },
+      },
+    },
+  });
+
+  await stack.waitForDeployComplete();
+
+  await simAws.s3().putObject(
+    new PutObjectCommand({
+      Bucket: "site-bucket",
+      Key: "index.html",
+      ContentType: "text/html",
+      Body: "<h1>Home</h1>",
+    }),
+  );
+
+  const domainName = stack.outputs.get("DistributionDomainName")
+    ?.value as string;
+  const response = await fetch(srv.localUrl(`http://${domainName}/`));
+
+  console.log(response.headers.get("cache-control"));
+} finally {
+  await srv.close();
+}
+```
+
+Each header in `CustomHeadersConfig` carries an `Override` boolean. With it set, the policy's value
+replaces one the Origin sent. Without it, the Origin's value is kept and the policy's is dropped. A
+header the Origin did not send is added either way.
+
+`RemoveHeadersConfig` takes headers away, and is applied before the added ones, so a header named in
+both sections ends up present with the policy's value.
+
+The policy is applied after a custom error response is fetched and before a `viewer-response`
+CloudFront Function runs, as CloudFront does. An error page carries the policy's headers, and a
+function sees them in `event.response.headers` and can change them.
+
 ## Available functionality
 
 Sim CloudFront currently supports:
@@ -792,6 +898,7 @@ Sim CloudFront currently supports:
 - Default cache Behavior and path-based cache Behaviors
 - `DefaultRootObject` and `CustomErrorResponses`, for static sites and single-page apps
 - `viewer-request` and `viewer-response` CloudFront Functions
+- `AWS::CloudFront::ResponseHeadersPolicy`, for headers a cache Behavior sets on every response
 - Viewer certificates from sim ACM, including CloudFront's `us-east-1` requirement
 - Serving simulated CloudFront traffic on localhost with `serveSimAws`
 
@@ -814,3 +921,14 @@ Where sim CloudFront knowingly behaves differently from AWS:
 - **`DeleteFunctionCommand` never answers `FunctionInUse`.** Nothing tells a CloudFront Function that
   a cache Behavior has taken it up, so every Function is deletable. A Behavior left pointing at a
   deleted Function runs no Function code.
+- **A response headers policy sets custom headers and removes named ones, and nothing else.** The
+  `CorsConfig`, `SecurityHeadersConfig` and `ServerTimingHeadersConfig` sections each set headers of
+  their own, and none of them is modelled. A policy declaring one fails the stack by naming the
+  section, rather than deploying and then serving responses missing the headers it promised.
+- **There is no command surface for a response headers policy.** `CreateResponseHeadersPolicy` and
+  its siblings are not simulated, so `AWS::CloudFront::ResponseHeadersPolicy` is the only way to make
+  one.
+- **A managed policy ID is not found.** CloudFront's managed policies belong to AWS rather than to a
+  template, so nothing here creates them. A Behavior naming one is refused with
+  `NoSuchResponseHeadersPolicy` when a request reaches it, rather than serving a response without the
+  headers the policy would have set.

--- a/docs/services/cloudfront/README.md
+++ b/docs/services/cloudfront/README.md
@@ -925,6 +925,9 @@ Where sim CloudFront knowingly behaves differently from AWS:
   `CorsConfig`, `SecurityHeadersConfig` and `ServerTimingHeadersConfig` sections each set headers of
   their own, and none of them is modelled. A policy declaring one fails the stack by naming the
   section, rather than deploying and then serving responses missing the headers it promised.
+- **A response headers policy name is unique, but nothing else about it is checked.** A second
+  policy claiming a name is refused with `ResponseHeadersPolicyAlreadyExists`, as CloudFront refuses
+  one. The header names and values themselves are stored as written.
 - **There is no command surface for a response headers policy.** `CreateResponseHeadersPolicy` and
   its siblings are not simulated, so `AWS::CloudFront::ResponseHeadersPolicy` is the only way to make
   one.

--- a/docs/services/cloudfront/sim-cloudfront-response-headers-policy.example.ts
+++ b/docs/services/cloudfront/sim-cloudfront-response-headers-policy.example.ts
@@ -1,0 +1,86 @@
+/**
+ * Setting response headers on what a cache Behavior serves.
+ */
+
+import { PutObjectCommand } from "@aws-sdk/client-s3";
+import { SimAws } from "@kensio/yulin";
+import { serveSimAws } from "@kensio/yulin/serve";
+
+const simAws = new SimAws();
+const srv = await serveSimAws({ simAws });
+
+try {
+  const stack = await simAws.cloudFormation().deployTemplate({
+    stackName: "site-stack",
+    template: {
+      Resources: {
+        SiteBucket: {
+          Type: "AWS::S3::Bucket",
+          Properties: { BucketName: "site-bucket" },
+        },
+        CacheHeaders: {
+          Type: "AWS::CloudFront::ResponseHeadersPolicy",
+          Properties: {
+            ResponseHeadersPolicyConfig: {
+              Name: "CacheHeaders",
+              CustomHeadersConfig: {
+                Items: [
+                  {
+                    Header: "Cache-Control",
+                    Override: true,
+                    Value: "public, max-age=0, must-revalidate",
+                  },
+                ],
+              },
+            },
+          },
+        },
+        SiteDistribution: {
+          Type: "AWS::CloudFront::Distribution",
+          DependsOn: ["SiteBucket", "CacheHeaders"],
+          Properties: {
+            DistributionConfig: {
+              DefaultRootObject: "index.html",
+              Origins: [
+                {
+                  Id: "SiteOrigin",
+                  DomainName: "site-bucket.s3.amazonaws.com",
+                  S3OriginConfig: {},
+                },
+              ],
+              DefaultCacheBehavior: {
+                TargetOriginId: "SiteOrigin",
+                ViewerProtocolPolicy: "allow-all",
+                ResponseHeadersPolicyId: { Ref: "CacheHeaders" },
+              },
+            },
+          },
+        },
+      },
+      Outputs: {
+        DistributionDomainName: {
+          Value: { "Fn::GetAtt": ["SiteDistribution", "DomainName"] },
+        },
+      },
+    },
+  });
+
+  await stack.waitForDeployComplete();
+
+  await simAws.s3().putObject(
+    new PutObjectCommand({
+      Bucket: "site-bucket",
+      Key: "index.html",
+      ContentType: "text/html",
+      Body: "<h1>Home</h1>",
+    }),
+  );
+
+  const domainName = stack.outputs.get("DistributionDomainName")
+    ?.value as string;
+  const response = await fetch(srv.localUrl(`http://${domainName}/`));
+
+  console.log(response.headers.get("cache-control"));
+} finally {
+  await srv.close();
+}

--- a/docs/services/route53/README.md
+++ b/docs/services/route53/README.md
@@ -136,7 +136,7 @@ The first record to name the zone names it, and a record above that name widens 
 
 Register the zone yourself when a test depends on its name, such as one listing zones by name, or
 when its name is not a suffix of any record the stack holds. A registered zone keeps the name it was
-given rather than inferring one, and a record outside it is refused.
+given rather than inferring one, so its records are stored under the name you chose.
 
 ## Creating records
 
@@ -1128,9 +1128,11 @@ This lets local integration tests use the same CDK infrastructure shape as produ
 the test process local.
 
 A CDK app whose Hosted Zone comes from `HostedZone.fromLookup` names a real Hosted Zone ID
-throughout its template rather than creating the zone. Register that zone before deploying, as in
-[Registering a Hosted Zone with a chosen ID](#registering-a-hosted-zone-with-a-chosen-id), and the
-template's RecordSets find it.
+throughout its template rather than creating the zone. The template deploys as it is: the zone is
+registered under that ID as the first RecordSet naming it is created, with its name inferred from the
+record names. Register it yourself with
+[Registering a Hosted Zone with a chosen ID](#registering-a-hosted-zone-with-a-chosen-id) when a test
+depends on the zone's name, or when no record in the stack sits inside it.
 
 ## Accounts and Regions
 

--- a/docs/services/route53/README.md
+++ b/docs/services/route53/README.md
@@ -123,6 +123,21 @@ already existing rather than created.
 `/hostedzone/Z...` form of the ID. An ID that another Hosted Zone already holds is refused with
 `HostedZoneAlreadyExists`, and one that is not a Route53 Hosted Zone ID with `InvalidInput`.
 
+### A zone a template names but does not create
+
+Registering the zone first is optional. An `AWS::Route53::RecordSet` naming a `HostedZoneId` that no
+Hosted Zone holds gets one registered under that ID as the record is created, so a template built
+with `HostedZone.fromLookup` deploys without being told separately about a zone it already describes.
+
+The template does not carry the zone's name, only its ID, so the name is inferred from the records.
+The first record to name the zone names it, and a record above that name widens it. A stack holding
+`example.test` and `www.example.test` ends up with a zone called `example.test`. A stack holding only
+`www.example.test` ends up with a zone called `www.example.test`.
+
+Register the zone yourself when a test depends on its name, such as one listing zones by name, or
+when its name is not a suffix of any record the stack holds. A registered zone keeps the name it was
+given rather than inferring one, and a record outside it is refused.
+
 ## Creating records
 
 Use `ChangeResourceRecordSetsCommand` to add records to a Hosted Zone.
@@ -1223,3 +1238,16 @@ Sim Route53 currently supports:
 The simulator focuses on useful behaviour for tests and local development rather than full Route53
 feature parity. Unsupported Route53 options may be ignored or may throw errors depending on whether
 the simulator needs them to model the requested behaviour.
+
+## Limitations
+
+Where sim Route53 knowingly behaves differently from AWS:
+
+- **A RecordSet naming a Hosted Zone that does not exist creates one.** CloudFormation would refuse
+  with `NoSuchHostedZone`, because the ID names a zone in an account the simulation is not. Every
+  template built with `HostedZone.fromLookup` would then be undeployable here, so the zone is
+  registered on demand instead. See
+  [A zone a template names but does not create](#a-zone-a-template-names-but-does-not-create).
+- **The name of such a zone is a guess.** Nothing in a synthesized template says what a looked-up
+  zone is called, so the name is inferred from the records that reference it and is only as specific
+  as they are. Register the zone yourself when a test depends on its name.

--- a/docs/services/s3/README.md
+++ b/docs/services/s3/README.md
@@ -1791,8 +1791,9 @@ Every path that serves an Object goes through the same mapping, so the REST endp
 for it. `content-encoding` is the one that matters most: bytes served without it are bytes no client
 can decode, so an Object stored as brotli is only usable if the header comes back with it.
 
-`PutObjectCommand` carries `ContentType` and nothing else, so the way to set the rest today is a CDK
-BucketDeployment's `SystemMetadata`, which applies them to every Object it copies. See
+Sim S3 stores only `ContentType` and your own `Metadata` from a `PutObjectCommand`. The AWS SDK
+carries the rest, and real S3 keeps them, but the simulator drops them, so the way to set them today
+is a CDK BucketDeployment's `SystemMetadata`, which applies them to every Object it copies. See
 [CDK S3 BucketDeployment](../cloudformation/README.md#cdk-s3-bucketdeployment).
 
 ## Standalone SimS3
@@ -1872,6 +1873,7 @@ These apply across the page. The sections above each list what is specific to th
   not simulated.
 - A Bucket using filesystem-backed storage cannot delete Objects, and raises no event
   notifications, because it swaps the whole storage backend rather than putting Objects.
-- `PutObjectCommand` stores `ContentType` and user-defined `Metadata`, and no other system metadata.
-  An Object needing `content-encoding` or `cache-control` gets it from a CDK BucketDeployment's
-  `SystemMetadata`. See [Object system metadata](#object-system-metadata).
+- Sim S3 stores only `ContentType` and user-defined `Metadata` from a `PutObjectCommand`, and drops
+  the other system metadata the SDK carries and real S3 keeps. An Object needing `content-encoding`
+  or `cache-control` gets it from a CDK BucketDeployment's `SystemMetadata`. See
+  [Object system metadata](#object-system-metadata).

--- a/docs/services/s3/README.md
+++ b/docs/services/s3/README.md
@@ -1779,6 +1779,22 @@ simAws.s3().mountBucketFilesystem("site", path.join(process.cwd(), "public"), {
 These are added to the list rather than replacing it, so naming one cannot cost you `.html`, and a
 leading dot is optional. Everything not named is still refused.
 
+## Object system metadata
+
+S3 keeps a handful of headers about an Object when it is written and hands them back on every read.
+Sim S3 stores and returns `cache-control`, `content-disposition`, `content-encoding`,
+`content-language`, `content-type` and `expires`, alongside a `content-length` describing the body
+being served.
+
+Every path that serves an Object goes through the same mapping, so the REST endpoint, the
+[website endpoint](#static-website-hosting) and a CloudFront S3 Origin all report the same headers
+for it. `content-encoding` is the one that matters most: bytes served without it are bytes no client
+can decode, so an Object stored as brotli is only usable if the header comes back with it.
+
+`PutObjectCommand` carries `ContentType` and nothing else, so the way to set the rest today is a CDK
+BucketDeployment's `SystemMetadata`, which applies them to every Object it copies. See
+[CDK S3 BucketDeployment](../cloudformation/README.md#cdk-s3-bucketdeployment).
+
 ## Standalone SimS3
 
 If you only need S3 alone, you can instantiate `SimS3` directly.
@@ -1830,6 +1846,7 @@ Sim S3 currently supports:
 - Serving static website requests on localhost with `serveSimAws`
 - Serving Object `GET`, `HEAD`, `PUT` and `DELETE` over the S3 REST endpoint, authorized by sim IAM
 - Presigned URLs built by the real `@aws-sdk/s3-request-presigner`, with expiry in simulated time
+- Object system metadata returned on a read, over every endpoint that serves an Object
 - Bucket website index documents, error documents, trailing-slash redirects, redirect-all
   configuration, and routing-rule redirects
 - Bucket-global uniqueness within a `SimAws` instance across simulated Accounts and Regions
@@ -1855,3 +1872,6 @@ These apply across the page. The sections above each list what is specific to th
   not simulated.
 - A Bucket using filesystem-backed storage cannot delete Objects, and raises no event
   notifications, because it swaps the whole storage backend rather than putting Objects.
+- `PutObjectCommand` stores `ContentType` and user-defined `Metadata`, and no other system metadata.
+  An Object needing `content-encoding` or `cache-control` gets it from a CDK BucketDeployment's
+  `SystemMetadata`. See [Object system metadata](#object-system-metadata).

--- a/src/service/cloudformation/cdk/s3/bucket-deployment/copy/sim-cdk-bucket-deploy-copier.iso.test.ts
+++ b/src/service/cloudformation/cdk/s3/bucket-deployment/copy/sim-cdk-bucket-deploy-copier.iso.test.ts
@@ -1,0 +1,321 @@
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimCfnResource } from "../../../../resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../../template/value/sim-cfn-template-value.js";
+import { SimS3Bucket } from "../../../../../s3/bucket/sim-s3-bucket.js";
+import {
+  SimS3Object,
+  SimS3ObjectMetadata,
+} from "../../../../../s3/object/s3-object.js";
+import { TemporaryDirectory } from "../../../../../../util/filesystem/temporary-directory.js";
+import { SimCdkBucketDeployProperties } from "../property/sim-cdk-bucket-deploy-properties.js";
+import { SimCdkBucketDeployCopier } from "./sim-cdk-bucket-deploy-copier.js";
+
+describe("SimCdkBucketDeployCopier", () => {
+  const resource = new SimCfnResource({ logicalId: "DeploySite" });
+
+  function properties(
+    values: SimCfnTemplateValueRecord = {},
+  ): SimCdkBucketDeployProperties {
+    return new SimCdkBucketDeployProperties(resource, {
+      DestinationBucketName: "site-bucket",
+      SourceObjectKeys: ["abc123.zip"],
+      ...values,
+    });
+  }
+
+  /**
+   * A staged asset directory holding the files a deployment would copy.
+   */
+  async function sourceDirectory(
+    files: Record<string, string>,
+  ): Promise<string> {
+    const temporaryDirectory = new TemporaryDirectory();
+
+    await Promise.all(
+      Object.entries(files).map(async ([relativePath, content]) => {
+        await temporaryDirectory.writeFile(relativePath.split("/"), content);
+      }),
+    );
+
+    return await temporaryDirectory.resolvePath();
+  }
+
+  async function objectKeys(bucket: SimS3Bucket): Promise<string[]> {
+    const objects = await bucket.listObjects();
+
+    return objects
+      .map((object) => object.key)
+      .toSorted((a, b) => a.localeCompare(b));
+  }
+
+  it("copies the source files in as Objects", async () => {
+    // Given a staged asset directory with a nested file.
+    const bucket = new SimS3Bucket({ bucketName: "site-bucket" });
+    const sourcePath = await sourceDirectory({
+      "index.html": "<h1>Hello</h1>",
+      "data/standard.keys": "keys",
+    });
+
+    // When the deployment is copied in.
+    await new SimCdkBucketDeployCopier({
+      bucket,
+      properties: properties(),
+    }).copy([sourcePath]);
+
+    // Then each file is an Object under its path relative to the asset root.
+    const keys = await objectKeys(bucket);
+
+    assertIdentical(keys.join(","), "data/standard.keys,index.html");
+
+    const object = await bucket.getObject("index.html");
+
+    assertNonNullable(object);
+    assertIdentical(object.body.toString("utf8"), "<h1>Hello</h1>");
+  });
+
+  it("copies several sources into one Bucket", async () => {
+    // Given two staged asset directories.
+    const bucket = new SimS3Bucket({ bucketName: "site-bucket" });
+    const firstPath = await sourceDirectory({ "index.html": "one" });
+    const secondPath = await sourceDirectory({ "about.html": "two" });
+
+    // When a deployment with both sources is copied in.
+    await new SimCdkBucketDeployCopier({
+      bucket,
+      properties: properties({
+        SourceObjectKeys: ["abc123.zip", "def456.zip"],
+      }),
+    }).copy([firstPath, secondPath]);
+
+    // Then the Bucket holds both, rather than only the last one.
+    const keys = await objectKeys(bucket);
+
+    assertIdentical(keys.join(","), "about.html,index.html");
+  });
+
+  it("copies files under the destination key prefix", async () => {
+    // Given a deployment into a key prefix.
+    const bucket = new SimS3Bucket({ bucketName: "site-bucket" });
+    const sourcePath = await sourceDirectory({ "app.css": "body{}" });
+
+    // When it is copied in.
+    await new SimCdkBucketDeployCopier({
+      bucket,
+      properties: properties({ DestinationBucketKeyPrefix: "assets" }),
+    }).copy([sourcePath]);
+
+    // Then the Objects sit under the prefix.
+    const keys = await objectKeys(bucket);
+
+    assertIdentical(keys.join(","), "assets/app.css");
+  });
+
+  it("copies only the files the filters select", async () => {
+    // Given a deployment saying "only the text files".
+    const bucket = new SimS3Bucket({ bucketName: "site-bucket" });
+    const sourcePath = await sourceDirectory({
+      "notes.txt": "text",
+      "index.html": "markup",
+    });
+
+    // When it is copied in.
+    await new SimCdkBucketDeployCopier({
+      bucket,
+      properties: properties({ Exclude: ["*"], Include: ["*.txt"] }),
+    }).copy([sourcePath]);
+
+    // Then the file no include pattern rescued is left behind.
+    const keys = await objectKeys(bucket);
+
+    assertIdentical(keys.join(","), "notes.txt");
+  });
+
+  it("stores the deployment's system metadata over the guessed content type", async () => {
+    // Given a deployment setting content headers on everything it copies.
+    const bucket = new SimS3Bucket({ bucketName: "site-bucket" });
+    const sourcePath = await sourceDirectory({ "standard.keys": "keys" });
+
+    // When it is copied in.
+    await new SimCdkBucketDeployCopier({
+      bucket,
+      properties: properties({
+        SystemMetadata: {
+          "content-type": "text/plain",
+          "content-encoding": "br",
+          "cache-control": "public, max-age=60",
+        },
+      }),
+    }).copy([sourcePath]);
+
+    // Then the Object carries what the construct was told to set, in place of
+    // the type the file extension would have suggested.
+    const object = await bucket.getObject("standard.keys");
+
+    assertNonNullable(object);
+    assertIdentical(object.metadata.values["content-type"], "text/plain");
+    assertIdentical(object.metadata.values["content-encoding"], "br");
+    assertIdentical(
+      object.metadata.values["cache-control"],
+      "public, max-age=60",
+    );
+  });
+
+  it("guesses a content type from the file extension without system metadata", async () => {
+    // Given a deployment that sets no headers of its own.
+    const bucket = new SimS3Bucket({ bucketName: "site-bucket" });
+    const sourcePath = await sourceDirectory({ "index.html": "<h1>Hi</h1>" });
+
+    // When it is copied in.
+    await new SimCdkBucketDeployCopier({
+      bucket,
+      properties: properties(),
+    }).copy([sourcePath]);
+
+    // Then the type comes from the extension, as the CLI guesses one.
+    const object = await bucket.getObject("index.html");
+
+    assertNonNullable(object);
+    assertIdentical(object.metadata.values["content-type"], "text/html");
+  });
+
+  it("prunes the Objects its source no longer holds", async () => {
+    // Given a Bucket holding an Object from an earlier deployment.
+    const bucket = new SimS3Bucket({ bucketName: "site-bucket" });
+
+    await bucket.putObject(
+      new SimS3Object({
+        key: "gone.html",
+        body: Buffer.from("old"),
+        metadata: new SimS3ObjectMetadata(),
+      }),
+    );
+
+    const sourcePath = await sourceDirectory({ "index.html": "new" });
+
+    // When a pruning deployment is copied in.
+    await new SimCdkBucketDeployCopier({
+      bucket,
+      properties: properties(),
+    }).copy([sourcePath]);
+
+    // Then what the source no longer holds is removed.
+    const keys = await objectKeys(bucket);
+
+    assertIdentical(keys.join(","), "index.html");
+  });
+
+  it("leaves everything alone when pruning is turned off", async () => {
+    // Given a Bucket another deployment has already written to.
+    const bucket = new SimS3Bucket({ bucketName: "site-bucket" });
+
+    await bucket.putObject(
+      new SimS3Object({
+        key: "other.html",
+        body: Buffer.from("other"),
+        metadata: new SimS3ObjectMetadata(),
+      }),
+    );
+
+    const sourcePath = await sourceDirectory({ "index.html": "new" });
+
+    // When a second deployment into the same Bucket is copied in with pruning
+    // turned off, which is what lets two of them share a Bucket.
+    await new SimCdkBucketDeployCopier({
+      bucket,
+      properties: properties({ Prune: false }),
+    }).copy([sourcePath]);
+
+    // Then both deployments' Objects are there.
+    const keys = await objectKeys(bucket);
+
+    assertIdentical(keys.join(","), "index.html,other.html");
+  });
+
+  it("prunes only inside its own destination prefix", async () => {
+    // Given a Bucket holding an Object outside this deployment's prefix.
+    const bucket = new SimS3Bucket({ bucketName: "site-bucket" });
+
+    await bucket.putObject(
+      new SimS3Object({
+        key: "index.html",
+        body: Buffer.from("root"),
+        metadata: new SimS3ObjectMetadata(),
+      }),
+    );
+
+    const sourcePath = await sourceDirectory({ "app.css": "body{}" });
+
+    // When a pruning deployment into a prefix is copied in.
+    await new SimCdkBucketDeployCopier({
+      bucket,
+      properties: properties({ DestinationBucketKeyPrefix: "assets" }),
+    }).copy([sourcePath]);
+
+    // Then the Object outside the prefix survives, because a sync only deletes
+    // what it would have copied.
+    const keys = await objectKeys(bucket);
+
+    assertIdentical(keys.join(","), "assets/app.css,index.html");
+  });
+
+  it("prunes only what its filters would have copied", async () => {
+    // Given a Bucket holding an Object a second deployment put in a directory
+    // this one excludes.
+    const bucket = new SimS3Bucket({ bucketName: "site-bucket" });
+
+    await bucket.putObject(
+      new SimS3Object({
+        key: "data/standard.keys",
+        body: Buffer.from("keys"),
+        metadata: new SimS3ObjectMetadata(),
+      }),
+    );
+
+    const sourcePath = await sourceDirectory({ "index.html": "markup" });
+
+    // When a pruning deployment excluding that directory is copied in.
+    await new SimCdkBucketDeployCopier({
+      bucket,
+      properties: properties({ Exclude: ["data/*"] }),
+    }).copy([sourcePath]);
+
+    // Then the excluded Object is left alone, on the destination side as well
+    // as the source side.
+    const keys = await objectKeys(bucket);
+
+    assertIdentical(keys.join(","), "data/standard.keys,index.html");
+  });
+
+  it("removes an Object a later deployment of the same source drops", async () => {
+    // Given a Bucket a deployment has already filled.
+    const bucket = new SimS3Bucket({ bucketName: "site-bucket" });
+    const firstPath = await sourceDirectory({
+      "index.html": "one",
+      "old.html": "two",
+    });
+
+    await new SimCdkBucketDeployCopier({
+      bucket,
+      properties: properties(),
+    }).copy([firstPath]);
+
+    // When the same deployment runs again from a source missing one file.
+    const secondPath = await sourceDirectory({ "index.html": "one" });
+
+    await new SimCdkBucketDeployCopier({
+      bucket,
+      properties: properties(),
+    }).copy([secondPath]);
+
+    // Then the dropped file is gone from the Bucket.
+    assertUndefined(await bucket.getObject("old.html"));
+    const keys = await objectKeys(bucket);
+
+    assertIdentical(keys.join(","), "index.html");
+  });
+});

--- a/src/service/cloudformation/cdk/s3/bucket-deployment/copy/sim-cdk-bucket-deploy-copier.ts
+++ b/src/service/cloudformation/cdk/s3/bucket-deployment/copy/sim-cdk-bucket-deploy-copier.ts
@@ -1,0 +1,84 @@
+import type { SimS3Bucket } from "../../../../../s3/bucket/sim-s3-bucket.js";
+import { SimCdkBucketDeployFilter } from "../filter/sim-cdk-bucket-deploy-filter.js";
+import type { SimCdkBucketDeployProperties } from "../property/sim-cdk-bucket-deploy-properties.js";
+import { SimCdkBucketDeployFile } from "./sim-cdk-bucket-deploy-file.js";
+import { simCdkBucketDeployFiles } from "./sim-cdk-bucket-deploy-files.js";
+import { SimCdkBucketDeployPruner } from "./sim-cdk-bucket-deploy-pruner.js";
+
+interface SimCdkBucketDeployCopierProperties {
+  readonly bucket: SimS3Bucket;
+  readonly properties: SimCdkBucketDeployProperties;
+}
+
+/**
+ * Copies a staged CDK asset into a simulated destination Bucket.
+ *
+ * This is the `aws s3 sync` the provider function runs: the files the filters
+ * select become Objects under the destination key prefix, carrying the content
+ * headers the deployment was given, and a pruning deployment then removes the
+ * Objects in its own view of the Bucket that its source no longer holds.
+ *
+ * Copying rather than mounting the asset directory is what lets several
+ * deployments share a Bucket, which is the usual arrangement whenever the
+ * headers differ by file type, since a `BucketDeployment` sets them for all of
+ * its files at once.
+ */
+export class SimCdkBucketDeployCopier {
+  private readonly properties: SimCdkBucketDeployProperties;
+  private readonly filter: SimCdkBucketDeployFilter;
+  private readonly file: SimCdkBucketDeployFile;
+  private readonly pruner: SimCdkBucketDeployPruner;
+
+  constructor(properties: SimCdkBucketDeployCopierProperties) {
+    this.properties = properties.properties;
+    this.filter = new SimCdkBucketDeployFilter({
+      exclude: this.properties.exclude,
+      include: this.properties.include,
+    });
+    this.file = new SimCdkBucketDeployFile(properties);
+    this.pruner = new SimCdkBucketDeployPruner({
+      bucket: properties.bucket,
+      filter: this.filter,
+      keyPrefix: this.properties.destinationKeyPrefix,
+    });
+  }
+
+  /**
+   * Copy every source directory into the Bucket, then prune what is left over.
+   */
+  async copy(sourceDirectoryPaths: readonly string[]): Promise<void> {
+    const deployedKeys = new Set<string>();
+
+    // One source at a time, because two of them can hold the same path and the
+    // sync the provider function runs lets the later one win.
+    for (const sourceDirectoryPath of sourceDirectoryPaths) {
+      // eslint-disable-next-line no-await-in-loop -- sources are copied in the order the deployment lists them
+      const keys = await this.copyDirectory(sourceDirectoryPath);
+
+      for (const key of keys) {
+        deployedKeys.add(key);
+      }
+    }
+
+    if (this.properties.prune) {
+      await this.pruner.prune(deployedKeys);
+    }
+  }
+
+  /**
+   * Copy the files one source directory holds and the filters select.
+   */
+  private async copyDirectory(
+    sourceDirectoryPath: string,
+  ): Promise<readonly string[]> {
+    const relativePaths = await simCdkBucketDeployFiles(sourceDirectoryPath);
+
+    return await Promise.all(
+      relativePaths
+        .filter((relativePath) => this.filter.includes(relativePath))
+        .map(async (relativePath) =>
+          this.file.copy(sourceDirectoryPath, relativePath),
+        ),
+    );
+  }
+}

--- a/src/service/cloudformation/cdk/s3/bucket-deployment/copy/sim-cdk-bucket-deploy-file.ts
+++ b/src/service/cloudformation/cdk/s3/bucket-deployment/copy/sim-cdk-bucket-deploy-file.ts
@@ -1,0 +1,63 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+import type { SimS3Bucket } from "../../../../../s3/bucket/sim-s3-bucket.js";
+import {
+  SimS3Object,
+  SimS3ObjectMetadata,
+} from "../../../../../s3/object/s3-object.js";
+import { metadataForFilesystemS3ObjectKey } from "../../../../../s3/storage/filesystem/s3-filesystem-object-metadata.js";
+import type { SimCdkBucketDeployProperties } from "../property/sim-cdk-bucket-deploy-properties.js";
+
+interface SimCdkBucketDeployFileProperties {
+  readonly bucket: SimS3Bucket;
+  readonly properties: SimCdkBucketDeployProperties;
+}
+
+/**
+ * Copies one file from a staged CDK asset into a simulated Bucket.
+ *
+ * The Object key is the file's path relative to the asset root, under the
+ * deployment's destination key prefix.
+ */
+export class SimCdkBucketDeployFile {
+  private readonly bucket: SimS3Bucket;
+  private readonly properties: SimCdkBucketDeployProperties;
+
+  constructor(properties: SimCdkBucketDeployFileProperties) {
+    this.bucket = properties.bucket;
+    this.properties = properties.properties;
+  }
+
+  /**
+   * Store one file as an Object, and answer with the key it went under.
+   */
+  async copy(
+    sourceDirectoryPath: string,
+    relativePath: string,
+  ): Promise<string> {
+    const key = this.properties.objectKey(relativePath);
+    // eslint-disable-next-line security/detect-non-literal-fs-filename
+    const body = await readFile(path.join(sourceDirectoryPath, relativePath));
+
+    await this.bucket.putObject(
+      new SimS3Object({ key, body, metadata: this.metadata(relativePath) }),
+    );
+
+    return key;
+  }
+
+  /**
+   * What S3 will report about the Object.
+   *
+   * The CLI guesses a content type from the file extension, and the
+   * deployment's own system metadata is what the construct was told to set, so
+   * it wins.
+   */
+  private metadata(relativePath: string): SimS3ObjectMetadata {
+    return new SimS3ObjectMetadata({
+      ...metadataForFilesystemS3ObjectKey(relativePath).values,
+      ...Object.fromEntries(this.properties.systemMetadata),
+    });
+  }
+}

--- a/src/service/cloudformation/cdk/s3/bucket-deployment/copy/sim-cdk-bucket-deploy-files.iso.test.ts
+++ b/src/service/cloudformation/cdk/s3/bucket-deployment/copy/sim-cdk-bucket-deploy-files.iso.test.ts
@@ -1,0 +1,42 @@
+import { assertArrayLength, assertIdentical } from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { TemporaryDirectory } from "../../../../../../util/filesystem/temporary-directory.js";
+import { simCdkBucketDeployFiles } from "./sim-cdk-bucket-deploy-files.js";
+
+describe("simCdkBucketDeployFiles", () => {
+  it("lists nested files relative to the asset root", async () => {
+    // Given a staged asset directory with files at more than one depth.
+    const temporaryDirectory = new TemporaryDirectory();
+
+    await temporaryDirectory.writeFile(["index.html"], "<h1>Hello</h1>");
+    await temporaryDirectory.writeFile(["data", "standard.keys"], "keys");
+    await temporaryDirectory.writeFile(
+      ["data", "nested", "deep.keys"],
+      "deeper",
+    );
+
+    // When its files are listed.
+    const relativePaths = await simCdkBucketDeployFiles(
+      await temporaryDirectory.resolvePath(),
+    );
+
+    // Then every file comes back as a path relative to the root, separated the
+    // way both the filters and the Object keys are written.
+    assertIdentical(
+      relativePaths.toSorted((a, b) => a.localeCompare(b)).join(","),
+      "data/nested/deep.keys,data/standard.keys,index.html",
+    );
+  });
+
+  it("lists nothing for an empty asset directory", async () => {
+    // Given a staged asset directory with nothing in it.
+    const temporaryDirectory = new TemporaryDirectory();
+
+    // When its files are listed, then there are none.
+    const relativePaths = await simCdkBucketDeployFiles(
+      await temporaryDirectory.resolvePath(),
+    );
+
+    assertArrayLength(relativePaths, 0);
+  });
+});

--- a/src/service/cloudformation/cdk/s3/bucket-deployment/copy/sim-cdk-bucket-deploy-files.iso.test.ts
+++ b/src/service/cloudformation/cdk/s3/bucket-deployment/copy/sim-cdk-bucket-deploy-files.iso.test.ts
@@ -1,4 +1,12 @@
-import { assertArrayLength, assertIdentical } from "@kensio/smartass";
+import { symlink } from "node:fs/promises";
+import path from "node:path";
+
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
 import { describe, it } from "vitest";
 import { TemporaryDirectory } from "../../../../../../util/filesystem/temporary-directory.js";
 import { simCdkBucketDeployFiles } from "./sim-cdk-bucket-deploy-files.js";
@@ -26,6 +34,72 @@ describe("simCdkBucketDeployFiles", () => {
       relativePaths.toSorted((a, b) => a.localeCompare(b)).join(","),
       "data/nested/deep.keys,data/standard.keys,index.html",
     );
+  });
+
+  it("follows a symbolic link to a file", async () => {
+    // Given a staged asset directory holding a link to a file beside it.
+    const temporaryDirectory = new TemporaryDirectory();
+
+    await temporaryDirectory.writeFile(["index.html"], "<h1>Hello</h1>");
+
+    const rootPath = await temporaryDirectory.resolvePath();
+
+    // eslint-disable-next-line security/detect-non-literal-fs-filename -- both paths are inside this test's own temporary directory
+    await symlink(
+      path.join(rootPath, "index.html"),
+      path.join(rootPath, "linked.html"),
+    );
+
+    // When its files are listed.
+    const relativePaths = await simCdkBucketDeployFiles(rootPath);
+
+    // Then the link is one of them, as `aws s3 sync` follows one by default.
+    // Leaving it out would deploy a Bucket quietly missing a file.
+    assertIdentical(
+      relativePaths.toSorted((a, b) => a.localeCompare(b)).join(","),
+      "index.html,linked.html",
+    );
+  });
+
+  it("leaves out a symbolic link pointing at nothing", async () => {
+    // Given a staged asset directory holding a broken link.
+    const temporaryDirectory = new TemporaryDirectory();
+
+    await temporaryDirectory.writeFile(["index.html"], "<h1>Hello</h1>");
+
+    const rootPath = await temporaryDirectory.resolvePath();
+
+    // eslint-disable-next-line security/detect-non-literal-fs-filename -- both paths are inside this test's own temporary directory
+    await symlink(
+      path.join(rootPath, "gone.html"),
+      path.join(rootPath, "broken.html"),
+    );
+
+    // When its files are listed, then the broken link is skipped rather than
+    // failing the deployment, which is what the CLI does with one.
+    const relativePaths = await simCdkBucketDeployFiles(rootPath);
+
+    assertIdentical(relativePaths.join(","), "index.html");
+  });
+
+  it("refuses a symbolic link to a directory", async () => {
+    // Given a staged asset directory holding a link to a directory.
+    const temporaryDirectory = new TemporaryDirectory();
+
+    await temporaryDirectory.writeFile(["data", "standard.keys"], "keys");
+
+    const rootPath = await temporaryDirectory.resolvePath();
+
+    // eslint-disable-next-line security/detect-non-literal-fs-filename -- both paths are inside this test's own temporary directory
+    await symlink(path.join(rootPath, "data"), path.join(rootPath, "linked"));
+
+    // When its files are listed, then it is refused by name rather than
+    // walked, since a link to an ancestor would be walked forever.
+    const error = await assertThrowsErrorAsync(async () =>
+      simCdkBucketDeployFiles(rootPath),
+    );
+
+    assertStringIncludes(error.message, "symbolic link to a directory");
   });
 
   it("lists nothing for an empty asset directory", async () => {

--- a/src/service/cloudformation/cdk/s3/bucket-deployment/copy/sim-cdk-bucket-deploy-files.ts
+++ b/src/service/cloudformation/cdk/s3/bucket-deployment/copy/sim-cdk-bucket-deploy-files.ts
@@ -1,4 +1,4 @@
-import { readdir } from "node:fs/promises";
+import { readdir, stat } from "node:fs/promises";
 import path from "node:path";
 
 /**
@@ -6,6 +6,11 @@ import path from "node:path";
  *
  * Paths come back relative to the asset root with `/` separators, which is the
  * form both the deployment filters and the S3 Object keys are written in.
+ *
+ * A symbolic link to a file is followed, as `aws s3 sync` follows one by
+ * default. A symbolic link to a directory is refused rather than walked,
+ * because a link pointing at one of its own ancestors would otherwise be walked
+ * forever, and a staged CDK asset has no reason to hold one.
  */
 export async function simCdkBucketDeployFiles(
   directoryPath: string,
@@ -31,13 +36,57 @@ async function filesUnder(
     }
 
     if (entry.isFile()) {
-      relativePaths.push(
-        path.relative(rootPath, entryPath).split(path.sep).join("/"),
-      );
+      relativePaths.push(relativeTo(rootPath, entryPath));
+      continue;
+    }
+
+    if (entry.isSymbolicLink()) {
+      nested.push(linkedFile(rootPath, entryPath));
     }
   }
 
   const nestedPaths = await Promise.all(nested);
 
   return [...relativePaths, ...nestedPaths.flat()];
+}
+
+/**
+ * The one path a symbolic link contributes, or none when it points nowhere.
+ */
+async function linkedFile(
+  rootPath: string,
+  entryPath: string,
+): Promise<string[]> {
+  const linked = await linkedStats(entryPath);
+
+  // A link pointing at nothing is left out rather than failing the deployment,
+  // which is what `aws s3 sync` does with one.
+  if (linked === undefined) {
+    return [];
+  }
+
+  if (linked.isDirectory()) {
+    throw new Error(
+      `Sim CDK BucketDeployment source ${entryPath} is a symbolic link to a ` +
+        `directory, which simulated deployments do not follow`,
+    );
+  }
+
+  return [relativeTo(rootPath, entryPath)];
+}
+
+async function linkedStats(
+  entryPath: string,
+): Promise<Awaited<ReturnType<typeof stat>> | undefined> {
+  try {
+    // `stat` rather than `lstat`, so the link is followed to what it names.
+    // eslint-disable-next-line security/detect-non-literal-fs-filename
+    return await stat(entryPath);
+  } catch {
+    return undefined;
+  }
+}
+
+function relativeTo(rootPath: string, entryPath: string): string {
+  return path.relative(rootPath, entryPath).split(path.sep).join("/");
 }

--- a/src/service/cloudformation/cdk/s3/bucket-deployment/copy/sim-cdk-bucket-deploy-files.ts
+++ b/src/service/cloudformation/cdk/s3/bucket-deployment/copy/sim-cdk-bucket-deploy-files.ts
@@ -1,0 +1,43 @@
+import { readdir } from "node:fs/promises";
+import path from "node:path";
+
+/**
+ * Lists the files a staged CDK asset directory holds.
+ *
+ * Paths come back relative to the asset root with `/` separators, which is the
+ * form both the deployment filters and the S3 Object keys are written in.
+ */
+export async function simCdkBucketDeployFiles(
+  directoryPath: string,
+): Promise<string[]> {
+  return await filesUnder(directoryPath, directoryPath);
+}
+
+async function filesUnder(
+  rootPath: string,
+  directoryPath: string,
+): Promise<string[]> {
+  // eslint-disable-next-line security/detect-non-literal-fs-filename
+  const entries = await readdir(directoryPath, { withFileTypes: true });
+  const relativePaths: string[] = [];
+  const nested: Promise<string[]>[] = [];
+
+  for (const entry of entries) {
+    const entryPath = path.join(directoryPath, entry.name);
+
+    if (entry.isDirectory()) {
+      nested.push(filesUnder(rootPath, entryPath));
+      continue;
+    }
+
+    if (entry.isFile()) {
+      relativePaths.push(
+        path.relative(rootPath, entryPath).split(path.sep).join("/"),
+      );
+    }
+  }
+
+  const nestedPaths = await Promise.all(nested);
+
+  return [...relativePaths, ...nestedPaths.flat()];
+}

--- a/src/service/cloudformation/cdk/s3/bucket-deployment/copy/sim-cdk-bucket-deploy-pruner.ts
+++ b/src/service/cloudformation/cdk/s3/bucket-deployment/copy/sim-cdk-bucket-deploy-pruner.ts
@@ -1,0 +1,53 @@
+import type { SimS3Bucket } from "../../../../../s3/bucket/sim-s3-bucket.js";
+import type { SimCdkBucketDeployFilter } from "../filter/sim-cdk-bucket-deploy-filter.js";
+
+interface SimCdkBucketDeployPrunerProperties {
+  readonly bucket: SimS3Bucket;
+  readonly filter: SimCdkBucketDeployFilter;
+  readonly keyPrefix: string;
+}
+
+/**
+ * Removes the Objects a deployment covers but no longer holds.
+ *
+ * This is the `--delete` the provider function's sync runs. It only considers
+ * what passes the filters, on the destination side as well as the source side,
+ * so a deployment that excludes a directory does not delete another
+ * deployment's Objects in it. That is the whole reason `prune: false` on a
+ * second deployment into the same Bucket is a real setting rather than a
+ * precaution.
+ */
+export class SimCdkBucketDeployPruner {
+  private readonly bucket: SimS3Bucket;
+  private readonly filter: SimCdkBucketDeployFilter;
+  private readonly keyPrefix: string;
+
+  constructor(properties: SimCdkBucketDeployPrunerProperties) {
+    this.bucket = properties.bucket;
+    this.filter = properties.filter;
+    this.keyPrefix = properties.keyPrefix;
+  }
+
+  /**
+   * Remove everything this deployment would have copied and did not.
+   */
+  async prune(deployedKeys: ReadonlySet<string>): Promise<void> {
+    const existing = await this.bucket.listObjects(this.keyPrefix);
+    const stale = existing.filter((object) =>
+      this.isStale(object.key, deployedKeys),
+    );
+
+    await Promise.all(
+      stale.map(async (object) => {
+        await this.bucket.deleteObject(object.key);
+      }),
+    );
+  }
+
+  private isStale(key: string, deployedKeys: ReadonlySet<string>): boolean {
+    return (
+      !deployedKeys.has(key) &&
+      this.filter.includes(key.slice(this.keyPrefix.length))
+    );
+  }
+}

--- a/src/service/cloudformation/cdk/s3/bucket-deployment/filter/sim-cdk-bucket-deploy-filter.iso.test.ts
+++ b/src/service/cloudformation/cdk/s3/bucket-deployment/filter/sim-cdk-bucket-deploy-filter.iso.test.ts
@@ -1,0 +1,121 @@
+import {
+  assertFalse,
+  assertStringIncludes,
+  assertThrowsError,
+  assertTrue,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimCdkBucketDeployFilter } from "./sim-cdk-bucket-deploy-filter.js";
+
+describe("SimCdkBucketDeployFilter", () => {
+  /**
+   * A file the deployment copies.
+   */
+  function assertFileIncluded(
+    deployFilter: SimCdkBucketDeployFilter,
+    relativePath: string,
+  ): void {
+    const included = deployFilter.includes(relativePath);
+
+    assertTrue(included);
+  }
+
+  /**
+   * A file the deployment leaves behind.
+   */
+  function assertFileExcluded(
+    deployFilter: SimCdkBucketDeployFilter,
+    relativePath: string,
+  ): void {
+    const included = deployFilter.includes(relativePath);
+
+    assertFalse(included);
+  }
+
+  function filter(
+    exclude: string[] = [],
+    include: string[] = [],
+  ): SimCdkBucketDeployFilter {
+    return new SimCdkBucketDeployFilter({ exclude, include });
+  }
+
+  it("copies every file when no filters are configured", () => {
+    // Given a deployment with no Exclude or Include.
+    const deployFilter = filter();
+
+    // When any file is considered, then it is part of the deployment.
+    assertFileIncluded(deployFilter, "index.html");
+    assertFileIncluded(deployFilter, "data/standard.keys");
+  });
+
+  it("drops the files an exclude pattern matches", () => {
+    // Given a deployment excluding the data directory.
+    const deployFilter = filter(["data/*"]);
+
+    // When files inside and outside it are considered.
+    // Then only the ones outside it are copied.
+    assertFileExcluded(deployFilter, "data/standard.keys");
+    assertFileIncluded(deployFilter, "index.html");
+  });
+
+  it("lets a later include win over an earlier exclude", () => {
+    // Given the common pair meaning "only the text files", which the CLI reads
+    // as all the excludes first and then all the includes.
+    const deployFilter = filter(["*"], ["*.txt"]);
+
+    // When files of each kind are considered.
+    // Then the last pattern to match decides.
+    assertFileIncluded(deployFilter, "notes.txt");
+    assertFileIncluded(deployFilter, "nested/notes.txt");
+    assertFileExcluded(deployFilter, "index.html");
+  });
+
+  it("matches a star across directory separators", () => {
+    // Given a deployment excluding everything under a directory.
+    const deployFilter = filter(["data/*"]);
+
+    // When a file nested more deeply is considered.
+    // Then it is excluded too: the CLI's star crosses a slash.
+    assertFileExcluded(deployFilter, "data/nested/deep.keys");
+  });
+
+  it("matches a single character with a question mark", () => {
+    // Given a deployment excluding one-character names.
+    const deployFilter = filter(["?.txt"]);
+
+    // When names of each length are considered.
+    // Then only the single-character one matches.
+    assertFileExcluded(deployFilter, "a.txt");
+    assertFileIncluded(deployFilter, "ab.txt");
+  });
+
+  it("matches a pattern against the whole relative path", () => {
+    // Given a deployment excluding a named file.
+    const deployFilter = filter(["index.html"]);
+
+    // When a file of that name in a subdirectory is considered.
+    // Then it is kept, because the pattern anchors to the whole path.
+    assertFileExcluded(deployFilter, "index.html");
+    assertFileIncluded(deployFilter, "nested/index.html");
+  });
+
+  it("treats regular expression characters in a pattern literally", () => {
+    // Given a pattern containing characters a regular expression would read.
+    const deployFilter = filter(["a+b(c).txt"]);
+
+    // When the file that pattern names is considered.
+    // Then it matches as written, and nothing else does.
+    assertFileExcluded(deployFilter, "a+b(c).txt");
+    assertFileIncluded(deployFilter, "aab c.txt");
+  });
+
+  it("refuses a character class rather than mismatching it", () => {
+    // Given a pattern using a character class, which the CLI supports and this
+    // filter does not.
+    // When the filter is built, then it refuses by naming the pattern.
+    const error = assertThrowsError(() => filter(["[abc].txt"]));
+
+    assertStringIncludes(error.message, "[abc].txt");
+    assertStringIncludes(error.message, "character class");
+  });
+});

--- a/src/service/cloudformation/cdk/s3/bucket-deployment/filter/sim-cdk-bucket-deploy-filter.iso.test.ts
+++ b/src/service/cloudformation/cdk/s3/bucket-deployment/filter/sim-cdk-bucket-deploy-filter.iso.test.ts
@@ -109,6 +109,17 @@ describe("SimCdkBucketDeployFilter", () => {
     assertFileIncluded(deployFilter, "aab c.txt");
   });
 
+  it("reads a run of stars as one", () => {
+    // Given a pattern written with a doubled star.
+    const deployFilter = filter(["data/**"]);
+
+    // When files inside and outside that directory are considered.
+    // Then it means what a single star means, since a star already crosses a
+    // slash, and a long near miss does not compile to nested wildcards.
+    assertFileExcluded(deployFilter, "data/nested/deep.keys");
+    assertFileIncluded(deployFilter, "index.html");
+  });
+
   it("refuses a character class rather than mismatching it", () => {
     // Given a pattern using a character class, which the CLI supports and this
     // filter does not.

--- a/src/service/cloudformation/cdk/s3/bucket-deployment/filter/sim-cdk-bucket-deploy-filter.ts
+++ b/src/service/cloudformation/cdk/s3/bucket-deployment/filter/sim-cdk-bucket-deploy-filter.ts
@@ -1,0 +1,88 @@
+interface SimCdkBucketDeployFilterProperties {
+  readonly exclude: readonly string[];
+  readonly include: readonly string[];
+}
+
+/**
+ * Decides which of a source's files a `BucketDeployment` copies.
+ *
+ * The provider function passes `Exclude` and `Include` through to `aws s3 sync`
+ * as `--exclude` and `--include`, all the excludes first and then all the
+ * includes, and the CLI applies them in that order with the last match winning.
+ * That is what makes the common `exclude: ["*"], include: ["*.txt"]` pair mean
+ * "only the text files". A file no pattern matches is copied.
+ *
+ * Patterns are matched against the path relative to the source root, and `*`
+ * matches across `/` the way the CLI's do, so `data/*` covers the whole of a
+ * `data` directory and `*.txt` covers a `.txt` file at any depth.
+ */
+export class SimCdkBucketDeployFilter {
+  private readonly rules: readonly FilterRule[];
+
+  constructor(properties: SimCdkBucketDeployFilterProperties) {
+    this.rules = [
+      ...properties.exclude.map((pattern) => new FilterRule(pattern, false)),
+      ...properties.include.map((pattern) => new FilterRule(pattern, true)),
+    ];
+  }
+
+  /**
+   * Whether a path relative to the source root is part of this deployment.
+   */
+  includes(relativePath: string): boolean {
+    let included = true;
+
+    for (const rule of this.rules) {
+      if (rule.matches(relativePath)) {
+        included = rule.included;
+      }
+    }
+
+    return included;
+  }
+}
+
+class FilterRule {
+  private readonly expression: RegExp;
+
+  constructor(
+    pattern: string,
+    readonly included: boolean,
+  ) {
+    this.expression = filterExpression(pattern);
+  }
+
+  matches(relativePath: string): boolean {
+    return this.expression.test(relativePath);
+  }
+}
+
+/**
+ * Turn one CLI filter pattern into a regular expression.
+ *
+ * `*` and `?` are the two wildcards CDK's own documentation shows, and are what
+ * a deployment filter is written with in practice. The CLI also takes character
+ * classes, which are refused here rather than matched literally: a pattern that
+ * quietly means something other than it says would copy the wrong files, and
+ * finding that out from a puzzling refusal beats finding it out from a
+ * half-deployed Bucket.
+ */
+function filterExpression(pattern: string): RegExp {
+  if (pattern.includes("[")) {
+    throw new Error(
+      `Sim CDK BucketDeployment filter pattern ${pattern} uses a character ` +
+        `class, which simulated deployment filters do not support`,
+    );
+  }
+
+  // Escape everything a regular expression would read, then turn the two
+  // escaped wildcards back into the patterns they stand for. Doing it in that
+  // order means a wildcard is never confused with a literal one.
+  const expression = pattern
+    .replaceAll(/[$()*+.?[\\\]^{|}]/gu, String.raw`\$&`)
+    .replaceAll(String.raw`\*`, ".*")
+    .replaceAll(String.raw`\?`, ".");
+
+  // eslint-disable-next-line security/detect-non-literal-regexp -- built from an escaped template pattern, not from anything a request carries
+  return new RegExp(`^${expression}$`, "u");
+}

--- a/src/service/cloudformation/cdk/s3/bucket-deployment/filter/sim-cdk-bucket-deploy-filter.ts
+++ b/src/service/cloudformation/cdk/s3/bucket-deployment/filter/sim-cdk-bucket-deploy-filter.ts
@@ -78,7 +78,12 @@ function filterExpression(pattern: string): RegExp {
   // Escape everything a regular expression would read, then turn the two
   // escaped wildcards back into the patterns they stand for. Doing it in that
   // order means a wildcard is never confused with a literal one.
+  //
+  // Runs of stars collapse to one first. A star already crosses `/`, so `**`
+  // means what `*` means, and leaving it would compile to `.*.*` and give the
+  // engine a needless amount of backtracking to do on a long near miss.
   const expression = pattern
+    .replaceAll(/\*+/gu, "*")
     .replaceAll(/[$()*+.?[\\\]^{|}]/gu, String.raw`\$&`)
     .replaceAll(String.raw`\*`, ".*")
     .replaceAll(String.raw`\?`, ".");

--- a/src/service/cloudformation/cdk/s3/bucket-deployment/property/sim-cdk-bucket-deploy-properties.iso.test.ts
+++ b/src/service/cloudformation/cdk/s3/bucket-deployment/property/sim-cdk-bucket-deploy-properties.iso.test.ts
@@ -1,0 +1,184 @@
+import {
+  assertArrayLength,
+  assertFalse,
+  assertIdentical,
+  assertStringIncludes,
+  assertThrowsError,
+  assertTrue,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimCfnResource } from "../../../../resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../../template/value/sim-cfn-template-value.js";
+import { SimCdkBucketDeployProperties } from "./sim-cdk-bucket-deploy-properties.js";
+
+describe("SimCdkBucketDeployProperties", () => {
+  const resource = new SimCfnResource({ logicalId: "DeploySite" });
+
+  function properties(
+    values: SimCfnTemplateValueRecord,
+  ): SimCdkBucketDeployProperties {
+    return new SimCdkBucketDeployProperties(resource, {
+      DestinationBucketName: "site-bucket",
+      SourceObjectKeys: ["abc123.zip"],
+      ...values,
+    });
+  }
+
+  it("reads the destination and source a deployment names", () => {
+    // Given the properties CDK synthesizes for a plain BucketDeployment.
+    const deployProperties = properties({});
+
+    // Then the destination and every source key are read.
+    assertIdentical(deployProperties.destinationBucketName, "site-bucket");
+    assertArrayLength(deployProperties.sourceObjectKeys, 1);
+    assertIdentical(deployProperties.sourceObjectKeys[0], "abc123.zip");
+  });
+
+  it("reads several source object keys", () => {
+    // Given a deployment with more than one source.
+    const deployProperties = properties({
+      SourceObjectKeys: ["abc123.zip", "def456.zip"],
+    });
+
+    // Then all of them are kept, because a BucketDeployment can take several
+    // sources and copy each into the same destination.
+    assertArrayLength(deployProperties.sourceObjectKeys, 2);
+  });
+
+  it("keys files under the destination prefix", () => {
+    // Given a deployment into a key prefix, which CDK synthesizes without a
+    // trailing slash.
+    const deployProperties = properties({
+      DestinationBucketKeyPrefix: "assets",
+    });
+
+    // When a source file's Object key is built.
+    // Then the prefix becomes a key prefix with the separator it needs.
+    assertIdentical(deployProperties.objectKey("app.css"), "assets/app.css");
+  });
+
+  it("does not double the separator on a prefix that already ends in one", () => {
+    // Given a deployment whose prefix was written with a trailing slash.
+    const deployProperties = properties({
+      DestinationBucketKeyPrefix: "assets/",
+    });
+
+    // Then the key has one separator, not two.
+    assertIdentical(deployProperties.objectKey("app.css"), "assets/app.css");
+  });
+
+  it("keys files at the Bucket root with no prefix", () => {
+    // Given a deployment with no key prefix.
+    const deployProperties = properties({});
+
+    // Then Object keys are the source paths as they stand.
+    assertIdentical(deployProperties.objectKey("index.html"), "index.html");
+  });
+
+  it("treats an empty key prefix as no prefix", () => {
+    // Given a deployment whose prefix resolved to an empty string.
+    const deployProperties = properties({ DestinationBucketKeyPrefix: "" });
+
+    // Then nothing is prepended, and no bare separator appears.
+    assertIdentical(deployProperties.objectKey("index.html"), "index.html");
+  });
+
+  it("prunes unless the deployment says otherwise", () => {
+    // Given deployments with each Prune setting, and one with none.
+    // Then the construct's own default stands in for an absent property, which
+    // is only synthesized when it is set.
+    assertTrue(properties({}).prune);
+    assertTrue(properties({ Prune: true }).prune);
+    assertFalse(properties({ Prune: false }).prune);
+  });
+
+  it("reads system metadata as the headers it sets", () => {
+    // Given a deployment setting content headers on everything it copies.
+    const deployProperties = properties({
+      SystemMetadata: {
+        "content-encoding": "br",
+        "Cache-Control": "public, max-age=60",
+      },
+    });
+
+    // Then each is kept under a lowercase name, as a stored Object holds it.
+    assertIdentical(
+      deployProperties.systemMetadata.get("content-encoding"),
+      "br",
+    );
+    assertIdentical(
+      deployProperties.systemMetadata.get("cache-control"),
+      "public, max-age=60",
+    );
+  });
+
+  it("reads the exclude and include filters", () => {
+    // Given a deployment with both kinds of filter.
+    const deployProperties = properties({
+      Exclude: ["*"],
+      Include: ["*.txt"],
+    });
+
+    // Then both lists are read, and an absent one is empty rather than missing.
+    assertIdentical(deployProperties.exclude[0], "*");
+    assertIdentical(deployProperties.include[0], "*.txt");
+    const unfiltered = properties({});
+
+    assertArrayLength(unfiltered.exclude, 0);
+    assertArrayLength(unfiltered.include, 0);
+  });
+
+  it("refuses a destination Bucket name that did not resolve to a string", () => {
+    // Given a deployment whose destination Bucket name is not a string.
+    // When the properties are read, then it is refused by name.
+    const error = assertThrowsError(() =>
+      properties({ DestinationBucketName: 123 }),
+    );
+
+    assertStringIncludes(
+      error.message,
+      "Custom::CDKBucketDeployment DeploySite: DestinationBucketName must resolve to a string",
+    );
+  });
+
+  it("refuses a key prefix that did not resolve to a string", () => {
+    // Given a deployment whose key prefix is not a string.
+    // When the properties are read, then it is refused by name.
+    const error = assertThrowsError(() =>
+      properties({ DestinationBucketKeyPrefix: ["assets"] }),
+    );
+
+    assertStringIncludes(
+      error.message,
+      "DestinationBucketKeyPrefix must resolve to a string",
+    );
+  });
+
+  it("refuses a filter list that is not a list of strings", () => {
+    // Given deployments whose filters are the wrong shape.
+    // When the properties are read, then each is refused by name.
+    assertStringIncludes(
+      assertThrowsError(() => properties({ Exclude: "*" })).message,
+      "Exclude must be an array of strings",
+    );
+    assertStringIncludes(
+      assertThrowsError(() => properties({ Include: [123] })).message,
+      "Include must be an array of strings",
+    );
+  });
+
+  it("refuses system metadata that is not an object of strings", () => {
+    // Given deployments whose system metadata is the wrong shape.
+    // When the properties are read, then each is refused by name.
+    assertStringIncludes(
+      assertThrowsError(() => properties({ SystemMetadata: ["br"] })).message,
+      "SystemMetadata must be an object",
+    );
+    assertStringIncludes(
+      assertThrowsError(() =>
+        properties({ SystemMetadata: { "content-encoding": 1 } }),
+      ).message,
+      "SystemMetadata content-encoding must be a string",
+    );
+  });
+});

--- a/src/service/cloudformation/cdk/s3/bucket-deployment/property/sim-cdk-bucket-deploy-properties.iso.test.ts
+++ b/src/service/cloudformation/cdk/s3/bucket-deployment/property/sim-cdk-bucket-deploy-properties.iso.test.ts
@@ -92,6 +92,22 @@ describe("SimCdkBucketDeployProperties", () => {
     assertFalse(properties({ Prune: false }).prune);
   });
 
+  it("refuses a Prune that is not a boolean", () => {
+    // Given a deployment whose Prune resolved to something other than a
+    // boolean, as a template substituting a parameter can leave it.
+    // When the properties are read, then it is refused rather than read as
+    // truthy: pruning deletes Objects, so "false" quietly meaning true would
+    // delete the ones the template was keeping.
+    assertStringIncludes(
+      assertThrowsError(() => properties({ Prune: "false" })).message,
+      "Custom::CDKBucketDeployment DeploySite: Prune must be a boolean",
+    );
+    assertStringIncludes(
+      assertThrowsError(() => properties({ Prune: 0 })).message,
+      "Prune must be a boolean",
+    );
+  });
+
   it("reads system metadata as the headers it sets", () => {
     // Given a deployment setting content headers on everything it copies.
     const deployProperties = properties({

--- a/src/service/cloudformation/cdk/s3/bucket-deployment/property/sim-cdk-bucket-deploy-properties.ts
+++ b/src/service/cloudformation/cdk/s3/bucket-deployment/property/sim-cdk-bucket-deploy-properties.ts
@@ -1,0 +1,147 @@
+import type { SimCfnResource } from "../../../../resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../../template/value/sim-cfn-template-value.js";
+
+/**
+ * The parts of a `Custom::CDKBucketDeployment` that say what to copy where.
+ *
+ * The CDK `BucketDeployment` construct compiles down to these properties, which
+ * its provider function turns into one `aws s3 sync` invocation. Reading them
+ * into one object keeps the parsing and the validation away from the copying.
+ */
+export class SimCdkBucketDeployProperties {
+  readonly destinationBucketName: string;
+  readonly destinationKeyPrefix: string;
+  readonly sourceObjectKeys: readonly string[];
+  readonly exclude: readonly string[];
+  readonly include: readonly string[];
+  readonly prune: boolean;
+  readonly systemMetadata: ReadonlyMap<string, string>;
+
+  constructor(resource: SimCfnResource, properties: SimCfnTemplateValueRecord) {
+    this.destinationBucketName = requiredString(
+      resource,
+      properties,
+      "DestinationBucketName",
+    );
+    this.destinationKeyPrefix = normaliseKeyPrefix(
+      optionalString(resource, properties, "DestinationBucketKeyPrefix"),
+    );
+    this.sourceObjectKeys = stringList(
+      resource,
+      properties,
+      "SourceObjectKeys",
+    );
+    this.exclude = stringList(resource, properties, "Exclude");
+    this.include = stringList(resource, properties, "Include");
+    // A `BucketDeployment` prunes unless told not to, and the property is only
+    // synthesized when it is set, so absent means the construct default.
+    this.prune = properties["Prune"] !== false;
+    this.systemMetadata = systemMetadata(resource, properties);
+  }
+
+  /**
+   * The Object key a source file relative path is stored under.
+   */
+  objectKey(relativePath: string): string {
+    return `${this.destinationKeyPrefix}${relativePath}`;
+  }
+}
+
+/**
+ * The destination prefix is synthesized without a trailing slash, and is a key
+ * prefix rather than a directory, so it grows one here and only here.
+ */
+function normaliseKeyPrefix(value: string | undefined): string {
+  if (value === undefined || value === "") {
+    return "";
+  }
+
+  return value.endsWith("/") ? value : `${value}/`;
+}
+
+function systemMetadata(
+  resource: SimCfnResource,
+  properties: SimCfnTemplateValueRecord,
+): ReadonlyMap<string, string> {
+  const value = properties["SystemMetadata"];
+
+  if (value === undefined) {
+    return new Map();
+  }
+
+  if (typeof value !== "object" || Array.isArray(value) || value === null) {
+    throw new TypeError(
+      `Custom::CDKBucketDeployment ${resource.logicalId}: SystemMetadata must be an object`,
+    );
+  }
+
+  const entries = Object.entries(value).map(([name, headerValue]) => {
+    if (typeof headerValue !== "string") {
+      throw new TypeError(
+        `Custom::CDKBucketDeployment ${resource.logicalId}: SystemMetadata ${name} must be a string`,
+      );
+    }
+
+    return [name.toLowerCase(), headerValue] as const;
+  });
+
+  return new Map(entries);
+}
+
+function requiredString(
+  resource: SimCfnResource,
+  properties: SimCfnTemplateValueRecord,
+  name: string,
+): string {
+  const value = optionalString(resource, properties, name);
+
+  if (value === undefined) {
+    throw new TypeError(
+      `Custom::CDKBucketDeployment ${resource.logicalId}: ${name} must resolve to a string`,
+    );
+  }
+
+  return value;
+}
+
+function optionalString(
+  resource: SimCfnResource,
+  properties: SimCfnTemplateValueRecord,
+  name: string,
+): string | undefined {
+  // eslint-disable-next-line security/detect-object-injection
+  const value = properties[name];
+
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (typeof value !== "string") {
+    throw new TypeError(
+      `Custom::CDKBucketDeployment ${resource.logicalId}: ${name} must resolve to a string`,
+    );
+  }
+
+  return value;
+}
+
+function stringList(
+  resource: SimCfnResource,
+  properties: SimCfnTemplateValueRecord,
+  name: string,
+): readonly string[] {
+  // eslint-disable-next-line security/detect-object-injection
+  const value = properties[name];
+
+  if (value === undefined) {
+    return [];
+  }
+
+  if (!Array.isArray(value) || value.some((item) => typeof item !== "string")) {
+    throw new TypeError(
+      `Custom::CDKBucketDeployment ${resource.logicalId}: ${name} must be an array of strings`,
+    );
+  }
+
+  return value as readonly string[];
+}

--- a/src/service/cloudformation/cdk/s3/bucket-deployment/property/sim-cdk-bucket-deploy-properties.ts
+++ b/src/service/cloudformation/cdk/s3/bucket-deployment/property/sim-cdk-bucket-deploy-properties.ts
@@ -1,5 +1,6 @@
 import type { SimCfnResource } from "../../../../resource/sim-cfn-resource.js";
 import type { SimCfnTemplateValueRecord } from "../../../../template/value/sim-cfn-template-value.js";
+import { SimCdkBucketDeployValues } from "./sim-cdk-bucket-deploy-values.js";
 
 /**
  * The parts of a `Custom::CDKBucketDeployment` that say what to copy where.
@@ -18,25 +19,19 @@ export class SimCdkBucketDeployProperties {
   readonly systemMetadata: ReadonlyMap<string, string>;
 
   constructor(resource: SimCfnResource, properties: SimCfnTemplateValueRecord) {
-    this.destinationBucketName = requiredString(
-      resource,
-      properties,
-      "DestinationBucketName",
-    );
+    const values = new SimCdkBucketDeployValues(resource, properties);
+
+    this.destinationBucketName = values.requiredString("DestinationBucketName");
     this.destinationKeyPrefix = normaliseKeyPrefix(
-      optionalString(resource, properties, "DestinationBucketKeyPrefix"),
+      values.optionalString("DestinationBucketKeyPrefix"),
     );
-    this.sourceObjectKeys = stringList(
-      resource,
-      properties,
-      "SourceObjectKeys",
-    );
-    this.exclude = stringList(resource, properties, "Exclude");
-    this.include = stringList(resource, properties, "Include");
+    this.sourceObjectKeys = values.stringList("SourceObjectKeys");
+    this.exclude = values.stringList("Exclude");
+    this.include = values.stringList("Include");
     // A `BucketDeployment` prunes unless told not to, and the property is only
     // synthesized when it is set, so absent means the construct default.
-    this.prune = properties["Prune"] !== false;
-    this.systemMetadata = systemMetadata(resource, properties);
+    this.prune = values.boolean("Prune", true);
+    this.systemMetadata = values.headers("SystemMetadata");
   }
 
   /**
@@ -57,91 +52,4 @@ function normaliseKeyPrefix(value: string | undefined): string {
   }
 
   return value.endsWith("/") ? value : `${value}/`;
-}
-
-function systemMetadata(
-  resource: SimCfnResource,
-  properties: SimCfnTemplateValueRecord,
-): ReadonlyMap<string, string> {
-  const value = properties["SystemMetadata"];
-
-  if (value === undefined) {
-    return new Map();
-  }
-
-  if (typeof value !== "object" || Array.isArray(value) || value === null) {
-    throw new TypeError(
-      `Custom::CDKBucketDeployment ${resource.logicalId}: SystemMetadata must be an object`,
-    );
-  }
-
-  const entries = Object.entries(value).map(([name, headerValue]) => {
-    if (typeof headerValue !== "string") {
-      throw new TypeError(
-        `Custom::CDKBucketDeployment ${resource.logicalId}: SystemMetadata ${name} must be a string`,
-      );
-    }
-
-    return [name.toLowerCase(), headerValue] as const;
-  });
-
-  return new Map(entries);
-}
-
-function requiredString(
-  resource: SimCfnResource,
-  properties: SimCfnTemplateValueRecord,
-  name: string,
-): string {
-  const value = optionalString(resource, properties, name);
-
-  if (value === undefined) {
-    throw new TypeError(
-      `Custom::CDKBucketDeployment ${resource.logicalId}: ${name} must resolve to a string`,
-    );
-  }
-
-  return value;
-}
-
-function optionalString(
-  resource: SimCfnResource,
-  properties: SimCfnTemplateValueRecord,
-  name: string,
-): string | undefined {
-  // eslint-disable-next-line security/detect-object-injection
-  const value = properties[name];
-
-  if (value === undefined) {
-    return undefined;
-  }
-
-  if (typeof value !== "string") {
-    throw new TypeError(
-      `Custom::CDKBucketDeployment ${resource.logicalId}: ${name} must resolve to a string`,
-    );
-  }
-
-  return value;
-}
-
-function stringList(
-  resource: SimCfnResource,
-  properties: SimCfnTemplateValueRecord,
-  name: string,
-): readonly string[] {
-  // eslint-disable-next-line security/detect-object-injection
-  const value = properties[name];
-
-  if (value === undefined) {
-    return [];
-  }
-
-  if (!Array.isArray(value) || value.some((item) => typeof item !== "string")) {
-    throw new TypeError(
-      `Custom::CDKBucketDeployment ${resource.logicalId}: ${name} must be an array of strings`,
-    );
-  }
-
-  return value as readonly string[];
 }

--- a/src/service/cloudformation/cdk/s3/bucket-deployment/property/sim-cdk-bucket-deploy-values.ts
+++ b/src/service/cloudformation/cdk/s3/bucket-deployment/property/sim-cdk-bucket-deploy-values.ts
@@ -1,0 +1,127 @@
+import type { SimCfnResource } from "../../../../resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../../template/value/sim-cfn-template-value.js";
+
+/**
+ * Reads one `Custom::CDKBucketDeployment` property, refusing a value of the
+ * wrong shape by naming the property it came from.
+ *
+ * Keeping the reading here leaves `SimCdkBucketDeployProperties` saying what a
+ * deployment is made of rather than how each part is checked.
+ */
+export class SimCdkBucketDeployValues {
+  private readonly resource: SimCfnResource;
+  private readonly properties: SimCfnTemplateValueRecord;
+
+  constructor(resource: SimCfnResource, properties: SimCfnTemplateValueRecord) {
+    this.resource = resource;
+    this.properties = properties;
+  }
+
+  /**
+   * A property that has to be there and has to be a string.
+   */
+  requiredString(name: string): string {
+    const value = this.optionalString(name);
+
+    if (value === undefined) {
+      this.refuse(`${name} must resolve to a string`);
+    }
+
+    return value;
+  }
+
+  /**
+   * A string property, or nothing when the deployment does not set it.
+   */
+  optionalString(name: string): string | undefined {
+    const value = this.value(name);
+
+    if (value === undefined) {
+      return undefined;
+    }
+
+    if (typeof value !== "string") {
+      this.refuse(`${name} must resolve to a string`);
+    }
+
+    return value;
+  }
+
+  /**
+   * A list of strings, empty when the deployment does not set it.
+   */
+  stringList(name: string): readonly string[] {
+    const value = this.value(name);
+
+    if (value === undefined) {
+      return [];
+    }
+
+    if (
+      !Array.isArray(value) ||
+      value.some((item) => typeof item !== "string")
+    ) {
+      this.refuse(`${name} must be an array of strings`);
+    }
+
+    return value as readonly string[];
+  }
+
+  /**
+   * A boolean property, falling back to the construct's own default.
+   *
+   * Anything other than a boolean is refused rather than read as truthy. This
+   * is what `Prune` comes through, and pruning deletes Objects, so a `"false"`
+   * quietly meaning `true` would delete the ones the template was keeping.
+   */
+  boolean(name: string, fallback: boolean): boolean {
+    const value = this.value(name);
+
+    if (value === undefined) {
+      return fallback;
+    }
+
+    if (typeof value !== "boolean") {
+      this.refuse(`${name} must be a boolean`);
+    }
+
+    return value;
+  }
+
+  /**
+   * A record of header names to values, keyed lowercase as a stored Object
+   * holds them.
+   */
+  headers(name: string): ReadonlyMap<string, string> {
+    const value = this.value(name);
+
+    if (value === undefined) {
+      return new Map();
+    }
+
+    if (typeof value !== "object" || Array.isArray(value) || value === null) {
+      this.refuse(`${name} must be an object`);
+    }
+
+    return new Map(
+      Object.entries(value).map(([headerName, headerValue]) => {
+        if (typeof headerValue !== "string") {
+          this.refuse(`${name} ${headerName} must be a string`);
+        }
+
+        return [headerName.toLowerCase(), headerValue] as const;
+      }),
+    );
+  }
+
+  private value(name: string): unknown {
+    // eslint-disable-next-line security/detect-object-injection -- name is a fixed property name from the caller
+    return this.properties[name];
+  }
+
+  private refuse(detail: string): never {
+    throw new TypeError(
+      `Custom::CDKBucketDeployment ${this.resource.logicalId}: ${detail}`,
+    );
+  }
+}

--- a/src/service/cloudformation/cdk/s3/bucket-deployment/sim-cdk-bucket-deployment-shared.iso.test.ts
+++ b/src/service/cloudformation/cdk/s3/bucket-deployment/sim-cdk-bucket-deployment-shared.iso.test.ts
@@ -1,0 +1,111 @@
+import { assertIdentical, assertNonNullable } from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../../aws/sim-aws.js";
+import { jsonStringify } from "../../../../../util/type-guard/json.js";
+import { TemporaryDirectory } from "../../../../../util/filesystem/temporary-directory.js";
+
+/**
+ * Two CDK BucketDeployments into one Bucket, which is the usual arrangement
+ * whenever the content headers differ by file type: a `BucketDeployment` sets
+ * them for all of its files at once, so a second deployment is how the rest of
+ * the site gets different ones.
+ */
+describe("CDK BucketDeployments sharing a destination Bucket [iso]", () => {
+  it("keeps both deployments' Objects, each with its own headers", async () => {
+    // Given a synthesized cloud assembly with two BucketDeployment assets into
+    // the same Bucket, the second of which does not prune.
+    const temporaryDirectory = new TemporaryDirectory();
+    const siteAsset = "asset.aaaa1111";
+    const dataAsset = "asset.bbbb2222";
+    const templatePathParts = ["cdk.out", "FooStack.template.json"];
+
+    await temporaryDirectory.writeFile(
+      ["cdk.out", siteAsset, "index.html"],
+      "<h1>Hello</h1>",
+    );
+    await temporaryDirectory.writeFile(
+      ["cdk.out", dataAsset, "data", "standard.keys"],
+      "compressed",
+    );
+
+    await temporaryDirectory.writeFile(
+      templatePathParts,
+      jsonStringify({
+        Resources: {
+          SiteBucket: {
+            Type: "AWS::S3::Bucket",
+            Properties: { BucketName: "site-bucket" },
+          },
+          DeploySite: {
+            Type: "Custom::CDKBucketDeployment",
+            Properties: {
+              DestinationBucketName: { Ref: "SiteBucket" },
+              SourceObjectKeys: ["site.zip"],
+              Exclude: ["data/*"],
+              SystemMetadata: { "cache-control": "public, max-age=0" },
+            },
+          },
+          DeployData: {
+            Type: "Custom::CDKBucketDeployment",
+            Properties: {
+              DestinationBucketName: { Ref: "SiteBucket" },
+              SourceObjectKeys: ["data.zip"],
+              Prune: false,
+              SystemMetadata: {
+                "cache-control": "public, max-age=31536000, immutable",
+                "content-encoding": "br",
+              },
+            },
+          },
+        },
+      }),
+    );
+
+    await temporaryDirectory.writeFile(
+      ["cdk.out", "FooStack.assets.json"],
+      jsonStringify({
+        files: {
+          site: {
+            source: { path: siteAsset, packaging: "zip" },
+            destinations: {
+              "current_account-current_region": { objectKey: "site.zip" },
+            },
+          },
+          data: {
+            source: { path: dataAsset, packaging: "zip" },
+            destinations: {
+              "current_account-current_region": { objectKey: "data.zip" },
+            },
+          },
+        },
+      }),
+    );
+
+    // When the template is deployed.
+    const simAws = new SimAws();
+
+    await simAws
+      .cloudFormation()
+      .deployTemplateFile(temporaryDirectory.join(...templatePathParts));
+
+    // Then the Bucket holds the files from both deployments, rather than only
+    // the last one to run.
+    const bucket = simAws.s3().getSimBucketByName("site-bucket");
+
+    assertNonNullable(bucket);
+
+    const page = await bucket.getObject("index.html");
+    const data = await bucket.getObject("data/standard.keys");
+
+    assertNonNullable(page);
+    assertNonNullable(data);
+
+    // And each carries the headers its own deployment set.
+    assertIdentical(page.metadata.values["cache-control"], "public, max-age=0");
+    assertIdentical(
+      data.metadata.values["cache-control"],
+      "public, max-age=31536000, immutable",
+    );
+    assertIdentical(data.metadata.values["content-encoding"], "br");
+  });
+});

--- a/src/service/cloudformation/cdk/s3/bucket-deployment/sim-cdk-bucket-deployment.iso.test.ts
+++ b/src/service/cloudformation/cdk/s3/bucket-deployment/sim-cdk-bucket-deployment.iso.test.ts
@@ -19,7 +19,7 @@ import type {
  * assets, without using real CDK synth.
  */
 describe("CDK BucketDeployment CloudFormation Custom Resource [iso]", () => {
-  it("configures the destination S3 Bucket with filesystem storage from the CDK asset", async () => {
+  it("copies the CDK asset into the destination S3 Bucket", async () => {
     // Given a synthesized CDK cloud assembly with a BucketDeployment asset.
     const temporaryDirectory = new TemporaryDirectory();
     const assetDirectoryName =
@@ -81,8 +81,8 @@ describe("CDK BucketDeployment CloudFormation Custom Resource [iso]", () => {
 
     await simAws.cloudFormation().deployTemplateFile(templatePath);
 
-    // Then the BucketDeployment configures the destination Bucket with
-    // filesystem storage rooted at the staged CDK asset.
+    // Then the BucketDeployment has copied the staged CDK asset's files into
+    // the destination Bucket as Objects.
     const bucket = simAws.s3().getSimBucketByName("site-bucket");
 
     assertNonNullable(bucket);

--- a/src/service/cloudformation/cdk/s3/bucket-deployment/sim-cdk-bucket-deployment.ts
+++ b/src/service/cloudformation/cdk/s3/bucket-deployment/sim-cdk-bucket-deployment.ts
@@ -1,12 +1,11 @@
-import path from "node:path";
-
-import { FilesystemS3BucketStorage } from "../../../../s3/storage/filesystem/s3-filesystem-storage.js";
 import type { SimCfnServiceResourceFactory } from "../../../resource/factory/sim-cfn-resource-factory.type.js";
 import type {
   SimCfnResource,
   SimCloudFormationResourceCreateContext,
 } from "../../../resource/sim-cfn-resource.js";
 import { SimCdkBucketDeploySource } from "./source/sim-cdk-bucket-deploy-source.js";
+import { SimCdkBucketDeployCopier } from "./copy/sim-cdk-bucket-deploy-copier.js";
+import { SimCdkBucketDeployProperties } from "./property/sim-cdk-bucket-deploy-properties.js";
 import { assertDefined } from "../../../../../util/type-guard/defined.js";
 
 /**
@@ -16,7 +15,7 @@ export class SimCdkBucketDeploymentResourceFactory implements SimCfnServiceResou
   private readonly sourceResolver = new SimCdkBucketDeploySource();
 
   /**
-   * Configure a simulated destination S3 Bucket for a CDK BucketDeployment.
+   * Copy a CDK BucketDeployment's staged asset into its destination Bucket.
    */
   async create(
     resourceTypeName: string,
@@ -29,9 +28,7 @@ export class SimCdkBucketDeploymentResourceFactory implements SimCfnServiceResou
       );
     }
 
-    this.createCdkBucketDeployment(resource, context);
-
-    await Promise.resolve();
+    await this.createCdkBucketDeployment(resource, context);
 
     return undefined;
   }
@@ -55,51 +52,14 @@ export class SimCdkBucketDeploymentResourceFactory implements SimCfnServiceResou
     }
   }
 
-  private createCdkBucketDeployment(
+  private async createCdkBucketDeployment(
     resource: SimCfnResource,
     context: SimCloudFormationResourceCreateContext,
-  ): void {
-    const properties = context.resolvedProperties ?? resource.properties;
-    const destinationBucketName = properties["DestinationBucketName"];
-
-    /* v8 ignore if -- defensive catch */
-    if (typeof destinationBucketName !== "string") {
-      throw new TypeError(
-        "Custom::CDKBucketDeployment DestinationBucketName must resolve to a string",
-      );
-    }
-
-    const sourceObjectKeys = properties["SourceObjectKeys"];
-    /* v8 ignore if -- defensive catch */
-    if (!Array.isArray(sourceObjectKeys)) {
-      throw new TypeError(
-        "Custom::CDKBucketDeployment SourceObjectKeys must be an array",
-      );
-    }
-
-    /* v8 ignore if -- defensive catch */
-    if (sourceObjectKeys.length !== 1) {
-      throw new Error(
-        "Custom::CDKBucketDeployment currently supports exactly one source object key",
-      );
-    }
-
-    const [sourceObjectKey] = sourceObjectKeys;
-
-    /* v8 ignore if -- defensive catch */
-    if (typeof sourceObjectKey !== "string") {
-      throw new TypeError(
-        "Custom::CDKBucketDeployment SourceObjectKeys must contain a string object key",
-      );
-    }
-
-    const sourceDirectoryPath =
-      this.sourceResolver.sourceDirectoryPathForObjectKey(
-        resource,
-        sourceObjectKey,
-        context.cdkOutContext,
-      );
-    const sourceDirectoryName = path.basename(sourceDirectoryPath);
+  ): Promise<void> {
+    const properties = new SimCdkBucketDeployProperties(
+      resource,
+      context.resolvedProperties ?? resource.properties,
+    );
 
     const bucket = context.simAws
       .accountRegionScope(
@@ -107,18 +67,23 @@ export class SimCdkBucketDeploymentResourceFactory implements SimCfnServiceResou
         resource.accountRegionScope.regionName,
       )
       .s3()
-      .getSimBucketByName(destinationBucketName);
+      .getSimBucketByName(properties.destinationBucketName);
     assertDefined(
       bucket,
-      `Custom::CDKBucketDeployment destination Bucket ${destinationBucketName} does not exist`,
+      `Custom::CDKBucketDeployment destination Bucket ${properties.destinationBucketName} does not exist`,
     );
 
-    bucket.configureSimStorage(
-      new FilesystemS3BucketStorage({
-        directoryPath: sourceDirectoryPath,
-        // Specifically allow the cdk.out asset directory we want to mount.
-        allowedDirectoryNames: [sourceDirectoryName],
-      }),
+    const sourceDirectoryPaths = properties.sourceObjectKeys.map(
+      (sourceObjectKey) =>
+        this.sourceResolver.sourceDirectoryPathForObjectKey(
+          resource,
+          sourceObjectKey,
+          context.cdkOutContext,
+        ),
+    );
+
+    await new SimCdkBucketDeployCopier({ bucket, properties }).copy(
+      sourceDirectoryPaths,
     );
   }
 }

--- a/src/service/cloudformation/resource/cfn/cloudfront/sim-cloudfront-cfn-value-adapter.ts
+++ b/src/service/cloudformation/resource/cfn/cloudfront/sim-cloudfront-cfn-value-adapter.ts
@@ -2,6 +2,8 @@ import { SimCloudFrontDistribution } from "../../../../cloudfront/distribution/s
 import { SimCloudFrontDistributionCfn } from "./sim-cloudfront-distribution-cfn.js";
 import { SimCloudFrontFunction } from "../../../../cloudfront/cff/sim-cloudfront-function.js";
 import { SimCloudFrontFunctionCfn } from "./sim-cloudfront-function-cfn.js";
+import { SimCloudFrontResponseHeadersPolicy } from "../../../../cloudfront/response-headers-policy/sim-cf-response-headers-policy.js";
+import { SimCloudFrontResponseHeadersPolicyCfn } from "./sim-cloudfront-rh-policy-cfn.js";
 import type {
   SimCfnResourceValueAdapterProperties,
   SimCfnServiceValueAdapter,
@@ -26,6 +28,15 @@ export function cloudFrontValueAdapter(
   ) {
     return new SimCloudFrontFunctionCfn({
       cloudFrontFunction: properties.simResource,
+    });
+  }
+
+  if (
+    properties.type === "AWS::CloudFront::ResponseHeadersPolicy" &&
+    properties.simResource instanceof SimCloudFrontResponseHeadersPolicy
+  ) {
+    return new SimCloudFrontResponseHeadersPolicyCfn({
+      policy: properties.simResource,
     });
   }
 

--- a/src/service/cloudformation/resource/cfn/cloudfront/sim-cloudfront-rh-policy-cfn.iso.test.ts
+++ b/src/service/cloudformation/resource/cfn/cloudfront/sim-cloudfront-rh-policy-cfn.iso.test.ts
@@ -1,0 +1,54 @@
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimCloudFrontResponseHeadersPolicy } from "../../../../cloudfront/response-headers-policy/sim-cf-response-headers-policy.js";
+import { cloudFrontValueAdapter } from "./sim-cloudfront-cfn-value-adapter.js";
+import { SimCloudFrontResponseHeadersPolicyCfn } from "./sim-cloudfront-rh-policy-cfn.js";
+
+describe("SimCloudFrontResponseHeadersPolicyCfn", () => {
+  const policy = new SimCloudFrontResponseHeadersPolicy({
+    name: "CacheHeaders",
+  });
+  const adapter = new SimCloudFrontResponseHeadersPolicyCfn({ policy });
+
+  it("answers a Ref with the policy ID", () => {
+    // Given a created policy.
+    // When a template Refs it, then it gets the ID a Cache Behavior's
+    // ResponseHeadersPolicyId wants.
+    assertIdentical(adapter.refValue(), policy.id);
+  });
+
+  it("answers the Id attribute with the policy ID", () => {
+    // Given a created policy.
+    // When a template reads its Id attribute, then it gets the same ID.
+    assertIdentical(adapter.attributeValue("Id"), policy.id);
+  });
+
+  it("is the adapter the CloudFront registry picks for the Resource type", () => {
+    // Given a created policy stored against its Resource type.
+    // When the CloudFront value adapter registry is asked for one.
+    const resolved = cloudFrontValueAdapter({
+      logicalId: "CacheHeaders",
+      type: "AWS::CloudFront::ResponseHeadersPolicy",
+      simResource: policy,
+    });
+
+    // Then the policy's own adapter answers, rather than the default one.
+    assertInstanceOf(resolved, SimCloudFrontResponseHeadersPolicyCfn);
+  });
+
+  it("leaves a Resource of another type to another service", () => {
+    // Given a policy under a Resource type it does not belong to.
+    // When the CloudFront registry is asked, then it claims nothing.
+    assertUndefined(
+      cloudFrontValueAdapter({
+        logicalId: "SomethingElse",
+        type: "AWS::SomeOther::Thing",
+        simResource: policy,
+      }),
+    );
+  });
+});

--- a/src/service/cloudformation/resource/cfn/cloudfront/sim-cloudfront-rh-policy-cfn.ts
+++ b/src/service/cloudformation/resource/cfn/cloudfront/sim-cloudfront-rh-policy-cfn.ts
@@ -1,0 +1,42 @@
+import type { SimCfnTemplateValue } from "../../../template/value/sim-cfn-template-value.js";
+import type { SimCloudFrontResponseHeadersPolicy } from "../../../../cloudfront/response-headers-policy/sim-cf-response-headers-policy.js";
+import type { SimCfnResourceValueAdapter } from "../sim-cfn-resource-value-adapter.js";
+
+interface SimCloudFrontResponseHeadersPolicyCfnProperties {
+  readonly policy: SimCloudFrontResponseHeadersPolicy;
+}
+
+/**
+ * CloudFormation-facing behavior for an AWS::CloudFront::ResponseHeadersPolicy
+ * Resource.
+ */
+export class SimCloudFrontResponseHeadersPolicyCfn implements SimCfnResourceValueAdapter {
+  private readonly policy: SimCloudFrontResponseHeadersPolicy;
+
+  constructor(properties: SimCloudFrontResponseHeadersPolicyCfnProperties) {
+    this.policy = properties.policy;
+  }
+
+  /**
+   * CloudFormation Ref for AWS::CloudFront::ResponseHeadersPolicy returns the
+   * policy ID, which is what a Cache Behavior's ResponseHeadersPolicyId wants.
+   */
+  refValue(): SimCfnTemplateValue {
+    return this.policy.id;
+  }
+
+  /**
+   * CloudFormation attributes for AWS::CloudFront::ResponseHeadersPolicy.
+   */
+  attributeValue(attributeName: string): SimCfnTemplateValue {
+    switch (attributeName) {
+      case "Id": {
+        return this.policy.id;
+      }
+      default: {
+        /* v8 ignore next */
+        return `${this.policy.id}.${attributeName}`;
+      }
+    }
+  }
+}

--- a/src/service/cloudfront/README.md
+++ b/src/service/cloudfront/README.md
@@ -123,6 +123,10 @@ HTTP request behaviour is split across a few directories:
   Origin fetch and before the viewer-response CloudFront Function. The response page is fetched
   through the same Behavior resolution and Origin fetching as any other request, so it can come from
   an Origin of its own.
+  `controller/response-headers/` applies the Behavior's response headers policy, after the custom
+  error response and before the viewer-response CloudFront Function. That ordering is CloudFront's
+  own: an error page carries the policy's headers, and a function sees them in its event and can
+  change them.
 - `router/` resolves an incoming `Request` to a simulated Distribution by CloudFront hostname or
   alternate domain name.
 - `resolver/` chooses the matching Cache Behavior for a request path.
@@ -146,6 +150,24 @@ Important pieces include:
 
 CloudFront Functions are represented as JavaScript handlers and can be associated with viewer
 request and viewer response events on cache Behaviors.
+
+## Response headers policies
+
+`response-headers-policy/` holds the policy model. A `SimCloudFrontResponseHeadersPolicy` is a name,
+an ID and two lists: the headers to add and the headers to remove. Removal happens first, so a header
+in both ends up present with the policy's value. Each added header carries an `Override` deciding
+whether it replaces one the Origin sent.
+
+Policies are stored on `SimCloudFront` and found by ID, which is what a Behavior's
+`responseHeadersPolicyId` names. There is no CreateResponseHeadersPolicy command, so
+`cfn/response-headers-policy/` is the only thing that makes one. Its config reader models the custom
+and removed headers, and refuses `CorsConfig`, `SecurityHeadersConfig` and `ServerTimingHeadersConfig`
+by name: each sets headers of its own, and a policy that quietly sets fewer here than in AWS is a
+divergence a passing test would hide.
+
+A lookup miss is `SimCloudFrontNoSuchResponseHeadersPolicy` rather than a pass-through, because the
+common cause is a managed policy ID, which names a policy AWS owns rather than one a template
+creates.
 
 ## Cross-service integration
 

--- a/src/service/cloudfront/README.md
+++ b/src/service/cloudfront/README.md
@@ -40,7 +40,8 @@ Current command areas include:
 - `create-function/`
 - `delete-function/`
 
-The main `SimCloudFront` class owns the Distribution and Function maps and nothing else.
+The main `SimCloudFront` class owns the Distribution, Function and response headers policy maps
+and nothing else.
 `SimCloudFrontCommands` holds the collaborators every command shares (IAM, the registry, the Origin
 resolvers, the background scheduler) and builds the handlers, so the facade stays state plus
 delegation.

--- a/src/service/cloudfront/behaviour/sim-cloud-front-behavior.ts
+++ b/src/service/cloudfront/behaviour/sim-cloud-front-behavior.ts
@@ -8,6 +8,10 @@ export interface SimCloudFrontBehavior {
   cachedMethods: Set<string>;
   viewerProtocolPolicy?: "allow-all" | "redirect-to-https" | "https-only";
   originPath?: string;
+  /**
+   * The response headers policy applied to every response this Behavior serves.
+   */
+  responseHeadersPolicyId?: string | undefined;
   functionAssociations?:
     | undefined
     | {

--- a/src/service/cloudfront/cfn/distro/sim-cfn-cf-distro-response-headers.iso.test.ts
+++ b/src/service/cloudfront/cfn/distro/sim-cfn-cf-distro-response-headers.iso.test.ts
@@ -223,6 +223,41 @@ describe("CloudFormation Distribution response headers policies", () => {
     );
   });
 
+  it("fails the stack for a second policy claiming a name", async () => {
+    // Given a template declaring two response headers policies with one name,
+    // which CloudFront refuses because a policy name is unique in an account.
+    const simAws = new SimAws();
+
+    const error = await assertThrowsErrorAsync(async () => {
+      const stack = await simAws.cloudFormation().deployTemplate({
+        stackName: "duplicate-policy-name-stack",
+        template: {
+          Resources: {
+            CacheHeaders: {
+              Type: "AWS::CloudFront::ResponseHeadersPolicy",
+              Properties: {
+                ResponseHeadersPolicyConfig: { Name: "CacheHeaders" },
+              },
+            },
+            MoreCacheHeaders: {
+              Type: "AWS::CloudFront::ResponseHeadersPolicy",
+              DependsOn: "CacheHeaders",
+              Properties: {
+                ResponseHeadersPolicyConfig: { Name: "CacheHeaders" },
+              },
+            },
+          },
+        },
+      });
+
+      await stack.waitForDeployComplete();
+    });
+
+    // Then the second one is refused, rather than both deploying under IDs of
+    // their own and diverging from what AWS would have done.
+    assertStringIncludes(error.message, "CacheHeaders already exists");
+  });
+
   it("fails the stack for a policy section it does not model", async () => {
     // Given a template whose policy sets security headers, which this
     // simulation does not model.

--- a/src/service/cloudfront/cfn/distro/sim-cfn-cf-distro-response-headers.iso.test.ts
+++ b/src/service/cloudfront/cfn/distro/sim-cfn-cf-distro-response-headers.iso.test.ts
@@ -1,0 +1,254 @@
+import { describe, it } from "vitest";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertResponseStatus,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  describeResponse,
+} from "@kensio/smartass";
+import { PutObjectCommand } from "@aws-sdk/client-s3";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import type { CfnTemplateBodyRecord } from "../../../cloudformation/template/sim-cfn-template.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import { SimCloudFrontDistribution } from "../../distribution/sim-cloudfront-distribution.js";
+import { SimCloudFrontResponseHeadersPolicy } from "../../response-headers-policy/sim-cf-response-headers-policy.js";
+import { simCfSiteRequest } from "../../../../../test/cloudfront/site-fixture.js";
+
+/**
+ * A template declaring a response headers policy and a Distribution applying
+ * it, the way CDK synthesizes the pair.
+ */
+function siteTemplate(
+  policyConfig: SimCfnTemplateValueRecord,
+  distributionConfig: SimCfnTemplateValueRecord = {},
+): CfnTemplateBodyRecord {
+  return {
+    Resources: {
+      SiteBucket: {
+        Type: "AWS::S3::Bucket",
+        Properties: { BucketName: "headers-site-bucket" },
+      },
+      CacheHeaders: {
+        Type: "AWS::CloudFront::ResponseHeadersPolicy",
+        Properties: { ResponseHeadersPolicyConfig: policyConfig },
+      },
+      SiteDistribution: {
+        Type: "AWS::CloudFront::Distribution",
+        DependsOn: ["SiteBucket", "CacheHeaders"],
+        Properties: {
+          DistributionConfig: {
+            DefaultRootObject: "index.html",
+            CustomErrorResponses: [
+              {
+                ErrorCode: 404,
+                ResponsePagePath: "/404.html",
+                ResponseCode: 404,
+              },
+            ],
+            Origins: [
+              {
+                Id: "SiteOrigin",
+                DomainName: "headers-site-bucket.s3.amazonaws.com",
+                S3OriginConfig: {},
+              },
+            ],
+            DefaultCacheBehavior: {
+              TargetOriginId: "SiteOrigin",
+              ViewerProtocolPolicy: "redirect-to-https",
+              ResponseHeadersPolicyId: { Ref: "CacheHeaders" },
+            },
+            ...distributionConfig,
+          },
+        },
+      },
+    },
+  };
+}
+
+describe("CloudFormation Distribution response headers policies", () => {
+  async function deployedSite(
+    policyConfig: SimCfnTemplateValueRecord,
+  ): Promise<{ simAws: SimAws; distributionId: string }> {
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "response-headers-stack",
+      template: siteTemplate(policyConfig),
+    });
+
+    const resource = stack.getResource("SiteDistribution");
+
+    assertNonNullable(resource);
+    assertInstanceOf(resource.simResource, SimCloudFrontDistribution);
+
+    await simAws.s3().putObject(
+      new PutObjectCommand({
+        Bucket: "headers-site-bucket",
+        Key: "index.html",
+        ContentType: "text/html",
+        Body: "<h1>Home</h1>",
+      }),
+    );
+    await simAws.s3().putObject(
+      new PutObjectCommand({
+        Bucket: "headers-site-bucket",
+        Key: "404.html",
+        ContentType: "text/html",
+        Body: "<h1>Not found</h1>",
+      }),
+    );
+
+    return { simAws, distributionId: resource.simResource.distributionId };
+  }
+
+  it("applies a policy's headers to what the Distribution serves", async () => {
+    // Given a Distribution whose default Behavior names a policy setting a
+    // cache directive.
+    const { simAws, distributionId } = await deployedSite({
+      Name: "CacheHeaders",
+      CustomHeadersConfig: {
+        Items: [
+          {
+            Header: "Cache-Control",
+            Override: true,
+            Value: "public, max-age=0, must-revalidate",
+          },
+        ],
+      },
+    });
+
+    // When a page is requested.
+    const home = await simCfSiteRequest(simAws, distributionId, "/");
+
+    // Then the policy's header is on the response.
+    assertResponseStatus(home, 200, await describeResponse(home));
+    assertIdentical(
+      home.headers.get("cache-control"),
+      "public, max-age=0, must-revalidate",
+    );
+  });
+
+  it("applies a policy to a custom error page too", async () => {
+    // Given the same Distribution, which answers a missing page with a custom
+    // error response.
+    const { simAws, distributionId } = await deployedSite({
+      Name: "CacheHeaders",
+      CustomHeadersConfig: {
+        Items: [{ Header: "Vary", Override: true, Value: "Accept-Encoding" }],
+      },
+    });
+
+    // When a page that does not exist is requested.
+    const missing = await simCfSiteRequest(simAws, distributionId, "/missing");
+
+    // Then the error page carries the policy's headers, because CloudFront
+    // applies a policy after the response leaves the cache.
+    assertResponseStatus(missing, 404, await describeResponse(missing));
+    assertIdentical(missing.headers.get("vary"), "Accept-Encoding");
+    assertIdentical(await missing.text(), "<h1>Not found</h1>");
+  });
+
+  it("keeps an Origin header the policy does not override", async () => {
+    // Given a policy setting the content type the Origin already sets, without
+    // Override.
+    const { simAws, distributionId } = await deployedSite({
+      Name: "CacheHeaders",
+      CustomHeadersConfig: {
+        Items: [
+          { Header: "Content-Type", Override: false, Value: "text/plain" },
+        ],
+      },
+    });
+
+    // When a page is requested.
+    const home = await simCfSiteRequest(simAws, distributionId, "/");
+
+    // Then the Origin's value stands, as it does in CloudFront.
+    assertIdentical(home.headers.get("content-type"), "text/html");
+  });
+
+  it("removes a header the policy is told to remove", async () => {
+    // Given a policy removing a header the S3 Origin sets.
+    const { simAws, distributionId } = await deployedSite({
+      Name: "CacheHeaders",
+      RemoveHeadersConfig: { Items: [{ Header: "Content-Type" }] },
+    });
+
+    // When a page is requested.
+    const home = await simCfSiteRequest(simAws, distributionId, "/");
+
+    // Then the header is gone.
+    assertIdentical(home.headers.get("content-type"), null);
+  });
+
+  it("stores the policy under the ID a Ref gives the Distribution", async () => {
+    // Given a deployed template.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "response-headers-ref-stack",
+      template: siteTemplate({
+        Name: "CacheHeaders",
+        CustomHeadersConfig: {
+          Items: [{ Header: "Vary", Override: true, Value: "Accept-Encoding" }],
+        },
+      }),
+    });
+
+    const policyResource = stack.getResource("CacheHeaders");
+
+    assertNonNullable(policyResource);
+    assertInstanceOf(
+      policyResource.simResource,
+      SimCloudFrontResponseHeadersPolicy,
+    );
+
+    // Then a Ref to the policy is its ID, and the Distribution can find it.
+    const distributionResource = stack.getResource("SiteDistribution");
+
+    assertNonNullable(distributionResource);
+    assertInstanceOf(
+      distributionResource.simResource,
+      SimCloudFrontDistribution,
+    );
+    assertIdentical(
+      distributionResource.simResource.behaviors[0]?.responseHeadersPolicyId,
+      policyResource.simResource.id,
+    );
+    assertNonNullable(
+      simAws
+        .cloudFront()
+        .getResponseHeadersPolicyById(policyResource.simResource.id),
+    );
+  });
+
+  it("fails the stack for a policy section it does not model", async () => {
+    // Given a template whose policy sets security headers, which this
+    // simulation does not model.
+    const simAws = new SimAws();
+
+    // When the template is deployed, then it fails rather than serving
+    // responses missing the headers the policy promised.
+    const error = await assertThrowsErrorAsync(async () => {
+      const stack = await simAws.cloudFormation().deployTemplate({
+        stackName: "unmodelled-section-stack",
+        template: siteTemplate({
+          Name: "CacheHeaders",
+          SecurityHeadersConfig: {
+            StrictTransportSecurity: {
+              AccessControlMaxAgeSec: 31_536_000,
+              Override: true,
+            },
+          },
+        }),
+      });
+
+      await stack.waitForDeployComplete();
+    });
+
+    // And the section is named for diagnosis.
+    assertStringIncludes(error.message, "SecurityHeadersConfig");
+    assertStringIncludes(error.message, "CacheHeaders");
+  });
+});

--- a/src/service/cloudfront/cfn/response-headers-policy/sim-cfn-cf-rh-policy-config.iso.test.ts
+++ b/src/service/cloudfront/cfn/response-headers-policy/sim-cfn-cf-rh-policy-config.iso.test.ts
@@ -1,0 +1,192 @@
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsError,
+  assertTrue,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimCloudFrontResponseHeadersPolicy } from "../../response-headers-policy/sim-cf-response-headers-policy.js";
+import { SimCfnCfResponseHeadersPolicyConfig } from "./sim-cfn-cf-rh-policy-config.js";
+
+describe("SimCfnCfResponseHeadersPolicyConfig", () => {
+  const resource = new SimCfnResource({ logicalId: "CacheHeaders" });
+
+  function policyFrom(
+    config: SimCfnTemplateValueRecord,
+  ): SimCloudFrontResponseHeadersPolicy {
+    return new SimCfnCfResponseHeadersPolicyConfig({
+      resource,
+      properties: {
+        ResponseHeadersPolicyConfig: { Name: "CacheHeaders", ...config },
+      },
+    }).build();
+  }
+
+  it("reads the custom headers a policy sets", () => {
+    // Given the config CDK synthesizes for a policy adding one header.
+    const policy = policyFrom({
+      CustomHeadersConfig: {
+        Items: [
+          {
+            Header: "Cache-Control",
+            Override: true,
+            Value: "public, max-age=0",
+          },
+        ],
+      },
+    });
+
+    // Then the header, its value and its Override are read.
+    assertIdentical(policy.name, "CacheHeaders");
+    assertArrayLength(policy.customHeaders, 1);
+
+    const [header] = policy.customHeaders;
+
+    assertNonNullable(header);
+    assertIdentical(header.name, "Cache-Control");
+    assertIdentical(header.value, "public, max-age=0");
+    assertTrue(header.override);
+  });
+
+  it("reads the headers a policy removes", () => {
+    // Given a policy config removing a header.
+    const policy = policyFrom({
+      RemoveHeadersConfig: { Items: [{ Header: "Server" }] },
+    });
+
+    // Then the name is read.
+    assertArrayLength(policy.headersToRemove, 1);
+    assertIdentical(policy.headersToRemove[0], "Server");
+  });
+
+  it("reads a policy that sets and removes nothing", () => {
+    // Given a policy config with neither section.
+    const policy = policyFrom({});
+
+    // Then it has no headers either way, rather than failing to build.
+    assertArrayLength(policy.customHeaders, 0);
+    assertArrayLength(policy.headersToRemove, 0);
+  });
+
+  it("reads a section with no items", () => {
+    // Given a policy config whose sections are present but empty.
+    const policy = policyFrom({
+      CustomHeadersConfig: {},
+      RemoveHeadersConfig: {},
+    });
+
+    // Then it has no headers either way.
+    assertArrayLength(policy.customHeaders, 0);
+    assertArrayLength(policy.headersToRemove, 0);
+  });
+
+  it("refuses each section it does not model, by name", () => {
+    // Given policy configs using the sections this simulation does not model.
+    // When each is read, then it is refused by name rather than stepped over,
+    // because a policy that quietly sets fewer headers here than in AWS is a
+    // divergence a test would not catch.
+    for (const section of [
+      "CorsConfig",
+      "SecurityHeadersConfig",
+      "ServerTimingHeadersConfig",
+    ]) {
+      const error = assertThrowsError(() => policyFrom({ [section]: {} }));
+
+      assertStringIncludes(error.message, section);
+      assertStringIncludes(error.message, "CacheHeaders");
+    }
+  });
+
+  it("refuses a policy config that is not an object", () => {
+    // Given a Resource whose policy config did not resolve to an object.
+    // When it is read, then it is refused.
+    const error = assertThrowsError(() =>
+      new SimCfnCfResponseHeadersPolicyConfig({
+        resource,
+        properties: { ResponseHeadersPolicyConfig: "nope" },
+      }).build(),
+    );
+
+    assertStringIncludes(
+      error.message,
+      "ResponseHeadersPolicyConfig must be an object",
+    );
+  });
+
+  it("refuses a policy with no name", () => {
+    // Given a policy config missing its Name.
+    // When it is read, then it is refused.
+    const error = assertThrowsError(() =>
+      new SimCfnCfResponseHeadersPolicyConfig({
+        resource,
+        properties: { ResponseHeadersPolicyConfig: {} },
+      }).build(),
+    );
+
+    assertStringIncludes(error.message, "Name must be a string");
+  });
+
+  it("refuses a custom header missing its Header, Value or Override", () => {
+    // Given policy configs whose header items are incomplete.
+    // When each is read, then it is refused by what is missing.
+    assertStringIncludes(
+      assertThrowsError(() =>
+        policyFrom({
+          CustomHeadersConfig: { Items: [{ Override: true, Value: "x" }] },
+        }),
+      ).message,
+      "need a string Header and Value",
+    );
+    assertStringIncludes(
+      assertThrowsError(() =>
+        policyFrom({
+          CustomHeadersConfig: { Items: [{ Header: "Vary", Value: "x" }] },
+        }),
+      ).message,
+      "CustomHeadersConfig item Vary needs a boolean Override",
+    );
+  });
+
+  it("refuses a custom header item that is not an object", () => {
+    // Given a policy config whose header item is not an object.
+    // When it is read, then it is refused.
+    assertStringIncludes(
+      assertThrowsError(() =>
+        policyFrom({ CustomHeadersConfig: { Items: ["Vary"] } }),
+      ).message,
+      "CustomHeadersConfig items must be objects",
+    );
+  });
+
+  it("refuses a removed header item without a name", () => {
+    // Given a policy config whose removal item names nothing.
+    // When it is read, then it is refused.
+    assertStringIncludes(
+      assertThrowsError(() =>
+        policyFrom({ RemoveHeadersConfig: { Items: [{}] } }),
+      ).message,
+      "RemoveHeadersConfig items need a string Header",
+    );
+  });
+
+  it("refuses a section or its items of the wrong shape", () => {
+    // Given policy configs whose sections are not objects or whose items are
+    // not arrays.
+    // When each is read, then it is refused by name.
+    assertStringIncludes(
+      assertThrowsError(() => policyFrom({ CustomHeadersConfig: "nope" }))
+        .message,
+      "CustomHeadersConfig must be an object",
+    );
+    assertStringIncludes(
+      assertThrowsError(() =>
+        policyFrom({ RemoveHeadersConfig: { Items: "nope" } }),
+      ).message,
+      "RemoveHeadersConfig Items must be an array",
+    );
+  });
+});

--- a/src/service/cloudfront/cfn/response-headers-policy/sim-cfn-cf-rh-policy-config.ts
+++ b/src/service/cloudfront/cfn/response-headers-policy/sim-cfn-cf-rh-policy-config.ts
@@ -1,0 +1,173 @@
+import { isRecord } from "../../../../util/type-guard/record.js";
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import { SimCloudFrontResponseHeader } from "../../response-headers-policy/sim-cf-response-header.js";
+import { SimCloudFrontResponseHeadersPolicy } from "../../response-headers-policy/sim-cf-response-headers-policy.js";
+
+/**
+ * The sections of a ResponseHeadersPolicyConfig this simulation does not model.
+ *
+ * Each of these turns into response headers of its own, so ignoring one would
+ * serve a response missing headers the policy promised. A CORS section that
+ * quietly does nothing is the worst of them, because the request it breaks is
+ * one a browser makes and a test does not.
+ */
+const unmodelledSections = [
+  "CorsConfig",
+  "SecurityHeadersConfig",
+  "ServerTimingHeadersConfig",
+] as const;
+
+/**
+ * Reads an AWS::CloudFront::ResponseHeadersPolicy Resource into a simulated
+ * policy.
+ *
+ * Only the custom headers and the removed headers are modelled. The other
+ * sections are refused by name rather than stepped over, so a policy that would
+ * serve different headers here than in AWS fails where it is written.
+ */
+export class SimCfnCfResponseHeadersPolicyConfig {
+  private readonly resource: SimCfnResource;
+  private readonly properties: SimCfnTemplateValueRecord;
+
+  constructor(properties: {
+    readonly resource: SimCfnResource;
+    readonly properties: SimCfnTemplateValueRecord;
+  }) {
+    this.resource = properties.resource;
+    this.properties = properties.properties;
+  }
+
+  /**
+   * Build the simulated policy this Resource describes.
+   */
+  build(): SimCloudFrontResponseHeadersPolicy {
+    const config = this.policyConfig();
+
+    this.assertModelled(config);
+
+    return new SimCloudFrontResponseHeadersPolicy({
+      name: this.policyName(config),
+      customHeaders: this.customHeaders(config),
+      headersToRemove: this.headersToRemove(config),
+    });
+  }
+
+  private policyConfig(): Record<string, unknown> {
+    const config = this.properties["ResponseHeadersPolicyConfig"];
+
+    if (!isRecord(config)) {
+      this.refuse(`ResponseHeadersPolicyConfig must be an object`);
+    }
+
+    return config;
+  }
+
+  private assertModelled(config: Record<string, unknown>): void {
+    for (const section of unmodelledSections) {
+      // eslint-disable-next-line security/detect-object-injection
+      if (config[section] !== undefined) {
+        this.refuse(
+          `${section} is not modelled by simulated response headers ` +
+            `policies, so the headers it sets would be missing from the ` +
+            `response`,
+        );
+      }
+    }
+  }
+
+  private policyName(config: Record<string, unknown>): string {
+    const name = config["Name"];
+
+    if (typeof name !== "string") {
+      this.refuse(`ResponseHeadersPolicyConfig Name must be a string`);
+    }
+
+    return name;
+  }
+
+  private customHeaders(
+    config: Record<string, unknown>,
+  ): SimCloudFrontResponseHeader[] {
+    return this.configItems(config, "CustomHeadersConfig").map((item) => {
+      if (!isRecord(item)) {
+        this.refuse(`CustomHeadersConfig items must be objects`);
+      }
+
+      return this.customHeader(item);
+    });
+  }
+
+  private customHeader(
+    item: Record<string, unknown>,
+  ): SimCloudFrontResponseHeader {
+    const name = item["Header"];
+    const value = item["Value"];
+
+    if (typeof name !== "string" || typeof value !== "string") {
+      this.refuse(`CustomHeadersConfig items need a string Header and Value`);
+    }
+
+    // Override is required by the CloudFormation schema, so anything else here
+    // is a template that would be refused before it reached a policy at all.
+    const override = item["Override"];
+
+    if (typeof override !== "boolean") {
+      this.refuse(`CustomHeadersConfig item ${name} needs a boolean Override`);
+    }
+
+    return new SimCloudFrontResponseHeader({ name, value, override });
+  }
+
+  private headersToRemove(config: Record<string, unknown>): string[] {
+    return this.configItems(config, "RemoveHeadersConfig").map((item) => {
+      const name = isRecord(item) ? item["Header"] : undefined;
+
+      if (typeof name !== "string") {
+        this.refuse(`RemoveHeadersConfig items need a string Header`);
+      }
+
+      return name;
+    });
+  }
+
+  /**
+   * The `Items` of one `<name>Config` section, or nothing when it is absent.
+   */
+  private configItems(
+    config: Record<string, unknown>,
+    sectionName: string,
+  ): unknown[] {
+    // eslint-disable-next-line security/detect-object-injection
+    const section = config[sectionName];
+
+    if (section === undefined) {
+      return [];
+    }
+
+    if (!isRecord(section)) {
+      this.refuse(`${sectionName} must be an object`);
+    }
+
+    const items = section["Items"];
+
+    if (items === undefined) {
+      return [];
+    }
+
+    if (!Array.isArray(items)) {
+      this.refuse(`${sectionName} Items must be an array`);
+    }
+
+    return items;
+  }
+
+  /**
+   * Refuse this Resource, saying which part of it could not be read.
+   */
+  private refuse(detail: string): never {
+    throw new Error(
+      `Invalid AWS::CloudFront::ResponseHeadersPolicy ${this.resource.logicalId}: ${detail}`,
+    );
+  }
+}

--- a/src/service/cloudfront/cfn/response-headers-policy/sim-cfn-cf-rh-policy-creator.ts
+++ b/src/service/cloudfront/cfn/response-headers-policy/sim-cfn-cf-rh-policy-creator.ts
@@ -1,0 +1,52 @@
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimCloudFront } from "../../sim-cloudfront.js";
+import type { SimCloudFrontResponseHeadersPolicy } from "../../response-headers-policy/sim-cf-response-headers-policy.js";
+import { SimCfnCfResponseHeadersPolicyConfig } from "./sim-cfn-cf-rh-policy-config.js";
+
+interface SimCfnCfResponseHeadersPolicyCreatorProperties {
+  readonly cloudFront: SimCloudFront;
+}
+
+/**
+ * Creates simulated response headers policies from
+ * AWS::CloudFront::ResponseHeadersPolicy Resources.
+ */
+export class SimCfnCfResponseHeadersPolicyCreator {
+  private readonly cloudFront: SimCloudFront;
+
+  constructor(properties: SimCfnCfResponseHeadersPolicyCreatorProperties) {
+    this.cloudFront = properties.cloudFront;
+  }
+
+  /**
+   * Create and store the policy one Resource describes.
+   */
+  create(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): SimCloudFrontResponseHeadersPolicy {
+    const policy = new SimCfnCfResponseHeadersPolicyConfig({
+      resource,
+      properties,
+    }).build();
+
+    this.cloudFront.addResponseHeadersPolicy(policy);
+
+    return policy;
+  }
+
+  /**
+   * Remove a policy created from a Resource.
+   */
+  delete(resource: SimCfnResource): void {
+    const policy = resource.simResource as
+      SimCloudFrontResponseHeadersPolicy | undefined;
+
+    if (policy === undefined) {
+      return;
+    }
+
+    this.cloudFront.removeResponseHeadersPolicy(policy.id);
+  }
+}

--- a/src/service/cloudfront/cfn/sim-cfn-cloudfront-resource-factory.iso.test.ts
+++ b/src/service/cloudfront/cfn/sim-cfn-cloudfront-resource-factory.iso.test.ts
@@ -4,6 +4,7 @@ import {
   assertNonNullable,
   assertThrowsErrorAsync,
   assertTrue,
+  assertUndefined,
 } from "@kensio/smartass";
 import { describe, it } from "vitest";
 
@@ -12,6 +13,7 @@ import type { SimAwsAccountId } from "../../aws/sim-aws-account.js";
 import type { SimCloudFormationResourceCreateContext } from "../../cloudformation/resource/sim-cfn-resource.js";
 import { SimCfnResource } from "../../cloudformation/resource/sim-cfn-resource.js";
 import { SimCloudFrontDistribution } from "../distribution/sim-cloudfront-distribution.js";
+import { SimCloudFrontResponseHeadersPolicy } from "../response-headers-policy/sim-cf-response-headers-policy.js";
 import { SimCloudFrontCloudFormationResourceFactory } from "./sim-cfn-cloudfront-resource-factory.js";
 import { simCfDistroConfigFactory } from "../distribution/sim-cf-distro-config.factory.js";
 
@@ -149,6 +151,67 @@ describe("SimCloudFrontCloudFormationResourceFactory", () => {
     assertIdentical(
       error.message,
       "Unsupported sim CloudFront CloudFormation Resource UnsupportedResource",
+    );
+  });
+
+  it("creates and deletes a response headers policy", async () => {
+    // Given a CloudFront CloudFormation Resource factory and a response
+    // headers policy resource.
+    const simAws = new SimAws();
+    const cloudFront = simAws.cloudFront();
+    const resource = new SimCfnResource({
+      logicalId: "CacheHeaders",
+      template: {
+        Type: "AWS::CloudFront::ResponseHeadersPolicy",
+        Properties: {
+          ResponseHeadersPolicyConfig: {
+            Name: "CacheHeaders",
+            CustomHeadersConfig: {
+              Items: [
+                { Header: "Vary", Override: true, Value: "Accept-Encoding" },
+              ],
+            },
+          },
+        },
+      },
+    });
+    const context: SimCloudFormationResourceCreateContext = {
+      simAws,
+      resources: new Map(),
+    };
+    const factory = new SimCloudFrontCloudFormationResourceFactory(cloudFront);
+
+    // When it is created.
+    const policy = await factory.create(
+      "ResponseHeadersPolicy",
+      resource,
+      context,
+    );
+
+    assertInstanceOf(policy, SimCloudFrontResponseHeadersPolicy);
+
+    // Then sim CloudFront holds it, so a Behavior naming its ID finds it.
+    assertNonNullable(cloudFront.getResponseHeadersPolicyById(policy.id));
+
+    // And when the Resource is deleted, sim CloudFront forgets it.
+    resource.markCreateComplete(policy);
+    await factory.delete("ResponseHeadersPolicy", resource);
+
+    assertUndefined(cloudFront.getResponseHeadersPolicyById(policy.id));
+  });
+
+  it("steps over deleting a response headers policy that was never created", async () => {
+    // Given a policy Resource whose creation did not get as far as a policy.
+    const simAws = new SimAws();
+    const factory = new SimCloudFrontCloudFormationResourceFactory(
+      simAws.cloudFront(),
+    );
+
+    // When its deletion is attempted, then there is nothing to forget and
+    // nothing is thrown.
+    await factory.delete(
+      "ResponseHeadersPolicy",
+      new SimCfnResource({ logicalId: "CacheHeaders" }),
     );
   });
 

--- a/src/service/cloudfront/cfn/sim-cfn-cloudfront-resource-factory.ts
+++ b/src/service/cloudfront/cfn/sim-cfn-cloudfront-resource-factory.ts
@@ -7,6 +7,7 @@ import type {
 import { SimCfnCfDistroCreator } from "./distro/sim-cfn-cf-distro-creator.js";
 import { SimCfnCffCreator } from "./cff/sim-cfn-cff-creator.js";
 import { SimCfnCfDistroDeleter } from "./distro/sim-cfn-cf-distro-deleter.js";
+import { SimCfnCfResponseHeadersPolicyCreator } from "./response-headers-policy/sim-cfn-cf-rh-policy-creator.js";
 import type { SimCloudFrontFunction } from "../cff/sim-cloudfront-function.js";
 import { assertDefined } from "../../../util/type-guard/defined.js";
 
@@ -18,12 +19,15 @@ export class SimCloudFrontCloudFormationResourceFactory implements SimCfnService
   private readonly distroCreator: SimCfnCfDistroCreator;
   private readonly functionCreator: SimCfnCffCreator;
   private readonly distroDeleter: SimCfnCfDistroDeleter;
+  private readonly responseHeadersPolicyCreator: SimCfnCfResponseHeadersPolicyCreator;
 
   constructor(cloudFront: SimCloudFront) {
     this.cloudFront = cloudFront;
     this.distroCreator = new SimCfnCfDistroCreator({ cloudFront });
     this.functionCreator = new SimCfnCffCreator({ cloudFront });
     this.distroDeleter = new SimCfnCfDistroDeleter({ cloudFront });
+    this.responseHeadersPolicyCreator =
+      new SimCfnCfResponseHeadersPolicyCreator({ cloudFront });
   }
 
   /**
@@ -46,6 +50,12 @@ export class SimCloudFrontCloudFormationResourceFactory implements SimCfnService
           resource,
           context.resolvedProperties ?? resource.properties,
           context,
+        );
+      }
+      case "ResponseHeadersPolicy": {
+        return this.responseHeadersPolicyCreator.create(
+          resource,
+          context.resolvedProperties ?? resource.properties,
         );
       }
       default: {
@@ -71,6 +81,10 @@ export class SimCloudFrontCloudFormationResourceFactory implements SimCfnService
       }
       case "Function": {
         await this.deleteFunction(resource);
+        return;
+      }
+      case "ResponseHeadersPolicy": {
+        this.responseHeadersPolicyCreator.delete(resource);
         return;
       }
       default: {

--- a/src/service/cloudfront/command/create-distribution/create-distribution.command.ts
+++ b/src/service/cloudfront/command/create-distribution/create-distribution.command.ts
@@ -115,6 +115,7 @@ export interface SimCloudFrontDefaultCacheBehaviorConfig {
   readonly AllowedMethods?: SimCloudFrontAllowedMethods | undefined;
   readonly ViewerProtocolPolicy?: SimCloudFrontViewerProtocolPolicy | undefined;
   readonly FunctionAssociations?: SimCloudFrontFunctionAssociations | undefined;
+  readonly ResponseHeadersPolicyId?: string | undefined;
 }
 
 /**

--- a/src/service/cloudfront/controller/dependency/sim-cf-controller-dependency.ts
+++ b/src/service/cloudfront/controller/dependency/sim-cf-controller-dependency.ts
@@ -7,6 +7,7 @@ import { SimCloudFrontBehaviorResolver as DefaultSimCloudFrontBehaviorResolver }
 import { SimCffApplicator } from "../cff/sim-cff-applicator.js";
 import { SimCloudFrontOriginFetcher } from "../origin/sim-cloudfront-origin-fetcher.js";
 import { SimCfCustomErrorResponder } from "../error/sim-cf-custom-error-responder.js";
+import { SimCfResponseHeadersApplicator } from "../response-headers/sim-cf-response-headers-applicator.js";
 
 export interface SimCloudFrontServiceControllerProperties {
   readonly simAws?: SimAws;
@@ -16,6 +17,7 @@ export interface SimCloudFrontServiceControllerProperties {
   readonly cffApplicator?: SimCffApplicator;
   readonly originFetcher?: SimCloudFrontOriginFetcher;
   readonly customErrorResponder?: SimCfCustomErrorResponder;
+  readonly responseHeadersApplicator?: SimCfResponseHeadersApplicator;
 }
 
 export interface SimCloudFrontControllerDependencies {
@@ -24,6 +26,7 @@ export interface SimCloudFrontControllerDependencies {
   readonly cffApplicator: SimCffApplicator;
   readonly originFetcher: SimCloudFrontOriginFetcher;
   readonly customErrorResponder: SimCfCustomErrorResponder;
+  readonly responseHeadersApplicator: SimCfResponseHeadersApplicator;
 }
 
 /**
@@ -62,6 +65,9 @@ export class SimCloudFrontControllerDependenciesFactory {
       customErrorResponder:
         properties.customErrorResponder ??
         new SimCfCustomErrorResponder({ behaviourResolver, originFetcher }),
+      responseHeadersApplicator:
+        properties.responseHeadersApplicator ??
+        new SimCfResponseHeadersApplicator(),
     };
   }
 }

--- a/src/service/cloudfront/controller/response-headers/sim-cf-response-headers-applicator.iso.test.ts
+++ b/src/service/cloudfront/controller/response-headers/sim-cf-response-headers-applicator.iso.test.ts
@@ -1,0 +1,103 @@
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsError,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { simCloudFrontBehaviorFactory } from "../../behaviour/sim-cloud-front-behavior.js";
+import { SimCloudFrontNoSuchResponseHeadersPolicy } from "../../error/sim-cloudfront.error.js";
+import { SimCloudFrontResponseHeader } from "../../response-headers-policy/sim-cf-response-header.js";
+import { SimCloudFrontResponseHeadersPolicy } from "../../response-headers-policy/sim-cf-response-headers-policy.js";
+import { SimCloudFront } from "../../sim-cloudfront.js";
+import { SimCfResponseHeadersApplicator } from "./sim-cf-response-headers-applicator.js";
+
+describe("SimCfResponseHeadersApplicator", () => {
+  const applicator = new SimCfResponseHeadersApplicator();
+
+  function policy(): SimCloudFrontResponseHeadersPolicy {
+    return new SimCloudFrontResponseHeadersPolicy({
+      name: "CacheHeaders",
+      customHeaders: [
+        new SimCloudFrontResponseHeader({
+          name: "Cache-Control",
+          value: "public, max-age=0, must-revalidate",
+          override: true,
+        }),
+      ],
+    });
+  }
+
+  it("applies the policy a Behavior names", () => {
+    // Given a Behavior naming a policy the simulation holds.
+    const cloudFront = new SimCloudFront();
+    const responseHeadersPolicy = policy();
+
+    cloudFront.addResponseHeadersPolicy(responseHeadersPolicy);
+
+    const behaviour = simCloudFrontBehaviorFactory.make({
+      responseHeadersPolicyId: responseHeadersPolicy.id,
+    });
+
+    // When an Origin response passes through it.
+    const response = applicator.apply(
+      cloudFront,
+      new Response("body"),
+      behaviour,
+    );
+
+    // Then the policy's headers are on what the viewer gets.
+    assertIdentical(
+      response.headers.get("cache-control"),
+      "public, max-age=0, must-revalidate",
+    );
+  });
+
+  it("passes a response through for a Behavior naming no policy", () => {
+    // Given a Behavior with no response headers policy.
+    const cloudFront = new SimCloudFront();
+    const behaviour = simCloudFrontBehaviorFactory.make();
+
+    // When an Origin response passes through it.
+    const originResponse = new Response("body");
+    const response = applicator.apply(cloudFront, originResponse, behaviour);
+
+    // Then nothing is done to it at all.
+    assertIdentical(response, originResponse);
+  });
+
+  it("refuses a policy ID nothing created", () => {
+    // Given a Behavior naming a policy the simulation does not hold, which is
+    // what a CloudFront managed policy ID is here.
+    const cloudFront = new SimCloudFront();
+    const behaviour = simCloudFrontBehaviorFactory.make({
+      responseHeadersPolicyId: "658327ea-f89d-4fab-a63d-7e88639e58f6",
+    });
+
+    // When an Origin response passes through it, then the gap is reported
+    // rather than the response being served without the headers it promised.
+    const error = assertThrowsError(() =>
+      applicator.apply(cloudFront, new Response("body"), behaviour),
+    );
+
+    assertInstanceOf(error, SimCloudFrontNoSuchResponseHeadersPolicy);
+    assertStringIncludes(error.message, "658327ea-f89d-4fab-a63d-7e88639e58f6");
+    assertStringIncludes(error.message, "managed policy ID");
+  });
+
+  it("forgets a policy that has been removed", () => {
+    // Given a policy the simulation held and no longer does, as a deleted
+    // CloudFormation Resource leaves it.
+    const cloudFront = new SimCloudFront();
+    const responseHeadersPolicy = policy();
+
+    cloudFront.addResponseHeadersPolicy(responseHeadersPolicy);
+    cloudFront.removeResponseHeadersPolicy(responseHeadersPolicy.id);
+
+    // Then looking it up finds nothing.
+    assertUndefined(
+      cloudFront.getResponseHeadersPolicyById(responseHeadersPolicy.id),
+    );
+  });
+});

--- a/src/service/cloudfront/controller/response-headers/sim-cf-response-headers-applicator.ts
+++ b/src/service/cloudfront/controller/response-headers/sim-cf-response-headers-applicator.ts
@@ -1,0 +1,43 @@
+import type { SimCloudFront } from "../../sim-cloudfront.js";
+import type { SimCloudFrontBehavior } from "../../behaviour/sim-cloud-front-behavior.js";
+import { SimCloudFrontNoSuchResponseHeadersPolicy } from "../../error/sim-cloudfront.error.js";
+
+/**
+ * Applies the response headers policy a resolved Behavior names.
+ *
+ * CloudFront applies the policy after the response leaves the cache and before
+ * the viewer-response event, so a custom error page carries the policy's
+ * headers and a viewer-response CloudFront Function sees them in its event.
+ *
+ * https://aws.amazon.com/about-aws/whats-new/2021/11/amazon-cloudfront-response-headers-policies/
+ */
+export class SimCfResponseHeadersApplicator {
+  /**
+   * Return the response with the Behavior's policy applied, or the response
+   * unchanged when the Behavior names no policy.
+   */
+  apply(
+    cloudFront: SimCloudFront,
+    response: Response,
+    behaviour: SimCloudFrontBehavior,
+  ): Response {
+    const policyId = behaviour.responseHeadersPolicyId;
+
+    if (policyId === undefined) {
+      return response;
+    }
+
+    const policy = cloudFront.getResponseHeadersPolicyById(policyId);
+
+    if (policy === undefined) {
+      throw new SimCloudFrontNoSuchResponseHeadersPolicy(
+        `Sim CloudFront response headers policy ${policyId} does not exist. ` +
+          `Only a policy created in this simulation can be applied, so a ` +
+          `managed policy ID, which names a policy AWS owns rather than one a ` +
+          `template creates, will not be found.`,
+      );
+    }
+
+    return policy.apply(response);
+  }
+}

--- a/src/service/cloudfront/controller/sim-cf-controller-response-headers.iso.test.ts
+++ b/src/service/cloudfront/controller/sim-cf-controller-response-headers.iso.test.ts
@@ -1,0 +1,161 @@
+import { assertIdentical, assertNonNullable } from "@kensio/smartass";
+import { CreateFunctionCommand } from "@aws-sdk/client-cloudfront";
+import { describe, it } from "vitest";
+import { SimAws } from "../../aws/sim-aws.js";
+import { makeCffFunctionCodeInput } from "../cff/function-code-input/cff-function-code-input.js";
+import { SimCloudFrontResponseHeader } from "../response-headers-policy/sim-cf-response-header.js";
+import { SimCloudFrontResponseHeadersPolicy } from "../response-headers-policy/sim-cf-response-headers-policy.js";
+import type { CloudFrontFunction } from "../typings/cloudfront-functions.namespace.js";
+import {
+  simCfSiteBucket,
+  simCfSiteDistributionConfig,
+  simCfSiteDistributionId,
+  simCfSiteRequest,
+} from "../../../../test/cloudfront/site-fixture.js";
+
+describe("Simulated CloudFront response headers policy in the request pipeline", () => {
+  it("lets a viewer-response CFF see the policy's headers in its event", async () => {
+    // Given a Distribution serving a page, with a policy setting a cache
+    // directive the Origin says nothing about.
+    const simAws = new SimAws();
+
+    await simCfSiteBucket(simAws, "policy-order-bucket", {
+      "index.html": "<h1>Home</h1>",
+    });
+
+    const policy = new SimCloudFrontResponseHeadersPolicy({
+      name: "CacheHeaders",
+      customHeaders: [
+        new SimCloudFrontResponseHeader({
+          name: "Cache-Control",
+          value: "public, max-age=60",
+          override: true,
+        }),
+      ],
+    });
+
+    simAws.cloudFront().addResponseHeadersPolicy(policy);
+
+    // And a viewer-response function copying whatever cache directive it is
+    // given into a header of its own.
+    const cff = await simAws.cloudFront().createFunction(
+      new CreateFunctionCommand({
+        Name: "cache-control-echo",
+        FunctionConfig: {
+          Comment: "Echoes the cache directive it was given",
+          Runtime: "cloudfront-js-2.0",
+        },
+        FunctionCode: makeCffFunctionCodeInput(
+          (event: CloudFrontFunction.ViewerResponseEvent) => {
+            event.response.headers["x-seen-cache-control"] = {
+              value: event.response.headers["cache-control"]?.value ?? "none",
+            };
+
+            return event.response;
+          },
+        ),
+      }),
+    );
+
+    assertNonNullable(cff.FunctionMetadata.FunctionARN);
+
+    const distributionId = await simCfSiteDistributionId(
+      simAws,
+      simCfSiteDistributionConfig("policy-order-bucket", {
+        DefaultCacheBehavior: {
+          TargetOriginId: "site-origin",
+          ViewerProtocolPolicy: "allow-all",
+          ResponseHeadersPolicyId: policy.id,
+          FunctionAssociations: {
+            Quantity: 1,
+            Items: [
+              {
+                EventType: "viewer-response",
+                FunctionARN: cff.FunctionMetadata.FunctionARN,
+              },
+            ],
+          },
+        },
+      }),
+    );
+
+    // When the page is requested.
+    const home = await simCfSiteRequest(simAws, distributionId, "/index.html");
+
+    // Then the function saw the policy's header, because CloudFront applies a
+    // policy before the viewer-response event rather than after it.
+    assertIdentical(
+      home.headers.get("x-seen-cache-control"),
+      "public, max-age=60",
+    );
+    assertIdentical(home.headers.get("cache-control"), "public, max-age=60");
+  });
+
+  it("lets a viewer-response CFF change what the policy set", async () => {
+    // Given the same arrangement, with a function that replaces the header.
+    const simAws = new SimAws();
+
+    await simCfSiteBucket(simAws, "policy-override-bucket", {
+      "index.html": "<h1>Home</h1>",
+    });
+
+    const policy = new SimCloudFrontResponseHeadersPolicy({
+      name: "CacheHeaders",
+      customHeaders: [
+        new SimCloudFrontResponseHeader({
+          name: "Cache-Control",
+          value: "public, max-age=60",
+          override: true,
+        }),
+      ],
+    });
+
+    simAws.cloudFront().addResponseHeadersPolicy(policy);
+
+    const cff = await simAws.cloudFront().createFunction(
+      new CreateFunctionCommand({
+        Name: "cache-control-replace",
+        FunctionConfig: {
+          Comment: "Replaces the cache directive",
+          Runtime: "cloudfront-js-2.0",
+        },
+        FunctionCode: makeCffFunctionCodeInput(
+          (event: CloudFrontFunction.ViewerResponseEvent) => {
+            event.response.headers["cache-control"] = { value: "no-store" };
+
+            return event.response;
+          },
+        ),
+      }),
+    );
+
+    assertNonNullable(cff.FunctionMetadata.FunctionARN);
+
+    const distributionId = await simCfSiteDistributionId(
+      simAws,
+      simCfSiteDistributionConfig("policy-override-bucket", {
+        DefaultCacheBehavior: {
+          TargetOriginId: "site-origin",
+          ViewerProtocolPolicy: "allow-all",
+          ResponseHeadersPolicyId: policy.id,
+          FunctionAssociations: {
+            Quantity: 1,
+            Items: [
+              {
+                EventType: "viewer-response",
+                FunctionARN: cff.FunctionMetadata.FunctionARN,
+              },
+            ],
+          },
+        },
+      }),
+    );
+
+    // When the page is requested.
+    const home = await simCfSiteRequest(simAws, distributionId, "/index.html");
+
+    // Then the function's value is what the viewer gets, being the last thing
+    // to touch the response.
+    assertIdentical(home.headers.get("cache-control"), "no-store");
+  });
+});

--- a/src/service/cloudfront/controller/sim-cloudfront-request-pipeline.ts
+++ b/src/service/cloudfront/controller/sim-cloudfront-request-pipeline.ts
@@ -1,17 +1,12 @@
-import type { SimCloudFrontDistroRouter } from "../router/sim-cloud-front-distro-router.js";
-import type { SimCloudFrontBehaviorResolver } from "../resolver/sim-cloud-front-behavior-resolver.js";
-import type { SimCffApplicator } from "./cff/sim-cff-applicator.js";
-import type { SimCloudFrontOriginFetcher } from "./origin/sim-cloudfront-origin-fetcher.js";
 import type { SimCloudFrontControllerDependencies } from "./dependency/sim-cf-controller-dependency.js";
-import type { SimCfCustomErrorResponder } from "./error/sim-cf-custom-error-responder.js";
 import { simCfDefaultRootObjectRequest } from "./root-object/sim-cf-default-root-object-request.js";
 
 /**
  * Runs a single simulated CloudFront request through its lifecycle:
  * route to a Distribution, apply the default root object, resolve the matching
  * Behavior, run viewer-request hooks, fetch from the Origin, replace an error
- * response with the Distribution's custom error page, then run viewer-response
- * hooks.
+ * response with the Distribution's custom error page, apply the Behavior's
+ * response headers policy, then run viewer-response hooks.
  *
  * This is the request-processing core, kept separate from the service
  * controller so the controller stays a thin adapter to the shared
@@ -19,19 +14,7 @@ import { simCfDefaultRootObjectRequest } from "./root-object/sim-cf-default-root
  * pipeline itself.
  */
 export class SimCloudFrontRequestPipeline {
-  private readonly distroRouter: SimCloudFrontDistroRouter;
-  private readonly behaviourResolver: SimCloudFrontBehaviorResolver;
-  private readonly cffApplicator: SimCffApplicator;
-  private readonly originFetcher: SimCloudFrontOriginFetcher;
-  private readonly customErrorResponder: SimCfCustomErrorResponder;
-
-  constructor(dependencies: SimCloudFrontControllerDependencies) {
-    this.distroRouter = dependencies.distroRouter;
-    this.behaviourResolver = dependencies.behaviourResolver;
-    this.cffApplicator = dependencies.cffApplicator;
-    this.originFetcher = dependencies.originFetcher;
-    this.customErrorResponder = dependencies.customErrorResponder;
-  }
+  constructor(private readonly stages: SimCloudFrontControllerDependencies) {}
 
   /**
    * Process one incoming request and produce the response the caller sees.
@@ -39,7 +22,7 @@ export class SimCloudFrontRequestPipeline {
   async handle(request: Request): Promise<Response> {
     let requestReference = request;
 
-    const route = this.distroRouter.routeForRequest(requestReference);
+    const route = this.stages.distroRouter.routeForRequest(requestReference);
 
     if (route === undefined) {
       return new Response("Suitable sim CloudFront Distribution not found", {
@@ -51,12 +34,15 @@ export class SimCloudFrontRequestPipeline {
 
     requestReference = simCfDefaultRootObjectRequest(requestReference, distro);
 
-    const behaviour = this.behaviourResolver.resolve(requestReference, distro);
+    const behaviour = this.stages.behaviourResolver.resolve(
+      requestReference,
+      distro,
+    );
 
     // Handle viewer-request CFF, if any.
     // A viewer-request CFF can either rewrite the Request that continues to the
     // Origin or short-circuit the request by returning a Response.
-    const cffResult = this.cffApplicator.applyViewerRequest(
+    const cffResult = this.stages.cffApplicator.applyViewerRequest(
       cloudFront,
       requestReference,
       behaviour,
@@ -66,7 +52,7 @@ export class SimCloudFrontRequestPipeline {
     }
     requestReference = cffResult;
 
-    const originResponse = await this.originFetcher.fetch(
+    const originResponse = await this.stages.originFetcher.fetch(
       requestReference,
       distro,
       behaviour,
@@ -75,16 +61,26 @@ export class SimCloudFrontRequestPipeline {
     // Replace an Origin error with the Distribution's custom error page, if it
     // configures one for that status. This happens before the viewer-response
     // CFF so that a function sees the response the viewer is about to get.
-    const response = await this.customErrorResponder.apply(
+    const errorResponse = await this.stages.customErrorResponder.apply(
       requestReference,
       distro,
       originResponse,
     );
 
+    // Apply the Behavior's response headers policy, if it names one. CloudFront
+    // does this after the response leaves the cache and before the
+    // viewer-response event, so the custom error page above carries the
+    // policy's headers and a viewer-response function sees them.
+    const response = this.stages.responseHeadersApplicator.apply(
+      cloudFront,
+      errorResponse,
+      behaviour,
+    );
+
     // Handle viewer-response CFF, if any.
     // A viewer-response CFF can inspect the original request and replace or
     // modify the Origin response before it is returned to the caller.
-    return this.cffApplicator.applyViewerResponse(
+    return this.stages.cffApplicator.applyViewerResponse(
       cloudFront,
       requestReference,
       response,

--- a/src/service/cloudfront/distribution/configurator/sim-cloud-front-behavior-configurator.ts
+++ b/src/service/cloudfront/distribution/configurator/sim-cloud-front-behavior-configurator.ts
@@ -64,6 +64,9 @@ function buildBaseBehaviorProperties(
     ...(cacheBehavior.ViewerProtocolPolicy !== undefined && {
       viewerProtocolPolicy: cacheBehavior.ViewerProtocolPolicy,
     }),
+    ...(cacheBehavior.ResponseHeadersPolicyId !== undefined && {
+      responseHeadersPolicyId: cacheBehavior.ResponseHeadersPolicyId,
+    }),
     functionAssociations: configureCffAssociations(cacheBehavior),
   };
 }

--- a/src/service/cloudfront/error/sim-cloudfront.error.ts
+++ b/src/service/cloudfront/error/sim-cloudfront.error.ts
@@ -106,6 +106,19 @@ export class SimCloudFrontNoSuchFunctionExists extends SimCloudFrontError {
 }
 
 /**
+ * Simulated CloudFront NoSuchResponseHeadersPolicy error.
+ *
+ * What CloudFront answers when a response headers policy ID names nothing.
+ */
+export class SimCloudFrontNoSuchResponseHeadersPolicy extends SimCloudFrontError {
+  public override readonly name = "NoSuchResponseHeadersPolicy";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 404 });
+  }
+}
+
+/**
  * Simulated CloudFront DistributionNotDisabled error.
  *
  * CloudFront will not delete a Distribution that is still serving. The caller

--- a/src/service/cloudfront/error/sim-cloudfront.error.ts
+++ b/src/service/cloudfront/error/sim-cloudfront.error.ts
@@ -119,6 +119,20 @@ export class SimCloudFrontNoSuchResponseHeadersPolicy extends SimCloudFrontError
 }
 
 /**
+ * Simulated CloudFront ResponseHeadersPolicyAlreadyExists error.
+ *
+ * CloudFront requires a response headers policy name to be unique within an
+ * account, so a second policy claiming a name is refused rather than created.
+ */
+export class SimCloudFrontResponseHeadersPolicyAlreadyExists extends SimCloudFrontError {
+  public override readonly name = "ResponseHeadersPolicyAlreadyExists";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 409 });
+  }
+}
+
+/**
  * Simulated CloudFront DistributionNotDisabled error.
  *
  * CloudFront will not delete a Distribution that is still serving. The caller

--- a/src/service/cloudfront/origin/s3/sim-cloudfront-s3-origin.iso.test.ts
+++ b/src/service/cloudfront/origin/s3/sim-cloudfront-s3-origin.iso.test.ts
@@ -6,9 +6,87 @@ import {
 } from "@kensio/smartass";
 import { describe, it } from "vitest";
 
+import { SimS3Bucket } from "../../../s3/bucket/sim-s3-bucket.js";
+import {
+  SimS3Object,
+  SimS3ObjectMetadata,
+} from "../../../s3/object/s3-object.js";
+import { simCloudFrontBehaviorFactory } from "../../behaviour/sim-cloud-front-behavior.js";
+import { SimCloudFrontDistribution } from "../../distribution/sim-cloudfront-distribution.js";
 import { bucketNameFromCfS3OriginDomainName } from "./sim-cf-s3-origin-bucket-name.js";
+import { SimCloudFrontS3Origin } from "./sim-cloudfront-s3-origin.js";
 
 describe("sim CloudFront S3 Origin", () => {
+  async function originWithObject(
+    metadata: Record<string, string>,
+  ): Promise<SimCloudFrontS3Origin> {
+    const bucket = new SimS3Bucket({ bucketName: "site-bucket" });
+
+    await bucket.putObject(
+      new SimS3Object({
+        key: "data/standard.keys",
+        body: Buffer.from("compressed"),
+        metadata: new SimS3ObjectMetadata(metadata),
+      }),
+    );
+
+    return new SimCloudFrontS3Origin({ bucket });
+  }
+
+  function originRequest(request: Request): {
+    distribution: SimCloudFrontDistribution;
+    behavior: ReturnType<typeof simCloudFrontBehaviorFactory.make>;
+    req: Request;
+  } {
+    return {
+      distribution: new SimCloudFrontDistribution(),
+      behavior: simCloudFrontBehaviorFactory.make(),
+      req: request,
+    };
+  }
+
+  it("serves the system metadata an Object was stored with", async () => {
+    // Given an Object stored as brotli with its own cache directive.
+    const origin = await originWithObject({
+      "content-type": "text/plain",
+      "content-encoding": "br",
+      "cache-control": "public, max-age=60",
+    });
+
+    // When CloudFront fetches it from the Origin.
+    const response = await origin.fetch(
+      originRequest(new Request("http://example.test/data/standard.keys")),
+    );
+
+    // Then the headers describing the stored bytes come back with them.
+    assertIdentical(response.headers.get("content-type"), "text/plain");
+    assertIdentical(response.headers.get("content-encoding"), "br");
+    assertIdentical(
+      response.headers.get("cache-control"),
+      "public, max-age=60",
+    );
+    assertIdentical(response.headers.get("content-length"), "10");
+  });
+
+  it("serves the same headers for a HEAD request, without the body", async () => {
+    // Given an Object stored as brotli.
+    const origin = await originWithObject({ "content-encoding": "br" });
+
+    // When CloudFront makes a HEAD request for it.
+    const response = await origin.fetch(
+      originRequest(
+        new Request("http://example.test/data/standard.keys", {
+          method: "HEAD",
+        }),
+      ),
+    );
+
+    // Then a caller learns what a GET would give them, body aside.
+    assertIdentical(response.headers.get("content-encoding"), "br");
+    assertIdentical(response.headers.get("content-length"), "10");
+    assertIdentical(await response.text(), "");
+  });
+
   it("resolves bucket name fallback from non-S3 origin domain name", () => {
     assertIdentical(
       bucketNameFromCfS3OriginDomainName("example.test"),

--- a/src/service/cloudfront/origin/s3/sim-cloudfront-s3-origin.ts
+++ b/src/service/cloudfront/origin/s3/sim-cloudfront-s3-origin.ts
@@ -1,5 +1,6 @@
 import type { SimS3Bucket } from "../../../s3/bucket/sim-s3-bucket.js";
 import type { SimS3Object } from "../../../s3/object/s3-object.js";
+import { simS3ObjectResponseHeaders } from "../../../s3/object/s3-object-response-headers.js";
 import type { SimCloudFrontOriginRequest } from "../sim-cloudfront-request-response.js";
 import type { SimCloudFrontOrigin } from "../sim-cloudfront-origin.js";
 
@@ -76,12 +77,10 @@ export class SimCloudFrontS3Origin implements SimCloudFrontOrigin {
   }
 
   private foundObjectResponse(object: SimS3Object, request: Request): Response {
-    const contentType = object.metadata.values["content-type"];
-
-    const headers = {
-      "content-length": String(object.body.length),
-      ...(contentType !== undefined && { "content-type": contentType }),
-    };
+    const headers = simS3ObjectResponseHeaders(
+      object.metadata.values,
+      object.body.length,
+    );
 
     if (request.method === "HEAD") {
       return new Response(undefined, {

--- a/src/service/cloudfront/response-headers-policy/sim-cf-response-header.iso.test.ts
+++ b/src/service/cloudfront/response-headers-policy/sim-cf-response-header.iso.test.ts
@@ -1,0 +1,81 @@
+import { assertIdentical } from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimCloudFrontResponseHeader } from "./sim-cf-response-header.js";
+
+describe("SimCloudFrontResponseHeader", () => {
+  it("adds a header the Origin did not send", () => {
+    // Given a policy header the Origin says nothing about.
+    const headers = new Headers();
+
+    // When it is applied without Override.
+    new SimCloudFrontResponseHeader({
+      name: "Vary",
+      value: "Accept-Encoding",
+      override: false,
+    }).applyTo(headers);
+
+    // Then it is added: Override only decides what happens to a header that is
+    // already there.
+    assertIdentical(headers.get("vary"), "Accept-Encoding");
+  });
+
+  it("replaces the Origin's value with Override set", () => {
+    // Given an Origin response already carrying the header.
+    const headers = new Headers({ "cache-control": "no-store" });
+
+    // When the policy's header is applied with Override.
+    new SimCloudFrontResponseHeader({
+      name: "Cache-Control",
+      value: "public, max-age=60",
+      override: true,
+    }).applyTo(headers);
+
+    // Then the policy's value wins.
+    assertIdentical(headers.get("cache-control"), "public, max-age=60");
+  });
+
+  it("keeps the Origin's value without Override", () => {
+    // Given an Origin response already carrying the header.
+    const headers = new Headers({ "cache-control": "no-store" });
+
+    // When the policy's header is applied without Override.
+    new SimCloudFrontResponseHeader({
+      name: "Cache-Control",
+      value: "public, max-age=60",
+      override: false,
+    }).applyTo(headers);
+
+    // Then the Origin's value stays and the policy's is dropped.
+    assertIdentical(headers.get("cache-control"), "no-store");
+  });
+
+  it("matches an Origin header whatever case it was sent in", () => {
+    // Given an Origin response whose header name is cased differently.
+    const headers = new Headers({ "Cache-Control": "no-store" });
+
+    // When a policy header of the same name is applied without Override.
+    new SimCloudFrontResponseHeader({
+      name: "cache-control",
+      value: "public, max-age=60",
+      override: false,
+    }).applyTo(headers);
+
+    // Then it is recognised as the same header, as HTTP treats it.
+    assertIdentical(headers.get("cache-control"), "no-store");
+  });
+
+  it("keeps the Origin's value when the policy does not say to override", () => {
+    // Given an Origin response already carrying the header, and a policy header
+    // built without an explicit Override.
+    const headers = new Headers({ "cache-control": "no-store" });
+
+    // When it is applied.
+    new SimCloudFrontResponseHeader({
+      name: "Cache-Control",
+      value: "public, max-age=60",
+    }).applyTo(headers);
+
+    // Then not overriding is the default, as it is in CloudFront.
+    assertIdentical(headers.get("cache-control"), "no-store");
+  });
+});

--- a/src/service/cloudfront/response-headers-policy/sim-cf-response-header.ts
+++ b/src/service/cloudfront/response-headers-policy/sim-cf-response-header.ts
@@ -1,0 +1,36 @@
+/**
+ * One header a response headers policy sets.
+ *
+ * The `Override` flag decides what happens when the Origin already sent a
+ * header of the same name. With it set, the policy's value replaces the
+ * Origin's. Without it, the Origin's value stays and the policy's is dropped.
+ * A header the Origin did not send is added either way.
+ *
+ * https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/adding-response-headers.html
+ */
+export class SimCloudFrontResponseHeader {
+  readonly name: string;
+  readonly value: string;
+  readonly override: boolean;
+
+  constructor(properties: {
+    readonly name: string;
+    readonly value: string;
+    readonly override?: boolean | undefined;
+  }) {
+    this.name = properties.name;
+    this.value = properties.value;
+    this.override = properties.override ?? false;
+  }
+
+  /**
+   * Set this header on a response's headers, where the policy says to.
+   */
+  applyTo(headers: Headers): void {
+    if (!this.override && headers.has(this.name)) {
+      return;
+    }
+
+    headers.set(this.name, this.value);
+  }
+}

--- a/src/service/cloudfront/response-headers-policy/sim-cf-response-headers-policy-registry.ts
+++ b/src/service/cloudfront/response-headers-policy/sim-cf-response-headers-policy-registry.ts
@@ -1,0 +1,54 @@
+import { SimCloudFrontResponseHeadersPolicyAlreadyExists } from "../error/sim-cloudfront.error.js";
+import type {
+  SimCloudFrontResponseHeadersPolicy,
+  SimCloudFrontResponseHeadersPolicyId,
+  SimCloudFrontResponseHeadersPolicyMap,
+} from "./sim-cf-response-headers-policy.js";
+
+/**
+ * The response headers policies one simulated CloudFront holds.
+ *
+ * Policies are found by ID, which is what a cache Behavior's
+ * `responseHeadersPolicyId` names, and by name, which is what decides whether a
+ * new one may be stored.
+ */
+export class SimCloudFrontResponseHeadersPolicyRegistry {
+  private readonly policies: SimCloudFrontResponseHeadersPolicyMap = new Map();
+
+  /**
+   * Store a policy, refusing a name another policy already holds as CloudFront
+   * does.
+   */
+  add(policy: SimCloudFrontResponseHeadersPolicy): void {
+    if (this.byName(policy.name) !== undefined) {
+      throw new SimCloudFrontResponseHeadersPolicyAlreadyExists(
+        `Sim CloudFront response headers policy ${policy.name} already exists`,
+      );
+    }
+
+    this.policies.set(policy.id, policy);
+  }
+
+  /**
+   * Forget a policy.
+   */
+  remove(policyId: SimCloudFrontResponseHeadersPolicyId): void {
+    this.policies.delete(policyId);
+  }
+
+  /**
+   * Get a policy by ID.
+   */
+  byId(
+    policyId: SimCloudFrontResponseHeadersPolicyId | string,
+  ): SimCloudFrontResponseHeadersPolicy | undefined {
+    return this.policies.get(policyId as SimCloudFrontResponseHeadersPolicyId);
+  }
+
+  /**
+   * Get a policy by name.
+   */
+  byName(policyName: string): SimCloudFrontResponseHeadersPolicy | undefined {
+    return this.policies.values().find((policy) => policy.name === policyName);
+  }
+}

--- a/src/service/cloudfront/response-headers-policy/sim-cf-response-headers-policy.iso.test.ts
+++ b/src/service/cloudfront/response-headers-policy/sim-cf-response-headers-policy.iso.test.ts
@@ -1,0 +1,111 @@
+import { assertIdentical, assertTrue, assertUuidV4 } from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimCloudFrontResponseHeader } from "./sim-cf-response-header.js";
+import { SimCloudFrontResponseHeadersPolicy } from "./sim-cf-response-headers-policy.js";
+
+describe("SimCloudFrontResponseHeadersPolicy", () => {
+  function policy(
+    properties: Partial<{
+      customHeaders: SimCloudFrontResponseHeader[];
+      headersToRemove: string[];
+    }> = {},
+  ): SimCloudFrontResponseHeadersPolicy {
+    return new SimCloudFrontResponseHeadersPolicy({
+      name: "TestPolicy",
+      ...properties,
+    });
+  }
+
+  it("gives each policy an ID of its own", () => {
+    // Given two policies created with the same name.
+    const first = policy();
+    const second = policy();
+
+    // Then each has an ID of the shape CloudFront gives a policy, and they are
+    // told apart by it.
+    assertUuidV4(first.id);
+    assertUuidV4(second.id);
+    assertTrue(first.id !== second.id);
+  });
+
+  it("adds its headers to a response", () => {
+    // Given a policy setting a header the Origin does not.
+    const applied = policy({
+      customHeaders: [
+        new SimCloudFrontResponseHeader({
+          name: "Vary",
+          value: "Accept-Encoding",
+          override: true,
+        }),
+      ],
+    }).apply(
+      new Response("body", { headers: { "content-type": "text/plain" } }),
+    );
+
+    // Then the policy's header joins the Origin's.
+    assertIdentical(applied.headers.get("vary"), "Accept-Encoding");
+    assertIdentical(applied.headers.get("content-type"), "text/plain");
+  });
+
+  it("removes the headers it is told to", () => {
+    // Given a policy removing a header the Origin sent.
+    const applied = policy({ headersToRemove: ["Server"] }).apply(
+      new Response("body", { headers: { server: "AmazonS3" } }),
+    );
+
+    // Then it is gone from the response.
+    assertIdentical(applied.headers.get("server"), null);
+  });
+
+  it("removes headers before adding them, so one named in both is present", () => {
+    // Given a policy that both removes and adds the same header, without
+    // Override, which alone would have kept the Origin's value.
+    const applied = policy({
+      headersToRemove: ["Cache-Control"],
+      customHeaders: [
+        new SimCloudFrontResponseHeader({
+          name: "Cache-Control",
+          value: "public, max-age=60",
+          override: false,
+        }),
+      ],
+    }).apply(
+      new Response("body", { headers: { "cache-control": "no-store" } }),
+    );
+
+    // Then the removal happens first, so nothing is there to keep and the
+    // policy's value is what the viewer gets.
+    assertIdentical(applied.headers.get("cache-control"), "public, max-age=60");
+  });
+
+  it("keeps the response status and body", async () => {
+    // Given an error response from the Origin.
+    const applied = policy({
+      customHeaders: [
+        new SimCloudFrontResponseHeader({
+          name: "Vary",
+          value: "Accept-Encoding",
+          override: true,
+        }),
+      ],
+    }).apply(
+      new Response("not found", { status: 404, statusText: "Not Found" }),
+    );
+
+    // Then only the headers change: a policy does not decide what is served.
+    assertIdentical(applied.status, 404);
+    assertIdentical(applied.statusText, "Not Found");
+    assertIdentical(await applied.text(), "not found");
+  });
+
+  it("passes a response through when it sets and removes nothing", () => {
+    // Given a policy with no headers configured either way.
+    const applied = policy().apply(
+      new Response("body", { headers: { "content-type": "text/plain" } }),
+    );
+
+    // Then the response is unchanged.
+    assertIdentical(applied.headers.get("content-type"), "text/plain");
+    assertIdentical(applied.status, 200);
+  });
+});

--- a/src/service/cloudfront/response-headers-policy/sim-cf-response-headers-policy.ts
+++ b/src/service/cloudfront/response-headers-policy/sim-cf-response-headers-policy.ts
@@ -1,0 +1,69 @@
+import { randomUUID } from "node:crypto";
+
+import type { Brand } from "../../../util/brand.type.js";
+import type { SimCloudFrontResponseHeader } from "./sim-cf-response-header.js";
+
+export type SimCloudFrontResponseHeadersPolicyId = Brand<
+  string,
+  "SimCloudFrontResponseHeadersPolicyId"
+>;
+
+interface SimCloudFrontResponseHeadersPolicyProperties {
+  readonly id?: SimCloudFrontResponseHeadersPolicyId;
+  readonly name: string;
+  readonly customHeaders?: readonly SimCloudFrontResponseHeader[];
+  readonly headersToRemove?: readonly string[];
+}
+
+/**
+ * Simulated CloudFront response headers policy.
+ *
+ * A policy is attached to a Cache Behavior, and CloudFront applies it to every
+ * response that Behavior serves. Headers to remove go first, then the headers
+ * to add, so a header named in both ends up present with the policy's value.
+ *
+ * https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/adding-response-headers.html
+ */
+export class SimCloudFrontResponseHeadersPolicy {
+  public readonly id: SimCloudFrontResponseHeadersPolicyId;
+  public readonly name: string;
+  public readonly customHeaders: readonly SimCloudFrontResponseHeader[];
+  public readonly headersToRemove: readonly string[];
+
+  constructor(properties: SimCloudFrontResponseHeadersPolicyProperties) {
+    this.id =
+      properties.id ?? (randomUUID() as SimCloudFrontResponseHeadersPolicyId);
+    this.name = properties.name;
+    this.customHeaders = properties.customHeaders ?? [];
+    this.headersToRemove = properties.headersToRemove ?? [];
+  }
+
+  /**
+   * Return the response this policy makes of one the Origin gave back.
+   *
+   * The body is passed straight through. Only the headers change, so a response
+   * whose body has already been read stays readable.
+   */
+  apply(response: Response): Response {
+    const headers = new Headers(response.headers);
+
+    for (const headerName of this.headersToRemove) {
+      headers.delete(headerName);
+    }
+
+    for (const customHeader of this.customHeaders) {
+      customHeader.applyTo(headers);
+    }
+
+    return new Response(response.body, {
+      status: response.status,
+      statusText: response.statusText,
+      headers,
+    });
+  }
+}
+
+export type SimCloudFrontResponseHeadersPolicyMap = Map<
+  SimCloudFrontResponseHeadersPolicyId,
+  SimCloudFrontResponseHeadersPolicy
+>;

--- a/src/service/cloudfront/sim-cloudfront.ts
+++ b/src/service/cloudfront/sim-cloudfront.ts
@@ -41,8 +41,8 @@ import type {
 import type {
   SimCloudFrontResponseHeadersPolicy,
   SimCloudFrontResponseHeadersPolicyId,
-  SimCloudFrontResponseHeadersPolicyMap,
 } from "./response-headers-policy/sim-cf-response-headers-policy.js";
+import { SimCloudFrontResponseHeadersPolicyRegistry } from "./response-headers-policy/sim-cf-response-headers-policy-registry.js";
 import { SimCloudFrontSdkCommandRouter } from "./sdk/sim-cloudfront-sdk-command-router.js";
 import {
   SimCloudFrontCommands,
@@ -62,8 +62,8 @@ export type {
 export class SimCloudFront {
   private readonly distributions: SimCloudFrontDistributionMap = new Map();
   private readonly cloudFrontFunctions: SimCloudFrontFunctionMap = new Map();
-  private readonly responseHeadersPolicies: SimCloudFrontResponseHeadersPolicyMap =
-    new Map();
+  private readonly responseHeadersPolicies =
+    new SimCloudFrontResponseHeadersPolicyRegistry();
 
   private readonly accountRegionScope: SimAwsAccountRegionScope;
   private readonly commands: SimCloudFrontCommands;
@@ -198,9 +198,10 @@ export class SimCloudFront {
    *
    * There is no CreateResponseHeadersPolicy command here, so CloudFormation is
    * the only thing that makes one, and this is how it hands the policy over.
+   * A name another policy already holds is refused, as CloudFront refuses one.
    */
   addResponseHeadersPolicy(policy: SimCloudFrontResponseHeadersPolicy): void {
-    this.responseHeadersPolicies.set(policy.id, policy);
+    this.responseHeadersPolicies.add(policy);
   }
 
   /**
@@ -209,7 +210,7 @@ export class SimCloudFront {
   removeResponseHeadersPolicy(
     policyId: SimCloudFrontResponseHeadersPolicyId,
   ): void {
-    this.responseHeadersPolicies.delete(policyId);
+    this.responseHeadersPolicies.remove(policyId);
   }
 
   /**
@@ -218,9 +219,7 @@ export class SimCloudFront {
   getResponseHeadersPolicyById(
     policyId: SimCloudFrontResponseHeadersPolicyId | string,
   ): SimCloudFrontResponseHeadersPolicy | undefined {
-    return this.responseHeadersPolicies.get(
-      policyId as SimCloudFrontResponseHeadersPolicyId,
-    );
+    return this.responseHeadersPolicies.byId(policyId);
   }
 
   /**

--- a/src/service/cloudfront/sim-cloudfront.ts
+++ b/src/service/cloudfront/sim-cloudfront.ts
@@ -38,6 +38,11 @@ import type {
   SimCloudFrontDistribution,
   SimCloudFrontDistributionId,
 } from "./distribution/sim-cloudfront-distribution.js";
+import type {
+  SimCloudFrontResponseHeadersPolicy,
+  SimCloudFrontResponseHeadersPolicyId,
+  SimCloudFrontResponseHeadersPolicyMap,
+} from "./response-headers-policy/sim-cf-response-headers-policy.js";
 import { SimCloudFrontSdkCommandRouter } from "./sdk/sim-cloudfront-sdk-command-router.js";
 import {
   SimCloudFrontCommands,
@@ -57,6 +62,8 @@ export type {
 export class SimCloudFront {
   private readonly distributions: SimCloudFrontDistributionMap = new Map();
   private readonly cloudFrontFunctions: SimCloudFrontFunctionMap = new Map();
+  private readonly responseHeadersPolicies: SimCloudFrontResponseHeadersPolicyMap =
+    new Map();
 
   private readonly accountRegionScope: SimAwsAccountRegionScope;
   private readonly commands: SimCloudFrontCommands;
@@ -184,6 +191,36 @@ export class SimCloudFront {
     cloudFrontFunctionName: SimCloudFrontFunctionName,
   ): SimCloudFrontFunction | undefined {
     return this.cloudFrontFunctions.get(cloudFrontFunctionName);
+  }
+
+  /**
+   * Store a simulated response headers policy.
+   *
+   * There is no CreateResponseHeadersPolicy command here, so CloudFormation is
+   * the only thing that makes one, and this is how it hands the policy over.
+   */
+  addResponseHeadersPolicy(policy: SimCloudFrontResponseHeadersPolicy): void {
+    this.responseHeadersPolicies.set(policy.id, policy);
+  }
+
+  /**
+   * Forget a simulated response headers policy.
+   */
+  removeResponseHeadersPolicy(
+    policyId: SimCloudFrontResponseHeadersPolicyId,
+  ): void {
+    this.responseHeadersPolicies.delete(policyId);
+  }
+
+  /**
+   * Get a simulated response headers policy by ID.
+   */
+  getResponseHeadersPolicyById(
+    policyId: SimCloudFrontResponseHeadersPolicyId | string,
+  ): SimCloudFrontResponseHeadersPolicy | undefined {
+    return this.responseHeadersPolicies.get(
+      policyId as SimCloudFrontResponseHeadersPolicyId,
+    );
   }
 
   /**

--- a/src/service/route53/README.md
+++ b/src/service/route53/README.md
@@ -151,6 +151,24 @@ to synchronize: the zone is described as already existing rather than created he
 reference is derived from its ID, since the creation that would have supplied one happened outside
 the simulation.
 
+### A zone the template names but never creates
+
+Registering the zone is a setup step the caller has to know to take, and a template using
+`HostedZone.fromLookup` describes the zone well enough that they should not have to. So
+`cfn/record-set/resolve/sim-cfn-r53-looked-up-zone.ts` registers one on demand: a RecordSet naming a
+`HostedZoneId` no zone holds gets that zone stood up as the record is created, with `nameInferred`
+set on the registration.
+
+The template carries the ID but never the name, so the name is inferred from the record names.
+`SimRoute53HostedZone.widenInferredName` takes each subsequent record name and drops labels from the
+front of the zone name until what is left is a suffix of both, using
+`hosted-zone/sim-route53-zone-name-widening.ts`. That converges on the shortest name containing every
+record, which is the zone apex for any stack holding a record there.
+
+`nameInferred` is what keeps this off ordinary zones. A zone that was named rather than guessed keeps
+its name, so a record outside it stays outside it rather than silently widening a zone the caller
+described.
+
 The simulator does not currently try to emulate all AWS edge cases around duplicate zone names,
 delegation sets, private-zone VPC associations, or caller-reference replay output. The caller
 reference is mainly used to prevent accidental duplicate CloudFormation-created zones and to match

--- a/src/service/route53/cfn/record-set/apply/sim-cfn-r53-record-set-applicator.iso.test.ts
+++ b/src/service/route53/cfn/record-set/apply/sim-cfn-r53-record-set-applicator.iso.test.ts
@@ -1,5 +1,7 @@
 import {
+  assertIdentical,
   assertInstanceOf,
+  assertNonNullable,
   assertObjectMatches,
   assertStringIncludes,
   assertThrowsErrorAsync,
@@ -7,7 +9,7 @@ import {
 import { describe, it } from "vitest";
 import { SimAws } from "../../../../aws/sim-aws.js";
 import { SimCfnResource } from "../../../../cloudformation/resource/sim-cfn-resource.js";
-import { SimRoute53NoSuchHostedZone } from "../../../error/sim-route53.error.js";
+import type { SimRoute53HostedZoneId } from "../../../command/create-hosted-zone/sim-route53-zone-id.js";
 import { SimCfnRoute53RecordSetApplicator } from "./sim-cfn-r53-record-set-applicator.js";
 
 describe("SimCfnRoute53RecordSetApplicator", () => {
@@ -73,26 +75,60 @@ describe("SimCfnRoute53RecordSetApplicator", () => {
     );
   });
 
-  it("reports an unknown real world HostedZoneId as NoSuchHostedZone", async () => {
+  it("registers a Hosted Zone named only by a real world HostedZoneId", async () => {
+    // Given a RecordSet applicator with no Hosted Zones.
+    const simAws = new SimAws();
+    const route53 = simAws.route53();
+    const applicator = new SimCfnRoute53RecordSetApplicator({ route53 });
+
+    // When a CloudFormation RecordSet uses a real 14 character HostedZoneId,
+    // as a zone the CDK app looked up rather than created does.
+    const record = await applicator.create(resource(), {
+      HostedZoneId: "Z2FDTNDATAQYW2",
+      Name: "www.example.com",
+      Type: "A",
+      TTL: 300,
+      ResourceRecords: ["192.0.2.1"],
+    });
+
+    // Then the zone is stood up under that ID and holds the record.
+    const hostedZone = route53.hostedZones.get(
+      "Z2FDTNDATAQYW2" as SimRoute53HostedZoneId,
+    );
+
+    assertNonNullable(hostedZone);
+    assertIdentical(hostedZone.name, "www.example.com.");
+    assertObjectMatches(record, {
+      name: "www.example.com",
+      type: "A",
+      values: ["192.0.2.1"],
+    });
+  });
+
+  it("throws when a RecordSet naming a Hosted Zone by ID has no usable Name", async () => {
     // Given a RecordSet applicator.
     const simAws = new SimAws();
     const applicator = new SimCfnRoute53RecordSetApplicator({
       route53: simAws.route53(),
     });
 
-    // When a CloudFormation RecordSet uses a real 14 character HostedZoneId.
+    // When a CloudFormation RecordSet names a Hosted Zone by ID but its own
+    // Name is not a string, so nothing says what the zone is called.
     const error = await assertThrowsErrorAsync(async () =>
       applicator.create(resource(), {
         HostedZoneId: "Z2FDTNDATAQYW2",
-        Name: "www.example.com",
+        Name: 123,
         Type: "A",
         ResourceRecords: ["192.0.2.1"],
       }),
     );
 
-    // Then the ID passes validation and the missing zone is reported.
-    assertInstanceOf(error, SimRoute53NoSuchHostedZone);
-    assertStringIncludes(error.message, "Z2FDTNDATAQYW2");
+    // Then a clear validation error is thrown.
+    assertInstanceOf(error, TypeError);
+    assertStringIncludes(
+      error.message,
+      "Invalid AWS::Route53::RecordSet TestRecordSet: Name must be a string",
+    );
   });
 
   it("throws when HostedZoneName is invalid or cannot be found", async () => {

--- a/src/service/route53/cfn/record-set/apply/sim-cfn-r53-record-set-applicator.iso.test.ts
+++ b/src/service/route53/cfn/record-set/apply/sim-cfn-r53-record-set-applicator.iso.test.ts
@@ -5,6 +5,7 @@ import {
   assertObjectMatches,
   assertStringIncludes,
   assertThrowsErrorAsync,
+  assertUndefined,
 } from "@kensio/smartass";
 import { describe, it } from "vitest";
 import { SimAws } from "../../../../aws/sim-aws.js";
@@ -103,6 +104,30 @@ describe("SimCfnRoute53RecordSetApplicator", () => {
       type: "A",
       values: ["192.0.2.1"],
     });
+  });
+
+  it("registers no Hosted Zone for a RecordSet it does not go on to create", async () => {
+    // Given a RecordSet applicator with no Hosted Zones.
+    const simAws = new SimAws();
+    const route53 = simAws.route53();
+    const applicator = new SimCfnRoute53RecordSetApplicator({ route53 });
+
+    // When a RecordSet names a looked-up Hosted Zone but declares a record
+    // type sim Route53 does not store, so the Resource is skipped.
+    await assertThrowsErrorAsync(async () =>
+      applicator.create(resource(), {
+        HostedZoneId: "Z2FDTNDATAQYW2",
+        Name: "www.example.com",
+        Type: "DS",
+        ResourceRecords: ["12345 13 2 abc"],
+      }),
+    );
+
+    // Then no zone is left behind for a record that was never created, which a
+    // retry or a later stack would otherwise find already there.
+    assertUndefined(
+      route53.hostedZones.get("Z2FDTNDATAQYW2" as SimRoute53HostedZoneId),
+    );
   });
 
   it("throws when a RecordSet naming a Hosted Zone by ID has no usable Name", async () => {

--- a/src/service/route53/cfn/record-set/apply/sim-cfn-r53-record-set-applicator.ts
+++ b/src/service/route53/cfn/record-set/apply/sim-cfn-r53-record-set-applicator.ts
@@ -34,10 +34,9 @@ export class SimCfnRoute53RecordSetApplicator {
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
   ): Promise<SimRoute53Record> {
-    const hostedZoneId = this.hostedZoneResolver.hostedZoneId(
-      resource,
-      properties,
-    );
+    // The record set is built first because resolving the Hosted Zone can
+    // register one, and a RecordSet that turns out to be unbuildable or of a
+    // skipped record type would otherwise leave that zone behind.
     const recordSetBuilder = new SimCfnRoute53RecordSetBuilder(
       resource,
       properties,
@@ -46,6 +45,11 @@ export class SimCfnRoute53RecordSetApplicator {
 
     assertDefined(recordSet.Name, "Route53 record set name");
     assertDefined(recordSet.Type, "Route53 record set type");
+
+    const hostedZoneId = this.hostedZoneResolver.hostedZoneId(
+      resource,
+      properties,
+    );
 
     await this.route53.changeResourceRecordSets({
       input: {

--- a/src/service/route53/cfn/record-set/resolve/sim-cfn-r53-looked-up-zone.iso.test.ts
+++ b/src/service/route53/cfn/record-set/resolve/sim-cfn-r53-looked-up-zone.iso.test.ts
@@ -1,0 +1,88 @@
+import { assertIdentical, assertNonNullable } from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimRoute53 } from "../../../sim-route53.js";
+import type { SimRoute53HostedZoneId } from "../../../command/create-hosted-zone/sim-route53-zone-id.js";
+import { SimCfnRoute53LookedUpZone } from "./sim-cfn-r53-looked-up-zone.js";
+
+describe("SimCfnRoute53LookedUpZone", () => {
+  const hostedZoneId = "Z2FDTNDATAQYW2" as SimRoute53HostedZoneId;
+
+  function lookedUpZone(route53: SimRoute53): SimCfnRoute53LookedUpZone {
+    return new SimCfnRoute53LookedUpZone({ route53 });
+  }
+
+  it("registers a Hosted Zone named after the first record to reference it", () => {
+    // Given a sim Route53 with no Hosted Zones.
+    const route53 = new SimRoute53();
+
+    // When a record names a Hosted Zone by ID alone.
+    lookedUpZone(route53).ensure(hostedZoneId, "www.example.com");
+
+    // Then the zone exists under that ID, named from the record.
+    const hostedZone = route53.hostedZones.get(hostedZoneId);
+
+    assertNonNullable(hostedZone);
+    assertIdentical(hostedZone.name, "www.example.com.");
+  });
+
+  it("widens the inferred name for a record above it", () => {
+    // Given a Hosted Zone inferred from a subdomain record.
+    const route53 = new SimRoute53();
+    const zone = lookedUpZone(route53);
+
+    zone.ensure(hostedZoneId, "www.example.com");
+
+    // When a second record at the apex references the same zone.
+    zone.ensure(hostedZoneId, "example.com");
+
+    // Then the inferred name widens to contain both records.
+    const hostedZone = route53.hostedZones.get(hostedZoneId);
+
+    assertNonNullable(hostedZone);
+    assertIdentical(hostedZone.name, "example.com.");
+  });
+
+  it("leaves the inferred name alone for a record already inside it", () => {
+    // Given a Hosted Zone inferred from an apex record.
+    const route53 = new SimRoute53();
+    const zone = lookedUpZone(route53);
+
+    zone.ensure(hostedZoneId, "example.com");
+
+    // When a subdomain record references the same zone.
+    zone.ensure(hostedZoneId, "www.example.com");
+
+    // Then the zone keeps the name that already contains the record.
+    const hostedZone = route53.hostedZones.get(hostedZoneId);
+
+    assertNonNullable(hostedZone);
+    assertIdentical(hostedZone.name, "example.com.");
+  });
+
+  it("leaves a Hosted Zone that was named rather than inferred", async () => {
+    // Given a Hosted Zone the caller created, so its name is known.
+    const route53 = new SimRoute53();
+    const created = await route53.createHostedZone({
+      input: {
+        Name: "www.example.com",
+        CallerReference: "looked-up-zone-test",
+      },
+    });
+    assertNonNullable(created.HostedZone?.Id);
+
+    const createdId = created.HostedZone.Id.replace(
+      "/hostedzone/",
+      "",
+    ) as SimRoute53HostedZoneId;
+
+    // When a record above it names it by ID.
+    lookedUpZone(route53).ensure(createdId, "example.com");
+
+    // Then the known name stands: the record is outside the zone, and widening
+    // here would hide that rather than report it.
+    const hostedZone = route53.hostedZones.get(createdId);
+
+    assertNonNullable(hostedZone);
+    assertIdentical(hostedZone.name, "www.example.com.");
+  });
+});

--- a/src/service/route53/cfn/record-set/resolve/sim-cfn-r53-looked-up-zone.ts
+++ b/src/service/route53/cfn/record-set/resolve/sim-cfn-r53-looked-up-zone.ts
@@ -1,0 +1,57 @@
+import type { SimRoute53HostedZoneId } from "../../../command/create-hosted-zone/sim-route53-zone-id.js";
+import type { SimRoute53 } from "../../../sim-route53.js";
+
+interface SimCfnRoute53LookedUpZoneProperties {
+  readonly route53: SimRoute53;
+}
+
+/**
+ * Stands up the Hosted Zone a CloudFormation template names but never creates.
+ *
+ * `HostedZone.fromLookup` resolves the zone at synth time, so the ID of a real
+ * zone in a real account is written into `cdk.context.json` and into every
+ * RecordSet in the synthesized template. Nothing in the template creates that
+ * zone, because as far as CloudFormation is concerned it is already there. A
+ * simulation deploying the same template has no such zone, and every record in
+ * it would fail with NoSuchHostedZone, which is a template that cannot be
+ * deployed here at all rather than a fault worth reporting.
+ *
+ * So the zone is registered on demand, under the ID the template names. This
+ * diverges from CloudFormation, which would refuse: the ID belongs to an
+ * account the simulation is not, and the alternative is that no stack using
+ * `fromLookup` can be simulated without being told separately about a zone the
+ * template already describes well enough.
+ *
+ * What the template does not carry is the zone's name, which `fromLookup` keeps
+ * in the context file. It is inferred from the records instead: the first
+ * record to reference the zone names it, and a record above that name widens
+ * it, which converges on the shortest name containing all of them. That is the
+ * zone apex for any stack holding a record there, which is the usual shape, and
+ * otherwise it is as much as the template says.
+ */
+export class SimCfnRoute53LookedUpZone {
+  private readonly route53: SimRoute53;
+
+  constructor(properties: SimCfnRoute53LookedUpZoneProperties) {
+    this.route53 = properties.route53;
+  }
+
+  /**
+   * Make sure a Hosted Zone with this ID exists and contains a record name.
+   */
+  ensure(hostedZoneId: SimRoute53HostedZoneId, recordName: string): void {
+    const hostedZone = this.route53.hostedZones.get(hostedZoneId);
+
+    if (hostedZone === undefined) {
+      this.route53.registerHostedZone({
+        id: hostedZoneId,
+        name: recordName,
+        nameInferred: true,
+      });
+
+      return;
+    }
+
+    hostedZone.widenInferredName(recordName);
+  }
+}

--- a/src/service/route53/cfn/record-set/resolve/sim-cfn-r53-rec-set-zone-resolver.ts
+++ b/src/service/route53/cfn/record-set/resolve/sim-cfn-r53-rec-set-zone-resolver.ts
@@ -7,6 +7,7 @@ import {
 import { normaliseSimRoute53Name } from "../../../local-name/sim-route53-local-name.js";
 import type { SimRoute53 } from "../../../sim-route53.js";
 import { assertDefined } from "../../../../../util/type-guard/defined.js";
+import { SimCfnRoute53LookedUpZone } from "./sim-cfn-r53-looked-up-zone.js";
 
 interface SimCfnRoute53RecordSetHostedZoneResolverProperties {
   readonly route53: SimRoute53;
@@ -17,9 +18,13 @@ interface SimCfnRoute53RecordSetHostedZoneResolverProperties {
  */
 export class SimCfnRoute53RecordSetHostedZoneResolver {
   private readonly route53: SimRoute53;
+  private readonly lookedUpZone: SimCfnRoute53LookedUpZone;
 
   constructor(properties: SimCfnRoute53RecordSetHostedZoneResolverProperties) {
     this.route53 = properties.route53;
+    this.lookedUpZone = new SimCfnRoute53LookedUpZone({
+      route53: this.route53,
+    });
   }
 
   /**
@@ -38,10 +43,35 @@ export class SimCfnRoute53RecordSetHostedZoneResolver {
         );
       }
 
-      return normalizeSimRoute53HostedZoneId(hostedZoneId);
+      const normalizedHostedZoneId =
+        normalizeSimRoute53HostedZoneId(hostedZoneId);
+
+      // A zone named by ID alone is one the CDK app looked up rather than
+      // created, so the simulation stands it up rather than refusing the record.
+      this.lookedUpZone.ensure(
+        normalizedHostedZoneId,
+        this.recordName(resource, properties),
+      );
+
+      return normalizedHostedZoneId;
     }
 
     return this.hostedZoneIdFromName(resource, properties);
+  }
+
+  private recordName(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): string {
+    const name = properties["Name"];
+
+    if (typeof name !== "string") {
+      throw new TypeError(
+        `Invalid AWS::Route53::RecordSet ${resource.logicalId}: Name must be a string`,
+      );
+    }
+
+    return name;
   }
 
   private hostedZoneIdFromName(

--- a/src/service/route53/hosted-zone/register-sim-route53-hosted-zone.ts
+++ b/src/service/route53/hosted-zone/register-sim-route53-hosted-zone.ts
@@ -18,6 +18,12 @@ export interface SimRoute53HostedZoneRegistration {
   readonly id: SimRoute53HostedZoneId | string;
   readonly name: string;
   readonly config?: SimRoute53HostedZoneConfig | undefined;
+  /**
+   * Whether the name is a guess that the records the zone comes to hold may
+   * widen. This is for the zone a CloudFormation template names by ID without
+   * saying what it is called, and ordinary registrations leave it alone.
+   */
+  readonly nameInferred?: boolean | undefined;
 }
 
 interface RegisterSimRoute53HostedZoneProperties {
@@ -59,6 +65,7 @@ export function registerSimRoute53HostedZone(
     // having happened elsewhere, so its ID stands in as the unique one.
     callerReference: `registered-${hostedZoneId}`,
     config: registration.config,
+    nameInferred: registration.nameInferred,
   });
   hostedZone.markSynchronized();
 

--- a/src/service/route53/hosted-zone/sim-route53-hosted-zone.ts
+++ b/src/service/route53/hosted-zone/sim-route53-hosted-zone.ts
@@ -71,8 +71,8 @@ export class SimRoute53HostedZone {
    *
    * A zone whose name was inferred from one record can be told about another,
    * and the two together say more about where the zone sits than either does
-   * alone. A zone that was named rather than inferred keeps its name: the
-   * record is outside it, and refusing here is how that gets noticed.
+   * alone. A zone that was named rather than inferred keeps its name, since
+   * nothing about it was a guess in the first place.
    */
   widenInferredName(recordName: string): void {
     if (!this.nameInferred) {

--- a/src/service/route53/hosted-zone/sim-route53-hosted-zone.ts
+++ b/src/service/route53/hosted-zone/sim-route53-hosted-zone.ts
@@ -6,7 +6,9 @@ import {
   type SimRoute53HostedZoneId,
 } from "../command/create-hosted-zone/sim-route53-zone-id.js";
 import type { BackgroundScheduler } from "../../../util/background/background.js";
+import { SimRoute53ZoneSynchronization } from "./sim-route53-zone-synchronization.js";
 import { SimRoute53HostedZoneNotEmpty } from "../error/sim-route53.error.js";
+import { widenSimRoute53ZoneName } from "./sim-route53-zone-name-widening.js";
 
 export type SimRoute53HostedZoneStatus = "PENDING" | "INSYNC";
 
@@ -16,6 +18,12 @@ interface SimRoute53HostedZoneProperties {
   // Route53 Hosted Zone caller reference is like an idempotency key.
   readonly callerReference: string;
   readonly config?: SimRoute53HostedZoneConfig | undefined;
+  /**
+   * Whether the name is a guess drawn from the records the zone holds, rather
+   * than something the simulation was told. Only the CloudFormation looked-up
+   * zone sets this; see `SimCfnRoute53LookedUpZone`.
+   */
+  readonly nameInferred?: boolean | undefined;
 }
 
 /**
@@ -26,43 +34,52 @@ interface SimRoute53HostedZoneProperties {
 export class SimRoute53HostedZone {
   /* @internal */
   public readonly records = new SimRoute53HostedZoneRecords();
-  private readonly hostedZoneId: SimRoute53HostedZoneId;
-  private readonly hostedZoneName: string;
-  // Route53 Hosted Zone caller reference is like an idempotency key.
-  private readonly hostedZoneCallerReference: string;
-  private readonly hostedZoneConfig: SimRoute53HostedZoneConfig | undefined;
-  #status: SimRoute53HostedZoneStatus = "PENDING";
-  private synchronizationComplete: Promise<void> | undefined;
-
-  constructor(properties: SimRoute53HostedZoneProperties) {
-    assertIsSimRoute53HostedZoneId(properties.id);
-    this.hostedZoneId = properties.id;
-    this.hostedZoneName = `${normaliseSimRoute53Name(properties.name)}.`;
-    this.hostedZoneCallerReference = properties.callerReference;
-    this.hostedZoneConfig =
-      properties.config === undefined ? undefined : { ...properties.config };
-  }
-
   /**
    * AWS Route53 Hosted Zone ID.
    */
-  get id(): SimRoute53HostedZoneId {
-    return this.hostedZoneId;
+  public readonly id: SimRoute53HostedZoneId;
+  /**
+   * Caller reference supplied when the Hosted Zone was created, which Route53
+   * treats like an idempotency key.
+   */
+  public readonly callerReference: string;
+  private readonly nameInferred: boolean;
+  private readonly hostedZoneConfig: SimRoute53HostedZoneConfig | undefined;
+  #name: string;
+  #status: SimRoute53HostedZoneStatus = "PENDING";
+  private readonly synchronization = new SimRoute53ZoneSynchronization();
+
+  constructor(properties: SimRoute53HostedZoneProperties) {
+    assertIsSimRoute53HostedZoneId(properties.id);
+    this.id = properties.id;
+    this.#name = `${normaliseSimRoute53Name(properties.name)}.`;
+    this.nameInferred = properties.nameInferred ?? false;
+    this.callerReference = properties.callerReference;
+    this.hostedZoneConfig =
+      properties.config === undefined ? undefined : { ...properties.config };
   }
 
   /**
    * Normalised Route53 Hosted Zone name.
    */
   get name(): string {
-    return this.hostedZoneName;
+    return this.#name;
   }
 
   /**
-   * Caller reference supplied when the hosted zone was created.
-   * A Route53 Hosted Zone caller reference is like an idempotency key.
+   * Widen an inferred zone name so that it contains a record name.
+   *
+   * A zone whose name was inferred from one record can be told about another,
+   * and the two together say more about where the zone sits than either does
+   * alone. A zone that was named rather than inferred keeps its name: the
+   * record is outside it, and refusing here is how that gets noticed.
    */
-  get callerReference(): string {
-    return this.hostedZoneCallerReference;
+  widenInferredName(recordName: string): void {
+    if (!this.nameInferred) {
+      return;
+    }
+
+    this.#name = `${widenSimRoute53ZoneName(this.#name, recordName)}.`;
   }
 
   /**
@@ -96,38 +113,14 @@ export class SimRoute53HostedZone {
     background: BackgroundScheduler,
     synchronize: () => Promise<void>,
   ): void {
-    const synchronizationComplete = new Promise<void>((resolve, reject) => {
-      background.schedule(async () => {
-        try {
-          await synchronize();
-          resolve();
-        } catch (error) {
-          /* v8 ignore start */
-          reject(error instanceof Error ? error : new Error(String(error)));
-          throw error;
-          /* v8 ignore stop */
-        }
-      });
-    });
-
-    this.synchronizationComplete =
-      this.synchronizationComplete === undefined
-        ? synchronizationComplete
-        : (async (): Promise<void> => {
-            await Promise.all([
-              this.synchronizationComplete,
-              synchronizationComplete,
-            ]);
-          })();
+    this.synchronization.schedule(background, synchronize);
   }
 
   /**
    * Wait for outstanding Hosted Zone synchronization operations.
    */
   async waitForSynchronizationComplete(): Promise<void> {
-    if (this.synchronizationComplete !== undefined) {
-      await this.synchronizationComplete;
-    }
+    await this.synchronization.waitForComplete();
   }
 
   /**

--- a/src/service/route53/hosted-zone/sim-route53-zone-name-widening.iso.test.ts
+++ b/src/service/route53/hosted-zone/sim-route53-zone-name-widening.iso.test.ts
@@ -1,0 +1,70 @@
+import {
+  assertIdentical,
+  assertStringIncludes,
+  assertThrowsError,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { widenSimRoute53ZoneName } from "./sim-route53-zone-name-widening.js";
+
+describe("widenSimRoute53ZoneName", () => {
+  it("keeps a zone name that already contains the record", () => {
+    // Given a zone name and a record name below it.
+    // When the zone name is widened by the record name.
+    const widened = widenSimRoute53ZoneName("example.com", "www.example.com");
+
+    // Then the zone name is unchanged, because it already contains the record.
+    assertIdentical(widened, "example.com");
+  });
+
+  it("keeps a zone name that is the record name", () => {
+    // Given a zone name equal to the record name.
+    // When the zone name is widened by it.
+    const widened = widenSimRoute53ZoneName("example.com", "example.com");
+
+    // Then the apex record leaves the zone name alone.
+    assertIdentical(widened, "example.com");
+  });
+
+  it("drops labels until the zone name contains the record", () => {
+    // Given a zone name inferred from a subdomain record.
+    // When a record at the apex widens it.
+    const widened = widenSimRoute53ZoneName("www.example.com", "example.com");
+
+    // Then the zone name is the shortest name containing both.
+    assertIdentical(widened, "example.com");
+  });
+
+  it("widens to the shared suffix of two sibling record names", () => {
+    // Given a zone name inferred from one subdomain record.
+    // When a sibling subdomain record widens it.
+    const widened = widenSimRoute53ZoneName(
+      "www.example.com",
+      "mail.example.com",
+    );
+
+    // Then neither name contains the other, so the shared parent is the zone.
+    assertIdentical(widened, "example.com");
+  });
+
+  it("ignores a trailing dot on either name", () => {
+    // Given a fully qualified zone name and record name.
+    // When the zone name is widened.
+    const widened = widenSimRoute53ZoneName("www.example.com.", "example.com.");
+
+    // Then the trailing dots make no difference to the labels compared.
+    assertIdentical(widened, "example.com");
+  });
+
+  it("refuses names that share no domain suffix", () => {
+    // Given a zone name and a record name in an unrelated domain.
+    // When the zone name is widened by it, then it refuses rather than
+    // returning a zone name containing neither.
+    const error = assertThrowsError(() =>
+      widenSimRoute53ZoneName("www.example.com", "www.example.org"),
+    );
+
+    // And both names are named for diagnosis.
+    assertStringIncludes(error.message, "www.example.com");
+    assertStringIncludes(error.message, "www.example.org");
+  });
+});

--- a/src/service/route53/hosted-zone/sim-route53-zone-name-widening.ts
+++ b/src/service/route53/hosted-zone/sim-route53-zone-name-widening.ts
@@ -1,0 +1,52 @@
+import { normaliseSimRoute53Name } from "../local-name/sim-route53-local-name.js";
+
+/**
+ * Widen a zone name so that it also contains a record name.
+ *
+ * A zone contains a name when the name is the zone apex or sits below it, so
+ * widening means dropping labels from the front of the zone name until what is
+ * left is a suffix of the record name too. `www.example.com` widened by
+ * `example.com` is `example.com`; widened by `mail.example.com` it is unchanged,
+ * because `mail.example.com` is not inside `www.example.com` and dropping labels
+ * cannot make it so without going up to `example.com`, which is what happens.
+ *
+ * This exists for the zone a CDK stack looked up rather than created, whose name
+ * the simulation has to infer from the records that reference it. See
+ * `SimCfnRoute53LookedUpZone`.
+ */
+export function widenSimRoute53ZoneName(
+  zoneName: string,
+  recordName: string,
+): string {
+  const zoneLabels = normaliseSimRoute53Name(zoneName).split(".");
+  const recordLabels = normaliseSimRoute53Name(recordName).split(".");
+
+  const sharedLabels: string[] = [];
+
+  // Walk both names from the right, which is where a domain name's containment
+  // is decided, and keep the labels they agree on.
+  for (
+    let offset = 1;
+    offset <= Math.min(zoneLabels.length, recordLabels.length);
+    offset += 1
+  ) {
+    const zoneLabel = zoneLabels[zoneLabels.length - offset];
+
+    if (
+      zoneLabel === undefined ||
+      zoneLabel !== recordLabels[recordLabels.length - offset]
+    ) {
+      break;
+    }
+
+    sharedLabels.unshift(zoneLabel);
+  }
+
+  if (sharedLabels.length === 0) {
+    throw new Error(
+      `Sim Route53 Hosted Zone ${zoneName} shares no domain suffix with record ${recordName}`,
+    );
+  }
+
+  return sharedLabels.join(".");
+}

--- a/src/service/route53/hosted-zone/sim-route53-zone-synchronization.ts
+++ b/src/service/route53/hosted-zone/sim-route53-zone-synchronization.ts
@@ -1,0 +1,53 @@
+import type { BackgroundScheduler } from "../../../util/background/background.js";
+
+/**
+ * The outstanding synchronization work for one simulated Hosted Zone.
+ *
+ * Route53 reports a zone as PENDING until its change has propagated, and a test
+ * that wants the settled state waits for it. A zone can be changed again before
+ * the previous change has finished, so this keeps one promise covering all of
+ * them rather than only the most recent.
+ */
+export class SimRoute53ZoneSynchronization {
+  #complete: Promise<void> | undefined;
+
+  /**
+   * Schedule synchronization work and remember its completion.
+   */
+  schedule(
+    background: BackgroundScheduler,
+    synchronize: () => Promise<void>,
+  ): void {
+    this.#complete = this.combined(this.scheduled(background, synchronize));
+  }
+
+  /**
+   * Wait for every synchronization scheduled so far.
+   */
+  async waitForComplete(): Promise<void> {
+    await this.#complete;
+  }
+
+  private scheduled(
+    background: BackgroundScheduler,
+    synchronize: () => Promise<void>,
+  ): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+      background.schedule(async () => {
+        try {
+          await synchronize();
+          resolve();
+        } catch (error) {
+          /* v8 ignore start */
+          reject(error instanceof Error ? error : new Error(String(error)));
+          throw error;
+          /* v8 ignore stop */
+        }
+      });
+    });
+  }
+
+  private async combined(scheduled: Promise<void>): Promise<void> {
+    await Promise.all([this.#complete, scheduled]);
+  }
+}

--- a/src/service/route53/sim-route53.ts
+++ b/src/service/route53/sim-route53.ts
@@ -122,8 +122,10 @@ export class SimRoute53 {
    * An ID another Hosted Zone holds, or one that is not a Route53 Hosted Zone
    * ID, is refused.
    */
-  registerHostedZone(registration: SimRoute53HostedZoneRegistration): void {
-    registerSimRoute53HostedZone(registration, {
+  registerHostedZone(
+    registration: SimRoute53HostedZoneRegistration,
+  ): SimRoute53HostedZone {
+    return registerSimRoute53HostedZone(registration, {
       hostedZones: this.hostedZones,
       route53Registry: this.route53Registry,
     });

--- a/src/service/s3/README.md
+++ b/src/service/s3/README.md
@@ -224,8 +224,15 @@ Metadata is stored separately from the object body. `PutObjectCommandHandler` co
 `GetObjectCommandHandler` returns object bodies as Node `Readable` streams and returns stored
 metadata through `Metadata`.
 
-The static website HTTP controller also reads the `"content-type"` metadata key when producing HTTP
-responses.
+`object/s3-object-response-headers.ts` is the single mapping from stored metadata to HTTP response
+headers, and every path that serves an Object goes through it: the S3 REST endpoint reader, the
+static website endpoint and the CloudFront S3 Origin. It returns the system metadata S3 keeps as a
+header and hands back on a read, and nothing else, so user-defined metadata does not leak into the
+response. Keeping it in one place is what stops the three endpoints disagreeing about what reading an
+Object looks like.
+
+Note that `PutObject` only writes `ContentType` into that set. The other headers reach an Object
+through a CDK BucketDeployment's `SystemMetadata`, which builds the metadata record directly.
 
 ## Storage implementations
 

--- a/src/service/s3/README.md
+++ b/src/service/s3/README.md
@@ -557,7 +557,8 @@ Signature verification itself is not here: it happens once at the serving bounda
 
 - returns `403` if static website hosting is not enabled
 - applies redirect-all-requests configuration before object lookup
-- serves objects with `content-length` and optional `content-type`
+- serves objects with `content-length` and the system metadata headers S3 returns on a read,
+  through `object/s3-object-response-headers.ts`
 - returns headers but no body for `HEAD`
 - applies trailing-slash redirects for folder index documents
 - serves configured error documents with status `404`

--- a/src/service/s3/object/s3-object-response-headers.iso.test.ts
+++ b/src/service/s3/object/s3-object-response-headers.iso.test.ts
@@ -1,0 +1,78 @@
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertObjectMatches,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { simS3ObjectResponseHeaders } from "./s3-object-response-headers.js";
+
+describe("simS3ObjectResponseHeaders", () => {
+  it("describes the body length of an Object with no metadata", () => {
+    // Given an Object stored without any system metadata.
+    // When its response headers are built.
+    const headers = simS3ObjectResponseHeaders(undefined, 42);
+
+    // Then only the length of what is being served is reported.
+    assertObjectMatches(headers, { "content-length": "42" });
+    assertArrayLength(Object.keys(headers), 1);
+  });
+
+  it("returns the system metadata S3 was given when the Object was written", () => {
+    // Given an Object stored with every system metadata header S3 keeps.
+    const metadata = {
+      "cache-control": "public, max-age=31536000, immutable",
+      "content-disposition": 'attachment; filename="report.csv"',
+      "content-encoding": "br",
+      "content-language": "en-GB",
+      "content-type": "text/csv",
+      expires: "Wed, 21 Oct 2026 07:28:00 GMT",
+    };
+
+    // When its response headers are built.
+    const headers = simS3ObjectResponseHeaders(metadata, 100);
+
+    // Then each one comes back unchanged, alongside the body length.
+    assertObjectMatches(headers, { ...metadata, "content-length": "100" });
+  });
+
+  it("keeps a content encoding so the body can be decoded", () => {
+    // Given an Object stored as brotli.
+    // When its response headers are built.
+    const headers = simS3ObjectResponseHeaders(
+      { "content-encoding": "br", "content-type": "text/plain" },
+      7,
+    );
+
+    // Then the encoding is reported, because bytes served without it are bytes
+    // no client can decode.
+    assertObjectMatches(headers, {
+      "content-encoding": "br",
+      "content-type": "text/plain",
+      "content-length": "7",
+    });
+  });
+
+  it("leaves out user metadata and anything else S3 does not return as a header", () => {
+    // Given an Object stored with user metadata alongside its content type.
+    const headers = simS3ObjectResponseHeaders(
+      { "content-type": "text/plain", "x-amz-meta-author": "hg", etag: "abc" },
+      3,
+    );
+
+    // Then only the system metadata S3 returns as a header comes back.
+    assertObjectMatches(headers, {
+      "content-type": "text/plain",
+      "content-length": "3",
+    });
+    assertArrayLength(Object.keys(headers), 2);
+  });
+
+  it("reports the length it is given rather than one from metadata", () => {
+    // Given an Object whose stored metadata claims a different length.
+    // When its response headers are built for a body of a known size.
+    const headers = simS3ObjectResponseHeaders({ "content-length": "999" }, 5);
+
+    // Then the body being served decides the length, not what was remembered.
+    assertIdentical(headers["content-length"], "5");
+  });
+});

--- a/src/service/s3/object/s3-object-response-headers.ts
+++ b/src/service/s3/object/s3-object-response-headers.ts
@@ -1,0 +1,51 @@
+/**
+ * The headers S3 sets on a read from what it was told when the Object was
+ * written.
+ *
+ * S3 keeps these as Object system metadata and hands them straight back,
+ * unchanged, on every read. That matters most for `Content-Encoding`: an Object
+ * stored as brotli and served without its encoding header is bytes no client
+ * can decode. `Cache-Control` matters for a different reason, being the only
+ * one of these a caller can set per Object rather than per response.
+ *
+ * Every path that serves an Object goes through here, so they agree on what
+ * reading one looks like.
+ *
+ * https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingMetadata.html
+ */
+export function simS3ObjectResponseHeaders(
+  metadata: Readonly<Record<string, string>> | undefined,
+  bodyLength: number,
+): Record<string, string> {
+  const headers: Record<string, string> = {
+    "content-length": String(bodyLength),
+  };
+
+  for (const name of simS3SystemMetadataHeaders) {
+    // eslint-disable-next-line security/detect-object-injection -- name comes from the fixed list below
+    const value = metadata?.[name];
+
+    if (value !== undefined) {
+      // eslint-disable-next-line security/detect-object-injection
+      headers[name] = value;
+    }
+  }
+
+  return headers;
+}
+
+/**
+ * The system metadata S3 stores as a header and returns as one.
+ *
+ * Content length is not here because it describes the body rather than being
+ * remembered about it, and content type is set for almost every Object because
+ * a deployment or the console guesses one from the file extension.
+ */
+const simS3SystemMetadataHeaders = [
+  "cache-control",
+  "content-disposition",
+  "content-encoding",
+  "content-language",
+  "content-type",
+  "expires",
+] as const;

--- a/src/service/s3/serve/sim-s3-rest-endpoint.iso.test.ts
+++ b/src/service/s3/serve/sim-s3-rest-endpoint.iso.test.ts
@@ -5,7 +5,7 @@ import {
   PutObjectCommand,
 } from "@aws-sdk/client-s3";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
-import { assertIdentical } from "@kensio/smartass";
+import { assertIdentical, assertNonNullable } from "@kensio/smartass";
 import { describe, expect, it } from "vitest";
 
 import {
@@ -14,6 +14,7 @@ import {
   presignObjectKey,
   presignSimulation,
 } from "../../../../test/s3/presign-simulation.js";
+import { SimS3Object, SimS3ObjectMetadata } from "../object/s3-object.js";
 
 const objectUrl = `http://${presignBucketName}.s3.eu-west-2.sim-aws.localhost/${presignObjectKey}`;
 
@@ -223,6 +224,49 @@ describe("The simulated S3 REST endpoint", () => {
     assertIdentical(
       simAws.s3().getBucketUrl(presignBucketName).toString(),
       `http://${presignBucketName}.s3.eu-west-2.sim-aws.localhost/`,
+    );
+  });
+
+  it("serves the system metadata an Object was stored with", async () => {
+    // Given an Object stored as brotli with a cache directive of its own, as a
+    // CDK BucketDeployment stores one
+    const { simAws, client, http } = await presignSimulation();
+    const bucket = simAws.s3().getSimBucketByName(presignBucketName);
+
+    assertNonNullable(bucket);
+
+    await bucket.putObject(
+      new SimS3Object({
+        key: "data/standard.keys",
+        body: Buffer.from("compressed"),
+        metadata: new SimS3ObjectMetadata({
+          "content-type": "text/plain",
+          "content-encoding": "br",
+          "cache-control": "public, max-age=60",
+        }),
+      }),
+    );
+
+    // When it is read back over the REST endpoint
+    const response = await http.fetch(
+      await getSignedUrl(
+        client,
+        new GetObjectCommand({
+          Bucket: presignBucketName,
+          Key: "data/standard.keys",
+        }),
+        { expiresIn: 900 },
+      ),
+    );
+
+    // Then the headers S3 was given come back with the bytes, so a client can
+    // decode what it is sent
+    assertIdentical(response.status, 200);
+    assertIdentical(response.headers.get("content-encoding"), "br");
+    assertIdentical(response.headers.get("content-type"), "text/plain");
+    assertIdentical(
+      response.headers.get("cache-control"),
+      "public, max-age=60",
     );
   });
 

--- a/src/service/s3/serve/sim-s3-rest-object-reader.ts
+++ b/src/service/s3/serve/sim-s3-rest-object-reader.ts
@@ -1,6 +1,7 @@
 import type { SimS3 } from "../sim-s3.js";
 import type { SimS3RestObjectRoute } from "./sim-s3-route.js";
 import type { SimAwsServiceRequest } from "../../../serve/controller/sim-service-controller.js";
+import { simS3ObjectResponseHeaders } from "../object/s3-object-response-headers.js";
 
 /**
  * Answers a `GET` or `HEAD` at the simulated S3 REST endpoint.
@@ -24,11 +25,7 @@ export class SimS3RestObjectReader {
     );
 
     const body = await bodyBytes(output.Body);
-    const contentType = output.Metadata?.["content-type"];
-    const headers = {
-      "content-length": String(body.length),
-      ...(contentType !== undefined && { "content-type": contentType }),
-    };
+    const headers = simS3ObjectResponseHeaders(output.Metadata, body.length);
 
     if (serviceRequest.request.method === "HEAD") {
       return new Response(undefined, { status: 200, headers });

--- a/src/service/s3/serve/website/sim-s3-website-object-loader.ts
+++ b/src/service/s3/serve/website/sim-s3-website-object-loader.ts
@@ -71,7 +71,7 @@ export class SimS3WebsiteObjectLoader {
 
       return new SimS3WebsiteObject(
         await simS3BodyToBuffer(output.Body as AsyncIterable<Buffer>),
-        output.Metadata?.["content-type"],
+        output.Metadata,
       );
     } catch (error) {
       if (error instanceof SimS3NoSuchKey) {

--- a/src/service/s3/serve/website/sim-s3-website-object.iso.test.ts
+++ b/src/service/s3/serve/website/sim-s3-website-object.iso.test.ts
@@ -1,0 +1,42 @@
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertObjectMatches,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimS3WebsiteObject } from "./sim-s3-website-object.js";
+
+describe("SimS3WebsiteObject", () => {
+  it("describes an Object with the system metadata it was stored with", () => {
+    // Given an Object the website endpoint has read, stored as brotli with a
+    // cache directive of its own.
+    const object = new SimS3WebsiteObject(Buffer.from("<h1>Hello</h1>"), {
+      "content-type": "text/html",
+      "content-encoding": "br",
+      "cache-control": "public, max-age=0, must-revalidate",
+    });
+
+    // When the website response headers are built.
+    const headers = object.headers();
+
+    // Then the endpoint serves what S3 remembers about the Object.
+    assertObjectMatches(headers, {
+      "content-type": "text/html",
+      "content-encoding": "br",
+      "cache-control": "public, max-age=0, must-revalidate",
+      "content-length": "14",
+    });
+  });
+
+  it("describes an Object stored without metadata by its length alone", () => {
+    // Given an Object with no stored metadata.
+    const object = new SimS3WebsiteObject(Buffer.from("plain"), undefined);
+
+    // When the website response headers are built.
+    const headers = object.headers();
+
+    // Then only the length of the body is reported.
+    assertIdentical(headers["content-length"], "5");
+    assertArrayLength(Object.keys(headers), 1);
+  });
+});

--- a/src/service/s3/serve/website/sim-s3-website-object.ts
+++ b/src/service/s3/serve/website/sim-s3-website-object.ts
@@ -1,26 +1,22 @@
+import { simS3ObjectResponseHeaders } from "../../object/s3-object-response-headers.js";
+
 /**
  * An Object the static website endpoint is about to serve.
  *
  * The website endpoint reads Objects through the ordinary GetObject command
  * rather than out of Bucket storage, so what it gets back is a stream and a
- * metadata record. This is that, collapsed into the two things an HTTP
- * response needs.
+ * metadata record. This is that, with the stream drained.
  */
 export class SimS3WebsiteObject {
   constructor(
     public readonly body: Buffer,
-    public readonly contentType: string | undefined,
+    public readonly metadata: Readonly<Record<string, string>> | undefined,
   ) {}
 
   /**
    * The headers describing this Object in a website response.
    */
   headers(): Record<string, string> {
-    return {
-      "content-length": String(this.body.length),
-      ...(this.contentType !== undefined && {
-        "content-type": this.contentType,
-      }),
-    };
+    return simS3ObjectResponseHeaders(this.metadata, this.body.length);
   }
 }


### PR DESCRIPTION
Four changes that between them make a CDK-synthesized documentation site stack deployable into the simulator and servable from it. A looked-up Route53 Hosted Zone is registered on demand rather than failing the first RecordSet, a CDK BucketDeployment copies its files in as Objects rather than mounting the asset directory, the system metadata an Object was stored with comes back on a read, and `AWS::CloudFront::ResponseHeadersPolicy` is applied to what a cache Behavior serves. Each is a commit of its own, with tests, docs and the deliberate divergences written up in the relevant Limitations sections.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CloudFront response headers policy support through CloudFormation and distribution behaviors.
  * Added custom header insertion, removal, override controls, and viewer-response interaction.
  * Enhanced CDK S3 bucket deployments with multiple sources, prefixes, filters, metadata, and pruning.
  * Added automatic Route 53 hosted zone creation and inferred name handling.
  * Expanded S3 responses to include supported system metadata headers consistently across access paths.

* **Documentation**
  * Added setup guidance, examples, supported functionality, and documented limitations for these features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->