### PR TITLE
feat: fire simulated Scheduler schedules through their execution role

### DIFF
--- a/docs/services/eventbridge/README.md
+++ b/docs/services/eventbridge/README.md
@@ -5,8 +5,8 @@ in memory and every operation is authorized by simulated IAM.
 
 Event buses, rules, targets and `PutEvents`. A rule can send matched events to a simulated Lambda
 function, SQS queue or SNS topic, or fire on a schedule when a test advances simulated time.
-EventBridge Scheduler is not simulated yet. EventBridge-specific types are imported from the
-`@kensio/yulin/eventbridge` subpath.
+[EventBridge Scheduler](../scheduler/) is a separate service with its own docs.
+EventBridge-specific types are imported from the `@kensio/yulin/eventbridge` subpath.
 
 ## Putting an event onto a bus
 
@@ -733,7 +733,8 @@ no permission for.
   simulated. Everything is read in UTC.
 - Firing is exact and exactly once. Real EventBridge may deliver a scheduled event a few seconds
   late, and may deliver it more than once.
-- EventBridge Scheduler is a separate service and is not simulated.
+- EventBridge Scheduler is a separate service, simulated separately: see
+  [simulated Scheduler](../scheduler/).
 - Rule tags, a rule `RoleArn`, managed rules and the
   `ENABLED_WITH_ALL_CLOUDTRAIL_MANAGEMENT_EVENTS` state are refused rather than simulated.
 - Deleting an event bus deletes its rules, and deleting a rule deletes its targets. Real EventBridge

--- a/docs/services/scheduler/README.md
+++ b/docs/services/scheduler/README.md
@@ -175,7 +175,9 @@ Two things therefore have to be right, and they are fixed in different places:
   `sqs:SendMessage` or `sns:Publish`.
 
 When either is missing the target is not invoked and nothing is thrown, exactly as on AWS, where the
-failure goes to CloudWatch and nowhere the caller can see. `deliveryFailures` is what explains it:
+failure goes to CloudWatch and nowhere the caller can see. `advanceBy(...)` still returns normally,
+so a test asserting on a failed invocation reads `deliveryFailures` rather than expecting the advance
+to reject:
 
 ```typescript sim-scheduler-delivery-failures
 /**
@@ -401,7 +403,8 @@ the `RoleArn` on the target rather than against whoever created the schedule.
 - Firing is exact and exactly once. Real Scheduler invokes within a minute of the due time and does
   not promise a single invocation.
 - An invocation is attempted once. There is no retry and no dead letter queue, so a target that
-  throws is a recorded failure rather than a redelivery.
+  throws is a recorded failure rather than a redelivery. A failed invocation never rejects
+  `advanceBy(...)`; it is read from `deliveryFailures`.
 - Schedule groups are not a manageable resource. Every schedule is in `default`, and a `GroupName`
   naming any other group is refused rather than quietly put in `default`, where its ARN would name a
   group it is not in.

--- a/docs/services/scheduler/README.md
+++ b/docs/services/scheduler/README.md
@@ -68,6 +68,179 @@ rule](../eventbridge/#rules-that-fire-on-a-schedule) with two differences:
   day-of-week and year, so every day at two in the morning is `cron(0 2 * * ? *)`. The day-of-month
   and day-of-week fields cannot both say something: whichever is not deciding the day is written `?`.
 
+## Firing a schedule
+
+A schedule fires on the simulation's clock, not the host's: advancing simulated time past a due
+instant invokes the target, and nothing happens otherwise. So a nightly job takes no time at all to
+test.
+
+```typescript sim-scheduler-firing
+/**
+ * A schedule invoking a function three times in three simulated hours.
+ */
+
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import { CreateScheduleCommand } from "@aws-sdk/client-scheduler";
+
+import { SimAws, SimFixedClock } from "@kensio/yulin";
+import { makeLambdaZipFileInput } from "@kensio/yulin/lambda";
+
+const simAws = new SimAws({
+  clock: new SimFixedClock(new Date("2026-07-26T09:00:00.000Z")),
+});
+
+const functionArn = "arn:aws:lambda:us-east-1:888888888888:function:report";
+const runs: string[] = [];
+
+await simAws.lambda().createFunction({
+  input: {
+    FunctionName: "report",
+    Role: "arn:aws:iam::888888888888:role/ReportRole",
+    Code: {
+      ZipFile: makeLambdaZipFileInput(() => {
+        runs.push("ran");
+        return { ok: true };
+      }),
+    },
+  },
+});
+
+// The execution role has to trust Scheduler, and be allowed to invoke.
+await simAws.iam().createRole(
+  new CreateRoleCommand({
+    RoleName: "SchedulerRole",
+    AssumeRolePolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Principal: { Service: "scheduler.amazonaws.com" },
+        Action: "sts:AssumeRole",
+      },
+    }),
+  }),
+);
+
+await simAws.iam().putRolePolicy(
+  new PutRolePolicyCommand({
+    RoleName: "SchedulerRole",
+    PolicyName: "InvokeReport",
+    PolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Action: "lambda:InvokeFunction",
+        Resource: functionArn,
+      },
+    }),
+  }),
+);
+
+await simAws.scheduler().createSchedule(
+  new CreateScheduleCommand({
+    Name: "hourly-report",
+    ScheduleExpression: "rate(1 hour)",
+    FlexibleTimeWindow: { Mode: "OFF" },
+    Target: {
+      Arn: functionArn,
+      RoleArn: "arn:aws:iam::888888888888:role/SchedulerRole",
+    },
+  }),
+);
+
+await simAws.clock().advanceBy({ hours: 3 });
+
+console.log(runs.length); // 3
+```
+
+Firing is per due instant rather than per advance. Advancing an hour with a `rate(1 minute)` schedule
+invokes the target sixty times, at sixty distinct simulated instants. `advanceBy(...)` returns once
+every one of those invocations has settled, so the next line can assert.
+
+A target with an `Input` receives that text; one without receives an empty JSON object, which is what
+AWS documents for a function with no payload. There is no envelope: a schedule has no event of its
+own to describe.
+
+### The execution role
+
+This is the part that differs most from an [EventBridge rule](../eventbridge/), and the part that
+most often goes wrong in a real account. A rule reaches its target as the `events.amazonaws.com`
+service principal, and the target's own resource policy decides. A schedule assumes the `RoleArn` on
+its target, and that role's policies decide. No resource policy on the target is involved at all.
+
+Two things therefore have to be right, and they are fixed in different places:
+
+- The role's **trust policy** has to let `scheduler.amazonaws.com` assume it. A role copied from an
+  EventBridge rule trusts `events.amazonaws.com` and fails here.
+- A policy **on the role** has to allow the action on the target: `lambda:InvokeFunction`,
+  `sqs:SendMessage` or `sns:Publish`.
+
+When either is missing the target is not invoked and nothing is thrown, exactly as on AWS, where the
+failure goes to CloudWatch and nowhere the caller can see. `deliveryFailures` is what explains it:
+
+```typescript sim-scheduler-delivery-failures
+/**
+ * Finding out why a schedule's target was never invoked.
+ */
+
+import { CreateRoleCommand } from "@aws-sdk/client-iam";
+import { CreateScheduleCommand } from "@aws-sdk/client-scheduler";
+
+import { SimAws, SimFixedClock } from "@kensio/yulin";
+
+const simAws = new SimAws({
+  clock: new SimFixedClock(new Date("2026-07-26T09:00:00.000Z")),
+});
+
+// A role that trusts EventBridge rules rather than Scheduler.
+await simAws.iam().createRole(
+  new CreateRoleCommand({
+    RoleName: "SchedulerRole",
+    AssumeRolePolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Principal: { Service: "events.amazonaws.com" },
+        Action: "sts:AssumeRole",
+      },
+    }),
+  }),
+);
+
+await simAws.scheduler().createSchedule(
+  new CreateScheduleCommand({
+    Name: "hourly-report",
+    ScheduleExpression: "rate(1 hour)",
+    FlexibleTimeWindow: { Mode: "OFF" },
+    Target: {
+      Arn: "arn:aws:lambda:us-east-1:888888888888:function:report",
+      RoleArn: "arn:aws:iam::888888888888:role/SchedulerRole",
+    },
+  }),
+);
+
+await simAws.clock().advanceBy({ hours: 1 });
+
+const [failure] = simAws.scheduler().deliveryFailures;
+
+console.log(failure?.message);
+// "The trust policy of arn:aws:iam::888888888888:role/SchedulerRole does not
+//  allow scheduler.amazonaws.com to assume it, ..."
+```
+
+### One-time schedules and what happens after
+
+An `at(...)` schedule fires once and then stops. By default it stays in the Account afterwards, which
+surprises people who expected it to clean up: it keeps counting against the schedule quota and keeps
+turning up in listings. `ActionAfterCompletion: "DELETE"` is what removes it, and after that
+`GetSchedule` reports it gone.
+
+A schedule that is disabled when its only instant passes has not completed, because nothing was
+invoked, so it is still there afterwards whatever `ActionAfterCompletion` says.
+
+`State: "DISABLED"` stops a recurring schedule firing while it is off, and an `UpdateSchedule`
+enabling it picks up from the next due instant rather than replaying what it missed. An update that
+changes the expression reschedules from the new one.
+
 ## Updating and deleting
 
 ```typescript sim-scheduler-update-schedule
@@ -210,8 +383,11 @@ the `RoleArn` on the target rather than against whoever created the schedule.
 ## Available functionality
 
 - `CreateSchedule`, `GetSchedule`, `UpdateSchedule`, `DeleteSchedule` and `ListSchedules`.
-- `at(...)`, `rate(...)` and six-field `cron(...)` expressions.
-- Lambda, SQS and SNS targets, with a target `Input`.
+- `at(...)`, `rate(...)` and six-field `cron(...)` expressions, fired by advancing the simulation's
+  clock.
+- Lambda, SQS and SNS targets, with a target `Input`, invoked as the target's execution role and
+  authorized against that role's own policies.
+- `ActionAfterCompletion`, and `deliveryFailures` for invocations that did not happen.
 - The `default` schedule group in every account and region, without one being created.
 - Creation and modification timestamps from the simulation's clock, and prefix-narrowed,
   state-narrowed, paged listings.
@@ -220,8 +396,12 @@ the `RoleArn` on the target rather than against whoever created the schedule.
 
 ## Limitations
 
-- A schedule does not fire yet. Creating one, reading it and deleting it all work; advancing the
-  clock past a due time invokes nothing. Firing and target invocation are the next change.
+- A schedule only fires while a test advances the simulation's clock. Nothing runs on the host's
+  clock, so a simulation left alone in real time fires nothing however long it is left.
+- Firing is exact and exactly once. Real Scheduler invokes within a minute of the due time and does
+  not promise a single invocation.
+- An invocation is attempted once. There is no retry and no dead letter queue, so a target that
+  throws is a recorded failure rather than a redelivery.
 - Schedule groups are not a manageable resource. Every schedule is in `default`, and a `GroupName`
   naming any other group is refused rather than quietly put in `default`, where its ARN would name a
   group it is not in.

