### PR TITLE
feat: create simulated EventBridge event buses

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ npm i -D @kensio/yulin
 - [CloudFormation](./docs/services/cloudformation "Simulated CloudFormation docs")
 - [CloudFront](./docs/services/cloudfront "Simulated CloudFront docs")
 - [Cognito user pools](./docs/services/cognito "Simulated Cognito user pools docs")
+- [DynamoDB](./docs/services/dynamodb "Simulated DynamoDB docs")
+- [EventBridge](./docs/services/eventbridge "Simulated EventBridge docs")
 - [IAM](./docs/services/iam "Simulated IAM docs")
 - [KMS](./docs/services/kms "Simulated KMS docs")
 - [Lambda](./docs/services/lambda "Simulated Lambda docs")

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,7 @@ behaviour and includes example code that can be copied into tests or local devel
 - [CloudFront](./services/cloudfront/ "Simulated CloudFront usage docs")
 - [Cognito user pools](./services/cognito/ "Simulated Cognito user pools usage docs")
 - [DynamoDB](./services/dynamodb/ "Simulated DynamoDB usage docs")
+- [EventBridge](./services/eventbridge/ "Simulated EventBridge usage docs")
 - [IAM](./services/iam/ "Simulated IAM usage docs")
 - [KMS](./services/kms/ "Simulated KMS usage docs")
 - [Lambda](./services/lambda/ "Simulated Lambda usage docs")

--- a/docs/services/eventbridge/README.md
+++ b/docs/services/eventbridge/README.md
@@ -1,0 +1,286 @@
+# Simulated EventBridge
+
+Yulin includes a simulated Amazon EventBridge for tests and local development. Event buses are held
+in memory and every operation is authorized by simulated IAM.
+
+Event buses and `PutEvents` only. Rules, targets and EventBridge Scheduler are not simulated yet, so
+an event put onto a bus today is accepted and then dropped. EventBridge-specific types are imported
+from the `@kensio/yulin/eventbridge` subpath.
+
+## Putting an event onto a bus
+
+```typescript sim-event-bridge-put-events
+/**
+ * Putting an event onto the default event bus.
+ */
+
+import { PutEventsCommand } from "@aws-sdk/client-eventbridge";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const events = simAws.eventBridge();
+
+const output = await events.putEvents(
+  new PutEventsCommand({
+    Entries: [
+      {
+        Source: "orders.service",
+        DetailType: "OrderPlaced",
+        Detail: JSON.stringify({ orderId: "order-1", total: 4200 }),
+      },
+    ],
+  }),
+);
+
+console.log(output.FailedEntryCount); // 0
+console.log(output.Entries?.[0]?.EventId !== undefined); // true
+```
+
+Every account and region has a `default` bus without one being created, and an entry that names no
+bus goes to it. A request carries between one and ten entries, and they are independent: each may
+name a different bus, and one that fails does not stop the others.
+
+`Detail`, `DetailType` and `Source` are all optional in the API model, and all three are needed for
+EventBridge to take an entry. An entry missing one fails on its own, with the rest of the request
+going through. A request in which no entry carries all three fails outright.
+
+The size limit applies to the request rather than to any one entry: the entries together come to less
+than 1 MB, measured the way AWS measures them, where a `Time` counts as 14 bytes and `Source`,
+`DetailType`, `Detail` and each `Resources` entry count as the length of their UTF-8 forms.
+
+## Creating an event bus
+
+```typescript sim-event-bridge-create-bus
+/**
+ * Creating a custom event bus and putting an event onto it.
+ */
+
+import {
+  CreateEventBusCommand,
+  DescribeEventBusCommand,
+  PutEventsCommand,
+} from "@aws-sdk/client-eventbridge";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const events = simAws.eventBridge();
+
+const created = await events.createEventBus(
+  new CreateEventBusCommand({ Name: "orders" }),
+);
+
+console.log(created.EventBusArn);
+// "arn:aws:events:us-east-1:888888888888:event-bus/orders"
+
+await events.putEvents(
+  new PutEventsCommand({
+    Entries: [
+      {
+        EventBusName: "orders",
+        Source: "orders.service",
+        DetailType: "OrderPlaced",
+        Detail: JSON.stringify({ orderId: "order-1" }),
+      },
+    ],
+  }),
+);
+
+const described = await events.describeEventBus(
+  new DescribeEventBusCommand({ Name: "orders" }),
+);
+
+console.log(described.Name); // "orders"
+```
+
+A bus ARN is `arn:aws:events:<region>:<account-id>:event-bus/<name>`. Unlike an SNS topic ARN it
+carries a resource type, so an IAM policy naming a bus has the `event-bus/` in it.
+
+A bus name is up to 256 characters of letters, numbers, full stops, hyphens and underscores. Creating
+one that already exists is refused with `ResourceAlreadyExistsException`, which includes `default`,
+since that bus is always there. That differs from SNS `CreateTopic`, which answers a repeated create
+with the existing topic.
+
+`DescribeEventBus` takes a name or a bus ARN, and describes the default bus when the request names
+neither. `ListEventBuses` reports the default bus alongside the custom ones, narrowed by `NamePrefix`
+and paged by `Limit` and `NextToken`.
+
+`DeleteEventBus` frees the name at once, so it can be reused straight away. Deleting a bus that is
+not there succeeds. The default bus cannot be deleted.
+
+## A bus that does not exist
+
+An event put onto a bus that was never created **succeeds**:
+
+```typescript sim-event-bridge-missing-bus
+/**
+ * An event put onto a bus that does not exist is accepted and dropped.
+ */
+
+import { PutEventsCommand } from "@aws-sdk/client-eventbridge";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+const output = await simAws.eventBridge().putEvents(
+  new PutEventsCommand({
+    Entries: [
+      {
+        EventBusName: "odrers", // A typo, and nothing says so.
+        Source: "orders.service",
+        DetailType: "OrderPlaced",
+        Detail: JSON.stringify({ orderId: "order-1" }),
+      },
+    ],
+  }),
+);
+
+console.log(output.FailedEntryCount); // 0
+console.log(output.Entries?.[0]?.EventId !== undefined); // true
+```
+
+This is real EventBridge behaviour rather than a gap. AWS answers 200, finds no rule to match the
+event against, and drops it, without counting the entry as failed. A mistyped bus name therefore
+looks exactly like a working call, which is worth knowing before it costs an afternoon, so the
+simulation reproduces it rather than being helpfully stricter.
+
+## Inspecting what a bus received
+
+Real EventBridge keeps no events, so there is no API for reading them back. For tests,
+`eventsOn(...)` reports what a bus received, in arrival order. It is a simulator accessor rather than
+a simulated API: nothing an SDK command returns is built from it.
+
+```typescript sim-event-bridge-inspecting-events
+/**
+ * Asserting on the envelope EventBridge built from an entry.
+ */
+
+import { PutEventsCommand } from "@aws-sdk/client-eventbridge";
+
+import { SimAws, SimFixedClock } from "@kensio/yulin";
+
+const simAws = new SimAws({
+  defaultAccountId: "111111111111",
+  defaultRegionName: "eu-west-2",
+  clock: new SimFixedClock(new Date("2026-07-26T09:00:00.000Z")),
+});
+
+await simAws.eventBridge().putEvents(
+  new PutEventsCommand({
+    Entries: [
+      {
+        Source: "orders.service",
+        DetailType: "OrderPlaced",
+        Detail: JSON.stringify({ orderId: "order-1" }),
+        Resources: ["arn:aws:s3:::orders"],
+      },
+    ],
+  }),
+);
+
+const [event] = simAws.eventBridge().eventsOn("default");
+
+console.log(event?.toEnvelope());
+// {
+//   version: "0",
+//   id: "0f2c...",
+//   "detail-type": "OrderPlaced",
+//   source: "orders.service",
+//   account: "111111111111",
+//   time: "2026-07-26T09:00:00Z",
+//   region: "eu-west-2",
+//   resources: ["arn:aws:s3:::orders"],
+//   detail: { orderId: "order-1" },
+// }
+```
+
+The envelope is the shape a rule matches against and a target receives. An entry that names no `Time`
+is stamped from the simulation's own clock, so a test with a fixed clock gets a predictable
+timestamp, and the timestamp is written to the second, as real EventBridge writes it.
+
+## Permissions
+
+Every operation is authorized by simulated IAM against the bus ARN. `events:ListEventBuses` has no
+bus-level resource on real AWS, so it authorizes against `*` and a policy naming a bus does not allow
+it.
+
+```typescript sim-event-bridge-iam-policy
+/**
+ * A policy allowing events onto one bus and nothing else.
+ */
+
+const policy = {
+  Version: "2012-10-17",
+  Statement: [
+    {
+      Effect: "Allow",
+      Action: "events:PutEvents",
+      Resource: "arn:aws:events:us-east-1:888888888888:event-bus/orders",
+    },
+  ],
+};
+
+console.log(JSON.stringify(policy).length > 0); // true
+```
+
+A caller refused by IAM gets `AccessDeniedException`. Permission is checked before the bus is looked
+up, so a caller who is not allowed to reach a bus is refused whether or not that bus exists.
+
+## Scoping
+
+Buses belong to one account and region, as they do on real AWS:
+
+```typescript sim-event-bridge-scoping
+/**
+ * Event buses in two Regions of the same Account.
+ */
+
+import { CreateEventBusCommand } from "@aws-sdk/client-eventbridge";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+await simAws
+  .account("111111111111")
+  .region("eu-west-2")
+  .eventBridge()
+  .createEventBus(new CreateEventBusCommand({ Name: "orders" }));
+
+const elsewhere = simAws.account("111111111111").region("us-east-1");
+
+console.log(elsewhere.eventBridge().findEventBus("orders")); // undefined
+```
+
+An entry naming a bus ARN in another account or region is refused. Real EventBridge does deliver
+events across accounts that way, but nothing here can reach another simulation's bus, and quietly
+treating a foreign ARN as local would let a test pass while the real call crossed a boundary it has
+no permission for.
+
+## Available functionality
+
+- `CreateEventBus`, `DeleteEventBus`, `DescribeEventBus`, `ListEventBuses` and `PutEvents`.
+- The `default` bus in every account and region, without one being created.
+- Bus descriptions, creation timestamps from the simulation's clock, and prefix-narrowed paged
+  listings.
+- The event envelope EventBridge builds from an entry, reached through `eventsOn(...)`.
+- IAM authorization against the bus ARN.
+- SDK interception of `EventBridgeClient`.
+
+## Limitations
+
+- Rules, event patterns and targets are not simulated, so every event put onto a bus is dropped after
+  it arrives.
+- Scheduled rules and EventBridge Scheduler are not simulated.
+- `AWS::Events::*` CloudFormation resource types are not simulated.
+- Event bus resource policies are not simulated. `PutPermission`, `RemovePermission` and the bus
+  `Policy` attribute are all absent, so a caller from another account cannot be admitted to a bus,
+  which is stricter than real AWS.
+- Putting an event onto another account's or region's bus is refused rather than delivered.
+- Partner event buses and partner event sources are refused rather than simulated, as are event bus
+  tags, encryption with a customer managed key, dead letter queues, logging configuration and global
+  endpoints.
+- Archives, replay, schema registry and discovery, API destinations and connections are not
+  simulated.

--- a/docs/services/eventbridge/sim-event-bridge-create-bus.example.ts
+++ b/docs/services/eventbridge/sim-event-bridge-create-bus.example.ts
@@ -1,0 +1,40 @@
+/**
+ * Creating a custom event bus and putting an event onto it.
+ */
+
+import {
+  CreateEventBusCommand,
+  DescribeEventBusCommand,
+  PutEventsCommand,
+} from "@aws-sdk/client-eventbridge";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const events = simAws.eventBridge();
+
+const created = await events.createEventBus(
+  new CreateEventBusCommand({ Name: "orders" }),
+);
+
+console.log(created.EventBusArn);
+// "arn:aws:events:us-east-1:888888888888:event-bus/orders"
+
+await events.putEvents(
+  new PutEventsCommand({
+    Entries: [
+      {
+        EventBusName: "orders",
+        Source: "orders.service",
+        DetailType: "OrderPlaced",
+        Detail: JSON.stringify({ orderId: "order-1" }),
+      },
+    ],
+  }),
+);
+
+const described = await events.describeEventBus(
+  new DescribeEventBusCommand({ Name: "orders" }),
+);
+
+console.log(described.Name); // "orders"

--- a/docs/services/eventbridge/sim-event-bridge-iam-policy.example.ts
+++ b/docs/services/eventbridge/sim-event-bridge-iam-policy.example.ts
@@ -1,0 +1,16 @@
+/**
+ * A policy allowing events onto one bus and nothing else.
+ */
+
+const policy = {
+  Version: "2012-10-17",
+  Statement: [
+    {
+      Effect: "Allow",
+      Action: "events:PutEvents",
+      Resource: "arn:aws:events:us-east-1:888888888888:event-bus/orders",
+    },
+  ],
+};
+
+console.log(JSON.stringify(policy).length > 0); // true

--- a/docs/services/eventbridge/sim-event-bridge-inspecting-events.example.ts
+++ b/docs/services/eventbridge/sim-event-bridge-inspecting-events.example.ts
@@ -1,0 +1,41 @@
+/**
+ * Asserting on the envelope EventBridge built from an entry.
+ */
+
+import { PutEventsCommand } from "@aws-sdk/client-eventbridge";
+
+import { SimAws, SimFixedClock } from "@kensio/yulin";
+
+const simAws = new SimAws({
+  defaultAccountId: "111111111111",
+  defaultRegionName: "eu-west-2",
+  clock: new SimFixedClock(new Date("2026-07-26T09:00:00.000Z")),
+});
+
+await simAws.eventBridge().putEvents(
+  new PutEventsCommand({
+    Entries: [
+      {
+        Source: "orders.service",
+        DetailType: "OrderPlaced",
+        Detail: JSON.stringify({ orderId: "order-1" }),
+        Resources: ["arn:aws:s3:::orders"],
+      },
+    ],
+  }),
+);
+
+const [event] = simAws.eventBridge().eventsOn("default");
+
+console.log(event?.toEnvelope());
+// {
+//   version: "0",
+//   id: "0f2c...",
+//   "detail-type": "OrderPlaced",
+//   source: "orders.service",
+//   account: "111111111111",
+//   time: "2026-07-26T09:00:00Z",
+//   region: "eu-west-2",
+//   resources: ["arn:aws:s3:::orders"],
+//   detail: { orderId: "order-1" },
+// }

--- a/docs/services/eventbridge/sim-event-bridge-missing-bus.example.ts
+++ b/docs/services/eventbridge/sim-event-bridge-missing-bus.example.ts
@@ -1,0 +1,25 @@
+/**
+ * An event put onto a bus that does not exist is accepted and dropped.
+ */
+
+import { PutEventsCommand } from "@aws-sdk/client-eventbridge";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+const output = await simAws.eventBridge().putEvents(
+  new PutEventsCommand({
+    Entries: [
+      {
+        EventBusName: "odrers", // A typo, and nothing says so.
+        Source: "orders.service",
+        DetailType: "OrderPlaced",
+        Detail: JSON.stringify({ orderId: "order-1" }),
+      },
+    ],
+  }),
+);
+
+console.log(output.FailedEntryCount); // 0
+console.log(output.Entries?.[0]?.EventId !== undefined); // true

--- a/docs/services/eventbridge/sim-event-bridge-put-events.example.ts
+++ b/docs/services/eventbridge/sim-event-bridge-put-events.example.ts
@@ -1,0 +1,25 @@
+/**
+ * Putting an event onto the default event bus.
+ */
+
+import { PutEventsCommand } from "@aws-sdk/client-eventbridge";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const events = simAws.eventBridge();
+
+const output = await events.putEvents(
+  new PutEventsCommand({
+    Entries: [
+      {
+        Source: "orders.service",
+        DetailType: "OrderPlaced",
+        Detail: JSON.stringify({ orderId: "order-1", total: 4200 }),
+      },
+    ],
+  }),
+);
+
+console.log(output.FailedEntryCount); // 0
+console.log(output.Entries?.[0]?.EventId !== undefined); // true

--- a/docs/services/eventbridge/sim-event-bridge-scoping.example.ts
+++ b/docs/services/eventbridge/sim-event-bridge-scoping.example.ts
@@ -1,0 +1,19 @@
+/**
+ * Event buses in two Regions of the same Account.
+ */
+
+import { CreateEventBusCommand } from "@aws-sdk/client-eventbridge";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+await simAws
+  .account("111111111111")
+  .region("eu-west-2")
+  .eventBridge()
+  .createEventBus(new CreateEventBusCommand({ Name: "orders" }));
+
+const elsewhere = simAws.account("111111111111").region("us-east-1");
+
+console.log(elsewhere.eventBridge().findEventBus("orders")); // undefined

--- a/package.json
+++ b/package.json
@@ -74,6 +74,10 @@
       "import": "./dist/config/eslint/index.js",
       "types": "./dist/config/eslint/index.d.ts"
     },
