### PR TITLE
feat: match ALB listener rules on host and path

### DIFF
--- a/docs/services/elbv2/README.md
+++ b/docs/services/elbv2/README.md
@@ -7,8 +7,8 @@ subpath.
 
 A load balancer created here has a DNS name of the shape real ELB issues, so a
 [Route53](../route53/) alias or a [CloudFront](../cloudfront/) origin has something of the right form
-to point at. It also carries a request: a request is matched to a listener by port, and the
-listener's default `forward` action sends it to a target group, where a registered
+to point at. It also carries a request: a request is matched to a listener by port and then to one of
+that listener's rules, and a `forward` action sends it to a target group, where a registered
 [Lambda](../lambda/) function is invoked with the request and its response becomes the HTTP
 response.
 
@@ -187,9 +187,6 @@ on one listener cannot hold the same priority.
 ```typescript sim-elbv2-listener-rules
 /**
  * A listener and a rule sending one host name to a different target group.
- *
- * The rule is stored rather than applied: nothing matches a request against it
- * yet.
  */
 
 import {
@@ -259,10 +256,12 @@ const rules = await elbV2.describeRules(
 console.log(rules.Rules?.map((rule) => rule.Priority)); // ["10", "default"]
 ```
 
-Conditions are held rather than matched, so a request is not routed by them yet. What is checked when
-a rule is written is that it could match something: the field has to be one an Application Load
-Balancer understands, and it has to have values to compare against. A forward action naming a target
-group that was never created is refused for the same reason.
+Conditions are `host-header` and `path-pattern`. What is checked when a rule is written is that it
+could match something: the field has to be one of those two, and it has to have values to compare
+against. A forward action naming a target group that was never created is refused for the same
+reason. The other four condition fields real ELB has are refused, rather than stored and then never
+matched. [Matching a request against the rules](#matching-a-request-against-the-rules) covers how the
+values are compared.
 
 `ModifyRule` changes a rule's conditions and actions but not its priority, as on real ELB. Moving
 rules about is `SetRulePriorities`, which reorders a whole listener, and which judges a request
@@ -275,8 +274,9 @@ places in one request.
 without a socket. The port in the URL is the listener's, so `http://<dns-name>/orders` reaches the
 listener on port 80.
 
-The listener's default action decides what happens next. A `forward` action sends the request to its
-target group, and a `lambda` target group invokes the function registered in it.
+The listener then evaluates its rules, and the first one to claim the request says what happens to
+it. A request no rule claims is answered by the listener's default action. A `forward` action sends
+the request to its target group, and a `lambda` target group invokes the function registered in it.
 
 ```typescript sim-elbv2-serve-lambda-target
 /**
@@ -367,6 +367,230 @@ console.log(response.status); // 200
 console.log(response.statusText); // "OK"
 console.log(await response.json()); // { path: "/orders", method: "GET" }
 ```
+
+### Matching a request against the rules
+
+Rules are evaluated in priority order, lowest number first, and the first one whose conditions all
+hold claims the request. A rule later in the order that would also have matched never sees it. A
+request no rule claims falls through to the listener's default action.
+
+A rule with more than one condition claims a request only when every one of them holds. Within one
+condition, a list of values is satisfied when any one of them matches.
+
+Both fields support the two wildcards real ELB has, `*` for zero or more characters and `?` for
+exactly one, and both compare the pattern against the whole value rather than looking for it inside
+one. That last part is the one worth knowing, because a pattern can read as though it covers
+something it does not:
+
+- `/api/*` claims `/api/orders` and `/api/v1/orders`, and does not claim `/api`. The pattern has a
+  slash the bare path does not. Real ELB behaves the same way, which is why a rule meant to cover
+  both is written as `["/api", "/api/*"]`.
+- `*.example.com` claims `admin.example.com` and `a.b.example.com`, and does not claim
+  `example.com`, for the same reason.
+- `*` covers slashes and dots, so `/api/*` claims paths any number of segments deep.
+
+A path pattern is compared with regard to case and a host name without, as on real ELB. A path
+pattern is compared against the path alone, so a query string is not part of it.
+
+```typescript sim-elbv2-serve-listener-rules
+/**
+ * An application split across two services by path, with the rules matched
+ * when a request arrives.
+ */
+
+import {
+  CreateListenerCommand,
+  CreateLoadBalancerCommand,
+  CreateRuleCommand,
+  CreateTargetGroupCommand,
+  RegisterTargetsCommand,
+} from "@aws-sdk/client-elastic-load-balancing-v2";
+import {
+  AddPermissionCommand,
+  CreateFunctionCommand,
+} from "@aws-sdk/client-lambda";
+
+import { SimAws } from "@kensio/yulin";
+import type { SimElbV2Result } from "@kensio/yulin/elbv2";
+import { simElbV2Fetch, simElbV2ServicePrincipal } from "@kensio/yulin/elbv2";
+import { makeLambdaZipFileInput } from "@kensio/yulin/lambda";
+
+const simAws = new SimAws();
+const elbV2 = simAws.elbV2();
+const lambda = simAws.lambda();
+
+/**
+ * Create a function answering with its own name, a target group holding it,
+ * and the permission the load balancer needs to invoke it.
+ */
+async function makeTargetGroup(name: string): Promise<string> {
+  const created = await lambda.createFunction(
+    new CreateFunctionCommand({
+      FunctionName: name,
+      Role: `arn:aws:iam::888888888888:role/${name}-role`,
+      Code: {
+        ZipFile: makeLambdaZipFileInput((): SimElbV2Result => ({
+          statusCode: 200,
+          body: name,
+        })),
+      },
+    }),
+  );
+
+  const group = await elbV2.createTargetGroup(
+    new CreateTargetGroupCommand({ Name: `${name}-tg`, TargetType: "lambda" }),
+  );
+  const groupArn = group.TargetGroups?.[0]?.TargetGroupArn;
+
+  await lambda.addPermission(
+    new AddPermissionCommand({
+      FunctionName: name,
+      StatementId: "elb-invoke",
+      Action: "lambda:InvokeFunction",
+      Principal: simElbV2ServicePrincipal,
+      SourceArn: groupArn,
+    }),
+  );
+  await elbV2.registerTargets(
+    new RegisterTargetsCommand({
+      TargetGroupArn: groupArn,
+      Targets: [{ Id: created.FunctionArn }],
+    }),
+  );
+
+  return groupArn ?? "";
+}
+
+const web = await makeTargetGroup("web");
+const api = await makeTargetGroup("api");
+
+const loadBalancer = await elbV2.createLoadBalancer(
+  new CreateLoadBalancerCommand({ Name: "shop-alb" }),
+);
+const listener = await elbV2.createListener(
+  new CreateListenerCommand({
+    LoadBalancerArn: loadBalancer.LoadBalancers?.[0]?.LoadBalancerArn,
+    Protocol: "HTTP",
+    Port: 80,
+    DefaultActions: [{ Type: "forward", TargetGroupArn: web }],
+  }),
+);
+
+await elbV2.createRule(
+  new CreateRuleCommand({
+    ListenerArn: listener.Listeners?.[0]?.ListenerArn,
+    Priority: 10,
+    Conditions: [{ Field: "path-pattern", Values: ["/api/*"] }],
+    Actions: [{ Type: "forward", TargetGroupArn: api }],
+  }),
+);
+
+const dnsName = loadBalancer.LoadBalancers?.[0]?.DNSName ?? "";
+
+const toApi = await simElbV2Fetch(simAws, `http://${dnsName}/api/orders`);
+console.log(await toApi.text()); // "api"
+
+// The pattern has a slash the bare path does not, so this request is not one
+// the rule claims, and the listener's default action answers it.
+const toWeb = await simElbV2Fetch(simAws, `http://${dnsName}/api`);
+console.log(await toWeb.text()); // "web"
+```
+
+A `host-header` condition is matched against the request's Host header, falling back to the host name
+in the URL when the request carries none. On real AWS those are the same thing, since DNS is what
+brought the request to the load balancer. Here a request reaches one at its own DNS name, so sending
+a Host header is how a test says which name the client asked for. Any port in the header is left out
+of the comparison, since a condition value cannot carry one.
+
+### Answering without a target
+
+A `fixed-response` action answers with the status, content type and body it holds, and a `redirect`
+action answers with a status and a `Location`. Neither touches a target group, so a listener holding
+one serves with nothing registered behind it.
+
+```typescript sim-elbv2-serve-fixed-response
+/**
+ * A health endpoint and an HTTP to HTTPS redirect, neither of which needs a
+ * target group.
+ */
+
+import {
+  CreateListenerCommand,
+  CreateLoadBalancerCommand,
+  CreateRuleCommand,
+} from "@aws-sdk/client-elastic-load-balancing-v2";
+
+import { SimAws } from "@kensio/yulin";
+import { simElbV2Fetch } from "@kensio/yulin/elbv2";
+
+const simAws = new SimAws();
+const elbV2 = simAws.elbV2();
+
+const loadBalancer = await elbV2.createLoadBalancer(
+  new CreateLoadBalancerCommand({ Name: "shop-alb" }),
+);
+
+// Nothing is registered behind this listener, and nothing needs to be: both
+// actions are answered by the load balancer itself.
+const listener = await elbV2.createListener(
+  new CreateListenerCommand({
+    LoadBalancerArn: loadBalancer.LoadBalancers?.[0]?.LoadBalancerArn,
+    Protocol: "HTTP",
+    Port: 80,
+    DefaultActions: [
+      {
+        Type: "redirect",
+        RedirectConfig: {
+          Protocol: "HTTPS",
+          Port: "443",
+          StatusCode: "HTTP_301",
+        },
+      },
+    ],
+  }),
+);
+
+await elbV2.createRule(
+  new CreateRuleCommand({
+    ListenerArn: listener.Listeners?.[0]?.ListenerArn,
+    Priority: 10,
+    Conditions: [{ Field: "path-pattern", Values: ["/health"] }],
+    Actions: [
+      {
+        Type: "fixed-response",
+        FixedResponseConfig: {
+          StatusCode: "200",
+          ContentType: "application/json",
+          MessageBody: '{"ok":true}',
+        },
+      },
+    ],
+  }),
+);
+
+const dnsName = loadBalancer.LoadBalancers?.[0]?.DNSName ?? "";
+
+const health = await simElbV2Fetch(simAws, `http://${dnsName}/health`);
+console.log(health.status); // 200
+console.log(await health.text()); // '{"ok":true}'
+
+const redirected = await simElbV2Fetch(simAws, `http://${dnsName}/orders`, {
+  headers: { host: "shop.example.com" },
+});
+console.log(redirected.status); // 301
+console.log(redirected.headers.get("location"));
+// "https://shop.example.com:443/orders"
+```
+
+A redirect keeps the components it does not name, and the five reserved keywords put a component back
+where one is named: `#{protocol}`, `#{host}`, `#{port}`, `#{path}` and `#{query}`. `#{path}` comes
+without its leading slash, which is why a redirect keeping the path writes it as `/#{path}`, and
+`#{query}` comes without its leading question mark, which the load balancer adds. A redirect that
+changes none of the protocol, host, port or path is refused when it is written, since it would
+redirect to the request's own URI.
+
+The port is always in the `Location`, including when it is the protocol's own. A redirect to HTTPS on
+443 therefore answers with a `Location` ending `:443`, which is what real ELB sends.
 
 ### The event and the response
 
@@ -716,12 +940,16 @@ console.log(created.LoadBalancers?.[0]?.DNSName);
 - `CreateListener`, `DescribeListeners`, `ModifyListener` and `DeleteListener`, on HTTP and HTTPS.
 - `CreateRule`, `DescribeRules`, `ModifyRule`, `DeleteRule` and `SetRulePriorities`, with priorities
   unique within a listener and the listener's default rule reported last.
-- `forward`, `fixed-response` and `redirect` actions, and `host-header`, `path-pattern`,
-  `http-header`, `http-request-method`, `query-string` and `source-ip` conditions. A condition is
-  read through its own field's configuration, so one carrying another field's is refused.
+- `forward`, `fixed-response` and `redirect` actions, and `host-header` and `path-pattern`
+  conditions. A condition is read through its own field's configuration, so one carrying another
+  field's is refused.
 - Paged describes with `PageSize` and `Marker`.
-- Carrying a request through `simElbV2Fetch`: a listener matched by port, its default `forward`
-  action, and a `lambda` target group invoking its function with an ALB-shaped event.
+- Carrying a request through `simElbV2Fetch`: a listener matched by port, its rules evaluated in
+  priority order with the first match winning, and a fall through to the default action.
+- `host-header` and `path-pattern` matching with ELB's own wildcard semantics, and a rule claiming a
+  request only when all of its conditions hold.
+- `forward` to a `lambda` target group, which invokes its function with an ALB-shaped event, and the
+  `fixed-response` and `redirect` actions, which the load balancer answers itself.
 - The load balancer's own 503, 502 and 413, and the invoke permission the function's resource policy
   has to grant `elasticloadbalancing.amazonaws.com`.
 - IAM authorization against the ARN of whatever an operation names.
@@ -729,11 +957,22 @@ console.log(created.LoadBalancers?.[0]?.DNSName);
 
 ## Limitations
 
-- Only a listener's default action carries a request. Listener rules are stored and are not matched
-  against a request, so every request a listener takes is answered by its default action.
-- Only a `forward` action to a `lambda` target group is performed. A `fixed-response` or `redirect`
-  default action, an `ip` target group, and a `ForwardConfig` naming several target groups by weight
-  are each refused when the request arrives rather than answered with something else.
+- Only `host-header` and `path-pattern` conditions exist. The `http-header`, `http-request-method`,
+  `query-string` and `source-ip` fields real ELB has are refused when the rule is written, rather
+  than stored and then never matching, which would leave a rule that looks configured and claims
+  nothing. Regular expression condition values, which real ELB takes in `RegexValues`, are not
+  matched either.
+- A `host-header` condition is matched against the request's Host header, falling back to the host
+  name in the URL. On real AWS those are the same thing, because DNS is what brought the request to
+  the load balancer, and here a request reaches one at its own DNS name.
+- A `forward` action is carried out only to a `lambda` target group. An `ip` target group and a
+  `ForwardConfig` naming several target groups by weight are each refused when the request arrives
+  rather than answered with something else.
+- A redirect is not checked against the listener it is on, so redirecting HTTPS to HTTP is accepted
+  where real ELB refuses it. Nothing here performs TLS, so the listener's protocol is not something a
+  request can be trusted to have arrived over.
+- The length limits real ELB puts on a condition value, a fixed response's message body and a
+  redirect's components are not enforced.
 - A request only reaches a load balancer through `simElbV2Fetch`. Nothing resolves a load balancer's
   DNS name yet, so `serveSimAws` does not serve one and a Route53 alias to one does not answer.
 - No TLS is performed. `simElbV2Fetch` reads only the port out of a URL, so an `https:` URL reaches

--- a/docs/services/elbv2/README.md
+++ b/docs/services/elbv2/README.md
@@ -971,8 +971,8 @@ console.log(created.LoadBalancers?.[0]?.DNSName);
 - A redirect is not checked against the listener it is on, so redirecting HTTPS to HTTP is accepted
   where real ELB refuses it. Nothing here performs TLS, so the listener's protocol is not something a
   request can be trusted to have arrived over.
-- The length limits real ELB puts on a condition value, a fixed response's message body and a
-  redirect's components are not enforced.
+- The length limits real ELB puts on a fixed response's message body and a redirect's components are
+  not enforced. A condition value is held to ELB's own 128 characters.
 - A request only reaches a load balancer through `simElbV2Fetch`. Nothing resolves a load balancer's
   DNS name yet, so `serveSimAws` does not serve one and a Route53 alias to one does not answer.
 - No TLS is performed. `simElbV2Fetch` reads only the port out of a URL, so an `https:` URL reaches

--- a/docs/services/elbv2/sim-elbv2-listener-rules.example.ts
+++ b/docs/services/elbv2/sim-elbv2-listener-rules.example.ts
@@ -1,8 +1,5 @@
 /**
  * A listener and a rule sending one host name to a different target group.
- *
- * The rule is stored rather than applied: nothing matches a request against it
- * yet.
  */
 
 import {

--- a/docs/services/elbv2/sim-elbv2-serve-fixed-response.example.ts
+++ b/docs/services/elbv2/sim-elbv2-serve-fixed-response.example.ts
@@ -1,0 +1,71 @@
+/**
+ * A health endpoint and an HTTP to HTTPS redirect, neither of which needs a
+ * target group.
+ */
+
+import {
+  CreateListenerCommand,
+  CreateLoadBalancerCommand,
+  CreateRuleCommand,
+} from "@aws-sdk/client-elastic-load-balancing-v2";
+
+import { SimAws } from "@kensio/yulin";
+import { simElbV2Fetch } from "@kensio/yulin/elbv2";
+
+const simAws = new SimAws();
+const elbV2 = simAws.elbV2();
+
+const loadBalancer = await elbV2.createLoadBalancer(
+  new CreateLoadBalancerCommand({ Name: "shop-alb" }),
+);
+
+// Nothing is registered behind this listener, and nothing needs to be: both
+// actions are answered by the load balancer itself.
+const listener = await elbV2.createListener(
+  new CreateListenerCommand({
+    LoadBalancerArn: loadBalancer.LoadBalancers?.[0]?.LoadBalancerArn,
+    Protocol: "HTTP",
+    Port: 80,
+    DefaultActions: [
+      {
+        Type: "redirect",
+        RedirectConfig: {
+          Protocol: "HTTPS",
+          Port: "443",
+          StatusCode: "HTTP_301",
+        },
+      },
+    ],
+  }),
+);
+
+await elbV2.createRule(
+  new CreateRuleCommand({
+    ListenerArn: listener.Listeners?.[0]?.ListenerArn,
+    Priority: 10,
+    Conditions: [{ Field: "path-pattern", Values: ["/health"] }],
+    Actions: [
+      {
+        Type: "fixed-response",
+        FixedResponseConfig: {
+          StatusCode: "200",
+          ContentType: "application/json",
+          MessageBody: '{"ok":true}',
+        },
+      },
+    ],
+  }),
+);
+
+const dnsName = loadBalancer.LoadBalancers?.[0]?.DNSName ?? "";
+
+const health = await simElbV2Fetch(simAws, `http://${dnsName}/health`);
+console.log(health.status); // 200
+console.log(await health.text()); // '{"ok":true}'
+
+const redirected = await simElbV2Fetch(simAws, `http://${dnsName}/orders`, {
+  headers: { host: "shop.example.com" },
+});
+console.log(redirected.status); // 301
+console.log(redirected.headers.get("location"));
+// "https://shop.example.com:443/orders"

--- a/docs/services/elbv2/sim-elbv2-serve-listener-rules.example.ts
+++ b/docs/services/elbv2/sim-elbv2-serve-listener-rules.example.ts
@@ -1,0 +1,101 @@
+/**
+ * An application split across two services by path, with the rules matched
+ * when a request arrives.
+ */
+
+import {
+  CreateListenerCommand,
+  CreateLoadBalancerCommand,
+  CreateRuleCommand,
+  CreateTargetGroupCommand,
+  RegisterTargetsCommand,
+} from "@aws-sdk/client-elastic-load-balancing-v2";
+import {
+  AddPermissionCommand,
+  CreateFunctionCommand,
+} from "@aws-sdk/client-lambda";
+
+import { SimAws } from "@kensio/yulin";
+import type { SimElbV2Result } from "@kensio/yulin/elbv2";
+import { simElbV2Fetch, simElbV2ServicePrincipal } from "@kensio/yulin/elbv2";
+import { makeLambdaZipFileInput } from "@kensio/yulin/lambda";
+
+const simAws = new SimAws();
+const elbV2 = simAws.elbV2();
+const lambda = simAws.lambda();
+
+/**
+ * Create a function answering with its own name, a target group holding it,
+ * and the permission the load balancer needs to invoke it.
+ */
+async function makeTargetGroup(name: string): Promise<string> {
+  const created = await lambda.createFunction(
+    new CreateFunctionCommand({
+      FunctionName: name,
+      Role: `arn:aws:iam::888888888888:role/${name}-role`,
+      Code: {
+        ZipFile: makeLambdaZipFileInput((): SimElbV2Result => ({
+          statusCode: 200,
+          body: name,
+        })),
+      },
+    }),
+  );
+
+  const group = await elbV2.createTargetGroup(
+    new CreateTargetGroupCommand({ Name: `${name}-tg`, TargetType: "lambda" }),
+  );
+  const groupArn = group.TargetGroups?.[0]?.TargetGroupArn;
+
+  await lambda.addPermission(
+    new AddPermissionCommand({
+      FunctionName: name,
+      StatementId: "elb-invoke",
+      Action: "lambda:InvokeFunction",
+      Principal: simElbV2ServicePrincipal,
+      SourceArn: groupArn,
+    }),
+  );
+  await elbV2.registerTargets(
+    new RegisterTargetsCommand({
+      TargetGroupArn: groupArn,
+      Targets: [{ Id: created.FunctionArn }],
+    }),
+  );
+
+  return groupArn ?? "";
+}
+
+const web = await makeTargetGroup("web");
+const api = await makeTargetGroup("api");
+
+const loadBalancer = await elbV2.createLoadBalancer(
+  new CreateLoadBalancerCommand({ Name: "shop-alb" }),
+);
+const listener = await elbV2.createListener(
+  new CreateListenerCommand({
+    LoadBalancerArn: loadBalancer.LoadBalancers?.[0]?.LoadBalancerArn,
+    Protocol: "HTTP",
+    Port: 80,
+    DefaultActions: [{ Type: "forward", TargetGroupArn: web }],
+  }),
+);
+
+await elbV2.createRule(
+  new CreateRuleCommand({
+    ListenerArn: listener.Listeners?.[0]?.ListenerArn,
+    Priority: 10,
+    Conditions: [{ Field: "path-pattern", Values: ["/api/*"] }],
+    Actions: [{ Type: "forward", TargetGroupArn: api }],
+  }),
+);
+
+const dnsName = loadBalancer.LoadBalancers?.[0]?.DNSName ?? "";
+
+const toApi = await simElbV2Fetch(simAws, `http://${dnsName}/api/orders`);
+console.log(await toApi.text()); // "api"
+
+// The pattern has a slash the bare path does not, so this request is not one
+// the rule claims, and the listener's default action answers it.
+const toWeb = await simElbV2Fetch(simAws, `http://${dnsName}/api`);
+console.log(await toWeb.text()); // "web"

--- a/src/service/elbv2/README.md
+++ b/src/service/elbv2/README.md
@@ -46,10 +46,18 @@ configured and route nowhere. A request naming no type at all is refused too, be
 defaults it to `instance`.
 
 `SimElbV2Action` and `SimElbV2RuleCondition` hold what a listener or rule would do and what it would
-match, and neither performs it. What they own is that what is stored is something a real load
-balancer would have accepted: a forward action names a target group that exists, a fixed-response
-action has a status code, and a condition is on a field with something to compare against. Each is
-checked when the rule is written rather than when a request arrives.
+match. What they own is that what is stored is something a real load balancer would have accepted: a
+forward action names a target group that exists, a fixed-response action has a status code, and a
+condition is on a field with something to compare against. Each is checked when the rule is written
+rather than when a request arrives.
+
+A condition is read once, when the rule is written, and what comes out of it is a
+`SimElbV2ConditionMatcher` under `listener/rule/match/`, one implementation per field. That is why
+nothing branches on which field a condition was written on once the rule exists, and why a field this
+does not match on is refused there rather than stored: a rule that looks configured and never claims
+a request is the worst of the three outcomes. `SimElbV2WildcardPattern` is the whole of ELB's pattern
+language, which is `*` and `?` compared against the whole value, and keeping it in one class is what
+makes the case sensitivity the only difference between a host name and a path.
 
 `SimElbV2ListenerRuleStore` owns priority uniqueness, because it is a property of a listener's whole
 set of rules rather than of any one rule. `SetRulePriorities` judges a request against the order it
@@ -94,12 +102,21 @@ is refused at runtime with an explanation rather than by the type checker with n
   group to the function registered in it. Neither hop is local: a DNS name says nothing about the
   Account, which is what `registry/sim-elbv2-registry.ts` answers, and a function is looked for in
   the target group's own Account and Region, which is where real ELB requires a Lambda target to be.
-- `sim-elbv2-controller.ts` matches the port to a listener. A port no listener holds throws rather
-  than answering, because on real AWS the connection is refused and there is no status to send.
-- `sim-elbv2-forward-target.ts` performs the listener's default action, which so far means a
-  `forward` to a `lambda` target group. Everything else it could hold is refused here rather than
-  answered with something else, because a load balancer that forwards a request its configuration
-  said to redirect is worse than one that says it cannot.
+- `sim-elbv2-controller.ts` and `sim-elbv2-listener-match.ts` match the port to a listener. A port no
+  listener holds throws rather than answering, because on real AWS the connection is refused and
+  there is no status to send.
+- `sim-elbv2-rule-evaluation.ts` picks the action answering the request. Rules are evaluated in
+  priority order and the first match wins, and a request no rule claims falls through to the
+  listener's default action. What comes out carries the rule or listener it came from, so a refusal
+  can name the thing a reader has to go and change.
+- `sim-elbv2-action-performer.ts` carries that action out. A fixed response and a redirect need no
+  target and are written by the load balancer itself, which is why a listener holding one serves with
+  nothing registered behind it. `sim-elbv2-redirect-location.ts` is separate because building the URI
+  is where the reserved keywords and the components a redirect leaves alone live.
+- `sim-elbv2-forward-target.ts` gets from a `forward` action to the target group it names, which so
+  far has to be a `lambda` one. What it cannot carry out is refused here rather than answered with
+  something else, because a load balancer that quietly sends a request somewhere its configuration
+  did not say is worse than one that says it cannot.
 - `sim-elbv2-lambda-target-invocation.ts` owns what the load balancer answers itself. An empty target
   group is a 503 and everything after that is a 502, which is the same collapse real ELB makes: the
   difference between a missing permission, a missing function and a thrown handler is only in the
@@ -149,6 +166,13 @@ There is no resource policy support here, and none to add: ELBv2 has none on rea
 - A listener or rule takes exactly one action. Real ELB takes one routing action with an optional
   authentication action before it, and neither authentication action is simulated, so a longer list
   is refused rather than half honoured.
+- Only `host-header` and `path-pattern` conditions exist here. The other four fields real ELB has are
+  refused when the rule is written, since a stored condition nothing matches would leave a rule that
+  looks configured and never claims a request.
+- A rule is matched against the request's own Host header, falling back to the host name in the URL.
+  On real AWS those are the same thing, because DNS is what brought the request to the load balancer.
+  Here a request reaches one at its own DNS name, so sending a Host header is how a test says which
+  name the client asked for.
 - What a request carries in is copied when it is stored, so a caller mutating the command input it
   sent cannot change a listener or rule afterwards. Real ELB reads the request off the wire and is
   immune to that by construction.

--- a/src/service/elbv2/action/sim-elbv2-action.iso.test.ts
+++ b/src/service/elbv2/action/sim-elbv2-action.iso.test.ts
@@ -167,4 +167,130 @@ describe("sim ELBv2 actions", () => {
     assertStringIncludes(fixedResponse.message, "2XX, 4XX or 5XX");
     assertStringIncludes(redirect.message, "HTTP_301 or HTTP_302");
   });
+
+  it("refuses a content type a fixed response will not be sent as", () => {
+    // Given a fixed response naming a content type ELB does not send.
+    const error = assertThrowsError(() => {
+      SimElbV2Action.read(
+        {
+          Type: "fixed-response",
+          FixedResponseConfig: {
+            StatusCode: "200",
+            ContentType: "image/png",
+          },
+        },
+        "Actions",
+      );
+    });
+
+    // Then it is refused: the action is for a short answer the load balancer
+    // writes itself, and the list of types ELB will send is short with it.
+    assertInstanceOf(error, SimElbV2ValidationError);
+    assertStringIncludes(error.message, "image/png");
+  });
+
+  it("refuses a redirect component ELB would not take", () => {
+    // Given redirects naming a protocol, port and path outside what ELB takes.
+    const protocol = assertThrowsError(() => {
+      SimElbV2Action.read(
+        {
+          Type: "redirect",
+          RedirectConfig: { StatusCode: "HTTP_301", Protocol: "FTP" },
+        },
+        "Actions",
+      );
+    });
+
+    assertInstanceOf(protocol, SimElbV2ValidationError);
+
+    const port = assertThrowsError(() => {
+      SimElbV2Action.read(
+        {
+          Type: "redirect",
+          RedirectConfig: { StatusCode: "HTTP_301", Port: "99999" },
+        },
+        "Actions",
+      );
+    });
+
+    assertInstanceOf(port, SimElbV2ValidationError);
+
+    const path = assertThrowsError(() => {
+      SimElbV2Action.read(
+        {
+          Type: "redirect",
+          RedirectConfig: { StatusCode: "HTTP_301", Path: "moved/#{path}" },
+        },
+        "Actions",
+      );
+    });
+
+    assertInstanceOf(path, SimElbV2ValidationError);
+
+    // Then each is refused when the rule is written.
+    assertStringIncludes(protocol.message, "HTTP, HTTPS or #{protocol}");
+    assertStringIncludes(port.message, "1 to 65535");
+    assertStringIncludes(path.message, "must start with a '/'");
+  });
+
+  it("takes the keywords a redirect reuses the request's own parts with", () => {
+    // Given a redirect keeping every component but the host.
+    const action = SimElbV2Action.read(
+      {
+        Type: "redirect",
+        RedirectConfig: {
+          StatusCode: "HTTP_302",
+          Protocol: "#{protocol}",
+          Host: "new.#{host}",
+          Port: "#{port}",
+          Path: "/#{path}",
+          Query: "#{query}",
+        },
+      },
+      "Actions",
+    );
+
+    // Then it is accepted, since the host is a change and the rest of the URI
+    // being kept is what the keywords are for.
+    assertIdentical(action.redirect?.Host, "new.#{host}");
+  });
+
+  it("refuses a redirect that changes no part of the request URI", () => {
+    // Given a redirect naming only the query string, and one naming every
+    // other component as the request's own.
+    const queryOnly = assertThrowsError(() => {
+      SimElbV2Action.read(
+        {
+          Type: "redirect",
+          RedirectConfig: { StatusCode: "HTTP_301", Query: "moved=1" },
+        },
+        "Actions",
+      );
+    });
+
+    assertInstanceOf(queryOnly, SimElbV2ValidationError);
+
+    const unchanged = assertThrowsError(() => {
+      SimElbV2Action.read(
+        {
+          Type: "redirect",
+          RedirectConfig: {
+            StatusCode: "HTTP_301",
+            Protocol: "#{protocol}",
+            Host: "#{host}",
+            Port: "#{port}",
+            Path: "/#{path}",
+          },
+        },
+        "Actions",
+      );
+    });
+
+    assertInstanceOf(unchanged, SimElbV2ValidationError);
+
+    // Then both are refused, because a redirect to the request's own URI is a
+    // loop, and real ELB requires the protocol, host, port or path to change.
+    assertStringIncludes(queryOnly.message, "redirects to itself");
+    assertStringIncludes(unchanged.message, "redirects to itself");
+  });
 });

