### PR TITLE
feat: simulate ECR repositories holding images

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ npm i -D @kensio/yulin
 - [CloudFront](./docs/services/cloudfront "Simulated CloudFront docs")
 - [Cognito user pools](./docs/services/cognito "Simulated Cognito user pools docs")
 - [DynamoDB](./docs/services/dynamodb "Simulated DynamoDB docs")
+- [ECR](./docs/services/ecr "Simulated ECR docs")
 - [ECS](./docs/services/ecs "Simulated ECS docs")
 - [EventBridge](./docs/services/eventbridge "Simulated EventBridge docs")
 - [IAM](./docs/services/iam "Simulated IAM docs")

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,7 @@ behaviour and includes example code that can be copied into tests or local devel
 - [CloudFront](./services/cloudfront/ "Simulated CloudFront usage docs")
 - [Cognito user pools](./services/cognito/ "Simulated Cognito user pools usage docs")
 - [DynamoDB](./services/dynamodb/ "Simulated DynamoDB usage docs")
+- [ECR](./services/ecr/ "Simulated ECR usage docs")
 - [ECS](./services/ecs/ "Simulated ECS usage docs")
 - [Elastic Load Balancing](./services/elbv2/ "Simulated Application Load Balancer usage docs")
 - [EventBridge](./services/eventbridge/ "Simulated EventBridge usage docs")

--- a/docs/services/cloudformation/README.md
+++ b/docs/services/cloudformation/README.md
@@ -2046,6 +2046,7 @@ The resource types it creates are:
 - `AWS::Cognito::UserPool`, `AWS::Cognito::UserPoolClient` and
   `AWS::Cognito::UserPoolGroup`
 - `AWS::DynamoDB::Table` and `AWS::DynamoDB::GlobalTable`
+- `AWS::ECR::Repository`
 - `AWS::Events::EventBus` and `AWS::Events::Rule`, with the rule's inline `Targets`
 - `AWS::IAM::Role`, `AWS::IAM::ManagedPolicy` and `AWS::IAM::Policy`
 - `AWS::KMS::Key` and `AWS::KMS::Alias`

--- a/docs/services/ecr/README.md
+++ b/docs/services/ecr/README.md
@@ -91,21 +91,27 @@ are names and an image URI is not one. A name real ECR would refuse is refused h
 
 ## How an image URI is matched
 
-A function's `Code.ImageUri` is matched to a repository on the registry host and the repository
-name, with the tag and any digest ignored.
+Resolving an image URI happens in two steps, and the tag means something different in each.
 
-The tag is ignored because no tag is stable enough to write into a test. A CDK image asset is tagged
-with the asset content hash, which changes whenever the image source does, and a pipeline-built
-image is usually tagged with a git sha or a build number passed in as a stack parameter. An
-`ImageUri` built by `Fn::Sub` or from a stack parameter is matched on what it resolves to.
+Finding the repository ignores the tag. A function's `Code.ImageUri` is matched on the registry host
+and the repository name, with any tag or digest dropped, because no tag is stable enough to write
+into a test: a CDK image asset is tagged with the asset content hash, which changes whenever the
+image source does, and a pipeline-built image is usually tagged with a git sha or a build number
+passed in as a stack parameter. An `ImageUri` built by `Fn::Sub` or from a stack parameter is
+matched on what it resolves to.
+
+Choosing the image in that repository does read the tag. A tag the repository holds selects exactly
+that image, and any other tag, or none at all, falls back to the image registered most recently.
 
 The registry host is part of the match, so the account and the region have to agree. A function can
 run an image from another account's repository, as it can on real AWS, and a same-named repository
 in another account is a different repository.
 
