### PR TITLE
feat: create a key value store from CloudFormation

### DIFF
--- a/docs/services/cloudfront/README.md
+++ b/docs/services/cloudfront/README.md
@@ -1475,6 +1475,38 @@ the CloudFront Function event types. Each invocation gets its own `cf` through N
 context, so two Functions associated with different stores read their own even when they run at the
 same time.
 
+### From CloudFormation
+
+`AWS::CloudFront::KeyValueStore` creates a store, and a Function associates one with
+`FunctionConfig.KeyValueStoreAssociations`. CloudFormation takes a plain array there rather than the
+`Quantity` and `Items` pair the SDK uses, and `Ref` on a key value store is its ARN, so the two fit
+together directly:
+
+```yaml
+Redirects:
+  Type: AWS::CloudFront::KeyValueStore
+  Properties:
+    Name: redirects
+
+RedirectFunction:
+  Type: AWS::CloudFront::Function
+  Properties:
+    Name: redirect-cff
+    AutoPublish: true
+    FunctionCode: !Sub "..."
+    FunctionConfig:
+      Comment: Redirects from a key value store
+      Runtime: cloudfront-js-2.0
+      KeyValueStoreAssociations:
+        - KeyValueStoreARN: !Ref Redirects
+```
+
+`Fn::GetAtt` supports `Arn`, `Id` and `Status`. Deleting the Stack deletes the store, after the
+Functions holding it have gone.
+
+CDK's `cloudfront.KeyValueStore` and the `keyValueStore` prop on `cloudfront.Function` both deploy,
+so a CDK stack needs no hand-editing.
+
 `cf.kvs()` refuses when the Function is associated with no store, and refuses an ID that is not the
 associated store's. Neither hands back an empty store, which would let a Function that lost its
 association run to completion and quietly take every default.
@@ -1495,6 +1527,7 @@ Sim CloudFront currently supports:
 - `viewer-request` and `viewer-response` CloudFront Functions, including async ones
 - CloudFront Functions reading an associated key value store through `cf.kvs()`
 - `AWS::CloudFront::ResponseHeadersPolicy`, for headers a cache Behavior sets on every response
+- `AWS::CloudFront::KeyValueStore`, and `KeyValueStoreAssociations` on `AWS::CloudFront::Function`
 - `AWS::CloudFront::OriginAccessControl`, so an Origin reads a private Bucket as CloudFront
 - Viewer certificates from sim ACM, including CloudFront's `us-east-1` requirement
 - Serving simulated CloudFront traffic on localhost with `serveSimAws`
@@ -1540,8 +1573,15 @@ Where sim CloudFront knowingly behaves differently from AWS:
 - **A key value store association cannot be changed after the Function is created.** There is no
   `UpdateFunction` here, so the store a Function reads is the one it was created with. Delete the
   Function and create it again to change it.
-- **`ImportSource` is not supported.** `CreateKeyValueStoreCommand` ignores it, so a store is always
-  created empty rather than seeded from an S3 Object.
+- **`ImportSource` is not supported.** `CreateKeyValueStoreCommand` ignores it, and
+  `AWS::CloudFront::KeyValueStore` refuses a Resource carrying one rather than deploying a store that
+  came up empty. Nothing here reads an S3 Object as key data, and a test passing against no data the
+  deploy would have seeded is the failure worth avoiding. Write the keys with `PutKey` or
+  `UpdateKeys` instead.
+- **A `Status` Output holds the status at deploy time.** CloudFormation Outputs are resolved once,
+  while a new store is still `PROVISIONING`, so `Fn::GetAtt` on `Status` in an Output reads
+  `PROVISIONING` even though the store goes on to become `READY`. Read the store itself for its
+  current status.
 - **Key listing is not paginated.** `ListKeysCommand` and `ListKeyValueStoresCommand` answer with
   everything and never set a `NextToken` or `NextMarker`, so a test cannot exercise a paging loop.
 - **A deletion does not wait for the disable to deploy.** Real CloudFront needs the disabled

