### PR TITLE
feat: simulate KMS signing keys and Route53 DNSSEC

### DIFF
--- a/docs/services/cloudformation/README.md
+++ b/docs/services/cloudformation/README.md
@@ -2050,7 +2050,8 @@ The resource types it creates are:
 - `AWS::IAM::Role`, `AWS::IAM::ManagedPolicy` and `AWS::IAM::Policy`
 - `AWS::KMS::Key` and `AWS::KMS::Alias`
 - `AWS::Lambda::Function`, `AWS::Lambda::Url` and `AWS::Lambda::Permission`
-- `AWS::Route53::HostedZone` and `AWS::Route53::RecordSet`
+- `AWS::Route53::HostedZone`, `AWS::Route53::RecordSet`, `AWS::Route53::KeySigningKey` and
+  `AWS::Route53::DNSSEC`
 - `AWS::S3::Bucket` and `AWS::S3::BucketPolicy`
 - `AWS::Scheduler::Schedule`
 - `AWS::SecretsManager::Secret`

--- a/docs/services/kms/README.md
+++ b/docs/services/kms/README.md
@@ -138,6 +138,126 @@ const recovered = await kms.decrypt(
 console.log(recovered.Plaintext?.length); // 32
 ```
 
+## Signing and verifying
+
+A key created with `KeyUsage: SIGN_VERIFY` holds a real key pair, and the signatures are real
+signatures. A key spec is required, because the default `SYMMETRIC_DEFAULT` spec cannot sign.
+
+```typescript sim-kms-sign-verify
+/**
+ * Signing and verifying with a simulated asymmetric KMS key.
+ */
+
+import {
+  CreateKeyCommand,
+  SignCommand,
+  VerifyCommand,
+} from "@aws-sdk/client-kms";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const kms = simAws.kms();
+
+const created = await kms.createKey(
+  new CreateKeyCommand({
+    KeySpec: "ECC_NIST_P256",
+    KeyUsage: "SIGN_VERIFY",
+  }),
+);
+
+const message = Buffer.from("order-1234", "utf8");
+
+const signed = await kms.sign(
+  new SignCommand({
+    KeyId: created.KeyMetadata?.Arn,
+    Message: message,
+    SigningAlgorithm: "ECDSA_SHA_256",
+  }),
+);
+
+const verified = await kms.verify(
+  new VerifyCommand({
+    KeyId: created.KeyMetadata?.Arn,
+    Message: message,
+    Signature: signed.Signature,
+    SigningAlgorithm: "ECDSA_SHA_256",
+  }),
+);
+
+console.log(verified.SignatureValid); // true
+```
+
+`Verify` fails with `KMSInvalidSignatureException` when a signature does not check out, rather than
+answering `SignatureValid: false`. That is what real KMS does.
+
+The key specs simulated are `ECC_NIST_P256`, `ECC_NIST_P384`, `ECC_NIST_P521`, `ECC_SECG_P256K1`,
+`RSA_2048`, `RSA_3072` and `RSA_4096`. Each ECC spec offers the one ECDSA algorithm paired with its
+curve; each RSA spec offers all six RSASSA algorithms. A signing algorithm the key spec does not
+offer is refused. So is `Sign` against an encryption key, and `Encrypt` against a signing key.
+
+`DescribeKey` reports the key's own spec, usage and algorithms, so code that branches on them
+branches the same way it would on AWS.
+
+### Verifying outside KMS
+
+`GetPublicKey` returns the public key as DER `SubjectPublicKeyInfo`, the encoding real KMS returns.
+A verifier that never sees the simulator accepts a signature made in it.
+
+```typescript sim-kms-public-key
+/**
+ * Verifying a simulated KMS signature outside KMS, with its public key.
+ */
+
+import { createPublicKey, verify } from "node:crypto";
+
+import {
+  CreateKeyCommand,
+  GetPublicKeyCommand,
+  SignCommand,
+} from "@aws-sdk/client-kms";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const kms = simAws.kms();
+
+const created = await kms.createKey(
+  new CreateKeyCommand({
+    KeySpec: "ECC_NIST_P256",
+    KeyUsage: "SIGN_VERIFY",
+  }),
+);
+
+const message = Buffer.from("order-1234", "utf8");
+
+const signed = await kms.sign(
+  new SignCommand({
+    KeyId: created.KeyMetadata?.Arn,
+    Message: message,
+    SigningAlgorithm: "ECDSA_SHA_256",
+  }),
+);
+
+const fetched = await kms.getPublicKey(
+  new GetPublicKeyCommand({ KeyId: created.KeyMetadata?.Arn }),
+);
+
+const publicKey = createPublicKey({
+  key: Buffer.from(fetched.PublicKey ?? new Uint8Array()),
+  format: "der",
+  type: "spki",
+});
+
+console.log(
+  verify("sha256", message, publicKey, signed.Signature ?? new Uint8Array()),
+); // true
+```
+
+ECDSA signatures are DER encoded, and RSASSA-PSS signatures use a salt the length of the digest,
+both matching what KMS produces. `GetPublicKey` against a symmetric key is
+`UnsupportedOperationException`, since there is no public key to hand out.
+
 ## Key policies and IAM
 
 Every KMS key has a policy, and it cannot be removed. An IAM policy granting `kms:Decrypt` reaches
@@ -457,9 +577,10 @@ created without them and each one is recorded in
 [`stack.ignoredProperties`](../cloudformation/README.md#properties-a-resource-was-created-without),
 so a template deploys and the record says what the key does not do. `EnableKeyRotation`,
 `RotationPeriodInDays`, `MultiRegion` and `Tags` are all recorded that way: the key encrypts and
-decrypts, its material never rotates, it exists in one region, and nothing reads its tags. An
-asymmetric or HMAC `KeySpec` or `KeyUsage`, or an `Origin` other than `AWS_KMS`, is still refused by
-`CreateKey` in the same terms it refuses an SDK caller, because there is no key to create at all.
+decrypts, its material never rotates, it exists in one region, and nothing reads its tags. A `KeySpec`
+or `KeyUsage` pair simulated KMS does not model, or an `Origin` other than `AWS_KMS`, is still
+refused by `CreateKey` in the same terms it refuses an SDK caller, because there is no key to
+create at all.
 `Enabled: false` is supported, and deploys a key that is disabled from the moment it exists.
 
 ## Inside a simulated Lambda handler
@@ -473,11 +594,12 @@ allowed to, by both the key policy and the role's identity policy, the same as o
 
 Sim KMS currently supports:
 
-- `CreateKeyCommand`, for symmetric encryption keys
+- `CreateKeyCommand`, for symmetric encryption keys and asymmetric signing keys
 - `DescribeKeyCommand` and `ListKeysCommand`
 - `GetKeyPolicyCommand` and `PutKeyPolicyCommand`
 - `EncryptCommand` and `DecryptCommand`, including encryption context
 - `GenerateDataKeyCommand`, by `KeySpec` or `NumberOfBytes`
+- `SignCommand`, `VerifyCommand` and `GetPublicKeyCommand`, for asymmetric signing keys
 - `CreateAliasCommand` and `ListAliasesCommand`, including AWS managed key aliases
 - `EnableKeyCommand`, `DisableKeyCommand`, `ScheduleKeyDeletionCommand`, `CancelKeyDeletionCommand`
 - Key policy evaluation by simulated IAM
@@ -489,8 +611,16 @@ Sim KMS currently supports:
 
 Current documented limitations:
 
-- Only symmetric encryption keys (`SYMMETRIC_DEFAULT`, `ENCRYPT_DECRYPT`) are simulated. Asymmetric
-  keys, HMAC keys, `Sign`, `Verify` and `ReEncrypt` are not.
+- Only encryption with a symmetric key and signing with an asymmetric key are simulated. Asymmetric
+  encryption (`RSAES_OAEP_SHA_1` and `RSAES_OAEP_SHA_256`), HMAC keys and `GENERATE_VERIFY_MAC`,
+  key agreement and `DeriveSharedSecret`, the `SM2` key spec, and `ReEncrypt` are not. An RSA key
+  asked for with `KeyUsage: ENCRYPT_DECRYPT` is refused, which real KMS allows.
+- `Sign` and `Verify` take a `MessageType` of `RAW` only. A `DIGEST` message is refused, because
+  Node cannot sign a digest that has already been computed: `crypto.sign` with no algorithm hashes
+  what it is given rather than signing it, so the signature would not be the one real KMS makes and
+  would not verify against the message anywhere outside the simulator.
+- Generating an RSA key pair is real key generation, so an `RSA_4096` key costs a second or so of
+  test time. The ECC specs are effectively free.
 - Imported key material and custom key stores are not simulated; `Origin` other than `AWS_KMS` is
   refused.
 - Grants (`CreateGrant` and friends) are not simulated.

--- a/docs/services/kms/sim-kms-public-key.example.ts
+++ b/docs/services/kms/sim-kms-public-key.example.ts
@@ -1,0 +1,47 @@
+/**
+ * Verifying a simulated KMS signature outside KMS, with its public key.
+ */
+
+import { createPublicKey, verify } from "node:crypto";
+
+import {
+  CreateKeyCommand,
+  GetPublicKeyCommand,
+  SignCommand,
+} from "@aws-sdk/client-kms";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const kms = simAws.kms();
+
+const created = await kms.createKey(
+  new CreateKeyCommand({
+    KeySpec: "ECC_NIST_P256",
+    KeyUsage: "SIGN_VERIFY",
+  }),
+);
+
+const message = Buffer.from("order-1234", "utf8");
+
+const signed = await kms.sign(
+  new SignCommand({
+    KeyId: created.KeyMetadata?.Arn,
+    Message: message,
+    SigningAlgorithm: "ECDSA_SHA_256",
+  }),
+);
+
+const fetched = await kms.getPublicKey(
+  new GetPublicKeyCommand({ KeyId: created.KeyMetadata?.Arn }),
+);
+
+const publicKey = createPublicKey({
+  key: Buffer.from(fetched.PublicKey ?? new Uint8Array()),
+  format: "der",
+  type: "spki",
+});
+
+console.log(
+  verify("sha256", message, publicKey, signed.Signature ?? new Uint8Array()),
+); // true

--- a/docs/services/kms/sim-kms-sign-verify.example.ts
+++ b/docs/services/kms/sim-kms-sign-verify.example.ts
@@ -1,0 +1,42 @@
+/**
+ * Signing and verifying with a simulated asymmetric KMS key.
+ */
+
+import {
+  CreateKeyCommand,
+  SignCommand,
+  VerifyCommand,
+} from "@aws-sdk/client-kms";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const kms = simAws.kms();
+
+const created = await kms.createKey(
+  new CreateKeyCommand({
+    KeySpec: "ECC_NIST_P256",
+    KeyUsage: "SIGN_VERIFY",
+  }),
+);
+
+const message = Buffer.from("order-1234", "utf8");
+
+const signed = await kms.sign(
+  new SignCommand({
+    KeyId: created.KeyMetadata?.Arn,
+    Message: message,
+    SigningAlgorithm: "ECDSA_SHA_256",
+  }),
+);
+
+const verified = await kms.verify(
+  new VerifyCommand({
+    KeyId: created.KeyMetadata?.Arn,
+    Message: message,
+    Signature: signed.Signature,
+    SigningAlgorithm: "ECDSA_SHA_256",
+  }),
+);
+
+console.log(verified.SignatureValid); // true

--- a/docs/services/route53/README.md
+++ b/docs/services/route53/README.md
@@ -1024,6 +1024,12 @@ created, so a stack naming the wrong key fails here rather than on the deploymen
 cannot be deleted either, for the reason real Route53 gives: the DS record at the parent would be
 left pointing at a zone that had gone.
 
+The key's policy is not checked. Real Route53 needs the key to allow `kms:DescribeKey`,
+`kms:GetPublicKey` and `kms:Sign` to the `dnssec-route53.amazonaws.com` service principal, and
+`kms:CreateGrant` conditioned on `kms:GrantIsForAWSResource`, which is what CDK's `KeySigningKey`
+construct adds for you. A key created here without those statements takes a key-signing key anyway,
+so a template that would fail on AWS for that reason deploys here.
+
 ### DNSSEC from CloudFormation
 
 `AWS::Route53::KeySigningKey` and `AWS::Route53::DNSSEC` deploy, which is the shape CDK's
@@ -1460,6 +1466,10 @@ Where sim Route53 knowingly behaves differently from AWS:
   are the only key statuses, and `SIGNING` and `NOT_SIGNING` the only zone statuses. Real Route53
   also has `DELETING`, `ACTION_NEEDED` and `INTERNAL_FAILURE`, which describe a key mid-operation or
   a zone that needs attention, and nothing here produces either.
+- **A key-signing key's KMS key policy is not checked.** Real Route53 refuses a key that does not
+  admit the `dnssec-route53.amazonaws.com` service principal, and this does not, so a template
+  missing those statements deploys here and fails on AWS. Checking it would mean authorizing the
+  service principal against the key policy, which is its own piece of work.
 - **DNSSEC needs KMS wired to Route53.** A standalone `new SimRoute53()` has no simulated KMS to
   resolve a key ARN against, so `CreateKeySigningKey` refuses. Reach Route53 through `SimAws` when a
   test signs a zone.

--- a/docs/services/route53/README.md
+++ b/docs/services/route53/README.md
@@ -944,6 +944,160 @@ try {
 You can also call `srv.localUrl(...)` with a URL that contains the simulated hostname when you want
 the server to adapt it to the selected local port.
 
+## DNSSEC
+
+A Hosted Zone can be signed. Signing needs a key-signing key, and a key-signing key needs a KMS
+customer managed key: an enabled `ECC_NIST_P256` `SIGN_VERIFY` key, which is the only kind real
+Route53 accepts.
+
+```typescript sim-route53-dnssec
+/**
+ * Signing a simulated Route53 Hosted Zone with DNSSEC.
+ */
+
+import { CreateKeyCommand } from "@aws-sdk/client-kms";
+import {
+  CreateHostedZoneCommand,
+  CreateKeySigningKeyCommand,
+  EnableHostedZoneDNSSECCommand,
+  GetDNSSECCommand,
+} from "@aws-sdk/client-route-53";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+const zone = await simAws.route53().createHostedZone(
+  new CreateHostedZoneCommand({
+    Name: "example.test",
+    CallerReference: "dnssec-zone",
+  }),
+);
+const HostedZoneId = zone.HostedZone?.Id;
+
+const key = await simAws.kms().createKey(
+  new CreateKeyCommand({
+    KeySpec: "ECC_NIST_P256",
+    KeyUsage: "SIGN_VERIFY",
+  }),
+);
+
+await simAws.route53().createKeySigningKey(
+  new CreateKeySigningKeyCommand({
+    CallerReference: "ksk",
+    HostedZoneId,
+    KeyManagementServiceArn: key.KeyMetadata?.Arn,
+    Name: "zone_signing_key",
+    Status: "ACTIVE",
+  }),
+);
+
+await simAws
+  .route53()
+  .enableHostedZoneDnssec(new EnableHostedZoneDNSSECCommand({ HostedZoneId }));
+
+const dnssec = await simAws
+  .route53()
+  .getDnssec(new GetDNSSECCommand({ HostedZoneId }));
+
+console.log(dnssec.Status?.ServeSignature); // "SIGNING"
+
+// The DS record the zone's registrar would be given, computed from the KMS
+// key's own public key: "<KeyTag> 13 2 <DigestValue>".
+console.log(dnssec.KeySigningKeys?.[0]?.DSRecord);
+```
+
+Nothing about the key-signing key is invented. Its `PublicKey` is the KMS key's own public key in
+the base64 form RFC 4034 defines, its `KeyTag` is computed by the RFC 4034 Appendix B algorithm, and
+its `DigestValue` is the SHA-256 delegation signer digest over the zone name and the DNSKEY. So a
+test can assert on the DS record it would hand to a registrar, and two zones on two keys get two
+different ones.
+
+Adding a key-signing key does not start signing, and stopping signing leaves the keys in place, the
+same as on AWS. `ActivateKeySigningKey` and `DeactivateKeySigningKey` move a key between `ACTIVE`
+and `INACTIVE`; `DeleteKeySigningKey` refuses a key that is still active. `EnableHostedZoneDNSSEC`
+refuses a zone with no active key to sign with, and `DisableHostedZoneDNSSEC` refuses a zone that is
+not signed.
+
+A KMS key that is symmetric, disabled, or not there at all is refused when the key-signing key is
+created, so a stack naming the wrong key fails here rather than on the deployment. A signed zone
+cannot be deleted either, for the reason real Route53 gives: the DS record at the parent would be
+left pointing at a zone that had gone.
+
+### DNSSEC from CloudFormation
+
+`AWS::Route53::KeySigningKey` and `AWS::Route53::DNSSEC` deploy, which is the shape CDK's
+`KeySigningKey` construct and `CfnDNSSEC` synthesize.
+
+```typescript sim-route53-cloudformation-dnssec
+/**
+ * Deploying a signed Route53 Hosted Zone from CloudFormation.
+ */
+
+import { GetDNSSECCommand } from "@aws-sdk/client-route-53";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "dns-stack",
+  template: {
+    Resources: {
+      SiteZone: {
+        Type: "AWS::Route53::HostedZone",
+        Properties: { Name: "example.test" },
+      },
+      ZoneSigningKey: {
+        Type: "AWS::KMS::Key",
+        Properties: {
+          KeySpec: "ECC_NIST_P256",
+          KeyUsage: "SIGN_VERIFY",
+        },
+      },
+      ZoneKeySigningKey: {
+        Type: "AWS::Route53::KeySigningKey",
+        Properties: {
+          HostedZoneId: { Ref: "SiteZone" },
+          KeyManagementServiceArn: { "Fn::GetAtt": ["ZoneSigningKey", "Arn"] },
+          Name: "zone_signing_key",
+          Status: "ACTIVE",
+        },
+      },
+      ZoneDnssec: {
+        Type: "AWS::Route53::DNSSEC",
+        Properties: { HostedZoneId: { Ref: "SiteZone" } },
+        DependsOn: "ZoneKeySigningKey",
+      },
+    },
+    Outputs: {
+      ZoneId: { Value: { Ref: "SiteZone" } },
+    },
+  },
+});
+await stack.waitForDeployComplete();
+
+const hostedZoneId = stack.outputs.get("ZoneId")?.value;
+
+if (typeof hostedZoneId !== "string") {
+  throw new TypeError("The stack did not output a hosted zone ID");
+}
+
+const dnssec = await simAws
+  .route53()
+  .getDnssec(new GetDNSSECCommand({ HostedZoneId: hostedZoneId }));
+
+console.log(dnssec.Status?.ServeSignature); // "SIGNING"
+console.log(dnssec.KeySigningKeys?.[0]?.Status); // "ACTIVE"
+```
+
+`Ref` on an `AWS::Route53::KeySigningKey` returns `<HostedZoneId>|<Name>`, which is what CDK reads
+as `keySigningKeyId`. `Ref` on an `AWS::Route53::DNSSEC` returns the hosted zone ID. Neither type
+has any `Fn::GetAtt` attributes, so one is refused rather than answered.
+
+Tearing the stack down stops signing and takes the key-signing key with it, deactivating it first,
+because an active key cannot be deleted.
+
 ## CloudFormation Hosted Zones
 
 Sim CloudFormation can create Route53 Hosted Zones from `AWS::Route53::HostedZone`.
@@ -1273,8 +1427,12 @@ Sim Route53 currently supports:
 - A browser-viewable hosted zone and record summary at `dns.sim-aws.localhost`
 - DNS answers over UDP for `A`, `AAAA`, `CNAME`, `TXT`, `NS` and `SOA`, so those records can be
   queried with `dig` or any DNS client
+- `CreateKeySigningKeyCommand`, `ActivateKeySigningKeyCommand`,
+  `DeactivateKeySigningKeyCommand`, `DeleteKeySigningKeyCommand`,
+  `EnableHostedZoneDNSSECCommand`, `DisableHostedZoneDNSSECCommand` and `GetDNSSECCommand`
 - The `AWS::Route53::HostedZone` and `AWS::Route53::RecordSet` CloudFormation resources, with a
   RecordSet declaring an unstored record type skipped rather than failing the stack
+- The `AWS::Route53::KeySigningKey` and `AWS::Route53::DNSSEC` CloudFormation resources
 - CDK-created Route53 Hosted Zones and records in synthesized templates
 
 The simulator focuses on useful behaviour for tests and local development rather than full Route53
@@ -1293,3 +1451,15 @@ Where sim Route53 knowingly behaves differently from AWS:
 - **The name of such a zone is a guess.** Nothing in a synthesized template says what a looked-up
   zone is called, so the name is inferred from the records that reference it and is only as specific
   as they are. Register the zone yourself when a test depends on its name.
+- **A signed zone is signed on paper only.** No RRSIG records are produced, no DNSKEY records are
+  added to the zone, and a query answered over UDP is unsigned whatever `GetDNSSEC` says. Signing is
+  observable through `GetDNSSEC`, which is where the key-signing keys and the DS record fields are.
+  Sim Route53 is not a general DNS server, and an RRSIG needs canonical RRset ordering and
+  wire-format signing that nothing here would read back.
+- **A key-signing key does not rotate, and a zone never reports trouble.** `ACTIVE` and `INACTIVE`
+  are the only key statuses, and `SIGNING` and `NOT_SIGNING` the only zone statuses. Real Route53
+  also has `DELETING`, `ACTION_NEEDED` and `INTERNAL_FAILURE`, which describe a key mid-operation or
+  a zone that needs attention, and nothing here produces either.
+- **DNSSEC needs KMS wired to Route53.** A standalone `new SimRoute53()` has no simulated KMS to
+  resolve a key ARN against, so `CreateKeySigningKey` refuses. Reach Route53 through `SimAws` when a
+  test signs a zone.

--- a/docs/services/route53/sim-route53-cloudformation-dnssec.example.ts
+++ b/docs/services/route53/sim-route53-cloudformation-dnssec.example.ts
@@ -1,0 +1,59 @@
+/**
+ * Deploying a signed Route53 Hosted Zone from CloudFormation.
+ */
+
+import { GetDNSSECCommand } from "@aws-sdk/client-route-53";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "dns-stack",
+  template: {
+    Resources: {
+      SiteZone: {
+        Type: "AWS::Route53::HostedZone",
+        Properties: { Name: "example.test" },
+      },
+      ZoneSigningKey: {
+        Type: "AWS::KMS::Key",
+        Properties: {
+          KeySpec: "ECC_NIST_P256",
+          KeyUsage: "SIGN_VERIFY",
+        },
+      },
+      ZoneKeySigningKey: {
+        Type: "AWS::Route53::KeySigningKey",
+        Properties: {
+          HostedZoneId: { Ref: "SiteZone" },
+          KeyManagementServiceArn: { "Fn::GetAtt": ["ZoneSigningKey", "Arn"] },
+          Name: "zone_signing_key",
+          Status: "ACTIVE",
+        },
+      },
+      ZoneDnssec: {
+        Type: "AWS::Route53::DNSSEC",
+        Properties: { HostedZoneId: { Ref: "SiteZone" } },
+        DependsOn: "ZoneKeySigningKey",
+      },
+    },
+    Outputs: {
+      ZoneId: { Value: { Ref: "SiteZone" } },
+    },
+  },
+});
+await stack.waitForDeployComplete();
+
+const hostedZoneId = stack.outputs.get("ZoneId")?.value;
+
+if (typeof hostedZoneId !== "string") {
+  throw new TypeError("The stack did not output a hosted zone ID");
+}
+
+const dnssec = await simAws
+  .route53()
+  .getDnssec(new GetDNSSECCommand({ HostedZoneId: hostedZoneId }));
+
+console.log(dnssec.Status?.ServeSignature); // "SIGNING"
+console.log(dnssec.KeySigningKeys?.[0]?.Status); // "ACTIVE"

--- a/docs/services/route53/sim-route53-dnssec.example.ts
+++ b/docs/services/route53/sim-route53-dnssec.example.ts
@@ -1,0 +1,54 @@
+/**
+ * Signing a simulated Route53 Hosted Zone with DNSSEC.
+ */
+
+import { CreateKeyCommand } from "@aws-sdk/client-kms";
+import {
+  CreateHostedZoneCommand,
+  CreateKeySigningKeyCommand,
+  EnableHostedZoneDNSSECCommand,
+  GetDNSSECCommand,
+} from "@aws-sdk/client-route-53";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+const zone = await simAws.route53().createHostedZone(
+  new CreateHostedZoneCommand({
+    Name: "example.test",
+    CallerReference: "dnssec-zone",
+  }),
+);
+const HostedZoneId = zone.HostedZone?.Id;
+
+const key = await simAws.kms().createKey(
+  new CreateKeyCommand({
+    KeySpec: "ECC_NIST_P256",
+    KeyUsage: "SIGN_VERIFY",
+  }),
+);
+
+await simAws.route53().createKeySigningKey(
+  new CreateKeySigningKeyCommand({
+    CallerReference: "ksk",
+    HostedZoneId,
+    KeyManagementServiceArn: key.KeyMetadata?.Arn,
+    Name: "zone_signing_key",
+    Status: "ACTIVE",
+  }),
+);
+
+await simAws
+  .route53()
+  .enableHostedZoneDnssec(new EnableHostedZoneDNSSECCommand({ HostedZoneId }));
+
+const dnssec = await simAws
+  .route53()
+  .getDnssec(new GetDNSSECCommand({ HostedZoneId }));
+
+console.log(dnssec.Status?.ServeSignature); // "SIGNING"
+
+// The DS record the zone's registrar would be given, computed from the KMS
+// key's own public key: "<KeyTag> 13 2 <DigestValue>".
+console.log(dnssec.KeySigningKeys?.[0]?.DSRecord);

--- a/src/service/aws/factory/sim-aws-account-region-service-builder.ts
+++ b/src/service/aws/factory/sim-aws-account-region-service-builder.ts
@@ -91,7 +91,6 @@ export class SimAwsAccountRegionServiceBuilder {
       ...this.scoped(scope),
       dnsRecords: simAwsAcmDnsRecords(this.registries),
     });
-
     this.registries.acm.register(scope.accountRegionScope, acm);
 
     return acm;
@@ -160,10 +159,13 @@ export class SimAwsAccountRegionServiceBuilder {
    * Create simulated KMS for an Account Region scope.
    *
    * KMS keys are Region-scoped on real AWS: a key ARN names its Region, and a
-   * ciphertext produced in one Region cannot be decrypted in another.
+   * ciphertext produced in one Region cannot be decrypted in another. That is
+   * why it is registered: a key ARN carries the Region another service needs.
    */
   createKms(scope: SimAwsAccountRegionContainer): SimKms {
-    return new SimKms(this.scoped(scope));
+    const kms = new SimKms(this.scoped(scope));
+    this.registries.kms.register(scope.accountRegionScope, kms);
+    return kms;
   }
 
   /** Create simulated Lambda for an Account Region scope. */

--- a/src/service/aws/factory/sim-aws-account-service-cache.ts
+++ b/src/service/aws/factory/sim-aws-account-service-cache.ts
@@ -11,6 +11,7 @@ import { makeSimCfCustomOriginDispatcher } from "../../cloudfront/origin/custom/
 import { SimCloudFront } from "../../cloudfront/sim-cloudfront.js";
 import { SimRoute53 } from "../../route53/index.js";
 import type { SimRoute53Registry } from "../../route53/registry/sim-route53-registry.js";
+import type { SimKmsRegistry } from "../../kms/registry/sim-kms-registry.js";
 import { SimIam } from "../../iam/index.js";
 import type { SimIamRegistry } from "../../iam/registry/sim-iam-registry.js";
 import {
@@ -28,6 +29,7 @@ interface SimAwsAccountServiceCacheProperties {
   readonly acmRegistry: SimAcmRegistry;
   readonly cloudFrontRegistry: SimCloudFrontRegistry;
   readonly route53Registry: SimRoute53Registry;
+  readonly kmsRegistry: SimKmsRegistry;
   readonly serviceHosts: SimAwsServiceHosts;
   readonly iamRegistry: SimIamRegistry;
   readonly accessKeyRegistry: SimIamAccessKeyRegistry;
@@ -62,6 +64,7 @@ export class SimAwsAccountServiceCache {
   private readonly iamRegistry: SimIamRegistry;
   private readonly accessKeyRegistry: SimIamAccessKeyRegistry;
   private readonly route53Registry: SimRoute53Registry;
+  private readonly kmsRegistry: SimKmsRegistry;
   private readonly serviceHosts: SimAwsServiceHosts;
 
   /**
@@ -81,6 +84,7 @@ export class SimAwsAccountServiceCache {
     this.iamRegistry = properties.iamRegistry;
     this.accessKeyRegistry = properties.accessKeyRegistry;
     this.route53Registry = properties.route53Registry;
+    this.kmsRegistry = properties.kmsRegistry;
     this.serviceHosts = properties.serviceHosts;
   }
 
@@ -150,6 +154,9 @@ export class SimAwsAccountServiceCache {
           background: this.background,
           route53Registry: this.route53Registry,
           serviceHosts: this.serviceHosts,
+          // A DNSSEC key-signing key names a KMS key by ARN, in whichever
+          // Region holds it, so Route53 resolves it through the registry.
+          kmsKeys: this.kmsRegistry,
         }),
     );
   }

--- a/src/service/aws/factory/sim-aws-scoped-service-registries.ts
+++ b/src/service/aws/factory/sim-aws-scoped-service-registries.ts
@@ -1,6 +1,7 @@
 import { SimAcmRegistry } from "../../acm/registry/sim-acm-registry.js";
 import { SimCognitoDomainRegistry } from "../../cognito/registry/sim-cognito-domain-registry.js";
 import { SimCognitoUserPoolRegistry } from "../../cognito/registry/sim-cognito-user-pool-registry.js";
+import { SimKmsRegistry } from "../../kms/registry/sim-kms-registry.js";
 import { SimRoute53Registry } from "../../route53/registry/sim-route53-registry.js";
 import { SimS3GlobalRegistry } from "../../s3/sim-s3-global-registry.js";
 
@@ -34,6 +35,13 @@ export class SimAwsScopedServiceRegistries {
    * where DNS resolution finds the pool a hosted request is for.
    */
   public readonly cognitoDomains = new SimCognitoDomainRegistry();
+
+  /**
+   * Indexes the account/region-scoped KMS facades created for one SimAws
+   * instance, so services holding only a key ARN, such as Route53 DNSSEC, can
+   * resolve the key it names.
+   */
+  public readonly kms = new SimKmsRegistry();
 
   /**
    * Owns hosted zone and DNS record state shared by the account-scoped Route53

--- a/src/service/aws/factory/sim-aws-service-factory.ts
+++ b/src/service/aws/factory/sim-aws-service-factory.ts
@@ -114,6 +114,7 @@ export class SimAwsServiceFactory {
       acmRegistry: this.registries.acm,
       cloudFrontRegistry: this.cloudFrontRegistry,
       route53Registry: this.registries.route53,
+      kmsRegistry: this.registries.kms,
       // A Cognito hosted domain answers on a hostname of its own, so DNS
       // resolution asks the registry holding those domains about it.
       serviceHosts: this.registries.cognitoDomains,

--- a/src/service/cloudformation/resource/cfn/route53/sim-route53-cfn-value-adapter.ts
+++ b/src/service/cloudformation/resource/cfn/route53/sim-route53-cfn-value-adapter.ts
@@ -1,5 +1,8 @@
 import { SimRoute53HostedZone } from "../../../../route53/hosted-zone/sim-route53-hosted-zone.js";
+import { SimRoute53KeySigningKey } from "../../../../route53/dnssec/sim-route53-key-signing-key.js";
+import { SimRoute53DnssecCfn } from "./sim-route53-dnssec-cfn.js";
 import { SimRoute53HostedZoneCfn } from "./sim-route53-hosted-zone-cfn.js";
+import { SimRoute53KeySigningKeyCfn } from "./sim-route53-key-signing-key-cfn.js";
 import type {
   SimCfnResourceValueAdapterProperties,
   SimCfnServiceValueAdapter,
@@ -16,6 +19,24 @@ export function route53ValueAdapter(
     properties.simResource instanceof SimRoute53HostedZone
   ) {
     return new SimRoute53HostedZoneCfn({ hostedZone: properties.simResource });
+  }
+
+  if (
+    properties.type === "AWS::Route53::KeySigningKey" &&
+    properties.simResource instanceof SimRoute53KeySigningKey
+  ) {
+    return new SimRoute53KeySigningKeyCfn({
+      keySigningKey: properties.simResource,
+    });
+  }
+
+  // A DNSSEC Resource creates nothing of its own, so the simulated resource
+  // behind it is the zone it turns signing on for.
+  if (
+    properties.type === "AWS::Route53::DNSSEC" &&
+    properties.simResource instanceof SimRoute53HostedZone
+  ) {
+    return new SimRoute53DnssecCfn({ hostedZone: properties.simResource });
   }
 
   return undefined;

--- a/src/service/cloudformation/resource/cfn/route53/sim-route53-dnssec-cfn.ts
+++ b/src/service/cloudformation/resource/cfn/route53/sim-route53-dnssec-cfn.ts
@@ -1,0 +1,37 @@
+import type { SimRoute53HostedZone } from "../../../../route53/hosted-zone/sim-route53-hosted-zone.js";
+import type { SimCfnTemplateValue } from "../../../template/value/sim-cfn-template-value.js";
+import type { SimCfnResourceValueAdapter } from "../sim-cfn-resource-value-adapter.js";
+
+interface SimRoute53DnssecCfnProperties {
+  readonly hostedZone: SimRoute53HostedZone;
+}
+
+/**
+ * CloudFormation-facing values for DNSSEC signing on a simulated Hosted Zone.
+ */
+export class SimRoute53DnssecCfn implements SimCfnResourceValueAdapter {
+  private readonly hostedZone: SimRoute53HostedZone;
+
+  constructor(properties: SimRoute53DnssecCfnProperties) {
+    this.hostedZone = properties.hostedZone;
+  }
+
+  /**
+   * AWS::Route53::DNSSEC Ref returns the hosted zone ID, which is the whole of
+   * the Resource's identity: it holds nothing of its own beyond the zone it
+   * turns signing on for.
+   */
+  refValue(): SimCfnTemplateValue {
+    return this.hostedZone.id;
+  }
+
+  /**
+   * AWS::Route53::DNSSEC has no Fn::GetAtt attributes, so one is refused
+   * rather than answered with something invented.
+   */
+  attributeValue(attributeName: string): SimCfnTemplateValue {
+    throw new Error(
+      `Unsupported AWS::Route53::DNSSEC attribute ${attributeName}`,
+    );
+  }
+}

--- a/src/service/cloudformation/resource/cfn/route53/sim-route53-key-signing-key-cfn.ts
+++ b/src/service/cloudformation/resource/cfn/route53/sim-route53-key-signing-key-cfn.ts
@@ -1,0 +1,36 @@
+import type { SimRoute53KeySigningKey } from "../../../../route53/dnssec/sim-route53-key-signing-key.js";
+import type { SimCfnTemplateValue } from "../../../template/value/sim-cfn-template-value.js";
+import type { SimCfnResourceValueAdapter } from "../sim-cfn-resource-value-adapter.js";
+
+interface SimRoute53KeySigningKeyCfnProperties {
+  readonly keySigningKey: SimRoute53KeySigningKey;
+}
+
+/**
+ * CloudFormation-facing values for a simulated Route53 key-signing key.
+ */
+export class SimRoute53KeySigningKeyCfn implements SimCfnResourceValueAdapter {
+  private readonly keySigningKey: SimRoute53KeySigningKey;
+
+  constructor(properties: SimRoute53KeySigningKeyCfnProperties) {
+    this.keySigningKey = properties.keySigningKey;
+  }
+
+  /**
+   * AWS::Route53::KeySigningKey Ref returns the hosted zone ID and the key
+   * name joined by a pipe, which is what CDK's `keySigningKeyId` reads.
+   */
+  refValue(): SimCfnTemplateValue {
+    return `${this.keySigningKey.hostedZoneId}|${this.keySigningKey.name}`;
+  }
+
+  /**
+   * AWS::Route53::KeySigningKey has no Fn::GetAtt attributes, so one is
+   * refused rather than answered with something invented.
+   */
+  attributeValue(attributeName: string): SimCfnTemplateValue {
+    throw new Error(
+      `Unsupported AWS::Route53::KeySigningKey attribute ${attributeName}`,
+    );
+  }
+}

--- a/src/service/kms/README.md
+++ b/src/service/kms/README.md
@@ -3,10 +3,11 @@
 This directory contains the simulated KMS service implementation.
 
 The guiding decision here is that the cryptography is real. A simulated key holds real AES-256 key
-material and every operation goes through Node.js's `crypto`, rather than a stand-in that records
-what it was asked to encrypt. That costs almost nothing in a test suite and it buys behaviour that
-would otherwise have to be hand-modelled: a ciphertext that cannot be read without its key, an
-authentication tag that fails on tampering, and an encryption context that has to match.
+material, or a real key pair, and every operation goes through Node.js's `crypto`, rather than a
+stand-in that records what it was asked to encrypt. That costs almost nothing in a test suite and it
+buys behaviour that would otherwise have to be hand-modelled: a ciphertext that cannot be read
+without its key, an authentication tag that fails on tampering, an encryption context that has to
+match, and a signature that verifies against the public key `GetPublicKey` hands out.
 
 ## Entry points
 
@@ -26,9 +27,21 @@ material and its lifecycle. `SimKmsKeyLifecycle` holds the state and the rules a
 transitions are legal, so no command handler has to remember that a key pending deletion cannot be
 enabled, or which of the two failures an unusable key produces.
 
-`SimKmsKeyMaterial` holds the AES-256 bytes and performs the cipher operations. Nothing exposes the
-bytes, mirroring the fact that real key material never leaves KMS. That is a modelling choice, not a
-security boundary: this all runs in one process.
+`SimKmsKeyMaterial` is what a key holds and operates through. It declares every operation and
+refuses each one by default, because that is how AWS answers one: an `Encrypt` against a signing key
+is not an unknown operation, it is `InvalidKeyUsageException` on a key that cannot do it. Two
+subclasses override what their usage allows.
+
+`SimKmsSymmetricKeyMaterial` holds the AES-256 bytes and performs the cipher operations.
+`SimKmsSigningKeyMaterial` holds a key pair and performs the signing ones. Neither exposes its
+private material, mirroring the fact that real key material never leaves KMS. That is a modelling
+choice, not a security boundary: this all runs in one process.
+
+`key/spec/` is the third answer that used to be a constant. `SimKmsKeySpec` says what a key of one
+spec can do: which usage it has, which algorithms it offers, and which Node key pair it needs.
+`sim-kms-key-specs.ts` is the catalogue, and a spec absent from it is a spec `CreateKey` refuses.
+`SimKmsKeyType` resolves a requested spec and usage pair against that catalogue, and reports which
+of the ways it can fail applies.
 
 `SimKmsCiphertextBlob` encodes the opaque blob KMS hands back. Real blobs are opaque to the caller
 but not to KMS, which is why `Decrypt` needs no `KeyId` for a symmetric key. The layout keeps that
@@ -54,6 +67,8 @@ rather than one class per command, so the `SimKms` facade stays a delegation:
 - `command/key/` — `CreateKey` and `DescribeKey`; `ListKeys`; the lifecycle commands; the key policy
   commands
 - `command/crypto/` — `Encrypt` and `Decrypt`; `GenerateDataKey`
+- `command/sign/` — `Sign`, `Verify` and `GetPublicKey`, which go together because they are the
+  operations an asymmetric signing key answers and each has to refuse a key that is not one
 - `command/alias/` — `CreateAlias`, `ListAliases`
 - `command/authorize/` — the shared IAM authorizer
 - `command/sim-kms-command.types.ts` — the command types gathered for the facade
@@ -61,8 +76,18 @@ rather than one class per command, so the `SimKms` facade stays a delegation:
 Input validation that is a rule in its own right lives beside the commands that apply it, rather
 than inside them: `SimKmsKeyType` for the key types this simulation models, `SimKmsPendingWindow`
 for the deletion recovery window, `SimKmsDataKeySpec` for data key lengths, `SimKmsPolicyDocument`
-for the JSON policy both `CreateKey` and `PutKeyPolicy` take, and `SimKmsCiphertextKey` for finding
-the key behind a ciphertext.
+for the JSON policy both `CreateKey` and `PutKeyPolicy` take, `SimKmsCiphertextKey` for finding the
+key behind a ciphertext, and `SimKmsSignedMessage` for the message `Sign` and `Verify` take.
+
+`SimKmsSignedMessage` is where the one deliberate divergence in this service lives. A `MessageType`
+of `DIGEST` is refused, because Node cannot sign a digest that has already been computed:
+`crypto.sign` with no algorithm hashes what it is given rather than signing it. A signature made
+that way would not be the one real KMS makes and would not verify against the message anywhere
+outside this simulator, which is worse than not answering at all.
+
+`SimKmsRegistry` indexes the KMS facade of each account and region for one simulation, so a service
+holding only a key ARN can reach the key it names. Simulated Route53 uses it to check the customer
+managed key behind a DNSSEC key-signing key.
 
 As elsewhere, implementation code under `src/` does not import real AWS SDK packages. The structural
 command types in `*.command.ts` match the SDK shapes closely enough for callers to pass real SDK

--- a/src/service/kms/cfn/sim-cfn-kms-validation.iso.test.ts
+++ b/src/service/kms/cfn/sim-cfn-kms-validation.iso.test.ts
@@ -144,8 +144,9 @@ describe("KMS CloudFormation Resource validation", () => {
     );
   });
 
-  it("refuses an asymmetric KeySpec", async () => {
-    // Given a template asking for an asymmetric key.
+  it("refuses an asymmetric KeySpec used for encryption", async () => {
+    // Given a template asking for an RSA key to encrypt with, which real KMS
+    // allows and this simulation does not.
     // When the Resource is created, then CreateKey refuses it in the same
     // terms it refuses an SDK caller.
     const error = await createKmsResource("Key", {
@@ -153,7 +154,18 @@ describe("KMS CloudFormation Resource validation", () => {
       KeyUsage: "ENCRYPT_DECRYPT",
     });
 
-    assertStringIncludes(error.message, "KeySpec 'RSA_2048' is not simulated");
+    assertStringIncludes(
+      error.message,
+      "KeyUsage 'ENCRYPT_DECRYPT' with KeySpec 'RSA_2048' is not simulated",
+    );
+  });
+
+  it("refuses a KeySpec this simulation does not create", async () => {
+    // Given a template asking for a key spec with no simulated key behind it.
+    // When the Resource is created, then it is refused.
+    const error = await createKmsResource("Key", { KeySpec: "SM2" });
+
+    assertStringIncludes(error.message, "KeySpec 'SM2' is not simulated");
   });
 
   it("refuses an HMAC KeyUsage", async () => {

--- a/src/service/kms/command/key/sim-kms-key-commands.ts
+++ b/src/service/kms/command/key/sim-kms-key-commands.ts
@@ -48,7 +48,7 @@ export class SimKmsKeyCommands {
     command: SimCreateKeyCommand,
     options?: SimKmsRequestOptions,
   ): SimCreateKeyCommandOutput {
-    this.keyType.require(
+    const keySpec = this.keyType.require(
       command.input.KeyUsage,
       command.input.KeySpec,
       command.input.Origin,
@@ -58,6 +58,7 @@ export class SimKmsKeyCommands {
     const key = this.keyFactory.make({
       description: command.input.Description,
       policy: this.policyDocument.parseOptional(command.input.Policy),
+      keySpec,
     });
 
     this.keys.add(key);

--- a/src/service/kms/command/key/sim-kms-key-type.ts
+++ b/src/service/kms/command/key/sim-kms-key-type.ts
@@ -109,7 +109,13 @@ export class SimKmsKeyType {
     keyUsage: string | undefined,
     requestedKeySpec: string | undefined,
   ): void {
-    if (keyUsage === undefined || keyUsage === spec.keyUsage) {
+    if (keyUsage === undefined) {
+      this.requireDefaultableSpec(spec);
+
+      return;
+    }
+
+    if (keyUsage === spec.keyUsage) {
       return;
     }
 
@@ -121,6 +127,24 @@ export class SimKmsKeyType {
 
     throw new SimKmsInvalidKeyUsageException(
       `KeyUsage '${keyUsage}' with KeySpec '${spec.name}' is not simulated: simulated KMS creates ${spec.name} keys for ${spec.keyUsage}`,
+    );
+  }
+
+  /**
+   * Refuse a spec that cannot take the default key usage.
+   *
+   * `KeyUsage` is optional only for a symmetric encryption key. Every other
+   * spec requires it, so leaving it out is a request AWS refuses rather than
+   * one it fills in, and filling it in here would create a key real KMS would
+   * not have made.
+   */
+  private requireDefaultableSpec(spec: SimKmsKeySpec): void {
+    if (!spec.isAsymmetric) {
+      return;
+    }
+
+    throw new SimKmsInvalidKeyUsageException(
+      `KeySpec '${spec.name}' needs a KeyUsage: it is only optional for a ${simKmsSymmetricKeySpecName} key`,
     );
   }
 }

--- a/src/service/kms/command/key/sim-kms-key-type.ts
+++ b/src/service/kms/command/key/sim-kms-key-type.ts
@@ -2,46 +2,125 @@ import {
   SimKmsInvalidKeyUsageException,
   SimKmsValidationException,
 } from "../../error/sim-kms.error.js";
+import {
+  SimKmsKeyUsage,
+  type SimKmsKeySpec,
+} from "../../key/spec/sim-kms-key-spec.js";
+import {
+  simKmsKeySpecNames,
+  simKmsKeySpecs,
+  simKmsSymmetricKeySpecName,
+} from "../../key/spec/sim-kms-key-specs.js";
 
-/**
- * The only key type this simulation models.
- */
-const symmetricKeySpec = "SYMMETRIC_DEFAULT";
-const encryptDecryptUsage = "ENCRYPT_DECRYPT";
 const kmsOrigin = "AWS_KMS";
 
 /**
- * Checks a requested key type against what this simulation models.
+ * The key usages this simulation has key specs for.
+ */
+const simKmsKeyUsages: ReadonlySet<string> = new Set([
+  SimKmsKeyUsage.EncryptDecrypt,
+  SimKmsKeyUsage.SignVerify,
+]);
+
+/**
+ * Resolves the key spec a CreateKey request asks for.
  *
- * Asymmetric keys, HMAC keys and imported material all behave differently
- * enough that pretending a symmetric key is one of them would make a passing
- * test meaningless, so an unmodelled type is refused rather than substituted.
+ * A key spec and key usage pair says what the key is, so a pair this
+ * simulation does not model is refused rather than substituted: asymmetric
+ * encryption, HMAC and key agreement keys all behave differently enough that a
+ * signing key or a symmetric one standing in for them would make a passing
+ * test meaningless. Imported key material is refused for the same reason.
  */
 export class SimKmsKeyType {
   /**
-   * Refuse a key type this simulation does not model.
+   * Resolve a requested key type, or refuse one this simulation does not
+   * model.
    */
   require(
     keyUsage: string | undefined,
     keySpec: string | undefined,
     origin: string | undefined,
-  ): void {
-    if (keyUsage !== undefined && keyUsage !== encryptDecryptUsage) {
-      throw new SimKmsInvalidKeyUsageException(
-        `KeyUsage '${keyUsage}' is not simulated: simulated KMS creates ${encryptDecryptUsage} keys`,
-      );
+  ): SimKmsKeySpec {
+    this.requireSimulatedOrigin(origin);
+    this.requireSimulatedKeyUsage(keyUsage);
+
+    const spec = this.requireSimulatedSpec(
+      keySpec ?? simKmsSymmetricKeySpecName,
+    );
+
+    this.requireSpecAllowsUsage(spec, keyUsage, keySpec);
+
+    return spec;
+  }
+
+  /**
+   * Refuse a key usage no simulated key spec has.
+   *
+   * HMAC and key agreement keys are the two this rules out. Neither has a spec
+   * here at all, so saying the usage is unsimulated is more use than sending
+   * the caller looking for a spec that would allow it.
+   */
+  private requireSimulatedKeyUsage(keyUsage: string | undefined): void {
+    if (keyUsage === undefined || simKmsKeyUsages.has(keyUsage)) {
+      return;
     }
 
-    if (keySpec !== undefined && keySpec !== symmetricKeySpec) {
-      throw new SimKmsInvalidKeyUsageException(
-        `KeySpec '${keySpec}' is not simulated: simulated KMS creates ${symmetricKeySpec} keys`,
-      );
-    }
+    throw new SimKmsInvalidKeyUsageException(
+      `KeyUsage '${keyUsage}' is not simulated: simulated KMS creates ${[...simKmsKeyUsages].join(" and ")} keys`,
+    );
+  }
 
+  /**
+   * Refuse key material this simulation does not generate itself.
+   */
+  private requireSimulatedOrigin(origin: string | undefined): void {
     if (origin !== undefined && origin !== kmsOrigin) {
       throw new SimKmsValidationException(
         `Origin '${origin}' is not simulated: simulated KMS generates its own key material`,
       );
     }
+  }
+
+  /**
+   * Resolve a key spec name, or refuse one this simulation does not create.
+   */
+  private requireSimulatedSpec(keySpecName: string): SimKmsKeySpec {
+    const spec = simKmsKeySpecs.get(keySpecName);
+
+    if (spec === undefined) {
+      throw new SimKmsInvalidKeyUsageException(
+        `KeySpec '${keySpecName}' is not simulated: simulated KMS creates ${simKmsKeySpecNames().join(", ")} keys`,
+      );
+    }
+
+    return spec;
+  }
+
+  /**
+   * Refuse a key usage the resolved spec does not have here.
+   *
+   * Real KMS offers the RSA specs for encryption as well as signing, and
+   * offers no spec at all for a `SIGN_VERIFY` key that names none. Both of
+   * those come out here, and the two need different explanations, so the
+   * refusal says which case it is rather than repeating the pair back.
+   */
+  private requireSpecAllowsUsage(
+    spec: SimKmsKeySpec,
+    keyUsage: string | undefined,
+    requestedKeySpec: string | undefined,
+  ): void {
+    if (keyUsage === undefined || keyUsage === spec.keyUsage) {
+      return;
+    }
+
+    if (requestedKeySpec === undefined) {
+      throw new SimKmsInvalidKeyUsageException(
+        `KeyUsage '${keyUsage}' needs a KeySpec: the default ${simKmsSymmetricKeySpecName} spec is ${spec.keyUsage} only`,
+      );
+    }
+
+    throw new SimKmsInvalidKeyUsageException(
+      `KeyUsage '${keyUsage}' with KeySpec '${spec.name}' is not simulated: simulated KMS creates ${spec.name} keys for ${spec.keyUsage}`,
+    );
   }
 }

--- a/src/service/kms/command/key/sim-kms-key-validation.iso.test.ts
+++ b/src/service/kms/command/key/sim-kms-key-validation.iso.test.ts
@@ -52,6 +52,22 @@ describe("KMS CreateKey validation", () => {
     assertInstanceOf(error, SimKmsInvalidKeyUsageException);
   });
 
+  it("refuses an asymmetric key spec with no key usage", async () => {
+    // Given a simulation where KeyUsage is only optional for a symmetric key.
+    const simAws = new SimAws();
+
+    // When an ECC key is asked for without one, which real KMS requires.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws
+        .kms()
+        .createKey(new CreateKeyCommand({ KeySpec: "ECC_NIST_P256" })),
+    );
+
+    // Then it is refused rather than filled in, because a key created that
+    // way would be a key real KMS would not have made.
+    assertInstanceOf(error, SimKmsInvalidKeyUsageException);
+  });
+
   it("refuses a signing key usage with no key spec", async () => {
     // Given a simulation whose default key spec is symmetric.
     const simAws = new SimAws();

--- a/src/service/kms/command/key/sim-kms-key-validation.iso.test.ts
+++ b/src/service/kms/command/key/sim-kms-key-validation.iso.test.ts
@@ -20,27 +20,60 @@ import {
 const plaintext = Uint8Array.from(Buffer.from("hunter2", "utf8"));
 
 describe("KMS CreateKey validation", () => {
-  it("refuses an asymmetric key spec", async () => {
-    // Given a simulation that models only symmetric keys.
+  it("refuses a key spec this simulation does not create", async () => {
+    // Given a simulation that models a fixed set of key specs.
     const simAws = new SimAws();
 
-    // When an asymmetric key is asked for.
+    // When a key spec outside that set is asked for.
     const error = await assertThrowsErrorAsync(async () =>
-      simAws.kms().createKey(new CreateKeyCommand({ KeySpec: "RSA_2048" })),
+      simAws.kms().createKey(new CreateKeyCommand({ KeySpec: "SM2" })),
     );
 
-    // Then it is refused rather than quietly made symmetric, so a test cannot
-    // pass against a key type this simulation does not model.
+    // Then it is refused rather than quietly made something else, so a test
+    // cannot pass against a key type this simulation does not model.
     assertInstanceOf(error, SimKmsInvalidKeyUsageException);
   });
 
-  it("refuses a key usage other than encrypt and decrypt", async () => {
-    // Given a simulation that models only encryption keys.
+  it("refuses an asymmetric key spec used for encryption", async () => {
+    // Given a simulation whose asymmetric keys only sign.
     const simAws = new SimAws();
 
-    // When a signing key is asked for.
+    // When an RSA key is asked for to encrypt with, which real KMS allows.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.kms().createKey(
+        new CreateKeyCommand({
+          KeySpec: "RSA_2048",
+          KeyUsage: "ENCRYPT_DECRYPT",
+        }),
+      ),
+    );
+
+    // Then it is refused.
+    assertInstanceOf(error, SimKmsInvalidKeyUsageException);
+  });
+
+  it("refuses a signing key usage with no key spec", async () => {
+    // Given a simulation whose default key spec is symmetric.
+    const simAws = new SimAws();
+
+    // When a signing key is asked for without naming a spec that can sign.
     const error = await assertThrowsErrorAsync(async () =>
       simAws.kms().createKey(new CreateKeyCommand({ KeyUsage: "SIGN_VERIFY" })),
+    );
+
+    // Then it is refused, as real KMS refuses it.
+    assertInstanceOf(error, SimKmsInvalidKeyUsageException);
+  });
+
+  it("refuses a key usage no simulated key spec has", async () => {
+    // Given a simulation with no HMAC keys.
+    const simAws = new SimAws();
+
+    // When an HMAC key is asked for.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws
+        .kms()
+        .createKey(new CreateKeyCommand({ KeyUsage: "GENERATE_VERIFY_MAC" })),
     );
 
     // Then it is refused.

--- a/src/service/kms/command/sign/sign.command.ts
+++ b/src/service/kms/command/sign/sign.command.ts
@@ -1,0 +1,79 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type { SimKmsKeyUsage } from "../../key/spec/sim-kms-key-spec.js";
+
+/**
+ * Minimal structural sim KMS Sign command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/kms/command/SignCommand/
+ */
+export interface SimSignCommand {
+  readonly input: SimSignCommandInput;
+}
+
+export interface SimSignCommandInput {
+  readonly KeyId?: string | undefined;
+  readonly Message?: Uint8Array | undefined;
+
+  /**
+   * `RAW` only. A `DIGEST` message is refused, because Node cannot sign a
+   * digest that has already been computed.
+   */
+  readonly MessageType?: string | undefined;
+
+  readonly SigningAlgorithm?: string | undefined;
+}
+
+export interface SimSignCommandOutput {
+  readonly KeyId?: string | undefined;
+  readonly Signature?: Uint8Array | undefined;
+  readonly SigningAlgorithm?: string | undefined;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim KMS Verify command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/kms/command/VerifyCommand/
+ */
+export interface SimVerifyCommand {
+  readonly input: SimVerifyCommandInput;
+}
+
+export interface SimVerifyCommandInput {
+  readonly KeyId?: string | undefined;
+  readonly Message?: Uint8Array | undefined;
+  readonly MessageType?: string | undefined;
+  readonly Signature?: Uint8Array | undefined;
+  readonly SigningAlgorithm?: string | undefined;
+}
+
+export interface SimVerifyCommandOutput {
+  readonly KeyId?: string | undefined;
+  readonly SignatureValid?: boolean | undefined;
+  readonly SigningAlgorithm?: string | undefined;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim KMS GetPublicKey command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/kms/command/GetPublicKeyCommand/
+ */
+export interface SimGetPublicKeyCommand {
+  readonly input: SimGetPublicKeyCommandInput;
+}
+
+export interface SimGetPublicKeyCommandInput {
+  readonly KeyId?: string | undefined;
+}
+
+export interface SimGetPublicKeyCommandOutput {
+  readonly KeyId?: string | undefined;
+  readonly PublicKey?: Uint8Array | undefined;
+  readonly KeySpec?: string | undefined;
+  readonly CustomerMasterKeySpec?: string | undefined;
+  readonly KeyUsage?: SimKmsKeyUsage | undefined;
+  readonly EncryptionAlgorithms?: readonly string[] | undefined;
+  readonly SigningAlgorithms?: readonly string[] | undefined;
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/kms/command/sign/sim-kms-sign-commands.ts
+++ b/src/service/kms/command/sign/sim-kms-sign-commands.ts
@@ -1,0 +1,132 @@
+import { SimKmsInvalidSignatureException } from "../../error/sim-kms.error.js";
+import type { SimKmsKey } from "../../key/sim-kms-key.js";
+import type { SimKmsKeyStore } from "../../key/sim-kms-key-store.js";
+import type { SimKmsAuthorizer } from "../authorize/sim-kms-authorizer.js";
+import type { SimKmsRequestOptions } from "../sim-kms-request-options.js";
+import { SimKmsSignedMessage } from "./sim-kms-signed-message.js";
+import type {
+  SimGetPublicKeyCommand,
+  SimGetPublicKeyCommandOutput,
+  SimSignCommand,
+  SimSignCommandOutput,
+  SimVerifyCommand,
+  SimVerifyCommandOutput,
+} from "./sign.command.js";
+
+interface SimKmsSignCommandsProperties {
+  readonly keys: SimKmsKeyStore;
+  readonly authorizer: SimKmsAuthorizer;
+}
+
+/**
+ * The Sign, Verify and GetPublicKey commands of one simulated KMS scope.
+ *
+ * The three go together: they are the operations an asymmetric signing key
+ * answers, they share the key store and the authorizer, and each of them has
+ * to refuse a key whose usage is not SIGN_VERIFY.
+ */
+export class SimKmsSignCommands {
+  private readonly keys: SimKmsKeyStore;
+  private readonly authorizer: SimKmsAuthorizer;
+  private readonly message = new SimKmsSignedMessage();
+
+  constructor(properties: SimKmsSignCommandsProperties) {
+    this.keys = properties.keys;
+    this.authorizer = properties.authorizer;
+  }
+
+  /**
+   * Sign a message under a key.
+   */
+  sign(
+    command: SimSignCommand,
+    options?: SimKmsRequestOptions,
+  ): SimSignCommandOutput {
+    const message = this.message.require(
+      command.input.Message,
+      command.input.MessageType,
+    );
+    const key = this.authorizedKey("kms:Sign", command.input.KeyId, options);
+    const algorithm = key.keySpec.requireSigningAlgorithm(
+      command.input.SigningAlgorithm,
+    );
+
+    return {
+      $metadata: {},
+      KeyId: key.arn,
+      Signature: key.sign(message, algorithm),
+      SigningAlgorithm: algorithm.name,
+    };
+  }
+
+  /**
+   * Check a signature against a message and a key.
+   *
+   * A signature that does not check out fails rather than returning false.
+   * That is what real KMS does, so a caller that only handles the exception is
+   * not left believing an unverified signature was good.
+   */
+  verify(
+    command: SimVerifyCommand,
+    options?: SimKmsRequestOptions,
+  ): SimVerifyCommandOutput {
+    const message = this.message.require(
+      command.input.Message,
+      command.input.MessageType,
+    );
+    const key = this.authorizedKey("kms:Verify", command.input.KeyId, options);
+    const algorithm = key.keySpec.requireSigningAlgorithm(
+      command.input.SigningAlgorithm,
+    );
+    const signature = command.input.Signature ?? new Uint8Array();
+
+    if (!key.verify(message, signature, algorithm)) {
+      throw new SimKmsInvalidSignatureException(
+        `The signature was not verified by key ${key.arn} under ${algorithm.name}`,
+      );
+    }
+
+    return {
+      $metadata: {},
+      KeyId: key.arn,
+      SignatureValid: true,
+      SigningAlgorithm: algorithm.name,
+    };
+  }
+
+  /**
+   * Get a key's public key.
+   */
+  getPublicKey(
+    command: SimGetPublicKeyCommand,
+    options?: SimKmsRequestOptions,
+  ): SimGetPublicKeyCommandOutput {
+    const key = this.authorizedKey(
+      "kms:GetPublicKey",
+      command.input.KeyId,
+      options,
+    );
+    const keySpec = key.keySpec;
+
+    return {
+      $metadata: {},
+      KeyId: key.arn,
+      PublicKey: key.publicKeyDer(),
+      KeySpec: keySpec.name,
+      CustomerMasterKeySpec: keySpec.name,
+      KeyUsage: keySpec.keyUsage,
+      SigningAlgorithms: keySpec.signingAlgorithmNames(),
+    };
+  }
+
+  private authorizedKey(
+    action: string,
+    keyId: string | undefined,
+    options: SimKmsRequestOptions | undefined,
+  ): SimKmsKey {
+    const key = this.keys.require(keyId);
+    this.authorizer.authorizeKey(action, key, options);
+
+    return key;
+  }
+}

--- a/src/service/kms/command/sign/sim-kms-sign-commands.ts
+++ b/src/service/kms/command/sign/sim-kms-sign-commands.ts
@@ -78,7 +78,7 @@ export class SimKmsSignCommands {
     const algorithm = key.keySpec.requireSigningAlgorithm(
       command.input.SigningAlgorithm,
     );
-    const signature = command.input.Signature ?? new Uint8Array();
+    const signature = this.message.requireSignature(command.input.Signature);
 
     if (!key.verify(message, signature, algorithm)) {
       throw new SimKmsInvalidSignatureException(

--- a/src/service/kms/command/sign/sim-kms-signed-message.ts
+++ b/src/service/kms/command/sign/sim-kms-signed-message.ts
@@ -11,6 +11,12 @@ const rawMessageType = "RAW";
 const maxMessageBytes = 4096;
 
 /**
+ * The largest signature Verify accepts, which is what an RSA_4096 signature
+ * needs room for.
+ */
+const maxSignatureBytes = 6144;
+
+/**
  * Reads the message a Sign or Verify request carries.
  *
  * `MessageType: DIGEST` is refused rather than answered. Node has no way to
@@ -41,6 +47,27 @@ export class SimKmsSignedMessage {
     }
 
     return message;
+  }
+
+  /**
+   * The signature bytes to check.
+   *
+   * A missing signature is a request AWS refuses before it does any
+   * cryptography, so it fails as validation here rather than as a signature
+   * that did not verify. The two mean different things to a caller.
+   */
+  requireSignature(signature: Uint8Array | undefined): Uint8Array {
+    if (signature === undefined || signature.length === 0) {
+      throw new SimKmsValidationException("Signature is required");
+    }
+
+    if (signature.length > maxSignatureBytes) {
+      throw new SimKmsValidationException(
+        `Signature of ${String(signature.length)} bytes exceeds the ${String(maxSignatureBytes)} byte limit`,
+      );
+    }
+
+    return signature;
   }
 
   private requireRawMessageType(messageType: string | undefined): void {

--- a/src/service/kms/command/sign/sim-kms-signed-message.ts
+++ b/src/service/kms/command/sign/sim-kms-signed-message.ts
@@ -1,0 +1,55 @@
+import { SimKmsValidationException } from "../../error/sim-kms.error.js";
+
+const rawMessageType = "RAW";
+
+/**
+ * The largest message Sign and Verify accept.
+ *
+ * Real KMS takes 4096 bytes for a RAW message, which is the limit that pushes
+ * a caller signing something larger towards hashing it first.
+ */
+const maxMessageBytes = 4096;
+
+/**
+ * Reads the message a Sign or Verify request carries.
+ *
+ * `MessageType: DIGEST` is refused rather than answered. Node has no way to
+ * sign a digest that has already been computed: `crypto.sign` with no
+ * algorithm hashes what it is given rather than signing it, so the signature
+ * would not be the one real KMS makes and would not verify against the message
+ * anywhere outside this simulation. A wrong signature that passes here is the
+ * worst outcome available, so this fails closed.
+ */
+export class SimKmsSignedMessage {
+  /**
+   * The message bytes to sign or verify.
+   */
+  require(
+    message: Uint8Array | undefined,
+    messageType: string | undefined,
+  ): Uint8Array {
+    this.requireRawMessageType(messageType);
+
+    if (message === undefined || message.length === 0) {
+      throw new SimKmsValidationException("Message is required");
+    }
+
+    if (message.length > maxMessageBytes) {
+      throw new SimKmsValidationException(
+        `Message of ${String(message.length)} bytes exceeds the ${String(maxMessageBytes)} byte limit`,
+      );
+    }
+
+    return message;
+  }
+
+  private requireRawMessageType(messageType: string | undefined): void {
+    if (messageType === undefined || messageType === rawMessageType) {
+      return;
+    }
+
+    throw new SimKmsValidationException(
+      `MessageType '${messageType}' is not simulated: simulated KMS signs ${rawMessageType} messages, and hashes them itself`,
+    );
+  }
+}

--- a/src/service/kms/command/sign/sim-kms-signing-validation.iso.test.ts
+++ b/src/service/kms/command/sign/sim-kms-signing-validation.iso.test.ts
@@ -119,8 +119,30 @@ describe("KMS signing validation", () => {
       }),
     );
 
-    // Then nothing verifies, which is the same answer as a wrong one.
-    assertInstanceOf(error, SimKmsInvalidSignatureException);
+    // Then it is a validation failure rather than a signature that did not
+    // verify. The two mean different things to a caller.
+    assertInstanceOf(error, SimKmsValidationException);
+  });
+
+  it("refuses a signature larger than KMS accepts", async () => {
+    // Given a signing key.
+    const simAws = new SimAws();
+    const signingKeyArn = await keyArn(simAws, "ECC_NIST_P256");
+
+    // When a signature past the 6144 byte limit is checked.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.kms().verify(
+        new VerifyCommand({
+          KeyId: signingKeyArn,
+          Message: message("zone apex"),
+          Signature: new Uint8Array(6145),
+          SigningAlgorithm: "ECDSA_SHA_256",
+        }),
+      ),
+    );
+
+    // Then it is refused before any cryptography runs.
+    assertInstanceOf(error, SimKmsValidationException);
   });
 
   it("refuses signing with a symmetric key", async () => {

--- a/src/service/kms/command/sign/sim-kms-signing-validation.iso.test.ts
+++ b/src/service/kms/command/sign/sim-kms-signing-validation.iso.test.ts
@@ -1,0 +1,285 @@
+import {
+  CreateKeyCommand,
+  EncryptCommand,
+  GetPublicKeyCommand,
+  SignCommand,
+  VerifyCommand,
+  type KeySpec,
+} from "@aws-sdk/client-kms";
+import {
+  assertInstanceOf,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import {
+  SimKmsInvalidKeyUsageException,
+  SimKmsInvalidSignatureException,
+  SimKmsUnsupportedOperationException,
+  SimKmsValidationException,
+} from "../../error/sim-kms.error.js";
+
+const message = (value: string): Uint8Array =>
+  Uint8Array.from(Buffer.from(value, "utf8"));
+
+async function symmetricKeyArn(simAws: SimAws): Promise<string> {
+  const created = await simAws.kms().createKey(new CreateKeyCommand({}));
+  assertNonNullable(created.KeyMetadata);
+
+  return created.KeyMetadata.Arn;
+}
+
+async function keyArn(simAws: SimAws, KeySpec: KeySpec): Promise<string> {
+  const created = await simAws
+    .kms()
+    .createKey(new CreateKeyCommand({ KeySpec, KeyUsage: "SIGN_VERIFY" }));
+  assertNonNullable(created.KeyMetadata);
+
+  return created.KeyMetadata.Arn;
+}
+
+async function signedBy(
+  simAws: SimAws,
+  signingKeyArn: string,
+): Promise<Uint8Array> {
+  const signed = await simAws.kms().sign(
+    new SignCommand({
+      KeyId: signingKeyArn,
+      Message: message("zone apex"),
+      SigningAlgorithm: "ECDSA_SHA_256",
+    }),
+  );
+  assertNonNullable(signed.Signature);
+
+  return signed.Signature;
+}
+
+describe("KMS signing validation", () => {
+  it("refuses a signature that does not check out", async () => {
+    // Given a signing key and a signature over one message.
+    const simAws = new SimAws();
+    const signingKeyArn = await keyArn(simAws, "ECC_NIST_P256");
+    const signature = await signedBy(simAws, signingKeyArn);
+
+    // When the signature is verified against a different message.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.kms().verify(
+        new VerifyCommand({
+          KeyId: signingKeyArn,
+          Message: message("some other zone"),
+          Signature: signature,
+          SigningAlgorithm: "ECDSA_SHA_256",
+        }),
+      ),
+    );
+
+    // Then it fails rather than reporting SignatureValid false, which is how
+    // real KMS reports it.
+    assertInstanceOf(error, SimKmsInvalidSignatureException);
+  });
+
+  it("refuses a signature made under another key", async () => {
+    // Given two signing keys, and a signature from the first.
+    const simAws = new SimAws();
+    const signingKeyArn = await keyArn(simAws, "ECC_NIST_P256");
+    const otherKeyArn = await keyArn(simAws, "ECC_NIST_P256");
+    const signature = await signedBy(simAws, signingKeyArn);
+
+    // When the signature is verified against the second key.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.kms().verify(
+        new VerifyCommand({
+          KeyId: otherKeyArn,
+          Message: message("zone apex"),
+          Signature: signature,
+          SigningAlgorithm: "ECDSA_SHA_256",
+        }),
+      ),
+    );
+
+    // Then it fails, because the cryptography here is real.
+    assertInstanceOf(error, SimKmsInvalidSignatureException);
+  });
+
+  it("refuses a Verify with no signature", async () => {
+    // Given a signing key.
+    const simAws = new SimAws();
+    const signingKeyArn = await keyArn(simAws, "ECC_NIST_P256");
+
+    // When a verification carries no signature.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.kms().verify({
+        input: {
+          KeyId: signingKeyArn,
+          Message: message("zone apex"),
+          SigningAlgorithm: "ECDSA_SHA_256",
+        },
+      }),
+    );
+
+    // Then nothing verifies, which is the same answer as a wrong one.
+    assertInstanceOf(error, SimKmsInvalidSignatureException);
+  });
+
+  it("refuses signing with a symmetric key", async () => {
+    // Given a symmetric encryption key.
+    const simAws = new SimAws();
+    const keyWithNoPair = await symmetricKeyArn(simAws);
+
+    // When it is asked to sign.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.kms().sign(
+        new SignCommand({
+          KeyId: keyWithNoPair,
+          Message: message("zone apex"),
+          SigningAlgorithm: "ECDSA_SHA_256",
+        }),
+      ),
+    );
+
+    // Then it is refused for its key usage, before any algorithm question.
+    assertInstanceOf(error, SimKmsInvalidKeyUsageException);
+    assertStringIncludes(
+      error.message,
+      "A SYMMETRIC_DEFAULT key cannot sign or verify",
+    );
+  });
+
+  it("refuses encrypting with a signing key", async () => {
+    // Given an asymmetric signing key.
+    const simAws = new SimAws();
+    const signingKeyArn = await keyArn(simAws, "ECC_NIST_P256");
+
+    // When it is asked to encrypt.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.kms().encrypt(
+        new EncryptCommand({
+          KeyId: signingKeyArn,
+          Plaintext: message("hunter2"),
+        }),
+      ),
+    );
+
+    // Then it is refused, as real KMS refuses it.
+    assertInstanceOf(error, SimKmsInvalidKeyUsageException);
+    assertStringIncludes(error.message, "its KeyUsage is SIGN_VERIFY");
+  });
+
+  it("refuses the public key of a symmetric key", async () => {
+    // Given a symmetric key, which has no public key at all.
+    const simAws = new SimAws();
+    const keyWithNoPair = await symmetricKeyArn(simAws);
+
+    // When its public key is asked for.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws
+        .kms()
+        .getPublicKey(new GetPublicKeyCommand({ KeyId: keyWithNoPair })),
+    );
+
+    // Then it is an unsupported operation rather than a key usage refusal,
+    // which is the distinction real KMS makes here.
+    assertInstanceOf(error, SimKmsUnsupportedOperationException);
+  });
+
+  it("refuses a signing algorithm the key spec does not offer", async () => {
+    // Given an ECC signing key.
+    const simAws = new SimAws();
+    const signingKeyArn = await keyArn(simAws, "ECC_NIST_P256");
+
+    // When it is asked to sign with an RSA algorithm.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.kms().sign(
+        new SignCommand({
+          KeyId: signingKeyArn,
+          Message: message("zone apex"),
+          SigningAlgorithm: "RSASSA_PSS_SHA_256",
+        }),
+      ),
+    );
+
+    // Then it is refused, naming the algorithms the key does offer.
+    assertInstanceOf(error, SimKmsInvalidKeyUsageException);
+    assertStringIncludes(error.message, "ECDSA_SHA_256");
+  });
+
+  it("refuses a Sign with no signing algorithm", async () => {
+    // Given an ECC signing key.
+    const simAws = new SimAws();
+    const signingKeyArn = await keyArn(simAws, "ECC_NIST_P256");
+
+    // When the algorithm is left out, which real KMS requires.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws
+        .kms()
+        .sign({ input: { KeyId: signingKeyArn, Message: message("x") } }),
+    );
+
+    // Then it is refused rather than defaulted.
+    assertInstanceOf(error, SimKmsInvalidKeyUsageException);
+  });
+
+  it("refuses a digest message type", async () => {
+    // Given an ECC signing key.
+    const simAws = new SimAws();
+    const signingKeyArn = await keyArn(simAws, "ECC_NIST_P256");
+
+    // When a pre-hashed message is signed.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.kms().sign(
+        new SignCommand({
+          KeyId: signingKeyArn,
+          Message: message("a digest"),
+          MessageType: "DIGEST",
+          SigningAlgorithm: "ECDSA_SHA_256",
+        }),
+      ),
+    );
+
+    // Then it is refused rather than signed as if it were the message, which
+    // would produce a signature nothing outside this simulation would accept.
+    assertInstanceOf(error, SimKmsValidationException);
+    assertStringIncludes(
+      error.message,
+      "MessageType 'DIGEST' is not simulated",
+    );
+  });
+
+  it("refuses a Sign with no message", async () => {
+    // Given an ECC signing key.
+    const simAws = new SimAws();
+    const signingKeyArn = await keyArn(simAws, "ECC_NIST_P256");
+
+    // When nothing is given to sign.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.kms().sign({
+        input: { KeyId: signingKeyArn, SigningAlgorithm: "ECDSA_SHA_256" },
+      }),
+    );
+
+    // Then it is refused.
+    assertInstanceOf(error, SimKmsValidationException);
+  });
+
+  it("refuses a message larger than KMS accepts", async () => {
+    // Given an ECC signing key.
+    const simAws = new SimAws();
+    const signingKeyArn = await keyArn(simAws, "ECC_NIST_P256");
+
+    // When a message past the 4096 byte limit is signed.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.kms().sign(
+        new SignCommand({
+          KeyId: signingKeyArn,
+          Message: new Uint8Array(4097),
+          SigningAlgorithm: "ECDSA_SHA_256",
+        }),
+      ),
+    );
+
+    // Then it is refused, as real KMS refuses it.
+    assertInstanceOf(error, SimKmsValidationException);
+  });
+});

--- a/src/service/kms/command/sign/sim-kms-signing.iso.test.ts
+++ b/src/service/kms/command/sign/sim-kms-signing.iso.test.ts
@@ -1,0 +1,192 @@
+import { createPublicKey, verify } from "node:crypto";
+import {
+  CreateKeyCommand,
+  DescribeKeyCommand,
+  GetPublicKeyCommand,
+  SignCommand,
+  VerifyCommand,
+  type KeySpec,
+} from "@aws-sdk/client-kms";
+import {
+  assertArrayIncludes,
+  assertUndefined,
+  assertIdentical,
+  assertNonNullable,
+  assertTrue,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+
+const message = (value: string): Uint8Array =>
+  Uint8Array.from(Buffer.from(value, "utf8"));
+
+async function signingKeyArn(
+  simAws: SimAws,
+  KeySpec: KeySpec,
+): Promise<string> {
+  const created = await simAws
+    .kms()
+    .createKey(new CreateKeyCommand({ KeySpec, KeyUsage: "SIGN_VERIFY" }));
+  assertNonNullable(created.KeyMetadata);
+
+  return created.KeyMetadata.Arn;
+}
+
+describe("KMS Sign and Verify", () => {
+  it("round-trips a signature through an ECC key", async () => {
+    // Given a simulated ECC signing key.
+    const simAws = new SimAws();
+    const keyArn = await signingKeyArn(simAws, "ECC_NIST_P256");
+
+    // When a message is signed and the signature verified.
+    const signed = await simAws.kms().sign(
+      new SignCommand({
+        KeyId: keyArn,
+        Message: message("zone apex"),
+        SigningAlgorithm: "ECDSA_SHA_256",
+      }),
+    );
+    const verified = await simAws.kms().verify(
+      new VerifyCommand({
+        KeyId: keyArn,
+        Message: message("zone apex"),
+        Signature: signed.Signature,
+        SigningAlgorithm: "ECDSA_SHA_256",
+      }),
+    );
+
+    // Then the signature checks out, against the key that made it.
+    assertTrue(verified.SignatureValid);
+    assertIdentical(verified.KeyId, keyArn);
+    assertIdentical(signed.SigningAlgorithm, "ECDSA_SHA_256");
+  });
+
+  it("round-trips a signature through an RSA key", async () => {
+    // Given a simulated RSA signing key.
+    const simAws = new SimAws();
+    const keyArn = await signingKeyArn(simAws, "RSA_2048");
+
+    // When a message is signed with PSS padding and verified.
+    const signed = await simAws.kms().sign(
+      new SignCommand({
+        KeyId: keyArn,
+        Message: message("licence"),
+        SigningAlgorithm: "RSASSA_PSS_SHA_256",
+      }),
+    );
+    const verified = await simAws.kms().verify(
+      new VerifyCommand({
+        KeyId: keyArn,
+        Message: message("licence"),
+        Signature: signed.Signature,
+        SigningAlgorithm: "RSASSA_PSS_SHA_256",
+      }),
+    );
+
+    // Then the signature checks out.
+    assertTrue(verified.SignatureValid);
+  });
+
+  it("signs with real cryptography a public key verifies", async () => {
+    // Given a signing key and its public key.
+    const simAws = new SimAws();
+    const keyArn = await signingKeyArn(simAws, "ECC_NIST_P384");
+    const publicKey = await simAws
+      .kms()
+      .getPublicKey(new GetPublicKeyCommand({ KeyId: keyArn }));
+    assertNonNullable(publicKey.PublicKey);
+
+    // When a message is signed here and checked outside the simulation.
+    const signed = await simAws.kms().sign(
+      new SignCommand({
+        KeyId: keyArn,
+        Message: message("out of band"),
+        SigningAlgorithm: "ECDSA_SHA_384",
+      }),
+    );
+
+    // Then Node's own verifier accepts it against the DER public key, so the
+    // signature means something outside this process.
+    const verifier = createPublicKey({
+      key: Buffer.from(publicKey.PublicKey),
+      format: "der",
+      type: "spki",
+    });
+
+    assertTrue(
+      verify(
+        "sha384",
+        message("out of band"),
+        verifier,
+        signed.Signature ?? new Uint8Array(),
+      ),
+    );
+  });
+
+  it("reports the key type of a signing key", async () => {
+    // Given a simulated ECC signing key.
+    const simAws = new SimAws();
+    const keyArn = await signingKeyArn(simAws, "ECC_NIST_P256");
+
+    // When the key is described.
+    const described = await simAws
+      .kms()
+      .describeKey(new DescribeKeyCommand({ KeyId: keyArn }));
+    assertNonNullable(described.KeyMetadata);
+
+    // Then it reports its own spec and usage rather than the symmetric
+    // defaults, and lists no encryption algorithms, because it has none.
+    assertIdentical(described.KeyMetadata.KeySpec, "ECC_NIST_P256");
+    assertIdentical(
+      described.KeyMetadata.CustomerMasterKeySpec,
+      "ECC_NIST_P256",
+    );
+    assertIdentical(described.KeyMetadata.KeyUsage, "SIGN_VERIFY");
+    assertArrayIncludes(
+      described.KeyMetadata.SigningAlgorithms ?? [],
+      "ECDSA_SHA_256",
+    );
+    assertUndefined(described.KeyMetadata.EncryptionAlgorithms);
+  });
+
+  it("reports the key type of a symmetric key", async () => {
+    // Given a simulated symmetric key.
+    const simAws = new SimAws();
+    const created = await simAws.kms().createKey(new CreateKeyCommand({}));
+    assertNonNullable(created.KeyMetadata);
+
+    // When the key is described, then it lists no signing algorithms.
+    const described = await simAws
+      .kms()
+      .describeKey(new DescribeKeyCommand({ KeyId: created.KeyMetadata.Arn }));
+    assertNonNullable(described.KeyMetadata);
+
+    assertIdentical(described.KeyMetadata.KeySpec, "SYMMETRIC_DEFAULT");
+    assertIdentical(described.KeyMetadata.KeyUsage, "ENCRYPT_DECRYPT");
+    assertUndefined(described.KeyMetadata.SigningAlgorithms);
+    assertArrayIncludes(
+      described.KeyMetadata.EncryptionAlgorithms ?? [],
+      "SYMMETRIC_DEFAULT",
+    );
+  });
+
+  it("reports the public key type from GetPublicKey", async () => {
+    // Given a simulated RSA signing key.
+    const simAws = new SimAws();
+    const keyArn = await signingKeyArn(simAws, "RSA_3072");
+
+    // When its public key is fetched.
+    const publicKey = await simAws
+      .kms()
+      .getPublicKey(new GetPublicKeyCommand({ KeyId: keyArn }));
+
+    // Then it carries the key type alongside the key, as real KMS does.
+    assertIdentical(publicKey.KeyId, keyArn);
+    assertIdentical(publicKey.KeySpec, "RSA_3072");
+    assertIdentical(publicKey.KeyUsage, "SIGN_VERIFY");
+    assertArrayIncludes(
+      publicKey.SigningAlgorithms ?? [],
+      "RSASSA_PKCS1_V1_5_SHA_512",
+    );
+  });
+});

--- a/src/service/kms/command/sim-kms-command.types.ts
+++ b/src/service/kms/command/sim-kms-command.types.ts
@@ -42,3 +42,12 @@ export type {
   SimScheduleKeyDeletionCommand,
   SimScheduleKeyDeletionCommandOutput,
 } from "./key/key.command.js";
+
+export type {
+  SimGetPublicKeyCommand,
+  SimGetPublicKeyCommandOutput,
+  SimSignCommand,
+  SimSignCommandOutput,
+  SimVerifyCommand,
+  SimVerifyCommandOutput,
+} from "./sign/sign.command.js";

--- a/src/service/kms/error/sim-kms.error.ts
+++ b/src/service/kms/error/sim-kms.error.ts
@@ -122,3 +122,33 @@ export class SimKmsInvalidKeyUsageException extends SimKmsError {
     super(message, { httpStatusCode: 400 });
   }
 }
+
+/**
+ * Simulated KMS UnsupportedOperationException error.
+ *
+ * Real KMS keeps this apart from InvalidKeyUsageException, and GetPublicKey is
+ * where the difference shows: a symmetric key has no public key to hand out at
+ * all, rather than having one it is not allowed to use for the operation.
+ */
+export class SimKmsUnsupportedOperationException extends SimKmsError {
+  public override readonly name = "UnsupportedOperationException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
+ * Simulated KMS KMSInvalidSignatureException error.
+ *
+ * Verify reports a signature that does not check out by failing rather than by
+ * returning SignatureValid false, which is what real KMS does and what code
+ * written against it handles.
+ */
+export class SimKmsInvalidSignatureException extends SimKmsError {
+  public override readonly name = "KMSInvalidSignatureException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}

--- a/src/service/kms/index.ts
+++ b/src/service/kms/index.ts
@@ -10,6 +10,8 @@ export { SimKmsAlias } from "./key/sim-kms-alias.js";
 export { SimKmsKeyPolicy } from "./key/sim-kms-key-policy.js";
 export type { SimKmsEncryptionContext } from "./key/sim-kms-encryption-context.js";
 export type { SimKmsKeyMetadata } from "./key/sim-kms-key-metadata.js";
+export { SimKmsKeySpec, SimKmsKeyUsage } from "./key/spec/sim-kms-key-spec.js";
+export { simKmsKeySpecs } from "./key/spec/sim-kms-key-specs.js";
 export {
   SimKmsAlreadyExistsException,
   SimKmsDisabledException,
@@ -17,7 +19,9 @@ export {
   SimKmsIncorrectKeyException,
   SimKmsInvalidCiphertextException,
   SimKmsInvalidKeyUsageException,
+  SimKmsInvalidSignatureException,
   SimKmsInvalidStateException,
   SimKmsNotFoundException,
+  SimKmsUnsupportedOperationException,
   SimKmsValidationException,
 } from "./error/sim-kms.error.js";

--- a/src/service/kms/key/sim-kms-key-factory.ts
+++ b/src/service/kms/key/sim-kms-key-factory.ts
@@ -4,9 +4,11 @@ import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-
 import type { SimIamPolicyDocument } from "../../iam/policy/sim-iam-policy.js";
 import { SimKmsCiphertextBlob } from "./sim-kms-ciphertext-blob.js";
 import { SimKmsKey, SimKmsKeyManager } from "./sim-kms-key.js";
-import { SimKmsKeyMaterial } from "./sim-kms-key-material.js";
+import { makeSimKmsKeyMaterial } from "./sim-kms-key-material-factory.js";
 import { SimKmsKeyPolicy } from "./sim-kms-key-policy.js";
 import { SimKmsViaService } from "./sim-kms-via-service.js";
+import type { SimKmsKeySpec } from "./spec/sim-kms-key-spec.js";
+import { simKmsSymmetricKeySpec } from "./spec/sim-kms-key-specs.js";
 
 interface SimKmsKeyFactoryProperties {
   readonly accountRegionScope: SimAwsAccountRegionScope;
@@ -16,6 +18,12 @@ interface SimKmsKeyFactoryProperties {
 interface SimKmsMakeKeyProperties {
   readonly description?: string | undefined;
   readonly policy?: SimIamPolicyDocument | undefined;
+
+  /**
+   * The spec the key is made to. Omitting it gets a symmetric encryption key,
+   * which is what CreateKey gives a request naming no KeySpec.
+   */
+  readonly keySpec?: SimKmsKeySpec | undefined;
 
   /**
    * The service an AWS managed key belongs to, such as `ssm`.
@@ -57,7 +65,11 @@ export class SimKmsKeyFactory {
     return new SimKmsKey({
       keyId,
       accountRegionScope: this.accountRegionScope,
-      material: new SimKmsKeyMaterial({ keyArn: arn, blob: this.blob }),
+      material: makeSimKmsKeyMaterial({
+        keyArn: arn,
+        keySpec: properties.keySpec ?? simKmsSymmetricKeySpec,
+        blob: this.blob,
+      }),
       policy: this.keyPolicy(arn, properties),
       creationDate: this.clock.now(),
       description: properties.description,

--- a/src/service/kms/key/sim-kms-key-material-factory.ts
+++ b/src/service/kms/key/sim-kms-key-material-factory.ts
@@ -1,0 +1,34 @@
+import type { SimKmsCiphertextBlob } from "./sim-kms-ciphertext-blob.js";
+import type { SimKmsKeyMaterial } from "./sim-kms-key-material.js";
+import { SimKmsSigningKeyMaterial } from "./sim-kms-signing-key-material.js";
+import { SimKmsSymmetricKeyMaterial } from "./sim-kms-symmetric-key-material.js";
+import type { SimKmsKeySpec } from "./spec/sim-kms-key-spec.js";
+
+interface SimKmsMakeKeyMaterialProperties {
+  readonly keyArn: string;
+  readonly keySpec: SimKmsKeySpec;
+  readonly blob: SimKmsCiphertextBlob;
+}
+
+/**
+ * Make the key material a key spec calls for: an AES key or a key pair.
+ *
+ * Which of the two a spec means is the only thing the key factory would have
+ * to know about key material, so it lives here instead and the factory stays
+ * about assembling a key.
+ */
+export function makeSimKmsKeyMaterial(
+  properties: SimKmsMakeKeyMaterialProperties,
+): SimKmsKeyMaterial {
+  const { keyArn, keySpec } = properties;
+
+  if (keySpec.isAsymmetric) {
+    return new SimKmsSigningKeyMaterial({ keyArn, keySpec });
+  }
+
+  return new SimKmsSymmetricKeyMaterial({
+    keyArn,
+    keySpec,
+    blob: properties.blob,
+  });
+}

--- a/src/service/kms/key/sim-kms-key-material.iso.test.ts
+++ b/src/service/kms/key/sim-kms-key-material.iso.test.ts
@@ -1,0 +1,84 @@
+import {
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsError,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimKmsCiphertextBlob } from "./sim-kms-ciphertext-blob.js";
+import { SimKmsSigningKeyMaterial } from "./sim-kms-signing-key-material.js";
+import { SimKmsSymmetricKeyMaterial } from "./sim-kms-symmetric-key-material.js";
+import { simKmsSymmetricKeySpec } from "./spec/sim-kms-key-specs.js";
+import { SimKmsSigningAlgorithm } from "./spec/sim-kms-signing-algorithm.js";
+import { simKmsKeySpecs } from "./spec/sim-kms-key-specs.js";
+import { SimKmsInvalidKeyUsageException } from "../error/sim-kms.error.js";
+import { assertNonNullable } from "@kensio/smartass";
+
+const keyArn = "arn:aws:kms:eu-west-2:123456789012:key/a-key";
+const ecdsa = new SimKmsSigningAlgorithm({
+  name: "ECDSA_SHA_256",
+  digest: "sha256",
+});
+
+function symmetricMaterial(): SimKmsSymmetricKeyMaterial {
+  return new SimKmsSymmetricKeyMaterial({
+    keyArn,
+    keySpec: simKmsSymmetricKeySpec,
+    blob: new SimKmsCiphertextBlob(),
+  });
+}
+
+function signingMaterial(): SimKmsSigningKeyMaterial {
+  const keySpec = simKmsKeySpecs.get("ECC_NIST_P256");
+  assertNonNullable(keySpec);
+
+  return new SimKmsSigningKeyMaterial({ keyArn, keySpec });
+}
+
+/**
+ * The key spec refuses most of these before the material is ever asked, so
+ * these cover the material's own answer directly. It is the last line rather
+ * than the first, and a key material that quietly did the wrong thing here
+ * would be the worst kind of bug to have.
+ */
+describe("KMS key material by key usage", () => {
+  it("refuses to sign with symmetric key material", () => {
+    // Given symmetric AES key material.
+    // When it is asked to sign, then it refuses for its key usage.
+    const error = assertThrowsError(() =>
+      symmetricMaterial().sign(new Uint8Array([1]), ecdsa),
+    );
+
+    assertInstanceOf(error, SimKmsInvalidKeyUsageException);
+    assertStringIncludes(error.message, "Sign cannot be used with key");
+  });
+
+  it("refuses to verify with symmetric key material", () => {
+    // Given symmetric AES key material.
+    // When it is asked to verify, then it refuses.
+    const error = assertThrowsError(() =>
+      symmetricMaterial().verify(
+        new Uint8Array([1]),
+        new Uint8Array([2]),
+        ecdsa,
+      ),
+    );
+
+    assertInstanceOf(error, SimKmsInvalidKeyUsageException);
+  });
+
+  it("refuses to decrypt with signing key material", () => {
+    // Given an asymmetric key pair.
+    // When it is asked to decrypt, then it refuses.
+    const error = assertThrowsError(() =>
+      signingMaterial().decrypt({
+        keyArn,
+        iv: new Uint8Array(12),
+        authTag: new Uint8Array(16),
+        ciphertext: new Uint8Array(1),
+      }),
+    );
+
+    assertInstanceOf(error, SimKmsInvalidKeyUsageException);
+    assertStringIncludes(error.message, "Decrypt cannot be used with key");
+  });
+});

--- a/src/service/kms/key/sim-kms-key-material.ts
+++ b/src/service/kms/key/sim-kms-key-material.ts
@@ -1,106 +1,97 @@
-import { createCipheriv, createDecipheriv, randomBytes } from "node:crypto";
-import { SimKmsInvalidCiphertextException } from "../error/sim-kms.error.js";
 import {
-  SimKmsCiphertextBlobParts,
-  type SimKmsCiphertextBlob,
-} from "./sim-kms-ciphertext-blob.js";
-import {
-  SimKmsEncryptionContextAad,
-  type SimKmsEncryptionContext,
-} from "./sim-kms-encryption-context.js";
-
-/**
- * The cipher backing a simulated symmetric KMS key.
- *
- * Real KMS symmetric keys are AES-256-GCM, so this uses the same thing rather
- * than a stand-in. Encryption in this simulation is real encryption: a
- * ciphertext genuinely cannot be read without the key, and the authentication
- * tag genuinely fails on a tampered blob or a mismatched encryption context.
- */
-const algorithm = "aes-256-gcm";
-
-const keyLength = 32;
-const ivLength = 12;
+  SimKmsInvalidKeyUsageException,
+  SimKmsUnsupportedOperationException,
+} from "../error/sim-kms.error.js";
+import type { SimKmsSigningAlgorithm } from "./spec/sim-kms-signing-algorithm.js";
+import type { SimKmsKeySpec } from "./spec/sim-kms-key-spec.js";
+import type { SimKmsCiphertextBlobParts } from "./sim-kms-ciphertext-blob.js";
+import type { SimKmsEncryptionContext } from "./sim-kms-encryption-context.js";
 
 interface SimKmsKeyMaterialProperties {
   readonly keyArn: string;
-  readonly blob: SimKmsCiphertextBlob;
-  readonly bytes?: Uint8Array | undefined;
+  readonly keySpec: SimKmsKeySpec;
 }
 
 /**
  * The key material of one simulated KMS key, and the operations that use it.
  *
- * The bytes are generated here and never leave: nothing exposes them, exactly
- * as real key material never leaves KMS. That is a modelling choice rather
- * than a security boundary, since this all runs in one process and anything
- * sharing that process can reach the object.
+ * The bytes are generated in the subclass and never leave, exactly as real key
+ * material never leaves KMS. That is a modelling choice rather than a security
+ * boundary, since this all runs in one process and anything sharing that
+ * process can reach the object.
+ *
+ * Every operation is declared here and refused by default, because that is how
+ * AWS answers one: an `Encrypt` against a signing key is not an unknown
+ * operation, it is `InvalidKeyUsageException` on a key that cannot do it. A
+ * subclass overrides the operations its usage allows and inherits the refusal
+ * for the rest.
  */
-export class SimKmsKeyMaterial {
-  private readonly keyArn: string;
-  private readonly blob: SimKmsCiphertextBlob;
-  private readonly bytes: Uint8Array;
-  private readonly aad = new SimKmsEncryptionContextAad();
+export abstract class SimKmsKeyMaterial {
+  public readonly keySpec: SimKmsKeySpec;
+
+  protected readonly keyArn: string;
 
   constructor(properties: SimKmsKeyMaterialProperties) {
     this.keyArn = properties.keyArn;
-    this.blob = properties.blob;
-    this.bytes = properties.bytes ?? randomBytes(keyLength);
+    this.keySpec = properties.keySpec;
   }
 
   /**
    * Encrypt plaintext under this key, binding the encryption context.
    */
   encrypt(
-    plaintext: Uint8Array,
-    encryptionContext?: SimKmsEncryptionContext,
+    _plaintext: Uint8Array,
+    _encryptionContext?: SimKmsEncryptionContext,
   ): Uint8Array {
-    const iv = randomBytes(ivLength);
-    const cipher = createCipheriv(algorithm, this.bytes, iv);
-    cipher.setAAD(this.aad.serialise(encryptionContext));
-
-    const ciphertext = Buffer.concat([
-      cipher.update(plaintext),
-      cipher.final(),
-    ]);
-
-    const authTag = cipher.getAuthTag();
-
-    return this.blob.encode(
-      new SimKmsCiphertextBlobParts({
-        keyArn: this.keyArn,
-        iv: Uint8Array.from(iv),
-        authTag: Uint8Array.from(authTag),
-        ciphertext: Uint8Array.from(ciphertext),
-      }),
-    );
+    throw this.notForThisUsage("Encrypt");
   }
 
   /**
    * Decrypt a ciphertext produced under this key.
-   *
-   * A wrong encryption context fails the GCM authentication tag rather than an
-   * explicit comparison, so the failure comes from the cipher for the same
-   * reason it does on real KMS.
    */
   decrypt(
-    parts: SimKmsCiphertextBlobParts,
-    encryptionContext?: SimKmsEncryptionContext,
+    _parts: SimKmsCiphertextBlobParts,
+    _encryptionContext?: SimKmsEncryptionContext,
   ): Uint8Array {
-    const decipher = createDecipheriv(algorithm, this.bytes, parts.iv);
-    decipher.setAAD(this.aad.serialise(encryptionContext));
-    decipher.setAuthTag(parts.authTag);
+    throw this.notForThisUsage("Decrypt");
+  }
 
-    try {
-      return Uint8Array.from(
-        Buffer.concat([decipher.update(parts.ciphertext), decipher.final()]),
-      );
-    } catch {
-      throw new SimKmsInvalidCiphertextException(
-        "The ciphertext could not be decrypted: it was produced under a " +
-          "different key, with a different encryption context, or has been " +
-          "altered",
-      );
-    }
+  /**
+   * Sign a message under this key.
+   */
+  sign(_message: Uint8Array, _algorithm: SimKmsSigningAlgorithm): Uint8Array {
+    throw this.notForThisUsage("Sign");
+  }
+
+  /**
+   * Check a signature made under this key.
+   */
+  verify(
+    _message: Uint8Array,
+    _signature: Uint8Array,
+    _algorithm: SimKmsSigningAlgorithm,
+  ): boolean {
+    throw this.notForThisUsage("Verify");
+  }
+
+  /**
+   * This key's public key, as DER SubjectPublicKeyInfo.
+   *
+   * A symmetric key has no public key at all, which real KMS reports as an
+   * unsupported operation rather than as a key usage that does not allow it.
+   */
+  publicKeyDer(): Uint8Array {
+    throw new SimKmsUnsupportedOperationException(
+      `GetPublicKey cannot be used with key ${this.keyArn}: its KeySpec is ${this.keySpec.name}, which holds no public key`,
+    );
+  }
+
+  /**
+   * The refusal for an operation this key's usage does not allow.
+   */
+  private notForThisUsage(operation: string): SimKmsInvalidKeyUsageException {
+    return new SimKmsInvalidKeyUsageException(
+      `${operation} cannot be used with key ${this.keyArn}: its KeyUsage is ${this.keySpec.keyUsage}`,
+    );
   }
 }

--- a/src/service/kms/key/sim-kms-key-metadata.ts
+++ b/src/service/kms/key/sim-kms-key-metadata.ts
@@ -1,34 +1,8 @@
 import type { SimAwsAccountId } from "../../aws/sim-aws-account.js";
-import type {
-  SimKmsKey,
-  SimKmsKeyManager,
-  SimKmsKeyState,
-} from "./sim-kms-key.js";
+import type { SimKmsKey } from "./sim-kms-key.js";
+import type { SimKmsKeyMetadata } from "./sim-kms-key-metadata.type.js";
 
-/**
- * The KeyMetadata structure CreateKey and DescribeKey return.
- *
- * Only symmetric encryption keys are simulated, so the fields describing key
- * type are constants rather than stored state. They are reported anyway
- * because application code reads them to decide what a key can do.
- */
-export interface SimKmsKeyMetadata {
-  readonly AWSAccountId: SimAwsAccountId;
-  readonly KeyId: string;
-  readonly Arn: string;
-  readonly CreationDate: Date;
-  readonly Enabled: boolean;
-  readonly Description: string;
-  readonly KeyUsage: "ENCRYPT_DECRYPT";
-  readonly KeyState: SimKmsKeyState;
-  readonly DeletionDate?: Date | undefined;
-  readonly Origin: "AWS_KMS";
-  readonly KeyManager: SimKmsKeyManager;
-  readonly KeySpec: "SYMMETRIC_DEFAULT";
-  readonly CustomerMasterKeySpec: "SYMMETRIC_DEFAULT";
-  readonly EncryptionAlgorithms: readonly ["SYMMETRIC_DEFAULT"];
-  readonly MultiRegion: false;
-}
+export type { SimKmsKeyMetadata } from "./sim-kms-key-metadata.type.js";
 
 /**
  * Builds the AWS-shaped view of a stored key.
@@ -47,6 +21,8 @@ export class SimKmsKeyMetadataView {
    * Describe a key the way KMS reports it.
    */
   describe(key: SimKmsKey): SimKmsKeyMetadata {
+    const keySpec = key.keySpec;
+
     return {
       AWSAccountId: this.accountId,
       KeyId: key.keyId,
@@ -54,16 +30,32 @@ export class SimKmsKeyMetadataView {
       CreationDate: new Date(key.creationDate),
       Enabled: key.isEnabled,
       Description: key.description,
-      KeyUsage: "ENCRYPT_DECRYPT",
+      KeyUsage: keySpec.keyUsage,
       KeyState: key.keyState,
       DeletionDate: this.copied(key.deletionDate),
       Origin: "AWS_KMS",
       KeyManager: key.keyManager,
-      KeySpec: "SYMMETRIC_DEFAULT",
-      CustomerMasterKeySpec: "SYMMETRIC_DEFAULT",
-      EncryptionAlgorithms: ["SYMMETRIC_DEFAULT"],
+      KeySpec: keySpec.name,
+      CustomerMasterKeySpec: keySpec.name,
+      EncryptionAlgorithms: this.listed(keySpec.encryptionAlgorithms),
+      SigningAlgorithms: this.listed(keySpec.signingAlgorithmNames()),
       MultiRegion: false,
     };
+  }
+
+  /**
+   * An algorithm list, or nothing at all where the key has none.
+   *
+   * Real KMS omits the list that does not apply rather than returning it
+   * empty, so an encryption key reports no SigningAlgorithms and a signing key
+   * reports no EncryptionAlgorithms.
+   */
+  private listed(algorithms: readonly string[]): readonly string[] | undefined {
+    if (algorithms.length === 0) {
+      return undefined;
+    }
+
+    return algorithms;
   }
 
   /**

--- a/src/service/kms/key/sim-kms-key-metadata.type.ts
+++ b/src/service/kms/key/sim-kms-key-metadata.type.ts
@@ -1,0 +1,28 @@
+import type { SimAwsAccountId } from "../../aws/sim-aws-account.js";
+import type { SimKmsKeyUsage } from "./spec/sim-kms-key-spec.js";
+import type { SimKmsKeyManager, SimKmsKeyState } from "./sim-kms-key.js";
+
+/**
+ * The KeyMetadata structure CreateKey and DescribeKey return.
+ *
+ * The key type fields are read from the key's own spec. Application code uses
+ * them to decide what a key can do, so a key that signs has to say so.
+ */
+export interface SimKmsKeyMetadata {
+  readonly AWSAccountId: SimAwsAccountId;
+  readonly KeyId: string;
+  readonly Arn: string;
+  readonly CreationDate: Date;
+  readonly Enabled: boolean;
+  readonly Description: string;
+  readonly KeyUsage: SimKmsKeyUsage;
+  readonly KeyState: SimKmsKeyState;
+  readonly DeletionDate?: Date | undefined;
+  readonly Origin: "AWS_KMS";
+  readonly KeyManager: SimKmsKeyManager;
+  readonly KeySpec: string;
+  readonly CustomerMasterKeySpec: string;
+  readonly EncryptionAlgorithms?: readonly string[] | undefined;
+  readonly SigningAlgorithms?: readonly string[] | undefined;
+  readonly MultiRegion: false;
+}

--- a/src/service/kms/key/sim-kms-key.ts
+++ b/src/service/kms/key/sim-kms-key.ts
@@ -8,6 +8,8 @@ import {
 } from "./sim-kms-key-lifecycle.js";
 import type { SimKmsKeyMaterial } from "./sim-kms-key-material.js";
 import type { SimKmsKeyPolicy } from "./sim-kms-key-policy.js";
+import type { SimKmsKeySpec } from "./spec/sim-kms-key-spec.js";
+import type { SimKmsSigningAlgorithm } from "./spec/sim-kms-signing-algorithm.js";
 
 export { SimKmsKeyState } from "./sim-kms-key-lifecycle.js";
 
@@ -64,6 +66,13 @@ export class SimKmsKey {
     this.description = properties.description ?? "";
     this.keyManager = properties.keyManager ?? SimKmsKeyManager.Customer;
     this.lifecycle = new SimKmsKeyLifecycle(this.arn);
+  }
+
+  /**
+   * The spec this key was created with, which is what says what it can do.
+   */
+  get keySpec(): SimKmsKeySpec {
+    return this.material.keySpec;
   }
 
   /**
@@ -148,5 +157,36 @@ export class SimKmsKey {
   ): Uint8Array {
     this.lifecycle.requireUsable();
     return this.material.decrypt(parts, encryptionContext);
+  }
+
+  /**
+   * Sign a message under this key.
+   */
+  sign(message: Uint8Array, algorithm: SimKmsSigningAlgorithm): Uint8Array {
+    this.lifecycle.requireUsable();
+    return this.material.sign(message, algorithm);
+  }
+
+  /**
+   * Check a signature made under this key.
+   */
+  verify(
+    message: Uint8Array,
+    signature: Uint8Array,
+    algorithm: SimKmsSigningAlgorithm,
+  ): boolean {
+    this.lifecycle.requireUsable();
+    return this.material.verify(message, signature, algorithm);
+  }
+
+  /**
+   * This key's public key, as DER SubjectPublicKeyInfo.
+   *
+   * A disabled key still has one on real KMS, but GetPublicKey refuses it, so
+   * this goes through the same usability check every other operation does.
+   */
+  publicKeyDer(): Uint8Array {
+    this.lifecycle.requireUsable();
+    return this.material.publicKeyDer();
   }
 }

--- a/src/service/kms/key/sim-kms-signing-key-material.ts
+++ b/src/service/kms/key/sim-kms-signing-key-material.ts
@@ -1,0 +1,96 @@
+import { generateKeyPairSync, sign, verify, type KeyObject } from "node:crypto";
+import { SimKmsKeyMaterial } from "./sim-kms-key-material.js";
+import type { SimKmsKeySpec } from "./spec/sim-kms-key-spec.js";
+import type { SimKmsSigningAlgorithm } from "./spec/sim-kms-signing-algorithm.js";
+
+interface SimKmsSigningKeyMaterialProperties {
+  readonly keyArn: string;
+  readonly keySpec: SimKmsKeySpec;
+}
+
+interface SimKmsKeyPair {
+  readonly publicKey: KeyObject;
+  readonly privateKey: KeyObject;
+}
+
+/**
+ * The key pair of one simulated asymmetric KMS signing key.
+ *
+ * The pair is a real one and the signatures are real signatures: a signature
+ * made here verifies against the public key GetPublicKey hands out, using any
+ * verifier, and one made over a different message does not. ECDSA signatures
+ * come out DER encoded, which is the encoding real KMS returns.
+ *
+ * The private key never leaves, the same as the AES bytes of a symmetric key.
+ */
+export class SimKmsSigningKeyMaterial extends SimKmsKeyMaterial {
+  private readonly keyPair: SimKmsKeyPair;
+
+  constructor(properties: SimKmsSigningKeyMaterialProperties) {
+    super(properties);
+
+    this.keyPair = generateSimKmsKeyPair(properties.keySpec);
+  }
+
+  /**
+   * Sign a message under this key.
+   */
+  override sign(
+    message: Uint8Array,
+    algorithm: SimKmsSigningAlgorithm,
+  ): Uint8Array {
+    return Uint8Array.from(
+      sign(
+        algorithm.digest,
+        message,
+        algorithm.keyInput(this.keyPair.privateKey),
+      ),
+    );
+  }
+
+  /**
+   * Check a signature made under this key.
+   */
+  override verify(
+    message: Uint8Array,
+    signature: Uint8Array,
+    algorithm: SimKmsSigningAlgorithm,
+  ): boolean {
+    return verify(
+      algorithm.digest,
+      message,
+      algorithm.keyInput(this.keyPair.publicKey),
+      signature,
+    );
+  }
+
+  /**
+   * This key's public key, as DER SubjectPublicKeyInfo.
+   *
+   * That is the encoding real GetPublicKey returns, so a caller can hand the
+   * bytes straight to a verifier without knowing they came from a simulator.
+   */
+  override publicKeyDer(): Uint8Array {
+    return Uint8Array.from(
+      this.keyPair.publicKey.export({ type: "spki", format: "der" }),
+    );
+  }
+}
+
+/**
+ * Generate the key pair a key spec calls for.
+ *
+ * Kept out of the class so the spec-to-Node translation is one expression
+ * rather than a branch inside a constructor.
+ */
+function generateSimKmsKeyPair(keySpec: SimKmsKeySpec): SimKmsKeyPair {
+  const parameters = keySpec.keyPairParameters();
+
+  if (parameters.type === "ec") {
+    return generateKeyPairSync("ec", { namedCurve: parameters.namedCurve });
+  }
+
+  return generateKeyPairSync("rsa", {
+    modulusLength: parameters.modulusLength,
+  });
+}

--- a/src/service/kms/key/sim-kms-symmetric-key-material.ts
+++ b/src/service/kms/key/sim-kms-symmetric-key-material.ts
@@ -1,0 +1,109 @@
+import { createCipheriv, createDecipheriv, randomBytes } from "node:crypto";
+import { SimKmsInvalidCiphertextException } from "../error/sim-kms.error.js";
+import {
+  SimKmsCiphertextBlobParts,
+  type SimKmsCiphertextBlob,
+} from "./sim-kms-ciphertext-blob.js";
+import {
+  SimKmsEncryptionContextAad,
+  type SimKmsEncryptionContext,
+} from "./sim-kms-encryption-context.js";
+import { SimKmsKeyMaterial } from "./sim-kms-key-material.js";
+import type { SimKmsKeySpec } from "./spec/sim-kms-key-spec.js";
+
+/**
+ * The cipher backing a simulated symmetric KMS key.
+ *
+ * Real KMS symmetric keys are AES-256-GCM, so this uses the same thing rather
+ * than a stand-in. Encryption in this simulation is real encryption: a
+ * ciphertext genuinely cannot be read without the key, and the authentication
+ * tag genuinely fails on a tampered blob or a mismatched encryption context.
+ */
+const algorithm = "aes-256-gcm";
+
+const keyLength = 32;
+const ivLength = 12;
+
+interface SimKmsSymmetricKeyMaterialProperties {
+  readonly keyArn: string;
+  readonly keySpec: SimKmsKeySpec;
+  readonly blob: SimKmsCiphertextBlob;
+  readonly bytes?: Uint8Array | undefined;
+}
+
+/**
+ * The AES key material of one simulated symmetric KMS key.
+ *
+ * The bytes are generated here and never leave: nothing exposes them, exactly
+ * as real key material never leaves KMS. That is a modelling choice rather
+ * than a security boundary, since this all runs in one process and anything
+ * sharing that process can reach the object.
+ */
+export class SimKmsSymmetricKeyMaterial extends SimKmsKeyMaterial {
+  private readonly blob: SimKmsCiphertextBlob;
+  private readonly bytes: Uint8Array;
+  private readonly aad = new SimKmsEncryptionContextAad();
+
+  constructor(properties: SimKmsSymmetricKeyMaterialProperties) {
+    super({ keyArn: properties.keyArn, keySpec: properties.keySpec });
+
+    this.blob = properties.blob;
+    this.bytes = properties.bytes ?? randomBytes(keyLength);
+  }
+
+  /**
+   * Encrypt plaintext under this key, binding the encryption context.
+   */
+  override encrypt(
+    plaintext: Uint8Array,
+    encryptionContext?: SimKmsEncryptionContext,
+  ): Uint8Array {
+    const iv = randomBytes(ivLength);
+    const cipher = createCipheriv(algorithm, this.bytes, iv);
+    cipher.setAAD(this.aad.serialise(encryptionContext));
+
+    const ciphertext = Buffer.concat([
+      cipher.update(plaintext),
+      cipher.final(),
+    ]);
+
+    const authTag = cipher.getAuthTag();
+
+    return this.blob.encode(
+      new SimKmsCiphertextBlobParts({
+        keyArn: this.keyArn,
+        iv: Uint8Array.from(iv),
+        authTag: Uint8Array.from(authTag),
+        ciphertext: Uint8Array.from(ciphertext),
+      }),
+    );
+  }
+
+  /**
+   * Decrypt a ciphertext produced under this key.
+   *
+   * A wrong encryption context fails the GCM authentication tag rather than an
+   * explicit comparison, so the failure comes from the cipher for the same
+   * reason it does on real KMS.
+   */
+  override decrypt(
+    parts: SimKmsCiphertextBlobParts,
+    encryptionContext?: SimKmsEncryptionContext,
+  ): Uint8Array {
+    const decipher = createDecipheriv(algorithm, this.bytes, parts.iv);
+    decipher.setAAD(this.aad.serialise(encryptionContext));
+    decipher.setAuthTag(parts.authTag);
+
+    try {
+      return Uint8Array.from(
+        Buffer.concat([decipher.update(parts.ciphertext), decipher.final()]),
+      );
+    } catch {
+      throw new SimKmsInvalidCiphertextException(
+        "The ciphertext could not be decrypted: it was produced under a " +
+          "different key, with a different encryption context, or has been " +
+          "altered",
+      );
+    }
+  }
+}

--- a/src/service/kms/key/spec/sim-kms-key-spec.ts
+++ b/src/service/kms/key/spec/sim-kms-key-spec.ts
@@ -1,0 +1,124 @@
+import { SimKmsInvalidKeyUsageException } from "../../error/sim-kms.error.js";
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type { SimKmsSigningAlgorithm } from "./sim-kms-signing-algorithm.js";
+
+/**
+ * What a key can be used for. A key has exactly one usage, fixed when it is
+ * created, and it is what decides which operations the key answers.
+ */
+export const SimKmsKeyUsage = {
+  EncryptDecrypt: "ENCRYPT_DECRYPT",
+  SignVerify: "SIGN_VERIFY",
+} as const;
+
+export type SimKmsKeyUsage =
+  (typeof SimKmsKeyUsage)[keyof typeof SimKmsKeyUsage];
+
+/**
+ * The Node key pair parameters behind an asymmetric key spec.
+ *
+ * A key spec is an AWS name for a curve or a modulus length, so this is the
+ * translation of that name into what `generateKeyPairSync` needs.
+ */
+export interface SimKmsEcKeyPair {
+  readonly type: "ec";
+  readonly namedCurve: string;
+}
+
+export interface SimKmsRsaKeyPair {
+  readonly type: "rsa";
+  readonly modulusLength: number;
+}
+
+export type SimKmsKeyPairParameters = SimKmsEcKeyPair | SimKmsRsaKeyPair;
+
+interface SimKmsKeySpecProperties {
+  readonly name: string;
+  readonly keyUsage: SimKmsKeyUsage;
+  readonly keyPair?: SimKmsKeyPairParameters | undefined;
+  readonly signingAlgorithms?: readonly SimKmsSigningAlgorithm[] | undefined;
+  readonly encryptionAlgorithms?: readonly string[] | undefined;
+}
+
+/**
+ * One key spec this simulation models, and what a key of that spec can do.
+ *
+ * The spec is the single answer to three questions that used to be constants:
+ * what material the key holds, which operations it answers, and which
+ * algorithms those operations accept.
+ */
+export class SimKmsKeySpec {
+  public readonly name: string;
+  public readonly keyUsage: SimKmsKeyUsage;
+  public readonly signingAlgorithms: readonly SimKmsSigningAlgorithm[];
+  public readonly encryptionAlgorithms: readonly string[];
+
+  private readonly keyPair: SimKmsKeyPairParameters | undefined;
+
+  constructor(properties: SimKmsKeySpecProperties) {
+    this.name = properties.name;
+    this.keyUsage = properties.keyUsage;
+    this.keyPair = properties.keyPair;
+    this.signingAlgorithms = properties.signingAlgorithms ?? [];
+    this.encryptionAlgorithms = properties.encryptionAlgorithms ?? [];
+  }
+
+  /**
+   * Whether this spec holds a key pair rather than symmetric key material.
+   */
+  get isAsymmetric(): boolean {
+    return this.keyPair !== undefined;
+  }
+
+  /**
+   * The Node key pair parameters for this spec.
+   */
+  keyPairParameters(): SimKmsKeyPairParameters {
+    const keyPair = this.keyPair;
+    assertDefined(keyPair, `key pair parameters for key spec ${this.name}`);
+
+    return keyPair;
+  }
+
+  /**
+   * The signing algorithm names, as DescribeKey and GetPublicKey report them.
+   */
+  signingAlgorithmNames(): readonly string[] {
+    return this.signingAlgorithms.map((algorithm) => algorithm.name);
+  }
+
+  /**
+   * Resolve the signing algorithm a Sign or Verify request asks for.
+   *
+   * AWS requires the algorithm on every signing request rather than defaulting
+   * it, because the choice is part of what the signature means, so an omitted
+   * one is refused here too.
+   */
+  requireSigningAlgorithm(
+    algorithmName: string | undefined,
+  ): SimKmsSigningAlgorithm {
+    if (this.signingAlgorithms.length === 0) {
+      throw new SimKmsInvalidKeyUsageException(
+        `A ${this.name} key cannot sign or verify: its KeyUsage is ${this.keyUsage}`,
+      );
+    }
+
+    if (algorithmName === undefined) {
+      throw new SimKmsInvalidKeyUsageException(
+        `SigningAlgorithm is required, and must be one of ${this.signingAlgorithmNames().join(", ")}`,
+      );
+    }
+
+    const algorithm = this.signingAlgorithms.find(
+      (candidate) => candidate.name === algorithmName,
+    );
+
+    if (algorithm === undefined) {
+      throw new SimKmsInvalidKeyUsageException(
+        `SigningAlgorithm '${algorithmName}' is not valid for a ${this.name} key: use one of ${this.signingAlgorithmNames().join(", ")}`,
+      );
+    }
+
+    return algorithm;
+  }
+}

--- a/src/service/kms/key/spec/sim-kms-key-specs.ts
+++ b/src/service/kms/key/spec/sim-kms-key-specs.ts
@@ -1,0 +1,127 @@
+import {
+  SimKmsKeySpec,
+  SimKmsKeyUsage,
+  type SimKmsKeyPairParameters,
+} from "./sim-kms-key-spec.js";
+import { SimKmsSigningAlgorithm } from "./sim-kms-signing-algorithm.js";
+
+/**
+ * The symmetric encryption spec, which is what a key gets when a request names
+ * no spec at all.
+ */
+export const simKmsSymmetricKeySpecName = "SYMMETRIC_DEFAULT";
+
+/**
+ * The symmetric encryption key spec itself, which several call sites need
+ * directly because it is the default a key gets.
+ */
+export const simKmsSymmetricKeySpec = new SimKmsKeySpec({
+  name: simKmsSymmetricKeySpecName,
+  keyUsage: SimKmsKeyUsage.EncryptDecrypt,
+  encryptionAlgorithms: [simKmsSymmetricKeySpecName],
+});
+
+/**
+ * An ECC key spec offers exactly one signing algorithm, the one paired with
+ * its curve.
+ */
+const ecdsa = (
+  name: string,
+  digest: string,
+): readonly SimKmsSigningAlgorithm[] => [
+  new SimKmsSigningAlgorithm({ name, digest }),
+];
+
+/**
+ * Every RSA signing key offers the same six algorithms, in the order KMS lists
+ * them: the two padding schemes across the three digests.
+ */
+const rsaSigningAlgorithms: readonly SimKmsSigningAlgorithm[] = [
+  new SimKmsSigningAlgorithm({
+    name: "RSASSA_PSS_SHA_256",
+    digest: "sha256",
+    probabilisticPadding: true,
+  }),
+  new SimKmsSigningAlgorithm({
+    name: "RSASSA_PSS_SHA_384",
+    digest: "sha384",
+    probabilisticPadding: true,
+  }),
+  new SimKmsSigningAlgorithm({
+    name: "RSASSA_PSS_SHA_512",
+    digest: "sha512",
+    probabilisticPadding: true,
+  }),
+  new SimKmsSigningAlgorithm({
+    name: "RSASSA_PKCS1_V1_5_SHA_256",
+    digest: "sha256",
+  }),
+  new SimKmsSigningAlgorithm({
+    name: "RSASSA_PKCS1_V1_5_SHA_384",
+    digest: "sha384",
+  }),
+  new SimKmsSigningAlgorithm({
+    name: "RSASSA_PKCS1_V1_5_SHA_512",
+    digest: "sha512",
+  }),
+];
+
+const signingKeySpec = (
+  name: string,
+  keyPair: SimKmsKeyPairParameters,
+  signingAlgorithms: readonly SimKmsSigningAlgorithm[],
+): SimKmsKeySpec =>
+  new SimKmsKeySpec({
+    name,
+    keyUsage: SimKmsKeyUsage.SignVerify,
+    keyPair,
+    signingAlgorithms,
+  });
+
+const ecSigningKeySpec = (
+  name: string,
+  namedCurve: string,
+  signingAlgorithm: string,
+  digest: string,
+): SimKmsKeySpec =>
+  signingKeySpec(
+    name,
+    { type: "ec", namedCurve },
+    ecdsa(signingAlgorithm, digest),
+  );
+
+const rsaSigningKeySpec = (modulusLength: number): SimKmsKeySpec =>
+  signingKeySpec(
+    `RSA_${String(modulusLength)}`,
+    { type: "rsa", modulusLength },
+    rsaSigningAlgorithms,
+  );
+
+/**
+ * Every key spec this simulation models, by the name AWS gives it.
+ *
+ * Real KMS also offers asymmetric encryption, HMAC and key agreement specs,
+ * and offers the RSA specs for encryption as well as signing. Those are absent
+ * rather than listed, so `CreateKey` refuses them: a key that cannot do what
+ * its spec says it does would be worse than no key at all.
+ */
+export const simKmsKeySpecs: ReadonlyMap<string, SimKmsKeySpec> = new Map(
+  [
+    simKmsSymmetricKeySpec,
+    ecSigningKeySpec("ECC_NIST_P256", "prime256v1", "ECDSA_SHA_256", "sha256"),
+    ecSigningKeySpec("ECC_NIST_P384", "secp384r1", "ECDSA_SHA_384", "sha384"),
+    ecSigningKeySpec("ECC_NIST_P521", "secp521r1", "ECDSA_SHA_512", "sha512"),
+    // secp256k1 signs with SHA-256, the same as the P-256 curve above.
+    ecSigningKeySpec("ECC_SECG_P256K1", "secp256k1", "ECDSA_SHA_256", "sha256"),
+    rsaSigningKeySpec(2048),
+    rsaSigningKeySpec(3072),
+    rsaSigningKeySpec(4096),
+  ].map((keySpec) => [keySpec.name, keySpec]),
+);
+
+/**
+ * The names of the key specs this simulation models, for a refusal to list.
+ */
+export function simKmsKeySpecNames(): readonly string[] {
+  return simKmsKeySpecs.keys().toArray();
+}

--- a/src/service/kms/key/spec/sim-kms-signing-algorithm.ts
+++ b/src/service/kms/key/spec/sim-kms-signing-algorithm.ts
@@ -1,0 +1,52 @@
+import {
+  constants,
+  type KeyObject,
+  type SignKeyObjectInput,
+} from "node:crypto";
+
+interface SimKmsSigningAlgorithmProperties {
+  readonly name: string;
+  readonly digest: string;
+  readonly probabilisticPadding?: boolean | undefined;
+}
+
+/**
+ * One KMS signing algorithm, translated into what Node's crypto needs.
+ *
+ * The AWS name carries two things: the digest to hash the message with, and,
+ * for RSA, which of the two padding schemes to use. Both signatures are real,
+ * so the padding has to be the padding AWS uses rather than whichever one Node
+ * defaults to.
+ */
+export class SimKmsSigningAlgorithm {
+  public readonly name: string;
+  public readonly digest: string;
+
+  private readonly probabilisticPadding: boolean;
+
+  constructor(properties: SimKmsSigningAlgorithmProperties) {
+    this.name = properties.name;
+    this.digest = properties.digest;
+    this.probabilisticPadding = properties.probabilisticPadding ?? false;
+  }
+
+  /**
+   * The key input for a sign or verify call under this algorithm.
+   *
+   * RSASSA-PSS needs the padding named and a salt the length of the digest,
+   * which is what KMS signs with. Everything else takes the key on its own:
+   * PKCS#1 v1.5 is Node's default RSA padding, and an EC key has no padding to
+   * choose.
+   */
+  keyInput(key: KeyObject): KeyObject | SignKeyObjectInput {
+    if (!this.probabilisticPadding) {
+      return key;
+    }
+
+    return {
+      key,
+      padding: constants.RSA_PKCS1_PSS_PADDING,
+      saltLength: constants.RSA_PSS_SALTLEN_DIGEST,
+    };
+  }
+}

--- a/src/service/kms/registry/sim-kms-registry.ts
+++ b/src/service/kms/registry/sim-kms-registry.ts
@@ -1,0 +1,65 @@
+import { parseSimArn } from "../../aws/arn.js";
+import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+import type { SimKmsKey } from "../key/sim-kms-key.js";
+import type { SimKms } from "../sim-kms.js";
+
+type SimKmsScopeKey = string;
+
+/**
+ * How another simulated service gets from a key ARN to the key it names.
+ *
+ * Named as an interface so a service depending on it depends on the lookup
+ * rather than on the whole of KMS.
+ */
+export interface SimKmsKeyResolver {
+  key(keyArn: string): SimKmsKey | undefined;
+}
+
+/**
+ * Simulation-wide registry of Account/Region-scoped KMS facades.
+ *
+ * One registry belongs to one SimAws environment. KMS is scoped to an account
+ * and Region, but other services hold only a key ARN, so this is how they get
+ * from that ARN back to the key it names. Route53 uses it to check the
+ * customer managed key a key-signing key is built on.
+ *
+ * The registry indexes KMS facades but does not create or own them.
+ */
+export class SimKmsRegistry implements SimKmsKeyResolver {
+  private readonly kmsByScope = new Map<SimKmsScopeKey, SimKms>();
+
+  /**
+   * Register the KMS facade belonging to an Account and Region.
+   */
+  register(accountRegionScope: SimAwsAccountRegionScope, kms: SimKms): void {
+    this.kmsByScope.set(scopeKey(accountRegionScope), kms);
+  }
+
+  /**
+   * Find the key an ARN names, wherever in the simulation it lives.
+   *
+   * Undefined covers every way an ARN can fail to name a key: it is not an
+   * ARN, it is not a KMS ARN, its account and Region hold no simulated KMS, or
+   * that KMS holds no such key. Callers report the failure in their own terms,
+   * as AWS services do.
+   */
+  key(keyArn: string): SimKmsKey | undefined {
+    const arn = parseSimArn(keyArn);
+
+    if (arn?.service !== "kms") {
+      return undefined;
+    }
+
+    const kms = this.kmsByScope.get(
+      scopeKey({ accountId: arn.accountId, regionName: arn.region }),
+    );
+
+    return kms?.findKey(keyArn);
+  }
+}
+
+function scopeKey(
+  accountRegionScope: SimAwsAccountRegionScope,
+): SimKmsScopeKey {
+  return `${accountRegionScope.accountId}:${accountRegionScope.regionName}`;
+}

--- a/src/service/kms/sdk/sim-kms-sdk-command-router.ts
+++ b/src/service/kms/sdk/sim-kms-sdk-command-router.ts
@@ -24,6 +24,11 @@ import type {
   SimPutKeyPolicyCommand,
   SimScheduleKeyDeletionCommand,
 } from "../command/key/key.command.js";
+import type {
+  SimGetPublicKeyCommand,
+  SimSignCommand,
+  SimVerifyCommand,
+} from "../command/sign/sign.command.js";
 import type { SimKms } from "../sim-kms.js";
 
 /**
@@ -151,6 +156,30 @@ export class SimKmsSdkCommandRouter implements SimSdkCommandRouter {
         async (command, context): Promise<unknown> =>
           await simKms.generateDataKey(
             command as SimGenerateDataKeyCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "SignCommand",
+        async (command, context): Promise<unknown> =>
+          await simKms.sign(
+            command as SimSignCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "VerifyCommand",
+        async (command, context): Promise<unknown> =>
+          await simKms.verify(
+            command as SimVerifyCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "GetPublicKeyCommand",
+        async (command, context): Promise<unknown> =>
+          await simKms.getPublicKey(
+            command as SimGetPublicKeyCommand,
             simSdkCallerOptions(context),
           ),
       ],

--- a/src/service/kms/sdk/sim-kms-sdk-routing.iso.test.ts
+++ b/src/service/kms/sdk/sim-kms-sdk-routing.iso.test.ts
@@ -3,13 +3,17 @@ import {
   CreateKeyCommand,
   DecryptCommand,
   EncryptCommand,
+  GetPublicKeyCommand,
   KMSClient,
+  SignCommand,
+  VerifyCommand,
 } from "@aws-sdk/client-kms";
 import { CreateFunctionCommand, InvokeCommand } from "@aws-sdk/client-lambda";
 import {
   assertIdentical,
   assertNonNullable,
   assertStringIncludes,
+  assertTrue,
 } from "@kensio/smartass";
 import { SimSdk } from "../../../sdk/index.js";
 import { describe, it } from "vitest";
@@ -21,6 +25,43 @@ const emptyBytes = new Uint8Array();
 const plaintext = Uint8Array.from(Buffer.from("hunter2", "utf8"));
 
 describe("KMS SDK interception", () => {
+  it("routes the signing Commands to simulated KMS", async () => {
+    // Given an intercepted KMS SDK client and an asymmetric signing key.
+    using simSdk = new SimSdk();
+    simSdk.intercept(KMSClient);
+
+    const kmsClient = new KMSClient({ region: "eu-west-2" });
+    const created = await kmsClient.send(
+      new CreateKeyCommand({
+        KeySpec: "ECC_NIST_P256",
+        KeyUsage: "SIGN_VERIFY",
+      }),
+    );
+    const KeyId = created.KeyMetadata?.KeyId;
+
+    // When ordinary SDK code signs, verifies and reads the public key.
+    const signed = await kmsClient.send(
+      new SignCommand({
+        KeyId,
+        Message: plaintext,
+        SigningAlgorithm: "ECDSA_SHA_256",
+      }),
+    );
+    const verified = await kmsClient.send(
+      new VerifyCommand({
+        KeyId,
+        Message: plaintext,
+        Signature: signed.Signature,
+        SigningAlgorithm: "ECDSA_SHA_256",
+      }),
+    );
+    const publicKey = await kmsClient.send(new GetPublicKeyCommand({ KeyId }));
+
+    // Then all three reached the simulation.
+    assertTrue(verified.SignatureValid);
+    assertIdentical(publicKey.KeySpec, "ECC_NIST_P256");
+  });
+
   it("routes an intercepted KMSClient to simulated KMS", async () => {
     // Given an intercepted KMS SDK client.
     const simSdk = new SimSdk();

--- a/src/service/kms/sim-kms-commands.ts
+++ b/src/service/kms/sim-kms-commands.ts
@@ -16,6 +16,7 @@ import { SimKmsKeyCommands } from "./command/key/sim-kms-key-commands.js";
 import { SimKmsKeyLifecycleCommands } from "./command/key/sim-kms-key-lifecycle-commands.js";
 import { SimKmsKeyPolicyCommands } from "./command/key/sim-kms-key-policy-commands.js";
 import { SimKmsListKeys } from "./command/key/sim-kms-list-keys.js";
+import { SimKmsSignCommands } from "./command/sign/sim-kms-sign-commands.js";
 import { SimKmsKeyFactory } from "./key/sim-kms-key-factory.js";
 import { SimKmsKeyMetadataView } from "./key/sim-kms-key-metadata.js";
 import { SimKmsKeyStore } from "./key/sim-kms-key-store.js";
@@ -45,6 +46,7 @@ export class SimKmsCommands {
   public readonly policies: SimKmsKeyPolicyCommands;
   public readonly aliases: SimKmsAliasCommands;
   public readonly crypto: SimKmsCryptoCommands;
+  public readonly signing: SimKmsSignCommands;
   public readonly generateDataKey: SimKmsGenerateDataKey;
   public readonly background: BackgroundScheduler;
 
@@ -81,6 +83,7 @@ export class SimKmsCommands {
     });
     this.aliases = new SimKmsAliasCommands({ keys: this.keys, authorizer });
     this.crypto = new SimKmsCryptoCommands({ keys: this.keys, authorizer });
+    this.signing = new SimKmsSignCommands({ keys: this.keys, authorizer });
     this.generateDataKey = new SimKmsGenerateDataKey({
       keys: this.keys,
       authorizer,

--- a/src/service/kms/sim-kms.ts
+++ b/src/service/kms/sim-kms.ts
@@ -210,6 +210,39 @@ export class SimKms {
   }
 
   /**
+   * Handle a Sign Command from the SDK.
+   */
+  async sign(
+    command: simKmsCommands.SimSignCommand,
+    options?: SimKmsRequestOptions,
+  ): Promise<simKmsCommands.SimSignCommandOutput> {
+    await this.commands.background.sequence();
+    return this.commands.signing.sign(command, options);
+  }
+
+  /**
+   * Handle a Verify Command from the SDK.
+   */
+  async verify(
+    command: simKmsCommands.SimVerifyCommand,
+    options?: SimKmsRequestOptions,
+  ): Promise<simKmsCommands.SimVerifyCommandOutput> {
+    await this.commands.background.sequence();
+    return this.commands.signing.verify(command, options);
+  }
+
+  /**
+   * Handle a GetPublicKey Command from the SDK.
+   */
+  async getPublicKey(
+    command: simKmsCommands.SimGetPublicKeyCommand,
+    options?: SimKmsRequestOptions,
+  ): Promise<simKmsCommands.SimGetPublicKeyCommandOutput> {
+    await this.commands.background.sequence();
+    return this.commands.signing.getPublicKey(command, options);
+  }
+
+  /**
    * Get this service's CloudFormation Resource factory, which creates
    * simulated keys and aliases from AWS::KMS::* Resources.
    */

--- a/src/service/route53/README.md
+++ b/src/service/route53/README.md
@@ -23,6 +23,7 @@ or sim CloudFront.
 - `resolve/` contains Yulin-local hostname resolution.
 - `local-name/` contains conversion and normalization helpers for simulated hostnames.
 - `cfn/` contains CloudFormation support for supported `AWS::Route53::*` resources.
+- `dnssec/` contains the key-signing key model and the DNSKEY derivation behind it.
 - `error/` contains Route53-specific AWS-like errors.
 
 When used through `SimAws`, Route53 is exposed from account/region containers like other services,
@@ -47,9 +48,9 @@ or missing ID with `SimRoute53InvalidInput`. A well-formed ID that no hosted zon
 fail later with `SimRoute53NoSuchHostedZone`, so callers can tell a bad ID apart from an unknown
 zone. `assertIsSimRoute53HostedZoneId` applies the same shape check as an internal invariant.
 
-`SimRoute53` is a thin facade. It does not contain command implementation details. Each
-public AWS-style operation constructs the appropriate command handler with the hosted-zone map and
-background scheduler, then delegates to that handler.
+`SimRoute53` is a thin facade. It does not contain command implementation details. Each public
+AWS-style operation is one line into `SimRoute53Commands`, which holds the command handlers and the
+hosted-zone map, IAM and background scheduler they share.
 
 This keeps the service object responsible for shared state and wiring, while command handlers own
 validation, state transitions, and AWS-shaped outputs.
@@ -67,9 +68,15 @@ Supported command areas currently include:
 
 - `create-hosted-zone/`
 - `get-hosted-zone/`
+- `delete-hosted-zone/`
 - `list-hosted-zones-by-name/`
 - `change-resource-record-sets/`
 - `list-resource-record-sets/`
+- `dnssec/`
+
+`dnssec/` is the exception to one directory per command. Its seven commands all start from the same
+hosted zone lookup and authorization, and four of them work on the same key-signing key list, so
+they are grouped by the collaborators they share the way the simulated KMS commands are.
 
 The command handlers follow the same broad pattern used by other sim services:
 
@@ -225,8 +232,9 @@ insertion order rather than DNS order, because the store is a lookup structure; 
 Route53 ordering sort the result themselves.
 
 The simulator does not currently model routing policies, weighted records, health checks,
-multi-value answer records, DNSSEC, or alias-specific evaluation beyond converting alias targets
-into record values for supported routing scenarios.
+multi-value answer records, or alias-specific evaluation beyond converting alias targets into record
+values for supported routing scenarios. DNSSEC is modelled as zone state rather than as records:
+see [DNSSEC](#dnssec).
 
 ## ChangeResourceRecordSets behaviour
 
@@ -364,6 +372,8 @@ Sim Route53 CloudFormation support lives under `cfn/`.
 
 - `AWS::Route53::HostedZone`
 - `AWS::Route53::RecordSet`
+- `AWS::Route53::KeySigningKey`
+- `AWS::Route53::DNSSEC`
 
 CloudFormation creation is delegated from the generic CloudFormation engine into this
 service-specific factory. The generic CloudFormation service resolves dependencies and properties;
@@ -430,6 +440,47 @@ one Account and it does not apply sim IAM authorization. Zones come from `SimRou
 Rendering is split into `zone-summary/`, with the page structure in
 `sim-route53-zone-summary-page.ts` and escaping in `sim-route53-summary-html.ts`. Hosted-zone names
 and record values originate in user templates and test code, so everything rendered is escaped.
