### PR TITLE
feat: add CloudFront key value stores

### DIFF
--- a/docs/services/cloudfront/README.md
+++ b/docs/services/cloudfront/README.md
@@ -1304,6 +1304,7 @@ and `simAws.cloudFrontKeyValueStore()`.
 
 import { CreateKeyValueStoreCommand } from "@aws-sdk/client-cloudfront";
 import {
+  DescribeKeyValueStoreCommand,
   GetKeyCommand,
   UpdateKeysCommand,
 } from "@aws-sdk/client-cloudfront-keyvaluestore";
@@ -1324,13 +1325,19 @@ const created = await simAws
   );
 
 const kvsArn = created.KeyValueStore.ARN;
+const data = simAws.cloudFrontKeyValueStore();
 
 // The key value store client owns the data, and addresses the store by ARN.
-// Every write carries the current ETag, which the previous write returns.
-const written = await simAws.cloudFrontKeyValueStore().updateKeys(
+// Every write carries an ETag, and it is this API's own: the one the
+// CloudFront client returned above versions the resource, not the keys.
+const described = await data.describeKeyValueStore(
+  new DescribeKeyValueStoreCommand({ KvsARN: kvsArn }),
+);
+
+const written = await data.updateKeys(
   new UpdateKeysCommand({
     KvsARN: kvsArn,
-    IfMatch: created.ETag,
+    IfMatch: described.ETag,
     Puts: [
       { Key: "/old-page", Value: "/new-page" },
       { Key: "/legacy", Value: "/current" },
@@ -1340,9 +1347,9 @@ const written = await simAws.cloudFrontKeyValueStore().updateKeys(
 
 console.log(written.ItemCount); // 2
 
-const read = await simAws
-  .cloudFrontKeyValueStore()
-  .getKey(new GetKeyCommand({ KvsARN: kvsArn, Key: "/old-page" }));
+const read = await data.getKey(
+  new GetKeyCommand({ KvsARN: kvsArn, Key: "/old-page" }),
+);
 
 console.log(read.Value); // /new-page
 ```
@@ -1352,14 +1359,17 @@ CloudFront. `await simAws.backgroundTasksComplete()` waits for that.
 
 ### ETags
 
-Unlike the Distribution and Function commands, the key value store commands do check `IfMatch`. The
-data API requires it on every write, and CloudFront refuses a stale one, which is what stops two
-writers overwriting each other. A write carrying an ETag that is not the store's current one is
-refused with `PreconditionFailed`, so a caller has to thread the ETag through the way it does
-against CloudFront. Each write returns the new ETag for the next one.
+Unlike the Distribution and Function commands, the key value store commands do check `IfMatch`. Both
+APIs require it on every write and CloudFront refuses a stale one, which is what stops two writers
+overwriting each other. A write carrying an ETag that is not current is refused with
+`PreconditionFailed`, so a caller has to thread the ETag through the way it does against CloudFront.
+Each write returns the new ETag for the next one.
 
-`DescribeKeyValueStoreCommand` on the CloudFront client is how to read the current ETag without
-writing.
+A store has two ETags and they are not interchangeable, as in AWS. Each `DescribeKeyValueStore`
+returns its own: the CloudFront client's versions the store's configuration, and the key value store
+client's versions the keys. Writing a key does not move the configuration's ETag, and changing the
+comment does not move the keys'. A write carrying the other API's ETag is refused, and the message
+says which of the two it wanted.
 
 ## Available functionality
 

--- a/docs/services/cloudfront/README.md
+++ b/docs/services/cloudfront/README.md
@@ -1282,6 +1282,85 @@ fails the Stack by name.
 There is no `CreateOriginAccessControl` command here, so a CloudFormation template is the only way
 to make one.
 
+## Key value stores
+
+A key value store holds data a CloudFront Function reads at request time, so a redirect table or a
+feature flag does not have to be baked into the Function's code.
+
+AWS splits this across two SDK clients, and so does the simulator. The CloudFront client owns the
+store: `CreateKeyValueStoreCommand`, `DescribeKeyValueStoreCommand`, `ListKeyValueStoresCommand`,
+`UpdateKeyValueStoreCommand` and `DeleteKeyValueStoreCommand`, all addressing a store by name. The
+key value store client owns the data: `GetKeyCommand`, `PutKeyCommand`, `DeleteKeyCommand`,
+`ListKeysCommand`, `UpdateKeysCommand` and its own `DescribeKeyValueStoreCommand`, all addressing a
+store by ARN.
+
+Both clients are intercepted by `SimSdk`. Used directly, they are `simAws.cloudFront().keyValueStores()`
+and `simAws.cloudFrontKeyValueStore()`.
+
+```typescript sim-cloudfront-key-value-store
+/**
+ * Creating a CloudFront key value store and writing keys to it.
+ */
+
+import { CreateKeyValueStoreCommand } from "@aws-sdk/client-cloudfront";
+import {
+  GetKeyCommand,
+  UpdateKeysCommand,
+} from "@aws-sdk/client-cloudfront-keyvaluestore";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+// The CloudFront client owns the store itself.
+const created = await simAws
+  .cloudFront()
+  .keyValueStores()
+  .createKeyValueStore(
+    new CreateKeyValueStoreCommand({
+      Name: "redirects",
+      Comment: "Where old paths go",
+    }),
+  );
+
+const kvsArn = created.KeyValueStore.ARN;
+
+// The key value store client owns the data, and addresses the store by ARN.
+// Every write carries the current ETag, which the previous write returns.
+const written = await simAws.cloudFrontKeyValueStore().updateKeys(
+  new UpdateKeysCommand({
+    KvsARN: kvsArn,
+    IfMatch: created.ETag,
+    Puts: [
+      { Key: "/old-page", Value: "/new-page" },
+      { Key: "/legacy", Value: "/current" },
+    ],
+  }),
+);
+
+console.log(written.ItemCount); // 2
+
+const read = await simAws
+  .cloudFrontKeyValueStore()
+  .getKey(new GetKeyCommand({ KvsARN: kvsArn, Key: "/old-page" }));
+
+console.log(read.Value); // /new-page
+```
+
+A new store is `PROVISIONING` when the command returns and becomes `READY` in the background, as in
+CloudFront. `await simAws.backgroundTasksComplete()` waits for that.
+
+### ETags
+
+Unlike the Distribution and Function commands, the key value store commands do check `IfMatch`. The
+data API requires it on every write, and CloudFront refuses a stale one, which is what stops two
+writers overwriting each other. A write carrying an ETag that is not the store's current one is
+refused with `PreconditionFailed`, so a caller has to thread the ETag through the way it does
+against CloudFront. Each write returns the new ETag for the next one.
+
+`DescribeKeyValueStoreCommand` on the CloudFront client is how to read the current ETag without
+writing.
+
 ## Available functionality
 
 Sim CloudFront currently supports:
@@ -1289,6 +1368,7 @@ Sim CloudFront currently supports:
 - `CreateDistributionCommand`, `GetDistributionCommand`, `UpdateDistributionCommand` and
   `DeleteDistributionCommand`
 - `CreateFunctionCommand` and `DeleteFunctionCommand`
+- Key value stores, through both the CloudFront client and the key value store data client
 - S3 Origins backed by sim S3 Buckets, reading them as the Bucket policy allows
 - Custom Origins reaching sim HTTP APIs and sim Lambda Function URLs in process
 - CloudFront Distribution hostnames such as `distro123.cloudfront.net`
@@ -1328,10 +1408,23 @@ Where sim CloudFront knowingly behaves differently from AWS:
   claiming a name is refused with `OriginAccessControlAlreadyExists`, as CloudFront refuses one.
 - **There is no command surface for an origin access control.** `CreateOriginAccessControl` and its
   siblings are not simulated, so `AWS::CloudFront::OriginAccessControl` is the only way to make one.
-- **`IfMatch` ETags are not checked.** `UpdateDistributionCommand`, `DeleteDistributionCommand` and
-  `DeleteFunctionCommand` all accept `IfMatch` and ignore it, so neither `PreconditionFailed` nor
-  `InvalidIfMatchVersion` is ever returned. Nothing else here versions a resource, and a stale ETag
-  is a retry rather than a design mistake. A test expecting the ETag refusal will not get it.
+- **`IfMatch` ETags are not checked on a Distribution or a Function.**
+  `UpdateDistributionCommand`, `DeleteDistributionCommand` and `DeleteFunctionCommand` all accept
+  `IfMatch` and ignore it, so neither `PreconditionFailed` nor `InvalidIfMatchVersion` is returned
+  for those. A stale ETag there is a retry rather than a design mistake. The key value store
+  commands are the exception and do check it, because the data API is built around it: two writers
+  racing on one store is the case it exists to catch.
+- **A key value store has no size quota.** CloudFront caps a store's total size and the length of a
+  single key and value, and refuses a write that would exceed either. Nothing here counts against a
+  quota, so `TotalSizeInBytes` is reported but never enforced. A test cannot find out that its data
+  would be too large for a real store.
+- **Nothing is associated with a key value store yet.** A CloudFront Function cannot name one, so
+  `DeleteKeyValueStoreCommand` never answers `CannotDeleteEntityWhileInUse` and no Function can read
+  one at request time.
+- **`ImportSource` is not supported.** `CreateKeyValueStoreCommand` ignores it, so a store is always
+  created empty rather than seeded from an S3 Object.
+- **Key listing is not paginated.** `ListKeysCommand` and `ListKeyValueStoresCommand` answer with
+  everything and never set a `NextToken` or `NextMarker`, so a test cannot exercise a paging loop.
 - **A deletion does not wait for the disable to deploy.** Real CloudFront needs the disabled
   Distribution to reach `Deployed` before it accepts the deletion. Here, `Enabled: false` is enough.
 - **A disabled Distribution still serves requests.** Real CloudFront answers a disabled Distribution

--- a/docs/services/cloudfront/sim-cloudfront-key-value-store.example.ts
+++ b/docs/services/cloudfront/sim-cloudfront-key-value-store.example.ts
@@ -1,0 +1,47 @@
+/**
+ * Creating a CloudFront key value store and writing keys to it.
+ */
+
+import { CreateKeyValueStoreCommand } from "@aws-sdk/client-cloudfront";
+import {
+  GetKeyCommand,
+  UpdateKeysCommand,
+} from "@aws-sdk/client-cloudfront-keyvaluestore";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+// The CloudFront client owns the store itself.
+const created = await simAws
+  .cloudFront()
+  .keyValueStores()
+  .createKeyValueStore(
+    new CreateKeyValueStoreCommand({
+      Name: "redirects",
+      Comment: "Where old paths go",
+    }),
+  );
+
+const kvsArn = created.KeyValueStore.ARN;
+
+// The key value store client owns the data, and addresses the store by ARN.
+// Every write carries the current ETag, which the previous write returns.
+const written = await simAws.cloudFrontKeyValueStore().updateKeys(
+  new UpdateKeysCommand({
+    KvsARN: kvsArn,
+    IfMatch: created.ETag,
+    Puts: [
+      { Key: "/old-page", Value: "/new-page" },
+      { Key: "/legacy", Value: "/current" },
+    ],
+  }),
+);
+
+console.log(written.ItemCount); // 2
+
+const read = await simAws
+  .cloudFrontKeyValueStore()
+  .getKey(new GetKeyCommand({ KvsARN: kvsArn, Key: "/old-page" }));
+
+console.log(read.Value); // /new-page

--- a/docs/services/cloudfront/sim-cloudfront-key-value-store.example.ts
+++ b/docs/services/cloudfront/sim-cloudfront-key-value-store.example.ts
@@ -4,6 +4,7 @@
 
 import { CreateKeyValueStoreCommand } from "@aws-sdk/client-cloudfront";
 import {
+  DescribeKeyValueStoreCommand,
   GetKeyCommand,
   UpdateKeysCommand,
 } from "@aws-sdk/client-cloudfront-keyvaluestore";
@@ -24,13 +25,19 @@ const created = await simAws
   );
 
 const kvsArn = created.KeyValueStore.ARN;
+const data = simAws.cloudFrontKeyValueStore();
 
 // The key value store client owns the data, and addresses the store by ARN.
-// Every write carries the current ETag, which the previous write returns.
-const written = await simAws.cloudFrontKeyValueStore().updateKeys(
+// Every write carries an ETag, and it is this API's own: the one the
+// CloudFront client returned above versions the resource, not the keys.
+const described = await data.describeKeyValueStore(
+  new DescribeKeyValueStoreCommand({ KvsARN: kvsArn }),
+);
+
+const written = await data.updateKeys(
   new UpdateKeysCommand({
     KvsARN: kvsArn,
-    IfMatch: created.ETag,
+    IfMatch: described.ETag,
     Puts: [
       { Key: "/old-page", Value: "/new-page" },
       { Key: "/legacy", Value: "/current" },
@@ -40,8 +47,8 @@ const written = await simAws.cloudFrontKeyValueStore().updateKeys(
 
 console.log(written.ItemCount); // 2
 
-const read = await simAws
-  .cloudFrontKeyValueStore()
-  .getKey(new GetKeyCommand({ KvsARN: kvsArn, Key: "/old-page" }));
+const read = await data.getKey(
+  new GetKeyCommand({ KvsARN: kvsArn, Key: "/old-page" }),
+);
 
 console.log(read.Value); // /new-page

--- a/package.json
+++ b/package.json
@@ -147,6 +147,7 @@
     "@aws-sdk/client-apigatewayv2": "^3.1101.0",
     "@aws-sdk/client-cloudformation": "^3.1101.0",
     "@aws-sdk/client-cloudfront": "^3.1101.0",
+    "@aws-sdk/client-cloudfront-keyvaluestore": "^3.1108.0",
     "@aws-sdk/client-cognito-identity-provider": "^3.1101.0",
     "@aws-sdk/client-dynamodb": "^3.1101.0",
     "@aws-sdk/client-dynamodb-streams": "^3.1101.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,6 +33,9 @@ importers:
       '@aws-sdk/client-cloudfront':
         specifier: ^3.1101.0
         version: 3.1104.0
+      '@aws-sdk/client-cloudfront-keyvaluestore':
+        specifier: ^3.1108.0
+        version: 3.1108.0
       '@aws-sdk/client-cognito-identity-provider':
         specifier: ^3.1101.0
         version: 3.1104.0
@@ -223,6 +226,10 @@ packages:
 
   '@aws-sdk/client-cloudformation@3.1104.0':
     resolution: {integrity: sha512-ZPzvu6ON2WNBwIIWemkvxd33JUit9Kb12AuI4Zbdlvd3IlxJNu7pDXN8JXS11AI1mMSvDQavqumuY/EARAPqWw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/client-cloudfront-keyvaluestore@3.1108.0':
+    resolution: {integrity: sha512-FvV6o2sts0U8ef7pfTTfy6WS1jVyzccp8/rvDJvR5DKMZ7nzVcqGVELKGj72Igjpy2riYnUfkiJxx9qsRPQ1HA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/client-cloudfront@3.1104.0':
@@ -3437,6 +3444,18 @@ snapshots:
     dependencies:
       '@aws-sdk/core': 3.977.7
       '@aws-sdk/credential-provider-node': 3.972.79
+      '@aws-sdk/types': 3.974.3
+      '@smithy/core': 3.32.0
+      '@smithy/fetch-http-handler': 5.7.0
+      '@smithy/node-http-handler': 4.10.0
+      '@smithy/types': 4.17.0
+      tslib: 2.8.1
+
+  '@aws-sdk/client-cloudfront-keyvaluestore@3.1108.0':
+    dependencies:
+      '@aws-sdk/core': 3.977.7
+      '@aws-sdk/credential-provider-node': 3.972.79
+      '@aws-sdk/signature-v4-multi-region': 3.996.44
       '@aws-sdk/types': 3.974.3
       '@smithy/core': 3.32.0
       '@smithy/fetch-http-handler': 5.7.0

--- a/src/sdk/router/resolve-sim-sdk-command-router.ts
+++ b/src/sdk/router/resolve-sim-sdk-command-router.ts
@@ -35,6 +35,9 @@ export function resolveSimSdkCommandRouter(
     case "CloudFront": {
       return scoped.cloudFront().sdkCommandRouter();
     }
+    case "CloudFront KeyValueStore": {
+      return scoped.cloudFrontKeyValueStore().sdkCommandRouter();
+    }
     case "Cognito Identity Provider": {
       return scoped.cognitoIdentityProvider().sdkCommandRouter();
     }

--- a/src/service/aws/sim-aws-account-region-scope.ts
+++ b/src/service/aws/sim-aws-account-region-scope.ts
@@ -5,6 +5,7 @@ import { isSimAwsClosing } from "./sim-aws-closing.js";
 import { SimAws } from "./sim-aws.js";
 import type { SimS3 } from "../s3/sim-s3.js";
 import type { SimCloudFront } from "../cloudfront/sim-cloudfront.js";
+import type { SimCloudFrontKeyValueStoreApi } from "../cloudfront/sim-cloudfront-key-value-store.js";
 import type {
   SimDynamoDb as SimDynamoDatabase,
   SimDynamoDbStreams,
@@ -95,6 +96,17 @@ export class SimAwsAccountRegionContainer {
     return this.memo.getOrCreate("cloudFront", () =>
       this.simAws.serviceFactory.createCloudFront(this),
     );
+  }
+
+  /**
+   * Get the simulated CloudFront key value store data API for this account.
+   *
+   * It is not made here, unlike the services around it. The stores it reads
+   * and writes are the ones this scope's CloudFront owns, so it belongs to
+   * that service and is reached through it.
+   */
+  cloudFrontKeyValueStore(): SimCloudFrontKeyValueStoreApi {
+    return this.cloudFront().keyValueStoreApi();
   }
 
   /**

--- a/src/service/aws/sim-aws-account.ts
+++ b/src/service/aws/sim-aws-account.ts
@@ -3,6 +3,7 @@ import type { SimAwsAccountRegionContainer } from "./sim-aws-account-region-scop
 import { simAwsAccountId, type SimAwsAccountId } from "./sim-aws-account-id.js";
 import type { SimS3 } from "../s3/sim-s3.js";
 import type { SimCloudFront } from "../cloudfront/sim-cloudfront.js";
+import type { SimCloudFrontKeyValueStoreApi } from "../cloudfront/sim-cloudfront-key-value-store.js";
 import type {
   SimDynamoDb as SimDynamoDatabase,
   SimDynamoDbStreams,
@@ -91,6 +92,13 @@ export class SimAwsAccount {
    */
   cloudFront(): SimCloudFront {
     return this.region().cloudFront();
+  }
+
+  /**
+   * Get the simulated CloudFront key value store data API.
+   */
+  cloudFrontKeyValueStore(): SimCloudFrontKeyValueStoreApi {
+    return this.region().cloudFrontKeyValueStore();
   }
 
   /**

--- a/src/service/aws/sim-aws-region.ts
+++ b/src/service/aws/sim-aws-region.ts
@@ -3,6 +3,7 @@ import type { SimAwsAccountRegionContainer } from "./sim-aws-account-region-scop
 import { faker } from "@faker-js/faker";
 import type { SimS3 } from "../s3/sim-s3.js";
 import type { SimCloudFront } from "../cloudfront/sim-cloudfront.js";
+import type { SimCloudFrontKeyValueStoreApi } from "../cloudfront/sim-cloudfront-key-value-store.js";
 import type {
   SimDynamoDb as SimDynamoDatabase,
   SimDynamoDbStreams,
@@ -145,6 +146,13 @@ export class SimAwsRegion {
    */
   cloudFront(): SimCloudFront {
     return this.account().cloudFront();
+  }
+
+  /**
+   * Get the simulated CloudFront key value store data API.
+   */
+  cloudFrontKeyValueStore(): SimCloudFrontKeyValueStoreApi {
+    return this.account().cloudFrontKeyValueStore();
   }
 
   /**

--- a/src/service/aws/sim-aws-service-accessors.ts
+++ b/src/service/aws/sim-aws-service-accessors.ts
@@ -3,6 +3,7 @@ import type { SimAcm } from "../acm/sim-acm.js";
 import type { SimApiGatewayV2 } from "../apigatewayv2/index.js";
 import type { SimCloudFormation } from "../cloudformation/index.js";
 import type { SimCloudFront } from "../cloudfront/sim-cloudfront.js";
+import type { SimCloudFrontKeyValueStoreApi } from "../cloudfront/sim-cloudfront-key-value-store.js";
 import type { SimCognitoIdentityProvider } from "../cognito/index.js";
 import type {
   SimDynamoDb as SimDynamoDatabase,
@@ -52,6 +53,13 @@ export abstract class SimAwsServiceAccessors {
   /** Get simulated CloudFront in the default Account scope. */
   cloudFront(): SimCloudFront {
     return this.defaultAccountRegionScope().cloudFront();
+  }
+
+  /**
+   * Get the simulated CloudFront key value store data API.
+   */
+  cloudFrontKeyValueStore(): SimCloudFrontKeyValueStoreApi {
+    return this.defaultAccountRegionScope().cloudFrontKeyValueStore();
   }
 
   /** Get simulated Cognito user pools in the default Account Region scope. */

--- a/src/service/cloudfront/README.md
+++ b/src/service/cloudfront/README.md
@@ -40,8 +40,39 @@ Current command areas include:
 - `create-function/`
 - `delete-function/`
 
+## Key value stores
+
+`key-value-store/` holds the store model and the collaborators the commands share.
+
+The store is reached through two different AWS SDK clients, so it is reached two ways here. The
+CloudFront client owns the resource, and its five commands are under `command/key-value-store/`,
+grouped behind `SimCfKeyValueStoreCommands` and reached as `simCloudFront.keyValueStores()`. The key
+value store client owns the data, and its six commands are under `command/key-value-store-data/`,
+behind `SimCloudFrontKeyValueStoreApi` and reached as `simAws.cloudFrontKeyValueStore()`. Both work
+on the same `SimCloudFrontKeyValueStoreRegistry`, the way both AWS clients work on one store. This
+mirrors how sim DynamoDB Streams is a second API over sim DynamoDB's state rather than a service of
+its own.
+
+`DescribeKeyValueStore` is a command name both clients have, answering with different things. They
+do not collide because SDK interception resolves the router by the client's AWS service before it
+looks up the command name.
+
+`SimCfKeyValueStoreAccess` is what every command is given: the registry, IAM and the clock. Its
+`authorizedByName` resolves a store and authorizes the action on the store's ARN, and authorizes
+against the store wildcard first when the name resolves to nothing, so an unauthorized caller cannot
+learn which names exist.
+
+`SimCfKeyValueStoreUsers` decides whether a store can be deleted. Nothing can be associated with a
+store yet, so its default says nothing uses one. Associating a Function with a store is what will
+supply the real implementation.
+
+Unlike the Distribution commands, these enforce the `IfMatch` ETag rather than accepting and
+ignoring it. The data API requires it on every write and CloudFront refuses a stale one, so a caller
+that does not thread the ETag through fails here the way it would fail against CloudFront.
+
 The main `SimCloudFront` class owns the Distribution, Function and response headers policy maps
-and nothing else.
+and nothing else. The key value store registry is owned by `SimCloudFrontCommands` instead, because
+the facade never reads it.
 `SimCloudFrontCommands` holds the collaborators every command shares (IAM, the registry, the Origin
 resolvers, the background scheduler) and builds the handlers, so the facade stays state plus
 delegation.

--- a/src/service/cloudfront/command/key-value-store-data/sim-cf-key-value-store-data-command.types.ts
+++ b/src/service/cloudfront/command/key-value-store-data/sim-cf-key-value-store-data-command.types.ts
@@ -1,0 +1,123 @@
+/**
+ * Structural types for the commands on the key value store data client.
+ *
+ * These are the commands that read and write the keys. They are a separate AWS
+ * SDK client from CloudFront's own, and they address a store by ARN rather
+ * than by name. The commands that own the resource live beside them under
+ * `command/key-value-store/`.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/cloudfront-keyvaluestore/
+ */
+
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+
+/**
+ * What every write answers with: the store's new size and ETag.
+ */
+export interface SimCfKeyValueStoreWriteOutput {
+  readonly $metadata: SimResponseMetadata;
+  ItemCount: number;
+  TotalSizeInBytes: number;
+  ETag: string;
+}
+
+/**
+ * Minimal structural sim key value store DescribeKeyValueStore command.
+ */
+export interface SimKvsDescribeKeyValueStoreCommand {
+  readonly input: {
+    readonly KvsARN?: string | undefined;
+  };
+}
+
+/**
+ * Minimal structural sim key value store DescribeKeyValueStore output.
+ */
+export interface SimKvsDescribeKeyValueStoreCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+  KvsARN: string;
+  Created: Date;
+  LastModified: Date;
+  Status: string;
+  ItemCount: number;
+  TotalSizeInBytes: number;
+  ETag: string;
+}
+
+/**
+ * Minimal structural sim key value store GetKey command.
+ */
+export interface SimKvsGetKeyCommand {
+  readonly input: {
+    readonly KvsARN?: string | undefined;
+    readonly Key?: string | undefined;
+  };
+}
+
+/**
+ * Minimal structural sim key value store GetKey output.
+ */
+export interface SimKvsGetKeyCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+  Key: string;
+  Value: string;
+  ItemCount: number;
+  TotalSizeInBytes: number;
+}
+
+/**
+ * Minimal structural sim key value store PutKey command.
+ */
+export interface SimKvsPutKeyCommand {
+  readonly input: {
+    readonly KvsARN?: string | undefined;
+    readonly Key?: string | undefined;
+    readonly Value?: string | undefined;
+    readonly IfMatch?: string | undefined;
+  };
+}
+
+/**
+ * Minimal structural sim key value store DeleteKey command.
+ */
+export interface SimKvsDeleteKeyCommand {
+  readonly input: {
+    readonly KvsARN?: string | undefined;
+    readonly Key?: string | undefined;
+    readonly IfMatch?: string | undefined;
+  };
+}
+
+/**
+ * Minimal structural sim key value store ListKeys command.
+ */
+export interface SimKvsListKeysCommand {
+  readonly input: {
+    readonly KvsARN?: string | undefined;
+  };
+}
+
+/**
+ * Minimal structural sim key value store ListKeys output.
+ */
+export interface SimKvsListKeysCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+  Items: { Key: string; Value: string }[];
+}
+
+/**
+ * Minimal structural sim key value store UpdateKeys command.
+ */
+export interface SimKvsUpdateKeysCommand {
+  readonly input: {
+    readonly KvsARN?: string | undefined;
+    readonly IfMatch?: string | undefined;
+    // The SDK types a required member as `string | undefined`, so a batch
+    // entry has to be read as possibly missing its key or value even though
+    // neither is optional. Both are checked before the batch is applied.
+    readonly Puts?:
+      | readonly { Key: string | undefined; Value: string | undefined }[]
+      | undefined;
+    readonly Deletes?: readonly { Key: string | undefined }[] | undefined;
+  };
+}

--- a/src/service/cloudfront/command/key-value-store-data/sim-kvs-batch.ts
+++ b/src/service/cloudfront/command/key-value-store-data/sim-kvs-batch.ts
@@ -1,0 +1,45 @@
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type { SimKvsUpdateKeysCommand } from "./sim-cf-key-value-store-data-command.types.js";
+
+type UpdateKeysInput = SimKvsUpdateKeysCommand["input"];
+
+/**
+ * Read the puts out of an UpdateKeys batch, refusing an incomplete pair.
+ *
+ * The SDK types a batch entry's key and value as `string | undefined` even
+ * though both are required, so an entry missing either reaches here as a
+ * well-typed value. Refusing it is what stops a key being written as the string
+ * "undefined".
+ */
+export function kvsBatchPuts(
+  input: UpdateKeysInput,
+): readonly { Key: string; Value: string }[] {
+  return (input.Puts ?? []).map((put, index) => {
+    assertDefined(
+      put.Key,
+      `UpdateKeysCommand.input.Puts[${String(index)}].Key`,
+    );
+    assertDefined(
+      put.Value,
+      `UpdateKeysCommand.input.Puts[${String(index)}].Value`,
+    );
+
+    return { Key: put.Key, Value: put.Value };
+  });
+}
+
+/**
+ * Read the deletes out of an UpdateKeys batch, refusing one with no key.
+ */
+export function kvsBatchDeletes(
+  input: UpdateKeysInput,
+): readonly { Key: string }[] {
+  return (input.Deletes ?? []).map((remove, index) => {
+    assertDefined(
+      remove.Key,
+      `UpdateKeysCommand.input.Deletes[${String(index)}].Key`,
+    );
+
+    return { Key: remove.Key };
+  });
+}

--- a/src/service/cloudfront/command/key-value-store-data/sim-kvs-key-reads.ts
+++ b/src/service/cloudfront/command/key-value-store-data/sim-kvs-key-reads.ts
@@ -110,7 +110,7 @@ export class SimKvsKeyReads {
       Status: store.status,
       ItemCount: store.keys.itemCount,
       TotalSizeInBytes: store.keys.totalSizeInBytes,
-      ETag: store.eTag,
+      ETag: store.dataETag,
     };
   }
 }

--- a/src/service/cloudfront/command/key-value-store-data/sim-kvs-key-reads.ts
+++ b/src/service/cloudfront/command/key-value-store-data/sim-kvs-key-reads.ts
@@ -1,0 +1,116 @@
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimCfKeyValueStoreAccess } from "../../key-value-store/sim-cf-key-value-store-access.js";
+import type {
+  SimKvsDescribeKeyValueStoreCommand,
+  SimKvsDescribeKeyValueStoreCommandOutput,
+  SimKvsGetKeyCommand,
+  SimKvsGetKeyCommandOutput,
+  SimKvsListKeysCommand,
+  SimKvsListKeysCommandOutput,
+} from "./sim-cf-key-value-store-data-command.types.js";
+
+interface ReadOptions {
+  readonly caller?: SimAwsCaller;
+}
+
+/**
+ * The commands that read a key value store without changing it.
+ *
+ * None of them take an IfMatch, since nothing is being overwritten.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/cloudfront-keyvaluestore/
+ */
+export class SimKvsKeyReads {
+  private static readonly getAction = "cloudfront-keyvaluestore:GetKey";
+  private static readonly listAction = "cloudfront-keyvaluestore:ListKeys";
+  private static readonly describeAction =
+    "cloudfront-keyvaluestore:DescribeKeyValueStore";
+
+  constructor(private readonly access: SimCfKeyValueStoreAccess) {}
+
+  /**
+   * Read one key, refusing one the store does not hold.
+   */
+  async getKey(
+    command: SimKvsGetKeyCommand,
+    options?: ReadOptions,
+  ): Promise<SimKvsGetKeyCommandOutput> {
+    assertDefined(command.input.KvsARN, "GetKeyCommand.input.KvsARN");
+    assertDefined(command.input.Key, "GetKeyCommand.input.Key");
+
+    await this.access.background.sequence();
+
+    const store = this.access.authorizedByArn(
+      SimKvsKeyReads.getAction,
+      command.input.KvsARN,
+      options?.caller,
+    );
+
+    return {
+      $metadata: {},
+      Key: command.input.Key,
+      Value: store.keys.get(command.input.Key),
+      ItemCount: store.keys.itemCount,
+      TotalSizeInBytes: store.keys.totalSizeInBytes,
+    };
+  }
+
+  /**
+   * List every key and value the store holds.
+   */
+  async listKeys(
+    command: SimKvsListKeysCommand,
+    options?: ReadOptions,
+  ): Promise<SimKvsListKeysCommandOutput> {
+    assertDefined(command.input.KvsARN, "ListKeysCommand.input.KvsARN");
+
+    await this.access.background.sequence();
+
+    const store = this.access.authorizedByArn(
+      SimKvsKeyReads.listAction,
+      command.input.KvsARN,
+      options?.caller,
+    );
+
+    return {
+      $metadata: {},
+      Items: store.listKeys().map((pair) => ({ ...pair })),
+    };
+  }
+
+  /**
+   * Describe the store's data: how much of it there is, and its status.
+   *
+   * The CloudFront client has a command of this name too, answering with the
+   * resource rather than the data.
+   */
+  async describeKeyValueStore(
+    command: SimKvsDescribeKeyValueStoreCommand,
+    options?: ReadOptions,
+  ): Promise<SimKvsDescribeKeyValueStoreCommandOutput> {
+    assertDefined(
+      command.input.KvsARN,
+      "DescribeKeyValueStoreCommand.input.KvsARN",
+    );
+
+    await this.access.background.sequence();
+
+    const store = this.access.authorizedByArn(
+      SimKvsKeyReads.describeAction,
+      command.input.KvsARN,
+      options?.caller,
+    );
+
+    return {
+      $metadata: {},
+      KvsARN: store.arn,
+      Created: store.createdTime,
+      LastModified: store.lastModifiedTime,
+      Status: store.status,
+      ItemCount: store.keys.itemCount,
+      TotalSizeInBytes: store.keys.totalSizeInBytes,
+      ETag: store.eTag,
+    };
+  }
+}

--- a/src/service/cloudfront/command/key-value-store-data/sim-kvs-key-writes.ts
+++ b/src/service/cloudfront/command/key-value-store-data/sim-kvs-key-writes.ts
@@ -1,0 +1,137 @@
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimCfKeyValueStoreAccess } from "../../key-value-store/sim-cf-key-value-store-access.js";
+import type {
+  SimCfKeyValueStoreWriteOutput,
+  SimKvsDeleteKeyCommand,
+  SimKvsPutKeyCommand,
+  SimKvsUpdateKeysCommand,
+} from "./sim-cf-key-value-store-data-command.types.js";
+import { kvsBatchDeletes, kvsBatchPuts } from "./sim-kvs-batch.js";
+
+interface WriteOptions {
+  readonly caller?: SimAwsCaller;
+}
+
+/**
+ * One write, whichever command asked for it.
+ */
+interface KeyValueStoreWrite {
+  readonly action: string;
+  readonly KvsARN?: string | undefined;
+  readonly IfMatch?: string | undefined;
+  readonly puts: readonly { Key: string; Value: string }[];
+  readonly deletes: readonly { Key: string }[];
+}
+
+/**
+ * The three commands that write keys: PutKey, DeleteKey and UpdateKeys.
+ *
+ * They are one class because they are the same operation three ways: a batch
+ * of puts and deletes against a store, checked against its ETag. PutKey is a
+ * batch of one put and DeleteKey a batch of one delete, so each only has to say
+ * what its batch is.
+ *
+ * IfMatch is required on all three, as it is in the real data API, and a stale
+ * one is refused rather than accepted. A caller therefore has to read the
+ * current ETag before each write, which is what writing against CloudFront
+ * involves.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/cloudfront-keyvaluestore/
+ */
+export class SimKvsKeyWrites {
+  constructor(private readonly access: SimCfKeyValueStoreAccess) {}
+
+  /**
+   * Write one key.
+   */
+  async putKey(
+    command: SimKvsPutKeyCommand,
+    options?: WriteOptions,
+  ): Promise<SimCfKeyValueStoreWriteOutput> {
+    assertDefined(command.input.Key, "PutKeyCommand.input.Key");
+    assertDefined(command.input.Value, "PutKeyCommand.input.Value");
+
+    return await this.write(
+      {
+        action: "cloudfront-keyvaluestore:PutKey",
+        KvsARN: command.input.KvsARN,
+        IfMatch: command.input.IfMatch,
+        puts: [{ Key: command.input.Key, Value: command.input.Value }],
+        deletes: [],
+      },
+      options,
+    );
+  }
+
+  /**
+   * Forget one key.
+   */
+  async deleteKey(
+    command: SimKvsDeleteKeyCommand,
+    options?: WriteOptions,
+  ): Promise<SimCfKeyValueStoreWriteOutput> {
+    assertDefined(command.input.Key, "DeleteKeyCommand.input.Key");
+
+    return await this.write(
+      {
+        action: "cloudfront-keyvaluestore:DeleteKey",
+        KvsARN: command.input.KvsARN,
+        IfMatch: command.input.IfMatch,
+        puts: [],
+        deletes: [{ Key: command.input.Key }],
+      },
+      options,
+    );
+  }
+
+  /**
+   * Apply a batch of puts and deletes together.
+   */
+  async updateKeys(
+    command: SimKvsUpdateKeysCommand,
+    options?: WriteOptions,
+  ): Promise<SimCfKeyValueStoreWriteOutput> {
+    return await this.write(
+      {
+        action: "cloudfront-keyvaluestore:UpdateKeys",
+        KvsARN: command.input.KvsARN,
+        IfMatch: command.input.IfMatch,
+        puts: kvsBatchPuts(command.input),
+        deletes: kvsBatchDeletes(command.input),
+      },
+      options,
+    );
+  }
+
+  /**
+   * Resolve, authorize, check the ETag, apply the batch and report the size.
+   */
+  private async write(
+    write: KeyValueStoreWrite,
+    options: WriteOptions | undefined,
+  ): Promise<SimCfKeyValueStoreWriteOutput> {
+    assertDefined(write.KvsARN, "key value store write input KvsARN");
+    assertDefined(write.IfMatch, "key value store write input IfMatch");
+
+    await this.access.background.sequence();
+
+    const store = this.access.authorizedByArn(
+      write.action,
+      write.KvsARN,
+      options?.caller,
+    );
+
+    store.assertETag(write.IfMatch);
+
+    store.keys.applyBatch(write.puts, write.deletes);
+    store.touch(this.access.background.now());
+
+    return {
+      $metadata: {},
+      ItemCount: store.keys.itemCount,
+      TotalSizeInBytes: store.keys.totalSizeInBytes,
+      ETag: store.eTag,
+    };
+  }
+}

--- a/src/service/cloudfront/command/key-value-store-data/sim-kvs-key-writes.ts
+++ b/src/service/cloudfront/command/key-value-store-data/sim-kvs-key-writes.ts
@@ -122,16 +122,16 @@ export class SimKvsKeyWrites {
       options?.caller,
     );
 
-    store.assertETag(write.IfMatch);
+    store.assertDataETag(write.IfMatch);
 
     store.keys.applyBatch(write.puts, write.deletes);
-    store.touch(this.access.background.now());
+    store.touchData(this.access.background.now());
 
     return {
       $metadata: {},
       ItemCount: store.keys.itemCount,
       TotalSizeInBytes: store.keys.totalSizeInBytes,
-      ETag: store.eTag,
+      ETag: store.dataETag,
     };
   }
 }

--- a/src/service/cloudfront/command/key-value-store-data/sim-kvs-keys.iso.test.ts
+++ b/src/service/cloudfront/command/key-value-store-data/sim-kvs-keys.iso.test.ts
@@ -1,0 +1,363 @@
+import { CreateKeyValueStoreCommand } from "@aws-sdk/client-cloudfront";
+import {
+  DeleteKeyCommand,
+  DescribeKeyValueStoreCommand,
+  GetKeyCommand,
+  ListKeysCommand,
+  PutKeyCommand,
+  UpdateKeysCommand,
+} from "@aws-sdk/client-cloudfront-keyvaluestore";
+import {
+  assertArrayLength,
+  assertFalse,
+  assertIdentical,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import type { SimCloudFrontKeyValueStoreApi } from "../../sim-cloudfront-key-value-store.js";
+
+/**
+ * A key value store, and the data API over it, ready to write to.
+ */
+async function storeToWriteTo(): Promise<{
+  readonly data: SimCloudFrontKeyValueStoreApi;
+  readonly kvsArn: string;
+  readonly eTag: string;
+}> {
+  const simAws = new SimAws();
+  const created = await simAws
+    .cloudFront()
+    .keyValueStores()
+    .createKeyValueStore(new CreateKeyValueStoreCommand({ Name: "redirects" }));
+
+  return {
+    data: simAws.cloudFrontKeyValueStore(),
+    kvsArn: created.KeyValueStore.ARN,
+    eTag: created.ETag,
+  };
+}
+
+describe("CloudFront key value store data commands", () => {
+  it("reads back a key that was written", async () => {
+    // Given a key value store
+    const { data, kvsArn, eTag } = await storeToWriteTo();
+
+    // When a key is written and read back
+    await data.putKey(
+      new PutKeyCommand({
+        KvsARN: kvsArn,
+        Key: "/old",
+        Value: "/new",
+        IfMatch: eTag,
+      }),
+    );
+    const read = await data.getKey(
+      new GetKeyCommand({ KvsARN: kvsArn, Key: "/old" }),
+    );
+
+    // Then the value written is the value read, and the store reports its size
+    assertIdentical(read.Value, "/new");
+    assertIdentical(read.ItemCount, 1);
+    assertIdentical(read.TotalSizeInBytes, 8);
+  });
+
+  it("moves the ETag on with every write", async () => {
+    // Given a key value store with one key written to it
+    const { data, kvsArn, eTag } = await storeToWriteTo();
+    const first = await data.putKey(
+      new PutKeyCommand({
+        KvsARN: kvsArn,
+        Key: "a",
+        Value: "1",
+        IfMatch: eTag,
+      }),
+    );
+
+    // When a second key is written with the ETag the first write returned
+    const second = await data.putKey(
+      new PutKeyCommand({
+        KvsARN: kvsArn,
+        Key: "b",
+        Value: "2",
+        IfMatch: first.ETag,
+      }),
+    );
+
+    // Then it is accepted, and the ETag moved on again
+    assertIdentical(second.ItemCount, 2);
+    assertFalse(second.ETag === first.ETag);
+  });
+
+  it("refuses a write carrying a stale ETag", async () => {
+    // Given a key value store that has been written to once
+    const { data, kvsArn, eTag } = await storeToWriteTo();
+    await data.putKey(
+      new PutKeyCommand({
+        KvsARN: kvsArn,
+        Key: "a",
+        Value: "1",
+        IfMatch: eTag,
+      }),
+    );
+
+    // When a second write carries the ETag from before that write
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await data.putKey(
+          new PutKeyCommand({
+            KvsARN: kvsArn,
+            Key: "b",
+            Value: "2",
+            IfMatch: eTag,
+          }),
+        ),
+    );
+
+    // Then it is refused rather than overwriting the other writer
+    assertIdentical(error.name, "PreconditionFailed");
+  });
+
+  it("forgets a deleted key", async () => {
+    // Given a key value store with a key in it
+    const { data, kvsArn, eTag } = await storeToWriteTo();
+    const written = await data.putKey(
+      new PutKeyCommand({
+        KvsARN: kvsArn,
+        Key: "a",
+        Value: "1",
+        IfMatch: eTag,
+      }),
+    );
+
+    // When the key is deleted
+    const deleted = await data.deleteKey(
+      new DeleteKeyCommand({
+        KvsARN: kvsArn,
+        Key: "a",
+        IfMatch: written.ETag,
+      }),
+    );
+
+    // Then the store is empty
+    assertIdentical(deleted.ItemCount, 0);
+    assertIdentical(deleted.TotalSizeInBytes, 0);
+  });
+
+  it("refuses a read for a key that is not there", async () => {
+    // Given an empty key value store
+    const { data, kvsArn } = await storeToWriteTo();
+
+    // When a key that was never written is read
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await data.getKey(new GetKeyCommand({ KvsARN: kvsArn, Key: "nope" })),
+    );
+
+    // Then it is refused, as the data API refuses one
+    assertIdentical(error.name, "ResourceNotFoundException");
+  });
+
+  it("lists every key the store holds", async () => {
+    // Given a key value store with two keys
+    const { data, kvsArn, eTag } = await storeToWriteTo();
+    const written = await data.putKey(
+      new PutKeyCommand({
+        KvsARN: kvsArn,
+        Key: "a",
+        Value: "1",
+        IfMatch: eTag,
+      }),
+    );
+    await data.putKey(
+      new PutKeyCommand({
+        KvsARN: kvsArn,
+        Key: "b",
+        Value: "2",
+        IfMatch: written.ETag,
+      }),
+    );
+
+    // When the keys are listed
+    const listed = await data.listKeys(new ListKeysCommand({ KvsARN: kvsArn }));
+
+    // Then both are there with their values
+    assertArrayLength(listed.Items, 2);
+    assertIdentical(listed.Items[1].Key, "b");
+    assertIdentical(listed.Items[1].Value, "2");
+  });
+
+  it("applies a batch of puts and deletes together", async () => {
+    // Given a key value store holding a key that is about to go
+    const { data, kvsArn, eTag } = await storeToWriteTo();
+    const written = await data.putKey(
+      new PutKeyCommand({
+        KvsARN: kvsArn,
+        Key: "gone",
+        Value: "1",
+        IfMatch: eTag,
+      }),
+    );
+
+    // When a batch writes two keys and deletes that one
+    const updated = await data.updateKeys(
+      new UpdateKeysCommand({
+        KvsARN: kvsArn,
+        IfMatch: written.ETag,
+        Puts: [
+          { Key: "a", Value: "1" },
+          { Key: "b", Value: "2" },
+        ],
+        Deletes: [{ Key: "gone" }],
+      }),
+    );
+
+    // Then both writes and the delete landed in the one call
+    assertIdentical(updated.ItemCount, 2);
+
+    const listed = await data.listKeys(new ListKeysCommand({ KvsARN: kvsArn }));
+    assertArrayLength(listed.Items, 2);
+  });
+
+  it("deletes a key a batch both writes and deletes", async () => {
+    // Given a key value store
+    const { data, kvsArn, eTag } = await storeToWriteTo();
+
+    // When one batch both writes and deletes the same key
+    await data.updateKeys(
+      new UpdateKeysCommand({
+        KvsARN: kvsArn,
+        IfMatch: eTag,
+        Puts: [{ Key: "both", Value: "1" }],
+        Deletes: [{ Key: "both" }],
+      }),
+    );
+
+    // Then the delete is what stands, because the deletes land last
+    const listed = await data.listKeys(new ListKeysCommand({ KvsARN: kvsArn }));
+    assertArrayLength(listed.Items, 0);
+  });
+
+  it("applies a batch that carries neither puts nor deletes", async () => {
+    // Given a key value store
+    const { data, kvsArn, eTag } = await storeToWriteTo();
+
+    // When a batch arrives with nothing in it
+    const updated = await data.updateKeys(
+      new UpdateKeysCommand({ KvsARN: kvsArn, IfMatch: eTag }),
+    );
+
+    // Then it is accepted and changes nothing but the ETag
+    assertIdentical(updated.ItemCount, 0);
+    assertFalse(updated.ETag === eTag);
+  });
+
+  it("describes the data in the store", async () => {
+    // Given a key value store with a key in it
+    const { data, kvsArn, eTag } = await storeToWriteTo();
+    await data.putKey(
+      new PutKeyCommand({
+        KvsARN: kvsArn,
+        Key: "a",
+        Value: "1",
+        IfMatch: eTag,
+      }),
+    );
+
+    // When the store is described through the data API
+    const described = await data.describeKeyValueStore(
+      new DescribeKeyValueStoreCommand({ KvsARN: kvsArn }),
+    );
+
+    // Then it answers with the data rather than the resource, which is what
+    // this client's DescribeKeyValueStore does
+    assertIdentical(described.KvsARN, kvsArn);
+    assertIdentical(described.ItemCount, 1);
+    assertIdentical(described.TotalSizeInBytes, 2);
+    assertIdentical(described.Status, "PROVISIONING");
+  });
+
+  it("refuses a command naming a store that does not exist", async () => {
+    // Given a simulated key value store data API
+    const { data } = await storeToWriteTo();
+    const missing = "arn:aws:cloudfront::111111111111:key-value-store/nope";
+
+    // When a command names a store this Account does not hold
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await data.getKey(new GetKeyCommand({ KvsARN: missing, Key: "a" })),
+    );
+
+    // Then it is refused
+    assertIdentical(error.name, "EntityNotFound");
+  });
+
+  it("refuses a command that leaves out what the data API requires", async () => {
+    // Given a key value store
+    const { data, kvsArn, eTag } = await storeToWriteTo();
+
+    // When commands arrive without the ARN, key, value or ETag required.
+    // These go in as plain input rather than through the SDK command classes,
+    // whose own types make a missing required member unrepresentable. A
+    // JavaScript caller and an intercepted client can still send one.
+    // Then each is refused rather than being applied with a missing value
+    await Promise.all(
+      [
+        async (): Promise<unknown> => await data.getKey({ input: {} }),
+        async (): Promise<unknown> =>
+          await data.getKey({ input: { KvsARN: kvsArn } }),
+        async (): Promise<unknown> => await data.listKeys({ input: {} }),
+        async (): Promise<unknown> =>
+          await data.describeKeyValueStore({ input: {} }),
+        async (): Promise<unknown> =>
+          await data.putKey({ input: { KvsARN: kvsArn, Key: "a" } }),
+        async (): Promise<unknown> =>
+          await data.putKey({
+            input: { KvsARN: kvsArn, Key: "a", Value: "1" },
+          }),
+        async (): Promise<unknown> =>
+          await data.deleteKey({ input: { KvsARN: kvsArn, Key: "a" } }),
+        async (): Promise<unknown> =>
+          await data.updateKeys({ input: { IfMatch: eTag } }),
+      ].map(async (incomplete) => await assertThrowsErrorAsync(incomplete)),
+    );
+  });
+
+  it("refuses a batch entry with no key or no value", async () => {
+    // Given a key value store
+    const { data, kvsArn, eTag } = await storeToWriteTo();
+
+    // When a batch carries an entry missing its key or its value, which the
+    // SDK types allow because it marks a required member as possibly undefined
+    // Then it is refused rather than writing "undefined" as a key or a value
+    await Promise.all(
+      [
+        async (): Promise<unknown> =>
+          await data.updateKeys({
+            input: {
+              KvsARN: kvsArn,
+              IfMatch: eTag,
+              Puts: [{ Key: undefined, Value: "1" }],
+            },
+          }),
+        async (): Promise<unknown> =>
+          await data.updateKeys({
+            input: {
+              KvsARN: kvsArn,
+              IfMatch: eTag,
+              Puts: [{ Key: "a", Value: undefined }],
+            },
+          }),
+        async (): Promise<unknown> =>
+          await data.updateKeys({
+            input: {
+              KvsARN: kvsArn,
+              IfMatch: eTag,
+              Deletes: [{ Key: undefined }],
+            },
+          }),
+      ].map(async (incomplete) => await assertThrowsErrorAsync(incomplete)),
+    );
+  });
+});

--- a/src/service/cloudfront/command/key-value-store-data/sim-kvs-keys.iso.test.ts
+++ b/src/service/cloudfront/command/key-value-store-data/sim-kvs-keys.iso.test.ts
@@ -25,6 +25,7 @@ async function storeToWriteTo(): Promise<{
   readonly data: SimCloudFrontKeyValueStoreApi;
   readonly kvsArn: string;
   readonly eTag: string;
+  readonly resourceETag: string;
 }> {
   const simAws = new SimAws();
   const created = await simAws
@@ -32,10 +33,19 @@ async function storeToWriteTo(): Promise<{
     .keyValueStores()
     .createKeyValueStore(new CreateKeyValueStoreCommand({ Name: "redirects" }));
 
+  const data = simAws.cloudFrontKeyValueStore();
+
+  // The ETag a data write has to carry is this API's own, not the one the
+  // CloudFront client just returned. The two are not interchangeable.
+  const described = await data.describeKeyValueStore(
+    new DescribeKeyValueStoreCommand({ KvsARN: created.KeyValueStore.ARN }),
+  );
+
   return {
-    data: simAws.cloudFrontKeyValueStore(),
+    data,
     kvsArn: created.KeyValueStore.ARN,
-    eTag: created.ETag,
+    eTag: described.ETag,
+    resourceETag: created.ETag,
   };
 }
 
@@ -278,6 +288,27 @@ describe("CloudFront key value store data commands", () => {
     assertIdentical(described.Status, "PROVISIONING");
   });
 
+  it("refuses a data write carrying the CloudFront client's ETag", async () => {
+    // Given a store, and the ETag its CreateKeyValueStore returned
+    const { data, kvsArn, resourceETag } = await storeToWriteTo();
+
+    // When a key write carries that ETag rather than the data API's own
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await data.putKey(
+          new PutKeyCommand({
+            KvsARN: kvsArn,
+            Key: "a",
+            Value: "1",
+            IfMatch: resourceETag,
+          }),
+        ),
+    );
+
+    // Then it is refused, because the two ETags are not interchangeable
+    assertIdentical(error.name, "PreconditionFailed");
+  });
+
   it("refuses a command naming a store that does not exist", async () => {
     // Given a simulated key value store data API
     const { data } = await storeToWriteTo();
@@ -290,7 +321,7 @@ describe("CloudFront key value store data commands", () => {
     );
 
     // Then it is refused
-    assertIdentical(error.name, "EntityNotFound");
+    assertIdentical(error.name, "ResourceNotFoundException");
   });
 
   it("refuses a command that leaves out what the data API requires", async () => {

--- a/src/service/cloudfront/command/key-value-store/sim-cf-create-key-value-store.ts
+++ b/src/service/cloudfront/command/key-value-store/sim-cf-create-key-value-store.ts
@@ -1,0 +1,60 @@
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimCfKeyValueStoreAccess } from "../../key-value-store/sim-cf-key-value-store-access.js";
+import { SimCloudFrontKeyValueStore } from "../../key-value-store/sim-cf-key-value-store.js";
+import { simCfKeyValueStoreSummary } from "./sim-cf-key-value-store-summary.js";
+import type {
+  SimCreateKeyValueStoreCommand,
+  SimCreateKeyValueStoreCommandOutput,
+} from "./sim-cf-key-value-store-command.types.js";
+
+/**
+ * Simulated CloudFront CreateKeyValueStore command.
+ *
+ * A new store is PROVISIONING when the command returns and becomes READY in
+ * the background, which is what CloudFront does: the store exists immediately
+ * but is not servable until provisioning finishes.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/cloudfront/command/CreateKeyValueStoreCommand/
+ */
+export class SimCfCreateKeyValueStore {
+  private static readonly action = "cloudfront:CreateKeyValueStore";
+
+  constructor(private readonly access: SimCfKeyValueStoreAccess) {}
+
+  /**
+   * Create a sim CloudFront key value store.
+   */
+  async handle(
+    command: SimCreateKeyValueStoreCommand,
+    options?: { readonly caller?: SimAwsCaller },
+  ): Promise<SimCreateKeyValueStoreCommandOutput> {
+    assertDefined(command.input.Name, "CreateKeyValueStoreCommand.input.Name");
+
+    await this.access.background.sequence();
+
+    this.access.authorizeAnyStore(
+      SimCfCreateKeyValueStore.action,
+      options?.caller,
+    );
+
+    const store = new SimCloudFrontKeyValueStore({
+      name: command.input.Name,
+      comment: command.input.Comment,
+      accountId: this.access.accountId,
+      lastModifiedTime: this.access.background.now(),
+    });
+
+    this.access.stores.add(store);
+
+    // A new store becomes servable asynchronously, as in CloudFront.
+    this.access.background.schedule(() => store.ready());
+
+    return {
+      $metadata: {},
+      KeyValueStore: simCfKeyValueStoreSummary(store),
+      ETag: store.eTag,
+      Location: `https://cloudfront.amazonaws.com/2020-05-31/key-value-store/${store.id}`,
+    };
+  }
+}

--- a/src/service/cloudfront/command/key-value-store/sim-cf-create-key-value-store.ts
+++ b/src/service/cloudfront/command/key-value-store/sim-cf-create-key-value-store.ts
@@ -53,7 +53,7 @@ export class SimCfCreateKeyValueStore {
     return {
       $metadata: {},
       KeyValueStore: simCfKeyValueStoreSummary(store),
-      ETag: store.eTag,
+      ETag: store.resourceETag,
       Location: `https://cloudfront.amazonaws.com/2020-05-31/key-value-store/${store.id}`,
     };
   }

--- a/src/service/cloudfront/command/key-value-store/sim-cf-delete-key-value-store.ts
+++ b/src/service/cloudfront/command/key-value-store/sim-cf-delete-key-value-store.ts
@@ -43,7 +43,7 @@ export class SimCfDeleteKeyValueStore {
       options?.caller,
     );
 
-    store.assertETag(command.input.IfMatch);
+    store.assertResourceETag(command.input.IfMatch);
     this.assertNotInUse(store.id, store.name);
 
     this.access.stores.remove(store.id);

--- a/src/service/cloudfront/command/key-value-store/sim-cf-delete-key-value-store.ts
+++ b/src/service/cloudfront/command/key-value-store/sim-cf-delete-key-value-store.ts
@@ -1,0 +1,70 @@
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import { SimCloudFrontCannotDeleteEntityWhileInUse } from "../../error/sim-cloudfront.error.js";
+import type { SimCfKeyValueStoreAccess } from "../../key-value-store/sim-cf-key-value-store-access.js";
+import type { SimCloudFrontKeyValueStoreId } from "../../key-value-store/sim-cf-key-value-store.js";
+import type { SimCfKeyValueStoreUsers } from "../../key-value-store/sim-cf-key-value-store-users.js";
+import type {
+  SimDeleteKeyValueStoreCommand,
+  SimDeleteKeyValueStoreCommandOutput,
+} from "./sim-cf-key-value-store-command.types.js";
+
+/**
+ * Simulated CloudFront DeleteKeyValueStore command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/cloudfront/command/DeleteKeyValueStoreCommand/
+ */
+export class SimCfDeleteKeyValueStore {
+  private static readonly action = "cloudfront:DeleteKeyValueStore";
+
+  constructor(
+    private readonly access: SimCfKeyValueStoreAccess,
+    private readonly users: SimCfKeyValueStoreUsers,
+  ) {}
+
+  /**
+   * Delete a sim CloudFront key value store.
+   */
+  async handle(
+    command: SimDeleteKeyValueStoreCommand,
+    options?: { readonly caller?: SimAwsCaller },
+  ): Promise<SimDeleteKeyValueStoreCommandOutput> {
+    assertDefined(command.input.Name, "DeleteKeyValueStoreCommand.input.Name");
+    assertDefined(
+      command.input.IfMatch,
+      "DeleteKeyValueStoreCommand.input.IfMatch",
+    );
+
+    await this.access.background.sequence();
+
+    const store = this.access.authorizedByName(
+      SimCfDeleteKeyValueStore.action,
+      command.input.Name,
+      options?.caller,
+    );
+
+    store.assertETag(command.input.IfMatch);
+    this.assertNotInUse(store.id, store.name);
+
+    this.access.stores.remove(store.id);
+
+    return { $metadata: {} };
+  }
+
+  /**
+   * CloudFront will not delete a store a Function is still associated with.
+   */
+  private assertNotInUse(
+    storeId: SimCloudFrontKeyValueStoreId,
+    storeName: string,
+  ): void {
+    const functions = this.users.functionsUsing(storeId);
+
+    if (functions.length > 0) {
+      throw new SimCloudFrontCannotDeleteEntityWhileInUse(
+        `Sim CloudFront key value store ${storeName} is still associated with ` +
+          `CloudFront Function ${functions.join(", ")}`,
+      );
+    }
+  }
+}

--- a/src/service/cloudfront/command/key-value-store/sim-cf-describe-key-value-store.ts
+++ b/src/service/cloudfront/command/key-value-store/sim-cf-describe-key-value-store.ts
@@ -44,7 +44,7 @@ export class SimCfDescribeKeyValueStore {
     return {
       $metadata: {},
       KeyValueStore: simCfKeyValueStoreSummary(store),
-      ETag: store.eTag,
+      ETag: store.resourceETag,
     };
   }
 }

--- a/src/service/cloudfront/command/key-value-store/sim-cf-describe-key-value-store.ts
+++ b/src/service/cloudfront/command/key-value-store/sim-cf-describe-key-value-store.ts
@@ -1,0 +1,50 @@
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimCfKeyValueStoreAccess } from "../../key-value-store/sim-cf-key-value-store-access.js";
+import { simCfKeyValueStoreSummary } from "./sim-cf-key-value-store-summary.js";
+import type {
+  SimDescribeKeyValueStoreCommand,
+  SimDescribeKeyValueStoreCommandOutput,
+} from "./sim-cf-key-value-store-command.types.js";
+
+/**
+ * Simulated CloudFront DescribeKeyValueStore command.
+ *
+ * This is the CloudFront client's describe, which answers with the resource
+ * and its ETag. The key value store client has a command of the same name that
+ * answers with the data instead: item count, size and status.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/cloudfront/command/DescribeKeyValueStoreCommand/
+ */
+export class SimCfDescribeKeyValueStore {
+  private static readonly action = "cloudfront:DescribeKeyValueStore";
+
+  constructor(private readonly access: SimCfKeyValueStoreAccess) {}
+
+  /**
+   * Describe a sim CloudFront key value store.
+   */
+  async handle(
+    command: SimDescribeKeyValueStoreCommand,
+    options?: { readonly caller?: SimAwsCaller },
+  ): Promise<SimDescribeKeyValueStoreCommandOutput> {
+    assertDefined(
+      command.input.Name,
+      "DescribeKeyValueStoreCommand.input.Name",
+    );
+
+    await this.access.background.sequence();
+
+    const store = this.access.authorizedByName(
+      SimCfDescribeKeyValueStore.action,
+      command.input.Name,
+      options?.caller,
+    );
+
+    return {
+      $metadata: {},
+      KeyValueStore: simCfKeyValueStoreSummary(store),
+      ETag: store.eTag,
+    };
+  }
+}

--- a/src/service/cloudfront/command/key-value-store/sim-cf-key-value-store-command.types.ts
+++ b/src/service/cloudfront/command/key-value-store/sim-cf-key-value-store-command.types.ts
@@ -1,0 +1,120 @@
+/**
+ * Structural types for the key value store commands on the CloudFront client.
+ *
+ * These are the commands that own the resource. They address a store by name,
+ * which is what the CloudFront client takes. The commands that read and write
+ * the keys are a separate client addressing a store by ARN, and their types
+ * live beside them under `command/key-value-store-data/`.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/cloudfront/
+ */
+
+import type { SimArn } from "../../../aws/arn.js";
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+
+/**
+ * Minimal structural sim CloudFront key value store summary.
+ */
+export interface SimCfKeyValueStoreSummary {
+  Id: string;
+  Name: string;
+  Comment: string | undefined;
+  ARN: SimArn;
+  Status: string;
+  LastModifiedTime: Date;
+}
+
+/**
+ * Minimal structural sim CloudFront CreateKeyValueStore command.
+ */
+export interface SimCreateKeyValueStoreCommand {
+  readonly input: {
+    readonly Name?: string | undefined;
+    readonly Comment?: string | undefined;
+  };
+}
+
+/**
+ * Minimal structural sim CloudFront CreateKeyValueStore output.
+ */
+export interface SimCreateKeyValueStoreCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+  KeyValueStore: SimCfKeyValueStoreSummary;
+  ETag: string;
+  Location: string;
+}
+
+/**
+ * Minimal structural sim CloudFront DescribeKeyValueStore command.
+ */
+export interface SimDescribeKeyValueStoreCommand {
+  readonly input: {
+    readonly Name?: string | undefined;
+  };
+}
+
+/**
+ * Minimal structural sim CloudFront DescribeKeyValueStore output.
+ */
+export interface SimDescribeKeyValueStoreCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+  KeyValueStore: SimCfKeyValueStoreSummary;
+  ETag: string;
+}
+
+/**
+ * Minimal structural sim CloudFront ListKeyValueStores command.
+ */
+export interface SimListKeyValueStoresCommand {
+  readonly input: {
+    readonly Status?: string | undefined;
+  };
+}
+
+/**
+ * Minimal structural sim CloudFront ListKeyValueStores output.
+ */
+export interface SimListKeyValueStoresCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+  KeyValueStoreList: {
+    Quantity: number;
+    Items: SimCfKeyValueStoreSummary[];
+  };
+}
+
+/**
+ * Minimal structural sim CloudFront UpdateKeyValueStore command.
+ */
+export interface SimUpdateKeyValueStoreCommand {
+  readonly input: {
+    readonly Name?: string | undefined;
+    readonly Comment?: string | undefined;
+    readonly IfMatch?: string | undefined;
+  };
+}
+
+/**
+ * Minimal structural sim CloudFront UpdateKeyValueStore output.
+ */
+export interface SimUpdateKeyValueStoreCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+  KeyValueStore: SimCfKeyValueStoreSummary;
+  ETag: string;
+}
+
+/**
+ * Minimal structural sim CloudFront DeleteKeyValueStore command.
+ */
+export interface SimDeleteKeyValueStoreCommand {
+  readonly input: {
+    readonly Name?: string | undefined;
+    readonly IfMatch?: string | undefined;
+  };
+}
+
+/**
+ * Minimal structural sim CloudFront DeleteKeyValueStore output.
+ */
+export interface SimDeleteKeyValueStoreCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/cloudfront/command/key-value-store/sim-cf-key-value-store-commands.iso.test.ts
+++ b/src/service/cloudfront/command/key-value-store/sim-cf-key-value-store-commands.iso.test.ts
@@ -1,0 +1,149 @@
+import {
+  CreateKeyValueStoreCommand,
+  DeleteKeyValueStoreCommand,
+  DescribeKeyValueStoreCommand,
+  ListKeyValueStoresCommand,
+  UpdateKeyValueStoreCommand,
+} from "@aws-sdk/client-cloudfront";
+import {
+  assertArrayLength,
+  assertFalse,
+  assertIdentical,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+
+describe("CloudFront key value store commands", () => {
+  it("creates a key value store that provisions in the background", async () => {
+    // Given a simulated CloudFront
+    const simAws = new SimAws();
+    const stores = simAws.cloudFront().keyValueStores();
+
+    // When a key value store is created
+    const created = await stores.createKeyValueStore(
+      new CreateKeyValueStoreCommand({
+        Name: "redirects",
+        Comment: "Where old paths go",
+      }),
+    );
+
+    // Then it exists straight away, and is not servable yet
+    assertIdentical(created.KeyValueStore.Name, "redirects");
+    assertIdentical(created.KeyValueStore.Comment, "Where old paths go");
+    assertIdentical(created.KeyValueStore.Status, "PROVISIONING");
+    assertIdentical(
+      created.KeyValueStore.ARN,
+      `arn:aws:cloudfront::${simAws.account().accountId}:key-value-store/${created.KeyValueStore.Id}`,
+    );
+
+    // And it becomes READY once provisioning finishes
+    await simAws.backgroundTasksComplete();
+    assertIdentical(stores.byName("redirects")?.status, "READY");
+  });
+
+  it("describes a key value store by name", async () => {
+    // Given a key value store
+    const simAws = new SimAws();
+    const stores = simAws.cloudFront().keyValueStores();
+    const created = await stores.createKeyValueStore(
+      new CreateKeyValueStoreCommand({ Name: "redirects" }),
+    );
+
+    // When it is described
+    const described = await stores.describeKeyValueStore(
+      new DescribeKeyValueStoreCommand({ Name: "redirects" }),
+    );
+
+    // Then the same store comes back, with the ETag a write has to match
+    assertIdentical(described.KeyValueStore.Id, created.KeyValueStore.Id);
+    assertIdentical(described.ETag, created.ETag);
+  });
+
+  it("lists the key value stores this Account holds", async () => {
+    // Given two key value stores
+    const simAws = new SimAws();
+    const stores = simAws.cloudFront().keyValueStores();
+    await stores.createKeyValueStore(
+      new CreateKeyValueStoreCommand({ Name: "redirects" }),
+    );
+    await stores.createKeyValueStore(
+      new CreateKeyValueStoreCommand({ Name: "flags" }),
+    );
+
+    // When they are listed
+    const listed = await stores.listKeyValueStores(
+      new ListKeyValueStoresCommand({}),
+    );
+
+    // Then both are there, counted the way CloudFront counts them
+    assertIdentical(listed.KeyValueStoreList.Quantity, 2);
+    assertArrayLength(listed.KeyValueStoreList.Items, 2);
+  });
+
+  it("lists only the key value stores in a requested status", async () => {
+    // Given one provisioned store and one still provisioning
+    const simAws = new SimAws();
+    const stores = simAws.cloudFront().keyValueStores();
+    await stores.createKeyValueStore(
+      new CreateKeyValueStoreCommand({ Name: "ready-one" }),
+    );
+    await simAws.backgroundTasksComplete();
+    await stores.createKeyValueStore(
+      new CreateKeyValueStoreCommand({ Name: "provisioning-one" }),
+    );
+
+    // When only the ready ones are listed
+    const listed = await stores.listKeyValueStores(
+      new ListKeyValueStoresCommand({ Status: "READY" }),
+    );
+
+    // Then the one still provisioning is left out
+    assertArrayLength(listed.KeyValueStoreList.Items, 1);
+    assertIdentical(listed.KeyValueStoreList.Items[0].Name, "ready-one");
+  });
+
+  it("updates a key value store's comment against its ETag", async () => {
+    // Given a key value store with a comment
+    const simAws = new SimAws();
+    const stores = simAws.cloudFront().keyValueStores();
+    const created = await stores.createKeyValueStore(
+      new CreateKeyValueStoreCommand({ Name: "redirects", Comment: "first" }),
+    );
+
+    // When the comment is updated with the current ETag
+    const updated = await stores.updateKeyValueStore(
+      new UpdateKeyValueStoreCommand({
+        Name: "redirects",
+        Comment: "second",
+        IfMatch: created.ETag,
+      }),
+    );
+
+    // Then the comment changed, and the ETag moved on with it
+    assertIdentical(updated.KeyValueStore.Comment, "second");
+    assertFalse(updated.ETag === created.ETag);
+  });
+
+  it("deletes a key value store against its ETag", async () => {
+    // Given a key value store
+    const simAws = new SimAws();
+    const stores = simAws.cloudFront().keyValueStores();
+    const created = await stores.createKeyValueStore(
+      new CreateKeyValueStoreCommand({ Name: "redirects" }),
+    );
+
+    // When it is deleted with the current ETag
+    await stores.deleteKeyValueStore(
+      new DeleteKeyValueStoreCommand({
+        Name: "redirects",
+        IfMatch: created.ETag,
+      }),
+    );
+
+    // Then it is gone
+    assertUndefined(stores.byName("redirects"));
+    assertUndefined(stores.byId(created.KeyValueStore.Id));
+  });
+});

--- a/src/service/cloudfront/command/key-value-store/sim-cf-key-value-store-failures.iso.test.ts
+++ b/src/service/cloudfront/command/key-value-store/sim-cf-key-value-store-failures.iso.test.ts
@@ -1,0 +1,154 @@
+import {
+  CreateKeyValueStoreCommand,
+  DeleteKeyValueStoreCommand,
+  DescribeKeyValueStoreCommand,
+  UpdateKeyValueStoreCommand,
+} from "@aws-sdk/client-cloudfront";
+import { assertIdentical, assertThrowsErrorAsync } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import type { SimCfKeyValueStoreCommands } from "../../key-value-store/sim-cf-key-value-store-commands.js";
+
+async function storesWithRedirects(): Promise<{
+  readonly stores: SimCfKeyValueStoreCommands;
+  readonly eTag: string;
+}> {
+  const stores = new SimAws().cloudFront().keyValueStores();
+  const created = await stores.createKeyValueStore(
+    new CreateKeyValueStoreCommand({ Name: "redirects" }),
+  );
+
+  return { stores, eTag: created.ETag };
+}
+
+describe("CloudFront key value store command failures", () => {
+  it("refuses a second key value store claiming a name", async () => {
+    // Given a key value store called redirects
+    const { stores } = await storesWithRedirects();
+
+    // When another store claims that name
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await stores.createKeyValueStore(
+          new CreateKeyValueStoreCommand({ Name: "redirects" }),
+        ),
+    );
+
+    // Then it is refused, as CloudFront refuses one
+    assertIdentical(error.name, "EntityAlreadyExists");
+  });
+
+  it("refuses a describe for a name no key value store holds", async () => {
+    // Given a simulated CloudFront with no stores
+    const stores = new SimAws().cloudFront().keyValueStores();
+
+    // When a store that does not exist is described
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await stores.describeKeyValueStore(
+          new DescribeKeyValueStoreCommand({ Name: "missing" }),
+        ),
+    );
+
+    // Then it is refused
+    assertIdentical(error.name, "EntityNotFound");
+  });
+
+  it("refuses an update carrying a stale ETag", async () => {
+    // Given a key value store that has changed since its ETag was read
+    const { stores, eTag } = await storesWithRedirects();
+    await stores.updateKeyValueStore(
+      new UpdateKeyValueStoreCommand({
+        Name: "redirects",
+        Comment: "moved on",
+        IfMatch: eTag,
+      }),
+    );
+
+    // When a second update carries the ETag from before that change
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await stores.updateKeyValueStore(
+          new UpdateKeyValueStoreCommand({
+            Name: "redirects",
+            Comment: "too late",
+            IfMatch: eTag,
+          }),
+        ),
+    );
+
+    // Then it is refused rather than overwriting the other write
+    assertIdentical(error.name, "PreconditionFailed");
+    assertIdentical(stores.byName("redirects")?.comment, "moved on");
+  });
+
+  it("refuses a delete carrying a stale ETag", async () => {
+    // Given a key value store that has changed since its ETag was read
+    const { stores, eTag } = await storesWithRedirects();
+    await stores.updateKeyValueStore(
+      new UpdateKeyValueStoreCommand({
+        Name: "redirects",
+        Comment: "moved on",
+        IfMatch: eTag,
+      }),
+    );
+
+    // When a delete carries the ETag from before that change
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await stores.deleteKeyValueStore(
+          new DeleteKeyValueStoreCommand({
+            Name: "redirects",
+            IfMatch: eTag,
+          }),
+        ),
+    );
+
+    // Then it is refused and the store is still there
+    assertIdentical(error.name, "PreconditionFailed");
+    assertIdentical(stores.byName("redirects")?.name, "redirects");
+  });
+
+  it("refuses a delete for a name no key value store holds", async () => {
+    // Given a simulated CloudFront with no stores
+    const stores = new SimAws().cloudFront().keyValueStores();
+
+    // When a store that does not exist is deleted
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await stores.deleteKeyValueStore(
+          new DeleteKeyValueStoreCommand({
+            Name: "missing",
+            IfMatch: "E1111111111111",
+          }),
+        ),
+    );
+
+    // Then it is refused
+    assertIdentical(error.name, "EntityNotFound");
+  });
+
+  it("refuses a command that leaves out what CloudFront requires", async () => {
+    // Given a key value store
+    const { stores } = await storesWithRedirects();
+
+    // When commands arrive without the name or the ETag CloudFront requires.
+    // These go in as plain input rather than through the SDK command classes,
+    // whose own types make a missing required member unrepresentable. A
+    // JavaScript caller and an intercepted client can still send one.
+    // Then each is refused rather than being applied with a missing value
+    await Promise.all(
+      [
+        async (): Promise<unknown> =>
+          await stores.createKeyValueStore({ input: {} }),
+        async (): Promise<unknown> =>
+          await stores.describeKeyValueStore({ input: {} }),
+        async (): Promise<unknown> =>
+          await stores.updateKeyValueStore({ input: { Name: "redirects" } }),
+        async (): Promise<unknown> =>
+          await stores.deleteKeyValueStore({ input: { Name: "redirects" } }),
+      ].map(async (incomplete) => await assertThrowsErrorAsync(incomplete)),
+    );
+  });
+});

