### PR TITLE
docs: document non-AWS dependencies

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -32,5 +32,6 @@ behaviour and includes example code that can be copied into tests or local devel
 
 - [AWS SDK interception](./sdk/ "Simulated AWS SDK usage docs")
 - [Linting CloudFront Functions JS2](./lint/ "CloudFront Functions JS2 lint config usage docs")
+- [Non-AWS dependencies](./non-aws-dependencies/ "Dependencies Yulin does not simulate usage docs")
 - [Serving on localhost](./serve/ "Serving simulated AWS on localhost usage docs")
 - [Simulated time](./time/ "Simulated time usage docs")

--- a/docs/non-aws-dependencies/README.md
+++ b/docs/non-aws-dependencies/README.md
@@ -1,0 +1,261 @@
+# Non-AWS dependencies
+
+Most applications talk to something other than AWS, such as a Redis or a Postgres. This page covers
+what happens to those when the application runs under Yulin.
+
+## Two kinds of dependency
+
+A simulated Lambda function and a simulated ECS container both run your own code in the same Node.js
+process as the test. Everything that code talks to falls into one of two categories.
+
+Simulated AWS services are handled by Yulin. A DynamoDB call reaches an in-memory table and an S3
+call reaches an in-memory bucket, with no network involved. [AWS SDK interception](../sdk/README.md)
+is how an ordinary SDK client in the code under test gets there.
+
+Everything else is yours to provide, and connects the way it normally would. Yulin does not
+simulate it, does not intercept it, and knows nothing about it. Code that opens a Redis connection
+opens a real one, to whatever address it was given.
+
+## Pointing the code at your own dependency
+
+A deployed Lambda function or ECS container reads its connection details from environment variables.
+The simulated ones do the same. A function's `Environment.Variables` and a container definition's
+`environment` are visible through `process.env` while the code runs, so pointing the application
+somewhere else means setting the value it already reads. No Yulin feature is involved, and the code
+under test does not change.
+
+```typescript non-aws-dependency-lambda
+/**
+ * Pointing a simulated Lambda function at a dependency Yulin does not
+ * simulate, alongside one it does.
+ */
+
+import { CreateFunctionCommand, InvokeCommand } from "@aws-sdk/client-lambda";
+
+import { SimAws } from "@kensio/yulin";
+import { makeLambdaZipFileInput } from "@kensio/yulin/lambda";
+
+const simAws = new SimAws();
+const lambda = simAws.lambda();
+
+await lambda.createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "rates",
+    Role: "arn:aws:iam::111111111111:role/RatesRole",
+    Environment: {
+      Variables: {
+        // Simulated by Yulin, reached with no network involved.
+        TABLE_NAME: "rates",
+        // Yours. A deployment points this at ElastiCache. A test points it
+        // at whatever it wants the code to talk to instead.
+        CACHE_URL: "redis://127.0.0.1:6379",
+      },
+    },
+    Code: {
+      ZipFile: makeLambdaZipFileInput(() => ({
+        // Building a Redis client from the second value involves nothing of
+        // Yulin's. It is an ordinary environment variable read.
+        tableName: process.env["TABLE_NAME"],
+        cacheUrl: process.env["CACHE_URL"],
+      })),
+    },
+  }),
+);
+
+const output = await lambda.invoke(
+  new InvokeCommand({ FunctionName: "rates" }),
+);
+
+if (output.Payload === undefined) throw new Error("No invoke Payload");
+// {"tableName":"rates","cacheUrl":"redis://127.0.0.1:6379"}
+console.log(Buffer.from(output.Payload).toString());
+```
+
+What that address points at is up to the test. A Redis running on localhost, one the test suite
+starts in a container, or a stand-in the test defines itself all work, because the application is
+doing what it always does with the value it is given.
+
+## A container reading from both
+
+The worked example below runs one simulated ECS container that writes to a simulated DynamoDB table
+and reads from a cache of its own. The two categories sit next to each other in the same handler and
+are configured the same way, through the container definition's `environment`.
+
+The cache here is a stand-in defined by the example, so nothing has to be running for it to work. A
+real client built from `CACHE_URL` would go in the same place.
+
+```typescript non-aws-dependency-ecs
+/**
+ * A simulated ECS container writing to a simulated DynamoDB table and reading
+ * from a cache of its own.
+ */
+
+import {
+  CreateTableCommand,
+  DynamoDBClient,
+  GetItemCommand,
+  PutItemCommand,
+} from "@aws-sdk/client-dynamodb";
+import {
+  CreateClusterCommand,
+  RegisterTaskDefinitionCommand,
+  RunTaskCommand,
+} from "@aws-sdk/client-ecs";
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+
+import { SimSdk } from "@kensio/yulin/sdk";
+
+/**
+ * Where the worker reads exchange rates from.
+ *
+ * A deployment builds a Redis client from the URL. This example stands one in,
+ * so nothing has to be running for it to work.
+ */
+class RateCache {
+  constructor(private readonly url: string) {}
+
+  rate(currency: string): Promise<string> {
+    console.log(`reading ${currency} from ${this.url}`);
+    // reading GBP from redis://127.0.0.1:6379
+    return Promise.resolve("1.27");
+  }
+}
+
+using simSdk = new SimSdk();
+const { simAws } = simSdk;
+const ecs = simAws.ecs();
+
+simSdk.intercept(DynamoDBClient);
+
+await simAws.dynamoDb().createTable(
+  new CreateTableCommand({
+    TableName: "rates",
+    KeySchema: [{ AttributeName: "currency", KeyType: "HASH" }],
+    AttributeDefinitions: [{ AttributeName: "currency", AttributeType: "S" }],
+    BillingMode: "PAY_PER_REQUEST",
+  }),
+);
+
+const taskRole = await simAws.iam().createRole(
+  new CreateRoleCommand({
+    RoleName: "RatesTaskRole",
+    AssumeRolePolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Principal: { Service: "ecs-tasks.amazonaws.com" },
+        Action: "sts:AssumeRole",
+      },
+    }),
+  }),
+);
+
+await simAws.iam().putRolePolicy(
+  new PutRolePolicyCommand({
+    RoleName: "RatesTaskRole",
+    PolicyName: "WriteRates",
+    PolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Action: "dynamodb:PutItem",
+        Resource:
+          `arn:aws:dynamodb:${simAws.defaultRegionName}:` +
+          `${simAws.defaultAccountId}:table/rates`,
+      },
+    }),
+  }),
+);
+
+await ecs.createCluster(new CreateClusterCommand({}));
+
+ecs.bindContainer({
+  family: "rates-worker",
+  containerName: "app",
+  run: async () => {
+    // Both reads happen inside the handler, so they see the container's own
+    // variables rather than the test process's.
+    const cache = new RateCache(process.env["CACHE_URL"] ?? "");
+    const rate = await cache.rate("GBP");
+
+    await new DynamoDBClient({}).send(
+      new PutItemCommand({
+        TableName: process.env["TABLE_NAME"],
+        Item: { currency: { S: "GBP" }, rate: { S: rate } },
+      }),
+    );
+  },
+});
+
+await ecs.registerTaskDefinition(
+  new RegisterTaskDefinitionCommand({
+    family: "rates-worker",
+    taskRoleArn: taskRole.Role.Arn,
+    containerDefinitions: [
+      {
+        name: "app",
+        image: "rates-worker:1",
+        environment: [
+          // Simulated by Yulin, reached with no network involved.
+          { name: "TABLE_NAME", value: "rates" },
+          // Yours, connected to the way it normally would be.
+          { name: "CACHE_URL", value: "redis://127.0.0.1:6379" },
+        ],
+      },
+    ],
+  }),
+);
+
+await ecs.runTask(new RunTaskCommand({ taskDefinition: "rates-worker" }));
+await simAws.backgroundTasksComplete();
+
+const stored = await simAws.dynamoDb().getItem(
+  new GetItemCommand({
+    TableName: "rates",
+    Key: { currency: { S: "GBP" } },
+  }),
+);
+
+console.log(stored.Item?.["rate"]?.S); // "1.27"
+```
+
+The DynamoDB write is authorized as the task role, in the same way it would be in a deployment. The
+cache read is not authorized by anything, because IAM has nothing to do with it.
+
+## Sidecar containers are not started
+
+A task definition sometimes declares the dependency itself as a second container, such as a Redis
+running next to the application in the same task. Yulin does not start it. It never looks inside a
+container image, and the only thing it can run is JavaScript or TypeScript in its own process, so
+there is nothing it could do with an image holding a Redis server.
+
+The container is stored and reported back as declared, and it is recorded as not simulated when the
+task runs, with a reason saying so. An application expecting it has to be given something else to
+talk to. Set the variable holding the address to something that answers, whether that is a Redis you
+run yourself or a stand-in, in the same way as for any other dependency of your own.
+
+## Reads happen inside the handler
+
+Handler code gets the function's or the container's variables while it runs, and reads the host
+process environment otherwise. A read at module scope, as in `const url = process.env.CACHE_URL` at
+the top of a file, happens when the test imports that file rather than when the code runs, so it
+sees the host value.
+
+That matters here because a connection is often built at module scope. Read inside the handler, or
+build the client there, to get the configured value. Sim Lambda warns on the console when the
+difference changes what the code sees, which is covered under
+[environment variables](../services/lambda/README.md#environment-variables) on the simulated Lambda
+page. Zip code running in the vm runtime is unaffected, because it is imported during an invocation.
+
+## Limitations
+
+Current documented limitations:
+
+- Nothing outside the simulated AWS services is simulated or started. Anything else the code talks
+  to is yours to run and to tear down.
+- A dependency declared as a sidecar container in an ECS task definition is not started, because
+  Yulin never runs a container image.
+- A connection built at module scope reads the host environment rather than the function's or the
+  container's, since the value is read before anything runs.
+- There is no interception point for a non-AWS dependency. The way to send the code somewhere else
+  is the environment variable it already reads, or an injection point in the code itself.

--- a/docs/non-aws-dependencies/non-aws-dependency-ecs.example.ts
+++ b/docs/non-aws-dependencies/non-aws-dependency-ecs.example.ts
@@ -1,0 +1,132 @@
+/**
+ * A simulated ECS container writing to a simulated DynamoDB table and reading
+ * from a cache of its own.
+ */
+
+import {
+  CreateTableCommand,
+  DynamoDBClient,
+  GetItemCommand,
+  PutItemCommand,
+} from "@aws-sdk/client-dynamodb";
+import {
+  CreateClusterCommand,
+  RegisterTaskDefinitionCommand,
+  RunTaskCommand,
+} from "@aws-sdk/client-ecs";
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+
+import { SimSdk } from "@kensio/yulin/sdk";
+
+/**
+ * Where the worker reads exchange rates from.
+ *
+ * A deployment builds a Redis client from the URL. This example stands one in,
+ * so nothing has to be running for it to work.
+ */
+class RateCache {
+  constructor(private readonly url: string) {}
+
+  rate(currency: string): Promise<string> {
+    console.log(`reading ${currency} from ${this.url}`);
+    // reading GBP from redis://127.0.0.1:6379
+    return Promise.resolve("1.27");
+  }
+}
+
+using simSdk = new SimSdk();
+const { simAws } = simSdk;
+const ecs = simAws.ecs();
+
+simSdk.intercept(DynamoDBClient);
+
+await simAws.dynamoDb().createTable(
+  new CreateTableCommand({
+    TableName: "rates",
+    KeySchema: [{ AttributeName: "currency", KeyType: "HASH" }],
+    AttributeDefinitions: [{ AttributeName: "currency", AttributeType: "S" }],
+    BillingMode: "PAY_PER_REQUEST",
+  }),
+);
+
+const taskRole = await simAws.iam().createRole(
+  new CreateRoleCommand({
+    RoleName: "RatesTaskRole",
+    AssumeRolePolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Principal: { Service: "ecs-tasks.amazonaws.com" },
+        Action: "sts:AssumeRole",
+      },
+    }),
+  }),
+);
+
+await simAws.iam().putRolePolicy(
+  new PutRolePolicyCommand({
+    RoleName: "RatesTaskRole",
+    PolicyName: "WriteRates",
+    PolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Action: "dynamodb:PutItem",
+        Resource:
+          `arn:aws:dynamodb:${simAws.defaultRegionName}:` +
+          `${simAws.defaultAccountId}:table/rates`,
+      },
+    }),
+  }),
+);
+
+await ecs.createCluster(new CreateClusterCommand({}));
+
+ecs.bindContainer({
+  family: "rates-worker",
+  containerName: "app",
+  run: async () => {
+    // Both reads happen inside the handler, so they see the container's own
+    // variables rather than the test process's.
+    const cache = new RateCache(process.env["CACHE_URL"] ?? "");
+    const rate = await cache.rate("GBP");
+
+    await new DynamoDBClient({}).send(
+      new PutItemCommand({
+        TableName: process.env["TABLE_NAME"],
+        Item: { currency: { S: "GBP" }, rate: { S: rate } },
+      }),
+    );
+  },
+});
+
+await ecs.registerTaskDefinition(
+  new RegisterTaskDefinitionCommand({
+    family: "rates-worker",
+    taskRoleArn: taskRole.Role.Arn,
+    containerDefinitions: [
+      {
+        name: "app",
+        image: "rates-worker:1",
+        environment: [
+          // Simulated by Yulin, reached with no network involved.
+          { name: "TABLE_NAME", value: "rates" },
+          // Yours, connected to the way it normally would be.
+          { name: "CACHE_URL", value: "redis://127.0.0.1:6379" },
+        ],
+      },
+    ],
+  }),
+);
+
+await ecs.runTask(new RunTaskCommand({ taskDefinition: "rates-worker" }));
+await simAws.backgroundTasksComplete();
+
+const stored = await simAws.dynamoDb().getItem(
+  new GetItemCommand({
+    TableName: "rates",
+    Key: { currency: { S: "GBP" } },
+  }),
+);
+
+console.log(stored.Item?.["rate"]?.S); // "1.27"

