### PR TITLE
feat: run ECS tasks from rules and schedules

### DIFF
--- a/docs/services/ecs/README.md
+++ b/docs/services/ecs/README.md
@@ -603,8 +603,11 @@ and both then run a task here when the rule matches an event or the schedule fal
 usual shape of a nightly batch job or an import kicked off by something happening.
 
 Both go through `RunTask`, so a task started that way is the same task as one started by a caller:
-the same cluster and revision lookups, the same refusals, the same IAM decision against
-`ecs:RunTask`, and the same task state afterwards. The difference is who runs it. A rule or a
+the same cluster and revision lookups, the same IAM decision against `ecs:RunTask`, and the same
+task state afterwards. What a target may ask for is not the same, though. `EcsParameters` takes and
+ignores the launch type, platform version, network configuration and capacity provider strategy that
+`RunTask` refuses, since a target written for real AWS carries them and refusing one would make an
+otherwise workable target unusable. The other difference is who runs it. A rule or a
 schedule runs the task as the role on its target, so that role needs `ecs:RunTask` on the revision,
 and the task role inside the task definition is still what the containers' own AWS calls are
 attributed to.

--- a/docs/services/ecs/README.md
+++ b/docs/services/ecs/README.md
@@ -595,6 +595,26 @@ has no credentials of its own, and taking the identity of whoever called `RunTas
 pass on permissions the deployed task has not got. The execution role is stored but does nothing
 here, because there is no image to pull and no log driver to write to.
 
+## Running a task from a rule or a schedule
+
+A task does not have to be started by a `RunTask` call. A [simulated EventBridge](../eventbridge/)
+rule target and a [simulated Scheduler](../scheduler/) schedule target can both name an ECS cluster,
+and both then run a task here when the rule matches an event or the schedule falls due. That is the
+usual shape of a nightly batch job or an import kicked off by something happening.
+
+Both go through `RunTask`, so a task started that way is the same task as one started by a caller:
+the same cluster and revision lookups, the same refusals, the same IAM decision against
+`ecs:RunTask`, and the same task state afterwards. The difference is who runs it. A rule or a
+schedule runs the task as the role on its target, so that role needs `ecs:RunTask` on the revision,
+and the task role inside the task definition is still what the containers' own AWS calls are
+attributed to.
+
+The container model applies unchanged: only a bound container runs, and a target naming a task
+definition with nothing bound records a task that never started rather than failing the rule or the
+schedule. Writing one of these targets is documented where the target is written, in
+[running an ECS task](../eventbridge/#running-an-ecs-task) for a rule and
+[running an ECS task on a schedule](../scheduler/#running-an-ecs-task-on-a-schedule) for a schedule.
+
 ## Describing, listing and stopping tasks
 
 `DescribeTasks` reports a task by its id or its full ARN, with its containers, which of them ran and
@@ -765,6 +785,8 @@ console.log(described.taskDefinition?.revision); // 1
 - `RunTaskCommand`, running the handlers bound to a task definition's containers, up to a `count` of
   ten tasks at a time
 - `DescribeTasksCommand`, `ListTasksCommand` and `StopTaskCommand`
+- Tasks run from an EventBridge rule target or a Scheduler schedule target, through that target's
+  role
 - `bindContainer`, targeting a container by family and container name or by image repository
 - Container environment variables and `RunTask` container overrides, through `process.env`
 - Container AWS calls authorized as the task role, including a `RunTask` `taskRoleArn` override
@@ -808,6 +830,14 @@ Current documented limitations:
   to, and container `secrets` are not resolved.
 - `StartTask` and the whole of the service API (`CreateService`, `UpdateService`,
   `DescribeServices`) are not simulated.
+- An EventBridge or Scheduler target's `EcsParameters` takes `TaskDefinitionArn` and `TaskCount`
+  only, taking and ignoring the launch type, platform version, network configuration and capacity
+  provider strategy for the same reason `RunTask` refuses them: there is no placement and no network
+  here. A `TaskCount` above one runs that many simulated tasks, and a bound container handler runs
+  once for each of them, in this process and one after another.
+- A rule or schedule target's `Input` is read as the task's overrides rather than as a payload,
+  since a task has nowhere to receive one, so container environment variables are set with a
+  `containerOverrides` list naming the container.
 - `DescribeTasks` refuses `include`, and a task carries no tags, so `RunTask` refuses `tags` too.
 - `ListTasks` refuses a `desiredStatus` of `PENDING`, which real ECS accepts. A simulated task is
   wanted either running or stopped, so the answer would always be an empty listing.

--- a/docs/services/eventbridge/README.md
+++ b/docs/services/eventbridge/README.md
@@ -972,7 +972,7 @@ no permission for.
 - An ECS target's `Input` is read as the task's overrides rather than as something the target
   receives, so a `containerOverrides` list is how a rule sets a container's environment. A target
   with no `Input` runs the task with no overrides, and the matched event is not passed on in its
-  place. Real EventBridge does pass the event, which fails there for the same reason.
+  place.
 - A `TaskCount` above one runs that many simulated tasks, and a bound container handler runs once
   for each of them, in this process and one after another.
 - An ECS target is refused in a CloudFormation template. `AWS::Events::Rule` still refuses a target

--- a/docs/services/eventbridge/README.md
+++ b/docs/services/eventbridge/README.md
@@ -4,7 +4,8 @@ Yulin includes a simulated Amazon EventBridge for tests and local development. E
 in memory and every operation is authorized by simulated IAM.
 
 Event buses, rules, targets and `PutEvents`. A rule can send matched events to a simulated Lambda
-function, SQS queue or SNS topic, or fire on a schedule when a test advances simulated time.
+function, SQS queue or SNS topic, run a simulated ECS task, or fire on a schedule when a test
+advances simulated time.
 [EventBridge Scheduler](../scheduler/) is a separate service with its own docs.
 EventBridge-specific types are imported from the `@kensio/yulin/eventbridge` subpath.
 
@@ -328,7 +329,8 @@ evaluate is refused here exactly as `PutRule` refuses it.
 ## Sending matched events to targets
 
 A rule sends every event it matches to each of its targets. A target is a simulated Lambda function,
-SQS queue or SNS topic.
+SQS queue or SNS topic, or an ECS cluster, where the rule runs a task rather than delivering
+anything: see [running an ECS task](#running-an-ecs-task).
 
 ```typescript sim-event-bridge-targets
 /**
@@ -426,9 +428,11 @@ that send to one target ARN.
 
 ## What a target has to allow
 
-EventBridge reaches a target as the `events.amazonaws.com` service principal, and the target's own
-resource policy is the whole of the decision. There is no execution role: a rule `RoleArn` is refused
-rather than simulated.
+EventBridge reaches a queue, topic or function target as the `events.amazonaws.com` service
+principal, and the target's own resource policy is the whole of the decision. There is no execution
+role for those three: a rule `RoleArn` and a target `RoleArn` are both refused rather than
+simulated. An ECS target is the exception, because there is no resource policy on a task definition
+for a rule to be admitted by, and it carries a role of its own.
 
 - **A queue** needs `sqs:SendMessage` for `events.amazonaws.com` in its `Policy` attribute.
 - **A topic** needs `sns:Publish` for `events.amazonaws.com` in its `Policy` attribute.
@@ -469,6 +473,147 @@ console.log(JSON.stringify(queuePolicy).length > 0); // true
 ```
 
 An event delivered across accounts still names the account it was put in, not the target's.
+
+## Running an ECS task
+
+A target whose ARN names an ECS cluster runs a [simulated ECS](../ecs/) task instead of receiving
+the event. `EcsParameters` says which task definition and how many tasks, and the target's `RoleArn`
+is the role the rule runs it as, both of which real EventBridge requires for the same reasons.
+
+```typescript sim-event-bridge-ecs-target
+/**
+ * A rule running an ECS task when an order event arrives.
+ */
+
+import {
+  CreateClusterCommand,
+  RegisterTaskDefinitionCommand,
+} from "@aws-sdk/client-ecs";
+import {
+  PutEventsCommand,
+  PutRuleCommand,
+  PutTargetsCommand,
+} from "@aws-sdk/client-eventbridge";
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const ecs = simAws.ecs();
+const imported: string[] = [];
+
+await ecs.createCluster(new CreateClusterCommand({ clusterName: "orders" }));
+
+ecs.bindContainer({
+  family: "order-import",
+  containerName: "app",
+  run: () => {
+    imported.push(process.env["ORDER_ID"] ?? "");
+  },
+});
+
+await ecs.registerTaskDefinition(
+  new RegisterTaskDefinitionCommand({
+    family: "order-import",
+    containerDefinitions: [{ name: "app", image: "order-import:1" }],
+  }),
+);
+
+// The rule runs the task as this role, so the role trusts EventBridge and is
+// allowed to run it.
+await simAws.iam().createRole(
+  new CreateRoleCommand({
+    RoleName: "EventsRole",
+    AssumeRolePolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Principal: { Service: "events.amazonaws.com" },
+        Action: "sts:AssumeRole",
+      },
+    }),
+  }),
+);
+
+await simAws.iam().putRolePolicy(
+  new PutRolePolicyCommand({
+    RoleName: "EventsRole",
+    PolicyName: "RunImport",
+    PolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: { Effect: "Allow", Action: "ecs:RunTask", Resource: "*" },
+    }),
+  }),
+);
+
+await simAws.eventBridge().putRule(
+  new PutRuleCommand({
+    Name: "orders",
+    EventPattern: JSON.stringify({ source: ["orders.service"] }),
+  }),
+);
+
+await simAws.eventBridge().putTargets(
+  new PutTargetsCommand({
+    Rule: "orders",
+    Targets: [
+      {
+        Id: "order-import",
+        Arn: "arn:aws:ecs:us-east-1:888888888888:cluster/orders",
+        RoleArn: "arn:aws:iam::888888888888:role/EventsRole",
+        EcsParameters: { TaskDefinitionArn: "order-import", TaskCount: 1 },
+        // An ECS target's Input is the task's overrides, since a task has
+        // nowhere to receive a payload.
+        Input: JSON.stringify({
+          containerOverrides: [
+            {
+              name: "app",
+              environment: [{ name: "ORDER_ID", value: "order-1" }],
+            },
+          ],
+        }),
+      },
+    ],
+  }),
+);
+
+await simAws.eventBridge().putEvents(
+  new PutEventsCommand({
+    Entries: [
+      {
+        Source: "orders.service",
+        DetailType: "OrderPlaced",
+        Detail: JSON.stringify({ orderId: "order-1" }),
+      },
+    ],
+  }),
+);
+
+// The task runs after PutEvents has answered, as it does on real AWS.
+await simAws.backgroundTasksComplete();
+
+console.log(imported); // ["order-1"]
+```
+
+The target ARN names the cluster, so an ARN naming anything else in ECS is refused when the target
+is added. `EcsParameters` names the task definition, as a family, a `family:revision` or a full ARN,
+and the same one `RunTask` would take.
+
+An ECS target's `Input` is the task's overrides rather than something the target receives, because
+a task has nowhere to receive a payload. So container environment variables are set the way the CDK
+sets them, with a `containerOverrides` list naming the container. A target with no `Input` runs the
+task with no overrides: the matched event is not passed to the container in its place.
+
+The role is the whole of the decision. It has to trust `events.amazonaws.com` in its
+`AssumeRolePolicyDocument`, and it has to be allowed `ecs:RunTask` on the task definition revision
+the target runs. A role that may not is a recorded delivery failure, in
+[deliveries that did not happen](#deliveries-that-did-not-happen), rather than an error the caller
+who put the event sees.
+
+Which containers actually run is [simulated ECS](../ecs/)'s answer rather than the rule's: a
+container with a binding runs its handler, and a container without one is recorded as not simulated.
+A target naming a task definition with nothing bound therefore records a task that never started,
+and the rule counts as delivered.
 
 ## Rules that fire on a schedule
 
@@ -801,6 +946,8 @@ no permission for.
   `numeric` and `exists`.
 - `PutTargets`, `RemoveTargets`, `ListTargetsByRule` and `ListRuleNamesByTarget`, with delivery to a
   simulated Lambda function, SQS queue or SNS topic, authorized by the target's own resource policy.
+- ECS targets, running a simulated task through the target's `RoleArn` with the task definition and
+  `TaskCount` from `EcsParameters` and container overrides from the target's `Input`.
 - Targets in another account or region of the same simulation, admitted by the target's own resource
   policy on `aws:SourceArn` or `aws:SourceAccount`, as real EventBridge does.
 - A target's fixed `Input`, and `deliveryFailures` for deliveries that did not happen.
@@ -813,10 +960,23 @@ no permission for.
 
 ## Limitations
 
-- Targets deliver to Lambda, SQS and SNS only. A target ARN naming any other service is refused when
-  the target is added rather than when an event first matches.
-- Target `InputPath` and `InputTransformer` are refused, as are a target `RoleArn`, dead letter
-  queues and retry policies. A delivery is attempted once.
+- Targets deliver to Lambda, SQS and SNS, and run a task in ECS. A target ARN naming any other
+  service is refused when the target is added rather than when an event first matches.
+- Target `InputPath` and `InputTransformer` are refused, as are dead letter queues and retry
+  policies. A delivery is attempted once. A target `RoleArn` is refused except on an ECS target,
+  which is the one target type that runs as a role rather than as the service principal.
+- An ECS target's `EcsParameters` takes `TaskDefinitionArn` and `TaskCount`, and takes and ignores
+  `LaunchType`, `PlatformVersion`, `NetworkConfiguration` and `CapacityProviderStrategy`, since
+  there is no placement and no network here for them to apply to. Anything else it can carry, such
+  as `Group`, `Tags` or `PropagateTags`, is refused rather than dropped.
+- An ECS target's `Input` is read as the task's overrides rather than as something the target
+  receives, so a `containerOverrides` list is how a rule sets a container's environment. A target
+  with no `Input` runs the task with no overrides, and the matched event is not passed on in its
+  place. Real EventBridge does pass the event, which fails there for the same reason.
+- A `TaskCount` above one runs that many simulated tasks, and a bound container handler runs once
+  for each of them, in this process and one after another.
+- An ECS target is refused in a CloudFormation template. `AWS::Events::Rule` still refuses a target
+  `RoleArn` and `EcsParameters`, so an ECS target is written with `PutTargets`.
 - Numbers are compared after JSON parsing, so `300`, `300.0` and `3.0e2` are one value here. Real
   EventBridge compares the JSON token when matching an exact value, and so may tell those forms
   apart. Use `numeric` to compare numbers, which is what it is for.

--- a/docs/services/eventbridge/sim-event-bridge-ecs-target.example.ts
+++ b/docs/services/eventbridge/sim-event-bridge-ecs-target.example.ts
@@ -1,0 +1,112 @@
+/**
+ * A rule running an ECS task when an order event arrives.
+ */
+
+import {
+  CreateClusterCommand,
+  RegisterTaskDefinitionCommand,
+} from "@aws-sdk/client-ecs";
+import {
+  PutEventsCommand,
+  PutRuleCommand,
+  PutTargetsCommand,
+} from "@aws-sdk/client-eventbridge";
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const ecs = simAws.ecs();
+const imported: string[] = [];
+
+await ecs.createCluster(new CreateClusterCommand({ clusterName: "orders" }));
+
+ecs.bindContainer({
+  family: "order-import",
+  containerName: "app",
+  run: () => {
+    imported.push(process.env["ORDER_ID"] ?? "");
+  },
+});
+
+await ecs.registerTaskDefinition(
+  new RegisterTaskDefinitionCommand({
+    family: "order-import",
+    containerDefinitions: [{ name: "app", image: "order-import:1" }],
+  }),
+);
+
+// The rule runs the task as this role, so the role trusts EventBridge and is
+// allowed to run it.
+await simAws.iam().createRole(
+  new CreateRoleCommand({
+    RoleName: "EventsRole",
+    AssumeRolePolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Principal: { Service: "events.amazonaws.com" },
+        Action: "sts:AssumeRole",
+      },
+    }),
+  }),
+);
+
+await simAws.iam().putRolePolicy(
+  new PutRolePolicyCommand({
+    RoleName: "EventsRole",
+    PolicyName: "RunImport",
+    PolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: { Effect: "Allow", Action: "ecs:RunTask", Resource: "*" },
+    }),
+  }),
+);
+
+await simAws.eventBridge().putRule(
+  new PutRuleCommand({
+    Name: "orders",
+    EventPattern: JSON.stringify({ source: ["orders.service"] }),
+  }),
+);
+
+await simAws.eventBridge().putTargets(
+  new PutTargetsCommand({
+    Rule: "orders",
+    Targets: [
+      {
+        Id: "order-import",
+        Arn: "arn:aws:ecs:us-east-1:888888888888:cluster/orders",
+        RoleArn: "arn:aws:iam::888888888888:role/EventsRole",
+        EcsParameters: { TaskDefinitionArn: "order-import", TaskCount: 1 },
+        // An ECS target's Input is the task's overrides, since a task has
+        // nowhere to receive a payload.
+        Input: JSON.stringify({
+          containerOverrides: [
+            {
+              name: "app",
+              environment: [{ name: "ORDER_ID", value: "order-1" }],
+            },
+          ],
+        }),
+      },
+    ],
+  }),
+);
+
+await simAws.eventBridge().putEvents(
+  new PutEventsCommand({
+    Entries: [
+      {
+        Source: "orders.service",
+        DetailType: "OrderPlaced",
+        Detail: JSON.stringify({ orderId: "order-1" }),
+      },
+    ],
+  }),
+);
+
+// The task runs after PutEvents has answered, as it does on real AWS.
+await simAws.backgroundTasksComplete();
+
+console.log(imported); // ["order-1"]

--- a/docs/services/scheduler/README.md
+++ b/docs/services/scheduler/README.md
@@ -172,7 +172,7 @@ Two things therefore have to be right, and they are fixed in different places:
 - The role's **trust policy** has to let `scheduler.amazonaws.com` assume it. A role copied from an
   EventBridge rule trusts `events.amazonaws.com` and fails here.
 - A policy **on the role** has to allow the action on the target: `lambda:InvokeFunction`,
-  `sqs:SendMessage` or `sns:Publish`.
+  `sqs:SendMessage`, `sns:Publish` or `ecs:RunTask`.
 
 When either is missing the target is not invoked and nothing is thrown, exactly as on AWS, where the
 failure goes to CloudWatch and nowhere the caller can see. `advanceBy(...)` still returns normally,
@@ -242,6 +242,128 @@ invoked, so it is still there afterwards whatever `ActionAfterCompletion` says.
 `State: "DISABLED"` stops a recurring schedule firing while it is off, and an `UpdateSchedule`
 enabling it picks up from the next due instant rather than replaying what it missed. An update that
 changes the expression reschedules from the new one.
+
+## Running an ECS task on a schedule
+
+A target whose ARN names an ECS cluster runs a [simulated ECS](../ecs/) task instead of being
+invoked with a payload. That is the shape a nightly batch job usually has: a container that runs,
+does its work and stops, rather than a function or a queue.
+
+```typescript sim-scheduler-ecs-target
+/**
+ * A schedule running an ECS task every night.
+ */
+
+import {
+  CreateClusterCommand,
+  ListTasksCommand,
+  RegisterTaskDefinitionCommand,
+} from "@aws-sdk/client-ecs";
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import { CreateScheduleCommand } from "@aws-sdk/client-scheduler";
+
+import { SimAws, SimFixedClock } from "@kensio/yulin";
+
+const simAws = new SimAws({
+  clock: new SimFixedClock(new Date("2026-07-26T09:00:00.000Z")),
+});
+const ecs = simAws.ecs();
+const imported: string[] = [];
+
+await ecs.createCluster(new CreateClusterCommand({ clusterName: "orders" }));
+
+ecs.bindContainer({
+  family: "nightly-import",
+  containerName: "app",
+  run: () => {
+    imported.push(process.env["IMPORT_MODE"] ?? "");
+  },
+});
+
+await ecs.registerTaskDefinition(
+  new RegisterTaskDefinitionCommand({
+    family: "nightly-import",
+    containerDefinitions: [{ name: "app", image: "nightly-import:1" }],
+  }),
+);
+
+// The schedule runs the task as this role, so the role trusts Scheduler and is
+// allowed to run it.
+await simAws.iam().createRole(
+  new CreateRoleCommand({
+    RoleName: "SchedulerRole",
+    AssumeRolePolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Principal: { Service: "scheduler.amazonaws.com" },
+        Action: "sts:AssumeRole",
+      },
+    }),
+  }),
+);
+
+await simAws.iam().putRolePolicy(
+  new PutRolePolicyCommand({
+    RoleName: "SchedulerRole",
+    PolicyName: "RunImport",
+    PolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: { Effect: "Allow", Action: "ecs:RunTask", Resource: "*" },
+    }),
+  }),
+);
+
+await simAws.scheduler().createSchedule(
+  new CreateScheduleCommand({
+    Name: "nightly-import",
+    ScheduleExpression: "cron(0 2 * * ? *)",
+    FlexibleTimeWindow: { Mode: "OFF" },
+    Target: {
+      Arn: "arn:aws:ecs:us-east-1:888888888888:cluster/orders",
+      RoleArn: "arn:aws:iam::888888888888:role/SchedulerRole",
+      EcsParameters: {
+        TaskDefinitionArn: "nightly-import",
+        TaskCount: 1,
+      },
+      // An ECS target's Input is the task's overrides, since a task has
+      // nowhere to receive a payload.
+      Input: JSON.stringify({
+        containerOverrides: [
+          {
+            name: "app",
+            environment: [{ name: "IMPORT_MODE", value: "full" }],
+          },
+        ],
+      }),
+    },
+  }),
+);
+
+// Advancing past 02:00 fires the schedule and runs the task.
+await simAws.clock().advanceBy({ hours: 24 });
+
+console.log(imported); // ["full"]
+
+const tasks = await ecs.listTasks(
+  new ListTasksCommand({ cluster: "orders", desiredStatus: "STOPPED" }),
+);
+
+console.log(tasks.taskArns?.length); // 1
+```
+
+The target ARN names the cluster, so an ARN naming anything else in ECS is refused when the schedule
+is created. `EcsParameters` names the task definition, as a family, a `family:revision` or a full
+ARN, and the same one `RunTask` would take.
+
+An ECS target's `Input` is the task's overrides rather than something the target receives, because a
+task has nowhere to receive a payload. A target with no `Input` runs the task with no overrides.
+`EcsParameters` on a target whose ARN names anything else is refused, since it would do nothing.
+
+Which containers actually run is [simulated ECS](../ecs/)'s answer rather than the schedule's: a
+container with a binding runs its handler, and a container without one is recorded as not simulated.
+A target naming a task definition with nothing bound therefore records a task that never started,
+and the schedule counts as invoked.
 
 ## Updating and deleting
 
@@ -495,6 +617,8 @@ removes the schedules it created, so nothing fires afterwards.
   clock.
 - Lambda, SQS and SNS targets, with a target `Input`, invoked as the target's execution role and
   authorized against that role's own policies.
+- ECS targets, running a simulated task as the execution role, with the task definition and
+  `TaskCount` from `EcsParameters` and container overrides from the target's `Input`.
 - `ActionAfterCompletion`, and `deliveryFailures` for invocations that did not happen.
 - The `default` schedule group in every account and region, without one being created.
 - Creation and modification timestamps from the simulation's clock, and prefix-narrowed,
@@ -520,12 +644,21 @@ removes the schedules it created, so nothing fires afterwards.
 - `ScheduleExpressionTimezone` other than `UTC` is refused rather than ignored, since running a
   schedule in the wrong zone fires it at the wrong hour.
 - `StartDate` and `EndDate` are refused rather than ignored.
-- Targets are Lambda, SQS and SNS only. The universal target
+- Targets are Lambda, SQS, SNS and ECS. The universal target
   (`arn:aws:scheduler:::aws-sdk:<service>:<action>`) and every other target service are refused when
   the schedule is created rather than when it first falls due.
-- A target `DeadLetterConfig`, `RetryPolicy`, `EcsParameters`, `EventBridgeParameters`,
-  `KinesisParameters`, `SageMakerPipelineParameters` and `SqsParameters` are refused rather than
-  dropped.
+- A target `DeadLetterConfig`, `RetryPolicy`, `EventBridgeParameters`, `KinesisParameters`,
+  `SageMakerPipelineParameters` and `SqsParameters` are refused rather than dropped, as is
+  `EcsParameters` on a target whose ARN does not name an ECS cluster.
+- An ECS target's `EcsParameters` takes `TaskDefinitionArn` and `TaskCount`, and takes and ignores
+  `LaunchType`, `PlatformVersion`, `NetworkConfiguration` and `CapacityProviderStrategy`, since
+  there is no placement and no network here for them to apply to. Anything else it can carry, such
+  as `Group`, `Tags` or `PropagateTags`, is refused rather than dropped.
+- An ECS target's `Input` is read as the task's overrides rather than as text the target receives,
+  so a `containerOverrides` list is how a schedule sets a container's environment. An `Input` that
+  is not a JSON object is refused on an ECS target, where every other target type takes any text.
+- A `TaskCount` above one runs that many simulated tasks, and a bound container handler runs once
+  for each of them, in this process and one after another.
 - `KmsKeyArn` is refused, and `ClientToken` is accepted and ignored: nothing here retries, so there is
   no request for it to make idempotent.
 - `AWS::Scheduler::ScheduleGroup` is not simulated as a CloudFormation resource type.

--- a/docs/services/scheduler/sim-scheduler-ecs-target.example.ts
+++ b/docs/services/scheduler/sim-scheduler-ecs-target.example.ts
@@ -1,0 +1,100 @@
+/**
+ * A schedule running an ECS task every night.
+ */
+
+import {
+  CreateClusterCommand,
+  ListTasksCommand,
+  RegisterTaskDefinitionCommand,
+} from "@aws-sdk/client-ecs";
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import { CreateScheduleCommand } from "@aws-sdk/client-scheduler";
+
+import { SimAws, SimFixedClock } from "@kensio/yulin";
+
+const simAws = new SimAws({
+  clock: new SimFixedClock(new Date("2026-07-26T09:00:00.000Z")),
+});
+const ecs = simAws.ecs();
+const imported: string[] = [];
+
+await ecs.createCluster(new CreateClusterCommand({ clusterName: "orders" }));
+
+ecs.bindContainer({
+  family: "nightly-import",
+  containerName: "app",
+  run: () => {
+    imported.push(process.env["IMPORT_MODE"] ?? "");
+  },
+});
+
+await ecs.registerTaskDefinition(
+  new RegisterTaskDefinitionCommand({
+    family: "nightly-import",
+    containerDefinitions: [{ name: "app", image: "nightly-import:1" }],
+  }),
+);
+
+// The schedule runs the task as this role, so the role trusts Scheduler and is
+// allowed to run it.
+await simAws.iam().createRole(
+  new CreateRoleCommand({
+    RoleName: "SchedulerRole",
+    AssumeRolePolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Principal: { Service: "scheduler.amazonaws.com" },
+        Action: "sts:AssumeRole",
+      },
+    }),
+  }),
+);
+
+await simAws.iam().putRolePolicy(
+  new PutRolePolicyCommand({
+    RoleName: "SchedulerRole",
+    PolicyName: "RunImport",
+    PolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: { Effect: "Allow", Action: "ecs:RunTask", Resource: "*" },
+    }),
+  }),
+);
+
+await simAws.scheduler().createSchedule(
+  new CreateScheduleCommand({
+    Name: "nightly-import",
+    ScheduleExpression: "cron(0 2 * * ? *)",
+    FlexibleTimeWindow: { Mode: "OFF" },
+    Target: {
+      Arn: "arn:aws:ecs:us-east-1:888888888888:cluster/orders",
+      RoleArn: "arn:aws:iam::888888888888:role/SchedulerRole",
+      EcsParameters: {
+        TaskDefinitionArn: "nightly-import",
+        TaskCount: 1,
+      },
+      // An ECS target's Input is the task's overrides, since a task has
+      // nowhere to receive a payload.
+      Input: JSON.stringify({
+        containerOverrides: [
+          {
+            name: "app",
+            environment: [{ name: "IMPORT_MODE", value: "full" }],
+          },
+        ],
+      }),
+    },
+  }),
+);
+
+// Advancing past 02:00 fires the schedule and runs the task.
+await simAws.clock().advanceBy({ hours: 24 });
+
+console.log(imported); // ["full"]
+
+const tasks = await ecs.listTasks(
+  new ListTasksCommand({ cluster: "orders", desiredStatus: "STOPPED" }),
+);
+
+console.log(tasks.taskArns?.length); // 1

--- a/src/service/ecs/README.md
+++ b/src/service/ecs/README.md
@@ -135,6 +135,25 @@ override and the Region variables, and applies them through `simProcessEnvironme
 process global: two of them would each install a getter, and the second would capture whatever the
 first was reporting as its host environment.
 
