### PR TITLE
feat: resolve simulated ECS container secrets

### DIFF
--- a/docs/services/ecs/README.md
+++ b/docs/services/ecs/README.md
@@ -592,8 +592,132 @@ test rather than in the deployment.
 A `RunTask` request can override the role with `overrides.taskRoleArn`. A task definition declaring
 no task role runs its containers as nobody, so their AWS calls are denied: a real task without one
 has no credentials of its own, and taking the identity of whoever called `RunTask` would let a test
-pass on permissions the deployed task has not got. The execution role is stored but does nothing
-here, because there is no image to pull and no log driver to write to.
+pass on permissions the deployed task has not got. The execution role is what a container's
+`secrets` are resolved as, and nothing else: there is no image to pull and no log driver to write
+to.
+
+## Container secrets
+
+A container definition's `secrets` are resolved when the task starts, from simulated Secrets Manager
+or simulated SSM Parameter Store according to the ARN each one names, and the values appear in the
+container's environment alongside its declared `environment`. A handler reads them through
+`process.env` like anything else.
+
+They are read as the task definition's `executionRoleArn`, not its `taskRoleArn`, which is the
+split real ECS makes: the execution role is what the task agent pulls secrets with before a
+container starts, and the task role is what the running container's own AWS calls are attributed to.
+A role allowed one is not thereby allowed the other.
+
+```typescript sim-ecs-container-secrets
+/**
+ * Resolving a simulated ECS container's secrets as the execution Role.
+ */
+
+import {
+  CreateClusterCommand,
+  RegisterTaskDefinitionCommand,
+  RunTaskCommand,
+} from "@aws-sdk/client-ecs";
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import { CreateSecretCommand } from "@aws-sdk/client-secrets-manager";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const ecs = simAws.ecs();
+
+const secret = await simAws.secretsManager().createSecret(
+  new CreateSecretCommand({
+    Name: "orders/db",
+    SecretString: JSON.stringify({ username: "orders", password: "s3cr3t" }),
+  }),
+);
+
+const executionRole = await simAws.iam().createRole(
+  new CreateRoleCommand({
+    RoleName: "OrdersExecutionRole",
+    AssumeRolePolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Principal: { Service: "ecs-tasks.amazonaws.com" },
+        Action: "sts:AssumeRole",
+      },
+    }),
+  }),
+);
+
+await simAws.iam().putRolePolicy(
+  new PutRolePolicyCommand({
+    RoleName: "OrdersExecutionRole",
+    PolicyName: "ReadOrdersDbSecret",
+    PolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Action: "secretsmanager:GetSecretValue",
+        Resource: secret.ARN,
+      },
+    }),
+  }),
+);
+
+await ecs.createCluster(new CreateClusterCommand({}));
+
+const passwords: (string | undefined)[] = [];
+
+ecs.bindContainer({
+  family: "orders-worker",
+  containerName: "app",
+  run: () => {
+    passwords.push(process.env["DB_PASSWORD"]);
+  },
+});
+
+await ecs.registerTaskDefinition(
+  new RegisterTaskDefinitionCommand({
+    family: "orders-worker",
+    executionRoleArn: executionRole.Role.Arn,
+    containerDefinitions: [
+      {
+        name: "app",
+        image: "orders-worker:1",
+        secrets: [
+          {
+            name: "DB_PASSWORD",
+            valueFrom: `${String(secret.ARN)}:password::`,
+          },
+        ],
+      },
+    ],
+  }),
+);
+
+await ecs.runTask(new RunTaskCommand({ taskDefinition: "orders-worker" }));
+await simAws.backgroundTasksComplete();
+
+console.log(passwords); // ["s3cr3t"]
+```
+
+A `valueFrom` may be a Secrets Manager ARN, an SSM parameter ARN, or a bare parameter name, which
+real ECS accepts for a parameter in the task's own region. A Secrets Manager ARN may carry a JSON
+key, a version stage and a version id after the secret id, in the form
+`...:secret:orders/db-AbCdEf:password::` that a CDK construct given a field writes. The key selects
+one field of a secret holding a JSON object. A `SecureString` parameter is decrypted, as it is for a
+real task.
+
+A secret that cannot be resolved stops the task before any container runs, with a
+`ResourceInitializationError` reason naming the variable:
+
+```
+ResourceInitializationError: unable to pull secrets: DB_PASSWORD: User:
+arn:aws:iam::111111111111:role/OrdersExecutionRole is not authorized to perform:
+secretsmanager:GetSecretValue on resource: arn:aws:secretsmanager:...
+```
+
+The task stops with `TaskFailedToStart` and never reaches `RUNNING`, so the bound handler does not
+run. A secret that does not exist, a task definition declaring secrets with no `executionRoleArn`,
+and a JSON key the secret has not got each stop it the same way with their own reason.
 
 ## Describing, listing and stopping tasks
 
@@ -768,6 +892,8 @@ console.log(described.taskDefinition?.revision); // 1
 - `bindContainer`, targeting a container by family and container name or by image repository
 - Container environment variables and `RunTask` container overrides, through `process.env`
 - Container AWS calls authorized as the task role, including a `RunTask` `taskRoleArn` override
+- Container `secrets` resolved from simulated Secrets Manager and SSM Parameter Store as the
+  execution role, including a JSON key selector and a `SecureString` parameter
 - Container definitions stored and reported as declared, whatever their image
 - Task definition tags, reported under `include: ["TAGS"]`
 - Cluster settings, configuration and tags, reported under their matching `include` values
@@ -804,8 +930,20 @@ Current documented limitations:
   no capacity here for any of them to apply to.
 - A `RunTask` override may name `taskRoleArn` and a container's `environment`. A `command`, `cpu` or
   `memory` override is refused, since Yulin never runs an image and nothing here has capacity.
-- The execution role is stored and does nothing. There is no image to pull and no log driver to write
-  to, and container `secrets` are not resolved.
+- The execution role resolves container `secrets` and does nothing else. There is no image to pull
+  and no log driver to write to.
+- A container secret can only come from simulated Secrets Manager or simulated SSM Parameter Store.
+  A `valueFrom` naming anything else stops the task rather than being ignored. Secret rotation is
+  not simulated, so a task always reads the version that is current when it starts.
+- A JSON key selector resolves only where the key holds a string. A key holding a number, a boolean
+  or a nested object is refused, because an environment variable is text and real ECS does not
+  document which text it would become.
+- A secret holding a binary value is refused. Real ECS cannot put one in an environment variable
+  either, but it reports the problem differently.
+- `secretOptions` on a `logConfiguration` are stored and never resolved. There is no log driver here
+  for them to configure.
+- A task definition declaring `secrets` and no `executionRoleArn` fails when a task is run rather
+  than when the revision is registered. Real ECS refuses the registration.
 - `StartTask` and the whole of the service API (`CreateService`, `UpdateService`,
   `DescribeServices`) are not simulated.
 - `DescribeTasks` refuses `include`, and a task carries no tags, so `RunTask` refuses `tags` too.

--- a/docs/services/ecs/README.md
+++ b/docs/services/ecs/README.md
@@ -599,8 +599,8 @@ to.
 ## Container secrets
 
 A container definition's `secrets` are resolved when the task starts, from simulated Secrets Manager
-or simulated SSM Parameter Store according to the ARN each one names, and the values appear in the
-container's environment alongside its declared `environment`. A handler reads them through
+or simulated SSM Parameter Store according to what each `valueFrom` names, and the values appear in
+the container's environment alongside its declared `environment`. A handler reads them through
 `process.env` like anything else.
 
 They are read as the task definition's `executionRoleArn`, not its `taskRoleArn`, which is the
@@ -709,7 +709,7 @@ real task.
 A secret that cannot be resolved stops the task before any container runs, with a
 `ResourceInitializationError` reason naming the variable:
 
-```
+```text
 ResourceInitializationError: unable to pull secrets: DB_PASSWORD: User:
 arn:aws:iam::111111111111:role/OrdersExecutionRole is not authorized to perform:
 secretsmanager:GetSecretValue on resource: arn:aws:secretsmanager:...

--- a/docs/services/ecs/sim-ecs-container-secrets.example.ts
+++ b/docs/services/ecs/sim-ecs-container-secrets.example.ts
@@ -1,0 +1,88 @@
+/**
+ * Resolving a simulated ECS container's secrets as the execution Role.
+ */
+
+import {
+  CreateClusterCommand,
+  RegisterTaskDefinitionCommand,
+  RunTaskCommand,
+} from "@aws-sdk/client-ecs";
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import { CreateSecretCommand } from "@aws-sdk/client-secrets-manager";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const ecs = simAws.ecs();
+
+const secret = await simAws.secretsManager().createSecret(
+  new CreateSecretCommand({
+    Name: "orders/db",
+    SecretString: JSON.stringify({ username: "orders", password: "s3cr3t" }),
+  }),
+);
+
+const executionRole = await simAws.iam().createRole(
+  new CreateRoleCommand({
+    RoleName: "OrdersExecutionRole",
+    AssumeRolePolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Principal: { Service: "ecs-tasks.amazonaws.com" },
+        Action: "sts:AssumeRole",
+      },
+    }),
+  }),
+);
+
+await simAws.iam().putRolePolicy(
+  new PutRolePolicyCommand({
+    RoleName: "OrdersExecutionRole",
+    PolicyName: "ReadOrdersDbSecret",
+    PolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Action: "secretsmanager:GetSecretValue",
+        Resource: secret.ARN,
+      },
+    }),
+  }),
+);
+
+await ecs.createCluster(new CreateClusterCommand({}));
+
+const passwords: (string | undefined)[] = [];
+
+ecs.bindContainer({
+  family: "orders-worker",
+  containerName: "app",
+  run: () => {
+    passwords.push(process.env["DB_PASSWORD"]);
+  },
+});
+
+await ecs.registerTaskDefinition(
+  new RegisterTaskDefinitionCommand({
+    family: "orders-worker",
+    executionRoleArn: executionRole.Role.Arn,
+    containerDefinitions: [
+      {
+        name: "app",
+        image: "orders-worker:1",
+        secrets: [
+          {
+            name: "DB_PASSWORD",
+            valueFrom: `${String(secret.ARN)}:password::`,
+          },
+        ],
+      },
+    ],
+  }),
+);
+
+await ecs.runTask(new RunTaskCommand({ taskDefinition: "orders-worker" }));
+await simAws.backgroundTasksComplete();
+
+console.log(passwords); // ["s3cr3t"]

