### PR TITLE
feat: sign a CloudFront S3 Origin read with an origin access control

### DIFF
--- a/docs/services/cloudfront/README.md
+++ b/docs/services/cloudfront/README.md
@@ -100,6 +100,10 @@ what the Distribution can serve. An Origin with no origin access control reads a
 the unsigned request real CloudFront sends to the S3 REST endpoint, so an Object has to be publicly
 readable for the Distribution to serve it. A Bucket with no policy answers 403 for every Object.
 
+An Origin that does have an origin access control reads as the CloudFront service principal instead,
+so the Bucket stays private and its policy names the Distribution. See
+[Origin access controls](#origin-access-controls) for the policy that needs.
+
 That is the two commands in the example above: `PutPublicAccessBlockCommand` to opt out of the block
 on public Bucket policies, then `PutBucketPolicyCommand` granting `s3:GetObject` to `Principal: "*"`.
 The same pair is what a static website Bucket needs, and it is what CDK's `publicReadAccess: true`
@@ -1095,83 +1099,140 @@ An origin access control is how a Distribution authenticates to a private S3 Buc
 `AWS::CloudFront::OriginAccessControl` and point an Origin's `OriginAccessControlId` at it with a
 `Ref`, which is what CDK's `S3BucketOrigin.withOriginAccessControl` synthesizes.
 
-Read the first paragraph of [Limitations](#limitations) before relying on this. Sim CloudFront
-stores an origin access control and reports it back, and it does not yet sign the Origin request.
-The Origin still reads its Bucket anonymously, so a Bucket only an origin access control could reach
-answers 403 rather than serving. See
-[What an S3 Origin can read](#what-an-s3-origin-can-read).
+An Origin whose origin access control signs reads its Bucket as the `cloudfront.amazonaws.com`
+service principal, carrying the Distribution's ARN as `aws:SourceArn`. The Bucket policy is then the
+whole decision, so the Bucket needs a statement granting `s3:GetObject` to that principal,
+conditioned on the Distribution allowed to read it. That is the policy CDK writes. A condition
+naming a different Distribution, or an Origin that was never given an origin access control,
+answers 403 rather than serving.
 
 ```typescript sim-cloudfront-origin-access-control
 /**
- * Giving a Distribution's S3 Origin an origin access control.
+ * Serving a private S3 Bucket through an origin access control.
  */
 
-import { GetDistributionCommand } from "@aws-sdk/client-cloudfront";
+import { PutObjectCommand } from "@aws-sdk/client-s3";
 
 import { SimAws } from "@kensio/yulin";
+import { serveSimAws } from "@kensio/yulin/serve";
 
 const simAws = new SimAws();
+const srv = await serveSimAws({ simAws });
 
-const stack = await simAws.cloudFormation().deployTemplate({
-  stackName: "site-stack",
-  template: {
-    Resources: {
-      SiteBucket: {
-        Type: "AWS::S3::Bucket",
-        Properties: { BucketName: "site-bucket" },
-      },
-      SiteOac: {
-        Type: "AWS::CloudFront::OriginAccessControl",
-        Properties: {
-          OriginAccessControlConfig: {
-            Name: "site-oac",
-            OriginAccessControlOriginType: "s3",
-            SigningBehavior: "always",
-            SigningProtocol: "sigv4",
+try {
+  const stack = await simAws.cloudFormation().deployTemplate({
+    stackName: "site-stack",
+    template: {
+      Resources: {
+        SiteBucket: {
+          Type: "AWS::S3::Bucket",
+          Properties: { BucketName: "site-bucket" },
+        },
+        SiteOac: {
+          Type: "AWS::CloudFront::OriginAccessControl",
+          Properties: {
+            OriginAccessControlConfig: {
+              Name: "site-oac",
+              OriginAccessControlOriginType: "s3",
+              SigningBehavior: "always",
+              SigningProtocol: "sigv4",
+            },
           },
         },
-      },
-      SiteDistribution: {
-        Type: "AWS::CloudFront::Distribution",
-        DependsOn: ["SiteBucket", "SiteOac"],
-        Properties: {
-          DistributionConfig: {
-            Enabled: true,
-            Origins: [
-              {
-                Id: "SiteOrigin",
-                DomainName: "site-bucket.s3.amazonaws.com",
-                S3OriginConfig: {},
-                OriginAccessControlId: { Ref: "SiteOac" },
+        SiteDistribution: {
+          Type: "AWS::CloudFront::Distribution",
+          Properties: {
+            DistributionConfig: {
+              Enabled: true,
+              DefaultRootObject: "index.html",
+              Origins: [
+                {
+                  Id: "SiteOrigin",
+                  DomainName: "site-bucket.s3.amazonaws.com",
+                  S3OriginConfig: {},
+                  OriginAccessControlId: { Ref: "SiteOac" },
+                },
+              ],
+              DefaultCacheBehavior: {
+                TargetOriginId: "SiteOrigin",
+                ViewerProtocolPolicy: "allow-all",
               },
-            ],
-            DefaultCacheBehavior: {
-              TargetOriginId: "SiteOrigin",
-              ViewerProtocolPolicy: "allow-all",
+            },
+          },
+        },
+        // Nothing but this Distribution may read the Bucket, which is what the
+        // condition on the Distribution's ARN says.
+        SiteBucketPolicy: {
+          Type: "AWS::S3::BucketPolicy",
+          Properties: {
+            Bucket: { Ref: "SiteBucket" },
+            PolicyDocument: {
+              Version: "2012-10-17",
+              Statement: [
+                {
+                  Effect: "Allow",
+                  Principal: { Service: "cloudfront.amazonaws.com" },
+                  Action: "s3:GetObject",
+                  Resource: "arn:aws:s3:::site-bucket/*",
+                  Condition: {
+                    StringEquals: {
+                      "AWS:SourceArn": {
+                        "Fn::Join": [
+                          "",
+                          [
+                            "arn:aws:cloudfront::",
+                            { Ref: "AWS::AccountId" },
+                            ":distribution/",
+                            { Ref: "SiteDistribution" },
+                          ],
+                        ],
+                      },
+                    },
+                  },
+                },
+              ],
             },
           },
         },
       },
+      Outputs: {
+        SiteHostname: {
+          Value: { "Fn::GetAtt": ["SiteDistribution", "DomainName"] },
+        },
+      },
     },
-    Outputs: {
-      DistributionId: { Value: { Ref: "SiteDistribution" } },
-    },
-  },
-});
+  });
 
-await stack.waitForDeployComplete();
+  await stack.waitForDeployComplete();
 
-const distributionId = stack.outputs.get("DistributionId")?.value as string;
-const output = await simAws
-  .cloudFront()
-  .getDistribution(new GetDistributionCommand({ Id: distributionId }));
+  await simAws.s3().putObject(
+    new PutObjectCommand({
+      Bucket: "site-bucket",
+      Key: "index.html",
+      ContentType: "text/html",
+      Body: "<h1>Home</h1>",
+    }),
+  );
 
-const [origin] = output.Distribution?.DistributionConfig?.Origins?.Items ?? [];
+  const siteHostname = stack.outputs.get("SiteHostname")?.value as string;
+  const home = await fetch(srv.localUrl(`http://${siteHostname}/`));
 
-// The ID the Ref resolved to, which is the origin access control the Origin
-// was created with.
-console.log(origin?.OriginAccessControlId);
+  console.log(await home.text()); // <h1>Home</h1>
+} finally {
+  await srv.close();
+}
 ```
+
+The Bucket policy names the Distribution's ARN, so it is created after the Distribution: the `Ref`
+inside `Fn::Join` is the dependency CloudFormation orders the Stack by. Nothing about the read is
+settled when the Distribution is created, because the policy deciding it does not exist yet. The
+Origin works out who it is reading as per request instead.
+
+`SigningBehavior` takes any of `always`, `never` and `no-override`. `always` and `no-override` both
+sign, since nothing here sends a pre-signed viewer request to an Origin for `no-override` to pass
+through. `never` turns the origin access control off without removing it, so the Origin reads
+anonymously and needs a Bucket policy allowing that, as an Origin with no origin access control
+does.
 
 `Ref` and `Fn::GetAtt` on `Id` both return the ID, so either resolves an Origin's
 `OriginAccessControlId`. An Origin naming an ID no origin access control holds is refused with
@@ -1179,8 +1240,7 @@ console.log(origin?.OriginAccessControlId);
 Tearing the Stack down removes the origin access control, and its name is free again.
 
 `OriginAccessControlOriginType` must be `s3` and `SigningProtocol` must be `sigv4`. Any other value
-fails the Stack by name. `SigningBehavior` takes any of `always`, `never` and `no-override`, and is
-stored as written.
+fails the Stack by name.
 
 There is no `CreateOriginAccessControl` command here, so a CloudFormation template is the only way
 to make one.
@@ -1199,7 +1259,7 @@ Sim CloudFront currently supports:
 - `DefaultRootObject` and `CustomErrorResponses`, for static sites and single-page apps
 - `viewer-request` and `viewer-response` CloudFront Functions
 - `AWS::CloudFront::ResponseHeadersPolicy`, for headers a cache Behavior sets on every response
-- `AWS::CloudFront::OriginAccessControl`, stored against the Origin that names it
+- `AWS::CloudFront::OriginAccessControl`, so an Origin reads a private Bucket as CloudFront
 - Viewer certificates from sim ACM, including CloudFront's `us-east-1` requirement
 - Serving simulated CloudFront traffic on localhost with `serveSimAws`
 
@@ -1211,16 +1271,17 @@ whether the simulator needs them to model the requested behaviour safely.
 
 Where sim CloudFront knowingly behaves differently from AWS:
 
-- **An S3 Origin reads its Bucket anonymously.** That is the unsigned request real CloudFront sends
-  to the S3 REST endpoint without an origin access control, so the Bucket policy has to make an
-  Object publicly readable for the Distribution to serve it. A legacy
+- **An S3 Origin with no origin access control reads its Bucket anonymously.** That is the unsigned
+  request real CloudFront sends to the S3 REST endpoint without one, so the Bucket policy has to
+  make an Object publicly readable for the Distribution to serve it. A legacy
   `S3OriginConfig.OriginAccessIdentity` is refused by name rather than read as anonymous: it signs
   the Origin request as a CloudFront canonical user nothing here models, so a Bucket policy written
   for one would deny the read and say nothing about why.
-- **An origin access control is stored and reported, and does not sign anything.** The Origin
-  request is unsigned whether or not the Origin names one, so a Bucket only an origin access control
-  could reach answers 403. A test can assert that an Origin was given the right origin access
-  control, and cannot yet serve a private Bucket through one.
+- **A signed Origin request is not really signed.** An Origin whose origin access control signs
+  reads the Bucket as the `cloudfront.amazonaws.com` service principal carrying the Distribution's
+  ARN, which is what the Bucket policy is evaluated against, but no SigV4 signature is computed or
+  checked. Nothing else here signs a simulated request either, so a test cannot assert anything
+  about the signature itself.
 - **An origin access control is only accepted for an S3 Origin with SigV4.** CloudFront also signs for
   MediaStore, MediaPackage V2 and Lambda Function URL Origins, and none of those is modelled. An
   `OriginAccessControlOriginType` other than `s3`, or a `SigningProtocol` other than `sigv4`, fails

--- a/docs/services/cloudfront/README.md
+++ b/docs/services/cloudfront/README.md
@@ -102,7 +102,7 @@ readable for the Distribution to serve it. A Bucket with no policy answers 403 f
 
 An Origin that does have an origin access control reads as the CloudFront service principal instead,
 so the Bucket stays private and its policy names the Distribution. See
-[Origin access controls](#origin-access-controls) for the policy that needs.
+[Origin access controls](#origin-access-controls) for the Bucket policy that takes.
 
 That is the two commands in the example above: `PutPublicAccessBlockCommand` to opt out of the block
 on public Bucket policies, then `PutBucketPolicyCommand` granting `s3:GetObject` to `Principal: "*"`.

--- a/docs/services/cloudfront/sim-cloudfront-origin-access-control.example.ts
+++ b/docs/services/cloudfront/sim-cloudfront-origin-access-control.example.ts
@@ -1,69 +1,114 @@
 /**
- * Giving a Distribution's S3 Origin an origin access control.
+ * Serving a private S3 Bucket through an origin access control.
  */
 
-import { GetDistributionCommand } from "@aws-sdk/client-cloudfront";
+import { PutObjectCommand } from "@aws-sdk/client-s3";
 
 import { SimAws } from "@kensio/yulin";
+import { serveSimAws } from "@kensio/yulin/serve";
 
 const simAws = new SimAws();
+const srv = await serveSimAws({ simAws });
 
-const stack = await simAws.cloudFormation().deployTemplate({
-  stackName: "site-stack",
-  template: {
-    Resources: {
-      SiteBucket: {
-        Type: "AWS::S3::Bucket",
-        Properties: { BucketName: "site-bucket" },
-      },
-      SiteOac: {
-        Type: "AWS::CloudFront::OriginAccessControl",
-        Properties: {
-          OriginAccessControlConfig: {
-            Name: "site-oac",
-            OriginAccessControlOriginType: "s3",
-            SigningBehavior: "always",
-            SigningProtocol: "sigv4",
+try {
+  const stack = await simAws.cloudFormation().deployTemplate({
+    stackName: "site-stack",
+    template: {
+      Resources: {
+        SiteBucket: {
+          Type: "AWS::S3::Bucket",
+          Properties: { BucketName: "site-bucket" },
+        },
+        SiteOac: {
+          Type: "AWS::CloudFront::OriginAccessControl",
+          Properties: {
+            OriginAccessControlConfig: {
+              Name: "site-oac",
+              OriginAccessControlOriginType: "s3",
+              SigningBehavior: "always",
+              SigningProtocol: "sigv4",
+            },
           },
         },
-      },
-      SiteDistribution: {
-        Type: "AWS::CloudFront::Distribution",
-        DependsOn: ["SiteBucket", "SiteOac"],
-        Properties: {
-          DistributionConfig: {
-            Enabled: true,
-            Origins: [
-              {
-                Id: "SiteOrigin",
-                DomainName: "site-bucket.s3.amazonaws.com",
-                S3OriginConfig: {},
-                OriginAccessControlId: { Ref: "SiteOac" },
+        SiteDistribution: {
+          Type: "AWS::CloudFront::Distribution",
+          Properties: {
+            DistributionConfig: {
+              Enabled: true,
+              DefaultRootObject: "index.html",
+              Origins: [
+                {
+                  Id: "SiteOrigin",
+                  DomainName: "site-bucket.s3.amazonaws.com",
+                  S3OriginConfig: {},
+                  OriginAccessControlId: { Ref: "SiteOac" },
+                },
+              ],
+              DefaultCacheBehavior: {
+                TargetOriginId: "SiteOrigin",
+                ViewerProtocolPolicy: "allow-all",
               },
-            ],
-            DefaultCacheBehavior: {
-              TargetOriginId: "SiteOrigin",
-              ViewerProtocolPolicy: "allow-all",
+            },
+          },
+        },
+        // Nothing but this Distribution may read the Bucket, which is what the
+        // condition on the Distribution's ARN says.
+        SiteBucketPolicy: {
+          Type: "AWS::S3::BucketPolicy",
+          Properties: {
+            Bucket: { Ref: "SiteBucket" },
+            PolicyDocument: {
+              Version: "2012-10-17",
+              Statement: [
+                {
+                  Effect: "Allow",
+                  Principal: { Service: "cloudfront.amazonaws.com" },
+                  Action: "s3:GetObject",
+                  Resource: "arn:aws:s3:::site-bucket/*",
+                  Condition: {
+                    StringEquals: {
+                      "AWS:SourceArn": {
+                        "Fn::Join": [
+                          "",
+                          [
+                            "arn:aws:cloudfront::",
+                            { Ref: "AWS::AccountId" },
+                            ":distribution/",
+                            { Ref: "SiteDistribution" },
+                          ],
+                        ],
+                      },
+                    },
+                  },
+                },
+              ],
             },
           },
         },
       },
+      Outputs: {
+        SiteHostname: {
+          Value: { "Fn::GetAtt": ["SiteDistribution", "DomainName"] },
+        },
+      },
     },
-    Outputs: {
-      DistributionId: { Value: { Ref: "SiteDistribution" } },
-    },
-  },
-});
+  });
 
-await stack.waitForDeployComplete();
+  await stack.waitForDeployComplete();
 
-const distributionId = stack.outputs.get("DistributionId")?.value as string;
-const output = await simAws
-  .cloudFront()
-  .getDistribution(new GetDistributionCommand({ Id: distributionId }));
+  await simAws.s3().putObject(
+    new PutObjectCommand({
+      Bucket: "site-bucket",
+      Key: "index.html",
+      ContentType: "text/html",
+      Body: "<h1>Home</h1>",
+    }),
+  );
 
-const [origin] = output.Distribution?.DistributionConfig?.Origins?.Items ?? [];
+  const siteHostname = stack.outputs.get("SiteHostname")?.value as string;
+  const home = await fetch(srv.localUrl(`http://${siteHostname}/`));
 
-// The ID the Ref resolved to, which is the origin access control the Origin
-// was created with.
-console.log(origin?.OriginAccessControlId);
+  console.log(await home.text()); // <h1>Home</h1>
+} finally {
+  await srv.close();
+}

--- a/docs/services/s3/README.md
+++ b/docs/services/s3/README.md
@@ -1083,6 +1083,30 @@ succeeds either way, matching S3's idempotent behaviour.
 A Bucket policy granting `Principal: "*"` is refused by default. See
 [Block Public Access](#block-public-access) below.
 
+### Where a request came from
+
+A request can say what it is being made for, which is what a simulated service supplies when it
+reaches a Bucket on a resource's behalf. `sourceArn` and `sourceAccount` go alongside the caller and
+reach IAM as the `aws:SourceArn` and `aws:SourceAccount` condition keys:
+
+```typescript
+await simS3.getObject(
+  new GetObjectCommand({ Bucket: "site", Key: "index.html" }),
+  {
+    caller: { kind: "service", service: "cloudfront.amazonaws.com" },
+    sourceArn: "arn:aws:cloudfront::111111111111:distribution/E1EXAMPLE",
+  },
+);
+```
+
+That is the condition a Bucket policy granting a service principal usually carries, since a service
+principal is shared by every resource of that service. A request carrying neither leaves the key out
+rather than supplying an empty string, so a statement conditioned on it fails to match. Condition
+key names are matched case insensitively, so CDK's `AWS:SourceArn` spelling matches the same key.
+
+Sim CloudFront supplies both when a Distribution's S3 Origin has an origin access control, which is
+[how it serves a private Bucket](../cloudfront/README.md#origin-access-controls).
+
 ## Block Public Access
 
 Real S3 turns on all four Block Public Access settings for every new Bucket, and `BlockPublicPolicy`

--- a/src/service/cloudformation/cdk/cloudfront/sim-cdk-cf-distro-oac.loc.test.ts
+++ b/src/service/cloudformation/cdk/cloudfront/sim-cdk-cf-distro-oac.loc.test.ts
@@ -1,0 +1,96 @@
+import path from "node:path";
+import { PutObjectCommand } from "@aws-sdk/client-s3";
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertResponseStatus,
+  describeResponse,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { simCfSiteRequest } from "../../../../../test/cloudfront/site-fixture.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { TestCdkProject } from "../../../../util/filesystem/test-cdk-project.js";
+
+/**
+ * Slower local integration test. Calls the real CDK CLI to synth the output
+ * template file and deploys the synthesized Distribution, origin access control
+ * and Bucket policy through sim CloudFormation.
+ *
+ * This is the shape a CDK static site actually has, and the one the simulator
+ * is worth having for: the Bucket admits nothing but this Distribution, and the
+ * page is served only because the Origin read carries the Distribution's ARN.
+ */
+describe("Sim CDK CloudFront origin access control local integration", () => {
+  it("serves a page through a Distribution CDK gave an origin access control", async () => {
+    // Given a CDK stack whose Distribution reaches its Bucket with an origin
+    // access control, which writes the Bucket policy granting CloudFront.
+    const cdkProject = new TestCdkProject();
+
+    await cdkProject.writeCdkAppFile(`
+import * as cdk from "aws-cdk-lib";
+import * as s3 from "aws-cdk-lib/aws-s3";
+import * as cloudfront from "aws-cdk-lib/aws-cloudfront";
+import * as origins from "aws-cdk-lib/aws-cloudfront-origins";
+
+const app = new cdk.App();
+const stack = new cdk.Stack(app, "TestStack", {
+  env: { account: "111111111111", region: "eu-west-2" },
+});
+
+const siteBucket = new s3.Bucket(stack, "SiteBucket", {
+  bucketName: "cdk-oac-site-bucket",
+});
+
+const distribution = new cloudfront.Distribution(stack, "SiteDistribution", {
+  defaultBehavior: {
+    origin: origins.S3BucketOrigin.withOriginAccessControl(siteBucket),
+  },
+});
+
+new cdk.CfnOutput(stack, "DistributionId", {
+  value: distribution.distributionId,
+});
+
+app.synth();
+`);
+
+    // And the CDK app is synthesized to a CloudFormation template.
+    const cdkOutDirectory = await cdkProject.synth();
+
+    // When the synthesized template is deployed through sim CloudFormation.
+    const simAws = new SimAws();
+    const stack = await simAws
+      .cloudFormation()
+      .deployTemplateFile(
+        path.join(cdkOutDirectory, "TestStack.template.json"),
+      );
+
+    await stack.waitForDeployComplete();
+
+    // And a page is put in the Bucket, which nothing but the Distribution may
+    // read back.
+    await simAws.s3().putObject(
+      new PutObjectCommand({
+        Bucket: "cdk-oac-site-bucket",
+        Key: "index.html",
+        ContentType: "text/html",
+        Body: "<h1>Home</h1>",
+      }),
+    );
+
+    const distributionId = stack.outputs.get("DistributionId")?.value;
+    assertNonNullable(distributionId);
+
+    const response = await simCfSiteRequest(
+      simAws,
+      distributionId as string,
+      "/index.html",
+    );
+
+    // Then the Bucket policy CDK wrote admits the Origin read and the page is
+    // served.
+    assertResponseStatus(response, 200, await describeResponse(response));
+    assertIdentical(await response.text(), "<h1>Home</h1>");
+  });
+});

--- a/src/service/cloudfront/README.md
+++ b/src/service/cloudfront/README.md
@@ -135,10 +135,11 @@ HTTP request behaviour is split across a few directories:
   that Bucket's own GetObject command, while `origin/custom/` turns the Origin request back into an
   HTTP request and sends it into the wider simulated environment.
 
-  An S3 Origin reads as an anonymous caller, which is the unsigned request real CloudFront sends to
-  the S3 REST endpoint when the Origin has no origin access control, so the Bucket policy decides
-  what the Distribution can serve. That is why `SimCloudFrontS3OriginResolver` answers with the
-  Bucket and the sim S3 holding it rather than a bare `SimS3Bucket`: the read goes through that
+  Who an S3 Origin reads as is worked out per request by `SimCfS3OriginSigner`: as the CloudFront
+  service principal where the origin access control signs, and anonymously otherwise, which is the
+  unsigned request real CloudFront sends to the S3 REST endpoint. Either way the Bucket policy
+  decides what the Distribution can serve. That is why `SimCloudFrontS3OriginResolver` answers with
+  the Bucket and the sim S3 holding it rather than a bare `SimS3Bucket`: the read goes through that
   scope's command. A denial becomes a 403 from the Origin, which the Distribution's custom error
   response for 403 can then replace.
 
@@ -192,9 +193,15 @@ nothing created is `SimCloudFrontInvalidOriginAccessControl`, as CloudFront refu
 CreateDistribution. Resolution is eager here, unlike a response headers policy, because CloudFront
 checks an origin access control at creation rather than when a request arrives.
 
-Nothing reads the stored origin access control yet. It does not sign the Origin request, so an
-Origin naming one still reads its Bucket anonymously and a Bucket only an origin access control
-could reach answers 403.
+`SimCfS3OriginSigner` reads the stored origin access control on every Origin fetch. One whose
+`signs` getter is true makes the read a request from the `cloudfront.amazonaws.com` service
+principal, carrying the Distribution's ARN as `aws:SourceArn` and its Account as
+`aws:SourceAccount`, which is the pair a Bucket policy written for an origin access control is
+conditioned on. A `never` signing behaviour reads anonymously, as an Origin with none does.
+
+That resolution is per request rather than per Origin because an Origin does not know its
+Distribution until one fetches through it. Deciding it earlier would be wrong anyway: in a CDK stack
+the Bucket policy is created after the Distribution, since it names the Distribution's ARN.
 
 ## Cross-service integration
 

--- a/src/service/cloudfront/origin/s3/sim-cf-s3-origin-oac-authorization.iso.test.ts
+++ b/src/service/cloudfront/origin/s3/sim-cf-s3-origin-oac-authorization.iso.test.ts
@@ -1,0 +1,149 @@
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertResponseStatus,
+  assertThrowsErrorAsync,
+  describeResponse,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import {
+  simCfOacCloudFrontReadStatement,
+  simCfOacPublicReadStatement,
+  simCfOacSiteBucketName,
+  simCfOacSiteDistributionArn,
+  simCfOacSitePage,
+  simCfOacSiteStack,
+} from "../../../../../test/cloudfront/oac-site-fixture.js";
+import { simCfSiteRequest } from "../../../../../test/cloudfront/site-fixture.js";
+import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+
+/**
+ * Serving a private Bucket through an origin access control.
+ *
+ * An Origin whose origin access control signs reads its Bucket as the
+ * CloudFront service principal, carrying the Distribution's ARN as
+ * `aws:SourceArn`. The Bucket policy is then the whole decision, which is the
+ * mistake worth catching locally: a condition naming the wrong Distribution, or
+ * an Origin that was never given an origin access control, looks identical to a
+ * correct one until the site 403s on deploy.
+ */
+describe("Simulated CloudFront S3 Origin with an origin access control", () => {
+  it("serves a page the Bucket policy grants this Distribution", async () => {
+    // Given a Bucket admitting CloudFront reads made by this Distribution.
+    const { simAws, distributionId } = await simCfOacSiteStack({
+      signingBehavior: "always",
+      statement: simCfOacCloudFrontReadStatement(simCfOacSiteDistributionArn),
+    });
+
+    // When a viewer asks for the page.
+    const response = await simCfSiteRequest(
+      simAws,
+      distributionId,
+      "/index.html",
+    );
+
+    // Then the signed read is allowed and the page is served.
+    assertResponseStatus(response, 200, await describeResponse(response));
+    assertIdentical(await response.text(), simCfOacSitePage);
+  });
+
+  it("refuses a read the Bucket policy grants a different Distribution", async () => {
+    // Given the same grant, conditioned on somebody else's Distribution ARN.
+    const { simAws, distributionId } = await simCfOacSiteStack({
+      signingBehavior: "always",
+      statement: simCfOacCloudFrontReadStatement(
+        "arn:aws:cloudfront::111111111111:distribution/E1OTHERONE1234",
+      ),
+    });
+
+    // When a viewer asks for the page.
+    const response = await simCfSiteRequest(
+      simAws,
+      distributionId,
+      "/index.html",
+    );
+
+    // Then the condition does not match this Distribution and the read is
+    // refused, which is the mistake a deploy would otherwise be the first to
+    // report.
+    assertResponseStatus(response, 403, await describeResponse(response));
+  });
+
+  it("refuses an Origin that was never given an origin access control", async () => {
+    // Given a Bucket admitting only CloudFront, and an Origin with nothing to
+    // sign the read with.
+    const { simAws, distributionId } = await simCfOacSiteStack({
+      statement: simCfOacCloudFrontReadStatement(simCfOacSiteDistributionArn),
+    });
+
+    // When a viewer asks for the page.
+    const response = await simCfSiteRequest(
+      simAws,
+      distributionId,
+      "/index.html",
+    );
+
+    // Then the unsigned read is refused, as it is in real CloudFront.
+    assertResponseStatus(response, 403, await describeResponse(response));
+  });
+
+  it("refuses an anonymous SDK caller reading the same Bucket", async () => {
+    // Given the Bucket admitting only CloudFront.
+    const { simAws } = await simCfOacSiteStack({
+      signingBehavior: "always",
+      statement: simCfOacCloudFrontReadStatement(simCfOacSiteDistributionArn),
+    });
+
+    // When something outside the Distribution reads the Object.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws
+        .s3()
+        .getObject(
+          { input: { Bucket: simCfOacSiteBucketName, Key: "index.html" } },
+          { caller: { kind: "anonymous" } },
+        );
+    });
+
+    // Then the grant written for CloudFront does nothing for it.
+    assertInstanceOf(error, SimIamAccessDenied);
+  });
+
+  it("reads anonymously when the signing behaviour is never", async () => {
+    // Given an origin access control turned off without being removed.
+    const { simAws, distributionId } = await simCfOacSiteStack({
+      signingBehavior: "never",
+      statement: simCfOacCloudFrontReadStatement(simCfOacSiteDistributionArn),
+    });
+
+    // When a viewer asks for the page.
+    const response = await simCfSiteRequest(
+      simAws,
+      distributionId,
+      "/index.html",
+    );
+
+    // Then nothing signed the read and the CloudFront grant does not cover it.
+    assertResponseStatus(response, 403, await describeResponse(response));
+  });
+
+  it("serves a publicly readable page when the signing behaviour is never", async () => {
+    // Given the same Origin over a Bucket anyone may read.
+    const { simAws, distributionId } = await simCfOacSiteStack({
+      signingBehavior: "never",
+      statement: simCfOacPublicReadStatement,
+      publicPolicyAllowed: true,
+    });
+
+    // When a viewer asks for the page.
+    const response = await simCfSiteRequest(
+      simAws,
+      distributionId,
+      "/index.html",
+    );
+
+    // Then the anonymous read is what serves it.
+    assertResponseStatus(response, 200, await describeResponse(response));
+    assertIdentical(await response.text(), simCfOacSitePage);
+  });
+});

--- a/src/service/cloudfront/origin/s3/sim-cf-s3-origin-oac-authorization.iso.test.ts
+++ b/src/service/cloudfront/origin/s3/sim-cf-s3-origin-oac-authorization.iso.test.ts
@@ -48,6 +48,26 @@ describe("Simulated CloudFront S3 Origin with an origin access control", () => {
     assertIdentical(await response.text(), simCfOacSitePage);
   });
 
+  it("signs the read for a no-override signing behaviour too", async () => {
+    // Given the same grant, and an origin access control that signs a request
+    // the viewer did not sign, which is every request reaching an Origin here.
+    const { simAws, distributionId } = await simCfOacSiteStack({
+      signingBehavior: "no-override",
+      statement: simCfOacCloudFrontReadStatement(simCfOacSiteDistributionArn),
+    });
+
+    // When a viewer asks for the page.
+    const response = await simCfSiteRequest(
+      simAws,
+      distributionId,
+      "/index.html",
+    );
+
+    // Then it is served, as it is for `always`.
+    assertResponseStatus(response, 200, await describeResponse(response));
+    assertIdentical(await response.text(), simCfOacSitePage);
+  });
+
   it("refuses a read the Bucket policy grants a different Distribution", async () => {
     // Given the same grant, conditioned on somebody else's Distribution ARN.
     const { simAws, distributionId } = await simCfOacSiteStack({

--- a/src/service/cloudfront/origin/s3/sim-cf-s3-origin-object-loader.ts
+++ b/src/service/cloudfront/origin/s3/sim-cf-s3-origin-object-loader.ts
@@ -1,5 +1,6 @@
 import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
 import type { SimS3BucketName } from "../../../s3/bucket/sim-s3-bucket.js";
+import type { SimS3RequestOptions } from "../../../s3/command/sim-s3-request-options.js";
 import { SimS3NoSuchKey } from "../../../s3/error/sim-s3.error.js";
 import {
   SimS3Object,
@@ -10,13 +11,16 @@ import { simS3BodyToBuffer } from "../../../s3/storage/s3-body-buffer.js";
 import type { SimCfS3OriginBucket } from "./sim-cf-s3-origin-bucket.js";
 
 /**
- * Reads Objects for a CloudFront S3 Origin, anonymously.
+ * Reads Objects for a CloudFront S3 Origin.
  *
- * Without an origin access control, CloudFront sends the S3 REST endpoint an
- * unsigned request, so the Bucket policy is the only thing that can make an
- * Object readable. Reading through the ordinary GetObject command is what
- * applies it: a Bucket with no policy answers the Distribution 403 here as it
- * does in real S3.
+ * The Bucket policy is the only thing that can make an Object readable, whether
+ * the Origin reads anonymously or as the CloudFront service principal an origin
+ * access control signs for. Reading through the ordinary GetObject command is
+ * what applies it: a Bucket whose policy covers neither answers the
+ * Distribution 403 here as it does in real S3.
+ *
+ * Who the read is made as comes in per Object, from `SimCfS3OriginSigner`,
+ * because it depends on the Distribution the request arrived at.
  */
 export class SimCfS3OriginObjectLoader {
   private readonly simS3: SimS3;
@@ -37,11 +41,12 @@ export class SimCfS3OriginObjectLoader {
    */
   async load(
     objectKey: string,
+    requestOptions: SimS3RequestOptions,
   ): Promise<SimS3Object | SimIamAccessDenied | undefined> {
     try {
       const output = await this.simS3.getObject(
         { input: { Bucket: this.bucketName, Key: objectKey } },
-        { caller: { kind: "anonymous" } },
+        requestOptions,
       );
 
       return new SimS3Object({

--- a/src/service/cloudfront/origin/s3/sim-cf-s3-origin-signer.ts
+++ b/src/service/cloudfront/origin/s3/sim-cf-s3-origin-signer.ts
@@ -1,0 +1,44 @@
+import type { SimS3RequestOptions } from "../../../s3/command/sim-s3-request-options.js";
+import { simCloudFrontDistributionArn } from "../../distribution/sim-cf-distribution-view.js";
+import type { SimCloudFrontOriginAccessControl } from "../../origin-access-control/sim-cf-origin-access-control.js";
+import { simCloudFrontServicePrincipal } from "../../sim-cloudfront-service-principal.js";
+import type { SimCloudFrontOriginRequest } from "../sim-cloudfront-request-response.js";
+
+/**
+ * Who a CloudFront S3 Origin reads its Bucket as.
+ *
+ * An origin access control that signs makes the read a request from the
+ * CloudFront service principal carrying the Distribution's ARN, which is the
+ * pair a Bucket policy for an origin access control is written against. Without
+ * one, or with a `SigningBehavior` of `never`, CloudFront sends the S3 REST
+ * endpoint an unsigned request, so the read is anonymous.
+ *
+ * Which Distribution the read belongs to is only known per request, so this
+ * answers per read rather than when the Origin is built. Nothing about the read
+ * could be settled earlier anyway: in a CDK stack the Bucket policy is created
+ * after the Distribution, because it names the Distribution's ARN.
+ */
+export class SimCfS3OriginSigner {
+  private readonly originAccessControl:
+    | SimCloudFrontOriginAccessControl
+    | undefined;
+
+  constructor(originAccessControl?: SimCloudFrontOriginAccessControl) {
+    this.originAccessControl = originAccessControl;
+  }
+
+  /**
+   * The S3 request options one Origin read is made with.
+   */
+  forRequest(request: SimCloudFrontOriginRequest): SimS3RequestOptions {
+    if (this.originAccessControl?.signs !== true) {
+      return { caller: { kind: "anonymous" } };
+    }
+
+    return {
+      caller: { kind: "service", service: simCloudFrontServicePrincipal },
+      sourceArn: simCloudFrontDistributionArn(request.distribution),
+      sourceAccount: request.distribution.accountId,
+    };
+  }
+}

--- a/src/service/cloudfront/origin/s3/sim-cloudfront-s3-origin.ts
+++ b/src/service/cloudfront/origin/s3/sim-cloudfront-s3-origin.ts
@@ -6,6 +6,7 @@ import type { SimCfS3OriginBucket } from "./sim-cf-s3-origin-bucket.js";
 import { SimCfS3OriginObjectKey } from "./sim-cf-s3-origin-object-key.js";
 import { SimCfS3OriginObjectLoader } from "./sim-cf-s3-origin-object-loader.js";
 import { SimCfS3OriginResponses } from "./sim-cf-s3-origin-responses.js";
+import { SimCfS3OriginSigner } from "./sim-cf-s3-origin-signer.js";
 
 export type SimCloudFrontS3OriginResolver = (
   originDomainName: string,
@@ -30,19 +31,21 @@ interface SimCloudFrontS3OriginProperties {
  *
  * This represents a basic S3 object origin, not an S3 static website endpoint.
  *
- * Objects are read through the ordinary GetObject command as an anonymous
- * caller, which is the unsigned request real CloudFront sends to the S3 REST
- * endpoint when the Origin has no origin access control. An Object the Bucket
- * policy has not made publicly readable is therefore refused, and the refusal
- * reaches the viewer as the Origin answering 403.
+ * Objects are read through the ordinary GetObject command, so the Bucket policy
+ * decides what the Origin can serve. An Origin whose origin access control
+ * signs reads as the CloudFront service principal, and one without reads
+ * anonymously, which is the unsigned request real CloudFront sends to the S3
+ * REST endpoint. An Object the Bucket policy does not make readable by whoever
+ * the Origin is reading as is refused, and the refusal reaches the viewer as
+ * the Origin answering 403.
  */
 export class SimCloudFrontS3Origin implements SimCloudFrontOrigin {
   /**
    * The origin access control this Origin was created with, if any.
    *
-   * It is stored and reported, and it does not yet sign the read below: the
-   * Object is read anonymously either way, so a Bucket only an origin access
-   * control could reach answers 403 until signing is simulated.
+   * One that signs is what makes the read below a request from the CloudFront
+   * service principal carrying this Distribution's ARN, so a Bucket policy
+   * written for an origin access control is what decides the read.
    */
   public readonly originAccessControl:
     | SimCloudFrontOriginAccessControl
@@ -51,9 +54,11 @@ export class SimCloudFrontS3Origin implements SimCloudFrontOrigin {
   private readonly loader: SimCfS3OriginObjectLoader;
   private readonly responses: SimCfS3OriginResponses;
   private readonly objectKey: SimCfS3OriginObjectKey;
+  private readonly signer: SimCfS3OriginSigner;
 
   constructor(properties: SimCloudFrontS3OriginProperties) {
     this.loader = new SimCfS3OriginObjectLoader(properties.originBucket);
+    this.signer = new SimCfS3OriginSigner(properties.originAccessControl);
     this.responses = new SimCfS3OriginResponses(
       properties.originBucket.bucket.bucketName,
     );
@@ -72,7 +77,10 @@ export class SimCloudFrontS3Origin implements SimCloudFrontOrigin {
     }
 
     const objectKey = this.objectKey.forRequest(request);
-    const object = await this.loader.load(objectKey);
+    const object = await this.loader.load(
+      objectKey,
+      this.signer.forRequest(request),
+    );
 
     if (object instanceof SimIamAccessDenied) {
       return this.responses.accessDenied(objectKey);

--- a/src/service/cloudfront/sim-cloudfront-service-principal.ts
+++ b/src/service/cloudfront/sim-cloudfront-service-principal.ts
@@ -1,0 +1,8 @@
+/**
+ * The service principal CloudFront reaches an Origin as.
+ *
+ * A Bucket policy written for an origin access control grants this principal,
+ * so it lives at the service root rather than inside the S3 Origin that uses
+ * it today.
+ */
+export const simCloudFrontServicePrincipal = "cloudfront.amazonaws.com";

--- a/src/service/s3/README.md
+++ b/src/service/s3/README.md
@@ -99,6 +99,15 @@ command means adding one method to the area it belongs to. `requireSimS3Bucket` 
 that raises `SimS3NoSuchBucket`, which is what real S3 answers before considering anything else
 about a Bucket-scoped request.
 
+Every command takes the same `SimS3RequestOptions` alongside its input: the caller, and the
+`sourceArn` and `sourceAccount` a simulated service reaching a Bucket on a resource's behalf
+supplies. `simS3ConditionContext` in `command/authorize/` turns the latter two into the
+`aws:SourceArn` and `aws:SourceAccount` condition keys every authorizer passes to IAM, which is what
+a Bucket policy granting a service principal is usually conditioned on. A request carrying neither
+leaves the keys out rather than supplying empty strings, so a statement conditioned on one fails to
+match instead of matching an empty value. Sim CloudFront supplies both when an Origin's origin
+access control signs the read.
+
 It's important that implementation code under `src/` does not depend on real AWS SDK package
 classes. Command types are local structural types with shapes compatible with the AWS SDK. Tests may
 use real AWS SDK command classes to prove compatibility.

--- a/src/service/s3/command/authorize/sim-s3-condition-context.ts
+++ b/src/service/s3/command/authorize/sim-s3-condition-context.ts
@@ -1,0 +1,29 @@
+import type { SimIamConditionValue } from "../../../iam/policy/sim-iam-policy.js";
+import {
+  simS3SourceAccountConditionKey,
+  simS3SourceArnConditionKey,
+  type SimS3RequestOptions,
+} from "../sim-s3-request-options.js";
+
+/**
+ * The request-time values a Bucket policy statement's conditions are matched
+ * against.
+ *
+ * A value the request does not carry is left out rather than supplied empty, so
+ * a statement conditioned on it fails to match instead of matching an empty
+ * string. That is the safe direction: a grant written for one CloudFront
+ * Distribution should not admit a read that says nothing about where it came
+ * from.
+ */
+export function simS3ConditionContext(
+  options: SimS3RequestOptions | undefined,
+): Readonly<Record<string, SimIamConditionValue>> {
+  return {
+    ...(options?.sourceArn !== undefined && {
+      [simS3SourceArnConditionKey]: options.sourceArn,
+    }),
+    ...(options?.sourceAccount !== undefined && {
+      [simS3SourceAccountConditionKey]: options.sourceAccount,
+    }),
+  };
+}

--- a/src/service/s3/command/authorize/sim-s3-source-condition.iso.test.ts
+++ b/src/service/s3/command/authorize/sim-s3-source-condition.iso.test.ts
@@ -1,0 +1,163 @@
+import {
+  CreateBucketCommand,
+  GetObjectCommand,
+  PutBucketPolicyCommand,
+  PutObjectCommand,
+} from "@aws-sdk/client-s3";
+import { assertInstanceOf, assertThrowsErrorAsync } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+import type { SimS3 } from "../../sim-s3.js";
+import type { SimS3RequestOptions } from "../sim-s3-request-options.js";
+
+/**
+ * The source condition keys a simulated service supplies with an S3 request.
+ *
+ * A Bucket policy granting a service principal is nearly always conditioned on
+ * `aws:SourceArn`, because a service principal is shared by every resource of
+ * that service. Supplying it is what tells one CloudFront Distribution, or one
+ * Account's resources, from another.
+ */
+describe("Simulated S3 request source conditions", () => {
+  const distributionArn =
+    "arn:aws:cloudfront::111111111111:distribution/E1EXAMPLE";
+
+  const cloudFrontCaller = {
+    kind: "service",
+    service: "cloudfront.amazonaws.com",
+  } as const;
+
+  /**
+   * A Bucket holding one Object, with a policy granting CloudFront the read
+   * under the given condition.
+   */
+  const bucketGranting = async (condition: unknown): Promise<SimS3> => {
+    const simS3 = new SimAws().s3();
+
+    await simS3.createBucket(new CreateBucketCommand({ Bucket: "site" }));
+    await simS3.putObject(
+      new PutObjectCommand({
+        Bucket: "site",
+        Key: "index.html",
+        Body: "<h1>Home</h1>",
+      }),
+    );
+    await simS3.putBucketPolicy(
+      new PutBucketPolicyCommand({
+        Bucket: "site",
+        Policy: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: [
+            {
+              Effect: "Allow",
+              Principal: { Service: "cloudfront.amazonaws.com" },
+              Action: "s3:GetObject",
+              Resource: "arn:aws:s3:::site/*",
+              Condition: condition,
+            },
+          ],
+        }),
+      }),
+    );
+
+    return simS3;
+  };
+
+  const readAsCloudFront = async (
+    simS3: SimS3,
+    options: SimS3RequestOptions,
+  ): Promise<unknown> =>
+    await simS3.getObject(
+      new GetObjectCommand({ Bucket: "site", Key: "index.html" }),
+      options,
+    );
+
+  it("allows a read carrying the source ARN the policy names", async () => {
+    // Given a grant conditioned on one Distribution's ARN.
+    const simS3 = await bucketGranting({
+      StringEquals: { "aws:SourceArn": distributionArn },
+    });
+
+    // When the read carries that ARN.
+    // Then it is allowed, and nothing is thrown.
+    await readAsCloudFront(simS3, {
+      caller: cloudFrontCaller,
+      sourceArn: distributionArn,
+    });
+  });
+
+  it("matches the condition key however it is capitalised", async () => {
+    // Given the same grant written the way CDK writes it.
+    const simS3 = await bucketGranting({
+      StringEquals: { "AWS:SourceArn": distributionArn },
+    });
+
+    // When the read carries the ARN.
+    // Then the key name is matched case insensitively, as IAM matches it.
+    await readAsCloudFront(simS3, {
+      caller: cloudFrontCaller,
+      sourceArn: distributionArn,
+    });
+  });
+
+  it("refuses a read carrying a different source ARN", async () => {
+    // Given a grant conditioned on one Distribution's ARN.
+    const simS3 = await bucketGranting({
+      StringEquals: { "aws:SourceArn": distributionArn },
+    });
+
+    // When the read comes from another Distribution.
+    const error = await assertThrowsErrorAsync(async () => {
+      await readAsCloudFront(simS3, {
+        caller: cloudFrontCaller,
+        sourceArn:
+          "arn:aws:cloudfront::111111111111:distribution/E1OTHERONE1234",
+      });
+    });
+
+    // Then the statement does not apply to it.
+    assertInstanceOf(error, SimIamAccessDenied);
+  });
+
+  it("refuses a read carrying no source at all", async () => {
+    // Given the same grant.
+    const simS3 = await bucketGranting({
+      StringEquals: { "aws:SourceArn": distributionArn },
+    });
+
+    // When the read says nothing about where it came from.
+    const error = await assertThrowsErrorAsync(async () => {
+      await readAsCloudFront(simS3, { caller: cloudFrontCaller });
+    });
+
+    // Then the missing key fails the condition rather than matching an empty
+    // string, which is the safe direction.
+    assertInstanceOf(error, SimIamAccessDenied);
+  });
+
+  it("matches a source Account condition the same way", async () => {
+    // Given a grant conditioned on the Account owning the calling resource.
+    const simS3 = await bucketGranting({
+      StringEquals: { "aws:SourceAccount": "111111111111" },
+    });
+
+    // When the read carries that Account.
+    // Then it is allowed.
+    await readAsCloudFront(simS3, {
+      caller: cloudFrontCaller,
+      sourceAccount: "111111111111",
+    });
+
+    // And a read from another Account's resource is refused.
+    const error = await assertThrowsErrorAsync(async () => {
+      await readAsCloudFront(simS3, {
+        caller: cloudFrontCaller,
+        sourceAccount: "222222222222",
+      });
+    });
+
+    assertInstanceOf(error, SimIamAccessDenied);
+  });
+});

--- a/src/service/s3/command/create-bucket/create-bucket.handler.ts
+++ b/src/service/s3/command/create-bucket/create-bucket.handler.ts
@@ -17,8 +17,9 @@ import {
   SimIamAllowAllAuth,
   type SimIamInterServiceAuthZ,
 } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
-import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimS3RequestOptions } from "../sim-s3-request-options.js";
 import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+import { simS3ConditionContext } from "../authorize/sim-s3-condition-context.js";
 
 interface CreateBucketCommandHandlerProperties {
   readonly accountRegionScope: SimAwsAccountRegionScope;
@@ -26,10 +27,6 @@ interface CreateBucketCommandHandlerProperties {
   readonly s3GlobalRegistry: SimS3GlobalRegistry;
   readonly iam?: SimIamInterServiceAuthZ;
   readonly background?: BackgroundScheduler;
-}
-
-interface CreateBucketCommandHandlerOptions {
-  readonly caller?: SimAwsCaller;
 }
 
 /**
@@ -67,7 +64,7 @@ export class CreateBucketCommandHandler implements CommandHandler<
    */
   async handle(
     command: SimCreateBucketCommand,
-    options?: CreateBucketCommandHandlerOptions,
+    options?: SimS3RequestOptions,
   ): Promise<SimCreateBucketCommandOutput> {
     assertDefined(
       command.input.Bucket,
@@ -85,6 +82,7 @@ export class CreateBucketCommandHandler implements CommandHandler<
       action: "s3:CreateBucket",
       resource,
       caller: options?.caller,
+      conditionContext: simS3ConditionContext(options),
     });
 
     if (decision.isDenied) {

--- a/src/service/s3/command/delete-bucket-policy/delete-bucket-policy-authorizer.ts
+++ b/src/service/s3/command/delete-bucket-policy/delete-bucket-policy-authorizer.ts
@@ -1,9 +1,10 @@
-import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
 import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
 import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
 import { simS3BucketArn } from "../../bucket/sim-s3-bucket-arn.js";
 import type { SimS3Bucket } from "../../bucket/sim-s3-bucket.js";
 import { simS3BucketResourcePolicies } from "../authorize/sim-s3-bucket-resource-policies.js";
+import { simS3ConditionContext } from "../authorize/sim-s3-condition-context.js";
+import type { SimS3RequestOptions } from "../sim-s3-request-options.js";
 
 interface DeleteBucketPolicyAuthorizerProperties {
   readonly iam: SimIamInterServiceAuthZ;
@@ -27,12 +28,13 @@ export class DeleteBucketPolicyAuthorizer {
   /**
    * Ensure the caller may remove the Bucket policy.
    */
-  authorize(bucket: SimS3Bucket, caller?: SimAwsCaller): void {
+  authorize(bucket: SimS3Bucket, options?: SimS3RequestOptions): void {
     const resource = simS3BucketArn(bucket.bucketName);
     const decision = this.iam.authorize({
       action: DeleteBucketPolicyAuthorizer.action,
       resource,
-      caller,
+      caller: options?.caller,
+      conditionContext: simS3ConditionContext(options),
       resourcePolicies: simS3BucketResourcePolicies(bucket),
     });
 

--- a/src/service/s3/command/delete-bucket-policy/delete-bucket-policy.handler.ts
+++ b/src/service/s3/command/delete-bucket-policy/delete-bucket-policy.handler.ts
@@ -4,7 +4,7 @@ import {
   BackgroundTasks,
 } from "../../../../util/background/background.js";
 import { assertDefined } from "../../../../util/type-guard/defined.js";
-import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimS3RequestOptions } from "../sim-s3-request-options.js";
 import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
 import { SimIamAllowAllAuth } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
 import type {
@@ -22,10 +22,6 @@ interface DeleteBucketPolicyCommandHandlerProperties {
   readonly buckets: Map<SimS3BucketName, SimS3Bucket>;
   readonly iam?: SimIamInterServiceAuthZ;
   readonly background?: BackgroundScheduler;
-}
-
-interface DeleteBucketPolicyCommandHandlerOptions {
-  readonly caller?: SimAwsCaller;
 }
 
 /**
@@ -59,7 +55,7 @@ export class DeleteBucketPolicyCommandHandler implements CommandHandler<
    */
   async handle(
     command: SimDeleteBucketPolicyCommand,
-    options?: DeleteBucketPolicyCommandHandlerOptions,
+    options?: SimS3RequestOptions,
   ): Promise<SimDeleteBucketPolicyCommandOutput> {
     assertDefined(
       command.input.Bucket,
@@ -71,7 +67,7 @@ export class DeleteBucketPolicyCommandHandler implements CommandHandler<
 
     await this.background.sequence();
 
-    this.authorizer.authorize(bucket, options?.caller);
+    this.authorizer.authorize(bucket, options);
 
     bucket.deletePolicy();
 

--- a/src/service/s3/command/delete-bucket/delete-bucket-authorizer.ts
+++ b/src/service/s3/command/delete-bucket/delete-bucket-authorizer.ts
@@ -1,9 +1,10 @@
-import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
 import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
 import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
 import { simS3BucketArn } from "../../bucket/sim-s3-bucket-arn.js";
 import type { SimS3Bucket } from "../../bucket/sim-s3-bucket.js";
 import { simS3BucketResourcePolicies } from "../authorize/sim-s3-bucket-resource-policies.js";
+import { simS3ConditionContext } from "../authorize/sim-s3-condition-context.js";
+import type { SimS3RequestOptions } from "../sim-s3-request-options.js";
 
 interface DeleteBucketAuthorizerProperties {
   readonly iam: SimIamInterServiceAuthZ;
@@ -28,12 +29,13 @@ export class DeleteBucketAuthorizer {
   /**
    * Ensure the caller may delete the Bucket.
    */
-  authorize(bucket: SimS3Bucket, caller?: SimAwsCaller): void {
+  authorize(bucket: SimS3Bucket, options?: SimS3RequestOptions): void {
     const resource = simS3BucketArn(bucket.bucketName);
     const decision = this.iam.authorize({
       action: DeleteBucketAuthorizer.action,
       resource,
-      caller,
+      caller: options?.caller,
+      conditionContext: simS3ConditionContext(options),
       resourcePolicies: simS3BucketResourcePolicies(bucket),
     });
 

--- a/src/service/s3/command/delete-bucket/delete-bucket.handler.ts
+++ b/src/service/s3/command/delete-bucket/delete-bucket.handler.ts
@@ -4,7 +4,7 @@ import {
   BackgroundTasks,
 } from "../../../../util/background/background.js";
 import { assertDefined } from "../../../../util/type-guard/defined.js";
-import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimS3RequestOptions } from "../sim-s3-request-options.js";
 import {
   SimIamAllowAllAuth,
   type SimIamInterServiceAuthZ,
@@ -27,10 +27,6 @@ interface DeleteBucketCommandHandlerProperties {
   readonly s3GlobalRegistry: SimS3GlobalRegistry;
   readonly iam?: SimIamInterServiceAuthZ;
   readonly background?: BackgroundScheduler;
-}
-
-interface DeleteBucketCommandHandlerOptions {
-  readonly caller?: SimAwsCaller;
 }
 
 /**
@@ -74,7 +70,7 @@ export class DeleteBucketCommandHandler implements CommandHandler<
    */
   async handle(
     command: SimDeleteBucketCommand,
-    options?: DeleteBucketCommandHandlerOptions,
+    options?: SimS3RequestOptions,
   ): Promise<SimDeleteBucketCommandOutput> {
     assertDefined(command.input.Bucket, "DeleteBucketCommand.input.Bucket");
 
@@ -83,7 +79,7 @@ export class DeleteBucketCommandHandler implements CommandHandler<
 
     await this.background.sequence();
 
-    this.authorizer.authorize(bucket, options?.caller);
+    this.authorizer.authorize(bucket, options);
     await this.assertEmpty(bucket);
 
     this.buckets.delete(bucketName);

--- a/src/service/s3/command/delete-object/delete-object-authorizer.ts
+++ b/src/service/s3/command/delete-object/delete-object-authorizer.ts
@@ -1,10 +1,11 @@
-import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
 import type { SimAwsResolvedCaller } from "../../../aws/caller/sim-aws-caller-resolver.js";
 import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
 import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
 import { simS3BucketArn } from "../../bucket/sim-s3-bucket-arn.js";
 import type { SimS3Bucket } from "../../bucket/sim-s3-bucket.js";
 import { simS3BucketResourcePolicies } from "../authorize/sim-s3-bucket-resource-policies.js";
+import { simS3ConditionContext } from "../authorize/sim-s3-condition-context.js";
+import type { SimS3RequestOptions } from "../sim-s3-request-options.js";
 
 interface DeleteObjectAuthorizerProperties {
   readonly iam: SimIamInterServiceAuthZ;
@@ -40,13 +41,14 @@ export class DeleteObjectAuthorizer {
   authorize(
     bucket: SimS3Bucket,
     key: string,
-    caller?: SimAwsCaller,
+    options?: SimS3RequestOptions,
   ): SimAwsResolvedCaller {
     const resource = `${simS3BucketArn(bucket.bucketName)}/${key}`;
     const decision = this.iam.authorize({
       action: DeleteObjectAuthorizer.action,
       resource,
-      caller,
+      caller: options?.caller,
+      conditionContext: simS3ConditionContext(options),
       resourcePolicies: simS3BucketResourcePolicies(bucket),
     });
 

--- a/src/service/s3/command/delete-object/delete-object.handler.ts
+++ b/src/service/s3/command/delete-object/delete-object.handler.ts
@@ -4,7 +4,7 @@ import {
   BackgroundTasks,
 } from "../../../../util/background/background.js";
 import { assertDefined } from "../../../../util/type-guard/defined.js";
-import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimS3RequestOptions } from "../sim-s3-request-options.js";
 import {
   SimIamAllowAllAuth,
   type SimIamInterServiceAuthZ,
@@ -26,10 +26,6 @@ interface DeleteObjectCommandHandlerProperties {
   readonly iam?: SimIamInterServiceAuthZ;
   readonly background?: BackgroundScheduler;
   readonly notifications: SimS3ObjectNotifier;
-}
-
-interface DeleteObjectCommandHandlerOptions {
-  readonly caller?: SimAwsCaller;
 }
 
 /**
@@ -68,7 +64,7 @@ export class DeleteObjectCommandHandler implements CommandHandler<
    */
   async handle(
     command: SimDeleteObjectCommand,
-    options?: DeleteObjectCommandHandlerOptions,
+    options?: SimS3RequestOptions,
   ): Promise<SimDeleteObjectCommandOutput> {
     assertDefined(command.input.Bucket, "DeleteObjectCommand.input.Bucket");
     assertDefined(command.input.Key, "DeleteObjectCommand.input.Key");
@@ -81,7 +77,7 @@ export class DeleteObjectCommandHandler implements CommandHandler<
     const caller = this.authorizer.authorize(
       bucket,
       command.input.Key,
-      options?.caller,
+      options,
     );
 
     const removed = await bucket.deleteObject(command.input.Key);

--- a/src/service/s3/command/delete-objects/delete-objects-key-removal.ts
+++ b/src/service/s3/command/delete-objects/delete-objects-key-removal.ts
@@ -1,4 +1,4 @@
-import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimS3RequestOptions } from "../sim-s3-request-options.js";
 import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
 import type { SimS3Bucket } from "../../bucket/sim-s3-bucket.js";
 import type { SimS3ObjectNotifier } from "../../notification/sim-s3-object-notifier.js";
@@ -33,10 +33,10 @@ export class DeleteObjectsKeyRemoval {
   async remove(
     bucket: SimS3Bucket,
     key: string,
-    caller?: SimAwsCaller,
+    options?: SimS3RequestOptions,
   ): Promise<DeleteObjectAttempt> {
     try {
-      const resolvedCaller = this.authorizer.authorize(bucket, key, caller);
+      const resolvedCaller = this.authorizer.authorize(bucket, key, options);
       const removed = await bucket.deleteObject(key);
 
       if (removed) {

--- a/src/service/s3/command/delete-objects/delete-objects.handler.ts
+++ b/src/service/s3/command/delete-objects/delete-objects.handler.ts
@@ -4,7 +4,7 @@ import {
   BackgroundTasks,
 } from "../../../../util/background/background.js";
 import { assertDefined } from "../../../../util/type-guard/defined.js";
-import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimS3RequestOptions } from "../sim-s3-request-options.js";
 import {
   SimIamAllowAllAuth,
   type SimIamInterServiceAuthZ,
@@ -28,10 +28,6 @@ interface DeleteObjectsCommandHandlerProperties {
   readonly iam?: SimIamInterServiceAuthZ;
   readonly background?: BackgroundScheduler;
   readonly notifications: SimS3ObjectNotifier;
-}
-
-interface DeleteObjectsCommandHandlerOptions {
-  readonly caller?: SimAwsCaller;
 }
 
 /**
@@ -70,7 +66,7 @@ export class DeleteObjectsCommandHandler implements CommandHandler<
    */
   async handle(
     command: SimDeleteObjectsCommand,
-    options?: DeleteObjectsCommandHandlerOptions,
+    options?: SimS3RequestOptions,
   ): Promise<SimDeleteObjectsCommandOutput> {
     assertDefined(command.input.Bucket, "DeleteObjectsCommand.input.Bucket");
     assertDefined(command.input.Delete, "DeleteObjectsCommand.input.Delete");
@@ -83,7 +79,7 @@ export class DeleteObjectsCommandHandler implements CommandHandler<
 
     const attempts = await Promise.all(
       request.keys.map(
-        async (key) => await this.removal.remove(bucket, key, options?.caller),
+        async (key) => await this.removal.remove(bucket, key, options),
       ),
     );
 

--- a/src/service/s3/command/delete-public-access-block/delete-public-access-block.handler.ts
+++ b/src/service/s3/command/delete-public-access-block/delete-public-access-block.handler.ts
@@ -4,7 +4,7 @@ import {
   BackgroundTasks,
 } from "../../../../util/background/background.js";
 import { assertDefined } from "../../../../util/type-guard/defined.js";
-import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimS3RequestOptions } from "../sim-s3-request-options.js";
 import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
 import { SimIamAllowAllAuth } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
 import type {
@@ -22,10 +22,6 @@ interface DeletePublicAccessBlockCommandHandlerProperties {
   readonly buckets: Map<SimS3BucketName, SimS3Bucket>;
   readonly iam?: SimIamInterServiceAuthZ;
   readonly background?: BackgroundScheduler;
-}
-
-interface DeletePublicAccessBlockCommandHandlerOptions {
-  readonly caller?: SimAwsCaller;
 }
 
 /**
@@ -57,7 +53,7 @@ export class DeletePublicAccessBlockCommandHandler implements CommandHandler<
    */
   async handle(
     command: SimDeletePublicAccessBlockCommand,
-    options?: DeletePublicAccessBlockCommandHandlerOptions,
+    options?: SimS3RequestOptions,
   ): Promise<SimDeletePublicAccessBlockCommandOutput> {
     assertDefined(
       command.input.Bucket,
@@ -69,7 +65,7 @@ export class DeletePublicAccessBlockCommandHandler implements CommandHandler<
 
     await this.background.sequence();
 
-    this.authorizer.authorizeWrite(bucket, options?.caller);
+    this.authorizer.authorizeWrite(bucket, options);
 
     bucket.deletePublicAccessBlock();
 

--- a/src/service/s3/command/get-bucket-notification-configuration/get-bucket-notification-configuration.handler.ts
+++ b/src/service/s3/command/get-bucket-notification-configuration/get-bucket-notification-configuration.handler.ts
@@ -4,7 +4,7 @@ import {
   BackgroundTasks,
 } from "../../../../util/background/background.js";
 import { assertDefined } from "../../../../util/type-guard/defined.js";
-import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimS3RequestOptions } from "../sim-s3-request-options.js";
 import {
   SimIamAllowAllAuth,
   type SimIamInterServiceAuthZ,
@@ -24,10 +24,6 @@ interface GetBucketNotificationConfigurationHandlerProperties {
   readonly buckets: Map<SimS3BucketName, SimS3Bucket>;
   readonly iam?: SimIamInterServiceAuthZ;
   readonly background?: BackgroundScheduler;
-}
-
-interface GetBucketNotificationConfigurationHandlerOptions {
-  readonly caller?: SimAwsCaller;
 }
 
 /**
@@ -64,7 +60,7 @@ export class GetBucketNotificationConfigurationCommandHandler implements Command
    */
   async handle(
     command: SimGetBucketNotificationConfigurationCommand,
-    options?: GetBucketNotificationConfigurationHandlerOptions,
+    options?: SimS3RequestOptions,
   ): Promise<SimGetBucketNotificationConfigurationCommandOutput> {
     assertDefined(
       command.input.Bucket,
@@ -76,7 +72,7 @@ export class GetBucketNotificationConfigurationCommandHandler implements Command
 
     await this.background.sequence();
 
-    this.authorizer.authorizeRead(bucket, options?.caller);
+    this.authorizer.authorizeRead(bucket, options);
 
     return {
       ...bucket.getNotifications().toOutput(),

--- a/src/service/s3/command/get-bucket-policy/get-bucket-policy-authorizer.ts
+++ b/src/service/s3/command/get-bucket-policy/get-bucket-policy-authorizer.ts
@@ -1,9 +1,10 @@
-import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
 import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
 import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
 import { simS3BucketArn } from "../../bucket/sim-s3-bucket-arn.js";
 import type { SimS3Bucket } from "../../bucket/sim-s3-bucket.js";
 import { simS3BucketResourcePolicies } from "../authorize/sim-s3-bucket-resource-policies.js";
+import { simS3ConditionContext } from "../authorize/sim-s3-condition-context.js";
+import type { SimS3RequestOptions } from "../sim-s3-request-options.js";
 
 interface GetBucketPolicyAuthorizerProperties {
   readonly iam: SimIamInterServiceAuthZ;
@@ -24,12 +25,13 @@ export class GetBucketPolicyAuthorizer {
   /**
    * Ensure the caller may read the Bucket policy.
    */
-  authorize(bucket: SimS3Bucket, caller?: SimAwsCaller): void {
+  authorize(bucket: SimS3Bucket, options?: SimS3RequestOptions): void {
     const resource = simS3BucketArn(bucket.bucketName);
     const decision = this.iam.authorize({
       action: GetBucketPolicyAuthorizer.action,
       resource,
-      caller,
+      caller: options?.caller,
+      conditionContext: simS3ConditionContext(options),
       resourcePolicies: simS3BucketResourcePolicies(bucket),
     });
 

--- a/src/service/s3/command/get-bucket-policy/get-bucket-policy.handler.ts
+++ b/src/service/s3/command/get-bucket-policy/get-bucket-policy.handler.ts
@@ -5,7 +5,7 @@ import {
 } from "../../../../util/background/background.js";
 import { assertDefined } from "../../../../util/type-guard/defined.js";
 import { jsonStringify } from "../../../../util/type-guard/json.js";
-import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimS3RequestOptions } from "../sim-s3-request-options.js";
 import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
 import { SimIamAllowAllAuth } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
 import type {
@@ -24,10 +24,6 @@ interface GetBucketPolicyCommandHandlerProperties {
   readonly buckets: Map<SimS3BucketName, SimS3Bucket>;
   readonly iam?: SimIamInterServiceAuthZ;
   readonly background?: BackgroundScheduler;
-}
-
-interface GetBucketPolicyCommandHandlerOptions {
-  readonly caller?: SimAwsCaller;
 }
 
 /**
@@ -58,7 +54,7 @@ export class GetBucketPolicyCommandHandler implements CommandHandler<
    */
   async handle(
     command: SimGetBucketPolicyCommand,
-    options?: GetBucketPolicyCommandHandlerOptions,
+    options?: SimS3RequestOptions,
   ): Promise<SimGetBucketPolicyCommandOutput> {
     assertDefined(command.input.Bucket, "GetBucketPolicyCommand.input.Bucket");
 
@@ -67,7 +63,7 @@ export class GetBucketPolicyCommandHandler implements CommandHandler<
 
     await this.background.sequence();
 
-    this.authorizer.authorize(bucket, options?.caller);
+    this.authorizer.authorize(bucket, options);
 
     const policy = bucket.getPolicy();
     if (policy === undefined) {

--- a/src/service/s3/command/get-object/get-object-authorizer.ts
+++ b/src/service/s3/command/get-object/get-object-authorizer.ts
@@ -1,7 +1,8 @@
-import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
 import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
 import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
 import type { SimS3Bucket } from "../../bucket/sim-s3-bucket.js";
+import { simS3ConditionContext } from "../authorize/sim-s3-condition-context.js";
+import type { SimS3RequestOptions } from "../sim-s3-request-options.js";
 
 interface GetObjectAuthorizerProperties {
   readonly iam: SimIamInterServiceAuthZ;
@@ -13,6 +14,10 @@ interface GetObjectAuthorizerProperties {
  * GetObject is authorized against the target Object ARN rather than the Bucket
  * ARN. An omitted caller is passed through to sim IAM so Account root fallback
  * behavior remains owned by IAM.
+ *
+ * The request's source ARN and source Account go in as condition keys, which is
+ * what a Bucket policy written for a CloudFront origin access control is
+ * conditioned on.
  */
 export class GetObjectAuthorizer {
   private static readonly action = "s3:GetObject";
@@ -26,13 +31,18 @@ export class GetObjectAuthorizer {
   /**
    * Ensure the caller may read the requested S3 Object.
    */
-  authorize(bucket: SimS3Bucket, key: string, caller?: SimAwsCaller): void {
+  authorize(
+    bucket: SimS3Bucket,
+    key: string,
+    options?: SimS3RequestOptions,
+  ): void {
     const resource = `arn:aws:s3:::${bucket.bucketName}/${key}`;
     const policy = bucket.getPolicy();
     const decision = this.iam.authorize({
       action: GetObjectAuthorizer.action,
       resource,
-      caller,
+      caller: options?.caller,
+      conditionContext: simS3ConditionContext(options),
       resourcePolicies:
         policy === undefined
           ? []

--- a/src/service/s3/command/get-object/get-object.handler.ts
+++ b/src/service/s3/command/get-object/get-object.handler.ts
@@ -17,7 +17,7 @@ import {
   SimIamAllowAllAuth,
   type SimIamInterServiceAuthZ,
 } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
-import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimS3RequestOptions } from "../sim-s3-request-options.js";
 import { GetObjectAuthorizer } from "./get-object-authorizer.js";
 import { GetObjectLoader } from "./get-object-loader.js";
 
@@ -25,10 +25,6 @@ interface GetObjectCommandHandlerProperties {
   readonly buckets: Map<SimS3BucketName, SimS3Bucket>;
   readonly iam?: SimIamInterServiceAuthZ;
   readonly background?: BackgroundScheduler;
-}
-
-interface GetObjectCommandHandlerOptions {
-  readonly caller?: SimAwsCaller;
 }
 
 /**
@@ -69,7 +65,7 @@ export class GetObjectCommandHandler implements CommandHandler<
    */
   async handle(
     command: SimGetObjectCommand,
-    options?: GetObjectCommandHandlerOptions,
+    options?: SimS3RequestOptions,
   ): Promise<SimGetObjectCommandOutput> {
     assertDefined(command.input.Bucket, "GetObjectCommand.input.Bucket");
     assertDefined(command.input.Key, "GetObjectCommand.input.Key");
@@ -83,7 +79,7 @@ export class GetObjectCommandHandler implements CommandHandler<
     // Complete request sequencing before authorization and storage access.
     await this.background.sequence();
 
-    this.authorizer.authorize(bucket, command.input.Key, options?.caller);
+    this.authorizer.authorize(bucket, command.input.Key, options);
 
     return await this.loader.load(bucket, command.input.Key);
   }

--- a/src/service/s3/command/get-public-access-block/get-public-access-block.handler.ts
+++ b/src/service/s3/command/get-public-access-block/get-public-access-block.handler.ts
@@ -4,7 +4,7 @@ import {
   BackgroundTasks,
 } from "../../../../util/background/background.js";
 import { assertDefined } from "../../../../util/type-guard/defined.js";
-import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimS3RequestOptions } from "../sim-s3-request-options.js";
 import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
 import { SimIamAllowAllAuth } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
 import type {
@@ -22,10 +22,6 @@ interface GetPublicAccessBlockCommandHandlerProperties {
   readonly buckets: Map<SimS3BucketName, SimS3Bucket>;
   readonly iam?: SimIamInterServiceAuthZ;
   readonly background?: BackgroundScheduler;
-}
-
-interface GetPublicAccessBlockCommandHandlerOptions {
-  readonly caller?: SimAwsCaller;
 }
 
 /**
@@ -59,7 +55,7 @@ export class GetPublicAccessBlockCommandHandler implements CommandHandler<
    */
   async handle(
     command: SimGetPublicAccessBlockCommand,
-    options?: GetPublicAccessBlockCommandHandlerOptions,
+    options?: SimS3RequestOptions,
   ): Promise<SimGetPublicAccessBlockCommandOutput> {
     assertDefined(
       command.input.Bucket,
@@ -71,7 +67,7 @@ export class GetPublicAccessBlockCommandHandler implements CommandHandler<
 
     await this.background.sequence();
 
-    this.authorizer.authorizeRead(bucket, options?.caller);
+    this.authorizer.authorizeRead(bucket, options);
 
     return {
       PublicAccessBlockConfiguration: bucket

--- a/src/service/s3/command/list-buckets/list-buckets-authorizer.ts
+++ b/src/service/s3/command/list-buckets/list-buckets-authorizer.ts
@@ -1,6 +1,7 @@
-import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
 import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
 import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+import { simS3ConditionContext } from "../authorize/sim-s3-condition-context.js";
+import type { SimS3RequestOptions } from "../sim-s3-request-options.js";
 
 interface ListBucketsAuthorizerProperties {
   readonly iam: SimIamInterServiceAuthZ;
@@ -36,11 +37,12 @@ export class ListBucketsAuthorizer {
    * omitted caller, which defaults to Account root, from an explicit anonymous
    * caller, which has no identity policy permissions.
    */
-  authorize(caller?: SimAwsCaller): void {
+  authorize(options?: SimS3RequestOptions): void {
     const decision = this.iam.authorize({
       action: ListBucketsAuthorizer.action,
       resource: ListBucketsAuthorizer.resource,
-      caller,
+      caller: options?.caller,
+      conditionContext: simS3ConditionContext(options),
     });
 
     if (decision.isDenied) {

--- a/src/service/s3/command/list-buckets/list-buckets.handler.ts
+++ b/src/service/s3/command/list-buckets/list-buckets.handler.ts
@@ -15,7 +15,7 @@ import {
   SimIamAllowAllAuth,
   type SimIamInterServiceAuthZ,
 } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
-import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimS3RequestOptions } from "../sim-s3-request-options.js";
 import { ListBucketsAuthorizer } from "./list-buckets-authorizer.js";
 import { ListBucketsPageBuilder } from "./list-buckets-page-builder.js";
 
@@ -23,10 +23,6 @@ interface ListBucketsCommandHandlerProperties {
   readonly buckets: Map<SimS3BucketName, SimS3Bucket>;
   readonly iam?: SimIamInterServiceAuthZ;
   readonly background?: BackgroundScheduler;
-}
-
-interface ListBucketsCommandHandlerOptions {
-  readonly caller?: SimAwsCaller;
 }
 
 /**
@@ -65,12 +61,12 @@ export class ListBucketsCommandHandler implements CommandHandler<
    */
   async handle(
     command: SimListBucketsCommand,
-    options?: ListBucketsCommandHandlerOptions,
+    options?: SimS3RequestOptions,
   ): Promise<SimListBucketsCommandOutput> {
     // Allow for potential non-deterministic sequencing of async events.
     await this.background.sequence();
 
-    this.authorizer.authorize(options?.caller);
+    this.authorizer.authorize(options);
 
     return {
       ...this.pageBuilder.build(command.input),

--- a/src/service/s3/command/list-objects/list-objects-authorizer.ts
+++ b/src/service/s3/command/list-objects/list-objects-authorizer.ts
@@ -1,7 +1,8 @@
-import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
 import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
 import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
 import type { SimS3Bucket } from "../../bucket/sim-s3-bucket.js";
+import { simS3ConditionContext } from "../authorize/sim-s3-condition-context.js";
+import type { SimS3RequestOptions } from "../sim-s3-request-options.js";
 
 interface ListObjectsAuthorizerProperties {
   readonly iam: SimIamInterServiceAuthZ;
@@ -11,7 +12,7 @@ interface ListObjectsAuthorizationInput {
   readonly bucket: SimS3Bucket;
   readonly prefix?: string | undefined;
   readonly maxKeys: number;
-  readonly caller?: SimAwsCaller | undefined;
+  readonly options?: SimS3RequestOptions | undefined;
 }
 
 /**
@@ -44,8 +45,9 @@ export class ListObjectsAuthorizer {
     const decision = this.iam.authorize({
       action: ListObjectsAuthorizer.action,
       resource,
-      caller: input.caller,
+      caller: input.options?.caller,
       conditionContext: {
+        ...simS3ConditionContext(input.options),
         "s3:prefix": input.prefix ?? "",
         "s3:max-keys": input.maxKeys,
       },

--- a/src/service/s3/command/list-objects/list-objects.handler.ts
+++ b/src/service/s3/command/list-objects/list-objects.handler.ts
@@ -17,7 +17,7 @@ import {
   SimIamAllowAllAuth,
   type SimIamInterServiceAuthZ,
 } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
-import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimS3RequestOptions } from "../sim-s3-request-options.js";
 import { ListObjectsAuthorizer } from "./list-objects-authorizer.js";
 import { ListObjectsPageBuilder } from "./list-objects-page-builder.js";
 
@@ -25,10 +25,6 @@ interface ListObjectsCommandHandlerProperties {
   readonly buckets: Map<SimS3BucketName, SimS3Bucket>;
   readonly iam?: SimIamInterServiceAuthZ;
   readonly background?: BackgroundScheduler;
-}
-
-interface ListObjectsCommandHandlerOptions {
-  readonly caller?: SimAwsCaller;
 }
 
 /**
@@ -66,7 +62,7 @@ export class ListObjectsCommandHandler implements CommandHandler<
    */
   async handle(
     command: SimListObjectsCommand,
-    options?: ListObjectsCommandHandlerOptions,
+    options?: SimS3RequestOptions,
   ): Promise<SimListObjectsCommandOutput> {
     assertDefined(command.input.Bucket, "ListObjectsCommand.input.Bucket");
 
@@ -84,7 +80,7 @@ export class ListObjectsCommandHandler implements CommandHandler<
       bucket,
       prefix: command.input.Prefix,
       maxKeys,
-      caller: options?.caller,
+      options,
     });
 
     return await this.pageBuilder.build({

--- a/src/service/s3/command/notification/sim-s3-notification-authorizer.ts
+++ b/src/service/s3/command/notification/sim-s3-notification-authorizer.ts
@@ -1,9 +1,10 @@
-import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
 import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
 import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
 import { simS3BucketArn } from "../../bucket/sim-s3-bucket-arn.js";
 import type { SimS3Bucket } from "../../bucket/sim-s3-bucket.js";
 import { simS3BucketResourcePolicies } from "../authorize/sim-s3-bucket-resource-policies.js";
+import { simS3ConditionContext } from "../authorize/sim-s3-condition-context.js";
+import type { SimS3RequestOptions } from "../sim-s3-request-options.js";
 
 interface SimS3NotificationAuthorizerProperties {
   readonly iam: SimIamInterServiceAuthZ;
@@ -32,27 +33,28 @@ export class SimS3NotificationAuthorizer {
   /**
    * Ensure the caller may read the Bucket's notification configuration.
    */
-  authorizeRead(bucket: SimS3Bucket, caller?: SimAwsCaller): void {
-    this.authorize(SimS3NotificationAuthorizer.readAction, bucket, caller);
+  authorizeRead(bucket: SimS3Bucket, options?: SimS3RequestOptions): void {
+    this.authorize(SimS3NotificationAuthorizer.readAction, bucket, options);
   }
 
   /**
    * Ensure the caller may replace the Bucket's notification configuration.
    */
-  authorizeWrite(bucket: SimS3Bucket, caller?: SimAwsCaller): void {
-    this.authorize(SimS3NotificationAuthorizer.writeAction, bucket, caller);
+  authorizeWrite(bucket: SimS3Bucket, options?: SimS3RequestOptions): void {
+    this.authorize(SimS3NotificationAuthorizer.writeAction, bucket, options);
   }
 
   private authorize(
     action: string,
     bucket: SimS3Bucket,
-    caller?: SimAwsCaller,
+    options?: SimS3RequestOptions,
   ): void {
     const resource = simS3BucketArn(bucket.bucketName);
     const decision = this.iam.authorize({
       action,
       resource,
-      caller,
+      caller: options?.caller,
+      conditionContext: simS3ConditionContext(options),
       resourcePolicies: simS3BucketResourcePolicies(bucket),
     });
 

--- a/src/service/s3/command/public-access-block/sim-s3-public-access-block-authorizer.ts
+++ b/src/service/s3/command/public-access-block/sim-s3-public-access-block-authorizer.ts
@@ -1,9 +1,10 @@
-import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
 import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
 import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
 import { simS3BucketArn } from "../../bucket/sim-s3-bucket-arn.js";
 import type { SimS3Bucket } from "../../bucket/sim-s3-bucket.js";
 import { simS3BucketResourcePolicies } from "../authorize/sim-s3-bucket-resource-policies.js";
+import { simS3ConditionContext } from "../authorize/sim-s3-condition-context.js";
+import type { SimS3RequestOptions } from "../sim-s3-request-options.js";
 
 interface SimS3PublicAccessBlockAuthorizerProperties {
   readonly iam: SimIamInterServiceAuthZ;
@@ -30,31 +31,36 @@ export class SimS3PublicAccessBlockAuthorizer {
   /**
    * Ensure the caller may read the Bucket's Block Public Access settings.
    */
-  authorizeRead(bucket: SimS3Bucket, caller?: SimAwsCaller): void {
-    this.authorize(SimS3PublicAccessBlockAuthorizer.readAction, bucket, caller);
+  authorizeRead(bucket: SimS3Bucket, options?: SimS3RequestOptions): void {
+    this.authorize(
+      SimS3PublicAccessBlockAuthorizer.readAction,
+      bucket,
+      options,
+    );
   }
 
   /**
    * Ensure the caller may replace or remove the Block Public Access settings.
    */
-  authorizeWrite(bucket: SimS3Bucket, caller?: SimAwsCaller): void {
+  authorizeWrite(bucket: SimS3Bucket, options?: SimS3RequestOptions): void {
     this.authorize(
       SimS3PublicAccessBlockAuthorizer.writeAction,
       bucket,
-      caller,
+      options,
     );
   }
 
   private authorize(
     action: string,
     bucket: SimS3Bucket,
-    caller?: SimAwsCaller,
+    options?: SimS3RequestOptions,
   ): void {
     const resource = simS3BucketArn(bucket.bucketName);
     const decision = this.iam.authorize({
       action,
       resource,
-      caller,
+      caller: options?.caller,
+      conditionContext: simS3ConditionContext(options),
       resourcePolicies: simS3BucketResourcePolicies(bucket),
     });
 

--- a/src/service/s3/command/put-bucket-notification-configuration/put-bucket-notification-configuration.handler.ts
+++ b/src/service/s3/command/put-bucket-notification-configuration/put-bucket-notification-configuration.handler.ts
@@ -4,7 +4,7 @@ import {
   BackgroundTasks,
 } from "../../../../util/background/background.js";
 import { assertDefined } from "../../../../util/type-guard/defined.js";
-import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimS3RequestOptions } from "../sim-s3-request-options.js";
 import {
   SimIamAllowAllAuth,
   type SimIamInterServiceAuthZ,
@@ -28,10 +28,6 @@ interface PutBucketNotificationConfigurationHandlerProperties {
   readonly iam?: SimIamInterServiceAuthZ;
   readonly background?: BackgroundScheduler;
   readonly notificationDestinations: SimS3NotificationDestinations;
-}
-
-interface PutBucketNotificationConfigurationHandlerOptions {
-  readonly caller?: SimAwsCaller;
 }
 
 /**
@@ -74,7 +70,7 @@ export class PutBucketNotificationConfigurationCommandHandler implements Command
    */
   async handle(
     command: SimPutBucketNotificationConfigurationCommand,
-    options?: PutBucketNotificationConfigurationHandlerOptions,
+    options?: SimS3RequestOptions,
   ): Promise<SimPutBucketNotificationConfigurationCommandOutput> {
     const input = command.input;
     assertDefined(
@@ -93,7 +89,7 @@ export class PutBucketNotificationConfigurationCommandHandler implements Command
 
     await this.background.sequence();
 
-    this.authorizer.authorizeWrite(bucket, options?.caller);
+    this.authorizer.authorizeWrite(bucket, options);
 
     const configuration = this.reader.read(input.NotificationConfiguration);
 

--- a/src/service/s3/command/put-bucket-policy/put-bucket-policy-authorizer.ts
+++ b/src/service/s3/command/put-bucket-policy/put-bucket-policy-authorizer.ts
@@ -1,7 +1,8 @@
-import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
 import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
 import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
 import type { SimS3BucketName } from "../../bucket/sim-s3-bucket.js";
+import { simS3ConditionContext } from "../authorize/sim-s3-condition-context.js";
+import type { SimS3RequestOptions } from "../sim-s3-request-options.js";
 
 interface PutBucketPolicyAuthorizerProperties {
   readonly iam: SimIamInterServiceAuthZ;
@@ -22,12 +23,13 @@ export class PutBucketPolicyAuthorizer {
   /**
    * Ensure the caller may replace the Bucket policy.
    */
-  authorize(bucketName: SimS3BucketName, caller?: SimAwsCaller): void {
+  authorize(bucketName: SimS3BucketName, options?: SimS3RequestOptions): void {
     const resource = `arn:aws:s3:::${bucketName}`;
     const decision = this.iam.authorize({
       action: PutBucketPolicyAuthorizer.action,
       resource,
-      caller,
+      caller: options?.caller,
+      conditionContext: simS3ConditionContext(options),
     });
 
     if (decision.isDenied) {

--- a/src/service/s3/command/put-bucket-policy/put-bucket-policy.handler.ts
+++ b/src/service/s3/command/put-bucket-policy/put-bucket-policy.handler.ts
@@ -5,7 +5,7 @@ import {
 } from "../../../../util/background/background.js";
 import { assertDefined } from "../../../../util/type-guard/defined.js";
 import { jsonParse } from "../../../../util/type-guard/json.js";
-import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimS3RequestOptions } from "../sim-s3-request-options.js";
 import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
 import { SimIamAllowAllAuth } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
 import { SimIamPolicyDocumentValidator } from "../../../iam/validate/sim-iam-policy-document-validator.js";
@@ -25,10 +25,6 @@ interface PutBucketPolicyCommandHandlerProperties {
   readonly buckets: Map<SimS3BucketName, SimS3Bucket>;
   readonly iam?: SimIamInterServiceAuthZ;
   readonly background?: BackgroundScheduler;
-}
-
-interface PutBucketPolicyCommandHandlerOptions {
-  readonly caller?: SimAwsCaller;
 }
 
 /**
@@ -62,7 +58,7 @@ export class PutBucketPolicyCommandHandler implements CommandHandler<
    */
   async handle(
     command: SimPutBucketPolicyCommand,
-    options?: PutBucketPolicyCommandHandlerOptions,
+    options?: SimS3RequestOptions,
   ): Promise<SimPutBucketPolicyCommandOutput> {
     assertDefined(command.input.Bucket, "PutBucketPolicyCommand.input.Bucket");
     assertDefined(command.input.Policy, "PutBucketPolicyCommand.input.Policy");
@@ -73,7 +69,7 @@ export class PutBucketPolicyCommandHandler implements CommandHandler<
 
     await this.background.sequence();
 
-    this.authorizer.authorize(bucketName, options?.caller);
+    this.authorizer.authorize(bucketName, options);
 
     const document = jsonParse(command.input.Policy);
 

--- a/src/service/s3/command/put-bucket-website/put-bucket-website-authorizer.ts
+++ b/src/service/s3/command/put-bucket-website/put-bucket-website-authorizer.ts
@@ -1,7 +1,8 @@
-import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
 import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
 import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
 import type { SimS3BucketName } from "../../bucket/sim-s3-bucket.js";
+import { simS3ConditionContext } from "../authorize/sim-s3-condition-context.js";
+import type { SimS3RequestOptions } from "../sim-s3-request-options.js";
 
 interface PutBucketWebsiteAuthorizerProperties {
   readonly iam: SimIamInterServiceAuthZ;
@@ -39,12 +40,13 @@ export class PutBucketWebsiteAuthorizer {
    * This method returns only for an allowed decision. A denied decision becomes
    * the service-shaped access error expected by callers of the S3 simulation.
    */
-  authorize(bucketName: SimS3BucketName, caller?: SimAwsCaller): void {
+  authorize(bucketName: SimS3BucketName, options?: SimS3RequestOptions): void {
     const resource = `arn:aws:s3:::${bucketName}`;
     const decision = this.iam.authorize({
       action: PutBucketWebsiteAuthorizer.action,
       resource,
-      caller,
+      caller: options?.caller,
+      conditionContext: simS3ConditionContext(options),
     });
 
     if (decision.isDenied) {

--- a/src/service/s3/command/put-bucket-website/put-bucket-website.handler.ts
+++ b/src/service/s3/command/put-bucket-website/put-bucket-website.handler.ts
@@ -15,7 +15,7 @@ import {
   BackgroundTasks,
 } from "../../../../util/background/background.js";
 import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
-import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimS3RequestOptions } from "../sim-s3-request-options.js";
 import { SimIam } from "../../../iam/index.js";
 import { PutBucketWebsiteAuthorizer } from "./put-bucket-website-authorizer.js";
 
@@ -23,10 +23,6 @@ interface PutBucketWebsiteCommandHandlerProperties {
   readonly buckets: Map<SimS3BucketName, SimS3Bucket>;
   readonly iam?: SimIamInterServiceAuthZ;
   readonly background?: BackgroundScheduler;
-}
-
-interface PutBucketWebsiteCommandHandlerOptions {
-  readonly caller?: SimAwsCaller;
 }
 
 /**
@@ -63,7 +59,7 @@ export class PutBucketWebsiteCommandHandler implements CommandHandler<
    */
   async handle(
     command: SimPutBucketWebsiteCommand,
-    options?: PutBucketWebsiteCommandHandlerOptions,
+    options?: SimS3RequestOptions,
   ): Promise<SimPutBucketWebsiteCommandOutput> {
     assertDefined(
       command.input.Bucket,
@@ -84,7 +80,7 @@ export class PutBucketWebsiteCommandHandler implements CommandHandler<
     // Allow for potential non-deterministic sequencing of async events.
     await this.background.sequence();
 
-    this.authorizer.authorize(bucketName, options?.caller);
+    this.authorizer.authorize(bucketName, options);
 
     bucket.configureWebsite(
       new SimS3BucketWebsite(command.input.WebsiteConfiguration),

--- a/src/service/s3/command/put-object/put-object-authorizer.ts
+++ b/src/service/s3/command/put-object/put-object-authorizer.ts
@@ -1,8 +1,9 @@
-import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
 import type { SimAwsResolvedCaller } from "../../../aws/caller/sim-aws-caller-resolver.js";
 import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
 import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
 import type { SimS3Bucket } from "../../bucket/sim-s3-bucket.js";
+import { simS3ConditionContext } from "../authorize/sim-s3-condition-context.js";
+import type { SimS3RequestOptions } from "../sim-s3-request-options.js";
 
 interface PutObjectAuthorizerProperties {
   readonly iam: SimIamInterServiceAuthZ;
@@ -34,14 +35,15 @@ export class PutObjectAuthorizer {
   authorize(
     bucket: SimS3Bucket,
     key: string,
-    caller?: SimAwsCaller,
+    options?: SimS3RequestOptions,
   ): SimAwsResolvedCaller {
     const resource = `arn:aws:s3:::${bucket.bucketName}/${key}`;
     const policy = bucket.getPolicy();
     const decision = this.iam.authorize({
       action: PutObjectAuthorizer.action,
       resource,
-      caller,
+      caller: options?.caller,
+      conditionContext: simS3ConditionContext(options),
       resourcePolicies:
         policy === undefined
           ? []

--- a/src/service/s3/command/put-object/put-object.handler.ts
+++ b/src/service/s3/command/put-object/put-object.handler.ts
@@ -17,7 +17,7 @@ import {
   SimIamAllowAllAuth,
   type SimIamInterServiceAuthZ,
 } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
-import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimS3RequestOptions } from "../sim-s3-request-options.js";
 import { PutObjectAuthorizer } from "./put-object-authorizer.js";
 import { PutObjectBuilder } from "./put-object-builder.js";
 import type { SimS3ObjectNotifier } from "../../notification/sim-s3-object-notifier.js";
@@ -27,10 +27,6 @@ interface PutObjectCommandHandlerProperties {
   readonly iam?: SimIamInterServiceAuthZ;
   readonly background?: BackgroundScheduler;
   readonly notifications: SimS3ObjectNotifier;
-}
-
-interface PutObjectCommandHandlerOptions {
-  readonly caller?: SimAwsCaller;
 }
 
 /**
@@ -74,7 +70,7 @@ export class PutObjectCommandHandler implements CommandHandler<
    */
   async handle(
     command: SimPutObjectCommand,
-    options?: PutObjectCommandHandlerOptions,
+    options?: SimS3RequestOptions,
   ): Promise<SimPutObjectCommandOutput> {
     assertDefined(command.input.Bucket, "PutObjectCommand.input.Bucket");
     assertDefined(command.input.Key, "PutObjectCommand.input.Key");
@@ -91,7 +87,7 @@ export class PutObjectCommandHandler implements CommandHandler<
     const caller = this.authorizer.authorize(
       bucket,
       command.input.Key,
-      options?.caller,
+      options,
     );
 
     const object = this.objectBuilder.build(command);

--- a/src/service/s3/command/put-public-access-block/put-public-access-block.handler.ts
+++ b/src/service/s3/command/put-public-access-block/put-public-access-block.handler.ts
@@ -4,7 +4,7 @@ import {
   BackgroundTasks,
 } from "../../../../util/background/background.js";
 import { assertDefined } from "../../../../util/type-guard/defined.js";
-import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimS3RequestOptions } from "../sim-s3-request-options.js";
 import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
 import { SimIamAllowAllAuth } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
 import { SimS3PublicAccessBlock } from "../../bucket/public-access/sim-s3-public-access-block.js";
@@ -23,10 +23,6 @@ interface PutPublicAccessBlockCommandHandlerProperties {
   readonly buckets: Map<SimS3BucketName, SimS3Bucket>;
   readonly iam?: SimIamInterServiceAuthZ;
   readonly background?: BackgroundScheduler;
-}
-
-interface PutPublicAccessBlockCommandHandlerOptions {
-  readonly caller?: SimAwsCaller;
 }
 
 /**
@@ -61,7 +57,7 @@ export class PutPublicAccessBlockCommandHandler implements CommandHandler<
    */
   async handle(
     command: SimPutPublicAccessBlockCommand,
-    options?: PutPublicAccessBlockCommandHandlerOptions,
+    options?: SimS3RequestOptions,
   ): Promise<SimPutPublicAccessBlockCommandOutput> {
     assertDefined(
       command.input.Bucket,
@@ -77,7 +73,7 @@ export class PutPublicAccessBlockCommandHandler implements CommandHandler<
 
     await this.background.sequence();
 
-    this.authorizer.authorizeWrite(bucket, options?.caller);
+    this.authorizer.authorizeWrite(bucket, options);
 
     bucket.configurePublicAccessBlock(
       SimS3PublicAccessBlock.fromConfiguration(

--- a/src/service/s3/command/sim-s3-request-options.ts
+++ b/src/service/s3/command/sim-s3-request-options.ts
@@ -1,11 +1,55 @@
 import type { SimAwsCaller } from "../../aws/caller/sim-aws-caller.js";
 
 /**
+ * The condition key naming what a simulated service is reaching the Bucket for,
+ * such as the CloudFront Distribution an Origin read belongs to.
+ *
+ * This is the key a Bucket policy granting a service principal is nearly always
+ * conditioned on, since a service principal is shared by every resource of that
+ * service. CDK writes it as `AWS:SourceArn`, which matches the same key: the
+ * condition matcher is case insensitive on key names, as IAM is.
+ */
+export const simS3SourceArnConditionKey = "aws:SourceArn";
+
+/**
+ * The condition key naming the Account owning the resource a simulated service
+ * is reaching the Bucket for.
+ *
+ * It only has a job when that resource and the Bucket are in different
+ * Accounts, which is why AWS's own documented Bucket policies carry it
+ * alongside the source ARN.
+ */
+export const simS3SourceAccountConditionKey = "aws:SourceAccount";
+
+/**
  * The per-request options every simulated S3 command accepts.
  *
  * This lives beside the commands rather than on the service facade so a command
  * area can name it without importing the facade back.
  */
 export interface SimS3RequestOptions {
+  /**
+   * Who is making the request. An omitted caller is the Account root, as it is
+   * everywhere else in the simulation.
+   */
   readonly caller?: SimAwsCaller;
+
+  /**
+   * What the caller is reaching the Bucket for, supplied to IAM as
+   * `aws:SourceArn`.
+   *
+   * This is for a simulated service making a request on a resource's behalf,
+   * which is how real AWS supplies it. A value the caller does not have is left
+   * out rather than supplied empty, so a statement conditioned on it fails to
+   * match instead of matching an empty string.
+   */
+  readonly sourceArn?: string;
+
+  /**
+   * The Account owning the resource the caller is reaching the Bucket for,
+   * supplied to IAM as `aws:SourceAccount`.
+   *
+   * Left out the same way when the caller has no value for it.
+   */
+  readonly sourceAccount?: string;
 }

--- a/test/cloudfront/oac-site-fixture.ts
+++ b/test/cloudfront/oac-site-fixture.ts
@@ -1,0 +1,178 @@
+/**
+ * A simulated static site reached through a CloudFront origin access control,
+ * which every test about serving a private Bucket needs before it can say
+ * anything about the response.
+ *
+ * This lives under `test/` for the same reasons as `site-fixture.ts` beside it.
+ */
+
+import { assertNonNullable } from "@kensio/smartass";
+import { PutObjectCommand } from "@aws-sdk/client-s3";
+
+import { SimAws } from "../../src/service/aws/sim-aws.js";
+import type { SimCfnTemplateValue } from "../../src/service/cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimCloudFrontOriginAccessControlSigningBehavior } from "../../src/service/cloudfront/origin-access-control/sim-cf-origin-access-control.js";
+
+export const simCfOacSiteBucketName = "oac-site-bucket";
+
+export const simCfOacSitePage = "<h1>Home</h1>";
+
+/**
+ * The Distribution ARN as a template writes it, which is what CDK's
+ * `S3BucketOrigin.withOriginAccessControl` synthesizes for the condition.
+ */
+export const simCfOacSiteDistributionArn = {
+  "Fn::Join": [
+    "",
+    [
+      "arn:aws:cloudfront::",
+      { Ref: "AWS::AccountId" },
+      ":distribution/",
+      { Ref: "SiteDistribution" },
+    ],
+  ],
+};
+
+/**
+ * A statement granting CloudFront the read, conditioned on the Distribution
+ * making it. `AWS:SourceArn` is CDK's spelling of `aws:SourceArn`, and
+ * condition key names are matched case insensitively.
+ */
+export function simCfOacCloudFrontReadStatement(
+  sourceArn: SimCfnTemplateValue,
+): SimCfnTemplateValue {
+  return {
+    Effect: "Allow",
+    Principal: { Service: "cloudfront.amazonaws.com" },
+    Action: "s3:GetObject",
+    Resource: `arn:aws:s3:::${simCfOacSiteBucketName}/*`,
+    Condition: { StringEquals: { "AWS:SourceArn": sourceArn } },
+  };
+}
+
+/**
+ * A statement granting everyone the read, which is what a Bucket reached
+ * anonymously needs.
+ */
+export const simCfOacPublicReadStatement = {
+  Effect: "Allow",
+  Principal: "*",
+  Action: "s3:GetObject",
+  Resource: `arn:aws:s3:::${simCfOacSiteBucketName}/*`,
+};
+
+export interface SimCfOacSiteStackProperties {
+  readonly statement: SimCfnTemplateValue;
+
+  /**
+   * An omitted signing behaviour leaves the origin access control out
+   * altogether, so the Origin is one that was never given one.
+   */
+  readonly signingBehavior?: SimCloudFrontOriginAccessControlSigningBehavior;
+
+  /**
+   * Opt the Bucket out of the block on public Bucket policies, which a publicly
+   * readable site Bucket has to do and a Bucket reached through an origin
+   * access control does not.
+   */
+  readonly publicPolicyAllowed?: boolean;
+}
+
+export interface SimCfOacSite {
+  readonly simAws: SimAws;
+  readonly distributionId: string;
+}
+
+/**
+ * Deploy a site Stack shaped the way CDK builds one: a Bucket, an origin access
+ * control, a Distribution naming it, and a Bucket policy naming the
+ * Distribution back.
+ *
+ * The Bucket policy comes last because it needs the Distribution's ARN, which
+ * is why nothing about the read can be settled when the Distribution is
+ * created. The page goes in after the Stack, so the Bucket policy is the only
+ * thing deciding whether the Distribution can read it back.
+ */
+export async function simCfOacSiteStack(
+  properties: SimCfOacSiteStackProperties,
+): Promise<SimCfOacSite> {
+  const simAws = new SimAws();
+  const withOac = properties.signingBehavior !== undefined;
+
+  const stack = await simAws.cloudFormation().deployTemplate({
+    stackName: "oac-site-stack",
+    template: {
+      Resources: {
+        SiteBucket: {
+          Type: "AWS::S3::Bucket",
+          Properties: {
+            BucketName: simCfOacSiteBucketName,
+            ...(properties.publicPolicyAllowed === true && {
+              PublicAccessBlockConfiguration: { BlockPublicPolicy: false },
+            }),
+          },
+        },
+        ...(withOac && {
+          SiteOac: {
+            Type: "AWS::CloudFront::OriginAccessControl",
+            Properties: {
+              OriginAccessControlConfig: {
+                Name: "site-oac",
+                OriginAccessControlOriginType: "s3",
+                SigningBehavior: properties.signingBehavior,
+                SigningProtocol: "sigv4",
+              },
+            },
+          },
+        }),
+        SiteDistribution: {
+          Type: "AWS::CloudFront::Distribution",
+          Properties: {
+            DistributionConfig: {
+              Enabled: true,
+              Origins: [
+                {
+                  Id: "SiteOrigin",
+                  DomainName: `${simCfOacSiteBucketName}.s3.amazonaws.com`,
+                  S3OriginConfig: {},
+                  ...(withOac && { OriginAccessControlId: { Ref: "SiteOac" } }),
+                },
+              ],
+              DefaultCacheBehavior: {
+                TargetOriginId: "SiteOrigin",
+                ViewerProtocolPolicy: "allow-all",
+              },
+            },
+          },
+        },
+        SiteBucketPolicy: {
+          Type: "AWS::S3::BucketPolicy",
+          Properties: {
+            Bucket: { Ref: "SiteBucket" },
+            PolicyDocument: {
+              Version: "2012-10-17",
+              Statement: [properties.statement],
+            },
+          },
+        },
+      },
+      Outputs: { DistributionId: { Value: { Ref: "SiteDistribution" } } },
+    },
+  });
+
+  await stack.waitForDeployComplete();
+
+  await simAws.s3().putObject(
+    new PutObjectCommand({
+      Bucket: simCfOacSiteBucketName,
+      Key: "index.html",
+      ContentType: "text/html",
+      Body: simCfOacSitePage,
+    }),
+  );
+
+  const distributionId = stack.outputs.get("DistributionId")?.value;
+  assertNonNullable(distributionId);
+
+  return { simAws, distributionId: distributionId as string };
+}


### PR DESCRIPTION
An Origin whose origin access control signs now reads its Bucket as the `cloudfront.amazonaws.com` service principal, carrying the Distribution ARN as `aws:SourceArn`, so the Bucket policy written for origin access control is what decides whether the site serves. The two halves that landed separately, authorizing an S3 Origin read and creating an origin access control, now meet: a wrong or missing condition answers 403 here rather than on deploy.

Resolves https://github.com/KensioSoftware/yulin/issues/495

## The missing S3 primitive

`SimS3RequestOptions` carried a caller and nothing else, so there was no way to supply `aws:SourceArn` on a simulated S3 read. It now carries `sourceArn` and `sourceAccount` alongside the caller, and `simS3ConditionContext` turns them into condition keys, copying the shape SQS already had. A value the request does not carry is left out rather than supplied empty, so a statement conditioned on it fails to match.

They are threaded through every S3 authorizer rather than only GetObject. SQS got that free because it has one shared authorizer; S3 has twelve, so the alternative was an option on the shared request type that only one command honours. Each authorizer edit is the same two lines, and the handlers' local `{ caller? }` option interfaces are now just `SimS3RequestOptions`.

## The CloudFront half

`SimCfS3OriginSigner` answers who a read is made as, per fetch: the CloudFront service principal with the Distribution's ARN and Account where the origin access control's `signs` is true, and anonymous otherwise. It resolves per request because an Origin only knows its Distribution through `SimCloudFrontOriginRequest`, and because in a CDK stack the Bucket policy is created after the Distribution, since it names the Distribution's ARN. Nothing about the read could be settled earlier.

## Tests

- `sim-cf-s3-origin-oac-authorization.iso.test.ts` covers a policy conditioned on this Distribution serving a page, the same policy naming another Distribution answering 403, an Origin with no origin access control answering 403, an anonymous SDK caller refused by the same Bucket, and `SigningBehavior: never` reading anonymously both ways. The stack builder lives in `test/cloudfront/oac-site-fixture.ts` because inline it pushed the test file to an FTA score of 61.
- `sim-s3-source-condition.iso.test.ts` covers both condition keys at the S3 level, including CDK's `AWS:SourceArn` spelling.
- `sim-cdk-cf-distro-oac.loc.test.ts` synths a real CDK stack built with `S3BucketOrigin.withOriginAccessControl` and fetches a page through the Distribution, so the Bucket policy CDK actually writes is the one being evaluated.

## Docs

The origin access control section is rewritten around an example that deploys the whole private site and serves a page from it. Both stale Limitations bullets are replaced: the first now scopes anonymous reading to an Origin without an origin access control, and a new one states the divergence that remains, which is that no SigV4 signature is computed or checked, only the principal and the source keys. `docs/services/s3` gained a section on supplying the source of a request, and both service READMEs and the class comment on `SimCloudFrontS3Origin.originAccessControl` are updated.

`pnpm run check` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added functional CloudFront Origin Access Control for private S3 content.
  * CloudFront-signed requests now identify the distribution and account for bucket-policy authorization.
  * Added support for S3 `SourceArn` and `SourceAccount` policy conditions.
  * Added anonymous, signed, and public-access behavior based on origin and bucket-policy settings.

* **Documentation**
  * Expanded CloudFront and S3 guidance with setup examples, request flows, signing modes, limitations, and validation details.

* **Tests**
  * Added coverage for authorized, denied, unsigned, mismatched-distribution, and public-read scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->