+## Event and schedule targets
+
+`target/` holds what an EventBridge rule target or a Scheduler schedule target says about the task it
+runs. It lives here rather than in either of those services because both say the same things in the
+same words: `EcsParameters` names the task definition and how many tasks, and the target's `Input` is
+the task's overrides, since a task has nowhere to receive a payload. Two copies of that would be two
+answers to what a target may ask ECS for.
+
+`SimEcsTargetParameters` refuses a parameter it does not model rather than dropping it, and takes the
+four that describe placement and networking without doing anything with them: a target written for
+real AWS carries them, and refusing one would make an otherwise workable target unusable, where
+dropping a `Group` or a `PropagateTags` would leave a target looking configured and behaving as
+though it is not.
+
+`SimEcsTargetRun` runs the task through the `RunTask` command rather than through the task runner
+behind it, so a task a rule started is the same task as one a caller started: the same lookups, the
+same refusals, and the same IAM decision against `ecs:RunTask` for the role the target carries. What
+neither service holds is a second answer to whether that role may run the task.
+
 ## Command handling
 
 AWS SDK-style operations are implemented under `command/`, one directory per operation, so the

--- a/src/service/ecs/index.ts
+++ b/src/service/ecs/index.ts
@@ -89,6 +89,14 @@ export {
   type SimEcsContainerOverrideType,
   type SimEcsTaskOverrideType,
 } from "./task/run/sim-ecs-task-overrides.js";
+export {
+  SimEcsTargetParameters,
+  type SimEcsTargetParametersType,
+} from "./target/sim-ecs-target-parameters.js";
+export {
+  SimEcsTargetTask,
+  type SimEcsTargetTaskProperties,
+} from "./target/sim-ecs-target-task.js";
 export type * from "./command/sim-ecs-command.types.js";
 export {
   SimEcsAccessDeniedException,

--- a/src/service/ecs/target/sim-ecs-target-overrides.ts
+++ b/src/service/ecs/target/sim-ecs-target-overrides.ts
@@ -1,0 +1,49 @@
+import { isRecord } from "../../../util/type-guard/record.js";
+import type { SimEcsTaskOverrideType } from "../task/run/sim-ecs-task-overrides.js";
+
+/**
+ * Read a target's fixed `Input` as the overrides the task runs with.
+ *
+ * A target that runs a task has nowhere else to say what the container should
+ * read, so its `Input` is the task's overrides rather than a payload handed to
+ * anything. That is what an EventBridge rule does on real AWS, and it is what
+ * the CDK writes when a target is given container overrides. Simulated
+ * Scheduler reads its target the same way, so one thing is true of both.
+ *
+ * A target with no `Input` runs the task with no overrides. The event a rule
+ * matched is deliberately not passed on in its place: a task's overrides are
+ * not an event envelope, and handing one over would refuse every delivery.
+ */
+export function simEcsTargetOverrides(
+  input: string | undefined,
+  refuse: (reason: string) => Error,
+): SimEcsTaskOverrideType | undefined {
+  if (input === undefined || input === "") {
+    return undefined;
+  }
+
+  const document: unknown = parsed(input, refuse);
+
+  if (!isRecord(document)) {
+    throw refuse(
+      "Target Input names the overrides an ECS task runs with, so it is a " +
+        "JSON object with taskRoleArn or containerOverrides on it",
+    );
+  }
+
+  return document;
+}
+
+/**
+ * Read the `Input` text as JSON, saying so where it is not.
+ */
+function parsed(input: string, refuse: (reason: string) => Error): unknown {
+  try {
+    return JSON.parse(input) as unknown;
+  } catch {
+    throw refuse(
+      "Target Input names the overrides an ECS task runs with, and this one " +
+        "is not JSON",
+    );
+  }
+}

--- a/src/service/ecs/target/sim-ecs-target-parameters.ts
+++ b/src/service/ecs/target/sim-ecs-target-parameters.ts
@@ -93,12 +93,15 @@ export class SimEcsTargetParameters {
 
     this.refuseUnaccepted(parameters, refuse);
 
-    const declared = parameters as SimEcsTargetParametersType;
+    // Copied rather than held by reference, the way a `RunTask` override is,
+    // since the caller owns what it passed in and this is read again every
+    // time the target runs and every time it is reported back.
+    const declared = structuredClone(parameters);
 
     return new this(
       declared,
-      this.taskDefinitionArnIn(declared.TaskDefinitionArn, refuse),
-      this.taskCountIn(declared.TaskCount, refuse),
+      this.taskDefinitionArnIn(declared["TaskDefinitionArn"], refuse),
+      this.taskCountIn(declared["TaskCount"], refuse),
     );
   }
 
@@ -124,14 +127,23 @@ export class SimEcsTargetParameters {
     }
   }
 