--- a/src/service/cloudfront/command/key-value-store/sim-cf-key-value-store-iam.iso.test.ts
+++ b/src/service/cloudfront/command/key-value-store/sim-cf-key-value-store-iam.iso.test.ts
@@ -1,5 +1,6 @@
 import { CreateKeyValueStoreCommand } from "@aws-sdk/client-cloudfront";
 import {
+  DescribeKeyValueStoreCommand,
   GetKeyCommand,
   PutKeyCommand,
 } from "@aws-sdk/client-cloudfront-keyvaluestore";
@@ -148,6 +149,11 @@ describe("CloudFront key value store IAM authorization", () => {
     const data = simAws.account(accountId).cloudFrontKeyValueStore();
     const caller = { kind: "arn", arn: roleArn } as const;
 
+    // A data write carries this API's own ETag, not the CloudFront client's.
+    const described = await data.describeKeyValueStore(
+      new DescribeKeyValueStoreCommand({ KvsARN: created.KeyValueStore.ARN }),
+    );
+
     // When the Role writes a key
     const error = await assertThrowsErrorAsync(
       async () =>
@@ -156,7 +162,7 @@ describe("CloudFront key value store IAM authorization", () => {
             KvsARN: created.KeyValueStore.ARN,
             Key: "a",
             Value: "1",
-            IfMatch: created.ETag,
+            IfMatch: described.ETag,
           }),
           { caller },
         ),
@@ -173,7 +179,7 @@ describe("CloudFront key value store IAM authorization", () => {
           KvsARN: created.KeyValueStore.ARN,
           Key: "a",
           Value: "1",
-          IfMatch: created.ETag,
+          IfMatch: described.ETag,
         }),
       );
 

--- a/src/service/cloudfront/command/key-value-store/sim-cf-key-value-store-iam.iso.test.ts
+++ b/src/service/cloudfront/command/key-value-store/sim-cf-key-value-store-iam.iso.test.ts
@@ -1,0 +1,186 @@
+import { CreateKeyValueStoreCommand } from "@aws-sdk/client-cloudfront";
+import {
+  GetKeyCommand,
+  PutKeyCommand,
+} from "@aws-sdk/client-cloudfront-keyvaluestore";
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { makeSimAwsAccountId } from "../../../aws/sim-aws-account.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+import type { SimAwsAccountId } from "../../../aws/sim-aws-account.js";
+import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+
+/**
+ * A Role in the given Account, granted one policy statement.
+ */
+async function roleGranted(
+  simAws: SimAws,
+  accountId: SimAwsAccountId,
+  roleName: string,
+  statement: object,
+): Promise<string> {
+  const simIam = simAws.account(accountId).iam();
+  const roleCreation = await simIam.createRole(
+    new CreateRoleCommand({
+      RoleName: roleName,
+      AssumeRolePolicyDocument: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: {
+          Effect: "Allow",
+          Principal: { AWS: `arn:aws:iam::${accountId}:root` },
+          Action: "sts:AssumeRole",
+        },
+      }),
+    }),
+  );
+
+  await simIam.putRolePolicy(
+    new PutRolePolicyCommand({
+      RoleName: roleName,
+      PolicyName: "KeyValueStoreAccess",
+      PolicyDocument: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: statement,
+      }),
+    }),
+  );
+
+  return roleCreation.Role.Arn;
+}
+
+describe("CloudFront key value store IAM authorization", () => {
+  it("allows the default Account root caller", async () => {
+    // Given CloudFront in a known simulated AWS Account
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws();
+
+    // When a store is created without an explicit caller
+    const created = await simAws
+      .account(accountId)
+      .cloudFront()
+      .keyValueStores()
+      .createKeyValueStore(
+        new CreateKeyValueStoreCommand({ Name: "redirects" }),
+      );
+
+    // Then IAM defaults to Account root and CloudFront creates it
+    assertIdentical(
+      created.KeyValueStore.ARN,
+      `arn:aws:cloudfront::${accountId}:key-value-store/${created.KeyValueStore.Id}`,
+    );
+  });
+
+  it("allows a Role granted the create action on the store wildcard", async () => {
+    // Given a Role allowed to create any key value store, which is what a
+    // policy for this action has to say: the ID is not known before creation
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws();
+    const roleArn = await roleGranted(simAws, accountId, "StoreCreator", {
+      Effect: "Allow",
+      Action: "cloudfront:CreateKeyValueStore",
+      Resource: `arn:aws:cloudfront::${accountId}:key-value-store/*`,
+    });
+
+    // When the Role creates a store
+    const created = await simAws
+      .account(accountId)
+      .cloudFront()
+      .keyValueStores()
+      .createKeyValueStore(
+        new CreateKeyValueStoreCommand({ Name: "redirects" }),
+        { caller: { kind: "arn", arn: roleArn } },
+      );
+
+    // Then IAM permits it
+    assertIdentical(created.KeyValueStore.Name, "redirects");
+  });
+
+  it("denies a Role with no key value store permission", async () => {
+    // Given a Role allowed to create Functions but not stores
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws();
+    const roleArn = await roleGranted(simAws, accountId, "FunctionCreator", {
+      Effect: "Allow",
+      Action: "cloudfront:CreateFunction",
+      Resource: "*",
+    });
+
+    // When the Role tries to create a store
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await simAws
+          .account(accountId)
+          .cloudFront()
+          .keyValueStores()
+          .createKeyValueStore(
+            new CreateKeyValueStoreCommand({ Name: "redirects" }),
+            { caller: { kind: "arn", arn: roleArn } },
+          ),
+    );
+
+    // Then IAM refuses it
+    assertInstanceOf(error, SimIamAccessDenied);
+  });
+
+  it("denies a data API write to a Role granted only reads", async () => {
+    // Given a store, and a Role allowed to read it but not write to it
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws();
+    const created = await simAws
+      .account(accountId)
+      .cloudFront()
+      .keyValueStores()
+      .createKeyValueStore(
+        new CreateKeyValueStoreCommand({ Name: "redirects" }),
+      );
+    const roleArn = await roleGranted(simAws, accountId, "StoreReader", {
+      Effect: "Allow",
+      Action: "cloudfront-keyvaluestore:GetKey",
+      Resource: created.KeyValueStore.ARN,
+    });
+
+    const data = simAws.account(accountId).cloudFrontKeyValueStore();
+    const caller = { kind: "arn", arn: roleArn } as const;
+
+    // When the Role writes a key
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await data.putKey(
+          new PutKeyCommand({
+            KvsARN: created.KeyValueStore.ARN,
+            Key: "a",
+            Value: "1",
+            IfMatch: created.ETag,
+          }),
+          { caller },
+        ),
+    );
+
+    // Then the write is refused, while a read of the same store is not
+    assertInstanceOf(error, SimIamAccessDenied);
+
+    await simAws
+      .account(accountId)
+      .cloudFrontKeyValueStore()
+      .putKey(
+        new PutKeyCommand({
+          KvsARN: created.KeyValueStore.ARN,
+          Key: "a",
+          Value: "1",
+          IfMatch: created.ETag,
+        }),
+      );
+
+    const read = await data.getKey(
+      new GetKeyCommand({ KvsARN: created.KeyValueStore.ARN, Key: "a" }),
+      { caller },
+    );
+    assertIdentical(read.Value, "1");
+  });
+});

