### PR TITLE
fix: resolve an S3 Origin in its owning Account

### DIFF
--- a/src/service/aws/factory/sim-aws-account-service-cache.ts
+++ b/src/service/aws/factory/sim-aws-account-service-cache.ts
@@ -92,7 +92,7 @@ export class SimAwsAccountServiceCache {
         new SimCloudFront({
           accountRegionScope: scope.accountRegionScope,
           cloudFrontRegistry: this.cloudFrontRegistry,
-          s3OriginResolver: makeSimCfS3OriginResolver(this.simAws, scope),
+          s3OriginResolver: makeSimCfS3OriginResolver(this.simAws),
           customOriginDispatcher: makeSimCfCustomOriginDispatcher(this.simAws),
           iam,
           acmRegistry: this.acmRegistry,

--- a/src/service/cloudfront/README.md
+++ b/src/service/cloudfront/README.md
@@ -179,7 +179,10 @@ The key integration points are:
 - `SimCloudFrontRegistry`, which records Distribution ownership and alternate domain routing
   information across the broader simulated AWS instance.
 - S3 Origin resolution, which lets CloudFront Distributions fetch from simulated S3 buckets and S3
-  website Origins.
+  website Origins. `makeSimCfS3OriginResolver` resolves an Origin domain to the Bucket in the
+  Account and Region that own it, which need not be where the Distribution was created: real
+  CloudFront checks neither ownership nor existence at CreateDistribution, and what a Distribution
+  may read is the Bucket policy's business.
 - `SimCfCustomOriginDispatcher`, which resolves a custom Origin domain through simulated Route53 and
   serves the request over the same in-process HTTP entry point as a request arriving on localhost.
   CloudFront therefore needs no per-service knowledge: an HTTP API endpoint, a Lambda Function URL

--- a/src/service/cloudfront/origin/s3/sim-cf-s3-origin-cross-account.iso.test.ts
+++ b/src/service/cloudfront/origin/s3/sim-cf-s3-origin-cross-account.iso.test.ts
@@ -1,0 +1,184 @@
+import {
+  CreateDistributionCommand,
+  type DistributionConfig,
+} from "@aws-sdk/client-cloudfront";
+import { CreateBucketCommand, PutObjectCommand } from "@aws-sdk/client-s3";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertResponseStatus,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  describeResponse,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimAwsServiceRequest } from "../../../../serve/controller/sim-service-controller.js";
+import { SimCloudFrontServiceController } from "../../controller/sim-cloudfront-controller.js";
+
+/**
+ * A minimal DistributionConfig with one S3 Origin on the given domain.
+ */
+function distributionConfig(originDomainName: string): DistributionConfig {
+  return {
+    CallerReference: `s3-origin-${originDomainName}`,
+    Comment: "S3 Origin resolution test distribution",
+    Enabled: true,
+    Origins: {
+      Quantity: 1,
+      Items: [
+        {
+          Id: "site-origin",
+          DomainName: originDomainName,
+          S3OriginConfig: { OriginAccessIdentity: "" },
+        },
+      ],
+    },
+    DefaultCacheBehavior: {
+      TargetOriginId: "site-origin",
+      ViewerProtocolPolicy: "allow-all",
+    },
+  };
+}
+
+/**
+ * Make a request through a Distribution over its CloudFront hostname.
+ */
+async function fetchThroughDistribution(
+  simAws: SimAws,
+  distributionId: string,
+  path: string,
+): Promise<Response> {
+  const host = `${distributionId}.cloudfront.net.sim-aws.localhost`;
+
+  return new SimCloudFrontServiceController({ simAws }).handleRequest(
+    new SimAwsServiceRequest({
+      target: { service: "cloudFront", resourceName: "" },
+      request: new Request(`http://${host}${path}`, { headers: { host } }),
+    }),
+  );
+}
+
+describe("Sim CloudFront S3 Origin Bucket resolution", () => {
+  it("serves an S3 Origin Bucket owned by another Account", async () => {
+    // Given a Bucket holding a page in one Account.
+    const simAws = new SimAws();
+    const bucketS3 = simAws.account("222222222222").region("eu-west-2").s3();
+
+    await bucketS3.createBucket(
+      new CreateBucketCommand({ Bucket: "other-account-bucket" }),
+    );
+    await bucketS3.putObject(
+      new PutObjectCommand({
+        Bucket: "other-account-bucket",
+        Key: "index.html",
+        ContentType: "text/html",
+        Body: "<h1>From the other Account</h1>",
+      }),
+    );
+
+    // When a Distribution in a different Account takes it as an S3 Origin.
+    const distributionCreation = await simAws
+      .account("111111111111")
+      .cloudFront()
+      .createDistribution(
+        new CreateDistributionCommand({
+          DistributionConfig: distributionConfig(
+            "other-account-bucket.s3.eu-west-2.amazonaws.com",
+          ),
+        }),
+      );
+
+    const distributionId = distributionCreation.Distribution?.Id;
+    assertNonNullable(distributionId);
+
+    // Then the Distribution is created, and a request through it reads the
+    // Bucket in the Account that owns it.
+    const response = await fetchThroughDistribution(
+      simAws,
+      distributionId,
+      "/index.html",
+    );
+
+    assertResponseStatus(response, 200, await describeResponse(response));
+    assertIdentical(await response.text(), "<h1>From the other Account</h1>");
+  });
+
+  it("serves an S3 Origin Bucket in another Region of the same Account", async () => {
+    // Given a Bucket holding a page in one Region of an Account.
+    const simAws = new SimAws();
+    const account = simAws.account("111111111111");
+    const bucketS3 = account.region("us-east-1").s3();
+
+    await bucketS3.createBucket(
+      new CreateBucketCommand({ Bucket: "other-region-bucket" }),
+    );
+    await bucketS3.putObject(
+      new PutObjectCommand({
+        Bucket: "other-region-bucket",
+        Key: "index.html",
+        ContentType: "text/html",
+        Body: "<h1>From the other Region</h1>",
+      }),
+    );
+
+    // When a Distribution created in another Region of that Account takes it
+    // as an S3 Origin.
+    const distributionCreation = await account
+      .region("eu-west-2")
+      .cloudFront()
+      .createDistribution(
+        new CreateDistributionCommand({
+          DistributionConfig: distributionConfig(
+            "other-region-bucket.s3.us-east-1.amazonaws.com",
+          ),
+        }),
+      );
+
+    const distributionId = distributionCreation.Distribution?.Id;
+    assertNonNullable(distributionId);
+
+    // Then the Origin still resolves to that Bucket and serves from it.
+    const response = await fetchThroughDistribution(
+      simAws,
+      distributionId,
+      "/index.html",
+    );
+
+    assertResponseStatus(response, 200, await describeResponse(response));
+    assertIdentical(await response.text(), "<h1>From the other Region</h1>");
+  });
+
+  it("refuses an Origin domain naming no Bucket in any Account", async () => {
+    // Given a simulation holding a Bucket of another name.
+    const simAws = new SimAws();
+
+    await simAws
+      .account("222222222222")
+      .s3()
+      .createBucket(new CreateBucketCommand({ Bucket: "a-different-bucket" }));
+
+    // When a Distribution names a Bucket no Account has.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws
+        .account("111111111111")
+        .cloudFront()
+        .createDistribution(
+          new CreateDistributionCommand({
+            DistributionConfig: distributionConfig(
+              "no-such-bucket.s3.eu-west-2.amazonaws.com",
+            ),
+          }),
+        );
+    });
+
+    // Then creation fails saying which Bucket could not be found.
+    assertInstanceOf(error, Error);
+    assertStringIncludes(
+      error.message,
+      "Unable to find sim S3 Bucket no-such-bucket for sim CloudFront S3 Origin",
+    );
+  });
+});

