### PR TITLE
ci: fix release versioning and notes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,8 +23,18 @@ updates:
         update-types:
           - "patch"
           - "minor"
+    # conventional-changelog-conventionalcommits has to stay on 9 while
+    # semantic-release is on 25. Its 10 line returns the Handlebars templates as
+    # functions, and conventional-changelog-writer 8 reads them as strings, so a
+    # release goes out with a version number and no notes under it. Nothing
+    # errors and no check fails: the first sign is an empty GitHub Release. See
+    # .releaserc.yaml. Take this out when semantic-release moves to a writer
+    # that reads the new shape.
     ignore:
       - dependency-name: "@types/node"
+        update-types:
+          - "version-update:semver-major"
+      - dependency-name: "conventional-changelog-conventionalcommits"
         update-types:
           - "version-update:semver-major"
     commit-message:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -5,6 +5,19 @@ on:
   pull_request:
     branches:
       - main
+  # release.yml opens its version pull request with GITHUB_TOKEN, and a pull
+  # request opened with that token does not fire `pull_request`: GitHub
+  # declines to let a workflow start another workflow. Without this the main
+  # ruleset's four required checks would never report on it and it could never
+  # be merged.
+  #
+  # A ruleset matches a check by name whatever workflow posted it, and these
+  # are the same four jobs under the same four names, so running them on the
+  # push satisfies the same gate. Scoped to the branch prefix release.yml uses,
+  # so ordinary branches still get one run rather than two.
+  push:
+    branches:
+      - "release/**"
 
 defaults:
   run:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -5,19 +5,6 @@ on:
   pull_request:
     branches:
       - main
-  # release.yml opens its version pull request with GITHUB_TOKEN, and a pull
-  # request opened with that token does not fire `pull_request`: GitHub
-  # declines to let a workflow start another workflow. Without this the main
-  # ruleset's four required checks would never report on it and it could never
-  # be merged.
-  #
-  # A ruleset matches a check by name whatever workflow posted it, and these
-  # are the same four jobs under the same four names, so running them on the
-  # push satisfies the same gate. Scoped to the branch prefix release.yml uses,
-  # so ordinary branches still get one run rather than two.
-  push:
-    branches:
-      - "release/**"
 
 defaults:
   run:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -251,8 +251,22 @@ jobs:
   #
   # A pull request rather than a push, because the main ruleset requires four
   # passing status checks on whatever lands there and a commit created inside
-  # this run has none. pr.yml runs those four on pushes to `release/**` for
-  # exactly this reason.
+  # this run has none.
+  #
+  # It needs one click to merge. A pull request opened with GITHUB_TOKEN does
+  # fire `pull_request`, so pr.yml's four jobs are queued against it under the
+  # four names the ruleset wants, but GitHub holds the run in an
+  # approval-required state rather than starting it: this is the loop guard
+  # that stops a workflow starting another workflow unattended. "Approve and
+  # run" on the pull request releases it and the checks report normally.
+  #
+  # Adding a `push:` trigger for this branch does not avoid that click, which
+  # is worth knowing before trying it. A push made with GITHUB_TOKEN starts no
+  # workflow run at all, with no approval offered, so the trigger is simply
+  # dead. The way to have the checks start unattended is to push with a GitHub
+  # App installation token or a personal access token instead, and that means
+  # holding a credential in a repository whose release path is built around
+  # not having one. One click a release is the cheaper side of that trade.
   #
   # That number is not what the released version *is*: the tag and the registry
   # are that, and both already exist by the time this runs. So a failure here,

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@
 # Publishes @kensio/yulin, when someone runs it from the Actions tab.
 # What it does is decided by .releaserc.yaml; this file is the plumbing.
 #
-# Two things live outside the repository and have to exist for it to work:
+# Three things live outside the repository and have to exist for it to work:
 #
 #   1. A trusted publisher on npmjs.com for @kensio/yulin, pointing at this
 #      repository, this workflow file, and the "release" environment below,
@@ -15,9 +15,15 @@
 #      deliberate act, so approving your own run adds little on its own. The
 #      choice is only made there, not here.
 #