+  /**
+   * The task definition the target runs, which has to be named as a string.
+   *
+   * The type is checked as well as the value because these arrive as `unknown`:
+   * a target written in a template, or in JavaScript, can carry a number or a
+   * null here, and one of those reaching the task definition reader is a type
+   * error a long way from the target that caused it.
+   */
   private static taskDefinitionArnIn(
-    value: string | undefined,
+    value: unknown,
     refuse: (reason: string) => Error,
   ): string {
-    if (value === undefined || value === "") {
+    if (typeof value !== "string" || value === "") {
       throw refuse(
-        "EcsParameters TaskDefinitionArn is required: a target that runs a " +
-          "task says which task definition it runs",
+        "EcsParameters TaskDefinitionArn is required, as a family, a " +
+          "family:revision or an ARN: a target that runs a task says which " +
+          "task definition it runs",
       );
     }
 
@@ -139,14 +151,19 @@ export class SimEcsTargetParameters {
   }
 
   private static taskCountIn(
-    value: number | undefined,
+    value: unknown,
     refuse: (reason: string) => Error,
   ): number {
     if (value === undefined) {
       return defaultTaskCount;
     }
 
-    if (!Number.isSafeInteger(value) || value < 1 || value > maximumTaskCount) {
+    if (
+      typeof value !== "number" ||
+      !Number.isSafeInteger(value) ||
+      value < 1 ||
+      value > maximumTaskCount
+    ) {
       throw refuse(
         `EcsParameters TaskCount is a whole number from 1 to ${String(
           maximumTaskCount,

--- a/src/service/ecs/target/sim-ecs-target-parameters.ts
+++ b/src/service/ecs/target/sim-ecs-target-parameters.ts
@@ -1,0 +1,159 @@
+import { isRecord } from "../../../util/type-guard/record.js";
+
+/**
+ * Minimal structural `EcsParameters`, as an EventBridge rule target and a
+ * Scheduler schedule target both carry it.
+ *
+ * The two services name these the same things and mean the same things by
+ * them, so one shape serves both.
+ *
+ * https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_EcsParameters.html
+ */
+export interface SimEcsTargetParametersType {
+  readonly TaskDefinitionArn?: string | undefined;
+  readonly TaskCount?: number | undefined;
+  readonly LaunchType?: string | undefined;
+  readonly PlatformVersion?: string | undefined;
+  readonly NetworkConfiguration?: unknown;
+  readonly CapacityProviderStrategy?: unknown;
+}
+
+/**
+ * What a target may say about the task it runs.
+ *
+ * The first two decide what runs and how many of it. The other four describe
+ * where a real task would be placed and what it would be attached to, and there
+ * is no placement and no network here, so they are taken and ignored rather
+ * than refused: a target written for real AWS carries them, and refusing one
+ * would make an otherwise workable target unusable.
+ */
+const accepted: ReadonlySet<string> = new Set([
+  "TaskDefinitionArn",
+  "TaskCount",
+  "LaunchType",
+  "PlatformVersion",
+  "NetworkConfiguration",
+  "CapacityProviderStrategy",
+]);
+
+/**
+ * The most tasks one target may run, as both services limit it.
+ */
+const maximumTaskCount = 10;
+
+/**
+ * How many tasks a target with no `TaskCount` runs.
+ */
+const defaultTaskCount = 1;
+
+/**
+ * The `EcsParameters` one target carries.
+ *
+ * Reading them is the same job for both services, and the refusals are the
+ * same refusals, so the only thing either service supplies is the error to
+ * raise. That keeps a message reading as EventBridge's or Scheduler's own
+ * while there is one answer to what a target may ask for.
+ */
+export class SimEcsTargetParameters {
+  public readonly taskDefinitionArn: string;
+  public readonly taskCount: number;
+
+  /**
+   * The parameters as the request wrote them, for reporting them back.
+   */
+  public readonly declared: SimEcsTargetParametersType;
+
+  private constructor(
+    declared: SimEcsTargetParametersType,
+    taskDefinitionArn: string,
+    taskCount: number,
+  ) {
+    this.declared = declared;
+    this.taskDefinitionArn = taskDefinitionArn;
+    this.taskCount = taskCount;
+  }
+
+  /**
+   * Read the parameters a target carries, refusing what cannot be run.
+   *
+   * A target naming an ECS cluster and no task definition names nothing to
+   * run, so it is refused where it was written rather than at the first
+   * delivery.
+   */
+  static of(
+    parameters: unknown,
+    refuse: (reason: string) => Error,
+  ): SimEcsTargetParameters {
+    if (!isRecord(parameters)) {
+      throw refuse(
+        "EcsParameters is required on a target that runs an ECS task, and " +
+          "names at least a TaskDefinitionArn",
+      );
+    }
+
+    this.refuseUnaccepted(parameters, refuse);
+
+    const declared = parameters as SimEcsTargetParametersType;
+
+    return new this(
+      declared,
+      this.taskDefinitionArnIn(declared.TaskDefinitionArn, refuse),
+      this.taskCountIn(declared.TaskCount, refuse),
+    );
+  }
+
+  /**
+   * Refuse anything the parameters carry that this simulation does not hold.
+   *
+   * Working from what is accepted rather than from a list of everything ECS
+   * offers is what makes a parameter nobody thought about refused rather than
+   * dropped, which is the failure mode worth avoiding: a target that looks
+   * configured and behaves as though it is not.
+   */
+  private static refuseUnaccepted(
+    parameters: Record<string, unknown>,
+    refuse: (reason: string) => Error,
+  ): void {
+    for (const [name, value] of Object.entries(parameters)) {
+      if (value !== undefined && !accepted.has(name)) {
+        throw refuse(
+          `EcsParameters ${name} is not simulated, so a target carrying one ` +
+            `is refused rather than taken with it dropped`,
+        );
+      }
+    }
+  }
+
+  private static taskDefinitionArnIn(
+    value: string | undefined,
+    refuse: (reason: string) => Error,
+  ): string {
+    if (value === undefined || value === "") {
+      throw refuse(
+        "EcsParameters TaskDefinitionArn is required: a target that runs a " +
+          "task says which task definition it runs",
+      );
+    }
+
+    return value;
+  }
+
+  private static taskCountIn(
+    value: number | undefined,
+    refuse: (reason: string) => Error,
+  ): number {
+    if (value === undefined) {
+      return defaultTaskCount;
+    }
+
+    if (!Number.isSafeInteger(value) || value < 1 || value > maximumTaskCount) {
+      throw refuse(
+        `EcsParameters TaskCount is a whole number from 1 to ${String(
+          maximumTaskCount,
+        )}`,
+      );
+    }
+
+    return value;
+  }
+}

--- a/src/service/ecs/target/sim-ecs-target-run.ts
+++ b/src/service/ecs/target/sim-ecs-target-run.ts
@@ -1,0 +1,65 @@
+import type { SimAwsCaller } from "../../aws/caller/sim-aws-caller.js";
+import type { SimAwsAccountRegionContainer } from "../../aws/sim-aws-account-region-scope.js";
+import type { SimEcsTargetTask } from "./sim-ecs-target-task.js";
+
+interface SimEcsTargetRunProperties {
+  readonly scope: SimAwsAccountRegionContainer;
+}
+
+/**
+ * One task an event target or a schedule target is asking for.
+ */
+export interface SimEcsTargetRunRequest {
+  /**
+   * The cluster, as the target ARN names it.
+   */
+  readonly cluster: string;
+
+  readonly task: SimEcsTargetTask;
+
+  /**
+   * The session of the target's role, which is who runs the task.
+   */
+  readonly caller: SimAwsCaller;
+}
+
+/**
+ * Runs the task an EventBridge or Scheduler target names.
+ *
+ * It goes through `RunTask` rather than through the runner behind it, so a
+ * task started by a rule or a schedule is the same task as one started by a
+ * caller: the same cluster and revision lookups, the same refusals, the same
+ * IAM decision against `ecs:RunTask`, and the same task state afterwards. The
+ * role's permission to run the task is therefore ECS's own answer rather than
+ * a second one kept here.
+ *
+ * `RunTask` answers before the containers run, as real ECS does. That is the
+ * right moment to return to: the delivery has been made, and what the task
+ * does happens on the simulator's background work like the rest of it.
+ */
+export class SimEcsTargetRun {
+  private readonly scope: SimAwsAccountRegionContainer;
+
+  constructor(properties: SimEcsTargetRunProperties) {
+    this.scope = properties.scope;
+  }
+
+  /**
+   * Run the target's task as the target's role.
+   */
+  async run(request: SimEcsTargetRunRequest): Promise<void> {
+    const { parameters, overrides } = request.task;
+
+    await this.scope.ecs().runTask(
+      {
+        input: {
+          cluster: request.cluster,
+          taskDefinition: parameters.taskDefinitionArn,
+          count: parameters.taskCount,
+          overrides,
+        },
+      },
+      { caller: request.caller },
+    );
+  }
+}

--- a/src/service/ecs/target/sim-ecs-target-task.ts
+++ b/src/service/ecs/target/sim-ecs-target-task.ts
@@ -1,0 +1,53 @@
+import type { SimEcsTaskOverrideType } from "../task/run/sim-ecs-task-overrides.js";
+import { simEcsTargetOverrides } from "./sim-ecs-target-overrides.js";
+import { SimEcsTargetParameters } from "./sim-ecs-target-parameters.js";
+
+/**
+ * What a target request says about the task it runs.
+ */
+export interface SimEcsTargetTaskProperties {
+  readonly EcsParameters?: unknown;
+  readonly Input?: string | undefined;
+}
+
+/**
+ * The task one EventBridge rule target or Scheduler schedule target runs.
+ *
+ * Both services describe it the same way, in `EcsParameters` and an `Input`,
+ * so both read it here. What they do not share is who runs it: a rule carries
+ * the role on the target itself, and a schedule already has an execution role
+ * for every target it has.
+ */
+export class SimEcsTargetTask {
+  public readonly parameters: SimEcsTargetParameters;
+
+  /**
+   * What the target's `Input` overrides on the task, where it had one.
+   */
+  public readonly overrides: SimEcsTaskOverrideType | undefined;
+
+  private constructor(
+    parameters: SimEcsTargetParameters,
+    overrides: SimEcsTaskOverrideType | undefined,
+  ) {
+    this.parameters = parameters;
+    this.overrides = overrides;
+  }
+
+  /**
+   * Read the task a target runs, refusing one that could not be run.
+   *
+   * The refusals happen where the target was written rather than at the first
+   * delivery, so a target that names no task definition, or an `Input` that is
+   * not the overrides it has to be, is reported to whoever wrote it.
+   */
+  static of(
+    target: SimEcsTargetTaskProperties,
+    refuse: (reason: string) => Error,
+  ): SimEcsTargetTask {
+    return new this(
+      SimEcsTargetParameters.of(target.EcsParameters, refuse),
+      simEcsTargetOverrides(target.Input, refuse),
+    );
+  }
+}

--- a/src/service/eventbridge/README.md
+++ b/src/service/eventbridge/README.md
@@ -118,15 +118,30 @@ a rule that matches events and sends them nowhere, which real EventBridge lets y
 them apart is what keeps that from looking like a broken rule.
 
 `SimEventTargetArn` reads target ARNs itself rather than deferring to `parseSimArn`, because the
-three services it delivers to write their resource part three ways: a queue and a topic put the name
-straight after the Account, and a function writes `function:<name>`. An ARN naming any other service
-is refused when the target is added, so a rule that cannot work says so at the point it was written.
+services it delivers to write their resource part several ways: a queue and a topic put the name
+straight after the Account, a function writes `function:<name>` and a cluster writes
+`cluster/<name>`. An ARN naming any other service is refused when the target is added, so a rule
+that cannot work says so at the point it was written. The two services whose resource part carries
+a type are checked for naming something in it, because a layer ARN and a task definition ARN are
+both well formed ARNs of a service this delivers to, and neither names anything a rule can reach.
 
 Delivery has one class per destination service, and each asks that service's own authorizer:
 `SimSqsServiceSendAuthorizer`, `SimSnsServicePublishAuthorizer` and
 `SimLambdaServiceInvokeAuthorizer`. Those already existed for simulated SNS's own fan-out, and they
 answer the same question here with a different service principal, so nothing about who may reach a
 queue lives in this service.
+
+`SimEventBridgeDeliveryTask` is the exception, and it is the one target type that is not a delivery.
+There is no resource policy on a task definition for a rule to be admitted by, so a rule runs a task
+as a role of the account instead: `SimEventTargetEcs` is where the target's `RoleArn` and
+`EcsParameters` are read, `sim-event-bridge-target-role.ts` assumes that role, and the task itself is
+run through simulated ECS's own `RunTask`. Nothing about which containers run, or whether the role
+may run them, lives in this service either.
+
+That target's `Input` is the task's overrides rather than what the target receives, since a task has
+nowhere to receive a payload. Reading it, and reading `EcsParameters`, is the same job for a
+Scheduler schedule target, so both are in `src/service/ecs/target/` and neither service holds a
+second answer to what a target may ask ECS for.
 
 `SimAwsEventBridgeDeliveryTargets` is the SimAws-level dispatcher, and a `SimEventBridge` built on
 its own gets `SimEventBridgeNoDeliveryTargets` instead, which records every delivery as a failure

--- a/src/service/eventbridge/cfn/rule/sim-cfn-event-rule-targets.ts
+++ b/src/service/eventbridge/cfn/rule/sim-cfn-event-rule-targets.ts
@@ -20,12 +20,20 @@ export interface SimCfnEventRuleTarget {
 const unsimulatedTargetProperties: readonly (readonly [string, string])[] = [
   ["InputPath", "a target receives the whole event or its fixed Input"],
   ["InputTransformer", "a target receives the whole event or its fixed Input"],
-  ["RoleArn", "a rule reaches its target as the EventBridge service principal"],
+  [
+    "RoleArn",
+    "a rule reaches its target as the EventBridge service principal, and an " +
+      "ECS target, which does carry a role, is written with PutTargets",
+  ],
   ["DeadLetterConfig", "a failed delivery is recorded rather than sent on"],
   ["RetryPolicy", "a delivery is attempted once"],
   ["SqsParameters", "a FIFO queue target is not simulated"],
   ["KinesisParameters", "Kinesis is not a simulated target"],
-  ["EcsParameters", "ECS is not a simulated target"],
+  [
+    "EcsParameters",
+    "an ECS target is simulated and is written with PutTargets rather than " +
+      "from a template",
+  ],
   ["BatchParameters", "Batch is not a simulated target"],
   ["HttpParameters", "an API destination is not a simulated target"],
   ["RunCommandParameters", "Run Command is not a simulated target"],

--- a/src/service/eventbridge/command/target/sim-event-bridge-target-commands.ts
+++ b/src/service/eventbridge/command/target/sim-event-bridge-target-commands.ts
@@ -95,6 +95,8 @@ export class SimEventBridgeTargetCommands {
         Id: target.id,
         Arn: target.arn.value,
         Input: target.input,
+        RoleArn: target.ecs?.roleArn,
+        EcsParameters: target.ecs?.task.parameters.declared,
       }));
     const page = new SimEventBridgePage(listed, input.Limit, input.NextToken);
 

--- a/src/service/eventbridge/command/target/sim-event-bridge-unsimulated-target-input.ts
+++ b/src/service/eventbridge/command/target/sim-event-bridge-unsimulated-target-input.ts
@@ -29,12 +29,6 @@ const behaviourRefusals: readonly SimEventBridgeTargetRefusal[] = [
       "rather than sending the untransformed event",
   ],
   [
-    (target): unknown => target.RoleArn,
-    "A target RoleArn is not simulated. A rule reaches its target as the " +
-      "events.amazonaws.com service principal, which the target's own " +
-      "resource policy admits.",
-  ],
-  [
     (target): unknown => target.DeadLetterConfig,
     "Target dead letter queues are not simulated, so PutTargets refuses a " +
       "DeadLetterConfig rather than dropping undelivered events silently",
@@ -63,7 +57,6 @@ const unsimulatedTargetTypes: readonly (readonly [
   string,
 ])[] = [
   [(target): unknown => target.KinesisParameters, "Kinesis"],
-  [(target): unknown => target.EcsParameters, "ECS"],
   [(target): unknown => target.BatchParameters, "Batch"],
   [(target): unknown => target.HttpParameters, "API destination"],
   [(target): unknown => target.RunCommandParameters, "Run Command"],

--- a/src/service/eventbridge/command/target/target.command.ts
+++ b/src/service/eventbridge/command/target/target.command.ts
@@ -1,11 +1,12 @@
 import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type { SimEcsTargetParametersType } from "../../../ecs/target/sim-ecs-target-parameters.js";
 
 /**
  * One target as a request carries it, and as ListTargetsByRule reports it.
  *
- * The properties beyond `Id`, `Arn` and `Input` are the ones real EventBridge
- * takes and this simulation refuses, kept in the shape so a request carrying
- * one is recognised and named rather than ignored.
+ * The properties beyond `Id`, `Arn`, `Input`, `RoleArn` and `EcsParameters`
+ * are the ones real EventBridge takes and this simulation refuses, kept in the
+ * shape so a request carrying one is recognised and named rather than ignored.
  */
 export interface SimEventBridgeTarget {
   readonly Id?: string | undefined;
@@ -18,7 +19,7 @@ export interface SimEventBridgeTarget {
   readonly RetryPolicy?: object | undefined;
   readonly SqsParameters?: object | undefined;
   readonly KinesisParameters?: object | undefined;
-  readonly EcsParameters?: object | undefined;
+  readonly EcsParameters?: SimEcsTargetParametersType | undefined;
   readonly BatchParameters?: object | undefined;
   readonly HttpParameters?: object | undefined;
   readonly RunCommandParameters?: object | undefined;

--- a/src/service/eventbridge/delivery/sim-aws-event-bridge-delivery-targets.ts
+++ b/src/service/eventbridge/delivery/sim-aws-event-bridge-delivery-targets.ts
@@ -5,6 +5,7 @@ import type {
 } from "./sim-event-bridge-delivery.js";
 import { SimEventBridgeDeliveryFunction } from "./sim-event-bridge-delivery-function.js";
 import { SimEventBridgeDeliveryQueue } from "./sim-event-bridge-delivery-queue.js";
+import { SimEventBridgeDeliveryTask } from "./sim-event-bridge-delivery-task.js";
 import { SimEventBridgeDeliveryTopic } from "./sim-event-bridge-delivery-topic.js";
 import type { SimEventTargetService } from "../target/sim-event-target-arn.js";
 
@@ -63,6 +64,12 @@ export class SimAwsEventBridgeDeliveryTargets implements SimEventBridgeDeliveryT
       }
       case "sns": {
         await new SimEventBridgeDeliveryTopic({ scope }).deliver(request);
+        return;
+      }
+      case "ecs": {
+        await new SimEventBridgeDeliveryTask({ simAws: this.simAws }).deliver(
+          request,
+        );
         return;
       }
     }

--- a/src/service/eventbridge/delivery/sim-event-bridge-delivery-task.iso.test.ts
+++ b/src/service/eventbridge/delivery/sim-event-bridge-delivery-task.iso.test.ts
@@ -1,0 +1,371 @@
+import { RegisterTaskDefinitionCommand } from "@aws-sdk/client-ecs";
+import {
+  PutEventsCommand,
+  PutRuleCommand,
+  PutTargetsCommand,
+} from "@aws-sdk/client-eventbridge";
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import { simEcsClusterFactory } from "../../ecs/cluster/sim-ecs-cluster.factory.js";
+
+const clusterArn = "arn:aws:ecs:us-east-1:888888888888:cluster/default";
+
+const roleArn = "arn:aws:iam::888888888888:role/EventsRole";
+
+const orderPattern = JSON.stringify({ source: ["orders.service"] });
+
+/**
+ * A simulation with a cluster, and a role that trusts EventBridge and is
+ * allowed exactly what one policy statement says.
+ */
+async function simulationWithRole(
+  statement: object,
+  trusts = "events.amazonaws.com",
+): Promise<SimAws> {
+  const simAws = new SimAws();
+
+  await simEcsClusterFactory.make({}, simAws);
+
+  await simAws.iam().createRole(
+    new CreateRoleCommand({
+      RoleName: "EventsRole",
+      AssumeRolePolicyDocument: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: {
+          Effect: "Allow",
+          Principal: { Service: trusts },
+          Action: "sts:AssumeRole",
+        },
+      }),
+    }),
+  );
+
+  await simAws.iam().putRolePolicy(
+    new PutRolePolicyCommand({
+      RoleName: "EventsRole",
+      PolicyName: "RunTasks",
+      PolicyDocument: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: statement,
+      }),
+    }),
+  );
+
+  return simAws;
+}
+
+/**
+ * A simulation whose role may run any task.
+ */
+async function simulationAllowedToRunTasks(): Promise<SimAws> {
+  return await simulationWithRole({
+    Effect: "Allow",
+    Action: "ecs:RunTask",
+    Resource: "*",
+  });
+}
+
+/**
+ * A task definition of one container, bound to the handler given.
+ */
+async function boundTaskDefinition(
+  simAws: SimAws,
+  run: () => void,
+  environment: readonly { name: string; value: string }[] = [],
+): Promise<void> {
+  simAws.ecs().bindContainer({
+    family: "nightly-import",
+    containerName: "app",
+    run,
+  });
+
+  await simAws.ecs().registerTaskDefinition(
+    new RegisterTaskDefinitionCommand({
+      family: "nightly-import",
+      containerDefinitions: [
+        {
+          name: "app",
+          image: "nightly-import:1",
+          environment: [...environment],
+        },
+      ],
+    }),
+  );
+}
+
+/**
+ * A rule matching order events, with one ECS target on it.
+ */
+async function ruleRunningTask(
+  simAws: SimAws,
+  target: {
+    readonly TaskCount?: number;
+    readonly Input?: string;
+  } = {},
+): Promise<void> {
+  await simAws
+    .eventBridge()
+    .putRule(
+      new PutRuleCommand({ Name: "orders", EventPattern: orderPattern }),
+    );
+
+  await simAws.eventBridge().putTargets(
+    new PutTargetsCommand({
+      Rule: "orders",
+      Targets: [
+        {
+          Id: "import",
+          Arn: clusterArn,
+          RoleArn: roleArn,
+          Input: target.Input,
+          EcsParameters: {
+            TaskDefinitionArn: "nightly-import",
+            TaskCount: target.TaskCount,
+          },
+        },
+      ],
+    }),
+  );
+}
+
+/**
+ * Put one matching event and settle everything it caused.
+ */
+async function putOrderEvent(simAws: SimAws): Promise<void> {
+  await simAws.eventBridge().putEvents(
+    new PutEventsCommand({
+      Entries: [
+        {
+          Source: "orders.service",
+          DetailType: "OrderPlaced",
+          Detail: JSON.stringify({ orderId: "order-1" }),
+        },
+      ],
+    }),
+  );
+
+  await simAws.backgroundTasksComplete();
+}
+
+describe("EventBridge ECS target", () => {
+  it("runs the task a matched event's target names", async () => {
+    // Given a rule whose target runs a task definition with a bound container.
+    const simAws = await simulationAllowedToRunTasks();
+    let runs = 0;
+
+    await boundTaskDefinition(simAws, () => {
+      runs += 1;
+    });
+    await ruleRunningTask(simAws);
+
+    // When an event the rule matches is put.
+    await putOrderEvent(simAws);
+
+    // Then the container ran, and the task is in ECS's own state rather than
+    // in something the rule kept for itself.
+    assertIdentical(runs, 1);
+
+    const tasks = await simAws
+      .ecs()
+      .listTasks({ input: { desiredStatus: "STOPPED" } });
+
+    assertArrayLength(tasks.taskArns ?? [], 1);
+    assertArrayLength(simAws.eventBridge().deliveryFailures, 0);
+  });
+
+  it("puts the target's container overrides in the container", async () => {
+    // Given a target whose Input overrides the container's environment.
+    const simAws = await simulationAllowedToRunTasks();
+    let reportedFor = "";
+
+    await boundTaskDefinition(simAws, () => {
+      reportedFor = process.env["REPORT_DATE"] ?? "";
+    }, [{ name: "REPORT_DATE", value: "yesterday" }]);
+    await ruleRunningTask(simAws, {
+      Input: JSON.stringify({
+        containerOverrides: [
+          {
+            name: "app",
+            environment: [{ name: "REPORT_DATE", value: "today" }],
+          },
+        ],
+      }),
+    });
+
+    // When the rule matches.
+    await putOrderEvent(simAws);
+
+    // Then the override reached the container, over the top of what the
+    // container definition declared.
+    assertIdentical(reportedFor, "today");
+  });
+
+  it("runs the number of tasks the target asked for", async () => {
+    // Given a target asking for three tasks.
+    const simAws = await simulationAllowedToRunTasks();
+
+    await boundTaskDefinition(simAws, () => {
+      //
+    });
+    await ruleRunningTask(simAws, { TaskCount: 3 });
+
+    // When the rule matches.
+    await putOrderEvent(simAws);
+
+    // Then three tasks were started from the one event.
+    const tasks = await simAws
+      .ecs()
+      .listTasks({ input: { desiredStatus: "STOPPED" } });
+
+    assertArrayLength(tasks.taskArns ?? [], 3);
+  });
+
+  it("does not run the task when the role may not, and says why", async () => {
+    // Given a role that trusts EventBridge and may run something else.
+    const simAws = await simulationWithRole({
+      Effect: "Allow",
+      Action: "ecs:RunTask",
+      Resource: "arn:aws:ecs:us-east-1:888888888888:task-definition/other:1",
+    });
+    let runs = 0;
+
+    await boundTaskDefinition(simAws, () => {
+      runs += 1;
+    });
+    await ruleRunningTask(simAws);
+
+    // When the rule matches.
+    await putOrderEvent(simAws);
+
+    // Then nothing ran, and the failure names the action, since that is where
+    // it is fixed.
+    assertIdentical(runs, 0);
+
+    const [failure] = simAws.eventBridge().deliveryFailures;
+
+    assertNonNullable(failure);
+    assertStringIncludes(failure.message, "ecs:RunTask");
+    assertIdentical(failure.targetArn, clusterArn);
+  });
+
+  it("does not run the task when the role does not trust EventBridge", async () => {
+    // Given a role trusting Scheduler rather than rules, which is an easy
+    // thing to get wrong when moving from one to the other.
+    const simAws = await simulationWithRole(
+      { Effect: "Allow", Action: "ecs:RunTask", Resource: "*" },
+      "scheduler.amazonaws.com",
+    );
+
+    await boundTaskDefinition(simAws, () => {
+      //
+    });
+    await ruleRunningTask(simAws);
+
+    await putOrderEvent(simAws);
+
+    // Then the failure points at the trust policy rather than the permission,
+    // because that is the one to change.
+    const [failure] = simAws.eventBridge().deliveryFailures;
+
+    assertNonNullable(failure);
+    assertStringIncludes(failure.message, "trust policy");
+    assertStringIncludes(failure.message, "AssumeRolePolicyDocument");
+  });
+
+  it("reports a role that is not there rather than failing silently", async () => {
+    // Given a simulation with a cluster and no role at all.
+    const simAws = new SimAws();
+
+    await simEcsClusterFactory.make({}, simAws);
+    await boundTaskDefinition(simAws, () => {
+      //
+    });
+    await ruleRunningTask(simAws);
+
+    await putOrderEvent(simAws);
+
+    const [failure] = simAws.eventBridge().deliveryFailures;
+
+    assertNonNullable(failure);
+    assertStringIncludes(failure.message, "is not a simulated IAM role");
+  });
+
+  it("records that no container ran rather than failing the rule", async () => {
+    // Given a task definition whose container is bound to nothing, which is
+    // every container Yulin cannot run.
+    const simAws = await simulationAllowedToRunTasks();
+
+    await simAws.ecs().registerTaskDefinition(
+      new RegisterTaskDefinitionCommand({
+        family: "nightly-import",
+        containerDefinitions: [{ name: "app", image: "nightly-import:1" }],
+      }),
+    );
+    await ruleRunningTask(simAws);
+
+    // When the rule matches.
+    await putOrderEvent(simAws);
+
+    // Then the delivery was made, and the task says nothing started.
+    assertArrayLength(simAws.eventBridge().deliveryFailures, 0);
+
+    const tasks = await simAws
+      .ecs()
+      .listTasks({ input: { desiredStatus: "STOPPED" } });
+    const described = await simAws
+      .ecs()
+      .describeTasks({ input: { tasks: [...(tasks.taskArns ?? [])] } });
+
+    const [task] = described.tasks ?? [];
+
+    assertNonNullable(task);
+    assertIdentical(task.stopCode, "TaskFailedToStart");
+    assertStringIncludes(task.containers?.[0]?.reason ?? "", "no executable");
+  });
+
+  it("reports a cluster that is not there as a delivery failure", async () => {
+    // Given a target naming a cluster nothing created.
+    const simAws = await simulationAllowedToRunTasks();
+
+    await boundTaskDefinition(simAws, () => {
+      //
+    });
+
+    await simAws
+      .eventBridge()
+      .putRule(
+        new PutRuleCommand({ Name: "orders", EventPattern: orderPattern }),
+      );
+    await simAws.eventBridge().putTargets(
+      new PutTargetsCommand({
+        Rule: "orders",
+        Targets: [
+          {
+            Id: "import",
+            Arn: "arn:aws:ecs:us-east-1:888888888888:cluster/nightly",
+            RoleArn: roleArn,
+            EcsParameters: { TaskDefinitionArn: "nightly-import" },
+          },
+        ],
+      }),
+    );
+
+    // When the rule matches.
+    await putOrderEvent(simAws);
+
+    // Then the failure says which cluster, rather than the rule looking as
+    // though it delivered.
+    const [failure] = simAws.eventBridge().deliveryFailures;
+
+    assertNonNullable(failure);
+    assertStringIncludes(failure.message, "nightly");
+  });
+});

--- a/src/service/eventbridge/delivery/sim-event-bridge-delivery-task.ts
+++ b/src/service/eventbridge/delivery/sim-event-bridge-delivery-task.ts
@@ -1,0 +1,71 @@
+import { SimEcsTargetRun } from "../../ecs/target/sim-ecs-target-run.js";
+import type { SimAws } from "../../aws/sim-aws.js";
+import { SimEventBridgeTargetNotFound } from "../error/sim-event-bridge-delivery.error.js";
+import type { SimEventTargetEcs } from "../target/sim-event-target-ecs.js";
+import type { SimEventBridgeDeliveryRequest } from "./sim-event-bridge-delivery.js";
+import {
+  assumeEventBridgeTargetRole,
+  eventBridgeTargetRole,
+} from "./sim-event-bridge-target-role.js";
+
+interface SimEventBridgeDeliveryTaskProperties {
+  readonly simAws: SimAws;
+}
+
+/**
+ * An ECS task a simulated rule runs when it matches an event.
+ *
+ * This is the one target type that is not a delivery. Nothing receives the
+ * event: the rule calls `ecs:RunTask` as the target's role, and what the
+ * container reads comes from the target's `Input` as the task's overrides.
+ *
+ * The role is assumed in its own Account and the task is run in the cluster
+ * ARN's, which are not necessarily the same one.
+ */
+export class SimEventBridgeDeliveryTask {
+  private readonly simAws: SimAws;
+
+  constructor(properties: SimEventBridgeDeliveryTaskProperties) {
+    this.simAws = properties.simAws;
+  }
+
+  /**
+   * Run the target's task as the target's role.
+   */
+  async deliver(request: SimEventBridgeDeliveryRequest): Promise<void> {
+    const arn = request.target.arn;
+    const ecs = this.taskTarget(request);
+    const role = eventBridgeTargetRole(ecs.roleArn);
+    const roleScope = this.simAws.accountRegionScope(
+      role.accountId,
+      arn.regionName,
+    );
+    const caller = await assumeEventBridgeTargetRole(role, roleScope.iam());
+
+    await new SimEcsTargetRun({
+      scope: this.simAws.accountRegionScope(arn.accountId, arn.regionName),
+    }).run({ cluster: arn.value, task: ecs.task, caller });
+  }
+
+  /**
+   * What the target said about the task, which an ECS target always has.
+   *
+   * It is read here rather than assumed, because the target that reaches this
+   * is chosen by the service its ARN names and that is one step removed from
+   * the properties that were read off it.
+   */
+  private taskTarget(
+    request: SimEventBridgeDeliveryRequest,
+  ): SimEventTargetEcs {
+    const ecs = request.target.ecs;
+
+    if (ecs === undefined) {
+      throw new SimEventBridgeTargetNotFound(
+        `${request.target.arn.value} names an ECS cluster and the target ` +
+          `carries no EcsParameters, so there is no task to run.`,
+      );
+    }
+
+    return ecs;
+  }
+}

--- a/src/service/eventbridge/delivery/sim-event-bridge-target-role.ts
+++ b/src/service/eventbridge/delivery/sim-event-bridge-target-role.ts
@@ -1,0 +1,63 @@
+import type { SimAwsCaller } from "../../aws/caller/sim-aws-caller.js";
+import type { SimIam } from "../../iam/sim-iam.js";
+import {
+  assumeSimServiceRole,
+  type SimServiceRoleRefusals,
+  type SimServiceRoleTarget,
+  simServiceRoleTarget,
+} from "../../sts/service-role/sim-service-role.js";
+import { SimEventBridgeDeliveryNotPermitted } from "../error/sim-event-bridge-delivery.error.js";
+import { simEventBridgeServicePrincipal } from "./sim-event-bridge-delivery.js";
+
+/**
+ * The session name AWS gives a role a rule assumes to run a task.
+ */
+const sessionName = "AWSEvents";
+
+export type SimEventBridgeTargetRole = SimServiceRoleTarget;
+
+/**
+ * Read the Account and name out of a target's role ARN.
+ */
+export function eventBridgeTargetRole(roleArn: string): SimServiceRoleTarget {
+  return simServiceRoleTarget(roleArn);
+}
+
+/**
+ * What a rule says when it could not assume its target's role.
+ */
+const refusals: SimServiceRoleRefusals = {
+  missingRole: (target) =>
+    new SimEventBridgeDeliveryNotPermitted(
+      `${target.roleArn} is not a simulated IAM role, so the rule could not ` +
+        `assume it to run its target's task.`,
+    ),
+  untrustedRole: (target, servicePrincipal) =>
+    new SimEventBridgeDeliveryNotPermitted(
+      `The trust policy of ${target.roleArn} does not allow ` +
+        `${servicePrincipal} to assume it, so the rule could not run its ` +
+        `target's task. Add it to the role's AssumeRolePolicyDocument.`,
+    ),
+};
+
+/**
+ * Assume a target's role, and answer with the caller it makes.
+ *
+ * Only an ECS target has one. A queue, topic or function is reached as the
+ * `events.amazonaws.com` service principal and admitted by its own resource
+ * policy, but there is no resource policy on a task definition for a rule to be
+ * admitted by, so running a task is a call the rule makes as a role of the
+ * account instead. Real EventBridge requires the role for that reason.
+ */
+export async function assumeEventBridgeTargetRole(
+  target: SimEventBridgeTargetRole,
+  iam: SimIam,
+): Promise<SimAwsCaller> {
+  return await assumeSimServiceRole({
+    target,
+    servicePrincipal: simEventBridgeServicePrincipal,
+    sessionName,
+    iam,
+    refusals,
+  });
+}

--- a/src/service/eventbridge/target/sim-event-target-arn.ts
+++ b/src/service/eventbridge/target/sim-event-target-arn.ts
@@ -174,15 +174,21 @@ export class SimEventTargetArn {
    * The name of the ECS cluster this ARN names, or nothing when it names
    * something else in ECS.
    *
-   * A cluster ARN's resource is `cluster/<name>`, with a slash rather than the
-   * colon Lambda uses. The resource type is checked rather than assumed for
-   * the same reason: a task definition is `task-definition/<family>:<revision>`
-   * and a task is `task/<cluster>/<id>`, and taking the part after the slash
-   * would read either as a cluster that is not there.
+   * A cluster ARN's resource is `cluster/<name>` exactly, with a slash rather
+   * than the colon Lambda uses. Both the resource type and there being nothing
+   * after the name are checked rather than assumed, because ECS writes more
+   * than clusters this way: a task definition is
+   * `task-definition/<family>:<revision>` and a task is `task/<cluster>/<id>`,
+   * and reading the first two segments alone would take a task ARN for the
+   * cluster it runs in.
    */
   get clusterName(): string {
-    const [resourceType, name = ""] = this.resource.split("/", 2);
+    const [resourceType, name = "", beyond] = this.resource.split("/", 3);
 
-    return resourceType === "cluster" ? name : "";
+    if (resourceType !== "cluster" || beyond !== undefined) {
+      return "";
+    }
+
+    return name;
   }
 }

--- a/src/service/eventbridge/target/sim-event-target-arn.ts
+++ b/src/service/eventbridge/target/sim-event-target-arn.ts
@@ -5,7 +5,7 @@ import { SimEventBridgeValidationException } from "../error/sim-event-bridge.err
 /**
  * The services a simulated rule can send an event to.
  */
-export const simEventTargetServices = ["lambda", "sqs", "sns"] as const;
+export const simEventTargetServices = ["lambda", "sqs", "sns", "ecs"] as const;
 
 export type SimEventTargetService = (typeof simEventTargetServices)[number];
 
@@ -38,10 +38,10 @@ interface SimEventTargetArnProperties {
 /**
  * The ARN of somewhere a rule sends events.
  *
- * Target ARNs are read here rather than by `parseSimArn`, because the three
- * services this delivers to write their resource part three ways: a queue and
- * a topic put the name straight after the Account with no type in front of it,
- * and a function writes `function:<name>`.
+ * Target ARNs are read here rather than by `parseSimArn`, because the services
+ * this delivers to write their resource part several ways: a queue and a topic
+ * put the name straight after the Account with no type in front of it, a
+ * function writes `function:<name>`, and a cluster writes `cluster/<name>`.
  *
  * A target in another Account or Region is allowed, as real EventBridge
  * delivers across both.
@@ -120,15 +120,36 @@ export class SimEventTargetArn {
       resource,
     });
 
+    this.refuseUnnamedResource(arn);
+
+    return arn;
+  }
+
+  /**
+   * Refuse an ARN of the right service that names nothing in it.
+   *
+   * Both services whose resource part carries a type are checked, because both
+   * write more than one kind of resource: `arn:aws:lambda:...:layer:shared` and
+   * `arn:aws:ecs:...:task-definition/orders:3` are well formed ARNs of a
+   * service this delivers to, and neither names anything a rule can reach.
+   */
+  private static refuseUnnamedResource(arn: SimEventTargetArn): void {
     if (arn.service === "lambda" && arn.functionName === "") {
       throw new SimEventBridgeValidationException(
-        `Invalid parameter: Target Arn Reason: ${value} names no function. ` +
-          `A function ARN is ` +
+        `Invalid parameter: Target Arn Reason: ${arn.value} names no ` +
+          `function. A function ARN is ` +
           `arn:aws:lambda:<region>:<account-id>:function:<function-name>`,
       );
     }
 
-    return arn;
+    if (arn.service === "ecs" && arn.clusterName === "") {
+      throw new SimEventBridgeValidationException(
+        `Invalid parameter: Target Arn Reason: ${arn.value} names no ` +
+          `cluster. An ECS target names the cluster the task runs in, as ` +
+          `arn:aws:ecs:<region>:<account-id>:cluster/<cluster-name>, and ` +
+          `names its task definition in EcsParameters.`,
+      );
+    }
   }
 
   /**
@@ -147,5 +168,21 @@ export class SimEventTargetArn {
     const [resourceType, name = ""] = this.resource.split(":", 2);
 
     return resourceType === "function" ? name : "";
+  }
+
+  /**
+   * The name of the ECS cluster this ARN names, or nothing when it names
+   * something else in ECS.
+   *
+   * A cluster ARN's resource is `cluster/<name>`, with a slash rather than the
+   * colon Lambda uses. The resource type is checked rather than assumed for
+   * the same reason: a task definition is `task-definition/<family>:<revision>`
+   * and a task is `task/<cluster>/<id>`, and taking the part after the slash
+   * would read either as a cluster that is not there.
+   */
+  get clusterName(): string {
+    const [resourceType, name = ""] = this.resource.split("/", 2);
+
+    return resourceType === "cluster" ? name : "";
   }
 }

--- a/src/service/eventbridge/target/sim-event-target-ecs.iso.test.ts
+++ b/src/service/eventbridge/target/sim-event-target-ecs.iso.test.ts
@@ -1,0 +1,234 @@
+import {
+  ListTargetsByRuleCommand,
+  PutRuleCommand,
+  PutTargetsCommand,
+  type Target,
+} from "@aws-sdk/client-eventbridge";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import {
+  SimEventBridgeUnsimulatedInputException,
+  SimEventBridgeValidationException,
+} from "../error/sim-event-bridge.error.js";
+
+const clusterArn = "arn:aws:ecs:us-east-1:888888888888:cluster/orders";
+
+const queueArn = "arn:aws:sqs:us-east-1:888888888888:orders";
+
+const roleArn = "arn:aws:iam::888888888888:role/EventsRole";
+
+const orderPattern = JSON.stringify({ source: ["orders.service"] });
+
+/**
+ * A simulation with one rule to put targets on.
+ */
+async function simulationWithRule(): Promise<SimAws> {
+  const simAws = new SimAws();
+
+  await simAws
+    .eventBridge()
+    .putRule(
+      new PutRuleCommand({ Name: "orders", EventPattern: orderPattern }),
+    );
+
+  return simAws;
+}
+
+/**
+ * Put one target on the rule, answering with whatever it raised.
+ */
+async function refusedTarget(target: Target): Promise<Error> {
+  const simAws = await simulationWithRule();
+
+  return await assertThrowsErrorAsync(async () => {
+    await simAws
+      .eventBridge()
+      .putTargets(new PutTargetsCommand({ Rule: "orders", Targets: [target] }));
+  });
+}
+
+/**
+ * An ECS target with the parameters given.
+ */
+function ecsTarget(parameters: Target["EcsParameters"]): Target {
+  return {
+    Id: "import",
+    Arn: clusterArn,
+    RoleArn: roleArn,
+    EcsParameters: parameters,
+  };
+}
+
+describe("EventBridge ECS target validation", () => {
+  it("refuses an ECS ARN that names no cluster", async () => {
+    // Given a target naming a task definition, which is an ECS ARN a rule
+    // cannot run anything from.
+    const error = await refusedTarget({
+      Id: "import",
+      Arn: "arn:aws:ecs:us-east-1:888888888888:task-definition/nightly:3",
+      RoleArn: roleArn,
+      EcsParameters: { TaskDefinitionArn: "nightly" },
+    });
+
+    // Then it is refused when the target is added, saying what an ECS target
+    // names.
+    assertInstanceOf(error, SimEventBridgeValidationException);
+    assertStringIncludes(error.message, "names no cluster");
+  });
+
+  it("refuses an ECS target with no role to run the task as", async () => {
+    const error = await refusedTarget({
+      Id: "import",
+      Arn: clusterArn,
+      EcsParameters: { TaskDefinitionArn: "nightly" },
+    });
+
+    assertInstanceOf(error, SimEventBridgeValidationException);
+    assertStringIncludes(error.message, "carries a RoleArn");
+  });
+
+  it("refuses a RoleArn that is not a role ARN", async () => {
+    const error = await refusedTarget({
+      Id: "import",
+      Arn: clusterArn,
+      RoleArn: "arn:aws:iam::888888888888:user/someone",
+      EcsParameters: { TaskDefinitionArn: "nightly" },
+    });
+
+    assertInstanceOf(error, SimEventBridgeValidationException);
+    assertStringIncludes(error.message, "is not an IAM role ARN");
+  });
+
+  it("refuses an ECS target with no EcsParameters", async () => {
+    const error = await refusedTarget({
+      Id: "import",
+      Arn: clusterArn,
+      RoleArn: roleArn,
+    });
+
+    assertInstanceOf(error, SimEventBridgeValidationException);
+    assertStringIncludes(error.message, "EcsParameters is required");
+  });
+
+  it("refuses EcsParameters naming no task definition", async () => {
+    const error = await refusedTarget(ecsTarget({ TaskDefinitionArn: "" }));
+
+    assertInstanceOf(error, SimEventBridgeValidationException);
+    assertStringIncludes(error.message, "TaskDefinitionArn is required");
+  });
+
+  it("refuses a TaskCount outside what ECS runs", async () => {
+    // Given counts below, above and between the whole numbers ECS takes.
+    const counts = [0, 11, 1.5];
+
+    for (const TaskCount of counts) {
+      // oxlint-disable-next-line no-await-in-loop
+      const error = await refusedTarget(
+        ecsTarget({ TaskDefinitionArn: "nightly", TaskCount }),
+      );
+
+      // Then each is refused where it was written, rather than failing every
+      // delivery afterwards.
+      assertInstanceOf(error, SimEventBridgeValidationException);
+      assertStringIncludes(error.message, "TaskCount");
+    }
+  });
+
+  it("refuses an EcsParameter it does not model rather than dropping it", async () => {
+    // Given parameters that would place or tag a real task.
+    const error = await refusedTarget(
+      ecsTarget({ TaskDefinitionArn: "nightly", Group: "nightly" }),
+    );
+
+    // Then it is named rather than ignored, since a target that looks
+    // configured and is not is the worse answer.
+    assertInstanceOf(error, SimEventBridgeValidationException);
+    assertStringIncludes(error.message, "EcsParameters Group");
+  });
+
+  it("takes the parameters there is no placement or network for", async () => {
+    // Given a target written for real AWS, which says where the task runs.
+    const simAws = await simulationWithRule();
+
+    await simAws.eventBridge().putTargets(
+      new PutTargetsCommand({
+        Rule: "orders",
+        Targets: [
+          ecsTarget({
+            TaskDefinitionArn: "nightly",
+            LaunchType: "FARGATE",
+            PlatformVersion: "1.4.0",
+            NetworkConfiguration: {
+              awsvpcConfiguration: { Subnets: ["subnet-1"] },
+            },
+            CapacityProviderStrategy: [
+              { capacityProvider: "FARGATE_SPOT", weight: 1 },
+            ],
+          }),
+        ],
+      }),
+    );
+
+    // Then the target was taken, and reports back what it was given: there is
+    // no placement and no network here for any of them to apply to, and
+    // refusing one would make an otherwise workable target unusable.
+    const listed = await simAws
+      .eventBridge()
+      .listTargetsByRule(new ListTargetsByRuleCommand({ Rule: "orders" }));
+
+    const [target] = listed.Targets ?? [];
+
+    assertNonNullable(target);
+    assertIdentical(target.RoleArn, roleArn);
+    assertNonNullable(target.EcsParameters);
+    assertIdentical(target.EcsParameters.LaunchType, "FARGATE");
+    assertIdentical(target.EcsParameters.TaskDefinitionArn, "nightly");
+  });
+
+  it("refuses an Input that is not the overrides a task runs with", async () => {
+    // Given an Input that is JSON and is not an object.
+    const error = await refusedTarget({
+      ...ecsTarget({ TaskDefinitionArn: "nightly" }),
+      Input: JSON.stringify("nightly"),
+    });
+
+    // Then it is refused, since an ECS target has nothing to hand a payload
+    // to and reads its Input as the task's overrides instead.
+    assertInstanceOf(error, SimEventBridgeValidationException);
+    assertStringIncludes(error.message, "overrides");
+  });
+
+  it("refuses EcsParameters on a target that runs no task", async () => {
+    const error = await refusedTarget({
+      Id: "orders-queue",
+      Arn: queueArn,
+      EcsParameters: { TaskDefinitionArn: "nightly" },
+    });
+
+    assertInstanceOf(error, SimEventBridgeUnsimulatedInputException);
+    assertStringIncludes(error.message, "names an ECS cluster");
+  });
+
+  it("still refuses a RoleArn on a target that runs no task", async () => {
+    // Given a queue target with a role on it, which real EventBridge takes and
+    // never uses.
+    const error = await refusedTarget({
+      Id: "orders-queue",
+      Arn: queueArn,
+      RoleArn: roleArn,
+    });
+
+    // Then it is refused, because a queue admits the rule through its own
+    // resource policy and the role would do nothing.
+    assertInstanceOf(error, SimEventBridgeUnsimulatedInputException);
+    assertStringIncludes(error.message, "events.amazonaws.com");
+  });
+});

--- a/src/service/eventbridge/target/sim-event-target-ecs.iso.test.ts
+++ b/src/service/eventbridge/target/sim-event-target-ecs.iso.test.ts
@@ -84,6 +84,37 @@ describe("EventBridge ECS target validation", () => {
     assertStringIncludes(error.message, "names no cluster");
   });
 
+  it("refuses a cluster ARN carrying more than the cluster name", async () => {
+    // Given a task ARN, whose resource starts `task/<cluster>/` and so reads
+    // as a cluster for as long as nothing looks past the name.
+    const error = await refusedTarget({
+      Id: "import",
+      Arn: "arn:aws:ecs:us-east-1:888888888888:task/orders/2f1c",
+      RoleArn: roleArn,
+      EcsParameters: { TaskDefinitionArn: "nightly" },
+    });
+
+    // Then it is refused rather than run against the cluster it names.
+    assertInstanceOf(error, SimEventBridgeValidationException);
+    assertStringIncludes(error.message, "names no cluster");
+  });
+
+  it("refuses a TaskDefinitionArn that is not a string", async () => {
+    // Given a target built somewhere the types are not checked, which is any
+    // template or plain JavaScript.
+    const error = await refusedTarget({
+      ...ecsTarget({ TaskDefinitionArn: "nightly" }),
+      EcsParameters: {
+        TaskDefinitionArn: 3,
+      } as unknown as Target["EcsParameters"],
+    });
+
+    // Then it is refused where it was written, rather than reaching the task
+    // definition reader as a type error a long way from its cause.
+    assertInstanceOf(error, SimEventBridgeValidationException);
+    assertStringIncludes(error.message, "TaskDefinitionArn is required");
+  });
+
   it("refuses an ECS target with no role to run the task as", async () => {
     const error = await refusedTarget({
       Id: "import",

--- a/src/service/eventbridge/target/sim-event-target-ecs.ts
+++ b/src/service/eventbridge/target/sim-event-target-ecs.ts
@@ -1,0 +1,121 @@
+import {
+  SimEcsTargetTask,
+  type SimEcsTargetTaskProperties,
+} from "../../ecs/target/sim-ecs-target-task.js";
+import {
+  SimEventBridgeUnsimulatedInputException,
+  SimEventBridgeValidationException,
+} from "../error/sim-event-bridge.error.js";
+import type { SimEventTargetArn } from "./sim-event-target-arn.js";
+
+/**
+ * The shape an IAM role ARN has.
+ */
+const roleArnPattern = /^arn:aws[a-z-]*:iam::\d{12}:role\/.+$/u;
+
+/**
+ * What a target request says about running a task.
+ */
+export interface SimEventTargetTaskProperties extends SimEcsTargetTaskProperties {
+  readonly RoleArn?: string | undefined;
+}
+
+/**
+ * Refuse the task properties on a target that does not run a task.
+ *
+ * A `RoleArn` on a queue, topic or function target is the one refusal here
+ * that is about EventBridge rather than about ECS: a rule reaches those three
+ * as the `events.amazonaws.com` service principal and their own resource
+ * policies decide, so a role would be taken and never used.
+ */
+function refuseTaskProperties(target: SimEventTargetTaskProperties): void {
+  if (target.RoleArn !== undefined) {
+    throw new SimEventBridgeUnsimulatedInputException(
+      "A target RoleArn is not simulated except on an ECS target. A rule " +
+        "reaches its target as the events.amazonaws.com service principal, " +
+        "which the target's own resource policy admits.",
+    );
+  }
+
+  if (target.EcsParameters !== undefined) {
+    throw new SimEventBridgeUnsimulatedInputException(
+      "EcsParameters belongs to a target whose Arn names an ECS cluster, " +
+        "and this target's does not",
+    );
+  }
+}
+
+/**
+ * How this reports a target that could never run the task it describes.
+ */
+function refuse(reason: string): Error {
+  return new SimEventBridgeValidationException(
+    `Invalid parameter: Targets Reason: ${reason}`,
+  );
+}
+
+/**
+ * What one rule target says about the ECS task it runs.
+ *
+ * A rule runs a task as the target's own role rather than as the EventBridge
+ * service principal, which is why an ECS target is the one target type here
+ * that carries a `RoleArn`. Real EventBridge requires one for exactly the same
+ * reason: `ecs:RunTask` is a call it makes on the account's behalf rather than
+ * a delivery a resource policy can admit.
+ */
+export class SimEventTargetEcs {
+  public readonly roleArn: string;
+  public readonly task: SimEcsTargetTask;
+
+  private constructor(roleArn: string, task: SimEcsTargetTask) {
+    this.roleArn = roleArn;
+    this.task = task;
+  }
+
+  /**
+   * Read what a target says about running a task, where it runs one.
+   *
+   * A target whose ARN names anything but an ECS cluster runs no task, and is
+   * refused for carrying the properties of one rather than being taken with
+   * them ignored.
+   */
+  static of(
+    arn: SimEventTargetArn,
+    target: SimEventTargetTaskProperties,
+  ): SimEventTargetEcs | undefined {
+    if (arn.service !== "ecs") {
+      refuseTaskProperties(target);
+
+      return undefined;
+    }
+
+    return new this(
+      this.roleArnIn(target.RoleArn),
+      SimEcsTargetTask.of(target, refuse),
+    );
+  }
+
+  /**
+   * Read the role the rule runs the task as, which it has to have.
+   *
+   * It is checked for being a role ARN when the target is added rather than
+   * when an event first matches, so a target that could never run anything
+   * says so at the point it was written.
+   */
+  private static roleArnIn(value: string | undefined): string {
+    if (value === undefined || value === "") {
+      throw refuse(
+        "an ECS target runs its task as a role, so it carries a RoleArn",
+      );
+    }
+
+    if (!roleArnPattern.test(value)) {
+      throw refuse(
+        `'${value}' is not an IAM role ARN. One is ` +
+          `arn:aws:iam::<account-id>:role/<role-name>`,
+      );
+    }
+
+    return value;
+  }
+}

--- a/src/service/eventbridge/target/sim-event-target.ts
+++ b/src/service/eventbridge/target/sim-event-target.ts
@@ -1,5 +1,9 @@
 import { SimEventBridgeValidationException } from "../error/sim-event-bridge.error.js";
 import { SimEventTargetArn } from "./sim-event-target-arn.js";
+import {
+  SimEventTargetEcs,
+  type SimEventTargetTaskProperties,
+} from "./sim-event-target-ecs.js";
 
 /**
  * Real EventBridge allows alphanumerics, full stops, hyphens and underscores,
@@ -11,6 +15,7 @@ interface SimEventTargetProperties {
   readonly id: string;
   readonly arn: SimEventTargetArn;
   readonly input: string | undefined;
+  readonly ecs: SimEventTargetEcs | undefined;
 }
 
 /**
@@ -36,24 +41,38 @@ export class SimEventTarget {
    */
   public readonly input: string | undefined;
 
+  /**
+   * What this target says about the ECS task it runs, where it runs one.
+   *
+   * An ECS target is the one target type here whose `Input` is not what the
+   * target receives: a task has nowhere to receive a payload, so the `Input`
+   * is what the task overrides instead.
+   */
+  public readonly ecs: SimEventTargetEcs | undefined;
+
   private constructor(properties: SimEventTargetProperties) {
     this.id = properties.id;
     this.arn = properties.arn;
     this.input = properties.input;
+    this.ecs = properties.ecs;
   }
 
   /**
    * Read a target from request input.
    */
-  static of(properties: {
-    readonly Id?: string | undefined;
-    readonly Arn?: string | undefined;
-    readonly Input?: string | undefined;
-  }): SimEventTarget {
+  static of(
+    properties: SimEventTargetTaskProperties & {
+      readonly Id?: string | undefined;
+      readonly Arn?: string | undefined;
+    },
+  ): SimEventTarget {
+    const arn = SimEventTargetArn.of(properties.Arn);
+
     return new this({
       id: this.requiredId(properties.Id),
-      arn: SimEventTargetArn.of(properties.Arn),
+      arn,
       input: this.readInput(properties.Input),
+      ecs: SimEventTargetEcs.of(arn, properties),
     });
   }
 

--- a/src/service/scheduler/README.md
+++ b/src/service/scheduler/README.md
@@ -8,7 +8,9 @@ corner of it. The two look similar from a distance and differ in every detail th
 separate SDK client, an ARN carrying a schedule group, `CreateSchedule` conflicting where `PutRule`
 replaces, a listing shaped differently from a describe, and an execution model built on an IAM role
 instead of a resource policy. Code sharing between them is therefore deliberate and narrow: the
-schedule expression parser, and nothing else.
+schedule expression parser, assuming a service role, and reading what a target says about an ECS
+task. The last two arrived with ECS targets, which both services reach the same way because ECS is
+the same service on the other side of them.
 
 ## Entry points
 

--- a/src/service/scheduler/README.md
+++ b/src/service/scheduler/README.md
@@ -106,12 +106,15 @@ an EventBridge rule to anything — arrives as a service principal and is admitt
 resource policy. A schedule arrives as an assumed role and is admitted by that role's identity
 policies, with no resource policy involved.
 
-`sim-scheduler-execution-role.ts` is that difference. It asks STS's own
-`AssumeRoleTrustPolicyAuthorizer` whether the role admits `scheduler.amazonaws.com`, then builds a
-`SimResolvedCaller` whose principal is the session and whose `identityPolicyPrincipal` is the role.
-That split is exactly what `SimResolvedCaller` exists for, and it is why no STS session or temporary
-credential is created: nothing would read them, and registering credentials nobody uses would be
-state the simulation has to keep straight for no benefit.
+`sim-scheduler-execution-role.ts` is that difference. It names the two refusals in Scheduler's own
+words and hands the mechanism to `assumeSimServiceRole` under `src/service/sts/service-role/`, which
+asks STS's own `AssumeRoleTrustPolicyAuthorizer` whether the role admits `scheduler.amazonaws.com`
+and then builds a `SimResolvedCaller` whose principal is the session and whose
+`identityPolicyPrincipal` is the role. That split is exactly what `SimResolvedCaller` exists for, and
+it is why no STS session or temporary credential is created: nothing would read them, and
+registering credentials nobody uses would be state the simulation has to keep straight for no
+benefit. It is shared because an EventBridge rule assumes a role the same way for its one target type
+that runs rather than receives.
 
 The two failures are reported apart from each other, because they are fixed in different places: the
 trust policy is on the role's `AssumeRolePolicyDocument`, and the permission is in a policy attached
@@ -121,6 +124,12 @@ to it. Telling a reader which one it was saves the whole diagnosis.
 the target's, which need not be the same one. A `SimScheduler` built outside SimAws gets
 `SimSchedulerNoDeliveryTargets`, which records every invocation as a failure saying why there was
 nowhere to make it.
+
+`SimSchedulerDeliveryTask` is the one target type that runs something rather than being invoked with
+a payload. It runs the task through simulated ECS's own `RunTask` as the execution role, so the
+role's permission to run it is ECS's answer rather than a second one kept here. Its `EcsParameters`
+and its `Input`, which is the task's overrides, are read by `src/service/ecs/target/`, shared with
+EventBridge because a rule target says the same things about a task in the same words.
 
 ## Authorization
 

--- a/src/service/scheduler/command/schedule/schedule.command.ts
+++ b/src/service/scheduler/command/schedule/schedule.command.ts
@@ -1,4 +1,5 @@
 import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type { SimEcsTargetParametersType } from "../../../ecs/target/sim-ecs-target-parameters.js";
 
 /**
  * The target properties a simulated schedule reads.
@@ -13,7 +14,7 @@ export interface SimSchedulerRequestTarget {
   readonly Input?: string | undefined;
   readonly DeadLetterConfig?: unknown;
   readonly RetryPolicy?: unknown;
-  readonly EcsParameters?: unknown;
+  readonly EcsParameters?: SimEcsTargetParametersType | undefined;
   readonly EventBridgeParameters?: unknown;
   readonly KinesisParameters?: unknown;
   readonly SageMakerPipelineParameters?: unknown;

--- a/src/service/scheduler/command/schedule/sim-scheduler-described-schedule.ts
+++ b/src/service/scheduler/command/schedule/sim-scheduler-described-schedule.ts
@@ -28,6 +28,7 @@ export function describedSchedule(
       Arn: schedule.target.arn.value,
       RoleArn: schedule.target.roleArn,
       Input: schedule.target.input,
+      EcsParameters: schedule.target.task?.parameters.declared,
     },
     CreationDate: schedule.creationDate,
     LastModificationDate: schedule.lastModificationDate,

--- a/src/service/scheduler/command/schedule/sim-scheduler-unsimulated-target.ts
+++ b/src/service/scheduler/command/schedule/sim-scheduler-unsimulated-target.ts
@@ -19,7 +19,6 @@ function unsimulatedTargetProperties(
       "a failed invocation is recorded rather than sent on",
     ],
     ["RetryPolicy", target.RetryPolicy, "an invocation is attempted once"],
-    ["EcsParameters", target.EcsParameters, "ECS is not a simulated target"],
     [
       "EventBridgeParameters",
       target.EventBridgeParameters,

--- a/src/service/scheduler/delivery/sim-aws-scheduler-delivery-targets.ts
+++ b/src/service/scheduler/delivery/sim-aws-scheduler-delivery-targets.ts
@@ -7,6 +7,7 @@ import type {
 } from "./sim-scheduler-delivery.js";
 import { SimSchedulerDeliveryFunction } from "./sim-scheduler-delivery-function.js";
 import { SimSchedulerDeliveryQueue } from "./sim-scheduler-delivery-queue.js";
+import { SimSchedulerDeliveryTask } from "./sim-scheduler-delivery-task.js";
 import { SimSchedulerDeliveryTopic } from "./sim-scheduler-delivery-topic.js";
 import {
   assumeSchedulerExecutionRole,
@@ -75,6 +76,10 @@ export class SimAwsSchedulerDeliveryTargets implements SimSchedulerDeliveryTarge
       }
       case "sns": {
         await new SimSchedulerDeliveryTopic({ scope }).deliver(delivery);
+        return;
+      }
+      case "ecs": {
+        await new SimSchedulerDeliveryTask({ scope }).deliver(delivery);
         return;
       }
     }

--- a/src/service/scheduler/delivery/sim-scheduler-delivery-task.iso.test.ts
+++ b/src/service/scheduler/delivery/sim-scheduler-delivery-task.iso.test.ts
@@ -328,22 +328,33 @@ describe("Scheduler ECS target", () => {
   });
 
   it("refuses an ECS ARN that names no cluster", async () => {
-    const simAws = await simulationAllowedToRunTasks();
+    // Given a task definition ARN and a task ARN, which are both well formed
+    // ECS ARNs and neither of which names a cluster. The second reads as one
+    // for as long as nothing looks past the name, since a task's resource
+    // starts `task/<cluster>/`.
+    const arns = [
+      "arn:aws:ecs:us-east-1:888888888888:task-definition/x:1",
+      "arn:aws:ecs:us-east-1:888888888888:task/default/2f1c",
+    ];
 
-    const error = await assertThrowsErrorAsync(async () => {
-      await simAws.scheduler().createSchedule(
-        new CreateScheduleCommand({
-          Name: "nightly-import",
-          ScheduleExpression: "rate(1 day)",
-          FlexibleTimeWindow: { Mode: "OFF" },
-          Target: importTarget({
-            Arn: "arn:aws:ecs:us-east-1:888888888888:task-definition/x:1",
+    for (const Arn of arns) {
+      // oxlint-disable-next-line no-await-in-loop
+      const simAws = await simulationAllowedToRunTasks();
+      // oxlint-disable-next-line no-await-in-loop
+      const error = await assertThrowsErrorAsync(async () => {
+        await simAws.scheduler().createSchedule(
+          new CreateScheduleCommand({
+            Name: "nightly-import",
+            ScheduleExpression: "rate(1 day)",
+            FlexibleTimeWindow: { Mode: "OFF" },
+            Target: importTarget({ Arn }),
           }),
-        }),
-      );
-    });
+        );
+      });
 
-    assertInstanceOf(error, SimSchedulerValidationException);
-    assertStringIncludes(error.message, "names no cluster");
+      // Then each is refused when the schedule is created.
+      assertInstanceOf(error, SimSchedulerValidationException);
+      assertStringIncludes(error.message, "names no cluster");
+    }
   });
 });

--- a/src/service/scheduler/delivery/sim-scheduler-delivery-task.iso.test.ts
+++ b/src/service/scheduler/delivery/sim-scheduler-delivery-task.iso.test.ts
@@ -1,0 +1,349 @@
+import { RegisterTaskDefinitionCommand } from "@aws-sdk/client-ecs";
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import {
+  CreateScheduleCommand,
+  GetScheduleCommand,
+  type Target,
+} from "@aws-sdk/client-scheduler";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimFixedClock } from "../../../util/clock/sim-clock.js";
+import { SimAws } from "../../aws/sim-aws.js";
+import { simEcsClusterFactory } from "../../ecs/cluster/sim-ecs-cluster.factory.js";
+import {
+  SimSchedulerUnsimulatedInputException,
+  SimSchedulerValidationException,
+} from "../error/sim-scheduler.error.js";
+
+const startedAt = "2026-07-26T09:00:00.000Z";
+
+const clusterArn = "arn:aws:ecs:us-east-1:888888888888:cluster/default";
+
+const roleArn = "arn:aws:iam::888888888888:role/SchedulerRole";
+
+/**
+ * A simulation with a cluster, and a role that trusts Scheduler and is allowed
+ * exactly what one policy statement says.
+ */
+async function simulationWithRole(statement: object): Promise<SimAws> {
+  const simAws = new SimAws({ clock: new SimFixedClock(new Date(startedAt)) });
+
+  await simEcsClusterFactory.make({}, simAws);
+
+  await simAws.iam().createRole(
+    new CreateRoleCommand({
+      RoleName: "SchedulerRole",
+      AssumeRolePolicyDocument: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: {
+          Effect: "Allow",
+          Principal: { Service: "scheduler.amazonaws.com" },
+          Action: "sts:AssumeRole",
+        },
+      }),
+    }),
+  );
+
+  await simAws.iam().putRolePolicy(
+    new PutRolePolicyCommand({
+      RoleName: "SchedulerRole",
+      PolicyName: "RunTasks",
+      PolicyDocument: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: statement,
+      }),
+    }),
+  );
+
+  return simAws;
+}
+
+/**
+ * A simulation whose execution role may run any task.
+ */
+async function simulationAllowedToRunTasks(): Promise<SimAws> {
+  return await simulationWithRole({
+    Effect: "Allow",
+    Action: "ecs:RunTask",
+    Resource: "*",
+  });
+}
+
+/**
+ * A task definition of one container, bound to the handler given.
+ */
+async function boundTaskDefinition(
+  simAws: SimAws,
+  run: () => void,
+): Promise<void> {
+  simAws.ecs().bindContainer({
+    family: "nightly-import",
+    containerName: "app",
+    run,
+  });
+
+  await simAws.ecs().registerTaskDefinition(
+    new RegisterTaskDefinitionCommand({
+      family: "nightly-import",
+      containerDefinitions: [{ name: "app", image: "nightly-import:1" }],
+    }),
+  );
+}
+
+/**
+ * A one-time schedule an hour out, advanced past so it fires exactly once.
+ */
+async function scheduleFor(simAws: SimAws, target: Target): Promise<void> {
+  await simAws.scheduler().createSchedule(
+    new CreateScheduleCommand({
+      Name: "nightly-import",
+      ScheduleExpression: "at(2026-07-26T10:00:00)",
+      FlexibleTimeWindow: { Mode: "OFF" },
+      Target: target,
+    }),
+  );
+
+  await simAws.clock().advanceBy({ hours: 2 });
+}
+
+/**
+ * The target of a schedule that runs the nightly import.
+ */
+function importTarget(overrides: Partial<Target> = {}): Target {
+  return {
+    Arn: clusterArn,
+    RoleArn: roleArn,
+    EcsParameters: { TaskDefinitionArn: "nightly-import" },
+    ...overrides,
+  };
+}
+
+describe("Scheduler ECS target", () => {
+  it("runs the task when simulated time reaches the schedule", async () => {
+    // Given a schedule whose target runs a task definition with a bound
+    // container.
+    const simAws = await simulationAllowedToRunTasks();
+    let runs = 0;
+
+    await boundTaskDefinition(simAws, () => {
+      runs += 1;
+    });
+
+    // When simulated time reaches the schedule.
+    await scheduleFor(simAws, importTarget());
+
+    // Then the container ran, and the task is in ECS's own state. Nothing ran
+    // on the host's clock: only advancing the simulation's fired it.
+    assertIdentical(runs, 1);
+
+    const tasks = await simAws
+      .ecs()
+      .listTasks({ input: { desiredStatus: "STOPPED" } });
+
+    assertArrayLength(tasks.taskArns ?? [], 1);
+    assertArrayLength(simAws.scheduler().deliveryFailures, 0);
+  });
+
+  it("puts the target's container overrides in the container", async () => {
+    // Given a target whose Input overrides the container's environment.
+    const simAws = await simulationAllowedToRunTasks();
+    let reportedFor = "";
+
+    await boundTaskDefinition(simAws, () => {
+      reportedFor = process.env["REPORT_DATE"] ?? "";
+    });
+
+    // When the schedule fires.
+    await scheduleFor(
+      simAws,
+      importTarget({
+        Input: JSON.stringify({
+          containerOverrides: [
+            {
+              name: "app",
+              environment: [{ name: "REPORT_DATE", value: "today" }],
+            },
+          ],
+        }),
+      }),
+    );
+
+    // Then the override reached the container, which is what an ECS target's
+    // Input is for: a task has nowhere to receive a payload.
+    assertIdentical(reportedFor, "today");
+  });
+
+  it("runs the number of tasks the target asked for", async () => {
+    const simAws = await simulationAllowedToRunTasks();
+
+    await boundTaskDefinition(simAws, () => {
+      //
+    });
+
+    await scheduleFor(
+      simAws,
+      importTarget({
+        EcsParameters: { TaskDefinitionArn: "nightly-import", TaskCount: 3 },
+      }),
+    );
+
+    const tasks = await simAws
+      .ecs()
+      .listTasks({ input: { desiredStatus: "STOPPED" } });
+
+    assertArrayLength(tasks.taskArns ?? [], 3);
+  });
+
+  it("does not run the task when the role may not, and says why", async () => {
+    // Given an execution role allowed to run something else.
+    const simAws = await simulationWithRole({
+      Effect: "Allow",
+      Action: "ecs:RunTask",
+      Resource: "arn:aws:ecs:us-east-1:888888888888:task-definition/other:1",
+    });
+    let runs = 0;
+
+    await boundTaskDefinition(simAws, () => {
+      runs += 1;
+    });
+
+    // When the schedule fires.
+    await scheduleFor(simAws, importTarget());
+
+    // Then nothing ran, and the failure names the role and the action, since
+    // that is where it is fixed.
+    assertIdentical(runs, 0);
+
+    const [failure] = simAws.scheduler().deliveryFailures;
+
+    assertNonNullable(failure);
+    assertIdentical(failure.roleArn, roleArn);
+    assertStringIncludes(failure.message, "ecs:RunTask");
+    assertIdentical(failure.at.toISOString(), "2026-07-26T10:00:00.000Z");
+  });
+
+  it("records that no container ran rather than failing the schedule", async () => {
+    // Given a task definition whose container is bound to nothing.
+    const simAws = await simulationAllowedToRunTasks();
+
+    await simAws.ecs().registerTaskDefinition(
+      new RegisterTaskDefinitionCommand({
+        family: "nightly-import",
+        containerDefinitions: [{ name: "app", image: "nightly-import:1" }],
+      }),
+    );
+
+    // When the schedule fires.
+    await scheduleFor(simAws, importTarget());
+
+    // Then the schedule invoked without failing, and the task says nothing
+    // started, which is what makes a binding that matches nothing visible.
+    assertArrayLength(simAws.scheduler().deliveryFailures, 0);
+
+    const tasks = await simAws
+      .ecs()
+      .listTasks({ input: { desiredStatus: "STOPPED" } });
+    const described = await simAws
+      .ecs()
+      .describeTasks({ input: { tasks: [...(tasks.taskArns ?? [])] } });
+
+    assertIdentical(described.tasks?.[0]?.stopCode, "TaskFailedToStart");
+  });
+
+  it("reports what the schedule's target runs", async () => {
+    // Given a schedule that runs a task.
+    const simAws = await simulationAllowedToRunTasks();
+
+    await simAws.scheduler().createSchedule(
+      new CreateScheduleCommand({
+        Name: "nightly-import",
+        ScheduleExpression: "rate(1 day)",
+        FlexibleTimeWindow: { Mode: "OFF" },
+        Target: importTarget(),
+      }),
+    );
+
+    // When it is described.
+    const described = await simAws
+      .scheduler()
+      .getSchedule(new GetScheduleCommand({ Name: "nightly-import" }));
+
+    // Then the parameters come back as they were written.
+    assertIdentical(
+      described.Target?.EcsParameters?.TaskDefinitionArn,
+      "nightly-import",
+    );
+  });
+
+  it("refuses an Input that is not JSON on a target that runs a task", async () => {
+    // Given a schedule target whose Input is the plain text Scheduler takes
+    // for its other target types.
+    const simAws = await simulationAllowedToRunTasks();
+
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.scheduler().createSchedule(
+        new CreateScheduleCommand({
+          Name: "nightly-import",
+          ScheduleExpression: "rate(1 day)",
+          FlexibleTimeWindow: { Mode: "OFF" },
+          Target: importTarget({ Input: "run it" }),
+        }),
+      );
+    });
+
+    // Then it is refused where it was written, rather than failing every
+    // invocation an hour of simulated time later.
+    assertInstanceOf(error, SimSchedulerValidationException);
+    assertStringIncludes(error.message, "is not JSON");
+  });
+
+  it("refuses EcsParameters on a target that runs no task", async () => {
+    const simAws = await simulationAllowedToRunTasks();
+
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.scheduler().createSchedule(
+        new CreateScheduleCommand({
+          Name: "nightly-import",
+          ScheduleExpression: "rate(1 day)",
+          FlexibleTimeWindow: { Mode: "OFF" },
+          Target: {
+            Arn: "arn:aws:sqs:us-east-1:888888888888:reports",
+            RoleArn: roleArn,
+            EcsParameters: { TaskDefinitionArn: "nightly-import" },
+          },
+        }),
+      );
+    });
+
+    assertInstanceOf(error, SimSchedulerUnsimulatedInputException);
+    assertStringIncludes(error.message, "names an ECS cluster");
+  });
+
+  it("refuses an ECS ARN that names no cluster", async () => {
+    const simAws = await simulationAllowedToRunTasks();
+
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.scheduler().createSchedule(
+        new CreateScheduleCommand({
+          Name: "nightly-import",
+          ScheduleExpression: "rate(1 day)",
+          FlexibleTimeWindow: { Mode: "OFF" },
+          Target: importTarget({
+            Arn: "arn:aws:ecs:us-east-1:888888888888:task-definition/x:1",
+          }),
+        }),
+      );
+    });
+
+    assertInstanceOf(error, SimSchedulerValidationException);
+    assertStringIncludes(error.message, "names no cluster");
+  });
+});

