### PR TITLE
docs: neutral example terminology in the docs

### DIFF
--- a/docs/services/rekognition/README.md
+++ b/docs/services/rekognition/README.md
@@ -1,7 +1,7 @@
 # Simulated Rekognition
 
 Simulated Rekognition answers detection calls from results declared against images, so a test can
-say which image fails moderation or holds a dog without any image analysis happening. No recognition
+say which image fails moderation or holds a cat without any image analysis happening. No recognition
 of any kind is performed on the bytes.
 
 Rekognition-specific types are imported from the `@kensio/yulin/rekognition` subpath.
@@ -27,7 +27,7 @@ await simAws.s3().createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
 await simAws.s3().putObject(
   new PutObjectCommand({
     Bucket: "uploads",
-    Key: "raw/nsfw.png",
+    Key: "incoming/photo.png",
     Body: Buffer.from(
       "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGO4I2IDAAL8AS3VzMq8AAAAAElFTkSuQmCC",
       "base64",
@@ -39,16 +39,16 @@ await simAws.s3().putObject(
 simAws
   .rekognition()
   .moderation()
-  .onName("raw/nsfw.png", { labels: ["Explicit Nudity"] });
+  .onName("incoming/photo.png", { labels: ["Weapons"] });
 
 const detected = await simAws.rekognition().detectModerationLabels(
   new DetectModerationLabelsCommand({
-    Image: { S3Object: { Bucket: "uploads", Name: "raw/nsfw.png" } },
+    Image: { S3Object: { Bucket: "uploads", Name: "incoming/photo.png" } },
   }),
 );
 
 console.log(detected.ModerationLabels.map((label) => label.Name));
-// [ "Explicit", "Explicit Nudity" ]
+// [ "Violence", "Weapons" ]
 console.log(detected.ModerationModelVersion); // "7.0"
 ```
 
@@ -87,7 +87,7 @@ await simAws.s3().createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
 await simAws.s3().putObject(
   new PutObjectCommand({
     Bucket: "uploads",
-    Key: "raw/dog.png",
+    Key: "incoming/cat.png",
     Body: Buffer.from(
       "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGO4I2IDAAL8AS3VzMq8AAAAAElFTkSuQmCC",
       "base64",
@@ -98,13 +98,13 @@ await simAws.s3().putObject(
 simAws
   .rekognition()
   .labels()
-  .onName("raw/dog.png", {
+  .onName("incoming/cat.png", {
     labels: [
       {
-        name: "Dog",
+        name: "Cat",
         confidence: 98.2,
-        parents: ["Animal", "Pet", "Canine"],
-        aliases: ["Puppy"],
+        parents: ["Animal", "Pet", "Feline"],
+        aliases: ["Kitten"],
         categories: ["Animals and Pets"],
         // A bounding box is in ratios of the image size, as AWS reports it.
         instances: [
@@ -117,14 +117,14 @@ simAws
 
 const detected = await simAws.rekognition().detectLabels(
   new DetectLabelsCommand({
-    Image: { S3Object: { Bucket: "uploads", Name: "raw/dog.png" } },
+    Image: { S3Object: { Bucket: "uploads", Name: "incoming/cat.png" } },
     MaxLabels: 10,
   }),
 );
 
-console.log(detected.Labels.map((label) => label.Name)); // [ "Dog", "Grass" ]
+console.log(detected.Labels.map((label) => label.Name)); // [ "Cat", "Grass" ]
 console.log(detected.Labels[0]?.Parents);
-// [ { Name: "Animal" }, { Name: "Pet" }, { Name: "Canine" } ]
+// [ { Name: "Animal" }, { Name: "Pet" }, { Name: "Feline" } ]
 console.log(detected.LabelModelVersion); // "3.0"
 ```
 
@@ -136,7 +136,7 @@ example response in the AWS `DetectLabels` documentation, with the parent, alias
 bounding box AWS documents it with. That is a real Rekognition response, but which labels an
 unconfigured image gets is a simulator convention rather than what AWS would return for it.
 
-Nothing is filled in from a label name. Declaring `Dog` with no parents reports `Dog` with no
+Nothing is filled in from a label name. Declaring `Cat` with no parents reports `Cat` with no
 parents, and declaring a `Pizza` nobody has heard of reports `Pizza`, because Yulin ships no general
 label ontology to check a name against or to expand one from.
 
@@ -161,7 +161,7 @@ await simAws.s3().createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
 await simAws.s3().putObject(
   new PutObjectCommand({
     Bucket: "uploads",
-    Key: "raw/selfie.png",
+    Key: "incoming/selfie.png",
     Body: Buffer.from(
       "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGO4I2IDAAL8AS3VzMq8AAAAAElFTkSuQmCC",
       "base64",
@@ -172,7 +172,7 @@ await simAws.s3().putObject(
 simAws
   .rekognition()
   .faces()
-  .onName("raw/selfie.png", {
+  .onName("incoming/selfie.png", {
     faces: [
       {
         // A bounding box is in ratios of the image size, as AWS reports it.
@@ -189,7 +189,7 @@ simAws
 
 const detected = await simAws.rekognition().detectFaces(
   new DetectFacesCommand({
-    Image: { S3Object: { Bucket: "uploads", Name: "raw/selfie.png" } },
+    Image: { S3Object: { Bucket: "uploads", Name: "incoming/selfie.png" } },
     Attributes: ["ALL"],
   }),
 );
@@ -215,8 +215,8 @@ import {
 
 const faces = simAws.rekognition().faces();
 
-faces.onName("raw/landscape.png", simRekognitionNoFaces);
-faces.onName("raw/crowd.png", simRekognitionSeveralFaces);
+faces.onName("incoming/landscape.png", simRekognitionNoFaces);
+faces.onName("incoming/crowd.png", simRekognitionSeveralFaces);
 ```
 
 An image no rule matches gets the built-in default result: the one face from the example response in
@@ -325,7 +325,7 @@ const moderation = simAws.rekognition().moderation();
 moderation.byDefault({ labels: [] });
 
 // One S3 object, by the Name a request gives Rekognition.
-moderation.onName("raw/nsfw.png", { labels: ["Explicit Nudity"] });
+moderation.onName("incoming/photo.png", { labels: ["Weapons"] });
 
 // One image, by the hash of its bytes, for a system that generates its own
 // object keys. These bytes would usually come from a fixture file, read with
@@ -384,7 +384,7 @@ import { simRekognitionSampleImages } from "@kensio/yulin/rekognition";
 const simAws = new SimAws();
 await simAws.s3().createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
 
-const key = `raw/${randomUUID()}.jpg`;
+const key = `incoming/${randomUUID()}.jpg`;
 
 await simAws.s3().putObject(
   new PutObjectCommand({
@@ -470,10 +470,10 @@ so a surviving label never names a parent that is not in the response. A label t
 reported once, at the higher of the two confidences.
 
 A label the taxonomy does not have is refused where it is declared rather than at detection time.
-That includes a version 6.1 name that version 7.0 dropped, such as `Graphic Male Nudity`, which
-became `Exposed Male Genitalia`. Some names survived the move with a different place in the
-taxonomy: `Explicit Nudity` is still a label, but it now sits under `Explicit` rather than being a
-top-level category itself.
+That includes a version 6.1 name that version 7.0 dropped, such as `Drug Products`, which became
+`Products` under `Drugs & Tobacco`. Some names survived the move with a different place in the
+taxonomy: `Drinking` is still a label, but it now sits under `Alcohol Use` rather than directly
+under `Alcohol`.
 
 ## Filtering by confidence
 
@@ -544,7 +544,7 @@ simAws
   .labels()
   .byDefault({
     labels: [
-      { name: "Dog", confidence: 98.2 },
+      { name: "Cat", confidence: 98.2 },
       { name: "Grass", confidence: 88 },
       { name: "Fence", confidence: 62 },
     ],
@@ -558,7 +558,7 @@ const detected = await simAws.rekognition().detectLabels(
   }),
 );
 
-console.log(detected.Labels.map((label) => label.Name)); // [ "Dog", "Grass" ]
+console.log(detected.Labels.map((label) => label.Name)); // [ "Cat", "Grass" ]
 ```
 
 ## Moderating an upload
@@ -689,7 +689,9 @@ await simAws.s3().putBucketNotificationConfiguration(
           Id: "moderate-uploads",
           Events: ["s3:ObjectCreated:*"],
           LambdaFunctionArn: moderatorArn,
-          Filter: { Key: { FilterRules: [{ Name: "prefix", Value: "raw/" }] } },
+          Filter: {
+            Key: { FilterRules: [{ Name: "prefix", Value: "incoming/" }] },
+          },
         },
       ],
     },
@@ -701,7 +703,7 @@ await simAws.s3().putBucketNotificationConfiguration(
 await simAws.s3().putObject(
   new PutObjectCommand({
     Bucket: "uploads",
-    Key: `raw/${randomUUID()}.jpg`,
+    Key: `incoming/${randomUUID()}.jpg`,
     Body: simRekognitionSampleImages.flaggedByModeration(),
   }),
 );

--- a/docs/services/rekognition/sim-rekognition-detect-faces.example.ts
+++ b/docs/services/rekognition/sim-rekognition-detect-faces.example.ts
@@ -13,7 +13,7 @@ await simAws.s3().createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
 await simAws.s3().putObject(
   new PutObjectCommand({
     Bucket: "uploads",
-    Key: "raw/selfie.png",
+    Key: "incoming/selfie.png",
     Body: Buffer.from(
       "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGO4I2IDAAL8AS3VzMq8AAAAAElFTkSuQmCC",
       "base64",
@@ -24,7 +24,7 @@ await simAws.s3().putObject(
 simAws
   .rekognition()
   .faces()
-  .onName("raw/selfie.png", {
+  .onName("incoming/selfie.png", {
     faces: [
       {
         // A bounding box is in ratios of the image size, as AWS reports it.
@@ -41,7 +41,7 @@ simAws
 
 const detected = await simAws.rekognition().detectFaces(
   new DetectFacesCommand({
-    Image: { S3Object: { Bucket: "uploads", Name: "raw/selfie.png" } },
+    Image: { S3Object: { Bucket: "uploads", Name: "incoming/selfie.png" } },
     Attributes: ["ALL"],
   }),
 );

--- a/docs/services/rekognition/sim-rekognition-detect-labels.example.ts
+++ b/docs/services/rekognition/sim-rekognition-detect-labels.example.ts
@@ -13,7 +13,7 @@ await simAws.s3().createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
 await simAws.s3().putObject(
   new PutObjectCommand({
     Bucket: "uploads",
-    Key: "raw/dog.png",
+    Key: "incoming/cat.png",
     Body: Buffer.from(
       "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGO4I2IDAAL8AS3VzMq8AAAAAElFTkSuQmCC",
       "base64",
@@ -24,13 +24,13 @@ await simAws.s3().putObject(
 simAws
   .rekognition()
   .labels()
-  .onName("raw/dog.png", {
+  .onName("incoming/cat.png", {
     labels: [
       {
-        name: "Dog",
+        name: "Cat",
         confidence: 98.2,
-        parents: ["Animal", "Pet", "Canine"],
-        aliases: ["Puppy"],
+        parents: ["Animal", "Pet", "Feline"],
+        aliases: ["Kitten"],
         categories: ["Animals and Pets"],
         // A bounding box is in ratios of the image size, as AWS reports it.
         instances: [
@@ -43,12 +43,12 @@ simAws
 
 const detected = await simAws.rekognition().detectLabels(
   new DetectLabelsCommand({
-    Image: { S3Object: { Bucket: "uploads", Name: "raw/dog.png" } },
+    Image: { S3Object: { Bucket: "uploads", Name: "incoming/cat.png" } },
     MaxLabels: 10,
   }),
 );
 
-console.log(detected.Labels.map((label) => label.Name)); // [ "Dog", "Grass" ]
+console.log(detected.Labels.map((label) => label.Name)); // [ "Cat", "Grass" ]
 console.log(detected.Labels[0]?.Parents);
-// [ { Name: "Animal" }, { Name: "Pet" }, { Name: "Canine" } ]
+// [ { Name: "Animal" }, { Name: "Pet" }, { Name: "Feline" } ]
 console.log(detected.LabelModelVersion); // "3.0"

--- a/docs/services/rekognition/sim-rekognition-detect-moderation-labels.example.ts
+++ b/docs/services/rekognition/sim-rekognition-detect-moderation-labels.example.ts
@@ -13,7 +13,7 @@ await simAws.s3().createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
 await simAws.s3().putObject(
   new PutObjectCommand({
     Bucket: "uploads",
-    Key: "raw/nsfw.png",
+    Key: "incoming/photo.png",
     Body: Buffer.from(
       "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGO4I2IDAAL8AS3VzMq8AAAAAElFTkSuQmCC",
       "base64",
@@ -25,14 +25,14 @@ await simAws.s3().putObject(
 simAws
   .rekognition()
   .moderation()
-  .onName("raw/nsfw.png", { labels: ["Explicit Nudity"] });
+  .onName("incoming/photo.png", { labels: ["Weapons"] });
 
 const detected = await simAws.rekognition().detectModerationLabels(
   new DetectModerationLabelsCommand({
-    Image: { S3Object: { Bucket: "uploads", Name: "raw/nsfw.png" } },
+    Image: { S3Object: { Bucket: "uploads", Name: "incoming/photo.png" } },
   }),
 );
 
 console.log(detected.ModerationLabels.map((label) => label.Name));
-// [ "Explicit", "Explicit Nudity" ]
+// [ "Violence", "Weapons" ]
 console.log(detected.ModerationModelVersion); // "7.0"

--- a/docs/services/rekognition/sim-rekognition-max-labels.example.ts
+++ b/docs/services/rekognition/sim-rekognition-max-labels.example.ts
@@ -17,7 +17,7 @@ simAws
   .labels()
   .byDefault({
     labels: [
-      { name: "Dog", confidence: 98.2 },
+      { name: "Cat", confidence: 98.2 },
       { name: "Grass", confidence: 88 },
       { name: "Fence", confidence: 62 },
     ],
@@ -31,4 +31,4 @@ const detected = await simAws.rekognition().detectLabels(
   }),
 );
 
-console.log(detected.Labels.map((label) => label.Name)); // [ "Dog", "Grass" ]
+console.log(detected.Labels.map((label) => label.Name)); // [ "Cat", "Grass" ]

--- a/docs/services/rekognition/sim-rekognition-moderation-rules.example.ts
+++ b/docs/services/rekognition/sim-rekognition-moderation-rules.example.ts
@@ -12,7 +12,7 @@ const moderation = simAws.rekognition().moderation();
 moderation.byDefault({ labels: [] });
 
 // One S3 object, by the Name a request gives Rekognition.
-moderation.onName("raw/nsfw.png", { labels: ["Explicit Nudity"] });
+moderation.onName("incoming/photo.png", { labels: ["Weapons"] });
 
 // One image, by the hash of its bytes, for a system that generates its own
 // object keys. These bytes would usually come from a fixture file, read with

--- a/docs/services/rekognition/sim-rekognition-sample-images.example.ts
+++ b/docs/services/rekognition/sim-rekognition-sample-images.example.ts
@@ -13,7 +13,7 @@ import { simRekognitionSampleImages } from "@kensio/yulin/rekognition";
 const simAws = new SimAws();
 await simAws.s3().createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
 
-const key = `raw/${randomUUID()}.jpg`;
+const key = `incoming/${randomUUID()}.jpg`;
 
 await simAws.s3().putObject(
   new PutObjectCommand({

--- a/docs/services/rekognition/sim-rekognition-upload-pipeline.example.ts
+++ b/docs/services/rekognition/sim-rekognition-upload-pipeline.example.ts
@@ -115,7 +115,9 @@ await simAws.s3().putBucketNotificationConfiguration(
           Id: "moderate-uploads",
           Events: ["s3:ObjectCreated:*"],
           LambdaFunctionArn: moderatorArn,
-          Filter: { Key: { FilterRules: [{ Name: "prefix", Value: "raw/" }] } },
+          Filter: {
+            Key: { FilterRules: [{ Name: "prefix", Value: "incoming/" }] },
+          },
         },
       ],
     },
@@ -127,7 +129,7 @@ await simAws.s3().putBucketNotificationConfiguration(
 await simAws.s3().putObject(
   new PutObjectCommand({
     Bucket: "uploads",
-    Key: `raw/${randomUUID()}.jpg`,
+    Key: `incoming/${randomUUID()}.jpg`,
     Body: simRekognitionSampleImages.flaggedByModeration(),
   }),
 );

--- a/docs/services/route53/README.md
+++ b/docs/services/route53/README.md
@@ -387,8 +387,8 @@ await route53.changeResourceRecordSets(
             Type: "MX",
             TTL: 3600,
             ResourceRecords: [
-              { Value: "10 in1-smtp.messagingengine.com." },
-              { Value: "20 in2-smtp.messagingengine.com." },
+              { Value: "10 mx1.example.test." },
+              { Value: "20 mx2.example.test." },
             ],
           },
         },
@@ -418,7 +418,7 @@ const mailRecord = listOutput.ResourceRecordSets?.find(
   (recordSet) => recordSet.Type === "MX",
 );
 
-// [ '10 in1-smtp.messagingengine.com.', '20 in2-smtp.messagingengine.com.' ]
+// [ '10 mx1.example.test.', '20 mx2.example.test.' ]
 console.log(mailRecord?.ResourceRecords?.map((record) => record.Value));
 ```
 

--- a/docs/services/route53/sim-route53-mail-records.example.ts
+++ b/docs/services/route53/sim-route53-mail-records.example.ts
@@ -36,8 +36,8 @@ await route53.changeResourceRecordSets(
             Type: "MX",
             TTL: 3600,
             ResourceRecords: [
-              { Value: "10 in1-smtp.messagingengine.com." },
-              { Value: "20 in2-smtp.messagingengine.com." },
+              { Value: "10 mx1.example.test." },
+              { Value: "20 mx2.example.test." },
             ],
           },
         },
@@ -67,5 +67,5 @@ const mailRecord = listOutput.ResourceRecordSets?.find(
   (recordSet) => recordSet.Type === "MX",
 );
 
-// [ '10 in1-smtp.messagingengine.com.', '20 in2-smtp.messagingengine.com.' ]
+// [ '10 mx1.example.test.', '20 mx2.example.test.' ]
 console.log(mailRecord?.ResourceRecords?.map((record) => record.Value));

--- a/src/service/rekognition/command/detect-faces/detect-faces.iso.test.ts
+++ b/src/service/rekognition/command/detect-faces/detect-faces.iso.test.ts
@@ -206,12 +206,12 @@ describe("Detecting faces in a simulated image", () => {
   });
 
   it("keeps face rules apart from label rules", async () => {
-    // Given an object declared to hold a dog and no faces.
+    // Given an object declared to hold a cat and no faces.
     const simAws = await simAwsWithImage();
     simAws
       .rekognition()
       .labels()
-      .onName("selfie.jpg", { labels: ["Dog"] });
+      .onName("selfie.jpg", { labels: ["Cat"] });
     simAws.rekognition().faces().onName("selfie.jpg", simRekognitionNoFaces);
 
     // When its faces and its labels are detected.
@@ -225,7 +225,7 @@ describe("Detecting faces in a simulated image", () => {
     assertArrayLength(faces.FaceDetails, 0);
     assertArrayEquals(
       labels.Labels.map((label) => label.Name),
-      ["Dog"],
+      ["Cat"],
     );
   });
 

--- a/src/service/rekognition/command/detect-labels/detect-labels-iam.iso.test.ts
+++ b/src/service/rekognition/command/detect-labels/detect-labels-iam.iso.test.ts
@@ -26,7 +26,7 @@ async function simAwsWithImage(): Promise<SimAws> {
   await simAws.s3().putObject(
     new PutObjectCommand({
       Bucket: "uploads",
-      Key: "dog.jpg",
+      Key: "cat.jpg",
       Body: redPngBytes,
     }),
   );
@@ -35,7 +35,7 @@ async function simAwsWithImage(): Promise<SimAws> {
 }
 
 const imageCommand = new DetectLabelsCommand({
-  Image: { S3Object: { Bucket: "uploads", Name: "dog.jpg" } },
+  Image: { S3Object: { Bucket: "uploads", Name: "cat.jpg" } },
 });
 
 describe("Authorizing a simulated Rekognition label detection", () => {
@@ -49,7 +49,7 @@ describe("Authorizing a simulated Rekognition label detection", () => {
     simAws
       .rekognition()
       .labels()
-      .onName("dog.jpg", { labels: ["Dog"] });
+      .onName("cat.jpg", { labels: ["Cat"] });
 
     // When it detects labels in an image.
     const detected = await simAws.rekognition().detectLabels(imageCommand, {
@@ -57,7 +57,7 @@ describe("Authorizing a simulated Rekognition label detection", () => {
     });
 
     // Then the detection runs.
-    assertIdentical(detected.Labels[0]?.Name, "Dog");
+    assertIdentical(detected.Labels[0]?.Name, "Cat");
   });
 
   it("refuses a caller with no Rekognition permission", async () => {

--- a/src/service/rekognition/command/detect-labels/detect-labels-validation.iso.test.ts
+++ b/src/service/rekognition/command/detect-labels/detect-labels-validation.iso.test.ts
@@ -158,7 +158,7 @@ describe("Rejecting a malformed DetectLabels request", () => {
     await simAws.s3().putObject(
       new PutObjectCommand({
         Bucket: "uploads",
-        Key: "dog.jpg",
+        Key: "cat.jpg",
         Body: redPngBytes,
       }),
     );
@@ -167,7 +167,7 @@ describe("Rejecting a malformed DetectLabels request", () => {
     const error = await detectFailure(
       {
         Image: {
-          S3Object: { Bucket: "uploads", Name: "dog.jpg", Version: "3" },
+          S3Object: { Bucket: "uploads", Name: "cat.jpg", Version: "3" },
         },
       },
       simAws,
@@ -190,14 +190,14 @@ describe("Detecting labels in an image Rekognition cannot use", () => {
     await simAws.s3().putObject(
       new PutObjectCommand({
         Bucket: "uploads",
-        Key: "dog.jpg",
-        Body: "dog picture",
+        Key: "cat.jpg",
+        Body: "cat picture",
       }),
     );
 
     // When its labels are detected.
     const error = await detectFailure(
-      { Image: { S3Object: { Bucket: "uploads", Name: "dog.jpg" } } },
+      { Image: { S3Object: { Bucket: "uploads", Name: "cat.jpg" } } },
       simAws,
     );
 
@@ -211,7 +211,7 @@ describe("Detecting labels in an image Rekognition cannot use", () => {
     // Given no Bucket of that name anywhere in the simulation.
     // When labels in an image in it are detected.
     const error = await detectFailure({
-      Image: { S3Object: { Bucket: "nowhere", Name: "dog.jpg" } },
+      Image: { S3Object: { Bucket: "nowhere", Name: "cat.jpg" } },
     });
 
     // Then it is an S3 object error, which is how real Rekognition reports
@@ -222,7 +222,7 @@ describe("Detecting labels in an image Rekognition cannot use", () => {
   it("detects labels in bytes without any simulated S3 at all", async () => {
     // Given a Rekognition built on its own rather than through SimAws.
     const simRekognition = new SimRekognition();
-    simRekognition.labels().byDefault({ labels: ["Dog"] });
+    simRekognition.labels().byDefault({ labels: ["Cat"] });
 
     // When labels are detected in bytes.
     const detected = await simRekognition.detectLabels(
@@ -230,6 +230,6 @@ describe("Detecting labels in an image Rekognition cannot use", () => {
     );
 
     // Then it answers, since nothing needed reading.
-    assertIdentical(detected.Labels[0]?.Name, "Dog");
+    assertIdentical(detected.Labels[0]?.Name, "Cat");
   });
 });

--- a/src/service/rekognition/command/detect-labels/detect-labels.iso.test.ts
+++ b/src/service/rekognition/command/detect-labels/detect-labels.iso.test.ts
@@ -17,7 +17,7 @@ import { simRekognitionImageHash } from "../../image/sim-rekognition-image-hash.
 import type { SimDetectLabelsCommandOutput } from "./detect-labels.command.js";
 
 async function simAwsWithImage(
-  objectName = "dog.jpg",
+  objectName = "cat.jpg",
   bytes = redPngBytes,
 ): Promise<SimAws> {
   const simAws = new SimAws();
@@ -56,7 +56,7 @@ describe("Detecting labels in a simulated image", () => {
     const simAws = await simAwsWithImage();
 
     // When its labels are detected.
-    const detected = await detect(simAws, "dog.jpg");
+    const detected = await detect(simAws, "cat.jpg");
 
     // Then the documented AWS example response comes back, from the version
     // of the model it was published against.
@@ -82,38 +82,38 @@ describe("Detecting labels in a simulated image", () => {
   });
 
   it("answers with the labels declared for an object name", async () => {
-    // Given an object declared to hold a photograph of a dog.
+    // Given an object declared to hold a photograph of a cat.
     const simAws = await simAwsWithImage();
     simAws
       .rekognition()
       .labels()
-      .onName("dog.jpg", {
+      .onName("cat.jpg", {
         labels: [
           {
-            name: "Dog",
+            name: "Cat",
             confidence: 98.2,
-            parents: ["Animal", "Pet", "Canine"],
+            parents: ["Animal", "Pet", "Feline"],
           },
         ],
       });
 
     // When its labels are detected.
-    const detected = await detect(simAws, "dog.jpg", { MaxLabels: 10 });
+    const detected = await detect(simAws, "cat.jpg", { MaxLabels: 10 });
 
     // Then the declared label comes back with what was declared alongside it.
-    assertArrayEquals(labelNames(detected), ["Dog"]);
-    const [dog] = detected.Labels;
-    assertNonNullable(dog);
-    assertIdentical(dog.Confidence, Math.fround(98.2));
+    assertArrayEquals(labelNames(detected), ["Cat"]);
+    const [cat] = detected.Labels;
+    assertNonNullable(cat);
+    assertIdentical(cat.Confidence, Math.fround(98.2));
     assertArrayEquals(
-      dog.Parents.map((parent) => parent.Name),
-      ["Animal", "Pet", "Canine"],
+      cat.Parents.map((parent) => parent.Name),
+      ["Animal", "Pet", "Feline"],
     );
     // Nothing is filled in from the label name, so what was not declared is
     // empty rather than guessed at from an ontology Yulin does not have.
-    assertArrayLength(dog.Aliases, 0);
-    assertArrayLength(dog.Categories, 0);
-    assertArrayLength(dog.Instances, 0);
+    assertArrayLength(cat.Aliases, 0);
+    assertArrayLength(cat.Categories, 0);
+    assertArrayLength(cat.Instances, 0);
   });
 
   it("reports a label declared as a bare name", async () => {
@@ -122,10 +122,10 @@ describe("Detecting labels in a simulated image", () => {
     simAws
       .rekognition()
       .labels()
-      .onName("dog.jpg", { labels: ["Dog"] });
+      .onName("cat.jpg", { labels: ["Cat"] });
 
     // When its labels are detected.
-    const detected = await detect(simAws, "dog.jpg");
+    const detected = await detect(simAws, "cat.jpg");
 
     // Then it is reported at the default confidence, which is a float32 value
     // as every real Rekognition confidence is.
@@ -138,20 +138,20 @@ describe("Detecting labels in a simulated image", () => {
     simAws
       .rekognition()
       .labels()
-      .onName("dog.jpg", {
+      .onName("cat.jpg", {
         labels: [
           { name: "Pet", confidence: 71.5 },
-          { name: "Dog", confidence: 98.2 },
+          { name: "Cat", confidence: 98.2 },
           { name: "Grass", confidence: 88 },
         ],
       });
 
     // When its labels are detected.
-    const detected = await detect(simAws, "dog.jpg");
+    const detected = await detect(simAws, "cat.jpg");
 
     // Then the most confident label is first, as real Rekognition reports
     // them.
-    assertArrayEquals(labelNames(detected), ["Dog", "Grass", "Pet"]);
+    assertArrayEquals(labelNames(detected), ["Cat", "Grass", "Pet"]);
   });
 
   it("filters labels below the requested confidence", async () => {
@@ -160,18 +160,18 @@ describe("Detecting labels in a simulated image", () => {
     simAws
       .rekognition()
       .labels()
-      .onName("dog.jpg", {
+      .onName("cat.jpg", {
         labels: [
-          { name: "Dog", confidence: 98.2 },
+          { name: "Cat", confidence: 98.2 },
           { name: "Fence", confidence: 62 },
         ],
       });
 
     // When its labels are detected at a confidence above one of them.
-    const detected = await detect(simAws, "dog.jpg", { MinConfidence: 80 });
+    const detected = await detect(simAws, "cat.jpg", { MinConfidence: 80 });
 
     // Then the doubtful one is gone.
-    assertArrayEquals(labelNames(detected), ["Dog"]);
+    assertArrayEquals(labelNames(detected), ["Cat"]);
   });
 
   it("filters at 55 when the request does not say", async () => {
@@ -181,10 +181,10 @@ describe("Detecting labels in a simulated image", () => {
     simAws
       .rekognition()
       .labels()
-      .onName("dog.jpg", { labels: [{ name: "Fence", confidence: 52 }] });
+      .onName("cat.jpg", { labels: [{ name: "Fence", confidence: 52 }] });
 
     // When its labels are detected with no MinConfidence.
-    const detected = await detect(simAws, "dog.jpg");
+    const detected = await detect(simAws, "cat.jpg");
 
     // Then it is filtered out, because label detection defaults to 55 rather
     // than to the 50 moderation uses.
@@ -197,11 +197,11 @@ describe("Detecting labels in a simulated image", () => {
     simAws
       .rekognition()
       .labels()
-      .onName("dog.jpg", { labels: [{ name: "Fence", confidence: 12 }] });
+      .onName("cat.jpg", { labels: [{ name: "Fence", confidence: 12 }] });
 
     // When its labels are detected with an explicit zero rather than no value
     // at all.
-    const detected = await detect(simAws, "dog.jpg", { MinConfidence: 0 });
+    const detected = await detect(simAws, "cat.jpg", { MinConfidence: 0 });
 
     // Then the label survives: an explicit 0 is a request for everything, not
     // an unset value to be promoted to 55.
@@ -214,20 +214,20 @@ describe("Detecting labels in a simulated image", () => {
     simAws
       .rekognition()
       .labels()
-      .onName("dog.jpg", {
+      .onName("cat.jpg", {
         labels: [
           { name: "Pet", confidence: 71.5 },
-          { name: "Dog", confidence: 98.2 },
+          { name: "Cat", confidence: 98.2 },
           { name: "Grass", confidence: 88 },
         ],
       });
 
     // When its labels are detected with room for two.
-    const detected = await detect(simAws, "dog.jpg", { MaxLabels: 2 });
+    const detected = await detect(simAws, "cat.jpg", { MaxLabels: 2 });
 
     // Then the two most confident come back, which is what AWS documents
     // MaxLabels as returning.
-    assertArrayEquals(labelNames(detected), ["Dog", "Grass"]);
+    assertArrayEquals(labelNames(detected), ["Cat", "Grass"]);
   });
 
   it("applies MaxLabels after the confidence filter", async () => {
@@ -237,23 +237,23 @@ describe("Detecting labels in a simulated image", () => {
     simAws
       .rekognition()
       .labels()
-      .onName("dog.jpg", {
+      .onName("cat.jpg", {
         labels: [
-          { name: "Dog", confidence: 98.2 },
+          { name: "Cat", confidence: 98.2 },
           { name: "Fence", confidence: 62 },
           { name: "Grass", confidence: 88 },
         ],
       });
 
     // When its labels are detected with a confidence one of them fails.
-    const detected = await detect(simAws, "dog.jpg", {
+    const detected = await detect(simAws, "cat.jpg", {
       MaxLabels: 2,
       MinConfidence: 80,
     });
 
     // Then the room is spent on labels that survived the filter rather than
     // on labels that then filtered out.
-    assertArrayEquals(labelNames(detected), ["Dog", "Grass"]);
+    assertArrayEquals(labelNames(detected), ["Cat", "Grass"]);
   });
 
   it("answers with nothing when the request asks for no labels", async () => {
@@ -262,10 +262,10 @@ describe("Detecting labels in a simulated image", () => {
     simAws
       .rekognition()
       .labels()
-      .onName("dog.jpg", { labels: ["Dog"] });
+      .onName("cat.jpg", { labels: ["Cat"] });
 
     // When its labels are detected with an explicit MaxLabels of zero.
-    const detected = await detect(simAws, "dog.jpg", { MaxLabels: 0 });
+    const detected = await detect(simAws, "cat.jpg", { MaxLabels: 0 });
 
     // Then no labels come back: an explicit 0 is a request for none, not an
     // unset value to be read as uncapped.
@@ -278,10 +278,10 @@ describe("Detecting labels in a simulated image", () => {
     simAws
       .rekognition()
       .labels()
-      .onName("dog.jpg", {
+      .onName("cat.jpg", {
         labels: [
           {
-            name: "Dog",
+            name: "Cat",
             confidence: 98.2,
             instances: [
               {
@@ -297,16 +297,16 @@ describe("Detecting labels in a simulated image", () => {
       });
 
     // When its labels are detected.
-    const detected = await detect(simAws, "dog.jpg");
+    const detected = await detect(simAws, "cat.jpg");
 
     // Then both instances are located, and the one with no confidence of its
-    // own takes the label's, since a dog detected at 98 is not located at 40.
-    const [dog] = detected.Labels;
-    assertNonNullable(dog);
-    assertArrayLength(dog.Instances, 2);
-    assertIdentical(dog.Instances[0].Confidence, Math.fround(96.5));
-    assertIdentical(dog.Instances[0].BoundingBox.Height, Math.fround(0.4));
-    assertIdentical(dog.Instances[1].Confidence, Math.fround(98.2));
+    // own takes the label's, since a cat detected at 98 is not located at 40.
+    const [cat] = detected.Labels;
+    assertNonNullable(cat);
+    assertArrayLength(cat.Instances, 2);
+    assertIdentical(cat.Instances[0].Confidence, Math.fround(96.5));
+    assertIdentical(cat.Instances[0].BoundingBox.Height, Math.fround(0.4));
+    assertIdentical(cat.Instances[1].Confidence, Math.fround(98.2));
   });
 
   it("matches an image by content hash whatever it is called", async () => {
@@ -316,14 +316,14 @@ describe("Detecting labels in a simulated image", () => {
     simAws
       .rekognition()
       .labels()
-      .onHash(simRekognitionImageHash(bluePngBytes), { labels: ["Dog"] });
+      .onHash(simRekognitionImageHash(bluePngBytes), { labels: ["Cat"] });
 
     // When its labels are detected.
     const detected = await detect(simAws, "2f9c1e40-uuid.png");
 
     // Then the hash rule answers, which is what makes a system that generates
     // its own object keys testable.
-    assertArrayEquals(labelNames(detected), ["Dog"]);
+    assertArrayEquals(labelNames(detected), ["Cat"]);
   });
 
   it("consults hash rules and the default for an image passed as bytes", async () => {
@@ -331,7 +331,7 @@ describe("Detecting labels in a simulated image", () => {
     const simAws = new SimAws();
     const labels = simAws.rekognition().labels();
     labels.byDefault({ labels: ["Grass"] });
-    labels.onName("dog.jpg", { labels: ["Dog"] });
+    labels.onName("cat.jpg", { labels: ["Cat"] });
     labels.onHash(simRekognitionImageHash(bluePngBytes), { labels: ["Cat"] });
 
     // When images are detected as bytes rather than as S3 objects.
@@ -351,23 +351,23 @@ describe("Detecting labels in a simulated image", () => {
   });
 
   it("keeps label rules apart from moderation rules", async () => {
-    // Given an object declared to hold a dog and to fail moderation.
+    // Given an object declared to hold a cat and to fail moderation.
     const simAws = await simAwsWithImage();
     simAws
       .rekognition()
       .labels()
-      .onName("dog.jpg", { labels: ["Dog"] });
+      .onName("cat.jpg", { labels: ["Cat"] });
     simAws
       .rekognition()
       .moderation()
-      .onName("dog.jpg", { labels: ["Explicit Nudity"] });
+      .onName("cat.jpg", { labels: ["Weapons"] });
 
     // When its labels are detected.
-    const detected = await detect(simAws, "dog.jpg");
+    const detected = await detect(simAws, "cat.jpg");
 
     // Then it answers from the label rules alone, since each operation owns
     // the result shape it answers with.
-    assertArrayEquals(labelNames(detected), ["Dog"]);
+    assertArrayEquals(labelNames(detected), ["Cat"]);
   });
 
   it("keeps rules to the Account and Region they were registered in", async () => {
@@ -376,7 +376,7 @@ describe("Detecting labels in a simulated image", () => {
     simAws
       .rekognition()
       .labels()
-      .byDefault({ labels: ["Dog"] });
+      .byDefault({ labels: ["Cat"] });
 
     // When labels are detected in another Region.
     const elsewhere = await simAws

--- a/src/service/rekognition/command/detect-moderation-labels/detect-moderation-labels.iso.test.ts
+++ b/src/service/rekognition/command/detect-moderation-labels/detect-moderation-labels.iso.test.ts
@@ -62,14 +62,14 @@ describe("Detecting moderation labels in a simulated image", () => {
 
   it("answers with the labels declared for an object name", async () => {
     // Given an object declared to fail moderation.
-    const simAws = await simAwsWithImage("nsfw.png");
+    const simAws = await simAwsWithImage("photo.png");
     simAws
       .rekognition()
       .moderation()
-      .onName("nsfw.png", { labels: ["Explicit Nudity"] });
+      .onName("photo.png", { labels: ["Weapons"] });
 
     // When it is moderated.
-    const detected = await detect(simAws, "nsfw.png");
+    const detected = await detect(simAws, "photo.png");
 
     // Then the declared label comes back with the category above it, as real
     // Rekognition returns a detected label with its whole chain.
@@ -77,11 +77,11 @@ describe("Detecting moderation labels in a simulated image", () => {
     const [top, declared] = detected.ModerationLabels;
     assertNonNullable(top);
     assertNonNullable(declared);
-    assertIdentical(top.Name, "Explicit");
+    assertIdentical(top.Name, "Violence");
     assertIdentical(top.ParentName, "");
     assertIdentical(top.TaxonomyLevel, 1);
-    assertIdentical(declared.Name, "Explicit Nudity");
-    assertIdentical(declared.ParentName, "Explicit");
+    assertIdentical(declared.Name, "Weapons");
+    assertIdentical(declared.ParentName, "Violence");
     assertIdentical(declared.TaxonomyLevel, 2);
   });
 
@@ -283,7 +283,7 @@ describe("Detecting moderation labels in a simulated image", () => {
     simAws
       .rekognition()
       .moderation()
-      .byDefault({ labels: ["Explicit Sexual Activity"] });
+      .byDefault({ labels: ["Gambling"] });
 
     // When an image is moderated in another Region.
     const elsewhere = await simAws

--- a/src/service/rekognition/label/sim-rekognition-label-declaration.iso.test.ts
+++ b/src/service/rekognition/label/sim-rekognition-label-declaration.iso.test.ts
@@ -41,7 +41,7 @@ describe("Declaring a simulated label result", () => {
     // Given a simulated Rekognition.
     // When a rule declares a confidence outside the range AWS reports in.
     const error = assertThrowsError(() => {
-      labels().byDefault({ labels: [{ name: "Dog", confidence: 101 }] });
+      labels().byDefault({ labels: [{ name: "Cat", confidence: 101 }] });
     });
 
     // Then it is refused.
@@ -53,38 +53,38 @@ describe("Declaring a simulated label result", () => {
     // Given a simulated Rekognition.
     // When a rule declares a label whose parent has an empty name.
     const error = assertThrowsError(() => {
-      labels().onName("dog.jpg", {
-        labels: [{ name: "Dog", parents: ["Animal", ""] }],
+      labels().onName("cat.jpg", {
+        labels: [{ name: "Cat", parents: ["Animal", ""] }],
       });
     });
 
     // Then it is refused, rather than a response carrying a nameless parent.
     assertInstanceOf(error, SimRekognitionDeclarationError);
-    assertStringIncludes(error.message, "A declared parent for 'Dog'");
+    assertStringIncludes(error.message, "A declared parent for 'Cat'");
   });
 
   it("refuses an alias with no name of its own", () => {
     // Given a simulated Rekognition.
     // When a rule declares a label whose alias has an empty name.
     const error = assertThrowsError(() => {
-      labels().byDefault({ labels: [{ name: "Dog", aliases: [""] }] });
+      labels().byDefault({ labels: [{ name: "Cat", aliases: [""] }] });
     });
 
     // Then it is refused.
     assertInstanceOf(error, SimRekognitionDeclarationError);
-    assertStringIncludes(error.message, "A declared alias for 'Dog'");
+    assertStringIncludes(error.message, "A declared alias for 'Cat'");
   });
 
   it("refuses a category with no name of its own", () => {
     // Given a simulated Rekognition.
     // When a rule declares a label whose category has an empty name.
     const error = assertThrowsError(() => {
-      labels().byDefault({ labels: [{ name: "Dog", categories: [""] }] });
+      labels().byDefault({ labels: [{ name: "Cat", categories: [""] }] });
     });
 
     // Then it is refused.
     assertInstanceOf(error, SimRekognitionDeclarationError);
-    assertStringIncludes(error.message, "A declared category for 'Dog'");
+    assertStringIncludes(error.message, "A declared category for 'Cat'");
   });
 
   it("refuses a bounding box that is not a ratio of the image size", () => {
@@ -94,7 +94,7 @@ describe("Declaring a simulated label result", () => {
       labels().byDefault({
         labels: [
           {
-            name: "Dog",
+            name: "Cat",
             instances: [
               { boundingBox: { left: 120, top: 40, width: 300, height: 220 } },
             ],
@@ -117,7 +117,7 @@ describe("Declaring a simulated label result", () => {
       labels().byDefault({
         labels: [
           {
-            name: "Dog",
+            name: "Cat",
             instances: [
               {
                 boundingBox: { left: 0.1, top: 0.1, width: 0.2, height: 0.2 },
@@ -138,7 +138,7 @@ describe("Declaring a simulated label result", () => {
     // Given a simulated Rekognition.
     // When a rule is registered against a truncated digest.
     const error = assertThrowsError(() => {
-      labels().onHash("9f86d081884c7d65", { labels: ["Dog"] });
+      labels().onHash("9f86d081884c7d65", { labels: ["Cat"] });
     });
 
     // Then it is refused, rather than being stored as a hash nothing can ever
@@ -151,7 +151,7 @@ describe("Declaring a simulated label result", () => {
     // Given a simulated Rekognition.
     // When a rule is registered against an empty name.
     const error = assertThrowsError(() => {
-      labels().onName("", { labels: ["Dog"] });
+      labels().onName("", { labels: ["Cat"] });
     });
 
     // Then it is refused.

--- a/src/service/rekognition/label/sim-rekognition-label-declaration.ts
+++ b/src/service/rekognition/label/sim-rekognition-label-declaration.ts
@@ -17,7 +17,7 @@ export interface SimRekognitionDeclaredLabelInstance {
  *
  * Everything but the name is optional and empty when it is left out. Yulin
  * ships no general label ontology, so nothing here is filled in from a label
- * name: a `Dog` that is to arrive with its parents says what they are.
+ * name: a `Cat` that is to arrive with its parents says what they are.
  */
 export interface SimRekognitionDeclaredLabel {
   readonly name: string;

--- a/src/service/rekognition/moderation/sim-rekognition-moderation-declaration.iso.test.ts
+++ b/src/service/rekognition/moderation/sim-rekognition-moderation-declaration.iso.test.ts
@@ -19,7 +19,7 @@ describe("Declaring a simulated moderation result", () => {
       simAws
         .rekognition()
         .moderation()
-        .onName("nsfw.png", { labels: ["Graphic Male Nudity"] });
+        .onName("photo.png", { labels: ["Drug Products"] });
     });
 
     // Then it is refused where it was written, rather than at detection time.

--- a/src/service/rekognition/moderation/sim-rekognition-moderation-taxonomy.iso.test.ts
+++ b/src/service/rekognition/moderation/sim-rekognition-moderation-taxonomy.iso.test.ts
@@ -40,14 +40,13 @@ describe("The simulated Rekognition moderation taxonomy", () => {
     const taxonomy = simRekognitionModerationTaxonomy;
 
     // When a third level label's chain is taken.
-    const chain = taxonomy.chain("Implied Nudity");
+    const chain = taxonomy.chain("Weapon Violence");
 
     // Then it runs from the top level category down to the label itself.
     assertArrayLength(chain, 3);
     assertIdentical(
       chain.map((node) => node.name).join(" / "),
-      "Non-Explicit Nudity of Intimate parts and Kissing / " +
-        "Non-Explicit Nudity / Implied Nudity",
+      "Violence / Graphic Violence / Weapon Violence",
     );
   });
 

--- a/src/service/rekognition/moderation/sim-rekognition-moderation-taxonomy.ts
+++ b/src/service/rekognition/moderation/sim-rekognition-moderation-taxonomy.ts
@@ -24,8 +24,8 @@ export class SimRekognitionModerationLabelNode {
  *
  * Declaring a label is declaring a whole chain: real Rekognition returns the
  * detected label together with every label above it, so an image declared as
- * `Implied Nudity` comes back as that, its `Non-Explicit Nudity` parent, and
- * the top-level category above that. Handler code filtering on the top-level
+ * `Weapon Violence` comes back as that, its `Graphic Violence` parent, and the
+ * top-level category above that. Handler code filtering on the top-level
  * category therefore sees what it would see on AWS.
  */
 export class SimRekognitionModerationTaxonomy {
@@ -76,7 +76,7 @@ export class SimRekognitionModerationTaxonomy {
         `'${name}' is not a Rekognition moderation label. Declare one of the ` +
           `${String(this.nodes.size)} labels in the version ` +
           `${simRekognitionModerationModelVersion} content moderation ` +
-          `taxonomy, such as 'Explicit Nudity' or 'Violence'.`,
+          `taxonomy, such as 'Violence' or 'Gambling'.`,
       );
     }
 

--- a/src/service/rekognition/sdk/sim-rekognition-sdk-routing.iso.test.ts
+++ b/src/service/rekognition/sdk/sim-rekognition-sdk-routing.iso.test.ts
@@ -24,7 +24,7 @@ describe("Rekognition SDK interception", () => {
     simSdk.simAws
       .rekognition()
       .moderation()
-      .byDefault({ labels: ["Explicit Nudity"] });
+      .byDefault({ labels: ["Weapons"] });
 
     const rekognition = new RekognitionClient({ region: "us-east-1" });
 
@@ -37,19 +37,19 @@ describe("Rekognition SDK interception", () => {
     assertIdentical(detected.ModerationModelVersion, "7.0");
     assertStringIncludes(
       (detected.ModerationLabels ?? []).map((label) => label.Name).join(","),
-      "Explicit Nudity",
+      "Weapons",
     );
   });
 
   it("routes an intercepted label detection to simulated Rekognition", async () => {
     // Given an intercepted Rekognition SDK client, with an image declared to
-    // hold a dog.
+    // hold a cat.
     using simSdk = new SimSdk();
     simSdk.intercept(RekognitionClient);
     simSdk.simAws
       .rekognition()
       .labels()
-      .byDefault({ labels: [{ name: "Dog", parents: ["Animal"] }] });
+      .byDefault({ labels: [{ name: "Cat", parents: ["Animal"] }] });
 
     const rekognition = new RekognitionClient({ region: "us-east-1" });
 
@@ -62,7 +62,7 @@ describe("Rekognition SDK interception", () => {
     assertIdentical(detected.LabelModelVersion, "3.0");
     assertStringIncludes(
       (detected.Labels ?? []).map((label) => label.Name).join(","),
-      "Dog",
+      "Cat",
     );
   });
 

--- a/src/service/rekognition/sim-rekognition-moderation-pipeline.iso.test.ts
+++ b/src/service/rekognition/sim-rekognition-moderation-pipeline.iso.test.ts
@@ -148,20 +148,20 @@ async function simAwsWithModerationPipeline(): Promise<SimAws> {
 }
 
 describe("Moderating an uploaded image through a simulated pipeline", () => {
-  it("flags an upload the moderation rules declare as explicit", async () => {
+  it("flags an upload the moderation rules declare a label for", async () => {
     // Given a Bucket that moderates its uploads with a Lambda function, and an
     // image declared to fail moderation.
     const simAws = await simAwsWithModerationPipeline();
     simAws
       .rekognition()
       .moderation()
-      .onName("raw/nsfw.png", { labels: ["Explicit Nudity"] });
+      .onName("raw/photo.png", { labels: ["Weapons"] });
 
     // When the image is uploaded.
     await simAws.s3().putObject(
       new PutObjectCommand({
         Bucket: "uploads",
-        Key: "raw/nsfw.png",
+        Key: "raw/photo.png",
         Body: redPngBytes,
       }),
     );
@@ -172,11 +172,11 @@ describe("Moderating an uploaded image through a simulated pipeline", () => {
     const flagged = await simAws.s3().getObject(
       new GetObjectCommand({
         Bucket: "uploads",
-        Key: "flagged/raw/nsfw.png",
+        Key: "flagged/raw/photo.png",
       }),
     );
     assertNonNullable(flagged.Body);
-    assertStringIncludes(await text(flagged.Body), "Explicit,Explicit Nudity");
+    assertStringIncludes(await text(flagged.Body), "Violence,Weapons");
   });
 
   it("flags a sample image uploaded under a key nothing was declared for", async () => {

--- a/src/service/rekognition/sim-rekognition.ts
+++ b/src/service/rekognition/sim-rekognition.ts
@@ -97,8 +97,8 @@ export class SimRekognition {
    * Every image is clean until a rule says otherwise:
    *
    * ```typescript
-   * simAws.rekognition().moderation().onName("nsfw.jpg", {
-   *   labels: ["Explicit Nudity"],
+   * simAws.rekognition().moderation().onName("photo.jpg", {
+   *   labels: ["Weapons"],
    * });
    * ```
    */
@@ -112,8 +112,8 @@ export class SimRekognition {
    * Every image gets the built-in default result until a rule says otherwise:
    *
    * ```typescript
-   * simAws.rekognition().labels().onName("dog.jpg", {
-   *   labels: [{ name: "Dog", parents: ["Animal", "Pet"] }],
+   * simAws.rekognition().labels().onName("cat.jpg", {
+   *   labels: [{ name: "Cat", parents: ["Animal", "Pet"] }],
    * });
    * ```
    */

--- a/src/service/route53/cfn/record-set/sim-cfn-r53-mail-record-set.iso.test.ts
+++ b/src/service/route53/cfn/record-set/sim-cfn-r53-mail-record-set.iso.test.ts
@@ -28,10 +28,7 @@ describe("Route53 CloudFormation RecordSets for stored-only record types", () =>
               Name: "example.test",
               Type: "MX",
               TTL: "3600",
-              ResourceRecords: [
-                "10 in1-smtp.messagingengine.com.",
-                "20 in2-smtp.messagingengine.com.",
-              ],
+              ResourceRecords: ["10 mx1.example.test.", "20 mx2.example.test."],
             },
           },
         },
@@ -54,10 +51,7 @@ describe("Route53 CloudFormation RecordSets for stored-only record types", () =>
       name: "example.test",
       type: "MX",
       ttl: 3600,
-      values: [
-        "10 in1-smtp.messagingengine.com.",
-        "20 in2-smtp.messagingengine.com.",
-      ],
+      values: ["10 mx1.example.test.", "20 mx2.example.test."],
     });
   });
 });

--- a/src/service/route53/dns/answer/sim-route53-dns-negative.iso.test.ts
+++ b/src/service/route53/dns/answer/sim-route53-dns-negative.iso.test.ts
@@ -123,7 +123,7 @@ describe("Simulated Route53 DNS negative answers", () => {
       {
         name: "example.test",
         type: "MX",
-        values: ["10 in1-smtp.messagingengine.com."],
+        values: ["10 mx1.example.test."],
       },
     ]);
 

--- a/src/service/route53/record/sim-route53-record-type.iso.test.ts
+++ b/src/service/route53/record/sim-route53-record-type.iso.test.ts
@@ -29,8 +29,8 @@ const zoneRecords: readonly ZoneRecord[] = [
       Type: "MX",
       TTL: 3600,
       ResourceRecords: [
-        { Value: "10 in1-smtp.messagingengine.com." },
-        { Value: "20 in2-smtp.messagingengine.com." },
+        { Value: "10 mx1.example.test." },
+        { Value: "20 mx2.example.test." },
       ],
     },
   },


### PR DESCRIPTION
The published sim Rekognition docs had picked up an S3 key whose prefix and filename read together as a crude phrase, and moderation examples that reached for the coarsest labels in the AWS taxonomy when a milder one demonstrates the same behaviour. Object keys now sit under an `incoming/` prefix so no filename can recombine with it, the moderation examples declare `Weapons` under `Violence`, and the taxonomy-version note uses the `Drug Products` rename and the `Drinking` move instead. The label examples are a cat rather than a dog, since the project is named Yulin. A real third party's mail hostnames in the Route53 MX example are replaced with reserved `example.test` ones. The same terminology is carried through the tests that mirror these examples, the JSDoc shown on IDE hover and the error message naming an unknown moderation label; AWS's own taxonomy data is untouched, since the simulator has to answer with the names AWS uses.

## For a reviewer

- **Nothing behavioural changes.** The only shipped strings that move are one JSDoc example and one error message's suggestions (`'Explicit Nudity' or 'Violence'` becomes `'Violence' or 'Gambling'`). Everything else is example data and test fixtures.
- **The `raw/` to `incoming/` rename is deliberate rather than cosmetic.** Renaming only `dog.png` would leave the trap open for whatever filename lands there next; changing the prefix closes it. Other services' docs keep `raw/cat.jpg`, which is fine on its own.
- **`Weapons` was chosen because it expands identically.** It sits under `Violence`, so the two-level parent-chain expansion the moderation example exists to show is unchanged. The taxonomy tests that genuinely exercise deep chains now use `Violence / Graphic Violence / Weapon Violence`.
- **The 6.1-to-7.0 prose is still accurate.** `Drug Products` became `Products` under `Drugs & Tobacco`, and `Drinking` moved from directly under `Alcohol` to under `Alcohol Use`; both are checkable against the shipped 7.0 label list.
- **`docs/**/*.example.ts` are generated**, so they were regenerated with `pnpm examples:extract` rather than hand-edited.
- The `/pets/dog/{id}` routes in the API Gateway docs are left alone, since that section reproduces AWS's own published route-selection example.

`pnpm run check` passes: 966 test files, 5856 tests, coverage threshold met.