### PR TITLE
feat: declare system metadata for a mount

### DIFF
--- a/docs/services/s3/README.md
+++ b/docs/services/s3/README.md
@@ -1775,6 +1775,48 @@ simAws.s3().mountBucketFilesystem("site", path.join(process.cwd(), "public"), {
 These are added to the list rather than replacing it, so naming one cannot cost you `.html`, and a
 leading dot is optional. Everything not named is still refused.
 
+### Metadata a file cannot carry
+
+A stored Object holds what S3 was told when it was written. A file holds its bytes and its name, so
+a mounted Bucket has only the extension to go on, and reports a `content-type` and nothing else.
+Anything a deployment would have set is declared on the mount instead, for the Objects under a key
+prefix.
+
+`ContentEncoding` is the one a site can be broken without. A directory of brotli files served with
+no `content-encoding` is bytes no browser can decode:
+
+```typescript sim-s3-mount-system-metadata
+/**
+ * Declaring the encoding of a compressed mirror in a mounted directory.
+ */
+
+import path from "node:path";
+
+import { CreateBucketCommand } from "@aws-sdk/client-s3";
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+await simAws.s3().createBucket(new CreateBucketCommand({ Bucket: "site" }));
+
+simAws.s3().mountBucketFilesystem("site", path.join(process.cwd(), "public"), {
+  // The mirrored copies keep their own names, so `br/js/app.js` is still typed
+  // `text/javascript` from its extension. Nothing about the file says it is
+  // compressed, which is what this declares.
+  systemMetadata: [{ keyPrefix: "br/", metadata: { ContentEncoding: "br" } }],
+});
+```
+
+The fields are the ones a [`PutObjectCommand`](#object-system-metadata) sets, and every value is a
+string, including `Expires`. Every declaration whose prefix the key starts with applies, in the
+order they were given, so a later one wins where two name the same header. An empty prefix is every
+Object in the Bucket. A declared `ContentType` replaces the one guessed from the extension.
+
+This is what a Bucket mounted for local development needs to answer as the deployed one does. A CDK
+`BucketDeployment` sets the same headers through its own `SystemMetadata`, and a mount serves the
+files as they are built rather than as they were staged, so the two say the same thing in different
+places. See [CDK S3 BucketDeployment](../cloudformation/README.md#cdk-s3-bucketdeployment).
+
 ## Object system metadata
 
 S3 keeps a handful of headers about an Object when it is written and hands them back on every read.
@@ -1833,7 +1875,9 @@ report it. `Expires` is the one field that is not a string: the SDK takes a `Dat
 as the HTTP date a read hands back.
 
 A CDK BucketDeployment's `SystemMetadata` sets the same headers on every Object it copies. See
-[CDK S3 BucketDeployment](../cloudformation/README.md#cdk-s3-bucketdeployment).
+[CDK S3 BucketDeployment](../cloudformation/README.md#cdk-s3-bucketdeployment). A
+[mounted directory](#metadata-a-file-cannot-carry) declares them for the Objects under a key prefix,
+since a file on disk carries none of them.
 
 ## Standalone SimS3
 
@@ -1893,7 +1937,8 @@ Sim S3 currently supports:
 - Bucket-global uniqueness within a `SimAws` instance across simulated Accounts and Regions
 - In-memory Object storage by default
 - Optional filesystem-backed Bucket storage with `mountBucketFilesystem(...)`, watching the mounted
-  directory and reloading connected browsers when it is rebuilt
+  directory and reloading connected browsers when it is rebuilt, and reporting the system metadata
+  the mount declares for a key prefix
 
 The simulator focuses on useful behaviour for tests and local development rather than full S3 feature
 parity. Unsupported S3 options may be ignored or may throw errors depending on whether the simulator

--- a/docs/services/s3/sim-s3-mount-system-metadata.example.ts
+++ b/docs/services/s3/sim-s3-mount-system-metadata.example.ts
@@ -1,0 +1,19 @@
+/**
+ * Declaring the encoding of a compressed mirror in a mounted directory.
+ */
+
+import path from "node:path";
+
+import { CreateBucketCommand } from "@aws-sdk/client-s3";
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+await simAws.s3().createBucket(new CreateBucketCommand({ Bucket: "site" }));
+
+simAws.s3().mountBucketFilesystem("site", path.join(process.cwd(), "public"), {
+  // The mirrored copies keep their own names, so `br/js/app.js` is still typed
+  // `text/javascript` from its extension. Nothing about the file says it is
+  // compressed, which is what this declares.
+  systemMetadata: [{ keyPrefix: "br/", metadata: { ContentEncoding: "br" } }],
+});

--- a/src/service/s3/README.md
+++ b/src/service/s3/README.md
@@ -299,8 +299,9 @@ Filesystem storage behaviour:
 - path traversal and unsafe directory/object paths are rejected
 - `deleteObject` refuses with `SimS3NotImplemented` rather than unlinking the file
 - system metadata comes from `object/s3-key-prefix-metadata.ts`, because a file carries none of it:
-  the extension gives a `content-type`, and the mount's `systemMetadata` option declares the rest
-  for the Objects under a key prefix
+  the extension gives a default `content-type`, and the mount's `systemMetadata` option declares
+  system metadata for the Objects under a key prefix, including a `ContentType` that replaces the
+  inferred one
 
 The filesystem implementation includes safety checks to reduce accidental unsafe file access, but it
 should still be treated as local-development tooling rather than a sandbox boundary. That is why

--- a/src/service/s3/README.md
+++ b/src/service/s3/README.md
@@ -298,6 +298,9 @@ Filesystem storage behaviour:
 - file extensions are filtered through filesystem safety rules
 - path traversal and unsafe directory/object paths are rejected
 - `deleteObject` refuses with `SimS3NotImplemented` rather than unlinking the file
+- system metadata comes from `object/s3-key-prefix-metadata.ts`, because a file carries none of it:
+  the extension gives a `content-type`, and the mount's `systemMetadata` option declares the rest
+  for the Objects under a key prefix
 
 The filesystem implementation includes safety checks to reduce accidental unsafe file access, but it
 should still be treated as local-development tooling rather than a sandbox boundary. That is why

--- a/src/service/s3/bucket/sim-s3-bucket-access.ts
+++ b/src/service/s3/bucket/sim-s3-bucket-access.ts
@@ -3,6 +3,7 @@ import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-
 import { FilesystemS3BucketStorage } from "../storage/filesystem/s3-filesystem-storage.js";
 import { simS3BucketUrl } from "./sim-s3-endpoint-url.js";
 import type { SimS3Bucket, SimS3BucketName } from "./sim-s3-bucket.js";
+import { SimS3KeyPrefixSystemMetadata } from "../object/s3-key-prefix-metadata.js";
 import { SimS3MountWatches } from "../mount/sim-s3-mount-watches.js";
 import type { SimS3MountFilesystemOptions } from "../mount/sim-s3-mount.type.js";
 
@@ -64,6 +65,10 @@ export class SimS3BucketAccess {
    * directory is only named to a `yulin watch` supervisor, so editing a file
    * the Bucket serves restarts the process without the directory having been
    * listed anywhere, and nothing happens outside watch mode.
+   *
+   * A file says nothing about how it was compressed or how long it may be
+   * cached, so `systemMetadata` is where a mount declares what a deployment
+   * would have set.
    */
   mountFilesystem(
     bucketName: SimS3BucketName | string,
@@ -75,6 +80,9 @@ export class SimS3BucketAccess {
         directoryPath,
         ...(options.additionalFileExtensions !== undefined && {
           additionalFileExtensions: options.additionalFileExtensions,
+        }),
+        systemMetadata: new SimS3KeyPrefixSystemMetadata({
+          declarations: options.systemMetadata,
         }),
       }),
     );

--- a/src/service/s3/index.ts
+++ b/src/service/s3/index.ts
@@ -3,4 +3,9 @@ export type {
   SimS3MountFilesystemOptions,
   SimS3MountReloadTarget,
 } from "./mount/sim-s3-mount.type.js";
+export type {
+  SimS3KeyPrefixMetadata,
+  SimS3SystemMetadataValues,
+} from "./object/s3-key-prefix-metadata.js";
+export type { SimS3SystemMetadataField } from "./object/s3-system-metadata.js";
 export type { SimS3NotificationDeliveryFailure } from "./notification/sim-s3-notification-failures.js";

--- a/src/service/s3/mount/sim-s3-mount.type.ts
+++ b/src/service/s3/mount/sim-s3-mount.type.ts
@@ -1,3 +1,5 @@
+import type { SimS3KeyPrefixMetadata } from "../object/s3-key-prefix-metadata.js";
+
 /**
  * Somewhere a reload can be sent, which in practice is a local server.
  *
@@ -42,4 +44,26 @@ export interface SimS3MountFilesystemOptions {
    * Added to the list rather than replacing it, and a leading dot is optional.
    */
   readonly additionalFileExtensions?: readonly string[] | undefined;
+
+  /**
+   * System metadata to report for the Objects under a key prefix.
+   *
+   * A stored Object carries what S3 was told at upload time. A file carries
+   * its bytes and its name, so a mounted Bucket has only the extension to go
+   * on and describes every Object with a `content-type` and nothing else. This
+   * is where the rest is declared.
+   *
+   * `ContentEncoding` is the one a site can be broken without. A directory of
+   * brotli files served with no `content-encoding` is bytes no browser can
+   * decode, and a deployment that sets the header would have made them work:
+   *
+   * ```typescript
+   * systemMetadata: [{ keyPrefix: "br/", metadata: { ContentEncoding: "br" } }]
+   * ```
+   *
+   * Every declaration whose prefix the key starts with applies, in the order
+   * they were given, so a later one wins where two name the same header. A
+   * declared `ContentType` replaces the one guessed from the extension.
+   */
+  readonly systemMetadata?: readonly SimS3KeyPrefixMetadata[] | undefined;
 }

--- a/src/service/s3/object/s3-key-prefix-metadata.iso.test.ts
+++ b/src/service/s3/object/s3-key-prefix-metadata.iso.test.ts
@@ -1,0 +1,96 @@
+import { assertArrayLength, assertObjectEquals } from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimS3KeyPrefixSystemMetadata } from "./s3-key-prefix-metadata.js";
+
+describe("SimS3KeyPrefixSystemMetadata", () => {
+  it("declares system metadata for the Objects under a prefix", () => {
+    // Given a compressed mirror published under its own prefix.
+    const declared = new SimS3KeyPrefixSystemMetadata({
+      declarations: [{ keyPrefix: "br/", metadata: { ContentEncoding: "br" } }],
+    });
+
+    // When an Object in the mirror is described.
+    const headers = declared.headersForObjectKey("br/js/app.js");
+
+    // Then it is reported as brotli, under the name a read returns it by.
+    assertObjectEquals(headers, { "content-encoding": "br" });
+  });
+
+  it("leaves an Object outside the prefix undescribed", () => {
+    // Given the same declaration.
+    const declared = new SimS3KeyPrefixSystemMetadata({
+      declarations: [{ keyPrefix: "br/", metadata: { ContentEncoding: "br" } }],
+    });
+
+    // When the uncompressed copy of the same file is described.
+    const headers = declared.headersForObjectKey("js/app.js");
+
+    // Then nothing is declared about it, so it is served as it is on disk.
+    assertArrayLength(Object.keys(headers), 0);
+  });
+
+  it("declares every system metadata header a deployment can set", () => {
+    // Given a declaration naming each of them.
+    const declared = new SimS3KeyPrefixSystemMetadata({
+      declarations: [
+        {
+          keyPrefix: "",
+          metadata: {
+            CacheControl: "public, max-age=31536000, immutable",
+            ContentDisposition: 'inline; filename="app.js"',
+            ContentEncoding: "br",
+            ContentLanguage: "en-GB",
+            ContentType: "text/javascript",
+            Expires: "Sat, 02 Jan 2027 03:04:05 GMT",
+          },
+        },
+      ],
+    });
+
+    // When an Object is described. An empty prefix is every key.
+    const headers = declared.headersForObjectKey("anything.bin");
+
+    // Then each one is reported under its header name.
+    assertObjectEquals(headers, {
+      "cache-control": "public, max-age=31536000, immutable",
+      "content-disposition": 'inline; filename="app.js"',
+      "content-encoding": "br",
+      "content-language": "en-GB",
+      "content-type": "text/javascript",
+      expires: "Sat, 02 Jan 2027 03:04:05 GMT",
+    });
+  });
+
+  it("lets a later declaration win where two name the same header", () => {
+    // Given a cache directive for the whole Bucket and a longer one for the
+    // hashed assets in it.
+    const declared = new SimS3KeyPrefixSystemMetadata({
+      declarations: [
+        { keyPrefix: "", metadata: { CacheControl: "max-age=60" } },
+        {
+          keyPrefix: "js/",
+          metadata: { CacheControl: "max-age=31536000, immutable" },
+        },
+      ],
+    });
+
+    // When a hashed asset is described.
+    const headers = declared.headersForObjectKey("js/app.F3H4LLPU.js");
+
+    // Then the more specific declaration is the one reported.
+    assertObjectEquals(headers, {
+      "cache-control": "max-age=31536000, immutable",
+    });
+  });
+
+  it("declares nothing when a mount says nothing", () => {
+    // Given a mount that declared no metadata at all.
+    const declared = new SimS3KeyPrefixSystemMetadata();
+
+    // When an Object is described.
+    const headers = declared.headersForObjectKey("index.html");
+
+    // Then the Object is left to be described by its file extension alone.
+    assertArrayLength(Object.keys(headers), 0);
+  });
+});

--- a/src/service/s3/object/s3-key-prefix-metadata.ts
+++ b/src/service/s3/object/s3-key-prefix-metadata.ts
@@ -1,0 +1,85 @@
+import {
+  simS3SystemMetadataHeaders,
+  type SimS3SystemMetadataField,
+} from "./s3-system-metadata.js";
+
+/**
+ * System metadata values, under the request field names a `PutObject` sets
+ * them with.
+ *
+ * Every value is a string here, including `Expires`, which a `PutObject` takes
+ * as a `Date`. Nothing is being written, so there is no request field to format:
+ * this says what S3 already holds about a file, in the form a read hands back.
+ */
+export type SimS3SystemMetadataValues = Partial<
+  Record<SimS3SystemMetadataField, string>
+>;
+
+/**
+ * System metadata declared for the Objects under one key prefix.
+ */
+export interface SimS3KeyPrefixMetadata {
+  /**
+   * The Object key prefix this applies to, such as `br/`. An empty prefix
+   * applies to every Object.
+   */
+  readonly keyPrefix: string;
+
+  /** What S3 reports about the Objects under that prefix. */
+  readonly metadata: SimS3SystemMetadataValues;
+}
+
+interface SimS3KeyPrefixSystemMetadataProperties {
+  readonly declarations?: readonly SimS3KeyPrefixMetadata[] | undefined;
+}
+
+/**
+ * The system metadata declared for an Object key by the prefixes it starts
+ * with.
+ *
+ * Storage that holds an Object holds its metadata with it, so nothing needs
+ * this. Storage that maps Objects onto files has only the file to go on, and a
+ * file carries its bytes and its name and nothing else, so anything S3 would
+ * have been told at upload time has to be declared instead. `Content-Encoding`
+ * is the one that stops a site working without it: a directory of brotli files
+ * served without the header is bytes no browser can decode.
+ */
+export class SimS3KeyPrefixSystemMetadata {
+  private readonly declarations: readonly SimS3KeyPrefixMetadata[];
+
+  constructor(properties: SimS3KeyPrefixSystemMetadataProperties = {}) {
+    this.declarations = properties.declarations ?? [];
+  }
+
+  /**
+   * The headers declared for one Object key, under the names a read returns
+   * them by.
+   *
+   * Every declaration whose prefix the key starts with applies, in the order
+   * they were given, so a later one wins where two name the same header.
+   */
+  headersForObjectKey(key: string): Record<string, string> {
+    const headers: Record<string, string> = {};
+
+    for (const declaration of this.declarations) {
+      if (key.startsWith(declaration.keyPrefix)) {
+        this.addDeclared(headers, declaration);
+      }
+    }
+
+    return headers;
+  }
+
+  private addDeclared(
+    headers: Record<string, string>,
+    declaration: SimS3KeyPrefixMetadata,
+  ): void {
+    for (const header of simS3SystemMetadataHeaders) {
+      const value = declaration.metadata[header.field];
+
+      if (value !== undefined) {
+        headers[header.name] = value;
+      }
+    }
+  }
+}

--- a/src/service/s3/sim-s3.ts
+++ b/src/service/s3/sim-s3.ts
@@ -237,6 +237,11 @@ export class SimS3 {
    * Passing somewhere to reload, as `{ reload: srv }`, also watches the
    * directory: a build that writes into it reloads the connected browsers once
    * the writes stop, without the Bucket having to be filled again.
+   *
+   * A file on disk carries no metadata, so an Object read out of one is
+   * described by its extension alone. `systemMetadata` declares the rest for
+   * the Objects under a key prefix, which is what a directory of brotli files
+   * needs to be served with a `content-encoding` a browser can act on.
    */
   mountBucketFilesystem(
     bucketName: SimS3BucketName | string,

--- a/src/service/s3/storage/filesystem/s3-filesystem-object-metadata.ts
+++ b/src/service/s3/storage/filesystem/s3-filesystem-object-metadata.ts
@@ -3,9 +3,15 @@ import { SimS3ObjectMetadata } from "../../object/s3-object.js";
 
 /**
  * Make up reasonable metadata for an Object based on the file on disk.
+ *
+ * Anything the mount declared about the key is laid over the guess, so a
+ * declared `content-type` replaces the one the extension suggested, and a
+ * declared `content-encoding` is reported for a file whose name says nothing
+ * about how it was compressed.
  */
 export function metadataForFilesystemS3ObjectKey(
   key: string,
+  declaredHeaders: Readonly<Record<string, string>> = {},
 ): SimS3ObjectMetadata {
   return new SimS3ObjectMetadata({
     // Octet-stream for anything the table below has never heard of, which is
@@ -14,6 +20,7 @@ export function metadataForFilesystemS3ObjectKey(
     // types, and the option exists for files that are not one of them.
     "content-type":
       contentTypeForFilesystemS3ObjectKey(key) ?? "application/octet-stream",
+    ...declaredHeaders,
   });
 }
 

--- a/src/service/s3/storage/filesystem/s3-filesystem-storage.ts
+++ b/src/service/s3/storage/filesystem/s3-filesystem-storage.ts
@@ -7,11 +7,18 @@ import { metadataForFilesystemS3ObjectKey } from "./s3-filesystem-object-metadat
 import { FilesystemS3ObjectKeys } from "./s3-filesystem-object-keys.js";
 import { assertDefined } from "../../../../util/type-guard/defined.js";
 import { SimS3NotImplemented } from "../../error/sim-s3.error.js";
+import { SimS3KeyPrefixSystemMetadata } from "../../object/s3-key-prefix-metadata.js";
 
 interface FilesystemS3BucketStorageProperties {
   readonly directoryPath: string;
   readonly allowedDirectoryNames?: readonly string[];
   readonly additionalFileExtensions?: readonly string[];
+
+  /**
+   * What S3 was told about these files, which a file cannot say for itself.
+   * Without it an Object is described by its extension and nothing else.
+   */
+  readonly systemMetadata?: SimS3KeyPrefixSystemMetadata;
 }
 
 /**
@@ -26,8 +33,11 @@ export class FilesystemS3BucketStorage implements SimS3BucketStorage {
   private readonly directoryPath: string;
   private readonly safety: FilesystemS3StorageSafety;
   private readonly objectKeys: FilesystemS3ObjectKeys;
+  private readonly systemMetadata: SimS3KeyPrefixSystemMetadata;
 
   constructor(properties: FilesystemS3BucketStorageProperties) {
+    this.systemMetadata =
+      properties.systemMetadata ?? new SimS3KeyPrefixSystemMetadata();
     this.safety = new FilesystemS3StorageSafety({
       allowedDirectoryNames: properties.allowedDirectoryNames,
       additionalFileExtensions: properties.additionalFileExtensions,
@@ -57,7 +67,10 @@ export class FilesystemS3BucketStorage implements SimS3BucketStorage {
       return new SimS3Object({
         key,
         body,
-        metadata: metadataForFilesystemS3ObjectKey(key),
+        metadata: metadataForFilesystemS3ObjectKey(
+          key,
+          this.systemMetadata.headersForObjectKey(key),
+        ),
       });
     } catch (error) {
       if (

--- a/src/service/s3/storage/filesystem/s3-filesystem-system-metadata.loc.test.ts
+++ b/src/service/s3/storage/filesystem/s3-filesystem-system-metadata.loc.test.ts
@@ -1,0 +1,114 @@
+import { brotliCompressSync } from "node:zlib";
+
+import {
+  CreateBucketCommand,
+  GetObjectCommand,
+  PutBucketWebsiteCommand,
+} from "@aws-sdk/client-s3";
+import {
+  assertIdentical,
+  assertObjectMatches,
+  assertUndefined,
+} from "@kensio/smartass";
+import { afterAll, beforeAll, describe, it } from "vitest";
+
+import { SimAwsLocalServer } from "../../../../serve/index.js";
+import { TemporaryDirectory } from "../../../../util/filesystem/temporary-directory.js";
+import { makeAwsRegionName } from "../../../aws/sim-aws-region.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+import type { SimS3BucketName } from "../../bucket/sim-s3-bucket.js";
+import { grantPublicWebsiteRead } from "../../bucket/website/sim-s3-public-website.fixture.js";
+
+/**
+ * A site publishing a compressed mirror of its assets, which is what the
+ * declaration exists for. The mirrored copies keep their names, so nothing
+ * about `br/js/app.js` says it is brotli except the mount saying so.
+ */
+const compressedMirror = [
+  { keyPrefix: "br/", metadata: { ContentEncoding: "br" } },
+] as const;
+
+describe("System metadata declared for a mounted directory", () => {
+  const simAws = new SimAws();
+  const srv: SimAwsLocalServer = new SimAwsLocalServer({ simAws });
+
+  beforeAll(async () => {
+    await srv.listen();
+  });
+
+  afterAll(async () => {
+    await srv.close();
+  });
+
+  it("reports the metadata declared for the Objects under a prefix", async () => {
+    // Given a site with a brotli mirror of one of its scripts.
+    const testDirectory = new TemporaryDirectory();
+    await testDirectory.writeFile(["public", "js", "app.js"], "console.log(1)");
+    await testDirectory.writeFile(
+      ["public", "br", "js", "app.js"],
+      brotliCompressSync(Buffer.from("console.log(1)")),
+    );
+
+    const simS3 = simAws.region(makeAwsRegionName()).s3();
+    await simS3.createBucket(new CreateBucketCommand({ Bucket: "mirror" }));
+
+    // When the directory is mounted, saying what is under the mirror.
+    simS3.mountBucketFilesystem("mirror", testDirectory.join("public"), {
+      systemMetadata: compressedMirror,
+    });
+
+    const mirrored = await simS3.getObject(
+      new GetObjectCommand({ Bucket: "mirror", Key: "br/js/app.js" }),
+    );
+    const plain = await simS3.getObject(
+      new GetObjectCommand({ Bucket: "mirror", Key: "js/app.js" }),
+    );
+
+    // Then the mirrored copy is brotli, still typed by its own extension.
+    assertObjectMatches(mirrored.Metadata, {
+      "content-encoding": "br",
+      "content-type": "text/javascript",
+    });
+
+    // And the copy outside the mirror is left as it is on disk.
+    assertUndefined(plain.Metadata?.["content-encoding"]);
+    assertIdentical(plain.Metadata?.["content-type"], "text/javascript");
+  });
+
+  it("serves a mounted mirror as bytes a client can decode", async () => {
+    // Given the same mirror, served as a static website.
+    const testDirectory = new TemporaryDirectory();
+    await testDirectory.writeFile(
+      ["public", "br", "js", "app.js"],
+      brotliCompressSync(Buffer.from("console.log('decoded')")),
+    );
+
+    const region = makeAwsRegionName();
+    const bucketName = "mirror-site" as SimS3BucketName;
+    const simS3 = simAws.region(region).s3();
+
+    await simS3.createBucket(new CreateBucketCommand({ Bucket: bucketName }));
+    await simS3.putBucketWebsite(
+      new PutBucketWebsiteCommand({
+        Bucket: bucketName,
+        WebsiteConfiguration: { IndexDocument: { Suffix: "index.html" } },
+      }),
+    );
+    await grantPublicWebsiteRead(simS3, bucketName);
+
+    simS3.mountBucketFilesystem(bucketName, testDirectory.join("public"), {
+      systemMetadata: compressedMirror,
+    });
+
+    // When a client asks for the mirrored copy.
+    const response = await fetch(
+      `http://${bucketName}.s3-website.${region}.sim-aws.localhost:${srv.port}/br/js/app.js`,
+    );
+
+    // Then it arrives labelled as brotli, and decodes to the original script.
+    // Without the header these are bytes the client hands back unread.
+    assertIdentical(response.headers.get("content-encoding"), "br");
+    assertIdentical(response.headers.get("content-type"), "text/javascript");
+    assertIdentical(await response.text(), "console.log('decoded')");
+  });
+});