--- a/src/service/cloudformation/cdk/cloudfront/sim-cdk-cf-key-value-store.loc.test.ts
+++ b/src/service/cloudformation/cdk/cloudfront/sim-cdk-cf-key-value-store.loc.test.ts
@@ -1,0 +1,120 @@
+import {
+  DescribeKeyValueStoreCommand,
+  PutKeyCommand,
+} from "@aws-sdk/client-cloudfront-keyvaluestore";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+} from "@kensio/smartass";
+import path from "node:path";
+import { describe, it } from "vitest";
+
+/**
+ * Slower local integration test. Calls the real CDK CLI to synth the output
+ * template file to pass to sim CloudFormation, so the template under test is
+ * one CDK actually produced rather than one written by hand.
+ */
+import { SimAws } from "../../../aws/sim-aws.js";
+import { TestCdkProject } from "../../../../util/filesystem/test-cdk-project.js";
+
+const accountIdOneOnes = "111111111111";
+
+/**
+ * A Function reading its associated store, written the way CDK inlines it.
+ */
+const redirectFunctionSource = `
+import cf from "cloudfront";
+
+async function handler(event) {
+  var request = event.request;
+
+  if (await cf.kvs().exists(request.uri)) {
+    request.uri = await cf.kvs().get(request.uri);
+  }
+
+  return request;
+}
+`;
+
+describe("Sim CDK CloudFront key value store deployment local integration", () => {
+  it("deploys a CDK key value store a CDK Function reads", async () => {
+    // Given a CDK stack with a key value store and a CloudFront Function
+    // that CDK associates with it
+    const cdkProject = new TestCdkProject();
+    await cdkProject.writeCdkAppFile(
+      `
+import * as cdk from "aws-cdk-lib/core";
+import * as cloudfront from "aws-cdk-lib/aws-cloudfront";
+
+const app = new cdk.App();
+const stack = new cdk.Stack(app, "TestStack", {
+  env: { account: "111111111111", region: "eu-west-2" },
+});
+
+const store = new cloudfront.KeyValueStore(stack, "Redirects", {
+  keyValueStoreName: "redirects",
+  comment: "Where old paths go",
+});
+
+new cloudfront.Function(stack, "RedirectFunction", {
+  functionName: "cdk-redirect-cff",
+  runtime: cloudfront.FunctionRuntime.JS_2_0,
+  code: cloudfront.FunctionCode.fromInline(${JSON.stringify(redirectFunctionSource)}),
+  keyValueStore: store,
+});
+
+new cdk.CfnOutput(stack, "StoreArn", { value: store.keyValueStoreArn });
+
+app.synth();
+      `,
+    );
+
+    // And we synth the CDK template.
+    const cdkOutDirectory = await cdkProject.synth();
+
+    // When we deploy the synthesized template, with no hand-editing of the
+    // AWS::CloudFront::KeyValueStore Resource CDK emits
+    const simAws = new SimAws();
+    const scoped = simAws.account(accountIdOneOnes).region("eu-west-2");
+    const stack = await scoped
+      .cloudFormation()
+      .deployTemplateFile(
+        path.join(cdkOutDirectory, "TestStack.template.json"),
+      );
+    await simAws.backgroundTasksComplete();
+
+    // Then the store CDK declared is there, and its ARN is what CDK output
+    const store = scoped.cloudFront().keyValueStores().byName("redirects");
+    assertNonNullable(store);
+    assertIdentical(stack.outputs.get("StoreArn")?.value, store.arn);
+    assertIdentical(store.status, "READY");
+
+    // And the Function CDK associated with it reads a key written afterwards,
+    // through the association CDK's keyValueStore prop produced
+    const data = scoped.cloudFrontKeyValueStore();
+    const described = await data.describeKeyValueStore(
+      new DescribeKeyValueStoreCommand({ KvsARN: store.arn }),
+    );
+    await data.putKey(
+      new PutKeyCommand({
+        KvsARN: store.arn,
+        Key: "/old",
+        Value: "/new",
+        IfMatch: described.ETag,
+      }),
+    );
+
+    const cff = scoped
+      .cloudFront()
+      .getCloudFrontFunctionByName("cdk-redirect-cff");
+    assertNonNullable(cff);
+    assertIdentical(cff.keyValueStore?.arn, store.arn);
+
+    const result = await cff.handleViewerRequest(
+      new Request("https://cdn.test/old"),
+    );
+    assertInstanceOf(result, Request);
+    assertIdentical(new URL(result.url).pathname, "/new");
+  });
+});

--- a/src/service/cloudformation/resource/cfn/cloudfront/sim-cloudfront-cfn-value-adapter.ts
+++ b/src/service/cloudformation/resource/cfn/cloudfront/sim-cloudfront-cfn-value-adapter.ts
@@ -6,6 +6,8 @@ import { SimCloudFrontResponseHeadersPolicy } from "../../../../cloudfront/respo
 import { SimCloudFrontResponseHeadersPolicyCfn } from "./sim-cloudfront-rh-policy-cfn.js";
 import { SimCloudFrontOriginAccessControl } from "../../../../cloudfront/origin-access-control/sim-cf-origin-access-control.js";
 import { SimCloudFrontOriginAccessControlCfn } from "./sim-cloudfront-oac-cfn.js";