--- a/src/service/scheduler/delivery/sim-scheduler-delivery-task.ts
+++ b/src/service/scheduler/delivery/sim-scheduler-delivery-task.ts
@@ -1,0 +1,63 @@
+import { SimEcsTargetRun } from "../../ecs/target/sim-ecs-target-run.js";
+import type { SimAwsAccountRegionContainer } from "../../aws/sim-aws-account-region-scope.js";
+import { SimSchedulerTargetNotFound } from "../error/sim-scheduler-delivery.error.js";
+import type { SimEcsTargetTask } from "../../ecs/target/sim-ecs-target-task.js";
+import type { SimSchedulerAssumedDelivery } from "./sim-scheduler-delivery.js";
+
+interface SimSchedulerDeliveryTaskProperties {
+  readonly scope: SimAwsAccountRegionContainer;
+}
+
+/**
+ * An ECS task a simulated schedule runs when it falls due.
+ *
+ * This is the one target type that is not an invocation. Nothing receives the
+ * schedule's `Input`: a task has nowhere to receive a payload, so the `Input`
+ * is read as the task's overrides instead, which is what puts a variable in
+ * front of the container's code.
+ *
+ * The execution role has already been assumed by the time this runs, and the
+ * task is run as that role, so a role without `ecs:RunTask` on the revision
+ * fails the invocation in exactly the way a role without
+ * `lambda:InvokeFunction` fails a function target.
+ */
+export class SimSchedulerDeliveryTask {
+  private readonly scope: SimAwsAccountRegionContainer;
+
+  constructor(properties: SimSchedulerDeliveryTaskProperties) {
+    this.scope = properties.scope;
+  }
+
+  /**
+   * Run the target's task as the execution role.
+   */
+  async deliver(delivery: SimSchedulerAssumedDelivery): Promise<void> {
+    const target = delivery.request.schedule.target;
+
+    await new SimEcsTargetRun({ scope: this.scope }).run({
+      cluster: target.arn.value,
+      task: this.task(delivery),
+      caller: delivery.caller,
+    });
+  }
+
+  /**
+   * What the target said about the task, which an ECS target always has.
+   *
+   * It is read here rather than assumed, because the target that reaches this
+   * is chosen by the service its ARN names and that is one step removed from
+   * the properties that were read off it.
+   */
+  private task(delivery: SimSchedulerAssumedDelivery): SimEcsTargetTask {
+    const target = delivery.request.schedule.target;
+
+    if (target.task === undefined) {
+      throw new SimSchedulerTargetNotFound(
+        `${target.arn.value} names an ECS cluster and the target carries no ` +
+          `EcsParameters, so there is no task to run.`,
+      );
+    }
+
+    return target.task;
+  }
+}

