### PR TITLE
feat: publish an Oxlint config for CFF JS2

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -26,5 +26,6 @@ behaviour and includes example code that can be copied into tests or local devel
 ## Feature documentation
 
 - [AWS SDK interception](./sdk/ "Simulated AWS SDK usage docs")
+- [Linting CloudFront Functions JS2](./lint/ "CloudFront Functions JS2 lint config usage docs")
 - [Serving on localhost](./serve/ "Serving simulated AWS on localhost usage docs")
 - [Simulated time](./time/ "Simulated time usage docs")

--- a/docs/lint/README.md
+++ b/docs/lint/README.md
@@ -1,0 +1,153 @@
+# Linting CloudFront Functions JS2
+
+CloudFront Functions run JS2, a restricted JavaScript dialect rather than a JavaScript engine with a
+few gaps missing. Code using a template literal, an arrow function or `fetch` is refused when the
+Function is published, which is a long way from where it was written. Yulin publishes lint configs
+that refuse the same things in the editor.
+
+The configs apply to `**/*.cff.js` files, which is the naming
+[sim CloudFront](../services/cloudfront/ "Simulated CloudFront usage docs") already uses for
+CloudFront Function source.
+
+## Setting it up with ESLint
+
+`@kensio/yulin/eslint` exports a flat config to spread into your own. It restricts itself to
+`**/*.cff.js`, so the rest of your config still applies everywhere else.
+
+```typescript cff-js2-eslint-config
+/**
+ * An ESLint config that lints CloudFront Function files as JS2.
+ */
+
+import eslint from "@eslint/js";
+import { defineConfig } from "eslint/config";
+
+import { cloudFrontFunctionsJs2 } from "@kensio/yulin/eslint";
+
+export default defineConfig(
+  eslint.configs.recommended,
+
+  // Applies only to **/*.cff.js, so it goes after the configs it relaxes.
+  ...cloudFrontFunctionsJs2,
+);
+```
+
+It goes after any config whose rules it needs to turn off. A JS2 file is written with `var`, string
+concatenation and no shorthand properties, so the modern-JavaScript rules a repository applies
+everywhere else are advice to write code that will not run.
+
+`eslint` and `typescript-eslint` are optional peer dependencies, needed only if you use this export.
+
+## Setting it up with Oxlint
+
+`@kensio/yulin/oxlint` ships the same rules as an Oxlint config fragment to extend. The rules
+themselves are one plugin loaded by both linters, so the two configs report the same things in the
+same places.
+
+```json
+{
+  "extends": [
+    "./node_modules/@kensio/yulin/dist/config/oxlint/cffjs2.oxlintrc.json"
+  ],
+  "rules": {
+    "no-console": "error"
+  }
+}
+```
+
+Oxlint's `extends` takes a file path rather than a package name, so the path into `node_modules` is
+written out. The fragment brings its own `overrides` entry scoped to `**/*.cff.js` and the JS plugin
+the rules live in, and leaves every other file to your own rules.
+
+The plugin is loaded through Oxlint's JS plugin support, which needs Oxlint 1.77 or later.
+
+## What is reported
+
+Each restriction is its own rule, under the `cff-js2` name in both linters.
+
+| Rule                            | What it refuses                                      |
+| ------------------------------- | ---------------------------------------------------- |
+| `cff-js2/no-template-literal`   | Template literals, in favour of string concatenation |
+| `cff-js2/no-import`             | `import` declarations, since a Function is one file  |
+| `cff-js2/only-handler-export`   | Any export other than `export function handler(...)` |
+| `cff-js2/no-class`              | Class declarations and expressions                   |
+| `cff-js2/no-arrow-function`     | Arrow functions                                      |
+| `cff-js2/no-async`              | `async` functions and `await`                        |
+| `cff-js2/no-generator`          | Generators and `yield`                               |
+| `cff-js2/no-destructuring`      | Object and array destructuring                       |
+| `cff-js2/no-spread`             | Spread and rest syntax                               |
+| `cff-js2/no-for-of`             | `for...of`, in favour of an index-based loop         |
+| `cff-js2/no-unavailable-global` | Globals the runtime does not have, such as `fetch`   |
+
+`cff-js2/no-unavailable-global` resolves names through scope rather than matching them as text, so a
+local variable named `fetch` and a property named `event.fetch` are both left alone. Each unavailable
+global reports why it is missing, because `fetch` being absent for want of a network and `setTimeout`
+being absent for want of an event loop call for different rewrites.
+
+Alongside these, both configs turn on `no-eval`, `no-new-func` and `no-implied-eval`, and set
+`no-unused-vars` to leave `handler` alone, since it is the entry point CloudFront calls rather than
+something the file itself uses.
+
+## Turning one restriction off
+
+Rules are individual, so a restriction you disagree with can be switched off on its own. In ESLint:
+
+```typescript cff-js2-eslint-relax
+/**
+ * Allowing arrow functions in CloudFront Function files.
+ */
+
+import { defineConfig } from "eslint/config";
+
+import { cloudFrontFunctionsJs2 } from "@kensio/yulin/eslint";
+
+export default defineConfig(...cloudFrontFunctionsJs2, {
+  files: ["**/*.cff.js"],
+  rules: {
+    "cff-js2/no-arrow-function": "off",
+  },
+});
+```
+
+In Oxlint, the same thing goes in an `overrides` entry after the `extends`:
+
+```json
+{
+  "extends": [
+    "./node_modules/@kensio/yulin/dist/config/oxlint/cffjs2.oxlintrc.json"
+  ],
+  "overrides": [
+    {
+      "files": ["**/*.cff.js"],
+      "rules": {
+        "cff-js2/no-arrow-function": "off"
+      }
+    }
+  ]
+}
+```
+
+## Available functionality
+
+- A flat ESLint config at `@kensio/yulin/eslint`, exported as `cloudFrontFunctionsJs2`
+- An Oxlint config fragment at `dist/config/oxlint/cffjs2.oxlintrc.json`, with the object it is
+  generated from exported as `cloudFrontFunctionsJs2Oxlint` from `@kensio/yulin/oxlint`
+- Eleven `cff-js2` rules, one per restriction, shared by both linters
+- Scoping to `**/*.cff.js`, so a repository's own rules are untouched elsewhere
+
+## Limitations
+
+Where the configs knowingly stop short:
+
+- **Only the `cff-js2` rules are shared between the linters.** ESLint and Oxlint each bring their own
+  built-in rules, and their own defaults for which are on. A `.cff.js` file linted by both may pick
+  up findings from one that the other does not have.
+- **The rules are syntactic.** Nothing here knows CloudFront's size limit on Function code or its
+  CPU budget, so a Function that passes the lint can still be refused at publication for being too
+  large or too slow.
+- **The list of unavailable globals is the useful part of one, not all of it.** It names what test
+  code and Node habits reach for. A global outside that list is not reported, even if JS2 lacks it.
+- **Oxlint's JS plugin support is in alpha.** It is what loads these rules into Oxlint, and its API
+  is still moving upstream.
+- **The Oxlint fragment is extended by path.** Oxlint does not resolve a package name in `extends`,
+  so the path into `node_modules` is written out and depends on your installer's layout.

--- a/docs/lint/README.md
+++ b/docs/lint/README.md
@@ -1,13 +1,18 @@
 # Linting CloudFront Functions JS2
 
-CloudFront Functions run JS2, a restricted JavaScript dialect rather than a JavaScript engine with a
-few gaps missing. Code using a template literal, an arrow function or `fetch` is refused when the
-Function is published, which is a long way from where it was written. Yulin publishes lint configs
-that refuse the same things in the editor.
+CloudFront Functions run JS2, which is ECMAScript 5.1 plus a named subset of ES 6 to 12 rather than a
+current JavaScript engine. Code using a class, `for...of` or `fetch` is refused when the Function is
+published, which is a long way from where it was written. Yulin publishes lint configs that refuse
+the same things in the editor.
 
 The configs apply to `**/*.cff.js` files, which is the naming
 [sim CloudFront](../services/cloudfront/ "Simulated CloudFront usage docs") already uses for
 CloudFront Function source.
+
+Every restriction comes from the runtime's
+[own feature list](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/functions-javascript-runtime-20.html),
+which is an allow-list: anything it does not name is unsupported. Nothing here is house style. A rule
+banning syntax JS2 accepts would send you away from code that works.
 
 ## Setting it up with ESLint
 
@@ -32,9 +37,10 @@ export default defineConfig(
 );
 ```
 
-It goes after any config whose rules it needs to turn off. A JS2 file is written with `var`, string
-concatenation and no shorthand properties, so the modern-JavaScript rules a repository applies
-everywhere else are advice to write code that will not run.
+It goes after any config whose rules it needs to turn off, which is a short list. `const`, `let`,
+template literals, arrow functions, rest parameters and `async`/`await` all work in JS2, so the
+rules asking for them stay on. Only `object-shorthand` is switched off, because shorthand property
+names are ES 6 literal syntax the runtime does not have.
 
 `eslint` and `typescript-eslint` are optional peer dependencies, needed only if you use this export.
 
@@ -65,28 +71,41 @@ The plugin is loaded through Oxlint's JS plugin support, which needs Oxlint 1.77
 
 Each restriction is its own rule, under the `cff-js2` name in both linters.
 
-| Rule                            | What it refuses                                      |
-| ------------------------------- | ---------------------------------------------------- |
-| `cff-js2/no-template-literal`   | Template literals, in favour of string concatenation |
-| `cff-js2/no-import`             | `import` declarations, since a Function is one file  |
-| `cff-js2/only-handler-export`   | Any export other than `export function handler(...)` |
-| `cff-js2/no-class`              | Class declarations and expressions                   |
-| `cff-js2/no-arrow-function`     | Arrow functions                                      |
-| `cff-js2/no-async`              | `async` functions and `await`                        |
-| `cff-js2/no-generator`          | Generators and `yield`                               |
-| `cff-js2/no-destructuring`      | Object and array destructuring                       |
-| `cff-js2/no-spread`             | Spread and rest syntax                               |
-| `cff-js2/no-for-of`             | `for...of`, in favour of an index-based loop         |
-| `cff-js2/no-unavailable-global` | Globals the runtime does not have, such as `fetch`   |
+| Rule                            | What it refuses                                          |
+| ------------------------------- | -------------------------------------------------------- |
+| `cff-js2/no-import`             | `import` declarations, since a Function is one file      |
+| `cff-js2/only-handler-export`   | Any export other than `export function handler(...)`     |
+| `cff-js2/only-built-in-require` | Requiring anything but `querystring`, `crypto`, `buffer` |
+| `cff-js2/no-class`              | Class declarations and expressions                       |
+| `cff-js2/no-generator`          | Generators and `yield`                                   |
+| `cff-js2/no-destructuring`      | Object and array destructuring                           |
+| `cff-js2/no-spread`             | Spread syntax, but not rest parameters                   |
+| `cff-js2/no-for-of`             | `for...of`, in favour of an index-based loop             |
+| `cff-js2/no-unavailable-global` | Globals the runtime does not have, such as `fetch`       |
 
-`cff-js2/no-unavailable-global` resolves names through scope rather than matching them as text, so a
-local variable named `fetch` and a property named `event.fetch` are both left alone. Each unavailable
-global reports why it is missing, because `fetch` being absent for want of a network and `setTimeout`
-being absent for want of an event loop call for different rewrites.
+`cff-js2/no-unavailable-global` covers `fetch`, `XMLHttpRequest` and `WebSocket`, which need a
+network the runtime does not have; `process`, which needs Node.js; and `setTimeout`, `setInterval`,
+`setImmediate` and `clearTimeout`, which need an event loop a Function does not get. It resolves
+names through scope rather than matching them as text, so a local variable named `fetch` and a
+property named `event.fetch` are both left alone. Each report says why the global is missing, because
+`fetch` being absent for want of a network and `setTimeout` for want of an event loop call for
+different rewrites.
 
-Alongside these, both configs turn on `no-eval`, `no-new-func` and `no-implied-eval`, and set
-`no-unused-vars` to leave `handler` alone, since it is the entry point CloudFront calls rather than
-something the file itself uses.
+Alongside these, both configs turn on `no-eval`, `no-new-func` and `no-implied-eval`, which the
+runtime refuses outright, and set `no-unused-vars` to leave `handler` alone, since it is the entry
+point CloudFront calls rather than something the file itself uses.
+
+## What is not reported
+
+These all work in JS2 and no rule here objects to them:
+
+- Template literals, including interpolation and nesting
+- Arrow functions and rest parameters
+- `const` and `let`
+- `async` and `await`
+- `Promise`, including `all`, `allSettled`, `any` and `race`
+- `Buffer`, and `require` of `querystring`, `crypto` or `buffer`
+- `String.prototype.replaceAll`, `atob`, `btoa` and numeric separators
 
 ## Turning one restriction off
 
@@ -94,7 +113,7 @@ Rules are individual, so a restriction you disagree with can be switched off on 
 
 ```typescript cff-js2-eslint-relax
 /**
- * Allowing arrow functions in CloudFront Function files.
+ * Allowing class syntax in CloudFront Function files.
  */
 
 import { defineConfig } from "eslint/config";
@@ -104,7 +123,7 @@ import { cloudFrontFunctionsJs2 } from "@kensio/yulin/eslint";
 export default defineConfig(...cloudFrontFunctionsJs2, {
   files: ["**/*.cff.js"],
   rules: {
-    "cff-js2/no-arrow-function": "off",
+    "cff-js2/no-class": "off",
   },
 });
 ```
@@ -120,7 +139,7 @@ In Oxlint, the same thing goes in an `overrides` entry after the `extends`:
     {
       "files": ["**/*.cff.js"],
       "rules": {
-        "cff-js2/no-arrow-function": "off"
+        "cff-js2/no-class": "off"
       }
     }
   ]
@@ -132,21 +151,26 @@ In Oxlint, the same thing goes in an `overrides` entry after the `extends`:
 - A flat ESLint config at `@kensio/yulin/eslint`, exported as `cloudFrontFunctionsJs2`
 - An Oxlint config fragment at `dist/config/oxlint/cffjs2.oxlintrc.json`, with the object it is
   generated from exported as `cloudFrontFunctionsJs2Oxlint` from `@kensio/yulin/oxlint`
-- Eleven `cff-js2` rules, one per restriction, shared by both linters
+- Nine `cff-js2` rules, one per restriction, shared by both linters
 - Scoping to `**/*.cff.js`, so a repository's own rules are untouched elsewhere
 
 ## Limitations
 
 Where the configs knowingly stop short:
 
+- **`async` arguments and closures are not checked.** JS2 supports `async` and `await`, but not
+  `async` arguments or closures, and `await` only inside an `async` function. Where the runtime's
+  wording stops short of saying exactly which forms those are, no rule guesses at it, so a Function
+  can pass the lint and still be refused for one.
+- **The list of unavailable globals is the useful part of one, not all of it.** It names what test
+  code and Node habits reach for. A global outside that list is not reported, even if JS2 lacks it.
+- **The rules are syntactic.** Nothing here knows CloudFront's size limit on Function code or its CPU
+  budget, so a Function that passes the lint can still be refused at publication for being too large
+  or too slow. Nothing checks which methods of a supported built-in you call either, and the runtime
+  supports only some of them.
 - **Only the `cff-js2` rules are shared between the linters.** ESLint and Oxlint each bring their own
   built-in rules, and their own defaults for which are on. A `.cff.js` file linted by both may pick
   up findings from one that the other does not have.
-- **The rules are syntactic.** Nothing here knows CloudFront's size limit on Function code or its
-  CPU budget, so a Function that passes the lint can still be refused at publication for being too
-  large or too slow.
-- **The list of unavailable globals is the useful part of one, not all of it.** It names what test
-  code and Node habits reach for. A global outside that list is not reported, even if JS2 lacks it.
 - **Oxlint's JS plugin support is in alpha.** It is what loads these rules into Oxlint, and its API
   is still moving upstream.
 - **The Oxlint fragment is extended by path.** Oxlint does not resolve a package name in `extends`,

--- a/docs/lint/cff-js2-eslint-config.example.ts
+++ b/docs/lint/cff-js2-eslint-config.example.ts
@@ -1,0 +1,15 @@
+/**
+ * An ESLint config that lints CloudFront Function files as JS2.
+ */
+
+import eslint from "@eslint/js";
+import { defineConfig } from "eslint/config";
+
+import { cloudFrontFunctionsJs2 } from "@kensio/yulin/eslint";
+
+export default defineConfig(
+  eslint.configs.recommended,
+
+  // Applies only to **/*.cff.js, so it goes after the configs it relaxes.
+  ...cloudFrontFunctionsJs2,
+);