--- a/src/service/cloudfront/command/key-value-store/sim-cf-key-value-store-summary.ts
+++ b/src/service/cloudfront/command/key-value-store/sim-cf-key-value-store-summary.ts
@@ -1,0 +1,21 @@
+import type { SimCloudFrontKeyValueStore } from "../../key-value-store/sim-cf-key-value-store.js";
+import type { SimCfKeyValueStoreSummary } from "./sim-cf-key-value-store-command.types.js";
+
+/**
+ * Describe a key value store the way every CloudFront client command does.
+ *
+ * Create, Describe, List and Update all answer with the same summary shape, so
+ * it is built in one place rather than four.
+ */
+export function simCfKeyValueStoreSummary(
+  store: SimCloudFrontKeyValueStore,
+): SimCfKeyValueStoreSummary {
+  return {
+    Id: store.id,
+    Name: store.name,
+    Comment: store.comment,
+    ARN: store.arn,
+    Status: store.status,
+    LastModifiedTime: store.lastModifiedTime,
+  };
+}

--- a/src/service/cloudfront/command/key-value-store/sim-cf-list-key-value-stores.ts
+++ b/src/service/cloudfront/command/key-value-store/sim-cf-list-key-value-stores.ts
@@ -1,0 +1,48 @@
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimCfKeyValueStoreAccess } from "../../key-value-store/sim-cf-key-value-store-access.js";
+import { simCfKeyValueStoreSummary } from "./sim-cf-key-value-store-summary.js";
+import type {
+  SimListKeyValueStoresCommand,
+  SimListKeyValueStoresCommandOutput,
+} from "./sim-cf-key-value-store-command.types.js";
+
+/**
+ * Simulated CloudFront ListKeyValueStores command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/cloudfront/command/ListKeyValueStoresCommand/
+ */
+export class SimCfListKeyValueStores {
+  private static readonly action = "cloudfront:ListKeyValueStores";
+
+  constructor(private readonly access: SimCfKeyValueStoreAccess) {}
+
+  /**
+   * List this Account's sim CloudFront key value stores.
+   */
+  async handle(
+    command: SimListKeyValueStoresCommand,
+    options?: { readonly caller?: SimAwsCaller },
+  ): Promise<SimListKeyValueStoresCommandOutput> {
+    await this.access.background.sequence();
+
+    // Listing is authorized across the Account rather than per store, which is
+    // what a policy for this action grants.
+    this.access.authorizeAnyStore(
+      SimCfListKeyValueStores.action,
+      options?.caller,
+    );
+
+    const status = command.input.Status;
+    const stores = this.access.stores
+      .all()
+      .filter((store) => status === undefined || store.status === status);
+
+    return {
+      $metadata: {},
+      KeyValueStoreList: {
+        Quantity: stores.length,
+        Items: stores.map((store) => simCfKeyValueStoreSummary(store)),
+      },
+    };
+  }
+}

