### PR TITLE
feat: bind a Lambda handler by image repository

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -294,7 +294,8 @@
           "configuration": { "config": false },
           "fn": false,
           "ref": false,
-          "db": false
+          "db": false,
+          "repository": false
         }
       }
     ],

--- a/docs/services/lambda/README.md
+++ b/docs/services/lambda/README.md
@@ -1647,6 +1647,10 @@ A function declaring `Code.ImageUri` without `PackageType` is treated the same w
 is ignored, because `Command`, `EntryPoint` and `WorkingDirectory` have no meaning for a handler
 running in this process.
 
+A binding can also name the image repository instead of the function, which covers every function
+running that image without repeating the binding per stack. See
+[binding by container image repository](#binding-by-container-image-repository).
+
 ## Function URLs in templates
 
 `AWS::Lambda::Url` creates a Function URL for a deployed function, which is what CDK's
@@ -1789,10 +1793,89 @@ await simAws.backgroundTasksComplete();
 ```
 
 A binding can target the function by `logicalId` (which also matches a CDK construct ID from
-`aws:cdk:path` metadata), by `functionName`, by `arn`, or by full `cdkPath`. A bound function may
-omit template `Code` and `Handler` entirely; unbound functions in the same template keep their
-template code on the vm path. A binding that does not resolve to any template resource fails the
-deploy with the unmatched target named for diagnosis.
+`aws:cdk:path` metadata), by `functionName`, by `arn`, by full `cdkPath`, or by `imageRepository`
+for a function packaged as a container image. A bound function may omit template `Code` and
+`Handler` entirely; unbound functions in the same template keep their template code on the vm path.
+A binding that does not resolve to any template resource fails the deploy with the unmatched target
+named for diagnosis. Where two bindings could both back the same function, the one listed first is
+the one that backs it.
+
+### Binding by container image repository
+
+`imageRepository` matches any function whose resolved `Code.ImageUri` names that repository. One
+binding covers every function running that image, in every stack deployed from the same `SimAws`,
+rather than naming a logical ID that belongs to one construct tree.
+
+The image tag is ignored on both sides of the match. No tag is stable enough to write into a test:
+a CDK image asset is tagged with the asset content hash, which changes whenever the image source
+does, and a pipeline-built image is usually tagged with a git sha or a build number passed in as a
+stack parameter. The registry host is part of the repository, so the account and region have to
+match too, and an `ImageUri` built by `Fn::Sub` or from a stack parameter is matched on what it
+resolves to.
+
+```typescript sim-lambda-image-repository-binding
+/**
+ * Binding a handler to a container image function by its image repository.
+ */
+
+import { InvokeCommand } from "@aws-sdk/client-lambda";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+await simAws.cloudFormation().deployTemplate({
+  stackName: "orders-stack",
+  template: {
+    Parameters: {
+      ImageTag: { Type: "String" },
+    },
+    Resources: {
+      OrdersFunction: {
+        Type: "AWS::Lambda::Function",
+        Properties: {
+          FunctionName: "orders",
+          Role: "arn:aws:iam::111111111111:role/OrdersRole",
+          PackageType: "Image",
+          Code: {
+            ImageUri: {
+              "Fn::Sub":
+                // eslint-disable-next-line no-template-curly-in-string
+                "${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/orders:${ImageTag}",
+            },
+          },
+        },
+      },
+    },
+  },
+  parameters: { ImageTag: "build-4172" },
+  bindings: [
+    {
+      imageRepository:
+        `${simAws.defaultAccountId}.dkr.ecr.` +
+        `${simAws.defaultRegionName}.amazonaws.com/orders`,
+      handler: (event: { orderId: string }): string =>
+        `Processed ${event.orderId}`,
+    },
+  ],
+});
+
+const output = await simAws.lambda().invoke(
+  new InvokeCommand({
+    FunctionName: "orders",
+    Payload: JSON.stringify({ orderId: "order-1" }),
+  }),
+);
+
+if (output.Payload === undefined) throw new Error("No invoke Payload");
+console.log(Buffer.from(output.Payload).toString());
+
+await simAws.backgroundTasksComplete();
+```
+
+A function matched this way is created from the bound handler, so it never reaches the
+[container image skip](#container-image-functions). Functions in the same template running an image
+from another repository are skipped as usual.
 
 ## Available functionality
 

--- a/docs/services/lambda/sim-lambda-image-repository-binding.example.ts
+++ b/docs/services/lambda/sim-lambda-image-repository-binding.example.ts
@@ -1,0 +1,57 @@
+/**
+ * Binding a handler to a container image function by its image repository.
+ */
+
+import { InvokeCommand } from "@aws-sdk/client-lambda";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+await simAws.cloudFormation().deployTemplate({
+  stackName: "orders-stack",
+  template: {
+    Parameters: {
+      ImageTag: { Type: "String" },
+    },
+    Resources: {
+      OrdersFunction: {
+        Type: "AWS::Lambda::Function",
+        Properties: {
+          FunctionName: "orders",
+          Role: "arn:aws:iam::111111111111:role/OrdersRole",
+          PackageType: "Image",
+          Code: {
+            ImageUri: {
+              "Fn::Sub":
+                // eslint-disable-next-line no-template-curly-in-string
+                "${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/orders:${ImageTag}",
+            },
+          },
+        },
+      },
+    },
+  },
+  parameters: { ImageTag: "build-4172" },
+  bindings: [
+    {
+      imageRepository:
+        `${simAws.defaultAccountId}.dkr.ecr.` +
+        `${simAws.defaultRegionName}.amazonaws.com/orders`,
+      handler: (event: { orderId: string }): string =>
+        `Processed ${event.orderId}`,
+    },
+  ],
+});
+
+const output = await simAws.lambda().invoke(
+  new InvokeCommand({
+    FunctionName: "orders",
+    Payload: JSON.stringify({ orderId: "order-1" }),
+  }),
+);
+
+if (output.Payload === undefined) throw new Error("No invoke Payload");
+console.log(Buffer.from(output.Payload).toString());
+
+await simAws.backgroundTasksComplete();

--- a/src/service/cloudformation/bind/sim-cfn-exec-binding.type.ts
+++ b/src/service/cloudformation/bind/sim-cfn-exec-binding.type.ts
@@ -20,6 +20,7 @@ export type SimCfnExecutableResourceBinding<
       readonly functionName?: never;
       readonly arn?: never;
       readonly cdkPath?: never;
+      readonly imageRepository?: never;
       readonly handler: H;
     }
   | {
@@ -27,6 +28,7 @@ export type SimCfnExecutableResourceBinding<
       readonly logicalId?: never;
       readonly arn?: never;
       readonly cdkPath?: never;
+      readonly imageRepository?: never;
       readonly handler: H;
     }
   | {
@@ -34,6 +36,7 @@ export type SimCfnExecutableResourceBinding<
       readonly logicalId?: never;
       readonly functionName?: never;
       readonly cdkPath?: never;
+      readonly imageRepository?: never;
       readonly handler: H;
     }
   | {
@@ -41,6 +44,20 @@ export type SimCfnExecutableResourceBinding<
       readonly logicalId?: never;
       readonly functionName?: never;
       readonly arn?: never;
+      readonly imageRepository?: never;
+      readonly handler: H;
+    }
+  /**
+   * A container image repository, matching any AWS::Lambda::Function whose
+   * `Code.ImageUri` names it. The image tag is ignored, so one binding covers
+   * every stack that runs that image.
+   */
+  | {
+      readonly imageRepository: string;
+      readonly logicalId?: never;
+      readonly functionName?: never;
+      readonly arn?: never;
+      readonly cdkPath?: never;
       readonly handler: H;
     };
 

--- a/src/service/cloudformation/bind/validate/sim-cfn-exec-binding-finder.ts
+++ b/src/service/cloudformation/bind/validate/sim-cfn-exec-binding-finder.ts
@@ -2,7 +2,8 @@ import type {
   SimCfnExecutableResource,
   SimCfnExecutableResourceBinding,
 } from "../sim-cfn-exec-binding.type.js";
-import { cdkPathMetadataKeys } from "./sim-cfn-exec-binding-matcher.js";
+import { SimCfnImageRepositoryTarget } from "./sim-cfn-image-repository-target.js";
+import { SimCfnResourceCdkPath } from "./sim-cfn-resource-cdk-path.js";
 import type { SimCfnResource } from "../../resource/sim-cfn-resource.js";
 
 interface SimCfnExecBindingFinderProperties {
@@ -17,6 +18,7 @@ interface SimCfnExecBindingFinderProperties {
 export interface SimCfnExecBindingTargets {
   readonly functionName: string;
   readonly arn?: string | undefined;
+  readonly imageUri?: string | undefined;
 }
 
 /**
@@ -36,27 +38,32 @@ export interface SimCfnExecBindingTargets {
  * - resolved function name, for name-based bindings
  * - resource ARN, when the creating factory supplies its ARN format
  * - CDK construct path, matched against Resource Metadata
+ * - container image repository, when the creating factory supplies the image
+ *   URI the Resource resolved to
  */
 export class SimCfnExecBindingFinder<
   H extends SimCfnExecutableResource = SimCfnExecutableResource,
 > {
   private readonly resource: SimCfnResource;
+  private readonly cdkPath: SimCfnResourceCdkPath;
   private readonly bindings:
     | readonly SimCfnExecutableResourceBinding[]
     | undefined;
 
   constructor(properties: SimCfnExecBindingFinderProperties) {
     this.resource = properties.resource;
+    this.cdkPath = new SimCfnResourceCdkPath(properties.resource);
     this.bindings = properties.bindings;
   }
 
   /**
    * Return the first binding that targets this executable Resource.
    *
-   * Logical ID matching is evaluated before function-name matching because the
-   * logical ID is stable even when the template omits the function name
-   * property and the simulator falls back to the Resource logical ID as the
-   * local name.
+   * Bindings are considered in the order they were given, so where two of them
+   * could match the same Resource, the earlier one is the one that backs it.
+   * That matters for a container image binding covering a whole repository
+   * alongside a logical ID binding naming one function: whichever is listed
+   * first wins.
    */
   findBinding(
     targets: SimCfnExecBindingTargets,
@@ -90,7 +97,13 @@ export class SimCfnExecBindingFinder<
     }
 
     if ("cdkPath" in binding) {
-      return binding.cdkPath === this.cdkPath();
+      return binding.cdkPath === this.cdkPath.path();
+    }
+
+    if ("imageRepository" in binding) {
+      return new SimCfnImageRepositoryTarget(
+        binding.imageRepository,
+      ).matchesImageUri(targets.imageUri);
     }
 
     /* v8 ignore next */
@@ -108,61 +121,7 @@ export class SimCfnExecBindingFinder<
   private resourceMatchesLogicalIdBinding(logicalId: string): boolean {
     return (
       this.resource.logicalId === logicalId ||
-      this.cdkConstructIdFromPath() === logicalId
+      this.cdkPath.constructId() === logicalId
     );
-  }
-
-  /**
-   * Extract the construct ID from a CDK metadata path.
-   *
-   * CDK paths for low-level resources often end with `/Resource`. In that case,
-   * the construct ID is the previous path segment. If the path does not end with
-   * `Resource`, the last path segment is the best available construct identifier.
-   */
-  private cdkConstructIdFromPath(): string | undefined {
-    const path = this.cdkPath();
-
-    if (path === undefined) {
-      return undefined;
-    }
-
-    const parts = path.split("/").filter((part) => part.length > 0);
-    const resourceIndex = parts.lastIndexOf("Resource");
-
-    if (resourceIndex > 0) {
-      return parts[resourceIndex - 1];
-    }
-
-    return parts.at(-1);
-  }
-
-  /**
-   * Read a CDK path value from Resource Metadata.
-   *
-   * CDK has used more than one metadata key for construct paths over time. The
-   * shared `cdkPathMetadataKeys` list captures those supported keys, and the first
-   * string value found is treated as the path for this Resource.
-   */
-  private cdkPath(): string | undefined {
-    const metadata = this.resource.template["Metadata"];
-
-    if (
-      metadata === null ||
-      typeof metadata !== "object" ||
-      Array.isArray(metadata)
-    ) {
-      return undefined;
-    }
-
-    for (const metadataKey of cdkPathMetadataKeys) {
-      // oxlint-disable-next-line security/detect-object-injection
-      const value = metadata[metadataKey];
-
-      if (typeof value === "string") {
-        return value;
-      }
-    }
-
-    return undefined;
   }
 }

--- a/src/service/cloudformation/bind/validate/sim-cfn-exec-binding-matcher.ts
+++ b/src/service/cloudformation/bind/validate/sim-cfn-exec-binding-matcher.ts
@@ -1,15 +1,9 @@
 import { simLambdaFunctionArn } from "../../../lambda/function/sim-lambda-function.js";
 import type { SimCfnResource } from "../../resource/sim-cfn-resource.js";
 import type { SimCfnExecutableResourceBinding } from "../sim-cfn-exec-binding.type.js";
-
-/**
- * CDK metadata paths for identifying resources corresponding to bindings.
- *
- * CDK templates commonly store construct path information under `aws:cdk:path`.
- * Some synthesized templates also expose `aws:cdk:logicalId`. Both values can
- * help map a user-facing executable binding back to the synthesized Resource.
- */
-export const cdkPathMetadataKeys = ["aws:cdk:path", "aws:cdk:logicalId"];
+import { SimCfnImageRepositoryTarget } from "./sim-cfn-image-repository-target.js";
+import { SimCfnResourceCdkPath } from "./sim-cfn-resource-cdk-path.js";
+import { SimCfnResourceImageUri } from "./sim-cfn-resource-image-uri.js";
 
 /**
  * Matches executable-resource bindings against synthesized CloudFormation
@@ -42,6 +36,7 @@ export class SimCfnExecutableResourceBindingMatcher {
    * - `arn` reconstructs the simulator's CloudFront Function or Lambda
    *   function ARN format.
    * - `cdkPath` checks CDK metadata emitted into the synthesized template.
+   * - `imageRepository` checks the Lambda Code.ImageUri, ignoring its tag.
    */
   matches(binding: SimCfnExecutableResourceBinding): boolean {
     if ("logicalId" in binding) {
@@ -65,12 +60,28 @@ export class SimCfnExecutableResourceBindingMatcher {
 
     if ("cdkPath" in binding) {
       return this.#resources.some(
-        (resource) => this.#cdkPath(resource) === binding.cdkPath,
+        (resource) =>
+          new SimCfnResourceCdkPath(resource).path() === binding.cdkPath,
       );
+    }
+
+    if ("imageRepository" in binding) {
+      return this.#matchesImageRepository(binding.imageRepository);
     }
 
     /* v8 ignore next -- compile-time exhaustive guard */
     return false;
+  }
+
+  /**
+   * Whether any function in the Stack runs an image from this repository.
+   */
+  #matchesImageRepository(imageRepository: string): boolean {
+    const target = new SimCfnImageRepositoryTarget(imageRepository);
+
+    return this.#resources.some((resource) =>
+      target.matchesImageUri(new SimCfnResourceImageUri(resource).value()),
+    );
   }
 
   #resourceMatchesLogicalIdBinding(
@@ -85,7 +96,7 @@ export class SimCfnExecutableResourceBindingMatcher {
      */
     return (
       resource.logicalId === logicalId ||
-      this.#cdkConstructIdFromPath(resource) === logicalId
+      new SimCfnResourceCdkPath(resource).constructId() === logicalId
     );
   }
 
@@ -145,52 +156,5 @@ export class SimCfnExecutableResourceBindingMatcher {
       return simLambdaFunctionArn(resource.accountRegionScope, functionName);
     }
     return `arn:aws:cloudfront::${resource.accountRegionScope.accountId}:function/${functionName}`;
-  }
-
-  #cdkPath(resource: SimCfnResource): string | undefined {
-    const metadata = resource.template["Metadata"];
-
-    if (
-      metadata === null ||
-      typeof metadata !== "object" ||
-      Array.isArray(metadata)
-    ) {
-      return undefined;
-    }
-
-    for (const metadataKey of cdkPathMetadataKeys) {
-      // oxlint-disable-next-line security/detect-object-injection
-      const value = metadata[metadataKey];
-
-      if (typeof value === "string") {
-        return value;
-      }
-    }
-
-    /* v8 ignore next */
-    return undefined;
-  }
-
-  #cdkConstructIdFromPath(resource: SimCfnResource): string | undefined {
-    const path = this.#cdkPath(resource);
-
-    if (path === undefined) {
-      return undefined;
-    }
-
-    const parts = path.split("/").filter((part) => part.length > 0);
-    const resourceIndex = parts.lastIndexOf("Resource");
-
-    /*
-     * L2 CDK constructs often synthesize a child named `Resource`, for example:
-     * `Stack/RedirectFunction/Resource`. In that case the meaningful construct
-     * ID is the path segment before `Resource`, not the generated child
-     * segment.
-     */
-    if (resourceIndex > 0) {
-      return parts[resourceIndex - 1];
-    }
-
-    return parts.at(-1);
   }
 }

--- a/src/service/cloudformation/bind/validate/sim-cfn-exec-binding-validator.ts
+++ b/src/service/cloudformation/bind/validate/sim-cfn-exec-binding-validator.ts
@@ -48,6 +48,10 @@ function describeBinding(binding: SimCfnExecutableResourceBinding): string {
     return `cdkPath ${JSON.stringify(binding.cdkPath)}`;
   }
 
+  if ("imageRepository" in binding) {
+    return `imageRepository ${JSON.stringify(binding.imageRepository)}`;
+  }
+
   /* v8 ignore next -- compile-time exhaustive guard */
   return "unknown binding target";
 }

--- a/src/service/cloudformation/bind/validate/sim-cfn-image-repository-target.iso.test.ts
+++ b/src/service/cloudformation/bind/validate/sim-cfn-image-repository-target.iso.test.ts
@@ -1,0 +1,87 @@
+import { assertFalse, assertTrue } from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimCfnImageRepositoryTarget } from "./sim-cfn-image-repository-target.js";
+
+const ordersRepository = "111111111111.dkr.ecr.eu-west-2.amazonaws.com/orders";
+
+describe("Sim CloudFormation image repository binding target", () => {
+  it("matches an image URI naming the repository, whatever its tag", () => {
+    // Given a binding target naming a repository with no tag.
+    const target = new SimCfnImageRepositoryTarget(ordersRepository);
+
+    // When image URIs from that repository are matched against it.
+    // Then the tag makes no difference, including a content hash tag of the
+    // kind CDK gives an image asset.
+    assertTrue(target.matchesImageUri(`${ordersRepository}:latest`));
+    assertTrue(target.matchesImageUri(`${ordersRepository}:2f0e1d`));
+    assertTrue(target.matchesImageUri(ordersRepository));
+    assertTrue(target.matchesImageUri(`${ordersRepository}@sha256:2f0e1d`));
+  });
+
+  it("ignores a tag on the binding target itself", () => {
+    // Given a binding target that names a tag anyway.
+    const target = new SimCfnImageRepositoryTarget(
+      `${ordersRepository}:latest`,
+    );
+
+    // When an image URI with a different tag is matched against it.
+    // Then it still matches, because no tag is stable enough to match on.
+    assertTrue(target.matchesImageUri(`${ordersRepository}:2f0e1d`));
+  });
+
+  it("matches a repository named in a different case", () => {
+    // Given a binding target naming the registry host in upper case.
+    const target = new SimCfnImageRepositoryTarget(
+      "111111111111.DKR.ECR.EU-WEST-2.AMAZONAWS.COM/orders",
+    );
+
+    // When the image URI from the template is matched against it.
+    // Then case is not what separates one repository from another.
+    assertTrue(target.matchesImageUri(`${ordersRepository}:latest`));
+  });
+
+  it("keeps a registry port out of the tag", () => {
+    // Given a binding target on a registry host carrying a port.
+    const target = new SimCfnImageRepositoryTarget(
+      "registry.example.test:5000/orders",
+    );
+
+    // When a tagged image URI from that registry is matched against it.
+    // Then the port is read as part of the host rather than as a tag.
+    assertTrue(target.matchesImageUri("registry.example.test:5000/orders:v2"));
+    assertFalse(target.matchesImageUri("registry.example.test:5000/invoices"));
+  });
+
+  it("does not match another repository, account or region", () => {
+    // Given a binding target naming one repository in one account and region.
+    const target = new SimCfnImageRepositoryTarget(ordersRepository);
+
+    // When image URIs differing in only one of those are matched against it.
+    // Then none of them match, so a binding cannot reach a same-named
+    // repository somewhere else.
+    assertFalse(
+      target.matchesImageUri(
+        "111111111111.dkr.ecr.eu-west-2.amazonaws.com/invoices:latest",
+      ),
+    );
+    assertFalse(
+      target.matchesImageUri(
+        "222222222222.dkr.ecr.eu-west-2.amazonaws.com/orders:latest",
+      ),
+    );
+    assertFalse(
+      target.matchesImageUri(
+        "111111111111.dkr.ecr.us-east-1.amazonaws.com/orders:latest",
+      ),
+    );
+  });
+
+  it("does not match a function with no image URI", () => {
+    // Given a binding target and a function packaged as a zip.
+    const target = new SimCfnImageRepositoryTarget(ordersRepository);
+
+    // When there is no image URI to match.
+    // Then the binding does not target it.
+    assertFalse(target.matchesImageUri(undefined));
+  });
+});

--- a/src/service/cloudformation/bind/validate/sim-cfn-image-repository-target.ts
+++ b/src/service/cloudformation/bind/validate/sim-cfn-image-repository-target.ts
@@ -1,0 +1,67 @@
+/**
+ * The container image repository an executable binding targets.
+ *
+ * A binding names a repository, such as
+ * `111111111111.dkr.ecr.eu-west-2.amazonaws.com/orders`, and matches any
+ * template function whose `Code.ImageUri` names that repository.
+ *
+ * The tag is ignored on both sides, because no tag is stable enough to write
+ * into a test. A CDK image asset is tagged with the asset content hash, which
+ * changes whenever the source does, and a pipeline-built image is usually
+ * tagged with a git sha or build number injected as a stack parameter. A
+ * digest is ignored for the same reason.
+ *
+ * The registry host is part of the repository, so the account and region have
+ * to match too. That keeps a binding from reaching a same-named repository in
+ * another account.
+ */
+export class SimCfnImageRepositoryTarget {
+  private readonly repository: string;
+
+  constructor(imageRepository: string) {
+    this.repository = repositoryOf(imageRepository);
+  }
+
+  /**
+   * Whether a function's image URI names this repository.
+   */
+  matchesImageUri(imageUri: string | undefined): boolean {
+    if (imageUri === undefined) {
+      return false;
+    }
+
+    return repositoryOf(imageUri) === this.repository;
+  }
+}
+
+/**
+ * An image reference with any tag or digest removed.
+ *
+ * A registry host can carry a port, as in `registry.test:5000/orders`, so the
+ * tag separator is only looked for in the last path segment. Repository names
+ * are lower case on ECR, and a registry host is a DNS name, so comparing in
+ * lower case matches how a registry would read the two references.
+ */
+function repositoryOf(reference: string): string {
+  const trimmed = reference.trim();
+  const lastSlash = trimmed.lastIndexOf("/");
+  const registryPath = trimmed.slice(0, lastSlash + 1);
+  const name = trimmed.slice(lastSlash + 1);
+
+  return `${registryPath}${untagged(name)}`.toLowerCase();
+}
+
+/**
+ * The repository name with a `:tag` or `@digest` suffix removed.
+ */
+function untagged(name: string): string {
+  const separators = [name.indexOf(":"), name.indexOf("@")].filter(
+    (index) => index >= 0,
+  );
+
+  if (separators.length === 0) {
+    return name;
+  }
+
+  return name.slice(0, Math.min(...separators));
+}

--- a/src/service/cloudformation/bind/validate/sim-cfn-resource-cdk-path.ts
+++ b/src/service/cloudformation/bind/validate/sim-cfn-resource-cdk-path.ts
@@ -1,0 +1,78 @@
+import type { SimCfnResource } from "../../resource/sim-cfn-resource.js";
+
+/**
+ * CDK metadata keys holding a construct path.
+ *
+ * CDK templates commonly store construct path information under `aws:cdk:path`.
+ * Some synthesized templates also expose `aws:cdk:logicalId`. Both values can
+ * help map a user-facing executable binding back to the synthesized Resource.
+ */
+const cdkPathMetadataKeys = ["aws:cdk:path", "aws:cdk:logicalId"];
+
+/**
+ * The CDK construct path a synthesized Resource carries in its Metadata.
+ *
+ * Both the binding validator and the binding finder ask the same two questions
+ * of a Resource, so the reading lives here rather than in either of them.
+ */
+export class SimCfnResourceCdkPath {
+  private readonly resource: SimCfnResource;
+
+  constructor(resource: SimCfnResource) {
+    this.resource = resource;
+  }
+
+  /**
+   * The CDK path value from Resource Metadata.
+   *
+   * CDK has used more than one metadata key for construct paths over time, and
+   * the first string value found is treated as the path for this Resource.
+   */
+  path(): string | undefined {
+    const metadata = this.resource.template["Metadata"];
+
+    if (
+      metadata === null ||
+      typeof metadata !== "object" ||
+      Array.isArray(metadata)
+    ) {
+      return undefined;
+    }
+
+    for (const metadataKey of cdkPathMetadataKeys) {
+      // oxlint-disable-next-line security/detect-object-injection
+      const value = metadata[metadataKey];
+
+      if (typeof value === "string") {
+        return value;
+      }
+    }
+
+    return undefined;
+  }
+
+  /**
+   * The construct ID from the CDK path.
+   *
+   * L2 CDK constructs often synthesize a child named `Resource`, for example
+   * `Stack/RedirectFunction/Resource`. In that case the meaningful construct ID
+   * is the path segment before `Resource`, not the generated child segment.
+   * Otherwise the last path segment is the best available construct identifier.
+   */
+  constructId(): string | undefined {
+    const path = this.path();
+
+    if (path === undefined) {
+      return undefined;
+    }
+
+    const parts = path.split("/").filter((part) => part.length > 0);
+    const resourceIndex = parts.lastIndexOf("Resource");
+
+    if (resourceIndex > 0) {
+      return parts[resourceIndex - 1];
+    }
+
+    return parts.at(-1);
+  }
+}

--- a/src/service/cloudformation/bind/validate/sim-cfn-resource-image-uri.iso.test.ts
+++ b/src/service/cloudformation/bind/validate/sim-cfn-resource-image-uri.iso.test.ts
@@ -1,0 +1,63 @@
+import { assertIdentical, assertUndefined } from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { simCfnResourceFactory } from "../../resource/sim-cfn-resource.factory.js";
+import type { SimCfnTemplateValueRecord } from "../../template/value/sim-cfn-template-value.js";
+import { SimCfnResourceImageUri } from "./sim-cfn-resource-image-uri.js";
+
+const ordersImageUri =
+  "111111111111.dkr.ecr.eu-west-2.amazonaws.com/orders:latest";
+
+const imageCode: SimCfnTemplateValueRecord = {
+  Code: { ImageUri: ordersImageUri },
+};
+
+function imageUriOf(
+  type: string,
+  properties: SimCfnTemplateValueRecord,
+): string | undefined {
+  const resource = simCfnResourceFactory.make({
+    logicalId: "OrdersFunction",
+    template: { Type: type, Properties: properties },
+  });
+
+  return new SimCfnResourceImageUri(resource).value();
+}
+
+describe("Sim CloudFormation Resource image URI", () => {
+  it("reads the image URI of a container image function", () => {
+    // Given a Lambda function Resource naming a container image.
+    // When its image URI is read.
+    // Then it is the URI the template resolved to.
+    assertIdentical(
+      imageUriOf("AWS::Lambda::Function", imageCode),
+      ordersImageUri,
+    );
+  });
+
+  it("has no image URI for a Resource of another type", () => {
+    // Given a Resource that is not a Lambda function, whatever it declares.
+    // When its image URI is read.
+    // Then there is none, so no image binding can reach it.
+    assertUndefined(imageUriOf("AWS::S3::Bucket", imageCode));
+  });
+
+  it("has no image URI without an image URI string in Code", () => {
+    // Given Lambda functions whose Code is missing, is not an object, or does
+    // not name an image, which a hand-written template can produce.
+    const cases: readonly SimCfnTemplateValueRecord[] = [
+      {},
+      { Code: {} },
+      { Code: { ZipFile: "exports.handler = async () => 'code';" } },
+      { Code: { ImageUri: 42 } },
+      { Code: "orders.zip" },
+      { Code: ["orders.zip"] },
+      { Code: null },
+    ];
+
+    // When each one's image URI is read.
+    // Then there is none to match a binding against.
+    for (const properties of cases) {
+      assertUndefined(imageUriOf("AWS::Lambda::Function", properties));
+    }
+  });
+});

--- a/src/service/cloudformation/bind/validate/sim-cfn-resource-image-uri.ts
+++ b/src/service/cloudformation/bind/validate/sim-cfn-resource-image-uri.ts
@@ -1,0 +1,42 @@
+import type { SimCfnResource } from "../../resource/sim-cfn-resource.js";
+
+/**
+ * The container image a synthesized Resource runs.
+ *
+ * Only AWS::Lambda::Function names one, on `Code.ImageUri`. Resource
+ * Properties have already had Parameters and intrinsic functions resolved by
+ * the time the Stack builds its Resources, so an image URI built by Fn::Sub or
+ * from a Parameter reads here as the string it resolved to. Anything else,
+ * including a template that is wrong about the shape of Code, has no image URI
+ * for a binding to match.
+ */
+export class SimCfnResourceImageUri {
+  private readonly resource: SimCfnResource;
+
+  constructor(resource: SimCfnResource) {
+    this.resource = resource;
+  }
+
+  /**
+   * The resolved image URI, if this Resource is a function that names one.
+   */
+  value(): string | undefined {
+    if (this.resource.type !== "AWS::Lambda::Function") {
+      return undefined;
+    }
+
+    const code = this.resource.properties["Code"];
+
+    if (code === null || typeof code !== "object" || Array.isArray(code)) {
+      return undefined;
+    }
+
+    const imageUri = code["ImageUri"];
+
+    if (typeof imageUri !== "string") {
+      return undefined;
+    }
+
+    return imageUri;
+  }
+}

--- a/src/service/lambda/cfn/function/sim-cfn-lambda-code-input.ts
+++ b/src/service/lambda/cfn/function/sim-cfn-lambda-code-input.ts
@@ -31,7 +31,8 @@ export interface SimCfnLambdaCodeInput {
  * uses, so execution-role attribution and invocation behave identically. A
  * bound function may omit template Code and Handler entirely, as the binding
  * replaces the code wholesale. Bindings can target the logical ID (or CDK
- * construct ID), the resolved function name, or the function ARN.
+ * construct ID), the resolved function name, the function ARN, or the
+ * container image repository the function's Code.ImageUri names.
  */
 export function simCfnLambdaCodeInput(
   properties: SimCfnLambdaCodeInputProperties,
@@ -48,6 +49,7 @@ export function simCfnLambdaCodeInput(
       resource.accountRegionScope,
       functionProperties.functionName,
     ),
+    imageUri: functionProperties.imageUri,
   });
 
   if (binding === undefined) {

--- a/src/service/lambda/cfn/sim-cfn-lambda-image-bindings.iso.test.ts
+++ b/src/service/lambda/cfn/sim-cfn-lambda-image-bindings.iso.test.ts
@@ -1,0 +1,314 @@
+import { InvokeCommand } from "@aws-sdk/client-lambda";
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertTrue,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import type {
+  SimCfnTemplateValue,
+  SimCfnTemplateValueRecord,
+} from "../../cloudformation/template/value/sim-cfn-template-value.js";
+
+const ordersRepository = "111111111111.dkr.ecr.eu-west-2.amazonaws.com/orders";
+
+/**
+ * A container image function, tagged the way CDK tags an image asset: with a
+ * content hash, which changes whenever the image source does.
+ */
+function imageFunctionResource(properties: {
+  readonly functionName: string;
+  readonly imageUri?: SimCfnTemplateValue;
+}): SimCfnTemplateValueRecord {
+  return {
+    Type: "AWS::Lambda::Function",
+    Properties: {
+      FunctionName: properties.functionName,
+      Role: "arn:aws:iam::111111111111:role/OrdersRole",
+      PackageType: "Image",
+      Code: {
+        ImageUri: properties.imageUri ?? `${ordersRepository}:2f0e1dab4c`,
+      },
+    },
+  };
+}
+
+function parsePayload(payload: Uint8Array | undefined): unknown {
+  assertNonNullable(payload);
+  return JSON.parse(Buffer.from(payload).toString()) as unknown;
+}
+
+async function invokePayload(
+  simAws: SimAws,
+  functionName: string,
+): Promise<unknown> {
+  const output = await simAws
+    .lambda()
+    .invoke(new InvokeCommand({ FunctionName: functionName }));
+
+  assertIdentical(output.StatusCode, 200);
+  assertUndefined(output.FunctionError);
+
+  return parsePayload(output.Payload);
+}
+
+describe("Lambda CloudFormation Function image repository bindings", () => {
+  it("binds a real in-process handler by container image repository", async () => {
+    // Given a container image function whose image tag is a content hash, and
+    // a binding naming only the repository it comes from.
+    const simAws = new SimAws();
+
+    // When the template is deployed with the binding.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: {
+        Resources: {
+          OrdersFunction: imageFunctionResource({ functionName: "orders" }),
+        },
+      },
+      bindings: [
+        {
+          imageRepository: ordersRepository,
+          handler: () => "bound by image repository",
+        },
+      ],
+    });
+
+    // Then the function is created rather than skipped for its image, and
+    // the bound handler is what runs.
+    const functionResource = stack.getResource("OrdersFunction");
+
+    assertNonNullable(functionResource);
+    assertUndefined(functionResource.skippedReason);
+    assertIdentical(
+      await invokePayload(simAws, "orders"),
+      "bound by image repository",
+    );
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("matches an image URI built from a stack parameter", async () => {
+    // Given an image URI assembled by Fn::Sub from pseudo parameters and a
+    // build tag passed in as a stack parameter, as a pipeline-built image is.
+    const simAws = new SimAws();
+    const repository =
+      `${simAws.defaultAccountId}.dkr.ecr.` +
+      `${simAws.defaultRegionName}.amazonaws.com/orders`;
+
+    // When the template is deployed with a binding naming the repository.
+    await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: {
+        Parameters: {
+          ImageTag: { Type: "String" },
+        },
+        Resources: {
+          OrdersFunction: imageFunctionResource({
+            functionName: "orders",
+            imageUri: {
+              "Fn::Sub":
+                // eslint-disable-next-line no-template-curly-in-string
+                "${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/orders:${ImageTag}",
+            },
+          }),
+        },
+      },
+      parameters: { ImageTag: "build-4172" },
+      bindings: [
+        {
+          imageRepository: repository,
+          handler: () => "bound by resolved image repository",
+        },
+      ],
+    });
+
+    // Then the resolved image URI is what the binding matched.
+    assertIdentical(
+      await invokePayload(simAws, "orders"),
+      "bound by resolved image repository",
+    );
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("matches functions in more than one stack", async () => {
+    // Given one binding for a repository two stacks both run a function from.
+    const simAws = new SimAws();
+    const bindings = [
+      {
+        imageRepository: ordersRepository,
+        handler: () => "bound in both stacks",
+      },
+    ];
+
+    // When both stacks are deployed with the same binding.
+    await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-api-stack",
+      template: {
+        Resources: {
+          OrdersFunction: imageFunctionResource({ functionName: "orders-api" }),
+        },
+      },
+      bindings,
+    });
+    await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-worker-stack",
+      template: {
+        Resources: {
+          OrdersFunction: imageFunctionResource({
+            functionName: "orders-worker",
+            imageUri: `${ordersRepository}:9c3b7f`,
+          }),
+        },
+      },
+      bindings,
+    });
+
+    // Then the handler backs the function in each stack.
+    assertIdentical(
+      await invokePayload(simAws, "orders-api"),
+      "bound in both stacks",
+    );
+    assertIdentical(
+      await invokePayload(simAws, "orders-worker"),
+      "bound in both stacks",
+    );
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("rejects an image repository binding that matches nothing", async () => {
+    // Given a binding for a repository no function in the template runs.
+    const simAws = new SimAws();
+
+    // When the template is deployed, then binding validation rejects it with
+    // the unmatched repository for diagnosis.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.cloudFormation().deployTemplate({
+        stackName: "orders-stack",
+        template: {
+          Resources: {
+            OrdersFunction: imageFunctionResource({ functionName: "orders" }),
+          },
+        },
+        bindings: [
+          {
+            imageRepository:
+              "111111111111.dkr.ecr.eu-west-2.amazonaws.com/invoices",
+            handler: () => "never runs",
+          },
+        ],
+      }),
+    );
+
+    assertIdentical(
+      error.message,
+      "Invalid sim CloudFormation executable binding in Stack orders-stack: " +
+        'imageRepository "111111111111.dkr.ecr.eu-west-2.amazonaws.com/invoices" ' +
+        "does not resolve to a Resource in the Stack",
+    );
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("backs a function with the first binding that matches it", async () => {
+    // Given a function both an image repository binding and a logicalId
+    // binding could back, listed in one order and then the other.
+    const simAws = new SimAws();
+    const imageBinding = {
+      imageRepository: ordersRepository,
+      handler: () => "bound by image repository",
+    };
+    const logicalIdBinding = {
+      logicalId: "OrdersFunction",
+      handler: () => "bound by logical id",
+    };
+    const template = {
+      Resources: {
+        OrdersFunction: imageFunctionResource({ functionName: "orders" }),
+      },
+    };
+
+    // When each order is deployed, into its own simulated AWS so the function
+    // name is free both times.
+    await simAws.cloudFormation().deployTemplate({
+      stackName: "image-first-stack",
+      template,
+      bindings: [imageBinding, logicalIdBinding],
+    });
+
+    const reversedSimAws = new SimAws();
+
+    await reversedSimAws.cloudFormation().deployTemplate({
+      stackName: "logical-id-first-stack",
+      template,
+      bindings: [logicalIdBinding, imageBinding],
+    });
+
+    // Then the binding listed first is the one that backs the function.
+    assertIdentical(
+      await invokePayload(simAws, "orders"),
+      "bound by image repository",
+    );
+    assertIdentical(
+      await invokePayload(reversedSimAws, "orders"),
+      "bound by logical id",
+    );
+
+    await simAws.backgroundTasksComplete();
+    await reversedSimAws.backgroundTasksComplete();
+  });
+
+  it("leaves a function from another repository skipped", async () => {
+    // Given two image functions from different repositories, with a binding
+    // for one of them.
+    const simAws = new SimAws();
+
+    // When the template is deployed with that binding.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: {
+        Resources: {
+          OrdersFunction: imageFunctionResource({ functionName: "orders" }),
+          InvoicesFunction: imageFunctionResource({
+            functionName: "invoices",
+            imageUri:
+              "111111111111.dkr.ecr.eu-west-2.amazonaws.com/invoices:latest",
+          }),
+        },
+      },
+      bindings: [
+        {
+          imageRepository: ordersRepository,
+          handler: () => "bound by image repository",
+        },
+      ],
+    });
+
+    await stack.waitForDeployComplete();
+
+    // Then the unmatched function is skipped for its image, as an unbound
+    // image function is, while the matched one runs its handler.
+    const invoicesResource = stack.getResource("InvoicesFunction");
+
+    assertNonNullable(invoicesResource);
+    assertTrue(invoicesResource.skipped);
+    assertNonNullable(invoicesResource.skippedReason);
+    assertStringIncludes(
+      invoicesResource.skippedReason,
+      "cannot run the container image",
+    );
+    assertIdentical(
+      await invokePayload(simAws, "orders"),
+      "bound by image repository",
+    );
+
+    await simAws.backgroundTasksComplete();
+  });
+});


### PR DESCRIPTION
An executable binding can now target an `AWS::Lambda::Function` by the container image repository its `Code.ImageUri` names, alongside the existing logical ID, function name, ARN and CDK path targets. One binding covers every function running that image, in every stack deployed from the same `SimAws`, and a function matched this way is created from the bound handler rather than reaching the container image skip. Matching is on the registry host and repository name with the tag or digest ignored, because a CDK image asset tag is the asset content hash and a pipeline tag is usually a git sha or build number passed in as a stack parameter, so neither is stable enough to write into a test. An `ImageUri` built by `Fn::Sub` or from a parameter is matched on what it resolves to, an unmatched image repository fails the deploy like any other unresolved binding, and where two bindings could both back one function the one listed first wins. The CDK path reading the binding finder and the binding validator each had a copy of is now one collaborator, which is what left both files room for the new target.

Resolves https://github.com/KensioSoftware/yulin/issues/551

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CloudFormation Lambda bindings now support matching container-image functions by ECR image repository.
  * Repository matching works across tags, digests, parameterized image URIs, and multiple stacks while preserving registry, account, and region identity.
  * Matching image-based functions now run their bound handlers; functions from unmatched repositories remain skipped.
  * Added an executable example demonstrating deployment and invocation of an image-based Lambda function.

* **Documentation**
  * Documented binding precedence and validation behavior for unmatched targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->