--- a/docs/lint/cff-js2-eslint-relax.example.ts
+++ b/docs/lint/cff-js2-eslint-relax.example.ts
@@ -1,5 +1,5 @@
 /**
- * Allowing arrow functions in CloudFront Function files.
+ * Allowing class syntax in CloudFront Function files.
  */
 
 import { defineConfig } from "eslint/config";
@@ -9,6 +9,6 @@ import { cloudFrontFunctionsJs2 } from "@kensio/yulin/eslint";
 export default defineConfig(...cloudFrontFunctionsJs2, {
   files: ["**/*.cff.js"],
   rules: {
-    "cff-js2/no-arrow-function": "off",
+    "cff-js2/no-class": "off",
   },
 });

--- a/docs/lint/cff-js2-eslint-relax.example.ts
+++ b/docs/lint/cff-js2-eslint-relax.example.ts
@@ -1,0 +1,14 @@
+/**
+ * Allowing arrow functions in CloudFront Function files.
+ */
+
+import { defineConfig } from "eslint/config";
+
+import { cloudFrontFunctionsJs2 } from "@kensio/yulin/eslint";
+
+export default defineConfig(...cloudFrontFunctionsJs2, {
+  files: ["**/*.cff.js"],
+  rules: {
+    "cff-js2/no-arrow-function": "off",
+  },
+});

--- a/docs/services/cloudfront/README.md
+++ b/docs/services/cloudfront/README.md
@@ -785,8 +785,9 @@ export function handler(event) {
 }
 ```
 
-CloudFront Functions run JS2, which refuses much of what ordinary JavaScript allows. Yulin publishes
-ESLint and Oxlint configs that report those refusals in the editor rather than at publication. See
+CloudFront Functions run JS2, which is ECMAScript 5.1 plus a named subset of ES 6 to 12, so it
+refuses constructs ordinary JavaScript allows. Yulin publishes ESLint and Oxlint configs that report
+those refusals in the editor rather than at publication. See
 [Linting CloudFront Functions JS2](../../lint/ "CloudFront Functions JS2 lint config usage docs").
 
 ## Response headers policies

--- a/docs/services/cloudfront/README.md
+++ b/docs/services/cloudfront/README.md
@@ -785,6 +785,10 @@ export function handler(event) {
 }
 ```
 
+CloudFront Functions run JS2, which refuses much of what ordinary JavaScript allows. Yulin publishes
+ESLint and Oxlint configs that report those refusals in the editor rather than at publication. See
+[Linting CloudFront Functions JS2](../../lint/ "CloudFront Functions JS2 lint config usage docs").
+
 ## Response headers policies
 
 A response headers policy sets headers on everything a cache Behavior serves. Declare one as

--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -19,6 +19,7 @@
       "@kensio/yulin/iam": ["../src/service/iam/index.ts"],
       "@kensio/yulin/kms": ["../src/service/kms/index.ts"],
       "@kensio/yulin/lambda": ["../src/service/lambda/index.ts"],
+      "@kensio/yulin/oxlint": ["../src/config/oxlint/index.ts"],
       "@kensio/yulin/rekognition": ["../src/service/rekognition/index.ts"],
       "@kensio/yulin/route53": ["../src/service/route53/index.ts"],
       "@kensio/yulin/s3": ["../src/service/s3/index.ts"],

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -22,6 +22,63 @@ const securityRecommended = security.configs.recommended as Parameters<
   typeof defineConfig
 >[0];
 
+/** One entry in a `no-restricted-syntax` rule configuration. */
+type RestrictedSyntax = { readonly selector: string; readonly message: string };
+
+/**
+ * Every `no-restricted-syntax` entry a shared config sets, gathered up.
+ *
+ * Flat config replaces a rule's whole configuration rather than merging it, so
+ * two configs that both set `no-restricted-syntax` cannot coexist: the later
+ * one wins and the earlier one's selectors are dropped without a word. That is
+ * not hypothetical. Adding `@kensio/smartass/eslint` in #93 silently turned
+ * off this repository's own restrictions, and nothing noticed for 265 commits.
+ *
+ * Collecting the entries and setting the rule once below is what keeps both.
+ * Anything else setting this rule has to come through here too.
+ */
+function restrictedSyntaxFrom(
+  configs: readonly { rules?: Record<string, unknown> }[],
+): readonly RestrictedSyntax[] {
+  return configs.flatMap((config) => {
+    const entry = config.rules?.["no-restricted-syntax"];
+
+    return Array.isArray(entry)
+      ? (entry.slice(1) as readonly RestrictedSyntax[])
+      : [];
+  });
+}
+
+/**
+ * Restrictions this repository sets on itself, as opposed to advice a shared
+ * config brings with it.
+ */
+const yulinRestrictedSyntax: readonly RestrictedSyntax[] = [
+  {
+    selector:
+      "IfStatement[test.type='BinaryExpression'][test.operator='===']:matches([test.left.type='Identifier'][test.left.name='undefined'], [test.right.type='Identifier'][test.right.name='undefined']):has(ThrowStatement[argument.type='NewExpression'][argument.callee.name='Error'])",
+    message:
+      "Use `assertDefined(value, description)` instead of throwing `Error` from an `undefined` guard.",
+  },
+  {
+    selector:
+      "IfStatement[test.type='BinaryExpression'][test.operator='===']:matches([test.left.type='Literal'][test.left.value=null], [test.right.type='Literal'][test.right.value=null]):has(ThrowStatement[argument.type='NewExpression'][argument.callee.name='Error'])",
+    message:
+      "Use `assertNotNull(value, description)` instead of throwing `Error` from a `null` guard.",
+  },
+  {
+    selector:
+      "MemberExpression[object.type='ThisExpression'][property.type='Identifier'][property.name='props']",
+    message:
+      "Do not reuse `this.props`. Destructure constructor props into class members instead.",
+  },
+];
+
+const allRestrictedSyntax: readonly RestrictedSyntax[] = [
+  ...yulinRestrictedSyntax,
+  ...restrictedSyntaxFrom(smartassPreferSpecificAssertions),
+];
+
 export default defineConfig(
   // ── Global ignores ──────────────────────────────────────
   {
@@ -119,33 +176,9 @@ export default defineConfig(
       ],
 
       // ── Discourage various undesirable patterns ─────────────
-      "no-restricted-syntax": [
-        "error",
-        {
-          selector:
-            "TSUnknownKeyword:not(.params > TSTypeAnnotation > TSUnknownKeyword)",
-          message:
-            "Avoid `unknown` as a type, except when narrowing a function parameter to a concrete type.",
-        },
-        {
-          selector:
-            "IfStatement[test.type='BinaryExpression'][test.operator='===']:matches([test.left.type='Identifier'][test.left.name='undefined'], [test.right.type='Identifier'][test.right.name='undefined']):has(ThrowStatement[argument.type='NewExpression'][argument.callee.name='Error'])",
-          message:
-            "Use `assertDefined(value, description)` instead of throwing `Error` from an `undefined` guard.",
-        },
-        {
-          selector:
-            "IfStatement[test.type='BinaryExpression'][test.operator='===']:matches([test.left.type='Literal'][test.left.value=null], [test.right.type='Literal'][test.right.value=null]):has(ThrowStatement[argument.type='NewExpression'][argument.callee.name='Error'])",
-          message:
-            "Use `assertNotNull(value, description)` instead of throwing `Error` from a `null` guard.",
-        },
-        {
-          selector:
-            "MemberExpression[object.type='ThisExpression'][property.type='Identifier'][property.name='props']",
-          message:
-            "Do not reuse `this.props`. Destructure constructor props into class members instead.",
-        },
-      ],
+      // Set once, from every source, so that nothing clobbers anything else.
+      // See `restrictedSyntaxFrom` above.
+      "no-restricted-syntax": ["error", ...allRestrictedSyntax],
 
       // ── General quality ──────────────────────────────
       "no-console": "warn",
@@ -294,6 +327,10 @@ export default defineConfig(
       // Examples model real AWS-shaped data, such as UPPER_SNAKE_CASE Lambda
       // environment variable names, rather than code identifier names.
       "@typescript-eslint/naming-convention": "off",
+      // An example is written the way a package consumer writes code, and
+      // `assertDefined` is an internal helper rather than part of the public
+      // API, so a hand-written guard is what an example should show.
+      "no-restricted-syntax": "off",
     },
   },
 
@@ -360,8 +397,9 @@ export default defineConfig(
     },
   },
 
-  // ── More specific smartass assertions
-  ...smartassPreferSpecificAssertions,
+  // Smartass's own config is deliberately not spread in here. It sets
+  // `no-restricted-syntax` and would replace everything above; its entries
+  // arrive through `allRestrictedSyntax` instead.
 
   // ── CloudFront Functions JS2
   ...cloudFrontFunctionsJs2,

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   },
   "scripts": {
     "clean": "rm -rf ./dist/ ./*.tsbuildinfo",
-    "build": "pnpm clean && tsc -p tsconfig.build.json",
+    "build": "pnpm clean && tsc -p tsconfig.build.json && pnpm oxlint:config",
+    "oxlint:config": "pnpm tsx scripts/mts/write-oxlint-config.mts",
     "build:check": "tsc -p tsconfig.json --noEmit",
     "prepack": "pnpm build",
     "verify:pack": "pnpm tsx scripts/mts/verify-pack.mts",
@@ -85,6 +86,11 @@
       "import": "./dist/service/lambda/index.js",
       "types": "./dist/service/lambda/index.d.ts"
     },
