### PR TITLE
feat: route ALB requests to Lambda targets

### DIFF
--- a/docs/services/elbv2/README.md
+++ b/docs/services/elbv2/README.md
@@ -388,14 +388,20 @@ in it.
 
 Every field is always there. A request with no query string carries an empty `queryStringParameters`
 rather than none, and one with no body carries an empty `body`. Cookies stay in the `cookie` header
-they arrived in rather than being lifted into a field of their own. The load balancer writes `host`,
-`x-amzn-trace-id`, `x-forwarded-for`, `x-forwarded-port` and `x-forwarded-proto` itself, so whatever
-a client sent under those names does not survive.
+they arrived in rather than being lifted into a field of their own. Query string values arrive as
+they were sent, since real ELB does not decode percent escapes and leaves that to the function.
+
+The load balancer writes `host`, `x-amzn-trace-id`, `x-forwarded-port` and `x-forwarded-proto`
+itself, so whatever a client sent under those names does not survive. `x-forwarded-for` is the
+exception: the client's address is appended to what the request already carried, which is what makes
+that header a chain of proxies.
 
 A body is passed through as text for `text/*`, `application/json`, `application/javascript` and
 `application/xml`, and base64 encoded otherwise, with `isBase64Encoded` saying which happened. A
 request carrying a `content-encoding` header is always base64. That list is shorter than API
-Gateway's: a form post is text to API Gateway and base64 to a load balancer.
+Gateway's: a form post is text to API Gateway and base64 to a load balancer. A body called text that
+is not valid UTF-8 fails the invocation rather than reaching the handler with replacement characters
+in it.
 
 The response has to carry a `statusCode`. `statusDescription`, `headers`, `body` and
 `isBase64Encoded` are all optional, and a `statusDescription` of `200 OK` becomes the reason phrase
@@ -489,8 +495,9 @@ registered in it.
 
 A 502 means there was a target and it did not produce a response. A missing invoke permission, a
 function that is not there, a handler that threw, a result with no usable `statusCode`, and a
-response body over 1 MB are all 502, as they are on real ELB, where the difference between them is
-only visible in the load balancer's own logs.
+response over 1 MB are all 502, as they are on real ELB, where the difference between them is only
+visible in the load balancer's own logs. The response limit is on the whole response document rather
+than on the body alone, so a base64 body counts at its encoded size.
 
 A request body over 1 MB is a 413, which is the limit on what real ELB sends to a Lambda target.
 
@@ -729,6 +736,9 @@ console.log(created.LoadBalancers?.[0]?.DNSName);
   are each refused when the request arrives rather than answered with something else.
 - A request only reaches a load balancer through `simElbV2Fetch`. Nothing resolves a load balancer's
   DNS name yet, so `serveSimAws` does not serve one and a Route53 alias to one does not answer.
+- No TLS is performed. `simElbV2Fetch` reads only the port out of a URL, so an `https:` URL reaches
+  the listener on 443 without a handshake and without being checked against that listener's
+  protocol. HTTPS listeners and their certificates follow separately.
 - The invoke permission is checked when the request arrives, where real ELB checks it when a Lambda
   target is registered and refuses `RegisterTargets` without it. A target naming a function in
   another Account or Region is registered here and then answers 502, where real ELB refuses the

--- a/docs/services/elbv2/README.md
+++ b/docs/services/elbv2/README.md
@@ -5,10 +5,12 @@ balancers, target groups, listeners and listener rules are held in memory and ev
 authorized by simulated IAM. ELBv2-specific types are imported from the `@kensio/yulin/elbv2`
 subpath.
 
-This is the state an Application Load Balancer holds. A load balancer created here has a DNS name of
-the shape real ELB issues, so a [Route53](../route53/) alias or a [CloudFront](../cloudfront/) origin
-has something of the right form to point at, and its listeners and rules say what it would do with a
-request. Answering a request is separate work that follows.
+A load balancer created here has a DNS name of the shape real ELB issues, so a
+[Route53](../route53/) alias or a [CloudFront](../cloudfront/) origin has something of the right form
+to point at. It also carries a request: a request is matched to a listener by port, and the
+listener's default `forward` action sends it to a target group, where a registered
+[Lambda](../lambda/) function is invoked with the request and its response becomes the HTTP
+response.
 
 Only the application load balancer is simulated. A network or gateway load balancer routes below
 HTTP, which nothing here speaks, so `Type: "network"` is refused rather than created as an
@@ -267,6 +269,249 @@ rules about is `SetRulePriorities`, which reorders a whole listener, and which j
 against the order it would leave behind rather than the one it started from, so two rules can swap
 places in one request.
 
+## Carrying a request to a Lambda function
+
+`simElbV2Fetch` sends a request to whichever load balancer its host name names, in process and
+without a socket. The port in the URL is the listener's, so `http://<dns-name>/orders` reaches the
+listener on port 80.
+
+The listener's default action decides what happens next. A `forward` action sends the request to its
+target group, and a `lambda` target group invokes the function registered in it.
+
+```typescript sim-elbv2-serve-lambda-target
+/**
+ * A request carried through a load balancer to a Lambda function.
+ */
+
+import {
+  CreateListenerCommand,
+  CreateLoadBalancerCommand,
+  CreateTargetGroupCommand,
+  RegisterTargetsCommand,
+} from "@aws-sdk/client-elastic-load-balancing-v2";
+import {
+  AddPermissionCommand,
+  CreateFunctionCommand,
+} from "@aws-sdk/client-lambda";
+
+import { SimAws } from "@kensio/yulin";
+import type { SimElbV2Event, SimElbV2Result } from "@kensio/yulin/elbv2";
+import { simElbV2Fetch } from "@kensio/yulin/elbv2";
+import { makeLambdaZipFileInput } from "@kensio/yulin/lambda";
+
+const simAws = new SimAws();
+const region = simAws.account("888888888888").region("eu-west-1");
+
+const created = await region.lambda().createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "checkout",
+    Role: "arn:aws:iam::888888888888:role/CheckoutRole",
+    Code: {
+      ZipFile: makeLambdaZipFileInput(
+        (event: SimElbV2Event): SimElbV2Result => ({
+          statusCode: 200,
+          statusDescription: "200 OK",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ path: event.path, method: event.httpMethod }),
+          isBase64Encoded: false,
+        }),
+      ),
+    },
+  }),
+);
+
+const elbV2 = region.elbV2();
+
+const loadBalancer = await elbV2.createLoadBalancer(
+  new CreateLoadBalancerCommand({ Name: "shop-alb" }),
+);
+const targetGroup = await elbV2.createTargetGroup(
+  new CreateTargetGroupCommand({ Name: "checkout-tg", TargetType: "lambda" }),
+);
+
+const targetGroupArn = targetGroup.TargetGroups?.[0]?.TargetGroupArn;
+
+// Without this the load balancer cannot invoke the function, and every request
+// gets a 502.
+await region.lambda().addPermission(
+  new AddPermissionCommand({
+    FunctionName: "checkout",
+    StatementId: "elb-invoke",
+    Action: "lambda:InvokeFunction",
+    Principal: "elasticloadbalancing.amazonaws.com",
+    SourceArn: targetGroupArn,
+  }),
+);
+
+await elbV2.registerTargets(
+  new RegisterTargetsCommand({
+    TargetGroupArn: targetGroupArn,
+    Targets: [{ Id: created.FunctionArn }],
+  }),
+);
+
+await elbV2.createListener(
+  new CreateListenerCommand({
+    LoadBalancerArn: loadBalancer.LoadBalancers?.[0]?.LoadBalancerArn,
+    Protocol: "HTTP",
+    Port: 80,
+    DefaultActions: [{ Type: "forward", TargetGroupArn: targetGroupArn }],
+  }),
+);
+
+const dnsName = loadBalancer.LoadBalancers?.[0]?.DNSName;
+
+const response = await simElbV2Fetch(simAws, `http://${dnsName}/orders`);
+
+console.log(response.status); // 200
+console.log(response.statusText); // "OK"
+console.log(await response.json()); // { path: "/orders", method: "GET" }
+```
+
+### The event and the response
+
+The event is ELB's own shape, not either API Gateway payload format. A handler can tell them apart by
+the request context: an ALB event has an `elb` block carrying the target group ARN, and nothing else
+in it.
+
+```typescript
+{
+  requestContext: { elb: { targetGroupArn: "arn:aws:elasticloadbalancing:..." } },
+  httpMethod: "GET",
+  path: "/orders",
+  queryStringParameters: { page: "2" },
+  headers: { host: "shop-alb-0000000001.eu-west-1.elb.amazonaws.com", ... },
+  body: "",
+  isBase64Encoded: false,
+}
+```
+
+Every field is always there. A request with no query string carries an empty `queryStringParameters`
+rather than none, and one with no body carries an empty `body`. Cookies stay in the `cookie` header
+they arrived in rather than being lifted into a field of their own. The load balancer writes `host`,
+`x-amzn-trace-id`, `x-forwarded-for`, `x-forwarded-port` and `x-forwarded-proto` itself, so whatever
+a client sent under those names does not survive.
+
+A body is passed through as text for `text/*`, `application/json`, `application/javascript` and
+`application/xml`, and base64 encoded otherwise, with `isBase64Encoded` saying which happened. A
+request carrying a `content-encoding` header is always base64. That list is shorter than API
+Gateway's: a form post is text to API Gateway and base64 to a load balancer.
+
+The response has to carry a `statusCode`. `statusDescription`, `headers`, `body` and
+`isBase64Encoded` are all optional, and a `statusDescription` of `200 OK` becomes the reason phrase
+`OK`, since the status line already has the code. Hop-by-hop headers and `content-length` are
+dropped, because the load balancer writes those itself.
+
+### What a load balancer answers itself
+
+```typescript sim-elbv2-serve-errors
+/**
+ * What a load balancer answers when its target cannot serve the request.
+ */
+
+import {
+  CreateListenerCommand,
+  CreateLoadBalancerCommand,
+  CreateTargetGroupCommand,
+  RegisterTargetsCommand,
+} from "@aws-sdk/client-elastic-load-balancing-v2";
+import {
+  AddPermissionCommand,
+  CreateFunctionCommand,
+} from "@aws-sdk/client-lambda";
+
+import { SimAws } from "@kensio/yulin";
+import { simElbV2Fetch } from "@kensio/yulin/elbv2";
+import { makeLambdaZipFileInput } from "@kensio/yulin/lambda";
+
+const simAws = new SimAws();
+const simLambda = simAws.lambda();
+const elbV2 = simAws.elbV2();
+
+const created = await simLambda.createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "checkout",
+    Role: "arn:aws:iam::888888888888:role/CheckoutRole",
+    // A handler written for an API Gateway proxy integration, which returns no
+    // status code of its own.
+    Code: { ZipFile: makeLambdaZipFileInput(() => ({ body: "checkout" })) },
+  }),
+);
+
+const loadBalancer = await elbV2.createLoadBalancer(
+  new CreateLoadBalancerCommand({ Name: "shop-alb" }),
+);
+const targetGroup = await elbV2.createTargetGroup(
+  new CreateTargetGroupCommand({ Name: "checkout-tg", TargetType: "lambda" }),
+);
+
+const targetGroupArn = targetGroup.TargetGroups?.[0]?.TargetGroupArn;
+const dnsName = loadBalancer.LoadBalancers?.[0]?.DNSName;
+
+await elbV2.createListener(
+  new CreateListenerCommand({
+    LoadBalancerArn: loadBalancer.LoadBalancers?.[0]?.LoadBalancerArn,
+    Protocol: "HTTP",
+    Port: 80,
+    DefaultActions: [{ Type: "forward", TargetGroupArn: targetGroupArn }],
+  }),
+);
+
+// Nothing is registered yet, so there is no target to send the request to.
+const empty = await simElbV2Fetch(simAws, `http://${dnsName}/orders`);
+
+console.log(empty.status); // 503
+
+await simLambda.addPermission(
+  new AddPermissionCommand({
+    FunctionName: "checkout",
+    StatementId: "elb-invoke",
+    Action: "lambda:InvokeFunction",
+    Principal: "elasticloadbalancing.amazonaws.com",
+    SourceArn: targetGroupArn,
+  }),
+);
+await elbV2.registerTargets(
+  new RegisterTargetsCommand({
+    TargetGroupArn: targetGroupArn,
+    Targets: [{ Id: created.FunctionArn }],
+  }),
+);
+
+// The function runs now, and what it returns is not a response ELB can send.
+const malformed = await simElbV2Fetch(simAws, `http://${dnsName}/orders`);
+
+console.log(malformed.status); // 502
+```
+
+A 503 means there was no target to send the request to, which is a target group with nothing
+registered in it.
+
+A 502 means there was a target and it did not produce a response. A missing invoke permission, a
+function that is not there, a handler that threw, a result with no usable `statusCode`, and a
+response body over 1 MB are all 502, as they are on real ELB, where the difference between them is
+only visible in the load balancer's own logs.
+
+A request body over 1 MB is a 413, which is the limit on what real ELB sends to a Lambda target.
+
+A host name no load balancer answers on, and a port no listener holds, both throw a
+`SimElbV2ConnectionRefusedError` rather than answering. Neither reaches a load balancer on real AWS
+either: one resolves to nothing and the other refuses the connection, so there is no status for
+either.
+
+### The invoke permission
+
+A load balancer invokes a Lambda function through the function's resource-based policy, exactly as
+real ELB does. The grant names `elasticloadbalancing.amazonaws.com` as the principal and the target
+group as the source ARN, and the load balancer supplies the target group's own Account as the source
+Account, so a policy written with the `aws:SourceAccount` condition the ELB documentation recommends
+matches.
+
+Forgetting the grant is a common way to end up with a load balancer that looks configured and serves
+nothing but 502s. Real ELB refuses to register a Lambda target at all until the permission is there;
+here the permission is checked when the request arrives instead, so a target group can be built in
+any order and a policy that is later removed stops the requests.
+
 ## Deleting
 
 Deleting a load balancer takes its listeners and their rules with it, and leaves its target groups
@@ -468,13 +713,34 @@ console.log(created.LoadBalancers?.[0]?.DNSName);
   `http-header`, `http-request-method`, `query-string` and `source-ip` conditions. A condition is
   read through its own field's configuration, so one carrying another field's is refused.
 - Paged describes with `PageSize` and `Marker`.
+- Carrying a request through `simElbV2Fetch`: a listener matched by port, its default `forward`
+  action, and a `lambda` target group invoking its function with an ALB-shaped event.
+- The load balancer's own 503, 502 and 413, and the invoke permission the function's resource policy
+  has to grant `elasticloadbalancing.amazonaws.com`.
 - IAM authorization against the ARN of whatever an operation names.
 - SDK interception of `ElasticLoadBalancingV2Client`.
 
 ## Limitations
 
-- Nothing routes a request yet. Listeners, rules and target groups say what would happen to one, and
-  a simulated load balancer answers nothing.
+- Only a listener's default action carries a request. Listener rules are stored and are not matched
+  against a request, so every request a listener takes is answered by its default action.
+- Only a `forward` action to a `lambda` target group is performed. A `fixed-response` or `redirect`
+  default action, an `ip` target group, and a `ForwardConfig` naming several target groups by weight
+  are each refused when the request arrives rather than answered with something else.
+- A request only reaches a load balancer through `simElbV2Fetch`. Nothing resolves a load balancer's
+  DNS name yet, so `serveSimAws` does not serve one and a Route53 alias to one does not answer.
+- The invoke permission is checked when the request arrives, where real ELB checks it when a Lambda
+  target is registered and refuses `RegisterTargets` without it. A target naming a function in
+  another Account or Region is registered here and then answers 502, where real ELB refuses the
+  registration.
+- Multi-value headers are not simulated. `lambda.multi_value_headers.enabled` cannot be set, since
+  target group attributes are not simulated, so the event and the accepted response always use the
+  single-value `headers` and `queryStringParameters` fields. A repeated query string key keeps its
+  last value, as real ELB does with the attribute off, while repeated request headers arrive already
+  joined with commas rather than reduced to the last one.
+- Health check requests are never sent to a Lambda target, so a handler will not see the
+  `ELB-HealthChecker/2.0` event real ELB sends when health checks are enabled on a `lambda` target
+  group.
 - Network and gateway load balancers are not simulated. `Type: "network"` and `"gateway"` are
   refused, as are the `TCP`, `TLS`, `UDP`, `TCP_UDP` and `GENEVE` protocols.
 - `TargetType: "instance"` and `"alb"` are refused rather than accepted and ignored, and a target
@@ -496,8 +762,7 @@ console.log(created.LoadBalancers?.[0]?.DNSName);
   exchange, and treating one as a plain forward would quietly skip authentication. Since those are
   the only actions that may precede a routing action, a listener or rule takes exactly one action
   here and a longer list is refused.
-- Load balancer attributes, access logs, listener certificates as a separate resource, trust stores,
-  tags as a readable resource, and weighted forwarding across target groups are not simulated. A
-  `ForwardConfig` naming several target groups is stored and its weights are not acted on.
+- Load balancer and target group attributes, access logs, listener certificates as a separate
+  resource, trust stores, and tags as a readable resource are not simulated.
 - There is no CloudFormation support yet, so `AWS::ElasticLoadBalancingV2::*` resources in a template
   are not deployed.

--- a/docs/services/elbv2/sim-elbv2-serve-errors.example.ts
+++ b/docs/services/elbv2/sim-elbv2-serve-errors.example.ts
@@ -1,0 +1,77 @@
+/**
+ * What a load balancer answers when its target cannot serve the request.
+ */
+
+import {
+  CreateListenerCommand,
+  CreateLoadBalancerCommand,
+  CreateTargetGroupCommand,
+  RegisterTargetsCommand,
+} from "@aws-sdk/client-elastic-load-balancing-v2";
+import {
+  AddPermissionCommand,
+  CreateFunctionCommand,
+} from "@aws-sdk/client-lambda";
+
+import { SimAws } from "@kensio/yulin";
+import { simElbV2Fetch } from "@kensio/yulin/elbv2";
+import { makeLambdaZipFileInput } from "@kensio/yulin/lambda";
+
+const simAws = new SimAws();
+const simLambda = simAws.lambda();
+const elbV2 = simAws.elbV2();
+
+const created = await simLambda.createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "checkout",
+    Role: "arn:aws:iam::888888888888:role/CheckoutRole",
+    // A handler written for an API Gateway proxy integration, which returns no
+    // status code of its own.
+    Code: { ZipFile: makeLambdaZipFileInput(() => ({ body: "checkout" })) },
+  }),
+);
+
+const loadBalancer = await elbV2.createLoadBalancer(
+  new CreateLoadBalancerCommand({ Name: "shop-alb" }),
+);
+const targetGroup = await elbV2.createTargetGroup(
+  new CreateTargetGroupCommand({ Name: "checkout-tg", TargetType: "lambda" }),
+);
+
+const targetGroupArn = targetGroup.TargetGroups?.[0]?.TargetGroupArn;
+const dnsName = loadBalancer.LoadBalancers?.[0]?.DNSName;
+
+await elbV2.createListener(
+  new CreateListenerCommand({
+    LoadBalancerArn: loadBalancer.LoadBalancers?.[0]?.LoadBalancerArn,
+    Protocol: "HTTP",
+    Port: 80,
+    DefaultActions: [{ Type: "forward", TargetGroupArn: targetGroupArn }],
+  }),
+);
+
+// Nothing is registered yet, so there is no target to send the request to.
+const empty = await simElbV2Fetch(simAws, `http://${dnsName}/orders`);
+
+console.log(empty.status); // 503
+
+await simLambda.addPermission(
+  new AddPermissionCommand({
+    FunctionName: "checkout",
+    StatementId: "elb-invoke",
+    Action: "lambda:InvokeFunction",
+    Principal: "elasticloadbalancing.amazonaws.com",
+    SourceArn: targetGroupArn,
+  }),
+);
+await elbV2.registerTargets(
+  new RegisterTargetsCommand({
+    TargetGroupArn: targetGroupArn,
+    Targets: [{ Id: created.FunctionArn }],
+  }),
+);
+
+// The function runs now, and what it returns is not a response ELB can send.
+const malformed = await simElbV2Fetch(simAws, `http://${dnsName}/orders`);
+
+console.log(malformed.status); // 502