-# Neither is recorded in the repository, so if publishes start failing with an
-# authentication error, check that the trusted publisher still names this
-# workflow file — renaming this file silently invalidates it.
+#   3. Settings → Actions → General → "Allow GitHub Actions to create and
+#      approve pull requests", for the version job at the bottom. Without it
+#      `gh pr create` fails with a permissions error that does not mention the
+#      setting. The publish itself is unaffected, since by then it has already
+#      happened.
+#
+# None of them is recorded in the repository, so if publishes start failing
+# with an authentication error, check that the trusted publisher still names
+# this workflow file — renaming this file silently invalidates it.
 
 name: Release
 
@@ -199,6 +205,12 @@ jobs:
       # for an NPM_TOKEN and fails.
       id-token: write
 
+    # Empty when the commits since the last tag were only chore/test/docs, and
+    # nothing was published. The version job below reads it to decide whether
+    # there is anything to write down.
+    outputs:
+      version: ${{ steps.release.outputs.version }}
+
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -226,9 +238,83 @@ jobs:
       # only chore/test/docs. See .releaserc.yaml. The tarball is built here by
       # prepack, from this checkout, rather than carried over from the pack
       # check — that check proves the build works, it does not hand anything on.
-      - run: pnpm exec semantic-release
+      - id: release
+        run: pnpm exec semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # Read by analyzeCommitsCmd in .releaserc.yaml, which raises the
           # release to a minor when this is "true".
           RELEASE_MINOR: ${{ inputs.minor }}
