### PR TITLE
feat: create an origin access control from CloudFormation

### DIFF
--- a/docs/services/cloudfront/README.md
+++ b/docs/services/cloudfront/README.md
@@ -896,6 +896,100 @@ The policy is applied after a custom error response is fetched and before a `vie
 CloudFront Function runs, as CloudFront does. An error page carries the policy's headers, and a
 function sees them in `event.response.headers` and can change them.
 
+## Origin access controls
+
+An origin access control is how a Distribution authenticates to a private S3 Bucket. Declare one as
+`AWS::CloudFront::OriginAccessControl` and point an Origin's `OriginAccessControlId` at it with a
+`Ref`, which is what CDK's `S3BucketOrigin.withOriginAccessControl` synthesizes.
+
+Read the first paragraph of [Limitations](#limitations) before relying on this. Sim CloudFront
+stores an origin access control and reports it back, and it does not yet sign the Origin request or
+decide whether the Distribution may read the Bucket.
+
+```typescript sim-cloudfront-origin-access-control
+/**
+ * Giving a Distribution's S3 Origin an origin access control.
+ */
+
+import { GetDistributionCommand } from "@aws-sdk/client-cloudfront";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "site-stack",
+  template: {
+    Resources: {
+      SiteBucket: {
+        Type: "AWS::S3::Bucket",
+        Properties: { BucketName: "site-bucket" },
+      },
+      SiteOac: {
+        Type: "AWS::CloudFront::OriginAccessControl",
+        Properties: {
+          OriginAccessControlConfig: {
+            Name: "site-oac",
+            OriginAccessControlOriginType: "s3",
+            SigningBehavior: "always",
+            SigningProtocol: "sigv4",
+          },
+        },
+      },
+      SiteDistribution: {
+        Type: "AWS::CloudFront::Distribution",
+        DependsOn: ["SiteBucket", "SiteOac"],
+        Properties: {
+          DistributionConfig: {
+            Enabled: true,
+            Origins: [
+              {
+                Id: "SiteOrigin",
+                DomainName: "site-bucket.s3.amazonaws.com",
+                S3OriginConfig: {},
+                OriginAccessControlId: { Ref: "SiteOac" },
+              },
+            ],
+            DefaultCacheBehavior: {
+              TargetOriginId: "SiteOrigin",
+              ViewerProtocolPolicy: "allow-all",
+            },
+          },
+        },
+      },
+    },
+    Outputs: {
+      DistributionId: { Value: { Ref: "SiteDistribution" } },
+    },
+  },
+});
+
+await stack.waitForDeployComplete();
+
+const distributionId = stack.outputs.get("DistributionId")?.value as string;
+const output = await simAws
+  .cloudFront()
+  .getDistribution(new GetDistributionCommand({ Id: distributionId }));
+
+const [origin] = output.Distribution?.DistributionConfig?.Origins?.Items ?? [];
+
+// The ID the Ref resolved to, which is the origin access control the Origin
+// was created with.
+console.log(origin?.OriginAccessControlId);
+```
+
+`Ref` and `Fn::GetAtt` on `Id` both return the ID, so either resolves an Origin's
+`OriginAccessControlId`. An Origin naming an ID no origin access control holds is refused with
+`InvalidOriginAccessControl` when the Distribution is created, rather than created without one.
+Tearing the Stack down removes the origin access control, and its name is free again.
+
+`OriginAccessControlOriginType` must be `s3` and `SigningProtocol` must be `sigv4`. Any other value
+fails the Stack by name. `SigningBehavior` takes any of `always`, `never` and `no-override`, and is
+stored as written.
+
+There is no `CreateOriginAccessControl` command here, so a CloudFormation template is the only way
+to make one.
+
 ## Available functionality
 
 Sim CloudFront currently supports:
@@ -910,6 +1004,7 @@ Sim CloudFront currently supports:
 - `DefaultRootObject` and `CustomErrorResponses`, for static sites and single-page apps
 - `viewer-request` and `viewer-response` CloudFront Functions
 - `AWS::CloudFront::ResponseHeadersPolicy`, for headers a cache Behavior sets on every response
+- `AWS::CloudFront::OriginAccessControl`, stored against the Origin that names it
 - Viewer certificates from sim ACM, including CloudFront's `us-east-1` requirement
 - Serving simulated CloudFront traffic on localhost with `serveSimAws`
 
@@ -921,6 +1016,20 @@ whether the simulator needs them to model the requested behaviour safely.
 
 Where sim CloudFront knowingly behaves differently from AWS:
 
+- **An origin access control is stored and reported, and nothing else.** The Origin request is not
+  signed, and the Bucket policy is not consulted, so a Distribution reads its S3 Origin the same way
+  with an origin access control as without one. A test can assert that an Origin was given the
+  right origin access control, and cannot yet tell a Bucket policy that grants the Distribution
+  apart from one that grants nothing.
+- **An origin access control only signs for an S3 Origin with SigV4.** CloudFront also signs for
+  MediaStore, MediaPackage V2 and Lambda Function URL Origins, and none of those is modelled. An
+  `OriginAccessControlOriginType` other than `s3`, or a `SigningProtocol` other than `sigv4`, fails
+  the Stack by naming the value, rather than deploying and behaving like an S3 one. For the same
+  reason, a custom Origin naming an origin access control is refused.
+- **An origin access control name is unique, but nothing else about it is checked.** A second one
+  claiming a name is refused with `OriginAccessControlAlreadyExists`, as CloudFront refuses one.
+- **There is no command surface for an origin access control.** `CreateOriginAccessControl` and its
+  siblings are not simulated, so `AWS::CloudFront::OriginAccessControl` is the only way to make one.
 - **`IfMatch` ETags are not checked.** `UpdateDistributionCommand`, `DeleteDistributionCommand` and
   `DeleteFunctionCommand` all accept `IfMatch` and ignore it, so neither `PreconditionFailed` nor
   `InvalidIfMatchVersion` is ever returned. Nothing else here versions a resource, and a stale ETag

--- a/docs/services/cloudfront/sim-cloudfront-origin-access-control.example.ts
+++ b/docs/services/cloudfront/sim-cloudfront-origin-access-control.example.ts
@@ -1,0 +1,69 @@
+/**
+ * Giving a Distribution's S3 Origin an origin access control.
+ */
+
+import { GetDistributionCommand } from "@aws-sdk/client-cloudfront";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "site-stack",
+  template: {
+    Resources: {
+      SiteBucket: {
+        Type: "AWS::S3::Bucket",
+        Properties: { BucketName: "site-bucket" },
+      },
+      SiteOac: {
+        Type: "AWS::CloudFront::OriginAccessControl",
+        Properties: {
+          OriginAccessControlConfig: {
+            Name: "site-oac",
+            OriginAccessControlOriginType: "s3",
+            SigningBehavior: "always",
+            SigningProtocol: "sigv4",
+          },
+        },
+      },
+      SiteDistribution: {
+        Type: "AWS::CloudFront::Distribution",
+        DependsOn: ["SiteBucket", "SiteOac"],
+        Properties: {
+          DistributionConfig: {
+            Enabled: true,
+            Origins: [
+              {
+                Id: "SiteOrigin",
+                DomainName: "site-bucket.s3.amazonaws.com",
+                S3OriginConfig: {},
+                OriginAccessControlId: { Ref: "SiteOac" },
+              },
+            ],
+            DefaultCacheBehavior: {
+              TargetOriginId: "SiteOrigin",
+              ViewerProtocolPolicy: "allow-all",
+            },
+          },
+        },
+      },
+    },
+    Outputs: {
+      DistributionId: { Value: { Ref: "SiteDistribution" } },
+    },
+  },
+});
+
+await stack.waitForDeployComplete();
+
+const distributionId = stack.outputs.get("DistributionId")?.value as string;
+const output = await simAws
+  .cloudFront()
+  .getDistribution(new GetDistributionCommand({ Id: distributionId }));
+
+const [origin] = output.Distribution?.DistributionConfig?.Origins?.Items ?? [];
+
+// The ID the Ref resolved to, which is the origin access control the Origin
+// was created with.
+console.log(origin?.OriginAccessControlId);

--- a/src/service/cloudformation/resource/cfn/cloudfront/sim-cloudfront-cfn-value-adapter.ts
+++ b/src/service/cloudformation/resource/cfn/cloudfront/sim-cloudfront-cfn-value-adapter.ts
@@ -4,6 +4,8 @@ import { SimCloudFrontFunction } from "../../../../cloudfront/cff/sim-cloudfront
 import { SimCloudFrontFunctionCfn } from "./sim-cloudfront-function-cfn.js";
 import { SimCloudFrontResponseHeadersPolicy } from "../../../../cloudfront/response-headers-policy/sim-cf-response-headers-policy.js";
 import { SimCloudFrontResponseHeadersPolicyCfn } from "./sim-cloudfront-rh-policy-cfn.js";
+import { SimCloudFrontOriginAccessControl } from "../../../../cloudfront/origin-access-control/sim-cf-origin-access-control.js";
+import { SimCloudFrontOriginAccessControlCfn } from "./sim-cloudfront-oac-cfn.js";
 import type {
   SimCfnResourceValueAdapterProperties,
   SimCfnServiceValueAdapter,
@@ -37,6 +39,15 @@ export function cloudFrontValueAdapter(
   ) {
     return new SimCloudFrontResponseHeadersPolicyCfn({
       policy: properties.simResource,
+    });
+  }
+
+  if (
+    properties.type === "AWS::CloudFront::OriginAccessControl" &&
+    properties.simResource instanceof SimCloudFrontOriginAccessControl
+  ) {
+    return new SimCloudFrontOriginAccessControlCfn({
+      originAccessControl: properties.simResource,
     });
   }
 

--- a/src/service/cloudformation/resource/cfn/cloudfront/sim-cloudfront-oac-cfn.iso.test.ts
+++ b/src/service/cloudformation/resource/cfn/cloudfront/sim-cloudfront-oac-cfn.iso.test.ts
@@ -1,0 +1,44 @@
+import { assertIdentical, assertInstanceOf } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimCloudFrontOriginAccessControl } from "../../../../cloudfront/origin-access-control/sim-cf-origin-access-control.js";
+import { cloudFrontValueAdapter } from "./sim-cloudfront-cfn-value-adapter.js";
+import { SimCloudFrontOriginAccessControlCfn } from "./sim-cloudfront-oac-cfn.js";
+
+describe("SimCloudFrontOriginAccessControlCfn", () => {
+  const originAccessControl = new SimCloudFrontOriginAccessControl({
+    name: "site-oac",
+    signingBehavior: "always",
+  });
+  const adapter = new SimCloudFrontOriginAccessControlCfn({
+    originAccessControl,
+  });
+
+  it("answers a Ref with the origin access control ID", () => {
+    // Given a created origin access control.
+    // When a template Refs it, then it gets the ID an Origin's
+    // OriginAccessControlId wants.
+    assertIdentical(adapter.refValue(), originAccessControl.id);
+  });
+
+  it("answers the Id attribute with the same ID", () => {
+    // Given a created origin access control.
+    // When a template reads its Id attribute, then it gets the same ID a Ref
+    // gives, which is what CDK's L1 construct reads.
+    assertIdentical(adapter.attributeValue("Id"), originAccessControl.id);
+  });
+
+  it("is the adapter the CloudFront registry picks for the Resource type", () => {
+    // Given a created origin access control stored against its Resource type.
+    // When the CloudFront value adapter registry is asked for one.
+    const resolved = cloudFrontValueAdapter({
+      logicalId: "SiteOac",
+      type: "AWS::CloudFront::OriginAccessControl",
+      simResource: originAccessControl,
+    });
+
+    // Then the origin access control's own adapter answers, rather than the
+    // default one, which would answer a Ref with the logical ID.
+    assertInstanceOf(resolved, SimCloudFrontOriginAccessControlCfn);
+  });
+});

--- a/src/service/cloudformation/resource/cfn/cloudfront/sim-cloudfront-oac-cfn.ts
+++ b/src/service/cloudformation/resource/cfn/cloudfront/sim-cloudfront-oac-cfn.ts
@@ -1,0 +1,42 @@
+import type { SimCfnTemplateValue } from "../../../template/value/sim-cfn-template-value.js";
+import type { SimCloudFrontOriginAccessControl } from "../../../../cloudfront/origin-access-control/sim-cf-origin-access-control.js";
+import type { SimCfnResourceValueAdapter } from "../sim-cfn-resource-value-adapter.js";
+
+interface SimCloudFrontOriginAccessControlCfnProperties {
+  readonly originAccessControl: SimCloudFrontOriginAccessControl;
+}
+
+/**
+ * CloudFormation-facing behavior for an AWS::CloudFront::OriginAccessControl
+ * Resource.
+ */
+export class SimCloudFrontOriginAccessControlCfn implements SimCfnResourceValueAdapter {
+  private readonly originAccessControl: SimCloudFrontOriginAccessControl;
+
+  constructor(properties: SimCloudFrontOriginAccessControlCfnProperties) {
+    this.originAccessControl = properties.originAccessControl;
+  }
+
+  /**
+   * CloudFormation Ref for AWS::CloudFront::OriginAccessControl returns the ID,
+   * which is what an Origin's OriginAccessControlId wants.
+   */
+  refValue(): SimCfnTemplateValue {
+    return this.originAccessControl.id;
+  }
+
+  /**
+   * CloudFormation attributes for AWS::CloudFront::OriginAccessControl.
+   */
+  attributeValue(attributeName: string): SimCfnTemplateValue {
+    switch (attributeName) {
+      case "Id": {
+        return this.originAccessControl.id;
+      }
+      default: {
+        /* v8 ignore next */
+        return `${this.originAccessControl.id}.${attributeName}`;
+      }
+    }
+  }
+}

--- a/src/service/cloudfront/README.md
+++ b/src/service/cloudfront/README.md
@@ -170,6 +170,25 @@ A lookup miss is `SimCloudFrontNoSuchResponseHeadersPolicy` rather than a pass-t
 common cause is a managed policy ID, which names a policy AWS owns rather than one a template
 creates.
 
+## Origin access controls
+
+`origin-access-control/` holds the model and its registry, laid out the same way as the response
+headers policies above. A `SimCloudFrontOriginAccessControl` is a name, an ID, an optional
+description and a signing behaviour. The origin type and signing protocol are fixed at `s3` and
+`sigv4`, because `cfn/origin-access-control/` refuses any other value by name rather than storing
+one the simulator would then treat as an S3 origin access control. There is no
+CreateOriginAccessControl command, so a template is the only thing that makes one.
+
+`SimCloudFrontOriginConfigurator` resolves an Origin's `OriginAccessControlId` through the registry
+when the Distribution is created, and stores the result on the `SimCloudFrontS3Origin`. An ID
+nothing created is `SimCloudFrontInvalidOriginAccessControl`, as CloudFront refuses the whole
+CreateDistribution. Resolution is eager here, unlike a response headers policy, because CloudFront
+checks an origin access control at creation rather than when a request arrives.
+
+Nothing reads the stored origin access control yet. It does not sign the Origin request and does not
+decide whether the Bucket may be read, so a Distribution serves its S3 Origin the same way with one
+as without.
+
 ## Cross-service integration
 
 CloudFront often depends on other simulated services.

--- a/src/service/cloudfront/cfn/origin-access-control/sim-cfn-cf-oac-config.iso.test.ts
+++ b/src/service/cloudfront/cfn/origin-access-control/sim-cfn-cf-oac-config.iso.test.ts
@@ -1,0 +1,175 @@
+import {
+  assertIdentical,
+  assertStringIncludes,
+  assertThrowsError,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimCloudFrontOriginAccessControl } from "../../origin-access-control/sim-cf-origin-access-control.js";
+import { SimCfnCfOriginAccessControlConfig } from "./sim-cfn-cf-oac-config.js";
+
+describe("SimCfnCfOriginAccessControlConfig", () => {
+  const resource = new SimCfnResource({ logicalId: "SiteOac" });
+
+  function originAccessControlFrom(
+    config: SimCfnTemplateValueRecord,
+  ): SimCloudFrontOriginAccessControl {
+    return new SimCfnCfOriginAccessControlConfig({
+      resource,
+      properties: {
+        OriginAccessControlConfig: {
+          Name: "site-oac",
+          OriginAccessControlOriginType: "s3",
+          SigningBehavior: "always",
+          SigningProtocol: "sigv4",
+          ...config,
+        },
+      },
+    }).build();
+  }
+
+  function refusalFrom(config: SimCfnTemplateValueRecord): string {
+    return assertThrowsError(() => originAccessControlFrom(config)).message;
+  }
+
+  it("reads the config CDK synthesizes for an S3 origin", () => {
+    // Given the config CDK emits for S3BucketOrigin.withOriginAccessControl.
+    const originAccessControl = originAccessControlFrom({});
+
+    // Then the name and signing behaviour are read, and the supported origin
+    // type and protocol are what the origin access control reports.
+    assertIdentical(originAccessControl.name, "site-oac");
+    assertIdentical(originAccessControl.signingBehavior, "always");
+    assertIdentical(originAccessControl.originType, "s3");
+    assertIdentical(originAccessControl.signingProtocol, "sigv4");
+    assertUndefined(originAccessControl.description);
+  });
+
+  it("reads a description", () => {
+    // Given a config carrying the optional description.
+    const originAccessControl = originAccessControlFrom({
+      Description: "Signs reads of the site bucket",
+    });
+
+    assertIdentical(
+      originAccessControl.description,
+      "Signs reads of the site bucket",
+    );
+  });
+
+  it("reads each signing behaviour CloudFront offers", () => {
+    // Given each of the three signing behaviours.
+    for (const signingBehavior of ["always", "never", "no-override"] as const) {
+      const originAccessControl = originAccessControlFrom({
+        SigningBehavior: signingBehavior,
+      });
+
+      // Then each is stored as written rather than refused.
+      assertIdentical(originAccessControl.signingBehavior, signingBehavior);
+    }
+  });
+
+  it("refuses an origin type it does not sign for", () => {
+    // Given a config for a Lambda Function URL Origin, which CloudFront signs
+    // for and this simulation does not.
+    const message = refusalFrom({
+      OriginAccessControlOriginType: "lambda",
+    });
+
+    // Then it is refused by name, rather than stored and treated as an S3
+    // origin access control.
+    assertStringIncludes(
+      message,
+      "Invalid AWS::CloudFront::OriginAccessControl SiteOac",
+    );
+    assertStringIncludes(message, "OriginAccessControlOriginType lambda");
+  });
+
+  it("refuses a missing origin type", () => {
+    // Given a config with no origin type, which the CloudFormation schema
+    // requires.
+    const error = assertThrowsError(() =>
+      new SimCfnCfOriginAccessControlConfig({
+        resource,
+        properties: {
+          OriginAccessControlConfig: {
+            Name: "site-oac",
+            SigningBehavior: "always",
+            SigningProtocol: "sigv4",
+          },
+        },
+      }).build(),
+    );
+
+    assertStringIncludes(
+      error.message,
+      "OriginAccessControlOriginType undefined",
+    );
+  });
+
+  it("refuses a signing protocol it cannot sign with", () => {
+    // Given a config naming a protocol other than SigV4.
+    const message = refusalFrom({ SigningProtocol: "sigv2" });
+
+    assertStringIncludes(message, "SigningProtocol sigv2");
+  });
+
+  it("refuses a signing behaviour that is not one of CloudFront's", () => {
+    // Given a config naming a signing behaviour CloudFront has no such value
+    // for.
+    const message = refusalFrom({ SigningBehavior: "sometimes" });
+
+    assertStringIncludes(message, "SigningBehavior sometimes");
+    assertStringIncludes(message, "always, never, no-override");
+  });
+
+  it("refuses a name that is not a string", () => {
+    // Given a config whose Name did not resolve to a string.
+    const message = refusalFrom({ Name: 42 });
+
+    assertStringIncludes(message, "Name must be a string");
+  });
+
+  it("refuses a missing name", () => {
+    // Given a config with no Name, which the CloudFormation schema requires.
+    const error = assertThrowsError(() =>
+      new SimCfnCfOriginAccessControlConfig({
+        resource,
+        properties: {
+          OriginAccessControlConfig: {
+            OriginAccessControlOriginType: "s3",
+            SigningBehavior: "always",
+            SigningProtocol: "sigv4",
+          },
+        },
+      }).build(),
+    );
+
+    assertStringIncludes(error.message, "Name must be a string");
+  });
+
+  it("refuses a description that is not a string", () => {
+    // Given a config whose Description did not resolve to a string.
+    const message = refusalFrom({ Description: 42 });
+
+    assertStringIncludes(message, "Description must be a string");
+  });
+
+  it("refuses a config that is not an object", () => {
+    // Given a Resource with no OriginAccessControlConfig at all.
+    const error = assertThrowsError(() =>
+      new SimCfnCfOriginAccessControlConfig({
+        resource,
+        properties: {},
+      }).build(),
+    );
+
+    assertStringIncludes(
+      error.message,
+      "OriginAccessControlConfig must be an object",
+    );
+  });
+});

--- a/src/service/cloudfront/cfn/origin-access-control/sim-cfn-cf-oac-config.ts
+++ b/src/service/cloudfront/cfn/origin-access-control/sim-cfn-cf-oac-config.ts
@@ -1,0 +1,145 @@
+import { isRecord } from "../../../../util/type-guard/record.js";
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import {
+  SimCloudFrontOriginAccessControl,
+  type SimCloudFrontOriginAccessControlSigningBehavior,
+} from "../../origin-access-control/sim-cf-origin-access-control.js";
+
+/**
+ * The config values a simulated origin access control is fixed to.
+ *
+ * CloudFront also signs for MediaStore, MediaPackage V2 and Lambda Function URL
+ * Origins, and none of those is modelled. SigV4 is the only protocol CloudFront
+ * offers. Anything else is refused by name rather than stored and treated as
+ * though it behaved like these.
+ */
+const fixedValues = {
+  OriginAccessControlOriginType: "s3",
+  SigningProtocol: "sigv4",
+};
+
+const signingBehaviors: readonly SimCloudFrontOriginAccessControlSigningBehavior[] =
+  ["always", "never", "no-override"];
+
+/**
+ * Reads an AWS::CloudFront::OriginAccessControl Resource into a simulated
+ * origin access control.
+ *
+ * Everything the config carries is required by the CloudFormation schema apart
+ * from the description, so anything missing is a template AWS would refuse
+ * before it reached an origin access control at all.
+ */
+export class SimCfnCfOriginAccessControlConfig {
+  private readonly resource: SimCfnResource;
+  private readonly properties: SimCfnTemplateValueRecord;
+
+  constructor(properties: {
+    readonly resource: SimCfnResource;
+    readonly properties: SimCfnTemplateValueRecord;
+  }) {
+    this.resource = properties.resource;
+    this.properties = properties.properties;
+  }
+
+  /**
+   * Build the simulated origin access control this Resource describes.
+   */
+  build(): SimCloudFrontOriginAccessControl {
+    const config = this.originAccessControlConfig();
+
+    this.assertFixedValues(config);
+
+    const description = this.text(config, "Description");
+
+    return new SimCloudFrontOriginAccessControl({
+      name:
+        this.text(config, "Name") ??
+        this.refuse("OriginAccessControlConfig Name must be a string"),
+      signingBehavior: this.signingBehavior(config),
+      ...(description !== undefined && { description }),
+    });
+  }
+
+  private originAccessControlConfig(): Record<string, unknown> {
+    const config = this.properties["OriginAccessControlConfig"];
+
+    if (!isRecord(config)) {
+      this.refuse("OriginAccessControlConfig must be an object");
+    }
+
+    return config;
+  }
+
+  /**
+   * Refuse a config asking for anything but the one origin type and protocol a
+   * simulated origin access control signs.
+   */
+  private assertFixedValues(config: Record<string, unknown>): void {
+    for (const [key, fixed] of Object.entries(fixedValues)) {
+      // oxlint-disable-next-line security/detect-object-injection
+      const value = config[key];
+
+      if (value !== fixed) {
+        this.refuse(
+          `${key} ${String(value)} is not modelled by simulated origin ` +
+            `access controls, which only sign an ${fixedValues.OriginAccessControlOriginType} Origin with ${fixedValues.SigningProtocol}`,
+        );
+      }
+    }
+  }
+
+  /**
+   * One string field of the config, or nothing when it is absent.
+   */
+  private text(
+    config: Record<string, unknown>,
+    key: string,
+  ): string | undefined {
+    // oxlint-disable-next-line security/detect-object-injection
+    const value = config[key];
+
+    if (value === undefined) {
+      return undefined;
+    }
+
+    if (typeof value !== "string") {
+      this.refuse(`OriginAccessControlConfig ${key} must be a string`);
+    }
+
+    return value;
+  }
+
+  private signingBehavior(
+    config: Record<string, unknown>,
+  ): SimCloudFrontOriginAccessControlSigningBehavior {
+    const value = config["SigningBehavior"];
+
+    if (!isSigningBehavior(value)) {
+      this.refuse(
+        `SigningBehavior ${String(value)} is not one of ${signingBehaviors.join(
+          ", ",
+        )}`,
+      );
+    }
+
+    return value;
+  }
+
+  /**
+   * Refuse this Resource, saying which part of it could not be read.
+   */
+  private refuse(detail: string): never {
+    throw new Error(
+      `Invalid AWS::CloudFront::OriginAccessControl ${this.resource.logicalId}: ${detail}`,
+    );
+  }
+}
+
+function isSigningBehavior(
+  value: unknown,
+): value is SimCloudFrontOriginAccessControlSigningBehavior {
+  return signingBehaviors.includes(
+    value as SimCloudFrontOriginAccessControlSigningBehavior,
+  );
+}

--- a/src/service/cloudfront/cfn/origin-access-control/sim-cfn-cf-oac-creator.ts
+++ b/src/service/cloudfront/cfn/origin-access-control/sim-cfn-cf-oac-creator.ts
@@ -1,0 +1,53 @@
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimCloudFront } from "../../sim-cloudfront.js";
+import type { SimCloudFrontOriginAccessControl } from "../../origin-access-control/sim-cf-origin-access-control.js";
+import { SimCfnCfOriginAccessControlConfig } from "./sim-cfn-cf-oac-config.js";
+
+interface SimCfnCfOriginAccessControlCreatorProperties {
+  readonly cloudFront: SimCloudFront;
+}
+
+/**
+ * Creates simulated origin access controls from
+ * AWS::CloudFront::OriginAccessControl Resources.
+ */
+export class SimCfnCfOriginAccessControlCreator {
+  private readonly cloudFront: SimCloudFront;
+
+  constructor(properties: SimCfnCfOriginAccessControlCreatorProperties) {
+    this.cloudFront = properties.cloudFront;
+  }
+
+  /**
+   * Create and store the origin access control one Resource describes.
+   */
+  create(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): SimCloudFrontOriginAccessControl {
+    const originAccessControl = new SimCfnCfOriginAccessControlConfig({
+      resource,
+      properties,
+    }).build();
+
+    this.cloudFront.addOriginAccessControl(originAccessControl);
+
+    return originAccessControl;
+  }
+
+  /**
+   * Remove an origin access control created from a Resource.
+   */
+  delete(resource: SimCfnResource): void {
+    const originAccessControl = resource.simResource as
+      | SimCloudFrontOriginAccessControl
+      | undefined;
+
+    if (originAccessControl === undefined) {
+      return;
+    }
+
+    this.cloudFront.removeOriginAccessControl(originAccessControl.id);
+  }
+}

--- a/src/service/cloudfront/cfn/origin-access-control/sim-cfn-cf-oac-refusals.iso.test.ts
+++ b/src/service/cloudfront/cfn/origin-access-control/sim-cfn-cf-oac-refusals.iso.test.ts
@@ -1,0 +1,206 @@
+import {
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import type { SimCfnTemplateValue } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import { SimCloudFrontOriginAccessControl } from "../../origin-access-control/sim-cf-origin-access-control.js";
+
+/**
+ * A Stack whose Distribution names an origin access control, deployed with
+ * whatever the Origin should carry.
+ */
+async function deployFailingOrigin(
+  origin: Record<string, SimCfnTemplateValue>,
+): Promise<Error> {
+  const simAws = new SimAws();
+
+  return await assertThrowsErrorAsync(async () => {
+    await simAws.cloudFormation().deployTemplate({
+      stackName: "site-stack",
+      template: {
+        Resources: {
+          SiteBucket: {
+            Type: "AWS::S3::Bucket",
+            Properties: { BucketName: "site-bucket" },
+          },
+          SiteDistribution: {
+            Type: "AWS::CloudFront::Distribution",
+            DependsOn: ["SiteBucket"],
+            Properties: {
+              DistributionConfig: {
+                Enabled: true,
+                Origins: [origin],
+                DefaultCacheBehavior: {
+                  TargetOriginId: "SiteOrigin",
+                  ViewerProtocolPolicy: "redirect-to-https",
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+  });
+}
+
+describe("AWS::CloudFront::OriginAccessControl refusals", () => {
+  it("refuses an Origin naming an origin access control that does not exist", async () => {
+    // Given a Distribution whose Origin names an ID nothing created, which is
+    // what a hand-written template gets wrong.
+    const error = await deployFailingOrigin({
+      Id: "SiteOrigin",
+      DomainName: "site-bucket.s3.amazonaws.com",
+      S3OriginConfig: {},
+      OriginAccessControlId: "E1EXAMPLE12345",
+    });
+
+    // Then the Stack fails when the Distribution is created, naming the ID,
+    // rather than the Origin quietly reading without one.
+    assertStringIncludes(error.message, "E1EXAMPLE12345");
+    assertStringIncludes(error.message, "does not exist");
+  });
+
+  it("refuses an origin access control on a custom Origin", async () => {
+    // Given a custom Origin naming an origin access control, which every one
+    // here signs for an S3 Origin rather than a custom one.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "oac-stack",
+      template: {
+        Resources: {
+          SiteOac: {
+            Type: "AWS::CloudFront::OriginAccessControl",
+            Properties: {
+              OriginAccessControlConfig: {
+                Name: "site-oac",
+                OriginAccessControlOriginType: "s3",
+                SigningBehavior: "always",
+                SigningProtocol: "sigv4",
+              },
+            },
+          },
+        },
+      },
+    });
+    await stack.waitForDeployComplete();
+
+    const originAccessControl = stack.resources.get("SiteOac")?.simResource;
+    assertInstanceOf(originAccessControl, SimCloudFrontOriginAccessControl);
+
+    // When a Distribution attaches it to a custom Origin.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.cloudFormation().deployTemplate({
+        stackName: "site-stack",
+        template: {
+          Resources: {
+            SiteDistribution: {
+              Type: "AWS::CloudFront::Distribution",
+              Properties: {
+                DistributionConfig: {
+                  Enabled: true,
+                  Origins: [
+                    {
+                      Id: "SiteOrigin",
+                      DomainName: "api.example.test",
+                      CustomOriginConfig: {
+                        OriginProtocolPolicy: "https-only",
+                      },
+                      OriginAccessControlId: originAccessControl.id,
+                    },
+                  ],
+                  DefaultCacheBehavior: {
+                    TargetOriginId: "SiteOrigin",
+                    ViewerProtocolPolicy: "redirect-to-https",
+                  },
+                },
+              },
+            },
+          },
+        },
+      });
+    });
+
+    // Then it is refused rather than attached to an Origin it cannot sign for.
+    assertStringIncludes(error.message, "custom Origin SiteOrigin");
+    assertStringIncludes(error.message, "site-oac");
+  });
+
+  it("refuses a second origin access control claiming a name", async () => {
+    // Given a template declaring two origin access controls with one name.
+    const simAws = new SimAws();
+
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.cloudFormation().deployTemplate({
+        stackName: "oac-stack",
+        template: {
+          Resources: {
+            FirstOac: {
+              Type: "AWS::CloudFront::OriginAccessControl",
+              Properties: {
+                OriginAccessControlConfig: {
+                  Name: "site-oac",
+                  OriginAccessControlOriginType: "s3",
+                  SigningBehavior: "always",
+                  SigningProtocol: "sigv4",
+                },
+              },
+            },
+            SecondOac: {
+              Type: "AWS::CloudFront::OriginAccessControl",
+              DependsOn: ["FirstOac"],
+              Properties: {
+                OriginAccessControlConfig: {
+                  Name: "site-oac",
+                  OriginAccessControlOriginType: "s3",
+                  SigningBehavior: "always",
+                  SigningProtocol: "sigv4",
+                },
+              },
+            },
+          },
+        },
+      });
+    });
+
+    // Then the second is refused, as CloudFront refuses it.
+    assertStringIncludes(error.message, "site-oac already exists");
+  });
+
+  it("refuses an origin type it does not sign for", async () => {
+    // Given a template asking for a Lambda Function URL origin access control.
+    const simAws = new SimAws();
+
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.cloudFormation().deployTemplate({
+        stackName: "oac-stack",
+        template: {
+          Resources: {
+            ApiOac: {
+              Type: "AWS::CloudFront::OriginAccessControl",
+              Properties: {
+                OriginAccessControlConfig: {
+                  Name: "api-oac",
+                  OriginAccessControlOriginType: "lambda",
+                  SigningBehavior: "always",
+                  SigningProtocol: "sigv4",
+                },
+              },
+            },
+          },
+        },
+      });
+    });
+
+    // Then the Stack fails naming the origin type, rather than deploying an
+    // origin access control that behaves like an S3 one.
+    assertStringIncludes(
+      error.message,
+      "Invalid AWS::CloudFront::OriginAccessControl ApiOac",
+    );
+    assertStringIncludes(error.message, "OriginAccessControlOriginType lambda");
+  });
+});

--- a/src/service/cloudfront/cfn/origin-access-control/sim-cfn-cf-oac.iso.test.ts
+++ b/src/service/cloudfront/cfn/origin-access-control/sim-cfn-cf-oac.iso.test.ts
@@ -1,0 +1,223 @@
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimCloudFrontOriginAccessControl } from "../../origin-access-control/sim-cf-origin-access-control.js";
+import { SimCloudFrontS3Origin } from "../../origin/s3/sim-cloudfront-s3-origin.js";
+import type { SimCloudFrontDistribution } from "../../distribution/sim-cloudfront-distribution.js";
+
+/**
+ * The template CDK synthesizes for an S3 origin site built with
+ * `S3BucketOrigin.withOriginAccessControl`, which is what makes an
+ * AWS::CloudFront::OriginAccessControl Resource.
+ */
+const template = {
+  Resources: {
+    SiteBucket: {
+      Type: "AWS::S3::Bucket",
+      Properties: { BucketName: "site-bucket" },
+    },
+    SiteOac: {
+      Type: "AWS::CloudFront::OriginAccessControl",
+      Properties: {
+        OriginAccessControlConfig: {
+          Name: "site-oac",
+          OriginAccessControlOriginType: "s3",
+          SigningBehavior: "always",
+          SigningProtocol: "sigv4",
+        },
+      },
+    },
+    SiteDistribution: {
+      Type: "AWS::CloudFront::Distribution",
+      DependsOn: ["SiteBucket", "SiteOac"],
+      Properties: {
+        DistributionConfig: {
+          Enabled: true,
+          Origins: [
+            {
+              Id: "SiteOrigin",
+              DomainName: "site-bucket.s3.amazonaws.com",
+              S3OriginConfig: {},
+              OriginAccessControlId: { Ref: "SiteOac" },
+            },
+          ],
+          DefaultCacheBehavior: {
+            TargetOriginId: "SiteOrigin",
+            ViewerProtocolPolicy: "redirect-to-https",
+          },
+        },
+      },
+    },
+  },
+  Outputs: {
+    OacId: { Value: { "Fn::GetAtt": ["SiteOac", "Id"] } },
+    OacRef: { Value: { Ref: "SiteOac" } },
+  },
+};
+
+describe("AWS::CloudFront::OriginAccessControl", () => {
+  it("creates an origin access control sim CloudFront holds", async () => {
+    // Given the template a modern S3 origin stack synthesizes.
+    const simAws = new SimAws();
+
+    // When it is deployed.
+    const stack = await simAws
+      .cloudFormation()
+      .deployTemplate({ stackName: "site-stack", template });
+    await stack.waitForDeployComplete();
+
+    // Then the Resource made a simulated origin access control, which sim
+    // CloudFront holds by ID.
+    const originAccessControl = stack.resources.get("SiteOac")?.simResource;
+    assertInstanceOf(originAccessControl, SimCloudFrontOriginAccessControl);
+    assertIdentical(
+      simAws.cloudFront().getOriginAccessControlById(originAccessControl.id),
+      originAccessControl,
+    );
+    assertIdentical(originAccessControl.name, "site-oac");
+    assertIdentical(originAccessControl.signingBehavior, "always");
+  });
+
+  it("answers Ref and the Id attribute with the ID", async () => {
+    // Given the deployed Stack.
+    const simAws = new SimAws();
+    const stack = await simAws
+      .cloudFormation()
+      .deployTemplate({ stackName: "site-stack", template });
+    await stack.waitForDeployComplete();
+
+    const originAccessControl = stack.resources.get("SiteOac")?.simResource;
+    assertInstanceOf(originAccessControl, SimCloudFrontOriginAccessControl);
+
+    // Then both Outputs carry the origin access control's ID, which is what an
+    // Origin's OriginAccessControlId names.
+    assertIdentical(stack.outputs.get("OacRef")?.value, originAccessControl.id);
+    assertIdentical(stack.outputs.get("OacId")?.value, originAccessControl.id);
+  });
+
+  it("resolves the origin access control an Origin names", async () => {
+    // Given the deployed Stack.
+    const simAws = new SimAws();
+    const stack = await simAws
+      .cloudFormation()
+      .deployTemplate({ stackName: "site-stack", template });
+    await stack.waitForDeployComplete();
+
+    const originAccessControl = stack.resources.get("SiteOac")?.simResource;
+    assertInstanceOf(originAccessControl, SimCloudFrontOriginAccessControl);
+
+    // Then the Origin holds the origin access control itself, rather than the
+    // ID the template wrote.
+    const distribution = stack.resources.get("SiteDistribution")
+      ?.simResource as SimCloudFrontDistribution | undefined;
+    assertNonNullable(distribution);
+
+    const origin = distribution.getOrigin("SiteOrigin");
+    assertInstanceOf(origin, SimCloudFrontS3Origin);
+    assertIdentical(origin.originAccessControl, originAccessControl);
+  });
+
+  it("reports the OriginAccessControlId an Origin was created with", async () => {
+    // Given the deployed Stack.
+    const simAws = new SimAws();
+    const stack = await simAws
+      .cloudFormation()
+      .deployTemplate({ stackName: "site-stack", template });
+    await stack.waitForDeployComplete();
+
+    const originAccessControl = stack.resources.get("SiteOac")?.simResource;
+    assertInstanceOf(originAccessControl, SimCloudFrontOriginAccessControl);
+
+    const distribution = stack.resources.get("SiteDistribution")
+      ?.simResource as SimCloudFrontDistribution | undefined;
+    assertNonNullable(distribution);
+
+    // When GetDistribution is called.
+    const output = await simAws
+      .cloudFront()
+      .getDistribution({ input: { Id: distribution.distributionId } });
+
+    // Then the Origin reports the resolved ID, so a test can assert the
+    // association without reaching into the simulator.
+    const [origin] =
+      output.Distribution?.DistributionConfig?.Origins?.Items ?? [];
+    assertNonNullable(origin);
+    assertIdentical(origin.OriginAccessControlId, originAccessControl.id);
+  });
+
+  it("reads an empty OriginAccessControlId as no origin access control", async () => {
+    // Given an Origin carrying the empty ID the CloudFront API uses to say an
+    // Origin has none, rather than leaving the field out.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "site-stack",
+      template: {
+        Resources: {
+          SiteBucket: {
+            Type: "AWS::S3::Bucket",
+            Properties: { BucketName: "site-bucket" },
+          },
+          SiteDistribution: {
+            Type: "AWS::CloudFront::Distribution",
+            DependsOn: ["SiteBucket"],
+            Properties: {
+              DistributionConfig: {
+                Enabled: true,
+                Origins: [
+                  {
+                    Id: "SiteOrigin",
+                    DomainName: "site-bucket.s3.amazonaws.com",
+                    S3OriginConfig: {},
+                    OriginAccessControlId: "",
+                  },
+                ],
+                DefaultCacheBehavior: {
+                  TargetOriginId: "SiteOrigin",
+                  ViewerProtocolPolicy: "redirect-to-https",
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+    await stack.waitForDeployComplete();
+
+    // Then the Origin is created with none, rather than the empty ID being
+    // looked up and refused.
+    const distribution = stack.resources.get("SiteDistribution")
+      ?.simResource as SimCloudFrontDistribution | undefined;
+    assertNonNullable(distribution);
+
+    const origin = distribution.getOrigin("SiteOrigin");
+    assertInstanceOf(origin, SimCloudFrontS3Origin);
+    assertUndefined(origin.originAccessControl);
+  });
+
+  it("removes the origin access control when the Stack is torn down", async () => {
+    // Given the deployed Stack.
+    const simAws = new SimAws();
+    const stack = await simAws
+      .cloudFormation()
+      .deployTemplate({ stackName: "site-stack", template });
+    await stack.waitForDeployComplete();
+
+    const originAccessControl = stack.resources.get("SiteOac")?.simResource;
+    assertInstanceOf(originAccessControl, SimCloudFrontOriginAccessControl);
+
+    // When the Stack's Resources are torn down.
+    await stack.teardown();
+
+    // Then sim CloudFront has forgotten it, and the Resource is gone.
+    assertUndefined(
+      simAws.cloudFront().getOriginAccessControlById(originAccessControl.id),
+    );
+    assertIdentical(stack.resources.get("SiteOac")?.status, "DELETE_COMPLETE");
+  });
+});

--- a/src/service/cloudfront/cfn/sim-cfn-cloudfront-resource-factory.ts
+++ b/src/service/cloudfront/cfn/sim-cfn-cloudfront-resource-factory.ts
@@ -8,6 +8,7 @@ import { SimCfnCfDistroCreator } from "./distro/sim-cfn-cf-distro-creator.js";
 import { SimCfnCffCreator } from "./cff/sim-cfn-cff-creator.js";
 import { SimCfnCfDistroDeleter } from "./distro/sim-cfn-cf-distro-deleter.js";
 import { SimCfnCfResponseHeadersPolicyCreator } from "./response-headers-policy/sim-cfn-cf-rh-policy-creator.js";
+import { SimCfnCfOriginAccessControlCreator } from "./origin-access-control/sim-cfn-cf-oac-creator.js";
 import type { SimCloudFrontFunction } from "../cff/sim-cloudfront-function.js";
 import { assertDefined } from "../../../util/type-guard/defined.js";
 
@@ -20,6 +21,7 @@ export class SimCloudFrontCloudFormationResourceFactory implements SimCfnService
   private readonly functionCreator: SimCfnCffCreator;
   private readonly distroDeleter: SimCfnCfDistroDeleter;
   private readonly responseHeadersPolicyCreator: SimCfnCfResponseHeadersPolicyCreator;
+  private readonly originAccessControlCreator: SimCfnCfOriginAccessControlCreator;
 
   constructor(cloudFront: SimCloudFront) {
     this.cloudFront = cloudFront;
@@ -28,6 +30,9 @@ export class SimCloudFrontCloudFormationResourceFactory implements SimCfnService
     this.distroDeleter = new SimCfnCfDistroDeleter({ cloudFront });
     this.responseHeadersPolicyCreator =
       new SimCfnCfResponseHeadersPolicyCreator({ cloudFront });
+    this.originAccessControlCreator = new SimCfnCfOriginAccessControlCreator({
+      cloudFront,
+    });
   }
 
   /**
@@ -54,6 +59,12 @@ export class SimCloudFrontCloudFormationResourceFactory implements SimCfnService
       }
       case "ResponseHeadersPolicy": {
         return this.responseHeadersPolicyCreator.create(
+          resource,
+          context.resolvedProperties ?? resource.properties,
+        );
+      }
+      case "OriginAccessControl": {
+        return this.originAccessControlCreator.create(
           resource,
           context.resolvedProperties ?? resource.properties,
         );
@@ -85,6 +96,10 @@ export class SimCloudFrontCloudFormationResourceFactory implements SimCfnService
       }
       case "ResponseHeadersPolicy": {
         this.responseHeadersPolicyCreator.delete(resource);
+        return;
+      }
+      case "OriginAccessControl": {
+        this.originAccessControlCreator.delete(resource);
         return;
       }
       default: {

--- a/src/service/cloudfront/command/create-distribution/create-distribution.command.ts
+++ b/src/service/cloudfront/command/create-distribution/create-distribution.command.ts
@@ -106,6 +106,7 @@ export interface SimCloudFrontOriginConfig {
   readonly Id?: string | undefined;
   readonly DomainName?: string | undefined;
   readonly OriginPath?: string | undefined;
+  readonly OriginAccessControlId?: string | undefined;
   readonly S3OriginConfig?: object | undefined;
   readonly CustomOriginConfig?: object | undefined;
 }

--- a/src/service/cloudfront/command/create-distribution/create-distribution.handler.ts
+++ b/src/service/cloudfront/command/create-distribution/create-distribution.handler.ts
@@ -12,6 +12,7 @@ import type { SimAwsAccountId } from "../../../aws/sim-aws-account.js";
 import { assertDefined } from "../../../../util/type-guard/defined.js";
 import type { SimCloudFrontS3OriginResolver } from "../../origin/s3/sim-cloudfront-s3-origin.js";
 import type { SimCfCustomOriginDispatcher } from "../../origin/custom/sim-cf-custom-origin-dispatcher.js";
+import type { SimCloudFrontOriginAccessControlRegistry } from "../../origin-access-control/sim-cf-origin-access-control-registry.js";
 import type { BackgroundScheduler } from "../../../../util/background/background.js";
 import { makeSimCloudFrontDistributionConfigurator } from "../../distribution/configurator/sim-cf-distribution-configurator.factory.js";
 import type { SimCloudFrontDistributionConfigurator } from "../../distribution/configurator/sim-cloud-front-distribution-configurator.js";
@@ -35,6 +36,7 @@ interface CreateDistributionCommandHandlerProperties {
   readonly cloudFrontRegistry: SimCloudFrontRegistry;
   readonly s3OriginResolver: SimCloudFrontS3OriginResolver;
   readonly customOriginDispatcher?: SimCfCustomOriginDispatcher | undefined;
+  readonly originAccessControls: SimCloudFrontOriginAccessControlRegistry;
   readonly iam?: SimIamInterServiceAuthZ;
   readonly acmRegistry?: SimAcmRegistry | undefined;
   readonly background: BackgroundScheduler;

--- a/src/service/cloudfront/command/update-distribution/update-distribution.handler.ts
+++ b/src/service/cloudfront/command/update-distribution/update-distribution.handler.ts
@@ -21,6 +21,7 @@ import { SimCloudFrontViewerCertificateValidator } from "../../distribution/view
 import { SimCloudFrontNoSuchDistribution } from "../../error/sim-cloudfront.error.js";
 import type { SimCfCustomOriginDispatcher } from "../../origin/custom/sim-cf-custom-origin-dispatcher.js";
 import type { SimCloudFrontS3OriginResolver } from "../../origin/s3/sim-cloudfront-s3-origin.js";
+import type { SimCloudFrontOriginAccessControlRegistry } from "../../origin-access-control/sim-cf-origin-access-control-registry.js";
 import type { SimCloudFrontRegistry } from "../../registry/sim-cloud-front-registry.js";
 import { SimCloudFrontDistributionConfigNormalizer } from "../create-distribution/sim-cf-distro-config-normalizer.js";
 import { UpdateDistributionAuthorizer } from "./update-distribution-authorizer.js";
@@ -38,6 +39,7 @@ interface UpdateDistributionCommandHandlerProperties {
   readonly cloudFrontRegistry: SimCloudFrontRegistry;
   readonly s3OriginResolver: SimCloudFrontS3OriginResolver;
   readonly customOriginDispatcher?: SimCfCustomOriginDispatcher | undefined;
+  readonly originAccessControls: SimCloudFrontOriginAccessControlRegistry;
   readonly iam?: SimIamInterServiceAuthZ;
   readonly acmRegistry?: SimAcmRegistry | undefined;
   readonly background?: BackgroundScheduler;

--- a/src/service/cloudfront/distribution/configurator/sim-cf-distribution-configurator.factory.ts
+++ b/src/service/cloudfront/distribution/configurator/sim-cf-distribution-configurator.factory.ts
@@ -1,5 +1,6 @@
 import type { SimCfCustomOriginDispatcher } from "../../origin/custom/sim-cf-custom-origin-dispatcher.js";
 import type { SimCloudFrontS3OriginResolver } from "../../origin/s3/sim-cloudfront-s3-origin.js";
+import type { SimCloudFrontOriginAccessControlRegistry } from "../../origin-access-control/sim-cf-origin-access-control-registry.js";
 import { SimCloudFrontBehaviorConfigurator } from "./sim-cloud-front-behavior-configurator.js";
 import { SimCloudFrontDistributionConfigurator } from "./sim-cloud-front-distribution-configurator.js";
 import { SimCloudFrontOriginConfigurator } from "./sim-cloud-front-origin-configurator.js";
@@ -7,6 +8,7 @@ import { SimCloudFrontOriginConfigurator } from "./sim-cloud-front-origin-config
 interface SimCloudFrontConfiguratorOrigins {
   readonly s3OriginResolver: SimCloudFrontS3OriginResolver;
   readonly customOriginDispatcher?: SimCfCustomOriginDispatcher | undefined;
+  readonly originAccessControls: SimCloudFrontOriginAccessControlRegistry;
 }
 
 /**
@@ -21,6 +23,7 @@ export function makeSimCloudFrontDistributionConfigurator(
   return new SimCloudFrontDistributionConfigurator(
     new SimCloudFrontOriginConfigurator(
       origins.s3OriginResolver,
+      origins.originAccessControls,
       origins.customOriginDispatcher,
     ),
     new SimCloudFrontBehaviorConfigurator(),

--- a/src/service/cloudfront/distribution/configurator/sim-cloud-front-origin-configurator.ts
+++ b/src/service/cloudfront/distribution/configurator/sim-cloud-front-origin-configurator.ts
@@ -7,6 +7,9 @@ import {
 } from "../../origin/s3/sim-cloudfront-s3-origin.js";
 import type { SimCfCustomOriginDispatcher } from "../../origin/custom/sim-cf-custom-origin-dispatcher.js";
 import { SimCloudFrontCustomOrigin } from "../../origin/custom/sim-cloudfront-custom-origin.js";
+import type { SimCloudFrontOriginAccessControl } from "../../origin-access-control/sim-cf-origin-access-control.js";
+import type { SimCloudFrontOriginAccessControlRegistry } from "../../origin-access-control/sim-cf-origin-access-control-registry.js";
+import { SimCloudFrontInvalidOriginAccessControl } from "../../error/sim-cloudfront.error.js";
 
 /**
  * Applies Origin configuration to a sim CloudFront Distribution.
@@ -21,6 +24,7 @@ import { SimCloudFrontCustomOrigin } from "../../origin/custom/sim-cloudfront-cu
 export class SimCloudFrontOriginConfigurator {
   constructor(
     private readonly s3OriginResolver: SimCloudFrontS3OriginResolver,
+    private readonly originAccessControls: SimCloudFrontOriginAccessControlRegistry,
     private readonly customOriginDispatcher?: SimCfCustomOriginDispatcher,
   ) {}
 
@@ -34,6 +38,11 @@ export class SimCloudFrontOriginConfigurator {
     assertDefined(origin.Id, "CloudFront Origin Id");
     assertDefined(origin.DomainName, "CloudFront Origin DomainName");
 
+    const originAccessControl = this.originAccessControl(
+      origin.Id,
+      origin.OriginAccessControlId,
+    );
+
     if (origin.S3OriginConfig !== undefined) {
       const bucket = this.s3OriginResolver(origin.DomainName);
 
@@ -44,12 +53,18 @@ export class SimCloudFrontOriginConfigurator {
 
       distribution.addOrigin(
         origin.Id,
-        new SimCloudFrontS3Origin({ bucket, originPath: origin.OriginPath }),
+        new SimCloudFrontS3Origin({
+          bucket,
+          originPath: origin.OriginPath,
+          ...(originAccessControl !== undefined && { originAccessControl }),
+        }),
       );
       return;
     }
 
     if (origin.CustomOriginConfig !== undefined) {
+      this.assertNoOriginAccessControl(origin.Id, originAccessControl);
+
       assertDefined(
         this.customOriginDispatcher,
         `Simulated AWS environment for sim CloudFront custom Origin ${origin.Id}, which a standalone SimCloudFront has no way to reach`,
@@ -69,6 +84,62 @@ export class SimCloudFrontOriginConfigurator {
 
     throw new Error(
       `Unsupported sim CloudFront Origin type for Origin ${origin.Id}`,
+    );
+  }
+
+  /**
+   * Resolve the origin access control an Origin names.
+   *
+   * CloudFront refuses a Distribution whose Origin names an origin access
+   * control the account does not hold, so an ID nothing here created is
+   * refused rather than stored as written. An empty ID means no origin access
+   * control, which is how the CloudFront API says an Origin has none.
+   */
+  private originAccessControl(
+    originId: string,
+    originAccessControlId: string | undefined,
+  ): SimCloudFrontOriginAccessControl | undefined {
+    if (
+      originAccessControlId === undefined ||
+      originAccessControlId.length === 0
+    ) {
+      return undefined;
+    }
+
+    const originAccessControl = this.originAccessControls.byId(
+      originAccessControlId,
+    );
+
+    if (originAccessControl === undefined) {
+      throw new SimCloudFrontInvalidOriginAccessControl(
+        `Sim CloudFront Origin ${originId} names origin access control ` +
+          `${originAccessControlId}, which does not exist. Only an origin ` +
+          `access control an AWS::CloudFront::OriginAccessControl Resource ` +
+          `created in this simulation can be named.`,
+      );
+    }
+
+    return originAccessControl;
+  }
+
+  /**
+   * Refuse an origin access control on a custom Origin.
+   *
+   * Every origin access control here signs for an S3 Origin, and CloudFront
+   * refuses one whose origin type does not match the Origin it is attached to.
+   */
+  private assertNoOriginAccessControl(
+    originId: string,
+    originAccessControl: SimCloudFrontOriginAccessControl | undefined,
+  ): void {
+    if (originAccessControl === undefined) {
+      return;
+    }
+
+    throw new SimCloudFrontInvalidOriginAccessControl(
+      `Sim CloudFront custom Origin ${originId} names origin access control ` +
+        `${originAccessControl.name}, which signs for an ` +
+        `${originAccessControl.originType} Origin`,
     );
   }
 }

--- a/src/service/cloudfront/distribution/sim-cf-distribution-reconfigurer.ts
+++ b/src/service/cloudfront/distribution/sim-cf-distribution-reconfigurer.ts
@@ -1,6 +1,7 @@
 import type { SimCloudFrontDistributionConfig } from "../command/create-distribution/create-distribution.command.js";
 import type { SimCfCustomOriginDispatcher } from "../origin/custom/sim-cf-custom-origin-dispatcher.js";
 import type { SimCloudFrontS3OriginResolver } from "../origin/s3/sim-cloudfront-s3-origin.js";
+import type { SimCloudFrontOriginAccessControlRegistry } from "../origin-access-control/sim-cf-origin-access-control-registry.js";
 import type { SimCloudFrontRegistry } from "../registry/sim-cloud-front-registry.js";
 import { makeSimCloudFrontDistributionConfigurator } from "./configurator/sim-cf-distribution-configurator.factory.js";
 import type { SimCloudFrontDistributionConfigurator } from "./configurator/sim-cloud-front-distribution-configurator.js";
@@ -10,6 +11,7 @@ interface SimCloudFrontDistributionReconfigurerProperties {
   readonly cloudFrontRegistry: SimCloudFrontRegistry;
   readonly s3OriginResolver: SimCloudFrontS3OriginResolver;
   readonly customOriginDispatcher?: SimCfCustomOriginDispatcher | undefined;
+  readonly originAccessControls: SimCloudFrontOriginAccessControlRegistry;
 }
 
 /**

--- a/src/service/cloudfront/error/sim-cloudfront.error.ts
+++ b/src/service/cloudfront/error/sim-cloudfront.error.ts
@@ -133,6 +133,34 @@ export class SimCloudFrontResponseHeadersPolicyAlreadyExists extends SimCloudFro
 }
 
 /**
+ * Simulated CloudFront InvalidOriginAccessControl error.
+ *
+ * What CloudFront answers when an Origin's `OriginAccessControlId` names no
+ * origin access control the account holds.
+ */
+export class SimCloudFrontInvalidOriginAccessControl extends SimCloudFrontError {
+  public override readonly name = "InvalidOriginAccessControl";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
+ * Simulated CloudFront OriginAccessControlAlreadyExists error.
+ *
+ * CloudFront requires an origin access control name to be unique within an
+ * account, so a second one claiming a name is refused rather than created.
+ */
+export class SimCloudFrontOriginAccessControlAlreadyExists extends SimCloudFrontError {
+  public override readonly name = "OriginAccessControlAlreadyExists";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 409 });
+  }
+}
+
+/**
  * Simulated CloudFront DistributionNotDisabled error.
  *
  * CloudFront will not delete a Distribution that is still serving. The caller

--- a/src/service/cloudfront/origin-access-control/sim-cf-origin-access-control-registry.iso.test.ts
+++ b/src/service/cloudfront/origin-access-control/sim-cf-origin-access-control-registry.iso.test.ts
@@ -1,0 +1,71 @@
+import {
+  assertIdentical,
+  assertStringIncludes,
+  assertThrowsError,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimCloudFrontOriginAccessControlRegistry } from "./sim-cf-origin-access-control-registry.js";
+import { SimCloudFrontOriginAccessControl } from "./sim-cf-origin-access-control.js";
+
+describe("SimCloudFrontOriginAccessControlRegistry", () => {
+  function anOriginAccessControl(
+    name: string,
+  ): SimCloudFrontOriginAccessControl {
+    return new SimCloudFrontOriginAccessControl({
+      name,
+      signingBehavior: "always",
+    });
+  }
+
+  it("finds a stored origin access control by ID and by name", () => {
+    // Given a stored origin access control.
+    const registry = new SimCloudFrontOriginAccessControlRegistry();
+    const originAccessControl = anOriginAccessControl("site-oac");
+    registry.add(originAccessControl);
+
+    // Then it is found by the ID an Origin names, and by name.
+    assertIdentical(registry.byId(originAccessControl.id), originAccessControl);
+    assertIdentical(registry.byName("site-oac"), originAccessControl);
+  });
+
+  it("finds nothing for an ID it does not hold", () => {
+    // Given an empty registry.
+    const registry = new SimCloudFrontOriginAccessControlRegistry();
+
+    // Then an ID nothing created finds nothing, which is what lets a
+    // Distribution refuse it.
+    assertUndefined(registry.byId("E1EXAMPLE12345"));
+    assertUndefined(registry.byName("site-oac"));
+  });
+
+  it("refuses a name another origin access control already holds", () => {
+    // Given a stored origin access control.
+    const registry = new SimCloudFrontOriginAccessControlRegistry();
+    registry.add(anOriginAccessControl("site-oac"));
+
+    // When a second one claims the same name.
+    const error = assertThrowsError(() => {
+      registry.add(anOriginAccessControl("site-oac"));
+    });
+
+    // Then it is refused as CloudFront refuses one, naming the duplicate.
+    assertIdentical(error.name, "OriginAccessControlAlreadyExists");
+    assertStringIncludes(error.message, "site-oac");
+  });
+
+  it("forgets an origin access control", () => {
+    // Given a stored origin access control.
+    const registry = new SimCloudFrontOriginAccessControlRegistry();
+    const originAccessControl = anOriginAccessControl("site-oac");
+    registry.add(originAccessControl);
+
+    // When it is removed, as a Stack teardown removes it.
+    registry.remove(originAccessControl.id);
+
+    // Then it is no longer found, and its name is free again.
+    assertUndefined(registry.byId(originAccessControl.id));
+    registry.add(anOriginAccessControl("site-oac"));
+  });
+});

--- a/src/service/cloudfront/origin-access-control/sim-cf-origin-access-control-registry.ts
+++ b/src/service/cloudfront/origin-access-control/sim-cf-origin-access-control-registry.ts
@@ -1,0 +1,63 @@
+import { SimCloudFrontOriginAccessControlAlreadyExists } from "../error/sim-cloudfront.error.js";
+import type {
+  SimCloudFrontOriginAccessControl,
+  SimCloudFrontOriginAccessControlId,
+  SimCloudFrontOriginAccessControlMap,
+} from "./sim-cf-origin-access-control.js";
+
+/**
+ * The origin access controls one simulated CloudFront holds.
+ *
+ * They are found by ID, which is what an Origin's `OriginAccessControlId`
+ * names, and by name, which is what decides whether a new one may be stored.
+ */
+export class SimCloudFrontOriginAccessControlRegistry {
+  private readonly originAccessControls: SimCloudFrontOriginAccessControlMap =
+    new Map();
+
+  /**
+   * Store an origin access control, refusing a name another one already holds
+   * as CloudFront does.
+   */
+  add(originAccessControl: SimCloudFrontOriginAccessControl): void {
+    if (this.byName(originAccessControl.name) !== undefined) {
+      throw new SimCloudFrontOriginAccessControlAlreadyExists(
+        `Sim CloudFront origin access control ${originAccessControl.name} already exists`,
+      );
+    }
+
+    this.originAccessControls.set(originAccessControl.id, originAccessControl);
+  }
+
+  /**
+   * Forget an origin access control.
+   */
+  remove(originAccessControlId: SimCloudFrontOriginAccessControlId): void {
+    this.originAccessControls.delete(originAccessControlId);
+  }
+
+  /**
+   * Get an origin access control by ID.
+   */
+  byId(
+    originAccessControlId: SimCloudFrontOriginAccessControlId | string,
+  ): SimCloudFrontOriginAccessControl | undefined {
+    return this.originAccessControls.get(
+      originAccessControlId as SimCloudFrontOriginAccessControlId,
+    );
+  }
+
+  /**
+   * Get an origin access control by name.
+   */
+  byName(
+    originAccessControlName: string,
+  ): SimCloudFrontOriginAccessControl | undefined {
+    return this.originAccessControls
+      .values()
+      .find(
+        (originAccessControl) =>
+          originAccessControl.name === originAccessControlName,
+      );
+  }
+}

--- a/src/service/cloudfront/origin-access-control/sim-cf-origin-access-control.iso.test.ts
+++ b/src/service/cloudfront/origin-access-control/sim-cf-origin-access-control.iso.test.ts
@@ -1,0 +1,99 @@
+import {
+  assertFalse,
+  assertIdentical,
+  assertStringLength,
+  assertStringStartsWith,
+  assertTrue,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import {
+  SimCloudFrontOriginAccessControl,
+  type SimCloudFrontOriginAccessControlId,
+} from "./sim-cf-origin-access-control.js";
+
+describe("SimCloudFrontOriginAccessControl", () => {
+  it("is given an ID in the shape CloudFront gives one", () => {
+    // Given an origin access control created without an ID.
+    const originAccessControl = new SimCloudFrontOriginAccessControl({
+      name: "site-oac",
+      signingBehavior: "always",
+    });
+
+    // Then it allocated one of its own, which a template can Ref.
+    assertStringStartsWith(originAccessControl.id, "E");
+    assertStringLength(originAccessControl.id, 14);
+  });
+
+  it("keeps the ID it was created with", () => {
+    // Given an origin access control created with an ID.
+    const originAccessControl = new SimCloudFrontOriginAccessControl({
+      id: "E1EXAMPLE12345" as SimCloudFrontOriginAccessControlId,
+      name: "site-oac",
+      signingBehavior: "always",
+    });
+
+    // Then it keeps it rather than allocating one.
+    assertIdentical(originAccessControl.id, "E1EXAMPLE12345");
+  });
+
+  it("only signs for an S3 Origin with SigV4", () => {
+    // Given an origin access control.
+    const originAccessControl = new SimCloudFrontOriginAccessControl({
+      name: "site-oac",
+      signingBehavior: "always",
+    });
+
+    // Then the origin type and signing protocol are the only ones modelled,
+    // rather than whatever the template happened to ask for.
+    assertIdentical(originAccessControl.originType, "s3");
+    assertIdentical(originAccessControl.signingProtocol, "sigv4");
+  });
+
+  it("has no description unless it was given one", () => {
+    // Given an origin access control created without a description.
+    const originAccessControl = new SimCloudFrontOriginAccessControl({
+      name: "site-oac",
+      signingBehavior: "always",
+    });
+
+    assertUndefined(originAccessControl.description);
+  });
+
+  it("keeps the description it was created with", () => {
+    // Given an origin access control created with a description.
+    const originAccessControl = new SimCloudFrontOriginAccessControl({
+      name: "site-oac",
+      description: "Signs reads of the site bucket",
+      signingBehavior: "always",
+    });
+
+    assertIdentical(
+      originAccessControl.description,
+      "Signs reads of the site bucket",
+    );
+  });
+
+  it("signs unless the signing behaviour says never", () => {
+    // Given the three signing behaviours CloudFront offers.
+    const always = new SimCloudFrontOriginAccessControl({
+      name: "always-oac",
+      signingBehavior: "always",
+    });
+    const noOverride = new SimCloudFrontOriginAccessControl({
+      name: "no-override-oac",
+      signingBehavior: "no-override",
+    });
+    const never = new SimCloudFrontOriginAccessControl({
+      name: "never-oac",
+      signingBehavior: "never",
+    });
+
+    // Then only `never` turns the signing off. Nothing here sends a viewer's
+    // own signature to an Origin, so `no-override` always signs.
+    assertTrue(always.signs);
+    assertTrue(noOverride.signs);
+    assertFalse(never.signs);
+  });
+});

--- a/src/service/cloudfront/origin-access-control/sim-cf-origin-access-control.ts
+++ b/src/service/cloudfront/origin-access-control/sim-cf-origin-access-control.ts
@@ -1,0 +1,91 @@
+import { faker } from "@faker-js/faker";
+
+import type { Brand } from "../../../util/brand.type.js";
+
+export type SimCloudFrontOriginAccessControlId = Brand<
+  string,
+  "SimCloudFrontOriginAccessControlId"
+>;
+
+/**
+ * When CloudFront signs the request it sends to the Origin.
+ *
+ * `always` signs every request. `never` signs none, which turns the origin
+ * access control off without removing it. `no-override` signs a request the
+ * viewer did not already sign, and passes a signed one through.
+ */
+export type SimCloudFrontOriginAccessControlSigningBehavior =
+  | "always"
+  | "never"
+  | "no-override";
+
+interface SimCloudFrontOriginAccessControlProperties {
+  readonly id?: SimCloudFrontOriginAccessControlId;
+  readonly name: string;
+  readonly description?: string;
+  readonly signingBehavior: SimCloudFrontOriginAccessControlSigningBehavior;
+}
+
+/**
+ * Simulated CloudFront origin access control.
+ *
+ * An origin access control is attached to an Origin, and it is how a
+ * Distribution authenticates to a private S3 Bucket: CloudFront signs the
+ * Origin request with SigV4 as the CloudFront service principal, and the Bucket
+ * policy grants that principal on the Distribution's ARN.
+ *
+ * Only an `s3` origin type signed with `sigv4` is modelled, so those are fixed
+ * here rather than stored. Anything else is refused where the origin access
+ * control is read, rather than kept and treated as though it behaved like the
+ * supported values.
+ *
+ * https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-restricting-access-to-s3.html
+ */
+export class SimCloudFrontOriginAccessControl {
+  public readonly id: SimCloudFrontOriginAccessControlId;
+  public readonly name: string;
+  public readonly description: string | undefined;
+  public readonly signingBehavior: SimCloudFrontOriginAccessControlSigningBehavior;
+
+  /**
+   * The kind of Origin this origin access control signs for.
+   */
+  public readonly originType = "s3";
+
+  /**
+   * The protocol CloudFront signs the Origin request with.
+   */
+  public readonly signingProtocol = "sigv4";
+
+  constructor(properties: SimCloudFrontOriginAccessControlProperties) {
+    this.id = properties.id ?? makeOriginAccessControlId();
+    this.name = properties.name;
+    this.description = properties.description;
+    this.signingBehavior = properties.signingBehavior;
+  }
+
+  /**
+   * Whether this origin access control signs the request for an Origin read.
+   *
+   * `no-override` signs a request the viewer did not sign, and nothing here
+   * sends a pre-signed viewer request to an Origin, so it signs too.
+   */
+  get signs(): boolean {
+    return this.signingBehavior !== "never";
+  }
+}
+
+export type SimCloudFrontOriginAccessControlMap = Map<
+  SimCloudFrontOriginAccessControlId,
+  SimCloudFrontOriginAccessControl
+>;
+
+/**
+ * Generate a fake sim CloudFront origin access control ID, in the shape
+ * CloudFront gives one.
+ */
+export function makeOriginAccessControlId(): SimCloudFrontOriginAccessControlId {
+  return faker.helpers.fromRegExp(
+    /E[0-9A-Z]{13}/,
+  ) as SimCloudFrontOriginAccessControlId;
+}

--- a/src/service/cloudfront/origin/s3/sim-cf-s3-origin-object-key.ts
+++ b/src/service/cloudfront/origin/s3/sim-cf-s3-origin-object-key.ts
@@ -1,0 +1,27 @@
+import type { SimCloudFrontOriginRequest } from "../sim-cloudfront-request-response.js";
+
+/**
+ * The Bucket object key an S3 Origin reads for a request.
+ *
+ * The Origin path goes in front of the request path, and the result is decoded
+ * and tidied into a key: repeated slashes collapse into one, and the leading
+ * slash goes, because an S3 object key has neither.
+ */
+export class SimCfS3OriginObjectKey {
+  private readonly originPath: string;
+
+  constructor(originPath: string) {
+    this.originPath = originPath;
+  }
+
+  /**
+   * The object key one Origin request reads.
+   */
+  forRequest(request: SimCloudFrontOriginRequest): string {
+    const { pathname } = new URL(request.req.url);
+
+    return decodeURIComponent(`${this.originPath}/${pathname}`)
+      .replaceAll(/\/+/gu, "/")
+      .replace(/^\/+/u, "");
+  }
+}

--- a/src/service/cloudfront/origin/s3/sim-cloudfront-s3-origin.ts
+++ b/src/service/cloudfront/origin/s3/sim-cloudfront-s3-origin.ts
@@ -3,6 +3,8 @@ import type { SimS3Object } from "../../../s3/object/s3-object.js";
 import { simS3ObjectResponseHeaders } from "../../../s3/object/s3-object-response-headers.js";
 import type { SimCloudFrontOriginRequest } from "../sim-cloudfront-request-response.js";
 import type { SimCloudFrontOrigin } from "../sim-cloudfront-origin.js";
+import type { SimCloudFrontOriginAccessControl } from "../../origin-access-control/sim-cf-origin-access-control.js";
+import { SimCfS3OriginObjectKey } from "./sim-cf-s3-origin-object-key.js";
 
 export type SimCloudFrontS3OriginResolver = (
   originDomainName: string,
@@ -19,6 +21,7 @@ export function emptyCloudFrontS3OriginResolver(): undefined {
 interface SimCloudFrontS3OriginProperties {
   readonly bucket: SimS3Bucket;
   readonly originPath?: string | undefined;
+  readonly originAccessControl?: SimCloudFrontOriginAccessControl | undefined;
 }
 
 /**
@@ -27,12 +30,23 @@ interface SimCloudFrontS3OriginProperties {
  * This represents a basic S3 object origin, not an S3 static website endpoint.
  */
 export class SimCloudFrontS3Origin implements SimCloudFrontOrigin {
+  /**
+   * The origin access control this Origin was created with, if any.
+   *
+   * It is stored and reported, and it does not yet decide whether the read
+   * below is allowed: the object is fetched from the Bucket model either way.
+   */
+  public readonly originAccessControl:
+    | SimCloudFrontOriginAccessControl
+    | undefined;
+
   private readonly bucket: SimS3Bucket;
-  private readonly originPath: string;
+  private readonly objectKey: SimCfS3OriginObjectKey;
 
   constructor(properties: SimCloudFrontS3OriginProperties) {
     this.bucket = properties.bucket;
-    this.originPath = properties.originPath ?? "";
+    this.objectKey = new SimCfS3OriginObjectKey(properties.originPath ?? "");
+    this.originAccessControl = properties.originAccessControl;
   }
 
   /**
@@ -49,7 +63,7 @@ export class SimCloudFrontS3Origin implements SimCloudFrontOrigin {
       });
     }
 
-    const objectKey = this.objectKeyForRequest(request);
+    const objectKey = this.objectKey.forRequest(request);
     const object = await this.bucket.getObject(objectKey);
 
     if (object === undefined) {
@@ -61,19 +75,6 @@ export class SimCloudFrontS3Origin implements SimCloudFrontOrigin {
 
   private methodSupported(method: string): boolean {
     return method === "GET" || method === "HEAD";
-  }
-
-  private objectKeyForRequest(request: SimCloudFrontOriginRequest): string {
-    const url = new URL(request.req.url);
-    const requestPath = url.pathname;
-
-    return this.normalizeObjectKey(`${this.originPath}/${requestPath}`);
-  }
-
-  private normalizeObjectKey(path: string): string {
-    return decodeURIComponent(path)
-      .replaceAll(/\/+/gu, "/")
-      .replace(/^\/+/u, "");
   }
 
   private foundObjectResponse(object: SimS3Object, request: Request): Response {

--- a/src/service/cloudfront/sim-cloudfront-commands.ts
+++ b/src/service/cloudfront/sim-cloudfront-commands.ts
@@ -52,6 +52,7 @@ import {
   emptyCloudFrontS3OriginResolver,
   type SimCloudFrontS3OriginResolver,
 } from "./origin/s3/sim-cloudfront-s3-origin.js";
+import type { SimCloudFrontOriginAccessControlRegistry } from "./origin-access-control/sim-cf-origin-access-control-registry.js";
 import { SimCloudFrontRegistry } from "./registry/sim-cloud-front-registry.js";
 
 /**
@@ -71,6 +72,7 @@ interface SimCloudFrontCommandsProperties extends SimCloudFrontProperties {
   readonly accountId: SimAwsAccountId;
   readonly distributions: SimCloudFrontDistributionMap;
   readonly cloudFrontFunctions: SimCloudFrontFunctionMap;
+  readonly originAccessControls: SimCloudFrontOriginAccessControlRegistry;
 }
 
 /**
@@ -122,6 +124,7 @@ export class SimCloudFrontCommands {
     | SimCfCustomOriginDispatcher
     | undefined;
   private readonly acmRegistry: SimAcmRegistry | undefined;
+  private readonly originAccessControls: SimCloudFrontOriginAccessControlRegistry;
 
   constructor(properties: SimCloudFrontCommandsProperties) {
     const {
@@ -152,6 +155,7 @@ export class SimCloudFrontCommands {
     this.s3OriginResolver = s3OriginResolver;
     this.customOriginDispatcher = customOriginDispatcher;
     this.acmRegistry = acmRegistry;
+    this.originAccessControls = properties.originAccessControls;
   }
 
   /**
@@ -237,11 +241,13 @@ export class SimCloudFrontCommands {
     readonly s3OriginResolver: SimCloudFrontS3OriginResolver;
     readonly customOriginDispatcher: SimCfCustomOriginDispatcher | undefined;
     readonly acmRegistry: SimAcmRegistry | undefined;
+    readonly originAccessControls: SimCloudFrontOriginAccessControlRegistry;
   } {
     return {
       s3OriginResolver: this.s3OriginResolver,
       customOriginDispatcher: this.customOriginDispatcher,
       acmRegistry: this.acmRegistry,
+      originAccessControls: this.originAccessControls,
     };
   }
 }

--- a/src/service/cloudfront/sim-cloudfront.ts
+++ b/src/service/cloudfront/sim-cloudfront.ts
@@ -43,6 +43,11 @@ import type {
   SimCloudFrontResponseHeadersPolicyId,
 } from "./response-headers-policy/sim-cf-response-headers-policy.js";
 import { SimCloudFrontResponseHeadersPolicyRegistry } from "./response-headers-policy/sim-cf-response-headers-policy-registry.js";
+import type {
+  SimCloudFrontOriginAccessControl,
+  SimCloudFrontOriginAccessControlId,
+} from "./origin-access-control/sim-cf-origin-access-control.js";
+import { SimCloudFrontOriginAccessControlRegistry } from "./origin-access-control/sim-cf-origin-access-control-registry.js";
 import { SimCloudFrontSdkCommandRouter } from "./sdk/sim-cloudfront-sdk-command-router.js";
 import {
   SimCloudFrontCommands,
@@ -64,6 +69,8 @@ export class SimCloudFront {
   private readonly cloudFrontFunctions: SimCloudFrontFunctionMap = new Map();
   private readonly responseHeadersPolicies =
     new SimCloudFrontResponseHeadersPolicyRegistry();
+  private readonly originAccessControls =
+    new SimCloudFrontOriginAccessControlRegistry();
 
   private readonly accountRegionScope: SimAwsAccountRegionScope;
   private readonly commands: SimCloudFrontCommands;
@@ -80,6 +87,7 @@ export class SimCloudFront {
       accountId: this.accountRegionScope.accountId,
       distributions: this.distributions,
       cloudFrontFunctions: this.cloudFrontFunctions,
+      originAccessControls: this.originAccessControls,
     });
   }
 
@@ -220,6 +228,38 @@ export class SimCloudFront {
     policyId: SimCloudFrontResponseHeadersPolicyId | string,
   ): SimCloudFrontResponseHeadersPolicy | undefined {
     return this.responseHeadersPolicies.byId(policyId);
+  }
+
+  /**
+   * Store a simulated origin access control.
+   *
+   * There is no CreateOriginAccessControl command here, so CloudFormation is
+   * the only thing that makes one, and this is how it hands it over. A name
+   * another origin access control already holds is refused, as CloudFront
+   * refuses one.
+   */
+  addOriginAccessControl(
+    originAccessControl: SimCloudFrontOriginAccessControl,
+  ): void {
+    this.originAccessControls.add(originAccessControl);
+  }
+
+  /**
+   * Forget a simulated origin access control.
+   */
+  removeOriginAccessControl(
+    originAccessControlId: SimCloudFrontOriginAccessControlId,
+  ): void {
+    this.originAccessControls.remove(originAccessControlId);
+  }
+
+  /**
+   * Get a simulated origin access control by ID.
+   */
+  getOriginAccessControlById(
+    originAccessControlId: SimCloudFrontOriginAccessControlId | string,
+  ): SimCloudFrontOriginAccessControl | undefined {
+    return this.originAccessControls.byId(originAccessControlId);
   }
 
   /**


### PR DESCRIPTION
`AWS::CloudFront::OriginAccessControl` was unsupported, so the CloudFront resource factory threw and CloudFormation skipped the resource. That is what CDK emits for `S3BucketOrigin.withOriginAccessControl`, so any modern S3 origin stack deployed locally with a skip line against it. It now creates a stored origin access control on simulated CloudFront, found by ID the way a response headers policy is, with `Ref` and `Fn::GetAtt` on `Id` both returning that ID. An origin's `OriginAccessControlId` resolves through the registry when the distribution is created, and an ID nothing holds is refused with `InvalidOriginAccessControl` rather than ignored. An `OriginAccessControlOriginType` other than `s3` and a `SigningProtocol` other than `sigv4` fail the stack by name rather than being stored and treated as supported. Tearing the stack down removes the origin access control.

This is storage and reporting only. Nothing signs the origin request and no bucket policy is consulted, so a distribution reads its S3 origin identically with or without one, which is #495 and depends on this plus #493. The docs say that plainly in the first Limitations bullet.

The model and its registry live in `src/service/cloudfront/origin-access-control/`, the config reader and creator in `src/service/cloudfront/cfn/origin-access-control/`, and the value adapter in `src/service/cloudformation/resource/cfn/cloudfront/`, following how response headers policies already work at each layer.

Two judgement calls worth a reviewer's attention. An origin access control on a **custom origin** is refused: every one here signs for `s3`, and CloudFront refuses a type mismatch, so allowing it would store something that could never apply. An **empty** `OriginAccessControlId` reads as no origin access control, which is how the CloudFront API expresses it, rather than being looked up and refused.

One incidental change: `sim-cloudfront-s3-origin.ts` was already at FTA 49.97, and the new field tipped it to 50.76. Extracting the object key resolution into `SimCfS3OriginObjectKey` brings it back to 49.33. That extraction was picked over the response builders because #493 rewrites `fetch` and the response mapping but leaves key resolution alone.

#493 is being worked in parallel and also touches `SimCloudFrontOriginConfigurator`, so expect a small rebase there.

`pnpm run check` passes.

Resolves https://github.com/KensioSoftware/yulin/issues/494