--- a/docs/services/elbv2/sim-elbv2-serve-lambda-target.example.ts
+++ b/docs/services/elbv2/sim-elbv2-serve-lambda-target.example.ts
@@ -1,0 +1,87 @@
+/**
+ * A request carried through a load balancer to a Lambda function.
+ */
+
+import {
+  CreateListenerCommand,
+  CreateLoadBalancerCommand,
+  CreateTargetGroupCommand,
+  RegisterTargetsCommand,
+} from "@aws-sdk/client-elastic-load-balancing-v2";
+import {
+  AddPermissionCommand,
+  CreateFunctionCommand,
+} from "@aws-sdk/client-lambda";
+
+import { SimAws } from "@kensio/yulin";
+import type { SimElbV2Event, SimElbV2Result } from "@kensio/yulin/elbv2";
+import { simElbV2Fetch } from "@kensio/yulin/elbv2";
+import { makeLambdaZipFileInput } from "@kensio/yulin/lambda";
+
+const simAws = new SimAws();
+const region = simAws.account("888888888888").region("eu-west-1");
+
+const created = await region.lambda().createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "checkout",
+    Role: "arn:aws:iam::888888888888:role/CheckoutRole",
+    Code: {
+      ZipFile: makeLambdaZipFileInput(
+        (event: SimElbV2Event): SimElbV2Result => ({
+          statusCode: 200,
+          statusDescription: "200 OK",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ path: event.path, method: event.httpMethod }),
+          isBase64Encoded: false,
+        }),
+      ),
+    },
+  }),
+);
+
+const elbV2 = region.elbV2();
+
+const loadBalancer = await elbV2.createLoadBalancer(
+  new CreateLoadBalancerCommand({ Name: "shop-alb" }),
+);
+const targetGroup = await elbV2.createTargetGroup(
+  new CreateTargetGroupCommand({ Name: "checkout-tg", TargetType: "lambda" }),
+);
+
+const targetGroupArn = targetGroup.TargetGroups?.[0]?.TargetGroupArn;
+
+// Without this the load balancer cannot invoke the function, and every request
+// gets a 502.
+await region.lambda().addPermission(
+  new AddPermissionCommand({
+    FunctionName: "checkout",
+    StatementId: "elb-invoke",
+    Action: "lambda:InvokeFunction",
+    Principal: "elasticloadbalancing.amazonaws.com",
+    SourceArn: targetGroupArn,
+  }),
+);
+
+await elbV2.registerTargets(
+  new RegisterTargetsCommand({
+    TargetGroupArn: targetGroupArn,
+    Targets: [{ Id: created.FunctionArn }],
+  }),
+);
+
+await elbV2.createListener(
+  new CreateListenerCommand({
+    LoadBalancerArn: loadBalancer.LoadBalancers?.[0]?.LoadBalancerArn,
+    Protocol: "HTTP",
+    Port: 80,
+    DefaultActions: [{ Type: "forward", TargetGroupArn: targetGroupArn }],
+  }),
+);
+
+const dnsName = loadBalancer.LoadBalancers?.[0]?.DNSName;
+
+const response = await simElbV2Fetch(simAws, `http://${dnsName}/orders`);
+
+console.log(response.status); // 200
+console.log(response.statusText); // "OK"
+console.log(await response.json()); // { path: "/orders", method: "GET" }

--- a/src/serve/controller/factory/sim-aws-service-controller-factory.ts
+++ b/src/serve/controller/factory/sim-aws-service-controller-factory.ts
@@ -3,6 +3,7 @@ import type { SimAws } from "../../../service/aws/sim-aws.js";
 import { SimApiGatewayV2ServiceController } from "../../../service/apigatewayv2/serve/sim-api-gateway-v2-controller.js";
 import { SimCloudFrontServiceController } from "../../../service/cloudfront/controller/sim-cloudfront-controller.js";
 import { SimCognitoServiceController } from "../../../service/cognito/serve/sim-cognito-controller.js";
+import { SimElbV2ServiceController } from "../../../service/elbv2/serve/sim-elbv2-controller.js";
 import { SimLambdaServiceController } from "../../../service/lambda/serve/sim-lambda-controller.js";
 import { SimRoute53ServiceController } from "../../../service/route53/serve/sim-route53-controller.js";
 import { SimS3ServiceController } from "../../../service/s3/serve/sim-s3-controller.js";
@@ -34,6 +35,9 @@ export class SimAwsServiceControllerFactory {
       }
       case "apiGatewayV2": {
         return new SimApiGatewayV2ServiceController({ simAws: this.simAws });
+      }
+      case "elbV2": {
+        return new SimElbV2ServiceController({ simAws: this.simAws });
       }
       case "cognitoIdentityProvider": {
         return new SimCognitoServiceController({ simAws: this.simAws });

--- a/src/serve/controller/sim-aws-service-signing-name.ts
+++ b/src/serve/controller/sim-aws-service-signing-name.ts
@@ -32,5 +32,11 @@ export function simAwsServiceSigningName(
       // apigateway control plane that created the API.
       return "execute-api";
     }
+    case "elbV2": {
+      // Nothing signs a request to a load balancer: what it serves is an
+      // ordinary application rather than an AWS API. The name is here so the
+      // mapping stays complete.
+      return "elasticloadbalancing";
+    }
   }
 }

--- a/src/serve/controller/sim-service-controller.ts
+++ b/src/serve/controller/sim-service-controller.ts
@@ -22,7 +22,8 @@ export interface SimAwsServiceTarget {
     | "lambda"
     | "route53"
     | "cognitoIdentityProvider"
-    | "apiGatewayV2";
+    | "apiGatewayV2"
+    | "elbV2";
   readonly resourceName: string;
   // regionName is used for validation, not look-up
   readonly regionName?: AwsRegionName;

--- a/src/serve/http/sim-aws-proxied-connection.ts
+++ b/src/serve/http/sim-aws-proxied-connection.ts
@@ -1,14 +1,14 @@
 import { faker } from "@faker-js/faker";
 
 /**
- * The client address a simulated invocation is reported as coming from.
+ * The client address a simulated proxied request is reported as coming from.
  *
  * Requests reach a simulated endpoint over localhost or not over a socket at
  * all, so there is no remote address to report. Everything a handler can see
  * about the caller's network origin says loopback rather than pretending to a
  * public address the simulation does not have.
  */
-export const simPayload2SourceIp = "127.0.0.1";
+export const simAwsProxiedSourceIp = "127.0.0.1";
 
 /**
  * Build the X-Ray trace header AWS stamps on a proxied request.
@@ -17,8 +17,11 @@ export const simPayload2SourceIp = "127.0.0.1";
  * encodes when the trace started. Nothing here is a real trace: X-Ray is not
  * simulated, and this exists because a handler reading `x-amzn-trace-id`
  * should find the shape it would find on AWS rather than nothing at all.
+ *
+ * Every AWS service that proxies a request to a function stamps this, which is
+ * why it is here rather than under one payload format.
  */
-export function simPayload2TraceId(at: Date): string {
+export function simAwsProxiedTraceId(at: Date): string {
   const startedAt = Math.floor(at.getTime() / 1000)
     .toString(16)
     .padStart(8, "0");

--- a/src/serve/payload-2/sim-payload-2-event-builder.ts
+++ b/src/serve/payload-2/sim-payload-2-event-builder.ts
@@ -1,9 +1,9 @@
 import { type SimClock, SimRealClock } from "../../util/clock/sim-clock.js";
-import { SimPayload2BodyEncoding } from "./sim-payload-2-body-encoding.js";
 import {
-  simPayload2SourceIp,
-  simPayload2TraceId,
-} from "./sim-payload-2-connection.js";
+  simAwsProxiedSourceIp,
+  simAwsProxiedTraceId,
+} from "../http/sim-aws-proxied-connection.js";
+import { SimPayload2BodyEncoding } from "./sim-payload-2-body-encoding.js";
 import type { SimPayload2Endpoint } from "./sim-payload-2-endpoint.js";
 import type { SimPayload2Event } from "./sim-payload-2-event.type.js";
 import {
@@ -68,8 +68,8 @@ export class SimPayload2EventBuilder {
       headers: this.requestParts.headers({
         request,
         domainName: endpoint.domainName,
-        traceId: simPayload2TraceId(at),
-        sourceIp: simPayload2SourceIp,
+        traceId: simAwsProxiedTraceId(at),
+        sourceIp: simAwsProxiedSourceIp,
       }),
       requestContext: this.requestContext.build({
         request,

--- a/src/serve/payload-2/sim-payload-2-request-context.ts
+++ b/src/serve/payload-2/sim-payload-2-request-context.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "node:crypto";
 
 import type { SimAwsRequestCaller } from "../../service/iam/request/sim-aws-request-caller.js";
-import { simPayload2SourceIp } from "./sim-payload-2-connection.js";
+import { simAwsProxiedSourceIp } from "../http/sim-aws-proxied-connection.js";
 import type { SimPayload2Endpoint } from "./sim-payload-2-endpoint.js";
 import type {
   SimPayload2JwtAuthorizer,
@@ -69,7 +69,7 @@ export class SimPayload2RequestContextBuilder {
         method: request.method,
         path: url.pathname,
         protocol: "HTTP/1.1",
-        sourceIp: simPayload2SourceIp,
+        sourceIp: simAwsProxiedSourceIp,
         userAgent: request.headers.get("user-agent") ?? "",
       },
       requestId: randomUUID(),

--- a/src/service/aws/factory/sim-aws-account-region-service-builder.ts
+++ b/src/service/aws/factory/sim-aws-account-region-service-builder.ts
@@ -18,10 +18,10 @@ import { SimCognitoIdentityProvider } from "../../cognito/index.js";
 import { SimEcr } from "../../ecr/index.js";
 import { SimEcs } from "../../ecs/index.js";
 import { simAwsCognitoTriggerFunctions } from "../../cognito/user-pool/trigger/sim-aws-cognito-trigger-functions.js";
+import { SimElbV2 } from "../../elbv2/index.js";
 import { SimEventBridge } from "../../eventbridge/index.js";
 import type { SimIamRegistry } from "../../iam/registry/sim-iam-registry.js";
 import { SimKms } from "../../kms/index.js";
-import type { SimHttpApiRegistry } from "../../apigatewayv2/registry/sim-http-api-registry.js";
 import { SimLambda } from "../../lambda/index.js";
 import type { SimLambdaUrlRegistry } from "../../lambda/registry/sim-lambda-url-registry.js";
 import { SimRekognition } from "../../rekognition/index.js";
@@ -42,7 +42,6 @@ interface SimAwsAccountRegionServiceBuilderProperties {
   readonly registries: SimAwsScopedServiceRegistries;
   readonly iamRegistry: SimIamRegistry;
   readonly lambdaUrlRegistry: SimLambdaUrlRegistry;
-  readonly httpApiRegistry: SimHttpApiRegistry;
   readonly accountServices: SimAwsAccountServiceCache;
 }
 
@@ -74,7 +73,6 @@ export class SimAwsAccountRegionServiceBuilder {
   private readonly registries: SimAwsScopedServiceRegistries;
   private readonly iamRegistry: SimIamRegistry;
   private readonly lambdaUrlRegistry: SimLambdaUrlRegistry;
-  private readonly httpApiRegistry: SimHttpApiRegistry;
   private readonly accountServices: SimAwsAccountServiceCache;
 
   constructor(properties: SimAwsAccountRegionServiceBuilderProperties) {
@@ -83,7 +81,6 @@ export class SimAwsAccountRegionServiceBuilder {
     this.registries = properties.registries;
     this.iamRegistry = properties.iamRegistry;
     this.lambdaUrlRegistry = properties.lambdaUrlRegistry;
-    this.httpApiRegistry = properties.httpApiRegistry;
     this.accountServices = properties.accountServices;
   }
 
@@ -109,7 +106,7 @@ export class SimAwsAccountRegionServiceBuilder {
       ...this.scoped(scope),
       // API ids are unique across the simulation, and an API is reachable by
       // id alone from the serving layer, whichever scope created it.
-      registry: this.httpApiRegistry,
+      registry: this.registries.httpApi,
       jwtIssuerKeys: simAwsHttpApiJwtIssuerKeys(this.registries),
     });
   }
@@ -176,6 +173,18 @@ export class SimAwsAccountRegionServiceBuilder {
       ...this.scoped(scope),
       deliveryTargets: simAwsEventBridgeDeliveryTargets(this.simAws),
     });
+  }
+
+  /**
+   * Create simulated Elastic Load Balancing v2 for an Account Region scope.
+   *
+   * The registry is what gets a request from a load balancer's DNS name to the
+   * scope holding it, since a host name names neither an Account nor a Region.
+   */
+  createElbV2(scope: SimAwsAccountRegionContainer): SimElbV2 {
+    const registry = this.registries.elbV2;
+
+    return new SimElbV2({ ...this.scoped(scope), registry });
   }
 
   /**

--- a/src/service/aws/factory/sim-aws-scoped-service-registries.ts
+++ b/src/service/aws/factory/sim-aws-scoped-service-registries.ts
@@ -1,7 +1,9 @@
 import { SimAcmRegistry } from "../../acm/registry/sim-acm-registry.js";
+import { SimHttpApiRegistry } from "../../apigatewayv2/registry/sim-http-api-registry.js";
 import { SimCognitoDomainRegistry } from "../../cognito/registry/sim-cognito-domain-registry.js";
 import { SimCognitoUserPoolRegistry } from "../../cognito/registry/sim-cognito-user-pool-registry.js";
 import { SimEcrRegistry } from "../../ecr/registry/sim-ecr-registry.js";
+import { SimElbV2Registry } from "../../elbv2/registry/sim-elbv2-registry.js";
 import { SimKmsRegistry } from "../../kms/registry/sim-kms-registry.js";
 import { SimRoute53Registry } from "../../route53/registry/sim-route53-registry.js";
 import { SimS3GlobalRegistry } from "../../s3/sim-s3-global-registry.js";
@@ -43,6 +45,22 @@ export class SimAwsScopedServiceRegistries {
    * the repository that URI names, whichever Account and Region it is in.
    */
   public readonly ecr = new SimEcrRegistry();
+
+  /**
+   * Indexes the load balancers created in any Account and Region of one SimAws
+   * instance by the DNS name they answer on. A request reaching one carries
+   * that name and no Account, so this is the hop from a host name to the scope
+   * holding the load balancer.
+   */
+  public readonly elbV2 = new SimElbV2Registry();
+
+  /**
+   * Indexes the API ids allocated in any Account and Region of one SimAws
+   * instance. A served request carries its Region in the host name and no
+   * Account, so this is what gets the serving layer from an API id to the
+   * scope that owns it.
+   */
+  public readonly httpApi = new SimHttpApiRegistry();
 
   /**
    * Indexes the account/region-scoped KMS facades created for one SimAws

--- a/src/service/aws/factory/sim-aws-self-contained-service-builder.ts
+++ b/src/service/aws/factory/sim-aws-self-contained-service-builder.ts
@@ -1,6 +1,5 @@
 import type { SimAwsAccountRegionContainer } from "../sim-aws-account-region-scope.js";
 import { SimDynamoDb as SimDynamoDatabase } from "../../dynamodb/index.js";
-import { SimElbV2 } from "../../elbv2/index.js";
 import { SimSecretsManager } from "../../secretsmanager/index.js";
 import { SimSqs } from "../../sqs/index.js";
 import { SimSsm } from "../../ssm/index.js";
@@ -36,11 +35,6 @@ export class SimAwsSelfContainedServiceBuilder {
   /** Create simulated DynamoDB for an Account Region scope. */
   createDynamoDb(scope: SimAwsAccountRegionContainer): SimDynamoDatabase {
     return new SimDynamoDatabase(this.scoped(scope));
-  }
-
-  /** Create simulated Elastic Load Balancing v2 for an Account Region scope. */
-  createElbV2(scope: SimAwsAccountRegionContainer): SimElbV2 {
-    return new SimElbV2(this.scoped(scope));
   }
 
   /**

--- a/src/service/aws/factory/sim-aws-service-factory.ts
+++ b/src/service/aws/factory/sim-aws-service-factory.ts
@@ -6,7 +6,7 @@ import type { SimAwsAccountRegionContainer } from "../sim-aws-account-region-sco
 import type { SimAws } from "../sim-aws.js";
 import type { SimAcm } from "../../acm/sim-acm.js";
 import type { SimApiGatewayV2 } from "../../apigatewayv2/index.js";
-import { SimHttpApiRegistry } from "../../apigatewayv2/registry/sim-http-api-registry.js";
+import type { SimHttpApiRegistry } from "../../apigatewayv2/registry/sim-http-api-registry.js";
 import type { SimCloudFormation } from "../../cloudformation/index.js";
 import type { SimCognitoIdentityProvider } from "../../cognito/index.js";
 import { SimCloudFrontRegistry } from "../../cloudfront/registry/sim-cloud-front-registry.js";
@@ -19,6 +19,7 @@ import type { SimRoute53 } from "../../route53/index.js";
 import type { SimS3 } from "../../s3/sim-s3.js";
 import type { SimScheduler } from "../../scheduler/index.js";
 import type { SimElbV2 } from "../../elbv2/index.js";
+import type { SimElbV2Registry } from "../../elbv2/registry/sim-elbv2-registry.js";
 import type { SimIam } from "../../iam/index.js";
 import { SimIamRegistry } from "../../iam/registry/sim-iam-registry.js";
 import type { SimKms } from "../../kms/index.js";
@@ -94,16 +95,6 @@ export class SimAwsServiceFactory {
   public readonly lambdaUrlRegistry = new SimLambdaUrlRegistry();
 
   /**
-   * Shared simulated API Gateway HTTP API registry.
-   *
-   * This maps API ids to the Accounts that own them, so the localhost serving
-   * layer can route a request to the right Account/Region scope from the
-   * request hostname alone.
-   * @internal
-   */
-  public readonly httpApiRegistry = new SimHttpApiRegistry();
-
-  /**
    * The registries this simulation's scoped services share between them.
    */
   private readonly registries = new SimAwsScopedServiceRegistries();
@@ -132,12 +123,35 @@ export class SimAwsServiceFactory {
       registries: this.registries,
       iamRegistry: this.iamRegistry,
       lambdaUrlRegistry: this.lambdaUrlRegistry,
-      httpApiRegistry: this.httpApiRegistry,
       accountServices: this.accountServices,
     });
     this.selfContainedServices = new SimAwsSelfContainedServiceBuilder({
       accountServices: this.accountServices,
     });
+  }
+
+  /**
+   * Shared simulated API Gateway HTTP API registry.
+   *
+   * This maps API ids to the Accounts that own them, so the localhost serving
+   * layer routes a request to the right Account/Region scope from the request
+   * host name alone.
+   * @internal
+   */
+  get httpApiRegistry(): SimHttpApiRegistry {
+    return this.registries.httpApi;
+  }
+
+  /**
+   * Shared simulated ELBv2 registry.
+   *
+   * This maps load balancer DNS names to the Accounts that own them, so a
+   * request reaching a load balancer is routed to the right Account/Region
+   * scope from the host name alone.
+   * @internal
+   */
+  get elbV2Registry(): SimElbV2Registry {
+    return this.registries.elbV2;
   }
 
   /** Create simulated ACM for an Account Region scope. */
@@ -189,7 +203,7 @@ export class SimAwsServiceFactory {
 
   /** Create simulated Elastic Load Balancing v2 for an Account Region scope. */
   createElbV2(scope: SimAwsAccountRegionContainer): SimElbV2 {
-    return this.selfContainedServices.createElbV2(scope);
+    return this.accountRegionServices.createElbV2(scope);
   }
 
   /** Create or get simulated IAM for an Account scope. */

--- a/src/service/elbv2/README.md
+++ b/src/service/elbv2/README.md
@@ -4,13 +4,15 @@ This directory contains the simulated ELBv2 service implementation.
 
 The guiding decision here is that this is the Application Load Balancer and nothing else. A network
 or gateway load balancer routes below HTTP, which nothing in this simulation speaks, so one is
-refused rather than created as something it is not. The second decision is that this piece is state:
-a load balancer here has a DNS name of the shape real ELB issues, and listeners, rules and target
-groups saying what it would do with a request. Answering a request is separate work.
+refused rather than created as something it is not. The second decision is that the state and the
+answering of a request are separate: a load balancer here has a DNS name of the shape real ELB
+issues, and listeners, rules and target groups saying what it would do with a request, and `serve/`
+is the part that does it.
 
 ## Entry points
 
 - `sim-elbv2.ts` is the main in-memory service object for one account/region scope.
+- `serve/sim-elbv2-fetch.ts` is how a request reaches a load balancer.
 - `index.ts` exports the public ELBv2 simulator API for `@kensio/yulin/elbv2`.
 
 A `SimElbV2` instance owns a `SimElbV2Stores` holding its four resources. The simulator is scoped to
@@ -81,6 +83,37 @@ command types in `*.command.ts` match the SDK shapes closely enough for callers 
 command instances. Enum-shaped fields are widened to `string`, so an input this simulation refuses
 is refused at runtime with an explanation rather than by the type checker with none.
 
+## Answering a request
+
+`serve/` is where a request becomes a response, and it is a chain of one decision each:
+
+- `sim-elbv2-fetch.ts` turns a URL into a service request, taking the load balancer's DNS name from
+  the host name. It exists because nothing resolves that name to a load balancer yet, and it is what
+  the DNS and local serving work will sit on top of rather than replace.
+- `sim-elbv2-router.ts` gets from a DNS name to the load balancer answering on it, and from a target
+  group to the function registered in it. Neither hop is local: a DNS name says nothing about the
+  Account, which is what `registry/sim-elbv2-registry.ts` answers, and a function is looked for in
+  the target group's own Account and Region, which is where real ELB requires a Lambda target to be.
+- `sim-elbv2-controller.ts` matches the port to a listener. A port no listener holds throws rather
+  than answering, because on real AWS the connection is refused and there is no status to send.
+- `sim-elbv2-forward-target.ts` performs the listener's default action, which so far means a
+  `forward` to a `lambda` target group. Everything else it could hold is refused here rather than
+  answered with something else, because a load balancer that forwards a request its configuration
+  said to redirect is worse than one that says it cannot.
+- `sim-elbv2-lambda-target-invocation.ts` owns what the load balancer answers itself. An empty target
+  group is a 503 and everything after that is a 502, which is the same collapse real ELB makes: the
+  difference between a missing permission, a missing function and a thrown handler is only in the
+  load balancer's own logs.
+- `sim-elbv2-event-builder.ts` and `sim-elbv2-response-builder.ts` hold the ALB shapes, which are
+  ELB's own rather than either API Gateway payload format. `sim-elbv2-body-encoding.ts` is separate
+  because its list of text media types is ELB's too, and is shorter than API Gateway's.
+- `sim-elbv2-invoke-authorizer.ts` asks simulated Lambda whether the load balancer may invoke the
+  function, supplying the target group as the source ARN. Who may invoke a function is Lambda's rule,
+  so the decision is made there and only the ELB-shaped part of the question is here.
+
+`SimElbV2ServiceController` implements `SimAwsServiceController`, so the localhost serving layer can
+route to it once a load balancer's DNS name is resolved. Nothing resolves one yet.
+
 ## Authorization
 
 `SimElbV2Authorizer` serves the whole service rather than one authorizer per command, because ELBv2
@@ -100,6 +133,13 @@ There is no resource policy support here, and none to add: ELBv2 has none on rea
   simulated Route53 resolves an alias by looking the target up rather than by its zone id.
 - Deregistration is immediate, where real ELB drains connections first, because there are no
   connections to drain.
+- The invoke permission is checked when a request arrives, where real ELB checks it when a Lambda
+  target is registered. That is why a target group here can be built in any order, and why removing
+  the permission afterwards stops the requests.
+- Target group attributes are not simulated, so `lambda.multi_value_headers.enabled` cannot be
+  turned on. A repeated query string key keeps its last value, as real ELB does with the attribute
+  off, while repeated request headers arrive already joined by the Fetch API and cannot be reduced
+  to the last one or split back apart.
 - Subnets, security groups and availability zones are accepted and left out of a describe rather
   than invented.
 - ARN ids and DNS name suffixes count rather than being random, so a test can assert on an ARN it

--- a/src/service/elbv2/README.md
+++ b/src/service/elbv2/README.md
@@ -143,7 +143,9 @@ There is no resource policy support here, and none to add: ELBv2 has none on rea
 - Subnets, security groups and availability zones are accepted and left out of a describe rather
   than invented.
 - ARN ids and DNS name suffixes count rather than being random, so a test can assert on an ARN it
-  did not capture. The shape is the real one either way.
+  did not capture. The shape is the real one either way. The ARN id counts within one scope, because
+  an ARN already names the Account; the DNS name counts across the whole simulation, because a host
+  name names nothing but itself and two Accounts issued the same one could not both answer on it.
 - A listener or rule takes exactly one action. Real ELB takes one routing action with an optional
   authentication action before it, and neither authentication action is simulated, so a longer list
   is refused rather than half honoured.

--- a/src/service/elbv2/command/load-balancer/create-load-balancer.handler.ts
+++ b/src/service/elbv2/command/load-balancer/create-load-balancer.handler.ts
@@ -67,13 +67,15 @@ export class CreateLoadBalancerCommandHandler
 
     this.stores.loadBalancers.requireNameAvailable(name);
 
-    const sequence = this.stores.loadBalancers.nextSequence();
     const loadBalancer = new SimElbV2LoadBalancer({
       name,
       scheme,
       ipAddressType: input.IpAddressType ?? "ipv4",
-      id: simElbV2ResourceId(sequence),
-      dnsSuffix: simElbV2DnsSuffix(sequence),
+      // The ARN id counts within this scope, because an ARN already names the
+      // Account. The DNS name counts across the whole simulation, because a
+      // host name names nothing but itself.
+      id: simElbV2ResourceId(this.stores.loadBalancers.nextSequence()),
+      dnsSuffix: simElbV2DnsSuffix(this.stores.loadBalancers.nextDnsSequence()),
       createdTime: this.background.now(),
       accountRegionScope: this.accountRegionScope,
     });

--- a/src/service/elbv2/command/load-balancer/create-load-balancer.iso.test.ts
+++ b/src/service/elbv2/command/load-balancer/create-load-balancer.iso.test.ts
@@ -203,4 +203,33 @@ describe("ELBv2 CreateLoadBalancerCommand", () => {
     );
     assertNonNullable(second.findLoadBalancerByName("shop-alb"));
   });
+
+  it("issues a DNS name no other Account's load balancer holds", async () => {
+    // Given two Accounts each creating their first load balancer of the same
+    // name in one Region
+    const simAws = new SimAws();
+    const first = await simAws
+      .account("111111111111")
+      .region("eu-west-1")
+      .elbV2()
+      .createLoadBalancer(new CreateLoadBalancerCommand({ Name: "shop-alb" }));
+    const second = await simAws
+      .account("222222222222")
+      .region("eu-west-1")
+      .elbV2()
+      .createLoadBalancer(new CreateLoadBalancerCommand({ Name: "shop-alb" }));
+
+    // Then the two host names differ, as they do on real AWS, where a DNS name
+    // names nothing but itself and only one load balancer can answer on it
+    assertArrayLength(first.LoadBalancers, 1);
+    assertArrayLength(second.LoadBalancers, 1);
+    assertIdentical(
+      first.LoadBalancers[0].DNSName,
+      "shop-alb-0000000001.eu-west-1.elb.amazonaws.com",
+    );
+    assertIdentical(
+      second.LoadBalancers[0].DNSName,
+      "shop-alb-0000000002.eu-west-1.elb.amazonaws.com",
+    );
+  });
 });

--- a/src/service/elbv2/error/sim-elbv2.error.ts
+++ b/src/service/elbv2/error/sim-elbv2.error.ts
@@ -189,6 +189,19 @@ export class SimElbV2InvalidConfigurationRequestException extends SimElbV2Error 
 }
 
 /**
+ * Nothing answered a request sent to a load balancer.
+ *
+ * There is no HTTP status for this, because on real AWS there is no HTTP
+ * response either: a host name no load balancer answers on resolves to nothing,
+ * and a port no listener holds refuses the connection. Both reach a client as a
+ * failed connection rather than as a response, so both are thrown here rather
+ * than answered.
+ */
+export class SimElbV2ConnectionRefusedError extends SimElbV2Error {
+  public override readonly name = "ConnectionRefusedError";
+}
+
+/**
  * Request input that real ELBv2 takes and this simulation does not.
  *
  * Held apart from a validation failure because the two mean different things:

--- a/src/service/elbv2/index.ts
+++ b/src/service/elbv2/index.ts
@@ -18,8 +18,27 @@ export type { SimElbV2ListenerView } from "./listener/sim-elbv2-listener.js";
 export { SimElbV2ListenerRule } from "./listener/rule/sim-elbv2-listener-rule.js";
 export type { SimElbV2ListenerRuleView } from "./listener/rule/sim-elbv2-listener-rule.js";
 export { SimElbV2Action } from "./action/sim-elbv2-action.js";
+export { SimElbV2Registry } from "./registry/sim-elbv2-registry.js";
+export { SimElbV2ServiceController } from "./serve/sim-elbv2-controller.js";
+export { simElbV2Fetch } from "./serve/sim-elbv2-fetch.js";
+export { SimElbV2Router } from "./serve/sim-elbv2-router.js";
+export type {
+  SimElbV2FunctionTarget,
+  SimElbV2LoadBalancerRoute,
+} from "./serve/sim-elbv2-router.js";
+export { simElbV2ServicePrincipal } from "./serve/sim-elbv2-invoke-authorizer.js";
+export type {
+  SimElbV2Event,
+  SimElbV2EventRequestContext,
+  SimElbV2Result,
+} from "./serve/sim-elbv2-event.type.js";
+export {
+  simElbV2LambdaTargetFactory,
+  type SimElbV2LambdaTargetInput,
+} from "./serve/sim-elbv2-lambda-target.factory.js";
 export {
   SimElbV2AccessDeniedException,
+  SimElbV2ConnectionRefusedError,
   SimElbV2DuplicateListenerException,
   SimElbV2DuplicateLoadBalancerNameException,
   SimElbV2DuplicateTargetGroupNameException,

--- a/src/service/elbv2/listener/sim-elbv2-listener-store.ts
+++ b/src/service/elbv2/listener/sim-elbv2-listener-store.ts
@@ -40,6 +40,22 @@ export class SimElbV2ListenerStore {
   }
 
   /**
+   * Find the listener answering on one port of a load balancer.
+   *
+   * A port holds at most one listener, which is what makes a request's port
+   * the whole of the question a load balancer asks about which listener takes
+   * it.
+   */
+  findOnPort(
+    loadBalancerArn: string,
+    port: number,
+  ): SimElbV2Listener | undefined {
+    return this.forLoadBalancer(loadBalancerArn).find(
+      (listener) => listener.port === port,
+    );
+  }
+
+  /**
    * Refuse a port another listener on the same load balancer already answers
    * on.
    *

--- a/src/service/elbv2/load-balancer/sim-elbv2-load-balancer-store.ts
+++ b/src/service/elbv2/load-balancer/sim-elbv2-load-balancer-store.ts
@@ -2,7 +2,12 @@ import {
   SimElbV2DuplicateLoadBalancerNameException,
   SimElbV2LoadBalancerNotFoundException,
 } from "../error/sim-elbv2.error.js";
+import type { SimElbV2Registry } from "../registry/sim-elbv2-registry.js";
 import type { SimElbV2LoadBalancer } from "./sim-elbv2-load-balancer.js";
+
+interface SimElbV2LoadBalancerStoreProperties {
+  readonly registry: SimElbV2Registry;
+}
 
 /**
  * The load balancers of one simulated ELBv2 scope.
@@ -10,10 +15,20 @@ import type { SimElbV2LoadBalancer } from "./sim-elbv2-load-balancer.js";
  * A name is unique within an account and region on real ELB rather than
  * globally, which is the same scope this store is created in, so holding the
  * names here is all that uniqueness needs.
+ *
+ * A DNS name is not scoped that way: a request arriving at one has no account
+ * to start from. Storing and forgetting a load balancer therefore also tells
+ * the cross-scope registry, so the two cannot disagree about which names
+ * answer.
  */
 export class SimElbV2LoadBalancerStore {
   private readonly loadBalancers = new Map<string, SimElbV2LoadBalancer>();
+  private readonly registry: SimElbV2Registry;
   private sequence = 0;
+
+  constructor(properties: SimElbV2LoadBalancerStoreProperties) {
+    this.registry = properties.registry;
+  }
 
   /**
    * Every load balancer in this scope, in creation order.
@@ -47,6 +62,7 @@ export class SimElbV2LoadBalancerStore {
    */
   put(loadBalancer: SimElbV2LoadBalancer): void {
     this.loadBalancers.set(loadBalancer.arn, loadBalancer);
+    this.registry.register(loadBalancer);
   }
 
   /**
@@ -54,6 +70,17 @@ export class SimElbV2LoadBalancerStore {
    */
   findByName(name: string): SimElbV2LoadBalancer | undefined {
     return this.all.find((loadBalancer) => loadBalancer.name === name);
+  }
+
+  /**
+   * Find the load balancer answering on a DNS name.
+   */
+  findByDnsName(dnsName: string): SimElbV2LoadBalancer | undefined {
+    const wanted = dnsName.toLowerCase();
+
+    return this.all.find(
+      (loadBalancer) => loadBalancer.dnsName.toLowerCase() === wanted,
+    );
   }
 
   /**
@@ -91,5 +118,6 @@ export class SimElbV2LoadBalancerStore {
    */
   remove(loadBalancer: SimElbV2LoadBalancer): void {
     this.loadBalancers.delete(loadBalancer.arn);
+    this.registry.deregister(loadBalancer);
   }
 }

