### PR TITLE
feat: deploy simulated EventBridge and Scheduler resources from a template

### DIFF
--- a/docs/services/cloudformation/README.md
+++ b/docs/services/cloudformation/README.md
@@ -586,27 +586,27 @@ const stack = await simAws.cloudFormation().deployTemplate({
   template: {
     Resources: {
       AlarmRule: {
-        Type: "AWS::Events::Rule",
+        Type: "AWS::CloudWatch::Alarm",
       },
     },
     Outputs: {
-      RuleRef: { Value: { Ref: "AlarmRule" } },
-      RuleArn: { Value: { "Fn::GetAtt": ["AlarmRule", "Arn"] } },
+      AlarmRef: { Value: { Ref: "AlarmRule" } },
+      AlarmArn: { Value: { "Fn::GetAtt": ["AlarmRule", "Arn"] } },
     },
   },
 });
 
 await stack.waitForDeployComplete();
 
-console.log(stack.outputs.get("RuleRef")?.value);
+console.log(stack.outputs.get("AlarmRef")?.value);
 // "AlarmRule"
 
-console.log(stack.outputs.get("RuleArn")?.value);
+console.log(stack.outputs.get("AlarmArn")?.value);
 // "AlarmRule.Arn"
 
 for (const skipped of stack.skippedResources) {
   console.log(skipped.logicalId, skipped.skippedReason);
-  // "AlarmRule Unsupported sim CloudFormation Resource service Events"
+  // "AlarmRule Unsupported sim CloudFormation Resource service CloudWatch"
 }
 ```
 
@@ -1781,7 +1781,7 @@ const stack = await simAws.cloudFormation().deployTemplate({
         },
       },
       AlarmRule: {
-        Type: "AWS::Events::Rule",
+        Type: "AWS::CloudWatch::Alarm",
       },
     },
   },
@@ -1793,7 +1793,7 @@ console.log(stack.skippedResources.map((resource) => resource.logicalId));
 // ["AlarmRule"]
 
 console.log(stack.getResource("AlarmRule")?.skippedReason);
-// "Unsupported sim CloudFormation Resource service Events"
+// "Unsupported sim CloudFormation Resource service CloudWatch"
 ```
 
 A skipped Resource is still in `stack.resources`, and still answers `Ref` and `Fn::GetAtt` with
@@ -1837,7 +1837,7 @@ const stack = await simAws.cloudFormation().deployTemplate({
         },
       },
       AlarmRule: {
-        Type: "AWS::Events::Rule",
+        Type: "AWS::CloudWatch::Alarm",
       },
     },
   },
@@ -2046,11 +2046,13 @@ The resource types it creates are:
 - `AWS::Cognito::UserPool`, `AWS::Cognito::UserPoolClient` and
   `AWS::Cognito::UserPoolGroup`
 - `AWS::DynamoDB::Table` and `AWS::DynamoDB::GlobalTable`
+- `AWS::Events::EventBus` and `AWS::Events::Rule`, with the rule's inline `Targets`
 - `AWS::IAM::Role`, `AWS::IAM::ManagedPolicy` and `AWS::IAM::Policy`
 - `AWS::KMS::Key` and `AWS::KMS::Alias`
 - `AWS::Lambda::Function`, `AWS::Lambda::Url` and `AWS::Lambda::Permission`
 - `AWS::Route53::HostedZone` and `AWS::Route53::RecordSet`
 - `AWS::S3::Bucket` and `AWS::S3::BucketPolicy`
+- `AWS::Scheduler::Schedule`
 - `AWS::SecretsManager::Secret`
 - `AWS::SQS::Queue`
 - `AWS::SSM::Parameter`

--- a/docs/services/cloudformation/sim-cloudformation-inert-resources.example.ts
+++ b/docs/services/cloudformation/sim-cloudformation-inert-resources.example.ts
@@ -17,7 +17,7 @@ const stack = await simAws.cloudFormation().deployTemplate({
         },
       },
       AlarmRule: {
-        Type: "AWS::Events::Rule",
+        Type: "AWS::CloudWatch::Alarm",
       },
     },
   },

--- a/docs/services/cloudformation/sim-cloudformation-inspect-skipped.example.ts
+++ b/docs/services/cloudformation/sim-cloudformation-inspect-skipped.example.ts
@@ -17,7 +17,7 @@ const stack = await simAws.cloudFormation().deployTemplate({
         },
       },
       AlarmRule: {
-        Type: "AWS::Events::Rule",
+        Type: "AWS::CloudWatch::Alarm",
       },
     },
   },
@@ -29,4 +29,4 @@ console.log(stack.skippedResources.map((resource) => resource.logicalId));
 // ["AlarmRule"]
 
 console.log(stack.getResource("AlarmRule")?.skippedReason);
-// "Unsupported sim CloudFormation Resource service Events"
+// "Unsupported sim CloudFormation Resource service CloudWatch"

--- a/docs/services/cloudformation/sim-cloudformation-skipped-resource-values.example.ts
+++ b/docs/services/cloudformation/sim-cloudformation-skipped-resource-values.example.ts
@@ -11,25 +11,25 @@ const stack = await simAws.cloudFormation().deployTemplate({
   template: {
     Resources: {
       AlarmRule: {
-        Type: "AWS::Events::Rule",
+        Type: "AWS::CloudWatch::Alarm",
       },
     },
     Outputs: {
-      RuleRef: { Value: { Ref: "AlarmRule" } },
-      RuleArn: { Value: { "Fn::GetAtt": ["AlarmRule", "Arn"] } },
+      AlarmRef: { Value: { Ref: "AlarmRule" } },
+      AlarmArn: { Value: { "Fn::GetAtt": ["AlarmRule", "Arn"] } },
     },
   },
 });
 
 await stack.waitForDeployComplete();
 
-console.log(stack.outputs.get("RuleRef")?.value);
+console.log(stack.outputs.get("AlarmRef")?.value);
 // "AlarmRule"
 
-console.log(stack.outputs.get("RuleArn")?.value);
+console.log(stack.outputs.get("AlarmArn")?.value);
 // "AlarmRule.Arn"
 
 for (const skipped of stack.skippedResources) {
   console.log(skipped.logicalId, skipped.skippedReason);
-  // "AlarmRule Unsupported sim CloudFormation Resource service Events"
+  // "AlarmRule Unsupported sim CloudFormation Resource service CloudWatch"
 }

--- a/docs/services/eventbridge/README.md
+++ b/docs/services/eventbridge/README.md
@@ -576,6 +576,104 @@ replacing a scheduled rule restarts the schedule from the replacement.
 A rule with no target still fires, and what it produced can be read with `eventsOn(...)`, which is
 useful for asserting on the schedule itself before there is anything to deliver to.
 
+## Deploying from a CloudFormation template
+
+`AWS::Events::EventBus` and `AWS::Events::Rule` deploy through
+[simulated CloudFormation](../cloudformation/), so a stack that declares its routing rather than
+calling the SDK can be exercised end to end. A rule carries its `EventPattern` or
+`ScheduleExpression`, its `State`, and its inline `Targets`, and a target ARN resolved by
+`Fn::GetAtt` from a function or queue in the same template works as it would in a real deployment.
+
+```typescript sim-event-bridge-cloudformation
+/**
+ * A rule and its target, deployed from a template rather than by the SDK.
+ */
+
+import { PutEventsCommand } from "@aws-sdk/client-eventbridge";
+
+import { SimAws } from "@kensio/yulin";
+import { makeLambdaZipFileInput } from "@kensio/yulin/lambda";
+
+const simAws = new SimAws();
+const handled: unknown[] = [];
+
+await simAws.lambda().createFunction({
+  input: {
+    FunctionName: "fulfilment",
+    Role: "arn:aws:iam::888888888888:role/FulfilmentRole",
+    Code: {
+      ZipFile: makeLambdaZipFileInput((event: unknown) => {
+        handled.push(event);
+        return { ok: true };
+      }),
+    },
+  },
+});
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "orders-stack",
+  template: {
+    Resources: {
+      OrdersRule: {
+        Type: "AWS::Events::Rule",
+        Properties: {
+          Name: "orders",
+          // A template carries the pattern as an object, where the API takes
+          // it as a string of JSON.
+          EventPattern: { source: ["orders.service"] },
+          Targets: [
+            {
+              Id: "fulfilment",
+              Arn: "arn:aws:lambda:us-east-1:888888888888:function:fulfilment",
+            },
+          ],
+        },
+      },
+      // The grant CDK emits alongside a Lambda target, and that the target
+      // needs here too.
+      PermissionForEventsToInvokeLambda: {
+        Type: "AWS::Lambda::Permission",
+        Properties: {
+          FunctionName: "fulfilment",
+          Action: "lambda:InvokeFunction",
+          Principal: "events.amazonaws.com",
+          SourceArn: { "Fn::GetAtt": ["OrdersRule", "Arn"] },
+        },
+      },
+    },
+  },
+});
+
+await stack.waitForDeployComplete();
+
+await simAws.eventBridge().putEvents(
+  new PutEventsCommand({
+    Entries: [
+      {
+        Source: "orders.service",
+        DetailType: "OrderPlaced",
+        Detail: JSON.stringify({ orderId: "order-1" }),
+      },
+    ],
+  }),
+);
+
+await simAws.backgroundTasksComplete();
+
+console.log(handled.length); // 1
+```
+
+`Ref` returns the **name** of a bus or a rule, not its ARN, which is what AWS returns and what makes
+a bus `Ref` usable straight away as another resource's `EventBusName`. The ARN comes from
+`Fn::GetAtt ... Arn`, which is what an `AWS::Lambda::Permission` `SourceArn` needs. A rule the
+template does not name gets one generated from the stack name and the logical ID, as real
+CloudFormation generates one.
+
+A target property this simulation does not model, such as `InputTransformer` or `InputPath`, is
+refused at deploy time naming the property and the Resource, rather than deploying a rule that sends
+the whole event where one field was asked for. Tearing the stack down removes the buses, rules and
+targets it created.
+
 ## Deliveries that did not happen
 
 Real EventBridge tells the caller nothing about a failed delivery: a `PutEvents` that matched a rule
@@ -739,7 +837,10 @@ no permission for.
   `ENABLED_WITH_ALL_CLOUDTRAIL_MANAGEMENT_EVENTS` state are refused rather than simulated.
 - Deleting an event bus deletes its rules, and deleting a rule deletes its targets. Real EventBridge
   refuses to delete either while it still has what hangs off it.
-- `AWS::Events::*` CloudFormation resource types are not simulated.
+- `AWS::Events::EventBusPolicy`, `AWS::Events::Archive`, `AWS::Events::Connection` and
+  `AWS::Events::ApiDestination` are not simulated as CloudFormation resource types.
+  `AWS::Events::EventBus` and `AWS::Events::Rule` are: see
+  [deploying from a template](#deploying-from-a-cloudformation-template).
 - Event bus resource policies are not simulated. `PutPermission`, `RemovePermission` and the bus
   `Policy` attribute are all absent, so a caller from another account cannot be admitted to a bus,
   which is stricter than real AWS.

--- a/docs/services/eventbridge/sim-event-bridge-cloudformation.example.ts
+++ b/docs/services/eventbridge/sim-event-bridge-cloudformation.example.ts
@@ -1,0 +1,76 @@
+/**
+ * A rule and its target, deployed from a template rather than by the SDK.
+ */
+
+import { PutEventsCommand } from "@aws-sdk/client-eventbridge";
+
+import { SimAws } from "@kensio/yulin";
+import { makeLambdaZipFileInput } from "@kensio/yulin/lambda";
+
+const simAws = new SimAws();
+const handled: unknown[] = [];
+
+await simAws.lambda().createFunction({
+  input: {
+    FunctionName: "fulfilment",
+    Role: "arn:aws:iam::888888888888:role/FulfilmentRole",
+    Code: {
+      ZipFile: makeLambdaZipFileInput((event: unknown) => {
+        handled.push(event);
+        return { ok: true };
+      }),
+    },
+  },
+});
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "orders-stack",
+  template: {
+    Resources: {
+      OrdersRule: {
+        Type: "AWS::Events::Rule",
+        Properties: {
+          Name: "orders",
+          // A template carries the pattern as an object, where the API takes
+          // it as a string of JSON.
+          EventPattern: { source: ["orders.service"] },
+          Targets: [
+            {
+              Id: "fulfilment",
+              Arn: "arn:aws:lambda:us-east-1:888888888888:function:fulfilment",
+            },
+          ],
+        },
+      },
+      // The grant CDK emits alongside a Lambda target, and that the target
+      // needs here too.
+      PermissionForEventsToInvokeLambda: {
+        Type: "AWS::Lambda::Permission",
+        Properties: {
+          FunctionName: "fulfilment",
+          Action: "lambda:InvokeFunction",
+          Principal: "events.amazonaws.com",
+          SourceArn: { "Fn::GetAtt": ["OrdersRule", "Arn"] },
+        },
+      },
+    },
+  },
+});
+
+await stack.waitForDeployComplete();
+
+await simAws.eventBridge().putEvents(
+  new PutEventsCommand({
+    Entries: [
+      {
+        Source: "orders.service",
+        DetailType: "OrderPlaced",
+        Detail: JSON.stringify({ orderId: "order-1" }),
+      },
+    ],
+  }),
+);
+
+await simAws.backgroundTasksComplete();
+
+console.log(handled.length); // 1

--- a/docs/services/scheduler/README.md
+++ b/docs/services/scheduler/README.md
@@ -382,6 +382,64 @@ That is the caller's own permission to manage schedules, and it is a separate qu
 schedule's execution role may invoke its target. The second is asked when the schedule fires, against
 the `RoleArn` on the target rather than against whoever created the schedule.
 
