### PR TITLE
docs: document that CachePolicyId is accepted and ignored

### DIFF
--- a/docs/services/cloudfront/README.md
+++ b/docs/services/cloudfront/README.md
@@ -1316,3 +1316,7 @@ Where sim CloudFront knowingly behaves differently from AWS:
   template, so nothing here creates them. A Behavior naming one is refused with
   `NoSuchResponseHeadersPolicy` when a request reaches it, rather than serving a response without the
   headers the policy would have set.
+- **`CachePolicyId` and `OriginRequestPolicyId` are accepted and ignored.** Sim CloudFront does not
+  model edge caching, so a Behavior's cache policy — including an AWS managed policy such as
+  `CachingOptimized` — is neither validated nor applied to TTLs or the cache key. Every request
+  reaches the Origin regardless of what the policy would have cached on real CloudFront.


### PR DESCRIPTION
Sim CloudFront never modelled edge caching, so a Behavior's `CachePolicyId` or `OriginRequestPolicyId` — including an AWS managed policy such as `CachingOptimized` — rides along unread with no validation and no effect on TTLs or the cache key. That silence was undocumented, unlike the sibling `ResponseHeadersPolicyId` limitation nearby, so this adds a Limitations entry alongside it explaining that every request still reaches the Origin regardless of what the policy would have cached on real CloudFront.

## Test plan
- [x] `pnpm run check` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that CloudFront cache and origin request policy identifiers are accepted but not applied.
  * Documented that requests always reach the origin without simulated edge caching, TTL behavior, or cache-key processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->