### PR TITLE
feat: fire scheduled simulated EventBridge rules on the clock

### DIFF
--- a/docs/services/eventbridge/README.md
+++ b/docs/services/eventbridge/README.md
@@ -4,8 +4,9 @@ Yulin includes a simulated Amazon EventBridge for tests and local development. E
 in memory and every operation is authorized by simulated IAM.
 
 Event buses, rules, targets and `PutEvents`. A rule can send matched events to a simulated Lambda
-function, SQS queue or SNS topic. EventBridge Scheduler and scheduled rules are not simulated yet. EventBridge-specific
-types are imported from the `@kensio/yulin/eventbridge` subpath.
+function, SQS queue or SNS topic, or fire on a schedule when a test advances simulated time.
+EventBridge Scheduler is not simulated yet. EventBridge-specific types are imported from the
+`@kensio/yulin/eventbridge` subpath.
 
 ## Putting an event onto a bus
 
@@ -469,6 +470,112 @@ console.log(JSON.stringify(queuePolicy).length > 0); // true
 
 An event delivered across accounts still names the account it was put in, not the target's.
 
+## Rules that fire on a schedule
+
+A rule created with a `ScheduleExpression` instead of an event pattern fires on its own timing rather
+than in response to anything put onto a bus. That timing is the simulation's clock, not the host's:
+the rule fires when a test advances simulated time past a due instant, and never otherwise. So a
+schedule that takes an hour in production takes no time at all to test.
+
+```typescript sim-event-bridge-scheduled-rules
+/**
+ * A scheduled rule invoking a function three times in three simulated hours.
+ */
+
+import { PutRuleCommand, PutTargetsCommand } from "@aws-sdk/client-eventbridge";
+import { AddPermissionCommand } from "@aws-sdk/client-lambda";
+
+import { SimAws, SimFixedClock } from "@kensio/yulin";
+import { makeLambdaZipFileInput } from "@kensio/yulin/lambda";
+
+const simAws = new SimAws({
+  clock: new SimFixedClock(new Date("2026-07-26T09:00:00.000Z")),
+});
+
+const ranAt: string[] = [];
+
+await simAws.lambda().createFunction({
+  input: {
+    FunctionName: "reconcile",
+    Role: "arn:aws:iam::888888888888:role/ReconcileRole",
+    Code: {
+      ZipFile: makeLambdaZipFileInput((event: { time: string }) => {
+        ranAt.push(event.time);
+        return { ok: true };
+      }),
+    },
+  },
+});
+
+await simAws.lambda().addPermission(
+  new AddPermissionCommand({
+    FunctionName: "reconcile",
+    StatementId: "events",
+    Action: "lambda:InvokeFunction",
+    Principal: "events.amazonaws.com",
+  }),
+);
+
+await simAws.eventBridge().putRule(
+  new PutRuleCommand({
+    Name: "hourly-reconciliation",
+    ScheduleExpression: "rate(1 hour)",
+  }),
+);
+
+await simAws.eventBridge().putTargets(
+  new PutTargetsCommand({
+    Rule: "hourly-reconciliation",
+    Targets: [
+      {
+        Id: "reconcile",
+        Arn: "arn:aws:lambda:us-east-1:888888888888:function:reconcile",
+      },
+    ],
+  }),
+);
+
+// Three simulated hours later, the function has run three times.
+await simAws.clock().advanceBy({ hours: 3 });
+
+console.log(ranAt);
+// [ '2026-07-26T10:00:00Z', '2026-07-26T11:00:00Z', '2026-07-26T12:00:00Z' ]
+```
+
+Firing is per due instant rather than per advance. Advancing an hour with a `rate(1 minute)` rule
+invokes the target sixty times, at sixty distinct simulated timestamps, because that is what an hour
+of that rule does. `advanceBy(...)` returns once every one of those firings and its deliveries have
+settled, so the next line can assert.
+
+A scheduled event carries the standard envelope with `source: "aws.events"`,
+`detail-type: "Scheduled Event"` and an empty `detail`, and names the rule that fired in `resources`.
+Its `time` is the instant the rule fell due, not the instant the advance finished, which is the field
+AWS advises scheduled handler code to read instead of the clock.
+
+### Writing the schedule
+
+`rate(<value> <unit>)` runs from the moment the rule was created, so a `rate(1 day)` rule created at
+half past nine falls due at half past nine. The unit is `minute`, `hour` or `day`, and has to agree
+with its value: `rate(1 hour)` and `rate(5 hours)` are the valid forms, and `rate(1 hours)` is
+refused as real EventBridge refuses it. There is no unit under a minute, which is the finest schedule
+AWS runs.
+
+`cron(<six fields>)` names absolute instants in UTC. The six fields are minutes, hours, day-of-month,
+month, day-of-week and year, so the every-day-at-noon expression is `cron(0 12 * * ? *)`. A five field
+expression, which is what Unix cron takes, is refused naming the six-field form. Day-of-week runs
+`1-7` or `SUN-SAT` with Sunday as one, unlike Unix cron, and the day-of-month and day-of-week fields
+cannot both say something: whichever is not deciding the day is written `?`.
+
+A scheduled rule only works on the `default` bus, as it does on real AWS, and a `ScheduleExpression`
+on any other bus is refused.
+
+`DisableRule` stops a scheduled rule firing while it is off, and `EnableRule` picks up from the next
+due instant rather than replaying what was missed. `DeleteRule` stops it for good, and `PutRule`
+replacing a scheduled rule restarts the schedule from the replacement.
+
+A rule with no target still fires, and what it produced can be read with `eventsOn(...)`, which is
+useful for asserting on the schedule itself before there is anything to deliver to.
+
 ## Deliveries that did not happen
 
 Real EventBridge tells the caller nothing about a failed delivery: a `PutEvents` that matched a rule
@@ -590,6 +697,8 @@ no permission for.
 - `CreateEventBus`, `DeleteEventBus`, `DescribeEventBus`, `ListEventBuses` and `PutEvents`.
 - `PutRule`, `DeleteRule`, `DescribeRule`, `ListRules`, `EnableRule`, `DisableRule` and
   `TestEventPattern`.
+- Scheduled rules, with a `rate(...)` or six field `cron(...)` `ScheduleExpression`, fired by
+  advancing the simulation's clock.
 - Event pattern matching on exact values, nested fields, lists, `prefix`, `suffix`, `anything-but`,
   `numeric` and `exists`.
 - `PutTargets`, `RemoveTargets`, `ListTargetsByRule` and `ListRuleNamesByTarget`, with delivery to a
@@ -616,8 +725,15 @@ no permission for.
 - The `cidr`, `equals-ignore-case`, `wildcard` and `$or` pattern operators are refused rather than
   evaluated, as are the nested forms of `anything-but` and the case-insensitive forms of `prefix`
   and `suffix`.
-- Scheduled rules and EventBridge Scheduler are not simulated, so `PutRule` refuses a
-  `ScheduleExpression`. A rule needs an event pattern.
+- A rule needs an `EventPattern`, a `ScheduleExpression` or both. Real EventBridge takes a rule with
+  neither, which matches nothing and fires never, and that is refused here rather than created.
+- A scheduled rule only fires while a test advances the simulation's clock. Nothing runs on the
+  host's clock, so a simulation left alone in real time fires nothing.
+- `ScheduleExpressionTimezone` and the `L`, `W` and `#` cron wildcards are refused rather than
+  simulated. Everything is read in UTC.
+- Firing is exact and exactly once. Real EventBridge may deliver a scheduled event a few seconds
+  late, and may deliver it more than once.
+- EventBridge Scheduler is a separate service and is not simulated.
 - Rule tags, a rule `RoleArn`, managed rules and the
   `ENABLED_WITH_ALL_CLOUDTRAIL_MANAGEMENT_EVENTS` state are refused rather than simulated.
 - Deleting an event bus deletes its rules, and deleting a rule deletes its targets. Real EventBridge

--- a/docs/services/eventbridge/README.md
+++ b/docs/services/eventbridge/README.md
@@ -561,7 +561,7 @@ refused as real EventBridge refuses it. There is no unit under a minute, which i
 AWS runs.
 
 `cron(<six fields>)` names absolute instants in UTC. The six fields are minutes, hours, day-of-month,
-month, day-of-week and year, so the every-day-at-noon expression is `cron(0 12 * * ? *)`. A five field
+month, day-of-week and year, so the every-day-at-noon expression is `cron(0 12 * * ? *)`. A five-field
 expression, which is what Unix cron takes, is refused naming the six-field form. Day-of-week runs
 `1-7` or `SUN-SAT` with Sunday as one, unlike Unix cron, and the day-of-month and day-of-week fields
 cannot both say something: whichever is not deciding the day is written `?`.
@@ -697,7 +697,7 @@ no permission for.
 - `CreateEventBus`, `DeleteEventBus`, `DescribeEventBus`, `ListEventBuses` and `PutEvents`.
 - `PutRule`, `DeleteRule`, `DescribeRule`, `ListRules`, `EnableRule`, `DisableRule` and
   `TestEventPattern`.
-- Scheduled rules, with a `rate(...)` or six field `cron(...)` `ScheduleExpression`, fired by
+- Scheduled rules, with a `rate(...)` or six-field `cron(...)` `ScheduleExpression`, fired by
   advancing the simulation's clock.
 - Event pattern matching on exact values, nested fields, lists, `prefix`, `suffix`, `anything-but`,
   `numeric` and `exists`.

--- a/docs/services/eventbridge/sim-event-bridge-scheduled-rules.example.ts
+++ b/docs/services/eventbridge/sim-event-bridge-scheduled-rules.example.ts
@@ -1,0 +1,62 @@
+/**
+ * A scheduled rule invoking a function three times in three simulated hours.
+ */
+
+import { PutRuleCommand, PutTargetsCommand } from "@aws-sdk/client-eventbridge";
+import { AddPermissionCommand } from "@aws-sdk/client-lambda";
+
+import { SimAws, SimFixedClock } from "@kensio/yulin";
+import { makeLambdaZipFileInput } from "@kensio/yulin/lambda";
+
+const simAws = new SimAws({
+  clock: new SimFixedClock(new Date("2026-07-26T09:00:00.000Z")),
+});
+
+const ranAt: string[] = [];
+
+await simAws.lambda().createFunction({
+  input: {
+    FunctionName: "reconcile",
+    Role: "arn:aws:iam::888888888888:role/ReconcileRole",
+    Code: {
+      ZipFile: makeLambdaZipFileInput((event: { time: string }) => {
+        ranAt.push(event.time);
+        return { ok: true };
+      }),
+    },
+  },
+});
+
+await simAws.lambda().addPermission(
+  new AddPermissionCommand({
+    FunctionName: "reconcile",
+    StatementId: "events",
+    Action: "lambda:InvokeFunction",
+    Principal: "events.amazonaws.com",
+  }),
+);
+
+await simAws.eventBridge().putRule(
+  new PutRuleCommand({
+    Name: "hourly-reconciliation",
+    ScheduleExpression: "rate(1 hour)",
+  }),
+);
+
+await simAws.eventBridge().putTargets(
+  new PutTargetsCommand({
+    Rule: "hourly-reconciliation",
+    Targets: [
+      {
+        Id: "reconcile",
+        Arn: "arn:aws:lambda:us-east-1:888888888888:function:reconcile",
+      },
+    ],
+  }),
+);
+
+// Three simulated hours later, the function has run three times.
+await simAws.clock().advanceBy({ hours: 3 });
+
+console.log(ranAt);
+// [ '2026-07-26T10:00:00Z', '2026-07-26T11:00:00Z', '2026-07-26T12:00:00Z' ]