+## Deploying from a CloudFormation template
+
+`AWS::Scheduler::Schedule` deploys through [simulated CloudFormation](../cloudformation/), so a stack
+that declares its schedules rather than calling the SDK can be exercised end to end. Everything the
+Resource carries lines up with `CreateSchedule`, and a target ARN or execution role resolved by
+`Fn::GetAtt` from the same template works as it would in a real deployment.
+
+```typescript sim-scheduler-cloudformation
+/**
+ * A schedule deployed from a template, firing as simulated time advances.
+ */
+
+import { SimAws, SimFixedClock } from "@kensio/yulin";
+
+const simAws = new SimAws({
+  clock: new SimFixedClock(new Date("2026-07-26T09:00:00.000Z")),
+});
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "reporting-stack",
+  template: {
+    Resources: {
+      ReportQueue: {
+        Type: "AWS::SQS::Queue",
+        Properties: { QueueName: "reports" },
+      },
+      HourlyReport: {
+        Type: "AWS::Scheduler::Schedule",
+        Properties: {
+          Name: "hourly-report",
+          ScheduleExpression: "rate(1 hour)",
+          FlexibleTimeWindow: { Mode: "OFF" },
+          Target: {
+            Arn: { "Fn::GetAtt": ["ReportQueue", "Arn"] },
+            RoleArn: "arn:aws:iam::888888888888:role/SchedulerRole",
+          },
+        },
+      },
+    },
+  },
+});
+
+await stack.waitForDeployComplete();
+
+console.log(stack.outputs.size); // 0, and the schedule is armed
+
+// Three simulated hours on, the schedule has fallen due three times.
+await simAws.clock().advanceBy({ hours: 3 });
+```
+
+`Ref` returns the schedule's **name** and `Fn::GetAtt ... Arn` its ARN, which carries the schedule
+group as it always does. A schedule the template does not name gets one generated from the stack name
+and the logical ID.
+
+A property this simulation does not model is refused at deploy time naming the Resource, rather than
+deploying a schedule that behaves differently from the one that was declared. Tearing the stack down
+removes the schedules it created, so nothing fires afterwards.
+
 ## Available functionality
 
 - `CreateSchedule`, `GetSchedule`, `UpdateSchedule`, `DeleteSchedule` and `ListSchedules`.
@@ -422,4 +480,5 @@ the `RoleArn` on the target rather than against whoever created the schedule.
   dropped.
 - `KmsKeyArn` is refused, and `ClientToken` is accepted and ignored: nothing here retries, so there is
   no request for it to make idempotent.