+    "./eventbridge": {
+      "import": "./dist/service/eventbridge/index.js",
+      "types": "./dist/service/eventbridge/index.d.ts"
+    },
     "./iam": {
       "import": "./dist/service/iam/index.js",
       "types": "./dist/service/iam/index.d.ts"
@@ -151,6 +155,7 @@
     "@aws-sdk/client-cognito-identity-provider": "^3.1101.0",
     "@aws-sdk/client-dynamodb": "^3.1101.0",
     "@aws-sdk/client-dynamodb-streams": "^3.1101.0",
+    "@aws-sdk/client-eventbridge": "^3.1109.0",
     "@aws-sdk/client-iam": "^3.1101.0",
     "@aws-sdk/client-kms": "^3.1101.0",
     "@aws-sdk/client-lambda": "^3.1101.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,6 +45,9 @@ importers:
       '@aws-sdk/client-dynamodb-streams':
         specifier: ^3.1101.0
         version: 3.1104.0
+      '@aws-sdk/client-eventbridge':
+        specifier: ^3.1109.0
+        version: 3.1109.0
       '@aws-sdk/client-iam':
         specifier: ^3.1101.0
         version: 3.1104.0
@@ -246,6 +249,10 @@ packages:
 
   '@aws-sdk/client-dynamodb@3.1104.0':
     resolution: {integrity: sha512-Ydt8aMkemljnYy9jlj6u1entx5k9YqeLPVngeSZdVovL/VBUX/DXO7GzgXZGHT2eV5fshXCLwZ0jHLZJAAMHYA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/client-eventbridge@3.1109.0':
+    resolution: {integrity: sha512-4zDZWphJ07MSb9YAh5gU02uayj7vxbB/McYbOFqZVhGitKwlz2L78GFHa93kFcT6JS5RR0oWrZMcAQsBnk4qrw==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/client-iam@3.1104.0':
@@ -3502,6 +3509,18 @@ snapshots:
       '@aws-sdk/credential-provider-node': 3.972.79
       '@aws-sdk/dynamodb-codec': 3.973.42
       '@aws-sdk/middleware-endpoint-discovery': 3.972.28
+      '@aws-sdk/types': 3.974.3
+      '@smithy/core': 3.32.0
+      '@smithy/fetch-http-handler': 5.7.0
+      '@smithy/node-http-handler': 4.10.0
+      '@smithy/types': 4.17.0
+      tslib: 2.8.1
+
+  '@aws-sdk/client-eventbridge@3.1109.0':
+    dependencies:
+      '@aws-sdk/core': 3.977.7
+      '@aws-sdk/credential-provider-node': 3.972.79
+      '@aws-sdk/signature-v4-multi-region': 3.996.44
       '@aws-sdk/types': 3.974.3
       '@smithy/core': 3.32.0
       '@smithy/fetch-http-handler': 5.7.0

--- a/src/sdk/router/resolve-sim-sdk-command-router.ts
+++ b/src/sdk/router/resolve-sim-sdk-command-router.ts
@@ -1,8 +1,92 @@
 import type { SimAwsAccountId } from "../../service/aws/sim-aws-account.js";
+import type { SimAwsAccountRegionContainer } from "../../service/aws/sim-aws-account-region-scope.js";
 import type { AwsRegionName } from "../../service/aws/sim-aws-region.js";
 import type { SimAws } from "../../service/aws/sim-aws.js";
 import { SimSdkUnknownServiceError } from "../error/sim-sdk.error.js";
 import type { SimSdkCommandRouter } from "./sim-sdk-command-router.type.js";
+
+/**
+ * How one AWS service identity reaches its scoped simulated service.
+ */
+type SimSdkScopedRouter = (
+  scoped: SimAwsAccountRegionContainer,
+) => SimSdkCommandRouter;
+
+/**
+ * Every AWS service identity SDK interception supports, and the scoped
+ * simulated service each one routes to.
+ *
+ * A table rather than a switch, because there is one entry per simulated
+ * service and the list only grows: a branch per service would put the whole of
+ * this file's complexity in one function.
+ *
+ * The keys are the SDK's own `serviceId` values, which is why some of them
+ * carry spaces.
+ */
+const scopedRouters: ReadonlyMap<string, SimSdkScopedRouter> = new Map<
+  string,
+  SimSdkScopedRouter
+>([
+  ["ACM", (scoped): SimSdkCommandRouter => scoped.acm().sdkCommandRouter()],
+  [
+    "ApiGatewayV2",
+    (scoped): SimSdkCommandRouter => scoped.apiGatewayV2().sdkCommandRouter(),
+  ],
+  [
+    "CloudFormation",
+    (scoped): SimSdkCommandRouter => scoped.cloudFormation().sdkCommandRouter(),
+  ],
+  [
+    "CloudFront",
+    (scoped): SimSdkCommandRouter => scoped.cloudFront().sdkCommandRouter(),
+  ],
+  [
+    "CloudFront KeyValueStore",
+    (scoped): SimSdkCommandRouter =>
+      scoped.cloudFrontKeyValueStore().sdkCommandRouter(),
+  ],
+  [
+    "Cognito Identity Provider",
+    (scoped): SimSdkCommandRouter =>
+      scoped.cognitoIdentityProvider().sdkCommandRouter(),
+  ],
+  [
+    "DynamoDB",
+    (scoped): SimSdkCommandRouter => scoped.dynamoDb().sdkCommandRouter(),
+  ],
+  [
+    "DynamoDB Streams",
+    (scoped): SimSdkCommandRouter =>
+      scoped.dynamoDbStreams().sdkCommandRouter(),
+  ],
+  [
+    "EventBridge",
+    (scoped): SimSdkCommandRouter => scoped.eventBridge().sdkCommandRouter(),
+  ],
+  ["IAM", (scoped): SimSdkCommandRouter => scoped.iam().sdkCommandRouter()],
+  ["KMS", (scoped): SimSdkCommandRouter => scoped.kms().sdkCommandRouter()],
+  [
+    "Lambda",
+    (scoped): SimSdkCommandRouter => scoped.lambda().sdkCommandRouter(),
+  ],
+  [
+    "Rekognition",
+    (scoped): SimSdkCommandRouter => scoped.rekognition().sdkCommandRouter(),
+  ],
+  [
+    "Route 53",
+    (scoped): SimSdkCommandRouter => scoped.route53().sdkCommandRouter(),
+  ],
+  ["S3", (scoped): SimSdkCommandRouter => scoped.s3().sdkCommandRouter()],
+  [
+    "Secrets Manager",
+    (scoped): SimSdkCommandRouter => scoped.secretsManager().sdkCommandRouter(),
+  ],
+  ["SNS", (scoped): SimSdkCommandRouter => scoped.sns().sdkCommandRouter()],
+  ["SQS", (scoped): SimSdkCommandRouter => scoped.sqs().sdkCommandRouter()],
+  ["SSM", (scoped): SimSdkCommandRouter => scoped.ssm().sdkCommandRouter()],
+  ["STS", (scoped): SimSdkCommandRouter => scoped.sts().sdkCommandRouter()],
+]);
 
 /**
  * Resolve the scoped simulated service SDK Command router for an intercepted
@@ -20,71 +104,14 @@ export function resolveSimSdkCommandRouter(
   accountId: SimAwsAccountId | string,
   regionName: AwsRegionName,
 ): SimSdkCommandRouter {
-  const scoped = simAws.account(accountId).region(regionName);
+  const scopedRouter = scopedRouters.get(serviceId);
 
-  switch (serviceId) {
-    case "ACM": {
-      return scoped.acm().sdkCommandRouter();
-    }
-    case "ApiGatewayV2": {
-      return scoped.apiGatewayV2().sdkCommandRouter();
-    }
-    case "CloudFormation": {
-      return scoped.cloudFormation().sdkCommandRouter();
-    }
-    case "CloudFront": {
-      return scoped.cloudFront().sdkCommandRouter();
-    }
-    case "CloudFront KeyValueStore": {
-      return scoped.cloudFrontKeyValueStore().sdkCommandRouter();
-    }
-    case "Cognito Identity Provider": {
-      return scoped.cognitoIdentityProvider().sdkCommandRouter();
-    }
-    case "DynamoDB": {
-      return scoped.dynamoDb().sdkCommandRouter();
-    }
-    case "DynamoDB Streams": {
-      return scoped.dynamoDbStreams().sdkCommandRouter();
-    }
-    case "IAM": {
-      return scoped.iam().sdkCommandRouter();
-    }
-    case "KMS": {
-      return scoped.kms().sdkCommandRouter();
-    }
-    case "Lambda": {
-      return scoped.lambda().sdkCommandRouter();
-    }
-    case "Rekognition": {
-      return scoped.rekognition().sdkCommandRouter();
-    }
-    case "Route 53": {
-      return scoped.route53().sdkCommandRouter();
-    }
-    case "S3": {
-      return scoped.s3().sdkCommandRouter();
-    }
-    case "Secrets Manager": {
-      return scoped.secretsManager().sdkCommandRouter();
-    }
-    case "SNS": {
-      return scoped.sns().sdkCommandRouter();
-    }
-    case "SQS": {
-      return scoped.sqs().sdkCommandRouter();
-    }
-    case "SSM": {
-      return scoped.ssm().sdkCommandRouter();
-    }
-    case "STS": {
-      return scoped.sts().sdkCommandRouter();
-    }
-    default: {
-      throw new SimSdkUnknownServiceError(
-        `Simulated AWS has no SDK interception support for service ` +
-          `${serviceId} yet`,
-      );
-    }
+  if (scopedRouter === undefined) {
+    throw new SimSdkUnknownServiceError(
+      `Simulated AWS has no SDK interception support for service ` +
+        `${serviceId} yet`,
+    );
   }
+
+  return scopedRouter(simAws.account(accountId).region(regionName));
 }

--- a/src/service/aws/factory/sim-aws-account-region-service-builder.ts
+++ b/src/service/aws/factory/sim-aws-account-region-service-builder.ts
@@ -12,18 +12,16 @@ import { SimCloudFormation } from "../../cloudformation/index.js";
 import { SimCognitoIdentityProvider } from "../../cognito/index.js";
 import { simAwsCognitoTriggerFunctions } from "../../cognito/user-pool/trigger/sim-aws-cognito-trigger-functions.js";
 import { SimDynamoDb as SimDynamoDatabase } from "../../dynamodb/index.js";
+import { SimEventBridge } from "../../eventbridge/index.js";
 import type { SimIamRegistry } from "../../iam/registry/sim-iam-registry.js";
 import { SimKms } from "../../kms/index.js";
 import type { SimHttpApiRegistry } from "../../apigatewayv2/registry/sim-http-api-registry.js";
 import { SimLambda } from "../../lambda/index.js";
 import type { SimLambdaUrlRegistry } from "../../lambda/registry/sim-lambda-url-registry.js";
-import { SimSqsEventSourceQueues } from "../../lambda/event-source/queue/sim-sqs-event-source-queues.js";
-import { SimDynamoDbEventSourceStreams } from "../../lambda/event-source/stream/sim-dynamodb-event-source-streams.js";
-import { SimS3LambdaCodeStore } from "../../lambda/function/code/store/sim-s3-lambda-code-store.js";
-import { SimSdkLambdaVmModuleProvider } from "../../lambda/function/code/vm/sdk/sim-sdk-lambda-vm-module-provider.js";
 import { SimRekognition } from "../../rekognition/index.js";
 import { SimAwsRekognitionImageObjects } from "../../rekognition/image/s3/sim-aws-rekognition-image-objects.js";
 import { SimS3 } from "../../s3/sim-s3.js";
+import { simAwsLambdaCollaborators } from "./sim-aws-lambda-collaborators.js";
 import { simAwsS3NotificationDestinations } from "./sim-aws-s3-notification-destinations.js";
 import { SimSecretsManager } from "../../secretsmanager/index.js";
 import { SimSns } from "../../sns/index.js";
@@ -148,6 +146,16 @@ export class SimAwsAccountRegionServiceBuilder {
   }
 
   /**
+   * Create simulated EventBridge for an Account Region scope.
+   *
+   * Event buses are Region-scoped on real AWS: a bus ARN names its Region, and
+   * an event put in one Region reaches no rule in another.
+   */
+  createEventBridge(scope: SimAwsAccountRegionContainer): SimEventBridge {
+    return new SimEventBridge(this.scoped(scope));
+  }
+
+  /**
    * Create simulated KMS for an Account Region scope.
    *
    * KMS keys are Region-scoped on real AWS: a key ARN names its Region, and a
@@ -157,32 +165,14 @@ export class SimAwsAccountRegionServiceBuilder {
     return new SimKms(this.scoped(scope));
   }
 
-  /**
-   * Create simulated Lambda for an Account Region scope.
-   *
-   * S3-located function code is fetched from the same Account/Region scope's
-   * simulated S3, as real Lambda requires same-region code buckets. Function
-   * code running in the vm runtime is provided host-installed AWS SDK
-   * packages intercepted into this SimAws, as the real Lambda runtime
-   * provides the SDK.
-   *
-   * Event source mappings poll the same scope's simulated SQS and DynamoDB, as
-   * a queue or a table's stream can only be an event source for a function in
-   * its own Account and Region.
-   */
+  /** Create simulated Lambda for an Account Region scope. */
   createLambda(scope: SimAwsAccountRegionContainer): SimLambda {
     return new SimLambda({
       ...this.scoped(scope),
-      runAsOwner: this.simAws,
-      urlRegistry: this.lambdaUrlRegistry,
-      codeStore: new SimS3LambdaCodeStore({ s3: scope.s3() }),
-      eventSourceQueues: new SimSqsEventSourceQueues({ sqs: scope.sqs() }),
-      eventSourceStreams: new SimDynamoDbEventSourceStreams({
-        dynamoDb: scope.dynamoDb(),
-      }),
-      vmSdkModuleProvider: new SimSdkLambdaVmModuleProvider({
+      ...simAwsLambdaCollaborators({
         simAws: this.simAws,
-        regionName: scope.accountRegionScope.regionName,
+        scope,
+        urlRegistry: this.lambdaUrlRegistry,
       }),
     });
   }

--- a/src/service/aws/factory/sim-aws-lambda-collaborators.ts
+++ b/src/service/aws/factory/sim-aws-lambda-collaborators.ts
@@ -1,0 +1,58 @@
+import { SimDynamoDbEventSourceStreams } from "../../lambda/event-source/stream/sim-dynamodb-event-source-streams.js";
+import { SimSqsEventSourceQueues } from "../../lambda/event-source/queue/sim-sqs-event-source-queues.js";
+import { SimS3LambdaCodeStore } from "../../lambda/function/code/store/sim-s3-lambda-code-store.js";
+import { SimSdkLambdaVmModuleProvider } from "../../lambda/function/code/vm/sdk/sim-sdk-lambda-vm-module-provider.js";
+import type { SimLambdaUrlRegistry } from "../../lambda/registry/sim-lambda-url-registry.js";
+import type { SimAwsAccountRegionContainer } from "../sim-aws-account-region-scope.js";
+import type { SimAws } from "../sim-aws.js";
+
+interface SimAwsLambdaCollaboratorsProperties {
+  readonly simAws: SimAws;
+  readonly scope: SimAwsAccountRegionContainer;
+  readonly urlRegistry: SimLambdaUrlRegistry;
+}
+
+/**
+ * What simulated Lambda reaches for in the rest of the simulation.
+ */
+interface SimAwsLambdaCollaborators {
+  readonly runAsOwner: SimAws;
+  readonly urlRegistry: SimLambdaUrlRegistry;
+  readonly codeStore: SimS3LambdaCodeStore;
+  readonly eventSourceQueues: SimSqsEventSourceQueues;
+  readonly eventSourceStreams: SimDynamoDbEventSourceStreams;
+  readonly vmSdkModuleProvider: SimSdkLambdaVmModuleProvider;
+}
+
+/**
+ * Build the collaborators simulated Lambda takes beyond the scoped ones every
+ * service gets.
+ *
+ * S3-located function code is fetched from the same Account/Region scope's
+ * simulated S3, as real Lambda requires same-region code buckets. Function
+ * code running in the vm runtime is provided host-installed AWS SDK packages
+ * intercepted into this SimAws, as the real Lambda runtime provides the SDK.
+ *
+ * Event source mappings poll the same scope's simulated SQS and DynamoDB, as a
+ * queue or a table's stream can only be an event source for a function in its
+ * own Account and Region.
+ */
+export function simAwsLambdaCollaborators(
+  properties: SimAwsLambdaCollaboratorsProperties,
+): SimAwsLambdaCollaborators {
+  const { simAws, scope } = properties;
+
+  return {
+    runAsOwner: simAws,
+    urlRegistry: properties.urlRegistry,
+    codeStore: new SimS3LambdaCodeStore({ s3: scope.s3() }),
+    eventSourceQueues: new SimSqsEventSourceQueues({ sqs: scope.sqs() }),
+    eventSourceStreams: new SimDynamoDbEventSourceStreams({
+      dynamoDb: scope.dynamoDb(),
+    }),
+    vmSdkModuleProvider: new SimSdkLambdaVmModuleProvider({
+      simAws,
+      regionName: scope.accountRegionScope.regionName,
+    }),
+  };
+}

--- a/src/service/aws/factory/sim-aws-service-factory.ts
+++ b/src/service/aws/factory/sim-aws-service-factory.ts
@@ -21,6 +21,7 @@ import type { SimKms } from "../../kms/index.js";
 import type { SimLambda } from "../../lambda/index.js";
 import { SimLambdaUrlRegistry } from "../../lambda/registry/sim-lambda-url-registry.js";
 import type { SimSecretsManager } from "../../secretsmanager/index.js";
+import type { SimEventBridge } from "../../eventbridge/index.js";
 import type { SimSns } from "../../sns/index.js";
 import type { SimSqs } from "../../sqs/index.js";
 import type { SimSsm } from "../../ssm/index.js";
@@ -156,6 +157,11 @@ export class SimAwsServiceFactory {
   /** Create simulated DynamoDB for an Account Region scope. */
   createDynamoDb(scope: SimAwsAccountRegionContainer): SimDynamoDatabase {
     return this.accountRegionServices.createDynamoDb(scope);
+  }
+
+  /** Create simulated EventBridge for an Account Region scope. */
+  createEventBridge(scope: SimAwsAccountRegionContainer): SimEventBridge {
+    return this.accountRegionServices.createEventBridge(scope);
   }
 
   /** Create or get simulated IAM for an Account scope. */

--- a/src/service/aws/sim-aws-account-region-scope.ts
+++ b/src/service/aws/sim-aws-account-region-scope.ts
@@ -11,6 +11,7 @@ import type {
   SimDynamoDbStreams,
 } from "../dynamodb/index.js";
 import type { SimCloudFormation } from "../cloudformation/index.js";
+import type { SimEventBridge } from "../eventbridge/index.js";
 import type { SimCognitoIdentityProvider } from "../cognito/index.js";
 import type { SimRekognition } from "../rekognition/index.js";
 import type { SimRoute53 } from "../route53/index.js";
@@ -136,6 +137,15 @@ export class SimAwsAccountRegionContainer {
    */
   dynamoDbStreams(): SimDynamoDbStreams {
     return this.dynamoDb().streams();
+  }
+
+  /**
+   * Get simulated EventBridge for this account and region.
+   */
+  eventBridge(): SimEventBridge {
+    return this.memo.getOrCreate("eventBridge", () =>
+      this.simAws.serviceFactory.createEventBridge(this),
+    );
   }
 
   /**

--- a/src/service/aws/sim-aws-service-accessors.ts
+++ b/src/service/aws/sim-aws-service-accessors.ts
@@ -16,6 +16,7 @@ import type { SimRekognition } from "../rekognition/index.js";
 import type { SimRoute53 } from "../route53/index.js";
 import type { SimS3 } from "../s3/sim-s3.js";
 import type { SimSecretsManager } from "../secretsmanager/index.js";
+import type { SimEventBridge } from "../eventbridge/index.js";
 import type { SimSns } from "../sns/index.js";
 import type { SimSqs } from "../sqs/index.js";
 import type { SimSsm } from "../ssm/index.js";
@@ -75,6 +76,11 @@ export abstract class SimAwsServiceAccessors {
   /** Get simulated DynamoDB Streams in the default Account Region scope. */
   dynamoDbStreams(): SimDynamoDbStreams {
     return this.defaultAccountRegionScope().dynamoDbStreams();
+  }
+
+  /** Get simulated EventBridge in the default Account Region scope. */
+  eventBridge(): SimEventBridge {
+    return this.defaultAccountRegionScope().eventBridge();
   }
 
   /** Get simulated IAM in the default Account scope. */

--- a/src/service/eventbridge/README.md
+++ b/src/service/eventbridge/README.md
@@ -1,0 +1,83 @@
+# Simulated EventBridge implementation
+
+This directory contains the simulated EventBridge service implementation. Event buses and PutEvents
+only, for now: rules, targets and EventBridge Scheduler come later.
+
+The guiding decision here is that a bus is a router rather than a store. Real EventBridge keeps no
+events, so nothing here answers an SDK command from stored events. The events a bus does keep are a
+simulator affordance for tests, reached through `SimEventBridge.eventsOn(...)`, and no command reads
+them.
+
+## Entry points
+
+- `sim-event-bridge.ts` is the main in-memory service object for one account/region scope.
+- `index.ts` exports the public EventBridge simulator API for `@kensio/yulin/eventbridge`.
+
+A `SimEventBridge` instance owns a `SimEventBusStore` holding its buses. The simulator is scoped to
+an account and region because buses are: a bus ARN names the region, and a bus name is unique within
+one account and region rather than globally.
+
+## Bus model
+
+Bus state lives under `bus/`.
+
+`SimEventBus` is the stored resource: its name, its ARN, when it was created, and the events it has
+received. `SimEventBus.default(...)` builds the bus every account and region has without one being
+created, and `SimEventBusStore` is constructed with it rather than seeding itself, so the store stays
+a store.
+
+`SimEventBusArn` carries a resource type, unlike an SNS topic ARN: it is
+`arn:aws:events:<region>:<account>:event-bus/<name>`. That is why `parseEventBusArn` does this
+service's own ARN reading rather than deferring to `parseSimArn`, and why an IAM policy resource for a
+bus has the `event-bus/` in it.
+
+`SimEventBusName` validates a name in one place. The API's own pattern allows `/`, but only for
+partner bus names of the form `aws.partner/...`, so a name carrying one is refused here as an
+unsimulated input rather than as a malformed name.
+
+## Event model
+
+`SimEventBridgeEvent` under `event/` is what a bus received. It is deliberately not the PutEvents
+entry that produced it: the entry carries `DetailType` and a `Detail` string, and the event carries
+`detail-type` and a parsed `detail` object, which is the shape a rule matches and a target receives.
+`toEnvelope()` produces that shape, writing the timestamp RFC3339 to the second, as real EventBridge
+does.
+
+## Commands
+
+Command handling follows the usual layout: `command/<area>/*.command.ts` for the local structural SDK
+types, and a handler class beside it.
+
+`SimEventBridgeBusAccess` is how a request reaches the bus it names. Every operation but
+ListEventBuses goes through it, and it authorizes before looking the bus up, so a caller with no
+permission is refused for a bus that does not exist rather than told the bus is missing.
+
+`SimEventBridgePutEvents` is the one with real behaviour in it, and most of that behaviour is about
+what fails and how:
+
+- Entries are independent. One EventBridge will not take comes back as a failure in its own place in
+  the result while the rest go through, which is why `SimEventBridgeEntryFailure` is a returned value
+  rather than a thrown error.
+- `Detail`, `DetailType` and `Source` are optional in the API model and required in practice. An entry
+  missing one fails on its own; a request in which _no_ entry carries all three fails outright. Both
+  halves of that rule are AWS's, and `SimEventBridgeEntryReader.isRoutable` is what the second half
+  asks of each entry.
+- The size limit is on the request, not the entry, and it is measured by AWS's own documented
+  calculation rather than by the JSON on the wire. `sim-event-bridge-entry-size.ts` implements that
+  calculation, which is why a `Time` counts as a flat 14 bytes and a `TraceHeader` counts as nothing.
+
+## Divergences
+
+Two, both deliberate and both in `PutEvents`.
+
+An entry naming a bus that does not exist **succeeds**. Real EventBridge answers 200, matches the
+event against no rule, and drops it, without counting the entry as failed. It is a trap, because a
+mistyped bus name looks exactly like a working call, and reproducing it is the point.
+
+An entry naming a bus ARN in another account or region is **refused**, which real EventBridge allows.
+Nothing here can reach another simulation's bus, and treating a foreign ARN as local would let a test
+pass while the real call crossed a boundary it has no permission for.
+
+Event bus resource policies are not modelled at all, since nothing sets one: `PutPermission` and the
+bus `Policy` attribute are both absent. A caller from another account therefore has no way to be
+admitted to a bus, which is stricter than real AWS.

--- a/src/service/eventbridge/bus/sim-event-bus-arn.iso.test.ts
+++ b/src/service/eventbridge/bus/sim-event-bus-arn.iso.test.ts
@@ -1,0 +1,73 @@
+import {
+  assertIdentical,
+  assertObjectEquals,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { eventBusArnPrefix, parseEventBusArn } from "./sim-event-bus-arn.js";
+import { SimEventBusArn } from "./sim-event-bus-arn.js";
+import { SimEventBusName } from "./sim-event-bus-name.js";
+import { simAwsAccountRegionScopeFactory } from "../../aws/sim-aws-account-region-scope.factory.js";
+
+describe("EventBridge event bus ARN", () => {
+  it("builds an ARN carrying the event-bus resource type", () => {
+    // Given a bus name in an Account and Region.
+    const scope = simAwsAccountRegionScopeFactory.make();
+    const arn = new SimEventBusArn({
+      name: SimEventBusName.of("orders"),
+      accountRegionScope: scope,
+    });
+
+    // Then the ARN puts the type in front of the name, unlike an SNS topic.
+    const expected = `arn:aws:events:${scope.regionName}:${scope.accountId}:event-bus/`;
+
+    assertIdentical(arn.value, `${expected}orders`);
+    assertIdentical(arn.name, "orders");
+    assertIdentical(eventBusArnPrefix(scope), expected);
+  });
+
+  it("reads the Region, Account and name out of an ARN", () => {
+    // Given an event bus ARN.
+    const parsed = parseEventBusArn(
+      "arn:aws:events:eu-west-2:111111111111:event-bus/orders",
+    );
+
+    // Then all three come back.
+    assertObjectEquals(parsed, {
+      regionName: "eu-west-2",
+      accountId: "111111111111",
+      name: "orders",
+    });
+  });
+
+  it("reads nothing out of a string that is not an event bus ARN", () => {
+    // Given strings that are each wrong in one way.
+    const notArns = [
+      // Too few parts.
+      "arn:aws:events:eu-west-2:event-bus/orders",
+      // Too many parts, which is what a rule on a custom bus looks like.
+      "arn:aws:events:eu-west-2:111111111111:rule/orders:matcher",
+      // Not an ARN at all.
+      "orders",
+      // Another partition.
+      "arn:aws-cn:events:eu-west-2:111111111111:event-bus/orders",
+      // Another service.
+      "arn:aws:sns:eu-west-2:111111111111:event-bus/orders",
+      // No Region.
+      "arn:aws:events::111111111111:event-bus/orders",
+      // No Account.
+      "arn:aws:events:eu-west-2::event-bus/orders",
+      // Another resource type in the same service.
+      "arn:aws:events:eu-west-2:111111111111:rule/orders",
+      // The right resource type with no name after it.
+      "arn:aws:events:eu-west-2:111111111111:event-bus/",
+      // No resource type separator at all.
+      "arn:aws:events:eu-west-2:111111111111:orders",
+    ];
+
+    // Then none of them reads as a bus location.
+    for (const notArn of notArns) {
+      assertUndefined(parseEventBusArn(notArn));
+    }
+  });
+});

--- a/src/service/eventbridge/bus/sim-event-bus-arn.ts
+++ b/src/service/eventbridge/bus/sim-event-bus-arn.ts
@@ -1,0 +1,124 @@
+import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+import type { SimEventBusName } from "./sim-event-bus-name.js";
+
+/**
+ * The number of colon separated parts in an event bus ARN.
+ *
+ * The resource part carries a type separator, so the sixth part is
+ * `event-bus/<name>` rather than the name on its own. That is what keeps an
+ * event bus ARN from being read as a rule ARN, which carries `rule/` instead.
+ */
+const eventBusArnParts = 6;
+
+const eventBusArnPartition = "aws";
+
+const eventBusArnService = "events";
+
+const eventBusResourceType = "event-bus";
+
+/**
+ * The part of an event bus ARN that comes before the bus's own name.
+ */
+export function eventBusArnPrefix(
+  accountRegionScope: SimAwsAccountRegionScope,
+): string {
+  const { regionName, accountId } = accountRegionScope;
+
+  return `arn:aws:events:${regionName}:${accountId}:${eventBusResourceType}/`;
+}
+
+/**
+ * Where one event bus is, in the three facts its ARN carries.
+ *
+ * The strings are unbranded because the callers that have only read an ARN,
+ * rather than been handed a scope, have nothing but strings to offer.
+ */
+export interface SimEventBusLocation {
+  readonly regionName: string;
+  readonly accountId: string;
+  readonly name: string;
+}
+
+/**
+ * Read an event bus ARN into the Region, Account and name it carries.
+ *
+ * All three matter. An ARN naming another Account or Region reaches nothing in
+ * a simulated EventBridge scope rather than having its name read out and
+ * looked up locally, and treating a foreign one as local would let a test pass
+ * while the real call crossed a boundary it has no permission for.
+ *
+ * Nothing is returned for a string that is not an event bus ARN.
+ */
+export function parseEventBusArn(
+  value: string,
+): SimEventBusLocation | undefined {
+  const parts = value.split(":");
+
+  if (parts.length !== eventBusArnParts) {
+    return undefined;
+  }
+
+  const [prefix, partition, service, regionName, accountId, resource] = parts;
+
+  if (
+    prefix !== "arn" ||
+    partition !== eventBusArnPartition ||
+    service !== eventBusArnService ||
+    regionName === undefined ||
+    regionName === "" ||
+    accountId === undefined ||
+    accountId === "" ||
+    resource === undefined
+  ) {
+    return undefined;
+  }
+
+  return busLocation(resource, regionName, accountId);
+}
+
+/**
+ * Read the name out of an ARN's `event-bus/<name>` resource part.
+ */
+function busLocation(
+  resource: string,
+  regionName: string,
+  accountId: string,
+): SimEventBusLocation | undefined {
+  const separatorIndex = resource.indexOf("/");
+
+  if (resource.slice(0, separatorIndex) !== eventBusResourceType) {
+    return undefined;
+  }
+
+  const name = resource.slice(separatorIndex + 1);
+
+  if (name === "") {
+    return undefined;
+  }
+
+  return { regionName, accountId, name };
+}
+
+interface SimEventBusArnProperties {
+  readonly name: SimEventBusName;
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+}
+
+/**
+ * The ARN of one simulated event bus.
+ *
+ * A request names a bus by name rather than by ARN in most places, but the ARN
+ * is what IAM authorizes against, and what a rule or a CloudFormation template
+ * refers to.
+ */
+export class SimEventBusArn {
+  public readonly name: string;
+  public readonly value: string;
+
+  constructor(properties: SimEventBusArnProperties) {
+    const { name, accountRegionScope } = properties;
+
+    this.name = name.value;
+    this.value = eventBusArnPrefix(accountRegionScope) + name.value;
+  }
+}

--- a/src/service/eventbridge/bus/sim-event-bus-name.ts
+++ b/src/service/eventbridge/bus/sim-event-bus-name.ts
@@ -1,0 +1,91 @@
+import {
+  SimEventBridgeUnsimulatedInputException,
+  SimEventBridgeValidationException,
+} from "../error/sim-event-bridge.error.js";
+
+/**
+ * The name of the event bus every Account has without creating one.
+ *
+ * A request that names no bus reaches this one, which is why an AWS service
+ * sending events to an Account with no EventBridge configuration at all still
+ * has somewhere to send them.
+ */
+export const defaultEventBusName = "default";
+
+/**
+ * Real EventBridge allows alphanumerics, full stops, hyphens and underscores,
+ * up to 256 characters. The `/` character is in the API's own pattern but only
+ * for partner event bus names, which take the form `aws.partner/...`.
+ */
+const eventBusNamePattern = /^[.\-_A-Za-z0-9]{1,256}$/;
+
+const partnerNameSeparator = "/";
+
+/**
+ * The name of one simulated event bus.
+ *
+ * The name is the whole identity of a bus within an Account and Region, and it
+ * is the resource part of the ARN. Validating it in one place is what keeps a
+ * name that works here one that would work on real AWS.
+ */
+export class SimEventBusName {
+  public readonly value: string;
+
+  private constructor(value: string) {
+    this.value = value;
+  }
+
+  /**
+   * The name of the default event bus.
+   */
+  static default(): SimEventBusName {
+    return new this(defaultEventBusName);
+  }
+
+  /**
+   * Read the bus name a request has to carry.
+   */
+  static required(
+    name: string | undefined,
+    parameterName: string,
+  ): SimEventBusName {
+    if (name === undefined || name === "") {
+      throw new SimEventBridgeValidationException(
+        `Invalid parameter: ${parameterName} is required`,
+      );
+    }
+
+    return this.of(name);
+  }
+
+  /**
+   * Read a bus name from request input, refusing one real EventBridge would
+   * refuse.
+   */
+  static of(value: string): SimEventBusName {
+    if (value.includes(partnerNameSeparator)) {
+      throw new SimEventBridgeUnsimulatedInputException(
+        `Event bus name '${value}' carries a '/', which only a partner event ` +
+          `bus name does. Partner event buses are not simulated.`,
+      );
+    }
+
+    if (!eventBusNamePattern.test(value)) {
+      throw new SimEventBridgeValidationException(
+        `Invalid parameter: Name Reason: '${value}' is not a valid event bus ` +
+          `name. Event bus names are made up of only letters, numbers, full ` +
+          `stops, hyphens and underscores, and are between 1 and 256 ` +
+          `characters long.`,
+      );
+    }
+
+    return new this(value);
+  }
+
+  /**
+   * Whether this is the name of the default event bus.
+   */
+  get isDefault(): boolean {
+    return this.value === defaultEventBusName;
+  }
+}

--- a/src/service/eventbridge/bus/sim-event-bus-store.ts
+++ b/src/service/eventbridge/bus/sim-event-bus-store.ts
@@ -1,0 +1,61 @@
+import { SimEventBridgeResourceNotFoundException } from "../error/sim-event-bridge.error.js";
+import type { SimEventBus } from "./sim-event-bus.js";
+
+/**
+ * The event buses of one simulated EventBridge scope.
+ *
+ * Buses are keyed by name, which is unique within one Account and Region. The
+ * default bus is put here when the scope is built rather than created by a
+ * request, which is what makes it available to an Account that has never
+ * called EventBridge at all.
+ */
+export class SimEventBusStore {
+  private readonly buses = new Map<string, SimEventBus>();
+
+  constructor(defaultBus: SimEventBus) {
+    this.add(defaultBus);
+  }
+
+  /**
+   * Every bus in this scope, in creation order, starting with the default one.
+   */
+  get all(): readonly SimEventBus[] {
+    return this.buses.values().toArray();
+  }
+
+  /**
+   * Store a newly created bus.
+   */
+  add(bus: SimEventBus): void {
+    this.buses.set(bus.name.value, bus);
+  }
+
+  /**
+   * Find a bus by name.
+   */
+  find(name: string): SimEventBus | undefined {
+    return this.buses.get(name);
+  }
+
+  /**
+   * Resolve a bus by name, or refuse.
+   */
+  require(name: string): SimEventBus {
+    const found = this.find(name);
+
+    if (found === undefined) {
+      throw new SimEventBridgeResourceNotFoundException(
+        `Event bus ${name} does not exist.`,
+      );
+    }
+
+    return found;
+  }
+
+  /**
+   * Forget a deleted bus.
+   */
+  remove(bus: SimEventBus): void {
+    this.buses.delete(bus.name.value);
+  }
+}

--- a/src/service/eventbridge/bus/sim-event-bus.ts
+++ b/src/service/eventbridge/bus/sim-event-bus.ts
@@ -1,0 +1,75 @@
+import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+import type { SimEventBridgeEvent } from "../event/sim-event-bridge-event.js";
+import { SimEventBusArn } from "./sim-event-bus-arn.js";
+import { SimEventBusName } from "./sim-event-bus-name.js";
+
+interface SimEventBusProperties {
+  readonly name: SimEventBusName;
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+  readonly createdAt: Date;
+  readonly description?: string | undefined;
+}
+
+/**
+ * One simulated event bus.
+ *
+ * A bus is a router rather than a store: real EventBridge keeps no events, and
+ * an event that matches no rule is gone as soon as it arrives. The events this
+ * class keeps are a simulator affordance so a test can see what a bus
+ * received, not modelled AWS state, and nothing an SDK command returns is
+ * built from them.
+ */
+export class SimEventBus {
+  public readonly name: SimEventBusName;
+  public readonly arn: SimEventBusArn;
+  public readonly creationTime: Date;
+  public readonly description: string | undefined;
+
+  private readonly received: SimEventBridgeEvent[] = [];
+
+  constructor(properties: SimEventBusProperties) {
+    this.name = properties.name;
+    this.arn = new SimEventBusArn({
+      name: properties.name,
+      accountRegionScope: properties.accountRegionScope,
+    });
+    this.creationTime = properties.createdAt;
+    this.description = properties.description;
+  }
+
+  /**
+   * The default event bus, which every Account and Region has without one
+   * being created.
+   */
+  static default(properties: {
+    readonly accountRegionScope: SimAwsAccountRegionScope;
+    readonly createdAt: Date;
+  }): SimEventBus {
+    return new this({
+      name: SimEventBusName.default(),
+      accountRegionScope: properties.accountRegionScope,
+      createdAt: properties.createdAt,
+    });
+  }
+
+  /**
+   * Every event this bus has received, in arrival order.
+   *
+   * This is the simulator's own accessor, for a test asserting on what
+   * EventBridge built from a PutEvents entry. Real EventBridge offers nothing
+   * like it without an archive.
+   */
+  get receivedEvents(): readonly SimEventBridgeEvent[] {
+    return [...this.received];
+  }
+
+  /**
+   * Take an event onto this bus.
+   *
+   * Today that only records it. Matching it against the bus's rules, and
+   * sending it to their targets, is what a later change adds here.
+   */
+  receive(event: SimEventBridgeEvent): void {
+    this.received.push(event);
+  }
+}

--- a/src/service/eventbridge/command/authorize/sim-event-bridge-auth-z.iso.test.ts
+++ b/src/service/eventbridge/command/authorize/sim-event-bridge-auth-z.iso.test.ts
@@ -1,0 +1,228 @@
+import {
+  CreateEventBusCommand,
+  DescribeEventBusCommand,
+  ListEventBusesCommand,
+  PutEventsCommand,
+} from "@aws-sdk/client-eventbridge";
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import { SimEventBridgeAccessDeniedException } from "../../error/sim-event-bridge.error.js";
+
+/**
+ * A simulated AWS with an `orders` bus, and a Role allowed only what a policy
+ * statement says.
+ */
+async function simAwsWithRole(
+  statement: object,
+): Promise<{ simAws: SimAws; caller: SimAwsCaller }> {
+  const simAws = new SimAws();
+
+  await simAws
+    .eventBridge()
+    .createEventBus(new CreateEventBusCommand({ Name: "orders" }));
+
+  const role = await simAws.iam().createRole(
+    new CreateRoleCommand({
+      RoleName: "OrderPublisher",
+      AssumeRolePolicyDocument: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: {
+          Effect: "Allow",
+          Principal: { AWS: `arn:aws:iam::${simAws.defaultAccountId}:root` },
+          Action: "sts:AssumeRole",
+        },
+      }),
+    }),
+  );
+
+  await simAws.iam().putRolePolicy(
+    new PutRolePolicyCommand({
+      RoleName: "OrderPublisher",
+      PolicyName: "PublishOrders",
+      PolicyDocument: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: statement,
+      }),
+    }),
+  );
+
+  return { simAws, caller: { kind: "arn", arn: role.Role.Arn } };
+}
+
+describe("EventBridge IAM authorization", () => {
+  it("admits a caller whose policy names the bus ARN", async () => {
+    // Given a Role allowed to put events on one bus.
+    const { simAws, caller } = await simAwsWithRole({
+      Effect: "Allow",
+      Action: "events:PutEvents",
+      Resource: "arn:aws:events:us-east-1:888888888888:event-bus/orders",
+    });
+
+    // When it puts an event on that bus.
+    const output = await simAws.eventBridge().putEvents(
+      new PutEventsCommand({
+        Entries: [
+          {
+            EventBusName: "orders",
+            Source: "orders.service",
+            DetailType: "OrderPlaced",
+            Detail: "{}",
+          },
+        ],
+      }),
+      { caller },
+    );
+
+    // Then it is allowed.
+    assertIdentical(output.FailedEntryCount, 0);
+  });
+
+  it("refuses a caller putting events on a bus its policy does not name", async () => {
+    // Given a Role allowed only the orders bus.
+    const { simAws, caller } = await simAwsWithRole({
+      Effect: "Allow",
+      Action: "events:PutEvents",
+      Resource: "arn:aws:events:us-east-1:888888888888:event-bus/orders",
+    });
+
+    // When it puts an event on the default bus.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.eventBridge().putEvents(
+        new PutEventsCommand({
+          Entries: [
+            {
+              Source: "orders.service",
+              DetailType: "OrderPlaced",
+              Detail: "{}",
+            },
+          ],
+        }),
+        { caller },
+      );
+    });
+
+    // Then it is refused, naming the action and the bus it could not reach.
+    assertInstanceOf(error, SimEventBridgeAccessDeniedException);
+    assertStringIncludes(error.message, "events:PutEvents");
+    assertStringIncludes(error.message, "event-bus/default");
+  });
+
+  it("refuses a bus ARN written without its resource type", async () => {
+    // Given a Role whose policy leaves the event-bus/ out of the resource,
+    // the way an SNS topic ARN would be written.
+    const { simAws, caller } = await simAwsWithRole({
+      Effect: "Allow",
+      Action: "events:PutEvents",
+      Resource: "arn:aws:events:us-east-1:888888888888:orders",
+    });
+
+    // When it puts an event on the orders bus.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.eventBridge().putEvents(
+        new PutEventsCommand({
+          Entries: [
+            {
+              EventBusName: "orders",
+              Source: "orders.service",
+              DetailType: "OrderPlaced",
+              Detail: "{}",
+            },
+          ],
+        }),
+        { caller },
+      );
+    });
+
+    // Then it matches nothing, as it matches nothing on real AWS.
+    assertInstanceOf(error, SimEventBridgeAccessDeniedException);
+  });
+
+  it("refuses creating and describing a bus without permission", async () => {
+    // Given a Role allowed only to put events.
+    const { simAws, caller } = await simAwsWithRole({
+      Effect: "Allow",
+      Action: "events:PutEvents",
+      Resource: "*",
+    });
+
+    // When it creates a bus, and describes one.
+    const created = await assertThrowsErrorAsync(async () => {
+      await simAws
+        .eventBridge()
+        .createEventBus(new CreateEventBusCommand({ Name: "billing" }), {
+          caller,
+        });
+    });
+    const described = await assertThrowsErrorAsync(async () => {
+      await simAws
+        .eventBridge()
+        .describeEventBus(new DescribeEventBusCommand({}), { caller });
+    });
+
+    // Then both are refused.
+    assertInstanceOf(created, SimEventBridgeAccessDeniedException);
+    assertInstanceOf(described, SimEventBridgeAccessDeniedException);
+  });
+
+  it("refuses a caller for a bus that does not exist, rather than saying so", async () => {
+    // Given a Role with no EventBridge permission at all.
+    const { simAws, caller } = await simAwsWithRole({
+      Effect: "Allow",
+      Action: "s3:GetObject",
+      Resource: "*",
+    });
+
+    // When it describes a bus that was never created.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws
+        .eventBridge()
+        .describeEventBus(new DescribeEventBusCommand({ Name: "secret" }), {
+          caller,
+        });
+    });
+
+    // Then the refusal is the permission one, so nothing leaks about which
+    // buses the Account has.
+    assertInstanceOf(error, SimEventBridgeAccessDeniedException);
+  });
+
+  it("authorizes a listing against every bus rather than one", async () => {
+    // Given a Role allowed to list only if the resource is everything.
+    const { simAws, caller } = await simAwsWithRole({
+      Effect: "Allow",
+      Action: "events:ListEventBuses",
+      Resource: "arn:aws:events:us-east-1:888888888888:event-bus/orders",
+    });
+
+    // When it lists the buses.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws
+        .eventBridge()
+        .listEventBuses(new ListEventBusesCommand({}), { caller });
+    });
+
+    // Then a policy naming one bus does not allow it, here as on real AWS.
+    assertInstanceOf(error, SimEventBridgeAccessDeniedException);
+
+    // And a policy whose resource is everything does.
+    const { simAws: allowed, caller: listCaller } = await simAwsWithRole({
+      Effect: "Allow",
+      Action: "events:ListEventBuses",
+      Resource: "*",
+    });
+    const listed = await allowed
+      .eventBridge()
+      .listEventBuses(new ListEventBusesCommand({}), { caller: listCaller });
+
+    assertNonNullable(listed.EventBuses);
+  });
+});