--- a/src/service/cloudfront/command/key-value-store/sim-cf-update-key-value-store.ts
+++ b/src/service/cloudfront/command/key-value-store/sim-cf-update-key-value-store.ts
@@ -1,0 +1,54 @@
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimCfKeyValueStoreAccess } from "../../key-value-store/sim-cf-key-value-store-access.js";
+import { simCfKeyValueStoreSummary } from "./sim-cf-key-value-store-summary.js";
+import type {
+  SimUpdateKeyValueStoreCommand,
+  SimUpdateKeyValueStoreCommandOutput,
+} from "./sim-cf-key-value-store-command.types.js";
+
+/**
+ * Simulated CloudFront UpdateKeyValueStore command.
+ *
+ * Only the comment can be changed. The name identifies the store in this API,
+ * so it is what the command looks the store up by rather than something the
+ * command can set.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/cloudfront/command/UpdateKeyValueStoreCommand/
+ */
+export class SimCfUpdateKeyValueStore {
+  private static readonly action = "cloudfront:UpdateKeyValueStore";
+
+  constructor(private readonly access: SimCfKeyValueStoreAccess) {}
+
+  /**
+   * Update a sim CloudFront key value store's comment.
+   */
+  async handle(
+    command: SimUpdateKeyValueStoreCommand,
+    options?: { readonly caller?: SimAwsCaller },
+  ): Promise<SimUpdateKeyValueStoreCommandOutput> {
+    assertDefined(command.input.Name, "UpdateKeyValueStoreCommand.input.Name");
+    assertDefined(
+      command.input.IfMatch,
+      "UpdateKeyValueStoreCommand.input.IfMatch",
+    );
+
+    await this.access.background.sequence();
+
+    const store = this.access.authorizedByName(
+      SimCfUpdateKeyValueStore.action,
+      command.input.Name,
+      options?.caller,
+    );
+
+    store.assertETag(command.input.IfMatch);
+    store.update({ comment: command.input.Comment });
+
+    return {
+      $metadata: {},
+      KeyValueStore: simCfKeyValueStoreSummary(store),
+      ETag: store.eTag,
+    };
+  }
+}

