### PR TITLE
fix: encode SNS certificate serials as valid DER

### DIFF
--- a/src/service/sns/signature/sim-sns-certificate.iso.test.ts
+++ b/src/service/sns/signature/sim-sns-certificate.iso.test.ts
@@ -68,9 +68,8 @@ describe("sim SNS certificate serial number", () => {
     // When the certificate is issued and read back.
     const certificate = issuedCertificate(digest);
 
-    // Then the serial number is zero, written as the one byte DER writes zero
-    // as rather than as no bytes at all, which is a number and not a value a
-    // reader refuses.
-    assertIdentical(certificate.serialNumber, "0");
+    // Then the serial number is one rather than the zero those bytes name,
+    // because X.509 says a serial number is positive and zero is not.
+    assertIdentical(certificate.serialNumber, "01");
   });
 });

--- a/src/service/sns/signature/sim-sns-certificate.iso.test.ts
+++ b/src/service/sns/signature/sim-sns-certificate.iso.test.ts
@@ -1,0 +1,76 @@
+import { generateKeyPairSync, X509Certificate } from "node:crypto";
+import { assertIdentical } from "@kensio/smartass";
+import { describe, it } from "vitest";
+import {
+  simSnsSelfSignedCertificatePem,
+  simSnsSerialNumber,
+} from "./sim-sns-certificate.js";
+
+/**
+ * One key pair, generated once, because generating RSA takes long enough to
+ * notice and nothing here is about the key.
+ */
+const keyPair = generateKeyPairSync("rsa", { modulusLength: 2048 });
+
+/**
+ * Issue a certificate whose serial number comes from this digest, and read it
+ * back the way a verifier reads it.
+ *
+ * Parsing is the assertion this makes on its own: OpenSSL refuses a
+ * certificate it cannot read rather than reading it leniently, so a digest
+ * that produces a serial number DER cannot carry fails here.
+ */
+function issuedCertificate(digest: Buffer): X509Certificate {
+  return new X509Certificate(
+    simSnsSelfSignedCertificatePem({
+      privateKey: keyPair.privateKey,
+      publicKey: keyPair.publicKey,
+      subjectName: "sns.us-east-1.yulin.invalid",
+      serialNumber: simSnsSerialNumber(digest),
+    }),
+  );
+}
+
+describe("sim SNS certificate serial number", () => {
+  it("issues a readable certificate for a digest starting with a zero byte", () => {
+    // Given a public key whose digest starts with a byte of zero, followed by
+    // one whose top bit is clear.
+    const digest = Buffer.from("0037d739ee739e1900112233445566", "hex");
+
+    // When the certificate is issued and read back.
+    const certificate = issuedCertificate(digest);
+
+    // Then the leading zero is left out of the serial number, because a DER
+    // integer carries no byte it does not need and OpenSSL rejects the whole
+    // certificate over the one it did not need.
+    assertIdentical(certificate.serialNumber, "37D739EE739E19");
+  });
+
+  it("issues a positive serial number for a digest starting with a high byte", () => {
+    // Given a public key whose digest starts with a byte whose top bit is set,
+    // which is the sign bit of a DER integer.
+    const digest = Buffer.from("f037d739ee739e1900112233445566", "hex");
+
+    // When the certificate is issued and read back.
+    const certificate = issuedCertificate(digest);
+
+    // Then it reads back as that number rather than as the negative one those
+    // same bytes are when nothing keeps a DER integer positive, because a
+    // certificate serial number has to be positive.
+    assertIdentical(certificate.serialNumber, "F037D739EE739E19");
+  });
+
+  it("issues a readable certificate for a digest of nothing but zeroes", () => {
+    // Given a public key whose digest is all zeroes, which no real digest is
+    // and which the encoding still has to have an answer for.
+    const digest = Buffer.alloc(16);
+
+    // When the certificate is issued and read back.
+    const certificate = issuedCertificate(digest);
+
+    // Then the serial number is zero, written as the one byte DER writes zero
+    // as rather than as no bytes at all, which is a number and not a value a
+    // reader refuses.
+    assertIdentical(certificate.serialNumber, "0");
+  });
+});

