### PR TITLE
fix: skip container image Lambda functions

### DIFF
--- a/docs/services/lambda/README.md
+++ b/docs/services/lambda/README.md
@@ -1565,6 +1565,88 @@ Two cases are skipped with a diagnostic rather than failing the stack:
   inline to `deployTemplate`, where there is no asset to publish and the staging bucket does not
   exist.
 
+### Container image functions
+
+A function with `PackageType: Image` names a container image instead of code, which is what CDK's
+`DockerImageFunction` and `lambda.DockerImageCode` synthesize. Yulin never reads an image, so there
+is nothing for it to run. The Resource is skipped with a diagnostic naming the image, and the rest
+of the stack deploys.
+
+Bind a real in-process handler to the function to simulate it. The binding replaces the image, so
+the function is created and invoked like any other. This is the same mechanism as
+[executable bindings](#executable-bindings), and it is the only way to run an image-packaged
+function.
+
+```typescript sim-lambda-container-image-function
+/**
+ * Simulating a container image Lambda function with a bound handler.
+ */
+
+import { InvokeCommand } from "@aws-sdk/client-lambda";
+
+import { SimAws } from "@kensio/yulin";
+
+const imageFunctionTemplate = {
+  Resources: {
+    OrdersFunction: {
+      Type: "AWS::Lambda::Function",
+      Properties: {
+        FunctionName: "orders",
+        Role: "arn:aws:iam::111111111111:role/OrdersRole",
+        PackageType: "Image",
+        Code: {
+          ImageUri:
+            "111111111111.dkr.ecr.eu-west-2.amazonaws.com/orders:latest",
+        },
+      },
+    },
+  },
+};
+
+// Without a binding, the function is skipped and the stack still deploys.
+const skippedSimAws = new SimAws();
+
+const skippedStack = await skippedSimAws.cloudFormation().deployTemplate({
+  stackName: "orders-stack",
+  template: imageFunctionTemplate,
+});
+
+console.log(skippedStack.getResource("OrdersFunction")?.skippedReason);
+
+await skippedSimAws.backgroundTasksComplete();
+
+// With a binding, the handler replaces the image and the function runs.
+const simAws = new SimAws();
+
+await simAws.cloudFormation().deployTemplate({
+  stackName: "orders-stack",
+  template: imageFunctionTemplate,
+  bindings: [
+    {
+      logicalId: "OrdersFunction",
+      handler: (event: { orderId: string }): string =>
+        `Processed ${event.orderId}`,
+    },
+  ],
+});
+
+const output = await simAws.lambda().invoke(
+  new InvokeCommand({
+    FunctionName: "orders",
+    Payload: JSON.stringify({ orderId: "order-1" }),
+  }),
+);
+
+if (output.Payload === undefined) throw new Error("No invoke Payload");
+console.log(Buffer.from(output.Payload).toString());
+
+await simAws.backgroundTasksComplete();
+```
+
+A function declaring `Code.ImageUri` without `PackageType` is treated the same way. `ImageConfig`
+is ignored, because `Command`, `EntryPoint` and `WorkingDirectory` have no meaning for a handler
+running in this process.
+
 ## Function URLs in templates
 
 `AWS::Lambda::Url` creates a Function URL for a deployed function, which is what CDK's
@@ -1782,7 +1864,9 @@ Current documented limitations:
 - Function versions, aliases, and qualifiers are not simulated (`Version` is always `$LATEST`).
 - The vm runtime supports CommonJS function code only; ES module source (`.mjs` / `export`
   syntax) is not supported yet.
-- Container image functions (`Code.ImageUri`) are not supported. The simulator stays Docker-free.
+- Container image functions are not run. Yulin never reads a container image, and stays Docker-free.
+  A template function with `PackageType: Image` is skipped unless a real in-process handler is bound
+  to it. See [Container image functions](#container-image-functions).
 - Lambda Layers are not simulated.
 - Environment variables declared with `Environment.Variables` reach a real in-process handler
   function only while it runs, so a variable read at module scope sees the host process value

--- a/docs/services/lambda/sim-lambda-container-image-function.example.ts
+++ b/docs/services/lambda/sim-lambda-container-image-function.example.ts
@@ -1,0 +1,63 @@
+/**
+ * Simulating a container image Lambda function with a bound handler.
+ */
+
+import { InvokeCommand } from "@aws-sdk/client-lambda";
+
+import { SimAws } from "@kensio/yulin";
+
+const imageFunctionTemplate = {
+  Resources: {
+    OrdersFunction: {
+      Type: "AWS::Lambda::Function",
+      Properties: {
+        FunctionName: "orders",
+        Role: "arn:aws:iam::111111111111:role/OrdersRole",
+        PackageType: "Image",
+        Code: {
+          ImageUri:
+            "111111111111.dkr.ecr.eu-west-2.amazonaws.com/orders:latest",
+        },
+      },
+    },
+  },
+};
+
+// Without a binding, the function is skipped and the stack still deploys.
+const skippedSimAws = new SimAws();
+
+const skippedStack = await skippedSimAws.cloudFormation().deployTemplate({
+  stackName: "orders-stack",
+  template: imageFunctionTemplate,
+});
+
+console.log(skippedStack.getResource("OrdersFunction")?.skippedReason);
+
+await skippedSimAws.backgroundTasksComplete();
+
+// With a binding, the handler replaces the image and the function runs.
+const simAws = new SimAws();
+
+await simAws.cloudFormation().deployTemplate({
+  stackName: "orders-stack",
+  template: imageFunctionTemplate,
+  bindings: [
+    {
+      logicalId: "OrdersFunction",
+      handler: (event: { orderId: string }): string =>
+        `Processed ${event.orderId}`,
+    },
+  ],
+});
+
+const output = await simAws.lambda().invoke(
+  new InvokeCommand({
+    FunctionName: "orders",
+    Payload: JSON.stringify({ orderId: "order-1" }),
+  }),
+);
+
+if (output.Payload === undefined) throw new Error("No invoke Payload");
+console.log(Buffer.from(output.Payload).toString());
+
+await simAws.backgroundTasksComplete();

--- a/src/service/lambda/cfn/function/sim-cfn-lambda-creation-skips.ts
+++ b/src/service/lambda/cfn/function/sim-cfn-lambda-creation-skips.ts
@@ -1,0 +1,51 @@
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import { SimCfnLambdaCdkAssetsSkip } from "./sim-cfn-lambda-cdk-assets-skip.js";
+import type { SimCfnLambdaFunctionProperties } from "./sim-cfn-lambda-function-properties-parser.js";
+import { SimCfnLambdaImageSkip } from "./sim-cfn-lambda-image-skip.js";
+import { SimCfnLambdaRuntimeSkip } from "./sim-cfn-lambda-runtime-skip.js";
+
+/**
+ * The reasons an AWS::Lambda::Function Resource is skipped rather than created.
+ *
+ * Some are known before anything is attempted, from what the template
+ * declares. One is only known from the failure creating the function produced.
+ * Gathering them here keeps the creator to orchestrating the creation itself.
+ */
+export class SimCfnLambdaCreationSkips {
+  private readonly imageSkip = new SimCfnLambdaImageSkip();
+  private readonly runtimeSkip = new SimCfnLambdaRuntimeSkip();
+  private readonly cdkAssetsSkip = new SimCfnLambdaCdkAssetsSkip();
+
+  /**
+   * The reason this Resource cannot be created, before anything is created.
+   *
+   * The image gate goes first because it is the more specific reason: a
+   * container image function declares no Runtime, so the runtime gate would
+   * pass it through with nothing to say.
+   */
+  beforeCreate(
+    resource: SimCfnResource,
+    functionProperties: SimCfnLambdaFunctionProperties,
+    bound: boolean,
+  ): Error | undefined {
+    return (
+      this.imageSkip.findSkipError(resource, functionProperties, bound) ??
+      this.runtimeSkip.findSkipError(resource, functionProperties, bound)
+    );
+  }
+
+  /**
+   * The reason a creation failure is a skip rather than a stack failure.
+   */
+  fromCreateFailure(
+    resource: SimCfnResource,
+    functionProperties: SimCfnLambdaFunctionProperties,
+    error: unknown,
+  ): Error | undefined {
+    return this.cdkAssetsSkip.findSkipError(
+      resource,
+      functionProperties,
+      error,
+    );
+  }
+}

--- a/src/service/lambda/cfn/function/sim-cfn-lambda-function-code-parser.ts
+++ b/src/service/lambda/cfn/function/sim-cfn-lambda-function-code-parser.ts
@@ -5,6 +5,19 @@ import { makeLambdaCodeZip } from "../../function/code/make-lambda-code-zip.js";
 import { SimCfnLambdaPropertyParser } from "./sim-cfn-lambda-property-parser.js";
 
 /**
+ * The parsed AWS::Lambda::Function Code property.
+ *
+ * The image URI is kept apart from the CreateFunction code input because sim
+ * Lambda has nothing to do with it: a container image function is either
+ * backed by an executable binding, which replaces its code wholesale, or
+ * skipped. Carrying it here is what lets the skip name the image.
+ */
+export interface SimCfnLambdaParsedCode {
+  readonly code: SimLambdaFunctionCode | undefined;
+  readonly imageUri: string | undefined;
+}
+
+/**
  * Parses the AWS::Lambda::Function Code property into sim Lambda
  * CreateFunction code input.
  *
@@ -22,9 +35,9 @@ export class SimCfnLambdaFunctionCodeParser {
   parse(
     resource: SimCfnResource,
     value: SimCfnTemplateValue | undefined,
-  ): SimLambdaFunctionCode | undefined {
+  ): SimCfnLambdaParsedCode {
     if (value === undefined) {
-      return undefined;
+      return { code: undefined, imageUri: undefined };
     }
 
     if (typeof value !== "object" || value === null || Array.isArray(value)) {
@@ -36,21 +49,28 @@ export class SimCfnLambdaFunctionCodeParser {
     }
 
     return {
-      ZipFile: this.zipFileBytes(resource, value["ZipFile"]),
-      S3Bucket: this.propertyParser.optionalString(
+      code: {
+        ZipFile: this.zipFileBytes(resource, value["ZipFile"]),
+        S3Bucket: this.propertyParser.optionalString(
+          resource,
+          value["S3Bucket"],
+          "Code.S3Bucket",
+        ),
+        S3Key: this.propertyParser.optionalString(
+          resource,
+          value["S3Key"],
+          "Code.S3Key",
+        ),
+        S3ObjectVersion: this.propertyParser.optionalString(
+          resource,
+          value["S3ObjectVersion"],
+          "Code.S3ObjectVersion",
+        ),
+      },
+      imageUri: this.propertyParser.optionalString(
         resource,
-        value["S3Bucket"],
-        "Code.S3Bucket",
-      ),
-      S3Key: this.propertyParser.optionalString(
-        resource,
-        value["S3Key"],
-        "Code.S3Key",
-      ),
-      S3ObjectVersion: this.propertyParser.optionalString(
-        resource,
-        value["S3ObjectVersion"],
-        "Code.S3ObjectVersion",
+        value["ImageUri"],
+        "Code.ImageUri",
       ),
     };
   }

--- a/src/service/lambda/cfn/function/sim-cfn-lambda-function-creator.ts
+++ b/src/service/lambda/cfn/function/sim-cfn-lambda-function-creator.ts
@@ -4,9 +4,8 @@ import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template
 import { assertDefined } from "../../../../util/type-guard/defined.js";
 import type { SimLambdaFunction } from "../../function/sim-lambda-function.js";
 import type { SimLambda } from "../../sim-lambda.js";
-import { SimCfnLambdaCdkAssetsSkip } from "./sim-cfn-lambda-cdk-assets-skip.js";
 import { simCfnLambdaCodeInput } from "./sim-cfn-lambda-code-input.js";
-import { SimCfnLambdaRuntimeSkip } from "./sim-cfn-lambda-runtime-skip.js";
+import { SimCfnLambdaCreationSkips } from "./sim-cfn-lambda-creation-skips.js";
 import {
   simCfnLambdaCreateFunctionInput,
   SimCfnLambdaFunctionPropertiesParser,
@@ -23,8 +22,7 @@ export class SimCfnLambdaFunctionCreator {
   private readonly lambda: SimLambda;
   private readonly propertiesParser =
     new SimCfnLambdaFunctionPropertiesParser();
-  private readonly cdkAssetsSkip = new SimCfnLambdaCdkAssetsSkip();
-  private readonly runtimeSkip = new SimCfnLambdaRuntimeSkip();
+  private readonly skips = new SimCfnLambdaCreationSkips();
 
   constructor(properties: SimCfnLambdaFunctionCreatorProperties) {
     this.lambda = properties.lambda;
@@ -53,13 +51,13 @@ export class SimCfnLambdaFunctionCreator {
       bindings,
     });
 
-    const runtimeSkipError = this.runtimeSkip.findSkipError(
+    const skipError = this.skips.beforeCreate(
       resource,
       functionProperties,
       bound,
     );
-    if (runtimeSkipError !== undefined) {
-      throw runtimeSkipError;
+    if (skipError !== undefined) {
+      throw skipError;
     }
 
     try {
@@ -67,13 +65,13 @@ export class SimCfnLambdaFunctionCreator {
         input: simCfnLambdaCreateFunctionInput(functionProperties, code),
       });
     } catch (error) {
-      const skipError = this.cdkAssetsSkip.findSkipError(
+      const assetsSkipError = this.skips.fromCreateFailure(
         resource,
         functionProperties,
         error,
       );
-      if (skipError !== undefined) {
-        throw skipError;
+      if (assetsSkipError !== undefined) {
+        throw assetsSkipError;
       }
 
       throw error;

--- a/src/service/lambda/cfn/function/sim-cfn-lambda-function-properties-parser.ts
+++ b/src/service/lambda/cfn/function/sim-cfn-lambda-function-properties-parser.ts
@@ -15,6 +15,8 @@ export interface SimCfnLambdaFunctionProperties {
   readonly functionName: string;
   readonly roleArn: string;
   readonly code: SimLambdaFunctionCode | undefined;
+  readonly imageUri: string | undefined;
+  readonly packageType: string | undefined;
   readonly handlerName: string | undefined;
   readonly runtimeName: string | undefined;
   readonly description: string | undefined;
@@ -64,10 +66,18 @@ export class SimCfnLambdaFunctionPropertiesParser {
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
   ): SimCfnLambdaFunctionProperties {
+    const parsedCode = this.codeParser.parse(resource, properties["Code"]);
+
     return {
       functionName: this.functionName(resource, properties),
       roleArn: this.roleArn(resource, properties),
-      code: this.codeParser.parse(resource, properties["Code"]),
+      code: parsedCode.code,
+      imageUri: parsedCode.imageUri,
+      packageType: this.propertyParser.optionalString(
+        resource,
+        properties["PackageType"],
+        "PackageType",
+      ),
       handlerName: this.propertyParser.optionalString(
         resource,
         properties["Handler"],

--- a/src/service/lambda/cfn/function/sim-cfn-lambda-image-skip.iso.test.ts
+++ b/src/service/lambda/cfn/function/sim-cfn-lambda-image-skip.iso.test.ts
@@ -1,0 +1,244 @@
+import { InvokeCommand } from "@aws-sdk/client-lambda";
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertTrue,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+
+const ordersImageUri =
+  "111111111111.dkr.ecr.eu-west-2.amazonaws.com/orders:latest";
+
+/**
+ * What CDK synthesizes for a DockerImageFunction: PackageType and an image
+ * URI, with no Runtime and no Handler.
+ */
+const imageFunctionTemplate = {
+  Resources: {
+    OrdersFunction: {
+      Type: "AWS::Lambda::Function",
+      Properties: {
+        FunctionName: "orders",
+        Role: "arn:aws:iam::111111111111:role/OrdersRole",
+        PackageType: "Image",
+        Code: { ImageUri: ordersImageUri },
+      },
+    },
+  },
+};
+
+describe("Lambda CloudFormation container image Functions", () => {
+  it("skips a container image function with no bound handler", async () => {
+    // Given a template with a container image function, as CDK synthesizes
+    // for a DockerImageFunction.
+    const simAws = new SimAws();
+
+    // When the template is deployed through sim CloudFormation.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: imageFunctionTemplate,
+    });
+
+    // Then the Resource is skipped rather than failing the stack, naming the
+    // image it could not run.
+    const functionResource = stack.getResource("OrdersFunction");
+
+    assertNonNullable(functionResource);
+    assertTrue(functionResource.skipped);
+    assertNonNullable(functionResource.skippedReason);
+    assertStringIncludes(functionResource.skippedReason, ordersImageUri);
+    assertStringIncludes(functionResource.skippedReason, "Bind a real");
+
+    // And no simulated function is created for it.
+    assertUndefined(simAws.lambda().getSimFunctionByName("orders"));
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("deploys the rest of a stack around a skipped image function", async () => {
+    // Given an image function alongside another Resource in the same stack.
+    const simAws = new SimAws();
+
+    // When the template is deployed through sim CloudFormation.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: {
+        Resources: {
+          ...imageFunctionTemplate.Resources,
+          OrdersBucket: {
+            Type: "AWS::S3::Bucket",
+            Properties: { BucketName: "orders-uploads" },
+          },
+        },
+      },
+    });
+
+    // Then the skipped function does not take the stack down with it.
+    await stack.waitForDeployComplete();
+
+    assertNonNullable(simAws.s3().getSimBucketByName("orders-uploads"));
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("deploys a container image function when a handler is bound", async () => {
+    // Given the same image function, with a real in-process handler bound to
+    // it, which replaces the image wholesale.
+    const simAws = new SimAws();
+
+    // When the template is deployed with the binding.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: imageFunctionTemplate,
+      bindings: [
+        {
+          logicalId: "OrdersFunction",
+          handler: (): { source: string } => ({ source: "bound-handler" }),
+        },
+      ],
+    });
+
+    // Then the Resource deploys, because the bound handler is what runs.
+    const functionResource = stack.getResource("OrdersFunction");
+
+    assertNonNullable(functionResource);
+    assertUndefined(functionResource.skippedReason);
+
+    const invokeOutput = await simAws
+      .lambda()
+      .invoke(new InvokeCommand({ FunctionName: "orders" }));
+
+    assertIdentical(invokeOutput.StatusCode, 200);
+    assertUndefined(invokeOutput.FunctionError);
+    assertNonNullable(invokeOutput.Payload);
+    assertStringIncludes(
+      Buffer.from(invokeOutput.Payload).toString(),
+      "bound-handler",
+    );
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("skips a function declaring an image URI without PackageType", async () => {
+    // Given a hand-written template naming an image but leaving PackageType
+    // out, which CDK never does but a template author can.
+    const simAws = new SimAws();
+
+    // When the template is deployed through sim CloudFormation.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: {
+        Resources: {
+          OrdersFunction: {
+            Type: "AWS::Lambda::Function",
+            Properties: {
+              FunctionName: "orders",
+              Role: "arn:aws:iam::111111111111:role/OrdersRole",
+              Code: { ImageUri: ordersImageUri },
+            },
+          },
+        },
+      },
+    });
+
+    // Then it is skipped in the same way, naming the image.
+    const functionResource = stack.getResource("OrdersFunction");
+
+    assertNonNullable(functionResource);
+    assertTrue(functionResource.skipped);
+    assertNonNullable(functionResource.skippedReason);
+    assertStringIncludes(functionResource.skippedReason, ordersImageUri);
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("skips a function packaged as an image that names no image", async () => {
+    // Given PackageType Image with no Code at all, which is invalid on real
+    // AWS but must not fail the stack here.
+    const simAws = new SimAws();
+
+    // When the template is deployed through sim CloudFormation.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: {
+        Resources: {
+          OrdersFunction: {
+            Type: "AWS::Lambda::Function",
+            Properties: {
+              FunctionName: "orders",
+              Role: "arn:aws:iam::111111111111:role/OrdersRole",
+              PackageType: "Image",
+            },
+          },
+        },
+      },
+    });
+
+    // Then it is skipped with a reason that still reads properly.
+    const functionResource = stack.getResource("OrdersFunction");
+
+    assertNonNullable(functionResource);
+    assertTrue(functionResource.skipped);
+    assertNonNullable(functionResource.skippedReason);
+    assertStringIncludes(
+      functionResource.skippedReason,
+      "cannot run container images",
+    );
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("ignores ImageConfig on a bound container image function", async () => {
+    // Given an image function declaring ImageConfig, which has no meaning for
+    // a bound in-process handler.
+    const simAws = new SimAws();
+
+    // When the template is deployed with a binding.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: {
+        Resources: {
+          OrdersFunction: {
+            Type: "AWS::Lambda::Function",
+            Properties: {
+              FunctionName: "orders",
+              Role: "arn:aws:iam::111111111111:role/OrdersRole",
+              PackageType: "Image",
+              Code: { ImageUri: ordersImageUri },
+              ImageConfig: {
+                Command: ["index.handler"],
+                EntryPoint: ["/lambda-entrypoint.sh"],
+                WorkingDirectory: "/var/task",
+              },
+            },
+          },
+        },
+      },
+      bindings: [
+        {
+          logicalId: "OrdersFunction",
+          handler: (): string => "bound-handler",
+        },
+      ],
+    });
+
+    // Then ImageConfig is ignored rather than refused, and the function runs.
+    const functionResource = stack.getResource("OrdersFunction");
+
+    assertNonNullable(functionResource);
+    assertUndefined(functionResource.skippedReason);
+
+    const invokeOutput = await simAws
+      .lambda()
+      .invoke(new InvokeCommand({ FunctionName: "orders" }));
+
+    assertIdentical(invokeOutput.StatusCode, 200);
+    assertUndefined(invokeOutput.FunctionError);
+
+    await simAws.backgroundTasksComplete();
+  });
+});

