### PR TITLE
feat: send simulated EventBridge events to rule targets

### DIFF
--- a/docs/services/eventbridge/README.md
+++ b/docs/services/eventbridge/README.md
@@ -437,6 +437,38 @@ rather than simulated.
 The policy is consulted on every delivery rather than when the target is added, so a permission taken
 away afterwards stops delivery. Real EventBridge does not check it at `PutTargets` time either.
 
+A target may be in another account or region of the same simulation. It is the target's own account
+that decides, so the policy lives with the target and is evaluated by that account's IAM, as it is on
+real AWS. Both condition keys AWS documents for this work: `aws:SourceArn` carries the rule's ARN and
+`aws:SourceAccount` carries the account the rule belongs to.
+
+```typescript sim-event-bridge-cross-account
+/**
+ * A rule in one Account sending to a queue in another.
+ */
+
+const queuePolicy = {
+  Version: "2012-10-17",
+  Statement: [
+    {
+      Effect: "Allow",
+      Principal: { Service: "events.amazonaws.com" },
+      Action: "sqs:SendMessage",
+      Resource: "arn:aws:sqs:us-east-1:222222222222:orders",
+      Condition: {
+        ArnLike: {
+          "aws:SourceArn": "arn:aws:events:us-east-1:111111111111:rule/orders",
+        },
+      },
+    },
+  ],
+};
+
+console.log(JSON.stringify(queuePolicy).length > 0); // true
+```
+
+An event delivered across accounts still names the account it was put in, not the target's.
+
 ## Deliveries that did not happen
 
 Real EventBridge tells the caller nothing about a failed delivery: a `PutEvents` that matched a rule
@@ -562,8 +594,8 @@ no permission for.
   `numeric` and `exists`.
 - `PutTargets`, `RemoveTargets`, `ListTargetsByRule` and `ListRuleNamesByTarget`, with delivery to a
   simulated Lambda function, SQS queue or SNS topic, authorized by the target's own resource policy.
-- Targets in another account or region of the same simulation, which the target's own account
-  decides on, as real EventBridge does.
+- Targets in another account or region of the same simulation, admitted by the target's own resource
+  policy on `aws:SourceArn` or `aws:SourceAccount`, as real EventBridge does.
 - A target's fixed `Input`, and `deliveryFailures` for deliveries that did not happen.
 - The `default` bus in every account and region, without one being created.
 - Bus descriptions, creation timestamps from the simulation's clock, and prefix-narrowed paged

--- a/docs/services/eventbridge/README.md
+++ b/docs/services/eventbridge/README.md
@@ -3,8 +3,8 @@
 Yulin includes a simulated Amazon EventBridge for tests and local development. Event buses are held
 in memory and every operation is authorized by simulated IAM.
 
-Event buses, rules and `PutEvents`. Targets and EventBridge Scheduler are not simulated yet, so the
-bus records the event and the names of the rules it matched rather than sending it to a target. EventBridge-specific
+Event buses, rules, targets and `PutEvents`. A rule can send matched events to a simulated Lambda
+function, SQS queue or SNS topic. EventBridge Scheduler and scheduled rules are not simulated yet. EventBridge-specific
 types are imported from the `@kensio/yulin/eventbridge` subpath.
 
 ## Putting an event onto a bus
@@ -324,6 +324,176 @@ console.log(Result); // true
 This is the quickest way to find out why a rule is not firing, and a pattern this simulation cannot
 evaluate is refused here exactly as `PutRule` refuses it.
 
+## Sending matched events to targets
+
+A rule sends every event it matches to each of its targets. A target is a simulated Lambda function,
+SQS queue or SNS topic.
+
+```typescript sim-event-bridge-targets
+/**
+ * A rule sending order events to a queue.
+ */
+
+import {
+  PutEventsCommand,
+  PutRuleCommand,
+  PutTargetsCommand,
+} from "@aws-sdk/client-eventbridge";
+import {
+  CreateQueueCommand,
+  ReceiveMessageCommand,
+  SetQueueAttributesCommand,
+} from "@aws-sdk/client-sqs";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const queueArn = "arn:aws:sqs:us-east-1:888888888888:orders";
+
+const queue = await simAws
+  .sqs()
+  .createQueue(new CreateQueueCommand({ QueueName: "orders" }));
+
+// The queue's own policy is what admits EventBridge.
+await simAws.sqs().setQueueAttributes(
+  new SetQueueAttributesCommand({
+    QueueUrl: queue.QueueUrl,
+    Attributes: {
+      Policy: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: [
+          {
+            Effect: "Allow",
+            Principal: { Service: "events.amazonaws.com" },
+            Action: "sqs:SendMessage",
+            Resource: queueArn,
+          },
+        ],
+      }),
+    },
+  }),
+);
+
+await simAws.eventBridge().putRule(
+  new PutRuleCommand({
+    Name: "orders",
+    EventPattern: JSON.stringify({ source: ["orders.service"] }),
+  }),
+);
+
+await simAws.eventBridge().putTargets(
+  new PutTargetsCommand({
+    Rule: "orders",
+    Targets: [{ Id: "orders-queue", Arn: queueArn }],
+  }),
+);
+
+await simAws.eventBridge().putEvents(
+  new PutEventsCommand({
+    Entries: [
+      {
+        Source: "orders.service",
+        DetailType: "OrderPlaced",
+        Detail: JSON.stringify({ orderId: "order-1" }),
+      },
+    ],
+  }),
+);
+
+// Delivery happens after PutEvents has answered, as it does on real AWS.
+await simAws.backgroundTasksComplete();
+
+const received = await simAws
+  .sqs()
+  .receiveMessage(new ReceiveMessageCommand({ QueueUrl: queue.QueueUrl }));
+
+console.log(received.Messages?.length); // 1
+```
+
+A queue or topic target receives the event as its message body, with no envelope around it. A Lambda
+target is invoked with the event as its payload. A target with an `Input` receives that fixed JSON
+instead of the event, which is what makes `Input` useful for a target that only needs to know
+something happened.
+
+A rule has at most five targets, and a target id is unique within one rule. `PutTargets` replaces a
+target of the same id rather than adding a second beside it. `RemoveTargets` reports an id the rule
+does not have as a failed entry rather than failing the request. Deleting a rule takes its targets
+with it.
+
+`ListTargetsByRule` reports a rule's targets, and `ListRuleNamesByTarget` reports the rules of a bus
+that send to one target ARN.
+
+## What a target has to allow
+
+EventBridge reaches a target as the `events.amazonaws.com` service principal, and the target's own
+resource policy is the whole of the decision. There is no execution role: a rule `RoleArn` is refused
+rather than simulated.
+
+- **A queue** needs `sqs:SendMessage` for `events.amazonaws.com` in its `Policy` attribute.
+- **A topic** needs `sns:Publish` for `events.amazonaws.com` in its `Policy` attribute.
+- **A function** needs an `AddPermission` grant of `lambda:InvokeFunction` to
+  `events.amazonaws.com`.
+
+The policy is consulted on every delivery rather than when the target is added, so a permission taken
+away afterwards stops delivery. Real EventBridge does not check it at `PutTargets` time either.
+
+## Deliveries that did not happen
+
+Real EventBridge tells the caller nothing about a failed delivery: a `PutEvents` that matched a rule
+whose target refuses the call still answers with an event id. A target that is unexpectedly empty is
+explained by `deliveryFailures` instead:
+
+```typescript sim-event-bridge-delivery-failures
+/**
+ * Finding out why a target received nothing.
+ */
+
+import {
+  PutEventsCommand,
+  PutRuleCommand,
+  PutTargetsCommand,
+} from "@aws-sdk/client-eventbridge";
+import { CreateQueueCommand } from "@aws-sdk/client-sqs";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+// A queue with no policy admitting EventBridge.
+await simAws.sqs().createQueue(new CreateQueueCommand({ QueueName: "orders" }));
+
+await simAws.eventBridge().putRule(
+  new PutRuleCommand({
+    Name: "orders",
+    EventPattern: JSON.stringify({ source: ["orders.service"] }),
+  }),
+);
+await simAws.eventBridge().putTargets(
+  new PutTargetsCommand({
+    Rule: "orders",
+    Targets: [{ Id: "q", Arn: "arn:aws:sqs:us-east-1:888888888888:orders" }],
+  }),
+);
+
+await simAws.eventBridge().putEvents(
+  new PutEventsCommand({
+    Entries: [
+      { Source: "orders.service", DetailType: "OrderPlaced", Detail: "{}" },
+    ],
+  }),
+);
+await simAws.backgroundTasksComplete();
+
+const [failure] = simAws.eventBridge().deliveryFailures;
+
+console.log(failure?.targetId); // "q"
+console.log(failure?.message);
+// "The queue policy of arn:aws:sqs:... does not allow events.amazonaws.com..."
+```
+
+A target that names nothing reads differently from one whose policy said no, because a policy saying
+no is a modelled outcome a test may be asking for on purpose.
+
 ## Permissions
 
 Every operation is authorized by simulated IAM against the bus ARN. `events:ListEventBuses` has no
@@ -390,6 +560,9 @@ no permission for.
   `TestEventPattern`.
 - Event pattern matching on exact values, nested fields, lists, `prefix`, `suffix`, `anything-but`,
   `numeric` and `exists`.
+- `PutTargets`, `RemoveTargets`, `ListTargetsByRule` and `ListRuleNamesByTarget`, with delivery to a
+  simulated Lambda function, SQS queue or SNS topic, authorized by the target's own resource policy.
+- A target's fixed `Input`, and `deliveryFailures` for deliveries that did not happen.
 - The `default` bus in every account and region, without one being created.
 - Bus descriptions, creation timestamps from the simulation's clock, and prefix-narrowed paged
   listings.
@@ -399,9 +572,10 @@ no permission for.
 
 ## Limitations
 
-- Rule targets are not simulated, so a matched event is recorded in the bus receipt with the names
-  of the rules it matched and goes no further. `PutTargets`, `RemoveTargets` and `ListTargetsByRule`
-  are absent.
+- Targets deliver to Lambda, SQS and SNS only. A target ARN naming any other service is refused when
+  the target is added rather than when an event first matches.
+- Target `InputPath` and `InputTransformer` are refused, as are a target `RoleArn`, dead letter
+  queues and retry policies. A delivery is attempted once.
 - Numbers are compared after JSON parsing, so `300`, `300.0` and `3.0e2` are one value here. Real
   EventBridge compares the JSON token when matching an exact value, and so may tell those forms
   apart. Use `numeric` to compare numbers, which is what it is for.
@@ -412,8 +586,8 @@ no permission for.
   `ScheduleExpression`. A rule needs an event pattern.
 - Rule tags, a rule `RoleArn`, managed rules and the
   `ENABLED_WITH_ALL_CLOUDTRAIL_MANAGEMENT_EVENTS` state are refused rather than simulated.
-- Deleting an event bus deletes its rules. Real EventBridge refuses to delete a bus that still has
-  rules on it.
+- Deleting an event bus deletes its rules, and deleting a rule deletes its targets. Real EventBridge
+  refuses to delete either while it still has what hangs off it.
 - `AWS::Events::*` CloudFormation resource types are not simulated.
 - Event bus resource policies are not simulated. `PutPermission`, `RemovePermission` and the bus
   `Policy` attribute are all absent, so a caller from another account cannot be admitted to a bus,

--- a/docs/services/eventbridge/README.md
+++ b/docs/services/eventbridge/README.md
@@ -562,6 +562,8 @@ no permission for.
   `numeric` and `exists`.
 - `PutTargets`, `RemoveTargets`, `ListTargetsByRule` and `ListRuleNamesByTarget`, with delivery to a
   simulated Lambda function, SQS queue or SNS topic, authorized by the target's own resource policy.
+- Targets in another account or region of the same simulation, which the target's own account
+  decides on, as real EventBridge does.
 - A target's fixed `Input`, and `deliveryFailures` for deliveries that did not happen.
 - The `default` bus in every account and region, without one being created.
 - Bus descriptions, creation timestamps from the simulation's clock, and prefix-narrowed paged

--- a/docs/services/eventbridge/sim-event-bridge-cross-account.example.ts
+++ b/docs/services/eventbridge/sim-event-bridge-cross-account.example.ts
@@ -1,0 +1,22 @@
+/**
+ * A rule in one Account sending to a queue in another.
+ */
+
+const queuePolicy = {
+  Version: "2012-10-17",
+  Statement: [
+    {
+      Effect: "Allow",
+      Principal: { Service: "events.amazonaws.com" },
+      Action: "sqs:SendMessage",
+      Resource: "arn:aws:sqs:us-east-1:222222222222:orders",
+      Condition: {
+        ArnLike: {
+          "aws:SourceArn": "arn:aws:events:us-east-1:111111111111:rule/orders",
+        },
+      },
+    },
+  ],
+};
+
+console.log(JSON.stringify(queuePolicy).length > 0); // true

--- a/docs/services/eventbridge/sim-event-bridge-delivery-failures.example.ts
+++ b/docs/services/eventbridge/sim-event-bridge-delivery-failures.example.ts
@@ -1,0 +1,45 @@
+/**
+ * Finding out why a target received nothing.
+ */
+
+import {
+  PutEventsCommand,
+  PutRuleCommand,
+  PutTargetsCommand,
+} from "@aws-sdk/client-eventbridge";
+import { CreateQueueCommand } from "@aws-sdk/client-sqs";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+// A queue with no policy admitting EventBridge.
+await simAws.sqs().createQueue(new CreateQueueCommand({ QueueName: "orders" }));
+
+await simAws.eventBridge().putRule(
+  new PutRuleCommand({
+    Name: "orders",
+    EventPattern: JSON.stringify({ source: ["orders.service"] }),
+  }),
+);
+await simAws.eventBridge().putTargets(
+  new PutTargetsCommand({
+    Rule: "orders",
+    Targets: [{ Id: "q", Arn: "arn:aws:sqs:us-east-1:888888888888:orders" }],
+  }),
+);
+
+await simAws.eventBridge().putEvents(
+  new PutEventsCommand({
+    Entries: [
+      { Source: "orders.service", DetailType: "OrderPlaced", Detail: "{}" },
+    ],
+  }),
+);
+await simAws.backgroundTasksComplete();
+
+const [failure] = simAws.eventBridge().deliveryFailures;
+
+console.log(failure?.targetId); // "q"
+console.log(failure?.message);
+// "The queue policy of arn:aws:sqs:... does not allow events.amazonaws.com..."

--- a/docs/services/eventbridge/sim-event-bridge-targets.example.ts
+++ b/docs/services/eventbridge/sim-event-bridge-targets.example.ts
@@ -1,0 +1,78 @@
+/**
+ * A rule sending order events to a queue.
+ */
+
+import {
+  PutEventsCommand,
+  PutRuleCommand,
+  PutTargetsCommand,
+} from "@aws-sdk/client-eventbridge";
+import {
+  CreateQueueCommand,
+  ReceiveMessageCommand,
+  SetQueueAttributesCommand,
+} from "@aws-sdk/client-sqs";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const queueArn = "arn:aws:sqs:us-east-1:888888888888:orders";
+
+const queue = await simAws
+  .sqs()
+  .createQueue(new CreateQueueCommand({ QueueName: "orders" }));
+
+// The queue's own policy is what admits EventBridge.
+await simAws.sqs().setQueueAttributes(
+  new SetQueueAttributesCommand({
+    QueueUrl: queue.QueueUrl,
+    Attributes: {
+      Policy: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: [
+          {
+            Effect: "Allow",
+            Principal: { Service: "events.amazonaws.com" },
+            Action: "sqs:SendMessage",
+            Resource: queueArn,
+          },
+        ],
+      }),
+    },
+  }),
+);
+
+await simAws.eventBridge().putRule(
+  new PutRuleCommand({
+    Name: "orders",
+    EventPattern: JSON.stringify({ source: ["orders.service"] }),
+  }),
+);
+
+await simAws.eventBridge().putTargets(
+  new PutTargetsCommand({
+    Rule: "orders",
+    Targets: [{ Id: "orders-queue", Arn: queueArn }],
+  }),
+);
+
+await simAws.eventBridge().putEvents(
+  new PutEventsCommand({
+    Entries: [
+      {
+        Source: "orders.service",
+        DetailType: "OrderPlaced",
+        Detail: JSON.stringify({ orderId: "order-1" }),
+      },
+    ],
+  }),
+);
+
+// Delivery happens after PutEvents has answered, as it does on real AWS.
+await simAws.backgroundTasksComplete();
+
+const received = await simAws
+  .sqs()
+  .receiveMessage(new ReceiveMessageCommand({ QueueUrl: queue.QueueUrl }));
+
+console.log(received.Messages?.length); // 1

--- a/src/service/aws/factory/sim-aws-account-region-service-builder.ts
+++ b/src/service/aws/factory/sim-aws-account-region-service-builder.ts
@@ -13,6 +13,7 @@ import { SimCognitoIdentityProvider } from "../../cognito/index.js";
 import { simAwsCognitoTriggerFunctions } from "../../cognito/user-pool/trigger/sim-aws-cognito-trigger-functions.js";
 import { SimDynamoDb as SimDynamoDatabase } from "../../dynamodb/index.js";
 import { SimEventBridge } from "../../eventbridge/index.js";
+import { SimAwsEventBridgeDeliveryTargets } from "../../eventbridge/delivery/sim-aws-event-bridge-delivery-targets.js";
 import type { SimIamRegistry } from "../../iam/registry/sim-iam-registry.js";
 import { SimKms } from "../../kms/index.js";
 import type { SimHttpApiRegistry } from "../../apigatewayv2/registry/sim-http-api-registry.js";
