### PR TITLE
fix: allow the cloudfront module import in JS2

### DIFF
--- a/docs/lint/README.md
+++ b/docs/lint/README.md
@@ -73,7 +73,7 @@ Each restriction is its own rule, under the `cff-js2` name in both linters.
 
 | Rule                            | What it refuses                                          |
 | ------------------------------- | -------------------------------------------------------- |
-| `cff-js2/no-import`             | `import` declarations, since a Function is one file      |
+| `cff-js2/no-import`             | `import` declarations, apart from `cloudfront`           |
 | `cff-js2/only-handler-export`   | Any export other than `export function handler(...)`     |
 | `cff-js2/only-built-in-require` | Requiring anything but `querystring`, `crypto`, `buffer` |
 | `cff-js2/no-class`              | Class declarations and expressions                       |
@@ -105,6 +105,8 @@ These all work in JS2 and no rule here objects to them:
 - `async` and `await`
 - `Promise`, including `all`, `allSettled`, `any` and `race`
 - `Buffer`, and `require` of `querystring`, `crypto` or `buffer`
+- `import cf from "cloudfront"`, which is how a Function reaches `cf.kvs()` and
+  `cf.updateRequestOrigin()`
 - `String.prototype.replaceAll`, `atob`, `btoa` and numeric separators
 
 ## Turning one restriction off

--- a/src/config/lint/cff-js2-lint.fixture.ts
+++ b/src/config/lint/cff-js2-lint.fixture.ts
@@ -64,6 +64,16 @@ export function handler() {
 `,
   },
   {
+    rule: "no-import",
+    what: "an import of a package other than the built-in module",
+    source: `import helper from "helper";
+
+export function handler() {
+  return helper();
+}
+`,
+  },
+  {
     rule: "only-handler-export",
     what: "an export other than the handler",
     source: `export var version = 1;
@@ -214,6 +224,19 @@ export function handler(event) {
     what: "a Buffer",
     source: `export function handler(event) {
   return Buffer.from(event.request.uri, "utf8").toString("base64");
+}
+`,
+  },
+  {
+    what: "importing the built-in cloudfront module",
+    source: `import cf from "cloudfront";
+
+export async function handler(event) {
+  const request = event.request;
+
+  request.uri = await cf.kvs().get(request.uri);
+
+  return request;
 }
 `,
   },

--- a/src/config/lint/cff-js2-restriction.ts
+++ b/src/config/lint/cff-js2-restriction.ts
@@ -19,9 +19,12 @@
  */
 export const cffJs2SyntaxRestrictions = {
   "no-import": {
-    selector: "ImportDeclaration",
+    // `cloudfront` is the runtime's own built-in module, and importing it is
+    // the documented way to reach the `cf` helpers, so it is the one specifier
+    // a Function may import.
+    selector: "ImportDeclaration:not([source.value='cloudfront'])",
     message:
-      "CloudFront Functions must be self-contained and should not use import syntax.",
+      "CloudFront Functions must be self-contained, and may only import the built-in `cloudfront` module. Everything else must be inlined.",
   },
   "only-handler-export": {
     selector:
@@ -83,12 +86,12 @@ export const cffJs2UnavailableGlobals = {
   XMLHttpRequest: "CloudFront Functions cannot make network requests.",
   WebSocket: "CloudFront Functions cannot open network connections.",
   process: "CloudFront Functions do not have access to Node.js process APIs.",
-  setTimeout:
-    "CloudFront Functions do not support timers, and must run to completion synchronously.",
-  setInterval:
-    "CloudFront Functions do not support timers, and must run to completion synchronously.",
-  setImmediate:
-    "CloudFront Functions do not support timers, and must run to completion synchronously.",
+  // Awaiting is not the problem here: a Function may await a key value store
+  // read. Deferring work to a later tick is, because there is no event loop to
+  // run it on.
+  setTimeout: "CloudFront Functions do not support timers.",
+  setInterval: "CloudFront Functions do not support timers.",
+  setImmediate: "CloudFront Functions do not support timers.",
   clearTimeout:
     "CloudFront Functions do not support timers, so there is nothing to clear.",
 } as const satisfies Readonly<Record<string, string>>;


### PR DESCRIPTION
The `no-import` restriction matched every `ImportDeclaration`, so it flagged `import cf from "cloudfront"`, which is the documented way a CloudFront Function reaches the `cf` helpers for a key value store read or an origin update. The selector now exempts that one specifier and every other import is still refused, with a violation case for a bare package specifier added alongside the existing relative-path one so the discrimination is covered both ways. The timer messages lose their claim that a Function runs to completion synchronously, which stops being true once one awaits a key value store read.

Resolves https://github.com/KensioSoftware/yulin/issues/520


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that importing the built-in `cloudfront` module is permitted for CloudFront APIs.

- **Bug Fixes**
  - Updated linting rules to allow the built-in `cloudfront` module while continuing to reject other imports.
  - Improved diagnostics for unsupported timers and supported asynchronous key-value-store reads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->