+import { SimCloudFrontKeyValueStore } from "../../../../cloudfront/key-value-store/sim-cf-key-value-store.js";
+import { SimCloudFrontKeyValueStoreCfn } from "./sim-cloudfront-kvs-cfn.js";
 import type {
   SimCfnResourceValueAdapterProperties,
   SimCfnServiceValueAdapter,
@@ -48,6 +50,15 @@ export function cloudFrontValueAdapter(
   ) {
     return new SimCloudFrontOriginAccessControlCfn({
       originAccessControl: properties.simResource,
+    });
+  }
+
+  if (
+    properties.type === "AWS::CloudFront::KeyValueStore" &&
+    properties.simResource instanceof SimCloudFrontKeyValueStore
+  ) {
+    return new SimCloudFrontKeyValueStoreCfn({
+      keyValueStore: properties.simResource,
     });
   }
 

--- a/src/service/cloudformation/resource/cfn/cloudfront/sim-cloudfront-kvs-cfn.ts
+++ b/src/service/cloudformation/resource/cfn/cloudfront/sim-cloudfront-kvs-cfn.ts
@@ -1,0 +1,51 @@
+import type { SimCloudFrontKeyValueStore } from "../../../../cloudfront/key-value-store/sim-cf-key-value-store.js";
+import type { SimCfnTemplateValue } from "../../../template/value/sim-cfn-template-value.js";
+import type { SimCfnResourceValueAdapter } from "../sim-cfn-resource-value-adapter.js";
+
+interface SimCloudFrontKeyValueStoreCfnProperties {
+  readonly keyValueStore: SimCloudFrontKeyValueStore;
+}
+
+/**
+ * CloudFormation-facing behavior for an AWS::CloudFront::KeyValueStore
+ * Resource.
+ */
+export class SimCloudFrontKeyValueStoreCfn implements SimCfnResourceValueAdapter {
+  private readonly keyValueStore: SimCloudFrontKeyValueStore;
+
+  constructor(properties: SimCloudFrontKeyValueStoreCfnProperties) {
+    this.keyValueStore = properties.keyValueStore;
+  }
+
+  /**
+   * CloudFormation Ref for AWS::CloudFront::KeyValueStore returns the ARN.
+   *
+   * That is the odd one out among the CloudFront resources here, which Ref to
+   * an ID, and it is what makes `Ref` usable straight from a Function's
+   * `KeyValueStoreARN`.
+   */
+  refValue(): SimCfnTemplateValue {
+    return this.keyValueStore.arn;
+  }
+
+  /**
+   * CloudFormation attributes for AWS::CloudFront::KeyValueStore.
+   */
+  attributeValue(attributeName: string): SimCfnTemplateValue {
+    switch (attributeName) {
+      case "Arn": {
+        return this.keyValueStore.arn;
+      }
+      case "Id": {
+        return this.keyValueStore.id;
+      }
+      case "Status": {
+        return this.keyValueStore.status;
+      }
+      default: {
+        /* v8 ignore next */
+        return `${this.keyValueStore.id}.${attributeName}`;
+      }
+    }
+  }
+}

--- a/src/service/cloudfront/cfn/cff/sim-cfn-cff-function-config.ts
+++ b/src/service/cloudfront/cfn/cff/sim-cfn-cff-function-config.ts
@@ -12,6 +12,12 @@ export type SimCfnCffRuntime = "cloudfront-js-1.0" | "cloudfront-js-2.0";
 export interface SimCfnCffFunctionConfig {
   readonly Comment?: string | undefined;
   readonly Runtime?: SimCfnCffRuntime | undefined;
+  readonly KeyValueStoreAssociations?:
+    | {
+        readonly Quantity: number;
+        readonly Items: readonly { readonly KeyValueStoreARN: string }[];
+      }
+    | undefined;
 }
 
 const simCfnCffRuntimes = new Set<SimCfnCffRuntime>([
@@ -42,11 +48,45 @@ export function simCfnCffFunctionConfig(
 
   const commentValue = functionConfigValue["Comment"];
   const runtimeValue = functionConfigValue["Runtime"];
+  const associations = cffKeyValueStoreAssociations(
+    functionConfigValue["KeyValueStoreAssociations"],
+  );
 
   return {
     Comment: typeof commentValue === "string" ? commentValue : undefined,
     Runtime: cffRuntime(runtimeValue),
+    ...(associations !== undefined && {
+      KeyValueStoreAssociations: associations,
+    }),
   };
+}
+
+/**
+ * Read the template's key value store associations into the command's shape.
+ *
+ * CloudFormation takes a plain array here, while the CreateFunction API takes
+ * the Quantity and Items pair every other CloudFront list uses. The template is
+ * the shape being read, so the translation happens here rather than the command
+ * learning a second shape.
+ *
+ * An entry with no `KeyValueStoreARN` is dropped rather than refused. The
+ * command refuses an association it cannot resolve, and refusing it here would
+ * report the same mistake in worse terms.
+ */
+function cffKeyValueStoreAssociations(
+  value: SimCfnTemplateValue | undefined,
+): SimCfnCffFunctionConfig["KeyValueStoreAssociations"] {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+
+  const items = value
+    .filter((entry) => isCfnTemplateValueRecord(entry))
+    .map((entry) => entry["KeyValueStoreARN"])
+    .filter((arn) => typeof arn === "string")
+    .map((KeyValueStoreARN) => ({ KeyValueStoreARN }));
+
+  return { Quantity: items.length, Items: items };
 }
 
 /**

--- a/src/service/cloudfront/cfn/cff/sim-cfn-cff-function-config.ts
+++ b/src/service/cloudfront/cfn/cff/sim-cfn-cff-function-config.ts
@@ -69,24 +69,57 @@ export function simCfnCffFunctionConfig(
  * the shape being read, so the translation happens here rather than the command
  * learning a second shape.
  *
- * An entry with no `KeyValueStoreARN` is dropped rather than refused. The
- * command refuses an association it cannot resolve, and refusing it here would
- * report the same mistake in worse terms.
+ * An entry that cannot be read is refused rather than dropped. Dropping one
+ * leaves the command nothing to refuse: a Function whose only association was
+ * misspelled would deploy with no store at all and fail at request time on
+ * `cf.kvs()`, a long way from the template line that was wrong.
  */
 function cffKeyValueStoreAssociations(
   value: SimCfnTemplateValue | undefined,
 ): SimCfnCffFunctionConfig["KeyValueStoreAssociations"] {
-  if (!Array.isArray(value)) {
+  if (value === undefined || value === null) {
     return undefined;
   }
 
-  const items = value
-    .filter((entry) => isCfnTemplateValueRecord(entry))
-    .map((entry) => entry["KeyValueStoreARN"])
-    .filter((arn) => typeof arn === "string")
-    .map((KeyValueStoreARN) => ({ KeyValueStoreARN }));
+  if (!Array.isArray(value)) {
+    throw new TypeError(
+      "AWS::CloudFront::Function FunctionConfig KeyValueStoreAssociations " +
+        "must be an array",
+    );
+  }
+
+  const items = value.map((entry, index) =>
+    keyValueStoreAssociation(entry, index),
+  );
 
   return { Quantity: items.length, Items: items };
+}
+
+/**
+ * One association from the template array, refusing one that cannot be read.
+ */
+function keyValueStoreAssociation(
+  entry: SimCfnTemplateValue,
+  index: number,
+): { readonly KeyValueStoreARN: string } {
+  const at = `KeyValueStoreAssociations[${String(index)}]`;
+
+  if (!isCfnTemplateValueRecord(entry)) {
+    throw new TypeError(
+      `AWS::CloudFront::Function FunctionConfig ${at} must be an object`,
+    );
+  }
+
+  const arn = entry["KeyValueStoreARN"];
+
+  if (typeof arn !== "string") {
+    throw new TypeError(
+      `AWS::CloudFront::Function FunctionConfig ${at} KeyValueStoreARN must ` +
+        `be a string`,
+    );
+  }
+
+  return { KeyValueStoreARN: arn };
 }
 
 /**

--- a/src/service/cloudfront/cfn/key-value-store/sim-cfn-cf-kvs-config.ts
+++ b/src/service/cloudfront/cfn/key-value-store/sim-cfn-cf-kvs-config.ts
@@ -1,0 +1,75 @@
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+
+/**
+ * What a key value store Resource asks for, once read out of the template.
+ */
+export interface SimCfnCfKeyValueStoreConfig {
+  readonly name: string;
+  readonly comment: string | undefined;
+}
+
+/**
+ * Reads an AWS::CloudFront::KeyValueStore Resource.
+ *
+ * `Name` is the only required property. `Comment` is kept when it is a string.
+ *
+ * `ImportSource` seeds a store from an S3 Object at deploy time, and nothing
+ * here reads one. It is refused rather than ignored: a store that came up empty
+ * when the template said to fill it would let a test pass against no data and
+ * the same stack serve real data in AWS, which is the divergence worth failing
+ * on. Write the keys with the key value store data API instead.
+ */
+export class SimCfnCfKeyValueStoreConfigReader {
+  private readonly resource: SimCfnResource;
+  private readonly properties: SimCfnTemplateValueRecord;
+
+  constructor(properties: {
+    readonly resource: SimCfnResource;
+    readonly properties: SimCfnTemplateValueRecord;
+  }) {
+    this.resource = properties.resource;
+    this.properties = properties.properties;
+  }
+
+  /**
+   * Read the config this Resource describes.
+   */
+  read(): SimCfnCfKeyValueStoreConfig {
+    this.assertNoImportSource();
+
+    const name = this.properties["Name"];
+
+    if (typeof name !== "string") {
+      this.refuse("Name must be a string");
+    }
+
+    const comment = this.properties["Comment"];
+
+    return {
+      name,
+      comment: typeof comment === "string" ? comment : undefined,
+    };
+  }
+
+  private assertNoImportSource(): void {
+    if (this.properties["ImportSource"] === undefined) {
+      return;
+    }
+
+    this.refuse(
+      "ImportSource is not simulated, so the store would come up empty " +
+        "rather than seeded. Write the keys with PutKey or UpdateKeys on the " +
+        "key value store data API instead.",
+    );
+  }
+
+  /**
+   * Refuse this Resource, saying which part of it could not be read.
+   */
+  private refuse(detail: string): never {
+    throw new Error(
+      `Invalid AWS::CloudFront::KeyValueStore ${this.resource.logicalId}: ${detail}`,
+    );
+  }
+}

--- a/src/service/cloudfront/cfn/key-value-store/sim-cfn-cf-kvs-creator.ts
+++ b/src/service/cloudfront/cfn/key-value-store/sim-cfn-cf-kvs-creator.ts
@@ -1,0 +1,79 @@
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimCloudFrontKeyValueStore } from "../../key-value-store/sim-cf-key-value-store.js";
+import type { SimCloudFront } from "../../sim-cloudfront.js";
+import { SimCfnCfKeyValueStoreConfigReader } from "./sim-cfn-cf-kvs-config.js";
+
+interface SimCfnCfKeyValueStoreCreatorProperties {
+  readonly cloudFront: SimCloudFront;
+}
+
+/**
+ * Creates simulated key value stores from AWS::CloudFront::KeyValueStore
+ * Resources.
+ *
+ * Creation goes through the same CreateKeyValueStore command an SDK caller
+ * uses, so a duplicate name is refused here the way it is there, and the store
+ * provisions in the background the same way.
+ */
+export class SimCfnCfKeyValueStoreCreator {
+  private readonly cloudFront: SimCloudFront;
+
+  constructor(properties: SimCfnCfKeyValueStoreCreatorProperties) {
+    this.cloudFront = properties.cloudFront;
+  }
+
+  /**
+   * Create the key value store one Resource describes.
+   */
+  async create(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): Promise<SimCloudFrontKeyValueStore> {
+    const config = new SimCfnCfKeyValueStoreConfigReader({
+      resource,
+      properties,
+    }).read();
+
+    const created = await this.cloudFront.keyValueStores().createKeyValueStore({
+      input: {
+        Name: config.name,
+        ...(config.comment !== undefined && { Comment: config.comment }),
+      },
+    });
+
+    const store = this.cloudFront
+      .keyValueStores()
+      .byId(created.KeyValueStore.Id);
+
+    assertDefined(
+      store,
+      `sim CloudFront key value store ${config.name} for CloudFormation ` +
+        `Resource ${resource.logicalId}`,
+    );
+
+    return store;
+  }
+
+  /**
+   * Remove a key value store created from a Resource.
+   *
+   * The ETag is read from the store rather than carried from creation, because
+   * anything written to it since will have moved the one creation returned.
+   * Tearing a Stack down is not the place to make a caller thread that through.
+   */
+  async delete(resource: SimCfnResource): Promise<void> {
+    const store = resource.simResource as
+      | SimCloudFrontKeyValueStore
+      | undefined;
+
+    if (store === undefined) {
+      return;
+    }
+
+    await this.cloudFront.keyValueStores().deleteKeyValueStore({
+      input: { Name: store.name, IfMatch: store.resourceETag },
+    });
+  }
+}

--- a/src/service/cloudfront/cfn/key-value-store/sim-cfn-cf-kvs.iso.test.ts
+++ b/src/service/cloudfront/cfn/key-value-store/sim-cfn-cf-kvs.iso.test.ts
@@ -1,0 +1,197 @@
+import {
+  DescribeKeyValueStoreCommand,
+  PutKeyCommand,
+} from "@aws-sdk/client-cloudfront-keyvaluestore";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertStringStartsWith,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import type { CfnTemplateBodyRecord } from "../../../cloudformation/template/sim-cfn-template.js";
+
+const redirectSource = `
+  import cf from "cloudfront";
+
+  async function handler(event) {
+    const request = event.request;
+
+    if (await cf.kvs().exists(request.uri)) {
+      request.uri = await cf.kvs().get(request.uri);
+    }
+
+    return request;
+  }
+`;
+
+/**
+ * A Stack with a key value store and a Function that associates it.
+ */
+function storeAndFunctionTemplate(): CfnTemplateBodyRecord {
+  return {
+    Resources: {
+      Redirects: {
+        Type: "AWS::CloudFront::KeyValueStore",
+        Properties: { Name: "redirects", Comment: "Where old paths go" },
+      },
+      RedirectFunction: {
+        Type: "AWS::CloudFront::Function",
+        Properties: {
+          Name: "redirect-cff",
+          AutoPublish: true,
+          FunctionCode: redirectSource,
+          FunctionConfig: {
+            Comment: "Redirects from a key value store",
+            Runtime: "cloudfront-js-2.0",
+            // CloudFormation takes a plain array here, not Quantity and Items,
+            // and Ref on a key value store is its ARN.
+            KeyValueStoreAssociations: [
+              { KeyValueStoreARN: { Ref: "Redirects" } },
+            ],
+          },
+        },
+      },
+    },
+  };
+}
+
+describe("AWS::CloudFront::KeyValueStore", () => {
+  it("creates a store a Function in the same template can read", async () => {
+    // Given a Stack declaring a store and a Function that associates it
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "redirect-stack",
+      template: storeAndFunctionTemplate(),
+    });
+    await stack.waitForDeployComplete();
+
+    // When a key is written to the deployed store
+    const store = simAws.cloudFront().keyValueStores().byName("redirects");
+    assertNonNullable(store);
+
+    const data = simAws.cloudFrontKeyValueStore();
+    const described = await data.describeKeyValueStore(
+      new DescribeKeyValueStoreCommand({ KvsARN: store.arn }),
+    );
+    await data.putKey(
+      new PutKeyCommand({
+        KvsARN: store.arn,
+        Key: "/old",
+        Value: "/new",
+        IfMatch: described.ETag,
+      }),
+    );
+
+    // Then the Function the same template created reads it
+    const cff = simAws.cloudFront().getCloudFrontFunctionByName("redirect-cff");
+    assertNonNullable(cff);
+    assertIdentical(cff.keyValueStore?.arn, store.arn);
+
+    const result = await cff.handleViewerRequest(
+      new Request("https://cdn.test/old"),
+    );
+    assertInstanceOf(result, Request);
+    assertIdentical(new URL(result.url).pathname, "/new");
+  });
+
+  it("resolves Ref to the ARN and each supported attribute", async () => {
+    // Given a Stack whose Outputs read the store every way CloudFormation
+    // offers
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "outputs-stack",
+      template: {
+        Resources: {
+          Redirects: {
+            Type: "AWS::CloudFront::KeyValueStore",
+            Properties: { Name: "redirects" },
+          },
+        },
+        Outputs: {
+          StoreRef: { Value: { Ref: "Redirects" } },
+          StoreArn: { Value: { "Fn::GetAtt": ["Redirects", "Arn"] } },
+          StoreId: { Value: { "Fn::GetAtt": ["Redirects", "Id"] } },
+          StoreStatus: { Value: { "Fn::GetAtt": ["Redirects", "Status"] } },
+        },
+      },
+    });
+    await stack.waitForDeployComplete();
+
+    // When the Outputs are read
+    const store = simAws.cloudFront().keyValueStores().byName("redirects");
+    assertNonNullable(store);
+
+    // Then Ref is the ARN, which is what a Function's KeyValueStoreARN wants
+    assertIdentical(stack.outputs.get("StoreRef")?.value, store.arn);
+    assertIdentical(stack.outputs.get("StoreArn")?.value, store.arn);
+    assertIdentical(stack.outputs.get("StoreId")?.value, store.id);
+    // The Status Output holds what the store's status was when the Outputs
+    // were resolved, which is while it was still provisioning. The store
+    // itself goes on to become READY.
+    assertIdentical(stack.outputs.get("StoreStatus")?.value, "PROVISIONING");
+    await simAws.backgroundTasksComplete();
+    assertIdentical(store.status, "READY");
+  });
+
+  it("removes the store when the Stack is torn down", async () => {
+    // Given a deployed Stack with a store and the Function holding it
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "teardown-stack",
+      template: storeAndFunctionTemplate(),
+    });
+    await stack.waitForDeployComplete();
+    assertNonNullable(simAws.cloudFront().keyValueStores().byName("redirects"));
+
+    // When the Stack is deleted
+    await simAws.cloudFormation().deleteStack({
+      input: { StackName: "teardown-stack" },
+    });
+    await simAws.backgroundTasksComplete();
+
+    // Then the store is gone along with the Function that held it
+    assertUndefined(simAws.cloudFront().keyValueStores().byName("redirects"));
+    assertUndefined(
+      simAws.cloudFront().getCloudFrontFunctionByName("redirect-cff"),
+    );
+  });
+
+  it("refuses a store asking to be seeded from an ImportSource", async () => {
+    // Given a Stack whose store names an S3 Object to import
+    const simAws = new SimAws();
+
+    // When it is deployed
+    const error = await assertThrowsErrorAsync(async () => {
+      const stack = await simAws.cloudFormation().deployTemplate({
+        stackName: "import-stack",
+        template: {
+          Resources: {
+            Redirects: {
+              Type: "AWS::CloudFront::KeyValueStore",
+              Properties: {
+                Name: "redirects",
+                ImportSource: {
+                  SourceType: "S3",
+                  SourceArn: "arn:aws:s3:::seed-bucket/redirects.json",
+                },
+              },
+            },
+          },
+        },
+      });
+      await stack.waitForDeployComplete();
+    });
+
+    // Then the Stack fails rather than coming up with an empty store, which
+    // would let a test pass against no data the deploy would have seeded
+    assertStringStartsWith(
+      error.message.includes("ImportSource") ? "ImportSource" : error.message,
+      "ImportSource",
+    );
+  });
+});