--- a/src/service/elbv2/action/sim-elbv2-action.ts
+++ b/src/service/elbv2/action/sim-elbv2-action.ts
@@ -1,11 +1,15 @@
 import type {
   SimElbV2ActionInput,
   SimElbV2ActionView,
+  SimElbV2FixedResponseActionConfig,
+  SimElbV2RedirectActionConfig,
 } from "../command/sim-elbv2-shared.command.js";
 import {
   SimElbV2UnsimulatedInputException,
   SimElbV2ValidationError,
 } from "../error/sim-elbv2.error.js";
+import { requireSimElbV2FixedResponseConfig } from "./sim-elbv2-fixed-response-config.js";
+import { requireSimElbV2RedirectConfig } from "./sim-elbv2-redirect-config.js";
 
 /**
  * The action types an Application Load Balancer listener or rule can hold
@@ -17,19 +21,6 @@ import {
  * than treated as a forward that quietly skips authentication.
  */
 const simulatedActionTypes = new Set(["forward", "fixed-response", "redirect"]);
-
-/**
- * The status codes real ELB takes on a redirect action.
- */
-const redirectStatusCodes = new Set(["HTTP_301", "HTTP_302"]);
-
-/**
- * The status codes real ELB takes on a fixed-response action.
- *
- * A 3XX is missing on purpose rather than by oversight: redirecting is the
- * redirect action's job, and real ELB refuses one here.
- */
-const fixedResponseStatusCodes = /^[245]\d\d$/u;
 
 /**
  * The target groups a forward action names, whichever form it names them in.
@@ -125,6 +116,16 @@ export class SimElbV2Action {
     return action;
   }
 
+  /** What a fixed-response action answers with. */
+  get fixedResponse(): SimElbV2FixedResponseActionConfig | undefined {
+    return this.input.FixedResponseConfig;
+  }
+
+  /** Where a redirect action sends the client. */
+  get redirect(): SimElbV2RedirectActionConfig | undefined {
+    return this.input.RedirectConfig;
+  }
+
   /**
    * Report this action in the shape the SDK reads it back in.
    */
@@ -146,11 +147,11 @@ export class SimElbV2Action {
     }
 
     if (this.type === "fixed-response") {
-      this.validateFixedResponse(field);
+      requireSimElbV2FixedResponseConfig(this.fixedResponse, field);
       return;
     }
 
-    this.validateRedirect(field);
+    requireSimElbV2RedirectConfig(this.redirect, field);
   }
 
   private validateForward(field: string): void {
@@ -158,30 +159,6 @@ export class SimElbV2Action {
       throw new SimElbV2ValidationError(
         `${field} forward action requires a TargetGroupArn or a ` +
           `ForwardConfig naming at least one target group`,
-      );
-    }
-  }
-
-  private validateFixedResponse(field: string): void {
-    const statusCode = this.input.FixedResponseConfig?.StatusCode;
-
-    if (
-      statusCode === undefined ||
-      !fixedResponseStatusCodes.test(statusCode)
-    ) {
-      throw new SimElbV2ValidationError(
-        `${field} fixed-response action requires a FixedResponseConfig ` +
-          `StatusCode of 2XX, 4XX or 5XX. A 3XX code is a redirect action.`,
-      );
-    }
-  }
-
-  private validateRedirect(field: string): void {
-    const statusCode = this.input.RedirectConfig?.StatusCode;
-
-    if (statusCode === undefined || !redirectStatusCodes.has(statusCode)) {
-      throw new SimElbV2ValidationError(
-        `${field} redirect action requires a RedirectConfig StatusCode of ${[...redirectStatusCodes].join(" or ")}`,
       );
     }
   }