--- a/docs/time/README.md
+++ b/docs/time/README.md
@@ -141,9 +141,10 @@ If work triggered by advancing fails, the failure is thrown from `advanceBy(...)
 in the background, and the clock is left at the point it failed rather than at the instant asked
 for. Anything still queued stays queued.
 
-Nothing in the simulator schedules work on the clock yet, so today advancing mostly changes what
-timestamps and expiry checks see. The mechanism is there for scheduled behaviour to hook into as
-it arrives.
+Several parts of the simulator schedule work on the clock, so advancing time does more than change
+what timestamps and expiry checks see. A scheduled EventBridge rule fires, a DynamoDB item passes
+its time to live, a Secrets Manager deletion falls due, and a Lambda event source mapping polls
+again. Each of those runs at its own due instant inside the interval, not all at once at the end.
 
 ## Time inside a simulated Lambda handler
 
@@ -253,10 +254,11 @@ runs on a clock a test can control: `await simSdk.simAws.clock().advanceBy({ hou
 
 ## Limitations
 
-- There are no scheduled event sources such as EventBridge rules, so nothing here is driven by a
-  cron or rate expression. What the clock does drive is state that falls due: a Secrets Manager
-  recovery window running out, or a DynamoDB item passing its
-  [time to live](../services/dynamodb/#expiring-items-with-time-to-live) deletion window.
+- Advancing the clock is the only thing that fires a scheduled
+  [EventBridge rule](../services/eventbridge/#rules-that-fire-on-a-schedule). Nothing runs on the
+  host's clock, so a simulation left alone in real time fires nothing however long it is left.
+- EventBridge Scheduler is not simulated, so `rate` and `cron` reach the clock through an
+  EventBridge rule only.
 - Only `SimAws` exposes time control. Services constructed standalone, such as `new SimS3()`, get
   their own real clock and no way to move it.
 - A `SimAws` constructed with a `background` scheduler of its own cannot control time, because that

--- a/src/service/eventbridge/README.md
+++ b/src/service/eventbridge/README.md
@@ -1,7 +1,7 @@
 # Simulated EventBridge implementation
 
 This directory contains the simulated EventBridge service implementation. Event buses, rules,
-targets and PutEvents. EventBridge Scheduler and scheduled rules come later.
+targets, PutEvents and scheduled rules. EventBridge Scheduler comes later.
 
 The guiding decision here is that a bus is a router rather than a store. Real EventBridge keeps no
 events, so nothing here answers an SDK command from stored events. The events a bus does keep are a
@@ -47,9 +47,12 @@ does.
 
 Rule state lives under `rule/`, and the pattern engine under `pattern/`.
 
-`SimEventRule` is a pattern and a state. What a rule does when it matches is deliberately not on it:
-targets will live in their own store, keyed by rule, the same way a topic's subscriptions are in
-simulated SNS.
+`SimEventRule` is a state and whatever makes it fire: an event pattern, a schedule, or both. Both are
+optional on it and PutRule refuses a rule carrying neither, rather than the rule type being an
+enumeration: real EventBridge takes both on one rule, and a rule with only a schedule matching no
+event falls out of `pattern` being absent rather than out of a check. What a rule does when it fires
+is deliberately not on it: targets live in their own store, keyed by rule, the same way a topic's
+subscriptions are in simulated SNS.
 
 `eventRuleArn` is the one place a rule ARN is built, because a request has to authorize against the
 ARN a rule would have before knowing whether that rule exists. A rule on the default bus leaves the
@@ -130,11 +133,44 @@ its own gets `SimEventBridgeNoDeliveryTargets` instead, which records every deli
 saying why there was nowhere to make it. A rule that appeared to deliver to a target that was never
 reachable would be the worst of the possible answers.
 
+## Scheduled rules
+
+`schedule/` holds what makes a rule fire on its own, and the expression parser it uses lives in
+`src/util/schedule/` rather than here.
+
+That split is the point. EventBridge Scheduler is a separate service with its own dialect: its cron
+fields are the same six and its rate expression does not insist a unit agrees with its value. So
+`SimScheduleDialect` is what a service brings, and `eventBridgeScheduleDialect` in
+`sim-event-bridge-schedule.ts` is EventBridge's. The parser throws `SimScheduleExpressionError` and
+`SimUnsimulatedScheduleExpressionError`, which know nothing about any service, and
+`eventBridgeSchedule(...)` turns them into this service's own `ValidationException` and
+`UnsimulatedInputException`.
+
+`SimCronExpression.nextAfter(...)` searches rather than enumerates. A field that does not match skips
+the whole of the unit below it, so a month that does not match moves to the first of the next month
+instead of trying its forty thousand minutes. The search ends at the year after the dialect's highest,
+which is what gives a cron expression naming only past years an answer of "never" rather than a loop.
+
+`SimEventBridgeRuleSchedules` arms a rule for its next due instant through
+`BackgroundScheduler.scheduleAt`, and a firing arms the next one before it returns. That is what makes
+firing per due instant rather than per advance: `SimClockControl.advanceBy` walks the interval taking
+whatever has fallen due, so a rule rescheduling itself inside the interval is taken again in the same
+walk. An hour of `rate(1 minute)` is therefore sixty firings at sixty instants.
+
+Nothing cancels a timer. A firing checks that the rule it holds is still the rule its store has under
+that name, and stops if it is not, which covers deletion and a PutRule replacement in one. A disabled
+rule is re-armed without firing, which is what makes `EnableRule` pick up from the next due instant
+rather than replay what it missed.
+
 ## Routing
 
 `SimEventBridgeRouter` under `routing/` is what a bus does with an event: find the bus, ask each of
 its enabled rules, record the matches, and schedule a delivery for every target of every rule that
 matched. `SimEventBridgeTargetDelivery` makes each of those deliveries and keeps whatever went wrong.
+
+`fire(...)` is the scheduled path, and it skips the matching: nothing put the event onto the bus, so
+there is nothing to match it against. It still records the event on the bus, which is what lets a test
+with no target yet assert on a schedule through `eventsOn(...)`.
 
 The split is that the router decides and the delivery does. A failure is recorded rather than thrown
 because these run as background tasks: one left rejected would fail an unrelated
@@ -143,7 +179,7 @@ anyway.
 
 ## Divergences
 
-Five, all deliberate.
+Six, all deliberate.
 
 An entry naming a bus that does not exist **succeeds**. Real EventBridge answers 200, matches the
 event against no rule, and drops it, without counting the entry as failed. It is a trap, because a
@@ -166,3 +202,7 @@ no-op.
 Event bus resource policies are not modelled at all, since nothing sets one: `PutPermission` and the
 bus `Policy` attribute are both absent. A caller from another account therefore has no way to be
 admitted to a bus, which is stricter than real AWS.
+
+A scheduled rule fires **exactly, and exactly once**. Real EventBridge documents a delay of several
+seconds between a rule falling due and its target running, and does not promise a single delivery.
+Reproducing either would make a test on a schedule assert on something that is not the schedule.

--- a/src/service/eventbridge/command/rule/rule.command.ts
+++ b/src/service/eventbridge/command/rule/rule.command.ts
@@ -8,6 +8,7 @@ export interface SimListedRule {
   readonly Name: string;
   readonly Arn: string;
   readonly EventPattern?: string | undefined;
+  readonly ScheduleExpression?: string | undefined;
   readonly State: string;
   readonly Description?: string | undefined;
   readonly EventBusName: string;
@@ -75,6 +76,7 @@ export interface SimDescribeRuleCommandOutput {
   readonly Name?: string | undefined;
   readonly Arn?: string | undefined;
   readonly EventPattern?: string | undefined;
+  readonly ScheduleExpression?: string | undefined;
   readonly State?: string | undefined;
   readonly Description?: string | undefined;
   readonly EventBusName?: string | undefined;

--- a/src/service/eventbridge/command/rule/sim-event-bridge-listed-rule.ts
+++ b/src/service/eventbridge/command/rule/sim-event-bridge-listed-rule.ts
@@ -4,15 +4,17 @@ import type { SimListedRule } from "./rule.command.js";
 /**
  * One rule as a describe or a listing reports it.
  *
- * The pattern comes back as the string the rule was created with rather than a
- * re-serialised version of it, so a caller comparing what they read against
- * what they sent sees what they sent.
+ * The pattern and the schedule expression both come back as the strings the
+ * rule was created with rather than re-serialised versions of them, so a caller
+ * comparing what they read against what they sent sees what they sent. A rule
+ * with only a schedule reports no pattern, and the other way round.
  */
 export function listedRule(rule: SimEventRule): SimListedRule {
   return {
     Name: rule.name.value,
     Arn: rule.arn,
-    EventPattern: rule.pattern.source,
+    EventPattern: rule.pattern?.source,
+    ScheduleExpression: rule.schedule?.source,
     State: rule.state.value,
     Description: rule.description,
     EventBusName: rule.busName.value,

--- a/src/service/eventbridge/command/rule/sim-event-bridge-put-rule.ts
+++ b/src/service/eventbridge/command/rule/sim-event-bridge-put-rule.ts
@@ -1,21 +1,21 @@
 import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
-import { SimEventBridgeUnsimulatedInputException } from "../../error/sim-event-bridge.error.js";
-import { SimEventPattern } from "../../pattern/sim-event-pattern.js";
 import { SimEventRule } from "../../rule/sim-event-rule.js";
 import { SimEventRuleState } from "../../rule/sim-event-rule-state.js";
 import type { SimEventRuleStore } from "../../rule/sim-event-rule-store.js";
+import type { SimEventBridgeRuleSchedules } from "../../schedule/sim-event-bridge-rule-schedules.js";
 import type { SimEventBridgeRequestOptions } from "../sim-event-bridge-request-options.js";
 import { refuseUnsimulatedRuleInput } from "./sim-event-bridge-unsimulated-rule-input.js";
 import type { SimEventBridgeRuleAccess } from "./sim-event-bridge-rule-access.js";
+import { eventBridgeRuleTrigger } from "./sim-event-bridge-rule-trigger.js";
 import type {
   SimPutRuleCommand,
-  SimPutRuleCommandInput,
   SimPutRuleCommandOutput,
 } from "./rule.command.js";
 
 interface SimEventBridgePutRuleProperties {
   readonly rules: SimEventRuleStore;
   readonly access: SimEventBridgeRuleAccess;
+  readonly schedules: SimEventBridgeRuleSchedules;
   readonly accountRegionScope: SimAwsAccountRegionScope;
 }
 
@@ -28,38 +28,22 @@ interface SimEventBridgePutRuleProperties {
  * real behaviour and a common surprise, since a request meaning to change only
  * the state also clears the description.
  *
- * A rule needs an event pattern here. Real EventBridge also takes a schedule
- * expression instead, which is a rule that fires on a timer rather than on an
- * event, and that is not simulated yet.
+ * A rule carrying a `ScheduleExpression` is armed on the simulation's clock as
+ * soon as it is created, so a test advancing time past a due instant fires it.
+ * Replacing a scheduled rule restarts its schedule, since the rule the old one
+ * was counting for is no longer the rule of that name.
  */
 export class SimEventBridgePutRule {
   private readonly rules: SimEventRuleStore;
   private readonly access: SimEventBridgeRuleAccess;
+  private readonly schedules: SimEventBridgeRuleSchedules;
   private readonly accountRegionScope: SimAwsAccountRegionScope;
 
   constructor(properties: SimEventBridgePutRuleProperties) {
     this.rules = properties.rules;
     this.access = properties.access;
+    this.schedules = properties.schedules;
     this.accountRegionScope = properties.accountRegionScope;
-  }
-
-  /**
-   * Read the event pattern a rule has to carry here.
-   *
-   * Real EventBridge takes a rule with a schedule expression and no pattern,
-   * which fires on a timer. Nothing here fires on a timer yet, so a rule with
-   * neither is refused rather than created as a rule that matches nothing.
-   */
-  private static patternIn(input: SimPutRuleCommandInput): string {
-    if (input.EventPattern === undefined || input.EventPattern === "") {
-      throw new SimEventBridgeUnsimulatedInputException(
-        "A rule needs an EventPattern. Real EventBridge also takes a rule " +
-          "with a ScheduleExpression and no pattern, which fires on a timer " +
-          "rather than on an event, and scheduled rules are not simulated.",
-      );
-    }
-
-    return input.EventPattern;
   }
 
   /**
@@ -77,16 +61,20 @@ export class SimEventBridgePutRule {
 
     this.access.authorize("events:PutRule", requested, options);
 
+    const trigger = eventBridgeRuleTrigger(input, requested.busName.value);
+
     const rule = new SimEventRule({
       name: requested.name,
       busName: requested.busName,
       accountRegionScope: this.accountRegionScope,
-      pattern: SimEventPattern.of(SimEventBridgePutRule.patternIn(input)),
+      pattern: trigger.pattern,
+      schedule: trigger.schedule,
       state: SimEventRuleState.of(input.State),
       description: input.Description,
     });
 
     this.rules.put(rule);
+    this.schedules.arm(rule);
 
     return { $metadata: {}, RuleArn: rule.arn };
   }

--- a/src/service/eventbridge/command/rule/sim-event-bridge-rule-trigger.ts
+++ b/src/service/eventbridge/command/rule/sim-event-bridge-rule-trigger.ts
@@ -1,0 +1,65 @@
+import type { SimSchedule } from "../../../../util/schedule/sim-schedule.js";
+import { defaultEventBusName } from "../../bus/sim-event-bus-name.js";
+import {
+  SimEventBridgeUnsimulatedInputException,
+  SimEventBridgeValidationException,
+} from "../../error/sim-event-bridge.error.js";
+import { SimEventPattern } from "../../pattern/sim-event-pattern.js";
+import { eventBridgeSchedule } from "../../schedule/sim-event-bridge-schedule.js";
+import type { SimPutRuleCommandInput } from "./rule.command.js";
+
+/**
+ * What makes a rule fire: an event pattern, a schedule, or both.
+ */
+export interface SimEventBridgeRuleTrigger {
+  readonly pattern: SimEventPattern | undefined;
+  readonly schedule: SimSchedule | undefined;
+}
+
+/**
+ * Read what a PutRule says should make its rule fire.
+ *
+ * Real EventBridge takes a rule with neither, which matches nothing and fires
+ * never. That is refused here rather than created, because a rule that quietly
+ * does nothing is indistinguishable from a rule whose pattern went missing on
+ * the way in.
+ *
+ * A `ScheduleExpression` only works on the `default` bus, which is AWS's own
+ * restriction and worth reproducing: a scheduled rule put onto a custom bus is
+ * created on real AWS by neither the console nor the API, and a simulation that
+ * allowed it would let a test pass on a stack that cannot be deployed.
+ */
+export function eventBridgeRuleTrigger(
+  input: SimPutRuleCommandInput,
+  busName: string,
+): SimEventBridgeRuleTrigger {
+  const written = input.ScheduleExpression;
+
+  if (written !== undefined && busName !== defaultEventBusName) {
+    throw new SimEventBridgeValidationException(
+      `Parameter ScheduleExpression is not valid. Reason: a scheduled rule ` +
+        `is only allowed on the ${defaultEventBusName} event bus, and this ` +
+        `one is on ${busName}.`,
+    );
+  }
+
+  // An empty pattern is the same as none at all, since a rule needs something
+  // in it to match anything.
+  const patternText =
+    input.EventPattern === "" ? undefined : input.EventPattern;
+
+  if (patternText === undefined && written === undefined) {
+    throw new SimEventBridgeUnsimulatedInputException(
+      "A rule needs an EventPattern, a ScheduleExpression, or both. Real " +
+        "EventBridge also takes a rule with neither, which matches nothing " +
+        "and fires never, and that is refused here rather than created as a " +
+        "rule that quietly does nothing.",
+    );
+  }
+
+  return {
+    pattern:
+      patternText === undefined ? undefined : SimEventPattern.of(patternText),
+    schedule: written === undefined ? undefined : eventBridgeSchedule(written),
+  };
+}

--- a/src/service/eventbridge/command/rule/sim-event-bridge-rule-validation.iso.test.ts
+++ b/src/service/eventbridge/command/rule/sim-event-bridge-rule-validation.iso.test.ts
@@ -56,26 +56,17 @@ describe("EventBridge rule validation", () => {
     assertInstanceOf(tooLong, SimEventBridgeValidationException);
   });
 
-  it("refuses a rule with no event pattern, pointing at scheduled rules", async () => {
-    // Given a rule carrying neither a pattern nor anything else.
+  it("refuses a rule with neither a pattern nor a schedule", async () => {
+    // Given a rule carrying nothing that would make it fire.
     const error = await refusedRule({
       Name: "watcher",
       EventPattern: undefined,
     });
 
-    // Then it is refused, saying what the other kind of rule would be.
+    // Then it is refused, naming both of the things it could have carried.
     assertInstanceOf(error, SimEventBridgeUnsimulatedInputException);
+    assertStringIncludes(error.message, "EventPattern");
     assertStringIncludes(error.message, "ScheduleExpression");
-  });
-
-  it("refuses a scheduled rule rather than creating one that never fires", async () => {
-    const error = await refusedRule({
-      Name: "hourly",
-      ScheduleExpression: "rate(1 hour)",
-    });
-
-    assertInstanceOf(error, SimEventBridgeUnsimulatedInputException);
-    assertStringIncludes(error.message, "Scheduled rules are not simulated");
   });
 
   it("refuses rule inputs it does not model rather than dropping them", async () => {

--- a/src/service/eventbridge/command/rule/sim-event-bridge-unsimulated-rule-input.ts
+++ b/src/service/eventbridge/command/rule/sim-event-bridge-unsimulated-rule-input.ts
@@ -12,21 +12,13 @@ const maximumDescriptionLength = 512;
 /**
  * Refuse the rule request inputs this simulation does not model.
  *
- * A schedule expression is refused pointing at what it would have done, since
- * it is the one of these that is planned rather than declined. A role and tags
- * are refused because dropping either would leave a rule looking configured to
- * the request that sent it and unconfigured to everything else.
+ * A role and tags are refused because dropping either would leave a rule
+ * looking configured to the request that sent it and unconfigured to
+ * everything else.
  */
 export function refuseUnsimulatedRuleInput(
   input: SimPutRuleCommandInput,
 ): void {
-  if (input.ScheduleExpression !== undefined) {
-    throw new SimEventBridgeUnsimulatedInputException(
-      "Scheduled rules are not simulated, so PutRule refuses a " +
-        "ScheduleExpression rather than creating a rule that never fires",
-    );
-  }
-
   if (input.RoleArn !== undefined) {
     throw new SimEventBridgeUnsimulatedInputException(
       "A rule RoleArn is not simulated, so PutRule refuses one rather than " +

--- a/src/service/eventbridge/command/sim-event-bridge-commands.ts
+++ b/src/service/eventbridge/command/sim-event-bridge-commands.ts
@@ -7,6 +7,7 @@ import type { SimEventBridgeDeliveryTargets } from "../delivery/sim-event-bridge
 import { SimEventBridgeNoDeliveryTargets } from "../delivery/sim-event-bridge-no-delivery-targets.js";
 import type { SimEventRuleStore } from "../rule/sim-event-rule-store.js";
 import type { SimEventTargetStore } from "../target/sim-event-target-store.js";
+import { SimEventBridgeRuleSchedules } from "../schedule/sim-event-bridge-rule-schedules.js";
 import { SimEventBridgeAuthorizer } from "./authorize/sim-event-bridge-authorizer.js";
 import { SimEventBridgeBusAccess } from "./bus/sim-event-bridge-bus-access.js";
 import { SimEventBridgeBusCommands } from "./bus/sim-event-bridge-bus-commands.js";
@@ -49,6 +50,7 @@ export class SimEventBridgeCommands {
   public readonly targetCreation: SimEventBridgePutTargets;
   public readonly targets: SimEventBridgeTargetCommands;
   public readonly router: SimEventBridgeRouter;
+  public readonly schedules: SimEventBridgeRuleSchedules;
 
   constructor(properties: SimEventBridgeCommandsProperties) {
     const { buses, rules, targets, accountRegionScope, background } =
@@ -88,6 +90,12 @@ export class SimEventBridgeCommands {
       background,
       accountId: accountRegionScope.accountId,
     });
+    this.schedules = new SimEventBridgeRuleSchedules({
+      rules,
+      router: this.router,
+      background,
+      accountRegionScope,
+    });
     this.putEvents = new SimEventBridgePutEvents({
       access,
       accountRegionScope,
@@ -97,6 +105,7 @@ export class SimEventBridgeCommands {
     this.ruleCreation = new SimEventBridgePutRule({
       rules,
       access: ruleAccess,
+      schedules: this.schedules,
       accountRegionScope,
     });
     this.rules = new SimEventBridgeRuleCommands({

--- a/src/service/eventbridge/routing/sim-event-bridge-router.ts
+++ b/src/service/eventbridge/routing/sim-event-bridge-router.ts
@@ -86,6 +86,20 @@ export class SimEventBridgeRouter {
   }
 
   /**
+   * Send a scheduled rule's own event to its targets.
+   *
+   * This does not go through pattern matching, because nothing put it onto the
+   * bus: the rule's schedule produced it and the rule is the only thing it is
+   * for. It is still recorded on the bus, so a test with no target yet can see
+   * what firing produced through `eventsOn(...)`.
+   */
+  fire(rule: SimEventRule, event: SimEventBridgeEvent): void {
+    this.buses.find(rule.busName.value)?.receive(event, [rule.name.value]);
+
+    this.send(rule, event);
+  }
+
+  /**
    * Schedule one event for every target of a rule that matched it.
    */
   private send(rule: SimEventRule, event: SimEventBridgeEvent): void {

--- a/src/service/eventbridge/rule/sim-event-rule.ts
+++ b/src/service/eventbridge/rule/sim-event-rule.ts
@@ -1,3 +1,4 @@
+import type { SimSchedule } from "../../../util/schedule/sim-schedule.js";
 import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
 import type { SimEventBusName } from "../bus/sim-event-bus-name.js";
 import type { SimEventBridgeEnvelope } from "../event/sim-event-bridge-event.js";
@@ -10,7 +11,8 @@ interface SimEventRuleProperties {
   readonly name: SimEventRuleName;
   readonly busName: SimEventBusName;
   readonly accountRegionScope: SimAwsAccountRegionScope;
-  readonly pattern: SimEventPattern;
+  readonly pattern?: SimEventPattern | undefined;
+  readonly schedule?: SimSchedule | undefined;
   readonly state: SimEventRuleState;
   readonly description?: string | undefined;
 }
@@ -18,16 +20,26 @@ interface SimEventRuleProperties {
 /**
  * One simulated rule on one event bus.
  *
- * A rule is a pattern and a state. What it does when it matches is held apart
- * from it, in the targets of the rule, because a rule with no targets is a
- * rule that matches events and sends them nowhere, which is a thing real
+ * A rule is a state and something that triggers it: an event pattern, a
+ * schedule, or on real EventBridge both. What it does when it triggers is held
+ * apart from it, in the targets of the rule, because a rule with no targets is
+ * a rule that triggers and sends the event nowhere, which is a thing real
  * EventBridge lets you have.
  */
 export class SimEventRule {
   public readonly name: SimEventRuleName;
   public readonly busName: SimEventBusName;
   public readonly arn: string;
-  public readonly pattern: SimEventPattern;
+  public readonly pattern: SimEventPattern | undefined;
+
+  /**
+   * When this rule fires of its own accord, if it does.
+   *
+   * A scheduled rule is armed on the simulation's clock rather than the host's,
+   * so it fires when a test advances time past a due instant.
+   */
+  public readonly schedule: SimSchedule | undefined;
+
   public readonly description: string | undefined;
 
   private held: SimEventRuleState;
@@ -41,6 +53,7 @@ export class SimEventRule {
       properties.accountRegionScope,
     );
     this.pattern = properties.pattern;
+    this.schedule = properties.schedule;
     this.description = properties.description;
     this.held = properties.state;
   }
@@ -66,12 +79,15 @@ export class SimEventRule {
    * nowhere. That is the difference between disabling a rule and removing its
    * targets, and it is why a rule enabled again picks up from the next event
    * rather than replaying what it missed.
+   *
+   * A rule with only a schedule matches nothing either. It fires on its own
+   * timing, and an event put onto its bus has nothing to do with it.
    */
   matches(envelope: SimEventBridgeEnvelope): boolean {
     if (!this.held.isEnabled) {
       return false;
     }
 
-    return this.pattern.matches(envelope);
+    return this.pattern?.matches(envelope) ?? false;
   }
 }

--- a/src/service/eventbridge/schedule/sim-event-bridge-rule-schedules.ts
+++ b/src/service/eventbridge/schedule/sim-event-bridge-rule-schedules.ts
@@ -1,0 +1,107 @@
+import type { BackgroundScheduler } from "../../../util/background/background.js";
+import type { SimSchedule } from "../../../util/schedule/sim-schedule.js";
+import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+import type { SimEventBridgeRouter } from "../routing/sim-event-bridge-router.js";
+import type { SimEventRule } from "../rule/sim-event-rule.js";
+import type { SimEventRuleStore } from "../rule/sim-event-rule-store.js";
+import { simEventBridgeScheduledEvent } from "./sim-event-bridge-scheduled-event.js";
+
+interface SimEventBridgeRuleSchedulesProperties {
+  readonly rules: SimEventRuleStore;
+  readonly router: SimEventBridgeRouter;
+  readonly background: BackgroundScheduler;
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+}
+
+/**
+ * What makes a scheduled rule fire, which is simulated time reaching it.
+ *
+ * Nothing here runs on the host's clock. A scheduled rule is armed for its next
+ * due instant on the simulation's own clock, so it fires when a test advances
+ * time past that instant and never otherwise. Advancing an hour with a
+ * `rate(1 minute)` rule therefore fires it sixty times, at sixty distinct
+ * simulated instants, rather than once at the end: `advanceBy` walks the
+ * interval, and each firing arms the next before the walk moves on.
+ *
+ * A rule is re-armed whether or not it fired, so a rule disabled while time
+ * passes picks up from the next due instant when it is enabled again rather
+ * than replaying what it missed. A rule that has been deleted, or replaced by a
+ * PutRule of the same name, is no longer the rule its store holds, and that is
+ * what stops it: there is no timer to cancel, only a firing that finds itself
+ * out of date.
+ */
+export class SimEventBridgeRuleSchedules {
+  private readonly rules: SimEventRuleStore;
+  private readonly router: SimEventBridgeRouter;
+  private readonly background: BackgroundScheduler;
+  private readonly accountRegionScope: SimAwsAccountRegionScope;
+
+  constructor(properties: SimEventBridgeRuleSchedulesProperties) {
+    this.rules = properties.rules;
+    this.router = properties.router;
+    this.background = properties.background;
+    this.accountRegionScope = properties.accountRegionScope;
+  }
+
+  /**
+   * Start a rule's schedule, if it has one.
+   *
+   * A rate runs from the moment the rule was created, as it does on real
+   * EventBridge, so a `rate(1 hour)` rule made at half past nine falls due at
+   * half past ten rather than on the hour.
+   */
+  arm(rule: SimEventRule): void {
+    if (rule.schedule !== undefined) {
+      this.armAfter(rule, rule.schedule, this.background.now());
+    }
+  }
+
+  /**
+   * Wait for the next instant a schedule falls due after an instant.
+   *
+   * A schedule with nothing left, such as a cron expression whose years have
+   * run out, is simply not armed again.
+   */
+  private armAfter(
+    rule: SimEventRule,
+    schedule: SimSchedule,
+    from: Date,
+  ): void {
+    const due = schedule.nextAfter(from);
+
+    if (due === undefined) {
+      return;
+    }
+
+    this.background.scheduleAt(due, () => {
+      this.fire(rule, schedule, due);
+
+      return Promise.resolve();
+    });
+  }
+
+  /**
+   * Fire a rule that has fallen due, and arm it for the next time.
+   *
+   * The next firing is counted from the due instant rather than from the clock,
+   * so a schedule keeps its own timing however far a single advance moved time.
+   */
+  private fire(rule: SimEventRule, schedule: SimSchedule, due: Date): void {
+    if (this.rules.find(rule.busName.value, rule.name.value) !== rule) {
+      return;
+    }
+
+    if (rule.state.isEnabled) {
+      this.router.fire(
+        rule,
+        simEventBridgeScheduledEvent({
+          rule,
+          at: due,
+          accountRegionScope: this.accountRegionScope,
+        }),
+      );
+    }
+
+    this.armAfter(rule, schedule, due);
+  }
+}

--- a/src/service/eventbridge/schedule/sim-event-bridge-schedule-validation.iso.test.ts
+++ b/src/service/eventbridge/schedule/sim-event-bridge-schedule-validation.iso.test.ts
@@ -57,13 +57,13 @@ describe("EventBridge schedule expression validation", () => {
   });
 
   it("refuses a cron expression short of its six fields", async () => {
-    // Given a five field expression, which is what Unix cron takes.
+    // Given a five-field expression, which is what Unix cron takes.
     const error = await refusedRule({
       Name: "noon",
       ScheduleExpression: "cron(0 12 * * ?)",
     });
 
-    // Then it is refused naming the six field form EventBridge expects.
+    // Then it is refused naming the six-field form EventBridge expects.
     assertInstanceOf(error, SimEventBridgeValidationException);
     assertStringIncludes(
       error.message,

--- a/src/service/eventbridge/schedule/sim-event-bridge-schedule-validation.iso.test.ts
+++ b/src/service/eventbridge/schedule/sim-event-bridge-schedule-validation.iso.test.ts
@@ -1,0 +1,170 @@
+import {
+  CreateEventBusCommand,
+  DescribeRuleCommand,
+  ListRulesCommand,
+  PutRuleCommand,
+  type PutRuleCommandInput,
+} from "@aws-sdk/client-eventbridge";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import {
+  SimEventBridgeUnsimulatedInputException,
+  SimEventBridgeValidationException,
+} from "../error/sim-event-bridge.error.js";
+
+/**
+ * Try to create a rule, and answer with what it was refused with.
+ */
+async function refusedRule(input: PutRuleCommandInput): Promise<Error> {
+  const simAws = new SimAws();
+
+  return await assertThrowsErrorAsync(async () => {
+    await simAws.eventBridge().putRule(new PutRuleCommand(input));
+  });
+}
+
+describe("EventBridge schedule expression validation", () => {
+  it("refuses a rate under the minute AWS runs", async () => {
+    // Given a rule asking to fire every thirty seconds.
+    const error = await refusedRule({
+      Name: "twitchy",
+      ScheduleExpression: "rate(30 seconds)",
+    });
+
+    // Then it is refused saying why there is no such unit.
+    assertInstanceOf(error, SimEventBridgeValidationException);
+    assertStringIncludes(error.message, "no schedule finer than one a minute");
+  });
+
+  it("refuses a rate whose unit does not agree with its value", async () => {
+    const error = await refusedRule({
+      Name: "hourly",
+      ScheduleExpression: "rate(1 hours)",
+    });
+
+    assertInstanceOf(error, SimEventBridgeValidationException);
+    assertStringIncludes(error.message, "'1 hour'");
+  });
+
+  it("refuses a cron expression short of its six fields", async () => {
+    // Given a five field expression, which is what Unix cron takes.
+    const error = await refusedRule({
+      Name: "noon",
+      ScheduleExpression: "cron(0 12 * * ?)",
+    });
+
+    // Then it is refused naming the six field form EventBridge expects.
+    assertInstanceOf(error, SimEventBridgeValidationException);
+    assertStringIncludes(
+      error.message,
+      "minutes hours day-of-month month day-of-week year",
+    );
+  });
+
+  it("refuses the cron wildcards it reads no meaning from", async () => {
+    // Given the last-day-of-month wildcard, which real EventBridge does take.
+    const error = await refusedRule({
+      Name: "month-end",
+      ScheduleExpression: "cron(0 12 L * ? *)",
+    });
+
+    // Then it is refused as unsimulated rather than as a mistake.
+    assertInstanceOf(error, SimEventBridgeUnsimulatedInputException);
+    assertStringIncludes(error.message, "'L', 'W' or '#'");
+  });
+
+  it("refuses a schedule on a bus other than the default one", async () => {
+    // Given a custom bus.
+    const simAws = new SimAws();
+
+    await simAws
+      .eventBridge()
+      .createEventBus(new CreateEventBusCommand({ Name: "orders" }));
+
+    // When a scheduled rule is put onto it.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.eventBridge().putRule(
+        new PutRuleCommand({
+          Name: "hourly",
+          EventBusName: "orders",
+          ScheduleExpression: "rate(1 hour)",
+        }),
+      );
+    });
+
+    // Then it is refused, as AWS refuses it: only the default bus takes one.
+    assertInstanceOf(error, SimEventBridgeValidationException);
+    assertStringIncludes(
+      error.message,
+      "only allowed on the default event bus",
+    );
+  });
+});
+
+describe("EventBridge scheduled rule reporting", () => {
+  it("reports a schedule back as it was written, and no pattern", async () => {
+    // Given a scheduled rule.
+    const simAws = new SimAws();
+
+    await simAws.eventBridge().putRule(
+      new PutRuleCommand({
+        Name: "hourly",
+        ScheduleExpression: "rate(1 hour)",
+      }),
+    );
+
+    // When it is described.
+    const described = await simAws
+      .eventBridge()
+      .describeRule(new DescribeRuleCommand({ Name: "hourly" }));
+
+    // Then the expression comes back as it was sent, and there is no pattern
+    // to report rather than an empty one.
+    assertIdentical(described.ScheduleExpression, "rate(1 hour)");
+    assertUndefined(described.EventPattern);
+    assertIdentical(described.State, "ENABLED");
+  });
+
+  it("lists a scheduled rule alongside a pattern rule", async () => {
+    // Given one rule of each kind.
+    const simAws = new SimAws();
+
+    await simAws.eventBridge().putRule(
+      new PutRuleCommand({
+        Name: "hourly",
+        ScheduleExpression: "cron(0 12 * * ? *)",
+      }),
+    );
+    await simAws.eventBridge().putRule(
+      new PutRuleCommand({
+        Name: "orders",
+        EventPattern: JSON.stringify({ source: ["orders.service"] }),
+      }),
+    );
+
+    // When the bus is listed.
+    const listed = await simAws
+      .eventBridge()
+      .listRules(new ListRulesCommand({}));
+
+    // Then each reports what it was created with and nothing it was not.
+    const [scheduled, patterned] = listed.Rules ?? [];
+
+    assertArrayLength(listed.Rules ?? [], 2);
+    assertNonNullable(scheduled);
+    assertNonNullable(patterned);
+    assertIdentical(scheduled.ScheduleExpression, "cron(0 12 * * ? *)");
+    assertUndefined(scheduled.EventPattern);
+    assertUndefined(patterned.ScheduleExpression);
+  });
+});

--- a/src/service/eventbridge/schedule/sim-event-bridge-schedule.ts
+++ b/src/service/eventbridge/schedule/sim-event-bridge-schedule.ts
@@ -1,0 +1,52 @@
+import { awsCronFieldSpecs } from "../../../util/schedule/cron/sim-cron-field-spec.js";
+import { SimSchedule } from "../../../util/schedule/sim-schedule.js";
+import type { SimScheduleDialect } from "../../../util/schedule/sim-schedule-dialect.js";
+import {
+  SimScheduleExpressionError,
+  SimUnsimulatedScheduleExpressionError,
+} from "../../../util/schedule/sim-schedule.error.js";
+import {
+  SimEventBridgeUnsimulatedInputException,
+  SimEventBridgeValidationException,
+} from "../error/sim-event-bridge.error.js";
+
+/**
+ * How EventBridge reads a rule's `ScheduleExpression`.
+ *
+ * Six cron fields, and a rate whose unit has to agree with its value:
+ * `rate(1 hours)` is refused by real EventBridge rather than read as one hour.
+ * EventBridge Scheduler is a separate service with its own dialect, which is
+ * why this is a value here rather than the parser's own assumption.
+ */
+export const eventBridgeScheduleDialect: SimScheduleDialect = {
+  cronFields: awsCronFieldSpecs,
+  requiresRateAgreement: true,
+};
+
+/**
+ * Read the `ScheduleExpression` a PutRule carried.
+ *
+ * The parser is shared and knows nothing about EventBridge, so its refusals are
+ * turned into this service's own errors here. Which of the two a caller gets
+ * tells them whether they wrote the expression wrongly or reached for a part of
+ * cron this simulation does not read.
+ */
+export function eventBridgeSchedule(source: string): SimSchedule {
+  try {
+    return SimSchedule.of(source, eventBridgeScheduleDialect);
+  } catch (error) {
+    if (error instanceof SimUnsimulatedScheduleExpressionError) {
+      throw new SimEventBridgeUnsimulatedInputException(
+        `ScheduleExpression '${source}' is not simulated: ${error.message}`,
+      );
+    }
+
+    if (error instanceof SimScheduleExpressionError) {
+      throw new SimEventBridgeValidationException(
+        `Parameter ScheduleExpression is not valid. Reason: ${error.message}`,
+      );
+    }
+
+    throw error;
+  }
+}

--- a/src/service/eventbridge/schedule/sim-event-bridge-scheduled-event.ts
+++ b/src/service/eventbridge/schedule/sim-event-bridge-scheduled-event.ts
@@ -1,0 +1,49 @@
+import { randomUUID } from "node:crypto";
+
+import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+import { SimEventBridgeEvent } from "../event/sim-event-bridge-event.js";
+import type { SimEventRule } from "../rule/sim-event-rule.js";
+
+/**
+ * The source every scheduled event carries, as AWS's own events do.
+ */
+export const simEventBridgeScheduledEventSource = "aws.events";
+
+/**
+ * The detail type every scheduled event carries.
+ */
+export const simEventBridgeScheduledEventDetailType = "Scheduled Event";
+
+interface SimEventBridgeScheduledEventProperties {
+  readonly rule: SimEventRule;
+  readonly at: Date;
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+}
+
+/**
+ * The event a scheduled rule sends to its targets when it falls due.
+ *
+ * There is nothing of the caller's in it, because nothing of the caller's
+ * caused it: the detail is empty, and the only thing naming what fired is the
+ * rule's own ARN in `resources`. A target wanting more than that is what a
+ * target `Input` is for.
+ *
+ * The timestamp is the instant the rule fell due rather than the instant the
+ * work ran. AWS's advice for a scheduled invocation is to read the event's time
+ * rather than the clock, because a delayed delivery runs later than the time
+ * the work was for, and that only holds if the event says when it was for.
+ */
+export function simEventBridgeScheduledEvent(
+  properties: SimEventBridgeScheduledEventProperties,
+): SimEventBridgeEvent {
+  return new SimEventBridgeEvent({
+    id: randomUUID(),
+    detailType: simEventBridgeScheduledEventDetailType,
+    source: simEventBridgeScheduledEventSource,
+    account: properties.accountRegionScope.accountId,
+    time: new Date(properties.at),
+    region: properties.accountRegionScope.regionName,
+    resources: [properties.rule.arn],
+    detail: {},
+  });
+}

--- a/src/service/eventbridge/schedule/sim-event-bridge-scheduled-rules.iso.test.ts
+++ b/src/service/eventbridge/schedule/sim-event-bridge-scheduled-rules.iso.test.ts
@@ -1,0 +1,311 @@
+import {
+  DeleteRuleCommand,
+  DisableRuleCommand,
+  EnableRuleCommand,
+  PutRuleCommand,
+  PutTargetsCommand,
+  RemoveTargetsCommand,
+  type RuleState,
+} from "@aws-sdk/client-eventbridge";
+import { AddPermissionCommand } from "@aws-sdk/client-lambda";
+import {
+  assertArrayEquals,
+  assertArrayLength,
+  assertObjectEquals,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimFixedClock } from "../../../util/clock/sim-clock.js";
+import { SimAws } from "../../aws/sim-aws.js";
+import { makeLambdaZipFileInput } from "../../lambda/index.js";
+
+const startedAt = "2026-07-26T09:00:00.000Z";
+
+const functionArn = "arn:aws:lambda:us-east-1:888888888888:function:reconcile";
+
+/**
+ * A simulation started at a known instant, with a function recording the time
+ * of every event it is handed.
+ */
+async function simulationWithTarget(): Promise<{
+  readonly simAws: SimAws;
+  readonly received: { time: string }[];
+}> {
+  const simAws = new SimAws({ clock: new SimFixedClock(new Date(startedAt)) });
+  const received: { time: string }[] = [];
+
+  await simAws.lambda().createFunction({
+    input: {
+      FunctionName: "reconcile",
+      Role: "arn:aws:iam::888888888888:role/ReconcileRole",
+      Code: {
+        ZipFile: makeLambdaZipFileInput((event: unknown) => {
+          received.push(event as { time: string });
+          return { ok: true };
+        }),
+      },
+    },
+  });
+
+  await simAws.lambda().addPermission(
+    new AddPermissionCommand({
+      FunctionName: "reconcile",
+      StatementId: "events",
+      Action: "lambda:InvokeFunction",
+      Principal: "events.amazonaws.com",
+    }),
+  );
+
+  return { simAws, received };
+}
+
+/**
+ * A scheduled rule, with the function as its target unless told otherwise.
+ */
+async function scheduledRule(
+  simAws: SimAws,
+  schedule: string,
+  state?: RuleState,
+): Promise<void> {
+  await simAws.eventBridge().putRule(
+    new PutRuleCommand({
+      Name: "reconciliation",
+      ScheduleExpression: schedule,
+      State: state,
+    }),
+  );
+
+  await simAws.eventBridge().putTargets(
+    new PutTargetsCommand({
+      Rule: "reconciliation",
+      Targets: [{ Id: "reconcile", Arn: functionArn }],
+    }),
+  );
+}
+
+describe("EventBridge scheduled rules", () => {
+  it("fires a rate rule once for every interval time passes", async () => {
+    // Given an hourly rule with a function target.
+    const { simAws, received } = await simulationWithTarget();
+
+    await scheduledRule(simAws, "rate(1 hour)");
+
+    // When three simulated hours pass.
+    await simAws.clock().advanceBy({ hours: 3 });
+
+    // Then the function ran three times, each stamped with its own due
+    // instant rather than with the instant the advance finished.
+    assertArrayEquals(
+      received.map((event) => event.time),
+      ["2026-07-26T10:00:00Z", "2026-07-26T11:00:00Z", "2026-07-26T12:00:00Z"],
+    );
+  });
+
+  it("fires per due instant rather than once per advance", async () => {
+    // Given a rule due every minute.
+    const { simAws, received } = await simulationWithTarget();
+
+    await scheduledRule(simAws, "rate(1 minute)");
+
+    // When an hour passes in one step.
+    await simAws.clock().advanceBy({ hours: 1 });
+
+    // Then it fired sixty times, at sixty distinct instants, because that is
+    // what an hour of that rule actually does.
+    assertArrayLength(received, 60);
+    assertArrayLength([...new Set(received.map((event) => event.time))], 60);
+  });
+
+  it("fires a cron rule at the instants it names", async () => {
+    // Given the every-day-at-noon expression.
+    const { simAws, received } = await simulationWithTarget();
+
+    await scheduledRule(simAws, "cron(0 12 * * ? *)");
+
+    // When three simulated days pass.
+    await simAws.clock().advanceBy({ days: 3 });
+
+    // Then it fired once a day at noon UTC.
+    assertArrayEquals(
+      received.map((event) => event.time),
+      ["2026-07-26T12:00:00Z", "2026-07-27T12:00:00Z", "2026-07-28T12:00:00Z"],
+    );
+  });
+
+  it("sends the scheduled event AWS sends", async () => {
+    // Given an hourly rule that has fired once.
+    const { simAws, received } = await simulationWithTarget();
+
+    await scheduledRule(simAws, "rate(1 hour)");
+    await simAws.clock().advanceBy({ hours: 1 });
+
+    // Then the target got the standard envelope with an empty detail, naming
+    // the rule that fired and the instant it was due.
+    assertArrayLength(received, 1);
+    assertObjectEquals(received[0], {
+      version: "0",
+      id: (received[0] as unknown as { id: string }).id,
+      "detail-type": "Scheduled Event",
+      source: "aws.events",
+      account: "888888888888",
+      time: "2026-07-26T10:00:00Z",
+      region: "us-east-1",
+      resources: ["arn:aws:events:us-east-1:888888888888:rule/reconciliation"],
+      detail: {},
+    });
+  });
+
+  it("does not fire while disabled, and does not replay on enabling", async () => {
+    // Given an hourly rule created disabled.
+    const { simAws, received } = await simulationWithTarget();
+
+    await scheduledRule(simAws, "rate(1 hour)", "DISABLED");
+
+    // When three hours pass with it off, and one more with it back on.
+    await simAws.clock().advanceBy({ hours: 3 });
+
+    assertArrayLength(received, 0);
+
+    await simAws
+      .eventBridge()
+      .enableRule(new EnableRuleCommand({ Name: "reconciliation" }));
+
+    await simAws.clock().advanceBy({ hours: 1 });
+
+    // Then it fired once, for the interval it was on for, rather than four
+    // times catching up on what it missed.
+    assertArrayEquals(
+      received.map((event) => event.time),
+      ["2026-07-26T13:00:00Z"],
+    );
+  });
+
+  it("stops firing once disabled again", async () => {
+    // Given a rule that has fired.
+    const { simAws, received } = await simulationWithTarget();
+
+    await scheduledRule(simAws, "rate(1 hour)");
+    await simAws.clock().advanceBy({ hours: 1 });
+
+    // When it is switched off and more time passes.
+    await simAws
+      .eventBridge()
+      .disableRule(new DisableRuleCommand({ Name: "reconciliation" }));
+
+    await simAws.clock().advanceBy({ hours: 3 });
+
+    // Then nothing more arrived.
+    assertArrayLength(received, 1);
+  });
+
+  it("stops firing when the rule is deleted", async () => {
+    // Given a rule that has fired once.
+    const { simAws, received } = await simulationWithTarget();
+
+    await scheduledRule(simAws, "rate(1 hour)");
+    await simAws.clock().advanceBy({ hours: 1 });
+
+    // When the rule is deleted and more time passes.
+    await simAws
+      .eventBridge()
+      .deleteRule(new DeleteRuleCommand({ Name: "reconciliation" }));
+
+    await simAws.clock().advanceBy({ hours: 3 });
+
+    // Then nothing more arrived: the firing found itself out of date.
+    assertArrayLength(received, 1);
+  });
+
+  it("reaches nothing once its targets are removed", async () => {
+    // Given a rule that has fired once.
+    const { simAws, received } = await simulationWithTarget();
+
+    await scheduledRule(simAws, "rate(1 hour)");
+    await simAws.clock().advanceBy({ hours: 1 });
+
+    // When its target is removed and more time passes.
+    await simAws.eventBridge().removeTargets(
+      new RemoveTargetsCommand({
+        Rule: "reconciliation",
+        Ids: ["reconcile"],
+      }),
+    );
+
+    await simAws.clock().advanceBy({ hours: 3 });
+
+    // Then the function was not invoked again.
+    assertArrayLength(received, 1);
+  });
+
+  it("restarts the schedule when the rule is replaced", async () => {
+    // Given an hourly rule, half an hour into its interval.
+    const { simAws, received } = await simulationWithTarget();
+
+    await scheduledRule(simAws, "rate(1 hour)");
+    await simAws.clock().advanceBy({ minutes: 30 });
+
+    // When PutRule replaces it, which is a whole new rule of that name.
+    await scheduledRule(simAws, "rate(1 hour)");
+
+    await simAws.clock().advanceBy({ hours: 1 });
+
+    // Then it fired an hour after the replacement rather than on the old
+    // rule's timing, and the old rule fired not at all.
+    assertArrayEquals(
+      received.map((event) => event.time),
+      ["2026-07-26T10:30:00Z"],
+    );
+  });
+
+  it("records what it fired on the bus for a test with no target", async () => {
+    // Given a rule with no target at all.
+    const simAws = new SimAws({
+      clock: new SimFixedClock(new Date(startedAt)),
+    });
+
+    await simAws.eventBridge().putRule(
+      new PutRuleCommand({
+        Name: "reconciliation",
+        ScheduleExpression: "rate(1 hour)",
+      }),
+    );
+
+    // When two simulated hours pass.
+    await simAws.clock().advanceBy({ hours: 2 });
+
+    // Then the events it produced can still be seen, which is the simulator's
+    // own accessor rather than anything real EventBridge offers.
+    assertArrayEquals(
+      simAws
+        .eventBridge()
+        .eventsOn("default")
+        .map((event) => event.time.toISOString()),
+      ["2026-07-26T10:00:00.000Z", "2026-07-26T11:00:00.000Z"],
+    );
+  });
+
+  it("leaves a rule with only a schedule matching no event", async () => {
+    // Given a scheduled rule and an event put onto its bus.
+    const { simAws, received } = await simulationWithTarget();
+
+    await scheduledRule(simAws, "rate(1 hour)");
+
+    await simAws.eventBridge().putEvents({
+      input: {
+        Entries: [
+          {
+            Source: "orders.service",
+            DetailType: "OrderPlaced",
+            Detail: "{}",
+          },
+        ],
+      },
+    });
+
+    await simAws.backgroundTasksComplete();
+
+    // Then it went nowhere: a scheduled rule fires on its own timing and has
+    // no pattern for an event to match.
+    assertArrayLength(received, 0);
+  });
+});

--- a/src/service/eventbridge/sim-event-bridge.ts
+++ b/src/service/eventbridge/sim-event-bridge.ts
@@ -45,8 +45,8 @@ interface SimEventBridgeProperties {
  *
  * A bus is a router rather than a store. An event put onto one is matched
  * against that bus's rules and sent to their targets, and an event that
- * matches nothing is gone. Rules and targets are not simulated yet, so every
- * event put onto a bus today is dropped after it arrives.
+ * matches nothing is gone. A rule carrying a schedule instead fires on the
+ * simulation's own clock, so advancing time is what sends its event.
  */
 export class SimEventBridge extends SimEventBridgeInspection {
   protected readonly buses: SimEventBusStore;

--- a/src/util/schedule/cron/sim-cron-expression.ts
+++ b/src/util/schedule/cron/sim-cron-expression.ts
@@ -1,0 +1,144 @@
+import { SimScheduleExpressionError } from "../sim-schedule.error.js";
+import type { SimCronFieldSpec } from "./sim-cron-field-spec.js";
+import { readFields, type SimCronFields } from "./sim-cron-fields.js";
+
+const millisecondsPerMinute = 60_000;
+
+const whitespace = /\s+/u;
+
+/**
+ * The instant the minute after an instant starts.
+ *
+ * A cron expression names minutes, so a search for the next occurrence starts
+ * at the next whole minute. It is strictly after, so a rule due exactly now
+ * does not come back as due again.
+ */
+function startOfNextMinute(instant: Date): number {
+  return (
+    Math.floor(instant.getTime() / millisecondsPerMinute) *
+      millisecondsPerMinute +
+    millisecondsPerMinute
+  );
+}
+
+/**
+ * One cron expression, read into the instants it falls due at.
+ *
+ * Everything is read in UTC. AWS runs scheduled rules in UTC and offers a
+ * timezone as a separate setting, so a local timezone never enters into this.
+ */
+export class SimCronExpression {
+  public readonly source: string;
+
+  private readonly fields: SimCronFields;
+
+  private constructor(source: string, fields: SimCronFields) {
+    this.source = source;
+    this.fields = fields;
+  }
+
+  /**
+   * Read a cron expression against a dialect's fields.
+   *
+   * The fields are positional, so an expression with the wrong number of them
+   * is refused naming the form expected rather than read as though the missing
+   * one were at the end.
+   */
+  static of(
+    specs: readonly SimCronFieldSpec[],
+    source: string,
+  ): SimCronExpression {
+    const written = source.trim().split(whitespace);
+
+    if (written.length !== specs.length) {
+      throw new SimScheduleExpressionError(
+        `a cron expression has ${String(specs.length)} fields separated by ` +
+          `spaces, ${specs.map((spec) => spec.name).join(" ")}, and this one ` +
+          `has ${String(written.length)}`,
+      );
+    }
+
+    return new this(source, readFields(specs, written));
+  }
+
+  /**
+   * The next instant this expression falls due after an instant.
+   *
+   * Nothing comes back once the search has run past the last year the dialect
+   * has, since a cron expression naming only years in the past falls due never.
+   */
+  nextAfter(instant: Date): Date | undefined {
+    const end = Date.UTC(this.fields.year.maximum + 1, 0, 1);
+    let candidate = startOfNextMinute(instant);
+
+    while (candidate < end) {
+      const skipTo = this.skipUnmatched(candidate);
+
+      if (skipTo === undefined) {
+        return new Date(candidate);
+      }
+
+      candidate = skipTo;
+    }
+
+    return undefined;
+  }
+
+  /**
+   * Where to look next when an instant is not one this expression names, or
+   * nothing when it is.
+   *
+   * A field that does not match skips the whole of the unit below it: a month
+   * that does not match moves to the first of the next month rather than trying
+   * every minute of it. That is what keeps a search over years to a few hundred
+   * steps rather than the million minutes they hold.
+   */
+  private skipUnmatched(at: number): number | undefined {
+    const date = new Date(at);
+    const year = date.getUTCFullYear();
+
+    if (!this.fields.year.allows(year)) {
+      return Date.UTC(year + 1, 0, 1);
+    }
+
+    const month = date.getUTCMonth();
+
+    if (!this.fields.month.allows(month + 1)) {
+      return Date.UTC(year, month + 1, 1);
+    }
+
+    const day = date.getUTCDate();
+
+    if (!this.allowsDay(date)) {
+      return Date.UTC(year, month, day + 1);
+    }
+
+    const hour = date.getUTCHours();
+
+    if (!this.fields.hours.allows(hour)) {
+      return Date.UTC(year, month, day, hour + 1);
+    }
+
+    if (!this.fields.minutes.allows(date.getUTCMinutes())) {
+      return at + millisecondsPerMinute;
+    }
+
+    return undefined;
+  }
+
+  /**
+   * Whether this expression names a day.
+   *
+   * Whichever of the two day fields is not `?` is the one that decides, which
+   * is why they cannot both say something.
+   */
+  private allowsDay(date: Date): boolean {
+    if (this.fields.dayOfMonth.isAny) {
+      // AWS numbers the week from Sunday as one, and JavaScript from Sunday as
+      // zero.
+      return this.fields.dayOfWeek.allows(date.getUTCDay() + 1);
+    }
+
+    return this.fields.dayOfMonth.allows(date.getUTCDate());
+  }
+}

--- a/src/util/schedule/cron/sim-cron-field-bounds.ts
+++ b/src/util/schedule/cron/sim-cron-field-bounds.ts
@@ -1,0 +1,90 @@
+import type { SimCronFieldSpec } from "./sim-cron-field-spec.js";
+import {
+  cronBadStep,
+  cronOutOfRange,
+  cronUnexpectedStep,
+  cronUnreadable,
+  cronUnsimulatedWildcard,
+} from "./sim-cron-refusals.js";
+
+/**
+ * A token using one of the wildcards this simulation reads no meaning from:
+ * `L` for the last day, `W` for the nearest weekday, and `#` for the nth
+ * weekday of a month.
+ */
+const unsimulatedWildcard = /^\d*[LW]$|#/u;
+
+const wholeNumber = /^\d+$/u;
+
+/**
+ * Read one number of a field, by name where the field has names for them.
+ */
+function valueOf(spec: SimCronFieldSpec, token: string): number {
+  const upper = token.toUpperCase();
+  const alias = spec.aliases.get(upper);
+
+  if (alias !== undefined) {
+    return alias;
+  }
+
+  if (unsimulatedWildcard.test(upper)) {
+    throw cronUnsimulatedWildcard(spec);
+  }
+
+  if (!wholeNumber.test(upper)) {
+    throw cronUnreadable(spec, token);
+  }
+
+  const value = Number(upper);
+
+  if (value < spec.minimum || value > spec.maximum) {
+    throw cronOutOfRange(spec, token);
+  }
+
+  return value;
+}
+
+/**
+ * Read how far apart the values of a stepped part are.
+ */
+export function stepOf(spec: SimCronFieldSpec, written: string): number {
+  if (!spec.allowsStep) {
+    throw cronUnexpectedStep(spec);
+  }
+
+  if (!wholeNumber.test(written) || Number(written) < 1) {
+    throw cronBadStep(written);
+  }
+
+  return Number(written);
+}
+
+/**
+ * The start and end of one comma separated part, before its step is applied.
+ *
+ * A bare number with a step behind it starts there and runs to the end of the
+ * field, which is what makes minutes `0/15` every quarter hour rather than only
+ * the hour itself.
+ */
+export function boundsOf(
+  spec: SimCronFieldSpec,
+  written: string,
+  stepped: boolean,
+): readonly [number, number] {
+  if (written === "*") {
+    return [spec.minimum, spec.maximum];
+  }
+
+  const dash = written.indexOf("-");
+
+  if (dash > 0) {
+    return [
+      valueOf(spec, written.slice(0, dash)),
+      valueOf(spec, written.slice(dash + 1)),
+    ];
+  }
+
+  const only = valueOf(spec, written);
+
+  return stepped ? [only, spec.maximum] : [only, only];
+}

--- a/src/util/schedule/cron/sim-cron-field-spec.ts
+++ b/src/util/schedule/cron/sim-cron-field-spec.ts
@@ -1,0 +1,120 @@
+/**
+ * What one field of a cron expression takes.
+ *
+ * A dialect is a list of these, in field order, which is what keeps the parser
+ * from having any one service's cron rules baked into it. The ranges are the
+ * same in most dialects and which wildcards a field allows is not, so both are
+ * described here rather than assumed.
+ */
+export interface SimCronFieldSpec {
+  /**
+   * What to call this field in a refusal, as its own documentation names it.
+   */
+  readonly name: string;
+
+  readonly minimum: number;
+  readonly maximum: number;
+
+  /**
+   * The names this field takes in place of numbers, such as `JAN` for 1.
+   */
+  readonly aliases: ReadonlyMap<string, number>;
+
+  /**
+   * Whether `?`, meaning "any", may be written in this field.
+   */
+  readonly allowsAny: boolean;
+
+  /**
+   * Whether `/`, meaning "in steps of", may be written in this field.
+   */
+  readonly allowsStep: boolean;
+}
+
+const monthNames = [
+  "JAN",
+  "FEB",
+  "MAR",
+  "APR",
+  "MAY",
+  "JUN",
+  "JUL",
+  "AUG",
+  "SEP",
+  "OCT",
+  "NOV",
+  "DEC",
+];
+
+/**
+ * Sunday first, so `1` is Sunday and `7` is Saturday, which is how AWS numbers
+ * the day-of-week field. Unix cron numbers it from zero, and a rule written for
+ * one and read by the other is off by a day.
+ */
+const dayNames = ["SUN", "MON", "TUE", "WED", "THU", "FRI", "SAT"];
+
+/**
+ * The names a field takes, numbered from one.
+ */
+function aliasesFor(names: readonly string[]): ReadonlyMap<string, number> {
+  return new Map(names.map((name, index) => [name, index + 1]));
+}
+
+/**
+ * The six fields of an AWS cron expression: minutes, hours, day-of-month,
+ * month, day-of-week and year.
+ *
+ * This is the shape both EventBridge and EventBridge Scheduler use. A dialect
+ * that wanted different ranges would write its own list rather than change this
+ * one.
+ */
+export const awsCronFieldSpecs: readonly SimCronFieldSpec[] = [
+  {
+    name: "minutes",
+    minimum: 0,
+    maximum: 59,
+    aliases: new Map(),
+    allowsAny: false,
+    allowsStep: true,
+  },
+  {
+    name: "hours",
+    minimum: 0,
+    maximum: 23,
+    aliases: new Map(),
+    allowsAny: false,
+    allowsStep: true,
+  },
+  {
+    name: "day-of-month",
+    minimum: 1,
+    maximum: 31,
+    aliases: new Map(),
+    allowsAny: true,
+    allowsStep: true,
+  },
+  {
+    name: "month",
+    minimum: 1,
+    maximum: 12,
+    aliases: aliasesFor(monthNames),
+    allowsAny: false,
+    allowsStep: true,
+  },
+  {
+    name: "day-of-week",
+    minimum: 1,
+    maximum: 7,
+    aliases: aliasesFor(dayNames),
+    allowsAny: true,
+    allowsStep: false,
+  },
+  {
+    name: "year",
+    minimum: 1970,
+    maximum: 2199,
+    aliases: new Map(),
+    allowsAny: false,
+    allowsStep: true,
+  },
+];

--- a/src/util/schedule/cron/sim-cron-field.ts
+++ b/src/util/schedule/cron/sim-cron-field.ts
@@ -1,0 +1,116 @@
+import { boundsOf, stepOf } from "./sim-cron-field-bounds.js";
+import type { SimCronFieldSpec } from "./sim-cron-field-spec.js";
+import { cronRepeatedStep, cronUnexpectedAny } from "./sim-cron-refusals.js";
+
+/**
+ * Every value a range covers, counting around the end of the field.
+ *
+ * A range whose start is after its end wraps, so hours `20-2` is ten at night
+ * through two in the morning rather than nothing at all.
+ */
+function rangeValues(
+  spec: SimCronFieldSpec,
+  [from, to]: readonly [number, number],
+  step: number,
+): number[] {
+  const span = spec.maximum - spec.minimum + 1;
+  const covered = from <= to ? to - from : span - (from - to);
+  const values: number[] = [];
+
+  for (let offset = 0; offset <= covered; offset += step) {
+    values.push(spec.minimum + ((from - spec.minimum + offset) % span));
+  }
+
+  return values;
+}
+
+/**
+ * Every value one comma separated part of a field covers.
+ */
+function partValues(spec: SimCronFieldSpec, part: string): readonly number[] {
+  const [written = "", step, ...extra] = part.split("/");
+
+  if (extra.length > 0) {
+    throw cronRepeatedStep(spec, part);
+  }
+
+  return rangeValues(
+    spec,
+    boundsOf(spec, written, step !== undefined),
+    step === undefined ? 1 : stepOf(spec, step),
+  );
+}
+
+/**
+ * Every value a whole field covers.
+ */
+function fieldValues(spec: SimCronFieldSpec, source: string): Set<number> {
+  const allowed = new Set<number>();
+
+  for (const part of source.split(",")) {
+    for (const value of partValues(spec, part)) {
+      allowed.add(value);
+    }
+  }
+
+  return allowed;
+}
+
+/**
+ * One field of a cron expression, read into the values it allows.
+ *
+ * Whether a field was written as `?` is kept, because that is not a fact about
+ * which values it allows: `?` and `*` allow the same ones, and only `?` says
+ * "this field is not the one deciding the day".
+ */
+export class SimCronField {
+  /**
+   * Whether this field was written as `?`, meaning "any".
+   */
+  public readonly isAny: boolean;
+
+  /**
+   * The highest value this field's position takes, whether or not it is
+   * allowed. A search for the next occurrence stops once it has run past the
+   * highest year, so it needs to know what that is.
+   */
+  public readonly maximum: number;
+
+  private readonly allowed: ReadonlySet<number>;
+
+  private constructor(
+    isAny: boolean,
+    maximum: number,
+    allowed: ReadonlySet<number>,
+  ) {
+    this.isAny = isAny;
+    this.maximum = maximum;
+    this.allowed = allowed;
+  }
+
+  /**
+   * Read one field of an expression against what its position takes.
+   */
+  static of(spec: SimCronFieldSpec, source: string): SimCronField {
+    if (source !== "?") {
+      return new this(false, spec.maximum, fieldValues(spec, source));
+    }
+
+    if (!spec.allowsAny) {
+      throw cronUnexpectedAny(spec);
+    }
+
+    return new this(
+      true,
+      spec.maximum,
+      new Set(rangeValues(spec, [spec.minimum, spec.maximum], 1)),
+    );
+  }
+
+  /**
+   * Whether this field allows a value.
+   */
+  allows(value: number): boolean {
+    return this.allowed.has(value);
+  }
+}

--- a/src/util/schedule/cron/sim-cron-fields.ts
+++ b/src/util/schedule/cron/sim-cron-fields.ts
@@ -1,0 +1,53 @@
+import { SimScheduleExpressionError } from "../sim-schedule.error.js";
+import { SimCronField } from "./sim-cron-field.js";
+import type { SimCronFieldSpec } from "./sim-cron-field-spec.js";
+
+/**
+ * The six fields of a cron expression, once each has been read.
+ */
+export interface SimCronFields {
+  readonly minutes: SimCronField;
+  readonly hours: SimCronField;
+  readonly dayOfMonth: SimCronField;
+  readonly month: SimCronField;
+  readonly dayOfWeek: SimCronField;
+  readonly year: SimCronField;
+}
+
+/**
+ * Read every field of an expression, in the positions the dialect describes.
+ */
+export function readFields(
+  specs: readonly SimCronFieldSpec[],
+  written: readonly string[],
+): SimCronFields {
+  const [minutes, hours, dayOfMonth, month, dayOfWeek, year] = specs.map(
+    (spec, index) => SimCronField.of(spec, written.at(index) ?? ""),
+  );
+
+  if (
+    minutes === undefined ||
+    hours === undefined ||
+    dayOfMonth === undefined ||
+    month === undefined ||
+    dayOfWeek === undefined ||
+    year === undefined
+  ) {
+    throw new SimScheduleExpressionError(
+      "a cron dialect describes six fields: minutes, hours, day-of-month, " +
+        "month, day-of-week and year",
+    );
+  }
+
+  // AWS asks for `?` in one of the two day fields, since a rule naming both
+  // the 1st and Monday has no obvious meaning: one reading is the 1st when it
+  // falls on a Monday, and the other is the 1st and also every Monday.
+  if (!dayOfMonth.isAny && !dayOfWeek.isAny) {
+    throw new SimScheduleExpressionError(
+      "the day-of-month and day-of-week fields cannot both be given: use " +
+        "'?' in whichever of the two is not deciding the day",
+    );
+  }
+
+  return { minutes, hours, dayOfMonth, month, dayOfWeek, year };
+}

--- a/src/util/schedule/cron/sim-cron-refusals.ts
+++ b/src/util/schedule/cron/sim-cron-refusals.ts
@@ -7,7 +7,7 @@ import type { SimCronFieldSpec } from "./sim-cron-field-spec.js";
 /**
  * Every way one field of a cron expression can be refused, in one place.
  *
- * Each says which field it is about, since a six field expression gives a
+ * Each says which field it is about, since a six-field expression gives a
  * reader nothing to go on otherwise, and each says what was written, since a
  * cron expression is usually wrong by one character.
  */

--- a/src/util/schedule/cron/sim-cron-refusals.ts
+++ b/src/util/schedule/cron/sim-cron-refusals.ts
@@ -1,0 +1,95 @@
+import {
+  SimScheduleExpressionError,
+  SimUnsimulatedScheduleExpressionError,
+} from "../sim-schedule.error.js";
+import type { SimCronFieldSpec } from "./sim-cron-field-spec.js";
+
+/**
+ * Every way one field of a cron expression can be refused, in one place.
+ *
+ * Each says which field it is about, since a six field expression gives a
+ * reader nothing to go on otherwise, and each says what was written, since a
+ * cron expression is usually wrong by one character.
+ */
+export function cronFieldRefusal(
+  spec: SimCronFieldSpec,
+  reason: string,
+): SimScheduleExpressionError {
+  return new SimScheduleExpressionError(`the ${spec.name} field ${reason}`);
+}
+
+/**
+ * A value outside the range its field takes.
+ */
+export function cronOutOfRange(
+  spec: SimCronFieldSpec,
+  token: string,
+): SimScheduleExpressionError {
+  return cronFieldRefusal(
+    spec,
+    `takes ${String(spec.minimum)} to ${String(spec.maximum)}, and this one ` +
+      `has '${token}'`,
+  );
+}
+
+/**
+ * A part that is neither a number, a name, nor a wildcard.
+ */
+export function cronUnreadable(
+  spec: SimCronFieldSpec,
+  token: string,
+): SimScheduleExpressionError {
+  return cronFieldRefusal(spec, `cannot be read: '${token}'`);
+}
+
+/**
+ * One of the wildcards real AWS reads and this simulation does not.
+ */
+export function cronUnsimulatedWildcard(
+  spec: SimCronFieldSpec,
+): SimUnsimulatedScheduleExpressionError {
+  return new SimUnsimulatedScheduleExpressionError(
+    `the ${spec.name} field uses 'L', 'W' or '#', which real AWS reads and ` +
+      `this simulation does not: only ',', '-', '*', '?' and '/' are read here`,
+  );
+}
+
+/**
+ * A `?` written in a field that is not one of the two day fields.
+ */
+export function cronUnexpectedAny(
+  spec: SimCronFieldSpec,
+): SimScheduleExpressionError {
+  return cronFieldRefusal(
+    spec,
+    `does not take '?', which only the day-of-month and day-of-week fields do`,
+  );
+}
+
+/**
+ * A `/` written in a field that does not take a step.
+ */
+export function cronUnexpectedStep(
+  spec: SimCronFieldSpec,
+): SimScheduleExpressionError {
+  return cronFieldRefusal(spec, `does not take '/'`);
+}
+
+/**
+ * A step that is not a whole number of at least one.
+ */
+export function cronBadStep(written: string): SimScheduleExpressionError {
+  return new SimScheduleExpressionError(
+    `a '/' step is a whole number of at least one, and this one is '${written}'`,
+  );
+}
+
+/**
+ * A part carrying more than one step.
+ */
+export function cronRepeatedStep(
+  spec: SimCronFieldSpec,
+  part: string,
+): SimScheduleExpressionError {
+  return cronFieldRefusal(spec, `has a part with more than one '/': '${part}'`);
+}

--- a/src/util/schedule/rate/sim-rate-expression.ts
+++ b/src/util/schedule/rate/sim-rate-expression.ts
@@ -1,0 +1,125 @@
+import { SimScheduleExpressionError } from "../sim-schedule.error.js";
+
+const millisecondsPerMinute = 60_000;
+
+const wholeNumber = /^\d+$/u;
+
+const whitespace = /\s+/u;
+
+/**
+ * How long each unit a rate expression takes is, in minutes.
+ *
+ * Seconds are absent because AWS has none: the finest schedule it runs is one a
+ * minute, so a rate under that has no unit to be written in.
+ */
+const unitMinutes: ReadonlyMap<string, number> = new Map([
+  ["minute", 1],
+  ["hour", 60],
+  ["day", 24 * 60],
+]);
+
+/**
+ * The unit a rate is in, without its plural.
+ */
+function readUnit(written: string): { singular: string; minutes: number } {
+  const singular = written.toLowerCase().replace(/s$/u, "");
+  const minutes = unitMinutes.get(singular);
+
+  if (minutes === undefined) {
+    throw new SimScheduleExpressionError(
+      `a rate is in minutes, hours or days, and this one is in ` +
+        `'${written}'. AWS runs no schedule finer than one a minute, so ` +
+        `there is no smaller unit to ask for.`,
+    );
+  }
+
+  return { singular, minutes };
+}
+
+/**
+ * The number of units a rate is, which has to be a whole one or more.
+ */
+function readValue(written: string): number {
+  if (!wholeNumber.test(written) || Number(written) < 1) {
+    throw new SimScheduleExpressionError(
+      `a rate is a positive whole number of units, and this one is ` +
+        `'${written}'`,
+    );
+  }
+
+  return Number(written);
+}
+
+/**
+ * Refuse a value and unit that do not agree, as AWS does.
+ *
+ * `rate(1 hours)` and `rate(5 hour)` are both refused by real EventBridge, and
+ * both are the kind of thing that is written by accident, so refusing them here
+ * is what stops a rule failing to deploy after the tests passed.
+ */
+function refuseDisagreement(
+  value: number,
+  written: string,
+  singular: string,
+): void {
+  const expected = value === 1 ? singular : `${singular}s`;
+
+  if (written.toLowerCase() !== expected) {
+    throw new SimScheduleExpressionError(
+      `a rate of ${String(value)} is written '${String(value)} ${expected}', ` +
+        `not '${String(value)} ${written}'`,
+    );
+  }
+}
+
+/**
+ * One rate expression, as an interval between occurrences.
+ *
+ * A rate runs from whenever the thing carrying it was created rather than from
+ * a wall clock boundary, so this holds only how long the interval is. Where the
+ * interval is counted from is the caller's, which is what makes a `rate(1 day)`
+ * rule created at half past nine fire at half past nine.
+ */
+export class SimRateExpression {
+  public readonly source: string;
+
+  private readonly interval: number;
+
+  private constructor(source: string, interval: number) {
+    this.source = source;
+    this.interval = interval;
+  }
+
+  /**
+   * Read the value and unit inside a `rate(...)`.
+   */
+  static of(source: string, requireAgreement: boolean): SimRateExpression {
+    const [value, unit, ...extra] = source.trim().split(whitespace);
+
+    if (value === undefined || unit === undefined || extra.length > 0) {
+      throw new SimScheduleExpressionError(
+        `a rate expression is a value and a unit separated by a space, such ` +
+          `as '5 minutes', and this one is '${source}'`,
+      );
+    }
+
+    const count = readValue(value);
+    const read = readUnit(unit);
+
+    if (requireAgreement) {
+      refuseDisagreement(count, unit, read.singular);
+    }
+
+    return new this(source, count * read.minutes * millisecondsPerMinute);
+  }
+
+  /**
+   * The next instant this rate falls due after an instant.
+   *
+   * One interval on from whatever it is asked about, so asking it about each
+   * due time in turn walks the schedule from where it started.
+   */
+  nextAfter(instant: Date): Date {
+    return new Date(instant.getTime() + this.interval);
+  }
+}

--- a/src/util/schedule/rate/sim-rate-expression.ts
+++ b/src/util/schedule/rate/sim-rate-expression.ts
@@ -2,6 +2,12 @@ import { SimScheduleExpressionError } from "../sim-schedule.error.js";
 
 const millisecondsPerMinute = 60_000;
 
+/**
+ * The furthest apart two instants can be, which is the whole span a JavaScript
+ * Date reaches either side of the epoch.
+ */
+const maximumInterval = 2 * 8_640_000_000_000_000;
+
 const wholeNumber = /^\d+$/u;
 
 const whitespace = /\s+/u;
@@ -110,7 +116,18 @@ export class SimRateExpression {
       refuseDisagreement(count, unit, read.singular);
     }
 
-    return new this(source, count * read.minutes * millisecondsPerMinute);
+    const interval = count * read.minutes * millisecondsPerMinute;
+
+    // A rate longer than time itself would otherwise arrive as an interval no
+    // Date can hold, and a rule armed for an instant that is not one never
+    // fires and never says why.
+    if (interval > maximumInterval) {
+      throw new SimScheduleExpressionError(
+        `a rate of '${source}' is longer than any two instants can be apart`,
+      );
+    }
+
+    return new this(source, interval);
   }
 
   /**
@@ -118,8 +135,18 @@ export class SimRateExpression {
    *
    * One interval on from whatever it is asked about, so asking it about each
    * due time in turn walks the schedule from where it started.
+   *
+   * Nothing comes back when that lands past the end of representable time. A
+   * schedule that has run out of instants is not armed again, which is a better
+   * answer than a due time of Not a Number that quietly never arrives.
    */
-  nextAfter(instant: Date): Date {
-    return new Date(instant.getTime() + this.interval);
+  nextAfter(instant: Date): Date | undefined {
+    const due = new Date(instant.getTime() + this.interval);
+
+    if (Number.isNaN(due.getTime())) {
+      return undefined;
+    }
+
+    return due;
   }
 }

--- a/src/util/schedule/sim-schedule-cron-refusals.iso.test.ts
+++ b/src/util/schedule/sim-schedule-cron-refusals.iso.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+
+import { awsCronFieldSpecs } from "./cron/sim-cron-field-spec.js";
+import { SimSchedule } from "./sim-schedule.js";
+import type { SimScheduleDialect } from "./sim-schedule-dialect.js";
+import { SimUnsimulatedScheduleExpressionError } from "./sim-schedule.error.js";
+
+/**
+ * A dialect insisting a rate's unit agrees with its value, as EventBridge does.
+ */
+const strict: SimScheduleDialect = {
+  cronFields: awsCronFieldSpecs,
+  requiresRateAgreement: true,
+};
+
+const noon = new Date("2026-07-26T12:00:00.000Z");
+
+/**
+ * The next instant a schedule falls due after one, as an ISO string.
+ */
+function nextAfter(source: string, from = noon): string | undefined {
+  return SimSchedule.of(source, strict).nextAfter(from)?.toISOString();
+}
+
+describe("SimSchedule cron refusals", () => {
+  it("refuses an expression without the six fields", () => {
+    // Given the same expression missing its year
+    // When it is read
+    // Then it is refused naming the six fields EventBridge expects
+    expect(() => nextAfter("cron(0 12 * * ?)")).toThrow(
+      /6 fields separated by spaces, minutes hours day-of-month month day-of-week year/u,
+    );
+  });
+
+  it("refuses a dialect that does not describe six fields", () => {
+    // Given a dialect a field short, and an expression matching it
+    // When it is read
+    // Then it is refused, since the positions are what give a field meaning
+    expect(() =>
+      SimSchedule.of("cron(0 12 * * ?)", {
+        cronFields: awsCronFieldSpecs.slice(0, 5),
+        requiresRateAgreement: true,
+      }).nextAfter(noon),
+    ).toThrow(/a cron dialect describes six fields/u);
+  });
+
+  it("refuses both day fields saying something", () => {
+    expect(() => nextAfter("cron(0 12 1 * MON *)")).toThrow(
+      /cannot both be given/u,
+    );
+  });
+
+  it("refuses a wildcard in a field that does not take it", () => {
+    expect(() => nextAfter("cron(? 12 * * ? *)")).toThrow(
+      /minutes field does not take '\?'/u,
+    );
+    expect(() => nextAfter("cron(0 12 ? * MON/2 *)")).toThrow(
+      /day-of-week field does not take '\/'/u,
+    );
+  });
+
+  it("refuses a value outside its field", () => {
+    expect(() => nextAfter("cron(60 12 * * ? *)")).toThrow(
+      /minutes field takes 0 to 59/u,
+    );
+  });
+
+  it("refuses a part it cannot read at all", () => {
+    expect(() => nextAfter("cron(0 12 * SOM ? *)")).toThrow(
+      /month field cannot be read: 'SOM'/u,
+    );
+    expect(() => nextAfter("cron(0/2/3 12 * * ? *)")).toThrow(
+      /more than one '\/'/u,
+    );
+    expect(() => nextAfter("cron(0/x 12 * * ? *)")).toThrow(
+      /step is a whole number/u,
+    );
+  });
+
+  it("refuses the wildcards it reads no meaning from", () => {
+    // Given the last-day, nearest-weekday and nth-weekday wildcards
+    // When each is read
+    // Then each is refused as unsimulated rather than as a mistake, since real
+    // EventBridge does take them
+    for (const source of [
+      "cron(0 12 L * ? *)",
+      "cron(0 12 3W * ? *)",
+      "cron(0 12 ? * 3#2 *)",
+    ]) {
+      expect(() => nextAfter(source)).toThrow(
+        SimUnsimulatedScheduleExpressionError,
+      );
+    }
+  });
+});

--- a/src/util/schedule/sim-schedule-cron.iso.test.ts
+++ b/src/util/schedule/sim-schedule-cron.iso.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+
+import { awsCronFieldSpecs } from "./cron/sim-cron-field-spec.js";
+import { SimSchedule } from "./sim-schedule.js";
+import type { SimScheduleDialect } from "./sim-schedule-dialect.js";
+
+/**
+ * A dialect insisting a rate's unit agrees with its value, as EventBridge does.
+ */
+const strict: SimScheduleDialect = {
+  cronFields: awsCronFieldSpecs,
+  requiresRateAgreement: true,
+};
+
+/**
+ * A Sunday lunchtime, which is where these are asked from unless said
+ * otherwise. Sunday matters, because it is what a weekday expression skips.
+ */
+const noon = new Date("2026-07-26T12:00:00.000Z");
+
+/**
+ * The next instant a schedule falls due after one, as an ISO string.
+ */
+function nextAfter(source: string, from = noon): string | undefined {
+  return SimSchedule.of(source, strict).nextAfter(from)?.toISOString();
+}
+
+describe("SimSchedule cron expressions", () => {
+  it("falls due at the absolute instants it names", () => {
+    // Given the every-day-at-noon expression from AWS's own examples
+    // When it is asked from noon, and from the noon it answers with
+    // Then each answer is the next day, so it falls due once a day
+    expect(nextAfter("cron(0 12 * * ? *)")).toBe("2026-07-27T12:00:00.000Z");
+    expect(
+      nextAfter("cron(0 12 * * ? *)", new Date("2026-07-27T12:00:00.000Z")),
+    ).toBe("2026-07-28T12:00:00.000Z");
+  });
+
+  it("reads a step as every so many from where it starts", () => {
+    expect(nextAfter("cron(0/15 * * * ? *)")).toBe("2026-07-26T12:15:00.000Z");
+    expect(
+      nextAfter("cron(0/15 * * * ? *)", new Date("2026-07-26T12:45:00.000Z")),
+    ).toBe("2026-07-26T13:00:00.000Z");
+  });
+
+  it("reads a range of named days, skipping the weekend", () => {
+    // Given six in the evening on weekdays, asked from a Sunday lunchtime
+    // When the next occurrence is taken
+    // Then it is Monday rather than that same Sunday evening
+    expect(nextAfter("cron(0 18 ? * MON-FRI *)")).toBe(
+      "2026-07-27T18:00:00.000Z",
+    );
+  });
+
+  it("reads a range that wraps around the end of its field", () => {
+    // Given AWS's own example of hours from ten at night to two in the morning
+    // When the occurrence after eleven at night is taken
+    // Then it is one in the morning, so the range covered the wrap rather than
+    // covering nothing at all
+    expect(
+      nextAfter("cron(0 20-2 * * ? *)", new Date("2026-07-27T00:30:00.000Z")),
+    ).toBe("2026-07-27T01:00:00.000Z");
+  });
+
+  it("reads a list of named months and a day of the month", () => {
+    expect(nextAfter("cron(0 8 1 JAN,JUL ? *)")).toBe(
+      "2027-01-01T08:00:00.000Z",
+    );
+  });
+
+  it("has nothing left once its years have run out", () => {
+    // Given an expression naming only a year in the past
+    // When it is asked when it is next due
+    // Then there is no answer, rather than a search that never ends
+    expect(nextAfter("cron(0 12 * * ? 1971)")).toBeUndefined();
+  });
+});

--- a/src/util/schedule/sim-schedule-dialect.ts
+++ b/src/util/schedule/sim-schedule-dialect.ts
@@ -1,0 +1,22 @@
+import type { SimCronFieldSpec } from "./cron/sim-cron-field-spec.js";
+
+/**
+ * One service's rules for reading a schedule expression.
+ *
+ * `rate(...)` and `cron(...)` look the same across AWS and are not read
+ * identically: EventBridge insists a rate's unit agrees with its value, and
+ * EventBridge Scheduler does not. Keeping the differences here is what lets one
+ * parser serve both, rather than one service's rules being the parser's.
+ */
+export interface SimScheduleDialect {
+  /**
+   * The fields of a cron expression, in order.
+   */
+  readonly cronFields: readonly SimCronFieldSpec[];
+
+  /**
+   * Whether a rate's unit has to agree with its value, so that `rate(1 hours)`
+   * is refused rather than read as one hour.
+   */
+  readonly requiresRateAgreement: boolean;
+}

--- a/src/util/schedule/sim-schedule-rate.iso.test.ts
+++ b/src/util/schedule/sim-schedule-rate.iso.test.ts
@@ -76,6 +76,24 @@ describe("SimSchedule rate expressions", () => {
     );
   });
 
+  it("refuses a rate longer than any two instants can be apart", () => {
+    // Given a rate of more days than time itself holds
+    // When it is read
+    // Then it is refused, rather than becoming an interval no Date can hold
+    expect(() => nextAfter("rate(99999999999 days)")).toThrow(
+      /longer than any two instants can be apart/u,
+    );
+  });
+
+  it("has nothing left once an interval runs past the end of time", () => {
+    // Given a daily rate asked from the last instant a Date reaches
+    // When the next occurrence is taken
+    // Then there is none, rather than a due time that quietly never arrives
+    expect(
+      nextAfter("rate(1 day)", new Date(8_640_000_000_000_000)),
+    ).toBeUndefined();
+  });
+
   it("refuses a rate that is not a value and a unit", () => {
     expect(() => nextAfter("rate(hour)")).toThrow(/value and a unit/u);
     expect(() => nextAfter("rate(1 hour or so)")).toThrow(/value and a unit/u);

--- a/src/util/schedule/sim-schedule-rate.iso.test.ts
+++ b/src/util/schedule/sim-schedule-rate.iso.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+
+import { awsCronFieldSpecs } from "./cron/sim-cron-field-spec.js";
+import { SimSchedule } from "./sim-schedule.js";
+import type { SimScheduleDialect } from "./sim-schedule-dialect.js";
+import { SimScheduleExpressionError } from "./sim-schedule.error.js";
+
+/**
+ * A dialect insisting a rate's unit agrees with its value, as EventBridge does.
+ */
+const strict: SimScheduleDialect = {
+  cronFields: awsCronFieldSpecs,
+  requiresRateAgreement: true,
+};
+
+/**
+ * A dialect taking a rate however its unit is written.
+ */
+const lenient: SimScheduleDialect = {
+  cronFields: awsCronFieldSpecs,
+  requiresRateAgreement: false,
+};
+
+const noon = new Date("2026-07-26T12:00:00.000Z");
+
+/**
+ * The next instant a schedule falls due after one, as an ISO string.
+ */
+function nextAfter(source: string, from = noon): string | undefined {
+  return SimSchedule.of(source, strict).nextAfter(from)?.toISOString();
+}
+
+describe("SimSchedule rate expressions", () => {
+  it("falls due one interval on from wherever it is asked", () => {
+    // Given a rate of an hour
+    // When it is asked from half past nine
+    // Then it is due at half past ten, not on the hour: a rate counts from
+    // where it started rather than from a wall clock boundary.
+    expect(
+      nextAfter("rate(1 hour)", new Date("2026-07-26T09:30:00.000Z")),
+    ).toBe("2026-07-26T10:30:00.000Z");
+  });
+
+  it("reads every unit AWS takes", () => {
+    expect(nextAfter("rate(5 minutes)")).toBe("2026-07-26T12:05:00.000Z");
+    expect(nextAfter("rate(2 hours)")).toBe("2026-07-26T14:00:00.000Z");
+    expect(nextAfter("rate(3 days)")).toBe("2026-07-29T12:00:00.000Z");
+  });
+
+  it("refuses a unit that does not agree with its value", () => {
+    // Given rates real EventBridge refuses for their plurals
+    // When they are read under a dialect insisting on agreement
+    // Then both are refused, naming the form that was wanted
+    expect(() => nextAfter("rate(1 hours)")).toThrow(/'1 hour'/u);
+    expect(() => nextAfter("rate(5 hour)")).toThrow(/'5 hours'/u);
+  });
+
+  it("takes either plural under a dialect that does not insist", () => {
+    // Given the same expression under a lenient dialect
+    // When it is read
+    // Then it is an hour, which is what keeps one parser serving two services
+    expect(
+      SimSchedule.of("rate(1 hours)", lenient).nextAfter(noon)?.toISOString(),
+    ).toBe("2026-07-26T13:00:00.000Z");
+  });
+
+  it("refuses a rate finer than the minute AWS runs", () => {
+    // Given a rate in seconds, and a rate of no time at all
+    // When each is read
+    // Then both are refused: AWS has no unit under a minute
+    expect(() => nextAfter("rate(30 seconds)")).toThrow(
+      /no schedule finer than one a minute/u,
+    );
+    expect(() => nextAfter("rate(0 minutes)")).toThrow(
+      SimScheduleExpressionError,
+    );
+  });
+
+  it("refuses a rate that is not a value and a unit", () => {
+    expect(() => nextAfter("rate(hour)")).toThrow(/value and a unit/u);
+    expect(() => nextAfter("rate(1 hour or so)")).toThrow(/value and a unit/u);
+  });
+});
+
+describe("SimSchedule expression forms", () => {
+  it("keeps the expression as it was written", () => {
+    expect(SimSchedule.of("rate(1 hour)", strict).source).toBe("rate(1 hour)");
+  });
+
+  it("refuses anything that is not a rate or a cron", () => {
+    expect(() => nextAfter("every(1 hour)")).toThrow(/'every\(\.\.\.\)'/u);
+    expect(() => nextAfter("at 12:00")).toThrow(
+      /'rate\(<value> <unit>\)' or 'cron\(<fields>\)'/u,
+    );
+  });
+});

--- a/src/util/schedule/sim-schedule.error.ts
+++ b/src/util/schedule/sim-schedule.error.ts
@@ -1,0 +1,18 @@
+/**
+ * A schedule expression the dialect reading it will not take.
+ *
+ * Parsing lives apart from any one service, so what it throws is generic and
+ * whoever asked for the parse turns it into their own API error. That is what
+ * lets two services share a parser and still refuse a bad expression the way
+ * each of their callers expects.
+ */
+export class SimScheduleExpressionError extends Error {}
+
+/**
+ * A schedule expression that real AWS takes and this simulation does not.
+ *
+ * Held apart from a plain refusal because the two mean different things to
+ * whoever reads them: one says the expression is wrong, and this one says the
+ * expression is right and the simulator does not go that far.
+ */
+export class SimUnsimulatedScheduleExpressionError extends SimScheduleExpressionError {}

--- a/src/util/schedule/sim-schedule.ts
+++ b/src/util/schedule/sim-schedule.ts
@@ -1,0 +1,85 @@
+import { SimCronExpression } from "./cron/sim-cron-expression.js";
+import { SimRateExpression } from "./rate/sim-rate-expression.js";
+import type { SimScheduleDialect } from "./sim-schedule-dialect.js";
+import { SimScheduleExpressionError } from "./sim-schedule.error.js";
+
+/**
+ * Something that knows when it next falls due.
+ *
+ * A rate always has a next occurrence and a cron expression need not, which is
+ * why the answer is optional here even though only one of the two ever declines
+ * to give one.
+ */
+interface SimScheduleOccurrences {
+  nextAfter(instant: Date): Date | undefined;
+}
+
+const expression = /^(?<kind>[a-z]+)\((?<body>.*)\)$/su;
+
+/**
+ * One schedule expression, whichever form it was written in.
+ *
+ * The two forms answer the same question and answer it differently: a rate
+ * counts from where it is asked, and a cron expression names absolute instants
+ * and ignores where it is asked from beyond needing somewhere to start.
+ */
+export class SimSchedule {
+  /**
+   * The expression as it was written, which a describe reports back.
+   */
+  public readonly source: string;
+
+  private readonly occurrences: SimScheduleOccurrences;
+
+  private constructor(source: string, occurrences: SimScheduleOccurrences) {
+    this.source = source;
+    this.occurrences = occurrences;
+  }
+
+  /**
+   * Read a schedule expression under a dialect's rules.
+   */
+  static of(source: string, dialect: SimScheduleDialect): SimSchedule {
+    const read = expression.exec(source.trim())?.groups;
+
+    if (read === undefined) {
+      throw new SimScheduleExpressionError(
+        `a schedule expression is 'rate(<value> <unit>)' or ` +
+          `'cron(<fields>)', and this one is '${source}'`,
+      );
+    }
+
+    return new this(source, this.occurrencesOf(read, dialect));
+  }
+
+  /**
+   * Read the body of whichever form the expression was written in.
+   */
+  private static occurrencesOf(
+    read: Partial<Record<string, string>>,
+    dialect: SimScheduleDialect,
+  ): SimScheduleOccurrences {
+    const body = read["body"] ?? "";
+
+    if (read["kind"] === "rate") {
+      return SimRateExpression.of(body, dialect.requiresRateAgreement);
+    }
+
+    if (read["kind"] === "cron") {
+      return SimCronExpression.of(dialect.cronFields, body);
+    }
+
+    throw new SimScheduleExpressionError(
+      `a schedule expression is a 'rate(...)' or a 'cron(...)', and this one ` +
+        `is a '${String(read["kind"])}(...)'`,
+    );
+  }
+
+  /**
+   * The next instant this schedule falls due after an instant, or nothing when
+   * it never falls due again.
+   */
+  nextAfter(instant: Date): Date | undefined {
+    return this.occurrences.nextAfter(instant);
+  }
+}


### PR DESCRIPTION
PutRule now takes a `rate()` or six field `cron()` `ScheduleExpression` in place of an event pattern, and a rule carrying one is armed on the simulation's own clock rather than the host's. Advancing simulated time past a due instant fires the rule and sends a standard scheduled event to its targets, and `advanceBy` returns once those deliveries have settled. Firing is per due instant rather than per advance, so an hour of `rate(1 minute)` invokes a target sixty times at sixty distinct simulated timestamps, each event stamped with the instant it was due. Disabling a rule stops it firing without replaying what it missed on the way back, and deleting or replacing one stops it for good. The expression parser lives in `src/util/schedule/` with the dialect as a parameter, so EventBridge Scheduler can reuse it without inheriting EventBridge's rules about rate unit agreement.

Resolves https://github.com/KensioSoftware/yulin/issues/533

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added simulated EventBridge scheduled rules using `rate(...)` and six-field `cron(...)` expressions.
  * Scheduled rules fire as simulated time advances, deliver AWS-compatible events to targets, and support enabling, disabling, replacement, and deletion.
  * Added validation for unsupported or invalid schedule expressions.
* **Documentation**
  * Updated EventBridge and simulated-time guides with scheduling behavior, limitations, UTC handling, and examples.
* **Tests**
  * Added coverage for scheduling, event delivery, validation, rule lifecycle changes, and timing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->