### PR TITLE
fix: refuse a rule target that names no function

### DIFF
--- a/src/service/eventbridge/command/target/sim-event-bridge-target-validation.iso.test.ts
+++ b/src/service/eventbridge/command/target/sim-event-bridge-target-validation.iso.test.ts
@@ -199,4 +199,27 @@ describe("EventBridge target validation", () => {
     assertInstanceOf(noName, SimEventBridgeValidationException);
     assertStringIncludes(noName.message, "names no function");
   });
+
+  it("refuses a Lambda ARN naming something that is not a function", async () => {
+    // Given a layer and an event source mapping, which are Lambda ARNs and
+    // are not functions.
+    const layer = await refusedTargets([
+      {
+        Id: "layer",
+        Arn: "arn:aws:lambda:us-east-1:888888888888:layer:shared",
+      },
+    ]);
+    const mapping = await refusedTargets([
+      {
+        Id: "mapping",
+        Arn: "arn:aws:lambda:us-east-1:888888888888:event-source-mapping:abcd",
+      },
+    ]);
+
+    // Then both are refused rather than read as a function of that name.
+    assertInstanceOf(layer, SimEventBridgeValidationException);
+    assertStringIncludes(layer.message, "names no function");
+    assertInstanceOf(mapping, SimEventBridgeValidationException);
+    assertStringIncludes(mapping.message, "names no function");
+  });
 });

--- a/src/service/eventbridge/target/sim-event-target-arn.ts
+++ b/src/service/eventbridge/target/sim-event-target-arn.ts
@@ -132,13 +132,20 @@ export class SimEventTargetArn {
   }
 
   /**
-   * The name of a Lambda function this ARN names.
+   * The name of a Lambda function this ARN names, or nothing when it names
+   * something else in Lambda.
    *
    * A function ARN's resource is `function:<name>`, and may carry a version or
    * alias after a second colon, which this simulation does not model and so
-   * reads as part of nothing.
+   * reads as part of nothing. The resource type is checked rather than
+   * assumed, because Lambda writes more than functions this way: a layer is
+   * `layer:<name>` and an event source mapping is
+   * `event-source-mapping:<uuid>`, and taking the part after the first colon
+   * would read either as a function that is not there.
    */
   get functionName(): string {
-    return this.resource.split(":", 2)[1] ?? "";
+    const [resourceType, name = ""] = this.resource.split(":", 2);
+
+    return resourceType === "function" ? name : "";
   }
 }


### PR DESCRIPTION
An EventBridge rule target reading a Lambda ARN took whatever followed the first colon of the resource as the function name, so a layer or an event source mapping passed PutTargets as a function of that name and only failed much later as a delivery to a function that does not exist. The resource type is now checked, which is what the class already promised: an ARN that cannot be delivered to says so when the target is added rather than when an event first matches. A version or alias after the name is still left out of it, and the equivalent fix in simulated Scheduler is #542.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation of Lambda targets to reject layer and event source mapping ARNs that do not identify a function.
  - Lambda resource names are now recognized only for function ARNs, preventing invalid target configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->