--- a/docs/services/scheduler/sim-scheduler-delivery-failures.example.ts
+++ b/docs/services/scheduler/sim-scheduler-delivery-failures.example.ts
@@ -1,0 +1,47 @@
+/**
+ * Finding out why a schedule's target was never invoked.
+ */
+
+import { CreateRoleCommand } from "@aws-sdk/client-iam";
+import { CreateScheduleCommand } from "@aws-sdk/client-scheduler";
+
+import { SimAws, SimFixedClock } from "@kensio/yulin";
+
+const simAws = new SimAws({
+  clock: new SimFixedClock(new Date("2026-07-26T09:00:00.000Z")),
+});
+
+// A role that trusts EventBridge rules rather than Scheduler.
+await simAws.iam().createRole(
+  new CreateRoleCommand({
+    RoleName: "SchedulerRole",
+    AssumeRolePolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Principal: { Service: "events.amazonaws.com" },
+        Action: "sts:AssumeRole",
+      },
+    }),
+  }),
+);
+
+await simAws.scheduler().createSchedule(
+  new CreateScheduleCommand({
+    Name: "hourly-report",
+    ScheduleExpression: "rate(1 hour)",
+    FlexibleTimeWindow: { Mode: "OFF" },
+    Target: {
+      Arn: "arn:aws:lambda:us-east-1:888888888888:function:report",
+      RoleArn: "arn:aws:iam::888888888888:role/SchedulerRole",
+    },
+  }),
+);
+
+await simAws.clock().advanceBy({ hours: 1 });
+
+const [failure] = simAws.scheduler().deliveryFailures;
+
+console.log(failure?.message);
+// "The trust policy of arn:aws:iam::888888888888:role/SchedulerRole does not
+//  allow scheduler.amazonaws.com to assume it, ..."

--- a/docs/services/scheduler/sim-scheduler-firing.example.ts
+++ b/docs/services/scheduler/sim-scheduler-firing.example.ts
@@ -1,0 +1,75 @@
+/**
+ * A schedule invoking a function three times in three simulated hours.
+ */
+
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import { CreateScheduleCommand } from "@aws-sdk/client-scheduler";
+
+import { SimAws, SimFixedClock } from "@kensio/yulin";
+import { makeLambdaZipFileInput } from "@kensio/yulin/lambda";
+
+const simAws = new SimAws({
+  clock: new SimFixedClock(new Date("2026-07-26T09:00:00.000Z")),
+});
+
+const functionArn = "arn:aws:lambda:us-east-1:888888888888:function:report";
+const runs: string[] = [];
+
+await simAws.lambda().createFunction({
+  input: {
+    FunctionName: "report",
+    Role: "arn:aws:iam::888888888888:role/ReportRole",
+    Code: {
+      ZipFile: makeLambdaZipFileInput(() => {
+        runs.push("ran");
+        return { ok: true };
+      }),
+    },
+  },
+});
+
+// The execution role has to trust Scheduler, and be allowed to invoke.
+await simAws.iam().createRole(
+  new CreateRoleCommand({
+    RoleName: "SchedulerRole",
+    AssumeRolePolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Principal: { Service: "scheduler.amazonaws.com" },
+        Action: "sts:AssumeRole",
+      },
+    }),
+  }),
+);
+
+await simAws.iam().putRolePolicy(
+  new PutRolePolicyCommand({
+    RoleName: "SchedulerRole",
+    PolicyName: "InvokeReport",
+    PolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Action: "lambda:InvokeFunction",
+        Resource: functionArn,
+      },
+    }),
+  }),
+);
+
+await simAws.scheduler().createSchedule(
+  new CreateScheduleCommand({
+    Name: "hourly-report",
+    ScheduleExpression: "rate(1 hour)",
+    FlexibleTimeWindow: { Mode: "OFF" },
+    Target: {
+      Arn: functionArn,
+      RoleArn: "arn:aws:iam::888888888888:role/SchedulerRole",
+    },
+  }),
+);
+
+await simAws.clock().advanceBy({ hours: 3 });
+
+console.log(runs.length); // 3