@@ -152,7 +153,14 @@ export class SimAwsAccountRegionServiceBuilder {
    * an event put in one Region reaches no rule in another.
    */
   createEventBridge(scope: SimAwsAccountRegionContainer): SimEventBridge {
-    return new SimEventBridge(this.scoped(scope));
+    return new SimEventBridge({
+      ...this.scoped(scope),
+      // Rules deliver to targets in any Account and Region of this
+      // simulation, as real EventBridge delivers across both.
+      deliveryTargets: new SimAwsEventBridgeDeliveryTargets({
+        simAws: this.simAws,
+      }),
+    });
   }
 
   /**

--- a/src/service/eventbridge/README.md
+++ b/src/service/eventbridge/README.md
@@ -143,7 +143,7 @@ anyway.
 
 ## Divergences
 
-Four, all deliberate.
+Five, all deliberate.
 
 An entry naming a bus that does not exist **succeeds**. Real EventBridge answers 200, matches the
 event against no rule, and drops it, without counting the entry as failed. It is a trap, because a

--- a/src/service/eventbridge/README.md
+++ b/src/service/eventbridge/README.md
@@ -1,7 +1,7 @@
 # Simulated EventBridge implementation
 
-This directory contains the simulated EventBridge service implementation. Event buses, rules and
-PutEvents: targets and EventBridge Scheduler come later.
+This directory contains the simulated EventBridge service implementation. Event buses, rules,
+targets and PutEvents. EventBridge Scheduler and scheduled rules come later.
 
 The guiding decision here is that a bus is a router rather than a store. Real EventBridge keeps no
 events, so nothing here answers an SDK command from stored events. The events a bus does keep are a
@@ -105,13 +105,45 @@ what fails and how:
   calculation rather than by the JSON on the wire. `sim-event-bridge-entry-size.ts` implements that
   calculation, which is why a `Time` counts as a flat 14 bytes and a `TraceHeader` counts as nothing.
 
+## Target model and delivery
+
+Targets live under `target/`, and getting an event to one lives under `delivery/`.
+
+`SimEventTargetStore` holds targets keyed by bus and rule rather than on the rule itself, the same
+way a topic's subscriptions are held apart from the topic in simulated SNS. A rule with no targets is
+a rule that matches events and sends them nowhere, which real EventBridge lets you have, and holding
+them apart is what keeps that from looking like a broken rule.
+
+`SimEventTargetArn` reads target ARNs itself rather than deferring to `parseSimArn`, because the
+three services it delivers to write their resource part three ways: a queue and a topic put the name
+straight after the Account, and a function writes `function:<name>`. An ARN naming any other service
+is refused when the target is added, so a rule that cannot work says so at the point it was written.
+
+Delivery has one class per destination service, and each asks that service's own authorizer:
+`SimSqsServiceSendAuthorizer`, `SimSnsServicePublishAuthorizer` and
+`SimLambdaServiceInvokeAuthorizer`. Those already existed for simulated SNS's own fan-out, and they
+answer the same question here with a different service principal, so nothing about who may reach a
+queue lives in this service.
+
+`SimAwsEventBridgeDeliveryTargets` is the SimAws-level dispatcher, and a `SimEventBridge` built on
+its own gets `SimEventBridgeNoDeliveryTargets` instead, which records every delivery as a failure
+saying why there was nowhere to make it. A rule that appeared to deliver to a target that was never
+reachable would be the worst of the possible answers.
+
+## Routing
+
 `SimEventBridgeRouter` under `routing/` is what a bus does with an event: find the bus, ask each of
-its enabled rules, and record the matches. Sending a matched event on to the rule's targets belongs
-here too, and is what the next change adds.
+its enabled rules, record the matches, and schedule a delivery for every target of every rule that
+matched. `SimEventBridgeTargetDelivery` makes each of those deliveries and keeps whatever went wrong.
+
+The split is that the router decides and the delivery does. A failure is recorded rather than thrown
+because these run as background tasks: one left rejected would fail an unrelated
+`backgroundTasksComplete()`, and real EventBridge has nowhere to report a delivery failure to
+anyway.
 
 ## Divergences
 
-Three, all deliberate.
+Four, all deliberate.
 
 An entry naming a bus that does not exist **succeeds**. Real EventBridge answers 200, matches the
 event against no rule, and drops it, without counting the entry as failed. It is a trap, because a
@@ -121,9 +153,15 @@ An entry naming a bus ARN in another account or region is **refused**, which rea
 Nothing here can reach another simulation's bus, and treating a foreign ARN as local would let a test
 pass while the real call crossed a boundary it has no permission for.
 
-Deleting an event bus **deletes its rules**. Real EventBridge refuses to delete a bus that still has
-rules on it. Refusing would mean a test tearing down a stack had to delete rules in order, and a rule
-that outlived its bus would match events put onto a bus later recreated under the same name.
+Deleting an event bus **deletes its rules**, and deleting a rule **deletes its targets**. Real
+EventBridge refuses to delete either while it still has what hangs off it. Refusing would mean a test
+tearing down a stack had to delete in order, and a rule that outlived its bus would match events put
+onto a bus later recreated under the same name.
+
+`PutTargets` **refuses the whole request** for a target it will not take, where real EventBridge
+reports a failed entry. Every failure this simulation has is about the request being written for
+something unmodelled, and a caller not reading `FailedEntryCount` would otherwise see a silent
+no-op.
 
 Event bus resource policies are not modelled at all, since nothing sets one: `PutPermission` and the
 bus `Policy` attribute are both absent. A caller from another account therefore has no way to be

--- a/src/service/eventbridge/command/bus/sim-event-bridge-delete-event-bus.ts
+++ b/src/service/eventbridge/command/bus/sim-event-bridge-delete-event-bus.ts
@@ -1,6 +1,7 @@
 import { SimEventBusName } from "../../bus/sim-event-bus-name.js";
 import type { SimEventBusStore } from "../../bus/sim-event-bus-store.js";
 import type { SimEventRuleStore } from "../../rule/sim-event-rule-store.js";
+import type { SimEventTargetStore } from "../../target/sim-event-target-store.js";
 import { SimEventBridgeValidationException } from "../../error/sim-event-bridge.error.js";
 import type { SimEventBridgeRequestOptions } from "../sim-event-bridge-request-options.js";
 import type { SimEventBridgeBusAccess } from "./sim-event-bridge-bus-access.js";
@@ -12,6 +13,7 @@ import type {
 interface SimEventBridgeDeleteEventBusProperties {
   readonly buses: SimEventBusStore;
   readonly rules: SimEventRuleStore;
+  readonly targets: SimEventTargetStore;
   readonly access: SimEventBridgeBusAccess;
 }
 
@@ -29,11 +31,13 @@ interface SimEventBridgeDeleteEventBusProperties {
 export class SimEventBridgeDeleteEventBus {
   private readonly buses: SimEventBusStore;
   private readonly rules: SimEventRuleStore;
+  private readonly targets: SimEventTargetStore;
   private readonly access: SimEventBridgeBusAccess;
 
   constructor(properties: SimEventBridgeDeleteEventBusProperties) {
     this.buses = properties.buses;
     this.rules = properties.rules;
+    this.targets = properties.targets;
     this.access = properties.access;
   }
 
@@ -64,6 +68,7 @@ export class SimEventBridgeDeleteEventBus {
       // Real EventBridge refuses to delete a bus that still has rules on it.
       // Nothing here can be left orphaned instead: a rule outliving its bus
       // would match events put onto a bus recreated under the same name.
+      this.targets.removeForRules(this.rules.forBus(bus.name.value));
       this.rules.removeForBus(bus.name.value);
       this.buses.remove(bus);
     }

--- a/src/service/eventbridge/command/rule/sim-event-bridge-rule-commands.ts
+++ b/src/service/eventbridge/command/rule/sim-event-bridge-rule-commands.ts
@@ -1,4 +1,5 @@
 import type { SimEventRuleStore } from "../../rule/sim-event-rule-store.js";
+import type { SimEventTargetStore } from "../../target/sim-event-target-store.js";
 import { SimEventRuleState } from "../../rule/sim-event-rule-state.js";
 import { SimEventBridgePage } from "../sim-event-bridge-page.js";
 import type { SimEventBridgeRequestOptions } from "../sim-event-bridge-request-options.js";
@@ -19,6 +20,7 @@ import type {
 
 interface SimEventBridgeRuleCommandsProperties {
   readonly rules: SimEventRuleStore;
+  readonly targets: SimEventTargetStore;
   readonly access: SimEventBridgeRuleAccess;
 }
 
@@ -30,10 +32,12 @@ interface SimEventBridgeRuleCommandsProperties {
  */
 export class SimEventBridgeRuleCommands {
   private readonly rules: SimEventRuleStore;
+  private readonly targets: SimEventTargetStore;
   private readonly access: SimEventBridgeRuleAccess;
 
   constructor(properties: SimEventBridgeRuleCommandsProperties) {
     this.rules = properties.rules;
+    this.targets = properties.targets;
     this.access = properties.access;
   }
 
@@ -50,6 +54,11 @@ export class SimEventBridgeRuleCommands {
     const rule = this.access.find("events:DeleteRule", command.input, options);
 
     if (rule !== undefined) {
+      // Real EventBridge refuses to delete a rule that still has targets
+      // unless the request forces it. Nothing here can be left orphaned
+      // instead: targets outliving their rule would be delivered to by a rule
+      // recreated under the same name.
+      this.targets.removeForRule(rule.busName.value, rule.name.value);
       this.rules.remove(rule);
     }
 

--- a/src/service/eventbridge/command/sim-event-bridge-command.types.ts
+++ b/src/service/eventbridge/command/sim-event-bridge-command.types.ts
@@ -47,3 +47,19 @@ export type {
   SimTestEventPatternCommandInput,
   SimTestEventPatternCommandOutput,
 } from "./rule/rule.command.js";
+export type {
+  SimEventBridgeTarget,
+  SimEventBridgeTargetFailure,
+  SimListRuleNamesByTargetCommand,
+  SimListRuleNamesByTargetCommandInput,
+  SimListRuleNamesByTargetCommandOutput,
+  SimListTargetsByRuleCommand,
+  SimListTargetsByRuleCommandInput,
+  SimListTargetsByRuleCommandOutput,
+  SimPutTargetsCommand,
+  SimPutTargetsCommandInput,
+  SimPutTargetsCommandOutput,
+  SimRemoveTargetsCommand,
+  SimRemoveTargetsCommandInput,
+  SimRemoveTargetsCommandOutput,
+} from "./target/target.command.js";

--- a/src/service/eventbridge/command/sim-event-bridge-commands.ts
+++ b/src/service/eventbridge/command/sim-event-bridge-commands.ts
@@ -3,7 +3,10 @@ import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-
 import type { SimIamInterServiceAuthZ } from "../../iam/authorize/sim-iam-inter-service-auth-z.js";
 import type { SimEventBusStore } from "../bus/sim-event-bus-store.js";
 import { SimEventBridgeRouter } from "../routing/sim-event-bridge-router.js";
+import type { SimEventBridgeDeliveryTargets } from "../delivery/sim-event-bridge-delivery.js";
+import { SimEventBridgeNoDeliveryTargets } from "../delivery/sim-event-bridge-no-delivery-targets.js";
 import type { SimEventRuleStore } from "../rule/sim-event-rule-store.js";
+import type { SimEventTargetStore } from "../target/sim-event-target-store.js";
 import { SimEventBridgeAuthorizer } from "./authorize/sim-event-bridge-authorizer.js";
 import { SimEventBridgeBusAccess } from "./bus/sim-event-bridge-bus-access.js";
 import { SimEventBridgeBusCommands } from "./bus/sim-event-bridge-bus-commands.js";
@@ -14,10 +17,14 @@ import { SimEventBridgePutRule } from "./rule/sim-event-bridge-put-rule.js";
 import { SimEventBridgeRuleAccess } from "./rule/sim-event-bridge-rule-access.js";
 import { SimEventBridgeRuleCommands } from "./rule/sim-event-bridge-rule-commands.js";
 import { SimEventBridgeTestEventPattern } from "./rule/sim-event-bridge-test-event-pattern.js";
+import { SimEventBridgePutTargets } from "./target/sim-event-bridge-put-targets.js";
+import { SimEventBridgeTargetCommands } from "./target/sim-event-bridge-target-commands.js";
 
 interface SimEventBridgeCommandsProperties {
   readonly buses: SimEventBusStore;
   readonly rules: SimEventRuleStore;
+  readonly targets: SimEventTargetStore;
+  readonly deliveryTargets?: SimEventBridgeDeliveryTargets | undefined;
   readonly iam: SimIamInterServiceAuthZ;
   readonly background: BackgroundScheduler;
   readonly accountRegionScope: SimAwsAccountRegionScope;
@@ -39,9 +46,13 @@ export class SimEventBridgeCommands {
   public readonly ruleCreation: SimEventBridgePutRule;
   public readonly rules: SimEventBridgeRuleCommands;
   public readonly patternTest: SimEventBridgeTestEventPattern;
+  public readonly targetCreation: SimEventBridgePutTargets;
+  public readonly targets: SimEventBridgeTargetCommands;
+  public readonly router: SimEventBridgeRouter;
 
   constructor(properties: SimEventBridgeCommandsProperties) {
-    const { buses, rules, accountRegionScope, background } = properties;
+    const { buses, rules, targets, accountRegionScope, background } =
+      properties;
     const authorizer = new SimEventBridgeAuthorizer({ iam: properties.iam });
     const access = new SimEventBridgeBusAccess({
       buses,
@@ -64,21 +75,44 @@ export class SimEventBridgeCommands {
     this.busDeletion = new SimEventBridgeDeleteEventBus({
       buses,
       rules,
+      targets,
       access,
     });
     this.buses = new SimEventBridgeBusCommands({ buses, access });
+    this.router = new SimEventBridgeRouter({
+      buses,
+      rules,
+      targets,
+      endpoints:
+        properties.deliveryTargets ?? new SimEventBridgeNoDeliveryTargets(),
+      background,
+      accountId: accountRegionScope.accountId,
+    });
     this.putEvents = new SimEventBridgePutEvents({
       access,
       accountRegionScope,
       clock: background,
-      router: new SimEventBridgeRouter({ buses, rules }),
+      router: this.router,
     });
     this.ruleCreation = new SimEventBridgePutRule({
       rules,
       access: ruleAccess,
       accountRegionScope,
     });
-    this.rules = new SimEventBridgeRuleCommands({ rules, access: ruleAccess });
+    this.rules = new SimEventBridgeRuleCommands({
+      rules,
+      targets,
+      access: ruleAccess,
+    });
     this.patternTest = new SimEventBridgeTestEventPattern({ authorizer });
+    this.targetCreation = new SimEventBridgePutTargets({
+      targets,
+      access: ruleAccess,
+    });
+    this.targets = new SimEventBridgeTargetCommands({
+      rules,
+      targets,
+      access: ruleAccess,
+    });
   }
 }

--- a/src/service/eventbridge/command/target/sim-event-bridge-put-targets.ts
+++ b/src/service/eventbridge/command/target/sim-event-bridge-put-targets.ts
@@ -1,0 +1,99 @@
+import { SimEventBridgeValidationException } from "../../error/sim-event-bridge.error.js";
+import { SimEventTarget } from "../../target/sim-event-target.js";
+import {
+  simEventMaximumTargets,
+  type SimEventTargetStore,
+} from "../../target/sim-event-target-store.js";
+import type { SimEventBridgeRequestOptions } from "../sim-event-bridge-request-options.js";
+import type { SimEventBridgeRuleAccess } from "../rule/sim-event-bridge-rule-access.js";
+import { refuseUnsimulatedTargetInput } from "./sim-event-bridge-unsimulated-target-input.js";
+import type {
+  SimPutTargetsCommand,
+  SimPutTargetsCommandOutput,
+} from "./target.command.js";
+
+interface SimEventBridgePutTargetsProperties {
+  readonly targets: SimEventTargetStore;
+  readonly access: SimEventBridgeRuleAccess;
+}
+
+/**
+ * The PutTargets command.
+ *
+ * The whole request is refused where a target is unusable, rather than that
+ * target coming back in `FailedEntries`. Real EventBridge reports a failed
+ * entry for a target it could not add, but the failures this simulation has
+ * are all about the request being written for something it does not model, and
+ * a caller who is not looking at `FailedEntryCount` would otherwise see a
+ * silent no-op.
+ */
+export class SimEventBridgePutTargets {
+  private readonly targets: SimEventTargetStore;
+  private readonly access: SimEventBridgeRuleAccess;
+
+  constructor(properties: SimEventBridgePutTargetsProperties) {
+    this.targets = properties.targets;
+    this.access = properties.access;
+  }
+
+  /**
+   * Add targets to a rule, replacing any of the same id.
+   */
+  handle(
+    command: SimPutTargetsCommand,
+    options?: SimEventBridgeRequestOptions,
+  ): SimPutTargetsCommandOutput {
+    const input = command.input;
+    const rule = this.access.require(
+      "events:PutTargets",
+      { Name: input.Rule, EventBusName: input.EventBusName },
+      options,
+    );
+    const requested = input.Targets ?? [];
+
+    if (requested.length === 0) {
+      throw new SimEventBridgeValidationException(
+        "Invalid parameter: Targets Reason: a PutTargets request carries at " +
+          "least one target",
+      );
+    }
+
+    for (const target of requested) {
+      refuseUnsimulatedTargetInput(target);
+    }
+
+    const added = requested.map((target) => SimEventTarget.of(target));
+    const busName = rule.busName.value;
+    const ruleName = rule.name.value;
+
+    this.refuseOverfullRule(busName, ruleName, added);
+    this.targets.put(busName, ruleName, added);
+
+    return { $metadata: {}, FailedEntryCount: 0, FailedEntries: [] };
+  }
+
+  /**
+   * Refuse a request that would take a rule past the targets it may have.
+   *
+   * Targets already on the rule count, except the ones this request replaces,
+   * so replacing an existing id is the only way past a full rule.
+   */
+  private refuseOverfullRule(
+    busName: string,
+    ruleName: string,
+    added: readonly SimEventTarget[],
+  ): void {
+    const kept = this.targets
+      .forRule(busName, ruleName)
+      .filter((existing) =>
+        added.every((target) => target.id !== existing.id),
+      ).length;
+
+    if (kept + added.length > simEventMaximumTargets) {
+      throw new SimEventBridgeValidationException(
+        `Rule ${ruleName} would have ${String(kept + added.length)} targets, ` +
+          `and a rule has at most ${String(simEventMaximumTargets)}.`,
+      );
+    }
+  }
+}

--- a/src/service/eventbridge/command/target/sim-event-bridge-put-targets.ts
+++ b/src/service/eventbridge/command/target/sim-event-bridge-put-targets.ts
@@ -1,11 +1,12 @@
 import { SimEventBridgeValidationException } from "../../error/sim-event-bridge.error.js";
 import { SimEventTarget } from "../../target/sim-event-target.js";
-import {
-  simEventMaximumTargets,
-  type SimEventTargetStore,
-} from "../../target/sim-event-target-store.js";
+import type { SimEventTargetStore } from "../../target/sim-event-target-store.js";
 import type { SimEventBridgeRequestOptions } from "../sim-event-bridge-request-options.js";
 import type { SimEventBridgeRuleAccess } from "../rule/sim-event-bridge-rule-access.js";
+import {
+  refuseOverfullRule,
+  refuseRepeatedTargetIds,
+} from "./sim-event-bridge-target-refusals.js";
 import { refuseUnsimulatedTargetInput } from "./sim-event-bridge-unsimulated-target-input.js";
 import type {
   SimPutTargetsCommand,
@@ -63,37 +64,19 @@ export class SimEventBridgePutTargets {
     }
 
     const added = requested.map((target) => SimEventTarget.of(target));
+
+    refuseRepeatedTargetIds(added);
+
     const busName = rule.busName.value;
     const ruleName = rule.name.value;
 
-    this.refuseOverfullRule(busName, ruleName, added);
+    refuseOverfullRule(
+      ruleName,
+      this.targets.forRule(busName, ruleName),
+      added,
+    );
     this.targets.put(busName, ruleName, added);
 
     return { $metadata: {}, FailedEntryCount: 0, FailedEntries: [] };
-  }
-
-  /**
-   * Refuse a request that would take a rule past the targets it may have.
-   *
-   * Targets already on the rule count, except the ones this request replaces,
-   * so replacing an existing id is the only way past a full rule.
-   */
-  private refuseOverfullRule(
-    busName: string,
-    ruleName: string,
-    added: readonly SimEventTarget[],
-  ): void {
-    const kept = this.targets
-      .forRule(busName, ruleName)
-      .filter((existing) =>
-        added.every((target) => target.id !== existing.id),
-      ).length;
-
-    if (kept + added.length > simEventMaximumTargets) {
-      throw new SimEventBridgeValidationException(
-        `Rule ${ruleName} would have ${String(kept + added.length)} targets, ` +
-          `and a rule has at most ${String(simEventMaximumTargets)}.`,
-      );
-    }
   }
 }

--- a/src/service/eventbridge/command/target/sim-event-bridge-target-commands.iso.test.ts
+++ b/src/service/eventbridge/command/target/sim-event-bridge-target-commands.iso.test.ts
@@ -1,0 +1,264 @@
+import {
+  DeleteRuleCommand,
+  ListRuleNamesByTargetCommand,
+  ListTargetsByRuleCommand,
+  PutRuleCommand,
+  PutTargetsCommand,
+  RemoveTargetsCommand,
+} from "@aws-sdk/client-eventbridge";
+import {
+  assertArrayEquals,
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+
+const orderPattern = JSON.stringify({ source: ["orders.service"] });
+
+const queueArn = "arn:aws:sqs:us-east-1:888888888888:orders";
+
+const topicArn = "arn:aws:sns:us-east-1:888888888888:orders";
+
+/**
+ * A simulated AWS with one rule to hang targets on.
+ */
+async function simAwsWithRule(name = "orders"): Promise<SimAws> {
+  const simAws = new SimAws();
+
+  await simAws
+    .eventBridge()
+    .putRule(new PutRuleCommand({ Name: name, EventPattern: orderPattern }));
+
+  return simAws;
+}
+
+describe("EventBridge target commands", () => {
+  it("adds targets to a rule and lists them in the order they were added", async () => {
+    // Given a rule.
+    const simAws = await simAwsWithRule();
+
+    // When two targets are added.
+    const put = await simAws.eventBridge().putTargets(
+      new PutTargetsCommand({
+        Rule: "orders",
+        Targets: [
+          { Id: "queue", Arn: queueArn },
+          { Id: "topic", Arn: topicArn, Input: '{"note":"placed"}' },
+        ],
+      }),
+    );
+
+    // Then neither failed, and both come back in order.
+    assertIdentical(put.FailedEntryCount, 0);
+
+    const listed = await simAws
+      .eventBridge()
+      .listTargetsByRule(new ListTargetsByRuleCommand({ Rule: "orders" }));
+
+    assertArrayEquals(
+      listed.Targets?.map((target) => target.Id),
+      ["queue", "topic"],
+    );
+    assertIdentical(listed.Targets[1]?.Input, '{"note":"placed"}');
+  });
+
+  it("replaces a target of the same id rather than adding a second", async () => {
+    // Given a rule with a target.
+    const simAws = await simAwsWithRule();
+
+    await simAws.eventBridge().putTargets(
+      new PutTargetsCommand({
+        Rule: "orders",
+        Targets: [{ Id: "main", Arn: queueArn }],
+      }),
+    );
+
+    // When a target of the same id is put with a different ARN.
+    await simAws.eventBridge().putTargets(
+      new PutTargetsCommand({
+        Rule: "orders",
+        Targets: [{ Id: "main", Arn: topicArn }],
+      }),
+    );
+
+    // Then there is still one target, with the new ARN.
+    const listed = await simAws
+      .eventBridge()
+      .listTargetsByRule(new ListTargetsByRuleCommand({ Rule: "orders" }));
+
+    assertArrayLength(listed.Targets ?? [], 1);
+    assertIdentical(listed.Targets?.[0]?.Arn, topicArn);
+  });
+
+  it("removes targets by id, and reports an id the rule does not have", async () => {
+    // Given a rule with one target.
+    const simAws = await simAwsWithRule();
+
+    await simAws.eventBridge().putTargets(
+      new PutTargetsCommand({
+        Rule: "orders",
+        Targets: [{ Id: "main", Arn: queueArn }],
+      }),
+    );
+
+    // When that target and one that was never there are removed.
+    const removed = await simAws.eventBridge().removeTargets(
+      new RemoveTargetsCommand({
+        Rule: "orders",
+        Ids: ["main", "ghost"],
+      }),
+    );
+
+    // Then the real one is gone, and the other is a failed entry rather than
+    // a failed request.
+    assertIdentical(removed.FailedEntryCount, 1);
+    assertIdentical(removed.FailedEntries?.[0]?.TargetId, "ghost");
+    assertArrayLength(simAws.eventBridge().ruleTargets("orders"), 0);
+  });
+
+  it("lists the rules that send to a target", async () => {
+    // Given two rules targeting the same queue and one targeting a topic.
+    const simAws = await simAwsWithRule("orders");
+
+    await simAws
+      .eventBridge()
+      .putRule(
+        new PutRuleCommand({ Name: "audit", EventPattern: orderPattern }),
+      );
+    await simAws
+      .eventBridge()
+      .putRule(
+        new PutRuleCommand({ Name: "notify", EventPattern: orderPattern }),
+      );
+
+    for (const [rule, arn] of [
+      ["orders", queueArn],
+      ["audit", queueArn],
+      ["notify", topicArn],
+    ] as const) {
+      // oxlint-disable-next-line no-await-in-loop
+      await simAws.eventBridge().putTargets(
+        new PutTargetsCommand({
+          Rule: rule,
+          Targets: [{ Id: "main", Arn: arn }],
+        }),
+      );
+    }
+
+    // When the rules sending to the queue are listed.
+    const listed = await simAws
+      .eventBridge()
+      .listRuleNamesByTarget(
+        new ListRuleNamesByTargetCommand({ TargetArn: queueArn }),
+      );
+
+    // Then only the two that name it come back.
+    assertArrayEquals(listed.RuleNames, ["orders", "audit"]);
+  });
+
+  it("takes a rule's targets with it when the rule is deleted", async () => {
+    // Given a rule with a target.
+    const simAws = await simAwsWithRule();
+
+    await simAws.eventBridge().putTargets(
+      new PutTargetsCommand({
+        Rule: "orders",
+        Targets: [{ Id: "main", Arn: queueArn }],
+      }),
+    );
+
+    // When the rule is deleted and recreated under the same name.
+    await simAws
+      .eventBridge()
+      .deleteRule(new DeleteRuleCommand({ Name: "orders" }));
+    await simAws
+      .eventBridge()
+      .putRule(
+        new PutRuleCommand({ Name: "orders", EventPattern: orderPattern }),
+      );
+
+    // Then the new rule has no targets, rather than inheriting the old ones.
+    assertArrayLength(simAws.eventBridge().ruleTargets("orders"), 0);
+  });
+
+  it("keeps the targets of two buses' rules of the same name apart", async () => {
+    // Given a rule of the same name on two buses, each with its own target.
+    const simAws = await simAwsWithRule();
+
+    await simAws.eventBridge().createEventBus({ input: { Name: "billing" } });
+    await simAws.eventBridge().putRule(
+      new PutRuleCommand({
+        Name: "orders",
+        EventBusName: "billing",
+        EventPattern: orderPattern,
+      }),
+    );
+    await simAws.eventBridge().putTargets(
+      new PutTargetsCommand({
+        Rule: "orders",
+        Targets: [{ Id: "default-bus", Arn: queueArn }],
+      }),
+    );
+    await simAws.eventBridge().putTargets(
+      new PutTargetsCommand({
+        Rule: "orders",
+        EventBusName: "billing",
+        Targets: [{ Id: "billing-bus", Arn: topicArn }],
+      }),
+    );
+
+    // Then each rule has only its own.
+    const onDefault = simAws.eventBridge().ruleTargets("orders");
+    const onBilling = simAws.eventBridge().ruleTargets("orders", "billing");
+
+    assertNonNullable(onDefault[0]);
+    assertIdentical(onDefault[0].id, "default-bus");
+    assertNonNullable(onBilling[0]);
+    assertIdentical(onBilling[0].id, "billing-bus");
+  });
+
+  it("lists nothing for a rule with no targets, and removes nothing when asked for nothing", async () => {
+    // Given a rule with no targets.
+    const simAws = await simAwsWithRule();
+
+    // When its targets are listed, and a removal names no ids.
+    const listed = await simAws
+      .eventBridge()
+      .listTargetsByRule(new ListTargetsByRuleCommand({ Rule: "orders" }));
+    const removed = await simAws
+      .eventBridge()
+      .removeTargets(
+        new RemoveTargetsCommand({ Rule: "orders", Ids: undefined }),
+      );
+
+    // Then both are answered rather than refused.
+    assertArrayLength(listed.Targets ?? [], 0);
+    assertIdentical(removed.FailedEntryCount, 0);
+  });
+
+  it("reads the function name out of a qualified Lambda target ARN", async () => {
+    // Given a target ARN carrying a version after the function name.
+    const simAws = await simAwsWithRule();
+
+    await simAws.eventBridge().putTargets(
+      new PutTargetsCommand({
+        Rule: "orders",
+        Targets: [
+          {
+            Id: "fulfilment",
+            Arn: "arn:aws:lambda:us-east-1:888888888888:function:fulfilment:2",
+          },
+        ],
+      }),
+    );
+
+    // Then the name is read without the qualifier, which this simulation does
+    // not model.
+    const [target] = simAws.eventBridge().ruleTargets("orders");
+
+    assertNonNullable(target);
+    assertIdentical(target.arn.functionName, "fulfilment");
+  });
+});

--- a/src/service/eventbridge/command/target/sim-event-bridge-target-commands.ts
+++ b/src/service/eventbridge/command/target/sim-event-bridge-target-commands.ts
@@ -1,0 +1,138 @@
+import { SimEventTargetArn } from "../../target/sim-event-target-arn.js";
+import type { SimEventTargetStore } from "../../target/sim-event-target-store.js";
+import type { SimEventRuleStore } from "../../rule/sim-event-rule-store.js";
+import { SimEventBridgePage } from "../sim-event-bridge-page.js";
+import type { SimEventBridgeRequestOptions } from "../sim-event-bridge-request-options.js";
+import type { SimEventBridgeRuleAccess } from "../rule/sim-event-bridge-rule-access.js";
+import type {
+  SimEventBridgeTarget,
+  SimListRuleNamesByTargetCommand,
+  SimListRuleNamesByTargetCommandOutput,
+  SimListTargetsByRuleCommand,
+  SimListTargetsByRuleCommandOutput,
+  SimRemoveTargetsCommand,
+  SimRemoveTargetsCommandOutput,
+} from "./target.command.js";
+
+interface SimEventBridgeTargetCommandsProperties {
+  readonly rules: SimEventRuleStore;
+  readonly targets: SimEventTargetStore;
+  readonly access: SimEventBridgeRuleAccess;
+}
+
+/**
+ * The commands that remove and list a rule's targets.
+ *
+ * Adding them is its own handler, since PutTargets is the only one of these
+ * with request input to validate and resources to build.
+ *
+ * A rule request names the rule and its bus, so all of these go through the
+ * same rule access as the rule commands, and authorize against the rule's own
+ * ARN.
+ */
+export class SimEventBridgeTargetCommands {
+  private readonly rules: SimEventRuleStore;
+  private readonly targets: SimEventTargetStore;
+  private readonly access: SimEventBridgeRuleAccess;
+
+  constructor(properties: SimEventBridgeTargetCommandsProperties) {
+    this.rules = properties.rules;
+    this.targets = properties.targets;
+    this.access = properties.access;
+  }
+
+  /**
+   * Remove targets from a rule by id.
+   *
+   * An id the rule does not have comes back as a failed entry rather than
+   * failing the request, which is what real EventBridge does.
+   */
+  removeTargets(
+    command: SimRemoveTargetsCommand,
+    options?: SimEventBridgeRequestOptions,
+  ): SimRemoveTargetsCommandOutput {
+    const input = command.input;
+    const rule = this.access.require(
+      "events:RemoveTargets",
+      { Name: input.Rule, EventBusName: input.EventBusName },
+      options,
+    );
+    const missing = this.targets.remove(
+      rule.busName.value,
+      rule.name.value,
+      input.Ids ?? [],
+    );
+
+    return {
+      $metadata: {},
+      FailedEntryCount: missing.length,
+      FailedEntries: missing.map((id) => ({
+        TargetId: id,
+        ErrorCode: "ResourceNotFoundException",
+        ErrorMessage:
+          `Rule ${rule.name.value} does not have a target with ` +
+          `the id ${id}.`,
+      })),
+    };
+  }
+
+  /**
+   * List the targets of a rule, in the order they were added.
+   */
+  listTargetsByRule(
+    command: SimListTargetsByRuleCommand,
+    options?: SimEventBridgeRequestOptions,
+  ): SimListTargetsByRuleCommandOutput {
+    const input = command.input;
+    const rule = this.access.require(
+      "events:ListTargetsByRule",
+      { Name: input.Rule, EventBusName: input.EventBusName },
+      options,
+    );
+    const listed: readonly SimEventBridgeTarget[] = this.targets
+      .forRule(rule.busName.value, rule.name.value)
+      .map((target) => ({
+        Id: target.id,
+        Arn: target.arn.value,
+        Input: target.input,
+      }));
+    const page = new SimEventBridgePage(listed, input.Limit, input.NextToken);
+
+    return {
+      $metadata: {},
+      Targets: page.items,
+      NextToken: page.nextToken,
+    };
+  }
+
+  /**
+   * List the rules of a bus that send events to one target.
+   */
+  listRuleNamesByTarget(
+    command: SimListRuleNamesByTargetCommand,
+    options?: SimEventBridgeRequestOptions,
+  ): SimListRuleNamesByTargetCommandOutput {
+    const input = command.input;
+    const busName = this.access.listedBusName(
+      "events:ListRuleNamesByTarget",
+      input.EventBusName,
+      options,
+    );
+    const targetArn = SimEventTargetArn.of(input.TargetArn);
+    const sending = this.targets.rulesSendingTo(
+      this.rules.forBus(busName),
+      targetArn.value,
+    );
+    const page = new SimEventBridgePage(
+      sending.map((rule) => rule.name.value),
+      input.Limit,
+      input.NextToken,
+    );
+
+    return {
+      $metadata: {},
+      RuleNames: page.items,
+      NextToken: page.nextToken,
+    };
+  }
+}

--- a/src/service/eventbridge/command/target/sim-event-bridge-target-refusals.ts
+++ b/src/service/eventbridge/command/target/sim-event-bridge-target-refusals.ts
@@ -1,0 +1,54 @@
+import { SimEventBridgeValidationException } from "../../error/sim-event-bridge.error.js";
+import type { SimEventTarget } from "../../target/sim-event-target.js";
+import { simEventMaximumTargets } from "../../target/sim-event-target-store.js";
+
+/**
+ * Refuse a request naming one target id twice.
+ *
+ * Putting both would leave the rule with two targets of one id, which is not a
+ * state PutTargets can otherwise reach: a second request for an id replaces
+ * the first. The rule would then deliver twice, and a single RemoveTargets
+ * would take both away.
+ */
+export function refuseRepeatedTargetIds(
+  added: readonly SimEventTarget[],
+): void {
+  const seen = new Set<string>();
+  const repeated = added.find((target) => {
+    const alreadySeen = seen.has(target.id);
+
+    seen.add(target.id);
+
+    return alreadySeen;
+  });
+
+  if (repeated !== undefined) {
+    throw new SimEventBridgeValidationException(
+      `Invalid parameter: Targets Reason: the target id ${repeated.id} is ` +
+        `named twice in one request, and a rule has one target per id`,
+    );
+  }
+}
+
+/**
+ * Refuse a request that would take a rule past the targets it may have.
+ *
+ * Targets already on the rule count, except the ones this request replaces, so
+ * replacing an existing id is the only way past a full rule.
+ */
+export function refuseOverfullRule(
+  ruleName: string,
+  existing: readonly SimEventTarget[],
+  added: readonly SimEventTarget[],
+): void {
+  const kept = existing.filter((target) =>
+    added.every((replacement) => replacement.id !== target.id),
+  ).length;
+
+  if (kept + added.length > simEventMaximumTargets) {
+    throw new SimEventBridgeValidationException(
+      `Rule ${ruleName} would have ${String(kept + added.length)} targets, ` +
+        `and a rule has at most ${String(simEventMaximumTargets)}.`,
+    );
+  }
+}

--- a/src/service/eventbridge/command/target/sim-event-bridge-target-validation.iso.test.ts
+++ b/src/service/eventbridge/command/target/sim-event-bridge-target-validation.iso.test.ts
@@ -1,0 +1,175 @@
+import {
+  PutRuleCommand,
+  PutTargetsCommand,
+  type Target,
+} from "@aws-sdk/client-eventbridge";
+import {
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import {
+  SimEventBridgeUnsimulatedInputException,
+  SimEventBridgeValidationException,
+} from "../../error/sim-event-bridge.error.js";
+
+const orderPattern = JSON.stringify({ source: ["orders.service"] });
+
+const queueArn = "arn:aws:sqs:us-east-1:888888888888:orders";
+
+/**
+ * Try to add targets to a rule, and answer with what it was refused with.
+ */
+async function refusedTargets(targets: readonly Target[]): Promise<Error> {
+  const simAws = new SimAws();
+
+  await simAws
+    .eventBridge()
+    .putRule(
+      new PutRuleCommand({ Name: "orders", EventPattern: orderPattern }),
+    );
+
+  return await assertThrowsErrorAsync(async () => {
+    await simAws
+      .eventBridge()
+      .putTargets(
+        new PutTargetsCommand({ Rule: "orders", Targets: [...targets] }),
+      );
+  });
+}
+
+describe("EventBridge target validation", () => {
+  it("refuses a target naming a service it cannot deliver to", async () => {
+    // Given a target naming a Step Functions state machine.
+    const error = await refusedTargets([
+      {
+        Id: "workflow",
+        Arn: "arn:aws:states:us-east-1:888888888888:stateMachine:orders",
+      },
+    ]);
+
+    // Then it is refused when the target is added rather than when an event
+    // first matches, and it names what can be delivered to.
+    assertInstanceOf(error, SimEventBridgeValidationException);
+    assertStringIncludes(error.message, "lambda, sqs, sns");
+  });
+
+  it("refuses a target ARN that is not an ARN", async () => {
+    const error = await refusedTargets([{ Id: "queue", Arn: "orders" }]);
+
+    assertInstanceOf(error, SimEventBridgeValidationException);
+    assertStringIncludes(error.message, "is not an ARN");
+  });
+
+  it("refuses a target with no id or no ARN", async () => {
+    const noId = await refusedTargets([{ Id: undefined, Arn: queueArn }]);
+    const noArn = await refusedTargets([{ Id: "queue", Arn: undefined }]);
+
+    assertInstanceOf(noId, SimEventBridgeValidationException);
+    assertStringIncludes(noId.message, "Target Id is required");
+    assertInstanceOf(noArn, SimEventBridgeValidationException);
+    assertStringIncludes(noArn.message, "Target Arn is required");
+  });
+
+  it("refuses a target id real EventBridge would refuse", async () => {
+    const error = await refusedTargets([{ Id: "orders queue", Arn: queueArn }]);
+
+    assertInstanceOf(error, SimEventBridgeValidationException);
+    assertStringIncludes(error.message, "orders queue");
+  });
+
+  it("refuses an input that is not JSON, when the target is added", async () => {
+    // Given a target whose fixed input could never be sent.
+    const error = await refusedTargets([
+      { Id: "queue", Arn: queueArn, Input: "not json" },
+    ]);
+
+    // Then it is refused here rather than failing every delivery later.
+    assertInstanceOf(error, SimEventBridgeValidationException);
+    assertStringIncludes(error.message, "not valid JSON");
+  });
+
+  it("refuses a request carrying no targets", async () => {
+    const error = await refusedTargets([]);
+
+    assertInstanceOf(error, SimEventBridgeValidationException);
+  });
+
+  it("refuses more targets than a rule may have", async () => {
+    // Given six targets where a rule takes five.
+    const error = await refusedTargets(
+      Array.from({ length: 6 }, (_, index) => ({
+        Id: `target-${String(index)}`,
+        Arn: queueArn,
+      })),
+    );
+
+    assertInstanceOf(error, SimEventBridgeValidationException);
+    assertStringIncludes(error.message, "at most 5");
+  });
+
+  it("counts the targets a rule already has against the limit", async () => {
+    // Given a rule already at the limit.
+    const simAws = new SimAws();
+
+    await simAws
+      .eventBridge()
+      .putRule(
+        new PutRuleCommand({ Name: "orders", EventPattern: orderPattern }),
+      );
+    await simAws.eventBridge().putTargets(
+      new PutTargetsCommand({
+        Rule: "orders",
+        Targets: Array.from({ length: 5 }, (_, index) => ({
+          Id: `target-${String(index)}`,
+          Arn: queueArn,
+        })),
+      }),
+    );
+
+    // When one more is added.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.eventBridge().putTargets(
+        new PutTargetsCommand({
+          Rule: "orders",
+          Targets: [{ Id: "one-more", Arn: queueArn }],
+        }),
+      );
+    });
+
+    // Then it is refused, since replacing an existing id is the only way to
+    // put a sixth request through.
+    assertInstanceOf(error, SimEventBridgeValidationException);
+  });
+
+  it("refuses target properties it does not model rather than dropping them", async () => {
+    // Given targets carrying each unmodelled property in turn.
+    const unmodelled: readonly Target[] = [
+      { Id: "t", Arn: queueArn, InputPath: "$.detail" },
+      {
+        Id: "t",
+        Arn: queueArn,
+        InputTransformer: { InputTemplate: '{"id": <id>}' },
+      },
+      { Id: "t", Arn: queueArn, RoleArn: "arn:aws:iam::888888888888:role/R" },
+      {
+        Id: "t",
+        Arn: queueArn,
+        DeadLetterConfig: { Arn: "arn:aws:sqs:us-east-1:888888888888:dlq" },
+      },
+      { Id: "t", Arn: queueArn, RetryPolicy: { MaximumRetryAttempts: 2 } },
+      { Id: "t", Arn: queueArn, SqsParameters: { MessageGroupId: "orders" } },
+      { Id: "t", Arn: queueArn, HttpParameters: { PathParameterValues: [] } },
+    ];
+
+    // Then each is refused, so nothing looks configured that is not.
+    for (const target of unmodelled) {
+      // oxlint-disable-next-line no-await-in-loop
+      const error = await refusedTargets([target]);
+
+      assertInstanceOf(error, SimEventBridgeUnsimulatedInputException);
+    }
+  });
+});

--- a/src/service/eventbridge/command/target/sim-event-bridge-target-validation.iso.test.ts
+++ b/src/service/eventbridge/command/target/sim-event-bridge-target-validation.iso.test.ts
@@ -172,4 +172,31 @@ describe("EventBridge target validation", () => {
       assertInstanceOf(error, SimEventBridgeUnsimulatedInputException);
     }
   });
+
+  it("refuses a request naming one target id twice", async () => {
+    // Given two targets in one request sharing an id.
+    const error = await refusedTargets([
+      { Id: "main", Arn: queueArn },
+      { Id: "main", Arn: "arn:aws:sns:us-east-1:888888888888:orders" },
+    ]);
+
+    // Then it is refused rather than leaving the rule with two targets of one
+    // id, which would deliver twice and be removed by a single RemoveTargets.
+    assertInstanceOf(error, SimEventBridgeValidationException);
+    assertStringIncludes(error.message, "named twice");
+  });
+
+  it("refuses an ARN whose parts are there but empty", async () => {
+    // Given ARNs with the right number of parts and nothing in them.
+    const empty = await refusedTargets([{ Id: "q", Arn: "arn:aws:sqs:::" }]);
+    const noName = await refusedTargets([
+      { Id: "f", Arn: "arn:aws:lambda:us-east-1:888888888888:function" },
+    ]);
+
+    // Then both are refused when the target is added, rather than failing
+    // every delivery later.
+    assertInstanceOf(empty, SimEventBridgeValidationException);
+    assertInstanceOf(noName, SimEventBridgeValidationException);
+    assertStringIncludes(noName.message, "names no function");
+  });
 });

--- a/src/service/eventbridge/command/target/sim-event-bridge-unsimulated-target-input.ts
+++ b/src/service/eventbridge/command/target/sim-event-bridge-unsimulated-target-input.ts
@@ -1,0 +1,94 @@
+import { SimEventBridgeUnsimulatedInputException } from "../../error/sim-event-bridge.error.js";
+import type { SimEventBridgeTarget } from "./target.command.js";
+
+/**
+ * One target property this simulation does not model, read straight off the
+ * target rather than by key, and what refusing it should say.
+ */
+type SimEventBridgeTargetRefusal = readonly [
+  (target: SimEventBridgeTarget) => unknown,
+  string,
+];
+
+/**
+ * The properties that change what a target receives, or whether it receives
+ * anything at all.
+ *
+ * Ignoring one would leave a test believing in a transformation, a retry or a
+ * dead letter queue that never happened.
+ */
+const behaviourRefusals: readonly SimEventBridgeTargetRefusal[] = [
+  [
+    (target): unknown => target.InputPath,
+    "Target InputPath is not simulated, so PutTargets refuses one rather " +
+      "than sending the whole event where a part of it was asked for",
+  ],
+  [
+    (target): unknown => target.InputTransformer,
+    "Target InputTransformer is not simulated, so PutTargets refuses one " +
+      "rather than sending the untransformed event",
+  ],
+  [
+    (target): unknown => target.RoleArn,
+    "A target RoleArn is not simulated. A rule reaches its target as the " +
+      "events.amazonaws.com service principal, which the target's own " +
+      "resource policy admits.",
+  ],
+  [
+    (target): unknown => target.DeadLetterConfig,
+    "Target dead letter queues are not simulated, so PutTargets refuses a " +
+      "DeadLetterConfig rather than dropping undelivered events silently",
+  ],
+  [
+    (target): unknown => target.RetryPolicy,
+    "Target retry policies are not simulated, so PutTargets refuses a " +
+      "RetryPolicy rather than delivering once and calling it retried",
+  ],
+  [
+    (target): unknown => target.SqsParameters,
+    "SqsParameters names a FIFO queue's message group, and FIFO queues are " +
+      "not simulated",
+  ],
+];
+
+/**
+ * The per-service parameters of the target types this does not deliver to.
+ *
+ * A target ARN naming one of these services is already refused when the target
+ * is added, so these only catch a request that named the parameters without
+ * the matching ARN. They share one message, since there is one reason.
+ */
+const unsimulatedTargetTypes: readonly (readonly [
+  (target: SimEventBridgeTarget) => unknown,
+  string,
+])[] = [
+  [(target): unknown => target.KinesisParameters, "Kinesis"],
+  [(target): unknown => target.EcsParameters, "ECS"],
+  [(target): unknown => target.BatchParameters, "Batch"],
+  [(target): unknown => target.HttpParameters, "API destination"],
+  [(target): unknown => target.RunCommandParameters, "Run Command"],
+  [(target): unknown => target.RedshiftDataParameters, "Redshift Data"],
+  [(target): unknown => target.SageMakerPipelineParameters, "SageMaker"],
+  [(target): unknown => target.AppSyncParameters, "AppSync"],
+];
+
+/**
+ * Refuse the target request inputs this simulation does not model.
+ */
+export function refuseUnsimulatedTargetInput(
+  target: SimEventBridgeTarget,
+): void {
+  for (const [read, message] of behaviourRefusals) {
+    if (read(target) !== undefined) {
+      throw new SimEventBridgeUnsimulatedInputException(message);
+    }
+  }
+
+  for (const [read, name] of unsimulatedTargetTypes) {
+    if (read(target) !== undefined) {
+      throw new SimEventBridgeUnsimulatedInputException(
+        `${name} targets are not simulated`,
+      );
+    }
+  }
+}

--- a/src/service/eventbridge/command/target/target.command.ts
+++ b/src/service/eventbridge/command/target/target.command.ts
@@ -1,0 +1,124 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+
+/**
+ * One target as a request carries it, and as ListTargetsByRule reports it.
+ *
+ * The properties beyond `Id`, `Arn` and `Input` are the ones real EventBridge
+ * takes and this simulation refuses, kept in the shape so a request carrying
+ * one is recognised and named rather than ignored.
+ */
+export interface SimEventBridgeTarget {
+  readonly Id?: string | undefined;
+  readonly Arn?: string | undefined;
+  readonly Input?: string | undefined;
+  readonly InputPath?: string | undefined;
+  readonly InputTransformer?: object | undefined;
+  readonly RoleArn?: string | undefined;
+  readonly DeadLetterConfig?: object | undefined;
+  readonly RetryPolicy?: object | undefined;
+  readonly SqsParameters?: object | undefined;
+  readonly KinesisParameters?: object | undefined;
+  readonly EcsParameters?: object | undefined;
+  readonly BatchParameters?: object | undefined;
+  readonly HttpParameters?: object | undefined;
+  readonly RunCommandParameters?: object | undefined;
+  readonly RedshiftDataParameters?: object | undefined;
+  readonly SageMakerPipelineParameters?: object | undefined;
+  readonly AppSyncParameters?: object | undefined;
+}
+
+/**
+ * One target a request could not add or remove, and why.
+ */
+export interface SimEventBridgeTargetFailure {
+  readonly TargetId?: string | undefined;
+  readonly ErrorCode?: string | undefined;
+  readonly ErrorMessage?: string | undefined;
+}
+
+/**
+ * Minimal structural sim EventBridge PutTargets command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/eventbridge/command/PutTargetsCommand/
+ */
+export interface SimPutTargetsCommand {
+  readonly input: SimPutTargetsCommandInput;
+}
+
+export interface SimPutTargetsCommandInput {
+  readonly Rule?: string | undefined;
+  readonly EventBusName?: string | undefined;
+  readonly Targets?: readonly SimEventBridgeTarget[] | undefined;
+}
+
+export interface SimPutTargetsCommandOutput {
+  readonly FailedEntryCount?: number | undefined;
+  readonly FailedEntries?: readonly SimEventBridgeTargetFailure[] | undefined;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim EventBridge RemoveTargets command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/eventbridge/command/RemoveTargetsCommand/
+ */
+export interface SimRemoveTargetsCommand {
+  readonly input: SimRemoveTargetsCommandInput;
+}
+
+export interface SimRemoveTargetsCommandInput {
+  readonly Rule?: string | undefined;
+  readonly EventBusName?: string | undefined;
+  readonly Ids?: readonly string[] | undefined;
+  readonly Force?: boolean | undefined;
+}
+
+export interface SimRemoveTargetsCommandOutput {
+  readonly FailedEntryCount?: number | undefined;
+  readonly FailedEntries?: readonly SimEventBridgeTargetFailure[] | undefined;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim EventBridge ListTargetsByRule command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/eventbridge/command/ListTargetsByRuleCommand/
+ */
+export interface SimListTargetsByRuleCommand {
+  readonly input: SimListTargetsByRuleCommandInput;
+}
+
+export interface SimListTargetsByRuleCommandInput {
+  readonly Rule?: string | undefined;
+  readonly EventBusName?: string | undefined;
+  readonly Limit?: number | undefined;
+  readonly NextToken?: string | undefined;
+}
+
+export interface SimListTargetsByRuleCommandOutput {
+  readonly Targets?: readonly SimEventBridgeTarget[] | undefined;
+  readonly NextToken?: string | undefined;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim EventBridge ListRuleNamesByTarget command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/eventbridge/command/ListRuleNamesByTargetCommand/
+ */
+export interface SimListRuleNamesByTargetCommand {
+  readonly input: SimListRuleNamesByTargetCommandInput;
+}
+
+export interface SimListRuleNamesByTargetCommandInput {
+  readonly TargetArn?: string | undefined;
+  readonly EventBusName?: string | undefined;
+  readonly Limit?: number | undefined;
+  readonly NextToken?: string | undefined;
+}
+
+export interface SimListRuleNamesByTargetCommandOutput {
+  readonly RuleNames?: readonly string[] | undefined;
+  readonly NextToken?: string | undefined;
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/eventbridge/delivery/sim-aws-event-bridge-delivery-targets.ts
+++ b/src/service/eventbridge/delivery/sim-aws-event-bridge-delivery-targets.ts
@@ -1,0 +1,70 @@
+import type { SimAws } from "../../aws/sim-aws.js";
+import type {
+  SimEventBridgeDeliveryRequest,
+  SimEventBridgeDeliveryTargets,
+} from "./sim-event-bridge-delivery.js";
+import { SimEventBridgeDeliveryFunction } from "./sim-event-bridge-delivery-function.js";
+import { SimEventBridgeDeliveryQueue } from "./sim-event-bridge-delivery-queue.js";
+import { SimEventBridgeDeliveryTopic } from "./sim-event-bridge-delivery-topic.js";
+import type { SimEventTargetService } from "../target/sim-event-target-arn.js";
+
+interface SimAwsEventBridgeDeliveryTargetsProperties {
+  readonly simAws: SimAws;
+}
+
+/**
+ * Everywhere the rules of one simulated AWS instance can send events.
+ *
+ * The target is looked up when an event is delivered, never when this is
+ * built: reaching another service while this one is being constructed is a
+ * cycle with no bottom to it.
+ *
+ * A target in another Account or Region is allowed, since real EventBridge
+ * delivers to both, and it is the target's own Account that decides whether
+ * the delivery is permitted.
+ */
+export class SimAwsEventBridgeDeliveryTargets implements SimEventBridgeDeliveryTargets {
+  private readonly simAws: SimAws;
+
+  constructor(properties: SimAwsEventBridgeDeliveryTargetsProperties) {
+    this.simAws = properties.simAws;
+  }
+
+  /**
+   * Send one event to the target its ARN names.
+   */
+  async deliver(request: SimEventBridgeDeliveryRequest): Promise<void> {
+    const arn = request.target.arn;
+    const scope = this.simAws.accountRegionScope(arn.accountId, arn.regionName);
+
+    await this.deliverTo(arn.service, { request, scope });
+  }
+
+  /**
+   * Hand the delivery to the one destination that knows this service.
+   */
+  private async deliverTo(
+    service: SimEventTargetService,
+    delivery: {
+      readonly request: SimEventBridgeDeliveryRequest;
+      readonly scope: ReturnType<SimAws["accountRegionScope"]>;
+    },
+  ): Promise<void> {
+    const { request, scope } = delivery;
+
+    switch (service) {
+      case "lambda": {
+        await new SimEventBridgeDeliveryFunction({ scope }).deliver(request);
+        return;
+      }
+      case "sqs": {
+        await new SimEventBridgeDeliveryQueue({ scope }).deliver(request);
+        return;
+      }
+      case "sns": {
+        await new SimEventBridgeDeliveryTopic({ scope }).deliver(request);
+        return;
+      }
+    }
+  }
+}

--- a/src/service/eventbridge/delivery/sim-event-bridge-cross-account-delivery.iso.test.ts
+++ b/src/service/eventbridge/delivery/sim-event-bridge-cross-account-delivery.iso.test.ts
@@ -1,0 +1,276 @@
+import {
+  PutEventsCommand,
+  PutRuleCommand,
+  PutTargetsCommand,
+} from "@aws-sdk/client-eventbridge";
+import { AddPermissionCommand } from "@aws-sdk/client-lambda";
+import {
+  CreateQueueCommand,
+  ReceiveMessageCommand,
+  SetQueueAttributesCommand,
+} from "@aws-sdk/client-sqs";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../aws/sim-aws.js";
+import { makeLambdaZipFileInput } from "../../lambda/index.js";
+
+const ruleAccount = "111111111111";
+
+const targetAccount = "222222222222";
+
+const orderPattern = JSON.stringify({ source: ["orders.service"] });
+
+/**
+ * The ARN the rule below has, which a target's policy is conditioned on.
+ */
+const ruleArn = `arn:aws:events:us-east-1:${ruleAccount}:rule/orders`;
+
+/**
+ * A policy admitting EventBridge to one resource, for one rule.
+ */
+function policyForRule(
+  action: string,
+  resource: string,
+  sourceArn = ruleArn,
+): string {
+  return JSON.stringify({
+    Version: "2012-10-17",
+    Statement: [
+      {
+        Effect: "Allow",
+        Principal: { Service: "events.amazonaws.com" },
+        Action: action,
+        Resource: resource,
+        Condition: { ArnLike: { "aws:SourceArn": sourceArn } },
+      },
+    ],
+  });
+}
+
+/**
+ * Put an order event through a rule in the rule Account, with one target.
+ */
+async function deliverAcross(
+  simAws: SimAws,
+  target: { readonly Id: string; readonly Arn: string },
+): Promise<void> {
+  const events = simAws.account(ruleAccount).region("us-east-1").eventBridge();
+
+  await events.putRule(
+    new PutRuleCommand({ Name: "orders", EventPattern: orderPattern }),
+  );
+  await events.putTargets(
+    new PutTargetsCommand({ Rule: "orders", Targets: [target] }),
+  );
+  await events.putEvents(
+    new PutEventsCommand({
+      Entries: [
+        {
+          Source: "orders.service",
+          DetailType: "OrderPlaced",
+          Detail: JSON.stringify({ orderId: "order-1" }),
+        },
+      ],
+    }),
+  );
+
+  await simAws.backgroundTasksComplete();
+}
+
+describe("EventBridge delivery across Accounts and Regions", () => {
+  it("sends an event to a queue in another Account that admits the rule", async () => {
+    // Given a queue in a second Account, whose policy admits EventBridge for
+    // the first Account's rule.
+    const simAws = new SimAws();
+    const queueArn = `arn:aws:sqs:us-east-1:${targetAccount}:orders`;
+    const targetSqs = simAws.account(targetAccount).region("us-east-1").sqs();
+
+    const queue = await targetSqs.createQueue(
+      new CreateQueueCommand({ QueueName: "orders" }),
+    );
+
+    await targetSqs.setQueueAttributes(
+      new SetQueueAttributesCommand({
+        QueueUrl: queue.QueueUrl,
+        Attributes: { Policy: policyForRule("sqs:SendMessage", queueArn) },
+      }),
+    );
+
+    // When a rule in the first Account targets it.
+    await deliverAcross(simAws, { Id: "orders-queue", Arn: queueArn });
+
+    // Then the queue in the other Account received the event.
+    const received = await targetSqs.receiveMessage(
+      new ReceiveMessageCommand({ QueueUrl: queue.QueueUrl }),
+    );
+
+    assertArrayLength(received.Messages ?? [], 1);
+
+    const event = JSON.parse(String(received.Messages?.[0]?.Body)) as {
+      account: string;
+    };
+
+    // And the event still names the Account it was put in, not the target's.
+    assertIdentical(event.account, ruleAccount);
+  });
+
+  it("refuses a queue in another Account whose policy does not name the rule", async () => {
+    // Given a queue in a second Account admitting a different rule.
+    const simAws = new SimAws();
+    const queueArn = `arn:aws:sqs:us-east-1:${targetAccount}:orders`;
+    const targetSqs = simAws.account(targetAccount).region("us-east-1").sqs();
+
+    const queue = await targetSqs.createQueue(
+      new CreateQueueCommand({ QueueName: "orders" }),
+    );
+
+    await targetSqs.setQueueAttributes(
+      new SetQueueAttributesCommand({
+        QueueUrl: queue.QueueUrl,
+        Attributes: {
+          Policy: policyForRule(
+            "sqs:SendMessage",
+            queueArn,
+            `arn:aws:events:us-east-1:${ruleAccount}:rule/something-else`,
+          ),
+        },
+      }),
+    );
+
+    // When the orders rule targets it.
+    await deliverAcross(simAws, { Id: "orders-queue", Arn: queueArn });
+
+    // Then the delivery is refused, because the condition names another rule.
+    const [failure] = simAws
+      .account(ruleAccount)
+      .region("us-east-1")
+      .eventBridge().deliveryFailures;
+
+    const received = await targetSqs.receiveMessage(
+      new ReceiveMessageCommand({ QueueUrl: queue.QueueUrl }),
+    );
+
+    assertNonNullable(failure);
+    assertStringIncludes(failure.message, "does not allow");
+    assertArrayLength(received.Messages ?? [], 0);
+  });
+
+  it("invokes a function in another Account that granted the rule", async () => {
+    // Given a function in a second Account with an AddPermission grant.
+    const simAws = new SimAws();
+    const received: unknown[] = [];
+    const targetLambda = simAws
+      .account(targetAccount)
+      .region("us-east-1")
+      .lambda();
+
+    await targetLambda.createFunction({
+      input: {
+        FunctionName: "fulfilment",
+        Role: `arn:aws:iam::${targetAccount}:role/FulfilmentRole`,
+        Code: {
+          ZipFile: makeLambdaZipFileInput((event: unknown) => {
+            received.push(event);
+            return { ok: true };
+          }),
+        },
+      },
+    });
+
+    await targetLambda.addPermission(
+      new AddPermissionCommand({
+        FunctionName: "fulfilment",
+        StatementId: "events",
+        Action: "lambda:InvokeFunction",
+        Principal: "events.amazonaws.com",
+        SourceArn: ruleArn,
+      }),
+    );
+
+    // When a rule in the first Account targets it.
+    await deliverAcross(simAws, {
+      Id: "fulfilment",
+      Arn: `arn:aws:lambda:us-east-1:${targetAccount}:function:fulfilment`,
+    });
+
+    // Then the function in the other Account ran.
+    assertArrayLength(received, 1);
+  });
+
+  it("sends an event to a queue in another Region of the same Account", async () => {
+    // Given a queue in another Region.
+    const simAws = new SimAws();
+    const queueArn = `arn:aws:sqs:eu-west-2:${ruleAccount}:orders`;
+    const targetSqs = simAws.account(ruleAccount).region("eu-west-2").sqs();
+
+    const queue = await targetSqs.createQueue(
+      new CreateQueueCommand({ QueueName: "orders" }),
+    );
+
+    await targetSqs.setQueueAttributes(
+      new SetQueueAttributesCommand({
+        QueueUrl: queue.QueueUrl,
+        Attributes: { Policy: policyForRule("sqs:SendMessage", queueArn) },
+      }),
+    );
+
+    // When a rule in us-east-1 targets it.
+    await deliverAcross(simAws, { Id: "orders-queue", Arn: queueArn });
+
+    // Then the queue in the other Region received the event.
+    const received = await targetSqs.receiveMessage(
+      new ReceiveMessageCommand({ QueueUrl: queue.QueueUrl }),
+    );
+
+    assertArrayLength(received.Messages ?? [], 1);
+  });
+
+  it("admits a rule by the Account it belongs to", async () => {
+    // Given a queue admitting EventBridge for any rule of the first Account,
+    // which is the other condition AWS pairs with the source ARN.
+    const simAws = new SimAws();
+    const queueArn = `arn:aws:sqs:us-east-1:${targetAccount}:orders`;
+    const targetSqs = simAws.account(targetAccount).region("us-east-1").sqs();
+
+    const queue = await targetSqs.createQueue(
+      new CreateQueueCommand({ QueueName: "orders" }),
+    );
+
+    await targetSqs.setQueueAttributes(
+      new SetQueueAttributesCommand({
+        QueueUrl: queue.QueueUrl,
+        Attributes: {
+          Policy: JSON.stringify({
+            Version: "2012-10-17",
+            Statement: [
+              {
+                Effect: "Allow",
+                Principal: { Service: "events.amazonaws.com" },
+                Action: "sqs:SendMessage",
+                Resource: queueArn,
+                Condition: {
+                  StringEquals: { "aws:SourceAccount": ruleAccount },
+                },
+              },
+            ],
+          }),
+        },
+      }),
+    );
+
+    // When a rule in that Account targets it.
+    await deliverAcross(simAws, { Id: "orders-queue", Arn: queueArn });
+
+    // Then the delivery is admitted by the Account condition alone.
+    const received = await targetSqs.receiveMessage(
+      new ReceiveMessageCommand({ QueueUrl: queue.QueueUrl }),
+    );
+
+    assertArrayLength(received.Messages ?? [], 1);
+  });
+});

--- a/src/service/eventbridge/delivery/sim-event-bridge-delivery-failure.iso.test.ts
+++ b/src/service/eventbridge/delivery/sim-event-bridge-delivery-failure.iso.test.ts
@@ -1,0 +1,25 @@
+import { assertIdentical } from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimEventBridgeDeliveryFailures } from "./sim-event-bridge-delivery-failures.js";
+
+describe("EventBridge delivery failure", () => {
+  it("reads a message off whatever the delivery threw", () => {
+    // Given deliveries that failed with an Error and with something else.
+    const failures = new SimEventBridgeDeliveryFailures();
+    const recorded = {
+      ruleName: "orders",
+      ruleArn: "arn:aws:events:us-east-1:888888888888:rule/orders",
+      targetId: "queue",
+      targetArn: "arn:aws:sqs:us-east-1:888888888888:orders",
+      eventId: "0f2c9d6e",
+    };
+
+    failures.record({ ...recorded, error: new Error("the queue said no") });
+    failures.record({ ...recorded, error: "the queue said no, rudely" });
+
+    // Then both read as a message, so a test asserting on one does not have to
+    // know what a target threw.
+    assertIdentical(failures.all[0]?.message, "the queue said no");
+    assertIdentical(failures.all[1]?.message, "the queue said no, rudely");
+  });
+});

--- a/src/service/eventbridge/delivery/sim-event-bridge-delivery-failures.iso.test.ts
+++ b/src/service/eventbridge/delivery/sim-event-bridge-delivery-failures.iso.test.ts
@@ -1,0 +1,260 @@
+import {
+  PutEventsCommand,
+  PutRuleCommand,
+  PutTargetsCommand,
+} from "@aws-sdk/client-eventbridge";
+import { CreateTopicCommand, SubscribeCommand } from "@aws-sdk/client-sns";
+import {
+  CreateQueueCommand,
+  ReceiveMessageCommand,
+  SetQueueAttributesCommand,
+} from "@aws-sdk/client-sqs";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../aws/sim-aws.js";
+import { SimEventBridge } from "../sim-event-bridge.js";
+import { makeLambdaZipFileInput } from "../../lambda/index.js";
+
+const orderPattern = JSON.stringify({ source: ["orders.service"] });
+
+/**
+ * A policy admitting one service principal to one resource for one action.
+ */
+function policyAdmittingEvents(action: string, resource: string): string {
+  return JSON.stringify({
+    Version: "2012-10-17",
+    Statement: [
+      {
+        Effect: "Allow",
+        Principal: { Service: "events.amazonaws.com" },
+        Action: action,
+        Resource: resource,
+      },
+    ],
+  });
+}
+
+/**
+ * A rule with one target, and one order event put through it.
+ */
+async function deliverOrderTo(
+  simAws: SimAws,
+  target: { readonly Id: string; readonly Arn: string },
+): Promise<void> {
+  await simAws
+    .eventBridge()
+    .putRule(
+      new PutRuleCommand({ Name: "orders", EventPattern: orderPattern }),
+    );
+  await simAws
+    .eventBridge()
+    .putTargets(new PutTargetsCommand({ Rule: "orders", Targets: [target] }));
+  await simAws.eventBridge().putEvents(
+    new PutEventsCommand({
+      Entries: [
+        {
+          Source: "orders.service",
+          DetailType: "OrderPlaced",
+          Detail: "{}",
+        },
+      ],
+    }),
+  );
+
+  await simAws.backgroundTasksComplete();
+}
+
+describe("EventBridge delivery to topics and its failures", () => {
+  it("publishes a matched event to a topic target, which fans out", async () => {
+    // Given a topic admitting EventBridge, with a queue subscribed to it.
+    const simAws = new SimAws();
+    const topicArn = "arn:aws:sns:us-east-1:888888888888:orders";
+    const queueArn = "arn:aws:sqs:us-east-1:888888888888:inbox";
+
+    await simAws.sns().createTopic(
+      new CreateTopicCommand({
+        Name: "orders",
+        Attributes: { Policy: policyAdmittingEvents("sns:Publish", topicArn) },
+      }),
+    );
+
+    const queue = await simAws
+      .sqs()
+      .createQueue(new CreateQueueCommand({ QueueName: "inbox" }));
+
+    await simAws.sqs().setQueueAttributes(
+      new SetQueueAttributesCommand({
+        QueueUrl: queue.QueueUrl,
+        Attributes: {
+          Policy: JSON.stringify({
+            Version: "2012-10-17",
+            Statement: [
+              {
+                Effect: "Allow",
+                Principal: { Service: "sns.amazonaws.com" },
+                Action: "sqs:SendMessage",
+                Resource: queueArn,
+              },
+            ],
+          }),
+        },
+      }),
+    );
+
+    await simAws.sns().subscribe(
+      new SubscribeCommand({
+        TopicArn: topicArn,
+        Protocol: "sqs",
+        Endpoint: queueArn,
+      }),
+    );
+
+    // When a matching event is put.
+    await deliverOrderTo(simAws, { Id: "topic", Arn: topicArn });
+
+    // Then the subscribed queue got the event inside SNS's own envelope.
+    const received = await simAws
+      .sqs()
+      .receiveMessage(new ReceiveMessageCommand({ QueueUrl: queue.QueueUrl }));
+
+    assertArrayLength(received.Messages ?? [], 1);
+
+    const envelope = JSON.parse(String(received.Messages?.[0]?.Body)) as {
+      Message: string;
+    };
+    const event = JSON.parse(envelope.Message) as { source: string };
+
+    assertIdentical(event.source, "orders.service");
+  });
+
+  it("records a topic target whose policy refuses EventBridge", async () => {
+    // Given a topic with no policy admitting EventBridge.
+    const simAws = new SimAws();
+
+    await simAws.sns().createTopic(new CreateTopicCommand({ Name: "orders" }));
+
+    // When a matching event is put.
+    await deliverOrderTo(simAws, {
+      Id: "topic",
+      Arn: "arn:aws:sns:us-east-1:888888888888:orders",
+    });
+
+    // Then the refusal is recorded, naming what to grant.
+    const [failure] = simAws.eventBridge().deliveryFailures;
+
+    assertNonNullable(failure);
+    assertStringIncludes(failure.message, "sns:Publish");
+  });
+
+  it("records a topic target that names nothing", async () => {
+    // Given a rule targeting a topic that was never created.
+    const simAws = new SimAws();
+
+    await deliverOrderTo(simAws, {
+      Id: "topic",
+      Arn: "arn:aws:sns:us-east-1:888888888888:nowhere",
+    });
+
+    const [failure] = simAws.eventBridge().deliveryFailures;
+
+    assertNonNullable(failure);
+    assertStringIncludes(failure.message, "is not a simulated SNS topic");
+  });
+
+  it("records a Lambda target that names nothing, and one that refuses", async () => {
+    // Given a function with no permission for EventBridge, and a name that is
+    // not a function at all.
+    const simAws = new SimAws();
+
+    await simAws.lambda().createFunction({
+      input: {
+        FunctionName: "fulfilment",
+        Role: "arn:aws:iam::888888888888:role/FulfilmentRole",
+        Code: { ZipFile: makeLambdaZipFileInput(() => ({ ok: true })) },
+      },
+    });
+
+    await simAws
+      .eventBridge()
+      .putRule(
+        new PutRuleCommand({ Name: "orders", EventPattern: orderPattern }),
+      );
+    await simAws.eventBridge().putTargets(
+      new PutTargetsCommand({
+        Rule: "orders",
+        Targets: [
+          {
+            Id: "unpermitted",
+            Arn: "arn:aws:lambda:us-east-1:888888888888:function:fulfilment",
+          },
+          {
+            Id: "missing",
+            Arn: "arn:aws:lambda:us-east-1:888888888888:function:nowhere",
+          },
+        ],
+      }),
+    );
+
+    await simAws.eventBridge().putEvents(
+      new PutEventsCommand({
+        Entries: [
+          { Source: "orders.service", DetailType: "OrderPlaced", Detail: "{}" },
+        ],
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // Then both are recorded, and each says which kind of problem it was.
+    const failures = simAws.eventBridge().deliveryFailures;
+
+    assertArrayLength(failures, 2);
+    const [unpermitted, missing] = failures;
+
+    assertNonNullable(unpermitted);
+    assertNonNullable(missing);
+    assertStringIncludes(unpermitted.message, "AddPermission");
+    assertStringIncludes(missing.message, "is not a simulated Lambda function");
+  });
+
+  it("records that a standalone simulated EventBridge has nowhere to deliver", async () => {
+    // Given an EventBridge built on its own rather than through SimAws.
+    const simEventBridge = new SimEventBridge();
+
+    await simEventBridge.putRule(
+      new PutRuleCommand({ Name: "orders", EventPattern: orderPattern }),
+    );
+    await simEventBridge.putTargets(
+      new PutTargetsCommand({
+        Rule: "orders",
+        Targets: [
+          { Id: "queue", Arn: "arn:aws:sqs:us-east-1:888888888888:orders" },
+        ],
+      }),
+    );
+
+    // When a matching event is put.
+    await simEventBridge.putEvents(
+      new PutEventsCommand({
+        Entries: [
+          { Source: "orders.service", DetailType: "OrderPlaced", Detail: "{}" },
+        ],
+      }),
+    );
+
+    // Then the delivery is recorded as having nowhere to go, rather than
+    // quietly looking delivered.
+    await new Promise((resolve) => {
+      setTimeout(resolve, 0);
+    });
+
+    const [failure] = simEventBridge.deliveryFailures;
+
+    assertNonNullable(failure);
+    assertStringIncludes(failure.message, "no targets to deliver to");
+  });
+});

--- a/src/service/eventbridge/delivery/sim-event-bridge-delivery-failures.ts
+++ b/src/service/eventbridge/delivery/sim-event-bridge-delivery-failures.ts
@@ -1,0 +1,66 @@
+interface SimEventBridgeDeliveryFailureProperties {
+  readonly ruleName: string;
+  readonly ruleArn: string;
+  readonly targetId: string;
+  readonly targetArn: string;
+  readonly eventId: string;
+  readonly error: unknown;
+}
+
+/**
+ * One event a rule could not get to one of its targets.
+ */
+export class SimEventBridgeDeliveryFailure {
+  public readonly ruleName: string;
+  public readonly ruleArn: string;
+  public readonly targetId: string;
+  public readonly targetArn: string;
+  public readonly eventId: string;
+  public readonly error: unknown;
+
+  constructor(properties: SimEventBridgeDeliveryFailureProperties) {
+    this.ruleName = properties.ruleName;
+    this.ruleArn = properties.ruleArn;
+    this.targetId = properties.targetId;
+    this.targetArn = properties.targetArn;
+    this.eventId = properties.eventId;
+    this.error = properties.error;
+  }
+
+  /**
+   * What went wrong, as a message.
+   */
+  get message(): string {
+    if (this.error instanceof Error) {
+      return this.error.message;
+    }
+
+    return String(this.error);
+  }
+}
+
+/**
+ * Every delivery one simulated EventBridge scope could not make.
+ *
+ * Real EventBridge tells the publisher nothing about a failed delivery: a
+ * PutEvents that matched a rule whose target refuses the call still answers
+ * with an event id. So a target that is unexpectedly empty is explained here
+ * rather than by anything the SDK returned.
+ */
+export class SimEventBridgeDeliveryFailures {
+  private readonly failures: SimEventBridgeDeliveryFailure[] = [];
+
+  /**
+   * Every failure so far, oldest first.
+   */
+  get all(): readonly SimEventBridgeDeliveryFailure[] {
+    return [...this.failures];
+  }
+
+  /**
+   * Keep a failed delivery.
+   */
+  record(properties: SimEventBridgeDeliveryFailureProperties): void {
+    this.failures.push(new SimEventBridgeDeliveryFailure(properties));
+  }
+}

--- a/src/service/eventbridge/delivery/sim-event-bridge-delivery-function.ts
+++ b/src/service/eventbridge/delivery/sim-event-bridge-delivery-function.ts
@@ -1,0 +1,78 @@
+import type { SimAwsAccountRegionContainer } from "../../aws/sim-aws-account-region-scope.js";
+import { SimLambdaServiceInvokeAuthorizer } from "../../lambda/command/authorize/sim-lambda-service-invoke-authorizer.js";
+import {
+  SimEventBridgeDeliveryNotPermitted,
+  SimEventBridgeTargetNotFound,
+} from "../error/sim-event-bridge-delivery.error.js";
+import {
+  type SimEventBridgeDeliveryRequest,
+  simEventBridgeDeliveryDocument,
+  simEventBridgeDeliverySource,
+  simEventBridgeServicePrincipal,
+} from "./sim-event-bridge-delivery.js";
+
+interface SimEventBridgeDeliveryFunctionProperties {
+  readonly scope: SimAwsAccountRegionContainer;
+}
+
+/**
+ * A Lambda function a simulated rule is sending an event to, in the Account
+ * and Region the target ARN names.
+ *
+ * Everything is asked of the function's own Account, which is what makes a
+ * function in another Account reachable: its resource policy is the grant, and
+ * its Account's IAM is what evaluates it.
+ */
+export class SimEventBridgeDeliveryFunction {
+  private readonly scope: SimAwsAccountRegionContainer;
+
+  constructor(properties: SimEventBridgeDeliveryFunctionProperties) {
+    this.scope = properties.scope;
+  }
+
+  /**
+   * Invoke the function with the event, if it admits EventBridge for this
+   * rule.
+   *
+   * The resource policy is consulted on every delivery rather than remembered
+   * from the moment the target was added, so a permission taken away
+   * afterwards stops delivery. Real EventBridge does not check it at
+   * `PutTargets` time either.
+   */
+  async deliver(request: SimEventBridgeDeliveryRequest): Promise<void> {
+    const source = simEventBridgeDeliverySource(request);
+    const targetArn = request.target.arn;
+    const simFunction = this.scope
+      .lambda()
+      .getSimFunctionByName(targetArn.functionName);
+
+    if (simFunction === undefined) {
+      throw new SimEventBridgeTargetNotFound(
+        `${targetArn.value} is not a simulated Lambda function.`,
+      );
+    }
+
+    const decision = new SimLambdaServiceInvokeAuthorizer({
+      iam: this.scope.iam(),
+    }).authorize({
+      simFunction,
+      servicePrincipal: simEventBridgeServicePrincipal,
+      ...source,
+    });
+
+    if (decision.isDenied) {
+      throw new SimEventBridgeDeliveryNotPermitted(
+        `The resource policy of ${targetArn.value} does not allow ` +
+          `${simEventBridgeServicePrincipal} to invoke it for ` +
+          `${source.sourceArn}. Grant it with AddPermission.`,
+      );
+    }
+
+    // Invoked directly rather than through an Invoke command, because the
+    // rule is already inside the background task that stands for the
+    // asynchronous invocation real EventBridge makes, and because a handler
+    // failure has to reach the delivery outcome rather than being swallowed
+    // as an asynchronous invocation error.
+    await simFunction.invoke(simEventBridgeDeliveryDocument(request));
+  }
+}

--- a/src/service/eventbridge/delivery/sim-event-bridge-delivery-queue.ts
+++ b/src/service/eventbridge/delivery/sim-event-bridge-delivery-queue.ts
@@ -1,0 +1,83 @@
+import type { SimAwsAccountRegionContainer } from "../../aws/sim-aws-account-region-scope.js";
+import { SimSqsServiceSendAuthorizer } from "../../sqs/command/authorize/sim-sqs-service-send-authorizer.js";
+import {
+  SimEventBridgeDeliveryNotPermitted,
+  SimEventBridgeTargetNotFound,
+} from "../error/sim-event-bridge-delivery.error.js";
+import {
+  type SimEventBridgeDeliveryRequest,
+  simEventBridgeDeliveryJson,
+  simEventBridgeDeliverySource,
+  simEventBridgeServicePrincipal,
+} from "./sim-event-bridge-delivery.js";
+
+interface SimEventBridgeDeliveryQueueProperties {
+  readonly scope: SimAwsAccountRegionContainer;
+}
+
+/**
+ * A queue a simulated rule is sending an event to, in the Account and Region
+ * the target ARN names.
+ *
+ * The message body is the event, as JSON. Real EventBridge puts the event
+ * itself on the queue rather than wrapping it in an envelope of its own, which
+ * is what makes a queue target simpler to consume than an SNS subscription.
+ */
+export class SimEventBridgeDeliveryQueue {
+  private readonly scope: SimAwsAccountRegionContainer;
+
+  constructor(properties: SimEventBridgeDeliveryQueueProperties) {
+    this.scope = properties.scope;
+  }
+
+  /**
+   * Put the event on the queue, if it admits EventBridge for this rule.
+   */
+  async deliver(request: SimEventBridgeDeliveryRequest): Promise<void> {
+    const source = simEventBridgeDeliverySource(request);
+    const targetArn = request.target.arn;
+    const queue = this.scope.sqs().findQueue(targetArn.resource);
+
+    if (queue === undefined) {
+      throw new SimEventBridgeTargetNotFound(
+        `${targetArn.value} is not a simulated SQS queue.`,
+      );
+    }
+
+    const decision = new SimSqsServiceSendAuthorizer({
+      iam: this.scope.iam(),
+    }).authorize({
+      queue,
+      servicePrincipal: simEventBridgeServicePrincipal,
+      ...source,
+    });
+
+    if (decision.isDenied) {
+      throw new SimEventBridgeDeliveryNotPermitted(
+        `The queue policy of ${targetArn.value} does not allow ` +
+          `${simEventBridgeServicePrincipal} to send to it for ` +
+          `${source.sourceArn}. Grant sqs:SendMessage with the queue's ` +
+          `Policy attribute.`,
+      );
+    }
+
+    // Sent through the ordinary SendMessage path, so a delivered event is the
+    // same thing an SDK caller would have sent, and is authorized again on the
+    // way in.
+    await this.scope.sqs().sendMessage(
+      {
+        input: {
+          QueueUrl: queue.arn.url,
+          MessageBody: simEventBridgeDeliveryJson(request),
+        },
+      },
+      {
+        caller: {
+          kind: "service",
+          service: simEventBridgeServicePrincipal,
+        },
+        ...source,
+      },
+    );
+  }
+}

--- a/src/service/eventbridge/delivery/sim-event-bridge-delivery-topic.ts
+++ b/src/service/eventbridge/delivery/sim-event-bridge-delivery-topic.ts
@@ -1,0 +1,84 @@
+import type { SimAwsAccountRegionContainer } from "../../aws/sim-aws-account-region-scope.js";
+import { SimSnsServicePublishAuthorizer } from "../../sns/command/authorize/sim-sns-service-publish-authorizer.js";
+import {
+  SimEventBridgeDeliveryNotPermitted,
+  SimEventBridgeTargetNotFound,
+} from "../error/sim-event-bridge-delivery.error.js";
+import {
+  type SimEventBridgeDeliveryRequest,
+  simEventBridgeDeliveryJson,
+  simEventBridgeDeliverySource,
+  simEventBridgeServicePrincipal,
+} from "./sim-event-bridge-delivery.js";
+
+interface SimEventBridgeDeliveryTopicProperties {
+  readonly scope: SimAwsAccountRegionContainer;
+}
+
+/**
+ * A topic a simulated rule is sending an event to, in the Account and Region
+ * the target ARN names.
+ *
+ * The published message is the event as JSON, which the topic then fans out to
+ * its own subscriptions. So a rule targeting a topic reaches everything
+ * subscribed to that topic, and each subscriber sees the event inside SNS's
+ * own envelope rather than on its own.
+ */
+export class SimEventBridgeDeliveryTopic {
+  private readonly scope: SimAwsAccountRegionContainer;
+
+  constructor(properties: SimEventBridgeDeliveryTopicProperties) {
+    this.scope = properties.scope;
+  }
+
+  /**
+   * Publish the event to the topic, if it admits EventBridge for this rule.
+   */
+  async deliver(request: SimEventBridgeDeliveryRequest): Promise<void> {
+    const source = simEventBridgeDeliverySource(request);
+    const targetArn = request.target.arn;
+    const topic = this.scope.sns().findTopic(targetArn.resource);
+
+    if (topic === undefined) {
+      throw new SimEventBridgeTargetNotFound(
+        `${targetArn.value} is not a simulated SNS topic.`,
+      );
+    }
+
+    const decision = new SimSnsServicePublishAuthorizer({
+      iam: this.scope.iam(),
+    }).authorize({
+      topic,
+      servicePrincipal: simEventBridgeServicePrincipal,
+      ...source,
+    });
+
+    if (decision.isDenied) {
+      throw new SimEventBridgeDeliveryNotPermitted(
+        `The topic policy of ${targetArn.value} does not allow ` +
+          `${simEventBridgeServicePrincipal} to publish to it for ` +
+          `${source.sourceArn}. Grant sns:Publish with the topic's Policy ` +
+          `attribute.`,
+      );
+    }
+
+    // Published through the ordinary Publish path, so a delivered event fans
+    // out to the topic's subscriptions exactly as an SDK caller's message
+    // would.
+    await this.scope.sns().publish(
+      {
+        input: {
+          TopicArn: topic.arn.value,
+          Message: simEventBridgeDeliveryJson(request),
+        },
+      },
+      {
+        caller: {
+          kind: "service",
+          service: simEventBridgeServicePrincipal,
+        },
+        ...source,
+      },
+    );
+  }
+}

--- a/src/service/eventbridge/delivery/sim-event-bridge-delivery.iso.test.ts
+++ b/src/service/eventbridge/delivery/sim-event-bridge-delivery.iso.test.ts
@@ -1,0 +1,356 @@
+import {
+  PutEventsCommand,
+  PutRuleCommand,
+  PutTargetsCommand,
+} from "@aws-sdk/client-eventbridge";
+import { AddPermissionCommand } from "@aws-sdk/client-lambda";
+import {
+  CreateQueueCommand,
+  ReceiveMessageCommand,
+  SetQueueAttributesCommand,
+} from "@aws-sdk/client-sqs";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertObjectEquals,
+  assertStringIncludes,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../aws/sim-aws.js";
+import { makeLambdaZipFileInput } from "../../lambda/index.js";
+
+const orderPattern = JSON.stringify({ source: ["orders.service"] });
+
+/**
+ * A queue whose policy admits EventBridge for every rule of the Account.
+ */
+async function queueAdmittingEvents(simAws: SimAws): Promise<string> {
+  const created = await simAws
+    .sqs()
+    .createQueue(new CreateQueueCommand({ QueueName: "orders" }));
+
+  await simAws.sqs().setQueueAttributes(
+    new SetQueueAttributesCommand({
+      QueueUrl: created.QueueUrl,
+      Attributes: {
+        Policy: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: [
+            {
+              Effect: "Allow",
+              Principal: { Service: "events.amazonaws.com" },
+              Action: "sqs:SendMessage",
+              Resource: "arn:aws:sqs:us-east-1:888888888888:orders",
+            },
+          ],
+        }),
+      },
+    }),
+  );
+
+  return String(created.QueueUrl);
+}
+
+/**
+ * A rule matching order events, with one target.
+ */
+async function ruleWithTarget(
+  simAws: SimAws,
+  target: {
+    readonly Id: string;
+    readonly Arn: string;
+    readonly Input?: string;
+  },
+): Promise<void> {
+  await simAws
+    .eventBridge()
+    .putRule(
+      new PutRuleCommand({ Name: "orders", EventPattern: orderPattern }),
+    );
+
+  await simAws
+    .eventBridge()
+    .putTargets(new PutTargetsCommand({ Rule: "orders", Targets: [target] }));
+}
+
+/**
+ * Put one order event and wait for the deliveries it caused.
+ */
+async function putOrder(simAws: SimAws): Promise<void> {
+  await simAws.eventBridge().putEvents(
+    new PutEventsCommand({
+      Entries: [
+        {
+          Source: "orders.service",
+          DetailType: "OrderPlaced",
+          Detail: JSON.stringify({ orderId: "order-1" }),
+        },
+      ],
+    }),
+  );
+
+  await simAws.backgroundTasksComplete();
+}
+
+describe("EventBridge target delivery", () => {
+  it("sends a matched event to a queue target", async () => {
+    // Given a rule targeting a queue that admits EventBridge.
+    const simAws = new SimAws();
+    const queueUrl = await queueAdmittingEvents(simAws);
+
+    await ruleWithTarget(simAws, {
+      Id: "orders-queue",
+      Arn: "arn:aws:sqs:us-east-1:888888888888:orders",
+    });
+
+    // When a matching event is put.
+    await putOrder(simAws);
+
+    // Then the queue received the event itself, with no envelope around it.
+    const received = await simAws
+      .sqs()
+      .receiveMessage(new ReceiveMessageCommand({ QueueUrl: queueUrl }));
+
+    assertArrayLength(received.Messages ?? [], 1);
+
+    const body: unknown = JSON.parse(String(received.Messages?.[0]?.Body));
+
+    assertObjectEquals(body, {
+      version: "0",
+      id: (body as { id: string }).id,
+      "detail-type": "OrderPlaced",
+      source: "orders.service",
+      account: "888888888888",
+      time: (body as { time: string }).time,
+      region: "us-east-1",
+      resources: [],
+      detail: { orderId: "order-1" },
+    });
+  });
+
+  it("invokes a Lambda target that admits EventBridge", async () => {
+    // Given a rule targeting a function with an events.amazonaws.com grant.
+    const simAws = new SimAws();
+    const received: unknown[] = [];
+
+    await simAws.lambda().createFunction({
+      input: {
+        FunctionName: "fulfilment",
+        Role: "arn:aws:iam::888888888888:role/FulfilmentRole",
+        Code: {
+          ZipFile: makeLambdaZipFileInput((event: unknown) => {
+            received.push(event);
+            return { ok: true };
+          }),
+        },
+      },
+    });
+
+    await simAws.lambda().addPermission(
+      new AddPermissionCommand({
+        FunctionName: "fulfilment",
+        StatementId: "events",
+        Action: "lambda:InvokeFunction",
+        Principal: "events.amazonaws.com",
+      }),
+    );
+
+    await ruleWithTarget(simAws, {
+      Id: "fulfilment",
+      Arn: "arn:aws:lambda:us-east-1:888888888888:function:fulfilment",
+    });
+
+    // When a matching event is put.
+    await putOrder(simAws);
+
+    // Then the handler ran with the event.
+    assertArrayLength(received, 1);
+    assertIdentical(
+      (received[0] as { source: string } | undefined)?.source,
+      "orders.service",
+    );
+  });
+
+  it("sends a target its fixed input instead of the event", async () => {
+    // Given a target with an Input of its own.
+    const simAws = new SimAws();
+    const queueUrl = await queueAdmittingEvents(simAws);
+
+    await ruleWithTarget(simAws, {
+      Id: "orders-queue",
+      Arn: "arn:aws:sqs:us-east-1:888888888888:orders",
+      Input: JSON.stringify({ wake: "up" }),
+    });
+
+    // When a matching event is put.
+    await putOrder(simAws);
+
+    // Then the target received the input as written, not the event.
+    const received = await simAws
+      .sqs()
+      .receiveMessage(new ReceiveMessageCommand({ QueueUrl: queueUrl }));
+
+    assertIdentical(received.Messages?.[0]?.Body, '{"wake":"up"}');
+  });
+
+  it("hands a Lambda target its fixed input as a parsed value", async () => {
+    // Given a function target with an Input of its own.
+    const simAws = new SimAws();
+    const received: unknown[] = [];
+
+    await simAws.lambda().createFunction({
+      input: {
+        FunctionName: "fulfilment",
+        Role: "arn:aws:iam::888888888888:role/FulfilmentRole",
+        Code: {
+          ZipFile: makeLambdaZipFileInput((event: unknown) => {
+            received.push(event);
+            return { ok: true };
+          }),
+        },
+      },
+    });
+    await simAws.lambda().addPermission(
+      new AddPermissionCommand({
+        FunctionName: "fulfilment",
+        StatementId: "events",
+        Action: "lambda:InvokeFunction",
+        Principal: "events.amazonaws.com",
+      }),
+    );
+
+    await ruleWithTarget(simAws, {
+      Id: "fulfilment",
+      Arn: "arn:aws:lambda:us-east-1:888888888888:function:fulfilment",
+      Input: JSON.stringify({ wake: "up" }),
+    });
+
+    // When a matching event is put.
+    await putOrder(simAws);
+
+    // Then the handler was given the input, parsed, rather than the event.
+    assertObjectEquals(received[0], { wake: "up" });
+  });
+
+  it("sends nothing when the event matches no rule", async () => {
+    // Given a rule wanting a different source.
+    const simAws = new SimAws();
+    const queueUrl = await queueAdmittingEvents(simAws);
+
+    await simAws.eventBridge().putRule(
+      new PutRuleCommand({
+        Name: "billing",
+        EventPattern: JSON.stringify({ source: ["billing.service"] }),
+      }),
+    );
+    await simAws.eventBridge().putTargets(
+      new PutTargetsCommand({
+        Rule: "billing",
+        Targets: [
+          { Id: "q", Arn: "arn:aws:sqs:us-east-1:888888888888:orders" },
+        ],
+      }),
+    );
+
+    // When an order event is put.
+    await putOrder(simAws);
+
+    // Then the queue is empty.
+    const received = await simAws
+      .sqs()
+      .receiveMessage(new ReceiveMessageCommand({ QueueUrl: queueUrl }));
+
+    assertArrayLength(received.Messages ?? [], 0);
+  });
+
+  it("records a delivery a target's policy refused, and tells the caller nothing", async () => {
+    // Given a rule targeting a queue whose policy says nothing about
+    // EventBridge.
+    const simAws = new SimAws();
+
+    await simAws
+      .sqs()
+      .createQueue(new CreateQueueCommand({ QueueName: "orders" }));
+
+    await ruleWithTarget(simAws, {
+      Id: "orders-queue",
+      Arn: "arn:aws:sqs:us-east-1:888888888888:orders",
+    });
+
+    // When a matching event is put.
+    await putOrder(simAws);
+
+    // Then the put succeeded and the failure is readable here instead.
+    const [failure] = simAws.eventBridge().deliveryFailures;
+
+    assertNonNullable(failure);
+    assertIdentical(failure.ruleName, "orders");
+    assertIdentical(failure.targetId, "orders-queue");
+    assertStringIncludes(failure.message, "does not allow");
+    assertStringIncludes(failure.message, "events.amazonaws.com");
+  });
+
+  it("records a target that names nothing", async () => {
+    // Given a rule targeting a queue that was never created.
+    const simAws = new SimAws();
+
+    await ruleWithTarget(simAws, {
+      Id: "missing",
+      Arn: "arn:aws:sqs:us-east-1:888888888888:nowhere",
+    });
+
+    // When a matching event is put.
+    await putOrder(simAws);
+
+    // Then the failure says the target is not there, which reads differently
+    // from a policy refusing the delivery.
+    const [failure] = simAws.eventBridge().deliveryFailures;
+
+    assertNonNullable(failure);
+    assertStringIncludes(failure.message, "is not a simulated SQS queue");
+  });
+
+  it("sends one event to every target of every rule that matched it", async () => {
+    // Given two rules matching the same event, each with a target.
+    const simAws = new SimAws();
+    const queueUrl = await queueAdmittingEvents(simAws);
+
+    await simAws
+      .eventBridge()
+      .putRule(
+        new PutRuleCommand({ Name: "orders", EventPattern: orderPattern }),
+      );
+    await simAws.eventBridge().putRule(
+      new PutRuleCommand({
+        Name: "everything",
+        EventPattern: JSON.stringify({ version: ["0"] }),
+      }),
+    );
+
+    for (const rule of ["orders", "everything"]) {
+      // oxlint-disable-next-line no-await-in-loop
+      await simAws.eventBridge().putTargets(
+        new PutTargetsCommand({
+          Rule: rule,
+          Targets: [
+            { Id: "q", Arn: "arn:aws:sqs:us-east-1:888888888888:orders" },
+          ],
+        }),
+      );
+    }
+
+    // When one matching event is put.
+    await putOrder(simAws);
+
+    // Then the queue has it twice, once for each rule.
+    const received = await simAws.sqs().receiveMessage(
+      new ReceiveMessageCommand({
+        QueueUrl: queueUrl,
+        MaxNumberOfMessages: 10,
+      }),
+    );
+
+    assertArrayLength(received.Messages ?? [], 2);
+  });
+});

--- a/src/service/eventbridge/delivery/sim-event-bridge-delivery.ts
+++ b/src/service/eventbridge/delivery/sim-event-bridge-delivery.ts
@@ -1,0 +1,91 @@
+import type { SimEventBridgeEvent } from "../event/sim-event-bridge-event.js";
+import type { SimEventTarget } from "../target/sim-event-target.js";
+
+/**
+ * The service principal simulated EventBridge reaches another service as.
+ *
+ * This is the principal a target's resource policy has to admit, which is why
+ * a queue targeted by a rule needs `events.amazonaws.com` in its policy and a
+ * function needs it in an `AddPermission` grant.
+ */
+export const simEventBridgeServicePrincipal = "events.amazonaws.com";
+
+/**
+ * One event on its way from a rule to one of its targets.
+ *
+ * The rule comes along because the target's policy is nearly always
+ * conditioned on it: a queue admits `events.amazonaws.com` for one rule ARN
+ * rather than for EventBridge at large, which is what `aws:SourceArn` carries.
+ */
+export interface SimEventBridgeDeliveryRequest {
+  readonly target: SimEventTarget;
+  readonly event: SimEventBridgeEvent;
+  readonly ruleArn: string;
+  readonly ruleName: string;
+  readonly ruleOwnerAccountId: string;
+}
+
+/**
+ * Somewhere a simulated rule can send an event.
+ *
+ * There is one implementation per target service, because what a target is
+ * asked and what it is handed differ by service: a queue receives a message
+ * body, a topic receives a published message, and a function receives an
+ * invocation payload. A fourth target service adds a fourth implementation
+ * rather than a branch in an existing one.
+ */
+export interface SimEventBridgeDeliveryTargets {
+  /**
+   * Send one event to a target, refusing if the target does not admit
+   * EventBridge.
+   */
+  deliver(request: SimEventBridgeDeliveryRequest): Promise<void>;
+}
+
+/**
+ * What a target's policy is asked about, as IAM condition values.
+ */
+export interface SimEventBridgeDeliverySource {
+  readonly sourceArn: string;
+  readonly sourceAccount: string;
+}
+
+/**
+ * Which rule a delivery is being made for, and whose it is.
+ */
+export function simEventBridgeDeliverySource(
+  request: SimEventBridgeDeliveryRequest,
+): SimEventBridgeDeliverySource {
+  return {
+    sourceArn: request.ruleArn,
+    sourceAccount: request.ruleOwnerAccountId,
+  };
+}
+
+/**
+ * What a target receives, as the JSON text a queue or a topic carries.
+ *
+ * Real EventBridge sends `Input` as written, so a target with an `Input` of
+ * `"hello"` receives the JSON string rather than the event that triggered it.
+ */
+export function simEventBridgeDeliveryJson(
+  request: SimEventBridgeDeliveryRequest,
+): string {
+  return request.target.input ?? JSON.stringify(request.event.toEnvelope());
+}
+
+/**
+ * What a target receives, as the value a Lambda handler is handed.
+ *
+ * A target's input is known to be JSON, because that is checked when the
+ * target is added, so nothing here can fail to read it.
+ */
+export function simEventBridgeDeliveryDocument(
+  request: SimEventBridgeDeliveryRequest,
+): unknown {
+  if (request.target.input === undefined) {
+    return request.event.toEnvelope();
+  }
+
+  return JSON.parse(request.target.input);
+}

--- a/src/service/eventbridge/delivery/sim-event-bridge-no-delivery-targets.ts
+++ b/src/service/eventbridge/delivery/sim-event-bridge-no-delivery-targets.ts
@@ -1,0 +1,29 @@
+import { SimEventBridgeTargetNotFound } from "../error/sim-event-bridge-delivery.error.js";
+import type {
+  SimEventBridgeDeliveryRequest,
+  SimEventBridgeDeliveryTargets,
+} from "./sim-event-bridge-delivery.js";
+
+/**
+ * The targets of a simulated EventBridge built on its own, which are none.
+ *
+ * A queue, topic or function in another simulated service is only reachable
+ * through SimAws, so a `SimEventBridge` constructed directly has nowhere to
+ * deliver. Every delivery is recorded as a failure saying so, rather than
+ * quietly succeeding, because a rule that appears to have delivered to a
+ * target that was never reachable is the worst of the possible answers.
+ */
+export class SimEventBridgeNoDeliveryTargets implements SimEventBridgeDeliveryTargets {
+  /**
+   * Refuse the delivery, saying why there was nowhere to make it.
+   */
+  deliver(request: SimEventBridgeDeliveryRequest): Promise<void> {
+    return Promise.reject(
+      new SimEventBridgeTargetNotFound(
+        `This simulated EventBridge has no targets to deliver to, so ` +
+          `${request.target.arn.value} was not reached. Reach EventBridge ` +
+          `through SimAws for a rule that delivers.`,
+      ),
+    );
+  }
+}

--- a/src/service/eventbridge/delivery/sim-event-bridge-target-delivery.ts
+++ b/src/service/eventbridge/delivery/sim-event-bridge-target-delivery.ts
@@ -1,0 +1,53 @@
+import type {
+  SimEventBridgeDeliveryRequest,
+  SimEventBridgeDeliveryTargets,
+} from "./sim-event-bridge-delivery.js";
+import type { SimEventBridgeDeliveryFailure } from "./sim-event-bridge-delivery-failures.js";
+import { SimEventBridgeDeliveryFailures } from "./sim-event-bridge-delivery-failures.js";
+
+interface SimEventBridgeTargetDeliveryProperties {
+  readonly endpoints: SimEventBridgeDeliveryTargets;
+}
+
+/**
+ * Makes one delivery and keeps whatever went wrong.
+ *
+ * A failure is recorded rather than thrown, because these run as background
+ * tasks and one left rejected would fail an unrelated
+ * `backgroundTasksComplete()`. Real EventBridge never reports a delivery
+ * failure to the caller who put the event either, so there is nowhere to throw
+ * it to.
+ */
+export class SimEventBridgeTargetDelivery {
+  private readonly endpoints: SimEventBridgeDeliveryTargets;
+  private readonly failures = new SimEventBridgeDeliveryFailures();
+
+  constructor(properties: SimEventBridgeTargetDeliveryProperties) {
+    this.endpoints = properties.endpoints;
+  }
+
+  /**
+   * Every delivery that could not be made.
+   */
+  get deliveryFailures(): readonly SimEventBridgeDeliveryFailure[] {
+    return this.failures.all;
+  }
+
+  /**
+   * Send one event to one target.
+   */
+  async deliver(request: SimEventBridgeDeliveryRequest): Promise<void> {
+    try {
+      await this.endpoints.deliver(request);
+    } catch (error) {
+      this.failures.record({
+        ruleName: request.ruleName,
+        ruleArn: request.ruleArn,
+        targetId: request.target.id,
+        targetArn: request.target.arn.value,
+        eventId: request.event.id,
+        error,
+      });
+    }
+  }
+}

--- a/src/service/eventbridge/error/sim-event-bridge-delivery.error.ts
+++ b/src/service/eventbridge/error/sim-event-bridge-delivery.error.ts
@@ -1,0 +1,24 @@
+import { SimEventBridgeError } from "./sim-event-bridge.error.js";
+
+/**
+ * Thrown when a target's own policy does not admit EventBridge.
+ *
+ * Not an error real EventBridge reports to anybody: a rule whose target
+ * refuses the call fails quietly, and the PutEvents that matched it has
+ * already answered with an event id. This is thrown inside the delivery so
+ * that the failure is recorded and readable, rather than reaching the caller.
+ */
+export class SimEventBridgeDeliveryNotPermitted extends SimEventBridgeError {
+  public override readonly name = "SimEventBridgeDeliveryNotPermitted";
+}
+
+/**
+ * Thrown when a target ARN names nothing in this simulation.
+ *
+ * Distinct from a refusal: a policy saying no is a modelled outcome a test may
+ * be asking for on purpose, where a target pointing at nothing is a mistake
+ * worth being loud about.
+ */
+export class SimEventBridgeTargetNotFound extends SimEventBridgeError {
+  public override readonly name = "SimEventBridgeTargetNotFound";
+}

--- a/src/service/eventbridge/pattern/sim-event-pattern-refusals.iso.test.ts
+++ b/src/service/eventbridge/pattern/sim-event-pattern-refusals.iso.test.ts
@@ -93,11 +93,18 @@ describe("EventBridge event pattern refusals", () => {
     const badOperand = await refusedPattern({
       detail: { total: [{ numeric: [">", "10"] }] },
     });
+    const numericComparator = await refusedPattern({
+      detail: { total: [{ numeric: [10, 10] }] },
+    });
 
     // Then each is refused.
     assertInstanceOf(oddLength, SimEventBridgeInvalidEventPatternException);
     assertInstanceOf(badComparator, SimEventBridgeInvalidEventPatternException);
     assertInstanceOf(badOperand, SimEventBridgeInvalidEventPatternException);
+    assertInstanceOf(
+      numericComparator,
+      SimEventBridgeInvalidEventPatternException,
+    );
   });
 
   it("refuses an exists condition that is not a boolean", async () => {

--- a/src/service/eventbridge/routing/sim-event-bridge-router.ts
+++ b/src/service/eventbridge/routing/sim-event-bridge-router.ts
@@ -1,36 +1,63 @@
-import type { SimEventBridgeEvent } from "../event/sim-event-bridge-event.js";
+import type { BackgroundScheduler } from "../../../util/background/background.js";
 import type { SimEventBusStore } from "../bus/sim-event-bus-store.js";
+import type { SimEventBridgeDeliveryTargets } from "../delivery/sim-event-bridge-delivery.js";
+import type { SimEventBridgeDeliveryFailure } from "../delivery/sim-event-bridge-delivery-failures.js";
+import { SimEventBridgeTargetDelivery } from "../delivery/sim-event-bridge-target-delivery.js";
+import type { SimEventBridgeEvent } from "../event/sim-event-bridge-event.js";
+import type { SimEventRule } from "../rule/sim-event-rule.js";
 import type { SimEventRuleStore } from "../rule/sim-event-rule-store.js";
+import type { SimEventTargetStore } from "../target/sim-event-target-store.js";
 
 interface SimEventBridgeRouterProperties {
   readonly buses: SimEventBusStore;
   readonly rules: SimEventRuleStore;
+  readonly targets: SimEventTargetStore;
+  readonly endpoints: SimEventBridgeDeliveryTargets;
+  readonly background: BackgroundScheduler;
+  readonly accountId: string;
 }
 
 /**
- * Works out which of a bus's rules an event matches.
+ * Works out which of a bus's rules an event matches, and sends it on.
  *
- * This is the whole of what a bus does with an event: every enabled rule on
- * that bus is asked, and each one that matches gets the event. Rules are
- * independent, so one rule's pattern has nothing to do with whether another
- * matches, and an event matching two rules goes to both.
+ * Every enabled rule on the bus is asked. Rules are independent, so one rule's
+ * pattern has nothing to do with whether another matches, and an event
+ * matching two rules goes to the targets of both.
  *
- * Sending a matched event on to the rule's targets is what a later change adds
- * here. Today the match is recorded on the bus and goes no further, because
- * targets are not simulated yet.
+ * Delivery happens on the background scheduler, as real EventBridge delivers
+ * after PutEvents has been answered: an event gets an id whether or not
+ * anything downstream takes it. `simAws.backgroundTasksComplete()` is what
+ * waits for it.
  */
 export class SimEventBridgeRouter {
   private readonly buses: SimEventBusStore;
   private readonly rules: SimEventRuleStore;
+  private readonly targets: SimEventTargetStore;
+  private readonly background: BackgroundScheduler;
+  private readonly accountId: string;
+  private readonly delivery: SimEventBridgeTargetDelivery;
 
   constructor(properties: SimEventBridgeRouterProperties) {
     this.buses = properties.buses;
     this.rules = properties.rules;
+    this.targets = properties.targets;
+    this.background = properties.background;
+    this.accountId = properties.accountId;
+    this.delivery = new SimEventBridgeTargetDelivery({
+      endpoints: properties.endpoints,
+    });
   }
 
   /**
-   * Put an event onto the bus it was addressed to, and work out which of that
-   * bus's rules it matched.
+   * Every delivery this scope could not make.
+   */
+  get deliveryFailures(): readonly SimEventBridgeDeliveryFailure[] {
+    return this.delivery.deliveryFailures;
+  }
+
+  /**
+   * Put an event onto the bus it was addressed to, and send it to the targets
+   * of every rule it matched.
    *
    * A bus that is not there takes the event nowhere, and the caller is not
    * told: real EventBridge answers a PutEvents naming an unknown bus with a
@@ -52,5 +79,28 @@ export class SimEventBridgeRouter {
       event,
       matched.map((rule) => rule.name.value),
     );
+
+    for (const rule of matched) {
+      this.send(rule, event);
+    }
+  }
+
+  /**
+   * Schedule one event for every target of a rule that matched it.
+   */
+  private send(rule: SimEventRule, event: SimEventBridgeEvent): void {
+    const targets = this.targets.forRule(rule.busName.value, rule.name.value);
+
+    for (const target of targets) {
+      this.background.schedule(async () => {
+        await this.delivery.deliver({
+          target,
+          event,
+          ruleArn: rule.arn,
+          ruleName: rule.name.value,
+          ruleOwnerAccountId: this.accountId,
+        });
+      });
+    }
   }
 }

--- a/src/service/eventbridge/sdk/sim-event-bridge-sdk-command-router.iso.test.ts
+++ b/src/service/eventbridge/sdk/sim-event-bridge-sdk-command-router.iso.test.ts
@@ -10,7 +10,7 @@ describe("EventBridge SDK Command router", () => {
     // When its router is asked what it supports.
     const supported = simEventBridge.sdkCommandRouter().supportedCommandNames();
 
-    // Then it names the bus commands, PutEvents and the rule commands.
+    // Then it names the bus, event, rule and target commands.
     assertArrayEquals(supported, [
       "CreateEventBusCommand",
       "DeleteEventBusCommand",
@@ -24,6 +24,10 @@ describe("EventBridge SDK Command router", () => {
       "EnableRuleCommand",
       "DisableRuleCommand",
       "TestEventPatternCommand",
+      "PutTargetsCommand",
+      "RemoveTargetsCommand",
+      "ListTargetsByRuleCommand",
+      "ListRuleNamesByTargetCommand",
     ]);
   });
 
@@ -31,11 +35,14 @@ describe("EventBridge SDK Command router", () => {
     // Given a simulated EventBridge.
     const simEventBridge = new SimEventBridge();
 
-    // When a Command from a later change is asked for.
-    const route = simEventBridge.sdkCommandRouter().route("PutTargetsCommand");
+    // When a Command for something this simulation does not model is asked
+    // for, such as granting another Account access to a bus.
+    const route = simEventBridge
+      .sdkCommandRouter()
+      .route("PutPermissionCommand");
 
     // Then there is none, so the interception engine reports it rather than
-    // this service answering a target request it cannot handle.
+    // this service answering a request it cannot handle.
     assertUndefined(route);
   });
 });

--- a/src/service/eventbridge/sdk/sim-event-bridge-sdk-command-router.ts
+++ b/src/service/eventbridge/sdk/sim-event-bridge-sdk-command-router.ts
@@ -19,6 +19,12 @@ import type {
   SimPutRuleCommand,
   SimTestEventPatternCommand,
 } from "../command/rule/rule.command.js";
+import type {
+  SimListRuleNamesByTargetCommand,
+  SimListTargetsByRuleCommand,
+  SimPutTargetsCommand,
+  SimRemoveTargetsCommand,
+} from "../command/target/target.command.js";
 import type { SimEventBridge } from "../sim-event-bridge.js";
 
 /**
@@ -122,6 +128,38 @@ export class SimEventBridgeSdkCommandRouter implements SimSdkCommandRouter {
         async (command, context): Promise<unknown> =>
           await simEventBridge.testEventPattern(
             command as SimTestEventPatternCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "PutTargetsCommand",
+        async (command, context): Promise<unknown> =>
+          await simEventBridge.putTargets(
+            command as SimPutTargetsCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "RemoveTargetsCommand",
+        async (command, context): Promise<unknown> =>
+          await simEventBridge.removeTargets(
+            command as SimRemoveTargetsCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "ListTargetsByRuleCommand",
+        async (command, context): Promise<unknown> =>
+          await simEventBridge.listTargetsByRule(
+            command as SimListTargetsByRuleCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "ListRuleNamesByTargetCommand",
+        async (command, context): Promise<unknown> =>
+          await simEventBridge.listRuleNamesByTarget(
+            command as SimListRuleNamesByTargetCommand,
             simSdkCallerOptions(context),
           ),
       ],

--- a/src/service/eventbridge/sdk/sim-event-bridge-sdk-routing.iso.test.ts
+++ b/src/service/eventbridge/sdk/sim-event-bridge-sdk-routing.iso.test.ts
@@ -8,12 +8,17 @@ import {
   EnableRuleCommand,
   EventBridgeClient,
   ListEventBusesCommand,
+  ListRuleNamesByTargetCommand,
   ListRulesCommand,
+  ListTargetsByRuleCommand,
   PutEventsCommand,
   PutRuleCommand,
+  PutTargetsCommand,
+  RemoveTargetsCommand,
   TestEventPatternCommand,
 } from "@aws-sdk/client-eventbridge";
 import {
+  assertArrayEquals,
   assertArrayLength,
   assertIdentical,
   assertNonNullable,
@@ -127,5 +132,48 @@ describe("EventBridge SDK interception", () => {
     assertArrayLength(listed.Rules ?? [], 1);
     assertTrue(tested.Result);
     assertArrayLength(afterDelete.Rules ?? [], 0);
+  });
+
+  it("routes every target Command through the intercepted client", async () => {
+    // Given an intercepted client with a rule to hang targets on.
+    using simSdk = new SimSdk();
+    simSdk.intercept(EventBridgeClient);
+
+    const client = new EventBridgeClient({ region: "us-east-1" });
+    const queueArn = "arn:aws:sqs:us-east-1:888888888888:orders";
+
+    await client.send(
+      new PutRuleCommand({
+        Name: "orders",
+        EventPattern: JSON.stringify({ source: ["orders.service"] }),
+      }),
+    );
+
+    // When targets are added, listed both ways, and removed.
+    const put = await client.send(
+      new PutTargetsCommand({
+        Rule: "orders",
+        Targets: [{ Id: "queue", Arn: queueArn }],
+      }),
+    );
+    const listed = await client.send(
+      new ListTargetsByRuleCommand({ Rule: "orders" }),
+    );
+    const byTarget = await client.send(
+      new ListRuleNamesByTargetCommand({ TargetArn: queueArn }),
+    );
+    const removed = await client.send(
+      new RemoveTargetsCommand({ Rule: "orders", Ids: ["queue"] }),
+    );
+    const afterRemove = await client.send(
+      new ListTargetsByRuleCommand({ Rule: "orders" }),
+    );
+
+    // Then each answers as the simulated service does.
+    assertIdentical(put.FailedEntryCount, 0);
+    assertArrayLength(listed.Targets ?? [], 1);
+    assertArrayEquals(byTarget.RuleNames ?? [], ["orders"]);
+    assertIdentical(removed.FailedEntryCount, 0);
+    assertArrayLength(afterRemove.Targets ?? [], 0);
   });
 });

--- a/src/service/eventbridge/sim-event-bridge-inspection.ts
+++ b/src/service/eventbridge/sim-event-bridge-inspection.ts
@@ -1,0 +1,85 @@
+import type { SimEventBusStore } from "./bus/sim-event-bus-store.js";
+import type { SimEventBusReceipt } from "./bus/sim-event-bus.js";
+import type { SimEventBus } from "./bus/sim-event-bus.js";
+import { defaultEventBusName } from "./bus/sim-event-bus-name.js";
+import type { SimEventBridgeEvent } from "./event/sim-event-bridge-event.js";
+import type { SimEventRule } from "./rule/sim-event-rule.js";
+import type { SimEventRuleStore } from "./rule/sim-event-rule-store.js";
+import type { SimEventTarget } from "./target/sim-event-target.js";
+import type { SimEventTargetStore } from "./target/sim-event-target-store.js";
+
+/**
+ * What a test can ask a simulated EventBridge about its own state.
+ *
+ * These are the simulator's own accessors rather than simulated API
+ * operations: they go through no Command and no authorization, and real
+ * EventBridge offers nothing like most of them. They are held apart from the
+ * facade for the same reason SimAws holds its service accessors apart, which
+ * is that the facade's job is delegating SDK commands and this is a different
+ * job that happens to live on the same object.
+ */
+export abstract class SimEventBridgeInspection {
+  protected abstract readonly buses: SimEventBusStore;
+  protected abstract readonly rules: SimEventRuleStore;
+  protected abstract readonly targets: SimEventTargetStore;
+
+  /**
+   * Find an event bus by name.
+   *
+   * This is the simulator's own accessor, for tests seeding or inspecting bus
+   * state without going through a Command and its authorization.
+   */
+  findEventBus(name: string): SimEventBus | undefined {
+    return this.buses.find(name);
+  }
+
+  /**
+   * Every event a bus received, in arrival order.
+   *
+   * This is the simulator's own accessor, for a test asserting on the envelope
+   * EventBridge built from a PutEvents entry. Real EventBridge keeps no events
+   * and offers nothing like it, so nothing an SDK command returns is built
+   * from this. A bus that is not there received nothing.
+   */
+  eventsOn(busName: string): readonly SimEventBridgeEvent[] {
+    return this.buses.find(busName)?.receivedEvents ?? [];
+  }
+
+  /**
+   * Find a rule by name, on a bus.
+   *
+   * This is the simulator's own accessor, for tests seeding or inspecting rule
+   * state without going through a Command and its authorization.
+   */
+  findRule(
+    ruleName: string,
+    busName = defaultEventBusName,
+  ): SimEventRule | undefined {
+    return this.rules.find(busName, ruleName);
+  }
+
+  /**
+   * Every event a bus received, with the rules each one matched.
+   *
+   * This is the simulator's own accessor, for a test asserting on which rules
+   * an event reached. Real EventBridge keeps nothing like it, and nothing an
+   * SDK command returns is built from it.
+   */
+  receiptsOn(busName: string): readonly SimEventBusReceipt[] {
+    return this.buses.find(busName)?.receipts ?? [];
+  }
+
+  /**
+   * The targets of a rule.
+   *
+   * This is the simulator's own accessor, for a test inspecting where a rule
+   * would send an event without going through a Command and its
+   * authorization.
+   */
+  ruleTargets(
+    ruleName: string,
+    busName = defaultEventBusName,
+  ): readonly SimEventTarget[] {
+    return this.targets.forRule(busName, ruleName);
+  }
+}

--- a/src/service/eventbridge/sim-event-bridge.ts
+++ b/src/service/eventbridge/sim-event-bridge.ts
@@ -10,21 +10,29 @@ import {
   type SimIamInterServiceAuthZ,
 } from "../iam/authorize/sim-iam-inter-service-auth-z.js";
 import { SimEventBus } from "./bus/sim-event-bus.js";
-import { defaultEventBusName } from "./bus/sim-event-bus-name.js";
 import { SimEventBusStore } from "./bus/sim-event-bus-store.js";
 import type * as simEventBridgeCommands from "./command/sim-event-bridge-command.types.js";
 import { SimEventBridgeCommands } from "./command/sim-event-bridge-commands.js";
 import type { SimEventBridgeRequestOptions } from "./command/sim-event-bridge-request-options.js";
-import type { SimEventBridgeEvent } from "./event/sim-event-bridge-event.js";
-import type { SimEventBusReceipt } from "./bus/sim-event-bus.js";
-import type { SimEventRule } from "./rule/sim-event-rule.js";
 import { SimEventRuleStore } from "./rule/sim-event-rule-store.js";
+import { SimEventTargetStore } from "./target/sim-event-target-store.js";
+import type { SimEventBridgeDeliveryTargets } from "./delivery/sim-event-bridge-delivery.js";
+import type { SimEventBridgeDeliveryFailure } from "./delivery/sim-event-bridge-delivery-failures.js";
 import { SimEventBridgeSdkCommandRouter } from "./sdk/sim-event-bridge-sdk-command-router.js";
+import { SimEventBridgeInspection } from "./sim-event-bridge-inspection.js";
 
 interface SimEventBridgeProperties {
   readonly accountRegionScope?: SimAwsAccountRegionScope;
   readonly iam?: SimIamInterServiceAuthZ;
   readonly background?: BackgroundScheduler;
+
+  /**
+   * Where this scope's rules deliver to.
+   *
+   * A SimEventBridge built on its own has none, since a queue, topic or
+   * function in another simulated service is only reachable through SimAws.
+   */
+  readonly deliveryTargets?: SimEventBridgeDeliveryTargets;
 }
 
 /**
@@ -40,14 +48,17 @@ interface SimEventBridgeProperties {
  * matches nothing is gone. Rules and targets are not simulated yet, so every
  * event put onto a bus today is dropped after it arrives.
  */
-export class SimEventBridge {
-  private readonly buses: SimEventBusStore;
-  private readonly rules = new SimEventRuleStore();
+export class SimEventBridge extends SimEventBridgeInspection {
+  protected readonly buses: SimEventBusStore;
+  protected readonly rules = new SimEventRuleStore();
+  protected readonly targets = new SimEventTargetStore();
   private readonly commands: SimEventBridgeCommands;
   private readonly background: BackgroundScheduler;
   private readonly sdkRouter = new SimEventBridgeSdkCommandRouter(this);
 
   constructor(properties: SimEventBridgeProperties = {}) {
+    super();
+
     const {
       accountRegionScope = simAwsAccountRegionScopeFactory.make(),
       iam = new SimIamAllowAllAuth(),
@@ -61,6 +72,8 @@ export class SimEventBridge {
     this.commands = new SimEventBridgeCommands({
       buses: this.buses,
       rules: this.rules,
+      targets: this.targets,
+      deliveryTargets: properties.deliveryTargets,
       iam,
       background,
       accountRegionScope,
@@ -68,49 +81,13 @@ export class SimEventBridge {
   }
 
   /**
-   * Find an event bus by name.
+   * Every event this scope's rules could not get to a target.
    *
-   * This is the simulator's own accessor, for tests seeding or inspecting bus
-   * state without going through a Command and its authorization.
+   * Real EventBridge tells the caller nothing about a failed delivery, and
+   * neither does this. A target that is unexpectedly empty is explained here.
    */
-  findEventBus(name: string): SimEventBus | undefined {
-    return this.buses.find(name);
-  }
-
-  /**
-   * Every event a bus received, in arrival order.
-   *
-   * This is the simulator's own accessor, for a test asserting on the envelope
-   * EventBridge built from a PutEvents entry. Real EventBridge keeps no events
-   * and offers nothing like it, so nothing an SDK command returns is built
-   * from this. A bus that is not there received nothing.
-   */
-  eventsOn(busName: string): readonly SimEventBridgeEvent[] {
-    return this.buses.find(busName)?.receivedEvents ?? [];
-  }
-
-  /**
-   * Find a rule by name, on a bus.
-   *
-   * This is the simulator's own accessor, for tests seeding or inspecting rule
-   * state without going through a Command and its authorization.
-   */
-  findRule(
-    ruleName: string,
-    busName = defaultEventBusName,
-  ): SimEventRule | undefined {
-    return this.rules.find(busName, ruleName);
-  }
-
-  /**
-   * Every event a bus received, with the rules each one matched.
-   *
-   * This is the simulator's own accessor, for a test asserting on which rules
-   * an event reached. Real EventBridge keeps nothing like it, and nothing an
-   * SDK command returns is built from it.
-   */
-  receiptsOn(busName: string): readonly SimEventBusReceipt[] {
-    return this.buses.find(busName)?.receipts ?? [];
+  get deliveryFailures(): readonly SimEventBridgeDeliveryFailure[] {
+    return this.commands.router.deliveryFailures;
   }
 
   /**
@@ -243,6 +220,50 @@ export class SimEventBridge {
   ): Promise<simEventBridgeCommands.SimTestEventPatternCommandOutput> {
     await this.background.sequence();
     return this.commands.patternTest.handle(command, options);
+  }
+
+  /**
+   * Handle a PutTargets Command from the SDK.
+   */
+  async putTargets(
+    command: simEventBridgeCommands.SimPutTargetsCommand,
+    options?: SimEventBridgeRequestOptions,
+  ): Promise<simEventBridgeCommands.SimPutTargetsCommandOutput> {
+    await this.background.sequence();
+    return this.commands.targetCreation.handle(command, options);
+  }
+
+  /**
+   * Handle a RemoveTargets Command from the SDK.
+   */
+  async removeTargets(
+    command: simEventBridgeCommands.SimRemoveTargetsCommand,
+    options?: SimEventBridgeRequestOptions,
+  ): Promise<simEventBridgeCommands.SimRemoveTargetsCommandOutput> {
+    await this.background.sequence();
+    return this.commands.targets.removeTargets(command, options);
+  }
+
+  /**
+   * Handle a ListTargetsByRule Command from the SDK.
+   */
+  async listTargetsByRule(
+    command: simEventBridgeCommands.SimListTargetsByRuleCommand,
+    options?: SimEventBridgeRequestOptions,
+  ): Promise<simEventBridgeCommands.SimListTargetsByRuleCommandOutput> {
+    await this.background.sequence();
+    return this.commands.targets.listTargetsByRule(command, options);
+  }
+
+  /**
+   * Handle a ListRuleNamesByTarget Command from the SDK.
+   */
+  async listRuleNamesByTarget(
+    command: simEventBridgeCommands.SimListRuleNamesByTargetCommand,
+    options?: SimEventBridgeRequestOptions,
+  ): Promise<simEventBridgeCommands.SimListRuleNamesByTargetCommandOutput> {
+    await this.background.sequence();
+    return this.commands.targets.listRuleNamesByTarget(command, options);
   }
 
   /**

--- a/src/service/eventbridge/target/sim-event-target-arn.ts
+++ b/src/service/eventbridge/target/sim-event-target-arn.ts
@@ -1,0 +1,127 @@
+import type { SimAwsAccountId } from "../../aws/sim-aws-account-id.js";
+import type { AwsRegionName } from "../../aws/sim-aws-region.js";
+import { SimEventBridgeValidationException } from "../error/sim-event-bridge.error.js";
+
+/**
+ * The services a simulated rule can send an event to.
+ */
+export const simEventTargetServices = ["lambda", "sqs", "sns"] as const;
+
+export type SimEventTargetService = (typeof simEventTargetServices)[number];
+
+/**
+ * The fewest colon separated parts any target ARN has.
+ */
+const minimumArnParts = 6;
+
+/**
+ * The same set as strings, for asking whether an arbitrary service name is one
+ * of them.
+ */
+const targetServices: ReadonlySet<string> = new Set(simEventTargetServices);
+
+/**
+ * Whether a service name is one this simulation delivers to.
+ */
+function isTargetService(value: string): value is SimEventTargetService {
+  return targetServices.has(value);
+}
+
+interface SimEventTargetArnProperties {
+  readonly value: string;
+  readonly service: SimEventTargetService;
+  readonly regionName: AwsRegionName;
+  readonly accountId: SimAwsAccountId;
+  readonly resource: string;
+}
+
+/**
+ * The ARN of somewhere a rule sends events.
+ *
+ * Target ARNs are read here rather than by `parseSimArn`, because the three
+ * services this delivers to write their resource part three ways: a queue and
+ * a topic put the name straight after the Account with no type in front of it,
+ * and a function writes `function:<name>`.
+ *
+ * A target in another Account or Region is allowed, as real EventBridge
+ * delivers across both.
+ */
+export class SimEventTargetArn {
+  public readonly value: string;
+  public readonly service: SimEventTargetService;
+  public readonly regionName: AwsRegionName;
+  public readonly accountId: SimAwsAccountId;
+
+  /**
+   * The resource part of the ARN, with no type separator taken off it.
+   */
+  public readonly resource: string;
+
+  private constructor(properties: SimEventTargetArnProperties) {
+    this.value = properties.value;
+    this.service = properties.service;
+    this.regionName = properties.regionName;
+    this.accountId = properties.accountId;
+    this.resource = properties.resource;
+  }
+
+  /**
+   * Read a target ARN, refusing one this simulation cannot deliver to.
+   *
+   * An ARN naming a service that is not simulated as a target is refused when
+   * the target is added rather than when an event first matches, so a rule
+   * that cannot work says so at the point it was written.
+   */
+  static of(value: string | undefined): SimEventTargetArn {
+    if (value === undefined || value === "") {
+      throw new SimEventBridgeValidationException(
+        "Invalid parameter: Target Arn is required",
+      );
+    }
+
+    const parts = value.split(":");
+    const [prefix, partition, service, regionName, accountId] = parts;
+
+    if (
+      parts.length < minimumArnParts ||
+      prefix !== "arn" ||
+      partition !== "aws" ||
+      service === undefined ||
+      regionName === undefined ||
+      accountId === undefined
+    ) {
+      throw new SimEventBridgeValidationException(
+        `Invalid parameter: Target Arn Reason: ${value} is not an ARN`,
+      );
+    }
+
+    if (!isTargetService(service)) {
+      throw new SimEventBridgeValidationException(
+        `Target ${value} names ${service}, and simulated EventBridge rules ` +
+          `deliver to ${simEventTargetServices.join(", ")} targets only.`,
+      );
+    }
+
+    // Branded at the parse boundary, the way every other ARN reader in the
+    // simulator does it: what came off the wire is a string, and this is where
+    // it becomes a scope the rest of the simulation can be asked about.
+    return new this({
+      value,
+      service,
+      regionName: regionName as AwsRegionName,
+      accountId: accountId as SimAwsAccountId,
+      resource: parts.slice(minimumArnParts - 1).join(":"),
+    });
+  }
+
+  /**
+   * The name of a Lambda function this ARN names.
+   *
+   * A function ARN's resource is `function:<name>`, and may carry a version or
+   * alias after a second colon, which this simulation does not model and so
+   * reads as part of nothing.
+   */
+  get functionName(): string {
+    return this.resource.split(":", 2)[1] ?? "";
+  }
+}

--- a/src/service/eventbridge/target/sim-event-target-arn.ts
+++ b/src/service/eventbridge/target/sim-event-target-arn.ts
@@ -81,14 +81,21 @@ export class SimEventTargetArn {
 
     const parts = value.split(":");
     const [prefix, partition, service, regionName, accountId] = parts;
+    const resource = parts.slice(minimumArnParts - 1).join(":");
 
+    // Every part after a split is a string, so each one has to be checked for
+    // being empty as well as for being there: `arn:aws:sqs:::` has six parts
+    // and names nothing.
     if (
       parts.length < minimumArnParts ||
       prefix !== "arn" ||
       partition !== "aws" ||
       service === undefined ||
       regionName === undefined ||
-      accountId === undefined
+      regionName === "" ||
+      accountId === undefined ||
+      accountId === "" ||
+      resource === ""
     ) {
       throw new SimEventBridgeValidationException(
         `Invalid parameter: Target Arn Reason: ${value} is not an ARN`,
@@ -105,13 +112,23 @@ export class SimEventTargetArn {
     // Branded at the parse boundary, the way every other ARN reader in the
     // simulator does it: what came off the wire is a string, and this is where
     // it becomes a scope the rest of the simulation can be asked about.
-    return new this({
+    const arn = new this({
       value,
       service,
       regionName: regionName as AwsRegionName,
       accountId: accountId as SimAwsAccountId,
-      resource: parts.slice(minimumArnParts - 1).join(":"),
+      resource,
     });
+
+    if (arn.service === "lambda" && arn.functionName === "") {
+      throw new SimEventBridgeValidationException(
+        `Invalid parameter: Target Arn Reason: ${value} names no function. ` +
+          `A function ARN is ` +
+          `arn:aws:lambda:<region>:<account-id>:function:<function-name>`,
+      );
+    }
+
+    return arn;
   }
 
   /**

--- a/src/service/eventbridge/target/sim-event-target-store.ts
+++ b/src/service/eventbridge/target/sim-event-target-store.ts
@@ -1,0 +1,104 @@
+import type { SimEventRule } from "../rule/sim-event-rule.js";
+import type { SimEventTarget } from "./sim-event-target.js";
+
+/**
+ * The most targets real EventBridge allows on one rule.
+ */
+export const simEventMaximumTargets = 5;
+
+/**
+ * How a rule's targets are keyed, which is by bus as well as by rule name,
+ * since a rule name is only unique within one bus.
+ */
+function ruleKey(busName: string, ruleName: string): string {
+  return `${busName} ${ruleName}`;
+}
+
+/**
+ * The targets of the rules of one simulated EventBridge scope.
+ *
+ * Targets are held apart from the rules rather than on them, the same way a
+ * topic's subscriptions are held apart from the topic in simulated SNS. A rule
+ * with no targets is a rule that matches events and sends them nowhere, which
+ * is a thing real EventBridge lets you have, and holding them apart is what
+ * keeps that from looking like a broken rule.
+ */
+export class SimEventTargetStore {
+  private readonly byRule = new Map<string, SimEventTarget[]>();
+
+  /**
+   * The targets of one rule, in the order they were added.
+   */
+  forRule(busName: string, ruleName: string): readonly SimEventTarget[] {
+    return this.byRule.get(ruleKey(busName, ruleName)) ?? [];
+  }
+
+  /**
+   * Add targets to a rule, replacing any of the same id.
+   *
+   * Replacing by id is what PutTargets does: a second request naming an
+   * existing id is that target's new definition rather than a second target
+   * beside it.
+   */
+  put(
+    busName: string,
+    ruleName: string,
+    targets: readonly SimEventTarget[],
+  ): void {
+    const key = ruleKey(busName, ruleName);
+    const kept = this.forRule(busName, ruleName).filter((existing) =>
+      targets.every((target) => target.id !== existing.id),
+    );
+
+    this.byRule.set(key, [...kept, ...targets]);
+  }
+
+  /**
+   * Remove the targets of a rule by id, answering the ids that were not there.
+   */
+  remove(
+    busName: string,
+    ruleName: string,
+    ids: readonly string[],
+  ): readonly string[] {
+    const key = ruleKey(busName, ruleName);
+    const existing = this.forRule(busName, ruleName);
+
+    this.byRule.set(
+      key,
+      existing.filter((target) => !ids.includes(target.id)),
+    );
+
+    return ids.filter((id) => existing.every((target) => target.id !== id));
+  }
+
+  /**
+   * Forget every target of a rule, which deleting that rule does.
+   */
+  removeForRule(busName: string, ruleName: string): void {
+    this.byRule.delete(ruleKey(busName, ruleName));
+  }
+
+  /**
+   * Forget the targets of every rule of a bus, which deleting that bus does.
+   */
+  removeForRules(rules: readonly SimEventRule[]): void {
+    for (const rule of rules) {
+      this.removeForRule(rule.busName.value, rule.name.value);
+    }
+  }
+
+  /**
+   * Whether any rule of a bus sends events to a target ARN.
+   */
+  rulesSendingTo(
+    rules: readonly SimEventRule[],
+    targetArn: string,
+  ): readonly SimEventRule[] {
+    return rules.filter((rule) =>
+      this.forRule(rule.busName.value, rule.name.value).some(
+        (target) => target.arn.value === targetArn,
+      ),
+    );
+  }
+}

--- a/src/service/eventbridge/target/sim-event-target.ts
+++ b/src/service/eventbridge/target/sim-event-target.ts
@@ -1,0 +1,103 @@
+import { SimEventBridgeValidationException } from "../error/sim-event-bridge.error.js";
+import { SimEventTargetArn } from "./sim-event-target-arn.js";
+
+/**
+ * Real EventBridge allows alphanumerics, full stops, hyphens and underscores,
+ * up to 64 characters, for a target id.
+ */
+const targetIdPattern = /^[.\-_A-Za-z0-9]{1,64}$/;
+
+interface SimEventTargetProperties {
+  readonly id: string;
+  readonly arn: SimEventTargetArn;
+  readonly input: string | undefined;
+}
+
+/**
+ * One place a rule sends the events it matches.
+ *
+ * A target's id is how it is replaced and removed, and it is unique within one
+ * rule rather than globally. Two rules may each have a target called `main`,
+ * and one rule may send the same event to two targets with different ids and
+ * the same ARN.
+ */
+export class SimEventTarget {
+  public readonly id: string;
+  public readonly arn: SimEventTargetArn;
+
+  /**
+   * The fixed JSON this target receives instead of the event, where one was
+   * set.
+   *
+   * Real EventBridge sends the value as written, so a target with an `Input`
+   * of `"hello"` receives the JSON string rather than the event that triggered
+   * it. That is what makes `Input` useful for a target which only needs to
+   * know that something happened.
+   */
+  public readonly input: string | undefined;
+
+  private constructor(properties: SimEventTargetProperties) {
+    this.id = properties.id;
+    this.arn = properties.arn;
+    this.input = properties.input;
+  }
+
+  /**
+   * Read a target from request input.
+   */
+  static of(properties: {
+    readonly Id?: string | undefined;
+    readonly Arn?: string | undefined;
+    readonly Input?: string | undefined;
+  }): SimEventTarget {
+    return new this({
+      id: this.requiredId(properties.Id),
+      arn: SimEventTargetArn.of(properties.Arn),
+      input: this.readInput(properties.Input),
+    });
+  }
+
+  /**
+   * Read a target's fixed input, which has to be JSON.
+   *
+   * Checked here rather than at delivery, because a target that cannot be
+   * delivered to should say so when it is added, and because a delivery
+   * failing on a parse would be reported as the target refusing the event.
+   */
+  private static readInput(input: string | undefined): string | undefined {
+    if (input === undefined) {
+      return undefined;
+    }
+
+    try {
+      JSON.parse(input);
+    } catch {
+      throw new SimEventBridgeValidationException(
+        `Invalid parameter: Target Input Reason: the input is not valid JSON`,
+      );
+    }
+
+    return input;
+  }
+
+  /**
+   * Read the id a target has to carry.
+   */
+  private static requiredId(id: string | undefined): string {
+    if (id === undefined || id === "") {
+      throw new SimEventBridgeValidationException(
+        "Invalid parameter: Target Id is required",
+      );
+    }
+
+    if (!targetIdPattern.test(id)) {
+      throw new SimEventBridgeValidationException(
+        `Invalid parameter: Target Id Reason: '${id}' is not a valid target ` +
+          `id. Target ids are made up of only letters, numbers, full stops, ` +
+          `hyphens and underscores, and are between 1 and 64 characters long.`,
+      );
+    }
+
+    return id;
+  }
+}


### PR DESCRIPTION
The second half of issue #532, and the part that closes it. Rules can now send the events they match to a simulated Lambda function, SQS queue or SNS topic.

Adds PutTargets, RemoveTargets, ListTargetsByRule and ListRuleNamesByTarget. A rule takes at most five targets, a target id is unique within a rule, and PutTargets replaces a target of the same id rather than adding a second. A target's fixed `Input` is sent as written where one is set, and is validated as JSON when the target is added rather than failing every delivery later.

Authorization reuses what was already there. EventBridge reaches a target as the `events.amazonaws.com` service principal, and the target's own resource policy is the whole decision: `SimSqsServiceSendAuthorizer`, `SimSnsServicePublishAuthorizer` and `SimLambdaServiceInvokeAuthorizer` all existed for simulated SNS's fan-out and answer the same question here with a different principal. Nothing about who may reach a queue lives in this service. The policy is consulted on every delivery rather than when the target is added, so a permission taken away afterwards stops delivery, which is also what real EventBridge does.

Delivery runs on the background scheduler, as real EventBridge delivers after PutEvents has answered, so a test waits with `backgroundTasksComplete()`. Real EventBridge tells the caller nothing about a failed delivery, so a delivery that could not be made is recorded on `deliveryFailures` instead, and a target that names nothing reads differently from one whose policy said no.

Two divergences beyond the ones already recorded. Deleting a rule deletes its targets, matching the existing bus behaviour, where real EventBridge refuses to delete either while something still hangs off it. And PutTargets refuses the whole request for a target it will not take, where real EventBridge reports a failed entry: every failure this simulation has is about the request naming something unmodelled, and a caller not reading `FailedEntryCount` would otherwise see a silent no-op. Both are in the docs page and the service README.

A target ARN naming a service other than Lambda, SQS or SNS is refused when the target is added rather than when an event first matches, so a rule that cannot work says so at the point it was written.

Resolves https://github.com/KensioSoftware/yulin/issues/532


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added simulated EventBridge targets for Lambda, SQS, and SNS.
  * Added target management commands for creating, listing, and removing targets.
  * Events are delivered asynchronously to matching targets, with resource-policy authorization.
  * Added delivery failure tracking for unavailable or unauthorized targets.
  * Added inspection support for rule targets, received events, and delivery failures.
  * Added validation for target ARNs, inputs, unsupported services, and target limits.

* **Documentation**
  * Expanded EventBridge documentation and examples covering target configuration, authorization, delivery, failures, and limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->