### PR TITLE
fix: refuse a CloudFront list that miscounts its Items

### DIFF
--- a/docs/services/cloudfront/README.md
+++ b/docs/services/cloudfront/README.md
@@ -1560,6 +1560,12 @@ Where sim CloudFront knowingly behaves differently from AWS:
   claiming a name is refused with `OriginAccessControlAlreadyExists`, as CloudFront refuses one.
 - **There is no command surface for an origin access control.** `CreateOriginAccessControl` and its
   siblings are not simulated, so `AWS::CloudFront::OriginAccessControl` is the only way to make one.
+- **A list's `Quantity` is only checked when it is there.** Every CloudFront list carries a count
+  alongside its items, and a `Quantity` that disagrees with `Items` is refused with
+  `InconsistentQuantities`, as CloudFront refuses it. A list arriving as a plain array has no count
+  to disagree with, which is the CloudFormation shape, so a template is not checked this way. Nor is
+  a hand-written `{ Items: [...] }` with the count left out: the AWS SDK types make omitting
+  `Quantity` a compile error, so what arrives without one is not the mistake this catches.
 - **`IfMatch` ETags are not checked on a Distribution or a Function.**
   `UpdateDistributionCommand`, `DeleteDistributionCommand` and `DeleteFunctionCommand` all accept
   `IfMatch` and ignore it, so neither `PreconditionFailed` nor `InvalidIfMatchVersion` is returned