--- a/src/service/scheduler/delivery/sim-scheduler-execution-role.ts
+++ b/src/service/scheduler/delivery/sim-scheduler-execution-role.ts
@@ -1,9 +1,11 @@
 import type { SimAwsCaller } from "../../aws/caller/sim-aws-caller.js";
-import type { SimAwsAccountId } from "../../aws/sim-aws-account.js";
-import { SimIamAccessDenied } from "../../iam/error/sim-iam.error.js";
-import { IamRoleArnParser } from "../../iam/role/arn/sim-iam-role-arn-parser.js";
 import type { SimIam } from "../../iam/sim-iam.js";
-import { AssumeRoleTrustPolicyAuthorizer } from "../../sts/auth-z/assume-role-trust-policy-authorizer.js";
+import {
+  assumeSimServiceRole,
+  type SimServiceRoleRefusals,
+  type SimServiceRoleTarget,
+  simServiceRoleTarget,
+} from "../../sts/service-role/sim-service-role.js";
 import { SimSchedulerDeliveryNotPermitted } from "../error/sim-scheduler-delivery.error.js";
 import { simSchedulerServicePrincipal } from "./sim-scheduler-delivery.js";
 
@@ -12,14 +14,7 @@ import { simSchedulerServicePrincipal } from "./sim-scheduler-delivery.js";
  */
 const sessionName = "EventBridgeScheduler";
 