--- a/src/service/cloudfront/command/key-value-store/sim-cf-update-key-value-store.ts
+++ b/src/service/cloudfront/command/key-value-store/sim-cf-update-key-value-store.ts
@@ -42,13 +42,13 @@ export class SimCfUpdateKeyValueStore {
       options?.caller,
     );
 
-    store.assertETag(command.input.IfMatch);
+    store.assertResourceETag(command.input.IfMatch);
     store.update({ comment: command.input.Comment });
 
     return {
       $metadata: {},
       KeyValueStore: simCfKeyValueStoreSummary(store),
-      ETag: store.eTag,
+      ETag: store.resourceETag,
     };
   }
 }

--- a/src/service/cloudfront/error/sim-cloudfront.error.ts
+++ b/src/service/cloudfront/error/sim-cloudfront.error.ts
@@ -188,3 +188,75 @@ export class SimCloudFrontDistributionNotDisabled extends SimCloudFrontError {
     super(message, { httpStatusCode: 409 });
   }
 }
+
+/**
+ * Simulated CloudFront EntityAlreadyExists error.
+ *
+ * CloudFront requires a key value store name to be unique within an account,
+ * so a second store claiming a name is refused rather than created.
+ */
+export class SimCloudFrontEntityAlreadyExists extends SimCloudFrontError {
+  public override readonly name = "EntityAlreadyExists";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 409 });
+  }
+}
+
+/**
+ * Simulated CloudFront EntityNotFound error.
+ *
+ * What CloudFront answers when a key value store name, ID or ARN names
+ * nothing the account holds.
+ */
+export class SimCloudFrontEntityNotFound extends SimCloudFrontError {
+  public override readonly name = "EntityNotFound";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 404 });
+  }
+}
+
+/**
+ * Simulated CloudFront CannotDeleteEntityWhileInUse error.
+ *
+ * CloudFront will not delete a key value store a Function is still associated
+ * with. The caller updates the Function to drop the association first.
+ */
+export class SimCloudFrontCannotDeleteEntityWhileInUse extends SimCloudFrontError {
+  public override readonly name = "CannotDeleteEntityWhileInUse";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 409 });
+  }
+}
+
+/**
+ * Simulated CloudFront PreconditionFailed error.
+ *
+ * What CloudFront answers when a write carries an IfMatch ETag that is not the
+ * resource's current one, which is how it stops two writers overwriting each
+ * other.
+ */
+export class SimCloudFrontPreconditionFailed extends SimCloudFrontError {
+  public override readonly name = "PreconditionFailed";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 412 });
+  }
+}
+
+/**
+ * Simulated CloudFront key value store ResourceNotFoundException error.
+ *
+ * What the key value store data API answers for a key that is not stored. It
+ * is the data API's own error rather than one of CloudFront's, which is why it
+ * is named in the exception style that API uses.
+ */
+export class SimCloudFrontKeyValueStoreKeyNotFound extends SimCloudFrontError {
+  public override readonly name = "ResourceNotFoundException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 404 });
+  }
+}

--- a/src/service/cloudfront/error/sim-cloudfront.error.ts
+++ b/src/service/cloudfront/error/sim-cloudfront.error.ts
@@ -260,3 +260,18 @@ export class SimCloudFrontKeyValueStoreKeyNotFound extends SimCloudFrontError {
     super(message, { httpStatusCode: 404 });
   }
 }
+
+/**
+ * Simulated key value store data API ResourceNotFoundException error.
+ *
+ * What that API answers for a `KvsARN` naming no store. The two clients have
+ * separate error sets, so this is not CloudFront's `EntityNotFound` even
+ * though both mean the store was not found.
+ */
+export class SimCloudFrontKeyValueStoreNotFound extends SimCloudFrontError {
+  public override readonly name = "ResourceNotFoundException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 404 });
+  }
+}

--- a/src/service/cloudfront/index.ts
+++ b/src/service/cloudfront/index.ts
@@ -2,3 +2,10 @@ export { makeCffFunctionCodeInput } from "./cff/function-code-input/cff-function
 export { cloudFrontViewerRequestEventFactory } from "./factory/cloudfront-functions.factory.js";
 export { cloudFrontFunctionSourceFromModule } from "./cff/function-code-module/cff-code-module-file.js";
 export type { CloudFrontFunction } from "./typings/cloudfront-functions.namespace.js";
+export type { SimCloudFrontKeyValueStoreApi } from "./sim-cloudfront-key-value-store.js";
+export type { SimCfKeyValueStoreCommands } from "./key-value-store/sim-cf-key-value-store-commands.js";
+export type {
+  SimCloudFrontKeyValueStore,
+  SimCloudFrontKeyValueStoreId,
+  SimCloudFrontKeyValueStoreStatus,
+} from "./key-value-store/sim-cf-key-value-store.js";

--- a/src/service/cloudfront/key-value-store/sim-cf-key-value-store-access.ts
+++ b/src/service/cloudfront/key-value-store/sim-cf-key-value-store-access.ts
@@ -1,0 +1,109 @@
+import type { BackgroundScheduler } from "../../../util/background/background.js";
+import type { SimAwsCaller } from "../../aws/caller/sim-aws-caller.js";
+import type { SimAwsAccountId } from "../../aws/sim-aws-account.js";
+import type { SimIamInterServiceAuthZ } from "../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { SimIamAccessDenied } from "../../iam/error/sim-iam.error.js";
+import type { SimCloudFrontKeyValueStore } from "./sim-cf-key-value-store.js";
+import type { SimCloudFrontKeyValueStoreRegistry } from "./sim-cf-key-value-store-registry.js";
+
+interface SimCfKeyValueStoreAccessProperties {
+  readonly accountId: SimAwsAccountId;
+  readonly stores: SimCloudFrontKeyValueStoreRegistry;
+  readonly iam: SimIamInterServiceAuthZ;
+  readonly background: BackgroundScheduler;
+}
+
+/**
+ * What every key value store command needs: the stores, IAM, and the clock.
+ *
+ * The commands across the two clients all authorize the same way and work on
+ * the same registry, so the wiring is here once rather than repeated in each
+ * of them. Each command class is then only its own AWS behaviour.
+ */
+export class SimCfKeyValueStoreAccess {
+  public readonly accountId: SimAwsAccountId;
+  public readonly stores: SimCloudFrontKeyValueStoreRegistry;
+  public readonly background: BackgroundScheduler;
+
+  private readonly iam: SimIamInterServiceAuthZ;
+
+  constructor(properties: SimCfKeyValueStoreAccessProperties) {
+    this.accountId = properties.accountId;
+    this.stores = properties.stores;
+    this.iam = properties.iam;
+    this.background = properties.background;
+  }
+
+  /**
+   * Ensure the caller may take an action on a key value store ARN.
+   */
+  authorize(action: string, resource: string, caller?: SimAwsCaller): void {
+    const decision = this.iam.authorize({ action, resource, caller });
+
+    if (decision.isDenied) {
+      throw new SimIamAccessDenied({
+        principal: decision.caller.principal,
+        action,
+        resource,
+      });
+    }
+  }
+
+  /**
+   * Ensure the caller may take an action on any key value store.
+   *
+   * CreateKeyValueStore has no store to name yet, and a command naming a store
+   * that does not exist has no ARN to authorize against either, so both go
+   * through the wildcard. A policy granting these actions has to use one too.
+   */
+  authorizeAnyStore(action: string, caller?: SimAwsCaller): void {
+    this.authorize(
+      action,
+      `arn:aws:cloudfront::${this.accountId}:key-value-store/*`,
+      caller,
+    );
+  }
+
+  /**
+   * Resolve a store by name, having authorized the action against it.
+   *
+   * The ARN carries the store's ID rather than its name, so the store has to be
+   * found before the action can be authorized on it. A name that resolves to
+   * nothing is authorized against the wildcard first, so a caller without
+   * permission is refused either way rather than learning which names exist.
+   */
+  authorizedByName(
+    action: string,
+    storeName: string,
+    caller?: SimAwsCaller,
+  ): SimCloudFrontKeyValueStore {
+    const store = this.stores.byName(storeName);
+
+    if (store === undefined) {
+      this.authorizeAnyStore(action, caller);
+
+      return this.stores.requireByName(storeName);
+    }
+
+    this.authorize(action, store.arn, caller);
+
+    return store;
+  }
+
+  /**
+   * Resolve a store by ARN, having authorized the action against it.
+   *
+   * This is the data API's way in. The ARN it was given is the resource the
+   * action is authorized on whether or not it resolves, so an unknown ARN is
+   * authorized before it is refused.
+   */
+  authorizedByArn(
+    action: string,
+    storeArn: string,
+    caller?: SimAwsCaller,
+  ): SimCloudFrontKeyValueStore {
+    this.authorize(action, storeArn, caller);
+
+    return this.stores.requireByArn(storeArn);
+  }
+}

--- a/src/service/cloudfront/key-value-store/sim-cf-key-value-store-commands.ts
+++ b/src/service/cloudfront/key-value-store/sim-cf-key-value-store-commands.ts
@@ -1,0 +1,131 @@
+import type { SimAwsCaller } from "../../aws/caller/sim-aws-caller.js";
+import { SimCfCreateKeyValueStore } from "../command/key-value-store/sim-cf-create-key-value-store.js";
+import { SimCfDeleteKeyValueStore } from "../command/key-value-store/sim-cf-delete-key-value-store.js";
+import { SimCfDescribeKeyValueStore } from "../command/key-value-store/sim-cf-describe-key-value-store.js";
+import { SimCfListKeyValueStores } from "../command/key-value-store/sim-cf-list-key-value-stores.js";
+import { SimCfUpdateKeyValueStore } from "../command/key-value-store/sim-cf-update-key-value-store.js";
+import type {
+  SimCreateKeyValueStoreCommand,
+  SimCreateKeyValueStoreCommandOutput,
+  SimDeleteKeyValueStoreCommand,
+  SimDeleteKeyValueStoreCommandOutput,
+  SimDescribeKeyValueStoreCommand,
+  SimDescribeKeyValueStoreCommandOutput,
+  SimListKeyValueStoresCommand,
+  SimListKeyValueStoresCommandOutput,
+  SimUpdateKeyValueStoreCommand,
+  SimUpdateKeyValueStoreCommandOutput,
+} from "../command/key-value-store/sim-cf-key-value-store-command.types.js";
+import type { SimCfKeyValueStoreAccess } from "./sim-cf-key-value-store-access.js";
+import type {
+  SimCloudFrontKeyValueStore,
+  SimCloudFrontKeyValueStoreId,
+} from "./sim-cf-key-value-store.js";
+import {
+  noKeyValueStoreUsers,
+  type SimCfKeyValueStoreUsers,
+} from "./sim-cf-key-value-store-users.js";
+
+interface KeyValueStoreRequestOptions {
+  readonly caller?: SimAwsCaller;
+}
+
+/**
+ * The key value store commands on the CloudFront client.
+ *
+ * These are the five that own the resource. They are grouped here rather than
+ * on SimCloudFrontCommands beside the Distribution and Function commands
+ * because they share a collaborator none of those need, and because there are
+ * enough of them to be their own thing.
+ */
+export class SimCfKeyValueStoreCommands {
+  private readonly users: SimCfKeyValueStoreUsers;
+
+  constructor(
+    private readonly access: SimCfKeyValueStoreAccess,
+    users: SimCfKeyValueStoreUsers = noKeyValueStoreUsers,
+  ) {
+    this.users = users;
+  }
+
+  /**
+   * Get a key value store by name, for asserting on its state directly.
+   */
+  byName(storeName: string): SimCloudFrontKeyValueStore | undefined {
+    return this.access.stores.byName(storeName);
+  }
+
+  /**
+   * Get a key value store by ID.
+   */
+  byId(
+    storeId: SimCloudFrontKeyValueStoreId | string,
+  ): SimCloudFrontKeyValueStore | undefined {
+    return this.access.stores.byId(storeId);
+  }
+
+  /**
+   * Handle a Create Key Value Store Command from the SDK.
+   */
+  async createKeyValueStore(
+    command: SimCreateKeyValueStoreCommand,
+    options?: KeyValueStoreRequestOptions,
+  ): Promise<SimCreateKeyValueStoreCommandOutput> {
+    return await new SimCfCreateKeyValueStore(this.access).handle(
+      command,
+      options,
+    );
+  }
+
+  /**
+   * Handle a Describe Key Value Store Command from the SDK.
+   */
+  async describeKeyValueStore(
+    command: SimDescribeKeyValueStoreCommand,
+    options?: KeyValueStoreRequestOptions,
+  ): Promise<SimDescribeKeyValueStoreCommandOutput> {
+    return await new SimCfDescribeKeyValueStore(this.access).handle(
+      command,
+      options,
+    );
+  }
+
+  /**
+   * Handle a List Key Value Stores Command from the SDK.
+   */
+  async listKeyValueStores(
+    command: SimListKeyValueStoresCommand,
+    options?: KeyValueStoreRequestOptions,
+  ): Promise<SimListKeyValueStoresCommandOutput> {
+    return await new SimCfListKeyValueStores(this.access).handle(
+      command,
+      options,
+    );
+  }
+
+  /**
+   * Handle an Update Key Value Store Command from the SDK.
+   */
+  async updateKeyValueStore(
+    command: SimUpdateKeyValueStoreCommand,
+    options?: KeyValueStoreRequestOptions,
+  ): Promise<SimUpdateKeyValueStoreCommandOutput> {
+    return await new SimCfUpdateKeyValueStore(this.access).handle(
+      command,
+      options,
+    );
+  }
+
+  /**
+   * Handle a Delete Key Value Store Command from the SDK.
+   */
+  async deleteKeyValueStore(
+    command: SimDeleteKeyValueStoreCommand,
+    options?: KeyValueStoreRequestOptions,
+  ): Promise<SimDeleteKeyValueStoreCommandOutput> {
+    return await new SimCfDeleteKeyValueStore(this.access, this.users).handle(
+      command,
+      options,
+    );
+  }
+}

--- a/src/service/cloudfront/key-value-store/sim-cf-key-value-store-keys.iso.test.ts
+++ b/src/service/cloudfront/key-value-store/sim-cf-key-value-store-keys.iso.test.ts
@@ -1,0 +1,109 @@
+import {
+  assertArrayLength,
+  assertFalse,
+  assertIdentical,
+  assertThrowsError,
+  assertTrue,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimCloudFrontKeyValueStoreKeys } from "./sim-cf-key-value-store-keys.js";
+
+describe("Sim CloudFront key value store keys", () => {
+  it("reads back a key that was written", () => {
+    // Given a store with a key written to it
+    const keys = new SimCloudFrontKeyValueStoreKeys();
+    keys.put("/old", "/new");
+
+    // When the key is read
+    // Then the value written is the value read
+    assertIdentical(keys.get("/old"), "/new");
+    assertTrue(keys.has("/old"));
+  });
+
+  it("replaces the value already under a key", () => {
+    // Given a key that has been written twice
+    const keys = new SimCloudFrontKeyValueStoreKeys();
+    keys.put("flag", "off");
+    keys.put("flag", "on");
+
+    // When the key is read
+    // Then the second write is what is there, and it is still one key
+    assertIdentical(keys.get("flag"), "on");
+    assertIdentical(keys.itemCount, 1);
+  });
+
+  it("refuses a key that was never written", () => {
+    // Given an empty store
+    const keys = new SimCloudFrontKeyValueStoreKeys();
+
+    // When a key that is not there is read
+    // Then it is refused, as the data API refuses one
+    const error = assertThrowsError(() => keys.get("missing"));
+    assertIdentical(error.name, "ResourceNotFoundException");
+    assertFalse(keys.has("missing"));
+  });
+
+  it("forgets a deleted key, and is untroubled by deleting twice", () => {
+    // Given a store with one key
+    const keys = new SimCloudFrontKeyValueStoreKeys();
+    keys.put("gone", "value");
+
+    // When the key is deleted twice
+    keys.delete("gone");
+    keys.delete("gone");
+
+    // Then it is gone, and the second delete was not an error: DeleteKey is
+    // idempotent in the data API
+    assertFalse(keys.has("gone"));
+    assertIdentical(keys.itemCount, 0);
+  });
+
+  it("lists every key and value in the order they were written", () => {
+    // Given a store with three keys
+    const keys = new SimCloudFrontKeyValueStoreKeys();
+    keys.put("a", "1");
+    keys.put("b", "2");
+    keys.put("c", "3");
+
+    // When the keys are listed
+    const listed = keys.list();
+
+    // Then all three are there, in the order they arrived
+    assertArrayLength(listed, 3);
+    assertIdentical(listed[0].Key, "a");
+    assertIdentical(listed[2].Value, "3");
+  });
+
+  it("counts the bytes of both the keys and the values", () => {
+    // Given a store holding one two-byte key and one three-byte value
+    const keys = new SimCloudFrontKeyValueStoreKeys();
+    keys.put("ab", "cde");
+
+    // When the size is read
+    // Then the key counts towards it as well as the value
+    assertIdentical(keys.totalSizeInBytes, 5);
+  });
+
+  it("counts a multi-byte character as its bytes, not its length", () => {
+    // Given a value holding a character outside ASCII
+    const keys = new SimCloudFrontKeyValueStoreKeys();
+    keys.put("k", "é");
+
+    // When the size is read
+    // Then the two bytes of the character are counted, which is what the
+    // store's size quota is measured in
+    assertIdentical(keys.totalSizeInBytes, 3);
+  });
+
+  it("has nothing in it to begin with", () => {
+    // Given a new store
+    const keys = new SimCloudFrontKeyValueStoreKeys();
+
+    // When its size is read
+    // Then it is empty
+    assertIdentical(keys.itemCount, 0);
+    assertIdentical(keys.totalSizeInBytes, 0);
+    assertArrayLength(keys.list(), 0);
+  });
+});