--- a/src/service/cloudfront/cfn/key-value-store/sim-cfn-cf-kvs.iso.test.ts
+++ b/src/service/cloudfront/cfn/key-value-store/sim-cfn-cf-kvs.iso.test.ts
@@ -6,6 +6,7 @@ import {
   assertIdentical,
   assertInstanceOf,
   assertNonNullable,
+  assertStringIncludes,
   assertStringStartsWith,
   assertThrowsErrorAsync,
   assertUndefined,
@@ -192,6 +193,51 @@ describe("AWS::CloudFront::KeyValueStore", () => {
     assertStringStartsWith(
       error.message.includes("ImportSource") ? "ImportSource" : error.message,
       "ImportSource",
+    );
+  });
+
+  it("refuses a Function association the template got wrong", async () => {
+    // Given Stacks whose Function associations cannot be read: a misspelled
+    // key, an entry that is not an object, and a value that is not an array
+    const badAssociations: readonly [string, unknown][] = [
+      ["misspelled-key", [{ KeyValueStoreArn: "arn:aws:cloudfront::1:kvs/x" }]],
+      ["not-an-object", ["arn:aws:cloudfront::1:kvs/x"]],
+      ["not-an-array", { KeyValueStoreARN: "arn:aws:cloudfront::1:kvs/x" }],
+    ];
+
+    await Promise.all(
+      badAssociations.map(async ([name, associations]) => {
+        const simAws = new SimAws();
+
+        // When each is deployed
+        const error = await assertThrowsErrorAsync(async () => {
+          const stack = await simAws.cloudFormation().deployTemplate({
+            stackName: `bad-${name}`,
+            template: {
+              Resources: {
+                RedirectFunction: {
+                  Type: "AWS::CloudFront::Function",
+                  Properties: {
+                    Name: `cff-${name}`,
+                    AutoPublish: true,
+                    FunctionCode: redirectSource,
+                    FunctionConfig: {
+                      Comment: "Associates a store badly",
+                      Runtime: "cloudfront-js-2.0",
+                      KeyValueStoreAssociations: associations,
+                    },
+                  },
+                },
+              },
+            } as CfnTemplateBodyRecord,
+          });
+          await stack.waitForDeployComplete();
+        });
+
+        // Then the Stack fails naming the property, rather than deploying a
+        // Function with no store that fails later on cf.kvs()
+        assertStringIncludes(error.message, "KeyValueStoreAssociations");
+      }),
     );
   });
 });