--- a/src/service/cloudfront/command/create-distribution/create-distribution.command.ts
+++ b/src/service/cloudfront/command/create-distribution/create-distribution.command.ts
@@ -35,6 +35,7 @@ export interface SimCloudFrontDistributionConfig {
   readonly CustomErrorResponses?:
     | undefined
     | {
+        readonly Quantity?: number | undefined;
         readonly Items?:
           | readonly SimCloudFrontCustomErrorResponseConfig[]
           | undefined;
@@ -42,11 +43,13 @@ export interface SimCloudFrontDistributionConfig {
   readonly Aliases?:
     | undefined
     | {
+        readonly Quantity?: number | undefined;
         readonly Items?: readonly string[] | undefined;
       };
   readonly Origins?:
     | undefined
     | {
+        readonly Quantity?: number | undefined;
         readonly Items?: readonly SimCloudFrontOriginConfig[] | undefined;
       };
   readonly DefaultCacheBehavior?:
@@ -55,6 +58,7 @@ export interface SimCloudFrontDistributionConfig {
   readonly CacheBehaviors?:
     | undefined
     | {
+        readonly Quantity?: number | undefined;
         readonly Items?:
           | readonly SimCloudFrontCacheBehaviorConfig[]
           | undefined;
@@ -162,6 +166,7 @@ export interface SimCloudFrontFunctionAssociation {
  * Minimal structural sim CloudFront allowed methods list.
  */
 export interface SimCloudFrontAllowedMethods {
+  readonly Quantity?: number | undefined;
   readonly Items?: readonly string[] | undefined;
   readonly CachedMethods?: SimCloudFrontMethodList | undefined;
 }
@@ -170,6 +175,7 @@ export interface SimCloudFrontAllowedMethods {
  * Minimal structural sim CloudFront method list.
  */
 export interface SimCloudFrontMethodList {
+  readonly Quantity?: number | undefined;
   readonly Items?: readonly string[] | undefined;
 }
 

--- a/src/service/cloudfront/command/create-distribution/sim-cf-distro-config-normalizer.ts
+++ b/src/service/cloudfront/command/create-distribution/sim-cf-distro-config-normalizer.ts
@@ -7,6 +7,7 @@ import type {
   SimCloudFrontOriginConfig,
 } from "./create-distribution.command.js";
 import { isRecord } from "../../../../util/type-guard/record.js";
+import { assertConsistentQuantity } from "../sim-cf-list-quantity.js";
 
 interface SimCloudFrontConfigList<T> {
   readonly Items?: readonly T[] | undefined;
@@ -38,17 +39,23 @@ export class SimCloudFrontDistributionConfigNormalizer {
       object
     >;
     const cacheBehaviors = this.normalizeList<SimCloudFrontCacheBehaviorConfig>(
+      "CacheBehaviors",
       distributionConfig["CacheBehaviors"],
     );
 
     return {
       ...this.distributionConfig,
-      Aliases: this.normalizeList<string>(distributionConfig["Aliases"]),
+      Aliases: this.normalizeList<string>(
+        "Aliases",
+        distributionConfig["Aliases"],
+      ),
       Origins: this.normalizeList<SimCloudFrontOriginConfig>(
+        "Origins",
         distributionConfig["Origins"],
       ),
       CustomErrorResponses:
         this.normalizeList<SimCloudFrontCustomErrorResponseConfig>(
+          "CustomErrorResponses",
           distributionConfig["CustomErrorResponses"],
         ),
       DefaultCacheBehavior:
@@ -78,17 +85,21 @@ export class SimCloudFrontDistributionConfigNormalizer {
       ...cacheBehavior,
       FunctionAssociations:
         this.normalizeList<SimCloudFrontFunctionAssociation>(
+          "FunctionAssociations",
           cacheBehaviorRecord["FunctionAssociations"],
         ),
     };
   }
 
   private normalizeList<T>(
+    listName: string,
     value: unknown,
   ): SimCloudFrontConfigList<T> | undefined {
     if (value === undefined) {
       return undefined;
     }
+
+    assertConsistentQuantity(listName, value);
 
     if (Array.isArray(value)) {
       return {

--- a/src/service/cloudfront/command/create-function/create-function-kvs-association.ts
+++ b/src/service/cloudfront/command/create-function/create-function-kvs-association.ts
@@ -1,4 +1,5 @@
 import { SimCloudFrontInvalidKeyValueStoreAssociation } from "../../error/sim-cf-key-value-store.error.js";
+import { assertConsistentQuantity } from "../sim-cf-list-quantity.js";
 import type { SimCloudFrontKeyValueStore } from "../../key-value-store/sim-cf-key-value-store.js";
 import type { SimCloudFrontKeyValueStoreRegistry } from "../../key-value-store/sim-cf-key-value-store-registry.js";
 import type { SimCreateFunctionCommandInput } from "./create-function.command.js";
@@ -25,6 +26,11 @@ export class CreateFunctionKeyValueStoreAssociation {
     functionName: string,
     config: FunctionConfig,
   ): SimCloudFrontKeyValueStore | undefined {
+    assertConsistentQuantity(
+      "KeyValueStoreAssociations",
+      config?.KeyValueStoreAssociations,
+    );
+
     const items = config?.KeyValueStoreAssociations?.Items ?? [];
 
     if (items.length === 0) {

--- a/src/service/cloudfront/command/sim-cf-list-quantity.iso.test.ts
+++ b/src/service/cloudfront/command/sim-cf-list-quantity.iso.test.ts
@@ -1,0 +1,237 @@
+import {
+  CreateDistributionCommand,
+  CreateFunctionCommand,
+  CreateKeyValueStoreCommand,
+} from "@aws-sdk/client-cloudfront";
+import { CreateBucketCommand } from "@aws-sdk/client-s3";
+import {
+  assertIdentical,
+  assertStringIncludes,
+  assertThrowsError,
+  assertThrowsErrorAsync,
+  assertTrue,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import { assertConsistentQuantity } from "./sim-cf-list-quantity.js";
+import type { SimCloudFrontDistributionConfig } from "./create-distribution/create-distribution.command.js";
+
+const anOrigin = {
+  Id: "origin1",
+  DomainName: "origin-bucket.s3.amazonaws.com",
+  S3OriginConfig: { OriginAccessIdentity: "" },
+};
+
+const aDefaultCacheBehavior = {
+  TargetOriginId: "origin1",
+  ViewerProtocolPolicy: "allow-all" as const,
+};
+
+/**
+ * A DistributionConfig that is fine apart from whatever the case overrides.
+ */
+function distributionConfig(
+  overrides: Partial<SimCloudFrontDistributionConfig>,
+): SimCloudFrontDistributionConfig {
+  return {
+    CallerReference: "quantity-ref",
+    Comment: "Quantity check",
+    Enabled: true,
+    Origins: { Quantity: 1, Items: [anOrigin] },
+    DefaultCacheBehavior: aDefaultCacheBehavior,
+    ...overrides,
+  };
+}
+
+describe("A CloudFront list whose Quantity disagrees with its Items", () => {
+  it("is refused on every list a Distribution carries", async () => {
+    // Given a DistributionConfig with one list miscounted, a list at a time
+    const miscounted: readonly [
+      string,
+      Partial<SimCloudFrontDistributionConfig>,
+    ][] = [
+      ["Origins", { Origins: { Quantity: 2, Items: [anOrigin] } }],
+      ["Aliases", { Aliases: { Quantity: 1, Items: [] } }],
+      [
+        "CustomErrorResponses",
+        {
+          CustomErrorResponses: {
+            Quantity: 0,
+            Items: [{ ErrorCode: 404, ResponsePagePath: "/404.html" }],
+          },
+        },
+      ],
+      [
+        "CacheBehaviors",
+        {
+          CacheBehaviors: {
+            Quantity: 3,
+            Items: [{ ...aDefaultCacheBehavior, PathPattern: "/api/*" }],
+          },
+        },
+      ],
+      [
+        "FunctionAssociations",
+        {
+          DefaultCacheBehavior: {
+            ...aDefaultCacheBehavior,
+            FunctionAssociations: { Quantity: 1, Items: [] },
+          },
+        },
+      ],
+      [
+        "AllowedMethods",
+        {
+          DefaultCacheBehavior: {
+            ...aDefaultCacheBehavior,
+            AllowedMethods: { Quantity: 5, Items: ["GET", "HEAD"] },
+          },
+        },
+      ],
+      [
+        "CachedMethods",
+        {
+          DefaultCacheBehavior: {
+            ...aDefaultCacheBehavior,
+            AllowedMethods: {
+              Quantity: 2,
+              Items: ["GET", "HEAD"],
+              CachedMethods: { Quantity: 9, Items: ["GET"] },
+            },
+          },
+        },
+      ],
+    ];
+
+    // When each is used to create a Distribution
+    // Then each is refused naming the list that disagrees
+    await Promise.all(
+      miscounted.map(async ([listName, overrides]) => {
+        const simAws = new SimAws();
+        await simAws
+          .s3()
+          .createBucket(new CreateBucketCommand({ Bucket: "origin-bucket" }));
+
+        const error = await assertThrowsErrorAsync(
+          async () =>
+            await simAws.cloudFront().createDistribution({
+              input: { DistributionConfig: distributionConfig(overrides) },
+            }),
+        );
+
+        assertIdentical(error.name, "InconsistentQuantities");
+        assertStringIncludes(error.message, listName);
+      }),
+    );
+  });
+
+  it("is refused on a Function's key value store associations", async () => {
+    // Given a store, and a Function miscounting its one association
+    const simAws = new SimAws();
+    const created = await simAws
+      .cloudFront()
+      .keyValueStores()
+      .createKeyValueStore(
+        new CreateKeyValueStoreCommand({ Name: "redirects" }),
+      );
+
+    // When the Function is created
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await simAws.cloudFront().createFunction(
+          new CreateFunctionCommand({
+            Name: "miscounted",
+            FunctionConfig: {
+              Comment: "Miscounts its association",
+              Runtime: "cloudfront-js-2.0",
+              KeyValueStoreAssociations: {
+                Quantity: 0,
+                Items: [{ KeyValueStoreARN: created.KeyValueStore.ARN }],
+              },
+            },
+            FunctionCode: Buffer.from(
+              "function handler(event) { return event.request; }",
+            ),
+          }),
+        ),
+    );
+
+    // Then it is refused, rather than creating a Function with no store
+    assertIdentical(error.name, "InconsistentQuantities");
+  });
+
+  it("accepts a Distribution whose counts are right", async () => {
+    // Given a DistributionConfig counting every list correctly
+    const simAws = new SimAws();
+    await simAws
+      .s3()
+      .createBucket(new CreateBucketCommand({ Bucket: "origin-bucket" }));
+
+    // When the Distribution is created through the real SDK command, so the
+    // counted lists are checked against the AWS types as well
+    const created = await simAws.cloudFront().createDistribution(
+      new CreateDistributionCommand({
+        DistributionConfig: {
+          CallerReference: "quantity-ref",
+          Comment: "Quantity check",
+          Enabled: true,
+          Origins: { Quantity: 1, Items: [anOrigin] },
+          DefaultCacheBehavior: aDefaultCacheBehavior,
+          Aliases: { Quantity: 1, Items: ["cdn.test"] },
+          CustomErrorResponses: {
+            Quantity: 1,
+            Items: [
+              {
+                ErrorCode: 404,
+                ResponsePagePath: "/404.html",
+                ResponseCode: "404",
+              },
+            ],
+          },
+        },
+      }),
+    );
+
+    // Then it is created
+    assertTrue(created.Distribution?.DistributionConfig?.Enabled);
+  });
+});
+
+describe("The Quantity check itself", () => {
+  it("has nothing to check on a plain array", () => {
+    // Given the CloudFormation shape, which is an array with no count
+    // When it is checked
+    // Then nothing is refused, because there is no Quantity to disagree
+    assertConsistentQuantity("Origins", [anOrigin]);
+  });
+
+  it("has nothing to check without a Quantity", () => {
+    // Given a hand-written list with only Items
+    // When it is checked
+    // Then it is accepted: the AWS SDK types make omitting Quantity a compile
+    // error, so what arrives without one is not the mistake this catches
+    assertConsistentQuantity("Origins", { Items: [anOrigin] });
+  });
+
+  it("counts a missing Items as none", () => {
+    // Given a list claiming items it does not carry at all
+    // When it is checked
+    const error = assertThrowsError(() => {
+      assertConsistentQuantity("Origins", { Quantity: 1 });
+    });
+
+    // Then it is refused
+    assertIdentical(error.name, "InconsistentQuantities");
+  });
+
+  it("has nothing to check on a value that is not a list", () => {
+    // Given something that is not a list at all
+    // When it is checked
+    // Then nothing is refused: whatever reads it will report it in its own
+    // terms, and this is not the place to learn a second shape
+    assertConsistentQuantity("Origins", "not a list");
+    assertConsistentQuantity("Origins", undefined);
+    assertConsistentQuantity("Origins", { Quantity: "two", Items: [] });
+  });
+});

--- a/src/service/cloudfront/command/sim-cf-list-quantity.ts
+++ b/src/service/cloudfront/command/sim-cf-list-quantity.ts
@@ -1,0 +1,45 @@
+import { isRecord } from "../../../util/type-guard/record.js";
+import { SimCloudFrontInconsistentQuantities } from "../error/sim-cloudfront.error.js";
+
+/**
+ * Refuse a CloudFront list whose `Quantity` disagrees with its `Items`.
+ *
+ * Every CloudFront list carries both a count and the items, and CloudFront
+ * refuses a request where they disagree. The count is easy to get wrong by hand
+ * and nothing else catches it: a `Quantity` of 0 alongside one item would
+ * otherwise create the item, and a `Quantity` of 1 alongside none would create
+ * nothing, either way deploying something the caller did not describe.
+ *
+ * A list arriving as a plain array carries no count to disagree with. That is
+ * the CloudFormation shape, where the property is an array rather than the pair,
+ * so there is nothing to check.
+ *
+ * A record with no `Quantity` at all is accepted rather than refused. The AWS
+ * SDK types make omitting it a compile error, so what reaches here without one
+ * is a hand-written `{ Items: [...] }`, and refusing that would be stricter
+ * than the mistake is worth.
+ */
+export function assertConsistentQuantity(
+  listName: string,
+  value: unknown,
+): void {
+  if (!isRecord(value)) {
+    return;
+  }
+
+  const quantity = value["Quantity"];
+
+  if (typeof quantity !== "number") {
+    return;
+  }
+
+  const items = value["Items"];
+  const itemCount = Array.isArray(items) ? items.length : 0;
+
+  if (quantity !== itemCount) {
+    throw new SimCloudFrontInconsistentQuantities(
+      `CloudFront ${listName} has Quantity ${String(quantity)} and ` +
+        `${String(itemCount)} Items`,
+    );
+  }
+}

--- a/src/service/cloudfront/distribution/configurator/sim-cf-behavior-properties.ts
+++ b/src/service/cloudfront/distribution/configurator/sim-cf-behavior-properties.ts
@@ -7,6 +7,7 @@ import type { SimCloudFrontBehavior } from "../../behaviour/sim-cloud-front-beha
 import { assertDefined } from "../../../../util/type-guard/defined.js";
 import type { SimCfBehaviorResponseHeadersPolicy } from "./sim-cf-behavior-response-headers-policy.js";
 import { configureCffAssociations } from "./sim-cff-associations-configure.js";
+import { assertConsistentQuantity } from "../../command/sim-cf-list-quantity.js";
 
 /**
  * Build the Behavior properties common to both the default Cache Behavior and
@@ -26,11 +27,15 @@ export function simCfBehaviorProperties(
 
   return {
     targetOriginName: TargetOriginId,
-    allowedMethods: methodsSet(cacheBehavior.AllowedMethods, ["GET", "HEAD"]),
-    cachedMethods: methodsSet(cacheBehavior.AllowedMethods?.CachedMethods, [
+    allowedMethods: methodsSet("AllowedMethods", cacheBehavior.AllowedMethods, [
       "GET",
       "HEAD",
     ]),
+    cachedMethods: methodsSet(
+      "CachedMethods",
+      cacheBehavior.AllowedMethods?.CachedMethods,
+      ["GET", "HEAD"],
+    ),
     ...(cacheBehavior.ViewerProtocolPolicy !== undefined && {
       viewerProtocolPolicy: cacheBehavior.ViewerProtocolPolicy,
     }),
@@ -46,8 +51,11 @@ export function simCfBehaviorProperties(
  * provided defaults when no items are configured.
  */
 function methodsSet(
+  listName: string,
   methods: SimCloudFrontMethodList | undefined,
   fallback: string[],
 ): Set<string> {
+  assertConsistentQuantity(listName, methods);
+
   return new Set(methods?.Items ?? fallback);
 }

--- a/src/service/cloudfront/error/sim-cloudfront.error.ts
+++ b/src/service/cloudfront/error/sim-cloudfront.error.ts
@@ -176,6 +176,20 @@ export class SimCloudFrontOriginAccessControlAlreadyExists extends SimCloudFront
 }
 
 /**
+ * Simulated CloudFront InconsistentQuantities error.
+ *
+ * Every CloudFront list carries a `Quantity` alongside its `Items`, and
+ * CloudFront refuses a request where the two disagree.
+ */
+export class SimCloudFrontInconsistentQuantities extends SimCloudFrontError {
+  public override readonly name = "InconsistentQuantities";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
  * Simulated CloudFront DistributionNotDisabled error.
  *
  * CloudFront will not delete a Distribution that is still serving. The caller


### PR DESCRIPTION
Every CloudFront list carries a `Quantity` alongside its `Items`, and CloudFront refuses a request where the two disagree with `InconsistentQuantities`. Nothing here read `Quantity` at all: a `Quantity` of 0 with one item created the item, and a `Quantity` of 1 with none created nothing, either way deploying something the caller did not describe and would not have got from AWS.

The check goes in one place per read rather than one per list. `SimCloudFrontDistributionConfigNormalizer` turned out to be the choke point every Distribution list already passes through, and it also already understood both input shapes, so `Origins`, `Aliases`, `CustomErrorResponses`, `CacheBehaviors` and `FunctionAssociations` are covered there for `CreateDistribution` and `UpdateDistribution` alike. `AllowedMethods` and `CachedMethods` are read separately in the Behavior configurator, and a Function's `KeyValueStoreAssociations` in its own resolver, so both call the same helper. There is a case per list type.

Two shapes are deliberately left alone, and the issue has been corrected where it said otherwise. A list arriving as a plain array has no count to disagree with, which is the CloudFormation shape, so a template is unaffected. A record with `Items` and no `Quantity` is accepted too: the AWS SDK types make omitting it a compile error, so what reaches the simulator without one is a hand-written `{ Items: [...] }` rather than the mistake worth catching, and refusing it would only break the looser input the simulator has always taken.

The structural command types gained `Quantity` where they were missing it, which is what let the tests express a miscounted list at all. They were accepting it from real SDK input by structural typing while never declaring or reading it.

Resolves https://github.com/KensioSoftware/yulin/issues/527


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for optional `Quantity` metadata across CloudFront distribution lists and method configurations.
  * Validates that `Quantity` matches the number of provided items.
  * Applies validation to distribution settings and key-value store associations.

* **Bug Fixes**
  * Configurations with inconsistent quantities now return a CloudFront-compatible `InconsistentQuantities` error.
  * Plain arrays and configurations without applicable quantity metadata continue to work as expected.

* **Documentation**
  * Documented CloudFront quantity validation behavior and its limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->