+
+## DNSSEC
+
+DNSSEC state lives under `dnssec/`, on the hosted zone rather than on the account-scoped service.
+`SimRoute53HostedZone` holds a `SimRoute53ZoneDnssec` in the same way it holds its records, so a
+zone reached through the shared registry carries its signing state with it.
+
+`SimRoute53ZoneDnssec` keeps the zone's key-signing keys and whether the zone is being signed apart,
+because AWS does: adding a key does not start signing, and stopping signing leaves the keys in
+place. That separation is what lets a zone be prepared for DNSSEC before its DS record is published.
+
+`SimRoute53KeySigningKey` holds what Route53 adds on top of the KMS key: a name within the zone, a
+status, and the DNSSEC parameters derived once at creation. Real Route53 derives them once in the
+same way, which is why there is no operation to point an existing key-signing key at another KMS
+key.
+
+The derivation is the part worth getting right, because it is what a test asserts on:
+
+- `sim-route53-dnskey-rdata.ts` takes the raw X and Y point out of the DER `SubjectPublicKeyInfo`
+  `GetPublicKey` returns, and builds the DNSKEY RDATA from it. A point that is not an uncompressed
+  P-256 one is refused rather than read as if it were.
+- `sim-route53-dnskey-tag.ts` computes the key tag by the RFC 4034 Appendix B algorithm.
+- `SimRoute53Dnskey` digests the canonical owner name and that RDATA into the delegation signer
+  value, and formats the DS and DNSKEY records.
+
+There is one algorithm rather than a table, in `sim-route53-dnssec-algorithm.ts`, because Route53
+only accepts an `ECC_NIST_P256` key: ECDSA with SHA-256, algorithm 13, and the SHA-256 digest,
+algorithm 2.
+
+`sim-route53-dnskey.iso.test.ts` checks the key tag and the digest against the published ECDSA
+P-256 example in RFC 6605 Appendix A.1. Self-consistency would not catch an algorithm that is wrong
+in the same way twice, and these values are exactly the ones a registrar would be given.
+
+### Reaching KMS
+
+A key-signing key is built on a KMS customer managed key, and Route53 is account-scoped while KMS is
+account and region-scoped. `SimKmsRegistry` bridges that, in the way `SimAcmRegistry` lets CloudFront
+reach a certificate: a key ARN carries both the account and the region, so the lookup is the same
+shape. `SimRoute53KskKmsKey` then applies the checks real Route53 applies before it takes a key.
+
+A standalone `new SimRoute53()` has no registry, and refuses rather than accepting an unchecked key.
 
 ## DNS wire format
 