--- a/docs/time/README.md
+++ b/docs/time/README.md
@@ -141,6 +141,12 @@ If work triggered by advancing fails, the failure is thrown from `advanceBy(...)
 in the background, and the clock is left at the point it failed rather than at the instant asked
 for. Anything still queued stays queued.
 
+Delivery to a target is the exception, and deliberately so. An EventBridge rule or a Scheduler
+schedule that cannot reach its target records the failure instead of throwing, because real AWS
+reports a failed delivery to nobody and because one rejected delivery would otherwise fail an
+unrelated `advanceBy(...)` elsewhere in the same test. Those are read from
+`eventBridge().deliveryFailures` and `scheduler().deliveryFailures` rather than caught.
+
 Several parts of the simulator schedule work on the clock, so advancing time does more than change
 what timestamps and expiry checks see. A scheduled EventBridge rule fires, an EventBridge Scheduler
 schedule invokes its target, a DynamoDB item passes its time to live, a Secrets Manager deletion

--- a/docs/time/README.md
+++ b/docs/time/README.md
@@ -142,9 +142,9 @@ in the background, and the clock is left at the point it failed rather than at t
 for. Anything still queued stays queued.
 
 Several parts of the simulator schedule work on the clock, so advancing time does more than change
-what timestamps and expiry checks see. A scheduled EventBridge rule fires, a DynamoDB item passes
-its time to live, a Secrets Manager deletion falls due, and a Lambda event source mapping polls
-again. Each of those runs at its own due instant inside the interval, not all at once at the end.
+what timestamps and expiry checks see. A scheduled EventBridge rule fires, an EventBridge Scheduler
+schedule invokes its target, a DynamoDB item passes its time to live, a Secrets Manager deletion
+falls due, and a Lambda event source mapping polls again. Each of those runs at its own due instant inside the interval, not all at once at the end.
 
 ## Time inside a simulated Lambda handler
 
@@ -257,8 +257,8 @@ runs on a clock a test can control: `await simSdk.simAws.clock().advanceBy({ hou
 - Advancing the clock is the only thing that fires a scheduled
   [EventBridge rule](../services/eventbridge/#rules-that-fire-on-a-schedule). Nothing runs on the
   host's clock, so a simulation left alone in real time fires nothing however long it is left.
-- EventBridge Scheduler is not simulated, so `rate` and `cron` reach the clock through an
-  EventBridge rule only.
+- Advancing the clock is also the only thing that fires an [EventBridge Scheduler
+  schedule](../services/scheduler/#firing-a-schedule), including a one-time `at(...)` one.
 - Only `SimAws` exposes time control. Services constructed standalone, such as `new SimS3()`, get
   their own real clock and no way to move it.
 - A `SimAws` constructed with a `background` scheduler of its own cannot control time, because that

--- a/src/service/aws/factory/sim-aws-account-region-service-builder.ts
+++ b/src/service/aws/factory/sim-aws-account-region-service-builder.ts
@@ -8,14 +8,15 @@ import { SimAcm } from "../../acm/sim-acm.js";
 import { SimApiGatewayV2 } from "../../apigatewayv2/index.js";
 import {
   simAwsAcmDnsRecords,
+  simAwsEventBridgeDeliveryTargets,
   simAwsHttpApiJwtIssuerKeys,
+  simAwsSchedulerDeliveryTargets,
 } from "./sim-aws-cross-account-collaborators.js";
 import { SimCloudFormation } from "../../cloudformation/index.js";
 import { SimCognitoIdentityProvider } from "../../cognito/index.js";
 import { simAwsCognitoTriggerFunctions } from "../../cognito/user-pool/trigger/sim-aws-cognito-trigger-functions.js";
 import { SimDynamoDb as SimDynamoDatabase } from "../../dynamodb/index.js";
 import { SimEventBridge } from "../../eventbridge/index.js";
-import { SimAwsEventBridgeDeliveryTargets } from "../../eventbridge/delivery/sim-aws-event-bridge-delivery-targets.js";
 import type { SimIamRegistry } from "../../iam/registry/sim-iam-registry.js";
 import { SimKms } from "../../kms/index.js";
 import type { SimHttpApiRegistry } from "../../apigatewayv2/registry/sim-http-api-registry.js";
@@ -150,11 +151,7 @@ export class SimAwsAccountRegionServiceBuilder {
   createEventBridge(scope: SimAwsAccountRegionContainer): SimEventBridge {
     return new SimEventBridge({
       ...this.scoped(scope),
-      // Rules deliver to targets in any Account and Region of this
-      // simulation, as real EventBridge delivers across both.
-      deliveryTargets: new SimAwsEventBridgeDeliveryTargets({
-        simAws: this.simAws,
-      }),
+      deliveryTargets: simAwsEventBridgeDeliveryTargets(this.simAws),
     });
   }
 
@@ -265,7 +262,10 @@ export class SimAwsAccountRegionServiceBuilder {
 
   /** Create simulated EventBridge Scheduler for an Account Region scope. */
   createScheduler(scope: SimAwsAccountRegionContainer): SimScheduler {
-    return new SimScheduler(this.scoped(scope));
+    return new SimScheduler({
+      ...this.scoped(scope),
+      deliveryTargets: simAwsSchedulerDeliveryTargets(this.simAws),
+    });
   }
 
   /** Create simulated STS for an Account/Region scope. */

--- a/src/service/aws/factory/sim-aws-cross-account-collaborators.ts
+++ b/src/service/aws/factory/sim-aws-cross-account-collaborators.ts
@@ -1,5 +1,8 @@
 import { SimRoute53AcmDnsRecords } from "../../acm/validation/sim-route53-acm-dns-records.js";
 import { SimCognitoHttpApiJwtIssuerKeys } from "../../apigatewayv2/api/authorizer/sim-cognito-http-api-jwt-issuer-keys.js";
+import { SimAwsEventBridgeDeliveryTargets } from "../../eventbridge/delivery/sim-aws-event-bridge-delivery-targets.js";
+import { SimAwsSchedulerDeliveryTargets } from "../../scheduler/delivery/sim-aws-scheduler-delivery-targets.js";
+import type { SimAws } from "../sim-aws.js";
 import type { SimAwsScopedServiceRegistries } from "./sim-aws-scoped-service-registries.js";
 
 /**
@@ -27,4 +30,29 @@ export function simAwsHttpApiJwtIssuerKeys(
   return new SimCognitoHttpApiJwtIssuerKeys({
     userPoolRegistry: registries.cognito,
   });
+}
+
+/**
+ * Everywhere a simulated EventBridge rule can deliver.
+ *
+ * Rules deliver to targets in any Account and Region of the simulation, as real
+ * EventBridge delivers across both.
+ */
+export function simAwsEventBridgeDeliveryTargets(
+  simAws: SimAws,
+): SimAwsEventBridgeDeliveryTargets {
+  return new SimAwsEventBridgeDeliveryTargets({ simAws });
+}
+
+/**
+ * Everywhere a simulated Scheduler schedule can invoke.
+ *
+ * A schedule assumes its execution role in that role's own Account and reaches
+ * its target in the target's, which need not be the same one, so this reads the
+ * whole simulation rather than one scope.
+ */
+export function simAwsSchedulerDeliveryTargets(
+  simAws: SimAws,
+): SimAwsSchedulerDeliveryTargets {
+  return new SimAwsSchedulerDeliveryTargets({ simAws });
 }

--- a/src/service/scheduler/README.md
+++ b/src/service/scheduler/README.md
@@ -1,8 +1,7 @@
 # Simulated EventBridge Scheduler implementation
 
 This directory contains the simulated EventBridge Scheduler service implementation. Schedules, their
-targets, and the five commands that manage them. Firing a schedule as simulated time advances, and
-invoking its target through an execution role, come next.
+targets, the five commands that manage them, and firing a schedule as simulated time advances.
 
 The guiding decision is that this is a separate service from simulated EventBridge rather than a
 corner of it. The two look similar from a distance and differ in every detail that matters: a
@@ -81,6 +80,48 @@ decisions are. Every one of them refuses rather than drops, on the same reasonin
 simulator: a schedule that silently ignored its `ScheduleExpressionTimezone` would fire at the wrong
 hour, and that is exactly the thing a test of a nightly job is checking.
 
+## Firing
+
+`SimSchedulerSchedules` arms a schedule for its next due instant through
+`BackgroundScheduler.scheduleAt`, and a firing arms the next one before it returns. That is what
+makes firing per due instant rather than per advance: `SimClockControl.advanceBy` walks the interval
+taking whatever has fallen due, so a schedule rescheduling itself inside the interval is taken again
+in the same walk.
+
+Nothing cancels a timer. A firing checks that the schedule it holds is still the one its store has
+under that name and stops if it is not, which covers deletion and an update replacement in one. That
+is also what makes an update reschedule from the new expression: an update stores a newly built
+schedule and arms it, and the previous one's next firing finds itself out of date.
+
+`ActionAfterCompletion` needs a schedule that has _completed_, which is one that invoked its target
+and has no next occurrence. A disabled schedule whose only instant goes past has not completed, so it
+survives whatever the action says. Nothing else needs to know a schedule is one-time: `SimAtExpression`
+answers with its instant once and with nothing afterwards, so arming simply stops.
+
+## Delivery
+
+`delivery/` is where Scheduler's execution model lives, and it is the part with no precedent
+elsewhere in the simulator. Everything else that reaches across services — SNS to Lambda, S3 to SQS,
+an EventBridge rule to anything — arrives as a service principal and is admitted by the target's
+resource policy. A schedule arrives as an assumed role and is admitted by that role's identity
+policies, with no resource policy involved.
+
+`sim-scheduler-execution-role.ts` is that difference. It asks STS's own
+`AssumeRoleTrustPolicyAuthorizer` whether the role admits `scheduler.amazonaws.com`, then builds a
+`SimResolvedCaller` whose principal is the session and whose `identityPolicyPrincipal` is the role.
+That split is exactly what `SimResolvedCaller` exists for, and it is why no STS session or temporary
+credential is created: nothing would read them, and registering credentials nobody uses would be
+state the simulation has to keep straight for no benefit.
+
+The two failures are reported apart from each other, because they are fixed in different places: the
+trust policy is on the role's `AssumeRolePolicyDocument`, and the permission is in a policy attached
+to it. Telling a reader which one it was saves the whole diagnosis.
+
+`SimAwsSchedulerDeliveryTargets` assumes the role in the role's own Account and reaches the target in
+the target's, which need not be the same one. A `SimScheduler` built outside SimAws gets
+`SimSchedulerNoDeliveryTargets`, which records every invocation as a failure saying why there was
+nowhere to make it.
+
 ## Authorization
 
 `SimSchedulerAuthorizer` authorizes the caller against the schedule ARN. It is deliberately not
@@ -90,7 +131,7 @@ the command that created the schedule.
 
 ## Divergences
 
-Two so far, both deliberate.
+Four, all deliberate.
 
 Schedule groups are **refused rather than simulated**. A `GroupName` other than `default` fails, where
 real AWS creates the schedule in whichever group is named. Accepting the name and using `default`
@@ -100,3 +141,11 @@ lie.
 `ClientToken` is **accepted and ignored**, on `CreateSchedule`, `UpdateSchedule` and
 `DeleteSchedule`. It exists to make a retried request idempotent, nothing here retries, and refusing
 it would break ordinary AWS code that passes one as a matter of course.
+
+A schedule fires **exactly, and exactly once**. Real Scheduler invokes within a minute of the due
+time and promises no more than that. Reproducing the imprecision would make a test of a schedule
+assert on something that is not the schedule.
+
+A target with no `Input` receives an **empty JSON object**. AWS documents that for a Lambda target
+and says nothing about it for a queue or a topic, so the same answer is used for all three rather
+than inventing a different one per service.

--- a/src/service/scheduler/command/schedule/sim-scheduler-create-schedule.ts
+++ b/src/service/scheduler/command/schedule/sim-scheduler-create-schedule.ts
@@ -1,4 +1,5 @@
 import { SimSchedulerConflictException } from "../../error/sim-scheduler.error.js";
+import type { SimSchedulerSchedules } from "../../schedule/sim-scheduler-schedules.js";
 import type { SimSchedulerScheduleStore } from "../../schedule/sim-scheduler-schedule-store.js";
 import type { SimSchedulerRequestOptions } from "../sim-scheduler-request-options.js";
 import type { SimSchedulerScheduleAccess } from "./sim-scheduler-schedule-access.js";
@@ -12,6 +13,7 @@ interface SimSchedulerCreateScheduleProperties {
   readonly schedules: SimSchedulerScheduleStore;
   readonly access: SimSchedulerScheduleAccess;
   readonly writer: SimSchedulerScheduleWriter;
+  readonly firing: SimSchedulerSchedules;
 }
 
 /**
@@ -27,11 +29,13 @@ export class SimSchedulerCreateSchedule {
   private readonly schedules: SimSchedulerScheduleStore;
   private readonly access: SimSchedulerScheduleAccess;
   private readonly writer: SimSchedulerScheduleWriter;
+  private readonly firing: SimSchedulerSchedules;
 
   constructor(properties: SimSchedulerCreateScheduleProperties) {
     this.schedules = properties.schedules;
     this.access = properties.access;
     this.writer = properties.writer;
+    this.firing = properties.firing;
   }
 
   /**
@@ -59,6 +63,7 @@ export class SimSchedulerCreateSchedule {
     const schedule = this.writer.write(input, requested);
 
     this.schedules.put(schedule);
+    this.firing.arm(schedule);
 
     return { $metadata: {}, ScheduleArn: schedule.arn };
   }

--- a/src/service/scheduler/command/schedule/sim-scheduler-update-schedule.ts
+++ b/src/service/scheduler/command/schedule/sim-scheduler-update-schedule.ts
@@ -1,3 +1,4 @@
+import type { SimSchedulerSchedules } from "../../schedule/sim-scheduler-schedules.js";
 import type { SimSchedulerScheduleStore } from "../../schedule/sim-scheduler-schedule-store.js";
 import type { SimSchedulerRequestOptions } from "../sim-scheduler-request-options.js";
 import type { SimSchedulerScheduleAccess } from "./sim-scheduler-schedule-access.js";
@@ -11,6 +12,7 @@ interface SimSchedulerUpdateScheduleProperties {
   readonly schedules: SimSchedulerScheduleStore;
   readonly access: SimSchedulerScheduleAccess;
   readonly writer: SimSchedulerScheduleWriter;
+  readonly firing: SimSchedulerSchedules;
 }
 
 /**
@@ -28,11 +30,13 @@ export class SimSchedulerUpdateSchedule {
   private readonly schedules: SimSchedulerScheduleStore;
   private readonly access: SimSchedulerScheduleAccess;
   private readonly writer: SimSchedulerScheduleWriter;
+  private readonly firing: SimSchedulerSchedules;
 
   constructor(properties: SimSchedulerUpdateScheduleProperties) {
     this.schedules = properties.schedules;
     this.access = properties.access;
     this.writer = properties.writer;
+    this.firing = properties.firing;
   }
 
   /**
@@ -55,6 +59,11 @@ export class SimSchedulerUpdateSchedule {
     const schedule = this.writer.write(input, requested, existing.creationDate);
 
     this.schedules.put(schedule);
+
+    // Arming the replacement is what reschedules from the new expression. The
+    // schedule it replaced is no longer the one the store holds, so its next
+    // firing finds itself out of date and stops.
+    this.firing.arm(schedule);
 
     return { $metadata: {}, ScheduleArn: schedule.arn };
   }

--- a/src/service/scheduler/command/sim-scheduler-commands.ts
+++ b/src/service/scheduler/command/sim-scheduler-commands.ts
@@ -1,6 +1,10 @@
-import type { SimClock } from "../../../util/clock/sim-clock.js";
+import type { BackgroundScheduler } from "../../../util/background/background.js";
 import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
 import type { SimIamInterServiceAuthZ } from "../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import type { SimSchedulerDeliveryTargets } from "../delivery/sim-scheduler-delivery.js";
+import { SimSchedulerNoDeliveryTargets } from "../delivery/sim-scheduler-no-delivery-targets.js";
+import { SimSchedulerTargetDelivery } from "../delivery/sim-scheduler-target-delivery.js";
+import { SimSchedulerSchedules } from "../schedule/sim-scheduler-schedules.js";
 import type { SimSchedulerScheduleStore } from "../schedule/sim-scheduler-schedule-store.js";
 import { SimSchedulerAuthorizer } from "./authorize/sim-scheduler-authorizer.js";
 import { SimSchedulerCreateSchedule } from "./schedule/sim-scheduler-create-schedule.js";
@@ -12,7 +16,8 @@ import { SimSchedulerUpdateSchedule } from "./schedule/sim-scheduler-update-sche
 interface SimSchedulerCommandsProperties {
   readonly schedules: SimSchedulerScheduleStore;
   readonly iam: SimIamInterServiceAuthZ;
-  readonly clock: SimClock;
+  readonly background: BackgroundScheduler;
+  readonly deliveryTargets?: SimSchedulerDeliveryTargets | undefined;
   readonly accountRegionScope: SimAwsAccountRegionScope;
 }
 
@@ -26,9 +31,11 @@ export class SimSchedulerCommands {
   public readonly scheduleCreation: SimSchedulerCreateSchedule;
   public readonly scheduleUpdate: SimSchedulerUpdateSchedule;
   public readonly schedules: SimSchedulerScheduleCommands;
+  public readonly delivery: SimSchedulerTargetDelivery;
+  public readonly firing: SimSchedulerSchedules;
 
   constructor(properties: SimSchedulerCommandsProperties) {
-    const { schedules, accountRegionScope } = properties;
+    const { schedules, accountRegionScope, background } = properties;
     const authorizer = new SimSchedulerAuthorizer({ iam: properties.iam });
     const access = new SimSchedulerScheduleAccess({
       schedules,
@@ -37,18 +44,30 @@ export class SimSchedulerCommands {
     });
     const writer = new SimSchedulerScheduleWriter({
       accountRegionScope,
-      clock: properties.clock,
+      clock: background,
+    });
+
+    this.delivery = new SimSchedulerTargetDelivery({
+      endpoints:
+        properties.deliveryTargets ?? new SimSchedulerNoDeliveryTargets(),
+    });
+    this.firing = new SimSchedulerSchedules({
+      schedules,
+      delivery: this.delivery,
+      background,
     });
 
     this.scheduleCreation = new SimSchedulerCreateSchedule({
       schedules,
       access,
       writer,
+      firing: this.firing,
     });
     this.scheduleUpdate = new SimSchedulerUpdateSchedule({
       schedules,
       access,
       writer,
+      firing: this.firing,
     });
     this.schedules = new SimSchedulerScheduleCommands({ schedules, access });
   }

--- a/src/service/scheduler/delivery/sim-aws-scheduler-delivery-targets.ts
+++ b/src/service/scheduler/delivery/sim-aws-scheduler-delivery-targets.ts
@@ -1,0 +1,82 @@
+import type { SimAws } from "../../aws/sim-aws.js";
+import type { SimSchedulerTargetService } from "../target/sim-scheduler-target-arn.js";
+import type {
+  SimSchedulerAssumedDelivery,
+  SimSchedulerDeliveryRequest,
+  SimSchedulerDeliveryTargets,
+} from "./sim-scheduler-delivery.js";
+import { SimSchedulerDeliveryFunction } from "./sim-scheduler-delivery-function.js";
+import { SimSchedulerDeliveryQueue } from "./sim-scheduler-delivery-queue.js";
+import { SimSchedulerDeliveryTopic } from "./sim-scheduler-delivery-topic.js";
+import {
+  assumeSchedulerExecutionRole,
+  schedulerExecutionRoleTarget,
+} from "./sim-scheduler-execution-role.js";
+
+interface SimAwsSchedulerDeliveryTargetsProperties {
+  readonly simAws: SimAws;
+}
+
+/**
+ * Everywhere the schedules of one simulated AWS instance can invoke.
+ *
+ * The target is looked up when a schedule fires, never when this is built:
+ * reaching another service while this one is being constructed is a cycle with
+ * no bottom to it.
+ *
+ * A target in another Account or Region is allowed, since real Scheduler
+ * invokes across both, and it is the target's own Account that evaluates
+ * whether the execution role may.
+ */
+export class SimAwsSchedulerDeliveryTargets implements SimSchedulerDeliveryTargets {
+  private readonly simAws: SimAws;
+
+  constructor(properties: SimAwsSchedulerDeliveryTargetsProperties) {
+    this.simAws = properties.simAws;
+  }
+
+  /**
+   * Assume the schedule's execution role, then invoke its target as that role.
+   *
+   * The role is assumed in its own Account, and the target is reached in the
+   * target's, which are not necessarily the same one.
+   */
+  async deliver(request: SimSchedulerDeliveryRequest): Promise<void> {
+    const arn = request.schedule.target.arn;
+    const role = schedulerExecutionRoleTarget(request.schedule.target.roleArn);
+    const roleScope = this.simAws.accountRegionScope(
+      role.accountId,
+      arn.regionName,
+    );
+
+    const caller = await assumeSchedulerExecutionRole(role, roleScope.iam());
+
+    await this.invoke(arn.service, { request, caller });
+  }
+
+  /**
+   * Hand the invocation to the one destination that knows this service.
+   */
+  private async invoke(
+    service: SimSchedulerTargetService,
+    delivery: SimSchedulerAssumedDelivery,
+  ): Promise<void> {
+    const arn = delivery.request.schedule.target.arn;
+    const scope = this.simAws.accountRegionScope(arn.accountId, arn.regionName);
+
+    switch (service) {
+      case "lambda": {
+        await new SimSchedulerDeliveryFunction({ scope }).deliver(delivery);
+        return;
+      }
+      case "sqs": {
+        await new SimSchedulerDeliveryQueue({ scope }).deliver(delivery);
+        return;
+      }
+      case "sns": {
+        await new SimSchedulerDeliveryTopic({ scope }).deliver(delivery);
+        return;
+      }
+    }
+  }
+}

--- a/src/service/scheduler/delivery/sim-scheduler-delivery-failures.ts
+++ b/src/service/scheduler/delivery/sim-scheduler-delivery-failures.ts
@@ -1,0 +1,77 @@
+interface SimSchedulerDeliveryFailureProperties {
+  readonly scheduleName: string;
+  readonly scheduleArn: string;
+  readonly targetArn: string;
+  readonly roleArn: string;
+  readonly at: Date;
+  readonly error: unknown;
+}
+
+/**
+ * One invocation a schedule could not make.
+ */
+export class SimSchedulerDeliveryFailure {
+  public readonly scheduleName: string;
+  public readonly scheduleArn: string;
+  public readonly targetArn: string;
+
+  /**
+   * The execution role the invocation was attempted as, which is where most of
+   * these are fixed.
+   */
+  public readonly roleArn: string;
+
+  /**
+   * The instant the schedule fell due, on the simulation's clock.
+   */
+  public readonly at: Date;
+
+  public readonly error: unknown;
+
+  constructor(properties: SimSchedulerDeliveryFailureProperties) {
+    this.scheduleName = properties.scheduleName;
+    this.scheduleArn = properties.scheduleArn;
+    this.targetArn = properties.targetArn;
+    this.roleArn = properties.roleArn;
+    this.at = properties.at;
+    this.error = properties.error;
+  }
+
+  /**
+   * What went wrong, as a message.
+   */
+  get message(): string {
+    if (this.error instanceof Error) {
+      return this.error.message;
+    }
+
+    return String(this.error);
+  }
+}
+
+/**
+ * Every invocation one simulated Scheduler scope could not make.
+ *
+ * Real Scheduler tells nobody about a failed invocation as it happens: it goes
+ * to CloudWatch metrics, or to a dead letter queue if one is configured, and
+ * the caller who created the schedule is long gone. So a target that is
+ * unexpectedly empty is explained here rather than by anything an SDK call
+ * returned.
+ */
+export class SimSchedulerDeliveryFailures {
+  private readonly failures: SimSchedulerDeliveryFailure[] = [];
+
+  /**
+   * Every failure so far, oldest first.
+   */
+  get all(): readonly SimSchedulerDeliveryFailure[] {
+    return [...this.failures];
+  }
+
+  /**
+   * Keep a failed invocation.
+   */
+  record(properties: SimSchedulerDeliveryFailureProperties): void {
+    this.failures.push(new SimSchedulerDeliveryFailure(properties));
+  }
+}

--- a/src/service/scheduler/delivery/sim-scheduler-delivery-function.ts
+++ b/src/service/scheduler/delivery/sim-scheduler-delivery-function.ts
@@ -1,0 +1,67 @@
+import type { SimAwsAccountRegionContainer } from "../../aws/sim-aws-account-region-scope.js";
+import {
+  SimSchedulerDeliveryNotPermitted,
+  SimSchedulerTargetNotFound,
+} from "../error/sim-scheduler-delivery.error.js";
+import {
+  type SimSchedulerAssumedDelivery,
+  simSchedulerDeliveryDocument,
+} from "./sim-scheduler-delivery.js";
+
+const invokeAction = "lambda:InvokeFunction";
+
+interface SimSchedulerDeliveryFunctionProperties {
+  readonly scope: SimAwsAccountRegionContainer;
+}
+
+/**
+ * A Lambda function a simulated schedule invokes.
+ *
+ * The function's own resource policy is not consulted, which is the difference
+ * from an EventBridge rule target: the schedule arrives as an assumed role
+ * rather than as a service principal, and a role in the same Account needs only
+ * its own identity policy to invoke a function.
+ */
+export class SimSchedulerDeliveryFunction {
+  private readonly scope: SimAwsAccountRegionContainer;
+
+  constructor(properties: SimSchedulerDeliveryFunctionProperties) {
+    this.scope = properties.scope;
+  }
+
+  /**
+   * Invoke the function, if the execution role may.
+   */
+  async deliver(delivery: SimSchedulerAssumedDelivery): Promise<void> {
+    const targetArn = delivery.request.schedule.target.arn;
+    const simFunction = this.scope
+      .lambda()
+      .getSimFunctionByName(targetArn.functionName);
+
+    if (simFunction === undefined) {
+      throw new SimSchedulerTargetNotFound(
+        `${targetArn.value} is not a simulated Lambda function.`,
+      );
+    }
+
+    const decision = this.scope.iam().authorize({
+      action: invokeAction,
+      resource: targetArn.value,
+      caller: delivery.caller,
+    });
+
+    if (decision.isDenied) {
+      throw new SimSchedulerDeliveryNotPermitted(
+        `${delivery.request.schedule.target.roleArn} is not allowed to ` +
+          `${invokeAction} on ${targetArn.value}. Grant it in a policy on ` +
+          `the execution role.`,
+      );
+    }
+
+    // Invoked directly rather than through an Invoke command, because the
+    // schedule is already inside the background task standing for the
+    // asynchronous invocation real Scheduler makes, and because a handler
+    // failure has to reach the delivery outcome rather than being swallowed.
+    await simFunction.invoke(simSchedulerDeliveryDocument(delivery.request));
+  }
+}

--- a/src/service/scheduler/delivery/sim-scheduler-delivery-queue.ts
+++ b/src/service/scheduler/delivery/sim-scheduler-delivery-queue.ts
@@ -1,0 +1,67 @@
+import type { SimAwsAccountRegionContainer } from "../../aws/sim-aws-account-region-scope.js";
+import {
+  SimSchedulerDeliveryNotPermitted,
+  SimSchedulerTargetNotFound,
+} from "../error/sim-scheduler-delivery.error.js";
+import {
+  type SimSchedulerAssumedDelivery,
+  simSchedulerDeliveryJson,
+} from "./sim-scheduler-delivery.js";
+
+const sendAction = "sqs:SendMessage";
+
+interface SimSchedulerDeliveryQueueProperties {
+  readonly scope: SimAwsAccountRegionContainer;
+}
+
+/**
+ * An SQS queue a simulated schedule sends to.
+ */
+export class SimSchedulerDeliveryQueue {
+  private readonly scope: SimAwsAccountRegionContainer;
+
+  constructor(properties: SimSchedulerDeliveryQueueProperties) {
+    this.scope = properties.scope;
+  }
+
+  /**
+   * Send the schedule's input to the queue, if the execution role may.
+   */
+  async deliver(delivery: SimSchedulerAssumedDelivery): Promise<void> {
+    const targetArn = delivery.request.schedule.target.arn;
+    const queue = this.scope.sqs().findQueue(targetArn.resource);
+
+    if (queue === undefined) {
+      throw new SimSchedulerTargetNotFound(
+        `${targetArn.value} is not a simulated SQS queue.`,
+      );
+    }
+
+    const decision = this.scope.iam().authorize({
+      action: sendAction,
+      resource: targetArn.value,
+      caller: delivery.caller,
+    });
+
+    if (decision.isDenied) {
+      throw new SimSchedulerDeliveryNotPermitted(
+        `${delivery.request.schedule.target.roleArn} is not allowed to ` +
+          `${sendAction} on ${targetArn.value}. Grant it in a policy on the ` +
+          `execution role.`,
+      );
+    }
+
+    // Sent through the ordinary SendMessage path, as the execution role, so a
+    // delivered message is the same thing an SDK caller would have sent and is
+    // authorized again on the way in.
+    await this.scope.sqs().sendMessage(
+      {
+        input: {
+          QueueUrl: queue.arn.url,
+          MessageBody: simSchedulerDeliveryJson(delivery.request),
+        },
+      },
+      { caller: delivery.caller },
+    );
+  }
+}

--- a/src/service/scheduler/delivery/sim-scheduler-delivery-topic.ts
+++ b/src/service/scheduler/delivery/sim-scheduler-delivery-topic.ts
@@ -1,0 +1,67 @@
+import type { SimAwsAccountRegionContainer } from "../../aws/sim-aws-account-region-scope.js";
+import {
+  SimSchedulerDeliveryNotPermitted,
+  SimSchedulerTargetNotFound,
+} from "../error/sim-scheduler-delivery.error.js";
+import {
+  type SimSchedulerAssumedDelivery,
+  simSchedulerDeliveryJson,
+} from "./sim-scheduler-delivery.js";
+
+const publishAction = "sns:Publish";
+
+interface SimSchedulerDeliveryTopicProperties {
+  readonly scope: SimAwsAccountRegionContainer;
+}
+
+/**
+ * An SNS topic a simulated schedule publishes to.
+ */
+export class SimSchedulerDeliveryTopic {
+  private readonly scope: SimAwsAccountRegionContainer;
+
+  constructor(properties: SimSchedulerDeliveryTopicProperties) {
+    this.scope = properties.scope;
+  }
+
+  /**
+   * Publish the schedule's input to the topic, if the execution role may.
+   */
+  async deliver(delivery: SimSchedulerAssumedDelivery): Promise<void> {
+    const targetArn = delivery.request.schedule.target.arn;
+    const topic = this.scope.sns().findTopic(targetArn.resource);
+
+    if (topic === undefined) {
+      throw new SimSchedulerTargetNotFound(
+        `${targetArn.value} is not a simulated SNS topic.`,
+      );
+    }
+
+    const decision = this.scope.iam().authorize({
+      action: publishAction,
+      resource: targetArn.value,
+      caller: delivery.caller,
+    });
+
+    if (decision.isDenied) {
+      throw new SimSchedulerDeliveryNotPermitted(
+        `${delivery.request.schedule.target.roleArn} is not allowed to ` +
+          `${publishAction} on ${targetArn.value}. Grant it in a policy on ` +
+          `the execution role.`,
+      );
+    }
+
+    // Published through the ordinary Publish path, as the execution role, so a
+    // delivered message fans out to the topic's subscriptions exactly as an SDK
+    // caller's would.
+    await this.scope.sns().publish(
+      {
+        input: {
+          TopicArn: topic.arn.value,
+          Message: simSchedulerDeliveryJson(delivery.request),
+        },
+      },
+      { caller: delivery.caller },
+    );
+  }
+}

--- a/src/service/scheduler/delivery/sim-scheduler-delivery.iso.test.ts
+++ b/src/service/scheduler/delivery/sim-scheduler-delivery.iso.test.ts
@@ -1,0 +1,264 @@
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import { CreateScheduleCommand } from "@aws-sdk/client-scheduler";
+import { CreateTopicCommand, SubscribeCommand } from "@aws-sdk/client-sns";
+import {
+  CreateQueueCommand,
+  ReceiveMessageCommand,
+  SetQueueAttributesCommand,
+} from "@aws-sdk/client-sqs";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimFixedClock } from "../../../util/clock/sim-clock.js";
+import { SimAws } from "../../aws/sim-aws.js";
+import { makeLambdaZipFileInput } from "../../lambda/index.js";
+import { simSnsQueuePolicy } from "../../../../test/sns/subscription-fixture.js";
+
+const startedAt = "2026-07-26T09:00:00.000Z";
+
+const functionArn = "arn:aws:lambda:us-east-1:888888888888:function:reconcile";
+
+const roleArn = "arn:aws:iam::888888888888:role/SchedulerRole";
+
+const queueArn = "arn:aws:sqs:us-east-1:888888888888:reports";
+
+const topicArn = "arn:aws:sns:us-east-1:888888888888:reports";
+
+/**
+ * A simulation whose execution role trusts Scheduler and is allowed exactly
+ * what one policy statement says.
+ */
+async function simulationWithRole(
+  statement: object,
+  trusts = "scheduler.amazonaws.com",
+): Promise<SimAws> {
+  const simAws = new SimAws({ clock: new SimFixedClock(new Date(startedAt)) });
+
+  await simAws.iam().createRole(
+    new CreateRoleCommand({
+      RoleName: "SchedulerRole",
+      AssumeRolePolicyDocument: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: {
+          Effect: "Allow",
+          Principal: { Service: trusts },
+          Action: "sts:AssumeRole",
+        },
+      }),
+    }),
+  );
+
+  await simAws.iam().putRolePolicy(
+    new PutRolePolicyCommand({
+      RoleName: "SchedulerRole",
+      PolicyName: "Invoke",
+      PolicyDocument: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: statement,
+      }),
+    }),
+  );
+
+  return simAws;
+}
+
+/**
+ * A one-time schedule an hour out, so one advance fires it exactly once.
+ */
+async function scheduleFor(
+  simAws: SimAws,
+  target: { Arn: string; RoleArn: string; Input?: string },
+): Promise<void> {
+  await simAws.scheduler().createSchedule(
+    new CreateScheduleCommand({
+      Name: "nightly-report",
+      ScheduleExpression: "at(2026-07-26T10:00:00)",
+      FlexibleTimeWindow: { Mode: "OFF" },
+      Target: target,
+    }),
+  );
+
+  await simAws.clock().advanceBy({ hours: 2 });
+}
+
+describe("Scheduler target invocation", () => {
+  it("sends a schedule's input to a queue target", async () => {
+    // Given a role allowed to send to a queue.
+    const simAws = await simulationWithRole({
+      Effect: "Allow",
+      Action: "sqs:SendMessage",
+      Resource: queueArn,
+    });
+
+    await simAws
+      .sqs()
+      .createQueue(new CreateQueueCommand({ QueueName: "reports" }));
+
+    // When a schedule targeting it fires.
+    await scheduleFor(simAws, {
+      Arn: queueArn,
+      RoleArn: roleArn,
+      Input: JSON.stringify({ report: "nightly" }),
+    });
+
+    // Then the queue has the input, with no envelope around it. No queue
+    // policy was involved: the role's own policy was the whole decision.
+    const received = await simAws.sqs().receiveMessage(
+      new ReceiveMessageCommand({
+        QueueUrl: `https://sqs.us-east-1.amazonaws.com/888888888888/reports`,
+      }),
+    );
+
+    assertArrayLength(received.Messages ?? [], 1);
+    assertIdentical(received.Messages?.[0]?.Body, '{"report":"nightly"}');
+  });
+
+  it("publishes a schedule's input to a topic target", async () => {
+    // Given a role allowed to publish, and a topic with a queue subscribed.
+    const simAws = await simulationWithRole({
+      Effect: "Allow",
+      Action: "sns:Publish",
+      Resource: topicArn,
+    });
+
+    await simAws.sns().createTopic(new CreateTopicCommand({ Name: "reports" }));
+    const queue = await simAws
+      .sqs()
+      .createQueue(new CreateQueueCommand({ QueueName: "subscriber" }));
+
+    // The subscribed queue's own policy admits the topic, which is SNS fan-out
+    // rather than anything Scheduler does.
+    await simAws.sqs().setQueueAttributes(
+      new SetQueueAttributesCommand({
+        QueueUrl: queue.QueueUrl,
+        Attributes: {
+          Policy: simSnsQueuePolicy(
+            "arn:aws:sqs:us-east-1:888888888888:subscriber",
+            topicArn,
+          ),
+        },
+      }),
+    );
+
+    await simAws.sns().subscribe(
+      new SubscribeCommand({
+        TopicArn: topicArn,
+        Protocol: "sqs",
+        Endpoint: "arn:aws:sqs:us-east-1:888888888888:subscriber",
+      }),
+    );
+
+    // When a schedule targeting the topic fires.
+    await scheduleFor(simAws, {
+      Arn: topicArn,
+      RoleArn: roleArn,
+      Input: JSON.stringify({ report: "nightly" }),
+    });
+
+    await simAws.backgroundTasksComplete();
+
+    // Then it fanned out to the subscription as an ordinary publish would.
+    const received = await simAws
+      .sqs()
+      .receiveMessage(new ReceiveMessageCommand({ QueueUrl: queue.QueueUrl }));
+
+    assertArrayLength(received.Messages ?? [], 1);
+  });
+
+  it("does not invoke when the role may not, and says why", async () => {
+    // Given a role that trusts Scheduler but is allowed nothing on the target.
+    const invocations: unknown[] = [];
+    const simAws = await simulationWithRole({
+      Effect: "Allow",
+      Action: "lambda:InvokeFunction",
+      Resource: "arn:aws:lambda:us-east-1:888888888888:function:something-else",
+    });
+
+    await simAws.lambda().createFunction({
+      input: {
+        FunctionName: "reconcile",
+        Role: "arn:aws:iam::888888888888:role/ReconcileRole",
+        Code: {
+          ZipFile: makeLambdaZipFileInput(() => {
+            invocations.push(1);
+            return { ok: true };
+          }),
+        },
+      },
+    });
+
+    // When the schedule fires.
+    await scheduleFor(simAws, { Arn: functionArn, RoleArn: roleArn });
+
+    // Then nothing was invoked, and the failure explains which role and which
+    // action, since that is where it is fixed.
+    assertArrayLength(invocations, 0);
+
+    const [failure] = simAws.scheduler().deliveryFailures;
+
+    assertNonNullable(failure);
+    assertIdentical(failure.roleArn, roleArn);
+    assertStringIncludes(failure.message, "lambda:InvokeFunction");
+    assertIdentical(failure.at.toISOString(), "2026-07-26T10:00:00.000Z");
+  });
+
+  it("does not invoke when the role does not trust Scheduler", async () => {
+    // Given a role trusting EventBridge rules rather than Scheduler, which is
+    // an easy thing to get wrong when moving from one to the other.
+    const simAws = await simulationWithRole(
+      { Effect: "Allow", Action: "lambda:InvokeFunction", Resource: "*" },
+      "events.amazonaws.com",
+    );
+
+    await simAws.lambda().createFunction({
+      input: {
+        FunctionName: "reconcile",
+        Role: "arn:aws:iam::888888888888:role/ReconcileRole",
+        Code: { ZipFile: makeLambdaZipFileInput(() => ({ ok: true })) },
+      },
+    });
+
+    await scheduleFor(simAws, { Arn: functionArn, RoleArn: roleArn });
+
+    // Then the failure points at the trust policy rather than the permission,
+    // because that is the one to change.
+    const [failure] = simAws.scheduler().deliveryFailures;
+
+    assertNonNullable(failure);
+    assertStringIncludes(failure.message, "trust policy");
+    assertStringIncludes(failure.message, "AssumeRolePolicyDocument");
+  });
+
+  it("reports a role that is not there rather than failing silently", async () => {
+    const simAws = new SimAws({
+      clock: new SimFixedClock(new Date(startedAt)),
+    });
+
+    await scheduleFor(simAws, { Arn: functionArn, RoleArn: roleArn });
+
+    const [failure] = simAws.scheduler().deliveryFailures;
+
+    assertNonNullable(failure);
+    assertStringIncludes(failure.message, "is not a simulated IAM role");
+  });
+
+  it("reports a target that is not a simulated resource", async () => {
+    const simAws = await simulationWithRole({
+      Effect: "Allow",
+      Action: "lambda:InvokeFunction",
+      Resource: "*",
+    });
+
+    await scheduleFor(simAws, { Arn: functionArn, RoleArn: roleArn });
+
+    const [failure] = simAws.scheduler().deliveryFailures;
+
+    assertNonNullable(failure);
+    assertStringIncludes(failure.message, "is not a simulated Lambda function");
+  });
+});

--- a/src/service/scheduler/delivery/sim-scheduler-delivery.iso.test.ts
+++ b/src/service/scheduler/delivery/sim-scheduler-delivery.iso.test.ts
@@ -160,9 +160,9 @@ describe("Scheduler target invocation", () => {
       Input: JSON.stringify({ report: "nightly" }),
     });
 
-    await simAws.backgroundTasksComplete();
-
     // Then it fanned out to the subscription as an ordinary publish would.
+    // No extra draining: advanceBy settles the invocation and the fan-out it
+    // caused before it returns.
     const received = await simAws
       .sqs()
       .receiveMessage(new ReceiveMessageCommand({ QueueUrl: queue.QueueUrl }));

--- a/src/service/scheduler/delivery/sim-scheduler-delivery.ts
+++ b/src/service/scheduler/delivery/sim-scheduler-delivery.ts
@@ -1,0 +1,82 @@
+import type { SimAwsCaller } from "../../aws/caller/sim-aws-caller.js";
+import type { SimSchedulerSchedule } from "../schedule/sim-scheduler-schedule.js";
+
+/**
+ * The service principal Scheduler assumes an execution role as.
+ *
+ * This is the principal a role's trust policy has to admit, which is what makes
+ * `scheduler.amazonaws.com` the thing to put in an `AssumeRolePolicyDocument`
+ * for a schedule to work at all.
+ */
+export const simSchedulerServicePrincipal = "scheduler.amazonaws.com";
+
+/**
+ * One schedule on its way to its target.
+ *
+ * The due instant travels with it because a schedule invokes with whatever its
+ * target's `Input` says and nothing about when it fired, so the due time is
+ * only of interest to whatever records a failure.
+ */
+export interface SimSchedulerDeliveryRequest {
+  readonly schedule: SimSchedulerSchedule;
+  readonly at: Date;
+}
+
+/**
+ * Somewhere a simulated schedule can invoke.
+ *
+ * One implementation per target service, because what each is asked and what
+ * each is handed differ: a function receives an invocation payload, and a queue
+ * and a topic receive a message body.
+ */
+export interface SimSchedulerDeliveryTargets {
+  /**
+   * Invoke a schedule's target, refusing if its execution role may not.
+   */
+  deliver(request: SimSchedulerDeliveryRequest): Promise<void>;
+}
+
+/**
+ * What a target receives, as the JSON text a queue or a topic carries.
+ *
+ * A schedule has no event of its own, so a target with no `Input` is sent an
+ * empty JSON object rather than an envelope describing the schedule. AWS
+ * documents that behaviour for a function and says nothing about it for a queue
+ * or a topic, so the same answer is used for all three rather than inventing a
+ * different one for each.
+ */
+export function simSchedulerDeliveryJson(
+  request: SimSchedulerDeliveryRequest,
+): string {
+  return request.schedule.target.input ?? "{}";
+}
+
+/**
+ * What a target receives, as the value a Lambda handler is handed.
+ */
+export function simSchedulerDeliveryDocument(
+  request: SimSchedulerDeliveryRequest,
+): unknown {
+  const input = request.schedule.target.input;
+
+  if (input === undefined) {
+    return {};
+  }
+
+  // A target's Input is text rather than JSON as far as AWS is concerned, so
+  // one that does not parse is handed over as the string it is instead of
+  // failing the invocation.
+  try {
+    return JSON.parse(input) as unknown;
+  } catch {
+    return input;
+  }
+}
+
+/**
+ * A schedule's target, and the caller its execution role makes it as.
+ */
+export interface SimSchedulerAssumedDelivery {
+  readonly request: SimSchedulerDeliveryRequest;
+  readonly caller: SimAwsCaller;
+}

--- a/src/service/scheduler/delivery/sim-scheduler-execution-role.ts
+++ b/src/service/scheduler/delivery/sim-scheduler-execution-role.ts
@@ -1,0 +1,105 @@
+import type { SimAwsCaller } from "../../aws/caller/sim-aws-caller.js";
+import type { SimAwsAccountId } from "../../aws/sim-aws-account.js";
+import { SimIamAccessDenied } from "../../iam/error/sim-iam.error.js";
+import { IamRoleArnParser } from "../../iam/role/arn/sim-iam-role-arn-parser.js";
+import type { SimIam } from "../../iam/sim-iam.js";
+import { AssumeRoleTrustPolicyAuthorizer } from "../../sts/auth-z/assume-role-trust-policy-authorizer.js";
+import { SimSchedulerDeliveryNotPermitted } from "../error/sim-scheduler-delivery.error.js";
+import { simSchedulerServicePrincipal } from "./sim-scheduler-delivery.js";
+
+/**
+ * The session name AWS gives a role Scheduler assumes for an invocation.
+ */
+const sessionName = "EventBridgeScheduler";
+
+/**
+ * Which IAM a role ARN belongs to, and what the role is called there.
+ */
+export interface SimSchedulerExecutionRoleTarget {
+  readonly accountId: SimAwsAccountId;
+  readonly roleName: string;
+  readonly roleArn: string;
+}
+
+/**
+ * Read the Account and name out of a schedule's execution role ARN.
+ *
+ * The ARN was checked for being a role ARN when the schedule was written, so
+ * this is reading a known shape rather than validating an unknown one.
+ */
+export function schedulerExecutionRoleTarget(
+  roleArn: string,
+): SimSchedulerExecutionRoleTarget {
+  const parts = new IamRoleArnParser().parse(roleArn);
+
+  return { accountId: parts.accountId, roleName: parts.roleName, roleArn };
+}
+
+/**
+ * Assume a schedule's execution role, and answer with the caller it makes.
+ *
+ * This is the whole of what makes Scheduler's execution model different from an
+ * EventBridge rule's. A rule reaches its target as the `events.amazonaws.com`
+ * service principal and the target's own resource policy decides; a schedule
+ * assumes a role, and the role's policies decide. So the two things checked
+ * here are the two things that go wrong in a real account: whether the role
+ * trusts Scheduler at all, and then, separately, whether it may do the thing.
+ *
+ * The caller carries both principals. The request is attributed to the session,
+ * as it is on AWS, while the policies that apply are the role's, which is
+ * exactly the split `SimResolvedCaller` exists for.
+ */
+export async function assumeSchedulerExecutionRole(
+  target: SimSchedulerExecutionRoleTarget,
+  iam: SimIam,
+): Promise<SimAwsCaller> {
+  const role = await roleOrRefuse(target, iam);
+
+  try {
+    new AssumeRoleTrustPolicyAuthorizer().authorize({
+      roleArn: target.roleArn,
+      role,
+      targetIam: iam,
+      caller: { kind: "service", service: simSchedulerServicePrincipal },
+    });
+  } catch (error) {
+    if (error instanceof SimIamAccessDenied) {
+      throw new SimSchedulerDeliveryNotPermitted(
+        `The trust policy of ${target.roleArn} does not allow ` +
+          `${simSchedulerServicePrincipal} to assume it, so the schedule ` +
+          `could not invoke its target. Add it to the role's ` +
+          `AssumeRolePolicyDocument.`,
+      );
+    }
+
+    throw error;
+  }
+
+  return {
+    kind: "resolved",
+    principal: {
+      kind: "arn",
+      arn: `arn:aws:sts::${target.accountId}:assumed-role/${target.roleName}/${sessionName}`,
+    },
+    identityPolicyPrincipal: { kind: "arn", arn: target.roleArn },
+  };
+}
+
+/**
+ * Load the execution role, refusing when it is not there.
+ */
+async function roleOrRefuse(
+  target: SimSchedulerExecutionRoleTarget,
+  iam: SimIam,
+): Promise<Awaited<ReturnType<SimIam["getRole"]>>["Role"]> {
+  try {
+    const found = await iam.getRole({ input: { RoleName: target.roleName } });
+
+    return found.Role;
+  } catch {
+    throw new SimSchedulerDeliveryNotPermitted(
+      `${target.roleArn} is not a simulated IAM role, so the schedule could ` +
+        `not assume it to invoke its target.`,
+    );
+  }
+}

--- a/src/service/scheduler/delivery/sim-scheduler-no-delivery-targets.ts
+++ b/src/service/scheduler/delivery/sim-scheduler-no-delivery-targets.ts
@@ -1,0 +1,29 @@
+import { SimSchedulerTargetNotFound } from "../error/sim-scheduler-delivery.error.js";
+import type {
+  SimSchedulerDeliveryRequest,
+  SimSchedulerDeliveryTargets,
+} from "./sim-scheduler-delivery.js";
+
+/**
+ * The targets of a simulated Scheduler built on its own, which are none.
+ *
+ * A function, queue or topic in another simulated service is only reachable
+ * through SimAws, so a `SimScheduler` constructed directly has nowhere to
+ * invoke. Every invocation is recorded as a failure saying so, rather than
+ * quietly succeeding, because a schedule that appears to have invoked a target
+ * that was never reachable is the worst of the possible answers.
+ */
+export class SimSchedulerNoDeliveryTargets implements SimSchedulerDeliveryTargets {
+  /**
+   * Refuse the invocation, saying why there was nowhere to make it.
+   */
+  deliver(request: SimSchedulerDeliveryRequest): Promise<void> {
+    return Promise.reject(
+      new SimSchedulerTargetNotFound(
+        `This simulated Scheduler has no targets to invoke, so ` +
+          `${request.schedule.target.arn.value} was not reached. Reach ` +
+          `Scheduler through SimAws for a schedule that invokes.`,
+      ),
+    );
+  }
+}

--- a/src/service/scheduler/delivery/sim-scheduler-target-delivery.ts
+++ b/src/service/scheduler/delivery/sim-scheduler-target-delivery.ts
@@ -1,0 +1,56 @@
+import type {
+  SimSchedulerDeliveryRequest,
+  SimSchedulerDeliveryTargets,
+} from "./sim-scheduler-delivery.js";
+import {
+  type SimSchedulerDeliveryFailure,
+  SimSchedulerDeliveryFailures,
+} from "./sim-scheduler-delivery-failures.js";
+
+interface SimSchedulerTargetDeliveryProperties {
+  readonly endpoints: SimSchedulerDeliveryTargets;
+}
+
+/**
+ * Makes one invocation and keeps whatever went wrong.
+ *
+ * A failure is recorded rather than thrown, because these run as background
+ * tasks and one left rejected would fail an unrelated
+ * `backgroundTasksComplete()`, or an unrelated `advanceBy(...)`. Real Scheduler
+ * has nowhere to report a failed invocation to either.
+ */
+export class SimSchedulerTargetDelivery {
+  private readonly endpoints: SimSchedulerDeliveryTargets;
+  private readonly failures = new SimSchedulerDeliveryFailures();
+
+  constructor(properties: SimSchedulerTargetDeliveryProperties) {
+    this.endpoints = properties.endpoints;
+  }
+
+  /**
+   * Every invocation that could not be made.
+   */
+  get deliveryFailures(): readonly SimSchedulerDeliveryFailure[] {
+    return this.failures.all;
+  }
+
+  /**
+   * Invoke one schedule's target.
+   */
+  async deliver(request: SimSchedulerDeliveryRequest): Promise<void> {
+    try {
+      await this.endpoints.deliver(request);
+    } catch (error) {
+      const schedule = request.schedule;
+
+      this.failures.record({
+        scheduleName: schedule.name.value,
+        scheduleArn: schedule.arn,
+        targetArn: schedule.target.arn.value,
+        roleArn: schedule.target.roleArn,
+        at: request.at,
+        error,
+      });
+    }
+  }
+}

--- a/src/service/scheduler/error/sim-scheduler-delivery.error.ts
+++ b/src/service/scheduler/error/sim-scheduler-delivery.error.ts
@@ -1,0 +1,24 @@
+import { SimSchedulerError } from "./sim-scheduler.error.js";
+
+/**
+ * A schedule's target is not a simulated resource.
+ *
+ * Real Scheduler has nowhere to report this to either: the schedule was
+ * created against an ARN, and nothing checks that the ARN names anything until
+ * the moment of invocation.
+ */
+export class SimSchedulerTargetNotFound extends SimSchedulerError {
+  public override readonly name = "TargetNotFound";
+}
+
+/**
+ * A schedule's execution role would not have this invocation.
+ *
+ * Either the role does not trust Scheduler to assume it, or its policies do not
+ * allow the action on the target. The two are told apart by the message,
+ * because they are fixed in different places: one is the role's trust policy
+ * and the other is the policy attached to it.
+ */
+export class SimSchedulerDeliveryNotPermitted extends SimSchedulerError {
+  public override readonly name = "DeliveryNotPermitted";
+}

--- a/src/service/scheduler/index.ts
+++ b/src/service/scheduler/index.ts
@@ -18,6 +18,15 @@ export {
   type SimSchedulerTargetService,
 } from "./target/sim-scheduler-target-arn.js";
 export {
+  simSchedulerServicePrincipal,
+  type SimSchedulerDeliveryTargets,
+} from "./delivery/sim-scheduler-delivery.js";
+export { SimSchedulerDeliveryFailure } from "./delivery/sim-scheduler-delivery-failures.js";
+export {
+  SimSchedulerDeliveryNotPermitted,
+  SimSchedulerTargetNotFound,
+} from "./error/sim-scheduler-delivery.error.js";
+export {
   SimSchedulerAccessDeniedException,
   SimSchedulerConflictException,
   SimSchedulerError,

--- a/src/service/scheduler/schedule/sim-scheduler-firing.iso.test.ts
+++ b/src/service/scheduler/schedule/sim-scheduler-firing.iso.test.ts
@@ -1,0 +1,295 @@
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import {
+  CreateScheduleCommand,
+  type CreateScheduleCommandInput,
+  DeleteScheduleCommand,
+  GetScheduleCommand,
+  UpdateScheduleCommand,
+} from "@aws-sdk/client-scheduler";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertObjectEquals,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimFixedClock } from "../../../util/clock/sim-clock.js";
+import { SimAws } from "../../aws/sim-aws.js";
+import { makeLambdaZipFileInput } from "../../lambda/index.js";
+import { SimSchedulerResourceNotFoundException } from "../error/sim-scheduler.error.js";
+
+const startedAt = "2026-07-26T09:00:00.000Z";
+
+const functionArn = "arn:aws:lambda:us-east-1:888888888888:function:reconcile";
+
+const roleArn = "arn:aws:iam::888888888888:role/SchedulerRole";
+
+/**
+ * A simulation with a function to invoke and an execution role allowed to
+ * invoke it, which is the least a working schedule needs.
+ */
+async function simulationWithRole(): Promise<{
+  readonly simAws: SimAws;
+  readonly invocations: unknown[];
+}> {
+  const simAws = new SimAws({ clock: new SimFixedClock(new Date(startedAt)) });
+  const invocations: unknown[] = [];
+
+  await simAws.lambda().createFunction({
+    input: {
+      FunctionName: "reconcile",
+      Role: "arn:aws:iam::888888888888:role/ReconcileRole",
+      Code: {
+        ZipFile: makeLambdaZipFileInput((event: unknown) => {
+          invocations.push(event);
+          return { ok: true };
+        }),
+      },
+    },
+  });
+
+  await simAws.iam().createRole(
+    new CreateRoleCommand({
+      RoleName: "SchedulerRole",
+      AssumeRolePolicyDocument: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: {
+          Effect: "Allow",
+          Principal: { Service: "scheduler.amazonaws.com" },
+          Action: "sts:AssumeRole",
+        },
+      }),
+    }),
+  );
+
+  await simAws.iam().putRolePolicy(
+    new PutRolePolicyCommand({
+      RoleName: "SchedulerRole",
+      PolicyName: "InvokeReconcile",
+      PolicyDocument: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: {
+          Effect: "Allow",
+          Action: "lambda:InvokeFunction",
+          Resource: functionArn,
+        },
+      }),
+    }),
+  );
+
+  return { simAws, invocations };
+}
+
+/**
+ * The request every schedule here is made with.
+ */
+function creation(
+  overrides: Partial<CreateScheduleCommandInput> = {},
+): CreateScheduleCommandInput {
+  return {
+    Name: "reconciliation",
+    ScheduleExpression: "rate(1 hour)",
+    FlexibleTimeWindow: { Mode: "OFF" },
+    Target: { Arn: functionArn, RoleArn: roleArn },
+    ...overrides,
+  };
+}
+
+describe("Scheduler firing on the clock", () => {
+  it("invokes a rate target once per due instant as time advances", async () => {
+    // Given an hourly schedule.
+    const { simAws, invocations } = await simulationWithRole();
+
+    await simAws
+      .scheduler()
+      .createSchedule(new CreateScheduleCommand(creation()));
+
+    // When three simulated hours pass.
+    await simAws.clock().advanceBy({ hours: 3 });
+
+    // Then it invoked three times rather than once at the end.
+    assertArrayLength(invocations, 3);
+  });
+
+  it("fires per due instant rather than once per advance", async () => {
+    // Given a schedule due every minute.
+    const { simAws, invocations } = await simulationWithRole();
+
+    await simAws
+      .scheduler()
+      .createSchedule(
+        new CreateScheduleCommand(
+          creation({ ScheduleExpression: "rate(1 minute)" }),
+        ),
+      );
+
+    // When an hour passes in one step.
+    await simAws.clock().advanceBy({ hours: 1 });
+
+    assertArrayLength(invocations, 60);
+  });
+
+  it("fires a one-time schedule once, and never again", async () => {
+    // Given an at() schedule for later the same day.
+    const { simAws, invocations } = await simulationWithRole();
+
+    await simAws
+      .scheduler()
+      .createSchedule(
+        new CreateScheduleCommand(
+          creation({ ScheduleExpression: "at(2026-07-26T10:00:00)" }),
+        ),
+      );
+
+    // When time runs well past it.
+    await simAws.clock().advanceBy({ days: 3 });
+
+    // Then it invoked exactly once, and the schedule is still there, because
+    // ActionAfterCompletion defaults to NONE.
+    assertArrayLength(invocations, 1);
+
+    const described = await simAws
+      .scheduler()
+      .getSchedule(new GetScheduleCommand({ Name: "reconciliation" }));
+
+    assertIdentical(described.Name, "reconciliation");
+  });
+
+  it("deletes a completed schedule when asked to", async () => {
+    // Given a one-time schedule that cleans up after itself.
+    const { simAws, invocations } = await simulationWithRole();
+
+    await simAws.scheduler().createSchedule(
+      new CreateScheduleCommand(
+        creation({
+          ScheduleExpression: "at(2026-07-26T10:00:00)",
+          ActionAfterCompletion: "DELETE",
+        }),
+      ),
+    );
+
+    // When it has fired.
+    await simAws.clock().advanceBy({ hours: 2 });
+
+    assertArrayLength(invocations, 1);
+
+    // Then it is gone.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws
+        .scheduler()
+        .getSchedule(new GetScheduleCommand({ Name: "reconciliation" }));
+    });
+
+    assertInstanceOf(error, SimSchedulerResourceNotFoundException);
+  });
+
+  it("does not fire while disabled, and resumes on being enabled", async () => {
+    // Given a schedule created disabled.
+    const { simAws, invocations } = await simulationWithRole();
+
+    await simAws
+      .scheduler()
+      .createSchedule(
+        new CreateScheduleCommand(creation({ State: "DISABLED" })),
+      );
+
+    await simAws.clock().advanceBy({ hours: 3 });
+
+    assertArrayLength(invocations, 0);
+
+    // When an update enables it and one more hour passes.
+    await simAws
+      .scheduler()
+      .updateSchedule(
+        new UpdateScheduleCommand(creation({ State: "ENABLED" })),
+      );
+
+    await simAws.clock().advanceBy({ hours: 1 });
+
+    // Then it fired once, rather than catching up on what it missed.
+    assertArrayLength(invocations, 1);
+  });
+
+  it("reschedules from the new expression on an update", async () => {
+    // Given an hourly schedule, half an hour in.
+    const { simAws, invocations } = await simulationWithRole();
+
+    await simAws
+      .scheduler()
+      .createSchedule(new CreateScheduleCommand(creation()));
+
+    await simAws.clock().advanceBy({ minutes: 30 });
+
+    // When it becomes a ten minute schedule.
+    await simAws
+      .scheduler()
+      .updateSchedule(
+        new UpdateScheduleCommand(
+          creation({ ScheduleExpression: "rate(10 minutes)" }),
+        ),
+      );
+
+    await simAws.clock().advanceBy({ minutes: 30 });
+
+    // Then it fired on the new expression's timing, three times, rather than
+    // once on the old one's.
+    assertArrayLength(invocations, 3);
+  });
+
+  it("stops firing when the schedule is deleted", async () => {
+    // Given a schedule that has fired once.
+    const { simAws, invocations } = await simulationWithRole();
+
+    await simAws
+      .scheduler()
+      .createSchedule(new CreateScheduleCommand(creation()));
+
+    await simAws.clock().advanceBy({ hours: 1 });
+
+    // When it is deleted and more time passes.
+    await simAws
+      .scheduler()
+      .deleteSchedule(new DeleteScheduleCommand({ Name: "reconciliation" }));
+
+    await simAws.clock().advanceBy({ hours: 3 });
+
+    assertArrayLength(invocations, 1);
+  });
+
+  it("hands the target its input, and an empty event without one", async () => {
+    // Given two schedules, one with an Input and one without.
+    const { simAws, invocations } = await simulationWithRole();
+
+    const withInput = creation({
+      Name: "with-input",
+      ScheduleExpression: "at(2026-07-26T10:00:00)",
+      Target: {
+        Arn: functionArn,
+        RoleArn: roleArn,
+        Input: JSON.stringify({ wake: "up" }),
+      },
+    });
+
+    await simAws
+      .scheduler()
+      .createSchedule(new CreateScheduleCommand(withInput));
+    const withoutInput = creation({
+      Name: "without-input",
+      ScheduleExpression: "at(2026-07-26T11:00:00)",
+    });
+
+    await simAws
+      .scheduler()
+      .createSchedule(new CreateScheduleCommand(withoutInput));
+
+    await simAws.clock().advanceBy({ hours: 3 });
+
+    // Then the first got its input and the second got an empty event, which is
+    // what AWS documents for a schedule with no payload.
+    assertArrayLength(invocations, 2);
+    assertObjectEquals(invocations[0], { wake: "up" });
+    assertObjectEquals(invocations[1], {});
+  });
+});