--- a/src/service/sns/signature/sim-sns-certificate.ts
+++ b/src/service/sns/signature/sim-sns-certificate.ts
@@ -168,10 +168,17 @@ export function simSnsSelfSignedCertificatePem(
  * matters: two simulated scopes with different keys have different serials.
  *
  * The bytes are the number itself, unsigned, and `derInteger` writes them the
- * way DER writes an unsigned number: a serial has to be positive, and how a
- * positive number is kept positive is the encoding's business rather than
- * this function's.
+ * way DER writes an unsigned number, so how the sign of a written number is
+ * kept is the encoding's business rather than this function's.
+ *
+ * Which number it is stays this function's business, and X.509 says a serial
+ * number is positive. Zero is the one value a digest could name that is not,
+ * so it is answered with one instead. No real digest is all zeroes, and a
+ * certificate that is not a certificate is not worth the byte saved by leaving
+ * that to chance.
  */
 export function simSnsSerialNumber(digest: Buffer): Buffer {
-  return Buffer.from(digest.subarray(0, serialNumberBytes));
+  const serial = Buffer.from(digest.subarray(0, serialNumberBytes));
+
+  return serial.some((byte) => byte !== 0) ? serial : Buffer.from([1]);
 }

--- a/src/service/sns/signature/sim-sns-certificate.ts
+++ b/src/service/sns/signature/sim-sns-certificate.ts
@@ -4,7 +4,7 @@ import {
   derBitStringTag,
   derBytes,
   derExplicitZeroTag,
-  derIntegerTag,
+  derInteger,
   derNullTag,
   derObjectIdentifierTag,
   derPrintableStringTag,
@@ -34,7 +34,7 @@ const commonName = [0x55, 0x04, 0x03];
 /**
  * The version number of an X.509 v3 certificate, which counts from zero.
  */
-const version3 = 2;
+const version3 = Buffer.from([2]);
 
 /**
  * When the certificate becomes valid, and when it stops being valid.
@@ -124,8 +124,8 @@ function certificateBody(input: SimSnsCertificateInput): Buffer {
 
   return derValue(
     derSequenceTag,
-    derValue(derExplicitZeroTag, derBytes(derIntegerTag, version3)),
-    derValue(derIntegerTag, input.serialNumber),
+    derValue(derExplicitZeroTag, derInteger(version3)),
+    derInteger(input.serialNumber),
     signatureAlgorithm(),
     name,
     derValue(derSequenceTag, utcTime(notBefore), utcTime(notAfter)),
@@ -167,14 +167,11 @@ export function simSnsSelfSignedCertificatePem(
  * to allocate, and a serial derived from the key is unique in the only way that
  * matters: two simulated scopes with different keys have different serials.
  *
- * The top bit of the first byte is cleared, because a certificate serial number
- * has to be positive and a DER integer is signed. Clearing it is one byte of
- * uniqueness given up for a serial that never needs a leading zero.
+ * The bytes are the number itself, unsigned, and `derInteger` writes them the
+ * way DER writes an unsigned number: a serial has to be positive, and how a
+ * positive number is kept positive is the encoding's business rather than
+ * this function's.
  */
 export function simSnsSerialNumber(digest: Buffer): Buffer {
-  const serial = Buffer.from(digest.subarray(0, serialNumberBytes));
-
-  serial.writeUInt8(serial.readUInt8(0) & 0x7f, 0);
-
-  return serial;
+  return Buffer.from(digest.subarray(0, serialNumberBytes));
 }

--- a/src/service/sns/signature/sim-sns-der.iso.test.ts
+++ b/src/service/sns/signature/sim-sns-der.iso.test.ts
@@ -1,0 +1,29 @@
+import { assertIdentical } from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { derInteger } from "./sim-sns-der.js";
+
+describe("DER integer", () => {
+  it("writes a magnitude of nothing but zeroes as zero", () => {
+    // Given bytes that name no number at all, which nothing a certificate
+    // numbers is and which the encoding is still asked for.
+    const magnitude = Buffer.alloc(4);
+
+    // When they are written as a DER integer.
+    const written = derInteger(magnitude);
+
+    // Then they are written as the single byte DER writes zero as, rather than
+    // as the four they arrived as or as no bytes at all, both of which a
+    // reader refuses.
+    assertIdentical(written.toString("hex"), "020100");
+  });
+
+  it("writes no bytes at all as zero", () => {
+    // Given no bytes.
+    // When they are written as a DER integer.
+    const written = derInteger(Buffer.alloc(0));
+
+    // Then the value is zero, because an integer of no bytes is not a value a
+    // reader can read.
+    assertIdentical(written.toString("hex"), "020100");
+  });
+});

--- a/src/service/sns/signature/sim-sns-der.ts
+++ b/src/service/sns/signature/sim-sns-der.ts
@@ -79,3 +79,29 @@ export function derText(tag: number, value: string): Buffer {
 export function derBytes(tag: number, ...bytes: number[]): Buffer {
   return derValue(tag, Buffer.from(bytes));
 }
+
+/**
+ * A DER integer holding a number given as unsigned bytes, most significant
+ * first.
+ *
+ * A DER integer is signed, and it is written in the fewest bytes that say what
+ * it is, so the bytes a number arrives as are not always the bytes it is
+ * written as. A leading zero is dropped, unless the byte after it has its top
+ * bit set: there the zero is the only thing keeping the number positive, and
+ * dropping it would say the number is negative instead.
+ *
+ * Getting either wrong does not produce a number read a little differently. A
+ * reader rejects the value rather than reading it leniently: OpenSSL answers a
+ * zero byte that was not needed with `illegal padding` and then refuses to
+ * parse the certificate carrying it at all.
+ */
+export function derInteger(magnitude: Buffer): Buffer {
+  const significant = magnitude.findIndex((byte) => byte !== 0);
+  const body =
+    significant === -1 ? Buffer.from([0]) : magnitude.subarray(significant);
+  const readsAsNegative = (body.readUInt8(0) & 0x80) !== 0;
+
+  return readsAsNegative
+    ? derValue(derIntegerTag, Buffer.from([0]), body)
+    : derValue(derIntegerTag, body);
+}


### PR DESCRIPTION
A simulated SNS signing certificate took its serial number from the first eight bytes of the signing key's digest and cleared the top bit to keep the number positive, which left a leading zero byte DER forbids whenever the byte after it had its top bit clear as well. About one key in 256 therefore produced a certificate OpenSSL refuses to parse at all, answering `illegal padding`, so verifying a message that had been signed perfectly well threw rather than answering — which is what made `sim-sns-signature.iso.test.ts` flaky. The serial number and the version now go through a `derInteger` that writes the minimal signed form, dropping a leading zero unless it is the one thing keeping the number positive, and the new tests cover a digest starting with a zero byte, one starting with a high byte, and one of nothing but zeroes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved SNS certificate serial-number encoding for values with leading zeroes, high-bit values, and all-zero values.
  - Ensured generated serial numbers remain valid positive integers while preserving their intended byte values.
  - Improved certificate version and integer encoding consistency for standards-compliant certificate handling.

- **Tests**
  - Added coverage for edge cases involving serial-number DER encoding, including zero trimming, positive high-bit values, and zero representation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->