-- `AWS::Scheduler::Schedule` CloudFormation resources are not simulated.
+- `AWS::Scheduler::ScheduleGroup` is not simulated as a CloudFormation resource type.
+  `AWS::Scheduler::Schedule` is: see [deploying from a template](#deploying-from-a-cloudformation-template).

--- a/docs/services/scheduler/README.md
+++ b/docs/services/scheduler/README.md
@@ -394,11 +394,47 @@ Resource carries lines up with `CreateSchedule`, and a target ARN or execution r
  * A schedule deployed from a template, firing as simulated time advances.
  */
 
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import { ReceiveMessageCommand } from "@aws-sdk/client-sqs";
+
 import { SimAws, SimFixedClock } from "@kensio/yulin";
 
 const simAws = new SimAws({
   clock: new SimFixedClock(new Date("2026-07-26T09:00:00.000Z")),
 });
+
+const queueArn = "arn:aws:sqs:us-east-1:888888888888:reports";
+const roleArn = "arn:aws:iam::888888888888:role/SchedulerRole";
+
+// The execution role has to trust Scheduler, and be allowed to send.
+await simAws.iam().createRole(
+  new CreateRoleCommand({
+    RoleName: "SchedulerRole",
+    AssumeRolePolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Principal: { Service: "scheduler.amazonaws.com" },
+        Action: "sts:AssumeRole",
+      },
+    }),
+  }),
+);
+
+await simAws.iam().putRolePolicy(
+  new PutRolePolicyCommand({
+    RoleName: "SchedulerRole",
+    PolicyName: "SendReports",
+    PolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Action: "sqs:SendMessage",
+        Resource: queueArn,
+      },
+    }),
+  }),
+);
 
 const stack = await simAws.cloudFormation().deployTemplate({
   stackName: "reporting-stack",
@@ -416,7 +452,8 @@ const stack = await simAws.cloudFormation().deployTemplate({
           FlexibleTimeWindow: { Mode: "OFF" },
           Target: {
             Arn: { "Fn::GetAtt": ["ReportQueue", "Arn"] },
-            RoleArn: "arn:aws:iam::888888888888:role/SchedulerRole",
+            RoleArn: roleArn,
+            Input: JSON.stringify({ report: "hourly" }),
           },
         },
       },
@@ -426,10 +463,21 @@ const stack = await simAws.cloudFormation().deployTemplate({
 
 await stack.waitForDeployComplete();
 
-console.log(stack.outputs.size); // 0, and the schedule is armed
-
-// Three simulated hours on, the schedule has fallen due three times.
+// Three simulated hours on, the schedule has invoked its target three times.
 await simAws.clock().advanceBy({ hours: 3 });
+
+const received = await simAws.sqs().receiveMessage(
+  new ReceiveMessageCommand({
+    QueueUrl: "https://sqs.us-east-1.amazonaws.com/888888888888/reports",
+    MaxNumberOfMessages: 10,
+  }),
+);
+
+console.log(received.Messages?.length); // 3
+
+// Nothing went wrong on the way, which is worth checking: a schedule that
+// could not reach its target says so here rather than by throwing.
+console.log(simAws.scheduler().deliveryFailures.length); // 0
 ```
 
 `Ref` returns the schedule's **name** and `Fn::GetAtt ... Arn` its ARN, which carries the schedule

--- a/docs/services/scheduler/sim-scheduler-cloudformation.example.ts
+++ b/docs/services/scheduler/sim-scheduler-cloudformation.example.ts
@@ -2,11 +2,47 @@
  * A schedule deployed from a template, firing as simulated time advances.
  */
 
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import { ReceiveMessageCommand } from "@aws-sdk/client-sqs";
+
 import { SimAws, SimFixedClock } from "@kensio/yulin";
 
 const simAws = new SimAws({
   clock: new SimFixedClock(new Date("2026-07-26T09:00:00.000Z")),
 });
+
+const queueArn = "arn:aws:sqs:us-east-1:888888888888:reports";
+const roleArn = "arn:aws:iam::888888888888:role/SchedulerRole";
+
+// The execution role has to trust Scheduler, and be allowed to send.
+await simAws.iam().createRole(
+  new CreateRoleCommand({
+    RoleName: "SchedulerRole",
+    AssumeRolePolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Principal: { Service: "scheduler.amazonaws.com" },
+        Action: "sts:AssumeRole",
+      },
+    }),
+  }),
+);
+
+await simAws.iam().putRolePolicy(
+  new PutRolePolicyCommand({
+    RoleName: "SchedulerRole",
+    PolicyName: "SendReports",
+    PolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Action: "sqs:SendMessage",
+        Resource: queueArn,
+      },
+    }),
+  }),
+);
 
 const stack = await simAws.cloudFormation().deployTemplate({
   stackName: "reporting-stack",
@@ -24,7 +60,8 @@ const stack = await simAws.cloudFormation().deployTemplate({
           FlexibleTimeWindow: { Mode: "OFF" },
           Target: {
             Arn: { "Fn::GetAtt": ["ReportQueue", "Arn"] },
-            RoleArn: "arn:aws:iam::888888888888:role/SchedulerRole",
+            RoleArn: roleArn,
+            Input: JSON.stringify({ report: "hourly" }),
           },
         },
       },
@@ -34,7 +71,18 @@ const stack = await simAws.cloudFormation().deployTemplate({
 
 await stack.waitForDeployComplete();
 
-console.log(stack.outputs.size); // 0, and the schedule is armed
-
-// Three simulated hours on, the schedule has fallen due three times.
+// Three simulated hours on, the schedule has invoked its target three times.
 await simAws.clock().advanceBy({ hours: 3 });
+
+const received = await simAws.sqs().receiveMessage(
+  new ReceiveMessageCommand({
+    QueueUrl: "https://sqs.us-east-1.amazonaws.com/888888888888/reports",
+    MaxNumberOfMessages: 10,
+  }),
+);
+
+console.log(received.Messages?.length); // 3
+
+// Nothing went wrong on the way, which is worth checking: a schedule that
+// could not reach its target says so here rather than by throwing.
+console.log(simAws.scheduler().deliveryFailures.length); // 0

--- a/docs/services/scheduler/sim-scheduler-cloudformation.example.ts
+++ b/docs/services/scheduler/sim-scheduler-cloudformation.example.ts
@@ -1,0 +1,40 @@
+/**
+ * A schedule deployed from a template, firing as simulated time advances.
+ */
+
+import { SimAws, SimFixedClock } from "@kensio/yulin";
+
+const simAws = new SimAws({
+  clock: new SimFixedClock(new Date("2026-07-26T09:00:00.000Z")),
+});
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "reporting-stack",
+  template: {
+    Resources: {
+      ReportQueue: {
+        Type: "AWS::SQS::Queue",
+        Properties: { QueueName: "reports" },
+      },
+      HourlyReport: {
+        Type: "AWS::Scheduler::Schedule",
+        Properties: {
+          Name: "hourly-report",
+          ScheduleExpression: "rate(1 hour)",
+          FlexibleTimeWindow: { Mode: "OFF" },
+          Target: {
+            Arn: { "Fn::GetAtt": ["ReportQueue", "Arn"] },
+            RoleArn: "arn:aws:iam::888888888888:role/SchedulerRole",
+          },
+        },
+      },
+    },
+  },
+});
+
+await stack.waitForDeployComplete();
+
+console.log(stack.outputs.size); // 0, and the schedule is armed
+
+// Three simulated hours on, the schedule has fallen due three times.
+await simAws.clock().advanceBy({ hours: 3 });

--- a/src/service/cloudformation/cdk/provider/sim-cdk-provider-scaffolding.iso.test.ts
+++ b/src/service/cloudformation/cdk/provider/sim-cdk-provider-scaffolding.iso.test.ts
@@ -122,7 +122,7 @@ describe("CDK custom Resource provider scaffolding [iso]", () => {
           Prune: false,
         },
       },
-      AlarmRule: { Type: "AWS::Events::Rule" },
+      AlarmRule: { Type: "AWS::CloudWatch::Alarm" },
     });
 
     // Then it deploys like any other, and the scaffolding around the two that

--- a/src/service/cloudformation/resource/cfn/events/sim-event-bridge-cfn-value-adapter.ts
+++ b/src/service/cloudformation/resource/cfn/events/sim-event-bridge-cfn-value-adapter.ts
@@ -1,0 +1,34 @@
+import { SimEventBus } from "../../../../eventbridge/bus/sim-event-bus.js";
+import { SimEventRule } from "../../../../eventbridge/rule/sim-event-rule.js";
+import type {
+  SimCfnResourceValueAdapterProperties,
+  SimCfnServiceValueAdapter,
+} from "../sim-cfn-resource-value-adapter.js";
+import { SimEventBusCfn } from "./sim-event-bus-cfn.js";
+import { SimEventRuleCfn } from "./sim-event-rule-cfn.js";
+
+/**
+ * The CloudFormation-facing value adapter for a simulated EventBridge Resource.
+ *
+ * Both types answer a `Ref` with their name rather than their ARN, which is
+ * unlike most of the simulator's other resources and is what AWS does here.
+ */
+export function eventBridgeValueAdapter(
+  properties: SimCfnResourceValueAdapterProperties,
+): SimCfnServiceValueAdapter {
+  if (
+    properties.type === "AWS::Events::EventBus" &&
+    properties.simResource instanceof SimEventBus
+  ) {
+    return new SimEventBusCfn({ bus: properties.simResource });
+  }
+
+  if (
+    properties.type === "AWS::Events::Rule" &&
+    properties.simResource instanceof SimEventRule
+  ) {
+    return new SimEventRuleCfn({ rule: properties.simResource });
+  }
+
+  return undefined;
+}

--- a/src/service/cloudformation/resource/cfn/events/sim-event-bus-cfn.ts
+++ b/src/service/cloudformation/resource/cfn/events/sim-event-bus-cfn.ts
@@ -1,0 +1,47 @@
+import type { SimEventBus } from "../../../../eventbridge/bus/sim-event-bus.js";
+import type { SimCfnTemplateValue } from "../../../template/value/sim-cfn-template-value.js";
+import type { SimCfnResourceValueAdapter } from "../sim-cfn-resource-value-adapter.js";
+
+interface SimEventBusCfnProperties {
+  readonly bus: SimEventBus;
+}
+
+/**
+ * CloudFormation-facing values for a simulated event bus.
+ */
+export class SimEventBusCfn implements SimCfnResourceValueAdapter {
+  private readonly bus: SimEventBus;
+
+  constructor(properties: SimEventBusCfnProperties) {
+    this.bus = properties.bus;
+  }
+
+  /**
+   * AWS::Events::EventBus Ref returns the bus name, not its ARN.
+   *
+   * That is what makes a `Ref` usable straight away as the `EventBusName` of a
+   * rule in the same template, which is the common thing to do with one.
+   */
+  refValue(): SimCfnTemplateValue {
+    return this.bus.name.value;
+  }
+
+  /**
+   * AWS::Events::EventBus attributes.
+   */
+  attributeValue(attributeName: string): SimCfnTemplateValue {
+    switch (attributeName) {
+      case "Arn": {
+        return this.bus.arn.value;
+      }
+      case "Name": {
+        return this.bus.name.value;
+      }
+      default: {
+        throw new Error(
+          `Unsupported AWS::Events::EventBus attribute ${attributeName}`,
+        );
+      }
+    }
+  }
+}

--- a/src/service/cloudformation/resource/cfn/events/sim-event-rule-cfn.ts
+++ b/src/service/cloudformation/resource/cfn/events/sim-event-rule-cfn.ts
@@ -1,0 +1,41 @@
+import type { SimEventRule } from "../../../../eventbridge/rule/sim-event-rule.js";
+import type { SimCfnTemplateValue } from "../../../template/value/sim-cfn-template-value.js";
+import type { SimCfnResourceValueAdapter } from "../sim-cfn-resource-value-adapter.js";
+
+interface SimEventRuleCfnProperties {
+  readonly rule: SimEventRule;
+}
+
+/**
+ * CloudFormation-facing values for a simulated rule.
+ */
+export class SimEventRuleCfn implements SimCfnResourceValueAdapter {
+  private readonly rule: SimEventRule;
+
+  constructor(properties: SimEventRuleCfnProperties) {
+    this.rule = properties.rule;
+  }
+
+  /**
+   * AWS::Events::Rule Ref returns the rule name, not its ARN.
+   *
+   * AWS documents this as the "rule ID", which for an unnamed rule is the name
+   * CloudFormation generated for it, such as `mystack-ScheduledRule-ABC123`.
+   * A template wanting the ARN, as an `AWS::Lambda::Permission` `SourceArn`
+   * does, has to ask for it with `Fn::GetAtt`.
+   */
+  refValue(): SimCfnTemplateValue {
+    return this.rule.name.value;
+  }
+
+  /**
+   * AWS::Events::Rule attributes.
+   */
+  attributeValue(attributeName: string): SimCfnTemplateValue {
+    if (attributeName === "Arn") {
+      return this.rule.arn;
+    }
+
+    throw new Error(`Unsupported AWS::Events::Rule attribute ${attributeName}`);
+  }
+}

--- a/src/service/cloudformation/resource/cfn/scheduler/sim-scheduler-cfn-value-adapter.ts
+++ b/src/service/cloudformation/resource/cfn/scheduler/sim-scheduler-cfn-value-adapter.ts
@@ -1,0 +1,54 @@
+import { SimSchedulerSchedule } from "../../../../scheduler/schedule/sim-scheduler-schedule.js";
+import type { SimCfnTemplateValue } from "../../../template/value/sim-cfn-template-value.js";
+import type {
+  SimCfnResourceValueAdapter,
+  SimCfnResourceValueAdapterProperties,
+  SimCfnServiceValueAdapter,
+} from "../sim-cfn-resource-value-adapter.js";
+
+/**
+ * CloudFormation-facing values for a simulated schedule.
+ */
+class SimSchedulerScheduleCfn implements SimCfnResourceValueAdapter {
+  private readonly schedule: SimSchedulerSchedule;
+
+  constructor(properties: { readonly schedule: SimSchedulerSchedule }) {
+    this.schedule = properties.schedule;
+  }
+
+  /**
+   * AWS::Scheduler::Schedule Ref returns the schedule's name.
+   */
+  refValue(): SimCfnTemplateValue {
+    return this.schedule.name.value;
+  }
+
+  /**
+   * AWS::Scheduler::Schedule attributes.
+   */
+  attributeValue(attributeName: string): SimCfnTemplateValue {
+    if (attributeName === "Arn") {
+      return this.schedule.arn;
+    }
+
+    throw new Error(
+      `Unsupported AWS::Scheduler::Schedule attribute ${attributeName}`,
+    );
+  }
+}
+
+/**
+ * The CloudFormation-facing value adapter for a simulated Scheduler Resource.
+ */
+export function schedulerValueAdapter(
+  properties: SimCfnResourceValueAdapterProperties,
+): SimCfnServiceValueAdapter {
+  if (
+    properties.type === "AWS::Scheduler::Schedule" &&
+    properties.simResource instanceof SimSchedulerSchedule
+  ) {
+    return new SimSchedulerScheduleCfn({ schedule: properties.simResource });
+  }
+
+  return undefined;
+}

--- a/src/service/cloudformation/resource/cfn/sim-cfn-default-resource-value-adapter.iso.test.ts
+++ b/src/service/cloudformation/resource/cfn/sim-cfn-default-resource-value-adapter.iso.test.ts
@@ -12,15 +12,15 @@ import type { CfnTemplateBodyRecord } from "../../template/sim-cfn-template.js";
  * A template whose only Resource is one no service claims, referenced both
  * ways, so a test can read what a skipped Resource answers with.
  */
-const skippedRuleTemplate: CfnTemplateBodyRecord = {
+const skippedAlarmTemplate: CfnTemplateBodyRecord = {
   Resources: {
     AlarmRule: {
-      Type: "AWS::Events::Rule",
+      Type: "AWS::CloudWatch::Alarm",
     },
   },
   Outputs: {
-    RuleRef: { Value: { Ref: "AlarmRule" } },
-    RuleArn: { Value: { "Fn::GetAtt": ["AlarmRule", "Arn"] } },
+    AlarmRef: { Value: { Ref: "AlarmRule" } },
+    AlarmArn: { Value: { "Fn::GetAtt": ["AlarmRule", "Arn"] } },
   },
 };
 
@@ -32,13 +32,13 @@ describe("skipped CloudFormation Resource values", () => {
     // When the template is deployed.
     const stack = await simAws.cloudFormation().deployTemplate({
       stackName: "stand-in-stack",
-      template: skippedRuleTemplate,
+      template: skippedAlarmTemplate,
     });
     await stack.waitForDeployComplete();
 
     // Then the Ref resolved to the logical ID rather than failing the
     // Resources that hold it.
-    assertIdentical(stack.outputs.get("RuleRef")?.value, "AlarmRule");
+    assertIdentical(stack.outputs.get("AlarmRef")?.value, "AlarmRule");
   });
 
   it("answers an Fn::GetAtt with the logical ID and attribute name", async () => {
@@ -49,13 +49,13 @@ describe("skipped CloudFormation Resource values", () => {
     // When the template is deployed.
     const stack = await simAws.cloudFormation().deployTemplate({
       stackName: "stand-in-stack",
-      template: skippedRuleTemplate,
+      template: skippedAlarmTemplate,
     });
     await stack.waitForDeployComplete();
 
     // Then the attribute resolved to a stand-in that is deliberately not
     // ARN-shaped, so it fails closed wherever it is read as one.
-    assertIdentical(stack.outputs.get("RuleArn")?.value, "AlarmRule.Arn");
+    assertIdentical(stack.outputs.get("AlarmArn")?.value, "AlarmRule.Arn");
   });
 
   it("records the skip the stand-ins came from", async () => {
@@ -65,7 +65,7 @@ describe("skipped CloudFormation Resource values", () => {
     // When the template is deployed.
     const stack = await simAws.cloudFormation().deployTemplate({
       stackName: "stand-in-stack",
-      template: skippedRuleTemplate,
+      template: skippedAlarmTemplate,
     });
     await stack.waitForDeployComplete();
 
@@ -74,7 +74,7 @@ describe("skipped CloudFormation Resource values", () => {
     assertArrayLength(stack.skippedResources, 1);
     assertStringIncludes(
       stack.getResource("AlarmRule")?.skippedReason ?? "",
-      "Unsupported sim CloudFormation Resource service Events",
+      "Unsupported sim CloudFormation Resource service CloudWatch",
     );
   });
 });

--- a/src/service/cloudformation/resource/cfn/sim-cfn-resource-value-adapter.ts
+++ b/src/service/cloudformation/resource/cfn/sim-cfn-resource-value-adapter.ts
@@ -4,11 +4,13 @@ import { apiGatewayV2ValueAdapter } from "./apigatewayv2/sim-api-gateway-v2-cfn-
 import { cloudFrontValueAdapter } from "./cloudfront/sim-cloudfront-cfn-value-adapter.js";
 import { cognitoValueAdapter } from "./cognito/sim-cognito-cfn-value-adapter.js";
 import { dynamoDbValueAdapter } from "./dynamodb/sim-dynamodb-cfn-value-adapter.js";
+import { eventBridgeValueAdapter } from "./events/sim-event-bridge-cfn-value-adapter.js";
 import { iamValueAdapter } from "./iam/sim-iam-cfn-value-adapter.js";
 import { kmsValueAdapter } from "./kms/sim-kms-cfn-value-adapter.js";
 import { lambdaValueAdapter } from "./lambda/sim-lambda-cfn-value-adapter.js";
 import { route53ValueAdapter } from "./route53/sim-route53-cfn-value-adapter.js";
 import { s3ValueAdapter } from "./s3/sim-s3-cfn-value-adapter.js";
+import { schedulerValueAdapter } from "./scheduler/sim-scheduler-cfn-value-adapter.js";
 import { secretsManagerValueAdapter } from "./secretsmanager/sim-secrets-manager-cfn-value-adapter.js";
 import { snsValueAdapter } from "./sns/sim-sns-cfn-value-adapter.js";
 import { sqsValueAdapter } from "./sqs/sim-sqs-cfn-value-adapter.js";
@@ -54,11 +56,13 @@ export function simCfnResourceValueAdapter(
     cloudFrontValueAdapter(properties) ??
     cognitoValueAdapter(properties) ??
     dynamoDbValueAdapter(properties) ??
+    eventBridgeValueAdapter(properties) ??
     iamValueAdapter(properties) ??
     kmsValueAdapter(properties) ??
     lambdaValueAdapter(properties) ??
     route53ValueAdapter(properties) ??
     s3ValueAdapter(properties) ??
+    schedulerValueAdapter(properties) ??
     secretsManagerValueAdapter(properties) ??
     snsValueAdapter(properties) ??
     sqsValueAdapter(properties) ??

--- a/src/service/cloudformation/resource/resolve/service/sim-cfn-service-factories.ts
+++ b/src/service/cloudformation/resource/resolve/service/sim-cfn-service-factories.ts
@@ -90,6 +90,16 @@ export const simCfnServiceResourceFactories: ReadonlyMap<
       scopedAws.secretsManager().cfnResourceFactory(),
   ],
   [
+    "Events",
+    (scopedAws): SimCfnServiceResourceFactory =>
+      scopedAws.eventBridge().cfnResourceFactory(),
+  ],
+  [
+    "Scheduler",
+    (scopedAws): SimCfnServiceResourceFactory =>
+      scopedAws.scheduler().cfnResourceFactory(),
+  ],
+  [
     "SNS",
     (scopedAws): SimCfnServiceResourceFactory =>
       scopedAws.sns().cfnResourceFactory(),

--- a/src/service/cloudformation/resource/resolve/service/sim-cfn-service-resolver.iso.test.ts
+++ b/src/service/cloudformation/resource/resolve/service/sim-cfn-service-resolver.iso.test.ts
@@ -105,7 +105,7 @@ describe("resolveSimCloudFormationServiceResourceFactory", () => {
         accountRegionScope,
         {
           providerName: "AWS",
-          serviceName: "Events",
+          serviceName: "CloudWatch",
           resourceTypeName: "Rule",
         },
       ),
@@ -114,7 +114,7 @@ describe("resolveSimCloudFormationServiceResourceFactory", () => {
     // Then the unsupported service name is included for diagnosis.
     assertIdentical(
       error.message,
-      "Unsupported sim CloudFormation Resource service Events",
+      "Unsupported sim CloudFormation Resource service CloudWatch",
     );
   });
 

--- a/src/service/cloudformation/stack/sim-cfn-stack.iso.test.ts
+++ b/src/service/cloudformation/stack/sim-cfn-stack.iso.test.ts
@@ -229,7 +229,7 @@ describe("SimCfnStack", () => {
       template: {
         Resources: {
           TestRule: {
-            Type: "AWS::Events::Rule",
+            Type: "AWS::CloudWatch::Alarm",
           },
         },
       },
@@ -244,7 +244,7 @@ describe("SimCfnStack", () => {
     assertTrue(skippedResource.skipped);
     assertIdentical(
       skippedResource.skippedReason,
-      "Unsupported sim CloudFormation Resource service Events",
+      "Unsupported sim CloudFormation Resource service CloudWatch",
     );
   });
 

--- a/src/service/eventbridge/cfn/bus/sim-cfn-event-bus-creator.ts
+++ b/src/service/eventbridge/cfn/bus/sim-cfn-event-bus-creator.ts
@@ -1,0 +1,65 @@
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimEventBus } from "../../bus/sim-event-bus.js";
+import type { SimEventBridge } from "../../sim-event-bridge.js";
+import { simCfnEventBridgeResourceCreation } from "../sim-cfn-event-bridge-resource-error.js";
+import { eventBusResourceType } from "../sim-cfn-event-bridge-resource-types.js";
+import { SimCfnEventBusProperties } from "./sim-cfn-event-bus-properties.js";
+
+interface SimCfnEventBusCreatorProperties {
+  readonly eventBridge: SimEventBridge;
+}
+
+/**
+ * Creates simulated event buses from AWS::Events::EventBus Resources.
+ *
+ * The bus is created through the ordinary CreateEventBus command rather than
+ * constructed directly, so a bus a template deployed is the same thing an SDK
+ * caller would have got: the same name validation, and the same refusals for
+ * what this simulation does not model.
+ */
+export class SimCfnEventBusCreator {
+  private readonly eventBridge: SimEventBridge;
+
+  constructor(properties: SimCfnEventBusCreatorProperties) {
+    this.eventBridge = properties.eventBridge;
+  }
+
+  /**
+   * Create an event bus from an AWS::Events::EventBus Resource.
+   */
+  async create(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): Promise<SimEventBus> {
+    const busProperties = new SimCfnEventBusProperties({
+      resource,
+      properties,
+    });
+
+    busProperties.refuseUnsimulated();
+
+    const name = busProperties.name();
+    const description = busProperties.description();
+
+    return await simCfnEventBridgeResourceCreation(
+      eventBusResourceType,
+      resource.logicalId,
+      async () => {
+        await this.eventBridge.createEventBus({
+          input: { Name: name, Description: description },
+        });
+
+        const bus = this.eventBridge.findEventBus(name);
+
+        assertDefined(
+          bus,
+          `sim EventBridge bus ${name} after CloudFormation creation`,
+        );
+
+        return bus;
+      },
+    );
+  }
+}

--- a/src/service/eventbridge/cfn/bus/sim-cfn-event-bus-properties.ts
+++ b/src/service/eventbridge/cfn/bus/sim-cfn-event-bus-properties.ts
@@ -84,7 +84,9 @@ export class SimCfnEventBusProperties {
    */
   refuseUnsimulated(): void {
     for (const [property, reason] of unsimulatedProperties) {
-      if (this.properties.get(property) !== undefined) {
+      // Asked by key rather than by value, so a template writing `null` for
+      // one of these is refused rather than read as having left it out.
+      if (this.properties.has(property)) {
         throw this.propertyError(
           `${property} is not simulated, so the Resource is refused rather ` +
             `than deployed without it: ${reason}`,

--- a/src/service/eventbridge/cfn/bus/sim-cfn-event-bus-properties.ts
+++ b/src/service/eventbridge/cfn/bus/sim-cfn-event-bus-properties.ts
@@ -1,0 +1,103 @@
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type {
+  SimCfnTemplateValue,
+  SimCfnTemplateValueRecord,
+} from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import { simCfnEventBridgeResourceError } from "../sim-cfn-event-bridge-resource-error.js";
+import { eventBusResourceType } from "../sim-cfn-event-bridge-resource-types.js";
+
+/**
+ * What a template can say about an event bus that this simulation does not
+ * model, and what each would have done.
+ *
+ * Each is refused rather than dropped, because a bus deployed without one looks
+ * configured to the template that wrote it and behaves as though it were not: a
+ * dead letter queue that is never written to is worse than one that was
+ * refused, and a `Policy` silently missing is a bus that admits nobody while
+ * the template says it admits an Account.
+ */
+const unsimulatedProperties: readonly (readonly [string, string])[] = [
+  ["Policy", "event bus resource policies are not simulated"],
+  [
+    "DeadLetterConfig",
+    "an undeliverable event is recorded rather than sent on",
+  ],
+  ["EventSourceName", "partner event buses are not simulated"],
+  ["KmsKeyIdentifier", "events are not encrypted with a customer managed key"],
+  ["LogConfig", "event bus logging is not simulated"],
+  ["Tags", "event bus tags are not simulated"],
+];
+
+interface SimCfnEventBusPropertiesProperties {
+  readonly resource: SimCfnResource;
+  readonly properties: SimCfnTemplateValueRecord;
+}
+
+/**
+ * Reads AWS::Events::EventBus properties into the shape CreateEventBus takes.
+ */
+export class SimCfnEventBusProperties {
+  private readonly resource: SimCfnResource;
+  private readonly properties: ReadonlyMap<string, SimCfnTemplateValue>;
+
+  constructor(properties: SimCfnEventBusPropertiesProperties) {
+    this.resource = properties.resource;
+    this.properties = new Map(Object.entries(properties.properties));
+  }
+
+  /**
+   * The bus name, which AWS requires on this Resource type.
+   *
+   * Unlike most named resources there is no generated fallback, because
+   * CloudFormation does not generate one either: `Name` is a required property
+   * of an `AWS::Events::EventBus`.
+   */
+  name(): string {
+    const name = this.properties.get("Name");
+
+    if (typeof name !== "string" || name === "") {
+      throw this.propertyError("Name is required, and is a string");
+    }
+
+    return name;
+  }
+
+  /**
+   * The bus description, which a template may leave out.
+   */
+  description(): string | undefined {
+    const description = this.properties.get("Description");
+
+    if (description === undefined) {
+      return undefined;
+    }
+
+    if (typeof description !== "string") {
+      throw this.propertyError("Description must be a string");
+    }
+
+    return description;
+  }
+
+  /**
+   * Refuse what this simulation does not model, naming the property.
+   */
+  refuseUnsimulated(): void {
+    for (const [property, reason] of unsimulatedProperties) {
+      if (this.properties.get(property) !== undefined) {
+        throw this.propertyError(
+          `${property} is not simulated, so the Resource is refused rather ` +
+            `than deployed without it: ${reason}`,
+        );
+      }
+    }
+  }
+
+  private propertyError(reason: string): Error {
+    return simCfnEventBridgeResourceError(
+      eventBusResourceType,
+      this.resource.logicalId,
+      reason,
+    );
+  }
+}

--- a/src/service/eventbridge/cfn/rule/sim-cfn-event-rule-creator.ts
+++ b/src/service/eventbridge/cfn/rule/sim-cfn-event-rule-creator.ts
@@ -1,0 +1,105 @@
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimEventRule } from "../../rule/sim-event-rule.js";
+import type { SimEventBridge } from "../../sim-event-bridge.js";
+import { simCfnEventBridgeResourceCreation } from "../sim-cfn-event-bridge-resource-error.js";
+import { eventRuleResourceType } from "../sim-cfn-event-bridge-resource-types.js";
+import { SimCfnEventRuleProperties } from "./sim-cfn-event-rule-properties.js";
+import type { SimCfnEventRuleTarget } from "./sim-cfn-event-rule-targets.js";
+
+interface SimCfnEventRuleCreatorProperties {
+  readonly eventBridge: SimEventBridge;
+}
+
+/**
+ * Creates simulated rules from AWS::Events::Rule Resources.
+ *
+ * The rule and its targets go through the ordinary PutRule and PutTargets
+ * commands rather than being constructed directly, so a rule a template
+ * deployed is the same thing an SDK caller would have got: the same pattern
+ * parsing, the same schedule expression rules, and the same refusals.
+ *
+ * A rule's `Targets` are inline in the template rather than a Resource of their
+ * own, the same way an SNS topic's subscriptions can be, so they are created
+ * here as part of the rule rather than reaching CloudFormation separately.
+ */
+export class SimCfnEventRuleCreator {
+  private readonly eventBridge: SimEventBridge;
+
+  constructor(properties: SimCfnEventRuleCreatorProperties) {
+    this.eventBridge = properties.eventBridge;
+  }
+
+  /**
+   * Create a rule, and its targets, from an AWS::Events::Rule Resource.
+   */
+  async create(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): Promise<SimEventRule> {
+    const ruleProperties = new SimCfnEventRuleProperties({
+      resource,
+      properties,
+    });
+
+    ruleProperties.refuseUnsimulated();
+
+    const name = ruleProperties.name();
+    const busName = ruleProperties.busName();
+    const targets = ruleProperties.targets();
+
+    return await simCfnEventBridgeResourceCreation(
+      eventRuleResourceType,
+      resource.logicalId,
+      async () => {
+        await this.eventBridge.putRule({
+          input: {
+            Name: name,
+            EventBusName: busName,
+            EventPattern: ruleProperties.eventPattern(),
+            ScheduleExpression: ruleProperties.scheduleExpression(),
+            State: ruleProperties.state(),
+            Description: ruleProperties.description(),
+          },
+        });
+
+        await this.putTargets(name, busName, targets);
+
+        const rule = this.eventBridge.findRule(name, busName);
+
+        assertDefined(
+          rule,
+          `sim EventBridge rule ${name} after CloudFormation creation`,
+        );
+
+        return rule;
+      },
+    );
+  }
+
+  /**
+   * Add everything the rule's own `Targets` list declares.
+   */
+  private async putTargets(
+    ruleName: string,
+    busName: string | undefined,
+    targets: readonly SimCfnEventRuleTarget[],
+  ): Promise<void> {
+    if (targets.length === 0) {
+      return;
+    }
+
+    await this.eventBridge.putTargets({
+      input: {
+        Rule: ruleName,
+        EventBusName: busName,
+        Targets: targets.map((target) => ({
+          Id: target.Id,
+          Arn: target.Arn,
+          Input: target.Input,
+        })),
+      },
+    });
+  }
+}

--- a/src/service/eventbridge/cfn/rule/sim-cfn-event-rule-properties.ts
+++ b/src/service/eventbridge/cfn/rule/sim-cfn-event-rule-properties.ts
@@ -1,0 +1,165 @@
+import { SimCfnGeneratedResourceName } from "../../../cloudformation/resource/name/sim-cfn-generated-resource-name.js";
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type {
+  SimCfnTemplateValue,
+  SimCfnTemplateValueRecord,
+} from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import { simCfnEventBridgeResourceError } from "../sim-cfn-event-bridge-resource-error.js";
+import { eventRuleResourceType } from "../sim-cfn-event-bridge-resource-types.js";
+import {
+  type SimCfnEventRuleTarget,
+  simCfnEventRuleTargets,
+} from "./sim-cfn-event-rule-targets.js";
+
+const maximumNameLength = 64;
+
+/**
+ * Reads AWS::Events::Rule properties into the shape PutRule and PutTargets
+ * take.
+ */
+export class SimCfnEventRuleProperties {
+  private readonly resource: SimCfnResource;
+  private readonly properties: ReadonlyMap<string, SimCfnTemplateValue>;
+
+  constructor(properties: {
+    readonly resource: SimCfnResource;
+    readonly properties: SimCfnTemplateValueRecord;
+  }) {
+    this.resource = properties.resource;
+    this.properties = new Map(Object.entries(properties.properties));
+  }
+
+  /**
+   * The rule name.
+   *
+   * An unnamed rule is named after the stack and the logical ID, as real
+   * CloudFormation names one, which is why `Ref` on a rule gives back something
+   * like `mystack-ScheduledRule-ABC123` rather than the logical ID.
+   */
+  name(): string {
+    const name = this.properties.get("Name");
+
+    if (name === undefined) {
+      return new SimCfnGeneratedResourceName({
+        stackName: this.resource.stackName,
+        logicalId: this.resource.logicalId,
+        maximumLength: maximumNameLength,
+      }).value;
+    }
+
+    if (typeof name !== "string") {
+      throw this.propertyError("Name must be a string");
+    }
+
+    return name;
+  }
+
+  /**
+   * The bus the rule watches, which is the default bus when unnamed.
+   */
+  busName(): string | undefined {
+    const busName = this.properties.get("EventBusName");
+
+    if (busName === undefined) {
+      return undefined;
+    }
+
+    if (typeof busName !== "string") {
+      throw this.propertyError("EventBusName must be a string");
+    }
+
+    return busName;
+  }
+
+  /**
+   * The event pattern, as the JSON string PutRule takes.
+   *
+   * A template carries the pattern as an object rather than as a string, which
+   * is the one place this Resource type does not line up with the API, so it is
+   * written back out here.
+   */
+  eventPattern(): string | undefined {
+    const pattern = this.properties.get("EventPattern");
+
+    if (pattern === undefined) {
+      return undefined;
+    }
+
+    if (typeof pattern === "string") {
+      return pattern;
+    }
+
+    return JSON.stringify(pattern);
+  }
+
+  /**
+   * The schedule expression, for a rule that fires on a timer.
+   */
+  scheduleExpression(): string | undefined {
+    return this.stringProperty("ScheduleExpression");
+  }
+
+  /**
+   * The rule state, which simulated EventBridge validates.
+   */
+  state(): string | undefined {
+    return this.stringProperty("State");
+  }
+
+  /**
+   * The rule description.
+   */
+  description(): string | undefined {
+    return this.stringProperty("Description");
+  }
+
+  /**
+   * The rule's inline targets.
+   */
+  targets(): readonly SimCfnEventRuleTarget[] {
+    return simCfnEventRuleTargets(this.properties.get("Targets"), (reason) =>
+      this.propertyError(reason),
+    );
+  }
+
+  /**
+   * Refuse what this simulation does not model, naming the property.
+   *
+   * A rule `RoleArn` and rule tags are both refused by simulated EventBridge
+   * itself, so they are left to it rather than repeated here. What is refused
+   * here is what only the template can say.
+   */
+  refuseUnsimulated(): void {
+    const roleArn = this.properties.get("RoleArn");
+
+    if (roleArn !== undefined) {
+      throw this.propertyError(
+        "RoleArn is not simulated, so the Resource is refused rather than " +
+          "deployed without it: a rule reaches its target as the EventBridge " +
+          "service principal, admitted by the target's own resource policy",
+      );
+    }
+  }
+
+  private stringProperty(name: string): string | undefined {
+    const value = this.properties.get(name);
+
+    if (value === undefined) {
+      return undefined;
+    }
+
+    if (typeof value !== "string") {
+      throw this.propertyError(`${name} must be a string`);
+    }
+
+    return value;
+  }
+
+  private propertyError(reason: string): Error {
+    return simCfnEventBridgeResourceError(
+      eventRuleResourceType,
+      this.resource.logicalId,
+      reason,
+    );
+  }
+}

--- a/src/service/eventbridge/cfn/rule/sim-cfn-event-rule-properties.ts
+++ b/src/service/eventbridge/cfn/rule/sim-cfn-event-rule-properties.ts
@@ -125,18 +125,25 @@ export class SimCfnEventRuleProperties {
   /**
    * Refuse what this simulation does not model, naming the property.
    *
-   * A rule `RoleArn` and rule tags are both refused by simulated EventBridge
-   * itself, so they are left to it rather than repeated here. What is refused
-   * here is what only the template can say.
+   * Both are asked by key rather than by value, so a template writing `null`
+   * for one is refused rather than read as having left it out.
    */
   refuseUnsimulated(): void {
-    const roleArn = this.properties.get("RoleArn");
-
-    if (roleArn !== undefined) {
+    if (this.properties.has("RoleArn")) {
       throw this.propertyError(
         "RoleArn is not simulated, so the Resource is refused rather than " +
           "deployed without it: a rule reaches its target as the EventBridge " +
           "service principal, admitted by the target's own resource policy",
+      );
+    }
+
+    // Rule tags never reach PutRule, which is the one place that would
+    // otherwise refuse them, so a tagged rule would deploy and quietly lose
+    // its tags.
+    if (this.properties.has("Tags")) {
+      throw this.propertyError(
+        "Tags are not simulated, so the Resource is refused rather than " +
+          "deployed without them",
       );
     }
   }

--- a/src/service/eventbridge/cfn/rule/sim-cfn-event-rule-targets.ts
+++ b/src/service/eventbridge/cfn/rule/sim-cfn-event-rule-targets.ts
@@ -1,0 +1,106 @@
+import { isRecord } from "../../../../util/type-guard/record.js";
+import type { SimCfnTemplateValue } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+
+/**
+ * One target of a rule, as this simulation takes it.
+ */
+export interface SimCfnEventRuleTarget {
+  readonly Id: string;
+  readonly Arn: string;
+  readonly Input?: string | undefined;
+}
+
+/**
+ * What a template can say about a target that this simulation does not model.
+ *
+ * `InputPath` and `InputTransformer` are the two most likely to be reached for,
+ * and the two whose absence would be least visible: a target receiving the
+ * whole event when the template asked for one field of it looks like it worked.
+ */
+const unsimulatedTargetProperties: readonly (readonly [string, string])[] = [
+  ["InputPath", "a target receives the whole event or its fixed Input"],
+  ["InputTransformer", "a target receives the whole event or its fixed Input"],
+  ["RoleArn", "a rule reaches its target as the EventBridge service principal"],
+  ["DeadLetterConfig", "a failed delivery is recorded rather than sent on"],
+  ["RetryPolicy", "a delivery is attempted once"],
+  ["SqsParameters", "a FIFO queue target is not simulated"],
+  ["KinesisParameters", "Kinesis is not a simulated target"],
+  ["EcsParameters", "ECS is not a simulated target"],
+  ["BatchParameters", "Batch is not a simulated target"],
+  ["HttpParameters", "an API destination is not a simulated target"],
+  ["RunCommandParameters", "Run Command is not a simulated target"],
+  ["RedshiftDataParameters", "Redshift is not a simulated target"],
+  ["SageMakerPipelineParameters", "SageMaker is not a simulated target"],
+  ["AppSyncParameters", "AppSync is not a simulated target"],
+];
+
+/**
+ * Read one entry of a rule's inline `Targets` list.
+ *
+ * A property this simulation gives no behaviour to is refused naming itself,
+ * rather than the target being created without it, so a rule that would not
+ * behave as written fails the deployment instead of quietly under-delivering.
+ */
+function readTarget(
+  target: unknown,
+  refuse: (reason: string) => Error,
+): SimCfnEventRuleTarget {
+  if (!isRecord(target)) {
+    throw refuse("each entry of Targets is an object");
+  }
+
+  // Read as a set of the keys the template wrote, rather than by looking each
+  // one up on the target, so the property names stay data.
+  const declared = new Set(Object.keys(target));
+
+  for (const [property, reason] of unsimulatedTargetProperties) {
+    if (declared.has(property)) {
+      throw refuse(
+        `target ${property} is not simulated, so the Resource is refused ` +
+          `rather than deployed without it: ${reason}`,
+      );
+    }
+  }
+
+  const id = target["Id"];
+
+  if (typeof id !== "string" || id === "") {
+    throw refuse("each entry of Targets needs an Id");
+  }
+
+  const arn = target["Arn"];
+
+  if (typeof arn !== "string" || arn === "") {
+    throw refuse(`target ${id} needs an Arn`);
+  }
+
+  const input = target["Input"];
+
+  if (input !== undefined && typeof input !== "string") {
+    throw refuse(`target ${id} Input must be a string of JSON`);
+  }
+
+  return { Id: id, Arn: arn, Input: input };
+}
+
+/**
+ * Read a rule's inline `Targets` list.
+ *
+ * A rule with no targets is a rule that matches events and sends them nowhere,
+ * which real EventBridge lets you have, so an absent list is none rather than a
+ * refusal.
+ */
+export function simCfnEventRuleTargets(
+  targets: SimCfnTemplateValue | undefined,
+  refuse: (reason: string) => Error,
+): readonly SimCfnEventRuleTarget[] {
+  if (targets === undefined) {
+    return [];
+  }
+
+  if (!Array.isArray(targets)) {
+    throw refuse("Targets is a list");
+  }
+
+  return targets.map((target) => readTarget(target, refuse));
+}

--- a/src/service/eventbridge/cfn/sim-cfn-event-bridge-resource-deleter.ts
+++ b/src/service/eventbridge/cfn/sim-cfn-event-bridge-resource-deleter.ts
@@ -1,0 +1,87 @@
+import type { SimCfnResource } from "../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimEventBridge } from "../sim-event-bridge.js";
+import { SimCfnEventBusProperties } from "./bus/sim-cfn-event-bus-properties.js";
+import { SimCfnEventRuleProperties } from "./rule/sim-cfn-event-rule-properties.js";
+
+interface SimCfnEventBridgeResourceDeleterProperties {
+  readonly eventBridge: SimEventBridge;
+}
+
+/**
+ * Deletes the simulated EventBridge resources a CloudFormation Stack created.
+ *
+ * A rule needs no separate teardown for its targets, since DeleteRule takes a
+ * rule's targets with it here, and deleting a bus takes its rules. A teardown
+ * reaches them in dependency order anyway, so both are usually already gone by
+ * the time the bus is deleted, and both commands are content to be asked twice.
+ */
+export class SimCfnEventBridgeResourceDeleter {
+  private readonly eventBridge: SimEventBridge;
+
+  constructor(properties: SimCfnEventBridgeResourceDeleterProperties) {
+    this.eventBridge = properties.eventBridge;
+  }
+
+  /**
+   * Delete one simulated EventBridge Resource.
+   */
+  async delete(
+    resourceTypeName: string,
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): Promise<void> {
+    switch (resourceTypeName) {
+      case "EventBus": {
+        await this.deleteBus(resource, properties);
+        return;
+      }
+      case "Rule": {
+        await this.deleteRule(resource, properties);
+        return;
+      }
+      default: {
+        throw new Error(
+          `Unsupported sim EventBridge CloudFormation Resource ${
+            resourceTypeName
+          }`,
+        );
+      }
+    }
+  }
+
+  /**
+   * Delete the bus a Resource created, and the rules that hang off it.
+   */
+  private async deleteBus(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): Promise<void> {
+    const name = new SimCfnEventBusProperties({
+      resource,
+      properties,
+    }).name();
+
+    await this.eventBridge.deleteEventBus({ input: { Name: name } });
+  }
+
+  /**
+   * Delete the rule a Resource created, and its targets with it.
+   */
+  private async deleteRule(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): Promise<void> {
+    const ruleProperties = new SimCfnEventRuleProperties({
+      resource,
+      properties,
+    });
+
+    await this.eventBridge.deleteRule({
+      input: {
+        Name: ruleProperties.name(),
+        EventBusName: ruleProperties.busName(),
+      },
+    });
+  }
+}

--- a/src/service/eventbridge/cfn/sim-cfn-event-bridge-resource-error.ts
+++ b/src/service/eventbridge/cfn/sim-cfn-event-bridge-resource-error.ts
@@ -1,0 +1,54 @@
+import { SimEventBridgeError } from "../error/sim-event-bridge.error.js";
+
+/**
+ * Build the error a Resource of a simulated EventBridge type is refused with.
+ *
+ * The wording is deliberate. Sim CloudFormation reads an error saying a
+ * Resource is unsupported as one to record and step over, and stepping over a
+ * rule that cannot be created as the template asked for it is the wrong
+ * answer: the Stack would look deployed while nothing routed anywhere. So a
+ * refusal here says the Resource is invalid.
+ */
+export function simCfnEventBridgeResourceError(
+  resourceType: string,
+  logicalId: string,
+  reason: string,
+  cause?: unknown,
+): Error {
+  return new Error(`Invalid ${resourceType} Resource ${logicalId}: ${reason}`, {
+    cause,
+  });
+}
+
+/**
+ * Run the simulated EventBridge commands one Resource is made of, naming the
+ * Resource in whatever they refuse.
+ *
+ * Every Resource type here goes through the ordinary EventBridge commands, so
+ * what a template may ask for is decided once, by simulated EventBridge, rather
+ * than again in the CloudFormation layer. What that leaves out is where the
+ * request came from: a deployment failing with `Rule tags are not simulated`
+ * says nothing about which Resource asked for it. Only EventBridge's own errors
+ * are renamed, so a refusal the CloudFormation layer decided keeps the wording
+ * it was written with.
+ */
+export async function simCfnEventBridgeResourceCreation<T>(
+  resourceType: string,
+  logicalId: string,
+  create: () => Promise<T>,
+): Promise<T> {
+  try {
+    return await create();
+  } catch (error) {
+    if (error instanceof SimEventBridgeError) {
+      throw simCfnEventBridgeResourceError(
+        resourceType,
+        logicalId,
+        error.message,
+        error,
+      );
+    }
+
+    throw error;
+  }
+}

--- a/src/service/eventbridge/cfn/sim-cfn-event-bridge-resource-types.ts
+++ b/src/service/eventbridge/cfn/sim-cfn-event-bridge-resource-types.ts
@@ -1,0 +1,10 @@
+/**
+ * The CloudFormation Resource types simulated EventBridge creates.
+ *
+ * Named here rather than spelled out where they are used, because each one is
+ * written twice: once by the factory dispatching on it, and once by the
+ * refusals that quote it back to whoever wrote the template.
+ */
+export const eventBusResourceType = "AWS::Events::EventBus";
+
+export const eventRuleResourceType = "AWS::Events::Rule";

--- a/src/service/eventbridge/cfn/sim-cfn-event-bridge-rule.iso.test.ts
+++ b/src/service/eventbridge/cfn/sim-cfn-event-bridge-rule.iso.test.ts
@@ -1,0 +1,281 @@
+import { PutEventsCommand } from "@aws-sdk/client-eventbridge";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import { makeLambdaZipFileInput } from "../../lambda/index.js";
+
+const orderPattern = { source: ["orders.service"] };
+
+/**
+ * A simulation with a function to target, recording what it is invoked with.
+ */
+async function simAwsWithFunction(): Promise<{
+  readonly simAws: SimAws;
+  readonly received: unknown[];
+}> {
+  const simAws = new SimAws();
+  const received: unknown[] = [];
+
+  await simAws.lambda().createFunction({
+    input: {
+      FunctionName: "fulfilment",
+      Role: "arn:aws:iam::888888888888:role/FulfilmentRole",
+      Code: {
+        ZipFile: makeLambdaZipFileInput((event: unknown) => {
+          received.push(event);
+          return { ok: true };
+        }),
+      },
+    },
+  });
+
+  return { simAws, received };
+}
+
+/**
+ * Put one order event and wait for what it caused.
+ */
+async function putOrder(simAws: SimAws): Promise<void> {
+  await simAws.eventBridge().putEvents(
+    new PutEventsCommand({
+      Entries: [
+        {
+          Source: "orders.service",
+          DetailType: "OrderPlaced",
+          Detail: JSON.stringify({ orderId: "order-1" }),
+        },
+      ],
+    }),
+  );
+
+  await simAws.backgroundTasksComplete();
+}
+
+describe("EventBridge CloudFormation Rule deployment", () => {
+  it("deploys a rule whose target a matching event reaches", async () => {
+    // Given a template with a rule targeting a function, and the permission
+    // CDK emits alongside it.
+    const { simAws, received } = await simAwsWithFunction();
+
+    await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: {
+        Resources: {
+          OrdersRule: {
+            Type: "AWS::Events::Rule",
+            Properties: {
+              Name: "orders",
+              EventPattern: orderPattern,
+              State: "ENABLED",
+              Targets: [
+                {
+                  Id: "fulfilment",
+                  Arn: "arn:aws:lambda:us-east-1:888888888888:function:fulfilment",
+                },
+              ],
+            },
+          },
+          PermissionForEventsToInvokeLambda: {
+            Type: "AWS::Lambda::Permission",
+            Properties: {
+              FunctionName: "fulfilment",
+              Action: "lambda:InvokeFunction",
+              Principal: "events.amazonaws.com",
+              SourceArn: { "Fn::GetAtt": ["OrdersRule", "Arn"] },
+            },
+          },
+        },
+      },
+    });
+
+    // When a matching event is put, with no further SDK setup.
+    await putOrder(simAws);
+
+    // Then the function ran, so the rule and its target were both deployed.
+    assertArrayLength(received, 1);
+  });
+
+  it("resolves a target ARN from Fn::GetAtt in the same template", async () => {
+    // Given a template whose rule targets a queue it also declares.
+    const simAws = new SimAws();
+
+    await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: {
+        Resources: {
+          OrdersQueue: {
+            Type: "AWS::SQS::Queue",
+            Properties: { QueueName: "orders" },
+          },
+          OrdersRule: {
+            Type: "AWS::Events::Rule",
+            Properties: {
+              Name: "orders",
+              EventPattern: orderPattern,
+              Targets: [
+                {
+                  Id: "orders-queue",
+                  Arn: { "Fn::GetAtt": ["OrdersQueue", "Arn"] },
+                },
+              ],
+            },
+          },
+        },
+      },
+    });
+
+    // Then the target carries the queue's real ARN rather than the intrinsic.
+    const [target] = simAws.eventBridge().ruleTargets("orders");
+
+    assertNonNullable(target);
+    assertIdentical(
+      target.arn.value,
+      "arn:aws:sqs:us-east-1:888888888888:orders",
+    );
+  });
+
+  it("attaches a rule to a bus the same template creates", async () => {
+    // Given a template with a bus and a rule that Refs it.
+    const simAws = new SimAws();
+
+    await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: {
+        Resources: {
+          OrdersBus: {
+            Type: "AWS::Events::EventBus",
+            Properties: { Name: "orders" },
+          },
+          OrdersRule: {
+            Type: "AWS::Events::Rule",
+            Properties: {
+              Name: "orders",
+              EventBusName: { Ref: "OrdersBus" },
+              EventPattern: orderPattern,
+            },
+          },
+        },
+      },
+    });
+
+    // Then the rule is on that bus, because Ref on a bus is its name rather
+    // than its ARN, which is what makes it usable as an EventBusName.
+    assertNonNullable(simAws.eventBridge().findRule("orders", "orders"));
+    assertUndefined(simAws.eventBridge().findRule("orders"));
+  });
+
+  it("names an unnamed rule after the stack and logical id", async () => {
+    // Given a rule the template does not name.
+    const simAws = new SimAws();
+
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: {
+        Resources: {
+          OrdersRule: {
+            Type: "AWS::Events::Rule",
+            Properties: { EventPattern: orderPattern },
+          },
+        },
+      },
+    });
+
+    await stack.waitForDeployComplete();
+
+    // Then it got a generated name, as real CloudFormation gives one, rather
+    // than being named after its logical ID alone.
+    const listed = await simAws.eventBridge().listRules({ input: {} });
+    const [rule] = listed.Rules ?? [];
+
+    assertNonNullable(rule);
+    assertStringIncludes(rule.Name, "orders-stack");
+    assertStringIncludes(rule.Name, "OrdersRule");
+  });
+
+  it("refuses a target property it does not model, naming it", async () => {
+    // Given a rule whose target asks for an input transformer.
+    const simAws = new SimAws();
+
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.cloudFormation().deployTemplate({
+        stackName: "orders-stack",
+        template: {
+          Resources: {
+            OrdersRule: {
+              Type: "AWS::Events::Rule",
+              Properties: {
+                Name: "orders",
+                EventPattern: orderPattern,
+                Targets: [
+                  {
+                    Id: "fulfilment",
+                    Arn: "arn:aws:sqs:us-east-1:888888888888:orders",
+                    InputTransformer: {
+                      InputTemplate: '{"id": <id>}',
+                      InputPathsMap: { id: "$.detail.orderId" },
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        },
+      });
+    });
+
+    // Then the deployment failed naming the property, rather than deploying a
+    // rule that sends the whole event where one field was asked for.
+    assertStringIncludes(error.message, "InputTransformer");
+    assertStringIncludes(error.message, "OrdersRule");
+  });
+
+  it("removes the rules and targets a stack created", async () => {
+    // Given a deployed stack with a rule and a target.
+    const simAws = new SimAws();
+
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: {
+        Resources: {
+          OrdersBus: {
+            Type: "AWS::Events::EventBus",
+            Properties: { Name: "orders" },
+          },
+          OrdersRule: {
+            Type: "AWS::Events::Rule",
+            Properties: {
+              Name: "orders",
+              EventBusName: { Ref: "OrdersBus" },
+              EventPattern: orderPattern,
+              Targets: [
+                {
+                  Id: "orders-queue",
+                  Arn: "arn:aws:sqs:us-east-1:888888888888:orders",
+                },
+              ],
+            },
+          },
+        },
+      },
+    });
+
+    await stack.waitForDeployComplete();
+
+    // When the stack is torn down.
+    await stack.teardown();
+    await simAws.backgroundTasksComplete();
+
+    // Then the bus, the rule and the targets are all gone.
+    assertUndefined(simAws.eventBridge().findEventBus("orders"));
+    assertUndefined(simAws.eventBridge().findRule("orders", "orders"));
+    assertArrayLength(simAws.eventBridge().ruleTargets("orders", "orders"), 0);
+  });
+});

--- a/src/service/eventbridge/cfn/sim-cfn-event-bridge-rule.iso.test.ts
+++ b/src/service/eventbridge/cfn/sim-cfn-event-bridge-rule.iso.test.ts
@@ -65,7 +65,7 @@ describe("EventBridge CloudFormation Rule deployment", () => {
     // CDK emits alongside it.
     const { simAws, received } = await simAwsWithFunction();
 
-    await simAws.cloudFormation().deployTemplate({
+    const stack = await simAws.cloudFormation().deployTemplate({
       stackName: "orders-stack",
       template: {
         Resources: {
@@ -96,6 +96,8 @@ describe("EventBridge CloudFormation Rule deployment", () => {
       },
     });
 
+    await stack.waitForDeployComplete();
+
     // When a matching event is put, with no further SDK setup.
     await putOrder(simAws);
 
@@ -107,7 +109,7 @@ describe("EventBridge CloudFormation Rule deployment", () => {
     // Given a template whose rule targets a queue it also declares.
     const simAws = new SimAws();
 
-    await simAws.cloudFormation().deployTemplate({
+    const stack = await simAws.cloudFormation().deployTemplate({
       stackName: "orders-stack",
       template: {
         Resources: {
@@ -132,6 +134,8 @@ describe("EventBridge CloudFormation Rule deployment", () => {
       },
     });
 
+    await stack.waitForDeployComplete();
+
     // Then the target carries the queue's real ARN rather than the intrinsic.
     const [target] = simAws.eventBridge().ruleTargets("orders");
 
@@ -146,7 +150,7 @@ describe("EventBridge CloudFormation Rule deployment", () => {
     // Given a template with a bus and a rule that Refs it.
     const simAws = new SimAws();
 
-    await simAws.cloudFormation().deployTemplate({
+    const stack = await simAws.cloudFormation().deployTemplate({
       stackName: "orders-stack",
       template: {
         Resources: {
@@ -165,6 +169,8 @@ describe("EventBridge CloudFormation Rule deployment", () => {
         },
       },
     });
+
+    await stack.waitForDeployComplete();
 
     // Then the rule is on that bus, because Ref on a bus is its name rather
     // than its ARN, which is what makes it usable as an EventBusName.
@@ -205,7 +211,7 @@ describe("EventBridge CloudFormation Rule deployment", () => {
     const simAws = new SimAws();
 
     const error = await assertThrowsErrorAsync(async () => {
-      await simAws.cloudFormation().deployTemplate({
+      const stack = await simAws.cloudFormation().deployTemplate({
         stackName: "orders-stack",
         template: {
           Resources: {
@@ -229,12 +235,67 @@ describe("EventBridge CloudFormation Rule deployment", () => {
           },
         },
       });
+
+      await stack.waitForDeployComplete();
     });
 
     // Then the deployment failed naming the property, rather than deploying a
     // rule that sends the whole event where one field was asked for.
     assertStringIncludes(error.message, "InputTransformer");
     assertStringIncludes(error.message, "OrdersRule");
+  });
+
+  it("refuses rule tags rather than deploying without them", async () => {
+    // Given a tagged rule. Tags reach no EventBridge command, so nothing else
+    // would notice them going missing.
+    const simAws = new SimAws();
+
+    const error = await assertThrowsErrorAsync(async () => {
+      const stack = await simAws.cloudFormation().deployTemplate({
+        stackName: "orders-stack",
+        template: {
+          Resources: {
+            OrdersRule: {
+              Type: "AWS::Events::Rule",
+              Properties: {
+                Name: "orders",
+                EventPattern: orderPattern,
+                Tags: [{ Key: "team", Value: "orders" }],
+              },
+            },
+          },
+        },
+      });
+
+      await stack.waitForDeployComplete();
+    });
+
+    assertStringIncludes(error.message, "Tags");
+  });
+
+  it("refuses a bus property written as null", async () => {
+    // Given a template writing null for a property that is not simulated,
+    // which is a value rather than an absence.
+    const simAws = new SimAws();
+
+    const error = await assertThrowsErrorAsync(async () => {
+      const stack = await simAws.cloudFormation().deployTemplate({
+        stackName: "orders-stack",
+        template: {
+          Resources: {
+            OrdersBus: {
+              Type: "AWS::Events::EventBus",
+              Properties: { Name: "orders", Policy: null },
+            },
+          },
+        },
+      });
+
+      await stack.waitForDeployComplete();
+    });
+
+    // Then it is refused, rather than read as having left the policy out.
+    assertStringIncludes(error.message, "Policy");
   });
 
   it("removes the rules and targets a stack created", async () => {

--- a/src/service/eventbridge/cfn/sim-cfn-event-bridge-values.iso.test.ts
+++ b/src/service/eventbridge/cfn/sim-cfn-event-bridge-values.iso.test.ts
@@ -1,0 +1,110 @@
+import { assertIdentical, assertStringIncludes } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import type { CfnTemplateBodyRecord } from "../../cloudformation/template/sim-cfn-template.js";
+
+/**
+ * Deploy one template and read back what its Outputs resolved to.
+ */
+async function outputsOf(
+  template: CfnTemplateBodyRecord,
+): Promise<ReadonlyMap<string, unknown>> {
+  const simAws = new SimAws();
+  const stack = await simAws
+    .cloudFormation()
+    .deployTemplate({ stackName: "orders-stack", template });
+
+  await stack.waitForDeployComplete();
+
+  return new Map(
+    stack.outputs.entries().map(([name, output]) => [name, output.value]),
+  );
+}
+
+describe("EventBridge CloudFormation Ref and Fn::GetAtt", () => {
+  it("answers a bus Ref with its name and GetAtt with its ARN", async () => {
+    // Given a template outputting every value a bus offers.
+    const outputs = await outputsOf({
+      Resources: {
+        OrdersBus: {
+          Type: "AWS::Events::EventBus",
+          Properties: { Name: "orders" },
+        },
+      },
+      Outputs: {
+        BusRef: { Value: { Ref: "OrdersBus" } },
+        BusArn: { Value: { "Fn::GetAtt": ["OrdersBus", "Arn"] } },
+        BusName: { Value: { "Fn::GetAtt": ["OrdersBus", "Name"] } },
+      },
+    });
+
+    // Then Ref is the name rather than the ARN, which is what makes it usable
+    // straight away as another Resource's EventBusName.
+    assertIdentical(outputs.get("BusRef"), "orders");
+    assertIdentical(
+      outputs.get("BusArn"),
+      "arn:aws:events:us-east-1:888888888888:event-bus/orders",
+    );
+    assertIdentical(outputs.get("BusName"), "orders");
+  });
+
+  it("answers a rule Ref with its name and GetAtt with its ARN", async () => {
+    // Given a template outputting both of a rule's values.
+    const outputs = await outputsOf({
+      Resources: {
+        OrdersRule: {
+          Type: "AWS::Events::Rule",
+          Properties: {
+            Name: "orders",
+            EventPattern: { source: ["orders.service"] },
+          },
+        },
+      },
+      Outputs: {
+        RuleRef: { Value: { Ref: "OrdersRule" } },
+        RuleArn: { Value: { "Fn::GetAtt": ["OrdersRule", "Arn"] } },
+      },
+    });
+
+    // Then Ref is the rule name, and only Fn::GetAtt gives the ARN an
+    // AWS::Lambda::Permission SourceArn needs.
+    assertIdentical(outputs.get("RuleRef"), "orders");
+    assertIdentical(
+      outputs.get("RuleArn"),
+      "arn:aws:events:us-east-1:888888888888:rule/orders",
+    );
+  });
+
+  it("answers a schedule Ref with its name and GetAtt with its ARN", async () => {
+    // Given a template outputting both of a schedule's values.
+    const outputs = await outputsOf({
+      Resources: {
+        HourlyReport: {
+          Type: "AWS::Scheduler::Schedule",
+          Properties: {
+            Name: "hourly-report",
+            ScheduleExpression: "rate(1 hour)",
+            FlexibleTimeWindow: { Mode: "OFF" },
+            Target: {
+              Arn: "arn:aws:sqs:us-east-1:888888888888:reports",
+              RoleArn: "arn:aws:iam::888888888888:role/SchedulerRole",
+            },
+          },
+        },
+      },
+      Outputs: {
+        ScheduleRef: { Value: { Ref: "HourlyReport" } },
+        ScheduleArn: { Value: { "Fn::GetAtt": ["HourlyReport", "Arn"] } },
+      },
+    });
+
+    // Then the ARN carries the schedule group, which a schedule ARN always
+    // does even for the default group.
+    assertIdentical(outputs.get("ScheduleRef"), "hourly-report");
+    assertStringIncludes(
+      String(outputs.get("ScheduleArn")),
+      "schedule/default/hourly-report",
+    );
+  });
+});

--- a/src/service/eventbridge/cfn/sim-event-bridge-cfn-resource-factory.ts
+++ b/src/service/eventbridge/cfn/sim-event-bridge-cfn-resource-factory.ts
@@ -1,0 +1,82 @@
+import type { SimCfnServiceResourceFactory } from "../../cloudformation/resource/factory/sim-cfn-resource-factory.type.js";
+import type {
+  SimCfnResource,
+  SimCloudFormationResourceCreateContext,
+} from "../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCloudFormationResourceDeleteContext } from "../../cloudformation/resource/sim-cfn-resource.type.js";
+import type { SimEventBridge } from "../sim-event-bridge.js";
+import { SimCfnEventBusCreator } from "./bus/sim-cfn-event-bus-creator.js";
+import { SimCfnEventRuleCreator } from "./rule/sim-cfn-event-rule-creator.js";
+import { SimCfnEventBridgeResourceDeleter } from "./sim-cfn-event-bridge-resource-deleter.js";
+
+interface SimEventBridgeCfnResourceFactoryProperties {
+  readonly eventBridge: SimEventBridge;
+}
+
+/**
+ * CloudFormation Resource factory for simulated EventBridge resources.
+ */
+export class SimEventBridgeCfnResourceFactory implements SimCfnServiceResourceFactory {
+  private readonly busCreator: SimCfnEventBusCreator;
+  private readonly ruleCreator: SimCfnEventRuleCreator;
+  private readonly deleter: SimCfnEventBridgeResourceDeleter;
+
+  constructor(properties: SimEventBridgeCfnResourceFactoryProperties) {
+    this.busCreator = new SimCfnEventBusCreator({
+      eventBridge: properties.eventBridge,
+    });
+    this.ruleCreator = new SimCfnEventRuleCreator({
+      eventBridge: properties.eventBridge,
+    });
+    this.deleter = new SimCfnEventBridgeResourceDeleter({
+      eventBridge: properties.eventBridge,
+    });
+  }
+
+  /**
+   * Create a simulated EventBridge resource from a CloudFormation Resource.
+   *
+   * The bus and the rule are the AWS::Events::* Resource types this simulation
+   * models. Anything else is reported as unsupported and skipped rather than
+   * quietly treated as deployed.
+   */
+  async create(
+    resourceTypeName: string,
+    resource: SimCfnResource,
+    context: SimCloudFormationResourceCreateContext,
+  ): Promise<object | undefined> {
+    const properties = context.resolvedProperties ?? resource.properties;
+
+    switch (resourceTypeName) {
+      case "EventBus": {
+        return await this.busCreator.create(resource, properties);
+      }
+      case "Rule": {
+        return await this.ruleCreator.create(resource, properties);
+      }
+      default: {
+        throw new Error(
+          `Unsupported sim EventBridge CloudFormation Resource ${
+            resourceTypeName
+          }`,
+        );
+      }
+    }
+  }
+
+  /**
+   * Delete a simulated EventBridge resource created from a CloudFormation
+   * Resource.
+   */
+  async delete(
+    resourceTypeName: string,
+    resource: SimCfnResource,
+    context: SimCloudFormationResourceDeleteContext,
+  ): Promise<void> {
+    await this.deleter.delete(
+      resourceTypeName,
+      resource,
+      context.resolvedProperties ?? resource.properties,
+    );
+  }
+}

--- a/src/service/eventbridge/sim-event-bridge.ts
+++ b/src/service/eventbridge/sim-event-bridge.ts
@@ -18,6 +18,7 @@ import { SimEventRuleStore } from "./rule/sim-event-rule-store.js";
 import { SimEventTargetStore } from "./target/sim-event-target-store.js";
 import type { SimEventBridgeDeliveryTargets } from "./delivery/sim-event-bridge-delivery.js";
 import type { SimEventBridgeDeliveryFailure } from "./delivery/sim-event-bridge-delivery-failures.js";
+import { SimEventBridgeCfnResourceFactory } from "./cfn/sim-event-bridge-cfn-resource-factory.js";
 import { SimEventBridgeSdkCommandRouter } from "./sdk/sim-event-bridge-sdk-command-router.js";
 import { SimEventBridgeInspection } from "./sim-event-bridge-inspection.js";
 
@@ -55,6 +56,9 @@ export class SimEventBridge extends SimEventBridgeInspection {
   private readonly commands: SimEventBridgeCommands;
   private readonly background: BackgroundScheduler;
   private readonly sdkRouter = new SimEventBridgeSdkCommandRouter(this);
+  private readonly cfnFactory = new SimEventBridgeCfnResourceFactory({
+    eventBridge: this,
+  });
 
   constructor(properties: SimEventBridgeProperties = {}) {
     super();
@@ -271,5 +275,12 @@ export class SimEventBridge extends SimEventBridgeInspection {
    */
   sdkCommandRouter(): SimSdkCommandRouter {
     return this.sdkRouter;
+  }
+
+  /**
+   * Get this service's CloudFormation Resource factory.
+   */
+  cfnResourceFactory(): SimEventBridgeCfnResourceFactory {
+    return this.cfnFactory;
   }
 }

--- a/src/service/scheduler/cfn/sim-cfn-schedule-properties.ts
+++ b/src/service/scheduler/cfn/sim-cfn-schedule-properties.ts
@@ -1,0 +1,164 @@
+import { isRecord } from "../../../util/type-guard/record.js";
+import { SimCfnGeneratedResourceName } from "../../cloudformation/resource/name/sim-cfn-generated-resource-name.js";
+import type { SimCfnResource } from "../../cloudformation/resource/sim-cfn-resource.js";
+import type {
+  SimCfnTemplateValue,
+  SimCfnTemplateValueRecord,
+} from "../../cloudformation/template/value/sim-cfn-template-value.js";
+import type {
+  SimSchedulerFlexibleTimeWindow,
+  SimSchedulerRequestTarget,
+  SimSchedulerScheduleInput,
+} from "../command/schedule/schedule.command.js";
+import { simCfnSchedulerResourceError } from "./sim-cfn-scheduler-resource-error.js";
+
+const maximumNameLength = 64;
+
+/**
+ * Reads AWS::Scheduler::Schedule properties into the shape CreateSchedule
+ * takes.
+ *
+ * Nearly everything lines up one to one with the API, so this is mostly reading
+ * and type checking. What it does not pass through is refused by simulated
+ * Scheduler itself rather than here, which keeps one answer to what a schedule
+ * may ask for however it was created.
+ */
+export class SimCfnScheduleProperties {
+  private readonly resource: SimCfnResource;
+  private readonly properties: ReadonlyMap<string, SimCfnTemplateValue>;
+
+  constructor(properties: {
+    readonly resource: SimCfnResource;
+    readonly properties: SimCfnTemplateValueRecord;
+  }) {
+    this.resource = properties.resource;
+    this.properties = new Map(Object.entries(properties.properties));
+  }
+
+  /**
+   * The schedule name.
+   *
+   * An unnamed schedule is named after the stack and the logical ID, as real
+   * CloudFormation names one.
+   */
+  name(): string {
+    const name = this.properties.get("Name");
+
+    if (name === undefined) {
+      return new SimCfnGeneratedResourceName({
+        stackName: this.resource.stackName,
+        logicalId: this.resource.logicalId,
+        maximumLength: maximumNameLength,
+      }).value;
+    }
+
+    if (typeof name !== "string") {
+      throw this.propertyError("Name must be a string");
+    }
+
+    return name;
+  }
+
+  /**
+   * Everything CreateSchedule takes, read out of the template.
+   *
+   * Dates arrive as strings in a template and as `Date` values through the SDK,
+   * so they are read here into what the command expects. Simulated Scheduler
+   * refuses both of them, and refusing a well-formed date is a better answer
+   * than refusing it for being the wrong type.
+   */
+  scheduleInput(): SimSchedulerScheduleInput {
+    return {
+      Name: this.name(),
+      GroupName: this.stringProperty("GroupName"),
+      ScheduleExpression: this.stringProperty("ScheduleExpression"),
+      ScheduleExpressionTimezone: this.stringProperty(
+        "ScheduleExpressionTimezone",
+      ),
+      FlexibleTimeWindow: this.flexibleTimeWindow(),
+      Target: this.target(),
+      State: this.stringProperty("State"),
+      Description: this.stringProperty("Description"),
+      ActionAfterCompletion: this.stringProperty("ActionAfterCompletion"),
+      StartDate: this.dateProperty("StartDate"),
+      EndDate: this.dateProperty("EndDate"),
+      KmsKeyArn: this.stringProperty("KmsKeyArn"),
+    };
+  }
+
+  /**
+   * The time window, which AWS requires on this Resource type.
+   */
+  private flexibleTimeWindow(): SimSchedulerFlexibleTimeWindow | undefined {
+    const window = this.properties.get("FlexibleTimeWindow");
+
+    if (window === undefined) {
+      return undefined;
+    }
+
+    if (!isRecord(window)) {
+      throw this.propertyError("FlexibleTimeWindow is an object");
+    }
+
+    return {
+      Mode: typeof window["Mode"] === "string" ? window["Mode"] : undefined,
+      MaximumWindowInMinutes:
+        typeof window["MaximumWindowInMinutes"] === "number"
+          ? window["MaximumWindowInMinutes"]
+          : undefined,
+    };
+  }
+
+  /**
+   * The schedule's target, which AWS requires on this Resource type.
+   *
+   * Everything the target carries is handed to simulated Scheduler as it was
+   * written, including the properties it refuses, so a template asking for a
+   * dead letter queue is refused by the one place that knows it is unmodelled.
+   */
+  private target(): SimSchedulerRequestTarget | undefined {
+    const target = this.properties.get("Target");
+
+    if (target === undefined) {
+      return undefined;
+    }
+
+    if (!isRecord(target)) {
+      throw this.propertyError("Target is an object");
+    }
+
+    return target;
+  }
+
+  private dateProperty(name: string): Date | undefined {
+    const value = this.properties.get(name);
+
+    if (value === undefined) {
+      return undefined;
+    }
+
+    if (typeof value !== "string") {
+      throw this.propertyError(`${name} must be a string`);
+    }
+
+    return new Date(value);
+  }
+
+  private stringProperty(name: string): string | undefined {
+    const value = this.properties.get(name);
+
+    if (value === undefined) {
+      return undefined;
+    }
+
+    if (typeof value !== "string") {
+      throw this.propertyError(`${name} must be a string`);
+    }
+
+    return value;
+  }
+
+  private propertyError(reason: string): Error {
+    return simCfnSchedulerResourceError(this.resource.logicalId, reason);
+  }
+}

--- a/src/service/scheduler/cfn/sim-cfn-scheduler-resource-error.ts
+++ b/src/service/scheduler/cfn/sim-cfn-scheduler-resource-error.ts
@@ -1,0 +1,49 @@
+import { SimSchedulerError } from "../error/sim-scheduler.error.js";
+
+/**
+ * The CloudFormation Resource type simulated Scheduler creates.
+ */
+export const schedulerScheduleResourceType = "AWS::Scheduler::Schedule";
+
+/**
+ * Build the error a Resource of a simulated Scheduler type is refused with.
+ *
+ * Sim CloudFormation reads an error saying a Resource is unsupported as one to
+ * record and step over, and stepping over a schedule that cannot be created as
+ * the template asked for it is the wrong answer: the Stack would look deployed
+ * while nothing ever fired. So a refusal here says the Resource is invalid.
+ */
+export function simCfnSchedulerResourceError(
+  logicalId: string,
+  reason: string,
+  cause?: unknown,
+): Error {
+  return new Error(
+    `Invalid ${schedulerScheduleResourceType} Resource ${logicalId}: ${reason}`,
+    { cause },
+  );
+}
+
+/**
+ * Run the simulated Scheduler commands one Resource is made of, naming the
+ * Resource in whatever they refuse.
+ *
+ * Every Resource here goes through the ordinary Scheduler commands, so what a
+ * template may ask for is decided once, by simulated Scheduler, rather than
+ * again in the CloudFormation layer. Only Scheduler's own errors are renamed,
+ * so a refusal the CloudFormation layer decided keeps its own wording.
+ */
+export async function simCfnSchedulerResourceCreation<T>(
+  logicalId: string,
+  create: () => Promise<T>,
+): Promise<T> {
+  try {
+    return await create();
+  } catch (error) {
+    if (error instanceof SimSchedulerError) {
+      throw simCfnSchedulerResourceError(logicalId, error.message, error);
+    }
+
+    throw error;
+  }
+}

--- a/src/service/scheduler/cfn/sim-cfn-scheduler-resource-lookup.ts
+++ b/src/service/scheduler/cfn/sim-cfn-scheduler-resource-lookup.ts
@@ -1,0 +1,39 @@
+import type { SimSchedulerScheduleInput } from "../command/schedule/schedule.command.js";
+import type { SimSchedulerSchedule } from "../schedule/sim-scheduler-schedule.js";
+import type { SimScheduler } from "../sim-scheduler.js";
+
+/**
+ * Find the schedule a Resource just created, in whichever group it went into.
+ *
+ * The group is left out of the lookup when the template named none, so the
+ * default the service itself picks is the one used, rather than this having a
+ * second opinion about what that default is.
+ */
+export function createdSchedule(
+  scheduler: SimScheduler,
+  input: SimSchedulerScheduleInput,
+): SimSchedulerSchedule | undefined {
+  const name = input.Name;
+
+  if (name === undefined) {
+    return undefined;
+  }
+
+  return input.GroupName === undefined
+    ? scheduler.findSchedule(name)
+    : scheduler.findSchedule(name, input.GroupName);
+}
+
+/**
+ * Refuse a Resource type this service does not create.
+ *
+ * Schedule groups are the other `AWS::Scheduler::*` type, and are reported as
+ * unsupported rather than quietly treated as deployed.
+ */
+export function refuseUnknownType(resourceTypeName: string): void {
+  if (resourceTypeName !== "Schedule") {
+    throw new Error(
+      `Unsupported sim Scheduler CloudFormation Resource ${resourceTypeName}`,
+    );
+  }
+}

--- a/src/service/scheduler/cfn/sim-cfn-scheduler-schedule.iso.test.ts
+++ b/src/service/scheduler/cfn/sim-cfn-scheduler-schedule.iso.test.ts
@@ -1,0 +1,224 @@
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimFixedClock } from "../../../util/clock/sim-clock.js";
+import { SimAws } from "../../aws/sim-aws.js";
+import { makeLambdaZipFileInput } from "../../lambda/index.js";
+import type { SimCfnTemplateValue } from "../../cloudformation/template/value/sim-cfn-template-value.js";
+
+const functionArn = "arn:aws:lambda:us-east-1:888888888888:function:report";
+
+const roleArn = "arn:aws:iam::888888888888:role/SchedulerRole";
+
+/**
+ * A simulation with a function to invoke and a role allowed to invoke it.
+ */
+async function simAwsWithRole(): Promise<{
+  readonly simAws: SimAws;
+  readonly runs: unknown[];
+}> {
+  const simAws = new SimAws({
+    clock: new SimFixedClock(new Date("2026-07-26T09:00:00.000Z")),
+  });
+  const runs: unknown[] = [];
+
+  await simAws.lambda().createFunction({
+    input: {
+      FunctionName: "report",
+      Role: "arn:aws:iam::888888888888:role/ReportRole",
+      Code: {
+        ZipFile: makeLambdaZipFileInput(() => {
+          runs.push(1);
+          return { ok: true };
+        }),
+      },
+    },
+  });
+
+  await simAws.iam().createRole(
+    new CreateRoleCommand({
+      RoleName: "SchedulerRole",
+      AssumeRolePolicyDocument: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: {
+          Effect: "Allow",
+          Principal: { Service: "scheduler.amazonaws.com" },
+          Action: "sts:AssumeRole",
+        },
+      }),
+    }),
+  );
+
+  await simAws.iam().putRolePolicy(
+    new PutRolePolicyCommand({
+      RoleName: "SchedulerRole",
+      PolicyName: "InvokeReport",
+      PolicyDocument: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: {
+          Effect: "Allow",
+          Action: "lambda:InvokeFunction",
+          Resource: functionArn,
+        },
+      }),
+    }),
+  );
+
+  return { simAws, runs };
+}
+
+/**
+ * The schedule Resource these templates declare.
+ */
+function scheduleResource(
+  properties: Record<string, SimCfnTemplateValue> = {},
+): SimCfnTemplateValue {
+  return {
+    Type: "AWS::Scheduler::Schedule",
+    Properties: {
+      Name: "hourly-report",
+      ScheduleExpression: "rate(1 hour)",
+      FlexibleTimeWindow: { Mode: "OFF" },
+      Target: { Arn: functionArn, RoleArn: roleArn },
+      ...properties,
+    },
+  };
+}
+
+describe("Scheduler CloudFormation Schedule deployment", () => {
+  it("deploys a schedule that fires as the clock advances", async () => {
+    // Given a template declaring a schedule.
+    const { simAws, runs } = await simAwsWithRole();
+
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "reporting-stack",
+      template: { Resources: { HourlyReport: scheduleResource() } },
+    });
+
+    await stack.waitForDeployComplete();
+
+    // When three simulated hours pass, with no further SDK setup.
+    await simAws.clock().advanceBy({ hours: 3 });
+
+    // Then the target ran three times, so the schedule deployed and armed.
+    assertArrayLength(runs, 3);
+  });
+
+  it("resolves the target ARN and role from the same template", async () => {
+    // Given a template whose schedule targets a queue it also declares.
+    const { simAws } = await simAwsWithRole();
+
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "reporting-stack",
+      template: {
+        Resources: {
+          ReportQueue: {
+            Type: "AWS::SQS::Queue",
+            Properties: { QueueName: "reports" },
+          },
+          HourlyReport: scheduleResource({
+            Target: {
+              Arn: { "Fn::GetAtt": ["ReportQueue", "Arn"] },
+              RoleArn: roleArn,
+            },
+          }),
+        },
+      },
+    });
+
+    await stack.waitForDeployComplete();
+
+    // Then the schedule carries the queue's real ARN.
+    const schedule = simAws.scheduler().findSchedule("hourly-report");
+
+    assertNonNullable(schedule);
+    assertIdentical(
+      schedule.target.arn.value,
+      "arn:aws:sqs:us-east-1:888888888888:reports",
+    );
+  });
+
+  it("names an unnamed schedule after the stack and logical id", async () => {
+    const { simAws } = await simAwsWithRole();
+
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "reporting-stack",
+      template: {
+        Resources: {
+          HourlyReport: {
+            Type: "AWS::Scheduler::Schedule",
+            Properties: {
+              ScheduleExpression: "rate(1 hour)",
+              FlexibleTimeWindow: { Mode: "OFF" },
+              Target: { Arn: functionArn, RoleArn: roleArn },
+            },
+          },
+        },
+      },
+    });
+
+    await stack.waitForDeployComplete();
+
+    const [schedule] = simAws.scheduler().allSchedules;
+
+    assertNonNullable(schedule);
+    assertStringIncludes(schedule.name.value, "reporting-stack");
+  });
+
+  it("refuses a property it does not model, naming the Resource", async () => {
+    // Given a schedule asking for a flexible window.
+    const { simAws } = await simAwsWithRole();
+
+    const error = await assertThrowsErrorAsync(async () => {
+      const stack = await simAws.cloudFormation().deployTemplate({
+        stackName: "reporting-stack",
+        template: {
+          Resources: {
+            HourlyReport: scheduleResource({
+              FlexibleTimeWindow: {
+                Mode: "FLEXIBLE",
+                MaximumWindowInMinutes: 15,
+              },
+            }),
+          },
+        },
+      });
+
+      await stack.waitForDeployComplete();
+    });
+
+    assertStringIncludes(error.message, "HourlyReport");
+    assertStringIncludes(error.message, "FLEXIBLE");
+  });
+
+  it("removes the schedules a stack created", async () => {
+    // Given a deployed schedule.
+    const { simAws, runs } = await simAwsWithRole();
+
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "reporting-stack",
+      template: { Resources: { HourlyReport: scheduleResource() } },
+    });
+
+    await stack.waitForDeployComplete();
+
+    // When the stack is torn down.
+    await stack.teardown();
+    await simAws.backgroundTasksComplete();
+
+    // Then it is gone, and time passing fires nothing.
+    assertUndefined(simAws.scheduler().findSchedule("hourly-report"));
+
+    await simAws.clock().advanceBy({ hours: 3 });
+
+    assertArrayLength(runs, 0);
+  });
+});

--- a/src/service/scheduler/cfn/sim-scheduler-cfn-resource-factory.ts
+++ b/src/service/scheduler/cfn/sim-scheduler-cfn-resource-factory.ts
@@ -1,0 +1,99 @@
+import { assertDefined } from "../../../util/type-guard/defined.js";
+import type { SimCfnServiceResourceFactory } from "../../cloudformation/resource/factory/sim-cfn-resource-factory.type.js";
+import type {
+  SimCfnResource,
+  SimCloudFormationResourceCreateContext,
+} from "../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCloudFormationResourceDeleteContext } from "../../cloudformation/resource/sim-cfn-resource.type.js";
+import type { SimCfnTemplateValueRecord } from "../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimScheduler } from "../sim-scheduler.js";
+import {
+  createdSchedule,
+  refuseUnknownType,
+} from "./sim-cfn-scheduler-resource-lookup.js";
+import { SimCfnScheduleProperties } from "./sim-cfn-schedule-properties.js";
+import { simCfnSchedulerResourceCreation } from "./sim-cfn-scheduler-resource-error.js";
+
+interface SimSchedulerCfnResourceFactoryProperties {
+  readonly scheduler: SimScheduler;
+}
+
+/**
+ * CloudFormation Resource factory for simulated Scheduler resources.
+ *
+ * There is one type, and the schedule goes through the ordinary CreateSchedule
+ * command rather than being constructed directly, so a schedule a template
+ * deployed is the same thing an SDK caller would have got, down to the
+ * refusals.
+ */
+export class SimSchedulerCfnResourceFactory implements SimCfnServiceResourceFactory {
+  private readonly scheduler: SimScheduler;
+
+  constructor(properties: SimSchedulerCfnResourceFactoryProperties) {
+    this.scheduler = properties.scheduler;
+  }
+
+  /**
+   * Create a simulated schedule from a CloudFormation Resource.
+   */
+  async create(
+    resourceTypeName: string,
+    resource: SimCfnResource,
+    context: SimCloudFormationResourceCreateContext,
+  ): Promise<object | undefined> {
+    refuseUnknownType(resourceTypeName);
+
+    const properties = this.read(
+      resource,
+      context.resolvedProperties ?? resource.properties,
+    );
+    const input = properties.scheduleInput();
+
+    return await simCfnSchedulerResourceCreation(
+      resource.logicalId,
+      async () => {
+        await this.scheduler.createSchedule({ input });
+
+        const schedule = createdSchedule(this.scheduler, input);
+
+        assertDefined(
+          schedule,
+          `sim Scheduler schedule ${String(input.Name)} after ` +
+            `CloudFormation creation`,
+        );
+
+        return schedule;
+      },
+    );
+  }
+
+  /**
+   * Delete the schedule a Resource created.
+   */
+  async delete(
+    resourceTypeName: string,
+    resource: SimCfnResource,
+    context: SimCloudFormationResourceDeleteContext,
+  ): Promise<void> {
+    refuseUnknownType(resourceTypeName);
+
+    const properties = this.read(
+      resource,
+      context.resolvedProperties ?? resource.properties,
+    );
+
+    await this.scheduler.deleteSchedule({
+      input: {
+        Name: properties.name(),
+        GroupName: properties.scheduleInput().GroupName,
+      },
+    });
+  }
+
+  private read(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): SimCfnScheduleProperties {
+    return new SimCfnScheduleProperties({ resource, properties });
+  }
+}

--- a/src/service/scheduler/sim-scheduler.ts
+++ b/src/service/scheduler/sim-scheduler.ts
@@ -15,6 +15,7 @@ import type { SimSchedulerDeliveryFailure } from "./delivery/sim-scheduler-deliv
 import { SimSchedulerCommands } from "./command/sim-scheduler-commands.js";
 import type { SimSchedulerRequestOptions } from "./command/sim-scheduler-request-options.js";
 import { SimSchedulerScheduleStore } from "./schedule/sim-scheduler-schedule-store.js";
+import { SimSchedulerCfnResourceFactory } from "./cfn/sim-scheduler-cfn-resource-factory.js";
 import { SimSchedulerSdkCommandRouter } from "./sdk/sim-scheduler-sdk-command-router.js";
 import { SimSchedulerInspection } from "./sim-scheduler-inspection.js";
 
@@ -49,6 +50,9 @@ export class SimScheduler extends SimSchedulerInspection {
   private readonly commands: SimSchedulerCommands;
   private readonly background: BackgroundScheduler;
   private readonly sdkRouter = new SimSchedulerSdkCommandRouter(this);
+  private readonly cfnFactory = new SimSchedulerCfnResourceFactory({
+    scheduler: this,
+  });
 
   constructor(properties: SimSchedulerProperties = {}) {
     super();
@@ -139,5 +143,12 @@ export class SimScheduler extends SimSchedulerInspection {
    */
   sdkCommandRouter(): SimSdkCommandRouter {
     return this.sdkRouter;
+  }
+
+  /**
+   * Get this service's CloudFormation Resource factory.
+   */
+  cfnResourceFactory(): SimSchedulerCfnResourceFactory {
+    return this.cfnFactory;
   }
 }


### PR DESCRIPTION
Closes #535, and with it the initial simulated EventBridge work.

Simulated CloudFormation now creates `AWS::Events::EventBus`, `AWS::Events::Rule` and `AWS::Scheduler::Schedule`, and removes them on teardown. A rule carries its `EventPattern` or `ScheduleExpression`, its `State` and its inline `Targets`, so a deployed stack routes events with no further SDK calls, and a target ARN resolved by `Fn::GetAtt` from a function or queue in the same template works as it would in a real deployment.

Every resource goes through the ordinary service commands rather than being constructed directly, following the SNS precedent. What a template may ask for is therefore decided once, by the service, rather than again in the CloudFormation layer — a rule with neither a pattern nor a schedule is refused by simulated EventBridge itself, and a `FLEXIBLE` time window by simulated Scheduler. What the CloudFormation layer decides for itself is only what a template can say and the API cannot, such as a target's `InputTransformer`.

Two details worth checking against the AWS docs, since both are easy to assume wrongly and I confirmed them at implementation time. `Ref` returns the **name** for all three types, never the ARN, so only `Fn::GetAtt ... Arn` gives an `AWS::Lambda::Permission` the `SourceArn` it needs. And a template carries `EventPattern` as a JSON object where the API takes a string, so it is written back out.

**One ripple worth a reviewer's attention.** `AWS::Events::Rule` was the codebase's canonical stand-in for an unsupported resource type, in three CloudFormation tests and three docs examples. It is not unsupported any more, so those now use `AWS::CloudWatch::Alarm`, which is not simulated and is a natural thing to find in a template. That is the bulk of the changes outside the two service directories.

Resolves https://github.com/KensioSoftware/yulin/issues/535

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added simulated CloudFormation support for EventBridge event buses and rules, including targets, references, attributes, and stack cleanup.
  * Added simulated CloudFormation support for EventBridge Scheduler schedules, including generated names, ARN resolution, timed execution, and teardown.
  * Added examples demonstrating EventBridge and Scheduler deployments.
* **Documentation**
  * Expanded service documentation with supported resource types, limitations, property behavior, and usage examples.
* **Bug Fixes**
  * Updated skipped-resource examples and expectations to use CloudWatch alarms consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->