-/**
- * Which IAM a role ARN belongs to, and what the role is called there.
- */
-export interface SimSchedulerExecutionRoleTarget {
-  readonly accountId: SimAwsAccountId;
-  readonly roleName: string;
-  readonly roleArn: string;
-}
+export type SimSchedulerExecutionRoleTarget = SimServiceRoleTarget;
 
 /**
  * Read the Account and name out of a schedule's execution role ARN.
@@ -30,76 +25,44 @@ export interface SimSchedulerExecutionRoleTarget {
 export function schedulerExecutionRoleTarget(
   roleArn: string,
 ): SimSchedulerExecutionRoleTarget {
-  const parts = new IamRoleArnParser().parse(roleArn);
-
-  return { accountId: parts.accountId, roleName: parts.roleName, roleArn };
+  return simServiceRoleTarget(roleArn);
 }
+
+/**
+ * What Scheduler says when it could not assume a schedule's execution role.
+ */
+const refusals: SimServiceRoleRefusals = {
+  missingRole: (target) =>
+    new SimSchedulerDeliveryNotPermitted(
+      `${target.roleArn} is not a simulated IAM role, so the schedule could ` +
+        `not assume it to invoke its target.`,
+    ),
+  untrustedRole: (target, servicePrincipal) =>
+    new SimSchedulerDeliveryNotPermitted(
+      `The trust policy of ${target.roleArn} does not allow ` +
+        `${servicePrincipal} to assume it, so the schedule could not invoke ` +
+        `its target. Add it to the role's AssumeRolePolicyDocument.`,
+    ),
+};
 
 /**
  * Assume a schedule's execution role, and answer with the caller it makes.
  *
  * This is the whole of what makes Scheduler's execution model different from an
- * EventBridge rule's. A rule reaches its target as the `events.amazonaws.com`
- * service principal and the target's own resource policy decides; a schedule
- * assumes a role, and the role's policies decide. So the two things checked
- * here are the two things that go wrong in a real account: whether the role
- * trusts Scheduler at all, and then, separately, whether it may do the thing.
- *
- * The caller carries both principals. The request is attributed to the session,
- * as it is on AWS, while the policies that apply are the role's, which is
- * exactly the split `SimResolvedCaller` exists for.
+ * EventBridge rule's for most target types. A rule reaches a queue, topic or
+ * function as the `events.amazonaws.com` service principal and the target's own
+ * resource policy decides; a schedule assumes a role, and the role's policies
+ * decide.
  */
 export async function assumeSchedulerExecutionRole(
   target: SimSchedulerExecutionRoleTarget,
   iam: SimIam,
 ): Promise<SimAwsCaller> {
-  const role = await roleOrRefuse(target, iam);
-
-  try {
-    new AssumeRoleTrustPolicyAuthorizer().authorize({
-      roleArn: target.roleArn,
-      role,
-      targetIam: iam,
-      caller: { kind: "service", service: simSchedulerServicePrincipal },
-    });
-  } catch (error) {
-    if (error instanceof SimIamAccessDenied) {
-      throw new SimSchedulerDeliveryNotPermitted(
-        `The trust policy of ${target.roleArn} does not allow ` +
-          `${simSchedulerServicePrincipal} to assume it, so the schedule ` +
-          `could not invoke its target. Add it to the role's ` +
-          `AssumeRolePolicyDocument.`,
-      );
-    }
-
-    throw error;
-  }
-
-  return {
-    kind: "resolved",
-    principal: {
-      kind: "arn",
-      arn: `arn:aws:sts::${target.accountId}:assumed-role/${target.roleName}/${sessionName}`,
-    },
-    identityPolicyPrincipal: { kind: "arn", arn: target.roleArn },
-  };
-}
-
-/**
- * Load the execution role, refusing when it is not there.
- */
-async function roleOrRefuse(
-  target: SimSchedulerExecutionRoleTarget,
-  iam: SimIam,
-): Promise<Awaited<ReturnType<SimIam["getRole"]>>["Role"]> {
-  try {
-    const found = await iam.getRole({ input: { RoleName: target.roleName } });
-
-    return found.Role;
-  } catch {
-    throw new SimSchedulerDeliveryNotPermitted(
-      `${target.roleArn} is not a simulated IAM role, so the schedule could ` +
-        `not assume it to invoke its target.`,
-    );
-  }
+  return await assumeSimServiceRole({
+    target,
+    servicePrincipal: simSchedulerServicePrincipal,
+    sessionName,
+    iam,
+    refusals,
+  });
 }