--- a/src/service/lambda/cfn/function/sim-cfn-lambda-image-skip.ts
+++ b/src/service/lambda/cfn/function/sim-cfn-lambda-image-skip.ts
@@ -1,0 +1,79 @@
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnLambdaFunctionProperties } from "./sim-cfn-lambda-function-properties-parser.js";
+
+/**
+ * The PackageType real Lambda uses for a container image function.
+ */
+const imagePackageType = "Image";
+
+/**
+ * Skips template functions packaged as a container image.
+ *
+ * Yulin never looks inside an image. It cannot: an image may hold a Go binary
+ * or a Python application, and sim Lambda evaluates handler modules as
+ * CommonJS in a vm. So the image URI is only ever an identifier, and a
+ * function packaged as an image has no code Yulin can run.
+ *
+ * A function with an executable binding is exempt, because the binding
+ * replaces the code with a real in-process handler. That is how to simulate a
+ * container image function, and the skip message says so.
+ *
+ * This is separate from the runtime skip because a container image function
+ * declares no Runtime at all, so there is nothing there for that gate to
+ * decline.
+ *
+ * The "Unsupported sim ... CloudFormation" wording marks the Resource as
+ * skipped rather than failing the stack.
+ */
+export class SimCfnLambdaImageSkip {
+  /**
+   * A skip error when this function is packaged as a container image,
+   * otherwise undefined.
+   */
+  findSkipError(
+    resource: SimCfnResource,
+    functionProperties: SimCfnLambdaFunctionProperties,
+    bound: boolean,
+  ): Error | undefined {
+    if (bound || !this.isImagePackaged(functionProperties)) {
+      return undefined;
+    }
+
+    return new Error(
+      `Unsupported sim Lambda CloudFormation Resource ${resource.logicalId}: ` +
+        `${this.imageDescription(functionProperties)}. Bind a real ` +
+        `in-process handler to this function to simulate it.`,
+    );
+  }
+
+  /**
+   * Whether this function is packaged as a container image.
+   *
+   * CDK always synthesizes PackageType alongside Code.ImageUri, but a
+   * hand-written template need not, so either one on its own is enough.
+   */
+  private isImagePackaged(
+    functionProperties: SimCfnLambdaFunctionProperties,
+  ): boolean {
+    return (
+      functionProperties.packageType === imagePackageType ||
+      functionProperties.imageUri !== undefined
+    );
+  }
+
+  /**
+   * What the skip reason says could not be run, naming the image where the
+   * template gave one.
+   */
+  private imageDescription(
+    functionProperties: SimCfnLambdaFunctionProperties,
+  ): string {
+    const { imageUri } = functionProperties;
+
+    if (imageUri === undefined) {
+      return "sim Lambda cannot run container images";
+    }
+
+    return `sim Lambda cannot run the container image ${imageUri}`;
+  }
+}