--- a/src/service/cloudfront/cfn/sim-cfn-cloudfront-resource-factory.ts
+++ b/src/service/cloudfront/cfn/sim-cfn-cloudfront-resource-factory.ts
@@ -9,6 +9,7 @@ import { SimCfnCffCreator } from "./cff/sim-cfn-cff-creator.js";
 import { SimCfnCfDistroDeleter } from "./distro/sim-cfn-cf-distro-deleter.js";
 import { SimCfnCfResponseHeadersPolicyCreator } from "./response-headers-policy/sim-cfn-cf-rh-policy-creator.js";
 import { SimCfnCfOriginAccessControlCreator } from "./origin-access-control/sim-cfn-cf-oac-creator.js";
+import { SimCfnCfKeyValueStoreCreator } from "./key-value-store/sim-cfn-cf-kvs-creator.js";
 import type { SimCloudFrontFunction } from "../cff/sim-cloudfront-function.js";
 import { assertDefined } from "../../../util/type-guard/defined.js";
 
@@ -22,6 +23,7 @@ export class SimCloudFrontCloudFormationResourceFactory implements SimCfnService
   private readonly distroDeleter: SimCfnCfDistroDeleter;
   private readonly responseHeadersPolicyCreator: SimCfnCfResponseHeadersPolicyCreator;
   private readonly originAccessControlCreator: SimCfnCfOriginAccessControlCreator;