--- a/src/service/route53/cfn/dnssec/sim-cfn-r53-dnssec-properties.ts
+++ b/src/service/route53/cfn/dnssec/sim-cfn-r53-dnssec-properties.ts
@@ -1,0 +1,25 @@
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValue } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+
+/**
+ * Read a required string property off a Route53 DNSSEC Resource.
+ *
+ * Both DNSSEC Resource types are only strings, and every one of them is
+ * required, so this is the whole of their property parsing. The value is
+ * passed in rather than the property looked up here, matching the other
+ * property parsers, so the property names stay literals at their call sites.
+ */
+export function simCfnRoute53String(
+  resource: SimCfnResource,
+  value: SimCfnTemplateValue | undefined,
+  resourceType: string,
+  name: string,
+): string {
+  if (typeof value !== "string") {
+    throw new TypeError(
+      `Invalid ${resourceType} ${resource.logicalId}: ${name} must be a string`,
+    );
+  }
+
+  return value;
+}

--- a/src/service/route53/cfn/dnssec/sim-cfn-r53-dnssec.iso.test.ts
+++ b/src/service/route53/cfn/dnssec/sim-cfn-r53-dnssec.iso.test.ts
@@ -1,0 +1,199 @@
+import { GetDNSSECCommand } from "@aws-sdk/client-route-53";
+import {
+  assertArrayLength,
+  assertFalse,
+  assertIdentical,
+  assertMapSize,
+  assertNonNullable,
+  assertStringIncludes,
+  assertTrue,
+  assertThrowsErrorAsync,
+  assertTypeString,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import type { SimCfnStack } from "../../../cloudformation/stack/sim-cfn-stack.js";
+import { simCfnDnssecTemplate } from "../../../../../test/route53/dnssec-template.js";
+
+async function deployedDnssecStack(simAws: SimAws): Promise<SimCfnStack> {
+  const stack = await simAws.cloudFormation().deployTemplate({
+    stackName: "dns-stack",
+    template: simCfnDnssecTemplate(),
+  });
+  await stack.waitForDeployComplete();
+
+  return stack;
+}
+
+function output(stack: SimCfnStack, name: string): string {
+  const value = stack.outputs.get(name)?.value;
+  assertTypeString(value);
+
+  return value;
+}
+
+describe("Route53 DNSSEC CloudFormation Resources", () => {
+  it("signs a zone deployed from a template", async () => {
+    // Given the shape CDK synthesizes for a signed hosted zone: a signing key,
+    // a key signing key naming it, and a DNSSEC Resource for the zone.
+    const simAws = new SimAws();
+
+    // When the Stack is deployed.
+    const stack = await deployedDnssecStack(simAws);
+
+    // Then all three Resources were created rather than skipped, so the DNSSEC
+    // half of the Stack is actually simulated.
+    assertFalse(stack.resources.get("ZoneSigningKey")?.skipped);
+    assertFalse(stack.resources.get("ZoneKeySigningKey")?.skipped);
+    assertFalse(stack.resources.get("ZoneDnssec")?.skipped);
+
+    // And the zone reports itself as signed, with a key a registrar could be
+    // given the DS record for.
+    const dnssec = await simAws
+      .route53()
+      .getDnssec(
+        new GetDNSSECCommand({ HostedZoneId: output(stack, "ZoneId") }),
+      );
+
+    assertIdentical(dnssec.Status?.ServeSignature, "SIGNING");
+    assertArrayLength(dnssec.KeySigningKeys ?? [], 1);
+    const keySigningKey = dnssec.KeySigningKeys?.[0];
+    assertNonNullable(keySigningKey);
+    assertIdentical(keySigningKey.Status, "ACTIVE");
+    assertStringIncludes(keySigningKey.DSRecord, " 13 2 ");
+  });
+
+  it("refers to a key signing key by zone and name", async () => {
+    // Given the deployed Stack.
+    const simAws = new SimAws();
+    const stack = await deployedDnssecStack(simAws);
+
+    // When the key signing key Resource is referred to, then the Ref is the
+    // zone ID and the key name joined, which is what CDK's KeySigningKey
+    // construct reads as its key signing key ID.
+    assertIdentical(
+      output(stack, "KeySigningKeyId"),
+      `${output(stack, "ZoneId")}|zone_signing_key`,
+    );
+  });
+
+  it("refers to the DNSSEC Resource by hosted zone", async () => {
+    // Given the deployed Stack.
+    const simAws = new SimAws();
+    const stack = await deployedDnssecStack(simAws);
+
+    // When the DNSSEC Resource is referred to, then it is the zone it signs.
+    assertIdentical(output(stack, "DnssecRef"), output(stack, "ZoneId"));
+  });
+
+  it("accepts the key policy CDK gives a signing key", async () => {
+    // Given the deployed Stack, whose key policy carries the statements CDK's
+    // KeySigningKey construct adds for the dnssec-route53 service principal.
+    const simAws = new SimAws();
+    const stack = await deployedDnssecStack(simAws);
+
+    // When the deployed key is read, then it exists as an ECC_NIST_P256 key:
+    // the policy was accepted rather than refused for a principal or condition
+    // it does not model.
+    const key = simAws.kms().findKey(output(stack, "SigningKeyArn"));
+
+    assertNonNullable(key);
+    assertIdentical(key.keySpec.name, "ECC_NIST_P256");
+  });
+
+  it("refuses an attribute neither DNSSEC Resource has", async () => {
+    // Given a Stack asking for an attribute of a key signing key, which real
+    // CloudFormation gives neither DNSSEC Resource type.
+    const simAws = new SimAws();
+    const template = simCfnDnssecTemplate();
+
+    // When it is deployed, then the reference is refused rather than answered
+    // with something invented.
+    const error = await assertThrowsErrorAsync(async () => {
+      const stack = await simAws.cloudFormation().deployTemplate({
+        stackName: "dns-stack",
+        template: {
+          ...template,
+          Outputs: {
+            KeyArn: { Value: { "Fn::GetAtt": ["ZoneKeySigningKey", "Arn"] } },
+          },
+        },
+      });
+      await stack.waitForDeployComplete();
+    });
+
+    assertStringIncludes(
+      error.message,
+      "Unsupported AWS::Route53::KeySigningKey attribute Arn",
+    );
+  });
+
+  it("refuses a DNSSEC attribute", async () => {
+    // Given a Stack asking for an attribute of the DNSSEC Resource.
+    const simAws = new SimAws();
+    const template = simCfnDnssecTemplate();
+
+    // When it is deployed, then it is refused.
+    const error = await assertThrowsErrorAsync(async () => {
+      const stack = await simAws.cloudFormation().deployTemplate({
+        stackName: "dns-stack",
+        template: {
+          ...template,
+          Outputs: {
+            Status: { Value: { "Fn::GetAtt": ["ZoneDnssec", "Status"] } },
+          },
+        },
+      });
+      await stack.waitForDeployComplete();
+    });
+
+    assertStringIncludes(
+      error.message,
+      "Unsupported AWS::Route53::DNSSEC attribute Status",
+    );
+  });
+
+  it("refuses a key signing key property that is not a string", async () => {
+    // Given a template whose key signing key names its zone as a number.
+    const simAws = new SimAws();
+
+    // When it is deployed, then the Resource is refused before a key exists.
+    const error = await assertThrowsErrorAsync(async () => {
+      const stack = await simAws.cloudFormation().deployTemplate({
+        stackName: "dns-stack",
+        template: {
+          Resources: {
+            ZoneKeySigningKey: {
+              Type: "AWS::Route53::KeySigningKey",
+              Properties: {
+                HostedZoneId: 42,
+                KeyManagementServiceArn: "arn:aws:kms:us-east-1:1:key/a",
+                Name: "zone_signing_key",
+                Status: "ACTIVE",
+              },
+            },
+          },
+        },
+      });
+      await stack.waitForDeployComplete();
+    });
+
+    assertStringIncludes(error.message, "HostedZoneId must be a string");
+  });
+
+  it("unsigns the zone as the Stack is torn down", async () => {
+    // Given the deployed Stack, with its zone signed by an active key.
+    const simAws = new SimAws();
+    const stack = await deployedDnssecStack(simAws);
+
+    // When the Stack is torn down.
+    await stack.teardown();
+
+    // Then every DNSSEC Resource came off, which only happens if signing
+    // stopped before the key did and the key was deactivated before deletion.
+    assertTrue(stack.resources.get("ZoneDnssec")?.deleteComplete);
+    assertTrue(stack.resources.get("ZoneKeySigningKey")?.deleteComplete);
+    assertMapSize(simAws.route53().hostedZones, 0);
+  });
+});

--- a/src/service/route53/cfn/dnssec/sim-cfn-r53-ksk-creator.ts
+++ b/src/service/route53/cfn/dnssec/sim-cfn-r53-ksk-creator.ts
@@ -1,0 +1,104 @@
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type {
+  SimCfnTemplateValue,
+  SimCfnTemplateValueRecord,
+} from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimRoute53KeySigningKey } from "../../dnssec/sim-route53-key-signing-key.js";
+import type { SimRoute53 } from "../../sim-route53.js";
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import { normalizeSimRoute53HostedZoneId } from "../../command/create-hosted-zone/sim-route53-zone-id.js";
+import { simCfnRoute53String } from "./sim-cfn-r53-dnssec-properties.js";
+
+const resourceType = "AWS::Route53::KeySigningKey";
+
+interface SimCfnRoute53KskCreatorProperties {
+  readonly route53: SimRoute53;
+}
+
+/**
+ * Creates simulated Route53 key-signing keys from CloudFormation Resources.
+ *
+ * Creation goes through `CreateKeySigningKey` rather than building the stored
+ * object, so a template gets the same KMS key checks and the same DNSSEC field
+ * derivation an SDK caller gets.
+ */
+export class SimCfnRoute53KskCreator {
+  private readonly route53: SimRoute53;
+
+  constructor(properties: SimCfnRoute53KskCreatorProperties) {
+    this.route53 = properties.route53;
+  }
+
+  /**
+   * Create a key-signing key from an AWS::Route53::KeySigningKey Resource.
+   */
+  async create(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): Promise<SimRoute53KeySigningKey> {
+    const hostedZoneId = this.string(
+      resource,
+      properties["HostedZoneId"],
+      "HostedZoneId",
+    );
+    const name = this.string(resource, properties["Name"], "Name");
+
+    await this.route53.createKeySigningKey({
+      input: {
+        CallerReference: resource.logicalId,
+        HostedZoneId: hostedZoneId,
+        KeyManagementServiceArn: this.string(
+          resource,
+          properties["KeyManagementServiceArn"],
+          "KeyManagementServiceArn",
+        ),
+        Name: name,
+        Status: this.string(resource, properties["Status"], "Status"),
+      },
+    });
+
+    const keySigningKey = this.route53.hostedZones
+      .get(normalizeSimRoute53HostedZoneId(hostedZoneId))
+      ?.dnssec.keys()
+      .find((key) => key.name === name);
+
+    assertDefined(
+      keySigningKey,
+      `sim Route53 key signing key ${name} after CloudFormation creation`,
+    );
+
+    return keySigningKey;
+  }
+
+  /**
+   * Delete a key-signing key an AWS::Route53::KeySigningKey Resource created.
+   *
+   * A key still signing cannot be deleted, and a template that deployed one
+   * active would otherwise be undeployable, so it is deactivated first. Real
+   * CloudFormation does the same thing on its way to removing the Resource.
+   */
+  async delete(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): Promise<void> {
+    const input = {
+      HostedZoneId: this.string(
+        resource,
+        properties["HostedZoneId"],
+        "HostedZoneId",
+      ),
+      Name: this.string(resource, properties["Name"], "Name"),
+    };
+
+    await this.route53.deactivateKeySigningKey({ input });
+    await this.route53.deleteKeySigningKey({ input });
+  }
+
+  private string(
+    resource: SimCfnResource,
+    value: SimCfnTemplateValue | undefined,
+    name: string,
+  ): string {
+    return simCfnRoute53String(resource, value, resourceType, name);
+  }
+}

