### PR TITLE
feat: register sim ECS task definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ npm i -D @kensio/yulin
 - [CloudFront](./docs/services/cloudfront "Simulated CloudFront docs")
 - [Cognito user pools](./docs/services/cognito "Simulated Cognito user pools docs")
 - [DynamoDB](./docs/services/dynamodb "Simulated DynamoDB docs")
+- [ECS](./docs/services/ecs "Simulated ECS docs")
 - [EventBridge](./docs/services/eventbridge "Simulated EventBridge docs")
 - [IAM](./docs/services/iam "Simulated IAM docs")
 - [KMS](./docs/services/kms "Simulated KMS docs")

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,7 @@ behaviour and includes example code that can be copied into tests or local devel
 - [CloudFront](./services/cloudfront/ "Simulated CloudFront usage docs")
 - [Cognito user pools](./services/cognito/ "Simulated Cognito user pools usage docs")
 - [DynamoDB](./services/dynamodb/ "Simulated DynamoDB usage docs")
+- [ECS](./services/ecs/ "Simulated ECS usage docs")
 - [EventBridge](./services/eventbridge/ "Simulated EventBridge usage docs")
 - [IAM](./services/iam/ "Simulated IAM usage docs")
 - [KMS](./services/kms/ "Simulated KMS usage docs")

--- a/docs/services/ecs/README.md
+++ b/docs/services/ecs/README.md
@@ -1,0 +1,481 @@
+# Simulated ECS
+
+Yulin includes a simulated Amazon ECS for tests and local development. It holds clusters and task
+definitions in memory, and every operation is authorized by simulated IAM.
+
+Nothing runs yet. Registering a task definition and describing it back is what this covers.
+
+ECS-specific types are imported from the `@kensio/yulin/ecs` subpath.
+
+## What Yulin does with a container image
+
+Yulin never looks inside a container image. It cannot: an image may hold a Go binary, nginx, Redis or
+anything else, and the only thing Yulin can run is JavaScript or TypeScript in its own process.
+
+So an image URI is only ever an identifier. It is what a container will be matched on when a task is
+run, in the same way an image URI identifies a container image Lambda function. A container matched
+to a handler runs it. A container with no match does not run, and is recorded as not simulated rather
+than failing anything.
+
+A realistic task definition holds an application container, a log router and an observability agent.
+Only the first of those is something Yulin could ever run, and the other two are stored and reported
+back exactly as declared.
+
+Where this does not work is a sidecar the application depends on, such as a Redis or a database in
+the same task. Yulin does not simulate that. The connection details are ordinary environment
+variables, so point them at a real one you run yourself.
+
+## Registering a task definition
+
+`RegisterTaskDefinition` stores a revision under its family. Revisions number from one and go up by
+one with each registration.
+
+```typescript sim-ecs-register-task-definition
+/**
+ * Registering a simulated task definition and reading it back.
+ */
+
+import {
+  DescribeTaskDefinitionCommand,
+  RegisterTaskDefinitionCommand,
+} from "@aws-sdk/client-ecs";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const ecs = simAws.ecs();
+
+await ecs.registerTaskDefinition(
+  new RegisterTaskDefinitionCommand({
+    family: "checkout",
+    cpu: "512",
+    memory: "1024",
+    networkMode: "awsvpc",
+    requiresCompatibilities: ["FARGATE"],
+    containerDefinitions: [
+      {
+        name: "app",
+        image: "example.dkr.ecr.eu-west-2.amazonaws.com/checkout:1",
+        essential: true,
+        portMappings: [{ containerPort: 8080, protocol: "tcp" }],
+        environment: [{ name: "LOG_LEVEL", value: "debug" }],
+      },
+    ],
+  }),
+);
+
+const described = await ecs.describeTaskDefinition(
+  new DescribeTaskDefinitionCommand({ taskDefinition: "checkout" }),
+);
+
+console.log(described.taskDefinition?.revision); // 1
+console.log(described.taskDefinition?.status); // "ACTIVE"
+console.log(described.taskDefinition?.containerDefinitions?.[0]?.image);
+// "example.dkr.ecr.eu-west-2.amazonaws.com/checkout:1"
+```
+
+Container definitions are stored as declared, whatever the image is and whether or not Yulin could
+ever run it. That includes port mappings, environment variables and secrets: a `valueFrom` naming a
+Secrets Manager secret is held as the identifier it is, since nothing resolves it.
+
+A registration is refused rather than trimmed if it declares something this simulation does not hold.
+That way a declaration cannot go missing from the revision it made.
+
+## Revisions
+
+Each registration of a family takes the next revision number. Naming the family alone means its
+latest active revision, so it follows registrations as they are made.
+
+```typescript sim-ecs-task-definition-revisions
+/**
+ * Registering a second revision of a simulated task definition family.
+ */
+
+import {
+  DescribeTaskDefinitionCommand,
+  RegisterTaskDefinitionCommand,
+} from "@aws-sdk/client-ecs";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const ecs = simAws.ecs();
+
+for (const tag of ["checkout:1", "checkout:2"]) {
+  await ecs.registerTaskDefinition(
+    new RegisterTaskDefinitionCommand({
+      family: "checkout",
+      containerDefinitions: [{ name: "app", image: tag }],
+    }),
+  );
+}
+
+const latest = await ecs.describeTaskDefinition(
+  new DescribeTaskDefinitionCommand({ taskDefinition: "checkout" }),
+);
+
+console.log(latest.taskDefinition?.revision); // 2
+
+const first = await ecs.describeTaskDefinition(
+  new DescribeTaskDefinitionCommand({ taskDefinition: "checkout:1" }),
+);
+
+console.log(first.taskDefinition?.containerDefinitions?.[0]?.image);
+// "checkout:1"
+```
+
+`DescribeTaskDefinition` takes all three forms ECS takes: a family, a `family:revision`, and a full
+task definition ARN. The ARN of a revision is
+`arn:aws:ecs:<region>:<account>:task-definition/<family>:<revision>`.
+
+## Deregistering a revision
+
+`DeregisterTaskDefinition` marks one revision `INACTIVE` without removing it. It stays describable by
+`family:revision` and by ARN, because something already holding either of those still needs to find
+out what it declared. What it stops being is the revision the family resolves to.
+
+```typescript sim-ecs-deregister-task-definition
+/**
+ * Deregistering a simulated task definition revision.
+ */
+
+import {
+  DeregisterTaskDefinitionCommand,
+  DescribeTaskDefinitionCommand,
+  RegisterTaskDefinitionCommand,
+} from "@aws-sdk/client-ecs";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const ecs = simAws.ecs();
+
+for (const tag of ["checkout:1", "checkout:2"]) {
+  await ecs.registerTaskDefinition(
+    new RegisterTaskDefinitionCommand({
+      family: "checkout",
+      containerDefinitions: [{ name: "app", image: tag }],
+    }),
+  );
+}
+
+await ecs.deregisterTaskDefinition(
+  new DeregisterTaskDefinitionCommand({ taskDefinition: "checkout:2" }),
+);
+
+const deregistered = await ecs.describeTaskDefinition(
+  new DescribeTaskDefinitionCommand({ taskDefinition: "checkout:2" }),
+);
+
+console.log(deregistered.taskDefinition?.status); // "INACTIVE"
+
+const latest = await ecs.describeTaskDefinition(
+  new DescribeTaskDefinitionCommand({ taskDefinition: "checkout" }),
+);
+
+console.log(latest.taskDefinition?.revision); // 1
+```
+
+Deregistering must name one revision, as it must on real ECS. A family on its own is refused.
+
+Revision numbers are never reused. Registering the family again after deregistering revision 2 gives
+revision 3.
+
+## Listing task definitions
+
+`ListTaskDefinitions` reports revision ARNs and `ListTaskDefinitionFamilies` reports family names.
+Both list what is active unless the request asks otherwise, and both take a `familyPrefix`.
+
+```typescript sim-ecs-list-task-definitions
+/**
+ * Listing simulated task definition revisions and families.
+ */
+
+import {
+  ListTaskDefinitionFamiliesCommand,
+  ListTaskDefinitionsCommand,
+  RegisterTaskDefinitionCommand,
+} from "@aws-sdk/client-ecs";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const ecs = simAws.ecs();
+
+for (const family of ["checkout", "billing"]) {
+  await ecs.registerTaskDefinition(
+    new RegisterTaskDefinitionCommand({
+      family,
+      containerDefinitions: [{ name: "app", image: `${family}:1` }],
+    }),
+  );
+}
+
+const revisions = await ecs.listTaskDefinitions(
+  new ListTaskDefinitionsCommand({ familyPrefix: "check" }),
+);
+
+console.log(revisions.taskDefinitionArns?.length); // 1
+
+const families = await ecs.listTaskDefinitionFamilies(
+  new ListTaskDefinitionFamiliesCommand({}),
+);
+
+console.log(families.families); // ["checkout", "billing"]
+```
+
+A family counts as inactive once every one of its revisions has been deregistered.
+`ListTaskDefinitionFamilies` takes `ACTIVE`, `INACTIVE` and `ALL`, and `ListTaskDefinitions` takes
+`ACTIVE` and `INACTIVE` along with a `sort` of `ASC` or `DESC`.
+
+## Clusters
+
+A cluster is a named scope for the tasks and services that will run in it. `CreateCluster`,
+`DescribeClusters`, `ListClusters` and `DeleteCluster` hold them.
+
+```typescript sim-ecs-clusters
+/**
+ * Creating and describing a simulated ECS cluster.
+ */
+
+import {
+  CreateClusterCommand,
+  DescribeClustersCommand,
+  ListClustersCommand,
+} from "@aws-sdk/client-ecs";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const ecs = simAws.ecs();
+
+await ecs.createCluster(
+  new CreateClusterCommand({
+    clusterName: "services",
+    settings: [{ name: "containerInsights", value: "enabled" }],
+    tags: [{ key: "team", value: "platform" }],
+  }),
+);
+
+const described = await ecs.describeClusters(
+  new DescribeClustersCommand({
+    clusters: ["services"],
+    include: ["SETTINGS", "TAGS"],
+  }),
+);
+
+console.log(described.clusters?.[0]?.status); // "ACTIVE"
+console.log(described.clusters?.[0]?.runningTasksCount); // 0
+console.log(described.clusters?.[0]?.tags?.[0]?.key); // "team"
+
+const listed = await ecs.listClusters(new ListClustersCommand({}));
+
+console.log(listed.clusterArns?.[0]);
+// "arn:aws:ecs:us-east-1:888888888888:cluster/services"
+```
+
+Settings, configuration and tags are reported only where the request asked for them by name, as they
+are on real ECS. A request naming no cluster means the `default` cluster.
+
+`DeleteCluster` marks a cluster `INACTIVE`. It stays describable and drops out of `ListClusters`, and
+creating a cluster of the same name again makes a new active one.
+
+A cluster is named either by its short name or by its full ARN, and the two are interchangeable. An
+ARN belonging to another account or region names a different cluster, so `DescribeClusters` reports
+it as a `MISSING` failure and `DeleteCluster` refuses it.
+
+## Authorization
+
+Every operation is authorized by simulated IAM against the real ECS action.
+
+Real ECS gives the task definition operations no resource type at all, and gives `CreateCluster` and
+`ListClusters` none either, so all of those authorize against `*`. A policy naming a task definition
+ARN grants nothing, here as on AWS. `DescribeClusters` and `DeleteCluster` are the two that do take
+a resource, which is the cluster's ARN.
+
+```typescript sim-ecs-iam-policy
+/**
+ * A simulated IAM policy allowing a Role to register task definitions.
+ */
+
+import { RegisterTaskDefinitionCommand } from "@aws-sdk/client-ecs";
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const accountId = simAws.defaultAccountId;
+
+const role = await simAws.iam().createRole(
+  new CreateRoleCommand({
+    RoleName: "Deployer",
+    AssumeRolePolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Principal: { AWS: `arn:aws:iam::${accountId}:root` },
+        Action: "sts:AssumeRole",
+      },
+    }),
+  }),
+);
+
+await simAws.iam().putRolePolicy(
+  new PutRolePolicyCommand({
+    RoleName: "Deployer",
+    PolicyName: "RegisterTaskDefinitions",
+    PolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Action: "ecs:RegisterTaskDefinition",
+        // ECS gives this action no resource type, so only `*` grants it.
+        Resource: "*",
+      },
+    }),
+  }),
+);
+
+const registered = await simAws.ecs().registerTaskDefinition(
+  new RegisterTaskDefinitionCommand({
+    family: "checkout",
+    containerDefinitions: [{ name: "app", image: "checkout:1" }],
+  }),
+  { caller: { kind: "arn", arn: role.Role.Arn } },
+);
+
+console.log(registered.taskDefinition?.registeredBy); // the Role ARN
+```
+
+A registered revision records the caller that registered it as `registeredBy`, as real ECS does.
+
+## Scoping by account and region
+
+Clusters and task definitions belong to one account and region. A family registered in one region
+has its own revision numbering and its own ARNs.
+
+```typescript sim-ecs-scoping
+/**
+ * Simulated ECS state in two account and region scopes.
+ */
+
+import {
+  ListTaskDefinitionsCommand,
+  RegisterTaskDefinitionCommand,
+} from "@aws-sdk/client-ecs";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+const registered = await simAws
+  .account("222222222222")
+  .region("us-east-1")
+  .ecs()
+  .registerTaskDefinition(
+    new RegisterTaskDefinitionCommand({
+      family: "checkout",
+      containerDefinitions: [{ name: "app", image: "checkout:1" }],
+    }),
+  );
+
+console.log(registered.taskDefinition?.taskDefinitionArn);
+// "arn:aws:ecs:us-east-1:222222222222:task-definition/checkout:1"
+
+const elsewhere = await simAws
+  .account("222222222222")
+  .region("eu-west-2")
+  .ecs()
+  .listTaskDefinitions(new ListTaskDefinitionsCommand({}));
+
+console.log(elsewhere.taskDefinitionArns?.length); // 0
+```
+
+## Using it through an ECS SDK client
+
+Ordinary SDK code reaches simulated ECS through `SimSdk`, without a Yulin type appearing in the code
+under test.
+
+```typescript sim-ecs-sdk-interception
+/**
+ * Reaching simulated ECS through an intercepted ECS SDK client.
+ */
+
+import {
+  DescribeTaskDefinitionCommand,
+  ECSClient,
+  RegisterTaskDefinitionCommand,
+} from "@aws-sdk/client-ecs";
+
+import { SimSdk } from "@kensio/yulin/sdk";
+
+using simSdk = new SimSdk();
+simSdk.intercept(ECSClient);
+
+const ecs = new ECSClient({ region: "eu-west-2" });
+
+await ecs.send(
+  new RegisterTaskDefinitionCommand({
+    family: "checkout",
+    containerDefinitions: [{ name: "app", image: "checkout:1" }],
+  }),
+);
+
+const described = await ecs.send(
+  new DescribeTaskDefinitionCommand({ taskDefinition: "checkout" }),
+);
+
+console.log(described.taskDefinition?.revision); // 1
+```
+
+## Available functionality
+
+- `RegisterTaskDefinitionCommand`, with revisions numbered per family from one
+- `DeregisterTaskDefinitionCommand`, marking one revision `INACTIVE`
+- `DescribeTaskDefinitionCommand`, taking a family, a `family:revision` or a full ARN
+- `ListTaskDefinitionsCommand` and `ListTaskDefinitionFamiliesCommand`, with prefix, status and
+  paging
+- `CreateClusterCommand`, `DescribeClustersCommand`, `ListClustersCommand` and `DeleteClusterCommand`
+- Container definitions stored and reported as declared, whatever their image
+- Task definition tags, reported under `include: ["TAGS"]`
+- Cluster settings, configuration and tags, reported under their matching `include` values
+- Authorization of every operation by simulated IAM, against the real IAM action and resource
+- Clusters and task definitions scoped by account and region
+- ECS SDK clients intercepted by `SimSdk`
+
+## Limitations
+
+Current documented limitations:
+
+- Image contents are never read. An image URI is an identifier and nothing else, so no image is
+  pulled, inspected or run, and a tag that does not exist on any registry is stored without
+  complaint.
+- Nothing runs. `RunTask`, `StartTask`, `StopTask`, `DescribeTasks`, `ListTasks` and the whole of the
+  service API (`CreateService`, `UpdateService`, `DescribeServices`) are not simulated.
+- A described task definition reports neither `compatibilities` nor `requiresAttributes`. Real ECS
+  works both out from what the definition declares, which would mean reading a container
+  definition's meaning.
+- `RegisterTaskDefinition` refuses a setting this simulation does not hold, rather than dropping it.
+  `inferenceAccelerators` and `enableFaultInjection` are refused for that reason.
+- Nothing is defaulted. A revision registered without `networkMode` describes without one, rather
+  than reporting the `bridge` real ECS would have chosen, because that value would be made up here.
+- `CreateCluster` refuses `capacityProviders`, `defaultCapacityProviderStrategy` and
+  `serviceConnectDefaults`. There is no capacity and no service discovery here to attach them to.
+- `DescribeClusters` refuses `include` values of `ATTACHMENTS` and `STATISTICS`, and always reports
+  zero for every count. A simulated task runs in this process rather than on an instance, so there
+  is nothing to count.
+- `ListClusters` leaves out a deleted cluster, which is still describable by name or ARN as
+  `INACTIVE`.
+- `CreateCluster` with a name an active cluster already has hands that cluster back rather than
+  raising, as real ECS does. The settings, configuration and tags on the second request are ignored.
+- Deleting a cluster is immediate, and never fails for a cluster holding tasks or services, because
+  there are none to hold.
+- Task definition and cluster tags are stored and reported, but `TagResource`,
+  `UntagResource` and `ListTagsForResource` are not simulated.
+- There are no ECS CloudFormation resource types yet. `AWS::ECS::Cluster` and
+  `AWS::ECS::TaskDefinition` are reported as unsupported and skipped rather than deployed.
+- Cluster and family names are validated to the 255 letters, numbers, hyphens and underscores real
+  ECS accepts, but error messages differ from the real ones.
+- Account-wide limits do not exist, so no request fails for having registered too many task
+  definitions or created too many clusters.
+- ECS is not served as an HTTP API by `serveSimAws`.

--- a/docs/services/ecs/README.md
+++ b/docs/services/ecs/README.md
@@ -12,14 +12,15 @@ ECS-specific types are imported from the `@kensio/yulin/ecs` subpath.
 Yulin never looks inside a container image. It cannot: an image may hold a Go binary, nginx, Redis or
 anything else, and the only thing Yulin can run is JavaScript or TypeScript in its own process.
 
-So an image URI is only ever an identifier. It is what a container will be matched on when a task is
-run, in the same way an image URI identifies a container image Lambda function. A container matched
-to a handler runs it. A container with no match does not run, and is recorded as not simulated rather
-than failing anything.
+So an image URI is only ever an identifier. Nothing here reads it, pulls it, or runs anything from
+it. It is stored as declared, and it is what a container will be matched on once running a task
+arrives, in the same way an image URI identifies a container image Lambda function. The rule that
+will follow from it is that a container matched to a handler will run that handler, and a container
+with no match will be recorded as not simulated rather than failing anything.
 
 A realistic task definition holds an application container, a log router and an observability agent.
-Only the first of those is something Yulin could ever run, and the other two are stored and reported
-back exactly as declared.
+Only the first of those is something Yulin could ever run, and all three are stored and reported back
+exactly as declared.
 
 Where this does not work is a sidecar the application depends on, such as a Redis or a database in
 the same task. Yulin does not simulate that. The connection details are ordinary environment
@@ -184,7 +185,9 @@ revision 3.
 ## Listing task definitions
 
 `ListTaskDefinitions` reports revision ARNs and `ListTaskDefinitionFamilies` reports family names.