--- a/src/service/elbv2/action/sim-elbv2-fixed-response-config.ts
+++ b/src/service/elbv2/action/sim-elbv2-fixed-response-config.ts
@@ -1,0 +1,51 @@
+import type { SimElbV2FixedResponseActionConfig } from "../command/sim-elbv2-shared.command.js";
+import { SimElbV2ValidationError } from "../error/sim-elbv2.error.js";
+
+/**
+ * The status codes real ELB takes on a fixed-response action.
+ *
+ * A 3XX is missing on purpose rather than by oversight: redirecting is the
+ * redirect action's job, and real ELB refuses one here.
+ */
+const statusCodes = /^[245]\d\d$/u;
+
+/**
+ * The content types real ELB will send a fixed response as.
+ *
+ * The list is short because the action is for a short answer the load balancer
+ * writes itself, such as a health endpoint or a maintenance page, rather than
+ * for serving content.
+ */
+const contentTypes = new Set([
+  "text/plain",
+  "text/css",
+  "text/html",
+  "application/javascript",
+  "application/json",
+]);
+
+/**
+ * Check a fixed-response configuration, refusing one ELB would not take.
+ */
+export function requireSimElbV2FixedResponseConfig(
+  config: SimElbV2FixedResponseActionConfig | undefined,
+  field: string,
+): void {
+  const statusCode = config?.StatusCode;
+
+  if (statusCode === undefined || !statusCodes.test(statusCode)) {
+    throw new SimElbV2ValidationError(
+      `${field} fixed-response action requires a FixedResponseConfig ` +
+        `StatusCode of 2XX, 4XX or 5XX. A 3XX code is a redirect action.`,
+    );
+  }
+
+  const contentType = config?.ContentType;
+
+  if (contentType !== undefined && !contentTypes.has(contentType)) {
+    throw new SimElbV2ValidationError(
+      `${field} fixed-response action ContentType '${contentType}' is not ` +
+        `one ELB sends. The content types are ${[...contentTypes].join(", ")}.`,
+    );
+  }
+}