--- a/src/service/cloudfront/key-value-store/sim-cf-key-value-store-keys.ts
+++ b/src/service/cloudfront/key-value-store/sim-cf-key-value-store-keys.ts
@@ -1,0 +1,122 @@
+import { SimCloudFrontKeyValueStoreKeyNotFound } from "../error/sim-cloudfront.error.js";
+
+/**
+ * One key and its value, as the key value store data API returns a pair.
+ */
+export interface SimCloudFrontKeyValuePair {
+  readonly Key: string;
+  readonly Value: string;
+}
+
+/**
+ * The keys one simulated CloudFront key value store holds.
+ *
+ * Kept apart from the store itself because the store is an AWS resource with
+ * an identity, a status and an ETag, while this is the map underneath it. The
+ * two change for different reasons: a key write touches this, and a rename
+ * touches the store.
+ *
+ * Values are strings. The data API takes and returns strings, and the `json`
+ * and `bytes` formats a Function can ask for are parsings of the stored string
+ * rather than separate stored types.
+ */
+export class SimCloudFrontKeyValueStoreKeys {
+  private readonly pairs = new Map<string, string>();
+
+  /**
+   * Write a key, replacing a value already stored under it.
+   */
+  put(key: string, value: string): void {
+    this.pairs.set(key, value);
+  }
+
+  /**
+   * Apply a batch of puts and then a batch of deletes.
+   *
+   * Every write in the data API is this: PutKey is one put, DeleteKey is one
+   * delete, and UpdateKeys is both. The deletes land last, so a key in both is
+   * deleted, which is what the data API does with a batch naming one twice.
+   */
+  applyBatch(
+    puts: readonly SimCloudFrontKeyValuePair[],
+    deletes: readonly { readonly Key: string }[],
+  ): void {
+    for (const put of puts) {
+      this.put(put.Key, put.Value);
+    }
+
+    for (const remove of deletes) {
+      this.delete(remove.Key);
+    }
+  }
+
+  /**
+   * Forget a key.
+   *
+   * Deleting a key that is not there is not an error, which is what the data
+   * API does: DeleteKey is idempotent.
+   */
+  delete(key: string): void {
+    this.pairs.delete(key);
+  }
+
+  /**
+   * Read a key, refusing one that is not stored.
+   *
+   * The data API answers a missing key with ResourceNotFoundException rather
+   * than an empty value, and a Function's `get` rejects for the same reason,
+   * so there is nothing here that should hand back undefined.
+   */
+  get(key: string): string {
+    const value = this.pairs.get(key);
+
+    if (value === undefined) {
+      throw new SimCloudFrontKeyValueStoreKeyNotFound(
+        `Sim CloudFront key value store has no key ${key}`,
+      );
+    }
+
+    return value;
+  }
+
+  /**
+   * Whether a key is stored.
+   */
+  has(key: string): boolean {
+    return this.pairs.has(key);
+  }
+
+  /**
+   * Every key and value, in the order they were first written.
+   */
+  list(): readonly SimCloudFrontKeyValuePair[] {
+    return this.pairs
+      .entries()
+      .map(([key, value]) => ({ Key: key, Value: value }))
+      .toArray();
+  }
+
+  /**
+   * How many keys are stored.
+   */
+  get itemCount(): number {
+    return this.pairs.size;
+  }
+
+  /**
+   * The size of the stored data in bytes.
+   *
+   * CloudFront counts a key value store against a size quota, and the data API
+   * reports this alongside the item count on every write. Both the key and the
+   * value count towards it.
+   */
+  get totalSizeInBytes(): number {
+    return this.pairs
+      .entries()
+      .reduce(
+        (total, [key, value]) =>
+          total + Buffer.byteLength(key) + Buffer.byteLength(value),
+        0,
+      );
+  }
+}

--- a/src/service/cloudfront/key-value-store/sim-cf-key-value-store-registry.iso.test.ts
+++ b/src/service/cloudfront/key-value-store/sim-cf-key-value-store-registry.iso.test.ts
@@ -62,14 +62,25 @@ describe("Sim CloudFront key value store registry", () => {
     const registry = new SimCloudFrontKeyValueStoreRegistry();
 
     // When a store is required by each of the three ways
-    // Then each is refused, quoting back what it was given
+    // Then each is refused, quoting back what it was given. The ARN lookup is
+    // the data API's way in, so it answers with that API's own error rather
+    // than CloudFront's: the two clients have separate error sets.
     for (const required of [
-      (): unknown => registry.requireById("no-such-id"),
-      (): unknown => registry.requireByName("no-such-name"),
-      (): unknown => registry.requireByArn("no-such-arn"),
+      {
+        find: (): unknown => registry.requireById("no-such-id"),
+        name: "EntityNotFound",
+      },
+      {
+        find: (): unknown => registry.requireByName("no-such-name"),
+        name: "EntityNotFound",
+      },
+      {
+        find: (): unknown => registry.requireByArn("no-such-arn"),
+        name: "ResourceNotFoundException",
+      },
     ]) {
-      const error = assertThrowsError(required);
-      assertIdentical(error.name, "EntityNotFound");
+      const error = assertThrowsError(required.find);
+      assertIdentical(error.name, required.name);
     }
   });
 

--- a/src/service/cloudfront/key-value-store/sim-cf-key-value-store-registry.iso.test.ts
+++ b/src/service/cloudfront/key-value-store/sim-cf-key-value-store-registry.iso.test.ts
@@ -1,0 +1,98 @@
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertThrowsError,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimCloudFrontKeyValueStore } from "./sim-cf-key-value-store.js";
+import { SimCloudFrontKeyValueStoreRegistry } from "./sim-cf-key-value-store-registry.js";
+
+function storeNamed(name: string): SimCloudFrontKeyValueStore {
+  return new SimCloudFrontKeyValueStore({ name });
+}
+
+describe("Sim CloudFront key value store registry", () => {
+  it("finds a stored key value store by ID, name and ARN", () => {
+    // Given a registry holding one store
+    const registry = new SimCloudFrontKeyValueStoreRegistry();
+    const store = storeNamed("redirects");
+    registry.add(store);
+
+    // When it is looked for each of the three ways
+    // Then each finds it, because each API reaches for a different one
+    assertIdentical(registry.byId(store.id), store);
+    assertIdentical(registry.byName("redirects"), store);
+    assertIdentical(registry.byArn(store.arn), store);
+  });
+
+  it("refuses a name another key value store already holds", () => {
+    // Given a registry that already holds a store called redirects
+    const registry = new SimCloudFrontKeyValueStoreRegistry();
+    registry.add(storeNamed("redirects"));
+
+    // When a second store claims the same name
+    const error = assertThrowsError(() => {
+      registry.add(storeNamed("redirects"));
+    });
+
+    // Then it is refused, as CloudFront refuses one
+    assertIdentical(error.name, "EntityAlreadyExists");
+  });
+
+  it("allows a name that was freed by a delete", () => {
+    // Given a registry whose only store has been removed
+    const registry = new SimCloudFrontKeyValueStoreRegistry();
+    const first = storeNamed("redirects");
+    registry.add(first);
+    registry.remove(first.id);
+
+    // When another store claims that name
+    const second = storeNamed("redirects");
+    registry.add(second);
+
+    // Then it is stored, and the first one is gone
+    assertIdentical(registry.byName("redirects"), second);
+    assertUndefined(registry.byId(first.id));
+  });
+
+  it("refuses a lookup for a key value store it does not hold", () => {
+    // Given an empty registry
+    const registry = new SimCloudFrontKeyValueStoreRegistry();
+
+    // When a store is required by each of the three ways
+    // Then each is refused, quoting back what it was given
+    for (const required of [
+      (): unknown => registry.requireById("no-such-id"),
+      (): unknown => registry.requireByName("no-such-name"),
+      (): unknown => registry.requireByArn("no-such-arn"),
+    ]) {
+      const error = assertThrowsError(required);
+      assertIdentical(error.name, "EntityNotFound");
+    }
+  });
+
+  it("hands back every key value store it holds", () => {
+    // Given a registry holding two stores
+    const registry = new SimCloudFrontKeyValueStoreRegistry();
+    registry.add(storeNamed("redirects"));
+    registry.add(storeNamed("flags"));
+
+    // When they are all read
+    // Then both are there
+    assertArrayLength(registry.all(), 2);
+  });
+
+  it("finds nothing in an empty registry", () => {
+    // Given an empty registry
+    const registry = new SimCloudFrontKeyValueStoreRegistry();
+
+    // When a store is looked for
+    // Then nothing is found, rather than something being thrown
+    assertUndefined(registry.byId("nope"));
+    assertUndefined(registry.byName("nope"));
+    assertUndefined(registry.byArn("nope"));
+    assertArrayLength(registry.all(), 0);
+  });
+});

--- a/src/service/cloudfront/key-value-store/sim-cf-key-value-store-registry.ts
+++ b/src/service/cloudfront/key-value-store/sim-cf-key-value-store-registry.ts
@@ -1,0 +1,125 @@
+import {
+  SimCloudFrontEntityAlreadyExists,
+  SimCloudFrontEntityNotFound,
+} from "../error/sim-cloudfront.error.js";
+import type {
+  SimCloudFrontKeyValueStore,
+  SimCloudFrontKeyValueStoreId,
+  SimCloudFrontKeyValueStoreMap,
+} from "./sim-cf-key-value-store.js";
+
+/**
+ * The key value stores one simulated CloudFront holds.
+ *
+ * A store is found three ways, because each API reaches for a different one.
+ * The CloudFront client names a store by ID, the data API addresses it by ARN,
+ * and the name is what decides whether a new one may be stored.
+ */
+export class SimCloudFrontKeyValueStoreRegistry {
+  private readonly stores: SimCloudFrontKeyValueStoreMap = new Map();
+
+  /**
+   * Store a key value store, refusing a name another one already holds as
+   * CloudFront refuses it.
+   */
+  add(store: SimCloudFrontKeyValueStore): void {
+    if (this.byName(store.name) !== undefined) {
+      throw new SimCloudFrontEntityAlreadyExists(
+        `Sim CloudFront key value store ${store.name} already exists`,
+      );
+    }
+
+    this.stores.set(store.id, store);
+  }
+
+  /**
+   * Forget a key value store.
+   */
+  remove(storeId: SimCloudFrontKeyValueStoreId): void {
+    this.stores.delete(storeId);
+  }
+
+  /**
+   * Get a key value store by ID.
+   */
+  byId(
+    storeId: SimCloudFrontKeyValueStoreId | string,
+  ): SimCloudFrontKeyValueStore | undefined {
+    return this.stores.get(storeId as SimCloudFrontKeyValueStoreId);
+  }
+
+  /**
+   * Get a key value store by name.
+   */
+  byName(storeName: string): SimCloudFrontKeyValueStore | undefined {
+    return this.stores.values().find((store) => store.name === storeName);
+  }
+
+  /**
+   * Get a key value store by ARN.
+   */
+  byArn(storeArn: string): SimCloudFrontKeyValueStore | undefined {
+    return this.stores.values().find((store) => store.arn === storeArn);
+  }
+
+  /**
+   * Get a key value store by ID, refusing one this Account does not hold.
+   */
+  requireById(
+    storeId: SimCloudFrontKeyValueStoreId | string,
+  ): SimCloudFrontKeyValueStore {
+    const store = this.byId(storeId);
+
+    if (store === undefined) {
+      throw new SimCloudFrontEntityNotFound(
+        `Sim CloudFront has no key value store with ID ${storeId}`,
+      );
+    }
+
+    return store;
+  }
+
+  /**
+   * Get a key value store by name, refusing one this Account does not hold.
+   *
+   * This is how the CloudFront client reaches a store: Describe, Update and
+   * Delete all take the name rather than the ID.
+   */
+  requireByName(storeName: string): SimCloudFrontKeyValueStore {
+    const store = this.byName(storeName);
+
+    if (store === undefined) {
+      throw new SimCloudFrontEntityNotFound(
+        `Sim CloudFront has no key value store named ${storeName}`,
+      );
+    }
+
+    return store;
+  }
+
+  /**
+   * Get a key value store by ARN, refusing one this Account does not hold.
+   *
+   * This is the data API's way in, so the ARN it was given is quoted back on
+   * a miss: a store in another Account and a store that was deleted both
+   * arrive here, and the ARN is what tells them apart.
+   */
+  requireByArn(storeArn: string): SimCloudFrontKeyValueStore {
+    const store = this.byArn(storeArn);
+
+    if (store === undefined) {
+      throw new SimCloudFrontEntityNotFound(
+        `Sim CloudFront has no key value store with ARN ${storeArn}`,
+      );
+    }
+
+    return store;
+  }
+
+  /**
+   * Every key value store this Account holds.
+   */
+  all(): readonly SimCloudFrontKeyValueStore[] {
+    return this.stores.values().toArray();
+  }
+}

