### PR TITLE
build: lint with the smartass Oxlint plugin

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -10,7 +10,9 @@
   // something to pick up on purpose rather than something that lands silently.
   //
   // Four ESLint plugins are loaded through Oxlint's JS plugin API rather than
-  // reimplemented. Oxlint carries native `unicorn` and `jsdoc` plugins whose
+  // reimplemented, alongside two written for Oxlint directly: this
+  // repository's own restrictions, and the assertion advice `@kensio/smartass`
+  // publishes. Oxlint carries native `unicorn` and `jsdoc` plugins whose
   // rule coverage is a long way short of what this repository uses — 166 and 18
   // of ours have no native counterpart — so both are taken wholesale from the
   // real plugin under an alias. `unicorn` and `jsdoc` are reserved names, which
@@ -30,8 +32,10 @@
   //   `no-octal` has no Oxlint rule, and needs none: modules are strict mode,
   //   where a legacy octal literal is a parse error rather than a lint finding.
   //
-  // `no-restricted-syntax` is also absent, but it did survive: its selectors
-  // moved into the `yulin` plugin below as named rules.
+  // `no-restricted-syntax` is also absent, but it did survive: this
+  // repository's selectors moved into the `yulin` plugin below as named rules,
+  // and the 47 that used to arrive from `@kensio/smartass` as a
+  // `no-restricted-syntax` block now come from the Oxlint plugin it publishes.
   //
   // The published `cff-js2` plugin is not loaded here. It restricts syntax to
   // what the CloudFront Functions JS2 runtime will run, this repository has no
@@ -65,6 +69,7 @@
     { "name": "jsdoc-js", "specifier": "eslint-plugin-jsdoc" },
     { "name": "security", "specifier": "eslint-plugin-security" },
     { "name": "no-secrets", "specifier": "eslint-plugin-no-secrets" },
+    { "name": "smartass", "specifier": "@kensio/smartass/oxlint" },
     { "name": "yulin", "specifier": "./src/config/lint/repo-lint-plugin.ts" }
   ],
 
@@ -653,13 +658,19 @@
       "error",
       { "tolerance": 4.5, "ignoreContent": [" * https://", "http://"] }
     ],
-    // ── This repository's own restrictions (4) ──
+    // ── @kensio/smartass, as an Oxlint plugin of its own (1) ──
+    // One rule carrying the 47 selectors that ask for a narrower assertion than
+    // the one written. Generated from the same table as the `no-restricted-
+    // syntax` block in `@kensio/smartass/eslint`, so both linters say the same
+    // thing.
+    "smartass/prefer-specific-assertions": "error",
+
+    // ── This repository's own restrictions (3) ──
     // Named rules rather than a `no-restricted-syntax` block, which Oxlint has
     // no equivalent of. See src/config/lint/repo-lint-plugin.ts.
     "yulin/assert-defined-guard": "error",
     "yulin/assert-not-null-guard": "error",
-    "yulin/no-reused-props": "error",
-    "yulin/prefer-specific-assertions": "error"
+    "yulin/no-reused-props": "error"
   },
 
   // Later overrides win, so these run from the widest scope to the narrowest.
@@ -715,7 +726,9 @@
         "yulin/assert-defined-guard": "off",
         "yulin/assert-not-null-guard": "off",
         "yulin/no-reused-props": "off",
-        "yulin/prefer-specific-assertions": "off"
+        // Likewise the assertion helpers the advice points at: an example is
+        // read by someone who has not installed @kensio/smartass.
+        "smartass/prefer-specific-assertions": "off"
       }
     },
     {

--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     "@aws-sdk/lib-dynamodb": "^3.1101.0",
     "@aws-sdk/s3-request-presigner": "^3.1101.0",
     "@eslint/js": "^10.0.1",
-    "@kensio/smartass": "^1.36.0",
+    "@kensio/smartass": "^1.37.0",
     "@semantic-release/exec": "7.1.0",
     "@smithy/signature-v4": "^5.6.12",
     "@smithy/smithy-client": "^4.14.16",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -85,8 +85,8 @@ importers:
         specifier: ^10.0.1
         version: 10.0.1(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))
       '@kensio/smartass':