--- a/docs/non-aws-dependencies/non-aws-dependency-lambda.example.ts
+++ b/docs/non-aws-dependencies/non-aws-dependency-lambda.example.ts
@@ -1,0 +1,44 @@
+/**
+ * Pointing a simulated Lambda function at a dependency Yulin does not
+ * simulate, alongside one it does.
+ */
+
+import { CreateFunctionCommand, InvokeCommand } from "@aws-sdk/client-lambda";
+
+import { SimAws } from "@kensio/yulin";
+import { makeLambdaZipFileInput } from "@kensio/yulin/lambda";
+
+const simAws = new SimAws();
+const lambda = simAws.lambda();
+
+await lambda.createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "rates",
+    Role: "arn:aws:iam::111111111111:role/RatesRole",
+    Environment: {
+      Variables: {
+        // Simulated by Yulin, reached with no network involved.
+        TABLE_NAME: "rates",
+        // Yours. A deployment points this at ElastiCache. A test points it
+        // at whatever it wants the code to talk to instead.
+        CACHE_URL: "redis://127.0.0.1:6379",
+      },
+    },
+    Code: {
+      ZipFile: makeLambdaZipFileInput(() => ({
+        // Building a Redis client from the second value involves nothing of
+        // Yulin's. It is an ordinary environment variable read.
+        tableName: process.env["TABLE_NAME"],
+        cacheUrl: process.env["CACHE_URL"],
+      })),
+    },
+  }),
+);
+
+const output = await lambda.invoke(
+  new InvokeCommand({ FunctionName: "rates" }),
+);
+
+if (output.Payload === undefined) throw new Error("No invoke Payload");
+// {"tableName":"rates","cacheUrl":"redis://127.0.0.1:6379"}
+console.log(Buffer.from(output.Payload).toString());