--- a/src/service/elbv2/load-balancer/sim-elbv2-load-balancer-store.ts
+++ b/src/service/elbv2/load-balancer/sim-elbv2-load-balancer-store.ts
@@ -46,6 +46,18 @@ export class SimElbV2LoadBalancerStore {
   }
 
   /**
+   * Take the next number for the DNS name of a load balancer about to be
+   * created.
+   *
+   * This one comes from the registry rather than from this store, because a
+   * DNS name has to be unique across every scope while an ARN id only has to
+   * be unique within one.
+   */
+  nextDnsSequence(): number {
+    return this.registry.nextDnsSequence();
+  }
+
+  /**
    * Refuse a name another load balancer in this scope already holds.
    */
   requireNameAvailable(name: string): void {

--- a/src/service/elbv2/load-balancer/sim-elbv2-load-balancer.ts
+++ b/src/service/elbv2/load-balancer/sim-elbv2-load-balancer.ts
@@ -57,12 +57,21 @@ export class SimElbV2LoadBalancer {
   public readonly scheme: SimElbV2LoadBalancerScheme;
   public readonly ipAddressType: string;
   public readonly createdTime: Date;
+  /**
+   * The Account and Region this load balancer belongs to.
+   *
+   * Held rather than read back out of the ARN, because whatever answers a
+   * request to this load balancer has to look for its listeners, target groups
+   * and functions in the same scope.
+   */
+  public readonly accountRegionScope: SimAwsAccountRegionScope;
 
   constructor(properties: SimElbV2LoadBalancerProperties) {
     const { name, scheme, accountRegionScope } = properties;
 
     this.name = name;
     this.scheme = scheme;
+    this.accountRegionScope = accountRegionScope;
     this.ipAddressType = properties.ipAddressType;
     this.createdTime = properties.createdTime;
     this.arn = simElbV2LoadBalancerArn(name, properties.id, accountRegionScope);

--- a/src/service/elbv2/registry/sim-elbv2-registry.ts
+++ b/src/service/elbv2/registry/sim-elbv2-registry.ts
@@ -1,0 +1,41 @@
+import type { SimAwsAccountId } from "../../aws/sim-aws-account.js";
+import type { SimElbV2LoadBalancer } from "../load-balancer/sim-elbv2-load-balancer.js";
+
+/**
+ * Simulated ELBv2 cross-Account registry of load balancer DNS names.
+ *
+ * A request reaching a load balancer carries its DNS name and nothing else.
+ * That name says which Region the load balancer is in, because real ELB puts
+ * the Region in it, but it does not say which Account owns it. Simulated ELBv2
+ * state is per Account and Region, so this registry is the missing hop from a
+ * host name to the scope holding the load balancer that answers on it.
+ */
+export class SimElbV2Registry {
+  private readonly accountIdsByDnsName = new Map<string, SimAwsAccountId>();
+
+  /**
+   * Register a created load balancer, so requests to its DNS name resolve.
+   */
+  register(loadBalancer: SimElbV2LoadBalancer): void {
+    this.accountIdsByDnsName.set(
+      loadBalancer.dnsName.toLowerCase(),
+      loadBalancer.accountRegionScope.accountId,
+    );
+  }
+
+  /**
+   * Forget a deleted load balancer, so requests to its DNS name stop
+   * resolving.
+   */
+  deregister(loadBalancer: SimElbV2LoadBalancer): void {
+    this.accountIdsByDnsName.delete(loadBalancer.dnsName.toLowerCase());
+  }
+
+  /**
+   * Get the Account that owns the load balancer answering on a DNS name, if
+   * one does.
+   */
+  accountIdForDnsName(dnsName: string): SimAwsAccountId | undefined {
+    return this.accountIdsByDnsName.get(dnsName.toLowerCase());
+  }
+}

--- a/src/service/elbv2/registry/sim-elbv2-registry.ts
+++ b/src/service/elbv2/registry/sim-elbv2-registry.ts
@@ -1,25 +1,43 @@
-import type { SimAwsAccountId } from "../../aws/sim-aws-account.js";
+import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
 import type { SimElbV2LoadBalancer } from "../load-balancer/sim-elbv2-load-balancer.js";
 
 /**
  * Simulated ELBv2 cross-Account registry of load balancer DNS names.
  *
  * A request reaching a load balancer carries its DNS name and nothing else.
- * That name says which Region the load balancer is in, because real ELB puts
- * the Region in it, but it does not say which Account owns it. Simulated ELBv2
- * state is per Account and Region, so this registry is the missing hop from a
- * host name to the scope holding the load balancer that answers on it.
+ * Simulated ELBv2 state is per Account and Region, and a host name says which
+ * neither of those is, so this registry is the missing hop from a host name to
+ * the scope holding the load balancer that answers on it.
  */
 export class SimElbV2Registry {
-  private readonly accountIdsByDnsName = new Map<string, SimAwsAccountId>();
+  private readonly scopesByDnsName = new Map<
+    string,
+    SimAwsAccountRegionScope
+  >();
+  private dnsSequence = 0;
+
+  /**
+   * Take the next number for the DNS name of a load balancer about to be
+   * created.
+   *
+   * It counts across the whole simulation rather than within one scope,
+   * because a DNS name is not scoped: two Accounts each creating their first
+   * `shop-alb` in one Region would otherwise be issued the same host name, and
+   * only one of them could answer on it. Real ELB issues a name unique across
+   * the whole of AWS for the same reason.
+   */
+  nextDnsSequence(): number {
+    this.dnsSequence += 1;
+    return this.dnsSequence;
+  }
 
   /**
    * Register a created load balancer, so requests to its DNS name resolve.
    */
   register(loadBalancer: SimElbV2LoadBalancer): void {
-    this.accountIdsByDnsName.set(
+    this.scopesByDnsName.set(
       loadBalancer.dnsName.toLowerCase(),
-      loadBalancer.accountRegionScope.accountId,
+      loadBalancer.accountRegionScope,
     );
   }
 
@@ -28,14 +46,17 @@ export class SimElbV2Registry {
    * resolving.
    */
   deregister(loadBalancer: SimElbV2LoadBalancer): void {
-    this.accountIdsByDnsName.delete(loadBalancer.dnsName.toLowerCase());
+    this.scopesByDnsName.delete(loadBalancer.dnsName.toLowerCase());
   }
 
   /**
-   * Get the Account that owns the load balancer answering on a DNS name, if
-   * one does.
+   * Get the Account and Region of the load balancer answering on a DNS name,
+   * if one does.
+   *
+   * The Region is held rather than read back out of the host name, so nothing
+   * has to take a real ELB name apart to route a request.
    */
-  accountIdForDnsName(dnsName: string): SimAwsAccountId | undefined {
-    return this.accountIdsByDnsName.get(dnsName.toLowerCase());
+  scopeForDnsName(dnsName: string): SimAwsAccountRegionScope | undefined {
+    return this.scopesByDnsName.get(dnsName.toLowerCase());
   }
 }

--- a/src/service/elbv2/serve/sim-elbv2-body-encoding.ts
+++ b/src/service/elbv2/serve/sim-elbv2-body-encoding.ts
@@ -49,6 +49,11 @@ export class SimElbV2BodyEncoding {
 
   /**
    * Encode request body bytes for the handler event.
+   *
+   * A text body that is not valid UTF-8 throws rather than being decoded into
+   * replacement characters. Real ELB fails the invocation for the same reason,
+   * with `LambdaBadRequest` in its logs and a 502 for the client, so a handler
+   * never sees a body silently rewritten on its way in.
    */
   encode(
     bytes: Uint8Array,
@@ -56,7 +61,7 @@ export class SimElbV2BodyEncoding {
     contentEncoding: string | null,
   ): string {
     if (this.isText(contentType, contentEncoding)) {
-      return new TextDecoder().decode(bytes);
+      return new TextDecoder("utf-8", { fatal: true }).decode(bytes);
     }
 
     return Buffer.from(bytes).toString("base64");

--- a/src/service/elbv2/serve/sim-elbv2-body-encoding.ts
+++ b/src/service/elbv2/serve/sim-elbv2-body-encoding.ts
@@ -1,0 +1,75 @@
+/**
+ * The media types an Application Load Balancer passes to a Lambda target as
+ * text.
+ *
+ * This list is ELB's own and is shorter than the one API Gateway uses. A form
+ * post is the difference worth knowing about:
+ * `application/x-www-form-urlencoded` is text to API Gateway and base64 to a
+ * load balancer.
+ */
+const textMediaTypes: ReadonlySet<string> = new Set([
+  "application/json",
+  "application/javascript",
+  "application/xml",
+]);
+
+/**
+ * Decides how a request or response body crosses the boundary between HTTP
+ * bytes and the string an ALB invocation event carries.
+ *
+ * A body with a `content-encoding` header is always base64, whatever its
+ * content type, because the bytes are compressed rather than text. Without one,
+ * the content type decides, and the handler is told which happened with
+ * `isBase64Encoded`.
+ */
+export class SimElbV2BodyEncoding {
+  /**
+   * Whether a body is passed to the handler as text.
+   *
+   * An absent content type is treated as binary, as ELB does, because nothing
+   * says the bytes are decodable text.
+   */
+  isText(contentType: string | null, contentEncoding: string | null): boolean {
+    if (contentEncoding !== null) {
+      return false;
+    }
+
+    if (contentType === null) {
+      return false;
+    }
+
+    const mediaType = contentType.split(";", 1)[0]?.trim().toLowerCase() ?? "";
+
+    if (mediaType.startsWith("text/")) {
+      return true;
+    }
+
+    return textMediaTypes.has(mediaType);
+  }
+
+  /**
+   * Encode request body bytes for the handler event.
+   */
+  encode(
+    bytes: Uint8Array,
+    contentType: string | null,
+    contentEncoding: string | null,
+  ): string {
+    if (this.isText(contentType, contentEncoding)) {
+      return new TextDecoder().decode(bytes);
+    }
+
+    return Buffer.from(bytes).toString("base64");
+  }
+
+  /**
+   * Decode a handler's response body into the bytes sent to the client.
+   */
+  decode(body: string, isBase64Encoded: boolean): Uint8Array | string {
+    if (isBase64Encoded) {
+      return new Uint8Array(Buffer.from(body, "base64"));
+    }
+
+    return body;
+  }
+}

--- a/src/service/elbv2/serve/sim-elbv2-controller.ts
+++ b/src/service/elbv2/serve/sim-elbv2-controller.ts
@@ -1,0 +1,85 @@
+import type {
+  SimAwsServiceController,
+  SimAwsServiceRequest,
+} from "../../../serve/controller/sim-service-controller.js";
+import { SimAws } from "../../aws/sim-aws.js";
+import { SimElbV2ConnectionRefusedError } from "../error/sim-elbv2.error.js";
+import { SimElbV2ForwardTarget } from "./sim-elbv2-forward-target.js";
+import { SimElbV2LambdaTargetInvocation } from "./sim-elbv2-lambda-target-invocation.js";
+import { simElbV2RequestPort } from "./sim-elbv2-request-port.js";
+import {
+  type SimElbV2LoadBalancerRoute,
+  SimElbV2Router,
+} from "./sim-elbv2-router.js";
+
+interface SimElbV2ServiceControllerProperties {
+  readonly simAws?: SimAws;
+  readonly router?: SimElbV2Router;
+}
+
+/**
+ * HTTP controller for simulated Application Load Balancers.
+ *
+ * A request reaching a load balancer's DNS name is matched to a listener by the
+ * port it arrived on, and the listener's default action decides what happens
+ * next. A forward action sends it to a target group, and a lambda target group
+ * invokes the function registered in it with an ALB event.
+ *
+ * Nothing here matches listener rules yet, so every request a listener takes is
+ * answered by its default action.
+ */
+export class SimElbV2ServiceController implements SimAwsServiceController {
+  private readonly router: SimElbV2Router;
+  private readonly invocation: SimElbV2LambdaTargetInvocation;
+
+  constructor(properties: SimElbV2ServiceControllerProperties = {}) {
+    const { simAws = new SimAws() } = properties;
+    this.router = properties.router ?? new SimElbV2Router({ simAws });
+    // The clock is taken from the router rather than from properties, so a
+    // supplied router and the event timestamps belong to the same simulation.
+    this.invocation = new SimElbV2LambdaTargetInvocation({
+      router: this.router,
+      clock: this.router.simAws,
+    });
+  }
+
+  /**
+   * Handle an HTTP request routed to a simulated load balancer.
+   */
+  async handleRequest(serviceRequest: SimAwsServiceRequest): Promise<Response> {
+    const route = this.router.route(serviceRequest.target);
+
+    if (route === undefined) {
+      throw new SimElbV2ConnectionRefusedError(
+        `No simulated load balancer answers on ` +
+          `'${serviceRequest.target.resourceName}'`,
+      );
+    }
+
+    return await this.forward(route, serviceRequest.request);
+  }
+
+  private async forward(
+    route: SimElbV2LoadBalancerRoute,
+    request: Request,
+  ): Promise<Response> {
+    const { loadBalancer, elbV2 } = route;
+    const port = simElbV2RequestPort(new URL(request.url));
+    const listener = elbV2.findListenerOnPort(loadBalancer.arn, port);
+
+    if (listener === undefined) {
+      throw new SimElbV2ConnectionRefusedError(
+        `Load balancer '${loadBalancer.name}' has no listener on port ${String(
+          port,
+        )}`,
+      );
+    }
+
+    return await this.invocation.invoke({
+      loadBalancer,
+      listener,
+      targetGroup: new SimElbV2ForwardTarget(elbV2).resolve(listener),
+      request,
+    });
+  }
+}

--- a/src/service/elbv2/serve/sim-elbv2-error-response.ts
+++ b/src/service/elbv2/serve/sim-elbv2-error-response.ts
@@ -1,0 +1,53 @@
+/**
+ * The responses a load balancer generates itself, rather than getting from a
+ * target.
+ *
+ * Real ELB answers these with a short HTML page naming the status, which is
+ * what a browser shows when a target is missing or broken. The status code is
+ * the part worth asserting on: the page is reproduced so that a response looks
+ * like one a load balancer sent, not so that anything reads it.
+ */
+export class SimElbV2ErrorResponse {
+  /**
+   * The target could not be invoked, or answered with something that is not a
+   * response.
+   *
+   * This is what a Lambda target produces when the load balancer may not
+   * invoke it, when the function is not there, when the handler throws, and
+   * when what the handler returns has no usable status code.
+   */
+  badGateway(): Response {
+    return this.build(502, "Bad Gateway");
+  }
+
+  /**
+   * There was no target to send the request to.
+   *
+   * Real ELB answers this when a target group has no registered targets, or
+   * none of them is in service.
+   */
+  serviceUnavailable(): Response {
+    return this.build(503, "Service Unavailable");
+  }
+
+  /**
+   * The request body is larger than a Lambda target takes.
+   */
+  payloadTooLarge(): Response {
+    return this.build(413, "Payload Too Large");
+  }
+
+  private build(status: number, reason: string): Response {
+    const title = `${String(status)} ${reason}`;
+
+    return new Response(
+      `<html>\n<head><title>${title}</title></head>\n` +
+        `<body>\n<center><h1>${title}</h1></center>\n</body>\n</html>\n`,
+      {
+        status,
+        statusText: reason,
+        headers: { "content-type": "text/html" },
+      },
+    );
+  }
+}

--- a/src/service/elbv2/serve/sim-elbv2-event-builder.ts
+++ b/src/service/elbv2/serve/sim-elbv2-event-builder.ts
@@ -1,0 +1,79 @@
+import {
+  simAwsProxiedSourceIp,
+  simAwsProxiedTraceId,
+} from "../../../serve/http/sim-aws-proxied-connection.js";
+import type { SimClock } from "../../../util/clock/sim-clock.js";
+import { SimElbV2BodyEncoding } from "./sim-elbv2-body-encoding.js";
+import type { SimElbV2Event } from "./sim-elbv2-event.type.js";
+import { SimElbV2RequestParts } from "./sim-elbv2-request-parts.js";
+
+interface SimElbV2EventBuilderProperties {
+  /**
+   * Clock stamping the trace id, so a handler sees the same "now" as the rest
+   * of the simulation.
+   */
+  readonly clock: SimClock;
+}
+
+interface SimElbV2EventInput {
+  readonly request: Request;
+  /** The request body, already read, because its size is checked first. */
+  readonly bytes: Uint8Array;
+  /** The target group the listener forwarded to. */
+  readonly targetGroupArn: string;
+  /** The DNS name of the load balancer the request reached. */
+  readonly dnsName: string;
+  /** The port the listener taking the request answers on. */
+  readonly port: number;
+  /** The protocol that listener speaks. */
+  readonly protocol: string;
+}
+
+/**
+ * Builds the event an Application Load Balancer passes to a Lambda target.
+ *
+ * Every field is always present, which is what tells this apart from the API
+ * Gateway payload formats: a request with no query string carries an empty
+ * `queryStringParameters` map rather than none, and one with no body carries an
+ * empty `body` rather than leaving the field out.
+ */
+export class SimElbV2EventBuilder {
+  private readonly bodyEncoding = new SimElbV2BodyEncoding();
+  private readonly requestParts = new SimElbV2RequestParts();
+  private readonly clock: SimClock;
+
+  constructor(properties: SimElbV2EventBuilderProperties) {
+    this.clock = properties.clock;
+  }
+
+  /**
+   * Build the invocation event for one request forwarded to a target group.
+   */
+  build(input: SimElbV2EventInput): SimElbV2Event {
+    const { request, bytes } = input;
+    const url = new URL(request.url);
+    const contentType = request.headers.get("content-type");
+    const contentEncoding = request.headers.get("content-encoding");
+
+    return {
+      requestContext: { elb: { targetGroupArn: input.targetGroupArn } },
+      httpMethod: request.method,
+      path: url.pathname,
+      queryStringParameters: this.requestParts.queryStringParameters(url),
+      headers: this.requestParts.headers({
+        request,
+        dnsName: input.dnsName,
+        port: input.port,
+        protocol: input.protocol,
+        traceId: simAwsProxiedTraceId(this.clock.now()),
+        sourceIp: simAwsProxiedSourceIp,
+      }),
+      body: this.bodyEncoding.encode(bytes, contentType, contentEncoding),
+      // An empty body is text rather than empty base64, which is what real ELB
+      // reports for a GET carrying nothing.
+      isBase64Encoded:
+        bytes.length > 0 &&
+        !this.bodyEncoding.isText(contentType, contentEncoding),
+    };
+  }
+}

--- a/src/service/elbv2/serve/sim-elbv2-event.type.ts
+++ b/src/service/elbv2/serve/sim-elbv2-event.type.ts
@@ -1,0 +1,46 @@
+/**
+ * What an ALB invocation event says about where the request came from.
+ *
+ * The `elb` block is the whole of it, and it carries the target group ARN
+ * rather than the load balancer's. That is what a handler reads to tell an ALB
+ * event apart from an API Gateway one, which has a `requestContext` of a
+ * completely different shape.
+ */
+export interface SimElbV2EventRequestContext {
+  readonly elb: {
+    readonly targetGroupArn: string;
+  };
+}
+
+/**
+ * The event an Application Load Balancer passes to a Lambda target.
+ *
+ * This is ALB's own shape rather than either API Gateway payload format:
+ * `httpMethod` and `path` rather than a `requestContext.http` block, headers
+ * and query string parameters as flat single-value maps, and a body that is
+ * always present even when it is empty.
+ */
+export interface SimElbV2Event {
+  readonly requestContext: SimElbV2EventRequestContext;
+  readonly httpMethod: string;
+  readonly path: string;
+  readonly queryStringParameters: Readonly<Record<string, string>>;
+  readonly headers: Readonly<Record<string, string>>;
+  readonly body: string;
+  readonly isBase64Encoded: boolean;
+}
+
+/**
+ * The response an Application Load Balancer accepts from a Lambda target.
+ *
+ * Only `statusCode` is load bearing. A result without a numeric one is not a
+ * response ALB can send, and the load balancer answers 502 rather than passing
+ * the handler's shape on to the client.
+ */
+export interface SimElbV2Result {
+  readonly statusCode?: number;
+  readonly statusDescription?: string;
+  readonly headers?: Readonly<Record<string, string>>;
+  readonly body?: string;
+  readonly isBase64Encoded?: boolean;
+}

--- a/src/service/elbv2/serve/sim-elbv2-fetch.ts
+++ b/src/service/elbv2/serve/sim-elbv2-fetch.ts
@@ -1,0 +1,34 @@
+import { SimAwsServiceRequest } from "../../../serve/controller/sim-service-controller.js";
+import type { SimAws } from "../../aws/sim-aws.js";
+import { SimElbV2ServiceController } from "./sim-elbv2-controller.js";
+
+/**
+ * Send an HTTP request to whichever simulated load balancer its host name
+ * names.
+ *
+ * This is the in-process way to reach a load balancer, taking the same
+ * arguments as `fetch`. The host name of the URL is the load balancer's DNS
+ * name and the port is the listener's, which is what a client writes on real
+ * AWS too. Nothing is sent over a socket.
+ *
+ * A host name no load balancer answers on, and a port no listener holds, both
+ * throw rather than answering: on real AWS neither reaches a load balancer at
+ * all, so there is no status for either.
+ */
+export async function simElbV2Fetch(
+  simAws: SimAws,
+  input: Request | string,
+  init?: RequestInit,
+): Promise<Response> {
+  const request = new Request(input, init);
+
+  return await new SimElbV2ServiceController({ simAws }).handleRequest(
+    new SimAwsServiceRequest({
+      target: {
+        service: "elbV2",
+        resourceName: new URL(request.url).hostname,
+      },
+      request,
+    }),
+  );
+}

--- a/src/service/elbv2/serve/sim-elbv2-forward-target.ts
+++ b/src/service/elbv2/serve/sim-elbv2-forward-target.ts
@@ -1,0 +1,85 @@
+import { assertDefined } from "../../../util/type-guard/defined.js";
+import { SimElbV2UnsimulatedInputException } from "../error/sim-elbv2.error.js";
+import type { SimElbV2Listener } from "../listener/sim-elbv2-listener.js";
+import type { SimElbV2 } from "../sim-elbv2.js";
+import type { SimElbV2TargetGroup } from "../target-group/sim-elbv2-target-group.js";
+
+/**
+ * Works out which target group a listener's default action sends a request to.
+ *
+ * The action is stored when the listener is written and performed here, and the
+ * two are not the same thing: a listener holding an action this simulation does
+ * not carry out is a listener that was created and cannot serve. Each of those
+ * is refused when the request arrives rather than answered with something else,
+ * because a load balancer that silently forwards a request its configuration
+ * said to redirect is worse than one that says it cannot.
+ */
+export class SimElbV2ForwardTarget {
+  constructor(private readonly elbV2: SimElbV2) {}
+
+  /**
+   * The target group a listener's default action forwards to.
+   */
+  resolve(listener: SimElbV2Listener): SimElbV2TargetGroup {
+    const targetGroup = this.forwardedTargetGroup(listener);
+
+    if (targetGroup.targetType.value !== "lambda") {
+      throw new SimElbV2UnsimulatedInputException(
+        `Target group '${targetGroup.name}' holds ${targetGroup.targetType.value} ` +
+          `targets, and only a lambda target group answers a request here. ` +
+          `Nothing listens on an address in this simulation for an ip target ` +
+          `to name.`,
+      );
+    }
+
+    return targetGroup;
+  }
+
+  private forwardedTargetGroup(
+    listener: SimElbV2Listener,
+  ): SimElbV2TargetGroup {
+    const [action] = listener.defaultActions;
+
+    // A listener is created with exactly one action, so there is always one.
+    assertDefined(
+      action,
+      `Simulated ELBv2 listener ${listener.arn} holds no default action`,
+    );
+
+    if (action.type !== "forward") {
+      throw new SimElbV2UnsimulatedInputException(
+        `Listener ${listener.arn} answers a request with a '${action.type}' ` +
+          `action, which is stored and not yet performed. Only a forward ` +
+          `action carries a request here.`,
+      );
+    }
+
+    if (action.targetGroupArns.length > 1) {
+      throw new SimElbV2UnsimulatedInputException(
+        `Listener ${listener.arn} forwards to ` +
+          `${String(action.targetGroupArns.length)} target groups. Weighted ` +
+          `forwarding is not simulated, so which of them takes a request is ` +
+          `not something this can answer.`,
+      );
+    }
+
+    const [targetGroupArn] = action.targetGroupArns;
+
+    // A forward action names a target group that exists when it is written,
+    // and one anything forwards to cannot be deleted.
+    assertDefined(
+      targetGroupArn,
+      `Simulated ELBv2 listener ${listener.arn} forwards to no target group`,
+    );
+
+    const targetGroup = this.elbV2.findTargetGroupByArn(targetGroupArn);
+
+    assertDefined(
+      targetGroup,
+      `Simulated ELBv2 listener ${listener.arn} forwards to the target group ` +
+        `${targetGroupArn}, which is not there`,
+    );
+
+    return targetGroup;
+  }
+}

--- a/src/service/elbv2/serve/sim-elbv2-invoke-authorizer.ts
+++ b/src/service/elbv2/serve/sim-elbv2-invoke-authorizer.ts
@@ -1,0 +1,70 @@
+import type {
+  SimIamAuthorizationDecision,
+  SimIamInterServiceAuthZ,
+} from "../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { SimLambdaServiceInvokeAuthorizer } from "../../lambda/command/authorize/sim-lambda-service-invoke-authorizer.js";
+import type { SimLambdaFunction } from "../../lambda/function/sim-lambda-function.js";
+import type { SimElbV2TargetGroup } from "../target-group/sim-elbv2-target-group.js";
+
+/**
+ * The service principal Elastic Load Balancing invokes a Lambda function as.
+ */
+export const simElbV2ServicePrincipal = "elasticloadbalancing.amazonaws.com";
+
+interface SimElbV2InvokeAuthorizerProperties {
+  readonly iam: SimIamInterServiceAuthZ;
+}
+
+interface SimElbV2InvokeAuthorizationInput {
+  readonly simFunction: SimLambdaFunction;
+  readonly targetGroup: SimElbV2TargetGroup;
+  readonly accountId: string;
+}
+
+/**
+ * Decides whether a load balancer may invoke the function in a target group.
+ *
+ * A Lambda target registered through CloudFormation, the CLI or an SDK does not
+ * serve anything until the function's resource policy allows
+ * `elasticloadbalancing.amazonaws.com` to invoke it. That grant is the one
+ * thing standing between a target group that looks configured and one that
+ * answers, and forgetting it is a common way to get a load balancer that
+ * returns nothing but errors.
+ *
+ * Whether a service may invoke a function is Lambda's own rule, so the decision
+ * is made there. What this adds is the part only ELB knows: which target group
+ * is calling.
+ *
+ * The answer is a decision rather than a thrown error, because a refusal is an
+ * ordinary HTTP outcome: the load balancer answers 502 the way real ELB does,
+ * with nothing to propagate to a caller in process.
+ */
+export class SimElbV2InvokeAuthorizer {
+  private readonly lambdaAuthorizer: SimLambdaServiceInvokeAuthorizer;
+
+  constructor(properties: SimElbV2InvokeAuthorizerProperties) {
+    this.lambdaAuthorizer = new SimLambdaServiceInvokeAuthorizer({
+      iam: properties.iam,
+    });
+  }
+
+  /**
+   * Evaluate `lambda:InvokeFunction` for the load balancer against the
+   * function.
+   *
+   * The target group is supplied as `AWS:SourceArn` and its Account as
+   * `AWS:SourceAccount`, which is what the `add-permission` call in the ELB
+   * documentation names, so a permission granted for one target group does not
+   * open another.
+   */
+  authorize(
+    input: SimElbV2InvokeAuthorizationInput,
+  ): SimIamAuthorizationDecision {
+    return this.lambdaAuthorizer.authorize({
+      simFunction: input.simFunction,
+      servicePrincipal: simElbV2ServicePrincipal,
+      sourceArn: input.targetGroup.arn,
+      sourceAccount: input.accountId,
+    });
+  }
+}

--- a/src/service/elbv2/serve/sim-elbv2-invoke-permission.iso.test.ts
+++ b/src/service/elbv2/serve/sim-elbv2-invoke-permission.iso.test.ts
@@ -1,0 +1,220 @@
+import {
+  AddPermissionCommand,
+  RemovePermissionCommand,
+} from "@aws-sdk/client-lambda";
+import { assertIdentical } from "@kensio/smartass";
+import { describe, expect, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import type { SimElbV2Result } from "./sim-elbv2-event.type.js";
+import { simElbV2Fetch } from "./sim-elbv2-fetch.js";
+import { simElbV2LambdaTargetFactory } from "./sim-elbv2-lambda-target.factory.js";
+
+/**
+ * The ARN of the target group the factory creates.
+ */
+const targetGroupArn =
+  "arn:aws:elasticloadbalancing:us-east-1:888888888888:targetgroup/checkout-tg/0000000000000001";
+
+/**
+ * Take the invoke permission the factory granted back off the function, so a
+ * test states the grant it is about itself.
+ */
+async function revokeInvokePermission(simAws: SimAws): Promise<void> {
+  await simAws.lambda().removePermission(
+    new RemovePermissionCommand({
+      FunctionName: "checkout",
+      StatementId: "elb-invoke",
+    }),
+  );
+}
+
+describe("Invoking a sim ELBv2 target group's function", () => {
+  it("refuses a function whose resource policy grants the load balancer nothing", async () => {
+    // Given a target group whose function has no resource policy at all
+    const simAws = new SimAws();
+    let invocations = 0;
+    const loadBalancer = await simElbV2LambdaTargetFactory.make(
+      {
+        handler: (): SimElbV2Result => {
+          invocations += 1;
+          return { statusCode: 200, body: "checkout" };
+        },
+      },
+      simAws,
+    );
+    await revokeInvokePermission(simAws);
+
+    // When a request reaches the load balancer
+    const response = await simElbV2Fetch(
+      simAws,
+      `http://${loadBalancer.dnsName}/orders`,
+    );
+
+    // Then the load balancer could not invoke the function and answers 502,
+    // and the handler never ran
+    assertIdentical(response.status, 502);
+    assertIdentical(invocations, 0);
+  });
+
+  it("serves the same request once the permission is granted", async () => {
+    // Given the same target group, refused for want of the permission
+    const simAws = new SimAws();
+    const loadBalancer = await simElbV2LambdaTargetFactory.make({}, simAws);
+    await revokeInvokePermission(simAws);
+    const refused = await simElbV2Fetch(
+      simAws,
+      `http://${loadBalancer.dnsName}/orders`,
+    );
+
+    // When the function grants Elastic Load Balancing the invoke action for
+    // this target group, which is the grant the ELB documentation writes
+    await simAws.lambda().addPermission(
+      new AddPermissionCommand({
+        FunctionName: "checkout",
+        StatementId: "elb-invoke",
+        Action: "lambda:InvokeFunction",
+        Principal: "elasticloadbalancing.amazonaws.com",
+        SourceArn: targetGroupArn,
+      }),
+    );
+    const served = await simElbV2Fetch(
+      simAws,
+      `http://${loadBalancer.dnsName}/orders`,
+    );
+
+    // Then the permission is the whole of the difference
+    assertIdentical(refused.status, 502);
+    assertIdentical(served.status, 200);
+    expect(await served.text()).toBe("checkout");
+  });
+
+  it("allows a permission granted with no source ARN", async () => {
+    // Given a function granting the ELB service principal the invoke action
+    // for anything
+    const simAws = new SimAws();
+    const loadBalancer = await simElbV2LambdaTargetFactory.make({}, simAws);
+    await revokeInvokePermission(simAws);
+    await simAws.lambda().addPermission(
+      new AddPermissionCommand({
+        FunctionName: "checkout",
+        StatementId: "elb-invoke",
+        Action: "lambda:InvokeFunction",
+        Principal: "elasticloadbalancing.amazonaws.com",
+      }),
+    );
+
+    // When a request reaches the load balancer
+    const response = await simElbV2Fetch(
+      simAws,
+      `http://${loadBalancer.dnsName}/orders`,
+    );
+
+    // Then the unconditioned grant admits it
+    assertIdentical(response.status, 200);
+  });
+
+  it("refuses a permission naming a different target group", async () => {
+    // Given a grant for a target group other than the one forwarding here
+    const simAws = new SimAws();
+    const loadBalancer = await simElbV2LambdaTargetFactory.make({}, simAws);
+    await revokeInvokePermission(simAws);
+    await simAws.lambda().addPermission(
+      new AddPermissionCommand({
+        FunctionName: "checkout",
+        StatementId: "elb-invoke",
+        Action: "lambda:InvokeFunction",
+        Principal: "elasticloadbalancing.amazonaws.com",
+        SourceArn:
+          "arn:aws:elasticloadbalancing:us-east-1:888888888888:targetgroup/refunds-tg/0000000000000009",
+      }),
+    );
+
+    // When a request reaches the load balancer
+    const response = await simElbV2Fetch(
+      simAws,
+      `http://${loadBalancer.dnsName}/orders`,
+    );
+
+    // Then the source ARN of the invocation does not match the grant, so a
+    // permission written for one target group does not open another
+    assertIdentical(response.status, 502);
+  });
+
+  it("refuses a permission granted to a different service", async () => {
+    // Given the grant an API Gateway integration needs, on an ELB target
+    const simAws = new SimAws();
+    const loadBalancer = await simElbV2LambdaTargetFactory.make({}, simAws);
+    await revokeInvokePermission(simAws);
+    await simAws.lambda().addPermission(
+      new AddPermissionCommand({
+        FunctionName: "checkout",
+        StatementId: "api-gateway-invoke",
+        Action: "lambda:InvokeFunction",
+        Principal: "apigateway.amazonaws.com",
+      }),
+    );
+
+    // When a request reaches the load balancer
+    const response = await simElbV2Fetch(
+      simAws,
+      `http://${loadBalancer.dnsName}/orders`,
+    );
+
+    // Then a grant to another service principal is no grant to this one
+    assertIdentical(response.status, 502);
+  });
+
+  it("supplies the target group's Account as the source Account", async () => {
+    // Given a grant conditioned on the Account the target group belongs to
+    const simAws = new SimAws();
+    const loadBalancer = await simElbV2LambdaTargetFactory.make({}, simAws);
+    await revokeInvokePermission(simAws);
+    await simAws.lambda().addPermission(
+      new AddPermissionCommand({
+        FunctionName: "checkout",
+        StatementId: "elb-invoke",
+        Action: "lambda:InvokeFunction",
+        Principal: "elasticloadbalancing.amazonaws.com",
+        SourceArn: targetGroupArn,
+        SourceAccount: "888888888888",
+      }),
+    );
+
+    // When a request reaches the load balancer
+    const response = await simElbV2Fetch(
+      simAws,
+      `http://${loadBalancer.dnsName}/orders`,
+    );
+
+    // Then the confused deputy condition the ELB documentation recommends
+    // matches, because the load balancer supplies it
+    assertIdentical(response.status, 200);
+  });
+
+  it("refuses a permission conditioned on another Account", async () => {
+    // Given the same grant naming an Account the target group is not in
+    const simAws = new SimAws();
+    const loadBalancer = await simElbV2LambdaTargetFactory.make({}, simAws);
+    await revokeInvokePermission(simAws);
+    await simAws.lambda().addPermission(
+      new AddPermissionCommand({
+        FunctionName: "checkout",
+        StatementId: "elb-invoke",
+        Action: "lambda:InvokeFunction",
+        Principal: "elasticloadbalancing.amazonaws.com",
+        SourceArn: targetGroupArn,
+        SourceAccount: "222222222222",
+      }),
+    );
+
+    // When a request reaches the load balancer
+    const response = await simElbV2Fetch(
+      simAws,
+      `http://${loadBalancer.dnsName}/orders`,
+    );
+
+    // Then the condition does not match what the load balancer supplied
+    assertIdentical(response.status, 502);
+  });
+});

--- a/src/service/elbv2/serve/sim-elbv2-lambda-target-invocation.ts
+++ b/src/service/elbv2/serve/sim-elbv2-lambda-target-invocation.ts
@@ -1,0 +1,119 @@
+import type { SimClock } from "../../../util/clock/sim-clock.js";
+import type { SimElbV2Listener } from "../listener/sim-elbv2-listener.js";
+import type { SimElbV2LoadBalancer } from "../load-balancer/sim-elbv2-load-balancer.js";
+import type { SimElbV2TargetGroup } from "../target-group/sim-elbv2-target-group.js";
+import { SimElbV2ErrorResponse } from "./sim-elbv2-error-response.js";
+import { SimElbV2EventBuilder } from "./sim-elbv2-event-builder.js";
+import { SimElbV2InvokeAuthorizer } from "./sim-elbv2-invoke-authorizer.js";
+import { SimElbV2ResponseBuilder } from "./sim-elbv2-response-builder.js";
+import type {
+  SimElbV2FunctionTarget,
+  SimElbV2Router,
+} from "./sim-elbv2-router.js";
+
+/**
+ * The largest request body real ELB sends to a Lambda target.
+ */
+const maximumRequestBytes = 1024 * 1024;
+
+interface SimElbV2LambdaTargetInvocationProperties {
+  readonly router: SimElbV2Router;
+  /** Clock the invocation event is stamped with. */
+  readonly clock: SimClock;
+}
+
+interface SimElbV2LambdaTargetInvocationInput {
+  readonly loadBalancer: SimElbV2LoadBalancer;
+  readonly listener: SimElbV2Listener;
+  readonly targetGroup: SimElbV2TargetGroup;
+  readonly request: Request;
+}
+
+/**
+ * Invokes the Lambda function registered in a target group, and turns what it
+ * returns into the HTTP response.
+ *
+ * A target group with nothing in it is a 503, because there is no target to
+ * send the request to. Everything that goes wrong once there is one is a 502:
+ * a function that is not there, one the load balancer may not invoke, one that
+ * threw, and one whose result is not a response. That is what real ELB does
+ * too, and it is why the load balancer's own logs are the only place the
+ * difference between them shows.
+ */
+export class SimElbV2LambdaTargetInvocation {
+  private readonly router: SimElbV2Router;
+  private readonly eventBuilder: SimElbV2EventBuilder;
+  private readonly responseBuilder = new SimElbV2ResponseBuilder();
+  private readonly errorResponse = new SimElbV2ErrorResponse();
+
+  constructor(properties: SimElbV2LambdaTargetInvocationProperties) {
+    this.router = properties.router;
+    this.eventBuilder = new SimElbV2EventBuilder({
+      clock: properties.clock,
+    });
+  }
+
+  /**
+   * Invoke the target group's function for one request.
+   */
+  async invoke(input: SimElbV2LambdaTargetInvocationInput): Promise<Response> {
+    const { targetGroup } = input;
+
+    if (targetGroup.registeredTargets.length === 0) {
+      return this.errorResponse.serviceUnavailable();
+    }
+
+    const target = this.router.functionFor(targetGroup);
+
+    if (target === undefined || this.mayNotInvoke(targetGroup, target)) {
+      return this.errorResponse.badGateway();
+    }
+
+    return await this.run(input, target);
+  }
+
+  /**
+   * Whether the load balancer lacks permission to invoke the function.
+   */
+  private mayNotInvoke(
+    targetGroup: SimElbV2TargetGroup,
+    target: SimElbV2FunctionTarget,
+  ): boolean {
+    return new SimElbV2InvokeAuthorizer({ iam: target.iam }).authorize({
+      simFunction: target.simFunction,
+      targetGroup,
+      accountId: targetGroup.accountRegionScope.accountId,
+    }).isDenied;
+  }
+
+  private async run(
+    input: SimElbV2LambdaTargetInvocationInput,
+    target: SimElbV2FunctionTarget,
+  ): Promise<Response> {
+    const { loadBalancer, listener, targetGroup, request } = input;
+
+    try {
+      const bytes = new Uint8Array(await request.arrayBuffer());
+
+      if (bytes.length > maximumRequestBytes) {
+        return this.errorResponse.payloadTooLarge();
+      }
+
+      const event = this.eventBuilder.build({
+        request,
+        bytes,
+        targetGroupArn: targetGroup.arn,
+        dnsName: loadBalancer.dnsName,
+        port: listener.port,
+        protocol: listener.protocol,
+      });
+
+      return this.responseBuilder.build(await target.simFunction.invoke(event));
+    } catch {
+      // A handler that threw is a 502 with the error only in the function's
+      // own logs, as it is on real ELB. Reading the request body can fail the
+      // same way, so building the event is inside this too.
+      return this.errorResponse.badGateway();
+    }
+  }
+}

--- a/src/service/elbv2/serve/sim-elbv2-lambda-target.factory.ts
+++ b/src/service/elbv2/serve/sim-elbv2-lambda-target.factory.ts
@@ -1,0 +1,125 @@
+import { AsyncMappedFactory } from "@kensio/part-factory";
+
+import { assertDefined } from "../../../util/type-guard/defined.js";
+import type { SimAws } from "../../aws/sim-aws.js";
+import { makeLambdaZipFileInput } from "../../lambda/function/code/lambda-zip-file-input.js";
+import type { SimElbV2LoadBalancer } from "../load-balancer/sim-elbv2-load-balancer.js";
+import {
+  createFixtureLambdaTargetGroup,
+  createFixtureListener,
+  createFixtureLoadBalancer,
+} from "../sim-elbv2.fixture.js";
+import type { SimElbV2Event, SimElbV2Result } from "./sim-elbv2-event.type.js";
+import { simElbV2ServicePrincipal } from "./sim-elbv2-invoke-authorizer.js";
+
+/**
+ * The load balancer, target group and function this builds.
+ *
+ * The names are fixed rather than asked for, so a test asserting on an ARN or
+ * a DNS name has one value to write down.
+ */
+export const simElbV2LambdaTargetNames = {
+  loadBalancer: "shop-alb",
+  targetGroup: "checkout-tg",
+  function: "checkout",
+  /** The statement id the invoke permission is granted under. */
+  invokeStatement: "elb-invoke",
+} as const;
+
+/**
+ * What a test asks for when it wants a load balancer that serves something.
+ */
+export interface SimElbV2LambdaTargetInput {
+  /** The function code the load balancer hands its requests to. */
+  readonly handler: (event: SimElbV2Event) => unknown;
+  /** The port the listener answers on. */
+  readonly listenerPort: number;
+}
+
+/**
+ * Creates a load balancer that forwards every request to a Lambda function,
+ * through the ordinary commands.
+ *
+ * Five commands and a function stand between a test and a request a load
+ * balancer can answer, and a test about answering one is about none of them.
+ * Tests about the commands themselves send them one at a time instead.
+ *
+ * ```typescript
+ * const loadBalancer = await simElbV2LambdaTargetFactory.make(
+ *   { handler: () => ({ statusCode: 200, body: "hello" }) },
+ *   simAws,
+ * );
+ * ```
+ *
+ * What comes back is a load balancer that serves: the function is registered
+ * and it grants the load balancer the invoke action. A test about one of those
+ * missing takes it away again, which is also what a working stack losing it
+ * looks like.
+ *
+ * Everything is created in the default Account and Region of the simulated AWS
+ * it is given, because real ELB requires a Lambda target to be in the same
+ * Account and Region as its target group.
+ */
+export const simElbV2LambdaTargetFactory = new AsyncMappedFactory<
+  SimElbV2LambdaTargetInput,
+  SimElbV2LoadBalancer,
+  SimAws
+>(
+  () => ({
+    handler: (): SimElbV2Result => ({ statusCode: 200, body: "checkout" }),
+    listenerPort: 80,
+  }),
+  async (input, simAws) => {
+    const names = simElbV2LambdaTargetNames;
+    const simLambda = simAws.lambda();
+    const { FunctionArn } = await simLambda.createFunction({
+      input: {
+        FunctionName: names.function,
+        Role: "arn:aws:iam::888888888888:role/CheckoutRole",
+        Code: { ZipFile: makeLambdaZipFileInput(input.handler) },
+      },
+    });
+
+    const elbV2 = simAws.elbV2();
+    const balancerArn = await createFixtureLoadBalancer(
+      elbV2,
+      names.loadBalancer,
+    );
+    const groupArn = await createFixtureLambdaTargetGroup(
+      elbV2,
+      names.targetGroup,
+    );
+
+    await simLambda.addPermission({
+      input: {
+        FunctionName: names.function,
+        StatementId: names.invokeStatement,
+        Action: "lambda:InvokeFunction",
+        Principal: simElbV2ServicePrincipal,
+        SourceArn: groupArn,
+      },
+    });
+
+    await elbV2.registerTargets({
+      input: { TargetGroupArn: groupArn, Targets: [{ Id: FunctionArn }] },
+    });
+
+    await createFixtureListener(
+      elbV2,
+      balancerArn,
+      groupArn,
+      input.listenerPort,
+    );
+
+    // A load balancer CreateLoadBalancer reported is one the store holds, so
+    // this is only missing if something is wrong with the simulator itself.
+    const loadBalancer = elbV2.findLoadBalancerByName(names.loadBalancer);
+    assertDefined(
+      loadBalancer,
+      `Simulated ELBv2 created the load balancer ${names.loadBalancer} and ` +
+        `then did not hold it`,
+    );
+
+    return loadBalancer;
+  },
+);

--- a/src/service/elbv2/serve/sim-elbv2-request-parts.ts
+++ b/src/service/elbv2/serve/sim-elbv2-request-parts.ts
@@ -41,7 +41,7 @@ export class SimElbV2RequestParts {
     // arrived at, because that is the host name the request named on real AWS.
     headers.set("host", proxied.dnsName);
     headers.set("x-amzn-trace-id", proxied.traceId);
-    headers.set("x-forwarded-for", proxied.sourceIp);
+    headers.set("x-forwarded-for", this.forwardedFor(headers, proxied));
     headers.set("x-forwarded-port", String(proxied.port));
     headers.set("x-forwarded-proto", proxied.protocol.toLowerCase());
 
@@ -51,13 +51,58 @@ export class SimElbV2RequestParts {
   /**
    * Collect query string parameters, keeping the last value of a repeated key.
    *
-   * That last-value rule is ELB's, and it is what the `multiValueHeaders`
-   * target group attribute exists to turn off. It differs from API Gateway,
-   * which joins repeated values with commas.
+   * The last-value rule is ELB's, and it is what the multi-value headers target
+   * group attribute exists to turn off. API Gateway joins repeated values with
+   * commas instead.
+   *
+   * The query string is read as it arrived rather than through URLSearchParams,
+   * because real ELB does not decode percent escapes and leaves decoding to the
+   * function. A handler therefore reads `a%2Bb` as it was sent, rather than the
+   * `a+b` that decoding it here would produce.
    */
   queryStringParameters(url: URL): Record<string, string> {
-    const parameters = new Map<string, string>(url.searchParams);
+    const parameters = new Map<string, string>();
+
+    for (const pair of url.search.replace(/^\?/u, "").split("&")) {
+      if (pair === "") {
+        continue;
+      }
+
+      parameters.set(...this.queryPair(pair, pair.indexOf("=")));
+    }
 
     return Object.fromEntries(parameters);
+  }
+
+  /**
+   * Split one query string pair, where a key on its own has an empty value.
+   */
+  private queryPair(pair: string, separator: number): [string, string] {
+    if (separator === -1) {
+      return [pair, ""];
+    }
+
+    return [pair.slice(0, separator), pair.slice(separator + 1)];
+  }
+
+  /**
+   * The `x-forwarded-for` header the target sees.
+   *
+   * Real ELB appends the client's address to whatever the request already
+   * carried, which is what makes the header a chain of proxies rather than one
+   * address. The other forwarding headers are overwritten, because those
+   * describe the connection this load balancer terminated.
+   */
+  private forwardedFor(
+    headers: ReadonlyMap<string, string>,
+    proxied: SimElbV2ProxiedRequest,
+  ): string {
+    const forwarded = headers.get("x-forwarded-for");
+
+    if (forwarded === undefined || forwarded === "") {
+      return proxied.sourceIp;
+    }
+
+    return `${forwarded}, ${proxied.sourceIp}`;
   }
 }

--- a/src/service/elbv2/serve/sim-elbv2-request-parts.ts
+++ b/src/service/elbv2/serve/sim-elbv2-request-parts.ts
@@ -1,0 +1,63 @@
+interface SimElbV2ProxiedRequest {
+  readonly request: Request;
+  /** The DNS name of the load balancer the request reached. */
+  readonly dnsName: string;
+  /** The port the listener taking the request answers on. */
+  readonly port: number;
+  /** The protocol that listener speaks, lowercased for the header. */
+  readonly protocol: string;
+  readonly traceId: string;
+  readonly sourceIp: string;
+}
+
+/**
+ * Reads the parts of an HTTP request an ALB invocation event delivers in its
+ * own fields.
+ *
+ * Keeping this separate leaves the event builder to assemble the event from
+ * parts, without also owning the header and query conventions, which are ELB's
+ * own rather than either API Gateway payload format's.
+ */
+export class SimElbV2RequestParts {
+  /**
+   * Collect request headers, which an ALB event delivers as single lowercased
+   * values.
+   *
+   * Cookies stay in the `cookie` header they arrived in, unlike payload format
+   * 2.0, which lifts them into a field of their own. The four headers ELB adds
+   * are set rather than merged: ELB terminates the connection itself and
+   * writes them before the target sees them, so whatever a client sent under
+   * those names does not survive.
+   */
+  headers(proxied: SimElbV2ProxiedRequest): Record<string, string> {
+    // Fetch API header names are already lowercased, which is the case an ALB
+    // event delivers them in.
+    const headers = new Map<string, string>();
+    proxied.request.headers.forEach((value, name) => {
+      headers.set(name, value);
+    });
+
+    // The load balancer's own DNS name, not the localhost one the request
+    // arrived at, because that is the host name the request named on real AWS.
+    headers.set("host", proxied.dnsName);
+    headers.set("x-amzn-trace-id", proxied.traceId);
+    headers.set("x-forwarded-for", proxied.sourceIp);
+    headers.set("x-forwarded-port", String(proxied.port));
+    headers.set("x-forwarded-proto", proxied.protocol.toLowerCase());
+
+    return Object.fromEntries(headers);
+  }
+
+  /**
+   * Collect query string parameters, keeping the last value of a repeated key.
+   *
+   * That last-value rule is ELB's, and it is what the `multiValueHeaders`
+   * target group attribute exists to turn off. It differs from API Gateway,
+   * which joins repeated values with commas.
+   */
+  queryStringParameters(url: URL): Record<string, string> {
+    const parameters = new Map<string, string>(url.searchParams);
+
+    return Object.fromEntries(parameters);
+  }
+}

--- a/src/service/elbv2/serve/sim-elbv2-request-port.ts
+++ b/src/service/elbv2/serve/sim-elbv2-request-port.ts
@@ -1,0 +1,17 @@
+/**
+ * The port a request reached a load balancer on.
+ *
+ * A URL naming no port means the scheme's own, which is what decides between
+ * an HTTP listener on 80 and an HTTPS one on 443 when a client writes neither.
+ */
+export function simElbV2RequestPort(url: URL): number {
+  if (url.port !== "") {
+    return Number(url.port);
+  }
+
+  if (url.protocol === "https:") {
+    return 443;
+  }
+
+  return 80;
+}

--- a/src/service/elbv2/serve/sim-elbv2-response-builder.ts
+++ b/src/service/elbv2/serve/sim-elbv2-response-builder.ts
@@ -4,6 +4,9 @@ import type { SimElbV2Result } from "./sim-elbv2-event.type.js";
 
 /**
  * The largest response real ELB takes from a Lambda target.
+ *
+ * The limit is on the whole response document rather than on the body alone,
+ * so a base64 body counts at its encoded size and the headers count too.
  */
 const maximumResponseBytes = 1024 * 1024;
 
@@ -52,15 +55,15 @@ export class SimElbV2ResponseBuilder {
       return this.errorResponse.badGateway();
     }
 
+    if (this.isTooLarge(result)) {
+      return this.errorResponse.badGateway();
+    }
+
     const statusCode = result.statusCode;
     const body = this.bodyEncoding.decode(
       result.body ?? "",
       result.isBase64Encoded ?? false,
     );
-
-    if (body.length > maximumResponseBytes) {
-      return this.errorResponse.badGateway();
-    }
 
     return new Response(this.sendableBody(statusCode, body), {
       status: statusCode,
@@ -84,8 +87,22 @@ export class SimElbV2ResponseBuilder {
     const statusCode = (result as SimElbV2Result).statusCode;
 
     return (
-      typeof statusCode === "number" && statusCode >= 200 && statusCode <= 599
+      Number.isSafeInteger(statusCode) &&
+      typeof statusCode === "number" &&
+      statusCode >= 200 &&
+      statusCode <= 599
     );
+  }
+
+  /**
+   * Whether the response document is larger than a load balancer takes back.
+   *
+   * The whole document is measured, as real ELB measures it, so a body that is
+   * under the limit once decoded is still refused when its base64 and its
+   * headers put the response over.
+   */
+  private isTooLarge(result: SimElbV2SendableResult): boolean {
+    return Buffer.byteLength(JSON.stringify(result)) > maximumResponseBytes;
   }
 
   /**

--- a/src/service/elbv2/serve/sim-elbv2-response-builder.ts
+++ b/src/service/elbv2/serve/sim-elbv2-response-builder.ts
@@ -1,0 +1,137 @@
+import { SimElbV2BodyEncoding } from "./sim-elbv2-body-encoding.js";
+import { SimElbV2ErrorResponse } from "./sim-elbv2-error-response.js";
+import type { SimElbV2Result } from "./sim-elbv2-event.type.js";
+
+/**
+ * The largest response real ELB takes from a Lambda target.
+ */
+const maximumResponseBytes = 1024 * 1024;
+
+/**
+ * The statuses that cannot carry a body, whatever a handler returns with them.
+ */
+const nullBodyStatuses: ReadonlySet<number> = new Set([204, 205, 304]);
+
+/**
+ * The response headers a load balancer writes itself rather than passing on.
+ *
+ * ELB does not honour hop-by-hop headers, and it computes the content length
+ * from the body it is about to send, so a handler naming any of these is
+ * naming something the load balancer decides.
+ */
+const loadBalancerOwnedHeaders: ReadonlySet<string> = new Set([
+  "connection",
+  "content-length",
+  "keep-alive",
+  "transfer-encoding",
+]);
+
+/**
+ * A handler result a load balancer can actually send, which is one carrying a
+ * status code.
+ */
+type SimElbV2SendableResult = SimElbV2Result & { readonly statusCode: number };
+
+/**
+ * Turns what a Lambda target returned into the HTTP response the client sees.
+ *
+ * A load balancer takes one shape here, unlike API Gateway, which wraps
+ * anything unrecognised in a 200. A result with no usable status code is not a
+ * response ELB can send, so the client gets the load balancer's own 502 and
+ * never sees the handler's shape.
+ */
+export class SimElbV2ResponseBuilder {
+  private readonly bodyEncoding = new SimElbV2BodyEncoding();
+  private readonly errorResponse = new SimElbV2ErrorResponse();
+
+  /**
+   * Build the HTTP response for one handler result.
+   */
+  build(result: unknown): Response {
+    if (!this.isResult(result)) {
+      return this.errorResponse.badGateway();
+    }
+
+    const statusCode = result.statusCode;
+    const body = this.bodyEncoding.decode(
+      result.body ?? "",
+      result.isBase64Encoded ?? false,
+    );
+
+    if (body.length > maximumResponseBytes) {
+      return this.errorResponse.badGateway();
+    }
+
+    return new Response(this.sendableBody(statusCode, body), {
+      status: statusCode,
+      statusText: this.statusText(result, statusCode),
+      headers: this.headers(result),
+    });
+  }
+
+  /**
+   * Whether the handler returned something a load balancer can send.
+   *
+   * The status code is the whole of the test, as it is on real ELB: anything
+   * else the result carries is optional, and a result without a status code in
+   * the range a response can hold is malformed.
+   */
+  private isResult(result: unknown): result is SimElbV2SendableResult {
+    if (typeof result !== "object" || result === null) {
+      return false;
+    }
+
+    const statusCode = (result as SimElbV2Result).statusCode;
+
+    return (
+      typeof statusCode === "number" && statusCode >= 200 && statusCode <= 599
+    );
+  }
+
+  /**
+   * The body actually sent, which is nothing for a status that cannot hold
+   * one, and for an empty one.
+   */
+  private sendableBody(
+    statusCode: number,
+    body: Uint8Array | string,
+  ): Uint8Array | string | null {
+    if (nullBodyStatuses.has(statusCode) || body.length === 0) {
+      return null;
+    }
+
+    return body;
+  }
+
+  /**
+   * The reason phrase the response carries.
+   *
+   * Real ELB takes a `statusDescription` such as `200 OK` and puts it in the
+   * status line, where the code is already. The code is therefore taken off
+   * again here, so a client reading the reason phrase finds `OK`, which is what
+   * it would read from a real load balancer.
+   */
+  private statusText(result: SimElbV2Result, statusCode: number): string {
+    const description = result.statusDescription ?? "";
+    const prefix = `${String(statusCode)} `;
+
+    if (description.startsWith(prefix)) {
+      return description.slice(prefix.length);
+    }
+
+    return description;
+  }
+
+  private headers(result: SimElbV2Result): Headers {
+    const headers = new Headers();
+    const named = Object.entries(result.headers ?? {});
+
+    for (const [name, value] of named) {
+      if (!loadBalancerOwnedHeaders.has(name.toLowerCase())) {
+        headers.set(name, value);
+      }
+    }
+
+    return headers;
+  }
+}

--- a/src/service/elbv2/serve/sim-elbv2-router.ts
+++ b/src/service/elbv2/serve/sim-elbv2-router.ts
@@ -1,6 +1,6 @@
 import type { SimAwsServiceTarget } from "../../../serve/controller/sim-service-controller.js";
 import { assertDefined } from "../../../util/type-guard/defined.js";
-import { SimAws } from "../../aws/sim-aws.js";
+import type { SimAws } from "../../aws/sim-aws.js";
 import type { SimIamInterServiceAuthZ } from "../../iam/authorize/sim-iam-inter-service-auth-z.js";
 import { parseSimLambdaFunctionArn } from "../../lambda/function/sim-lambda-function-arn-parts.js";
 import type { SimLambdaFunction } from "../../lambda/function/sim-lambda-function.js";
@@ -10,7 +10,11 @@ import type { SimElbV2 } from "../sim-elbv2.js";
 import type { SimElbV2TargetGroup } from "../target-group/sim-elbv2-target-group.js";
 
 interface SimElbV2RouterProperties {
-  readonly simAws?: SimAws;
+  /**
+   * The simulation to route within. Required, because a router with a
+   * simulation of its own would find no load balancer anything created.
+   */
+  readonly simAws: SimAws;
 }
 
 /**
@@ -37,10 +41,11 @@ export interface SimElbV2FunctionTarget {
  * Routes a request to the load balancer behind its host name, and a target
  * group to the function behind that.
  *
- * The host name gives the Region, because real ELB puts it there, but not the
- * Account. The registry supplies that missing hop. The function is not a second
- * hop: real ELB requires a Lambda target to be in the same Account and Region
- * as its target group, so that is the only scope it is looked for in.
+ * A host name names nothing but itself, while simulated ELBv2 state is per
+ * Account and Region, and the registry is the hop between the two. The function
+ * is not a second hop: real ELB
+ * requires a Lambda target to be in the same Account and Region as its target
+ * group, so that is the only scope it is looked for in.
  */
 export class SimElbV2Router {
   /**
@@ -54,8 +59,8 @@ export class SimElbV2Router {
 
   private readonly registry: SimElbV2Registry;
 
-  constructor(properties: SimElbV2RouterProperties = {}) {
-    this.simAws = properties.simAws ?? new SimAws();
+  constructor(properties: SimElbV2RouterProperties) {
+    this.simAws = properties.simAws;
     this.registry = this.simAws.serviceFactory.elbV2Registry;
   }
 
@@ -63,23 +68,23 @@ export class SimElbV2Router {
    * Find the load balancer a request target addresses.
    */
   route(target: SimAwsServiceTarget): SimElbV2LoadBalancerRoute | undefined {
-    const accountId = this.registry.accountIdForDnsName(target.resourceName);
+    const scope = this.registry.scopeForDnsName(target.resourceName);
 
-    if (accountId === undefined) {
+    if (scope === undefined) {
       return undefined;
     }
 
     const elbV2 = this.simAws
-      .accountRegionScope(accountId, target.regionName)
+      .accountRegionScope(scope.accountId, scope.regionName)
       .elbV2();
     const loadBalancer = elbV2.findLoadBalancerByDnsName(target.resourceName);
 
-    // A registered DNS name is one the scope's own store holds, because the
+    // A registered DNS name is one that scope's own store holds, because the
     // store is what registers and deregisters it.
     assertDefined(
       loadBalancer,
-      `Account ${accountId} is registered for the load balancer DNS name ` +
-        `${target.resourceName} and does not hold it`,
+      `${scope.accountId} in ${scope.regionName} is registered for the load ` +
+        `balancer DNS name ${target.resourceName} and does not hold it`,
     );
 
     return { loadBalancer, elbV2 };

--- a/src/service/elbv2/serve/sim-elbv2-router.ts
+++ b/src/service/elbv2/serve/sim-elbv2-router.ts
@@ -1,0 +1,132 @@
+import type { SimAwsServiceTarget } from "../../../serve/controller/sim-service-controller.js";
+import { assertDefined } from "../../../util/type-guard/defined.js";
+import { SimAws } from "../../aws/sim-aws.js";
+import type { SimIamInterServiceAuthZ } from "../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { parseSimLambdaFunctionArn } from "../../lambda/function/sim-lambda-function-arn-parts.js";
+import type { SimLambdaFunction } from "../../lambda/function/sim-lambda-function.js";
+import type { SimElbV2LoadBalancer } from "../load-balancer/sim-elbv2-load-balancer.js";
+import type { SimElbV2Registry } from "../registry/sim-elbv2-registry.js";
+import type { SimElbV2 } from "../sim-elbv2.js";
+import type { SimElbV2TargetGroup } from "../target-group/sim-elbv2-target-group.js";
+
+interface SimElbV2RouterProperties {
+  readonly simAws?: SimAws;
+}
+
+/**
+ * A load balancer a request reached, and the scope it lives in.
+ */
+export interface SimElbV2LoadBalancerRoute {
+  readonly loadBalancer: SimElbV2LoadBalancer;
+  readonly elbV2: SimElbV2;
+}
+
+/**
+ * A function a target group invokes, and what decides whether it may.
+ */
+export interface SimElbV2FunctionTarget {
+  readonly simFunction: SimLambdaFunction;
+  /**
+   * IAM of the Account owning the function, which is what the load balancer's
+   * invoke permission is evaluated against.
+   */
+  readonly iam: SimIamInterServiceAuthZ;
+}
+
+/**
+ * Routes a request to the load balancer behind its host name, and a target
+ * group to the function behind that.
+ *
+ * The host name gives the Region, because real ELB puts it there, but not the
+ * Account. The registry supplies that missing hop. The function is not a second
+ * hop: real ELB requires a Lambda target to be in the same Account and Region
+ * as its target group, so that is the only scope it is looked for in.
+ */
+export class SimElbV2Router {
+  /**
+   * The simulation this router routes within.
+   *
+   * Exposed so collaborators needing the same simulation, such as the clock
+   * stamping invocation events, take it from here rather than being given a
+   * second SimAws that could be a different one.
+   */
+  public readonly simAws: SimAws;
+
+  private readonly registry: SimElbV2Registry;
+
+  constructor(properties: SimElbV2RouterProperties = {}) {
+    this.simAws = properties.simAws ?? new SimAws();
+    this.registry = this.simAws.serviceFactory.elbV2Registry;
+  }
+
+  /**
+   * Find the load balancer a request target addresses.
+   */
+  route(target: SimAwsServiceTarget): SimElbV2LoadBalancerRoute | undefined {
+    const accountId = this.registry.accountIdForDnsName(target.resourceName);
+
+    if (accountId === undefined) {
+      return undefined;
+    }
+
+    const elbV2 = this.simAws
+      .accountRegionScope(accountId, target.regionName)
+      .elbV2();
+    const loadBalancer = elbV2.findLoadBalancerByDnsName(target.resourceName);
+
+    // A registered DNS name is one the scope's own store holds, because the
+    // store is what registers and deregisters it.
+    assertDefined(
+      loadBalancer,
+      `Account ${accountId} is registered for the load balancer DNS name ` +
+        `${target.resourceName} and does not hold it`,
+    );
+
+    return { loadBalancer, elbV2 };
+  }
+
+  /**
+   * Find the function registered in a target group, and the IAM deciding
+   * whether the load balancer may invoke it.
+   *
+   * A target naming another Account or Region finds nothing. Real ELB refuses
+   * to register one at all, so answering as though it were there would be the
+   * looser of the two behaviours.
+   */
+  functionFor(
+    targetGroup: SimElbV2TargetGroup,
+  ): SimElbV2FunctionTarget | undefined {
+    const target = targetGroup.registeredTargets[0];
+
+    // A group with nothing in it never gets here: that is the 503 the load
+    // balancer answers before it looks for a function.
+    assertDefined(
+      target,
+      `Target group ${targetGroup.name} has no registered target`,
+    );
+
+    const parts = parseSimLambdaFunctionArn(target.id);
+    const { accountId, regionName } = targetGroup.accountRegionScope;
+
+    // A lambda target group refuses anything but a function ARN when the
+    // target is registered, so a registered one is always readable.
+    assertDefined(
+      parts,
+      `Target '${target.id}' in target group ${targetGroup.name} is not a ` +
+        `Lambda function ARN`,
+    );
+
+    if (parts.accountId !== accountId || parts.regionName !== regionName) {
+      return undefined;
+    }
+
+    const scope = this.simAws.accountRegionScope(accountId, regionName);
+    const simFunction = scope.lambda().getSimFunctionByName(parts.functionName);
+
+    if (simFunction === undefined) {
+      return undefined;
+    }
+
+    return { simFunction, iam: scope.iam() };
+  }
+}

--- a/src/service/elbv2/serve/sim-elbv2-serve-errors.iso.test.ts
+++ b/src/service/elbv2/serve/sim-elbv2-serve-errors.iso.test.ts
@@ -1,0 +1,250 @@
+import { assertIdentical } from "@kensio/smartass";
+import { describe, expect, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import type { SimElbV2Result } from "./sim-elbv2-event.type.js";
+import { simElbV2Fetch } from "./sim-elbv2-fetch.js";
+import { simElbV2LambdaTargetFactory } from "./sim-elbv2-lambda-target.factory.js";
+
+/**
+ * The ARN of the target group the factory creates.
+ */
+const targetGroupArn =
+  "arn:aws:elasticloadbalancing:us-east-1:888888888888:targetgroup/checkout-tg/0000000000000001";
+
+/**
+ * Take the registered function out of the target group, leaving it empty.
+ */
+async function deregisterFunction(simAws: SimAws): Promise<void> {
+  await simAws.elbV2().deregisterTargets({
+    input: {
+      TargetGroupArn: targetGroupArn,
+      Targets: [
+        { Id: "arn:aws:lambda:us-east-1:888888888888:function:checkout" },
+      ],
+    },
+  });
+}
+
+describe("What a sim ELBv2 load balancer answers when a target fails", () => {
+  it("answers 503 for a target group with nothing registered in it", async () => {
+    // Given a load balancer whose function has been taken out of the target
+    // group, leaving it empty
+    const simAws = new SimAws();
+    const loadBalancer = await simElbV2LambdaTargetFactory.make({}, simAws);
+    await deregisterFunction(simAws);
+
+    // When a request reaches it
+    const response = await simElbV2Fetch(
+      simAws,
+      `http://${loadBalancer.dnsName}/orders`,
+    );
+
+    // Then there is no target to send it to, which is what real ELB answers
+    // 503 for
+    assertIdentical(response.status, 503);
+    assertIdentical(response.statusText, "Service Unavailable");
+  });
+
+  it("answers 502 for a handler result with no status code", async () => {
+    // Given a handler answering with a body and nothing else, which is what a
+    // handler written for an API Gateway proxy integration returns
+    const simAws = new SimAws();
+    const loadBalancer = await simElbV2LambdaTargetFactory.make(
+      { handler: (): unknown => ({ body: "checkout" }) },
+      simAws,
+    );
+
+    // When a request reaches it
+    const response = await simElbV2Fetch(
+      simAws,
+      `http://${loadBalancer.dnsName}/orders`,
+    );
+
+    // Then the load balancer answers 502 rather than passing the handler's
+    // shape on to the client, as real ELB does
+    assertIdentical(response.status, 502);
+    assertIdentical(response.statusText, "Bad Gateway");
+    expect(await response.text()).toContain("502 Bad Gateway");
+  });
+
+  it("answers 502 for a handler returning something that is not a result", async () => {
+    // Given a handler answering with a bare string
+    const simAws = new SimAws();
+    const loadBalancer = await simElbV2LambdaTargetFactory.make(
+      { handler: (): unknown => "checkout" },
+      simAws,
+    );
+
+    // When a request reaches it
+    const response = await simElbV2Fetch(
+      simAws,
+      `http://${loadBalancer.dnsName}/orders`,
+    );
+
+    // Then there is no response in it, so the load balancer answers its own
+    assertIdentical(response.status, 502);
+  });
+
+  it("answers 502 for a status code outside the range a response can hold", async () => {
+    // Given a handler answering with a number that is not an HTTP status
+    const simAws = new SimAws();
+    const loadBalancer = await simElbV2LambdaTargetFactory.make(
+      { handler: (): unknown => ({ statusCode: 99, body: "checkout" }) },
+      simAws,
+    );
+
+    // When a request reaches it
+    const response = await simElbV2Fetch(
+      simAws,
+      `http://${loadBalancer.dnsName}/orders`,
+    );
+
+    // Then it is malformed for the same reason a missing one is
+    assertIdentical(response.status, 502);
+  });
+
+  it("answers 502 when the handler throws", async () => {
+    // Given a handler that fails
+    const simAws = new SimAws();
+    const loadBalancer = await simElbV2LambdaTargetFactory.make(
+      {
+        handler: (): SimElbV2Result => {
+          throw new Error("no stock");
+        },
+      },
+      simAws,
+    );
+
+    // When a request reaches it
+    const response = await simElbV2Fetch(
+      simAws,
+      `http://${loadBalancer.dnsName}/orders`,
+    );
+
+    // Then the error stays in the function's own logs, as it does on real ELB
+    assertIdentical(response.status, 502);
+  });
+
+  it("answers 502 when the registered function is not there", async () => {
+    // Given a target group naming a function that was never created
+    const simAws = new SimAws();
+    const loadBalancer = await simElbV2LambdaTargetFactory.make({}, simAws);
+    const elbV2 = simAws.elbV2();
+    await deregisterFunction(simAws);
+    await elbV2.registerTargets({
+      input: {
+        TargetGroupArn: targetGroupArn,
+        Targets: [
+          { Id: "arn:aws:lambda:us-east-1:888888888888:function:refunds" },
+        ],
+      },
+    });
+
+    // When a request reaches it
+    const response = await simElbV2Fetch(
+      simAws,
+      `http://${loadBalancer.dnsName}/orders`,
+    );
+
+    // Then the load balancer has a target and cannot invoke it
+    assertIdentical(response.status, 502);
+  });
+
+  it("answers 502 for a target in another Account or Region", async () => {
+    // Given a target group naming a function in another Region, which real ELB
+    // refuses to register at all
+    const simAws = new SimAws();
+    const loadBalancer = await simElbV2LambdaTargetFactory.make({}, simAws);
+    const elbV2 = simAws.elbV2();
+    await deregisterFunction(simAws);
+    await elbV2.registerTargets({
+      input: {
+        TargetGroupArn: targetGroupArn,
+        Targets: [
+          { Id: "arn:aws:lambda:eu-west-1:888888888888:function:checkout" },
+        ],
+      },
+    });
+
+    // When a request reaches it
+    const response = await simElbV2Fetch(
+      simAws,
+      `http://${loadBalancer.dnsName}/orders`,
+    );
+
+    // Then the function is not looked for outside the target group's own
+    // scope, so there is nothing to invoke
+    assertIdentical(response.status, 502);
+  });
+
+  it("answers 502 for a target in another Account", async () => {
+    // Given a target group naming a function in another Account, which real
+    // ELB refuses to register at all
+    const simAws = new SimAws();
+    const loadBalancer = await simElbV2LambdaTargetFactory.make({}, simAws);
+    const elbV2 = simAws.elbV2();
+    await deregisterFunction(simAws);
+    await elbV2.registerTargets({
+      input: {
+        TargetGroupArn: targetGroupArn,
+        Targets: [
+          { Id: "arn:aws:lambda:us-east-1:222222222222:function:checkout" },
+        ],
+      },
+    });
+
+    // When a request reaches it
+    const response = await simElbV2Fetch(
+      simAws,
+      `http://${loadBalancer.dnsName}/orders`,
+    );
+
+    // Then the function is not looked for outside the target group's own
+    // Account, so there is nothing to invoke
+    assertIdentical(response.status, 502);
+  });
+
+  it("answers 413 for a request body larger than a function takes", async () => {
+    // Given a load balancer with a Lambda target
+    const simAws = new SimAws();
+    const loadBalancer = await simElbV2LambdaTargetFactory.make({}, simAws);
+
+    // When a request carries more than the megabyte ELB sends on
+    const response = await simElbV2Fetch(
+      simAws,
+      `http://${loadBalancer.dnsName}/orders`,
+      {
+        method: "POST",
+        headers: { "content-type": "text/plain" },
+        body: "x".repeat(1024 * 1024 + 1),
+      },
+    );
+
+    // Then the load balancer refuses it rather than invoking the function
+    assertIdentical(response.status, 413);
+  });
+
+  it("answers 502 for a response body larger than a function may return", async () => {
+    // Given a handler answering with more than the megabyte ELB takes back
+    const simAws = new SimAws();
+    const loadBalancer = await simElbV2LambdaTargetFactory.make(
+      {
+        handler: (): SimElbV2Result => ({
+          statusCode: 200,
+          body: "x".repeat(1024 * 1024 + 1),
+        }),
+      },
+      simAws,
+    );
+
+    // When a request reaches it
+    const response = await simElbV2Fetch(
+      simAws,
+      `http://${loadBalancer.dnsName}/orders`,
+    );
+
+    // Then the response is one ELB will not send
+    assertIdentical(response.status, 502);
+  });
+});

--- a/src/service/elbv2/serve/sim-elbv2-serve-errors.iso.test.ts
+++ b/src/service/elbv2/serve/sim-elbv2-serve-errors.iso.test.ts
@@ -205,6 +205,27 @@ describe("What a sim ELBv2 load balancer answers when a target fails", () => {
     assertIdentical(response.status, 502);
   });
 
+  it("answers 502 for a text body that is not valid UTF-8", async () => {
+    // Given a load balancer with a Lambda target
+    const simAws = new SimAws();
+    const loadBalancer = await simElbV2LambdaTargetFactory.make({}, simAws);
+
+    // When a request calls its body text and sends bytes that are not
+    const response = await simElbV2Fetch(
+      simAws,
+      `http://${loadBalancer.dnsName}/orders`,
+      {
+        method: "POST",
+        headers: { "content-type": "text/plain" },
+        body: new Uint8Array([0xc3, 0x28]),
+      },
+    );
+
+    // Then the invocation fails rather than the handler seeing the body
+    // rewritten into replacement characters
+    assertIdentical(response.status, 502);
+  });
+
   it("answers 413 for a request body larger than a function takes", async () => {
     // Given a load balancer with a Lambda target
     const simAws = new SimAws();
@@ -225,14 +246,16 @@ describe("What a sim ELBv2 load balancer answers when a target fails", () => {
     assertIdentical(response.status, 413);
   });
 
-  it("answers 502 for a response body larger than a function may return", async () => {
-    // Given a handler answering with more than the megabyte ELB takes back
+  it("answers 502 for a response larger than a function may return", async () => {
+    // Given a handler whose body fits in a megabyte only until it is base64
+    // encoded, which is how real ELB measures it
     const simAws = new SimAws();
     const loadBalancer = await simElbV2LambdaTargetFactory.make(
       {
         handler: (): SimElbV2Result => ({
           statusCode: 200,
-          body: "x".repeat(1024 * 1024 + 1),
+          isBase64Encoded: true,
+          body: Buffer.alloc(768 * 1024).toString("base64"),
         }),
       },
       simAws,

--- a/src/service/elbv2/serve/sim-elbv2-serve-event.iso.test.ts
+++ b/src/service/elbv2/serve/sim-elbv2-serve-event.iso.test.ts
@@ -76,6 +76,20 @@ describe("The event a sim ELBv2 load balancer invokes a function with", () => {
     });
   });
 
+  it("leaves an encoded query string value as it arrived", async () => {
+    // Given a load balancer with a Lambda target
+
+    // When a request carries percent escapes and a plus sign
+    const event = await eventFor("/orders?token=a%2Bb&note=one+two&flag");
+
+    // Then none of it is decoded, because real ELB leaves that to the function
+    expect(event.queryStringParameters).toStrictEqual({
+      token: "a%2Bb",
+      note: "one+two",
+      flag: "",
+    });
+  });
+
   it("carries an empty query map when there was no query string", async () => {
     // Given a load balancer with a Lambda target
 
@@ -99,14 +113,15 @@ describe("The event a sim ELBv2 load balancer invokes a function with", () => {
       },
     });
 
-    // Then the load balancer's own values replace what the client sent, the
-    // host is the load balancer's DNS name, and the cookie stays in its header
-    // rather than being lifted into a field of its own
+    // Then the load balancer appends its client's address to the forwarding
+    // chain, overwrites the headers describing the connection it terminated,
+    // and leaves the cookie in its header rather than lifting it into a field
+    // of its own
     assertIdentical(
       event.headers["host"],
       "shop-alb-0000000001.us-east-1.elb.amazonaws.com",
     );
-    assertIdentical(event.headers["x-forwarded-for"], "127.0.0.1");
+    assertIdentical(event.headers["x-forwarded-for"], "203.0.113.1, 127.0.0.1");
     assertIdentical(event.headers["x-forwarded-port"], "80");
     assertIdentical(event.headers["x-forwarded-proto"], "http");
     assertIdentical(event.headers["cookie"], "session=abc");

--- a/src/service/elbv2/serve/sim-elbv2-serve-event.iso.test.ts
+++ b/src/service/elbv2/serve/sim-elbv2-serve-event.iso.test.ts
@@ -1,0 +1,179 @@
+import { assertFalse, assertIdentical, assertTrue } from "@kensio/smartass";
+import { describe, expect, it } from "vitest";
+
+import { assertDefined } from "../../../util/type-guard/defined.js";
+import { SimAws } from "../../aws/sim-aws.js";
+import type { SimElbV2Event, SimElbV2Result } from "./sim-elbv2-event.type.js";
+import { simElbV2Fetch } from "./sim-elbv2-fetch.js";
+import { simElbV2LambdaTargetFactory } from "./sim-elbv2-lambda-target.factory.js";
+
+/**
+ * Serve one request and answer with the event the handler was given.
+ */
+async function eventFor(
+  path: string,
+  init?: RequestInit,
+): Promise<SimElbV2Event> {
+  const simAws = new SimAws();
+  let received: SimElbV2Event | undefined;
+  const loadBalancer = await simElbV2LambdaTargetFactory.make(
+    {
+      handler: (event: SimElbV2Event): SimElbV2Result => {
+        received = event;
+        return { statusCode: 200 };
+      },
+    },
+    simAws,
+  );
+
+  await simElbV2Fetch(simAws, `http://${loadBalancer.dnsName}${path}`, init);
+
+  assertDefined(received, "The target function was not invoked");
+
+  return received;
+}
+
+describe("The event a sim ELBv2 load balancer invokes a function with", () => {
+  it("names the target group in an elb request context", async () => {
+    // Given a load balancer forwarding to a lambda target group
+
+    // When a request reaches it
+    const event = await eventFor("/orders");
+
+    // Then the request context is ELB's own, carrying the target group ARN,
+    // which is what tells this apart from an API Gateway event
+    expect(event.requestContext).toStrictEqual({
+      elb: {
+        targetGroupArn:
+          "arn:aws:elasticloadbalancing:us-east-1:888888888888:targetgroup/checkout-tg/0000000000000001",
+      },
+    });
+  });
+
+  it("carries the method and path as ELB's own fields", async () => {
+    // Given a load balancer with a Lambda target
+
+    // When a POST reaches a path on it
+    const event = await eventFor("/orders/42", { method: "POST", body: "" });
+
+    // Then the event names them flat, rather than under an http block
+    assertIdentical(event.httpMethod, "POST");
+    assertIdentical(event.path, "/orders/42");
+  });
+
+  it("keeps the last value of a repeated query parameter", async () => {
+    // Given a load balancer whose target group leaves multi-value headers off,
+    // which is what real ELB defaults to
+
+    // When a request repeats a query string key
+    const event = await eventFor("/orders?status=open&status=shipped&page=2");
+
+    // Then the last value is the one the handler sees, as real ELB does
+    // without the multi-value attribute, rather than the two joined
+    expect(event.queryStringParameters).toStrictEqual({
+      status: "shipped",
+      page: "2",
+    });
+  });
+
+  it("carries an empty query map when there was no query string", async () => {
+    // Given a load balancer with a Lambda target
+
+    // When a request carries no query string
+    const event = await eventFor("/orders");
+
+    // Then the field is present and empty, rather than left out as an API
+    // Gateway event leaves it
+    expect(event.queryStringParameters).toStrictEqual({});
+  });
+
+  it("writes the headers a load balancer adds", async () => {
+    // Given a load balancer with a Lambda target
+
+    // When a request carries a cookie and its own forwarding headers
+    const event = await eventFor("/orders", {
+      headers: {
+        cookie: "session=abc",
+        "x-forwarded-for": "203.0.113.1",
+        "user-agent": "curl/8.0.0",
+      },
+    });
+
+    // Then the load balancer's own values replace what the client sent, the
+    // host is the load balancer's DNS name, and the cookie stays in its header
+    // rather than being lifted into a field of its own
+    assertIdentical(
+      event.headers["host"],
+      "shop-alb-0000000001.us-east-1.elb.amazonaws.com",
+    );
+    assertIdentical(event.headers["x-forwarded-for"], "127.0.0.1");
+    assertIdentical(event.headers["x-forwarded-port"], "80");
+    assertIdentical(event.headers["x-forwarded-proto"], "http");
+    assertIdentical(event.headers["cookie"], "session=abc");
+    assertIdentical(event.headers["user-agent"], "curl/8.0.0");
+    expect(event.headers["x-amzn-trace-id"]).toMatch(
+      /^Root=1-[\da-f]{8}-[\da-f]{24}$/u,
+    );
+  });
+
+  it("passes a text body through as it arrived", async () => {
+    // Given a load balancer with a Lambda target
+
+    // When a JSON request body arrives
+    const event = await eventFor("/orders", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ sku: "abc" }),
+    });
+
+    // Then the handler reads the text of it
+    assertIdentical(event.body, '{"sku":"abc"}');
+    assertFalse(event.isBase64Encoded);
+  });
+
+  it("base64 encodes a form body, which ELB does not treat as text", async () => {
+    // Given a load balancer with a Lambda target
+
+    // When a form post arrives
+    const event = await eventFor("/orders", {
+      method: "POST",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      body: "sku=abc",
+    });
+
+    // Then it is base64, because ELB's list of text types is shorter than API
+    // Gateway's and does not include this one
+    assertTrue(event.isBase64Encoded);
+    assertIdentical(Buffer.from(event.body, "base64").toString(), "sku=abc");
+  });
+
+  it("base64 encodes a body carrying a content encoding", async () => {
+    // Given a load balancer with a Lambda target
+
+    // When a body arrives compressed, whatever its content type says
+    const event = await eventFor("/orders", {
+      method: "POST",
+      headers: {
+        "content-type": "text/plain",
+        "content-encoding": "gzip",
+      },
+      body: "compressed",
+    });
+
+    // Then the content encoding decides, as it does on real ELB
+    assertTrue(event.isBase64Encoded);
+    assertIdentical(Buffer.from(event.body, "base64").toString(), "compressed");
+  });
+
+  it("carries an empty body rather than none for a request with none", async () => {
+    // Given a load balancer with a Lambda target
+
+    // When a GET with no body arrives
+    const event = await eventFor("/orders");
+
+    // Then the field is present and empty and is not called base64, which is
+    // what a real ELB health check event shows too
+    assertIdentical(event.body, "");
+    assertFalse(event.isBase64Encoded);
+  });
+});

--- a/src/service/elbv2/serve/sim-elbv2-serve-refusals.iso.test.ts
+++ b/src/service/elbv2/serve/sim-elbv2-serve-refusals.iso.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import { simElbV2Fetch } from "./sim-elbv2-fetch.js";
+import { simElbV2LambdaTargetFactory } from "./sim-elbv2-lambda-target.factory.js";
+
+describe("What a sim ELBv2 load balancer will not carry a request through", () => {
+  it("refuses a listener whose default action is a fixed response", async () => {
+    // Given a load balancer with a listener
+    const simAws = new SimAws();
+    const loadBalancer = await simElbV2LambdaTargetFactory.make({}, simAws);
+    const elbV2 = simAws.elbV2();
+
+    // And that listener answering with a fixed response rather than forwarding
+    await elbV2.modifyListener({
+      input: {
+        ListenerArn: elbV2.findListenerOnPort(loadBalancer.arn, 80)?.arn,
+        DefaultActions: [
+          {
+            Type: "fixed-response",
+            FixedResponseConfig: { StatusCode: "404" },
+          },
+        ],
+      },
+    });
+
+    // When a request reaches it
+    const request = simElbV2Fetch(
+      simAws,
+      `http://${loadBalancer.dnsName}/orders`,
+    );
+
+    // Then the action is stored and not performed, and saying so beats
+    // forwarding a request the configuration said to answer
+    await expect(request).rejects.toThrow(
+      "answers a request with a 'fixed-response' action",
+    );
+  });
+
+  it("refuses a listener forwarding to an ip target group", async () => {
+    // Given a load balancer with a listener
+    const simAws = new SimAws();
+    const loadBalancer = await simElbV2LambdaTargetFactory.make({}, simAws);
+    const elbV2 = simAws.elbV2();
+
+    // And that listener forwarding to a group of addresses
+    const addresses = await elbV2.createTargetGroup({
+      input: {
+        Name: "web-tg",
+        TargetType: "ip",
+        Protocol: "HTTP",
+        Port: 8080,
+      },
+    });
+    await elbV2.modifyListener({
+      input: {
+        ListenerArn: elbV2.findListenerOnPort(loadBalancer.arn, 80)?.arn,
+        DefaultActions: [
+          {
+            Type: "forward",
+            TargetGroupArn: addresses.TargetGroups?.[0]?.TargetGroupArn,
+          },
+        ],
+      },
+    });
+
+    // When a request reaches it
+    const request = simElbV2Fetch(
+      simAws,
+      `http://${loadBalancer.dnsName}/orders`,
+    );
+
+    // Then there is nothing listening on an address here for it to reach
+    await expect(request).rejects.toThrow("holds ip targets");
+  });
+
+  it("refuses a listener forwarding to several target groups by weight", async () => {
+    // Given a load balancer with a listener, and a second target group
+    const simAws = new SimAws();
+    const loadBalancer = await simElbV2LambdaTargetFactory.make({}, simAws);
+    const elbV2 = simAws.elbV2();
+    const checkout = await elbV2.describeTargetGroups({ input: {} });
+    const refunds = await elbV2.createTargetGroup({
+      input: { Name: "refunds-tg", TargetType: "lambda" },
+    });
+
+    // And that listener forwarding to both of them
+    await elbV2.modifyListener({
+      input: {
+        ListenerArn: elbV2.findListenerOnPort(loadBalancer.arn, 80)?.arn,
+        DefaultActions: [
+          {
+            Type: "forward",
+            ForwardConfig: {
+              TargetGroups: [
+                {
+                  TargetGroupArn: checkout.TargetGroups?.[0]?.TargetGroupArn,
+                  Weight: 1,
+                },
+                {
+                  TargetGroupArn: refunds.TargetGroups?.[0]?.TargetGroupArn,
+                  Weight: 1,
+                },
+              ],
+            },
+          },
+        ],
+      },
+    });
+
+    // When a request reaches it
+    const request = simElbV2Fetch(
+      simAws,
+      `http://${loadBalancer.dnsName}/orders`,
+    );
+
+    // Then which group takes it is a question the weights answer, and nothing
+    // here reads them
+    await expect(request).rejects.toThrow(
+      "Weighted forwarding is not simulated",
+    );
+  });
+});

--- a/src/service/elbv2/serve/sim-elbv2-serve.iso.test.ts
+++ b/src/service/elbv2/serve/sim-elbv2-serve.iso.test.ts
@@ -1,0 +1,191 @@
+import { assertIdentical } from "@kensio/smartass";
+import { describe, expect, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import type { SimElbV2Event, SimElbV2Result } from "./sim-elbv2-event.type.js";
+import { simElbV2Fetch } from "./sim-elbv2-fetch.js";
+import { simElbV2LambdaTargetFactory } from "./sim-elbv2-lambda-target.factory.js";
+
+describe("Serving a request through a sim ELBv2 load balancer", () => {
+  it("answers with what the Lambda target returned", async () => {
+    // Given a load balancer forwarding to a target group holding a function
+    const simAws = new SimAws();
+    const loadBalancer = await simElbV2LambdaTargetFactory.make(
+      {
+        handler: (): SimElbV2Result => ({
+          statusCode: 201,
+          statusDescription: "201 Created",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ ordered: true }),
+        }),
+      },
+      simAws,
+    );
+
+    // When a request reaches the load balancer
+    const response = await simElbV2Fetch(
+      simAws,
+      `http://${loadBalancer.dnsName}/orders`,
+    );
+
+    // Then the handler's response is what the client gets, with the status
+    // description as the reason phrase rather than repeated in the status line
+    assertIdentical(response.status, 201);
+    assertIdentical(response.statusText, "Created");
+    assertIdentical(response.headers.get("content-type"), "application/json");
+    expect(await response.json()).toStrictEqual({ ordered: true });
+  });
+
+  it("sends a body a handler omitted as no body at all", async () => {
+    // Given a handler answering with a status and nothing else
+    const simAws = new SimAws();
+    const loadBalancer = await simElbV2LambdaTargetFactory.make(
+      { handler: (): SimElbV2Result => ({ statusCode: 204 }) },
+      simAws,
+    );
+
+    // When a request reaches it
+    const response = await simElbV2Fetch(
+      simAws,
+      `http://${loadBalancer.dnsName}/orders`,
+    );
+
+    // Then the response carries none, which is what a 204 has to be
+    assertIdentical(response.status, 204);
+    assertIdentical(response.body, null);
+  });
+
+  it("decodes a base64 body into the bytes the client receives", async () => {
+    // Given a handler answering with base64 content, as it must for binary
+    const simAws = new SimAws();
+    const loadBalancer = await simElbV2LambdaTargetFactory.make(
+      {
+        handler: (): SimElbV2Result => ({
+          statusCode: 200,
+          headers: { "content-type": "application/octet-stream" },
+          isBase64Encoded: true,
+          body: Buffer.from([1, 2, 3]).toString("base64"),
+        }),
+      },
+      simAws,
+    );
+
+    // When a request reaches it
+    const response = await simElbV2Fetch(
+      simAws,
+      `http://${loadBalancer.dnsName}/orders`,
+    );
+
+    // Then the load balancer decoded it before sending it on
+    expect([...new Uint8Array(await response.arrayBuffer())]).toStrictEqual([
+      1, 2, 3,
+    ]);
+  });
+
+  it("drops the response headers a load balancer writes itself", async () => {
+    // Given a handler naming hop-by-hop headers and its own content length
+    const simAws = new SimAws();
+    const loadBalancer = await simElbV2LambdaTargetFactory.make(
+      {
+        handler: (): SimElbV2Result => ({
+          statusCode: 200,
+          headers: {
+            Connection: "keep-alive",
+            "Content-Length": "9999",
+            "X-Order": "42",
+          },
+          body: "checkout",
+        }),
+      },
+      simAws,
+    );
+
+    // When a request reaches it
+    const response = await simElbV2Fetch(
+      simAws,
+      `http://${loadBalancer.dnsName}/orders`,
+    );
+
+    // Then only the header the load balancer does not own survives
+    assertIdentical(response.headers.get("connection"), null);
+    assertIdentical(response.headers.get("x-order"), "42");
+    assertIdentical(await response.text(), "checkout");
+  });
+
+  it("matches a listener by the port the request arrived on", async () => {
+    // Given a load balancer whose only listener answers on 8080
+    const simAws = new SimAws();
+    const loadBalancer = await simElbV2LambdaTargetFactory.make(
+      {
+        listenerPort: 8080,
+        handler: (event: SimElbV2Event): SimElbV2Result => ({
+          statusCode: 200,
+          body: event.headers["x-forwarded-port"] ?? "",
+        }),
+      },
+      simAws,
+    );
+
+    // When a request reaches that port
+    const response = await simElbV2Fetch(
+      simAws,
+      `http://${loadBalancer.dnsName}:8080/orders`,
+    );
+
+    // Then that listener took it, and told the handler which port it was
+    assertIdentical(response.status, 200);
+    assertIdentical(await response.text(), "8080");
+  });
+
+  it("refuses a request to a port no listener answers on", async () => {
+    // Given a load balancer listening on 80 only
+    const simAws = new SimAws();
+    const loadBalancer = await simElbV2LambdaTargetFactory.make({}, simAws);
+
+    // When a request reaches another port
+    const request = simElbV2Fetch(
+      simAws,
+      `http://${loadBalancer.dnsName}:8080/orders`,
+    );
+
+    // Then nothing answers, as a real load balancer refuses the connection
+    // rather than sending back a status
+    await expect(request).rejects.toThrow("has no listener on port 8080");
+  });
+
+  it("takes the scheme's own port when a request names none", async () => {
+    // Given a load balancer listening on 80 only
+    const simAws = new SimAws();
+    const loadBalancer = await simElbV2LambdaTargetFactory.make({}, simAws);
+
+    // When an HTTPS request names no port
+    const request = simElbV2Fetch(
+      simAws,
+      `https://${loadBalancer.dnsName}/orders`,
+    );
+
+    // Then it is looking for the listener on 443, which is what an HTTPS URL
+    // naming no port means
+    await expect(request).rejects.toThrow("has no listener on port 443");
+  });
+
+  it("stops answering on a deleted load balancer's DNS name", async () => {
+    // Given a load balancer that has since been deleted
+    const simAws = new SimAws();
+    const loadBalancer = await simElbV2LambdaTargetFactory.make({}, simAws);
+    await simAws
+      .elbV2()
+      .deleteLoadBalancer({ input: { LoadBalancerArn: loadBalancer.arn } });
+
+    // When a request reaches the name it answered on
+    const request = simElbV2Fetch(
+      simAws,
+      `http://${loadBalancer.dnsName}/orders`,
+    );
+
+    // Then the name resolves to nothing
+    await expect(request).rejects.toThrow(
+      "No simulated load balancer answers on",
+    );
+  });
+});

--- a/src/service/elbv2/serve/sim-elbv2-serve.iso.test.ts
+++ b/src/service/elbv2/serve/sim-elbv2-serve.iso.test.ts
@@ -3,7 +3,14 @@ import { describe, expect, it } from "vitest";
 
 import { SimAws } from "../../aws/sim-aws.js";
 import type { SimElbV2Event, SimElbV2Result } from "./sim-elbv2-event.type.js";
+import { makeLambdaZipFileInput } from "../../lambda/function/code/lambda-zip-file-input.js";
+import {
+  createFixtureLambdaTargetGroup,
+  createFixtureListener,
+  createFixtureLoadBalancer,
+} from "../sim-elbv2.fixture.js";
 import { simElbV2Fetch } from "./sim-elbv2-fetch.js";
+import { simElbV2ServicePrincipal } from "./sim-elbv2-invoke-authorizer.js";
 import { simElbV2LambdaTargetFactory } from "./sim-elbv2-lambda-target.factory.js";
 
 describe("Serving a request through a sim ELBv2 load balancer", () => {
@@ -167,6 +174,69 @@ describe("Serving a request through a sim ELBv2 load balancer", () => {
     // Then it is looking for the listener on 443, which is what an HTTPS URL
     // naming no port means
     await expect(request).rejects.toThrow("has no listener on port 443");
+  });
+
+  it("answers on a load balancer in another Account and Region", async () => {
+    // Given a load balancer in the default Account and Region
+    const simAws = new SimAws();
+    const first = await simElbV2LambdaTargetFactory.make({}, simAws);
+
+    // And a second one of the same name in another Account and Region,
+    // forwarding to that scope's own function
+    const account = simAws.account("222222222222");
+    const { FunctionArn } = await account
+      .region("eu-west-1")
+      .lambda()
+      .createFunction({
+        input: {
+          FunctionName: "refunds",
+          Role: "arn:aws:iam::222222222222:role/RefundsRole",
+          Code: {
+            ZipFile: makeLambdaZipFileInput((): SimElbV2Result => ({
+              statusCode: 200,
+              body: "refunds",
+            })),
+          },
+        },
+      });
+    const elbV2 = account.region("eu-west-1").elbV2();
+    const loadBalancerArn = await createFixtureLoadBalancer(elbV2, "shop-alb");
+    const targetGroupArn = await createFixtureLambdaTargetGroup(
+      elbV2,
+      "refunds-tg",
+    );
+    await account
+      .region("eu-west-1")
+      .lambda()
+      .addPermission({
+        input: {
+          FunctionName: "refunds",
+          StatementId: "elb-invoke",
+          Action: "lambda:InvokeFunction",
+          Principal: simElbV2ServicePrincipal,
+          SourceArn: targetGroupArn,
+        },
+      });
+    await elbV2.registerTargets({
+      input: { TargetGroupArn: targetGroupArn, Targets: [{ Id: FunctionArn }] },
+    });
+    await createFixtureListener(elbV2, loadBalancerArn, targetGroupArn);
+
+    // When a request reaches each DNS name
+    const second = elbV2.findLoadBalancerByName("shop-alb");
+    const toFirst = await simElbV2Fetch(
+      simAws,
+      `http://${first.dnsName}/orders`,
+    );
+    const toSecond = await simElbV2Fetch(
+      simAws,
+      `http://${second?.dnsName ?? ""}/orders`,
+    );
+
+    // Then each name reaches the load balancer in its own scope, which is what
+    // the two host names being different is for
+    assertIdentical(await toFirst.text(), "checkout");
+    assertIdentical(await toSecond.text(), "refunds");
   });
 
   it("stops answering on a deleted load balancer's DNS name", async () => {

--- a/src/service/elbv2/sim-elbv2-stores.ts
+++ b/src/service/elbv2/sim-elbv2-stores.ts
@@ -3,7 +3,12 @@ import { SimElbV2ListenerRuleStore } from "./listener/rule/sim-elbv2-listener-ru
 import { SimElbV2LoadBalancerStore } from "./load-balancer/sim-elbv2-load-balancer-store.js";
 import type { SimElbV2LoadBalancer } from "./load-balancer/sim-elbv2-load-balancer.js";
 import type { SimElbV2Listener } from "./listener/sim-elbv2-listener.js";
+import type { SimElbV2Registry } from "./registry/sim-elbv2-registry.js";
 import { SimElbV2TargetGroupStore } from "./target-group/sim-elbv2-target-group-store.js";
+
+interface SimElbV2StoresProperties {
+  readonly registry: SimElbV2Registry;
+}
 
 /**
  * Everything one simulated ELBv2 scope holds.
@@ -15,10 +20,14 @@ import { SimElbV2TargetGroupStore } from "./target-group/sim-elbv2-target-group-
  * its listeners, and deleting a listener takes its rules.
  */
 export class SimElbV2Stores {
-  public readonly loadBalancers = new SimElbV2LoadBalancerStore();
+  public readonly loadBalancers: SimElbV2LoadBalancerStore;
   public readonly targetGroups = new SimElbV2TargetGroupStore();
   public readonly listeners = new SimElbV2ListenerStore();
   public readonly rules = new SimElbV2ListenerRuleStore();
+
+  constructor(properties: SimElbV2StoresProperties) {
+    this.loadBalancers = new SimElbV2LoadBalancerStore(properties);
+  }
 
   /**
    * Delete a load balancer, and everything that only existed on it.

--- a/src/service/elbv2/sim-elbv2.fixture.ts
+++ b/src/service/elbv2/sim-elbv2.fixture.ts
@@ -1,5 +1,4 @@
-import { assertArrayLength } from "@kensio/smartass";
-
+import { assertDefined } from "../../util/type-guard/defined.js";
 import type { SimElbV2 } from "./sim-elbv2.js";
 
 /**
@@ -29,9 +28,10 @@ export async function createFixtureLoadBalancer(
 ): Promise<string> {
   const output = await elbV2.createLoadBalancer({ input: { Name: name } });
 
-  assertArrayLength(output.LoadBalancers, 1);
+  const arn = output.LoadBalancers?.[0]?.LoadBalancerArn;
+  assertDefined(arn, `Sim ELBv2 created no load balancer named ${name}`);
 
-  return output.LoadBalancers[0].LoadBalancerArn;
+  return arn;
 }
 
 /**
@@ -48,9 +48,10 @@ export async function createFixtureLambdaTargetGroup(
     input: { Name: name, TargetType: "lambda" },
   });
 
-  assertArrayLength(output.TargetGroups, 1);
+  const arn = output.TargetGroups?.[0]?.TargetGroupArn;
+  assertDefined(arn, `Sim ELBv2 created no target group named ${name}`);
 
-  return output.TargetGroups[0].TargetGroupArn;
+  return arn;
 }
 
 /**
@@ -64,9 +65,10 @@ export async function createFixtureIpTargetGroup(
     input: { Name: name, TargetType: "ip", Protocol: "HTTP", Port: 8080 },
   });
 
-  assertArrayLength(output.TargetGroups, 1);
+  const arn = output.TargetGroups?.[0]?.TargetGroupArn;
+  assertDefined(arn, `Sim ELBv2 created no target group named ${name}`);
 
-  return output.TargetGroups[0].TargetGroupArn;
+  return arn;
 }
 
 /**
@@ -88,9 +90,10 @@ export async function createFixtureListener(
     },
   });
 
-  assertArrayLength(output.Listeners, 1);
+  const arn = output.Listeners?.[0]?.ListenerArn;
+  assertDefined(arn, `Sim ELBv2 created no listener on port ${String(port)}`);
 
-  return output.Listeners[0].ListenerArn;
+  return arn;
 }
 
 /**
@@ -112,7 +115,11 @@ export async function createFixtureRule(
     },
   });
 
-  assertArrayLength(output.Rules, 1);
+  const arn = output.Rules?.[0]?.RuleArn;
+  assertDefined(
+    arn,
+    `Sim ELBv2 created no rule at priority ${String(priority)}`,
+  );
 
-  return output.Rules[0].RuleArn;
+  return arn;
 }

--- a/src/service/elbv2/sim-elbv2.ts
+++ b/src/service/elbv2/sim-elbv2.ts
@@ -12,14 +12,22 @@ import {
 import type * as elbV2 from "./command/sim-elbv2-command.types.js";
 import { SimElbV2Commands } from "./command/sim-elbv2-commands.js";
 import type { SimElbV2RequestOptions } from "./command/sim-elbv2-request-options.js";
+import type { SimElbV2Listener } from "./listener/sim-elbv2-listener.js";
 import type { SimElbV2LoadBalancer } from "./load-balancer/sim-elbv2-load-balancer.js";
+import { SimElbV2Registry } from "./registry/sim-elbv2-registry.js";
 import { SimElbV2SdkCommandRouter } from "./sdk/sim-elbv2-sdk-command-router.js";
 import { SimElbV2Stores } from "./sim-elbv2-stores.js";
+import type { SimElbV2TargetGroup } from "./target-group/sim-elbv2-target-group.js";
 
 interface SimElbV2Properties {
   readonly accountRegionScope?: SimAwsAccountRegionScope;
   readonly iam?: SimIamInterServiceAuthZ;
   readonly background?: BackgroundScheduler;
+  /**
+   * Cross-scope index of load balancer DNS names, which is how a request
+   * arriving at one finds the Account that owns it.
+   */
+  readonly registry?: SimElbV2Registry;
 }
 
 /**
@@ -39,7 +47,7 @@ interface SimElbV2Properties {
  * a name is unique within one of those scopes and an ARN names the region.
  */
 export class SimElbV2 {
-  private readonly stores = new SimElbV2Stores();
+  private readonly stores: SimElbV2Stores;
   private readonly commands: SimElbV2Commands;
   private readonly sdkRouter = new SimElbV2SdkCommandRouter(this);
 
@@ -48,8 +56,10 @@ export class SimElbV2 {
       accountRegionScope = simAwsAccountRegionScopeFactory.make(),
       iam = new SimIamAllowAllAuth(),
       background = new BackgroundTasks(),
+      registry = new SimElbV2Registry(),
     } = properties;
 
+    this.stores = new SimElbV2Stores({ registry });
     this.commands = new SimElbV2Commands({
       stores: this.stores,
       iam,
@@ -66,6 +76,33 @@ export class SimElbV2 {
    */
   findLoadBalancerByName(name: string): SimElbV2LoadBalancer | undefined {
     return this.stores.loadBalancers.findByName(name);
+  }
+
+  /**
+   * Find the load balancer answering on a DNS name.
+   *
+   * This is what a request reaching a load balancer starts from, since the DNS
+   * name is the only thing it carries that names one.
+   */
+  findLoadBalancerByDnsName(dnsName: string): SimElbV2LoadBalancer | undefined {
+    return this.stores.loadBalancers.findByDnsName(dnsName);
+  }
+
+  /**
+   * Find the listener answering on one port of a load balancer.
+   */
+  findListenerOnPort(
+    loadBalancerArn: string,
+    port: number,
+  ): SimElbV2Listener | undefined {
+    return this.stores.listeners.findOnPort(loadBalancerArn, port);
+  }
+
+  /**
+   * Find a target group by ARN.
+   */
+  findTargetGroupByArn(arn: string): SimElbV2TargetGroup | undefined {
+    return this.stores.targetGroups.findByArn(arn);
   }
 
   /** Handle a CreateLoadBalancer Command from the SDK. */

--- a/src/service/elbv2/target-group/sim-elbv2-target-group-store.ts
+++ b/src/service/elbv2/target-group/sim-elbv2-target-group-store.ts
@@ -58,6 +58,13 @@ export class SimElbV2TargetGroupStore {
   }
 
   /**
+   * Find a target group by ARN.
+   */
+  findByArn(arn: string): SimElbV2TargetGroup | undefined {
+    return this.targetGroups.get(arn);
+  }
+
+  /**
    * Resolve a target group by ARN, or refuse.
    */
   requireByArn(arn: string): SimElbV2TargetGroup {

--- a/src/service/elbv2/target-group/sim-elbv2-target-group.ts
+++ b/src/service/elbv2/target-group/sim-elbv2-target-group.ts
@@ -48,6 +48,14 @@ export class SimElbV2TargetGroup {
   public readonly protocol: string | undefined;
   public readonly port: number | undefined;
   public readonly vpcId: string | undefined;
+  /**
+   * The Account and Region this target group belongs to.
+   *
+   * Real ELB requires a Lambda target to be in the same Account and Region as
+   * its target group, so this is also where the function a request reaches is
+   * looked for.
+   */
+  public readonly accountRegionScope: SimAwsAccountRegionScope;
 
   private readonly healthCheck: SimElbV2HealthCheck;
   private readonly targets: SimElbV2TargetSet;
@@ -55,6 +63,7 @@ export class SimElbV2TargetGroup {
   constructor(properties: SimElbV2TargetGroupProperties) {
     const { accountRegionScope } = properties;
 
+    this.accountRegionScope = accountRegionScope;
     this.name = properties.name;
     this.targetType = properties.targetType;
     this.protocol = properties.protocol;


### PR DESCRIPTION
A request sent to a simulated Application Load Balancer is now matched to a listener by port, and the listener's default forward action sends it to a target group, where a registered Lambda function is invoked with an ALB-shaped event and its response becomes the HTTP response. The event and response use ELB's own shapes rather than either API Gateway payload format, invocation goes through the function's resource policy allowing `elasticloadbalancing.amazonaws.com` with the target group as the source ARN, and the load balancer answers 503 for a target group with nothing in it and 502 for a target it cannot invoke or whose result is not a response. Only the default action is carried out and only to a `lambda` target group, so a `fixed-response` or `redirect` action, an `ip` target group and weighted forwarding are refused when the request arrives rather than answered with something else. `simElbV2Fetch` is how a request reaches a load balancer for now, since nothing resolves a load balancer's DNS name yet.

One departure from the issue: it says a function without the invoke permission gets a 403, and this returns a 502. The ALB docs give 403 only for a request blocked by AWS WAF, while every Lambda invocation failure, `LambdaAccessDenied` included, is a 502. The test still proves the permission is what makes the difference, refusing the request and never running the handler until the grant is there.

Resolves https://github.com/KensioSoftware/yulin/issues/563

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added request serving for simulated Application Load Balancers through a fetch-compatible interface.
  * Added Lambda target routing, ALB-shaped events, response conversion, and invoke-permission checks.
  * Added listener-port selection, DNS-based routing, binary body handling, and cross-account/Region resolution.
  * Added realistic 503, 502, 413, and connection-refused responses.
  * Added examples demonstrating successful Lambda routing and common failure scenarios.

* **Documentation**
  * Expanded ELBv2 guidance, supported functionality, limitations, and request-serving examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->