--- a/src/service/eventbridge/command/authorize/sim-event-bridge-auth-z.iso.test.ts
+++ b/src/service/eventbridge/command/authorize/sim-event-bridge-auth-z.iso.test.ts
@@ -1,11 +1,13 @@
 import {
   CreateEventBusCommand,
+  DeleteEventBusCommand,
   DescribeEventBusCommand,
   ListEventBusesCommand,
   PutEventsCommand,
 } from "@aws-sdk/client-eventbridge";
 import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
 import {
+  assertArrayLength,
   assertIdentical,
   assertInstanceOf,
   assertNonNullable,
@@ -143,6 +145,63 @@ describe("EventBridge IAM authorization", () => {
     });
 
     // Then it matches nothing, as it matches nothing on real AWS.
+    assertInstanceOf(error, SimEventBridgeAccessDeniedException);
+  });
+
+  it("puts no event at all when one entry of a request is refused", async () => {
+    // Given a Role allowed to put events on the orders bus only.
+    const { simAws, caller } = await simAwsWithRole({
+      Effect: "Allow",
+      Action: "events:PutEvents",
+      Resource: "arn:aws:events:us-east-1:888888888888:event-bus/orders",
+    });
+
+    // When a request puts one entry on that bus and a later one on default.
+    await assertThrowsErrorAsync(async () => {
+      await simAws.eventBridge().putEvents(
+        new PutEventsCommand({
+          Entries: [
+            {
+              EventBusName: "orders",
+              Source: "orders.service",
+              DetailType: "OrderPlaced",
+              Detail: "{}",
+            },
+            {
+              Source: "orders.service",
+              DetailType: "OrderPlaced",
+              Detail: "{}",
+            },
+          ],
+        }),
+        { caller },
+      );
+    });
+
+    // Then the allowed entry was not delivered either, so a refused request
+    // leaves nothing behind.
+    assertArrayLength(simAws.eventBridge().eventsOn("orders"), 0);
+  });
+
+  it("refuses deleting the default bus with the permission error first", async () => {
+    // Given a Role with no EventBridge permission at all.
+    const { simAws, caller } = await simAwsWithRole({
+      Effect: "Allow",
+      Action: "s3:GetObject",
+      Resource: "*",
+    });
+
+    // When it deletes the default bus, which nobody may delete.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws
+        .eventBridge()
+        .deleteEventBus(new DeleteEventBusCommand({ Name: "default" }), {
+          caller,
+        });
+    });
+
+    // Then IAM decides first, as it does on real AWS, so the answer is the
+    // permission one rather than the rule about the default bus.
     assertInstanceOf(error, SimEventBridgeAccessDeniedException);
   });
 