--- a/src/service/route53/cfn/dnssec/sim-cfn-r53-zone-signing-creator.ts
+++ b/src/service/route53/cfn/dnssec/sim-cfn-r53-zone-signing-creator.ts
@@ -1,0 +1,77 @@
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import { normalizeSimRoute53HostedZoneId } from "../../command/create-hosted-zone/sim-route53-zone-id.js";
+import type { SimRoute53HostedZone } from "../../hosted-zone/sim-route53-hosted-zone.js";
+import type { SimRoute53 } from "../../sim-route53.js";
+import { simCfnRoute53String } from "./sim-cfn-r53-dnssec-properties.js";
+
+const resourceType = "AWS::Route53::DNSSEC";
+
+interface SimCfnRoute53ZoneSigningCreatorProperties {
+  readonly route53: SimRoute53;
+}
+
+/**
+ * Turns DNSSEC signing on for a hosted zone from a CloudFormation Resource.
+ *
+ * The Resource has no state of its own beyond the zone it names, so the
+ * simulated resource behind it is that hosted zone. Its `Ref` is the hosted
+ * zone ID, which is what the Resource's physical ID is on real
+ * CloudFormation.
+ */
+export class SimCfnRoute53ZoneSigningCreator {
+  private readonly route53: SimRoute53;
+
+  constructor(properties: SimCfnRoute53ZoneSigningCreatorProperties) {
+    this.route53 = properties.route53;
+  }
+
+  /**
+   * Start signing the zone an AWS::Route53::DNSSEC Resource names.
+   */
+  async create(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): Promise<SimRoute53HostedZone> {
+    const hostedZoneId = this.hostedZoneId(resource, properties);
+
+    await this.route53.enableHostedZoneDnssec({
+      input: { HostedZoneId: hostedZoneId },
+    });
+
+    const hostedZone = this.route53.hostedZones.get(
+      normalizeSimRoute53HostedZoneId(hostedZoneId),
+    );
+    assertDefined(
+      hostedZone,
+      `sim Route53 Hosted Zone ${hostedZoneId} after enabling DNSSEC`,
+    );
+
+    return hostedZone;
+  }
+
+  /**
+   * Stop signing the zone as the Resource is removed.
+   */
+  async delete(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): Promise<void> {
+    await this.route53.disableHostedZoneDnssec({
+      input: { HostedZoneId: this.hostedZoneId(resource, properties) },
+    });
+  }
+
+  private hostedZoneId(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): string {
+    return simCfnRoute53String(
+      resource,
+      properties["HostedZoneId"],
+      resourceType,
+      "HostedZoneId",
+    );
+  }
+}