--- a/src/service/scheduler/schedule/sim-scheduler-schedules.ts
+++ b/src/service/scheduler/schedule/sim-scheduler-schedules.ts
@@ -1,0 +1,111 @@
+import type { BackgroundScheduler } from "../../../util/background/background.js";
+import type { SimSchedulerTargetDelivery } from "../delivery/sim-scheduler-target-delivery.js";
+import type { SimSchedulerSchedule } from "./sim-scheduler-schedule.js";
+import type { SimSchedulerScheduleStore } from "./sim-scheduler-schedule-store.js";
+
+interface SimSchedulerSchedulesProperties {
+  readonly schedules: SimSchedulerScheduleStore;
+  readonly delivery: SimSchedulerTargetDelivery;
+  readonly background: BackgroundScheduler;
+}
+
+/**
+ * What makes a schedule fire, which is simulated time reaching it.
+ *
+ * Nothing here runs on the host's clock. A schedule is armed for its next due
+ * instant on the simulation's own clock, so it fires when a test advances time
+ * past that instant and never otherwise. Advancing an hour with a
+ * `rate(1 minute)` schedule therefore invokes the target sixty times, at sixty
+ * distinct simulated instants, because each firing arms the next before the
+ * walk through the interval moves on.
+ *
+ * A schedule that has been deleted, or replaced by an update, is no longer the
+ * schedule its store holds under that name, and that is what stops it: there is
+ * no timer to cancel, only a firing that finds itself out of date. That is also
+ * what makes an update reschedule from the new expression rather than keeping
+ * the old due times, since an update stores a new schedule and arms it.
+ */
+export class SimSchedulerSchedules {
+  private readonly schedules: SimSchedulerScheduleStore;
+  private readonly delivery: SimSchedulerTargetDelivery;
+  private readonly background: BackgroundScheduler;
+
+  constructor(properties: SimSchedulerSchedulesProperties) {
+    this.schedules = properties.schedules;
+    this.delivery = properties.delivery;
+    this.background = properties.background;
+  }
+
+  /**
+   * Start a schedule, from now.
+   *
+   * A rate runs from the moment the schedule was created, as it does on real
+   * AWS, and a one-time `at(...)` already in the past is never armed at all.
+   */
+  arm(schedule: SimSchedulerSchedule): void {
+    this.armAfter(schedule, this.background.now());
+  }
+
+  /**
+   * Wait for the next instant a schedule falls due after an instant.
+   */
+  private armAfter(schedule: SimSchedulerSchedule, from: Date): void {
+    const due = schedule.schedule.nextAfter(from);
+
+    if (due === undefined) {
+      return;
+    }
+
+    this.background.scheduleAt(due, () => {
+      this.fire(schedule, due);
+
+      return Promise.resolve();
+    });
+  }
+
+  /**
+   * Fire a schedule that has fallen due, and arm it for the next time.
+   */
+  private fire(schedule: SimSchedulerSchedule, due: Date): void {
+    if (
+      this.schedules.find(schedule.groupName, schedule.name.value) !== schedule
+    ) {
+      return;
+    }
+
+    const invoked = schedule.state.isEnabled;
+
+    if (invoked) {
+      this.background.schedule(async () => {
+        await this.delivery.deliver({ schedule, at: due });
+      });
+    }
+
+    if (schedule.schedule.nextAfter(due) !== undefined) {
+      this.armAfter(schedule, due);
+
+      return;
+    }
+
+    this.completed(schedule, invoked);
+  }
+
+  /**
+   * Deal with a schedule that has no next occurrence.
+   *
+   * `ActionAfterCompletion` is the reason this is worth having: a one-time
+   * schedule left at the default `NONE` stays in the Account after it has
+   * fired, counting against the quota and turning up in listings, which
+   * surprises people who expected it to clean up after itself.
+   *
+   * A schedule that never invoked anything has not completed. One that was
+   * disabled when its only instant went past is still there afterwards, which
+   * is what AWS does: the action is what happens after the target is invoked,
+   * and nothing was.
+   */
+  private completed(schedule: SimSchedulerSchedule, invoked: boolean): void {
+    if (invoked && schedule.actionAfterCompletion === "DELETE") {
+      this.schedules.remove(schedule);
+    }
+  }
+}