--- a/src/service/eventbridge/command/authorize/sim-event-bridge-authorizer.ts
+++ b/src/service/eventbridge/command/authorize/sim-event-bridge-authorizer.ts
@@ -1,0 +1,94 @@
+import type { SimAwsResolvedCaller } from "../../../aws/caller/sim-aws-caller-resolver.js";
+import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { SimIamCallerIdentifier } from "../../../iam/error/sim-iam-caller-identifier.js";
+import { SimEventBridgeAccessDeniedException } from "../../error/sim-event-bridge.error.js";
+import type { SimEventBridgeRequestOptions } from "../sim-event-bridge-request-options.js";
+
+/**
+ * The resource an action with no resource type authorizes against.
+ *
+ * Real EventBridge gives ListEventBuses no resource, so IAM evaluates it
+ * against `*` and only a policy whose Resource is `*` allows it. A policy
+ * naming a bus ARN allows no listing, here as on AWS.
+ */
+const noResource = "*";
+
+interface SimEventBridgeAuthorizerProperties {
+  readonly iam: SimIamInterServiceAuthZ;
+}
+
+/**
+ * Applies simulated IAM authorization to EventBridge requests.
+ *
+ * The resource an operation authorizes against is the event bus ARN,
+ * `arn:aws:events:<region>:<account>:event-bus/<name>`, which carries a
+ * resource type unlike an SNS topic ARN. A policy written without the
+ * `event-bus/` in it matches nothing here, as it matches nothing on real AWS.
+ *
+ * A denial is reported as AccessDeniedException, which is what EventBridge
+ * answers a refused request with. It has no error of its own for the case, so
+ * there is nothing service-specific to translate to.
+ *
+ * Event bus resource policies are not part of the decision yet, because
+ * nothing sets one: PutPermission and the bus `Policy` attribute are not
+ * simulated. A caller from another Account therefore has no way to be admitted
+ * to a bus, which is stricter than real AWS and is recorded as a limitation.
+ */
+export class SimEventBridgeAuthorizer {
+  private readonly iam: SimIamInterServiceAuthZ;
+  private readonly callerIdentifier = new SimIamCallerIdentifier();
+
+  constructor(properties: SimEventBridgeAuthorizerProperties) {
+    this.iam = properties.iam;
+  }
+
+  /**
+   * Ensure the caller may perform an action on a bus, named by its ARN.
+   *
+   * The bus need not exist. CreateEventBus authorizes against the ARN the bus
+   * is about to have, and PutEvents authorizes against the ARN of a bus that
+   * may well not be there.
+   */
+  authorizeBus(
+    action: string,
+    busArn: string,
+    options?: SimEventBridgeRequestOptions,
+  ): SimAwsResolvedCaller {
+    return this.authorizeResource(action, busArn, options);
+  }
+
+  /**
+   * Ensure the caller may perform an action that names no particular bus.
+   */
+  authorizeAnyBus(
+    action: string,
+    options?: SimEventBridgeRequestOptions,
+  ): SimAwsResolvedCaller {
+    return this.authorizeResource(action, noResource, options);
+  }
+
+  private authorizeResource(
+    action: string,
+    resource: string,
+    options: SimEventBridgeRequestOptions | undefined,
+  ): SimAwsResolvedCaller {
+    const decision = this.iam.authorize({
+      action,
+      resource,
+      caller: options?.caller,
+    });
+
+    if (decision.isDenied) {
+      const identifier = this.callerIdentifier.format(
+        decision.caller.principal,
+      );
+
+      throw new SimEventBridgeAccessDeniedException(
+        `User: ${identifier} is not authorized to perform: ${action} on ` +
+          `resource: ${resource}`,
+      );
+    }
+
+    return decision.caller;
+  }
+}

--- a/src/service/eventbridge/command/bus/bus.command.ts
+++ b/src/service/eventbridge/command/bus/bus.command.ts
@@ -1,0 +1,122 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+
+/**
+ * One event bus as a listing reports it.
+ */
+export interface SimListedEventBus {
+  readonly Name: string;
+  readonly Arn: string;
+  readonly Description?: string | undefined;
+  readonly CreationTime: Date;
+  readonly LastModifiedTime: Date;
+}
+
+/**
+ * The dead letter queue configuration a bus request can carry, which this
+ * simulation refuses rather than models.
+ */
+export interface SimEventBridgeDeadLetterConfig {
+  readonly Arn?: string | undefined;
+}
+
+/**
+ * The log configuration a bus request can carry, which this simulation refuses
+ * rather than models.
+ */
+export interface SimEventBridgeLogConfig {
+  readonly IncludeDetail?: string | undefined;
+  readonly Level?: string | undefined;
+}
+
+/**
+ * One tag as an event bus request carries it.
+ */
+export interface SimEventBridgeTag {
+  readonly Key?: string | undefined;
+  readonly Value?: string | undefined;
+}
+
+/**
+ * Minimal structural sim EventBridge CreateEventBus command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/eventbridge/command/CreateEventBusCommand/
+ */
+export interface SimCreateEventBusCommand {
+  readonly input: SimCreateEventBusCommandInput;
+}
+
+export interface SimCreateEventBusCommandInput {
+  readonly Name?: string | undefined;
+  readonly Description?: string | undefined;
+  readonly EventSourceName?: string | undefined;
+  readonly KmsKeyIdentifier?: string | undefined;
+  readonly DeadLetterConfig?: SimEventBridgeDeadLetterConfig | undefined;
+  readonly LogConfig?: SimEventBridgeLogConfig | undefined;
+  readonly Tags?: readonly SimEventBridgeTag[] | undefined;
+}
+
+export interface SimCreateEventBusCommandOutput {
+  readonly EventBusArn?: string | undefined;
+  readonly Description?: string | undefined;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim EventBridge DeleteEventBus command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/eventbridge/command/DeleteEventBusCommand/
+ */
+export interface SimDeleteEventBusCommand {
+  readonly input: SimDeleteEventBusCommandInput;
+}
+
+export interface SimDeleteEventBusCommandInput {
+  readonly Name?: string | undefined;
+}
+
+export interface SimDeleteEventBusCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim EventBridge DescribeEventBus command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/eventbridge/command/DescribeEventBusCommand/
+ */
+export interface SimDescribeEventBusCommand {
+  readonly input: SimDescribeEventBusCommandInput;
+}
+
+export interface SimDescribeEventBusCommandInput {
+  readonly Name?: string | undefined;
+}
+
+export interface SimDescribeEventBusCommandOutput {
+  readonly Name?: string | undefined;
+  readonly Arn?: string | undefined;
+  readonly Description?: string | undefined;
+  readonly CreationTime?: Date | undefined;
+  readonly LastModifiedTime?: Date | undefined;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim EventBridge ListEventBuses command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/eventbridge/command/ListEventBusesCommand/
+ */
+export interface SimListEventBusesCommand {
+  readonly input: SimListEventBusesCommandInput;
+}
+
+export interface SimListEventBusesCommandInput {
+  readonly NamePrefix?: string | undefined;
+  readonly Limit?: number | undefined;
+  readonly NextToken?: string | undefined;
+}
+
+export interface SimListEventBusesCommandOutput {
+  readonly EventBuses?: readonly SimListedEventBus[] | undefined;
+  readonly NextToken?: string | undefined;
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/eventbridge/command/bus/sim-event-bridge-bus-access.ts
+++ b/src/service/eventbridge/command/bus/sim-event-bridge-bus-access.ts
@@ -1,0 +1,108 @@
+import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
+import { eventBusArnPrefix } from "../../bus/sim-event-bus-arn.js";
+import type { SimEventBusName } from "../../bus/sim-event-bus-name.js";
+import type { SimEventBus } from "../../bus/sim-event-bus.js";
+import type { SimEventBusStore } from "../../bus/sim-event-bus-store.js";
+import type { SimEventBridgeAuthorizer } from "../authorize/sim-event-bridge-authorizer.js";
+import type { SimEventBridgeRequestOptions } from "../sim-event-bridge-request-options.js";
+import { simEventBridgeRequestBusName } from "./sim-event-bridge-request-bus-name.js";
+
+interface SimEventBridgeBusAccessProperties {
+  readonly buses: SimEventBusStore;
+  readonly authorizer: SimEventBridgeAuthorizer;
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+}
+
+/**
+ * How a request reaches the event bus it names.
+ *
+ * Every operation but ListEventBuses starts the same way: read the name or ARN
+ * the request carries, authorize the action against the ARN that name implies,
+ * then look the bus up.
+ *
+ * Authorizing before looking the bus up is deliberate. A caller with no
+ * permission is refused for a bus that does not exist rather than told the bus
+ * is missing, which is what keeps a listing of an Account's buses from leaking
+ * out of a permission error.
+ */
+export class SimEventBridgeBusAccess {
+  private readonly buses: SimEventBusStore;
+  private readonly authorizer: SimEventBridgeAuthorizer;
+  private readonly accountRegionScope: SimAwsAccountRegionScope;
+
+  constructor(properties: SimEventBridgeBusAccessProperties) {
+    this.buses = properties.buses;
+    this.authorizer = properties.authorizer;
+    this.accountRegionScope = properties.accountRegionScope;
+  }
+
+  /**
+   * The ARN a bus of this name has, or would have.
+   */
+  arnFor(name: SimEventBusName): string {
+    return eventBusArnPrefix(this.accountRegionScope) + name.value;
+  }
+
+  /**
+   * Read the bus name a request names, as a name or an ARN.
+   */
+  requestedName(value: string | undefined): SimEventBusName {
+    return simEventBridgeRequestBusName(value, this.accountRegionScope);
+  }
+
+  /**
+   * Ensure the caller may perform an action on the bus of a given name.
+   *
+   * The bus need not exist, which is what CreateEventBus and PutEvents both
+   * need: they authorize against the ARN a bus of that name has.
+   */
+  authorizeName(
+    action: string,
+    name: SimEventBusName,
+    options?: SimEventBridgeRequestOptions,
+  ): void {
+    this.authorizer.authorizeBus(action, this.arnFor(name), options);
+  }
+
+  /**
+   * Ensure the caller may perform an action naming no particular bus.
+   */
+  authorizeAnyBus(
+    action: string,
+    options?: SimEventBridgeRequestOptions,
+  ): void {
+    this.authorizer.authorizeAnyBus(action, options);
+  }
+
+  /**
+   * Resolve the bus a request names, authorizing the action first.
+   */
+  require(
+    action: string,
+    requested: string | undefined,
+    options?: SimEventBridgeRequestOptions,
+  ): SimEventBus {
+    const name = this.requestedName(requested);
+
+    this.authorizeName(action, name, options);
+
+    return this.buses.require(name.value);
+  }
+
+  /**
+   * Resolve the bus a request names, or nothing when there is none.
+   *
+   * This is what DeleteEventBus needs. Real EventBridge documents no
+   * not-found error for it, so deleting a bus that is not there succeeds, and
+   * the caller still has to be allowed to delete it.
+   */
+  find(
+    action: string,
+    name: SimEventBusName,
+    options?: SimEventBridgeRequestOptions,
+  ): SimEventBus | undefined {
+    this.authorizeName(action, name, options);
+
+    return this.buses.find(name.value);
+  }
+}

--- a/src/service/eventbridge/command/bus/sim-event-bridge-bus-commands.iso.test.ts
+++ b/src/service/eventbridge/command/bus/sim-event-bridge-bus-commands.iso.test.ts
@@ -1,0 +1,211 @@
+import {
+  CreateEventBusCommand,
+  DeleteEventBusCommand,
+  DescribeEventBusCommand,
+  ListEventBusesCommand,
+} from "@aws-sdk/client-eventbridge";
+import {
+  assertArrayEquals,
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimFixedClock } from "../../../../util/clock/sim-clock.js";
+import { SimEventBridgeResourceNotFoundException } from "../../error/sim-event-bridge.error.js";
+
+describe("EventBridge event bus commands", () => {
+  it("has a default event bus that was never created", async () => {
+    // Given a simulated AWS in one Account and Region.
+    const simAws = new SimAws({
+      defaultAccountId: "111111111111",
+      defaultRegionName: "eu-west-2",
+    });
+
+    // When the bus nothing created is described.
+    const described = await simAws
+      .eventBridge()
+      .describeEventBus(new DescribeEventBusCommand({}));
+
+    // Then it is the default bus, with an ARN naming its Account and Region.
+    assertIdentical(described.Name, "default");
+    assertIdentical(
+      described.Arn,
+      "arn:aws:events:eu-west-2:111111111111:event-bus/default",
+    );
+  });
+
+  it("creates a custom bus and reports it alongside the default one", async () => {
+    // Given a simulated EventBridge.
+    const simAws = new SimAws();
+
+    // When a bus is created.
+    const created = await simAws.eventBridge().createEventBus(
+      new CreateEventBusCommand({
+        Name: "orders",
+        Description: "Order domain events",
+      }),
+    );
+
+    // Then its ARN carries the event-bus resource type.
+    assertIdentical(
+      created.EventBusArn,
+      "arn:aws:events:us-east-1:888888888888:event-bus/orders",
+    );
+
+    // And a listing reports it after the default bus.
+    const listed = await simAws
+      .eventBridge()
+      .listEventBuses(new ListEventBusesCommand({}));
+
+    assertArrayEquals(
+      listed.EventBuses?.map((bus) => bus.Name),
+      ["default", "orders"],
+    );
+    assertUndefined(listed.NextToken);
+
+    // And describing it reports the description it was created with.
+    const described = await simAws
+      .eventBridge()
+      .describeEventBus(new DescribeEventBusCommand({ Name: "orders" }));
+
+    assertIdentical(described.Description, "Order domain events");
+  });
+
+  it("stamps a bus creation time from the simulation's clock", async () => {
+    // Given a simulation started at a known instant.
+    const simAws = new SimAws({
+      clock: new SimFixedClock(new Date("2026-07-26T09:00:00.000Z")),
+    });
+
+    // When time moves on and a bus is created.
+    await simAws.clock().advanceBy({ hours: 2 });
+    await simAws
+      .eventBridge()
+      .createEventBus(new CreateEventBusCommand({ Name: "orders" }));
+
+    // Then the bus was created at the simulated time, not the host's.
+    const described = await simAws
+      .eventBridge()
+      .describeEventBus(new DescribeEventBusCommand({ Name: "orders" }));
+
+    assertIdentical(
+      described.CreationTime?.toISOString(),
+      "2026-07-26T11:00:00.000Z",
+    );
+  });
+
+  it("describes a bus by its ARN as well as by its name", async () => {
+    // Given a created bus.
+    const simAws = new SimAws();
+    const created = await simAws
+      .eventBridge()
+      .createEventBus(new CreateEventBusCommand({ Name: "orders" }));
+
+    // When it is described by ARN.
+    const described = await simAws
+      .eventBridge()
+      .describeEventBus(
+        new DescribeEventBusCommand({ Name: created.EventBusArn }),
+      );
+
+    // Then it is the same bus.
+    assertIdentical(described.Name, "orders");
+  });
+
+  it("deletes a custom bus, and takes a repeated delete in its stride", async () => {
+    // Given a created bus.
+    const simAws = new SimAws();
+    await simAws
+      .eventBridge()
+      .createEventBus(new CreateEventBusCommand({ Name: "orders" }));
+
+    // When it is deleted twice.
+    await simAws
+      .eventBridge()
+      .deleteEventBus(new DeleteEventBusCommand({ Name: "orders" }));
+    await simAws
+      .eventBridge()
+      .deleteEventBus(new DeleteEventBusCommand({ Name: "orders" }));
+
+    // Then it is gone, and neither delete failed.
+    assertUndefined(simAws.eventBridge().findEventBus("orders"));
+
+    // And the name is free to use again straight away.
+    await simAws
+      .eventBridge()
+      .createEventBus(new CreateEventBusCommand({ Name: "orders" }));
+
+    assertNonNullable(simAws.eventBridge().findEventBus("orders"));
+  });
+
+  it("keeps buses to their own Account and Region", async () => {
+    // Given a bus in one Account and Region.
+    const simAws = new SimAws();
+    await simAws
+      .account("111111111111")
+      .region("eu-west-2")
+      .eventBridge()
+      .createEventBus(new CreateEventBusCommand({ Name: "orders" }));
+
+    // When another Region's EventBridge is asked for it.
+    const listed = await simAws
+      .account("111111111111")
+      .region("us-east-1")
+      .eventBridge()
+      .listEventBuses(new ListEventBusesCommand({}));
+
+    // Then it has only its own default bus.
+    assertArrayEquals(
+      listed.EventBuses?.map((bus) => bus.Name),
+      ["default"],
+    );
+
+    // And describing the bus there finds nothing.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws
+        .account("111111111111")
+        .region("us-east-1")
+        .eventBridge()
+        .describeEventBus(new DescribeEventBusCommand({ Name: "orders" }));
+    });
+
+    assertInstanceOf(error, SimEventBridgeResourceNotFoundException);
+  });
+
+  it("narrows a listing to a name prefix, a page at a time", async () => {
+    // Given more buses than one listing page holds.
+    const simAws = new SimAws();
+    for (let index = 0; index < 12; index += 1) {
+      // oxlint-disable-next-line no-await-in-loop
+      await simAws
+        .eventBridge()
+        .createEventBus(
+          new CreateEventBusCommand({ Name: `orders-${String(index)}` }),
+        );
+    }
+
+    // When they are listed by prefix, ten at a time.
+    const first = await simAws.eventBridge().listEventBuses(
+      new ListEventBusesCommand({
+        NamePrefix: "orders-",
+        Limit: 10,
+      }),
+    );
+    const second = await simAws.eventBridge().listEventBuses(
+      new ListEventBusesCommand({
+        NamePrefix: "orders-",
+        Limit: 10,
+        NextToken: first.NextToken,
+      }),
+    );
+
+    // Then the default bus is left out by the prefix, and the rest page.
+    assertIdentical(first.EventBuses?.length, 10);
+    assertIdentical(second.EventBuses?.length, 2);
+    assertUndefined(second.NextToken);
+  });
+});

--- a/src/service/eventbridge/command/bus/sim-event-bridge-bus-commands.ts
+++ b/src/service/eventbridge/command/bus/sim-event-bridge-bus-commands.ts
@@ -1,0 +1,82 @@
+import type { SimEventBusStore } from "../../bus/sim-event-bus-store.js";
+import { SimEventBridgePage } from "../sim-event-bridge-page.js";
+import type { SimEventBridgeRequestOptions } from "../sim-event-bridge-request-options.js";
+import type { SimEventBridgeBusAccess } from "./sim-event-bridge-bus-access.js";
+import {
+  listedEventBus,
+  listedEventBuses,
+} from "./sim-event-bridge-listed-bus.js";
+import type {
+  SimDescribeEventBusCommand,
+  SimDescribeEventBusCommandOutput,
+  SimListEventBusesCommand,
+  SimListEventBusesCommandOutput,
+} from "./bus.command.js";
+
+interface SimEventBridgeBusCommandsProperties {
+  readonly buses: SimEventBusStore;
+  readonly access: SimEventBridgeBusAccess;
+}
+
+/**
+ * The commands that read event buses back.
+ *
+ * Creating and deleting one are their own handlers, since each carries rules
+ * of its own about which names it will take. Describing and listing carry
+ * none, and report the same fields as each other.
+ */
+export class SimEventBridgeBusCommands {
+  private readonly buses: SimEventBusStore;
+  private readonly access: SimEventBridgeBusAccess;
+
+  constructor(properties: SimEventBridgeBusCommandsProperties) {
+    this.buses = properties.buses;
+    this.access = properties.access;
+  }
+
+  /**
+   * Describe an event bus, by name or ARN.
+   *
+   * A request naming no bus describes the default one, as it does on real AWS.
+   */
+  describeEventBus(
+    command: SimDescribeEventBusCommand,
+    options?: SimEventBridgeRequestOptions,
+  ): SimDescribeEventBusCommandOutput {
+    const bus = this.access.require(
+      "events:DescribeEventBus",
+      command.input.Name,
+      options,
+    );
+
+    return { $metadata: {}, ...listedEventBus(bus) };
+  }
+
+  /**
+   * List the buses in this scope, the default one first.
+   *
+   * Real EventBridge gives this action no bus-level permission, so it
+   * authorizes against every bus in the Account and Region and does not filter
+   * the list by what the caller can reach.
+   */
+  listEventBuses(
+    command: SimListEventBusesCommand,
+    options?: SimEventBridgeRequestOptions,
+  ): SimListEventBusesCommandOutput {
+    const input = command.input;
+
+    this.access.authorizeAnyBus("events:ListEventBuses", options);
+
+    const page = new SimEventBridgePage(
+      listedEventBuses(this.buses.all, input.NamePrefix),
+      input.Limit,
+      input.NextToken,
+    );
+
+    return {
+      $metadata: {},
+      EventBuses: page.items,
+      NextToken: page.nextToken,
+    };
+  }
+}

--- a/src/service/eventbridge/command/bus/sim-event-bridge-bus-validation.iso.test.ts
+++ b/src/service/eventbridge/command/bus/sim-event-bridge-bus-validation.iso.test.ts
@@ -1,0 +1,207 @@
+import {
+  CreateEventBusCommand,
+  type CreateEventBusCommandInput,
+  DeleteEventBusCommand,
+  ListEventBusesCommand,
+} from "@aws-sdk/client-eventbridge";
+import {
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import {
+  SimEventBridgeResourceAlreadyExistsException,
+  SimEventBridgeUnsimulatedInputException,
+  SimEventBridgeValidationException,
+} from "../../error/sim-event-bridge.error.js";
+
+describe("EventBridge event bus validation", () => {
+  it("refuses a second bus of the same name", async () => {
+    // Given a created bus.
+    const simAws = new SimAws();
+    await simAws
+      .eventBridge()
+      .createEventBus(new CreateEventBusCommand({ Name: "orders" }));
+
+    // When the same name is created again.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws
+        .eventBridge()
+        .createEventBus(new CreateEventBusCommand({ Name: "orders" }));
+    });
+
+    // Then it is refused rather than answered with the existing bus, unlike
+    // an SNS CreateTopic.
+    assertInstanceOf(error, SimEventBridgeResourceAlreadyExistsException);
+  });
+
+  it("refuses a custom bus named default", async () => {
+    // Given a simulated EventBridge, whose default bus is always there.
+    const simAws = new SimAws();
+
+    // When a bus is created under that name.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws
+        .eventBridge()
+        .createEventBus(new CreateEventBusCommand({ Name: "default" }));
+    });
+
+    // Then it is refused as a name already taken.
+    assertInstanceOf(error, SimEventBridgeResourceAlreadyExistsException);
+  });
+
+  it("refuses deleting the default bus", async () => {
+    // Given a simulated EventBridge.
+    const simAws = new SimAws();
+
+    // When its default bus is deleted.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws
+        .eventBridge()
+        .deleteEventBus(new DeleteEventBusCommand({ Name: "default" }));
+    });
+
+    // Then it is refused, as real EventBridge refuses it.
+    assertInstanceOf(error, SimEventBridgeValidationException);
+    assertStringIncludes(error.message, "Cannot delete event bus default.");
+  });
+
+  it("refuses a bus name real EventBridge would refuse", async () => {
+    // Given a simulated EventBridge.
+    const simAws = new SimAws();
+
+    // When a name with a disallowed character is used.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws
+        .eventBridge()
+        .createEventBus(new CreateEventBusCommand({ Name: "orders events" }));
+    });
+
+    // Then it is refused rather than created under a name AWS would not take.
+    assertInstanceOf(error, SimEventBridgeValidationException);
+    assertStringIncludes(error.message, "orders events");
+  });
+
+  it("refuses a partner event bus name", async () => {
+    // Given a simulated EventBridge.
+    const simAws = new SimAws();
+
+    // When a name carrying a partner separator is used.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.eventBridge().createEventBus(
+        new CreateEventBusCommand({
+          Name: "aws.partner/example.com/orders",
+        }),
+      );
+    });
+
+    // Then it is refused rather than created as an ordinary custom bus.
+    assertInstanceOf(error, SimEventBridgeUnsimulatedInputException);
+    assertStringIncludes(error.message, "Partner event buses");
+  });
+
+  it("refuses bus inputs it does not model rather than dropping them", async () => {
+    // Given a simulated EventBridge.
+    const simAws = new SimAws();
+
+    // When a bus is asked for with each unmodelled property in turn.
+    const inputs: CreateEventBusCommandInput[] = [
+      { Name: "orders", Tags: [{ Key: "team", Value: "orders" }] },
+      { Name: "orders", KmsKeyIdentifier: "alias/events" },
+      {
+        Name: "orders",
+        DeadLetterConfig: {
+          Arn: "arn:aws:sqs:us-east-1:888888888888:undelivered",
+        },
+      },
+      { Name: "orders", LogConfig: { Level: "INFO" } },
+      { Name: "orders", EventSourceName: "aws.partner/example.com/orders" },
+    ];
+
+    // Then each is refused, so nothing looks configured that is not.
+    for (const input of inputs) {
+      // oxlint-disable-next-line no-await-in-loop
+      const error = await assertThrowsErrorAsync(async () => {
+        await simAws
+          .eventBridge()
+          .createEventBus(new CreateEventBusCommand(input));
+      });
+
+      assertInstanceOf(error, SimEventBridgeUnsimulatedInputException);
+    }
+  });
+
+  it("refuses a request that names no bus where one is required", async () => {
+    // Given a simulated EventBridge.
+    const simAws = new SimAws();
+
+    // When a bus is created and deleted with no name.
+    const created = await assertThrowsErrorAsync(async () => {
+      await simAws
+        .eventBridge()
+        .createEventBus(new CreateEventBusCommand({ Name: undefined }));
+    });
+    const deleted = await assertThrowsErrorAsync(async () => {
+      await simAws
+        .eventBridge()
+        .deleteEventBus(new DeleteEventBusCommand({ Name: "" }));
+    });
+
+    // Then both are refused, unlike a describe, which defaults to the default
+    // bus.
+    assertInstanceOf(created, SimEventBridgeValidationException);
+    assertStringIncludes(created.message, "Name is required");
+    assertInstanceOf(deleted, SimEventBridgeValidationException);
+  });
+
+  it("refuses a description longer than real EventBridge takes", async () => {
+    // Given a simulated EventBridge.
+    const simAws = new SimAws();
+
+    // When a bus is created with a description over 512 characters.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.eventBridge().createEventBus(
+        new CreateEventBusCommand({
+          Name: "orders",
+          Description: "x".repeat(513),
+        }),
+      );
+    });
+
+    // Then it is refused rather than stored and truncated later.
+    assertInstanceOf(error, SimEventBridgeValidationException);
+    assertStringIncludes(error.message, "512");
+  });
+
+  it("refuses a listing limit outside the range real EventBridge takes", async () => {
+    // Given a simulated EventBridge.
+    const simAws = new SimAws();
+
+    // When a listing asks for more than a page holds.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws
+        .eventBridge()
+        .listEventBuses(new ListEventBusesCommand({ Limit: 101 }));
+    });
+
+    // Then it is refused rather than answered with everything.
+    assertInstanceOf(error, SimEventBridgeValidationException);
+  });
+
+  it("refuses a continuation token it did not issue", async () => {
+    // Given a simulated EventBridge with one bus to list.
+    const simAws = new SimAws();
+
+    // When a listing carries a token from nowhere.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws
+        .eventBridge()
+        .listEventBuses(new ListEventBusesCommand({ NextToken: "3" }));
+    });
+
+    // Then it is refused rather than answered from an arbitrary offset.
+    assertInstanceOf(error, SimEventBridgeValidationException);
+  });
+});