-        specifier: ^1.36.0
-        version: 1.36.0
+        specifier: ^1.37.0
+        version: 1.37.0
       '@semantic-release/exec':
         specifier: 7.1.0
         version: 7.1.0(semantic-release@25.0.9(@typescript/typescript6@6.0.2)(supports-color@7.2.0))(supports-color@7.2.0)
@@ -715,8 +715,8 @@ packages:
     resolution: {integrity: sha512-vaVPwq9uUVvxAsr4K7l/Ux85+SpYFOXjzG+LcV/RYbrCON++mTy2wotwAPgVIzsH5LK3G/m2rM/qj8O7PZwYnQ==}
     engines: {node: '>=22.0.0'}
 
-  '@kensio/smartass@1.36.0':
-    resolution: {integrity: sha512-rvi9sOTJq0cvsvgUbXODI5MBuseLP2XXQila6V8m/3iOl6zfHqCrRpvGWQQyO33CBVOJEHg7iRGgv4J06NJVfQ==}
+  '@kensio/smartass@1.37.0':
+    resolution: {integrity: sha512-jxkPr7vOFtbGb15dr+7TcxNMQRMtVJd54G6OIAeQpZjqTqZb7CwNDfDykWspvE9h7KS9T3ZoZDHDuAFABd6UVQ==}
     engines: {node: '>=24.0.0'}
 
   '@napi-rs/wasm-runtime@1.1.6':
@@ -4105,7 +4105,7 @@ snapshots:
     dependencies:
       lodash: 4.18.1
 
-  '@kensio/smartass@1.36.0': {}
+  '@kensio/smartass@1.37.0': {}
 
   '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,6 @@
 allowBuilds:
   esbuild: true
 minimumReleaseAgeExclude:
-  - '@kensio/smartass@1.33.0'
+  - '@kensio/smartass@1.33.0 || 1.37.0'
   - '@kensio/part-factory@1.4.0 || 1.9.0'
 useNodeVersion: 24.18.0

--- a/src/config/lint/repo-lint-plugin.iso.test.ts
+++ b/src/config/lint/repo-lint-plugin.iso.test.ts
@@ -1,12 +1,7 @@
 import { assertArrayIncludes, assertArrayLength } from "@kensio/smartass";
 import { describe, it } from "vitest";
 