--- a/src/service/cloudfront/key-value-store/sim-cf-key-value-store-registry.ts
+++ b/src/service/cloudfront/key-value-store/sim-cf-key-value-store-registry.ts
@@ -1,6 +1,7 @@
 import {
   SimCloudFrontEntityAlreadyExists,
   SimCloudFrontEntityNotFound,
+  SimCloudFrontKeyValueStoreNotFound,
 } from "../error/sim-cloudfront.error.js";
 import type {
   SimCloudFrontKeyValueStore,
@@ -100,15 +101,18 @@ export class SimCloudFrontKeyValueStoreRegistry {
   /**
    * Get a key value store by ARN, refusing one this Account does not hold.
    *
-   * This is the data API's way in, so the ARN it was given is quoted back on
-   * a miss: a store in another Account and a store that was deleted both
-   * arrive here, and the ARN is what tells them apart.
+   * This is the data API's way in, so the refusal is that API's own
+   * ResourceNotFoundException rather than CloudFront's EntityNotFound: the two
+   * clients have separate error sets, and EntityNotFound is not in this one.
+   *
+   * The ARN it was given is quoted back on a miss, because a store in another
+   * Account and a store that was deleted both arrive here.
    */
   requireByArn(storeArn: string): SimCloudFrontKeyValueStore {
     const store = this.byArn(storeArn);
 
     if (store === undefined) {
-      throw new SimCloudFrontEntityNotFound(
+      throw new SimCloudFrontKeyValueStoreNotFound(
         `Sim CloudFront has no key value store with ARN ${storeArn}`,
       );
     }

--- a/src/service/cloudfront/key-value-store/sim-cf-key-value-store-users.iso.test.ts
+++ b/src/service/cloudfront/key-value-store/sim-cf-key-value-store-users.iso.test.ts
@@ -1,0 +1,90 @@
+import { CreateKeyValueStoreCommand } from "@aws-sdk/client-cloudfront";
+import {
+  assertArrayLength,
+  assertStringIncludes,
+  assertIdentical,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { BackgroundTasks } from "../../../util/background/background.js";
+import { makeSimAwsAccountId } from "../../aws/sim-aws-account.js";
+import { SimIamAllowAllAuth } from "../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { SimCfKeyValueStoreAccess } from "./sim-cf-key-value-store-access.js";
+import { SimCfKeyValueStoreCommands } from "./sim-cf-key-value-store-commands.js";
+import { SimCloudFrontKeyValueStoreRegistry } from "./sim-cf-key-value-store-registry.js";
+import {
+  noKeyValueStoreUsers,
+  type SimCfKeyValueStoreUsers,
+} from "./sim-cf-key-value-store-users.js";
+
+function commandsWith(
+  users: SimCfKeyValueStoreUsers,
+): SimCfKeyValueStoreCommands {
+  return new SimCfKeyValueStoreCommands(
+    new SimCfKeyValueStoreAccess({
+      accountId: makeSimAwsAccountId(),
+      stores: new SimCloudFrontKeyValueStoreRegistry(),
+      iam: new SimIamAllowAllAuth(),
+      background: new BackgroundTasks(),
+    }),
+    users,
+  );
+}
+
+describe("Deleting a key value store something still uses", () => {
+  it("says nothing uses any store, while nothing can be associated", () => {
+    // Given the default collaborator
+    // When it is asked what uses a store
+    // Then nothing does, because a Function cannot be associated with one yet
+    assertArrayLength(
+      noKeyValueStoreUsers.functionsUsing(
+        "any-store-id" as Parameters<
+          SimCfKeyValueStoreUsers["functionsUsing"]
+        >[0],
+      ),
+      0,
+    );
+  });
+
+  it("refuses to delete a store a Function is associated with", async () => {
+    // Given a store that something reports as being in use
+    const stores = commandsWith({
+      functionsUsing: (): readonly string[] => ["viewer-request-cff"],
+    });
+    const created = await stores.createKeyValueStore(
+      new CreateKeyValueStoreCommand({ Name: "redirects" }),
+    );
+
+    // When it is deleted
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await stores.deleteKeyValueStore({
+          input: { Name: "redirects", IfMatch: created.ETag },
+        }),
+    );
+
+    // Then CloudFront refuses it, naming what is still using it, and the store
+    // is still there
+    assertIdentical(error.name, "CannotDeleteEntityWhileInUse");
+    assertStringIncludes(error.message, "viewer-request-cff");
+    assertIdentical(stores.byName("redirects")?.name, "redirects");
+  });
+
+  it("deletes a store nothing is associated with", async () => {
+    // Given a store nothing reports as being in use
+    const stores = commandsWith(noKeyValueStoreUsers);
+    const created = await stores.createKeyValueStore(
+      new CreateKeyValueStoreCommand({ Name: "redirects" }),
+    );
+
+    // When it is deleted
+    await stores.deleteKeyValueStore({
+      input: { Name: "redirects", IfMatch: created.ETag },
+    });
+
+    // Then it is gone
+    assertUndefined(stores.byName("redirects"));
+  });
+});

--- a/src/service/cloudfront/key-value-store/sim-cf-key-value-store-users.ts
+++ b/src/service/cloudfront/key-value-store/sim-cf-key-value-store-users.ts
@@ -1,0 +1,25 @@
+import type { SimCloudFrontKeyValueStoreId } from "./sim-cf-key-value-store.js";
+
+/**
+ * What still uses a key value store, which decides whether it can be deleted.
+ *
+ * CloudFront refuses to delete a store a Function is still associated with, so
+ * the delete command has to ask something what is using it. That something is
+ * the Function map, and a Function cannot be associated with a store yet: the
+ * association arrives with the runtime read path. Until then the answer is
+ * always nothing, and the guard is here so that wiring the real one in is a
+ * change of collaborator rather than a change to the delete command.
+ */
+export interface SimCfKeyValueStoreUsers {
+  /**
+   * The names of the CloudFront Functions associated with a key value store.
+   */
+  functionsUsing(storeId: SimCloudFrontKeyValueStoreId): readonly string[];
+}
+
+/**
+ * Nothing uses any key value store.
+ */
+export const noKeyValueStoreUsers: SimCfKeyValueStoreUsers = {
+  functionsUsing: (): readonly string[] => [],
+};

--- a/src/service/cloudfront/key-value-store/sim-cf-key-value-store.iso.test.ts
+++ b/src/service/cloudfront/key-value-store/sim-cf-key-value-store.iso.test.ts
@@ -1,0 +1,140 @@
+import {
+  assertFalse,
+  assertIdentical,
+  assertNonNullable,
+  assertObjectEquals,
+  assertThrowsError,
+  assertTrue,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { makeSimAwsAccountId } from "../../aws/sim-aws-account.js";
+import { SimCloudFrontKeyValueStore } from "./sim-cf-key-value-store.js";
+
+describe("Sim CloudFront key value store", () => {
+  it("has a global ARN with no Region, as CloudFront gives one", () => {
+    // Given a store in a known Account
+    const accountId = makeSimAwsAccountId();
+    const store = new SimCloudFrontKeyValueStore({
+      name: "redirects",
+      accountId,
+    });
+
+    // When its ARN is read
+    // Then the Region is empty, the way a Distribution and Function ARN are
+    assertIdentical(
+      store.arn,
+      `arn:aws:cloudfront::${accountId}:key-value-store/${store.id}`,
+    );
+  });
+
+  it("starts PROVISIONING and becomes READY", async () => {
+    // Given a newly created store
+    const store = new SimCloudFrontKeyValueStore({ name: "redirects" });
+    assertIdentical(store.status, "PROVISIONING");
+
+    // When provisioning finishes
+    await store.ready();
+
+    // Then it is servable
+    assertIdentical(store.status, "READY");
+  });
+
+  it("takes its name and comment, and can change the comment", () => {
+    // Given a store with a comment
+    const store = new SimCloudFrontKeyValueStore({
+      name: "redirects",
+      comment: "first",
+    });
+
+    // When the comment is changed
+    store.update({ comment: "second" });
+
+    // Then the new comment is stored and the name is untouched
+    assertIdentical(store.comment, "second");
+    assertIdentical(store.name, "redirects");
+  });
+
+  it("keeps the comment when an update does not carry one", () => {
+    // Given a store with a comment
+    const store = new SimCloudFrontKeyValueStore({
+      name: "redirects",
+      comment: "kept",
+    });
+
+    // When it is updated with nothing to change
+    store.update({});
+
+    // Then the comment it had is still there
+    assertIdentical(store.comment, "kept");
+  });
+
+  it("gives a new ETag on every change", () => {
+    // Given a store with a comment
+    const store = new SimCloudFrontKeyValueStore({ name: "redirects" });
+    const before = store.eTag;
+
+    // When it changes
+    store.touch();
+
+    // Then the ETag it had is no longer current, which is what makes a stale
+    // write fail
+    assertFalse(store.eTag === before);
+  });
+
+  it("refuses a write carrying an ETag that is not the current one", () => {
+    // Given a store that has changed since a caller read its ETag
+    const store = new SimCloudFrontKeyValueStore({ name: "redirects" });
+    const stale = store.eTag;
+    store.touch();
+
+    // When a write carries the ETag from before the change
+    const error = assertThrowsError(() => {
+      store.assertETag(stale);
+    });
+
+    // Then it is refused
+    assertIdentical(error.name, "PreconditionFailed");
+  });
+
+  it("accepts a write carrying the current ETag", () => {
+    // Given a store
+    const store = new SimCloudFrontKeyValueStore({ name: "redirects" });
+
+    // When a write carries the ETag it has now
+    // Then it is not refused
+    store.assertETag(store.eTag);
+  });
+
+  it("was created when it was last modified, to begin with", () => {
+    // Given a store created at a known time
+    const lastModifiedTime = new Date("2026-01-01T00:00:00.000Z");
+    const store = new SimCloudFrontKeyValueStore({
+      name: "redirects",
+      lastModifiedTime,
+    });
+
+    // When both times are read
+    // Then they are the same, and a later change moves only one of them
+    assertIdentical(store.createdTime, lastModifiedTime);
+
+    store.touch(new Date("2026-02-01T00:00:00.000Z"));
+
+    assertIdentical(store.createdTime, lastModifiedTime);
+    assertTrue(store.lastModifiedTime > store.createdTime);
+  });
+
+  it("lists the keys it holds", () => {
+    // Given a store with a key
+    const store = new SimCloudFrontKeyValueStore({ name: "redirects" });
+    store.keys.put("/old", "/new");
+
+    // When its keys are listed
+    const listed = store.listKeys();
+
+    // Then the key is there
+    const [pair] = listed;
+    assertNonNullable(pair);
+    assertObjectEquals(pair, { Key: "/old", Value: "/new" });
+  });
+});

--- a/src/service/cloudfront/key-value-store/sim-cf-key-value-store.iso.test.ts
+++ b/src/service/cloudfront/key-value-store/sim-cf-key-value-store.iso.test.ts
@@ -3,6 +3,7 @@ import {
   assertIdentical,
   assertNonNullable,
   assertObjectEquals,
+  assertStringIncludes,
   assertThrowsError,
   assertTrue,
 } from "@kensio/smartass";
@@ -69,41 +70,87 @@ describe("Sim CloudFront key value store", () => {
     assertIdentical(store.comment, "kept");
   });
 
-  it("gives a new ETag on every change", () => {
-    // Given a store with a comment
+  it("gives a new resource ETag when the configuration changes", () => {
+    // Given a store
     const store = new SimCloudFrontKeyValueStore({ name: "redirects" });
-    const before = store.eTag;
+    const before = store.resourceETag;
 
-    // When it changes
-    store.touch();
+    // When its comment changes
+    store.update({ comment: "changed" });
 
-    // Then the ETag it had is no longer current, which is what makes a stale
-    // write fail
-    assertFalse(store.eTag === before);
+    // Then the resource ETag it had is no longer current, which is what makes
+    // a stale CloudFront client write fail
+    assertFalse(store.resourceETag === before);
+  });
+
+  it("keeps the two ETags apart, as AWS does", () => {
+    // Given a store, and both of its ETags read
+    const store = new SimCloudFrontKeyValueStore({ name: "redirects" });
+    const resourceBefore = store.resourceETag;
+    const dataBefore = store.dataETag;
+
+    // Then they are different values to begin with
+    assertFalse(resourceBefore === dataBefore);
+
+    // When the keys change
+    store.touchData();
+
+    // Then only the data ETag moves, so a CloudFront client write that was
+    // already holding the resource ETag is still good
+    assertIdentical(store.resourceETag, resourceBefore);
+    assertFalse(store.dataETag === dataBefore);
+
+    // And when the configuration changes, only the resource ETag moves
+    const dataAfterWrite = store.dataETag;
+    store.touchResource();
+    assertIdentical(store.dataETag, dataAfterWrite);
+    assertFalse(store.resourceETag === resourceBefore);
   });
 
   it("refuses a write carrying an ETag that is not the current one", () => {
-    // Given a store that has changed since a caller read its ETag
+    // Given a store that has changed since a caller read both its ETags
     const store = new SimCloudFrontKeyValueStore({ name: "redirects" });
-    const stale = store.eTag;
-    store.touch();
+    const staleResource = store.resourceETag;
+    const staleData = store.dataETag;
+    store.touchResource();
+    store.touchData();
 
-    // When a write carries the ETag from before the change
-    const error = assertThrowsError(() => {
-      store.assertETag(stale);
+    // When each write carries the ETag from before its change
+    const resourceError = assertThrowsError(() => {
+      store.assertResourceETag(staleResource);
+    });
+    const dataError = assertThrowsError(() => {
+      store.assertDataETag(staleData);
     });
 
-    // Then it is refused
+    // Then both are refused
+    assertIdentical(resourceError.name, "PreconditionFailed");
+    assertIdentical(dataError.name, "PreconditionFailed");
+  });
+
+  it("refuses a write carrying the other API's ETag", () => {
+    // Given a store nothing has written to
+    const store = new SimCloudFrontKeyValueStore({ name: "redirects" });
+
+    // When a write reaches for the ETag belonging to the other client, which
+    // is the mistake two separate ETags exist to catch
+    const error = assertThrowsError(() => {
+      store.assertDataETag(store.resourceETag);
+    });
+
+    // Then it is refused, and the message says which side it wanted
     assertIdentical(error.name, "PreconditionFailed");
+    assertStringIncludes(error.message, "data ETag");
   });
 
   it("accepts a write carrying the current ETag", () => {
     // Given a store
     const store = new SimCloudFrontKeyValueStore({ name: "redirects" });
 
-    // When a write carries the ETag it has now
-    // Then it is not refused
-    store.assertETag(store.eTag);
+    // When each write carries the ETag its own side has now
+    // Then neither is refused
+    store.assertResourceETag(store.resourceETag);
+    store.assertDataETag(store.dataETag);
   });
 
   it("was created when it was last modified, to begin with", () => {
@@ -118,7 +165,7 @@ describe("Sim CloudFront key value store", () => {
     // Then they are the same, and a later change moves only one of them
     assertIdentical(store.createdTime, lastModifiedTime);
 
-    store.touch(new Date("2026-02-01T00:00:00.000Z"));
+    store.touchData(new Date("2026-02-01T00:00:00.000Z"));
 
     assertIdentical(store.createdTime, lastModifiedTime);
     assertTrue(store.lastModifiedTime > store.createdTime);

--- a/src/service/cloudfront/key-value-store/sim-cf-key-value-store.ts
+++ b/src/service/cloudfront/key-value-store/sim-cf-key-value-store.ts
@@ -1,0 +1,191 @@
+import { faker } from "@faker-js/faker";
+
+import type { Brand } from "../../../util/brand.type.js";
+import type { SimArn } from "../../aws/arn.js";
+import {
+  makeSimAwsAccountId,
+  type SimAwsAccountId,
+} from "../../aws/sim-aws-account.js";
+import { SimCloudFrontPreconditionFailed } from "../error/sim-cloudfront.error.js";
+import {
+  type SimCloudFrontKeyValuePair,
+  SimCloudFrontKeyValueStoreKeys,
+} from "./sim-cf-key-value-store-keys.js";
+
+export type SimCloudFrontKeyValueStoreId = Brand<
+  string,
+  "SimCloudFrontKeyValueStoreId"
+>;
+
+/**
+ * A key value store is PROVISIONING until CloudFront has it ready to serve.
+ */
+export type SimCloudFrontKeyValueStoreStatus = "PROVISIONING" | "READY";
+
+interface SimCloudFrontKeyValueStoreProperties {
+  readonly id?: SimCloudFrontKeyValueStoreId;
+  readonly name: string;
+  readonly comment?: string | undefined;
+  readonly accountId?: SimAwsAccountId;
+  readonly status?: SimCloudFrontKeyValueStoreStatus;
+  readonly lastModifiedTime?: Date;
+}
+
+/**
+ * Simulated CloudFront key value store.
+ *
+ * A key value store holds data a CloudFront Function reads at request time,
+ * which is how a Function gets a redirect table or a feature flag without
+ * having the value baked into its code. The Function reads it and never writes
+ * to it: writes come from the separate key value store data API.
+ *
+ * The store is reached through two different SDK clients in AWS, and both are
+ * simulated. The CloudFront client owns the resource, so it creates, describes,
+ * renames and deletes the store. The key value store client owns the data, so
+ * it reads and writes the keys, addressing the store by ARN.
+ *
+ * https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/kvs-with-functions.html
+ */
+export class SimCloudFrontKeyValueStore {
+  public readonly id: SimCloudFrontKeyValueStoreId;
+  public readonly accountId: SimAwsAccountId;
+  public readonly keys = new SimCloudFrontKeyValueStoreKeys();
+
+  /**
+   * When this key value store was created, which the data API reports and the
+   * CloudFront client does not.
+   */
+  public readonly createdTime: Date;
+
+  #name: string;
+  #comment: string | undefined;
+  #status: SimCloudFrontKeyValueStoreStatus;
+  #lastModifiedTime: Date;
+  #eTag: string;
+
+  constructor(properties: SimCloudFrontKeyValueStoreProperties) {
+    this.id = properties.id ?? makeKeyValueStoreId();
+    this.accountId = properties.accountId ?? makeSimAwsAccountId();
+    this.#name = properties.name;
+    this.#comment = properties.comment;
+    this.#status = properties.status ?? "PROVISIONING";
+    this.#lastModifiedTime = properties.lastModifiedTime ?? new Date();
+    this.createdTime = this.#lastModifiedTime;
+    this.#eTag = makeKeyValueStoreETag();
+  }
+
+  /**
+   * The name this key value store is known by, which is unique per Account.
+   */
+  get name(): string {
+    return this.#name;
+  }
+
+  /**
+   * The comment stored with this key value store, if it has one.
+   */
+  get comment(): string | undefined {
+    return this.#comment;
+  }
+
+  /**
+   * The current status of this key value store.
+   */
+  get status(): SimCloudFrontKeyValueStoreStatus {
+    return this.#status;
+  }
+
+  /**
+   * When this key value store was last changed, by either API.
+   */
+  get lastModifiedTime(): Date {
+    return this.#lastModifiedTime;
+  }
+
+  /**
+   * The current ETag, which every write has to match.
+   */
+  get eTag(): string {
+    return this.#eTag;
+  }
+
+  /**
+   * The ARN for this key value store.
+   *
+   * CloudFront is a global service, so the Region is empty, the same way a
+   * Distribution and a Function ARN have no Region.
+   */
+  get arn(): SimArn {
+    return `arn:aws:cloudfront::${this.accountId}:key-value-store/${this.id}`;
+  }
+
+  /**
+   * Move this key value store to the READY status.
+   */
+  ready(): Promise<void> {
+    this.#status = "READY";
+    return Promise.resolve();
+  }
+
+  /**
+   * Rename this key value store, or change its comment.
+   */
+  update(properties: {
+    readonly name?: string | undefined;
+    readonly comment?: string | undefined;
+  }): void {
+    this.#name = properties.name ?? this.#name;
+    this.#comment = properties.comment ?? this.#comment;
+    this.touch();
+  }
+
+  /**
+   * Refuse a write whose ETag is not the current one.
+   *
+   * The data API takes IfMatch on every write and CloudFront refuses a stale
+   * one, which is what stops two writers overwriting each other. Yulin enforces
+   * it rather than accepting and ignoring it, so a caller that does not thread
+   * the ETag through fails here the way it would fail against CloudFront.
+   */
+  assertETag(ifMatch: string): void {
+    if (ifMatch !== this.#eTag) {
+      throw new SimCloudFrontPreconditionFailed(
+        `Sim CloudFront key value store ${this.name} has ETag ${this.#eTag}, not ${ifMatch}`,
+      );
+    }
+  }
+
+  /**
+   * Record that this key value store changed, giving it a new ETag.
+   */
+  touch(lastModifiedTime: Date = new Date()): void {
+    this.#lastModifiedTime = lastModifiedTime;
+    this.#eTag = makeKeyValueStoreETag();
+  }
+
+  /**
+   * Every key and value this store holds.
+   */
+  listKeys(): readonly SimCloudFrontKeyValuePair[] {
+    return this.keys.list();
+  }
+}
+
+export type SimCloudFrontKeyValueStoreMap = Map<
+  SimCloudFrontKeyValueStoreId,
+  SimCloudFrontKeyValueStore
+>;
+
+/**
+ * Generate a fake key value store ID, in the shape CloudFront gives one.
+ */
+export function makeKeyValueStoreId(): SimCloudFrontKeyValueStoreId {
+  return faker.string.uuid() as SimCloudFrontKeyValueStoreId;
+}
+
+/**
+ * Generate a fake ETag, in the shape CloudFront gives one.
+ */
+export function makeKeyValueStoreETag(): string {
+  return faker.helpers.fromRegExp(/E[0-9A-Z]{13}/);
+}

--- a/src/service/cloudfront/key-value-store/sim-cf-key-value-store.ts
+++ b/src/service/cloudfront/key-value-store/sim-cf-key-value-store.ts
@@ -61,7 +61,8 @@ export class SimCloudFrontKeyValueStore {
   #comment: string | undefined;
   #status: SimCloudFrontKeyValueStoreStatus;
   #lastModifiedTime: Date;
-  #eTag: string;
+  #resourceETag: string;
+  #dataETag: string;
 
   constructor(properties: SimCloudFrontKeyValueStoreProperties) {
     this.id = properties.id ?? makeKeyValueStoreId();
@@ -71,7 +72,8 @@ export class SimCloudFrontKeyValueStore {
     this.#status = properties.status ?? "PROVISIONING";
     this.#lastModifiedTime = properties.lastModifiedTime ?? new Date();
     this.createdTime = this.#lastModifiedTime;
-    this.#eTag = makeKeyValueStoreETag();
+    this.#resourceETag = makeKeyValueStoreETag();
+    this.#dataETag = makeKeyValueStoreETag();
   }
 
   /**
@@ -103,10 +105,28 @@ export class SimCloudFrontKeyValueStore {
   }
 
   /**
-   * The current ETag, which every write has to match.
+   * The ETag of the resource, which the CloudFront client works against.
+   *
+   * A store has two ETags and they are not interchangeable, which is what AWS
+   * has: each of the two DescribeKeyValueStore operations returns its own, and
+   * a write has to carry the one belonging to the API it is calling. This one
+   * versions the store's configuration, so a key write does not move it and a
+   * comment change does.
+   *
+   * https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/kvs-with-functions-get-reference.html
    */
-  get eTag(): string {
-    return this.#eTag;
+  get resourceETag(): string {
+    return this.#resourceETag;
+  }
+
+  /**
+   * The ETag of the data, which the key value store client works against.
+   *
+   * This one versions the keys, so a key write moves it and a comment change
+   * does not. See resourceETag for why there are two.
+   */
+  get dataETag(): string {
+    return this.#dataETag;
   }
 
   /**
@@ -136,31 +156,42 @@ export class SimCloudFrontKeyValueStore {
   }): void {
     this.#name = properties.name ?? this.#name;
     this.#comment = properties.comment ?? this.#comment;
-    this.touch();
+    this.touchResource();
   }
 
   /**
-   * Refuse a write whose ETag is not the current one.
+   * Refuse a CloudFront client write whose ETag is not the resource's.
    *
-   * The data API takes IfMatch on every write and CloudFront refuses a stale
-   * one, which is what stops two writers overwriting each other. Yulin enforces
-   * it rather than accepting and ignoring it, so a caller that does not thread
-   * the ETag through fails here the way it would fail against CloudFront.
+   * CloudFront takes IfMatch on every write and refuses a stale one, which is
+   * what stops two writers overwriting each other. Yulin enforces it here
+   * rather than accepting and ignoring it, so a caller that does not thread the
+   * ETag through fails the way it would fail against CloudFront.
    */
-  assertETag(ifMatch: string): void {
-    if (ifMatch !== this.#eTag) {
-      throw new SimCloudFrontPreconditionFailed(
-        `Sim CloudFront key value store ${this.name} has ETag ${this.#eTag}, not ${ifMatch}`,
-      );
-    }
+  assertResourceETag(ifMatch: string): void {
+    this.assertETag(ifMatch, this.#resourceETag, "resource");
   }
 
   /**
-   * Record that this key value store changed, giving it a new ETag.
+   * Refuse a data API write whose ETag is not the data's.
    */
-  touch(lastModifiedTime: Date = new Date()): void {
+  assertDataETag(ifMatch: string): void {
+    this.assertETag(ifMatch, this.#dataETag, "data");
+  }
+
+  /**
+   * Record that this store's configuration changed.
+   */
+  touchResource(lastModifiedTime: Date = new Date()): void {
     this.#lastModifiedTime = lastModifiedTime;
-    this.#eTag = makeKeyValueStoreETag();
+    this.#resourceETag = makeKeyValueStoreETag();
+  }
+
+  /**
+   * Record that this store's keys changed.
+   */
+  touchData(lastModifiedTime: Date = new Date()): void {
+    this.#lastModifiedTime = lastModifiedTime;
+    this.#dataETag = makeKeyValueStoreETag();
   }
 
   /**
@@ -168,6 +199,22 @@ export class SimCloudFrontKeyValueStore {
    */
   listKeys(): readonly SimCloudFrontKeyValuePair[] {
     return this.keys.list();
+  }
+
+  /**
+   * Refuse a write against the wrong version of one side of the store.
+   *
+   * The side is named in the message because the two ETags are not
+   * interchangeable, and reaching for the other API's ETag is the mistake this
+   * is most likely to be catching.
+   */
+  private assertETag(ifMatch: string, current: string, side: string): void {
+    if (ifMatch !== current) {
+      throw new SimCloudFrontPreconditionFailed(
+        `Sim CloudFront key value store ${this.name} has ${side} ETag ` +
+          `${current}, not ${ifMatch}`,
+      );
+    }
   }
 }
 

--- a/src/service/cloudfront/sdk/sim-cf-key-value-store-sdk-command-router.iso.test.ts
+++ b/src/service/cloudfront/sdk/sim-cf-key-value-store-sdk-command-router.iso.test.ts
@@ -1,0 +1,110 @@
+import {
+  CloudFrontClient,
+  CreateKeyValueStoreCommand,
+  DescribeKeyValueStoreCommand,
+  ListKeyValueStoresCommand,
+} from "@aws-sdk/client-cloudfront";
+import {
+  CloudFrontKeyValueStoreClient,
+  DescribeKeyValueStoreCommand as DescribeKeyValueStoreDataCommand,
+  GetKeyCommand,
+  ListKeysCommand,
+  PutKeyCommand,
+} from "@aws-sdk/client-cloudfront-keyvaluestore";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimSdk } from "../../../sdk/index.js";
+
+describe("simulated key value store SDK Command routing", () => {
+  it("round-trips a key value store through both intercepted clients", async () => {
+    // Given the two clients AWS splits this across, both intercepted
+    using simSdk = new SimSdk();
+    const cloudFront = new CloudFrontClient({ region: "us-east-1" });
+    const keyValueStore = new CloudFrontKeyValueStoreClient({
+      region: "us-east-1",
+    });
+    simSdk.intercept(cloudFront);
+    simSdk.intercept(keyValueStore);
+
+    // When the CloudFront client creates the store
+    const created = await cloudFront.send(
+      new CreateKeyValueStoreCommand({ Name: "redirects" }),
+    );
+    assertNonNullable(created.KeyValueStore?.ARN);
+    assertNonNullable(created.ETag);
+
+    // And the key value store client writes to it
+    await keyValueStore.send(
+      new PutKeyCommand({
+        KvsARN: created.KeyValueStore.ARN,
+        Key: "/old",
+        Value: "/new",
+        IfMatch: created.ETag,
+      }),
+    );
+
+    // Then the key written through one client is readable through the other's
+    // store, because both reach the same simulated CloudFront
+    const read = await keyValueStore.send(
+      new GetKeyCommand({ KvsARN: created.KeyValueStore.ARN, Key: "/old" }),
+    );
+    assertIdentical(read.Value, "/new");
+
+    const listed = await keyValueStore.send(
+      new ListKeysCommand({ KvsARN: created.KeyValueStore.ARN }),
+    );
+    assertArrayLength(listed.Items ?? [], 1);
+  });
+
+  it("keeps the two DescribeKeyValueStore commands apart", async () => {
+    // Given a store, and both clients intercepted
+    using simSdk = new SimSdk();
+    const cloudFront = new CloudFrontClient({ region: "us-east-1" });
+    const keyValueStore = new CloudFrontKeyValueStoreClient({
+      region: "us-east-1",
+    });
+    simSdk.intercept(cloudFront);
+    simSdk.intercept(keyValueStore);
+
+    const created = await cloudFront.send(
+      new CreateKeyValueStoreCommand({ Name: "redirects" }),
+    );
+    assertNonNullable(created.KeyValueStore?.ARN);
+
+    // When each client sends its own command of that name
+    const resource = await cloudFront.send(
+      new DescribeKeyValueStoreCommand({ Name: "redirects" }),
+    );
+    const data = await keyValueStore.send(
+      new DescribeKeyValueStoreDataCommand({
+        KvsARN: created.KeyValueStore.ARN,
+      }),
+    );
+
+    // Then each answers with its own thing: the CloudFront client with the
+    // resource, the data client with what is in it. The command names are the
+    // same and do not collide, because routing resolves the service first.
+    assertIdentical(resource.KeyValueStore?.Name, "redirects");
+    assertIdentical(data.ItemCount, 0);
+    assertIdentical(data.KvsARN, created.KeyValueStore.ARN);
+  });
+
+  it("lists stores created through the intercepted client", async () => {
+    // Given a store created through an intercepted CloudFront client
+    using simSdk = new SimSdk();
+    const cloudFront = new CloudFrontClient({ region: "us-east-1" });
+    simSdk.intercept(cloudFront);
+    await cloudFront.send(new CreateKeyValueStoreCommand({ Name: "flags" }));
+
+    // When the stores are listed through the same client
+    const listed = await cloudFront.send(new ListKeyValueStoresCommand({}));
+
+    // Then the store is there
+    assertIdentical(listed.KeyValueStoreList?.Quantity, 1);
+  });
+});

--- a/src/service/cloudfront/sdk/sim-cf-key-value-store-sdk-command-router.iso.test.ts
+++ b/src/service/cloudfront/sdk/sim-cf-key-value-store-sdk-command-router.iso.test.ts
@@ -36,15 +36,22 @@ describe("simulated key value store SDK Command routing", () => {
       new CreateKeyValueStoreCommand({ Name: "redirects" }),
     );
     assertNonNullable(created.KeyValueStore?.ARN);
-    assertNonNullable(created.ETag);
 
-    // And the key value store client writes to it
+    // And the key value store client writes to it, carrying the ETag from its
+    // own describe rather than the one CloudFront just returned
+    const described = await keyValueStore.send(
+      new DescribeKeyValueStoreDataCommand({
+        KvsARN: created.KeyValueStore.ARN,
+      }),
+    );
+    assertNonNullable(described.ETag);
+
     await keyValueStore.send(
       new PutKeyCommand({
         KvsARN: created.KeyValueStore.ARN,
         Key: "/old",
         Value: "/new",
-        IfMatch: created.ETag,
+        IfMatch: described.ETag,
       }),
     );
 

--- a/src/service/cloudfront/sdk/sim-cf-key-value-store-sdk-command-router.ts
+++ b/src/service/cloudfront/sdk/sim-cf-key-value-store-sdk-command-router.ts
@@ -1,0 +1,94 @@
+import {
+  simSdkCallerOptions,
+  type SimSdkCommandRoute,
+  type SimSdkCommandRouter,
+} from "../../../sdk/index.js";
+import type {
+  SimKvsDeleteKeyCommand,
+  SimKvsDescribeKeyValueStoreCommand,
+  SimKvsGetKeyCommand,
+  SimKvsListKeysCommand,
+  SimKvsPutKeyCommand,
+  SimKvsUpdateKeysCommand,
+} from "../command/key-value-store-data/sim-cf-key-value-store-data-command.types.js";
+import type { SimCloudFrontKeyValueStoreApi } from "../sim-cloudfront-key-value-store.js";
+
+/**
+ * Routes intercepted key value store SDK Commands to one scoped simulated
+ * CloudFront's stores.
+ *
+ * DescribeKeyValueStore is a command name both this client and the CloudFront
+ * client have, answering with different things. They do not collide because
+ * interception resolves the router by the client's AWS service first, and only
+ * then looks up the command name.
+ */
+export class SimCloudFrontKeyValueStoreSdkCommandRouter implements SimSdkCommandRouter {
+  private readonly routes: ReadonlyMap<string, SimSdkCommandRoute>;
+
+  constructor(keyValueStore: SimCloudFrontKeyValueStoreApi) {
+    this.routes = new Map<string, SimSdkCommandRoute>([
+      [
+        "DescribeKeyValueStoreCommand",
+        async (command, context): Promise<unknown> =>
+          await keyValueStore.describeKeyValueStore(
+            command as SimKvsDescribeKeyValueStoreCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "GetKeyCommand",
+        async (command, context): Promise<unknown> =>
+          await keyValueStore.getKey(
+            command as SimKvsGetKeyCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "ListKeysCommand",
+        async (command, context): Promise<unknown> =>
+          await keyValueStore.listKeys(
+            command as SimKvsListKeysCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "PutKeyCommand",
+        async (command, context): Promise<unknown> =>
+          await keyValueStore.putKey(
+            command as SimKvsPutKeyCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "DeleteKeyCommand",
+        async (command, context): Promise<unknown> =>
+          await keyValueStore.deleteKey(
+            command as SimKvsDeleteKeyCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "UpdateKeysCommand",
+        async (command, context): Promise<unknown> =>
+          await keyValueStore.updateKeys(
+            command as SimKvsUpdateKeysCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+    ]);
+  }
+
+  /**
+   * The SDK Command names the simulated key value store data API can handle.
+   */
+  supportedCommandNames(): readonly string[] {
+    return this.routes.keys().toArray();
+  }
+
+  /**
+   * Get the route for an SDK Command name, if the data API supports it.
+   */
+  route(commandName: string): SimSdkCommandRoute | undefined {
+    return this.routes.get(commandName);
+  }
+}

--- a/src/service/cloudfront/sdk/sim-cloudfront-sdk-command-router.ts
+++ b/src/service/cloudfront/sdk/sim-cloudfront-sdk-command-router.ts
@@ -8,6 +8,13 @@ import type { SimCreateFunctionCommand } from "../command/create-function/create
 import type { SimDeleteDistributionCommand } from "../command/delete-distribution/delete-distribution.command.js";
 import type { SimDeleteFunctionCommand } from "../command/delete-function/delete-function.command.js";
 import type { SimGetDistributionCommand } from "../command/get-distribution/get-distribution.command.js";
+import type {
+  SimCreateKeyValueStoreCommand,
+  SimDeleteKeyValueStoreCommand,
+  SimDescribeKeyValueStoreCommand,
+  SimListKeyValueStoresCommand,
+  SimUpdateKeyValueStoreCommand,
+} from "../command/key-value-store/sim-cf-key-value-store-command.types.js";
 import type { SimUpdateDistributionCommand } from "../command/update-distribution/update-distribution.command.js";
 import type { SimCloudFront } from "../sim-cloudfront.js";
 
@@ -59,6 +66,56 @@ export class SimCloudFrontSdkCommandRouter implements SimSdkCommandRouter {
             command as SimGetDistributionCommand,
             simSdkCallerOptions(context),
           ),
+      ],
+      [
+        "CreateKeyValueStoreCommand",
+        async (command, context): Promise<unknown> =>
+          await simCloudFront
+            .keyValueStores()
+            .createKeyValueStore(
+              command as SimCreateKeyValueStoreCommand,
+              simSdkCallerOptions(context),
+            ),
+      ],
+      [
+        "DescribeKeyValueStoreCommand",
+        async (command, context): Promise<unknown> =>
+          await simCloudFront
+            .keyValueStores()
+            .describeKeyValueStore(
+              command as SimDescribeKeyValueStoreCommand,
+              simSdkCallerOptions(context),
+            ),
+      ],
+      [
+        "ListKeyValueStoresCommand",
+        async (command, context): Promise<unknown> =>
+          await simCloudFront
+            .keyValueStores()
+            .listKeyValueStores(
+              command as SimListKeyValueStoresCommand,
+              simSdkCallerOptions(context),
+            ),
+      ],
+      [
+        "UpdateKeyValueStoreCommand",
+        async (command, context): Promise<unknown> =>
+          await simCloudFront
+            .keyValueStores()
+            .updateKeyValueStore(
+              command as SimUpdateKeyValueStoreCommand,
+              simSdkCallerOptions(context),
+            ),
+      ],
+      [
+        "DeleteKeyValueStoreCommand",
+        async (command, context): Promise<unknown> =>
+          await simCloudFront
+            .keyValueStores()
+            .deleteKeyValueStore(
+              command as SimDeleteKeyValueStoreCommand,
+              simSdkCallerOptions(context),
+            ),
       ],
       [
         "UpdateDistributionCommand",

--- a/src/service/cloudfront/sim-cloudfront-commands.ts
+++ b/src/service/cloudfront/sim-cloudfront-commands.ts
@@ -55,6 +55,10 @@ import {
 import type { SimCloudFrontOriginAccessControlRegistry } from "./origin-access-control/sim-cf-origin-access-control-registry.js";
 import type { SimCloudFrontResponseHeadersPolicyRegistry } from "./response-headers-policy/sim-cf-response-headers-policy-registry.js";
 import { SimCloudFrontRegistry } from "./registry/sim-cloud-front-registry.js";
+import { SimCfKeyValueStoreAccess } from "./key-value-store/sim-cf-key-value-store-access.js";
+import { SimCfKeyValueStoreCommands } from "./key-value-store/sim-cf-key-value-store-commands.js";
+import { SimCloudFrontKeyValueStoreRegistry } from "./key-value-store/sim-cf-key-value-store-registry.js";
+import { SimCloudFrontKeyValueStoreApi } from "./sim-cloudfront-key-value-store.js";
 
 /**
  * How one simulated CloudFront is put together.
@@ -119,6 +123,16 @@ interface SimCloudFrontFunctionState {
  * what it should be: state plus delegation.
  */
 export class SimCloudFrontCommands {
+  /**
+   * The key value store commands on the CloudFront client.
+   */
+  public readonly keyValueStores: SimCfKeyValueStoreCommands;
+
+  /**
+   * The key value store data API over those same stores.
+   */
+  public readonly keyValueStoreApi: SimCloudFrontKeyValueStoreApi;
+
   private readonly distributionState: SimCloudFrontDistributionState;
   private readonly functionState: SimCloudFrontFunctionState;
   private readonly s3OriginResolver: SimCloudFrontS3OriginResolver;
@@ -160,6 +174,19 @@ export class SimCloudFrontCommands {
     this.acmRegistry = acmRegistry;
     this.originAccessControls = properties.originAccessControls;
     this.responseHeadersPolicies = properties.responseHeadersPolicies;
+    const keyValueStoreAccess = new SimCfKeyValueStoreAccess({
+      accountId,
+      stores: new SimCloudFrontKeyValueStoreRegistry(),
+      iam,
+      background,
+    });
+
+    // Nothing can be associated with a store yet, so the delete command's
+    // in-use guard is left on its default. See SimCfKeyValueStoreUsers.
+    this.keyValueStores = new SimCfKeyValueStoreCommands(keyValueStoreAccess);
+    this.keyValueStoreApi = new SimCloudFrontKeyValueStoreApi(
+      keyValueStoreAccess,
+    );
   }
 
   /**

--- a/src/service/cloudfront/sim-cloudfront-key-value-store.ts
+++ b/src/service/cloudfront/sim-cloudfront-key-value-store.ts
@@ -1,0 +1,118 @@
+import type { SimSdkCommandRouter } from "../../sdk/router/sim-sdk-command-router.type.js";
+import type { SimAwsCaller } from "../aws/caller/sim-aws-caller.js";
+import { SimKvsKeyReads } from "./command/key-value-store-data/sim-kvs-key-reads.js";
+import { SimKvsKeyWrites } from "./command/key-value-store-data/sim-kvs-key-writes.js";
+import type {
+  SimCfKeyValueStoreWriteOutput,
+  SimKvsDeleteKeyCommand,
+  SimKvsDescribeKeyValueStoreCommand,
+  SimKvsDescribeKeyValueStoreCommandOutput,
+  SimKvsGetKeyCommand,
+  SimKvsGetKeyCommandOutput,
+  SimKvsListKeysCommand,
+  SimKvsListKeysCommandOutput,
+  SimKvsPutKeyCommand,
+  SimKvsUpdateKeysCommand,
+} from "./command/key-value-store-data/sim-cf-key-value-store-data-command.types.js";
+import type { SimCfKeyValueStoreAccess } from "./key-value-store/sim-cf-key-value-store-access.js";
+import { SimCloudFrontKeyValueStoreSdkCommandRouter } from "./sdk/sim-cf-key-value-store-sdk-command-router.js";
+
+/**
+ * Options carried by any simulated key value store data request.
+ */
+export interface SimCfKeyValueStoreRequestOptions {
+  readonly caller?: SimAwsCaller;
+}
+
+/**
+ * Simulated CloudFront key value store data API.
+ *
+ * This is a second API over one simulated CloudFront's stores rather than a
+ * service of its own, which is what AWS has too: the stores here are the ones
+ * this Account's CloudFront created, and the resource is owned by the
+ * CloudFront client while the data is written through this one.
+ *
+ * It exists separately because the AWS SDK splits it that way. Application code
+ * and deploy scripts that populate a store import
+ * `@aws-sdk/client-cloudfront-keyvaluestore`, so a test exercising that code
+ * needs the same split rather than the writes hanging off `cloudFront()`.
+ */
+export class SimCloudFrontKeyValueStoreApi {
+  private readonly reads: SimKvsKeyReads;
+  private readonly writes: SimKvsKeyWrites;
+  private readonly sdkRouter = new SimCloudFrontKeyValueStoreSdkCommandRouter(
+    this,
+  );
+
+  constructor(access: SimCfKeyValueStoreAccess) {
+    this.reads = new SimKvsKeyReads(access);
+    this.writes = new SimKvsKeyWrites(access);
+  }
+
+  /**
+   * Handle a DescribeKeyValueStore Command from the key value store SDK.
+   */
+  async describeKeyValueStore(
+    command: SimKvsDescribeKeyValueStoreCommand,
+    options?: SimCfKeyValueStoreRequestOptions,
+  ): Promise<SimKvsDescribeKeyValueStoreCommandOutput> {
+    return await this.reads.describeKeyValueStore(command, options);
+  }
+
+  /**
+   * Handle a GetKey Command from the SDK.
+   */
+  async getKey(
+    command: SimKvsGetKeyCommand,
+    options?: SimCfKeyValueStoreRequestOptions,
+  ): Promise<SimKvsGetKeyCommandOutput> {
+    return await this.reads.getKey(command, options);
+  }
+
+  /**
+   * Handle a ListKeys Command from the SDK.
+   */
+  async listKeys(
+    command: SimKvsListKeysCommand,
+    options?: SimCfKeyValueStoreRequestOptions,
+  ): Promise<SimKvsListKeysCommandOutput> {
+    return await this.reads.listKeys(command, options);
+  }
+
+  /**
+   * Handle a PutKey Command from the SDK.
+   */
+  async putKey(
+    command: SimKvsPutKeyCommand,
+    options?: SimCfKeyValueStoreRequestOptions,
+  ): Promise<SimCfKeyValueStoreWriteOutput> {
+    return await this.writes.putKey(command, options);
+  }
+
+  /**
+   * Handle a DeleteKey Command from the SDK.
+   */
+  async deleteKey(
+    command: SimKvsDeleteKeyCommand,
+    options?: SimCfKeyValueStoreRequestOptions,
+  ): Promise<SimCfKeyValueStoreWriteOutput> {
+    return await this.writes.deleteKey(command, options);
+  }
+
+  /**
+   * Handle an UpdateKeys Command from the SDK.
+   */
+  async updateKeys(
+    command: SimKvsUpdateKeysCommand,
+    options?: SimCfKeyValueStoreRequestOptions,
+  ): Promise<SimCfKeyValueStoreWriteOutput> {
+    return await this.writes.updateKeys(command, options);
+  }
+
+  /**
+   * Get this service's SDK Command router for SDK client interception.
+   */
+  sdkCommandRouter(): SimSdkCommandRouter {
+    return this.sdkRouter;
+  }
+}

--- a/src/service/cloudfront/sim-cloudfront.ts
+++ b/src/service/cloudfront/sim-cloudfront.ts
@@ -48,6 +48,8 @@ import type {
   SimCloudFrontOriginAccessControlId,
 } from "./origin-access-control/sim-cf-origin-access-control.js";
 import { SimCloudFrontOriginAccessControlRegistry } from "./origin-access-control/sim-cf-origin-access-control-registry.js";
+import type { SimCfKeyValueStoreCommands } from "./key-value-store/sim-cf-key-value-store-commands.js";
+import type { SimCloudFrontKeyValueStoreApi } from "./sim-cloudfront-key-value-store.js";
 import { SimCloudFrontSdkCommandRouter } from "./sdk/sim-cloudfront-sdk-command-router.js";
 import {
   SimCloudFrontCommands,
@@ -90,6 +92,23 @@ export class SimCloudFront {
       originAccessControls: this.originAccessControls,
       responseHeadersPolicies: this.responseHeadersPolicies,
     });
+  }
+
+  /**
+   * The key value store commands, and the stores they work on.
+   */
+  keyValueStores(): SimCfKeyValueStoreCommands {
+    return this.commands.keyValueStores;
+  }
+
+  /**
+   * The key value store data API over this sim CloudFront's stores.
+   *
+   * This is what the separate `@aws-sdk/client-cloudfront-keyvaluestore`
+   * client talks to, reached from SimAws as `cloudFrontKeyValueStore()`.
+   */
+  keyValueStoreApi(): SimCloudFrontKeyValueStoreApi {
+    return this.commands.keyValueStoreApi;
   }
 
   /**


### PR DESCRIPTION
A key value store holds data a CloudFront Function reads at request time, so a redirect table or a feature flag does not have to be baked into the Function's code. AWS splits this across two SDK clients and so does this: the CloudFront client owns the resource, with `CreateKeyValueStore`, `DescribeKeyValueStore`, `ListKeyValueStores`, `UpdateKeyValueStore` and `DeleteKeyValueStore` addressing a store by name, and `@aws-sdk/client-cloudfront-keyvaluestore` owns the data, with `GetKey`, `PutKey`, `DeleteKey`, `ListKeys`, `UpdateKeys` and its own `DescribeKeyValueStore` addressing it by ARN. Both reach one registry, mirroring how sim DynamoDB Streams is a second API over sim DynamoDB's state, and both are intercepted by `SimSdk`. The two same-named `DescribeKeyValueStore` commands do not collide because routing resolves the client's service before the command name, and there is a test for that.

Unlike the Distribution and Function commands, these enforce the `IfMatch` ETag rather than accepting and ignoring it: the data API requires it on every write and CloudFront refuses a stale one, so a caller that does not thread the ETag through fails here the way it would against CloudFront. That difference is written up in the docs alongside the other limitations, which now also record the absent size quota, `ImportSource` being ignored, and listing not being paginated.

Two things worth flagging for review. The delete command's "still in use" guard is behind `SimCfKeyValueStoreUsers`, defaulted to "nothing uses one", because a Function cannot be associated with a store until #521; the guard is tested against a stub so wiring the real one in is a change of collaborator rather than a change to the command. And `@aws-sdk/client-cloudfront-keyvaluestore` is added as a devDependency so the tests check the structural types against the real client, which is how the batch types were caught marking required members as `string | undefined`.

Resolves https://github.com/KensioSoftware/yulin/issues/519


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added simulated CloudFront key-value store support.
  * Create, describe, list, update, and delete stores with asynchronous provisioning.
  * Read, write, batch-update, delete, and list stored keys.
  * Added ETag-based concurrency checks and IAM authorization behavior.
  * Added SDK routing and service accessors for key-value store operations.
* **Documentation**
  * Added usage guidance, examples, supported operations, and known limitations.
* **Tests**
  * Added comprehensive coverage for lifecycle, data operations, errors, ETags, permissions, and SDK integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->