--- a/src/service/eventbridge/command/bus/sim-event-bridge-create-event-bus.ts
+++ b/src/service/eventbridge/command/bus/sim-event-bridge-create-event-bus.ts
@@ -1,0 +1,93 @@
+import type { BackgroundScheduler } from "../../../../util/background/background.js";
+import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
+import { SimEventBus } from "../../bus/sim-event-bus.js";
+import { SimEventBusName } from "../../bus/sim-event-bus-name.js";
+import type { SimEventBusStore } from "../../bus/sim-event-bus-store.js";
+import { SimEventBridgeResourceAlreadyExistsException } from "../../error/sim-event-bridge.error.js";
+import type { SimEventBridgeRequestOptions } from "../sim-event-bridge-request-options.js";
+import type { SimEventBridgeBusAccess } from "./sim-event-bridge-bus-access.js";
+import { refuseUnsimulatedBusInput } from "./sim-event-bridge-unsimulated-bus-input.js";
+import type {
+  SimCreateEventBusCommand,
+  SimCreateEventBusCommandOutput,
+} from "./bus.command.js";
+
+interface SimEventBridgeCreateEventBusProperties {
+  readonly buses: SimEventBusStore;
+  readonly access: SimEventBridgeBusAccess;
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+  readonly clock: BackgroundScheduler;
+}
+
+/**
+ * The CreateEventBus command.
+ *
+ * Unlike SNS CreateTopic this is not idempotent: a name already taken is
+ * refused rather than answered with the existing bus. `default` is among those
+ * names, since that bus is always there.
+ */
+export class SimEventBridgeCreateEventBus {
+  private readonly buses: SimEventBusStore;
+  private readonly access: SimEventBridgeBusAccess;
+  private readonly accountRegionScope: SimAwsAccountRegionScope;
+  private readonly clock: BackgroundScheduler;
+
+  constructor(properties: SimEventBridgeCreateEventBusProperties) {
+    this.buses = properties.buses;
+    this.access = properties.access;
+    this.accountRegionScope = properties.accountRegionScope;
+    this.clock = properties.clock;
+  }
+
+  /**
+   * Create a custom event bus.
+   *
+   * The inputs are read before the name is looked for, so a request naming one
+   * this simulation will not take is refused whether or not the name is free.
+   */
+  handle(
+    command: SimCreateEventBusCommand,
+    options?: SimEventBridgeRequestOptions,
+  ): SimCreateEventBusCommandOutput {
+    const input = command.input;
+
+    refuseUnsimulatedBusInput(input);
+
+    const name = SimEventBusName.required(input.Name, "Name");
+
+    this.access.authorizeName("events:CreateEventBus", name, options);
+
+    if (this.buses.find(name.value) !== undefined) {
+      throw new SimEventBridgeResourceAlreadyExistsException(
+        `Event bus ${name.value} already exists.`,
+      );
+    }
+
+    const bus = this.created(name, input.Description);
+
+    return {
+      $metadata: {},
+      EventBusArn: bus.arn.value,
+      Description: bus.description,
+    };
+  }
+
+  /**
+   * Create the bus itself, once the name is known to be free.
+   */
+  private created(
+    name: SimEventBusName,
+    description: string | undefined,
+  ): SimEventBus {
+    const bus = new SimEventBus({
+      name,
+      accountRegionScope: this.accountRegionScope,
+      createdAt: this.clock.now(),
+      description,
+    });
+
+    this.buses.add(bus);
+
+    return bus;
+  }
+}

--- a/src/service/eventbridge/command/bus/sim-event-bridge-delete-event-bus.ts
+++ b/src/service/eventbridge/command/bus/sim-event-bridge-delete-event-bus.ts
@@ -1,0 +1,61 @@
+import { SimEventBusName } from "../../bus/sim-event-bus-name.js";
+import type { SimEventBusStore } from "../../bus/sim-event-bus-store.js";
+import { SimEventBridgeValidationException } from "../../error/sim-event-bridge.error.js";
+import type { SimEventBridgeRequestOptions } from "../sim-event-bridge-request-options.js";
+import type { SimEventBridgeBusAccess } from "./sim-event-bridge-bus-access.js";
+import type {
+  SimDeleteEventBusCommand,
+  SimDeleteEventBusCommandOutput,
+} from "./bus.command.js";
+
+interface SimEventBridgeDeleteEventBusProperties {
+  readonly buses: SimEventBusStore;
+  readonly access: SimEventBridgeBusAccess;
+}
+
+/**
+ * The DeleteEventBus command.
+ *
+ * Two rules of its own. The default bus cannot go, as it cannot on real AWS.
+ * And deleting a bus that is not there succeeds, because EventBridge documents
+ * no not-found error for this operation, so a teardown that runs twice is
+ * safe.
+ *
+ * The name is taken as a name rather than as an ARN, unlike DescribeEventBus:
+ * the API's own pattern for this operation admits no ARN form.
+ */
+export class SimEventBridgeDeleteEventBus {
+  private readonly buses: SimEventBusStore;
+  private readonly access: SimEventBridgeBusAccess;
+
+  constructor(properties: SimEventBridgeDeleteEventBusProperties) {
+    this.buses = properties.buses;
+    this.access = properties.access;
+  }
+
+  /**
+   * Delete a custom event bus.
+   *
+   * The name frees at once, so it can be reused straight away.
+   */
+  handle(
+    command: SimDeleteEventBusCommand,
+    options?: SimEventBridgeRequestOptions,
+  ): SimDeleteEventBusCommandOutput {
+    const name = SimEventBusName.required(command.input.Name, "Name");
+
+    if (name.isDefault) {
+      throw new SimEventBridgeValidationException(
+        "Cannot delete event bus default.",
+      );
+    }
+
+    const bus = this.access.find("events:DeleteEventBus", name, options);
+
+    if (bus !== undefined) {
+      this.buses.remove(bus);
+    }
+
+    return { $metadata: {} };
+  }
+}