--- a/src/service/elbv2/action/sim-elbv2-redirect-config.ts
+++ b/src/service/elbv2/action/sim-elbv2-redirect-config.ts
@@ -1,0 +1,117 @@
+import type { SimElbV2RedirectActionConfig } from "../command/sim-elbv2-shared.command.js";
+import { SimElbV2ValidationError } from "../error/sim-elbv2.error.js";
+
+/**
+ * The status codes real ELB takes on a redirect action.
+ */
+const statusCodes = new Set(["HTTP_301", "HTTP_302"]);
+
+/**
+ * The keyword each component of the URI is written as to keep the request's
+ * own value.
+ *
+ * The path carries its leading slash and the keyword does not, which is why
+ * keeping the path is written with one in front of it.
+ */
+const keywords = {
+  protocol: "#{protocol}",
+  host: "#{host}",
+  port: "#{port}",
+  path: "/#{path}",
+} as const;
+
+/**
+ * What real ELB takes as a redirect's protocol.
+ */
+const protocols = /^(?:HTTPS?|#\{protocol\})$/u;
+
+/**
+ * What real ELB takes as a redirect's port, which is a port number or the
+ * keyword leaving the request's own.
+ */
+function isPort(value: string): boolean {
+  if (value === keywords.port) {
+    return true;
+  }
+
+  const port = Number(value);
+
+  return /^\d+$/u.test(value) && port >= 1 && port <= 65_535;
+}
+
+/**
+ * Whether a redirect changes any part of the URI it was sent.
+ *
+ * Real ELB requires the protocol, host, port or path to be modified, since a
+ * redirect to the request's own URI is a loop. Each component is paired with
+ * the keyword that leaves it as it was, so naming one of those is not a
+ * change. The query is absent from the list because changing it alone still
+ * leaves the loop.
+ */
+function modifiesUri(config: SimElbV2RedirectActionConfig): boolean {
+  const components: readonly (readonly [string | undefined, string])[] = [
+    [config.Protocol, keywords.protocol],
+    [config.Host, keywords.host],
+    [config.Port, keywords.port],
+    [config.Path, keywords.path],
+  ];
+
+  return components.some(
+    ([value, unchanged]) => value !== undefined && value !== unchanged,
+  );
+}
+
+/**
+ * Check the parts of a redirect one at a time, refusing what ELB refuses.
+ */
+function requireComponents(
+  config: SimElbV2RedirectActionConfig,
+  field: string,
+): void {
+  if (config.Protocol !== undefined && !protocols.test(config.Protocol)) {
+    throw new SimElbV2ValidationError(
+      `${field} redirect action Protocol must be HTTP, HTTPS or ${keywords.protocol}`,
+    );
+  }
+
+  if (config.Port !== undefined && !isPort(config.Port)) {
+    throw new SimElbV2ValidationError(
+      `${field} redirect action Port must be a number from 1 to 65535 or ${
+        keywords.port
+      }`,
+    );
+  }
+
+  if (config.Path !== undefined && !config.Path.startsWith("/")) {
+    throw new SimElbV2ValidationError(
+      `${field} redirect action Path must start with a '/', as an absolute ` +
+        `path does. Keeping the request's own path is ${keywords.path}.`,
+    );
+  }
+}
+
+/**
+ * Check a redirect configuration, refusing one ELB would not take.
+ */
+export function requireSimElbV2RedirectConfig(
+  config: SimElbV2RedirectActionConfig | undefined,
+  field: string,
+): void {
+  if (config?.StatusCode === undefined || !statusCodes.has(config.StatusCode)) {
+    throw new SimElbV2ValidationError(
+      `${field} redirect action requires a RedirectConfig StatusCode of ${statusCodes
+        .values()
+        .toArray()
+        .join(" or ")}`,
+    );
+  }
+
+  requireComponents(config, field);
+
+  if (!modifiesUri(config)) {
+    throw new SimElbV2ValidationError(
+      `${field} redirect action changes no part of the request URI, so it ` +
+        `redirects to itself. Name a Protocol, Host, Port or Path.`,
+    );
+  }
+}

--- a/src/service/elbv2/command/rule/rule.iso.test.ts
+++ b/src/service/elbv2/command/rule/rule.iso.test.ts
@@ -180,7 +180,7 @@ describe("ELBv2 listener rules", () => {
     const output = await elbV2.modifyRule(
       new ModifyRuleCommand({
         RuleArn: ruleArn,
-        Conditions: [{ Field: "http-request-method", Values: ["POST"] }],
+        Conditions: [{ Field: "path-pattern", Values: ["/orders"] }],
         Actions: [
           {
             Type: "redirect",
@@ -197,7 +197,7 @@ describe("ELBv2 listener rules", () => {
     assertIdentical(rule.Priority, "10");
     assertArrayLength(rule.Conditions, 1);
     assertArrayLength(rule.Actions, 1);
-    assertIdentical(rule.Conditions[0].Field, "http-request-method");
+    assertIdentical(rule.Conditions[0].Field, "path-pattern");
     assertIdentical(rule.Actions[0].Type, "redirect");
   });
 

--- a/src/service/elbv2/index.ts
+++ b/src/service/elbv2/index.ts
@@ -17,6 +17,8 @@ export { SimElbV2Listener } from "./listener/sim-elbv2-listener.js";
 export type { SimElbV2ListenerView } from "./listener/sim-elbv2-listener.js";
 export { SimElbV2ListenerRule } from "./listener/rule/sim-elbv2-listener-rule.js";
 export type { SimElbV2ListenerRuleView } from "./listener/rule/sim-elbv2-listener-rule.js";
+export { SimElbV2RuleCondition } from "./listener/rule/sim-elbv2-rule-condition.js";
+export type { SimElbV2MatchableRequest } from "./listener/rule/match/sim-elbv2-matchable-request.js";
 export { SimElbV2Action } from "./action/sim-elbv2-action.js";
 export { SimElbV2Registry } from "./registry/sim-elbv2-registry.js";
 export { SimElbV2ServiceController } from "./serve/sim-elbv2-controller.js";
@@ -36,6 +38,10 @@ export {
   simElbV2LambdaTargetFactory,
   type SimElbV2LambdaTargetInput,
 } from "./serve/sim-elbv2-lambda-target.factory.js";
+export {
+  simElbV2ServingTargetGroupFactory,
+  type SimElbV2ServingTargetGroupInput,
+} from "./serve/sim-elbv2-serving-target-group.factory.js";
 export {
   SimElbV2AccessDeniedException,
   SimElbV2ConnectionRefusedError,

--- a/src/service/elbv2/listener/rule/match/sim-elbv2-condition-field.ts
+++ b/src/service/elbv2/listener/rule/match/sim-elbv2-condition-field.ts
@@ -1,0 +1,47 @@
+import type {
+  SimElbV2ConditionValues,
+  SimElbV2RuleConditionInput,
+} from "../../../command/rule/rule-condition.command.js";
+import type { SimElbV2ConditionMatcher } from "./sim-elbv2-condition-matcher.js";
+
+interface SimElbV2ConditionFieldProperties {
+  /**
+   * Where this field keeps its values when they are written as a per-field
+   * configuration rather than as a plain list.
+   */
+  readonly config: (
+    input: SimElbV2RuleConditionInput,
+  ) => SimElbV2ConditionValues | undefined;
+  readonly matcher: (values: readonly string[]) => SimElbV2ConditionMatcher;
+}
+
+/**
+ * One condition field a rule can be written on, and how a request is matched
+ * against it.
+ *
+ * The field decides which configuration is read rather than the first one that
+ * happens to be there, so a `host-header` condition carrying only a
+ * `PathPatternConfig` has no values and is refused, as it is on real ELB.
+ */
+export class SimElbV2ConditionField {
+  private readonly properties: SimElbV2ConditionFieldProperties;
+
+  constructor(properties: SimElbV2ConditionFieldProperties) {
+    this.properties = properties;
+  }
+
+  /**
+   * The values a condition carries for this field, in either of the two forms
+   * ELB writes them in.
+   */
+  values(input: SimElbV2RuleConditionInput): readonly string[] {
+    return input.Values ?? this.properties.config(input)?.Values ?? [];
+  }
+
+  /**
+   * Build what decides whether a request satisfies those values.
+   */
+  matcher(values: readonly string[]): SimElbV2ConditionMatcher {
+    return this.properties.matcher(values);
+  }
+}

--- a/src/service/elbv2/listener/rule/match/sim-elbv2-condition-fields.ts
+++ b/src/service/elbv2/listener/rule/match/sim-elbv2-condition-fields.ts
@@ -1,0 +1,78 @@
+import type { SimElbV2ConditionValues } from "../../../command/rule/rule-condition.command.js";
+import {
+  SimElbV2UnsimulatedInputException,
+  SimElbV2ValidationError,
+} from "../../../error/sim-elbv2.error.js";
+import { SimElbV2ConditionField } from "./sim-elbv2-condition-field.js";
+import { SimElbV2HostHeaderMatcher } from "./sim-elbv2-host-header-matcher.js";
+import { SimElbV2PathPatternMatcher } from "./sim-elbv2-path-pattern-matcher.js";
+
+/**
+ * The condition fields a rule here can be written on.
+ *
+ * These two cover most real routing, and both are matched when a request
+ * arrives rather than only stored.
+ */
+const simulatedFields = new Map<string, SimElbV2ConditionField>([
+  [
+    "host-header",
+    new SimElbV2ConditionField({
+      config: (input): SimElbV2ConditionValues | undefined =>
+        input.HostHeaderConfig,
+      matcher: (values): SimElbV2HostHeaderMatcher =>
+        new SimElbV2HostHeaderMatcher(values),
+    }),
+  ],
+  [
+    "path-pattern",
+    new SimElbV2ConditionField({
+      config: (input): SimElbV2ConditionValues | undefined =>
+        input.PathPatternConfig,
+      matcher: (values): SimElbV2PathPatternMatcher =>
+        new SimElbV2PathPatternMatcher(values),
+    }),
+  ],
+]);
+
+/**
+ * The condition fields real ELB has and nothing here matches on.
+ *
+ * They are held apart from a field ELB does not have at all, because the two
+ * mean different things to whoever wrote the rule: one request is wrong, and
+ * the other is right and goes further than this simulation does. Either way the
+ * rule is refused when it is written, rather than stored and then never
+ * claiming a request it was meant to claim.
+ */
+const unmatchedFields = new Set([
+  "http-header",
+  "http-request-method",
+  "query-string",
+  "source-ip",
+]);
+
+/**
+ * Resolve the field a condition is written on, or refuse.
+ */
+export function requireSimElbV2ConditionField(
+  field: string,
+): SimElbV2ConditionField {
+  const simulated = simulatedFields.get(field);
+
+  if (simulated !== undefined) {
+    return simulated;
+  }
+
+  const simulatedNames = simulatedFields.keys().toArray();
+
+  if (unmatchedFields.has(field)) {
+    throw new SimElbV2UnsimulatedInputException(
+      `Condition field '${field}' is not simulated. Simulated fields are ` +
+        `${simulatedNames.join(" and ")}.`,
+    );
+  }
+
+  throw new SimElbV2ValidationError(
+    `'${field}' is not a listener rule condition field. The fields are ` +
+      `${[...simulatedNames, ...unmatchedFields].join(", ")}.`,
+  );
+}

--- a/src/service/elbv2/listener/rule/match/sim-elbv2-condition-match.iso.test.ts
+++ b/src/service/elbv2/listener/rule/match/sim-elbv2-condition-match.iso.test.ts
@@ -1,0 +1,144 @@
+import { assertFalse, assertTrue } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimElbV2RuleCondition } from "../sim-elbv2-rule-condition.js";
+import type { SimElbV2MatchableRequest } from "./sim-elbv2-matchable-request.js";
+
+/**
+ * A request to match a condition against, where only one part matters at a
+ * time.
+ */
+function requestFor(
+  parts: Partial<SimElbV2MatchableRequest>,
+): SimElbV2MatchableRequest {
+  return { host: "shop.example.com", path: "/", ...parts };
+}
+
+describe("Matching a sim ELBv2 rule condition against a request", () => {
+  it("matches a path pattern against the whole path", () => {
+    // Given a rule condition on a path prefix.
+    const condition = SimElbV2RuleCondition.read({
+      Field: "path-pattern",
+      Values: ["/api/*"],
+    });
+
+    // When paths under and beside that prefix are matched.
+    // Then the wildcard covers everything after the slash, including further
+    // slashes, and stops at the prefix itself.
+    assertTrue(condition.matches(requestFor({ path: "/api/orders" })));
+    assertTrue(condition.matches(requestFor({ path: "/api/v1/orders" })));
+    assertTrue(condition.matches(requestFor({ path: "/api/" })));
+    assertFalse(condition.matches(requestFor({ path: "/apiv2/orders" })));
+    assertFalse(condition.matches(requestFor({ path: "/orders" })));
+  });
+
+  it("does not match the bare prefix of a path pattern", () => {
+    // Given the same condition, which reads as though it covers the prefix.
+    const condition = SimElbV2RuleCondition.read({
+      Field: "path-pattern",
+      Values: ["/api/*"],
+    });
+
+    // When the prefix itself arrives, with no trailing slash.
+    // Then it does not match: the pattern has a slash the path does not, and
+    // the wildcard's zero characters come after it. This is the usual reason a
+    // rule that looks right never claims anything, and real ELB does the same,
+    // which is why a rule for both is written as ["/api", "/api/*"].
+    assertFalse(condition.matches(requestFor({ path: "/api" })));
+
+    const both = SimElbV2RuleCondition.read({
+      Field: "path-pattern",
+      Values: ["/api", "/api/*"],
+    });
+
+    assertTrue(both.matches(requestFor({ path: "/api" })));
+    assertTrue(both.matches(requestFor({ path: "/api/orders" })));
+  });
+
+  it("matches exactly one character for a question mark", () => {
+    // Given a path pattern using the single character wildcard.
+    const condition = SimElbV2RuleCondition.read({
+      Field: "path-pattern",
+      PathPatternConfig: { Values: ["/order?"] },
+    });
+
+    // When paths of each length arrive.
+    // Then only the one with exactly one character in that place matches.
+    assertTrue(condition.matches(requestFor({ path: "/orders" })));
+    assertFalse(condition.matches(requestFor({ path: "/order" })));
+    assertFalse(condition.matches(requestFor({ path: "/orders2" })));
+  });
+
+  it("compares a path pattern with regard to case", () => {
+    // Given a path pattern written in upper case.
+    const condition = SimElbV2RuleCondition.read({
+      Field: "path-pattern",
+      Values: ["/API/*"],
+    });
+
+    // When the lower case path arrives.
+    // Then it does not match, as on real ELB, where a path pattern is the case
+    // sensitive condition and a host name is not.
+    assertFalse(condition.matches(requestFor({ path: "/api/orders" })));
+    assertTrue(condition.matches(requestFor({ path: "/API/orders" })));
+  });
+
+  it("treats everything but the two wildcards as a literal", () => {
+    // Given a path pattern holding characters a regular expression would read.
+    const condition = SimElbV2RuleCondition.read({
+      Field: "path-pattern",
+      Values: ["/prices/$1.00"],
+    });
+
+    // When a path that would match those as expression syntax arrives.
+    // Then only the literal path matches, since ELB has two wildcards and no
+    // other syntax.
+    assertTrue(condition.matches(requestFor({ path: "/prices/$1.00" })));
+    assertFalse(condition.matches(requestFor({ path: "/prices/$1x00" })));
+  });
+
+  it("matches a wildcard subdomain and not the domain under it", () => {
+    // Given a host header condition on a wildcard subdomain.
+    const condition = SimElbV2RuleCondition.read({
+      Field: "host-header",
+      Values: ["*.example.com"],
+    });
+
+    // When host names at and below that domain arrive.
+    // Then the wildcard stands for the label and the dot is a literal, so the
+    // bare domain does not match however many characters the wildcard covers.
+    assertTrue(condition.matches(requestFor({ host: "admin.example.com" })));
+    assertTrue(condition.matches(requestFor({ host: "a.b.example.com" })));
+    assertFalse(condition.matches(requestFor({ host: "example.com" })));
+    assertFalse(
+      condition.matches(requestFor({ host: "example.com.evil.net" })),
+    );
+  });
+
+  it("compares a host name without regard to case", () => {
+    // Given a host header condition written in mixed case.
+    const condition = SimElbV2RuleCondition.read({
+      Field: "host-header",
+      HostHeaderConfig: { Values: ["Shop.Example.com"] },
+    });
+
+    // When the host name arrives in another case.
+    // Then it matches, as host names are case insensitive.
+    assertTrue(condition.matches(requestFor({ host: "SHOP.example.com" })));
+  });
+
+  it("matches when any one of a condition's values matches", () => {
+    // Given a condition carrying two host names.
+    const condition = SimElbV2RuleCondition.read({
+      Field: "host-header",
+      Values: ["admin.example.com", "ops.example.com"],
+    });
+
+    // When each of them arrives, and one that is neither.
+    // Then a value list is an or, which is what makes several conditions on a
+    // rule the and.
+    assertTrue(condition.matches(requestFor({ host: "admin.example.com" })));
+    assertTrue(condition.matches(requestFor({ host: "ops.example.com" })));
+    assertFalse(condition.matches(requestFor({ host: "shop.example.com" })));
+  });
+});

--- a/src/service/elbv2/listener/rule/match/sim-elbv2-condition-matcher.ts
+++ b/src/service/elbv2/listener/rule/match/sim-elbv2-condition-matcher.ts
@@ -1,0 +1,39 @@
+import type { SimElbV2MatchableRequest } from "./sim-elbv2-matchable-request.js";
+import type { SimElbV2WildcardPattern } from "./sim-elbv2-wildcard-pattern.js";
+
+/**
+ * Decides whether one condition on a rule claims a request.
+ *
+ * There is one implementation per simulated condition field, so nothing has to
+ * branch on which field a condition was written on once the rule exists.
+ */
+export interface SimElbV2ConditionMatcher {
+  /**
+   * Whether this condition is satisfied by a request.
+   */
+  matches(request: SimElbV2MatchableRequest): boolean;
+}
+
+/**
+ * A condition matching one part of a request against a list of patterns.
+ *
+ * A condition with several values is satisfied when any one of them matches,
+ * which is what makes a value list an or and several conditions on a rule an
+ * and. Each subclass says which part of the request its field compares.
+ */
+export abstract class SimElbV2ValueListMatcher implements SimElbV2ConditionMatcher {
+  protected constructor(
+    private readonly patterns: readonly SimElbV2WildcardPattern[],
+  ) {}
+
+  matches(request: SimElbV2MatchableRequest): boolean {
+    const subject = this.subject(request);
+
+    return this.patterns.some((pattern) => pattern.matches(subject));
+  }
+
+  /**
+   * The part of the request this field compares its values against.
+   */
+  protected abstract subject(request: SimElbV2MatchableRequest): string;
+}

--- a/src/service/elbv2/listener/rule/match/sim-elbv2-condition-values.ts
+++ b/src/service/elbv2/listener/rule/match/sim-elbv2-condition-values.ts
@@ -1,0 +1,48 @@
+import { SimElbV2ValidationError } from "../../../error/sim-elbv2.error.js";
+
+/**
+ * The longest condition value real ELB takes.
+ *
+ * The limit is the same for a host name and for a path pattern, and it is per
+ * value rather than across the list.
+ */
+const maximumValueLength = 128;
+
+/**
+ * Read the values a condition compares against, refusing a list ELB would not
+ * take.
+ *
+ * The length limit is real ELB's rather than one of this simulation's own. A
+ * pattern longer than this is accepted here and refused by AWS, which is the
+ * divergence worth avoiding: a test passes and the deployment fails.
+ *
+ * It also bounds what the matcher compiles. A pattern with many wildcards
+ * still compiles to that many `.*` runs, and a backtracking engine can take a
+ * while to settle on a long near miss, so the bound is worth having even
+ * though it is not what stops that. What stops it is that a condition value is
+ * written by whoever wrote the rule and is never carried on a request, so the
+ * only run a pathological pattern can hold up is that author's own. A cap on
+ * wildcards is deliberately not added, since real ELB has none and a rule AWS
+ * accepts should not be refused here.
+ */
+export function requireSimElbV2ConditionValues(
+  values: readonly string[],
+  field: string,
+): readonly string[] {
+  if (values.length === 0) {
+    throw new SimElbV2ValidationError(
+      `A '${field}' condition requires at least one value`,
+    );
+  }
+
+  const tooLong = values.find((value) => value.length > maximumValueLength);
+
+  if (tooLong !== undefined) {
+    throw new SimElbV2ValidationError(
+      `A '${field}' condition value is ${String(tooLong.length)} characters, ` +
+        `and ELB takes at most ${String(maximumValueLength)}`,
+    );
+  }
+
+  return values;
+}

--- a/src/service/elbv2/listener/rule/match/sim-elbv2-host-header-matcher.ts
+++ b/src/service/elbv2/listener/rule/match/sim-elbv2-host-header-matcher.ts
@@ -1,0 +1,23 @@
+import { SimElbV2ValueListMatcher } from "./sim-elbv2-condition-matcher.js";
+import type { SimElbV2MatchableRequest } from "./sim-elbv2-matchable-request.js";
+import { SimElbV2WildcardPattern } from "./sim-elbv2-wildcard-pattern.js";
+
+/**
+ * A `host-header` condition, matched against the host name a request named.
+ *
+ * The comparison is case insensitive, as host names are. It is still a whole
+ * value comparison, so `*.example.com` matches `admin.example.com` and does not
+ * match `example.com`: the pattern has a dot before the wildcard's zero
+ * characters, and the bare domain has nothing there.
+ */
+export class SimElbV2HostHeaderMatcher extends SimElbV2ValueListMatcher {
+  constructor(values: readonly string[]) {
+    super(
+      values.map((value) => SimElbV2WildcardPattern.caseInsensitive(value)),
+    );
+  }
+
+  protected override subject(request: SimElbV2MatchableRequest): string {
+    return request.host;
+  }
+}

--- a/src/service/elbv2/listener/rule/match/sim-elbv2-matchable-request.ts
+++ b/src/service/elbv2/listener/rule/match/sim-elbv2-matchable-request.ts
@@ -1,0 +1,46 @@
+/**
+ * The parts of a request a listener rule is matched against.
+ *
+ * A rule is matched against the request rather than against the load balancer
+ * it reached, so this is everything the two simulated condition fields need and
+ * nothing else.
+ */
+export interface SimElbV2MatchableRequest {
+  /** The host name the request named, with any port taken off. */
+  readonly host: string;
+  /** The path of the request URL, which is not its query string. */
+  readonly path: string;
+}
+
+/**
+ * A host name with any port taken off.
+ *
+ * A `host-header` condition value cannot carry a port on real ELB, so the port
+ * a client wrote is not part of the comparison. An IPv6 host keeps its
+ * brackets, since the port is what follows them.
+ */
+function hostName(host: string): string {
+  return host.replace(/:\d+$/u, "");
+}
+
+/**
+ * Read the parts of an HTTP request that listener rules match on.
+ *
+ * The Host header is what real ELB compares a `host-header` condition against,
+ * so it wins over the host name in the URL. They are the same thing on real
+ * AWS, where DNS is what brought the request here. In this simulation a request
+ * reaches a load balancer at its own DNS name, so sending a Host header is how
+ * a test says which name the client asked for.
+ */
+export function simElbV2MatchableRequest(
+  request: Request,
+): SimElbV2MatchableRequest {
+  const url = new URL(request.url);
+
+  return {
+    host: hostName(request.headers.get("host") ?? url.host),
+    // The pathname excludes the query string, which is what real ELB compares
+    // a path pattern against.
+    path: url.pathname,
+  };
+}

--- a/src/service/elbv2/listener/rule/match/sim-elbv2-path-pattern-matcher.ts
+++ b/src/service/elbv2/listener/rule/match/sim-elbv2-path-pattern-matcher.ts
@@ -1,0 +1,21 @@
+import { SimElbV2ValueListMatcher } from "./sim-elbv2-condition-matcher.js";
+import type { SimElbV2MatchableRequest } from "./sim-elbv2-matchable-request.js";
+import { SimElbV2WildcardPattern } from "./sim-elbv2-wildcard-pattern.js";
+
+/**
+ * A `path-pattern` condition, matched against the path of the request URL.
+ *
+ * The comparison is case sensitive, unlike a host name's, and it is against the
+ * path alone: a query string is matched by a `query-string` condition, which is
+ * not simulated. The whole path has to match, so `/api/*` claims `/api/orders`
+ * and does not claim `/api`.
+ */
+export class SimElbV2PathPatternMatcher extends SimElbV2ValueListMatcher {
+  constructor(values: readonly string[]) {
+    super(values.map((value) => SimElbV2WildcardPattern.caseSensitive(value)));
+  }
+
+  protected override subject(request: SimElbV2MatchableRequest): string {
+    return request.path;
+  }
+}

--- a/src/service/elbv2/listener/rule/match/sim-elbv2-wildcard-pattern.ts
+++ b/src/service/elbv2/listener/rule/match/sim-elbv2-wildcard-pattern.ts
@@ -1,0 +1,65 @@
+/**
+ * The regular expression characters an ELB pattern holds as literals.
+ *
+ * `*` and `?` are absent on purpose: those are the two characters an ELB
+ * pattern uses as wildcards, and they are turned into their regular expression
+ * equivalents once everything else has been escaped.
+ */
+const regExpMetaCharacters = /[.+^${}()|[\]\\]/gu;
+
+/**
+ * One `host-header` or `path-pattern` value, compiled so a request can be
+ * compared against it.
+ *
+ * Real ELB supports two wildcards, `*` for zero or more characters and `?` for
+ * exactly one, and compares them against the whole of the host name or path
+ * rather than against part of it. That whole-value comparison is the part that
+ * surprises people: `/api/*` does not match `/api`, because the pattern has a
+ * literal slash the path does not, and `*.example.com` does not match
+ * `example.com` for the same reason.
+ */
+export class SimElbV2WildcardPattern {
+  private readonly expression: RegExp;
+
+  private constructor(pattern: string, flags: string) {
+    const escaped = pattern.replaceAll(regExpMetaCharacters, String.raw`\$&`);
+    const source = escaped.replaceAll("*", ".*").replaceAll("?", ".");
+
+    /*
+     * Anchored at both ends, because ELB compares a pattern against the whole
+     * value rather than looking for it inside one.
+     *
+     * The pattern is not read as an expression: every character with a meaning
+     * of its own is escaped above, and only the two ELB wildcards become
+     * syntax. A pattern holding many of them compiles to as many `.*` runs and
+     * can take a backtracking engine a while to settle on a long near miss,
+     * which is left alone: a condition value is written by whoever wrote the
+     * rule and is never carried on a request.
+     */
+    // oxlint-disable-next-line security/detect-non-literal-regexp
+    this.expression = new RegExp(`^${source}$`, flags);
+  }
+
+  /**
+   * Compile a pattern compared exactly as it is written, which is how real ELB
+   * compares a path pattern.
+   */
+  static caseSensitive(pattern: string): SimElbV2WildcardPattern {
+    return new SimElbV2WildcardPattern(pattern, "u");
+  }
+
+  /**
+   * Compile a pattern compared without regard to case, which is how real ELB
+   * compares a host name.
+   */
+  static caseInsensitive(pattern: string): SimElbV2WildcardPattern {
+    return new SimElbV2WildcardPattern(pattern, "iu");
+  }
+
+  /**
+   * Whether a value is one this pattern matches.
+   */
+  matches(value: string): boolean {
+    return this.expression.test(value);
+  }
+}

--- a/src/service/elbv2/listener/rule/match/sim-elbv2-wildcard-pattern.ts
+++ b/src/service/elbv2/listener/rule/match/sim-elbv2-wildcard-pattern.ts
@@ -32,9 +32,11 @@ export class SimElbV2WildcardPattern {
      * The pattern is not read as an expression: every character with a meaning
      * of its own is escaped above, and only the two ELB wildcards become
      * syntax. A pattern holding many of them compiles to as many `.*` runs and
-     * can take a backtracking engine a while to settle on a long near miss,
-     * which is left alone: a condition value is written by whoever wrote the
-     * rule and is never carried on a request.
+     * can take a backtracking engine a while to settle on a long near miss.
+     * The value is bounded to ELB's own 128 characters before it gets here,
+     * and beyond that this is left alone: a condition value is written by
+     * whoever wrote the rule and is never carried on a request, so the only
+     * run a pathological one can hold up is that author's own.
      */
     // oxlint-disable-next-line security/detect-non-literal-regexp
     this.expression = new RegExp(`^${source}$`, flags);

--- a/src/service/elbv2/listener/rule/sim-elbv2-listener-rule.ts
+++ b/src/service/elbv2/listener/rule/sim-elbv2-listener-rule.ts
@@ -2,6 +2,7 @@ import type { SimElbV2Action } from "../../action/sim-elbv2-action.js";
 import type { SimElbV2ActionView } from "../../command/sim-elbv2-shared.command.js";
 import type { SimElbV2Listener } from "../sim-elbv2-listener.js";
 import type { SimElbV2RuleConditionInput } from "../../command/rule/rule-condition.command.js";
+import type { SimElbV2MatchableRequest } from "./match/sim-elbv2-matchable-request.js";
 import type { SimElbV2RuleCondition } from "./sim-elbv2-rule-condition.js";
 
 interface SimElbV2ListenerRuleProperties {
@@ -74,6 +75,17 @@ export class SimElbV2ListenerRule {
   /** What this rule does with a request it claims. */
   get actions(): readonly SimElbV2Action[] {
     return this.currentActions;
+  }
+
+  /**
+   * Whether this rule claims a request.
+   *
+   * Every condition has to be satisfied, which is what makes several
+   * conditions on one rule an and. A value list within one condition is an or,
+   * and that part belongs to the condition.
+   */
+  matches(request: SimElbV2MatchableRequest): boolean {
+    return this.conditions.every((condition) => condition.matches(request));
   }
 
   /**

--- a/src/service/elbv2/listener/rule/sim-elbv2-rule-condition.iso.test.ts
+++ b/src/service/elbv2/listener/rule/sim-elbv2-rule-condition.iso.test.ts
@@ -135,4 +135,26 @@ describe("sim ELBv2 rule conditions", () => {
     assertStringIncludes(hostHeader.message, "at least one value");
     assertStringIncludes(pathPattern.message, "at least one value");
   });
+
+  it("refuses a value longer than ELB takes", () => {
+    // Given a path pattern at the limit, and one character past it.
+    const atLimit = SimElbV2RuleCondition.read({
+      Field: "path-pattern",
+      Values: [`/${"a".repeat(127)}`],
+    });
+
+    assertIdentical(atLimit.field, "path-pattern");
+
+    const error = assertThrowsError(() => {
+      SimElbV2RuleCondition.read({
+        Field: "path-pattern",
+        Values: [`/${"a".repeat(128)}`],
+      });
+    });
+
+    // Then the longer one is refused here rather than by AWS after a passing
+    // test, which is the divergence worth avoiding.
+    assertInstanceOf(error, SimElbV2ValidationError);
+    assertStringIncludes(error.message, "at most 128");
+  });
 });

--- a/src/service/elbv2/listener/rule/sim-elbv2-rule-condition.iso.test.ts
+++ b/src/service/elbv2/listener/rule/sim-elbv2-rule-condition.iso.test.ts
@@ -31,27 +31,15 @@ describe("sim ELBv2 rule conditions", () => {
     assertIdentical(configured.view().Field, "host-header");
   });
 
-  it("takes the conditions an ALB rule can be written on", () => {
+  it("takes the conditions a rule here can be written on", () => {
     // Given one condition of each simulated field.
     const conditions = SimElbV2RuleCondition.readAll([
       { Field: "path-pattern", PathPatternConfig: { Values: ["/api/*"] } },
-      {
-        Field: "http-request-method",
-        HttpRequestMethodConfig: { Values: ["POST"] },
-      },
-      { Field: "source-ip", SourceIpConfig: { Values: ["10.0.0.0/8"] } },
-      {
-        Field: "http-header",
-        HttpHeaderConfig: { HttpHeaderName: "X-Tenant", Values: ["shop"] },
-      },
-      {
-        Field: "query-string",
-        QueryStringConfig: { Values: [{ Key: "version", Value: "2" }] },
-      },
+      { Field: "host-header", Values: ["shop.example.com"] },
     ]);
 
-    // Then all five are accepted.
-    assertArrayLength(conditions, 5);
+    // Then both are accepted.
+    assertArrayLength(conditions, 2);
   });
 
   it("refuses a condition list that is empty or absent", () => {
@@ -88,8 +76,27 @@ describe("sim ELBv2 rule conditions", () => {
     assertStringIncludes(error.message, "at least one value");
   });
 
-  it("refuses a field nothing here understands", () => {
-    // Given a condition with no field, and one on a field ELB does not have.
+  it("refuses a field real ELB has and nothing here matches on", () => {
+    // Given conditions on each of the fields ELB has and this does not.
+    for (const field of [
+      "http-header",
+      "http-request-method",
+      "query-string",
+      "source-ip",
+    ]) {
+      const error = assertThrowsError(() => {
+        SimElbV2RuleCondition.read({ Field: field, Values: ["anything"] });
+      });
+
+      // Then each is refused when the rule is written. Storing one would leave
+      // a rule that looks configured and never claims a request.
+      assertInstanceOf(error, SimElbV2UnsimulatedInputException);
+      assertStringIncludes(error.message, "is not simulated");
+    }
+  });
+
+  it("refuses a field ELB does not have at all", () => {
+    // Given a condition with no field, and one on a field ELB never had.
     const noField = assertThrowsError(() => {
       SimElbV2RuleCondition.read({});
     });
@@ -100,49 +107,32 @@ describe("sim ELBv2 rule conditions", () => {
       SimElbV2RuleCondition.read({ Field: "user-agent", Values: ["curl"] });
     });
 
-    assertInstanceOf(unknown, SimElbV2UnsimulatedInputException);
-
-    // Then both are refused rather than stored and never matched.
+    // Then both are a validation failure rather than something unsimulated,
+    // because the request is wrong rather than ahead of this simulation.
+    assertInstanceOf(unknown, SimElbV2ValidationError);
     assertStringIncludes(noField.message, "requires a Field");
-    assertStringIncludes(unknown.message, "not simulated");
+    assertStringIncludes(unknown.message, "is not a listener rule condition");
   });
 
   it("refuses a condition with nothing to compare against", () => {
-    // Given conditions of three fields, each missing its values.
+    // Given conditions of both simulated fields, each missing its values.
     const hostHeader = assertThrowsError(() => {
       SimElbV2RuleCondition.read({ Field: "host-header" });
     });
 
     assertInstanceOf(hostHeader, SimElbV2ValidationError);
 
-    const httpHeaderName = assertThrowsError(() => {
+    const pathPattern = assertThrowsError(() => {
       SimElbV2RuleCondition.read({
-        Field: "http-header",
-        HttpHeaderConfig: { Values: ["shop"] },
+        Field: "path-pattern",
+        PathPatternConfig: {},
       });
     });
 
-    assertInstanceOf(httpHeaderName, SimElbV2ValidationError);
-
-    const httpHeaderValues = assertThrowsError(() => {
-      SimElbV2RuleCondition.read({
-        Field: "http-header",
-        HttpHeaderConfig: { HttpHeaderName: "X-Tenant" },
-      });
-    });
-
-    assertInstanceOf(httpHeaderValues, SimElbV2ValidationError);
-
-    const queryString = assertThrowsError(() => {
-      SimElbV2RuleCondition.read({ Field: "query-string" });
-    });
-
-    assertInstanceOf(queryString, SimElbV2ValidationError);
+    assertInstanceOf(pathPattern, SimElbV2ValidationError);
 
     // Then each is refused.
     assertStringIncludes(hostHeader.message, "at least one value");
-    assertStringIncludes(httpHeaderName.message, "HttpHeaderName");
-    assertStringIncludes(httpHeaderValues.message, "at least one value");
-    assertStringIncludes(queryString.message, "key and value pair");
+    assertStringIncludes(pathPattern.message, "at least one value");
   });
 });

--- a/src/service/elbv2/listener/rule/sim-elbv2-rule-condition.ts
+++ b/src/service/elbv2/listener/rule/sim-elbv2-rule-condition.ts
@@ -2,6 +2,7 @@ import type { SimElbV2RuleConditionInput } from "../../command/rule/rule-conditi
 import { SimElbV2ValidationError } from "../../error/sim-elbv2.error.js";
 import { requireSimElbV2ConditionField } from "./match/sim-elbv2-condition-fields.js";
 import type { SimElbV2ConditionMatcher } from "./match/sim-elbv2-condition-matcher.js";
+import { requireSimElbV2ConditionValues } from "./match/sim-elbv2-condition-values.js";
 import type { SimElbV2MatchableRequest } from "./match/sim-elbv2-matchable-request.js";
 
 /**
@@ -57,13 +58,10 @@ export class SimElbV2RuleCondition {
     }
 
     const definition = requireSimElbV2ConditionField(field);
-    const values = definition.values(input);
-
-    if (values.length === 0) {
-      throw new SimElbV2ValidationError(
-        `A '${field}' condition requires at least one value`,
-      );
-    }
+    const values = requireSimElbV2ConditionValues(
+      definition.values(input),
+      field,
+    );
 
     return new SimElbV2RuleCondition(input, field, definition.matcher(values));
   }

--- a/src/service/elbv2/listener/rule/sim-elbv2-rule-condition.ts
+++ b/src/service/elbv2/listener/rule/sim-elbv2-rule-condition.ts
@@ -1,76 +1,34 @@
-import type {
-  SimElbV2ConditionValues,
-  SimElbV2RuleConditionInput,
-} from "../../command/rule/rule-condition.command.js";
-import {
-  SimElbV2UnsimulatedInputException,
-  SimElbV2ValidationError,
-} from "../../error/sim-elbv2.error.js";
-
-/**
- * The condition fields whose values are a plain list, and where each one keeps
- * them.
- *
- * The field decides which configuration is read rather than the first one that
- * happens to be there, so a `host-header` condition carrying only a
- * `PathPatternConfig` has no values and is refused, as it is on real ELB.
- */
-const valueFields = new Map<
-  string,
-  (input: SimElbV2RuleConditionInput) => SimElbV2ConditionValues | undefined
->([
-  [
-    "host-header",
-    (input): SimElbV2ConditionValues | undefined => input.HostHeaderConfig,
-  ],
-  [
-    "path-pattern",
-    (input): SimElbV2ConditionValues | undefined => input.PathPatternConfig,
-  ],
-  [
-    "http-request-method",
-    (input): SimElbV2ConditionValues | undefined =>
-      input.HttpRequestMethodConfig,
-  ],
-  [
-    "source-ip",
-    (input): SimElbV2ConditionValues | undefined => input.SourceIpConfig,
-  ],
-]);
-
-/**
- * The condition fields carrying a shape of their own rather than a value list,
- * each checked by its own rule.
- */
-const shapedFields = new Set(["http-header", "query-string"]);
-
-/**
- * Every condition field an Application Load Balancer rule can be written on.
- */
-function simulatedFieldNames(): readonly string[] {
-  return [...valueFields.keys(), ...shapedFields];
-}
+import type { SimElbV2RuleConditionInput } from "../../command/rule/rule-condition.command.js";
+import { SimElbV2ValidationError } from "../../error/sim-elbv2.error.js";
+import { requireSimElbV2ConditionField } from "./match/sim-elbv2-condition-fields.js";
+import type { SimElbV2ConditionMatcher } from "./match/sim-elbv2-condition-matcher.js";
+import type { SimElbV2MatchableRequest } from "./match/sim-elbv2-matchable-request.js";
 
 /**
  * One condition on a simulated listener rule.
  *
- * Conditions are held rather than matched here, and matching a request against
- * them is separate work. What this class owns is that a condition stored on a
- * rule is one that could match something: a field nothing understands, or a
- * field with nothing to compare against, is refused when the rule is written
- * rather than ignored when a request arrives.
+ * A condition is read once, when the rule is written, and what comes out of it
+ * is the thing that matches a request. A field nothing here understands, or a
+ * field with nothing to compare against, is refused at that point rather than
+ * stored and then never claiming a request.
  */
 export class SimElbV2RuleCondition {
   public readonly field: string;
 
   private readonly input: SimElbV2RuleConditionInput;
+  private readonly matcher: SimElbV2ConditionMatcher;
 
-  private constructor(input: SimElbV2RuleConditionInput, field: string) {
+  private constructor(
+    input: SimElbV2RuleConditionInput,
+    field: string,
+    matcher: SimElbV2ConditionMatcher,
+  ) {
     // Copied, so that a caller mutating the command input it sent cannot
     // change what a rule matches on afterwards. Real ELB reads the request off
     // the wire, and nothing a caller does to its own objects reaches it.
     this.input = structuredClone(input);
     this.field = field;
+    this.matcher = matcher;
   }
 
   /**
@@ -98,18 +56,23 @@ export class SimElbV2RuleCondition {
       throw new SimElbV2ValidationError("Conditions member requires a Field");
     }
 
-    if (!valueFields.has(field) && !shapedFields.has(field)) {
-      throw new SimElbV2UnsimulatedInputException(
-        `Condition field '${field}' is not simulated. Simulated fields are ` +
-          `${simulatedFieldNames().join(", ")}.`,
+    const definition = requireSimElbV2ConditionField(field);
+    const values = definition.values(input);
+
+    if (values.length === 0) {
+      throw new SimElbV2ValidationError(
+        `A '${field}' condition requires at least one value`,
       );
     }
 
-    const condition = new SimElbV2RuleCondition(input, field);
+    return new SimElbV2RuleCondition(input, field, definition.matcher(values));
+  }
 
-    condition.validate();
-
-    return condition;
+  /**
+   * Whether a request satisfies this condition.
+   */
+  matches(request: SimElbV2MatchableRequest): boolean {
+    return this.matcher.matches(request);
   }
 
   /**
@@ -117,60 +80,5 @@ export class SimElbV2RuleCondition {
    */
   view(): SimElbV2RuleConditionInput {
     return this.input;
-  }
-
-  private validate(): void {
-    const readValues = valueFields.get(this.field);
-
-    if (readValues === undefined) {
-      this.validateShapedField();
-      return;
-    }
-
-    if (
-      (this.input.Values ?? readValues(this.input)?.Values ?? []).length === 0
-    ) {
-      throw new SimElbV2ValidationError(
-        `A '${this.field}' condition requires at least one value`,
-      );
-    }
-  }
-
-  /**
-   * Check a field whose values are not a plain list against its own rule.
-   */
-  private validateShapedField(): void {
-    if (this.field === "http-header") {
-      this.validateHttpHeader();
-      return;
-    }
-
-    this.validateQueryString();
-  }
-
-  private validateHttpHeader(): void {
-    const config = this.input.HttpHeaderConfig;
-
-    if (config?.HttpHeaderName === undefined || config.HttpHeaderName === "") {
-      throw new SimElbV2ValidationError(
-        "An 'http-header' condition requires an HttpHeaderConfig with an " +
-          "HttpHeaderName",
-      );
-    }
-
-    if ((config.Values ?? []).length === 0) {
-      throw new SimElbV2ValidationError(
-        "An 'http-header' condition requires at least one value",
-      );
-    }
-  }
-
-  private validateQueryString(): void {
-    if ((this.input.QueryStringConfig?.Values ?? []).length === 0) {
-      throw new SimElbV2ValidationError(
-        "A 'query-string' condition requires a QueryStringConfig with at " +
-          "least one key and value pair",
-      );
-    }
   }
 }

--- a/src/service/elbv2/serve/sim-elbv2-action-performer.ts
+++ b/src/service/elbv2/serve/sim-elbv2-action-performer.ts
@@ -1,0 +1,65 @@
+import type { SimElbV2Listener } from "../listener/sim-elbv2-listener.js";
+import type { SimElbV2LoadBalancer } from "../load-balancer/sim-elbv2-load-balancer.js";
+import type { SimElbV2 } from "../sim-elbv2.js";
+import { SimElbV2FixedResponse } from "./sim-elbv2-fixed-response.js";
+import { SimElbV2ForwardTarget } from "./sim-elbv2-forward-target.js";
+import type { SimElbV2LambdaTargetInvocation } from "./sim-elbv2-lambda-target-invocation.js";
+import { SimElbV2RedirectResponse } from "./sim-elbv2-redirect-response.js";
+import type { SimElbV2MatchedAction } from "./sim-elbv2-rule-evaluation.js";
+
+interface SimElbV2PerformedActionInput {
+  readonly matched: SimElbV2MatchedAction;
+  readonly loadBalancer: SimElbV2LoadBalancer;
+  readonly listener: SimElbV2Listener;
+  readonly elbV2: SimElbV2;
+  readonly request: Request;
+}
+
+/**
+ * Carries out the action a listener or a rule answers a request with.
+ *
+ * Two of the three need no target at all: a fixed response and a redirect are
+ * written by the load balancer itself, which is why a listener holding one can
+ * serve with nothing registered behind it. A forward is the one that goes on to
+ * a target group.
+ */
+export class SimElbV2ActionPerformer {
+  private readonly fixedResponse = new SimElbV2FixedResponse();
+  private readonly redirect = new SimElbV2RedirectResponse();
+
+  constructor(private readonly invocation: SimElbV2LambdaTargetInvocation) {}
+
+  /**
+   * Answer one request with one matched action.
+   */
+  async perform(input: SimElbV2PerformedActionInput): Promise<Response> {
+    const { action } = input.matched;
+
+    if (action.type === "fixed-response") {
+      return this.fixedResponse.respond(action);
+    }
+
+    if (action.type === "redirect") {
+      return this.redirect.respond({
+        action,
+        listener: input.listener,
+        request: input.request,
+      });
+    }
+
+    return await this.forward(input);
+  }
+
+  private async forward(
+    input: SimElbV2PerformedActionInput,
+  ): Promise<Response> {
+    return await this.invocation.invoke({
+      loadBalancer: input.loadBalancer,
+      listener: input.listener,
+      targetGroup: new SimElbV2ForwardTarget(input.elbV2).resolve(
+        input.matched,
+      ),
+      request: input.request,
+    });
+  }
+}

--- a/src/service/elbv2/serve/sim-elbv2-controller.ts
+++ b/src/service/elbv2/serve/sim-elbv2-controller.ts
@@ -4,13 +4,14 @@ import type {
 } from "../../../serve/controller/sim-service-controller.js";
 import { SimAws } from "../../aws/sim-aws.js";
 import { SimElbV2ConnectionRefusedError } from "../error/sim-elbv2.error.js";
-import { SimElbV2ForwardTarget } from "./sim-elbv2-forward-target.js";
+import { SimElbV2ActionPerformer } from "./sim-elbv2-action-performer.js";
 import { SimElbV2LambdaTargetInvocation } from "./sim-elbv2-lambda-target-invocation.js";
-import { simElbV2RequestPort } from "./sim-elbv2-request-port.js";
+import { requireSimElbV2Listener } from "./sim-elbv2-listener-match.js";
 import {
   type SimElbV2LoadBalancerRoute,
   SimElbV2Router,
 } from "./sim-elbv2-router.js";
+import { SimElbV2RuleEvaluation } from "./sim-elbv2-rule-evaluation.js";
 
 interface SimElbV2ServiceControllerProperties {
   readonly simAws?: SimAws;
@@ -21,26 +22,25 @@ interface SimElbV2ServiceControllerProperties {
  * HTTP controller for simulated Application Load Balancers.
  *
  * A request reaching a load balancer's DNS name is matched to a listener by the
- * port it arrived on, and the listener's default action decides what happens
- * next. A forward action sends it to a target group, and a lambda target group
- * invokes the function registered in it with an ALB event.
- *
- * Nothing here matches listener rules yet, so every request a listener takes is
- * answered by its default action.
+ * port it arrived on. That listener's rules are then evaluated in priority
+ * order, and the first one claiming the request says what happens to it. A
+ * request no rule claims is answered by the listener's default action.
  */
 export class SimElbV2ServiceController implements SimAwsServiceController {
   private readonly router: SimElbV2Router;
-  private readonly invocation: SimElbV2LambdaTargetInvocation;
+  private readonly actions: SimElbV2ActionPerformer;
 
   constructor(properties: SimElbV2ServiceControllerProperties = {}) {
     const { simAws = new SimAws() } = properties;
     this.router = properties.router ?? new SimElbV2Router({ simAws });
     // The clock is taken from the router rather than from properties, so a
     // supplied router and the event timestamps belong to the same simulation.
-    this.invocation = new SimElbV2LambdaTargetInvocation({
-      router: this.router,
-      clock: this.router.simAws,
-    });
+    this.actions = new SimElbV2ActionPerformer(
+      new SimElbV2LambdaTargetInvocation({
+        router: this.router,
+        clock: this.router.simAws,
+      }),
+    );
   }
 
   /**
@@ -56,29 +56,21 @@ export class SimElbV2ServiceController implements SimAwsServiceController {
       );
     }
 
-    return await this.forward(route, serviceRequest.request);
+    return await this.answer(route, serviceRequest.request);
   }
 
-  private async forward(
+  private async answer(
     route: SimElbV2LoadBalancerRoute,
     request: Request,
   ): Promise<Response> {
     const { loadBalancer, elbV2 } = route;
-    const port = simElbV2RequestPort(new URL(request.url));
-    const listener = elbV2.findListenerOnPort(loadBalancer.arn, port);
+    const listener = requireSimElbV2Listener(route, request);
 
-    if (listener === undefined) {
-      throw new SimElbV2ConnectionRefusedError(
-        `Load balancer '${loadBalancer.name}' has no listener on port ${String(
-          port,
-        )}`,
-      );
-    }
-
-    return await this.invocation.invoke({
+    return await this.actions.perform({
+      matched: new SimElbV2RuleEvaluation(elbV2).actionFor(listener, request),
       loadBalancer,
       listener,
-      targetGroup: new SimElbV2ForwardTarget(elbV2).resolve(listener),
+      elbV2,
       request,
     });
   }

--- a/src/service/elbv2/serve/sim-elbv2-fixed-response.ts
+++ b/src/service/elbv2/serve/sim-elbv2-fixed-response.ts
@@ -1,0 +1,67 @@
+import { assertDefined } from "../../../util/type-guard/defined.js";
+import type { SimElbV2Action } from "../action/sim-elbv2-action.js";
+import type { SimElbV2FixedResponseActionConfig } from "../command/sim-elbv2-shared.command.js";
+import { simElbV2NullBodyStatuses } from "./sim-elbv2-null-body-statuses.js";
+
+/**
+ * Answers a request with a listener or rule's `fixed-response` action.
+ *
+ * No target is involved and none is needed, which is what makes this the usual
+ * way to serve a health endpoint or a maintenance page. The load balancer
+ * writes the response itself from what the action holds.
+ */
+export class SimElbV2FixedResponse {
+  /**
+   * Build the response one fixed-response action sends.
+   */
+  respond(action: SimElbV2Action): Response {
+    const config = action.fixedResponse;
+
+    // A fixed-response action is created with a configuration and a status
+    // code, so a stored one always has both.
+    assertDefined(
+      config,
+      `Simulated ELBv2 fixed-response action holds no FixedResponseConfig`,
+    );
+
+    const status = Number(config.StatusCode);
+
+    return new Response(this.body(config, status), {
+      status,
+      headers: this.headers(config),
+    });
+  }
+
+  /**
+   * The body actually sent, which is nothing for a status that cannot hold
+   * one, and for a configuration naming none.
+   */
+  private body(
+    config: SimElbV2FixedResponseActionConfig,
+    status: number,
+  ): string | null {
+    const message = config.MessageBody ?? "";
+
+    if (message === "" || simElbV2NullBodyStatuses.has(status)) {
+      return null;
+    }
+
+    return message;
+  }
+
+  /**
+   * The response headers, which are the content type or nothing.
+   *
+   * Real ELB sends no content type when the action names none, rather than
+   * guessing one from the body.
+   */
+  private headers(config: SimElbV2FixedResponseActionConfig): Headers {
+    const headers = new Headers();
+
+    if (config.ContentType !== undefined) {
+      headers.set("content-type", config.ContentType);
+    }
+
+    return headers;
+  }
+}

--- a/src/service/elbv2/serve/sim-elbv2-forward-target.ts
+++ b/src/service/elbv2/serve/sim-elbv2-forward-target.ts
@@ -1,27 +1,27 @@
 import { assertDefined } from "../../../util/type-guard/defined.js";
 import { SimElbV2UnsimulatedInputException } from "../error/sim-elbv2.error.js";
-import type { SimElbV2Listener } from "../listener/sim-elbv2-listener.js";
 import type { SimElbV2 } from "../sim-elbv2.js";
 import type { SimElbV2TargetGroup } from "../target-group/sim-elbv2-target-group.js";
+import type { SimElbV2MatchedAction } from "./sim-elbv2-rule-evaluation.js";
 
 /**
- * Works out which target group a listener's default action sends a request to.
+ * Works out which target group a `forward` action sends a request to.
  *
- * The action is stored when the listener is written and performed here, and the
- * two are not the same thing: a listener holding an action this simulation does
- * not carry out is a listener that was created and cannot serve. Each of those
- * is refused when the request arrives rather than answered with something else,
- * because a load balancer that silently forwards a request its configuration
- * said to redirect is worse than one that says it cannot.
+ * The action is stored when the listener or rule is written and performed here,
+ * and the two are not the same thing: a forward this simulation cannot carry
+ * out is one that was accepted and cannot serve. Each of those is refused when
+ * the request arrives rather than answered with something else, because a load
+ * balancer that quietly sends a request somewhere its configuration did not say
+ * is worse than one that says it cannot.
  */
 export class SimElbV2ForwardTarget {
   constructor(private readonly elbV2: SimElbV2) {}
 
   /**
-   * The target group a listener's default action forwards to.
+   * The target group a matched forward action sends a request to.
    */
-  resolve(listener: SimElbV2Listener): SimElbV2TargetGroup {
-    const targetGroup = this.forwardedTargetGroup(listener);
+  resolve(matched: SimElbV2MatchedAction): SimElbV2TargetGroup {
+    const targetGroup = this.forwardedTargetGroup(matched);
 
     if (targetGroup.targetType.value !== "lambda") {
       throw new SimElbV2UnsimulatedInputException(
@@ -36,27 +36,13 @@ export class SimElbV2ForwardTarget {
   }
 
   private forwardedTargetGroup(
-    listener: SimElbV2Listener,
+    matched: SimElbV2MatchedAction,
   ): SimElbV2TargetGroup {
-    const [action] = listener.defaultActions;
-
-    // A listener is created with exactly one action, so there is always one.
-    assertDefined(
-      action,
-      `Simulated ELBv2 listener ${listener.arn} holds no default action`,
-    );
-
-    if (action.type !== "forward") {
-      throw new SimElbV2UnsimulatedInputException(
-        `Listener ${listener.arn} answers a request with a '${action.type}' ` +
-          `action, which is stored and not yet performed. Only a forward ` +
-          `action carries a request here.`,
-      );
-    }
+    const { action, source } = matched;
 
     if (action.targetGroupArns.length > 1) {
       throw new SimElbV2UnsimulatedInputException(
-        `Listener ${listener.arn} forwards to ` +
+        `${source} forwards to ` +
           `${String(action.targetGroupArns.length)} target groups. Weighted ` +
           `forwarding is not simulated, so which of them takes a request is ` +
           `not something this can answer.`,
@@ -67,17 +53,14 @@ export class SimElbV2ForwardTarget {
 
     // A forward action names a target group that exists when it is written,
     // and one anything forwards to cannot be deleted.
-    assertDefined(
-      targetGroupArn,
-      `Simulated ELBv2 listener ${listener.arn} forwards to no target group`,
-    );
+    assertDefined(targetGroupArn, `${source} forwards to no target group`);
 
     const targetGroup = this.elbV2.findTargetGroupByArn(targetGroupArn);
 
     assertDefined(
       targetGroup,
-      `Simulated ELBv2 listener ${listener.arn} forwards to the target group ` +
-        `${targetGroupArn}, which is not there`,
+      `${source} forwards to the target group ${targetGroupArn}, which is ` +
+        `not there`,
     );
 
     return targetGroup;

--- a/src/service/elbv2/serve/sim-elbv2-lambda-target.factory.ts
+++ b/src/service/elbv2/serve/sim-elbv2-lambda-target.factory.ts
@@ -2,15 +2,17 @@ import { AsyncMappedFactory } from "@kensio/part-factory";
 
 import { assertDefined } from "../../../util/type-guard/defined.js";
 import type { SimAws } from "../../aws/sim-aws.js";
-import { makeLambdaZipFileInput } from "../../lambda/function/code/lambda-zip-file-input.js";
 import type { SimElbV2LoadBalancer } from "../load-balancer/sim-elbv2-load-balancer.js";
 import {
-  createFixtureLambdaTargetGroup,
   createFixtureListener,
   createFixtureLoadBalancer,
 } from "../sim-elbv2.fixture.js";
-import type { SimElbV2Event, SimElbV2Result } from "./sim-elbv2-event.type.js";
-import { simElbV2ServicePrincipal } from "./sim-elbv2-invoke-authorizer.js";
+import type { SimElbV2Event } from "./sim-elbv2-event.type.js";
+import {
+  simElbV2CheckoutHandler,
+  simElbV2InvokeStatementId,
+  simElbV2ServingTargetGroupFactory,
+} from "./sim-elbv2-serving-target-group.factory.js";
 
 /**
  * The load balancer, target group and function this builds.
@@ -23,7 +25,7 @@ export const simElbV2LambdaTargetNames = {
   targetGroup: "checkout-tg",
   function: "checkout",
   /** The statement id the invoke permission is granted under. */
-  invokeStatement: "elb-invoke",
+  invokeStatement: simElbV2InvokeStatementId,
 } as const;
 
 /**
@@ -65,49 +67,24 @@ export const simElbV2LambdaTargetFactory = new AsyncMappedFactory<
   SimElbV2LoadBalancer,
   SimAws
 >(
-  () => ({
-    handler: (): SimElbV2Result => ({ statusCode: 200, body: "checkout" }),
-    listenerPort: 80,
-  }),
+  () => ({ handler: simElbV2CheckoutHandler, listenerPort: 80 }),
   async (input, simAws) => {
     const names = simElbV2LambdaTargetNames;
-    const simLambda = simAws.lambda();
-    const { FunctionArn } = await simLambda.createFunction({
-      input: {
-        FunctionName: names.function,
-        Role: "arn:aws:iam::888888888888:role/CheckoutRole",
-        Code: { ZipFile: makeLambdaZipFileInput(input.handler) },
-      },
-    });
+    const targetGroup = await simElbV2ServingTargetGroupFactory.make(
+      { name: names.function, handler: input.handler },
+      simAws,
+    );
 
     const elbV2 = simAws.elbV2();
     const balancerArn = await createFixtureLoadBalancer(
       elbV2,
       names.loadBalancer,
     );
-    const groupArn = await createFixtureLambdaTargetGroup(
-      elbV2,
-      names.targetGroup,
-    );
-
-    await simLambda.addPermission({
-      input: {
-        FunctionName: names.function,
-        StatementId: names.invokeStatement,
-        Action: "lambda:InvokeFunction",
-        Principal: simElbV2ServicePrincipal,
-        SourceArn: groupArn,
-      },
-    });
-
-    await elbV2.registerTargets({
-      input: { TargetGroupArn: groupArn, Targets: [{ Id: FunctionArn }] },
-    });
 
     await createFixtureListener(
       elbV2,
       balancerArn,
-      groupArn,
+      targetGroup.arn,
       input.listenerPort,
     );
 

--- a/src/service/elbv2/serve/sim-elbv2-listener-match.ts
+++ b/src/service/elbv2/serve/sim-elbv2-listener-match.ts
@@ -1,0 +1,29 @@
+import { SimElbV2ConnectionRefusedError } from "../error/sim-elbv2.error.js";
+import type { SimElbV2Listener } from "../listener/sim-elbv2-listener.js";
+import { simElbV2RequestPort } from "./sim-elbv2-request-port.js";
+import type { SimElbV2LoadBalancerRoute } from "./sim-elbv2-router.js";
+
+/**
+ * Find the listener answering the port a request arrived on, or refuse.
+ *
+ * A port no listener holds throws rather than answering, because on real AWS
+ * the connection is refused and there is no status to send back.
+ */
+export function requireSimElbV2Listener(
+  route: SimElbV2LoadBalancerRoute,
+  request: Request,
+): SimElbV2Listener {
+  const { loadBalancer, elbV2 } = route;
+  const port = simElbV2RequestPort(new URL(request.url));
+  const listener = elbV2.findListenerOnPort(loadBalancer.arn, port);
+
+  if (listener === undefined) {
+    throw new SimElbV2ConnectionRefusedError(
+      `Load balancer '${loadBalancer.name}' has no listener on port ${String(
+        port,
+      )}`,
+    );
+  }
+
+  return listener;
+}

--- a/src/service/elbv2/serve/sim-elbv2-null-body-statuses.ts
+++ b/src/service/elbv2/serve/sim-elbv2-null-body-statuses.ts
@@ -1,0 +1,7 @@
+/**
+ * The statuses that cannot carry a body, whatever is configured or returned
+ * with them.
+ */
+export const simElbV2NullBodyStatuses: ReadonlySet<number> = new Set([
+  204, 205, 304,
+]);

--- a/src/service/elbv2/serve/sim-elbv2-redirect-location.ts
+++ b/src/service/elbv2/serve/sim-elbv2-redirect-location.ts
@@ -1,0 +1,94 @@
+import { assertDefined } from "../../../util/type-guard/defined.js";
+import type { SimElbV2RedirectActionConfig } from "../command/sim-elbv2-shared.command.js";
+
+/**
+ * The URI a request arrived at, in the five parts a redirect can reuse.
+ */
+export interface SimElbV2RequestUri {
+  /** The protocol the listener taking the request speaks. */
+  readonly protocol: string;
+  /** The host name the request named, without any port. */
+  readonly host: string;
+  /** The port the listener taking the request answers on. */
+  readonly port: string;
+  /** The path of the request URL, with its leading slash. */
+  readonly path: string;
+  /** The query string of the request URL, without its leading question mark. */
+  readonly query: string;
+}
+
+/**
+ * The keywords a redirect can carry, which are the only ones substituted.
+ */
+const keywordPattern = /#\{(?:protocol|host|port|path|query)\}/gu;
+
+/**
+ * Builds the URI a `redirect` action sends the client to.
+ *
+ * A component the action does not name keeps the request's own value, so a
+ * redirect that changes only the protocol still lands on the same path. The
+ * five reserved keywords put a component back where the action names another,
+ * and `#{path}` is the one with a shape of its own: it has the leading slash
+ * removed, which is why leaving the path alone is written as `/#{path}`.
+ *
+ * The port is always in the URI, including when it is the protocol's own, which
+ * is what real ELB sends. A redirect to HTTPS on 443 therefore answers with a
+ * Location ending `:443`, and a test asserting on it is asserting on what a
+ * client would really receive.
+ */
+export class SimElbV2RedirectLocation {
+  private readonly keywords: ReadonlyMap<string, string>;
+
+  constructor(original: SimElbV2RequestUri) {
+    this.keywords = new Map([
+      ["#{protocol}", original.protocol],
+      ["#{host}", original.host],
+      ["#{port}", original.port],
+      ["#{path}", original.path.replace(/^\//u, "")],
+      ["#{query}", original.query],
+    ]);
+  }
+
+  /**
+   * Build the Location one redirect action sends.
+   */
+  build(config: SimElbV2RedirectActionConfig): string {
+    const protocol = this.substitute(config.Protocol ?? "#{protocol}");
+    const host = this.substitute(config.Host ?? "#{host}");
+    const port = this.substitute(config.Port ?? "#{port}");
+    const path = this.substitute(config.Path ?? "/#{path}");
+    const query = this.substitute(config.Query ?? "#{query}");
+
+    // Lowercased, because ELB takes the protocol as HTTP or HTTPS and a URI
+    // scheme is written in lower case.
+    return `${protocol.toLowerCase()}://${host}:${port}${path}${this.queryPart(query)}`;
+  }
+
+  private substitute(component: string): string {
+    return component.replaceAll(keywordPattern, (keyword) =>
+      this.keyword(keyword),
+    );
+  }
+
+  private keyword(keyword: string): string {
+    const value = this.keywords.get(keyword);
+
+    // The pattern matches only the five keywords the map was built with.
+    assertDefined(value, `No sim ELBv2 redirect value for ${keyword}`);
+
+    return value;
+  }
+
+  /**
+   * The query string as the URI carries it, which is nothing when there is
+   * none. The question mark is ELB's to add, which is why a configured query
+   * does not carry one.
+   */
+  private queryPart(query: string): string {
+    if (query === "") {
+      return "";
+    }
+
+    return `?${query}`;
+  }
+}

--- a/src/service/elbv2/serve/sim-elbv2-redirect-response.ts
+++ b/src/service/elbv2/serve/sim-elbv2-redirect-response.ts
@@ -1,0 +1,72 @@
+import { assertDefined } from "../../../util/type-guard/defined.js";
+import type { SimElbV2Action } from "../action/sim-elbv2-action.js";
+import { simElbV2MatchableRequest } from "../listener/rule/match/sim-elbv2-matchable-request.js";
+import type { SimElbV2Listener } from "../listener/sim-elbv2-listener.js";
+import {
+  SimElbV2RedirectLocation,
+  type SimElbV2RequestUri,
+} from "./sim-elbv2-redirect-location.js";
+
+interface SimElbV2RedirectInput {
+  readonly action: SimElbV2Action;
+  readonly listener: SimElbV2Listener;
+  readonly request: Request;
+}
+
+/**
+ * Answers a request with a listener or rule's `redirect` action.
+ *
+ * Like a fixed response this needs no target, which is why it is the usual way
+ * to send HTTP to HTTPS: a listener on port 80 can redirect without anything
+ * being registered behind it.
+ */
+export class SimElbV2RedirectResponse {
+  /**
+   * Build the response one redirect action sends.
+   */
+  respond(input: SimElbV2RedirectInput): Response {
+    const config = input.action.redirect;
+
+    // A redirect action is created with a configuration and a status code, so
+    // a stored one always has both.
+    assertDefined(
+      config,
+      `Simulated ELBv2 redirect action holds no RedirectConfig`,
+    );
+    assertDefined(
+      config.StatusCode,
+      `Simulated ELBv2 redirect action holds no StatusCode`,
+    );
+
+    const location = new SimElbV2RedirectLocation(this.uri(input)).build(
+      config,
+    );
+
+    // The status code is written as HTTP_301 or HTTP_302, which is the form
+    // ELB takes it in rather than the number it sends.
+    return new Response(null, {
+      status: Number(config.StatusCode.replace("HTTP_", "")),
+      headers: { location },
+    });
+  }
+
+  /**
+   * The URI the request arrived at, which is what an unnamed component of the
+   * redirect keeps.
+   *
+   * The protocol and port are the listener's rather than the URL's, because
+   * they are what the load balancer answered on. Nothing here performs TLS, so
+   * a URL can name a scheme the listener does not speak.
+   */
+  private uri(input: SimElbV2RedirectInput): SimElbV2RequestUri {
+    const { host, path } = simElbV2MatchableRequest(input.request);
+
+    return {
+      protocol: input.listener.protocol,
+      host,
+      port: String(input.listener.port),
+      path,
+      query: new URL(input.request.url).search.replace(/^\?/u, ""),
+    };
+  }
+}

--- a/src/service/elbv2/serve/sim-elbv2-response-builder.ts
+++ b/src/service/elbv2/serve/sim-elbv2-response-builder.ts
@@ -1,6 +1,7 @@
 import { SimElbV2BodyEncoding } from "./sim-elbv2-body-encoding.js";
 import { SimElbV2ErrorResponse } from "./sim-elbv2-error-response.js";
 import type { SimElbV2Result } from "./sim-elbv2-event.type.js";
+import { simElbV2NullBodyStatuses } from "./sim-elbv2-null-body-statuses.js";
 
 /**
  * The largest response real ELB takes from a Lambda target.
@@ -9,11 +10,6 @@ import type { SimElbV2Result } from "./sim-elbv2-event.type.js";
  * so a base64 body counts at its encoded size and the headers count too.
  */
 const maximumResponseBytes = 1024 * 1024;
-
-/**
- * The statuses that cannot carry a body, whatever a handler returns with them.
- */
-const nullBodyStatuses: ReadonlySet<number> = new Set([204, 205, 304]);
 
 /**
  * The response headers a load balancer writes itself rather than passing on.
@@ -113,7 +109,7 @@ export class SimElbV2ResponseBuilder {
     statusCode: number,
     body: Uint8Array | string,
   ): Uint8Array | string | null {
-    if (nullBodyStatuses.has(statusCode) || body.length === 0) {
+    if (simElbV2NullBodyStatuses.has(statusCode) || body.length === 0) {
       return null;
     }
 

--- a/src/service/elbv2/serve/sim-elbv2-rule-evaluation.ts
+++ b/src/service/elbv2/serve/sim-elbv2-rule-evaluation.ts
@@ -1,0 +1,67 @@
+import { assertDefined } from "../../../util/type-guard/defined.js";
+import type { SimElbV2Action } from "../action/sim-elbv2-action.js";
+import { simElbV2MatchableRequest } from "../listener/rule/match/sim-elbv2-matchable-request.js";
+import type { SimElbV2Listener } from "../listener/sim-elbv2-listener.js";
+import type { SimElbV2 } from "../sim-elbv2.js";
+
+/**
+ * The action answering one request, and what it came from.
+ *
+ * The source is carried so a refusal can name the rule or listener holding the
+ * action rather than only the action itself, which is the part a reader has to
+ * go and change.
+ */
+export class SimElbV2MatchedAction {
+  constructor(
+    public readonly action: SimElbV2Action,
+    public readonly source: string,
+  ) {}
+}
+
+/**
+ * Chooses the action a listener answers a request with.
+ *
+ * Rules are evaluated in priority order, lowest number first, and the first one
+ * whose conditions all hold claims the request. A later rule that would also
+ * have matched never sees it, which is what makes priority the thing worth
+ * getting right. A request no rule claims falls through to the listener's
+ * default action, which is the rule real ELB reports as `default`.
+ */
+export class SimElbV2RuleEvaluation {
+  constructor(private readonly elbV2: SimElbV2) {}
+
+  /**
+   * The action answering one request on one listener.
+   */
+  actionFor(
+    listener: SimElbV2Listener,
+    request: Request,
+  ): SimElbV2MatchedAction {
+    const matchable = simElbV2MatchableRequest(request);
+    const rule = this.elbV2
+      .findRulesForListener(listener.arn)
+      .find((candidate) => candidate.matches(matchable));
+
+    if (rule === undefined) {
+      return this.only(listener.defaultActions, `Listener ${listener.arn}`);
+    }
+
+    return this.only(rule.actions, `Rule ${rule.arn}`);
+  }
+
+  /**
+   * The one action a listener or rule holds.
+   */
+  private only(
+    actions: readonly SimElbV2Action[],
+    source: string,
+  ): SimElbV2MatchedAction {
+    const [action] = actions;
+
+    // A listener and a rule are each created with exactly one action, and
+    // modifying either replaces the list with another one action long.
+    assertDefined(action, `${source} holds no action`);
+
+    return new SimElbV2MatchedAction(action, source);
+  }
+}

--- a/src/service/elbv2/serve/sim-elbv2-serve-actions.iso.test.ts
+++ b/src/service/elbv2/serve/sim-elbv2-serve-actions.iso.test.ts
@@ -1,0 +1,222 @@
+import { assertIdentical } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { assertDefined } from "../../../util/type-guard/defined.js";
+import { SimAws } from "../../aws/sim-aws.js";
+import type { SimElbV2ActionInput } from "../command/sim-elbv2-shared.command.js";
+import type { SimElbV2LoadBalancer } from "../load-balancer/sim-elbv2-load-balancer.js";
+import { simElbV2Fetch } from "./sim-elbv2-fetch.js";
+import { simElbV2LambdaTargetFactory } from "./sim-elbv2-lambda-target.factory.js";
+
+/**
+ * Add a rule answering a path with an action needing no target group.
+ */
+async function addRule(
+  simAws: SimAws,
+  loadBalancer: SimElbV2LoadBalancer,
+  path: string,
+  action: SimElbV2ActionInput,
+): Promise<void> {
+  const elbV2 = simAws.elbV2();
+  const listener = elbV2.findListenerOnPort(loadBalancer.arn, 80);
+
+  assertDefined(listener, `No listener on port 80 of ${loadBalancer.name}`);
+
+  await elbV2.createRule({
+    input: {
+      ListenerArn: listener.arn,
+      Priority: 10,
+      Conditions: [{ Field: "path-pattern", Values: [path] }],
+      Actions: [action],
+    },
+  });
+}
+
+describe("Answering a sim ELBv2 request without a target", () => {
+  it("answers a fixed-response rule with what it holds", async () => {
+    // Given a rule answering a health path itself
+    const simAws = new SimAws();
+    const loadBalancer = await simElbV2LambdaTargetFactory.make({}, simAws);
+    await addRule(simAws, loadBalancer, "/health", {
+      Type: "fixed-response",
+      FixedResponseConfig: {
+        StatusCode: "200",
+        ContentType: "application/json",
+        MessageBody: '{"ok":true}',
+      },
+    });
+
+    // When a request arrives at it
+    const response = await simElbV2Fetch(
+      simAws,
+      `http://${loadBalancer.dnsName}/health`,
+    );
+
+    // Then the load balancer wrote the response itself, with no function
+    // invoked and no target group named by the action at all
+    assertIdentical(response.status, 200);
+    assertIdentical(response.headers.get("content-type"), "application/json");
+    assertIdentical(await response.text(), '{"ok":true}');
+  });
+
+  it("sends no body and no content type when a fixed response names none", async () => {
+    // Given a fixed response that is only a status code
+    const simAws = new SimAws();
+    const loadBalancer = await simElbV2LambdaTargetFactory.make({}, simAws);
+    await addRule(simAws, loadBalancer, "/gone", {
+      Type: "fixed-response",
+      FixedResponseConfig: { StatusCode: "410" },
+    });
+
+    // When a request arrives at it
+    const response = await simElbV2Fetch(
+      simAws,
+      `http://${loadBalancer.dnsName}/gone`,
+    );
+
+    // Then nothing is invented to go with the status
+    assertIdentical(response.status, 410);
+    assertIdentical(response.headers.get("content-type"), null);
+    assertIdentical(await response.text(), "");
+  });
+
+  it("sends no body with a status that cannot carry one", async () => {
+    // Given a fixed response on a status with no body
+    const simAws = new SimAws();
+    const loadBalancer = await simElbV2LambdaTargetFactory.make({}, simAws);
+    await addRule(simAws, loadBalancer, "/ping", {
+      Type: "fixed-response",
+      FixedResponseConfig: { StatusCode: "204", MessageBody: "pong" },
+    });
+
+    // When a request arrives at it
+    const response = await simElbV2Fetch(
+      simAws,
+      `http://${loadBalancer.dnsName}/ping`,
+    );
+
+    // Then the message body is dropped, as a 204 has to have none
+    assertIdentical(response.status, 204);
+    assertIdentical(response.body, null);
+  });
+
+  it("answers a listener whose default action is a fixed response", async () => {
+    // Given a listener answering everything itself rather than forwarding
+    const simAws = new SimAws();
+    const loadBalancer = await simElbV2LambdaTargetFactory.make({}, simAws);
+    const elbV2 = simAws.elbV2();
+
+    await elbV2.modifyListener({
+      input: {
+        ListenerArn: elbV2.findListenerOnPort(loadBalancer.arn, 80)?.arn,
+        DefaultActions: [
+          {
+            Type: "fixed-response",
+            FixedResponseConfig: {
+              StatusCode: "404",
+              ContentType: "text/plain",
+              MessageBody: "no route",
+            },
+          },
+        ],
+      },
+    });
+
+    // When a request arrives
+    const response = await simElbV2Fetch(
+      simAws,
+      `http://${loadBalancer.dnsName}/orders`,
+    );
+
+    // Then the default action answered it, with no target involved
+    assertIdentical(response.status, 404);
+    assertIdentical(await response.text(), "no route");
+  });
+
+  it("redirects with the components a rule names and keeps the rest", async () => {
+    // Given a rule redirecting to HTTPS, which is the usual reason to have one
+    const simAws = new SimAws();
+    const loadBalancer = await simElbV2LambdaTargetFactory.make({}, simAws);
+    await addRule(simAws, loadBalancer, "/*", {
+      Type: "redirect",
+      RedirectConfig: {
+        Protocol: "HTTPS",
+        Port: "443",
+        StatusCode: "HTTP_301",
+      },
+    });
+
+    // When a request arrives on the HTTP listener
+    const response = await simElbV2Fetch(
+      simAws,
+      `http://${loadBalancer.dnsName}/orders?ref=email`,
+      { headers: { host: "shop.example.com" } },
+    );
+
+    // Then the host, path and query came through untouched, and the port is in
+    // the Location even though it is the protocol's own, which is what real
+    // ELB sends
+    assertIdentical(response.status, 301);
+    assertIdentical(
+      response.headers.get("location"),
+      "https://shop.example.com:443/orders?ref=email",
+    );
+    assertIdentical(response.body, null);
+  });
+
+  it("substitutes the reserved keywords a redirect writes", async () => {
+    // Given a redirect building each component out of the request's own
+    const simAws = new SimAws();
+    const loadBalancer = await simElbV2LambdaTargetFactory.make({}, simAws);
+    await addRule(simAws, loadBalancer, "/*", {
+      Type: "redirect",
+      RedirectConfig: {
+        Protocol: "#{protocol}",
+        Host: "new.#{host}",
+        Port: "#{port}",
+        Path: "/moved/#{path}",
+        Query: "#{query}&moved=1",
+        StatusCode: "HTTP_302",
+      },
+    });
+
+    // When a request arrives
+    const response = await simElbV2Fetch(
+      simAws,
+      `http://${loadBalancer.dnsName}/orders/42?ref=email`,
+      { headers: { host: "shop.example.com" } },
+    );
+
+    // Then each keyword was replaced with the request's own value, and
+    // #{path} came without its leading slash, which is why the path a redirect
+    // keeps is written as /#{path}
+    assertIdentical(response.status, 302);
+    assertIdentical(
+      response.headers.get("location"),
+      "http://new.shop.example.com:80/moved/orders/42?ref=email&moved=1",
+    );
+  });
+
+  it("leaves the question mark off a redirect with no query string", async () => {
+    // Given a redirect keeping the request's query string
+    const simAws = new SimAws();
+    const loadBalancer = await simElbV2LambdaTargetFactory.make({}, simAws);
+    await addRule(simAws, loadBalancer, "/*", {
+      Type: "redirect",
+      RedirectConfig: { Host: "www.example.com", StatusCode: "HTTP_301" },
+    });
+
+    // When a request with no query string arrives
+    const response = await simElbV2Fetch(
+      simAws,
+      `http://${loadBalancer.dnsName}/orders`,
+    );
+
+    // Then the Location ends at the path, since the question mark is ELB's to
+    // add rather than the configuration's
+    assertIdentical(
+      response.headers.get("location"),
+      "http://www.example.com:80/orders",
+    );
+  });
+});

--- a/src/service/elbv2/serve/sim-elbv2-serve-refusals.iso.test.ts
+++ b/src/service/elbv2/serve/sim-elbv2-serve-refusals.iso.test.ts
@@ -5,38 +5,6 @@ import { simElbV2Fetch } from "./sim-elbv2-fetch.js";
 import { simElbV2LambdaTargetFactory } from "./sim-elbv2-lambda-target.factory.js";
 
 describe("What a sim ELBv2 load balancer will not carry a request through", () => {
-  it("refuses a listener whose default action is a fixed response", async () => {
-    // Given a load balancer with a listener
-    const simAws = new SimAws();
-    const loadBalancer = await simElbV2LambdaTargetFactory.make({}, simAws);
-    const elbV2 = simAws.elbV2();
-
-    // And that listener answering with a fixed response rather than forwarding
-    await elbV2.modifyListener({
-      input: {
-        ListenerArn: elbV2.findListenerOnPort(loadBalancer.arn, 80)?.arn,
-        DefaultActions: [
-          {
-            Type: "fixed-response",
-            FixedResponseConfig: { StatusCode: "404" },
-          },
-        ],
-      },
-    });
-
-    // When a request reaches it
-    const request = simElbV2Fetch(
-      simAws,
-      `http://${loadBalancer.dnsName}/orders`,
-    );
-
-    // Then the action is stored and not performed, and saying so beats
-    // forwarding a request the configuration said to answer
-    await expect(request).rejects.toThrow(
-      "answers a request with a 'fixed-response' action",
-    );
-  });
-
   it("refuses a listener forwarding to an ip target group", async () => {
     // Given a load balancer with a listener
     const simAws = new SimAws();
@@ -118,6 +86,55 @@ describe("What a sim ELBv2 load balancer will not carry a request through", () =
     // here reads them
     await expect(request).rejects.toThrow(
       "Weighted forwarding is not simulated",
+    );
+  });
+
+  it("names the rule holding a forward it cannot carry out", async () => {
+    // Given a load balancer with a second target group
+    const simAws = new SimAws();
+    const loadBalancer = await simElbV2LambdaTargetFactory.make({}, simAws);
+    const elbV2 = simAws.elbV2();
+    const checkout = await elbV2.describeTargetGroups({ input: {} });
+    const refunds = await elbV2.createTargetGroup({
+      input: { Name: "refunds-tg", TargetType: "lambda" },
+    });
+
+    // And a rule forwarding to both of them by weight
+    const created = await elbV2.createRule({
+      input: {
+        ListenerArn: elbV2.findListenerOnPort(loadBalancer.arn, 80)?.arn,
+        Priority: 10,
+        Conditions: [{ Field: "path-pattern", Values: ["/web/*"] }],
+        Actions: [
+          {
+            Type: "forward",
+            ForwardConfig: {
+              TargetGroups: [
+                {
+                  TargetGroupArn: checkout.TargetGroups?.[0]?.TargetGroupArn,
+                  Weight: 1,
+                },
+                {
+                  TargetGroupArn: refunds.TargetGroups?.[0]?.TargetGroupArn,
+                  Weight: 1,
+                },
+              ],
+            },
+          },
+        ],
+      },
+    });
+
+    // When a request the rule claims reaches it
+    const request = simElbV2Fetch(
+      simAws,
+      `http://${loadBalancer.dnsName}/web/index.html`,
+    );
+
+    // Then the refusal names the rule holding the action, which is what a
+    // reader has to go and change, rather than only the listener it is on
+    await expect(request).rejects.toThrow(
+      `Rule ${created.Rules?.[0]?.RuleArn ?? ""} forwards to 2 target groups`,
     );
   });
 });

--- a/src/service/elbv2/serve/sim-elbv2-serve-refusals.iso.test.ts
+++ b/src/service/elbv2/serve/sim-elbv2-serve-refusals.iso.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 
+import { assertDefined } from "../../../util/type-guard/defined.js";
 import { SimAws } from "../../aws/sim-aws.js";
 import { simElbV2Fetch } from "./sim-elbv2-fetch.js";
 import { simElbV2LambdaTargetFactory } from "./sim-elbv2-lambda-target.factory.js";
@@ -133,8 +134,11 @@ describe("What a sim ELBv2 load balancer will not carry a request through", () =
 
     // Then the refusal names the rule holding the action, which is what a
     // reader has to go and change, rather than only the listener it is on
+    const ruleArn = created.Rules?.[0]?.RuleArn;
+    assertDefined(ruleArn, "CreateRule reported no rule ARN");
+
     await expect(request).rejects.toThrow(
-      `Rule ${created.Rules?.[0]?.RuleArn ?? ""} forwards to 2 target groups`,
+      `Rule ${ruleArn} forwards to 2 target groups`,
     );
   });
 });

--- a/src/service/elbv2/serve/sim-elbv2-serve-rules.iso.test.ts
+++ b/src/service/elbv2/serve/sim-elbv2-serve-rules.iso.test.ts
@@ -1,0 +1,237 @@
+import { assertIdentical } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { assertDefined } from "../../../util/type-guard/defined.js";
+import { SimAws } from "../../aws/sim-aws.js";
+import type { SimElbV2RuleConditionInput } from "../command/rule/rule-condition.command.js";
+import type { SimElbV2LoadBalancer } from "../load-balancer/sim-elbv2-load-balancer.js";
+import type { SimElbV2 } from "../sim-elbv2.js";
+import type { SimElbV2Result } from "./sim-elbv2-event.type.js";
+import { simElbV2Fetch } from "./sim-elbv2-fetch.js";
+import { simElbV2LambdaTargetFactory } from "./sim-elbv2-lambda-target.factory.js";
+import { simElbV2ServingTargetGroupFactory } from "./sim-elbv2-serving-target-group.factory.js";
+
+/**
+ * A load balancer whose default action answers `checkout`.
+ */
+async function makeLoadBalancer(simAws: SimAws): Promise<SimElbV2LoadBalancer> {
+  return await simElbV2LambdaTargetFactory.make({}, simAws);
+}
+
+/**
+ * Add a rule sending a request to a target group answering with its own name.
+ */
+async function addRule(
+  simAws: SimAws,
+  loadBalancer: SimElbV2LoadBalancer,
+  priority: number,
+  name: string,
+  conditions: readonly SimElbV2RuleConditionInput[],
+): Promise<void> {
+  const elbV2: SimElbV2 = simAws.elbV2();
+  const targetGroup = await simElbV2ServingTargetGroupFactory.make(
+    { name, handler: (): SimElbV2Result => ({ statusCode: 200, body: name }) },
+    simAws,
+  );
+  const listener = elbV2.findListenerOnPort(loadBalancer.arn, 80);
+
+  assertDefined(listener, `No listener on port 80 of ${loadBalancer.name}`);
+
+  await elbV2.createRule({
+    input: {
+      ListenerArn: listener.arn,
+      Priority: priority,
+      Conditions: conditions,
+      Actions: [{ Type: "forward", TargetGroupArn: targetGroup.arn }],
+    },
+  });
+}
+
+describe("Matching sim ELBv2 listener rules against a request", () => {
+  it("sends a request to the target group its path pattern names", async () => {
+    // Given a load balancer with a rule on a path prefix
+    const simAws = new SimAws();
+    const loadBalancer = await makeLoadBalancer(simAws);
+    await addRule(simAws, loadBalancer, 10, "api", [
+      { Field: "path-pattern", Values: ["/api/*"] },
+    ]);
+
+    // When a request arrives under that path
+    const response = await simElbV2Fetch(
+      simAws,
+      `http://${loadBalancer.dnsName}/api/orders`,
+    );
+
+    // Then the rule claimed it rather than the listener's default action
+    assertIdentical(await response.text(), "api");
+  });
+
+  it("falls through to the default action when no rule matches", async () => {
+    // Given the same load balancer and rule
+    const simAws = new SimAws();
+    const loadBalancer = await makeLoadBalancer(simAws);
+    await addRule(simAws, loadBalancer, 10, "api", [
+      { Field: "path-pattern", Values: ["/api/*"] },
+    ]);
+
+    // When a request arrives at the prefix itself, which the pattern does not
+    // cover, and at a path nothing mentions
+    const bare = await simElbV2Fetch(
+      simAws,
+      `http://${loadBalancer.dnsName}/api`,
+    );
+    const elsewhere = await simElbV2Fetch(
+      simAws,
+      `http://${loadBalancer.dnsName}/orders`,
+    );
+
+    // Then both are answered by the default action, which is the listener's
+    // own and the rule real ELB reports as `default`
+    assertIdentical(await bare.text(), "checkout");
+    assertIdentical(await elsewhere.text(), "checkout");
+  });
+
+  it("takes the first matching rule in priority order", async () => {
+    // Given two rules that both match a request, the lower priority one last
+    const simAws = new SimAws();
+    const loadBalancer = await makeLoadBalancer(simAws);
+    await addRule(simAws, loadBalancer, 20, "everything", [
+      { Field: "path-pattern", Values: ["/*"] },
+    ]);
+    await addRule(simAws, loadBalancer, 10, "api", [
+      { Field: "path-pattern", Values: ["/api/*"] },
+    ]);
+
+    // When a request both would claim arrives
+    const response = await simElbV2Fetch(
+      simAws,
+      `http://${loadBalancer.dnsName}/api/orders`,
+    );
+
+    // Then the lowest priority number won, and the rule created first never
+    // saw the request
+    assertIdentical(await response.text(), "api");
+  });
+
+  it("takes the later rule once the earlier one stops matching", async () => {
+    // Given the same two rules
+    const simAws = new SimAws();
+    const loadBalancer = await makeLoadBalancer(simAws);
+    await addRule(simAws, loadBalancer, 20, "everything", [
+      { Field: "path-pattern", Values: ["/*"] },
+    ]);
+    await addRule(simAws, loadBalancer, 10, "api", [
+      { Field: "path-pattern", Values: ["/api/*"] },
+    ]);
+
+    // When a request only the second one claims arrives
+    const response = await simElbV2Fetch(
+      simAws,
+      `http://${loadBalancer.dnsName}/orders`,
+    );
+
+    // Then evaluation carried on past the rule that did not match
+    assertIdentical(await response.text(), "everything");
+  });
+
+  it("matches a host header rule against the Host header sent", async () => {
+    // Given a rule on a wildcard subdomain
+    const simAws = new SimAws();
+    const loadBalancer = await makeLoadBalancer(simAws);
+    await addRule(simAws, loadBalancer, 10, "admin", [
+      { Field: "host-header", Values: ["*.internal.example.com"] },
+    ]);
+
+    // When requests naming a host under and beside that domain arrive
+    const claimed = await simElbV2Fetch(
+      simAws,
+      `http://${loadBalancer.dnsName}/orders`,
+      { headers: { host: "ops.internal.example.com:8080" } },
+    );
+    const missed = await simElbV2Fetch(
+      simAws,
+      `http://${loadBalancer.dnsName}/orders`,
+      { headers: { host: "internal.example.com" } },
+    );
+
+    // Then the Host header decided it, with the port left out of the
+    // comparison, and the bare domain fell through
+    assertIdentical(await claimed.text(), "admin");
+    assertIdentical(await missed.text(), "checkout");
+  });
+
+  it("claims a request only when every condition on a rule holds", async () => {
+    // Given a rule carrying a host header and a path pattern
+    const simAws = new SimAws();
+    const loadBalancer = await makeLoadBalancer(simAws);
+    await addRule(simAws, loadBalancer, 10, "admin", [
+      { Field: "host-header", Values: ["admin.example.com"] },
+      { Field: "path-pattern", Values: ["/api/*"] },
+    ]);
+
+    // When requests satisfying both, and each on its own, arrive
+    const both = await simElbV2Fetch(
+      simAws,
+      `http://${loadBalancer.dnsName}/api/orders`,
+      { headers: { host: "admin.example.com" } },
+    );
+    const hostOnly = await simElbV2Fetch(
+      simAws,
+      `http://${loadBalancer.dnsName}/orders`,
+      { headers: { host: "admin.example.com" } },
+    );
+    const pathOnly = await simElbV2Fetch(
+      simAws,
+      `http://${loadBalancer.dnsName}/api/orders`,
+    );
+
+    // Then several conditions on one rule are an and
+    assertIdentical(await both.text(), "admin");
+    assertIdentical(await hostOnly.text(), "checkout");
+    assertIdentical(await pathOnly.text(), "checkout");
+  });
+
+  it("matches a path pattern against the path and not the query string", async () => {
+    // Given a rule on a path
+    const simAws = new SimAws();
+    const loadBalancer = await makeLoadBalancer(simAws);
+    await addRule(simAws, loadBalancer, 10, "reports", [
+      { Field: "path-pattern", Values: ["/reports"] },
+    ]);
+
+    // When a request carrying a query string arrives at that path
+    const response = await simElbV2Fetch(
+      simAws,
+      `http://${loadBalancer.dnsName}/reports?from=2026-01-01`,
+    );
+
+    // Then the query string was not part of the comparison, which is what the
+    // query-string condition would be for
+    assertIdentical(await response.text(), "reports");
+  });
+
+  it("stops matching a rule that has been deleted", async () => {
+    // Given a load balancer whose rule is then deleted
+    const simAws = new SimAws();
+    const loadBalancer = await makeLoadBalancer(simAws);
+    await addRule(simAws, loadBalancer, 10, "api", [
+      { Field: "path-pattern", Values: ["/api/*"] },
+    ]);
+
+    const elbV2 = simAws.elbV2();
+    const listener = elbV2.findListenerOnPort(loadBalancer.arn, 80);
+    assertDefined(listener, "No listener on port 80");
+
+    const rules = elbV2.findRulesForListener(listener.arn);
+    await elbV2.deleteRule({ input: { RuleArn: rules[0]?.arn } });
+
+    // When the request it claimed arrives again
+    const response = await simElbV2Fetch(
+      simAws,
+      `http://${loadBalancer.dnsName}/api/orders`,
+    );
+
+    // Then it falls through to the default action
+    assertIdentical(await response.text(), "checkout");
+  });
+});

--- a/src/service/elbv2/serve/sim-elbv2-serving-target-group.factory.ts
+++ b/src/service/elbv2/serve/sim-elbv2-serving-target-group.factory.ts
@@ -1,0 +1,97 @@
+import { AsyncMappedFactory } from "@kensio/part-factory";
+
+import { assertDefined } from "../../../util/type-guard/defined.js";
+import type { SimAws } from "../../aws/sim-aws.js";
+import { makeLambdaZipFileInput } from "../../lambda/function/code/lambda-zip-file-input.js";
+import { createFixtureLambdaTargetGroup } from "../sim-elbv2.fixture.js";
+import type { SimElbV2TargetGroup } from "../target-group/sim-elbv2-target-group.js";
+import type { SimElbV2Event, SimElbV2Result } from "./sim-elbv2-event.type.js";
+import { simElbV2ServicePrincipal } from "./sim-elbv2-invoke-authorizer.js";
+
+/**
+ * The statement id the invoke permission is granted under.
+ */
+export const simElbV2InvokeStatementId = "elb-invoke";
+
+/**
+ * The function code a target group holds when a test does not care what it
+ * answers, only that something did.
+ */
+export function simElbV2CheckoutHandler(): SimElbV2Result {
+  return { statusCode: 200, body: "checkout" };
+}
+
+/**
+ * What a test asks for when it wants a target group that answers.
+ */
+export interface SimElbV2ServingTargetGroupInput {
+  /**
+   * The name the function takes, and which the target group takes with `-tg`
+   * on the end.
+   */
+  readonly name: string;
+  /** The function code the target group hands its requests to. */
+  readonly handler: (event: SimElbV2Event) => unknown;
+}
+
+/**
+ * Creates a `lambda` target group holding a function that answers, through the
+ * ordinary commands.
+ *
+ * A target group that serves is four commands rather than one: the function,
+ * the group, the invoke permission and the registration. A test about routing a
+ * request to one of several groups is about none of them, and it needs more
+ * than one group, so building one is done here.
+ *
+ * Everything is created in the default Account and Region of the simulated AWS
+ * it is given, because real ELB requires a Lambda target to be in the same
+ * Account and Region as its target group.
+ */
+export const simElbV2ServingTargetGroupFactory = new AsyncMappedFactory<
+  SimElbV2ServingTargetGroupInput,
+  SimElbV2TargetGroup,
+  SimAws
+>(
+  () => ({ name: "checkout", handler: simElbV2CheckoutHandler }),
+  async (input, simAws) => {
+    const simLambda = simAws.lambda();
+    const { FunctionArn } = await simLambda.createFunction({
+      input: {
+        FunctionName: input.name,
+        Role: `arn:aws:iam::888888888888:role/${input.name}-role`,
+        Code: { ZipFile: makeLambdaZipFileInput(input.handler) },
+      },
+    });
+
+    const elbV2 = simAws.elbV2();
+    const groupArn = await createFixtureLambdaTargetGroup(
+      elbV2,
+      `${input.name}-tg`,
+    );
+
+    await simLambda.addPermission({
+      input: {
+        FunctionName: input.name,
+        StatementId: simElbV2InvokeStatementId,
+        Action: "lambda:InvokeFunction",
+        Principal: simElbV2ServicePrincipal,
+        SourceArn: groupArn,
+      },
+    });
+
+    await elbV2.registerTargets({
+      input: { TargetGroupArn: groupArn, Targets: [{ Id: FunctionArn }] },
+    });
+
+    // A target group CreateTargetGroup reported is one the store holds, so
+    // this is only missing if something is wrong with the simulator itself.
+    const targetGroup = elbV2.findTargetGroupByArn(groupArn);
+    assertDefined(
+      targetGroup,
+      `Simulated ELBv2 created the target group ${groupArn} and then did ` +
+        `not hold it`,
+    );
+
+    return targetGroup;
+  },
+);

--- a/src/service/elbv2/sim-elbv2.ts
+++ b/src/service/elbv2/sim-elbv2.ts
@@ -12,6 +12,7 @@ import {
 import type * as elbV2 from "./command/sim-elbv2-command.types.js";
 import { SimElbV2Commands } from "./command/sim-elbv2-commands.js";
 import type { SimElbV2RequestOptions } from "./command/sim-elbv2-request-options.js";
+import type { SimElbV2ListenerRule } from "./listener/rule/sim-elbv2-listener-rule.js";
 import type { SimElbV2Listener } from "./listener/sim-elbv2-listener.js";
 import type { SimElbV2LoadBalancer } from "./load-balancer/sim-elbv2-load-balancer.js";
 import { SimElbV2Registry } from "./registry/sim-elbv2-registry.js";
@@ -96,6 +97,16 @@ export class SimElbV2 {
     port: number,
   ): SimElbV2Listener | undefined {
     return this.stores.listeners.findOnPort(loadBalancerArn, port);
+  }
+
+  /**
+   * The rules on one listener, in the order that listener evaluates them.
+   *
+   * This is what a request arriving at a listener is matched against, before
+   * it falls through to the listener's own default action.
+   */
+  findRulesForListener(listenerArn: string): readonly SimElbV2ListenerRule[] {
+    return this.stores.rules.forListener(listenerArn);
   }
 
   /**


### PR DESCRIPTION
A listener now evaluates its rules in priority order and the first one whose conditions all hold claims the request, falling through to the default action when none does. Conditions are `host-header` and `path-pattern`, compared with ELB's own wildcard semantics, which were checked against the AWS API reference rather than assumed: the whole value has to match, so `/api/*` does not claim `/api` and `*.example.com` does not claim `example.com`, and both of those have a test. A path pattern is compared with regard to case and against the path alone, and a host name without regard to case. The other four condition fields real ELB has are now refused when the rule is written, which narrows what #574 accepted: storing one would leave a rule that looks configured and never claims a request. A field ELB never had is a plain ValidationError instead, since the two mean different things to whoever sent the rule. The `fixed-response` and `redirect` actions are carried out alongside `forward`, and neither touches a target group, so a listener holding one serves with nothing registered behind it. A redirect substitutes the five reserved keywords, keeps the components it does not name, and always carries the port in the Location, including `:443`, which is what real ELB sends. Refused when the rule is written: a content type ELB will not send a fixed response as, a redirect protocol, port or path outside what ELB takes, and a redirect that changes nothing and so loops. The divergences are in Limitations: HTTPS to HTTP is not refused, since nothing here performs TLS for a listener protocol to be trusted, `RegexValues` are not matched, and the length limits are not enforced.

Resolves https://github.com/KensioSoftware/yulin/issues/564

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added listener-rule routing based on priority, host headers, and path patterns.
  * Added wildcard matching, multi-condition rules, and default-action fallback.
  * Added fixed responses and HTTP redirects, including status, content type, and URI handling.
  * Added support for routing requests to Lambda-backed target groups.
* **Bug Fixes**
  * Improved validation for unsupported rule conditions and invalid response or redirect configurations.
* **Documentation**
  * Expanded ELBv2 routing documentation with practical examples and current limitations.
* **Tests**
  * Added comprehensive coverage for matching, routing, fixed responses, redirects, and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->