### PR TITLE
feat: store Object system metadata on a write

### DIFF
--- a/docs/services/s3/README.md
+++ b/docs/services/s3/README.md
@@ -57,7 +57,8 @@ console.log(objectOut.Metadata?.["source"]);
 body is stored as an empty Object.
 
 `ContentType` is exposed as Object metadata under the `content-type` header name and is used when
-serving Bucket website responses.
+serving Bucket website responses. It is one of several headers a write can say about an Object. See
+[Object system metadata](#object-system-metadata).
 
 ## Accounts and Regions
 
@@ -1786,9 +1787,52 @@ Every path that serves an Object goes through the same mapping, so the REST endp
 for it. `content-encoding` is the one that matters most: bytes served without it are bytes no client
 can decode, so an Object stored as brotli is only usable if the header comes back with it.
 
-Sim S3 stores only `ContentType` and your own `Metadata` from a `PutObjectCommand`. The AWS SDK
-carries the rest, and real S3 keeps them, but the simulator drops them, so the way to set them today
-is a CDK BucketDeployment's `SystemMetadata`, which applies them to every Object it copies. See
+`PutObjectCommand` sets them, one request field per header.
+
+```typescript sim-s3-object-system-metadata
+/**
+ * Writing an Object with the system metadata S3 returns on a read.
+ */
+
+import {
+  CreateBucketCommand,
+  GetObjectCommand,
+  PutObjectCommand,
+} from "@aws-sdk/client-s3";
+import { SimAws } from "@kensio/yulin";
+
+const simS3 = new SimAws().s3();
+
+await simS3.createBucket(new CreateBucketCommand({ Bucket: "site" }));
+
+await simS3.putObject(
+  new PutObjectCommand({
+    Bucket: "site",
+    Key: "app.js",
+    Body: "compressed bytes",
+    CacheControl: "public, max-age=31536000, immutable",
+    ContentDisposition: 'inline; filename="app.js"',
+    ContentEncoding: "br",
+    ContentLanguage: "en-GB",
+    ContentType: "text/javascript",
+    Expires: new Date("2027-01-02T03:04:05Z"),
+  }),
+);
+
+const objectOut = await simS3.getObject(
+  new GetObjectCommand({ Bucket: "site", Key: "app.js" }),
+);
+
+// Each header is stored under the name a read returns it as.
+console.log(objectOut.Metadata?.["content-encoding"]); // br
+console.log(objectOut.Metadata?.["expires"]); // Sat, 02 Jan 2027 03:04:05 GMT
+```
+
+A header the write says nothing about is left unset rather than stored empty, so a read does not
+report it. `Expires` is the one field that is not a string: the SDK takes a `Date`, which is stored
+as the HTTP date a read hands back.
+
+A CDK BucketDeployment's `SystemMetadata` sets the same headers on every Object it copies. See
 [CDK S3 BucketDeployment](../cloudformation/README.md#cdk-s3-bucketdeployment).
 
 ## Standalone SimS3
@@ -1842,7 +1886,8 @@ Sim S3 currently supports:
 - Serving static website requests on localhost with `serveSimAws`
 - Serving Object `GET`, `HEAD`, `PUT` and `DELETE` over the S3 REST endpoint, authorized by sim IAM
 - Presigned URLs built by the real `@aws-sdk/s3-request-presigner`, with expiry in simulated time
-- Object system metadata returned on a read, over every endpoint that serves an Object
+- Object system metadata set by a `PutObjectCommand` and returned on a read, over every endpoint
+  that serves an Object
 - Bucket website index documents, error documents, trailing-slash redirects, redirect-all
   configuration, and routing-rule redirects
 - Bucket-global uniqueness within a `SimAws` instance across simulated Accounts and Regions
@@ -1868,7 +1913,11 @@ These apply across the page. The sections above each list what is specific to th
   not simulated.
 - A Bucket using filesystem-backed storage cannot delete Objects, and raises no event
   notifications, because it swaps the whole storage backend rather than putting Objects.
-- Sim S3 stores only `ContentType` and user-defined `Metadata` from a `PutObjectCommand`, and drops
-  the other system metadata the SDK carries and real S3 keeps. An Object needing `content-encoding`
-  or `cache-control` gets it from a CDK BucketDeployment's `SystemMetadata`. See
-  [Object system metadata](#object-system-metadata).
+- `GetObjectCommand` returns system metadata through `Metadata`, under the header name it is stored
+  as, rather than through the `ContentType`, `CacheControl` and other response fields real S3 uses.
+  See [Object system metadata](#object-system-metadata).
+- An upload over the S3 REST endpoint keeps its `content-type` and no other system metadata, so a
+  presigned `PUT` cannot set the rest. A `PutObjectCommand` through the SDK keeps all of them.
+- A presigned `GetObject` ignores the `response-content-type`, `response-cache-control` and other
+  `response-*` parameters that override a response header in real S3. An Object is served with the
+  system metadata it was written with.

--- a/docs/services/s3/sim-s3-object-system-metadata.example.ts
+++ b/docs/services/s3/sim-s3-object-system-metadata.example.ts
@@ -1,0 +1,36 @@
+/**
+ * Writing an Object with the system metadata S3 returns on a read.
+ */
+
+import {
+  CreateBucketCommand,
+  GetObjectCommand,
+  PutObjectCommand,
+} from "@aws-sdk/client-s3";
+import { SimAws } from "@kensio/yulin";
+
+const simS3 = new SimAws().s3();
+
+await simS3.createBucket(new CreateBucketCommand({ Bucket: "site" }));
+
+await simS3.putObject(
+  new PutObjectCommand({
+    Bucket: "site",
+    Key: "app.js",
+    Body: "compressed bytes",
+    CacheControl: "public, max-age=31536000, immutable",
+    ContentDisposition: 'inline; filename="app.js"',
+    ContentEncoding: "br",
+    ContentLanguage: "en-GB",
+    ContentType: "text/javascript",
+    Expires: new Date("2027-01-02T03:04:05Z"),
+  }),
+);
+
+const objectOut = await simS3.getObject(
+  new GetObjectCommand({ Bucket: "site", Key: "app.js" }),
+);
+
+// Each header is stored under the name a read returns it as.
+console.log(objectOut.Metadata?.["content-encoding"]); // br
+console.log(objectOut.Metadata?.["expires"]); // Sat, 02 Jan 2027 03:04:05 GMT

--- a/src/service/s3/README.md
+++ b/src/service/s3/README.md
@@ -219,10 +219,17 @@ Objects are represented as `SimS3Object` instances. In normal command flow,
 Metadata is stored separately from the object body. `PutObjectCommandHandler` combines:
 
 - `input.Metadata`
-- `input.ContentType`, mapped to a lowercase `"content-type"` metadata key
+- the system metadata request fields, mapped to their lowercase header names by
+  `object/s3-system-metadata.ts`
 
 `GetObjectCommandHandler` returns object bodies as Node `Readable` streams and returns stored
 metadata through `Metadata`.
+
+`object/s3-system-metadata.ts` holds the list of headers S3 remembers about an Object, pairing the
+request field a write sets each one with against the lowercase key it is stored under. Both sides
+read that list, so a header cannot be written without being served or served without being writable.
+`SimPutObjectCommandInput` declares one field per entry, and the builder indexes the input by those
+field names, which makes a missing field a type error rather than a silently dropped header.
 
 `object/s3-object-response-headers.ts` is the single mapping from stored metadata to HTTP response
 headers, and every path that serves an Object goes through it: the S3 REST endpoint reader, the
@@ -231,8 +238,9 @@ header and hands back on a read, and nothing else, so user-defined metadata does
 response. Keeping it in one place is what stops the three endpoints disagreeing about what reading an
 Object looks like.
 
-Note that `PutObject` only writes `ContentType` into that set. The other headers reach an Object
-through a CDK BucketDeployment's `SystemMetadata`, which builds the metadata record directly.
+The other way these headers reach an Object is a CDK BucketDeployment's `SystemMetadata`, which
+builds the metadata record directly. A `PUT` over the S3 REST endpoint is the one write path that
+does not cover them all: it reads `content-type` off the request and nothing else.
 
 ## Storage implementations
 

--- a/src/service/s3/command/put-object/put-object-builder.ts
+++ b/src/service/s3/command/put-object/put-object-builder.ts
@@ -1,4 +1,5 @@
 import { SimS3Object, SimS3ObjectMetadata } from "../../object/s3-object.js";
+import { simS3SystemMetadataHeaders } from "../../object/s3-system-metadata.js";
 import type { SimPutObjectCommand } from "./put-object.command.js";
 import { assertDefined } from "../../../../util/type-guard/defined.js";
 
@@ -36,18 +37,41 @@ export class PutObjectBuilder {
   /**
    * Convert SDK metadata fields to the string map stored by SimS3ObjectMetadata.
    *
-   * User-defined metadata is retained as supplied. ContentType is represented by
-   * the standard lowercase metadata key used by the existing GetObject response
-   * path. Omitting ContentType leaves that key absent rather than assigning an
-   * undefined value.
+   * User-defined metadata is retained as supplied. System metadata is read by
+   * the same list of headers a read returns, under the lowercase key that read
+   * looks the value up by, so a write and a read agree on what S3 remembers
+   * about an Object. An omitted header leaves its key absent rather than
+   * assigning an undefined value.
    */
   private toMetadata(command: SimPutObjectCommand): Record<string, string> {
-    return {
-      ...command.input.Metadata,
-      ...(command.input.ContentType !== undefined && {
-        "content-type": command.input.ContentType,
-      }),
-    };
+    const metadata: Record<string, string> = { ...command.input.Metadata };
+
+    for (const header of simS3SystemMetadataHeaders) {
+      const value = this.toMetadataValue(command.input[header.field]);
+
+      if (value !== undefined) {
+        metadata[header.name] = value;
+      }
+    }
+
+    return metadata;
+  }
+
+  /**
+   * Represent a system metadata value as the string S3 stores and returns.
+   *
+   * Only `Expires` arrives as a Date, which the SDK would otherwise format on
+   * the wire. It becomes the same HTTP date here so the read side has a header
+   * value to hand back rather than an object.
+   */
+  private toMetadataValue(
+    value: string | Date | undefined,
+  ): string | undefined {
+    if (value instanceof Date) {
+      return value.toUTCString();
+    }
+
+    return value;
   }
 
   /**

--- a/src/service/s3/command/put-object/put-object-system-metadata.iso.test.ts
+++ b/src/service/s3/command/put-object/put-object-system-metadata.iso.test.ts
@@ -1,0 +1,183 @@
+import {
+  CreateBucketCommand,
+  GetObjectCommand,
+  PutObjectCommand,
+} from "@aws-sdk/client-s3";
+import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
+import { assertIdentical, assertObjectEquals } from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import {
+  presignBucketName,
+  presignSimulation,
+} from "../../../../../test/s3/presign-simulation.js";
+
+describe("S3 PutObjectCommand system metadata", () => {
+  it("stores every system metadata header S3 keeps about an Object", async () => {
+    // Given a Bucket.
+    const simS3 = new SimAws().s3();
+    await simS3.createBucket(new CreateBucketCommand({ Bucket: "bucket-a" }));
+
+    // When an Object is written carrying all of them.
+    await simS3.putObject(
+      new PutObjectCommand({
+        Bucket: "bucket-a",
+        Key: "report.csv",
+        Body: "a,b,c",
+        CacheControl: "public, max-age=31536000, immutable",
+        ContentDisposition: 'attachment; filename="report.csv"',
+        ContentEncoding: "br",
+        ContentLanguage: "en-GB",
+        ContentType: "text/csv",
+        Expires: new Date("2026-10-21T07:28:00Z"),
+      }),
+    );
+
+    // Then each one is remembered under the header name a read returns it as.
+    const objectOut = await simS3.getObject(
+      new GetObjectCommand({ Bucket: "bucket-a", Key: "report.csv" }),
+    );
+    assertObjectEquals(objectOut.Metadata, {
+      "cache-control": "public, max-age=31536000, immutable",
+      "content-disposition": 'attachment; filename="report.csv"',
+      "content-encoding": "br",
+      "content-language": "en-GB",
+      "content-type": "text/csv",
+      expires: "Wed, 21 Oct 2026 07:28:00 GMT",
+    });
+  });
+
+  it("records an expiry as the HTTP date a read hands back", async () => {
+    // Given a Bucket.
+    const simS3 = new SimAws().s3();
+    await simS3.createBucket(new CreateBucketCommand({ Bucket: "bucket-a" }));
+
+    // When an Object is written with the Date the SDK takes for an expiry.
+    await simS3.putObject(
+      new PutObjectCommand({
+        Bucket: "bucket-a",
+        Key: "menu.json",
+        Body: "{}",
+        Expires: new Date("2027-01-02T03:04:05Z"),
+      }),
+    );
+
+    // Then it is stored as the header value itself, not as an object a read
+    // would have nothing to do with.
+    const objectOut = await simS3.getObject(
+      new GetObjectCommand({ Bucket: "bucket-a", Key: "menu.json" }),
+    );
+    assertIdentical(
+      objectOut.Metadata?.["expires"],
+      "Sat, 02 Jan 2027 03:04:05 GMT",
+    );
+  });
+
+  it("leaves out a system metadata header the write did not carry", async () => {
+    // Given a Bucket.
+    const simS3 = new SimAws().s3();
+    await simS3.createBucket(new CreateBucketCommand({ Bucket: "bucket-a" }));
+
+    // When an Object is written with a content type alone.
+    await simS3.putObject(
+      new PutObjectCommand({
+        Bucket: "bucket-a",
+        Key: "index.html",
+        Body: "<h1>Hello</h1>",
+        ContentType: "text/html",
+      }),
+    );
+
+    // Then the content type is the only thing stored: the five headers it said
+    // nothing about are absent, rather than undefined values a read would serve
+    // as empty headers.
+    const objectOut = await simS3.getObject(
+      new GetObjectCommand({ Bucket: "bucket-a", Key: "index.html" }),
+    );
+    assertObjectEquals(objectOut.Metadata, { "content-type": "text/html" });
+  });
+
+  it("remembers nothing about an Object written without system metadata", async () => {
+    // Given a Bucket.
+    const simS3 = new SimAws().s3();
+    await simS3.createBucket(new CreateBucketCommand({ Bucket: "bucket-a" }));
+
+    // When an Object is written with a body alone.
+    await simS3.putObject(
+      new PutObjectCommand({
+        Bucket: "bucket-a",
+        Key: "notes.txt",
+        Body: "nothing to say",
+      }),
+    );
+
+    // Then nothing is stored about it.
+    const objectOut = await simS3.getObject(
+      new GetObjectCommand({ Bucket: "bucket-a", Key: "notes.txt" }),
+    );
+    assertObjectEquals(objectOut.Metadata, {});
+  });
+
+  it("keeps user-defined metadata alongside system metadata", async () => {
+    // Given a Bucket.
+    const simS3 = new SimAws().s3();
+    await simS3.createBucket(new CreateBucketCommand({ Bucket: "bucket-a" }));
+
+    // When an Object is written with both.
+    await simS3.putObject(
+      new PutObjectCommand({
+        Bucket: "bucket-a",
+        Key: "styles.css",
+        Body: "body{}",
+        Metadata: { author: "hg" },
+        ContentEncoding: "gzip",
+        ContentType: "text/css",
+      }),
+    );
+
+    // Then the two sit side by side, since S3 keeps user metadata as well as
+    // what it remembers about the Object itself.
+    const objectOut = await simS3.getObject(
+      new GetObjectCommand({ Bucket: "bucket-a", Key: "styles.css" }),
+    );
+    assertObjectEquals(objectOut.Metadata, {
+      author: "hg",
+      "content-encoding": "gzip",
+      "content-type": "text/css",
+    });
+  });
+
+  it("serves what a write said about an Object back over the REST endpoint", async () => {
+    // Given an Object written through the SDK with a cache directive and an
+    // encoding.
+    const { simAws, client, http } = await presignSimulation();
+    await simAws.s3().putObject(
+      new PutObjectCommand({
+        Bucket: presignBucketName,
+        Key: "q3/report.js",
+        Body: "compressed bytes",
+        CacheControl: "public, max-age=60",
+        ContentEncoding: "br",
+        ContentType: "text/javascript",
+      }),
+    );
+
+    // When it is read back over the endpoint that serves it.
+    const url = await getSignedUrl(
+      client,
+      new GetObjectCommand({ Bucket: presignBucketName, Key: "q3/report.js" }),
+      { expiresIn: 900 },
+    );
+    const response = await http.fetch(url);
+
+    // Then the write and the read agree: bytes stored as brotli are served with
+    // the encoding a client needs to decode them.
+    assertIdentical(response.status, 200);
+    assertIdentical(
+      response.headers.get("cache-control"),
+      "public, max-age=60",
+    );
+    assertIdentical(response.headers.get("content-encoding"), "br");
+    assertIdentical(response.headers.get("content-type"), "text/javascript");
+  });
+});

--- a/src/service/s3/command/put-object/put-object.command.ts
+++ b/src/service/s3/command/put-object/put-object.command.ts
@@ -10,13 +10,24 @@ export interface SimPutObjectCommand {
 
 /**
  * Minimal structural sim S3 PutObject input.
+ *
+ * The fields below `Metadata` are the system metadata headers S3 remembers
+ * about an Object and returns on a read. There is one for every entry in
+ * `simS3SystemMetadataHeaders`, which is what the builder reads them by, so a
+ * header added to that list without a field here fails to compile. `Expires` is
+ * a `Date` because the SDK takes one and formats it as an HTTP date.
  */
 export interface SimPutObjectCommandInput {
   readonly Bucket?: string | undefined;
   readonly Key?: string | undefined;
   readonly Body?: SimPutObjectBody;
   readonly Metadata?: Record<string, string> | undefined;
+  readonly CacheControl?: string | undefined;
+  readonly ContentDisposition?: string | undefined;
+  readonly ContentEncoding?: string | undefined;
+  readonly ContentLanguage?: string | undefined;
   readonly ContentType?: string | undefined;
+  readonly Expires?: Date | undefined;
 }
 
 /**

--- a/src/service/s3/object/s3-object-response-headers.ts
+++ b/src/service/s3/object/s3-object-response-headers.ts
@@ -1,3 +1,5 @@
+import { simS3SystemMetadataHeaders } from "./s3-system-metadata.js";
+
 /**
  * The headers S3 sets on a read from what it was told when the Object was
  * written.
@@ -21,31 +23,13 @@ export function simS3ObjectResponseHeaders(
     "content-length": String(bodyLength),
   };
 
-  for (const name of simS3SystemMetadataHeaders) {
-    // eslint-disable-next-line security/detect-object-injection -- name comes from the fixed list below
-    const value = metadata?.[name];
+  for (const header of simS3SystemMetadataHeaders) {
+    const value = metadata?.[header.name];
 
     if (value !== undefined) {
-      // eslint-disable-next-line security/detect-object-injection
-      headers[name] = value;
+      headers[header.name] = value;
     }
   }
 
   return headers;
 }
-
-/**
- * The system metadata S3 stores as a header and returns as one.
- *
- * Content length is not here because it describes the body rather than being
- * remembered about it, and content type is set for almost every Object because
- * a deployment or the console guesses one from the file extension.
- */
-const simS3SystemMetadataHeaders = [
-  "cache-control",
-  "content-disposition",
-  "content-encoding",
-  "content-language",
-  "content-type",
-  "expires",
-] as const;

--- a/src/service/s3/object/s3-system-metadata.ts
+++ b/src/service/s3/object/s3-system-metadata.ts
@@ -1,0 +1,48 @@
+/**
+ * One header S3 keeps about an Object when it is written and hands back,
+ * unchanged, on every read.
+ *
+ * The request field a write sets the header with and the key the value is
+ * stored under are paired here rather than in the write and read paths. Adding
+ * a header to the list below adds it to `PutObject` and to every endpoint that
+ * serves an Object at the same time, so the two sides cannot drift apart.
+ *
+ * https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingMetadata.html
+ */
+export class SimS3SystemMetadataHeader {
+  constructor(
+    public readonly field: SimS3SystemMetadataField,
+    public readonly name: string,
+  ) {}
+}
+
+/**
+ * The request field name a write sets a system metadata header with.
+ *
+ * These are the AWS SDK spellings, so an input carrying system metadata is
+ * indexable by them.
+ */
+export type SimS3SystemMetadataField =
+  | "CacheControl"
+  | "ContentDisposition"
+  | "ContentEncoding"
+  | "ContentLanguage"
+  | "ContentType"
+  | "Expires";
+
+/**
+ * The system metadata S3 stores as a header and returns as one.
+ *
+ * Content length is not here because it describes the body rather than being
+ * remembered about it, and content type is set for almost every Object because
+ * a deployment or the console guesses one from the file extension.
+ */
+export const simS3SystemMetadataHeaders: readonly SimS3SystemMetadataHeader[] =
+  [
+    new SimS3SystemMetadataHeader("CacheControl", "cache-control"),
+    new SimS3SystemMetadataHeader("ContentDisposition", "content-disposition"),
+    new SimS3SystemMetadataHeader("ContentEncoding", "content-encoding"),
+    new SimS3SystemMetadataHeader("ContentLanguage", "content-language"),
+    new SimS3SystemMetadataHeader("ContentType", "content-type"),
+    new SimS3SystemMetadataHeader("Expires", "expires"),
+  ];


### PR DESCRIPTION
PutObject kept `ContentType` and dropped the other headers S3 remembers about an Object, so a cache directive or a content encoding set through the SDK could never come back on a read, even though every path that serves an Object already knows how to return them. The write and read sides now share one list of those headers, pairing each request field with the key it is stored under, and the builder indexes the input by those field names so a header without a matching field on the input type is a type error rather than a silently dropped value. `Expires` is the one field that is not a string: the SDK takes a `Date`, which is stored as the HTTP date a read hands back. Two related gaps stay as they were and are written up in Limitations instead: a `PUT` over the S3 REST endpoint still reads only `content-type` off the request, and a presigned `GetObject` still ignores the `response-*` override parameters.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * S3 object uploads now support preserving cache control, content disposition, content encoding, content language, content type, and expiration metadata.
  * Retrieved objects expose supported system metadata through `Metadata`, including normalized expiration values.
  * Date-based expiration values are formatted consistently as HTTP dates.
  * System metadata can coexist with user-defined metadata.

* **Documentation**
  * Added guidance and examples for supported metadata, upload behavior, response headers, and known limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->