--- a/src/service/eventbridge/command/bus/sim-event-bridge-delete-event-bus.ts
+++ b/src/service/eventbridge/command/bus/sim-event-bridge-delete-event-bus.ts
@@ -37,20 +37,24 @@ export class SimEventBridgeDeleteEventBus {
    * Delete a custom event bus.
    *
    * The name frees at once, so it can be reused straight away.
+   *
+   * The caller is authorized before the default bus is refused, because IAM
+   * decides a request on real AWS before the operation's own rules do. A
+   * caller with no permission is told that rather than told which bus it may
+   * not delete.
    */
   handle(
     command: SimDeleteEventBusCommand,
     options?: SimEventBridgeRequestOptions,
   ): SimDeleteEventBusCommandOutput {
     const name = SimEventBusName.required(command.input.Name, "Name");
+    const bus = this.access.find("events:DeleteEventBus", name, options);
 
     if (name.isDefault) {
       throw new SimEventBridgeValidationException(
         "Cannot delete event bus default.",
       );
     }
-
-    const bus = this.access.find("events:DeleteEventBus", name, options);
 
     if (bus !== undefined) {
       this.buses.remove(bus);

--- a/src/service/eventbridge/command/bus/sim-event-bridge-listed-bus.ts
+++ b/src/service/eventbridge/command/bus/sim-event-bridge-listed-bus.ts
@@ -1,0 +1,43 @@
+import type { SimEventBus } from "../../bus/sim-event-bus.js";
+import type { SimListedEventBus } from "./bus.command.js";
+
+/**
+ * One bus as a describe or a listing reports it.
+ *
+ * Both report the same fields, so both build them here rather than each
+ * writing the mapping out and drifting from the other.
+ *
+ * `LastModifiedTime` is the creation time, because nothing modifies a bus:
+ * there is no UpdateEventBus in this simulation, and a bus's description is
+ * fixed when it is created.
+ */
+export function listedEventBus(bus: SimEventBus): SimListedEventBus {
+  return {
+    Name: bus.name.value,
+    Arn: bus.arn.value,
+    Description: bus.description,
+    CreationTime: bus.creationTime,
+    LastModifiedTime: bus.creationTime,
+  };
+}
+
+/**
+ * The buses a listing reports, narrowed to a name prefix when one is asked
+ * for.
+ *
+ * Real EventBridge matches the prefix against the name rather than the ARN, so
+ * the default bus drops out of any listing whose prefix it does not start
+ * with.
+ */
+export function listedEventBuses(
+  buses: readonly SimEventBus[],
+  namePrefix: string | undefined,
+): readonly SimListedEventBus[] {
+  if (namePrefix === undefined) {
+    return buses.map(listedEventBus);
+  }
+
+  return buses
+    .filter((bus) => bus.name.value.startsWith(namePrefix))
+    .map(listedEventBus);
+}

--- a/src/service/eventbridge/command/bus/sim-event-bridge-request-bus-name.ts
+++ b/src/service/eventbridge/command/bus/sim-event-bridge-request-bus-name.ts
@@ -1,0 +1,67 @@
+import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
+import { parseEventBusArn } from "../../bus/sim-event-bus-arn.js";
+import { SimEventBusName } from "../../bus/sim-event-bus-name.js";
+import {
+  SimEventBridgeUnsimulatedInputException,
+  SimEventBridgeValidationException,
+} from "../../error/sim-event-bridge.error.js";
+
+const arnPrefix = "arn:";
+
+/**
+ * Read the bus name out of the name or ARN a request carries.
+ *
+ * DescribeEventBus and a PutEvents entry both take either form, so both arrive
+ * here. A value that is not an ARN is read as a name and validated as one.
+ *
+ * An ARN naming another Account or Region is refused rather than having its
+ * name read out and looked up locally. Real EventBridge does deliver an event
+ * across Accounts that way, but nothing here can reach another simulation's
+ * bus, and quietly treating a foreign ARN as local would let a test pass while
+ * the real call crossed a boundary it has no permission for.
+ */
+export function simEventBridgeRequestBusName(
+  value: string | undefined,
+  scope: SimAwsAccountRegionScope,
+): SimEventBusName {
+  if (value === undefined || value === "") {
+    return SimEventBusName.default();
+  }
+
+  if (!value.startsWith(arnPrefix)) {
+    return SimEventBusName.of(value);
+  }
+
+  return busNameFromArn(value, scope);
+}
+
+/**
+ * Read the bus name out of an ARN, refusing one this scope cannot reach.
+ */
+function busNameFromArn(
+  value: string,
+  scope: SimAwsAccountRegionScope,
+): SimEventBusName {
+  const parts = parseEventBusArn(value);
+
+  if (parts === undefined) {
+    throw new SimEventBridgeValidationException(
+      `Invalid parameter: ${value} is not an event bus ARN, which is ` +
+        `arn:aws:events:<region>:<account-id>:event-bus/<name>`,
+    );
+  }
+
+  if (
+    parts.accountId !== scope.accountId ||
+    parts.regionName !== scope.regionName
+  ) {
+    throw new SimEventBridgeUnsimulatedInputException(
+      `${value} names Account ${parts.accountId} in ${parts.regionName}, and ` +
+        `this simulated EventBridge is Account ${scope.accountId} in ` +
+        `${scope.regionName}. Sending events to another Account's event bus ` +
+        `is not simulated.`,
+    );
+  }
+
+  return SimEventBusName.of(parts.name);
+}

--- a/src/service/eventbridge/command/bus/sim-event-bridge-unsimulated-bus-input.ts
+++ b/src/service/eventbridge/command/bus/sim-event-bridge-unsimulated-bus-input.ts
@@ -1,0 +1,86 @@
+import {
+  SimEventBridgeUnsimulatedInputException,
+  SimEventBridgeValidationException,
+} from "../../error/sim-event-bridge.error.js";
+import type { SimCreateEventBusCommandInput } from "./bus.command.js";
+
+/**
+ * The maximum length real EventBridge takes for an event bus description.
+ */
+const maximumDescriptionLength = 512;
+
+/**
+ * One property this simulation does not model, read straight off the input
+ * rather than by key, and what refusing it should say.
+ */
+type SimEventBridgeBusRefusal = readonly [
+  (input: SimCreateEventBusCommandInput) => unknown,
+  string,
+];
+
+/**
+ * What a CreateEventBus input carrying an unmodelled property is refused with.
+ */
+const refusals: readonly SimEventBridgeBusRefusal[] = [
+  [
+    (input): unknown => input.EventSourceName,
+    "Partner event buses are not simulated, so CreateEventBus refuses an " +
+      "EventSourceName rather than creating a bus no partner can reach",
+  ],
+  [
+    (input): unknown => input.KmsKeyIdentifier,
+    "Event bus encryption with a customer managed key is not simulated, so " +
+      "CreateEventBus refuses a KmsKeyIdentifier rather than creating a bus " +
+      "that encrypts nothing",
+  ],
+  [
+    (input): unknown => input.DeadLetterConfig,
+    "Event bus dead letter queues are not simulated, so CreateEventBus " +
+      "refuses a DeadLetterConfig rather than creating a bus that drops " +
+      "undelivered events silently",
+  ],
+  [
+    (input): unknown => input.LogConfig,
+    "Event bus logging is not simulated, so CreateEventBus refuses a " +
+      "LogConfig rather than creating a bus that logs nothing",
+  ],
+  [
+    (input): unknown => input.Tags,
+    "Event bus tags are not simulated, so CreateEventBus refuses them rather " +
+      "than dropping them",
+  ],
+];
+
+/**
+ * Refuse the event bus request inputs this simulation does not model.
+ *
+ * Each is refused rather than ignored. A dropped tag would leave a bus looking
+ * tagged to the request that sent it and untagged to everything else, and a
+ * dead letter queue that received nothing would be one a test believed was
+ * catching undelivered events.
+ */
+export function refuseUnsimulatedBusInput(
+  input: SimCreateEventBusCommandInput,
+): void {
+  for (const [read, message] of refusals) {
+    if (read(input) !== undefined) {
+      throw new SimEventBridgeUnsimulatedInputException(message);
+    }
+  }
+
+  refuseOverlongDescription(input.Description);
+}
+
+/**
+ * Refuse a description real EventBridge would refuse.
+ */
+function refuseOverlongDescription(description: string | undefined): void {
+  if (
+    description !== undefined &&
+    description.length > maximumDescriptionLength
+  ) {
+    throw new SimEventBridgeValidationException(
+      `Invalid parameter: Description Reason: a description is at most ${String(maximumDescriptionLength)} characters, and this one is ${String(description.length)}`,
+    );
+  }
+}

--- a/src/service/eventbridge/command/put-events/put-events.command.ts
+++ b/src/service/eventbridge/command/put-events/put-events.command.ts
@@ -1,0 +1,50 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+
+/**
+ * One event as a PutEvents request carries it.
+ *
+ * Every field is optional in the API model, but `Detail`, `DetailType` and
+ * `Source` are all required for EventBridge to take the entry, which is why an
+ * entry missing one of them comes back as a failure rather than being refused
+ * up front.
+ *
+ * https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_PutEventsRequestEntry.html
+ */
+export interface SimPutEventsRequestEntry {
+  readonly Source?: string | undefined;
+  readonly DetailType?: string | undefined;
+  readonly Detail?: string | undefined;
+  readonly EventBusName?: string | undefined;
+  readonly Resources?: readonly string[] | undefined;
+  readonly Time?: Date | undefined;
+  readonly TraceHeader?: string | undefined;
+}
+
+/**
+ * One entry's result, which carries either an event id or a failure.
+ */
+export interface SimPutEventsResultEntry {
+  readonly EventId?: string | undefined;
+  readonly ErrorCode?: string | undefined;
+  readonly ErrorMessage?: string | undefined;
+}
+
+/**
+ * Minimal structural sim EventBridge PutEvents command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/eventbridge/command/PutEventsCommand/
+ */
+export interface SimPutEventsCommand {
+  readonly input: SimPutEventsCommandInput;
+}
+
+export interface SimPutEventsCommandInput {
+  readonly Entries?: readonly SimPutEventsRequestEntry[] | undefined;
+  readonly EndpointId?: string | undefined;
+}
+
+export interface SimPutEventsCommandOutput {
+  readonly Entries?: readonly SimPutEventsResultEntry[] | undefined;
+  readonly FailedEntryCount?: number | undefined;
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/eventbridge/command/put-events/sim-event-bridge-entry-failure.ts
+++ b/src/service/eventbridge/command/put-events/sim-event-bridge-entry-failure.ts
@@ -1,0 +1,66 @@
+import type { SimPutEventsResultEntry } from "./put-events.command.js";
+
+/**
+ * The error code a malformed `Detail` comes back with.
+ *
+ * This one AWS documents.
+ */
+export const simEventBridgeMalformedDetailCode = "MalformedDetail";
+
+/**
+ * The error code an entry missing a required field comes back with.
+ *
+ * The API reference documents that EventBridge fails such an entry but not
+ * what it calls the failure, so this is taken from the code observed in
+ * practice rather than from the documentation.
+ */
+export const simEventBridgeInvalidArgumentCode = "InvalidArgument";
+
+/**
+ * One entry EventBridge would not take, and why.
+ *
+ * A failure is a value rather than a thrown error because PutEvents keeps
+ * going: the rest of the request is processed, and the failure is reported in
+ * this entry's place in the result.
+ */
+export class SimEventBridgeEntryFailure {
+  private constructor(
+    public readonly code: string,
+    public readonly message: string,
+  ) {}
+
+  /**
+   * An entry whose `Detail` is not a JSON object.
+   */
+  static malformedDetail(): SimEventBridgeEntryFailure {
+    return new this(simEventBridgeMalformedDetailCode, "Detail is malformed.");
+  }
+
+  /**
+   * An entry with none of the field a routable event has to carry.
+   */
+  static missing(field: string): SimEventBridgeEntryFailure {
+    return new this(
+      simEventBridgeInvalidArgumentCode,
+      `Parameter ${field} is not valid. Reason: ${field} is a required argument.`,
+    );
+  }
+
+  /**
+   * An entry whose `DetailType` is longer than EventBridge takes.
+   */
+  static detailTypeTooLong(length: number): SimEventBridgeEntryFailure {
+    return new this(
+      simEventBridgeInvalidArgumentCode,
+      `Parameter DetailType is not valid. Reason: DetailType is at most 128 ` +
+        `characters, and this one is ${String(length)}.`,
+    );
+  }
+
+  /**
+   * This failure as it appears in the PutEvents result.
+   */
+  toResultEntry(): SimPutEventsResultEntry {
+    return { ErrorCode: this.code, ErrorMessage: this.message };
+  }
+}

--- a/src/service/eventbridge/command/put-events/sim-event-bridge-entry-reader.ts
+++ b/src/service/eventbridge/command/put-events/sim-event-bridge-entry-reader.ts
@@ -1,0 +1,140 @@
+import { randomUUID } from "node:crypto";
+
+import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
+import { isRecord } from "../../../../util/type-guard/record.js";
+import { SimEventBridgeEvent } from "../../event/sim-event-bridge-event.js";
+import { SimEventBridgeEntryFailure } from "./sim-event-bridge-entry-failure.js";
+import type { SimPutEventsRequestEntry } from "./put-events.command.js";
+
+/**
+ * The longest `DetailType` real EventBridge takes.
+ */
+const maximumDetailTypeLength = 128;
+
+/**
+ * Whether an entry carries everything a routable event needs.
+ *
+ * A request in which no entry does at all is refused outright, which is why
+ * this is asked of every entry before any of them is read.
+ */
+export function isRoutableEntry(entry: SimPutEventsRequestEntry): boolean {
+  return (
+    entry.Source !== undefined &&
+    entry.DetailType !== undefined &&
+    entry.Detail !== undefined
+  );
+}
+
+/**
+ * Read an entry's `Detail` as the JSON object it has to be.
+ *
+ * Anything that is not an object is malformed, including a JSON array, number
+ * or string, since a rule's event pattern matches fields of an object and has
+ * nothing to match against otherwise.
+ */
+function readDetail(detail: string): Record<string, unknown> | undefined {
+  try {
+    const parsed: unknown = JSON.parse(detail);
+
+    if (!isRecord(parsed)) {
+      return undefined;
+    }
+
+    return parsed;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * One entry, once it is known to carry everything an event needs.
+ */
+interface SimEventBridgeReadEntry {
+  readonly entry: SimPutEventsRequestEntry;
+  readonly source: string;
+  readonly detailType: string;
+  readonly detail: string;
+  readonly at: Date;
+}
+
+interface SimEventBridgeEntryReaderProperties {
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+}
+
+/**
+ * Reads one PutEvents entry into the event EventBridge would build from it.
+ *
+ * `Detail`, `DetailType` and `Source` are all optional in the API model and
+ * all required for an entry to be taken, so this is where that gap is closed.
+ * An entry missing one comes back as a failure rather than a thrown error,
+ * because the rest of the request still goes through.
+ */
+export class SimEventBridgeEntryReader {
+  private readonly accountRegionScope: SimAwsAccountRegionScope;
+
+  constructor(properties: SimEventBridgeEntryReaderProperties) {
+    this.accountRegionScope = properties.accountRegionScope;
+  }
+
+  /**
+   * Read an entry into an event, or into the failure it comes back as.
+   *
+   * The timestamp is the one the entry carries, or the instant of the call
+   * when it carries none, which is what puts a simulation's own clock on every
+   * event that did not name a time.
+   */
+  read(
+    entry: SimPutEventsRequestEntry,
+    at: Date,
+  ): SimEventBridgeEvent | SimEventBridgeEntryFailure {
+    if (entry.Source === undefined) {
+      return SimEventBridgeEntryFailure.missing("Source");
+    }
+
+    if (entry.DetailType === undefined) {
+      return SimEventBridgeEntryFailure.missing("DetailType");
+    }
+
+    if (entry.Detail === undefined) {
+      return SimEventBridgeEntryFailure.missing("Detail");
+    }
+
+    if (entry.DetailType.length > maximumDetailTypeLength) {
+      return SimEventBridgeEntryFailure.detailTypeTooLong(
+        entry.DetailType.length,
+      );
+    }
+
+    return this.eventFrom({
+      entry,
+      source: entry.Source,
+      detailType: entry.DetailType,
+      detail: entry.Detail,
+      at,
+    });
+  }
+
+  /**
+   * Build the event, once the entry is known to carry what one needs.
+   */
+  private eventFrom(
+    read: SimEventBridgeReadEntry,
+  ): SimEventBridgeEvent | SimEventBridgeEntryFailure {
+    const detail = readDetail(read.detail);
+
+    if (detail === undefined) {
+      return SimEventBridgeEntryFailure.malformedDetail();
+    }
+
+    return new SimEventBridgeEvent({
+      id: randomUUID(),
+      detailType: read.detailType,
+      source: read.source,
+      account: this.accountRegionScope.accountId,
+      time: read.entry.Time ?? read.at,
+      region: this.accountRegionScope.regionName,
+      resources: read.entry.Resources ?? [],
+      detail,
+    });
+  }
+}

--- a/src/service/eventbridge/command/put-events/sim-event-bridge-entry-reader.ts
+++ b/src/service/eventbridge/command/put-events/sim-event-bridge-entry-reader.ts
@@ -126,14 +126,18 @@ export class SimEventBridgeEntryReader {
       return SimEventBridgeEntryFailure.malformedDetail();
     }
 
+    // The timestamp and the resource list are copied rather than held onto,
+    // because they belong to the request the caller still has a reference to.
+    // A caller reusing an entry object between calls would otherwise change an
+    // event that has already been put.
     return new SimEventBridgeEvent({
       id: randomUUID(),
       detailType: read.detailType,
       source: read.source,
       account: this.accountRegionScope.accountId,
-      time: read.entry.Time ?? read.at,
+      time: new Date(read.entry.Time?.getTime() ?? read.at.getTime()),
       region: this.accountRegionScope.regionName,
-      resources: read.entry.Resources ?? [],
+      resources: [...(read.entry.Resources ?? [])],
       detail,
     });
   }

--- a/src/service/eventbridge/command/put-events/sim-event-bridge-entry-size.ts
+++ b/src/service/eventbridge/command/put-events/sim-event-bridge-entry-size.ts
@@ -1,0 +1,74 @@
+import type { SimPutEventsRequestEntry } from "./put-events.command.js";
+
+/**
+ * The size real EventBridge counts a `Time` as, whatever the instant is.
+ */
+const timeSizeBytes = 14;
+
+/**
+ * The most one PutEvents request may total.
+ *
+ * The limit is on the request rather than on any one entry, so a single entry
+ * may use the whole of it.
+ */
+export const simEventBridgeMaximumRequestBytes = 1_048_576;
+
+/**
+ * Measure one PutEvents entry the way real EventBridge measures it.
+ *
+ * This is AWS's own documented calculation rather than the size of the JSON on
+ * the wire: a `Time` counts as a flat 14 bytes, and `Source`, `DetailType`,
+ * `Detail` and each entry of `Resources` count as the length of their UTF-8
+ * encoded forms. Nothing else in the entry counts at all, which is why a
+ * `TraceHeader` or an `EventBusName` is free.
+ *
+ * https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-putevents.html#eb-putevent-size
+ */
+export function simEventBridgeEntrySize(
+  entry: SimPutEventsRequestEntry,
+): number {
+  const resources = entry.Resources ?? [];
+
+  return (
+    timeSize(entry.Time) +
+    utf8Length(entry.Source) +
+    utf8Length(entry.DetailType) +
+    utf8Length(entry.Detail) +
+    resources.reduce((total, resource) => total + utf8Length(resource), 0)
+  );
+}
+
+/**
+ * Measure every entry of a request together, which is what the limit applies
+ * to.
+ */
+export function simEventBridgeRequestSize(
+  entries: readonly SimPutEventsRequestEntry[],
+): number {
+  return entries.reduce(
+    (total, entry) => total + simEventBridgeEntrySize(entry),
+    0,
+  );
+}
+
+/**
+ * What a `Time` counts towards the total, which is a flat rate or nothing.
+ */
+function timeSize(time: Date | undefined): number {
+  if (time === undefined) {
+    return 0;
+  }
+
+  return timeSizeBytes;
+}
+
+/**
+ * The number of bytes a string takes in UTF-8, or none for an absent one.
+ */
+function utf8Length(value: string | undefined): number {
+  if (value === undefined) {
+    return 0;
+  }
+
+  return Buffer.byteLength(value, "utf8");
+}

--- a/src/service/eventbridge/command/put-events/sim-event-bridge-put-events-failures.iso.test.ts
+++ b/src/service/eventbridge/command/put-events/sim-event-bridge-put-events-failures.iso.test.ts
@@ -1,0 +1,267 @@
+import { PutEventsCommand } from "@aws-sdk/client-eventbridge";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import {
+  SimEventBridgeUnsimulatedInputException,
+  SimEventBridgeValidationException,
+} from "../../error/sim-event-bridge.error.js";
+
+/**
+ * An entry with everything a routable event needs, so a request under test
+ * carries at least one and is not refused outright.
+ */
+function routableEntry(): Record<string, string> {
+  return {
+    Source: "orders.service",
+    DetailType: "OrderPlaced",
+    Detail: "{}",
+  };
+}
+
+describe("EventBridge PutEvents failures", () => {
+  it("fails the entry whose Detail is not a JSON object, and keeps the rest", async () => {
+    // Given a simulated EventBridge.
+    const simAws = new SimAws();
+
+    // When one entry of three carries a malformed detail.
+    const output = await simAws.eventBridge().putEvents(
+      new PutEventsCommand({
+        Entries: [
+          routableEntry(),
+          { ...routableEntry(), Detail: "not json at all" },
+          routableEntry(),
+        ],
+      }),
+    );
+
+    // Then only that entry failed, in its own place in the result.
+    const results = output.Entries;
+
+    assertNonNullable(results);
+
+    const failed = results[1];
+
+    assertNonNullable(failed);
+    assertIdentical(output.FailedEntryCount, 1);
+    assertNonNullable(results[0]?.EventId);
+    assertIdentical(failed.ErrorCode, "MalformedDetail");
+    assertIdentical(failed.ErrorMessage, "Detail is malformed.");
+    assertUndefined(failed.EventId);
+    assertNonNullable(results[2]?.EventId);
+
+    // And the bus took the two that were usable.
+    assertArrayLength(simAws.eventBridge().eventsOn("default"), 2);
+  });
+
+  it("fails an entry whose Detail is valid JSON but not an object", async () => {
+    // Given a simulated EventBridge.
+    const simAws = new SimAws();
+
+    // When an entry's detail is a JSON array rather than an object.
+    const output = await simAws.eventBridge().putEvents(
+      new PutEventsCommand({
+        Entries: [routableEntry(), { ...routableEntry(), Detail: "[1, 2, 3]" }],
+      }),
+    );
+
+    // Then it is malformed, since an event pattern has no fields to match on.
+    assertIdentical(output.Entries?.[1]?.ErrorCode, "MalformedDetail");
+  });
+
+  it("fails an entry missing a field an event needs to be routed", async () => {
+    // Given a simulated EventBridge.
+    const simAws = new SimAws();
+
+    // When entries leave out each required field in turn.
+    const output = await simAws.eventBridge().putEvents(
+      new PutEventsCommand({
+        Entries: [
+          routableEntry(),
+          { DetailType: "OrderPlaced", Detail: "{}" },
+          { Source: "orders.service", Detail: "{}" },
+          { Source: "orders.service", DetailType: "OrderPlaced" },
+        ],
+      }),
+    );
+
+    // Then each fails on its own, naming the field it is missing.
+    assertIdentical(output.FailedEntryCount, 3);
+    assertStringIncludes(output.Entries?.[1]?.ErrorMessage ?? "", "Source");
+    assertStringIncludes(output.Entries?.[2]?.ErrorMessage ?? "", "DetailType");
+    assertStringIncludes(output.Entries?.[3]?.ErrorMessage ?? "", "Detail");
+  });
+
+  it("fails an entry whose DetailType is longer than EventBridge takes", async () => {
+    // Given a simulated EventBridge.
+    const simAws = new SimAws();
+
+    // When an entry's detail type runs past 128 characters.
+    const output = await simAws.eventBridge().putEvents(
+      new PutEventsCommand({
+        Entries: [
+          routableEntry(),
+          { ...routableEntry(), DetailType: "O".repeat(129) },
+        ],
+      }),
+    );
+
+    // Then that entry fails, naming the limit and the length it came to.
+    assertIdentical(output.FailedEntryCount, 1);
+    assertStringIncludes(output.Entries?.[1]?.ErrorMessage ?? "", "128");
+    assertStringIncludes(output.Entries?.[1]?.ErrorMessage ?? "", "129");
+  });
+
+  it("refuses a request carrying no Entries at all", async () => {
+    // Given a simulated EventBridge.
+    const simAws = new SimAws();
+
+    // When a request leaves the entries out rather than sending an empty list.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws
+        .eventBridge()
+        .putEvents(new PutEventsCommand({ Entries: undefined }));
+    });
+
+    // Then it is refused the same way an empty list is.
+    assertInstanceOf(error, SimEventBridgeValidationException);
+  });
+
+  it("refuses an entry naming something that is not an event bus ARN", async () => {
+    // Given a simulated EventBridge.
+    const simAws = new SimAws();
+
+    // When an entry names an ARN of another kind.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.eventBridge().putEvents(
+        new PutEventsCommand({
+          Entries: [
+            {
+              ...routableEntry(),
+              EventBusName: "arn:aws:sns:us-east-1:888888888888:orders",
+            },
+          ],
+        }),
+      );
+    });
+
+    // Then it is refused rather than read as a bus name.
+    assertInstanceOf(error, SimEventBridgeValidationException);
+    assertStringIncludes(error.message, "is not an event bus ARN");
+  });
+
+  it("refuses the whole request when no entry could be routed", async () => {
+    // Given a simulated EventBridge.
+    const simAws = new SimAws();
+
+    // When every entry is missing something.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.eventBridge().putEvents(
+        new PutEventsCommand({
+          Entries: [{ Source: "orders.service" }, { Detail: "{}" }],
+        }),
+      );
+    });
+
+    // Then the request fails outright rather than entry by entry, which is
+    // the rule real EventBridge documents.
+    assertInstanceOf(error, SimEventBridgeValidationException);
+  });
+
+  it("refuses a request carrying no entries or more than ten", async () => {
+    // Given a simulated EventBridge.
+    const simAws = new SimAws();
+
+    // When a request carries nothing.
+    const empty = await assertThrowsErrorAsync(async () => {
+      await simAws
+        .eventBridge()
+        .putEvents(new PutEventsCommand({ Entries: [] }));
+    });
+
+    // And when it carries one entry too many.
+    const tooMany = await assertThrowsErrorAsync(async () => {
+      await simAws.eventBridge().putEvents(
+        new PutEventsCommand({
+          Entries: Array.from({ length: 11 }, routableEntry),
+        }),
+      );
+    });
+
+    // Then both are refused.
+    assertInstanceOf(empty, SimEventBridgeValidationException);
+    assertInstanceOf(tooMany, SimEventBridgeValidationException);
+  });
+
+  it("refuses a request over the one megabyte limit", async () => {
+    // Given a simulated EventBridge.
+    const simAws = new SimAws();
+
+    // When two entries together come to more than a megabyte.
+    const half = JSON.stringify({ padding: "x".repeat(600_000) });
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.eventBridge().putEvents(
+        new PutEventsCommand({
+          Entries: [
+            { ...routableEntry(), Detail: half },
+            { ...routableEntry(), Detail: half },
+          ],
+        }),
+      );
+    });
+
+    // Then the request is refused, since the limit is on the whole of it.
+    assertInstanceOf(error, SimEventBridgeValidationException);
+    assertStringIncludes(error.message, "1048576");
+  });
+
+  it("refuses an entry naming another Account's event bus", async () => {
+    // Given a simulated EventBridge.
+    const simAws = new SimAws();
+
+    // When an entry names a bus ARN in another Account.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.eventBridge().putEvents(
+        new PutEventsCommand({
+          Entries: [
+            {
+              ...routableEntry(),
+              EventBusName:
+                "arn:aws:events:us-east-1:999999999999:event-bus/orders",
+            },
+          ],
+        }),
+      );
+    });
+
+    // Then it is refused rather than quietly put on a local bus of that name.
+    assertInstanceOf(error, SimEventBridgeUnsimulatedInputException);
+    assertStringIncludes(error.message, "another Account's event bus");
+  });
+
+  it("refuses a global endpoint rather than ignoring it", async () => {
+    // Given a simulated EventBridge.
+    const simAws = new SimAws();
+
+    // When a request names a global endpoint.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.eventBridge().putEvents(
+        new PutEventsCommand({
+          Entries: [routableEntry()],
+          EndpointId: "abcde.veo",
+        }),
+      );
+    });
+
+    // Then it is refused, so nothing looks routed that was not.
+    assertInstanceOf(error, SimEventBridgeUnsimulatedInputException);
+  });
+});