-import {
-  preferSpecificAssertionsRuleName,
-  repoLintPlugin,
-  repoSyntaxRestrictions,
-  smartassSyntaxRestrictions,
-} from "./repo-lint-plugin.js";
+import { repoLintPlugin, repoSyntaxRestrictions } from "./repo-lint-plugin.js";
 
 /** Every selector the plugin reports on, whichever rule carries it. */
 function publishedSelectors(): readonly string[] {
@@ -35,39 +30,17 @@ describe("This repository's own lint plugin", () => {
     assertArrayLength(own, 3);
   });
 
-  it("carries every selector the shared assertion config brings", () => {
-    // Given what @kensio/smartass asks for, read from the config it publishes
-    const wanted = smartassSyntaxRestrictions().map(
-      (restriction) => restriction.selector,
-    );
-
-    // When each of those selectors is looked for in the rule that rehouses them
-    const rule = Object.entries(repoLintPlugin.rules).find(
-      ([name]) => name === preferSpecificAssertionsRuleName,
-    )?.[1];
-    const carried = new Set(
-      Object.keys(
-        rule?.create({ sourceCode: { getScope: () => scope } } as never) ?? {},
-      ),
-    );
-    const missing = wanted.filter((selector) => !carried.has(selector));
-
-    // Then none was lost on the way across. Under ESLint these arrived through
-    // a `no-restricted-syntax` block that a second config could replace whole,
-    // and one silently did for 265 commits.
-    assertArrayLength(missing, 0);
-    assertArrayLength(wanted, 47);
-  });
-
-  it("keeps the repository's own restrictions alongside them", () => {
+  it("reports each restriction on the syntax it names", () => {
     // Given every selector the plugin reports on, from all of its rules
     const selectors = publishedSelectors();
 
-    // When this repository's own are looked for among them
-    // Then they are still there, next to the shared ones rather than replaced
-    // by them, which is the arrangement that failed before
+    // When each restriction's own selector is looked for among them
+    // Then it is there, so a rule that exists is also a rule that is wired to
+    // the syntax it was written for
     for (const restriction of Object.values(repoSyntaxRestrictions)) {
       assertArrayIncludes(selectors, restriction.selector);
     }
+
+    assertArrayLength(selectors, 3);
   });
 });

--- a/src/config/lint/repo-lint-plugin.loc.test.ts
+++ b/src/config/lint/repo-lint-plugin.loc.test.ts
@@ -3,6 +3,7 @@ import { execa } from "execa";
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { describe, it } from "vitest";
 
 import { repoLintPluginName } from "./repo-lint-plugin.js";
@@ -10,14 +11,51 @@ import { repoLintPluginName } from "./repo-lint-plugin.js";
 const projectRoot = path.resolve(import.meta.dirname, "../../..");
 
 /**
+ * The plugins carrying the syntax restrictions this repository lints with.
+ *
+ * `@kensio/smartass` is here rather than left to its own tests because its
+ * advice reaching this repository is what has failed before: under ESLint it
+ * arrived as a `no-restricted-syntax` block, and a second config setting the
+ * same rule turned it off for 265 commits with nothing to say so.
+ */
+const jsPlugins: readonly {
+  readonly name: string;
+  readonly specifier: string;
+}[] = [
+  {
+    name: repoLintPluginName,
+    specifier: path.join(
+      projectRoot,
+      "src",
+      "config",
+      "lint",
+      "repo-lint-plugin.ts",
+    ),
+  },
+  {
+    name: "smartass",
+    // Oxlint resolves a specifier from the config file's own directory, and
+    // the config this test writes lives outside the repository. Resolving the
+    // package's export here rather than pointing at a path inside it keeps the
+    // test going through the entry point `.oxlintrc.json` names.
+    specifier: fileURLToPath(import.meta.resolve("@kensio/smartass/oxlint")),
+  },
+];
+
+/**
  * A source file that should trip one rule, and the rule it should trip.
  *
- * Reading the plugin's rule list back would prove only that the list exists.
+ * Reading a plugin's rule list back would prove only that the list exists.
  * These prove Oxlint loads the plugin and the selectors match real syntax,
  * which is the part that would break silently.
  */
-const cases: readonly { readonly rule: string; readonly source: string }[] = [
+const cases: readonly {
+  readonly plugin: string;
+  readonly rule: string;
+  readonly source: string;
+}[] = [
   {
+    plugin: repoLintPluginName,
     rule: "assert-defined-guard",
     source: [
       "export function read(value: string | undefined): string {",
@@ -27,6 +65,7 @@ const cases: readonly { readonly rule: string; readonly source: string }[] = [
     ].join("\n"),
   },
   {
+    plugin: repoLintPluginName,
     rule: "assert-not-null-guard",
     source: [
       "export function read(value: string | null): string {",
@@ -36,6 +75,7 @@ const cases: readonly { readonly rule: string; readonly source: string }[] = [
     ].join("\n"),
   },
   {
+    plugin: repoLintPluginName,
     rule: "no-reused-props",
     source: [
       "export class Thing {",
@@ -46,6 +86,7 @@ const cases: readonly { readonly rule: string; readonly source: string }[] = [
     ].join("\n"),
   },
   {
+    plugin: "smartass",
     rule: "prefer-specific-assertions",
     source: [
       "declare function assertIdentical(a: unknown, b: unknown): void;",
@@ -56,12 +97,17 @@ const cases: readonly { readonly rule: string; readonly source: string }[] = [
   },
 ];
 
+/** Every rule under test, turned on and nothing else with it. */
+const enabledRules = Object.fromEntries(
+  cases.map((testCase) => [`${testCase.plugin}/${testCase.rule}`, "error"]),
+);
+
 interface OxlintReport {
   readonly diagnostics: readonly { readonly code: string }[];
 }
 
 /**
- * Lints one source through Oxlint with only this plugin turned on.
+ * Lints one source through Oxlint with only these plugins turned on.
  *
  * The fixture goes outside the repository because Oxlint honours `.gitignore`,
  * and a fixture under the repository's own `.tmp/` would be skipped rather than
@@ -82,24 +128,8 @@ async function lintWithOxlint(source: string): Promise<readonly string[]> {
       JSON.stringify({
         plugins: [],
         categories: { correctness: "off" },
-        jsPlugins: [
-          {
-            name: repoLintPluginName,
-            specifier: path.join(
-              projectRoot,
-              "src",
-              "config",
-              "lint",
-              "repo-lint-plugin.ts",
-            ),
-          },
-        ],
-        rules: {
-          "yulin/assert-defined-guard": "error",
-          "yulin/assert-not-null-guard": "error",
-          "yulin/no-reused-props": "error",
-          "yulin/prefer-specific-assertions": "error",
-        },
+        jsPlugins,
+        rules: enabledRules,
       }),
       "utf8",
     );
@@ -113,9 +143,9 @@ async function lintWithOxlint(source: string): Promise<readonly string[]> {
         "json",
         filePath,
       ],
-      // The working directory is the repository so that the plugin's own import
-      // of @kensio/smartass resolves. Node strips the types itself, so no
-      // loader is passed: tsx in the path breaks eslint-plugin-no-secrets.
+      // The working directory is the repository so that Node resolves what the
+      // plugins import. Node strips the types itself, so no loader is passed:
+      // tsx in the path breaks eslint-plugin-no-secrets.
       { cwd: projectRoot, reject: false },
     );
 
@@ -127,19 +157,19 @@ async function lintWithOxlint(source: string): Promise<readonly string[]> {
   }
 }
 
-describe("Linting this repository with its own plugin", () => {
+describe("Linting this repository with its syntax restriction plugins", () => {
   for (const testCase of cases) {
-    it(`reports ${testCase.rule}`, async () => {
+    it(`reports ${testCase.plugin}/${testCase.rule}`, async () => {
       // Given a file written the way the restriction says not to
       const source = testCase.source;
 
-      // When Oxlint lints it with only this plugin turned on
+      // When Oxlint lints it with only these plugins turned on
       const reported = await lintWithOxlint(source);
 
       // Then the rule for that restriction is what reported it, which means
-      // Oxlint loaded the plugin from TypeScript source and the selector
-      // matched
-      assertArrayIncludes(reported, `${repoLintPluginName}(${testCase.rule})`);
+      // Oxlint loaded the plugin — this repository's from TypeScript source,
+      // smartass's from the package — and the selector matched
+      assertArrayIncludes(reported, `${testCase.plugin}(${testCase.rule})`);
     });
   }
 

--- a/src/config/lint/repo-lint-plugin.ts
+++ b/src/config/lint/repo-lint-plugin.ts
@@ -1,5 +1,3 @@
-import { smartassPreferSpecificAssertions } from "@kensio/smartass/eslint";
-
 import type {
   LintNode,
   LintPlugin,
@@ -30,6 +28,12 @@ import type {
  * configs setting it cannot silently replace each other. That last one is not
  * hypothetical — under ESLint, `@kensio/smartass` setting `no-restricted-syntax`
  * turned this repository's own restrictions off for 265 commits.
+ *
+ * Only this repository's own restrictions live here. The assertion advice from
+ * `@kensio/smartass` used to as well, lifted out of the `no-restricted-syntax`
+ * block in the config it published because there was nothing else to load.
+ * Since 1.37.0 it publishes a real Oxlint plugin, so `.oxlintrc.json` loads
+ * `smartass/prefer-specific-assertions` from the package instead.
  */
 
 /**
@@ -70,78 +74,38 @@ export const repoSyntaxRestrictions = {
 } satisfies Readonly<Record<string, RepoSyntaxRestriction>>;
 
 /**
- * The name the assertion advice from `@kensio/smartass` is reported under.
+ * The one message id every rule here reports under.
+ *
+ * Each restriction is its own rule, so a rule never has a second message to
+ * tell apart from this one.
  */
-export const preferSpecificAssertionsRuleName = "prefer-specific-assertions";
+const messageId = "restriction";
 
 /**
- * Every selector `@kensio/smartass` asks for, read out of its shared config.
- *
- * Smartass ships its advice as a `no-restricted-syntax` block rather than as a
- * plugin, so there is nothing to load: the selectors have to be lifted out of
- * the config it publishes and rehoused in a rule here. Reading them rather than
- * copying them is what stops the two drifting.
+ * Builds the rule that reports one restriction.
  */
-export function smartassSyntaxRestrictions(): readonly RepoSyntaxRestriction[] {
-  return smartassPreferSpecificAssertions.flatMap((config) => {
-    const entry = (config as { rules?: Record<string, unknown> }).rules?.[
-      "no-restricted-syntax"
-    ];
-
-    return Array.isArray(entry)
-      ? (entry.slice(1) as readonly RepoSyntaxRestriction[])
-      : [];
-  });
-}
-
-/**
- * Builds one rule from the restrictions that share a concern.
- *
- * A visitor is keyed by selector, so two restrictions matching the same syntax
- * would leave only the later message. The selectors are distinct today, and
- * `repo-lint-plugin.iso.test.ts` fails if one goes missing.
- */
-function messageId(index: number): string {
-  return `restriction${String(index)}`;
-}
-
-function restrictionRule(
-  restrictions: readonly RepoSyntaxRestriction[],
-): LintRule {
+function restrictionRule(restriction: RepoSyntaxRestriction): LintRule {
   return {
     meta: {
       type: "problem",
       schema: [],
-      messages: Object.fromEntries(
-        restrictions.map((restriction, index) => [
-          messageId(index),
-          restriction.message,
-        ]),
-      ),
+      messages: { [messageId]: restriction.message },
     },
-    create: (context: LintRuleContext): LintVisitor =>
-      Object.fromEntries(
-        restrictions.map((restriction, index) => [
-          restriction.selector,
-          (node: LintNode): void => {
-            context.report({ node, messageId: messageId(index) });
-          },
-        ]),
-      ),
+    create: (context: LintRuleContext): LintVisitor => ({
+      [restriction.selector]: (node: LintNode): void => {
+        context.report({ node, messageId });
+      },
+    }),
   };
 }
 
 function buildRules(): Record<string, LintRule> {
-  const own = Object.entries(repoSyntaxRestrictions).map(
-    ([name, restriction]) => [name, restrictionRule([restriction])] as const,
+  return Object.fromEntries(
+    Object.entries(repoSyntaxRestrictions).map(([name, restriction]) => [
+      name,
+      restrictionRule(restriction),
+    ]),
   );
-
-  return {
-    ...Object.fromEntries(own),
-    [preferSpecificAssertionsRuleName]: restrictionRule(
-      smartassSyntaxRestrictions(),
-    ),
-  };
 }
 
 /**

--- a/src/service/apigatewayv2/api/authorizer/sim-http-api-jwt-verification.iso.test.ts
+++ b/src/service/apigatewayv2/api/authorizer/sim-http-api-jwt-verification.iso.test.ts
@@ -261,7 +261,7 @@ describe("Validating the claims of a token a JWT authorizer accepted", () => {
     const claims = authorization.jwt?.claims ?? {};
     assertIdentical(claims["cognito:groups"], "[Admins Readers]");
     assertIdentical(claims["auth_time"], String(nowSeconds));
-    // oxlint-disable-next-line yulin/prefer-specific-assertions -- the expected value is the string a boolean claim renders as, not a boolean.
+    // oxlint-disable-next-line smartass/prefer-specific-assertions -- the expected value is the string a boolean claim renders as, not a boolean.
     assertIdentical(claims["email_verified"], "true");
     assertIdentical(claims["address"], '{"formatted":"1 Test Street"}');
     assertIdentical(


### PR DESCRIPTION
Since 1.37.0, `@kensio/smartass` publishes its assertion advice as an Oxlint plugin, so this repository loads `smartass/prefer-specific-assertions` from the package rather than lifting the 47 selectors out of the `no-restricted-syntax` block in the ESLint config it publishes and rehousing them in the `yulin` plugin. That rehousing existed only because there was nothing to load; with it gone, every rule in `repo-lint-plugin.ts` carries exactly one restriction, which takes the message-id indexing with it. Reviewers may want to look at the local test, which keeps proving the advice actually reaches this repository — the failure mode that went unnoticed for 265 commits — by loading the published plugin through Oxlint and asserting it reports; it resolves the specifier with `import.meta.resolve` because Oxlint resolves a `jsPlugins` entry from the config file's own directory, and that test writes its config outside the repository. Verified beyond the usual gate by linting a throwaway `assertIdentical(value, true)` under the real config, which reports the rule rather than passing silently.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated linting integration to use Smartass’s dedicated Oxlint plugin.
  * Repository-specific lint rules are now reported individually for clearer diagnostics.
  * Updated lint configuration and test coverage to reflect the new rule ownership.

* **Bug Fixes**
  * Corrected lint suppression directives for boolean claim assertions.

* **Chores**
  * Updated Smartass tooling to version 1.37.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->