### PR TITLE
feat: model every response headers policy section

### DIFF
--- a/docs/services/cloudfront/README.md
+++ b/docs/services/cloudfront/README.md
@@ -1093,6 +1093,31 @@ The policy is applied after a custom error response is fetched and before a `vie
 CloudFront Function runs, as CloudFront does. An error page carries the policy's headers, and a
 function sees them in `event.response.headers` and can change them.
 
+`SecurityHeadersConfig` is what CDK's `ResponseHeadersPolicy` construct synthesizes from
+`securityHeadersBehavior`, and every one of its sections is modelled: `ContentSecurityPolicy`,
+`ContentTypeOptions`, `FrameOptions`, `ReferrerPolicy`, `StrictTransportSecurity` and `XSSProtection`
+each become the header CloudFront documents for it, honouring the section's own `Override` the same
+way a `CustomHeadersConfig` item does.
+
+`ServerTimingHeadersConfig` adds a `Server-Timing` header once `Enabled` is true. `SamplingRate` is
+not honoured: this simulation always adds the header rather than sampling a share of responses, so a
+test asserting on it does not depend on chance, and the header's value is a fixed placeholder rather
+than real Origin timing.
+
+`CorsConfig` is what CDK's `corsBehavior` synthesizes. CloudFront reflects the viewer request's
+`Origin` header against `AccessControlAllowOrigins` rather than sending the list itself: a request
+naming an Origin the list allows gets the CORS headers the section configures, with the response
+varying on `Origin` unless the list is `["*"]`; a request naming one it does not allow gets none of
+them, the same as CloudFront sending none rather than a mismatched one. `AccessControlAllowMethods`
+of `["ALL"]` expands to CloudFront's full method list, and `AccessControlAllowCredentials: false`
+leaves `Access-Control-Allow-Credentials` off entirely, since a header naming `false` means the same
+as its absence to a browser.
+
+A Behavior's `ResponseHeadersPolicyId` is checked when the Distribution is created or updated: naming
+a policy this simulation did not create, whether mistyped or a CloudFront managed policy ID, fails the
+Stack there rather than deploying successfully and only failing the first request that reaches the
+Behavior.
+
 ## Origin access controls
 
 An origin access control is how a Distribution authenticates to a private S3 Bucket. Declare one as
@@ -1302,17 +1327,19 @@ Where sim CloudFront knowingly behaves differently from AWS:
 - **`DeleteFunctionCommand` never answers `FunctionInUse`.** Nothing tells a CloudFront Function that
   a cache Behavior has taken it up, so every Function is deletable. A Behavior left pointing at a
   deleted Function runs no Function code.
-- **A response headers policy sets custom headers and removes named ones, and nothing else.** The
-  `CorsConfig`, `SecurityHeadersConfig` and `ServerTimingHeadersConfig` sections each set headers of
-  their own, and none of them is modelled. A policy declaring one fails the stack by naming the
-  section, rather than deploying and then serving responses missing the headers it promised.
 - **A response headers policy name is unique, but nothing else about it is checked.** A second
   policy claiming a name is refused with `ResponseHeadersPolicyAlreadyExists`, as CloudFront refuses
   one. The header names and values themselves are stored as written.
 - **There is no command surface for a response headers policy.** `CreateResponseHeadersPolicy` and
   its siblings are not simulated, so `AWS::CloudFront::ResponseHeadersPolicy` is the only way to make
   one.
+- **`ServerTimingHeadersConfig` always adds the header once enabled, rather than sampling.**
+  `SamplingRate` decides what share of real responses carry `Server-Timing`; this simulation adds it
+  to every response once `Enabled` is true, so a test asserting on it does not depend on chance. The
+  header's value is a fixed placeholder rather than real timing data, since nothing here measures an
+  Origin fetch the way CloudFront's edge does.
 - **A managed policy ID is not found.** CloudFront's managed policies belong to AWS rather than to a
   template, so nothing here creates them. A Behavior naming one is refused with
-  `NoSuchResponseHeadersPolicy` when a request reaches it, rather than serving a response without the
-  headers the policy would have set.
+  `InvalidResponseHeadersPolicyId` when the Distribution is created or updated, the same as real
+  CloudFront refuses one at that point, rather than deploying successfully and only failing the first
+  request that reaches the Behavior.

--- a/src/service/cloudfront/README.md
+++ b/src/service/cloudfront/README.md
@@ -163,20 +163,32 @@ request and viewer response events on cache Behaviors.
 ## Response headers policies
 
 `response-headers-policy/` holds the policy model. A `SimCloudFrontResponseHeadersPolicy` is a name,
-an ID and two lists: the headers to add and the headers to remove. Removal happens first, so a header
-in both ends up present with the policy's value. Each added header carries an `Override` deciding
-whether it replaces one the Origin sent.
+an ID, the headers to add and remove, the security headers list, an optional Server-Timing header and
+an optional `SimCloudFrontResponseHeadersPolicyCors`. Removal happens first, so a header in both ends
+up present with the policy's value. Each added header, including a security header, carries an
+`Override` deciding whether it replaces one the Origin sent; CORS has one `originOverride` for the
+whole section instead, matching CloudFront's own schema.
+
+`SimCloudFrontResponseHeadersPolicyCors` is its own class because applying it needs the viewer
+request, not just the response: CloudFront reflects the request's `Origin` header against the
+configured allow list rather than sending the list itself, so `apply()` takes the header's value and
+adds nothing when it names no allowed Origin, the same as CloudFront answering none rather than a
+mismatched one.
 
 Policies are stored on `SimCloudFront` and found by ID, which is what a Behavior's
 `responseHeadersPolicyId` names. There is no CreateResponseHeadersPolicy command, so
-`cfn/response-headers-policy/` is the only thing that makes one. Its config reader models the custom
-and removed headers, and refuses `CorsConfig`, `SecurityHeadersConfig` and `ServerTimingHeadersConfig`
-by name: each sets headers of its own, and a policy that quietly sets fewer here than in AWS is a
-divergence a passing test would hide.
+`cfn/response-headers-policy/` is the only thing that makes one. Its config reader models every
+section: `CustomHeadersConfig` and `RemoveHeadersConfig` as before, `SecurityHeadersConfig` as one
+header per sub-section, `ServerTimingHeadersConfig` as a fixed header once `Enabled` (not sampled, so
+a test does not depend on chance), and `CorsConfig` into the CORS model above.
 
-A lookup miss is `SimCloudFrontNoSuchResponseHeadersPolicy` rather than a pass-through, because the
-common cause is a managed policy ID, which names a policy AWS owns rather than one a template
-creates.
+A lookup miss at request time is `SimCloudFrontNoSuchResponseHeadersPolicy` rather than a
+pass-through. In practice this is defence in depth rather than the common path: `ResponseHeadersPolicyId` is checked eagerly too, by `SimCloudFrontBehaviorConfigurator` when the Distribution is
+created or updated, so a Behavior naming an ID nothing created — commonly a managed policy ID, which
+names a policy AWS owns rather than one a template creates — fails there as
+`SimCloudFrontInvalidResponseHeadersPolicyId`, the same as real CloudFront refuses the whole
+CreateDistribution/UpdateDistribution rather than deploying and failing the first request that needs
+it.
 
 ## Origin access controls
 
@@ -190,8 +202,9 @@ CreateOriginAccessControl command, so a template is the only thing that makes on
 `SimCloudFrontOriginConfigurator` resolves an Origin's `OriginAccessControlId` through the registry
 when the Distribution is created, and stores the result on the `SimCloudFrontS3Origin`. An ID
 nothing created is `SimCloudFrontInvalidOriginAccessControl`, as CloudFront refuses the whole
-CreateDistribution. Resolution is eager here, unlike a response headers policy, because CloudFront
-checks an origin access control at creation rather than when a request arrives.
+CreateDistribution. `SimCloudFrontBehaviorConfigurator` resolves a Behavior's
+`ResponseHeadersPolicyId` the same eager way, for the same reason: CloudFront checks both at creation
+rather than when a request arrives.
 
 `SimCfS3OriginSigner` reads the stored origin access control on every Origin fetch. One whose
 `signs` getter is true makes the read a request from the `cloudfront.amazonaws.com` service

--- a/src/service/cloudfront/cfn/distro/sim-cfn-cf-distro-response-headers-sections.iso.test.ts
+++ b/src/service/cloudfront/cfn/distro/sim-cfn-cf-distro-response-headers-sections.iso.test.ts
@@ -1,0 +1,236 @@
+import { describe, it } from "vitest";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertResponseStatus,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  describeResponse,
+} from "@kensio/smartass";
+import { PutObjectCommand } from "@aws-sdk/client-s3";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import type { CfnTemplateBodyRecord } from "../../../cloudformation/template/sim-cfn-template.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import { grantPublicObjectRead } from "../../../s3/bucket/sim-s3-public-read.fixture.js";
+import { SimCloudFrontDistribution } from "../../distribution/sim-cloudfront-distribution.js";
+import { simCfSiteRequest } from "../../../../../test/cloudfront/site-fixture.js";
+
+/**
+ * A template declaring a response headers policy and a Distribution applying
+ * it, the way CDK synthesizes the pair. Split from
+ * sim-cfn-cf-distro-response-headers.iso.test.ts, which covers
+ * CustomHeadersConfig and RemoveHeadersConfig, because this project holds
+ * every test file to a line count and the sections here — security headers,
+ * Server-Timing, CORS and the policy ID a Behavior names — are enough on
+ * their own to reach it.
+ */
+function siteTemplate(
+  policyConfig: SimCfnTemplateValueRecord,
+  distributionConfig: SimCfnTemplateValueRecord = {},
+): CfnTemplateBodyRecord {
+  return {
+    Resources: {
+      SiteBucket: {
+        Type: "AWS::S3::Bucket",
+        Properties: { BucketName: "headers-sections-site-bucket" },
+      },
+      CacheHeaders: {
+        Type: "AWS::CloudFront::ResponseHeadersPolicy",
+        Properties: { ResponseHeadersPolicyConfig: policyConfig },
+      },
+      SiteDistribution: {
+        Type: "AWS::CloudFront::Distribution",
+        DependsOn: ["SiteBucket", "CacheHeaders"],
+        Properties: {
+          DistributionConfig: {
+            DefaultRootObject: "index.html",
+            Origins: [
+              {
+                Id: "SiteOrigin",
+                DomainName: "headers-sections-site-bucket.s3.amazonaws.com",
+                S3OriginConfig: {},
+              },
+            ],
+            DefaultCacheBehavior: {
+              TargetOriginId: "SiteOrigin",
+              ViewerProtocolPolicy: "redirect-to-https",
+              ResponseHeadersPolicyId: { Ref: "CacheHeaders" },
+            },
+            ...distributionConfig,
+          },
+        },
+      },
+    },
+  };
+}
+
+describe("CloudFormation Distribution response headers policy sections", () => {
+  async function deployedSite(
+    policyConfig: SimCfnTemplateValueRecord,
+  ): Promise<{ simAws: SimAws; distributionId: string }> {
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "response-headers-sections-stack",
+      template: siteTemplate(policyConfig),
+    });
+
+    const resource = stack.getResource("SiteDistribution");
+
+    assertNonNullable(resource);
+    assertInstanceOf(resource.simResource, SimCloudFrontDistribution);
+
+    await simAws.s3().putObject(
+      new PutObjectCommand({
+        Bucket: "headers-sections-site-bucket",
+        Key: "index.html",
+        ContentType: "text/html",
+        Body: "<h1>Home</h1>",
+      }),
+    );
+    await grantPublicObjectRead(simAws.s3(), "headers-sections-site-bucket");
+
+    return { simAws, distributionId: resource.simResource.distributionId };
+  }
+
+  it("applies a policy's security headers to what the Distribution serves", async () => {
+    // Given a Distribution whose policy sets every security header section.
+    const { simAws, distributionId } = await deployedSite({
+      Name: "CacheHeaders",
+      SecurityHeadersConfig: {
+        ContentSecurityPolicy: {
+          ContentSecurityPolicy: "default-src 'self'",
+          Override: true,
+        },
+        ContentTypeOptions: { Override: true },
+        FrameOptions: { FrameOption: "DENY", Override: true },
+        ReferrerPolicy: { ReferrerPolicy: "same-origin", Override: true },
+        StrictTransportSecurity: {
+          AccessControlMaxAgeSec: 31_536_000,
+          IncludeSubdomains: true,
+          Preload: true,
+          Override: true,
+        },
+        XSSProtection: { Protection: true, ModeBlock: true, Override: true },
+      },
+    });
+
+    // When a page is requested.
+    const home = await simCfSiteRequest(simAws, distributionId, "/");
+
+    // Then every section's header is on the response, which is what CDK's
+    // securityHeadersBehavior needs to be exercised locally.
+    assertResponseStatus(home, 200, await describeResponse(home));
+    assertIdentical(
+      home.headers.get("content-security-policy"),
+      "default-src 'self'",
+    );
+    assertIdentical(home.headers.get("x-content-type-options"), "nosniff");
+    assertIdentical(home.headers.get("x-frame-options"), "DENY");
+    assertIdentical(home.headers.get("referrer-policy"), "same-origin");
+    assertIdentical(
+      home.headers.get("strict-transport-security"),
+      "max-age=31536000; includeSubDomains; preload",
+    );
+    assertIdentical(home.headers.get("x-xss-protection"), "1; mode=block");
+  });
+
+  it("adds a Server-Timing header once the policy enables it", async () => {
+    // Given a policy enabling the Server-Timing header.
+    const { simAws, distributionId } = await deployedSite({
+      Name: "CacheHeaders",
+      ServerTimingHeadersConfig: { Enabled: true, SamplingRate: 100 },
+    });
+
+    // When a page is requested.
+    const home = await simCfSiteRequest(simAws, distributionId, "/");
+
+    // Then the header is present.
+    assertNonNullable(home.headers.get("server-timing"));
+  });
+
+  it("reflects an allowed Origin in a policy's CORS headers", async () => {
+    // Given a policy allowing one Origin.
+    const { simAws, distributionId } = await deployedSite({
+      Name: "CacheHeaders",
+      CorsConfig: {
+        AccessControlAllowCredentials: false,
+        AccessControlAllowHeaders: { Items: ["*"] },
+        AccessControlAllowMethods: { Items: ["GET", "HEAD"] },
+        AccessControlAllowOrigins: { Items: ["https://example.com"] },
+        OriginOverride: true,
+      },
+    });
+
+    // When a page is requested with that Origin.
+    const home = await simCfSiteRequest(simAws, distributionId, "/", {
+      headers: { Origin: "https://example.com" },
+    });
+
+    // Then the CORS headers name it, and the response varies on Origin.
+    assertIdentical(
+      home.headers.get("access-control-allow-origin"),
+      "https://example.com",
+    );
+    assertIdentical(
+      home.headers.get("access-control-allow-methods"),
+      "GET,HEAD",
+    );
+    assertIdentical(home.headers.get("vary"), "Origin");
+  });
+
+  it("omits a policy's CORS headers for an Origin it does not allow", async () => {
+    // Given the same policy.
+    const { simAws, distributionId } = await deployedSite({
+      Name: "CacheHeaders",
+      CorsConfig: {
+        AccessControlAllowCredentials: false,
+        AccessControlAllowHeaders: { Items: ["*"] },
+        AccessControlAllowMethods: { Items: ["GET"] },
+        AccessControlAllowOrigins: { Items: ["https://example.com"] },
+        OriginOverride: true,
+      },
+    });
+
+    // When a page is requested with an Origin the policy does not allow.
+    const home = await simCfSiteRequest(simAws, distributionId, "/", {
+      headers: { Origin: "https://evil.example" },
+    });
+
+    // Then none of the CORS headers are added, as CloudFront sends none
+    // rather than a mismatched one.
+    assertIdentical(home.headers.get("access-control-allow-origin"), null);
+  });
+
+  it("fails the stack for a Behavior naming a response headers policy that does not exist", async () => {
+    // Given a Distribution whose default Behavior names an ID nothing in this
+    // simulation created, which is what a CloudFront managed policy ID is
+    // here.
+    const simAws = new SimAws();
+
+    // When the template is deployed, then it fails at deploy time rather than
+    // deploying successfully and only failing the first request that reaches
+    // the Behavior.
+    const error = await assertThrowsErrorAsync(async () => {
+      const stack = await simAws.cloudFormation().deployTemplate({
+        stackName: "missing-policy-stack",
+        template: siteTemplate(
+          { Name: "CacheHeaders" },
+          {
+            DefaultCacheBehavior: {
+              TargetOriginId: "SiteOrigin",
+              ViewerProtocolPolicy: "redirect-to-https",
+              ResponseHeadersPolicyId: "67f7725c-6f97-4210-82d7-5512b31e9d03",
+            },
+          },
+        ),
+      });
+
+      await stack.waitForDeployComplete();
+    });
+
+    assertStringIncludes(error.message, "67f7725c-6f97-4210-82d7-5512b31e9d03");
+    assertStringIncludes(error.message, "managed policy ID");
+  });
+});

--- a/src/service/cloudfront/cfn/distro/sim-cfn-cf-distro-response-headers.iso.test.ts
+++ b/src/service/cloudfront/cfn/distro/sim-cfn-cf-distro-response-headers.iso.test.ts
@@ -259,33 +259,4 @@ describe("CloudFormation Distribution response headers policies", () => {
     // their own and diverging from what AWS would have done.
     assertStringIncludes(error.message, "CacheHeaders already exists");
   });
-
-  it("fails the stack for a policy section it does not model", async () => {
-    // Given a template whose policy sets security headers, which this
-    // simulation does not model.
-    const simAws = new SimAws();
-
-    // When the template is deployed, then it fails rather than serving
-    // responses missing the headers the policy promised.
-    const error = await assertThrowsErrorAsync(async () => {
-      const stack = await simAws.cloudFormation().deployTemplate({
-        stackName: "unmodelled-section-stack",
-        template: siteTemplate({
-          Name: "CacheHeaders",
-          SecurityHeadersConfig: {
-            StrictTransportSecurity: {
-              AccessControlMaxAgeSec: 31_536_000,
-              Override: true,
-            },
-          },
-        }),
-      });
-
-      await stack.waitForDeployComplete();
-    });
-
-    // And the section is named for diagnosis.
-    assertStringIncludes(error.message, "SecurityHeadersConfig");
-    assertStringIncludes(error.message, "CacheHeaders");
-  });
 });

--- a/src/service/cloudfront/cfn/response-headers-policy/sim-cfn-cf-rh-policy-config.iso.test.ts
+++ b/src/service/cloudfront/cfn/response-headers-policy/sim-cfn-cf-rh-policy-config.iso.test.ts
@@ -5,6 +5,7 @@ import {
   assertStringIncludes,
   assertThrowsError,
   assertTrue,
+  assertUndefined,
 } from "@kensio/smartass";
 import { describe, it } from "vitest";
 import { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
@@ -84,21 +85,86 @@ describe("SimCfnCfResponseHeadersPolicyConfig", () => {
     assertArrayLength(policy.headersToRemove, 0);
   });
 
-  it("refuses each section it does not model, by name", () => {
-    // Given policy configs using the sections this simulation does not model.
-    // When each is read, then it is refused by name rather than stepped over,
-    // because a policy that quietly sets fewer headers here than in AWS is a
-    // divergence a test would not catch.
-    for (const section of [
-      "CorsConfig",
-      "SecurityHeadersConfig",
-      "ServerTimingHeadersConfig",
-    ]) {
-      const error = assertThrowsError(() => policyFrom({ [section]: {} }));
+  it("reads the security headers a policy sets", () => {
+    // Given the config CDK's securityHeadersBehavior synthesizes, which the
+    // per-section mapping is tested by SimCfnCfResponseHeadersPolicySecurityHeaders.
+    const policy = policyFrom({
+      SecurityHeadersConfig: {
+        ContentTypeOptions: { Override: true },
+      },
+    });
 
-      assertStringIncludes(error.message, section);
-      assertStringIncludes(error.message, "CacheHeaders");
-    }
+    // Then the section is delegated to and its header is on the policy.
+    assertArrayLength(policy.securityHeaders, 1);
+    assertIdentical(policy.securityHeaders[0].name, "X-Content-Type-Options");
+  });
+
+  it("reads a policy setting no security headers", () => {
+    // Given a SecurityHeadersConfig with no sections.
+    const policy = policyFrom({ SecurityHeadersConfig: {} });
+
+    // Then it sets none.
+    assertArrayLength(policy.securityHeaders, 0);
+  });
+
+  it("reads ServerTimingHeadersConfig once enabled", () => {
+    // Given the config enabling the Server-Timing header.
+    const policy = policyFrom({
+      ServerTimingHeadersConfig: { Enabled: true, SamplingRate: 50 },
+    });
+
+    // Then the header is set.
+    assertNonNullable(policy.serverTiming);
+    assertIdentical(policy.serverTiming.name, "Server-Timing");
+  });
+
+  it("reads a disabled ServerTimingHeadersConfig as setting nothing", () => {
+    // Given the config leaving the header off.
+    const policy = policyFrom({
+      ServerTimingHeadersConfig: { Enabled: false },
+    });
+
+    // Then no header is set.
+    assertUndefined(policy.serverTiming);
+  });
+
+  it("refuses a ServerTimingHeadersConfig with no boolean Enabled", () => {
+    assertStringIncludes(
+      assertThrowsError(() => policyFrom({ ServerTimingHeadersConfig: {} }))
+        .message,
+      "needs a boolean Enabled",
+    );
+  });
+
+  it("reads the CORS a policy sets", () => {
+    // Given the config CDK's corsBehavior synthesizes, which the per-field
+    // mapping is tested by SimCfnCfResponseHeadersPolicyCorsConfig.
+    const policy = policyFrom({
+      CorsConfig: {
+        AccessControlAllowCredentials: true,
+        AccessControlAllowHeaders: { Items: ["*"] },
+        AccessControlAllowMethods: { Items: ["GET"] },
+        AccessControlAllowOrigins: { Items: ["https://example.com"] },
+        OriginOverride: true,
+      },
+    });
+
+    // Then the section is delegated to and its model is on the policy.
+    assertNonNullable(policy.cors);
+
+    const headers = new Headers();
+    policy.cors.apply(headers, "https://example.com");
+
+    assertIdentical(
+      headers.get("access-control-allow-origin"),
+      "https://example.com",
+    );
+  });
+
+  it("reads a policy with no CorsConfig as having none", () => {
+    const policy = policyFrom({});
+
+    assertUndefined(policy.cors);
   });
 
   it("refuses a policy config that is not an object", () => {
@@ -127,7 +193,10 @@ describe("SimCfnCfResponseHeadersPolicyConfig", () => {
       }).build(),
     );
 
-    assertStringIncludes(error.message, "Name must be a string");
+    assertStringIncludes(
+      error.message,
+      "ResponseHeadersPolicyConfig needs a string Name",
+    );
   });
 
   it("refuses a custom header missing its Header, Value or Override", () => {

--- a/src/service/cloudfront/cfn/response-headers-policy/sim-cfn-cf-rh-policy-config.ts
+++ b/src/service/cloudfront/cfn/response-headers-policy/sim-cfn-cf-rh-policy-config.ts
@@ -1,34 +1,40 @@
 import { isRecord } from "../../../../util/type-guard/record.js";
 import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
 import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
-import { SimCloudFrontResponseHeader } from "../../response-headers-policy/sim-cf-response-header.js";
 import { SimCloudFrontResponseHeadersPolicy } from "../../response-headers-policy/sim-cf-response-headers-policy.js";
-
-/**
- * The sections of a ResponseHeadersPolicyConfig this simulation does not model.
- *
- * Each of these turns into response headers of its own, so ignoring one would
- * serve a response missing headers the policy promised. A CORS section that
- * quietly does nothing is the worst of them, because the request it breaks is
- * one a browser makes and a test does not.
- */
-const unmodelledSections = [
-  "CorsConfig",
-  "SecurityHeadersConfig",
-  "ServerTimingHeadersConfig",
-] as const;
+import { simCfnCfResponseHeadersPolicyCors } from "./sim-cfn-cf-rh-policy-cors-config.js";
+import {
+  simCfnCfResponseHeadersPolicyCustomHeaders,
+  simCfnCfResponseHeadersPolicyRemoveHeaders,
+} from "./sim-cfn-cf-rh-policy-custom-headers.js";
+import {
+  requiredString,
+  type SimCfnCfRhPolicyFieldRefuse,
+} from "./sim-cfn-cf-rh-policy-field-reader.js";
+import { simCfnCfResponseHeadersPolicySecurityHeaders } from "./sim-cfn-cf-rh-policy-security-headers.js";
+import { simCfnCfResponseHeadersPolicyServerTiming } from "./sim-cfn-cf-rh-policy-server-timing.js";
 
 /**
  * Reads an AWS::CloudFront::ResponseHeadersPolicy Resource into a simulated
  * policy.
  *
- * Only the custom headers and the removed headers are modelled. The other
- * sections are refused by name rather than stepped over, so a policy that would
- * serve different headers here than in AWS fails where it is written.
+ * Every section is read by its own function in this directory, each taking
+ * the whole config and finding its own section in it. This class only says
+ * which sections a policy has, and carries the refusal that names the
+ * Resource whichever section could not be read.
  */
 export class SimCfnCfResponseHeadersPolicyConfig {
   private readonly resource: SimCfnResource;
   private readonly properties: SimCfnTemplateValueRecord;
+
+  /**
+   * Refuse this Resource, saying which part of it could not be read.
+   */
+  private readonly refuse: SimCfnCfRhPolicyFieldRefuse = (detail) => {
+    throw new Error(
+      `Invalid AWS::CloudFront::ResponseHeadersPolicy ${this.resource.logicalId}: ${detail}`,
+    );
+  };
 
   constructor(properties: {
     readonly resource: SimCfnResource;
@@ -42,132 +48,31 @@ export class SimCfnCfResponseHeadersPolicyConfig {
    * Build the simulated policy this Resource describes.
    */
   build(): SimCloudFrontResponseHeadersPolicy {
-    const config = this.policyConfig();
-
-    this.assertModelled(config);
-
-    return new SimCloudFrontResponseHeadersPolicy({
-      name: this.policyName(config),
-      customHeaders: this.customHeaders(config),
-      headersToRemove: this.headersToRemove(config),
-    });
-  }
-
-  private policyConfig(): Record<string, unknown> {
+    const { refuse } = this;
     const config = this.properties["ResponseHeadersPolicyConfig"];
 
     if (!isRecord(config)) {
-      this.refuse(`ResponseHeadersPolicyConfig must be an object`);
+      return refuse(`ResponseHeadersPolicyConfig must be an object`);
     }
 
-    return config;
-  }
-
-  private assertModelled(config: Record<string, unknown>): void {
-    for (const section of unmodelledSections) {
-      // oxlint-disable-next-line security/detect-object-injection
-      if (config[section] !== undefined) {
-        this.refuse(
-          `${section} is not modelled by simulated response headers ` +
-            `policies, so the headers it sets would be missing from the ` +
-            `response`,
-        );
-      }
-    }
-  }
-
-  private policyName(config: Record<string, unknown>): string {
-    const name = config["Name"];
-
-    if (typeof name !== "string") {
-      this.refuse(`ResponseHeadersPolicyConfig Name must be a string`);
-    }
-
-    return name;
-  }
-
-  private customHeaders(
-    config: Record<string, unknown>,
-  ): SimCloudFrontResponseHeader[] {
-    return this.configItems(config, "CustomHeadersConfig").map((item) => {
-      if (!isRecord(item)) {
-        this.refuse(`CustomHeadersConfig items must be objects`);
-      }
-
-      return this.customHeader(item);
+    return new SimCloudFrontResponseHeadersPolicy({
+      name: requiredString(
+        config,
+        "Name",
+        "ResponseHeadersPolicyConfig",
+        refuse,
+      ),
+      customHeaders: simCfnCfResponseHeadersPolicyCustomHeaders(config, refuse),
+      headersToRemove: simCfnCfResponseHeadersPolicyRemoveHeaders(
+        config,
+        refuse,
+      ),
+      securityHeaders: simCfnCfResponseHeadersPolicySecurityHeaders(
+        config,
+        refuse,
+      ),
+      serverTiming: simCfnCfResponseHeadersPolicyServerTiming(config, refuse),
+      cors: simCfnCfResponseHeadersPolicyCors(config, refuse),
     });
-  }
-
-  private customHeader(
-    item: Record<string, unknown>,
-  ): SimCloudFrontResponseHeader {
-    const name = item["Header"];
-    const value = item["Value"];
-
-    if (typeof name !== "string" || typeof value !== "string") {
-      this.refuse(`CustomHeadersConfig items need a string Header and Value`);
-    }
-
-    // Override is required by the CloudFormation schema, so anything else here
-    // is a template that would be refused before it reached a policy at all.
-    const override = item["Override"];
-
-    if (typeof override !== "boolean") {
-      this.refuse(`CustomHeadersConfig item ${name} needs a boolean Override`);
-    }
-
-    return new SimCloudFrontResponseHeader({ name, value, override });
-  }
-
-  private headersToRemove(config: Record<string, unknown>): string[] {
-    return this.configItems(config, "RemoveHeadersConfig").map((item) => {
-      const name = isRecord(item) ? item["Header"] : undefined;
-
-      if (typeof name !== "string") {
-        this.refuse(`RemoveHeadersConfig items need a string Header`);
-      }
-
-      return name;
-    });
-  }
-
-  /**
-   * The `Items` of one `<name>Config` section, or nothing when it is absent.
-   */
-  private configItems(
-    config: Record<string, unknown>,
-    sectionName: string,
-  ): unknown[] {
-    // oxlint-disable-next-line security/detect-object-injection
-    const section = config[sectionName];
-
-    if (section === undefined) {
-      return [];
-    }
-
-    if (!isRecord(section)) {
-      this.refuse(`${sectionName} must be an object`);
-    }
-
-    const items = section["Items"];
-
-    if (items === undefined) {
-      return [];
-    }
-
-    if (!Array.isArray(items)) {
-      this.refuse(`${sectionName} Items must be an array`);
-    }
-
-    return items;
-  }
-
-  /**
-   * Refuse this Resource, saying which part of it could not be read.
-   */
-  private refuse(detail: string): never {
-    throw new Error(
-      `Invalid AWS::CloudFront::ResponseHeadersPolicy ${this.resource.logicalId}: ${detail}`,
-    );
   }
 }

--- a/src/service/cloudfront/cfn/response-headers-policy/sim-cfn-cf-rh-policy-cors-config.iso.test.ts
+++ b/src/service/cloudfront/cfn/response-headers-policy/sim-cfn-cf-rh-policy-cors-config.iso.test.ts
@@ -1,0 +1,174 @@
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsError,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import type { SimCloudFrontResponseHeadersPolicyCors } from "../../response-headers-policy/sim-cf-response-headers-policy-cors.js";
+import { simCfnCfResponseHeadersPolicyCors } from "./sim-cfn-cf-rh-policy-cors-config.js";
+
+describe("simCfnCfResponseHeadersPolicyCors", () => {
+  function refuse(detail: string): never {
+    throw new Error(
+      `Invalid AWS::CloudFront::ResponseHeadersPolicy CacheHeaders: ${detail}`,
+    );
+  }
+
+  function corsFrom(
+    section: Record<string, unknown>,
+  ): SimCloudFrontResponseHeadersPolicyCors {
+    const cors = simCfnCfResponseHeadersPolicyCors(
+      { CorsConfig: section },
+      refuse,
+    );
+
+    assertNonNullable(cors);
+
+    return cors;
+  }
+
+  it("reads no CORS from an absent section", () => {
+    assertUndefined(simCfnCfResponseHeadersPolicyCors({}, refuse));
+  });
+
+  it("reads the config CDK's corsBehavior synthesizes", () => {
+    // Given the config CDK synthesizes for a CORS policy.
+    const cors = corsFrom({
+      AccessControlAllowCredentials: true,
+      AccessControlAllowHeaders: { Items: ["*"] },
+      AccessControlAllowMethods: { Items: ["GET", "POST"] },
+      AccessControlAllowOrigins: { Items: ["https://example.com"] },
+      AccessControlExposeHeaders: { Items: ["X-Custom"] },
+      AccessControlMaxAgeSec: 600,
+      OriginOverride: true,
+    });
+
+    // Then applying it for the allowed Origin sets every header the section
+    // names.
+    const headers = new Headers();
+    cors.apply(headers, "https://example.com");
+
+    assertIdentical(
+      headers.get("access-control-allow-origin"),
+      "https://example.com",
+    );
+    assertIdentical(headers.get("access-control-allow-methods"), "GET,POST");
+    assertIdentical(headers.get("access-control-allow-headers"), "*");
+    assertIdentical(headers.get("access-control-allow-credentials"), "true");
+    assertIdentical(headers.get("access-control-expose-headers"), "X-Custom");
+    assertIdentical(headers.get("access-control-max-age"), "600");
+  });
+
+  it("reads a config naming no AccessControlExposeHeaders or AccessControlMaxAgeSec", () => {
+    // Given the two optional fields left out.
+    const cors = corsFrom({
+      AccessControlAllowCredentials: false,
+      AccessControlAllowHeaders: { Items: [] },
+      AccessControlAllowMethods: { Items: ["GET"] },
+      AccessControlAllowOrigins: { Items: ["*"] },
+      OriginOverride: true,
+    });
+
+    // Then applying it sets neither header.
+    const headers = new Headers();
+    cors.apply(headers, "https://example.com");
+
+    assertIdentical(headers.get("access-control-expose-headers"), null);
+    assertIdentical(headers.get("access-control-max-age"), null);
+  });
+
+  it("refuses a config missing a required boolean field", () => {
+    assertStringIncludes(
+      assertThrowsError(() =>
+        corsFrom({
+          AccessControlAllowHeaders: { Items: [] },
+          AccessControlAllowMethods: { Items: [] },
+          AccessControlAllowOrigins: { Items: [] },
+          OriginOverride: true,
+        }),
+      ).message,
+      "CorsConfig needs a boolean AccessControlAllowCredentials",
+    );
+    assertStringIncludes(
+      assertThrowsError(() =>
+        corsFrom({
+          AccessControlAllowCredentials: true,
+          AccessControlAllowHeaders: { Items: [] },
+          AccessControlAllowMethods: { Items: [] },
+          AccessControlAllowOrigins: { Items: [] },
+        }),
+      ).message,
+      "CorsConfig needs a boolean OriginOverride",
+    );
+  });
+
+  it("names the Resource in the refusal", () => {
+    assertStringIncludes(
+      assertThrowsError(() => corsFrom({})).message,
+      "CacheHeaders",
+    );
+  });
+
+  it("refuses a field of the wrong shape", () => {
+    assertStringIncludes(
+      assertThrowsError(() =>
+        corsFrom({
+          AccessControlAllowCredentials: true,
+          AccessControlAllowHeaders: { Items: [] },
+          AccessControlAllowMethods: { Items: [] },
+          AccessControlAllowOrigins: { Items: [] },
+          AccessControlMaxAgeSec: "not-a-number",
+          OriginOverride: true,
+        }),
+      ).message,
+      "AccessControlMaxAgeSec must be a number",
+    );
+    assertStringIncludes(
+      assertThrowsError(() =>
+        corsFrom({
+          AccessControlAllowCredentials: true,
+          AccessControlAllowHeaders: { Items: [] },
+          AccessControlAllowMethods: { Items: [] },
+          AccessControlAllowOrigins: "nope",
+          OriginOverride: true,
+        }),
+      ).message,
+      "AccessControlAllowOrigins must be an object",
+    );
+    assertStringIncludes(
+      assertThrowsError(() =>
+        corsFrom({
+          AccessControlAllowCredentials: true,
+          AccessControlAllowHeaders: { Items: [] },
+          AccessControlAllowMethods: { Items: [] },
+          AccessControlAllowOrigins: {},
+          OriginOverride: true,
+        }),
+      ).message,
+      "AccessControlAllowOrigins needs an array Items",
+    );
+    assertStringIncludes(
+      assertThrowsError(() =>
+        corsFrom({
+          AccessControlAllowCredentials: true,
+          AccessControlAllowHeaders: { Items: [] },
+          AccessControlAllowMethods: { Items: [] },
+          AccessControlAllowOrigins: { Items: [1] },
+          OriginOverride: true,
+        }),
+      ).message,
+      "AccessControlAllowOrigins Items must be strings",
+    );
+  });
+
+  it("refuses a section that is not an object", () => {
+    assertStringIncludes(
+      assertThrowsError(() =>
+        simCfnCfResponseHeadersPolicyCors({ CorsConfig: "nope" }, refuse),
+      ).message,
+      "CorsConfig must be an object",
+    );
+  });
+});

--- a/src/service/cloudfront/cfn/response-headers-policy/sim-cfn-cf-rh-policy-cors-config.ts
+++ b/src/service/cloudfront/cfn/response-headers-policy/sim-cfn-cf-rh-policy-cors-config.ts
@@ -1,0 +1,87 @@
+import { SimCloudFrontResponseHeadersPolicyCors } from "../../response-headers-policy/sim-cf-response-headers-policy-cors.js";
+import {
+  optionalObject,
+  requiredBoolean,
+  type SimCfnCfRhPolicyFieldRefuse,
+} from "./sim-cfn-cf-rh-policy-field-reader.js";
+
+/**
+ * Reads a ResponseHeadersPolicyConfig's CorsConfig section into the CORS
+ * model that applies it at request time.
+ *
+ * Split from the config reader that calls it for the same reason as
+ * simCfnCfResponseHeadersPolicySecurityHeaders: this project holds every
+ * source file to a line count, and CORS has enough of its own fields to
+ * reach it alongside the rest of the policy.
+ */
+export function simCfnCfResponseHeadersPolicyCors(
+  config: Record<string, unknown>,
+  refuse: SimCfnCfRhPolicyFieldRefuse,
+): SimCloudFrontResponseHeadersPolicyCors | undefined {
+  const section = optionalObject(config, "CorsConfig", "CorsConfig", refuse);
+
+  if (section === undefined) {
+    return undefined;
+  }
+
+  const maxAgeSec = section["AccessControlMaxAgeSec"];
+
+  if (maxAgeSec !== undefined && typeof maxAgeSec !== "number") {
+    refuse(`CorsConfig AccessControlMaxAgeSec must be a number`);
+  }
+
+  return new SimCloudFrontResponseHeadersPolicyCors({
+    allowCredentials: requiredBoolean(
+      section,
+      "AccessControlAllowCredentials",
+      "CorsConfig",
+      refuse,
+    ),
+    allowHeaders: originList(section, "AccessControlAllowHeaders", refuse),
+    allowMethods: originList(section, "AccessControlAllowMethods", refuse),
+    allowOrigins: originList(section, "AccessControlAllowOrigins", refuse),
+    exposeHeaders: originList(section, "AccessControlExposeHeaders", refuse),
+    ...(maxAgeSec !== undefined && { maxAgeSec }),
+    originOverride: requiredBoolean(
+      section,
+      "OriginOverride",
+      "CorsConfig",
+      refuse,
+    ),
+  });
+}
+
+/**
+ * The string `Items` of one `AccessControl*` field, which CloudFront requires
+ * whenever the field itself is present.
+ */
+function originList(
+  section: Record<string, unknown>,
+  fieldName: string,
+  refuse: SimCfnCfRhPolicyFieldRefuse,
+): string[] {
+  const field = optionalObject(
+    section,
+    fieldName,
+    `CorsConfig ${fieldName}`,
+    refuse,
+  );
+
+  if (field === undefined) {
+    return [];
+  }
+
+  const items = field["Items"];
+
+  if (!Array.isArray(items)) {
+    refuse(`CorsConfig ${fieldName} needs an array Items`);
+  }
+
+  return items.map((item) => {
+    if (typeof item !== "string") {
+      refuse(`CorsConfig ${fieldName} Items must be strings`);
+    }
+
+    return item;
+  });
+}

--- a/src/service/cloudfront/cfn/response-headers-policy/sim-cfn-cf-rh-policy-custom-headers.iso.test.ts
+++ b/src/service/cloudfront/cfn/response-headers-policy/sim-cfn-cf-rh-policy-custom-headers.iso.test.ts
@@ -1,0 +1,117 @@
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertStringIncludes,
+  assertThrowsError,
+  assertTrue,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import {
+  simCfnCfResponseHeadersPolicyCustomHeaders,
+  simCfnCfResponseHeadersPolicyRemoveHeaders,
+} from "./sim-cfn-cf-rh-policy-custom-headers.js";
+
+function refuse(detail: string): never {
+  throw new Error(
+    `Invalid AWS::CloudFront::ResponseHeadersPolicy CacheHeaders: ${detail}`,
+  );
+}
+
+describe("simCfnCfResponseHeadersPolicyCustomHeaders", () => {
+  function headersFrom(items: unknown[]) {
+    return simCfnCfResponseHeadersPolicyCustomHeaders(
+      { CustomHeadersConfig: { Items: items } },
+      refuse,
+    );
+  }
+
+  it("reads a custom header's name, value and Override", () => {
+    const headers = headersFrom([
+      { Header: "Cache-Control", Override: true, Value: "public, max-age=0" },
+    ]);
+
+    assertArrayLength(headers, 1);
+    assertIdentical(headers[0].name, "Cache-Control");
+    assertIdentical(headers[0].value, "public, max-age=0");
+    assertTrue(headers[0].override);
+  });
+
+  it("reads a policy with no CustomHeadersConfig as adding nothing", () => {
+    assertArrayLength(
+      simCfnCfResponseHeadersPolicyCustomHeaders({}, refuse),
+      0,
+    );
+  });
+
+  it("reads a section with no Items as adding nothing", () => {
+    assertArrayLength(
+      simCfnCfResponseHeadersPolicyCustomHeaders(
+        { CustomHeadersConfig: {} },
+        refuse,
+      ),
+      0,
+    );
+  });
+
+  it("refuses an item missing its Header, Value or Override", () => {
+    assertStringIncludes(
+      assertThrowsError(() => headersFrom([{ Override: true, Value: "x" }]))
+        .message,
+      "need a string Header and Value",
+    );
+    assertStringIncludes(
+      assertThrowsError(() => headersFrom([{ Header: "Vary", Value: "x" }]))
+        .message,
+      "CustomHeadersConfig item Vary needs a boolean Override",
+    );
+  });
+
+  it("refuses an item that is not an object", () => {
+    assertStringIncludes(
+      assertThrowsError(() => headersFrom(["Vary"])).message,
+      "CustomHeadersConfig items must be objects",
+    );
+  });
+
+  it("refuses Items that are not an array", () => {
+    assertStringIncludes(
+      assertThrowsError(() =>
+        simCfnCfResponseHeadersPolicyCustomHeaders(
+          { CustomHeadersConfig: { Items: "nope" } },
+          refuse,
+        ),
+      ).message,
+      "CustomHeadersConfig Items must be an array",
+    );
+  });
+});
+
+describe("simCfnCfResponseHeadersPolicyRemoveHeaders", () => {
+  function namesFrom(items: unknown[]) {
+    return simCfnCfResponseHeadersPolicyRemoveHeaders(
+      { RemoveHeadersConfig: { Items: items } },
+      refuse,
+    );
+  }
+
+  it("reads the name of a header to remove", () => {
+    const names = namesFrom([{ Header: "Server" }]);
+
+    assertArrayLength(names, 1);
+    assertIdentical(names[0], "Server");
+  });
+
+  it("reads a policy with no RemoveHeadersConfig as removing nothing", () => {
+    assertArrayLength(
+      simCfnCfResponseHeadersPolicyRemoveHeaders({}, refuse),
+      0,
+    );
+  });
+
+  it("refuses an item without a name", () => {
+    assertStringIncludes(
+      assertThrowsError(() => namesFrom([{}])).message,
+      "RemoveHeadersConfig items need a string Header",
+    );
+  });
+});

--- a/src/service/cloudfront/cfn/response-headers-policy/sim-cfn-cf-rh-policy-custom-headers.ts
+++ b/src/service/cloudfront/cfn/response-headers-policy/sim-cfn-cf-rh-policy-custom-headers.ts
@@ -1,0 +1,62 @@
+import { isRecord } from "../../../../util/type-guard/record.js";
+import { SimCloudFrontResponseHeader } from "../../response-headers-policy/sim-cf-response-header.js";
+import {
+  sectionItems,
+  type SimCfnCfRhPolicyFieldRefuse,
+} from "./sim-cfn-cf-rh-policy-field-reader.js";
+
+/**
+ * Reads a ResponseHeadersPolicyConfig's CustomHeadersConfig section into the
+ * headers it adds.
+ *
+ * Split from the config reader that calls it for the same reason as
+ * simCfnCfResponseHeadersPolicySecurityHeaders: this project holds every
+ * source file to a line count.
+ */
+export function simCfnCfResponseHeadersPolicyCustomHeaders(
+  config: Record<string, unknown>,
+  refuse: SimCfnCfRhPolicyFieldRefuse,
+): SimCloudFrontResponseHeader[] {
+  return sectionItems(config, "CustomHeadersConfig", refuse).map((item) => {
+    if (!isRecord(item)) {
+      refuse(`CustomHeadersConfig items must be objects`);
+    }
+
+    const name = item["Header"];
+    const value = item["Value"];
+
+    if (typeof name !== "string" || typeof value !== "string") {
+      refuse(`CustomHeadersConfig items need a string Header and Value`);
+    }
+
+    // Override is required by the CloudFormation schema, so anything else
+    // here is a template that would be refused before it reached a policy at
+    // all.
+    const override = item["Override"];
+
+    if (typeof override !== "boolean") {
+      refuse(`CustomHeadersConfig item ${name} needs a boolean Override`);
+    }
+
+    return new SimCloudFrontResponseHeader({ name, value, override });
+  });
+}
+
+/**
+ * Reads a ResponseHeadersPolicyConfig's RemoveHeadersConfig section into the
+ * header names it removes.
+ */
+export function simCfnCfResponseHeadersPolicyRemoveHeaders(
+  config: Record<string, unknown>,
+  refuse: SimCfnCfRhPolicyFieldRefuse,
+): string[] {
+  return sectionItems(config, "RemoveHeadersConfig", refuse).map((item) => {
+    const name = isRecord(item) ? item["Header"] : undefined;
+
+    if (typeof name !== "string") {
+      refuse(`RemoveHeadersConfig items need a string Header`);
+    }
+
+    return name;
+  });
+}

--- a/src/service/cloudfront/cfn/response-headers-policy/sim-cfn-cf-rh-policy-field-reader.iso.test.ts
+++ b/src/service/cloudfront/cfn/response-headers-policy/sim-cfn-cf-rh-policy-field-reader.iso.test.ts
@@ -1,0 +1,89 @@
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertStringIncludes,
+  assertThrowsError,
+  assertTrue,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import {
+  optionalObject,
+  requiredBoolean,
+  requiredNumber,
+  requiredString,
+  sectionItems,
+} from "./sim-cfn-cf-rh-policy-field-reader.js";
+
+describe("sim-cfn-cf-rh-policy-field-reader", () => {
+  function refuse(detail: string): never {
+    throw new Error(`Invalid: ${detail}`);
+  }
+
+  it("reads a required string", () => {
+    assertIdentical(
+      requiredString({ Name: "foo" }, "Name", "Config", refuse),
+      "foo",
+    );
+    assertStringIncludes(
+      assertThrowsError(() => requiredString({}, "Name", "Config", refuse))
+        .message,
+      "Config needs a string Name",
+    );
+  });
+
+  it("reads a required number", () => {
+    assertIdentical(requiredNumber({ Age: 5 }, "Age", "Config", refuse), 5);
+    assertStringIncludes(
+      assertThrowsError(() => requiredNumber({}, "Age", "Config", refuse))
+        .message,
+      "Config needs a number Age",
+    );
+  });
+
+  it("reads a required boolean", () => {
+    assertTrue(requiredBoolean({ Enabled: true }, "Enabled", "Config", refuse));
+    assertStringIncludes(
+      assertThrowsError(() => requiredBoolean({}, "Enabled", "Config", refuse))
+        .message,
+      "Config needs a boolean Enabled",
+    );
+  });
+
+  it("reads an optional object field", () => {
+    assertIdentical(
+      optionalObject({ Nested: { a: 1 } }, "Nested", "Config", refuse)?.["a"],
+      1,
+    );
+    assertUndefined(optionalObject({}, "Nested", "Config", refuse));
+    assertStringIncludes(
+      assertThrowsError(() =>
+        optionalObject({ Nested: "nope" }, "Nested", "Config", refuse),
+      ).message,
+      "Config must be an object",
+    );
+  });
+
+  it("reads a section's Items", () => {
+    assertIdentical(
+      sectionItems({ Section: { Items: ["a"] } }, "Section", refuse)[0],
+      "a",
+    );
+  });
+
+  it("reads no Items from an absent section, or a section without them", () => {
+    // Given a section that is not there at all, and one present but empty:
+    // CloudFormation allows both, and each means the section adds nothing.
+    assertArrayLength(sectionItems({}, "Section", refuse), 0);
+    assertArrayLength(sectionItems({ Section: {} }, "Section", refuse), 0);
+  });
+
+  it("refuses Items that are not an array", () => {
+    assertStringIncludes(
+      assertThrowsError(() =>
+        sectionItems({ Section: { Items: "nope" } }, "Section", refuse),
+      ).message,
+      "Section Items must be an array",
+    );
+  });
+});

--- a/src/service/cloudfront/cfn/response-headers-policy/sim-cfn-cf-rh-policy-field-reader.ts
+++ b/src/service/cloudfront/cfn/response-headers-policy/sim-cfn-cf-rh-policy-field-reader.ts
@@ -1,0 +1,101 @@
+import { isRecord } from "../../../../util/type-guard/record.js";
+
+export type SimCfnCfRhPolicyFieldRefuse = (detail: string) => never;
+
+/**
+ * Shared field readers for a ResponseHeadersPolicyConfig section, used by
+ * both the SecurityHeadersConfig and CorsConfig readers so the type checks
+ * every field needs are written once rather than once per section.
+ */
+
+/**
+ * A named field that must be a string.
+ */
+export function requiredString(
+  item: Record<string, unknown>,
+  field: string,
+  context: string,
+  refuse: SimCfnCfRhPolicyFieldRefuse,
+): string {
+  // oxlint-disable-next-line security/detect-object-injection
+  const value = item[field];
+
+  return typeof value === "string"
+    ? value
+    : refuse(`${context} needs a string ${field}`);
+}
+
+/**
+ * A named field that must be a number.
+ */
+export function requiredNumber(
+  item: Record<string, unknown>,
+  field: string,
+  context: string,
+  refuse: SimCfnCfRhPolicyFieldRefuse,
+): number {
+  // oxlint-disable-next-line security/detect-object-injection
+  const value = item[field];
+
+  return typeof value === "number"
+    ? value
+    : refuse(`${context} needs a number ${field}`);
+}
+
+/**
+ * A named field that must be a boolean.
+ */
+export function requiredBoolean(
+  item: Record<string, unknown>,
+  field: string,
+  context: string,
+  refuse: SimCfnCfRhPolicyFieldRefuse,
+): boolean {
+  // oxlint-disable-next-line security/detect-object-injection
+  const value = item[field];
+
+  return typeof value === "boolean"
+    ? value
+    : refuse(`${context} needs a boolean ${field}`);
+}
+
+/**
+ * A named field that must be an object, or nothing when the field is absent.
+ */
+export function optionalObject(
+  item: Record<string, unknown>,
+  field: string,
+  context: string,
+  refuse: SimCfnCfRhPolicyFieldRefuse,
+): Record<string, unknown> | undefined {
+  // oxlint-disable-next-line security/detect-object-injection
+  const value = item[field];
+
+  if (value === undefined) {
+    return undefined;
+  }
+
+  return isRecord(value) ? value : refuse(`${context} must be an object`);
+}
+
+/**
+ * The `Items` of one `<name>Config` section, or nothing when the section or
+ * its `Items` is absent.
+ */
+export function sectionItems(
+  config: Record<string, unknown>,
+  sectionName: string,
+  refuse: SimCfnCfRhPolicyFieldRefuse,
+): unknown[] {
+  const items = optionalObject(config, sectionName, sectionName, refuse)?.[
+    "Items"
+  ];
+
+  if (items === undefined) {
+    return [];
+  }
+
+  return Array.isArray(items)
+    ? items
+    : refuse(`${sectionName} Items must be an array`);
+}

--- a/src/service/cloudfront/cfn/response-headers-policy/sim-cfn-cf-rh-policy-security-headers.iso.test.ts
+++ b/src/service/cloudfront/cfn/response-headers-policy/sim-cfn-cf-rh-policy-security-headers.iso.test.ts
@@ -1,0 +1,162 @@
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsError,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import type { SimCloudFrontResponseHeader } from "../../response-headers-policy/sim-cf-response-header.js";
+import { simCfnCfResponseHeadersPolicySecurityHeaders } from "./sim-cfn-cf-rh-policy-security-headers.js";
+
+describe("simCfnCfResponseHeadersPolicySecurityHeaders", () => {
+  function refuse(detail: string): never {
+    throw new Error(
+      `Invalid AWS::CloudFront::ResponseHeadersPolicy CacheHeaders: ${detail}`,
+    );
+  }
+
+  function headersFrom(
+    section: Record<string, unknown>,
+  ): SimCloudFrontResponseHeader[] {
+    return simCfnCfResponseHeadersPolicySecurityHeaders(
+      { SecurityHeadersConfig: section },
+      refuse,
+    );
+  }
+
+  it("reads each section into its header", () => {
+    // Given the config CDK's securityHeadersBehavior synthesizes.
+    const headers = headersFrom({
+      ContentSecurityPolicy: {
+        ContentSecurityPolicy: "default-src 'self'",
+        Override: true,
+      },
+      ContentTypeOptions: { Override: true },
+      FrameOptions: { FrameOption: "DENY", Override: false },
+      ReferrerPolicy: { ReferrerPolicy: "same-origin", Override: true },
+      StrictTransportSecurity: {
+        AccessControlMaxAgeSec: 31_536_000,
+        IncludeSubdomains: true,
+        Preload: true,
+        Override: true,
+      },
+      XSSProtection: { Protection: true, ModeBlock: true, Override: true },
+    });
+
+    // Then each section becomes the header CloudFront documents for it.
+    assertArrayLength(headers, 6);
+
+    function headerValue(name: string): string | undefined {
+      return headers.find((header) => header.name === name)?.value;
+    }
+
+    assertIdentical(
+      headerValue("Content-Security-Policy"),
+      "default-src 'self'",
+    );
+    assertIdentical(headerValue("X-Content-Type-Options"), "nosniff");
+    assertIdentical(headerValue("X-Frame-Options"), "DENY");
+    assertIdentical(headerValue("Referrer-Policy"), "same-origin");
+    assertIdentical(
+      headerValue("Strict-Transport-Security"),
+      "max-age=31536000; includeSubDomains; preload",
+    );
+    assertIdentical(headerValue("X-XSS-Protection"), "1; mode=block");
+  });
+
+  it("reads a minimal StrictTransportSecurity and XSSProtection", () => {
+    // Given the optional directives left out.
+    const headers = headersFrom({
+      StrictTransportSecurity: { AccessControlMaxAgeSec: 600, Override: true },
+      XSSProtection: { Protection: false, Override: true },
+    });
+
+    // Then only the required directive is present, and Protection false gives
+    // the header CloudFront sends to turn XSS auditing off.
+    const strictTransportSecurity = headers.find(
+      (header) => header.name === "Strict-Transport-Security",
+    );
+    const xssProtection = headers.find(
+      (header) => header.name === "X-XSS-Protection",
+    );
+
+    assertNonNullable(strictTransportSecurity);
+    assertNonNullable(xssProtection);
+    assertIdentical(strictTransportSecurity.value, "max-age=600");
+    assertIdentical(xssProtection.value, "0");
+  });
+
+  it("reads an XSSProtection reporting URI", () => {
+    // Given a policy reporting rather than blocking.
+    const headers = headersFrom({
+      XSSProtection: {
+        Protection: true,
+        ReportUri: "https://example.com/report",
+        Override: true,
+      },
+    });
+
+    assertIdentical(headers[0]?.value, "1; report=https://example.com/report");
+  });
+
+  it("reads a section with no sub-sections as setting nothing", () => {
+    assertArrayLength(headersFrom({}), 0);
+  });
+
+  it("sets nothing when the section is absent", () => {
+    assertArrayLength(
+      simCfnCfResponseHeadersPolicySecurityHeaders({}, refuse),
+      0,
+    );
+  });
+
+  it("names the Resource and the field missing from a sub-section", () => {
+    assertStringIncludes(
+      assertThrowsError(() =>
+        headersFrom({ ContentSecurityPolicy: { Override: true } }),
+      ).message,
+      "CacheHeaders",
+    );
+    assertStringIncludes(
+      assertThrowsError(() =>
+        headersFrom({ ContentSecurityPolicy: { Override: true } }),
+      ).message,
+      "needs a string ContentSecurityPolicy",
+    );
+    assertStringIncludes(
+      assertThrowsError(() => headersFrom({ FrameOptions: { Override: true } }))
+        .message,
+      "needs a string FrameOption",
+    );
+    assertStringIncludes(
+      assertThrowsError(() =>
+        headersFrom({ StrictTransportSecurity: { Override: true } }),
+      ).message,
+      "needs a number AccessControlMaxAgeSec",
+    );
+    assertStringIncludes(
+      assertThrowsError(() => headersFrom({ ContentTypeOptions: {} })).message,
+      "needs a boolean Override",
+    );
+  });
+
+  it("refuses a sub-section that is not an object", () => {
+    assertStringIncludes(
+      assertThrowsError(() => headersFrom({ FrameOptions: "nope" })).message,
+      "SecurityHeadersConfig FrameOptions must be an object",
+    );
+  });
+
+  it("refuses a section that is not an object", () => {
+    assertStringIncludes(
+      assertThrowsError(() =>
+        simCfnCfResponseHeadersPolicySecurityHeaders(
+          { SecurityHeadersConfig: "nope" },
+          refuse,
+        ),
+      ).message,
+      "SecurityHeadersConfig must be an object",
+    );
+  });
+});

--- a/src/service/cloudfront/cfn/response-headers-policy/sim-cfn-cf-rh-policy-security-headers.ts
+++ b/src/service/cloudfront/cfn/response-headers-policy/sim-cfn-cf-rh-policy-security-headers.ts
@@ -1,0 +1,114 @@
+import { SimCloudFrontResponseHeader } from "../../response-headers-policy/sim-cf-response-header.js";
+import {
+  optionalObject,
+  requiredBoolean,
+  requiredNumber,
+  requiredString,
+  type SimCfnCfRhPolicyFieldRefuse,
+} from "./sim-cfn-cf-rh-policy-field-reader.js";
+
+/**
+ * Reads a ResponseHeadersPolicyConfig's SecurityHeadersConfig section into
+ * the header CloudFront documents for each of its sub-sections.
+ *
+ * Split from the config reader that calls it so that file stays under the
+ * line count this project holds every source file to, not because the two
+ * are conceptually separate: this is still config reading, just for one
+ * section with six sub-sections of its own.
+ */
+export function simCfnCfResponseHeadersPolicySecurityHeaders(
+  config: Record<string, unknown>,
+  refuse: SimCfnCfRhPolicyFieldRefuse,
+): SimCloudFrontResponseHeader[] {
+  const section = optionalObject(
+    config,
+    "SecurityHeadersConfig",
+    "SecurityHeadersConfig",
+    refuse,
+  );
+
+  if (section === undefined) {
+    return [];
+  }
+
+  const header = (
+    subsectionName: string,
+    headerName: string,
+    value: (item: Record<string, unknown>, context: string) => string,
+  ): SimCloudFrontResponseHeader | undefined => {
+    const context = `SecurityHeadersConfig ${subsectionName}`;
+    const item = optionalObject(section, subsectionName, context, refuse);
+
+    if (item === undefined) {
+      return undefined;
+    }
+
+    return new SimCloudFrontResponseHeader({
+      name: headerName,
+      value: value(item, context),
+      override: requiredBoolean(item, "Override", context, refuse),
+    });
+  };
+
+  return [
+    header(
+      "ContentSecurityPolicy",
+      "Content-Security-Policy",
+      (item, context) =>
+        requiredString(item, "ContentSecurityPolicy", context, refuse),
+    ),
+    header("ContentTypeOptions", "X-Content-Type-Options", () => "nosniff"),
+    header("FrameOptions", "X-Frame-Options", (item, context) =>
+      requiredString(item, "FrameOption", context, refuse),
+    ),
+    header("ReferrerPolicy", "Referrer-Policy", (item, context) =>
+      requiredString(item, "ReferrerPolicy", context, refuse),
+    ),
+    header(
+      "StrictTransportSecurity",
+      "Strict-Transport-Security",
+      (item, context) => strictTransportSecurityValue(item, context, refuse),
+    ),
+    header("XSSProtection", "X-XSS-Protection", (item, context) =>
+      xssProtectionValue(item, context, refuse),
+    ),
+  ].filter((h): h is SimCloudFrontResponseHeader => h !== undefined);
+}
+
+function strictTransportSecurityValue(
+  item: Record<string, unknown>,
+  context: string,
+  refuse: SimCfnCfRhPolicyFieldRefuse,
+): string {
+  const directives = [
+    `max-age=${requiredNumber(item, "AccessControlMaxAgeSec", context, refuse)}`,
+  ];
+
+  if (item["IncludeSubdomains"] === true) {
+    directives.push("includeSubDomains");
+  }
+
+  if (item["Preload"] === true) {
+    directives.push("preload");
+  }
+
+  return directives.join("; ");
+}
+
+function xssProtectionValue(
+  item: Record<string, unknown>,
+  context: string,
+  refuse: SimCfnCfRhPolicyFieldRefuse,
+): string {
+  if (!requiredBoolean(item, "Protection", context, refuse)) {
+    return "0";
+  }
+
+  if (item["ModeBlock"] === true) {
+    return "1; mode=block";
+  }
+
+  const reportUri = item["ReportUri"];
+
+  return typeof reportUri === "string" ? `1; report=${reportUri}` : "1";
+}

--- a/src/service/cloudfront/cfn/response-headers-policy/sim-cfn-cf-rh-policy-server-timing.iso.test.ts
+++ b/src/service/cloudfront/cfn/response-headers-policy/sim-cfn-cf-rh-policy-server-timing.iso.test.ts
@@ -1,0 +1,64 @@
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsError,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { simCfnCfResponseHeadersPolicyServerTiming } from "./sim-cfn-cf-rh-policy-server-timing.js";
+
+describe("simCfnCfResponseHeadersPolicyServerTiming", () => {
+  function refuse(detail: string): never {
+    throw new Error(
+      `Invalid AWS::CloudFront::ResponseHeadersPolicy CacheHeaders: ${detail}`,
+    );
+  }
+
+  it("sets the Server-Timing header once enabled", () => {
+    const header = simCfnCfResponseHeadersPolicyServerTiming(
+      { ServerTimingHeadersConfig: { Enabled: true, SamplingRate: 50 } },
+      refuse,
+    );
+
+    assertNonNullable(header);
+    assertIdentical(header.name, "Server-Timing");
+  });
+
+  it("sets nothing when disabled", () => {
+    assertUndefined(
+      simCfnCfResponseHeadersPolicyServerTiming(
+        { ServerTimingHeadersConfig: { Enabled: false } },
+        refuse,
+      ),
+    );
+  });
+
+  it("sets nothing when the section is absent", () => {
+    assertUndefined(simCfnCfResponseHeadersPolicyServerTiming({}, refuse));
+  });
+
+  it("refuses a section with no boolean Enabled", () => {
+    assertStringIncludes(
+      assertThrowsError(() =>
+        simCfnCfResponseHeadersPolicyServerTiming(
+          { ServerTimingHeadersConfig: {} },
+          refuse,
+        ),
+      ).message,
+      "ServerTimingHeadersConfig needs a boolean Enabled",
+    );
+  });
+
+  it("refuses a section that is not an object", () => {
+    assertStringIncludes(
+      assertThrowsError(() =>
+        simCfnCfResponseHeadersPolicyServerTiming(
+          { ServerTimingHeadersConfig: "nope" },
+          refuse,
+        ),
+      ).message,
+      "ServerTimingHeadersConfig must be an object",
+    );
+  });
+});

--- a/src/service/cloudfront/cfn/response-headers-policy/sim-cfn-cf-rh-policy-server-timing.ts
+++ b/src/service/cloudfront/cfn/response-headers-policy/sim-cfn-cf-rh-policy-server-timing.ts
@@ -1,0 +1,40 @@
+import { SimCloudFrontResponseHeader } from "../../response-headers-policy/sim-cf-response-header.js";
+import {
+  optionalObject,
+  requiredBoolean,
+  type SimCfnCfRhPolicyFieldRefuse,
+} from "./sim-cfn-cf-rh-policy-field-reader.js";
+
+/**
+ * Reads a ResponseHeadersPolicyConfig's ServerTimingHeadersConfig section
+ * into the Server-Timing header it enables, or nothing when it is absent or
+ * disabled.
+ *
+ * `SamplingRate` decides what share of real responses carry the header; this
+ * simulation always adds it once `Enabled` is true rather than sampling, so a
+ * test asserting on it does not depend on chance.
+ */
+export function simCfnCfResponseHeadersPolicyServerTiming(
+  config: Record<string, unknown>,
+  refuse: SimCfnCfRhPolicyFieldRefuse,
+): SimCloudFrontResponseHeader | undefined {
+  const section = optionalObject(
+    config,
+    "ServerTimingHeadersConfig",
+    "ServerTimingHeadersConfig",
+    refuse,
+  );
+
+  if (
+    section === undefined ||
+    !requiredBoolean(section, "Enabled", "ServerTimingHeadersConfig", refuse)
+  ) {
+    return undefined;
+  }
+
+  return new SimCloudFrontResponseHeader({
+    name: "Server-Timing",
+    value: `cdn-upstream-layer;desc="EDGE"`,
+    override: true,
+  });
+}

--- a/src/service/cloudfront/command/create-distribution/create-distribution.handler.ts
+++ b/src/service/cloudfront/command/create-distribution/create-distribution.handler.ts
@@ -13,6 +13,7 @@ import { assertDefined } from "../../../../util/type-guard/defined.js";
 import type { SimCloudFrontS3OriginResolver } from "../../origin/s3/sim-cloudfront-s3-origin.js";
 import type { SimCfCustomOriginDispatcher } from "../../origin/custom/sim-cf-custom-origin-dispatcher.js";
 import type { SimCloudFrontOriginAccessControlRegistry } from "../../origin-access-control/sim-cf-origin-access-control-registry.js";
+import type { SimCloudFrontResponseHeadersPolicyRegistry } from "../../response-headers-policy/sim-cf-response-headers-policy-registry.js";
 import type { BackgroundScheduler } from "../../../../util/background/background.js";
 import { makeSimCloudFrontDistributionConfigurator } from "../../distribution/configurator/sim-cf-distribution-configurator.factory.js";
 import type { SimCloudFrontDistributionConfigurator } from "../../distribution/configurator/sim-cloud-front-distribution-configurator.js";
@@ -37,6 +38,7 @@ interface CreateDistributionCommandHandlerProperties {
   readonly s3OriginResolver: SimCloudFrontS3OriginResolver;
   readonly customOriginDispatcher?: SimCfCustomOriginDispatcher | undefined;
   readonly originAccessControls: SimCloudFrontOriginAccessControlRegistry;
+  readonly responseHeadersPolicies: SimCloudFrontResponseHeadersPolicyRegistry;
   readonly iam?: SimIamInterServiceAuthZ;
   readonly acmRegistry?: SimAcmRegistry | undefined;
   readonly background: BackgroundScheduler;

--- a/src/service/cloudfront/command/update-distribution/update-distribution.handler.ts
+++ b/src/service/cloudfront/command/update-distribution/update-distribution.handler.ts
@@ -22,6 +22,7 @@ import { SimCloudFrontNoSuchDistribution } from "../../error/sim-cloudfront.erro
 import type { SimCfCustomOriginDispatcher } from "../../origin/custom/sim-cf-custom-origin-dispatcher.js";
 import type { SimCloudFrontS3OriginResolver } from "../../origin/s3/sim-cloudfront-s3-origin.js";
 import type { SimCloudFrontOriginAccessControlRegistry } from "../../origin-access-control/sim-cf-origin-access-control-registry.js";
+import type { SimCloudFrontResponseHeadersPolicyRegistry } from "../../response-headers-policy/sim-cf-response-headers-policy-registry.js";
 import type { SimCloudFrontRegistry } from "../../registry/sim-cloud-front-registry.js";
 import { SimCloudFrontDistributionConfigNormalizer } from "../create-distribution/sim-cf-distro-config-normalizer.js";
 import { UpdateDistributionAuthorizer } from "./update-distribution-authorizer.js";
@@ -40,6 +41,7 @@ interface UpdateDistributionCommandHandlerProperties {
   readonly s3OriginResolver: SimCloudFrontS3OriginResolver;
   readonly customOriginDispatcher?: SimCfCustomOriginDispatcher | undefined;
   readonly originAccessControls: SimCloudFrontOriginAccessControlRegistry;
+  readonly responseHeadersPolicies: SimCloudFrontResponseHeadersPolicyRegistry;
   readonly iam?: SimIamInterServiceAuthZ;
   readonly acmRegistry?: SimAcmRegistry | undefined;
   readonly background?: BackgroundScheduler;

--- a/src/service/cloudfront/controller/response-headers/sim-cf-response-headers-applicator.iso.test.ts
+++ b/src/service/cloudfront/controller/response-headers/sim-cf-response-headers-applicator.iso.test.ts
@@ -43,6 +43,7 @@ describe("SimCfResponseHeadersApplicator", () => {
     // When an Origin response passes through it.
     const response = applicator.apply(
       cloudFront,
+      new Request("https://distro123.cloudfront.net/"),
       new Response("body"),
       behaviour,
     );
@@ -61,7 +62,12 @@ describe("SimCfResponseHeadersApplicator", () => {
 
     // When an Origin response passes through it.
     const originResponse = new Response("body");
-    const response = applicator.apply(cloudFront, originResponse, behaviour);
+    const response = applicator.apply(
+      cloudFront,
+      new Request("https://distro123.cloudfront.net/"),
+      originResponse,
+      behaviour,
+    );
 
     // Then nothing is done to it at all.
     assertIdentical(response, originResponse);
@@ -78,7 +84,12 @@ describe("SimCfResponseHeadersApplicator", () => {
     // When an Origin response passes through it, then the gap is reported
     // rather than the response being served without the headers it promised.
     const error = assertThrowsError(() =>
-      applicator.apply(cloudFront, new Response("body"), behaviour),
+      applicator.apply(
+        cloudFront,
+        new Request("https://distro123.cloudfront.net/"),
+        new Response("body"),
+        behaviour,
+      ),
     );
 
     assertInstanceOf(error, SimCloudFrontNoSuchResponseHeadersPolicy);

--- a/src/service/cloudfront/controller/response-headers/sim-cf-response-headers-applicator.ts
+++ b/src/service/cloudfront/controller/response-headers/sim-cf-response-headers-applicator.ts
@@ -18,6 +18,7 @@ export class SimCfResponseHeadersApplicator {
    */
   apply(
     cloudFront: SimCloudFront,
+    request: Request,
     response: Response,
     behaviour: SimCloudFrontBehavior,
   ): Response {
@@ -38,6 +39,6 @@ export class SimCfResponseHeadersApplicator {
       );
     }
 
-    return policy.apply(response);
+    return policy.apply(response, request.headers.get("origin"));
   }
 }

--- a/src/service/cloudfront/controller/sim-cf-controller-response-headers.iso.test.ts
+++ b/src/service/cloudfront/controller/sim-cf-controller-response-headers.iso.test.ts
@@ -1,4 +1,10 @@
-import { assertIdentical, assertNonNullable } from "@kensio/smartass";
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertResponseStatus,
+  assertStringIncludes,
+  describeResponse,
+} from "@kensio/smartass";
 import { CreateFunctionCommand } from "@aws-sdk/client-cloudfront";
 import { describe, it } from "vitest";
 import { SimAws } from "../../aws/sim-aws.js";
@@ -157,5 +163,44 @@ describe("Simulated CloudFront response headers policy in the request pipeline",
     // Then the function's value is what the viewer gets, being the last thing
     // to touch the response.
     assertIdentical(home.headers.get("cache-control"), "no-store");
+  });
+
+  it("answers 404 rather than a mystery 500 when a named policy no longer exists", async () => {
+    // Given a Distribution whose Behavior named a policy that has since been
+    // removed. Creating a Distribution refuses an unknown policy ID, so this
+    // is the one way a request can still find one gone: the policy is removed
+    // after the Distribution was validated against it.
+    const simAws = new SimAws();
+
+    await simCfSiteBucket(simAws, "removed-policy-bucket", {
+      "index.html": "<h1>Home</h1>",
+    });
+
+    const policy = new SimCloudFrontResponseHeadersPolicy({
+      name: "CacheHeaders",
+    });
+
+    simAws.cloudFront().addResponseHeadersPolicy(policy);
+
+    const distributionId = await simCfSiteDistributionId(
+      simAws,
+      simCfSiteDistributionConfig("removed-policy-bucket", {
+        DefaultCacheBehavior: {
+          TargetOriginId: "site-origin",
+          ViewerProtocolPolicy: "allow-all",
+          ResponseHeadersPolicyId: policy.id,
+        },
+      }),
+    );
+
+    simAws.cloudFront().removeResponseHeadersPolicy(policy.id);
+
+    // When the page is requested.
+    const home = await simCfSiteRequest(simAws, distributionId, "/index.html");
+
+    // Then the response reports the gap with the status CloudFront answers
+    // it with, rather than the generic 500 an unrecognised throw becomes.
+    assertResponseStatus(home, 404, await describeResponse(home));
+    assertStringIncludes(await home.text(), policy.id);
   });
 });

--- a/src/service/cloudfront/controller/sim-cloudfront-controller.ts
+++ b/src/service/cloudfront/controller/sim-cloudfront-controller.ts
@@ -2,6 +2,7 @@ import type {
   SimAwsServiceController,
   SimAwsServiceRequest,
 } from "../../../serve/controller/sim-service-controller.js";
+import { SimCloudFrontErrorResponse } from "./sim-cloudfront-error-response.js";
 import { SimCloudFrontRequestPipeline } from "./sim-cloudfront-request-pipeline.js";
 import {
   SimCloudFrontControllerDependenciesFactory,
@@ -18,6 +19,7 @@ import {
  */
 export class SimCloudFrontServiceController implements SimAwsServiceController {
   private readonly pipeline: SimCloudFrontRequestPipeline;
+  private readonly errors = new SimCloudFrontErrorResponse();
 
   constructor(properties: SimCloudFrontServiceControllerProperties = {}) {
     const dependenciesFactory =
@@ -35,6 +37,10 @@ export class SimCloudFrontServiceController implements SimAwsServiceController {
    * own, so only the request itself is needed to find and serve it.
    */
   async handleRequest(serviceRequest: SimAwsServiceRequest): Promise<Response> {
-    return this.pipeline.handle(serviceRequest.request);
+    try {
+      return await this.pipeline.handle(serviceRequest.request);
+    } catch (error) {
+      return this.errors.build(error);
+    }
   }
 }

--- a/src/service/cloudfront/controller/sim-cloudfront-error-response.ts
+++ b/src/service/cloudfront/controller/sim-cloudfront-error-response.ts
@@ -1,0 +1,32 @@
+import { SimCloudFrontError } from "../error/sim-cloudfront.error.js";
+
+/**
+ * Turns a refused CloudFront content-serving request into the response real
+ * CloudFront answers with.
+ *
+ * A viewer request is plain HTTP rather than an SDK call, so there is no
+ * `$metadata` for a client to read the way an SDK caller would. The status
+ * code is the only part of it a viewer can see, and answering the generic 500
+ * every unhandled throw already becomes would turn a refusal CloudFront
+ * itself treats as a 404, such as a Behavior naming a response headers policy
+ * that no longer exists, into a response indistinguishable from a bug here.
+ */
+export class SimCloudFrontErrorResponse {
+  /**
+   * Build the response for an error raised while serving a viewer request.
+   *
+   * Anything the simulator does not recognise is re-raised rather than
+   * flattened into a plausible CloudFront failure, so a bug in the simulation
+   * cannot masquerade as an AWS failure a test then asserts on.
+   */
+  build(error: unknown): Response {
+    if (error instanceof SimCloudFrontError) {
+      return new Response(`${error.message}\n`, {
+        status: error.$metadata.httpStatusCode ?? 500,
+        headers: { "content-type": "text/plain; charset=utf-8" },
+      });
+    }
+
+    throw error;
+  }
+}

--- a/src/service/cloudfront/controller/sim-cloudfront-request-pipeline.ts
+++ b/src/service/cloudfront/controller/sim-cloudfront-request-pipeline.ts
@@ -73,6 +73,7 @@ export class SimCloudFrontRequestPipeline {
     // policy's headers and a viewer-response function sees them.
     const response = this.stages.responseHeadersApplicator.apply(
       cloudFront,
+      requestReference,
       errorResponse,
       behaviour,
     );

--- a/src/service/cloudfront/distribution/configurator/sim-cf-distribution-configurator.factory.ts
+++ b/src/service/cloudfront/distribution/configurator/sim-cf-distribution-configurator.factory.ts
@@ -1,6 +1,7 @@
 import type { SimCfCustomOriginDispatcher } from "../../origin/custom/sim-cf-custom-origin-dispatcher.js";
 import type { SimCloudFrontS3OriginResolver } from "../../origin/s3/sim-cloudfront-s3-origin.js";
 import type { SimCloudFrontOriginAccessControlRegistry } from "../../origin-access-control/sim-cf-origin-access-control-registry.js";
+import type { SimCloudFrontResponseHeadersPolicyRegistry } from "../../response-headers-policy/sim-cf-response-headers-policy-registry.js";
 import { SimCloudFrontBehaviorConfigurator } from "./sim-cloud-front-behavior-configurator.js";
 import { SimCloudFrontDistributionConfigurator } from "./sim-cloud-front-distribution-configurator.js";
 import { SimCloudFrontOriginConfigurator } from "./sim-cloud-front-origin-configurator.js";
@@ -9,6 +10,7 @@ interface SimCloudFrontConfiguratorOrigins {
   readonly s3OriginResolver: SimCloudFrontS3OriginResolver;
   readonly customOriginDispatcher?: SimCfCustomOriginDispatcher | undefined;
   readonly originAccessControls: SimCloudFrontOriginAccessControlRegistry;
+  readonly responseHeadersPolicies: SimCloudFrontResponseHeadersPolicyRegistry;
 }
 
 /**
@@ -26,6 +28,6 @@ export function makeSimCloudFrontDistributionConfigurator(
       origins.originAccessControls,
       origins.customOriginDispatcher,
     ),
-    new SimCloudFrontBehaviorConfigurator(),
+    new SimCloudFrontBehaviorConfigurator(origins.responseHeadersPolicies),
   );
 }

--- a/src/service/cloudfront/distribution/configurator/sim-cloud-front-behavior-configurator.ts
+++ b/src/service/cloudfront/distribution/configurator/sim-cloud-front-behavior-configurator.ts
@@ -6,12 +6,25 @@ import type {
 import type { SimCloudFrontBehavior } from "../../behaviour/sim-cloud-front-behavior.js";
 import { assertDefined } from "../../../../util/type-guard/defined.js";
 import type { SimCloudFrontDistribution } from "../sim-cloudfront-distribution.js";
+import type { SimCloudFrontResponseHeadersPolicyRegistry } from "../../response-headers-policy/sim-cf-response-headers-policy-registry.js";
+import { SimCloudFrontInvalidResponseHeadersPolicyId } from "../../error/sim-cloudfront.error.js";
 import { configureCffAssociations } from "./sim-cff-associations-configure.js";
 
 /**
  * Applies Cache Behavior configuration to a sim CloudFront Distribution.
+ *
+ * A Behavior naming a response headers policy this simulation does not hold
+ * is refused here, when the Distribution is created or updated, because
+ * that is when real CloudFront checks it too. Waiting until a request needs
+ * the policy would deploy successfully and only fail later, at the first
+ * request that reaches the Behavior, for a mistyped or AWS-managed policy ID
+ * that was always going to be wrong.
  */
 export class SimCloudFrontBehaviorConfigurator {
+  constructor(
+    private readonly responseHeadersPolicies: SimCloudFrontResponseHeadersPolicyRegistry,
+  ) {}
+
   /**
    * Configure the default Cache Behavior on a Distribution.
    */
@@ -20,7 +33,7 @@ export class SimCloudFrontBehaviorConfigurator {
     cacheBehavior: SimCloudFrontDefaultCacheBehaviorConfig | undefined,
   ): void {
     assertDefined(cacheBehavior, "CloudFront DefaultCacheBehavior");
-    distribution.addBehavior(buildBaseBehaviorProperties(cacheBehavior));
+    distribution.addBehavior(this.buildBaseBehaviorProperties(cacheBehavior));
   }
 
   /**
@@ -36,40 +49,53 @@ export class SimCloudFrontBehaviorConfigurator {
     );
     distribution.addBehavior({
       pathPattern: cacheBehavior.PathPattern,
-      ...buildBaseBehaviorProperties(cacheBehavior),
+      ...this.buildBaseBehaviorProperties(cacheBehavior),
     });
   }
-}
 
-/**
- * Build the shared Behavior properties common to both default and named Cache
- * Behaviors. Callers add their own fields (e.g. pathPattern) on top.
- */
-function buildBaseBehaviorProperties(
-  cacheBehavior:
-    | SimCloudFrontDefaultCacheBehaviorConfig
-    | SimCloudFrontCacheBehaviorConfig,
-): SimCloudFrontBehavior {
-  assertDefined(
-    cacheBehavior.TargetOriginId,
-    "CloudFront CacheBehavior TargetOriginId",
-  );
+  /**
+   * Build the shared Behavior properties common to both default and named
+   * Cache Behaviors. Callers add their own fields (e.g. pathPattern) on top.
+   */
+  private buildBaseBehaviorProperties(
+    cacheBehavior:
+      | SimCloudFrontDefaultCacheBehaviorConfig
+      | SimCloudFrontCacheBehaviorConfig,
+  ): SimCloudFrontBehavior {
+    const { TargetOriginId, ResponseHeadersPolicyId } = cacheBehavior;
 
-  return {
-    targetOriginName: cacheBehavior.TargetOriginId,
-    allowedMethods: methodsSet(cacheBehavior.AllowedMethods, ["GET", "HEAD"]),
-    cachedMethods: methodsSet(cacheBehavior.AllowedMethods?.CachedMethods, [
-      "GET",
-      "HEAD",
-    ]),
-    ...(cacheBehavior.ViewerProtocolPolicy !== undefined && {
-      viewerProtocolPolicy: cacheBehavior.ViewerProtocolPolicy,
-    }),
-    ...(cacheBehavior.ResponseHeadersPolicyId !== undefined && {
-      responseHeadersPolicyId: cacheBehavior.ResponseHeadersPolicyId,
-    }),
-    functionAssociations: configureCffAssociations(cacheBehavior),
-  };
+    assertDefined(TargetOriginId, "CloudFront CacheBehavior TargetOriginId");
+
+    if (
+      ResponseHeadersPolicyId !== undefined &&
+      this.responseHeadersPolicies.byId(ResponseHeadersPolicyId) === undefined
+    ) {
+      throw new SimCloudFrontInvalidResponseHeadersPolicyId(
+        `Sim CloudFront Behavior for Origin ${TargetOriginId} names response ` +
+          `headers policy ${ResponseHeadersPolicyId}, which does not exist. ` +
+          `Only a policy an AWS::CloudFront::ResponseHeadersPolicy Resource ` +
+          `created in this simulation can be named, so a managed policy ID, ` +
+          `which names a policy AWS owns rather than one a template creates, ` +
+          `will not be found.`,
+      );
+    }
+
+    return {
+      targetOriginName: TargetOriginId,
+      allowedMethods: methodsSet(cacheBehavior.AllowedMethods, ["GET", "HEAD"]),
+      cachedMethods: methodsSet(cacheBehavior.AllowedMethods?.CachedMethods, [
+        "GET",
+        "HEAD",
+      ]),
+      ...(cacheBehavior.ViewerProtocolPolicy !== undefined && {
+        viewerProtocolPolicy: cacheBehavior.ViewerProtocolPolicy,
+      }),
+      ...(ResponseHeadersPolicyId !== undefined && {
+        responseHeadersPolicyId: ResponseHeadersPolicyId,
+      }),
+      functionAssociations: configureCffAssociations(cacheBehavior),
+    };
+  }
 }
 
 /**

--- a/src/service/cloudfront/distribution/sim-cf-distribution-reconfigurer.ts
+++ b/src/service/cloudfront/distribution/sim-cf-distribution-reconfigurer.ts
@@ -2,6 +2,7 @@ import type { SimCloudFrontDistributionConfig } from "../command/create-distribu
 import type { SimCfCustomOriginDispatcher } from "../origin/custom/sim-cf-custom-origin-dispatcher.js";
 import type { SimCloudFrontS3OriginResolver } from "../origin/s3/sim-cloudfront-s3-origin.js";
 import type { SimCloudFrontOriginAccessControlRegistry } from "../origin-access-control/sim-cf-origin-access-control-registry.js";
+import type { SimCloudFrontResponseHeadersPolicyRegistry } from "../response-headers-policy/sim-cf-response-headers-policy-registry.js";
 import type { SimCloudFrontRegistry } from "../registry/sim-cloud-front-registry.js";
 import { makeSimCloudFrontDistributionConfigurator } from "./configurator/sim-cf-distribution-configurator.factory.js";
 import type { SimCloudFrontDistributionConfigurator } from "./configurator/sim-cloud-front-distribution-configurator.js";
@@ -12,6 +13,7 @@ interface SimCloudFrontDistributionReconfigurerProperties {
   readonly s3OriginResolver: SimCloudFrontS3OriginResolver;
   readonly customOriginDispatcher?: SimCfCustomOriginDispatcher | undefined;
   readonly originAccessControls: SimCloudFrontOriginAccessControlRegistry;
+  readonly responseHeadersPolicies: SimCloudFrontResponseHeadersPolicyRegistry;
 }
 
 /**

--- a/src/service/cloudfront/error/sim-cloudfront.error.ts
+++ b/src/service/cloudfront/error/sim-cloudfront.error.ts
@@ -119,6 +119,21 @@ export class SimCloudFrontNoSuchResponseHeadersPolicy extends SimCloudFrontError
 }
 
 /**
+ * Simulated CloudFront InvalidResponseHeadersPolicyId error.
+ *
+ * What CloudFront answers when a Behavior's `ResponseHeadersPolicyId` names no
+ * response headers policy the account holds, at Distribution create or update
+ * time rather than when a request first needs the policy.
+ */
+export class SimCloudFrontInvalidResponseHeadersPolicyId extends SimCloudFrontError {
+  public override readonly name = "InvalidResponseHeadersPolicyId";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
  * Simulated CloudFront ResponseHeadersPolicyAlreadyExists error.
  *
  * CloudFront requires a response headers policy name to be unique within an

--- a/src/service/cloudfront/response-headers-policy/sim-cf-response-headers-policy-cors.iso.test.ts
+++ b/src/service/cloudfront/response-headers-policy/sim-cf-response-headers-policy-cors.iso.test.ts
@@ -1,0 +1,141 @@
+import { assertIdentical } from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimCloudFrontResponseHeadersPolicyCors } from "./sim-cf-response-headers-policy-cors.js";
+
+describe("SimCloudFrontResponseHeadersPolicyCors", () => {
+  function cors(
+    properties: Partial<{
+      allowCredentials: boolean;
+      allowHeaders: readonly string[];
+      allowMethods: readonly string[];
+      allowOrigins: readonly string[];
+      exposeHeaders: readonly string[];
+      maxAgeSec: number;
+      originOverride: boolean;
+    }> = {},
+  ): SimCloudFrontResponseHeadersPolicyCors {
+    return new SimCloudFrontResponseHeadersPolicyCors({
+      allowCredentials: false,
+      allowHeaders: [],
+      allowMethods: ["GET"],
+      allowOrigins: ["https://example.com"],
+      originOverride: true,
+      ...properties,
+    });
+  }
+
+  it("reflects an Origin the allow list names", () => {
+    // Given a policy allowing one Origin.
+    const headers = new Headers();
+
+    // When a request names it.
+    cors().apply(headers, "https://example.com");
+
+    // Then it is reflected back, with Vary telling a cache the response
+    // depends on it.
+    assertIdentical(
+      headers.get("access-control-allow-origin"),
+      "https://example.com",
+    );
+    assertIdentical(headers.get("vary"), "Origin");
+  });
+
+  it("sends a literal wildcard for an allow list of *", () => {
+    // Given a policy allowing every Origin.
+    const headers = new Headers();
+
+    // When any Origin, or none, requests it.
+    cors({ allowOrigins: ["*"] }).apply(headers, "https://anything.example");
+
+    // Then the header is the wildcard itself, and there is nothing to vary
+    // the cache on since every Origin gets the same response.
+    assertIdentical(headers.get("access-control-allow-origin"), "*");
+    assertIdentical(headers.get("vary"), null);
+  });
+
+  it("adds none of its headers for an Origin the allow list does not name", () => {
+    // Given a policy allowing one Origin.
+    const headers = new Headers();
+
+    // When a different Origin requests it.
+    cors().apply(headers, "https://evil.example");
+
+    // Then nothing is added, as CloudFront sends none rather than a
+    // mismatched one.
+    assertIdentical(headers.get("access-control-allow-origin"), null);
+    assertIdentical(headers.get("access-control-allow-methods"), null);
+  });
+
+  it("adds none of its headers for a request naming no Origin", () => {
+    // Given a policy allowing one Origin.
+    const headers = new Headers();
+
+    // When a request carries no Origin header at all.
+    cors().apply(headers, null);
+
+    // Then nothing is added.
+    assertIdentical(headers.get("access-control-allow-origin"), null);
+  });
+
+  it("expands ALL to CloudFront's full method list", () => {
+    // Given a policy allowing every method.
+    const headers = new Headers();
+
+    cors({ allowMethods: ["ALL"] }).apply(headers, "https://example.com");
+
+    // Then the header names every method CloudFront documents for ALL.
+    assertIdentical(
+      headers.get("access-control-allow-methods"),
+      "GET,DELETE,HEAD,OPTIONS,PATCH,POST,PUT",
+    );
+  });
+
+  it("omits Access-Control-Allow-Credentials when credentials are not allowed", () => {
+    // Given a policy that does not allow credentials.
+    const headers = new Headers();
+
+    cors({ allowCredentials: false }).apply(headers, "https://example.com");
+
+    // Then the header is left off entirely, since fetch treats it the same
+    // as a header naming "false" would be, and CloudFront sends neither.
+    assertIdentical(headers.get("access-control-allow-credentials"), null);
+  });
+
+  it("sends Access-Control-Allow-Credentials true when credentials are allowed", () => {
+    const headers = new Headers();
+
+    cors({ allowCredentials: true }).apply(headers, "https://example.com");
+
+    assertIdentical(headers.get("access-control-allow-credentials"), "true");
+  });
+
+  it("omits Access-Control-Expose-Headers and -Max-Age when unset", () => {
+    // Given a policy naming neither.
+    const headers = new Headers();
+
+    cors().apply(headers, "https://example.com");
+
+    // Then neither header is added.
+    assertIdentical(headers.get("access-control-expose-headers"), null);
+    assertIdentical(headers.get("access-control-max-age"), null);
+  });
+
+  it("keeps an Origin header it does not override", () => {
+    // Given a policy without OriginOverride, and a response that already
+    // carries the header CloudFront would otherwise set.
+    const headers = new Headers({
+      "Access-Control-Allow-Methods": "GET,POST,PUT",
+    });
+
+    cors({ originOverride: false, allowMethods: ["GET"] }).apply(
+      headers,
+      "https://example.com",
+    );
+
+    // Then the Origin's value stands.
+    assertIdentical(
+      headers.get("access-control-allow-methods"),
+      "GET,POST,PUT",
+    );
+  });
+});

--- a/src/service/cloudfront/response-headers-policy/sim-cf-response-headers-policy-cors.ts
+++ b/src/service/cloudfront/response-headers-policy/sim-cf-response-headers-policy-cors.ts
@@ -1,0 +1,127 @@
+const allAccessControlMethods = [
+  "GET",
+  "DELETE",
+  "HEAD",
+  "OPTIONS",
+  "PATCH",
+  "POST",
+  "PUT",
+] as const;
+
+interface SimCloudFrontResponseHeadersPolicyCorsProperties {
+  readonly allowCredentials: boolean;
+  readonly allowHeaders: readonly string[];
+  readonly allowMethods: readonly string[];
+  readonly allowOrigins: readonly string[];
+  readonly exposeHeaders?: readonly string[];
+  readonly maxAgeSec?: number;
+  readonly originOverride: boolean;
+}
+
+/**
+ * The CORS section of a response headers policy.
+ *
+ * CloudFront reflects the viewer request's `Origin` header against the
+ * configured allow list rather than sending the list itself, so the headers
+ * this adds depend on the request they answer: a request naming an Origin
+ * the list does not allow gets none of them, the same as CloudFront sending
+ * none rather than a mismatched one.
+ *
+ * https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/understanding-response-headers-policies.html#understanding-response-headers-policies-cors
+ */
+export class SimCloudFrontResponseHeadersPolicyCors {
+  private readonly allowCredentials: boolean;
+  private readonly allowHeaders: readonly string[];
+  private readonly allowMethods: readonly string[];
+  private readonly allowOrigins: readonly string[];
+  private readonly exposeHeaders: readonly string[];
+  private readonly maxAgeSec: number | undefined;
+  private readonly originOverride: boolean;
+
+  constructor(properties: SimCloudFrontResponseHeadersPolicyCorsProperties) {
+    this.allowCredentials = properties.allowCredentials;
+    this.allowHeaders = properties.allowHeaders;
+    this.allowMethods = properties.allowMethods;
+    this.allowOrigins = properties.allowOrigins;
+    this.exposeHeaders = properties.exposeHeaders ?? [];
+    this.maxAgeSec = properties.maxAgeSec;
+    this.originOverride = properties.originOverride;
+  }
+
+  /**
+   * Set this policy's CORS headers on a response, for the `Origin` header a
+   * viewer request carried.
+   */
+  apply(headers: Headers, requestOrigin: string | null): void {
+    const allowOrigin = this.resolveAllowOrigin(requestOrigin);
+
+    if (allowOrigin === undefined) {
+      return;
+    }
+
+    this.set(headers, "Access-Control-Allow-Origin", allowOrigin);
+
+    // CloudFront varies the cache on Origin whenever the header it sent back
+    // was chosen for this request rather than good for every request, so a
+    // cached response for one Origin is never served to a different one.
+    if (allowOrigin !== "*") {
+      headers.append("Vary", "Origin");
+    }
+
+    this.set(
+      headers,
+      "Access-Control-Allow-Methods",
+      this.resolvedAllowMethods().join(","),
+    );
+    this.set(
+      headers,
+      "Access-Control-Allow-Headers",
+      this.allowHeaders.join(","),
+    );
+
+    // A false Access-Control-Allow-Credentials is not a header value the
+    // fetch spec recognises, so CloudFront leaves it off rather than sending
+    // a value meaning the same as absence.
+    if (this.allowCredentials) {
+      this.set(headers, "Access-Control-Allow-Credentials", "true");
+    }
+
+    if (this.exposeHeaders.length > 0) {
+      this.set(
+        headers,
+        "Access-Control-Expose-Headers",
+        this.exposeHeaders.join(","),
+      );
+    }
+
+    if (this.maxAgeSec !== undefined) {
+      this.set(headers, "Access-Control-Max-Age", String(this.maxAgeSec));
+    }
+  }
+
+  private resolveAllowOrigin(requestOrigin: string | null): string | undefined {
+    if (this.allowOrigins.includes("*")) {
+      return "*";
+    }
+
+    if (requestOrigin !== null && this.allowOrigins.includes(requestOrigin)) {
+      return requestOrigin;
+    }
+
+    return undefined;
+  }
+
+  private resolvedAllowMethods(): readonly string[] {
+    return this.allowMethods.includes("ALL")
+      ? allAccessControlMethods
+      : this.allowMethods;
+  }
+
+  private set(headers: Headers, name: string, value: string): void {
+    if (!this.originOverride && headers.has(name)) {
+      return;
+    }
+
+    headers.set(name, value);
+  }
+}

--- a/src/service/cloudfront/response-headers-policy/sim-cf-response-headers-policy.iso.test.ts
+++ b/src/service/cloudfront/response-headers-policy/sim-cf-response-headers-policy.iso.test.ts
@@ -2,12 +2,16 @@ import { assertIdentical, assertTrue, assertUuidV4 } from "@kensio/smartass";
 import { describe, it } from "vitest";
 import { SimCloudFrontResponseHeader } from "./sim-cf-response-header.js";
 import { SimCloudFrontResponseHeadersPolicy } from "./sim-cf-response-headers-policy.js";
+import { SimCloudFrontResponseHeadersPolicyCors } from "./sim-cf-response-headers-policy-cors.js";
 
 describe("SimCloudFrontResponseHeadersPolicy", () => {
   function policy(
     properties: Partial<{
       customHeaders: SimCloudFrontResponseHeader[];
       headersToRemove: string[];
+      securityHeaders: SimCloudFrontResponseHeader[];
+      serverTiming: SimCloudFrontResponseHeader;
+      cors: SimCloudFrontResponseHeadersPolicyCors;
     }> = {},
   ): SimCloudFrontResponseHeadersPolicy {
     return new SimCloudFrontResponseHeadersPolicy({
@@ -96,6 +100,50 @@ describe("SimCloudFrontResponseHeadersPolicy", () => {
     assertIdentical(applied.status, 404);
     assertIdentical(applied.statusText, "Not Found");
     assertIdentical(await applied.text(), "not found");
+  });
+
+  it("adds its security headers and Server-Timing header to a response", () => {
+    // Given a policy setting a security header and Server-Timing.
+    const applied = policy({
+      securityHeaders: [
+        new SimCloudFrontResponseHeader({
+          name: "X-Frame-Options",
+          value: "DENY",
+          override: true,
+        }),
+      ],
+      serverTiming: new SimCloudFrontResponseHeader({
+        name: "Server-Timing",
+        value: `cdn-upstream-layer;desc="EDGE"`,
+        override: true,
+      }),
+    }).apply(new Response("body"));
+
+    // Then both are on the response, alongside whatever else the policy sets.
+    assertIdentical(applied.headers.get("x-frame-options"), "DENY");
+    assertIdentical(
+      applied.headers.get("server-timing"),
+      `cdn-upstream-layer;desc="EDGE"`,
+    );
+  });
+
+  it("applies its CORS headers for the Origin the viewer request carried", () => {
+    // Given a policy with a CORS section allowing one Origin.
+    const applied = policy({
+      cors: new SimCloudFrontResponseHeadersPolicyCors({
+        allowCredentials: false,
+        allowHeaders: [],
+        allowMethods: ["GET"],
+        allowOrigins: ["https://example.com"],
+        originOverride: true,
+      }),
+    }).apply(new Response("body"), "https://example.com");
+
+    // Then the CORS headers are on the response.
+    assertIdentical(
+      applied.headers.get("access-control-allow-origin"),
+      "https://example.com",
+    );
   });
 
   it("passes a response through when it sets and removes nothing", () => {

--- a/src/service/cloudfront/response-headers-policy/sim-cf-response-headers-policy.ts
+++ b/src/service/cloudfront/response-headers-policy/sim-cf-response-headers-policy.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 
 import type { Brand } from "../../../util/brand.type.js";
 import type { SimCloudFrontResponseHeader } from "./sim-cf-response-header.js";
+import type { SimCloudFrontResponseHeadersPolicyCors } from "./sim-cf-response-headers-policy-cors.js";
 
 export type SimCloudFrontResponseHeadersPolicyId = Brand<
   string,
@@ -13,6 +14,9 @@ interface SimCloudFrontResponseHeadersPolicyProperties {
   readonly name: string;
   readonly customHeaders?: readonly SimCloudFrontResponseHeader[];
   readonly headersToRemove?: readonly string[];
+  readonly securityHeaders?: readonly SimCloudFrontResponseHeader[];
+  readonly serverTiming?: SimCloudFrontResponseHeader | undefined;
+  readonly cors?: SimCloudFrontResponseHeadersPolicyCors | undefined;
 }
 
 /**
@@ -29,6 +33,9 @@ export class SimCloudFrontResponseHeadersPolicy {
   public readonly name: string;
   public readonly customHeaders: readonly SimCloudFrontResponseHeader[];
   public readonly headersToRemove: readonly string[];
+  public readonly securityHeaders: readonly SimCloudFrontResponseHeader[];
+  public readonly serverTiming: SimCloudFrontResponseHeader | undefined;
+  public readonly cors: SimCloudFrontResponseHeadersPolicyCors | undefined;
 
   constructor(properties: SimCloudFrontResponseHeadersPolicyProperties) {
     this.id =
@@ -36,15 +43,19 @@ export class SimCloudFrontResponseHeadersPolicy {
     this.name = properties.name;
     this.customHeaders = properties.customHeaders ?? [];
     this.headersToRemove = properties.headersToRemove ?? [];
+    this.securityHeaders = properties.securityHeaders ?? [];
+    this.serverTiming = properties.serverTiming;
+    this.cors = properties.cors;
   }
 
   /**
-   * Return the response this policy makes of one the Origin gave back.
+   * Return the response this policy makes of one the Origin gave back, for
+   * the `Origin` header the viewer request carried.
    *
    * The body is passed straight through. Only the headers change, so a response
    * whose body has already been read stays readable.
    */
-  apply(response: Response): Response {
+  apply(response: Response, requestOrigin: string | null = null): Response {
     const headers = new Headers(response.headers);
 
     for (const headerName of this.headersToRemove) {
@@ -54,6 +65,13 @@ export class SimCloudFrontResponseHeadersPolicy {
     for (const customHeader of this.customHeaders) {
       customHeader.applyTo(headers);
     }
+
+    for (const securityHeader of this.securityHeaders) {
+      securityHeader.applyTo(headers);
+    }
+
+    this.serverTiming?.applyTo(headers);
+    this.cors?.apply(headers, requestOrigin);
 
     return new Response(response.body, {
       status: response.status,

--- a/src/service/cloudfront/sim-cloudfront-commands.ts
+++ b/src/service/cloudfront/sim-cloudfront-commands.ts
@@ -53,6 +53,7 @@ import {
   type SimCloudFrontS3OriginResolver,
 } from "./origin/s3/sim-cloudfront-s3-origin.js";
 import type { SimCloudFrontOriginAccessControlRegistry } from "./origin-access-control/sim-cf-origin-access-control-registry.js";
+import type { SimCloudFrontResponseHeadersPolicyRegistry } from "./response-headers-policy/sim-cf-response-headers-policy-registry.js";
 import { SimCloudFrontRegistry } from "./registry/sim-cloud-front-registry.js";
 
 /**
@@ -73,6 +74,7 @@ interface SimCloudFrontCommandsProperties extends SimCloudFrontProperties {
   readonly distributions: SimCloudFrontDistributionMap;
   readonly cloudFrontFunctions: SimCloudFrontFunctionMap;
   readonly originAccessControls: SimCloudFrontOriginAccessControlRegistry;
+  readonly responseHeadersPolicies: SimCloudFrontResponseHeadersPolicyRegistry;
 }
 
 /**
@@ -125,6 +127,7 @@ export class SimCloudFrontCommands {
     | undefined;
   private readonly acmRegistry: SimAcmRegistry | undefined;
   private readonly originAccessControls: SimCloudFrontOriginAccessControlRegistry;
+  private readonly responseHeadersPolicies: SimCloudFrontResponseHeadersPolicyRegistry;
 
   constructor(properties: SimCloudFrontCommandsProperties) {
     const {
@@ -156,6 +159,7 @@ export class SimCloudFrontCommands {
     this.customOriginDispatcher = customOriginDispatcher;
     this.acmRegistry = acmRegistry;
     this.originAccessControls = properties.originAccessControls;
+    this.responseHeadersPolicies = properties.responseHeadersPolicies;
   }
 
   /**
@@ -242,12 +246,14 @@ export class SimCloudFrontCommands {
     readonly customOriginDispatcher: SimCfCustomOriginDispatcher | undefined;
     readonly acmRegistry: SimAcmRegistry | undefined;
     readonly originAccessControls: SimCloudFrontOriginAccessControlRegistry;
+    readonly responseHeadersPolicies: SimCloudFrontResponseHeadersPolicyRegistry;
   } {
     return {
       s3OriginResolver: this.s3OriginResolver,
       customOriginDispatcher: this.customOriginDispatcher,
       acmRegistry: this.acmRegistry,
       originAccessControls: this.originAccessControls,
+      responseHeadersPolicies: this.responseHeadersPolicies,
     };
   }
 }

--- a/src/service/cloudfront/sim-cloudfront.ts
+++ b/src/service/cloudfront/sim-cloudfront.ts
@@ -88,6 +88,7 @@ export class SimCloudFront {
       distributions: this.distributions,
       cloudFrontFunctions: this.cloudFrontFunctions,
       originAccessControls: this.originAccessControls,
+      responseHeadersPolicies: this.responseHeadersPolicies,
     });
   }
 


### PR DESCRIPTION
A response headers policy now models its `CorsConfig`, `SecurityHeadersConfig` and `ServerTimingHeadersConfig` sections rather than failing the stack by naming them, so the `securityHeadersBehavior` and `corsBehavior` a CDK `ResponseHeadersPolicy` synthesizes can be exercised locally. CORS reflects the viewer request's `Origin` against the allow list as CloudFront does, so applying a policy now takes the request as well as the response. A Behavior naming a response headers policy the simulation does not hold is refused when the Distribution is created or updated, as real CloudFront refuses it, rather than deploying and then failing the first request that reaches the Behavior; and a simulated CloudFront error that does reach a viewer is answered with the status its metadata names instead of a bare 500.

## What prompted it

A user reported that a policy naming any of the three sections failed the stack, so they left the policy off entirely and could not exercise security headers locally at all. They also reported that a managed policy ID surfaced as a mystery 500 at request time rather than a deploy error. Both were accurate, and both were documented limitations rather than accidents — this closes them.

## Sections

- `SecurityHeadersConfig`: `ContentSecurityPolicy`, `ContentTypeOptions`, `FrameOptions`, `ReferrerPolicy`, `StrictTransportSecurity` and `XSSProtection` each become the header CloudFront documents for it, honouring the sub-section's own `Override`.
- `CorsConfig`: reflects an allowed `Origin` and varies on it, expands `ALL` to CloudFront's method list, and leaves `Access-Control-Allow-Credentials` off when false, since a header naming `false` means the same as its absence to a browser. An `Origin` the list does not allow gets none of the headers, as CloudFront sends none rather than a mismatched one.
- `ServerTimingHeadersConfig`: adds `Server-Timing` once `Enabled`.

## Notes for review

- **`SamplingRate` is not honoured.** The header is always added once enabled rather than sampled, so a test asserting on it does not depend on chance, and its value is a fixed placeholder rather than real Origin timing. Documented under Limitations.
- **`InvalidResponseHeadersPolicyId` is a new error class**, 400, matching the `InvalidOriginAccessControl` precedent for a deploy-time cross-resource refusal. The request-time `NoSuchResponseHeadersPolicy` stays as defence in depth, reachable when a policy is removed after the Distribution was validated against it.
- **The error-to-status mapping is CloudFront's own**, added at its controller boundary the way `SimS3RestErrorResponse` already does it for S3, rather than widening the generic catch in `sim-aws-http.ts`. Lambda and API Gateway deliberately flatten everything to 500, so that generic branch was left alone.
- **Two message changes**: a policy missing its `Name` now says `ResponseHeadersPolicyConfig needs a string Name`, sharing wording with the other field readers.
- **The CFN reader was split** across one function per section, each finding its own section in the config, with shared field readers behind them. That was needed to keep every file under the FTA threshold — the first attempt left a dispatcher of thin wrapper methods that scored *worse* than the file it replaced, because FTA scores token density rather than length. `fta.json` needs no exclusions.

`pnpm run check` passes: FTA clean with no exclusions, 5914 tests, coverage 99.88%.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for CloudFront security headers, Server-Timing, and CORS response header configurations.
  * CORS behavior now supports origin reflection, wildcard origins, method expansion, credentials, exposed headers, and header overrides.
  * Referenced response headers policies are validated during distribution creation and updates.
* **Bug Fixes**
  * CloudFront errors now return structured HTTP error responses instead of uncaught failures.
  * Requests referencing removed policies now return an informative 404 response.
* **Documentation**
  * Updated CloudFront documentation with configuration details, validation behavior, and known limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->