### PR TITLE
feat: simulate ELBv2 load balancers and listeners

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@ behaviour and includes example code that can be copied into tests or local devel
 - [Cognito user pools](./services/cognito/ "Simulated Cognito user pools usage docs")
 - [DynamoDB](./services/dynamodb/ "Simulated DynamoDB usage docs")
 - [ECS](./services/ecs/ "Simulated ECS usage docs")
+- [Elastic Load Balancing](./services/elbv2/ "Simulated Application Load Balancer usage docs")
 - [EventBridge](./services/eventbridge/ "Simulated EventBridge usage docs")
 - [IAM](./services/iam/ "Simulated IAM usage docs")
 - [KMS](./services/kms/ "Simulated KMS usage docs")

--- a/docs/services/elbv2/README.md
+++ b/docs/services/elbv2/README.md
@@ -18,7 +18,10 @@ application load balancer in disguise.
 
 ```typescript sim-elbv2-create-load-balancer
 /**
- * Creating a load balancer and reading the DNS name it answers on.
+ * Creating a load balancer and reading the DNS name it is issued.
+ *
+ * Nothing answers on that name yet: it is the name a Route53 alias or a
+ * CloudFront origin would point at.
  */
 
 import {
@@ -54,8 +57,8 @@ const described = await elbV2.describeLoadBalancers(
 console.log(described.LoadBalancers?.[0]?.State.Code); // "active"
 ```
 
-A load balancer is `active` as soon as it is created, where real ELB leaves one `provisioning` for a
-few minutes first. A name is unique within one account and region, so the same name can be used in
+A load balancer is `active` as soon as it is created, where real ELB leaves one in `provisioning`
+for a few minutes first. A name is unique within one account and region, so the same name can be used in
 another region and the two do not see each other.
 
 An internal load balancer's host name carries the `internal-` prefix real ELB gives it, which is also
@@ -181,7 +184,10 @@ on one listener cannot hold the same priority.
 
 ```typescript sim-elbv2-listener-rules
 /**
- * A listener with a rule routing one host name somewhere else.
+ * A listener and a rule sending one host name to a different target group.
+ *
+ * The rule is stored rather than applied: nothing matches a request against it
+ * yet.
  */
 
 import {
@@ -459,7 +465,8 @@ console.log(created.LoadBalancers?.[0]?.DNSName);
 - `CreateRule`, `DescribeRules`, `ModifyRule`, `DeleteRule` and `SetRulePriorities`, with priorities
   unique within a listener and the listener's default rule reported last.
 - `forward`, `fixed-response` and `redirect` actions, and `host-header`, `path-pattern`,
-  `http-header`, `http-request-method`, `query-string` and `source-ip` conditions.
+  `http-header`, `http-request-method`, `query-string` and `source-ip` conditions. A condition is
+  read through its own field's configuration, so one carrying another field's is refused.
 - Paged describes with `PageSize` and `Marker`.
 - IAM authorization against the ARN of whatever an operation names.
 - SDK interception of `ElasticLoadBalancingV2Client`.
@@ -481,12 +488,14 @@ console.log(created.LoadBalancers?.[0]?.DNSName);
   of a describe rather than modelled, and `AvailabilityZones` and `SecurityGroups` are therefore
   absent from a described load balancer.
 - `CanonicalHostedZoneId` is one value everywhere rather than the real per-region one. Simulated
-  Route53 resolves an alias by looking its target up, so only the shape is load bearing, and copying
+  Route53 resolves an alias by looking its target up, so only the shape is load-bearing, and copying
   this value into a real template would be copying the wrong one.
 - ARN ids and DNS name suffixes count from one rather than being random, so a test can assert on an
   ARN it did not capture. The shape is the one real ELB issues either way.
 - `authenticate-oidc` and `authenticate-cognito` actions are refused. Nothing here performs that
-  exchange, and treating one as a plain forward would quietly skip authentication.
+  exchange, and treating one as a plain forward would quietly skip authentication. Since those are
+  the only actions that may precede a routing action, a listener or rule takes exactly one action
+  here and a longer list is refused.
 - Load balancer attributes, access logs, listener certificates as a separate resource, trust stores,
   tags as a readable resource, and weighted forwarding across target groups are not simulated. A
   `ForwardConfig` naming several target groups is stored and its weights are not acted on.

--- a/docs/services/elbv2/README.md
+++ b/docs/services/elbv2/README.md
@@ -1,0 +1,494 @@
+# Simulated Elastic Load Balancing
+
+Yulin includes a simulated Application Load Balancer for tests and local development. Load
+balancers, target groups, listeners and listener rules are held in memory and every operation is
+authorized by simulated IAM. ELBv2-specific types are imported from the `@kensio/yulin/elbv2`
+subpath.
+
+This is the state an Application Load Balancer holds. A load balancer created here has a DNS name of
+the shape real ELB issues, so a [Route53](../route53/) alias or a [CloudFront](../cloudfront/) origin
+has something of the right form to point at, and its listeners and rules say what it would do with a
+request. Answering a request is separate work that follows.
+
+Only the application load balancer is simulated. A network or gateway load balancer routes below
+HTTP, which nothing here speaks, so `Type: "network"` is refused rather than created as an
+application load balancer in disguise.
+
+## Creating a load balancer
+
+```typescript sim-elbv2-create-load-balancer
+/**
+ * Creating a load balancer and reading the DNS name it answers on.
+ */
+
+import {
+  CreateLoadBalancerCommand,
+  DescribeLoadBalancersCommand,
+} from "@aws-sdk/client-elastic-load-balancing-v2";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const elbV2 = simAws.account("888888888888").region("eu-west-1").elbV2();
+
+const created = await elbV2.createLoadBalancer(
+  new CreateLoadBalancerCommand({
+    Name: "shop-alb",
+    Scheme: "internet-facing",
+    // Subnets and security groups are accepted and not modelled: there is no
+    // network here to place a load balancer on.
+    Subnets: ["subnet-a", "subnet-b"],
+  }),
+);
+
+console.log(created.LoadBalancers?.[0]?.DNSName);
+// "shop-alb-0000000001.eu-west-1.elb.amazonaws.com"
+
+console.log(created.LoadBalancers?.[0]?.LoadBalancerArn);
+// "arn:aws:elasticloadbalancing:eu-west-1:888888888888:loadbalancer/app/shop-alb/0000000000000001"
+
+const described = await elbV2.describeLoadBalancers(
+  new DescribeLoadBalancersCommand({ Names: ["shop-alb"] }),
+);
+
+console.log(described.LoadBalancers?.[0]?.State.Code); // "active"
+```
+
+A load balancer is `active` as soon as it is created, where real ELB leaves one `provisioning` for a
+few minutes first. A name is unique within one account and region, so the same name can be used in
+another region and the two do not see each other.
+
+An internal load balancer's host name carries the `internal-` prefix real ELB gives it, which is also
+why a load balancer cannot be named starting with `internal-`.
+
+## Target groups hold functions or addresses
+
+A target group names what it holds through its `TargetType`, and that decides the rest: how many
+targets it takes, what a target's `Id` has to look like, and whether the group carries a protocol and
+port at all.
+
+```typescript sim-elbv2-lambda-target-group
+/**
+ * A target group holding one Lambda function.
+ */
+
+import {
+  CreateTargetGroupCommand,
+  DescribeTargetHealthCommand,
+  RegisterTargetsCommand,
+} from "@aws-sdk/client-elastic-load-balancing-v2";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const elbV2 = simAws.account("888888888888").region("eu-west-1").elbV2();
+
+const targetGroup = await elbV2.createTargetGroup(
+  new CreateTargetGroupCommand({
+    Name: "checkout-tg",
+    // A lambda target group takes no Protocol or Port: the load balancer
+    // invokes the function rather than connecting to it.
+    TargetType: "lambda",
+  }),
+);
+
+const targetGroupArn = targetGroup.TargetGroups?.[0]?.TargetGroupArn;
+
+await elbV2.registerTargets(
+  new RegisterTargetsCommand({
+    TargetGroupArn: targetGroupArn,
+    Targets: [
+      { Id: "arn:aws:lambda:eu-west-1:888888888888:function:checkout" },
+    ],
+  }),
+);
+
+const health = await elbV2.describeTargetHealth(
+  new DescribeTargetHealthCommand({ TargetGroupArn: targetGroupArn }),
+);
+
+console.log(health.TargetHealthDescriptions?.[0]?.Target.Id);
+// "arn:aws:lambda:eu-west-1:888888888888:function:checkout"
+console.log(health.TargetHealthDescriptions?.[0]?.TargetHealth.State);
+// "healthy"
+```
+
+A `lambda` target group takes exactly one function, as real ELB does, so registering a second is
+refused. An `ip` target group is what a container service registers itself as, takes many addresses,
+and requires the `Protocol` and `Port` its targets are reached on.
+
+```typescript sim-elbv2-ip-target-group
+/**
+ * A target group holding addresses, and taking one out again.
+ */
+
+import {
+  CreateTargetGroupCommand,
+  DeregisterTargetsCommand,
+  DescribeTargetHealthCommand,
+  RegisterTargetsCommand,
+} from "@aws-sdk/client-elastic-load-balancing-v2";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const elbV2 = simAws.elbV2();
+
+const targetGroup = await elbV2.createTargetGroup(
+  new CreateTargetGroupCommand({
+    Name: "web-tg",
+    TargetType: "ip",
+    Protocol: "HTTP",
+    Port: 8080,
+  }),
+);
+
+const targetGroupArn = targetGroup.TargetGroups?.[0]?.TargetGroupArn;
+
+await elbV2.registerTargets(
+  new RegisterTargetsCommand({
+    TargetGroupArn: targetGroupArn,
+    // A target naming no port takes the group's, as it does on real ELB.
+    Targets: [{ Id: "10.0.1.5" }, { Id: "10.0.1.6", Port: 9090 }],
+  }),
+);
+
+await elbV2.deregisterTargets(
+  new DeregisterTargetsCommand({
+    TargetGroupArn: targetGroupArn,
+    Targets: [{ Id: "10.0.1.6", Port: 9090 }],
+  }),
+);
+
+const health = await elbV2.describeTargetHealth(
+  new DescribeTargetHealthCommand({ TargetGroupArn: targetGroupArn }),
+);
+
+console.log(health.TargetHealthDescriptions?.length); // 1
+console.log(health.TargetHealthDescriptions?.[0]?.Target.Port); // 8080
+```
+
+`TargetType: "instance"` is refused rather than accepted and ignored, because there are no EC2
+instances here for it to mean anything about: a group created as one would look configured and route
+nowhere. A request naming no target type at all is refused for the same reason, since real ELB
+defaults it to `instance`.
+
+## Listeners and the rules on them
+
+A listener answers on a port and holds the default actions for a request no rule claims. Rules carry
+a priority, and that is what decides which of several matching rules claims a request, so two rules
+on one listener cannot hold the same priority.
+
+```typescript sim-elbv2-listener-rules
+/**
+ * A listener with a rule routing one host name somewhere else.
+ */
+
+import {
+  CreateListenerCommand,
+  CreateLoadBalancerCommand,
+  CreateRuleCommand,
+  CreateTargetGroupCommand,
+  DescribeRulesCommand,
+} from "@aws-sdk/client-elastic-load-balancing-v2";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const elbV2 = simAws.elbV2();
+
+const loadBalancer = await elbV2.createLoadBalancer(
+  new CreateLoadBalancerCommand({ Name: "shop-alb" }),
+);
+const web = await elbV2.createTargetGroup(
+  new CreateTargetGroupCommand({
+    Name: "web-tg",
+    TargetType: "ip",
+    Protocol: "HTTP",
+    Port: 8080,
+  }),
+);
+const admin = await elbV2.createTargetGroup(
+  new CreateTargetGroupCommand({ Name: "admin-tg", TargetType: "lambda" }),
+);
+
+const listener = await elbV2.createListener(
+  new CreateListenerCommand({
+    LoadBalancerArn: loadBalancer.LoadBalancers?.[0]?.LoadBalancerArn,
+    Protocol: "HTTP",
+    Port: 80,
+    DefaultActions: [
+      {
+        Type: "forward",
+        TargetGroupArn: web.TargetGroups?.[0]?.TargetGroupArn,
+      },
+    ],
+  }),
+);
+
+const listenerArn = listener.Listeners?.[0]?.ListenerArn;
+
+await elbV2.createRule(
+  new CreateRuleCommand({
+    ListenerArn: listenerArn,
+    Priority: 10,
+    Conditions: [{ Field: "host-header", Values: ["admin.example.com"] }],
+    Actions: [
+      {
+        Type: "forward",
+        TargetGroupArn: admin.TargetGroups?.[0]?.TargetGroupArn,
+      },
+    ],
+  }),
+);
+
+const rules = await elbV2.describeRules(
+  new DescribeRulesCommand({ ListenerArn: listenerArn }),
+);
+
+// The listener's rules come back in evaluation order, ending in the default
+// rule, which is the listener's own default actions.
+console.log(rules.Rules?.map((rule) => rule.Priority)); // ["10", "default"]
+```
+
+Conditions are held rather than matched, so a request is not routed by them yet. What is checked when
+a rule is written is that it could match something: the field has to be one an Application Load
+Balancer understands, and it has to have values to compare against. A forward action naming a target
+group that was never created is refused for the same reason.
+
+`ModifyRule` changes a rule's conditions and actions but not its priority, as on real ELB. Moving
+rules about is `SetRulePriorities`, which reorders a whole listener, and which judges a request
+against the order it would leave behind rather than the one it started from, so two rules can swap
+places in one request.
+
+## Deleting
+
+Deleting a load balancer takes its listeners and their rules with it, and leaves its target groups
+where they are, which is what real ELB does: a target group is a resource in its own right and a
+replacement load balancer's listeners forward to the same ones. A target group a listener or rule
+still forwards to cannot be deleted until it does not.
+
+```typescript sim-elbv2-delete-load-balancer
+/**
+ * Deleting a load balancer, and what survives it.
+ */
+
+import {
+  CreateListenerCommand,
+  CreateLoadBalancerCommand,
+  CreateTargetGroupCommand,
+  DeleteLoadBalancerCommand,
+  DeleteTargetGroupCommand,
+  DescribeListenersCommand,
+  DescribeTargetGroupsCommand,
+} from "@aws-sdk/client-elastic-load-balancing-v2";
+
+import { SimAws } from "@kensio/yulin";
+import {
+  SimElbV2LoadBalancerNotFoundException,
+  SimElbV2ResourceInUseException,
+} from "@kensio/yulin/elbv2";
+
+const simAws = new SimAws();
+const elbV2 = simAws.elbV2();
+
+const loadBalancer = await elbV2.createLoadBalancer(
+  new CreateLoadBalancerCommand({ Name: "shop-alb" }),
+);
+const targetGroup = await elbV2.createTargetGroup(
+  new CreateTargetGroupCommand({ Name: "checkout-tg", TargetType: "lambda" }),
+);
+
+const loadBalancerArn = loadBalancer.LoadBalancers?.[0]?.LoadBalancerArn;
+const targetGroupArn = targetGroup.TargetGroups?.[0]?.TargetGroupArn;
+
+await elbV2.createListener(
+  new CreateListenerCommand({
+    LoadBalancerArn: loadBalancerArn,
+    Protocol: "HTTP",
+    Port: 80,
+    DefaultActions: [{ Type: "forward", TargetGroupArn: targetGroupArn }],
+  }),
+);
+
+// While the listener forwards to it, the target group cannot go.
+try {
+  await elbV2.deleteTargetGroup(
+    new DeleteTargetGroupCommand({ TargetGroupArn: targetGroupArn }),
+  );
+} catch (error) {
+  console.log(error instanceof SimElbV2ResourceInUseException); // true
+}
+
+await elbV2.deleteLoadBalancer(
+  new DeleteLoadBalancerCommand({ LoadBalancerArn: loadBalancerArn }),
+);
+
+// The listener went with the load balancer; the target group did not.
+const remaining = await elbV2.describeTargetGroups(
+  new DescribeTargetGroupsCommand({}),
+);
+
+console.log(remaining.TargetGroups?.length); // 1
+console.log(remaining.TargetGroups?.[0]?.LoadBalancerArns.length); // 0
+
+try {
+  await elbV2.describeListeners(
+    new DescribeListenersCommand({ LoadBalancerArn: loadBalancerArn }),
+  );
+} catch (error) {
+  // The listener went with the load balancer, and so did the load balancer.
+  console.log(error instanceof SimElbV2LoadBalancerNotFoundException); // true
+}
+```
+
+## IAM authorization
+
+Every operation is authorized by simulated [IAM](../iam/) as the caller making it, against the
+`elasticloadbalancing:` action and the ARN of whatever it names. An operation naming nothing that
+exists yet, such as `CreateLoadBalancer` or a describe, is authorized against `*`, so only a policy
+whose Resource is `*` allows it.
+
+```typescript sim-elbv2-iam-policy
+/**
+ * A Role allowed to describe load balancers but not to create one.
+ */
+
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import {
+  CreateLoadBalancerCommand,
+  DescribeLoadBalancersCommand,
+} from "@aws-sdk/client-elastic-load-balancing-v2";
+
+import { SimAws } from "@kensio/yulin";
+import { SimElbV2AccessDeniedException } from "@kensio/yulin/elbv2";
+
+const simAws = new SimAws();
+const account = simAws.account("888888888888");
+const elbV2 = account.region("eu-west-1").elbV2();
+
+await account.iam().createRole(
+  new CreateRoleCommand({
+    RoleName: "ReadOnlyRole",
+    AssumeRolePolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Principal: { AWS: "arn:aws:iam::888888888888:root" },
+        Action: "sts:AssumeRole",
+      },
+    }),
+  }),
+);
+
+await account.iam().putRolePolicy(
+  new PutRolePolicyCommand({
+    RoleName: "ReadOnlyRole",
+    PolicyName: "describe-only",
+    PolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Action: "elasticloadbalancing:DescribeLoadBalancers",
+        Resource: "*",
+      },
+    }),
+  }),
+);
+
+const caller = {
+  kind: "arn",
+  arn: "arn:aws:iam::888888888888:role/ReadOnlyRole",
+} as const;
+
+const described = await elbV2.describeLoadBalancers(
+  new DescribeLoadBalancersCommand({}),
+  { caller },
+);
+
+console.log(described.LoadBalancers?.length); // 0
+
+try {
+  await elbV2.createLoadBalancer(
+    new CreateLoadBalancerCommand({ Name: "shop-alb" }),
+    { caller },
+  );
+} catch (error) {
+  console.log(error instanceof SimElbV2AccessDeniedException); // true
+}
+```
+
+## AWS SDK interception
+
+An `ElasticLoadBalancingV2Client` can be intercepted so ordinary SDK code reaches the simulation
+without being handed a simulator object. See [AWS SDK interception](../../sdk/) for how that works.
+
+```typescript sim-elbv2-sdk-interception
+/**
+ * Intercepting an ELBv2 SDK client.
+ */
+
+import {
+  CreateLoadBalancerCommand,
+  ElasticLoadBalancingV2Client,
+} from "@aws-sdk/client-elastic-load-balancing-v2";
+
+import { SimSdk } from "@kensio/yulin/sdk";
+
+using simSdk = new SimSdk();
+simSdk.intercept(ElasticLoadBalancingV2Client);
+
+const client = new ElasticLoadBalancingV2Client({ region: "eu-west-2" });
+
+const created = await client.send(
+  new CreateLoadBalancerCommand({ Name: "shop-alb" }),
+);
+
+console.log(created.LoadBalancers?.[0]?.DNSName);
+// "shop-alb-0000000001.eu-west-2.elb.amazonaws.com"
+```
+
+## Available functionality
+
+- `CreateLoadBalancer`, `DescribeLoadBalancers` and `DeleteLoadBalancer`, with a DNS name, ARN,
+  canonical hosted zone id, scheme and state on every load balancer.
+- `CreateTargetGroup`, `DescribeTargetGroups`, `ModifyTargetGroup` and `DeleteTargetGroup`, with the
+  `lambda` and `ip` target types.
+- `RegisterTargets`, `DeregisterTargets` and `DescribeTargetHealth`.
+- `CreateListener`, `DescribeListeners`, `ModifyListener` and `DeleteListener`, on HTTP and HTTPS.
+- `CreateRule`, `DescribeRules`, `ModifyRule`, `DeleteRule` and `SetRulePriorities`, with priorities
+  unique within a listener and the listener's default rule reported last.
+- `forward`, `fixed-response` and `redirect` actions, and `host-header`, `path-pattern`,
+  `http-header`, `http-request-method`, `query-string` and `source-ip` conditions.
+- Paged describes with `PageSize` and `Marker`.
+- IAM authorization against the ARN of whatever an operation names.
+- SDK interception of `ElasticLoadBalancingV2Client`.
+
+## Limitations
+
+- Nothing routes a request yet. Listeners, rules and target groups say what would happen to one, and
+  a simulated load balancer answers nothing.
+- Network and gateway load balancers are not simulated. `Type: "network"` and `"gateway"` are
+  refused, as are the `TCP`, `TLS`, `UDP`, `TCP_UDP` and `GENEVE` protocols.
+- `TargetType: "instance"` and `"alb"` are refused rather than accepted and ignored, and a target
+  group naming no target type at all is refused rather than defaulted to `instance` as real ELB
+  defaults it.
+- Health checks are not performed. Health check settings are held and reported, and every registered
+  target is `healthy` however it is configured, so a test cannot watch a deployment come up.
+- A load balancer is `active` immediately rather than `provisioning` for the minutes real ELB takes,
+  and deregistration is immediate rather than draining connections first.
+- Subnets, security groups, availability zones and cross-zone configuration are accepted and left out
+  of a describe rather than modelled, and `AvailabilityZones` and `SecurityGroups` are therefore
+  absent from a described load balancer.
+- `CanonicalHostedZoneId` is one value everywhere rather than the real per-region one. Simulated
+  Route53 resolves an alias by looking its target up, so only the shape is load bearing, and copying
+  this value into a real template would be copying the wrong one.
+- ARN ids and DNS name suffixes count from one rather than being random, so a test can assert on an
+  ARN it did not capture. The shape is the one real ELB issues either way.
+- `authenticate-oidc` and `authenticate-cognito` actions are refused. Nothing here performs that
+  exchange, and treating one as a plain forward would quietly skip authentication.
+- Load balancer attributes, access logs, listener certificates as a separate resource, trust stores,
+  tags as a readable resource, and weighted forwarding across target groups are not simulated. A
+  `ForwardConfig` naming several target groups is stored and its weights are not acted on.
+- There is no CloudFormation support yet, so `AWS::ElasticLoadBalancingV2::*` resources in a template
+  are not deployed.

--- a/docs/services/elbv2/sim-elbv2-create-load-balancer.example.ts
+++ b/docs/services/elbv2/sim-elbv2-create-load-balancer.example.ts
@@ -1,5 +1,8 @@
 /**
- * Creating a load balancer and reading the DNS name it answers on.
+ * Creating a load balancer and reading the DNS name it is issued.
+ *
+ * Nothing answers on that name yet: it is the name a Route53 alias or a
+ * CloudFront origin would point at.
  */
 
 import {

--- a/docs/services/elbv2/sim-elbv2-create-load-balancer.example.ts
+++ b/docs/services/elbv2/sim-elbv2-create-load-balancer.example.ts
@@ -1,0 +1,35 @@
+/**
+ * Creating a load balancer and reading the DNS name it answers on.
+ */
+
+import {
+  CreateLoadBalancerCommand,
+  DescribeLoadBalancersCommand,
+} from "@aws-sdk/client-elastic-load-balancing-v2";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const elbV2 = simAws.account("888888888888").region("eu-west-1").elbV2();
+
+const created = await elbV2.createLoadBalancer(
+  new CreateLoadBalancerCommand({
+    Name: "shop-alb",
+    Scheme: "internet-facing",
+    // Subnets and security groups are accepted and not modelled: there is no
+    // network here to place a load balancer on.
+    Subnets: ["subnet-a", "subnet-b"],
+  }),
+);
+
+console.log(created.LoadBalancers?.[0]?.DNSName);
+// "shop-alb-0000000001.eu-west-1.elb.amazonaws.com"
+
+console.log(created.LoadBalancers?.[0]?.LoadBalancerArn);
+// "arn:aws:elasticloadbalancing:eu-west-1:888888888888:loadbalancer/app/shop-alb/0000000000000001"
+
+const described = await elbV2.describeLoadBalancers(
+  new DescribeLoadBalancersCommand({ Names: ["shop-alb"] }),
+);
+
+console.log(described.LoadBalancers?.[0]?.State.Code); // "active"

--- a/docs/services/elbv2/sim-elbv2-delete-load-balancer.example.ts
+++ b/docs/services/elbv2/sim-elbv2-delete-load-balancer.example.ts
@@ -1,0 +1,71 @@
+/**
+ * Deleting a load balancer, and what survives it.
+ */
+
+import {
+  CreateListenerCommand,
+  CreateLoadBalancerCommand,
+  CreateTargetGroupCommand,
+  DeleteLoadBalancerCommand,
+  DeleteTargetGroupCommand,
+  DescribeListenersCommand,
+  DescribeTargetGroupsCommand,
+} from "@aws-sdk/client-elastic-load-balancing-v2";
+
+import { SimAws } from "@kensio/yulin";
+import {
+  SimElbV2LoadBalancerNotFoundException,
+  SimElbV2ResourceInUseException,
+} from "@kensio/yulin/elbv2";
+
+const simAws = new SimAws();
+const elbV2 = simAws.elbV2();
+
+const loadBalancer = await elbV2.createLoadBalancer(
+  new CreateLoadBalancerCommand({ Name: "shop-alb" }),
+);
+const targetGroup = await elbV2.createTargetGroup(
+  new CreateTargetGroupCommand({ Name: "checkout-tg", TargetType: "lambda" }),
+);
+
+const loadBalancerArn = loadBalancer.LoadBalancers?.[0]?.LoadBalancerArn;
+const targetGroupArn = targetGroup.TargetGroups?.[0]?.TargetGroupArn;
+
+await elbV2.createListener(
+  new CreateListenerCommand({
+    LoadBalancerArn: loadBalancerArn,
+    Protocol: "HTTP",
+    Port: 80,
+    DefaultActions: [{ Type: "forward", TargetGroupArn: targetGroupArn }],
+  }),
+);
+
+// While the listener forwards to it, the target group cannot go.
+try {
+  await elbV2.deleteTargetGroup(
+    new DeleteTargetGroupCommand({ TargetGroupArn: targetGroupArn }),
+  );
+} catch (error) {
+  console.log(error instanceof SimElbV2ResourceInUseException); // true
+}
+
+await elbV2.deleteLoadBalancer(
+  new DeleteLoadBalancerCommand({ LoadBalancerArn: loadBalancerArn }),
+);
+
+// The listener went with the load balancer; the target group did not.
+const remaining = await elbV2.describeTargetGroups(
+  new DescribeTargetGroupsCommand({}),
+);
+
+console.log(remaining.TargetGroups?.length); // 1
+console.log(remaining.TargetGroups?.[0]?.LoadBalancerArns.length); // 0
+
+try {
+  await elbV2.describeListeners(
+    new DescribeListenersCommand({ LoadBalancerArn: loadBalancerArn }),
+  );
+} catch (error) {
+  // The listener went with the load balancer, and so did the load balancer.
+  console.log(error instanceof SimElbV2LoadBalancerNotFoundException); // true
+}

--- a/docs/services/elbv2/sim-elbv2-iam-policy.example.ts
+++ b/docs/services/elbv2/sim-elbv2-iam-policy.example.ts
@@ -1,0 +1,66 @@
+/**
+ * A Role allowed to describe load balancers but not to create one.
+ */
+
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import {
+  CreateLoadBalancerCommand,
+  DescribeLoadBalancersCommand,
+} from "@aws-sdk/client-elastic-load-balancing-v2";
+
+import { SimAws } from "@kensio/yulin";
+import { SimElbV2AccessDeniedException } from "@kensio/yulin/elbv2";
+
+const simAws = new SimAws();
+const account = simAws.account("888888888888");
+const elbV2 = account.region("eu-west-1").elbV2();
+
+await account.iam().createRole(
+  new CreateRoleCommand({
+    RoleName: "ReadOnlyRole",
+    AssumeRolePolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Principal: { AWS: "arn:aws:iam::888888888888:root" },
+        Action: "sts:AssumeRole",
+      },
+    }),
+  }),
+);
+
+await account.iam().putRolePolicy(
+  new PutRolePolicyCommand({
+    RoleName: "ReadOnlyRole",
+    PolicyName: "describe-only",
+    PolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Action: "elasticloadbalancing:DescribeLoadBalancers",
+        Resource: "*",
+      },
+    }),
+  }),
+);
+
+const caller = {
+  kind: "arn",
+  arn: "arn:aws:iam::888888888888:role/ReadOnlyRole",
+} as const;
+
+const described = await elbV2.describeLoadBalancers(
+  new DescribeLoadBalancersCommand({}),
+  { caller },
+);
+
+console.log(described.LoadBalancers?.length); // 0
+
+try {
+  await elbV2.createLoadBalancer(
+    new CreateLoadBalancerCommand({ Name: "shop-alb" }),
+    { caller },
+  );
+} catch (error) {
+  console.log(error instanceof SimElbV2AccessDeniedException); // true
+}

--- a/docs/services/elbv2/sim-elbv2-ip-target-group.example.ts
+++ b/docs/services/elbv2/sim-elbv2-ip-target-group.example.ts
@@ -1,0 +1,48 @@
+/**
+ * A target group holding addresses, and taking one out again.
+ */
+
+import {
+  CreateTargetGroupCommand,
+  DeregisterTargetsCommand,
+  DescribeTargetHealthCommand,
+  RegisterTargetsCommand,
+} from "@aws-sdk/client-elastic-load-balancing-v2";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const elbV2 = simAws.elbV2();
+
+const targetGroup = await elbV2.createTargetGroup(
+  new CreateTargetGroupCommand({
+    Name: "web-tg",
+    TargetType: "ip",
+    Protocol: "HTTP",
+    Port: 8080,
+  }),
+);
+
+const targetGroupArn = targetGroup.TargetGroups?.[0]?.TargetGroupArn;
+
+await elbV2.registerTargets(
+  new RegisterTargetsCommand({
+    TargetGroupArn: targetGroupArn,
+    // A target naming no port takes the group's, as it does on real ELB.
+    Targets: [{ Id: "10.0.1.5" }, { Id: "10.0.1.6", Port: 9090 }],
+  }),
+);
+
+await elbV2.deregisterTargets(
+  new DeregisterTargetsCommand({
+    TargetGroupArn: targetGroupArn,
+    Targets: [{ Id: "10.0.1.6", Port: 9090 }],
+  }),
+);
+
+const health = await elbV2.describeTargetHealth(
+  new DescribeTargetHealthCommand({ TargetGroupArn: targetGroupArn }),
+);
+
+console.log(health.TargetHealthDescriptions?.length); // 1
+console.log(health.TargetHealthDescriptions?.[0]?.Target.Port); // 8080

--- a/docs/services/elbv2/sim-elbv2-lambda-target-group.example.ts
+++ b/docs/services/elbv2/sim-elbv2-lambda-target-group.example.ts
@@ -1,0 +1,43 @@
+/**
+ * A target group holding one Lambda function.
+ */
+
+import {
+  CreateTargetGroupCommand,
+  DescribeTargetHealthCommand,
+  RegisterTargetsCommand,
+} from "@aws-sdk/client-elastic-load-balancing-v2";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const elbV2 = simAws.account("888888888888").region("eu-west-1").elbV2();
+
+const targetGroup = await elbV2.createTargetGroup(
+  new CreateTargetGroupCommand({
+    Name: "checkout-tg",
+    // A lambda target group takes no Protocol or Port: the load balancer
+    // invokes the function rather than connecting to it.
+    TargetType: "lambda",
+  }),
+);
+
+const targetGroupArn = targetGroup.TargetGroups?.[0]?.TargetGroupArn;
+
+await elbV2.registerTargets(
+  new RegisterTargetsCommand({
+    TargetGroupArn: targetGroupArn,
+    Targets: [
+      { Id: "arn:aws:lambda:eu-west-1:888888888888:function:checkout" },
+    ],
+  }),
+);
+
+const health = await elbV2.describeTargetHealth(
+  new DescribeTargetHealthCommand({ TargetGroupArn: targetGroupArn }),
+);
+
+console.log(health.TargetHealthDescriptions?.[0]?.Target.Id);
+// "arn:aws:lambda:eu-west-1:888888888888:function:checkout"
+console.log(health.TargetHealthDescriptions?.[0]?.TargetHealth.State);
+// "healthy"

--- a/docs/services/elbv2/sim-elbv2-listener-rules.example.ts
+++ b/docs/services/elbv2/sim-elbv2-listener-rules.example.ts
@@ -1,5 +1,8 @@
 /**
- * A listener with a rule routing one host name somewhere else.
+ * A listener and a rule sending one host name to a different target group.
+ *
+ * The rule is stored rather than applied: nothing matches a request against it
+ * yet.
  */
 
 import {

--- a/docs/services/elbv2/sim-elbv2-listener-rules.example.ts
+++ b/docs/services/elbv2/sim-elbv2-listener-rules.example.ts
@@ -1,0 +1,69 @@
+/**
+ * A listener with a rule routing one host name somewhere else.
+ */
+
+import {
+  CreateListenerCommand,
+  CreateLoadBalancerCommand,
+  CreateRuleCommand,
+  CreateTargetGroupCommand,
+  DescribeRulesCommand,
+} from "@aws-sdk/client-elastic-load-balancing-v2";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const elbV2 = simAws.elbV2();
+
+const loadBalancer = await elbV2.createLoadBalancer(
+  new CreateLoadBalancerCommand({ Name: "shop-alb" }),
+);
+const web = await elbV2.createTargetGroup(
+  new CreateTargetGroupCommand({
+    Name: "web-tg",
+    TargetType: "ip",
+    Protocol: "HTTP",
+    Port: 8080,
+  }),
+);
+const admin = await elbV2.createTargetGroup(
+  new CreateTargetGroupCommand({ Name: "admin-tg", TargetType: "lambda" }),
+);
+
+const listener = await elbV2.createListener(
+  new CreateListenerCommand({
+    LoadBalancerArn: loadBalancer.LoadBalancers?.[0]?.LoadBalancerArn,
+    Protocol: "HTTP",
+    Port: 80,
+    DefaultActions: [
+      {
+        Type: "forward",
+        TargetGroupArn: web.TargetGroups?.[0]?.TargetGroupArn,
+      },
+    ],
+  }),
+);
+
+const listenerArn = listener.Listeners?.[0]?.ListenerArn;
+
+await elbV2.createRule(
+  new CreateRuleCommand({
+    ListenerArn: listenerArn,
+    Priority: 10,
+    Conditions: [{ Field: "host-header", Values: ["admin.example.com"] }],
+    Actions: [
+      {
+        Type: "forward",
+        TargetGroupArn: admin.TargetGroups?.[0]?.TargetGroupArn,
+      },
+    ],
+  }),
+);
+
+const rules = await elbV2.describeRules(
+  new DescribeRulesCommand({ ListenerArn: listenerArn }),
+);
+
+// The listener's rules come back in evaluation order, ending in the default
+// rule, which is the listener's own default actions.
+console.log(rules.Rules?.map((rule) => rule.Priority)); // ["10", "default"]

--- a/docs/services/elbv2/sim-elbv2-sdk-interception.example.ts
+++ b/docs/services/elbv2/sim-elbv2-sdk-interception.example.ts
@@ -1,0 +1,22 @@
+/**
+ * Intercepting an ELBv2 SDK client.
+ */
+
+import {
+  CreateLoadBalancerCommand,
+  ElasticLoadBalancingV2Client,
+} from "@aws-sdk/client-elastic-load-balancing-v2";
+
+import { SimSdk } from "@kensio/yulin/sdk";
+
+using simSdk = new SimSdk();
+simSdk.intercept(ElasticLoadBalancingV2Client);
+
+const client = new ElasticLoadBalancingV2Client({ region: "eu-west-2" });
+
+const created = await client.send(
+  new CreateLoadBalancerCommand({ Name: "shop-alb" }),
+);
+
+console.log(created.LoadBalancers?.[0]?.DNSName);
+// "shop-alb-0000000001.eu-west-2.elb.amazonaws.com"

--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -15,6 +15,7 @@
       ],
       "@kensio/yulin/cognito": ["../src/service/cognito/index.ts"],
       "@kensio/yulin/dynamodb": ["../src/service/dynamodb/index.ts"],
+      "@kensio/yulin/elbv2": ["../src/service/elbv2/index.ts"],
       "@kensio/yulin/eslint": ["../src/config/eslint/index.ts"],
       "@kensio/yulin/iam": ["../src/service/iam/index.ts"],
       "@kensio/yulin/kms": ["../src/service/kms/index.ts"],

--- a/package.json
+++ b/package.json
@@ -74,6 +74,10 @@
       "import": "./dist/service/ecs/index.js",
       "types": "./dist/service/ecs/index.d.ts"
     },
+    "./elbv2": {
+      "import": "./dist/service/elbv2/index.js",
+      "types": "./dist/service/elbv2/index.d.ts"
+    },
     "./eslint": {
       "import": "./dist/config/eslint/index.js",
       "types": "./dist/config/eslint/index.d.ts"
@@ -164,6 +168,7 @@
     "@aws-sdk/client-dynamodb": "^3.1101.0",
     "@aws-sdk/client-dynamodb-streams": "^3.1101.0",
     "@aws-sdk/client-ecs": "^3.1101.0",
+    "@aws-sdk/client-elastic-load-balancing-v2": "^3.1109.0",
     "@aws-sdk/client-eventbridge": "^3.1109.0",
     "@aws-sdk/client-iam": "^3.1101.0",
     "@aws-sdk/client-kms": "^3.1101.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,9 @@ importers:
       '@aws-sdk/client-ecs':
         specifier: ^3.1101.0
         version: 3.1109.0
+      '@aws-sdk/client-elastic-load-balancing-v2':
+        specifier: ^3.1109.0
+        version: 3.1110.0
       '@aws-sdk/client-eventbridge':
         specifier: ^3.1109.0
         version: 3.1109.0
@@ -259,6 +262,10 @@ packages:
 
   '@aws-sdk/client-ecs@3.1109.0':
     resolution: {integrity: sha512-1r7K8jdDnFEaS0CvgkUPSlr0Sh8BGgHITzER6xWNDqe160gxSWmCwzhRJzRCKiSdN4CzRhOLsJaSHlRpeh1Fiw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/client-elastic-load-balancing-v2@3.1110.0':
+    resolution: {integrity: sha512-kUZvrU1TElScmnvlXToHeKGVtCt5q4fvbLgjxaLspBfXkiuSP8qSn3HNOpkh2p40mcgShb7HsPtyvhqSUUYslA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/client-eventbridge@3.1109.0':
@@ -3488,6 +3495,17 @@ snapshots:
       tslib: 2.8.1
 
   '@aws-sdk/client-ecs@3.1109.0':
+    dependencies:
+      '@aws-sdk/core': 3.977.7
+      '@aws-sdk/credential-provider-node': 3.972.79
+      '@aws-sdk/types': 3.974.3
+      '@smithy/core': 3.32.0
+      '@smithy/fetch-http-handler': 5.7.0
+      '@smithy/node-http-handler': 4.10.0
+      '@smithy/types': 4.17.0
+      tslib: 2.8.1
+
+  '@aws-sdk/client-elastic-load-balancing-v2@3.1110.0':
     dependencies:
       '@aws-sdk/core': 3.977.7
       '@aws-sdk/credential-provider-node': 3.972.79

--- a/src/sdk/router/resolve-sim-sdk-command-router.ts
+++ b/src/sdk/router/resolve-sim-sdk-command-router.ts
@@ -61,6 +61,10 @@ const scopedRouters: ReadonlyMap<string, SimSdkScopedRouter> = new Map<
   ],
   ["ECS", (scoped): SimSdkCommandRouter => scoped.ecs().sdkCommandRouter()],
   [
+    "Elastic Load Balancing v2",
+    (scoped): SimSdkCommandRouter => scoped.elbV2().sdkCommandRouter(),
+  ],
+  [
     "EventBridge",
     (scoped): SimSdkCommandRouter => scoped.eventBridge().sdkCommandRouter(),
   ],

--- a/src/service/aws/factory/sim-aws-account-region-service-builder.ts
+++ b/src/service/aws/factory/sim-aws-account-region-service-builder.ts
@@ -10,6 +10,7 @@ import {
   simAwsAcmDnsRecords,
   simAwsEventBridgeDeliveryTargets,
   simAwsHttpApiJwtIssuerKeys,
+  simAwsRekognitionImages,
   simAwsSchedulerDeliveryTargets,
 } from "./sim-aws-cross-account-collaborators.js";
 import { SimCloudFormation } from "../../cloudformation/index.js";
@@ -17,6 +18,7 @@ import { SimCognitoIdentityProvider } from "../../cognito/index.js";
 import { simAwsCognitoTriggerFunctions } from "../../cognito/user-pool/trigger/sim-aws-cognito-trigger-functions.js";
 import { SimDynamoDb as SimDynamoDatabase } from "../../dynamodb/index.js";
 import { SimEcs } from "../../ecs/index.js";
+import { SimElbV2 } from "../../elbv2/index.js";
 import { SimEventBridge } from "../../eventbridge/index.js";
 import type { SimIamRegistry } from "../../iam/registry/sim-iam-registry.js";
 import { SimKms } from "../../kms/index.js";
@@ -24,7 +26,6 @@ import type { SimHttpApiRegistry } from "../../apigatewayv2/registry/sim-http-ap
 import { SimLambda } from "../../lambda/index.js";
 import type { SimLambdaUrlRegistry } from "../../lambda/registry/sim-lambda-url-registry.js";
 import { SimRekognition } from "../../rekognition/index.js";
-import { SimAwsRekognitionImageObjects } from "../../rekognition/image/s3/sim-aws-rekognition-image-objects.js";
 import { SimS3 } from "../../s3/sim-s3.js";
 import { SimScheduler } from "../../scheduler/index.js";
 import { simAwsLambdaCollaborators } from "./sim-aws-lambda-collaborators.js";
@@ -161,6 +162,11 @@ export class SimAwsAccountRegionServiceBuilder {
     });
   }
 
+  /** Create simulated Elastic Load Balancing v2 for an Account Region scope. */
+  createElbV2(scope: SimAwsAccountRegionContainer): SimElbV2 {
+    return new SimElbV2(this.scoped(scope));
+  }
+
   /**
    * Create simulated KMS for an Account Region scope.
    *
@@ -190,18 +196,13 @@ export class SimAwsAccountRegionServiceBuilder {
    * Create simulated Rekognition for an Account Region scope.
    *
    * Rekognition is Region-scoped because the results declared against it are:
-   * a detection made in one Region is answered by that Region's rules. Image
-   * objects come from the whole simulation rather than this scope's S3, since
-   * real Rekognition reads a Bucket another Account's policy admits it to.
+   * a detection made in one Region is answered by that Region's rules.
    */
   createRekognition(scope: SimAwsAccountRegionContainer): SimRekognition {
     return new SimRekognition({
       iam: this.accountServices.createIam(scope),
       background: this.background,
-      images: new SimAwsRekognitionImageObjects({
-        simAws: this.simAws,
-        accountRegionScope: scope.accountRegionScope,
-      }),
+      images: simAwsRekognitionImages(this.simAws, scope),
     });
   }
 

--- a/src/service/aws/factory/sim-aws-cross-account-collaborators.ts
+++ b/src/service/aws/factory/sim-aws-cross-account-collaborators.ts
@@ -1,7 +1,9 @@
 import { SimRoute53AcmDnsRecords } from "../../acm/validation/sim-route53-acm-dns-records.js";
 import { SimCognitoHttpApiJwtIssuerKeys } from "../../apigatewayv2/api/authorizer/sim-cognito-http-api-jwt-issuer-keys.js";
 import { SimAwsEventBridgeDeliveryTargets } from "../../eventbridge/delivery/sim-aws-event-bridge-delivery-targets.js";
+import { SimAwsRekognitionImageObjects } from "../../rekognition/image/s3/sim-aws-rekognition-image-objects.js";
 import { SimAwsSchedulerDeliveryTargets } from "../../scheduler/delivery/sim-aws-scheduler-delivery-targets.js";
+import type { SimAwsAccountRegionContainer } from "../sim-aws-account-region-scope.js";
 import type { SimAws } from "../sim-aws.js";
 import type { SimAwsScopedServiceRegistries } from "./sim-aws-scoped-service-registries.js";
 
@@ -55,4 +57,20 @@ export function simAwsSchedulerDeliveryTargets(
   simAws: SimAws,
 ): SimAwsSchedulerDeliveryTargets {
   return new SimAwsSchedulerDeliveryTargets({ simAws });
+}
+
+/**
+ * The images a simulated Rekognition detection reads.
+ *
+ * Real Rekognition reads a Bucket another Account's policy admits it to, so
+ * this reads the whole simulation's S3 rather than one scope's.
+ */
+export function simAwsRekognitionImages(
+  simAws: SimAws,
+  scope: SimAwsAccountRegionContainer,
+): SimAwsRekognitionImageObjects {
+  return new SimAwsRekognitionImageObjects({
+    simAws,
+    accountRegionScope: scope.accountRegionScope,
+  });
 }

--- a/src/service/aws/factory/sim-aws-service-factory.ts
+++ b/src/service/aws/factory/sim-aws-service-factory.ts
@@ -17,6 +17,7 @@ import type { SimRekognition } from "../../rekognition/index.js";
 import type { SimRoute53 } from "../../route53/index.js";
 import type { SimS3 } from "../../s3/sim-s3.js";
 import type { SimScheduler } from "../../scheduler/index.js";
+import type { SimElbV2 } from "../../elbv2/index.js";
 import type { SimIam } from "../../iam/index.js";
 import { SimIamRegistry } from "../../iam/registry/sim-iam-registry.js";
 import type { SimKms } from "../../kms/index.js";
@@ -173,6 +174,11 @@ export class SimAwsServiceFactory {
   /** Create simulated EventBridge for an Account Region scope. */
   createEventBridge(scope: SimAwsAccountRegionContainer): SimEventBridge {
     return this.accountRegionServices.createEventBridge(scope);
+  }
+
+  /** Create simulated Elastic Load Balancing v2 for an Account Region scope. */
+  createElbV2(scope: SimAwsAccountRegionContainer): SimElbV2 {
+    return this.accountRegionServices.createElbV2(scope);
   }
 
   /** Create or get simulated IAM for an Account scope. */

--- a/src/service/aws/sim-aws-account-region-scope.ts
+++ b/src/service/aws/sim-aws-account-region-scope.ts
@@ -19,6 +19,7 @@ import type { SimRekognition } from "../rekognition/index.js";
 import type { SimRoute53 } from "../route53/index.js";
 import type { SimAcm } from "../acm/sim-acm.js";
 import type { SimApiGatewayV2 } from "../apigatewayv2/index.js";
+import type { SimElbV2 } from "../elbv2/index.js";
 import type { SimIam } from "../iam/index.js";
 import type { SimKms } from "../kms/index.js";
 import type { SimLambda } from "../lambda/index.js";
@@ -165,6 +166,15 @@ export class SimAwsAccountRegionContainer {
   scheduler(): SimScheduler {
     return this.memo.getOrCreate("scheduler", () =>
       this.simAws.serviceFactory.createScheduler(this),
+    );
+  }
+
+  /**
+   * Get simulated Elastic Load Balancing v2 for this account and region.
+   */
+  elbV2(): SimElbV2 {
+    return this.memo.getOrCreate("elbV2", () =>
+      this.simAws.serviceFactory.createElbV2(this),
     );
   }
 

--- a/src/service/aws/sim-aws-account-region-scope.ts
+++ b/src/service/aws/sim-aws-account-region-scope.ts
@@ -70,9 +70,7 @@ export class SimAwsAccountRegionContainer {
    * Get simulated ACM for this account and region.
    */
   acm(): SimAcm {
-    return this.memo.getOrCreate("acm", () =>
-      this.simAws.serviceFactory.createAcm(this),
-    );
+    return this.memo.getOrCreate("acm", () => this.factory.createAcm(this));
   }
 
   /**
@@ -80,7 +78,7 @@ export class SimAwsAccountRegionContainer {
    */
   apiGatewayV2(): SimApiGatewayV2 {
     return this.memo.getOrCreate("apiGatewayV2", () =>
-      this.simAws.serviceFactory.createApiGatewayV2(this),
+      this.factory.createApiGatewayV2(this),
     );
   }
 
@@ -89,7 +87,7 @@ export class SimAwsAccountRegionContainer {
    */
   cloudFormation(): SimCloudFormation {
     return this.memo.getOrCreate("cloudFormation", () =>
-      this.simAws.serviceFactory.createCloudFormation(this),
+      this.factory.createCloudFormation(this),
     );
   }
 
@@ -98,7 +96,7 @@ export class SimAwsAccountRegionContainer {
    */
   cloudFront(): SimCloudFront {
     return this.memo.getOrCreate("cloudFront", () =>
-      this.simAws.serviceFactory.createCloudFront(this),
+      this.factory.createCloudFront(this),
     );
   }
 
@@ -118,7 +116,7 @@ export class SimAwsAccountRegionContainer {
    */
   cognitoIdentityProvider(): SimCognitoIdentityProvider {
     return this.memo.getOrCreate("cognitoIdentityProvider", () =>
-      this.simAws.serviceFactory.createCognitoIdentityProvider(this),
+      this.factory.createCognitoIdentityProvider(this),
     );
   }
 
@@ -127,7 +125,7 @@ export class SimAwsAccountRegionContainer {
    */
   dynamoDb(): SimDynamoDatabase {
     return this.memo.getOrCreate("dynamoDb", () =>
-      this.simAws.serviceFactory.createDynamoDb(this),
+      this.factory.createDynamoDb(this),
     );
   }
 
@@ -146,9 +144,7 @@ export class SimAwsAccountRegionContainer {
    * Get simulated ECS for this account and region.
    */
   ecs(): SimEcs {
-    return this.memo.getOrCreate("ecs", () =>
-      this.simAws.serviceFactory.createEcs(this),
-    );
+    return this.memo.getOrCreate("ecs", () => this.factory.createEcs(this));
   }
 
   /**
@@ -156,7 +152,7 @@ export class SimAwsAccountRegionContainer {
    */
   eventBridge(): SimEventBridge {
     return this.memo.getOrCreate("eventBridge", () =>
-      this.simAws.serviceFactory.createEventBridge(this),
+      this.factory.createEventBridge(this),
     );
   }
 
@@ -165,7 +161,7 @@ export class SimAwsAccountRegionContainer {
    */
   scheduler(): SimScheduler {
     return this.memo.getOrCreate("scheduler", () =>
-      this.simAws.serviceFactory.createScheduler(this),
+      this.factory.createScheduler(this),
     );
   }
 
@@ -173,27 +169,21 @@ export class SimAwsAccountRegionContainer {
    * Get simulated Elastic Load Balancing v2 for this account and region.
    */
   elbV2(): SimElbV2 {
-    return this.memo.getOrCreate("elbV2", () =>
-      this.simAws.serviceFactory.createElbV2(this),
-    );
+    return this.memo.getOrCreate("elbV2", () => this.factory.createElbV2(this));
   }
 
   /**
    * Get simulated IAM for this account.
    */
   iam(): SimIam {
-    return this.memo.getOrCreate("iam", () =>
-      this.simAws.serviceFactory.createIam(this),
-    );
+    return this.memo.getOrCreate("iam", () => this.factory.createIam(this));
   }
 
   /**
    * Get simulated KMS for this account and region.
    */
   kms(): SimKms {
-    return this.memo.getOrCreate("kms", () =>
-      this.simAws.serviceFactory.createKms(this),
-    );
+    return this.memo.getOrCreate("kms", () => this.factory.createKms(this));
   }
 
   /**
@@ -201,7 +191,7 @@ export class SimAwsAccountRegionContainer {
    */
   lambda(): SimLambda {
     return this.memo.getOrCreate("lambda", () =>
-      this.simAws.serviceFactory.createLambda(this),
+      this.factory.createLambda(this),
     );
   }
 
@@ -210,7 +200,7 @@ export class SimAwsAccountRegionContainer {
    */
   rekognition(): SimRekognition {
     return this.memo.getOrCreate("rekognition", () =>
-      this.simAws.serviceFactory.createRekognition(this),
+      this.factory.createRekognition(this),
     );
   }
 
@@ -219,7 +209,7 @@ export class SimAwsAccountRegionContainer {
    */
   route53(): SimRoute53 {
     return this.memo.getOrCreate("route53", () =>
-      this.simAws.serviceFactory.createRoute53(this),
+      this.factory.createRoute53(this),
     );
   }
 
@@ -227,9 +217,7 @@ export class SimAwsAccountRegionContainer {
    * Get simulated S3 for this account and region.
    */
   s3(): SimS3 {
-    return this.memo.getOrCreate("s3", () =>
-      this.simAws.serviceFactory.createS3(this),
-    );
+    return this.memo.getOrCreate("s3", () => this.factory.createS3(this));
   }
 
   /**
@@ -237,7 +225,7 @@ export class SimAwsAccountRegionContainer {
    */
   secretsManager(): SimSecretsManager {
     return this.memo.getOrCreate("secretsManager", () =>
-      this.simAws.serviceFactory.createSecretsManager(this),
+      this.factory.createSecretsManager(this),
     );
   }
 
@@ -245,36 +233,28 @@ export class SimAwsAccountRegionContainer {
    * Get simulated SNS for this account and region.
    */
   sns(): SimSns {
-    return this.memo.getOrCreate("sns", () =>
-      this.simAws.serviceFactory.createSns(this),
-    );
+    return this.memo.getOrCreate("sns", () => this.factory.createSns(this));
   }
 
   /**
    * Get simulated SQS for this account and region.
    */
   sqs(): SimSqs {
-    return this.memo.getOrCreate("sqs", () =>
-      this.simAws.serviceFactory.createSqs(this),
-    );
+    return this.memo.getOrCreate("sqs", () => this.factory.createSqs(this));
   }
 
   /**
    * Get simulated SSM for this account and region.
    */
   ssm(): SimSsm {
-    return this.memo.getOrCreate("ssm", () =>
-      this.simAws.serviceFactory.createSsm(this),
-    );
+    return this.memo.getOrCreate("ssm", () => this.factory.createSsm(this));
   }
 
   /**
    * Get simulated STS for this account and region.
    */
   sts(): SimSts {
-    return this.memo.getOrCreate("sts", () =>
-      this.simAws.serviceFactory.createSts(this),
-    );
+    return this.memo.getOrCreate("sts", () => this.factory.createSts(this));
   }
 
   /**
@@ -295,6 +275,18 @@ export class SimAwsAccountRegionContainer {
           await service.close();
         }),
     );
+  }
+
+  /**
+   * Where every service in this scope is made.
+   *
+   * Read through here rather than reached for in full by each accessor above.
+   * The accessors are one memoised call each and there is one per simulated
+   * service, so what the whole block costs is worth keeping down: this file
+   * has twice been at its line limit with a service waiting to be added to it.
+   */
+  private get factory(): SimAws["serviceFactory"] {
+    return this.simAws.serviceFactory;
   }
 }
 

--- a/src/service/aws/sim-aws-service-accessors.ts
+++ b/src/service/aws/sim-aws-service-accessors.ts
@@ -10,6 +10,7 @@ import type {
   SimDynamoDbStreams,
 } from "../dynamodb/index.js";
 import type { SimEcs } from "../ecs/index.js";
+import type { SimElbV2 } from "../elbv2/index.js";
 import type { SimIam } from "../iam/index.js";
 import type { SimKms } from "../kms/index.js";
 import type { SimLambda } from "../lambda/index.js";
@@ -83,6 +84,11 @@ export abstract class SimAwsServiceAccessors {
   /** Get simulated ECS in the default Account Region scope. */
   ecs(): SimEcs {
     return this.defaultAccountRegionScope().ecs();
+  }
+
+  /** Get simulated Elastic Load Balancing v2 in the default Account Region scope. */
+  elbV2(): SimElbV2 {
+    return this.defaultAccountRegionScope().elbV2();
   }
 
   /** Get simulated EventBridge in the default Account Region scope. */

--- a/src/service/elbv2/README.md
+++ b/src/service/elbv2/README.md
@@ -1,0 +1,108 @@
+# Simulated Elastic Load Balancing v2 implementation
+
+This directory contains the simulated ELBv2 service implementation.
+
+The guiding decision here is that this is the Application Load Balancer and nothing else. A network
+or gateway load balancer routes below HTTP, which nothing in this simulation speaks, so one is
+refused rather than created as something it is not. The second decision is that this piece is state:
+a load balancer here has a DNS name of the shape real ELB issues, and listeners, rules and target
+groups saying what it would do with a request. Answering a request is separate work.
+
+## Entry points
+
+- `sim-elbv2.ts` is the main in-memory service object for one account/region scope.
+- `index.ts` exports the public ELBv2 simulator API for `@kensio/yulin/elbv2`.
+
+A `SimElbV2` instance owns a `SimElbV2Stores` holding its four resources. The simulator is scoped to
+an account and region because real load balancers are: an ARN names the region, a name is unique
+within one account and region rather than globally, and the DNS name ELB issues carries the region.
+
+## Resource model
+
+The four resources live in four stores rather than nested inside each other, because the SDK
+addresses each of them by its own ARN and a describe has no parent to start from. What they do have
+is a lifetime that runs one way, and `SimElbV2Stores` owns that: deleting a load balancer takes its
+listeners, and deleting a listener takes its rules. Target groups are left alone, which is what real
+ELB does, since a replacement load balancer's listeners forward to the same groups.
+
+`SimElbV2LoadBalancer` is the DNS name above all. That is the only way anything reaches a load
+balancer on real AWS, and it is what a Route53 alias or a CloudFront origin points at.
+`sim-elbv2-load-balancer-arn.ts` builds both it and the ARN, and owns the `internal-` prefix an
+internal load balancer's host name carries, which is why that prefix is refused in a load balancer's
+own name.
+
+`SimElbV2Listener` and `SimElbV2ListenerRule` build their ARNs from their parents' rather than from
+the scope. That is what makes the load balancer's name and id appear in a listener ARN the way real
+ELB has them, and what lets a rule say which listener it belongs to without anything looking it up.
+
+`SimElbV2TargetType` is a strategy rather than a label. How many targets a group takes, what a
+target's Id has to look like, and whether the group carries a protocol and port all depend on it,
+and each subclass is one set of those answers. That is why nothing else in the service branches on
+whether a group holds a function or an address. `instance` is refused rather than accepted: there
+are no EC2 instances here for it to mean anything about, and a group created as one would look
+configured and route nowhere. A request naming no type at all is refused too, because real ELB
+defaults it to `instance`.
+
+`SimElbV2Action` and `SimElbV2RuleCondition` hold what a listener or rule would do and what it would
+match, and neither performs it. What they own is that what is stored is something a real load
+balancer would have accepted: a forward action names a target group that exists, a fixed-response
+action has a status code, and a condition is on a field with something to compare against. Each is
+checked when the rule is written rather than when a request arrives.
+
+`SimElbV2ListenerRuleStore` owns priority uniqueness, because it is a property of a listener's whole
+set of rules rather than of any one rule. `SetRulePriorities` judges a request against the order it
+would leave behind rather than the one it started from, which is what lets two rules swap places in
+one request.
+
+`SimElbV2TargetGroupUsage` answers which load balancers forward to a target group by reading the
+listeners and rules rather than by a record on the group. A rule can be written and deleted without
+the group hearing about it, so reading it back is the only answer that cannot go stale. It is also
+what refuses to delete a group anything still forwards to.
+
+## Command handling
+
+AWS SDK-style operations are implemented under `command/`, one directory per resource and one
+handler per operation, so the `SimElbV2` facade stays a list of delegations:
+
+- `command/load-balancer/` — `CreateLoadBalancer`, `DescribeLoadBalancers`, `DeleteLoadBalancer`
+- `command/target-group/` — the target group create, describe, modify and delete
+- `command/target/` — `RegisterTargets`, `DeregisterTargets`, `DescribeTargetHealth`
+- `command/listener/` — the listener create, describe, modify and delete
+- `command/rule/` — the rule create, describe, modify and delete, and `SetRulePriorities`
+- `command/authorize/` — the shared IAM authorizer
+- `command/sim-elbv2-command-handler.ts` — the collaborators every handler holds
+- `command/sim-elbv2-command.types.ts` — the command types gathered for the facade
+
+`SimElbV2Commands` builds the handlers, so the facade is a method per operation and adding one is a
+handler there and a method here.
+
+As elsewhere, implementation code under `src/` does not import real AWS SDK packages. The structural
+command types in `*.command.ts` match the SDK shapes closely enough for callers to pass real SDK
+command instances. Enum-shaped fields are widened to `string`, so an input this simulation refuses
+is refused at runtime with an explanation rather than by the type checker with none.
+
+## Authorization
+
+`SimElbV2Authorizer` serves the whole service rather than one authorizer per command, because ELBv2
+has one action prefix for all four resources and the resource an action names is the ARN of whichever
+of them it operates on. An operation naming nothing that exists yet, such as `CreateLoadBalancer` or
+a describe, authorizes against `*`, so only a policy whose Resource is `*` allows it.
+
+There is no resource policy support here, and none to add: ELBv2 has none on real AWS either.
+
+## Divergences worth knowing
+
+- A load balancer is `active` as soon as it is created. Real ELB leaves one `provisioning` for a few
+  minutes, which every test would wait out for no behaviour it could observe.
+- Every registered target is `healthy`. No health check is ever performed, so health check settings
+  are held and reported and nothing acts on them.
+- `CanonicalHostedZoneId` is one value everywhere rather than the real per-region table, because
+  simulated Route53 resolves an alias by looking the target up rather than by its zone id.
+- Deregistration is immediate, where real ELB drains connections first, because there are no
+  connections to drain.
+- Subnets, security groups and availability zones are accepted and left out of a describe rather
+  than invented.
+- ARN ids and DNS name suffixes count rather than being random, so a test can assert on an ARN it
+  did not capture. The shape is the real one either way.
+
+The full list is in [docs/services/elbv2](../../../docs/services/elbv2/).

--- a/src/service/elbv2/README.md
+++ b/src/service/elbv2/README.md
@@ -104,5 +104,11 @@ There is no resource policy support here, and none to add: ELBv2 has none on rea
   than invented.
 - ARN ids and DNS name suffixes count rather than being random, so a test can assert on an ARN it
   did not capture. The shape is the real one either way.
+- A listener or rule takes exactly one action. Real ELB takes one routing action with an optional
+  authentication action before it, and neither authentication action is simulated, so a longer list
+  is refused rather than half honoured.
+- What a request carries in is copied when it is stored, so a caller mutating the command input it
+  sent cannot change a listener or rule afterwards. Real ELB reads the request off the wire and is
+  immune to that by construction.
 
 The full list is in [docs/services/elbv2](../../../docs/services/elbv2/).

--- a/src/service/elbv2/action/sim-elbv2-action-targets.ts
+++ b/src/service/elbv2/action/sim-elbv2-action-targets.ts
@@ -1,0 +1,29 @@
+import type { SimElbV2TargetGroupStore } from "../target-group/sim-elbv2-target-group-store.js";
+import type { SimElbV2Action } from "./sim-elbv2-action.js";
+
+/**
+ * Checks that the target groups a set of actions forwards to exist.
+ *
+ * A forward action naming a target group that was never created is the one
+ * mistake in a listener or a rule that nothing else would catch until a
+ * request arrived and went nowhere, so it is caught when the action is written
+ * instead. Real ELB does the same.
+ */
+export class SimElbV2ActionTargets {
+  private readonly targetGroups: SimElbV2TargetGroupStore;
+
+  constructor(targetGroups: SimElbV2TargetGroupStore) {
+    this.targetGroups = targetGroups;
+  }
+
+  /**
+   * Refuse actions forwarding to a target group that does not exist.
+   */
+  requireTargetGroups(actions: readonly SimElbV2Action[]): void {
+    for (const action of actions) {
+      for (const arn of action.targetGroupArns) {
+        this.targetGroups.requireByArn(arn);
+      }
+    }
+  }
+}

--- a/src/service/elbv2/action/sim-elbv2-action.iso.test.ts
+++ b/src/service/elbv2/action/sim-elbv2-action.iso.test.ts
@@ -1,0 +1,129 @@
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsError,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import {
+  SimElbV2UnsimulatedInputException,
+  SimElbV2ValidationError,
+} from "../error/sim-elbv2.error.js";
+import { SimElbV2Action } from "./sim-elbv2-action.js";
+
+const targetGroupArn =
+  "arn:aws:elasticloadbalancing:eu-west-1:888888888888:targetgroup/web/0001";
+
+describe("sim ELBv2 actions", () => {
+  it("reads the target groups a forward action names either way", () => {
+    // Given a forward action written in each of the two forms ELB takes.
+    const plain = SimElbV2Action.read(
+      { Type: "forward", TargetGroupArn: targetGroupArn },
+      "Actions",
+    );
+    const weighted = SimElbV2Action.read(
+      {
+        Type: "forward",
+        ForwardConfig: {
+          TargetGroups: [{ TargetGroupArn: targetGroupArn, Weight: 1 }],
+        },
+      },
+      "Actions",
+    );
+
+    // Then both name the same target group.
+    assertIdentical(plain.targetGroupArns[0], targetGroupArn);
+    assertIdentical(weighted.targetGroupArns[0], targetGroupArn);
+  });
+
+  it("reports an action in the shape the SDK reads it back in", () => {
+    // Given a fixed-response action with an order.
+    const action = SimElbV2Action.read(
+      {
+        Type: "fixed-response",
+        Order: 1,
+        FixedResponseConfig: { StatusCode: "503", ContentType: "text/plain" },
+      },
+      "DefaultActions",
+    );
+
+    // When it is viewed.
+    const view = action.view();
+
+    // Then it carries what it was given.
+    assertIdentical(view.Type, "fixed-response");
+    assertIdentical(view.Order, 1);
+    assertIdentical(view.FixedResponseConfig?.StatusCode, "503");
+  });
+
+  it("refuses an action list that is empty or absent", () => {
+    // Given no actions at all, and an empty list.
+    const absent = assertThrowsError(() => {
+      SimElbV2Action.readAll(undefined, "Actions");
+    });
+
+    assertInstanceOf(absent, SimElbV2ValidationError);
+
+    const empty = assertThrowsError(() => {
+      SimElbV2Action.readAll([], "Actions");
+    });
+
+    assertInstanceOf(empty, SimElbV2ValidationError);
+
+    // Then both are refused, since a listener with nothing to do is not one.
+    assertStringIncludes(absent.message, "at least one action");
+    assertStringIncludes(empty.message, "at least one action");
+  });
+
+  it("refuses an action type this simulation does not perform", () => {
+    // Given an action with no type, and one that authenticates.
+    const noType = assertThrowsError(() => {
+      SimElbV2Action.read({}, "Actions");
+    });
+
+    assertInstanceOf(noType, SimElbV2ValidationError);
+
+    const authenticate = assertThrowsError(() => {
+      SimElbV2Action.read({ Type: "authenticate-cognito" }, "Actions");
+    });
+
+    assertInstanceOf(authenticate, SimElbV2UnsimulatedInputException);
+
+    // Then both are refused rather than treated as a plain forward.
+    assertStringIncludes(noType.message, "requires a Type");
+    assertStringIncludes(authenticate.message, "not simulated");
+  });
+
+  it("refuses an action whose configuration would not work", () => {
+    // Given a forward with no target group, and two malformed responses.
+    const forward = assertThrowsError(() => {
+      SimElbV2Action.read({ Type: "forward" }, "Actions");
+    });
+
+    assertInstanceOf(forward, SimElbV2ValidationError);
+
+    const fixedResponse = assertThrowsError(() => {
+      SimElbV2Action.read(
+        { Type: "fixed-response", FixedResponseConfig: { StatusCode: "42" } },
+        "Actions",
+      );
+    });
+
+    assertInstanceOf(fixedResponse, SimElbV2ValidationError);
+
+    const redirect = assertThrowsError(() => {
+      SimElbV2Action.read({ Type: "redirect" }, "Actions");
+    });
+
+    assertInstanceOf(redirect, SimElbV2ValidationError);
+
+    // Then each is refused when written rather than when a request arrives.
+    assertStringIncludes(forward.message, "TargetGroupArn");
+    assertStringIncludes(
+      fixedResponse.message,
+      "StatusCode between 200 and 599",
+    );
+    assertStringIncludes(redirect.message, "HTTP_301 or HTTP_302");
+  });
+});

--- a/src/service/elbv2/action/sim-elbv2-action.iso.test.ts
+++ b/src/service/elbv2/action/sim-elbv2-action.iso.test.ts
@@ -76,6 +76,50 @@ describe("sim ELBv2 actions", () => {
     assertStringIncludes(empty.message, "at least one action");
   });
 
+  it("refuses a 3XX fixed response, which is a redirect action's job", () => {
+    // Given a fixed-response action carrying a redirect's status code.
+    const error = assertThrowsError(() => {
+      SimElbV2Action.read(
+        { Type: "fixed-response", FixedResponseConfig: { StatusCode: "302" } },
+        "Actions",
+      );
+    });
+
+    // Then it is refused, as real ELB takes only 2XX, 4XX and 5XX here.
+    assertInstanceOf(error, SimElbV2ValidationError);
+    assertStringIncludes(error.message, "redirect action");
+  });
+
+  it("refuses more than one action, since each one is a routing action", () => {
+    // Given two forward actions in one list.
+    const error = assertThrowsError(() => {
+      SimElbV2Action.readAll(
+        [
+          { Type: "forward", TargetGroupArn: targetGroupArn },
+          { Type: "forward", TargetGroupArn: targetGroupArn },
+        ],
+        "DefaultActions",
+      );
+    });
+
+    // Then it is refused: real ELB takes one routing action, and the
+    // authentication actions that could precede it are not simulated.
+    assertInstanceOf(error, SimElbV2ValidationError);
+    assertStringIncludes(error.message, "one routing action");
+  });
+
+  it("keeps what it stored when the caller mutates the input afterwards", () => {
+    // Given an action read from an object the caller still holds.
+    const input = { Type: "forward", TargetGroupArn: targetGroupArn };
+    const action = SimElbV2Action.read(input, "Actions");
+
+    // When the caller changes that object.
+    input.TargetGroupArn = "arn:aws:elasticloadbalancing:::targetgroup/other/1";
+
+    // Then the action still forwards where it was written to forward.
+    assertIdentical(action.view().TargetGroupArn, targetGroupArn);
+  });
+
   it("refuses an action type this simulation does not perform", () => {
     // Given an action with no type, and one that authenticates.
     const noType = assertThrowsError(() => {
@@ -120,10 +164,7 @@ describe("sim ELBv2 actions", () => {
 
     // Then each is refused when written rather than when a request arrives.
     assertStringIncludes(forward.message, "TargetGroupArn");
-    assertStringIncludes(
-      fixedResponse.message,
-      "StatusCode between 200 and 599",
-    );
+    assertStringIncludes(fixedResponse.message, "2XX, 4XX or 5XX");
     assertStringIncludes(redirect.message, "HTTP_301 or HTTP_302");
   });
 });

--- a/src/service/elbv2/action/sim-elbv2-action.ts
+++ b/src/service/elbv2/action/sim-elbv2-action.ts
@@ -24,6 +24,14 @@ const simulatedActionTypes = new Set(["forward", "fixed-response", "redirect"]);
 const redirectStatusCodes = new Set(["HTTP_301", "HTTP_302"]);
 
 /**
+ * The status codes real ELB takes on a fixed-response action.
+ *
+ * A 3XX is missing on purpose rather than by oversight: redirecting is the
+ * redirect action's job, and real ELB refuses one here.
+ */
+const fixedResponseStatusCodes = /^[245]\d\d$/u;
+
+/**
  * The target groups a forward action names, whichever form it names them in.
  */
 function forwardTargetGroupArns(input: SimElbV2ActionInput): readonly string[] {
@@ -54,14 +62,23 @@ export class SimElbV2Action {
   private readonly input: SimElbV2ActionInput;
 
   private constructor(input: SimElbV2ActionInput, type: string) {
-    this.input = input;
+    // Copied, so that a caller mutating the command input it sent cannot
+    // change where a listener or rule forwards afterwards. Real ELB reads the
+    // request off the wire, and nothing a caller does to its own objects
+    // reaches it.
+    this.input = structuredClone(input);
     this.type = type;
     this.order = input.Order;
     this.targetGroupArns = forwardTargetGroupArns(input);
   }
 
   /**
-   * Read the actions a request carries, refusing an empty or absent list.
+   * Read the actions a request carries, refusing a list ELB would not take.
+   *
+   * Real ELB takes exactly one routing action, last in the list, and the only
+   * thing that may come before it is an authentication action. None of those
+   * is simulated, so every action here is a routing action, and a list holding
+   * more than one names two places for the same request to go.
    */
   static readAll(
     actions: readonly SimElbV2ActionInput[] | undefined,
@@ -70,6 +87,14 @@ export class SimElbV2Action {
     if (actions === undefined || actions.length === 0) {
       throw new SimElbV2ValidationError(
         `${field} must hold at least one action`,
+      );
+    }
+
+    if (actions.length > 1) {
+      throw new SimElbV2ValidationError(
+        `${field} holds ${String(actions.length)} actions, and a listener or ` +
+          `rule takes one routing action. The authentication actions that can ` +
+          `precede it are not simulated.`,
       );
     }
 
@@ -140,10 +165,13 @@ export class SimElbV2Action {
   private validateFixedResponse(field: string): void {
     const statusCode = this.input.FixedResponseConfig?.StatusCode;
 
-    if (statusCode === undefined || !/^[2-5]\d\d$/u.test(statusCode)) {
+    if (
+      statusCode === undefined ||
+      !fixedResponseStatusCodes.test(statusCode)
+    ) {
       throw new SimElbV2ValidationError(
         `${field} fixed-response action requires a FixedResponseConfig ` +
-          `StatusCode between 200 and 599`,
+          `StatusCode of 2XX, 4XX or 5XX. A 3XX code is a redirect action.`,
       );
     }
   }

--- a/src/service/elbv2/action/sim-elbv2-action.ts
+++ b/src/service/elbv2/action/sim-elbv2-action.ts
@@ -1,0 +1,160 @@
+import type {
+  SimElbV2ActionInput,
+  SimElbV2ActionView,
+} from "../command/sim-elbv2-shared.command.js";
+import {
+  SimElbV2UnsimulatedInputException,
+  SimElbV2ValidationError,
+} from "../error/sim-elbv2.error.js";
+
+/**
+ * The action types an Application Load Balancer listener or rule can hold
+ * here.
+ *
+ * Real ALB also has `authenticate-oidc` and `authenticate-cognito`, which sit
+ * in front of the request and speak to an identity provider. Nothing in this
+ * simulation performs that exchange, so an action naming one is refused rather
+ * than treated as a forward that quietly skips authentication.
+ */
+const simulatedActionTypes = new Set(["forward", "fixed-response", "redirect"]);
+
+/**
+ * The status codes real ELB takes on a redirect action.
+ */
+const redirectStatusCodes = new Set(["HTTP_301", "HTTP_302"]);
+
+/**
+ * The target groups a forward action names, whichever form it names them in.
+ */
+function forwardTargetGroupArns(input: SimElbV2ActionInput): readonly string[] {
+  const tupleArns = (input.ForwardConfig?.TargetGroups ?? [])
+    .map((tuple) => tuple.TargetGroupArn)
+    .filter((arn) => arn !== undefined);
+
+  if (input.TargetGroupArn === undefined) {
+    return tupleArns;
+  }
+
+  return [input.TargetGroupArn, ...tupleArns];
+}
+
+/**
+ * One action on a simulated listener or listener rule.
+ *
+ * Actions are held rather than performed: choosing one and answering a request
+ * with it is a separate piece of work. What this class owns is that an action
+ * stored here is one a real load balancer would have accepted, so a listener
+ * that was created is a listener that could route.
+ */
+export class SimElbV2Action {
+  public readonly type: string;
+  public readonly order: number | undefined;
+  public readonly targetGroupArns: readonly string[];
+
+  private readonly input: SimElbV2ActionInput;
+
+  private constructor(input: SimElbV2ActionInput, type: string) {
+    this.input = input;
+    this.type = type;
+    this.order = input.Order;
+    this.targetGroupArns = forwardTargetGroupArns(input);
+  }
+
+  /**
+   * Read the actions a request carries, refusing an empty or absent list.
+   */
+  static readAll(
+    actions: readonly SimElbV2ActionInput[] | undefined,
+    field: string,
+  ): readonly SimElbV2Action[] {
+    if (actions === undefined || actions.length === 0) {
+      throw new SimElbV2ValidationError(
+        `${field} must hold at least one action`,
+      );
+    }
+
+    return actions.map((action) => this.read(action, field));
+  }
+
+  /**
+   * Read one action, refusing a type or configuration ELB would not take.
+   */
+  static read(input: SimElbV2ActionInput, field: string): SimElbV2Action {
+    const type = input.Type;
+
+    if (type === undefined || type === "") {
+      throw new SimElbV2ValidationError(`${field} action requires a Type`);
+    }
+
+    if (!simulatedActionTypes.has(type)) {
+      throw new SimElbV2UnsimulatedInputException(
+        `${field} action type '${type}' is not simulated. Simulated action ` +
+          `types are ${[...simulatedActionTypes].join(", ")}.`,
+      );
+    }
+
+    const action = new SimElbV2Action(input, type);
+
+    action.validate(field);
+
+    return action;
+  }
+
+  /**
+   * Report this action in the shape the SDK reads it back in.
+   */
+  view(): SimElbV2ActionView {
+    return {
+      Type: this.type,
+      Order: this.order,
+      TargetGroupArn: this.input.TargetGroupArn,
+      ForwardConfig: this.input.ForwardConfig,
+      FixedResponseConfig: this.input.FixedResponseConfig,
+      RedirectConfig: this.input.RedirectConfig,
+    };
+  }
+
+  private validate(field: string): void {
+    if (this.type === "forward") {
+      this.validateForward(field);
+      return;
+    }
+
+    if (this.type === "fixed-response") {
+      this.validateFixedResponse(field);
+      return;
+    }
+
+    this.validateRedirect(field);
+  }
+
+  private validateForward(field: string): void {
+    if (this.targetGroupArns.length === 0) {
+      throw new SimElbV2ValidationError(
+        `${field} forward action requires a TargetGroupArn or a ` +
+          `ForwardConfig naming at least one target group`,
+      );
+    }
+  }
+
+  private validateFixedResponse(field: string): void {
+    const statusCode = this.input.FixedResponseConfig?.StatusCode;
+
+    if (statusCode === undefined || !/^[2-5]\d\d$/u.test(statusCode)) {
+      throw new SimElbV2ValidationError(
+        `${field} fixed-response action requires a FixedResponseConfig ` +
+          `StatusCode between 200 and 599`,
+      );
+    }
+  }
+
+  private validateRedirect(field: string): void {
+    const statusCode = this.input.RedirectConfig?.StatusCode;
+
+    if (statusCode === undefined || !redirectStatusCodes.has(statusCode)) {
+      throw new SimElbV2ValidationError(
+        `${field} redirect action requires a RedirectConfig StatusCode of ${[...redirectStatusCodes].join(" or ")}`,
+      );
+    }
+  }
+}

--- a/src/service/elbv2/command/authorize/sim-elbv2-authorizer.ts
+++ b/src/service/elbv2/command/authorize/sim-elbv2-authorizer.ts
@@ -1,0 +1,87 @@
+import type { SimAwsResolvedCaller } from "../../../aws/caller/sim-aws-caller-resolver.js";
+import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { SimIamCallerIdentifier } from "../../../iam/error/sim-iam-caller-identifier.js";
+import { SimElbV2AccessDeniedException } from "../../error/sim-elbv2.error.js";
+import type { SimElbV2RequestOptions } from "../sim-elbv2-request-options.js";
+
+/**
+ * The resource an action naming no particular resource authorizes against.
+ *
+ * `CreateLoadBalancer` and the describes name nothing that exists yet, so IAM
+ * evaluates them against `*` and only a policy whose Resource is `*` allows
+ * them.
+ */
+const noResource = "*";
+
+interface SimElbV2AuthorizerProperties {
+  readonly iam: SimIamInterServiceAuthZ;
+}
+
+/**
+ * Applies simulated IAM authorization to ELBv2 requests.
+ *
+ * ELBv2 has one action prefix for all four resources, and the resource an
+ * action names is the ARN of whichever of them it operates on, so one
+ * authorizer serves the whole service rather than one per command.
+ */
+export class SimElbV2Authorizer {
+  private static readonly actionPrefix = "elasticloadbalancing:";
+
+  private readonly iam: SimIamInterServiceAuthZ;
+  private readonly callerIdentifier = new SimIamCallerIdentifier();
+
+  constructor(properties: SimElbV2AuthorizerProperties) {
+    this.iam = properties.iam;
+  }
+
+  /**
+   * Ensure the caller may perform an operation on a resource, named by its
+   * ARN.
+   *
+   * The resource need not exist yet: `CreateListener` authorizes against the
+   * load balancer the listener is about to be created on.
+   */
+  authorize(
+    operation: string,
+    resourceArn: string,
+    options?: SimElbV2RequestOptions,
+  ): SimAwsResolvedCaller {
+    return this.decide(operation, resourceArn, options);
+  }
+
+  /**
+   * Ensure the caller may perform an operation naming no particular resource.
+   */
+  authorizeAnyResource(
+    operation: string,
+    options?: SimElbV2RequestOptions,
+  ): SimAwsResolvedCaller {
+    return this.decide(operation, noResource, options);
+  }
+
+  private decide(
+    operation: string,
+    resource: string,
+    options: SimElbV2RequestOptions | undefined,
+  ): SimAwsResolvedCaller {
+    const action = `${SimElbV2Authorizer.actionPrefix}${operation}`;
+    const decision = this.iam.authorize({
+      action,
+      resource,
+      caller: options?.caller,
+    });
+
+    if (decision.isDenied) {
+      const identifier = this.callerIdentifier.format(
+        decision.caller.principal,
+      );
+
+      throw new SimElbV2AccessDeniedException(
+        `User: ${identifier} is not authorized to perform: ${action} on ` +
+          `resource: ${resource}`,
+      );
+    }
+
+    return decision.caller;
+  }
+}

--- a/src/service/elbv2/command/authorize/sim-elbv2-iam.iso.test.ts
+++ b/src/service/elbv2/command/authorize/sim-elbv2-iam.iso.test.ts
@@ -1,0 +1,154 @@
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import {
+  CreateLoadBalancerCommand,
+  DeleteLoadBalancerCommand,
+  DescribeLoadBalancersCommand,
+} from "@aws-sdk/client-elastic-load-balancing-v2";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimElbV2AccessDeniedException } from "../../error/sim-elbv2.error.js";
+
+const accountId = "555555555555";
+const roleArn = `arn:aws:iam::${accountId}:role/DeployRole`;
+
+async function makeRole(simAws: SimAws, policy: object): Promise<void> {
+  const iam = simAws.account(accountId).iam();
+
+  await iam.createRole(
+    new CreateRoleCommand({
+      RoleName: "DeployRole",
+      AssumeRolePolicyDocument: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: {
+          Effect: "Allow",
+          Principal: { AWS: `arn:aws:iam::${accountId}:root` },
+          Action: "sts:AssumeRole",
+        },
+      }),
+    }),
+  );
+
+  await iam.putRolePolicy(
+    new PutRolePolicyCommand({
+      RoleName: "DeployRole",
+      PolicyName: "elb",
+      PolicyDocument: JSON.stringify(policy),
+    }),
+  );
+}
+
+describe("ELBv2 IAM authorization", () => {
+  it("allows the default Account root caller", async () => {
+    // Given simulated ELBv2 with no caller named.
+    const simAws = new SimAws();
+    const elbV2 = simAws.account(accountId).region("eu-west-1").elbV2();
+
+    // When a load balancer is created.
+    const output = await elbV2.createLoadBalancer(
+      new CreateLoadBalancerCommand({ Name: "shop-alb" }),
+    );
+
+    // Then IAM defaults to Account root and the request is allowed.
+    assertArrayLength(output.LoadBalancers, 1);
+    assertNonNullable(output.LoadBalancers[0].LoadBalancerArn);
+  });
+
+  it("refuses a caller whose policy does not allow the action", async () => {
+    // Given a Role allowed to describe load balancers but not create them.
+    const simAws = new SimAws();
+    const elbV2 = simAws.account(accountId).region("eu-west-1").elbV2();
+
+    await makeRole(simAws, {
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Action: "elasticloadbalancing:DescribeLoadBalancers",
+        Resource: "*",
+      },
+    });
+
+    const caller = { kind: "arn", arn: roleArn } as const;
+
+    // When that Role describes and then creates.
+    const described = await elbV2.describeLoadBalancers(
+      new DescribeLoadBalancersCommand({}),
+      { caller },
+    );
+
+    const error = await assertThrowsErrorAsync(async () => {
+      await elbV2.createLoadBalancer(
+        new CreateLoadBalancerCommand({ Name: "shop-alb" }),
+        { caller },
+      );
+    });
+
+    assertInstanceOf(error, SimElbV2AccessDeniedException);
+
+    // Then the describe is allowed and the create is refused by name.
+    assertIdentical(described.LoadBalancers?.length, 0);
+    assertStringIncludes(
+      error.message,
+      "elasticloadbalancing:CreateLoadBalancer",
+    );
+    assertStringIncludes(error.message, roleArn);
+  });
+
+  it("authorizes an operation against the ARN of the resource it names", async () => {
+    // Given a Role allowed to delete only one load balancer.
+    const simAws = new SimAws();
+    const elbV2 = simAws.account(accountId).region("eu-west-1").elbV2();
+
+    const allowed = await elbV2.createLoadBalancer(
+      new CreateLoadBalancerCommand({ Name: "allowed-alb" }),
+    );
+    const refused = await elbV2.createLoadBalancer(
+      new CreateLoadBalancerCommand({ Name: "refused-alb" }),
+    );
+
+    assertArrayLength(allowed.LoadBalancers, 1);
+    assertArrayLength(refused.LoadBalancers, 1);
+
+    const allowedArn = allowed.LoadBalancers[0].LoadBalancerArn;
+    const refusedArn = refused.LoadBalancers[0].LoadBalancerArn;
+    assertNonNullable(allowedArn);
+    assertNonNullable(refusedArn);
+
+    await makeRole(simAws, {
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Action: "elasticloadbalancing:DeleteLoadBalancer",
+        Resource: allowedArn,
+      },
+    });
+
+    const caller = { kind: "arn", arn: roleArn } as const;
+
+    // When the Role deletes each of them.
+    await elbV2.deleteLoadBalancer(
+      new DeleteLoadBalancerCommand({ LoadBalancerArn: allowedArn }),
+      { caller },
+    );
+
+    const error = await assertThrowsErrorAsync(async () => {
+      await elbV2.deleteLoadBalancer(
+        new DeleteLoadBalancerCommand({ LoadBalancerArn: refusedArn }),
+        { caller },
+      );
+    });
+
+    assertInstanceOf(error, SimElbV2AccessDeniedException);
+
+    // Then only the one its policy names could be deleted.
+    assertStringIncludes(error.message, refusedArn);
+  });
+});

--- a/src/service/elbv2/command/listener/create-listener.handler.ts
+++ b/src/service/elbv2/command/listener/create-listener.handler.ts
@@ -1,0 +1,95 @@
+import type { CommandHandler } from "../../../../command/command-handler.js";
+import { SimElbV2Action } from "../../action/sim-elbv2-action.js";
+import type { SimElbV2ActionTargets } from "../../action/sim-elbv2-action-targets.js";
+import { SimElbV2ValidationError } from "../../error/sim-elbv2.error.js";
+import { SimElbV2Listener } from "../../listener/sim-elbv2-listener.js";
+import { simElbV2Port, simElbV2Protocol } from "../../sim-elbv2-protocol.js";
+import { simElbV2ResourceId } from "../../sim-elbv2-resource-id.js";
+import {
+  SimElbV2CommandHandler,
+  type SimElbV2CommandHandlerProperties,
+} from "../sim-elbv2-command-handler.js";
+import type { SimElbV2RequestOptions } from "../sim-elbv2-request-options.js";
+import type {
+  SimCreateListenerCommand,
+  SimCreateListenerCommandOutput,
+} from "./listener.command.js";
+
+interface CreateListenerCommandHandlerProperties extends SimElbV2CommandHandlerProperties {
+  readonly actionTargets: SimElbV2ActionTargets;
+}
+
+/**
+ * Simulated ELBv2 CreateListenerCommand handler.
+ *
+ * https://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_CreateListener.html
+ */
+export class CreateListenerCommandHandler
+  extends SimElbV2CommandHandler
+  implements
+    CommandHandler<SimCreateListenerCommand, SimCreateListenerCommandOutput>
+{
+  private readonly actionTargets: SimElbV2ActionTargets;
+
+  constructor(properties: CreateListenerCommandHandlerProperties) {
+    super(properties);
+    this.actionTargets = properties.actionTargets;
+  }
+
+  /**
+   * Create a listener on a load balancer.
+   *
+   * The listener is authorized against the load balancer it goes on, because
+   * that is the resource the request names and the resource an IAM policy
+   * would be written about.
+   */
+  async handle(
+    command: SimCreateListenerCommand,
+    options?: SimElbV2RequestOptions,
+  ): Promise<SimCreateListenerCommandOutput> {
+    const { input } = command;
+
+    if (input.LoadBalancerArn === undefined) {
+      throw new SimElbV2ValidationError("LoadBalancerArn is required");
+    }
+
+    if (input.Protocol === undefined || input.Port === undefined) {
+      throw new SimElbV2ValidationError(
+        "A listener requires a Protocol and a Port",
+      );
+    }
+
+    const protocol = simElbV2Protocol("Protocol", input.Protocol);
+    const port = simElbV2Port("Port", input.Port);
+    const defaultActions = SimElbV2Action.readAll(
+      input.DefaultActions,
+      "DefaultActions",
+    );
+
+    // Allow for potential non-deterministic sequencing of async events.
+    await this.background.sequence();
+
+    this.authorizer.authorize("CreateListener", input.LoadBalancerArn, options);
+
+    const loadBalancer = this.stores.loadBalancers.requireByArn(
+      input.LoadBalancerArn,
+    );
+
+    this.actionTargets.requireTargetGroups(defaultActions);
+    this.stores.listeners.requirePortAvailable(loadBalancer.arn, port);
+
+    const listener = new SimElbV2Listener({
+      loadBalancerArn: loadBalancer.arn,
+      id: simElbV2ResourceId(this.stores.listeners.nextSequence()),
+      port,
+      protocol,
+      sslPolicy: input.SslPolicy,
+      certificates: input.Certificates ?? [],
+      defaultActions,
+    });
+
+    this.stores.listeners.put(listener);
+
+    return { $metadata: {}, Listeners: [listener.view()] };
+  }
+}

--- a/src/service/elbv2/command/listener/delete-listener.handler.ts
+++ b/src/service/elbv2/command/listener/delete-listener.handler.ts
@@ -1,0 +1,46 @@
+import type { CommandHandler } from "../../../../command/command-handler.js";
+import { SimElbV2ValidationError } from "../../error/sim-elbv2.error.js";
+import { SimElbV2CommandHandler } from "../sim-elbv2-command-handler.js";
+import type { SimElbV2RequestOptions } from "../sim-elbv2-request-options.js";
+import type {
+  SimDeleteListenerCommand,
+  SimDeleteListenerCommandOutput,
+} from "./listener.command.js";
+
+/**
+ * Simulated ELBv2 DeleteListenerCommand handler.
+ *
+ * https://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_DeleteListener.html
+ */
+export class DeleteListenerCommandHandler
+  extends SimElbV2CommandHandler
+  implements
+    CommandHandler<SimDeleteListenerCommand, SimDeleteListenerCommandOutput>
+{
+  /**
+   * Delete a listener and the rules written on it.
+   *
+   * The rules go because they cannot exist without it: a rule ARN is built
+   * from a listener ARN, and there is nothing for one to be evaluated by once
+   * the listener is gone.
+   */
+  async handle(
+    command: SimDeleteListenerCommand,
+    options?: SimElbV2RequestOptions,
+  ): Promise<SimDeleteListenerCommandOutput> {
+    const listenerArn = command.input.ListenerArn;
+
+    if (listenerArn === undefined) {
+      throw new SimElbV2ValidationError("ListenerArn is required");
+    }
+
+    // Allow for potential non-deterministic sequencing of async events.
+    await this.background.sequence();
+
+    this.authorizer.authorize("DeleteListener", listenerArn, options);
+
+    this.stores.deleteListener(this.stores.listeners.requireByArn(listenerArn));
+
+    return { $metadata: {} };
+  }
+}

--- a/src/service/elbv2/command/listener/describe-listeners.handler.ts
+++ b/src/service/elbv2/command/listener/describe-listeners.handler.ts
@@ -1,0 +1,109 @@
+import type { CommandHandler } from "../../../../command/command-handler.js";
+import { SimElbV2ValidationError } from "../../error/sim-elbv2.error.js";
+import type { SimElbV2Listener } from "../../listener/sim-elbv2-listener.js";
+import { SimElbV2Page } from "../sim-elbv2-page.js";
+import { SimElbV2CommandHandler } from "../sim-elbv2-command-handler.js";
+import type { SimElbV2RequestOptions } from "../sim-elbv2-request-options.js";
+import type {
+  SimDescribeListenersCommand,
+  SimDescribeListenersCommandInput,
+  SimDescribeListenersCommandOutput,
+} from "./listener.command.js";
+
+/**
+ * Which listeners a describe named, resolved to one of the two ways.
+ */
+type SimElbV2ListenerSelector =
+  | {
+      readonly listenerArns: readonly string[];
+      readonly loadBalancerArn?: undefined;
+    }
+  | { readonly listenerArns?: undefined; readonly loadBalancerArn: string };
+
+/**
+ * Simulated ELBv2 DescribeListenersCommand handler.
+ *
+ * https://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_DescribeListeners.html
+ */
+export class DescribeListenersCommandHandler
+  extends SimElbV2CommandHandler
+  implements
+    CommandHandler<
+      SimDescribeListenersCommand,
+      SimDescribeListenersCommandOutput
+    >
+{
+  /**
+   * Read which of the two ways of naming listeners a request used.
+   *
+   * Real ELB requires exactly one of them, and answering with the resolved
+   * choice rather than with nothing is what keeps the reading of it in one
+   * place instead of split between a check and a later re-read.
+   */
+  private static readSelector(
+    input: SimDescribeListenersCommandInput,
+  ): SimElbV2ListenerSelector {
+    if (
+      input.ListenerArns !== undefined &&
+      input.LoadBalancerArn === undefined
+    ) {
+      return { listenerArns: input.ListenerArns };
+    }
+
+    if (
+      input.LoadBalancerArn !== undefined &&
+      input.ListenerArns === undefined
+    ) {
+      return { loadBalancerArn: input.LoadBalancerArn };
+    }
+
+    throw new SimElbV2ValidationError(
+      "DescribeListeners takes either ListenerArns or LoadBalancerArn",
+    );
+  }
+
+  /**
+   * Describe the listeners a request names, or those on one load balancer.
+   */
+  async handle(
+    command: SimDescribeListenersCommand,
+    options?: SimElbV2RequestOptions,
+  ): Promise<SimDescribeListenersCommandOutput> {
+    const { input } = command;
+
+    const selector = DescribeListenersCommandHandler.readSelector(input);
+
+    // Allow for potential non-deterministic sequencing of async events.
+    await this.background.sequence();
+
+    this.authorizer.authorizeAnyResource("DescribeListeners", options);
+
+    const page = new SimElbV2Page(
+      this.selected(selector),
+      input.PageSize,
+      input.Marker,
+    );
+
+    return {
+      $metadata: {},
+      Listeners: page.items.map((listener) => listener.view()),
+      NextMarker: page.nextMarker,
+    };
+  }
+
+  private selected(
+    selector: SimElbV2ListenerSelector,
+  ): readonly SimElbV2Listener[] {
+    if (selector.listenerArns === undefined) {
+      const loadBalancer = this.stores.loadBalancers.requireByArn(
+        selector.loadBalancerArn,
+      );
+
+      return this.stores.listeners.forLoadBalancer(loadBalancer.arn);
+    }
+
+    return selector.listenerArns.map((arn) =>
+      this.stores.listeners.requireByArn(arn),
+    );
+  }
+}

--- a/src/service/elbv2/command/listener/listener.command.ts
+++ b/src/service/elbv2/command/listener/listener.command.ts
@@ -1,0 +1,111 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type { SimElbV2ListenerView } from "../../listener/sim-elbv2-listener.js";
+import type {
+  SimElbV2ActionInput,
+  SimElbV2Certificate,
+  SimElbV2Tag,
+} from "../sim-elbv2-shared.command.js";
+
+/**
+ * Minimal structural sim ELBv2 CreateListener command.
+ */
+export interface SimCreateListenerCommand {
+  readonly input: SimCreateListenerCommandInput;
+}
+
+/**
+ * Minimal structural sim ELBv2 CreateListener input.
+ *
+ * https://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_CreateListener.html
+ */
+export interface SimCreateListenerCommandInput {
+  readonly LoadBalancerArn?: string | undefined;
+  readonly Protocol?: string | undefined;
+  readonly Port?: number | undefined;
+  readonly SslPolicy?: string | undefined;
+  readonly Certificates?: readonly SimElbV2Certificate[] | undefined;
+  readonly DefaultActions?: readonly SimElbV2ActionInput[] | undefined;
+  readonly Tags?: readonly SimElbV2Tag[] | undefined;
+}
+
+/**
+ * Minimal structural sim ELBv2 CreateListener output.
+ */
+export interface SimCreateListenerCommandOutput {
+  readonly Listeners?: readonly SimElbV2ListenerView[] | undefined;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim ELBv2 DescribeListeners command.
+ */
+export interface SimDescribeListenersCommand {
+  readonly input: SimDescribeListenersCommandInput;
+}
+
+/**
+ * Minimal structural sim ELBv2 DescribeListeners input.
+ */
+export interface SimDescribeListenersCommandInput {
+  readonly LoadBalancerArn?: string | undefined;
+  readonly ListenerArns?: readonly string[] | undefined;
+  readonly Marker?: string | undefined;
+  readonly PageSize?: number | undefined;
+}
+
+/**
+ * Minimal structural sim ELBv2 DescribeListeners output.
+ */
+export interface SimDescribeListenersCommandOutput {
+  readonly Listeners?: readonly SimElbV2ListenerView[] | undefined;
+  readonly NextMarker?: string | undefined;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim ELBv2 ModifyListener command.
+ */
+export interface SimModifyListenerCommand {
+  readonly input: SimModifyListenerCommandInput;
+}
+
+/**
+ * Minimal structural sim ELBv2 ModifyListener input.
+ */
+export interface SimModifyListenerCommandInput {
+  readonly ListenerArn?: string | undefined;
+  readonly Protocol?: string | undefined;
+  readonly Port?: number | undefined;
+  readonly SslPolicy?: string | undefined;
+  readonly Certificates?: readonly SimElbV2Certificate[] | undefined;
+  readonly DefaultActions?: readonly SimElbV2ActionInput[] | undefined;
+}
+
+/**
+ * Minimal structural sim ELBv2 ModifyListener output.
+ */
+export interface SimModifyListenerCommandOutput {
+  readonly Listeners?: readonly SimElbV2ListenerView[] | undefined;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim ELBv2 DeleteListener command.
+ */
+export interface SimDeleteListenerCommand {
+  readonly input: SimDeleteListenerCommandInput;
+}
+
+/**
+ * Minimal structural sim ELBv2 DeleteListener input.
+ */
+export interface SimDeleteListenerCommandInput {
+  readonly ListenerArn?: string | undefined;
+}
+
+/**
+ * Minimal structural sim ELBv2 DeleteListener output.
+ */
+export interface SimDeleteListenerCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/elbv2/command/listener/listener.iso.test.ts
+++ b/src/service/elbv2/command/listener/listener.iso.test.ts
@@ -183,7 +183,7 @@ describe("ELBv2 listeners", () => {
     // Then each is refused.
     assertStringIncludes(noLoadBalancer.message, "LoadBalancerArn is required");
     assertStringIncludes(noPort.message, "Protocol and a Port");
-    assertStringIncludes(networkProtocol.message, "not simulated");
+    assertStringIncludes(networkProtocol.message, "neither is simulated");
   });
 
   it("describes listeners by load balancer and by ARN, and refuses both at once", async () => {

--- a/src/service/elbv2/command/listener/listener.iso.test.ts
+++ b/src/service/elbv2/command/listener/listener.iso.test.ts
@@ -1,0 +1,287 @@
+import {
+  CreateListenerCommand,
+  DeleteListenerCommand,
+  DescribeListenersCommand,
+  DescribeRulesCommand,
+} from "@aws-sdk/client-elastic-load-balancing-v2";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import {
+  SimElbV2DuplicateListenerException,
+  SimElbV2InvalidConfigurationRequestException,
+  SimElbV2ListenerNotFoundException,
+  SimElbV2TargetGroupNotFoundException,
+  SimElbV2UnsimulatedInputException,
+  SimElbV2ValidationError,
+} from "../../error/sim-elbv2.error.js";
+import {
+  createFixtureLambdaTargetGroup,
+  createFixtureListener,
+  createFixtureLoadBalancer,
+  createFixtureRule,
+} from "../../sim-elbv2.fixture.js";
+
+const certificateArn =
+  "arn:aws:acm:eu-west-1:888888888888:certificate/00000001";
+
+describe("ELBv2 listeners", () => {
+  it("creates an HTTP listener whose ARN is built from its load balancer's", async () => {
+    // Given a load balancer and a target group.
+    const simAws = new SimAws();
+    const elbV2 = simAws.account("555555555555").region("eu-west-1").elbV2();
+    const loadBalancerArn = await createFixtureLoadBalancer(elbV2);
+    const targetGroupArn = await createFixtureLambdaTargetGroup(elbV2);
+
+    // When a listener is created on it.
+    const output = await elbV2.createListener(
+      new CreateListenerCommand({
+        LoadBalancerArn: loadBalancerArn,
+        Protocol: "HTTP",
+        Port: 80,
+        DefaultActions: [{ Type: "forward", TargetGroupArn: targetGroupArn }],
+      }),
+    );
+
+    // Then the ARN names the load balancer and the listener.
+    assertArrayLength(output.Listeners, 1);
+
+    const listener = output.Listeners[0];
+    assertIdentical(
+      listener.ListenerArn,
+      "arn:aws:elasticloadbalancing:eu-west-1:555555555555:listener/app/" +
+        "shop-alb/0000000000000001/0000000000000001",
+    );
+    assertIdentical(listener.Port, 80);
+    assertUndefined(listener.SslPolicy);
+    assertArrayLength(listener.DefaultActions, 1);
+    assertIdentical(listener.DefaultActions[0].TargetGroupArn, targetGroupArn);
+  });
+
+  it("gives an HTTPS listener a security policy, and refuses one with no certificate", async () => {
+    // Given a load balancer and a target group.
+    const simAws = new SimAws();
+    const elbV2 = simAws.elbV2();
+    const loadBalancerArn = await createFixtureLoadBalancer(elbV2);
+    const targetGroupArn = await createFixtureLambdaTargetGroup(elbV2);
+
+    // When an HTTPS listener is created with and without a certificate.
+    const output = await elbV2.createListener(
+      new CreateListenerCommand({
+        LoadBalancerArn: loadBalancerArn,
+        Protocol: "HTTPS",
+        Port: 443,
+        Certificates: [{ CertificateArn: certificateArn }],
+        DefaultActions: [{ Type: "forward", TargetGroupArn: targetGroupArn }],
+      }),
+    );
+
+    const error = await assertThrowsErrorAsync(async () => {
+      await elbV2.createListener(
+        new CreateListenerCommand({
+          LoadBalancerArn: loadBalancerArn,
+          Protocol: "HTTPS",
+          Port: 8443,
+          DefaultActions: [{ Type: "forward", TargetGroupArn: targetGroupArn }],
+        }),
+      );
+    });
+
+    assertInstanceOf(error, SimElbV2InvalidConfigurationRequestException);
+
+    // Then the one with a certificate got a policy and the other was refused.
+    assertArrayLength(output.Listeners, 1);
+    assertIdentical(output.Listeners[0].SslPolicy, "ELBSecurityPolicy-2016-08");
+    assertStringIncludes(error.message, "at least one certificate");
+  });
+
+  it("refuses a second listener on the same port", async () => {
+    // Given a load balancer already listening on port 80.
+    const simAws = new SimAws();
+    const elbV2 = simAws.elbV2();
+    const loadBalancerArn = await createFixtureLoadBalancer(elbV2);
+    const targetGroupArn = await createFixtureLambdaTargetGroup(elbV2);
+
+    await createFixtureListener(elbV2, loadBalancerArn, targetGroupArn);
+
+    // When another listener is created on the same port.
+    const error = await assertThrowsErrorAsync(async () => {
+      await createFixtureListener(elbV2, loadBalancerArn, targetGroupArn);
+    });
+
+    assertInstanceOf(error, SimElbV2DuplicateListenerException);
+
+    // Then it is refused.
+    assertStringIncludes(error.message, "port 80");
+  });
+
+  it("refuses a listener whose forward action names nothing that exists", async () => {
+    // Given a load balancer.
+    const simAws = new SimAws();
+    const elbV2 = simAws.elbV2();
+    const loadBalancerArn = await createFixtureLoadBalancer(elbV2);
+
+    // When a listener forwards to a target group that was never created.
+    const error = await assertThrowsErrorAsync(async () => {
+      await elbV2.createListener(
+        new CreateListenerCommand({
+          LoadBalancerArn: loadBalancerArn,
+          Protocol: "HTTP",
+          Port: 80,
+          DefaultActions: [{ Type: "forward", TargetGroupArn: "arn:missing" }],
+        }),
+      );
+    });
+
+    assertInstanceOf(error, SimElbV2TargetGroupNotFoundException);
+
+    // Then it is refused when written rather than when a request arrives.
+    assertStringIncludes(error.message, "arn:missing");
+  });
+
+  it("refuses a listener request that leaves out what it has to name", async () => {
+    // Given a load balancer.
+    const simAws = new SimAws();
+    const elbV2 = simAws.elbV2();
+    const loadBalancerArn = await createFixtureLoadBalancer(elbV2);
+
+    // When requests leave out a load balancer, a port and a protocol.
+    const noLoadBalancer = await assertThrowsErrorAsync(async () => {
+      await elbV2.createListener({ input: {} });
+    });
+
+    assertInstanceOf(noLoadBalancer, SimElbV2ValidationError);
+
+    const noPort = await assertThrowsErrorAsync(async () => {
+      await elbV2.createListener({
+        input: { LoadBalancerArn: loadBalancerArn, Protocol: "HTTP" },
+      });
+    });
+
+    assertInstanceOf(noPort, SimElbV2ValidationError);
+
+    const networkProtocol = await assertThrowsErrorAsync(async () => {
+      await elbV2.createListener({
+        input: {
+          LoadBalancerArn: loadBalancerArn,
+          Protocol: "TLS",
+          Port: 443,
+        },
+      });
+    });
+
+    assertInstanceOf(networkProtocol, SimElbV2UnsimulatedInputException);
+
+    // Then each is refused.
+    assertStringIncludes(noLoadBalancer.message, "LoadBalancerArn is required");
+    assertStringIncludes(noPort.message, "Protocol and a Port");
+    assertStringIncludes(networkProtocol.message, "not simulated");
+  });
+
+  it("describes listeners by load balancer and by ARN, and refuses both at once", async () => {
+    // Given a load balancer with one listener.
+    const simAws = new SimAws();
+    const elbV2 = simAws.elbV2();
+    const loadBalancerArn = await createFixtureLoadBalancer(elbV2);
+    const targetGroupArn = await createFixtureLambdaTargetGroup(elbV2);
+    const listenerArn = await createFixtureListener(
+      elbV2,
+      loadBalancerArn,
+      targetGroupArn,
+    );
+
+    // When it is described each way, and then both ways at once.
+    const byLoadBalancer = await elbV2.describeListeners(
+      new DescribeListenersCommand({ LoadBalancerArn: loadBalancerArn }),
+    );
+    const byArn = await elbV2.describeListeners(
+      new DescribeListenersCommand({ ListenerArns: [listenerArn] }),
+    );
+    const error = await assertThrowsErrorAsync(async () => {
+      await elbV2.describeListeners({ input: {} });
+    });
+
+    assertInstanceOf(error, SimElbV2ValidationError);
+
+    // Then each way answers and naming neither is refused.
+    assertArrayLength(byLoadBalancer.Listeners, 1);
+    assertArrayLength(byArn.Listeners, 1);
+    assertIdentical(byArn.Listeners[0].ListenerArn, listenerArn);
+    assertStringIncludes(error.message, "either ListenerArns");
+  });
+
+  it("refuses a modify or delete naming no listener, or one that is gone", async () => {
+    // Given simulated ELBv2.
+    const simAws = new SimAws();
+    const elbV2 = simAws.elbV2();
+
+    // When a modify and a delete leave out the ARN, or name an unknown one.
+    const noModifyArn = await assertThrowsErrorAsync(async () => {
+      await elbV2.modifyListener({ input: {} });
+    });
+
+    assertInstanceOf(noModifyArn, SimElbV2ValidationError);
+
+    const noDeleteArn = await assertThrowsErrorAsync(async () => {
+      await elbV2.deleteListener({ input: {} });
+    });
+
+    assertInstanceOf(noDeleteArn, SimElbV2ValidationError);
+
+    const unknown = await assertThrowsErrorAsync(async () => {
+      await elbV2.deleteListener(
+        new DeleteListenerCommand({ ListenerArn: "arn:missing" }),
+      );
+    });
+
+    assertInstanceOf(unknown, SimElbV2ListenerNotFoundException);
+
+    // Then each is refused.
+    assertStringIncludes(noModifyArn.message, "ListenerArn is required");
+    assertStringIncludes(noDeleteArn.message, "ListenerArn is required");
+    assertStringIncludes(unknown.message, "arn:missing");
+  });
+
+  it("takes a listener's rules with it when it is deleted", async () => {
+    // Given a listener with a rule on it.
+    const simAws = new SimAws();
+    const elbV2 = simAws.elbV2();
+    const loadBalancerArn = await createFixtureLoadBalancer(elbV2);
+    const targetGroupArn = await createFixtureLambdaTargetGroup(elbV2);
+    const listenerArn = await createFixtureListener(
+      elbV2,
+      loadBalancerArn,
+      targetGroupArn,
+    );
+    const ruleArn = await createFixtureRule(
+      elbV2,
+      listenerArn,
+      10,
+      targetGroupArn,
+    );
+
+    // When the listener is deleted.
+    await elbV2.deleteListener(
+      new DeleteListenerCommand({ ListenerArn: listenerArn }),
+    );
+
+    // Then its rule went with it.
+    const error = await assertThrowsErrorAsync(async () => {
+      await elbV2.describeRules(
+        new DescribeRulesCommand({ RuleArns: [ruleArn] }),
+      );
+    });
+
+    assertInstanceOf(error, Error);
+
+    assertStringIncludes(error.message, ruleArn);
+  });
+});

--- a/src/service/elbv2/command/listener/modify-listener.handler.ts
+++ b/src/service/elbv2/command/listener/modify-listener.handler.ts
@@ -1,0 +1,98 @@
+import type { CommandHandler } from "../../../../command/command-handler.js";
+import { SimElbV2Action } from "../../action/sim-elbv2-action.js";
+import type { SimElbV2ActionTargets } from "../../action/sim-elbv2-action-targets.js";
+import { SimElbV2ValidationError } from "../../error/sim-elbv2.error.js";
+import type { SimElbV2ListenerChanges } from "../../listener/sim-elbv2-listener.js";
+import { simElbV2Port, simElbV2Protocol } from "../../sim-elbv2-protocol.js";
+import {
+  SimElbV2CommandHandler,
+  type SimElbV2CommandHandlerProperties,
+} from "../sim-elbv2-command-handler.js";
+import type { SimElbV2RequestOptions } from "../sim-elbv2-request-options.js";
+import type {
+  SimModifyListenerCommand,
+  SimModifyListenerCommandInput,
+  SimModifyListenerCommandOutput,
+} from "./listener.command.js";
+
+interface ModifyListenerCommandHandlerProperties extends SimElbV2CommandHandlerProperties {
+  readonly actionTargets: SimElbV2ActionTargets;
+}
+
+/**
+ * Simulated ELBv2 ModifyListenerCommand handler.
+ *
+ * https://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_ModifyListener.html
+ */
+export class ModifyListenerCommandHandler
+  extends SimElbV2CommandHandler
+  implements
+    CommandHandler<SimModifyListenerCommand, SimModifyListenerCommandOutput>
+{
+  private readonly actionTargets: SimElbV2ActionTargets;
+
+  constructor(properties: ModifyListenerCommandHandlerProperties) {
+    super(properties);
+    this.actionTargets = properties.actionTargets;
+  }
+
+  private static readChanges(
+    input: SimModifyListenerCommandInput,
+  ): SimElbV2ListenerChanges {
+    return {
+      port:
+        input.Port === undefined ? undefined : simElbV2Port("Port", input.Port),
+      protocol:
+        input.Protocol === undefined
+          ? undefined
+          : simElbV2Protocol("Protocol", input.Protocol),
+      sslPolicy: input.SslPolicy,
+      certificates: input.Certificates,
+      defaultActions:
+        input.DefaultActions === undefined
+          ? undefined
+          : SimElbV2Action.readAll(input.DefaultActions, "DefaultActions"),
+    };
+  }
+
+  /**
+   * Change what a request names on a listener, leaving the rest as it was.
+   *
+   * The port is checked against the other listeners on the same load balancer
+   * before anything changes, so a request moving a listener onto a port
+   * another one holds leaves both where they were.
+   */
+  async handle(
+    command: SimModifyListenerCommand,
+    options?: SimElbV2RequestOptions,
+  ): Promise<SimModifyListenerCommandOutput> {
+    const { input } = command;
+
+    if (input.ListenerArn === undefined) {
+      throw new SimElbV2ValidationError("ListenerArn is required");
+    }
+
+    const changes = ModifyListenerCommandHandler.readChanges(input);
+
+    // Allow for potential non-deterministic sequencing of async events.
+    await this.background.sequence();
+
+    this.authorizer.authorize("ModifyListener", input.ListenerArn, options);
+
+    const listener = this.stores.listeners.requireByArn(input.ListenerArn);
+
+    this.actionTargets.requireTargetGroups(changes.defaultActions ?? []);
+
+    if (changes.port !== undefined) {
+      this.stores.listeners.requirePortAvailable(
+        listener.loadBalancerArn,
+        changes.port,
+        listener,
+      );
+    }
+
+    listener.modify(changes);
+
+    return { $metadata: {}, Listeners: [listener.view()] };
+  }
+}

--- a/src/service/elbv2/command/listener/modify-listener.iso.test.ts
+++ b/src/service/elbv2/command/listener/modify-listener.iso.test.ts
@@ -1,0 +1,137 @@
+import {
+  CreateListenerCommand,
+  ModifyListenerCommand,
+} from "@aws-sdk/client-elastic-load-balancing-v2";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimElbV2DuplicateListenerException } from "../../error/sim-elbv2.error.js";
+import {
+  createFixtureLambdaTargetGroup,
+  createFixtureListener,
+  createFixtureLoadBalancer,
+} from "../../sim-elbv2.fixture.js";
+
+const certificateArn =
+  "arn:aws:acm:eu-west-1:888888888888:certificate/00000001";
+
+describe("ELBv2 ModifyListenerCommand", () => {
+  it("changes only what a modify names", async () => {
+    // Given an HTTP listener on port 80.
+    const simAws = new SimAws();
+    const elbV2 = simAws.elbV2();
+    const loadBalancerArn = await createFixtureLoadBalancer(elbV2);
+    const targetGroupArn = await createFixtureLambdaTargetGroup(elbV2);
+    const listenerArn = await createFixtureListener(
+      elbV2,
+      loadBalancerArn,
+      targetGroupArn,
+    );
+
+    // When it is moved to HTTPS on 443 with a certificate in one request.
+    const output = await elbV2.modifyListener(
+      new ModifyListenerCommand({
+        ListenerArn: listenerArn,
+        Protocol: "HTTPS",
+        Port: 443,
+        Certificates: [{ CertificateArn: certificateArn }],
+        DefaultActions: [
+          {
+            Type: "fixed-response",
+            FixedResponseConfig: { StatusCode: "404" },
+          },
+        ],
+      }),
+    );
+
+    // Then the change took, and its default actions came with it.
+    assertArrayLength(output.Listeners, 1);
+
+    const listener = output.Listeners[0];
+    assertIdentical(listener.Protocol, "HTTPS");
+    assertIdentical(listener.Port, 443);
+    assertArrayLength(listener.DefaultActions, 1);
+    assertIdentical(listener.DefaultActions[0].Type, "fixed-response");
+  });
+
+  it("leaves a listener alone but for the one setting a modify names", async () => {
+    // Given an HTTPS listener.
+    const simAws = new SimAws();
+    const elbV2 = simAws.elbV2();
+    const loadBalancerArn = await createFixtureLoadBalancer(elbV2);
+    const targetGroupArn = await createFixtureLambdaTargetGroup(elbV2);
+    const created = await elbV2.createListener(
+      new CreateListenerCommand({
+        LoadBalancerArn: loadBalancerArn,
+        Protocol: "HTTPS",
+        Port: 443,
+        Certificates: [{ CertificateArn: certificateArn }],
+        DefaultActions: [{ Type: "forward", TargetGroupArn: targetGroupArn }],
+      }),
+    );
+
+    assertArrayLength(created.Listeners, 1);
+
+    const listenerArn = created.Listeners[0].ListenerArn;
+
+    // When only the security policy is changed.
+    const output = await elbV2.modifyListener(
+      new ModifyListenerCommand({
+        ListenerArn: listenerArn,
+        SslPolicy: "ELBSecurityPolicy-TLS13-1-2-2021-06",
+      }),
+    );
+
+    // Then everything else stayed as it was.
+    assertArrayLength(output.Listeners, 1);
+    assertIdentical(
+      output.Listeners[0].SslPolicy,
+      "ELBSecurityPolicy-TLS13-1-2-2021-06",
+    );
+    assertIdentical(output.Listeners[0].Port, 443);
+    assertIdentical(output.Listeners[0].Protocol, "HTTPS");
+    assertArrayLength(output.Listeners[0].DefaultActions, 1);
+    assertIdentical(output.Listeners[0].DefaultActions[0].Type, "forward");
+  });
+
+  it("refuses a modify onto a port another listener holds", async () => {
+    // Given two listeners on one load balancer.
+    const simAws = new SimAws();
+    const elbV2 = simAws.elbV2();
+    const loadBalancerArn = await createFixtureLoadBalancer(elbV2);
+    const targetGroupArn = await createFixtureLambdaTargetGroup(elbV2);
+    const listenerArn = await createFixtureListener(
+      elbV2,
+      loadBalancerArn,
+      targetGroupArn,
+      80,
+    );
+
+    await createFixtureListener(elbV2, loadBalancerArn, targetGroupArn, 8080);
+
+    // When the first is moved onto the second's port, and then onto its own.
+    const error = await assertThrowsErrorAsync(async () => {
+      await elbV2.modifyListener(
+        new ModifyListenerCommand({ ListenerArn: listenerArn, Port: 8080 }),
+      );
+    });
+
+    assertInstanceOf(error, SimElbV2DuplicateListenerException);
+
+    const unchanged = await elbV2.modifyListener(
+      new ModifyListenerCommand({ ListenerArn: listenerArn, Port: 80 }),
+    );
+
+    // Then the clash is refused and staying put is not a clash with itself.
+    assertStringIncludes(error.message, "port 8080");
+    assertArrayLength(unchanged.Listeners, 1);
+    assertIdentical(unchanged.Listeners[0].Port, 80);
+  });
+});

--- a/src/service/elbv2/command/load-balancer/create-load-balancer-validator.ts
+++ b/src/service/elbv2/command/load-balancer/create-load-balancer-validator.ts
@@ -1,0 +1,43 @@
+import {
+  SimElbV2UnsimulatedInputException,
+  SimElbV2ValidationError,
+} from "../../error/sim-elbv2.error.js";
+import type { SimCreateLoadBalancerCommandInput } from "./load-balancer.command.js";
+
+/**
+ * The addressing real ELB takes on an application load balancer.
+ */
+const simulatedIpAddressTypes = new Set(["ipv4", "dualstack"]);
+
+/**
+ * Refuse a load balancer this simulation does not have.
+ *
+ * Only the application type is simulated. A network or gateway load balancer
+ * routes at a layer nothing here speaks, so creating one and reporting it as
+ * an application load balancer would be worse than refusing it.
+ *
+ * These checks run before background sequencing and IAM authorization, so a
+ * malformed request stays a client error rather than producing an
+ * authorization result, as it does on real ELB.
+ */
+export function validateSimElbV2LoadBalancerRequest(
+  input: SimCreateLoadBalancerCommandInput,
+): void {
+  if (input.Type !== undefined && input.Type !== "application") {
+    throw new SimElbV2UnsimulatedInputException(
+      `Type '${input.Type}' is not simulated. Only the application load ` +
+        `balancer is, so a network or gateway load balancer is refused ` +
+        `rather than created as an application one.`,
+    );
+  }
+
+  if (
+    input.IpAddressType !== undefined &&
+    !simulatedIpAddressTypes.has(input.IpAddressType)
+  ) {
+    throw new SimElbV2ValidationError(
+      `IpAddressType '${input.IpAddressType}' is not valid. An address type ` +
+        `is ${[...simulatedIpAddressTypes].join(" or ")}.`,
+    );
+  }
+}

--- a/src/service/elbv2/command/load-balancer/create-load-balancer.handler.ts
+++ b/src/service/elbv2/command/load-balancer/create-load-balancer.handler.ts
@@ -1,0 +1,85 @@
+import type { CommandHandler } from "../../../../command/command-handler.js";
+import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
+import { validateSimElbV2LoadBalancerRequest } from "./create-load-balancer-validator.js";
+import { simElbV2LoadBalancerName } from "../../load-balancer/sim-elbv2-load-balancer-name.js";
+import { simElbV2LoadBalancerScheme } from "../../load-balancer/sim-elbv2-load-balancer-scheme.js";
+import { SimElbV2LoadBalancer } from "../../load-balancer/sim-elbv2-load-balancer.js";
+import {
+  simElbV2DnsSuffix,
+  simElbV2ResourceId,
+} from "../../sim-elbv2-resource-id.js";
+import {
+  SimElbV2CommandHandler,
+  type SimElbV2CommandHandlerProperties,
+} from "../sim-elbv2-command-handler.js";
+import type { SimElbV2RequestOptions } from "../sim-elbv2-request-options.js";
+import type {
+  SimCreateLoadBalancerCommand,
+  SimCreateLoadBalancerCommandOutput,
+} from "./load-balancer.command.js";
+
+interface CreateLoadBalancerCommandHandlerProperties extends SimElbV2CommandHandlerProperties {
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+}
+
+/**
+ * Simulated ELBv2 CreateLoadBalancerCommand handler.
+ *
+ * https://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_CreateLoadBalancer.html
+ */
+export class CreateLoadBalancerCommandHandler
+  extends SimElbV2CommandHandler
+  implements
+    CommandHandler<
+      SimCreateLoadBalancerCommand,
+      SimCreateLoadBalancerCommandOutput
+    >
+{
+  private readonly accountRegionScope: SimAwsAccountRegionScope;
+
+  constructor(properties: CreateLoadBalancerCommandHandlerProperties) {
+    super(properties);
+    this.accountRegionScope = properties.accountRegionScope;
+  }
+
+  /**
+   * Create an Application Load Balancer and report the DNS name it answers on.
+   *
+   * The name is checked before authorization so a malformed request stays a
+   * client error, as it is on real ELB, and nothing is stored before the
+   * caller has been allowed to store it.
+   */
+  async handle(
+    command: SimCreateLoadBalancerCommand,
+    options?: SimElbV2RequestOptions,
+  ): Promise<SimCreateLoadBalancerCommandOutput> {
+    const { input } = command;
+
+    validateSimElbV2LoadBalancerRequest(input);
+
+    const name = simElbV2LoadBalancerName(input.Name);
+    const scheme = simElbV2LoadBalancerScheme(input.Scheme);
+
+    // Allow for potential non-deterministic sequencing of async events.
+    await this.background.sequence();
+
+    this.authorizer.authorizeAnyResource("CreateLoadBalancer", options);
+
+    this.stores.loadBalancers.requireNameAvailable(name);
+
+    const sequence = this.stores.loadBalancers.nextSequence();
+    const loadBalancer = new SimElbV2LoadBalancer({
+      name,
+      scheme,
+      ipAddressType: input.IpAddressType ?? "ipv4",
+      id: simElbV2ResourceId(sequence),
+      dnsSuffix: simElbV2DnsSuffix(sequence),
+      createdTime: this.background.now(),
+      accountRegionScope: this.accountRegionScope,
+    });
+
+    this.stores.loadBalancers.put(loadBalancer);
+
+    return { $metadata: {}, LoadBalancers: [loadBalancer.view()] };
+  }
+}

--- a/src/service/elbv2/command/load-balancer/create-load-balancer.iso.test.ts
+++ b/src/service/elbv2/command/load-balancer/create-load-balancer.iso.test.ts
@@ -1,0 +1,206 @@
+import { CreateLoadBalancerCommand } from "@aws-sdk/client-elastic-load-balancing-v2";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import {
+  SimElbV2DuplicateLoadBalancerNameException,
+  SimElbV2UnsimulatedInputException,
+  SimElbV2ValidationError,
+} from "../../error/sim-elbv2.error.js";
+
+describe("ELBv2 CreateLoadBalancerCommand", () => {
+  it("creates an internet-facing load balancer with a real-shaped DNS name", async () => {
+    // Given simulated ELBv2 in a known account and region.
+    const simAws = new SimAws();
+    const elbV2 = simAws.account("555555555555").region("eu-west-1").elbV2();
+
+    // When a load balancer is created.
+    const output = await elbV2.createLoadBalancer(
+      new CreateLoadBalancerCommand({ Name: "shop-alb" }),
+    );
+
+    // Then it reports an ARN, a DNS name, a scheme and an active state.
+    assertArrayLength(output.LoadBalancers, 1);
+
+    const loadBalancer = output.LoadBalancers[0];
+    assertIdentical(
+      loadBalancer.LoadBalancerArn,
+      "arn:aws:elasticloadbalancing:eu-west-1:555555555555:loadbalancer/app/" +
+        "shop-alb/0000000000000001",
+    );
+    assertIdentical(
+      loadBalancer.DNSName,
+      "shop-alb-0000000001.eu-west-1.elb.amazonaws.com",
+    );
+    assertIdentical(loadBalancer.Scheme, "internet-facing");
+    assertIdentical(loadBalancer.Type, "application");
+    assertIdentical(loadBalancer.State.Code, "active");
+    assertIdentical(loadBalancer.IpAddressType, "ipv4");
+    assertNonNullable(loadBalancer.CanonicalHostedZoneId);
+  });
+
+  it("prefixes the DNS name of an internal load balancer", async () => {
+    // Given simulated ELBv2.
+    const simAws = new SimAws();
+    const elbV2 = simAws.account().region("us-east-1").elbV2();
+
+    // When an internal load balancer is created.
+    const output = await elbV2.createLoadBalancer(
+      new CreateLoadBalancerCommand({
+        Name: "private-alb",
+        Scheme: "internal",
+        IpAddressType: "dualstack",
+        Subnets: ["subnet-1", "subnet-2"],
+        SecurityGroups: ["sg-1"],
+        Tags: [{ Key: "team", Value: "shop" }],
+      }),
+    );
+
+    // Then its host name carries the prefix real ELB gives an internal one.
+    assertArrayLength(output.LoadBalancers, 1);
+
+    const loadBalancer = output.LoadBalancers[0];
+    assertStringIncludes(loadBalancer.DNSName, "internal-private-alb-");
+    assertIdentical(loadBalancer.Scheme, "internal");
+    assertIdentical(loadBalancer.IpAddressType, "dualstack");
+  });
+
+  it("refuses a second load balancer of the same name", async () => {
+    // Given a load balancer that already exists.
+    const simAws = new SimAws();
+    const elbV2 = simAws.elbV2();
+
+    await elbV2.createLoadBalancer(
+      new CreateLoadBalancerCommand({ Name: "shop-alb" }),
+    );
+
+    // When another is created with the same name.
+    const error = await assertThrowsErrorAsync(async () => {
+      await elbV2.createLoadBalancer(
+        new CreateLoadBalancerCommand({ Name: "shop-alb" }),
+      );
+    });
+
+    assertInstanceOf(error, SimElbV2DuplicateLoadBalancerNameException);
+
+    // Then it is refused, as a name is unique within an account and region.
+    assertStringIncludes(error.message, "already exists");
+  });
+
+  it("refuses a name real ELB would not take", async () => {
+    // Given simulated ELBv2.
+    const simAws = new SimAws();
+    const elbV2 = simAws.elbV2();
+
+    // When names outside the rules are used, including none at all.
+    const names = [
+      undefined,
+      "",
+      "-shop",
+      "shop-",
+      "shop_alb",
+      "internal-shop",
+      "a".repeat(33),
+    ];
+    const refusals = await Promise.all(
+      names.map(
+        async (name) =>
+          await assertThrowsErrorAsync(async () => {
+            await elbV2.createLoadBalancer(
+              new CreateLoadBalancerCommand({ Name: name }),
+            );
+          }),
+      ),
+    );
+
+    // Then each one is refused rather than trimmed or adjusted.
+    assertArrayLength(refusals, names.length);
+
+    for (const refusal of refusals) {
+      assertInstanceOf(refusal, SimElbV2ValidationError);
+    }
+
+    assertStringIncludes(refusals[0].message, "required");
+    assertStringIncludes(refusals[5].message, "internal-");
+  });
+
+  it("refuses a scheme or address type it does not have", async () => {
+    // Given simulated ELBv2.
+    const simAws = new SimAws();
+    const elbV2 = simAws.elbV2();
+
+    // When an unknown scheme and an unknown address type are asked for.
+    const scheme = await assertThrowsErrorAsync(async () => {
+      await elbV2.createLoadBalancer({
+        input: { Name: "shop-alb", Scheme: "public" },
+      });
+    });
+
+    assertInstanceOf(scheme, SimElbV2ValidationError);
+
+    const addressType = await assertThrowsErrorAsync(async () => {
+      await elbV2.createLoadBalancer({
+        input: { Name: "shop-alb", IpAddressType: "ipv6" },
+      });
+    });
+
+    assertInstanceOf(addressType, SimElbV2ValidationError);
+
+    // Then both are refused.
+    assertStringIncludes(scheme.message, "not valid");
+    assertStringIncludes(addressType.message, "not valid");
+  });
+
+  it("refuses a network load balancer rather than making an application one", async () => {
+    // Given simulated ELBv2.
+    const simAws = new SimAws();
+    const elbV2 = simAws.elbV2();
+
+    // When a network load balancer is asked for.
+    const error = await assertThrowsErrorAsync(async () => {
+      await elbV2.createLoadBalancer(
+        new CreateLoadBalancerCommand({ Name: "shop-nlb", Type: "network" }),
+      );
+    });
+
+    assertInstanceOf(error, SimElbV2UnsimulatedInputException);
+
+    // Then it is refused, because nothing here routes below HTTP.
+    assertStringIncludes(error.message, "not simulated");
+  });
+
+  it("keeps load balancers apart by account and region", async () => {
+    // Given the same name created in two regions.
+    const simAws = new SimAws();
+    const first = simAws.account("111111111111").region("eu-west-1").elbV2();
+    const second = simAws.account("111111111111").region("us-east-1").elbV2();
+
+    const firstOutput = await first.createLoadBalancer(
+      new CreateLoadBalancerCommand({ Name: "shop-alb" }),
+    );
+    const secondOutput = await second.createLoadBalancer(
+      new CreateLoadBalancerCommand({ Name: "shop-alb" }),
+    );
+
+    // Then each has its own ARN and neither sees the other.
+    assertArrayLength(firstOutput.LoadBalancers, 1);
+    assertArrayLength(secondOutput.LoadBalancers, 1);
+    assertStringIncludes(
+      firstOutput.LoadBalancers[0].LoadBalancerArn,
+      "eu-west-1",
+    );
+    assertStringIncludes(
+      secondOutput.LoadBalancers[0].LoadBalancerArn,
+      "us-east-1",
+    );
+    assertNonNullable(second.findLoadBalancerByName("shop-alb"));
+  });
+});

--- a/src/service/elbv2/command/load-balancer/delete-load-balancer.handler.ts
+++ b/src/service/elbv2/command/load-balancer/delete-load-balancer.handler.ts
@@ -1,0 +1,50 @@
+import type { CommandHandler } from "../../../../command/command-handler.js";
+import { SimElbV2ValidationError } from "../../error/sim-elbv2.error.js";
+import { SimElbV2CommandHandler } from "../sim-elbv2-command-handler.js";
+import type { SimElbV2RequestOptions } from "../sim-elbv2-request-options.js";
+import type {
+  SimDeleteLoadBalancerCommand,
+  SimDeleteLoadBalancerCommandOutput,
+} from "./load-balancer.command.js";
+
+/**
+ * Simulated ELBv2 DeleteLoadBalancerCommand handler.
+ *
+ * https://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_DeleteLoadBalancer.html
+ */
+export class DeleteLoadBalancerCommandHandler
+  extends SimElbV2CommandHandler
+  implements
+    CommandHandler<
+      SimDeleteLoadBalancerCommand,
+      SimDeleteLoadBalancerCommandOutput
+    >
+{
+  /**
+   * Delete a load balancer, its listeners and their rules.
+   *
+   * Target groups survive, as they do on real ELB: they are separate resources
+   * that a replacement load balancer's listeners can forward to again.
+   */
+  async handle(
+    command: SimDeleteLoadBalancerCommand,
+    options?: SimElbV2RequestOptions,
+  ): Promise<SimDeleteLoadBalancerCommandOutput> {
+    const loadBalancerArn = command.input.LoadBalancerArn;
+
+    if (loadBalancerArn === undefined) {
+      throw new SimElbV2ValidationError("LoadBalancerArn is required");
+    }
+
+    // Allow for potential non-deterministic sequencing of async events.
+    await this.background.sequence();
+
+    this.authorizer.authorize("DeleteLoadBalancer", loadBalancerArn, options);
+
+    this.stores.deleteLoadBalancer(
+      this.stores.loadBalancers.requireByArn(loadBalancerArn),
+    );
+
+    return { $metadata: {} };
+  }
+}

--- a/src/service/elbv2/command/load-balancer/describe-load-balancers.handler.ts
+++ b/src/service/elbv2/command/load-balancer/describe-load-balancers.handler.ts
@@ -1,0 +1,89 @@
+import type { CommandHandler } from "../../../../command/command-handler.js";
+import type { SimElbV2LoadBalancer } from "../../load-balancer/sim-elbv2-load-balancer.js";
+import { SimElbV2ValidationError } from "../../error/sim-elbv2.error.js";
+import { SimElbV2Page } from "../sim-elbv2-page.js";
+import { SimElbV2CommandHandler } from "../sim-elbv2-command-handler.js";
+import type { SimElbV2RequestOptions } from "../sim-elbv2-request-options.js";
+import type {
+  SimDescribeLoadBalancersCommand,
+  SimDescribeLoadBalancersCommandInput,
+  SimDescribeLoadBalancersCommandOutput,
+} from "./load-balancer.command.js";
+
+/**
+ * Simulated ELBv2 DescribeLoadBalancersCommand handler.
+ *
+ * https://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_DescribeLoadBalancers.html
+ */
+export class DescribeLoadBalancersCommandHandler
+  extends SimElbV2CommandHandler
+  implements
+    CommandHandler<
+      SimDescribeLoadBalancersCommand,
+      SimDescribeLoadBalancersCommandOutput
+    >
+{
+  /**
+   * Real ELB takes ARNs or names, never both, since the two could disagree.
+   */
+  private static requireOneSelector(
+    input: SimDescribeLoadBalancersCommandInput,
+  ): void {
+    if (input.LoadBalancerArns !== undefined && input.Names !== undefined) {
+      throw new SimElbV2ValidationError(
+        "DescribeLoadBalancers takes LoadBalancerArns or Names, not both",
+      );
+    }
+  }
+
+  /**
+   * Describe the load balancers a request names, or all of them.
+   *
+   * Naming one that does not exist is a refusal rather than an omission from
+   * the answer, which is what real ELB does and is the difference between a
+   * describe and a listing.
+   */
+  async handle(
+    command: SimDescribeLoadBalancersCommand,
+    options?: SimElbV2RequestOptions,
+  ): Promise<SimDescribeLoadBalancersCommandOutput> {
+    const { input } = command;
+
+    DescribeLoadBalancersCommandHandler.requireOneSelector(input);
+
+    // Allow for potential non-deterministic sequencing of async events.
+    await this.background.sequence();
+
+    this.authorizer.authorizeAnyResource("DescribeLoadBalancers", options);
+
+    const page = new SimElbV2Page(
+      this.selected(input),
+      input.PageSize,
+      input.Marker,
+    );
+
+    return {
+      $metadata: {},
+      LoadBalancers: page.items.map((loadBalancer) => loadBalancer.view()),
+      NextMarker: page.nextMarker,
+    };
+  }
+
+  private selected(
+    input: SimDescribeLoadBalancersCommandInput,
+  ): readonly SimElbV2LoadBalancer[] {
+    if (input.LoadBalancerArns !== undefined) {
+      return input.LoadBalancerArns.map((arn) =>
+        this.stores.loadBalancers.requireByArn(arn),
+      );
+    }
+
+    if (input.Names !== undefined) {
+      return input.Names.map((name) =>
+        this.stores.loadBalancers.requireByName(name),
+      );
+    }
+
+    return this.stores.loadBalancers.all;
+  }
+}

--- a/src/service/elbv2/command/load-balancer/describe-load-balancers.iso.test.ts
+++ b/src/service/elbv2/command/load-balancer/describe-load-balancers.iso.test.ts
@@ -1,0 +1,204 @@
+import {
+  DeleteLoadBalancerCommand,
+  DescribeLoadBalancersCommand,
+} from "@aws-sdk/client-elastic-load-balancing-v2";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import {
+  SimElbV2LoadBalancerNotFoundException,
+  SimElbV2ValidationError,
+} from "../../error/sim-elbv2.error.js";
+import { createFixtureLoadBalancer } from "../../sim-elbv2.fixture.js";
+
+describe("ELBv2 DescribeLoadBalancersCommand", () => {
+  it("describes every load balancer when the request names none", async () => {
+    // Given three load balancers.
+    const simAws = new SimAws();
+    const elbV2 = simAws.elbV2();
+    await createFixtureLoadBalancer(elbV2, "one-alb");
+    await createFixtureLoadBalancer(elbV2, "two-alb");
+    await createFixtureLoadBalancer(elbV2, "three-alb");
+
+    // When they are described without being named.
+    const output = await elbV2.describeLoadBalancers({ input: {} });
+
+    // Then all three come back, in creation order.
+    assertArrayLength(output.LoadBalancers, 3);
+    assertIdentical(output.LoadBalancers[0].LoadBalancerName, "one-alb");
+    assertUndefined(output.NextMarker);
+  });
+
+  it("describes load balancers by ARN and by name", async () => {
+    // Given two load balancers.
+    const simAws = new SimAws();
+    const elbV2 = simAws.elbV2();
+    const firstArn = await createFixtureLoadBalancer(elbV2, "one-alb");
+    await createFixtureLoadBalancer(elbV2, "two-alb");
+
+    // When one is described each way.
+    const byArn = await elbV2.describeLoadBalancers(
+      new DescribeLoadBalancersCommand({ LoadBalancerArns: [firstArn] }),
+    );
+    const byName = await elbV2.describeLoadBalancers(
+      new DescribeLoadBalancersCommand({ Names: ["two-alb"] }),
+    );
+
+    // Then each answers with the one it named.
+    assertArrayLength(byArn.LoadBalancers, 1);
+    assertIdentical(byArn.LoadBalancers[0].LoadBalancerArn, firstArn);
+    assertArrayLength(byName.LoadBalancers, 1);
+    assertIdentical(byName.LoadBalancers[0].LoadBalancerName, "two-alb");
+  });
+
+  it("refuses a load balancer that does not exist rather than leaving it out", async () => {
+    // Given no load balancers.
+    const simAws = new SimAws();
+    const elbV2 = simAws.elbV2();
+
+    // When one is described by name and another by ARN.
+    const byName = await assertThrowsErrorAsync(async () => {
+      await elbV2.describeLoadBalancers(
+        new DescribeLoadBalancersCommand({ Names: ["missing-alb"] }),
+      );
+    });
+
+    assertInstanceOf(byName, SimElbV2LoadBalancerNotFoundException);
+
+    const byArn = await assertThrowsErrorAsync(async () => {
+      await elbV2.describeLoadBalancers(
+        new DescribeLoadBalancersCommand({ LoadBalancerArns: ["arn:missing"] }),
+      );
+    });
+
+    assertInstanceOf(byArn, SimElbV2LoadBalancerNotFoundException);
+
+    // Then each is refused.
+    assertStringIncludes(byName.message, "missing-alb");
+    assertStringIncludes(byArn.message, "arn:missing");
+  });
+
+  it("refuses a request naming load balancers two ways at once", async () => {
+    // Given simulated ELBv2.
+    const simAws = new SimAws();
+    const elbV2 = simAws.elbV2();
+
+    // When a describe carries both ARNs and names.
+    const error = await assertThrowsErrorAsync(async () => {
+      await elbV2.describeLoadBalancers(
+        new DescribeLoadBalancersCommand({
+          LoadBalancerArns: ["arn:one"],
+          Names: ["one-alb"],
+        }),
+      );
+    });
+
+    assertInstanceOf(error, SimElbV2ValidationError);
+
+    // Then it is refused, since the two could disagree.
+    assertStringIncludes(error.message, "not both");
+  });
+
+  it("pages a describe with a page size and a marker", async () => {
+    // Given three load balancers.
+    const simAws = new SimAws();
+    const elbV2 = simAws.elbV2();
+    await createFixtureLoadBalancer(elbV2, "one-alb");
+    await createFixtureLoadBalancer(elbV2, "two-alb");
+    await createFixtureLoadBalancer(elbV2, "three-alb");
+
+    // When they are described two at a time.
+    const first = await elbV2.describeLoadBalancers(
+      new DescribeLoadBalancersCommand({ PageSize: 2 }),
+    );
+    const second = await elbV2.describeLoadBalancers(
+      new DescribeLoadBalancersCommand({
+        PageSize: 2,
+        Marker: first.NextMarker,
+      }),
+    );
+
+    // Then the marker reaches the rest and then runs out.
+    assertArrayLength(first.LoadBalancers, 2);
+    assertIdentical(first.NextMarker, "2");
+    assertArrayLength(second.LoadBalancers, 1);
+    assertUndefined(second.NextMarker);
+  });
+
+  it("refuses a page size or marker it could not have issued", async () => {
+    // Given one load balancer.
+    const simAws = new SimAws();
+    const elbV2 = simAws.elbV2();
+    await createFixtureLoadBalancer(elbV2, "one-alb");
+
+    // When an impossible page size and marker are asked for.
+    const pageSize = await assertThrowsErrorAsync(async () => {
+      await elbV2.describeLoadBalancers(
+        new DescribeLoadBalancersCommand({ PageSize: 0 }),
+      );
+    });
+
+    assertInstanceOf(pageSize, SimElbV2ValidationError);
+
+    const marker = await assertThrowsErrorAsync(async () => {
+      await elbV2.describeLoadBalancers(
+        new DescribeLoadBalancersCommand({ Marker: "9" }),
+      );
+    });
+
+    assertInstanceOf(marker, SimElbV2ValidationError);
+
+    // Then both are refused.
+    assertStringIncludes(pageSize.message, "PageSize");
+    assertStringIncludes(marker.message, "Marker");
+  });
+
+  it("forgets a deleted load balancer", async () => {
+    // Given a load balancer.
+    const simAws = new SimAws();
+    const elbV2 = simAws.elbV2();
+    const arn = await createFixtureLoadBalancer(elbV2, "one-alb");
+
+    // When it is deleted.
+    await elbV2.deleteLoadBalancer(
+      new DeleteLoadBalancerCommand({ LoadBalancerArn: arn }),
+    );
+
+    // Then nothing is left to describe.
+    const output = await elbV2.describeLoadBalancers({ input: {} });
+    assertArrayLength(output.LoadBalancers, 0);
+  });
+
+  it("refuses a delete naming no load balancer, or one that is gone", async () => {
+    // Given simulated ELBv2.
+    const simAws = new SimAws();
+    const elbV2 = simAws.elbV2();
+
+    // When a delete carries no ARN, and then an unknown one.
+    const missingArn = await assertThrowsErrorAsync(async () => {
+      await elbV2.deleteLoadBalancer({ input: {} });
+    });
+
+    assertInstanceOf(missingArn, SimElbV2ValidationError);
+
+    const unknown = await assertThrowsErrorAsync(async () => {
+      await elbV2.deleteLoadBalancer(
+        new DeleteLoadBalancerCommand({ LoadBalancerArn: "arn:missing" }),
+      );
+    });
+
+    assertInstanceOf(unknown, SimElbV2LoadBalancerNotFoundException);
+
+    // Then both are refused.
+    assertStringIncludes(missingArn.message, "LoadBalancerArn is required");
+    assertStringIncludes(unknown.message, "arn:missing");
+  });
+});

--- a/src/service/elbv2/command/load-balancer/load-balancer.command.ts
+++ b/src/service/elbv2/command/load-balancer/load-balancer.command.ts
@@ -1,0 +1,85 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type { SimElbV2LoadBalancerView } from "../../load-balancer/sim-elbv2-load-balancer.js";
+import type { SimElbV2Tag } from "../sim-elbv2-shared.command.js";
+
+/**
+ * Minimal structural sim ELBv2 CreateLoadBalancer command.
+ */
+export interface SimCreateLoadBalancerCommand {
+  readonly input: SimCreateLoadBalancerCommandInput;
+}
+
+/**
+ * Minimal structural sim ELBv2 CreateLoadBalancer input.
+ *
+ * `Subnets`, `SubnetMappings` and `SecurityGroups` are here so a request
+ * carrying them is accepted, and nothing is done with them: there is no
+ * network in this simulation for them to place a load balancer on.
+ *
+ * https://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_CreateLoadBalancer.html
+ */
+export interface SimCreateLoadBalancerCommandInput {
+  readonly Name?: string | undefined;
+  readonly Scheme?: string | undefined;
+  readonly Type?: string | undefined;
+  readonly IpAddressType?: string | undefined;
+  readonly Subnets?: readonly string[] | undefined;
+  readonly SubnetMappings?: readonly unknown[] | undefined;
+  readonly SecurityGroups?: readonly string[] | undefined;
+  readonly Tags?: readonly SimElbV2Tag[] | undefined;
+}
+
+/**
+ * Minimal structural sim ELBv2 CreateLoadBalancer output.
+ */
+export interface SimCreateLoadBalancerCommandOutput {
+  readonly LoadBalancers?: readonly SimElbV2LoadBalancerView[] | undefined;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim ELBv2 DescribeLoadBalancers command.
+ */
+export interface SimDescribeLoadBalancersCommand {
+  readonly input: SimDescribeLoadBalancersCommandInput;
+}
+
+/**
+ * Minimal structural sim ELBv2 DescribeLoadBalancers input.
+ */
+export interface SimDescribeLoadBalancersCommandInput {
+  readonly LoadBalancerArns?: readonly string[] | undefined;
+  readonly Names?: readonly string[] | undefined;
+  readonly Marker?: string | undefined;
+  readonly PageSize?: number | undefined;
+}
+
+/**
+ * Minimal structural sim ELBv2 DescribeLoadBalancers output.
+ */
+export interface SimDescribeLoadBalancersCommandOutput {
+  readonly LoadBalancers?: readonly SimElbV2LoadBalancerView[] | undefined;
+  readonly NextMarker?: string | undefined;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim ELBv2 DeleteLoadBalancer command.
+ */
+export interface SimDeleteLoadBalancerCommand {
+  readonly input: SimDeleteLoadBalancerCommandInput;
+}
+
+/**
+ * Minimal structural sim ELBv2 DeleteLoadBalancer input.
+ */
+export interface SimDeleteLoadBalancerCommandInput {
+  readonly LoadBalancerArn?: string | undefined;
+}
+
+/**
+ * Minimal structural sim ELBv2 DeleteLoadBalancer output.
+ */
+export interface SimDeleteLoadBalancerCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/elbv2/command/rule/create-rule.handler.ts
+++ b/src/service/elbv2/command/rule/create-rule.handler.ts
@@ -1,0 +1,82 @@
+import type { CommandHandler } from "../../../../command/command-handler.js";
+import { SimElbV2Action } from "../../action/sim-elbv2-action.js";
+import type { SimElbV2ActionTargets } from "../../action/sim-elbv2-action-targets.js";
+import { SimElbV2ValidationError } from "../../error/sim-elbv2.error.js";
+import { SimElbV2ListenerRule } from "../../listener/rule/sim-elbv2-listener-rule.js";
+import { SimElbV2RuleCondition } from "../../listener/rule/sim-elbv2-rule-condition.js";
+import { simElbV2RulePriority } from "../../listener/rule/sim-elbv2-rule-priority.js";
+import { simElbV2ResourceId } from "../../sim-elbv2-resource-id.js";
+import {
+  SimElbV2CommandHandler,
+  type SimElbV2CommandHandlerProperties,
+} from "../sim-elbv2-command-handler.js";
+import type { SimElbV2RequestOptions } from "../sim-elbv2-request-options.js";
+import type {
+  SimCreateRuleCommand,
+  SimCreateRuleCommandOutput,
+} from "./rule.command.js";
+
+interface CreateRuleCommandHandlerProperties extends SimElbV2CommandHandlerProperties {
+  readonly actionTargets: SimElbV2ActionTargets;
+}
+
+/**
+ * Simulated ELBv2 CreateRuleCommand handler.
+ *
+ * https://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_CreateRule.html
+ */
+export class CreateRuleCommandHandler
+  extends SimElbV2CommandHandler
+  implements CommandHandler<SimCreateRuleCommand, SimCreateRuleCommandOutput>
+{
+  private readonly actionTargets: SimElbV2ActionTargets;
+
+  constructor(properties: CreateRuleCommandHandlerProperties) {
+    super(properties);
+    this.actionTargets = properties.actionTargets;
+  }
+
+  /**
+   * Create a rule on a listener at a priority no other rule holds.
+   *
+   * Priority is what decides which of several matching rules claims a request,
+   * so two rules sharing one would leave the outcome undefined. Real ELB
+   * refuses the second, and so does this.
+   */
+  async handle(
+    command: SimCreateRuleCommand,
+    options?: SimElbV2RequestOptions,
+  ): Promise<SimCreateRuleCommandOutput> {
+    const { input } = command;
+
+    if (input.ListenerArn === undefined) {
+      throw new SimElbV2ValidationError("ListenerArn is required");
+    }
+
+    const priority = simElbV2RulePriority(input.Priority);
+    const conditions = SimElbV2RuleCondition.readAll(input.Conditions);
+    const actions = SimElbV2Action.readAll(input.Actions, "Actions");
+
+    // Allow for potential non-deterministic sequencing of async events.
+    await this.background.sequence();
+
+    this.authorizer.authorize("CreateRule", input.ListenerArn, options);
+
+    const listener = this.stores.listeners.requireByArn(input.ListenerArn);
+
+    this.actionTargets.requireTargetGroups(actions);
+    this.stores.rules.requirePriorityAvailable(listener.arn, priority);
+
+    const rule = new SimElbV2ListenerRule({
+      listenerArn: listener.arn,
+      id: simElbV2ResourceId(this.stores.rules.nextSequence()),
+      priority,
+      conditions,
+      actions,
+    });
+
+    this.stores.rules.put(rule);
+
+    return { $metadata: {}, Rules: [rule.view()] };
+  }
+}

--- a/src/service/elbv2/command/rule/delete-rule.handler.ts
+++ b/src/service/elbv2/command/rule/delete-rule.handler.ts
@@ -1,0 +1,41 @@
+import type { CommandHandler } from "../../../../command/command-handler.js";
+import { SimElbV2ValidationError } from "../../error/sim-elbv2.error.js";
+import { SimElbV2CommandHandler } from "../sim-elbv2-command-handler.js";
+import type { SimElbV2RequestOptions } from "../sim-elbv2-request-options.js";
+import type {
+  SimDeleteRuleCommand,
+  SimDeleteRuleCommandOutput,
+} from "./rule.command.js";
+
+/**
+ * Simulated ELBv2 DeleteRuleCommand handler.
+ *
+ * https://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_DeleteRule.html
+ */
+export class DeleteRuleCommandHandler
+  extends SimElbV2CommandHandler
+  implements CommandHandler<SimDeleteRuleCommand, SimDeleteRuleCommandOutput>
+{
+  /**
+   * Delete a rule, freeing the priority it held on its listener.
+   */
+  async handle(
+    command: SimDeleteRuleCommand,
+    options?: SimElbV2RequestOptions,
+  ): Promise<SimDeleteRuleCommandOutput> {
+    const ruleArn = command.input.RuleArn;
+
+    if (ruleArn === undefined) {
+      throw new SimElbV2ValidationError("RuleArn is required");
+    }
+
+    // Allow for potential non-deterministic sequencing of async events.
+    await this.background.sequence();
+
+    this.authorizer.authorize("DeleteRule", ruleArn, options);
+
+    this.stores.rules.remove(this.stores.rules.requireByArn(ruleArn));
+
+    return { $metadata: {} };
+  }
+}

--- a/src/service/elbv2/command/rule/describe-rules.handler.ts
+++ b/src/service/elbv2/command/rule/describe-rules.handler.ts
@@ -1,0 +1,107 @@
+import type { CommandHandler } from "../../../../command/command-handler.js";
+import { SimElbV2ValidationError } from "../../error/sim-elbv2.error.js";
+import {
+  simElbV2DefaultRuleView,
+  type SimElbV2ListenerRuleView,
+} from "../../listener/rule/sim-elbv2-listener-rule.js";
+import { SimElbV2Page } from "../sim-elbv2-page.js";
+import { SimElbV2CommandHandler } from "../sim-elbv2-command-handler.js";
+import type { SimElbV2RequestOptions } from "../sim-elbv2-request-options.js";
+import type {
+  SimDescribeRulesCommand,
+  SimDescribeRulesCommandInput,
+  SimDescribeRulesCommandOutput,
+} from "./rule.command.js";
+
+/**
+ * Which rules a describe named, resolved to one of the two ways.
+ */
+type SimElbV2RuleSelector =
+  | { readonly ruleArns: readonly string[]; readonly listenerArn?: undefined }
+  | { readonly ruleArns?: undefined; readonly listenerArn: string };
+
+/**
+ * Simulated ELBv2 DescribeRulesCommand handler.
+ *
+ * https://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_DescribeRules.html
+ */
+export class DescribeRulesCommandHandler
+  extends SimElbV2CommandHandler
+  implements
+    CommandHandler<SimDescribeRulesCommand, SimDescribeRulesCommandOutput>
+{
+  /**
+   * Read which of the two ways of naming rules a request used.
+   *
+   * Real ELB requires exactly one of them, and answering with the resolved
+   * choice rather than with nothing is what keeps the reading of it in one
+   * place instead of split between a check and a later re-read.
+   */
+  private static readSelector(
+    input: SimDescribeRulesCommandInput,
+  ): SimElbV2RuleSelector {
+    if (input.RuleArns !== undefined && input.ListenerArn === undefined) {
+      return { ruleArns: input.RuleArns };
+    }
+
+    if (input.ListenerArn !== undefined && input.RuleArns === undefined) {
+      return { listenerArn: input.ListenerArn };
+    }
+
+    throw new SimElbV2ValidationError(
+      "DescribeRules takes either RuleArns or ListenerArn",
+    );
+  }
+
+  /**
+   * Describe the rules a request names, or those on one listener.
+   *
+   * A listener's rules come back in priority order with the default rule last,
+   * which is the order the listener would evaluate them in and the order real
+   * ELB reports.
+   */
+  async handle(
+    command: SimDescribeRulesCommand,
+    options?: SimElbV2RequestOptions,
+  ): Promise<SimDescribeRulesCommandOutput> {
+    const { input } = command;
+
+    const selector = DescribeRulesCommandHandler.readSelector(input);
+
+    // Allow for potential non-deterministic sequencing of async events.
+    await this.background.sequence();
+
+    this.authorizer.authorizeAnyResource("DescribeRules", options);
+
+    const page = new SimElbV2Page(
+      this.selected(selector),
+      input.PageSize,
+      input.Marker,
+    );
+
+    return {
+      $metadata: {},
+      Rules: page.items,
+      NextMarker: page.nextMarker,
+    };
+  }
+
+  private selected(
+    selector: SimElbV2RuleSelector,
+  ): readonly SimElbV2ListenerRuleView[] {
+    if (selector.ruleArns === undefined) {
+      const listener = this.stores.listeners.requireByArn(selector.listenerArn);
+
+      return [
+        ...this.stores.rules
+          .forListener(listener.arn)
+          .map((rule) => rule.view()),
+        simElbV2DefaultRuleView(listener),
+      ];
+    }
+
+    return selector.ruleArns.map((arn) =>
+      this.stores.rules.requireByArn(arn).view(),
+    );
+  }
+}

--- a/src/service/elbv2/command/rule/modify-rule.handler.ts
+++ b/src/service/elbv2/command/rule/modify-rule.handler.ts
@@ -1,0 +1,84 @@
+import type { CommandHandler } from "../../../../command/command-handler.js";
+import { SimElbV2Action } from "../../action/sim-elbv2-action.js";
+import type { SimElbV2ActionTargets } from "../../action/sim-elbv2-action-targets.js";
+import { SimElbV2ValidationError } from "../../error/sim-elbv2.error.js";
+import type { SimElbV2ListenerRuleChanges } from "../../listener/rule/sim-elbv2-listener-rule.js";
+import { SimElbV2RuleCondition } from "../../listener/rule/sim-elbv2-rule-condition.js";
+import {
+  SimElbV2CommandHandler,
+  type SimElbV2CommandHandlerProperties,
+} from "../sim-elbv2-command-handler.js";
+import type { SimElbV2RequestOptions } from "../sim-elbv2-request-options.js";
+import type {
+  SimModifyRuleCommand,
+  SimModifyRuleCommandInput,
+  SimModifyRuleCommandOutput,
+} from "./rule.command.js";
+
+interface ModifyRuleCommandHandlerProperties extends SimElbV2CommandHandlerProperties {
+  readonly actionTargets: SimElbV2ActionTargets;
+}
+
+/**
+ * Simulated ELBv2 ModifyRuleCommand handler.
+ *
+ * https://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_ModifyRule.html
+ */
+export class ModifyRuleCommandHandler
+  extends SimElbV2CommandHandler
+  implements CommandHandler<SimModifyRuleCommand, SimModifyRuleCommandOutput>
+{
+  private readonly actionTargets: SimElbV2ActionTargets;
+
+  constructor(properties: ModifyRuleCommandHandlerProperties) {
+    super(properties);
+    this.actionTargets = properties.actionTargets;
+  }
+
+  private static readChanges(
+    input: SimModifyRuleCommandInput,
+  ): SimElbV2ListenerRuleChanges {
+    return {
+      conditions:
+        input.Conditions === undefined
+          ? undefined
+          : SimElbV2RuleCondition.readAll(input.Conditions),
+      actions:
+        input.Actions === undefined
+          ? undefined
+          : SimElbV2Action.readAll(input.Actions, "Actions"),
+    };
+  }
+
+  /**
+   * Change the conditions or actions of a rule.
+   *
+   * A priority cannot be changed here, as it cannot on real ELB, because where
+   * a rule sits is a property of its listener's whole order rather than of the
+   * rule. `SetRulePriorities` is where that happens.
+   */
+  async handle(
+    command: SimModifyRuleCommand,
+    options?: SimElbV2RequestOptions,
+  ): Promise<SimModifyRuleCommandOutput> {
+    const { input } = command;
+
+    if (input.RuleArn === undefined) {
+      throw new SimElbV2ValidationError("RuleArn is required");
+    }
+
+    const changes = ModifyRuleCommandHandler.readChanges(input);
+
+    // Allow for potential non-deterministic sequencing of async events.
+    await this.background.sequence();
+
+    this.authorizer.authorize("ModifyRule", input.RuleArn, options);
+
+    const rule = this.stores.rules.requireByArn(input.RuleArn);
+
+    this.actionTargets.requireTargetGroups(changes.actions ?? []);
+    rule.modify(changes);
+
+    return { $metadata: {}, Rules: [rule.view()] };
+  }
+}

--- a/src/service/elbv2/command/rule/rule-condition.command.ts
+++ b/src/service/elbv2/command/rule/rule-condition.command.ts
@@ -1,0 +1,48 @@
+/**
+ * Minimal structural sim ELBv2 rule condition configuration holding values.
+ */
+export interface SimElbV2ConditionValues {
+  readonly Values?: readonly string[] | undefined;
+}
+
+/**
+ * Minimal structural sim ELBv2 HTTP header condition configuration.
+ */
+export interface SimElbV2HttpHeaderConditionConfig {
+  readonly HttpHeaderName?: string | undefined;
+  readonly Values?: readonly string[] | undefined;
+}
+
+/**
+ * Minimal structural sim ELBv2 query string key and value pair.
+ */
+export interface SimElbV2QueryStringKeyValuePair {
+  readonly Key?: string | undefined;
+  readonly Value?: string | undefined;
+}
+
+/**
+ * Minimal structural sim ELBv2 query string condition configuration.
+ */
+export interface SimElbV2QueryStringConditionConfig {
+  readonly Values?: readonly SimElbV2QueryStringKeyValuePair[] | undefined;
+}
+
+/**
+ * Minimal structural sim ELBv2 rule condition.
+ *
+ * ELB takes a condition's values in two forms, a plain `Values` list and a
+ * per-field configuration, and a rule written by a stack may use either.
+ *
+ * https://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_RuleCondition.html
+ */
+export interface SimElbV2RuleConditionInput {
+  readonly Field?: string | undefined;
+  readonly Values?: readonly string[] | undefined;
+  readonly HostHeaderConfig?: SimElbV2ConditionValues | undefined;
+  readonly PathPatternConfig?: SimElbV2ConditionValues | undefined;
+  readonly HttpRequestMethodConfig?: SimElbV2ConditionValues | undefined;
+  readonly SourceIpConfig?: SimElbV2ConditionValues | undefined;
+  readonly HttpHeaderConfig?: SimElbV2HttpHeaderConditionConfig | undefined;
+  readonly QueryStringConfig?: SimElbV2QueryStringConditionConfig | undefined;
+}

--- a/src/service/elbv2/command/rule/rule.command.ts
+++ b/src/service/elbv2/command/rule/rule.command.ts
@@ -1,0 +1,140 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type { SimElbV2ListenerRuleView } from "../../listener/rule/sim-elbv2-listener-rule.js";
+import type { SimElbV2RuleConditionInput } from "./rule-condition.command.js";
+import type {
+  SimElbV2ActionInput,
+  SimElbV2Tag,
+} from "../sim-elbv2-shared.command.js";
+
+/**
+ * Minimal structural sim ELBv2 CreateRule command.
+ */
+export interface SimCreateRuleCommand {
+  readonly input: SimCreateRuleCommandInput;
+}
+
+/**
+ * Minimal structural sim ELBv2 CreateRule input.
+ *
+ * https://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_CreateRule.html
+ */
+export interface SimCreateRuleCommandInput {
+  readonly ListenerArn?: string | undefined;
+  readonly Priority?: number | undefined;
+  readonly Conditions?: readonly SimElbV2RuleConditionInput[] | undefined;
+  readonly Actions?: readonly SimElbV2ActionInput[] | undefined;
+  readonly Tags?: readonly SimElbV2Tag[] | undefined;
+}
+
+/**
+ * Minimal structural sim ELBv2 CreateRule output.
+ */
+export interface SimCreateRuleCommandOutput {
+  readonly Rules?: readonly SimElbV2ListenerRuleView[] | undefined;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim ELBv2 DescribeRules command.
+ */
+export interface SimDescribeRulesCommand {
+  readonly input: SimDescribeRulesCommandInput;
+}
+
+/**
+ * Minimal structural sim ELBv2 DescribeRules input.
+ */
+export interface SimDescribeRulesCommandInput {
+  readonly ListenerArn?: string | undefined;
+  readonly RuleArns?: readonly string[] | undefined;
+  readonly Marker?: string | undefined;
+  readonly PageSize?: number | undefined;
+}
+
+/**
+ * Minimal structural sim ELBv2 DescribeRules output.
+ */
+export interface SimDescribeRulesCommandOutput {
+  readonly Rules?: readonly SimElbV2ListenerRuleView[] | undefined;
+  readonly NextMarker?: string | undefined;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim ELBv2 ModifyRule command.
+ */
+export interface SimModifyRuleCommand {
+  readonly input: SimModifyRuleCommandInput;
+}
+
+/**
+ * Minimal structural sim ELBv2 ModifyRule input.
+ *
+ * A priority is not here because real ELB does not take one: moving a rule is
+ * `SetRulePriorities`, since it reorders a whole listener rather than changing
+ * one rule.
+ */
+export interface SimModifyRuleCommandInput {
+  readonly RuleArn?: string | undefined;
+  readonly Conditions?: readonly SimElbV2RuleConditionInput[] | undefined;
+  readonly Actions?: readonly SimElbV2ActionInput[] | undefined;
+}
+
+/**
+ * Minimal structural sim ELBv2 ModifyRule output.
+ */
+export interface SimModifyRuleCommandOutput {
+  readonly Rules?: readonly SimElbV2ListenerRuleView[] | undefined;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim ELBv2 DeleteRule command.
+ */
+export interface SimDeleteRuleCommand {
+  readonly input: SimDeleteRuleCommandInput;
+}
+
+/**
+ * Minimal structural sim ELBv2 DeleteRule input.
+ */
+export interface SimDeleteRuleCommandInput {
+  readonly RuleArn?: string | undefined;
+}
+
+/**
+ * Minimal structural sim ELBv2 DeleteRule output.
+ */
+export interface SimDeleteRuleCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim ELBv2 rule priority pair.
+ */
+export interface SimElbV2RulePriorityPair {
+  readonly RuleArn?: string | undefined;
+  readonly Priority?: number | undefined;
+}
+
+/**
+ * Minimal structural sim ELBv2 SetRulePriorities command.
+ */
+export interface SimSetRulePrioritiesCommand {
+  readonly input: SimSetRulePrioritiesCommandInput;
+}
+
+/**
+ * Minimal structural sim ELBv2 SetRulePriorities input.
+ */
+export interface SimSetRulePrioritiesCommandInput {
+  readonly RulePriorities?: readonly SimElbV2RulePriorityPair[] | undefined;
+}
+
+/**
+ * Minimal structural sim ELBv2 SetRulePriorities output.
+ */
+export interface SimSetRulePrioritiesCommandOutput {
+  readonly Rules?: readonly SimElbV2ListenerRuleView[] | undefined;
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/elbv2/command/rule/rule.iso.test.ts
+++ b/src/service/elbv2/command/rule/rule.iso.test.ts
@@ -1,0 +1,294 @@
+import {
+  CreateRuleCommand,
+  DeleteRuleCommand,
+  DescribeRulesCommand,
+  ModifyRuleCommand,
+} from "@aws-sdk/client-elastic-load-balancing-v2";
+import {
+  assertArrayLength,
+  assertFalse,
+  assertIdentical,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertTrue,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import {
+  SimElbV2PriorityInUseException,
+  SimElbV2RuleNotFoundException,
+  SimElbV2ValidationError,
+} from "../../error/sim-elbv2.error.js";
+import {
+  createFixtureLambdaTargetGroup,
+  createFixtureListener,
+  createFixtureLoadBalancer,
+  createFixtureRule,
+} from "../../sim-elbv2.fixture.js";
+
+interface RuleFixture {
+  readonly elbV2: ReturnType<SimAws["elbV2"]>;
+  readonly listenerArn: string;
+  readonly targetGroupArn: string;
+}
+
+async function makeListener(): Promise<RuleFixture> {
+  const simAws = new SimAws();
+  const elbV2 = simAws.account("555555555555").region("eu-west-1").elbV2();
+  const loadBalancerArn = await createFixtureLoadBalancer(elbV2);
+  const targetGroupArn = await createFixtureLambdaTargetGroup(elbV2);
+  const listenerArn = await createFixtureListener(
+    elbV2,
+    loadBalancerArn,
+    targetGroupArn,
+  );
+
+  return { elbV2, listenerArn, targetGroupArn };
+}
+
+describe("ELBv2 listener rules", () => {
+  it("creates a rule whose ARN is built from its listener's", async () => {
+    // Given a listener.
+    const { elbV2, listenerArn, targetGroupArn } = await makeListener();
+
+    // When a rule is written on it.
+    const output = await elbV2.createRule(
+      new CreateRuleCommand({
+        ListenerArn: listenerArn,
+        Priority: 10,
+        Conditions: [{ Field: "path-pattern", Values: ["/checkout/*"] }],
+        Actions: [{ Type: "forward", TargetGroupArn: targetGroupArn }],
+      }),
+    );
+
+    // Then the rule reports its priority as a string, as real ELB does.
+    assertArrayLength(output.Rules, 1);
+
+    const rule = output.Rules[0];
+    assertIdentical(
+      rule.RuleArn,
+      "arn:aws:elasticloadbalancing:eu-west-1:555555555555:listener-rule/app/" +
+        "shop-alb/0000000000000001/0000000000000001/0000000000000001",
+    );
+    assertIdentical(rule.Priority, "10");
+    assertFalse(rule.IsDefault);
+  });
+
+  it("refuses a second rule claiming a priority already taken", async () => {
+    // Given a listener with a rule at priority 10.
+    const { elbV2, listenerArn, targetGroupArn } = await makeListener();
+    await createFixtureRule(elbV2, listenerArn, 10, targetGroupArn);
+
+    // When another rule claims the same priority.
+    const error = await assertThrowsErrorAsync(async () => {
+      await createFixtureRule(elbV2, listenerArn, 10, targetGroupArn);
+    });
+
+    assertInstanceOf(error, SimElbV2PriorityInUseException);
+
+    // Then it is refused, since which one claimed a request would be undefined.
+    assertStringIncludes(error.message, "Priority 10 is already in use");
+  });
+
+  it("refuses a priority outside the range, or none at all", async () => {
+    // Given a listener.
+    const { elbV2, listenerArn, targetGroupArn } = await makeListener();
+
+    // When rules are written with no priority and with an impossible one.
+    const none = await assertThrowsErrorAsync(async () => {
+      await elbV2.createRule({
+        input: {
+          ListenerArn: listenerArn,
+          Conditions: [{ Field: "host-header", Values: ["shop.example.com"] }],
+          Actions: [{ Type: "forward", TargetGroupArn: targetGroupArn }],
+        },
+      });
+    });
+
+    assertInstanceOf(none, SimElbV2ValidationError);
+
+    const outOfRange = await assertThrowsErrorAsync(async () => {
+      await createFixtureRule(elbV2, listenerArn, 50_001, targetGroupArn);
+    });
+
+    assertInstanceOf(outOfRange, SimElbV2ValidationError);
+
+    // Then both are refused.
+    assertStringIncludes(none.message, "Priority is required");
+    assertStringIncludes(outOfRange.message, "between 1 and 50000");
+  });
+
+  it("describes a listener's rules in priority order with the default rule last", async () => {
+    // Given a listener with two rules written out of order.
+    const { elbV2, listenerArn, targetGroupArn } = await makeListener();
+    await createFixtureRule(elbV2, listenerArn, 20, targetGroupArn, "b.test");
+    await createFixtureRule(elbV2, listenerArn, 10, targetGroupArn, "a.test");
+
+    // When the listener's rules are described.
+    const output = await elbV2.describeRules(
+      new DescribeRulesCommand({ ListenerArn: listenerArn }),
+    );
+
+    // Then they come back in evaluation order, ending in the default rule.
+    assertArrayLength(output.Rules, 3);
+    assertIdentical(output.Rules[0].Priority, "10");
+    assertIdentical(output.Rules[1].Priority, "20");
+    assertIdentical(output.Rules[2].Priority, "default");
+    assertTrue(output.Rules[2].IsDefault);
+    assertArrayLength(output.Rules[2].Actions, 1);
+    assertIdentical(output.Rules[2].Actions[0].TargetGroupArn, targetGroupArn);
+  });
+
+  it("describes rules by ARN, and refuses naming neither way", async () => {
+    // Given a listener with one rule.
+    const { elbV2, listenerArn, targetGroupArn } = await makeListener();
+    const ruleArn = await createFixtureRule(
+      elbV2,
+      listenerArn,
+      10,
+      targetGroupArn,
+    );
+
+    // When it is described by ARN, and then with nothing named.
+    const byArn = await elbV2.describeRules(
+      new DescribeRulesCommand({ RuleArns: [ruleArn] }),
+    );
+    const error = await assertThrowsErrorAsync(async () => {
+      await elbV2.describeRules({ input: {} });
+    });
+
+    assertInstanceOf(error, SimElbV2ValidationError);
+
+    // Then the ARN answers and naming neither is refused.
+    assertArrayLength(byArn.Rules, 1);
+    assertStringIncludes(error.message, "either RuleArns");
+  });
+
+  it("changes a rule's conditions and actions but not its priority", async () => {
+    // Given a rule at priority 10.
+    const { elbV2, listenerArn, targetGroupArn } = await makeListener();
+    const ruleArn = await createFixtureRule(
+      elbV2,
+      listenerArn,
+      10,
+      targetGroupArn,
+    );
+
+    // When its conditions and actions are changed.
+    const output = await elbV2.modifyRule(
+      new ModifyRuleCommand({
+        RuleArn: ruleArn,
+        Conditions: [{ Field: "http-request-method", Values: ["POST"] }],
+        Actions: [
+          {
+            Type: "redirect",
+            RedirectConfig: { StatusCode: "HTTP_301", Host: "new.example.com" },
+          },
+        ],
+      }),
+    );
+
+    // Then the change took and the priority stayed where it was.
+    assertArrayLength(output.Rules, 1);
+
+    const rule = output.Rules[0];
+    assertIdentical(rule.Priority, "10");
+    assertArrayLength(rule.Conditions, 1);
+    assertArrayLength(rule.Actions, 1);
+    assertIdentical(rule.Conditions[0].Field, "http-request-method");
+    assertIdentical(rule.Actions[0].Type, "redirect");
+  });
+
+  it("leaves a rule's actions alone when a modify names only conditions", async () => {
+    // Given a rule forwarding to a target group.
+    const { elbV2, listenerArn, targetGroupArn } = await makeListener();
+    const ruleArn = await createFixtureRule(
+      elbV2,
+      listenerArn,
+      10,
+      targetGroupArn,
+    );
+
+    // When only its conditions are changed.
+    const output = await elbV2.modifyRule(
+      new ModifyRuleCommand({
+        RuleArn: ruleArn,
+        Conditions: [{ Field: "path-pattern", Values: ["/checkout/*"] }],
+      }),
+    );
+
+    // Then its actions came through untouched.
+    assertArrayLength(output.Rules, 1);
+    assertArrayLength(output.Rules[0].Actions, 1);
+    assertIdentical(output.Rules[0].Actions[0].TargetGroupArn, targetGroupArn);
+    assertArrayLength(output.Rules[0].Conditions, 1);
+    assertIdentical(output.Rules[0].Conditions[0].Field, "path-pattern");
+  });
+
+  it("frees a priority when the rule holding it is deleted", async () => {
+    // Given a rule at priority 10.
+    const { elbV2, listenerArn, targetGroupArn } = await makeListener();
+    const ruleArn = await createFixtureRule(
+      elbV2,
+      listenerArn,
+      10,
+      targetGroupArn,
+    );
+
+    // When it is deleted and another takes its place.
+    await elbV2.deleteRule(new DeleteRuleCommand({ RuleArn: ruleArn }));
+    await createFixtureRule(elbV2, listenerArn, 10, targetGroupArn);
+
+    // Then the priority was free again.
+    const output = await elbV2.describeRules(
+      new DescribeRulesCommand({ ListenerArn: listenerArn }),
+    );
+    assertArrayLength(output.Rules, 2);
+  });
+
+  it("refuses a rule request naming no rule, or one that is gone", async () => {
+    // Given simulated ELBv2.
+    const { elbV2 } = await makeListener();
+
+    // When a modify and a delete leave out the ARN or name an unknown one.
+    const noModifyArn = await assertThrowsErrorAsync(async () => {
+      await elbV2.modifyRule({ input: {} });
+    });
+
+    assertInstanceOf(noModifyArn, SimElbV2ValidationError);
+
+    const noDeleteArn = await assertThrowsErrorAsync(async () => {
+      await elbV2.deleteRule({ input: {} });
+    });
+
+    assertInstanceOf(noDeleteArn, SimElbV2ValidationError);
+
+    const unknown = await assertThrowsErrorAsync(async () => {
+      await elbV2.deleteRule(new DeleteRuleCommand({ RuleArn: "arn:missing" }));
+    });
+
+    assertInstanceOf(unknown, SimElbV2RuleNotFoundException);
+
+    // Then each is refused.
+    assertStringIncludes(noModifyArn.message, "RuleArn is required");
+    assertStringIncludes(noDeleteArn.message, "RuleArn is required");
+    assertStringIncludes(unknown.message, "arn:missing");
+  });
+
+  it("refuses a rule with no listener named", async () => {
+    // Given simulated ELBv2.
+    const { elbV2 } = await makeListener();
+
+    // When a rule is written without a listener.
+    const error = await assertThrowsErrorAsync(async () => {
+      await elbV2.createRule({ input: {} });
+    });
+
+    assertInstanceOf(error, SimElbV2ValidationError);
+
+    // Then it is refused.
+    assertStringIncludes(error.message, "ListenerArn is required");
+  });
+});

--- a/src/service/elbv2/command/rule/set-rule-priorities.handler.ts
+++ b/src/service/elbv2/command/rule/set-rule-priorities.handler.ts
@@ -1,0 +1,111 @@
+import type { CommandHandler } from "../../../../command/command-handler.js";
+import {
+  SimElbV2PriorityInUseException,
+  SimElbV2ValidationError,
+} from "../../error/sim-elbv2.error.js";
+import type { SimElbV2ListenerRule } from "../../listener/rule/sim-elbv2-listener-rule.js";
+import { simElbV2RulePriority } from "../../listener/rule/sim-elbv2-rule-priority.js";
+import { SimElbV2CommandHandler } from "../sim-elbv2-command-handler.js";
+import type { SimElbV2RequestOptions } from "../sim-elbv2-request-options.js";
+import type {
+  SimSetRulePrioritiesCommand,
+  SimSetRulePrioritiesCommandOutput,
+} from "./rule.command.js";
+
+/**
+ * One rule and where the request wants it moved to.
+ */
+interface SimElbV2RuleMove {
+  readonly rule: SimElbV2ListenerRule;
+  readonly priority: number;
+}
+
+/**
+ * Simulated ELBv2 SetRulePrioritiesCommand handler.
+ *
+ * https://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_SetRulePriorities.html
+ */
+export class SetRulePrioritiesCommandHandler
+  extends SimElbV2CommandHandler
+  implements
+    CommandHandler<
+      SimSetRulePrioritiesCommand,
+      SimSetRulePrioritiesCommandOutput
+    >
+{
+  /**
+   * Move rules to new priorities, all of them or none.
+   *
+   * The request is judged against the order it would leave behind rather than
+   * against the one it started from, which is what lets two rules swap places
+   * in one request. Checking each move against the current state instead would
+   * refuse a swap because each rule's destination is still occupied.
+   */
+  async handle(
+    command: SimSetRulePrioritiesCommand,
+    options?: SimElbV2RequestOptions,
+  ): Promise<SimSetRulePrioritiesCommandOutput> {
+    const pairs = command.input.RulePriorities;
+
+    if (pairs === undefined || pairs.length === 0) {
+      throw new SimElbV2ValidationError(
+        "RulePriorities must name at least one rule",
+      );
+    }
+
+    // Allow for potential non-deterministic sequencing of async events.
+    await this.background.sequence();
+
+    const moves = pairs.map((pair) => {
+      if (pair.RuleArn === undefined) {
+        throw new SimElbV2ValidationError(
+          "RulePriorities member requires a RuleArn",
+        );
+      }
+
+      this.authorizer.authorize("SetRulePriorities", pair.RuleArn, options);
+
+      return {
+        rule: this.stores.rules.requireByArn(pair.RuleArn),
+        priority: simElbV2RulePriority(pair.Priority),
+      };
+    });
+
+    this.requireNoClash(moves);
+
+    for (const move of moves) {
+      move.rule.reprioritize(move.priority);
+    }
+
+    return { $metadata: {}, Rules: moves.map((move) => move.rule.view()) };
+  }
+
+  /**
+   * Refuse a set of moves that would leave two rules on one listener sharing
+   * a priority.
+   */
+  private requireNoClash(moves: readonly SimElbV2RuleMove[]): void {
+    const moved = new Map(moves.map((move) => [move.rule.arn, move.priority]));
+
+    if (moved.size !== moves.length) {
+      throw new SimElbV2ValidationError(
+        "RulePriorities names the same rule more than once",
+      );
+    }
+
+    const listenerArns = new Set(moves.map((move) => move.rule.listenerArn));
+
+    for (const listenerArn of listenerArns) {
+      const priorities = this.stores.rules
+        .forListener(listenerArn)
+        .map((rule) => moved.get(rule.arn) ?? rule.priority);
+
+      if (new Set(priorities).size !== priorities.length) {
+        throw new SimElbV2PriorityInUseException(
+          `These priorities would leave two rules on listener ${listenerArn} ` +
+            `sharing one`,
+        );
+      }
+    }
+  }
+}

--- a/src/service/elbv2/command/rule/set-rule-priorities.iso.test.ts
+++ b/src/service/elbv2/command/rule/set-rule-priorities.iso.test.ts
@@ -1,0 +1,159 @@
+import {
+  DescribeRulesCommand,
+  SetRulePrioritiesCommand,
+} from "@aws-sdk/client-elastic-load-balancing-v2";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import {
+  SimElbV2PriorityInUseException,
+  SimElbV2ValidationError,
+} from "../../error/sim-elbv2.error.js";
+import {
+  createFixtureLambdaTargetGroup,
+  createFixtureListener,
+  createFixtureLoadBalancer,
+  createFixtureRule,
+} from "../../sim-elbv2.fixture.js";
+
+interface RuleFixture {
+  readonly elbV2: ReturnType<SimAws["elbV2"]>;
+  readonly listenerArn: string;
+  readonly targetGroupArn: string;
+}
+
+async function makeListener(): Promise<RuleFixture> {
+  const simAws = new SimAws();
+  const elbV2 = simAws.elbV2();
+  const loadBalancerArn = await createFixtureLoadBalancer(elbV2);
+  const targetGroupArn = await createFixtureLambdaTargetGroup(elbV2);
+  const listenerArn = await createFixtureListener(
+    elbV2,
+    loadBalancerArn,
+    targetGroupArn,
+  );
+
+  return { elbV2, listenerArn, targetGroupArn };
+}
+
+describe("ELBv2 SetRulePrioritiesCommand", () => {
+  it("swaps two rules over in one SetRulePriorities request", async () => {
+    // Given two rules at priorities 10 and 20.
+    const { elbV2, listenerArn, targetGroupArn } = await makeListener();
+    const first = await createFixtureRule(
+      elbV2,
+      listenerArn,
+      10,
+      targetGroupArn,
+      "a.test",
+    );
+    const second = await createFixtureRule(
+      elbV2,
+      listenerArn,
+      20,
+      targetGroupArn,
+      "b.test",
+    );
+
+    // When they are swapped.
+    const output = await elbV2.setRulePriorities(
+      new SetRulePrioritiesCommand({
+        RulePriorities: [
+          { RuleArn: first, Priority: 20 },
+          { RuleArn: second, Priority: 10 },
+        ],
+      }),
+    );
+
+    // Then the swap is allowed, because the order it leaves behind is valid.
+    assertArrayLength(output.Rules, 2);
+    assertIdentical(output.Rules[0].Priority, "20");
+    assertIdentical(output.Rules[1].Priority, "10");
+  });
+
+  it("refuses priorities that would leave two rules sharing one", async () => {
+    // Given two rules at priorities 10 and 20.
+    const { elbV2, listenerArn, targetGroupArn } = await makeListener();
+    const first = await createFixtureRule(
+      elbV2,
+      listenerArn,
+      10,
+      targetGroupArn,
+      "a.test",
+    );
+    const second = await createFixtureRule(
+      elbV2,
+      listenerArn,
+      20,
+      targetGroupArn,
+      "b.test",
+    );
+
+    // When one is moved onto the other, and then one is named twice.
+    const clash = await assertThrowsErrorAsync(async () => {
+      await elbV2.setRulePriorities(
+        new SetRulePrioritiesCommand({
+          RulePriorities: [{ RuleArn: first, Priority: 20 }],
+        }),
+      );
+    });
+
+    assertInstanceOf(clash, SimElbV2PriorityInUseException);
+
+    const repeated = await assertThrowsErrorAsync(async () => {
+      await elbV2.setRulePriorities(
+        new SetRulePrioritiesCommand({
+          RulePriorities: [
+            { RuleArn: second, Priority: 30 },
+            { RuleArn: second, Priority: 40 },
+          ],
+        }),
+      );
+    });
+
+    assertInstanceOf(repeated, SimElbV2ValidationError);
+
+    // Then both are refused, and nothing moved.
+    assertStringIncludes(clash.message, "sharing one");
+    assertStringIncludes(repeated.message, "more than once");
+
+    const unchanged = await elbV2.describeRules(
+      new DescribeRulesCommand({ RuleArns: [first, second] }),
+    );
+    assertArrayLength(unchanged.Rules, 2);
+    assertIdentical(unchanged.Rules[0].Priority, "10");
+    assertIdentical(unchanged.Rules[1].Priority, "20");
+  });
+
+  it("refuses a SetRulePriorities request naming nothing usable", async () => {
+    // Given a listener with a rule.
+    const { elbV2, listenerArn, targetGroupArn } = await makeListener();
+    await createFixtureRule(elbV2, listenerArn, 10, targetGroupArn);
+
+    // When the request is empty, or a pair names no rule.
+    const empty = await assertThrowsErrorAsync(async () => {
+      await elbV2.setRulePriorities({ input: {} });
+    });
+
+    assertInstanceOf(empty, SimElbV2ValidationError);
+
+    const noRuleArn = await assertThrowsErrorAsync(async () => {
+      await elbV2.setRulePriorities(
+        new SetRulePrioritiesCommand({ RulePriorities: [{ Priority: 5 }] }),
+      );
+    });
+
+    assertInstanceOf(noRuleArn, SimElbV2ValidationError);
+
+    // Then both are refused.
+    assertStringIncludes(empty.message, "at least one rule");
+    assertStringIncludes(noRuleArn.message, "requires a RuleArn");
+  });
+});

--- a/src/service/elbv2/command/sim-elbv2-command-handler.ts
+++ b/src/service/elbv2/command/sim-elbv2-command-handler.ts
@@ -1,0 +1,32 @@
+import type { BackgroundScheduler } from "../../../util/background/background.js";
+import type { SimElbV2Stores } from "../sim-elbv2-stores.js";
+import type { SimElbV2Authorizer } from "./authorize/sim-elbv2-authorizer.js";
+
+/**
+ * What every simulated ELBv2 command handler is built with.
+ */
+export interface SimElbV2CommandHandlerProperties {
+  readonly stores: SimElbV2Stores;
+  readonly authorizer: SimElbV2Authorizer;
+  readonly background: BackgroundScheduler;
+}
+
+/**
+ * The collaborators every simulated ELBv2 command handler holds.
+ *
+ * All nineteen operations read or write the same four stores, authorize
+ * against the same IAM, and wait at the same sequencing point, so those three
+ * are held here rather than declared and assigned in each handler. What is
+ * left in a handler is what that operation alone needs.
+ */
+export abstract class SimElbV2CommandHandler {
+  protected readonly stores: SimElbV2Stores;
+  protected readonly authorizer: SimElbV2Authorizer;
+  protected readonly background: BackgroundScheduler;
+
+  constructor(properties: SimElbV2CommandHandlerProperties) {
+    this.stores = properties.stores;
+    this.authorizer = properties.authorizer;
+    this.background = properties.background;
+  }
+}

--- a/src/service/elbv2/command/sim-elbv2-command.types.ts
+++ b/src/service/elbv2/command/sim-elbv2-command.types.ts
@@ -1,0 +1,13 @@
+/**
+ * The sim ELBv2 command types gathered for the service facade.
+ *
+ * The facade imports this as a namespace so that its own file stays a list of
+ * one-line delegations rather than a list of imports, and so that adding an
+ * operation touches the area it belongs to rather than the top of the facade.
+ */
+
+export type * from "./listener/listener.command.js";
+export type * from "./load-balancer/load-balancer.command.js";
+export type * from "./rule/rule.command.js";
+export type * from "./target-group/target-group.command.js";
+export type * from "./target/target.command.js";

--- a/src/service/elbv2/command/sim-elbv2-commands.ts
+++ b/src/service/elbv2/command/sim-elbv2-commands.ts
@@ -1,0 +1,102 @@
+import type { BackgroundScheduler } from "../../../util/background/background.js";
+import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+import type { SimIamInterServiceAuthZ } from "../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { SimElbV2ActionTargets } from "../action/sim-elbv2-action-targets.js";
+import type { SimElbV2Stores } from "../sim-elbv2-stores.js";
+import { SimElbV2TargetGroupUsage } from "../target-group/sim-elbv2-target-group-usage.js";
+import { SimElbV2Authorizer } from "./authorize/sim-elbv2-authorizer.js";
+import { CreateListenerCommandHandler } from "./listener/create-listener.handler.js";
+import { DeleteListenerCommandHandler } from "./listener/delete-listener.handler.js";
+import { DescribeListenersCommandHandler } from "./listener/describe-listeners.handler.js";
+import { ModifyListenerCommandHandler } from "./listener/modify-listener.handler.js";
+import { CreateLoadBalancerCommandHandler } from "./load-balancer/create-load-balancer.handler.js";
+import { DeleteLoadBalancerCommandHandler } from "./load-balancer/delete-load-balancer.handler.js";
+import { DescribeLoadBalancersCommandHandler } from "./load-balancer/describe-load-balancers.handler.js";
+import { CreateRuleCommandHandler } from "./rule/create-rule.handler.js";
+import { DeleteRuleCommandHandler } from "./rule/delete-rule.handler.js";
+import { DescribeRulesCommandHandler } from "./rule/describe-rules.handler.js";
+import { ModifyRuleCommandHandler } from "./rule/modify-rule.handler.js";
+import { SetRulePrioritiesCommandHandler } from "./rule/set-rule-priorities.handler.js";
+import { CreateTargetGroupCommandHandler } from "./target-group/create-target-group.handler.js";
+import { DeleteTargetGroupCommandHandler } from "./target-group/delete-target-group.handler.js";
+import { DescribeTargetGroupsCommandHandler } from "./target-group/describe-target-groups.handler.js";
+import { ModifyTargetGroupCommandHandler } from "./target-group/modify-target-group.handler.js";
+import { DeregisterTargetsCommandHandler } from "./target/deregister-targets.handler.js";
+import { DescribeTargetHealthCommandHandler } from "./target/describe-target-health.handler.js";
+import { RegisterTargetsCommandHandler } from "./target/register-targets.handler.js";
+
+interface SimElbV2CommandsProperties {
+  readonly stores: SimElbV2Stores;
+  readonly iam: SimIamInterServiceAuthZ;
+  readonly background: BackgroundScheduler;
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+}
+
+/**
+ * The command handlers of one simulated ELBv2 scope.
+ *
+ * Building them lives here rather than in the facade so that the facade stays
+ * a list of delegations: adding an operation is a handler here and a method
+ * there, and the wiring every handler shares is stated once.
+ */
+export class SimElbV2Commands {
+  public readonly createLoadBalancer: CreateLoadBalancerCommandHandler;
+  public readonly describeLoadBalancers: DescribeLoadBalancersCommandHandler;
+  public readonly deleteLoadBalancer: DeleteLoadBalancerCommandHandler;
+  public readonly createTargetGroup: CreateTargetGroupCommandHandler;
+  public readonly describeTargetGroups: DescribeTargetGroupsCommandHandler;
+  public readonly modifyTargetGroup: ModifyTargetGroupCommandHandler;
+  public readonly deleteTargetGroup: DeleteTargetGroupCommandHandler;
+  public readonly registerTargets: RegisterTargetsCommandHandler;
+  public readonly deregisterTargets: DeregisterTargetsCommandHandler;
+  public readonly describeTargetHealth: DescribeTargetHealthCommandHandler;
+  public readonly createListener: CreateListenerCommandHandler;
+  public readonly describeListeners: DescribeListenersCommandHandler;
+  public readonly modifyListener: ModifyListenerCommandHandler;
+  public readonly deleteListener: DeleteListenerCommandHandler;
+  public readonly createRule: CreateRuleCommandHandler;
+  public readonly describeRules: DescribeRulesCommandHandler;
+  public readonly modifyRule: ModifyRuleCommandHandler;
+  public readonly deleteRule: DeleteRuleCommandHandler;
+  public readonly setRulePriorities: SetRulePrioritiesCommandHandler;
+
+  constructor(properties: SimElbV2CommandsProperties) {
+    const { stores, background, accountRegionScope } = properties;
+    const authorizer = new SimElbV2Authorizer({ iam: properties.iam });
+    const usage = new SimElbV2TargetGroupUsage(stores);
+    const actionTargets = new SimElbV2ActionTargets(stores.targetGroups);
+    const shared = { stores, authorizer, background };
+    const withTargets = { ...shared, actionTargets };
+    const withUsage = { ...shared, usage };
+
+    this.createLoadBalancer = new CreateLoadBalancerCommandHandler({
+      ...shared,
+      accountRegionScope,
+    });
+    this.describeLoadBalancers = new DescribeLoadBalancersCommandHandler(
+      shared,
+    );
+    this.deleteLoadBalancer = new DeleteLoadBalancerCommandHandler(shared);
+    this.createTargetGroup = new CreateTargetGroupCommandHandler({
+      ...withUsage,
+      accountRegionScope,
+    });
+    this.describeTargetGroups = new DescribeTargetGroupsCommandHandler(
+      withUsage,
+    );
+    this.modifyTargetGroup = new ModifyTargetGroupCommandHandler(withUsage);
+    this.deleteTargetGroup = new DeleteTargetGroupCommandHandler(withUsage);
+    this.registerTargets = new RegisterTargetsCommandHandler(shared);
+    this.deregisterTargets = new DeregisterTargetsCommandHandler(shared);
+    this.describeTargetHealth = new DescribeTargetHealthCommandHandler(shared);
+    this.createListener = new CreateListenerCommandHandler(withTargets);
+    this.describeListeners = new DescribeListenersCommandHandler(shared);
+    this.modifyListener = new ModifyListenerCommandHandler(withTargets);
+    this.deleteListener = new DeleteListenerCommandHandler(shared);
+    this.createRule = new CreateRuleCommandHandler(withTargets);
+    this.describeRules = new DescribeRulesCommandHandler(shared);
+    this.modifyRule = new ModifyRuleCommandHandler(withTargets);
+    this.deleteRule = new DeleteRuleCommandHandler(shared);
+    this.setRulePriorities = new SetRulePrioritiesCommandHandler(shared);
+  }
+}

--- a/src/service/elbv2/command/sim-elbv2-page.ts
+++ b/src/service/elbv2/command/sim-elbv2-page.ts
@@ -1,0 +1,100 @@
+import { SimElbV2ValidationError } from "../error/sim-elbv2.error.js";
+
+/**
+ * How many items a describe carries when the request asks for no page size.
+ */
+const defaultItemsPerPage = 400;
+
+/**
+ * The most real ELB lets one describe carry.
+ */
+const maximumItemsPerPage = 400;
+
+/**
+ * One page of a describe, and the marker that reaches the next one.
+ *
+ * ELBv2 pages every describe with a `Marker` in and a `NextMarker` out, rather
+ * than with the `NextToken` most services use, so a caller written against the
+ * real SDK reads the same field here.
+ */
+export class SimElbV2Page<Item> {
+  public readonly items: readonly Item[];
+  public readonly nextMarker: string | undefined;
+
+  constructor(
+    listed: readonly Item[],
+    pageSize: number | undefined,
+    marker: string | undefined,
+  ) {
+    const startIndex = SimElbV2Page.startIndex(marker, listed.length);
+    const nextIndex = startIndex + SimElbV2Page.itemsPerPage(pageSize);
+
+    this.items = listed.slice(startIndex, nextIndex);
+    this.nextMarker = SimElbV2Page.markerFor(nextIndex, listed.length);
+  }
+
+  /**
+   * Read the page size a request asked for, refusing one outside the range
+   * real ELB takes.
+   */
+  private static itemsPerPage(pageSize: number | undefined): number {
+    if (pageSize === undefined) {
+      return defaultItemsPerPage;
+    }
+
+    if (
+      !Number.isSafeInteger(pageSize) ||
+      pageSize < 1 ||
+      pageSize > maximumItemsPerPage
+    ) {
+      throw new SimElbV2ValidationError(
+        `PageSize ${String(pageSize)} is outside the range 1 to ${String(
+          maximumItemsPerPage,
+        )}`,
+      );
+    }
+
+    return pageSize;
+  }
+
+  /**
+   * Read a marker as its offset into the listed items.
+   *
+   * A marker is refused unless it is one these describes could have issued,
+   * which is an offset landing inside the items still to come.
+   */
+  private static startIndex(
+    marker: string | undefined,
+    listedCount: number,
+  ): number {
+    if (marker === undefined) {
+      return 0;
+    }
+
+    const startIndex = Number(marker);
+
+    if (
+      !Number.isSafeInteger(startIndex) ||
+      startIndex <= 0 ||
+      startIndex >= listedCount ||
+      String(startIndex) !== marker
+    ) {
+      throw new SimElbV2ValidationError(
+        "Marker is not a marker this simulation issued",
+      );
+    }
+
+    return startIndex;
+  }
+
+  private static markerFor(
+    nextIndex: number,
+    listedCount: number,
+  ): string | undefined {
+    if (nextIndex >= listedCount) {
+      return undefined;
+    }
+
+    return String(nextIndex);
+  }
+}

--- a/src/service/elbv2/command/sim-elbv2-request-options.ts
+++ b/src/service/elbv2/command/sim-elbv2-request-options.ts
@@ -1,0 +1,12 @@
+import type { SimAwsCaller } from "../../aws/caller/sim-aws-caller.js";
+
+/**
+ * What an ELBv2 request carries besides its command input.
+ */
+export interface SimElbV2RequestOptions {
+  /**
+   * Who is making the request. An omitted caller is the Account root, as it is
+   * everywhere else in the simulation.
+   */
+  readonly caller?: SimAwsCaller;
+}

--- a/src/service/elbv2/command/sim-elbv2-shared.command.ts
+++ b/src/service/elbv2/command/sim-elbv2-shared.command.ts
@@ -1,0 +1,99 @@
+/**
+ * The structural sim ELBv2 shapes more than one command carries.
+ *
+ * An action appears on a listener and on a rule, a certificate and a tag on
+ * several creates, so they are written once here and imported rather than
+ * repeated per command file.
+ *
+ * Every field is widened to the plainest type that still accepts a real SDK
+ * command, so an input the simulation refuses is refused at runtime with an
+ * explanation rather than by the type checker with none. That matters for
+ * `Type` fields above all: the SDK's own union carries action types this
+ * simulation does not have.
+ */
+
+/**
+ * Minimal structural sim ELBv2 tag.
+ */
+export interface SimElbV2Tag {
+  readonly Key?: string | undefined;
+  readonly Value?: string | undefined;
+}
+
+/**
+ * Minimal structural sim ELBv2 certificate reference.
+ */
+export interface SimElbV2Certificate {
+  readonly CertificateArn?: string | undefined;
+  readonly IsDefault?: boolean | undefined;
+}
+
+/**
+ * Minimal structural sim ELBv2 health check matcher.
+ */
+export interface SimElbV2Matcher {
+  readonly HttpCode?: string | undefined;
+  readonly GrpcCode?: string | undefined;
+}
+
+/**
+ * Minimal structural sim ELBv2 fixed-response action configuration.
+ */
+export interface SimElbV2FixedResponseActionConfig {
+  readonly MessageBody?: string | undefined;
+  readonly StatusCode?: string | undefined;
+  readonly ContentType?: string | undefined;
+}
+
+/**
+ * Minimal structural sim ELBv2 redirect action configuration.
+ */
+export interface SimElbV2RedirectActionConfig {
+  readonly Protocol?: string | undefined;
+  readonly Port?: string | undefined;
+  readonly Host?: string | undefined;
+  readonly Path?: string | undefined;
+  readonly Query?: string | undefined;
+  readonly StatusCode?: string | undefined;
+}
+
+/**
+ * Minimal structural sim ELBv2 weighted target group.
+ */
+export interface SimElbV2TargetGroupTuple {
+  readonly TargetGroupArn?: string | undefined;
+  readonly Weight?: number | undefined;
+}
+
+/**
+ * Minimal structural sim ELBv2 forward action configuration.
+ */
+export interface SimElbV2ForwardActionConfig {
+  readonly TargetGroups?: readonly SimElbV2TargetGroupTuple[] | undefined;
+}
+
+/**
+ * Minimal structural sim ELBv2 action.
+ *
+ * https://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_Action.html
+ */
+export interface SimElbV2ActionInput {
+  readonly Type?: string | undefined;
+  readonly Order?: number | undefined;
+  readonly TargetGroupArn?: string | undefined;
+  readonly ForwardConfig?: SimElbV2ForwardActionConfig | undefined;
+  readonly FixedResponseConfig?: SimElbV2FixedResponseActionConfig | undefined;
+  readonly RedirectConfig?: SimElbV2RedirectActionConfig | undefined;
+}
+
+/**
+ * Minimal structural sim ELBv2 action as it is reported back.
+ */
+export interface SimElbV2ActionView {
+  readonly Type: string;
+  readonly Order?: number | undefined;
+  readonly TargetGroupArn?: string | undefined;
+  readonly ForwardConfig?: SimElbV2ForwardActionConfig | undefined;
+  readonly FixedResponseConfig?: SimElbV2FixedResponseActionConfig | undefined;
+  readonly RedirectConfig?: SimElbV2RedirectActionConfig | undefined;
+}

--- a/src/service/elbv2/command/target-group/create-target-group.handler.ts
+++ b/src/service/elbv2/command/target-group/create-target-group.handler.ts
@@ -1,0 +1,91 @@
+import type { CommandHandler } from "../../../../command/command-handler.js";
+import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
+import { simElbV2ResourceId } from "../../sim-elbv2-resource-id.js";
+import { simElbV2TargetGroupEndpoint } from "../../target-group/sim-elbv2-target-group-endpoint.js";
+import { simElbV2TargetGroupName } from "../../target-group/sim-elbv2-target-group-name.js";
+import { SimElbV2TargetGroup } from "../../target-group/sim-elbv2-target-group.js";
+import type { SimElbV2TargetGroupUsage } from "../../target-group/sim-elbv2-target-group-usage.js";
+import { simElbV2TargetType } from "../../target-group/sim-elbv2-target-type.js";
+import {
+  SimElbV2CommandHandler,
+  type SimElbV2CommandHandlerProperties,
+} from "../sim-elbv2-command-handler.js";
+import type { SimElbV2RequestOptions } from "../sim-elbv2-request-options.js";
+import type {
+  SimCreateTargetGroupCommand,
+  SimCreateTargetGroupCommandOutput,
+} from "./target-group.command.js";
+
+interface CreateTargetGroupCommandHandlerProperties extends SimElbV2CommandHandlerProperties {
+  readonly usage: SimElbV2TargetGroupUsage;
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+}
+
+/**
+ * Simulated ELBv2 CreateTargetGroupCommand handler.
+ *
+ * https://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_CreateTargetGroup.html
+ */
+export class CreateTargetGroupCommandHandler
+  extends SimElbV2CommandHandler
+  implements
+    CommandHandler<
+      SimCreateTargetGroupCommand,
+      SimCreateTargetGroupCommandOutput
+    >
+{
+  private readonly usage: SimElbV2TargetGroupUsage;
+  private readonly accountRegionScope: SimAwsAccountRegionScope;
+
+  constructor(properties: CreateTargetGroupCommandHandlerProperties) {
+    super(properties);
+    this.usage = properties.usage;
+    this.accountRegionScope = properties.accountRegionScope;
+  }
+
+  /**
+   * Create a target group of a type this simulation can route to.
+   *
+   * The target type decides whether a protocol and port belong on the group at
+   * all, so it is read first and then asked, rather than each combination
+   * being checked here.
+   */
+  async handle(
+    command: SimCreateTargetGroupCommand,
+    options?: SimElbV2RequestOptions,
+  ): Promise<SimCreateTargetGroupCommandOutput> {
+    const { input } = command;
+
+    const name = simElbV2TargetGroupName(input.Name);
+    const targetType = simElbV2TargetType(input.TargetType);
+    const endpoint = simElbV2TargetGroupEndpoint(input);
+
+    targetType.validateGroup(endpoint);
+
+    // Allow for potential non-deterministic sequencing of async events.
+    await this.background.sequence();
+
+    this.authorizer.authorizeAnyResource("CreateTargetGroup", options);
+
+    this.stores.targetGroups.requireNameAvailable(name);
+
+    const targetGroup = new SimElbV2TargetGroup({
+      ...endpoint,
+      name,
+      targetType,
+      vpcId: input.VpcId,
+      id: simElbV2ResourceId(this.stores.targetGroups.nextSequence()),
+      accountRegionScope: this.accountRegionScope,
+    });
+
+    targetGroup.modifyHealthCheck(input);
+    this.stores.targetGroups.put(targetGroup);
+
+    return {
+      $metadata: {},
+      TargetGroups: [
+        targetGroup.view(this.usage.loadBalancerArns(targetGroup)),
+      ],
+    };
+  }
+}

--- a/src/service/elbv2/command/target-group/create-target-group.iso.test.ts
+++ b/src/service/elbv2/command/target-group/create-target-group.iso.test.ts
@@ -1,0 +1,236 @@
+import { CreateTargetGroupCommand } from "@aws-sdk/client-elastic-load-balancing-v2";
+import {
+  assertArrayLength,
+  assertFalse,
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertTrue,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import {
+  SimElbV2DuplicateTargetGroupNameException,
+  SimElbV2InvalidConfigurationRequestException,
+  SimElbV2UnsimulatedInputException,
+  SimElbV2ValidationError,
+} from "../../error/sim-elbv2.error.js";
+
+describe("ELBv2 CreateTargetGroupCommand", () => {
+  it("creates a lambda target group with no protocol or port", async () => {
+    // Given simulated ELBv2 in a known account and region.
+    const simAws = new SimAws();
+    const elbV2 = simAws.account("555555555555").region("eu-west-1").elbV2();
+
+    // When a target group holding a function is created.
+    const output = await elbV2.createTargetGroup(
+      new CreateTargetGroupCommand({
+        Name: "checkout-tg",
+        TargetType: "lambda",
+      }),
+    );
+
+    // Then it has a real-shaped ARN and health checking is off, as on real ELB.
+    const targetGroup = output.TargetGroups?.[0];
+    assertNonNullable(targetGroup);
+    assertIdentical(
+      targetGroup.TargetGroupArn,
+      "arn:aws:elasticloadbalancing:eu-west-1:555555555555:targetgroup/" +
+        "checkout-tg/0000000000000001",
+    );
+    assertIdentical(targetGroup.TargetType, "lambda");
+    assertUndefined(targetGroup.Protocol);
+    assertFalse(targetGroup.HealthCheckEnabled);
+    assertArrayLength(targetGroup.LoadBalancerArns, 0);
+  });
+
+  it("creates an ip target group with the protocol and port a target is reached on", async () => {
+    // Given simulated ELBv2.
+    const simAws = new SimAws();
+    const elbV2 = simAws.elbV2();
+
+    // When a target group holding addresses is created.
+    const output = await elbV2.createTargetGroup(
+      new CreateTargetGroupCommand({
+        Name: "web-tg",
+        TargetType: "ip",
+        Protocol: "HTTP",
+        Port: 8080,
+        VpcId: "vpc-1",
+        HealthCheckPath: "/healthz",
+      }),
+    );
+
+    // Then it carries them, and the health check settings it was given.
+    const targetGroup = output.TargetGroups?.[0];
+    assertNonNullable(targetGroup);
+    assertIdentical(targetGroup.TargetType, "ip");
+    assertIdentical(targetGroup.Protocol, "HTTP");
+    assertIdentical(targetGroup.Port, 8080);
+    assertIdentical(targetGroup.VpcId, "vpc-1");
+    assertTrue(targetGroup.HealthCheckEnabled);
+    assertIdentical(targetGroup.HealthCheckPath, "/healthz");
+  });
+
+  it("refuses an instance target group rather than accepting and ignoring it", async () => {
+    // Given simulated ELBv2.
+    const simAws = new SimAws();
+    const elbV2 = simAws.elbV2();
+
+    // When a target group of instances is asked for.
+    const error = await assertThrowsErrorAsync(async () => {
+      await elbV2.createTargetGroup(
+        new CreateTargetGroupCommand({
+          Name: "web-tg",
+          TargetType: "instance",
+          Protocol: "HTTP",
+          Port: 80,
+        }),
+      );
+    });
+
+    assertInstanceOf(error, SimElbV2UnsimulatedInputException);
+
+    // Then it is refused, since there are no instances here to route to.
+    assertStringIncludes(error.message, "not simulated");
+    assertStringIncludes(error.message, "lambda and ip");
+  });
+
+  it("refuses a target group that names no target type", async () => {
+    // Given simulated ELBv2.
+    const simAws = new SimAws();
+    const elbV2 = simAws.elbV2();
+
+    // When a target group is created without one.
+    const error = await assertThrowsErrorAsync(async () => {
+      await elbV2.createTargetGroup(
+        new CreateTargetGroupCommand({
+          Name: "web-tg",
+          Protocol: "HTTP",
+          Port: 80,
+        }),
+      );
+    });
+
+    assertInstanceOf(error, SimElbV2UnsimulatedInputException);
+
+    // Then it is refused rather than defaulted to the type real ELB defaults to.
+    assertStringIncludes(error.message, "instance");
+  });
+
+  it("refuses a lambda target group given a protocol or port", async () => {
+    // Given simulated ELBv2.
+    const simAws = new SimAws();
+    const elbV2 = simAws.elbV2();
+
+    // When a function target group is given somewhere to connect to.
+    const error = await assertThrowsErrorAsync(async () => {
+      await elbV2.createTargetGroup(
+        new CreateTargetGroupCommand({
+          Name: "checkout-tg",
+          TargetType: "lambda",
+          Protocol: "HTTP",
+          Port: 80,
+        }),
+      );
+    });
+
+    assertInstanceOf(error, SimElbV2InvalidConfigurationRequestException);
+
+    // Then it is refused, as a function is invoked rather than connected to.
+    assertStringIncludes(error.message, "no Protocol or Port");
+  });
+
+  it("refuses an ip target group with nowhere to reach a target", async () => {
+    // Given simulated ELBv2.
+    const simAws = new SimAws();
+    const elbV2 = simAws.elbV2();
+
+    // When an address target group is created without a port.
+    const error = await assertThrowsErrorAsync(async () => {
+      await elbV2.createTargetGroup(
+        new CreateTargetGroupCommand({
+          Name: "web-tg",
+          TargetType: "ip",
+          Protocol: "HTTP",
+        }),
+      );
+    });
+
+    assertInstanceOf(error, SimElbV2InvalidConfigurationRequestException);
+
+    // Then it is refused.
+    assertStringIncludes(error.message, "requires a Protocol and a Port");
+  });
+
+  it("refuses a protocol only a network load balancer speaks", async () => {
+    // Given simulated ELBv2.
+    const simAws = new SimAws();
+    const elbV2 = simAws.elbV2();
+
+    // When a TCP target group is asked for.
+    const error = await assertThrowsErrorAsync(async () => {
+      await elbV2.createTargetGroup(
+        new CreateTargetGroupCommand({
+          Name: "web-tg",
+          TargetType: "ip",
+          Protocol: "TCP",
+          Port: 80,
+        }),
+      );
+    });
+
+    assertInstanceOf(error, SimElbV2UnsimulatedInputException);
+
+    // Then it is refused.
+    assertStringIncludes(error.message, "Application Load Balancer");
+  });
+
+  it("refuses a port outside the range, and a duplicate name", async () => {
+    // Given a target group that already exists.
+    const simAws = new SimAws();
+    const elbV2 = simAws.elbV2();
+
+    await elbV2.createTargetGroup(
+      new CreateTargetGroupCommand({
+        Name: "web-tg",
+        TargetType: "ip",
+        Protocol: "HTTP",
+        Port: 8080,
+      }),
+    );
+
+    // When an impossible port and a repeated name are used.
+    const port = await assertThrowsErrorAsync(async () => {
+      await elbV2.createTargetGroup(
+        new CreateTargetGroupCommand({
+          Name: "other-tg",
+          TargetType: "ip",
+          Protocol: "HTTP",
+          Port: 70_000,
+        }),
+      );
+    });
+
+    assertInstanceOf(port, SimElbV2ValidationError);
+
+    const duplicate = await assertThrowsErrorAsync(async () => {
+      await elbV2.createTargetGroup(
+        new CreateTargetGroupCommand({
+          Name: "web-tg",
+          TargetType: "lambda",
+        }),
+      );
+    });
+
+    assertInstanceOf(duplicate, SimElbV2DuplicateTargetGroupNameException);
+
+    // Then both are refused.
+    assertStringIncludes(port.message, "port between 1 and 65535");
+    assertStringIncludes(duplicate.message, "already exists");
+  });
+});

--- a/src/service/elbv2/command/target-group/create-target-group.iso.test.ts
+++ b/src/service/elbv2/command/target-group/create-target-group.iso.test.ts
@@ -190,6 +190,29 @@ describe("ELBv2 CreateTargetGroupCommand", () => {
     assertStringIncludes(error.message, "Application Load Balancer");
   });
 
+  it("refuses a protocol that is not an ELB protocol at all", async () => {
+    // Given simulated ELBv2.
+    const simAws = new SimAws();
+    const elbV2 = simAws.elbV2();
+
+    // When a target group names something that is not an ELB protocol.
+    const error = await assertThrowsErrorAsync(async () => {
+      await elbV2.createTargetGroup({
+        input: {
+          Name: "web-tg",
+          TargetType: "ip",
+          Protocol: "FTP",
+          Port: 21,
+        },
+      });
+    });
+
+    // Then it is a validation failure rather than something unsimulated: the
+    // request is wrong, not beyond what this goes as far as.
+    assertInstanceOf(error, SimElbV2ValidationError);
+    assertStringIncludes(error.message, "not a valid ELB protocol");
+  });
+
   it("refuses a port outside the range, and a duplicate name", async () => {
     // Given a target group that already exists.
     const simAws = new SimAws();

--- a/src/service/elbv2/command/target-group/delete-target-group.handler.ts
+++ b/src/service/elbv2/command/target-group/delete-target-group.handler.ts
@@ -1,0 +1,66 @@
+import type { CommandHandler } from "../../../../command/command-handler.js";
+import { SimElbV2ValidationError } from "../../error/sim-elbv2.error.js";
+import type { SimElbV2TargetGroupUsage } from "../../target-group/sim-elbv2-target-group-usage.js";
+import {
+  SimElbV2CommandHandler,
+  type SimElbV2CommandHandlerProperties,
+} from "../sim-elbv2-command-handler.js";
+import type { SimElbV2RequestOptions } from "../sim-elbv2-request-options.js";
+import type {
+  SimDeleteTargetGroupCommand,
+  SimDeleteTargetGroupCommandOutput,
+} from "./target-group.command.js";
+
+interface DeleteTargetGroupCommandHandlerProperties extends SimElbV2CommandHandlerProperties {
+  readonly usage: SimElbV2TargetGroupUsage;
+}
+
+/**
+ * Simulated ELBv2 DeleteTargetGroupCommand handler.
+ *
+ * https://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_DeleteTargetGroup.html
+ */
+export class DeleteTargetGroupCommandHandler
+  extends SimElbV2CommandHandler
+  implements
+    CommandHandler<
+      SimDeleteTargetGroupCommand,
+      SimDeleteTargetGroupCommandOutput
+    >
+{
+  private readonly usage: SimElbV2TargetGroupUsage;
+
+  constructor(properties: DeleteTargetGroupCommandHandlerProperties) {
+    super(properties);
+    this.usage = properties.usage;
+  }
+
+  /**
+   * Delete a target group nothing forwards to any more.
+   *
+   * Real ELB refuses while a listener or rule still names it, which is what
+   * makes deleting a load balancer first the way to get rid of both.
+   */
+  async handle(
+    command: SimDeleteTargetGroupCommand,
+    options?: SimElbV2RequestOptions,
+  ): Promise<SimDeleteTargetGroupCommandOutput> {
+    const targetGroupArn = command.input.TargetGroupArn;
+
+    if (targetGroupArn === undefined) {
+      throw new SimElbV2ValidationError("TargetGroupArn is required");
+    }
+
+    // Allow for potential non-deterministic sequencing of async events.
+    await this.background.sequence();
+
+    this.authorizer.authorize("DeleteTargetGroup", targetGroupArn, options);
+
+    const targetGroup = this.stores.targetGroups.requireByArn(targetGroupArn);
+
+    this.usage.requireUnused(targetGroup);
+    this.stores.targetGroups.remove(targetGroup);
+
+    return { $metadata: {} };
+  }
+}

--- a/src/service/elbv2/command/target-group/describe-target-groups-selection.ts
+++ b/src/service/elbv2/command/target-group/describe-target-groups-selection.ts
@@ -1,0 +1,79 @@
+import { SimElbV2ValidationError } from "../../error/sim-elbv2.error.js";
+import type { SimElbV2Stores } from "../../sim-elbv2-stores.js";
+import type { SimElbV2TargetGroup } from "../../target-group/sim-elbv2-target-group.js";
+import type { SimElbV2TargetGroupUsage } from "../../target-group/sim-elbv2-target-group-usage.js";
+import type { SimDescribeTargetGroupsCommandInput } from "./target-group.command.js";
+
+interface SimElbV2TargetGroupSelectionProperties {
+  readonly stores: SimElbV2Stores;
+  readonly usage: SimElbV2TargetGroupUsage;
+}
+
+/**
+ * Which target groups a describe named.
+ *
+ * Real ELB takes three ways of naming them and one way at a time, since two
+ * could disagree, so reading the request and resolving what it named are the
+ * same job and are held together here rather than split across the handler.
+ */
+export class SimElbV2TargetGroupSelection {
+  private readonly stores: SimElbV2Stores;
+  private readonly usage: SimElbV2TargetGroupUsage;
+
+  constructor(properties: SimElbV2TargetGroupSelectionProperties) {
+    this.stores = properties.stores;
+    this.usage = properties.usage;
+  }
+
+  /**
+   * Refuse a request naming target groups more than one way.
+   *
+   * This is separate from resolving them so that it can run before the request
+   * is authorized, as it does on real ELB.
+   */
+  validate(input: SimDescribeTargetGroupsCommandInput): void {
+    const named = [
+      input.TargetGroupArns,
+      input.Names,
+      input.LoadBalancerArn,
+    ].filter((selector) => selector !== undefined);
+
+    if (named.length > 1) {
+      throw new SimElbV2ValidationError(
+        "DescribeTargetGroups takes one of TargetGroupArns, Names or " +
+          "LoadBalancerArn",
+      );
+    }
+  }
+
+  /**
+   * The target groups a request named, or all of them.
+   */
+  resolve(
+    input: SimDescribeTargetGroupsCommandInput,
+  ): readonly SimElbV2TargetGroup[] {
+    if (input.TargetGroupArns !== undefined) {
+      return input.TargetGroupArns.map((arn) =>
+        this.stores.targetGroups.requireByArn(arn),
+      );
+    }
+
+    if (input.Names !== undefined) {
+      return input.Names.map((name) =>
+        this.stores.targetGroups.requireByName(name),
+      );
+    }
+
+    if (input.LoadBalancerArn === undefined) {
+      return this.stores.targetGroups.all;
+    }
+
+    const loadBalancer = this.stores.loadBalancers.requireByArn(
+      input.LoadBalancerArn,
+    );
+
+    return this.stores.targetGroups.all.filter((targetGroup) =>
+      this.usage.loadBalancerArns(targetGroup).includes(loadBalancer.arn),
+    );
+  }
+}

--- a/src/service/elbv2/command/target-group/describe-target-groups.handler.ts
+++ b/src/service/elbv2/command/target-group/describe-target-groups.handler.ts
@@ -1,0 +1,75 @@
+import type { CommandHandler } from "../../../../command/command-handler.js";
+import type { SimElbV2TargetGroupUsage } from "../../target-group/sim-elbv2-target-group-usage.js";
+import { SimElbV2Page } from "../sim-elbv2-page.js";
+import {
+  SimElbV2CommandHandler,
+  type SimElbV2CommandHandlerProperties,
+} from "../sim-elbv2-command-handler.js";
+import type { SimElbV2RequestOptions } from "../sim-elbv2-request-options.js";
+import { SimElbV2TargetGroupSelection } from "./describe-target-groups-selection.js";
+import type {
+  SimDescribeTargetGroupsCommand,
+  SimDescribeTargetGroupsCommandOutput,
+} from "./target-group.command.js";
+
+interface DescribeTargetGroupsCommandHandlerProperties extends SimElbV2CommandHandlerProperties {
+  readonly usage: SimElbV2TargetGroupUsage;
+}
+
+/**
+ * Simulated ELBv2 DescribeTargetGroupsCommand handler.
+ *
+ * https://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_DescribeTargetGroups.html
+ */
+export class DescribeTargetGroupsCommandHandler
+  extends SimElbV2CommandHandler
+  implements
+    CommandHandler<
+      SimDescribeTargetGroupsCommand,
+      SimDescribeTargetGroupsCommandOutput
+    >
+{
+  private readonly usage: SimElbV2TargetGroupUsage;
+  private readonly selection: SimElbV2TargetGroupSelection;
+
+  constructor(properties: DescribeTargetGroupsCommandHandlerProperties) {
+    super(properties);
+    this.usage = properties.usage;
+    this.selection = new SimElbV2TargetGroupSelection(properties);
+  }
+
+  /**
+   * Describe the target groups a request names, or all of them.
+   *
+   * Narrowing by load balancer answers with the groups its listeners and rules
+   * forward to, which is the same question the `LoadBalancerArns` on each
+   * group answers from the other side.
+   */
+  async handle(
+    command: SimDescribeTargetGroupsCommand,
+    options?: SimElbV2RequestOptions,
+  ): Promise<SimDescribeTargetGroupsCommandOutput> {
+    const { input } = command;
+
+    this.selection.validate(input);
+
+    // Allow for potential non-deterministic sequencing of async events.
+    await this.background.sequence();
+
+    this.authorizer.authorizeAnyResource("DescribeTargetGroups", options);
+
+    const page = new SimElbV2Page(
+      this.selection.resolve(input),
+      input.PageSize,
+      input.Marker,
+    );
+
+    return {
+      $metadata: {},
+      TargetGroups: page.items.map((targetGroup) =>
+        targetGroup.view(this.usage.loadBalancerArns(targetGroup)),
+      ),
+      NextMarker: page.nextMarker,
+    };
+  }
+}

--- a/src/service/elbv2/command/target-group/modify-target-group.handler.ts
+++ b/src/service/elbv2/command/target-group/modify-target-group.handler.ts
@@ -1,0 +1,78 @@
+import type { CommandHandler } from "../../../../command/command-handler.js";
+import { SimElbV2ValidationError } from "../../error/sim-elbv2.error.js";
+import type { SimElbV2TargetGroupUsage } from "../../target-group/sim-elbv2-target-group-usage.js";
+import {
+  SimElbV2CommandHandler,
+  type SimElbV2CommandHandlerProperties,
+} from "../sim-elbv2-command-handler.js";
+import type { SimElbV2RequestOptions } from "../sim-elbv2-request-options.js";
+import type {
+  SimModifyTargetGroupCommand,
+  SimModifyTargetGroupCommandOutput,
+} from "./target-group.command.js";
+
+interface ModifyTargetGroupCommandHandlerProperties extends SimElbV2CommandHandlerProperties {
+  readonly usage: SimElbV2TargetGroupUsage;
+}
+
+/**
+ * Simulated ELBv2 ModifyTargetGroupCommand handler.
+ *
+ * https://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_ModifyTargetGroup.html
+ */
+export class ModifyTargetGroupCommandHandler
+  extends SimElbV2CommandHandler
+  implements
+    CommandHandler<
+      SimModifyTargetGroupCommand,
+      SimModifyTargetGroupCommandOutput
+    >
+{
+  private readonly usage: SimElbV2TargetGroupUsage;
+
+  constructor(properties: ModifyTargetGroupCommandHandlerProperties) {
+    super(properties);
+    this.usage = properties.usage;
+  }
+
+  /**
+   * Change the health check settings of a target group.
+   *
+   * The settings are stored and reported and nothing acts on them: no request
+   * is ever made to a target to find out whether it is up. A stack still
+   * declares them, so a test comparing what it deployed against what it meant
+   * to deploy can read them back.
+   */
+  async handle(
+    command: SimModifyTargetGroupCommand,
+    options?: SimElbV2RequestOptions,
+  ): Promise<SimModifyTargetGroupCommandOutput> {
+    const { input } = command;
+
+    if (input.TargetGroupArn === undefined) {
+      throw new SimElbV2ValidationError("TargetGroupArn is required");
+    }
+
+    // Allow for potential non-deterministic sequencing of async events.
+    await this.background.sequence();
+
+    this.authorizer.authorize(
+      "ModifyTargetGroup",
+      input.TargetGroupArn,
+      options,
+    );
+
+    const targetGroup = this.stores.targetGroups.requireByArn(
+      input.TargetGroupArn,
+    );
+
+    targetGroup.modifyHealthCheck(input);
+
+    return {
+      $metadata: {},
+      TargetGroups: [
+        targetGroup.view(this.usage.loadBalancerArns(targetGroup)),
+      ],
+    };
+  }
+}

--- a/src/service/elbv2/command/target-group/target-group-lifecycle.iso.test.ts
+++ b/src/service/elbv2/command/target-group/target-group-lifecycle.iso.test.ts
@@ -1,0 +1,236 @@
+import {
+  DeleteLoadBalancerCommand,
+  DeleteTargetGroupCommand,
+  DescribeTargetGroupsCommand,
+  ModifyTargetGroupCommand,
+} from "@aws-sdk/client-elastic-load-balancing-v2";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import {
+  SimElbV2ResourceInUseException,
+  SimElbV2TargetGroupNotFoundException,
+  SimElbV2ValidationError,
+} from "../../error/sim-elbv2.error.js";
+import {
+  createFixtureIpTargetGroup,
+  createFixtureLambdaTargetGroup,
+  createFixtureListener,
+  createFixtureLoadBalancer,
+} from "../../sim-elbv2.fixture.js";
+
+describe("ELBv2 target group lifecycle", () => {
+  it("describes target groups by ARN, by name and by load balancer", async () => {
+    // Given a load balancer forwarding to one of two target groups.
+    const simAws = new SimAws();
+    const elbV2 = simAws.elbV2();
+    const loadBalancerArn = await createFixtureLoadBalancer(elbV2);
+    const forwardedTo = await createFixtureLambdaTargetGroup(elbV2);
+    const idle = await createFixtureIpTargetGroup(elbV2);
+
+    await createFixtureListener(elbV2, loadBalancerArn, forwardedTo);
+
+    // When they are described each way.
+    const all = await elbV2.describeTargetGroups({ input: {} });
+    const byArn = await elbV2.describeTargetGroups(
+      new DescribeTargetGroupsCommand({ TargetGroupArns: [idle] }),
+    );
+    const byName = await elbV2.describeTargetGroups(
+      new DescribeTargetGroupsCommand({ Names: ["checkout-tg"] }),
+    );
+    const byLoadBalancer = await elbV2.describeTargetGroups(
+      new DescribeTargetGroupsCommand({ LoadBalancerArn: loadBalancerArn }),
+    );
+
+    // Then the one being forwarded to knows which load balancer reaches it.
+    assertArrayLength(all.TargetGroups, 2);
+    assertArrayLength(byArn.TargetGroups, 1);
+    assertIdentical(byArn.TargetGroups[0].TargetGroupArn, idle);
+    assertArrayLength(byName.TargetGroups, 1);
+    assertArrayLength(byLoadBalancer.TargetGroups, 1);
+    assertIdentical(byLoadBalancer.TargetGroups[0].TargetGroupArn, forwardedTo);
+    assertIdentical(
+      byName.TargetGroups[0].LoadBalancerArns[0],
+      loadBalancerArn,
+    );
+  });
+
+  it("refuses a describe naming target groups more than one way", async () => {
+    // Given simulated ELBv2.
+    const simAws = new SimAws();
+    const elbV2 = simAws.elbV2();
+
+    // When a describe carries both names and ARNs.
+    const error = await assertThrowsErrorAsync(async () => {
+      await elbV2.describeTargetGroups(
+        new DescribeTargetGroupsCommand({
+          Names: ["web-tg"],
+          TargetGroupArns: ["arn:one"],
+        }),
+      );
+    });
+
+    assertInstanceOf(error, SimElbV2ValidationError);
+
+    // Then it is refused.
+    assertStringIncludes(error.message, "takes one of");
+  });
+
+  it("refuses a target group that does not exist, or a name it never had", async () => {
+    // Given simulated ELBv2 with one target group.
+    const simAws = new SimAws();
+    const elbV2 = simAws.elbV2();
+    await createFixtureIpTargetGroup(elbV2);
+
+    // When another name is described, and one is created with no name.
+    const unknownName = await assertThrowsErrorAsync(async () => {
+      await elbV2.describeTargetGroups(
+        new DescribeTargetGroupsCommand({ Names: ["missing-tg"] }),
+      );
+    });
+
+    assertInstanceOf(unknownName, SimElbV2TargetGroupNotFoundException);
+
+    const noName = await assertThrowsErrorAsync(async () => {
+      await elbV2.createTargetGroup({ input: { TargetType: "lambda" } });
+    });
+
+    assertInstanceOf(noName, SimElbV2ValidationError);
+
+    // Then both are refused.
+    assertStringIncludes(unknownName.message, "missing-tg");
+    assertStringIncludes(noName.message, "Name is required");
+  });
+
+  it("changes only the health check settings a modify names", async () => {
+    // Given an ip target group with the default health check settings.
+    const simAws = new SimAws();
+    const elbV2 = simAws.elbV2();
+    const targetGroupArn = await createFixtureIpTargetGroup(elbV2);
+
+    // When only the path is changed.
+    const output = await elbV2.modifyTargetGroup(
+      new ModifyTargetGroupCommand({
+        TargetGroupArn: targetGroupArn,
+        HealthCheckPath: "/ready",
+        Matcher: { HttpCode: "200-299" },
+      }),
+    );
+
+    // Then the rest is left as it was.
+    const targetGroup = output.TargetGroups?.[0];
+    assertNonNullable(targetGroup);
+    assertIdentical(targetGroup.HealthCheckPath, "/ready");
+    assertIdentical(targetGroup.Matcher?.HttpCode, "200-299");
+    assertIdentical(targetGroup.HealthCheckIntervalSeconds, 30);
+    assertIdentical(targetGroup.HealthyThresholdCount, 5);
+  });
+
+  it("refuses a modify naming no target group, or one that is gone", async () => {
+    // Given simulated ELBv2.
+    const simAws = new SimAws();
+    const elbV2 = simAws.elbV2();
+
+    // When a modify carries no ARN, and then an unknown one.
+    const missing = await assertThrowsErrorAsync(async () => {
+      await elbV2.modifyTargetGroup({ input: {} });
+    });
+
+    assertInstanceOf(missing, SimElbV2ValidationError);
+
+    const unknown = await assertThrowsErrorAsync(async () => {
+      await elbV2.modifyTargetGroup(
+        new ModifyTargetGroupCommand({ TargetGroupArn: "arn:missing" }),
+      );
+    });
+
+    assertInstanceOf(unknown, SimElbV2TargetGroupNotFoundException);
+
+    // Then both are refused.
+    assertStringIncludes(missing.message, "TargetGroupArn is required");
+    assertStringIncludes(unknown.message, "arn:missing");
+  });
+
+  it("refuses to delete a target group a listener still forwards to", async () => {
+    // Given a listener forwarding to a target group.
+    const simAws = new SimAws();
+    const elbV2 = simAws.elbV2();
+    const loadBalancerArn = await createFixtureLoadBalancer(elbV2);
+    const targetGroupArn = await createFixtureLambdaTargetGroup(elbV2);
+
+    await createFixtureListener(elbV2, loadBalancerArn, targetGroupArn);
+
+    // When the target group is deleted.
+    const error = await assertThrowsErrorAsync(async () => {
+      await elbV2.deleteTargetGroup(
+        new DeleteTargetGroupCommand({ TargetGroupArn: targetGroupArn }),
+      );
+    });
+
+    assertInstanceOf(error, SimElbV2ResourceInUseException);
+
+    // Then it is refused while anything still forwards to it.
+    assertStringIncludes(error.message, "still forwarded to by");
+  });
+
+  it("leaves target groups behind when their load balancer is deleted", async () => {
+    // Given a listener forwarding to a target group.
+    const simAws = new SimAws();
+    const elbV2 = simAws.elbV2();
+    const loadBalancerArn = await createFixtureLoadBalancer(elbV2);
+    const targetGroupArn = await createFixtureLambdaTargetGroup(elbV2);
+
+    await createFixtureListener(elbV2, loadBalancerArn, targetGroupArn);
+
+    // When the load balancer is deleted and then the target group.
+    await elbV2.deleteLoadBalancer(
+      new DeleteLoadBalancerCommand({ LoadBalancerArn: loadBalancerArn }),
+    );
+
+    const surviving = await elbV2.describeTargetGroups({ input: {} });
+
+    await elbV2.deleteTargetGroup(
+      new DeleteTargetGroupCommand({ TargetGroupArn: targetGroupArn }),
+    );
+
+    // Then the group survived the load balancer and is deletable afterwards.
+    assertArrayLength(surviving.TargetGroups, 1);
+    assertArrayLength(surviving.TargetGroups[0].LoadBalancerArns, 0);
+
+    const remaining = await elbV2.describeTargetGroups({ input: {} });
+    assertArrayLength(remaining.TargetGroups, 0);
+  });
+
+  it("refuses a delete naming no target group, or one that is gone", async () => {
+    // Given simulated ELBv2.
+    const simAws = new SimAws();
+    const elbV2 = simAws.elbV2();
+
+    // When a delete carries no ARN, and then an unknown one.
+    const missing = await assertThrowsErrorAsync(async () => {
+      await elbV2.deleteTargetGroup({ input: {} });
+    });
+
+    assertInstanceOf(missing, SimElbV2ValidationError);
+
+    const unknown = await assertThrowsErrorAsync(async () => {
+      await elbV2.deleteTargetGroup(
+        new DeleteTargetGroupCommand({ TargetGroupArn: "arn:missing" }),
+      );
+    });
+
+    assertInstanceOf(unknown, SimElbV2TargetGroupNotFoundException);
+
+    // Then both are refused.
+    assertStringIncludes(missing.message, "TargetGroupArn is required");
+    assertStringIncludes(unknown.message, "arn:missing");
+  });
+});

--- a/src/service/elbv2/command/target-group/target-group.command.ts
+++ b/src/service/elbv2/command/target-group/target-group.command.ts
@@ -1,0 +1,108 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type { SimElbV2HealthCheckInput } from "../../target-group/sim-elbv2-health-check.js";
+import type { SimElbV2TargetGroupView } from "../../target-group/sim-elbv2-target-group.js";
+import type { SimElbV2Tag } from "../sim-elbv2-shared.command.js";
+
+/**
+ * Minimal structural sim ELBv2 CreateTargetGroup command.
+ */
+export interface SimCreateTargetGroupCommand {
+  readonly input: SimCreateTargetGroupCommandInput;
+}
+
+/**
+ * Minimal structural sim ELBv2 CreateTargetGroup input.
+ *
+ * https://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_CreateTargetGroup.html
+ */
+export type SimCreateTargetGroupCommandInput = SimElbV2HealthCheckInput & {
+  readonly Name?: string | undefined;
+  readonly TargetType?: string | undefined;
+  readonly Protocol?: string | undefined;
+  readonly ProtocolVersion?: string | undefined;
+  readonly Port?: number | undefined;
+  readonly VpcId?: string | undefined;
+  readonly IpAddressType?: string | undefined;
+  readonly Tags?: readonly SimElbV2Tag[] | undefined;
+};
+
+/**
+ * Minimal structural sim ELBv2 CreateTargetGroup output.
+ */
+export interface SimCreateTargetGroupCommandOutput {
+  readonly TargetGroups?: readonly SimElbV2TargetGroupView[] | undefined;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim ELBv2 DescribeTargetGroups command.
+ */
+export interface SimDescribeTargetGroupsCommand {
+  readonly input: SimDescribeTargetGroupsCommandInput;
+}
+
+/**
+ * Minimal structural sim ELBv2 DescribeTargetGroups input.
+ */
+export interface SimDescribeTargetGroupsCommandInput {
+  readonly LoadBalancerArn?: string | undefined;
+  readonly TargetGroupArns?: readonly string[] | undefined;
+  readonly Names?: readonly string[] | undefined;
+  readonly Marker?: string | undefined;
+  readonly PageSize?: number | undefined;
+}
+
+/**
+ * Minimal structural sim ELBv2 DescribeTargetGroups output.
+ */
+export interface SimDescribeTargetGroupsCommandOutput {
+  readonly TargetGroups?: readonly SimElbV2TargetGroupView[] | undefined;
+  readonly NextMarker?: string | undefined;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim ELBv2 ModifyTargetGroup command.
+ */
+export interface SimModifyTargetGroupCommand {
+  readonly input: SimModifyTargetGroupCommandInput;
+}
+
+/**
+ * Minimal structural sim ELBv2 ModifyTargetGroup input.
+ *
+ * Real ELB only lets health check settings be changed on an existing target
+ * group, so those are the whole of this input.
+ */
+export type SimModifyTargetGroupCommandInput = SimElbV2HealthCheckInput & {
+  readonly TargetGroupArn?: string | undefined;
+};
+
+/**
+ * Minimal structural sim ELBv2 ModifyTargetGroup output.
+ */
+export interface SimModifyTargetGroupCommandOutput {
+  readonly TargetGroups?: readonly SimElbV2TargetGroupView[] | undefined;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim ELBv2 DeleteTargetGroup command.
+ */
+export interface SimDeleteTargetGroupCommand {
+  readonly input: SimDeleteTargetGroupCommandInput;
+}
+
+/**
+ * Minimal structural sim ELBv2 DeleteTargetGroup input.
+ */
+export interface SimDeleteTargetGroupCommandInput {
+  readonly TargetGroupArn?: string | undefined;
+}
+
+/**
+ * Minimal structural sim ELBv2 DeleteTargetGroup output.
+ */
+export interface SimDeleteTargetGroupCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/elbv2/command/target/deregister-targets.handler.ts
+++ b/src/service/elbv2/command/target/deregister-targets.handler.ts
@@ -1,0 +1,56 @@
+import type { CommandHandler } from "../../../../command/command-handler.js";
+import { SimElbV2ValidationError } from "../../error/sim-elbv2.error.js";
+import { SimElbV2CommandHandler } from "../sim-elbv2-command-handler.js";
+import type { SimElbV2RequestOptions } from "../sim-elbv2-request-options.js";
+import type {
+  SimDeregisterTargetsCommand,
+  SimDeregisterTargetsCommandOutput,
+} from "./target.command.js";
+
+/**
+ * Simulated ELBv2 DeregisterTargetsCommand handler.
+ *
+ * https://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_DeregisterTargets.html
+ */
+export class DeregisterTargetsCommandHandler
+  extends SimElbV2CommandHandler
+  implements
+    CommandHandler<
+      SimDeregisterTargetsCommand,
+      SimDeregisterTargetsCommandOutput
+    >
+{
+  /**
+   * Take targets out of a target group.
+   *
+   * A target that was not in the group is not an error, as it is not on real
+   * ELB: deregistering is stated as an end state rather than as a change.
+   * Deregistration is also immediate here, where real ELB drains connections
+   * for a few minutes first, because there are no connections to drain.
+   */
+  async handle(
+    command: SimDeregisterTargetsCommand,
+    options?: SimElbV2RequestOptions,
+  ): Promise<SimDeregisterTargetsCommandOutput> {
+    const { TargetGroupArn: targetGroupArn, Targets: targets } = command.input;
+
+    if (targetGroupArn === undefined) {
+      throw new SimElbV2ValidationError("TargetGroupArn is required");
+    }
+
+    if (targets === undefined || targets.length === 0) {
+      throw new SimElbV2ValidationError(
+        "Targets must name at least one target",
+      );
+    }
+
+    // Allow for potential non-deterministic sequencing of async events.
+    await this.background.sequence();
+
+    this.authorizer.authorize("DeregisterTargets", targetGroupArn, options);
+
+    this.stores.targetGroups.requireByArn(targetGroupArn).deregister(targets);
+
+    return { $metadata: {} };
+  }
+}

--- a/src/service/elbv2/command/target/describe-target-health.handler.ts
+++ b/src/service/elbv2/command/target/describe-target-health.handler.ts
@@ -1,0 +1,105 @@
+import type { CommandHandler } from "../../../../command/command-handler.js";
+import {
+  SimElbV2InvalidTargetException,
+  SimElbV2ValidationError,
+} from "../../error/sim-elbv2.error.js";
+import { SimElbV2Target } from "../../target-group/sim-elbv2-target.js";
+import type { SimElbV2TargetGroup } from "../../target-group/sim-elbv2-target-group.js";
+import { SimElbV2CommandHandler } from "../sim-elbv2-command-handler.js";
+import type { SimElbV2RequestOptions } from "../sim-elbv2-request-options.js";
+import type {
+  SimDescribeTargetHealthCommand,
+  SimDescribeTargetHealthCommandInput,
+  SimDescribeTargetHealthCommandOutput,
+} from "./target.command.js";
+
+/**
+ * Simulated ELBv2 DescribeTargetHealthCommand handler.
+ *
+ * https://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_DescribeTargetHealth.html
+ */
+export class DescribeTargetHealthCommandHandler
+  extends SimElbV2CommandHandler
+  implements
+    CommandHandler<
+      SimDescribeTargetHealthCommand,
+      SimDescribeTargetHealthCommandOutput
+    >
+{
+  /**
+   * The targets a request asks about, refusing one that is not registered.
+   *
+   * Real ELB answers `InvalidTarget` for a target the group does not hold,
+   * rather than leaving it out of the answer, so a test asking about the wrong
+   * target hears about it.
+   */
+  private static selected(
+    targetGroup: SimElbV2TargetGroup,
+    input: SimDescribeTargetHealthCommandInput,
+  ): readonly SimElbV2Target[] {
+    if (input.Targets === undefined) {
+      return targetGroup.registeredTargets;
+    }
+
+    return input.Targets.map((description) => {
+      const asked = SimElbV2Target.read(description, targetGroup.port);
+      const registered = targetGroup.registeredTargets.find(
+        (target) => target.key === asked.key,
+      );
+
+      if (registered === undefined) {
+        throw new SimElbV2InvalidTargetException(
+          `Target '${asked.id}' is not registered in target group ${
+            targetGroup.arn
+          }`,
+        );
+      }
+
+      return registered;
+    });
+  }
+
+  /**
+   * Report the targets registered in a target group.
+   *
+   * Every one of them is healthy, because nothing here ever asks a target
+   * whether it is: no health check is performed, so there is no state for a
+   * target to be in other than registered. This is therefore a way to read
+   * back what `RegisterTargets` did rather than a way to watch a deployment
+   * come up.
+   */
+  async handle(
+    command: SimDescribeTargetHealthCommand,
+    options?: SimElbV2RequestOptions,
+  ): Promise<SimDescribeTargetHealthCommandOutput> {
+    const { input } = command;
+
+    if (input.TargetGroupArn === undefined) {
+      throw new SimElbV2ValidationError("TargetGroupArn is required");
+    }
+
+    // Allow for potential non-deterministic sequencing of async events.
+    await this.background.sequence();
+
+    this.authorizer.authorize(
+      "DescribeTargetHealth",
+      input.TargetGroupArn,
+      options,
+    );
+
+    const targetGroup = this.stores.targetGroups.requireByArn(
+      input.TargetGroupArn,
+    );
+
+    return {
+      $metadata: {},
+      TargetHealthDescriptions: DescribeTargetHealthCommandHandler.selected(
+        targetGroup,
+        input,
+      ).map((target) => ({
+        Target: target.view(),
+        TargetHealth: { State: "healthy" },
+      })),
+    };
+  }
+}

--- a/src/service/elbv2/command/target/register-targets.handler.ts
+++ b/src/service/elbv2/command/target/register-targets.handler.ts
@@ -1,0 +1,52 @@
+import type { CommandHandler } from "../../../../command/command-handler.js";
+import { SimElbV2ValidationError } from "../../error/sim-elbv2.error.js";
+import { SimElbV2CommandHandler } from "../sim-elbv2-command-handler.js";
+import type { SimElbV2RequestOptions } from "../sim-elbv2-request-options.js";
+import type {
+  SimRegisterTargetsCommand,
+  SimRegisterTargetsCommandOutput,
+} from "./target.command.js";
+
+/**
+ * Simulated ELBv2 RegisterTargetsCommand handler.
+ *
+ * https://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_RegisterTargets.html
+ */
+export class RegisterTargetsCommandHandler
+  extends SimElbV2CommandHandler
+  implements
+    CommandHandler<SimRegisterTargetsCommand, SimRegisterTargetsCommandOutput>
+{
+  /**
+   * Put targets into a target group.
+   *
+   * What a target may be is the target group's business rather than this
+   * handler's, so a function ARN in an address group and an address in a
+   * function group are both refused by the group's own type.
+   */
+  async handle(
+    command: SimRegisterTargetsCommand,
+    options?: SimElbV2RequestOptions,
+  ): Promise<SimRegisterTargetsCommandOutput> {
+    const { TargetGroupArn: targetGroupArn, Targets: targets } = command.input;
+
+    if (targetGroupArn === undefined) {
+      throw new SimElbV2ValidationError("TargetGroupArn is required");
+    }
+
+    if (targets === undefined || targets.length === 0) {
+      throw new SimElbV2ValidationError(
+        "Targets must name at least one target",
+      );
+    }
+
+    // Allow for potential non-deterministic sequencing of async events.
+    await this.background.sequence();
+
+    this.authorizer.authorize("RegisterTargets", targetGroupArn, options);
+
+    this.stores.targetGroups.requireByArn(targetGroupArn).register(targets);
+
+    return { $metadata: {} };
+  }
+}

--- a/src/service/elbv2/command/target/register-targets.iso.test.ts
+++ b/src/service/elbv2/command/target/register-targets.iso.test.ts
@@ -178,6 +178,35 @@ describe("ELBv2 RegisterTargetsCommand", () => {
     );
   });
 
+  it("refuses an address that could not exist", async () => {
+    // Given an ip target group.
+    const simAws = new SimAws();
+    const elbV2 = simAws.elbV2();
+    const targetGroupArn = await createFixtureIpTargetGroup(elbV2);
+
+    // When addresses that are shaped right but impossible are registered.
+    const refusals = await Promise.all(
+      ["999.999.999.999", "::::", "1.2.3"].map(
+        async (id) =>
+          await assertThrowsErrorAsync(async () => {
+            await elbV2.registerTargets(
+              new RegisterTargetsCommand({
+                TargetGroupArn: targetGroupArn,
+                Targets: [{ Id: id }],
+              }),
+            );
+          }),
+      ),
+    );
+
+    // Then each is refused, because the address is parsed rather than matched.
+    assertArrayLength(refusals, 3);
+
+    for (const refusal of refusals) {
+      assertInstanceOf(refusal, SimElbV2InvalidTargetException);
+    }
+  });
+
   it("takes targets out again, and ignores one that was never in", async () => {
     // Given an ip target group holding two addresses.
     const simAws = new SimAws();

--- a/src/service/elbv2/command/target/register-targets.iso.test.ts
+++ b/src/service/elbv2/command/target/register-targets.iso.test.ts
@@ -1,0 +1,332 @@
+import {
+  DeregisterTargetsCommand,
+  DescribeTargetHealthCommand,
+  RegisterTargetsCommand,
+} from "@aws-sdk/client-elastic-load-balancing-v2";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import {
+  SimElbV2InvalidTargetException,
+  SimElbV2TargetGroupNotFoundException,
+  SimElbV2TooManyTargetsException,
+  SimElbV2ValidationError,
+} from "../../error/sim-elbv2.error.js";
+import {
+  createFixtureIpTargetGroup,
+  createFixtureLambdaTargetGroup,
+  fixtureFunctionArn,
+} from "../../sim-elbv2.fixture.js";
+
+describe("ELBv2 RegisterTargetsCommand", () => {
+  it("registers one function in a lambda target group", async () => {
+    // Given a lambda target group.
+    const simAws = new SimAws();
+    const elbV2 = simAws.elbV2();
+    const targetGroupArn = await createFixtureLambdaTargetGroup(elbV2);
+
+    // When a function is registered.
+    await elbV2.registerTargets(
+      new RegisterTargetsCommand({
+        TargetGroupArn: targetGroupArn,
+        Targets: [{ Id: fixtureFunctionArn }],
+      }),
+    );
+
+    // Then the function is the group's one target, reported as healthy.
+    const output = await elbV2.describeTargetHealth(
+      new DescribeTargetHealthCommand({ TargetGroupArn: targetGroupArn }),
+    );
+
+    assertArrayLength(output.TargetHealthDescriptions, 1);
+    assertIdentical(
+      output.TargetHealthDescriptions[0].Target.Id,
+      fixtureFunctionArn,
+    );
+    assertIdentical(
+      output.TargetHealthDescriptions[0].TargetHealth.State,
+      "healthy",
+    );
+  });
+
+  it("refuses a second function in a lambda target group", async () => {
+    // Given a lambda target group holding a function.
+    const simAws = new SimAws();
+    const elbV2 = simAws.elbV2();
+    const targetGroupArn = await createFixtureLambdaTargetGroup(elbV2);
+
+    await elbV2.registerTargets(
+      new RegisterTargetsCommand({
+        TargetGroupArn: targetGroupArn,
+        Targets: [{ Id: fixtureFunctionArn }],
+      }),
+    );
+
+    // When another is registered.
+    const error = await assertThrowsErrorAsync(async () => {
+      await elbV2.registerTargets(
+        new RegisterTargetsCommand({
+          TargetGroupArn: targetGroupArn,
+          Targets: [
+            {
+              Id: "arn:aws:lambda:eu-west-1:888888888888:function:other",
+            },
+          ],
+        }),
+      );
+    });
+
+    assertInstanceOf(error, SimElbV2TooManyTargetsException);
+
+    // Then it is refused, as real ELB takes exactly one.
+    assertStringIncludes(error.message, "it holds at most 1");
+  });
+
+  it("refuses a target the group's type will not take", async () => {
+    // Given one target group of each type.
+    const simAws = new SimAws();
+    const elbV2 = simAws.elbV2();
+    const lambdaGroup = await createFixtureLambdaTargetGroup(elbV2);
+    const ipGroup = await createFixtureIpTargetGroup(elbV2);
+
+    // When each is given the other's kind of target.
+    const address = await assertThrowsErrorAsync(async () => {
+      await elbV2.registerTargets(
+        new RegisterTargetsCommand({
+          TargetGroupArn: lambdaGroup,
+          Targets: [{ Id: "10.0.1.5" }],
+        }),
+      );
+    });
+
+    assertInstanceOf(address, SimElbV2InvalidTargetException);
+
+    const functionArn = await assertThrowsErrorAsync(async () => {
+      await elbV2.registerTargets(
+        new RegisterTargetsCommand({
+          TargetGroupArn: ipGroup,
+          Targets: [{ Id: fixtureFunctionArn }],
+        }),
+      );
+    });
+
+    assertInstanceOf(functionArn, SimElbV2InvalidTargetException);
+
+    // Then both are refused by the group's own target type.
+    assertStringIncludes(address.message, "not a Lambda function ARN");
+    assertStringIncludes(functionArn.message, "not an IP address");
+  });
+
+  it("refuses a port on a function target", async () => {
+    // Given a lambda target group.
+    const simAws = new SimAws();
+    const elbV2 = simAws.elbV2();
+    const targetGroupArn = await createFixtureLambdaTargetGroup(elbV2);
+
+    // When a function is registered with a port.
+    const error = await assertThrowsErrorAsync(async () => {
+      await elbV2.registerTargets(
+        new RegisterTargetsCommand({
+          TargetGroupArn: targetGroupArn,
+          Targets: [{ Id: fixtureFunctionArn, Port: 443 }],
+        }),
+      );
+    });
+
+    assertInstanceOf(error, SimElbV2InvalidTargetException);
+
+    // Then it is refused, as a function is invoked rather than connected to.
+    assertStringIncludes(error.message, "cannot carry a Port");
+  });
+
+  it("gives an address target the group's port when it names none", async () => {
+    // Given an ip target group listening on 8080.
+    const simAws = new SimAws();
+    const elbV2 = simAws.elbV2();
+    const targetGroupArn = await createFixtureIpTargetGroup(elbV2);
+
+    // When two addresses are registered, one with its own port.
+    await elbV2.registerTargets(
+      new RegisterTargetsCommand({
+        TargetGroupArn: targetGroupArn,
+        Targets: [
+          { Id: "10.0.1.5" },
+          { Id: "10.0.1.6", Port: 9090, AvailabilityZone: "all" },
+          { Id: "2001:db8::1" },
+        ],
+      }),
+    );
+
+    // Then the one that named none took the group's port.
+    const output = await elbV2.describeTargetHealth(
+      new DescribeTargetHealthCommand({ TargetGroupArn: targetGroupArn }),
+    );
+
+    assertArrayLength(output.TargetHealthDescriptions, 3);
+    assertIdentical(output.TargetHealthDescriptions[0].Target.Port, 8080);
+    assertIdentical(output.TargetHealthDescriptions[1].Target.Port, 9090);
+    assertIdentical(
+      output.TargetHealthDescriptions[1].Target.AvailabilityZone,
+      "all",
+    );
+  });
+
+  it("takes targets out again, and ignores one that was never in", async () => {
+    // Given an ip target group holding two addresses.
+    const simAws = new SimAws();
+    const elbV2 = simAws.elbV2();
+    const targetGroupArn = await createFixtureIpTargetGroup(elbV2);
+
+    await elbV2.registerTargets(
+      new RegisterTargetsCommand({
+        TargetGroupArn: targetGroupArn,
+        Targets: [{ Id: "10.0.1.5" }, { Id: "10.0.1.6" }],
+      }),
+    );
+
+    // When one of them and one that was never there are deregistered.
+    await elbV2.deregisterTargets(
+      new DeregisterTargetsCommand({
+        TargetGroupArn: targetGroupArn,
+        Targets: [{ Id: "10.0.1.5" }, { Id: "10.0.9.9" }],
+      }),
+    );
+
+    // Then the other is left, and the one that was never there was no error.
+    const output = await elbV2.describeTargetHealth(
+      new DescribeTargetHealthCommand({ TargetGroupArn: targetGroupArn }),
+    );
+
+    assertArrayLength(output.TargetHealthDescriptions, 1);
+    assertIdentical(output.TargetHealthDescriptions[0].Target.Id, "10.0.1.6");
+  });
+
+  it("answers about the targets a health describe names", async () => {
+    // Given an ip target group holding one address.
+    const simAws = new SimAws();
+    const elbV2 = simAws.elbV2();
+    const targetGroupArn = await createFixtureIpTargetGroup(elbV2);
+
+    await elbV2.registerTargets(
+      new RegisterTargetsCommand({
+        TargetGroupArn: targetGroupArn,
+        Targets: [{ Id: "10.0.1.5" }],
+      }),
+    );
+
+    // When it is asked about, and then an address that is not registered.
+    const registered = await elbV2.describeTargetHealth(
+      new DescribeTargetHealthCommand({
+        TargetGroupArn: targetGroupArn,
+        Targets: [{ Id: "10.0.1.5", Port: 8080 }],
+      }),
+    );
+
+    const error = await assertThrowsErrorAsync(async () => {
+      await elbV2.describeTargetHealth(
+        new DescribeTargetHealthCommand({
+          TargetGroupArn: targetGroupArn,
+          Targets: [{ Id: "10.0.9.9" }],
+        }),
+      );
+    });
+
+    assertInstanceOf(error, SimElbV2InvalidTargetException);
+
+    // Then the registered one is answered and the other is refused.
+    assertArrayLength(registered.TargetHealthDescriptions, 1);
+    assertStringIncludes(error.message, "not registered");
+  });
+
+  it("refuses a request with no target group or no targets", async () => {
+    // Given simulated ELBv2.
+    const simAws = new SimAws();
+    const elbV2 = simAws.elbV2();
+    const targetGroupArn = await createFixtureIpTargetGroup(elbV2);
+
+    // When requests leave out what they have to name.
+    const noGroup = await assertThrowsErrorAsync(async () => {
+      await elbV2.registerTargets({ input: {} });
+    });
+
+    assertInstanceOf(noGroup, SimElbV2ValidationError);
+
+    const noTargets = await assertThrowsErrorAsync(async () => {
+      await elbV2.registerTargets(
+        new RegisterTargetsCommand({
+          TargetGroupArn: targetGroupArn,
+          Targets: [],
+        }),
+      );
+    });
+
+    assertInstanceOf(noTargets, SimElbV2ValidationError);
+
+    const noId = await assertThrowsErrorAsync(async () => {
+      await elbV2.registerTargets(
+        new RegisterTargetsCommand({
+          TargetGroupArn: targetGroupArn,
+          Targets: [{ Id: "" }],
+        }),
+      );
+    });
+
+    assertInstanceOf(noId, SimElbV2ValidationError);
+
+    const deregisterNoGroup = await assertThrowsErrorAsync(async () => {
+      await elbV2.deregisterTargets({ input: {} });
+    });
+
+    assertInstanceOf(deregisterNoGroup, SimElbV2ValidationError);
+
+    const deregisterNoTargets = await assertThrowsErrorAsync(async () => {
+      await elbV2.deregisterTargets({
+        input: { TargetGroupArn: targetGroupArn },
+      });
+    });
+
+    assertInstanceOf(deregisterNoTargets, SimElbV2ValidationError);
+
+    const healthNoGroup = await assertThrowsErrorAsync(async () => {
+      await elbV2.describeTargetHealth({ input: {} });
+    });
+
+    assertInstanceOf(healthNoGroup, SimElbV2ValidationError);
+
+    // Then each is refused.
+    assertStringIncludes(noGroup.message, "TargetGroupArn is required");
+    assertStringIncludes(noTargets.message, "at least one target");
+    assertStringIncludes(noId.message, "requires an Id");
+    assertStringIncludes(deregisterNoGroup.message, "TargetGroupArn");
+    assertStringIncludes(deregisterNoTargets.message, "at least one target");
+    assertStringIncludes(healthNoGroup.message, "TargetGroupArn");
+  });
+
+  it("refuses targets for a target group that does not exist", async () => {
+    // Given simulated ELBv2.
+    const simAws = new SimAws();
+    const elbV2 = simAws.elbV2();
+
+    // When targets are registered against an unknown ARN.
+    const error = await assertThrowsErrorAsync(async () => {
+      await elbV2.registerTargets(
+        new RegisterTargetsCommand({
+          TargetGroupArn: "arn:missing",
+          Targets: [{ Id: "10.0.1.5" }],
+        }),
+      );
+    });
+
+    assertInstanceOf(error, SimElbV2TargetGroupNotFoundException);
+
+    // Then it is refused.
+    assertStringIncludes(error.message, "arn:missing");
+  });
+});

--- a/src/service/elbv2/command/target/target.command.ts
+++ b/src/service/elbv2/command/target/target.command.ts
@@ -1,0 +1,89 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type { SimElbV2TargetDescription } from "../../target-group/sim-elbv2-target.js";
+
+/**
+ * Minimal structural sim ELBv2 RegisterTargets command.
+ */
+export interface SimRegisterTargetsCommand {
+  readonly input: SimRegisterTargetsCommandInput;
+}
+
+/**
+ * Minimal structural sim ELBv2 RegisterTargets input.
+ *
+ * https://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_RegisterTargets.html
+ */
+export interface SimRegisterTargetsCommandInput {
+  readonly TargetGroupArn?: string | undefined;
+  readonly Targets?: readonly SimElbV2TargetDescription[] | undefined;
+}
+
+/**
+ * Minimal structural sim ELBv2 RegisterTargets output.
+ */
+export interface SimRegisterTargetsCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim ELBv2 DeregisterTargets command.
+ */
+export interface SimDeregisterTargetsCommand {
+  readonly input: SimDeregisterTargetsCommandInput;
+}
+
+/**
+ * Minimal structural sim ELBv2 DeregisterTargets input.
+ */
+export interface SimDeregisterTargetsCommandInput {
+  readonly TargetGroupArn?: string | undefined;
+  readonly Targets?: readonly SimElbV2TargetDescription[] | undefined;
+}
+
+/**
+ * Minimal structural sim ELBv2 DeregisterTargets output.
+ */
+export interface SimDeregisterTargetsCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim ELBv2 DescribeTargetHealth command.
+ */
+export interface SimDescribeTargetHealthCommand {
+  readonly input: SimDescribeTargetHealthCommandInput;
+}
+
+/**
+ * Minimal structural sim ELBv2 DescribeTargetHealth input.
+ */
+export interface SimDescribeTargetHealthCommandInput {
+  readonly TargetGroupArn?: string | undefined;
+  readonly Targets?: readonly SimElbV2TargetDescription[] | undefined;
+}
+
+/**
+ * Minimal structural sim ELBv2 target health.
+ */
+export interface SimElbV2TargetHealth {
+  readonly State: string;
+  readonly Description?: string | undefined;
+}
+
+/**
+ * Minimal structural sim ELBv2 target health description.
+ */
+export interface SimElbV2TargetHealthDescription {
+  readonly Target: SimElbV2TargetDescription;
+  readonly TargetHealth: SimElbV2TargetHealth;
+}
+
+/**
+ * Minimal structural sim ELBv2 DescribeTargetHealth output.
+ */
+export interface SimDescribeTargetHealthCommandOutput {
+  readonly TargetHealthDescriptions?:
+    | readonly SimElbV2TargetHealthDescription[]
+    | undefined;
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/elbv2/error/sim-elbv2.error.ts
+++ b/src/service/elbv2/error/sim-elbv2.error.ts
@@ -1,0 +1,206 @@
+/**
+ * Minimal metadata shape for simulated Elastic Load Balancing v2 errors.
+ */
+export interface SimElbV2ErrorMetadata {
+  readonly httpStatusCode?: number;
+}
+
+/**
+ * Base class for simulated Elastic Load Balancing v2 errors.
+ */
+export class SimElbV2Error extends Error {
+  constructor(
+    message: string,
+    public readonly $metadata: SimElbV2ErrorMetadata = {},
+  ) {
+    super(message);
+  }
+}
+
+/**
+ * Simulated ELBv2 AccessDeniedException.
+ */
+export class SimElbV2AccessDeniedException extends SimElbV2Error {
+  public override readonly name = "AccessDeniedException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 403 });
+  }
+}
+
+/**
+ * Simulated ELBv2 ValidationError.
+ *
+ * This is what request input ELBv2 will not take produces, such as a load
+ * balancer name outside the allowed characters or a rule priority out of range.
+ */
+export class SimElbV2ValidationError extends SimElbV2Error {
+  public override readonly name = "ValidationError";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
+ * Simulated ELBv2 LoadBalancerNotFoundException.
+ */
+export class SimElbV2LoadBalancerNotFoundException extends SimElbV2Error {
+  public override readonly name = "LoadBalancerNotFoundException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
+ * Simulated ELBv2 TargetGroupNotFoundException.
+ */
+export class SimElbV2TargetGroupNotFoundException extends SimElbV2Error {
+  public override readonly name = "TargetGroupNotFoundException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
+ * Simulated ELBv2 ListenerNotFoundException.
+ */
+export class SimElbV2ListenerNotFoundException extends SimElbV2Error {
+  public override readonly name = "ListenerNotFoundException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
+ * Simulated ELBv2 RuleNotFoundException.
+ */
+export class SimElbV2RuleNotFoundException extends SimElbV2Error {
+  public override readonly name = "RuleNotFoundException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
+ * Simulated ELBv2 DuplicateLoadBalancerNameException.
+ */
+export class SimElbV2DuplicateLoadBalancerNameException extends SimElbV2Error {
+  public override readonly name = "DuplicateLoadBalancerNameException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
+ * Simulated ELBv2 DuplicateTargetGroupNameException.
+ */
+export class SimElbV2DuplicateTargetGroupNameException extends SimElbV2Error {
+  public override readonly name = "DuplicateTargetGroupNameException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
+ * Simulated ELBv2 DuplicateListenerException.
+ *
+ * Two listeners on one load balancer cannot hold the same port.
+ */
+export class SimElbV2DuplicateListenerException extends SimElbV2Error {
+  public override readonly name = "DuplicateListenerException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
+ * Simulated ELBv2 PriorityInUseException.
+ *
+ * Two rules on one listener cannot claim the same priority.
+ */
+export class SimElbV2PriorityInUseException extends SimElbV2Error {
+  public override readonly name = "PriorityInUseException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
+ * Simulated ELBv2 InvalidTargetException.
+ *
+ * A target the target group's type will not take, such as a function ARN in an
+ * `ip` group or an address in a `lambda` one.
+ */
+export class SimElbV2InvalidTargetException extends SimElbV2Error {
+  public override readonly name = "InvalidTargetException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
+ * Simulated ELBv2 TooManyTargetsException.
+ *
+ * A `lambda` target group holds one target, which is what real ELB allows.
+ */
+export class SimElbV2TooManyTargetsException extends SimElbV2Error {
+  public override readonly name = "TooManyTargetsException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
+ * Simulated ELBv2 ResourceInUseException.
+ *
+ * A target group a listener or rule still forwards to cannot be deleted.
+ */
+export class SimElbV2ResourceInUseException extends SimElbV2Error {
+  public override readonly name = "ResourceInUseException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
+ * Simulated ELBv2 InvalidConfigurationRequestException.
+ *
+ * A request whose parts contradict each other, such as a `lambda` target group
+ * given a port, or an HTTPS listener with no certificate.
+ */
+export class SimElbV2InvalidConfigurationRequestException extends SimElbV2Error {
+  public override readonly name = "InvalidConfigurationRequestException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
+ * Request input that real ELBv2 takes and this simulation does not.
+ *
+ * Held apart from a validation failure because the two mean different things:
+ * one says the request is wrong, and this one says the request is right and the
+ * simulator does not go that far. Accepting the input instead would leave a
+ * load balancer looking configured to whoever sent it and unconfigured to
+ * everything else.
+ */
+export class SimElbV2UnsimulatedInputException extends SimElbV2Error {
+  public override readonly name = "UnsimulatedInputException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}

--- a/src/service/elbv2/index.ts
+++ b/src/service/elbv2/index.ts
@@ -1,0 +1,38 @@
+export { SimElbV2 } from "./sim-elbv2.js";
+export type { SimElbV2RequestOptions } from "./command/sim-elbv2-request-options.js";
+export { SimElbV2LoadBalancer } from "./load-balancer/sim-elbv2-load-balancer.js";
+export type { SimElbV2LoadBalancerView } from "./load-balancer/sim-elbv2-load-balancer.js";
+export {
+  simElbV2CanonicalHostedZoneId,
+  simElbV2LoadBalancerArn,
+  simElbV2LoadBalancerDnsName,
+} from "./load-balancer/sim-elbv2-load-balancer-arn.js";
+export type { SimElbV2LoadBalancerScheme } from "./load-balancer/sim-elbv2-load-balancer-scheme.js";
+export { SimElbV2TargetGroup } from "./target-group/sim-elbv2-target-group.js";
+export type { SimElbV2TargetGroupView } from "./target-group/sim-elbv2-target-group.js";
+export { SimElbV2Target } from "./target-group/sim-elbv2-target.js";
+export type { SimElbV2TargetDescription } from "./target-group/sim-elbv2-target.js";
+export { SimElbV2TargetType } from "./target-group/sim-elbv2-target-type.js";
+export { SimElbV2Listener } from "./listener/sim-elbv2-listener.js";
+export type { SimElbV2ListenerView } from "./listener/sim-elbv2-listener.js";
+export { SimElbV2ListenerRule } from "./listener/rule/sim-elbv2-listener-rule.js";
+export type { SimElbV2ListenerRuleView } from "./listener/rule/sim-elbv2-listener-rule.js";
+export { SimElbV2Action } from "./action/sim-elbv2-action.js";
+export {
+  SimElbV2AccessDeniedException,
+  SimElbV2DuplicateListenerException,
+  SimElbV2DuplicateLoadBalancerNameException,
+  SimElbV2DuplicateTargetGroupNameException,
+  SimElbV2Error,
+  SimElbV2InvalidConfigurationRequestException,
+  SimElbV2InvalidTargetException,
+  SimElbV2ListenerNotFoundException,
+  SimElbV2LoadBalancerNotFoundException,
+  SimElbV2PriorityInUseException,
+  SimElbV2ResourceInUseException,
+  SimElbV2RuleNotFoundException,
+  SimElbV2TargetGroupNotFoundException,
+  SimElbV2TooManyTargetsException,
+  SimElbV2UnsimulatedInputException,
+  SimElbV2ValidationError,
+} from "./error/sim-elbv2.error.js";

--- a/src/service/elbv2/listener/rule/sim-elbv2-listener-rule-store.ts
+++ b/src/service/elbv2/listener/rule/sim-elbv2-listener-rule-store.ts
@@ -1,0 +1,93 @@
+import {
+  SimElbV2PriorityInUseException,
+  SimElbV2RuleNotFoundException,
+} from "../../error/sim-elbv2.error.js";
+import type { SimElbV2ListenerRule } from "./sim-elbv2-listener-rule.js";
+
+/**
+ * The listener rules of one simulated ELBv2 scope.
+ *
+ * Priority uniqueness is this store's to keep, because it is a property of a
+ * listener's whole set of rules rather than of any one rule: two rules that
+ * each look valid alone are invalid together if they claim the same place in
+ * the order.
+ */
+export class SimElbV2ListenerRuleStore {
+  private readonly rules = new Map<string, SimElbV2ListenerRule>();
+  private sequence = 0;
+
+  /**
+   * Every rule in this scope, in creation order.
+   */
+  get all(): readonly SimElbV2ListenerRule[] {
+    return this.rules.values().toArray();
+  }
+
+  /**
+   * Take the next id for a rule about to be created.
+   */
+  nextSequence(): number {
+    this.sequence += 1;
+    return this.sequence;
+  }
+
+  /**
+   * Every rule on one listener, in the order that listener evaluates them.
+   */
+  forListener(listenerArn: string): readonly SimElbV2ListenerRule[] {
+    return this.all
+      .filter((rule) => rule.listenerArn === listenerArn)
+      .toSorted((left, right) => left.priority - right.priority);
+  }
+
+  /**
+   * Refuse a priority another rule on the same listener already claims.
+   *
+   * The rule being moved is passed when this is a reordering, so a rule
+   * staying where it is does not clash with itself.
+   */
+  requirePriorityAvailable(
+    listenerArn: string,
+    priority: number,
+    moving?: SimElbV2ListenerRule,
+  ): void {
+    const clash = this.forListener(listenerArn).find(
+      (rule) => rule.priority === priority && rule !== moving,
+    );
+
+    if (clash !== undefined) {
+      throw new SimElbV2PriorityInUseException(
+        `Priority ${String(priority)} is already in use by rule ${clash.arn}`,
+      );
+    }
+  }
+
+  /**
+   * Store a created rule.
+   */
+  put(rule: SimElbV2ListenerRule): void {
+    this.rules.set(rule.arn, rule);
+  }
+
+  /**
+   * Resolve a rule by ARN, or refuse.
+   */
+  requireByArn(arn: string): SimElbV2ListenerRule {
+    const found = this.rules.get(arn);
+
+    if (found === undefined) {
+      throw new SimElbV2RuleNotFoundException(
+        `No sim ELBv2 listener rule with ARN ${arn}`,
+      );
+    }
+
+    return found;
+  }
+
+  /**
+   * Forget a deleted rule.
+   */
+  remove(rule: SimElbV2ListenerRule): void {
+    this.rules.delete(rule.arn);
+  }
+}

--- a/src/service/elbv2/listener/rule/sim-elbv2-listener-rule.ts
+++ b/src/service/elbv2/listener/rule/sim-elbv2-listener-rule.ts
@@ -1,0 +1,130 @@
+import type { SimElbV2Action } from "../../action/sim-elbv2-action.js";
+import type { SimElbV2ActionView } from "../../command/sim-elbv2-shared.command.js";
+import type { SimElbV2Listener } from "../sim-elbv2-listener.js";
+import type { SimElbV2RuleConditionInput } from "../../command/rule/rule-condition.command.js";
+import type { SimElbV2RuleCondition } from "./sim-elbv2-rule-condition.js";
+
+interface SimElbV2ListenerRuleProperties {
+  readonly listenerArn: string;
+  readonly id: string;
+  readonly priority: number;
+  readonly conditions: readonly SimElbV2RuleCondition[];
+  readonly actions: readonly SimElbV2Action[];
+}
+
+/**
+ * What a request can change on an existing rule.
+ */
+export interface SimElbV2ListenerRuleChanges {
+  readonly conditions?: readonly SimElbV2RuleCondition[] | undefined;
+  readonly actions?: readonly SimElbV2Action[] | undefined;
+}
+
+/**
+ * A simulated listener rule as the SDK reads it back.
+ *
+ * `Priority` is a string here rather than a number, which is how real ELB
+ * reports it, because the default rule reports the word `default` in the same
+ * field.
+ */
+export interface SimElbV2ListenerRuleView {
+  readonly RuleArn: string;
+  readonly Priority: string;
+  readonly Conditions: readonly SimElbV2RuleConditionInput[];
+  readonly Actions: readonly SimElbV2ActionView[];
+  readonly IsDefault: boolean;
+}
+
+/**
+ * One simulated rule on a listener.
+ *
+ * A rule's ARN is built from its listener's, so it names the load balancer,
+ * the listener and the rule the way real ELB does, and nothing has to look a
+ * parent up to work out where a rule belongs.
+ */
+export class SimElbV2ListenerRule {
+  public readonly arn: string;
+  public readonly listenerArn: string;
+
+  private currentPriority: number;
+  private currentConditions: readonly SimElbV2RuleCondition[];
+  private currentActions: readonly SimElbV2Action[];
+
+  constructor(properties: SimElbV2ListenerRuleProperties) {
+    this.listenerArn = properties.listenerArn;
+    this.arn = `${properties.listenerArn.replace(
+      ":listener/",
+      ":listener-rule/",
+    )}/${properties.id}`;
+    this.currentPriority = properties.priority;
+    this.currentConditions = properties.conditions;
+    this.currentActions = properties.actions;
+  }
+
+  /** Where this rule sits in the order its listener evaluates rules in. */
+  get priority(): number {
+    return this.currentPriority;
+  }
+
+  /** What a request has to satisfy for this rule to claim it. */
+  get conditions(): readonly SimElbV2RuleCondition[] {
+    return this.currentConditions;
+  }
+
+  /** What this rule does with a request it claims. */
+  get actions(): readonly SimElbV2Action[] {
+    return this.currentActions;
+  }
+
+  /**
+   * Move this rule to another priority.
+   *
+   * Real ELB keeps this apart from `ModifyRule`, which cannot change a
+   * priority, because moving rules about is a reordering of the whole listener
+   * rather than a change to one rule.
+   */
+  reprioritize(priority: number): void {
+    this.currentPriority = priority;
+  }
+
+  /**
+   * Change the conditions or actions a request names, leaving the rest.
+   */
+  modify(changes: SimElbV2ListenerRuleChanges): void {
+    this.currentConditions = changes.conditions ?? this.currentConditions;
+    this.currentActions = changes.actions ?? this.currentActions;
+  }
+
+  /**
+   * Report this rule in the shape the SDK reads it back in.
+   */
+  view(): SimElbV2ListenerRuleView {
+    return {
+      RuleArn: this.arn,
+      Priority: String(this.priority),
+      Conditions: this.conditions.map((condition) => condition.view()),
+      Actions: this.actions.map((action) => action.view()),
+      IsDefault: false,
+    };
+  }
+}
+
+/**
+ * A listener's default actions, reported as the rule real ELB reports them as.
+ *
+ * Real `DescribeRules` answers with the default rule last, priority `default`,
+ * and a stack that reads the rules on a listener expects to find it. It is not
+ * a stored rule, because it is the listener: changing the listener's default
+ * actions changes it.
+ */
+export function simElbV2DefaultRuleView(
+  listener: SimElbV2Listener,
+): SimElbV2ListenerRuleView {
+  return {
+    RuleArn: `${listener.arn.replace(":listener/", ":listener-rule/")}/default`,
+    Priority: "default",
+    Conditions: [],
+    Actions: listener.defaultActions.map((action) => action.view()),
+    IsDefault: true,
+  };
+}

--- a/src/service/elbv2/listener/rule/sim-elbv2-rule-condition.iso.test.ts
+++ b/src/service/elbv2/listener/rule/sim-elbv2-rule-condition.iso.test.ts
@@ -35,7 +35,10 @@ describe("sim ELBv2 rule conditions", () => {
     // Given one condition of each simulated field.
     const conditions = SimElbV2RuleCondition.readAll([
       { Field: "path-pattern", PathPatternConfig: { Values: ["/api/*"] } },
-      { Field: "http-request-method", Values: ["POST"] },
+      {
+        Field: "http-request-method",
+        HttpRequestMethodConfig: { Values: ["POST"] },
+      },
       { Field: "source-ip", SourceIpConfig: { Values: ["10.0.0.0/8"] } },
       {
         Field: "http-header",
@@ -68,6 +71,21 @@ describe("sim ELBv2 rule conditions", () => {
     // Then both are refused, since a rule matching everything is the default.
     assertStringIncludes(absent.message, "at least one condition");
     assertStringIncludes(empty.message, "at least one condition");
+  });
+
+  it("refuses a condition carrying another field's configuration", () => {
+    // Given a host header condition whose only values are a path pattern's.
+    const error = assertThrowsError(() => {
+      SimElbV2RuleCondition.read({
+        Field: "host-header",
+        PathPatternConfig: { Values: ["/api/*"] },
+      });
+    });
+
+    // Then it is refused: the field decides which configuration is read, so
+    // this condition has no host names to match on.
+    assertInstanceOf(error, SimElbV2ValidationError);
+    assertStringIncludes(error.message, "at least one value");
   });
 
   it("refuses a field nothing here understands", () => {

--- a/src/service/elbv2/listener/rule/sim-elbv2-rule-condition.iso.test.ts
+++ b/src/service/elbv2/listener/rule/sim-elbv2-rule-condition.iso.test.ts
@@ -1,0 +1,130 @@
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsError,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import {
+  SimElbV2UnsimulatedInputException,
+  SimElbV2ValidationError,
+} from "../../error/sim-elbv2.error.js";
+import { SimElbV2RuleCondition } from "./sim-elbv2-rule-condition.js";
+
+describe("sim ELBv2 rule conditions", () => {
+  it("takes values in either of the two forms ELB writes them in", () => {
+    // Given a host header condition written each way.
+    const plain = SimElbV2RuleCondition.read({
+      Field: "host-header",
+      Values: ["shop.example.com"],
+    });
+    const configured = SimElbV2RuleCondition.read({
+      Field: "host-header",
+      HostHeaderConfig: { Values: ["shop.example.com"] },
+    });
+
+    // Then both are read as host header conditions.
+    assertIdentical(plain.field, "host-header");
+    assertIdentical(configured.field, "host-header");
+    assertIdentical(configured.view().Field, "host-header");
+  });
+
+  it("takes the conditions an ALB rule can be written on", () => {
+    // Given one condition of each simulated field.
+    const conditions = SimElbV2RuleCondition.readAll([
+      { Field: "path-pattern", PathPatternConfig: { Values: ["/api/*"] } },
+      { Field: "http-request-method", Values: ["POST"] },
+      { Field: "source-ip", SourceIpConfig: { Values: ["10.0.0.0/8"] } },
+      {
+        Field: "http-header",
+        HttpHeaderConfig: { HttpHeaderName: "X-Tenant", Values: ["shop"] },
+      },
+      {
+        Field: "query-string",
+        QueryStringConfig: { Values: [{ Key: "version", Value: "2" }] },
+      },
+    ]);
+
+    // Then all five are accepted.
+    assertArrayLength(conditions, 5);
+  });
+
+  it("refuses a condition list that is empty or absent", () => {
+    // Given no conditions at all, and an empty list.
+    const absent = assertThrowsError(() => {
+      SimElbV2RuleCondition.readAll(undefined);
+    });
+
+    assertInstanceOf(absent, SimElbV2ValidationError);
+
+    const empty = assertThrowsError(() => {
+      SimElbV2RuleCondition.readAll([]);
+    });
+
+    assertInstanceOf(empty, SimElbV2ValidationError);
+
+    // Then both are refused, since a rule matching everything is the default.
+    assertStringIncludes(absent.message, "at least one condition");
+    assertStringIncludes(empty.message, "at least one condition");
+  });
+
+  it("refuses a field nothing here understands", () => {
+    // Given a condition with no field, and one on a field ELB does not have.
+    const noField = assertThrowsError(() => {
+      SimElbV2RuleCondition.read({});
+    });
+
+    assertInstanceOf(noField, SimElbV2ValidationError);
+
+    const unknown = assertThrowsError(() => {
+      SimElbV2RuleCondition.read({ Field: "user-agent", Values: ["curl"] });
+    });
+
+    assertInstanceOf(unknown, SimElbV2UnsimulatedInputException);
+
+    // Then both are refused rather than stored and never matched.
+    assertStringIncludes(noField.message, "requires a Field");
+    assertStringIncludes(unknown.message, "not simulated");
+  });
+
+  it("refuses a condition with nothing to compare against", () => {
+    // Given conditions of three fields, each missing its values.
+    const hostHeader = assertThrowsError(() => {
+      SimElbV2RuleCondition.read({ Field: "host-header" });
+    });
+
+    assertInstanceOf(hostHeader, SimElbV2ValidationError);
+
+    const httpHeaderName = assertThrowsError(() => {
+      SimElbV2RuleCondition.read({
+        Field: "http-header",
+        HttpHeaderConfig: { Values: ["shop"] },
+      });
+    });
+
+    assertInstanceOf(httpHeaderName, SimElbV2ValidationError);
+
+    const httpHeaderValues = assertThrowsError(() => {
+      SimElbV2RuleCondition.read({
+        Field: "http-header",
+        HttpHeaderConfig: { HttpHeaderName: "X-Tenant" },
+      });
+    });
+
+    assertInstanceOf(httpHeaderValues, SimElbV2ValidationError);
+
+    const queryString = assertThrowsError(() => {
+      SimElbV2RuleCondition.read({ Field: "query-string" });
+    });
+
+    assertInstanceOf(queryString, SimElbV2ValidationError);
+
+    // Then each is refused.
+    assertStringIncludes(hostHeader.message, "at least one value");
+    assertStringIncludes(httpHeaderName.message, "HttpHeaderName");
+    assertStringIncludes(httpHeaderValues.message, "at least one value");
+    assertStringIncludes(queryString.message, "key and value pair");
+  });
+});

--- a/src/service/elbv2/listener/rule/sim-elbv2-rule-condition.ts
+++ b/src/service/elbv2/listener/rule/sim-elbv2-rule-condition.ts
@@ -1,0 +1,141 @@
+import type { SimElbV2RuleConditionInput } from "../../command/rule/rule-condition.command.js";
+import {
+  SimElbV2UnsimulatedInputException,
+  SimElbV2ValidationError,
+} from "../../error/sim-elbv2.error.js";
+
+/**
+ * The condition fields an Application Load Balancer rule can be written on.
+ */
+const simulatedFields = new Set([
+  "host-header",
+  "path-pattern",
+  "http-header",
+  "http-request-method",
+  "query-string",
+  "source-ip",
+]);
+
+/**
+ * One condition on a simulated listener rule.
+ *
+ * Conditions are held rather than matched here, and matching a request against
+ * them is separate work. What this class owns is that a condition stored on a
+ * rule is one that could match something: a field nothing understands, or a
+ * field with nothing to compare against, is refused when the rule is written
+ * rather than ignored when a request arrives.
+ */
+export class SimElbV2RuleCondition {
+  public readonly field: string;
+
+  private readonly input: SimElbV2RuleConditionInput;
+
+  private constructor(input: SimElbV2RuleConditionInput, field: string) {
+    this.input = input;
+    this.field = field;
+  }
+
+  /**
+   * Read the conditions a request carries, refusing an empty or absent list.
+   */
+  static readAll(
+    conditions: readonly SimElbV2RuleConditionInput[] | undefined,
+  ): readonly SimElbV2RuleCondition[] {
+    if (conditions === undefined || conditions.length === 0) {
+      throw new SimElbV2ValidationError(
+        "Conditions must hold at least one condition",
+      );
+    }
+
+    return conditions.map((condition) => this.read(condition));
+  }
+
+  /**
+   * Read one condition, refusing a field or value list ELB would not take.
+   */
+  static read(input: SimElbV2RuleConditionInput): SimElbV2RuleCondition {
+    const field = input.Field;
+
+    if (field === undefined || field === "") {
+      throw new SimElbV2ValidationError("Conditions member requires a Field");
+    }
+
+    if (!simulatedFields.has(field)) {
+      throw new SimElbV2UnsimulatedInputException(
+        `Condition field '${field}' is not simulated. Simulated fields are ` +
+          `${[...simulatedFields].join(", ")}.`,
+      );
+    }
+
+    const condition = new SimElbV2RuleCondition(input, field);
+
+    condition.validate();
+
+    return condition;
+  }
+
+  /**
+   * Report this condition in the shape the SDK reads it back in.
+   */
+  view(): SimElbV2RuleConditionInput {
+    return this.input;
+  }
+
+  private validate(): void {
+    if (this.field === "http-header") {
+      this.validateHttpHeader();
+      return;
+    }
+
+    if (this.field === "query-string") {
+      this.validateQueryString();
+      return;
+    }
+
+    if (this.valueCount() === 0) {
+      throw new SimElbV2ValidationError(
+        `A '${this.field}' condition requires at least one value`,
+      );
+    }
+  }
+
+  private validateHttpHeader(): void {
+    const config = this.input.HttpHeaderConfig;
+
+    if (config?.HttpHeaderName === undefined || config.HttpHeaderName === "") {
+      throw new SimElbV2ValidationError(
+        "An 'http-header' condition requires an HttpHeaderConfig with an " +
+          "HttpHeaderName",
+      );
+    }
+
+    if ((config.Values ?? []).length === 0) {
+      throw new SimElbV2ValidationError(
+        "An 'http-header' condition requires at least one value",
+      );
+    }
+  }
+
+  private validateQueryString(): void {
+    if ((this.input.QueryStringConfig?.Values ?? []).length === 0) {
+      throw new SimElbV2ValidationError(
+        "A 'query-string' condition requires a QueryStringConfig with at " +
+          "least one key and value pair",
+      );
+    }
+  }
+
+  /**
+   * How many values this condition compares against, in either of the two
+   * forms ELB takes them in.
+   */
+  private valueCount(): number {
+    const configValues =
+      this.input.HostHeaderConfig ??
+      this.input.PathPatternConfig ??
+      this.input.HttpRequestMethodConfig ??
+      this.input.SourceIpConfig;
+
+    return (this.input.Values ?? configValues?.Values ?? []).length;
+  }
+}

--- a/src/service/elbv2/listener/rule/sim-elbv2-rule-condition.ts
+++ b/src/service/elbv2/listener/rule/sim-elbv2-rule-condition.ts
@@ -1,20 +1,55 @@
-import type { SimElbV2RuleConditionInput } from "../../command/rule/rule-condition.command.js";
+import type {
+  SimElbV2ConditionValues,
+  SimElbV2RuleConditionInput,
+} from "../../command/rule/rule-condition.command.js";
 import {
   SimElbV2UnsimulatedInputException,
   SimElbV2ValidationError,
 } from "../../error/sim-elbv2.error.js";
 
 /**
- * The condition fields an Application Load Balancer rule can be written on.
+ * The condition fields whose values are a plain list, and where each one keeps
+ * them.
+ *
+ * The field decides which configuration is read rather than the first one that
+ * happens to be there, so a `host-header` condition carrying only a
+ * `PathPatternConfig` has no values and is refused, as it is on real ELB.
  */
-const simulatedFields = new Set([
-  "host-header",
-  "path-pattern",
-  "http-header",
-  "http-request-method",
-  "query-string",
-  "source-ip",
+const valueFields = new Map<
+  string,
+  (input: SimElbV2RuleConditionInput) => SimElbV2ConditionValues | undefined
+>([
+  [
+    "host-header",
+    (input): SimElbV2ConditionValues | undefined => input.HostHeaderConfig,
+  ],
+  [
+    "path-pattern",
+    (input): SimElbV2ConditionValues | undefined => input.PathPatternConfig,
+  ],
+  [
+    "http-request-method",
+    (input): SimElbV2ConditionValues | undefined =>
+      input.HttpRequestMethodConfig,
+  ],
+  [
+    "source-ip",
+    (input): SimElbV2ConditionValues | undefined => input.SourceIpConfig,
+  ],
 ]);
+
+/**
+ * The condition fields carrying a shape of their own rather than a value list,
+ * each checked by its own rule.
+ */
+const shapedFields = new Set(["http-header", "query-string"]);
+
+/**
+ * Every condition field an Application Load Balancer rule can be written on.
+ */
+function simulatedFieldNames(): readonly string[] {
+  return [...valueFields.keys(), ...shapedFields];
+}
 
 /**
  * One condition on a simulated listener rule.
@@ -31,7 +66,10 @@ export class SimElbV2RuleCondition {
   private readonly input: SimElbV2RuleConditionInput;
 
   private constructor(input: SimElbV2RuleConditionInput, field: string) {
-    this.input = input;
+    // Copied, so that a caller mutating the command input it sent cannot
+    // change what a rule matches on afterwards. Real ELB reads the request off
+    // the wire, and nothing a caller does to its own objects reaches it.
+    this.input = structuredClone(input);
     this.field = field;
   }
 
@@ -60,10 +98,10 @@ export class SimElbV2RuleCondition {
       throw new SimElbV2ValidationError("Conditions member requires a Field");
     }
 
-    if (!simulatedFields.has(field)) {
+    if (!valueFields.has(field) && !shapedFields.has(field)) {
       throw new SimElbV2UnsimulatedInputException(
         `Condition field '${field}' is not simulated. Simulated fields are ` +
-          `${[...simulatedFields].join(", ")}.`,
+          `${simulatedFieldNames().join(", ")}.`,
       );
     }
 
@@ -82,21 +120,32 @@ export class SimElbV2RuleCondition {
   }
 
   private validate(): void {
+    const readValues = valueFields.get(this.field);
+
+    if (readValues === undefined) {
+      this.validateShapedField();
+      return;
+    }
+
+    if (
+      (this.input.Values ?? readValues(this.input)?.Values ?? []).length === 0
+    ) {
+      throw new SimElbV2ValidationError(
+        `A '${this.field}' condition requires at least one value`,
+      );
+    }
+  }
+
+  /**
+   * Check a field whose values are not a plain list against its own rule.
+   */
+  private validateShapedField(): void {
     if (this.field === "http-header") {
       this.validateHttpHeader();
       return;
     }
 
-    if (this.field === "query-string") {
-      this.validateQueryString();
-      return;
-    }
-
-    if (this.valueCount() === 0) {
-      throw new SimElbV2ValidationError(
-        `A '${this.field}' condition requires at least one value`,
-      );
-    }
+    this.validateQueryString();
   }
 
   private validateHttpHeader(): void {
@@ -123,19 +172,5 @@ export class SimElbV2RuleCondition {
           "least one key and value pair",
       );
     }
-  }
-
-  /**
-   * How many values this condition compares against, in either of the two
-   * forms ELB takes them in.
-   */
-  private valueCount(): number {
-    const configValues =
-      this.input.HostHeaderConfig ??
-      this.input.PathPatternConfig ??
-      this.input.HttpRequestMethodConfig ??
-      this.input.SourceIpConfig;
-
-    return (this.input.Values ?? configValues?.Values ?? []).length;
   }
 }

--- a/src/service/elbv2/listener/rule/sim-elbv2-rule-priority.ts
+++ b/src/service/elbv2/listener/rule/sim-elbv2-rule-priority.ts
@@ -1,0 +1,27 @@
+import { SimElbV2ValidationError } from "../../error/sim-elbv2.error.js";
+
+/**
+ * The highest priority real ELB takes on a listener rule.
+ */
+const maximumPriority = 50_000;
+
+/**
+ * Read the priority a request names for a rule.
+ *
+ * Priority decides which rule claims a request when more than one could, so it
+ * is required rather than defaulted: a rule with no place in the order has no
+ * defined behaviour once a second rule exists.
+ */
+export function simElbV2RulePriority(value: number | undefined): number {
+  if (value === undefined) {
+    throw new SimElbV2ValidationError("Priority is required");
+  }
+
+  if (!Number.isSafeInteger(value) || value < 1 || value > maximumPriority) {
+    throw new SimElbV2ValidationError(
+      `Priority ${String(value)} is not between 1 and ${String(maximumPriority)}`,
+    );
+  }
+
+  return value;
+}

--- a/src/service/elbv2/listener/sim-elbv2-listener-security.ts
+++ b/src/service/elbv2/listener/sim-elbv2-listener-security.ts
@@ -1,0 +1,46 @@
+import type { SimElbV2Certificate } from "../command/sim-elbv2-shared.command.js";
+import { SimElbV2InvalidConfigurationRequestException } from "../error/sim-elbv2.error.js";
+
+/**
+ * The security policy real ELB gives an HTTPS listener that names none.
+ */
+const defaultSslPolicy = "ELBSecurityPolicy-2016-08";
+
+/**
+ * What a listener's protocol decides about its TLS settings.
+ *
+ * Both rules here are about the same thing, that HTTPS needs what HTTP does
+ * not, and both are asked on a create and again on a modify, so they live
+ * beside each other rather than inside the listener.
+ */
+
+/**
+ * The security policy a listener holds, which is none unless it is HTTPS.
+ */
+export function simElbV2ListenerSslPolicy(
+  protocol: string,
+  sslPolicy: string | undefined,
+): string | undefined {
+  if (protocol !== "HTTPS") {
+    return undefined;
+  }
+
+  return sslPolicy ?? defaultSslPolicy;
+}
+
+/**
+ * Refuse an HTTPS listener with no certificate.
+ *
+ * One could not complete a handshake, so real ELB refuses to create it and so
+ * does this.
+ */
+export function requireSimElbV2ListenerCertificate(
+  protocol: string,
+  certificates: readonly SimElbV2Certificate[],
+): void {
+  if (protocol === "HTTPS" && certificates.length === 0) {
+    throw new SimElbV2InvalidConfigurationRequestException(
+      "An HTTPS listener requires at least one certificate",
+    );
+  }
+}

--- a/src/service/elbv2/listener/sim-elbv2-listener-store.ts
+++ b/src/service/elbv2/listener/sim-elbv2-listener-store.ts
@@ -1,0 +1,95 @@
+import {
+  SimElbV2DuplicateListenerException,
+  SimElbV2ListenerNotFoundException,
+} from "../error/sim-elbv2.error.js";
+import type { SimElbV2Listener } from "./sim-elbv2-listener.js";
+
+/**
+ * The listeners of one simulated ELBv2 scope.
+ *
+ * Listeners belong to a load balancer, and are held here rather than on it so
+ * that a describe by listener ARN needs no load balancer to start from, which
+ * is how the SDK addresses them.
+ */
+export class SimElbV2ListenerStore {
+  private readonly listeners = new Map<string, SimElbV2Listener>();
+  private sequence = 0;
+
+  /**
+   * Every listener in this scope, in creation order.
+   */
+  get all(): readonly SimElbV2Listener[] {
+    return this.listeners.values().toArray();
+  }
+
+  /**
+   * Take the next id for a listener about to be created.
+   */
+  nextSequence(): number {
+    this.sequence += 1;
+    return this.sequence;
+  }
+
+  /**
+   * Every listener on one load balancer.
+   */
+  forLoadBalancer(loadBalancerArn: string): readonly SimElbV2Listener[] {
+    return this.all.filter(
+      (listener) => listener.loadBalancerArn === loadBalancerArn,
+    );
+  }
+
+  /**
+   * Refuse a port another listener on the same load balancer already answers
+   * on.
+   *
+   * The listener being changed is passed when this is a modification, so a
+   * request leaving a listener on the port it already holds is not a clash
+   * with itself.
+   */
+  requirePortAvailable(
+    loadBalancerArn: string,
+    port: number,
+    changing?: SimElbV2Listener,
+  ): void {
+    const clash = this.forLoadBalancer(loadBalancerArn).find(
+      (listener) => listener.port === port && listener !== changing,
+    );
+
+    if (clash !== undefined) {
+      throw new SimElbV2DuplicateListenerException(
+        `A listener on port ${String(port)} already exists on this load ` +
+          `balancer`,
+      );
+    }
+  }
+
+  /**
+   * Store a created listener.
+   */
+  put(listener: SimElbV2Listener): void {
+    this.listeners.set(listener.arn, listener);
+  }
+
+  /**
+   * Resolve a listener by ARN, or refuse.
+   */
+  requireByArn(arn: string): SimElbV2Listener {
+    const found = this.listeners.get(arn);
+
+    if (found === undefined) {
+      throw new SimElbV2ListenerNotFoundException(
+        `No sim ELBv2 listener with ARN ${arn}`,
+      );
+    }
+
+    return found;
+  }
+
+  /**
+   * Forget a deleted listener.
+   */
+  remove(listener: SimElbV2Listener): void {
+    this.listeners.delete(listener.arn);
+  }
+}

--- a/src/service/elbv2/listener/sim-elbv2-listener.ts
+++ b/src/service/elbv2/listener/sim-elbv2-listener.ts
@@ -72,7 +72,9 @@ export class SimElbV2Listener {
       properties.protocol,
       properties.sslPolicy,
     );
-    this.currentCertificates = properties.certificates;
+    // Copied for the same reason an action's input is: what a listener
+    // presents cannot change because a caller reused the array it sent.
+    this.currentCertificates = structuredClone(properties.certificates);
     this.currentDefaultActions = properties.defaultActions;
 
     requireSimElbV2ListenerCertificate(properties.protocol, this.certificates);
@@ -114,7 +116,7 @@ export class SimElbV2Listener {
 
     this.currentPort = changes.port ?? this.currentPort;
     this.currentProtocol = protocol;
-    this.currentCertificates = certificates;
+    this.currentCertificates = structuredClone(certificates);
     this.currentSslPolicy = simElbV2ListenerSslPolicy(
       protocol,
       changes.sslPolicy ?? this.currentSslPolicy,

--- a/src/service/elbv2/listener/sim-elbv2-listener.ts
+++ b/src/service/elbv2/listener/sim-elbv2-listener.ts
@@ -1,0 +1,140 @@
+import type { SimElbV2Action } from "../action/sim-elbv2-action.js";
+import type {
+  SimElbV2ActionView,
+  SimElbV2Certificate,
+} from "../command/sim-elbv2-shared.command.js";
+import {
+  requireSimElbV2ListenerCertificate,
+  simElbV2ListenerSslPolicy,
+} from "./sim-elbv2-listener-security.js";
+
+interface SimElbV2ListenerProperties {
+  readonly loadBalancerArn: string;
+  readonly id: string;
+  readonly port: number;
+  readonly protocol: string;
+  readonly sslPolicy: string | undefined;
+  readonly certificates: readonly SimElbV2Certificate[];
+  readonly defaultActions: readonly SimElbV2Action[];
+}
+
+/**
+ * What a request can change on an existing listener.
+ */
+export interface SimElbV2ListenerChanges {
+  readonly port?: number | undefined;
+  readonly protocol?: string | undefined;
+  readonly sslPolicy?: string | undefined;
+  readonly certificates?: readonly SimElbV2Certificate[] | undefined;
+  readonly defaultActions?: readonly SimElbV2Action[] | undefined;
+}
+
+/**
+ * A simulated listener as the SDK reads it back.
+ */
+export interface SimElbV2ListenerView {
+  readonly ListenerArn: string;
+  readonly LoadBalancerArn: string;
+  readonly Port: number;
+  readonly Protocol: string;
+  readonly SslPolicy?: string | undefined;
+  readonly Certificates: readonly SimElbV2Certificate[];
+  readonly DefaultActions: readonly SimElbV2ActionView[];
+}
+
+/**
+ * One simulated listener on an Application Load Balancer.
+ *
+ * A listener's ARN is built from its load balancer's rather than from the
+ * scope, which is what makes the load balancer's name and id appear in it the
+ * way real ELB has them, and what makes a listener ARN say which load balancer
+ * it belongs to without anything having to look it up.
+ */
+export class SimElbV2Listener {
+  public readonly arn: string;
+  public readonly loadBalancerArn: string;
+
+  private currentPort: number;
+  private currentProtocol: string;
+  private currentSslPolicy: string | undefined;
+  private currentCertificates: readonly SimElbV2Certificate[];
+  private currentDefaultActions: readonly SimElbV2Action[];
+
+  constructor(properties: SimElbV2ListenerProperties) {
+    this.loadBalancerArn = properties.loadBalancerArn;
+    this.arn = `${properties.loadBalancerArn.replace(
+      ":loadbalancer/",
+      ":listener/",
+    )}/${properties.id}`;
+    this.currentPort = properties.port;
+    this.currentProtocol = properties.protocol;
+    this.currentSslPolicy = simElbV2ListenerSslPolicy(
+      properties.protocol,
+      properties.sslPolicy,
+    );
+    this.currentCertificates = properties.certificates;
+    this.currentDefaultActions = properties.defaultActions;
+
+    requireSimElbV2ListenerCertificate(properties.protocol, this.certificates);
+  }
+
+  /** The port this listener answers on. */
+  get port(): number {
+    return this.currentPort;
+  }
+
+  /** The protocol this listener speaks. */
+  get protocol(): string {
+    return this.currentProtocol;
+  }
+
+  /** The certificates an HTTPS listener presents. */
+  get certificates(): readonly SimElbV2Certificate[] {
+    return this.currentCertificates;
+  }
+
+  /** What this listener does with a request no rule claims. */
+  get defaultActions(): readonly SimElbV2Action[] {
+    return this.currentDefaultActions;
+  }
+
+  /**
+   * Change what a request names, leaving the rest as it was.
+   *
+   * The certificate rule is checked against the listener as it would be after
+   * the change rather than against the request, so switching a listener to
+   * HTTPS and giving it a certificate in one request is allowed and switching
+   * it without one is not.
+   */
+  modify(changes: SimElbV2ListenerChanges): void {
+    const protocol = changes.protocol ?? this.currentProtocol;
+    const certificates = changes.certificates ?? this.currentCertificates;
+
+    requireSimElbV2ListenerCertificate(protocol, certificates);
+
+    this.currentPort = changes.port ?? this.currentPort;
+    this.currentProtocol = protocol;
+    this.currentCertificates = certificates;
+    this.currentSslPolicy = simElbV2ListenerSslPolicy(
+      protocol,
+      changes.sslPolicy ?? this.currentSslPolicy,
+    );
+    this.currentDefaultActions =
+      changes.defaultActions ?? this.currentDefaultActions;
+  }
+
+  /**
+   * Report this listener in the shape the SDK reads it back in.
+   */
+  view(): SimElbV2ListenerView {
+    return {
+      ListenerArn: this.arn,
+      LoadBalancerArn: this.loadBalancerArn,
+      Port: this.port,
+      Protocol: this.protocol,
+      SslPolicy: this.currentSslPolicy,
+      Certificates: this.certificates,
+      DefaultActions: this.defaultActions.map((action) => action.view()),
+    };
+  }
+}

--- a/src/service/elbv2/load-balancer/sim-elbv2-load-balancer-arn.ts
+++ b/src/service/elbv2/load-balancer/sim-elbv2-load-balancer-arn.ts
@@ -1,0 +1,54 @@
+import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+import type { SimElbV2LoadBalancerScheme } from "./sim-elbv2-load-balancer-scheme.js";
+
+/**
+ * The ARN of one simulated Application Load Balancer.
+ *
+ * An ALB ARN names the load balancer type as well as the load balancer:
+ * `arn:aws:elasticloadbalancing:<region>:<account>:loadbalancer/app/<name>/<id>`.
+ * The `app/` part is what tells it apart from a network or gateway load
+ * balancer, and everything derived from it, a listener ARN above all, carries
+ * that part too.
+ */
+export function simElbV2LoadBalancerArn(
+  name: string,
+  id: string,
+  scope: SimAwsAccountRegionScope,
+): string {
+  return (
+    `arn:aws:elasticloadbalancing:${scope.regionName}:${scope.accountId}:` +
+    `loadbalancer/app/${name}/${id}`
+  );
+}
+
+/**
+ * The DNS name real ELB issues for a load balancer.
+ *
+ * This is the whole point of creating one here: a Route53 alias or a CloudFront
+ * origin needs a host name of the right shape to point at, and it is the only
+ * name by which anything reaches a load balancer on real AWS. An internal load
+ * balancer's name carries the `internal-` prefix real ELB gives it, which is
+ * why that prefix is refused in a load balancer's own name.
+ */
+export function simElbV2LoadBalancerDnsName(
+  name: string,
+  suffix: string,
+  scheme: SimElbV2LoadBalancerScheme,
+  scope: SimAwsAccountRegionScope,
+): string {
+  const prefix = scheme === "internal" ? "internal-" : "";
+
+  return `${prefix}${name}-${suffix}.${scope.regionName}.elb.amazonaws.com`;
+}
+
+/**
+ * The Route53 hosted zone a load balancer's DNS name lives in.
+ *
+ * Real ELB has one of these per region, published by AWS and needed by an
+ * alias record pointing at a load balancer. This simulation issues one value
+ * everywhere instead of carrying that table, because simulated Route53
+ * resolves an alias by looking the target up rather than by its zone id, so
+ * only the shape is load bearing. A test copying this value into a real
+ * template would be copying the wrong one.
+ */
+export const simElbV2CanonicalHostedZoneId = "Z0000000000000";

--- a/src/service/elbv2/load-balancer/sim-elbv2-load-balancer-name.ts
+++ b/src/service/elbv2/load-balancer/sim-elbv2-load-balancer-name.ts
@@ -1,0 +1,26 @@
+import { SimElbV2ValidationError } from "../error/sim-elbv2.error.js";
+import { readSimElbV2Name } from "../sim-elbv2-resource-name.js";
+
+/**
+ * The prefix real ELB reserves for the DNS name of an internal load balancer.
+ *
+ * A load balancer named with it could not be told apart from an internal one
+ * by host name alone, which is why real ELB refuses the name.
+ */
+const reservedPrefix = "internal-";
+
+/**
+ * Read the name of a load balancer a request names.
+ */
+export function simElbV2LoadBalancerName(value: string | undefined): string {
+  const name = readSimElbV2Name("LoadBalancerName", value ?? "");
+
+  if (name.startsWith(reservedPrefix)) {
+    throw new SimElbV2ValidationError(
+      `LoadBalancerName '${name}' cannot begin with '${reservedPrefix}', ` +
+        `which real ELB reserves for the DNS name of an internal load balancer`,
+    );
+  }
+
+  return name;
+}

--- a/src/service/elbv2/load-balancer/sim-elbv2-load-balancer-scheme.ts
+++ b/src/service/elbv2/load-balancer/sim-elbv2-load-balancer-scheme.ts
@@ -1,0 +1,38 @@
+import { SimElbV2ValidationError } from "../error/sim-elbv2.error.js";
+
+/**
+ * Whether a load balancer answers from the internet or only from inside a VPC.
+ *
+ * The difference is visible here in one place, the DNS name, since an internal
+ * load balancer's host name carries an `internal-` prefix. Nothing about
+ * reachability follows from it in this simulation, because there is no network
+ * boundary to be on either side of.
+ */
+export type SimElbV2LoadBalancerScheme = "internet-facing" | "internal";
+
+const schemes = new Set<string>(["internet-facing", "internal"]);
+
+/**
+ * The scheme real ELB gives a load balancer whose request names none.
+ */
+const defaultScheme: SimElbV2LoadBalancerScheme = "internet-facing";
+
+/**
+ * Read the scheme a request names, defaulting as real ELB does.
+ */
+export function simElbV2LoadBalancerScheme(
+  value: string | undefined,
+): SimElbV2LoadBalancerScheme {
+  if (value === undefined) {
+    return defaultScheme;
+  }
+
+  if (!schemes.has(value)) {
+    throw new SimElbV2ValidationError(
+      `Scheme '${value}' is not valid. A scheme is ` +
+        `${[...schemes].join(" or ")}.`,
+    );
+  }
+
+  return value as SimElbV2LoadBalancerScheme;
+}

--- a/src/service/elbv2/load-balancer/sim-elbv2-load-balancer-store.ts
+++ b/src/service/elbv2/load-balancer/sim-elbv2-load-balancer-store.ts
@@ -1,0 +1,95 @@
+import {
+  SimElbV2DuplicateLoadBalancerNameException,
+  SimElbV2LoadBalancerNotFoundException,
+} from "../error/sim-elbv2.error.js";
+import type { SimElbV2LoadBalancer } from "./sim-elbv2-load-balancer.js";
+
+/**
+ * The load balancers of one simulated ELBv2 scope.
+ *
+ * A name is unique within an account and region on real ELB rather than
+ * globally, which is the same scope this store is created in, so holding the
+ * names here is all that uniqueness needs.
+ */
+export class SimElbV2LoadBalancerStore {
+  private readonly loadBalancers = new Map<string, SimElbV2LoadBalancer>();
+  private sequence = 0;
+
+  /**
+   * Every load balancer in this scope, in creation order.
+   */
+  get all(): readonly SimElbV2LoadBalancer[] {
+    return this.loadBalancers.values().toArray();
+  }
+
+  /**
+   * Take the next id for a load balancer about to be created.
+   */
+  nextSequence(): number {
+    this.sequence += 1;
+    return this.sequence;
+  }
+
+  /**
+   * Refuse a name another load balancer in this scope already holds.
+   */
+  requireNameAvailable(name: string): void {
+    if (this.findByName(name) !== undefined) {
+      throw new SimElbV2DuplicateLoadBalancerNameException(
+        `A load balancer named '${name}' already exists in this account and ` +
+          `region`,
+      );
+    }
+  }
+
+  /**
+   * Store a created load balancer.
+   */
+  put(loadBalancer: SimElbV2LoadBalancer): void {
+    this.loadBalancers.set(loadBalancer.arn, loadBalancer);
+  }
+
+  /**
+   * Find a load balancer by name.
+   */
+  findByName(name: string): SimElbV2LoadBalancer | undefined {
+    return this.all.find((loadBalancer) => loadBalancer.name === name);
+  }
+
+  /**
+   * Resolve a load balancer by ARN, or refuse.
+   */
+  requireByArn(arn: string): SimElbV2LoadBalancer {
+    const found = this.loadBalancers.get(arn);
+
+    if (found === undefined) {
+      throw new SimElbV2LoadBalancerNotFoundException(
+        `No sim ELBv2 load balancer with ARN ${arn}`,
+      );
+    }
+
+    return found;
+  }
+
+  /**
+   * Resolve a load balancer by name, or refuse.
+   */
+  requireByName(name: string): SimElbV2LoadBalancer {
+    const found = this.findByName(name);
+
+    if (found === undefined) {
+      throw new SimElbV2LoadBalancerNotFoundException(
+        `No sim ELBv2 load balancer named ${name}`,
+      );
+    }
+
+    return found;
+  }
+
+  /**
+   * Forget a deleted load balancer.
+   */
+  remove(loadBalancer: SimElbV2LoadBalancer): void {
+    this.loadBalancers.delete(loadBalancer.arn);
+  }
+}

--- a/src/service/elbv2/load-balancer/sim-elbv2-load-balancer.ts
+++ b/src/service/elbv2/load-balancer/sim-elbv2-load-balancer.ts
@@ -1,0 +1,97 @@
+import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+import {
+  simElbV2CanonicalHostedZoneId,
+  simElbV2LoadBalancerArn,
+  simElbV2LoadBalancerDnsName,
+} from "./sim-elbv2-load-balancer-arn.js";
+import type { SimElbV2LoadBalancerScheme } from "./sim-elbv2-load-balancer-scheme.js";
+
+interface SimElbV2LoadBalancerProperties {
+  readonly name: string;
+  readonly scheme: SimElbV2LoadBalancerScheme;
+  readonly ipAddressType: string;
+  readonly id: string;
+  readonly dnsSuffix: string;
+  readonly createdTime: Date;
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+}
+
+/**
+ * How a load balancer is reported once it is ready to take requests.
+ */
+export interface SimElbV2LoadBalancerStateView {
+  readonly Code: string;
+}
+
+/**
+ * A simulated load balancer as the SDK reads it back.
+ */
+export interface SimElbV2LoadBalancerView {
+  readonly LoadBalancerArn: string;
+  readonly LoadBalancerName: string;
+  readonly DNSName: string;
+  readonly CanonicalHostedZoneId: string;
+  readonly CreatedTime: Date;
+  readonly Scheme: SimElbV2LoadBalancerScheme;
+  readonly Type: string;
+  readonly State: SimElbV2LoadBalancerStateView;
+  readonly IpAddressType: string;
+}
+
+/**
+ * One simulated Application Load Balancer.
+ *
+ * The interesting part of it is the DNS name, which is the only way anything
+ * reaches a load balancer on real AWS: a Route53 alias or a CloudFront origin
+ * points at that name rather than at the ARN. Everything else here exists so
+ * that what a describe reports is what a real describe would have.
+ *
+ * A load balancer created here is `active` at once. Real ELB leaves one
+ * `provisioning` for a few minutes first, and waiting that out would cost
+ * every test the same minutes for no behaviour it could observe.
+ */
+export class SimElbV2LoadBalancer {
+  public readonly name: string;
+  public readonly arn: string;
+  public readonly dnsName: string;
+  public readonly scheme: SimElbV2LoadBalancerScheme;
+  public readonly ipAddressType: string;
+  public readonly createdTime: Date;
+
+  constructor(properties: SimElbV2LoadBalancerProperties) {
+    const { name, scheme, accountRegionScope } = properties;
+
+    this.name = name;
+    this.scheme = scheme;
+    this.ipAddressType = properties.ipAddressType;
+    this.createdTime = properties.createdTime;
+    this.arn = simElbV2LoadBalancerArn(name, properties.id, accountRegionScope);
+    this.dnsName = simElbV2LoadBalancerDnsName(
+      name,
+      properties.dnsSuffix,
+      scheme,
+      accountRegionScope,
+    );
+  }
+
+  /**
+   * Report this load balancer in the shape the SDK reads it back in.
+   *
+   * Subnets, security groups and availability zones are left out rather than
+   * invented: nothing declares them to this simulation, so reporting an empty
+   * list is the honest answer and reporting a made-up one would not be.
+   */
+  view(): SimElbV2LoadBalancerView {
+    return {
+      LoadBalancerArn: this.arn,
+      LoadBalancerName: this.name,
+      DNSName: this.dnsName,
+      CanonicalHostedZoneId: simElbV2CanonicalHostedZoneId,
+      CreatedTime: this.createdTime,
+      Scheme: this.scheme,
+      Type: "application",
+      State: { Code: "active" },
+      IpAddressType: this.ipAddressType,
+    };
+  }
+}

--- a/src/service/elbv2/sdk/sim-elbv2-sdk-command-router.ts
+++ b/src/service/elbv2/sdk/sim-elbv2-sdk-command-router.ts
@@ -1,0 +1,189 @@
+import {
+  simSdkCallerOptions,
+  type SimSdkCommandRoute,
+  type SimSdkCommandRouter,
+} from "../../../sdk/index.js";
+import type * as elbV2 from "../command/sim-elbv2-command.types.js";
+import type { SimElbV2 } from "../sim-elbv2.js";
+
+/**
+ * Routes intercepted SDK Commands to one scoped simulated ELBv2 instance.
+ *
+ * The table is built from one entry per operation rather than from a switch,
+ * because the list only grows and a branch per operation would put the whole
+ * of this file's complexity in one function.
+ */
+export class SimElbV2SdkCommandRouter implements SimSdkCommandRouter {
+  private readonly routes: ReadonlyMap<string, SimSdkCommandRoute>;
+
+  constructor(simElbV2: SimElbV2) {
+    this.routes = new Map<string, SimSdkCommandRoute>([
+      [
+        "CreateLoadBalancerCommand",
+        async (command, context): Promise<unknown> =>
+          await simElbV2.createLoadBalancer(
+            command as elbV2.SimCreateLoadBalancerCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "DescribeLoadBalancersCommand",
+        async (command, context): Promise<unknown> =>
+          await simElbV2.describeLoadBalancers(
+            command as elbV2.SimDescribeLoadBalancersCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "DeleteLoadBalancerCommand",
+        async (command, context): Promise<unknown> =>
+          await simElbV2.deleteLoadBalancer(
+            command as elbV2.SimDeleteLoadBalancerCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "CreateTargetGroupCommand",
+        async (command, context): Promise<unknown> =>
+          await simElbV2.createTargetGroup(
+            command as elbV2.SimCreateTargetGroupCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "DescribeTargetGroupsCommand",
+        async (command, context): Promise<unknown> =>
+          await simElbV2.describeTargetGroups(
+            command as elbV2.SimDescribeTargetGroupsCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "ModifyTargetGroupCommand",
+        async (command, context): Promise<unknown> =>
+          await simElbV2.modifyTargetGroup(
+            command as elbV2.SimModifyTargetGroupCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "DeleteTargetGroupCommand",
+        async (command, context): Promise<unknown> =>
+          await simElbV2.deleteTargetGroup(
+            command as elbV2.SimDeleteTargetGroupCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "RegisterTargetsCommand",
+        async (command, context): Promise<unknown> =>
+          await simElbV2.registerTargets(
+            command as elbV2.SimRegisterTargetsCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "DeregisterTargetsCommand",
+        async (command, context): Promise<unknown> =>
+          await simElbV2.deregisterTargets(
+            command as elbV2.SimDeregisterTargetsCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "DescribeTargetHealthCommand",
+        async (command, context): Promise<unknown> =>
+          await simElbV2.describeTargetHealth(
+            command as elbV2.SimDescribeTargetHealthCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "CreateListenerCommand",
+        async (command, context): Promise<unknown> =>
+          await simElbV2.createListener(
+            command as elbV2.SimCreateListenerCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "DescribeListenersCommand",
+        async (command, context): Promise<unknown> =>
+          await simElbV2.describeListeners(
+            command as elbV2.SimDescribeListenersCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "ModifyListenerCommand",
+        async (command, context): Promise<unknown> =>
+          await simElbV2.modifyListener(
+            command as elbV2.SimModifyListenerCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "DeleteListenerCommand",
+        async (command, context): Promise<unknown> =>
+          await simElbV2.deleteListener(
+            command as elbV2.SimDeleteListenerCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "CreateRuleCommand",
+        async (command, context): Promise<unknown> =>
+          await simElbV2.createRule(
+            command as elbV2.SimCreateRuleCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "DescribeRulesCommand",
+        async (command, context): Promise<unknown> =>
+          await simElbV2.describeRules(
+            command as elbV2.SimDescribeRulesCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "ModifyRuleCommand",
+        async (command, context): Promise<unknown> =>
+          await simElbV2.modifyRule(
+            command as elbV2.SimModifyRuleCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "DeleteRuleCommand",
+        async (command, context): Promise<unknown> =>
+          await simElbV2.deleteRule(
+            command as elbV2.SimDeleteRuleCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "SetRulePrioritiesCommand",
+        async (command, context): Promise<unknown> =>
+          await simElbV2.setRulePriorities(
+            command as elbV2.SimSetRulePrioritiesCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+    ]);
+  }
+
+  /**
+   * The SDK Command names simulated ELBv2 can handle.
+   */
+  supportedCommandNames(): readonly string[] {
+    return this.routes.keys().toArray();
+  }
+
+  /**
+   * Get the route for an SDK Command name, if simulated ELBv2 supports it.
+   */
+  route(commandName: string): SimSdkCommandRoute | undefined {
+    return this.routes.get(commandName);
+  }
+}

--- a/src/service/elbv2/sdk/sim-elbv2-sdk-routing.iso.test.ts
+++ b/src/service/elbv2/sdk/sim-elbv2-sdk-routing.iso.test.ts
@@ -1,0 +1,187 @@
+import {
+  CreateListenerCommand,
+  CreateLoadBalancerCommand,
+  CreateRuleCommand,
+  CreateTargetGroupCommand,
+  DeleteListenerCommand,
+  DeleteLoadBalancerCommand,
+  DeleteRuleCommand,
+  DeleteTargetGroupCommand,
+  DeregisterTargetsCommand,
+  DescribeListenersCommand,
+  DescribeLoadBalancersCommand,
+  DescribeRulesCommand,
+  DescribeTargetGroupsCommand,
+  DescribeTargetHealthCommand,
+  ElasticLoadBalancingV2Client,
+  ModifyListenerCommand,
+  ModifyRuleCommand,
+  ModifyTargetGroupCommand,
+  RegisterTargetsCommand,
+  SetRulePrioritiesCommand,
+} from "@aws-sdk/client-elastic-load-balancing-v2";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import { SimSdk } from "../../../sdk/index.js";
+
+const functionArn = "arn:aws:lambda:eu-west-2:888888888888:function:checkout";
+
+describe("ELBv2 SDK interception", () => {
+  it("routes an intercepted ElasticLoadBalancingV2Client to the simulation", async () => {
+    // Given an intercepted ELBv2 SDK client.
+    using simSdk = new SimSdk();
+    simSdk.intercept(ElasticLoadBalancingV2Client);
+
+    const client = new ElasticLoadBalancingV2Client({ region: "eu-west-2" });
+
+    // When ordinary SDK code creates a load balancer and reads it back.
+    const created = await client.send(
+      new CreateLoadBalancerCommand({ Name: "shop-alb" }),
+    );
+    const described = await client.send(
+      new DescribeLoadBalancersCommand({ Names: ["shop-alb"] }),
+    );
+
+    // Then it reached the simulation, in the client's own Region.
+    assertArrayLength(created.LoadBalancers, 1);
+    assertNonNullable(created.LoadBalancers[0].DNSName);
+    assertStringIncludes(
+      created.LoadBalancers[0].DNSName,
+      "shop-alb-0000000001.eu-west-2.elb.amazonaws.com",
+    );
+    assertArrayLength(described.LoadBalancers, 1);
+  });
+
+  it("routes every command simulated ELBv2 handles", async () => {
+    // Given an intercepted client with a load balancer and a target group.
+    using simSdk = new SimSdk();
+    simSdk.intercept(ElasticLoadBalancingV2Client);
+
+    const client = new ElasticLoadBalancingV2Client({ region: "eu-west-2" });
+
+    const loadBalancer = await client.send(
+      new CreateLoadBalancerCommand({ Name: "shop-alb" }),
+    );
+    const targetGroup = await client.send(
+      new CreateTargetGroupCommand({
+        Name: "checkout-tg",
+        TargetType: "lambda",
+      }),
+    );
+
+    assertArrayLength(loadBalancer.LoadBalancers, 1);
+    assertArrayLength(targetGroup.TargetGroups, 1);
+
+    const loadBalancerArn = loadBalancer.LoadBalancers[0].LoadBalancerArn;
+    const targetGroupArn = targetGroup.TargetGroups[0].TargetGroupArn;
+    assertNonNullable(loadBalancerArn);
+    assertNonNullable(targetGroupArn);
+
+    // When every other command is sent through the client.
+    const listener = await client.send(
+      new CreateListenerCommand({
+        LoadBalancerArn: loadBalancerArn,
+        Protocol: "HTTP",
+        Port: 80,
+        DefaultActions: [{ Type: "forward", TargetGroupArn: targetGroupArn }],
+      }),
+    );
+    assertArrayLength(listener.Listeners, 1);
+
+    const listenerArn = listener.Listeners[0].ListenerArn;
+    assertNonNullable(listenerArn);
+
+    const rule = await client.send(
+      new CreateRuleCommand({
+        ListenerArn: listenerArn,
+        Priority: 10,
+        Conditions: [{ Field: "host-header", Values: ["shop.example.com"] }],
+        Actions: [{ Type: "forward", TargetGroupArn: targetGroupArn }],
+      }),
+    );
+    assertArrayLength(rule.Rules, 1);
+
+    const ruleArn = rule.Rules[0].RuleArn;
+    assertNonNullable(ruleArn);
+
+    await client.send(
+      new RegisterTargetsCommand({
+        TargetGroupArn: targetGroupArn,
+        Targets: [{ Id: functionArn }],
+      }),
+    );
+    const health = await client.send(
+      new DescribeTargetHealthCommand({ TargetGroupArn: targetGroupArn }),
+    );
+    await client.send(
+      new DeregisterTargetsCommand({
+        TargetGroupArn: targetGroupArn,
+        Targets: [{ Id: functionArn }],
+      }),
+    );
+    await client.send(
+      new ModifyTargetGroupCommand({
+        TargetGroupArn: targetGroupArn,
+        HealthCheckEnabled: true,
+      }),
+    );
+    await client.send(
+      new DescribeTargetGroupsCommand({ TargetGroupArns: [targetGroupArn] }),
+    );
+    await client.send(
+      new ModifyListenerCommand({ ListenerArn: listenerArn, Port: 8080 }),
+    );
+    await client.send(
+      new DescribeListenersCommand({ ListenerArns: [listenerArn] }),
+    );
+    await client.send(
+      new ModifyRuleCommand({
+        RuleArn: ruleArn,
+        Actions: [
+          {
+            Type: "fixed-response",
+            FixedResponseConfig: { StatusCode: "204" },
+          },
+        ],
+      }),
+    );
+    await client.send(
+      new SetRulePrioritiesCommand({
+        RulePriorities: [{ RuleArn: ruleArn, Priority: 20 }],
+      }),
+    );
+    const rules = await client.send(
+      new DescribeRulesCommand({ ListenerArn: listenerArn }),
+    );
+
+    await client.send(new DeleteRuleCommand({ RuleArn: ruleArn }));
+    await client.send(new DeleteListenerCommand({ ListenerArn: listenerArn }));
+    await client.send(
+      new DeleteLoadBalancerCommand({ LoadBalancerArn: loadBalancerArn }),
+    );
+    await client.send(
+      new DeleteTargetGroupCommand({ TargetGroupArn: targetGroupArn }),
+    );
+
+    const remaining = await client.send(new DescribeLoadBalancersCommand({}));
+
+    // Then every command simulated ELBv2 knows about was one of them.
+    assertArrayLength(
+      new SimAws().elbV2().sdkCommandRouter().supportedCommandNames(),
+      19,
+    );
+
+    // Then each one reached the simulation and the stack was torn down.
+    assertArrayLength(health.TargetHealthDescriptions, 1);
+    assertArrayLength(rules.Rules, 2);
+    assertIdentical(rules.Rules[0].Priority, "20");
+    assertArrayLength(remaining.LoadBalancers, 0);
+  });
+});

--- a/src/service/elbv2/sim-elbv2-protocol.ts
+++ b/src/service/elbv2/sim-elbv2-protocol.ts
@@ -1,0 +1,42 @@
+import {
+  SimElbV2UnsimulatedInputException,
+  SimElbV2ValidationError,
+} from "./error/sim-elbv2.error.js";
+
+/**
+ * The protocols an Application Load Balancer speaks.
+ *
+ * `TCP`, `TLS`, `UDP` and `TCP_UDP` belong to a Network Load Balancer, and
+ * `GENEVE` to a Gateway Load Balancer. Neither is simulated, so a protocol
+ * naming one is refused rather than accepted onto an application load
+ * balancer that could never speak it.
+ */
+const appProtocols = new Set(["HTTP", "HTTPS"]);
+
+/**
+ * Read a protocol a request names, refusing one an ALB does not speak.
+ */
+export function simElbV2Protocol(field: string, value: string): string {
+  if (!appProtocols.has(value)) {
+    throw new SimElbV2UnsimulatedInputException(
+      `${field} '${value}' is not simulated. An Application Load Balancer ` +
+        `speaks ${[...appProtocols].join(" and ")}, and network and ` +
+        `gateway load balancers are out of scope here.`,
+    );
+  }
+
+  return value;
+}
+
+/**
+ * Read a port a request names, refusing one outside the range ELB takes.
+ */
+export function simElbV2Port(field: string, value: number): number {
+  if (!Number.isSafeInteger(value) || value < 1 || value > 65_535) {
+    throw new SimElbV2ValidationError(
+      `${field} ${String(value)} is not a port between 1 and 65535`,
+    );
+  }
+
+  return value;
+}

--- a/src/service/elbv2/sim-elbv2-protocol.ts
+++ b/src/service/elbv2/sim-elbv2-protocol.ts
@@ -5,27 +5,44 @@ import {
 
 /**
  * The protocols an Application Load Balancer speaks.
- *
- * `TCP`, `TLS`, `UDP` and `TCP_UDP` belong to a Network Load Balancer, and
- * `GENEVE` to a Gateway Load Balancer. Neither is simulated, so a protocol
- * naming one is refused rather than accepted onto an application load
- * balancer that could never speak it.
  */
 const appProtocols = new Set(["HTTP", "HTTPS"]);
+
+/**
+ * The protocols real ELB takes that no application load balancer speaks.
+ *
+ * `TCP`, `TLS`, `UDP` and `TCP_UDP` belong to a Network Load Balancer and
+ * `GENEVE` to a Gateway Load Balancer. Neither is simulated, so one of these
+ * is refused as input this simulation does not go far enough for, which is a
+ * different thing from a value that is not an ELB protocol at all.
+ */
+const otherLoadBalancerProtocols = new Set([
+  "TCP",
+  "TLS",
+  "UDP",
+  "TCP_UDP",
+  "GENEVE",
+]);
 
 /**
  * Read a protocol a request names, refusing one an ALB does not speak.
  */
 export function simElbV2Protocol(field: string, value: string): string {
-  if (!appProtocols.has(value)) {
+  if (appProtocols.has(value)) {
+    return value;
+  }
+
+  if (otherLoadBalancerProtocols.has(value)) {
     throw new SimElbV2UnsimulatedInputException(
-      `${field} '${value}' is not simulated. An Application Load Balancer ` +
-        `speaks ${[...appProtocols].join(" and ")}, and network and ` +
-        `gateway load balancers are out of scope here.`,
+      `${field} '${value}' is a network or gateway load balancer protocol, ` +
+        `and neither is simulated. An Application Load Balancer speaks ` +
+        `${[...appProtocols].join(" and ")}.`,
     );
   }
 
-  return value;
+  throw new SimElbV2ValidationError(
+    `${field} '${value}' is not a valid ELB protocol`,
+  );
 }
 
 /**

--- a/src/service/elbv2/sim-elbv2-resource-id.ts
+++ b/src/service/elbv2/sim-elbv2-resource-id.ts
@@ -1,0 +1,33 @@
+/**
+ * How long the hexadecimal id in an ELBv2 ARN is.
+ */
+const resourceIdLength = 16;
+
+/**
+ * How long the numeric suffix in a load balancer DNS name is.
+ */
+const dnsSuffixLength = 10;
+
+/**
+ * The id real ELB puts at the end of a load balancer, target group, listener
+ * or rule ARN.
+ *
+ * Real ELB generates it at random. Here it counts, because a test asserting on
+ * an ARN it did not capture is worth more than an id no one can predict, and
+ * the shape is what anything reading the ARN cares about. It is still 16
+ * hexadecimal characters, so an ARN from this simulation parses everywhere a
+ * real one does.
+ */
+export function simElbV2ResourceId(sequence: number): string {
+  return sequence.toString(16).padStart(resourceIdLength, "0");
+}
+
+/**
+ * The digits real ELB puts between a load balancer's name and its DNS suffix.
+ *
+ * Deterministic for the same reason the ARN id is, and the same length, so a
+ * host name from this simulation is one a real load balancer could have had.
+ */
+export function simElbV2DnsSuffix(sequence: number): string {
+  return String(sequence).padStart(dnsSuffixLength, "0");
+}

--- a/src/service/elbv2/sim-elbv2-resource-name.ts
+++ b/src/service/elbv2/sim-elbv2-resource-name.ts
@@ -1,0 +1,47 @@
+import { SimElbV2ValidationError } from "./error/sim-elbv2.error.js";
+
+/**
+ * The characters real ELB takes in a load balancer or target group name:
+ * letters, digits and hyphens.
+ */
+const allowedName = /^[0-9A-Za-z-]+$/u;
+
+/**
+ * The longest name real ELB takes, which is the same for both resources.
+ */
+export const maximumSimElbV2NameLength = 32;
+
+/**
+ * Read a load balancer or target group name, refusing one real ELB would not
+ * take.
+ *
+ * Both resources are named under the same rules, so the rules are stated once
+ * and the two callers say only which field they are reading and what real ELB
+ * additionally reserves.
+ */
+export function readSimElbV2Name(kind: string, value: string): string {
+  if (value === "") {
+    throw new SimElbV2ValidationError(`${kind} is required`);
+  }
+
+  if (value.length > maximumSimElbV2NameLength) {
+    throw new SimElbV2ValidationError(
+      `${kind} is at most ${String(maximumSimElbV2NameLength)} characters, ` +
+        `and this one is ${String(value.length)}`,
+    );
+  }
+
+  if (!allowedName.test(value)) {
+    throw new SimElbV2ValidationError(
+      `${kind} '${value}' is not valid. A name is letters, digits and hyphens.`,
+    );
+  }
+
+  if (value.startsWith("-") || value.endsWith("-")) {
+    throw new SimElbV2ValidationError(
+      `${kind} '${value}' cannot begin or end with a hyphen`,
+    );
+  }
+
+  return value;
+}

--- a/src/service/elbv2/sim-elbv2-stores.ts
+++ b/src/service/elbv2/sim-elbv2-stores.ts
@@ -1,0 +1,48 @@
+import { SimElbV2ListenerStore } from "./listener/sim-elbv2-listener-store.js";
+import { SimElbV2ListenerRuleStore } from "./listener/rule/sim-elbv2-listener-rule-store.js";
+import { SimElbV2LoadBalancerStore } from "./load-balancer/sim-elbv2-load-balancer-store.js";
+import type { SimElbV2LoadBalancer } from "./load-balancer/sim-elbv2-load-balancer.js";
+import type { SimElbV2Listener } from "./listener/sim-elbv2-listener.js";
+import { SimElbV2TargetGroupStore } from "./target-group/sim-elbv2-target-group-store.js";
+
+/**
+ * Everything one simulated ELBv2 scope holds.
+ *
+ * The four resources are kept in four stores rather than nested inside each
+ * other, because the SDK addresses each of them by its own ARN and a describe
+ * has no parent to start from. What they do have is a lifetime that runs one
+ * way, and that is the part this class owns: deleting a load balancer takes
+ * its listeners, and deleting a listener takes its rules.
+ */
+export class SimElbV2Stores {
+  public readonly loadBalancers = new SimElbV2LoadBalancerStore();
+  public readonly targetGroups = new SimElbV2TargetGroupStore();
+  public readonly listeners = new SimElbV2ListenerStore();
+  public readonly rules = new SimElbV2ListenerRuleStore();
+
+  /**
+   * Delete a load balancer, and everything that only existed on it.
+   *
+   * Target groups are left where they are, which is what real ELB does: a
+   * target group is a resource in its own right, and a stack that replaces a
+   * load balancer keeps the groups its new listeners will forward to.
+   */
+  deleteLoadBalancer(loadBalancer: SimElbV2LoadBalancer): void {
+    for (const listener of this.listeners.forLoadBalancer(loadBalancer.arn)) {
+      this.deleteListener(listener);
+    }
+
+    this.loadBalancers.remove(loadBalancer);
+  }
+
+  /**
+   * Delete a listener, and the rules that only existed on it.
+   */
+  deleteListener(listener: SimElbV2Listener): void {
+    for (const rule of this.rules.forListener(listener.arn)) {
+      this.rules.remove(rule);
+    }
+
+    this.listeners.remove(listener);
+  }
+}

--- a/src/service/elbv2/sim-elbv2.fixture.ts
+++ b/src/service/elbv2/sim-elbv2.fixture.ts
@@ -35,7 +35,10 @@ export async function createFixtureLoadBalancer(
 }
 
 /**
- * Create a target group holding one function and answer with its ARN.
+ * Create an empty target group of the `lambda` type and answer with its ARN.
+ *
+ * Nothing is registered in it: a test that wants a function in it registers
+ * `fixtureFunctionArn` itself, since that is usually the thing being tested.
  */
 export async function createFixtureLambdaTargetGroup(
   elbV2: SimElbV2,
@@ -51,7 +54,7 @@ export async function createFixtureLambdaTargetGroup(
 }
 
 /**
- * Create a target group holding addresses and answer with its ARN.
+ * Create an empty target group of the `ip` type and answer with its ARN.
  */
 export async function createFixtureIpTargetGroup(
   elbV2: SimElbV2,

--- a/src/service/elbv2/sim-elbv2.fixture.ts
+++ b/src/service/elbv2/sim-elbv2.fixture.ts
@@ -1,0 +1,115 @@
+import { assertArrayLength } from "@kensio/smartass";
+
+import type { SimElbV2 } from "./sim-elbv2.js";
+
+/**
+ * Test support for building a simulated ELBv2 stack.
+ *
+ * Almost every behaviour worth testing here needs a load balancer, a target
+ * group and a listener before it can be reached, so building those is done
+ * once here rather than at the top of every test.
+ *
+ * These helpers drive the simulator through structural command shapes rather
+ * than real SDK command objects, because this is source rather than a test
+ * file. The colocated tests cover SDK-shaped input.
+ */
+
+/**
+ * A Lambda function ARN a `lambda` target group will take.
+ */
+export const fixtureFunctionArn =
+  "arn:aws:lambda:eu-west-1:888888888888:function:checkout";
+
+/**
+ * Create a load balancer and answer with its ARN.
+ */
+export async function createFixtureLoadBalancer(
+  elbV2: SimElbV2,
+  name = "shop-alb",
+): Promise<string> {
+  const output = await elbV2.createLoadBalancer({ input: { Name: name } });
+
+  assertArrayLength(output.LoadBalancers, 1);
+
+  return output.LoadBalancers[0].LoadBalancerArn;
+}
+
+/**
+ * Create a target group holding one function and answer with its ARN.
+ */
+export async function createFixtureLambdaTargetGroup(
+  elbV2: SimElbV2,
+  name = "checkout-tg",
+): Promise<string> {
+  const output = await elbV2.createTargetGroup({
+    input: { Name: name, TargetType: "lambda" },
+  });
+
+  assertArrayLength(output.TargetGroups, 1);
+
+  return output.TargetGroups[0].TargetGroupArn;
+}
+
+/**
+ * Create a target group holding addresses and answer with its ARN.
+ */
+export async function createFixtureIpTargetGroup(
+  elbV2: SimElbV2,
+  name = "web-tg",
+): Promise<string> {
+  const output = await elbV2.createTargetGroup({
+    input: { Name: name, TargetType: "ip", Protocol: "HTTP", Port: 8080 },
+  });
+
+  assertArrayLength(output.TargetGroups, 1);
+
+  return output.TargetGroups[0].TargetGroupArn;
+}
+
+/**
+ * Create an HTTP listener forwarding to a target group, and answer with its
+ * ARN.
+ */
+export async function createFixtureListener(
+  elbV2: SimElbV2,
+  loadBalancerArn: string,
+  targetGroupArn: string,
+  port = 80,
+): Promise<string> {
+  const output = await elbV2.createListener({
+    input: {
+      LoadBalancerArn: loadBalancerArn,
+      Protocol: "HTTP",
+      Port: port,
+      DefaultActions: [{ Type: "forward", TargetGroupArn: targetGroupArn }],
+    },
+  });
+
+  assertArrayLength(output.Listeners, 1);
+
+  return output.Listeners[0].ListenerArn;
+}
+
+/**
+ * Create a rule on a listener, and answer with its ARN.
+ */
+export async function createFixtureRule(
+  elbV2: SimElbV2,
+  listenerArn: string,
+  priority: number,
+  targetGroupArn: string,
+  hostHeader = "shop.example.com",
+): Promise<string> {
+  const output = await elbV2.createRule({
+    input: {
+      ListenerArn: listenerArn,
+      Priority: priority,
+      Conditions: [{ Field: "host-header", Values: [hostHeader] }],
+      Actions: [{ Type: "forward", TargetGroupArn: targetGroupArn }],
+    },
+  });
+
+  assertArrayLength(output.Rules, 1);
+
+  return output.Rules[0].RuleArn;
+}

--- a/src/service/elbv2/sim-elbv2.ts
+++ b/src/service/elbv2/sim-elbv2.ts
@@ -1,0 +1,229 @@
+import {
+  type BackgroundScheduler,
+  BackgroundTasks,
+} from "../../util/background/background.js";
+import type { SimSdkCommandRouter } from "../../sdk/router/sim-sdk-command-router.type.js";
+import type { SimAwsAccountRegionScope } from "../aws/sim-aws-account-region-scope.js";
+import { simAwsAccountRegionScopeFactory } from "../aws/sim-aws-account-region-scope.factory.js";
+import {
+  SimIamAllowAllAuth,
+  type SimIamInterServiceAuthZ,
+} from "../iam/authorize/sim-iam-inter-service-auth-z.js";
+import type * as elbV2 from "./command/sim-elbv2-command.types.js";
+import { SimElbV2Commands } from "./command/sim-elbv2-commands.js";
+import type { SimElbV2RequestOptions } from "./command/sim-elbv2-request-options.js";
+import type { SimElbV2LoadBalancer } from "./load-balancer/sim-elbv2-load-balancer.js";
+import { SimElbV2SdkCommandRouter } from "./sdk/sim-elbv2-sdk-command-router.js";
+import { SimElbV2Stores } from "./sim-elbv2-stores.js";
+
+interface SimElbV2Properties {
+  readonly accountRegionScope?: SimAwsAccountRegionScope;
+  readonly iam?: SimIamInterServiceAuthZ;
+  readonly background?: BackgroundScheduler;
+}
+
+/**
+ * Simulated Elastic Load Balancing v2. Handles SDK commands. Emulates AWS
+ * behaviour and state.
+ *
+ * This is the Application Load Balancer and nothing else. Network and gateway
+ * load balancers route below HTTP, which nothing in this simulation speaks, so
+ * they are refused rather than created as something they are not.
+ *
+ * What a load balancer here is, so far, is state: it has a DNS name of the
+ * shape real ELB issues, so a Route53 alias or a CloudFront origin has
+ * something to point at, and it has listeners, rules and target groups that
+ * say what it would do with a request. Answering one is separate work.
+ *
+ * Load balancers are scoped to an account and region, as they are on real AWS:
+ * a name is unique within one of those scopes and an ARN names the region.
+ */
+export class SimElbV2 {
+  private readonly stores = new SimElbV2Stores();
+  private readonly commands: SimElbV2Commands;
+  private readonly sdkRouter = new SimElbV2SdkCommandRouter(this);
+
+  constructor(properties: SimElbV2Properties = {}) {
+    const {
+      accountRegionScope = simAwsAccountRegionScopeFactory.make(),
+      iam = new SimIamAllowAllAuth(),
+      background = new BackgroundTasks(),
+    } = properties;
+
+    this.commands = new SimElbV2Commands({
+      stores: this.stores,
+      iam,
+      background,
+      accountRegionScope,
+    });
+  }
+
+  /**
+   * Find a load balancer by name.
+   *
+   * This is the simulator's own accessor, for tests seeding or inspecting load
+   * balancer state without going through a Command and its authorization.
+   */
+  findLoadBalancerByName(name: string): SimElbV2LoadBalancer | undefined {
+    return this.stores.loadBalancers.findByName(name);
+  }
+
+  /** Handle a CreateLoadBalancer Command from the SDK. */
+  async createLoadBalancer(
+    command: elbV2.SimCreateLoadBalancerCommand,
+    options?: SimElbV2RequestOptions,
+  ): Promise<elbV2.SimCreateLoadBalancerCommandOutput> {
+    return await this.commands.createLoadBalancer.handle(command, options);
+  }
+
+  /** Handle a DescribeLoadBalancers Command from the SDK. */
+  async describeLoadBalancers(
+    command: elbV2.SimDescribeLoadBalancersCommand,
+    options?: SimElbV2RequestOptions,
+  ): Promise<elbV2.SimDescribeLoadBalancersCommandOutput> {
+    return await this.commands.describeLoadBalancers.handle(command, options);
+  }
+
+  /** Handle a DeleteLoadBalancer Command from the SDK. */
+  async deleteLoadBalancer(
+    command: elbV2.SimDeleteLoadBalancerCommand,
+    options?: SimElbV2RequestOptions,
+  ): Promise<elbV2.SimDeleteLoadBalancerCommandOutput> {
+    return await this.commands.deleteLoadBalancer.handle(command, options);
+  }
+
+  /** Handle a CreateTargetGroup Command from the SDK. */
+  async createTargetGroup(
+    command: elbV2.SimCreateTargetGroupCommand,
+    options?: SimElbV2RequestOptions,
+  ): Promise<elbV2.SimCreateTargetGroupCommandOutput> {
+    return await this.commands.createTargetGroup.handle(command, options);
+  }
+
+  /** Handle a DescribeTargetGroups Command from the SDK. */
+  async describeTargetGroups(
+    command: elbV2.SimDescribeTargetGroupsCommand,
+    options?: SimElbV2RequestOptions,
+  ): Promise<elbV2.SimDescribeTargetGroupsCommandOutput> {
+    return await this.commands.describeTargetGroups.handle(command, options);
+  }
+
+  /** Handle a ModifyTargetGroup Command from the SDK. */
+  async modifyTargetGroup(
+    command: elbV2.SimModifyTargetGroupCommand,
+    options?: SimElbV2RequestOptions,
+  ): Promise<elbV2.SimModifyTargetGroupCommandOutput> {
+    return await this.commands.modifyTargetGroup.handle(command, options);
+  }
+
+  /** Handle a DeleteTargetGroup Command from the SDK. */
+  async deleteTargetGroup(
+    command: elbV2.SimDeleteTargetGroupCommand,
+    options?: SimElbV2RequestOptions,
+  ): Promise<elbV2.SimDeleteTargetGroupCommandOutput> {
+    return await this.commands.deleteTargetGroup.handle(command, options);
+  }
+
+  /** Handle a RegisterTargets Command from the SDK. */
+  async registerTargets(
+    command: elbV2.SimRegisterTargetsCommand,
+    options?: SimElbV2RequestOptions,
+  ): Promise<elbV2.SimRegisterTargetsCommandOutput> {
+    return await this.commands.registerTargets.handle(command, options);
+  }
+
+  /** Handle a DeregisterTargets Command from the SDK. */
+  async deregisterTargets(
+    command: elbV2.SimDeregisterTargetsCommand,
+    options?: SimElbV2RequestOptions,
+  ): Promise<elbV2.SimDeregisterTargetsCommandOutput> {
+    return await this.commands.deregisterTargets.handle(command, options);
+  }
+
+  /** Handle a DescribeTargetHealth Command from the SDK. */
+  async describeTargetHealth(
+    command: elbV2.SimDescribeTargetHealthCommand,
+    options?: SimElbV2RequestOptions,
+  ): Promise<elbV2.SimDescribeTargetHealthCommandOutput> {
+    return await this.commands.describeTargetHealth.handle(command, options);
+  }
+
+  /** Handle a CreateListener Command from the SDK. */
+  async createListener(
+    command: elbV2.SimCreateListenerCommand,
+    options?: SimElbV2RequestOptions,
+  ): Promise<elbV2.SimCreateListenerCommandOutput> {
+    return await this.commands.createListener.handle(command, options);
+  }
+
+  /** Handle a DescribeListeners Command from the SDK. */
+  async describeListeners(
+    command: elbV2.SimDescribeListenersCommand,
+    options?: SimElbV2RequestOptions,
+  ): Promise<elbV2.SimDescribeListenersCommandOutput> {
+    return await this.commands.describeListeners.handle(command, options);
+  }
+
+  /** Handle a ModifyListener Command from the SDK. */
+  async modifyListener(
+    command: elbV2.SimModifyListenerCommand,
+    options?: SimElbV2RequestOptions,
+  ): Promise<elbV2.SimModifyListenerCommandOutput> {
+    return await this.commands.modifyListener.handle(command, options);
+  }
+
+  /** Handle a DeleteListener Command from the SDK. */
+  async deleteListener(
+    command: elbV2.SimDeleteListenerCommand,
+    options?: SimElbV2RequestOptions,
+  ): Promise<elbV2.SimDeleteListenerCommandOutput> {
+    return await this.commands.deleteListener.handle(command, options);
+  }
+
+  /** Handle a CreateRule Command from the SDK. */
+  async createRule(
+    command: elbV2.SimCreateRuleCommand,
+    options?: SimElbV2RequestOptions,
+  ): Promise<elbV2.SimCreateRuleCommandOutput> {
+    return await this.commands.createRule.handle(command, options);
+  }
+
+  /** Handle a DescribeRules Command from the SDK. */
+  async describeRules(
+    command: elbV2.SimDescribeRulesCommand,
+    options?: SimElbV2RequestOptions,
+  ): Promise<elbV2.SimDescribeRulesCommandOutput> {
+    return await this.commands.describeRules.handle(command, options);
+  }
+
+  /** Handle a ModifyRule Command from the SDK. */
+  async modifyRule(
+    command: elbV2.SimModifyRuleCommand,
+    options?: SimElbV2RequestOptions,
+  ): Promise<elbV2.SimModifyRuleCommandOutput> {
+    return await this.commands.modifyRule.handle(command, options);
+  }
+
+  /** Handle a DeleteRule Command from the SDK. */
+  async deleteRule(
+    command: elbV2.SimDeleteRuleCommand,
+    options?: SimElbV2RequestOptions,
+  ): Promise<elbV2.SimDeleteRuleCommandOutput> {
+    return await this.commands.deleteRule.handle(command, options);
+  }
+
+  /** Handle a SetRulePriorities Command from the SDK. */
+  async setRulePriorities(
+    command: elbV2.SimSetRulePrioritiesCommand,
+    options?: SimElbV2RequestOptions,
+  ): Promise<elbV2.SimSetRulePrioritiesCommandOutput> {
+    return await this.commands.setRulePriorities.handle(command, options);
+  }
+
+  /**
+   * Get this service's SDK Command router for SDK client interception.
+   */
+  sdkCommandRouter(): SimSdkCommandRouter {
+    return this.sdkRouter;
+  }
+}

--- a/src/service/elbv2/target-group/sim-elbv2-health-check.ts
+++ b/src/service/elbv2/target-group/sim-elbv2-health-check.ts
@@ -1,0 +1,102 @@
+import type { SimElbV2Matcher } from "../command/sim-elbv2-shared.command.js";
+
+/**
+ * The health check settings a request can carry, on either a create or a
+ * modify.
+ */
+export interface SimElbV2HealthCheckInput {
+  readonly HealthCheckEnabled?: boolean | undefined;
+  readonly HealthCheckProtocol?: string | undefined;
+  readonly HealthCheckPort?: string | undefined;
+  readonly HealthCheckPath?: string | undefined;
+  readonly HealthCheckIntervalSeconds?: number | undefined;
+  readonly HealthCheckTimeoutSeconds?: number | undefined;
+  readonly HealthyThresholdCount?: number | undefined;
+  readonly UnhealthyThresholdCount?: number | undefined;
+  readonly Matcher?: SimElbV2Matcher | undefined;
+}
+
+/**
+ * The health check settings of one simulated target group, as they are read
+ * back.
+ */
+export type SimElbV2HealthCheckView = Required<{
+  [Key in keyof SimElbV2HealthCheckInput]: SimElbV2HealthCheckInput[Key];
+}>;
+
+/**
+ * The health check settings of one simulated target group.
+ *
+ * They are held and reported, and nothing acts on them: no request is ever
+ * made to a target to find out whether it is up, so every registered target is
+ * healthy here however it is configured. They are still worth holding, because
+ * a stack declares them and a test comparing what it deployed against what it
+ * meant to deploy needs to read them back.
+ *
+ * The defaults are the ones real ELB applies to an HTTP target group, except
+ * that a `lambda` group starts with checking off, as real ELB has it.
+ */
+export class SimElbV2HealthCheck {
+  private enabled: boolean;
+  private protocol: string | undefined;
+  private port: string | undefined;
+  private path: string | undefined;
+  private intervalSeconds: number;
+  private timeoutSeconds: number;
+  private healthyThresholdCount: number;
+  private unhealthyThresholdCount: number;
+  private matcher: SimElbV2Matcher | undefined;
+
+  constructor(targetTypeValue: string) {
+    const isLambda = targetTypeValue === "lambda";
+
+    this.enabled = !isLambda;
+    this.protocol = isLambda ? undefined : "HTTP";
+    this.port = isLambda ? undefined : "traffic-port";
+    this.path = isLambda ? undefined : "/";
+    this.intervalSeconds = isLambda ? 35 : 30;
+    this.timeoutSeconds = isLambda ? 30 : 5;
+    this.healthyThresholdCount = 5;
+    this.unhealthyThresholdCount = isLambda ? 5 : 2;
+    this.matcher = isLambda ? undefined : { HttpCode: "200" };
+  }
+
+  /**
+   * Take the settings a request names, leaving the others as they were.
+   *
+   * This is what makes `ModifyTargetGroup` a partial update, as real ELB has
+   * it: a request naming only a path changes only the path.
+   */
+  apply(input: SimElbV2HealthCheckInput): void {
+    this.enabled = input.HealthCheckEnabled ?? this.enabled;
+    this.protocol = input.HealthCheckProtocol ?? this.protocol;
+    this.port = input.HealthCheckPort ?? this.port;
+    this.path = input.HealthCheckPath ?? this.path;
+    this.intervalSeconds =
+      input.HealthCheckIntervalSeconds ?? this.intervalSeconds;
+    this.timeoutSeconds =
+      input.HealthCheckTimeoutSeconds ?? this.timeoutSeconds;
+    this.healthyThresholdCount =
+      input.HealthyThresholdCount ?? this.healthyThresholdCount;
+    this.unhealthyThresholdCount =
+      input.UnhealthyThresholdCount ?? this.unhealthyThresholdCount;
+    this.matcher = input.Matcher ?? this.matcher;
+  }
+
+  /**
+   * Report these settings in the shape the SDK reads them back in.
+   */
+  view(): SimElbV2HealthCheckView {
+    return {
+      HealthCheckEnabled: this.enabled,
+      HealthCheckProtocol: this.protocol,
+      HealthCheckPort: this.port,
+      HealthCheckPath: this.path,
+      HealthCheckIntervalSeconds: this.intervalSeconds,
+      HealthCheckTimeoutSeconds: this.timeoutSeconds,
+      HealthyThresholdCount: this.healthyThresholdCount,
+      UnhealthyThresholdCount: this.unhealthyThresholdCount,
+      Matcher: this.matcher,
+    };
+  }
+}

--- a/src/service/elbv2/target-group/sim-elbv2-target-group-endpoint.ts
+++ b/src/service/elbv2/target-group/sim-elbv2-target-group-endpoint.ts
@@ -1,0 +1,38 @@
+import { simElbV2Port, simElbV2Protocol } from "../sim-elbv2-protocol.js";
+
+/**
+ * Where a target group's targets are reached, as a request states it.
+ */
+export interface SimElbV2TargetGroupEndpoint {
+  readonly protocol: string | undefined;
+  readonly port: number | undefined;
+}
+
+/**
+ * The endpoint properties a request can state.
+ */
+export interface SimElbV2TargetGroupEndpointInput {
+  readonly Protocol?: string | undefined;
+  readonly Port?: number | undefined;
+}
+
+/**
+ * Read the protocol and port a target group request names, if it names them.
+ *
+ * Both are optional here rather than required, because whether they belong on
+ * a group at all is the target type's decision: an address group needs them
+ * and a function group refuses them. What this owns is only that a value that
+ * is there is one real ELB would take.
+ */
+export function simElbV2TargetGroupEndpoint(
+  input: SimElbV2TargetGroupEndpointInput,
+): SimElbV2TargetGroupEndpoint {
+  return {
+    protocol:
+      input.Protocol === undefined
+        ? undefined
+        : simElbV2Protocol("Protocol", input.Protocol),
+    port:
+      input.Port === undefined ? undefined : simElbV2Port("Port", input.Port),
+  };
+}

--- a/src/service/elbv2/target-group/sim-elbv2-target-group-name.ts
+++ b/src/service/elbv2/target-group/sim-elbv2-target-group-name.ts
@@ -1,0 +1,11 @@
+import { readSimElbV2Name } from "../sim-elbv2-resource-name.js";
+
+/**
+ * Read the name of a target group a request names.
+ *
+ * Real ELB reserves nothing at the front of a target group name, unlike a load
+ * balancer name, because nothing derives a host name from it.
+ */
+export function simElbV2TargetGroupName(value: string | undefined): string {
+  return readSimElbV2Name("Name", value ?? "");
+}

--- a/src/service/elbv2/target-group/sim-elbv2-target-group-store.ts
+++ b/src/service/elbv2/target-group/sim-elbv2-target-group-store.ts
@@ -1,0 +1,96 @@
+import {
+  SimElbV2DuplicateTargetGroupNameException,
+  SimElbV2TargetGroupNotFoundException,
+} from "../error/sim-elbv2.error.js";
+import type { SimElbV2TargetGroup } from "./sim-elbv2-target-group.js";
+
+/**
+ * The target groups of one simulated ELBv2 scope.
+ *
+ * Target groups outlive the load balancers that forward to them, which is why
+ * they are held here rather than under a load balancer: deleting a load
+ * balancer takes its listeners and rules with it and leaves these alone, as
+ * real ELB does.
+ */
+export class SimElbV2TargetGroupStore {
+  private readonly targetGroups = new Map<string, SimElbV2TargetGroup>();
+  private sequence = 0;
+
+  /**
+   * Every target group in this scope, in creation order.
+   */
+  get all(): readonly SimElbV2TargetGroup[] {
+    return this.targetGroups.values().toArray();
+  }
+
+  /**
+   * Take the next id for a target group about to be created.
+   */
+  nextSequence(): number {
+    this.sequence += 1;
+    return this.sequence;
+  }
+
+  /**
+   * Refuse a name another target group in this scope already holds.
+   */
+  requireNameAvailable(name: string): void {
+    if (this.findByName(name) !== undefined) {
+      throw new SimElbV2DuplicateTargetGroupNameException(
+        `A target group named '${name}' already exists in this account and ` +
+          `region`,
+      );
+    }
+  }
+
+  /**
+   * Store a created target group.
+   */
+  put(targetGroup: SimElbV2TargetGroup): void {
+    this.targetGroups.set(targetGroup.arn, targetGroup);
+  }
+
+  /**
+   * Find a target group by name.
+   */
+  findByName(name: string): SimElbV2TargetGroup | undefined {
+    return this.all.find((targetGroup) => targetGroup.name === name);
+  }
+
+  /**
+   * Resolve a target group by ARN, or refuse.
+   */
+  requireByArn(arn: string): SimElbV2TargetGroup {
+    const found = this.targetGroups.get(arn);
+
+    if (found === undefined) {
+      throw new SimElbV2TargetGroupNotFoundException(
+        `No sim ELBv2 target group with ARN ${arn}`,
+      );
+    }
+
+    return found;
+  }
+
+  /**
+   * Resolve a target group by name, or refuse.
+   */
+  requireByName(name: string): SimElbV2TargetGroup {
+    const found = this.findByName(name);
+
+    if (found === undefined) {
+      throw new SimElbV2TargetGroupNotFoundException(
+        `No sim ELBv2 target group named ${name}`,
+      );
+    }
+
+    return found;
+  }
+
+  /**
+   * Forget a deleted target group.
+   */
+  remove(targetGroup: SimElbV2TargetGroup): void {
+    this.targetGroups.delete(targetGroup.arn);
+  }
+}

--- a/src/service/elbv2/target-group/sim-elbv2-target-group-usage.ts
+++ b/src/service/elbv2/target-group/sim-elbv2-target-group-usage.ts
@@ -1,0 +1,59 @@
+import { SimElbV2ResourceInUseException } from "../error/sim-elbv2.error.js";
+import type { SimElbV2Stores } from "../sim-elbv2-stores.js";
+import type { SimElbV2TargetGroup } from "./sim-elbv2-target-group.js";
+
+/**
+ * Which load balancers forward to a target group.
+ *
+ * Nothing records this on the target group, because a group learns it is being
+ * forwarded to only through a listener or a rule naming it, and a rule can be
+ * written and deleted without the group hearing about it. Reading it back out
+ * of the listeners and rules is therefore the only answer that cannot go
+ * stale.
+ */
+export class SimElbV2TargetGroupUsage {
+  private readonly stores: SimElbV2Stores;
+
+  constructor(stores: SimElbV2Stores) {
+    this.stores = stores;
+  }
+
+  /**
+   * The load balancers whose listeners or rules forward to a target group.
+   */
+  loadBalancerArns(targetGroup: SimElbV2TargetGroup): readonly string[] {
+    const fromListeners = this.stores.listeners.all
+      .filter((listener) =>
+        listener.defaultActions.some((action) =>
+          action.targetGroupArns.includes(targetGroup.arn),
+        ),
+      )
+      .map((listener) => listener.loadBalancerArn);
+
+    const fromRules = this.stores.rules.all
+      .filter((rule) =>
+        rule.actions.some((action) =>
+          action.targetGroupArns.includes(targetGroup.arn),
+        ),
+      )
+      .map(
+        (rule) =>
+          this.stores.listeners.requireByArn(rule.listenerArn).loadBalancerArn,
+      );
+
+    return [...new Set([...fromListeners, ...fromRules])];
+  }
+
+  /**
+   * Refuse to delete a target group anything still forwards to.
+   */
+  requireUnused(targetGroup: SimElbV2TargetGroup): void {
+    const inUseBy = this.loadBalancerArns(targetGroup);
+
+    if (inUseBy.length > 0) {
+      throw new SimElbV2ResourceInUseException(
+        `Target group ${targetGroup.arn} is still forwarded to by ${inUseBy.join(", ")}`,
+      );
+    }
+  }
+}

--- a/src/service/elbv2/target-group/sim-elbv2-target-group.ts
+++ b/src/service/elbv2/target-group/sim-elbv2-target-group.ts
@@ -1,0 +1,114 @@
+import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+import {
+  SimElbV2HealthCheck,
+  type SimElbV2HealthCheckInput,
+  type SimElbV2HealthCheckView,
+} from "./sim-elbv2-health-check.js";
+import type {
+  SimElbV2Target,
+  SimElbV2TargetDescription,
+} from "./sim-elbv2-target.js";
+import { SimElbV2TargetSet } from "./sim-elbv2-target-set.js";
+import type { SimElbV2TargetType } from "./sim-elbv2-target-type.js";
+
+interface SimElbV2TargetGroupProperties {
+  readonly name: string;
+  readonly id: string;
+  readonly targetType: SimElbV2TargetType;
+  readonly protocol: string | undefined;
+  readonly port: number | undefined;
+  readonly vpcId: string | undefined;
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+}
+
+/**
+ * A simulated target group as the SDK reads it back.
+ */
+export type SimElbV2TargetGroupView = SimElbV2HealthCheckView & {
+  readonly TargetGroupArn: string;
+  readonly TargetGroupName: string;
+  readonly TargetType: string;
+  readonly Protocol?: string | undefined;
+  readonly Port?: number | undefined;
+  readonly VpcId?: string | undefined;
+  readonly LoadBalancerArns: readonly string[];
+};
+
+/**
+ * One simulated target group, and the targets registered in it.
+ *
+ * The target type owns what this group will take, so nothing here branches on
+ * whether it holds a function or an address: registration asks the type, and
+ * the type refuses what it would not hold.
+ */
+export class SimElbV2TargetGroup {
+  public readonly name: string;
+  public readonly arn: string;
+  public readonly targetType: SimElbV2TargetType;
+  public readonly protocol: string | undefined;
+  public readonly port: number | undefined;
+  public readonly vpcId: string | undefined;
+
+  private readonly healthCheck: SimElbV2HealthCheck;
+  private readonly targets: SimElbV2TargetSet;
+
+  constructor(properties: SimElbV2TargetGroupProperties) {
+    const { accountRegionScope } = properties;
+
+    this.name = properties.name;
+    this.targetType = properties.targetType;
+    this.protocol = properties.protocol;
+    this.port = properties.port;
+    this.vpcId = properties.vpcId;
+    this.arn = `arn:aws:elasticloadbalancing:${accountRegionScope.regionName}:${accountRegionScope.accountId}:targetgroup/${properties.name}/${properties.id}`;
+    this.healthCheck = new SimElbV2HealthCheck(properties.targetType.value);
+    this.targets = new SimElbV2TargetSet({
+      targetType: properties.targetType,
+      port: properties.port,
+    });
+  }
+
+  /**
+   * Every target registered in this group, in registration order.
+   */
+  get registeredTargets(): readonly SimElbV2Target[] {
+    return this.targets.registered;
+  }
+
+  /**
+   * Change the health check settings a request names.
+   */
+  modifyHealthCheck(input: SimElbV2HealthCheckInput): void {
+    this.healthCheck.apply(input);
+  }
+
+  /**
+   * Register the targets a request names.
+   */
+  register(descriptions: readonly SimElbV2TargetDescription[]): void {
+    this.targets.register(descriptions);
+  }
+
+  /**
+   * Deregister the targets a request names.
+   */
+  deregister(descriptions: readonly SimElbV2TargetDescription[]): void {
+    this.targets.deregister(descriptions);
+  }
+
+  /**
+   * Report this target group in the shape the SDK reads it back in.
+   */
+  view(loadBalancerArns: readonly string[]): SimElbV2TargetGroupView {
+    return {
+      ...this.healthCheck.view(),
+      TargetGroupArn: this.arn,
+      TargetGroupName: this.name,
+      TargetType: this.targetType.value,
+      Protocol: this.protocol,
+      Port: this.port,
+      VpcId: this.vpcId,
+      LoadBalancerArns: loadBalancerArns,
+    };
+  }
+}

--- a/src/service/elbv2/target-group/sim-elbv2-target-set.ts
+++ b/src/service/elbv2/target-group/sim-elbv2-target-set.ts
@@ -1,0 +1,85 @@
+import { SimElbV2TooManyTargetsException } from "../error/sim-elbv2.error.js";
+import { SimElbV2Target } from "./sim-elbv2-target.js";
+import type { SimElbV2TargetDescription } from "./sim-elbv2-target.js";
+import type { SimElbV2TargetType } from "./sim-elbv2-target-type.js";
+
+interface SimElbV2TargetSetProperties {
+  readonly targetType: SimElbV2TargetType;
+  readonly port: number | undefined;
+}
+
+/**
+ * The targets registered in one simulated target group.
+ *
+ * This is where registering happens rather than on the group, because it is
+ * the only part of a group that changes after it is created, and keeping it
+ * here leaves the group itself immutable but for its health check settings.
+ *
+ * What a target may be is the target type's business: this asks the type and
+ * counts, and never looks at an address or an ARN itself.
+ */
+export class SimElbV2TargetSet {
+  private readonly targetType: SimElbV2TargetType;
+  private readonly port: number | undefined;
+  private readonly targets = new Map<string, SimElbV2Target>();
+
+  constructor(properties: SimElbV2TargetSetProperties) {
+    this.targetType = properties.targetType;
+    this.port = properties.port;
+  }
+
+  /**
+   * Every target in this set, in registration order.
+   */
+  get registered(): readonly SimElbV2Target[] {
+    return this.targets.values().toArray();
+  }
+
+  /**
+   * Register the targets a request names.
+   *
+   * Every target is read and checked before any is stored, so a request whose
+   * second target is refused leaves the group as it was rather than half
+   * registered.
+   */
+  register(descriptions: readonly SimElbV2TargetDescription[]): void {
+    const registering = descriptions.map((description) => {
+      const target = SimElbV2Target.read(description, this.port);
+
+      this.targetType.validateTarget(target);
+
+      return target;
+    });
+
+    this.requireRoom(registering);
+
+    for (const target of registering) {
+      this.targets.set(target.key, target);
+    }
+  }
+
+  /**
+   * Deregister the targets a request names.
+   *
+   * A target that was not registered is not an error on real ELB, and is not
+   * one here either.
+   */
+  deregister(descriptions: readonly SimElbV2TargetDescription[]): void {
+    for (const description of descriptions) {
+      this.targets.delete(SimElbV2Target.read(description, this.port).key);
+    }
+  }
+
+  private requireRoom(registering: readonly SimElbV2Target[]): void {
+    const keys = new Set([
+      ...this.targets.keys(),
+      ...registering.map((target) => target.key),
+    ]);
+
+    if (keys.size > this.targetType.maximumTargets) {
+      throw new SimElbV2TooManyTargetsException(
+        `Registering these targets would leave the ${this.targetType.value} target group holding ${String(keys.size)}, and it holds at most ${String(this.targetType.maximumTargets)}`,
+      );
+    }
+  }
+}

--- a/src/service/elbv2/target-group/sim-elbv2-target-type.ts
+++ b/src/service/elbv2/target-group/sim-elbv2-target-type.ts
@@ -1,0 +1,200 @@
+import {
+  SimElbV2InvalidConfigurationRequestException,
+  SimElbV2InvalidTargetException,
+  SimElbV2UnsimulatedInputException,
+} from "../error/sim-elbv2.error.js";
+
+/**
+ * What a target group holds, and the rules that follow from it.
+ *
+ * A target type is a strategy rather than a label: the number of targets a
+ * group takes, what a target's Id has to look like, and whether the group
+ * itself carries a protocol and port all depend on it, and each subclass here
+ * is one set of those answers.
+ *
+ * Two types are simulated. `lambda` is what real ALB invokes directly, and
+ * `ip` is what a service registers itself as. `instance` is refused rather
+ * than accepted, because there are no EC2 instances here for it to mean
+ * anything about: a group created as `instance` would look configured and
+ * route nowhere.
+ */
+export abstract class SimElbV2TargetType {
+  /**
+   * The value this type is named by, in a request and in a describe.
+   */
+  abstract readonly value: string;
+
+  /**
+   * The most targets real ELB lets a group of this type hold.
+   */
+  abstract readonly maximumTargets: number;
+
+  /**
+   * Refuse a target group whose other properties contradict this type.
+   */
+  abstract validateGroup(properties: SimElbV2TargetGroupShape): void;
+
+  /**
+   * Refuse a target this type would not take.
+   */
+  abstract validateTarget(target: SimElbV2TargetShape): void;
+}
+
+/**
+ * The target group properties a target type has an opinion about.
+ */
+export interface SimElbV2TargetGroupShape {
+  readonly protocol: string | undefined;
+  readonly port: number | undefined;
+}
+
+/**
+ * The registered target properties a target type has an opinion about.
+ */
+export interface SimElbV2TargetShape {
+  readonly id: string;
+  readonly port: number | undefined;
+}
+
+/**
+ * A function ARN, which is the only Id a `lambda` target takes.
+ */
+const functionArn = /^arn:aws:lambda:[\da-z-]+:\d{12}:function:[\w-]+$/u;
+
+/**
+ * An IPv4 address.
+ */
+const ipv4Address = /^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/u;
+
+/**
+ * An IPv6 address, recognised by the characters it is made of and the colons
+ * in it rather than parsed in full, since nothing here does anything with the
+ * address beyond storing it.
+ */
+const ipv6Characters = /^[\dA-Fa-f:]+$/u;
+
+/**
+ * Whether a target Id is an address of either family.
+ */
+function isIpAddress(id: string): boolean {
+  return ipv4Address.test(id) || (id.includes(":") && ipv6Characters.test(id));
+}
+
+/**
+ * A target group holding one Lambda function.
+ */
+class SimElbV2LambdaTargetType extends SimElbV2TargetType {
+  public override readonly value = "lambda";
+
+  /**
+   * Real ELB takes exactly one function per target group, which is what makes
+   * a Lambda target group a pointer at a function rather than a pool.
+   */
+  public override readonly maximumTargets = 1;
+
+  /**
+   * Refuse a protocol or port, which a function has no use for.
+   */
+  override validateGroup(properties: SimElbV2TargetGroupShape): void {
+    if (properties.protocol !== undefined || properties.port !== undefined) {
+      throw new SimElbV2InvalidConfigurationRequestException(
+        "A lambda target group takes no Protocol or Port, because the load " +
+          "balancer invokes the function rather than connecting to it",
+      );
+    }
+  }
+
+  /**
+   * Refuse anything but a function ARN, and refuse a port with it.
+   */
+  override validateTarget(target: SimElbV2TargetShape): void {
+    if (!functionArn.test(target.id)) {
+      throw new SimElbV2InvalidTargetException(
+        `Target '${target.id}' is not a Lambda function ARN. A lambda target ` +
+          `group registers a function by its ARN.`,
+      );
+    }
+
+    if (target.port !== undefined) {
+      throw new SimElbV2InvalidTargetException(
+        `Target '${target.id}' cannot carry a Port, because a function is ` +
+          `invoked rather than connected to`,
+      );
+    }
+  }
+}
+
+/**
+ * A target group holding addresses, which is what a container service
+ * registers itself as.
+ */
+class SimElbV2IpTargetType extends SimElbV2TargetType {
+  public override readonly value = "ip";
+
+  /**
+   * Far below what real ELB allows, and high enough that nothing a test
+   * registers reaches it.
+   */
+  public override readonly maximumTargets = 1000;
+
+  /**
+   * Require the protocol and port real ELB requires of an address group.
+   */
+  override validateGroup(properties: SimElbV2TargetGroupShape): void {
+    if (properties.protocol === undefined || properties.port === undefined) {
+      throw new SimElbV2InvalidConfigurationRequestException(
+        "An ip target group requires a Protocol and a Port, which is where a " +
+          "registered address is reached",
+      );
+    }
+  }
+
+  /**
+   * Refuse an Id that is not an address.
+   */
+  override validateTarget(target: SimElbV2TargetShape): void {
+    if (!isIpAddress(target.id)) {
+      throw new SimElbV2InvalidTargetException(
+        `Target '${target.id}' is not an IP address. An ip target group ` +
+          `registers addresses rather than instance ids or ARNs.`,
+      );
+    }
+  }
+}
+
+const targetTypes = new Map<string, SimElbV2TargetType>([
+  ["lambda", new SimElbV2LambdaTargetType()],
+  ["ip", new SimElbV2IpTargetType()],
+]);
+
+/**
+ * Read the target type a request names.
+ *
+ * A request naming none is refused rather than defaulted. Real ELB defaults to
+ * `instance`, which is not simulated, so silently choosing one of the two
+ * types that are would create a group the request did not ask for.
+ */
+export function simElbV2TargetType(
+  value: string | undefined,
+): SimElbV2TargetType {
+  if (value === undefined) {
+    throw new SimElbV2UnsimulatedInputException(
+      "TargetType is required here. Real ELB defaults it to 'instance', " +
+        "which is not simulated, so a target group has to name 'lambda' or " +
+        "'ip' rather than be given one of them.",
+    );
+  }
+
+  const targetType = targetTypes.get(value);
+
+  if (targetType === undefined) {
+    throw new SimElbV2UnsimulatedInputException(
+      `TargetType '${value}' is not simulated. There are no EC2 instances or ` +
+        `nested load balancers here for it to mean anything about, so it is ` +
+        `refused rather than accepted and ignored. Simulated target types are ` +
+        `${targetTypes.keys().toArray().join(" and ")}.`,
+    );
+  }
+
+  return targetType;
+}

--- a/src/service/elbv2/target-group/sim-elbv2-target-type.ts
+++ b/src/service/elbv2/target-group/sim-elbv2-target-type.ts
@@ -1,3 +1,5 @@
+import { isIP } from "node:net";
+
 import {
   SimElbV2InvalidConfigurationRequestException,
   SimElbV2InvalidTargetException,
@@ -60,25 +62,6 @@ export interface SimElbV2TargetShape {
  * A function ARN, which is the only Id a `lambda` target takes.
  */
 const functionArn = /^arn:aws:lambda:[\da-z-]+:\d{12}:function:[\w-]+$/u;
-
-/**
- * An IPv4 address.
- */
-const ipv4Address = /^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/u;
-
-/**
- * An IPv6 address, recognised by the characters it is made of and the colons
- * in it rather than parsed in full, since nothing here does anything with the
- * address beyond storing it.
- */
-const ipv6Characters = /^[\dA-Fa-f:]+$/u;
-
-/**
- * Whether a target Id is an address of either family.
- */
-function isIpAddress(id: string): boolean {
-  return ipv4Address.test(id) || (id.includes(":") && ipv6Characters.test(id));
-}
 
 /**
  * A target group holding one Lambda function.
@@ -153,7 +136,9 @@ class SimElbV2IpTargetType extends SimElbV2TargetType {
    * Refuse an Id that is not an address.
    */
   override validateTarget(target: SimElbV2TargetShape): void {
-    if (!isIpAddress(target.id)) {
+    // Parsed rather than pattern matched, so that something shaped like an
+    // address but impossible, such as 999.999.999.999, is refused too.
+    if (isIP(target.id) === 0) {
       throw new SimElbV2InvalidTargetException(
         `Target '${target.id}' is not an IP address. An ip target group ` +
           `registers addresses rather than instance ids or ARNs.`,

--- a/src/service/elbv2/target-group/sim-elbv2-target.ts
+++ b/src/service/elbv2/target-group/sim-elbv2-target.ts
@@ -1,0 +1,72 @@
+import { SimElbV2ValidationError } from "../error/sim-elbv2.error.js";
+
+/**
+ * Minimal structural sim ELBv2 target description.
+ */
+export interface SimElbV2TargetDescription {
+  readonly Id?: string | undefined;
+  readonly Port?: number | undefined;
+  readonly AvailabilityZone?: string | undefined;
+}
+
+/**
+ * One target registered in a simulated target group.
+ *
+ * Identity is the address and the port together, as it is on real ELB: the
+ * same address registered on two ports is two targets, and deregistering one
+ * leaves the other.
+ */
+export class SimElbV2Target {
+  public readonly id: string;
+  public readonly port: number | undefined;
+  public readonly availabilityZone: string | undefined;
+
+  private constructor(
+    id: string,
+    port: number | undefined,
+    availabilityZone: string | undefined,
+  ) {
+    this.id = id;
+    this.port = port;
+    this.availabilityZone = availabilityZone;
+  }
+
+  /**
+   * Read a target a request names, refusing one with no Id.
+   *
+   * A target naming no port takes the target group's, which is what real ELB
+   * does, so a group listening on one port needs the port named once.
+   */
+  static read(
+    target: SimElbV2TargetDescription,
+    groupPort: number | undefined,
+  ): SimElbV2Target {
+    if (target.Id === undefined || target.Id === "") {
+      throw new SimElbV2ValidationError("Targets member requires an Id");
+    }
+
+    return new SimElbV2Target(
+      target.Id,
+      target.Port ?? groupPort,
+      target.AvailabilityZone,
+    );
+  }
+
+  /**
+   * How this target is told apart from the others in its group.
+   */
+  get key(): string {
+    return `${this.id}:${String(this.port ?? "")}`;
+  }
+
+  /**
+   * Report this target in the shape the SDK reads it back in.
+   */
+  view(): SimElbV2TargetDescription {
+    return {
+      Id: this.id,
+      Port: this.port,
+      AvailabilityZone: this.availabilityZone,
+    };
+  }
+}


### PR DESCRIPTION
Adds a simulated Elastic Load Balancing v2 service under `src/service/elbv2/`, holding application load balancers, target groups, listeners and listener rules, with the create, describe, modify and delete operations for each and the target registration that goes with them. A created load balancer reports a DNS name of the shape real ELB issues, so a Route53 alias or a CloudFront origin has something of the right form to point at. Target types are `lambda`, which takes exactly one function ARN, and `ip`, which is what a service registers as; `instance` is refused rather than accepted and ignored, since there are no instances here for it to mean anything about, and a request naming no target type at all is refused rather than defaulted to `instance` as real ELB defaults it. Listener rules carry a priority and two rules cannot claim the same one on a listener, with `SetRulePriorities` judging a request against the order it would leave behind so two rules can swap places. Deleting a load balancer takes its listeners and their rules and leaves its target groups, and a target group anything still forwards to cannot be deleted. This is state only: routing a request (#563) and matching a rule against one (#564) are deliberately out of scope, as are network and gateway load balancers.

This is well past the rough 2000-line steer: about 5450 lines of source, 2800 of tests and 600 of docs. The size is the nineteen operations the issue asks for rather than scope creep, and the only thing cut is CloudFormation support, which the issue does not ask for and which is noted in the docs Limitations section. Three shared files outside the new service are touched: the `SimAws` service accessors, scope container and factory wiring, and the SDK interception table. Two small extractions in `SimAwsAccountRegionServiceBuilder` (the scoped-properties helper and the Rekognition image wiring) were needed to keep that file under its 300-line limit once a service was added to it, which is worth knowing given #553 adds one there too.

Resolves https://github.com/KensioSoftware/yulin/issues/562

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added simulated Elastic Load Balancing v2 support for Application Load Balancers.
  - Supports load balancers, Lambda and IP target groups, target registration, health queries, listeners, listener rules, priorities, pagination, and deletion workflows.
  - Added IAM authorization and AWS SDK client interception.
  - Added comprehensive usage examples and service documentation.
- **Documentation**
  - Added ELBv2 service documentation, limitations, supported operations, and integration guidance.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->