--- a/src/service/scheduler/sim-scheduler.ts
+++ b/src/service/scheduler/sim-scheduler.ts
@@ -10,6 +10,8 @@ import {
   type SimIamInterServiceAuthZ,
 } from "../iam/authorize/sim-iam-inter-service-auth-z.js";
 import type * as simSchedulerCommands from "./command/sim-scheduler-command.types.js";
+import type { SimSchedulerDeliveryTargets } from "./delivery/sim-scheduler-delivery.js";
+import type { SimSchedulerDeliveryFailure } from "./delivery/sim-scheduler-delivery-failures.js";
 import { SimSchedulerCommands } from "./command/sim-scheduler-commands.js";
 import type { SimSchedulerRequestOptions } from "./command/sim-scheduler-request-options.js";
 import { SimSchedulerScheduleStore } from "./schedule/sim-scheduler-schedule-store.js";
@@ -20,6 +22,14 @@ interface SimSchedulerProperties {
   readonly accountRegionScope?: SimAwsAccountRegionScope;
   readonly iam?: SimIamInterServiceAuthZ;
   readonly background?: BackgroundScheduler;
+
+  /**
+   * Where this scope's schedules invoke.
+   *
+   * A SimScheduler built on its own has none, since a function, queue or topic
+   * in another simulated service is only reachable through SimAws.
+   */
+  readonly deliveryTargets?: SimSchedulerDeliveryTargets;
 }
 
 /**
@@ -53,9 +63,20 @@ export class SimScheduler extends SimSchedulerInspection {
     this.commands = new SimSchedulerCommands({
       schedules: this.scheduleStore,
       iam,
-      clock: background,
+      background,
+      deliveryTargets: properties.deliveryTargets,
       accountRegionScope,
     });
+  }
+
+  /**
+   * Every invocation this scope's schedules could not make.
+   *
+   * Real Scheduler tells nobody about a failed invocation as it happens, and
+   * neither does this. A target that is unexpectedly empty is explained here.
+   */
+  get deliveryFailures(): readonly SimSchedulerDeliveryFailure[] {
+    return this.commands.delivery.deliveryFailures;
   }
 
   /**


### PR DESCRIPTION
The second of two PRs for #534, on top of #542, and the one that closes it. Schedules now fire.

A schedule is armed on the simulation's clock, so advancing simulated time past a due instant invokes its target and `advanceBy` returns once that work has settled. Firing is per due instant rather than per advance, so an hour of `rate(1 minute)` invokes sixty times. A one-time `at()` schedule fires once and stays in place unless `ActionAfterCompletion` is `DELETE` — a schedule that was disabled when its only instant passed has not completed, so it survives either way.

The interesting half is the execution role, which is the part with no precedent in the simulator. Everything else that reaches across services arrives as a service principal and is admitted by the target's resource policy; a schedule arrives as an assumed role and is admitted by that role's identity policies, with no resource policy involved. `sim-scheduler-execution-role.ts` asks STS's own `AssumeRoleTrustPolicyAuthorizer` whether the role admits `scheduler.amazonaws.com`, then builds a `SimResolvedCaller` whose principal is the session and whose `identityPolicyPrincipal` is the role — which is exactly the split that type exists for. No STS session or temporary credential is created, because nothing would read them.

The two ways it goes wrong in a real account are reported apart from each other, since they are fixed in different places: the trust policy on the role, and the permission in a policy attached to it. Both surface through `deliveryFailures` rather than being thrown at nobody, as on AWS.

One thing worth a reviewer's eye: `sim-aws-account-region-service-builder.ts` hit its 300-line limit again, so both delivery-target constructions moved into the cross-account collaborators helper. That file will keep needing this as services are added.

Resolves https://github.com/KensioSoftware/yulin/issues/534

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added simulated EventBridge Scheduler firing for recurring and one-time schedules.
  * Schedules now invoke Lambda, SQS, and SNS targets using execution-role permissions.
  * Added support for rescheduling, disabling, deletion, and automatic cleanup after one-time completion.
  * Delivery failures are recorded and available for inspection.
  * Target inputs are delivered as JSON, parsed documents, or strings as appropriate.

* **Documentation**
  * Expanded Scheduler documentation with firing behavior, permissions, failure handling, limitations, and runnable examples.
  * Clarified EventBridge Scheduler documentation and simulated-time behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->