-Both list what is active unless the request asks otherwise, and both take a `familyPrefix`.
+Both take a `familyPrefix`. A `ListTaskDefinitions` request saying nothing about status gets the
+active revisions, while a `ListTaskDefinitionFamilies` request saying nothing gets both the active
+and the inactive families, which is how real ECS defaults each of them.
 
 ```typescript sim-ecs-list-task-definitions
 /**
@@ -278,7 +281,9 @@ Settings, configuration and tags are reported only where the request asked for t
 are on real ECS. A request naming no cluster means the `default` cluster.
 
 `DeleteCluster` marks a cluster `INACTIVE`. It stays describable and drops out of `ListClusters`, and
-creating a cluster of the same name again makes a new active one.
+creating a cluster of the same name again makes a new active one, listed in the position it was
+created in. Unlike the operations that read a cluster, `DeleteCluster` needs one to be named: a
+request naming none is refused rather than taken as meaning the `default` cluster.
 
 A cluster is named either by its short name or by its full ARN, and the two are interchangeable. An
 ARN belonging to another account or region names a different cluster, so `DescribeClusters` reports
@@ -450,6 +455,13 @@ Current documented limitations:
 - Image contents are never read. An image URI is an identifier and nothing else, so no image is
   pulled, inspected or run, and a tag that does not exist on any registry is stored without
   complaint.
+- A container definition field the `SimEcsContainerDefinitionType` shape does not name, such as
+  `hostname` or `links`, is still stored and reported back. The shape names the fields the docs
+  describe rather than every field ECS has, and it deliberately carries no index signature, since
+  one would stop a real SDK command input being passed straight in.
+- `ListTaskDefinitions` refuses a `status` of `DELETE_IN_PROGRESS`, which real ECS accepts. Nothing
+  deletes a task definition here, so the answer would always be an empty listing, and refusing says
+  so rather than looking like a result.
 - Nothing runs. `RunTask`, `StartTask`, `StopTask`, `DescribeTasks`, `ListTasks` and the whole of the
   service API (`CreateService`, `UpdateService`, `DescribeServices`) are not simulated.
 - A described task definition reports neither `compatibilities` nor `requiresAttributes`. Real ECS

--- a/docs/services/ecs/sim-ecs-clusters.example.ts
+++ b/docs/services/ecs/sim-ecs-clusters.example.ts
@@ -1,0 +1,38 @@
+/**
+ * Creating and describing a simulated ECS cluster.
+ */
+
+import {
+  CreateClusterCommand,
+  DescribeClustersCommand,
+  ListClustersCommand,
+} from "@aws-sdk/client-ecs";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const ecs = simAws.ecs();
+
+await ecs.createCluster(
+  new CreateClusterCommand({
+    clusterName: "services",
+    settings: [{ name: "containerInsights", value: "enabled" }],
+    tags: [{ key: "team", value: "platform" }],
+  }),
+);
+
+const described = await ecs.describeClusters(
+  new DescribeClustersCommand({
+    clusters: ["services"],
+    include: ["SETTINGS", "TAGS"],
+  }),
+);
+
+console.log(described.clusters?.[0]?.status); // "ACTIVE"
+console.log(described.clusters?.[0]?.runningTasksCount); // 0
+console.log(described.clusters?.[0]?.tags?.[0]?.key); // "team"
+
+const listed = await ecs.listClusters(new ListClustersCommand({}));
+
+console.log(listed.clusterArns?.[0]);
+// "arn:aws:ecs:us-east-1:888888888888:cluster/services"

--- a/docs/services/ecs/sim-ecs-deregister-task-definition.example.ts
+++ b/docs/services/ecs/sim-ecs-deregister-task-definition.example.ts
@@ -1,0 +1,39 @@
+/**
+ * Deregistering a simulated task definition revision.
+ */
+
+import {
+  DeregisterTaskDefinitionCommand,
+  DescribeTaskDefinitionCommand,
+  RegisterTaskDefinitionCommand,
+} from "@aws-sdk/client-ecs";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const ecs = simAws.ecs();
+
+for (const tag of ["checkout:1", "checkout:2"]) {
+  await ecs.registerTaskDefinition(
+    new RegisterTaskDefinitionCommand({
+      family: "checkout",
+      containerDefinitions: [{ name: "app", image: tag }],
+    }),
+  );
+}
+
+await ecs.deregisterTaskDefinition(
+  new DeregisterTaskDefinitionCommand({ taskDefinition: "checkout:2" }),
+);
+
+const deregistered = await ecs.describeTaskDefinition(
+  new DescribeTaskDefinitionCommand({ taskDefinition: "checkout:2" }),
+);
+
+console.log(deregistered.taskDefinition?.status); // "INACTIVE"
+
+const latest = await ecs.describeTaskDefinition(
+  new DescribeTaskDefinitionCommand({ taskDefinition: "checkout" }),
+);
+
+console.log(latest.taskDefinition?.revision); // 1

--- a/docs/services/ecs/sim-ecs-iam-policy.example.ts
+++ b/docs/services/ecs/sim-ecs-iam-policy.example.ts
@@ -1,0 +1,51 @@
+/**
+ * A simulated IAM policy allowing a Role to register task definitions.
+ */
+
+import { RegisterTaskDefinitionCommand } from "@aws-sdk/client-ecs";
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const accountId = simAws.defaultAccountId;
+
+const role = await simAws.iam().createRole(
+  new CreateRoleCommand({
+    RoleName: "Deployer",
+    AssumeRolePolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Principal: { AWS: `arn:aws:iam::${accountId}:root` },
+        Action: "sts:AssumeRole",
+      },
+    }),
+  }),
+);
+
+await simAws.iam().putRolePolicy(
+  new PutRolePolicyCommand({
+    RoleName: "Deployer",
+    PolicyName: "RegisterTaskDefinitions",
+    PolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Action: "ecs:RegisterTaskDefinition",
+        // ECS gives this action no resource type, so only `*` grants it.
+        Resource: "*",
+      },
+    }),
+  }),
+);
+
+const registered = await simAws.ecs().registerTaskDefinition(
+  new RegisterTaskDefinitionCommand({
+    family: "checkout",
+    containerDefinitions: [{ name: "app", image: "checkout:1" }],
+  }),
+  { caller: { kind: "arn", arn: role.Role.Arn } },
+);
+
+console.log(registered.taskDefinition?.registeredBy); // the Role ARN

--- a/docs/services/ecs/sim-ecs-list-task-definitions.example.ts
+++ b/docs/services/ecs/sim-ecs-list-task-definitions.example.ts
@@ -1,0 +1,35 @@
+/**
+ * Listing simulated task definition revisions and families.
+ */
+
+import {
+  ListTaskDefinitionFamiliesCommand,
+  ListTaskDefinitionsCommand,
+  RegisterTaskDefinitionCommand,
+} from "@aws-sdk/client-ecs";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const ecs = simAws.ecs();
+
+for (const family of ["checkout", "billing"]) {
+  await ecs.registerTaskDefinition(
+    new RegisterTaskDefinitionCommand({
+      family,
+      containerDefinitions: [{ name: "app", image: `${family}:1` }],
+    }),
+  );
+}
+
+const revisions = await ecs.listTaskDefinitions(
+  new ListTaskDefinitionsCommand({ familyPrefix: "check" }),
+);
+
+console.log(revisions.taskDefinitionArns?.length); // 1
+
+const families = await ecs.listTaskDefinitionFamilies(
+  new ListTaskDefinitionFamiliesCommand({}),
+);
+
+console.log(families.families); // ["checkout", "billing"]

--- a/docs/services/ecs/sim-ecs-register-task-definition.example.ts
+++ b/docs/services/ecs/sim-ecs-register-task-definition.example.ts
@@ -1,0 +1,41 @@
+/**
+ * Registering a simulated task definition and reading it back.
+ */
+
+import {
+  DescribeTaskDefinitionCommand,
+  RegisterTaskDefinitionCommand,
+} from "@aws-sdk/client-ecs";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const ecs = simAws.ecs();
+
+await ecs.registerTaskDefinition(
+  new RegisterTaskDefinitionCommand({
+    family: "checkout",
+    cpu: "512",
+    memory: "1024",
+    networkMode: "awsvpc",
+    requiresCompatibilities: ["FARGATE"],
+    containerDefinitions: [
+      {
+        name: "app",
+        image: "example.dkr.ecr.eu-west-2.amazonaws.com/checkout:1",
+        essential: true,
+        portMappings: [{ containerPort: 8080, protocol: "tcp" }],
+        environment: [{ name: "LOG_LEVEL", value: "debug" }],
+      },
+    ],
+  }),
+);
+
+const described = await ecs.describeTaskDefinition(
+  new DescribeTaskDefinitionCommand({ taskDefinition: "checkout" }),
+);
+
+console.log(described.taskDefinition?.revision); // 1
+console.log(described.taskDefinition?.status); // "ACTIVE"
+console.log(described.taskDefinition?.containerDefinitions?.[0]?.image);
+// "example.dkr.ecr.eu-west-2.amazonaws.com/checkout:1"

--- a/docs/services/ecs/sim-ecs-scoping.example.ts
+++ b/docs/services/ecs/sim-ecs-scoping.example.ts
@@ -1,0 +1,34 @@
+/**
+ * Simulated ECS state in two account and region scopes.
+ */
+
+import {
+  ListTaskDefinitionsCommand,
+  RegisterTaskDefinitionCommand,
+} from "@aws-sdk/client-ecs";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+const registered = await simAws
+  .account("222222222222")
+  .region("us-east-1")
+  .ecs()
+  .registerTaskDefinition(
+    new RegisterTaskDefinitionCommand({
+      family: "checkout",
+      containerDefinitions: [{ name: "app", image: "checkout:1" }],
+    }),
+  );
+
+console.log(registered.taskDefinition?.taskDefinitionArn);
+// "arn:aws:ecs:us-east-1:222222222222:task-definition/checkout:1"
+
+const elsewhere = await simAws
+  .account("222222222222")
+  .region("eu-west-2")
+  .ecs()
+  .listTaskDefinitions(new ListTaskDefinitionsCommand({}));
+
+console.log(elsewhere.taskDefinitionArns?.length); // 0

--- a/docs/services/ecs/sim-ecs-sdk-interception.example.ts
+++ b/docs/services/ecs/sim-ecs-sdk-interception.example.ts
@@ -1,0 +1,29 @@
+/**
+ * Reaching simulated ECS through an intercepted ECS SDK client.
+ */
+
+import {
+  DescribeTaskDefinitionCommand,
+  ECSClient,
+  RegisterTaskDefinitionCommand,
+} from "@aws-sdk/client-ecs";
+
+import { SimSdk } from "@kensio/yulin/sdk";
+
+using simSdk = new SimSdk();
+simSdk.intercept(ECSClient);
+
+const ecs = new ECSClient({ region: "eu-west-2" });
+
+await ecs.send(
+  new RegisterTaskDefinitionCommand({
+    family: "checkout",
+    containerDefinitions: [{ name: "app", image: "checkout:1" }],
+  }),
+);
+
+const described = await ecs.send(
+  new DescribeTaskDefinitionCommand({ taskDefinition: "checkout" }),
+);
+
+console.log(described.taskDefinition?.revision); // 1

--- a/docs/services/ecs/sim-ecs-task-definition-revisions.example.ts
+++ b/docs/services/ecs/sim-ecs-task-definition-revisions.example.ts
@@ -1,0 +1,35 @@
+/**
+ * Registering a second revision of a simulated task definition family.
+ */
+
+import {
+  DescribeTaskDefinitionCommand,
+  RegisterTaskDefinitionCommand,
+} from "@aws-sdk/client-ecs";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const ecs = simAws.ecs();
+
+for (const tag of ["checkout:1", "checkout:2"]) {
+  await ecs.registerTaskDefinition(
+    new RegisterTaskDefinitionCommand({
+      family: "checkout",
+      containerDefinitions: [{ name: "app", image: tag }],
+    }),
+  );
+}
+
+const latest = await ecs.describeTaskDefinition(
+  new DescribeTaskDefinitionCommand({ taskDefinition: "checkout" }),
+);
+
+console.log(latest.taskDefinition?.revision); // 2
+
+const first = await ecs.describeTaskDefinition(
+  new DescribeTaskDefinitionCommand({ taskDefinition: "checkout:1" }),
+);
+
+console.log(first.taskDefinition?.containerDefinitions?.[0]?.image);
+// "checkout:1"

--- a/package.json
+++ b/package.json
@@ -70,6 +70,10 @@
       "import": "./dist/service/dynamodb/index.js",
       "types": "./dist/service/dynamodb/index.d.ts"
     },
+    "./ecs": {
+      "import": "./dist/service/ecs/index.js",
+      "types": "./dist/service/ecs/index.d.ts"
+    },
     "./eslint": {
       "import": "./dist/config/eslint/index.js",
       "types": "./dist/config/eslint/index.d.ts"
@@ -159,6 +163,7 @@
     "@aws-sdk/client-cognito-identity-provider": "^3.1101.0",
     "@aws-sdk/client-dynamodb": "^3.1101.0",
     "@aws-sdk/client-dynamodb-streams": "^3.1101.0",
+    "@aws-sdk/client-ecs": "^3.1101.0",
     "@aws-sdk/client-eventbridge": "^3.1109.0",
     "@aws-sdk/client-iam": "^3.1101.0",
     "@aws-sdk/client-kms": "^3.1101.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,6 +45,9 @@ importers:
       '@aws-sdk/client-dynamodb-streams':
         specifier: ^3.1101.0
         version: 3.1105.0
+      '@aws-sdk/client-ecs':
+        specifier: ^3.1101.0
+        version: 3.1109.0
       '@aws-sdk/client-eventbridge':
         specifier: ^3.1109.0
         version: 3.1109.0
@@ -252,6 +255,10 @@ packages:
 
   '@aws-sdk/client-dynamodb@3.1105.0':
     resolution: {integrity: sha512-CNtPFuLR3wn1U7cH1svRuouWl2VO+uP/LOUpNlhJe4rkPSBr8Y6eMmsWPwkIGAsASAN7ChyJ7ZJHtJ+aLZl9Hw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/client-ecs@3.1109.0':
+    resolution: {integrity: sha512-1r7K8jdDnFEaS0CvgkUPSlr0Sh8BGgHITzER6xWNDqe160gxSWmCwzhRJzRCKiSdN4CzRhOLsJaSHlRpeh1Fiw==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/client-eventbridge@3.1109.0':
@@ -3473,6 +3480,17 @@ snapshots:
       '@aws-sdk/credential-provider-node': 3.972.79
       '@aws-sdk/dynamodb-codec': 3.973.42
       '@aws-sdk/middleware-endpoint-discovery': 3.972.28
+      '@aws-sdk/types': 3.974.3
+      '@smithy/core': 3.32.0
+      '@smithy/fetch-http-handler': 5.7.0
+      '@smithy/node-http-handler': 4.10.0
+      '@smithy/types': 4.17.0
+      tslib: 2.8.1
+
+  '@aws-sdk/client-ecs@3.1109.0':
+    dependencies:
+      '@aws-sdk/core': 3.977.7
+      '@aws-sdk/credential-provider-node': 3.972.79
       '@aws-sdk/types': 3.974.3
       '@smithy/core': 3.32.0
       '@smithy/fetch-http-handler': 5.7.0

--- a/src/sdk/router/resolve-sim-sdk-command-router.ts
+++ b/src/sdk/router/resolve-sim-sdk-command-router.ts
@@ -59,6 +59,7 @@ const scopedRouters: ReadonlyMap<string, SimSdkScopedRouter> = new Map<
     (scoped): SimSdkCommandRouter =>
       scoped.dynamoDbStreams().sdkCommandRouter(),
   ],
+  ["ECS", (scoped): SimSdkCommandRouter => scoped.ecs().sdkCommandRouter()],
   [
     "EventBridge",
     (scoped): SimSdkCommandRouter => scoped.eventBridge().sdkCommandRouter(),

--- a/src/service/aws/factory/sim-aws-account-region-service-builder.ts
+++ b/src/service/aws/factory/sim-aws-account-region-service-builder.ts
@@ -16,6 +16,7 @@ import { SimCloudFormation } from "../../cloudformation/index.js";
 import { SimCognitoIdentityProvider } from "../../cognito/index.js";
 import { simAwsCognitoTriggerFunctions } from "../../cognito/user-pool/trigger/sim-aws-cognito-trigger-functions.js";
 import { SimDynamoDb as SimDynamoDatabase } from "../../dynamodb/index.js";
+import { SimEcs } from "../../ecs/index.js";
 import { SimEventBridge } from "../../eventbridge/index.js";
 import type { SimIamRegistry } from "../../iam/registry/sim-iam-registry.js";
 import { SimKms } from "../../kms/index.js";
@@ -141,6 +142,11 @@ export class SimAwsAccountRegionServiceBuilder {
   /** Create simulated DynamoDB for an Account Region scope. */
   createDynamoDb(scope: SimAwsAccountRegionContainer): SimDynamoDatabase {
     return new SimDynamoDatabase(this.scoped(scope));
+  }
+
+  /** Create simulated ECS for an Account Region scope. */
+  createEcs(scope: SimAwsAccountRegionContainer): SimEcs {
+    return new SimEcs(this.scoped(scope));
   }
 
   /**
@@ -282,17 +288,10 @@ export class SimAwsAccountRegionServiceBuilder {
 
   /**
    * The collaborators every service built here takes.
-   *
-   * Reaching for the Account's IAM through the same cache the factory uses is
-   * what makes a Region's services decide against the one IAM its Account owns.
    */
   private scoped(
     scope: SimAwsAccountRegionContainer,
   ): SimAwsScopedServiceProperties {
-    return {
-      accountRegionScope: scope.accountRegionScope,
-      iam: this.accountServices.createIam(scope),
-      background: this.background,
-    };
+    return this.accountServices.scopedServiceProperties(scope);
   }
 }

--- a/src/service/aws/factory/sim-aws-account-service-cache.ts
+++ b/src/service/aws/factory/sim-aws-account-service-cache.ts
@@ -21,6 +21,7 @@ import type { SimAwsServiceHosts } from "../../../serve/controller/host/sim-aws-
 import { SimIamCredentialRegistry } from "../../iam/credential/sim-iam-credential-registry.js";
 import { Memo } from "../../../util/memo/memo.js";
 import { accountServiceCacheKey } from "./account-service-cache-key.js";
+import type { SimAwsScopedServiceProperties } from "./sim-aws-scoped-service-properties.js";
 
 interface SimAwsAccountServiceCacheProperties {
   readonly simAws: SimAws;
@@ -82,6 +83,23 @@ export class SimAwsAccountServiceCache {
     this.accessKeyRegistry = properties.accessKeyRegistry;
     this.route53Registry = properties.route53Registry;
     this.serviceHosts = properties.serviceHosts;
+  }
+
+  /**
+   * The collaborators every Account/Region scoped service takes.
+   *
+   * It is assembled here because the IAM in it is the Account's one IAM, which
+   * is what makes a Region's services decide against it rather than against
+   * one of their own.
+   */
+  scopedServiceProperties(
+    scope: SimAwsAccountRegionContainer,
+  ): SimAwsScopedServiceProperties {
+    return {
+      accountRegionScope: scope.accountRegionScope,
+      iam: this.createIam(scope),
+      background: this.background,
+    };
   }
 
   /**

--- a/src/service/aws/factory/sim-aws-service-factory.ts
+++ b/src/service/aws/factory/sim-aws-service-factory.ts
@@ -12,6 +12,7 @@ import type { SimCognitoIdentityProvider } from "../../cognito/index.js";
 import { SimCloudFrontRegistry } from "../../cloudfront/registry/sim-cloud-front-registry.js";
 import type { SimCloudFront } from "../../cloudfront/sim-cloudfront.js";
 import type { SimDynamoDb as SimDynamoDatabase } from "../../dynamodb/index.js";
+import type { SimEcs } from "../../ecs/index.js";
 import type { SimRekognition } from "../../rekognition/index.js";
 import type { SimRoute53 } from "../../route53/index.js";
 import type { SimS3 } from "../../s3/sim-s3.js";
@@ -161,6 +162,11 @@ export class SimAwsServiceFactory {
   /** Create simulated DynamoDB for an Account Region scope. */
   createDynamoDb(scope: SimAwsAccountRegionContainer): SimDynamoDatabase {
     return this.accountRegionServices.createDynamoDb(scope);
+  }
+
+  /** Create simulated ECS for an Account Region scope. */
+  createEcs(scope: SimAwsAccountRegionContainer): SimEcs {
+    return this.accountRegionServices.createEcs(scope);
   }
 
   /** Create simulated EventBridge for an Account Region scope. */

--- a/src/service/aws/sim-aws-account-region-scope.ts
+++ b/src/service/aws/sim-aws-account-region-scope.ts
@@ -12,6 +12,7 @@ import type {
   SimDynamoDbStreams,
 } from "../dynamodb/index.js";
 import type { SimCloudFormation } from "../cloudformation/index.js";
+import type { SimEcs } from "../ecs/index.js";
 import type { SimEventBridge } from "../eventbridge/index.js";
 import type { SimCognitoIdentityProvider } from "../cognito/index.js";
 import type { SimRekognition } from "../rekognition/index.js";
@@ -138,6 +139,15 @@ export class SimAwsAccountRegionContainer {
    */
   dynamoDbStreams(): SimDynamoDbStreams {
     return this.dynamoDb().streams();
+  }
+
+  /**
+   * Get simulated ECS for this account and region.
+   */
+  ecs(): SimEcs {
+    return this.memo.getOrCreate("ecs", () =>
+      this.simAws.serviceFactory.createEcs(this),
+    );
   }
 
   /**

--- a/src/service/aws/sim-aws-service-accessors.ts
+++ b/src/service/aws/sim-aws-service-accessors.ts
@@ -9,6 +9,7 @@ import type {
   SimDynamoDb as SimDynamoDatabase,
   SimDynamoDbStreams,
 } from "../dynamodb/index.js";
+import type { SimEcs } from "../ecs/index.js";
 import type { SimIam } from "../iam/index.js";
 import type { SimKms } from "../kms/index.js";
 import type { SimLambda } from "../lambda/index.js";
@@ -77,6 +78,11 @@ export abstract class SimAwsServiceAccessors {
   /** Get simulated DynamoDB Streams in the default Account Region scope. */
   dynamoDbStreams(): SimDynamoDbStreams {
     return this.defaultAccountRegionScope().dynamoDbStreams();
+  }
+
+  /** Get simulated ECS in the default Account Region scope. */
+  ecs(): SimEcs {
+    return this.defaultAccountRegionScope().ecs();
   }
 
   /** Get simulated EventBridge in the default Account Region scope. */

--- a/src/service/ecs/README.md
+++ b/src/service/ecs/README.md
@@ -15,8 +15,9 @@ or anything else, and the only thing Yulin can run is JavaScript or TypeScript i
 An image URI is therefore only ever an identifier, used to match a container against an executable
 binding, exactly as it is for a container image Lambda function.
 
-That gives one rule. A container with a binding runs the bound handler. A container without one does
-not run, and is recorded as not simulated rather than failing anything. A realistic task definition
+That gives one rule, which running a task will follow when it arrives: a container with a binding
+will run the bound handler, and a container without one will not run and will be recorded as not
+simulated rather than failing anything. Nothing here runs anything yet. A realistic task definition
 holds an application container plus a log router plus an observability agent, and only the first of
 those is something Yulin could ever run.
 
@@ -115,4 +116,9 @@ command instances.
   meaning.
 - `CreateCluster` refuses capacity providers and Service Connect defaults, and
   `RegisterTaskDefinition` refuses any setting it does not model.
+- `ListTaskDefinitions` refuses a `status` of `DELETE_IN_PROGRESS`, which real ECS accepts, because
+  nothing deletes a task definition here for one to describe.
+- `SimEcsContainerDefinitionType` carries no index signature. One would stop a real SDK
+  `RegisterTaskDefinitionCommand` input being assignable to it, which is the whole point of the
+  structural types. A field it does not name is stored and reported back all the same.
 - The full list is in [docs/services/ecs](../../../docs/services/ecs/).

--- a/src/service/ecs/README.md
+++ b/src/service/ecs/README.md
@@ -1,0 +1,118 @@
+# Simulated ECS implementation
+
+This directory contains the simulated ECS service implementation.
+
+Nothing runs here. This is the state ECS holds: clusters, and task definitions with their container
+definitions and revisions. Running a task reads from it and comes separately.
+
+## The container model
+
+Everything in simulated ECS rests on one decision, so it is stated here as well as in the usage
+docs.
+
+Yulin never looks inside a container image. It cannot: an image may hold a Go binary, nginx, Redis
+or anything else, and the only thing Yulin can run is JavaScript or TypeScript in its own process.
+An image URI is therefore only ever an identifier, used to match a container against an executable
+binding, exactly as it is for a container image Lambda function.
+
+That gives one rule. A container with a binding runs the bound handler. A container without one does
+not run, and is recorded as not simulated rather than failing anything. A realistic task definition
+holds an application container plus a log router plus an observability agent, and only the first of
+those is something Yulin could ever run.
+
+Where this genuinely does not work is a sidecar the application depends on, such as a Redis or a
+database in the same task. That is not simulated and should not be. The application's connection
+details are ordinary environment variables, so a user who wants a real one points at their own.
+
+The consequence for the code here is that nothing reads a container definition's meaning.
+`SimEcsContainerDefinition` keeps the declaration as it was made and hands it back unchanged, and
+the only two fields it looks at are `name`, which is how everything else refers to a container, and
+`image`, which is the identifier a binding is matched on.
+
+## Entry points
+
+- `sim-ecs.ts` is the main in-memory service object for one account/region scope.
+- `index.ts` exports the public ECS simulator API for `@kensio/yulin/ecs`.
+
+A `SimEcs` instance owns a `SimEcsClusterStore` and a `SimEcsTaskDefinitionStore`. Both are scoped
+to an account and region because ECS scopes them that way: a cluster ARN and a task definition ARN
+both name their region, and a cluster name is unique within one account and region rather than
+globally.
+
+## Cluster model
+
+Cluster state lives under `cluster/`.
+
+`SimEcsCluster` is the stored resource. It reports zero for every count a described cluster carries,
+because there is nothing here to count: a simulated task runs in this process rather than on an
+instance. Deleting marks it `INACTIVE` rather than removing it, so something holding its ARN can
+still find out what became of it, and creating a cluster of the same name again replaces it with a
+new active one.
+
+`SimEcsClusterArn` builds a cluster ARN and reads one back. Reading answers with nothing rather than
+raising, because the two operations that read one report a cluster they cannot find differently:
+`DescribeClusters` reports a failure entry and `DeleteCluster` raises.
+
+## Task definition model
+
+Task definition state lives under `task-definition/`.
+
+`SimEcsTaskDefinitionStore` holds families rather than a flat list of revisions, because a family is
+what a registration adds to and what a describe resolves against. `SimEcsTaskDefinitionFamily` owns
+the revision numbering: revisions start at one and only ever go up, and deregistering does not free
+a number, because the number is part of an ARN that other things hold.
+
+`SimEcsTaskDefinitionId` is the part that turns the three forms a task definition can be named by
+into a family and, where there is one, a revision. A family with no revision is what makes naming a
+family alone mean its latest active revision.
+
+`parseSimEcsArn` is ECS's own ARN reader, unlike every other service here, which uses the shared
+`parseSimArn`. A task definition ARN carries a colon inside its resource part, in
+`task-definition/family:revision`, and the shared reader stops at the sixth colon. That would cut
+the revision off the end and leave every revision of a family looking like the same ARN.
+
+`SimEcsTaskDefinitionSettings` holds what a registration declared besides its family and containers.
+It keeps only what the request set, so a described revision reports what was declared rather than
+whatever value real ECS would have defaulted it to. A setting this simulation does not model is
+refused at the command rather than dropped, through `SimEcsUnsimulatedInput`: a registration is a
+declaration, and a declaration silently missing from the revision it made is state a test could pass
+against without it being what was asked for.
+
+## Command handling
+
+AWS SDK-style operations are implemented under `command/`, one directory per operation, so the
+`SimEcs` facade stays a delegation. `command/sim-ecs-command-context.ts` holds what each kind of
+handler is built with, split between the cluster operations and the task definition ones.
+
+`SimEcsCommandHandler` is what each handler extends. Every operation starts the same way: it refuses
+the inputs it does not hold, waits at the simulator's sequencing point, and authorizes the caller.
+Keeping those three in one place is what stops nine handlers drifting apart on the order they happen
+in, which is the order that decides whether a malformed request or an unauthorized one is reported
+first.
+
+As elsewhere, implementation code under `src/` does not import real AWS SDK packages. The structural
+command types in `*.command.ts` match the SDK shapes closely enough for callers to pass real SDK
+command instances.
+
+## Authorization
+
+`SimEcsAuthorizer` splits requests two ways, as real ECS does:
+
+- `DescribeClusters` and `DeleteCluster` authorize against the cluster's ARN, so a policy can name
+  one cluster;
+- everything else authorizes against `*`, because real ECS gives the task definition operations no
+  resource type at all, and gives `CreateCluster` and `ListClusters` none either. A policy naming a
+  task definition ARN grants nothing, here as on AWS.
+
+## Divergences worth knowing
+
+- `ListClusters` leaves out a deleted cluster. It is still describable by name or ARN as `INACTIVE`.
+- `DescribeClusters` refuses `include` values of `ATTACHMENTS` and `STATISTICS`. Both describe
+  capacity a cluster has attached to it, and there is none here, so answering would mean reporting
+  made-up numbers as though they had been counted.
+- A described task definition reports neither `compatibilities` nor `requiresAttributes`. Real ECS
+  works both out from what the definition declares, which would mean reading a container definition's
+  meaning.
+- `CreateCluster` refuses capacity providers and Service Connect defaults, and
+  `RegisterTaskDefinition` refuses any setting it does not model.
+- The full list is in [docs/services/ecs](../../../docs/services/ecs/).

--- a/src/service/ecs/cluster/sim-ecs-cluster-arn.ts
+++ b/src/service/ecs/cluster/sim-ecs-cluster-arn.ts
@@ -4,6 +4,9 @@ import { parseSimEcsArn } from "../sim-ecs-arn.js";
 
 /**
  * The cluster an ECS request means when it names no cluster at all.
+ *
+ * Only the operations that take an optional cluster fall back to it.
+ * `DeleteCluster` needs one to be named, as it does on real ECS.
  */
 export const simEcsDefaultClusterName = "default";
 
@@ -38,13 +41,11 @@ export class SimEcsClusterArn {
    * scope: it is not an ARN of the right shape, it is an ARN of something
    * else, or it is an ECS cluster ARN belonging to another Account or Region.
    * Callers report that in their own terms, because `DescribeClusters` reports
-   * a cluster it cannot find as a failure while `DeleteCluster` raises.
+   * a cluster it cannot find as a failure while `DeleteCluster` raises. An
+   * identifier is required here: the operations that take an optional cluster
+   * fall back to the default one before they get this far.
    */
-  clusterName(identifier: string | undefined): string | undefined {
-    if (identifier === undefined || identifier === "") {
-      return simEcsDefaultClusterName;
-    }
-
+  clusterName(identifier: string): string | undefined {
     if (!identifier.startsWith("arn:")) {
       return identifier;
     }

--- a/src/service/ecs/cluster/sim-ecs-cluster-arn.ts
+++ b/src/service/ecs/cluster/sim-ecs-cluster-arn.ts
@@ -1,0 +1,65 @@
+import type { SimArn } from "../../aws/arn.js";
+import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+import { parseSimEcsArn } from "../sim-ecs-arn.js";
+
+/**
+ * The cluster an ECS request means when it names no cluster at all.
+ */
+export const simEcsDefaultClusterName = "default";
+
+/**
+ * Builds and reads simulated ECS cluster ARNs for one Account and Region.
+ *
+ * A request may name a cluster by its short name or by its full ARN, and the
+ * two are interchangeable everywhere ECS takes a cluster. Reading an ARN
+ * belonging to another Account or Region gives no cluster rather than the
+ * same-named one here, because those are different clusters on real AWS.
+ */
+export class SimEcsClusterArn {
+  private readonly accountRegionScope: SimAwsAccountRegionScope;
+
+  constructor(accountRegionScope: SimAwsAccountRegionScope) {
+    this.accountRegionScope = accountRegionScope;
+  }
+
+  /**
+   * The ARN a cluster of this name has in this Account and Region.
+   */
+  make(clusterName: string): SimArn {
+    const { regionName, accountId } = this.accountRegionScope;
+
+    return `arn:aws:ecs:${regionName}:${accountId}:cluster/${clusterName}`;
+  }
+
+  /**
+   * Read the cluster name out of a short name or a full cluster ARN.
+   *
+   * Undefined covers every way an identifier can name no cluster in this
+   * scope: it is not an ARN of the right shape, it is an ARN of something
+   * else, or it is an ECS cluster ARN belonging to another Account or Region.
+   * Callers report that in their own terms, because `DescribeClusters` reports
+   * a cluster it cannot find as a failure while `DeleteCluster` raises.
+   */
+  clusterName(identifier: string | undefined): string | undefined {
+    if (identifier === undefined || identifier === "") {
+      return simEcsDefaultClusterName;
+    }
+
+    if (!identifier.startsWith("arn:")) {
+      return identifier;
+    }
+
+    const arn = parseSimEcsArn(identifier);
+    const { regionName, accountId } = this.accountRegionScope;
+
+    if (
+      arn?.resourceType !== "cluster" ||
+      arn.region !== regionName ||
+      arn.accountId !== accountId
+    ) {
+      return undefined;
+    }
+
+    return arn.resourceId;
+  }
+}

--- a/src/service/ecs/cluster/sim-ecs-cluster-store.ts
+++ b/src/service/ecs/cluster/sim-ecs-cluster-store.ts
@@ -1,0 +1,53 @@
+import type { SimEcsCluster } from "./sim-ecs-cluster.js";
+
+/**
+ * The simulated ECS clusters one Account and Region holds.
+ *
+ * Clusters are keyed by name because a cluster name is unique within an
+ * Account and Region on real ECS, and because both forms a request can name a
+ * cluster by, the short name and the ARN, come down to that name.
+ *
+ * A deleted cluster is kept rather than removed. It is still describable, as
+ * it is on real ECS, and creating a cluster with its name again replaces it
+ * with a new active one.
+ */
+export class SimEcsClusterStore {
+  private readonly clusters = new Map<string, SimEcsCluster>();
+
+  /**
+   * Hold a cluster, replacing any earlier one of the same name.
+   */
+  put(cluster: SimEcsCluster): void {
+    this.clusters.set(cluster.clusterName, cluster);
+  }
+
+  /**
+   * Find a cluster by name, whether it is active or deleted.
+   */
+  find(clusterName: string): SimEcsCluster | undefined {
+    return this.clusters.get(clusterName);
+  }
+
+  /**
+   * Find an active cluster by name.
+   */
+  findActive(clusterName: string): SimEcsCluster | undefined {
+    const cluster = this.clusters.get(clusterName);
+
+    if (cluster?.isActive() !== true) {
+      return undefined;
+    }
+
+    return cluster;
+  }
+
+  /**
+   * The active clusters, in the order they were created.
+   */
+  active(): readonly SimEcsCluster[] {
+    return this.clusters
+      .values()
+      .filter((cluster) => cluster.isActive())
+      .toArray();
+  }
+}

--- a/src/service/ecs/cluster/sim-ecs-cluster-store.ts
+++ b/src/service/ecs/cluster/sim-ecs-cluster-store.ts
@@ -16,8 +16,13 @@ export class SimEcsClusterStore {
 
   /**
    * Hold a cluster, replacing any earlier one of the same name.
+   *
+   * The earlier one is dropped before the replacement is held, so a cluster
+   * created again after being deleted takes its place at the end of the
+   * listing rather than keeping the position the deleted one had.
    */
   put(cluster: SimEcsCluster): void {
+    this.clusters.delete(cluster.clusterName);
     this.clusters.set(cluster.clusterName, cluster);
   }
 

--- a/src/service/ecs/cluster/sim-ecs-cluster.ts
+++ b/src/service/ecs/cluster/sim-ecs-cluster.ts
@@ -1,0 +1,134 @@
+import type { SimArn } from "../../aws/arn.js";
+import type { SimEcsTag } from "../task-definition/sim-ecs-task-definition-parts.js";
+
+/**
+ * Minimal structural sim ECS cluster setting.
+ *
+ * https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_ClusterSetting.html
+ */
+export interface SimEcsClusterSetting {
+  readonly name?: string | undefined;
+  readonly value?: string | undefined;
+}
+
+/**
+ * Minimal structural sim ECS described cluster.
+ *
+ * https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_Cluster.html
+ */
+export interface SimEcsClusterDetail {
+  readonly clusterArn?: SimArn | undefined;
+  readonly clusterName?: string | undefined;
+  readonly status?: SimEcsClusterStatus | undefined;
+  readonly registeredContainerInstancesCount?: number | undefined;
+  readonly runningTasksCount?: number | undefined;
+  readonly pendingTasksCount?: number | undefined;
+  readonly activeServicesCount?: number | undefined;
+  readonly statistics?: readonly SimEcsKeyValueString[] | undefined;
+  readonly settings?: readonly SimEcsClusterSetting[] | undefined;
+  readonly configuration?: object | undefined;
+  readonly tags?: readonly SimEcsTag[] | undefined;
+  readonly capacityProviders?: readonly string[] | undefined;
+  readonly defaultCapacityProviderStrategy?: readonly object[] | undefined;
+}
+
+/**
+ * Minimal structural sim ECS statistic entry.
+ */
+export interface SimEcsKeyValueString {
+  readonly name?: string | undefined;
+  readonly value?: string | undefined;
+}
+
+/**
+ * The states a simulated ECS cluster can be in.
+ */
+export type SimEcsClusterStatus = "ACTIVE" | "INACTIVE";
+
+interface SimEcsClusterProperties {
+  readonly clusterArn: SimArn;
+  readonly clusterName: string;
+  readonly settings?: readonly SimEcsClusterSetting[] | undefined;
+  readonly configuration?: object | undefined;
+  readonly tags?: readonly SimEcsTag[] | undefined;
+}
+
+/**
+ * One simulated ECS cluster.
+ *
+ * A cluster is little more than a named scope for the tasks and services that
+ * will run in it. It holds no capacity here, because there is nothing to hold:
+ * a simulated task runs in this process rather than on an instance, so the
+ * counts a described cluster reports are the ones it can honestly report.
+ */
+export class SimEcsCluster {
+  public readonly clusterArn: SimArn;
+  public readonly clusterName: string;
+
+  private status: SimEcsClusterStatus = "ACTIVE";
+  private readonly settings: readonly SimEcsClusterSetting[];
+  private readonly configuration: object | undefined;
+  private readonly tags: readonly SimEcsTag[];
+
+  constructor(properties: SimEcsClusterProperties) {
+    this.clusterArn = properties.clusterArn;
+    this.clusterName = properties.clusterName;
+    this.settings = structuredClone(properties.settings ?? []);
+    this.configuration = structuredClone(properties.configuration);
+    this.tags = structuredClone(properties.tags ?? []);
+  }
+
+  /**
+   * Whether this cluster is still the one a request naming it reaches.
+   */
+  isActive(): boolean {
+    return this.status === "ACTIVE";
+  }
+
+  /**
+   * Mark this cluster deleted.
+   *
+   * It stays describable as `INACTIVE` rather than being removed, which is
+   * what real ECS does with a deleted cluster: something holding its ARN can
+   * still find out what became of it.
+   */
+  markDeleted(): void {
+    this.status = "INACTIVE";
+  }
+
+  /**
+   * This cluster as `DescribeClusters` reports it.
+   *
+   * Tags and settings are only reported when the request asked for them, as
+   * real ECS only reports them under the matching `include` value.
+   */
+  toOutput(included: SimEcsClusterIncludes): SimEcsClusterDetail {
+    return {
+      clusterArn: this.clusterArn,
+      clusterName: this.clusterName,
+      status: this.status,
+      registeredContainerInstancesCount: 0,
+      runningTasksCount: 0,
+      pendingTasksCount: 0,
+      activeServicesCount: 0,
+      statistics: [],
+      capacityProviders: [],
+      defaultCapacityProviderStrategy: [],
+      settings: included.settings ? structuredClone(this.settings) : [],
+      tags: included.tags ? structuredClone(this.tags) : [],
+      ...(included.configuration &&
+        this.configuration !== undefined && {
+          configuration: structuredClone(this.configuration),
+        }),
+    };
+  }
+}
+
+/**
+ * Which parts of a cluster a describe request asked to be reported.
+ */
+export interface SimEcsClusterIncludes {
+  readonly settings: boolean;
+  readonly configuration: boolean;
+  readonly tags: boolean;
+}

--- a/src/service/ecs/command/authorize/sim-ecs-authorizer.ts
+++ b/src/service/ecs/command/authorize/sim-ecs-authorizer.ts
@@ -1,0 +1,91 @@
+import type { SimAwsResolvedCaller } from "../../../aws/caller/sim-aws-caller-resolver.js";
+import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { SimIamCallerIdentifier } from "../../../iam/error/sim-iam-caller-identifier.js";
+import { SimEcsAccessDeniedException } from "../../error/sim-ecs.error.js";
+import type { SimEcsRequestOptions } from "../sim-ecs-request-options.js";
+
+/**
+ * The resource an ECS action with no resource type authorizes against.
+ *
+ * Real ECS gives the task definition operations no resource type, because a
+ * task definition is not something an ECS policy can name. The same goes for
+ * `CreateCluster` and `ListClusters`. A policy allowing any of them has to use
+ * a resource of `*`, and one naming a cluster ARN allows none of them, here as
+ * on AWS.
+ */
+const noResource = "*";
+
+interface SimEcsAuthorizerProperties {
+  readonly iam: SimIamInterServiceAuthZ;
+}
+
+/**
+ * Applies simulated IAM authorization to ECS requests.
+ *
+ * ECS splits its operations two ways. `DescribeClusters` and `DeleteCluster`
+ * authorize against the cluster's ARN, so a policy can name one cluster. Every
+ * operation here that names a task definition, and both operations that name
+ * no cluster, authorize against `*` instead.
+ *
+ * A denial is reported as ECS's own AccessDeniedException rather than the
+ * shared IAM error, because that is the error a real ECS caller would have to
+ * handle.
+ */
+export class SimEcsAuthorizer {
+  private readonly iam: SimIamInterServiceAuthZ;
+  private readonly callerIdentifier = new SimIamCallerIdentifier();
+
+  constructor(properties: SimEcsAuthorizerProperties) {
+    this.iam = properties.iam;
+  }
+
+  /**
+   * Ensure the caller may perform an action on a cluster, named by its ARN.
+   *
+   * The cluster need not exist. Authorization comes first either way, so an
+   * unauthorized caller cannot learn from the error whether a cluster is
+   * there.
+   */
+  authorizeCluster(
+    action: string,
+    clusterArn: string,
+    options?: SimEcsRequestOptions,
+  ): SimAwsResolvedCaller {
+    return this.authorizeResource(action, clusterArn, options);
+  }
+
+  /**
+   * Ensure the caller may perform an action that names no ECS resource.
+   */
+  authorizeAnyResource(
+    action: string,
+    options?: SimEcsRequestOptions,
+  ): SimAwsResolvedCaller {
+    return this.authorizeResource(action, noResource, options);
+  }
+
+  private authorizeResource(
+    action: string,
+    resource: string,
+    options: SimEcsRequestOptions | undefined,
+  ): SimAwsResolvedCaller {
+    const decision = this.iam.authorize({
+      action,
+      resource,
+      caller: options?.caller,
+    });
+
+    if (decision.isDenied) {
+      const identifier = this.callerIdentifier.format(
+        decision.caller.principal,
+      );
+
+      throw new SimEcsAccessDeniedException(
+        `User: ${identifier} is not authorized to perform: ${action} on ` +
+          `resource: ${resource}`,
+      );
+    }
+
+    return decision.caller;
+  }
+}

--- a/src/service/ecs/command/authorize/sim-ecs-iam.iso.test.ts
+++ b/src/service/ecs/command/authorize/sim-ecs-iam.iso.test.ts
@@ -1,0 +1,197 @@
+import {
+  CreateClusterCommand,
+  DeleteClusterCommand,
+  DescribeClustersCommand,
+  DescribeTaskDefinitionCommand,
+  ListTaskDefinitionsCommand,
+  RegisterTaskDefinitionCommand,
+} from "@aws-sdk/client-ecs";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { simIamRoleWithPolicyFactory } from "../../../iam/role/sim-iam-role-with-policy.factory.js";
+import { SimEcsAccessDeniedException } from "../../error/sim-ecs.error.js";
+
+describe("Authorizing simulated ECS requests", () => {
+  it("allows a caller whose policy permits the registration", async () => {
+    // Given a Role allowed to register task definitions.
+    const simAws = new SimAws();
+    const role = await simIamRoleWithPolicyFactory.make(
+      { roleName: "Deployer", actions: ["ecs:RegisterTaskDefinition"] },
+      simAws,
+    );
+
+    // When it registers one.
+    const registered = await simAws.ecs().registerTaskDefinition(
+      new RegisterTaskDefinitionCommand({
+        family: "checkout",
+        containerDefinitions: [{ name: "app", image: "checkout:1" }],
+      }),
+      { caller: { kind: "arn", arn: role.Arn } },
+    );
+
+    // Then the registration goes through, recording who made it.
+    assertIdentical(registered.taskDefinition?.revision, 1);
+    assertIdentical(registered.taskDefinition.registeredBy, role.Arn);
+  });
+
+  it("refuses a caller whose policy does not permit the action", async () => {
+    // Given a Role allowed to describe but not to register.
+    const simAws = new SimAws();
+    const role = await simIamRoleWithPolicyFactory.make(
+      { roleName: "Reader", actions: ["ecs:DescribeTaskDefinition"] },
+      simAws,
+    );
+
+    // When it registers a task definition.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.ecs().registerTaskDefinition(
+        new RegisterTaskDefinitionCommand({
+          family: "checkout",
+          containerDefinitions: [{ name: "app", image: "checkout:1" }],
+        }),
+        { caller: { kind: "arn", arn: role.Arn } },
+      ),
+    );
+
+    // Then ECS refuses it as its own access denied error.
+    assertInstanceOf(error, SimEcsAccessDeniedException);
+    assertIdentical(error.name, "AccessDeniedException");
+    assertStringIncludes(error.message, "ecs:RegisterTaskDefinition");
+  });
+
+  it("registers nothing when the caller is refused", async () => {
+    // Given a Role allowed nothing in ECS.
+    const simAws = new SimAws();
+    const role = await simIamRoleWithPolicyFactory.make(
+      { roleName: "Nobody", actions: ["s3:GetObject"] },
+      simAws,
+    );
+    await assertThrowsErrorAsync(async () =>
+      simAws.ecs().registerTaskDefinition(
+        new RegisterTaskDefinitionCommand({
+          family: "checkout",
+          containerDefinitions: [{ name: "app", image: "checkout:1" }],
+        }),
+        { caller: { kind: "arn", arn: role.Arn } },
+      ),
+    );
+
+    // When the task definitions are listed as the Account root.
+    const listed = await simAws
+      .ecs()
+      .listTaskDefinitions(new ListTaskDefinitionsCommand({}));
+
+    // Then the refused registration left no revision behind.
+    assertArrayLength(listed.taskDefinitionArns, 0);
+  });
+
+  it("refuses a task definition policy naming an ARN", async () => {
+    // Given a Role allowed to describe task definitions on one ARN.
+    const simAws = new SimAws();
+    const role = await simIamRoleWithPolicyFactory.make(
+      {
+        roleName: "Reader",
+        actions: ["ecs:DescribeTaskDefinition"],
+        resource: `arn:aws:ecs:${simAws.defaultRegionName}:${simAws.defaultAccountId}:task-definition/checkout:1`,
+      },
+      simAws,
+    );
+    await simAws.ecs().registerTaskDefinition(
+      new RegisterTaskDefinitionCommand({
+        family: "checkout",
+        containerDefinitions: [{ name: "app", image: "checkout:1" }],
+      }),
+    );
+
+    // When it describes that task definition.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws
+        .ecs()
+        .describeTaskDefinition(
+          new DescribeTaskDefinitionCommand({ taskDefinition: "checkout" }),
+          { caller: { kind: "arn", arn: role.Arn } },
+        ),
+    );
+
+    // Then the policy grants nothing, because real ECS gives this action no
+    // resource-level permissions and evaluates it against `*`.
+    assertInstanceOf(error, SimEcsAccessDeniedException);
+    assertStringIncludes(error.message, "on resource: *");
+  });
+
+  it("authorizes a cluster operation against the cluster ARN", async () => {
+    // Given a Role allowed to describe one cluster.
+    const simAws = new SimAws();
+    const clusterArn = `arn:aws:ecs:${simAws.defaultRegionName}:${simAws.defaultAccountId}:cluster/services`;
+    const role = await simIamRoleWithPolicyFactory.make(
+      {
+        roleName: "ClusterReader",
+        actions: ["ecs:DescribeClusters"],
+        resource: clusterArn,
+      },
+      simAws,
+    );
+    await simAws
+      .ecs()
+      .createCluster(new CreateClusterCommand({ clusterName: "services" }));
+    await simAws
+      .ecs()
+      .createCluster(new CreateClusterCommand({ clusterName: "batch" }));
+
+    // When it describes that cluster.
+    const described = await simAws
+      .ecs()
+      .describeClusters(
+        new DescribeClustersCommand({ clusters: ["services"] }),
+        {
+          caller: { kind: "arn", arn: role.Arn },
+        },
+      );
+
+    // Then it is allowed, unlike the cluster its policy does not name.
+    assertArrayLength(described.clusters, 1);
+
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws
+        .ecs()
+        .describeClusters(
+          new DescribeClustersCommand({ clusters: ["batch"] }),
+          {
+            caller: { kind: "arn", arn: role.Arn },
+          },
+        ),
+    );
+
+    assertInstanceOf(error, SimEcsAccessDeniedException);
+    assertStringIncludes(error.message, "cluster/batch");
+  });
+
+  it("refuses a cluster deletion before finding out if it is there", async () => {
+    // Given a Role allowed nothing in ECS.
+    const simAws = new SimAws();
+    const role = await simIamRoleWithPolicyFactory.make(
+      { roleName: "Nobody", actions: ["s3:GetObject"] },
+      simAws,
+    );
+
+    // When it deletes a cluster that does not exist.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws
+        .ecs()
+        .deleteCluster(new DeleteClusterCommand({ cluster: "services" }), {
+          caller: { kind: "arn", arn: role.Arn },
+        }),
+    );
+
+    // Then the answer is the access denial, so nothing is learned about what
+    // the account holds.
+    assertInstanceOf(error, SimEcsAccessDeniedException);
+  });
+});

--- a/src/service/ecs/command/create-cluster/create-cluster-factory.ts
+++ b/src/service/ecs/command/create-cluster/create-cluster-factory.ts
@@ -1,0 +1,67 @@
+import {
+  simEcsDefaultClusterName,
+  type SimEcsClusterArn,
+} from "../../cluster/sim-ecs-cluster-arn.js";
+import { SimEcsCluster } from "../../cluster/sim-ecs-cluster.js";
+import type { SimEcsClusterStore } from "../../cluster/sim-ecs-cluster-store.js";
+import { requiredSimEcsName } from "../../sim-ecs-name.js";
+import type { SimCreateClusterCommandInput } from "./create-cluster.command.js";
+
+interface CreateClusterFactoryProperties {
+  readonly clusters: SimEcsClusterStore;
+  readonly clusterArn: SimEcsClusterArn;
+}
+
+/**
+ * Makes the cluster a CreateCluster request asked for.
+ *
+ * Real ECS answers a repeated CreateCluster with the cluster already holding
+ * the name rather than an error, which is what makes a stack deploying the
+ * same cluster twice work. That is why this finds before it makes.
+ */
+export class CreateClusterFactory {
+  private readonly clusters: SimEcsClusterStore;
+  private readonly clusterArn: SimEcsClusterArn;
+
+  constructor(properties: CreateClusterFactoryProperties) {
+    this.clusters = properties.clusters;
+    this.clusterArn = properties.clusterArn;
+  }
+
+  /**
+   * The name a request asked for, which is `default` when it asked for none.
+   */
+  static clusterName(input: SimCreateClusterCommandInput): string {
+    if (input.clusterName === undefined) {
+      return simEcsDefaultClusterName;
+    }
+
+    return requiredSimEcsName(input.clusterName, "cluster name");
+  }
+
+  /**
+   * The cluster this request means, made and held if it is not already there.
+   */
+  make(
+    input: SimCreateClusterCommandInput,
+    clusterName: string,
+  ): SimEcsCluster {
+    const held = this.clusters.findActive(clusterName);
+
+    if (held !== undefined) {
+      return held;
+    }
+
+    const cluster = new SimEcsCluster({
+      clusterArn: this.clusterArn.make(clusterName),
+      clusterName,
+      settings: input.settings,
+      configuration: input.configuration,
+      tags: input.tags,
+    });
+
+    this.clusters.put(cluster);
+
+    return cluster;
+  }
+}

--- a/src/service/ecs/command/create-cluster/create-cluster.command.ts
+++ b/src/service/ecs/command/create-cluster/create-cluster.command.ts
@@ -1,0 +1,33 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type {
+  SimEcsClusterDetail,
+  SimEcsClusterSetting,
+} from "../../cluster/sim-ecs-cluster.js";
+import type { SimEcsTag } from "../../task-definition/sim-ecs-task-definition-parts.js";
+
+/**
+ * Minimal structural sim ECS CreateCluster command.
+ */
+export interface SimCreateClusterCommand {
+  readonly input: SimCreateClusterCommandInput;
+}
+
+/**
+ * Minimal structural sim ECS CreateCluster input.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/ecs/command/CreateClusterCommand/
+ */
+export interface SimCreateClusterCommandInput {
+  readonly clusterName?: string | undefined;
+  readonly settings?: readonly SimEcsClusterSetting[] | undefined;
+  readonly configuration?: object | undefined;
+  readonly tags?: readonly SimEcsTag[] | undefined;
+}
+
+/**
+ * Minimal structural sim ECS CreateCluster output.
+ */
+export interface SimCreateClusterCommandOutput {
+  readonly cluster?: SimEcsClusterDetail | undefined;
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/ecs/command/create-cluster/create-cluster.handler.ts
+++ b/src/service/ecs/command/create-cluster/create-cluster.handler.ts
@@ -1,0 +1,70 @@
+import type { CommandHandler } from "../../../../command/command-handler.js";
+import type { SimEcsClusterCommandContext } from "../sim-ecs-command-context.js";
+import { SimEcsCommandHandler } from "../sim-ecs-command-handler.js";
+import type { SimEcsRequestOptions } from "../sim-ecs-request-options.js";
+import { CreateClusterFactory } from "./create-cluster-factory.js";
+import type {
+  SimCreateClusterCommand,
+  SimCreateClusterCommandOutput,
+} from "./create-cluster.command.js";
+
+/**
+ * What a simulated CreateCluster request may declare.
+ *
+ * Capacity providers and Service Connect defaults are left out because there
+ * is no capacity and no service discovery here to attach them to, and a
+ * declaration nothing acts on is refused rather than accepted.
+ */
+const acceptedInput: readonly string[] = [
+  "clusterName",
+  "settings",
+  "configuration",
+  "tags",
+];
+
+/**
+ * Everything a cluster reports, which is what a creation answers with.
+ */
+const everything = { settings: true, configuration: true, tags: true };
+
+/**
+ * Simulated ECS CreateClusterCommand handler.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/ecs/command/CreateClusterCommand/
+ */
+export class CreateClusterCommandHandler
+  extends SimEcsCommandHandler
+  implements
+    CommandHandler<SimCreateClusterCommand, SimCreateClusterCommandOutput>
+{
+  private readonly clusterFactory: CreateClusterFactory;
+
+  constructor(context: SimEcsClusterCommandContext) {
+    super(context, "CreateCluster", acceptedInput);
+    this.clusterFactory = new CreateClusterFactory(context);
+  }
+
+  /**
+   * Create a cluster, or hand back the one already holding the name.
+   *
+   * The name is read before authorization because a malformed request is
+   * malformed whoever made it, and nothing is held until the caller has been
+   * authorized.
+   */
+  async handle(
+    command: SimCreateClusterCommand,
+    options?: SimEcsRequestOptions,
+  ): Promise<SimCreateClusterCommandOutput> {
+    this.refuseUnaccepted(command.input);
+
+    const clusterName = CreateClusterFactory.clusterName(command.input);
+
+    await this.sequence();
+
+    this.authorizer.authorizeAnyResource("ecs:CreateCluster", options);
+
+    const cluster = this.clusterFactory.make(command.input, clusterName);
+
+    return { $metadata: {}, cluster: cluster.toOutput(everything) };
+  }
+}

--- a/src/service/ecs/command/create-cluster/create-cluster.iso.test.ts
+++ b/src/service/ecs/command/create-cluster/create-cluster.iso.test.ts
@@ -1,0 +1,147 @@
+import { CreateClusterCommand } from "@aws-sdk/client-ecs";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimEcsClientException } from "../../error/sim-ecs.error.js";
+
+describe("ECS CreateClusterCommand", () => {
+  it("creates a cluster in the account and region", async () => {
+    // Given simulated ECS in a known account and region.
+    const simEcs = new SimAws()
+      .account("555555555555")
+      .region("eu-west-1")
+      .ecs();
+
+    // When a cluster is created.
+    const created = await simEcs.createCluster(
+      new CreateClusterCommand({ clusterName: "services" }),
+    );
+
+    // Then it has the ARN it would have on real AWS, and no capacity.
+    assertIdentical(
+      created.cluster?.clusterArn,
+      "arn:aws:ecs:eu-west-1:555555555555:cluster/services",
+    );
+    assertIdentical(created.cluster.clusterName, "services");
+    assertIdentical(created.cluster.status, "ACTIVE");
+    assertIdentical(created.cluster.runningTasksCount, 0);
+    assertIdentical(created.cluster.activeServicesCount, 0);
+  });
+
+  it("creates the default cluster when the request names none", async () => {
+    // Given simulated ECS.
+    const simEcs = new SimAws().ecs();
+
+    // When a cluster is created without a name.
+    const created = await simEcs.createCluster(new CreateClusterCommand({}));
+
+    // Then it is the default cluster, as it is on real ECS.
+    assertIdentical(created.cluster?.clusterName, "default");
+  });
+
+  it("hands back the existing cluster when the name is taken", async () => {
+    // Given a cluster that already exists.
+    const simEcs = new SimAws().ecs();
+    const first = await simEcs.createCluster(
+      new CreateClusterCommand({
+        clusterName: "services",
+        tags: [{ key: "team", value: "platform" }],
+      }),
+    );
+
+    // When the same name is created again.
+    const second = await simEcs.createCluster(
+      new CreateClusterCommand({ clusterName: "services" }),
+    );
+
+    // Then the existing cluster answers, tags and all, rather than an error.
+    assertIdentical(second.cluster?.clusterArn, first.cluster?.clusterArn);
+    assertArrayLength(second.cluster?.tags, 1);
+  });
+
+  it("reports the settings and tags a cluster was created with", async () => {
+    // Given simulated ECS.
+    const simEcs = new SimAws().ecs();
+
+    // When a cluster is created with settings and tags.
+    const created = await simEcs.createCluster(
+      new CreateClusterCommand({
+        clusterName: "services",
+        settings: [{ name: "containerInsights", value: "enabled" }],
+        tags: [{ key: "team", value: "platform" }],
+      }),
+    );
+
+    // Then both come back with the created cluster.
+    assertArrayLength(created.cluster?.settings, 1);
+    assertIdentical(created.cluster.settings[0].value, "enabled");
+    assertArrayLength(created.cluster.tags, 1);
+    assertIdentical(created.cluster.tags[0].key, "team");
+  });
+
+  it("refuses a cluster name ECS would not accept", async () => {
+    // Given simulated ECS.
+    const simEcs = new SimAws().ecs();
+
+    // When a cluster name carries a character ECS does not allow.
+    const error = await assertThrowsErrorAsync(async () =>
+      simEcs.createCluster(new CreateClusterCommand({ clusterName: "my/app" })),
+    );
+
+    // Then it is refused here rather than on deployment.
+    assertInstanceOf(error, SimEcsClientException);
+    assertStringIncludes(error.message, "Invalid cluster name");
+  });
+
+  it("refuses a declaration this simulation does not hold", async () => {
+    // Given simulated ECS.
+    const simEcs = new SimAws().ecs();
+
+    // When a cluster is created with capacity providers.
+    const error = await assertThrowsErrorAsync(async () =>
+      simEcs.createCluster(
+        new CreateClusterCommand({
+          clusterName: "services",
+          capacityProviders: ["FARGATE"],
+        }),
+      ),
+    );
+
+    // Then it is refused, because there is no capacity here to attach.
+    assertInstanceOf(error, SimEcsClientException);
+    assertStringIncludes(error.message, "capacityProviders is not simulated");
+  });
+
+  it("keeps the clusters of one account and region to themselves", async () => {
+    // Given two account and region scopes.
+    const simAws = new SimAws();
+
+    // When a cluster of the same name is created in each of them.
+    const here = await simAws
+      .account("111111111111")
+      .region("eu-west-2")
+      .ecs()
+      .createCluster(new CreateClusterCommand({ clusterName: "services" }));
+    const elsewhere = await simAws
+      .account("111111111111")
+      .region("us-east-1")
+      .ecs()
+      .createCluster(new CreateClusterCommand({ clusterName: "services" }));
+
+    // Then each names its own region in its ARN.
+    assertIdentical(
+      here.cluster?.clusterArn,
+      "arn:aws:ecs:eu-west-2:111111111111:cluster/services",
+    );
+    assertIdentical(
+      elsewhere.cluster?.clusterArn,
+      "arn:aws:ecs:us-east-1:111111111111:cluster/services",
+    );
+  });
+});

--- a/src/service/ecs/command/delete-cluster/delete-cluster.command.ts
+++ b/src/service/ecs/command/delete-cluster/delete-cluster.command.ts
@@ -1,0 +1,26 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type { SimEcsClusterDetail } from "../../cluster/sim-ecs-cluster.js";
+
+/**
+ * Minimal structural sim ECS DeleteCluster command.
+ */
+export interface SimDeleteClusterCommand {
+  readonly input: SimDeleteClusterCommandInput;
+}
+
+/**
+ * Minimal structural sim ECS DeleteCluster input.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/ecs/command/DeleteClusterCommand/
+ */
+export interface SimDeleteClusterCommandInput {
+  readonly cluster?: string | undefined;
+}
+
+/**
+ * Minimal structural sim ECS DeleteCluster output.
+ */
+export interface SimDeleteClusterCommandOutput {
+  readonly cluster?: SimEcsClusterDetail | undefined;
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/ecs/command/delete-cluster/delete-cluster.handler.ts
+++ b/src/service/ecs/command/delete-cluster/delete-cluster.handler.ts
@@ -1,0 +1,92 @@
+import type { CommandHandler } from "../../../../command/command-handler.js";
+import type { SimEcsClusterArn } from "../../cluster/sim-ecs-cluster-arn.js";
+import type { SimEcsCluster } from "../../cluster/sim-ecs-cluster.js";
+import type { SimEcsClusterStore } from "../../cluster/sim-ecs-cluster-store.js";
+import { SimEcsClusterNotFoundException } from "../../error/sim-ecs.error.js";
+import type { SimEcsClusterCommandContext } from "../sim-ecs-command-context.js";
+import { SimEcsCommandHandler } from "../sim-ecs-command-handler.js";
+import type { SimEcsRequestOptions } from "../sim-ecs-request-options.js";
+import type {
+  SimDeleteClusterCommand,
+  SimDeleteClusterCommandOutput,
+} from "./delete-cluster.command.js";
+
+const acceptedInput: readonly string[] = ["cluster"];
+
+/**
+ * Simulated ECS DeleteClusterCommand handler.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/ecs/command/DeleteClusterCommand/
+ */
+export class DeleteClusterCommandHandler
+  extends SimEcsCommandHandler
+  implements
+    CommandHandler<SimDeleteClusterCommand, SimDeleteClusterCommandOutput>
+{
+  private readonly clusters: SimEcsClusterStore;
+  private readonly clusterArn: SimEcsClusterArn;
+
+  constructor(context: SimEcsClusterCommandContext) {
+    super(context, "DeleteCluster", acceptedInput);
+    this.clusters = context.clusters;
+    this.clusterArn = context.clusterArn;
+  }
+
+  /**
+   * Delete a cluster, which marks it `INACTIVE` rather than removing it.
+   *
+   * The deleted cluster is what the response reports, as real ECS reports it,
+   * and it stays describable afterwards. Creating a cluster of the same name
+   * again makes a new active one.
+   */
+  async handle(
+    command: SimDeleteClusterCommand,
+    options?: SimEcsRequestOptions,
+  ): Promise<SimDeleteClusterCommandOutput> {
+    this.refuseUnaccepted(command.input);
+
+    const identifier = command.input.cluster;
+    const clusterName = this.clusterArn.clusterName(identifier);
+
+    await this.sequence();
+
+    this.authorizer.authorizeCluster(
+      "ecs:DeleteCluster",
+      clusterName === undefined
+        ? String(identifier)
+        : this.clusterArn.make(clusterName),
+      options,
+    );
+
+    const cluster = this.deletable(clusterName, identifier);
+    cluster.markDeleted();
+
+    return {
+      $metadata: {},
+      cluster: cluster.toOutput({
+        settings: true,
+        configuration: true,
+        tags: true,
+      }),
+    };
+  }
+
+  private deletable(
+    clusterName: string | undefined,
+    identifier: string | undefined,
+  ): SimEcsCluster {
+    const cluster =
+      clusterName === undefined
+        ? undefined
+        : this.clusters.findActive(clusterName);
+
+    if (cluster === undefined) {
+      throw new SimEcsClusterNotFoundException(
+        `The simulated Account and Region hold no active cluster ` +
+          `${identifier ?? "default"}.`,
+      );
+    }
+
+    return cluster;
+  }
+}

--- a/src/service/ecs/command/delete-cluster/delete-cluster.handler.ts
+++ b/src/service/ecs/command/delete-cluster/delete-cluster.handler.ts
@@ -2,7 +2,10 @@ import type { CommandHandler } from "../../../../command/command-handler.js";
 import type { SimEcsClusterArn } from "../../cluster/sim-ecs-cluster-arn.js";
 import type { SimEcsCluster } from "../../cluster/sim-ecs-cluster.js";
 import type { SimEcsClusterStore } from "../../cluster/sim-ecs-cluster-store.js";
-import { SimEcsClusterNotFoundException } from "../../error/sim-ecs.error.js";
+import {
+  SimEcsClientException,
+  SimEcsClusterNotFoundException,
+} from "../../error/sim-ecs.error.js";
 import type { SimEcsClusterCommandContext } from "../sim-ecs-command-context.js";
 import { SimEcsCommandHandler } from "../sim-ecs-command-handler.js";
 import type { SimEcsRequestOptions } from "../sim-ecs-request-options.js";
@@ -45,7 +48,7 @@ export class DeleteClusterCommandHandler
   ): Promise<SimDeleteClusterCommandOutput> {
     this.refuseUnaccepted(command.input);
 
-    const identifier = command.input.cluster;
+    const identifier = this.requiredCluster(command);
     const clusterName = this.clusterArn.clusterName(identifier);
 
     await this.sequence();
@@ -53,7 +56,7 @@ export class DeleteClusterCommandHandler
     this.authorizer.authorizeCluster(
       "ecs:DeleteCluster",
       clusterName === undefined
-        ? String(identifier)
+        ? identifier
         : this.clusterArn.make(clusterName),
       options,
     );
@@ -71,9 +74,30 @@ export class DeleteClusterCommandHandler
     };
   }
 
+  /**
+   * The cluster the request named.
+   *
+   * Real ECS makes this required, unlike the operations that read a cluster,
+   * so a request naming none is refused rather than taken as meaning the
+   * `default` cluster. Deleting a cluster nobody asked to delete is the one
+   * answer worth being strict about.
+   */
+  private requiredCluster(command: SimDeleteClusterCommand): string {
+    const { cluster } = command.input;
+
+    if (cluster === undefined || cluster === "") {
+      throw new SimEcsClientException(
+        "DeleteCluster needs the cluster to delete, named by its short name " +
+          "or its full ARN.",
+      );
+    }
+
+    return cluster;
+  }
+
   private deletable(
     clusterName: string | undefined,
-    identifier: string | undefined,
+    identifier: string,
   ): SimEcsCluster {
     const cluster =
       clusterName === undefined
@@ -83,7 +107,7 @@ export class DeleteClusterCommandHandler
     if (cluster === undefined) {
       throw new SimEcsClusterNotFoundException(
         `The simulated Account and Region hold no active cluster ` +
-          `${identifier ?? "default"}.`,
+          `${identifier}.`,
       );
     }
 

--- a/src/service/ecs/command/delete-cluster/delete-cluster.iso.test.ts
+++ b/src/service/ecs/command/delete-cluster/delete-cluster.iso.test.ts
@@ -1,0 +1,175 @@
+import {
+  CreateClusterCommand,
+  DeleteClusterCommand,
+  DescribeClustersCommand,
+  ListClustersCommand,
+} from "@aws-sdk/client-ecs";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimEcsClusterNotFoundException } from "../../error/sim-ecs.error.js";
+import type { SimEcs } from "../../sim-ecs.js";
+
+async function simEcsWithCluster(): Promise<SimEcs> {
+  const simEcs = new SimAws().ecs();
+  await simEcs.createCluster(
+    new CreateClusterCommand({ clusterName: "services" }),
+  );
+
+  return simEcs;
+}
+
+describe("ECS DeleteClusterCommand", () => {
+  it("marks a deleted cluster inactive and leaves it describable", async () => {
+    // Given a cluster.
+    const simEcs = await simEcsWithCluster();
+
+    // When it is deleted.
+    const deleted = await simEcs.deleteCluster(
+      new DeleteClusterCommand({ cluster: "services" }),
+    );
+
+    // Then it is reported as INACTIVE, and it is still describable.
+    assertIdentical(deleted.cluster?.status, "INACTIVE");
+
+    const described = await simEcs.describeClusters(
+      new DescribeClustersCommand({ clusters: ["services"] }),
+    );
+
+    assertArrayLength(described.clusters, 1);
+    assertIdentical(described.clusters[0].status, "INACTIVE");
+  });
+
+  it("stops a deleted cluster being listed", async () => {
+    // Given a cluster that has been deleted.
+    const simEcs = await simEcsWithCluster();
+    await simEcs.deleteCluster(
+      new DeleteClusterCommand({ cluster: "services" }),
+    );
+
+    // When the clusters are listed.
+    const listed = await simEcs.listClusters(new ListClustersCommand({}));
+
+    // Then the deleted one is not among them.
+    assertArrayLength(listed.clusterArns, 0);
+  });
+
+  it("deletes a cluster named by its ARN", async () => {
+    // Given a cluster and the ARN it was given.
+    const simEcs = await simEcsWithCluster();
+    const described = await simEcs.describeClusters(
+      new DescribeClustersCommand({ clusters: ["services"] }),
+    );
+
+    // When it is deleted by ARN.
+    const deleted = await simEcs.deleteCluster(
+      new DeleteClusterCommand({
+        cluster: described.clusters?.[0]?.clusterArn,
+      }),
+    );
+
+    // Then the same cluster is the one deleted.
+    assertIdentical(deleted.cluster?.clusterName, "services");
+  });
+
+  it("frees the name for a new cluster", async () => {
+    // Given a cluster that has been deleted.
+    const simEcs = await simEcsWithCluster();
+    await simEcs.deleteCluster(
+      new DeleteClusterCommand({ cluster: "services" }),
+    );
+
+    // When a cluster with the same name is created again.
+    const created = await simEcs.createCluster(
+      new CreateClusterCommand({ clusterName: "services" }),
+    );
+
+    // Then it is a new active cluster.
+    assertIdentical(created.cluster?.status, "ACTIVE");
+  });
+
+  it("refuses a cluster that is not there", async () => {
+    // Given simulated ECS holding no clusters.
+    const simEcs = new SimAws().ecs();
+
+    // When a cluster that does not exist is deleted.
+    const error = await assertThrowsErrorAsync(async () =>
+      simEcs.deleteCluster(new DeleteClusterCommand({ cluster: "services" })),
+    );
+
+    // Then ECS refuses it.
+    assertInstanceOf(error, SimEcsClusterNotFoundException);
+    assertIdentical(error.name, "ClusterNotFoundException");
+    assertStringIncludes(error.message, "no active cluster services");
+  });
+
+  it("refuses a cluster that is already deleted", async () => {
+    // Given a cluster that has been deleted.
+    const simEcs = await simEcsWithCluster();
+    await simEcs.deleteCluster(
+      new DeleteClusterCommand({ cluster: "services" }),
+    );
+
+    // When it is deleted again.
+    const error = await assertThrowsErrorAsync(async () =>
+      simEcs.deleteCluster(new DeleteClusterCommand({ cluster: "services" })),
+    );
+
+    // Then ECS refuses it, since there is no active cluster of that name.
+    assertInstanceOf(error, SimEcsClusterNotFoundException);
+  });
+
+  it("refuses the default cluster where there is none", async () => {
+    // Given simulated ECS holding no clusters.
+    const simEcs = new SimAws().ecs();
+
+    // When a deletion names no cluster at all.
+    const error = await assertThrowsErrorAsync(async () =>
+      simEcs.deleteCluster({ input: {} }),
+    );
+
+    // Then it means the default cluster, which is not there either.
+    assertInstanceOf(error, SimEcsClusterNotFoundException);
+    assertStringIncludes(error.message, "no active cluster default");
+  });
+
+  it("refuses an identifier that is not an ECS ARN", async () => {
+    // Given a cluster.
+    const simEcs = await simEcsWithCluster();
+
+    // When something that is not an ECS ARN is deleted.
+    const error = await assertThrowsErrorAsync(async () =>
+      simEcs.deleteCluster(
+        new DeleteClusterCommand({
+          cluster: "arn:aws:s3:::example-bucket/services",
+        }),
+      ),
+    );
+
+    // Then it names no cluster here, so nothing is deleted.
+    assertInstanceOf(error, SimEcsClusterNotFoundException);
+  });
+
+  it("refuses an ARN belonging to another region", async () => {
+    // Given a cluster.
+    const simEcs = await simEcsWithCluster();
+
+    // When a cluster ARN in a different region is deleted.
+    const error = await assertThrowsErrorAsync(async () =>
+      simEcs.deleteCluster(
+        new DeleteClusterCommand({
+          cluster: "arn:aws:ecs:ap-south-1:888888888888:cluster/services",
+        }),
+      ),
+    );
+
+    // Then it names a cluster somewhere else, so nothing is deleted.
+    assertInstanceOf(error, SimEcsClusterNotFoundException);
+  });
+});

--- a/src/service/ecs/command/delete-cluster/delete-cluster.iso.test.ts
+++ b/src/service/ecs/command/delete-cluster/delete-cluster.iso.test.ts
@@ -13,7 +13,10 @@ import {
 } from "@kensio/smartass";
 import { describe, it } from "vitest";
 import { SimAws } from "../../../aws/sim-aws.js";
-import { SimEcsClusterNotFoundException } from "../../error/sim-ecs.error.js";
+import {
+  SimEcsClientException,
+  SimEcsClusterNotFoundException,
+} from "../../error/sim-ecs.error.js";
 import type { SimEcs } from "../../sim-ecs.js";
 
 async function simEcsWithCluster(): Promise<SimEcs> {
@@ -78,6 +81,29 @@ describe("ECS DeleteClusterCommand", () => {
     assertIdentical(deleted.cluster?.clusterName, "services");
   });
 
+  it("lists a recreated cluster in the order it was created again", async () => {
+    // Given two clusters, the first of which has been deleted.
+    const simEcs = await simEcsWithCluster();
+    await simEcs.createCluster(
+      new CreateClusterCommand({ clusterName: "batch" }),
+    );
+    await simEcs.deleteCluster(
+      new DeleteClusterCommand({ cluster: "services" }),
+    );
+
+    // When the deleted name is created again.
+    await simEcs.createCluster(
+      new CreateClusterCommand({ clusterName: "services" }),
+    );
+
+    // Then it comes last, since it is the most recently created one.
+    const listed = await simEcs.listClusters(new ListClustersCommand({}));
+
+    assertArrayLength(listed.clusterArns, 2);
+    assertStringIncludes(listed.clusterArns[0], "cluster/batch");
+    assertStringIncludes(listed.clusterArns[1], "cluster/services");
+  });
+
   it("frees the name for a new cluster", async () => {
     // Given a cluster that has been deleted.
     const simEcs = await simEcsWithCluster();
@@ -125,18 +151,23 @@ describe("ECS DeleteClusterCommand", () => {
     assertInstanceOf(error, SimEcsClusterNotFoundException);
   });
 
-  it("refuses the default cluster where there is none", async () => {
-    // Given simulated ECS holding no clusters.
+  it("refuses a deletion naming no cluster", async () => {
+    // Given the default cluster.
     const simEcs = new SimAws().ecs();
+    await simEcs.createCluster(new CreateClusterCommand({}));
 
     // When a deletion names no cluster at all.
     const error = await assertThrowsErrorAsync(async () =>
       simEcs.deleteCluster({ input: {} }),
     );
 
-    // Then it means the default cluster, which is not there either.
-    assertInstanceOf(error, SimEcsClusterNotFoundException);
-    assertStringIncludes(error.message, "no active cluster default");
+    // Then it is refused rather than taken as meaning the default cluster,
+    // because real ECS makes this one required.
+    assertInstanceOf(error, SimEcsClientException);
+    assertStringIncludes(error.message, "needs the cluster to delete");
+
+    const listed = await simEcs.listClusters(new ListClustersCommand({}));
+    assertArrayLength(listed.clusterArns, 1);
   });
 
   it("refuses an identifier that is not an ECS ARN", async () => {

--- a/src/service/ecs/command/deregister-task-definition/deregister-task-definition.command.ts
+++ b/src/service/ecs/command/deregister-task-definition/deregister-task-definition.command.ts
@@ -1,0 +1,29 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type { SimEcsTaskDefinitionDetail } from "../../task-definition/sim-ecs-task-definition-detail.js";
+
+/**
+ * Minimal structural sim ECS DeregisterTaskDefinition command.
+ */
+export interface SimDeregisterTaskDefinitionCommand {
+  readonly input: SimDeregisterTaskDefinitionCommandInput;
+}
+
+/**
+ * Minimal structural sim ECS DeregisterTaskDefinition input.
+ *
+ * `taskDefinition` takes a `family:revision` or a full ARN. A family on its
+ * own is not enough, because deregistering is done to one revision.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/ecs/command/DeregisterTaskDefinitionCommand/
+ */
+export interface SimDeregisterTaskDefinitionCommandInput {
+  readonly taskDefinition?: string | undefined;
+}
+
+/**
+ * Minimal structural sim ECS DeregisterTaskDefinition output.
+ */
+export interface SimDeregisterTaskDefinitionCommandOutput {
+  readonly taskDefinition?: SimEcsTaskDefinitionDetail | undefined;
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/ecs/command/deregister-task-definition/deregister-task-definition.handler.ts
+++ b/src/service/ecs/command/deregister-task-definition/deregister-task-definition.handler.ts
@@ -1,0 +1,88 @@
+import type { CommandHandler } from "../../../../command/command-handler.js";
+import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
+import { SimEcsClientException } from "../../error/sim-ecs.error.js";
+import { SimEcsTaskDefinitionId } from "../../task-definition/sim-ecs-task-definition-id.js";
+import type { SimEcsTaskDefinitionStore } from "../../task-definition/sim-ecs-task-definition-store.js";
+import type { SimEcsTaskDefinitionCommandContext } from "../sim-ecs-command-context.js";
+import { SimEcsCommandHandler } from "../sim-ecs-command-handler.js";
+import type { SimEcsRequestOptions } from "../sim-ecs-request-options.js";
+import type {
+  SimDeregisterTaskDefinitionCommand,
+  SimDeregisterTaskDefinitionCommandOutput,
+} from "./deregister-task-definition.command.js";
+
+const acceptedInput: readonly string[] = ["taskDefinition"];
+
+/**
+ * Simulated ECS DeregisterTaskDefinitionCommand handler.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/ecs/command/DeregisterTaskDefinitionCommand/
+ */
+export class DeregisterTaskDefinitionCommandHandler
+  extends SimEcsCommandHandler
+  implements
+    CommandHandler<
+      SimDeregisterTaskDefinitionCommand,
+      SimDeregisterTaskDefinitionCommandOutput
+    >
+{
+  private readonly taskDefinitions: SimEcsTaskDefinitionStore;
+  private readonly accountRegionScope: SimAwsAccountRegionScope;
+
+  constructor(context: SimEcsTaskDefinitionCommandContext) {
+    super(context, "DeregisterTaskDefinition", acceptedInput);
+    this.taskDefinitions = context.taskDefinitions;
+    this.accountRegionScope = context.accountRegionScope;
+  }
+
+  /**
+   * Deregister one revision, which marks it `INACTIVE` rather than removing
+   * it.
+   *
+   * The revision stays describable by `family:revision` and by ARN, because
+   * something already holding either of those still needs to find out what it
+   * declared. What it stops being is the revision the family resolves to, and
+   * it stops being listed among the family's active revisions.
+   *
+   * A revision that is already inactive is reported as it stands. The instant
+   * it was deregistered belongs to the deregistration that did it, so a second
+   * request does not move it.
+   */
+  async handle(
+    command: SimDeregisterTaskDefinitionCommand,
+    options?: SimEcsRequestOptions,
+  ): Promise<SimDeregisterTaskDefinitionCommandOutput> {
+    this.refuseUnaccepted(command.input);
+
+    const id = SimEcsTaskDefinitionId.parse(
+      command.input.taskDefinition,
+      this.accountRegionScope,
+    );
+
+    if (id.revision === undefined) {
+      throw new SimEcsClientException(
+        `Deregistering needs one revision, named as family:revision or as a ` +
+          `task definition ARN. ${String(command.input.taskDefinition)} names ` +
+          `a family.`,
+      );
+    }
+
+    await this.sequence();
+
+    this.authorizer.authorizeAnyResource(
+      "ecs:DeregisterTaskDefinition",
+      options,
+    );
+
+    const taskDefinition = this.taskDefinitions.resolve(id);
+
+    if (taskDefinition.isActive()) {
+      taskDefinition.markDeregistered(this.background.now());
+    }
+
+    return {
+      $metadata: {},
+      taskDefinition: taskDefinition.toOutput(),
+    };
+  }
+}

--- a/src/service/ecs/command/deregister-task-definition/deregister-task-definition.iso.test.ts
+++ b/src/service/ecs/command/deregister-task-definition/deregister-task-definition.iso.test.ts
@@ -1,0 +1,203 @@
+import {
+  DeregisterTaskDefinitionCommand,
+  DescribeTaskDefinitionCommand,
+} from "@aws-sdk/client-ecs";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimFixedClock } from "../../../../util/clock/sim-clock.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimEcsClientException } from "../../error/sim-ecs.error.js";
+import { simEcsRegisteredTaskDefinitionFactory } from "../../task-definition/sim-ecs-registered-task-definition.factory.js";
+
+describe("ECS DeregisterTaskDefinitionCommand", () => {
+  it("marks a revision inactive without removing it", async () => {
+    // Given a registered revision.
+    const simAws = new SimAws({
+      clock: new SimFixedClock(new Date("2026-05-06T07:08:09Z")),
+    });
+    await simEcsRegisteredTaskDefinitionFactory.make({}, simAws);
+
+    // When it is deregistered.
+    const deregistered = await simAws
+      .ecs()
+      .deregisterTaskDefinition(
+        new DeregisterTaskDefinitionCommand({ taskDefinition: "checkout:1" }),
+      );
+
+    // Then it is reported as INACTIVE, and it is still describable.
+    assertIdentical(deregistered.taskDefinition?.status, "INACTIVE");
+    assertIdentical(
+      deregistered.taskDefinition.deregisteredAt?.toISOString(),
+      "2026-05-06T07:08:09.000Z",
+    );
+
+    const described = await simAws
+      .ecs()
+      .describeTaskDefinition(
+        new DescribeTaskDefinitionCommand({ taskDefinition: "checkout:1" }),
+      );
+
+    assertIdentical(described.taskDefinition?.status, "INACTIVE");
+  });
+
+  it("stops a deregistered revision being the latest active one", async () => {
+    // Given a family with two revisions registered.
+    const simAws = new SimAws();
+    await simEcsRegisteredTaskDefinitionFactory.make(
+      { image: "checkout:1" },
+      simAws,
+    );
+    await simEcsRegisteredTaskDefinitionFactory.make(
+      { image: "checkout:2" },
+      simAws,
+    );
+
+    // When the newest revision is deregistered.
+    await simAws
+      .ecs()
+      .deregisterTaskDefinition(
+        new DeregisterTaskDefinitionCommand({ taskDefinition: "checkout:2" }),
+      );
+
+    // Then the family resolves to the revision before it.
+    const described = await simAws
+      .ecs()
+      .describeTaskDefinition(
+        new DescribeTaskDefinitionCommand({ taskDefinition: "checkout" }),
+      );
+
+    assertIdentical(described.taskDefinition?.revision, 1);
+  });
+
+  it("leaves the revision numbering where it was", async () => {
+    // Given a registered revision that has been deregistered.
+    const simAws = new SimAws();
+    await simEcsRegisteredTaskDefinitionFactory.make({}, simAws);
+    await simAws
+      .ecs()
+      .deregisterTaskDefinition(
+        new DeregisterTaskDefinitionCommand({ taskDefinition: "checkout:1" }),
+      );
+
+    // When the family is registered again.
+    const registered = await simEcsRegisteredTaskDefinitionFactory.make(
+      {},
+      simAws,
+    );
+
+    // Then the new revision is 2, since a number is never reused.
+    assertIdentical(registered.revision, 2);
+  });
+
+  it("refuses a family with no active revision left", async () => {
+    // Given a family whose only revision has been deregistered.
+    const simAws = new SimAws();
+    await simEcsRegisteredTaskDefinitionFactory.make({}, simAws);
+    await simAws
+      .ecs()
+      .deregisterTaskDefinition(
+        new DeregisterTaskDefinitionCommand({ taskDefinition: "checkout:1" }),
+      );
+
+    // When the family is described by name alone.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws
+        .ecs()
+        .describeTaskDefinition(
+          new DescribeTaskDefinitionCommand({ taskDefinition: "checkout" }),
+        ),
+    );
+
+    // Then there is nothing for it to resolve to.
+    assertInstanceOf(error, SimEcsClientException);
+    assertStringIncludes(error.message, "with an active revision");
+  });
+
+  it("deregisters a revision named by its ARN", async () => {
+    // Given a registered revision.
+    const simAws = new SimAws();
+    const registered = await simEcsRegisteredTaskDefinitionFactory.make(
+      {},
+      simAws,
+    );
+
+    // When it is deregistered by ARN.
+    const deregistered = await simAws.ecs().deregisterTaskDefinition(
+      new DeregisterTaskDefinitionCommand({
+        taskDefinition: registered.taskDefinitionArn,
+      }),
+    );
+
+    // Then that revision is the one marked inactive.
+    assertIdentical(deregistered.taskDefinition?.status, "INACTIVE");
+  });
+
+  it("leaves a deregistration instant where the first request set it", async () => {
+    // Given a revision that has already been deregistered.
+    const simAws = new SimAws();
+    await simEcsRegisteredTaskDefinitionFactory.make({}, simAws);
+    const first = await simAws
+      .ecs()
+      .deregisterTaskDefinition(
+        new DeregisterTaskDefinitionCommand({ taskDefinition: "checkout:1" }),
+      );
+
+    // When it is deregistered again.
+    const second = await simAws
+      .ecs()
+      .deregisterTaskDefinition(
+        new DeregisterTaskDefinitionCommand({ taskDefinition: "checkout:1" }),
+      );
+
+    // Then the instant belongs to the deregistration that did it.
+    assertNonNullable(first.taskDefinition?.deregisteredAt);
+    assertIdentical(
+      second.taskDefinition?.deregisteredAt?.toISOString(),
+      first.taskDefinition.deregisteredAt.toISOString(),
+    );
+  });
+
+  it("refuses a family named without a revision", async () => {
+    // Given a registered revision.
+    const simAws = new SimAws();
+    await simEcsRegisteredTaskDefinitionFactory.make({}, simAws);
+
+    // When the family alone is deregistered.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws
+        .ecs()
+        .deregisterTaskDefinition(
+          new DeregisterTaskDefinitionCommand({ taskDefinition: "checkout" }),
+        ),
+    );
+
+    // Then ECS refuses it, because deregistering is done to one revision.
+    assertInstanceOf(error, SimEcsClientException);
+    assertStringIncludes(error.message, "needs one revision");
+  });
+
+  it("refuses a revision that was never registered", async () => {
+    // Given a registered revision.
+    const simAws = new SimAws();
+    await simEcsRegisteredTaskDefinitionFactory.make({}, simAws);
+
+    // When a revision that does not exist is deregistered.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws
+        .ecs()
+        .deregisterTaskDefinition(
+          new DeregisterTaskDefinitionCommand({ taskDefinition: "checkout:9" }),
+        ),
+    );
+
+    // Then ECS refuses it.
+    assertInstanceOf(error, SimEcsClientException);
+    assertStringIncludes(error.message, "checkout:9");
+  });
+});

--- a/src/service/ecs/command/describe-clusters/describe-clusters-includes.ts
+++ b/src/service/ecs/command/describe-clusters/describe-clusters-includes.ts
@@ -1,0 +1,43 @@
+import type { SimEcsClusterIncludes } from "../../cluster/sim-ecs-cluster.js";
+import { SimEcsInvalidParameterException } from "../../error/sim-ecs.error.js";
+
+/**
+ * The `include` values a described cluster can answer for.
+ *
+ * `ATTACHMENTS` and `STATISTICS` are left out. Both describe capacity a
+ * cluster has attached to it, and there is none here, so answering either one
+ * would mean reporting made-up numbers as though they were counted.
+ */
+const answerable: ReadonlySet<string> = new Set([
+  "SETTINGS",
+  "CONFIGURATIONS",
+  "TAGS",
+]);
+
+/**
+ * Read what a `DescribeClusters` request asked to be reported.
+ *
+ * Real ECS leaves settings, configuration and tags out of a described cluster
+ * unless the request asked for them by name, so a test asserting on tags it
+ * did not ask for fails here as it would on AWS.
+ */
+export function describeClustersIncludes(
+  include: readonly string[] | undefined,
+): SimEcsClusterIncludes {
+  const asked = include ?? [];
+
+  for (const value of asked) {
+    if (!answerable.has(value)) {
+      throw new SimEcsInvalidParameterException(
+        `DescribeClusters include ${value} is not simulated. A simulated ` +
+          `cluster has no capacity attached to it to report.`,
+      );
+    }
+  }
+
+  return {
+    settings: asked.includes("SETTINGS"),
+    configuration: asked.includes("CONFIGURATIONS"),
+    tags: asked.includes("TAGS"),
+  };
+}

--- a/src/service/ecs/command/describe-clusters/describe-clusters.command.ts
+++ b/src/service/ecs/command/describe-clusters/describe-clusters.command.ts
@@ -1,0 +1,42 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type { SimEcsClusterDetail } from "../../cluster/sim-ecs-cluster.js";
+
+/**
+ * Minimal structural sim ECS DescribeClusters command.
+ */
+export interface SimDescribeClustersCommand {
+  readonly input: SimDescribeClustersCommandInput;
+}
+
+/**
+ * Minimal structural sim ECS DescribeClusters input.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/ecs/command/DescribeClustersCommand/
+ */
+export interface SimDescribeClustersCommandInput {
+  readonly clusters?: readonly string[] | undefined;
+  readonly include?: readonly string[] | undefined;
+}
+
+/**
+ * Minimal structural sim ECS failure entry.
+ *
+ * ECS reports a resource it could not act on here rather than raising, so one
+ * request naming several clusters answers for each of them.
+ *
+ * https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_Failure.html
+ */
+export interface SimEcsFailure {
+  readonly arn?: string | undefined;
+  readonly reason?: string | undefined;
+  readonly detail?: string | undefined;
+}
+
+/**
+ * Minimal structural sim ECS DescribeClusters output.
+ */
+export interface SimDescribeClustersCommandOutput {
+  readonly clusters?: readonly SimEcsClusterDetail[] | undefined;
+  readonly failures?: readonly SimEcsFailure[] | undefined;
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/ecs/command/describe-clusters/describe-clusters.handler.ts
+++ b/src/service/ecs/command/describe-clusters/describe-clusters.handler.ts
@@ -1,0 +1,59 @@
+import type { CommandHandler } from "../../../../command/command-handler.js";
+import type { SimEcsClusterCommandContext } from "../sim-ecs-command-context.js";
+import { SimEcsCommandHandler } from "../sim-ecs-command-handler.js";
+import type { SimEcsRequestOptions } from "../sim-ecs-request-options.js";
+import { describeClustersIncludes } from "./describe-clusters-includes.js";
+import { DescribedClusters } from "./described-clusters.js";
+import type {
+  SimDescribeClustersCommand,
+  SimDescribeClustersCommandOutput,
+} from "./describe-clusters.command.js";
+
+const acceptedInput: readonly string[] = ["clusters", "include"];
+
+/**
+ * Simulated ECS DescribeClustersCommand handler.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/ecs/command/DescribeClustersCommand/
+ */
+export class DescribeClustersCommandHandler
+  extends SimEcsCommandHandler
+  implements
+    CommandHandler<
+      SimDescribeClustersCommand,
+      SimDescribeClustersCommandOutput
+    >
+{
+  private readonly described: DescribedClusters;
+
+  constructor(context: SimEcsClusterCommandContext) {
+    super(context, "DescribeClusters", acceptedInput);
+    this.described = new DescribedClusters(context);
+  }
+
+  /**
+   * Describe each named cluster, or the default cluster when none is named.
+   */
+  async handle(
+    command: SimDescribeClustersCommand,
+    options?: SimEcsRequestOptions,
+  ): Promise<SimDescribeClustersCommandOutput> {
+    this.refuseUnaccepted(command.input);
+
+    const includes = describeClustersIncludes(command.input.include);
+
+    await this.sequence();
+
+    const described = this.described.describe(
+      command.input.clusters ?? [],
+      includes,
+      options,
+    );
+
+    return {
+      $metadata: {},
+      clusters: described.clusters,
+      failures: described.failures,
+    };
+  }
+}

--- a/src/service/ecs/command/describe-clusters/describe-clusters.iso.test.ts
+++ b/src/service/ecs/command/describe-clusters/describe-clusters.iso.test.ts
@@ -1,0 +1,156 @@
+import {
+  CreateClusterCommand,
+  DescribeClustersCommand,
+} from "@aws-sdk/client-ecs";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertObjectEquals,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimEcsInvalidParameterException } from "../../error/sim-ecs.error.js";
+import type { SimEcs } from "../../sim-ecs.js";
+
+async function simEcsWithCluster(): Promise<SimEcs> {
+  const simEcs = new SimAws().ecs();
+  await simEcs.createCluster(
+    new CreateClusterCommand({
+      clusterName: "services",
+      settings: [{ name: "containerInsights", value: "enabled" }],
+      configuration: { executeCommandConfiguration: { logging: "DEFAULT" } },
+      tags: [{ key: "team", value: "platform" }],
+    }),
+  );
+
+  return simEcs;
+}
+
+describe("ECS DescribeClustersCommand", () => {
+  it("describes a cluster by name and by ARN alike", async () => {
+    // Given a cluster.
+    const simEcs = await simEcsWithCluster();
+
+    // When it is described by name and by ARN.
+    const byName = await simEcs.describeClusters(
+      new DescribeClustersCommand({ clusters: ["services"] }),
+    );
+    const byArn = await simEcs.describeClusters(
+      new DescribeClustersCommand({
+        clusters: [byName.clusters?.[0]?.clusterArn ?? ""],
+      }),
+    );
+
+    // Then both reach the same cluster.
+    assertArrayLength(byArn.clusters, 1);
+    assertIdentical(byArn.clusters[0].clusterName, "services");
+    assertArrayLength(byArn.failures, 0);
+  });
+
+  it("reports a cluster that is not there as a failure", async () => {
+    // Given a cluster.
+    const simEcs = await simEcsWithCluster();
+
+    // When a request names it alongside one that does not exist.
+    const described = await simEcs.describeClusters(
+      new DescribeClustersCommand({ clusters: ["services", "missing"] }),
+    );
+
+    // Then the one that is there is described and the other is a failure.
+    assertArrayLength(described.clusters, 1);
+    assertArrayLength(described.failures, 1);
+    assertIdentical(described.failures[0].reason, "MISSING");
+    assertStringIncludes(described.failures[0].arn ?? "", "cluster/missing");
+  });
+
+  it("reports an ARN from another account as a failure", async () => {
+    // Given a cluster.
+    const simEcs = await simEcsWithCluster();
+
+    // When a cluster ARN in a different account is described.
+    const described = await simEcs.describeClusters(
+      new DescribeClustersCommand({
+        clusters: ["arn:aws:ecs:eu-west-2:999999999999:cluster/services"],
+      }),
+    );
+
+    // Then it names a cluster somewhere else, so nothing is described.
+    assertArrayLength(described.clusters, 0);
+    assertArrayLength(described.failures, 1);
+  });
+
+  it("describes the default cluster when the request names none", async () => {
+    // Given the default cluster.
+    const simEcs = new SimAws().ecs();
+    await simEcs.createCluster(new CreateClusterCommand({}));
+
+    // When clusters are described without naming one.
+    const described = await simEcs.describeClusters(
+      new DescribeClustersCommand({}),
+    );
+
+    // Then the default cluster answers.
+    assertArrayLength(described.clusters, 1);
+    assertIdentical(described.clusters[0].clusterName, "default");
+  });
+
+  it("leaves out settings, configuration and tags unless asked", async () => {
+    // Given a cluster with settings, configuration and tags.
+    const simEcs = await simEcsWithCluster();
+
+    // When it is described without an include list.
+    const described = await simEcs.describeClusters(
+      new DescribeClustersCommand({ clusters: ["services"] }),
+    );
+
+    // Then none of the three is reported, as on real ECS.
+    assertArrayLength(described.clusters, 1);
+    assertArrayLength(described.clusters[0].settings, 0);
+    assertArrayLength(described.clusters[0].tags, 0);
+    assertUndefined(described.clusters[0].configuration);
+  });
+
+  it("reports settings, configuration and tags where asked", async () => {
+    // Given a cluster with settings, configuration and tags.
+    const simEcs = await simEcsWithCluster();
+
+    // When it is described asking for all three.
+    const described = await simEcs.describeClusters(
+      new DescribeClustersCommand({
+        clusters: ["services"],
+        include: ["SETTINGS", "CONFIGURATIONS", "TAGS"],
+      }),
+    );
+
+    // Then each one comes back as it was created.
+    assertArrayLength(described.clusters, 1);
+    assertArrayLength(described.clusters[0].settings, 1);
+    assertArrayLength(described.clusters[0].tags, 1);
+    assertObjectEquals(described.clusters[0].configuration ?? {}, {
+      executeCommandConfiguration: { logging: "DEFAULT" },
+    });
+  });
+
+  it("refuses an include value naming capacity there is none of", async () => {
+    // Given a cluster.
+    const simEcs = await simEcsWithCluster();
+
+    // When statistics are asked for.
+    const error = await assertThrowsErrorAsync(async () =>
+      simEcs.describeClusters(
+        new DescribeClustersCommand({
+          clusters: ["services"],
+          include: ["STATISTICS"],
+        }),
+      ),
+    );
+
+    // Then ECS refuses it rather than reporting made-up counts.
+    assertInstanceOf(error, SimEcsInvalidParameterException);
+    assertStringIncludes(error.message, "STATISTICS is not simulated");
+  });
+});

--- a/src/service/ecs/command/describe-clusters/described-cluster.ts
+++ b/src/service/ecs/command/describe-clusters/described-cluster.ts
@@ -1,0 +1,84 @@
+import type { SimEcsClusterArn } from "../../cluster/sim-ecs-cluster-arn.js";
+import type {
+  SimEcsCluster,
+  SimEcsClusterDetail,
+  SimEcsClusterIncludes,
+} from "../../cluster/sim-ecs-cluster.js";
+import type { SimEcsClusterStore } from "../../cluster/sim-ecs-cluster-store.js";
+import type { SimEcsAuthorizer } from "../authorize/sim-ecs-authorizer.js";
+import type { SimEcsRequestOptions } from "../sim-ecs-request-options.js";
+import type { SimEcsFailure } from "./describe-clusters.command.js";
+
+interface DescribedClusterProperties {
+  readonly clusters: SimEcsClusterStore;
+  readonly clusterArn: SimEcsClusterArn;
+  readonly authorizer: SimEcsAuthorizer;
+}
+
+/**
+ * What one named cluster came to.
+ */
+export interface DescribedCluster {
+  readonly detail?: SimEcsClusterDetail | undefined;
+  readonly failure?: SimEcsFailure | undefined;
+}
+
+/**
+ * Describes one cluster a request named.
+ *
+ * A cluster that is not there comes back as a failure rather than raising, as
+ * real ECS reports it, which is what lets one request answer for several
+ * clusters at once. A deleted cluster is still described, as `INACTIVE`.
+ */
+export class SimEcsClusterDescriber {
+  private readonly clusters: SimEcsClusterStore;
+  private readonly clusterArn: SimEcsClusterArn;
+  private readonly authorizer: SimEcsAuthorizer;
+
+  constructor(properties: DescribedClusterProperties) {
+    this.clusters = properties.clusters;
+    this.clusterArn = properties.clusterArn;
+    this.authorizer = properties.authorizer;
+  }
+
+  /**
+   * Describe the cluster an identifier names, authorizing against its ARN.
+   *
+   * Authorization comes before the store is read, so a caller with no
+   * permission cannot learn from the answer whether the cluster is there.
+   */
+  describe(
+    identifier: string,
+    includes: SimEcsClusterIncludes,
+    options: SimEcsRequestOptions | undefined,
+  ): DescribedCluster {
+    const clusterName = this.clusterArn.clusterName(identifier);
+    const arn = this.arnFor(identifier, clusterName);
+
+    this.authorizer.authorizeCluster("ecs:DescribeClusters", arn, options);
+
+    const cluster = this.held(clusterName);
+
+    if (cluster === undefined) {
+      return { failure: { arn, reason: "MISSING" } };
+    }
+
+    return { detail: cluster.toOutput(includes) };
+  }
+
+  private arnFor(identifier: string, clusterName: string | undefined): string {
+    if (clusterName === undefined) {
+      return identifier;
+    }
+
+    return this.clusterArn.make(clusterName);
+  }
+
+  private held(clusterName: string | undefined): SimEcsCluster | undefined {
+    if (clusterName === undefined) {
+      return undefined;
+    }
+
+    return this.clusters.find(clusterName);
+  }
+}

--- a/src/service/ecs/command/describe-clusters/described-clusters.ts
+++ b/src/service/ecs/command/describe-clusters/described-clusters.ts
@@ -1,0 +1,62 @@
+import { simEcsDefaultClusterName } from "../../cluster/sim-ecs-cluster-arn.js";
+import type {
+  SimEcsClusterDetail,
+  SimEcsClusterIncludes,
+} from "../../cluster/sim-ecs-cluster.js";
+import type { SimEcsClusterCommandContext } from "../sim-ecs-command-context.js";
+import type { SimEcsRequestOptions } from "../sim-ecs-request-options.js";
+import { SimEcsClusterDescriber } from "./described-cluster.js";
+import type { SimEcsFailure } from "./describe-clusters.command.js";
+
+/**
+ * What a `DescribeClusters` request answers with.
+ */
+export interface DescribedClustersOutput {
+  readonly clusters: readonly SimEcsClusterDetail[];
+  readonly failures: readonly SimEcsFailure[];
+}
+
+/**
+ * Describes the clusters one request named, splitting answers from failures.
+ */
+export class DescribedClusters {
+  private readonly describer: SimEcsClusterDescriber;
+
+  constructor(context: SimEcsClusterCommandContext) {
+    this.describer = new SimEcsClusterDescriber(context);
+  }
+
+  /**
+   * Describe each identifier a request named.
+   */
+  describe(
+    identifiers: readonly string[],
+    includes: SimEcsClusterIncludes,
+    options: SimEcsRequestOptions | undefined,
+  ): DescribedClustersOutput {
+    const described = this.requested(identifiers).map((identifier) =>
+      this.describer.describe(identifier, includes, options),
+    );
+
+    return {
+      clusters: described
+        .map((one) => one.detail)
+        .filter((detail) => detail !== undefined),
+      failures: described
+        .map((one) => one.failure)
+        .filter((failure) => failure !== undefined),
+    };
+  }
+
+  /**
+   * The identifiers to describe, which is the default cluster when a request
+   * named none.
+   */
+  private requested(identifiers: readonly string[]): readonly string[] {
+    if (identifiers.length === 0) {
+      return [simEcsDefaultClusterName];
+    }
+
+    return identifiers;
+  }
+}

--- a/src/service/ecs/command/describe-task-definition/describe-task-definition.command.ts
+++ b/src/service/ecs/command/describe-task-definition/describe-task-definition.command.ts
@@ -1,0 +1,31 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type { SimEcsTag } from "../../task-definition/sim-ecs-task-definition-parts.js";
+import type { SimEcsTaskDefinitionDetail } from "../../task-definition/sim-ecs-task-definition-detail.js";
+
+/**
+ * Minimal structural sim ECS DescribeTaskDefinition command.
+ */
+export interface SimDescribeTaskDefinitionCommand {
+  readonly input: SimDescribeTaskDefinitionCommandInput;
+}
+
+/**
+ * Minimal structural sim ECS DescribeTaskDefinition input.
+ *
+ * `taskDefinition` takes a family, a `family:revision`, or a full ARN.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/ecs/command/DescribeTaskDefinitionCommand/
+ */
+export interface SimDescribeTaskDefinitionCommandInput {
+  readonly taskDefinition?: string | undefined;
+  readonly include?: readonly string[] | undefined;
+}
+
+/**
+ * Minimal structural sim ECS DescribeTaskDefinition output.
+ */
+export interface SimDescribeTaskDefinitionCommandOutput {
+  readonly taskDefinition?: SimEcsTaskDefinitionDetail | undefined;
+  readonly tags?: readonly SimEcsTag[] | undefined;
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/ecs/command/describe-task-definition/describe-task-definition.handler.ts
+++ b/src/service/ecs/command/describe-task-definition/describe-task-definition.handler.ts
@@ -1,0 +1,91 @@
+import type { CommandHandler } from "../../../../command/command-handler.js";
+import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
+import { SimEcsInvalidParameterException } from "../../error/sim-ecs.error.js";
+import { SimEcsTaskDefinitionId } from "../../task-definition/sim-ecs-task-definition-id.js";
+import type { SimEcsTaskDefinitionStore } from "../../task-definition/sim-ecs-task-definition-store.js";
+import type { SimEcsTaskDefinitionCommandContext } from "../sim-ecs-command-context.js";
+import { SimEcsCommandHandler } from "../sim-ecs-command-handler.js";
+import type { SimEcsRequestOptions } from "../sim-ecs-request-options.js";
+import type {
+  SimDescribeTaskDefinitionCommand,
+  SimDescribeTaskDefinitionCommandOutput,
+} from "./describe-task-definition.command.js";
+
+const acceptedInput: readonly string[] = ["taskDefinition", "include"];
+
+/**
+ * Simulated ECS DescribeTaskDefinitionCommand handler.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/ecs/command/DescribeTaskDefinitionCommand/
+ */
+export class DescribeTaskDefinitionCommandHandler
+  extends SimEcsCommandHandler
+  implements
+    CommandHandler<
+      SimDescribeTaskDefinitionCommand,
+      SimDescribeTaskDefinitionCommandOutput
+    >
+{
+  private readonly taskDefinitions: SimEcsTaskDefinitionStore;
+  private readonly accountRegionScope: SimAwsAccountRegionScope;
+
+  constructor(context: SimEcsTaskDefinitionCommandContext) {
+    super(context, "DescribeTaskDefinition", acceptedInput);
+    this.taskDefinitions = context.taskDefinitions;
+    this.accountRegionScope = context.accountRegionScope;
+  }
+
+  /**
+   * Describe the revision an identifier names.
+   *
+   * A family on its own resolves to its latest active revision, so it follows
+   * registrations as they are made and falls back to an earlier revision when
+   * the newest one is deregistered. A `family:revision` and an ARN both name
+   * one revision, which stays describable after it is deregistered.
+   */
+  async handle(
+    command: SimDescribeTaskDefinitionCommand,
+    options?: SimEcsRequestOptions,
+  ): Promise<SimDescribeTaskDefinitionCommandOutput> {
+    this.refuseUnaccepted(command.input);
+
+    const withTags = this.asksForTags(command.input.include);
+    const id = SimEcsTaskDefinitionId.parse(
+      command.input.taskDefinition,
+      this.accountRegionScope,
+    );
+
+    await this.sequence();
+
+    this.authorizer.authorizeAnyResource("ecs:DescribeTaskDefinition", options);
+
+    const taskDefinition = this.taskDefinitions.resolve(id);
+
+    return {
+      $metadata: {},
+      taskDefinition: taskDefinition.toOutput(),
+      tags: withTags ? taskDefinition.toTagsOutput() : [],
+    };
+  }
+
+  /**
+   * Whether the request asked for the revision's tags.
+   *
+   * `TAGS` is the only `include` value this operation takes on real ECS, so
+   * anything else is a request that would fail there too.
+   */
+  private asksForTags(include: readonly string[] | undefined): boolean {
+    const asked = include ?? [];
+
+    for (const value of asked) {
+      if (value !== "TAGS") {
+        throw new SimEcsInvalidParameterException(
+          `DescribeTaskDefinition include ${value} is not a value this ` +
+            `operation takes. Only TAGS is.`,
+        );
+      }
+    }
+
+    return asked.includes("TAGS");
+  }
+}

--- a/src/service/ecs/command/describe-task-definition/describe-task-definition.iso.test.ts
+++ b/src/service/ecs/command/describe-task-definition/describe-task-definition.iso.test.ts
@@ -186,6 +186,31 @@ describe("ECS DescribeTaskDefinitionCommand", () => {
     assertStringIncludes(error.message, "a whole number from 1");
   });
 
+  it("refuses a revision written as anything but digits", async () => {
+    // Given a registered revision.
+    const simAws = new SimAws();
+    await simEcsRegisteredTaskDefinitionFactory.make({}, simAws);
+
+    // When revisions are named in forms real ECS does not take.
+    const errors = await Promise.all(
+      ["checkout:1.0", "checkout:0x1", "checkout: 1"].map(async (written) =>
+        assertThrowsErrorAsync(async () =>
+          simAws
+            .ecs()
+            .describeTaskDefinition(
+              new DescribeTaskDefinitionCommand({ taskDefinition: written }),
+            ),
+        ),
+      ),
+    );
+
+    // Then each is refused, rather than being read as revision 1.
+    for (const error of errors) {
+      assertInstanceOf(error, SimEcsClientException);
+      assertStringIncludes(error.message, "a whole number from 1");
+    }
+  });
+
   it("refuses an ARN belonging to another account", async () => {
     // Given a registered revision.
     const simAws = new SimAws();

--- a/src/service/ecs/command/describe-task-definition/describe-task-definition.iso.test.ts
+++ b/src/service/ecs/command/describe-task-definition/describe-task-definition.iso.test.ts
@@ -1,0 +1,227 @@
+import {
+  DescribeTaskDefinitionCommand,
+  RegisterTaskDefinitionCommand,
+} from "@aws-sdk/client-ecs";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import {
+  SimEcsClientException,
+  SimEcsInvalidParameterException,
+} from "../../error/sim-ecs.error.js";
+import { simEcsRegisteredTaskDefinitionFactory } from "../../task-definition/sim-ecs-registered-task-definition.factory.js";
+
+async function simAwsWithTwoRevisions(): Promise<SimAws> {
+  const simAws = new SimAws();
+  await simEcsRegisteredTaskDefinitionFactory.make(
+    { image: "checkout:1" },
+    simAws,
+  );
+  await simEcsRegisteredTaskDefinitionFactory.make(
+    { image: "checkout:2" },
+    simAws,
+  );
+
+  return simAws;
+}
+
+describe("ECS DescribeTaskDefinitionCommand", () => {
+  it("resolves a family alone to its latest active revision", async () => {
+    // Given a family with two revisions registered.
+    const simAws = await simAwsWithTwoRevisions();
+
+    // When the family is described by name alone.
+    const described = await simAws
+      .ecs()
+      .describeTaskDefinition(
+        new DescribeTaskDefinitionCommand({ taskDefinition: "checkout" }),
+      );
+
+    // Then the newest revision answers.
+    assertIdentical(described.taskDefinition?.revision, 2);
+    assertIdentical(
+      described.taskDefinition.containerDefinitions?.[0]?.image,
+      "checkout:2",
+    );
+  });
+
+  it("resolves a family and revision to that revision", async () => {
+    // Given a family with two revisions registered.
+    const simAws = await simAwsWithTwoRevisions();
+
+    // When an earlier revision is named.
+    const described = await simAws
+      .ecs()
+      .describeTaskDefinition(
+        new DescribeTaskDefinitionCommand({ taskDefinition: "checkout:1" }),
+      );
+
+    // Then that revision answers rather than the newest.
+    assertIdentical(described.taskDefinition?.revision, 1);
+    assertIdentical(
+      described.taskDefinition.containerDefinitions?.[0]?.image,
+      "checkout:1",
+    );
+  });
+
+  it("resolves a full task definition ARN", async () => {
+    // Given a registered revision and the ARN it was given.
+    const simAws = new SimAws();
+    const registered = await simEcsRegisteredTaskDefinitionFactory.make(
+      {},
+      simAws,
+    );
+
+    // When that ARN is described.
+    const described = await simAws.ecs().describeTaskDefinition(
+      new DescribeTaskDefinitionCommand({
+        taskDefinition: registered.taskDefinitionArn,
+      }),
+    );
+
+    // Then the same revision answers.
+    assertIdentical(
+      described.taskDefinition?.taskDefinitionArn,
+      registered.taskDefinitionArn,
+    );
+  });
+
+  it("reports tags only where the request asked for them", async () => {
+    // Given a revision registered with tags.
+    const simEcs = new SimAws().ecs();
+    await simEcs.registerTaskDefinition(
+      new RegisterTaskDefinitionCommand({
+        family: "checkout",
+        containerDefinitions: [{ name: "app", image: "checkout:1" }],
+        tags: [{ key: "team", value: "payments" }],
+      }),
+    );
+
+    // When it is described with and without asking for tags.
+    const withoutTags = await simEcs.describeTaskDefinition(
+      new DescribeTaskDefinitionCommand({ taskDefinition: "checkout" }),
+    );
+    const withTags = await simEcs.describeTaskDefinition(
+      new DescribeTaskDefinitionCommand({
+        taskDefinition: "checkout",
+        include: ["TAGS"],
+      }),
+    );
+
+    // Then only the request that asked gets them.
+    assertArrayLength(withoutTags.tags, 0);
+    assertArrayLength(withTags.tags, 1);
+    assertIdentical(withTags.tags[0].key, "team");
+  });
+
+  it("refuses an include value this operation does not take", async () => {
+    // Given a registered revision.
+    const simAws = new SimAws();
+    await simEcsRegisteredTaskDefinitionFactory.make({}, simAws);
+
+    // When it is described asking for something other than tags.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.ecs().describeTaskDefinition({
+        input: { taskDefinition: "checkout", include: ["SETTINGS"] },
+      }),
+    );
+
+    // Then ECS refuses it.
+    assertInstanceOf(error, SimEcsInvalidParameterException);
+    assertStringIncludes(error.message, "Only TAGS is");
+  });
+
+  it("refuses a family that has never been registered", async () => {
+    // Given simulated ECS holding nothing.
+    const simEcs = new SimAws().ecs();
+
+    // When an unregistered family is described.
+    const error = await assertThrowsErrorAsync(async () =>
+      simEcs.describeTaskDefinition(
+        new DescribeTaskDefinitionCommand({ taskDefinition: "checkout" }),
+      ),
+    );
+
+    // Then ECS refuses it.
+    assertInstanceOf(error, SimEcsClientException);
+    assertStringIncludes(error.message, "Unable to describe task definition");
+  });
+
+  it("refuses a request naming no task definition", async () => {
+    // Given simulated ECS.
+    const simEcs = new SimAws().ecs();
+
+    // When nothing is named.
+    const error = await assertThrowsErrorAsync(async () =>
+      simEcs.describeTaskDefinition({ input: {} }),
+    );
+
+    // Then ECS refuses it.
+    assertInstanceOf(error, SimEcsClientException);
+    assertStringIncludes(error.message, "is required");
+  });
+
+  it("refuses a revision that is not a whole number", async () => {
+    // Given a registered revision.
+    const simAws = new SimAws();
+    await simEcsRegisteredTaskDefinitionFactory.make({}, simAws);
+
+    // When a revision that is not a number is named.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws
+        .ecs()
+        .describeTaskDefinition(
+          new DescribeTaskDefinitionCommand({ taskDefinition: "checkout:one" }),
+        ),
+    );
+
+    // Then ECS refuses it.
+    assertInstanceOf(error, SimEcsClientException);
+    assertStringIncludes(error.message, "a whole number from 1");
+  });
+
+  it("refuses an ARN belonging to another account", async () => {
+    // Given a registered revision.
+    const simAws = new SimAws();
+    await simEcsRegisteredTaskDefinitionFactory.make({}, simAws);
+
+    // When an ARN in a different account is described.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.ecs().describeTaskDefinition(
+        new DescribeTaskDefinitionCommand({
+          taskDefinition:
+            "arn:aws:ecs:eu-west-2:999999999999:task-definition/checkout:1",
+        }),
+      ),
+    );
+
+    // Then it names a task definition somewhere else, so nothing answers.
+    assertInstanceOf(error, SimEcsClientException);
+    assertStringIncludes(error.message, "does not name a task definition");
+  });
+
+  it("refuses an ARN that is not a task definition", async () => {
+    // Given a registered revision.
+    const simAws = new SimAws();
+    await simEcsRegisteredTaskDefinitionFactory.make({}, simAws);
+
+    // When a cluster ARN is described as a task definition.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.ecs().describeTaskDefinition(
+        new DescribeTaskDefinitionCommand({
+          taskDefinition: `arn:aws:ecs:${simAws.defaultRegionName}:${simAws.defaultAccountId}:cluster/checkout`,
+        }),
+      ),
+    );
+
+    // Then ECS refuses it.
+    assertInstanceOf(error, SimEcsClientException);
+    assertStringIncludes(error.message, "does not name a task definition");
+  });
+});

--- a/src/service/ecs/command/list-clusters/list-clusters.command.ts
+++ b/src/service/ecs/command/list-clusters/list-clusters.command.ts
@@ -1,0 +1,28 @@
+import type { SimArn } from "../../../aws/arn.js";
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+
+/**
+ * Minimal structural sim ECS ListClusters command.
+ */
+export interface SimListClustersCommand {
+  readonly input: SimListClustersCommandInput;
+}
+
+/**
+ * Minimal structural sim ECS ListClusters input.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/ecs/command/ListClustersCommand/
+ */
+export interface SimListClustersCommandInput {
+  readonly maxResults?: number | undefined;
+  readonly nextToken?: string | undefined;
+}
+
+/**
+ * Minimal structural sim ECS ListClusters output.
+ */
+export interface SimListClustersCommandOutput {
+  readonly clusterArns?: readonly SimArn[] | undefined;
+  readonly nextToken?: string | undefined;
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/ecs/command/list-clusters/list-clusters.handler.ts
+++ b/src/service/ecs/command/list-clusters/list-clusters.handler.ts
@@ -1,0 +1,59 @@
+import type { CommandHandler } from "../../../../command/command-handler.js";
+import type { SimArn } from "../../../aws/arn.js";
+import type { SimEcsClusterStore } from "../../cluster/sim-ecs-cluster-store.js";
+import { SimEcsPage } from "../sim-ecs-page.js";
+import type { SimEcsClusterCommandContext } from "../sim-ecs-command-context.js";
+import { SimEcsCommandHandler } from "../sim-ecs-command-handler.js";
+import type { SimEcsRequestOptions } from "../sim-ecs-request-options.js";
+import type {
+  SimListClustersCommand,
+  SimListClustersCommandOutput,
+} from "./list-clusters.command.js";
+
+const acceptedInput: readonly string[] = ["maxResults", "nextToken"];
+
+/**
+ * Simulated ECS ListClustersCommand handler.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/ecs/command/ListClustersCommand/
+ */
+export class ListClustersCommandHandler
+  extends SimEcsCommandHandler
+  implements
+    CommandHandler<SimListClustersCommand, SimListClustersCommandOutput>
+{
+  private readonly clusters: SimEcsClusterStore;
+
+  constructor(context: SimEcsClusterCommandContext) {
+    super(context, "ListClusters", acceptedInput);
+    this.clusters = context.clusters;
+  }
+
+  /**
+   * List the ARNs of the active clusters, in the order they were created.
+   *
+   * A deleted cluster is left out. It is still describable by name, but it is
+   * no longer one of the clusters this Account and Region has.
+   */
+  async handle(
+    command: SimListClustersCommand,
+    options?: SimEcsRequestOptions,
+  ): Promise<SimListClustersCommandOutput> {
+    this.refuseUnaccepted(command.input);
+
+    await this.sequence();
+
+    this.authorizer.authorizeAnyResource("ecs:ListClusters", options);
+
+    const page = new SimEcsPage<SimArn>(
+      this.clusters.active().map((cluster) => cluster.clusterArn),
+      command.input,
+    );
+
+    return {
+      $metadata: {},
+      clusterArns: page.items,
+      ...(page.nextToken !== undefined && { nextToken: page.nextToken }),
+    };
+  }
+}

--- a/src/service/ecs/command/list-clusters/list-clusters.iso.test.ts
+++ b/src/service/ecs/command/list-clusters/list-clusters.iso.test.ts
@@ -1,0 +1,106 @@
+import { CreateClusterCommand, ListClustersCommand } from "@aws-sdk/client-ecs";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimEcsInvalidParameterException } from "../../error/sim-ecs.error.js";
+import type { SimEcs } from "../../sim-ecs.js";
+
+async function simEcsWithClusters(): Promise<SimEcs> {
+  const simEcs = new SimAws().ecs();
+
+  await simEcs.createCluster(
+    new CreateClusterCommand({ clusterName: "services-1" }),
+  );
+  await simEcs.createCluster(
+    new CreateClusterCommand({ clusterName: "services-2" }),
+  );
+  await simEcs.createCluster(
+    new CreateClusterCommand({ clusterName: "services-3" }),
+  );
+
+  return simEcs;
+}
+
+describe("ECS ListClustersCommand", () => {
+  it("lists the ARNs of the clusters that are there", async () => {
+    // Given three clusters.
+    const simEcs = await simEcsWithClusters();
+
+    // When the clusters are listed.
+    const listed = await simEcs.listClusters(new ListClustersCommand({}));
+
+    // Then every ARN comes back, in the order they were created.
+    assertArrayLength(listed.clusterArns, 3);
+    assertStringIncludes(listed.clusterArns[0], "cluster/services-1");
+    assertStringIncludes(listed.clusterArns[2], "cluster/services-3");
+    assertUndefined(listed.nextToken);
+  });
+
+  it("lists nothing where there are no clusters", async () => {
+    // Given simulated ECS holding no clusters.
+    const simEcs = new SimAws().ecs();
+
+    // When the clusters are listed.
+    const listed = await simEcs.listClusters(new ListClustersCommand({}));
+
+    // Then the listing is empty rather than absent.
+    assertArrayLength(listed.clusterArns, 0);
+  });
+
+  it("pages a listing at the size the request asked for", async () => {
+    // Given three clusters.
+    const simEcs = await simEcsWithClusters();
+
+    // When they are listed two at a time.
+    const first = await simEcs.listClusters(
+      new ListClustersCommand({ maxResults: 2 }),
+    );
+    const second = await simEcs.listClusters(
+      new ListClustersCommand({ maxResults: 2, nextToken: first.nextToken }),
+    );
+
+    // Then the pages carry the clusters between them, and the last has no
+    // token.
+    assertArrayLength(first.clusterArns, 2);
+    assertIdentical(first.nextToken, "2");
+    assertArrayLength(second.clusterArns, 1);
+    assertUndefined(second.nextToken);
+  });
+
+  it("refuses a page size ECS would not take", async () => {
+    // Given some clusters.
+    const simEcs = await simEcsWithClusters();
+
+    // When a listing asks for more than one page holds.
+    const error = await assertThrowsErrorAsync(async () =>
+      simEcs.listClusters(new ListClustersCommand({ maxResults: 500 })),
+    );
+
+    // Then ECS refuses it.
+    assertInstanceOf(error, SimEcsInvalidParameterException);
+    assertStringIncludes(error.message, "maxResults");
+  });
+
+  it("refuses a continuation token it did not issue", async () => {
+    // Given three clusters.
+    const simEcs = await simEcsWithClusters();
+
+    // When a listing carries a token from nowhere.
+    const error = await assertThrowsErrorAsync(async () =>
+      simEcs.listClusters(
+        new ListClustersCommand({ maxResults: 2, nextToken: "1" }),
+      ),
+    );
+
+    // Then it is refused rather than answered from part way into a page.
+    assertInstanceOf(error, SimEcsInvalidParameterException);
+    assertStringIncludes(error.message, "nextToken");
+  });
+});

--- a/src/service/ecs/command/list-task-definition-families/family-status-filter.ts
+++ b/src/service/ecs/command/list-task-definition-families/family-status-filter.ts
@@ -1,0 +1,70 @@
+import { SimEcsInvalidParameterException } from "../../error/sim-ecs.error.js";
+import type { SimEcsTaskDefinitionFamily } from "../../task-definition/sim-ecs-task-definition-family.js";
+
+type FamilyStatus = "ACTIVE" | "INACTIVE" | "ALL";
+
+const familyStatuses: ReadonlySet<string> = new Set([
+  "ACTIVE",
+  "INACTIVE",
+  "ALL",
+]);
+
+/**
+ * Which families a listing asked for.
+ *
+ * A family is active while any of its revisions is. `INACTIVE` therefore means
+ * a family whose revisions have all been deregistered, which is the only way a
+ * family stops being current: nothing removes one.
+ */
+export class FamilyStatusFilter {
+  private readonly familyPrefix: string | undefined;
+  private readonly status: FamilyStatus;
+
+  constructor(familyPrefix: string | undefined, status: string | undefined) {
+    this.familyPrefix = familyPrefix;
+    this.status = FamilyStatusFilter.requestedStatus(status);
+  }
+
+  private static requestedStatus(status: string | undefined): FamilyStatus {
+    if (status === undefined) {
+      return "ACTIVE";
+    }
+
+    if (familyStatuses.has(status)) {
+      return status as FamilyStatus;
+    }
+
+    throw new SimEcsInvalidParameterException(
+      `ListTaskDefinitionFamilies status ${status} is not one this operation ` +
+        `takes. ACTIVE, INACTIVE and ALL are.`,
+    );
+  }
+
+  /**
+   * The families this listing reports, in registration order.
+   */
+  apply(
+    families: readonly SimEcsTaskDefinitionFamily[],
+  ): readonly SimEcsTaskDefinitionFamily[] {
+    return families.filter((family) => this.matches(family));
+  }
+
+  private matches(family: SimEcsTaskDefinitionFamily): boolean {
+    if (
+      this.familyPrefix !== undefined &&
+      !family.family.startsWith(this.familyPrefix)
+    ) {
+      return false;
+    }
+
+    return this.matchesStatus(family);
+  }
+
+  private matchesStatus(family: SimEcsTaskDefinitionFamily): boolean {
+    if (this.status === "ALL") {
+      return true;
+    }
+
+    return family.hasActiveRevision() === (this.status === "ACTIVE");
+  }
+}

--- a/src/service/ecs/command/list-task-definition-families/family-status-filter.ts
+++ b/src/service/ecs/command/list-task-definition-families/family-status-filter.ts
@@ -15,6 +15,10 @@ const familyStatuses: ReadonlySet<string> = new Set([
  * A family is active while any of its revisions is. `INACTIVE` therefore means
  * a family whose revisions have all been deregistered, which is the only way a
  * family stops being current: nothing removes one.
+ *
+ * A request saying nothing about status gets both, which is what real ECS
+ * reports here. That is the opposite of `ListTaskDefinitions`, where saying
+ * nothing means the active revisions.
  */
 export class FamilyStatusFilter {
   private readonly familyPrefix: string | undefined;
@@ -27,7 +31,7 @@ export class FamilyStatusFilter {
 
   private static requestedStatus(status: string | undefined): FamilyStatus {
     if (status === undefined) {
-      return "ACTIVE";
+      return "ALL";
     }
 
     if (familyStatuses.has(status)) {

--- a/src/service/ecs/command/list-task-definition-families/list-task-definition-families.command.ts
+++ b/src/service/ecs/command/list-task-definition-families/list-task-definition-families.command.ts
@@ -1,0 +1,29 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+
+/**
+ * Minimal structural sim ECS ListTaskDefinitionFamilies command.
+ */
+export interface SimListTaskDefinitionFamiliesCommand {
+  readonly input: SimListTaskDefinitionFamiliesCommandInput;
+}
+
+/**
+ * Minimal structural sim ECS ListTaskDefinitionFamilies input.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/ecs/command/ListTaskDefinitionFamiliesCommand/
+ */
+export interface SimListTaskDefinitionFamiliesCommandInput {
+  readonly familyPrefix?: string | undefined;
+  readonly status?: string | undefined;
+  readonly maxResults?: number | undefined;
+  readonly nextToken?: string | undefined;
+}
+
+/**
+ * Minimal structural sim ECS ListTaskDefinitionFamilies output.
+ */
+export interface SimListTaskDefinitionFamiliesCommandOutput {
+  readonly families?: readonly string[] | undefined;
+  readonly nextToken?: string | undefined;
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/ecs/command/list-task-definition-families/list-task-definition-families.handler.ts
+++ b/src/service/ecs/command/list-task-definition-families/list-task-definition-families.handler.ts
@@ -1,0 +1,77 @@
+import type { CommandHandler } from "../../../../command/command-handler.js";
+import type { SimEcsTaskDefinitionStore } from "../../task-definition/sim-ecs-task-definition-store.js";
+import type { SimEcsTaskDefinitionCommandContext } from "../sim-ecs-command-context.js";
+import { SimEcsCommandHandler } from "../sim-ecs-command-handler.js";
+import { SimEcsPage } from "../sim-ecs-page.js";
+import type { SimEcsRequestOptions } from "../sim-ecs-request-options.js";
+import { FamilyStatusFilter } from "./family-status-filter.js";
+import type {
+  SimListTaskDefinitionFamiliesCommand,
+  SimListTaskDefinitionFamiliesCommandOutput,
+} from "./list-task-definition-families.command.js";
+
+const acceptedInput: readonly string[] = [
+  "familyPrefix",
+  "status",
+  "maxResults",
+  "nextToken",
+];
+
+/**
+ * Simulated ECS ListTaskDefinitionFamiliesCommand handler.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/ecs/command/ListTaskDefinitionFamiliesCommand/
+ */
+export class ListTaskDefinitionFamiliesCommandHandler
+  extends SimEcsCommandHandler
+  implements
+    CommandHandler<
+      SimListTaskDefinitionFamiliesCommand,
+      SimListTaskDefinitionFamiliesCommandOutput
+    >
+{
+  private readonly taskDefinitions: SimEcsTaskDefinitionStore;
+
+  constructor(context: SimEcsTaskDefinitionCommandContext) {
+    super(context, "ListTaskDefinitionFamilies", acceptedInput);
+    this.taskDefinitions = context.taskDefinitions;
+  }
+
+  /**
+   * List the family names the request asked for.
+   *
+   * A request that says nothing about status gets the families with an active
+   * revision, which is what real ECS reports.
+   */
+  async handle(
+    command: SimListTaskDefinitionFamiliesCommand,
+    options?: SimEcsRequestOptions,
+  ): Promise<SimListTaskDefinitionFamiliesCommandOutput> {
+    this.refuseUnaccepted(command.input);
+
+    const filter = new FamilyStatusFilter(
+      command.input.familyPrefix,
+      command.input.status,
+    );
+
+    await this.sequence();
+
+    this.authorizer.authorizeAnyResource(
+      "ecs:ListTaskDefinitionFamilies",
+      options,
+    );
+
+    const page = new SimEcsPage<string>(
+      filter
+        .apply(this.taskDefinitions.families())
+        .map((family) => family.family),
+      command.input,
+    );
+
+    return {
+      $metadata: {},
+      families: page.items,
+      ...(page.nextToken !== undefined && { nextToken: page.nextToken }),
+    };
+  }
+}

--- a/src/service/ecs/command/list-task-definition-families/list-task-definition-families.iso.test.ts
+++ b/src/service/ecs/command/list-task-definition-families/list-task-definition-families.iso.test.ts
@@ -1,0 +1,134 @@
+import {
+  DeregisterTaskDefinitionCommand,
+  ListTaskDefinitionFamiliesCommand,
+} from "@aws-sdk/client-ecs";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimEcsInvalidParameterException } from "../../error/sim-ecs.error.js";
+import { simEcsRegisteredTaskDefinitionFactory } from "../../task-definition/sim-ecs-registered-task-definition.factory.js";
+
+async function simAwsWithTwoFamilies(): Promise<SimAws> {
+  const simAws = new SimAws();
+  await simEcsRegisteredTaskDefinitionFactory.make(
+    { family: "checkout" },
+    simAws,
+  );
+  await simEcsRegisteredTaskDefinitionFactory.make(
+    { family: "billing" },
+    simAws,
+  );
+
+  return simAws;
+}
+
+describe("ECS ListTaskDefinitionFamiliesCommand", () => {
+  it("lists the families that have been registered", async () => {
+    // Given two families.
+    const simAws = await simAwsWithTwoFamilies();
+
+    // When the families are listed.
+    const listed = await simAws
+      .ecs()
+      .listTaskDefinitionFamilies(new ListTaskDefinitionFamiliesCommand({}));
+
+    // Then both come back, in the order they were first registered.
+    assertArrayLength(listed.families, 2);
+    assertIdentical(listed.families[0], "checkout");
+    assertIdentical(listed.families[1], "billing");
+  });
+
+  it("lists the families a prefix asks for", async () => {
+    // Given two families.
+    const simAws = await simAwsWithTwoFamilies();
+
+    // When a family prefix is given.
+    const listed = await simAws
+      .ecs()
+      .listTaskDefinitionFamilies(
+        new ListTaskDefinitionFamiliesCommand({ familyPrefix: "bill" }),
+      );
+
+    // Then only the matching family is listed.
+    assertArrayLength(listed.families, 1);
+    assertIdentical(listed.families[0], "billing");
+  });
+
+  it("counts a family as inactive once its revisions are gone", async () => {
+    // Given a family whose only revision has been deregistered.
+    const simAws = await simAwsWithTwoFamilies();
+    await simAws
+      .ecs()
+      .deregisterTaskDefinition(
+        new DeregisterTaskDefinitionCommand({ taskDefinition: "billing:1" }),
+      );
+
+    // When the families are listed by each status in turn.
+    const active = await simAws
+      .ecs()
+      .listTaskDefinitionFamilies(new ListTaskDefinitionFamiliesCommand({}));
+    const inactive = await simAws
+      .ecs()
+      .listTaskDefinitionFamilies(
+        new ListTaskDefinitionFamiliesCommand({ status: "INACTIVE" }),
+      );
+    const all = await simAws
+      .ecs()
+      .listTaskDefinitionFamilies(
+        new ListTaskDefinitionFamiliesCommand({ status: "ALL" }),
+      );
+
+    // Then it has moved out of the active listing without being removed.
+    assertArrayLength(active.families, 1);
+    assertIdentical(active.families[0], "checkout");
+    assertArrayLength(inactive.families, 1);
+    assertIdentical(inactive.families[0], "billing");
+    assertArrayLength(all.families, 2);
+  });
+
+  it("pages a listing at the size the request asked for", async () => {
+    // Given two families.
+    const simAws = await simAwsWithTwoFamilies();
+
+    // When they are listed one at a time.
+    const first = await simAws
+      .ecs()
+      .listTaskDefinitionFamilies(
+        new ListTaskDefinitionFamiliesCommand({ maxResults: 1 }),
+      );
+    const second = await simAws.ecs().listTaskDefinitionFamilies(
+      new ListTaskDefinitionFamiliesCommand({
+        maxResults: 1,
+        nextToken: first.nextToken,
+      }),
+    );
+
+    // Then each page carries one family.
+    assertArrayLength(first.families, 1);
+    assertIdentical(first.nextToken, "1");
+    assertArrayLength(second.families, 1);
+    assertUndefined(second.nextToken);
+  });
+
+  it("refuses a status this operation does not take", async () => {
+    // Given a registered family.
+    const simAws = new SimAws();
+    await simEcsRegisteredTaskDefinitionFactory.make({}, simAws);
+
+    // When a listing asks for a status ECS has no such value for.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.ecs().listTaskDefinitionFamilies({ input: { status: "GONE" } }),
+    );
+
+    // Then ECS refuses it.
+    assertInstanceOf(error, SimEcsInvalidParameterException);
+    assertStringIncludes(error.message, "ACTIVE, INACTIVE and ALL are");
+  });
+});

--- a/src/service/ecs/command/list-task-definition-families/list-task-definition-families.iso.test.ts
+++ b/src/service/ecs/command/list-task-definition-families/list-task-definition-families.iso.test.ts
@@ -45,6 +45,24 @@ describe("ECS ListTaskDefinitionFamiliesCommand", () => {
     assertIdentical(listed.families[1], "billing");
   });
 
+  it("lists both active and inactive families where none is asked for", async () => {
+    // Given a family whose only revision has been deregistered.
+    const simAws = await simAwsWithTwoFamilies();
+    await simAws
+      .ecs()
+      .deregisterTaskDefinition(
+        new DeregisterTaskDefinitionCommand({ taskDefinition: "billing:1" }),
+      );
+
+    // When the families are listed without a status.
+    const listed = await simAws
+      .ecs()
+      .listTaskDefinitionFamilies(new ListTaskDefinitionFamiliesCommand({}));
+
+    // Then both are listed, as real ECS lists them when none is asked for.
+    assertArrayLength(listed.families, 2);
+  });
+
   it("lists the families a prefix asks for", async () => {
     // Given two families.
     const simAws = await simAwsWithTwoFamilies();
@@ -71,9 +89,11 @@ describe("ECS ListTaskDefinitionFamiliesCommand", () => {
       );
 
     // When the families are listed by each status in turn.
-    const active = await simAws
+    const asked = await simAws
       .ecs()
-      .listTaskDefinitionFamilies(new ListTaskDefinitionFamiliesCommand({}));
+      .listTaskDefinitionFamilies(
+        new ListTaskDefinitionFamiliesCommand({ status: "ACTIVE" }),
+      );
     const inactive = await simAws
       .ecs()
       .listTaskDefinitionFamilies(
@@ -86,8 +106,8 @@ describe("ECS ListTaskDefinitionFamiliesCommand", () => {
       );
 
     // Then it has moved out of the active listing without being removed.
-    assertArrayLength(active.families, 1);
-    assertIdentical(active.families[0], "checkout");
+    assertArrayLength(asked.families, 1);
+    assertIdentical(asked.families[0], "checkout");
     assertArrayLength(inactive.families, 1);
     assertIdentical(inactive.families[0], "billing");
     assertArrayLength(all.families, 2);

--- a/src/service/ecs/command/list-task-definitions/list-task-definitions-filter.ts
+++ b/src/service/ecs/command/list-task-definitions/list-task-definitions-filter.ts
@@ -1,0 +1,78 @@
+import { SimEcsInvalidParameterException } from "../../error/sim-ecs.error.js";
+import type { SimEcsTaskDefinition } from "../../task-definition/sim-ecs-task-definition.js";
+import type { SimListTaskDefinitionsCommandInput } from "./list-task-definitions.command.js";
+
+/**
+ * Which revisions a listing asked for, and in which order.
+ *
+ * Real ECS lists the active revisions when the request says nothing about
+ * status, so a listing that says nothing is a listing of what is current
+ * rather than of everything ever registered.
+ */
+export class ListTaskDefinitionsFilter {
+  private readonly familyPrefix: string | undefined;
+  private readonly active: boolean;
+  private readonly newestFirst: boolean;
+
+  constructor(input: SimListTaskDefinitionsCommandInput) {
+    this.familyPrefix = input.familyPrefix;
+    this.active = ListTaskDefinitionsFilter.wantsActive(input.status);
+    this.newestFirst = ListTaskDefinitionsFilter.wantsNewestFirst(input.sort);
+  }
+
+  private static wantsActive(status: string | undefined): boolean {
+    if (status === undefined || status === "ACTIVE") {
+      return true;
+    }
+
+    if (status === "INACTIVE") {
+      return false;
+    }
+
+    throw new SimEcsInvalidParameterException(
+      `ListTaskDefinitions status ${status} is not one this operation takes. ` +
+        `ACTIVE and INACTIVE are.`,
+    );
+  }
+
+  private static wantsNewestFirst(sort: string | undefined): boolean {
+    if (sort === undefined || sort === "ASC") {
+      return false;
+    }
+
+    if (sort === "DESC") {
+      return true;
+    }
+
+    throw new SimEcsInvalidParameterException(
+      `ListTaskDefinitions sort ${sort} is not one this operation takes. ASC ` +
+        `and DESC are.`,
+    );
+  }
+
+  /**
+   * The revisions this listing reports, in the order it reports them.
+   */
+  apply(
+    revisions: readonly SimEcsTaskDefinition[],
+  ): readonly SimEcsTaskDefinition[] {
+    const matched = revisions.filter((revision) => this.matches(revision));
+
+    if (this.newestFirst) {
+      return matched.toReversed();
+    }
+
+    return matched;
+  }
+
+  private matches(revision: SimEcsTaskDefinition): boolean {
+    if (revision.isActive() !== this.active) {
+      return false;
+    }
+
+    return (
+      this.familyPrefix === undefined ||
+      revision.family.startsWith(this.familyPrefix)
+    );
+  }
+}

--- a/src/service/ecs/command/list-task-definitions/list-task-definitions.command.ts
+++ b/src/service/ecs/command/list-task-definitions/list-task-definitions.command.ts
@@ -1,0 +1,31 @@
+import type { SimArn } from "../../../aws/arn.js";
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+
+/**
+ * Minimal structural sim ECS ListTaskDefinitions command.
+ */
+export interface SimListTaskDefinitionsCommand {
+  readonly input: SimListTaskDefinitionsCommandInput;
+}
+
+/**
+ * Minimal structural sim ECS ListTaskDefinitions input.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/ecs/command/ListTaskDefinitionsCommand/
+ */
+export interface SimListTaskDefinitionsCommandInput {
+  readonly familyPrefix?: string | undefined;
+  readonly status?: string | undefined;
+  readonly sort?: string | undefined;
+  readonly maxResults?: number | undefined;
+  readonly nextToken?: string | undefined;
+}
+
+/**
+ * Minimal structural sim ECS ListTaskDefinitions output.
+ */
+export interface SimListTaskDefinitionsCommandOutput {
+  readonly taskDefinitionArns?: readonly SimArn[] | undefined;
+  readonly nextToken?: string | undefined;
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/ecs/command/list-task-definitions/list-task-definitions.handler.ts
+++ b/src/service/ecs/command/list-task-definitions/list-task-definitions.handler.ts
@@ -1,0 +1,74 @@
+import type { CommandHandler } from "../../../../command/command-handler.js";
+import type { SimArn } from "../../../aws/arn.js";
+import type { SimEcsTaskDefinitionStore } from "../../task-definition/sim-ecs-task-definition-store.js";
+import type { SimEcsTaskDefinitionCommandContext } from "../sim-ecs-command-context.js";
+import { SimEcsCommandHandler } from "../sim-ecs-command-handler.js";
+import { SimEcsPage } from "../sim-ecs-page.js";
+import type { SimEcsRequestOptions } from "../sim-ecs-request-options.js";
+import { ListTaskDefinitionsFilter } from "./list-task-definitions-filter.js";
+import type {
+  SimListTaskDefinitionsCommand,
+  SimListTaskDefinitionsCommandOutput,
+} from "./list-task-definitions.command.js";
+
+const acceptedInput: readonly string[] = [
+  "familyPrefix",
+  "status",
+  "sort",
+  "maxResults",
+  "nextToken",
+];
+
+/**
+ * Simulated ECS ListTaskDefinitionsCommand handler.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/ecs/command/ListTaskDefinitionsCommand/
+ */
+export class ListTaskDefinitionsCommandHandler
+  extends SimEcsCommandHandler
+  implements
+    CommandHandler<
+      SimListTaskDefinitionsCommand,
+      SimListTaskDefinitionsCommandOutput
+    >
+{
+  private readonly taskDefinitions: SimEcsTaskDefinitionStore;
+
+  constructor(context: SimEcsTaskDefinitionCommandContext) {
+    super(context, "ListTaskDefinitions", acceptedInput);
+    this.taskDefinitions = context.taskDefinitions;
+  }
+
+  /**
+   * List the ARNs of the revisions the request asked for.
+   *
+   * They come out by family name and then by revision, which is the order real
+   * ECS calls ascending. A request that says nothing about status gets the
+   * active revisions.
+   */
+  async handle(
+    command: SimListTaskDefinitionsCommand,
+    options?: SimEcsRequestOptions,
+  ): Promise<SimListTaskDefinitionsCommandOutput> {
+    this.refuseUnaccepted(command.input);
+
+    const filter = new ListTaskDefinitionsFilter(command.input);
+
+    await this.sequence();
+
+    this.authorizer.authorizeAnyResource("ecs:ListTaskDefinitions", options);
+
+    const page = new SimEcsPage<SimArn>(
+      filter
+        .apply(this.taskDefinitions.revisions())
+        .map((revision) => revision.taskDefinitionArn),
+      command.input,
+    );
+
+    return {
+      $metadata: {},
+      taskDefinitionArns: page.items,
+      ...(page.nextToken !== undefined && { nextToken: page.nextToken }),
+    };
+  }
+}

--- a/src/service/ecs/command/list-task-definitions/list-task-definitions.iso.test.ts
+++ b/src/service/ecs/command/list-task-definitions/list-task-definitions.iso.test.ts
@@ -1,0 +1,157 @@
+import {
+  DeregisterTaskDefinitionCommand,
+  ListTaskDefinitionsCommand,
+} from "@aws-sdk/client-ecs";
+import {
+  assertArrayLength,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimEcsInvalidParameterException } from "../../error/sim-ecs.error.js";
+import { simEcsRegisteredTaskDefinitionFactory } from "../../task-definition/sim-ecs-registered-task-definition.factory.js";
+
+async function simAwsWithTwoFamilies(): Promise<SimAws> {
+  const simAws = new SimAws();
+  await simEcsRegisteredTaskDefinitionFactory.make(
+    { family: "checkout" },
+    simAws,
+  );
+  await simEcsRegisteredTaskDefinitionFactory.make(
+    { family: "checkout" },
+    simAws,
+  );
+  await simEcsRegisteredTaskDefinitionFactory.make(
+    { family: "billing" },
+    simAws,
+  );
+
+  return simAws;
+}
+
+describe("ECS ListTaskDefinitionsCommand", () => {
+  it("lists every active revision by family and then revision", async () => {
+    // Given two families, one with two revisions.
+    const simAws = await simAwsWithTwoFamilies();
+
+    // When the task definitions are listed.
+    const listed = await simAws
+      .ecs()
+      .listTaskDefinitions(new ListTaskDefinitionsCommand({}));
+
+    // Then they come out in ascending family and revision order.
+    assertArrayLength(listed.taskDefinitionArns, 3);
+    assertStringIncludes(listed.taskDefinitionArns[0], "billing:1");
+    assertStringIncludes(listed.taskDefinitionArns[1], "checkout:1");
+    assertStringIncludes(listed.taskDefinitionArns[2], "checkout:2");
+  });
+
+  it("lists one family where a prefix asks for it", async () => {
+    // Given two families.
+    const simAws = await simAwsWithTwoFamilies();
+
+    // When a family prefix is given.
+    const listed = await simAws
+      .ecs()
+      .listTaskDefinitions(
+        new ListTaskDefinitionsCommand({ familyPrefix: "check" }),
+      );
+
+    // Then only that family's revisions are listed.
+    assertArrayLength(listed.taskDefinitionArns, 2);
+    assertStringIncludes(listed.taskDefinitionArns[0], "checkout:1");
+  });
+
+  it("lists newest first where the request sorts descending", async () => {
+    // Given two families.
+    const simAws = await simAwsWithTwoFamilies();
+
+    // When the listing sorts descending.
+    const listed = await simAws
+      .ecs()
+      .listTaskDefinitions(new ListTaskDefinitionsCommand({ sort: "DESC" }));
+
+    // Then the order is reversed.
+    assertArrayLength(listed.taskDefinitionArns, 3);
+    assertStringIncludes(listed.taskDefinitionArns[0], "checkout:2");
+  });
+
+  it("lists the inactive revisions where the request asks", async () => {
+    // Given a family with one of its revisions deregistered.
+    const simAws = await simAwsWithTwoFamilies();
+    await simAws
+      .ecs()
+      .deregisterTaskDefinition(
+        new DeregisterTaskDefinitionCommand({ taskDefinition: "checkout:1" }),
+      );
+
+    // When active and inactive revisions are listed in turn.
+    const active = await simAws
+      .ecs()
+      .listTaskDefinitions(new ListTaskDefinitionsCommand({}));
+    const inactive = await simAws
+      .ecs()
+      .listTaskDefinitions(
+        new ListTaskDefinitionsCommand({ status: "INACTIVE" }),
+      );
+
+    // Then the deregistered revision has moved from one listing to the other.
+    assertArrayLength(active.taskDefinitionArns, 2);
+    assertArrayLength(inactive.taskDefinitionArns, 1);
+    assertStringIncludes(inactive.taskDefinitionArns[0], "checkout:1");
+  });
+
+  it("pages a listing at the size the request asked for", async () => {
+    // Given three revisions.
+    const simAws = await simAwsWithTwoFamilies();
+
+    // When they are listed two at a time.
+    const first = await simAws
+      .ecs()
+      .listTaskDefinitions(new ListTaskDefinitionsCommand({ maxResults: 2 }));
+    const second = await simAws.ecs().listTaskDefinitions(
+      new ListTaskDefinitionsCommand({
+        maxResults: 2,
+        nextToken: first.nextToken,
+      }),
+    );
+
+    // Then the pages carry the revisions between them.
+    assertArrayLength(first.taskDefinitionArns, 2);
+    assertArrayLength(second.taskDefinitionArns, 1);
+    assertUndefined(second.nextToken);
+  });
+
+  it("refuses a status this operation does not take", async () => {
+    // Given a registered revision.
+    const simAws = new SimAws();
+    await simEcsRegisteredTaskDefinitionFactory.make({}, simAws);
+
+    // When a listing asks for a status ECS has no such value for.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.ecs().listTaskDefinitions({ input: { status: "ALL" } }),
+    );
+
+    // Then ECS refuses it.
+    assertInstanceOf(error, SimEcsInvalidParameterException);
+    assertStringIncludes(error.message, "ACTIVE and INACTIVE are");
+  });
+
+  it("refuses a sort order this operation does not take", async () => {
+    // Given a registered revision.
+    const simAws = new SimAws();
+    await simEcsRegisteredTaskDefinitionFactory.make({}, simAws);
+
+    // When a listing asks for an order ECS has no such value for.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.ecs().listTaskDefinitions({ input: { sort: "NEWEST" } }),
+    );
+
+    // Then ECS refuses it.
+    assertInstanceOf(error, SimEcsInvalidParameterException);
+    assertStringIncludes(error.message, "ASC and DESC are");
+  });
+});

--- a/src/service/ecs/command/register-task-definition/register-task-definition-validation.iso.test.ts
+++ b/src/service/ecs/command/register-task-definition/register-task-definition-validation.iso.test.ts
@@ -1,0 +1,176 @@
+import { RegisterTaskDefinitionCommand } from "@aws-sdk/client-ecs";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimEcsClientException } from "../../error/sim-ecs.error.js";
+
+describe("Validating a simulated ECS task definition registration", () => {
+  it("refuses a registration with no family", async () => {
+    // Given simulated ECS.
+    const simEcs = new SimAws().ecs();
+
+    // When a task definition is registered without a family.
+    const error = await assertThrowsErrorAsync(async () =>
+      simEcs.registerTaskDefinition({
+        input: { containerDefinitions: [{ name: "app", image: "checkout:1" }] },
+      }),
+    );
+
+    // Then ECS refuses it.
+    assertInstanceOf(error, SimEcsClientException);
+    assertIdentical(error.name, "ClientException");
+    assertStringIncludes(error.message, "family cannot be blank");
+  });
+
+  it("refuses a family name ECS would not accept", async () => {
+    // Given simulated ECS.
+    const simEcs = new SimAws().ecs();
+
+    // When a family name carries a character ECS does not allow.
+    const error = await assertThrowsErrorAsync(async () =>
+      simEcs.registerTaskDefinition(
+        new RegisterTaskDefinitionCommand({
+          family: "check out",
+          containerDefinitions: [{ name: "app", image: "checkout:1" }],
+        }),
+      ),
+    );
+
+    // Then it is refused here rather than on deployment.
+    assertInstanceOf(error, SimEcsClientException);
+    assertStringIncludes(error.message, "Invalid task definition family");
+  });
+
+  it("refuses a registration with no container definitions", async () => {
+    // Given simulated ECS.
+    const simEcs = new SimAws().ecs();
+
+    // When a task definition declares no containers.
+    const error = await assertThrowsErrorAsync(async () =>
+      simEcs.registerTaskDefinition(
+        new RegisterTaskDefinitionCommand({
+          family: "checkout",
+          containerDefinitions: [],
+        }),
+      ),
+    );
+
+    // Then ECS refuses it.
+    assertInstanceOf(error, SimEcsClientException);
+    assertStringIncludes(error.message, "at least one container definition");
+  });
+
+  it("refuses a container with no name", async () => {
+    // Given simulated ECS.
+    const simEcs = new SimAws().ecs();
+
+    // When a container is declared without a name.
+    const error = await assertThrowsErrorAsync(async () =>
+      simEcs.registerTaskDefinition(
+        new RegisterTaskDefinitionCommand({
+          family: "checkout",
+          containerDefinitions: [{ image: "checkout:1" }],
+        }),
+      ),
+    );
+
+    // Then ECS refuses it, because a name is how a container is referred to.
+    assertInstanceOf(error, SimEcsClientException);
+    assertStringIncludes(error.message, "Container.name");
+  });
+
+  it("refuses a container with no image", async () => {
+    // Given simulated ECS.
+    const simEcs = new SimAws().ecs();
+
+    // When a container is declared without an image.
+    const error = await assertThrowsErrorAsync(async () =>
+      simEcs.registerTaskDefinition(
+        new RegisterTaskDefinitionCommand({
+          family: "checkout",
+          containerDefinitions: [{ name: "app" }],
+        }),
+      ),
+    );
+
+    // Then ECS refuses it. Nothing reads the image, but it is the identifier
+    // a bound handler would be matched against.
+    assertInstanceOf(error, SimEcsClientException);
+    assertStringIncludes(error.message, "Container.image");
+  });
+
+  it("refuses two containers sharing a name", async () => {
+    // Given simulated ECS.
+    const simEcs = new SimAws().ecs();
+
+    // When two containers are declared under the same name.
+    const error = await assertThrowsErrorAsync(async () =>
+      simEcs.registerTaskDefinition(
+        new RegisterTaskDefinitionCommand({
+          family: "checkout",
+          containerDefinitions: [
+            { name: "app", image: "checkout:1" },
+            { name: "app", image: "sidecar:1" },
+          ],
+        }),
+      ),
+    );
+
+    // Then ECS refuses it.
+    assertInstanceOf(error, SimEcsClientException);
+    assertStringIncludes(error.message, "declared more than once");
+  });
+
+  it("refuses a declaration this simulation does not hold", async () => {
+    // Given simulated ECS.
+    const simEcs = new SimAws().ecs();
+
+    // When a registration asks for fault injection.
+    const error = await assertThrowsErrorAsync(async () =>
+      simEcs.registerTaskDefinition(
+        new RegisterTaskDefinitionCommand({
+          family: "checkout",
+          containerDefinitions: [{ name: "app", image: "checkout:1" }],
+          enableFaultInjection: true,
+        }),
+      ),
+    );
+
+    // Then it is refused rather than dropped, so nothing declared goes
+    // missing from the revision it made.
+    assertInstanceOf(error, SimEcsClientException);
+    assertStringIncludes(
+      error.message,
+      "enableFaultInjection is not simulated",
+    );
+  });
+
+  it("registers nothing when the registration is refused", async () => {
+    // Given simulated ECS that has refused a registration.
+    const simEcs = new SimAws().ecs();
+    await assertThrowsErrorAsync(async () =>
+      simEcs.registerTaskDefinition(
+        new RegisterTaskDefinitionCommand({
+          family: "checkout",
+          containerDefinitions: [{ name: "app" }],
+        }),
+      ),
+    );
+
+    // When the family is registered properly afterwards.
+    const registered = await simEcs.registerTaskDefinition(
+      new RegisterTaskDefinitionCommand({
+        family: "checkout",
+        containerDefinitions: [{ name: "app", image: "checkout:1" }],
+      }),
+    );
+
+    // Then it is revision 1, because the refused request took no number.
+    assertIdentical(registered.taskDefinition?.revision, 1);
+  });
+});

--- a/src/service/ecs/command/register-task-definition/register-task-definition.command.ts
+++ b/src/service/ecs/command/register-task-definition/register-task-definition.command.ts
@@ -1,0 +1,37 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type { SimEcsContainerDefinitionType } from "../../task-definition/container/sim-ecs-container-definition.js";
+import type { SimEcsTag } from "../../task-definition/sim-ecs-task-definition-parts.js";
+import type { SimEcsTaskDefinitionSettingsType } from "../../task-definition/sim-ecs-task-definition-settings.js";
+import type { SimEcsTaskDefinitionDetail } from "../../task-definition/sim-ecs-task-definition-detail.js";
+
+/**
+ * Minimal structural sim ECS RegisterTaskDefinition command.
+ */
+export interface SimRegisterTaskDefinitionCommand {
+  readonly input: SimRegisterTaskDefinitionCommandInput;
+}
+
+/**
+ * Minimal structural sim ECS RegisterTaskDefinition input.
+ *
+ * The settings are the ones a described revision reports back, so registering
+ * and describing are two views of the same declaration.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/ecs/command/RegisterTaskDefinitionCommand/
+ */
+export interface SimRegisterTaskDefinitionCommandInput extends SimEcsTaskDefinitionSettingsType {
+  readonly family?: string | undefined;
+  readonly containerDefinitions?:
+    | readonly SimEcsContainerDefinitionType[]
+    | undefined;
+  readonly tags?: readonly SimEcsTag[] | undefined;
+}
+
+/**
+ * Minimal structural sim ECS RegisterTaskDefinition output.
+ */
+export interface SimRegisterTaskDefinitionCommandOutput {
+  readonly taskDefinition?: SimEcsTaskDefinitionDetail | undefined;
+  readonly tags?: readonly SimEcsTag[] | undefined;
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/ecs/command/register-task-definition/register-task-definition.handler.ts
+++ b/src/service/ecs/command/register-task-definition/register-task-definition.handler.ts
@@ -1,0 +1,109 @@
+import type { CommandHandler } from "../../../../command/command-handler.js";
+import { requiredSimEcsName } from "../../sim-ecs-name.js";
+import { SimEcsContainerDefinitions } from "../../task-definition/container/sim-ecs-container-definitions.js";
+import type { SimEcsTaskDefinitionArn } from "../../task-definition/sim-ecs-task-definition-arn.js";
+import {
+  simEcsTaskDefinitionSettingNames,
+  SimEcsTaskDefinitionSettings,
+} from "../../task-definition/sim-ecs-task-definition-settings.js";
+import type { SimEcsTaskDefinitionStore } from "../../task-definition/sim-ecs-task-definition-store.js";
+import { SimEcsTaskDefinition } from "../../task-definition/sim-ecs-task-definition.js";
+import type { SimEcsTaskDefinitionCommandContext } from "../sim-ecs-command-context.js";
+import { SimEcsCommandHandler } from "../sim-ecs-command-handler.js";
+import type { SimEcsRequestOptions } from "../sim-ecs-request-options.js";
+import type {
+  SimRegisterTaskDefinitionCommand,
+  SimRegisterTaskDefinitionCommandOutput,
+} from "./register-task-definition.command.js";
+
+/**
+ * What a simulated RegisterTaskDefinition request may declare.
+ *
+ * Anything else is refused rather than dropped, since a registration is a
+ * declaration and a declaration missing from the revision it made would be
+ * state a test could pass against without it being what was asked for.
+ */
+const acceptedInput: readonly string[] = [
+  "family",
+  "containerDefinitions",
+  "tags",
+  ...simEcsTaskDefinitionSettingNames,
+];
+
+/**
+ * Simulated ECS RegisterTaskDefinitionCommand handler.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/ecs/command/RegisterTaskDefinitionCommand/
+ */
+export class RegisterTaskDefinitionCommandHandler
+  extends SimEcsCommandHandler
+  implements
+    CommandHandler<
+      SimRegisterTaskDefinitionCommand,
+      SimRegisterTaskDefinitionCommandOutput
+    >
+{
+  private readonly taskDefinitions: SimEcsTaskDefinitionStore;
+  private readonly taskDefinitionArn: SimEcsTaskDefinitionArn;
+
+  constructor(context: SimEcsTaskDefinitionCommandContext) {
+    super(context, "RegisterTaskDefinition", acceptedInput);
+    this.taskDefinitions = context.taskDefinitions;
+    this.taskDefinitionArn = context.taskDefinitionArn;
+  }
+
+  /**
+   * Register a new revision of a task definition family.
+   *
+   * The revision number comes from the family rather than from the request:
+   * the first registration is revision 1 and each one after it takes the next
+   * number, whether or not the revisions before it are still active.
+   *
+   * The declaration is read before authorization, because a malformed
+   * registration is malformed whoever made it. Nothing is stored until the
+   * caller has been authorized.
+   */
+  async handle(
+    command: SimRegisterTaskDefinitionCommand,
+    options?: SimEcsRequestOptions,
+  ): Promise<SimRegisterTaskDefinitionCommandOutput> {
+    this.refuseUnaccepted(command.input);
+
+    const family = requiredSimEcsName(
+      command.input.family,
+      "task definition family",
+    );
+    const containers = new SimEcsContainerDefinitions(
+      command.input.containerDefinitions,
+    );
+    const settings = new SimEcsTaskDefinitionSettings(command.input);
+
+    await this.sequence();
+
+    const caller = this.authorizer.authorizeAnyResource(
+      "ecs:RegisterTaskDefinition",
+      options,
+    );
+
+    const familyRevisions = this.taskDefinitions.family(family);
+    const revision = familyRevisions.nextRevisionNumber();
+    const taskDefinition = new SimEcsTaskDefinition({
+      taskDefinitionArn: this.taskDefinitionArn.make(family, revision),
+      family,
+      revision,
+      containers,
+      settings,
+      tags: command.input.tags ?? [],
+      registeredAt: this.background.now(),
+      registeredBy: caller.arn,
+    });
+
+    familyRevisions.add(taskDefinition);
+
+    return {
+      $metadata: {},
+      taskDefinition: taskDefinition.toOutput(),
+      tags: taskDefinition.toTagsOutput(),
+    };
+  }
+}

--- a/src/service/ecs/command/register-task-definition/register-task-definition.iso.test.ts
+++ b/src/service/ecs/command/register-task-definition/register-task-definition.iso.test.ts
@@ -1,0 +1,301 @@
+import { RegisterTaskDefinitionCommand } from "@aws-sdk/client-ecs";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertObjectMatches,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimFixedClock } from "../../../../util/clock/sim-clock.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+
+describe("ECS RegisterTaskDefinitionCommand", () => {
+  it("numbers the revisions of a family from one", async () => {
+    // Given simulated ECS in a known account and region.
+    const simEcs = new SimAws()
+      .account("555555555555")
+      .region("eu-west-1")
+      .ecs();
+
+    // When the same family is registered twice.
+    const first = await simEcs.registerTaskDefinition(
+      new RegisterTaskDefinitionCommand({
+        family: "checkout",
+        containerDefinitions: [{ name: "app", image: "checkout:1" }],
+      }),
+    );
+    const second = await simEcs.registerTaskDefinition(
+      new RegisterTaskDefinitionCommand({
+        family: "checkout",
+        containerDefinitions: [{ name: "app", image: "checkout:2" }],
+      }),
+    );
+
+    // Then the revisions are 1 and 2, and each ARN names its own revision.
+    assertIdentical(first.taskDefinition?.revision, 1);
+    assertIdentical(second.taskDefinition?.revision, 2);
+    assertIdentical(
+      first.taskDefinition.taskDefinitionArn,
+      "arn:aws:ecs:eu-west-1:555555555555:task-definition/checkout:1",
+    );
+    assertIdentical(
+      second.taskDefinition.taskDefinitionArn,
+      "arn:aws:ecs:eu-west-1:555555555555:task-definition/checkout:2",
+    );
+    assertIdentical(second.taskDefinition.status, "ACTIVE");
+  });
+
+  it("numbers each family separately", async () => {
+    // Given simulated ECS.
+    const simEcs = new SimAws().ecs();
+
+    // When two families are registered.
+    await simEcs.registerTaskDefinition(
+      new RegisterTaskDefinitionCommand({
+        family: "checkout",
+        containerDefinitions: [{ name: "app", image: "checkout:1" }],
+      }),
+    );
+    const other = await simEcs.registerTaskDefinition(
+      new RegisterTaskDefinitionCommand({
+        family: "billing",
+        containerDefinitions: [{ name: "app", image: "billing:1" }],
+      }),
+    );
+
+    // Then the second family starts at revision 1 of its own.
+    assertIdentical(other.taskDefinition?.revision, 1);
+  });
+
+  it("stores container definitions as they were declared", async () => {
+    // Given simulated ECS.
+    const simEcs = new SimAws().ecs();
+
+    // When a task definition declares a container in full.
+    const registered = await simEcs.registerTaskDefinition(
+      new RegisterTaskDefinitionCommand({
+        family: "checkout",
+        containerDefinitions: [
+          {
+            name: "app",
+            image: "example.dkr.ecr.eu-west-2.amazonaws.com/checkout:1",
+            essential: true,
+            cpu: 256,
+            memory: 512,
+            command: ["node", "server.js"],
+            portMappings: [{ containerPort: 8080, protocol: "tcp" }],
+            environment: [{ name: "LOG_LEVEL", value: "debug" }],
+            secrets: [
+              {
+                name: "DB_PASSWORD",
+                valueFrom:
+                  "arn:aws:secretsmanager:eu-west-2:111111111111:secret:db",
+              },
+            ],
+          },
+        ],
+      }),
+    );
+
+    // Then every part of the declaration is reported back.
+    const container = registered.taskDefinition?.containerDefinitions?.[0];
+    assertObjectMatches(container ?? {}, {
+      name: "app",
+      image: "example.dkr.ecr.eu-west-2.amazonaws.com/checkout:1",
+      essential: true,
+      cpu: 256,
+      memory: 512,
+    });
+    assertIdentical(container?.command?.[1], "server.js");
+    assertIdentical(container.portMappings?.[0]?.containerPort, 8080);
+    assertIdentical(container.environment?.[0]?.value, "debug");
+    assertIdentical(container.secrets?.[0]?.name, "DB_PASSWORD");
+  });
+
+  it("stores a container Yulin could never run just the same", async () => {
+    // Given simulated ECS.
+    const simEcs = new SimAws().ecs();
+
+    // When a task definition declares a log router beside its application.
+    const registered = await simEcs.registerTaskDefinition(
+      new RegisterTaskDefinitionCommand({
+        family: "checkout",
+        containerDefinitions: [
+          { name: "app", image: "checkout:1" },
+          {
+            name: "log-router",
+            image: "amazon/aws-for-fluent-bit:stable",
+            essential: false,
+          },
+        ],
+      }),
+    );
+
+    // Then both containers are held, because nothing here reads an image.
+    assertArrayLength(registered.taskDefinition?.containerDefinitions, 2);
+    assertIdentical(
+      registered.taskDefinition.containerDefinitions[1].image,
+      "amazon/aws-for-fluent-bit:stable",
+    );
+  });
+
+  it("reports the settings the registration declared", async () => {
+    // Given simulated ECS.
+    const simEcs = new SimAws().ecs();
+
+    // When a task definition declares sizing, roles and compatibility.
+    const registered = await simEcs.registerTaskDefinition(
+      new RegisterTaskDefinitionCommand({
+        family: "checkout",
+        containerDefinitions: [{ name: "app", image: "checkout:1" }],
+        cpu: "512",
+        memory: "1024",
+        networkMode: "awsvpc",
+        requiresCompatibilities: ["FARGATE"],
+        executionRoleArn: "arn:aws:iam::111111111111:role/TaskExecution",
+        taskRoleArn: "arn:aws:iam::111111111111:role/Checkout",
+        runtimePlatform: { cpuArchitecture: "ARM64" },
+      }),
+    );
+
+    // Then each one is reported as it was declared.
+    assertObjectMatches(registered.taskDefinition ?? {}, {
+      cpu: "512",
+      memory: "1024",
+      networkMode: "awsvpc",
+      executionRoleArn: "arn:aws:iam::111111111111:role/TaskExecution",
+      taskRoleArn: "arn:aws:iam::111111111111:role/Checkout",
+    });
+    assertIdentical(
+      registered.taskDefinition?.requiresCompatibilities?.[0],
+      "FARGATE",
+    );
+    assertIdentical(
+      registered.taskDefinition.runtimePlatform?.cpuArchitecture,
+      "ARM64",
+    );
+  });
+
+  it("reports the storage and process settings too", async () => {
+    // Given simulated ECS.
+    const simEcs = new SimAws().ecs();
+
+    // When a task definition declares volumes, placement and process modes.
+    const registered = await simEcs.registerTaskDefinition(
+      new RegisterTaskDefinitionCommand({
+        family: "checkout",
+        containerDefinitions: [{ name: "app", image: "checkout:1" }],
+        volumes: [{ name: "scratch", host: { sourcePath: "/tmp/scratch" } }],
+        placementConstraints: [{ type: "memberOf", expression: "attribute:x" }],
+        ephemeralStorage: { sizeInGiB: 40 },
+        proxyConfiguration: { type: "APPMESH", containerName: "envoy" },
+        pidMode: "task",
+        ipcMode: "task",
+      }),
+    );
+
+    // Then each one is reported as it was declared.
+    assertIdentical(registered.taskDefinition?.volumes?.[0]?.name, "scratch");
+    assertIdentical(
+      registered.taskDefinition.placementConstraints?.[0]?.type,
+      "memberOf",
+    );
+    assertIdentical(registered.taskDefinition.ephemeralStorage?.sizeInGiB, 40);
+    assertIdentical(
+      registered.taskDefinition.proxyConfiguration?.containerName,
+      "envoy",
+    );
+    assertIdentical(registered.taskDefinition.pidMode, "task");
+    assertIdentical(registered.taskDefinition.ipcMode, "task");
+  });
+
+  it("leaves out a setting the registration did not declare", async () => {
+    // Given simulated ECS.
+    const simEcs = new SimAws().ecs();
+
+    // When a task definition declares nothing but its family and container.
+    const registered = await simEcs.registerTaskDefinition(
+      new RegisterTaskDefinitionCommand({
+        family: "checkout",
+        containerDefinitions: [{ name: "app", image: "checkout:1" }],
+      }),
+    );
+
+    // Then nothing is reported in place of what was not declared.
+    assertUndefined(registered.taskDefinition?.networkMode);
+    assertUndefined(registered.taskDefinition?.cpu);
+    assertUndefined(registered.taskDefinition?.deregisteredAt);
+  });
+
+  it("reports the tags the registration carried", async () => {
+    // Given simulated ECS.
+    const simEcs = new SimAws().ecs();
+
+    // When a task definition is registered with tags.
+    const registered = await simEcs.registerTaskDefinition(
+      new RegisterTaskDefinitionCommand({
+        family: "checkout",
+        containerDefinitions: [{ name: "app", image: "checkout:1" }],
+        tags: [{ key: "team", value: "payments" }],
+      }),
+    );
+
+    // Then the tags come back beside the task definition.
+    assertArrayLength(registered.tags, 1);
+    assertIdentical(registered.tags[0].value, "payments");
+  });
+
+  it("records when and by whom a revision was registered", async () => {
+    // Given simulated ECS with a stopped clock.
+    const simAws = new SimAws({
+      clock: new SimFixedClock(new Date("2026-03-04T05:06:07Z")),
+    });
+
+    // When a task definition is registered by the account root.
+    const registered = await simAws.ecs().registerTaskDefinition(
+      new RegisterTaskDefinitionCommand({
+        family: "checkout",
+        containerDefinitions: [{ name: "app", image: "checkout:1" }],
+      }),
+    );
+
+    // Then the revision records the simulation's time and the caller.
+    assertIdentical(
+      registered.taskDefinition?.registeredAt?.toISOString(),
+      "2026-03-04T05:06:07.000Z",
+    );
+    assertIdentical(
+      registered.taskDefinition.registeredBy,
+      `arn:aws:iam::${simAws.defaultAccountId}:root`,
+    );
+  });
+
+  it("keeps the families of one account and region to themselves", async () => {
+    // Given two account and region scopes.
+    const simAws = new SimAws();
+    const here = simAws.account("111111111111").region("eu-west-2").ecs();
+    const elsewhere = simAws.account("222222222222").region("eu-west-2").ecs();
+
+    // When the same family is registered in each of them.
+    const first = await here.registerTaskDefinition(
+      new RegisterTaskDefinitionCommand({
+        family: "checkout",
+        containerDefinitions: [{ name: "app", image: "checkout:1" }],
+      }),
+    );
+    const second = await elsewhere.registerTaskDefinition(
+      new RegisterTaskDefinitionCommand({
+        family: "checkout",
+        containerDefinitions: [{ name: "app", image: "checkout:1" }],
+      }),
+    );
+
+    // Then each starts its own revision numbering under its own ARN.
+    assertIdentical(first.taskDefinition?.revision, 1);
+    assertIdentical(second.taskDefinition?.revision, 1);
+    assertIdentical(
+      second.taskDefinition.taskDefinitionArn,
+      "arn:aws:ecs:eu-west-2:222222222222:task-definition/checkout:1",
+    );
+  });
+});

--- a/src/service/ecs/command/sim-ecs-command-context.ts
+++ b/src/service/ecs/command/sim-ecs-command-context.ts
@@ -1,0 +1,36 @@
+import type { BackgroundScheduler } from "../../../util/background/background.js";
+import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+import type { SimEcsClusterArn } from "../cluster/sim-ecs-cluster-arn.js";
+import type { SimEcsClusterStore } from "../cluster/sim-ecs-cluster-store.js";
+import type { SimEcsTaskDefinitionArn } from "../task-definition/sim-ecs-task-definition-arn.js";
+import type { SimEcsTaskDefinitionStore } from "../task-definition/sim-ecs-task-definition-store.js";
+import type { SimEcsAuthorizer } from "./authorize/sim-ecs-authorizer.js";
+
+/**
+ * What every simulated ECS command handler is built with.
+ *
+ * The scheduler is here because every operation sequences on it before it
+ * touches state, and the authorizer because every operation authorizes. The
+ * two halves below add the state each kind of operation works on.
+ */
+interface SimEcsCommandCollaborators {
+  readonly authorizer: SimEcsAuthorizer;
+  readonly background: BackgroundScheduler;
+}
+
+/**
+ * What a simulated ECS cluster command handler is built with.
+ */
+export interface SimEcsClusterCommandContext extends SimEcsCommandCollaborators {
+  readonly clusters: SimEcsClusterStore;
+  readonly clusterArn: SimEcsClusterArn;
+}
+
+/**
+ * What a simulated ECS task definition command handler is built with.
+ */
+export interface SimEcsTaskDefinitionCommandContext extends SimEcsCommandCollaborators {
+  readonly taskDefinitions: SimEcsTaskDefinitionStore;
+  readonly taskDefinitionArn: SimEcsTaskDefinitionArn;
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+}

--- a/src/service/ecs/command/sim-ecs-command-handler.ts
+++ b/src/service/ecs/command/sim-ecs-command-handler.ts
@@ -1,0 +1,53 @@
+import type { BackgroundScheduler } from "../../../util/background/background.js";
+import type { SimEcsAuthorizer } from "./authorize/sim-ecs-authorizer.js";
+import { SimEcsUnsimulatedInput } from "./sim-ecs-unsimulated-input.js";
+
+interface SimEcsHandlerCollaborators {
+  readonly authorizer: SimEcsAuthorizer;
+  readonly background: BackgroundScheduler;
+}
+
+/**
+ * What every simulated ECS command handler starts by doing.
+ *
+ * Each operation refuses the inputs it does not hold, waits at the simulator's
+ * sequencing point, and authorizes the caller. Those are the same three steps
+ * in each of them, in that order, so they are here rather than written out
+ * nine times.
+ */
+export abstract class SimEcsCommandHandler {
+  protected readonly authorizer: SimEcsAuthorizer;
+  protected readonly background: BackgroundScheduler;
+
+  private readonly unsimulated: SimEcsUnsimulatedInput;
+  private readonly accepted: readonly string[];
+
+  constructor(
+    collaborators: SimEcsHandlerCollaborators,
+    operation: string,
+    accepted: readonly string[],
+  ) {
+    this.authorizer = collaborators.authorizer;
+    this.background = collaborators.background;
+    this.unsimulated = new SimEcsUnsimulatedInput(operation);
+    this.accepted = accepted;
+  }
+
+  /**
+   * Refuse anything the request declared that this operation does not hold.
+   */
+  protected refuseUnaccepted(input: object): void {
+    this.unsimulated.refuseUnaccepted(input, this.accepted);
+  }
+
+  /**
+   * Wait at the simulator's sequencing point.
+   *
+   * This allows for potential non-deterministic sequencing of async events. It
+   * comes after a request has been read and before anything is authorized or
+   * stored, so a malformed request is refused whatever else is in flight.
+   */
+  protected async sequence(): Promise<void> {
+    await this.background.sequence();
+  }
+}

--- a/src/service/ecs/command/sim-ecs-command.types.ts
+++ b/src/service/ecs/command/sim-ecs-command.types.ts
@@ -1,0 +1,49 @@
+/**
+ * The sim ECS Command types, gathered for the service facade.
+ */
+export type {
+  SimCreateClusterCommand,
+  SimCreateClusterCommandInput,
+  SimCreateClusterCommandOutput,
+} from "./create-cluster/create-cluster.command.js";
+export type {
+  SimDeleteClusterCommand,
+  SimDeleteClusterCommandInput,
+  SimDeleteClusterCommandOutput,
+} from "./delete-cluster/delete-cluster.command.js";
+export type {
+  SimDescribeClustersCommand,
+  SimDescribeClustersCommandInput,
+  SimDescribeClustersCommandOutput,
+  SimEcsFailure,
+} from "./describe-clusters/describe-clusters.command.js";
+export type {
+  SimListClustersCommand,
+  SimListClustersCommandInput,
+  SimListClustersCommandOutput,
+} from "./list-clusters/list-clusters.command.js";
+export type {
+  SimDeregisterTaskDefinitionCommand,
+  SimDeregisterTaskDefinitionCommandInput,
+  SimDeregisterTaskDefinitionCommandOutput,
+} from "./deregister-task-definition/deregister-task-definition.command.js";
+export type {
+  SimDescribeTaskDefinitionCommand,
+  SimDescribeTaskDefinitionCommandInput,
+  SimDescribeTaskDefinitionCommandOutput,
+} from "./describe-task-definition/describe-task-definition.command.js";
+export type {
+  SimListTaskDefinitionFamiliesCommand,
+  SimListTaskDefinitionFamiliesCommandInput,
+  SimListTaskDefinitionFamiliesCommandOutput,
+} from "./list-task-definition-families/list-task-definition-families.command.js";
+export type {
+  SimListTaskDefinitionsCommand,
+  SimListTaskDefinitionsCommandInput,
+  SimListTaskDefinitionsCommandOutput,
+} from "./list-task-definitions/list-task-definitions.command.js";
+export type {
+  SimRegisterTaskDefinitionCommand,
+  SimRegisterTaskDefinitionCommandInput,
+  SimRegisterTaskDefinitionCommandOutput,
+} from "./register-task-definition/register-task-definition.command.js";

--- a/src/service/ecs/command/sim-ecs-page.ts
+++ b/src/service/ecs/command/sim-ecs-page.ts
@@ -1,0 +1,96 @@
+import { SimEcsInvalidParameterException } from "../error/sim-ecs.error.js";
+
+/**
+ * How many items one listing response carries when the request says nothing.
+ *
+ * ECS pages its listings at 100 by default, and takes a `maxResults` up to
+ * that same 100.
+ */
+const defaultItemsPerPage = 100;
+
+interface SimEcsPageRequest {
+  readonly maxResults?: number | undefined;
+  readonly nextToken?: string | undefined;
+}
+
+/**
+ * One page of an ECS listing, and the token that reaches the next one.
+ *
+ * The token is the offset the next page starts at. A token that could not have
+ * come from a listing of these items is refused rather than answered from
+ * somewhere in the middle, since a real token names a position ECS itself
+ * chose.
+ */
+export class SimEcsPage<Item> {
+  public readonly items: readonly Item[];
+  public readonly nextToken: string | undefined;
+
+  constructor(listed: readonly Item[], request: SimEcsPageRequest) {
+    const itemsPerPage = SimEcsPage.itemsPerPage(request.maxResults);
+    const startIndex = SimEcsPage.startIndex(
+      request.nextToken,
+      listed.length,
+      itemsPerPage,
+    );
+    const nextIndex = startIndex + itemsPerPage;
+
+    this.items = listed.slice(startIndex, nextIndex);
+    this.nextToken = SimEcsPage.tokenFor(nextIndex, listed.length);
+  }
+
+  private static itemsPerPage(maxResults: number | undefined): number {
+    if (maxResults === undefined) {
+      return defaultItemsPerPage;
+    }
+
+    if (
+      !Number.isSafeInteger(maxResults) ||
+      maxResults < 1 ||
+      maxResults > defaultItemsPerPage
+    ) {
+      throw new SimEcsInvalidParameterException(
+        `maxResults must be a whole number from 1 to ` +
+          `${String(defaultItemsPerPage)}.`,
+      );
+    }
+
+    return maxResults;
+  }
+
+  private static startIndex(
+    nextToken: string | undefined,
+    listedCount: number,
+    itemsPerPage: number,
+  ): number {
+    if (nextToken === undefined) {
+      return 0;
+    }
+
+    const startIndex = Number(nextToken);
+
+    if (
+      !Number.isSafeInteger(startIndex) ||
+      startIndex <= 0 ||
+      startIndex % itemsPerPage !== 0 ||
+      startIndex >= listedCount ||
+      String(startIndex) !== nextToken
+    ) {
+      throw new SimEcsInvalidParameterException(
+        "nextToken is not a token this simulation issued.",
+      );
+    }
+
+    return startIndex;
+  }
+
+  private static tokenFor(
+    nextIndex: number,
+    listedCount: number,
+  ): string | undefined {
+    if (nextIndex >= listedCount) {
+      return undefined;
+    }
+
+    return String(nextIndex);
+  }
+}

--- a/src/service/ecs/command/sim-ecs-request-options.ts
+++ b/src/service/ecs/command/sim-ecs-request-options.ts
@@ -1,0 +1,14 @@
+import type { SimAwsCaller } from "../../aws/caller/sim-aws-caller.js";
+
+/**
+ * The request context a simulated ECS operation is made in.
+ */
+export interface SimEcsRequestOptions {
+  /**
+   * The principal making the request. Defaults to the Account root.
+   *
+   * It is authorized for the ECS action, and it is also the principal a
+   * registered task definition records as having registered it.
+   */
+  readonly caller?: SimAwsCaller | undefined;
+}

--- a/src/service/ecs/command/sim-ecs-unsimulated-input.ts
+++ b/src/service/ecs/command/sim-ecs-unsimulated-input.ts
@@ -1,0 +1,34 @@
+import { SimEcsClientException } from "../error/sim-ecs.error.js";
+
+/**
+ * Refuses the request inputs this simulation does not hold.
+ *
+ * The refusal works from the small set of options each command accepts rather
+ * than from a list of everything ECS offers, so an option nobody thought about
+ * is refused rather than dropped. Dropping is the failure mode worth avoiding:
+ * a registration is a declaration, and a declaration silently missing from the
+ * revision it made is a test passing on state that is not what was asked for.
+ */
+export class SimEcsUnsimulatedInput {
+  private readonly operation: string;
+
+  constructor(operation: string) {
+    this.operation = operation;
+  }
+
+  /**
+   * Refuse every supplied input that is not one of the accepted options.
+   */
+  refuseUnaccepted(input: object, accepted: readonly string[]): void {
+    for (const [option, value] of Object.entries(input)) {
+      if (value === undefined || accepted.includes(option)) {
+        continue;
+      }
+
+      throw new SimEcsClientException(
+        `${this.operation} ${option} is not simulated: it would be dropped ` +
+          `here and applied on real AWS`,
+      );
+    }
+  }
+}

--- a/src/service/ecs/error/sim-ecs.error.ts
+++ b/src/service/ecs/error/sim-ecs.error.ts
@@ -1,0 +1,65 @@
+/**
+ * Minimal metadata shape for simulated ECS errors.
+ */
+export interface SimEcsErrorMetadata {
+  readonly httpStatusCode?: number;
+}
+
+/**
+ * Base class for simulated ECS errors.
+ */
+export class SimEcsError extends Error {
+  constructor(
+    message: string,
+    public readonly $metadata: SimEcsErrorMetadata = {},
+  ) {
+    super(message);
+  }
+}
+
+/**
+ * Simulated ECS ClientException error.
+ *
+ * Real ECS reports most request-level problems this way rather than with a
+ * more specific error, including a task definition it cannot describe.
+ */
+export class SimEcsClientException extends SimEcsError {
+  public override readonly name = "ClientException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
+ * Simulated ECS InvalidParameterException error.
+ */
+export class SimEcsInvalidParameterException extends SimEcsError {
+  public override readonly name = "InvalidParameterException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
+ * Simulated ECS ClusterNotFoundException error.
+ */
+export class SimEcsClusterNotFoundException extends SimEcsError {
+  public override readonly name = "ClusterNotFoundException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
+ * Simulated ECS AccessDeniedException error.
+ */
+export class SimEcsAccessDeniedException extends SimEcsError {
+  public override readonly name = "AccessDeniedException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}

--- a/src/service/ecs/index.ts
+++ b/src/service/ecs/index.ts
@@ -1,0 +1,65 @@
+export { SimEcs } from "./sim-ecs.js";
+export type { SimEcsRequestOptions } from "./command/sim-ecs-request-options.js";
+export { requiredSimEcsName } from "./sim-ecs-name.js";
+export { parseSimEcsArn, type SimEcsArnParts } from "./sim-ecs-arn.js";
+export {
+  simEcsDefaultClusterName,
+  SimEcsClusterArn,
+} from "./cluster/sim-ecs-cluster-arn.js";
+export {
+  SimEcsCluster,
+  type SimEcsClusterDetail,
+  type SimEcsClusterIncludes,
+  type SimEcsClusterSetting,
+  type SimEcsClusterStatus,
+  type SimEcsKeyValueString,
+} from "./cluster/sim-ecs-cluster.js";
+export { SimEcsClusterStore } from "./cluster/sim-ecs-cluster-store.js";
+export { SimEcsTaskDefinition } from "./task-definition/sim-ecs-task-definition.js";
+export {
+  simEcsTaskDefinitionDetail,
+  type SimEcsTaskDefinitionDetail,
+  type SimEcsTaskDefinitionDetailInput,
+  type SimEcsTaskDefinitionStatus,
+} from "./task-definition/sim-ecs-task-definition-detail.js";
+export { SimEcsTaskDefinitionArn } from "./task-definition/sim-ecs-task-definition-arn.js";
+export { SimEcsTaskDefinitionFamily } from "./task-definition/sim-ecs-task-definition-family.js";
+export { SimEcsTaskDefinitionId } from "./task-definition/sim-ecs-task-definition-id.js";
+export { SimEcsTaskDefinitionStore } from "./task-definition/sim-ecs-task-definition-store.js";
+export {
+  simEcsTaskDefinitionSettingNames,
+  SimEcsTaskDefinitionSettings,
+  type SimEcsTaskDefinitionSettingsType,
+} from "./task-definition/sim-ecs-task-definition-settings.js";
+export type {
+  SimEcsEphemeralStorage,
+  SimEcsHostVolumeProperties,
+  SimEcsProxyConfiguration,
+  SimEcsRuntimePlatform,
+  SimEcsTag,
+  SimEcsTaskDefinitionPlacementConstraint,
+  SimEcsVolume,
+} from "./task-definition/sim-ecs-task-definition-parts.js";
+export {
+  SimEcsContainerDefinition,
+  type SimEcsContainerDefinitionType,
+} from "./task-definition/container/sim-ecs-container-definition.js";
+export { SimEcsContainerDefinitions } from "./task-definition/container/sim-ecs-container-definitions.js";
+export type {
+  SimEcsContainerDependency,
+  SimEcsHealthCheck,
+  SimEcsKeyValuePair,
+  SimEcsLogConfiguration,
+  SimEcsMountPoint,
+  SimEcsPortMapping,
+  SimEcsSecret,
+  SimEcsUlimit,
+} from "./task-definition/container/sim-ecs-container-parts.js";
+export type * from "./command/sim-ecs-command.types.js";
+export {
+  SimEcsAccessDeniedException,
+  SimEcsClientException,
+  SimEcsClusterNotFoundException,
+  SimEcsError,
+  SimEcsInvalidParameterException,
+} from "./error/sim-ecs.error.js";

--- a/src/service/ecs/sdk/sim-ecs-sdk-command-router.ts
+++ b/src/service/ecs/sdk/sim-ecs-sdk-command-router.ts
@@ -1,0 +1,105 @@
+import {
+  simSdkCallerOptions,
+  type SimSdkCommandRoute,
+  type SimSdkCommandRouter,
+} from "../../../sdk/index.js";
+import type * as simEcsCommands from "../command/sim-ecs-command.types.js";
+import type { SimEcs } from "../sim-ecs.js";
+
+/**
+ * Routes intercepted SDK Commands to one scoped simulated ECS instance.
+ */
+export class SimEcsSdkCommandRouter implements SimSdkCommandRouter {
+  private readonly routes: ReadonlyMap<string, SimSdkCommandRoute>;
+
+  constructor(simEcs: SimEcs) {
+    this.routes = new Map<string, SimSdkCommandRoute>([
+      [
+        "CreateClusterCommand",
+        async (command, context): Promise<unknown> =>
+          await simEcs.createCluster(
+            command as simEcsCommands.SimCreateClusterCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "DescribeClustersCommand",
+        async (command, context): Promise<unknown> =>
+          await simEcs.describeClusters(
+            command as simEcsCommands.SimDescribeClustersCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "DeleteClusterCommand",
+        async (command, context): Promise<unknown> =>
+          await simEcs.deleteCluster(
+            command as simEcsCommands.SimDeleteClusterCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "ListClustersCommand",
+        async (command, context): Promise<unknown> =>
+          await simEcs.listClusters(
+            command as simEcsCommands.SimListClustersCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "RegisterTaskDefinitionCommand",
+        async (command, context): Promise<unknown> =>
+          await simEcs.registerTaskDefinition(
+            command as simEcsCommands.SimRegisterTaskDefinitionCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "DeregisterTaskDefinitionCommand",
+        async (command, context): Promise<unknown> =>
+          await simEcs.deregisterTaskDefinition(
+            command as simEcsCommands.SimDeregisterTaskDefinitionCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "DescribeTaskDefinitionCommand",
+        async (command, context): Promise<unknown> =>
+          await simEcs.describeTaskDefinition(
+            command as simEcsCommands.SimDescribeTaskDefinitionCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "ListTaskDefinitionsCommand",
+        async (command, context): Promise<unknown> =>
+          await simEcs.listTaskDefinitions(
+            command as simEcsCommands.SimListTaskDefinitionsCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "ListTaskDefinitionFamiliesCommand",
+        async (command, context): Promise<unknown> =>
+          await simEcs.listTaskDefinitionFamilies(
+            command as simEcsCommands.SimListTaskDefinitionFamiliesCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+    ]);
+  }
+
+  /**
+   * The SDK Command names simulated ECS can handle.
+   */
+  supportedCommandNames(): readonly string[] {
+    return this.routes.keys().toArray();
+  }
+
+  /**
+   * Get the route for an SDK Command name, if simulated ECS supports it.
+   */
+  route(commandName: string): SimSdkCommandRoute | undefined {
+    return this.routes.get(commandName);
+  }
+}

--- a/src/service/ecs/sdk/sim-ecs-sdk-routing.iso.test.ts
+++ b/src/service/ecs/sdk/sim-ecs-sdk-routing.iso.test.ts
@@ -1,0 +1,136 @@
+import {
+  CreateClusterCommand,
+  DeleteClusterCommand,
+  DeregisterTaskDefinitionCommand,
+  DescribeClustersCommand,
+  DescribeTaskDefinitionCommand,
+  ECSClient,
+  ListClustersCommand,
+  ListTaskDefinitionFamiliesCommand,
+  ListTaskDefinitionsCommand,
+  RegisterTaskDefinitionCommand,
+} from "@aws-sdk/client-ecs";
+import {
+  assertArrayIncludesAll,
+  assertArrayLength,
+  assertIdentical,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimSdk } from "../../../sdk/index.js";
+import { SimEcs } from "../sim-ecs.js";
+
+describe("ECS SDK interception", () => {
+  it("routes an intercepted ECSClient to simulated ECS", async () => {
+    // Given an intercepted ECS SDK client.
+    using simSdk = new SimSdk();
+    simSdk.intercept(ECSClient);
+
+    const ecs = new ECSClient({ region: "eu-west-2" });
+
+    // When ordinary SDK code registers and describes a task definition.
+    await ecs.send(
+      new RegisterTaskDefinitionCommand({
+        family: "checkout",
+        containerDefinitions: [{ name: "app", image: "checkout:1" }],
+      }),
+    );
+    const described = await ecs.send(
+      new DescribeTaskDefinitionCommand({ taskDefinition: "checkout" }),
+    );
+
+    // Then the simulated revision answers, with nothing touching the network.
+    assertIdentical(described.taskDefinition?.revision, 1);
+    assertIdentical(
+      described.taskDefinition.containerDefinitions?.[0]?.image,
+      "checkout:1",
+    );
+  });
+
+  it("routes an intercepted cluster command to simulated ECS", async () => {
+    // Given an intercepted ECS SDK client.
+    using simSdk = new SimSdk();
+    simSdk.intercept(ECSClient);
+
+    const ecs = new ECSClient({ region: "eu-west-2" });
+
+    // When ordinary SDK code creates a cluster and lists the clusters.
+    await ecs.send(new CreateClusterCommand({ clusterName: "services" }));
+    const listed = await ecs.send(new ListClustersCommand({}));
+
+    // Then the simulated cluster is the one listed.
+    assertArrayLength(listed.clusterArns, 1);
+    assertIdentical(
+      listed.clusterArns[0],
+      `arn:aws:ecs:eu-west-2:${simSdk.simAws.defaultAccountId}:cluster/services`,
+    );
+  });
+
+  it("routes every operation this service simulates", async () => {
+    // Given an intercepted ECS SDK client.
+    using simSdk = new SimSdk();
+    simSdk.intercept(ECSClient);
+
+    const ecs = new ECSClient({ region: "eu-west-2" });
+    await ecs.send(new CreateClusterCommand({ clusterName: "services" }));
+    await ecs.send(
+      new RegisterTaskDefinitionCommand({
+        family: "checkout",
+        containerDefinitions: [{ name: "app", image: "checkout:1" }],
+      }),
+    );
+
+    // When each remaining operation is sent through the client.
+    const clusters = await ecs.send(
+      new DescribeClustersCommand({ clusters: ["services"] }),
+    );
+    const families = await ecs.send(new ListTaskDefinitionFamiliesCommand({}));
+    const revisions = await ecs.send(new ListTaskDefinitionsCommand({}));
+    const deregistered = await ecs.send(
+      new DeregisterTaskDefinitionCommand({ taskDefinition: "checkout:1" }),
+    );
+    const deleted = await ecs.send(
+      new DeleteClusterCommand({ cluster: "services" }),
+    );
+
+    // Then each one is answered by the simulation.
+    assertArrayLength(clusters.clusters, 1);
+    assertArrayLength(families.families, 1);
+    assertArrayLength(revisions.taskDefinitionArns, 1);
+    assertIdentical(deregistered.taskDefinition?.status, "INACTIVE");
+    assertIdentical(deleted.cluster?.status, "INACTIVE");
+  });
+
+  it("supports every ECS operation this service simulates", () => {
+    // Given simulated ECS.
+    const simEcs = new SimEcs();
+
+    // When its SDK Command router is asked what it handles.
+    const supported = simEcs.sdkCommandRouter().supportedCommandNames();
+
+    // Then every simulated operation is routable from an SDK client.
+    assertArrayIncludesAll(supported, [
+      CreateClusterCommand.name,
+      DescribeClustersCommand.name,
+      DeleteClusterCommand.name,
+      ListClustersCommand.name,
+      RegisterTaskDefinitionCommand.name,
+      DeregisterTaskDefinitionCommand.name,
+      DescribeTaskDefinitionCommand.name,
+      ListTaskDefinitionsCommand.name,
+      ListTaskDefinitionFamiliesCommand.name,
+    ]);
+  });
+
+  it("has no route for an operation it does not simulate", () => {
+    // Given simulated ECS.
+    const simEcs = new SimEcs();
+
+    // When a command it does not handle is looked up.
+    const route = simEcs.sdkCommandRouter().route("RunTaskCommand");
+
+    // Then there is no route for it, so interception reports it as
+    // unsupported rather than answering with nothing.
+    assertUndefined(route);
+  });
+});

--- a/src/service/ecs/sim-ecs-arn.ts
+++ b/src/service/ecs/sim-ecs-arn.ts
@@ -1,0 +1,50 @@
+import type { AwsRegionName } from "../aws/sim-aws-region.js";
+import type { SimAwsAccountId } from "../aws/sim-aws-account.js";
+
+/**
+ * The parts of an ECS ARN that say what it names.
+ */
+export interface SimEcsArnParts {
+  readonly region: AwsRegionName;
+  readonly accountId: SimAwsAccountId;
+  readonly resourceType: string;
+  readonly resourceId: string;
+}
+
+/**
+ * Read an ECS ARN.
+ *
+ * ECS has its own reader rather than using the shared one because a task
+ * definition ARN carries a colon inside its resource part, in
+ * `task-definition/family:revision`. The shared reader stops at the sixth
+ * colon, which would cut the revision off the end and leave every revision of
+ * a family looking like the same ARN.
+ *
+ * Undefined means the value does not name an ECS resource, which is an
+ * ordinary case here: identifiers reach ECS from user input, where a value
+ * that is not an ARN at all is something each caller reports in its own terms.
+ */
+export function parseSimEcsArn(value: string): SimEcsArnParts | undefined {
+  const [arnPrefix, partition, service, region, accountId, ...rest] =
+    value.split(":");
+  const resource = rest.join(":");
+  const separatorIndex = resource.indexOf("/");
+
+  if (
+    arnPrefix !== "arn" ||
+    partition !== "aws" ||
+    service !== "ecs" ||
+    region === undefined ||
+    accountId === undefined ||
+    separatorIndex === -1
+  ) {
+    return undefined;
+  }
+
+  return {
+    region: region as AwsRegionName,
+    accountId: accountId as SimAwsAccountId,
+    resourceType: resource.slice(0, separatorIndex),
+    resourceId: resource.slice(separatorIndex + 1),
+  };
+}

--- a/src/service/ecs/sim-ecs-name.ts
+++ b/src/service/ecs/sim-ecs-name.ts
@@ -1,0 +1,34 @@
+import { SimEcsClientException } from "./error/sim-ecs.error.js";
+
+/**
+ * The names ECS accepts for a cluster and for a task definition family.
+ *
+ * Both take up to 255 letters, numbers, hyphens and underscores, and nothing
+ * else.
+ */
+const allowedName = /^[\w-]{1,255}$/;
+
+/**
+ * Take an ECS name, refusing one ECS would not accept.
+ *
+ * The rule is here once because a cluster name and a task definition family
+ * are the same rule on real ECS, and a name that would be refused on
+ * deployment should be refused here rather than stored.
+ */
+export function requiredSimEcsName(
+  value: string | undefined,
+  subject: string,
+): string {
+  if (value === undefined || value === "") {
+    throw new SimEcsClientException(`${subject} cannot be blank.`);
+  }
+
+  if (!allowedName.test(value)) {
+    throw new SimEcsClientException(
+      `Invalid ${subject}: ${value}. Up to 255 letters, numbers, hyphens and ` +
+        `underscores are allowed.`,
+    );
+  }
+
+  return value;
+}

--- a/src/service/ecs/sim-ecs.ts
+++ b/src/service/ecs/sim-ecs.ts
@@ -1,0 +1,201 @@
+import {
+  type BackgroundScheduler,
+  BackgroundTasks,
+} from "../../util/background/background.js";
+import type { SimSdkCommandRouter } from "../../sdk/router/sim-sdk-command-router.type.js";
+import type { SimAwsAccountRegionScope } from "../aws/sim-aws-account-region-scope.js";
+import { simAwsAccountRegionScopeFactory } from "../aws/sim-aws-account-region-scope.factory.js";
+import {
+  SimIamAllowAllAuth,
+  type SimIamInterServiceAuthZ,
+} from "../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { SimEcsClusterArn } from "./cluster/sim-ecs-cluster-arn.js";
+import { SimEcsClusterStore } from "./cluster/sim-ecs-cluster-store.js";
+import { SimEcsAuthorizer } from "./command/authorize/sim-ecs-authorizer.js";
+import { CreateClusterCommandHandler } from "./command/create-cluster/create-cluster.handler.js";
+import { DeleteClusterCommandHandler } from "./command/delete-cluster/delete-cluster.handler.js";
+import { DeregisterTaskDefinitionCommandHandler } from "./command/deregister-task-definition/deregister-task-definition.handler.js";
+import { DescribeClustersCommandHandler } from "./command/describe-clusters/describe-clusters.handler.js";
+import { DescribeTaskDefinitionCommandHandler } from "./command/describe-task-definition/describe-task-definition.handler.js";
+import { ListClustersCommandHandler } from "./command/list-clusters/list-clusters.handler.js";
+import { ListTaskDefinitionFamiliesCommandHandler } from "./command/list-task-definition-families/list-task-definition-families.handler.js";
+import { ListTaskDefinitionsCommandHandler } from "./command/list-task-definitions/list-task-definitions.handler.js";
+import { RegisterTaskDefinitionCommandHandler } from "./command/register-task-definition/register-task-definition.handler.js";
+import type * as simEcsCommands from "./command/sim-ecs-command.types.js";
+import type { SimEcsRequestOptions } from "./command/sim-ecs-request-options.js";
+import { SimEcsSdkCommandRouter } from "./sdk/sim-ecs-sdk-command-router.js";
+import { SimEcsTaskDefinitionArn } from "./task-definition/sim-ecs-task-definition-arn.js";
+import { SimEcsTaskDefinitionStore } from "./task-definition/sim-ecs-task-definition-store.js";
+
+interface SimEcsProperties {
+  readonly accountRegionScope?: SimAwsAccountRegionScope;
+  readonly iam?: SimIamInterServiceAuthZ;
+  readonly background?: BackgroundScheduler;
+}
+
+/**
+ * Simulated ECS. Handles SDK commands. Emulates AWS behaviour and state.
+ *
+ * Clusters and task definitions are scoped to an account and region, as they
+ * are on real AWS: both ARNs name the region, and a cluster name is unique
+ * within one account and region rather than globally.
+ *
+ * Nothing runs here yet. This is the state ECS holds, which is what everything
+ * that will run reads from.
+ */
+export class SimEcs {
+  private readonly clusters = new SimEcsClusterStore();
+  private readonly taskDefinitions = new SimEcsTaskDefinitionStore();
+
+  private readonly createClusterCommand: CreateClusterCommandHandler;
+  private readonly describeClustersCommand: DescribeClustersCommandHandler;
+  private readonly deleteClusterCommand: DeleteClusterCommandHandler;
+  private readonly listClustersCommand: ListClustersCommandHandler;
+  private readonly registerTaskDefinitionCommand: RegisterTaskDefinitionCommandHandler;
+  private readonly deregisterTaskDefinitionCommand: DeregisterTaskDefinitionCommandHandler;
+  private readonly describeTaskDefinitionCommand: DescribeTaskDefinitionCommandHandler;
+  private readonly listTaskDefinitionsCommand: ListTaskDefinitionsCommandHandler;
+  private readonly listTaskDefinitionFamiliesCommand: ListTaskDefinitionFamiliesCommandHandler;
+  private readonly sdkRouter = new SimEcsSdkCommandRouter(this);
+
+  constructor(properties: SimEcsProperties = {}) {
+    const {
+      accountRegionScope = simAwsAccountRegionScopeFactory.make(),
+      iam = new SimIamAllowAllAuth(),
+      background = new BackgroundTasks(),
+    } = properties;
+
+    const authorizer = new SimEcsAuthorizer({ iam });
+    const clusterContext = {
+      clusters: this.clusters,
+      clusterArn: new SimEcsClusterArn(accountRegionScope),
+      authorizer,
+      background,
+    };
+    const taskDefinitionContext = {
+      taskDefinitions: this.taskDefinitions,
+      taskDefinitionArn: new SimEcsTaskDefinitionArn(accountRegionScope),
+      accountRegionScope,
+      authorizer,
+      background,
+    };
+
+    this.createClusterCommand = new CreateClusterCommandHandler(clusterContext);
+    this.describeClustersCommand = new DescribeClustersCommandHandler(
+      clusterContext,
+    );
+    this.deleteClusterCommand = new DeleteClusterCommandHandler(clusterContext);
+    this.listClustersCommand = new ListClustersCommandHandler(clusterContext);
+    this.registerTaskDefinitionCommand =
+      new RegisterTaskDefinitionCommandHandler(taskDefinitionContext);
+    this.deregisterTaskDefinitionCommand =
+      new DeregisterTaskDefinitionCommandHandler(taskDefinitionContext);
+    this.describeTaskDefinitionCommand =
+      new DescribeTaskDefinitionCommandHandler(taskDefinitionContext);
+    this.listTaskDefinitionsCommand = new ListTaskDefinitionsCommandHandler(
+      taskDefinitionContext,
+    );
+    this.listTaskDefinitionFamiliesCommand =
+      new ListTaskDefinitionFamiliesCommandHandler(taskDefinitionContext);
+  }
+
+  /**
+   * Handle a CreateCluster Command from the SDK.
+   */
+  async createCluster(
+    command: simEcsCommands.SimCreateClusterCommand,
+    options?: SimEcsRequestOptions,
+  ): Promise<simEcsCommands.SimCreateClusterCommandOutput> {
+    return await this.createClusterCommand.handle(command, options);
+  }
+
+  /**
+   * Handle a DescribeClusters Command from the SDK.
+   */
+  async describeClusters(
+    command: simEcsCommands.SimDescribeClustersCommand,
+    options?: SimEcsRequestOptions,
+  ): Promise<simEcsCommands.SimDescribeClustersCommandOutput> {
+    return await this.describeClustersCommand.handle(command, options);
+  }
+
+  /**
+   * Handle a DeleteCluster Command from the SDK.
+   */
+  async deleteCluster(
+    command: simEcsCommands.SimDeleteClusterCommand,
+    options?: SimEcsRequestOptions,
+  ): Promise<simEcsCommands.SimDeleteClusterCommandOutput> {
+    return await this.deleteClusterCommand.handle(command, options);
+  }
+
+  /**
+   * Handle a ListClusters Command from the SDK.
+   */
+  async listClusters(
+    command: simEcsCommands.SimListClustersCommand,
+    options?: SimEcsRequestOptions,
+  ): Promise<simEcsCommands.SimListClustersCommandOutput> {
+    return await this.listClustersCommand.handle(command, options);
+  }
+
+  /**
+   * Handle a RegisterTaskDefinition Command from the SDK.
+   */
+  async registerTaskDefinition(
+    command: simEcsCommands.SimRegisterTaskDefinitionCommand,
+    options?: SimEcsRequestOptions,
+  ): Promise<simEcsCommands.SimRegisterTaskDefinitionCommandOutput> {
+    return await this.registerTaskDefinitionCommand.handle(command, options);
+  }
+
+  /**
+   * Handle a DeregisterTaskDefinition Command from the SDK.
+   */
+  async deregisterTaskDefinition(
+    command: simEcsCommands.SimDeregisterTaskDefinitionCommand,
+    options?: SimEcsRequestOptions,
+  ): Promise<simEcsCommands.SimDeregisterTaskDefinitionCommandOutput> {
+    return await this.deregisterTaskDefinitionCommand.handle(command, options);
+  }
+
+  /**
+   * Handle a DescribeTaskDefinition Command from the SDK.
+   */
+  async describeTaskDefinition(
+    command: simEcsCommands.SimDescribeTaskDefinitionCommand,
+    options?: SimEcsRequestOptions,
+  ): Promise<simEcsCommands.SimDescribeTaskDefinitionCommandOutput> {
+    return await this.describeTaskDefinitionCommand.handle(command, options);
+  }
+
+  /**
+   * Handle a ListTaskDefinitions Command from the SDK.
+   */
+  async listTaskDefinitions(
+    command: simEcsCommands.SimListTaskDefinitionsCommand,
+    options?: SimEcsRequestOptions,
+  ): Promise<simEcsCommands.SimListTaskDefinitionsCommandOutput> {
+    return await this.listTaskDefinitionsCommand.handle(command, options);
+  }
+
+  /**
+   * Handle a ListTaskDefinitionFamilies Command from the SDK.
+   */
+  async listTaskDefinitionFamilies(
+    command: simEcsCommands.SimListTaskDefinitionFamiliesCommand,
+    options?: SimEcsRequestOptions,
+  ): Promise<simEcsCommands.SimListTaskDefinitionFamiliesCommandOutput> {
+    return await this.listTaskDefinitionFamiliesCommand.handle(
+      command,
+      options,
+    );
+  }
+
+  /**
+   * Get this service's SDK Command router for SDK client interception.
+   */
+  sdkCommandRouter(): SimSdkCommandRouter {
+    return this.sdkRouter;
+  }
+}

--- a/src/service/ecs/task-definition/container/sim-ecs-container-definition.ts
+++ b/src/service/ecs/task-definition/container/sim-ecs-container-definition.ts
@@ -1,0 +1,112 @@
+import { SimEcsClientException } from "../../error/sim-ecs.error.js";
+import type {
+  SimEcsContainerDependency,
+  SimEcsHealthCheck,
+  SimEcsKeyValuePair,
+  SimEcsLogConfiguration,
+  SimEcsMountPoint,
+  SimEcsPortMapping,
+  SimEcsSecret,
+  SimEcsUlimit,
+} from "./sim-ecs-container-parts.js";
+
+/**
+ * Minimal structural sim ECS container definition.
+ *
+ * These are the fields a described task definition reports under a name of
+ * their own. A definition may carry more than this, and whatever it carries is
+ * stored and reported unchanged, because a task definition is a declaration
+ * rather than something this simulation reads the meaning out of.
+ *
+ * https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_ContainerDefinition.html
+ */
+export interface SimEcsContainerDefinitionType {
+  readonly name?: string | undefined;
+  readonly image?: string | undefined;
+  readonly cpu?: number | undefined;
+  readonly memory?: number | undefined;
+  readonly memoryReservation?: number | undefined;
+  readonly essential?: boolean | undefined;
+  readonly command?: readonly string[] | undefined;
+  readonly entryPoint?: readonly string[] | undefined;
+  readonly workingDirectory?: string | undefined;
+  readonly user?: string | undefined;
+  readonly environment?: readonly SimEcsKeyValuePair[] | undefined;
+  readonly secrets?: readonly SimEcsSecret[] | undefined;
+  readonly portMappings?: readonly SimEcsPortMapping[] | undefined;
+  readonly mountPoints?: readonly SimEcsMountPoint[] | undefined;
+  readonly dependsOn?: readonly SimEcsContainerDependency[] | undefined;
+  readonly healthCheck?: SimEcsHealthCheck | undefined;
+  readonly logConfiguration?: SimEcsLogConfiguration | undefined;
+  readonly ulimits?: readonly SimEcsUlimit[] | undefined;
+  readonly dockerLabels?: Readonly<Record<string, string>> | undefined;
+  readonly readonlyRootFilesystem?: boolean | undefined;
+  readonly privileged?: boolean | undefined;
+  readonly startTimeout?: number | undefined;
+  readonly stopTimeout?: number | undefined;
+}
+
+/**
+ * One container declared by a simulated ECS task definition.
+ *
+ * The declaration is kept as it was made. Yulin never looks inside a container
+ * image, so there is nothing here to read a definition's meaning out of: the
+ * image URI is an identifier, and the rest is configuration a running task
+ * would use. Storing it whole is what lets a test assert that what a template
+ * or a CDK construct declared is what ECS holds.
+ */
+export class SimEcsContainerDefinition {
+  public readonly name: string;
+  public readonly image: string;
+
+  private readonly declared: SimEcsContainerDefinitionType;
+
+  constructor(declared: SimEcsContainerDefinitionType) {
+    this.name = SimEcsContainerDefinition.requiredName(declared);
+    this.image = SimEcsContainerDefinition.requiredImage(declared, this.name);
+    // Copied rather than held by reference, since the caller owns the object
+    // it passed in and may reuse it for the next registration.
+    this.declared = structuredClone(declared);
+  }
+
+  private static requiredName(declared: SimEcsContainerDefinitionType): string {
+    const { name } = declared;
+
+    if (name === undefined || name === "") {
+      throw new SimEcsClientException(
+        "Container.name should not be null or empty.",
+      );
+    }
+
+    return name;
+  }
+
+  /**
+   * The image URI the container declared.
+   *
+   * It is required here as it is on real ECS. Nothing pulls it or reads it,
+   * but it is the identifier a simulated task run matches an executable
+   * binding against, so a definition without one could never run.
+   */
+  private static requiredImage(
+    declared: SimEcsContainerDefinitionType,
+    name: string,
+  ): string {
+    const { image } = declared;
+
+    if (image === undefined || image === "") {
+      throw new SimEcsClientException(
+        `Container.image should not be null or empty for container ${name}.`,
+      );
+    }
+
+    return image;
+  }
+
+  /**
+   * This container as a described task definition reports it.
+   */
+  toOutput(): SimEcsContainerDefinitionType {
+    return structuredClone(this.declared);
+  }
+}

--- a/src/service/ecs/task-definition/container/sim-ecs-container-definitions.ts
+++ b/src/service/ecs/task-definition/container/sim-ecs-container-definitions.ts
@@ -1,0 +1,58 @@
+import { SimEcsClientException } from "../../error/sim-ecs.error.js";
+import {
+  SimEcsContainerDefinition,
+  type SimEcsContainerDefinitionType,
+} from "./sim-ecs-container-definition.js";
+
+/**
+ * The containers one simulated ECS task definition declares.
+ *
+ * A task definition needs at least one container, and no two of them may share
+ * a name, because a name is how everything else in ECS refers to a container:
+ * a dependency, an override, and the binding a simulated task run would look
+ * up.
+ */
+export class SimEcsContainerDefinitions {
+  private readonly containers: readonly SimEcsContainerDefinition[];
+
+  constructor(declared: readonly SimEcsContainerDefinitionType[] | undefined) {
+    this.containers = SimEcsContainerDefinitions.declaredContainers(declared);
+    this.refuseRepeatedNames();
+  }
+
+  private static declaredContainers(
+    declared: readonly SimEcsContainerDefinitionType[] | undefined,
+  ): readonly SimEcsContainerDefinition[] {
+    if (declared === undefined || declared.length === 0) {
+      throw new SimEcsClientException(
+        "A task definition must declare at least one container definition.",
+      );
+    }
+
+    return declared.map(
+      (container) => new SimEcsContainerDefinition(container),
+    );
+  }
+
+  /**
+   * These containers as a described task definition reports them.
+   */
+  toOutput(): readonly SimEcsContainerDefinitionType[] {
+    return this.containers.map((container) => container.toOutput());
+  }
+
+  private refuseRepeatedNames(): void {
+    const seen = new Set<string>();
+
+    for (const container of this.containers) {
+      if (seen.has(container.name)) {
+        throw new SimEcsClientException(
+          `Container names must be unique within a task definition: ` +
+            `${container.name} is declared more than once.`,
+        );
+      }
+
+      seen.add(container.name);
+    }
+  }
+}

--- a/src/service/ecs/task-definition/container/sim-ecs-container-parts.ts
+++ b/src/service/ecs/task-definition/container/sim-ecs-container-parts.ts
@@ -1,0 +1,93 @@
+/**
+ * Minimal structural sim ECS key value pair, as used by `environment`.
+ *
+ * https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_KeyValuePair.html
+ */
+export interface SimEcsKeyValuePair {
+  readonly name?: string | undefined;
+  readonly value?: string | undefined;
+}
+
+/**
+ * Minimal structural sim ECS container secret.
+ *
+ * `valueFrom` names a Secrets Manager secret or an SSM parameter. Nothing
+ * resolves it here, so the value is only ever the identifier the definition
+ * declared.
+ *
+ * https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_Secret.html
+ */
+export interface SimEcsSecret {
+  readonly name?: string | undefined;
+  readonly valueFrom?: string | undefined;
+}
+
+/**
+ * Minimal structural sim ECS port mapping.
+ *
+ * https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_PortMapping.html
+ */
+export interface SimEcsPortMapping {
+  readonly containerPort?: number | undefined;
+  readonly hostPort?: number | undefined;
+  readonly protocol?: string | undefined;
+  readonly name?: string | undefined;
+  readonly appProtocol?: string | undefined;
+  readonly containerPortRange?: string | undefined;
+}
+
+/**
+ * Minimal structural sim ECS container dependency.
+ *
+ * https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_ContainerDependency.html
+ */
+export interface SimEcsContainerDependency {
+  readonly containerName?: string | undefined;
+  readonly condition?: string | undefined;
+}
+
+/**
+ * Minimal structural sim ECS container health check.
+ *
+ * https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_HealthCheck.html
+ */
+export interface SimEcsHealthCheck {
+  readonly command?: readonly string[] | undefined;
+  readonly interval?: number | undefined;
+  readonly timeout?: number | undefined;
+  readonly retries?: number | undefined;
+  readonly startPeriod?: number | undefined;
+}
+
+/**
+ * Minimal structural sim ECS container log configuration.
+ *
+ * https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_LogConfiguration.html
+ */
+export interface SimEcsLogConfiguration {
+  readonly logDriver?: string | undefined;
+  readonly options?: Readonly<Record<string, string>> | undefined;
+  readonly secretOptions?: readonly SimEcsSecret[] | undefined;
+}
+
+/**
+ * Minimal structural sim ECS ulimit.
+ *
+ * https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_Ulimit.html
+ */
+export interface SimEcsUlimit {
+  readonly name?: string | undefined;
+  readonly softLimit?: number | undefined;
+  readonly hardLimit?: number | undefined;
+}
+
+/**
+ * Minimal structural sim ECS mount point.
+ *
+ * https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_MountPoint.html
+ */
+export interface SimEcsMountPoint {
+  readonly sourceVolume?: string | undefined;
+  readonly containerPath?: string | undefined;
+  readonly readOnly?: boolean | undefined;
+}

--- a/src/service/ecs/task-definition/sim-ecs-registered-task-definition.factory.ts
+++ b/src/service/ecs/task-definition/sim-ecs-registered-task-definition.factory.ts
@@ -1,0 +1,56 @@
+import { AsyncMappedFactory } from "@kensio/part-factory";
+import { assertDefined } from "../../../util/type-guard/defined.js";
+import type { SimAws } from "../../aws/sim-aws.js";
+import type { SimEcsTaskDefinitionDetail } from "./sim-ecs-task-definition-detail.js";
+
+/**
+ * What a test asks for when it wants a task definition already registered.
+ */
+export interface SimEcsRegisteredTaskDefinitionInput {
+  readonly family: string;
+  readonly containerName: string;
+  readonly image: string;
+}
+
+/**
+ * Registers one revision of a task definition family.
+ *
+ * A family and one container is the smallest registration ECS accepts, and it
+ * is what a test wanting a revision to describe, deregister or list needs. A
+ * test about what a registration declares builds its own request instead.
+ *
+ * ```typescript
+ * const revision = await simEcsRegisteredTaskDefinitionFactory.make(
+ *   { family: "checkout" },
+ *   simAws,
+ * );
+ * ```
+ */
+export const simEcsRegisteredTaskDefinitionFactory = new AsyncMappedFactory<
+  SimEcsRegisteredTaskDefinitionInput,
+  SimEcsTaskDefinitionDetail,
+  SimAws
+>(
+  () => ({
+    family: "checkout",
+    containerName: "app",
+    image: "example.dkr.ecr.eu-west-2.amazonaws.com/checkout:latest",
+  }),
+  async (input, simAws) => {
+    const registration = await simAws.ecs().registerTaskDefinition({
+      input: {
+        family: input.family,
+        containerDefinitions: [
+          { name: input.containerName, image: input.image },
+        ],
+      },
+    });
+
+    assertDefined(
+      registration.taskDefinition,
+      "Registering a sim ECS task definition gave none back",
+    );
+
+    return registration.taskDefinition;
+  },
+);

--- a/src/service/ecs/task-definition/sim-ecs-task-definition-arn.ts
+++ b/src/service/ecs/task-definition/sim-ecs-task-definition-arn.ts
@@ -1,0 +1,27 @@
+import type { SimArn } from "../../aws/arn.js";
+import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+
+/**
+ * Builds simulated ECS task definition ARNs for one Account and Region.
+ *
+ * The resource part is `family:revision`, so an ARN names one revision rather
+ * than the family it belongs to. That is why a family on its own and an ARN
+ * are different kinds of identifier even though both are accepted wherever a
+ * task definition is named.
+ */
+export class SimEcsTaskDefinitionArn {
+  private readonly accountRegionScope: SimAwsAccountRegionScope;
+
+  constructor(accountRegionScope: SimAwsAccountRegionScope) {
+    this.accountRegionScope = accountRegionScope;
+  }
+
+  /**
+   * The ARN one revision of a family has in this Account and Region.
+   */
+  make(family: string, revision: number): SimArn {
+    const { regionName, accountId } = this.accountRegionScope;
+
+    return `arn:aws:ecs:${regionName}:${accountId}:task-definition/${family}:${String(revision)}`;
+  }
+}

--- a/src/service/ecs/task-definition/sim-ecs-task-definition-detail.ts
+++ b/src/service/ecs/task-definition/sim-ecs-task-definition-detail.ts
@@ -1,0 +1,69 @@
+import type { SimArn } from "../../aws/arn.js";
+import type { SimEcsContainerDefinitionType } from "./container/sim-ecs-container-definition.js";
+import type { SimEcsTaskDefinitionSettingsType } from "./sim-ecs-task-definition-settings.js";
+
+/**
+ * The states a simulated ECS task definition revision can be in.
+ */
+export type SimEcsTaskDefinitionStatus = "ACTIVE" | "INACTIVE";
+
+/**
+ * Minimal structural sim ECS described task definition.
+ *
+ * https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_TaskDefinition.html
+ */
+export interface SimEcsTaskDefinitionDetail extends SimEcsTaskDefinitionSettingsType {
+  readonly taskDefinitionArn?: SimArn | undefined;
+  readonly family?: string | undefined;
+  readonly revision?: number | undefined;
+  readonly status?: SimEcsTaskDefinitionStatus | undefined;
+  readonly containerDefinitions?:
+    | readonly SimEcsContainerDefinitionType[]
+    | undefined;
+  readonly registeredAt?: Date | undefined;
+  readonly registeredBy?: string | undefined;
+  readonly deregisteredAt?: Date | undefined;
+}
+
+/**
+ * What a revision hands over to be described.
+ */
+export interface SimEcsTaskDefinitionDetailInput {
+  readonly settings: SimEcsTaskDefinitionSettingsType;
+  readonly taskDefinitionArn: SimArn;
+  readonly family: string;
+  readonly revision: number;
+  readonly status: SimEcsTaskDefinitionStatus;
+  readonly containerDefinitions: readonly SimEcsContainerDefinitionType[];
+  readonly registeredAt: Date;
+  readonly registeredBy: string | undefined;
+  readonly deregisteredAt: Date | undefined;
+}
+
+/**
+ * Build one revision as `DescribeTaskDefinition` reports it.
+ *
+ * The two instants are copied out rather than handed over, so a caller reading
+ * a described revision cannot move the stored one by writing to the `Date` it
+ * was given. What the registration never set is left out rather than reported
+ * as undefined.
+ */
+export function simEcsTaskDefinitionDetail(
+  input: SimEcsTaskDefinitionDetailInput,
+): SimEcsTaskDefinitionDetail {
+  return {
+    ...input.settings,
+    taskDefinitionArn: input.taskDefinitionArn,
+    family: input.family,
+    revision: input.revision,
+    status: input.status,
+    containerDefinitions: input.containerDefinitions,
+    registeredAt: new Date(input.registeredAt),
+    ...(input.registeredBy !== undefined && {
+      registeredBy: input.registeredBy,
+    }),
+    ...(input.deregisteredAt !== undefined && {
+      deregisteredAt: new Date(input.deregisteredAt),
+    }),
+  };
+}

--- a/src/service/ecs/task-definition/sim-ecs-task-definition-family.ts
+++ b/src/service/ecs/task-definition/sim-ecs-task-definition-family.ts
@@ -1,0 +1,64 @@
+import type { SimEcsTaskDefinition } from "./sim-ecs-task-definition.js";
+
+/**
+ * The revisions registered under one simulated ECS task definition family.
+ *
+ * Revisions number from one and only ever go up. Deregistering a revision does
+ * not free its number, because the number is part of an ARN that other things
+ * hold: reusing it would point an existing ARN at a different declaration.
+ */
+export class SimEcsTaskDefinitionFamily {
+  public readonly family: string;
+
+  private readonly revisions: SimEcsTaskDefinition[] = [];
+
+  constructor(family: string) {
+    this.family = family;
+  }
+
+  /**
+   * The number the next revision registered in this family will have.
+   */
+  nextRevisionNumber(): number {
+    return this.revisions.length + 1;
+  }
+
+  /**
+   * Hold a newly registered revision.
+   */
+  add(taskDefinition: SimEcsTaskDefinition): void {
+    this.revisions.push(taskDefinition);
+  }
+
+  /**
+   * Every revision ever registered in this family, oldest first.
+   */
+  all(): readonly SimEcsTaskDefinition[] {
+    return this.revisions;
+  }
+
+  /**
+   * Find one revision by number.
+   */
+  revision(revision: number): SimEcsTaskDefinition | undefined {
+    return this.revisions.find((held) => held.revision === revision);
+  }
+
+  /**
+   * The revision a request naming the family alone means.
+   *
+   * That is the highest numbered active one, which is not always the most
+   * recently registered: deregistering the newest revision makes the one
+   * before it current again.
+   */
+  latestActive(): SimEcsTaskDefinition | undefined {
+    return this.revisions.findLast((held) => held.isActive());
+  }
+
+  /**
+   * Whether any revision in this family is still active.
+   */
+  hasActiveRevision(): boolean {
+    return this.latestActive() !== undefined;
+  }
+}

--- a/src/service/ecs/task-definition/sim-ecs-task-definition-id.ts
+++ b/src/service/ecs/task-definition/sim-ecs-task-definition-id.ts
@@ -3,6 +3,11 @@ import { parseSimEcsArn } from "../sim-ecs-arn.js";
 import { SimEcsClientException } from "../error/sim-ecs.error.js";
 
 /**
+ * What a revision is written as.
+ */
+const digits = /^\d+$/;
+
+/**
  * What a request means when it names a task definition.
  *
  * The three forms ECS accepts come down to two things: which family, and which
@@ -60,8 +65,8 @@ export class SimEcsTaskDefinitionId {
       arn.accountId !== accountId
     ) {
       throw new SimEcsClientException(
-        `Unable to describe task definition. ${identifier} does not name a ` +
-          `task definition in Account ${accountId} Region ${regionName}.`,
+        `${identifier} does not name a task definition in Account ` +
+          `${accountId} Region ${regionName}.`,
       );
     }
 
@@ -88,12 +93,15 @@ export class SimEcsTaskDefinitionId {
   }
 
   private static revisionNumber(value: string, identifier: string): number {
-    const revision = Number(value);
+    // Read the digits rather than the number, because `Number` also accepts
+    // hexadecimal, exponents, decimal points and surrounding spaces, none of
+    // which real ECS takes as a revision.
+    const revision = digits.test(value) ? Number(value) : NaN;
 
     if (!Number.isSafeInteger(revision) || revision < 1) {
       throw new SimEcsClientException(
-        `Unable to describe task definition. ${identifier} does not name a ` +
-          `revision, which is a whole number from 1.`,
+        `${identifier} does not name a task definition revision, which is a ` +
+          `whole number from 1.`,
       );
     }
 

--- a/src/service/ecs/task-definition/sim-ecs-task-definition-id.ts
+++ b/src/service/ecs/task-definition/sim-ecs-task-definition-id.ts
@@ -1,0 +1,102 @@
+import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+import { parseSimEcsArn } from "../sim-ecs-arn.js";
+import { SimEcsClientException } from "../error/sim-ecs.error.js";
+
+/**
+ * What a request means when it names a task definition.
+ *
+ * The three forms ECS accepts come down to two things: which family, and which
+ * revision of it. A family on its own leaves the revision open, which is what
+ * makes it mean the latest active one.
+ *
+ * https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_DescribeTaskDefinition.html
+ */
+export class SimEcsTaskDefinitionId {
+  public readonly family: string;
+  public readonly revision: number | undefined;
+
+  private constructor(family: string, revision: number | undefined) {
+    this.family = family;
+    this.revision = revision;
+  }
+
+  /**
+   * Read an identifier that is a family, a `family:revision`, or a full ARN.
+   */
+  static parse(
+    identifier: string | undefined,
+    accountRegionScope: SimAwsAccountRegionScope,
+  ): SimEcsTaskDefinitionId {
+    if (identifier === undefined || identifier === "") {
+      throw new SimEcsClientException(
+        "A task definition family, family:revision, or ARN is required.",
+      );
+    }
+
+    if (identifier.startsWith("arn:")) {
+      return this.fromArn(identifier, accountRegionScope);
+    }
+
+    return this.fromFamily(identifier, identifier);
+  }
+
+  /**
+   * Read the family and revision out of a task definition ARN.
+   *
+   * An ARN belonging to another Account or Region names nothing here, because
+   * it names a task definition somewhere else on real AWS. It is refused the
+   * way a task definition that is not there is refused.
+   */
+  private static fromArn(
+    identifier: string,
+    accountRegionScope: SimAwsAccountRegionScope,
+  ): SimEcsTaskDefinitionId {
+    const arn = parseSimEcsArn(identifier);
+    const { regionName, accountId } = accountRegionScope;
+
+    if (
+      arn?.resourceType !== "task-definition" ||
+      arn.region !== regionName ||
+      arn.accountId !== accountId
+    ) {
+      throw new SimEcsClientException(
+        `Unable to describe task definition. ${identifier} does not name a ` +
+          `task definition in Account ${accountId} Region ${regionName}.`,
+      );
+    }
+
+    return this.fromFamily(arn.resourceId, identifier);
+  }
+
+  /**
+   * Read a `family` or `family:revision`, whichever this is.
+   */
+  private static fromFamily(
+    value: string,
+    identifier: string,
+  ): SimEcsTaskDefinitionId {
+    const separatorIndex = value.lastIndexOf(":");
+
+    if (separatorIndex === -1) {
+      return new SimEcsTaskDefinitionId(value, undefined);
+    }
+
+    return new SimEcsTaskDefinitionId(
+      value.slice(0, separatorIndex),
+      this.revisionNumber(value.slice(separatorIndex + 1), identifier),
+    );
+  }
+
+  private static revisionNumber(value: string, identifier: string): number {
+    const revision = Number(value);
+
+    if (!Number.isSafeInteger(revision) || revision < 1) {
+      throw new SimEcsClientException(
+        `Unable to describe task definition. ${identifier} does not name a ` +
+          `revision, which is a whole number from 1.`,
+      );
+    }
+
+    return revision;
+  }
+}

--- a/src/service/ecs/task-definition/sim-ecs-task-definition-parts.ts
+++ b/src/service/ecs/task-definition/sim-ecs-task-definition-parts.ts
@@ -1,0 +1,76 @@
+/**
+ * Minimal structural sim ECS tag.
+ *
+ * ECS tags carry lowercase `key` and `value`, unlike most AWS services.
+ *
+ * https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_Tag.html
+ */
+export interface SimEcsTag {
+  readonly key?: string | undefined;
+  readonly value?: string | undefined;
+}
+
+/**
+ * Minimal structural sim ECS volume host path.
+ *
+ * https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_HostVolumeProperties.html
+ */
+export interface SimEcsHostVolumeProperties {
+  readonly sourcePath?: string | undefined;
+}
+
+/**
+ * Minimal structural sim ECS task definition volume.
+ *
+ * The driver-specific configurations are kept as declared rather than named
+ * field by field, because nothing here mounts anything.
+ *
+ * https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_Volume.html
+ */
+export interface SimEcsVolume {
+  readonly name?: string | undefined;
+  readonly host?: SimEcsHostVolumeProperties | undefined;
+  readonly configuredAtLaunch?: boolean | undefined;
+  readonly dockerVolumeConfiguration?: object | undefined;
+  readonly efsVolumeConfiguration?: object | undefined;
+}
+
+/**
+ * Minimal structural sim ECS task placement constraint.
+ *
+ * https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_TaskDefinitionPlacementConstraint.html
+ */
+export interface SimEcsTaskDefinitionPlacementConstraint {
+  readonly type?: string | undefined;
+  readonly expression?: string | undefined;
+}
+
+/**
+ * Minimal structural sim ECS runtime platform.
+ *
+ * https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_RuntimePlatform.html
+ */
+export interface SimEcsRuntimePlatform {
+  readonly cpuArchitecture?: string | undefined;
+  readonly operatingSystemFamily?: string | undefined;
+}
+
+/**
+ * Minimal structural sim ECS ephemeral storage.
+ *
+ * https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_EphemeralStorage.html
+ */
+export interface SimEcsEphemeralStorage {
+  readonly sizeInGiB?: number | undefined;
+}
+
+/**
+ * Minimal structural sim ECS proxy configuration.
+ *
+ * https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_ProxyConfiguration.html
+ */
+export interface SimEcsProxyConfiguration {
+  readonly type?: string | undefined;
+  readonly containerName?: string | undefined;
+  readonly properties?: readonly object[] | undefined;
+}

--- a/src/service/ecs/task-definition/sim-ecs-task-definition-settings.ts
+++ b/src/service/ecs/task-definition/sim-ecs-task-definition-settings.ts
@@ -1,0 +1,131 @@
+import type {
+  SimEcsEphemeralStorage,
+  SimEcsProxyConfiguration,
+  SimEcsRuntimePlatform,
+  SimEcsTaskDefinitionPlacementConstraint,
+  SimEcsVolume,
+} from "./sim-ecs-task-definition-parts.js";
+
+/**
+ * What a task definition declares besides its family and its containers.
+ *
+ * These are the settings a described task definition reports back. Nothing
+ * acts on any of them yet, since nothing runs a task yet, so each one is held
+ * as the registration declared it. A setting that is not one of these is
+ * refused at the command rather than held, so nothing a registration declared
+ * goes missing from the revision it made.
+ *
+ * https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_RegisterTaskDefinition.html
+ */
+export interface SimEcsTaskDefinitionSettingsType {
+  readonly taskRoleArn?: string | undefined;
+  readonly executionRoleArn?: string | undefined;
+  readonly networkMode?: string | undefined;
+  readonly cpu?: string | undefined;
+  readonly memory?: string | undefined;
+  readonly requiresCompatibilities?: readonly string[] | undefined;
+  readonly volumes?: readonly SimEcsVolume[] | undefined;
+  readonly placementConstraints?:
+    | readonly SimEcsTaskDefinitionPlacementConstraint[]
+    | undefined;
+  readonly runtimePlatform?: SimEcsRuntimePlatform | undefined;
+  readonly ephemeralStorage?: SimEcsEphemeralStorage | undefined;
+  readonly proxyConfiguration?: SimEcsProxyConfiguration | undefined;
+  readonly pidMode?: string | undefined;
+  readonly ipcMode?: string | undefined;
+}
+
+/**
+ * The names of the settings a registration may declare.
+ *
+ * The command refuses anything else, so this list is also what makes an
+ * unmodelled setting a refusal rather than a silent omission.
+ */
+export const simEcsTaskDefinitionSettingNames: readonly string[] = [
+  "taskRoleArn",
+  "executionRoleArn",
+  "networkMode",
+  "cpu",
+  "memory",
+  "requiresCompatibilities",
+  "volumes",
+  "placementConstraints",
+  "runtimePlatform",
+  "ephemeralStorage",
+  "proxyConfiguration",
+  "pidMode",
+  "ipcMode",
+];
+
+/**
+ * The settings a simulated task definition was registered with.
+ *
+ * They are copied out of the request rather than held by reference, so a
+ * described revision reports what the registration said at the time it was
+ * made even where the caller reuses its input object for the next one.
+ *
+ * Only what the request set is reported. A revision registered without a
+ * setting describes without it, rather than describing it as whatever value
+ * real ECS would have defaulted it to, which would be a value this simulation
+ * made up.
+ */
+export class SimEcsTaskDefinitionSettings {
+  private readonly settings: SimEcsTaskDefinitionSettingsType;
+
+  constructor(declared: SimEcsTaskDefinitionSettingsType) {
+    this.settings = structuredClone({
+      ...SimEcsTaskDefinitionSettings.declaredText(declared),
+      ...SimEcsTaskDefinitionSettings.declaredStructures(declared),
+    });
+  }
+
+  private static declaredText(
+    declared: SimEcsTaskDefinitionSettingsType,
+  ): SimEcsTaskDefinitionSettingsType {
+    return {
+      ...(declared.taskRoleArn !== undefined && {
+        taskRoleArn: declared.taskRoleArn,
+      }),
+      ...(declared.executionRoleArn !== undefined && {
+        executionRoleArn: declared.executionRoleArn,
+      }),
+      ...(declared.networkMode !== undefined && {
+        networkMode: declared.networkMode,
+      }),
+      ...(declared.cpu !== undefined && { cpu: declared.cpu }),
+      ...(declared.memory !== undefined && { memory: declared.memory }),
+      ...(declared.pidMode !== undefined && { pidMode: declared.pidMode }),
+      ...(declared.ipcMode !== undefined && { ipcMode: declared.ipcMode }),
+    };
+  }
+
+  private static declaredStructures(
+    declared: SimEcsTaskDefinitionSettingsType,
+  ): SimEcsTaskDefinitionSettingsType {
+    return {
+      ...(declared.requiresCompatibilities !== undefined && {
+        requiresCompatibilities: declared.requiresCompatibilities,
+      }),
+      ...(declared.volumes !== undefined && { volumes: declared.volumes }),
+      ...(declared.placementConstraints !== undefined && {
+        placementConstraints: declared.placementConstraints,
+      }),
+      ...(declared.runtimePlatform !== undefined && {
+        runtimePlatform: declared.runtimePlatform,
+      }),
+      ...(declared.ephemeralStorage !== undefined && {
+        ephemeralStorage: declared.ephemeralStorage,
+      }),
+      ...(declared.proxyConfiguration !== undefined && {
+        proxyConfiguration: declared.proxyConfiguration,
+      }),
+    };
+  }
+
+  /**
+   * These settings as a described task definition reports them.
+   */
+  toOutput(): SimEcsTaskDefinitionSettingsType {
+    return structuredClone(this.settings);
+  }
+}

--- a/src/service/ecs/task-definition/sim-ecs-task-definition-store.ts
+++ b/src/service/ecs/task-definition/sim-ecs-task-definition-store.ts
@@ -1,0 +1,83 @@
+import { SimEcsClientException } from "../error/sim-ecs.error.js";
+import { SimEcsTaskDefinitionFamily } from "./sim-ecs-task-definition-family.js";
+import type { SimEcsTaskDefinitionId } from "./sim-ecs-task-definition-id.js";
+import type { SimEcsTaskDefinition } from "./sim-ecs-task-definition.js";
+
+/**
+ * The simulated ECS task definitions one Account and Region holds.
+ *
+ * Task definitions are held by family rather than in one flat list, because
+ * the family is what a registration adds to and what a describe resolves
+ * against. Nothing is ever removed: deregistering marks a revision, and an
+ * emptied family would take its revision numbering with it.
+ */
+export class SimEcsTaskDefinitionStore {
+  private readonly familiesByName = new Map<
+    string,
+    SimEcsTaskDefinitionFamily
+  >();
+
+  /**
+   * The family of this name, started if this is its first registration.
+   */
+  family(family: string): SimEcsTaskDefinitionFamily {
+    const held = this.familiesByName.get(family);
+
+    if (held !== undefined) {
+      return held;
+    }
+
+    const started = new SimEcsTaskDefinitionFamily(family);
+    this.familiesByName.set(family, started);
+
+    return started;
+  }
+
+  /**
+   * The families that have ever been registered, oldest first.
+   */
+  families(): readonly SimEcsTaskDefinitionFamily[] {
+    return this.familiesByName.values().toArray();
+  }
+
+  /**
+   * Every revision of every family, by family name and then revision.
+   */
+  revisions(): readonly SimEcsTaskDefinition[] {
+    return this.families()
+      .toSorted((one, other) => one.family.localeCompare(other.family))
+      .flatMap((family) => family.all());
+  }
+
+  /**
+   * Find the revision an identifier names.
+   *
+   * A family named on its own resolves to its latest active revision, so a
+   * family whose revisions have all been deregistered resolves to nothing,
+   * while each of those revisions is still there to be named directly.
+   */
+  resolve(id: SimEcsTaskDefinitionId): SimEcsTaskDefinition {
+    const family = this.familiesByName.get(id.family);
+    const resolved =
+      id.revision === undefined
+        ? family?.latestActive()
+        : family?.revision(id.revision);
+
+    if (resolved === undefined) {
+      throw new SimEcsClientException(
+        `Unable to describe task definition. The simulated Account and ` +
+          `Region hold no task definition ${this.describeId(id)}.`,
+      );
+    }
+
+    return resolved;
+  }
+
+  private describeId(id: SimEcsTaskDefinitionId): string {
+    if (id.revision === undefined) {
+      return `family ${id.family} with an active revision`;
+    }
+
+    return `${id.family}:${String(id.revision)}`;
+  }
+}

--- a/src/service/ecs/task-definition/sim-ecs-task-definition.ts
+++ b/src/service/ecs/task-definition/sim-ecs-task-definition.ts
@@ -1,0 +1,92 @@
+import type { SimArn } from "../../aws/arn.js";
+import type { SimEcsContainerDefinitions } from "./container/sim-ecs-container-definitions.js";
+import {
+  simEcsTaskDefinitionDetail,
+  type SimEcsTaskDefinitionDetail,
+  type SimEcsTaskDefinitionStatus,
+} from "./sim-ecs-task-definition-detail.js";
+import type { SimEcsTag } from "./sim-ecs-task-definition-parts.js";
+import type { SimEcsTaskDefinitionSettings } from "./sim-ecs-task-definition-settings.js";
+
+interface SimEcsTaskDefinitionProperties {
+  readonly taskDefinitionArn: SimArn;
+  readonly family: string;
+  readonly revision: number;
+  readonly containers: SimEcsContainerDefinitions;
+  readonly settings: SimEcsTaskDefinitionSettings;
+  readonly tags: readonly SimEcsTag[];
+  readonly registeredAt: Date;
+  readonly registeredBy?: string | undefined;
+}
+
+/**
+ * One revision of one simulated ECS task definition family.
+ *
+ * A revision is immutable once registered. The only thing that ever changes
+ * about it is whether it is still active, because deregistering marks a
+ * revision rather than removing it: something already holding the ARN can
+ * still describe what it declared.
+ */
+export class SimEcsTaskDefinition {
+  public readonly taskDefinitionArn: SimArn;
+  public readonly family: string;
+  public readonly revision: number;
+  public readonly containers: SimEcsContainerDefinitions;
+  public readonly settings: SimEcsTaskDefinitionSettings;
+  public readonly registeredAt: Date;
+
+  private readonly tags: readonly SimEcsTag[];
+  private readonly registeredBy: string | undefined;
+  private status: SimEcsTaskDefinitionStatus = "ACTIVE";
+  private deregisteredAt: Date | undefined;
+
+  constructor(properties: SimEcsTaskDefinitionProperties) {
+    this.taskDefinitionArn = properties.taskDefinitionArn;
+    this.family = properties.family;
+    this.revision = properties.revision;
+    this.containers = properties.containers;
+    this.settings = properties.settings;
+    this.tags = structuredClone(properties.tags);
+    this.registeredAt = properties.registeredAt;
+    this.registeredBy = properties.registeredBy;
+  }
+
+  /**
+   * Whether this revision is one a family named on its own resolves to.
+   */
+  isActive(): boolean {
+    return this.status === "ACTIVE";
+  }
+
+  /**
+   * Mark this revision deregistered, at the simulation's current time.
+   */
+  markDeregistered(deregisteredAt: Date): void {
+    this.status = "INACTIVE";
+    this.deregisteredAt = deregisteredAt;
+  }
+
+  /**
+   * The tags this revision was registered with.
+   */
+  toTagsOutput(): readonly SimEcsTag[] {
+    return structuredClone(this.tags);
+  }
+
+  /**
+   * This revision as `DescribeTaskDefinition` reports it.
+   */
+  toOutput(): SimEcsTaskDefinitionDetail {
+    return simEcsTaskDefinitionDetail({
+      settings: this.settings.toOutput(),
+      taskDefinitionArn: this.taskDefinitionArn,
+      family: this.family,
+      revision: this.revision,
+      status: this.status,
+      containerDefinitions: this.containers.toOutput(),
+      registeredAt: this.registeredAt,
+      registeredBy: this.registeredBy,
+      deregisteredAt: this.deregisteredAt,
+    });
+  }
+}


### PR DESCRIPTION
Adds a simulated ECS service holding clusters and task definitions. `RegisterTaskDefinition` stores a revision under its family, numbering revisions from one and never reusing a number; `DeregisterTaskDefinition` marks one revision inactive without removing it, so it stays describable by `family:revision` and by ARN while dropping out of what the family resolves to; and `DescribeTaskDefinition` accepts a family, a `family:revision` and a full ARN, along with the two listings and the four cluster operations. Container definitions are stored and reported exactly as declared, whatever their image, because Yulin never looks inside a container image: an image URI is only ever an identifier for matching an executable binding, which is the model the rest of the ECS roadmap rests on and is written up in both the service README and the usage docs. This is state only, so running a task, the ECS CloudFormation resource types, and everything downstream of those follow in their own issues.

This is larger than the usual guideline at around 6,600 lines, but that is what a new simulated service costs rather than scope creep: roughly 1,700 lines of implementation, 1,800 of tests, 700 of usage docs and examples, and the rest structural command types, one per operation. Two shared files needed small changes to make room: `SimAwsAccountRegionServiceBuilder` was at its 300 line limit, so the assembly of the collaborators every scoped service takes moved to `SimAwsAccountServiceCache`, which is the class that owns the Account's IAM it reaches for.

Resolves https://github.com/KensioSoftware/yulin/issues/553

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added simulated Amazon ECS support for clusters and task definitions.
  - Supports creating, describing, listing, and deleting clusters.
  - Supports registering, describing, listing, and deregistering task definitions and revisions.
  - Added IAM authorization, account/region scoping, pagination, ARN handling, and SDK interception.
  - Added public ECS package exports and comprehensive usage examples.

- **Documentation**
  - Added ECS service documentation, limitations, supported operations, and examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->