--- a/src/service/eventbridge/command/put-events/sim-event-bridge-put-events.iso.test.ts
+++ b/src/service/eventbridge/command/put-events/sim-event-bridge-put-events.iso.test.ts
@@ -1,0 +1,204 @@
+import {
+  CreateEventBusCommand,
+  PutEventsCommand,
+} from "@aws-sdk/client-eventbridge";
+import {
+  assertArrayEquals,
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertObjectEquals,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimFixedClock } from "../../../../util/clock/sim-clock.js";
+
+describe("EventBridge PutEvents", () => {
+  it("takes an event onto the default bus and gives it an id", async () => {
+    // Given a simulated EventBridge.
+    const simAws = new SimAws();
+
+    // When an event is put with no bus named.
+    const output = await simAws.eventBridge().putEvents(
+      new PutEventsCommand({
+        Entries: [
+          {
+            Source: "orders.service",
+            DetailType: "OrderPlaced",
+            Detail: JSON.stringify({ orderId: "order-1", total: 4200 }),
+          },
+        ],
+      }),
+    );
+
+    // Then the entry succeeded, with an id and no failures.
+    assertIdentical(output.FailedEntryCount, 0);
+    assertNonNullable(output.Entries?.[0]?.EventId);
+
+    // And the default bus received it.
+    assertArrayLength(simAws.eventBridge().eventsOn("default"), 1);
+  });
+
+  it("builds the envelope AWS wraps around an entry", async () => {
+    // Given a simulation in a known Account and Region, at a known instant.
+    const simAws = new SimAws({
+      defaultAccountId: "111111111111",
+      defaultRegionName: "eu-west-2",
+      clock: new SimFixedClock(new Date("2026-07-26T09:00:00.000Z")),
+    });
+
+    // When an event naming no time of its own is put.
+    const output = await simAws.eventBridge().putEvents(
+      new PutEventsCommand({
+        Entries: [
+          {
+            Source: "orders.service",
+            DetailType: "OrderPlaced",
+            Detail: JSON.stringify({ orderId: "order-1" }),
+            Resources: ["arn:aws:s3:::orders"],
+          },
+        ],
+      }),
+    );
+
+    // Then the envelope carries the simulation's own clock and scope.
+    const event = simAws.eventBridge().eventsOn("default")[0];
+
+    assertNonNullable(event);
+    assertObjectEquals(event.toEnvelope(), {
+      version: "0",
+      id: output.Entries?.[0]?.EventId,
+      "detail-type": "OrderPlaced",
+      source: "orders.service",
+      account: "111111111111",
+      time: "2026-07-26T09:00:00Z",
+      region: "eu-west-2",
+      resources: ["arn:aws:s3:::orders"],
+      detail: { orderId: "order-1" },
+    });
+  });
+
+  it("keeps the time an entry names for itself", async () => {
+    // Given a simulation at a known instant.
+    const simAws = new SimAws({
+      clock: new SimFixedClock(new Date("2026-07-26T09:00:00.000Z")),
+    });
+
+    // When an entry carries a time of its own.
+    await simAws.eventBridge().putEvents(
+      new PutEventsCommand({
+        Entries: [
+          {
+            Source: "orders.service",
+            DetailType: "OrderPlaced",
+            Detail: "{}",
+            Time: new Date("2026-07-25T08:30:00.000Z"),
+          },
+        ],
+      }),
+    );
+
+    // Then that is the time on the event, not the time of the call.
+    const event = simAws.eventBridge().eventsOn("default")[0];
+
+    assertIdentical(event?.toEnvelope().time, "2026-07-25T08:30:00Z");
+  });
+
+  it("puts each entry on the bus that entry names", async () => {
+    // Given two buses alongside the default one.
+    const simAws = new SimAws();
+    await simAws
+      .eventBridge()
+      .createEventBus(new CreateEventBusCommand({ Name: "orders" }));
+
+    // When one request carries an entry for each.
+    await simAws.eventBridge().putEvents(
+      new PutEventsCommand({
+        Entries: [
+          {
+            EventBusName: "orders",
+            Source: "orders.service",
+            DetailType: "OrderPlaced",
+            Detail: "{}",
+          },
+          {
+            Source: "billing.service",
+            DetailType: "InvoiceRaised",
+            Detail: "{}",
+          },
+        ],
+      }),
+    );
+
+    // Then each bus received only its own.
+    assertArrayEquals(
+      simAws
+        .eventBridge()
+        .eventsOn("orders")
+        .map((event) => event.source),
+      ["orders.service"],
+    );
+    assertArrayEquals(
+      simAws
+        .eventBridge()
+        .eventsOn("default")
+        .map((event) => event.source),
+      ["billing.service"],
+    );
+  });
+
+  it("accepts an event for a bus that does not exist, and drops it", async () => {
+    // Given a simulated EventBridge with no bus of that name.
+    const simAws = new SimAws();
+
+    // When an event is put onto a name that was never created.
+    const output = await simAws.eventBridge().putEvents(
+      new PutEventsCommand({
+        Entries: [
+          {
+            EventBusName: "typo",
+            Source: "orders.service",
+            DetailType: "OrderPlaced",
+            Detail: "{}",
+          },
+        ],
+      }),
+    );
+
+    // Then the entry succeeded, as it does on real AWS, and the event is gone.
+    assertIdentical(output.FailedEntryCount, 0);
+    assertNonNullable(output.Entries?.[0]?.EventId);
+    assertArrayLength(simAws.eventBridge().eventsOn("typo"), 0);
+    assertArrayLength(simAws.eventBridge().eventsOn("default"), 0);
+  });
+
+  it("keeps events out of another Account and Region's buses", async () => {
+    // Given an event put in one Region.
+    const simAws = new SimAws();
+    await simAws
+      .account("111111111111")
+      .region("eu-west-2")
+      .eventBridge()
+      .putEvents(
+        new PutEventsCommand({
+          Entries: [
+            {
+              Source: "orders.service",
+              DetailType: "OrderPlaced",
+              Detail: "{}",
+            },
+          ],
+        }),
+      );
+
+    // When another Region's default bus is looked at.
+    const elsewhere = simAws
+      .account("111111111111")
+      .region("us-east-1")
+      .eventBridge()
+      .eventsOn("default");
+
+    // Then the event did not reach it.
+    assertArrayLength(elsewhere, 0);
+  });
+});

--- a/src/service/eventbridge/command/put-events/sim-event-bridge-put-events.ts
+++ b/src/service/eventbridge/command/put-events/sim-event-bridge-put-events.ts
@@ -1,0 +1,109 @@
+import type { BackgroundScheduler } from "../../../../util/background/background.js";
+import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
+import type { SimEventBusStore } from "../../bus/sim-event-bus-store.js";
+import type { SimEventBridgeEvent } from "../../event/sim-event-bridge-event.js";
+import type { SimEventBridgeRequestOptions } from "../sim-event-bridge-request-options.js";
+import type { SimEventBridgeBusAccess } from "../bus/sim-event-bridge-bus-access.js";
+import { SimEventBridgeEntryFailure } from "./sim-event-bridge-entry-failure.js";
+import { SimEventBridgeEntryReader } from "./sim-event-bridge-entry-reader.js";
+import { putEventsRequestEntries } from "./sim-event-bridge-request-entries.js";
+import type {
+  SimPutEventsCommand,
+  SimPutEventsCommandOutput,
+  SimPutEventsRequestEntry,
+  SimPutEventsResultEntry,
+} from "./put-events.command.js";
+
+interface SimEventBridgePutEventsProperties {
+  readonly buses: SimEventBusStore;
+  readonly access: SimEventBridgeBusAccess;
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+  readonly clock: BackgroundScheduler;
+}
+
+/**
+ * The PutEvents command.
+ *
+ * Entries are independent: one that EventBridge will not take comes back as a
+ * failure in its own place in the result while the rest go through, and each
+ * entry may name a different bus.
+ *
+ * An entry naming a bus that does not exist succeeds. Real EventBridge answers
+ * 200, finds no rule to match the event against, and drops it, without
+ * counting the entry as failed. That is a trap worth knowing about, since a
+ * mistyped bus name looks exactly like a working call, so this simulation
+ * reproduces it rather than being helpfully stricter.
+ */
+export class SimEventBridgePutEvents {
+  private readonly buses: SimEventBusStore;
+  private readonly access: SimEventBridgeBusAccess;
+  private readonly clock: BackgroundScheduler;
+  private readonly reader: SimEventBridgeEntryReader;
+
+  constructor(properties: SimEventBridgePutEventsProperties) {
+    this.buses = properties.buses;
+    this.access = properties.access;
+    this.clock = properties.clock;
+    this.reader = new SimEventBridgeEntryReader({
+      accountRegionScope: properties.accountRegionScope,
+    });
+  }
+
+  /**
+   * Put events onto the buses their entries name.
+   *
+   * Every entry is stamped with the one instant the call was made at, rather
+   * than each reading the clock again, so a request's events share a timestamp
+   * as they do on real AWS.
+   */
+  handle(
+    command: SimPutEventsCommand,
+    options?: SimEventBridgeRequestOptions,
+  ): SimPutEventsCommandOutput {
+    const entries = putEventsRequestEntries(command.input);
+    const at = this.clock.now();
+
+    const results = entries.map((entry) => this.put(entry, at, options));
+
+    return {
+      $metadata: {},
+      Entries: results,
+      FailedEntryCount: results.filter(
+        (result) => result.ErrorCode !== undefined,
+      ).length,
+    };
+  }
+
+  /**
+   * Put one entry onto the bus it names.
+   *
+   * A bus that is not there takes the event nowhere, and the entry still
+   * succeeds.
+   */
+  private put(
+    entry: SimPutEventsRequestEntry,
+    at: Date,
+    options: SimEventBridgeRequestOptions | undefined,
+  ): SimPutEventsResultEntry {
+    const name = this.access.requestedName(entry.EventBusName);
+
+    this.access.authorizeName("events:PutEvents", name, options);
+
+    const read = this.reader.read(entry, at);
+
+    if (read instanceof SimEventBridgeEntryFailure) {
+      return read.toResultEntry();
+    }
+
+    this.deliver(name.value, read);
+
+    return { EventId: read.id };
+  }
+
+  /**
+   * Hand an event to the bus it was put onto, where there is one.
+   */
+  private deliver(busName: string, event: SimEventBridgeEvent): void {
+    this.buses.find(busName)?.receive(event);
+  }
+}

--- a/src/service/eventbridge/command/put-events/sim-event-bridge-put-events.ts
+++ b/src/service/eventbridge/command/put-events/sim-event-bridge-put-events.ts
@@ -14,6 +14,14 @@ import type {
   SimPutEventsResultEntry,
 } from "./put-events.command.js";
 