--- a/src/service/route53/cfn/sim-cfn-route53-resource-deleter.ts
+++ b/src/service/route53/cfn/sim-cfn-route53-resource-deleter.ts
@@ -5,9 +5,13 @@ import type { SimRoute53HostedZone } from "../hosted-zone/sim-route53-hosted-zon
 import { SimCfnRoute53RecordSetBuilder } from "./record-set/build/sim-cfn-r53-record-set-builder.js";
 import { SimCfnRoute53RecordSetHostedZoneResolver } from "./record-set/resolve/sim-cfn-r53-rec-set-zone-resolver.js";
 import { assertDefined } from "../../../util/type-guard/defined.js";
+import type { SimCfnRoute53KskCreator } from "./dnssec/sim-cfn-r53-ksk-creator.js";
+import type { SimCfnRoute53ZoneSigningCreator } from "./dnssec/sim-cfn-r53-zone-signing-creator.js";
 
 interface SimCfnRoute53ResourceDeleterProperties {
   readonly route53: SimRoute53;
+  readonly keySigningKeyCreator: SimCfnRoute53KskCreator;
+  readonly zoneSigningCreator: SimCfnRoute53ZoneSigningCreator;
 }
 
 /**
@@ -20,13 +24,20 @@ interface SimCfnRoute53ResourceDeleterProperties {
  * The Hosted Zone goes last, and only works because it does: DeleteHostedZone
  * refuses a zone that still holds records, and the record set Resources naming
  * the zone have already been taken off it by then.
+ *
+ * DNSSEC comes off the same way. Signing stops before the key-signing keys go,
+ * because a key that is still signing cannot be deleted.
  */
 export class SimCfnRoute53ResourceDeleter {
   private readonly route53: SimRoute53;
+  private readonly keySigningKeyCreator: SimCfnRoute53KskCreator;
+  private readonly zoneSigningCreator: SimCfnRoute53ZoneSigningCreator;
   private readonly hostedZoneResolver: SimCfnRoute53RecordSetHostedZoneResolver;
 
   constructor(properties: SimCfnRoute53ResourceDeleterProperties) {
     this.route53 = properties.route53;
+    this.keySigningKeyCreator = properties.keySigningKeyCreator;
+    this.zoneSigningCreator = properties.zoneSigningCreator;
     this.hostedZoneResolver = new SimCfnRoute53RecordSetHostedZoneResolver({
       route53: this.route53,
     });
@@ -47,6 +58,14 @@ export class SimCfnRoute53ResourceDeleter {
       }
       case "RecordSet": {
         await this.deleteRecordSet(resource, properties);
+        return;
+      }
+      case "KeySigningKey": {
+        await this.keySigningKeyCreator.delete(resource, properties);
+        return;
+      }
+      case "DNSSEC": {
+        await this.zoneSigningCreator.delete(resource, properties);
         return;
       }
       default: {

--- a/src/service/route53/cfn/sim-cfn-route53-resource-factory.ts
+++ b/src/service/route53/cfn/sim-cfn-route53-resource-factory.ts
@@ -6,6 +6,8 @@ import type { SimCfnServiceResourceFactory } from "../../cloudformation/resource
 import { SimRoute53 } from "../sim-route53.js";
 import { SimCfnRoute53HostedZoneCreator } from "./hosted-zone/sim-cfn-r53-zone-creator.js";
 import { SimCfnRoute53RecordSetApplicator } from "./record-set/apply/sim-cfn-r53-record-set-applicator.js";
+import { SimCfnRoute53KskCreator } from "./dnssec/sim-cfn-r53-ksk-creator.js";
+import { SimCfnRoute53ZoneSigningCreator } from "./dnssec/sim-cfn-r53-zone-signing-creator.js";
 import { SimCfnRoute53ResourceDeleter } from "./sim-cfn-route53-resource-deleter.js";
 import type { SimCloudFormationResourceDeleteContext } from "../../cloudformation/resource/sim-cfn-resource.type.js";
 
@@ -19,6 +21,8 @@ interface SimRoute53CloudFormationResourceFactoryProperties {
 export class SimRoute53CloudFormationResourceFactory implements SimCfnServiceResourceFactory {
   private readonly hostedZoneCreator: SimCfnRoute53HostedZoneCreator;
   private readonly recordSetCreator: SimCfnRoute53RecordSetApplicator;
+  private readonly keySigningKeyCreator: SimCfnRoute53KskCreator;
+  private readonly zoneSigningCreator: SimCfnRoute53ZoneSigningCreator;
   private readonly deleter: SimCfnRoute53ResourceDeleter;
 
   constructor(
@@ -28,7 +32,13 @@ export class SimRoute53CloudFormationResourceFactory implements SimCfnServiceRes
 
     this.hostedZoneCreator = new SimCfnRoute53HostedZoneCreator({ route53 });
     this.recordSetCreator = new SimCfnRoute53RecordSetApplicator({ route53 });
-    this.deleter = new SimCfnRoute53ResourceDeleter({ route53 });
+    this.keySigningKeyCreator = new SimCfnRoute53KskCreator({ route53 });
+    this.zoneSigningCreator = new SimCfnRoute53ZoneSigningCreator({ route53 });
+    this.deleter = new SimCfnRoute53ResourceDeleter({
+      route53,
+      keySigningKeyCreator: this.keySigningKeyCreator,
+      zoneSigningCreator: this.zoneSigningCreator,
+    });
   }
 
   /**
@@ -48,6 +58,18 @@ export class SimRoute53CloudFormationResourceFactory implements SimCfnServiceRes
       }
       case "RecordSet": {
         return await this.recordSetCreator.create(
+          resource,
+          context.resolvedProperties ?? resource.properties,
+        );
+      }
+      case "KeySigningKey": {
+        return await this.keySigningKeyCreator.create(
+          resource,
+          context.resolvedProperties ?? resource.properties,
+        );
+      }
+      case "DNSSEC": {
+        return await this.zoneSigningCreator.create(
           resource,
           context.resolvedProperties ?? resource.properties,
         );

--- a/src/service/route53/command/change-resource-record-sets/change-resource-record-sets.handler.ts
+++ b/src/service/route53/command/change-resource-record-sets/change-resource-record-sets.handler.ts
@@ -96,11 +96,7 @@ export class ChangeResourceRecordSetsCommandHandler implements CommandHandler<
 
     const submittedAt = this.background.now();
 
-    await scheduleChangeResourceRecordSets(
-      this.background,
-      hostedZone,
-      changes,
-    );
+    scheduleChangeResourceRecordSets(this.background, hostedZone, changes);
 
     return {
       ChangeInfo: {

--- a/src/service/route53/command/change-resource-record-sets/schedule/schedule-change-resource-rec-sets.ts
+++ b/src/service/route53/command/change-resource-record-sets/schedule/schedule-change-resource-rec-sets.ts
@@ -8,23 +8,29 @@ import {
 
 /**
  * Validates and schedules Route53 record changes for a Hosted Zone.
+ *
+ * Nothing here waits: the changes are validated, the zone goes to PENDING, and
+ * the mutation is handed to the background scheduler. Waiting for it is what
+ * the zone's own synchronization is for.
  */
-export async function scheduleChangeResourceRecordSets(
+export function scheduleChangeResourceRecordSets(
   background: BackgroundScheduler,
   hostedZone: SimRoute53HostedZone,
   changes: readonly SimRoute53Change[],
-): Promise<void> {
+): void {
   for (const change of changes) {
     validateChangeResourceRecordSet(change);
   }
 
-  await hostedZone.beginSynchronization();
+  hostedZone.beginSynchronization();
 
-  hostedZone.scheduleSynchronization(background, async () => {
+  hostedZone.scheduleSynchronization(background, () => {
     for (const change of changes) {
       applyChangeResourceRecordSet(hostedZone, change);
     }
 
-    await hostedZone.completeSynchronization();
+    hostedZone.markSynchronized();
+
+    return Promise.resolve();
   });
 }

--- a/src/service/route53/command/create-hosted-zone/create-hosted-zone.handler.ts
+++ b/src/service/route53/command/create-hosted-zone/create-hosted-zone.handler.ts
@@ -109,7 +109,11 @@ export class CreateHostedZoneCommandHandler implements CommandHandler<
     this.route53Registry.registerHostedZone(hostedZoneId, hostedZone);
 
     // Schedule background task to complete creation of the sim Hosted Zone.
-    this.background.schedule(() => hostedZone.completeSynchronization());
+    this.background.schedule(() => {
+      hostedZone.markSynchronized();
+
+      return Promise.resolve();
+    });
 
     return {
       HostedZone: {

--- a/src/service/route53/command/delete-hosted-zone/delete-hosted-zone.handler.ts
+++ b/src/service/route53/command/delete-hosted-zone/delete-hosted-zone.handler.ts
@@ -72,6 +72,10 @@ export class DeleteHostedZoneCommandHandler implements CommandHandler<
    * simulated zone is created without those two, so any record at all counts
    * here, and the caller removes them with ChangeResourceRecordSets first.
    *
+   * A signed zone is refused for the same reason: real Route53 wants DNSSEC
+   * disabled before the zone goes, so the DS record at the parent stops
+   * pointing at a zone that no longer exists.
+   *
    * Deregistering the zone is what stops its names resolving, because DNS
    * resolution reads the cross-Account registry rather than this Account's
    * own hosted zone map.
@@ -97,6 +101,7 @@ export class DeleteHostedZoneCommandHandler implements CommandHandler<
     }
 
     hostedZone.assertDeletable();
+    hostedZone.dnssec.assertZoneDeletable();
 
     this.hostedZones.delete(hostedZoneId);
     this.route53Registry.deregisterHostedZone(hostedZoneId);

--- a/src/service/route53/command/dnssec/dnssec.command.ts
+++ b/src/service/route53/command/dnssec/dnssec.command.ts
@@ -1,0 +1,90 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type { SimRoute53KeySigningKeyView } from "../../dnssec/sim-route53-key-signing-key.js";
+import type { SimRoute53ServeSignature } from "../../dnssec/sim-route53-zone-dnssec.js";
+import type { SimRoute53ChangeInfo } from "../create-hosted-zone/create-hosted-zone.command.js";
+
+/**
+ * Minimal structural sim Route53 CreateKeySigningKey command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/route-53/command/CreateKeySigningKeyCommand/
+ */
+export interface SimCreateKeySigningKeyCommand {
+  readonly input: SimCreateKeySigningKeyCommandInput;
+}
+
+export interface SimCreateKeySigningKeyCommandInput {
+  readonly CallerReference?: string | undefined;
+  readonly HostedZoneId?: string | undefined;
+  readonly KeyManagementServiceArn?: string | undefined;
+  readonly Name?: string | undefined;
+  readonly Status?: string | undefined;
+}
+
+export interface SimCreateKeySigningKeyCommandOutput {
+  readonly ChangeInfo?: SimRoute53ChangeInfo | undefined;
+  readonly KeySigningKey?: SimRoute53KeySigningKeyView | undefined;
+  readonly Location?: string | undefined;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim Route53 key-signing key command input.
+ *
+ * ActivateKeySigningKey, DeactivateKeySigningKey and DeleteKeySigningKey all
+ * take the same two fields and answer with the same change info.
+ */
+export interface SimKeySigningKeyCommand {
+  readonly input: SimKeySigningKeyCommandInput;
+}
+
+export interface SimKeySigningKeyCommandInput {
+  readonly HostedZoneId?: string | undefined;
+  readonly Name?: string | undefined;
+}
+
+export interface SimKeySigningKeyCommandOutput {
+  readonly ChangeInfo?: SimRoute53ChangeInfo | undefined;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim Route53 zone signing command input.
+ *
+ * EnableHostedZoneDNSSEC and DisableHostedZoneDNSSEC share it.
+ */
+export interface SimHostedZoneDnssecCommand {
+  readonly input: SimHostedZoneDnssecCommandInput;
+}
+
+export interface SimHostedZoneDnssecCommandInput {
+  readonly HostedZoneId?: string | undefined;
+}
+
+export interface SimHostedZoneDnssecCommandOutput {
+  readonly ChangeInfo?: SimRoute53ChangeInfo | undefined;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim Route53 GetDNSSEC command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/route-53/command/GetDNSSECCommand/
+ */
+export interface SimGetDnssecCommand {
+  readonly input: SimGetDnssecCommandInput;
+}
+
+export interface SimGetDnssecCommandInput {
+  readonly HostedZoneId?: string | undefined;
+}
+
+export interface SimRoute53DnssecStatus {
+  readonly ServeSignature?: SimRoute53ServeSignature | undefined;
+  readonly StatusMessage?: string | undefined;
+}
+
+export interface SimGetDnssecCommandOutput {
+  readonly Status?: SimRoute53DnssecStatus | undefined;
+  readonly KeySigningKeys?: readonly SimRoute53KeySigningKeyView[] | undefined;
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/route53/command/dnssec/sim-route53-dnssec-authorizer.ts
+++ b/src/service/route53/command/dnssec/sim-route53-dnssec-authorizer.ts
@@ -1,0 +1,45 @@
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+import { simRoute53HostedZoneArn } from "../../hosted-zone/sim-route53-hosted-zone-arn.js";
+import type { SimRoute53HostedZoneId } from "../create-hosted-zone/sim-route53-zone-id.js";
+
+interface SimRoute53DnssecAuthorizerProperties {
+  readonly iam: SimIamInterServiceAuthZ;
+}
+
+/**
+ * Applies IAM authorization to a Route53 DNSSEC request.
+ *
+ * Every DNSSEC operation names a hosted zone and authorizes against that
+ * zone's ARN, so one authorizer takes the action rather than there being seven
+ * classes that differ by a string. Authorization runs before the zone is
+ * looked up, so an unauthorized caller cannot learn whether a zone ID exists.
+ */
+export class SimRoute53DnssecAuthorizer {
+  private readonly iam: SimIamInterServiceAuthZ;
+
+  constructor(properties: SimRoute53DnssecAuthorizerProperties) {
+    this.iam = properties.iam;
+  }
+
+  /**
+   * Ensure the caller may perform a DNSSEC action on a hosted zone.
+   */
+  authorize(
+    action: string,
+    hostedZoneId: SimRoute53HostedZoneId,
+    caller?: SimAwsCaller,
+  ): void {
+    const resource = simRoute53HostedZoneArn(hostedZoneId);
+    const decision = this.iam.authorize({ action, resource, caller });
+
+    if (decision.isDenied) {
+      throw new SimIamAccessDenied({
+        principal: decision.caller.principal,
+        action,
+        resource,
+      });
+    }
+  }
+}

--- a/src/service/route53/command/dnssec/sim-route53-dnssec-commands.ts
+++ b/src/service/route53/command/dnssec/sim-route53-dnssec-commands.ts
@@ -1,0 +1,44 @@
+import type { BackgroundScheduler } from "../../../../util/background/background.js";
+import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import type { SimKmsKeyResolver } from "../../../kms/registry/sim-kms-registry.js";
+import type { SimRoute53HostedZone } from "../../hosted-zone/sim-route53-hosted-zone.js";
+import type { SimRoute53HostedZoneId } from "../create-hosted-zone/sim-route53-zone-id.js";
+import { SimRoute53DnssecScope } from "./sim-route53-dnssec-scope.js";
+import { SimRoute53KskCommands } from "./sim-route53-ksk-commands.js";
+import { SimRoute53KskKmsKey } from "./sim-route53-ksk-kms-key.js";
+import { SimRoute53ZoneSigningCommands } from "./sim-route53-zone-signing-commands.js";
+
+interface SimRoute53DnssecCommandsProperties {
+  readonly hostedZones: Map<SimRoute53HostedZoneId, SimRoute53HostedZone>;
+  readonly iam: SimIamInterServiceAuthZ;
+  readonly background: BackgroundScheduler;
+  readonly kmsKeys?: SimKmsKeyResolver | undefined;
+}
+
+/**
+ * The DNSSEC commands of one simulated Route53 scope, and the state they
+ * share.
+ *
+ * Grouped rather than wired one at a time on the service facade, because all
+ * seven start from the same hosted zone lookup and authorization, and four of
+ * them work on the same key-signing key list.
+ */
+export class SimRoute53DnssecCommands {
+  public readonly keySigningKeys: SimRoute53KskCommands;
+  public readonly zoneSigning: SimRoute53ZoneSigningCommands;
+
+  constructor(properties: SimRoute53DnssecCommandsProperties) {
+    const scope = new SimRoute53DnssecScope({
+      hostedZones: properties.hostedZones,
+      iam: properties.iam,
+      background: properties.background,
+    });
+
+    this.keySigningKeys = new SimRoute53KskCommands({
+      scope,
+      kmsKey: new SimRoute53KskKmsKey({ kmsKeys: properties.kmsKeys }),
+      clock: properties.background,
+    });
+    this.zoneSigning = new SimRoute53ZoneSigningCommands({ scope });
+  }
+}

--- a/src/service/route53/command/dnssec/sim-route53-dnssec-iam.iso.test.ts
+++ b/src/service/route53/command/dnssec/sim-route53-dnssec-iam.iso.test.ts
@@ -1,0 +1,48 @@
+import { GetDNSSECCommand } from "@aws-sdk/client-route-53";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+import { simRoute53DnssecFixture } from "../../../../../test/route53/dnssec-fixture.js";
+
+describe("Route53 DNSSEC IAM authorization", () => {
+  it("denies an anonymous caller", async () => {
+    // Given a hosted zone in a simulated Account.
+    const fixture = await simRoute53DnssecFixture();
+
+    // When an explicitly anonymous caller reads its DNSSEC.
+    const error = await assertThrowsErrorAsync(async () =>
+      fixture.simAws
+        .route53()
+        .getDnssec(
+          new GetDNSSECCommand({ HostedZoneId: fixture.hostedZoneId }),
+          { caller: { kind: "anonymous" } },
+        ),
+    );
+
+    // Then it is denied, against the hosted zone's own ARN rather than a
+    // wildcard, so a policy can grant DNSSEC on one zone alone.
+    assertInstanceOf(error, SimIamAccessDenied);
+    assertIdentical(error.action, "route53:GetDNSSEC");
+    assertIdentical(
+      error.resource,
+      `arn:aws:route53:::hostedzone/${fixture.hostedZoneId}`,
+    );
+  });
+
+  it("allows the default Account root caller", async () => {
+    // Given the same hosted zone.
+    const fixture = await simRoute53DnssecFixture();
+
+    // When DNSSEC is read with no caller named, then IAM defaults to Account
+    // root and the read is allowed.
+    const dnssec = await fixture.simAws
+      .route53()
+      .getDnssec(new GetDNSSECCommand({ HostedZoneId: fixture.hostedZoneId }));
+
+    assertIdentical(dnssec.Status?.ServeSignature, "NOT_SIGNING");
+  });
+});

--- a/src/service/route53/command/dnssec/sim-route53-dnssec-scope.ts
+++ b/src/service/route53/command/dnssec/sim-route53-dnssec-scope.ts
@@ -1,0 +1,80 @@
+import type { BackgroundScheduler } from "../../../../util/background/background.js";
+import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { SimRoute53NoSuchHostedZone } from "../../error/sim-route53.error.js";
+import type { SimRoute53HostedZone } from "../../hosted-zone/sim-route53-hosted-zone.js";
+import type { SimRoute53RequestOptions } from "../../sim-route53-request-options.js";
+import {
+  normalizeSimRoute53HostedZoneId,
+  type SimRoute53HostedZoneId,
+} from "../create-hosted-zone/sim-route53-zone-id.js";
+import type { SimRoute53ChangeInfo } from "../create-hosted-zone/create-hosted-zone.command.js";
+import { SimRoute53DnssecAuthorizer } from "./sim-route53-dnssec-authorizer.js";
+
+interface SimRoute53DnssecScopeProperties {
+  readonly hostedZones: Map<SimRoute53HostedZoneId, SimRoute53HostedZone>;
+  readonly iam: SimIamInterServiceAuthZ;
+  readonly background: BackgroundScheduler;
+}
+
+/**
+ * What every DNSSEC command does before and after its own work.
+ *
+ * All seven start the same way: normalise the hosted zone ID, sequence through
+ * the background scheduler, authorize against the zone ARN, then find the
+ * zone. Doing that once here keeps each command to the part that differs.
+ */
+export class SimRoute53DnssecScope {
+  private readonly hostedZones: Map<
+    SimRoute53HostedZoneId,
+    SimRoute53HostedZone
+  >;
+  private readonly authorizer: SimRoute53DnssecAuthorizer;
+  private readonly background: BackgroundScheduler;
+
+  constructor(properties: SimRoute53DnssecScopeProperties) {
+    this.hostedZones = properties.hostedZones;
+    this.authorizer = new SimRoute53DnssecAuthorizer({ iam: properties.iam });
+    this.background = properties.background;
+  }
+
+  /**
+   * The hosted zone a DNSSEC request names, once the caller may reach it.
+   */
+  async zoneFor(
+    action: string,
+    hostedZoneId: string | undefined,
+    options?: SimRoute53RequestOptions,
+  ): Promise<SimRoute53HostedZone> {
+    const zoneId = normalizeSimRoute53HostedZoneId(hostedZoneId);
+
+    // Allow for potential non-deterministic sequencing of async events.
+    await this.background.sequence();
+
+    this.authorizer.authorize(action, zoneId, options?.caller);
+
+    const hostedZone = this.hostedZones.get(zoneId);
+
+    if (hostedZone === undefined) {
+      throw new SimRoute53NoSuchHostedZone(
+        `No sim Route53 Hosted Zone with ID ${zoneId}`,
+      );
+    }
+
+    return hostedZone;
+  }
+
+  /**
+   * The change info a DNSSEC change answers with.
+   *
+   * Route53 applies a DNSSEC change to the zone rather than to a record set,
+   * and nothing here defers the work, so the change is reported against the
+   * zone's own synchronization status.
+   */
+  changeInfo(hostedZone: SimRoute53HostedZone): SimRoute53ChangeInfo {
+    return {
+      Id: `/change/${hostedZone.id}`,
+      Status: hostedZone.status,
+      SubmittedAt: this.background.now(),
+    };
+  }
+}

--- a/src/service/route53/command/dnssec/sim-route53-dnssec-validation.iso.test.ts
+++ b/src/service/route53/command/dnssec/sim-route53-dnssec-validation.iso.test.ts
@@ -1,0 +1,380 @@
+import { CreateKeyCommand, DisableKeyCommand } from "@aws-sdk/client-kms";
+import {
+  CreateKeySigningKeyCommand,
+  DeleteHostedZoneCommand,
+  DeleteKeySigningKeyCommand,
+  DisableHostedZoneDNSSECCommand,
+  EnableHostedZoneDNSSECCommand,
+  GetDNSSECCommand,
+} from "@aws-sdk/client-route-53";
+import {
+  assertInstanceOf,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimRoute53 } from "../../sim-route53.js";
+import {
+  SimRoute53DnssecNotFound,
+  SimRoute53InvalidKeySigningKeyStatus,
+  SimRoute53InvalidKmsArn,
+  SimRoute53KeySigningKeyAlreadyExists,
+  SimRoute53NoActiveKeySigningKey,
+  SimRoute53NoSuchHostedZone,
+  SimRoute53NoSuchKeySigningKey,
+} from "../../error/sim-route53.error.js";
+import {
+  simKmsSigningKeyArn,
+  simRoute53DnssecFixture,
+  type SimRoute53DnssecFixture,
+} from "../../../../../test/route53/dnssec-fixture.js";
+
+async function withKeySigningKey(
+  fixture: SimRoute53DnssecFixture,
+  Status = "ACTIVE",
+): Promise<void> {
+  await fixture.simAws.route53().createKeySigningKey(
+    new CreateKeySigningKeyCommand({
+      CallerReference: "ksk",
+      HostedZoneId: fixture.hostedZoneId,
+      KeyManagementServiceArn: fixture.kmsKeyArn,
+      Name: "zone_signing_key",
+      Status,
+    }),
+  );
+}
+
+describe("Route53 DNSSEC validation", () => {
+  it("refuses a KMS key that is not a signing key", async () => {
+    // Given a hosted zone and a symmetric KMS key.
+    const fixture = await simRoute53DnssecFixture();
+    const symmetric = await fixture.simAws
+      .kms()
+      .createKey(new CreateKeyCommand({}));
+    assertNonNullable(symmetric.KeyMetadata);
+
+    // When a key signing key is built on it.
+    const error = await assertThrowsErrorAsync(async () =>
+      fixture.simAws.route53().createKeySigningKey(
+        new CreateKeySigningKeyCommand({
+          CallerReference: "ksk",
+          HostedZoneId: fixture.hostedZoneId,
+          KeyManagementServiceArn: symmetric.KeyMetadata?.Arn,
+          Name: "zone_signing_key",
+          Status: "ACTIVE",
+        }),
+      ),
+    );
+
+    // Then it is refused here, rather than on the deployment.
+    assertInstanceOf(error, SimRoute53InvalidKmsArn);
+    assertStringIncludes(
+      error.message,
+      "needs a ECC_NIST_P256 SIGN_VERIFY key",
+    );
+  });
+
+  it("refuses a KMS key that is disabled", async () => {
+    // Given a hosted zone whose signing key has been disabled.
+    const fixture = await simRoute53DnssecFixture();
+    await fixture.simAws
+      .kms()
+      .disableKey(new DisableKeyCommand({ KeyId: fixture.kmsKeyArn }));
+
+    // When a key signing key is built on it.
+    const error = await assertThrowsErrorAsync(async () =>
+      withKeySigningKey(fixture),
+    );
+
+    // Then it is refused, as real Route53 refuses it.
+    assertInstanceOf(error, SimRoute53InvalidKmsArn);
+    assertStringIncludes(error.message, "is not enabled");
+  });
+
+  it("refuses a KMS key no simulated KMS holds", async () => {
+    // Given a hosted zone.
+    const fixture = await simRoute53DnssecFixture();
+
+    // When a key signing key names a key that does not exist.
+    const error = await assertThrowsErrorAsync(async () =>
+      fixture.simAws.route53().createKeySigningKey(
+        new CreateKeySigningKeyCommand({
+          CallerReference: "ksk",
+          HostedZoneId: fixture.hostedZoneId,
+          KeyManagementServiceArn:
+            "arn:aws:kms:us-east-1:123456789012:key/00000000-0000-4000-8000-000000000000",
+          Name: "zone_signing_key",
+          Status: "ACTIVE",
+        }),
+      ),
+    );
+
+    // Then it is refused.
+    assertInstanceOf(error, SimRoute53InvalidKmsArn);
+  });
+
+  it("refuses an ARN that does not name a KMS key", async () => {
+    // Given a hosted zone.
+    const fixture = await simRoute53DnssecFixture();
+
+    // When a key signing key names something that is not a KMS ARN.
+    const error = await assertThrowsErrorAsync(async () =>
+      fixture.simAws.route53().createKeySigningKey(
+        new CreateKeySigningKeyCommand({
+          CallerReference: "ksk",
+          HostedZoneId: fixture.hostedZoneId,
+          KeyManagementServiceArn: "arn:aws:s3:::a-bucket",
+          Name: "zone_signing_key",
+          Status: "ACTIVE",
+        }),
+      ),
+    );
+
+    // Then it is refused, rather than the lookup being tried anyway.
+    assertInstanceOf(error, SimRoute53InvalidKmsArn);
+  });
+
+  it("refuses a key signing key with no simulated KMS to check", async () => {
+    // Given a standalone simulated Route53, with no KMS wired to it.
+    const route53 = new SimRoute53();
+    const zone = route53.registerHostedZone({
+      id: "Z00000000000000000000A",
+      name: "example.test",
+    });
+
+    // When a key signing key is created on it.
+    const error = await assertThrowsErrorAsync(async () =>
+      route53.createKeySigningKey({
+        input: {
+          HostedZoneId: zone.id,
+          KeyManagementServiceArn:
+            "arn:aws:kms:us-east-1:123456789012:key/00000000-0000-4000-8000-000000000000",
+          Name: "zone_signing_key",
+          Status: "ACTIVE",
+        },
+      }),
+    );
+
+    // Then it says so, rather than reporting the key as missing.
+    assertInstanceOf(error, SimRoute53InvalidKmsArn);
+    assertStringIncludes(error.message, "reach Route53 through SimAws");
+  });
+
+  it("refuses a second key signing key of the same name", async () => {
+    // Given a zone that already has a key signing key.
+    const fixture = await simRoute53DnssecFixture();
+    await withKeySigningKey(fixture);
+
+    // When another is created with the same name on a different KMS key.
+    const error = await assertThrowsErrorAsync(async () =>
+      fixture.simAws.route53().createKeySigningKey(
+        new CreateKeySigningKeyCommand({
+          CallerReference: "ksk",
+          HostedZoneId: fixture.hostedZoneId,
+          KeyManagementServiceArn: await simKmsSigningKeyArn(fixture.simAws),
+          Name: "zone_signing_key",
+          Status: "ACTIVE",
+        }),
+      ),
+    );
+
+    // Then it is refused: a name identifies a key within its zone.
+    assertInstanceOf(error, SimRoute53KeySigningKeyAlreadyExists);
+  });
+
+  it("refuses a second key signing key on the same KMS key", async () => {
+    // Given a zone that already has a key signing key.
+    const fixture = await simRoute53DnssecFixture();
+    await withKeySigningKey(fixture);
+
+    // When another is created on the same KMS key.
+    const error = await assertThrowsErrorAsync(async () =>
+      fixture.simAws.route53().createKeySigningKey(
+        new CreateKeySigningKeyCommand({
+          CallerReference: "ksk",
+          HostedZoneId: fixture.hostedZoneId,
+          KeyManagementServiceArn: fixture.kmsKeyArn,
+          Name: "another_key",
+          Status: "ACTIVE",
+        }),
+      ),
+    );
+
+    // Then it is refused, because the two would be indistinguishable in the
+    // zone's DNSKEY set.
+    assertInstanceOf(error, SimRoute53KeySigningKeyAlreadyExists);
+  });
+
+  it("refuses a key signing key status that is not a status", async () => {
+    // Given a hosted zone.
+    const fixture = await simRoute53DnssecFixture();
+
+    // When a key signing key is created with no status, which Route53
+    // requires rather than defaulting.
+    const error = await assertThrowsErrorAsync(async () =>
+      fixture.simAws.route53().createKeySigningKey({
+        input: {
+          HostedZoneId: fixture.hostedZoneId,
+          KeyManagementServiceArn: fixture.kmsKeyArn,
+          Name: "zone_signing_key",
+        },
+      }),
+    );
+
+    // Then it is refused.
+    assertStringIncludes(error.message, "Status");
+  });
+
+  it("refuses signing a zone with no active key signing key", async () => {
+    // Given a zone whose only key signing key is inactive.
+    const fixture = await simRoute53DnssecFixture();
+    await withKeySigningKey(fixture, "INACTIVE");
+
+    // When signing is turned on.
+    const error = await assertThrowsErrorAsync(async () =>
+      fixture.simAws.route53().enableHostedZoneDnssec(
+        new EnableHostedZoneDNSSECCommand({
+          HostedZoneId: fixture.hostedZoneId,
+        }),
+      ),
+    );
+
+    // Then it is refused rather than reporting a zone no resolver could
+    // validate.
+    assertInstanceOf(error, SimRoute53NoActiveKeySigningKey);
+  });
+
+  it("refuses deleting a key signing key that is still signing", async () => {
+    // Given a zone with an active key signing key.
+    const fixture = await simRoute53DnssecFixture();
+    await withKeySigningKey(fixture);
+
+    // When the key is deleted without being deactivated first.
+    const error = await assertThrowsErrorAsync(async () =>
+      fixture.simAws.route53().deleteKeySigningKey(
+        new DeleteKeySigningKeyCommand({
+          HostedZoneId: fixture.hostedZoneId,
+          Name: "zone_signing_key",
+        }),
+      ),
+    );
+
+    // Then it is refused, as real Route53 refuses it.
+    assertInstanceOf(error, SimRoute53InvalidKeySigningKeyStatus);
+  });
+
+  it("refuses a key signing key the zone does not have", async () => {
+    // Given a zone with no key signing keys.
+    const fixture = await simRoute53DnssecFixture();
+
+    // When one is deleted by name.
+    const error = await assertThrowsErrorAsync(async () =>
+      fixture.simAws.route53().deleteKeySigningKey(
+        new DeleteKeySigningKeyCommand({
+          HostedZoneId: fixture.hostedZoneId,
+          Name: "zone_signing_key",
+        }),
+      ),
+    );
+
+    // Then it is refused.
+    assertInstanceOf(error, SimRoute53NoSuchKeySigningKey);
+  });
+
+  it("refuses disabling DNSSEC on an unsigned zone", async () => {
+    // Given a zone that is not signed.
+    const fixture = await simRoute53DnssecFixture();
+
+    // When signing is turned off.
+    const error = await assertThrowsErrorAsync(async () =>
+      fixture.simAws.route53().disableHostedZoneDnssec(
+        new DisableHostedZoneDNSSECCommand({
+          HostedZoneId: fixture.hostedZoneId,
+        }),
+      ),
+    );
+
+    // Then it is refused rather than quietly doing nothing.
+    assertInstanceOf(error, SimRoute53DnssecNotFound);
+  });
+
+  it("refuses deleting a signed hosted zone", async () => {
+    // Given a zone that is being signed.
+    const fixture = await simRoute53DnssecFixture();
+    await withKeySigningKey(fixture);
+    await fixture.simAws.route53().enableHostedZoneDnssec(
+      new EnableHostedZoneDNSSECCommand({
+        HostedZoneId: fixture.hostedZoneId,
+      }),
+    );
+
+    // When the zone is deleted.
+    const error = await assertThrowsErrorAsync(async () =>
+      fixture.simAws
+        .route53()
+        .deleteHostedZone(
+          new DeleteHostedZoneCommand({ Id: fixture.hostedZoneId }),
+        ),
+    );
+
+    // Then it is refused, as real Route53 refuses it: the DS record at the
+    // parent would be left pointing at a zone that had gone.
+    assertInstanceOf(error, SimRoute53DnssecNotFound);
+  });
+
+  it("refuses DNSSEC on a hosted zone that does not exist", async () => {
+    // Given a simulation with a hosted zone.
+    const fixture = await simRoute53DnssecFixture();
+
+    // When DNSSEC is read for another zone ID.
+    const error = await assertThrowsErrorAsync(async () =>
+      fixture.simAws
+        .route53()
+        .getDnssec(
+          new GetDNSSECCommand({ HostedZoneId: "Z00000000000000000000A" }),
+        ),
+    );
+
+    // Then it is refused.
+    assertInstanceOf(error, SimRoute53NoSuchHostedZone);
+  });
+
+  it("refuses a key signing key with no name", async () => {
+    // Given a hosted zone.
+    const fixture = await simRoute53DnssecFixture();
+
+    // When a key signing key is created with no name.
+    const error = await assertThrowsErrorAsync(async () =>
+      fixture.simAws.route53().createKeySigningKey({
+        input: {
+          HostedZoneId: fixture.hostedZoneId,
+          KeyManagementServiceArn: fixture.kmsKeyArn,
+          Status: "ACTIVE",
+        },
+      }),
+    );
+
+    // Then it is refused, since the name is what identifies it in the zone.
+    assertStringIncludes(error.message, "Name is required");
+  });
+
+  it("refuses a key signing key with no KMS ARN", async () => {
+    // Given a hosted zone.
+    const fixture = await simRoute53DnssecFixture();
+
+    // When a key signing key is created with no KMS key behind it.
+    const error = await assertThrowsErrorAsync(async () =>
+      fixture.simAws.route53().createKeySigningKey({
+        input: {
+          HostedZoneId: fixture.hostedZoneId,
+          Name: "zone_signing_key",
+          Status: "ACTIVE",
+        },
+      }),
+    );
+
+    // Then it is refused.
+    assertInstanceOf(error, SimRoute53InvalidKmsArn);
+  });
+});

--- a/src/service/route53/command/dnssec/sim-route53-dnssec-validation.iso.test.ts
+++ b/src/service/route53/command/dnssec/sim-route53-dnssec-validation.iso.test.ts
@@ -18,6 +18,7 @@ import { SimRoute53 } from "../../sim-route53.js";
 import {
   SimRoute53DnssecNotFound,
   SimRoute53InvalidKeySigningKeyStatus,
+  SimRoute53InvalidInput,
   SimRoute53InvalidKmsArn,
   SimRoute53KeySigningKeyAlreadyExists,
   SimRoute53NoActiveKeySigningKey,
@@ -320,7 +321,8 @@ describe("Route53 DNSSEC validation", () => {
 
     // Then it is refused, as real Route53 refuses it: the DS record at the
     // parent would be left pointing at a zone that had gone.
-    assertInstanceOf(error, SimRoute53DnssecNotFound);
+    assertInstanceOf(error, SimRoute53InvalidInput);
+    assertStringIncludes(error.message, "disable DNSSEC first");
   });
 
   it("refuses DNSSEC on a hosted zone that does not exist", async () => {

--- a/src/service/route53/command/dnssec/sim-route53-dnssec.iso.test.ts
+++ b/src/service/route53/command/dnssec/sim-route53-dnssec.iso.test.ts
@@ -1,0 +1,299 @@
+import { CreateKeyCommand } from "@aws-sdk/client-kms";
+import {
+  ActivateKeySigningKeyCommand,
+  CreateHostedZoneCommand,
+  CreateKeySigningKeyCommand,
+  DeactivateKeySigningKeyCommand,
+  DeleteKeySigningKeyCommand,
+  DisableHostedZoneDNSSECCommand,
+  EnableHostedZoneDNSSECCommand,
+  GetDNSSECCommand,
+} from "@aws-sdk/client-route-53";
+import {
+  assertArrayLength,
+  assertFalse,
+  assertIdentical,
+  assertNonNullable,
+  assertStringLength,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import {
+  simRoute53DnssecFixture,
+  type SimRoute53DnssecFixture,
+} from "../../../../../test/route53/dnssec-fixture.js";
+
+async function signedZone(): Promise<SimRoute53DnssecFixture> {
+  const fixture = await simRoute53DnssecFixture();
+
+  await fixture.simAws.route53().createKeySigningKey(
+    new CreateKeySigningKeyCommand({
+      CallerReference: "ksk",
+      HostedZoneId: fixture.hostedZoneId,
+      KeyManagementServiceArn: fixture.kmsKeyArn,
+      Name: "zone_signing_key",
+      Status: "ACTIVE",
+    }),
+  );
+  await fixture.simAws.route53().enableHostedZoneDnssec(
+    new EnableHostedZoneDNSSECCommand({
+      HostedZoneId: fixture.hostedZoneId,
+    }),
+  );
+
+  return fixture;
+}
+
+describe("Route53 DNSSEC", () => {
+  it("creates a key signing key from a KMS key", async () => {
+    // Given a hosted zone and an ECC_NIST_P256 signing key.
+    const fixture = await simRoute53DnssecFixture();
+
+    // When a key signing key is created on the zone.
+    const created = await fixture.simAws.route53().createKeySigningKey(
+      new CreateKeySigningKeyCommand({
+        CallerReference: "ksk",
+        HostedZoneId: fixture.hostedZoneId,
+        KeyManagementServiceArn: fixture.kmsKeyArn,
+        Name: "zone_signing_key",
+        Status: "ACTIVE",
+      }),
+    );
+    assertNonNullable(created.KeySigningKey);
+
+    // Then it carries the DNSSEC parameters a registrar needs, derived from
+    // the KMS key rather than invented.
+    assertIdentical(created.KeySigningKey.Name, "zone_signing_key");
+    assertIdentical(created.KeySigningKey.KmsArn, fixture.kmsKeyArn);
+    assertIdentical(created.KeySigningKey.Flag, 257);
+    assertIdentical(
+      created.KeySigningKey.SigningAlgorithmMnemonic,
+      "ECDSAP256SHA256",
+    );
+    assertIdentical(created.KeySigningKey.SigningAlgorithmType, 13);
+    assertIdentical(created.KeySigningKey.DigestAlgorithmMnemonic, "SHA-256");
+    assertIdentical(created.KeySigningKey.DigestAlgorithmType, 2);
+    assertIdentical(created.KeySigningKey.Status, "ACTIVE");
+  });
+
+  it("derives DS record fields that agree with the public key", async () => {
+    // Given a zone with a key signing key.
+    const fixture = await signedZone();
+
+    // When the zone's DNSSEC is read.
+    const dnssec = await fixture.simAws
+      .route53()
+      .getDnssec(new GetDNSSECCommand({ HostedZoneId: fixture.hostedZoneId }));
+    const keySigningKey = dnssec.KeySigningKeys?.[0];
+    assertNonNullable(keySigningKey);
+
+    // Then the DS and DNSKEY records are assembled from the same key tag,
+    // digest and public key the key reports on its own.
+    const digestValue = keySigningKey.DigestValue;
+    assertNonNullable(digestValue);
+
+    assertIdentical(
+      keySigningKey.DSRecord,
+      `${String(keySigningKey.KeyTag)} 13 2 ${digestValue}`,
+    );
+    assertIdentical(
+      keySigningKey.DNSKEYRecord,
+      `257 3 13 ${keySigningKey.PublicKey}`,
+    );
+
+    // And the digest is a SHA-256 one, in the uppercase hex a registrar takes.
+    assertStringLength(digestValue, 64);
+    assertIdentical(digestValue, digestValue.toUpperCase());
+  });
+
+  it("gives two zones different DS records for different keys", async () => {
+    // Given two zones, each with a key signing key on its own KMS key.
+    const first = await signedZone();
+    const second = await signedZone();
+
+    // When both zones' DNSSEC is read.
+    const firstDnssec = await first.simAws
+      .route53()
+      .getDnssec(new GetDNSSECCommand({ HostedZoneId: first.hostedZoneId }));
+    const secondDnssec = await second.simAws
+      .route53()
+      .getDnssec(new GetDNSSECCommand({ HostedZoneId: second.hostedZoneId }));
+
+    // Then the DS records differ, because the cryptography behind them is
+    // real rather than a fixed string.
+    assertFalse(
+      firstDnssec.KeySigningKeys?.[0]?.DSRecord ===
+        secondDnssec.KeySigningKeys?.[0]?.DSRecord,
+    );
+  });
+
+  it("reports a signed zone", async () => {
+    // Given a zone with signing enabled.
+    const fixture = await signedZone();
+
+    // When its DNSSEC is read.
+    const dnssec = await fixture.simAws
+      .route53()
+      .getDnssec(new GetDNSSECCommand({ HostedZoneId: fixture.hostedZoneId }));
+
+    // Then it is signing, with the one key signing key on it.
+    assertIdentical(dnssec.Status?.ServeSignature, "SIGNING");
+    assertArrayLength(dnssec.KeySigningKeys ?? [], 1);
+  });
+
+  it("reports an unsigned zone", async () => {
+    // Given a zone with no DNSSEC at all.
+    const fixture = await simRoute53DnssecFixture();
+
+    // When its DNSSEC is read.
+    const dnssec = await fixture.simAws
+      .route53()
+      .getDnssec(new GetDNSSECCommand({ HostedZoneId: fixture.hostedZoneId }));
+
+    // Then it says so rather than failing.
+    assertIdentical(dnssec.Status?.ServeSignature, "NOT_SIGNING");
+    assertArrayLength(dnssec.KeySigningKeys ?? [], 0);
+  });
+
+  it("stops signing when DNSSEC is disabled", async () => {
+    // Given a signed zone.
+    const fixture = await signedZone();
+
+    // When signing is turned off.
+    await fixture.simAws.route53().disableHostedZoneDnssec(
+      new DisableHostedZoneDNSSECCommand({
+        HostedZoneId: fixture.hostedZoneId,
+      }),
+    );
+
+    // Then the zone is no longer signing, and keeps its key signing key.
+    const dnssec = await fixture.simAws
+      .route53()
+      .getDnssec(new GetDNSSECCommand({ HostedZoneId: fixture.hostedZoneId }));
+
+    assertIdentical(dnssec.Status?.ServeSignature, "NOT_SIGNING");
+    assertArrayLength(dnssec.KeySigningKeys ?? [], 1);
+  });
+
+  it("deactivates and deletes a key signing key", async () => {
+    // Given a zone with an active key signing key.
+    const fixture = await signedZone();
+    const keySigningKey = {
+      HostedZoneId: fixture.hostedZoneId,
+      Name: "zone_signing_key",
+    };
+
+    // When the key is deactivated and then deleted.
+    await fixture.simAws
+      .route53()
+      .deactivateKeySigningKey(
+        new DeactivateKeySigningKeyCommand(keySigningKey),
+      );
+    await fixture.simAws
+      .route53()
+      .deleteKeySigningKey(new DeleteKeySigningKeyCommand(keySigningKey));
+
+    // Then the zone has none left.
+    const dnssec = await fixture.simAws
+      .route53()
+      .getDnssec(new GetDNSSECCommand({ HostedZoneId: fixture.hostedZoneId }));
+
+    assertArrayLength(dnssec.KeySigningKeys ?? [], 0);
+  });
+
+  it("activates a key signing key created inactive", async () => {
+    // Given a zone with an inactive key signing key.
+    const fixture = await simRoute53DnssecFixture();
+    await fixture.simAws.route53().createKeySigningKey(
+      new CreateKeySigningKeyCommand({
+        CallerReference: "ksk",
+        HostedZoneId: fixture.hostedZoneId,
+        KeyManagementServiceArn: fixture.kmsKeyArn,
+        Name: "zone_signing_key",
+        Status: "INACTIVE",
+      }),
+    );
+
+    // When the key is activated.
+    await fixture.simAws.route53().activateKeySigningKey(
+      new ActivateKeySigningKeyCommand({
+        HostedZoneId: fixture.hostedZoneId,
+        Name: "zone_signing_key",
+      }),
+    );
+
+    // Then it reports as active, and the zone can be signed with it.
+    await fixture.simAws.route53().enableHostedZoneDnssec(
+      new EnableHostedZoneDNSSECCommand({
+        HostedZoneId: fixture.hostedZoneId,
+      }),
+    );
+    const dnssec = await fixture.simAws
+      .route53()
+      .getDnssec(new GetDNSSECCommand({ HostedZoneId: fixture.hostedZoneId }));
+
+    assertIdentical(dnssec.KeySigningKeys?.[0]?.Status, "ACTIVE");
+    assertIdentical(dnssec.Status?.ServeSignature, "SIGNING");
+  });
+
+  it("keeps DNSSEC state apart between hosted zones", async () => {
+    // Given a simulation with a signed zone.
+    const fixture = await signedZone();
+    const simAws = fixture.simAws;
+
+    // When a second zone is created in the same account.
+    const other = await simAws.route53().createHostedZone(
+      new CreateHostedZoneCommand({
+        Name: "other.example.test",
+        CallerReference: "other",
+      }),
+    );
+    assertNonNullable(other.HostedZone?.Id);
+
+    // Then the second zone is unsigned, since signing belongs to a zone rather
+    // than to the account.
+    const dnssec = await simAws
+      .route53()
+      .getDnssec(new GetDNSSECCommand({ HostedZoneId: other.HostedZone.Id }));
+
+    assertIdentical(dnssec.Status?.ServeSignature, "NOT_SIGNING");
+  });
+
+  it("resolves a KMS key from another region", async () => {
+    // Given a hosted zone, and a signing key in a region of its own. Route53
+    // is account scoped and KMS is not, which is what the key ARN carries.
+    const simAws = new SimAws();
+    const created = await simAws.route53().createHostedZone(
+      new CreateHostedZoneCommand({
+        Name: "example.test",
+        CallerReference: "zone",
+      }),
+    );
+    assertNonNullable(created.HostedZone?.Id);
+
+    const key = await simAws
+      .region("us-east-1")
+      .kms()
+      .createKey(
+        new CreateKeyCommand({
+          KeySpec: "ECC_NIST_P256",
+          KeyUsage: "SIGN_VERIFY",
+        }),
+      );
+    assertNonNullable(key.KeyMetadata);
+
+    // When a key signing key is created on that key.
+    const keySigningKey = await simAws.route53().createKeySigningKey(
+      new CreateKeySigningKeyCommand({
+        CallerReference: "ksk",
+        HostedZoneId: created.HostedZone.Id,
+        KeyManagementServiceArn: key.KeyMetadata.Arn,
+        Name: "zone_signing_key",
+        Status: "ACTIVE",
+      }),
+    );
+
+    // Then the key is found, wherever in the simulation it lives.
+    assertIdentical(keySigningKey.KeySigningKey?.KmsArn, key.KeyMetadata.Arn);
+  });
+});

--- a/src/service/route53/command/dnssec/sim-route53-ksk-commands.ts
+++ b/src/service/route53/command/dnssec/sim-route53-ksk-commands.ts
@@ -1,0 +1,159 @@
+import type { SimClock } from "../../../../util/clock/sim-clock.js";
+import {
+  SimRoute53KeySigningKey,
+  SimRoute53KeySigningKeyStatus,
+} from "../../dnssec/sim-route53-key-signing-key.js";
+import type { SimRoute53DnssecScope } from "./sim-route53-dnssec-scope.js";
+import type { SimRoute53KskKmsKey } from "./sim-route53-ksk-kms-key.js";
+import { SimRoute53KskInput } from "./sim-route53-ksk-input.js";
+import type {
+  SimCreateKeySigningKeyCommand,
+  SimCreateKeySigningKeyCommandOutput,
+  SimKeySigningKeyCommand,
+  SimKeySigningKeyCommandOutput,
+} from "./dnssec.command.js";
+import type { SimRoute53RequestOptions } from "../../sim-route53-request-options.js";
+
+interface SimRoute53KskCommandsProperties {
+  readonly scope: SimRoute53DnssecScope;
+  readonly kmsKey: SimRoute53KskKmsKey;
+  readonly clock: SimClock;
+}
+
+/**
+ * The key-signing key commands of one simulated Route53 scope.
+ *
+ * The four operate on the same key-signing key list on the same hosted zone,
+ * so they are grouped rather than wired separately on the service facade.
+ */
+export class SimRoute53KskCommands {
+  private readonly scope: SimRoute53DnssecScope;
+  private readonly kmsKey: SimRoute53KskKmsKey;
+  private readonly clock: SimClock;
+  private readonly input = new SimRoute53KskInput();
+
+  constructor(properties: SimRoute53KskCommandsProperties) {
+    this.scope = properties.scope;
+    this.kmsKey = properties.kmsKey;
+    this.clock = properties.clock;
+  }
+
+  /**
+   * Create a key-signing key for a hosted zone.
+   *
+   * The DNSSEC parameters are derived here, from the KMS key's real public
+   * key, so a test reading the DS record gets the one that key would produce.
+   */
+  async create(
+    command: SimCreateKeySigningKeyCommand,
+    options?: SimRoute53RequestOptions,
+  ): Promise<SimCreateKeySigningKeyCommandOutput> {
+    const zone = await this.scope.zoneFor(
+      "route53:CreateKeySigningKey",
+      command.input.HostedZoneId,
+      options,
+    );
+    const name = this.input.requireName(command.input.Name);
+    const key = this.kmsKey.require(command.input.KeyManagementServiceArn);
+
+    const keySigningKey = new SimRoute53KeySigningKey({
+      name,
+      kmsArn: key.arn,
+      hostedZoneId: zone.id,
+      zoneName: zone.name,
+      publicKeyDer: key.publicKeyDer(),
+      status: this.input.requireStatus(command.input.Status),
+      createdDate: this.clock.now(),
+    });
+
+    zone.dnssec.add(keySigningKey);
+
+    return {
+      $metadata: {},
+      ChangeInfo: this.scope.changeInfo(zone),
+      KeySigningKey: keySigningKey.describe(),
+      Location: `/2013-04-01/keysigningkey/${zone.id}/${name}`,
+    };
+  }
+
+  /**
+   * Start signing with a key-signing key.
+   */
+  async activate(
+    command: SimKeySigningKeyCommand,
+    options?: SimRoute53RequestOptions,
+  ): Promise<SimKeySigningKeyCommandOutput> {
+    return await this.changeStatus(
+      "route53:ActivateKeySigningKey",
+      command,
+      options,
+      SimRoute53KeySigningKeyStatus.Active,
+    );
+  }
+
+  /**
+   * Stop signing with a key-signing key.
+   */
+  async deactivate(
+    command: SimKeySigningKeyCommand,
+    options?: SimRoute53RequestOptions,
+  ): Promise<SimKeySigningKeyCommandOutput> {
+    return await this.changeStatus(
+      "route53:DeactivateKeySigningKey",
+      command,
+      options,
+      SimRoute53KeySigningKeyStatus.Inactive,
+    );
+  }
+
+  /**
+   * Remove a key-signing key from a hosted zone.
+   */
+  async delete(
+    command: SimKeySigningKeyCommand,
+    options?: SimRoute53RequestOptions,
+  ): Promise<SimKeySigningKeyCommandOutput> {
+    const zone = await this.scope.zoneFor(
+      "route53:DeleteKeySigningKey",
+      command.input.HostedZoneId,
+      options,
+    );
+
+    zone.dnssec.remove(this.input.requireName(command.input.Name));
+
+    return { $metadata: {}, ChangeInfo: this.scope.changeInfo(zone) };
+  }
+
+  private async changeStatus(
+    action: string,
+    command: SimKeySigningKeyCommand,
+    options: SimRoute53RequestOptions | undefined,
+    status: SimRoute53KeySigningKeyStatus,
+  ): Promise<SimKeySigningKeyCommandOutput> {
+    const zone = await this.scope.zoneFor(
+      action,
+      command.input.HostedZoneId,
+      options,
+    );
+    const keySigningKey = zone.dnssec.require(
+      this.input.requireName(command.input.Name),
+    );
+
+    this.applyStatus(keySigningKey, status);
+
+    return { $metadata: {}, ChangeInfo: this.scope.changeInfo(zone) };
+  }
+
+  private applyStatus(
+    keySigningKey: SimRoute53KeySigningKey,
+    status: SimRoute53KeySigningKeyStatus,
+  ): void {
+    if (status === SimRoute53KeySigningKeyStatus.Active) {
+      keySigningKey.activate(this.clock.now());
+
+      return;
+    }
+
+    keySigningKey.deactivate(this.clock.now());
+  }
+}

--- a/src/service/route53/command/dnssec/sim-route53-ksk-input.ts
+++ b/src/service/route53/command/dnssec/sim-route53-ksk-input.ts
@@ -1,0 +1,42 @@
+import { SimRoute53InvalidInput } from "../../error/sim-route53.error.js";
+import { SimRoute53KeySigningKeyStatus } from "../../dnssec/sim-route53-key-signing-key.js";
+
+/**
+ * The two fields a key-signing key request carries beyond its hosted zone.
+ *
+ * Route53 requires both rather than defaulting either: a name is what
+ * identifies the key within its zone, and a key created active starts being
+ * published straight away, so neither is a choice to make on the caller's
+ * behalf.
+ */
+export class SimRoute53KskInput {
+  /**
+   * The name identifying a key-signing key within its hosted zone.
+   */
+  requireName(name: string | undefined): string {
+    if (name === undefined || name.length === 0) {
+      throw new SimRoute53InvalidInput(
+        "A key signing key Name is required, and identifies the key within its hosted zone",
+      );
+    }
+
+    return name;
+  }
+
+  /**
+   * The status a new key-signing key starts in.
+   */
+  requireStatus(status: string | undefined): SimRoute53KeySigningKeyStatus {
+    if (status === SimRoute53KeySigningKeyStatus.Active) {
+      return SimRoute53KeySigningKeyStatus.Active;
+    }
+
+    if (status === SimRoute53KeySigningKeyStatus.Inactive) {
+      return SimRoute53KeySigningKeyStatus.Inactive;
+    }
+
+    throw new SimRoute53InvalidInput(
+      `A key signing key Status of '${String(status)}' is not valid: use ${SimRoute53KeySigningKeyStatus.Active} or ${SimRoute53KeySigningKeyStatus.Inactive}`,
+    );
+  }
+}

--- a/src/service/route53/command/dnssec/sim-route53-ksk-kms-key.ts
+++ b/src/service/route53/command/dnssec/sim-route53-ksk-kms-key.ts
@@ -1,0 +1,86 @@
+import type { SimKmsKey } from "../../../kms/key/sim-kms-key.js";
+import type { SimKmsKeyResolver } from "../../../kms/registry/sim-kms-registry.js";
+import { SimKmsKeyUsage } from "../../../kms/key/spec/sim-kms-key-spec.js";
+import { SimRoute53InvalidKmsArn } from "../../error/sim-route53.error.js";
+
+/**
+ * The one key spec Route53 will build a key-signing key on.
+ */
+const requiredKeySpec = "ECC_NIST_P256";
+
+interface SimRoute53KskKmsKeyProperties {
+  readonly kmsKeys?: SimKmsKeyResolver | undefined;
+}
+
+/**
+ * Finds and checks the customer managed key behind a key-signing key.
+ *
+ * Real Route53 is specific about this key: it has to be an enabled
+ * ECC_NIST_P256 key whose usage is sign and verify. Checking it here is what
+ * makes a stack that names the wrong key fail in this simulation rather than
+ * on the deployment, which is the whole point of deploying it here first.
+ */
+export class SimRoute53KskKmsKey {
+  private readonly kmsKeys: SimKmsKeyResolver | undefined;
+
+  constructor(properties: SimRoute53KskKmsKeyProperties) {
+    this.kmsKeys = properties.kmsKeys;
+  }
+
+  /**
+   * Resolve the KMS key an ARN names, or refuse it.
+   */
+  require(keyManagementServiceArn: string | undefined): SimKmsKey {
+    if (
+      keyManagementServiceArn === undefined ||
+      keyManagementServiceArn.length === 0
+    ) {
+      throw new SimRoute53InvalidKmsArn(
+        "KeyManagementServiceArn is required to create a key signing key",
+      );
+    }
+
+    const key = this.resolve(keyManagementServiceArn);
+
+    if (key === undefined) {
+      throw new SimRoute53InvalidKmsArn(
+        `No simulated KMS key at ${keyManagementServiceArn}: a key signing key needs a customer managed key that exists`,
+      );
+    }
+
+    this.requireUsable(key);
+
+    return key;
+  }
+
+  private resolve(keyManagementServiceArn: string): SimKmsKey | undefined {
+    if (this.kmsKeys === undefined) {
+      throw new SimRoute53InvalidKmsArn(
+        "This simulated Route53 has no simulated KMS to resolve a key signing key's KMS ARN against: reach Route53 through SimAws so the two are wired together",
+      );
+    }
+
+    return this.kmsKeys.key(keyManagementServiceArn);
+  }
+
+  /**
+   * Check the key is one Route53 would build a key-signing key on.
+   *
+   * Real Route53 checks the key usage as well as the spec. Here the spec
+   * decides the usage, so an ECC_NIST_P256 key is a SIGN_VERIFY key and there
+   * is nothing left for a separate usage check to catch.
+   */
+  private requireUsable(key: SimKmsKey): void {
+    if (key.keySpec.name !== requiredKeySpec) {
+      throw new SimRoute53InvalidKmsArn(
+        `KMS key ${key.arn} is ${key.keySpec.name}: a key signing key needs a ${requiredKeySpec} ${SimKmsKeyUsage.SignVerify} key`,
+      );
+    }
+
+    if (!key.isEnabled) {
+      throw new SimRoute53InvalidKmsArn(
+        `KMS key ${key.arn} is not enabled: a key signing key needs an enabled key`,
+      );
+    }
+  }
+}

--- a/src/service/route53/command/dnssec/sim-route53-zone-signing-commands.ts
+++ b/src/service/route53/command/dnssec/sim-route53-zone-signing-commands.ts
@@ -1,0 +1,82 @@
+import type { SimRoute53RequestOptions } from "../../sim-route53-request-options.js";
+import type { SimRoute53DnssecScope } from "./sim-route53-dnssec-scope.js";
+import type {
+  SimGetDnssecCommand,
+  SimGetDnssecCommandOutput,
+  SimHostedZoneDnssecCommand,
+  SimHostedZoneDnssecCommandOutput,
+} from "./dnssec.command.js";
+
+interface SimRoute53ZoneSigningCommandsProperties {
+  readonly scope: SimRoute53DnssecScope;
+}
+
+/**
+ * The zone signing commands of one simulated Route53 scope.
+ *
+ * Turning signing on and off, and reporting where a zone stands, all read the
+ * same DNSSEC state on the hosted zone.
+ */
+export class SimRoute53ZoneSigningCommands {
+  private readonly scope: SimRoute53DnssecScope;
+
+  constructor(properties: SimRoute53ZoneSigningCommandsProperties) {
+    this.scope = properties.scope;
+  }
+
+  /**
+   * Start signing a hosted zone.
+   */
+  async enable(
+    command: SimHostedZoneDnssecCommand,
+    options?: SimRoute53RequestOptions,
+  ): Promise<SimHostedZoneDnssecCommandOutput> {
+    const zone = await this.scope.zoneFor(
+      "route53:EnableHostedZoneDNSSEC",
+      command.input.HostedZoneId,
+      options,
+    );
+
+    zone.dnssec.enableSigning();
+
+    return { $metadata: {}, ChangeInfo: this.scope.changeInfo(zone) };
+  }
+
+  /**
+   * Stop signing a hosted zone, leaving its key-signing keys in place.
+   */
+  async disable(
+    command: SimHostedZoneDnssecCommand,
+    options?: SimRoute53RequestOptions,
+  ): Promise<SimHostedZoneDnssecCommandOutput> {
+    const zone = await this.scope.zoneFor(
+      "route53:DisableHostedZoneDNSSEC",
+      command.input.HostedZoneId,
+      options,
+    );
+
+    zone.dnssec.disableSigning();
+
+    return { $metadata: {}, ChangeInfo: this.scope.changeInfo(zone) };
+  }
+
+  /**
+   * Report a hosted zone's signing status and its key-signing keys.
+   */
+  async get(
+    command: SimGetDnssecCommand,
+    options?: SimRoute53RequestOptions,
+  ): Promise<SimGetDnssecCommandOutput> {
+    const zone = await this.scope.zoneFor(
+      "route53:GetDNSSEC",
+      command.input.HostedZoneId,
+      options,
+    );
+
+    return {
+      $metadata: {},
+      Status: { ServeSignature: zone.dnssec.serveSignature },
+      KeySigningKeys: zone.dnssec.keys().map((key) => key.describe()),
+    };
+  }
+}

--- a/src/service/route53/command/sim-route53-command.types.ts
+++ b/src/service/route53/command/sim-route53-command.types.ts
@@ -1,0 +1,46 @@
+/**
+ * The command types of every simulated Route53 operation, in one place.
+ *
+ * The SimRoute53 facade handles all of them, so gathering the types here keeps
+ * it a delegation rather than a page of imports.
+ */
+export type {
+  SimCreateHostedZoneCommand,
+  SimCreateHostedZoneCommandOutput,
+} from "./create-hosted-zone/create-hosted-zone.command.js";
+
+export type {
+  SimGetHostedZoneCommand,
+  SimGetHostedZoneCommandOutput,
+} from "./get-hosted-zone/get-hosted-zone.command.js";
+
+export type {
+  SimDeleteHostedZoneCommand,
+  SimDeleteHostedZoneCommandOutput,
+} from "./delete-hosted-zone/delete-hosted-zone.command.js";
+
+export type {
+  SimListHostedZonesByNameCommand,
+  SimListHostedZonesByNameCommandOutput,
+} from "./list-hosted-zones-by-name/list-hosted-zones-by-name.command.js";
+
+export type {
+  SimListResourceRecordSetsCommand,
+  SimListResourceRecordSetsCommandOutput,
+} from "./list-resource-record-sets/list-resource-record-sets.command.js";
+
+export type {
+  SimChangeResourceRecordSetsCommand,
+  SimChangeResourceRecordSetsCommandOutput,
+} from "./change-resource-record-sets/change-resource-record-sets.command.js";
+
+export type {
+  SimCreateKeySigningKeyCommand,
+  SimCreateKeySigningKeyCommandOutput,
+  SimGetDnssecCommand,
+  SimGetDnssecCommandOutput,
+  SimHostedZoneDnssecCommand,
+  SimHostedZoneDnssecCommandOutput,
+  SimKeySigningKeyCommand,
+  SimKeySigningKeyCommandOutput,
+} from "./dnssec/dnssec.command.js";

--- a/src/service/route53/dnssec/sim-route53-dnskey-rdata.ts
+++ b/src/service/route53/dnssec/sim-route53-dnskey-rdata.ts
@@ -1,0 +1,54 @@
+import { concatenateBytes } from "../dns/wire/dns-bytes.js";
+import { SimRoute53InvalidInput } from "../error/sim-route53.error.js";
+import {
+  simRoute53DnskeyProtocol,
+  simRoute53KskFlag,
+  simRoute53SigningAlgorithmType,
+} from "./sim-route53-dnssec-algorithm.js";
+
+/**
+ * An uncompressed elliptic curve point starts with this marker, and the 64
+ * bytes after it are the X and Y coordinates DNSSEC publishes.
+ */
+const uncompressedPointMarker = 0x04;
+const p256PointLength = 65;
+
+/**
+ * The raw X and Y coordinates inside a DER SubjectPublicKeyInfo.
+ *
+ * DNSSEC publishes the point on its own, with no ASN.1 around it and no
+ * uncompressed-point marker, so the tail of the DER encoding is what is
+ * wanted. The marker is checked rather than assumed, since a compressed point
+ * would silently produce the wrong key.
+ */
+export function simRoute53EcPoint(publicKeyDer: Uint8Array): Uint8Array {
+  const point = publicKeyDer.subarray(publicKeyDer.length - p256PointLength);
+
+  if (
+    point.length !== p256PointLength ||
+    point[0] !== uncompressedPointMarker
+  ) {
+    throw new SimRoute53InvalidInput(
+      "The key-signing key's public key is not an uncompressed P-256 point",
+    );
+  }
+
+  return point.subarray(1);
+}
+
+/**
+ * The DNSKEY RDATA: flags, protocol, algorithm, then the public key.
+ *
+ * This is the byte sequence both the key tag and the delegation signer digest
+ * are computed over, which is why it is built once and kept.
+ */
+export function simRoute53DnskeyRdata(point: Uint8Array): Uint8Array {
+  const header = Uint8Array.from([
+    (simRoute53KskFlag >> 8) & 0xff,
+    simRoute53KskFlag & 0xff,
+    simRoute53DnskeyProtocol,
+    simRoute53SigningAlgorithmType,
+  ]);
+
+  return concatenateBytes([header, point]);
+}

--- a/src/service/route53/dnssec/sim-route53-dnskey-tag.ts
+++ b/src/service/route53/dnssec/sim-route53-dnskey-tag.ts
@@ -1,0 +1,30 @@
+/**
+ * The key tag of a DNSKEY, by the RFC 4034 Appendix B algorithm.
+ *
+ * The RDATA is summed as a sequence of 16-bit words, the carry is folded back
+ * in, and what is left of the low 16 bits is the tag. It is not a hash and it
+ * is not unique; it is the hint a resolver uses to pick which key to try, and
+ * it is what a DS record leads with.
+ */
+export function simRoute53DnskeyKeyTag(rdata: Uint8Array): number {
+  let accumulator = 0;
+
+  for (const [index, byte] of rdata.entries()) {
+    accumulator += shiftedByte(index, byte);
+  }
+
+  accumulator += (accumulator >> 16) & 0xff_ff;
+
+  return accumulator & 0xff_ff;
+}
+
+/**
+ * A byte's contribution to the sum: the high half of a word, or the low half.
+ */
+function shiftedByte(index: number, byte: number): number {
+  if (index % 2 === 0) {
+    return byte << 8;
+  }
+
+  return byte;
+}

--- a/src/service/route53/dnssec/sim-route53-dnskey.iso.test.ts
+++ b/src/service/route53/dnssec/sim-route53-dnskey.iso.test.ts
@@ -1,0 +1,90 @@
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertThrowsError,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimRoute53Dnskey } from "./sim-route53-dnskey.js";
+import { SimRoute53InvalidInput } from "../error/sim-route53.error.js";
+
+/**
+ * The ECDSA P-256 example zone from RFC 6605 Appendix A.1, which publishes a
+ * DNSKEY, its key tag and the DS record derived from it. Checking against a
+ * published vector is the only way to know the key tag and digest here are
+ * the ones a resolver would compute, rather than being self-consistently
+ * wrong.
+ */
+const rfc6605PublicKey =
+  // oxlint-disable-next-line no-secrets/no-secrets -- a published public key
+  "GojIhhXUN/u4v54ZQqGSnyhWJwaubCvTmeexv7bR6edbkrSqQpF64cYbcB7wNcP+e+MAnLr+Wi9xMWyQLc8NAA==";
+const rfc6605KeyTag = 55_648;
+const rfc6605Digest =
+  "B4C8C1FE2E7477127B27115656AD6256F424625BF5C1E2770CE6D6E37DF61D17";
+
+/**
+ * The DER SubjectPublicKeyInfo header every P-256 public key carries, which is
+ * what turns a raw point back into the encoding GetPublicKey returns.
+ */
+const p256SpkiHeader = Buffer.from(
+  "3059301306072a8648ce3d020106082a8648ce3d03010703420004",
+  "hex",
+);
+
+function derPublicKey(rawPoint: string): Uint8Array {
+  return Uint8Array.from(
+    Buffer.concat([p256SpkiHeader, Buffer.from(rawPoint, "base64")]),
+  );
+}
+
+describe("Route53 DNSKEY derivation", () => {
+  it("computes the key tag of a published DNSKEY", () => {
+    // Given the P-256 public key RFC 6605 publishes for example.net.
+    const dnskey = new SimRoute53Dnskey(derPublicKey(rfc6605PublicKey));
+
+    // When its key tag is read, then it is the tag the RFC gives.
+    assertIdentical(dnskey.keyTag, rfc6605KeyTag);
+  });
+
+  it("computes the DS digest of a published DNSKEY", () => {
+    // Given the same key, and the zone it belongs to.
+    const dnskey = new SimRoute53Dnskey(derPublicKey(rfc6605PublicKey));
+
+    // When the delegation signer digest is computed, then it matches the DS
+    // record the RFC publishes.
+    assertIdentical(dnskey.digestValue("example.net."), rfc6605Digest);
+    assertIdentical(
+      dnskey.dsRecord("example.net."),
+      `${String(rfc6605KeyTag)} 13 2 ${rfc6605Digest}`,
+    );
+  });
+
+  it("publishes the public key it was given", () => {
+    // Given the same key.
+    const dnskey = new SimRoute53Dnskey(derPublicKey(rfc6605PublicKey));
+
+    // When the DNSKEY record is read, then it carries the key in the base64
+    // form RFC 4034 requires.
+    assertIdentical(dnskey.publicKey, rfc6605PublicKey);
+    assertIdentical(dnskey.dnskeyRecord(), `257 3 13 ${rfc6605PublicKey}`);
+  });
+
+  it("takes an owner name however it is cased", () => {
+    // Given the same key.
+    const dnskey = new SimRoute53Dnskey(derPublicKey(rfc6605PublicKey));
+
+    // When the digest is computed over a mixed-case zone name, then it is the
+    // same digest, because DNSSEC digests the canonical lowercase name.
+    assertIdentical(dnskey.digestValue("Example.NET."), rfc6605Digest);
+  });
+
+  it("refuses a public key that is not a P-256 point", () => {
+    // Given a public key too short to hold an uncompressed P-256 point.
+    // When a DNSKEY is derived from it, then it is refused rather than
+    // producing a key tag over the wrong bytes.
+    const error = assertThrowsError(
+      () => new SimRoute53Dnskey(Uint8Array.from([1, 2, 3])),
+    );
+
+    assertInstanceOf(error, SimRoute53InvalidInput);
+  });
+});

--- a/src/service/route53/dnssec/sim-route53-dnskey.ts
+++ b/src/service/route53/dnssec/sim-route53-dnskey.ts
@@ -1,0 +1,83 @@
+import { createHash } from "node:crypto";
+import { encodeDnsName } from "../dns/wire/dns-name.js";
+import { concatenateBytes } from "../dns/wire/dns-bytes.js";
+import { simRoute53DnskeyKeyTag } from "./sim-route53-dnskey-tag.js";
+import {
+  simRoute53DnskeyRdata,
+  simRoute53EcPoint,
+} from "./sim-route53-dnskey-rdata.js";
+import {
+  simRoute53DigestAlgorithmType,
+  simRoute53DnskeyProtocol,
+  simRoute53KskFlag,
+  simRoute53SigningAlgorithmType,
+} from "./sim-route53-dnssec-algorithm.js";
+
+/**
+ * The DNSKEY a key-signing key publishes, derived from its KMS public key.
+ *
+ * Everything here is computed rather than invented, so the DS record a test
+ * reads is the DS record the zone's registrar would need. Two zones on two
+ * keys get two different ones, and a key tag that does not match its public
+ * key would be a bug rather than a detail nobody checks.
+ */
+export class SimRoute53Dnskey {
+  /**
+   * The public key, base64 encoded as RFC 4034 requires.
+   */
+  public readonly publicKey: string;
+
+  /**
+   * The key tag, computed by the RFC 4034 Appendix B algorithm.
+   */
+  public readonly keyTag: number;
+
+  private readonly rdata: Uint8Array;
+
+  constructor(publicKeyDer: Uint8Array) {
+    const point = simRoute53EcPoint(publicKeyDer);
+
+    this.publicKey = Buffer.from(point).toString("base64");
+    this.rdata = simRoute53DnskeyRdata(point);
+    this.keyTag = simRoute53DnskeyKeyTag(this.rdata);
+  }
+
+  /**
+   * The delegation signer digest over a zone's owner name and this DNSKEY.
+   *
+   * Uppercase hex, which is the form Route53 returns and the form a registrar
+   * expects in a DS record.
+   */
+  digestValue(zoneName: string): string {
+    const ownerName = encodeDnsName(zoneName.toLowerCase());
+
+    return createHash("sha256")
+      .update(concatenateBytes([ownerName, this.rdata]))
+      .digest("hex")
+      .toUpperCase();
+  }
+
+  /**
+   * The DS record a registrar is given, as Route53 formats it.
+   */
+  dsRecord(zoneName: string): string {
+    return [
+      this.keyTag,
+      simRoute53SigningAlgorithmType,
+      simRoute53DigestAlgorithmType,
+      this.digestValue(zoneName),
+    ].join(" ");
+  }
+
+  /**
+   * The DNSKEY record this key publishes, as Route53 formats it.
+   */
+  dnskeyRecord(): string {
+    return [
+      simRoute53KskFlag,
+      simRoute53DnskeyProtocol,
+      simRoute53SigningAlgorithmType,
+      this.publicKey,
+    ].join(" ");
+  }
+}

--- a/src/service/route53/dnssec/sim-route53-dnssec-algorithm.ts
+++ b/src/service/route53/dnssec/sim-route53-dnssec-algorithm.ts
@@ -1,0 +1,18 @@
+/**
+ * The DNSSEC parameters of a Route53 key-signing key.
+ *
+ * Route53 only accepts an ECC_NIST_P256 customer managed key, so there is one
+ * algorithm here rather than a table: ECDSA with SHA-256, algorithm 13, and
+ * the SHA-256 delegation signer digest, algorithm 2. A key-signing key always
+ * carries flag 257, the secure entry point.
+ */
+export const simRoute53KskFlag = 257;
+export const simRoute53SigningAlgorithmMnemonic = "ECDSAP256SHA256";
+export const simRoute53SigningAlgorithmType = 13;
+export const simRoute53DigestAlgorithmMnemonic = "SHA-256";
+export const simRoute53DigestAlgorithmType = 2;
+
+/**
+ * The DNSKEY protocol field, which RFC 4034 fixes at 3.
+ */
+export const simRoute53DnskeyProtocol = 3;

--- a/src/service/route53/dnssec/sim-route53-key-signing-key.ts
+++ b/src/service/route53/dnssec/sim-route53-key-signing-key.ts
@@ -1,0 +1,166 @@
+import { SimRoute53InvalidKeySigningKeyStatus } from "../error/sim-route53.error.js";
+import { SimRoute53Dnskey } from "./sim-route53-dnskey.js";
+import {
+  simRoute53DigestAlgorithmMnemonic,
+  simRoute53DigestAlgorithmType,
+  simRoute53KskFlag,
+  simRoute53SigningAlgorithmMnemonic,
+  simRoute53SigningAlgorithmType,
+} from "./sim-route53-dnssec-algorithm.js";
+
+/**
+ * The statuses a key-signing key can hold here.
+ *
+ * Real Route53 also has DELETING and the two failure statuses, which describe
+ * a key mid-operation or a zone that needs attention. Nothing in this
+ * simulation produces either, so a key is one of these two.
+ */
+export const SimRoute53KeySigningKeyStatus = {
+  Active: "ACTIVE",
+  Inactive: "INACTIVE",
+} as const;
+
+export type SimRoute53KeySigningKeyStatus =
+  (typeof SimRoute53KeySigningKeyStatus)[keyof typeof SimRoute53KeySigningKeyStatus];
+
+interface SimRoute53KeySigningKeyProperties {
+  readonly name: string;
+  readonly kmsArn: string;
+  readonly hostedZoneId: string;
+  readonly zoneName: string;
+  readonly publicKeyDer: Uint8Array;
+  readonly status: SimRoute53KeySigningKeyStatus;
+  readonly createdDate: Date;
+}
+
+/**
+ * The AWS-shaped view of a key-signing key, as GetDNSSEC returns it.
+ */
+export interface SimRoute53KeySigningKeyView {
+  readonly Name: string;
+  readonly KmsArn: string;
+  readonly Flag: number;
+  readonly SigningAlgorithmMnemonic: string;
+  readonly SigningAlgorithmType: number;
+  readonly DigestAlgorithmMnemonic: string;
+  readonly DigestAlgorithmType: number;
+  readonly KeyTag: number;
+  readonly DigestValue: string;
+  readonly PublicKey: string;
+  readonly DSRecord: string;
+  readonly DNSKEYRecord: string;
+  readonly Status: SimRoute53KeySigningKeyStatus;
+  readonly CreatedDate: Date;
+  readonly LastModifiedDate: Date;
+}
+
+/**
+ * A simulated Route53 key-signing key.
+ *
+ * The key itself lives in KMS. What is held here is what Route53 adds: a name
+ * within the zone, a status, and the DNSSEC parameters derived from the KMS
+ * key's public key at the moment the key-signing key was created. Real Route53
+ * derives them once in the same way, which is why rotating the KMS key is not
+ * a thing you can do to an existing key-signing key.
+ */
+export class SimRoute53KeySigningKey {
+  public readonly name: string;
+  public readonly kmsArn: string;
+
+  /**
+   * The Hosted Zone this key belongs to. A key-signing key is only ever
+   * identified alongside its zone, which is why its CloudFormation Ref is the
+   * two joined together.
+   */
+  public readonly hostedZoneId: string;
+
+  private readonly zoneName: string;
+  private readonly dnskey: SimRoute53Dnskey;
+  private readonly createdDate: Date;
+  #status: SimRoute53KeySigningKeyStatus;
+  #lastModifiedDate: Date;
+
+  constructor(properties: SimRoute53KeySigningKeyProperties) {
+    this.name = properties.name;
+    this.kmsArn = properties.kmsArn;
+    this.hostedZoneId = properties.hostedZoneId;
+    this.zoneName = properties.zoneName;
+    this.dnskey = new SimRoute53Dnskey(properties.publicKeyDer);
+    this.createdDate = properties.createdDate;
+    this.#status = properties.status;
+    this.#lastModifiedDate = properties.createdDate;
+  }
+
+  /**
+   * Whether this key is being used to sign the zone.
+   */
+  get isActive(): boolean {
+    return this.#status === SimRoute53KeySigningKeyStatus.Active;
+  }
+
+  /**
+   * The DS record this key's registrar is given.
+   */
+  get dsRecord(): string {
+    return this.dnskey.dsRecord(this.zoneName);
+  }
+
+  /**
+   * Start signing with this key.
+   */
+  activate(modifiedDate: Date): void {
+    this.setStatus(SimRoute53KeySigningKeyStatus.Active, modifiedDate);
+  }
+
+  /**
+   * Stop signing with this key, leaving it on the zone.
+   */
+  deactivate(modifiedDate: Date): void {
+    this.setStatus(SimRoute53KeySigningKeyStatus.Inactive, modifiedDate);
+  }
+
+  /**
+   * Refuse removal of a key that is still signing.
+   *
+   * Real Route53 will not delete an active key-signing key, because doing so
+   * would leave the zone signed with a key resolvers can no longer find.
+   */
+  requireRemovable(): void {
+    if (this.isActive) {
+      throw new SimRoute53InvalidKeySigningKeyStatus(
+        `Key signing key ${this.name} is ACTIVE and cannot be deleted: deactivate it first`,
+      );
+    }
+  }
+
+  /**
+   * Describe this key the way GetDNSSEC reports it.
+   */
+  describe(): SimRoute53KeySigningKeyView {
+    return {
+      Name: this.name,
+      KmsArn: this.kmsArn,
+      Flag: simRoute53KskFlag,
+      SigningAlgorithmMnemonic: simRoute53SigningAlgorithmMnemonic,
+      SigningAlgorithmType: simRoute53SigningAlgorithmType,
+      DigestAlgorithmMnemonic: simRoute53DigestAlgorithmMnemonic,
+      DigestAlgorithmType: simRoute53DigestAlgorithmType,
+      KeyTag: this.dnskey.keyTag,
+      DigestValue: this.dnskey.digestValue(this.zoneName),
+      PublicKey: this.dnskey.publicKey,
+      DSRecord: this.dsRecord,
+      DNSKEYRecord: this.dnskey.dnskeyRecord(),
+      Status: this.#status,
+      CreatedDate: new Date(this.createdDate),
+      LastModifiedDate: new Date(this.#lastModifiedDate),
+    };
+  }
+
+  private setStatus(
+    status: SimRoute53KeySigningKeyStatus,
+    modifiedDate: Date,
+  ): void {
+    this.#status = status;
+    this.#lastModifiedDate = modifiedDate;
+  }
+}

--- a/src/service/route53/dnssec/sim-route53-zone-dnssec.ts
+++ b/src/service/route53/dnssec/sim-route53-zone-dnssec.ts
@@ -1,0 +1,142 @@
+import {
+  SimRoute53DnssecNotFound,
+  SimRoute53KeySigningKeyAlreadyExists,
+  SimRoute53NoActiveKeySigningKey,
+  SimRoute53NoSuchKeySigningKey,
+} from "../error/sim-route53.error.js";
+import type { SimRoute53KeySigningKey } from "./sim-route53-key-signing-key.js";
+
+/**
+ * Whether a zone is being signed.
+ *
+ * Real Route53 also reports DELETING while signing is being taken off, and two
+ * statuses for a zone that needs attention. Nothing here leaves a zone in any
+ * of those, so a zone is signing or it is not.
+ */
+export const SimRoute53ServeSignature = {
+  Signing: "SIGNING",
+  NotSigning: "NOT_SIGNING",
+} as const;
+
+export type SimRoute53ServeSignature =
+  (typeof SimRoute53ServeSignature)[keyof typeof SimRoute53ServeSignature];
+
+/**
+ * The DNSSEC state of one hosted zone: its key-signing keys, and whether the
+ * zone is signed with them.
+ *
+ * The two are separate on real Route53 and stay separate here. Adding a
+ * key-signing key does not start signing, and stopping signing leaves the keys
+ * in place, which is what makes it possible to prepare a zone for DNSSEC
+ * before the DS record is published.
+ */
+export class SimRoute53ZoneDnssec {
+  private readonly keySigningKeys = new Map<string, SimRoute53KeySigningKey>();
+  #serveSignature: SimRoute53ServeSignature =
+    SimRoute53ServeSignature.NotSigning;
+
+  /**
+   * Whether the zone is being signed.
+   */
+  get serveSignature(): SimRoute53ServeSignature {
+    return this.#serveSignature;
+  }
+
+  /**
+   * Every key-signing key on the zone, in the order they were added.
+   */
+  keys(): readonly SimRoute53KeySigningKey[] {
+    return this.keySigningKeys.values().toArray();
+  }
+
+  /**
+   * Add a key-signing key to the zone.
+   *
+   * A name is unique within the zone, and so is the KMS key behind it: real
+   * Route53 refuses both, because two keys sharing either would be
+   * indistinguishable in the zone's DNSKEY set.
+   */
+  add(keySigningKey: SimRoute53KeySigningKey): void {
+    if (this.keySigningKeys.has(keySigningKey.name)) {
+      throw new SimRoute53KeySigningKeyAlreadyExists(
+        `Key signing key ${keySigningKey.name} already exists in this hosted zone`,
+      );
+    }
+
+    if (this.keys().some((key) => key.kmsArn === keySigningKey.kmsArn)) {
+      throw new SimRoute53KeySigningKeyAlreadyExists(
+        `Key signing key ${keySigningKey.name} uses KMS key ${keySigningKey.kmsArn}, which another key signing key in this hosted zone already uses`,
+      );
+    }
+
+    this.keySigningKeys.set(keySigningKey.name, keySigningKey);
+  }
+
+  /**
+   * Find a key-signing key by name, or refuse an unknown one.
+   */
+  require(name: string): SimRoute53KeySigningKey {
+    const keySigningKey = this.keySigningKeys.get(name);
+
+    if (keySigningKey === undefined) {
+      throw new SimRoute53NoSuchKeySigningKey(
+        `No key signing key named ${name} in this hosted zone`,
+      );
+    }
+
+    return keySigningKey;
+  }
+
+  /**
+   * Remove a key-signing key, refusing one that is still signing.
+   */
+  remove(name: string): void {
+    this.require(name).requireRemovable();
+    this.keySigningKeys.delete(name);
+  }
+
+  /**
+   * Start signing the zone.
+   *
+   * A zone with no active key-signing key has nothing to sign with, which real
+   * Route53 refuses rather than reporting a signed zone no resolver could
+   * validate.
+   */
+  enableSigning(): void {
+    if (this.keys().every((key) => !key.isActive)) {
+      throw new SimRoute53NoActiveKeySigningKey(
+        "This hosted zone has no ACTIVE key signing key to sign with",
+      );
+    }
+
+    this.#serveSignature = SimRoute53ServeSignature.Signing;
+  }
+
+  /**
+   * Refuse deletion of the Hosted Zone while it is still being signed.
+   *
+   * Real Route53 will not delete a signed zone: DNSSEC has to be disabled
+   * first, so the DS record at the parent stops pointing at a zone that has
+   * gone.
+   */
+  assertZoneDeletable(): void {
+    if (this.#serveSignature === SimRoute53ServeSignature.Signing) {
+      throw new SimRoute53DnssecNotFound(
+        "This hosted zone is signed and cannot be deleted: disable DNSSEC first",
+      );
+    }
+  }
+
+  /**
+   * Stop signing the zone, leaving its key-signing keys in place.
+   */
+  disableSigning(): void {
+    if (this.#serveSignature === SimRoute53ServeSignature.NotSigning) {
+      throw new SimRoute53DnssecNotFound(
+        "This hosted zone is not signed, so signing cannot be disabled",
+      );
+    }
+
+    this.#serveSignature = SimRoute53ServeSignature.NotSigning;
+  }
+}

--- a/src/service/route53/dnssec/sim-route53-zone-dnssec.ts
+++ b/src/service/route53/dnssec/sim-route53-zone-dnssec.ts
@@ -1,5 +1,6 @@
 import {
   SimRoute53DnssecNotFound,
+  SimRoute53InvalidInput,
   SimRoute53KeySigningKeyAlreadyExists,
   SimRoute53NoActiveKeySigningKey,
   SimRoute53NoSuchKeySigningKey,
@@ -118,10 +119,14 @@ export class SimRoute53ZoneDnssec {
    * Real Route53 will not delete a signed zone: DNSSEC has to be disabled
    * first, so the DS record at the parent stops pointing at a zone that has
    * gone.
+   *
+   * Which error it answers with is not documented among DeleteHostedZone's
+   * errors, so this reports the InvalidInput that operation does document
+   * rather than claiming a code that may not be the one AWS sends.
    */
   assertZoneDeletable(): void {
     if (this.#serveSignature === SimRoute53ServeSignature.Signing) {
-      throw new SimRoute53DnssecNotFound(
+      throw new SimRoute53InvalidInput(
         "This hosted zone is signed and cannot be deleted: disable DNSSEC first",
       );
     }

--- a/src/service/route53/error/sim-route53.error.ts
+++ b/src/service/route53/error/sim-route53.error.ts
@@ -65,3 +65,82 @@ export class SimRoute53HostedZoneAlreadyExists extends SimRoute53Error {
     super(message, { httpStatusCode: 409 });
   }
 }
+
+/**
+ * Simulated Route53 InvalidKeySigningKeyStatus error.
+ *
+ * Real Route53 reports a key-signing key that is in the wrong state for what
+ * was asked of it this way, such as deleting one that is still active.
+ */
+export class SimRoute53InvalidKeySigningKeyStatus extends SimRoute53Error {
+  public override readonly name = "InvalidKeySigningKeyStatus";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
+ * Simulated Route53 NoSuchKeySigningKey error.
+ */
+export class SimRoute53NoSuchKeySigningKey extends SimRoute53Error {
+  public override readonly name = "NoSuchKeySigningKey";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 404 });
+  }
+}
+
+/**
+ * Simulated Route53 KeySigningKeyAlreadyExists error.
+ */
+export class SimRoute53KeySigningKeyAlreadyExists extends SimRoute53Error {
+  public override readonly name = "KeySigningKeyAlreadyExists";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 409 });
+  }
+}
+
+/**
+ * Simulated Route53 InvalidKMSArn error.
+ *
+ * Route53 checks the customer managed key a key-signing key names before it
+ * creates one: the key has to exist, be enabled, and be an ECC_NIST_P256
+ * SIGN_VERIFY key. This is how it reports a key that is not.
+ */
+export class SimRoute53InvalidKmsArn extends SimRoute53Error {
+  public override readonly name = "InvalidKMSArn";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
+ * Simulated Route53 DNSSECNotFound error.
+ *
+ * Real Route53 reports an attempt to stop signing a zone that is not signed
+ * this way.
+ */
+export class SimRoute53DnssecNotFound extends SimRoute53Error {
+  public override readonly name = "DNSSECNotFound";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
+ * Simulated Route53 KeySigningKeyWithActiveStatusNotFound error.
+ *
+ * Enabling DNSSEC signing needs an active key-signing key to sign with, and
+ * this is what real Route53 answers when the zone has none.
+ */
+export class SimRoute53NoActiveKeySigningKey extends SimRoute53Error {
+  public override readonly name = "KeySigningKeyWithActiveStatusNotFound";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}

--- a/src/service/route53/hosted-zone/sim-route53-hosted-zone.ts
+++ b/src/service/route53/hosted-zone/sim-route53-hosted-zone.ts
@@ -9,6 +9,7 @@ import type { BackgroundScheduler } from "../../../util/background/background.js
 import { SimRoute53ZoneSynchronization } from "./sim-route53-zone-synchronization.js";
 import { SimRoute53HostedZoneNotEmpty } from "../error/sim-route53.error.js";
 import { widenSimRoute53ZoneName } from "./sim-route53-zone-name-widening.js";
+import { SimRoute53ZoneDnssec } from "../dnssec/sim-route53-zone-dnssec.js";
 
 export type SimRoute53HostedZoneStatus = "PENDING" | "INSYNC";
 
@@ -34,6 +35,15 @@ interface SimRoute53HostedZoneProperties {
 export class SimRoute53HostedZone {
   /* @internal */
   public readonly records = new SimRoute53HostedZoneRecords();
+  /**
+   * This zone's key-signing keys and whether it is being signed.
+   *
+   * DNSSEC state belongs to the zone rather than to the account-scoped
+   * service, in the same way its records do, so a zone reached through the
+   * shared registry carries it too.
+   * @internal
+   */
+  public readonly dnssec = new SimRoute53ZoneDnssec();
   /**
    * AWS Route53 Hosted Zone ID.
    */
@@ -101,9 +111,8 @@ export class SimRoute53HostedZone {
   /**
    * Move the sim Hosted Zone into PENDING status.
    */
-  beginSynchronization(): Promise<void> {
+  beginSynchronization(): void {
     this.#status = "PENDING";
-    return Promise.resolve();
   }
 
   /**
@@ -140,18 +149,12 @@ export class SimRoute53HostedZone {
   }
 
   /**
-   * Move the sim Hosted Zone into INSYNC status.
-   */
-  completeSynchronization(): Promise<void> {
-    this.markSynchronized();
-    return Promise.resolve();
-  }
-
-  /**
-   * Put the sim Hosted Zone into INSYNC status without awaiting anything.
+   * Put the sim Hosted Zone into INSYNC status.
    *
-   * A zone registered as already existing has no synchronization to wait for,
-   * and setup methods are not asynchronous.
+   * Neither this nor `beginSynchronization` awaits anything. Both used to
+   * answer with a resolved promise, which said the status change was
+   * asynchronous when it never was: the waiting is what
+   * `scheduleSynchronization` arranges, and it is separate.
    */
   markSynchronized(): void {
     this.#status = "INSYNC";

--- a/src/service/route53/index.ts
+++ b/src/service/route53/index.ts
@@ -1,2 +1,19 @@
 export { SimRoute53 } from "./sim-route53.js";
 export { type SimRoute53HostedZoneRegistration } from "./hosted-zone/register-sim-route53-hosted-zone.js";
+export {
+  SimRoute53KeySigningKey,
+  SimRoute53KeySigningKeyStatus,
+  type SimRoute53KeySigningKeyView,
+} from "./dnssec/sim-route53-key-signing-key.js";
+export {
+  SimRoute53ServeSignature,
+  SimRoute53ZoneDnssec,
+} from "./dnssec/sim-route53-zone-dnssec.js";
+export {
+  SimRoute53DnssecNotFound,
+  SimRoute53InvalidKeySigningKeyStatus,
+  SimRoute53InvalidKmsArn,
+  SimRoute53KeySigningKeyAlreadyExists,
+  SimRoute53NoActiveKeySigningKey,
+  SimRoute53NoSuchKeySigningKey,
+} from "./error/sim-route53.error.js";

--- a/src/service/route53/sdk/sim-route53-sdk-command-router.ts
+++ b/src/service/route53/sdk/sim-route53-sdk-command-router.ts
@@ -9,6 +9,12 @@ import type { SimDeleteHostedZoneCommand } from "../command/delete-hosted-zone/d
 import type { SimGetHostedZoneCommand } from "../command/get-hosted-zone/get-hosted-zone.command.js";
 import type { SimListHostedZonesByNameCommand } from "../command/list-hosted-zones-by-name/list-hosted-zones-by-name.command.js";
 import type { SimListResourceRecordSetsCommand } from "../command/list-resource-record-sets/list-resource-record-sets.command.js";
+import type {
+  SimCreateKeySigningKeyCommand,
+  SimGetDnssecCommand,
+  SimHostedZoneDnssecCommand,
+  SimKeySigningKeyCommand,
+} from "../command/dnssec/dnssec.command.js";
 import type { SimRoute53 } from "../sim-route53.js";
 
 /**
@@ -64,6 +70,62 @@ export class SimRoute53SdkCommandRouter implements SimSdkCommandRouter {
         async (command, context): Promise<unknown> =>
           await simRoute53.listResourceRecordSets(
             command as SimListResourceRecordSetsCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "CreateKeySigningKeyCommand",
+        async (command, context): Promise<unknown> =>
+          await simRoute53.createKeySigningKey(
+            command as SimCreateKeySigningKeyCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "ActivateKeySigningKeyCommand",
+        async (command, context): Promise<unknown> =>
+          await simRoute53.activateKeySigningKey(
+            command as SimKeySigningKeyCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "DeactivateKeySigningKeyCommand",
+        async (command, context): Promise<unknown> =>
+          await simRoute53.deactivateKeySigningKey(
+            command as SimKeySigningKeyCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "DeleteKeySigningKeyCommand",
+        async (command, context): Promise<unknown> =>
+          await simRoute53.deleteKeySigningKey(
+            command as SimKeySigningKeyCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "EnableHostedZoneDNSSECCommand",
+        async (command, context): Promise<unknown> =>
+          await simRoute53.enableHostedZoneDnssec(
+            command as SimHostedZoneDnssecCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "DisableHostedZoneDNSSECCommand",
+        async (command, context): Promise<unknown> =>
+          await simRoute53.disableHostedZoneDnssec(
+            command as SimHostedZoneDnssecCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "GetDNSSECCommand",
+        async (command, context): Promise<unknown> =>
+          await simRoute53.getDnssec(
+            command as SimGetDnssecCommand,
             simSdkCallerOptions(context),
           ),
       ],

--- a/src/service/route53/sdk/sim-route53-sdk-dnssec-routing.iso.test.ts
+++ b/src/service/route53/sdk/sim-route53-sdk-dnssec-routing.iso.test.ts
@@ -1,0 +1,81 @@
+import {
+  ActivateKeySigningKeyCommand,
+  CreateHostedZoneCommand,
+  CreateKeySigningKeyCommand,
+  DeactivateKeySigningKeyCommand,
+  DeleteKeySigningKeyCommand,
+  DisableHostedZoneDNSSECCommand,
+  EnableHostedZoneDNSSECCommand,
+  GetDNSSECCommand,
+  Route53Client,
+} from "@aws-sdk/client-route-53";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimSdk } from "../../../sdk/index.js";
+import { simKmsSigningKeyArn } from "../../../../test/route53/dnssec-fixture.js";
+
+describe("simulated Route53 DNSSEC SDK Command routing", () => {
+  it("round-trips DNSSEC Commands through an intercepted client", async () => {
+    // Given an intercepted Route53 client, a hosted zone and a signing key.
+    using simSdk = new SimSdk();
+    const client = new Route53Client({ region: "us-east-1" });
+    simSdk.intercept(client);
+
+    const zone = await client.send(
+      new CreateHostedZoneCommand({
+        Name: "example.test",
+        CallerReference: "dnssec-sdk-ref",
+      }),
+    );
+    assertNonNullable(zone.HostedZone?.Id);
+    const HostedZoneId = zone.HostedZone.Id;
+    const kmsArn = await simKmsSigningKeyArn(simSdk.simAws);
+
+    // When every DNSSEC Command is sent through the client.
+    const created = await client.send(
+      new CreateKeySigningKeyCommand({
+        CallerReference: "ksk",
+        HostedZoneId,
+        KeyManagementServiceArn: kmsArn,
+        Name: "zone_signing_key",
+        Status: "INACTIVE",
+      }),
+    );
+    await client.send(
+      new ActivateKeySigningKeyCommand({
+        HostedZoneId,
+        Name: "zone_signing_key",
+      }),
+    );
+    await client.send(new EnableHostedZoneDNSSECCommand({ HostedZoneId }));
+
+    const signing = await client.send(new GetDNSSECCommand({ HostedZoneId }));
+
+    await client.send(new DisableHostedZoneDNSSECCommand({ HostedZoneId }));
+    await client.send(
+      new DeactivateKeySigningKeyCommand({
+        HostedZoneId,
+        Name: "zone_signing_key",
+      }),
+    );
+    await client.send(
+      new DeleteKeySigningKeyCommand({
+        HostedZoneId,
+        Name: "zone_signing_key",
+      }),
+    );
+
+    const unsigned = await client.send(new GetDNSSECCommand({ HostedZoneId }));
+
+    // Then each one reached the simulation and answered as it would directly.
+    assertIdentical(created.KeySigningKey?.Name, "zone_signing_key");
+    assertIdentical(signing.Status?.ServeSignature, "SIGNING");
+    assertArrayLength(signing.KeySigningKeys ?? [], 1);
+    assertIdentical(unsigned.Status?.ServeSignature, "NOT_SIGNING");
+    assertArrayLength(unsigned.KeySigningKeys ?? [], 0);
+  });
+});

--- a/src/service/route53/sim-route53-commands.ts
+++ b/src/service/route53/sim-route53-commands.ts
@@ -1,0 +1,82 @@
+import type { BackgroundScheduler } from "../../util/background/background.js";
+import type { SimIamInterServiceAuthZ } from "../iam/authorize/sim-iam-inter-service-auth-z.js";
+import type { SimKmsKeyResolver } from "../kms/registry/sim-kms-registry.js";
+import { ChangeResourceRecordSetsCommandHandler } from "./command/change-resource-record-sets/change-resource-record-sets.handler.js";
+import { CreateHostedZoneCommandHandler } from "./command/create-hosted-zone/create-hosted-zone.handler.js";
+import type { SimRoute53HostedZoneId } from "./command/create-hosted-zone/sim-route53-zone-id.js";
+import { DeleteHostedZoneCommandHandler } from "./command/delete-hosted-zone/delete-hosted-zone.handler.js";
+import { SimRoute53DnssecCommands } from "./command/dnssec/sim-route53-dnssec-commands.js";
+import { GetHostedZoneCommandHandler } from "./command/get-hosted-zone/get-hosted-zone.handler.js";
+import { ListHostedZonesByNameCommandHandler } from "./command/list-hosted-zones-by-name/list-hosted-zones-by-name.handler.js";
+import { ListResourceRecordSetsCommandHandler } from "./command/list-resource-record-sets/list-resource-record-sets.handler.js";
+import type { SimRoute53HostedZone } from "./hosted-zone/sim-route53-hosted-zone.js";
+import type { SimRoute53Registry } from "./registry/sim-route53-registry.js";
+
+interface SimRoute53CommandsProperties {
+  readonly hostedZones: Map<SimRoute53HostedZoneId, SimRoute53HostedZone>;
+  readonly iam: SimIamInterServiceAuthZ;
+  readonly background: BackgroundScheduler;
+  readonly route53Registry: SimRoute53Registry;
+  readonly kmsKeys?: SimKmsKeyResolver | undefined;
+}
+
+/**
+ * The command handlers of one simulated Route53, and the state they share.
+ *
+ * Every handler works on the same hosted zone map, authorizes against the same
+ * IAM and sequences through the same background scheduler, so the wiring lives
+ * here rather than being repeated once per command in the service facade. That
+ * keeps SimRoute53 what it should be: state plus delegation.
+ */
+export class SimRoute53Commands {
+  public readonly createHostedZone: CreateHostedZoneCommandHandler;
+  public readonly getHostedZone: GetHostedZoneCommandHandler;
+  public readonly deleteHostedZone: DeleteHostedZoneCommandHandler;
+  public readonly listHostedZonesByName: ListHostedZonesByNameCommandHandler;
+  public readonly listResourceRecordSets: ListResourceRecordSetsCommandHandler;
+  public readonly changeResourceRecordSets: ChangeResourceRecordSetsCommandHandler;
+  public readonly dnssec: SimRoute53DnssecCommands;
+
+  constructor(properties: SimRoute53CommandsProperties) {
+    const { hostedZones, iam, background, route53Registry } = properties;
+
+    this.createHostedZone = new CreateHostedZoneCommandHandler({
+      hostedZones,
+      iam,
+      background,
+      route53Registry,
+    });
+    this.getHostedZone = new GetHostedZoneCommandHandler({
+      hostedZones,
+      iam,
+      background,
+    });
+    this.deleteHostedZone = new DeleteHostedZoneCommandHandler({
+      hostedZones,
+      route53Registry,
+      iam,
+      background,
+    });
+    this.listHostedZonesByName = new ListHostedZonesByNameCommandHandler({
+      hostedZones,
+      iam,
+      background,
+    });
+    this.listResourceRecordSets = new ListResourceRecordSetsCommandHandler({
+      hostedZones,
+      iam,
+      background,
+    });
+    this.changeResourceRecordSets = new ChangeResourceRecordSetsCommandHandler({
+      hostedZones,
+      iam,
+      background,
+    });
+    this.dnssec = new SimRoute53DnssecCommands({
+      hostedZones,
+      iam,
+      background,
+      kmsKeys: properties.kmsKeys,
+    });
+  }
+}

--- a/src/service/route53/sim-route53-request-options.ts
+++ b/src/service/route53/sim-route53-request-options.ts
@@ -1,0 +1,8 @@
+import type { SimAwsCaller } from "../aws/caller/sim-aws-caller.js";
+
+/**
+ * The options every simulated Route53 command takes.
+ */
+export interface SimRoute53RequestOptions {
+  readonly caller?: SimAwsCaller;
+}

--- a/src/service/route53/sim-route53.ts
+++ b/src/service/route53/sim-route53.ts
@@ -1,42 +1,13 @@
 import type { SimAwsServiceHosts } from "../../serve/controller/host/sim-aws-service-hosts.js";
 import type { SimAwsServiceTarget } from "../../serve/controller/sim-service-controller.js";
 import { SimRoute53Resolver } from "./resolve/sim-route53-resolver.js";
-import { CreateHostedZoneCommandHandler } from "./command/create-hosted-zone/create-hosted-zone.handler.js";
-import type {
-  SimCreateHostedZoneCommand,
-  SimCreateHostedZoneCommandOutput,
-} from "./command/create-hosted-zone/create-hosted-zone.command.js";
+import type * as simRoute53Commands from "./command/sim-route53-command.types.js";
 import type { SimRoute53HostedZone } from "./hosted-zone/sim-route53-hosted-zone.js";
 import {
   registerSimRoute53HostedZone,
   type SimRoute53HostedZoneRegistration,
 } from "./hosted-zone/register-sim-route53-hosted-zone.js";
 import type { SimRoute53HostedZoneId } from "./command/create-hosted-zone/sim-route53-zone-id.js";
-import type {
-  SimGetHostedZoneCommand,
-  SimGetHostedZoneCommandOutput,
-} from "./command/get-hosted-zone/get-hosted-zone.command.js";
-import { GetHostedZoneCommandHandler } from "./command/get-hosted-zone/get-hosted-zone.handler.js";
-import type {
-  SimDeleteHostedZoneCommand,
-  SimDeleteHostedZoneCommandOutput,
-} from "./command/delete-hosted-zone/delete-hosted-zone.command.js";
-import { DeleteHostedZoneCommandHandler } from "./command/delete-hosted-zone/delete-hosted-zone.handler.js";
-import type {
-  SimListHostedZonesByNameCommand,
-  SimListHostedZonesByNameCommandOutput,
-} from "./command/list-hosted-zones-by-name/list-hosted-zones-by-name.command.js";
-import { ListHostedZonesByNameCommandHandler } from "./command/list-hosted-zones-by-name/list-hosted-zones-by-name.handler.js";
-import type {
-  SimListResourceRecordSetsCommand,
-  SimListResourceRecordSetsCommandOutput,
-} from "./command/list-resource-record-sets/list-resource-record-sets.command.js";
-import { ListResourceRecordSetsCommandHandler } from "./command/list-resource-record-sets/list-resource-record-sets.handler.js";
-import type {
-  SimChangeResourceRecordSetsCommand,
-  SimChangeResourceRecordSetsCommandOutput,
-} from "./command/change-resource-record-sets/change-resource-record-sets.command.js";
-import { ChangeResourceRecordSetsCommandHandler } from "./command/change-resource-record-sets/change-resource-record-sets.handler.js";
 import {
   type BackgroundScheduler,
   BackgroundTasks,
@@ -44,17 +15,17 @@ import {
 import { SimRoute53CloudFormationResourceFactory } from "./cfn/sim-cfn-route53-resource-factory.js";
 import type { SimCfnServiceResourceFactory } from "../cloudformation/resource/factory/sim-cfn-resource-factory.type.js";
 import { SimRoute53Registry } from "./registry/sim-route53-registry.js";
-import type { SimAwsCaller } from "../aws/caller/sim-aws-caller.js";
 import {
   SimIamAllowAllAuth,
   type SimIamInterServiceAuthZ,
 } from "../iam/authorize/sim-iam-inter-service-auth-z.js";
 import { SimRoute53SdkCommandRouter } from "./sdk/sim-route53-sdk-command-router.js";
 import type { SimSdkCommandRouter } from "../../sdk/index.js";
+import type { SimKmsKeyResolver } from "../kms/registry/sim-kms-registry.js";
+import type { SimRoute53RequestOptions } from "./sim-route53-request-options.js";
+import { SimRoute53Commands } from "./sim-route53-commands.js";
 
-export interface SimRoute53RequestOptions {
-  readonly caller?: SimAwsCaller;
-}
+export type { SimRoute53RequestOptions } from "./sim-route53-request-options.js";
 
 interface SimRoute53Properties {
   readonly iam?: SimIamInterServiceAuthZ | undefined;
@@ -68,6 +39,12 @@ interface SimRoute53Properties {
    * one arrives at the service holding it.
    */
   readonly serviceHosts?: SimAwsServiceHosts | undefined;
+
+  /**
+   * Where a KMS key ARN is looked up. A DNSSEC key-signing key is built on a
+   * customer managed key, and Route53 checks that key before it takes one.
+   */
+  readonly kmsKeys?: SimKmsKeyResolver | undefined;
 }
 
 /**
@@ -78,8 +55,6 @@ export class SimRoute53 {
     SimRoute53HostedZoneId,
     SimRoute53HostedZone
   >();
-  private readonly iam: SimIamInterServiceAuthZ;
-  private readonly background: BackgroundScheduler;
   private readonly route53Registry: SimRoute53Registry;
   private readonly cfnFactory = new SimRoute53CloudFormationResourceFactory({
     route53: this,
@@ -87,6 +62,7 @@ export class SimRoute53 {
   private readonly sdkRouter = new SimRoute53SdkCommandRouter(this);
 
   private readonly resolver: SimRoute53Resolver;
+  private readonly commands: SimRoute53Commands;
 
   constructor(properties: SimRoute53Properties = {}) {
     const {
@@ -95,12 +71,17 @@ export class SimRoute53 {
       route53Registry = new SimRoute53Registry(),
     } = properties;
 
-    this.iam = iam;
-    this.background = background;
     this.route53Registry = route53Registry;
     this.resolver = new SimRoute53Resolver({
-      hostedZones: this.route53Registry.hostedZones,
+      hostedZones: route53Registry.hostedZones,
       serviceHosts: properties.serviceHosts,
+    });
+    this.commands = new SimRoute53Commands({
+      hostedZones: this.hostedZones,
+      iam,
+      background,
+      route53Registry,
+      kmsKeys: properties.kmsKeys,
     });
   }
 
@@ -108,16 +89,10 @@ export class SimRoute53 {
    * Create a new simulated Route53 Hosted Zone.
    */
   async createHostedZone(
-    command: SimCreateHostedZoneCommand,
+    command: simRoute53Commands.SimCreateHostedZoneCommand,
     options?: SimRoute53RequestOptions,
-  ): Promise<SimCreateHostedZoneCommandOutput> {
-    const handler = new CreateHostedZoneCommandHandler({
-      hostedZones: this.hostedZones,
-      iam: this.iam,
-      background: this.background,
-      route53Registry: this.route53Registry,
-    });
-    return await handler.handle(command, options);
+  ): Promise<simRoute53Commands.SimCreateHostedZoneCommandOutput> {
+    return await this.commands.createHostedZone.handle(command, options);
   }
 
   /**
@@ -145,76 +120,126 @@ export class SimRoute53 {
    * Handle a Get Hosted Zone command from the SDK.
    */
   async getHostedZone(
-    command: SimGetHostedZoneCommand,
+    command: simRoute53Commands.SimGetHostedZoneCommand,
     options?: SimRoute53RequestOptions,
-  ): Promise<SimGetHostedZoneCommandOutput> {
-    const handler = new GetHostedZoneCommandHandler({
-      hostedZones: this.hostedZones,
-      iam: this.iam,
-      background: this.background,
-    });
-    return await handler.handle(command, options);
+  ): Promise<simRoute53Commands.SimGetHostedZoneCommandOutput> {
+    return await this.commands.getHostedZone.handle(command, options);
   }
 
   /**
    * Handle a Delete Hosted Zone command from the SDK.
    */
   async deleteHostedZone(
-    command: SimDeleteHostedZoneCommand,
+    command: simRoute53Commands.SimDeleteHostedZoneCommand,
     options?: SimRoute53RequestOptions,
-  ): Promise<SimDeleteHostedZoneCommandOutput> {
-    const handler = new DeleteHostedZoneCommandHandler({
-      hostedZones: this.hostedZones,
-      route53Registry: this.route53Registry,
-      iam: this.iam,
-      background: this.background,
-    });
-    return await handler.handle(command, options);
+  ): Promise<simRoute53Commands.SimDeleteHostedZoneCommandOutput> {
+    return await this.commands.deleteHostedZone.handle(command, options);
   }
 
   /**
    * Handle a List Hosted Zones By Name command from the SDK.
    */
   async listHostedZonesByName(
-    command: SimListHostedZonesByNameCommand,
+    command: simRoute53Commands.SimListHostedZonesByNameCommand,
     options?: SimRoute53RequestOptions,
-  ): Promise<SimListHostedZonesByNameCommandOutput> {
-    const handler = new ListHostedZonesByNameCommandHandler({
-      hostedZones: this.hostedZones,
-      iam: this.iam,
-      background: this.background,
-    });
-    return await handler.handle(command, options);
+  ): Promise<simRoute53Commands.SimListHostedZonesByNameCommandOutput> {
+    return await this.commands.listHostedZonesByName.handle(command, options);
   }
 
   /**
    * Handle a List Resource Record Sets command from the SDK.
    */
   async listResourceRecordSets(
-    command: SimListResourceRecordSetsCommand,
+    command: simRoute53Commands.SimListResourceRecordSetsCommand,
     options?: SimRoute53RequestOptions,
-  ): Promise<SimListResourceRecordSetsCommandOutput> {
-    const handler = new ListResourceRecordSetsCommandHandler({
-      hostedZones: this.hostedZones,
-      iam: this.iam,
-      background: this.background,
-    });
-    return await handler.handle(command, options);
+  ): Promise<simRoute53Commands.SimListResourceRecordSetsCommandOutput> {
+    return await this.commands.listResourceRecordSets.handle(command, options);
   }
 
   /**
    * Handle a Change Resource Record Sets command from the SDK.
    */
   async changeResourceRecordSets(
-    command: SimChangeResourceRecordSetsCommand,
+    command: simRoute53Commands.SimChangeResourceRecordSetsCommand,
     options?: SimRoute53RequestOptions,
-  ): Promise<SimChangeResourceRecordSetsCommandOutput> {
-    const handler = new ChangeResourceRecordSetsCommandHandler({
-      hostedZones: this.hostedZones,
-      iam: this.iam,
-      background: this.background,
-    });
-    return await handler.handle(command, options);
+  ): Promise<simRoute53Commands.SimChangeResourceRecordSetsCommandOutput> {
+    return await this.commands.changeResourceRecordSets.handle(
+      command,
+      options,
+    );
+  }
+
+  /**
+   * Handle a Create Key Signing Key command from the SDK.
+   */
+  async createKeySigningKey(
+    command: simRoute53Commands.SimCreateKeySigningKeyCommand,
+    options?: SimRoute53RequestOptions,
+  ): Promise<simRoute53Commands.SimCreateKeySigningKeyCommandOutput> {
+    return await this.commands.dnssec.keySigningKeys.create(command, options);
+  }
+
+  /**
+   * Handle an Activate Key Signing Key command from the SDK.
+   */
+  async activateKeySigningKey(
+    command: simRoute53Commands.SimKeySigningKeyCommand,
+    options?: SimRoute53RequestOptions,
+  ): Promise<simRoute53Commands.SimKeySigningKeyCommandOutput> {
+    return await this.commands.dnssec.keySigningKeys.activate(command, options);
+  }
+
+  /**
+   * Handle a Deactivate Key Signing Key command from the SDK.
+   */
+  async deactivateKeySigningKey(
+    command: simRoute53Commands.SimKeySigningKeyCommand,
+    options?: SimRoute53RequestOptions,
+  ): Promise<simRoute53Commands.SimKeySigningKeyCommandOutput> {
+    return await this.commands.dnssec.keySigningKeys.deactivate(
+      command,
+      options,
+    );
+  }
+
+  /**
+   * Handle a Delete Key Signing Key command from the SDK.
+   */
+  async deleteKeySigningKey(
+    command: simRoute53Commands.SimKeySigningKeyCommand,
+    options?: SimRoute53RequestOptions,
+  ): Promise<simRoute53Commands.SimKeySigningKeyCommandOutput> {
+    return await this.commands.dnssec.keySigningKeys.delete(command, options);
+  }
+
+  /**
+   * Handle an Enable Hosted Zone DNSSEC command from the SDK.
+   */
+  async enableHostedZoneDnssec(
+    command: simRoute53Commands.SimHostedZoneDnssecCommand,
+    options?: SimRoute53RequestOptions,
+  ): Promise<simRoute53Commands.SimHostedZoneDnssecCommandOutput> {
+    return await this.commands.dnssec.zoneSigning.enable(command, options);
+  }
+
+  /**
+   * Handle a Disable Hosted Zone DNSSEC command from the SDK.
+   */
+  async disableHostedZoneDnssec(
+    command: simRoute53Commands.SimHostedZoneDnssecCommand,
+    options?: SimRoute53RequestOptions,
+  ): Promise<simRoute53Commands.SimHostedZoneDnssecCommandOutput> {
+    return await this.commands.dnssec.zoneSigning.disable(command, options);
+  }
+
+  /**
+   * Handle a Get DNSSEC command from the SDK.
+   */
+  async getDnssec(
+    command: simRoute53Commands.SimGetDnssecCommand,
+    options?: SimRoute53RequestOptions,
+  ): Promise<simRoute53Commands.SimGetDnssecCommandOutput> {
+    return await this.commands.dnssec.zoneSigning.get(command, options);
   }
 
   /**

--- a/test/route53/dnssec-fixture.ts
+++ b/test/route53/dnssec-fixture.ts
@@ -1,0 +1,63 @@
+/**
+ * The arrangement the Route53 DNSSEC test files share: a hosted zone, and an
+ * ECC_NIST_P256 signing key in KMS for a key-signing key to be built on.
+ *
+ * It lives under `test/` for the same reasons as `test/kms/`: eslint rejects a
+ * test file that exports helpers alongside its own `describe` calls, and
+ * `test/**` is type-checked with everything else, excluded from the published
+ * build, not collected as a suite, and not counted in coverage.
+ */
+
+import { CreateKeyCommand } from "@aws-sdk/client-kms";
+import { CreateHostedZoneCommand } from "@aws-sdk/client-route-53";
+import { assertNonNullable } from "@kensio/smartass";
+
+import { SimAws } from "../../src/service/aws/sim-aws.js";
+
+/**
+ * The zone name the DNSSEC tests sign.
+ */
+export const simRoute53DnssecZoneName = "example.test";
+
+export interface SimRoute53DnssecFixture {
+  readonly simAws: SimAws;
+  readonly hostedZoneId: string;
+  readonly kmsKeyArn: string;
+}
+
+/**
+ * A hosted zone and a KMS signing key, ready for a key-signing key.
+ */
+export async function simRoute53DnssecFixture(): Promise<SimRoute53DnssecFixture> {
+  const simAws = new SimAws();
+
+  const zone = await simAws.route53().createHostedZone(
+    new CreateHostedZoneCommand({
+      Name: simRoute53DnssecZoneName,
+      CallerReference: "dnssec-zone",
+    }),
+  );
+  assertNonNullable(zone.HostedZone?.Id);
+
+  return {
+    simAws,
+    hostedZoneId: zone.HostedZone.Id,
+    kmsKeyArn: await simKmsSigningKeyArn(simAws),
+  };
+}
+
+/**
+ * An ECC_NIST_P256 signing key, which is the only kind Route53 will build a
+ * key-signing key on.
+ */
+export async function simKmsSigningKeyArn(simAws: SimAws): Promise<string> {
+  const key = await simAws.kms().createKey(
+    new CreateKeyCommand({
+      KeySpec: "ECC_NIST_P256",
+      KeyUsage: "SIGN_VERIFY",
+    }),
+  );
+  assertNonNullable(key.KeyMetadata);
+
+  return key.KeyMetadata.Arn;
+}

--- a/test/route53/dnssec-template.ts
+++ b/test/route53/dnssec-template.ts
@@ -1,0 +1,106 @@
+/**
+ * The CloudFormation template the Route53 DNSSEC tests deploy.
+ *
+ * It is the shape CDK synthesizes for a signed hosted zone, including the key
+ * policy statements the `KeySigningKey` construct adds for the
+ * `dnssec-route53.amazonaws.com` service principal, so what the tests deploy
+ * is what a real app's template holds rather than a tidied version of it.
+ *
+ * It lives under `test/` for the same reasons as `test/kms/`: eslint rejects a
+ * test file that exports helpers alongside its own `describe` calls, and
+ * `test/**` is type-checked with everything else, excluded from the published
+ * build, not collected as a suite, and not counted in coverage.
+ */
+
+import type { CfnTemplateBodyRecord } from "../../src/service/cloudformation/template/sim-cfn-template.js";
+import type { SimCfnTemplateValueRecord } from "../../src/service/cloudformation/template/value/sim-cfn-template-value.js";
+
+/**
+ * The account root the default key policy delegates to, as CDK writes it. Kept
+ * out of the policy literal because a `${...}` placeholder inside a plain
+ * string reads as a mistyped template literal.
+ */
+const accountRootArn = ["arn:aws:iam::$", "{AWS::AccountId}:root"].join("");
+
+/**
+ * The key policy CDK's KeySigningKey construct writes onto the signing key.
+ */
+function keyPolicy(): SimCfnTemplateValueRecord {
+  return {
+    Version: "2012-10-17",
+    Statement: [
+      {
+        Effect: "Allow",
+        Principal: { AWS: { "Fn::Sub": accountRootArn } },
+        Action: "kms:*",
+        Resource: "*",
+      },
+      {
+        Effect: "Allow",
+        Principal: { Service: "dnssec-route53.amazonaws.com" },
+        Action: ["kms:DescribeKey", "kms:GetPublicKey", "kms:Sign"],
+        Resource: "*",
+        Condition: {
+          ArnEquals: {
+            "aws:SourceArn": {
+              "Fn::Join": [
+                "",
+                ["arn:aws:route53:::hostedzone/", { Ref: "SiteZone" }],
+              ],
+            },
+          },
+        },
+      },
+      {
+        Effect: "Allow",
+        Principal: { Service: "dnssec-route53.amazonaws.com" },
+        Action: "kms:CreateGrant",
+        Resource: "*",
+        Condition: { Bool: { "kms:GrantIsForAWSResource": true } },
+      },
+    ],
+  };
+}
+
+/**
+ * A hosted zone, an ECC_NIST_P256 signing key, a key signing key naming that
+ * key, and DNSSEC signing for the zone.
+ */
+export function simCfnDnssecTemplate(): CfnTemplateBodyRecord {
+  return {
+    Resources: {
+      SiteZone: {
+        Type: "AWS::Route53::HostedZone",
+        Properties: { Name: "example.test" },
+      },
+      ZoneSigningKey: {
+        Type: "AWS::KMS::Key",
+        Properties: {
+          KeySpec: "ECC_NIST_P256",
+          KeyUsage: "SIGN_VERIFY",
+          KeyPolicy: keyPolicy(),
+        },
+      },
+      ZoneKeySigningKey: {
+        Type: "AWS::Route53::KeySigningKey",
+        Properties: {
+          HostedZoneId: { Ref: "SiteZone" },
+          KeyManagementServiceArn: { "Fn::GetAtt": ["ZoneSigningKey", "Arn"] },
+          Name: "zone_signing_key",
+          Status: "ACTIVE",
+        },
+      },
+      ZoneDnssec: {
+        Type: "AWS::Route53::DNSSEC",
+        Properties: { HostedZoneId: { Ref: "SiteZone" } },
+        DependsOn: "ZoneKeySigningKey",
+      },
+    },
+    Outputs: {
+      ZoneId: { Value: { Ref: "SiteZone" } },
+      SigningKeyArn: { Value: { "Fn::GetAtt": ["ZoneSigningKey", "Arn"] } },
+      KeySigningKeyId: { Value: { Ref: "ZoneKeySigningKey" } },
+      DnssecRef: { Value: { Ref: "ZoneDnssec" } },
+    },
+  };
+}


### PR DESCRIPTION
A KMS key can be created with `KeyUsage: SIGN_VERIFY`, and `Sign`, `Verify` and `GetPublicKey` do real cryptography with the key pair it holds: a signature made here verifies against the DER public key with any verifier, and one made over a different message does not. A Route53 hosted zone can be given a key-signing key built on such a key and have signing enabled, with `GetDNSSEC` reporting the key tag, digest and DS record derived from the KMS key's own public key rather than from anything invented. Both DNSSEC resource types deploy from CloudFormation and come off again on teardown, so the chineseboost stack that prompted this now deploys rather than failing on the key and silently skipping the rest.

Three things worth a decision. `MessageType: DIGEST` is refused rather than answered: Node cannot sign a digest that has already been computed, since `crypto.sign` with no algorithm hashes what it is given, so the signature would not be the one real KMS makes and would not verify against the message anywhere outside the simulator. The issue's acceptance criteria expected `DIGEST` to work, and it was moved to Out of scope once that came out. Second, the key tag and DS digest are checked against the published ECDSA P-256 example in RFC 6605 Appendix A.1, because self-consistency would not catch an algorithm that is wrong in the same way twice. Third, deleting a signed hosted zone is now refused, which real Route53 also refuses and the issue did not mention.

Resolves https://github.com/KensioSoftware/yulin/issues/570

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added simulated KMS asymmetric signing and verification with ECC/RSA keys, public-key retrieval, and supported signing algorithms.
  * Added simulated Route 53 DNSSEC, including key-signing-key lifecycle management, zone signing controls, DNSKEY/DS record generation, IAM authorization, and SDK operations.
  * Added CloudFormation support for Route 53 DNSSEC resources.
* **Bug Fixes**
  * Improved validation for unsupported key configurations, invalid signatures, DNSSEC states, and protected zone deletion.
* **Documentation**
  * Expanded KMS, Route 53, CloudFormation, and usage examples for signing and DNSSEC.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->