-A repository holding more than one tagged image answers a tag it holds with exactly that image, and
-any other tag with the image registered most recently. That is how a blue/green pair of images in
-one repository can back two functions differently.
+So `orders:blue` runs the handler registered under `blue` where there is one, and the handler
+registered most recently where there is not. That is how a blue/green pair of images in one
+repository can back two functions differently, while a content hash tag nobody registered still
+finds something to run. Registering a tag again both replaces what it held and makes it the most
+recent registration.
 
 ```typescript sim-ecr-image-tags
 /**
@@ -232,8 +238,14 @@ await simAws.backgroundTasksComplete();
 
 A repository a handler is already registered in is adopted rather than replaced, so the order these
 happen in does not matter: the image exists before the stack that declares the repository, as it
-does in real life. Tearing the stack down removes the repository, and the simulated images it holds
-go with it.
+does in real life.
+
+Tearing the stack down removes the repository only where it holds no simulated image. One that does
+is left where it is, and the deletion is recorded as skipped, because the handler in it was
+registered outside any stack and is what every later deploy resolves to. Real ECR also refuses to
+delete a repository that still holds images, which fails the stack unless the template says
+`EmptyOnDelete`; the refusal is recorded rather than failing the teardown here, since what is being
+protected is a test's own registration.
 
 Every other property a repository can declare is about image content, so each one is recorded as an
 ignored property and the repository is created without it. That covers
@@ -259,8 +271,8 @@ registered.
 
 - Repositories, made by naming them, scoped by account and region
 - `simulateImage`, registering a real in-process handler as the image under a tag
-- Resolution of a Lambda `Code.ImageUri` to that handler, matching on registry host and repository
-  name and ignoring the tag
+- Resolution of a Lambda `Code.ImageUri` to that handler, finding the repository on registry host
+  and name alone, then reading the tag to choose between the images it holds
 - Functions created from a repository image through CloudFormation and through `CreateFunction`
 - Images resolved across accounts and regions, as real Lambda pulls across them
 - `AWS::ECR::Repository`, answering `Ref` with the repository name and `Fn::GetAtt` with `Arn` and
@@ -282,9 +294,11 @@ Current documented limitations:
   not enforced, so registering the same tag again replaces what it held.
 - Naming a repository creates it. There is no `CreateRepository` to fail for a name already taken,
   and no way to ask whether a repository exists without making one, other than `hasRepository`.
-- A repository is deleted with the images it holds, where real ECR refuses to delete one that still
-  holds images unless it is emptied first. A simulated image is a handler a test registered rather
-  than an artifact anything could lose.
+- A stack teardown records the deletion of a repository holding a simulated image rather than
+  failing, where real CloudFormation fails the stack unless the template says `EmptyOnDelete`. The
+  repository and its handler are left in place. `EmptyOnDelete` itself is not read.
+- Nothing tracks which stack created a repository. A repository holding no simulated image is
+  removed by the teardown of any stack that declared it, and made again by the next deploy.
 - Repository tags, registry policies, pull through cache rules, replication configuration and
   ECR Public are not simulated.
 - ECR is not served as an HTTP API by `serveSimAws`, and there is nothing for a Docker client to

--- a/docs/services/ecr/README.md
+++ b/docs/services/ecr/README.md
@@ -1,0 +1,291 @@
+# Simulated ECR
+
+Yulin includes a simulated Amazon ECR for tests and local development. It holds repositories, and
+each repository holds images by tag, where a simulated image is a real in-process handler.
+
+That is what this service is for. A container image Lambda function cannot run here, because Yulin
+never reads an image, so something has to say what the code inside that image actually is. A
+repository is the natural place to say it: it is the stable name for the thing that holds the code,
+and it outlives any stack, any tag and any CDK construct ID.
+
+ECR-specific types are imported from the `@kensio/yulin/ecr` subpath.
+
+## What a simulated image is
+
+An image URI is only ever an identifier here. Nothing is pulled, nothing is inspected, and no layer,
+manifest, digest or scan finding exists. A simulated image is a handler function, registered against
+a repository and a tag.
+
+Registering one is a Yulin-native operation rather than a simulated `PutImage`, and it is named
+`simulateImage` so it cannot be mistaken for one. Real `PutImage` takes an image manifest for layers
+that were pushed over the Docker registry protocol, none of which happens in this process, so a
+simulated `PutImage` would be a command that took an argument nothing could produce.
+
+## Registering a handler as an image
+
+Register the handler once, in test setup, and every function that runs an image from that repository
+is created from it.
+
+```typescript sim-ecr-register-image
+/**
+ * Registering a handler as the image in a simulated ECR repository.
+ */
+
+import { InvokeCommand } from "@aws-sdk/client-lambda";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+simAws
+  .ecr()
+  .repository("orders")
+  .simulateImage({
+    imageTag: "latest",
+    handler: (event: { orderId: string }): string =>
+      `Processed ${event.orderId}`,
+  });
+
+// Any stack whose function image points into that repository runs the handler.
+await simAws.cloudFormation().deployTemplate({
+  stackName: "orders-api",
+  template: {
+    Resources: {
+      OrdersFunction: {
+        Type: "AWS::Lambda::Function",
+        Properties: {
+          FunctionName: "orders",
+          Role: `arn:aws:iam::${simAws.defaultAccountId}:role/OrdersRole`,
+          PackageType: "Image",
+          Code: {
+            ImageUri:
+              `${simAws.defaultAccountId}.dkr.ecr.` +
+              `${simAws.defaultRegionName}.amazonaws.com/orders:2f0e1dab4c`,
+          },
+        },
+      },
+    },
+  },
+});
+
+const output = await simAws.lambda().invoke(
+  new InvokeCommand({
+    FunctionName: "orders",
+    Payload: JSON.stringify({ orderId: "order-1" }),
+  }),
+);
+
+if (output.Payload === undefined) throw new Error("No invoke Payload");
+console.log(Buffer.from(output.Payload).toString());
+
+await simAws.backgroundTasksComplete();
+```
+
+Naming a repository is what creates it. There is nothing to declare first, because a repository
+holds nothing of its own beyond its images, so a test can name the repository its templates already
+point at.
+
+The repository name is a name rather than a URI. The account, the region and the registry host
+around it come from the simulated ECR the repository belongs to, so `orders` and `platform/orders`
+are names and an image URI is not one. A name real ECR would refuse is refused here too.
+
+## How an image URI is matched
+
+A function's `Code.ImageUri` is matched to a repository on the registry host and the repository
+name, with the tag and any digest ignored.
+
+The tag is ignored because no tag is stable enough to write into a test. A CDK image asset is tagged
+with the asset content hash, which changes whenever the image source does, and a pipeline-built
+image is usually tagged with a git sha or a build number passed in as a stack parameter. An
+`ImageUri` built by `Fn::Sub` or from a stack parameter is matched on what it resolves to.
+
+The registry host is part of the match, so the account and the region have to agree. A function can
+run an image from another account's repository, as it can on real AWS, and a same-named repository
+in another account is a different repository.
+
+A repository holding more than one tagged image answers a tag it holds with exactly that image, and
+any other tag with the image registered most recently. That is how a blue/green pair of images in
+one repository can back two functions differently.
+
+```typescript sim-ecr-image-tags
+/**
+ * Two tagged images in one simulated ECR repository.
+ */
+
+import { CreateFunctionCommand, InvokeCommand } from "@aws-sdk/client-lambda";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const registryHost =
+  `${simAws.defaultAccountId}.dkr.ecr.` +
+  `${simAws.defaultRegionName}.amazonaws.com`;
+
+simAws
+  .ecr()
+  .repository("orders")
+  .simulateImage({ imageTag: "blue", handler: (): string => "blue handler" })
+  .simulateImage({ imageTag: "green", handler: (): string => "green handler" });
+
+await simAws.lambda().createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "orders-blue",
+    Role: `arn:aws:iam::${simAws.defaultAccountId}:role/OrdersRole`,
+    PackageType: "Image",
+    Code: { ImageUri: `${registryHost}/orders:blue` },
+  }),
+);
+
+const output = await simAws
+  .lambda()
+  .invoke(new InvokeCommand({ FunctionName: "orders-blue" }));
+
+if (output.Payload === undefined) throw new Error("No invoke Payload");
+console.log(Buffer.from(output.Payload).toString()); // "blue handler"
+
+await simAws.backgroundTasksComplete();
+```
+
+A function created directly through `CreateFunction` resolves its image the same way a template
+function does, as the example above shows. A function whose image resolves to nothing is refused,
+the way real Lambda refuses a function whose image it cannot pull.
+
+## Repositories in CloudFormation
+
+`AWS::ECR::Repository` creates a simulated repository. A template declares a repository and never an
+image, which is what real CloudFormation does too, so a deployed repository starts empty unless a
+handler has already been registered in it.
+
+`Ref` returns the repository name, and `Fn::GetAtt` exposes `Arn` and `RepositoryUri`, so an
+application stack can build its function's `ImageUri` from the repository a platform stack declared.
+
+```typescript sim-ecr-cloudformation-repository
+/**
+ * An AWS::ECR::Repository declared by one stack and used by another.
+ */
+
+import { InvokeCommand } from "@aws-sdk/client-lambda";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+// The platform stack declares the repository.
+const platformStack = await simAws.cloudFormation().deployTemplate({
+  stackName: "platform",
+  template: {
+    Resources: {
+      OrdersRepository: {
+        Type: "AWS::ECR::Repository",
+        Properties: { RepositoryName: "orders" },
+      },
+    },
+    Outputs: {
+      RepositoryUri: {
+        Value: { "Fn::GetAtt": ["OrdersRepository", "RepositoryUri"] },
+      },
+    },
+  },
+});
+
+await platformStack.waitForDeployComplete();
+
+const repositoryUri = platformStack.outputs.get("RepositoryUri")?.value;
+
+if (typeof repositoryUri !== "string") {
+  throw new TypeError("No RepositoryUri Output");
+}
+
+// The handler stands in for whatever the pipeline would have pushed.
+simAws
+  .ecr()
+  .repository("orders")
+  .simulateImage({ handler: (): string => "ran the repository image" });
+
+// The application stack runs an image from it.
+await simAws.cloudFormation().deployTemplate({
+  stackName: "orders-api",
+  template: {
+    Resources: {
+      OrdersFunction: {
+        Type: "AWS::Lambda::Function",
+        Properties: {
+          FunctionName: "orders",
+          Role: `arn:aws:iam::${simAws.defaultAccountId}:role/OrdersRole`,
+          PackageType: "Image",
+          Code: { ImageUri: `${repositoryUri}:latest` },
+        },
+      },
+    },
+  },
+});
+
+const output = await simAws
+  .lambda()
+  .invoke(new InvokeCommand({ FunctionName: "orders" }));
+
+if (output.Payload === undefined) throw new Error("No invoke Payload");
+console.log(Buffer.from(output.Payload).toString());
+
+await simAws.backgroundTasksComplete();
+```
+
+A repository a handler is already registered in is adopted rather than replaced, so the order these
+happen in does not matter: the image exists before the stack that declares the repository, as it
+does in real life. Tearing the stack down removes the repository, and the simulated images it holds
+go with it.
+
+Every other property a repository can declare is about image content, so each one is recorded as an
+ignored property and the repository is created without it. That covers
+`ImageScanningConfiguration`, `ImageTagMutability`, `LifecyclePolicy`, `RepositoryPolicyText`,
+`EncryptionConfiguration`, `EmptyOnDelete` and `Tags`.
+
+## Where a function's handler comes from
+
+Two things can back a container image function, and a deploy is looked at in this order:
+
+1. An [executable binding](../lambda/#executable-bindings) given to that deploy, including one
+   naming the image repository. A binding is the more specific thing to have said, since it is about
+   one deploy.
+2. The simulated ECR repository the function's `Code.ImageUri` names, which is a standing statement
+   about what that image is, made once and good for every stack that runs it.
+
+A function neither backs is skipped with a diagnostic, and the rest of the stack deploys. The reason
+distinguishes an image whose repository nothing holds from one whose repository holds no image,
+since those send you to different places: a name that is wrong, or a handler that was never
+registered.
+
+## Available functionality
+
+- Repositories, made by naming them, scoped by account and region
+- `simulateImage`, registering a real in-process handler as the image under a tag
+- Resolution of a Lambda `Code.ImageUri` to that handler, matching on registry host and repository
+  name and ignoring the tag
+- Functions created from a repository image through CloudFormation and through `CreateFunction`
+- Images resolved across accounts and regions, as real Lambda pulls across them
+- `AWS::ECR::Repository`, answering `Ref` with the repository name and `Fn::GetAtt` with `Arn` and
+  `RepositoryUri`
+
+## Limitations
+
+Current documented limitations:
+
+- No image content, layer, digest, manifest or scan behaviour is simulated. Nothing is pulled,
+  nothing is inspected, and a repository holds handlers rather than artifacts.
+- There are no ECR SDK commands. `CreateRepository`, `DescribeRepositories`, `PutImage`,
+  `DescribeImages`, `BatchDeleteImage` and `GetAuthorizationToken` are not simulated. Registering an
+  image is a Yulin-native operation because real `PutImage` takes a manifest for layers pushed over
+  the Docker registry protocol, which does not happen in this process.
+- Nothing authorizes against a repository. There are no requests to authorize, so a repository
+  policy is not evaluated and simulated IAM is not consulted.
+- Lifecycle policies are not evaluated, so no simulated image ever expires, and tag mutability is
+  not enforced, so registering the same tag again replaces what it held.
+- Naming a repository creates it. There is no `CreateRepository` to fail for a name already taken,
+  and no way to ask whether a repository exists without making one, other than `hasRepository`.
+- A repository is deleted with the images it holds, where real ECR refuses to delete one that still
+  holds images unless it is emptied first. A simulated image is a handler a test registered rather
+  than an artifact anything could lose.
+- Repository tags, registry policies, pull through cache rules, replication configuration and
+  ECR Public are not simulated.
+- ECR is not served as an HTTP API by `serveSimAws`, and there is nothing for a Docker client to
+  talk to.

--- a/docs/services/ecr/sim-ecr-cloudformation-repository.example.ts
+++ b/docs/services/ecr/sim-ecr-cloudformation-repository.example.ts
@@ -1,0 +1,68 @@
+/**
+ * An AWS::ECR::Repository declared by one stack and used by another.
+ */
+
+import { InvokeCommand } from "@aws-sdk/client-lambda";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+// The platform stack declares the repository.
+const platformStack = await simAws.cloudFormation().deployTemplate({
+  stackName: "platform",
+  template: {
+    Resources: {
+      OrdersRepository: {
+        Type: "AWS::ECR::Repository",
+        Properties: { RepositoryName: "orders" },
+      },
+    },
+    Outputs: {
+      RepositoryUri: {
+        Value: { "Fn::GetAtt": ["OrdersRepository", "RepositoryUri"] },
+      },
+    },
+  },
+});
+
+await platformStack.waitForDeployComplete();
+
+const repositoryUri = platformStack.outputs.get("RepositoryUri")?.value;
+
+if (typeof repositoryUri !== "string") {
+  throw new TypeError("No RepositoryUri Output");
+}
+
+// The handler stands in for whatever the pipeline would have pushed.
+simAws
+  .ecr()
+  .repository("orders")
+  .simulateImage({ handler: (): string => "ran the repository image" });
+
+// The application stack runs an image from it.
+await simAws.cloudFormation().deployTemplate({
+  stackName: "orders-api",
+  template: {
+    Resources: {
+      OrdersFunction: {
+        Type: "AWS::Lambda::Function",
+        Properties: {
+          FunctionName: "orders",
+          Role: `arn:aws:iam::${simAws.defaultAccountId}:role/OrdersRole`,
+          PackageType: "Image",
+          Code: { ImageUri: `${repositoryUri}:latest` },
+        },
+      },
+    },
+  },
+});
+
+const output = await simAws
+  .lambda()
+  .invoke(new InvokeCommand({ FunctionName: "orders" }));
+
+if (output.Payload === undefined) throw new Error("No invoke Payload");
+console.log(Buffer.from(output.Payload).toString());
+
+await simAws.backgroundTasksComplete();

--- a/docs/services/ecr/sim-ecr-image-tags.example.ts
+++ b/docs/services/ecr/sim-ecr-image-tags.example.ts
@@ -1,0 +1,36 @@
+/**
+ * Two tagged images in one simulated ECR repository.
+ */
+
+import { CreateFunctionCommand, InvokeCommand } from "@aws-sdk/client-lambda";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const registryHost =
+  `${simAws.defaultAccountId}.dkr.ecr.` +
+  `${simAws.defaultRegionName}.amazonaws.com`;
+
+simAws
+  .ecr()
+  .repository("orders")
+  .simulateImage({ imageTag: "blue", handler: (): string => "blue handler" })
+  .simulateImage({ imageTag: "green", handler: (): string => "green handler" });
+
+await simAws.lambda().createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "orders-blue",
+    Role: `arn:aws:iam::${simAws.defaultAccountId}:role/OrdersRole`,
+    PackageType: "Image",
+    Code: { ImageUri: `${registryHost}/orders:blue` },
+  }),
+);
+
+const output = await simAws
+  .lambda()
+  .invoke(new InvokeCommand({ FunctionName: "orders-blue" }));
+
+if (output.Payload === undefined) throw new Error("No invoke Payload");
+console.log(Buffer.from(output.Payload).toString()); // "blue handler"
+
+await simAws.backgroundTasksComplete();

--- a/docs/services/ecr/sim-ecr-register-image.example.ts
+++ b/docs/services/ecr/sim-ecr-register-image.example.ts
@@ -1,0 +1,52 @@
+/**
+ * Registering a handler as the image in a simulated ECR repository.
+ */
+
+import { InvokeCommand } from "@aws-sdk/client-lambda";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+simAws
+  .ecr()
+  .repository("orders")
+  .simulateImage({
+    imageTag: "latest",
+    handler: (event: { orderId: string }): string =>
+      `Processed ${event.orderId}`,
+  });
+
+// Any stack whose function image points into that repository runs the handler.
+await simAws.cloudFormation().deployTemplate({
+  stackName: "orders-api",
+  template: {
+    Resources: {
+      OrdersFunction: {
+        Type: "AWS::Lambda::Function",
+        Properties: {
+          FunctionName: "orders",
+          Role: `arn:aws:iam::${simAws.defaultAccountId}:role/OrdersRole`,
+          PackageType: "Image",
+          Code: {
+            ImageUri:
+              `${simAws.defaultAccountId}.dkr.ecr.` +
+              `${simAws.defaultRegionName}.amazonaws.com/orders:2f0e1dab4c`,
+          },
+        },
+      },
+    },
+  },
+});
+
+const output = await simAws.lambda().invoke(
+  new InvokeCommand({
+    FunctionName: "orders",
+    Payload: JSON.stringify({ orderId: "order-1" }),
+  }),
+);
+
+if (output.Payload === undefined) throw new Error("No invoke Payload");
+console.log(Buffer.from(output.Payload).toString());
+
+await simAws.backgroundTasksComplete();

--- a/docs/services/lambda/README.md
+++ b/docs/services/lambda/README.md
@@ -1572,10 +1572,19 @@ A function with `PackageType: Image` names a container image instead of code, wh
 is nothing for it to run. The Resource is skipped with a diagnostic naming the image, and the rest
 of the stack deploys.
 
-Bind a real in-process handler to the function to simulate it. The binding replaces the image, so
-the function is created and invoked like any other. This is the same mechanism as
-[executable bindings](#executable-bindings), and it is the only way to run an image-packaged
-function.
+There are two ways to give that function a real in-process handler to run instead, and they suit
+different shapes of test:
+
+- Bind one to the function for this deploy, which is the same mechanism as
+  [executable bindings](#executable-bindings) and is shown below.
+- Register one as the image in a
+  [simulated ECR repository](../ecr/ "Simulated ECR usage docs"), which is a standing statement
+  about what that image is, made once and good for every stack that runs it, and for a function
+  created directly through `CreateFunction`.
+
+Either way the handler replaces the image, so the function is created and invoked like any other. A
+binding is looked at first, because it is about one deploy where a repository is about the image
+everywhere.
 
 ```typescript sim-lambda-container-image-function
 /**
@@ -1650,6 +1659,10 @@ running in this process.
 A binding can also name the image repository instead of the function, which covers every function
 running that image without repeating the binding per stack. See
 [binding by container image repository](#binding-by-container-image-repository).
+
+The skip reason says what was looked for. An image whose repository no simulated ECR holds is
+reported apart from one whose repository holds no image, since those send you to different places:
+a repository name that does not agree with the template, or a handler that was never registered.
 
 ## Function URLs in templates
 
@@ -1877,11 +1890,17 @@ A function matched this way is created from the bound handler, so it never reach
 [container image skip](#container-image-functions). Functions in the same template running an image
 from another repository are skipped as usual.
 
+A binding like this and a handler registered in
+[simulated ECR](../ecr/ "Simulated ECR usage docs") match on the same thing, and the binding is what
+backs the function where both could. Reach for the binding when the handler belongs to one deploy,
+and for the repository when it belongs to the image.
+
 ## Available functionality
 
 Sim Lambda currently supports:
 
-- `CreateFunctionCommand` and `GetFunctionCommand`
+- `CreateFunctionCommand` and `GetFunctionCommand`, including a function created from the
+  [simulated ECR](../ecr/ "Simulated ECR usage docs") image its `Code.ImageUri` names
 - `InvokeCommand`, with the `RequestResponse`, `Event` and `DryRun` invocation types
 - Function URLs, created with `CreateFunctionUrlConfigCommand` and served over HTTP on localhost
   with `serveSimAws`
@@ -1948,8 +1967,10 @@ Current documented limitations:
 - The vm runtime supports CommonJS function code only; ES module source (`.mjs` / `export`
   syntax) is not supported yet.
 - Container image functions are not run. Yulin never reads a container image, and stays Docker-free.
-  A template function with `PackageType: Image` is skipped unless a real in-process handler is bound
-  to it. See [Container image functions](#container-image-functions).
+  A function with `PackageType: Image` is skipped, or refused on `CreateFunction`, unless a real
+  in-process handler stands in for its image: one bound to it, or one registered in the
+  [simulated ECR](../ecr/ "Simulated ECR usage docs") repository the image URI names. See
+  [Container image functions](#container-image-functions).
 - Lambda Layers are not simulated.
 - Environment variables declared with `Environment.Variables` reach a real in-process handler
   function only while it runs, so a variable read at module scope sees the host process value

--- a/package.json
+++ b/package.json
@@ -70,6 +70,10 @@
       "import": "./dist/service/dynamodb/index.js",
       "types": "./dist/service/dynamodb/index.d.ts"
     },
+    "./ecr": {
+      "import": "./dist/service/ecr/index.js",
+      "types": "./dist/service/ecr/index.d.ts"
+    },
     "./ecs": {
       "import": "./dist/service/ecs/index.js",
       "types": "./dist/service/ecs/index.d.ts"

--- a/src/service/aws/factory/sim-aws-account-region-service-builder.ts
+++ b/src/service/aws/factory/sim-aws-account-region-service-builder.ts
@@ -15,10 +15,8 @@ import {
 } from "./sim-aws-cross-account-collaborators.js";
 import { SimCloudFormation } from "../../cloudformation/index.js";
 import { SimCognitoIdentityProvider } from "../../cognito/index.js";
+import { SimEcr } from "../../ecr/index.js";
 import { simAwsCognitoTriggerFunctions } from "../../cognito/user-pool/trigger/sim-aws-cognito-trigger-functions.js";
-import { SimDynamoDb as SimDynamoDatabase } from "../../dynamodb/index.js";
-import { SimEcs } from "../../ecs/index.js";
-import { SimElbV2 } from "../../elbv2/index.js";
 import { SimEventBridge } from "../../eventbridge/index.js";
 import type { SimIamRegistry } from "../../iam/registry/sim-iam-registry.js";
 import { SimKms } from "../../kms/index.js";
@@ -30,11 +28,8 @@ import { SimS3 } from "../../s3/sim-s3.js";
 import { SimScheduler } from "../../scheduler/index.js";
 import { simAwsLambdaCollaborators } from "./sim-aws-lambda-collaborators.js";
 import { simAwsS3NotificationDestinations } from "./sim-aws-s3-notification-destinations.js";
-import { SimSecretsManager } from "../../secretsmanager/index.js";
 import { SimSns } from "../../sns/index.js";
 import { SimAwsSnsDeliveryEndpoints } from "../../sns/delivery/sim-aws-sns-delivery-endpoints.js";
-import { SimSqs } from "../../sqs/index.js";
-import { SimSsm } from "../../ssm/index.js";
 import { SimSts } from "../../sts/sim-sts.js";
 import type { SimAwsAccountServiceCache } from "./sim-aws-account-service-cache.js";
 import type { SimAwsScopedServiceProperties } from "./sim-aws-scoped-service-properties.js";
@@ -57,6 +52,10 @@ interface SimAwsAccountRegionServiceBuilderProperties {
  * belongs to. This class is the half of that split holding the services whose
  * AWS state is scoped to an account/region pair, as SimAwsAccountServiceCache
  * is the half holding the services scoped to a whole account.
+ *
+ * A service whose wiring says nothing but which scope it is in belongs in
+ * SimAwsSelfContainedServiceBuilder instead, so what is left here is the
+ * services that reach for something outside their own scope.
  *
  * Nothing is cached here, which is the point of the split: a service in this
  * class is built fresh for the scope that asks for it, because on real AWS its
@@ -139,14 +138,19 @@ export class SimAwsAccountRegionServiceBuilder {
     });
   }
 
-  /** Create simulated DynamoDB for an Account Region scope. */
-  createDynamoDb(scope: SimAwsAccountRegionContainer): SimDynamoDatabase {
-    return new SimDynamoDatabase(this.scoped(scope));
-  }
-
-  /** Create simulated ECS for an Account Region scope. */
-  createEcs(scope: SimAwsAccountRegionContainer): SimEcs {
-    return new SimEcs(this.scoped(scope));
+  /**
+   * Create simulated ECR for an Account Region scope.
+   *
+   * Repositories are Region-scoped on real AWS: a repository ARN names the
+   * Region, and the registry host in an image URI carries the Account and the
+   * Region both. It is registered because a container image function holds
+   * nothing but that URI, and the function need not be in this scope.
+   */
+  createEcr(scope: SimAwsAccountRegionContainer): SimEcr {
+    return new SimEcr({
+      accountRegionScope: scope.accountRegionScope,
+      registry: this.registries.ecr,
+    });
   }
 
   /**
@@ -160,11 +164,6 @@ export class SimAwsAccountRegionServiceBuilder {
       ...this.scoped(scope),
       deliveryTargets: simAwsEventBridgeDeliveryTargets(this.simAws),
     });
-  }
-
-  /** Create simulated Elastic Load Balancing v2 for an Account Region scope. */
-  createElbV2(scope: SimAwsAccountRegionContainer): SimElbV2 {
-    return new SimElbV2(this.scoped(scope));
   }
 
   /**
@@ -188,6 +187,7 @@ export class SimAwsAccountRegionServiceBuilder {
         simAws: this.simAws,
         scope,
         urlRegistry: this.lambdaUrlRegistry,
+        registries: this.registries,
       }),
     });
   }
@@ -228,14 +228,6 @@ export class SimAwsAccountRegionServiceBuilder {
   }
 
   /**
-   * Create simulated Secrets Manager for an Account Region scope, whose secret
-   * values are encrypted through that same scope's simulated KMS.
-   */
-  createSecretsManager(scope: SimAwsAccountRegionContainer): SimSecretsManager {
-    return new SimSecretsManager({ ...this.scoped(scope), kms: scope.kms() });
-  }
-
-  /**
    * Create simulated SNS for an Account Region scope.
    *
    * Topics are Region-scoped on real AWS: a topic ARN names the Region. Where a
@@ -247,27 +239,6 @@ export class SimAwsAccountRegionServiceBuilder {
     const endpoints = new SimAwsSnsDeliveryEndpoints({ simAws: this.simAws });
 
     return new SimSns({ ...this.scoped(scope), deliveryEndpoints: endpoints });
-  }
-
-  /**
-   * Create simulated SQS for an Account Region scope.
-   *
-   * Queues are Region-scoped on real AWS: a queue URL and ARN both name the
-   * Region, and a queue cannot be reached from another one.
-   */
-  createSqs(scope: SimAwsAccountRegionContainer): SimSqs {
-    return new SimSqs(this.scoped(scope));
-  }
-
-  /**
-   * Create simulated SSM for an Account Region scope.
-   *
-   * Parameters are Region-scoped on real AWS: a parameter name is unique
-   * within one Account and Region, and its ARN names the Region. SecureString
-   * values are encrypted through that same scope's simulated KMS.
-   */
-  createSsm(scope: SimAwsAccountRegionContainer): SimSsm {
-    return new SimSsm({ ...this.scoped(scope), kms: scope.kms() });
   }
 
   /** Create simulated EventBridge Scheduler for an Account Region scope. */

--- a/src/service/aws/factory/sim-aws-lambda-collaborators.ts
+++ b/src/service/aws/factory/sim-aws-lambda-collaborators.ts
@@ -1,8 +1,10 @@
 import { SimDynamoDbEventSourceStreams } from "../../lambda/event-source/stream/sim-dynamodb-event-source-streams.js";
 import { SimSqsEventSourceQueues } from "../../lambda/event-source/queue/sim-sqs-event-source-queues.js";
+import { SimEcrLambdaContainerImages } from "../../lambda/function/code/image/sim-ecr-lambda-container-images.js";
 import { SimS3LambdaCodeStore } from "../../lambda/function/code/store/sim-s3-lambda-code-store.js";
 import { SimSdkLambdaVmModuleProvider } from "../../lambda/function/code/vm/sdk/sim-sdk-lambda-vm-module-provider.js";
 import type { SimLambdaUrlRegistry } from "../../lambda/registry/sim-lambda-url-registry.js";
+import type { SimAwsScopedServiceRegistries } from "./sim-aws-scoped-service-registries.js";
 import type { SimAwsAccountRegionContainer } from "../sim-aws-account-region-scope.js";
 import type { SimAws } from "../sim-aws.js";
 
@@ -10,6 +12,7 @@ interface SimAwsLambdaCollaboratorsProperties {
   readonly simAws: SimAws;
   readonly scope: SimAwsAccountRegionContainer;
   readonly urlRegistry: SimLambdaUrlRegistry;
+  readonly registries: SimAwsScopedServiceRegistries;
 }
 
 /**
@@ -19,6 +22,7 @@ interface SimAwsLambdaCollaborators {
   readonly runAsOwner: SimAws;
   readonly urlRegistry: SimLambdaUrlRegistry;
   readonly codeStore: SimS3LambdaCodeStore;
+  readonly containerImages: SimEcrLambdaContainerImages;
   readonly eventSourceQueues: SimSqsEventSourceQueues;
   readonly eventSourceStreams: SimDynamoDbEventSourceStreams;
   readonly vmSdkModuleProvider: SimSdkLambdaVmModuleProvider;
@@ -36,6 +40,10 @@ interface SimAwsLambdaCollaborators {
  * Event source mappings poll the same scope's simulated SQS and DynamoDB, as a
  * queue or a table's stream can only be an event source for a function in its
  * own Account and Region.
+ *
+ * A container image function's image is resolved in the whole simulation's ECR
+ * rather than this scope's, because an image URI names the Account and Region
+ * its registry is in, which need not be this one.
  */
 export function simAwsLambdaCollaborators(
   properties: SimAwsLambdaCollaboratorsProperties,
@@ -46,6 +54,9 @@ export function simAwsLambdaCollaborators(
     runAsOwner: simAws,
     urlRegistry: properties.urlRegistry,
     codeStore: new SimS3LambdaCodeStore({ s3: scope.s3() }),
+    containerImages: new SimEcrLambdaContainerImages({
+      repositories: properties.registries.ecr,
+    }),
     eventSourceQueues: new SimSqsEventSourceQueues({ sqs: scope.sqs() }),
     eventSourceStreams: new SimDynamoDbEventSourceStreams({
       dynamoDb: scope.dynamoDb(),

--- a/src/service/aws/factory/sim-aws-scoped-service-registries.ts
+++ b/src/service/aws/factory/sim-aws-scoped-service-registries.ts
@@ -1,6 +1,7 @@
 import { SimAcmRegistry } from "../../acm/registry/sim-acm-registry.js";
 import { SimCognitoDomainRegistry } from "../../cognito/registry/sim-cognito-domain-registry.js";
 import { SimCognitoUserPoolRegistry } from "../../cognito/registry/sim-cognito-user-pool-registry.js";
+import { SimEcrRegistry } from "../../ecr/registry/sim-ecr-registry.js";
 import { SimKmsRegistry } from "../../kms/registry/sim-kms-registry.js";
 import { SimRoute53Registry } from "../../route53/registry/sim-route53-registry.js";
 import { SimS3GlobalRegistry } from "../../s3/sim-s3-global-registry.js";
@@ -35,6 +36,13 @@ export class SimAwsScopedServiceRegistries {
    * where DNS resolution finds the pool a hosted request is for.
    */
   public readonly cognitoDomains = new SimCognitoDomainRegistry();
+
+  /**
+   * Indexes the repositories created in any Account and Region of one SimAws
+   * instance, so a container image function holding only an image URI finds
+   * the repository that URI names, whichever Account and Region it is in.
+   */
+  public readonly ecr = new SimEcrRegistry();
 
   /**
    * Indexes the account/region-scoped KMS facades created for one SimAws

--- a/src/service/aws/factory/sim-aws-self-contained-service-builder.ts
+++ b/src/service/aws/factory/sim-aws-self-contained-service-builder.ts
@@ -1,0 +1,89 @@
+import type { SimAwsAccountRegionContainer } from "../sim-aws-account-region-scope.js";
+import { SimDynamoDb as SimDynamoDatabase } from "../../dynamodb/index.js";
+import { SimEcs } from "../../ecs/index.js";
+import { SimElbV2 } from "../../elbv2/index.js";
+import { SimSecretsManager } from "../../secretsmanager/index.js";
+import { SimSqs } from "../../sqs/index.js";
+import { SimSsm } from "../../ssm/index.js";
+import type { SimAwsAccountServiceCache } from "./sim-aws-account-service-cache.js";
+import type { SimAwsScopedServiceProperties } from "./sim-aws-scoped-service-properties.js";
+
+interface SimAwsSelfContainedServiceBuilderProperties {
+  readonly accountServices: SimAwsAccountServiceCache;
+}
+
+/**
+ * Builder for the simulated services that reach nothing outside their own
+ * Account and Region.
+ *
+ * These are the services wired from the collaborators every scoped service
+ * gets, and at most from another service in the same scope: no simulation-wide
+ * registry, no delivery across Accounts, nothing that has to be resolved from
+ * somewhere else in the simulation. That is what makes them worth keeping
+ * apart from SimAwsAccountRegionServiceBuilder, where the wiring for a service
+ * is about what it reaches for.
+ *
+ * It is also what stops that file growing without end. Both grow by one method
+ * per simulated service, and a service belongs here when its build method says
+ * nothing but which scope it is in.
+ */
+export class SimAwsSelfContainedServiceBuilder {
+  private readonly accountServices: SimAwsAccountServiceCache;
+
+  constructor(properties: SimAwsSelfContainedServiceBuilderProperties) {
+    this.accountServices = properties.accountServices;
+  }
+
+  /** Create simulated DynamoDB for an Account Region scope. */
+  createDynamoDb(scope: SimAwsAccountRegionContainer): SimDynamoDatabase {
+    return new SimDynamoDatabase(this.scoped(scope));
+  }
+
+  /** Create simulated ECS for an Account Region scope. */
+  createEcs(scope: SimAwsAccountRegionContainer): SimEcs {
+    return new SimEcs(this.scoped(scope));
+  }
+
+  /** Create simulated Elastic Load Balancing v2 for an Account Region scope. */
+  createElbV2(scope: SimAwsAccountRegionContainer): SimElbV2 {
+    return new SimElbV2(this.scoped(scope));
+  }
+
+  /**
+   * Create simulated Secrets Manager for an Account Region scope, whose secret
+   * values are encrypted through that same scope's simulated KMS.
+   */
+  createSecretsManager(scope: SimAwsAccountRegionContainer): SimSecretsManager {
+    return new SimSecretsManager({ ...this.scoped(scope), kms: scope.kms() });
+  }
+
+  /**
+   * Create simulated SQS for an Account Region scope.
+   *
+   * Queues are Region-scoped on real AWS: a queue URL and ARN both name the
+   * Region, and a queue cannot be reached from another one.
+   */
+  createSqs(scope: SimAwsAccountRegionContainer): SimSqs {
+    return new SimSqs(this.scoped(scope));
+  }
+
+  /**
+   * Create simulated SSM for an Account Region scope.
+   *
+   * Parameters are Region-scoped on real AWS: a parameter name is unique
+   * within one Account and Region, and its ARN names the Region. SecureString
+   * values are encrypted through that same scope's simulated KMS.
+   */
+  createSsm(scope: SimAwsAccountRegionContainer): SimSsm {
+    return new SimSsm({ ...this.scoped(scope), kms: scope.kms() });
+  }
+
+  /**
+   * The collaborators every service built here takes.
+   */
+  private scoped(
+    scope: SimAwsAccountRegionContainer,
+  ): SimAwsScopedServiceProperties {
+    return this.accountServices.scopedServiceProperties(scope);
+  }
+}

--- a/src/service/aws/factory/sim-aws-service-factory.ts
+++ b/src/service/aws/factory/sim-aws-service-factory.ts
@@ -12,6 +12,7 @@ import type { SimCognitoIdentityProvider } from "../../cognito/index.js";
 import { SimCloudFrontRegistry } from "../../cloudfront/registry/sim-cloud-front-registry.js";
 import type { SimCloudFront } from "../../cloudfront/sim-cloudfront.js";
 import type { SimDynamoDb as SimDynamoDatabase } from "../../dynamodb/index.js";
+import type { SimEcr } from "../../ecr/index.js";
 import type { SimEcs } from "../../ecs/index.js";
 import type { SimRekognition } from "../../rekognition/index.js";
 import type { SimRoute53 } from "../../route53/index.js";
@@ -30,6 +31,7 @@ import type { SimSqs } from "../../sqs/index.js";
 import type { SimSsm } from "../../ssm/index.js";
 import type { SimSts } from "../../sts/sim-sts.js";
 import { SimAwsAccountRegionServiceBuilder } from "./sim-aws-account-region-service-builder.js";
+import { SimAwsSelfContainedServiceBuilder } from "./sim-aws-self-contained-service-builder.js";
 import { SimAwsAccountServiceCache } from "./sim-aws-account-service-cache.js";
 import { SimAwsRequestAuthWiring } from "./sim-aws-request-auth-wiring.js";
 import { SimAwsScopedServiceRegistries } from "./sim-aws-scoped-service-registries.js";
@@ -108,6 +110,7 @@ export class SimAwsServiceFactory {
 
   private readonly accountServices: SimAwsAccountServiceCache;
   private readonly accountRegionServices: SimAwsAccountRegionServiceBuilder;
+  private readonly selfContainedServices: SimAwsSelfContainedServiceBuilder;
 
   constructor(properties: SimAwsServiceFactoryProperties) {
     this.accountServices = new SimAwsAccountServiceCache({
@@ -130,6 +133,9 @@ export class SimAwsServiceFactory {
       iamRegistry: this.iamRegistry,
       lambdaUrlRegistry: this.lambdaUrlRegistry,
       httpApiRegistry: this.httpApiRegistry,
+      accountServices: this.accountServices,
+    });
+    this.selfContainedServices = new SimAwsSelfContainedServiceBuilder({
       accountServices: this.accountServices,
     });
   }
@@ -163,12 +169,17 @@ export class SimAwsServiceFactory {
 
   /** Create simulated DynamoDB for an Account Region scope. */
   createDynamoDb(scope: SimAwsAccountRegionContainer): SimDynamoDatabase {
-    return this.accountRegionServices.createDynamoDb(scope);
+    return this.selfContainedServices.createDynamoDb(scope);
+  }
+
+  /** Create simulated ECR for an Account Region scope. */
+  createEcr(scope: SimAwsAccountRegionContainer): SimEcr {
+    return this.accountRegionServices.createEcr(scope);
   }
 
   /** Create simulated ECS for an Account Region scope. */
   createEcs(scope: SimAwsAccountRegionContainer): SimEcs {
-    return this.accountRegionServices.createEcs(scope);
+    return this.selfContainedServices.createEcs(scope);
   }
 
   /** Create simulated EventBridge for an Account Region scope. */
@@ -178,7 +189,7 @@ export class SimAwsServiceFactory {
 
   /** Create simulated Elastic Load Balancing v2 for an Account Region scope. */
   createElbV2(scope: SimAwsAccountRegionContainer): SimElbV2 {
-    return this.accountRegionServices.createElbV2(scope);
+    return this.selfContainedServices.createElbV2(scope);
   }
 
   /** Create or get simulated IAM for an Account scope. */
@@ -213,7 +224,7 @@ export class SimAwsServiceFactory {
 
   /** Create simulated Secrets Manager for an Account Region scope. */
   createSecretsManager(scope: SimAwsAccountRegionContainer): SimSecretsManager {
-    return this.accountRegionServices.createSecretsManager(scope);
+    return this.selfContainedServices.createSecretsManager(scope);
   }
 
   /** Create simulated EventBridge Scheduler for an Account Region scope. */
@@ -228,12 +239,12 @@ export class SimAwsServiceFactory {
 
   /** Create simulated SQS for an Account Region scope. */
   createSqs(scope: SimAwsAccountRegionContainer): SimSqs {
-    return this.accountRegionServices.createSqs(scope);
+    return this.selfContainedServices.createSqs(scope);
   }
 
   /** Create simulated SSM for an Account Region scope. */
   createSsm(scope: SimAwsAccountRegionContainer): SimSsm {
-    return this.accountRegionServices.createSsm(scope);
+    return this.selfContainedServices.createSsm(scope);
   }
 
   /** Create simulated STS for an Account/Region scope. */

--- a/src/service/aws/sim-aws-account-region-scope.ts
+++ b/src/service/aws/sim-aws-account-region-scope.ts
@@ -12,6 +12,7 @@ import type {
   SimDynamoDbStreams,
 } from "../dynamodb/index.js";
 import type { SimCloudFormation } from "../cloudformation/index.js";
+import type { SimEcr } from "../ecr/index.js";
 import type { SimEcs } from "../ecs/index.js";
 import type { SimEventBridge } from "../eventbridge/index.js";
 import type { SimCognitoIdentityProvider } from "../cognito/index.js";
@@ -66,34 +67,26 @@ export class SimAwsAccountRegionContainer {
     };
   }
 
-  /**
-   * Get simulated ACM for this account and region.
-   */
+  /** Get simulated ACM for this account and region. */
   acm(): SimAcm {
     return this.memo.getOrCreate("acm", () => this.factory.createAcm(this));
   }
 
-  /**
-   * Get simulated API Gateway v2 for this account and region.
-   */
+  /** Get simulated API Gateway v2 for this account and region. */
   apiGatewayV2(): SimApiGatewayV2 {
     return this.memo.getOrCreate("apiGatewayV2", () =>
       this.factory.createApiGatewayV2(this),
     );
   }
 
-  /**
-   * Get simulated CloudFormation for this account and region.
-   */
+  /** Get simulated CloudFormation for this account and region. */
   cloudFormation(): SimCloudFormation {
     return this.memo.getOrCreate("cloudFormation", () =>
       this.factory.createCloudFormation(this),
     );
   }
 
-  /**
-   * Get simulated CloudFront for this account.
-   */
+  /** Get simulated CloudFront for this account. */
   cloudFront(): SimCloudFront {
     return this.memo.getOrCreate("cloudFront", () =>
       this.factory.createCloudFront(this),
@@ -111,18 +104,14 @@ export class SimAwsAccountRegionContainer {
     return this.cloudFront().keyValueStoreApi();
   }
 
-  /**
-   * Get simulated Cognito user pools for this account and region.
-   */
+  /** Get simulated Cognito user pools for this account and region. */
   cognitoIdentityProvider(): SimCognitoIdentityProvider {
     return this.memo.getOrCreate("cognitoIdentityProvider", () =>
       this.factory.createCognitoIdentityProvider(this),
     );
   }
 
-  /**
-   * Get simulated DynamoDB for this account and region.
-   */
+  /** Get simulated DynamoDB for this account and region. */
   dynamoDb(): SimDynamoDatabase {
     return this.memo.getOrCreate("dynamoDb", () =>
       this.factory.createDynamoDb(this),
@@ -140,119 +129,94 @@ export class SimAwsAccountRegionContainer {
     return this.dynamoDb().streams();
   }
 
-  /**
-   * Get simulated ECS for this account and region.
-   */
+  /** Get simulated ECR for this account and region. */
+  ecr(): SimEcr {
+    return this.memo.getOrCreate("ecr", () => this.factory.createEcr(this));
+  }
+
+  /** Get simulated ECS for this account and region. */
   ecs(): SimEcs {
     return this.memo.getOrCreate("ecs", () => this.factory.createEcs(this));
   }
 
-  /**
-   * Get simulated EventBridge for this account and region.
-   */
+  /** Get simulated EventBridge for this account and region. */
   eventBridge(): SimEventBridge {
     return this.memo.getOrCreate("eventBridge", () =>
       this.factory.createEventBridge(this),
     );
   }
 
-  /**
-   * Get simulated EventBridge Scheduler for this account and region.
-   */
+  /** Get simulated EventBridge Scheduler for this account and region. */
   scheduler(): SimScheduler {
     return this.memo.getOrCreate("scheduler", () =>
       this.factory.createScheduler(this),
     );
   }
 
-  /**
-   * Get simulated Elastic Load Balancing v2 for this account and region.
-   */
+  /** Get simulated Elastic Load Balancing v2 for this account and region. */
   elbV2(): SimElbV2 {
     return this.memo.getOrCreate("elbV2", () => this.factory.createElbV2(this));
   }
 
-  /**
-   * Get simulated IAM for this account.
-   */
+  /** Get simulated IAM for this account. */
   iam(): SimIam {
     return this.memo.getOrCreate("iam", () => this.factory.createIam(this));
   }
 
-  /**
-   * Get simulated KMS for this account and region.
-   */
+  /** Get simulated KMS for this account and region. */
   kms(): SimKms {
     return this.memo.getOrCreate("kms", () => this.factory.createKms(this));
   }
 
-  /**
-   * Get simulated Lambda for this account and region.
-   */
+  /** Get simulated Lambda for this account and region. */
   lambda(): SimLambda {
     return this.memo.getOrCreate("lambda", () =>
       this.factory.createLambda(this),
     );
   }
 
-  /**
-   * Get simulated Rekognition for this account and region.
-   */
+  /** Get simulated Rekognition for this account and region. */
   rekognition(): SimRekognition {
     return this.memo.getOrCreate("rekognition", () =>
       this.factory.createRekognition(this),
     );
   }
 
-  /**
-   * Get simulated Route53 for this account.
-   */
+  /** Get simulated Route53 for this account. */
   route53(): SimRoute53 {
     return this.memo.getOrCreate("route53", () =>
       this.factory.createRoute53(this),
     );
   }
 
-  /**
-   * Get simulated S3 for this account and region.
-   */
+  /** Get simulated S3 for this account and region. */
   s3(): SimS3 {
     return this.memo.getOrCreate("s3", () => this.factory.createS3(this));
   }
 
-  /**
-   * Get simulated Secrets Manager for this account and region.
-   */
+  /** Get simulated Secrets Manager for this account and region. */
   secretsManager(): SimSecretsManager {
     return this.memo.getOrCreate("secretsManager", () =>
       this.factory.createSecretsManager(this),
     );
   }
 
-  /**
-   * Get simulated SNS for this account and region.
-   */
+  /** Get simulated SNS for this account and region. */
   sns(): SimSns {
     return this.memo.getOrCreate("sns", () => this.factory.createSns(this));
   }
 
-  /**
-   * Get simulated SQS for this account and region.
-   */
+  /** Get simulated SQS for this account and region. */
   sqs(): SimSqs {
     return this.memo.getOrCreate("sqs", () => this.factory.createSqs(this));
   }
 
-  /**
-   * Get simulated SSM for this account and region.
-   */
+  /** Get simulated SSM for this account and region. */
   ssm(): SimSsm {
     return this.memo.getOrCreate("ssm", () => this.factory.createSsm(this));
   }
 
-  /**
-   * Get simulated STS for this account and region.
-   */
+  /** Get simulated STS for this account and region. */
   sts(): SimSts {
     return this.memo.getOrCreate("sts", () => this.factory.createSts(this));
   }

--- a/src/service/aws/sim-aws-service-accessors.ts
+++ b/src/service/aws/sim-aws-service-accessors.ts
@@ -9,6 +9,7 @@ import type {
   SimDynamoDb as SimDynamoDatabase,
   SimDynamoDbStreams,
 } from "../dynamodb/index.js";
+import type { SimEcr } from "../ecr/index.js";
 import type { SimEcs } from "../ecs/index.js";
 import type { SimElbV2 } from "../elbv2/index.js";
 import type { SimIam } from "../iam/index.js";
@@ -79,6 +80,11 @@ export abstract class SimAwsServiceAccessors {
   /** Get simulated DynamoDB Streams in the default Account Region scope. */
   dynamoDbStreams(): SimDynamoDbStreams {
     return this.defaultAccountRegionScope().dynamoDbStreams();
+  }
+
+  /** Get simulated ECR in the default Account Region scope. */
+  ecr(): SimEcr {
+    return this.defaultAccountRegionScope().ecr();
   }
 
   /** Get simulated ECS in the default Account Region scope. */

--- a/src/service/cloudformation/bind/validate/sim-cfn-image-repository-target.ts
+++ b/src/service/cloudformation/bind/validate/sim-cfn-image-repository-target.ts
@@ -23,6 +23,17 @@ export class SimCfnImageRepositoryTarget {
   }
 
   /**
+   * The repository this target names, with any tag or digest removed and read
+   * the same way both sides of a match are.
+   *
+   * A simulated ECR repository is indexed by this, so one reading of an image
+   * reference serves both binding matches and repository lookups.
+   */
+  repositoryReference(): string {
+    return this.repository;
+  }
+
+  /**
    * Whether a function's image URI names this repository.
    */
   matchesImageUri(imageUri: string | undefined): boolean {

--- a/src/service/cloudformation/resource/cfn/ecr/sim-ecr-cfn-value-adapter.iso.test.ts
+++ b/src/service/cloudformation/resource/cfn/ecr/sim-ecr-cfn-value-adapter.iso.test.ts
@@ -1,0 +1,84 @@
+import {
+  assertIdentical,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../../aws/sim-aws.js";
+import { ecrValueAdapter } from "./sim-ecr-cfn-value-adapter.js";
+
+describe("ECR CloudFormation value adapter", () => {
+  it("refuses an attribute an ECR repository does not answer", async () => {
+    // Given a template reading an attribute AWS::ECR::Repository has no
+    // value for here.
+    const simAws = new SimAws();
+
+    // When it is deployed.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.cloudFormation().deployTemplate({
+        stackName: "platform-stack",
+        template: {
+          Resources: {
+            OrdersRepository: {
+              Type: "AWS::ECR::Repository",
+              Properties: { RepositoryName: "orders" },
+            },
+            OrdersQueue: {
+              Type: "AWS::SQS::Queue",
+              Properties: {
+                QueueName: {
+                  "Fn::GetAtt": ["OrdersRepository", "RegistryId"],
+                },
+              },
+            },
+          },
+        },
+      }),
+    );
+
+    // Then the attribute is named in the refusal.
+    assertStringIncludes(
+      error.message,
+      "Unsupported AWS::ECR::Repository attribute RegistryId",
+    );
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("claims nothing but an ECR repository", () => {
+    // Given a Resource of another service, and an ECR Resource type with no
+    // simulated repository behind it.
+    // When the ECR adapter is offered each of them.
+    // Then it claims neither, so they fall through to the adapter that owns
+    // them, or to the default one.
+    assertUndefined(
+      ecrValueAdapter({
+        logicalId: "OrdersQueue",
+        type: "AWS::SQS::Queue",
+        simResource: undefined,
+      }),
+    );
+    assertUndefined(
+      ecrValueAdapter({
+        logicalId: "OrdersRepository",
+        type: "AWS::ECR::Repository",
+        simResource: undefined,
+      }),
+    );
+  });
+
+  it("answers Ref with the repository name", () => {
+    // Given the adapter over a simulated repository.
+    const repository = new SimAws().ecr().repository("orders");
+    const adapter = ecrValueAdapter({
+      logicalId: "OrdersRepository",
+      type: "AWS::ECR::Repository",
+      simResource: repository,
+    });
+
+    // Then a Ref reads as the name, as it does on real CloudFormation.
+    assertIdentical(adapter?.refValue(), "orders");
+  });
+});

--- a/src/service/cloudformation/resource/cfn/ecr/sim-ecr-cfn-value-adapter.ts
+++ b/src/service/cloudformation/resource/cfn/ecr/sim-ecr-cfn-value-adapter.ts
@@ -1,0 +1,22 @@
+import { SimEcrRepository } from "../../../../ecr/repository/sim-ecr-repository.js";
+import type {
+  SimCfnResourceValueAdapterProperties,
+  SimCfnServiceValueAdapter,
+} from "../sim-cfn-resource-value-adapter.js";
+import { SimEcrRepositoryCfn } from "./sim-ecr-repository-cfn.js";
+
+/**
+ * The CloudFormation-facing value adapter for a simulated ECR Resource.
+ */
+export function ecrValueAdapter(
+  properties: SimCfnResourceValueAdapterProperties,
+): SimCfnServiceValueAdapter {
+  if (
+    properties.type === "AWS::ECR::Repository" &&
+    properties.simResource instanceof SimEcrRepository
+  ) {
+    return new SimEcrRepositoryCfn({ repository: properties.simResource });
+  }
+
+  return undefined;
+}

--- a/src/service/cloudformation/resource/cfn/ecr/sim-ecr-repository-cfn.ts
+++ b/src/service/cloudformation/resource/cfn/ecr/sim-ecr-repository-cfn.ts
@@ -1,0 +1,48 @@
+import type { SimEcrRepository } from "../../../../ecr/repository/sim-ecr-repository.js";
+import type { SimCfnTemplateValue } from "../../../template/value/sim-cfn-template-value.js";
+import type { SimCfnResourceValueAdapter } from "../sim-cfn-resource-value-adapter.js";
+
+interface SimEcrRepositoryCfnProperties {
+  readonly repository: SimEcrRepository;
+}
+
+/**
+ * CloudFormation-facing values for a simulated ECR repository.
+ */
+export class SimEcrRepositoryCfn implements SimCfnResourceValueAdapter {
+  private readonly repository: SimEcrRepository;
+
+  constructor(properties: SimEcrRepositoryCfnProperties) {
+    this.repository = properties.repository;
+  }
+
+  /**
+   * AWS::ECR::Repository Ref returns the repository name.
+   */
+  refValue(): SimCfnTemplateValue {
+    return this.repository.repositoryName;
+  }
+
+  /**
+   * AWS::ECR::Repository attributes.
+   *
+   * The ARN is what an IAM policy names the repository by, and the URI is what
+   * a function's `Code.ImageUri` is built from, which is how a template says
+   * which repository a function's image comes from.
+   */
+  attributeValue(attributeName: string): SimCfnTemplateValue {
+    switch (attributeName) {
+      case "Arn": {
+        return this.repository.repositoryArn;
+      }
+      case "RepositoryUri": {
+        return this.repository.repositoryUri;
+      }
+      default: {
+        throw new Error(
+          `Unsupported AWS::ECR::Repository attribute ${attributeName}`,
+        );
+      }
+    }
+  }
+}

--- a/src/service/cloudformation/resource/cfn/sim-cfn-resource-value-adapter.ts
+++ b/src/service/cloudformation/resource/cfn/sim-cfn-resource-value-adapter.ts
@@ -4,6 +4,7 @@ import { apiGatewayV2ValueAdapter } from "./apigatewayv2/sim-api-gateway-v2-cfn-
 import { cloudFrontValueAdapter } from "./cloudfront/sim-cloudfront-cfn-value-adapter.js";
 import { cognitoValueAdapter } from "./cognito/sim-cognito-cfn-value-adapter.js";
 import { dynamoDbValueAdapter } from "./dynamodb/sim-dynamodb-cfn-value-adapter.js";
+import { ecrValueAdapter } from "./ecr/sim-ecr-cfn-value-adapter.js";
 import { eventBridgeValueAdapter } from "./events/sim-event-bridge-cfn-value-adapter.js";
 import { iamValueAdapter } from "./iam/sim-iam-cfn-value-adapter.js";
 import { kmsValueAdapter } from "./kms/sim-kms-cfn-value-adapter.js";
@@ -56,6 +57,7 @@ export function simCfnResourceValueAdapter(
     cloudFrontValueAdapter(properties) ??
     cognitoValueAdapter(properties) ??
     dynamoDbValueAdapter(properties) ??
+    ecrValueAdapter(properties) ??
     eventBridgeValueAdapter(properties) ??
     iamValueAdapter(properties) ??
     kmsValueAdapter(properties) ??

--- a/src/service/cloudformation/resource/resolve/service/sim-cfn-service-factories.ts
+++ b/src/service/cloudformation/resource/resolve/service/sim-cfn-service-factories.ts
@@ -60,6 +60,11 @@ export const simCfnServiceResourceFactories: ReadonlyMap<
       scopedAws.dynamoDb().cfnResourceFactory(),
   ],
   [
+    "ECR",
+    (scopedAws): SimCfnServiceResourceFactory =>
+      scopedAws.ecr().cfnResourceFactory(),
+  ],
+  [
     "IAM",
     (scopedAws): SimCfnServiceResourceFactory =>
       scopedAws.iam().cfnResourceFactory(),

--- a/src/service/ecr/README.md
+++ b/src/service/ecr/README.md
@@ -50,11 +50,15 @@ match.
 handler function is the only thing this simulator can run, and a duplicate structural type would
 only have to be kept in step with it.
 
-A repository resolves a reference to a tag it holds with exactly that image, and any other tag, or
-none, with the image registered most recently. Resolution ignoring the tag is the same decision
-deploy-time image bindings made: no tag is stable enough to write into a test, since a CDK image
-asset is tagged with a content hash and a pipeline-built image with a build number. Honouring a tag
-it does hold is what makes registering two of them mean anything.
+Finding a repository ignores the tag, which is the same decision deploy-time image bindings made: no
+tag is stable enough to write into a test, since a CDK image asset is tagged with a content hash and
+a pipeline-built image with a build number. Choosing an image within that repository does read it: a
+tag the repository holds answers with exactly that image, and any other tag, or none, with the image
+registered most recently. Honouring a tag it does hold is what makes registering two of them mean
+anything.
+
+Registering a tag again takes it out of the map before putting it back, so the replacement counts as
+the most recent registration rather than keeping the position the tag first went in at.
 
 ## Resolving an image URI
 
@@ -82,3 +86,9 @@ image is pushed by whatever built it, long before the stack that runs it.
 `SimCfnEcrRepositoryPropertyRules` records every other property as ignored. All of them describe
 image content, so a repository created without them is still a repository that does what one does
 here.
+
+A teardown removes a repository holding no simulated image, and records the deletion of one that
+holds an image rather than carrying it out. The handler in it was registered outside any stack, and
+it is what every later deploy resolves to, so taking it down with one stack would leave the next one
+resolving nothing. Real ECR refuses that deletion as well, which fails the stack unless the template
+says `EmptyOnDelete`; recording it keeps a teardown from failing over a test's own registration.

--- a/src/service/ecr/README.md
+++ b/src/service/ecr/README.md
@@ -1,0 +1,84 @@
+# Simulated ECR implementation
+
+This directory contains the simulated ECR service implementation.
+
+There is very little here, and that is the point. ECR holds repositories, a repository holds images
+by tag, and a simulated image is a real in-process handler. Everything else about a real registry is
+image content, which Yulin never reads.
+
+## Why there are no SDK commands
+
+Every other simulated service here handles SDK commands. This one handles none, because the
+operation that matters has no SDK equivalent worth simulating.
+
+Real `PutImage` takes an image manifest describing layers that were already pushed over the Docker
+registry protocol. None of that exists in this process: there are no layers, no digests and no
+Docker. So registering a handler as an image is a Yulin-native operation, `simulateImage`, named so
+it cannot be mistaken for a simulated `PutImage`. `DescribeImages` and the rest would answer with
+made-up manifest data for the same reason, so they are absent rather than wrong.
+
+What is left is state and lookup, which is why there is no `command/` directory, no authorizer and
+no SDK router.
+
+## Entry points
+
+- `sim-ecr.ts` is the main in-memory service object for one account/region scope.
+- `index.ts` exports the public ECR simulator API for `@kensio/yulin/ecr`.
+
+## Repository model
+
+Repository state lives under `repository/`.
+
+`SimEcrRepositoryStore` makes a repository the first time it is named, because a repository here
+holds nothing of its own beyond its images: there is no setting on one this simulation acts on, so
+there is nothing a creation could have got wrong. That is also what lets a test register a handler
+in a repository before any stack declaring it is deployed, and what makes an `AWS::ECR::Repository`
+Resource adopt that repository rather than replace it.
+
+`SimEcrRepositoryAddress` builds the two forms AWS names a repository by, from the account and
+region the service is scoped to: the registry host form a Lambda `Code.ImageUri` carries, and the
+ARN form an IAM policy and `Fn::GetAtt` carry.
+
+`requiredSimEcrRepositoryName` refuses a name real ECR would refuse. It reads the name by splitting
+on its separators rather than with the single expression AWS documents, because that expression
+nests three quantifiers, which is the shape a name can be written to make take exponential time to
+match.
+
+## Image model
+
+`SimEcrImage` is a tag and a handler. `SimEcrImageHandler` is the sim Lambda handler type, since a
+handler function is the only thing this simulator can run, and a duplicate structural type would
+only have to be kept in step with it.
+
+A repository resolves a reference to a tag it holds with exactly that image, and any other tag, or
+none, with the image registered most recently. Resolution ignoring the tag is the same decision
+deploy-time image bindings made: no tag is stable enough to write into a test, since a CDK image
+asset is tagged with a content hash and a pipeline-built image with a build number. Honouring a tag
+it does hold is what makes registering two of them mean anything.
+
+## Resolving an image URI
+
+`SimEcrImageReference` reads a container image reference as the repository it names and the tag it
+asks for. The repository half is read by `SimCfnImageRepositoryTarget`, which deploy-time image
+bindings already match on, so an image URI is understood one way wherever it arrives from.
+
+`SimEcrRegistry` indexes repositories across the whole simulation, by that repository reference
+rather than by name. A Lambda function holds nothing but an image URI, and the registry host in that
+URI carries the account and the region, so a function in one account can run an image from another
+account's registry, as it can on real AWS. This follows `SimAcmRegistry`, which is how a service
+holding only a certificate ARN reaches the certificate.
+
+Simulated Lambda is the one thing that reads it, through `SimEcrLambdaContainerImages` on the Lambda
+side. That adapter reports finding no repository apart from finding a repository with no image,
+because the two send a reader to different places: a name that is wrong, or a handler that was never
+registered.
+
+## CloudFormation
+
+`cfn/` owns `AWS::ECR::Repository`, which is the only ECR Resource type that means anything here. A
+template declares a repository and never an image, which is what real CloudFormation does too: an
+image is pushed by whatever built it, long before the stack that runs it.
+
+`SimCfnEcrRepositoryPropertyRules` records every other property as ignored. All of them describe
+image content, so a repository created without them is still a repository that does what one does
+here.

--- a/src/service/ecr/cfn/repository/sim-cfn-ecr-repository-creator.ts
+++ b/src/service/ecr/cfn/repository/sim-cfn-ecr-repository-creator.ts
@@ -45,13 +45,29 @@ export class SimCfnEcrRepositoryCreator {
   /**
    * Delete a repository created from an AWS::ECR::Repository Resource.
    *
-   * The simulated images go with it. They are handlers a test registered
-   * rather than artifacts a pipeline pushed, so there is nothing here for the
-   * refusal real ECR makes over a repository that still holds images to
-   * protect, and a teardown that could not remove a repository would leave a
-   * later deploy of the same template adopting the old one.
+   * A repository holding a simulated image is left where it is, and the
+   * deletion is recorded as skipped. The image is a handler registered outside
+   * any stack, usually in test setup, and it is the whole reason the
+   * repository is the place to say what an image is: it outlives the stack
+   * that declared it. Taking it down with one stack would leave the next
+   * deploy resolving nothing.
+   *
+   * Real ECR refuses to delete a repository that still holds images too,
+   * which fails the stack unless the template says `EmptyOnDelete`. This
+   * records the refusal rather than failing the teardown, because what is
+   * being protected here is a test's own registration rather than anything
+   * CloudFormation put there.
    */
-  delete(repository: SimEcrRepository): void {
+  delete(resource: SimCfnResource, repository: SimEcrRepository): void {
+    if (repository.hasImage) {
+      throw new Error(
+        `Unsupported sim ECR CloudFormation Resource ${resource.logicalId} ` +
+          `deletion: the simulated ECR repository ` +
+          `${repository.repositoryName} holds a simulated image, which ` +
+          `outlives the Stack that declared the repository`,
+      );
+    }
+
     this.ecr.deleteRepository(repository.repositoryName);
   }
 }

--- a/src/service/ecr/cfn/repository/sim-cfn-ecr-repository-creator.ts
+++ b/src/service/ecr/cfn/repository/sim-cfn-ecr-repository-creator.ts
@@ -1,0 +1,57 @@
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimEcrRepository } from "../../repository/sim-ecr-repository.js";
+import type { SimEcr } from "../../sim-ecr.js";
+import { SimCfnEcrRepositoryProperties } from "./sim-cfn-ecr-repository-properties.js";
+
+interface SimCfnEcrRepositoryCreatorProperties {
+  readonly ecr: SimEcr;
+}
+
+/**
+ * Creates simulated repositories from AWS::ECR::Repository Resources.
+ *
+ * A template declares a repository and never an image, which is what real
+ * CloudFormation does too: an image is pushed by whatever built it, long
+ * before any stack that runs it is deployed. So a deployed repository starts
+ * empty unless a test has already registered a handler as its image, and it
+ * keeps that handler if it has, since the repository outlives the stack.
+ */
+export class SimCfnEcrRepositoryCreator {
+  private readonly ecr: SimEcr;
+
+  constructor(properties: SimCfnEcrRepositoryCreatorProperties) {
+    this.ecr = properties.ecr;
+  }
+
+  /**
+   * Create a repository from an AWS::ECR::Repository Resource.
+   */
+  create(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): SimEcrRepository {
+    const repositoryProperties = new SimCfnEcrRepositoryProperties({
+      resource,
+      properties,
+    });
+    const repositoryName = repositoryProperties.repositoryName();
+
+    repositoryProperties.recordIgnoredProperties();
+
+    return this.ecr.repository(repositoryName);
+  }
+
+  /**
+   * Delete a repository created from an AWS::ECR::Repository Resource.
+   *
+   * The simulated images go with it. They are handlers a test registered
+   * rather than artifacts a pipeline pushed, so there is nothing here for the
+   * refusal real ECR makes over a repository that still holds images to
+   * protect, and a teardown that could not remove a repository would leave a
+   * later deploy of the same template adopting the old one.
+   */
+  delete(repository: SimEcrRepository): void {
+    this.ecr.deleteRepository(repository.repositoryName);
+  }
+}

--- a/src/service/ecr/cfn/repository/sim-cfn-ecr-repository-name.ts
+++ b/src/service/ecr/cfn/repository/sim-cfn-ecr-repository-name.ts
@@ -1,0 +1,35 @@
+import { SimCfnGeneratedResourceName } from "../../../cloudformation/resource/name/sim-cfn-generated-resource-name.js";
+
+const maximumNameLength = 256;
+
+interface SimCfnEcrRepositoryNameProperties {
+  readonly stackName: string | undefined;
+  readonly logicalId: string;
+}
+
+/**
+ * The name CloudFormation gives a repository whose template does not name it.
+ *
+ * A repository name is at most 256 characters, so a long stack name and
+ * logical ID together are trimmed to fit, the same way every other service's
+ * generated name is. It is lower cased because ECR repository names are, and a
+ * logical ID is usually not.
+ */
+export class SimCfnEcrRepositoryName {
+  private readonly generated: SimCfnGeneratedResourceName;
+
+  constructor(properties: SimCfnEcrRepositoryNameProperties) {
+    this.generated = new SimCfnGeneratedResourceName({
+      stackName: properties.stackName,
+      logicalId: properties.logicalId,
+      maximumLength: maximumNameLength,
+    });
+  }
+
+  /**
+   * The generated repository name.
+   */
+  get value(): string {
+    return this.generated.value.toLowerCase();
+  }
+}

--- a/src/service/ecr/cfn/repository/sim-cfn-ecr-repository-properties.ts
+++ b/src/service/ecr/cfn/repository/sim-cfn-ecr-repository-properties.ts
@@ -1,0 +1,76 @@
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import { SimCfnEcrRepositoryName } from "./sim-cfn-ecr-repository-name.js";
+import { SimCfnEcrRepositoryPropertyRules } from "./sim-cfn-ecr-repository-property-rules.js";
+
+/**
+ * A refusal naming the Resource whose properties could not be read.
+ */
+export function ecrRepositoryPropertyError(
+  logicalId: string,
+  reason: string,
+): Error {
+  return new Error(
+    `Invalid sim ECR CloudFormation Resource ${logicalId}: ${reason}`,
+  );
+}
+
+interface SimCfnEcrRepositoryPropertiesProperties {
+  readonly resource: SimCfnResource;
+  readonly properties: SimCfnTemplateValueRecord;
+}
+
+/**
+ * Reads AWS::ECR::Repository CloudFormation properties.
+ *
+ * A repository declares only a name that this simulation acts on. Everything
+ * else a template can put on one describes image content, which nothing here
+ * reads, so it is recorded as ignored by the property rules.
+ */
+export class SimCfnEcrRepositoryProperties {
+  private readonly resource: SimCfnResource;
+  private readonly properties: SimCfnTemplateValueRecord;
+  private readonly rules: SimCfnEcrRepositoryPropertyRules;
+
+  constructor(properties: SimCfnEcrRepositoryPropertiesProperties) {
+    this.resource = properties.resource;
+    this.properties = properties.properties;
+    this.rules = new SimCfnEcrRepositoryPropertyRules({
+      properties: properties.properties,
+      ignorer: properties.resource,
+    });
+  }
+
+  /**
+   * The repository name.
+   *
+   * An unnamed repository is named after the stack and the logical ID, as real
+   * CloudFormation names one.
+   */
+  repositoryName(): string {
+    const name = this.properties["RepositoryName"];
+
+    if (name === undefined) {
+      return new SimCfnEcrRepositoryName({
+        stackName: this.resource.stackName,
+        logicalId: this.resource.logicalId,
+      }).value;
+    }
+
+    if (typeof name !== "string") {
+      throw ecrRepositoryPropertyError(
+        this.resource.logicalId,
+        "RepositoryName must be a string",
+      );
+    }
+
+    return name;
+  }
+
+  /**
+   * Record the properties the repository is created without acting on.
+   */
+  recordIgnoredProperties(): void {
+    this.rules.apply();
+  }
+}

--- a/src/service/ecr/cfn/repository/sim-cfn-ecr-repository-property-rules.ts
+++ b/src/service/ecr/cfn/repository/sim-cfn-ecr-repository-property-rules.ts
@@ -1,0 +1,58 @@
+import type { SimCfnPropertyIgnorer } from "../../../cloudformation/resource/ignore/sim-cfn-ignored-property.type.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import { unsimulatedPropertyReasons } from "./sim-cfn-ecr-repository-unsimulated-properties.js";
+
+interface SimCfnEcrRepositoryPropertyRulesProperties {
+  readonly properties: SimCfnTemplateValueRecord;
+  readonly ignorer: SimCfnPropertyIgnorer;
+}
+
+/**
+ * What a repository Resource is created without acting on.
+ *
+ * RepositoryName is the only property this simulation reads. Everything else,
+ * whether ECR has it or not, is recorded so a reader can see what a deployed
+ * repository is not doing.
+ */
+export class SimCfnEcrRepositoryPropertyRules {
+  private readonly properties: SimCfnTemplateValueRecord;
+  private readonly ignorer: SimCfnPropertyIgnorer;
+
+  constructor(properties: SimCfnEcrRepositoryPropertyRulesProperties) {
+    this.properties = properties.properties;
+    this.ignorer = properties.ignorer;
+  }
+
+  /**
+   * Record every property the repository is created without.
+   */
+  apply(): void {
+    for (const name of Object.keys(this.properties)) {
+      this.applyToProperty(name);
+    }
+  }
+
+  private applyToProperty(name: string): void {
+    if (name === "RepositoryName") {
+      return;
+    }
+
+    const unsimulatedReason = unsimulatedPropertyReasons.get(name);
+
+    if (unsimulatedReason === undefined) {
+      this.ignorer.ignoreProperty(
+        name,
+        `${name} is not a property simulated ECR knows about, so the ` +
+          `repository is created without it`,
+      );
+
+      return;
+    }
+
+    this.ignorer.ignoreProperty(
+      name,
+      `${name} is a real AWS::ECR::Repository property simulated ECR does ` +
+        `not act on: ${unsimulatedReason}`,
+    );
+  }
+}

--- a/src/service/ecr/cfn/repository/sim-cfn-ecr-repository-unsimulated-properties.ts
+++ b/src/service/ecr/cfn/repository/sim-cfn-ecr-repository-unsimulated-properties.ts
@@ -1,0 +1,41 @@
+/**
+ * The AWS::ECR::Repository properties this simulation has nothing to act on,
+ * and why.
+ *
+ * Every one of them is about image content, and Yulin never reads any. They
+ * are recorded as ignored rather than refused, because a repository without
+ * them still does the one thing a repository does here: hold the handler that
+ * stands in for the image.
+ */
+export const unsimulatedPropertyReasons: ReadonlyMap<string, string> = new Map([
+  [
+    "ImageScanningConfiguration",
+    "no image is pulled or inspected, so nothing is scanned and no finding " +
+      "is reported",
+  ],
+  [
+    "ImageTagMutability",
+    "a simulated image is registered in this process rather than pushed, so " +
+      "nothing enforces which tags may be moved",
+  ],
+  [
+    "ImageTagMutabilityExclusionFilters",
+    "tag mutability is not enforced, so the tags excluded from it are not " +
+      "either",
+  ],
+  [
+    "LifecyclePolicy",
+    "no lifecycle rule is evaluated, so no simulated image expires",
+  ],
+  [
+    "RepositoryPolicyText",
+    "nothing authorizes against a repository, since no request reaches one",
+  ],
+  ["EncryptionConfiguration", "there are no layers to encrypt at rest"],
+  [
+    "EmptyOnDelete",
+    "a repository is deleted with whatever it holds, since a simulated image " +
+      "is a handler registered by a test rather than a pushed artifact",
+  ],
+  ["Tags", "repository tags are not held or reported"],
+]);

--- a/src/service/ecr/cfn/sim-cfn-ecr-repository.iso.test.ts
+++ b/src/service/ecr/cfn/sim-cfn-ecr-repository.iso.test.ts
@@ -1,0 +1,233 @@
+import {
+  assertArrayLength,
+  assertFalse,
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertTrue,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+
+const repositoryTemplate = {
+  Resources: {
+    OrdersRepository: {
+      Type: "AWS::ECR::Repository",
+      Properties: { RepositoryName: "orders" },
+    },
+  },
+  Outputs: {
+    RepositoryArn: {
+      Value: { "Fn::GetAtt": ["OrdersRepository", "Arn"] },
+    },
+    RepositoryUri: {
+      Value: { "Fn::GetAtt": ["OrdersRepository", "RepositoryUri"] },
+    },
+    RepositoryRef: { Value: { Ref: "OrdersRepository" } },
+  },
+};
+
+describe("AWS::ECR::Repository", () => {
+  it("creates a simulated repository the template declares", async () => {
+    // Given a template declaring a repository, as a platform stack does.
+    const simAws = new SimAws();
+
+    // When it is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "platform-stack",
+      template: repositoryTemplate,
+    });
+
+    await stack.waitForDeployComplete();
+
+    // Then simulated ECR holds the repository, and the Resource answers Ref
+    // with its name and Fn::GetAtt with its ARN and URI.
+    assertTrue(simAws.ecr().hasRepository("orders"));
+
+    const repository = simAws.ecr().repository("orders");
+
+    assertIdentical(stack.outputs.get("RepositoryRef")?.value, "orders");
+    assertIdentical(
+      stack.outputs.get("RepositoryArn")?.value,
+      repository.repositoryArn,
+    );
+    assertIdentical(
+      stack.outputs.get("RepositoryUri")?.value,
+      repository.repositoryUri,
+    );
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("adopts a repository a handler is already registered in", async () => {
+    // Given a handler registered as the image in a repository before any
+    // stack that declares it is deployed, which is the order these happen in:
+    // the image is built long before the stack that runs it.
+    const simAws = new SimAws();
+
+    simAws
+      .ecr()
+      .repository("orders")
+      .simulateImage({ handler: () => "held" });
+
+    // When a template declaring that same repository is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "platform-stack",
+      template: repositoryTemplate,
+    });
+
+    await stack.waitForDeployComplete();
+
+    // Then the registered image is still there, because the repository
+    // outlives the stack rather than being replaced by it.
+    assertTrue(simAws.ecr().repository("orders").hasImage);
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("names an unnamed repository after the stack and logical ID", async () => {
+    // Given a template leaving RepositoryName out, as CDK does.
+    const simAws = new SimAws();
+
+    // When it is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "platform-stack",
+      template: {
+        Resources: {
+          OrdersRepository: { Type: "AWS::ECR::Repository" },
+        },
+      },
+    });
+
+    await stack.waitForDeployComplete();
+
+    // Then the generated name is lower cased, since ECR names are.
+    assertTrue(simAws.ecr().hasRepository("platform-stack-ordersrepository"));
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("records the image properties it has nothing to act on", async () => {
+    // Given a repository declaring scanning, tag mutability and a lifecycle
+    // policy, all of which are about image content.
+    const simAws = new SimAws();
+
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "platform-stack",
+      template: {
+        Resources: {
+          OrdersRepository: {
+            Type: "AWS::ECR::Repository",
+            Properties: {
+              RepositoryName: "orders",
+              ImageScanningConfiguration: { ScanOnPush: true },
+              ImageTagMutability: "IMMUTABLE",
+              LifecyclePolicy: { LifecyclePolicyText: "{}" },
+              EmptyOnDelete: true,
+              Tags: [{ Key: "team", Value: "orders" }],
+              WhateverElse: "unknown to this simulation",
+            },
+          },
+        },
+      },
+    });
+
+    await stack.waitForDeployComplete();
+
+    // Then the repository is created, and each property is reported as
+    // ignored rather than refusing the stack.
+    const resource = stack.getResource("OrdersRepository");
+
+    assertNonNullable(resource);
+    assertTrue(resource.deployed);
+    assertArrayLength(resource.ignoredProperties, 6);
+    assertTrue(
+      resource.ignoredProperties.some((ignored) =>
+        ignored.reason.includes("nothing is scanned"),
+      ),
+    );
+    assertTrue(
+      resource.ignoredProperties.some((ignored) =>
+        ignored.reason.includes("not a property simulated ECR knows about"),
+      ),
+    );
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("refuses a RepositoryName that is not a string", async () => {
+    // Given a template whose RepositoryName is the wrong shape.
+    const simAws = new SimAws();
+
+    // When it is deployed, then the deploy fails with the reason rather than
+    // skipping the Resource: a repository under a name nothing asked for is
+    // not a repository the rest of the stack could refer to.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.cloudFormation().deployTemplate({
+        stackName: "platform-stack",
+        template: {
+          Resources: {
+            OrdersRepository: {
+              Type: "AWS::ECR::Repository",
+              Properties: { RepositoryName: 12 },
+            },
+          },
+        },
+      }),
+    );
+
+    assertStringIncludes(
+      error.message,
+      "Invalid sim ECR CloudFormation Resource OrdersRepository: " +
+        "RepositoryName must be a string",
+    );
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("removes the repository when the stack is torn down", async () => {
+    // Given a deployed repository stack.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "platform-stack",
+      template: repositoryTemplate,
+    });
+
+    await stack.waitForDeployComplete();
+
+    // When the Stack's Resources are torn down.
+    await stack.teardown();
+    await simAws.backgroundTasksComplete();
+
+    // Then the repository goes with it.
+    assertFalse(simAws.ecr().hasRepository("orders"));
+  });
+
+  it("refuses an ECR Resource type it does not simulate", async () => {
+    // Given the ECR Resource factory.
+    const simAws = new SimAws();
+    const factory = simAws.ecr().cfnResourceFactory();
+
+    // When a Resource type ECR has no simulation for is created or deleted.
+    const created = await assertThrowsErrorAsync(async () =>
+      factory.create("PullThroughCacheRule", {} as never, {} as never),
+    );
+    const deleted = await assertThrowsErrorAsync(async () =>
+      factory.delete("PullThroughCacheRule", {} as never, {} as never),
+    );
+
+    // Then both are reported as unsupported, which the Stack records as a
+    // skip rather than a failure.
+    assertIdentical(
+      created.message,
+      "Unsupported sim ECR CloudFormation Resource PullThroughCacheRule",
+    );
+    assertIdentical(
+      deleted.message,
+      "Unsupported sim ECR CloudFormation Resource PullThroughCacheRule " +
+        "deletion",
+    );
+  });
+});

--- a/src/service/ecr/cfn/sim-cfn-ecr-repository.iso.test.ts
+++ b/src/service/ecr/cfn/sim-cfn-ecr-repository.iso.test.ts
@@ -187,8 +187,8 @@ describe("AWS::ECR::Repository", () => {
     await simAws.backgroundTasksComplete();
   });
 
-  it("removes the repository when the stack is torn down", async () => {
-    // Given a deployed repository stack.
+  it("removes an empty repository when the stack is torn down", async () => {
+    // Given a deployed repository nothing has registered an image in.
     const simAws = new SimAws();
     const stack = await simAws.cloudFormation().deployTemplate({
       stackName: "platform-stack",
@@ -201,8 +201,46 @@ describe("AWS::ECR::Repository", () => {
     await stack.teardown();
     await simAws.backgroundTasksComplete();
 
-    // Then the repository goes with it.
+    // Then the repository goes with it, since nothing was holding on to it.
     assertFalse(simAws.ecr().hasRepository("orders"));
+    assertIdentical(
+      stack.resources.get("OrdersRepository")?.status,
+      "DELETE_COMPLETE",
+    );
+  });
+
+  it("keeps a repository holding an image through a teardown", async () => {
+    // Given a deployed repository a test registered a handler in, which is
+    // where the handler lives for every stack that runs that image.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "platform-stack",
+      template: repositoryTemplate,
+    });
+
+    await stack.waitForDeployComplete();
+
+    simAws
+      .ecr()
+      .repository("orders")
+      .simulateImage({ handler: () => "held" });
+
+    // When the Stack's Resources are torn down.
+    await stack.teardown();
+    await simAws.backgroundTasksComplete();
+
+    // Then the repository and its image outlive the Stack, and the deletion
+    // is recorded rather than failing the teardown.
+    assertTrue(simAws.ecr().repository("orders").hasImage);
+
+    const resource = stack.resources.get("OrdersRepository");
+
+    assertTrue(resource?.deletionSkipped ?? false);
+    assertNonNullable(resource?.deletionSkippedReason);
+    assertStringIncludes(
+      resource.deletionSkippedReason,
+      "the simulated ECR repository orders holds a simulated image",
+    );
   });
 
   it("refuses an ECR Resource type it does not simulate", async () => {

--- a/src/service/ecr/cfn/sim-ecr-cfn-resource-factory.ts
+++ b/src/service/ecr/cfn/sim-ecr-cfn-resource-factory.ts
@@ -1,0 +1,74 @@
+import { assertDefined } from "../../../util/type-guard/defined.js";
+import type { SimCfnServiceResourceFactory } from "../../cloudformation/resource/factory/sim-cfn-resource-factory.type.js";
+import type {
+  SimCfnResource,
+  SimCloudFormationResourceCreateContext,
+} from "../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimEcrRepository } from "../repository/sim-ecr-repository.js";
+import type { SimEcr } from "../sim-ecr.js";
+import { SimCfnEcrRepositoryCreator } from "./repository/sim-cfn-ecr-repository-creator.js";
+
+interface SimEcrCfnResourceFactoryProperties {
+  readonly ecr: SimEcr;
+}
+
+/**
+ * CloudFormation Resource factory for simulated ECR resources.
+ *
+ * AWS::ECR::Repository is the only Resource type ECR has that means anything
+ * here. There is no resource type for an image, on real AWS or in this
+ * simulation, because an image is pushed rather than declared.
+ */
+export class SimEcrCfnResourceFactory implements SimCfnServiceResourceFactory {
+  private readonly repositoryCreator: SimCfnEcrRepositoryCreator;
+
+  constructor(properties: SimEcrCfnResourceFactoryProperties) {
+    this.repositoryCreator = new SimCfnEcrRepositoryCreator({
+      ecr: properties.ecr,
+    });
+  }
+
+  /**
+   * Create a simulated ECR resource from a CloudFormation Resource.
+   */
+  create(
+    resourceTypeName: string,
+    resource: SimCfnResource,
+    context: SimCloudFormationResourceCreateContext,
+  ): Promise<object | undefined> {
+    if (resourceTypeName !== "Repository") {
+      throw new Error(
+        `Unsupported sim ECR CloudFormation Resource ${resourceTypeName}`,
+      );
+    }
+
+    return Promise.resolve(
+      this.repositoryCreator.create(
+        resource,
+        context.resolvedProperties ?? resource.properties,
+      ),
+    );
+  }
+
+  /**
+   * Delete a simulated ECR resource created from a CloudFormation Resource.
+   */
+  delete(resourceTypeName: string, resource: SimCfnResource): Promise<void> {
+    if (resourceTypeName !== "Repository") {
+      throw new Error(
+        `Unsupported sim ECR CloudFormation Resource ${resourceTypeName} ` +
+          `deletion`,
+      );
+    }
+
+    const repository = resource.simResource as SimEcrRepository | undefined;
+    assertDefined(
+      repository,
+      `sim ECR repository for CloudFormation Resource ${resource.logicalId}`,
+    );
+
+    this.repositoryCreator.delete(repository);
+
+    return Promise.resolve();
+  }
+}

--- a/src/service/ecr/cfn/sim-ecr-cfn-resource-factory.ts
+++ b/src/service/ecr/cfn/sim-ecr-cfn-resource-factory.ts
@@ -67,7 +67,7 @@ export class SimEcrCfnResourceFactory implements SimCfnServiceResourceFactory {
       `sim ECR repository for CloudFormation Resource ${resource.logicalId}`,
     );
 
-    this.repositoryCreator.delete(repository);
+    this.repositoryCreator.delete(resource, repository);
 
     return Promise.resolve();
   }

--- a/src/service/ecr/error/sim-ecr.error.ts
+++ b/src/service/ecr/error/sim-ecr.error.ts
@@ -1,0 +1,33 @@
+/**
+ * Minimal metadata shape for simulated ECR errors.
+ */
+export interface SimEcrErrorMetadata {
+  readonly httpStatusCode?: number;
+}
+
+/**
+ * Base class for simulated ECR errors.
+ */
+export class SimEcrError extends Error {
+  constructor(
+    message: string,
+    public readonly $metadata: SimEcrErrorMetadata = {},
+  ) {
+    super(message);
+  }
+}
+
+/**
+ * Simulated ECR InvalidParameterException error.
+ *
+ * Real ECR reports a repository name it will not accept this way. Nothing here
+ * takes an SDK command, so this reaches a caller from a Yulin-native
+ * registration rather than from a request.
+ */
+export class SimEcrInvalidParameterException extends SimEcrError {
+  public override readonly name = "InvalidParameterException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}

--- a/src/service/ecr/image/sim-ecr-image-reference.iso.test.ts
+++ b/src/service/ecr/image/sim-ecr-image-reference.iso.test.ts
@@ -1,0 +1,60 @@
+import { assertIdentical, assertUndefined } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimEcrImageReference } from "./sim-ecr-image-reference.js";
+
+describe("SimEcrImageReference", () => {
+  it("reads the repository a tagged image URI names", () => {
+    // Given an image URI with a tag on it.
+    const reference = new SimEcrImageReference(
+      " 111111111111.dkr.ecr.eu-west-2.amazonaws.com/orders:latest ",
+    );
+
+    // Then the repository is what is left with the tag and the padding gone.
+    assertIdentical(
+      reference.repositoryKey(),
+      "111111111111.dkr.ecr.eu-west-2.amazonaws.com/orders",
+    );
+    assertIdentical(reference.imageTag(), "latest");
+  });
+
+  it("reads a repository named in mixed case as the same repository", () => {
+    // Given the same repository written two ways, as a DNS name can be.
+    const lower = new SimEcrImageReference(
+      "111111111111.dkr.ecr.eu-west-2.amazonaws.com/orders:1",
+    );
+    const upper = new SimEcrImageReference(
+      "111111111111.DKR.ECR.EU-WEST-2.amazonaws.com/orders:1",
+    );
+
+    // Then both read as one repository.
+    assertIdentical(lower.repositoryKey(), upper.repositoryKey());
+  });
+
+  it("asks for no tag where the reference names a digest", () => {
+    // Given an image referenced by digest, as a pinned deployment does.
+    const reference = new SimEcrImageReference(
+      "111111111111.dkr.ecr.eu-west-2.amazonaws.com/orders@sha256:0f9c1e",
+    );
+
+    // Then the repository is read and no tag is asked for.
+    assertIdentical(
+      reference.repositoryKey(),
+      "111111111111.dkr.ecr.eu-west-2.amazonaws.com/orders",
+    );
+    assertUndefined(reference.imageTag());
+  });
+
+  it("asks for no tag where the reference carries none", () => {
+    // Given a bare repository reference, and one on a registry with a port.
+    const bare = new SimEcrImageReference(
+      "111111111111.dkr.ecr.eu-west-2.amazonaws.com/orders",
+    );
+    const ported = new SimEcrImageReference("registry.test:5000/orders");
+
+    // Then neither asks for a tag, and the port stays part of the registry.
+    assertUndefined(bare.imageTag());
+    assertUndefined(ported.imageTag());
+    assertIdentical(ported.repositoryKey(), "registry.test:5000/orders");
+  });
+});

--- a/src/service/ecr/image/sim-ecr-image-reference.ts
+++ b/src/service/ecr/image/sim-ecr-image-reference.ts
@@ -1,0 +1,52 @@
+import { SimCfnImageRepositoryTarget } from "../../cloudformation/bind/validate/sim-cfn-image-repository-target.js";
+
+/**
+ * A container image reference, read as the repository it names and the tag it
+ * asks for.
+ *
+ * The repository half is read by {@link SimCfnImageRepositoryTarget}, which
+ * deploy-time image bindings already match on, so an image URI is understood
+ * one way wherever it arrives from. That normalised repository is what a
+ * simulated repository is indexed by, since a registry host carries the
+ * account and the region, and a same-named repository in another account is a
+ * different repository.
+ *
+ * The tag is kept apart because it is not part of that identity. Resolution
+ * ignores it, in that a reference to a tag no simulated image carries still
+ * finds the repository. It is read here so a repository holding more than one
+ * simulated image can answer with the one the reference asked for.
+ */
+export class SimEcrImageReference {
+  private readonly reference: string;
+  private readonly target: SimCfnImageRepositoryTarget;
+
+  constructor(reference: string) {
+    this.reference = reference.trim();
+    this.target = new SimCfnImageRepositoryTarget(this.reference);
+  }
+
+  /**
+   * The repository this reference names, in the form repositories are indexed
+   * by.
+   */
+  repositoryKey(): string {
+    return this.target.repositoryReference();
+  }
+
+  /**
+   * The tag this reference asks for, where it names one.
+   *
+   * A reference by digest asks for no tag, and neither does a bare repository
+   * name. Both leave the repository to answer with whichever image it holds.
+   */
+  imageTag(): string | undefined {
+    const name = this.reference.slice(this.reference.lastIndexOf("/") + 1);
+    const separator = name.indexOf(":");
+
+    if (separator === -1 || name.includes("@")) {
+      return undefined;
+    }
+
+    return name.slice(separator + 1);
+  }
+}

--- a/src/service/ecr/image/sim-ecr-image.ts
+++ b/src/service/ecr/image/sim-ecr-image.ts
@@ -1,0 +1,35 @@
+import type { SimLambdaHandler } from "../../lambda/function/sim-lambda-handler.type.js";
+
+/**
+ * What a simulated container image actually is: a real in-process handler.
+ *
+ * Yulin never reads image content, so there is nothing else an image could be
+ * here. A handler function is the only thing this simulator can run, which is
+ * why this is the sim Lambda handler type rather than a shape of its own.
+ */
+export type SimEcrImageHandler<
+  TEvent = never,
+  TResult = unknown,
+> = SimLambdaHandler<TEvent, TResult>;
+
+interface SimEcrImageProperties {
+  readonly imageTag: string;
+  readonly handler: SimEcrImageHandler;
+}
+
+/**
+ * One image in a simulated ECR repository.
+ *
+ * An image is a tag and the handler simulating what that image runs. It holds
+ * no layers, no manifest and no digest, because nothing here would read them:
+ * a function created from this image is created from the handler.
+ */
+export class SimEcrImage {
+  public readonly imageTag: string;
+  public readonly handler: SimEcrImageHandler;
+
+  constructor(properties: SimEcrImageProperties) {
+    this.imageTag = properties.imageTag;
+    this.handler = properties.handler;
+  }
+}

--- a/src/service/ecr/index.ts
+++ b/src/service/ecr/index.ts
@@ -1,0 +1,16 @@
+export { SimEcr } from "./sim-ecr.js";
+export {
+  SimEcrRepository,
+  type SimEcrSimulatedImageInput,
+} from "./repository/sim-ecr-repository.js";
+export { SimEcrRepositoryAddress } from "./repository/sim-ecr-repository-address.js";
+export { SimEcrRepositoryStore } from "./repository/sim-ecr-repository-store.js";
+export { requiredSimEcrRepositoryName } from "./repository/sim-ecr-repository-name.js";
+export { SimEcrImage, type SimEcrImageHandler } from "./image/sim-ecr-image.js";
+export { SimEcrImageReference } from "./image/sim-ecr-image-reference.js";
+export { SimEcrRegistry } from "./registry/sim-ecr-registry.js";
+export {
+  SimEcrError,
+  type SimEcrErrorMetadata,
+  SimEcrInvalidParameterException,
+} from "./error/sim-ecr.error.js";

--- a/src/service/ecr/registry/sim-ecr-registry.iso.test.ts
+++ b/src/service/ecr/registry/sim-ecr-registry.iso.test.ts
@@ -1,0 +1,116 @@
+import {
+  assertFalse,
+  assertIdentical,
+  assertNonNullable,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import type { SimAwsAccountId } from "../../aws/sim-aws-account.js";
+import { SimAws } from "../../aws/sim-aws.js";
+import { SimEcrRegistry } from "./sim-ecr-registry.js";
+
+const accountIdTwoTwos = "222222222222" as SimAwsAccountId;
+
+const ordersRepositoryUri =
+  "888888888888.dkr.ecr.us-east-1.amazonaws.com/orders";
+
+/**
+ * The registry one simulation's repositories are indexed in, reached the way
+ * the rest of the simulation reaches it.
+ */
+function registryOf(simAws: SimAws): SimEcrRegistry {
+  // The repositories of every scope are indexed together, so any scope's ECR
+  // resolves the same way. Building one here keeps the test to the registry.
+  const registry = new SimEcrRegistry();
+
+  for (const repository of simAws.ecr().allRepositories()) {
+    registry.register(repository);
+  }
+
+  return registry;
+}
+
+describe("SimEcrRegistry", () => {
+  it("resolves a repository from an image URI of any tag", () => {
+    // Given a repository in the default account and region.
+    const simAws = new SimAws();
+    const repository = simAws.ecr().repository("orders");
+    const registry = registryOf(simAws);
+
+    // When image URIs naming it by tag, by digest and by nothing are resolved.
+    // Then each finds the repository, because the tag is not its identity.
+    assertIdentical(
+      registry.repositoryFor(`${ordersRepositoryUri}:latest`),
+      repository,
+    );
+    assertIdentical(
+      registry.repositoryFor(`${ordersRepositoryUri}:2f0e1dab4c`),
+      repository,
+    );
+    assertIdentical(
+      registry.repositoryFor(`${ordersRepositoryUri}@sha256:0f9c1e`),
+      repository,
+    );
+    assertIdentical(registry.repositoryFor(ordersRepositoryUri), repository);
+  });
+
+  it("keeps a same-named repository in another account apart", () => {
+    // Given repositories of one name in two accounts.
+    const simAws = new SimAws();
+
+    simAws.ecr().repository("orders");
+
+    const otherAccount = simAws
+      .accountRegionScope(accountIdTwoTwos)
+      .ecr()
+      .repository("orders");
+    const registry = new SimEcrRegistry();
+
+    registry.register(simAws.ecr().repository("orders"));
+    registry.register(otherAccount);
+
+    // When each account's image URI is resolved.
+    const found = registry.repositoryFor(`${ordersRepositoryUri}:latest`);
+    const otherFound = registry.repositoryFor(otherAccount.repositoryUri);
+
+    // Then each URI finds the repository in its own account, because the
+    // registry host is part of what a repository is.
+    assertNonNullable(found);
+    assertIdentical(otherFound, otherAccount);
+    assertFalse(found === otherAccount);
+  });
+
+  it("finds nothing for a repository no simulated ECR holds", () => {
+    // Given a simulation holding one repository.
+    const simAws = new SimAws();
+
+    simAws.ecr().repository("orders");
+
+    const registry = registryOf(simAws);
+
+    // When an image URI naming another repository is resolved.
+    // Then nothing is found, which is a different answer from a repository
+    // holding no image.
+    assertUndefined(
+      registry.repositoryFor(
+        "888888888888.dkr.ecr.us-east-1.amazonaws.com/invoices:latest",
+      ),
+    );
+  });
+
+  it("stops resolving a repository that has been deregistered", () => {
+    // Given a registered repository.
+    const simAws = new SimAws();
+    const registry = new SimEcrRegistry();
+    const repository = simAws.ecr().repository("orders");
+
+    registry.register(repository);
+
+    // When it is deregistered, as deleting one does.
+    registry.deregister(repository);
+
+    // Then its image URI resolves to nothing.
+    assertUndefined(registry.repositoryFor(`${ordersRepositoryUri}:latest`));
+  });
+});

--- a/src/service/ecr/registry/sim-ecr-registry.ts
+++ b/src/service/ecr/registry/sim-ecr-registry.ts
@@ -1,0 +1,56 @@
+import { SimEcrImageReference } from "../image/sim-ecr-image-reference.js";
+import type { SimEcrRepository } from "../repository/sim-ecr-repository.js";
+
+/**
+ * Simulation-wide registry of simulated ECR repositories.
+ *
+ * One registry belongs to one SimAws environment. ECR is scoped to an account
+ * and region, but the thing that resolves a repository holds only an image
+ * URI: a Lambda function created in one account and region can run an image
+ * from another account's registry, as it can on real AWS.
+ *
+ * Repositories are indexed by their image reference rather than their name,
+ * since the registry host in that reference is what carries the account and
+ * the region. Reading a reference here and matching one in a deploy-time image
+ * binding are the same reading, so a repository is found by whatever tag or
+ * digest a template happened to name it with.
+ *
+ * The registry indexes repositories but does not create or own them.
+ */
+export class SimEcrRegistry {
+  private readonly repositoriesByReference = new Map<
+    string,
+    SimEcrRepository
+  >();
+
+  /**
+   * Register a repository, under the image reference that names it.
+   */
+  register(repository: SimEcrRepository): void {
+    this.repositoriesByReference.set(referenceKey(repository), repository);
+  }
+
+  /**
+   * Remove a repository from the index.
+   */
+  deregister(repository: SimEcrRepository): void {
+    this.repositoriesByReference.delete(referenceKey(repository));
+  }
+
+  /**
+   * The repository an image URI names, wherever in the simulation it lives.
+   *
+   * Undefined means no simulated ECR anywhere holds that repository, which is
+   * a different thing from a repository holding no image. Callers report the
+   * two apart, because they send a reader to different places.
+   */
+  repositoryFor(imageUri: string): SimEcrRepository | undefined {
+    return this.repositoriesByReference.get(
+      new SimEcrImageReference(imageUri).repositoryKey(),
+    );
+  }
+}
+
+function referenceKey(repository: SimEcrRepository): string {
+  return new SimEcrImageReference(repository.repositoryUri).repositoryKey();
+}

--- a/src/service/ecr/repository/sim-ecr-repository-address.ts
+++ b/src/service/ecr/repository/sim-ecr-repository-address.ts
@@ -1,0 +1,43 @@
+import type { SimArn } from "../../aws/arn.js";
+import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+
+/**
+ * Where a simulated ECR repository is, in the two forms AWS names it by.
+ *
+ * The registry host carries the account and the region, which is what makes
+ * one account's `orders` repository a different repository from another's. It
+ * is the form a Lambda `Code.ImageUri` names, while the ARN is the form an IAM
+ * policy and a `Fn::GetAtt` name.
+ */
+export class SimEcrRepositoryAddress {
+  private readonly accountRegionScope: SimAwsAccountRegionScope;
+
+  constructor(accountRegionScope: SimAwsAccountRegionScope) {
+    this.accountRegionScope = accountRegionScope;
+  }
+
+  /**
+   * The registry host every repository in this account and region is under.
+   */
+  registryHost(): string {
+    const { accountId, regionName } = this.accountRegionScope;
+
+    return `${accountId}.dkr.ecr.${regionName}.amazonaws.com`;
+  }
+
+  /**
+   * The repository URI, which an image URI is this followed by a tag.
+   */
+  uri(repositoryName: string): string {
+    return `${this.registryHost()}/${repositoryName}`;
+  }
+
+  /**
+   * The repository ARN.
+   */
+  arn(repositoryName: string): SimArn {
+    const { accountId, regionName } = this.accountRegionScope;
+
+    return `arn:aws:ecr:${regionName}:${accountId}:repository/${repositoryName}`;
+  }
+}

--- a/src/service/ecr/repository/sim-ecr-repository-name.ts
+++ b/src/service/ecr/repository/sim-ecr-repository-name.ts
@@ -1,0 +1,51 @@
+import { SimEcrInvalidParameterException } from "../error/sim-ecr.error.js";
+
+const minimumLength = 2;
+const maximumLength = 256;
+
+/** What a repository name is made of between its separators. */
+const namePartPattern = /^[a-z0-9]+$/;
+
+/** The separators a repository name may have between those parts. */
+const nameSeparators = /[._\-/]/;
+
+/**
+ * Read a repository name, refusing one real ECR would refuse.
+ *
+ * A repository name is a name rather than a URI: the account, the region and
+ * the registry host around it come from the simulated ECR the repository
+ * belongs to. `orders` and `platform/orders` are names, and an image URI is
+ * not one.
+ */
+export function requiredSimEcrRepositoryName(repositoryName: string): string {
+  if (
+    repositoryName.length < minimumLength ||
+    repositoryName.length > maximumLength
+  ) {
+    throw new SimEcrInvalidParameterException(
+      `Invalid parameter at 'repositoryName' failed to satisfy constraint: ` +
+        `must be between ${minimumLength} and ${maximumLength} characters`,
+    );
+  }
+
+  /*
+   * Real ECR states the whole name as one expression: lower case letters and
+   * numbers in groups separated by one period, underscore, hyphen or slash.
+   * It is read here by splitting on those separators and checking the parts,
+   * which says the same thing, because the single expression nests three
+   * quantifiers and that is the shape a name can be written to make take
+   * exponential time to match. An empty part is a name that starts, ends or
+   * doubles up on a separator, which real ECR refuses too.
+   */
+  const parts = repositoryName.split(nameSeparators);
+
+  if (parts.some((part) => !namePartPattern.test(part))) {
+    throw new SimEcrInvalidParameterException(
+      `Invalid parameter at 'repositoryName' failed to satisfy constraint: ` +
+        `must be lower case letters and numbers, in groups separated by one ` +
+        `period, underscore, hyphen or slash`,
+    );
+  }
+
+  return repositoryName;
+}

--- a/src/service/ecr/repository/sim-ecr-repository-store.ts
+++ b/src/service/ecr/repository/sim-ecr-repository-store.ts
@@ -1,0 +1,87 @@
+import type { SimEcrRegistry } from "../registry/sim-ecr-registry.js";
+import { SimEcrRepository } from "./sim-ecr-repository.js";
+import type { SimEcrRepositoryAddress } from "./sim-ecr-repository-address.js";
+import { requiredSimEcrRepositoryName } from "./sim-ecr-repository-name.js";
+
+interface SimEcrRepositoryStoreProperties {
+  readonly address: SimEcrRepositoryAddress;
+  readonly registry: SimEcrRegistry;
+}
+
+/**
+ * The repositories one simulated ECR holds, in one account and region.
+ *
+ * A repository is registered simulation-wide as it is made, because the thing
+ * that resolves one is a Lambda function in whichever account and region its
+ * own stack deployed into, holding nothing but an image URI.
+ */
+export class SimEcrRepositoryStore {
+  private readonly address: SimEcrRepositoryAddress;
+  private readonly registry: SimEcrRegistry;
+  private readonly repositoriesByName = new Map<string, SimEcrRepository>();
+
+  constructor(properties: SimEcrRepositoryStoreProperties) {
+    this.address = properties.address;
+    this.registry = properties.registry;
+  }
+
+  /**
+   * The repository of this name, made if this is the first mention of it.
+   *
+   * Naming a repository is what creates it, because a repository here is only
+   * ever a name that holds code. That also means a template declaring a
+   * repository a test has already registered a handler in adopts that
+   * repository rather than replacing it, which is the whole point of the
+   * repository outliving the stack.
+   */
+  repository(repositoryName: string): SimEcrRepository {
+    const name = requiredSimEcrRepositoryName(repositoryName);
+    const existing = this.repositoriesByName.get(name);
+
+    if (existing !== undefined) {
+      return existing;
+    }
+
+    const repository = new SimEcrRepository({
+      repositoryName: name,
+      address: this.address,
+    });
+
+    this.repositoriesByName.set(name, repository);
+    this.registry.register(repository);
+
+    return repository;
+  }
+
+  /**
+   * Whether a repository of this name has been made.
+   */
+  has(repositoryName: string): boolean {
+    return this.repositoriesByName.has(repositoryName);
+  }
+
+  /**
+   * Remove a repository, and the simulated images it holds with it.
+   *
+   * A repository nothing made is already gone, so removing one is not a
+   * failure: a CloudFormation teardown deleting a repository a later stack
+   * also declared would otherwise have to know which stack made it.
+   */
+  delete(repositoryName: string): void {
+    const repository = this.repositoriesByName.get(repositoryName);
+
+    if (repository === undefined) {
+      return;
+    }
+
+    this.repositoriesByName.delete(repositoryName);
+    this.registry.deregister(repository);
+  }
+
+  /**
+   * Every repository this simulated ECR holds.
+   */
+  all(): readonly SimEcrRepository[] {
+    return this.repositoriesByName.values().toArray();
+  }
+}

--- a/src/service/ecr/repository/sim-ecr-repository.ts
+++ b/src/service/ecr/repository/sim-ecr-repository.ts
@@ -1,0 +1,119 @@
+import type { SimArn } from "../../aws/arn.js";
+import {
+  SimEcrImage,
+  type SimEcrImageHandler,
+} from "../image/sim-ecr-image.js";
+import type { SimEcrRepositoryAddress } from "./sim-ecr-repository-address.js";
+
+/**
+ * What registering a handler as the image in a repository says.
+ *
+ * The tag defaults to `latest`, as a push with no tag does. The handler is
+ * what a function created from this image runs.
+ */
+export interface SimEcrSimulatedImageInput<TEvent = never, TResult = unknown> {
+  readonly imageTag?: string;
+  readonly handler: SimEcrImageHandler<TEvent, TResult>;
+}
+
+interface SimEcrRepositoryProperties {
+  readonly repositoryName: string;
+  readonly address: SimEcrRepositoryAddress;
+}
+
+/**
+ * A simulated ECR repository: a name that holds images by tag.
+ *
+ * The repository is the point of all this. It is the stable name for the thing
+ * that holds a piece of code, and it outlives any stack, any tag and any CDK
+ * construct ID, so one registration in test setup backs every function in
+ * every stack that runs an image from it.
+ */
+export class SimEcrRepository {
+  public readonly repositoryName: string;
+
+  private readonly address: SimEcrRepositoryAddress;
+  private readonly imagesByTag = new Map<string, SimEcrImage>();
+
+  constructor(properties: SimEcrRepositoryProperties) {
+    this.repositoryName = properties.repositoryName;
+    this.address = properties.address;
+  }
+
+  /**
+   * The repository URI, which a Lambda `Code.ImageUri` names with a tag on the
+   * end of it.
+   */
+  get repositoryUri(): string {
+    return this.address.uri(this.repositoryName);
+  }
+
+  /**
+   * The repository ARN.
+   */
+  get repositoryArn(): SimArn {
+    return this.address.arn(this.repositoryName);
+  }
+
+  /**
+   * Whether this repository holds any simulated image.
+   */
+  get hasImage(): boolean {
+    return this.imagesByTag.size > 0;
+  }
+
+  /**
+   * Register a real in-process handler as the image this repository holds
+   * under a tag.
+   *
+   * This is a Yulin-native operation rather than a simulated `PutImage`, which
+   * is deliberate: real `PutImage` takes an image manifest for layers that
+   * were pushed over the Docker registry protocol, and none of that exists
+   * here. Registering the same tag again replaces what it held.
+   */
+  simulateImage<TEvent = never, TResult = unknown>(
+    input: SimEcrSimulatedImageInput<TEvent, TResult>,
+  ): this {
+    const imageTag = input.imageTag ?? "latest";
+
+    this.imagesByTag.set(
+      imageTag,
+      new SimEcrImage({ imageTag, handler: input.handler }),
+    );
+
+    return this;
+  }
+
+  /**
+   * The image a reference to this repository resolves to.
+   *
+   * A tag this repository holds is answered with exactly that image. Any other
+   * tag, and a reference carrying no tag at all, is answered with the image
+   * registered most recently, because the tag a template names is rarely one a
+   * test could have written down: a CDK image asset is tagged with a content
+   * hash and a pipeline-built image with a build number.
+   *
+   * Undefined means this repository holds no simulated image, which callers
+   * report in their own terms.
+   */
+  image(imageTag?: string): SimEcrImage | undefined {
+    const tagged =
+      imageTag === undefined ? undefined : this.imagesByTag.get(imageTag);
+
+    return tagged ?? this.latestRegisteredImage();
+  }
+
+  /**
+   * Every image this repository holds, in the order they were registered.
+   */
+  images(): readonly SimEcrImage[] {
+    return this.imagesByTag.values().toArray();
+  }
+
+  /**
+   * The image registered most recently, or undefined where there is none.
+   */
+  private latestRegisteredImage(): SimEcrImage | undefined {
+    return this.images().at(-1);
+  }
+}

--- a/src/service/ecr/repository/sim-ecr-repository.ts
+++ b/src/service/ecr/repository/sim-ecr-repository.ts
@@ -70,12 +70,17 @@ export class SimEcrRepository {
    * is deliberate: real `PutImage` takes an image manifest for layers that
    * were pushed over the Docker registry protocol, and none of that exists
    * here. Registering the same tag again replaces what it held.
+   *
+   * A replaced tag is taken out before it goes back in, because a Map keeps a
+   * key it already has where it first went. Without that, the image registered
+   * most recently would not be the one an untagged reference resolves to.
    */
   simulateImage<TEvent = never, TResult = unknown>(
     input: SimEcrSimulatedImageInput<TEvent, TResult>,
   ): this {
     const imageTag = input.imageTag ?? "latest";
 
+    this.imagesByTag.delete(imageTag);
     this.imagesByTag.set(
       imageTag,
       new SimEcrImage({ imageTag, handler: input.handler }),

--- a/src/service/ecr/sim-ecr.iso.test.ts
+++ b/src/service/ecr/sim-ecr.iso.test.ts
@@ -1,0 +1,180 @@
+import {
+  assertArrayLength,
+  assertFalse,
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertThrowsError,
+  assertTrue,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import type { SimAwsAccountId } from "../aws/sim-aws-account.js";
+import { SimAws } from "../aws/sim-aws.js";
+import { SimEcrInvalidParameterException } from "./error/sim-ecr.error.js";
+
+const accountIdTwoTwos = "222222222222" as SimAwsAccountId;
+
+describe("SimEcr repositories", () => {
+  it("makes a repository the first time it is named", () => {
+    // Given a simulated ECR holding nothing.
+    const simAws = new SimAws();
+    const ecr = simAws.ecr();
+
+    assertFalse(ecr.hasRepository("orders"));
+
+    // When the same repository is named twice.
+    const repository = ecr.repository("orders");
+    const again = ecr.repository("orders");
+
+    // Then naming it made it, and it is the same repository both times.
+    assertTrue(ecr.hasRepository("orders"));
+    assertIdentical(again, repository);
+    assertArrayLength(ecr.allRepositories(), 1);
+  });
+
+  it("names a repository by the account and region it is in", () => {
+    // Given a repository in one account and region.
+    const simAws = new SimAws();
+    const repository = simAws
+      .accountRegionScope(accountIdTwoTwos, "us-east-1")
+      .ecr()
+      .repository("orders");
+
+    // When its URI and ARN are read.
+    // Then both name the account and region it belongs to.
+    assertIdentical(
+      repository.repositoryUri,
+      "222222222222.dkr.ecr.us-east-1.amazonaws.com/orders",
+    );
+    assertIdentical(
+      repository.repositoryArn,
+      "arn:aws:ecr:us-east-1:222222222222:repository/orders",
+    );
+  });
+
+  it("refuses a repository name real ECR would refuse", () => {
+    // Given a simulated ECR.
+    const ecr = new SimAws().ecr();
+
+    // When a name is given that real ECR would not accept.
+    const upperCase = assertThrowsError(() => ecr.repository("Orders"));
+    const tooShort = assertThrowsError(() => ecr.repository("o"));
+    const imageUri = assertThrowsError(() =>
+      ecr.repository("888888888888.dkr.ecr.us-east-1.amazonaws.com/orders:1"),
+    );
+
+    // Then each is refused as an invalid parameter, saying what a name is.
+    assertInstanceOf(upperCase, SimEcrInvalidParameterException);
+    assertInstanceOf(imageUri, SimEcrInvalidParameterException);
+    assertIdentical(
+      tooShort.message,
+      "Invalid parameter at 'repositoryName' failed to satisfy constraint: " +
+        "must be between 2 and 256 characters",
+    );
+    assertIdentical(
+      upperCase.message,
+      "Invalid parameter at 'repositoryName' failed to satisfy constraint: " +
+        "must be lower case letters and numbers, in groups separated by one " +
+        "period, underscore, hyphen or slash",
+    );
+  });
+
+  it("accepts a repository name with path segments", () => {
+    // Given a repository named the way a team namespaces one.
+    const repository = new SimAws().ecr().repository("platform/orders-api.v2");
+
+    // Then the name is kept as it was given.
+    assertIdentical(repository.repositoryName, "platform/orders-api.v2");
+  });
+});
+
+describe("SimEcr simulated images", () => {
+  it("holds a registered handler under the tag it was given", () => {
+    // Given a repository with a handler registered under two tags.
+    const repository = new SimAws().ecr().repository("orders");
+
+    repository
+      .simulateImage({ imageTag: "blue", handler: () => "blue" })
+      .simulateImage({ imageTag: "green", handler: () => "green" });
+
+    // When each tag is asked for.
+    const blue = repository.image("blue");
+    const green = repository.image("green");
+
+    // Then each answers with the image registered under it.
+    assertNonNullable(blue);
+    assertNonNullable(green);
+    assertIdentical(blue.imageTag, "blue");
+    assertIdentical(green.imageTag, "green");
+    assertArrayLength(repository.images(), 2);
+  });
+
+  it("registers under latest where no tag is given", () => {
+    // Given a handler registered with no tag, as a push with none is tagged.
+    const repository = new SimAws().ecr().repository("orders");
+
+    repository.simulateImage({ handler: () => "only image" });
+
+    // Then it is held under latest.
+    assertNonNullable(repository.image("latest"));
+    assertTrue(repository.hasImage);
+  });
+
+  it("answers a tag it does not hold with the image registered last", () => {
+    // Given two images, neither tagged the way a template names one.
+    const repository = new SimAws().ecr().repository("orders");
+
+    repository
+      .simulateImage({ imageTag: "build-1", handler: () => "first" })
+      .simulateImage({ imageTag: "build-2", handler: () => "second" });
+
+    // When a tag nothing holds is asked for, as a content hash tag is.
+    const image = repository.image("2f0e1dab4c");
+
+    // Then the image registered most recently is the one that answers,
+    // because no tag a template carries is one a test could have written.
+    assertNonNullable(image);
+    assertIdentical(image.imageTag, "build-2");
+  });
+
+  it("replaces the image registered again under one tag", () => {
+    // Given a tag registered twice.
+    const repository = new SimAws().ecr().repository("orders");
+    const second = (): string => "second";
+
+    repository
+      .simulateImage({ handler: () => "first" })
+      .simulateImage({ handler: second });
+
+    // Then the repository holds one image, the later one.
+    assertArrayLength(repository.images(), 1);
+    assertIdentical(repository.image("latest")?.handler, second);
+  });
+
+  it("holds no image until one is registered", () => {
+    // Given a repository nothing has registered an image in.
+    const repository = new SimAws().ecr().repository("orders");
+
+    // Then it answers with no image, whatever tag is asked for.
+    assertFalse(repository.hasImage);
+    assertUndefined(repository.image("latest"));
+    assertUndefined(repository.image());
+  });
+
+  it("deletes a repository with the images it holds", () => {
+    // Given a repository holding an image.
+    const ecr = new SimAws().ecr();
+
+    ecr.repository("orders").simulateImage({ handler: () => "gone" });
+
+    // When the repository is deleted, twice over.
+    ecr.deleteRepository("orders");
+    ecr.deleteRepository("orders");
+
+    // Then it is gone, and deleting one that is already gone is not an error.
+    assertFalse(ecr.hasRepository("orders"));
+    assertFalse(ecr.repository("orders").hasImage);
+  });
+});

--- a/src/service/ecr/sim-ecr.iso.test.ts
+++ b/src/service/ecr/sim-ecr.iso.test.ts
@@ -153,6 +153,27 @@ describe("SimEcr simulated images", () => {
     assertIdentical(repository.image("latest")?.handler, second);
   });
 
+  it("counts a replaced tag as the image registered most recently", () => {
+    // Given a tag registered, another registered after it, and then the first
+    // one registered again.
+    const repository = new SimAws().ecr().repository("orders");
+    const replacement = (): string => "blue again";
+
+    repository
+      .simulateImage({ imageTag: "blue", handler: () => "blue" })
+      .simulateImage({ imageTag: "green", handler: () => "green" })
+      .simulateImage({ imageTag: "blue", handler: replacement });
+
+    // When a tag the repository does not hold is asked for.
+    const image = repository.image("2f0e1dab4c");
+
+    // Then the replacement is what answers, because registering a tag again
+    // is the most recent registration whatever order the tags first arrived
+    // in.
+    assertIdentical(image?.handler, replacement);
+    assertArrayLength(repository.images(), 2);
+  });
+
   it("holds no image until one is registered", () => {
     // Given a repository nothing has registered an image in.
     const repository = new SimAws().ecr().repository("orders");

--- a/src/service/ecr/sim-ecr.ts
+++ b/src/service/ecr/sim-ecr.ts
@@ -1,0 +1,84 @@
+import type { SimCfnServiceResourceFactory } from "../cloudformation/resource/factory/sim-cfn-resource-factory.type.js";
+import { simAwsAccountRegionScopeFactory } from "../aws/sim-aws-account-region-scope.factory.js";
+import type { SimAwsAccountRegionScope } from "../aws/sim-aws-account-region-scope.js";
+import { SimEcrCfnResourceFactory } from "./cfn/sim-ecr-cfn-resource-factory.js";
+import { SimEcrRegistry } from "./registry/sim-ecr-registry.js";
+import { SimEcrRepositoryAddress } from "./repository/sim-ecr-repository-address.js";
+import type { SimEcrRepository } from "./repository/sim-ecr-repository.js";
+import { SimEcrRepositoryStore } from "./repository/sim-ecr-repository-store.js";
+
+interface SimEcrProperties {
+  readonly accountRegionScope?: SimAwsAccountRegionScope;
+  readonly registry?: SimEcrRegistry;
+}
+
+/**
+ * Simulated ECR. Holds repositories, each holding images by tag.
+ *
+ * There are no SDK commands here, and that is deliberate. What this service is
+ * for is saying what an image actually is, and real ECR has no operation that
+ * could say it: `PutImage` takes a manifest for layers pushed over the Docker
+ * registry protocol, none of which exists in this process. So registering a
+ * handler as an image is a Yulin-native operation, named so it cannot be
+ * mistaken for a simulated `PutImage`.
+ *
+ * Repositories are scoped to an account and region, as they are on real AWS:
+ * a repository ARN names the region, and the registry host in an image URI
+ * carries both the account and the region.
+ */
+export class SimEcr {
+  private readonly repositories: SimEcrRepositoryStore;
+  private readonly cfnFactory = new SimEcrCfnResourceFactory({ ecr: this });
+
+  constructor(properties: SimEcrProperties = {}) {
+    const {
+      accountRegionScope = simAwsAccountRegionScopeFactory.make(),
+      registry = new SimEcrRegistry(),
+    } = properties;
+
+    this.repositories = new SimEcrRepositoryStore({
+      address: new SimEcrRepositoryAddress(accountRegionScope),
+      registry,
+    });
+  }
+
+  /**
+   * The repository of this name, made if this is the first mention of it.
+   *
+   * Naming a repository is what creates it. A repository holds no state of its
+   * own beyond the images registered in it, so there is nothing to declare
+   * before registering one, and a test can name the repository its templates
+   * already point at.
+   */
+  repository(repositoryName: string): SimEcrRepository {
+    return this.repositories.repository(repositoryName);
+  }
+
+  /**
+   * Whether a repository of this name has been made.
+   */
+  hasRepository(repositoryName: string): boolean {
+    return this.repositories.has(repositoryName);
+  }
+
+  /**
+   * Remove a repository, and the simulated images it holds with it.
+   */
+  deleteRepository(repositoryName: string): void {
+    this.repositories.delete(repositoryName);
+  }
+
+  /**
+   * Every repository this simulated ECR holds.
+   */
+  allRepositories(): readonly SimEcrRepository[] {
+    return this.repositories.all();
+  }
+
+  /**
+   * Get this service's CloudFormation Resource factory.
+   */
+  cfnResourceFactory(): SimCfnServiceResourceFactory {
+    return this.cfnFactory;
+  }
+}

--- a/src/service/lambda/README.md
+++ b/src/service/lambda/README.md
@@ -527,7 +527,9 @@ the CloudFormation engine with an "Unsupported" diagnostic.
 - Function URL `Cors` configuration and OPTIONS preflight handling
 - `InvokeMode: RESPONSE_STREAM`, which is accepted and reported but always served buffered
 - ES module function code (`.mjs` / `export` syntax) in the vm runtime
-- container image functions (`Code.ImageUri`) — the simulator stays Docker-free
+- running a container image: nothing reads one, so a function naming `Code.ImageUri` runs the real
+  in-process handler an executable binding or a simulated ECR repository stands in with, and is
+  skipped or refused where neither does
 - `UpdateFunctionCode`, `DeleteFunction`, function listing, versions, aliases and qualifiers
 - Lambda Layers
 - environment variables reaching a real in-process handler's module scope (see "Environment

--- a/src/service/lambda/cfn/function/sim-cfn-lambda-code-input.ts
+++ b/src/service/lambda/cfn/function/sim-cfn-lambda-code-input.ts
@@ -2,6 +2,7 @@ import type { SimCfnExecutableResourceBinding } from "../../../cloudformation/bi
 import { SimCfnExecBindingFinder } from "../../../cloudformation/bind/validate/sim-cfn-exec-binding-finder.js";
 import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
 import type { SimLambdaFunctionCode } from "../../command/create-function/create-function.command.js";
+import type { SimLambdaContainerImages } from "../../function/code/image/sim-lambda-container-images.js";
 import { makeLambdaZipFileInput } from "../../function/code/lambda-zip-file-input.js";
 import { simLambdaFunctionArn } from "../../function/sim-lambda-function.js";
 import type { SimLambdaHandler } from "../../function/sim-lambda-handler.type.js";
@@ -11,25 +12,40 @@ interface SimCfnLambdaCodeInputProperties {
   readonly resource: SimCfnResource;
   readonly functionProperties: SimCfnLambdaFunctionProperties;
   readonly bindings?: readonly SimCfnExecutableResourceBinding[] | undefined;
+  readonly containerImages: SimLambdaContainerImages;
 }
 
 /**
- * The code a Resource's function will be created with, and whether an
- * executable binding supplied it.
+ * The code a Resource's function will be created with, whether a real
+ * in-process handler supplied it, and why an image supplied none.
  */
 export interface SimCfnLambdaCodeInput {
   readonly code: SimLambdaFunctionCode | undefined;
   readonly bound: boolean;
+  /**
+   * Why the image this function names stands in for no handler, where it names
+   * one and nothing resolved it. This is what the skip reason says, so a
+   * reader is told whether the repository is missing or its image is.
+   */
+  readonly unsimulatedImageReason?: string | undefined;
 }
 
 /**
- * The CreateFunction code input for an AWS::Lambda::Function Resource: an
- * executable binding's real handler when one targets the Resource, otherwise
- * the template code.
+ * The CreateFunction code input for an AWS::Lambda::Function Resource: a real
+ * in-process handler where one backs the function, otherwise the template
+ * code.
  *
- * The bound handler rides the same stowaway Code.ZipFile input the SDK path
- * uses, so execution-role attribution and invocation behave identically. A
- * bound function may omit template Code and Handler entirely, as the binding
+ * A handler can come from two places, and they are looked at in this order:
+ *
+ * 1. An executable binding given to this deploy, which is the more specific
+ *    thing to have said, and can be about this one stack.
+ * 2. A simulated ECR repository the function's `Code.ImageUri` names, which
+ *    is a standing statement about what that image is, made once and good for
+ *    every stack that runs it.
+ *
+ * Either way the handler rides the same stowaway Code.ZipFile input the SDK
+ * path uses, so execution-role attribution and invocation behave identically.
+ * A bound function may omit template Code and Handler entirely, as the handler
  * replaces the code wholesale. Bindings can target the logical ID (or CDK
  * construct ID), the resolved function name, the function ARN, or the
  * container image repository the function's Code.ImageUri names.
@@ -52,12 +68,45 @@ export function simCfnLambdaCodeInput(
     imageUri: functionProperties.imageUri,
   });
 
-  if (binding === undefined) {
+  if (binding !== undefined) {
+    return handlerCode(binding.handler);
+  }
+
+  return registeredImageCode(properties);
+}
+
+/**
+ * The code input for a function whose image simulated ECR may hold.
+ *
+ * A function naming no image has no image to resolve, so it keeps its template
+ * code and the image skip has nothing to say about it either.
+ */
+function registeredImageCode(
+  properties: SimCfnLambdaCodeInputProperties,
+): SimCfnLambdaCodeInput {
+  const { functionProperties, containerImages } = properties;
+  const { imageUri } = functionProperties;
+
+  if (imageUri === undefined) {
     return { code: functionProperties.code, bound: false };
   }
 
-  return {
-    code: { ZipFile: makeLambdaZipFileInput(binding.handler) },
-    bound: true,
-  };
+  const image = containerImages.image(imageUri);
+
+  if (image.handler === undefined) {
+    return {
+      code: functionProperties.code,
+      bound: false,
+      unsimulatedImageReason: image.unsimulatedReason(),
+    };
+  }
+
+  return handlerCode(image.handler);
+}
+
+/**
+ * The code input for a function a real in-process handler backs.
+ */
+function handlerCode(handler: SimLambdaHandler): SimCfnLambdaCodeInput {
+  return { code: { ZipFile: makeLambdaZipFileInput(handler) }, bound: true };
 }

--- a/src/service/lambda/cfn/function/sim-cfn-lambda-creation-skips.ts
+++ b/src/service/lambda/cfn/function/sim-cfn-lambda-creation-skips.ts
@@ -1,5 +1,6 @@
 import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
 import { SimCfnLambdaCdkAssetsSkip } from "./sim-cfn-lambda-cdk-assets-skip.js";
+import type { SimCfnLambdaCodeInput } from "./sim-cfn-lambda-code-input.js";
 import type { SimCfnLambdaFunctionProperties } from "./sim-cfn-lambda-function-properties-parser.js";
 import { SimCfnLambdaImageSkip } from "./sim-cfn-lambda-image-skip.js";
 import { SimCfnLambdaRuntimeSkip } from "./sim-cfn-lambda-runtime-skip.js";
@@ -26,11 +27,11 @@ export class SimCfnLambdaCreationSkips {
   beforeCreate(
     resource: SimCfnResource,
     functionProperties: SimCfnLambdaFunctionProperties,
-    bound: boolean,
+    code: SimCfnLambdaCodeInput,
   ): Error | undefined {
     return (
-      this.imageSkip.findSkipError(resource, functionProperties, bound) ??
-      this.runtimeSkip.findSkipError(resource, functionProperties, bound)
+      this.imageSkip.findSkipError(resource, functionProperties, code) ??
+      this.runtimeSkip.findSkipError(resource, functionProperties, code.bound)
     );
   }
 

--- a/src/service/lambda/cfn/function/sim-cfn-lambda-ecr-image.iso.test.ts
+++ b/src/service/lambda/cfn/function/sim-cfn-lambda-ecr-image.iso.test.ts
@@ -1,0 +1,300 @@
+import { InvokeCommand } from "@aws-sdk/client-lambda";
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertTrue,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import type { SimAwsAccountId } from "../../../aws/sim-aws-account.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+import type {
+  SimCfnTemplateValue,
+  SimCfnTemplateValueRecord,
+} from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+
+const accountIdTwoTwos = "222222222222" as SimAwsAccountId;
+
+const ordersRepositoryUri =
+  "888888888888.dkr.ecr.us-east-1.amazonaws.com/orders";
+
+/**
+ * A container image function, tagged the way CDK tags an image asset: with a
+ * content hash, which changes whenever the image source does.
+ */
+function imageFunctionResource(properties: {
+  readonly functionName: string;
+  readonly imageUri?: SimCfnTemplateValue;
+}): SimCfnTemplateValueRecord {
+  return {
+    Type: "AWS::Lambda::Function",
+    Properties: {
+      FunctionName: properties.functionName,
+      Role: "arn:aws:iam::888888888888:role/OrdersRole",
+      PackageType: "Image",
+      Code: {
+        ImageUri: properties.imageUri ?? `${ordersRepositoryUri}:2f0e1dab4c`,
+      },
+    },
+  };
+}
+
+async function invokePayload(
+  simAws: SimAws,
+  functionName: string,
+): Promise<unknown> {
+  const output = await simAws
+    .lambda()
+    .invoke(new InvokeCommand({ FunctionName: functionName }));
+
+  assertIdentical(output.StatusCode, 200);
+  assertUndefined(output.FunctionError);
+  assertNonNullable(output.Payload);
+
+  return JSON.parse(Buffer.from(output.Payload).toString()) as unknown;
+}
+
+describe("Lambda CloudFormation Functions from simulated ECR images", () => {
+  it("creates a function from the image its repository holds", async () => {
+    // Given a handler registered as the image in a repository, and a template
+    // function running an image from it under some other tag.
+    const simAws = new SimAws();
+
+    simAws
+      .ecr()
+      .repository("orders")
+      .simulateImage({ handler: () => "ran the repository image" });
+
+    // When the template is deployed, with no binding of any kind.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: {
+        Resources: {
+          OrdersFunction: imageFunctionResource({ functionName: "orders" }),
+        },
+      },
+    });
+
+    // Then the function is created rather than skipped for its image, and the
+    // registered handler is what runs.
+    const functionResource = stack.getResource("OrdersFunction");
+
+    assertNonNullable(functionResource);
+    assertUndefined(functionResource.skippedReason);
+    assertIdentical(
+      await invokePayload(simAws, "orders"),
+      "ran the repository image",
+    );
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("serves functions in more than one stack from one registration", async () => {
+    // Given one registration, and two stacks running that image.
+    const simAws = new SimAws();
+
+    simAws
+      .ecr()
+      .repository("orders")
+      .simulateImage({ handler: () => "one registration" });
+
+    // When both stacks are deployed.
+    await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-api-stack",
+      template: {
+        Resources: {
+          OrdersFunction: imageFunctionResource({ functionName: "orders-api" }),
+        },
+      },
+    });
+    await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-worker-stack",
+      template: {
+        Resources: {
+          OrdersFunction: imageFunctionResource({
+            functionName: "orders-worker",
+            imageUri: `${ordersRepositoryUri}:9c3b7f`,
+          }),
+        },
+      },
+    });
+
+    // Then the handler backs the function in each stack, whatever tag each
+    // one names.
+    assertIdentical(
+      await invokePayload(simAws, "orders-api"),
+      "one registration",
+    );
+    assertIdentical(
+      await invokePayload(simAws, "orders-worker"),
+      "one registration",
+    );
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("runs the image tagged the way the template names it", async () => {
+    // Given two tags registered in one repository, as a blue/green deploy has.
+    const simAws = new SimAws();
+
+    simAws
+      .ecr()
+      .repository("orders")
+      .simulateImage({ imageTag: "blue", handler: () => "blue image" })
+      .simulateImage({ imageTag: "green", handler: () => "green image" });
+
+    // When a template names one of them.
+    await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: {
+        Resources: {
+          OrdersFunction: imageFunctionResource({
+            functionName: "orders",
+            imageUri: `${ordersRepositoryUri}:blue`,
+          }),
+        },
+      },
+    });
+
+    // Then that tag's image is the one the function runs.
+    assertIdentical(await invokePayload(simAws, "orders"), "blue image");
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("lets a deploy-time binding back a function the repository could", async () => {
+    // Given a registered repository image and a binding that both match one
+    // function.
+    const simAws = new SimAws();
+
+    simAws
+      .ecr()
+      .repository("orders")
+      .simulateImage({ handler: () => "repository image" });
+
+    // When the template is deployed with the binding.
+    await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: {
+        Resources: {
+          OrdersFunction: imageFunctionResource({ functionName: "orders" }),
+        },
+      },
+      bindings: [
+        { logicalId: "OrdersFunction", handler: () => "deploy binding" },
+      ],
+    });
+
+    // Then the binding is what backs the function, because it is the more
+    // specific thing to have said: it is about this deploy, where the
+    // repository is a standing statement about the image.
+    assertIdentical(await invokePayload(simAws, "orders"), "deploy binding");
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("skips an image whose repository nothing holds", async () => {
+    // Given a simulation with no repository of that name.
+    const simAws = new SimAws();
+
+    // When a template running an image from it is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: {
+        Resources: {
+          OrdersFunction: imageFunctionResource({ functionName: "orders" }),
+        },
+      },
+    });
+
+    await stack.waitForDeployComplete();
+
+    // Then the function is skipped, and the reason says the repository is
+    // missing rather than its image.
+    const functionResource = stack.getResource("OrdersFunction");
+
+    assertNonNullable(functionResource);
+    assertTrue(functionResource.skipped);
+    assertNonNullable(functionResource.skippedReason);
+    assertStringIncludes(
+      functionResource.skippedReason,
+      "no simulated ECR repository holds the container image",
+    );
+    assertStringIncludes(
+      functionResource.skippedReason,
+      "register one as the image in a simulated ECR repository",
+    );
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("skips an image whose repository holds no image", async () => {
+    // Given a repository made, as a platform stack declaring it makes one,
+    // with no handler registered in it.
+    const simAws = new SimAws();
+
+    simAws.ecr().repository("orders");
+
+    // When a template running an image from it is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: {
+        Resources: {
+          OrdersFunction: imageFunctionResource({ functionName: "orders" }),
+        },
+      },
+    });
+
+    await stack.waitForDeployComplete();
+
+    // Then the function is skipped, and the reason says the repository is
+    // there and its image is not, which is the other half of the answer.
+    const functionResource = stack.getResource("OrdersFunction");
+
+    assertNonNullable(functionResource);
+    assertTrue(functionResource.skipped);
+    assertNonNullable(functionResource.skippedReason);
+    assertStringIncludes(
+      functionResource.skippedReason,
+      `the simulated ECR repository ${ordersRepositoryUri} holds no image`,
+    );
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("creates a function from a repository in another account", async () => {
+    // Given an image registered in another account's registry, as a shared
+    // platform account holds one.
+    const simAws = new SimAws();
+    const repository = simAws
+      .accountRegionScope(accountIdTwoTwos)
+      .ecr()
+      .repository("orders");
+
+    repository.simulateImage({ handler: () => "another account's image" });
+
+    // When a function in the default account runs that image.
+    await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: {
+        Resources: {
+          OrdersFunction: imageFunctionResource({
+            functionName: "orders",
+            imageUri: `${repository.repositoryUri}:latest`,
+          }),
+        },
+      },
+    });
+
+    // Then it is created from that account's image, as real Lambda pulls
+    // across accounts.
+    assertIdentical(
+      await invokePayload(simAws, "orders"),
+      "another account's image",
+    );
+
+    await simAws.backgroundTasksComplete();
+  });
+});

--- a/src/service/lambda/cfn/function/sim-cfn-lambda-function-creator.ts
+++ b/src/service/lambda/cfn/function/sim-cfn-lambda-function-creator.ts
@@ -31,10 +31,11 @@ export class SimCfnLambdaFunctionCreator {
   /**
    * Create a simulated Lambda function from an AWS::Lambda::Function Resource.
    *
-   * When an executable binding targets this Resource, the binding's real
-   * in-process handler backs the function instead of the template code, so
-   * tests can step through their actual handler while still deploying it
-   * through CloudFormation.
+   * Where a real in-process handler backs this Resource, from an executable
+   * binding or from the simulated ECR repository its image URI names, that
+   * handler backs the function instead of the template code, so tests can step
+   * through their actual handler while still deploying it through
+   * CloudFormation.
    */
   async create(
     resource: SimCfnResource,
@@ -45,16 +46,17 @@ export class SimCfnLambdaFunctionCreator {
       resource,
       properties,
     );
-    const { code, bound } = simCfnLambdaCodeInput({
+    const codeInput = simCfnLambdaCodeInput({
       resource,
       functionProperties,
       bindings,
+      containerImages: this.lambda.containerImages(),
     });
 
     const skipError = this.skips.beforeCreate(
       resource,
       functionProperties,
-      bound,
+      codeInput,
     );
     if (skipError !== undefined) {
       throw skipError;
@@ -62,7 +64,10 @@ export class SimCfnLambdaFunctionCreator {
 
     try {
       await this.lambda.createFunction({
-        input: simCfnLambdaCreateFunctionInput(functionProperties, code),
+        input: simCfnLambdaCreateFunctionInput(
+          functionProperties,
+          codeInput.code,
+        ),
       });
     } catch (error) {
       const assetsSkipError = this.skips.fromCreateFailure(

--- a/src/service/lambda/cfn/function/sim-cfn-lambda-image-skip.ts
+++ b/src/service/lambda/cfn/function/sim-cfn-lambda-image-skip.ts
@@ -1,4 +1,5 @@
 import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnLambdaCodeInput } from "./sim-cfn-lambda-code-input.js";
 import type { SimCfnLambdaFunctionProperties } from "./sim-cfn-lambda-function-properties-parser.js";
 
 /**
@@ -14,9 +15,10 @@ const imagePackageType = "Image";
  * CommonJS in a vm. So the image URI is only ever an identifier, and a
  * function packaged as an image has no code Yulin can run.
  *
- * A function with an executable binding is exempt, because the binding
- * replaces the code with a real in-process handler. That is how to simulate a
- * container image function, and the skip message says so.
+ * A function a real in-process handler backs is exempt, whether that handler
+ * came from an executable binding or from the simulated ECR repository the
+ * image URI names. Those are the two ways to simulate a container image
+ * function, and the skip message says so.
  *
  * This is separate from the runtime skip because a container image function
  * declares no Runtime at all, so there is nothing there for that gate to
@@ -33,17 +35,34 @@ export class SimCfnLambdaImageSkip {
   findSkipError(
     resource: SimCfnResource,
     functionProperties: SimCfnLambdaFunctionProperties,
-    bound: boolean,
+    code: SimCfnLambdaCodeInput,
   ): Error | undefined {
-    if (bound || !this.isImagePackaged(functionProperties)) {
+    if (code.bound || !this.isImagePackaged(functionProperties)) {
       return undefined;
     }
 
     return new Error(
       `Unsupported sim Lambda CloudFormation Resource ${resource.logicalId}: ` +
-        `${this.imageDescription(functionProperties)}. Bind a real ` +
-        `in-process handler to this function to simulate it.`,
+        `${this.imageDescription(functionProperties)}${this.unsimulatedImage(code)}` +
+        `. Bind a real in-process handler to this function, or register one ` +
+        `as the image in a simulated ECR repository, to simulate it.`,
     );
+  }
+
+  /**
+   * What simulated ECR had to say about the image, where the function names
+   * one.
+   *
+   * This is the difference between a repository nothing made and a repository
+   * holding no image, which is the difference between a name that is wrong and
+   * a handler that was never registered.
+   */
+  private unsimulatedImage(code: SimCfnLambdaCodeInput): string {
+    if (code.unsimulatedImageReason === undefined) {
+      return "";
+    }
+
+    return `, and ${code.unsimulatedImageReason}`;
   }
 
   /**

--- a/src/service/lambda/command/create-function/create-function-image.iso.test.ts
+++ b/src/service/lambda/command/create-function/create-function-image.iso.test.ts
@@ -1,0 +1,164 @@
+import { CreateFunctionCommand, InvokeCommand } from "@aws-sdk/client-lambda";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimLambdaInvalidParameterValueException } from "../../error/sim-lambda.error.js";
+import { SimLambda } from "../../sim-lambda.js";
+import { makeLambdaZipFileInput } from "../../function/code/lambda-zip-file-input.js";
+
+const ordersRepositoryUri =
+  "888888888888.dkr.ecr.us-east-1.amazonaws.com/orders";
+
+const ordersRole = "arn:aws:iam::888888888888:role/OrdersRole";
+
+async function createImageFunction(
+  simAws: SimAws,
+  imageUri: string,
+): Promise<void> {
+  await simAws.lambda().createFunction(
+    new CreateFunctionCommand({
+      FunctionName: "orders",
+      Role: ordersRole,
+      PackageType: "Image",
+      Code: { ImageUri: imageUri },
+    }),
+  );
+}
+
+describe("Lambda CreateFunction from a simulated ECR image", () => {
+  it("creates a function from the image its repository holds", async () => {
+    // Given a handler registered as the image in a repository.
+    const simAws = new SimAws();
+
+    simAws
+      .ecr()
+      .repository("orders")
+      .simulateImage({ handler: () => "ran the repository image" });
+
+    // When a function is created through the SDK naming that image, with no
+    // CloudFormation and no binding anywhere.
+    await createImageFunction(simAws, `${ordersRepositoryUri}:latest`);
+
+    // Then the function runs the registered handler.
+    const output = await simAws
+      .lambda()
+      .invoke(new InvokeCommand({ FunctionName: "orders" }));
+
+    assertIdentical(output.StatusCode, 200);
+    assertUndefined(output.FunctionError);
+    assertNonNullable(output.Payload);
+    assertStringIncludes(
+      Buffer.from(output.Payload).toString(),
+      "ran the repository image",
+    );
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("refuses an image whose repository nothing holds", async () => {
+    // Given a simulation with no repository of that name.
+    const simAws = new SimAws();
+
+    // When a function naming that image is created.
+    const error = await assertThrowsErrorAsync(async () =>
+      createImageFunction(simAws, `${ordersRepositoryUri}:latest`),
+    );
+
+    // Then it is refused, as real Lambda refuses an image it cannot pull,
+    // saying the repository is what is missing.
+    assertInstanceOf(error, SimLambdaInvalidParameterValueException);
+    assertStringIncludes(
+      error.message,
+      `Source image ${ordersRepositoryUri}:latest cannot be run: no ` +
+        `simulated ECR repository holds the container image`,
+    );
+    assertStringIncludes(
+      error.message,
+      "Register a real in-process handler as the image in a simulated ECR " +
+        "repository to simulate it.",
+    );
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("refuses an image whose repository holds no image", async () => {
+    // Given a repository with no handler registered in it.
+    const simAws = new SimAws();
+
+    simAws.ecr().repository("orders");
+
+    // When a function naming an image from it is created.
+    const error = await assertThrowsErrorAsync(async () =>
+      createImageFunction(simAws, `${ordersRepositoryUri}:latest`),
+    );
+
+    // Then the refusal says the repository is there and its image is not.
+    assertStringIncludes(
+      error.message,
+      `the simulated ECR repository ${ordersRepositoryUri} holds no image`,
+    );
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("refuses an image URI alongside other function code", async () => {
+    // Given a request naming both an image and zip code, which real Lambda
+    // has no function shape for.
+    const simAws = new SimAws();
+
+    // When it is created.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.lambda().createFunction(
+        new CreateFunctionCommand({
+          FunctionName: "orders",
+          Role: ordersRole,
+          Code: {
+            ImageUri: `${ordersRepositoryUri}:latest`,
+            ZipFile: makeLambdaZipFileInput(() => "handler"),
+          },
+        }),
+      ),
+    );
+
+    // Then it is refused rather than one of the two being ignored.
+    assertInstanceOf(error, SimLambdaInvalidParameterValueException);
+    assertStringIncludes(
+      error.message,
+      "Please do not provide ZipFile bytes or an S3 object location when " +
+        "using Code.ImageUri",
+    );
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("refuses an image on a simulated Lambda with no simulated ECR", async () => {
+    // Given a standalone simulated Lambda, which is its own little universe
+    // with no simulated ECR beside it.
+    const lambda = new SimLambda();
+
+    // When a container image function is created on it.
+    const error = await assertThrowsErrorAsync(async () =>
+      lambda.createFunction(
+        new CreateFunctionCommand({
+          FunctionName: "orders",
+          Role: ordersRole,
+          Code: { ImageUri: `${ordersRepositoryUri}:latest` },
+        }),
+      ),
+    );
+
+    // Then the refusal says there is nowhere for the image to have come from.
+    assertStringIncludes(
+      error.message,
+      "as this simulated Lambda has no simulated ECR beside it",
+    );
+  });
+});

--- a/src/service/lambda/command/create-function/create-function.command.ts
+++ b/src/service/lambda/command/create-function/create-function.command.ts
@@ -15,8 +15,8 @@ export interface SimCreateFunctionCommand {
 /**
  * Minimal structural sim Lambda function code input.
  *
- * Either ZipFile bytes or an S3 object location, as on real AWS.
- * S3ObjectVersion is accepted but ignored, as sim S3 does not simulate
+ * ZipFile bytes, an S3 object location or a container image URI, as on real
+ * AWS. S3ObjectVersion is accepted but ignored, as sim S3 does not simulate
  * object versioning yet.
  */
 export interface SimLambdaFunctionCode {
@@ -24,6 +24,7 @@ export interface SimLambdaFunctionCode {
   S3Bucket?: string | undefined;
   S3Key?: string | undefined;
   S3ObjectVersion?: string | undefined;
+  ImageUri?: string | undefined;
 }
 
 /**

--- a/src/service/lambda/command/create-function/create-function.handler.ts
+++ b/src/service/lambda/command/create-function/create-function.handler.ts
@@ -13,6 +13,7 @@ import {
 import { SimLambdaResourceConflictException } from "../../error/sim-lambda.error.js";
 import type { SimLambdaExecutableCode } from "../../function/code/sim-lambda-executable-code.js";
 import { SimLambdaCodeResolver } from "../../function/code/sim-lambda-code-resolver.js";
+import type { SimLambdaContainerImages } from "../../function/code/image/sim-lambda-container-images.js";
 import type { SimLambdaCodeStore } from "../../function/code/store/sim-lambda-code-store.js";
 import type { SimLambdaVmSdkModuleProvider } from "../../function/code/vm/sdk/sim-lambda-vm-sdk-module-provider.js";
 import { SimLambdaEnvironmentConflicts } from "../../function/environment/sim-lambda-environment-conflicts.js";
@@ -41,6 +42,7 @@ interface CreateFunctionCommandHandlerProperties {
   iam?: SimIamInterServiceAuthZ;
   background?: BackgroundScheduler;
   codeStore?: SimLambdaCodeStore | undefined;
+  containerImages?: SimLambdaContainerImages | undefined;
   vmSdkModuleProvider?: SimLambdaVmSdkModuleProvider | undefined;
   environmentConflicts?: SimLambdaEnvironmentConflicts;
 }
@@ -74,6 +76,7 @@ export class CreateFunctionCommandHandler implements CommandHandler<
       iam = new SimIamAllowAllAuth(),
       background = new BackgroundTasks(),
       codeStore,
+      containerImages,
       vmSdkModuleProvider,
       environmentConflicts = new SimLambdaEnvironmentConflicts(),
     } = properties;
@@ -84,6 +87,7 @@ export class CreateFunctionCommandHandler implements CommandHandler<
     this.background = background;
     this.codeResolver = new SimLambdaCodeResolver({
       codeStore,
+      containerImages,
       vmSdkModuleProvider,
       // The background scheduler is this simulation's clock, and the same one
       // the created function is given.

--- a/src/service/lambda/command/create-function/create-function.iso.test.ts
+++ b/src/service/lambda/command/create-function/create-function.iso.test.ts
@@ -118,7 +118,7 @@ describe("Lambda CreateFunctionCommand", () => {
     assertInstanceOf(error, SimLambdaInvalidParameterValueException);
     assertStringIncludes(
       error.message,
-      "requires either ZipFile bytes or an S3Bucket and S3Key",
+      "requires either ZipFile bytes, an S3Bucket and S3Key",
     );
   });
 

--- a/src/service/lambda/command/function/sim-lambda-function-commands.ts
+++ b/src/service/lambda/command/function/sim-lambda-function-commands.ts
@@ -3,6 +3,7 @@ import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
 import type { SimAwsRunAsOwner } from "../../../aws/caller/sim-aws-run-as-context.js";
 import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
 import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import type { SimLambdaContainerImages } from "../../function/code/image/sim-lambda-container-images.js";
 import type { SimLambdaCodeStore } from "../../function/code/store/sim-lambda-code-store.js";
 import type { SimLambdaVmSdkModuleProvider } from "../../function/code/vm/sdk/sim-lambda-vm-sdk-module-provider.js";
 import type { SimLambdaEnvironmentConflicts } from "../../function/environment/sim-lambda-environment-conflicts.js";
@@ -38,6 +39,7 @@ interface SimLambdaFunctionCommandsProperties {
   readonly functionUrls: SimLambdaFunctionUrlStore;
   readonly environmentConflicts: SimLambdaEnvironmentConflicts;
   readonly codeStore?: SimLambdaCodeStore | undefined;
+  readonly containerImages?: SimLambdaContainerImages | undefined;
   readonly vmSdkModuleProvider?: SimLambdaVmSdkModuleProvider | undefined;
 }
 

--- a/src/service/lambda/function/code/image/sim-ecr-lambda-container-images.ts
+++ b/src/service/lambda/function/code/image/sim-ecr-lambda-container-images.ts
@@ -1,0 +1,57 @@
+import { SimEcrImageReference } from "../../../../ecr/image/sim-ecr-image-reference.js";
+import type { SimEcrRegistry } from "../../../../ecr/registry/sim-ecr-registry.js";
+import {
+  SimLambdaContainerImage,
+  type SimLambdaContainerImages,
+} from "./sim-lambda-container-images.js";
+
+interface SimEcrLambdaContainerImagesProperties {
+  readonly repositories: SimEcrRegistry;
+}
+
+/**
+ * The simulated ECR a container image function's image URI is resolved in.
+ *
+ * The whole simulation's repositories are read rather than one scope's,
+ * because an image URI names the account and region it comes from: a function
+ * in one account can run an image from another account's registry, as it can
+ * on real AWS.
+ *
+ * The two ways of finding nothing are reported apart, because they send a
+ * reader to different places. No repository means nothing registered a handler
+ * under that name, or registered it in another account. A repository with no
+ * image means the name was right and the handler is missing.
+ */
+export class SimEcrLambdaContainerImages implements SimLambdaContainerImages {
+  private readonly repositories: SimEcrRegistry;
+
+  constructor(properties: SimEcrLambdaContainerImagesProperties) {
+    this.repositories = properties.repositories;
+  }
+
+  /**
+   * The image a URI names, as simulated ECR holds it.
+   */
+  image(imageUri: string): SimLambdaContainerImage {
+    const repository = this.repositories.repositoryFor(imageUri);
+
+    if (repository === undefined) {
+      return SimLambdaContainerImage.unsimulated(
+        `no simulated ECR repository holds the container image ${imageUri}`,
+      );
+    }
+
+    const image = repository.image(
+      new SimEcrImageReference(imageUri).imageTag(),
+    );
+
+    if (image === undefined) {
+      return SimLambdaContainerImage.unsimulated(
+        `the simulated ECR repository ${repository.repositoryUri} holds no ` +
+          `image`,
+      );
+    }
+
+    return SimLambdaContainerImage.simulatedBy(image.handler);
+  }
+}

--- a/src/service/lambda/function/code/image/sim-lambda-container-images.ts
+++ b/src/service/lambda/function/code/image/sim-lambda-container-images.ts
@@ -1,0 +1,73 @@
+import type { SimLambdaHandler } from "../../sim-lambda-handler.type.js";
+
+/**
+ * What a container image URI resolved to.
+ *
+ * Yulin never reads an image, so an image URI is only ever an identifier. The
+ * most it can resolve to is a real in-process handler something registered as
+ * that image, and where nothing has, the reason is what a caller reports:
+ * CloudFormation puts it in a skip, and CreateFunction in a refusal.
+ */
+export class SimLambdaContainerImage {
+  public readonly handler: SimLambdaHandler | undefined;
+
+  private readonly reason: string;
+
+  private constructor(handler: SimLambdaHandler | undefined, reason: string) {
+    this.handler = handler;
+    this.reason = reason;
+  }
+
+  /**
+   * An image a real in-process handler stands in for.
+   */
+  static simulatedBy(handler: SimLambdaHandler): SimLambdaContainerImage {
+    return new SimLambdaContainerImage(handler, "");
+  }
+
+  /**
+   * An image nothing in this simulation stands in for, and why not.
+   */
+  static unsimulated(reason: string): SimLambdaContainerImage {
+    return new SimLambdaContainerImage(undefined, reason);
+  }
+
+  /**
+   * Why nothing here can run this image.
+   *
+   * Empty for an image a handler stands in for, which callers only reach when
+   * there is no handler.
+   */
+  unsimulatedReason(): string {
+    return this.reason;
+  }
+}
+
+/**
+ * Where a container image URI is resolved to something this simulation can
+ * run.
+ */
+export interface SimLambdaContainerImages {
+  /**
+   * The image this URI names, as far as this simulation can run it.
+   */
+  image(imageUri: string): SimLambdaContainerImage;
+}
+
+/**
+ * The container images of a simulated Lambda that has none to look in.
+ *
+ * A standalone SimLambda is its own little universe, with no simulated ECR
+ * beside it, so every image URI is one nothing stands in for.
+ */
+export class SimLambdaNoContainerImages implements SimLambdaContainerImages {
+  /**
+   * Never any image, whatever the URI names.
+   */
+  image(imageUri: string): SimLambdaContainerImage {
+    return SimLambdaContainerImage.unsimulated(
+      `nothing simulates the container image ${imageUri}, as this simulated ` +
+        `Lambda has no simulated ECR beside it`,
+    );
+  }
+}

--- a/src/service/lambda/function/code/lambda-code-source.ts
+++ b/src/service/lambda/function/code/lambda-code-source.ts
@@ -11,6 +11,7 @@ export interface SimLambdaCodeInput {
   S3Bucket?: string | undefined;
   S3Key?: string | undefined;
   S3ObjectVersion?: string | undefined;
+  ImageUri?: string | undefined;
 }
 
 /**
@@ -42,25 +43,42 @@ export interface SimLambdaS3LocationSource {
 }
 
 /**
+ * Function code given as a container image URI, as a function with
+ * PackageType Image names on real AWS.
+ *
+ * The URI is only ever an identifier here. What runs is whatever simulated ECR
+ * holds under the repository it names, which is resolved when the function is
+ * created, as real Lambda resolves the image then too.
+ */
+export interface SimLambdaContainerImageSource {
+  readonly kind: "container-image";
+  readonly imageUri: string;
+}
+
+/**
  * The validated source of a sim Lambda function's code.
  */
 export type SimLambdaCodeSource =
   | SimLambdaHandlerReferenceSource
   | SimLambdaZipBytesSource
-  | SimLambdaS3LocationSource;
+  | SimLambdaS3LocationSource
+  | SimLambdaContainerImageSource;
 
 /**
  * Validate CreateFunction code input into a sim Lambda code source.
  *
- * Exactly one of ZipFile or an S3 object location must be given, as on real
- * AWS. S3ObjectVersion is accepted but ignored, as sim S3 does not simulate
- * object versioning yet.
+ * Exactly one of ZipFile, an S3 object location or a container image URI must
+ * be given, as on real AWS. S3ObjectVersion is accepted but ignored, as sim S3
+ * does not simulate object versioning yet.
  */
 export function requireLambdaCodeSource(
   code: SimLambdaCodeInput | undefined,
 ): SimLambdaCodeSource {
   assertDefined(code, "CreateFunctionCommand.input.Code required");
 
+  if (code.ImageUri !== undefined) {
+    return containerImageSource(code.ImageUri, code);
+  }
   if (code.ZipFile !== undefined) {
     return zipFileSource(code.ZipFile, code);
   }
@@ -68,9 +86,31 @@ export function requireLambdaCodeSource(
     return s3LocationSource(code);
   }
   throw new SimLambdaInvalidParameterValueException(
-    "CreateFunctionCommand.input.Code requires either ZipFile bytes or an " +
-      "S3Bucket and S3Key object location",
+    "CreateFunctionCommand.input.Code requires either ZipFile bytes, an " +
+      "S3Bucket and S3Key object location, or an ImageUri",
   );
+}
+
+/**
+ * A container image function names its image and nothing else, as on real
+ * AWS, where an image function has no zip code to also name.
+ */
+function containerImageSource(
+  imageUri: string,
+  code: SimLambdaCodeInput,
+): SimLambdaContainerImageSource {
+  if (
+    code.ZipFile !== undefined ||
+    code.S3Bucket !== undefined ||
+    code.S3Key !== undefined
+  ) {
+    throw new SimLambdaInvalidParameterValueException(
+      "Please do not provide ZipFile bytes or an S3 object location when " +
+        "using Code.ImageUri",
+    );
+  }
+
+  return { kind: "container-image", imageUri };
 }
 
 function zipFileSource(

--- a/src/service/lambda/function/code/sim-lambda-code-resolver.ts
+++ b/src/service/lambda/function/code/sim-lambda-code-resolver.ts
@@ -1,6 +1,11 @@
 import type { SimClock } from "../../../../util/clock/sim-clock.js";
+import { SimLambdaInvalidParameterValueException } from "../../error/sim-lambda.error.js";
 import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
 import type { SimLambdaEnvironment } from "../environment/sim-lambda-environment.js";
+import {
+  type SimLambdaContainerImages,
+  SimLambdaNoContainerImages,
+} from "./image/sim-lambda-container-images.js";
 import type { SimLambdaCodeSource } from "./lambda-code-source.js";
 import {
   type SimLambdaExecutableCode,
@@ -11,11 +16,16 @@ import {
   type SimLambdaCodeStore,
   SimLambdaNoCodeStore,
 } from "./store/sim-lambda-code-store.js";
+import type { SimLambdaHandler } from "../sim-lambda-handler.type.js";
 import type { SimLambdaVmSdkModuleProvider } from "./vm/sdk/sim-lambda-vm-sdk-module-provider.js";
 
 interface SimLambdaCodeResolverProperties {
   readonly codeStore?: SimLambdaCodeStore | undefined;
   readonly vmSdkModuleProvider?: SimLambdaVmSdkModuleProvider | undefined;
+  /**
+   * Where a container image URI is resolved to a real in-process handler.
+   */
+  readonly containerImages?: SimLambdaContainerImages | undefined;
   /**
    * Clock vm zip code reports as the current time. A handler reference needs
    * none: it runs in the host scope, where the invocation bridges the clock.
@@ -44,10 +54,13 @@ export interface SimLambdaCodeResolveContext {
  */
 export class SimLambdaCodeResolver {
   private readonly codeStore: SimLambdaCodeStore;
+  private readonly containerImages: SimLambdaContainerImages;
   private readonly vmZipCodeFactory: SimLambdaVmZipCodeFactory;
 
   constructor(properties: SimLambdaCodeResolverProperties) {
     this.codeStore = properties.codeStore ?? new SimLambdaNoCodeStore();
+    this.containerImages =
+      properties.containerImages ?? new SimLambdaNoContainerImages();
     this.vmZipCodeFactory = new SimLambdaVmZipCodeFactory({
       vmSdkModuleProvider: properties.vmSdkModuleProvider,
       clock: properties.clock,
@@ -76,6 +89,33 @@ export class SimLambdaCodeResolver {
         });
         return this.vmZipCodeFactory.make(zipBytes, context);
       }
+      case "container-image": {
+        return new SimLambdaHandlerReferenceCode(
+          this.containerImageHandler(source.imageUri),
+        );
+      }
     }
+  }
+
+  /**
+   * The handler standing in for a container image, refusing the function where
+   * nothing stands in for it.
+   *
+   * Real Lambda refuses a function whose image it cannot pull, so refusing
+   * here is the closest thing to that: an image URI is an identifier, and one
+   * naming nothing this simulation holds is a function with no code.
+   */
+  private containerImageHandler(imageUri: string): SimLambdaHandler {
+    const image = this.containerImages.image(imageUri);
+
+    if (image.handler === undefined) {
+      throw new SimLambdaInvalidParameterValueException(
+        `Source image ${imageUri} cannot be run: ` +
+          `${image.unsimulatedReason()}. Register a real in-process handler ` +
+          `as the image in a simulated ECR repository to simulate it.`,
+      );
+    }
+
+    return image.handler;
   }
 }

--- a/src/service/lambda/sim-lambda-commands.ts
+++ b/src/service/lambda/sim-lambda-commands.ts
@@ -22,6 +22,10 @@ import {
   type SimLambdaEventSourceStreams,
   SimLambdaNoEventSourceStreams,
 } from "./event-source/stream/sim-lambda-event-source-streams.js";
+import {
+  type SimLambdaContainerImages,
+  SimLambdaNoContainerImages,
+} from "./function/code/image/sim-lambda-container-images.js";
 import type { SimLambdaCodeStore } from "./function/code/store/sim-lambda-code-store.js";
 import type { SimLambdaVmSdkModuleProvider } from "./function/code/vm/sdk/sim-lambda-vm-sdk-module-provider.js";
 import { SimLambdaEnvironmentConflicts } from "./function/environment/sim-lambda-environment-conflicts.js";
@@ -39,6 +43,7 @@ export interface SimLambdaProperties {
   readonly background?: BackgroundScheduler;
   readonly runAsOwner?: SimAwsRunAsOwner;
   readonly codeStore?: SimLambdaCodeStore;
+  readonly containerImages?: SimLambdaContainerImages;
   readonly vmSdkModuleProvider?: SimLambdaVmSdkModuleProvider;
   readonly urlRegistry?: SimLambdaUrlRegistry;
   readonly eventSourceQueues?: SimLambdaEventSourceQueues;
@@ -59,6 +64,13 @@ interface SimLambdaCommandsProperties extends SimLambdaProperties {
  * through the area it belongs to.
  */
 export class SimLambdaCommands {
+  /**
+   * Where a container image function's image URI is resolved to a real
+   * in-process handler. Read by CloudFormation as well as by CreateFunction,
+   * since a template function names an image the same way an SDK caller does.
+   */
+  public readonly containerImages: SimLambdaContainerImages;
+
   public readonly functionUrlStore: SimLambdaFunctionUrlStore;
   public readonly functionLookup: SimLambdaFunctionLookup;
   public readonly functions: SimLambdaFunctionCommands;
@@ -82,7 +94,12 @@ export class SimLambdaCommands {
       // delivering.
       eventSourceQueues = new SimLambdaNoEventSourceQueues(),
       eventSourceStreams = new SimLambdaNoEventSourceStreams(),
+      // A standalone SimLambda has no simulated ECR beside it, so a container
+      // image function created on one has nothing to resolve its image in.
+      containerImages = new SimLambdaNoContainerImages(),
     } = properties;
+
+    this.containerImages = containerImages;
 
     this.functionLookup = new SimLambdaFunctionLookup({
       accountRegionScope,
@@ -129,6 +146,7 @@ export class SimLambdaCommands {
       // is only reported once for this simulated Lambda.
       environmentConflicts: new SimLambdaEnvironmentConflicts(),
       codeStore,
+      containerImages,
       vmSdkModuleProvider,
     });
   }

--- a/src/service/lambda/sim-lambda.ts
+++ b/src/service/lambda/sim-lambda.ts
@@ -3,6 +3,7 @@ import type { SimAwsCaller } from "../aws/caller/sim-aws-caller.js";
 import type { SimCfnServiceResourceFactory } from "../cloudformation/resource/factory/sim-cfn-resource-factory.type.js";
 import { SimLambdaCloudFormationResourceFactory } from "./cfn/sim-cfn-lambda-resource-factory.js";
 import type { SimLambdaEventSourceMapping } from "./event-source/sim-lambda-event-source-mapping.js";
+import type { SimLambdaContainerImages } from "./function/code/image/sim-lambda-container-images.js";
 import type {
   SimLambdaFunction,
   SimLambdaFunctionMap,
@@ -33,6 +34,7 @@ export class SimLambda {
   private readonly cfnFactory = new SimLambdaCloudFormationResourceFactory(
     this,
   );
+
   private readonly sdkRouter = new SimLambdaSdkCommandRouter(this);
 
   constructor(properties: SimLambdaProperties = {}) {
@@ -44,6 +46,18 @@ export class SimLambda {
       // ambient callers.
       runAsOwner: properties.runAsOwner ?? this,
     });
+  }
+
+  /**
+   * Where this simulated Lambda resolves a container image URI to a real
+   * in-process handler.
+   *
+   * Read by the CloudFormation Resource factory, which decides whether a
+   * template's container image function can be created or has to be skipped.
+   * @internal
+   */
+  containerImages(): SimLambdaContainerImages {
+    return this.commands.containerImages;
   }
 
   /**


### PR DESCRIPTION
Adds a simulated ECR holding repositories, each holding images by tag, where a simulated image is a real in-process handler. A Lambda function whose `Code.ImageUri` resolves to a repository is created from that handler rather than skipped, from a template or from `CreateFunction`, so one registration in test setup serves several stacks and outlives any of them; a deploy-time image binding still wins where both could back the same function, and the skip reason now tells a missing repository apart from a repository holding no image. Registering a handler is the Yulin-native `simulateImage` rather than a simulated `PutImage`, because real `PutImage` takes a manifest for layers pushed over the Docker registry protocol and none of that exists in this process, which the docs record as a deliberate divergence. `AWS::ECR::Repository` creates a repository and answers `Ref`, `Arn` and `RepositoryUri`, adopting one a handler is already registered in, since a template declares a repository and never an image. Image layers, digests, manifests, scan findings and lifecycle evaluation are all out of scope and listed under Limitations. The services whose wiring says nothing but which scope they are in move to their own builder, which is what keeps the account/region service builder under its line limit as ECR joins it.

Resolves https://github.com/KensioSoftware/yulin/issues/552

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added simulated Amazon ECR repositories and image registration.
  * Added support for deploying and invoking Lambda functions from simulated ECR images, including image tags and cross-account or cross-region resolution.
  * Added CloudFormation support for ECR repositories, including repository names, ARNs, URIs, outputs, adoption, and deletion.
  * Added an ECR service export and direct service access.
* **Documentation**
  * Added ECR usage guidance and executable examples for repositories, image tags, Lambda functions, and CloudFormation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->