+/**
+ * One entry, and the name of the bus the caller is allowed to put it on.
+ */
+interface SimEventBridgeAuthorizedEntry {
+  readonly entry: SimPutEventsRequestEntry;
+  readonly busName: string;
+}
+
 interface SimEventBridgePutEventsProperties {
   readonly buses: SimEventBusStore;
   readonly access: SimEventBridgeBusAccess;
@@ -63,7 +71,9 @@ export class SimEventBridgePutEvents {
     const entries = putEventsRequestEntries(command.input);
     const at = this.clock.now();
 
-    const results = entries.map((entry) => this.put(entry, at, options));
+    const results = this.authorized(entries, options).map((authorized) =>
+      this.put(authorized, at),
+    );
 
     return {
       $metadata: {},
@@ -75,27 +85,44 @@ export class SimEventBridgePutEvents {
   }
 
   /**
-   * Put one entry onto the bus it names.
+   * Resolve and authorize the bus every entry names, before any of them is
+   * delivered.
+   *
+   * Authorizing entry by entry as each is delivered would leave a refused
+   * request half done: an earlier entry's event would already be on its bus
+   * when a later entry's refusal threw. Every entry is therefore decided
+   * first, so a request that throws has changed nothing.
+   */
+  private authorized(
+    entries: readonly SimPutEventsRequestEntry[],
+    options: SimEventBridgeRequestOptions | undefined,
+  ): readonly SimEventBridgeAuthorizedEntry[] {
+    return entries.map((entry) => {
+      const busName = this.access.requestedName(entry.EventBusName);
+
+      this.access.authorizeName("events:PutEvents", busName, options);
+
+      return { entry, busName: busName.value };
+    });
+  }
+
+  /**
+   * Put one authorized entry onto the bus it names.
    *
    * A bus that is not there takes the event nowhere, and the entry still
    * succeeds.
    */
   private put(
-    entry: SimPutEventsRequestEntry,
+    authorized: SimEventBridgeAuthorizedEntry,
     at: Date,
-    options: SimEventBridgeRequestOptions | undefined,
   ): SimPutEventsResultEntry {
-    const name = this.access.requestedName(entry.EventBusName);
-
-    this.access.authorizeName("events:PutEvents", name, options);
-
-    const read = this.reader.read(entry, at);
+    const read = this.reader.read(authorized.entry, at);
 
     if (read instanceof SimEventBridgeEntryFailure) {
       return read.toResultEntry();
     }
 
-    this.deliver(name.value, read);
+    this.deliver(authorized.busName, read);
 
     return { EventId: read.id };
   }

--- a/src/service/eventbridge/command/put-events/sim-event-bridge-request-entries.ts
+++ b/src/service/eventbridge/command/put-events/sim-event-bridge-request-entries.ts
@@ -1,0 +1,89 @@
+import {
+  SimEventBridgeUnsimulatedInputException,
+  SimEventBridgeValidationException,
+} from "../../error/sim-event-bridge.error.js";
+import { isRoutableEntry } from "./sim-event-bridge-entry-reader.js";
+import {
+  simEventBridgeMaximumRequestBytes,
+  simEventBridgeRequestSize,
+} from "./sim-event-bridge-entry-size.js";
+import type {
+  SimPutEventsCommandInput,
+  SimPutEventsRequestEntry,
+} from "./put-events.command.js";
+
+/**
+ * The most entries one PutEvents request may carry.
+ */
+const maximumEntries = 10;
+
+/**
+ * Read the entries a PutEvents request carries, refusing a request
+ * EventBridge would not take at all.
+ *
+ * These are the refusals that apply to the request rather than to an entry.
+ * Everything else about an entry is that entry's own failure, reported in its
+ * place in the result while the rest of the request goes through.
+ *
+ * The last of them is EventBridge's own rule: an entry missing `Detail`,
+ * `DetailType` or `Source` fails on its own, but a request in which no entry
+ * carries all three fails outright.
+ */
+export function putEventsRequestEntries(
+  input: SimPutEventsCommandInput,
+): readonly SimPutEventsRequestEntry[] {
+  if (input.EndpointId !== undefined) {
+    throw new SimEventBridgeUnsimulatedInputException(
+      "Global endpoints are not simulated, so PutEvents refuses an " +
+        "EndpointId rather than ignoring it and putting the event on this " +
+        "Region's bus",
+    );
+  }
+
+  const entries = input.Entries ?? [];
+
+  refuseUnusableCount(entries.length);
+  refuseOversizedRequest(entries);
+
+  if (entries.every((entry) => !isRoutableEntry(entry))) {
+    throw new SimEventBridgeValidationException(
+      "Invalid parameter: Entries Reason: no entry carries Detail, " +
+        "DetailType and Source, all of which an event needs to be routed",
+    );
+  }
+
+  return entries;
+}
+
+/**
+ * Refuse a request carrying no entries, or more than a request may.
+ */
+function refuseUnusableCount(count: number): void {
+  if (count === 0 || count > maximumEntries) {
+    throw new SimEventBridgeValidationException(
+      `Invalid parameter: Entries Reason: a PutEvents request carries ` +
+        `between 1 and ${String(maximumEntries)} entries, and this one ` +
+        `carries ${String(count)}`,
+    );
+  }
+}
+
+/**
+ * Refuse a request whose entries come to more than the limit together.
+ *
+ * The limit is on the request rather than on any one entry, so a single entry
+ * may use the whole of it.
+ */
+function refuseOversizedRequest(
+  entries: readonly SimPutEventsRequestEntry[],
+): void {
+  const size = simEventBridgeRequestSize(entries);
+
+  if (size > simEventBridgeMaximumRequestBytes) {
+    throw new SimEventBridgeValidationException(
+      `Total size of the entries in the request is ${String(size)} bytes, ` +
+        `which is over the ${String(simEventBridgeMaximumRequestBytes)} byte ` +
+        `limit.`,
+    );
+  }
+}

--- a/src/service/eventbridge/command/sim-event-bridge-command.types.ts
+++ b/src/service/eventbridge/command/sim-event-bridge-command.types.ts
@@ -1,0 +1,25 @@
+export type {
+  SimCreateEventBusCommand,
+  SimCreateEventBusCommandInput,
+  SimCreateEventBusCommandOutput,
+  SimDeleteEventBusCommand,
+  SimDeleteEventBusCommandInput,
+  SimDeleteEventBusCommandOutput,
+  SimDescribeEventBusCommand,
+  SimDescribeEventBusCommandInput,
+  SimDescribeEventBusCommandOutput,
+  SimEventBridgeDeadLetterConfig,
+  SimEventBridgeLogConfig,
+  SimEventBridgeTag,
+  SimListedEventBus,
+  SimListEventBusesCommand,
+  SimListEventBusesCommandInput,
+  SimListEventBusesCommandOutput,
+} from "./bus/bus.command.js";
+export type {
+  SimPutEventsCommand,
+  SimPutEventsCommandInput,
+  SimPutEventsCommandOutput,
+  SimPutEventsRequestEntry,
+  SimPutEventsResultEntry,
+} from "./put-events/put-events.command.js";

--- a/src/service/eventbridge/command/sim-event-bridge-commands.ts
+++ b/src/service/eventbridge/command/sim-event-bridge-commands.ts
@@ -1,0 +1,56 @@
+import type { BackgroundScheduler } from "../../../util/background/background.js";
+import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+import type { SimIamInterServiceAuthZ } from "../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import type { SimEventBusStore } from "../bus/sim-event-bus-store.js";
+import { SimEventBridgeAuthorizer } from "./authorize/sim-event-bridge-authorizer.js";
+import { SimEventBridgeBusAccess } from "./bus/sim-event-bridge-bus-access.js";
+import { SimEventBridgeBusCommands } from "./bus/sim-event-bridge-bus-commands.js";
+import { SimEventBridgeCreateEventBus } from "./bus/sim-event-bridge-create-event-bus.js";
+import { SimEventBridgeDeleteEventBus } from "./bus/sim-event-bridge-delete-event-bus.js";
+import { SimEventBridgePutEvents } from "./put-events/sim-event-bridge-put-events.js";
+
+interface SimEventBridgeCommandsProperties {
+  readonly buses: SimEventBusStore;
+  readonly iam: SimIamInterServiceAuthZ;
+  readonly background: BackgroundScheduler;
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+}
+
+/**
+ * Every command handler one simulated EventBridge scope delegates to.
+ *
+ * The wiring lives here rather than in the facade so that `SimEventBridge`
+ * stays what it is meant to be: state and delegation. Which handler shares
+ * which collaborator is a fact about the handlers, not about the service
+ * object in front of them.
+ */
+export class SimEventBridgeCommands {
+  public readonly busCreation: SimEventBridgeCreateEventBus;
+  public readonly busDeletion: SimEventBridgeDeleteEventBus;
+  public readonly buses: SimEventBridgeBusCommands;
+  public readonly putEvents: SimEventBridgePutEvents;
+
+  constructor(properties: SimEventBridgeCommandsProperties) {
+    const { buses, accountRegionScope, background } = properties;
+    const access = new SimEventBridgeBusAccess({
+      buses,
+      authorizer: new SimEventBridgeAuthorizer({ iam: properties.iam }),
+      accountRegionScope,
+    });
+
+    this.busCreation = new SimEventBridgeCreateEventBus({
+      buses,
+      access,
+      accountRegionScope,
+      clock: background,
+    });
+    this.busDeletion = new SimEventBridgeDeleteEventBus({ buses, access });
+    this.buses = new SimEventBridgeBusCommands({ buses, access });
+    this.putEvents = new SimEventBridgePutEvents({
+      buses,
+      access,
+      accountRegionScope,
+      clock: background,
+    });
+  }
+}

--- a/src/service/eventbridge/command/sim-event-bridge-page.ts
+++ b/src/service/eventbridge/command/sim-event-bridge-page.ts
@@ -1,0 +1,97 @@
+import { SimEventBridgeValidationException } from "../error/sim-event-bridge.error.js";
+
+/**
+ * How many items a listing carries when the request asks for no limit.
+ *
+ * Real EventBridge lets a request cap a listing at 100, and this is the cap it
+ * applies when the request names none.
+ */
+const defaultItemsPerPage = 100;
+
+const maximumItemsPerPage = 100;
+
+/**
+ * One page of a listing, and the token that reaches the next one.
+ */
+export class SimEventBridgePage<Item> {
+  public readonly items: readonly Item[];
+  public readonly nextToken: string | undefined;
+
+  constructor(
+    listed: readonly Item[],
+    limit: number | undefined,
+    nextToken: string | undefined,
+  ) {
+    const startIndex = SimEventBridgePage.startIndex(nextToken, listed.length);
+    const nextIndex = startIndex + SimEventBridgePage.pageSize(limit);
+
+    this.items = listed.slice(startIndex, nextIndex);
+    this.nextToken = SimEventBridgePage.tokenFor(nextIndex, listed.length);
+  }
+
+  /**
+   * Read the page size a request asked for, refusing one outside the range
+   * real EventBridge takes.
+   */
+  private static pageSize(limit: number | undefined): number {
+    if (limit === undefined) {
+      return defaultItemsPerPage;
+    }
+
+    if (
+      !Number.isSafeInteger(limit) ||
+      limit < 1 ||
+      limit > maximumItemsPerPage
+    ) {
+      throw new SimEventBridgeValidationException(
+        `Invalid parameter: Limit Reason: ${String(limit)} is outside the ` +
+          `range 1 to ${String(maximumItemsPerPage)}`,
+      );
+    }
+
+    return limit;
+  }
+
+  /**
+   * Read a continuation token as its offset into the listed items.
+   *
+   * A token is refused unless it is one of these listings could have issued,
+   * which is an offset landing inside the items still to come. Anything else
+   * is refused rather than answered with a listing starting somewhere real
+   * EventBridge would never start one.
+   */
+  private static startIndex(
+    nextToken: string | undefined,
+    listedCount: number,
+  ): number {
+    if (nextToken === undefined) {
+      return 0;
+    }
+
+    const startIndex = Number(nextToken);
+
+    if (
+      !Number.isSafeInteger(startIndex) ||
+      startIndex <= 0 ||
+      startIndex >= listedCount ||
+      String(startIndex) !== nextToken
+    ) {
+      throw new SimEventBridgeValidationException(
+        "Invalid parameter: NextToken is not a token this simulation issued",
+      );
+    }
+
+    return startIndex;
+  }
+
+  private static tokenFor(
+    nextIndex: number,
+    listedCount: number,
+  ): string | undefined {
+    if (nextIndex >= listedCount) {
+      return undefined;
+    }
+
+    return String(nextIndex);
+  }
+}

--- a/src/service/eventbridge/command/sim-event-bridge-request-options.ts
+++ b/src/service/eventbridge/command/sim-event-bridge-request-options.ts
@@ -1,0 +1,12 @@
+import type { SimAwsCaller } from "../../aws/caller/sim-aws-caller.js";
+
+/**
+ * What an EventBridge request carries besides its command input.
+ */
+export interface SimEventBridgeRequestOptions {
+  /**
+   * Who is making the request. An omitted caller is the Account root, as it is
+   * everywhere else in the simulation.
+   */
+  readonly caller?: SimAwsCaller;
+}

--- a/src/service/eventbridge/error/sim-event-bridge.error.ts
+++ b/src/service/eventbridge/error/sim-event-bridge.error.ts
@@ -1,0 +1,94 @@
+/**
+ * Minimal metadata shape for simulated EventBridge errors.
+ */
+export interface SimEventBridgeErrorMetadata {
+  readonly httpStatusCode?: number;
+}
+
+/**
+ * Base class for simulated EventBridge errors.
+ */
+export class SimEventBridgeError extends Error {
+  constructor(
+    message: string,
+    public readonly $metadata: SimEventBridgeErrorMetadata = {},
+  ) {
+    super(message);
+  }
+}
+
+/**
+ * Simulated EventBridge AccessDeniedException.
+ *
+ * EventBridge has no error of its own for an IAM denial, unlike SNS, so a
+ * refused request gets the standard AWS one.
+ */
+export class SimEventBridgeAccessDeniedException extends SimEventBridgeError {
+  public override readonly name = "AccessDeniedException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 403 });
+  }
+}
+
+/**
+ * Simulated EventBridge ResourceNotFoundException.
+ *
+ * This is what naming a bus that is not there produces, whether it never
+ * existed, has been deleted, or belongs to another Account or Region. Note
+ * that PutEvents is the exception: it accepts an event for a bus that does not
+ * exist rather than refusing it.
+ *
+ * Real EventBridge answers it with a 400 rather than the 404 the name
+ * suggests.
+ */
+export class SimEventBridgeResourceNotFoundException extends SimEventBridgeError {
+  public override readonly name = "ResourceNotFoundException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
+ * Simulated EventBridge ResourceAlreadyExistsException.
+ */
+export class SimEventBridgeResourceAlreadyExistsException extends SimEventBridgeError {
+  public override readonly name = "ResourceAlreadyExistsException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
+ * Simulated EventBridge ValidationException.
+ *
+ * Real EventBridge reports request input it will not take this way, such as a
+ * bus name outside the allowed characters or an attempt to delete the default
+ * bus.
+ */
+export class SimEventBridgeValidationException extends SimEventBridgeError {
+  public override readonly name = "ValidationException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
+ * Simulated EventBridge error for a request input this simulation does not
+ * model.
+ *
+ * This is not an error real EventBridge has, which is why it carries the name
+ * of the one real EventBridge answers an unusable parameter with. The input is
+ * refused rather than ignored, because an ignored input looks applied to the
+ * request that sent it and unapplied to everything else.
+ */
+export class SimEventBridgeUnsimulatedInputException extends SimEventBridgeError {
+  public override readonly name = "ValidationException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}

--- a/src/service/eventbridge/event/sim-event-bridge-event.ts
+++ b/src/service/eventbridge/event/sim-event-bridge-event.ts
@@ -1,0 +1,96 @@
+/**
+ * The envelope version every EventBridge event carries.
+ *
+ * Real EventBridge documents this as "Currently 0 (zero) for all events", and
+ * says it is an envelope field rather than a schema version for the detail.
+ */
+export const simEventBridgeEnvelopeVersion = "0";
+
+/**
+ * One event as EventBridge presents it to a rule and to a target.
+ *
+ * The shape is the envelope AWS wraps around whatever was put: the fields a
+ * rule's event pattern matches against, and the JSON a target receives. The
+ * key is `detail-type` rather than `detailType`, which is why this is a
+ * separate shape from the PutEvents entry that produced it.
+ */
+export interface SimEventBridgeEnvelope {
+  readonly version: string;
+  readonly id: string;
+  readonly "detail-type": string;
+  readonly source: string;
+  readonly account: string;
+  readonly time: string;
+  readonly region: string;
+  readonly resources: readonly string[];
+  readonly detail: Record<string, unknown>;
+}
+
+interface SimEventBridgeEventProperties {
+  readonly id: string;
+  readonly detailType: string;
+  readonly source: string;
+  readonly account: string;
+  readonly time: Date;
+  readonly region: string;
+  readonly resources: readonly string[];
+  readonly detail: Record<string, unknown>;
+}
+
+/**
+ * One event a simulated event bus received.
+ *
+ * An event is immutable once EventBridge has built it. What a rule matches and
+ * what a target receives are both this, so building it in one place is what
+ * keeps the two from drifting apart.
+ */
+export class SimEventBridgeEvent {
+  public readonly id: string;
+  public readonly detailType: string;
+  public readonly source: string;
+  public readonly account: string;
+  public readonly time: Date;
+  public readonly region: string;
+  public readonly resources: readonly string[];
+  public readonly detail: Record<string, unknown>;
+
+  constructor(properties: SimEventBridgeEventProperties) {
+    this.id = properties.id;
+    this.detailType = properties.detailType;
+    this.source = properties.source;
+    this.account = properties.account;
+    this.time = properties.time;
+    this.region = properties.region;
+    this.resources = properties.resources;
+    this.detail = properties.detail;
+  }
+
+  /**
+   * This event as the JSON a rule matches and a target receives.
+   *
+   * The timestamp is to the second, with no milliseconds, which is how real
+   * EventBridge writes it. A target asserting on the time gets the same string
+   * it would get from AWS rather than one with three more digits in it.
+   */
+  toEnvelope(): SimEventBridgeEnvelope {
+    return {
+      version: simEventBridgeEnvelopeVersion,
+      id: this.id,
+      "detail-type": this.detailType,
+      source: this.source,
+      account: this.account,
+      time: simEventBridgeEventTime(this.time),
+      region: this.region,
+      resources: this.resources,
+      detail: this.detail,
+    };
+  }
+}
+
+/**
+ * Write an instant the way an EventBridge event carries it: RFC3339, to the
+ * second.
+ */
+export function simEventBridgeEventTime(instant: Date): string {
+  return `${instant.toISOString().slice(0, "yyyy-mm-ddThh:mm:ss".length)}Z`;
+}

--- a/src/service/eventbridge/index.ts
+++ b/src/service/eventbridge/index.ts
@@ -1,0 +1,36 @@
+export { SimEventBridge } from "./sim-event-bridge.js";
+export type { SimEventBridgeRequestOptions } from "./command/sim-event-bridge-request-options.js";
+export { SimEventBus } from "./bus/sim-event-bus.js";
+export {
+  eventBusArnPrefix,
+  parseEventBusArn,
+  SimEventBusArn,
+  type SimEventBusLocation,
+} from "./bus/sim-event-bus-arn.js";
+export {
+  defaultEventBusName,
+  SimEventBusName,
+} from "./bus/sim-event-bus-name.js";
+export {
+  SimEventBridgeEvent,
+  type SimEventBridgeEnvelope,
+  simEventBridgeEnvelopeVersion,
+  simEventBridgeEventTime,
+} from "./event/sim-event-bridge-event.js";
+export {
+  SimEventBridgeEntryFailure,
+  simEventBridgeInvalidArgumentCode,
+  simEventBridgeMalformedDetailCode,
+} from "./command/put-events/sim-event-bridge-entry-failure.js";
+export {
+  simEventBridgeEntrySize,
+  simEventBridgeMaximumRequestBytes,
+} from "./command/put-events/sim-event-bridge-entry-size.js";
+export {
+  SimEventBridgeAccessDeniedException,
+  SimEventBridgeError,
+  SimEventBridgeResourceAlreadyExistsException,
+  SimEventBridgeResourceNotFoundException,
+  SimEventBridgeUnsimulatedInputException,
+  SimEventBridgeValidationException,
+} from "./error/sim-event-bridge.error.js";

--- a/src/service/eventbridge/sdk/sim-event-bridge-sdk-command-router.iso.test.ts
+++ b/src/service/eventbridge/sdk/sim-event-bridge-sdk-command-router.iso.test.ts
@@ -1,0 +1,34 @@
+import { assertArrayEquals, assertUndefined } from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimEventBridge } from "../sim-event-bridge.js";
+
+describe("EventBridge SDK Command router", () => {
+  it("names the Commands simulated EventBridge can handle", () => {
+    // Given a simulated EventBridge.
+    const simEventBridge = new SimEventBridge();
+
+    // When its router is asked what it supports.
+    const supported = simEventBridge.sdkCommandRouter().supportedCommandNames();
+
+    // Then it names the bus commands and PutEvents.
+    assertArrayEquals(supported, [
+      "CreateEventBusCommand",
+      "DeleteEventBusCommand",
+      "DescribeEventBusCommand",
+      "ListEventBusesCommand",
+      "PutEventsCommand",
+    ]);
+  });
+
+  it("has no route for a Command it does not support", () => {
+    // Given a simulated EventBridge.
+    const simEventBridge = new SimEventBridge();
+
+    // When a Command from a later change is asked for.
+    const route = simEventBridge.sdkCommandRouter().route("PutRuleCommand");
+
+    // Then there is none, so the interception engine reports it rather than
+    // this service answering a rule request it cannot handle.
+    assertUndefined(route);
+  });
+});

--- a/src/service/eventbridge/sdk/sim-event-bridge-sdk-command-router.ts
+++ b/src/service/eventbridge/sdk/sim-event-bridge-sdk-command-router.ts
@@ -1,0 +1,80 @@
+import {
+  simSdkCallerOptions,
+  type SimSdkCommandRoute,
+  type SimSdkCommandRouter,
+} from "../../../sdk/index.js";
+import type {
+  SimCreateEventBusCommand,
+  SimDeleteEventBusCommand,
+  SimDescribeEventBusCommand,
+  SimListEventBusesCommand,
+} from "../command/bus/bus.command.js";
+import type { SimPutEventsCommand } from "../command/put-events/put-events.command.js";
+import type { SimEventBridge } from "../sim-event-bridge.js";
+
+/**
+ * Routes intercepted SDK Commands to one scoped simulated EventBridge.
+ */
+export class SimEventBridgeSdkCommandRouter implements SimSdkCommandRouter {
+  private readonly routes: ReadonlyMap<string, SimSdkCommandRoute>;
+
+  constructor(simEventBridge: SimEventBridge) {
+    this.routes = new Map<string, SimSdkCommandRoute>([
+      [
+        "CreateEventBusCommand",
+        async (command, context): Promise<unknown> =>
+          await simEventBridge.createEventBus(
+            command as SimCreateEventBusCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "DeleteEventBusCommand",
+        async (command, context): Promise<unknown> =>
+          await simEventBridge.deleteEventBus(
+            command as SimDeleteEventBusCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "DescribeEventBusCommand",
+        async (command, context): Promise<unknown> =>
+          await simEventBridge.describeEventBus(
+            command as SimDescribeEventBusCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "ListEventBusesCommand",
+        async (command, context): Promise<unknown> =>
+          await simEventBridge.listEventBuses(
+            command as SimListEventBusesCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "PutEventsCommand",
+        async (command, context): Promise<unknown> =>
+          await simEventBridge.putEvents(
+            command as SimPutEventsCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+    ]);
+  }
+
+  /**
+   * The SDK Command names simulated EventBridge can handle.
+   */
+  supportedCommandNames(): readonly string[] {
+    return this.routes.keys().toArray();
+  }
+
+  /**
+   * Get the route for an SDK Command name, if simulated EventBridge supports
+   * it.
+   */
+  route(commandName: string): SimSdkCommandRoute | undefined {
+    return this.routes.get(commandName);
+  }
+}

--- a/src/service/eventbridge/sdk/sim-event-bridge-sdk-routing.iso.test.ts
+++ b/src/service/eventbridge/sdk/sim-event-bridge-sdk-routing.iso.test.ts
@@ -1,0 +1,78 @@
+import {
+  CreateEventBusCommand,
+  DeleteEventBusCommand,
+  DescribeEventBusCommand,
+  EventBridgeClient,
+  ListEventBusesCommand,
+  PutEventsCommand,
+} from "@aws-sdk/client-eventbridge";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimSdk } from "../../../sdk/index.js";
+
+describe("EventBridge SDK interception", () => {
+  it("routes an intercepted EventBridgeClient to simulated EventBridge", async () => {
+    // Given an intercepted EventBridge SDK client.
+    using simSdk = new SimSdk();
+    simSdk.intercept(EventBridgeClient);
+
+    const client = new EventBridgeClient({ region: "eu-west-2" });
+
+    // When ordinary SDK code creates a bus and puts an event on it.
+    const created = await client.send(
+      new CreateEventBusCommand({ Name: "orders" }),
+    );
+    const put = await client.send(
+      new PutEventsCommand({
+        Entries: [
+          {
+            EventBusName: "orders",
+            Source: "orders.service",
+            DetailType: "OrderPlaced",
+            Detail: JSON.stringify({ orderId: "order-1" }),
+          },
+        ],
+      }),
+    );
+
+    // Then it works with nothing touching the network, and the ARN names the
+    // Region the client was configured for.
+    assertStringIncludes(
+      String(created.EventBusArn),
+      "arn:aws:events:eu-west-2:",
+    );
+    assertIdentical(put.FailedEntryCount, 0);
+    assertNonNullable(put.Entries?.[0]?.EventId);
+  });
+
+  it("routes every supported Command through the intercepted client", async () => {
+    // Given an intercepted EventBridge SDK client with a bus.
+    using simSdk = new SimSdk();
+    simSdk.intercept(EventBridgeClient);
+
+    const client = new EventBridgeClient({ region: "us-east-1" });
+    await client.send(new CreateEventBusCommand({ Name: "orders" }));
+
+    // When each of the remaining operations is used.
+    const described = await client.send(
+      new DescribeEventBusCommand({ Name: "orders" }),
+    );
+    const listed = await client.send(new ListEventBusesCommand({}));
+
+    await client.send(new DeleteEventBusCommand({ Name: "orders" }));
+
+    const afterDelete = await client.send(new ListEventBusesCommand({}));
+
+    // Then each answers as the simulated service does.
+    assertIdentical(described.Name, "orders");
+    assertArrayLength(listed.EventBuses ?? [], 2);
+    assertArrayLength(afterDelete.EventBuses ?? [], 1);
+    assertUndefined(listed.NextToken);
+  });
+});

--- a/src/service/eventbridge/sim-event-bridge.ts
+++ b/src/service/eventbridge/sim-event-bridge.ts
@@ -1,0 +1,147 @@
+import {
+  type BackgroundScheduler,
+  BackgroundTasks,
+} from "../../util/background/background.js";
+import type { SimSdkCommandRouter } from "../../sdk/router/sim-sdk-command-router.type.js";
+import type { SimAwsAccountRegionScope } from "../aws/sim-aws-account-region-scope.js";
+import { simAwsAccountRegionScopeFactory } from "../aws/sim-aws-account-region-scope.factory.js";
+import {
+  SimIamAllowAllAuth,
+  type SimIamInterServiceAuthZ,
+} from "../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { SimEventBus } from "./bus/sim-event-bus.js";
+import { SimEventBusStore } from "./bus/sim-event-bus-store.js";
+import type * as simEventBridgeCommands from "./command/sim-event-bridge-command.types.js";
+import { SimEventBridgeCommands } from "./command/sim-event-bridge-commands.js";
+import type { SimEventBridgeRequestOptions } from "./command/sim-event-bridge-request-options.js";
+import type { SimEventBridgeEvent } from "./event/sim-event-bridge-event.js";
+import { SimEventBridgeSdkCommandRouter } from "./sdk/sim-event-bridge-sdk-command-router.js";
+
+interface SimEventBridgeProperties {
+  readonly accountRegionScope?: SimAwsAccountRegionScope;
+  readonly iam?: SimIamInterServiceAuthZ;
+  readonly background?: BackgroundScheduler;
+}
+
+/**
+ * Simulated EventBridge. Handles SDK commands. Emulates AWS behaviour and
+ * state.
+ *
+ * Event buses are scoped to an account and region, as they are on real AWS: a
+ * bus name is unique within one of those scopes, and every scope has a
+ * `default` bus without one being created.
+ *
+ * A bus is a router rather than a store. An event put onto one is matched
+ * against that bus's rules and sent to their targets, and an event that
+ * matches nothing is gone. Rules and targets are not simulated yet, so every
+ * event put onto a bus today is dropped after it arrives.
+ */
+export class SimEventBridge {
+  private readonly buses: SimEventBusStore;
+  private readonly commands: SimEventBridgeCommands;
+  private readonly background: BackgroundScheduler;
+  private readonly sdkRouter = new SimEventBridgeSdkCommandRouter(this);
+
+  constructor(properties: SimEventBridgeProperties = {}) {
+    const {
+      accountRegionScope = simAwsAccountRegionScopeFactory.make(),
+      iam = new SimIamAllowAllAuth(),
+      background = new BackgroundTasks(),
+    } = properties;
+
+    this.background = background;
+    this.buses = new SimEventBusStore(
+      SimEventBus.default({ accountRegionScope, createdAt: background.now() }),
+    );
+    this.commands = new SimEventBridgeCommands({
+      buses: this.buses,
+      iam,
+      background,
+      accountRegionScope,
+    });
+  }
+
+  /**
+   * Find an event bus by name.
+   *
+   * This is the simulator's own accessor, for tests seeding or inspecting bus
+   * state without going through a Command and its authorization.
+   */
+  findEventBus(name: string): SimEventBus | undefined {
+    return this.buses.find(name);
+  }
+
+  /**
+   * Every event a bus received, in arrival order.
+   *
+   * This is the simulator's own accessor, for a test asserting on the envelope
+   * EventBridge built from a PutEvents entry. Real EventBridge keeps no events
+   * and offers nothing like it, so nothing an SDK command returns is built
+   * from this. A bus that is not there received nothing.
+   */
+  eventsOn(busName: string): readonly SimEventBridgeEvent[] {
+    return this.buses.find(busName)?.receivedEvents ?? [];
+  }
+
+  /**
+   * Handle a CreateEventBus Command from the SDK.
+   */
+  async createEventBus(
+    command: simEventBridgeCommands.SimCreateEventBusCommand,
+    options?: SimEventBridgeRequestOptions,
+  ): Promise<simEventBridgeCommands.SimCreateEventBusCommandOutput> {
+    await this.background.sequence();
+    return this.commands.busCreation.handle(command, options);
+  }
+
+  /**
+   * Handle a DeleteEventBus Command from the SDK.
+   */
+  async deleteEventBus(
+    command: simEventBridgeCommands.SimDeleteEventBusCommand,
+    options?: SimEventBridgeRequestOptions,
+  ): Promise<simEventBridgeCommands.SimDeleteEventBusCommandOutput> {
+    await this.background.sequence();
+    return this.commands.busDeletion.handle(command, options);
+  }
+
+  /**
+   * Handle a DescribeEventBus Command from the SDK.
+   */
+  async describeEventBus(
+    command: simEventBridgeCommands.SimDescribeEventBusCommand,
+    options?: SimEventBridgeRequestOptions,
+  ): Promise<simEventBridgeCommands.SimDescribeEventBusCommandOutput> {
+    await this.background.sequence();
+    return this.commands.buses.describeEventBus(command, options);
+  }
+
+  /**
+   * Handle a ListEventBuses Command from the SDK.
+   */
+  async listEventBuses(
+    command: simEventBridgeCommands.SimListEventBusesCommand,
+    options?: SimEventBridgeRequestOptions,
+  ): Promise<simEventBridgeCommands.SimListEventBusesCommandOutput> {
+    await this.background.sequence();
+    return this.commands.buses.listEventBuses(command, options);
+  }
+
+  /**
+   * Handle a PutEvents Command from the SDK.
+   */
+  async putEvents(
+    command: simEventBridgeCommands.SimPutEventsCommand,
+    options?: SimEventBridgeRequestOptions,
+  ): Promise<simEventBridgeCommands.SimPutEventsCommandOutput> {
+    await this.background.sequence();
+    return this.commands.putEvents.handle(command, options);
+  }
+
+  /**
+   * Get this service's SDK Command router for SDK client interception.
+   */
+  sdkCommandRouter(): SimSdkCommandRouter {
+    return this.sdkRouter;
+  }
+}


### PR DESCRIPTION
Adds a simulated EventBridge with event buses and PutEvents: the default bus every account and region has, CreateEventBus, DeleteEventBus, DescribeEventBus, ListEventBuses, and PutEvents building the event envelope from the simulation's own clock. Every operation is authorized by simulated IAM against the bus ARN, and EventBridgeClient is routed through SDK interception. Rules and targets are not simulated yet, so an event put onto a bus is dropped after it arrives, and an entry naming a bus that does not exist succeeds and is dropped, as it does on real AWS.

Three things in the issue turned out not to match the AWS documentation, and the implementation follows the documentation instead:

- The PutEvents size limit is 1 MB across the whole request, measured by AWS's own documented calculation, not 256 KB per entry.
- An entry naming a bus that does not exist is accepted and dropped with a 200 and an event id, not refused. AWS documents this explicitly, and it is a trap worth reproducing rather than smoothing over.
- `Detail`, `DetailType` and `Source` are optional in the API model and required in practice. An entry missing one fails on its own; a request in which no entry carries all three fails outright.

Two deliberate divergences, both documented in the docs page and the service README: an entry naming a bus ARN in another account or region is refused rather than delivered, and event bus resource policies are not modelled at all, so a caller from another account cannot be admitted to a bus.

Two changes outside the new service. `resolveSimSdkCommandRouter` became a lookup table rather than a switch, because one more case took it past the complexity limit. The Lambda collaborator wiring moved out of `SimAwsAccountRegionServiceBuilder` into `simAwsLambdaCollaborators`, because the new build method took that file past 300 lines. The root README also gained the DynamoDB docs link, which was missing from the list I was editing.

Resolves https://github.com/KensioSoftware/yulin/issues/531


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added simulated Amazon EventBridge support with account and region scoping.
  * Create, delete, describe, and list event buses, including pagination and validation.
  * Publish events with default or custom buses, event envelopes, timestamps, and per-entry results.
  * Added IAM authorization and AWS SDK command interception.
  * Added comprehensive EventBridge documentation and usage examples.

* **Documentation**
  * Added README links for EventBridge and DynamoDB service documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->