--- a/src/service/scheduler/target/sim-scheduler-target-arn.ts
+++ b/src/service/scheduler/target/sim-scheduler-target-arn.ts
@@ -169,15 +169,21 @@ export class SimSchedulerTargetArn {
    * The name of the ECS cluster this ARN names, or nothing when it names
    * something else in ECS.
    *
-   * A cluster ARN's resource is `cluster/<name>`, with a slash rather than the
-   * colon Lambda uses. The resource type is checked rather than assumed for the
-   * same reason: a task definition is `task-definition/<family>:<revision>` and
-   * a task is `task/<cluster>/<id>`, and taking the part after the slash would
-   * read either as a cluster that is not there.
+   * A cluster ARN's resource is `cluster/<name>` exactly, with a slash rather
+   * than the colon Lambda uses. Both the resource type and there being nothing
+   * after the name are checked rather than assumed, because ECS writes more
+   * than clusters this way: a task definition is
+   * `task-definition/<family>:<revision>` and a task is `task/<cluster>/<id>`,
+   * and reading the first two segments alone would take a task ARN for the
+   * cluster it runs in.
    */
   get clusterName(): string {
-    const [resourceType, name = ""] = this.resource.split("/", 2);
+    const [resourceType, name = "", beyond] = this.resource.split("/", 3);
 
-    return resourceType === "cluster" ? name : "";
+    if (resourceType !== "cluster" || beyond !== undefined) {
+      return "";
+    }
+
+    return name;
   }
 }

