### PR TITLE
docs: document requests without a port

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,30 @@ console.log(bucketWebsiteUrl.toString());
 const res = await fetch(new URL("/foo/", bucketWebsiteUrl));
 ```
 
+#### Send requests without a port
+
+A test usually wants the same requests with nothing listening. `SimAwsHttp` answers a Fetch API
+`Request` with a `Response` in process, so there is no port for parallel test files to collide over,
+and no server to start or tear down:
+
+```typescript
+import { SimAws } from "@kensio/yulin";
+import { SimAwsHttp } from "@kensio/yulin/serve";
+
+const simAws = new SimAws();
+const simAwsHttp = new SimAwsHttp({ simAws });
+
+// Build the simulated environment the requests are answered from here.
+
+const response = await simAwsHttp.fetch("https://www.example.com/");
+```
+
+Nothing binds a port, so a URL a simulated service gives out is fetched as it is, with no
+`localUrl(...)` adapting, and a hostname a simulated Route53 answers for is requested by its own
+name. Both routes go through the same authentication, routing and service code, so `serveSimAws` is
+what you want only when the request comes from outside the process. See the
+[serving docs](./docs/serve "Serving simulated AWS on localhost docs") for which to reach for.
+
 #### Restarting a served environment
 
 A served environment takes an available port by default, so the URL changes every time the process

--- a/docs/serve/README.md
+++ b/docs/serve/README.md
@@ -1,7 +1,8 @@
 # Serving simulated AWS on localhost
 
 Serving puts a simulated AWS environment behind a real port, so a browser, `curl` or an SDK client
-reaches it over HTTP.
+reaches it over HTTP. The same request path is available in the process with no port at all, which
+is what a test wants.
 
 ## Serving a port
 
@@ -50,6 +51,109 @@ console.log(srv.localUrl(websiteUrl).toString());
 
 await srv.close();
 ```