--- a/src/service/aws/factory/sim-aws-account-region-service-builder.ts
+++ b/src/service/aws/factory/sim-aws-account-region-service-builder.ts
@@ -8,6 +8,7 @@ import { SimAcm } from "../../acm/sim-acm.js";
 import { SimApiGatewayV2 } from "../../apigatewayv2/index.js";
 import {
   simAwsAcmDnsRecords,
+  simAwsEcsSecretStores,
   simAwsEventBridgeDeliveryTargets,
   simAwsHttpApiJwtIssuerKeys,
   simAwsRekognitionImages,
@@ -156,10 +157,16 @@ export class SimAwsAccountRegionServiceBuilder {
    *
    * It reaches this simulation because a running task's containers take its
    * task Role as their ambient caller, so what they do is authorized across
-   * the whole of it rather than only in this scope.
+   * the whole of it rather than only in this scope. Container secrets are read
+   * from the whole simulation too, since the ARN a secret is named by carries
+   * the Account and Region it lives in.
    */
   createEcs(scope: SimAwsAccountRegionContainer): SimEcs {
-    return new SimEcs({ ...this.scoped(scope), runAsOwner: this.simAws });
+    return new SimEcs({
+      ...this.scoped(scope),
+      runAsOwner: this.simAws,
+      secretStores: simAwsEcsSecretStores(this.simAws, scope),
+    });
   }
 
   /**

--- a/src/service/aws/factory/sim-aws-cross-account-collaborators.ts
+++ b/src/service/aws/factory/sim-aws-cross-account-collaborators.ts
@@ -1,5 +1,6 @@
 import { SimRoute53AcmDnsRecords } from "../../acm/validation/sim-route53-acm-dns-records.js";
 import { SimCognitoHttpApiJwtIssuerKeys } from "../../apigatewayv2/api/authorizer/sim-cognito-http-api-jwt-issuer-keys.js";
+import { SimAwsEcsSecretStores } from "../../ecs/task/run/secret/sim-aws-ecs-secret-stores.js";
 import { SimAwsEventBridgeDeliveryTargets } from "../../eventbridge/delivery/sim-aws-event-bridge-delivery-targets.js";
 import { SimAwsRekognitionImageObjects } from "../../rekognition/image/s3/sim-aws-rekognition-image-objects.js";
 import { SimAwsSchedulerDeliveryTargets } from "../../scheduler/delivery/sim-aws-scheduler-delivery-targets.js";
@@ -57,6 +58,24 @@ export function simAwsSchedulerDeliveryTargets(
   simAws: SimAws,
 ): SimAwsSchedulerDeliveryTargets {
   return new SimAwsSchedulerDeliveryTargets({ simAws });
+}
+
+/**
+ * The stores a simulated ECS task's container secrets are read from.
+ *
+ * A `valueFrom` names the Account and Region its secret or parameter lives in,
+ * so this reads the whole simulation rather than one scope. The scope is passed
+ * as well because a bare SSM parameter name names neither, and real ECS reads
+ * one of those in the task's own Region.
+ */
+export function simAwsEcsSecretStores(
+  simAws: SimAws,
+  scope: SimAwsAccountRegionContainer,
+): SimAwsEcsSecretStores {
+  return new SimAwsEcsSecretStores({
+    simAws,
+    accountRegionScope: scope.accountRegionScope,
+  });
 }
 
 /**

--- a/src/service/ecs/README.md
+++ b/src/service/ecs/README.md
@@ -129,11 +129,42 @@ the one thing the ambient caller must not be left alone for: the background work
 containers keeps the `RunTask` caller's context, so leaving it would attribute a container's calls
 to whoever started the task.
 
-`SimEcsContainerEnvironment` merges the container definition's `environment` with any `RunTask`
-override and the Region variables, and applies them through `simProcessEnvironment`, the shared
-`process.env` patch under `util/process/`. It is shared with simulated Lambda because it patches a
-process global: two of them would each install a getter, and the second would capture whatever the
-first was reporting as its host environment.
+`SimEcsContainerEnvironment` merges the container definition's `environment` with its resolved
+secrets, any `RunTask` override and the Region variables, and applies them through
+`simProcessEnvironment`, the shared `process.env` patch under `util/process/`. It is shared with
+simulated Lambda because it patches a process global: two of them would each install a getter, and
+the second would capture whatever the first was reporting as its host environment.
+
+## Container secrets
+
+What resolves a container's `secrets` lives under `task/run/secret/`.
+
+The whole task is resolved before any container runs, which is what makes an unreadable secret a
+`TaskFailedToStart` rather than a container that failed. Real ECS pulls a task's secrets while it is
+still provisioning, so resolving one container at a time would let an earlier container run on a
+task that was never going to work.
+
+`SimEcsTaskSecrets` is the resolver and `SimEcsResolvedSecrets` is what it answers with, holding
+either every container's variables or the reason the task cannot start. It is a result object rather
+than a thrown error because the runner has to record the reason on the task and stop it, and there
+is nowhere above it for an error to go: `RunTask` answered long before this happens.
+
+`SimEcsContainerSecrets` resolves one container's entries as the task definition's
+`executionRoleArn`. Reading goes through simulated Secrets Manager's and simulated SSM's ordinary
+commands with that caller, rather than their state, so simulated IAM decides it exactly as it
+decides a call an application makes. A definition declaring secrets and no execution Role says so
+rather than reading anonymously and being denied, since forgetting it is the ordinary way to get
+here and the denial would name nobody.
+
+`parseSimEcsSecretReference` reads a `valueFrom`. It cannot use the shared `parseSimArn`, for the
+same reason ECS's own ARNs cannot: a Secrets Manager `valueFrom` carries a JSON key, a version stage
+and a version id after the secret id, all separated by colons. `sim-ecs-secret-arn.ts` holds the
+part positions and the small readers the two forms share.
+
+`SimEcsSecretStores` is the seam between ECS and the two stores. `SimAwsEcsSecretStores` is the
+implementation a SimAws instance supplies, resolving each reference in the Account and Region its
+ARN names, and `SimEcsUnreachableSecretStores` is what simulated ECS built on its own gets, so a
+container declaring a secret there says what is missing rather than running without the variable.
 
 ## Command handling
 
@@ -183,6 +214,9 @@ command instances.
 - `RunTask` refuses everything about networking, capacity and placement, and refuses an override
   naming a container the task definition does not declare. The last one is the refusal worth having:
   the usual cause is a container renamed in the definition and not in the test.
+- A container secret's JSON key selector resolves only where the key holds a string, and a binary
+  secret is refused outright. An environment variable is text, and real ECS does not document what
+  text a number or a nested object would become, so choosing one here would be inventing behaviour.
 - A task with no bound container stops with `TaskFailedToStart` rather than
   `EssentialContainerExited`. Nothing started, and saying so is what makes a binding that matches
   nothing visible.

--- a/src/service/ecs/command/run-task/run-task-secrets-failure.iso.test.ts
+++ b/src/service/ecs/command/run-task/run-task-secrets-failure.iso.test.ts
@@ -1,0 +1,149 @@
+import { DescribeTasksCommand, RunTaskCommand } from "@aws-sdk/client-ecs";
+import { CreateSecretCommand } from "@aws-sdk/client-secrets-manager";
+import { assertIdentical, assertStringIncludes } from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import type { SimEcsSecret } from "../../task-definition/container/sim-ecs-container-parts.js";
+import { simIamRoleWithPolicyFactory } from "../../../iam/role/sim-iam-role-with-policy.factory.js";
+import { simEcsClusterFactory } from "../../cluster/sim-ecs-cluster.factory.js";
+
+/**
+ * Run one task whose container declares the given secrets, and answer with the
+ * reason it stopped and how many times its handler ran.
+ *
+ * Every test here is about a secret that cannot become an environment
+ * variable, and the only thing that differs between them is the declaration,
+ * so the execution Role is allowed to read everything and the rest is the same
+ * task each time.
+ */
+async function stoppedTaskFor(
+  simAws: SimAws,
+  secrets: readonly SimEcsSecret[],
+): Promise<{ reason: string; runs: number }> {
+  const ecs = simAws.ecs();
+  await simEcsClusterFactory.make({}, simAws);
+  const executionRole = await simIamRoleWithPolicyFactory.make(
+    {
+      roleName: "OrdersExecutionRole",
+      actions: ["secretsmanager:GetSecretValue", "ssm:GetParameter"],
+    },
+    simAws,
+  );
+
+  let runs = 0;
+  ecs.bindContainer({
+    family: "orders-worker",
+    containerName: "app",
+    run: () => {
+      runs += 1;
+    },
+  });
+  // Registered through the structural command rather than the SDK one,
+  // because some of these declarations are ones the SDK's own types refuse
+  // to express and a running task still has to deal with.
+  await ecs.registerTaskDefinition({
+    input: {
+      family: "orders-worker",
+      executionRoleArn: executionRole.Arn,
+      containerDefinitions: [
+        { name: "app", image: "orders-worker:1", secrets },
+      ],
+    },
+  });
+
+  const run = await ecs.runTask(
+    new RunTaskCommand({ taskDefinition: "orders-worker" }),
+  );
+  await simAws.backgroundTasksComplete();
+
+  const described = await ecs.describeTasks(
+    new DescribeTasksCommand({ tasks: [run.tasks?.[0]?.taskArn ?? ""] }),
+  );
+
+  return { reason: described.tasks?.[0]?.stoppedReason ?? "", runs };
+}
+
+describe("A simulated ECS container secret that cannot be resolved", () => {
+  it("stops the task when the secret does not exist", async () => {
+    // Given a container naming a secret nothing created.
+    const simAws = new SimAws();
+
+    // When the task runs.
+    const stopped = await stoppedTaskFor(simAws, [
+      {
+        name: "DB_PASSWORD",
+        valueFrom:
+          `arn:aws:secretsmanager:${simAws.defaultRegionName}:` +
+          `${simAws.defaultAccountId}:secret:orders/db-AbCdEf`,
+      },
+    ]);
+
+    // Then the reason says the secret is missing, which is a different problem
+    // from a Role that may not read one.
+    assertIdentical(stopped.runs, 0);
+    assertStringIncludes(stopped.reason, "unable to pull secrets: DB_PASSWORD");
+    assertStringIncludes(stopped.reason, "can't find the specified secret");
+  });
+
+  it("stops the task when the parameter does not exist", async () => {
+    // Given a container naming a parameter nothing put.
+    const simAws = new SimAws();
+
+    // When the task runs.
+    const stopped = await stoppedTaskFor(simAws, [
+      { name: "API_KEY", valueFrom: "/orders/api-key" },
+    ]);
+
+    // Then the reason names the variable and says the parameter is not there.
+    assertIdentical(stopped.runs, 0);
+    assertStringIncludes(stopped.reason, "unable to pull secrets: API_KEY");
+    assertStringIncludes(stopped.reason, "not found");
+  });
+
+  it("stops the task when a secret sets no environment variable", async () => {
+    // Given a secret entry with nothing to set.
+    const simAws = new SimAws();
+
+    // When the task runs.
+    const stopped = await stoppedTaskFor(simAws, [
+      { valueFrom: "/orders/api-key" },
+    ]);
+
+    // Then it says so, rather than reading a value nothing could have used.
+    assertIdentical(stopped.runs, 0);
+    assertStringIncludes(stopped.reason, "sets no environment variable");
+  });
+
+  it("stops the task when a secret names nothing to read", async () => {
+    // Given a secret entry naming a variable and no source.
+    const simAws = new SimAws();
+
+    // When the task runs.
+    const stopped = await stoppedTaskFor(simAws, [{ name: "API_KEY" }]);
+
+    // Then the reason names the variable that would have been empty.
+    assertIdentical(stopped.runs, 0);
+    assertStringIncludes(stopped.reason, "unable to pull secrets: API_KEY");
+    assertStringIncludes(stopped.reason, "names no secret to read");
+  });
+
+  it("stops the task when the secret holds binary rather than text", async () => {
+    // Given a secret created with a binary value.
+    const simAws = new SimAws();
+    const secret = await simAws.secretsManager().createSecret(
+      new CreateSecretCommand({
+        Name: "orders/keystore",
+        SecretBinary: new Uint8Array([1, 2, 3]),
+      }),
+    );
+
+    // When a container declares it as a variable.
+    const stopped = await stoppedTaskFor(simAws, [
+      { name: "KEYSTORE", valueFrom: secret.ARN },
+    ]);
+
+    // Then it is refused, since an environment variable can only be text.
+    assertIdentical(stopped.runs, 0);
+    assertStringIncludes(stopped.reason, "holds a binary value");
+  });
+});

--- a/src/service/ecs/command/run-task/run-task-secrets-iam.iso.test.ts
+++ b/src/service/ecs/command/run-task/run-task-secrets-iam.iso.test.ts
@@ -1,0 +1,219 @@
+import {
+  DescribeTasksCommand,
+  RegisterTaskDefinitionCommand,
+  RunTaskCommand,
+} from "@aws-sdk/client-ecs";
+import { CreateSecretCommand } from "@aws-sdk/client-secrets-manager";
+import { PutParameterCommand, SSMClient } from "@aws-sdk/client-ssm";
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimSdk } from "../../../../sdk/index.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { simIamRoleWithPolicyFactory } from "../../../iam/role/sim-iam-role-with-policy.factory.js";
+import { simEcsClusterFactory } from "../../cluster/sim-ecs-cluster.factory.js";
+
+describe("Authorizing a simulated ECS container's secrets", () => {
+  it("reads the secret as the execution Role and runs the container as the task Role", async () => {
+    // Given an execution Role allowed only to read the secret, and a task Role
+    // allowed only what the container itself does.
+    using simSdk = new SimSdk();
+    const { simAws } = simSdk;
+    const ecs = simAws.ecs();
+    await simEcsClusterFactory.make({}, simAws);
+    const secret = await simAws
+      .secretsManager()
+      .createSecret(
+        new CreateSecretCommand({ Name: "orders/db", SecretString: "hunter2" }),
+      );
+    const executionRole = await simIamRoleWithPolicyFactory.make(
+      {
+        roleName: "OrdersExecutionRole",
+        actions: ["secretsmanager:GetSecretValue"],
+      },
+      simAws,
+    );
+    const taskRole = await simIamRoleWithPolicyFactory.make(
+      { roleName: "OrdersTaskRole", actions: ["ssm:PutParameter"] },
+      simAws,
+    );
+
+    // And a container that reads the secret from its environment and writes a
+    // parameter through an ordinary SDK client.
+    let observed: string | undefined;
+    simSdk.intercept(SSMClient);
+    ecs.bindContainer({
+      family: "orders-worker",
+      containerName: "app",
+      run: async () => {
+        observed = process.env["DB_PASSWORD"];
+        await new SSMClient({}).send(
+          new PutParameterCommand({
+            Name: "/orders/last-run",
+            Value: "done",
+            Type: "String",
+          }),
+        );
+      },
+    });
+    await ecs.registerTaskDefinition(
+      new RegisterTaskDefinitionCommand({
+        family: "orders-worker",
+        executionRoleArn: executionRole.Arn,
+        taskRoleArn: taskRole.Arn,
+        containerDefinitions: [
+          {
+            name: "app",
+            image: "orders-worker:1",
+            secrets: [{ name: "DB_PASSWORD", valueFrom: secret.ARN }],
+          },
+        ],
+      }),
+    );
+
+    // When the task runs.
+    const run = await ecs.runTask(
+      new RunTaskCommand({ taskDefinition: "orders-worker" }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // Then both halves went through, which neither Role could have done on its
+    // own: the execution Role cannot write the parameter, and the task Role
+    // cannot read the secret.
+    const described = await ecs.describeTasks(
+      new DescribeTasksCommand({ tasks: [run.tasks?.[0]?.taskArn ?? ""] }),
+    );
+
+    assertIdentical(observed, "hunter2");
+    assertIdentical(described.tasks?.[0]?.containers?.[0]?.exitCode, 0);
+  });
+
+  it("does not read the secret as the task Role", async () => {
+    // Given a task Role allowed to read the secret and an execution Role
+    // allowed nothing, which is the mistake the other way round.
+    const simAws = new SimAws();
+    const ecs = simAws.ecs();
+    await simEcsClusterFactory.make({}, simAws);
+    const secret = await simAws
+      .secretsManager()
+      .createSecret(
+        new CreateSecretCommand({ Name: "orders/db", SecretString: "hunter2" }),
+      );
+    const executionRole = await simIamRoleWithPolicyFactory.make(
+      { roleName: "OrdersExecutionRole", actions: [] },
+      simAws,
+    );
+    const taskRole = await simIamRoleWithPolicyFactory.make(
+      {
+        roleName: "OrdersTaskRole",
+        actions: ["secretsmanager:GetSecretValue"],
+      },
+      simAws,
+    );
+
+    let runs = 0;
+    ecs.bindContainer({
+      family: "orders-worker",
+      containerName: "app",
+      run: () => {
+        runs += 1;
+      },
+    });
+    await ecs.registerTaskDefinition(
+      new RegisterTaskDefinitionCommand({
+        family: "orders-worker",
+        executionRoleArn: executionRole.Arn,
+        taskRoleArn: taskRole.Arn,
+        containerDefinitions: [
+          {
+            name: "app",
+            image: "orders-worker:1",
+            secrets: [{ name: "DB_PASSWORD", valueFrom: secret.ARN }],
+          },
+        ],
+      }),
+    );
+
+    // When the task runs.
+    const run = await ecs.runTask(
+      new RunTaskCommand({ taskDefinition: "orders-worker" }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // Then the task failed to start naming the variable, and the bound handler
+    // never ran, whatever the task Role was allowed.
+    const described = await ecs.describeTasks(
+      new DescribeTasksCommand({ tasks: [run.tasks?.[0]?.taskArn ?? ""] }),
+    );
+    const task = described.tasks?.[0];
+    assertNonNullable(task);
+    const container = task.containers?.[0];
+    assertNonNullable(container);
+
+    assertIdentical(runs, 0);
+    assertIdentical(task.lastStatus, "STOPPED");
+    assertIdentical(task.stopCode, "TaskFailedToStart");
+    assertStringIncludes(
+      task.stoppedReason ?? "",
+      "ResourceInitializationError: unable to pull secrets: DB_PASSWORD:",
+    );
+    assertStringIncludes(task.stoppedReason ?? "", "not authorized to perform");
+    assertIdentical(container.lastStatus, "STOPPED");
+    assertUndefined(container.exitCode);
+  });
+
+  it("stops a task whose definition declares secrets but no execution Role", async () => {
+    // Given a container declaring a secret and a definition declaring no
+    // executionRoleArn, which is the ordinary way to get this wrong.
+    const simAws = new SimAws();
+    const ecs = simAws.ecs();
+    await simEcsClusterFactory.make({}, simAws);
+    const secret = await simAws
+      .secretsManager()
+      .createSecret(
+        new CreateSecretCommand({ Name: "orders/db", SecretString: "hunter2" }),
+      );
+
+    let runs = 0;
+    ecs.bindContainer({
+      family: "orders-worker",
+      containerName: "app",
+      run: () => {
+        runs += 1;
+      },
+    });
+    await ecs.registerTaskDefinition(
+      new RegisterTaskDefinitionCommand({
+        family: "orders-worker",
+        containerDefinitions: [
+          {
+            name: "app",
+            image: "orders-worker:1",
+            secrets: [{ name: "DB_PASSWORD", valueFrom: secret.ARN }],
+          },
+        ],
+      }),
+    );
+
+    // When the task runs.
+    const run = await ecs.runTask(
+      new RunTaskCommand({ taskDefinition: "orders-worker" }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // Then it says there was no Role to read the secret as.
+    const described = await ecs.describeTasks(
+      new DescribeTasksCommand({ tasks: [run.tasks?.[0]?.taskArn ?? ""] }),
+    );
+
+    assertIdentical(runs, 0);
+    assertStringIncludes(
+      described.tasks?.[0]?.stoppedReason ?? "",
+      "declares no executionRoleArn",
+    );
+  });
+});

--- a/src/service/ecs/command/run-task/run-task-secrets.iso.test.ts
+++ b/src/service/ecs/command/run-task/run-task-secrets.iso.test.ts
@@ -1,0 +1,278 @@
+import {
+  RegisterTaskDefinitionCommand,
+  RunTaskCommand,
+} from "@aws-sdk/client-ecs";
+import { CreateSecretCommand } from "@aws-sdk/client-secrets-manager";
+import { PutParameterCommand } from "@aws-sdk/client-ssm";
+import { assertIdentical, assertUndefined } from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { simIamRoleWithPolicyFactory } from "../../../iam/role/sim-iam-role-with-policy.factory.js";
+import { simEcsClusterFactory } from "../../cluster/sim-ecs-cluster.factory.js";
+
+describe("Resolving a simulated ECS container's secrets", () => {
+  it("puts a Secrets Manager secret in the container's environment", async () => {
+    // Given a secret and an execution Role allowed to read it.
+    const simAws = new SimAws();
+    const ecs = simAws.ecs();
+    await simEcsClusterFactory.make({}, simAws);
+    const secret = await simAws.secretsManager().createSecret(
+      new CreateSecretCommand({
+        Name: "orders/db",
+        SecretString: "hunter2",
+      }),
+    );
+    const executionRole = await simIamRoleWithPolicyFactory.make(
+      {
+        roleName: "OrdersExecutionRole",
+        actions: ["secretsmanager:GetSecretValue"],
+      },
+      simAws,
+    );
+
+    // And a container declaring it as DB_PASSWORD.
+    let observed: string | undefined;
+    ecs.bindContainer({
+      family: "orders-worker",
+      containerName: "app",
+      run: () => {
+        observed = process.env["DB_PASSWORD"];
+      },
+    });
+    await ecs.registerTaskDefinition(
+      new RegisterTaskDefinitionCommand({
+        family: "orders-worker",
+        executionRoleArn: executionRole.Arn,
+        containerDefinitions: [
+          {
+            name: "app",
+            image: "orders-worker:1",
+            secrets: [{ name: "DB_PASSWORD", valueFrom: secret.ARN }],
+          },
+        ],
+      }),
+    );
+
+    // When the task runs.
+    await ecs.runTask(new RunTaskCommand({ taskDefinition: "orders-worker" }));
+    await simAws.backgroundTasksComplete();
+
+    // Then the handler read the secret's value through process.env, and
+    // nothing was left behind in the host environment.
+    assertIdentical(observed, "hunter2");
+    assertUndefined(process.env["DB_PASSWORD"]);
+  });
+
+  it("puts an SSM SecureString parameter in the container's environment", async () => {
+    // Given a SecureString parameter and an execution Role allowed to read it.
+    const simAws = new SimAws();
+    const ecs = simAws.ecs();
+    await simEcsClusterFactory.make({}, simAws);
+    await simAws.ssm().putParameter(
+      new PutParameterCommand({
+        Name: "/orders/api-key",
+        Type: "SecureString",
+        Value: "k-1234",
+      }),
+    );
+    const executionRole = await simIamRoleWithPolicyFactory.make(
+      { roleName: "OrdersExecutionRole", actions: ["ssm:GetParameter"] },
+      simAws,
+    );
+
+    // And a container declaring it by its parameter ARN.
+    let observed: string | undefined;
+    ecs.bindContainer({
+      family: "orders-worker",
+      containerName: "app",
+      run: () => {
+        observed = process.env["API_KEY"];
+      },
+    });
+    await ecs.registerTaskDefinition(
+      new RegisterTaskDefinitionCommand({
+        family: "orders-worker",
+        executionRoleArn: executionRole.Arn,
+        containerDefinitions: [
+          {
+            name: "app",
+            image: "orders-worker:1",
+            secrets: [
+              {
+                name: "API_KEY",
+                valueFrom:
+                  `arn:aws:ssm:${simAws.defaultRegionName}:` +
+                  `${simAws.defaultAccountId}:parameter/orders/api-key`,
+              },
+            ],
+          },
+        ],
+      }),
+    );
+
+    // When the task runs.
+    await ecs.runTask(new RunTaskCommand({ taskDefinition: "orders-worker" }));
+    await simAws.backgroundTasksComplete();
+
+    // Then the handler read the decrypted value.
+    assertIdentical(observed, "k-1234");
+  });
+
+  it("reads a parameter named without its ARN in the task's own region", async () => {
+    // Given a parameter and an execution Role allowed to read it.
+    const simAws = new SimAws();
+    const ecs = simAws.ecs();
+    await simEcsClusterFactory.make({}, simAws);
+    await simAws.ssm().putParameter(
+      new PutParameterCommand({
+        Name: "/orders/api-key",
+        Type: "String",
+        Value: "k-5678",
+      }),
+    );
+    const executionRole = await simIamRoleWithPolicyFactory.make(
+      { roleName: "OrdersExecutionRole", actions: ["ssm:GetParameter"] },
+      simAws,
+    );
+
+    // And a container naming it by name alone, as real ECS allows for a
+    // parameter in the task's own region.
+    let observed: string | undefined;
+    ecs.bindContainer({
+      family: "orders-worker",
+      containerName: "app",
+      run: () => {
+        observed = process.env["API_KEY"];
+      },
+    });
+    await ecs.registerTaskDefinition(
+      new RegisterTaskDefinitionCommand({
+        family: "orders-worker",
+        executionRoleArn: executionRole.Arn,
+        containerDefinitions: [
+          {
+            name: "app",
+            image: "orders-worker:1",
+            secrets: [{ name: "API_KEY", valueFrom: "/orders/api-key" }],
+          },
+        ],
+      }),
+    );
+
+    // When the task runs.
+    await ecs.runTask(new RunTaskCommand({ taskDefinition: "orders-worker" }));
+    await simAws.backgroundTasksComplete();
+
+    // Then the parameter resolved just as its ARN would have.
+    assertIdentical(observed, "k-5678");
+  });
+
+  it("resolves the JSON key a Secrets Manager valueFrom selects", async () => {
+    // Given a secret holding a JSON object of connection details.
+    const simAws = new SimAws();
+    const ecs = simAws.ecs();
+    await simEcsClusterFactory.make({}, simAws);
+    const secret = await simAws.secretsManager().createSecret(
+      new CreateSecretCommand({
+        Name: "orders/db",
+        SecretString: JSON.stringify({
+          username: "orders",
+          password: "s3cr3t",
+        }),
+      }),
+    );
+    const executionRole = await simIamRoleWithPolicyFactory.make(
+      {
+        roleName: "OrdersExecutionRole",
+        actions: ["secretsmanager:GetSecretValue"],
+      },
+      simAws,
+    );
+
+    // And a container selecting one key of it, as a CDK construct given a
+    // field writes the valueFrom.
+    let observed: string | undefined;
+    ecs.bindContainer({
+      family: "orders-worker",
+      containerName: "app",
+      run: () => {
+        observed = process.env["DB_PASSWORD"];
+      },
+    });
+    await ecs.registerTaskDefinition(
+      new RegisterTaskDefinitionCommand({
+        family: "orders-worker",
+        executionRoleArn: executionRole.Arn,
+        containerDefinitions: [
+          {
+            name: "app",
+            image: "orders-worker:1",
+            secrets: [
+              {
+                name: "DB_PASSWORD",
+                valueFrom: `${String(secret.ARN)}:password::`,
+              },
+            ],
+          },
+        ],
+      }),
+    );
+
+    // When the task runs.
+    await ecs.runTask(new RunTaskCommand({ taskDefinition: "orders-worker" }));
+    await simAws.backgroundTasksComplete();
+
+    // Then that key's value is the variable, rather than the whole document.
+    assertIdentical(observed, "s3cr3t");
+  });
+
+  it("lets a secret replace a declared environment variable of the same name", async () => {
+    // Given a secret and a container declaring the same variable in plaintext.
+    const simAws = new SimAws();
+    const ecs = simAws.ecs();
+    await simEcsClusterFactory.make({}, simAws);
+    const secret = await simAws
+      .secretsManager()
+      .createSecret(
+        new CreateSecretCommand({ Name: "orders/db", SecretString: "hunter2" }),
+      );
+    const executionRole = await simIamRoleWithPolicyFactory.make(
+      {
+        roleName: "OrdersExecutionRole",
+        actions: ["secretsmanager:GetSecretValue"],
+      },
+      simAws,
+    );
+
+    let observed: string | undefined;
+    ecs.bindContainer({
+      family: "orders-worker",
+      containerName: "app",
+      run: () => {
+        observed = process.env["DB_PASSWORD"];
+      },
+    });
+    await ecs.registerTaskDefinition(
+      new RegisterTaskDefinitionCommand({
+        family: "orders-worker",
+        executionRoleArn: executionRole.Arn,
+        containerDefinitions: [
+          {
+            name: "app",
+            image: "orders-worker:1",
+            environment: [{ name: "DB_PASSWORD", value: "placeholder" }],
+            secrets: [{ name: "DB_PASSWORD", valueFrom: secret.ARN }],
+          },
+        ],
+      }),
+    );
+
+    // When the task runs.
+    await ecs.runTask(new RunTaskCommand({ taskDefinition: "orders-worker" }));
+    await simAws.backgroundTasksComplete();
+
+    // Then the secret won, since a plaintext variable of the same name is what
+    // a secret was introduced to replace.
+    assertIdentical(observed, "hunter2");
+  });
+});

--- a/src/service/ecs/command/run-task/run-task-secrets.iso.test.ts
+++ b/src/service/ecs/command/run-task/run-task-secrets.iso.test.ts
@@ -4,7 +4,7 @@ import {
 } from "@aws-sdk/client-ecs";
 import { CreateSecretCommand } from "@aws-sdk/client-secrets-manager";
 import { PutParameterCommand } from "@aws-sdk/client-ssm";
-import { assertIdentical, assertUndefined } from "@kensio/smartass";
+import { assertIdentical } from "@kensio/smartass";
 import { describe, it } from "vitest";
 import { SimAws } from "../../../aws/sim-aws.js";
 import { simIamRoleWithPolicyFactory } from "../../../iam/role/sim-iam-role-with-policy.factory.js";
@@ -57,10 +57,8 @@ describe("Resolving a simulated ECS container's secrets", () => {
     await ecs.runTask(new RunTaskCommand({ taskDefinition: "orders-worker" }));
     await simAws.backgroundTasksComplete();
 
-    // Then the handler read the secret's value through process.env, and
-    // nothing was left behind in the host environment.
+    // Then the handler read the secret's value through process.env.
     assertIdentical(observed, "hunter2");
-    assertUndefined(process.env["DB_PASSWORD"]);
   });
 
   it("puts an SSM SecureString parameter in the container's environment", async () => {
@@ -274,5 +272,66 @@ describe("Resolving a simulated ECS container's secrets", () => {
     // Then the secret won, since a plaintext variable of the same name is what
     // a secret was introduced to replace.
     assertIdentical(observed, "hunter2");
+  });
+
+  it("lets a RunTask override replace a resolved secret", async () => {
+    // Given a container whose DB_PASSWORD comes from a secret.
+    const simAws = new SimAws();
+    const ecs = simAws.ecs();
+    await simEcsClusterFactory.make({}, simAws);
+    const secret = await simAws
+      .secretsManager()
+      .createSecret(
+        new CreateSecretCommand({ Name: "orders/db", SecretString: "hunter2" }),
+      );
+    const executionRole = await simIamRoleWithPolicyFactory.make(
+      {
+        roleName: "OrdersExecutionRole",
+        actions: ["secretsmanager:GetSecretValue"],
+      },
+      simAws,
+    );
+
+    let observed: string | undefined;
+    ecs.bindContainer({
+      family: "orders-worker",
+      containerName: "app",
+      run: () => {
+        observed = process.env["DB_PASSWORD"];
+      },
+    });
+    await ecs.registerTaskDefinition(
+      new RegisterTaskDefinitionCommand({
+        family: "orders-worker",
+        executionRoleArn: executionRole.Arn,
+        containerDefinitions: [
+          {
+            name: "app",
+            image: "orders-worker:1",
+            secrets: [{ name: "DB_PASSWORD", valueFrom: secret.ARN }],
+          },
+        ],
+      }),
+    );
+
+    // When the task is run with an override setting the same variable.
+    await ecs.runTask(
+      new RunTaskCommand({
+        taskDefinition: "orders-worker",
+        overrides: {
+          containerOverrides: [
+            {
+              name: "app",
+              environment: [{ name: "DB_PASSWORD", value: "overridden" }],
+            },
+          ],
+        },
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // Then the override won, since it is what the caller asked for at the
+    // moment the task was started.
+    assertIdentical(observed, "overridden");
   });
 });

--- a/src/service/ecs/command/run-task/run-task.handler.ts
+++ b/src/service/ecs/command/run-task/run-task.handler.ts
@@ -66,6 +66,7 @@ export class RunTaskCommandHandler
       background: context.background,
       runAsOwner: context.runAsOwner,
       regionName: context.accountRegionScope.regionName,
+      secretStores: context.secretStores,
     });
   }
 

--- a/src/service/ecs/command/sim-ecs-command-context.ts
+++ b/src/service/ecs/command/sim-ecs-command-context.ts
@@ -4,6 +4,7 @@ import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-
 import type { SimEcsContainerBindings } from "../bind/sim-ecs-container-bindings.js";
 import type { SimEcsClusterArn } from "../cluster/sim-ecs-cluster-arn.js";
 import type { SimEcsClusterStore } from "../cluster/sim-ecs-cluster-store.js";
+import type { SimEcsSecretStores } from "../task/run/secret/sim-ecs-secret-stores.js";
 import type { SimEcsTaskArn } from "../task/sim-ecs-task-arn.js";
 import type { SimEcsTaskStore } from "../task/sim-ecs-task-store.js";
 import type { SimEcsTaskDefinitionArn } from "../task-definition/sim-ecs-task-definition-arn.js";
@@ -56,12 +57,14 @@ export interface SimEcsTaskCommandContext extends SimEcsCommandCollaborators {
  * What the simulated ECS RunTask handler is built with.
  *
  * Running a task is the one operation that reaches everything: the task
- * definition it runs, the bindings that say what its containers do, and the
- * SimAws instance whose ambient caller the task Role becomes while they run.
+ * definition it runs, the bindings that say what its containers do, the stores
+ * its container secrets are pulled from, and the SimAws instance whose ambient
+ * caller the task Role becomes while they run.
  */
 export interface SimEcsRunTaskCommandContext extends SimEcsTaskCommandContext {
   readonly taskDefinitions: SimEcsTaskDefinitionStore;
   readonly accountRegionScope: SimAwsAccountRegionScope;
   readonly bindings: SimEcsContainerBindings;
   readonly runAsOwner: SimAwsRunAsOwner;
+  readonly secretStores: SimEcsSecretStores;
 }

--- a/src/service/ecs/command/sim-ecs-command-contexts.ts
+++ b/src/service/ecs/command/sim-ecs-command-contexts.ts
@@ -4,6 +4,7 @@ import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-
 import type { SimEcsContainerBindings } from "../bind/sim-ecs-container-bindings.js";
 import { SimEcsClusterArn } from "../cluster/sim-ecs-cluster-arn.js";
 import type { SimEcsClusterStore } from "../cluster/sim-ecs-cluster-store.js";
+import type { SimEcsSecretStores } from "../task/run/secret/sim-ecs-secret-stores.js";
 import { SimEcsTaskArn } from "../task/sim-ecs-task-arn.js";
 import type { SimEcsTaskStore } from "../task/sim-ecs-task-store.js";
 import { SimEcsTaskDefinitionArn } from "../task-definition/sim-ecs-task-definition-arn.js";
@@ -25,6 +26,7 @@ interface SimEcsCommandContextsProperties {
   readonly taskDefinitions: SimEcsTaskDefinitionStore;
   readonly tasks: SimEcsTaskStore;
   readonly bindings: SimEcsContainerBindings;
+  readonly secretStores: SimEcsSecretStores;
 }
 
 /**
@@ -69,6 +71,7 @@ export class SimEcsCommandContexts {
       taskDefinitions: properties.taskDefinitions,
       bindings: properties.bindings,
       runAsOwner: properties.runAsOwner,
+      secretStores: properties.secretStores,
     };
   }
 }

--- a/src/service/ecs/sim-ecs-properties.ts
+++ b/src/service/ecs/sim-ecs-properties.ts
@@ -1,0 +1,39 @@
+import type { BackgroundScheduler } from "../../util/background/background.js";
+import type { SimAwsRunAsOwner } from "../aws/caller/sim-aws-run-as-context.js";
+import type { SimAwsAccountRegionScope } from "../aws/sim-aws-account-region-scope.js";
+import type { SimIamInterServiceAuthZ } from "../iam/authorize/sim-iam-inter-service-auth-z.js";
+import type { SimEcsSecretStores } from "./task/run/secret/sim-ecs-secret-stores.js";
+
+/**
+ * What simulated ECS is built with.
+ *
+ * Everything here has a default, so `new SimEcs()` works on its own. The two
+ * that reach outside ECS are the ones a SimAws instance supplies, and they are
+ * what makes a running task part of the surrounding simulation rather than
+ * something happening in a corner of it.
+ */
+export interface SimEcsProperties {
+  readonly accountRegionScope?: SimAwsAccountRegionScope;
+  readonly iam?: SimIamInterServiceAuthZ;
+  readonly background?: BackgroundScheduler;
+
+  /**
+   * Whose ambient caller a running task's task Role becomes.
+   *
+   * This is the owning SimAws instance when ECS was built through one, so a
+   * simulated AWS call a container makes is attributed to the task Role
+   * everywhere in that simulation. Simulated ECS built on its own is its own
+   * owner, which reaches nothing else.
+   */
+  readonly runAsOwner?: SimAwsRunAsOwner;
+
+  /**
+   * Where a running task's container secrets are read from.
+   *
+   * This is the surrounding simulation's Secrets Manager and SSM Parameter
+   * Store when ECS was built through a SimAws instance. Simulated ECS built on
+   * its own reaches neither, so a container declaring a secret says so rather
+   * than running without it.
+   */
+  readonly secretStores?: SimEcsSecretStores;
+}

--- a/src/service/ecs/sim-ecs.ts
+++ b/src/service/ecs/sim-ecs.ts
@@ -1,15 +1,7 @@
-import {
-  type BackgroundScheduler,
-  BackgroundTasks,
-} from "../../util/background/background.js";
+import { BackgroundTasks } from "../../util/background/background.js";
 import type { SimSdkCommandRouter } from "../../sdk/router/sim-sdk-command-router.type.js";
-import type { SimAwsRunAsOwner } from "../aws/caller/sim-aws-run-as-context.js";
-import type { SimAwsAccountRegionScope } from "../aws/sim-aws-account-region-scope.js";
 import { simAwsAccountRegionScopeFactory } from "../aws/sim-aws-account-region-scope.factory.js";
-import {
-  SimIamAllowAllAuth,
-  type SimIamInterServiceAuthZ,
-} from "../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { SimIamAllowAllAuth } from "../iam/authorize/sim-iam-inter-service-auth-z.js";
 import { SimEcsContainerBindings } from "./bind/sim-ecs-container-bindings.js";
 import type { SimEcsContainerBinding } from "./bind/sim-ecs-container-binding.type.js";
 import { SimEcsClusterStore } from "./cluster/sim-ecs-cluster-store.js";
@@ -31,23 +23,10 @@ import { StopTaskCommandHandler } from "./command/stop-task/stop-task.handler.js
 import type * as simEcsCommands from "./command/sim-ecs-command.types.js";
 import type { SimEcsRequestOptions } from "./command/sim-ecs-request-options.js";
 import { SimEcsSdkCommandRouter } from "./sdk/sim-ecs-sdk-command-router.js";
+import type { SimEcsProperties } from "./sim-ecs-properties.js";
+import { SimEcsUnreachableSecretStores } from "./task/run/secret/sim-ecs-secret-stores.js";
 import { SimEcsTaskStore } from "./task/sim-ecs-task-store.js";
 import { SimEcsTaskDefinitionStore } from "./task-definition/sim-ecs-task-definition-store.js";
-
-interface SimEcsProperties {
-  readonly accountRegionScope?: SimAwsAccountRegionScope;
-  readonly iam?: SimIamInterServiceAuthZ;
-  readonly background?: BackgroundScheduler;
-  /**
-   * Whose ambient caller a running task's task Role becomes.
-   *
-   * This is the owning SimAws instance when ECS was built through one, so a
-   * simulated AWS call a container makes is attributed to the task Role
-   * everywhere in that simulation. Simulated ECS built on its own is its own
-   * owner, which reaches nothing else.
-   */
-  readonly runAsOwner?: SimAwsRunAsOwner;
-}
 
 /**
  * Simulated ECS. Handles SDK commands. Emulates AWS behaviour and state.
@@ -88,6 +67,7 @@ export class SimEcs {
       iam = new SimIamAllowAllAuth(),
       background = new BackgroundTasks(),
       runAsOwner = this,
+      secretStores = new SimEcsUnreachableSecretStores(),
     } = properties;
 
     const contexts = new SimEcsCommandContexts({
@@ -99,6 +79,7 @@ export class SimEcs {
       taskDefinitions: this.taskDefinitions,
       tasks: this.tasks,
       bindings: this.bindings,
+      secretStores,
     });
     const { cluster, taskDefinition, task } = contexts;
 

--- a/src/service/ecs/task-definition/container/sim-ecs-container-definition.ts
+++ b/src/service/ecs/task-definition/container/sim-ecs-container-definition.ts
@@ -114,6 +114,18 @@ export class SimEcsContainerDefinition {
   }
 
   /**
+   * The secrets this container declared.
+   *
+   * Each one names a store to read a value from when the task starts, and the
+   * variable that value becomes. They are resolved as the task execution Role
+   * before any container runs, so a container reads them through `process.env`
+   * alongside its declared `environment`.
+   */
+  get secrets(): readonly SimEcsSecret[] {
+    return this.declared.secrets ?? [];
+  }
+
+  /**
    * This container as a described task definition reports it.
    */
   toOutput(): SimEcsContainerDefinitionType {

--- a/src/service/ecs/task-definition/sim-ecs-task-definition-settings.ts
+++ b/src/service/ecs/task-definition/sim-ecs-task-definition-settings.ts
@@ -9,11 +9,11 @@ import type {
 /**
  * What a task definition declares besides its family and its containers.
  *
- * These are the settings a described task definition reports back. Nothing
- * acts on any of them yet, since nothing runs a task yet, so each one is held
- * as the registration declared it. A setting that is not one of these is
- * refused at the command rather than held, so nothing a registration declared
- * goes missing from the revision it made.
+ * These are the settings a described task definition reports back. A running
+ * task acts on the two Roles, and every other setting is held as the
+ * registration declared it. A setting that is not one of these is refused at
+ * the command rather than held, so nothing a registration declared goes
+ * missing from the revision it made.
  *
  * https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_RegisterTaskDefinition.html
  */
@@ -130,6 +130,18 @@ export class SimEcsTaskDefinitionSettings {
    */
   get taskRoleArn(): string | undefined {
     return this.settings.taskRoleArn;
+  }
+
+  /**
+   * The Role a task made from this definition pulls its container secrets as.
+   *
+   * It is deliberately not the task Role. Real ECS reads a container's
+   * `secrets` with the execution Role while the task is still provisioning,
+   * and attributes what the container itself does to the task Role, so a
+   * policy allowing one grants nothing to the other.
+   */
+  get executionRoleArn(): string | undefined {
+    return this.settings.executionRoleArn;
   }
 
   /**

--- a/src/service/ecs/task/run/secret/sim-aws-ecs-secret-stores.ts
+++ b/src/service/ecs/task/run/secret/sim-aws-ecs-secret-stores.ts
@@ -1,0 +1,118 @@
+import type {
+  SimAwsAccountRegionContainer,
+  SimAwsAccountRegionScope,
+} from "../../../../aws/sim-aws-account-region-scope.js";
+import type { SimAws } from "../../../../aws/sim-aws.js";
+import type { SimEcsSecretReference } from "./sim-ecs-secret-reference.js";
+import type {
+  SimEcsSecretRead,
+  SimEcsSecretStores,
+} from "./sim-ecs-secret-stores.js";
+import { SimEcsSecretResolutionError } from "./sim-ecs-secret.error.js";
+
+interface SimAwsEcsSecretStoresProperties {
+  readonly simAws: SimAws;
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+}
+
+/**
+ * The simulated Secrets Manager and SSM Parameter Store of one simulated AWS
+ * instance, as the places a task's container secrets are read from.
+ *
+ * The store is reached when a task starts, never when this is built, for the
+ * same reason S3's notification destinations do it that way: reaching another
+ * service while this one is being constructed is a cycle with no bottom to it.
+ *
+ * A reference naming another Account or Region is read there. Real ECS requires
+ * a secret to be in the task's own Region and allows another Account's through
+ * a resource policy, but a reference carries the scope it names either way, and
+ * reading it where it says it is keeps a wrong Region a missing secret rather
+ * than a secret of the same name in the task's own.
+ */
+export class SimAwsEcsSecretStores implements SimEcsSecretStores {
+  private readonly simAws: SimAws;
+  private readonly accountRegionScope: SimAwsAccountRegionScope;
+
+  constructor(properties: SimAwsEcsSecretStoresProperties) {
+    this.simAws = properties.simAws;
+    this.accountRegionScope = properties.accountRegionScope;
+  }
+
+  /**
+   * Read one secret's value as the caller the request names.
+   */
+  async read(request: SimEcsSecretRead): Promise<string> {
+    if (request.reference.store === "secretsmanager") {
+      return await this.secretString(request);
+    }
+
+    return await this.parameterValue(request);
+  }
+
+  private async secretString(request: SimEcsSecretRead): Promise<string> {
+    const { reference } = request;
+    const answer = await this.scopeFor(reference)
+      .secretsManager()
+      .getSecretValue(
+        {
+          input: {
+            SecretId: reference.identifier,
+            ...(reference.versionId !== undefined && {
+              VersionId: reference.versionId,
+            }),
+            ...(reference.versionStage !== undefined && {
+              VersionStage: reference.versionStage,
+            }),
+          },
+        },
+        { caller: request.caller },
+      );
+
+    if (answer.SecretString === undefined) {
+      throw new SimEcsSecretResolutionError(
+        `${reference.identifier} holds a binary value, and only a string ` +
+          `secret can become an environment variable.`,
+      );
+    }
+
+    return answer.SecretString;
+  }
+
+  /**
+   * Read a parameter, decrypting it, as a real task agent does.
+   *
+   * `WithDecryption` is always on, because a `SecureString` is the only kind of
+   * parameter worth putting in `secrets` and a real task gets its plaintext.
+   * Parameter Store ignores the flag for the types it stores in the clear.
+   */
+  private async parameterValue(request: SimEcsSecretRead): Promise<string> {
+    const { reference } = request;
+    const answer = await this.scopeFor(reference)
+      .ssm()
+      .getParameter(
+        { input: { Name: reference.identifier, WithDecryption: true } },
+        { caller: request.caller },
+      );
+
+    if (answer.Parameter?.Value === undefined) {
+      throw new SimEcsSecretResolutionError(
+        `${reference.identifier} has no value to read.`,
+      );
+    }
+
+    return answer.Parameter.Value;
+  }
+
+  /**
+   * The Account and Region a reference is read in, which is the task's own
+   * where the reference named none.
+   */
+  private scopeFor(
+    reference: SimEcsSecretReference,
+  ): SimAwsAccountRegionContainer {
+    return this.simAws.accountRegionScope(
+      reference.accountId ?? this.accountRegionScope.accountId,
+      reference.regionName ?? this.accountRegionScope.regionName,
+    );
+  }
+}

--- a/src/service/ecs/task/run/secret/sim-ecs-container-secrets.iso.test.ts
+++ b/src/service/ecs/task/run/secret/sim-ecs-container-secrets.iso.test.ts
@@ -48,6 +48,33 @@ describe("Resolving one container's declared secrets", () => {
     assertIdentical(resolved["API_KEY"], "value");
   });
 
+  it("takes an empty execution Role as no execution Role at all", async () => {
+    // Given a definition carrying an executionRoleArn of nothing, which names
+    // no Role just as declaring none does.
+    const declared = new SimEcsContainerDefinition({
+      name: "app",
+      image: "orders-worker:1",
+      secrets: [{ name: "DB_PASSWORD", valueFrom: "/orders/db" }],
+    });
+    const secrets = new SimEcsContainerSecrets({
+      stores: new SimEcsFixedSecretStore(() => "value"),
+      executionRoleArn: "",
+    });
+
+    // When the secrets are resolved.
+    let reason = "";
+
+    try {
+      await secrets.resolve(declared);
+    } catch (error) {
+      reason = error instanceof Error ? error.message : "";
+    }
+
+    // Then it says there is no Role to read the secret as, rather than reading
+    // it as a principal named by an empty ARN.
+    assertStringIncludes(reason, "declares no executionRoleArn");
+  });
+
   it("reports a store that threw something other than an Error", async () => {
     // Given a store whose failure is not an Error, as an unwrapped rejection
     // from anything reached across a service boundary may not be.

--- a/src/service/ecs/task/run/secret/sim-ecs-container-secrets.iso.test.ts
+++ b/src/service/ecs/task/run/secret/sim-ecs-container-secrets.iso.test.ts
@@ -1,0 +1,80 @@
+import { assertIdentical, assertStringIncludes } from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimEcsContainerDefinition } from "../../../task-definition/container/sim-ecs-container-definition.js";
+import { SimEcsContainerSecrets } from "./sim-ecs-container-secrets.js";
+import type { SimEcsSecretStores } from "./sim-ecs-secret-stores.js";
+
+/**
+ * A store that answers every read the same way.
+ *
+ * Both cases here are about what a store hands back rather than about which
+ * store it is, so the two real ones are stood in for.
+ */
+class SimEcsFixedSecretStore implements SimEcsSecretStores {
+  private readonly answer: () => string;
+
+  constructor(answer: () => string) {
+    this.answer = answer;
+  }
+
+  read(): Promise<string> {
+    return Promise.resolve(this.answer());
+  }
+}
+
+const executionRoleArn = "arn:aws:iam::111111111111:role/OrdersExecutionRole";
+
+describe("Resolving one container's declared secrets", () => {
+  it("names each variable the value its reference read", async () => {
+    // Given a container declaring two secrets.
+    const declared = new SimEcsContainerDefinition({
+      name: "app",
+      image: "orders-worker:1",
+      secrets: [
+        { name: "DB_PASSWORD", valueFrom: "/orders/db" },
+        { name: "API_KEY", valueFrom: "/orders/api-key" },
+      ],
+    });
+    const secrets = new SimEcsContainerSecrets({
+      stores: new SimEcsFixedSecretStore(() => "value"),
+      executionRoleArn,
+    });
+
+    // When they are resolved.
+    const resolved = await secrets.resolve(declared);
+
+    // Then both variables are set.
+    assertIdentical(resolved["DB_PASSWORD"], "value");
+    assertIdentical(resolved["API_KEY"], "value");
+  });
+
+  it("reports a store that threw something other than an Error", async () => {
+    // Given a store whose failure is not an Error, as an unwrapped rejection
+    // from anything reached across a service boundary may not be.
+    const declared = new SimEcsContainerDefinition({
+      name: "app",
+      image: "orders-worker:1",
+      secrets: [{ name: "DB_PASSWORD", valueFrom: "/orders/db" }],
+    });
+    const secrets = new SimEcsContainerSecrets({
+      stores: new SimEcsFixedSecretStore(() => {
+        // oxlint-disable-next-line only-throw-error -- what this test is about
+        throw "the store gave up";
+      }),
+      executionRoleArn,
+    });
+
+    // When the secrets are resolved.
+    let reason = "";
+
+    try {
+      await secrets.resolve(declared);
+    } catch (error) {
+      reason = error instanceof Error ? error.message : "";
+    }
+
+    // Then the reason still names the variable and reads the failure out.
+    assertStringIncludes(reason, "unable to pull secrets: DB_PASSWORD");
+    assertStringIncludes(reason, "the store gave up");
+  });
+});

--- a/src/service/ecs/task/run/secret/sim-ecs-container-secrets.ts
+++ b/src/service/ecs/task/run/secret/sim-ecs-container-secrets.ts
@@ -1,0 +1,130 @@
+import type { SimEcsContainerDefinition } from "../../../task-definition/container/sim-ecs-container-definition.js";
+import type { SimEcsSecret } from "../../../task-definition/container/sim-ecs-container-parts.js";
+import { SimEcsSecretJsonKey } from "./sim-ecs-secret-json-key.js";
+import { parseSimEcsSecretReference } from "./sim-ecs-secret-reference-parse.js";
+import type { SimEcsSecretStores } from "./sim-ecs-secret-stores.js";
+import { SimEcsSecretResolutionError } from "./sim-ecs-secret.error.js";
+
+interface SimEcsContainerSecretsProperties {
+  readonly stores: SimEcsSecretStores;
+  readonly executionRoleArn: string | undefined;
+}
+
+/**
+ * Resolves one container's declared `secrets` into environment variables.
+ *
+ * Every read is made as the task execution Role, which is the Role a real task
+ * agent pulls secrets with before a container starts. It is not the task Role:
+ * a Role allowed to read the secret is not thereby allowed to do what the
+ * container does, and a Role allowed what the container does is not thereby
+ * allowed to read the secret.
+ *
+ * A secret that cannot be read stops the whole task, so the reason names the
+ * variable rather than the secret alone. The variable is what the container
+ * code was going to read, and the name of a secret nobody could reach says
+ * less about which part of the definition is wrong.
+ */
+export class SimEcsContainerSecrets {
+  private readonly stores: SimEcsSecretStores;
+  private readonly executionRoleArn: string | undefined;
+
+  constructor(properties: SimEcsContainerSecretsProperties) {
+    this.stores = properties.stores;
+    this.executionRoleArn = properties.executionRoleArn;
+  }
+
+  /**
+   * The variable a secret entry sets, which it has to name.
+   */
+  private static variableName(secret: SimEcsSecret): string {
+    const { name } = secret;
+
+    if (name === undefined || name === "") {
+      throw new SimEcsSecretResolutionError(
+        `unable to pull secrets: a secret naming ` +
+          `${secret.valueFrom ?? "nothing"} sets no environment variable, so ` +
+          `there is nothing for the container to read it as.`,
+      );
+    }
+
+    return name;
+  }
+
+  private static requiredValueFrom(secret: SimEcsSecret): string {
+    const { valueFrom } = secret;
+
+    if (valueFrom === undefined || valueFrom === "") {
+      throw new SimEcsSecretResolutionError(
+        "it names no secret to read the value from.",
+      );
+    }
+
+    return valueFrom;
+  }
+
+  /**
+   * What this container's `secrets` become in its environment.
+   */
+  async resolve(
+    declared: SimEcsContainerDefinition,
+  ): Promise<Record<string, string>> {
+    const resolved: [string, string][] = [];
+
+    for (const secret of declared.secrets) {
+      const name = SimEcsContainerSecrets.variableName(secret);
+
+      // One secret at a time, so the first one that cannot be read is the one
+      // the task reports, as a real task agent reports the first failure.
+      // oxlint-disable-next-line no-await-in-loop
+      resolved.push([name, await this.value(name, secret)]);
+    }
+
+    return Object.fromEntries(resolved);
+  }
+
+  private async value(name: string, secret: SimEcsSecret): Promise<string> {
+    try {
+      return await this.read(secret);
+    } catch (error) {
+      throw new SimEcsSecretResolutionError(
+        `unable to pull secrets: ${name}: ${SimEcsSecretResolutionError.reasonFor(
+          error,
+        )}`,
+      );
+    }
+  }
+
+  private async read(secret: SimEcsSecret): Promise<string> {
+    const reference = parseSimEcsSecretReference(
+      SimEcsContainerSecrets.requiredValueFrom(secret),
+    );
+    const value = await this.stores.read({
+      reference,
+      caller: { kind: "arn", arn: this.requiredExecutionRoleArn() },
+    });
+
+    if (reference.jsonKey === undefined) {
+      return value;
+    }
+
+    return new SimEcsSecretJsonKey(reference.jsonKey).valueIn(value);
+  }
+
+  /**
+   * The Role the read is made as.
+   *
+   * A task definition declaring secrets and no `executionRoleArn` says so
+   * rather than being read anonymously and denied. Real ECS refuses the same
+   * thing, and forgetting the execution role is the ordinary way to get here.
+   */
+  private requiredExecutionRoleArn(): string {
+    if (this.executionRoleArn === undefined) {
+      throw new SimEcsSecretResolutionError(
+        "the task definition declares no executionRoleArn, so there is no " +
+          "Role to read it as.",
+      );
+    }
+
+    return this.executionRoleArn;
+  }
+}

--- a/src/service/ecs/task/run/secret/sim-ecs-container-secrets.ts
+++ b/src/service/ecs/task/run/secret/sim-ecs-container-secrets.ts
@@ -118,7 +118,7 @@ export class SimEcsContainerSecrets {
    * thing, and forgetting the execution role is the ordinary way to get here.
    */
   private requiredExecutionRoleArn(): string {
-    if (this.executionRoleArn === undefined) {
+    if (this.executionRoleArn === undefined || this.executionRoleArn === "") {
       throw new SimEcsSecretResolutionError(
         "the task definition declares no executionRoleArn, so there is no " +
           "Role to read it as.",

--- a/src/service/ecs/task/run/secret/sim-ecs-resolved-secrets.iso.test.ts
+++ b/src/service/ecs/task/run/secret/sim-ecs-resolved-secrets.iso.test.ts
@@ -1,0 +1,46 @@
+import {
+  assertArrayLength,
+  assertFalse,
+  assertIdentical,
+  assertStringIncludes,
+  assertThrowsError,
+  assertTrue,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimEcsResolvedSecrets } from "./sim-ecs-resolved-secrets.js";
+
+describe("The secrets a simulated ECS task's containers run with", () => {
+  it("answers with the variables one container's secrets set", () => {
+    // Given secrets resolved for one container of a task.
+    const secrets = SimEcsResolvedSecrets.resolved(
+      new Map([["app", { DB_PASSWORD: "hunter2" }]]),
+    );
+
+    // When a container asks for its own.
+    // Then it gets them, and a container that declared none gets none.
+    assertTrue(secrets.isResolved);
+    assertIdentical(secrets.forContainer("app")["DB_PASSWORD"], "hunter2");
+    assertArrayLength(Object.keys(secrets.forContainer("logs")), 0);
+  });
+
+  it("carries the reason a task could not start", () => {
+    // Given a resolution that failed.
+    const secrets = SimEcsResolvedSecrets.failed("ResourceInitializationError");
+
+    // When the runner asks why.
+    // Then it has the reason to stop the task with.
+    assertFalse(secrets.isResolved);
+    assertIdentical(secrets.failureReason, "ResourceInitializationError");
+  });
+
+  it("refuses to report a failure reason where there is none", () => {
+    // Given secrets that resolved.
+    const secrets = SimEcsResolvedSecrets.resolved(new Map());
+
+    // When something asks why the task failed anyway.
+    const error = assertThrowsError(() => secrets.failureReason);
+
+    // Then it says there is no reason, rather than answering with an empty one.
+    assertStringIncludes(error.message, "no failure reason");
+  });
+});

--- a/src/service/ecs/task/run/secret/sim-ecs-resolved-secrets.ts
+++ b/src/service/ecs/task/run/secret/sim-ecs-resolved-secrets.ts
@@ -1,0 +1,66 @@
+import { SimEcsSecretResolutionError } from "./sim-ecs-secret.error.js";
+
+/**
+ * What a task's containers run with once their `secrets` have been resolved,
+ * or why the task cannot start.
+ *
+ * Every container of a task is resolved before any of them runs, because that
+ * is when a real task agent pulls them: a secret nobody can read stops the
+ * task rather than stopping the container that declared it, so an earlier
+ * container never runs on a task that was never going to work.
+ */
+export class SimEcsResolvedSecrets {
+  readonly #byContainer: ReadonlyMap<string, Record<string, string>>;
+  readonly #failureReason: string | undefined;
+
+  private constructor(
+    byContainer: ReadonlyMap<string, Record<string, string>>,
+    failureReason: string | undefined,
+  ) {
+    this.#byContainer = byContainer;
+    this.#failureReason = failureReason;
+  }
+
+  /**
+   * Every container's secrets, read as the task execution Role.
+   */
+  static resolved(
+    byContainer: ReadonlyMap<string, Record<string, string>>,
+  ): SimEcsResolvedSecrets {
+    return new SimEcsResolvedSecrets(byContainer, undefined);
+  }
+
+  /**
+   * A task that cannot start, because one of its secrets could not be read.
+   */
+  static failed(reason: string): SimEcsResolvedSecrets {
+    return new SimEcsResolvedSecrets(new Map(), reason);
+  }
+
+  /**
+   * Whether the task's containers can go on to run.
+   */
+  get isResolved(): boolean {
+    return this.#failureReason === undefined;
+  }
+
+  /**
+   * Why the task failed to start, in the terms real ECS reports it.
+   */
+  get failureReason(): string {
+    if (this.#failureReason === undefined) {
+      throw new SimEcsSecretResolutionError(
+        "These secrets resolved, so there is no failure reason to report.",
+      );
+    }
+
+    return this.#failureReason;
+  }
+
+  /**
+   * The variables one container's secrets set, which may be none.
+   */
+  forContainer(containerName: string): Record<string, string> {
+    return this.#byContainer.get(containerName) ?? {};
+  }
+}

--- a/src/service/ecs/task/run/secret/sim-ecs-secret-arn.ts
+++ b/src/service/ecs/task/run/secret/sim-ecs-secret-arn.ts
@@ -1,0 +1,79 @@
+import type { SimAwsAccountId } from "../../../../aws/sim-aws-account-id.js";
+import type { AwsRegionName } from "../../../../aws/sim-aws-region.js";
+import { SimEcsSecretResolutionError } from "./sim-ecs-secret.error.js";
+
+/**
+ * Where each part of a container secret's `valueFrom` sits once it is split on
+ * colons.
+ *
+ * The extended form real ECS accepts for a secret is
+ * `arn:aws:secretsmanager:region:account:secret:id:json-key:stage:version`,
+ * and every part after the id may be empty to mean it was not given. A secret
+ * id cannot itself contain a colon, so splitting is unambiguous. A parameter
+ * ARN stops at its resource, which carries the name after `parameter/`.
+ */
+export const simEcsSecretArnPart = {
+  service: 2,
+  region: 3,
+  account: 4,
+  resource: 5,
+  secretId: 6,
+  jsonKey: 7,
+  versionStage: 8,
+  versionId: 9,
+} as const;
+
+/**
+ * The Account and Region an ARN names.
+ */
+export interface SimEcsSecretArnScope {
+  readonly accountId: SimAwsAccountId | undefined;
+  readonly regionName: AwsRegionName | undefined;
+}
+
+/**
+ * One optional part of a reference, where empty means it was not given.
+ */
+export function simEcsSecretArnPartGiven(
+  part: string | undefined,
+): string | undefined {
+  if (part === undefined || part === "") {
+    return undefined;
+  }
+
+  return part;
+}
+
+/**
+ * One part of a reference that has to be there for it to name anything.
+ */
+export function simEcsSecretArnPartRequired(
+  part: string | undefined,
+  valueFrom: string,
+): string {
+  const value = simEcsSecretArnPartGiven(part);
+
+  if (value === undefined) {
+    throw new SimEcsSecretResolutionError(
+      `${valueFrom} names no secret or parameter.`,
+    );
+  }
+
+  return value;
+}
+
+/**
+ * The Account and Region the parts of an ARN name.
+ */
+export function simEcsSecretArnScope(
+  parts: readonly string[],
+): SimEcsSecretArnScope {
+  return {
+    accountId: simEcsSecretArnPartGiven(parts[simEcsSecretArnPart.account]) as
+      | SimAwsAccountId
+      | undefined,
+    regionName: simEcsSecretArnPartGiven(parts[simEcsSecretArnPart.region]) as
+      | AwsRegionName
+      | undefined,
+  };
+}

--- a/src/service/ecs/task/run/secret/sim-ecs-secret-json-key.iso.test.ts
+++ b/src/service/ecs/task/run/secret/sim-ecs-secret-json-key.iso.test.ts
@@ -1,0 +1,71 @@
+import {
+  assertIdentical,
+  assertStringIncludes,
+  assertThrowsError,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimEcsSecretJsonKey } from "./sim-ecs-secret-json-key.js";
+
+describe("Selecting one key of a JSON container secret", () => {
+  it("answers with the value that key holds", () => {
+    // Given a secret holding a JSON object.
+    const key = new SimEcsSecretJsonKey("password");
+
+    // When a key of it is selected.
+    const value = key.valueIn(
+      JSON.stringify({ user: "orders", password: "s3cr3t" }),
+    );
+
+    // Then that key's value is what the variable is set to.
+    assertIdentical(value, "s3cr3t");
+  });
+
+  it("refuses a key the secret has not got", () => {
+    // Given a secret holding other keys.
+    const key = new SimEcsSecretJsonKey("password");
+
+    // When the missing key is selected.
+    const error = assertThrowsError(() =>
+      key.valueIn(JSON.stringify({ user: "orders" })),
+    );
+
+    // Then it names the key, which is the part of the ARN to look at.
+    assertStringIncludes(error.message, "holds no password key");
+  });
+
+  it("refuses a secret that is not JSON", () => {
+    // Given a secret holding a plain string.
+    const key = new SimEcsSecretJsonKey("password");
+
+    // When a key of it is selected.
+    const error = assertThrowsError(() => key.valueIn("hunter2"));
+
+    // Then it says the secret is not JSON, rather than reporting a missing key.
+    assertStringIncludes(error.message, "is not JSON");
+  });
+
+  it("refuses a secret that is JSON but not an object", () => {
+    // Given a secret holding a JSON array.
+    const key = new SimEcsSecretJsonKey("password");
+
+    // When a key of it is selected.
+    const error = assertThrowsError(() => key.valueIn(JSON.stringify(["one"])));
+
+    // Then it says there is no object to take a key from.
+    assertStringIncludes(error.message, "is not a JSON object");
+  });
+
+  it("refuses a key whose value is not text", () => {
+    // Given a secret whose key holds a number.
+    const key = new SimEcsSecretJsonKey("port");
+
+    // When it is selected.
+    const error = assertThrowsError(() =>
+      key.valueIn(JSON.stringify({ port: 5432 })),
+    );
+
+    // Then it refuses rather than choosing how to write the value out, since
+    // an environment variable can only be text.
+    assertStringIncludes(error.message, "rather than a string");
+  });
+});

--- a/src/service/ecs/task/run/secret/sim-ecs-secret-json-key.iso.test.ts
+++ b/src/service/ecs/task/run/secret/sim-ecs-secret-json-key.iso.test.ts
@@ -33,6 +33,20 @@ describe("Selecting one key of a JSON container secret", () => {
     assertStringIncludes(error.message, "holds no password key");
   });
 
+  it("refuses a key the secret only inherits", () => {
+    // Given a key every object has on its prototype.
+    const key = new SimEcsSecretJsonKey("toString");
+
+    // When it is selected.
+    const error = assertThrowsError(() =>
+      key.valueIn(JSON.stringify({ user: "orders" })),
+    );
+
+    // Then the secret is reported as not holding it, rather than as holding
+    // whatever the prototype put there.
+    assertStringIncludes(error.message, "holds no toString key");
+  });
+
   it("refuses a secret that is not JSON", () => {
     // Given a secret holding a plain string.
     const key = new SimEcsSecretJsonKey("password");

--- a/src/service/ecs/task/run/secret/sim-ecs-secret-json-key.ts
+++ b/src/service/ecs/task/run/secret/sim-ecs-secret-json-key.ts
@@ -1,0 +1,70 @@
+import { SimEcsSecretResolutionError } from "./sim-ecs-secret.error.js";
+
+/**
+ * The one key of a JSON secret a `valueFrom` selects.
+ *
+ * A Secrets Manager secret is very often a JSON object holding a whole set of
+ * connection details, and a container wants one field of it as one variable.
+ * Real ECS takes that key from the seventh part of the ARN, which is what CDK
+ * writes when a construct is given a field.
+ *
+ * A key whose value is not a string is refused rather than converted. An
+ * environment variable is text, and turning a nested object or a number into
+ * text here would be this simulation choosing a representation real ECS has
+ * not documented.
+ */
+export class SimEcsSecretJsonKey {
+  private readonly key: string;
+
+  constructor(key: string) {
+    this.key = key;
+  }
+
+  private static parsed(secretString: string, key: string): unknown {
+    try {
+      return JSON.parse(secretString);
+    } catch {
+      throw new SimEcsSecretResolutionError(
+        `the secret is not JSON, so it has no ${key} key.`,
+      );
+    }
+  }
+
+  /**
+   * The value this key holds in a secret stored as a JSON object.
+   */
+  valueIn(secretString: string): string {
+    const value = this.object(secretString)[this.key];
+
+    if (value === undefined) {
+      throw new SimEcsSecretResolutionError(
+        `the secret holds no ${this.key} key.`,
+      );
+    }
+
+    if (typeof value !== "string") {
+      throw new SimEcsSecretResolutionError(
+        `the ${this.key} key holds a ${typeof value} rather than a string, ` +
+          `and an environment variable can only be text.`,
+      );
+    }
+
+    return value;
+  }
+
+  private object(secretString: string): Record<string, unknown> {
+    const parsed: unknown = SimEcsSecretJsonKey.parsed(secretString, this.key);
+
+    if (
+      parsed === null ||
+      typeof parsed !== "object" ||
+      Array.isArray(parsed)
+    ) {
+      throw new SimEcsSecretResolutionError(
+        `the secret is not a JSON object, so it has no ${this.key} key.`,
+      );
+    }
+
+    return parsed as Record<string, unknown>;
+  }
+}

--- a/src/service/ecs/task/run/secret/sim-ecs-secret-json-key.ts
+++ b/src/service/ecs/task/run/secret/sim-ecs-secret-json-key.ts
@@ -34,18 +34,22 @@ export class SimEcsSecretJsonKey {
    * The value this key holds in a secret stored as a JSON object.
    */
   valueIn(secretString: string): string {
-    const value = this.object(secretString)[this.key];
+    const object = this.object(secretString);
 
-    if (value === undefined) {
+    // An own property, so a key of `constructor` or `toString` is a key the
+    // secret has not got rather than something found on the prototype.
+    if (!Object.hasOwn(object, this.key)) {
       throw new SimEcsSecretResolutionError(
         `the secret holds no ${this.key} key.`,
       );
     }
 
+    const value = object[this.key];
+
     if (typeof value !== "string") {
       throw new SimEcsSecretResolutionError(
-        `the ${this.key} key holds a ${typeof value} rather than a string, ` +
-          `and an environment variable can only be text.`,
+        `the ${this.key} key holds a value of type ${typeof value} rather ` +
+          `than a string, and an environment variable can only be text.`,
       );
     }
 

--- a/src/service/ecs/task/run/secret/sim-ecs-secret-reference-parse.iso.test.ts
+++ b/src/service/ecs/task/run/secret/sim-ecs-secret-reference-parse.iso.test.ts
@@ -1,0 +1,127 @@
+import {
+  assertIdentical,
+  assertStringIncludes,
+  assertThrowsError,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { parseSimEcsSecretReference } from "./sim-ecs-secret-reference-parse.js";
+
+const secretArn =
+  "arn:aws:secretsmanager:eu-west-2:111111111111:secret:db-AbCdEf";
+
+describe("Reading a simulated ECS container secret's valueFrom", () => {
+  it("reads a Secrets Manager ARN", () => {
+    // Given a plain secret ARN.
+    // When it is read.
+    const reference = parseSimEcsSecretReference(secretArn);
+
+    // Then it names the secret in the account and region the ARN carries.
+    assertIdentical(reference.store, "secretsmanager");
+    assertIdentical(reference.identifier, "db-AbCdEf");
+    assertIdentical(reference.accountId, "111111111111");
+    assertIdentical(reference.regionName, "eu-west-2");
+    assertUndefined(reference.jsonKey);
+  });
+
+  it("reads the JSON key, stage and version a secret ARN may end with", () => {
+    // Given the extended form real ECS accepts.
+    // When it is read.
+    const reference = parseSimEcsSecretReference(
+      `${secretArn}:password:AWSPREVIOUS:v-1`,
+    );
+
+    // Then each selector is picked out, and the secret id stops before them.
+    assertIdentical(reference.identifier, "db-AbCdEf");
+    assertIdentical(reference.jsonKey, "password");
+    assertIdentical(reference.versionStage, "AWSPREVIOUS");
+    assertIdentical(reference.versionId, "v-1");
+  });
+
+  it("treats an empty selector as one that was not given", () => {
+    // Given the form a CDK construct writes for a field with no version.
+    // When it is read.
+    const reference = parseSimEcsSecretReference(`${secretArn}:password::`);
+
+    // Then only the key was given.
+    assertIdentical(reference.jsonKey, "password");
+    assertUndefined(reference.versionStage);
+    assertUndefined(reference.versionId);
+  });
+
+  it("reads an SSM parameter ARN back to its name", () => {
+    // Given a parameter ARN, which drops the name's leading slash.
+    // When it is read.
+    const reference = parseSimEcsSecretReference(
+      "arn:aws:ssm:eu-west-2:111111111111:parameter/orders/api-key",
+    );
+
+    // Then the name is put back together with its slash.
+    assertIdentical(reference.store, "ssm");
+    assertIdentical(reference.identifier, "/orders/api-key");
+    assertIdentical(reference.regionName, "eu-west-2");
+  });
+
+  it("leaves a top-level parameter name without a leading slash", () => {
+    // Given a parameter ARN naming no hierarchy.
+    // When it is read.
+    const reference = parseSimEcsSecretReference(
+      "arn:aws:ssm:eu-west-2:111111111111:parameter/api-key",
+    );
+
+    // Then it is the name as Parameter Store holds it.
+    assertIdentical(reference.identifier, "api-key");
+  });
+
+  it("takes something that is not an ARN as a parameter name", () => {
+    // Given a bare name, which real ECS allows in the task's own region.
+    // When it is read.
+    const reference = parseSimEcsSecretReference("/orders/api-key");
+
+    // Then it names no scope, so the task's own is used.
+    assertIdentical(reference.store, "ssm");
+    assertIdentical(reference.identifier, "/orders/api-key");
+    assertUndefined(reference.accountId);
+    assertUndefined(reference.regionName);
+  });
+
+  it("refuses a store that is not simulated", () => {
+    // Given an ARN naming a store other than the two simulated ones.
+    // When it is read.
+    const error = assertThrowsError(() =>
+      parseSimEcsSecretReference(
+        "arn:aws:kms:eu-west-2:111111111111:key/abc-123",
+      ),
+    );
+
+    // Then it says which stores there are, rather than guessing.
+    assertStringIncludes(error.message, "only Secrets Manager and");
+  });
+
+  it("refuses an SSM ARN that does not name a parameter", () => {
+    // Given an ARN for something else in Systems Manager.
+    // When it is read.
+    const error = assertThrowsError(() =>
+      parseSimEcsSecretReference(
+        "arn:aws:ssm:eu-west-2:111111111111:document/RunShellScript",
+      ),
+    );
+
+    // Then it says only Parameter Store is simulated.
+    assertStringIncludes(error.message, "only");
+    assertStringIncludes(error.message, "Parameter Store is simulated");
+  });
+
+  it("refuses an ARN naming no secret at all", () => {
+    // Given a secret ARN that stops at its resource type.
+    // When it is read.
+    const error = assertThrowsError(() =>
+      parseSimEcsSecretReference(
+        "arn:aws:secretsmanager:eu-west-2:111111111111:secret:",
+      ),
+    );
+
+    // Then it says so rather than looking the empty name up.
+    assertStringIncludes(error.message, "names no secret or parameter");
+  });
+});

--- a/src/service/ecs/task/run/secret/sim-ecs-secret-reference-parse.ts
+++ b/src/service/ecs/task/run/secret/sim-ecs-secret-reference-parse.ts
@@ -1,0 +1,119 @@
+import {
+  simEcsSecretArnPart,
+  simEcsSecretArnPartGiven,
+  simEcsSecretArnPartRequired,
+  simEcsSecretArnScope,
+} from "./sim-ecs-secret-arn.js";
+import type { SimEcsSecretReference } from "./sim-ecs-secret-reference.js";
+import { SimEcsSecretResolutionError } from "./sim-ecs-secret.error.js";
+
+/**
+ * The prefix of the resource part of an SSM parameter ARN.
+ */
+const parameterResourcePrefix = "parameter/";
+
+/**
+ * A parameter named without a scope, resolved in the task's own.
+ */
+function parameterNamed(name: string): SimEcsSecretReference {
+  return {
+    store: "ssm",
+    accountId: undefined,
+    regionName: undefined,
+    identifier: name,
+    jsonKey: undefined,
+    versionStage: undefined,
+    versionId: undefined,
+  };
+}
+
+/**
+ * The parameter name an ARN's resource part stands for.
+ *
+ * A parameter ARN drops the leading slash of a hierarchical name, so it is put
+ * back here. Parameter Store reads a parameter by either form, but the name
+ * with its slash is the one a reason should quote back.
+ */
+function parameterNameIn(resource: string): string {
+  if (resource.includes("/")) {
+    return `/${resource}`;
+  }
+
+  return resource;
+}
+
+function secretReference(
+  valueFrom: string,
+  parts: readonly string[],
+): SimEcsSecretReference {
+  return {
+    store: "secretsmanager",
+    ...simEcsSecretArnScope(parts),
+    identifier: simEcsSecretArnPartRequired(
+      parts[simEcsSecretArnPart.secretId],
+      valueFrom,
+    ),
+    jsonKey: simEcsSecretArnPartGiven(parts[simEcsSecretArnPart.jsonKey]),
+    versionStage: simEcsSecretArnPartGiven(
+      parts[simEcsSecretArnPart.versionStage],
+    ),
+    versionId: simEcsSecretArnPartGiven(parts[simEcsSecretArnPart.versionId]),
+  };
+}
+
+function parameterReference(
+  valueFrom: string,
+  parts: readonly string[],
+): SimEcsSecretReference {
+  const resource = simEcsSecretArnPartRequired(
+    parts[simEcsSecretArnPart.resource],
+    valueFrom,
+  );
+
+  if (!resource.startsWith(parameterResourcePrefix)) {
+    throw new SimEcsSecretResolutionError(
+      `${valueFrom} is an SSM ARN that does not name a parameter, and only ` +
+        `Parameter Store is simulated in Systems Manager.`,
+    );
+  }
+
+  return {
+    ...parameterNamed(
+      parameterNameIn(resource.slice(parameterResourcePrefix.length)),
+    ),
+    ...simEcsSecretArnScope(parts),
+  };
+}
+
+/**
+ * Read a container secret's `valueFrom` into the store and identifier it names.
+ *
+ * A `valueFrom` that is not an ARN at all is an SSM parameter name, as it is on
+ * real ECS, where a parameter in the task's own Region may be named without its
+ * ARN. Anything else, including a store this simulation does not hold, is
+ * refused rather than guessed at: a secret resolved from the wrong place is
+ * worse than a task that says it could not resolve one.
+ */
+export function parseSimEcsSecretReference(
+  valueFrom: string,
+): SimEcsSecretReference {
+  if (!valueFrom.startsWith("arn:")) {
+    return parameterNamed(valueFrom);
+  }
+
+  const parts = valueFrom.split(":");
+  const service = parts[simEcsSecretArnPart.service];
+
+  if (service === "secretsmanager") {
+    return secretReference(valueFrom, parts);
+  }
+
+  if (service === "ssm") {
+    return parameterReference(valueFrom, parts);
+  }
+
+  throw new SimEcsSecretResolutionError(
+    `${valueFrom} names ${String(service)}, and only Secrets Manager and SSM ` +
+      `Parameter Store are simulated as container secret stores.`,
+  );
+}

--- a/src/service/ecs/task/run/secret/sim-ecs-secret-reference.ts
+++ b/src/service/ecs/task/run/secret/sim-ecs-secret-reference.ts
@@ -1,0 +1,28 @@
+import type { SimAwsAccountId } from "../../../../aws/sim-aws-account-id.js";
+import type { AwsRegionName } from "../../../../aws/sim-aws-region.js";
+
+/**
+ * The stores a container secret's `valueFrom` may name.
+ */
+export type SimEcsSecretStoreName = "secretsmanager" | "ssm";
+
+/**
+ * Where one container secret's value comes from.
+ *
+ * The Account and Region are absent where the reference did not name them,
+ * which is a bare SSM parameter name. Real ECS reads one of those in the task's
+ * own Region, so whoever resolves the reference supplies the scope rather than
+ * this deciding it.
+ */
+export interface SimEcsSecretReference {
+  readonly store: SimEcsSecretStoreName;
+  readonly accountId: SimAwsAccountId | undefined;
+  readonly regionName: AwsRegionName | undefined;
+  /**
+   * The secret id or parameter name the store is asked for.
+   */
+  readonly identifier: string;
+  readonly jsonKey: string | undefined;
+  readonly versionStage: string | undefined;
+  readonly versionId: string | undefined;
+}

--- a/src/service/ecs/task/run/secret/sim-ecs-secret-stores.iso.test.ts
+++ b/src/service/ecs/task/run/secret/sim-ecs-secret-stores.iso.test.ts
@@ -1,0 +1,68 @@
+import {
+  CreateClusterCommand,
+  DescribeTasksCommand,
+  RegisterTaskDefinitionCommand,
+  RunTaskCommand,
+} from "@aws-sdk/client-ecs";
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { BackgroundTasks } from "../../../../../util/background/background.js";
+import { SimEcs } from "../../../sim-ecs.js";
+
+describe("A simulated ECS that reaches no secret store", () => {
+  it("stops a task declaring a secret rather than running it without one", async () => {
+    // Given simulated ECS built on its own, so there is no simulated Secrets
+    // Manager or Parameter Store around it.
+    const background = new BackgroundTasks();
+    const ecs = new SimEcs({ background });
+    await ecs.createCluster(new CreateClusterCommand({}));
+
+    let runs = 0;
+    ecs.bindContainer({
+      family: "orders-worker",
+      containerName: "app",
+      run: () => {
+        runs += 1;
+      },
+    });
+    await ecs.registerTaskDefinition(
+      new RegisterTaskDefinitionCommand({
+        family: "orders-worker",
+        executionRoleArn: "arn:aws:iam::111111111111:role/OrdersExecutionRole",
+        containerDefinitions: [
+          {
+            name: "app",
+            image: "orders-worker:1",
+            secrets: [{ name: "DB_PASSWORD", valueFrom: "/orders/db" }],
+          },
+        ],
+      }),
+    );
+
+    // When a task is run.
+    const run = await ecs.runTask(
+      new RunTaskCommand({ taskDefinition: "orders-worker" }),
+    );
+    await background.complete();
+
+    // Then it says what is missing, rather than starting a container without
+    // the variable it declared.
+    const described = await ecs.describeTasks(
+      new DescribeTasksCommand({ tasks: [run.tasks?.[0]?.taskArn ?? ""] }),
+    );
+
+    const task = described.tasks?.[0];
+    assertNonNullable(task);
+
+    assertIdentical(runs, 0);
+    assertIdentical(task.stopCode, "TaskFailedToStart");
+    assertStringIncludes(
+      task.stoppedReason ?? "",
+      "reaches no simulated Secrets Manager or SSM Parameter Store",
+    );
+  });
+});

--- a/src/service/ecs/task/run/secret/sim-ecs-secret-stores.ts
+++ b/src/service/ecs/task/run/secret/sim-ecs-secret-stores.ts
@@ -1,0 +1,46 @@
+import type { SimAwsPrincipal } from "../../../../aws/caller/sim-aws-caller.js";
+import type { SimEcsSecretReference } from "./sim-ecs-secret-reference.js";
+import { SimEcsSecretResolutionError } from "./sim-ecs-secret.error.js";
+
+/**
+ * One read of a container secret's value.
+ *
+ * The caller is the task execution Role rather than the task Role. That is the
+ * whole distinction: the execution Role is what the task agent pulls secrets
+ * with, before any container starts, and the task Role is what the container's
+ * own AWS calls are attributed to once it does.
+ */
+export interface SimEcsSecretRead {
+  readonly reference: SimEcsSecretReference;
+  readonly caller: SimAwsPrincipal;
+}
+
+/**
+ * Where a simulated ECS task's container secrets are read from.
+ *
+ * Reading goes through the store service's ordinary command path rather than
+ * its state, so simulated IAM decides it exactly as it decides a call an
+ * application makes. A denial is what makes a task fail to start.
+ */
+export interface SimEcsSecretStores {
+  read(request: SimEcsSecretRead): Promise<string>;
+}
+
+/**
+ * The secret stores a simulated ECS built on its own can reach, which is none.
+ *
+ * Simulated ECS is usually built through a SimAws instance, which hands it that
+ * simulation's Secrets Manager and Parameter Store. One built by itself has
+ * neither to reach, so a container declaring a secret says so rather than
+ * running without the variable it expects.
+ */
+export class SimEcsUnreachableSecretStores implements SimEcsSecretStores {
+  read(request: SimEcsSecretRead): Promise<string> {
+    throw new SimEcsSecretResolutionError(
+      `${request.reference.identifier} cannot be read, because this ` +
+        `simulated ECS reaches no simulated Secrets Manager or SSM Parameter ` +
+        `Store. Build it through a SimAws instance to resolve container ` +
+        `secrets.`,
+    );
+  }
+}

--- a/src/service/ecs/task/run/secret/sim-ecs-secret-stores.ts
+++ b/src/service/ecs/task/run/secret/sim-ecs-secret-stores.ts
@@ -35,7 +35,11 @@ export interface SimEcsSecretStores {
  * running without the variable it expects.
  */
 export class SimEcsUnreachableSecretStores implements SimEcsSecretStores {
-  read(request: SimEcsSecretRead): Promise<string> {
+  // Asynchronous so that it refuses the way the other implementation does,
+  // through a rejected promise rather than a throw the caller has to be
+  // holding a try around at the moment it calls.
+  // oxlint-disable-next-line require-await -- there is nothing here to await
+  async read(request: SimEcsSecretRead): Promise<string> {
     throw new SimEcsSecretResolutionError(
       `${request.reference.identifier} cannot be read, because this ` +
         `simulated ECS reaches no simulated Secrets Manager or SSM Parameter ` +

--- a/src/service/ecs/task/run/secret/sim-ecs-secret.error.ts
+++ b/src/service/ecs/task/run/secret/sim-ecs-secret.error.ts
@@ -1,0 +1,27 @@
+/**
+ * A container secret that could not be turned into an environment variable.
+ *
+ * This never reaches an ECS caller. Real ECS resolves a task's secrets after
+ * `RunTask` has answered, so the only place it can report one it could not read
+ * is the stopped task, and that is what this becomes: the reason a task carries
+ * when it failed to start.
+ */
+export class SimEcsSecretResolutionError extends Error {
+  public override readonly name = "SimEcsSecretResolutionError";
+
+  /**
+   * What a failure says, for something a store threw that need not be an Error.
+   *
+   * A secret store is reached through its own service, so what comes back from
+   * a failed read is whatever that service raises. Nothing here requires it to
+   * be an Error, and a reason reading `[object Object]` would be worse than one
+   * reading the value out.
+   */
+  static reasonFor(error: unknown): string {
+    if (error instanceof Error) {
+      return error.message;
+    }
+
+    return String(error);
+  }
+}

--- a/src/service/ecs/task/run/secret/sim-ecs-task-secrets.ts
+++ b/src/service/ecs/task/run/secret/sim-ecs-task-secrets.ts
@@ -1,0 +1,58 @@
+import type { SimEcsTaskDefinition } from "../../../task-definition/sim-ecs-task-definition.js";
+import { SimEcsContainerSecrets } from "./sim-ecs-container-secrets.js";
+import { SimEcsResolvedSecrets } from "./sim-ecs-resolved-secrets.js";
+import type { SimEcsSecretStores } from "./sim-ecs-secret-stores.js";
+import { SimEcsSecretResolutionError } from "./sim-ecs-secret.error.js";
+
+/**
+ * What real ECS calls a task that could not be given what it needs to start.
+ */
+const resourceInitializationError = "ResourceInitializationError";
+
+interface SimEcsTaskSecretsProperties {
+  readonly stores: SimEcsSecretStores;
+}
+
+/**
+ * Resolves the `secrets` every container of a task definition declares.
+ *
+ * This happens once, before the first container runs, because a real task
+ * agent pulls a task's secrets while the task is still provisioning. A secret
+ * it cannot read is a resource initialization error, which stops the task
+ * before anything of it has started.
+ */
+export class SimEcsTaskSecrets {
+  private readonly stores: SimEcsSecretStores;
+
+  constructor(properties: SimEcsTaskSecretsProperties) {
+    this.stores = properties.stores;
+  }
+
+  /**
+   * Resolve every container's secrets, or say why the task cannot start.
+   */
+  async resolve(
+    taskDefinition: SimEcsTaskDefinition,
+  ): Promise<SimEcsResolvedSecrets> {
+    const containerSecrets = new SimEcsContainerSecrets({
+      stores: this.stores,
+      executionRoleArn: taskDefinition.settings.executionRoleArn,
+    });
+    const byContainer = new Map<string, Record<string, string>>();
+
+    try {
+      for (const declared of taskDefinition.containers.all()) {
+        // oxlint-disable-next-line no-await-in-loop -- in declaration order, so a failure names the first secret that could not be read
+        const resolved = await containerSecrets.resolve(declared);
+
+        byContainer.set(declared.name, resolved);
+      }
+    } catch (error) {
+      return SimEcsResolvedSecrets.failed(
+        `${resourceInitializationError}: ${SimEcsSecretResolutionError.reasonFor(error)}`,
+      );
+    }
+
+    return SimEcsResolvedSecrets.resolved(byContainer);
+  }
+}

--- a/src/service/ecs/task/run/sim-ecs-container-environment.ts
+++ b/src/service/ecs/task/run/sim-ecs-container-environment.ts
@@ -4,16 +4,23 @@ import type { SimEcsKeyValuePair } from "../../task-definition/container/sim-ecs
 interface SimEcsContainerEnvironmentProperties {
   readonly regionName: string;
   readonly declared: readonly SimEcsKeyValuePair[];
+  readonly secrets: Record<string, string>;
   readonly overridden: readonly SimEcsKeyValuePair[];
 }
 
 /**
  * The environment one container of a simulated task runs with.
  *
- * It is the container definition's `environment`, with any `RunTask` container
- * override applied over the top, which is the order real ECS applies them in,
+ * It is the container definition's `environment`, with the values its `secrets`
+ * resolved to and then any `RunTask` container override applied over the top,
  * and the Region variables a real task agent adds, so code that reads
  * `AWS_REGION` to build a client finds one.
+ *
+ * A secret and a declared variable of the same name is not something real ECS
+ * documents an answer for. The secret wins here, since a plaintext variable of
+ * the same name is the thing a secret was introduced to replace, and a
+ * `RunTask` override wins over both, since an override is what a caller asked
+ * for at the moment the task was started.
  *
  * The variables are applied to `process.env` for the length of the run, in the
  * same way a sim Lambda function's are: a bound handler is an ordinary closure
@@ -24,6 +31,7 @@ interface SimEcsContainerEnvironmentProperties {
 export class SimEcsContainerEnvironment {
   private readonly regionName: string;
   private readonly declared: readonly SimEcsKeyValuePair[];
+  private readonly secrets: Record<string, string>;
   private readonly overridden: readonly SimEcsKeyValuePair[];
 
   #variables: Record<string, string> | undefined;
@@ -31,6 +39,7 @@ export class SimEcsContainerEnvironment {
   constructor(properties: SimEcsContainerEnvironmentProperties) {
     this.regionName = properties.regionName;
     this.declared = properties.declared;
+    this.secrets = properties.secrets;
     this.overridden = properties.overridden;
   }
 
@@ -54,7 +63,11 @@ export class SimEcsContainerEnvironment {
    * Whether this container has an environment of its own at all.
    */
   get hasVariables(): boolean {
-    return this.declared.length > 0 || this.overridden.length > 0;
+    return (
+      this.declared.length > 0 ||
+      this.overridden.length > 0 ||
+      Object.keys(this.secrets).length > 0
+    );
   }
 
   /**
@@ -80,6 +93,7 @@ export class SimEcsContainerEnvironment {
     this.#variables ??= {
       ...this.regionVariables(),
       ...SimEcsContainerEnvironment.namedValues(this.declared),
+      ...this.secrets,
       ...SimEcsContainerEnvironment.namedValues(this.overridden),
     };
 

--- a/src/service/ecs/task/run/sim-ecs-container-runner.ts
+++ b/src/service/ecs/task/run/sim-ecs-container-runner.ts
@@ -40,6 +40,11 @@ interface SimEcsContainerRunnerProperties {
  * message as its reason, rather than failing the request that started the
  * task. Nothing is watching a `RunTask` call by the time a container fails on
  * real ECS either.
+ *
+ * A container's secrets arrive here already resolved. They were read as the
+ * task execution Role before any container of the task started, so nothing in
+ * this class reads a secret store, and by the time it runs there is nothing
+ * left that could fail on one.
  */
 export class SimEcsContainerRunner {
   private readonly bindings: SimEcsContainerBindings;
@@ -73,12 +78,13 @@ export class SimEcsContainerRunner {
   async run(
     task: SimEcsTask,
     declared: SimEcsContainerDefinition,
+    secrets: Record<string, string>,
   ): Promise<void> {
     const container = task.container(declared.name);
     const bound = this.bindings.find(task.family, declared);
 
     if (bound === undefined) {
-      container.notSimulated(notSimulatedReason);
+      container.neverStarted(notSimulatedReason);
       return;
     }
 
@@ -86,7 +92,7 @@ export class SimEcsContainerRunner {
 
     try {
       await this.asTaskRole(async () => {
-        await this.environmentFor(declared).runWith(async () => {
+        await this.environmentFor(declared, secrets).runWith(async () => {
           await bound.runHandler();
         });
       });
@@ -98,10 +104,12 @@ export class SimEcsContainerRunner {
 
   private environmentFor(
     declared: SimEcsContainerDefinition,
+    secrets: Record<string, string>,
   ): SimEcsContainerEnvironment {
     return new SimEcsContainerEnvironment({
       regionName: this.regionName,
       declared: declared.environment,
+      secrets,
       overridden: this.overrides.environmentFor(declared.name),
     });
   }

--- a/src/service/ecs/task/run/sim-ecs-task-run.type.ts
+++ b/src/service/ecs/task/run/sim-ecs-task-run.type.ts
@@ -1,0 +1,17 @@
+import type { SimEcsTaskDefinition } from "../../task-definition/sim-ecs-task-definition.js";
+import type { SimEcsTask } from "../sim-ecs-task.js";
+import type { SimEcsTaskOverrides } from "./sim-ecs-task-overrides.js";
+
+/**
+ * One run of one simulated ECS task.
+ *
+ * The revision is carried alongside the task rather than looked up from it,
+ * because a task holds the family and revision it came from as text: the run
+ * needs the containers and the Roles that revision declared, and resolving
+ * them again part way through a run could find a different answer.
+ */
+export interface SimEcsTaskRun {
+  readonly task: SimEcsTask;
+  readonly taskDefinition: SimEcsTaskDefinition;
+  readonly overrides: SimEcsTaskOverrides;
+}

--- a/src/service/ecs/task/run/sim-ecs-task-runner.ts
+++ b/src/service/ecs/task/run/sim-ecs-task-runner.ts
@@ -1,10 +1,11 @@
 import type { BackgroundScheduler } from "../../../../util/background/background.js";
 import type { SimAwsRunAsOwner } from "../../../aws/caller/sim-aws-run-as-context.js";
 import type { SimEcsContainerBindings } from "../../bind/sim-ecs-container-bindings.js";
-import type { SimEcsTaskDefinition } from "../../task-definition/sim-ecs-task-definition.js";
-import type { SimEcsTask } from "../sim-ecs-task.js";
+import type { SimEcsResolvedSecrets } from "./secret/sim-ecs-resolved-secrets.js";
+import type { SimEcsSecretStores } from "./secret/sim-ecs-secret-stores.js";
+import { SimEcsTaskSecrets } from "./secret/sim-ecs-task-secrets.js";
 import { SimEcsContainerRunner } from "./sim-ecs-container-runner.js";
-import type { SimEcsTaskOverrides } from "./sim-ecs-task-overrides.js";
+import type { SimEcsTaskRun } from "./sim-ecs-task-run.type.js";
 import { simEcsTaskStopOutcome } from "./sim-ecs-task-stop-outcome.js";
 
 interface SimEcsTaskRunnerProperties {
@@ -12,12 +13,7 @@ interface SimEcsTaskRunnerProperties {
   readonly background: BackgroundScheduler;
   readonly runAsOwner: SimAwsRunAsOwner;
   readonly regionName: string;
-}
-
-interface SimEcsTaskRunProperties {
-  readonly task: SimEcsTask;
-  readonly taskDefinition: SimEcsTaskDefinition;
-  readonly overrides: SimEcsTaskOverrides;
+  readonly secretStores: SimEcsSecretStores;
 }
 
 /**
@@ -32,34 +28,56 @@ interface SimEcsTaskRunProperties {
  * what orders them there; running them in order here keeps what a test sees
  * deterministic, and nothing in this process gains from overlapping in-process
  * handlers.
+ *
+ * The task's container secrets are resolved before any of that, while the task
+ * is still provisioning, which is when a real task agent pulls them. A secret
+ * it cannot read stops the task before it ever reaches `RUNNING`, so no bound
+ * handler runs on a task that was never going to have what it declared.
  */
 export class SimEcsTaskRunner {
   private readonly bindings: SimEcsContainerBindings;
   private readonly background: BackgroundScheduler;
   private readonly runAsOwner: SimAwsRunAsOwner;
   private readonly regionName: string;
+  private readonly secrets: SimEcsTaskSecrets;
 
   constructor(properties: SimEcsTaskRunnerProperties) {
     this.bindings = properties.bindings;
     this.background = properties.background;
     this.runAsOwner = properties.runAsOwner;
     this.regionName = properties.regionName;
+    this.secrets = new SimEcsTaskSecrets({ stores: properties.secretStores });
   }
 
   /**
    * Schedule a task's containers to run, and the task to stop after them.
    */
-  start(properties: SimEcsTaskRunProperties): void {
+  start(properties: SimEcsTaskRun): void {
     this.background.schedule(async () => {
       await this.run(properties);
     });
   }
 
-  private async run(properties: SimEcsTaskRunProperties): Promise<void> {
+  private async run(properties: SimEcsTaskRun): Promise<void> {
     const { task, taskDefinition } = properties;
-    const containerRunner = this.containerRunner(properties);
+    const secrets = await this.secrets.resolve(taskDefinition);
+
+    if (!secrets.isResolved) {
+      task.failToStart(this.background.now(), secrets.failureReason);
+      return;
+    }
 
     task.start(this.background.now());
+    await this.runContainers(properties, secrets);
+    task.stop({ at: this.background.now(), ...simEcsTaskStopOutcome(task) });
+  }
+
+  private async runContainers(
+    properties: SimEcsTaskRun,
+    secrets: SimEcsResolvedSecrets,
+  ): Promise<void> {
+    const { task, taskDefinition } = properties;
+    const containerRunner = this.containerRunner(properties);
 
     for (const declared of taskDefinition.containers.all()) {
       if (task.isStopRequested) {
@@ -69,10 +87,12 @@ export class SimEcsTaskRunner {
       // Containers run in declaration order, so this awaits inside the loop
       // rather than starting them all at once.
       // oxlint-disable-next-line no-await-in-loop
-      await containerRunner.run(task, declared);
+      await containerRunner.run(
+        task,
+        declared,
+        secrets.forContainer(declared.name),
+      );
     }
-
-    task.stop({ at: this.background.now(), ...simEcsTaskStopOutcome(task) });
   }
 
   /**
@@ -82,9 +102,7 @@ export class SimEcsTaskRunner {
    * one, and from the task definition otherwise, which is the order real ECS
    * applies them in.
    */
-  private containerRunner(
-    properties: SimEcsTaskRunProperties,
-  ): SimEcsContainerRunner {
+  private containerRunner(properties: SimEcsTaskRun): SimEcsContainerRunner {
     const { taskDefinition, overrides } = properties;
 
     return new SimEcsContainerRunner({

--- a/src/service/ecs/task/sim-ecs-task-container.ts
+++ b/src/service/ecs/task/sim-ecs-task-container.ts
@@ -93,12 +93,14 @@ export class SimEcsTaskContainer {
   }
 
   /**
-   * Mark this container as one nothing here could run.
+   * Mark this container as one that never started, and say why.
    *
-   * It carries no exit code, because it never started. That is the difference
-   * between a container that ran and exited zero and one Yulin left alone.
+   * Two things get here: a container nothing is bound to, and a container of a
+   * task that could not pull its secrets. Neither carries an exit code, which
+   * is the difference between a container that ran and exited zero and one
+   * whose handler was never called.
    */
-  notSimulated(reason: string): void {
+  neverStarted(reason: string): void {
     this.#lastStatus = "STOPPED";
     this.#reason = reason;
   }

--- a/src/service/ecs/task/sim-ecs-task.ts
+++ b/src/service/ecs/task/sim-ecs-task.ts
@@ -113,6 +113,22 @@ export class SimEcsTask {
   }
 
   /**
+   * Stop this task without it ever having started its containers.
+   *
+   * A secret the task could not pull is what does this. The whole task carries
+   * the reason and so does every container, because a real resource
+   * initialization error happens while the task is still provisioning rather
+   * than to one container of it.
+   */
+  failToStart(at: Date, reason: string): void {
+    for (const container of this.containers) {
+      container.neverStarted(reason);
+    }
+
+    this.stop({ at, stopCode: "TaskFailedToStart", reason });
+  }
+
+  /**
    * Mark this task stopped, keeping any reason already recorded for it.
    */
   stop(stopped: SimEcsTaskStop): void {


### PR DESCRIPTION
A container definition's `secrets` are now resolved when a task starts, from simulated Secrets Manager or simulated SSM Parameter Store according to the ARN each one names, and the values appear in the container's environment alongside its declared `environment` so a handler reads them through `process.env`. Reading goes through each store's ordinary command path as the task definition's `executionRoleArn` rather than its `taskRoleArn`, which is the split real ECS makes, so simulated IAM decides it and a role allowed one is not thereby allowed the other. A secret that cannot be resolved, because it does not exist, because the execution role may not read it, or because the definition declares no execution role, stops the task before any container runs with a `ResourceInitializationError` reason naming the variable. A Secrets Manager `valueFrom` may select a JSON key, and a key holding anything other than a string is refused rather than converted, since an environment variable is text and real ECS does not document what text a number or a nested object would become.

Resolves https://github.com/KensioSoftware/yulin/issues/555

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ECS container secret injection from simulated Secrets Manager and SSM Parameter Store.
  * Supports name- and ARN-based references, secure parameters, version selectors, and JSON key extraction.
  * Secrets use the task execution role and take precedence over declared environment variables; run-task overrides remain highest priority.
  * Tasks fail before container startup when secrets are missing, invalid, inaccessible, or unsupported.
* **Documentation**
  * Added configuration guidance, limitations, and a runnable container-secret example.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->