--- a/src/service/scheduler/target/sim-scheduler-target-arn.ts
+++ b/src/service/scheduler/target/sim-scheduler-target-arn.ts
@@ -5,7 +5,12 @@ import { SimSchedulerValidationException } from "../error/sim-scheduler.error.js
 /**
  * The services a simulated schedule can invoke.
  */
-export const simSchedulerTargetServices = ["lambda", "sqs", "sns"] as const;
+export const simSchedulerTargetServices = [
+  "lambda",
+  "sqs",
+  "sns",
+  "ecs",
+] as const;
 
 export type SimSchedulerTargetService =
   (typeof simSchedulerTargetServices)[number];
@@ -33,9 +38,10 @@ interface SimSchedulerTargetArnProperties {
  * The ARN of whatever a schedule invokes.
  *
  * This reads target ARNs itself rather than deferring to `parseSimArn`, for the
- * same reason simulated EventBridge does: the three services it invokes write
- * their resource part three ways, with a queue and a topic putting the name
- * straight after the Account and a function writing `function:<name>`.
+ * same reason simulated EventBridge does: the services it invokes write their
+ * resource part several ways, with a queue and a topic putting the name
+ * straight after the Account, a function writing `function:<name>` and a
+ * cluster writing `cluster/<name>`.
  *
  * It is deliberately not shared with EventBridge's reader. The two look alike
  * today and are answering different questions: EventBridge refuses an ARN its
@@ -112,15 +118,36 @@ export class SimSchedulerTargetArn {
       resource,
     });
 
+    this.refuseUnnamedResource(arn);
+
+    return arn;
+  }
+
+  /**
+   * Refuse an ARN of the right service that names nothing in it.
+   *
+   * Both services whose resource part carries a type are checked, because both
+   * write more than one kind of resource: `arn:aws:lambda:...:layer:shared` and
+   * `arn:aws:ecs:...:task-definition/orders:3` are well formed ARNs of a
+   * service this invokes, and neither names anything a schedule can reach.
+   */
+  private static refuseUnnamedResource(arn: SimSchedulerTargetArn): void {
     if (arn.service === "lambda" && arn.functionName === "") {
       throw new SimSchedulerValidationException(
-        `Invalid parameter: Target Arn Reason: ${value} names no function. ` +
-          `A function ARN is ` +
+        `Invalid parameter: Target Arn Reason: ${arn.value} names no ` +
+          `function. A function ARN is ` +
           `arn:aws:lambda:<region>:<account-id>:function:<function-name>`,
       );
     }
 
-    return arn;
+    if (arn.service === "ecs" && arn.clusterName === "") {
+      throw new SimSchedulerValidationException(
+        `Invalid parameter: Target Arn Reason: ${arn.value} names no ` +
+          `cluster. An ECS target names the cluster the task runs in, as ` +
+          `arn:aws:ecs:<region>:<account-id>:cluster/<cluster-name>, and ` +
+          `names its task definition in EcsParameters.`,
+      );
+    }
   }
 
   /**
@@ -136,5 +163,21 @@ export class SimSchedulerTargetArn {
     const [resourceType, name = ""] = this.resource.split(":", 2);
 
     return resourceType === "function" ? name : "";
+  }
+
+  /**
+   * The name of the ECS cluster this ARN names, or nothing when it names
+   * something else in ECS.
+   *
+   * A cluster ARN's resource is `cluster/<name>`, with a slash rather than the
+   * colon Lambda uses. The resource type is checked rather than assumed for the
+   * same reason: a task definition is `task-definition/<family>:<revision>` and
+   * a task is `task/<cluster>/<id>`, and taking the part after the slash would
+   * read either as a cluster that is not there.
+   */
+  get clusterName(): string {
+    const [resourceType, name = ""] = this.resource.split("/", 2);
+
+    return resourceType === "cluster" ? name : "";
   }
 }

--- a/src/service/scheduler/target/sim-scheduler-target.ts
+++ b/src/service/scheduler/target/sim-scheduler-target.ts
@@ -1,4 +1,8 @@
-import { SimSchedulerValidationException } from "../error/sim-scheduler.error.js";
+import { SimEcsTargetTask } from "../../ecs/target/sim-ecs-target-task.js";
+import {
+  SimSchedulerUnsimulatedInputException,
+  SimSchedulerValidationException,
+} from "../error/sim-scheduler.error.js";
 import { SimSchedulerTargetArn } from "./sim-scheduler-target-arn.js";
 
 /**
@@ -6,10 +10,30 @@ import { SimSchedulerTargetArn } from "./sim-scheduler-target-arn.js";
  */
 const roleArn = /^arn:aws[a-z-]*:iam::\d{12}:role\/.+$/u;
 
+/**
+ * What a target request says, of the parts a target reads.
+ */
+interface SimSchedulerRequestedTarget {
+  readonly Arn?: string | undefined;
+  readonly RoleArn?: string | undefined;
+  readonly Input?: string | undefined;
+  readonly EcsParameters?: unknown;
+}
+
 interface SimSchedulerTargetProperties {
   readonly arn: SimSchedulerTargetArn;
   readonly roleArn: string;
   readonly input: string | undefined;
+  readonly task: SimEcsTargetTask | undefined;
+}
+
+/**
+ * How this reports a target that could never run the task it describes.
+ */
+function refuse(reason: string): Error {
+  return new SimSchedulerValidationException(
+    `Invalid parameter: Target Reason: ${reason}`,
+  );
 }
 
 /**
@@ -34,33 +58,66 @@ export class SimSchedulerTarget {
    */
   public readonly input: string | undefined;
 
+  /**
+   * The ECS task this target runs, where its ARN names a cluster.
+   *
+   * An ECS target is the one target type here whose `Input` is not what the
+   * target receives: a task has nowhere to receive a payload, so the `Input` is
+   * what the task overrides instead.
+   */
+  public readonly task: SimEcsTargetTask | undefined;
+
   private constructor(properties: SimSchedulerTargetProperties) {
     this.arn = properties.arn;
     this.roleArn = properties.roleArn;
     this.input = properties.input;
+    this.task = properties.task;
   }
 
   /**
    * Read the target a request carries.
    */
   static of(
-    target:
-      | {
-          readonly Arn?: string | undefined;
-          readonly RoleArn?: string | undefined;
-          readonly Input?: string | undefined;
-        }
-      | undefined,
+    target: SimSchedulerRequestedTarget | undefined,
   ): SimSchedulerTarget {
     if (target === undefined) {
       throw new SimSchedulerValidationException("Target is required");
     }
 
+    const arn = SimSchedulerTargetArn.of(target.Arn);
+
     return new this({
-      arn: SimSchedulerTargetArn.of(target.Arn),
+      arn,
       roleArn: this.roleArnIn(target.RoleArn),
       input: target.Input,
+      task: this.taskIn(arn, target),
     });
+  }
+
+  /**
+   * Read what the target says about the task it runs, where it runs one.
+   *
+   * A target whose ARN names anything but an ECS cluster runs no task, and
+   * `EcsParameters` on one is refused rather than taken and ignored: a target
+   * that looks configured to whoever wrote it and behaves as though it is not
+   * is the answer worth avoiding.
+   */
+  private static taskIn(
+    arn: SimSchedulerTargetArn,
+    target: SimSchedulerRequestedTarget,
+  ): SimEcsTargetTask | undefined {
+    if (arn.service === "ecs") {
+      return SimEcsTargetTask.of(target, refuse);
+    }
+
+    if (target.EcsParameters !== undefined) {
+      throw new SimSchedulerUnsimulatedInputException(
+        "EcsParameters belongs to a target whose Arn names an ECS cluster, " +
+          "and this target's does not.",
+      );
+    }
+
+    return undefined;
   }
 
   /**

--- a/src/service/sts/service-role/sim-service-role.ts
+++ b/src/service/sts/service-role/sim-service-role.ts
@@ -1,0 +1,129 @@
+import type { SimAwsCaller } from "../../aws/caller/sim-aws-caller.js";
+import type { SimAwsAccountId } from "../../aws/sim-aws-account.js";
+import { SimIamAccessDenied } from "../../iam/error/sim-iam.error.js";
+import { IamRoleArnParser } from "../../iam/role/arn/sim-iam-role-arn-parser.js";
+import type { SimIam } from "../../iam/sim-iam.js";
+import { AssumeRoleTrustPolicyAuthorizer } from "../auth-z/assume-role-trust-policy-authorizer.js";
+
+/**
+ * Which IAM a role ARN belongs to, and what the role is called there.
+ */
+export interface SimServiceRoleTarget {
+  readonly accountId: SimAwsAccountId;
+  readonly roleName: string;
+  readonly roleArn: string;
+}
+
+/**
+ * How a service says that it could not assume a role, in its own words.
+ *
+ * The two failures are the two that go wrong in a real account, and each
+ * service names them differently because each is fixed somewhere different: a
+ * schedule that cannot invoke its target and a rule that cannot reach one are
+ * the same mechanism and not the same message.
+ */
+export interface SimServiceRoleRefusals {
+  /**
+   * There is no such role to assume.
+   */
+  missingRole(target: SimServiceRoleTarget): Error;
+
+  /**
+   * The role is there and does not trust this service.
+   */
+  untrustedRole(target: SimServiceRoleTarget, servicePrincipal: string): Error;
+}
+
+/**
+ * What one service assuming a role needs to know.
+ */
+export interface SimServiceRoleAssumption {
+  readonly target: SimServiceRoleTarget;
+  readonly servicePrincipal: string;
+
+  /**
+   * The session name AWS gives the role this service assumes.
+   */
+  readonly sessionName: string;
+
+  /**
+   * The IAM of the role's own Account, which is not always the target's.
+   */
+  readonly iam: SimIam;
+
+  readonly refusals: SimServiceRoleRefusals;
+}
+
+/**
+ * Read the Account and name out of a role ARN a service will assume.
+ *
+ * The ARN is checked for being a role ARN where the request that carried it was
+ * written, so this is reading a known shape rather than validating an unknown
+ * one.
+ */
+export function simServiceRoleTarget(roleArn: string): SimServiceRoleTarget {
+  const parts = new IamRoleArnParser().parse(roleArn);
+
+  return { accountId: parts.accountId, roleName: parts.roleName, roleArn };
+}
+
+/**
+ * Assume a role as a service principal, and answer with the caller it makes.
+ *
+ * This is what an execution role is: a service reaches a resource as a session
+ * of the role rather than as itself, and the role's own policies decide what it
+ * may do. So the two things checked here are the two things that go wrong in a
+ * real account: whether the role trusts the service at all, and then,
+ * separately, whether it may do the thing.
+ *
+ * The caller carries both principals. The request is attributed to the session,
+ * as it is on AWS, while the policies that apply are the role's, which is
+ * exactly the split `SimResolvedCaller` exists for.
+ */
+export async function assumeSimServiceRole(
+  assumption: SimServiceRoleAssumption,
+): Promise<SimAwsCaller> {
+  const { target, servicePrincipal, sessionName, iam, refusals } = assumption;
+  const role = await roleOrRefuse(target, iam, refusals);
+
+  try {
+    new AssumeRoleTrustPolicyAuthorizer().authorize({
+      roleArn: target.roleArn,
+      role,
+      targetIam: iam,
+      caller: { kind: "service", service: servicePrincipal },
+    });
+  } catch (error) {
+    if (error instanceof SimIamAccessDenied) {
+      throw refusals.untrustedRole(target, servicePrincipal);
+    }
+
+    throw error;
+  }
+
+  return {
+    kind: "resolved",
+    principal: {
+      kind: "arn",
+      arn: `arn:aws:sts::${target.accountId}:assumed-role/${target.roleName}/${sessionName}`,
+    },
+    identityPolicyPrincipal: { kind: "arn", arn: target.roleArn },
+  };
+}
+
+/**
+ * Load the role, refusing when it is not there.
+ */
+async function roleOrRefuse(
+  target: SimServiceRoleTarget,
+  iam: SimIam,
+  refusals: SimServiceRoleRefusals,
+): Promise<Awaited<ReturnType<SimIam["getRole"]>>["Role"]> {
+  try {
+    const found = await iam.getRole({ input: { RoleName: target.roleName } });
+
+    return found.Role;
+  } catch {
+    throw refusals.missingRole(target);
+  }
+}


### PR DESCRIPTION
An EventBridge rule target or a Scheduler schedule target whose ARN names an ECS cluster now runs a simulated task instead of delivering to one. `EcsParameters` says which task definition and how many tasks, the target's `Input` is read as the task's overrides so a container override reaches the container's environment, and the task is run through the existing `RunTask` command as the target's role, so a role without `ecs:RunTask` fails delivery the way other target types already do. Reading `EcsParameters` and the overrides is shared between the two services under `src/service/ecs/target/`, and assuming a service role is now shared with Scheduler's execution role under `src/service/sts/service-role/`. Launch type, platform version, network configuration and capacity provider strategy are taken and ignored, and a target naming a task definition with nothing bound records a task that never started rather than failing the rule or the schedule.

Worth knowing for review: the issue asked for a `TaskCount` above one to be reflected in task state without running the handler more than once. This passes `TaskCount` straight through as `RunTask`'s `count`, so N tasks exist and a bound handler runs once for each. Doing it the other way would mean creating task records outside the ECS command path, and `RunTask` with a `count` of three already runs three handlers on main. What `TaskCount` does is documented in the Limitations of all three docs pages.

Resolves https://github.com/KensioSoftware/yulin/issues/557

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added ECS task targets for EventBridge rules and Scheduler schedules.
  - Supports task counts, container environment overrides, target roles, IAM authorization, and cluster/task validation.
  - ECS target configuration is now included when retrieving EventBridge targets and Scheduler schedules.
  - Added public ECS target types and executable simulation examples.

- **Documentation**
  - Expanded EventBridge, Scheduler, and ECS documentation with setup instructions, supported parameters, limitations, and authorization behavior.

- **Tests**
  - Added coverage for successful execution, overrides, multiple tasks, invalid inputs, missing resources, and IAM failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->