+
+## Requests without a port
+
+`SimAwsHttp` is the same request path with nothing listening under it. It takes a Fetch API
+`Request` and answers with a `Response`, in the process that built the environment:
+
+```typescript sim-serve-in-process-request
+/**
+ * Requesting a simulated S3 website with no server listening.
+ */
+
+import {
+  CreateBucketCommand,
+  PutBucketPolicyCommand,
+  PutBucketWebsiteCommand,
+  PutObjectCommand,
+  PutPublicAccessBlockCommand,
+} from "@aws-sdk/client-s3";
+import { SimAws } from "@kensio/yulin";
+import { SimAwsHttp } from "@kensio/yulin/serve";
+
+const simAws = new SimAws();
+const simAwsHttp = new SimAwsHttp({ simAws });
+const simS3 = simAws.region("eu-west-2").s3();
+
+await simS3.createBucket(new CreateBucketCommand({ Bucket: "foo-site" }));
+await simS3.putObject(
+  new PutObjectCommand({
+    Bucket: "foo-site",
+    Key: "index.html",
+    Body: "<h1>Hello, world!</h1>",
+    ContentType: "text/html; charset=utf-8",
+  }),
+);
+await simS3.putBucketWebsite(
+  new PutBucketWebsiteCommand({
+    Bucket: "foo-site",
+    WebsiteConfiguration: {
+      IndexDocument: {
+        Suffix: "index.html",
+      },
+    },
+  }),
+);
+
+// A website endpoint serves only what the Bucket policy makes readable, and a
+// public policy needs the Block Public Access opt-out first.
+await simS3.putPublicAccessBlock(
+  new PutPublicAccessBlockCommand({
+    Bucket: "foo-site",
+    PublicAccessBlockConfiguration: {
+      BlockPublicAcls: true,
+      IgnorePublicAcls: true,
+    },
+  }),
+);
+await simS3.putBucketPolicy(
+  new PutBucketPolicyCommand({
+    Bucket: "foo-site",
+    Policy: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Principal: "*",
+        Action: "s3:GetObject",
+        Resource: "arn:aws:s3:::foo-site/*",
+      },
+    }),
+  }),
+);
+
+const response = await simAwsHttp.fetch(simS3.getBucketWebsiteUrl("foo-site"));
+
+console.log(response.status); // 200
+console.log(await response.text()); // <h1>Hello, world!</h1>
+```
+
+`fetch(input, init)` takes what the global `fetch` takes. `handleRequest(request)` takes a `Request`
+that is already built, for a caller that is holding one.
+
+Nothing binds a port, so there is no URL to adapt. The website URL above is fetched as it is, where
+a served environment needs `srv.localUrl(...)` to add the port it took. A hostname a simulated
+Route53 answers for is requested by its own name, so a Distribution behind `www.example.com` is
+reached at `https://www.example.com/`. An `https` URL needs no certificate set up for it, since there
+is no connection to encrypt.
+
+There is nothing to close either, though `simAws.close()` still lets go of what the environment
+itself is holding, such as a watched template file. See
+[stopping and restarting](#stopping-and-restarting).
+
+Live reload sits either side of this interface rather than inside it, so a response from here never
+carries the injected script, even in a process that served one elsewhere with live reload on.
+
+Which to reach for:
+
+- `SimAwsHttp` for tests, and for anything else in the same process. Test files that run in parallel
+  have no port to collide over, and nothing listens, so there is no teardown to get wrong and no
+  socket between the request and the service answering it.
+- `serveSimAws` for anything outside the process: a browser, `curl`, or an SDK client pointed at a
+  local endpoint.
+
+Both go through the same authentication, routing and service code, so a request answered one way is
+answered the same way the other.
 
 ## Stopping and restarting
 

--- a/docs/serve/sim-serve-in-process-request.example.ts
+++ b/docs/serve/sim-serve-in-process-request.example.ts
@@ -1,0 +1,68 @@
+/**
+ * Requesting a simulated S3 website with no server listening.
+ */
+
+import {
+  CreateBucketCommand,
+  PutBucketPolicyCommand,
+  PutBucketWebsiteCommand,
+  PutObjectCommand,
+  PutPublicAccessBlockCommand,
+} from "@aws-sdk/client-s3";
+import { SimAws } from "@kensio/yulin";
+import { SimAwsHttp } from "@kensio/yulin/serve";
+
+const simAws = new SimAws();
+const simAwsHttp = new SimAwsHttp({ simAws });
+const simS3 = simAws.region("eu-west-2").s3();
+
+await simS3.createBucket(new CreateBucketCommand({ Bucket: "foo-site" }));
+await simS3.putObject(
+  new PutObjectCommand({
+    Bucket: "foo-site",
+    Key: "index.html",
+    Body: "<h1>Hello, world!</h1>",
+    ContentType: "text/html; charset=utf-8",
+  }),
+);
+await simS3.putBucketWebsite(
+  new PutBucketWebsiteCommand({
+    Bucket: "foo-site",
+    WebsiteConfiguration: {
+      IndexDocument: {
+        Suffix: "index.html",
+      },
+    },
+  }),
+);
+
+// A website endpoint serves only what the Bucket policy makes readable, and a
+// public policy needs the Block Public Access opt-out first.
+await simS3.putPublicAccessBlock(
+  new PutPublicAccessBlockCommand({
+    Bucket: "foo-site",
+    PublicAccessBlockConfiguration: {
+      BlockPublicAcls: true,
+      IgnorePublicAcls: true,
+    },
+  }),
+);
+await simS3.putBucketPolicy(
+  new PutBucketPolicyCommand({
+    Bucket: "foo-site",
+    Policy: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Principal: "*",
+        Action: "s3:GetObject",
+        Resource: "arn:aws:s3:::foo-site/*",
+      },
+    }),
+  }),
+);
+
+const response = await simAwsHttp.fetch(simS3.getBucketWebsiteUrl("foo-site"));
+
+console.log(response.status); // 200
+console.log(await response.text()); // <h1>Hello, world!</h1>

--- a/docs/services/cloudfront/README.md
+++ b/docs/services/cloudfront/README.md
@@ -257,6 +257,12 @@ try {
 The Distribution domain is adapted through `server.localUrl(...)` so that the request is sent to the
 local Yulin server while preserving the simulated CloudFront hostname.
 
+A test that needs no browser can skip the port. `SimAwsHttp` answers the same requests in the
+process, with no server listening and nothing to adapt the URL for, and an alternate domain name a
+simulated Route53 answers for is requested by its own name: `simAwsHttp.fetch("https://cdn.example.test/")`
+reaches the Distribution behind it. See
+[requests without a port](../../serve/#requests-without-a-port "Requests without a port docs").
+
 ## Custom Origins
 
 An Origin with a `CustomOriginConfig` is one CloudFront reaches over HTTP rather than as an S3


### PR DESCRIPTION
`SimAwsHttp` answers a Fetch API `Request` with a `Response` in the process that built the simulated environment, with nothing listening and no port to take, but it was only discoverable by reading the source. This documents it in the serving docs with a runnable example, covering the URLs it accepts without `localUrl` adapting, that live reload is never injected on that path, and when to reach for it over `serveSimAws`. It is mentioned from the root README and cross-referenced from the CloudFront serving section, where a test driving a Function is a likely reason to want it. The CloudFront cross-reference is a pointer rather than a fidelity warning: a Function sees the same `host` either way, since `simAwsRequestHostname` drops the local suffix and port before the event is built, which was checked by driving an exact-match Function through both routes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for handling simulated AWS HTTP requests in-process without starting a server or binding a port.
  * Documented request setup, response handling, lifecycle differences, URL behavior, and when to use each serving approach.
  * Added an example for serving and fetching a simulated S3 website in-process.
  * Added CloudFront guidance for requests using alternate domains resolved through simulated Route 53.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->