+  private readonly keyValueStoreCreator: SimCfnCfKeyValueStoreCreator;
 
   constructor(cloudFront: SimCloudFront) {
     this.cloudFront = cloudFront;
@@ -31,6 +33,9 @@ export class SimCloudFrontCloudFormationResourceFactory implements SimCfnService
     this.responseHeadersPolicyCreator =
       new SimCfnCfResponseHeadersPolicyCreator({ cloudFront });
     this.originAccessControlCreator = new SimCfnCfOriginAccessControlCreator({
+      cloudFront,
+    });
+    this.keyValueStoreCreator = new SimCfnCfKeyValueStoreCreator({
       cloudFront,
     });
   }
@@ -69,6 +74,12 @@ export class SimCloudFrontCloudFormationResourceFactory implements SimCfnService
           context.resolvedProperties ?? resource.properties,
         );
       }
+      case "KeyValueStore": {
+        return await this.keyValueStoreCreator.create(
+          resource,
+          context.resolvedProperties ?? resource.properties,
+        );
+      }
       default: {
         throw new Error(
           `Unsupported sim CloudFront CloudFormation Resource ${resourceTypeName}`,
@@ -100,6 +111,10 @@ export class SimCloudFrontCloudFormationResourceFactory implements SimCfnService
       }
       case "OriginAccessControl": {
         this.originAccessControlCreator.delete(resource);
+        return;
+      }
+      case "KeyValueStore": {
+        await this.keyValueStoreCreator.delete(resource);
         return;
       }
       default: {


### PR DESCRIPTION
`AWS::CloudFront::KeyValueStore` creates a simulated store, with `Ref` returning its ARN and `Fn::GetAtt` supporting `Arn`, `Id` and `Status`. A Function associates one with `FunctionConfig.KeyValueStoreAssociations`. Two details there were worth checking against the CloudFormation reference rather than assuming from the SDK shape, and both turned out to matter: CloudFormation takes a plain array of associations rather than the `Quantity` and `Items` pair every other CloudFront list uses, and `Ref` on a key value store is its ARN rather than its ID, which is the odd one out among the CloudFront resources here. Together they mean `!Ref` drops straight into `KeyValueStoreARN`, and the template reader translates the array into the shape `CreateFunction` already takes.

Creation goes through the same `CreateKeyValueStore` command an SDK caller uses, so a duplicate name is refused the same way. Teardown deletes the store, and because #521 made a Function hold its store open, the Functions have to go first, which the existing dependency ordering already handles. There is a local integration test that synths a real CDK stack using `cloudfront.KeyValueStore` and the `keyValueStore` prop on `cloudfront.Function`, deploys the emitted template unedited, and reads a key through the deployed Function.

`ImportSource` is refused rather than ignored. Nothing here reads an S3 Object as key data, and a store that came up empty when the template asked for it to be seeded would let a test pass against data the real deploy would have written, which is the divergence worth failing on. The refusal names `ImportSource` and points at the data API.

One limitation found while testing and now documented: CloudFormation Outputs resolve once, while a new store is still `PROVISIONING`, so `Fn::GetAtt` on `Status` in an Output reads `PROVISIONING` even though the store goes on to become `READY`. The test asserts both halves of that rather than the value I first expected.

Resolves https://github.com/KensioSoftware/yulin/issues/522


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CloudFormation support for CloudFront key-value stores.
  * Added support for associating key-value stores with CloudFront Functions.
  * CloudFormation now exposes store ARN, ID, and status attributes.
  * Added support for creating, updating, deleting, and reading key-value store entries in simulated deployments.

* **Documentation**
  * Documented configuration options, CDK compatibility, YAML examples, supported attributes, and current import limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->