--- a/src/util/filesystem/temporary-directory.ts
+++ b/src/util/filesystem/temporary-directory.ts
@@ -54,10 +54,13 @@ export class TemporaryDirectory {
 
   /**
    * Write a file inside this temporary directory, creating parent directories as needed.
+   *
+   * Bytes as well as text, so a test can lay down a fixture that is not a
+   * string, such as a compressed copy of a file.
    */
   async writeFile(
     pathParts: string | string[],
-    content: string,
+    content: string | Uint8Array,
   ): Promise<void> {
     await this.resolvePath();
     const filePath = this.join(


### PR DESCRIPTION
## What

`mountBucketFilesystem` takes a `systemMetadata` option, declaring what S3 was told about the Objects under a key prefix:

```typescript
simAws.s3().mountBucketFilesystem("site", publicDirectory, {
  systemMetadata: [{ keyPrefix: "br/", metadata: { ContentEncoding: "br" } }],
});
```

The fields are the ones a `PutObjectCommand` sets, and the values are laid over the metadata guessed from the file extension, so a declared `ContentType` replaces the guess and everything else is added. Every declaration whose prefix the key starts with applies, in the order given, so a later one wins where two name the same header.

## Why

A stored Object holds what S3 was told when it was written. A file holds its bytes and its name, so a mounted Bucket had only the extension to go on and described every Object with a `content-type` and nothing else.

`ContentEncoding` is the one a site can be broken without. A site that publishes a brotli mirror of its assets under `br/`, with the copies keeping their own names, relies on the header to tell a browser what it has been sent. A CDK `BucketDeployment` sets it through `SystemMetadata`, which Yulin now simulates, but a mount serves the files as they are built rather than as they were staged, and had no way to say the same thing. The mounted copy came back as raw brotli labelled `text/javascript`, which is a `SyntaxError` in the browser rather than a page.

## How

- `SimS3KeyPrefixSystemMetadata` in `object/` answers what is declared for one Object key, under the header names a read returns them by.
- `FilesystemS3BucketStorage` takes one and lays it over `metadataForFilesystemS3ObjectKey`.
- `SimS3BucketAccess.mountFilesystem` builds it from the new option.

Every endpoint that serves an Object already goes through `simS3ObjectResponseHeaders`, so the REST endpoint, the website endpoint and a CloudFront S3 Origin all report it without further change.

`TemporaryDirectory.writeFile` takes bytes as well as text, so a test can lay down a real brotli fixture.

## Tests

- `s3-key-prefix-metadata.iso.test.ts` covers prefix matching, ordering and the full set of headers.
- `s3-filesystem-system-metadata.loc.test.ts` mounts a directory holding a real brotli file and asserts the served response decodes, which is the failure this fixes.

`pnpm run check` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for assigning S3 system metadata to objects based on key prefixes when mounting filesystem directories.
  * Metadata declarations can add or override headers, including content encoding and content type.
  * Added public types and an example for configuring prefix-based metadata.

* **Documentation**
  * Expanded S3 mounting and object metadata documentation with configuration details and precedence rules.

* **Tests**
  * Added coverage for prefix matching, metadata precedence, filesystem-backed objects, and static website responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->