--- a/src/service/lambda/cfn/function/sim-cfn-lambda-runtime-skip.ts
+++ b/src/service/lambda/cfn/function/sim-cfn-lambda-runtime-skip.ts
@@ -11,11 +11,15 @@ const nodeJsRuntimePrefix = "nodejs";
  * Skips template functions declaring a runtime sim Lambda does not simulate.
  *
  * Yulin is a Node.js simulator: function code is evaluated as CommonJS modules
- * in a vm, so a Python, Java, Go or container function cannot run whatever its
- * code says. CDK synthesizes such functions into a user's stack without being
- * asked to. The CDK BucketDeployment provider, for instance, is a Python
- * function, and sim CloudFormation simulates that custom resource directly
- * rather than running its provider.
+ * in a vm, so a Python, Java or Go function cannot run whatever its code says.
+ * CDK synthesizes such functions into a user's stack without being asked to.
+ * The CDK BucketDeployment provider, for instance, is a Python function, and
+ * sim CloudFormation simulates that custom resource directly rather than
+ * running its provider.
+ *
+ * A container image function is not declined here. It declares no Runtime at
+ * all, so there is nothing for this gate to match on, and
+ * SimCfnLambdaImageSkip declines it instead.
  *
  * Declining those functions on their Runtime keeps the reason honest, and
  * keeps their code from being loaded at all. A function with an executable


### PR DESCRIPTION
An `AWS::Lambda::Function` declaring `PackageType: Image` failed its stack outright, because `Code.ImageUri` was never parsed and `CreateFunction` then refused the empty code input. Yulin never reads a container image, so there is nothing to run, and the Resource is now skipped with a reason naming the image and pointing at executable bindings. Binding a real in-process handler to an image function already worked incidentally and is now covered by tests and documented, along with a hand-written template naming an image without `PackageType`, and `ImageConfig` being ignored. The runtime skip's doc comment no longer claims to decline container functions, which it never could, since an image function declares no `Runtime` for it to match on.

Resolves https://github.com/KensioSoftware/yulin/issues/550

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for simulating CloudFormation Lambda functions packaged as container images.
  - Bound image-based functions can now deploy and invoke through their configured handlers.
  - Unbound image functions are skipped with clear diagnostic messages without blocking other stack resources.
  - Added an example demonstrating deployment and invocation scenarios.

- **Documentation**
  - Documented container-image limitations, supported configurations, and `ImageConfig` behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->