--- a/src/service/cloudfront/origin/s3/sim-cf-s3-origin-resolver-factory.ts
+++ b/src/service/cloudfront/origin/s3/sim-cf-s3-origin-resolver-factory.ts
@@ -1,15 +1,19 @@
 import type { SimAws } from "../../../aws/sim-aws.js";
-import type { SimAwsAccountRegionContainer } from "../../../aws/sim-aws-account-region-scope.js";
 import type { SimCloudFrontS3OriginResolver } from "./sim-cloudfront-s3-origin.js";
 import { bucketNameFromCfS3OriginDomainName } from "./sim-cf-s3-origin-bucket-name.js";
 import { assertDefined } from "../../../../util/type-guard/defined.js";
 
 /**
  * Create an S3 Origin Resolver backed by a simulated AWS Account/Region scope.
+ *
+ * The Bucket is resolved in the Account and Region that own it, which is not
+ * necessarily where the Distribution was created: serving a Bucket owned by
+ * one Account from a Distribution in another is ordinary, and real CloudFront
+ * checks neither ownership nor existence when a Distribution is created. What
+ * the Distribution may read is left to the Bucket policy.
  */
 export function makeSimCfS3OriginResolver(
   simAws: SimAws,
-  scope: SimAwsAccountRegionContainer,
 ): SimCloudFrontS3OriginResolver {
   return (originDomainName: string) => {
     const bucketName = bucketNameFromCfS3OriginDomainName(originDomainName);
@@ -20,8 +24,7 @@ export function makeSimCfS3OriginResolver(
     );
 
     return simAws
-      .region(bucketScope.regionName)
-      .account(scope.account.accountId)
+      .accountRegionScope(bucketScope.accountId, bucketScope.regionName)
       .s3()
       .getSimBucketByName(bucketName);
   };


### PR DESCRIPTION
A CloudFront S3 Origin was looked up in the Bucket's own Region but the Distribution's Account, so a Bucket owned by another Account resolved to nothing and creating the Distribution failed with a Bucket-not-found assertion. It now resolves against both halves of the scope `findBucketScope` already returns, which is where the Bucket actually is. Real CloudFront checks neither ownership nor existence at CreateDistribution, so nothing is refused on the grounds of which Account created the Distribution, and what a Distribution may read is left to the Bucket policy.

The `scope` argument to `makeSimCfS3OriginResolver` is no longer read, so it and its one call site have gone. New colocated `sim-cf-s3-origin-cross-account.iso.test.ts` covers a cross-account Origin creating and serving an object, a same-Account cross-Region Origin still working, and an Origin domain naming no Bucket in any Account still failing by name. The first of those reproduces the issue's `RequiredValueUndefinedError` exactly on the unfixed resolver.

This touches the same resolver as #493, so it is deliberately small.

Resolves #496

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - CloudFront S3 origins can now resolve buckets across accounts and regions.
  - Access to cross-account or cross-region buckets is governed by the bucket’s policy.
- **Bug Fixes**
  - Improved S3 origin resolution so distributions use the bucket’s actual ownership and region.
  - Requests now clearly reject configurations that reference non-existent buckets.
- **Documentation**
  - Updated CloudFront guidance to explain cross-account and cross-region S3 origin behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->