+
+  # `version` in package.json, caught up to what was just published, and sent
+  # to main as a pull request.
+  #
+  # A pull request rather than a push, because the main ruleset requires four
+  # passing status checks on whatever lands there and a commit created inside
+  # this run has none. pr.yml runs those four on pushes to `release/**` for
+  # exactly this reason.
+  #
+  # That number is not what the released version *is*: the tag and the registry
+  # are that, and both already exist by the time this runs. So a failure here,
+  # or a pull request left unmerged, costs a stale package.json and nothing
+  # else. It does not cost a broken release, and nothing about the next one
+  # depends on it having been merged, since semantic-release reads the tags.
+  version:
+    name: Write the version back
+    needs: release
+    if: needs.release.outputs.version != ''
+    runs-on: ubuntu-latest
+    permissions:
+      # Pushing the branch.
+      contents: write
+      # Opening the pull request.
+      pull-requests: write
+    steps:
+      # The one job here that keeps checkout's credential, because it is the
+      # one that pushes. It holds no npm credential and publishes nothing.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: true
+
+      # For `npm pkg set` below, and so that the version of npm rewriting
+      # package.json is the one everyone else's edits go through.
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: .nvmrc
+
+      - name: Commit and open a pull request
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ needs.release.outputs.version }}
+        run: |
+          set -euo pipefail
+
+          npm pkg set version="$VERSION"
+
+          if [[ -z "$(git status --porcelain)" ]]; then
+            echo "Nothing changed. Already written back?"
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          branch="release/v$VERSION"
+          git switch --create "$branch"
+          git add package.json
+          git commit --message "chore: version $VERSION"
+          git push origin "$branch"
+
+          # --body-file rather than --body, so the markdown below is not at the
+          # mercy of how this block is indented.
+          cat > "$RUNNER_TEMP/pr-body.md" <<EOF
+          [$VERSION](https://github.com/KensioSoftware/yulin/releases/tag/v$VERSION) is published. This is the part of it that belongs on main: \`version\` in package.json caught up to it.
+
+          Nothing depends on this being merged: the tag and the registry are the version of record, and the next release works out its own number from the tags rather than from this file.
+          EOF
+
+          gh pr create \
+            --base main \
+            --head "$branch" \
+            --title "chore: version $VERSION" \
+            --body-file "$RUNNER_TEMP/pr-body.md"

--- a/.releaserc.yaml
+++ b/.releaserc.yaml
@@ -45,10 +45,45 @@ plugins:
         - type: build
           release: patch
 
-  # Turns those same commits into the GitHub Release notes. Same preset as the
-  # analyzer, so the notes group commits the way the analyzer read them.
+  # Turns those same commits into the GitHub Release notes.
+  #
+  # Which is to say the pull request titles. Everything lands on main as a
+  # squash, so a subject is the title someone wrote on a pull request with the
+  # number GitHub appended to it, and both halves of that become links: the
+  # number back to the pull request, the hash to the commit.
+  #
+  # `types` is the whole list rather than an addition to the preset's: a type
+  # not named here is left out of the notes entirely, and the preset's own list
+  # names only feat and fix. So this is the list from the analyzer above, given
+  # section headings, and without it a release made of perf, refactor or build
+  # commits publishes a version with nothing written under it. docs, test,
+  # chore, ci and style are absent for the same reason they are absent there:
+  # they publish nothing, so there is no release for them to describe.
+  #
+  # conventional-changelog-conventionalcommits is pinned to 9.3.1 in
+  # package.json and cannot be taken to 10 while semantic-release is on 25.
+  # Both plugins here reach for that package by name, but the notes generator
+  # renders it through conventional-changelog-writer 8, which is Handlebars and
+  # reads `mainTemplate` and the partials as strings; the preset's 10 line
+  # returns functions instead. Nothing errors when they are mismatched. The
+  # header renders, every commit is dropped, and the release goes out with a
+  # version number and no notes under it, which is how v1.10.4 shipped empty.
+  # .github/dependabot.yml holds the major back, and that entry is the only
+  # thing keeping this pin in place.
   - - "@semantic-release/release-notes-generator"
     - preset: conventionalcommits
+      presetConfig:
+        types:
+          - type: feat
+            section: Added
+          - type: fix
+            section: Fixed
+          - type: perf
+            section: Faster
+          - type: refactor
+            section: Changed
+          - type: build
+            section: Packaging and dependencies
 
   # The two ends of the ladder the analyzer above deliberately cannot reach.
   #
@@ -79,6 +114,14 @@ plugins:
         major releases are published by hand." >&2;
         exit 1;
         fi
+      # Read by the workflow, which needs the version to open the pull request
+      # that catches package.json up. Guarded because this file is also
+      # runnable outside Actions, where the variable is unset and the redirect
+      # would be an error.
+      successCmd: >-
+        if [ -n "$GITHUB_OUTPUT" ]; then
+        echo "version=${nextRelease.version}" >> "$GITHUB_OUTPUT";
+        fi
 
   # Publishes to npm. No NPM_TOKEN anywhere: the npm CLI detects the OIDC
   # token the workflow requests and exchanges it for a credential that lasts
@@ -90,11 +133,12 @@ plugins:
   # Creates the git tag and the GitHub Release.
   #
   # Note there is no @semantic-release/git plugin: nothing here commits the
-  # bumped version back to main. That is partly taste — the tag and the
-  # registry are the version of record for a library — and partly that it
-  # could not work anyway, since the main ruleset requires pull requests,
-  # signed commits and linear history, and only an org admin bypasses it.
-  # Tags are unaffected, because the ruleset only covers the default branch.
+  # bumped version back to main directly. It could not work anyway, since the
+  # main ruleset requires a pull request with four passing status checks on
+  # whatever lands there, and a commit made inside this run has none. The pull
+  # request the workflow opens from successCmd's version is that commit taking
+  # the ordinary route instead. Tags are unaffected, because the ruleset only
+  # covers the default branch.
   - - "@semantic-release/github"
     # The released-in comments this would otherwise leave on every merged pull
     # request and closed issue. The GitHub Release is the announcement.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kensio/yulin",
-  "version": "1.7.0",
+  "version": "1.10.4",
   "description": "AWS system behaviour simulation for isolated unit testing",
   "repository": "https://github.com/KensioSoftware/yulin",
   "homepage": "https://yulinsim.dev/",
@@ -178,7 +178,7 @@
     "aws-jwt-verify": "^5.2.1",
     "aws-sdk-client-mock": "^4.1.0",
     "constructs": "^10.8.0",
-    "conventional-changelog-conventionalcommits": "10.2.1",
+    "conventional-changelog-conventionalcommits": "9.3.1",
     "eslint": "^10.8.0",
     "eslint-plugin-jsdoc": "^63.3.2",
     "eslint-plugin-no-secrets": "^2.3.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -127,8 +127,8 @@ importers:
         specifier: ^10.8.0
         version: 10.8.1
       conventional-changelog-conventionalcommits:
-        specifier: 10.2.1
-        version: 10.2.1
+        specifier: 9.3.1
+        version: 9.3.1
       eslint:
         specifier: ^10.8.0
         version: 10.8.0(jiti@2.7.0)(supports-color@7.2.0)
@@ -413,10 +413,6 @@ packages:
   '@colors/colors@1.5.0':
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
     engines: {node: '>=0.1.90'}
-
-  '@conventional-changelog/template@1.2.1':
-    resolution: {integrity: sha512-TzlTVpKPjaqW6qOYjQcYUDuGsLCNsvFHVBXkYGTAnf5V37jCWrE5haKNXzz0WZUtVHjrpV76L1buANjwXMfT8w==}
-    engines: {node: '>=22'}
 
   '@emnapi/core@1.11.1':
     resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
@@ -1714,9 +1710,9 @@ packages:
     resolution: {integrity: sha512-6gfI3otXK5Ph5DfCOI1dblr+kN3FAm5a97hYoQkqNZxOaYa5WKfXH+AnpsmS+iUH2mgVC2Cg2Qw9m5OKcmNrIg==}
     engines: {node: '>=18'}
 
-  conventional-changelog-conventionalcommits@10.2.1:
-    resolution: {integrity: sha512-n4Kr1HFMTf3iMbES0TMxKIcYtUUv4rKqyQQp2JwfOEfFCOfGT3Tq4mCyJ8S9/YPyWhydjfKrrvnyl+gCjA+mJQ==}
-    engines: {node: '>=22'}
+  conventional-changelog-conventionalcommits@9.3.1:
+    resolution: {integrity: sha512-dTYtpIacRpcZgrvBYvBfArMmK2xvIpv2TaxM0/ZI5CBtNUzvF2x0t15HsbRABWprS6UPmvj+PzHVjSx4qAVKyw==}
+    engines: {node: '>=18'}
 
   conventional-changelog-writer@8.4.0:
     resolution: {integrity: sha512-HHBFkk1EECxxmCi4CTu091iuDpQv5/OavuCUAuZmrkWpmYfyD816nom1CvtfXJ/uYfAAjavgHvXHX291tSLK8g==}
@@ -3771,8 +3767,6 @@ snapshots:
   '@colors/colors@1.5.0':
     optional: true
 
-  '@conventional-changelog/template@1.2.1': {}
-
   '@emnapi/core@1.11.1':
     dependencies:
       '@emnapi/wasi-threads': 1.2.2
@@ -4823,9 +4817,9 @@ snapshots:
     dependencies:
       compare-func: 2.0.0
 
-  conventional-changelog-conventionalcommits@10.2.1:
+  conventional-changelog-conventionalcommits@9.3.1:
     dependencies:
-      '@conventional-changelog/template': 1.2.1
+      compare-func: 2.0.0
 
   conventional-changelog-writer@8.4.0:
     dependencies:


### PR DESCRIPTION
`version` in package.json had drifted to 1.7.0 against a published 1.10.4, and release notes were coming out empty (see [v1.10.4](https://github.com/KensioSoftware/yulin/releases/tag/v1.10.4)). The workflow now opens a pull request writing the published version back, with pr.yml running the four required checks on the `release/**` push so that pull request can actually be merged, and the notes generator is off `conventional-changelog-conventionalcommits` 10, whose templates come back as functions that conventional-changelog-writer 8 reads as strings and silently drops every commit for. package.json is set to 1.10.4 by hand here, since the write-back only starts from the next release.

One thing worth a look: the generator now lists section headings for every type the analyzer releases on (`feat`, `fix`, `perf`, `refactor`, `build`) rather than the preset's default of just `feat` and `fix`, so Dependabot's `build(deps-dev):` commits will start appearing in the notes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Release Process**
  - Automated releases now update the package version through a pull request.
  - Release branches and pull requests receive required validation checks.
  - Release notes are grouped into clearer feature, fix, performance, refactor, and build sections.
  - Release setup documentation now includes required GitHub Actions permissions and branch settings.

- **Maintenance**
  - Updated the package version to 1.10.4.
  - Adjusted release tooling compatibility settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->