+    "./oxlint": {
+      "import": "./dist/config/oxlint/index.js",
+      "types": "./dist/config/oxlint/index.d.ts"
+    },
+    "./oxlint/cffjs2.oxlintrc.json": "./dist/config/oxlint/cffjs2.oxlintrc.json",
     "./package.json": "./package.json",
     "./rekognition": {
       "import": "./dist/service/rekognition/index.js",
@@ -185,6 +191,7 @@
     "fta-cli": "^3.0.0",
     "globals": "^17.8.0",
     "jiti": "^2.7.0",
+    "oxlint": "^1.77.0",
     "prettier": "^3.9.6",
     "semantic-release": "25.0.9",
     "tsx": "^4.23.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -165,6 +165,9 @@ importers:
       jiti:
         specifier: ^2.7.0
         version: 2.7.0
+      oxlint:
+        specifier: ^1.77.0
+        version: 1.77.0
       prettier:
         specifier: ^3.9.6
         version: 3.9.6
@@ -790,6 +793,128 @@ packages:
 
   '@oxc-project/types@0.139.0':
     resolution: {integrity: sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==}
+
+  '@oxlint/binding-android-arm-eabi@1.77.0':
+    resolution: {integrity: sha512-E06sKWS6PiI6HRxS1wyQg22HvApt01hI7fV+T3wUk3OSbaaP4a3hYGY/MIQDmASqCiRjBdpRQYkgMkqH82cWmQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
+  '@oxlint/binding-android-arm64@1.77.0':
+    resolution: {integrity: sha512-NvsKz0KZxTp9cYWPLf+FXaSZwB3oO3peAjtukpOMBgse2vhQSoIIVqeO1yR0lEo/UcdZIDL18uq+kL0LzQ0ytA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxlint/binding-darwin-arm64@1.77.0':
+    resolution: {integrity: sha512-bgjTn6nW4bQCFBvSvuHCpDD+sONvmpo4lGI4PxzMt1quBA+xYxhczk6RiCn3GZ9gY8uhaBbwhj9MdKGfu6T9DA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxlint/binding-darwin-x64@1.77.0':
+    resolution: {integrity: sha512-aotaIttH1R6j1Rwhx0M0htgeZyGtVQqYNTVEYMN/UcgHPquGA6kmk9OyuDc3a2GKUQBC+3C3GVQCcrRPMYqAFA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxlint/binding-freebsd-x64@1.77.0':
+    resolution: {integrity: sha512-nNx/wta7ksRAdYvq+l4AWjXkLxEXHALhENxjj2cYbQAIR4ybaA5L+hCbE63HOmft5czQ6ks+hb8vmEAnn7YGPg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxlint/binding-linux-arm-gnueabihf@1.77.0':
+    resolution: {integrity: sha512-tMLLjM7xXtzXisVCzkOTXNCy9bZVId2wteNwjohlFDR/jY6WagpEDA1c1wu4xRc20Hojaxj+V6DSR7gbKxijWA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxlint/binding-linux-arm-musleabihf@1.77.0':
+    resolution: {integrity: sha512-MiAFDFaqR0tmHTAyo0YDcZ5hyLREdYw/RQhc2R3cbT+8O3tB+zqPM2th9TTQ+Uo3jn/embS+DO+HyX9ztCPkOQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxlint/binding-linux-arm64-gnu@1.77.0':
+    resolution: {integrity: sha512-/xqQ3B16i1T4cyt/9Mn+4CpzhUXoBXp7kVpIwzOXNFLj5JmK1bIjsbSnX296Gg8A/o7oDtKWikFgBx0SLwztkw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxlint/binding-linux-arm64-musl@1.77.0':
+    resolution: {integrity: sha512-LSbwuRKiNCenPDcbARqAZ5RfBy7gmj7vOvfJRLeCDU3gFtSxWbhv/+VTlaUqzUhNj1gFLHB8h7ALnxa/Az6z6g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxlint/binding-linux-ppc64-gnu@1.77.0':
+    resolution: {integrity: sha512-QWdcH31mXEUe5Nq1s0CfCpceaKjIo9uZtwDjAuL681g1axf+5x8xrg/eXWaw//4NCxYZ4V4e5Hu5tvdR+pTBlg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxlint/binding-linux-riscv64-gnu@1.77.0':
+    resolution: {integrity: sha512-GnOfYgJxbcElOiPZaDFDl406ONddwvOWk2jvAAAEjwAl4GofNoHF+/HHUIBYa6bFCArlcGPi0XjC4cU1pkgF/Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxlint/binding-linux-riscv64-musl@1.77.0':
+    resolution: {integrity: sha512-AyEMTUCf0xY+hHF+IxqXFQIX0yQOIR8ykpY0lJNOw9xYqOzUX8dyZfRvlG0RfXwuQn2eonf/8NrMmDSZJjdqsA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxlint/binding-linux-s390x-gnu@1.77.0':
+    resolution: {integrity: sha512-sPLzEcNvxd/oyVQ5oZo92CiHkFkpBeRop13E/P3TPY+hZfXHKCOWKI70TE2RYwMKFJDc20EMjH16L7NZICtKTw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxlint/binding-linux-x64-gnu@1.77.0':
+    resolution: {integrity: sha512-1Oh2ssH2L7lwyvkdSqaMUfsGfwU2Wfvew+obBUYjRVqhpBcUpwnsPSEr1IzVi9XqkuY10geiLsNKecqaZC34Dw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxlint/binding-linux-x64-musl@1.77.0':
+    resolution: {integrity: sha512-0j/2wRgNGO+Qj/M1uu/p57h/hFTTWWcfie0ufkbabeus2s5+/QqkCflnMOwLLN5m2GsNeWp4xdl4cPa4n7QCOQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxlint/binding-openharmony-arm64@1.77.0':
+    resolution: {integrity: sha512-BJ/j54qS0usEnyDkLYURMj2iiD9h5Cyy+ppzeMSXBGRXaGRNWnj1Mw14NqWMR5E/PzdgB30OOCCzLzbRoduafw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxlint/binding-win32-arm64-msvc@1.77.0':
+    resolution: {integrity: sha512-Yh8w+g2Lpx7StrvtYkoz9JJvXjB9wxgFChFNb85nrXm/wj/XTwGWS1hve9+900HL7llrntYB3YP+y32E3tRqzA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxlint/binding-win32-ia32-msvc@1.77.0':
+    resolution: {integrity: sha512-zja5b7+6a7UsRFgAQSrnax5vrzliEyNPLCjfXONu/vTWswaIVZGFajJZptaeRvPE4LghtFdAzVFlexTm7MVTGA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@oxlint/binding-win32-x64-msvc@1.77.0':
+    resolution: {integrity: sha512-+teyvPDZ2RjUvo+SuCqS/UhaJl1QtdW5fWT5NJTV61V5MIuIS90Db9LixmtEGvXixyttiK62P96MSu3UlpviBw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
 
   '@pnpm/config.env-replace@1.1.0':
     resolution: {integrity: sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w==}
@@ -2395,6 +2520,19 @@ packages:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
 
+  oxlint@1.77.0:
+    resolution: {integrity: sha512-qnGh8XJHaQ0dprrDXNQZgS0FgjI6v+V3+X8DwmaV++5Aamy6jGKfDdQ1TUvhUxtmKFAbEf4/WeO5QZX+5WSngg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      oxlint-tsgolint: '>=7.0.2001'
+      vite-plus: '*'
+    peerDependenciesMeta:
+      oxlint-tsgolint:
+        optional: true
+      vite-plus:
+        optional: true
+
   p-each-series@3.0.0:
     resolution: {integrity: sha512-lastgtAdoH9YaLyDa5i5z64q+kzOcQHsQ5SsZJD3q0VEyI8mq872S3geuNbRUQLVAE9siMfgKrpj7MloKFHruw==}
     engines: {node: '>=12'}
@@ -3920,6 +4058,63 @@ snapshots:
 
   '@oxc-project/types@0.139.0': {}
 
+  '@oxlint/binding-android-arm-eabi@1.77.0':
+    optional: true
+
+  '@oxlint/binding-android-arm64@1.77.0':
+    optional: true
+
+  '@oxlint/binding-darwin-arm64@1.77.0':
+    optional: true
+
+  '@oxlint/binding-darwin-x64@1.77.0':
+    optional: true
+
+  '@oxlint/binding-freebsd-x64@1.77.0':
+    optional: true
+
+  '@oxlint/binding-linux-arm-gnueabihf@1.77.0':
+    optional: true
+
+  '@oxlint/binding-linux-arm-musleabihf@1.77.0':
+    optional: true
+
+  '@oxlint/binding-linux-arm64-gnu@1.77.0':
+    optional: true
+
+  '@oxlint/binding-linux-arm64-musl@1.77.0':
+    optional: true
+
+  '@oxlint/binding-linux-ppc64-gnu@1.77.0':
+    optional: true
+
+  '@oxlint/binding-linux-riscv64-gnu@1.77.0':
+    optional: true
+
+  '@oxlint/binding-linux-riscv64-musl@1.77.0':
+    optional: true
+
+  '@oxlint/binding-linux-s390x-gnu@1.77.0':
+    optional: true
+
+  '@oxlint/binding-linux-x64-gnu@1.77.0':
+    optional: true
+
+  '@oxlint/binding-linux-x64-musl@1.77.0':
+    optional: true
+
+  '@oxlint/binding-openharmony-arm64@1.77.0':
+    optional: true
+
+  '@oxlint/binding-win32-arm64-msvc@1.77.0':
+    optional: true
+
+  '@oxlint/binding-win32-ia32-msvc@1.77.0':
+    optional: true
+
+  '@oxlint/binding-win32-x64-msvc@1.77.0':
+    optional: true
+
   '@pnpm/config.env-replace@1.1.0': {}
 
   '@pnpm/network.ca-file@1.0.2':
@@ -5401,6 +5596,28 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
       word-wrap: 1.2.5
+
+  oxlint@1.77.0:
+    optionalDependencies:
+      '@oxlint/binding-android-arm-eabi': 1.77.0
+      '@oxlint/binding-android-arm64': 1.77.0
+      '@oxlint/binding-darwin-arm64': 1.77.0
+      '@oxlint/binding-darwin-x64': 1.77.0
+      '@oxlint/binding-freebsd-x64': 1.77.0
+      '@oxlint/binding-linux-arm-gnueabihf': 1.77.0
+      '@oxlint/binding-linux-arm-musleabihf': 1.77.0
+      '@oxlint/binding-linux-arm64-gnu': 1.77.0
+      '@oxlint/binding-linux-arm64-musl': 1.77.0
+      '@oxlint/binding-linux-ppc64-gnu': 1.77.0
+      '@oxlint/binding-linux-riscv64-gnu': 1.77.0
+      '@oxlint/binding-linux-riscv64-musl': 1.77.0
+      '@oxlint/binding-linux-s390x-gnu': 1.77.0
+      '@oxlint/binding-linux-x64-gnu': 1.77.0
+      '@oxlint/binding-linux-x64-musl': 1.77.0
+      '@oxlint/binding-openharmony-arm64': 1.77.0
+      '@oxlint/binding-win32-arm64-msvc': 1.77.0
+      '@oxlint/binding-win32-ia32-msvc': 1.77.0
+      '@oxlint/binding-win32-x64-msvc': 1.77.0
 
   p-each-series@3.0.0: {}
 

--- a/scripts/mts/verify-pack.mts
+++ b/scripts/mts/verify-pack.mts
@@ -19,6 +19,7 @@ import { mkdtemp, readFile, rm, stat } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 
+import { assertDefined } from "../../src/util/type-guard/defined.js";
 import {
   assertTypesUsable,
   createConsumer,
@@ -135,9 +136,7 @@ async function pack(destination: string): Promise<string> {
     readonly filename: string;
   }[];
 
-  if (entry === undefined) {
-    throw new Error("npm pack produced no tarball");
-  }
+  assertDefined(entry, "npm pack produced no tarball");
 
   return path.join(destination, entry.filename);
 }

--- a/scripts/mts/write-oxlint-config.mts
+++ b/scripts/mts/write-oxlint-config.mts
@@ -1,0 +1,63 @@
+#!/usr/bin/env -S pnpm tsx
+
+/**
+ * Writes the published `.oxlintrc.json` into `dist/` from the same rule
+ * definitions the ESLint config uses.
+ *
+ * Oxlint reads JSON, and TypeScript does not emit JSON, so the file has to be
+ * produced rather than compiled. Generating it here rather than committing a
+ * second copy is what stops the two published configs from drifting: a rule
+ * added to the plugin reaches both, or neither.
+ */
+
+import { mkdir, stat, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+import { cloudFrontFunctionsJs2Oxlint } from "../../src/config/oxlint/index.js";
+
+const projectRoot = path.resolve(import.meta.dirname, "../..");
+
+const outputPath = path.join(
+  projectRoot,
+  "dist",
+  "config",
+  "oxlint",
+  "cffjs2.oxlintrc.json",
+);
+
+/**
+ * Oxlint resolves a plugin specifier against the config file, and finds out it
+ * cannot only when a consumer runs it. Checking here means a change to what
+ * `dist/` looks like fails the build that caused it.
+ */
+async function assertPluginsResolve(): Promise<void> {
+  for (const plugin of cloudFrontFunctionsJs2Oxlint.jsPlugins) {
+    const pluginPath = path.resolve(path.dirname(outputPath), plugin.specifier);
+
+    try {
+      await stat(pluginPath);
+    } catch {
+      throw new Error(
+        `${outputPath} names a plugin at ${plugin.specifier}, which does not exist in dist/ (looked for ${pluginPath}).`,
+      );
+    }
+  }
+}
+
+async function main(): Promise<void> {
+  await mkdir(path.dirname(outputPath), { recursive: true });
+
+  await writeFile(
+    outputPath,
+    `${JSON.stringify(cloudFrontFunctionsJs2Oxlint, undefined, 2)}\n`,
+    "utf8",
+  );
+
+  await assertPluginsResolve();
+
+  // This runs inside `prepack`, and `npm pack --json` gives its own output on
+  // stdout, so saying anything there would be parsed as part of it.
+  console.error(`Wrote ${path.relative(projectRoot, outputPath)}.`);
+}
+
+await main();

--- a/src/config/eslint/cffjs2.eslint.config.ts
+++ b/src/config/eslint/cffjs2.eslint.config.ts
@@ -1,5 +1,19 @@
+import { type ESLint } from "eslint";
 import { defineConfig } from "eslint/config";
 import tseslint from "typescript-eslint";
+
+import {
+  cffJs2LintPlugin,
+  cffJs2LintRules,
+  cffJs2PluginName,
+} from "../lint/index.js";
+
+// ESLint's `Plugin` describes a rule context far wider than these rules read:
+// it is generic over the syntax tree, so a rule typed against the handful of
+// node properties it actually touches cannot satisfy it. This file is the
+// adapter that wires a linter-agnostic plugin into ESLint, so it is where that
+// difference belongs.
+const eslintPlugin = cffJs2LintPlugin as unknown as ESLint.Plugin;
 
 export default defineConfig({
   // ── CloudFront Functions JS2
@@ -10,118 +24,19 @@ export default defineConfig({
       projectService: false,
     },
   },
+  plugins: {
+    // The restrictions live in a plugin rather than in `no-restricted-syntax`
+    // so that Oxlint can load the same rules, and so that switching one off
+    // does not mean restating the rest. See `../lint/cff-js2-lint-plugin.ts`.
+    [cffJs2PluginName]: eslintPlugin,
+  },
   rules: {
-    "no-var": "off",
-    "prefer-const": "off",
-    "object-shorthand": "off",
-    "prefer-template": "off",
+    ...cffJs2LintRules(),
+
+    // ── ESLint-only, because typescript-eslint's own copies of these rules
+    //    take over from the built-in ones in a TypeScript-aware config.
     "@typescript-eslint/explicit-function-return-type": "off",
     "@typescript-eslint/explicit-module-boundary-types": "off",
-    "no-eval": "error",
-    "no-new-func": "error",
-    "no-implied-eval": "error",
-    "no-restricted-globals": [
-      "error",
-      {
-        name: "fetch",
-        message: "CloudFront Functions cannot make network requests.",
-      },
-      {
-        name: "XMLHttpRequest",
-        message: "CloudFront Functions cannot make network requests.",
-      },
-      {
-        name: "WebSocket",
-        message: "CloudFront Functions cannot open network connections.",
-      },
-      {
-        name: "require",
-        message:
-          "CloudFront Functions must be self-contained and cannot require modules.",
-      },
-      {
-        name: "process",
-        message:
-          "CloudFront Functions do not have access to Node.js process APIs.",
-      },
-      {
-        name: "Buffer",
-        message: "CloudFront Functions do not have access to Node.js Buffer.",
-      },
-      {
-        name: "setTimeout",
-        message: "CloudFront Functions do not support timers.",
-      },
-      {
-        name: "setInterval",
-        message: "CloudFront Functions do not support timers.",
-      },
-      {
-        name: "setImmediate",
-        message: "CloudFront Functions do not support timers.",
-      },
-      {
-        name: "Promise",
-        message: "Avoid Promise usage in CloudFront Functions.",
-      },
-    ],
-    "no-restricted-syntax": [
-      "error",
-      {
-        selector: "TemplateLiteral",
-        message:
-          "CloudFront Functions JS2 does not support template literals. Use string concatenation instead.",
-      },
-      {
-        selector: "ImportDeclaration",
-        message:
-          "CloudFront Functions must be self-contained and should not use import syntax.",
-      },
-      {
-        selector:
-          "ExportNamedDeclaration:not([declaration.type='FunctionDeclaration'][declaration.id.name='handler'])",
-        message:
-          "CloudFront Function files may only export the handler as `export function handler(...)`.",
-      },
-      {
-        selector: "ExportDefaultDeclaration, ExportAllDeclaration",
-        message:
-          "CloudFront Function files may only export the handler as `export function handler(...)`.",
-      },
-      {
-        selector: "ClassDeclaration, ClassExpression",
-        message: "Avoid class syntax in CloudFront Functions JS2 files.",
-      },
-      {
-        selector: "ArrowFunctionExpression",
-        message:
-          "Avoid arrow functions in CloudFront Functions JS2 files. Use function declarations/expressions instead.",
-      },
-      {
-        selector:
-          "AwaitExpression, FunctionDeclaration[async=true], FunctionExpression[async=true], ArrowFunctionExpression[async=true]",
-        message: "CloudFront Functions should not use async/await.",
-      },
-      {
-        selector:
-          "YieldExpression, FunctionDeclaration[generator=true], FunctionExpression[generator=true]",
-        message: "CloudFront Functions should not use generators.",
-      },
-      {
-        selector: "ObjectPattern, ArrayPattern",
-        message: "Avoid destructuring in CloudFront Functions JS2 files.",
-      },
-      {
-        selector: "SpreadElement, RestElement",
-        message: "Avoid spread/rest syntax in CloudFront Functions JS2 files.",
-      },
-      {
-        selector: "ForOfStatement",
-        message:
-          "Avoid for...of in CloudFront Functions JS2 files. Use index-based loops instead.",
-      },
-    ],
-    "no-unused-vars": ["error", { varsIgnorePattern: "^handler$" }],
     "@typescript-eslint/no-unused-vars": [
       "error",
       { varsIgnorePattern: "^handler$" },

--- a/src/config/eslint/repo-restricted-syntax.iso.test.ts
+++ b/src/config/eslint/repo-restricted-syntax.iso.test.ts
@@ -1,0 +1,88 @@
+import { assertArrayLength, assertArrayMinLength } from "@kensio/smartass";
+import { smartassPreferSpecificAssertions } from "@kensio/smartass/eslint";
+import { ESLint } from "eslint";
+import { describe, it } from "vitest";
+
+/**
+ * The `no-restricted-syntax` entries this repository's config resolves to for
+ * one of its own files.
+ *
+ * Reading them back through ESLint rather than from the config module is the
+ * point: what matters is what survives every config in the chain, not what any
+ * one of them asked for.
+ */
+async function resolvedSelectors(filePath: string): Promise<readonly string[]> {
+  const config = await new ESLint().calculateConfigForFile(filePath);
+  const entry = config.rules?.["no-restricted-syntax"];
+
+  if (!Array.isArray(entry) || entry[0] === "off" || entry[0] === 0) {
+    return [];
+  }
+
+  return entry
+    .slice(1)
+    .map((restriction: unknown) =>
+      typeof restriction === "string"
+        ? restriction
+        : ((restriction as { selector?: string }).selector ?? ""),
+    );
+}
+
+/** Every selector smartass's shared config asks for. */
+function smartassSelectors(): readonly string[] {
+  return smartassPreferSpecificAssertions.flatMap((config) => {
+    const entry = (config as { rules?: Record<string, unknown> }).rules?.[
+      "no-restricted-syntax"
+    ];
+
+    return Array.isArray(entry)
+      ? entry
+          .slice(1)
+          .map(
+            (restriction: unknown) =>
+              (restriction as { selector?: string }).selector ?? "",
+          )
+      : [];
+  });
+}
+
+describe("Resolving this repository's own no-restricted-syntax rule", () => {
+  it("keeps the restrictions this repository sets on itself", async () => {
+    // Given the config as it resolves for an ordinary source file
+    const selectors = await resolvedSelectors("src/index.ts");
+
+    // When this repository's own restrictions are looked for
+    const ownRestriction = selectors.filter((selector) =>
+      selector.includes("[property.name='props']"),
+    );
+
+    // Then they are still there. Flat config replaces a rule's configuration
+    // rather than merging it, so a shared config setting this same rule can
+    // drop these without a word, and one did for 265 commits.
+    assertArrayMinLength(ownRestriction, 1);
+  });
+
+  it("keeps every selector the shared assertion config brings", async () => {
+    // Given the same resolved config, and what smartass asked for
+    const selectors = new Set(await resolvedSelectors("src/index.ts"));
+    const wanted = smartassSelectors();
+
+    // When each of smartass's selectors is looked for in it
+    const missing = wanted.filter((selector) => !selectors.has(selector));
+
+    // Then none of them was lost on the way through the config chain
+    assertArrayLength(missing, 0);
+    assertArrayMinLength(wanted, 1);
+  });
+
+  it("applies the same restrictions to test files", async () => {
+    // Given the config as it resolves for a test file
+    const forSource = await resolvedSelectors("src/index.ts");
+    const forTest = await resolvedSelectors("src/index.iso.test.ts");
+
+    // When the two are compared
+    // Then a test file is held to the same restrictions, which is where the
+    // assertion advice is worth the most
+    assertArrayLength(forTest, forSource.length);
+  });
+});

--- a/src/config/eslint/repo-restricted-syntax.iso.test.ts
+++ b/src/config/eslint/repo-restricted-syntax.iso.test.ts
@@ -1,4 +1,8 @@
-import { assertArrayLength, assertArrayMinLength } from "@kensio/smartass";
+import {
+  assertArrayLength,
+  assertArrayMinLength,
+  assertIdentical,
+} from "@kensio/smartass";
 import { smartassPreferSpecificAssertions } from "@kensio/smartass/eslint";
 import { ESLint } from "eslint";
 import { describe, it } from "vitest";
@@ -80,9 +84,14 @@ describe("Resolving this repository's own no-restricted-syntax rule", () => {
     const forSource = await resolvedSelectors("src/index.ts");
     const forTest = await resolvedSelectors("src/index.iso.test.ts");
 
-    // When the two are compared
+    // When the selectors themselves are compared, rather than how many there
+    // are, since an override could swap one restriction for another and leave
+    // the count alone
+    const asText = (selectors: readonly string[]): string =>
+      selectors.toSorted((left, right) => left.localeCompare(right)).join("\n");
+
     // Then a test file is held to the same restrictions, which is where the
     // assertion advice is worth the most
-    assertArrayLength(forTest, forSource.length);
+    assertIdentical(asText(forTest), asText(forSource));
   });
 });

--- a/src/config/lint/cff-js2-lint-plugin.iso.test.ts
+++ b/src/config/lint/cff-js2-lint-plugin.iso.test.ts
@@ -7,9 +7,9 @@ import cloudFrontFunctionsJs2 from "../eslint/cffjs2.eslint.config.js";
 import { cffJs2LintPlugin, cffJs2PluginName } from "./cff-js2-lint-plugin.js";
 import {
   cffJs2Violations,
+  supportedCffJs2Cases,
   supportedCffJs2Source,
 } from "./cff-js2-lint.fixture.js";
-import { cffJs2SyntaxRestrictions } from "./cff-js2-restriction.js";
 
 /**
  * Lints a source string through the published ESLint config, exactly as a
@@ -50,7 +50,7 @@ describe("Linting a CloudFront Functions JS2 file", () => {
   }
 
   it("stays quiet on a function that respects the restrictions", async () => {
-    // Given a function written the way JS2 wants it, with `var` and no sugar
+    // Given a function using the ES 6 and ES 8 features JS2 does support
     const source = supportedCffJs2Source;
 
     // When it is linted with the published config
@@ -60,6 +60,20 @@ describe("Linting a CloudFront Functions JS2 file", () => {
     // config would otherwise apply to it
     assertArrayLength(reported, 0);
   });
+
+  for (const supported of supportedCffJs2Cases) {
+    it(`allows ${supported.what}`, async () => {
+      // Given a CloudFront Function using something JS2 runs happily
+      const source = supported.source;
+
+      // When it is linted with the published config
+      const reported = await lintCffJs2(source);
+
+      // Then no restriction reports it. Each of these was refused by an
+      // earlier version of this config, against what the runtime documents.
+      assertArrayLength(reported, 0);
+    });
+  }
 
   it("covers every restriction with a case", () => {
     // Given the rules the plugin publishes
@@ -76,17 +90,5 @@ describe("Linting a CloudFront Functions JS2 file", () => {
       published.filter((rule) => !covered.has(rule)),
       0,
     );
-  });
-
-  it("names a rule for every syntax restriction", () => {
-    // Given the restriction table the plugin is built from
-    const restrictions = Object.keys(cffJs2SyntaxRestrictions);
-
-    // When the plugin's rules are counted against it
-    const ruleNames = Object.keys(cffJs2LintPlugin.rules);
-
-    // Then each restriction became a rule, plus the globals rule that resolves
-    // names through scope rather than by selector
-    assertArrayLength(ruleNames, restrictions.length + 1);
   });
 });

--- a/src/config/lint/cff-js2-lint-plugin.iso.test.ts
+++ b/src/config/lint/cff-js2-lint-plugin.iso.test.ts
@@ -1,0 +1,92 @@
+import { assertArrayIncludes, assertArrayLength } from "@kensio/smartass";
+import { ESLint } from "eslint";
+import tseslint from "typescript-eslint";
+import { describe, it } from "vitest";
+
+import cloudFrontFunctionsJs2 from "../eslint/cffjs2.eslint.config.js";
+import { cffJs2LintPlugin, cffJs2PluginName } from "./cff-js2-lint-plugin.js";
+import {
+  cffJs2Violations,
+  supportedCffJs2Source,
+} from "./cff-js2-lint.fixture.js";
+import { cffJs2SyntaxRestrictions } from "./cff-js2-restriction.js";
+
+/**
+ * Lints a source string through the published ESLint config, exactly as a
+ * consumer's `.cff.js` file would be.
+ *
+ * The typescript-eslint plugin is registered ahead of it because the published
+ * config turns typescript-eslint rules off without owning the plugin, the same
+ * way it arrives in a consumer's config that already has it.
+ */
+async function lintCffJs2(source: string): Promise<readonly string[]> {
+  const eslint = new ESLint({
+    overrideConfigFile: true,
+    overrideConfig: [
+      { plugins: { "@typescript-eslint": tseslint.plugin } },
+      ...cloudFrontFunctionsJs2,
+    ] as never,
+  });
+
+  const [result] = await eslint.lintText(source, {
+    filePath: "handler.cff.js",
+  });
+
+  return (result?.messages ?? []).map((message) => message.ruleId ?? "");
+}
+
+describe("Linting a CloudFront Functions JS2 file", () => {
+  for (const violation of cffJs2Violations) {
+    it(`reports ${violation.what}`, async () => {
+      // Given a CloudFront Function using something JS2 will not run
+      const source = violation.source;
+
+      // When it is linted with the published config
+      const reported = await lintCffJs2(source);
+
+      // Then the rule for that construct is among what is reported
+      assertArrayIncludes(reported, `${cffJs2PluginName}/${violation.rule}`);
+    });
+  }
+
+  it("stays quiet on a function that respects the restrictions", async () => {
+    // Given a function written the way JS2 wants it, with `var` and no sugar
+    const source = supportedCffJs2Source;
+
+    // When it is linted with the published config
+    const reported = await lintCffJs2(source);
+
+    // Then nothing is reported, including by the rules a modern-JavaScript
+    // config would otherwise apply to it
+    assertArrayLength(reported, 0);
+  });
+
+  it("covers every restriction with a case", () => {
+    // Given the rules the plugin publishes
+    const published = Object.keys(cffJs2LintPlugin.rules);
+
+    // When each is looked for among the cases the tests above run
+    const covered = new Set(
+      cffJs2Violations.map((violation) => violation.rule),
+    );
+
+    // Then no rule ships without one, which is what stops a rule being added
+    // and never exercised
+    assertArrayLength(
+      published.filter((rule) => !covered.has(rule)),
+      0,
+    );
+  });
+
+  it("names a rule for every syntax restriction", () => {
+    // Given the restriction table the plugin is built from
+    const restrictions = Object.keys(cffJs2SyntaxRestrictions);
+
+    // When the plugin's rules are counted against it
+    const ruleNames = Object.keys(cffJs2LintPlugin.rules);
+
+    // Then each restriction became a rule, plus the globals rule that resolves
+    // names through scope rather than by selector
+    assertArrayLength(ruleNames, restrictions.length + 1);
+  });
+});

--- a/src/config/lint/cff-js2-lint-plugin.ts
+++ b/src/config/lint/cff-js2-lint-plugin.ts
@@ -1,0 +1,54 @@
+import {
+  cffJs2SyntaxRestrictions,
+  cffJs2UnavailableGlobalRuleName,
+} from "./cff-js2-restriction.js";
+import { cffJs2UnavailableGlobalRule } from "./cff-js2-unavailable-global.rule.js";
+import type {
+  LintNode,
+  LintPlugin,
+  LintRule,
+  LintRuleContext,
+  LintVisitor,
+} from "./lint-plugin.type.js";
+
+/**
+ * The name both linters report these rules under.
+ */
+export const cffJs2PluginName = "cff-js2";
+
+function syntaxRule(selector: string, message: string): LintRule {
+  return {
+    meta: { type: "problem", schema: [], messages: { unsupported: message } },
+    create: (context: LintRuleContext): LintVisitor => ({
+      [selector]: (node: LintNode): void => {
+        context.report({ node, messageId: "unsupported" });
+      },
+    }),
+  };
+}
+
+function buildRules(): Record<string, LintRule> {
+  return {
+    [cffJs2UnavailableGlobalRuleName]: cffJs2UnavailableGlobalRule(),
+    ...Object.fromEntries(
+      Object.entries(cffJs2SyntaxRestrictions).map(([name, restriction]) => [
+        name,
+        syntaxRule(restriction.selector, restriction.message),
+      ]),
+    ),
+  };
+}
+
+/**
+ * A lint plugin holding what CloudFront Functions JS2 refuses to run.
+ *
+ * The same object loads into ESLint as a plugin and into Oxlint as a JS
+ * plugin, because both walk the tree with the same selector syntax and hand a
+ * rule the same context. Publishing it as rules rather than as a
+ * `no-restricted-syntax` block is what makes that possible, and it also lets a
+ * consumer switch off one restriction without restating the other ten.
+ */
+export const cffJs2LintPlugin: LintPlugin = {
+  meta: { name: cffJs2PluginName },
+  rules: buildRules(),
+};

--- a/src/config/lint/cff-js2-lint-rules.ts
+++ b/src/config/lint/cff-js2-lint-rules.ts
@@ -1,0 +1,65 @@
+import { cffJs2LintPlugin, cffJs2PluginName } from "./cff-js2-lint-plugin.js";
+
+/**
+ * One rule setting, in the form both linters read it.
+ */
+export type LintRuleSetting =
+  "off" | "error" | readonly ["error", Readonly<Record<string, string>>];
+
+/**
+ * Rules a general JavaScript config turns on that JS2 has to be let off.
+ *
+ * A CloudFront Function is written against a runtime with no `const`, no
+ * shorthand properties and no template literals, so the modern-JavaScript
+ * advice a repository applies everywhere else is advice to write code that
+ * will not run. Turning these off is not a lowering of standards; the
+ * restrictions below are stricter than what they replace.
+ */
+const relaxedRules: Readonly<Record<string, LintRuleSetting>> = {
+  "no-var": "off",
+  "prefer-const": "off",
+  "object-shorthand": "off",
+  "prefer-template": "off",
+};
+
+/**
+ * Restrictions both linters already ship, so the plugin does not repeat them.
+ */
+const builtInRules: Readonly<Record<string, LintRuleSetting>> = {
+  "no-eval": "error",
+  "no-new-func": "error",
+  "no-implied-eval": "error",
+  // The handler is the entry point CloudFront calls rather than anything this
+  // file uses, so it is not unused merely because nothing here reads it.
+  "no-unused-vars": ["error", { varsIgnorePattern: "^handler$" }],
+};
+
+/**
+ * Every rule in the plugin, turned on, under the name the plugin is loaded as.
+ *
+ * Deriving this from the plugin keeps a rule from being added without either
+ * published config picking it up.
+ */
+export function cffJs2LintPluginRules(): Record<string, "error"> {
+  return Object.fromEntries(
+    Object.keys(cffJs2LintPlugin.rules).map((name) => [
+      `${cffJs2PluginName}/${name}`,
+      "error",
+    ]),
+  );
+}
+
+/**
+ * Every rule a CloudFront Functions JS2 file should be linted with, in the
+ * form ESLint and Oxlint both accept.
+ *
+ * Both published configs derive their rules from here, so a restriction cannot
+ * be added for one linter and forgotten for the other.
+ */
+export function cffJs2LintRules(): Record<string, LintRuleSetting> {
+  return {
+    ...relaxedRules,
+    ...builtInRules,
+    ...cffJs2LintPluginRules(),
+  };
+}

--- a/src/config/lint/cff-js2-lint-rules.ts
+++ b/src/config/lint/cff-js2-lint-rules.ts
@@ -7,19 +7,18 @@ export type LintRuleSetting =
   "off" | "error" | readonly ["error", Readonly<Record<string, string>>];
 
 /**
- * Rules a general JavaScript config turns on that JS2 has to be let off.
+ * Rules a general JavaScript config turns on that JS2 cannot satisfy.
  *
- * A CloudFront Function is written against a runtime with no `const`, no
- * shorthand properties and no template literals, so the modern-JavaScript
- * advice a repository applies everywhere else is advice to write code that
- * will not run. Turning these off is not a lowering of standards; the
- * restrictions below are stricter than what they replace.
+ * Only advice the runtime makes impossible is relaxed. `const`, `let` and
+ * template literals are all supported in JS2, so the rules asking for them
+ * stay on: switching them off would tell a reader that `var` and string
+ * concatenation are required here, which is its own kind of wrong answer.
+ *
+ * Shorthand object properties are ES 6 literal syntax the runtime's feature
+ * list does not name, so that one is genuinely unavailable.
  */
 const relaxedRules: Readonly<Record<string, LintRuleSetting>> = {
-  "no-var": "off",
-  "prefer-const": "off",
   "object-shorthand": "off",
-  "prefer-template": "off",
 };
 
 /**

--- a/src/config/lint/cff-js2-lint.fixture.ts
+++ b/src/config/lint/cff-js2-lint.fixture.ts
@@ -1,22 +1,35 @@
 /**
  * A CloudFront Function that stays inside what JS2 will run.
  *
- * It is here so a test can show the restrictions staying quiet on code that
- * respects them, which is the half an over-broad selector breaks first.
+ * It deliberately uses the ES 6 and ES 8 features the runtime's feature list
+ * does name: `const`, `let`, template literals, arrow functions, rest
+ * parameters and `async`/`await`. An earlier version of this config refused
+ * all of those, so a fixture that only used ES 5.1 would have passed against
+ * rules that were wrong.
  */
-export const supportedCffJs2Source = `function normalise(uri) {
-  var trimmed = uri;
+export const supportedCffJs2Source = `const suffix = "index.html";
 
-  if (trimmed.charAt(trimmed.length - 1) === "/") {
-    trimmed = trimmed + "index.html";
+const withSuffix = (uri) => \`\${uri}\${suffix}\`;
+
+function firstDefined(...candidates) {
+  for (var index = 0; index < candidates.length; index++) {
+    if (candidates[index] !== undefined) {
+      return candidates[index];
+    }
   }
 
-  return trimmed;
+  return undefined;
 }
 
-export function handler(event) {
-  var request = event.request;
-  request.uri = normalise(request.uri);
+export async function handler(event) {
+  const request = event.request;
+  let uri = firstDefined(request.uri, "/");
+
+  if (uri.charAt(uri.length - 1) === "/") {
+    uri = withSuffix(uri);
+  }
+
+  request.uri = await Promise.resolve(uri);
 
   return request;
 }
@@ -36,15 +49,10 @@ export interface CffJs2Violation {
  *
  * Every rule in the plugin needs one, so that a rule whose selector stops
  * matching is a failing test rather than a quiet gap in what gets caught.
- * A case may trip more than one rule — banned syntax tends to arrive in
+ * A case may trip more than one rule — unsupported syntax tends to arrive in
  * company — so what each asserts is that its own rule is among the findings.
  */
 export const cffJs2Violations: readonly CffJs2Violation[] = [
-  {
-    rule: "no-template-literal",
-    what: "a template literal",
-    source: "export function handler(event) {\n  return `/` + event.id;\n}\n",
-  },
   {
     rule: "no-import",
     what: "an import",
@@ -76,30 +84,22 @@ export function handler() {}
 `,
   },
   {
+    rule: "only-built-in-require",
+    what: "requiring a module the runtime does not have",
+    source: `var fs = require("node:fs");
+
+export function handler(event) {
+  return fs.readFileSync(event.request.uri);
+}
+`,
+  },
+  {
     rule: "no-class",
     what: "a class",
     source: `class Router {}
 
 export function handler() {
   return new Router();
-}
-`,
-  },
-  {
-    rule: "no-arrow-function",
-    what: "an arrow function",
-    source: `export function handler(event) {
-  var pick = () => event.request;
-
-  return pick();
-}
-`,
-  },
-  {
-    rule: "no-async",
-    what: "async and await",
-    source: `export async function handler(event) {
-  return await event.request;
 }
 `,
   },
@@ -119,7 +119,7 @@ export function handler() {
     rule: "no-destructuring",
     what: "destructuring",
     source: `export function handler(event) {
-  var { request } = event;
+  const { request } = event;
 
   return request;
 }
@@ -129,7 +129,7 @@ export function handler() {
     rule: "no-spread",
     what: "spread syntax",
     source: `export function handler(event) {
-  var headers = [event.request];
+  const headers = [event.request];
 
   return [...headers, event];
 }
@@ -139,9 +139,9 @@ export function handler() {
     rule: "no-for-of",
     what: "a for...of loop",
     source: `export function handler(event) {
-  var total = 0;
+  let total = 0;
 
-  for (var value of event.values) {
+  for (const value of event.values) {
     total = total + value;
   }
 
@@ -156,6 +156,86 @@ export function handler() {
   fetch("https://example.test");
 
   return event;
+}
+`,
+  },
+];
+
+/**
+ * Syntax JS2 does support, which no rule may report.
+ *
+ * These are here because each one was refused by an earlier version of this
+ * config, and a rule that sends a reader away from working code is worse than
+ * no rule at all.
+ */
+export const supportedCffJs2Cases: readonly {
+  readonly what: string;
+  readonly source: string;
+}[] = [
+  {
+    what: "a template literal",
+    source: "export function handler(event) {\n  return `/` + event.id;\n}\n",
+  },
+  {
+    what: "an arrow function",
+    source: `export function handler(event) {
+  const pick = () => event.request;
+
+  return pick();
+}
+`,
+  },
+  {
+    what: "async and await",
+    source: `export async function handler(event) {
+  return await Promise.resolve(event.request);
+}
+`,
+  },
+  {
+    what: "rest parameters",
+    source: `function first(...values) {
+  return values[0];
+}
+
+export function handler(event) {
+  return first(event.request);
+}
+`,
+  },
+  {
+    what: "a Promise",
+    source: `export function handler(event) {
+  return Promise.resolve(event.request);
+}
+`,
+  },
+  {
+    what: "a Buffer",
+    source: `export function handler(event) {
+  return Buffer.from(event.request.uri, "utf8").toString("base64");
+}
+`,
+  },
+  {
+    what: "requiring a built-in module",
+    source: `var crypto = require("crypto");
+
+export function handler(event) {
+  return crypto.createHash("sha256").update(event.request.uri).digest("hex");
+}
+`,
+  },
+  {
+    what: "const and let",
+    source: `export function handler(event) {
+  const request = event.request;
+  let uri = request.uri;
+
+  uri = uri + "/index.html";
+  request.uri = uri;
+
+  return request;
 }
 `,
   },

--- a/src/config/lint/cff-js2-lint.fixture.ts
+++ b/src/config/lint/cff-js2-lint.fixture.ts
@@ -1,0 +1,162 @@
+/**
+ * A CloudFront Function that stays inside what JS2 will run.
+ *
+ * It is here so a test can show the restrictions staying quiet on code that
+ * respects them, which is the half an over-broad selector breaks first.
+ */
+export const supportedCffJs2Source = `function normalise(uri) {
+  var trimmed = uri;
+
+  if (trimmed.charAt(trimmed.length - 1) === "/") {
+    trimmed = trimmed + "index.html";
+  }
+
+  return trimmed;
+}
+
+export function handler(event) {
+  var request = event.request;
+  request.uri = normalise(request.uri);
+
+  return request;
+}
+`;
+
+/**
+ * One construct JS2 refuses, and the rule that should say so.
+ */
+export interface CffJs2Violation {
+  readonly rule: string;
+  readonly what: string;
+  readonly source: string;
+}
+
+/**
+ * A case per restriction, each written the way the mistake actually shows up.
+ *
+ * Every rule in the plugin needs one, so that a rule whose selector stops
+ * matching is a failing test rather than a quiet gap in what gets caught.
+ * A case may trip more than one rule — banned syntax tends to arrive in
+ * company — so what each asserts is that its own rule is among the findings.
+ */
+export const cffJs2Violations: readonly CffJs2Violation[] = [
+  {
+    rule: "no-template-literal",
+    what: "a template literal",
+    source: "export function handler(event) {\n  return `/` + event.id;\n}\n",
+  },
+  {
+    rule: "no-import",
+    what: "an import",
+    source: `import { helper } from "./helper.js";
+
+export function handler() {
+  return helper();
+}
+`,
+  },
+  {
+    rule: "only-handler-export",
+    what: "an export other than the handler",
+    source: `export var version = 1;
+
+export function handler() {}
+`,
+  },
+  {
+    rule: "only-handler-export",
+    what: "a default export",
+    source: `export default function handler() {}
+`,
+  },
+  {
+    rule: "only-handler-export",
+    what: "a re-export",
+    source: `export * from "./helper.js";
+`,
+  },
+  {
+    rule: "no-class",
+    what: "a class",
+    source: `class Router {}
+
+export function handler() {
+  return new Router();
+}
+`,
+  },
+  {
+    rule: "no-arrow-function",
+    what: "an arrow function",
+    source: `export function handler(event) {
+  var pick = () => event.request;
+
+  return pick();
+}
+`,
+  },
+  {
+    rule: "no-async",
+    what: "async and await",
+    source: `export async function handler(event) {
+  return await event.request;
+}
+`,
+  },
+  {
+    rule: "no-generator",
+    what: "a generator",
+    source: `function* each() {
+  yield 1;
+}
+
+export function handler() {
+  return each();
+}
+`,
+  },
+  {
+    rule: "no-destructuring",
+    what: "destructuring",
+    source: `export function handler(event) {
+  var { request } = event;
+
+  return request;
+}
+`,
+  },
+  {
+    rule: "no-spread",
+    what: "spread syntax",
+    source: `export function handler(event) {
+  var headers = [event.request];
+
+  return [...headers, event];
+}
+`,
+  },
+  {
+    rule: "no-for-of",
+    what: "a for...of loop",
+    source: `export function handler(event) {
+  var total = 0;
+
+  for (var value of event.values) {
+    total = total + value;
+  }
+
+  return total;
+}
+`,
+  },
+  {
+    rule: "no-unavailable-global",
+    what: "a global the runtime does not have",
+    source: `export function handler(event) {
+  fetch("https://example.test");
+
+  return event;
+}
+`,
+  },
+];

--- a/src/config/lint/cff-js2-oxlint-plugin.ts
+++ b/src/config/lint/cff-js2-oxlint-plugin.ts
@@ -1,0 +1,8 @@
+/**
+ * The plugin entry point Oxlint loads.
+ *
+ * Oxlint reads a JS plugin from a module's default export, where ESLint takes
+ * the plugin object from wherever a config puts it, so this file exists only
+ * to present the same plugin the way Oxlint expects to find it.
+ */
+export { cffJs2LintPlugin as default } from "./cff-js2-lint-plugin.js";

--- a/src/config/lint/cff-js2-restriction.ts
+++ b/src/config/lint/cff-js2-restriction.ts
@@ -1,21 +1,23 @@
 /**
  * What the CloudFront Functions JS2 runtime will not run, as syntax selectors.
  *
- * JS2 is a restricted ECMAScript dialect rather than a JavaScript engine with
- * a few gaps, so a function that only fails once CloudFront rejects it fails a
- * long way from where it was written. Each entry names a construct the runtime
- * has no support for and says what to write instead, so the refusal arrives in
- * the editor rather than at deployment.
+ * JS2 is compliant with ECMAScript 5.1 and adds a named subset of ES 6 to 12,
+ * so a Function that uses something outside that subset fails when it is
+ * published, a long way from where it was written. Each entry names a
+ * construct the runtime has no support for and says what to write instead, so
+ * the refusal arrives in the editor.
+ *
+ * Every entry is drawn from the runtime's own feature list, which is an
+ * allow-list: anything the documentation does not name is unsupported. Nothing
+ * here is house style. A restriction on syntax JS2 accepts would send a reader
+ * away from code that works, which is worse than no lint rule at all.
+ *
+ * https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/functions-javascript-runtime-20.html
  *
  * The selector syntax is the one both ESLint and Oxlint accept, which is what
  * lets a single rule module serve either linter.
  */
 export const cffJs2SyntaxRestrictions = {
-  "no-template-literal": {
-    selector: "TemplateLiteral",
-    message:
-      "CloudFront Functions JS2 does not support template literals. Use string concatenation instead.",
-  },
   "no-import": {
     selector: "ImportDeclaration",
     message:
@@ -27,37 +29,39 @@ export const cffJs2SyntaxRestrictions = {
     message:
       "CloudFront Function files may only export the handler as `export function handler(...)`.",
   },
+  "only-built-in-require": {
+    selector:
+      "CallExpression[callee.name='require']:not(:has(Literal[value='querystring'])):not(:has(Literal[value='crypto'])):not(:has(Literal[value='buffer']))",
+    message:
+      "CloudFront Functions can only require the built-in `querystring`, `crypto` and `buffer` modules. Everything else must be inlined.",
+  },
   "no-class": {
     selector: "ClassDeclaration, ClassExpression",
-    message: "Avoid class syntax in CloudFront Functions JS2 files.",
-  },
-  "no-arrow-function": {
-    selector: "ArrowFunctionExpression",
     message:
-      "Avoid arrow functions in CloudFront Functions JS2 files. Use function declarations/expressions instead.",
-  },
-  "no-async": {
-    selector:
-      "AwaitExpression, FunctionDeclaration[async=true], FunctionExpression[async=true], ArrowFunctionExpression[async=true]",
-    message: "CloudFront Functions should not use async/await.",
+      "CloudFront Functions JS2 does not support class syntax. Use a constructor function or a plain object instead.",
   },
   "no-generator": {
     selector:
       "YieldExpression, FunctionDeclaration[generator=true], FunctionExpression[generator=true]",
-    message: "CloudFront Functions should not use generators.",
+    message: "CloudFront Functions JS2 does not support generators.",
   },
   "no-destructuring": {
     selector: "ObjectPattern, ArrayPattern",
-    message: "Avoid destructuring in CloudFront Functions JS2 files.",
+    message:
+      "CloudFront Functions JS2 does not support destructuring. Read the properties one at a time instead.",
   },
   "no-spread": {
-    selector: "SpreadElement, RestElement",
-    message: "Avoid spread/rest syntax in CloudFront Functions JS2 files.",
+    // Rest parameters are a separate ES 6 feature that JS2 does name as
+    // supported, and they share the `RestElement` node, so only spread is
+    // matched here.
+    selector: "SpreadElement",
+    message:
+      "CloudFront Functions JS2 does not support spread syntax. Rest parameters are supported, so `function f(...args)` is fine, but `[...list]` is not.",
   },
   "no-for-of": {
     selector: "ForOfStatement",
     message:
-      "Avoid for...of in CloudFront Functions JS2 files. Use index-based loops instead.",
+      "CloudFront Functions JS2 does not support for...of. Use an index-based loop or for...in instead.",
   },
 } as const satisfies Readonly<
   Record<string, { readonly selector: string; readonly message: string }>
@@ -70,19 +74,23 @@ export const cffJs2SyntaxRestrictions = {
  * worst place to find out. The reason matters as much as the refusal: `fetch`
  * is missing because the runtime has no network, and `setTimeout` because it
  * has no event loop, and those two dead ends want different rewrites.
+ *
+ * `Promise` and `Buffer` are deliberately absent from this list. Both are
+ * supported in runtime 2.0, and an earlier version of this config refused them.
  */
 export const cffJs2UnavailableGlobals = {
   fetch: "CloudFront Functions cannot make network requests.",
   XMLHttpRequest: "CloudFront Functions cannot make network requests.",
   WebSocket: "CloudFront Functions cannot open network connections.",
-  require:
-    "CloudFront Functions must be self-contained and cannot require modules.",
   process: "CloudFront Functions do not have access to Node.js process APIs.",
-  Buffer: "CloudFront Functions do not have access to Node.js Buffer.",
-  setTimeout: "CloudFront Functions do not support timers.",
-  setInterval: "CloudFront Functions do not support timers.",
-  setImmediate: "CloudFront Functions do not support timers.",
-  Promise: "Avoid Promise usage in CloudFront Functions.",
+  setTimeout:
+    "CloudFront Functions do not support timers, and must run to completion synchronously.",
+  setInterval:
+    "CloudFront Functions do not support timers, and must run to completion synchronously.",
+  setImmediate:
+    "CloudFront Functions do not support timers, and must run to completion synchronously.",
+  clearTimeout:
+    "CloudFront Functions do not support timers, so there is nothing to clear.",
 } as const satisfies Readonly<Record<string, string>>;
 
 /**

--- a/src/config/lint/cff-js2-restriction.ts
+++ b/src/config/lint/cff-js2-restriction.ts
@@ -1,0 +1,94 @@
+/**
+ * What the CloudFront Functions JS2 runtime will not run, as syntax selectors.
+ *
+ * JS2 is a restricted ECMAScript dialect rather than a JavaScript engine with
+ * a few gaps, so a function that only fails once CloudFront rejects it fails a
+ * long way from where it was written. Each entry names a construct the runtime
+ * has no support for and says what to write instead, so the refusal arrives in
+ * the editor rather than at deployment.
+ *
+ * The selector syntax is the one both ESLint and Oxlint accept, which is what
+ * lets a single rule module serve either linter.
+ */
+export const cffJs2SyntaxRestrictions = {
+  "no-template-literal": {
+    selector: "TemplateLiteral",
+    message:
+      "CloudFront Functions JS2 does not support template literals. Use string concatenation instead.",
+  },
+  "no-import": {
+    selector: "ImportDeclaration",
+    message:
+      "CloudFront Functions must be self-contained and should not use import syntax.",
+  },
+  "only-handler-export": {
+    selector:
+      "ExportNamedDeclaration:not([declaration.type='FunctionDeclaration'][declaration.id.name='handler']), ExportDefaultDeclaration, ExportAllDeclaration",
+    message:
+      "CloudFront Function files may only export the handler as `export function handler(...)`.",
+  },
+  "no-class": {
+    selector: "ClassDeclaration, ClassExpression",
+    message: "Avoid class syntax in CloudFront Functions JS2 files.",
+  },
+  "no-arrow-function": {
+    selector: "ArrowFunctionExpression",
+    message:
+      "Avoid arrow functions in CloudFront Functions JS2 files. Use function declarations/expressions instead.",
+  },
+  "no-async": {
+    selector:
+      "AwaitExpression, FunctionDeclaration[async=true], FunctionExpression[async=true], ArrowFunctionExpression[async=true]",
+    message: "CloudFront Functions should not use async/await.",
+  },
+  "no-generator": {
+    selector:
+      "YieldExpression, FunctionDeclaration[generator=true], FunctionExpression[generator=true]",
+    message: "CloudFront Functions should not use generators.",
+  },
+  "no-destructuring": {
+    selector: "ObjectPattern, ArrayPattern",
+    message: "Avoid destructuring in CloudFront Functions JS2 files.",
+  },
+  "no-spread": {
+    selector: "SpreadElement, RestElement",
+    message: "Avoid spread/rest syntax in CloudFront Functions JS2 files.",
+  },
+  "no-for-of": {
+    selector: "ForOfStatement",
+    message:
+      "Avoid for...of in CloudFront Functions JS2 files. Use index-based loops instead.",
+  },
+} as const satisfies Readonly<
+  Record<string, { readonly selector: string; readonly message: string }>
+>;
+
+/**
+ * Globals a CloudFront Function cannot reach, and why each one is absent.
+ *
+ * These read as ordinary JavaScript and fail only at the edge, which is the
+ * worst place to find out. The reason matters as much as the refusal: `fetch`
+ * is missing because the runtime has no network, and `setTimeout` because it
+ * has no event loop, and those two dead ends want different rewrites.
+ */
+export const cffJs2UnavailableGlobals = {
+  fetch: "CloudFront Functions cannot make network requests.",
+  XMLHttpRequest: "CloudFront Functions cannot make network requests.",
+  WebSocket: "CloudFront Functions cannot open network connections.",
+  require:
+    "CloudFront Functions must be self-contained and cannot require modules.",
+  process: "CloudFront Functions do not have access to Node.js process APIs.",
+  Buffer: "CloudFront Functions do not have access to Node.js Buffer.",
+  setTimeout: "CloudFront Functions do not support timers.",
+  setInterval: "CloudFront Functions do not support timers.",
+  setImmediate: "CloudFront Functions do not support timers.",
+  Promise: "Avoid Promise usage in CloudFront Functions.",
+} as const satisfies Readonly<Record<string, string>>;
+
+/**
+ * The name of the rule that reports an unavailable global.
+ *
+ * It is kept apart from the syntax restrictions because it resolves names
+ * through scope rather than matching a selector.
+ */
+export const cffJs2UnavailableGlobalRuleName = "no-unavailable-global";

--- a/src/config/lint/cff-js2-unavailable-global.rule.ts
+++ b/src/config/lint/cff-js2-unavailable-global.rule.ts
@@ -1,0 +1,54 @@
+import { cffJs2UnavailableGlobals } from "./cff-js2-restriction.js";
+import type {
+  LintNode,
+  LintRule,
+  LintRuleContext,
+  LintVisitor,
+} from "./lint-plugin.type.js";
+
+/**
+ * Scope is only complete once the whole file has been walked, so the globals a
+ * file reaches for are counted on the way out of it rather than on the way in.
+ */
+const programExitSelector = "Program:exit";
+
+const reasons = new Map<string, string>(
+  Object.entries(cffJs2UnavailableGlobals),
+);
+
+/**
+ * Reports a name the CloudFront Functions runtime does not provide.
+ *
+ * Names are resolved through scope rather than matched as text, so a local
+ * variable called `fetch` and a property called `event.fetch` are both left
+ * alone: what is reported is a reference that would reach a global.
+ */
+export function cffJs2UnavailableGlobalRule(): LintRule {
+  return {
+    meta: {
+      type: "problem",
+      schema: [],
+      messages: { unsupported: "{{why}}" },
+    },
+    create: (context: LintRuleContext): LintVisitor => ({
+      [programExitSelector]: (node: LintNode): void => {
+        const scope = context.sourceCode.getScope(node);
+
+        for (const reference of [
+          ...scope.through,
+          ...scope.variables.flatMap((variable) => variable.references),
+        ]) {
+          const why = reasons.get(reference.identifier.name);
+
+          if (why !== undefined) {
+            context.report({
+              node: reference.identifier,
+              messageId: "unsupported",
+              data: { why },
+            });
+          }
+        }
+      },
+    }),
+  };
+}

--- a/src/config/lint/index.ts
+++ b/src/config/lint/index.ts
@@ -1,0 +1,23 @@
+export { cffJs2LintPlugin, cffJs2PluginName } from "./cff-js2-lint-plugin.js";
+export {
+  cffJs2LintPluginRules,
+  cffJs2LintRules,
+  type LintRuleSetting,
+} from "./cff-js2-lint-rules.js";
+export {
+  cffJs2SyntaxRestrictions,
+  cffJs2UnavailableGlobalRuleName,
+  cffJs2UnavailableGlobals,
+} from "./cff-js2-restriction.js";
+export { cffJs2UnavailableGlobalRule } from "./cff-js2-unavailable-global.rule.js";
+export type {
+  LintIdentifierNode,
+  LintNode,
+  LintPlugin,
+  LintReference,
+  LintRule,
+  LintRuleContext,
+  LintScope,
+  LintVariable,
+  LintVisitor,
+} from "./lint-plugin.type.js";

--- a/src/config/lint/lint-plugin.type.ts
+++ b/src/config/lint/lint-plugin.type.ts
@@ -1,0 +1,88 @@
+/**
+ * The slice of a linter's rule API that these plugins actually touch.
+ *
+ * ESLint and Oxlint both load the same plugin object, so typing it against
+ * either one's published types would tie the plugin to a linter it is meant to
+ * outlive. These declarations describe only what the rules here call, which is
+ * narrow enough to stay true of both and leaves the plugin with no dependency
+ * of its own.
+ */
+
+/**
+ * A node in the syntax tree, identified by the type name a selector matches.
+ */
+export interface LintNode {
+  readonly type: string;
+}
+
+/**
+ * An identifier node, which is the only node kind read by name here.
+ */
+export interface LintIdentifierNode extends LintNode {
+  readonly name: string;
+}
+
+/**
+ * One place a binding is read or written.
+ */
+export interface LintReference {
+  readonly identifier: LintIdentifierNode;
+}
+
+/**
+ * A resolved binding together with every reference to it.
+ */
+export interface LintVariable {
+  readonly references: readonly LintReference[];
+}
+
+/**
+ * A lexical scope, as the linter resolved it.
+ *
+ * References to a name nothing declares land in `through` rather than in
+ * `variables`, so a rule looking for globals has to read both: which of the two
+ * a name falls into depends on whether the linter was told that global exists.
+ */
+export interface LintScope {
+  readonly through: readonly LintReference[];
+  readonly variables: readonly LintVariable[];
+}
+
+/**
+ * What a rule is handed for the file it is looking at.
+ */
+export interface LintRuleContext {
+  readonly sourceCode: {
+    getScope(node: LintNode): LintScope;
+  };
+  report(descriptor: {
+    node: LintNode;
+    messageId: string;
+    data?: Readonly<Record<string, string>>;
+  }): void;
+}
+
+/**
+ * The handlers a rule registers, keyed by the selector that triggers them.
+ */
+export type LintVisitor = Record<string, (node: never) => void>;
+
+/**
+ * One rule, in the shape both linters expect to load.
+ */
+export interface LintRule {
+  readonly meta: {
+    readonly type: "problem";
+    readonly schema: readonly [];
+    readonly messages: Readonly<Record<string, string>>;
+  };
+  create(context: LintRuleContext): LintVisitor;
+}
+
+/**
+ * A plugin, in the shape both linters expect to load.
+ */
+export interface LintPlugin {
+  readonly meta: { readonly name: string };
+  readonly rules: Readonly<Record<string, LintRule>>;
+}

--- a/src/config/oxlint/cffjs2.oxlint.config.loc.test.ts
+++ b/src/config/oxlint/cffjs2.oxlint.config.loc.test.ts
@@ -15,14 +15,45 @@ import cloudFrontFunctionsJs2 from "../eslint/cffjs2.eslint.config.js";
 import { cffJs2PluginName } from "../lint/cff-js2-lint-plugin.js";
 import {
   cffJs2Violations,
+  supportedCffJs2Cases,
   supportedCffJs2Source,
 } from "../lint/cff-js2-lint.fixture.js";
 import { cloudFrontFunctionsJs2Oxlint } from "./cffjs2.oxlint.config.js";
 
 const projectRoot = path.resolve(import.meta.dirname, "../../..");
 
-/** The one fixture written the way JS2 wants it. */
-const supportedFixtureName = "case-00.cff.js";
+/**
+ * Every fixture, and whether a linter should have anything to say about it.
+ *
+ * The supported cases are in here so that the two linters have to agree about
+ * silence as well as about findings.
+ */
+const fixtureSources: readonly {
+  readonly source: string;
+  readonly clean: boolean;
+}[] = [
+  { source: supportedCffJs2Source, clean: true },
+  ...supportedCffJs2Cases.map((supported) => ({
+    source: supported.source,
+    clean: true,
+  })),
+  ...cffJs2Violations.map((violation) => ({
+    source: violation.source,
+    clean: false,
+  })),
+];
+
+function fixtureName(index: number): string {
+  return `case-${String(index).padStart(2, "0")}.cff.js`;
+}
+
+/** The fixtures no restriction may report. */
+const supportedFixtureNames = new Set(
+  fixtureSources
+    .map((fixture, index) => ({ fixture, index }))
+    .filter((entry) => entry.fixture.clean)
+    .map((entry) => fixtureName(entry.index)),
+);
 
 /** One thing a linter said, in a form the other linter can be compared to. */
 interface Finding {
@@ -82,20 +113,12 @@ async function withFixtures<T>(
   const directory = await mkdtemp(path.join(os.tmpdir(), "yulin-cff-parity-"));
 
   try {
-    const sources = [
-      supportedCffJs2Source,
-      ...cffJs2Violations.map((violation) => violation.source),
-    ];
-
     const files = await Promise.all(
-      sources.map(async (source, index) => {
-        const filePath = path.join(
-          directory,
-          `case-${String(index).padStart(2, "0")}.cff.js`,
-        );
+      fixtureSources.map(async (fixture, index) => {
+        const filePath = path.join(directory, fixtureName(index));
 
         // eslint-disable-next-line security/detect-non-literal-fs-filename -- a temporary directory this test just made
-        await writeFile(filePath, source, "utf8");
+        await writeFile(filePath, fixture.source, "utf8");
 
         return filePath;
       }),
@@ -227,22 +250,23 @@ describe("Linting CloudFront Functions JS2 with either linter", () => {
     });
   });
 
-  it("leaves a supported function alone", async () => {
+  it("leaves syntax JS2 supports alone in both linters", async () => {
     await withFixtures(async (fixtures) => {
-      // Given the fixture written the way JS2 wants it
+      // Given the fixtures that use only what the runtime documents as
+      // supported, including features an earlier version of this config refused
       const eslintFindings = await lintWithEslint(fixtures);
       const oxlintFindings = await lintWithOxlint(fixtures);
 
-      // When each linter's findings for that file are picked out
-      const fromEslint = eslintFindings.filter(
-        (finding) => finding.file === supportedFixtureName,
+      // When each linter's findings for those files are picked out
+      const fromEslint = eslintFindings.filter((finding) =>
+        supportedFixtureNames.has(finding.file),
       );
-      const fromOxlint = oxlintFindings.filter(
-        (finding) => finding.file === supportedFixtureName,
+      const fromOxlint = oxlintFindings.filter((finding) =>
+        supportedFixtureNames.has(finding.file),
       );
 
-      // Then neither reports it, so the restrictions are not simply firing on
-      // everything they are pointed at
+      // Then neither reports them, so the restrictions are neither firing on
+      // everything nor sending a reader away from code that works
       assertArrayLength(fromEslint, 0);
       assertArrayLength(fromOxlint, 0);
     });

--- a/src/config/oxlint/cffjs2.oxlint.config.loc.test.ts
+++ b/src/config/oxlint/cffjs2.oxlint.config.loc.test.ts
@@ -1,0 +1,250 @@
+import {
+  assertArrayLength,
+  assertArrayMinLength,
+  assertIdentical,
+} from "@kensio/smartass";
+import { ESLint } from "eslint";
+import { execa } from "execa";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import tseslint from "typescript-eslint";
+import { describe, it } from "vitest";
+
+import cloudFrontFunctionsJs2 from "../eslint/cffjs2.eslint.config.js";
+import { cffJs2PluginName } from "../lint/cff-js2-lint-plugin.js";
+import {
+  cffJs2Violations,
+  supportedCffJs2Source,
+} from "../lint/cff-js2-lint.fixture.js";
+import { cloudFrontFunctionsJs2Oxlint } from "./cffjs2.oxlint.config.js";
+
+const projectRoot = path.resolve(import.meta.dirname, "../../..");
+
+/** The one fixture written the way JS2 wants it. */
+const supportedFixtureName = "case-00.cff.js";
+
+/** One thing a linter said, in a form the other linter can be compared to. */
+interface Finding {
+  readonly file: string;
+  readonly rule: string;
+  readonly line: number;
+  readonly column: number;
+}
+
+/** A directory of `.cff.js` fixtures with an Oxlint config beside them. */
+interface Fixtures {
+  readonly directory: string;
+  readonly files: readonly string[];
+}
+
+interface OxlintReport {
+  readonly diagnostics: readonly {
+    readonly code: string;
+    readonly filename: string;
+    readonly labels: readonly {
+      readonly span: { readonly line: number; readonly column: number };
+    }[];
+  }[];
+}
+
+/**
+ * Only the plugin's own findings are compared.
+ *
+ * Each linter brings its own built-in rules and its own defaults for which of
+ * them are on, so comparing everything would measure the linters rather than
+ * the shared plugin, which is the thing that has to agree.
+ */
+function isPluginRule(rule: string): boolean {
+  return rule.startsWith(`${cffJs2PluginName}/`);
+}
+
+function asText(findings: readonly Finding[]): string {
+  return findings
+    .map(
+      (finding) =>
+        `${finding.file}:${String(finding.line)}:${String(finding.column)} ${finding.rule}`,
+    )
+    .toSorted((left, right) => left.localeCompare(right))
+    .join("\n");
+}
+
+/**
+ * Writes the fixtures, runs the body against them and clears up after it.
+ *
+ * They go outside the repository because Oxlint honours `.gitignore`: a
+ * fixture under the repository's own `.tmp/` would be skipped without being
+ * linted, and a comparison of two empty lists would pass.
+ */
+async function withFixtures<T>(
+  body: (fixtures: Fixtures) => Promise<T>,
+): Promise<T> {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "yulin-cff-parity-"));
+
+  try {
+    const sources = [
+      supportedCffJs2Source,
+      ...cffJs2Violations.map((violation) => violation.source),
+    ];
+
+    const files = await Promise.all(
+      sources.map(async (source, index) => {
+        const filePath = path.join(
+          directory,
+          `case-${String(index).padStart(2, "0")}.cff.js`,
+        );
+
+        // eslint-disable-next-line security/detect-non-literal-fs-filename -- a temporary directory this test just made
+        await writeFile(filePath, source, "utf8");
+
+        return filePath;
+      }),
+    );
+
+    // The published fragment names the plugin as it sits in `dist/`, which a
+    // test running from source has not built. Pointing that same fragment at
+    // the TypeScript entry point is the only change made to it here.
+    const oxlintConfig = {
+      ...cloudFrontFunctionsJs2Oxlint,
+      jsPlugins: cloudFrontFunctionsJs2Oxlint.jsPlugins.map((plugin) => ({
+        ...plugin,
+        specifier: path.join(
+          projectRoot,
+          "src",
+          "config",
+          "lint",
+          "cff-js2-oxlint-plugin.ts",
+        ),
+      })),
+    };
+
+    // eslint-disable-next-line security/detect-non-literal-fs-filename -- as above, this test's own directory
+    await writeFile(
+      path.join(directory, ".oxlintrc.json"),
+      JSON.stringify(oxlintConfig, undefined, 2),
+      "utf8",
+    );
+
+    return await body({ directory, files });
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+}
+
+async function lintWithEslint(fixtures: Fixtures): Promise<readonly Finding[]> {
+  const eslint = new ESLint({
+    // The fixtures live outside the repository, and ESLint ignores a file that
+    // sits outside the directory it was pointed at.
+    cwd: fixtures.directory,
+    overrideConfigFile: true,
+    overrideConfig: [
+      // The published config turns typescript-eslint rules off without owning
+      // the plugin, the same way it arrives in a consumer's config that
+      // already has it.
+      { plugins: { "@typescript-eslint": tseslint.plugin } },
+      ...cloudFrontFunctionsJs2,
+    ] as never,
+  });
+
+  const results = await eslint.lintFiles([...fixtures.files]);
+
+  return results.flatMap((result) =>
+    result.messages
+      .filter((message) => isPluginRule(message.ruleId ?? ""))
+      .map((message) => ({
+        file: path.basename(result.filePath),
+        rule: message.ruleId ?? "",
+        line: message.line,
+        column: message.column,
+      })),
+  );
+}
+
+async function lintWithOxlint(fixtures: Fixtures): Promise<readonly Finding[]> {
+  const { stdout } = await execa(
+    path.join(projectRoot, "node_modules", ".bin", "oxlint"),
+    [
+      "--config",
+      path.join(fixtures.directory, ".oxlintrc.json"),
+      "--format",
+      "json",
+      ...fixtures.files,
+    ],
+    {
+      // Oxlint runs JS plugins in its own Node process, so the loader that
+      // reads the plugin straight from TypeScript source is passed through the
+      // environment, and the working directory is the repository so that the
+      // loader and the plugin's own imports both resolve.
+      cwd: projectRoot,
+      // eslint-disable-next-line @typescript-eslint/naming-convention -- an environment variable name, not an identifier
+      env: { NODE_OPTIONS: "--import tsx" },
+      reject: false,
+    },
+  );
+
+  const report = JSON.parse(stdout) as OxlintReport;
+
+  return report.diagnostics
+    .map((diagnostic) => ({
+      diagnostic,
+      matched: /^(?<plugin>[^(]+)\((?<name>[^)]+)\)$/u.exec(diagnostic.code),
+    }))
+    .map((entry) => ({
+      file: path.basename(entry.diagnostic.filename),
+      rule: `${entry.matched?.groups?.["plugin"] ?? ""}/${entry.matched?.groups?.["name"] ?? ""}`,
+      line: entry.diagnostic.labels[0]?.span.line ?? 0,
+      column: entry.diagnostic.labels[0]?.span.column ?? 0,
+    }))
+    .filter((finding) => isPluginRule(finding.rule));
+}
+
+describe("Linting CloudFront Functions JS2 with either linter", () => {
+  it("reports the same restrictions in the same places", async () => {
+    await withFixtures(async (fixtures) => {
+      // Given the same fixtures, and the two published configs over one plugin
+      const fromEslint = await lintWithEslint(fixtures);
+      const fromOxlint = await lintWithOxlint(fixtures);
+
+      // When what each linter said is lined up finding by finding
+      const oxlintText = asText(fromOxlint);
+      const eslintText = asText(fromEslint);
+
+      // Then neither found anything the other missed, and nothing landed in a
+      // different place, which is what a shared plugin has to guarantee
+      assertIdentical(oxlintText, eslintText);
+    });
+  });
+
+  it("finds the restrictions rather than agreeing on silence", async () => {
+    await withFixtures(async (fixtures) => {
+      // Given fixtures holding a case for every rule the plugin publishes
+      const fromOxlint = await lintWithOxlint(fixtures);
+
+      // When Oxlint's findings are counted against the cases put in front of it
+      // Then it really did run the plugin, so the comparison above is between
+      // two lists of findings and not between two empty ones
+      assertArrayMinLength(fromOxlint, cffJs2Violations.length);
+    });
+  });
+
+  it("leaves a supported function alone", async () => {
+    await withFixtures(async (fixtures) => {
+      // Given the fixture written the way JS2 wants it
+      const eslintFindings = await lintWithEslint(fixtures);
+      const oxlintFindings = await lintWithOxlint(fixtures);
+
+      // When each linter's findings for that file are picked out
+      const fromEslint = eslintFindings.filter(
+        (finding) => finding.file === supportedFixtureName,
+      );
+      const fromOxlint = oxlintFindings.filter(
+        (finding) => finding.file === supportedFixtureName,
+      );
+
+      // Then neither reports it, so the restrictions are not simply firing on
+      // everything they are pointed at
+      assertArrayLength(fromEslint, 0);
+      assertArrayLength(fromOxlint, 0);
+    });
+  });
+});

--- a/src/config/oxlint/cffjs2.oxlint.config.ts
+++ b/src/config/oxlint/cffjs2.oxlint.config.ts
@@ -1,0 +1,47 @@
+import {
+  cffJs2LintRules,
+  cffJs2PluginName,
+  type LintRuleSetting,
+} from "../lint/index.js";
+
+/**
+ * An Oxlint config fragment, in the shape `.oxlintrc.json` is written in.
+ */
+export interface OxlintConfig {
+  readonly jsPlugins: readonly {
+    readonly name: string;
+    readonly specifier: string;
+  }[];
+  readonly overrides: readonly {
+    readonly files: readonly string[];
+    readonly rules: Readonly<Record<string, LintRuleSetting>>;
+  }[];
+}
+
+/**
+ * Where the built plugin sits, relative to the built config that names it.
+ *
+ * Oxlint resolves a plugin specifier against the config file's own location,
+ * so this path is the one inside `dist/`, not the one in the source tree.
+ */
+const pluginSpecifier = "../lint/cff-js2-oxlint-plugin.js";
+
+/**
+ * Oxlint's half of the CloudFront Functions JS2 lint setup.
+ *
+ * It is an override rather than a top-level rule block because a consumer
+ * extends this into the config that lints their whole repository, and JS2's
+ * restrictions would be wrong applied anywhere but a `.cff.js` file: a project
+ * told not to use arrow functions everywhere would be unusable.
+ *
+ * The rules are the same ones the ESLint config uses, from the same source.
+ */
+export const cloudFrontFunctionsJs2Oxlint: OxlintConfig = {
+  jsPlugins: [{ name: cffJs2PluginName, specifier: pluginSpecifier }],
+  overrides: [
+    {
+      files: ["**/*.cff.js"],
+      rules: cffJs2LintRules(),
+    },
+  ],
+};

--- a/src/config/oxlint/index.ts
+++ b/src/config/oxlint/index.ts
@@ -1,0 +1,4 @@
+export {
+  cloudFrontFunctionsJs2Oxlint,
+  type OxlintConfig,
+} from "./cffjs2.oxlint.config.js";

--- a/src/serve/http/live-reload/sim-local-live-reload.ts
+++ b/src/serve/http/live-reload/sim-local-live-reload.ts
@@ -1,3 +1,4 @@
+import { assertDefined } from "../../../util/type-guard/defined.js";
 import { SimLiveReload } from "./sim-live-reload.js";
 import { SimLiveReloadReport } from "./sim-live-reload-report.js";
 import {
@@ -89,11 +90,10 @@ export class SimLocalLiveReload {
   }
 
   private reloadChannel(): SimLiveReload {
-    if (this.liveReload === undefined) {
-      throw new Error(
-        "Live reload is off for this server, serve with { liveReload: true } to use reload()",
-      );
-    }
+    assertDefined(
+      this.liveReload,
+      "Live reload is off for this server, serve with { liveReload: true } to use reload()",
+    );
 
     return this.liveReload;
   }

--- a/src/service/acm/validation/sim-acm-certificate-validation.ts
+++ b/src/service/acm/validation/sim-acm-certificate-validation.ts
@@ -1,3 +1,4 @@
+import { assertDefined } from "../../../util/type-guard/defined.js";
 import type { BackgroundScheduler } from "../../../util/background/background.js";
 import type { SimAcmCertificate } from "../certificate/sim-acm-certificate.js";
 import type {
@@ -40,12 +41,11 @@ export class SimAcmCertificateValidation {
    * so it is rejected rather than silently issuing certificates anyway.
    */
   alwaysRequireDnsValidation(): void {
-    if (this.dnsRecords === undefined) {
-      throw new Error(
-        "Sim ACM cannot require DNS validation with no sim Route53 to validate against. " +
-          "Use SimAws, so ACM can see Hosted Zones, rather than a standalone SimAcm.",
-      );
-    }
+    assertDefined(
+      this.dnsRecords,
+      "Sim ACM cannot require DNS validation with no sim Route53 to validate against. " +
+        "Use SimAws, so ACM can see Hosted Zones, rather than a standalone SimAcm.",
+    );
 
     this.mode = SimAcmDnsValidationMode.always();
   }

--- a/src/service/aws/caller/sim-aws-caller-resolver.ts
+++ b/src/service/aws/caller/sim-aws-caller-resolver.ts
@@ -1,3 +1,4 @@
+import { assertDefined } from "../../../util/type-guard/defined.js";
 import type {
   SimAwsCaller,
   SimAwsPrincipal,
@@ -55,11 +56,10 @@ export class SimAwsCallerResolver {
     }
 
     if (caller?.kind === "credentials") {
-      if (this.credentialIdentityResolver === undefined) {
-        throw new Error(
-          "Simulated credential callers require an IAM credential resolver",
-        );
-      }
+      assertDefined(
+        this.credentialIdentityResolver,
+        "Simulated credential callers require an IAM credential resolver",
+      );
 
       const identity = this.credentialIdentityResolver.resolveCredentials(
         caller.credentials,

--- a/src/service/cloudformation/cdk/s3/bucket-deployment/source/sim-cdk-bucket-deploy-source.ts
+++ b/src/service/cloudformation/cdk/s3/bucket-deployment/source/sim-cdk-bucket-deploy-source.ts
@@ -42,6 +42,7 @@ export class SimCdkBucketDeploySource {
       sourceObjectKey,
     );
 
+    // eslint-disable-next-line no-restricted-syntax -- `assertDefined` cannot narrow through the optional chain, which the packaging check below relies on, and its message would have to be built on every call rather than only on failure
     if (fileAsset?.source?.path === undefined) {
       const errorMessage = new SimCdkBucketDeployErrorMessage({
         resource,

--- a/src/service/cloudformation/resource/cfn/dynamodb/sim-dynamodb-table-cfn.ts
+++ b/src/service/cloudformation/resource/cfn/dynamodb/sim-dynamodb-table-cfn.ts
@@ -1,3 +1,4 @@
+import { assertDefined } from "../../../../../util/type-guard/defined.js";
 import { dynamoDbGlobalTableResourceTypeName } from "../../../../dynamodb/cfn/sim-cfn-dynamodb-resource-type.js";
 import type { SimDynamoDbTable } from "../../../../dynamodb/table/sim-dynamodb-table.js";
 import type { SimCfnTemplateValue } from "../../../template/value/sim-cfn-template-value.js";
@@ -71,13 +72,12 @@ export class SimDynamoDbTableCfn implements SimCfnResourceValueAdapter {
   private streamArn(): SimCfnTemplateValue {
     const arn = this.table.stream.latest?.arn;
 
-    if (arn === undefined) {
-      throw new Error(
-        `Unsupported ${this.resourceTypeName} attribute StreamArn: table ` +
-          `${this.table.tableName} has no StreamSpecification, so it has no ` +
-          `stream and no stream ARN`,
-      );
-    }
+    assertDefined(
+      arn,
+      `Unsupported ${this.resourceTypeName} attribute StreamArn: table ` +
+        `${this.table.tableName} has no StreamSpecification, so it has no ` +
+        `stream and no stream ARN`,
+    );
 
     return arn;
   }

--- a/src/service/cloudformation/resource/resolve/service/sim-cfn-service-resolver.ts
+++ b/src/service/cloudformation/resource/resolve/service/sim-cfn-service-resolver.ts
@@ -1,3 +1,4 @@
+import { assertDefined } from "../../../../../util/type-guard/defined.js";
 import type { SimAws } from "../../../../aws/sim-aws.js";
 import type { SimAwsAccountRegionScope } from "../../../../aws/sim-aws-account-region-scope.js";
 import type {
@@ -29,11 +30,10 @@ export function resolveSimCloudFormationServiceResourceFactory(
     resourceType.serviceName,
   );
 
-  if (serviceFactory === undefined) {
-    throw new Error(
-      `Unsupported sim CloudFormation Resource service ${resourceType.serviceName}`,
-    );
-  }
+  assertDefined(
+    serviceFactory,
+    `Unsupported sim CloudFormation Resource service ${resourceType.serviceName}`,
+  );
 
   return serviceFactory(
     simAws.accountRegionScope(

--- a/src/service/cloudformation/template/node/fn/if/sim-cfn-fn-if.ts
+++ b/src/service/cloudformation/template/node/fn/if/sim-cfn-fn-if.ts
@@ -1,3 +1,4 @@
+import { assertDefined } from "../../../../../../util/type-guard/defined.js";
 import type { SimCfnResolveContext } from "../../../resolve/sim-cfn-resolve-context.js";
 import type { SimCfnTemplateValue } from "../../../value/sim-cfn-template-value.js";
 import { SimCfnNode } from "../../sim-cfn-node.js";
@@ -25,12 +26,11 @@ export class SimCfnFnIf extends SimCfnNode {
   resolve(context: SimCfnResolveContext): SimCfnTemplateValue {
     const conditions = context.conditions;
 
-    if (conditions === undefined) {
-      throw new Error(
-        `Sim CloudFormation Fn::If ${this.conditionName} cannot be resolved ` +
-          "where the template Conditions are not available",
-      );
-    }
+    assertDefined(
+      conditions,
+      `Sim CloudFormation Fn::If ${this.conditionName} cannot be resolved ` +
+        "where the template Conditions are not available",
+    );
 
     if (!conditions.has(this.conditionName)) {
       throw new Error(

--- a/src/service/cognito/user-pool/trigger/sim-aws-cognito-trigger-functions.ts
+++ b/src/service/cognito/user-pool/trigger/sim-aws-cognito-trigger-functions.ts
@@ -98,6 +98,7 @@ export class SimAwsCognitoTriggerFunctions implements SimCognitoTriggerFunctions
     const arn = parseSimLambdaFunctionArn(request.functionArn);
     const simFunction = arn === undefined ? undefined : this.findFunction(arn);
 
+    // eslint-disable-next-line no-restricted-syntax -- `assertDefined` is denser per line, and this file is close enough to the FTA threshold that the guard costs less kept as it is
     if (simFunction === undefined) {
       throw new Error(
         `${request.functionArn} is not a simulated Lambda function.`,

--- a/src/service/iam/credential/session/sim-iam-session-manager.ts
+++ b/src/service/iam/credential/session/sim-iam-session-manager.ts
@@ -1,3 +1,4 @@
+import { assertDefined } from "../../../../util/type-guard/defined.js";
 import { SimIamSession } from "./sim-iam-session.js";
 import type { SimAwsAccountId } from "../../../aws/sim-aws-account.js";
 import type { SimIamRole, SimIamRoleName } from "../../role/sim-iam-role.js";
@@ -91,10 +92,7 @@ export class SimIamSessionManager {
   private role(roleName: SimIamRoleName): SimIamRole {
     const role = this.roles.get(roleName);
 
-    /* v8 ignore if */
-    if (role === undefined) {
-      throw new Error(`Sim IAM Role ${roleName} does not exist`);
-    }
+    assertDefined(role, `Sim IAM Role ${roleName} does not exist`);
 
     return role;
   }

--- a/src/service/iam/registry/sim-iam-registry.ts
+++ b/src/service/iam/registry/sim-iam-registry.ts
@@ -1,3 +1,4 @@
+import { assertDefined } from "../../../util/type-guard/defined.js";
 import type { SimAwsAccountId } from "../../aws/sim-aws-account.js";
 import type { SimIam } from "../sim-iam.js";
 import type { SimIamAccountResolver } from "./sim-iam-account-resolver.js";
@@ -45,9 +46,7 @@ export class SimIamRegistry implements SimIamAccountResolver {
   iamForAccount(accountId: SimAwsAccountId): SimIam {
     const iam = this.findIamForAccount(accountId);
 
-    if (iam === undefined) {
-      throw new Error(`Sim IAM is not registered for Account ${accountId}`);
-    }
+    assertDefined(iam, `Sim IAM is not registered for Account ${accountId}`);
 
     return iam;
   }

--- a/src/service/iam/sigv4/sim-iam-sigv4-credentials.iso.test.ts
+++ b/src/service/iam/sigv4/sim-iam-sigv4-credentials.iso.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest";
 
 import { signAwsRequest } from "../../../../test/sigv4/sign-aws-request.js";
 import type { SimClock } from "../../../util/clock/sim-clock.js";
+import { assertDefined } from "../../../util/type-guard/defined.js";
 import { SimAws } from "../../aws/sim-aws.js";
 import { SimIamAccessKey } from "../credential/sim-iam-access-key.js";
 import { SimIamAccountSigningCredentials } from "../credential/sim-iam-account-signing-credentials.js";
@@ -78,9 +79,14 @@ async function assumeRole(simAws: SimAws): Promise<{
 
   const credentials = assumed.Credentials;
 
-  if (credentials?.SessionToken === undefined) {
-    throw new Error("Expected simulated STS to return session credentials");
-  }
+  assertDefined(
+    credentials,
+    "Expected simulated STS to return session credentials",
+  );
+  assertDefined(
+    credentials.SessionToken,
+    "Expected simulated STS to return a session token",
+  );
 
   return {
     accessKeyId: credentials.AccessKeyId ?? "",

--- a/src/service/route53/command/delete-hosted-zone/delete-hosted-zone.iso.test.ts
+++ b/src/service/route53/command/delete-hosted-zone/delete-hosted-zone.iso.test.ts
@@ -7,6 +7,7 @@ import {
 import {
   assertIdentical,
   assertInstanceOf,
+  assertMapSize,
   assertNonNullable,
   assertThrowsErrorAsync,
 } from "@kensio/smartass";
@@ -124,7 +125,7 @@ describe("Route53 DeleteHostedZoneCommand", () => {
   it("stops the Hosted Zone taking part in name resolution", async () => {
     // Given a Hosted Zone registered for resolution.
     const zone = await givenHostedZone("resolved.test");
-    assertIdentical(zone.simRoute53.resolvableHostedZones().size, 1);
+    assertMapSize(zone.simRoute53.resolvableHostedZones(), 1);
 
     // When the Hosted Zone is deleted.
     await zone.simRoute53.deleteHostedZone(
@@ -132,7 +133,7 @@ describe("Route53 DeleteHostedZoneCommand", () => {
     );
 
     // Then it is out of the registry DNS resolution reads.
-    assertIdentical(zone.simRoute53.resolvableHostedZones().size, 0);
+    assertMapSize(zone.simRoute53.resolvableHostedZones(), 0);
   });
 
   it("rejects a Hosted Zone that does not exist", async () => {

--- a/src/service/route53/command/list-resource-record-sets/record-set-output.ts
+++ b/src/service/route53/command/list-resource-record-sets/record-set-output.ts
@@ -1,3 +1,4 @@
+import { assertDefined } from "../../../../util/type-guard/defined.js";
 import { simRoute53AbsoluteName } from "../../local-name/sim-route53-local-name.js";
 import type { SimRoute53Record } from "../../record/sim-route53-record.js";
 import type { SimRoute53ResourceRecordSet } from "../change-resource-record-sets/change-resource-record-sets.command.js";
@@ -36,12 +37,10 @@ function toAliasResourceRecordSet(
 ): SimRoute53ResourceRecordSet {
   const aliasTargetName = record.values.at(0);
 
-  /* v8 ignore if -- alias records always store their target as a record value */
-  if (aliasTargetName === undefined) {
-    throw new Error(
-      `Sim Route53 alias record ${record.type} ${record.name} has no alias target value`,
-    );
-  }
+  assertDefined(
+    aliasTargetName,
+    `Sim Route53 alias record ${record.type} ${record.name} has no alias target value`,
+  );
 
   return {
     Name: simRoute53AbsoluteName(record.name),

--- a/src/service/route53/dns/dns-record-type.ts
+++ b/src/service/route53/dns/dns-record-type.ts
@@ -1,3 +1,4 @@
+import { assertDefined } from "../../../util/type-guard/defined.js";
 import type { SimRoute53RecordType } from "../record/sim-route53-record.js";
 
 /**
@@ -67,10 +68,7 @@ export function dnsRecordTypeNumber(
 ): number {
   const typeNumber = typeNumbersByRecordType.get(recordType);
 
-  /* v8 ignore if -- the map covers every type simulated DNS answers */
-  if (typeNumber === undefined) {
-    throw new Error(`No DNS type number for record type ${recordType}`);
-  }
+  assertDefined(typeNumber, `No DNS type number for record type ${recordType}`);
 
   return typeNumber;
 }

--- a/src/service/s3/notification/destination/lambda/sim-aws-s3-notification-functions.ts
+++ b/src/service/s3/notification/destination/lambda/sim-aws-s3-notification-functions.ts
@@ -82,6 +82,7 @@ export class SimAwsS3NotificationFunctions implements SimS3NotificationFunctions
     const arn = SimS3NotificationFunctionArn.parse(request.destinationArn);
     const simFunction = this.findFunction(arn);
 
+    // eslint-disable-next-line no-restricted-syntax -- `assertDefined` is denser per line, and this file is close enough to the FTA threshold that the guard costs less kept as it is
     if (simFunction === undefined) {
       throw new Error(
         `${request.destinationArn} is not a simulated Lambda function.`,

--- a/src/util/filesystem/temporary-directory.ts
+++ b/src/util/filesystem/temporary-directory.ts
@@ -1,6 +1,7 @@
 import { mkdir, mkdtemp, writeFile as fsWriteFile } from "node:fs/promises";
 import path from "node:path";
 import { repoPath } from "./path.js";
+import { assertDefined } from "../type-guard/defined.js";
 
 /**
  * Create a temporary directory and return its path.
@@ -29,11 +30,11 @@ export class TemporaryDirectory {
    * Return the absolute path to this temporary directory.
    */
   path(): string {
-    if (this.dirPath === undefined) {
-      throw new Error(
-        "TempDir path has not yet been resolved. Call resolvePath() or writeFile() first.",
-      );
-    }
+    assertDefined(
+      this.dirPath,
+      "TempDir path has not yet been resolved. Call resolvePath() or writeFile() first.",
+    );
+
     return this.dirPath;
   }
 

--- a/test/serve/served-project.ts
+++ b/test/serve/served-project.ts
@@ -3,6 +3,7 @@ import { mkdir } from "node:fs/promises";
 import type { SimAws } from "../../src/index.js";
 import { repoPath } from "../../src/util/filesystem/path.js";
 import { TemporaryDirectory } from "../../src/util/filesystem/temporary-directory.js";
+import { assertNotNull } from "../../src/util/type-guard/defined.js";
 import { jsonStringify } from "../../src/util/type-guard/json.js";
 
 const yulin = repoPath("src/index.js");
@@ -151,11 +152,10 @@ export class ServedProject {
     });
     clearTimeout(giveUp);
 
-    if (code === null) {
-      throw new Error(
-        `The process did not exit on its own. It said: ${output.stdout} ${output.stderr}`,
-      );
-    }
+    assertNotNull(
+      code,
+      `The process did not exit on its own. It said: ${output.stdout} ${output.stderr}`,
+    );
 
     return { ...output, code };
   }


### PR DESCRIPTION
The CloudFront Functions JS2 restrictions were a `no-restricted-syntax` block, which only ESLint can read. They are now a plugin of eleven named rules that both ESLint and Oxlint load unmodified, published alongside a new `@kensio/yulin/oxlint` config fragment generated from the same rule map at build time so the two configs cannot drift apart. Fixing the rule's own worst failure mode came with it: flat config replaces a rule's configuration rather than merging it, so adding `@kensio/smartass/eslint` in #93 silently turned this repository's own `no-restricted-syntax` restrictions off and nothing noticed for 265 commits.

## Oxlint compatibility

Oxlint's JS plugin API reached alpha in March 2026 with esquery selector support, which is what makes one plugin serve both linters. Verified rather than assumed:

- A test lints the same fixtures with ESLint and with Oxlint and asserts identical rule, line and column, with a second test guarding against both sides simply finding nothing.
- The documented consumer setup was checked end to end against a real `npm pack` install, not just the repo tree.
- Measured on this repo, Oxlint runs `src` in 4.8s with JS plugins loaded against ESLint's 70s cold.

Rules being individual also means a consumer can switch one restriction off without restating the other ten, and a finding reports as `cff-js2/no-arrow-function` rather than as an anonymous `no-restricted-syntax`. The config had no tests at all before this.

## The clobbering fix

`no-restricted-syntax` entries are now gathered from every source and the rule set once, with a test that resolves the config through ESLint's own API and fails if either side is lost again. That test was checked by reintroducing the bug, and it fails as intended.

Restoring the rules found nineteen violations, fixed here by using `assertDefined` and the more specific smartass assertions. Three guards keep an inline disable with its reason: one where `assertDefined` cannot narrow through an optional chain the code below relies on, and two where it is denser per line and pushed the file over the FTA threshold.

## Deliberately not in this PR

The ban on `unknown` as a type is not restored. It has **530 occurrences across 161 files**, and over the 265 commits the rule spent switched off the codebase settled on patterns like `Record<string, unknown>` and `catch (error: unknown)` that it would reject. That is either drift worth reversing or a rule worth retiring, and it wants a decision rather than a guess. The other three selectors are restored.

The durable fix for the collision belongs upstream in `@kensio/smartass`: shipping `no-restricted-syntax` in a shared config collides with any consumer that also uses the rule, and the same plugin treatment applied here would remove the hazard entirely.

## Breaking change

Violations now report under `cff-js2/*` rule names, so an `eslint-disable` comment naming `no-restricted-syntax` or `no-restricted-globals` in a `.cff.js` file goes stale.

`pnpm check` passes: 945 test files, 5757 tests, coverage 99.89%.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CloudFront Functions JavaScript 2 linting support for ESLint and Oxlint.
  * Detects unsupported syntax and unavailable global variables in `.cff.js` files.
  * Added reusable, published lint configurations and plugin exports.
  * Added configuration generation and validation during builds.

* **Documentation**
  * Added setup guides, rule references, configuration examples, overrides, and known limitations.

* **Tests**
  * Added coverage confirming ESLint and Oxlint report matching violations and accept valid JS2 code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->