--- a/docs/services/ecs/README.md
+++ b/docs/services/ecs/README.md
@@ -23,7 +23,8 @@ exactly as declared.
 
 Where this does not work is a sidecar the application depends on, such as a Redis or a database in
 the same task. Yulin does not simulate that. The connection details are ordinary environment
-variables, so point them at a real one you run yourself.
+variables, so point them at a real one you run yourself. See
+[non-AWS dependencies](../../non-aws-dependencies/README.md) for how that fits together.
 
 ## Registering a task definition
 

--- a/docs/services/lambda/README.md
+++ b/docs/services/lambda/README.md
@@ -1384,6 +1384,9 @@ The same applies to zip-packaged code in the vm runtime and to functions deploye
 `AWS::Lambda::Function` template with an `Environment` property, including ones backed by an
 [executable binding](#executable-bindings).
 
+This is also how a function reaches something Yulin does not simulate, such as a Redis or a
+Postgres. See [non-AWS dependencies](../../non-aws-dependencies/README.md).
+
 Variable names are validated as on real AWS. A name must match the Lambda name pattern
 `[a-zA-Z]([a-zA-Z0-9_])+`, meaning it starts with a letter, is at least two characters, and otherwise
 holds letters, digits and underscores. A name that does not match is rejected with


### PR DESCRIPTION
Adds a docs page explaining that a simulated Lambda function or ECS container runs your own code in the same Node.js process, and that everything it talks to is either a simulated AWS service Yulin handles in memory or a dependency of your own that connects the way it normally would. Both are configured the same way, through the function's `Environment.Variables` or the container definition's `environment`, which Yulin makes visible through `process.env` while the code runs, so pointing an application at a Redis on localhost or at a stand-in is a matter of setting the value it already reads. The worked example runs one simulated ECS container writing to a simulated DynamoDB table and reading from a cache it was pointed at by an environment variable, with the cache inert so the example needs nothing running. The page also states that a dependency declared as a sidecar container in a task definition is not started, because Yulin never runs a container image, and links from the simulated Lambda and simulated ECS pages and the docs index. No behaviour changes.

Resolves https://github.com/KensioSoftware/yulin/issues/561

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a guide explaining how external services such as Redis and Postgres work alongside simulated AWS services.
  * Added Lambda and ECS examples demonstrating environment-based configuration and simulated service integration.
  * Documented limitations, including ECS sidecars and differences in environment-variable access timing.
  * Linked the new guidance from the main, ECS, and Lambda documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->