### PR TITLE
feat: keep tasks running with sim ECS services

### DIFF
--- a/docs/services/ecs/README.md
+++ b/docs/services/ecs/README.md
@@ -1,8 +1,8 @@
 # Simulated ECS
 
-Yulin includes a simulated Amazon ECS for tests and local development. It holds clusters and task
-definitions in memory, runs tasks from handlers you bind to their containers, and authorizes every
-operation with simulated IAM.
+Yulin includes a simulated Amazon ECS for tests and local development. It holds clusters, task
+definitions and services in memory, runs tasks from handlers you bind to their containers, and
+authorizes every operation with simulated IAM.
 
 ECS-specific types are imported from the `@kensio/yulin/ecs` subpath.
 
@@ -756,6 +756,247 @@ not started yet runs none of them, and one stopped part way through runs no more
 a task between `RunTask` and the background work that runs it. A task that has already stopped is
 reported as it stands, keeping the reason it stopped for.
 
+## Services
+
+A task runs and stops. A service keeps tasks running, which is what a deployed application usually
+is: a named service in a cluster, running some number of tasks from a task definition.
+
+`CreateService` creates one. Its tasks exist as soon as the request is answered and reach `RUNNING`
+on the simulation's background work, as real ECS brings a new service up, so the service reports the
+desired count it was given and a running count that catches up.
+
+```typescript sim-ecs-create-service
+/**
+ * Creating a simulated ECS service that keeps three tasks running.
+ */
+
+import {
+  CreateClusterCommand,
+  CreateServiceCommand,
+  DescribeServicesCommand,
+  ListTasksCommand,
+  RegisterTaskDefinitionCommand,
+} from "@aws-sdk/client-ecs";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const ecs = simAws.ecs();
+
+await ecs.createCluster(new CreateClusterCommand({ clusterName: "orders" }));
+
+ecs.bindContainer({
+  family: "checkout",
+  containerName: "app",
+  run: async () => {
+    await handleOneRequest();
+  },
+});
+
+await ecs.registerTaskDefinition(
+  new RegisterTaskDefinitionCommand({
+    family: "checkout",
+    containerDefinitions: [{ name: "app", image: "checkout:1" }],
+  }),
+);
+
+const created = await ecs.createService(
+  new CreateServiceCommand({
+    cluster: "orders",
+    serviceName: "checkout",
+    taskDefinition: "checkout",
+    desiredCount: 3,
+  }),
+);
+
+console.log(created.service?.desiredCount); // 3
+console.log(created.service?.runningCount); // 0, as real ECS answers one
+
+// The tasks come up in the background, as they do on real ECS.
+await simAws.backgroundTasksComplete();
+
+const described = await ecs.describeServices(
+  new DescribeServicesCommand({ cluster: "orders", services: ["checkout"] }),
+);
+
+console.log(described.services?.[0]?.runningCount); // 3
+
+const listed = await ecs.listTasks(
+  new ListTasksCommand({ cluster: "orders", serviceName: "checkout" }),
+);
+
+console.log(listed.taskArns?.length); // 3
+
+async function handleOneRequest(): Promise<void> {
+  await Promise.resolve();
+}
+```
+
+Each of those tasks is a task like any other: `ListTasks` returns its ARN, `DescribeTasks` describes
+it, and its containers report which of them Yulin is simulating.
+
+### The desired count is state, not concurrency
+
+A desired count of three does not mean three copies of your handler. Yulin runs in one Node.js
+process and there are no containers to copy, so the count is simulated as state: three tasks exist
+and are reported as running, while the handler bound to a container is called once per request or per
+poll, whenever something reaches it.
+
+That is a deliberate divergence. What it means in practice is that a service is worth asserting on
+for its state — how many tasks it keeps, which revision they run — rather than for anything about
+running three things at once. A test that needs concurrency is a test about your own code, not about
+ECS.
+
+Nothing calls a service container's handler yet. A container of a service that has come up is
+treated as running from that point, and what will call it is whatever reaches it: a load balancer
+sending it a request, or a queue it polls. Both follow separately.
+
+### Updating and deleting a service
+
+`UpdateService` changes the desired count, the task definition, or both. A new count starts or stops
+tasks to reach it. A new revision moves the service onto it, which replaces every task the service is
+running: real ECS replaces them a few at a time under a deployment configuration, and Yulin replaces
+them at once because nothing here takes any time to start.
+
+```typescript sim-ecs-update-service
+/**
+ * Scaling a simulated ECS service and moving it to a new revision.
+ */
+
+import {
+  CreateClusterCommand,
+  CreateServiceCommand,
+  ListTasksCommand,
+  RegisterTaskDefinitionCommand,
+  UpdateServiceCommand,
+} from "@aws-sdk/client-ecs";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const ecs = simAws.ecs();
+
+await ecs.createCluster(new CreateClusterCommand({ clusterName: "orders" }));
+await ecs.registerTaskDefinition(
+  new RegisterTaskDefinitionCommand({
+    family: "checkout",
+    containerDefinitions: [{ name: "app", image: "checkout:1" }],
+  }),
+);
+await ecs.createService(
+  new CreateServiceCommand({
+    cluster: "orders",
+    serviceName: "checkout",
+    taskDefinition: "checkout",
+    desiredCount: 1,
+  }),
+);
+
+const scaled = await ecs.updateService(
+  new UpdateServiceCommand({
+    cluster: "orders",
+    service: "checkout",
+    desiredCount: 4,
+  }),
+);
+
+console.log(scaled.service?.desiredCount); // 4
+
+const second = await ecs.registerTaskDefinition(
+  new RegisterTaskDefinitionCommand({
+    family: "checkout",
+    containerDefinitions: [{ name: "app", image: "checkout:2" }],
+  }),
+);
+
+const deployed = await ecs.updateService(
+  new UpdateServiceCommand({
+    cluster: "orders",
+    service: "checkout",
+    taskDefinition: "checkout:2",
+  }),
+);
+
+console.log(
+  deployed.service?.taskDefinition === second.taskDefinition?.taskDefinitionArn,
+); // true
+
+await simAws.backgroundTasksComplete();
+
+const listed = await ecs.listTasks(
+  new ListTasksCommand({ cluster: "orders", serviceName: "checkout" }),
+);
+
+console.log(listed.taskArns?.length); // 4, all of them on the new revision
+```
+
+`DeleteService` stops the service and its tasks. A service still scaled above zero is refused unless
+the request forces it, as real ECS refuses one, so scaling to zero first is the ordinary way round. A
+deleted service is still describable as `INACTIVE`, and its name is free to create again.
+
+```typescript sim-ecs-delete-service
+/**
+ * Deleting a simulated ECS service and the tasks it was keeping running.
+ */
+
+import {
+  CreateClusterCommand,
+  CreateServiceCommand,
+  DeleteServiceCommand,
+  DescribeServicesCommand,
+  ListTasksCommand,
+  RegisterTaskDefinitionCommand,
+} from "@aws-sdk/client-ecs";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const ecs = simAws.ecs();
+
+await ecs.createCluster(new CreateClusterCommand({ clusterName: "orders" }));
+await ecs.registerTaskDefinition(
+  new RegisterTaskDefinitionCommand({
+    family: "checkout",
+    containerDefinitions: [{ name: "app", image: "checkout:1" }],
+  }),
+);
+await ecs.createService(
+  new CreateServiceCommand({
+    cluster: "orders",
+    serviceName: "checkout",
+    taskDefinition: "checkout",
+    desiredCount: 2,
+  }),
+);
+await simAws.backgroundTasksComplete();
+
+const deleted = await ecs.deleteService(
+  new DeleteServiceCommand({
+    cluster: "orders",
+    service: "checkout",
+    force: true,
+  }),
+);
+
+console.log(deleted.service?.status); // "INACTIVE"
+
+const listed = await ecs.listTasks(
+  new ListTasksCommand({ cluster: "orders", serviceName: "checkout" }),
+);
+
+console.log(listed.taskArns?.length); // 0
+
+const described = await ecs.describeServices(
+  new DescribeServicesCommand({ cluster: "orders", services: ["checkout"] }),
+);
+
+console.log(described.services?.[0]?.runningCount); // 0
+```
+
+Closing the simulated environment with `simAws.close()` stops the tasks of every service in it, and
+nothing is left scheduled either way: a service is kept as state rather than by a timer, so a test
+that finishes with a service running leaves nothing behind it.
+
 ## Authorization
 
 Every operation is authorized by simulated IAM against the real ECS action.
@@ -764,7 +1005,9 @@ Real ECS gives the task definition operations no resource type at all, and gives
 `ListClusters` and `ListTasks` none either, so all of those authorize against `*`. A policy naming a
 task definition ARN grants none of them, here as on AWS. The operations that do take a resource are
 `DescribeClusters` and `DeleteCluster`, which take the cluster's ARN, `RunTask`, which takes the
-task definition revision it would run, and `DescribeTasks` and `StopTask`, which take the task's ARN.
+task definition revision it would run, `DescribeTasks` and `StopTask`, which take the task's ARN, and
+the service operations, which take the service's ARN. `CreateService` authorizes against the ARN the
+service is about to have, so a policy can name one service by name before it exists.
 
 ```typescript sim-ecs-iam-policy
 /**
@@ -914,6 +1157,10 @@ console.log(described.taskDefinition?.revision); // 1
 - `DescribeTasksCommand`, `ListTasksCommand` and `StopTaskCommand`
 - Tasks run from an EventBridge rule target or a Scheduler schedule target, through that target's
   role
+- `CreateServiceCommand`, keeping a desired count of tasks running from a task definition
+- `UpdateServiceCommand`, changing the desired count, the task definition, or both
+- `DescribeServicesCommand` and `DeleteServiceCommand`, with the `force` a scaled-up service needs
+- `ListTasks` filtering by `serviceName`, so a service's tasks can be listed on their own
 - `bindContainer`, targeting a container by family and container name or by image repository
 - Container environment variables and `RunTask` container overrides, through `process.env`
 - Container AWS calls authorized as the task role, including a `RunTask` `taskRoleArn` override
@@ -923,7 +1170,7 @@ console.log(described.taskDefinition?.revision); // 1
 - Task definition tags, reported under `include: ["TAGS"]`
 - Cluster settings, configuration and tags, reported under their matching `include` values
 - Authorization of every operation by simulated IAM, against the real IAM action and resource
-- Clusters, task definitions and tasks scoped by account and region
+- Clusters, task definitions, tasks and services scoped by account and region
 - ECS SDK clients intercepted by `SimSdk`
 
 ## Limitations
@@ -969,8 +1216,6 @@ Current documented limitations:
   for them to configure.
 - A task definition declaring `secrets` and no `executionRoleArn` fails when a task is run rather
   than when the revision is registered. Real ECS refuses the registration.
-- `StartTask` and the whole of the service API (`CreateService`, `UpdateService`,
-  `DescribeServices`) are not simulated.
 - An EventBridge or Scheduler target's `EcsParameters` takes `TaskDefinitionArn` and `TaskCount`
   only, taking and ignoring the launch type, platform version, network configuration and capacity
   provider strategy for the same reason `RunTask` refuses them: there is no placement and no network
@@ -979,6 +1224,32 @@ Current documented limitations:
 - A rule or schedule target's `Input` is read as the task's overrides rather than as a payload,
   since a task has nowhere to receive one, so container environment variables are set with a
   `containerOverrides` list naming the container.
+- A service's desired count is simulated as state rather than as concurrency. Three tasks exist and
+  are reported as running, and the handler bound to a container is called once per request or per
+  poll rather than once per task. Yulin runs in one Node.js process, so there is nothing to copy.
+- Nothing calls a service container's handler yet. A bound container of a service is treated as
+  running and stays available until the service is deleted or its `SimAws` is closed, but a load
+  balancer sending it a request and a queue it polls both follow separately. Its container secrets
+  are resolved as the task comes up, so a secret that cannot be read stops the task, but the values
+  reach a container's environment only when something calls its handler.
+- A service's tasks come up all at once and are replaced all at once. There are no deployments,
+  deployment controllers, circuit breakers or rolling replacement, so `DescribeServices` reports no
+  `deployments` and no `events`, and `UpdateService` refuses `forceNewDeployment`.
+- A service whose tasks fail to start does not start replacements for them. Real ECS keeps trying,
+  which would be an endless retry in a test rather than a result to assert on, so the service
+  reports the running count it actually has.
+- `CreateService` refuses `loadBalancers`, `serviceRegistries`, `networkConfiguration`,
+  `deploymentConfiguration`, `capacityProviderStrategy` and the rest of what it takes. There is no
+  network here, and nothing serves a service container yet.
+- `CreateService` refuses a `schedulingStrategy` of `DAEMON`, which places one task on each container
+  instance. There are no container instances here to place one on each of.
+- `CreateService` needs a `desiredCount`, as a replica service does on real ECS, and it can be zero.
+- A service's tasks are `startedBy` `ecs-svc/` and the service name. Real ECS uses `ecs-svc/` and a
+  number, which would name nothing here.
+- Service autoscaling and service discovery are not simulated, and neither is `ListServices`.
+- `StartTask` is not simulated.
+- Closing a `SimAws` stops the tasks of every service in it. The services stay describable with the
+  desired count they had, and their tasks are not brought back.
 - `DescribeTasks` refuses `include`, and a task carries no tags, so `RunTask` refuses `tags` too.
 - `ListTasks` refuses a `desiredStatus` of `PENDING`, which real ECS accepts. A simulated task is
   wanted either running or stopped, so the answer would always be an empty listing.
@@ -1002,12 +1273,15 @@ Current documented limitations:
   `INACTIVE`.
 - `CreateCluster` with a name an active cluster already has hands that cluster back rather than
   raising, as real ECS does. The settings, configuration and tags on the second request are ignored.
-- Deleting a cluster is immediate, and never fails for a cluster holding tasks or services, because
-  there are none to hold.
+- Deleting a cluster is immediate, and never fails for a cluster still holding running tasks or
+  active services, which real ECS refuses. The services in it go on reporting what they are keeping.
+- `DescribeClusters` reports zero services and zero tasks whatever the cluster holds.
+  `DescribeServices` and `ListTasks` are what report those.
 - Task definition and cluster tags are stored and reported, but `TagResource`,
   `UntagResource` and `ListTagsForResource` are not simulated.
-- There are no ECS CloudFormation resource types yet. `AWS::ECS::Cluster` and
-  `AWS::ECS::TaskDefinition` are reported as unsupported and skipped rather than deployed.
+- There are no ECS CloudFormation resource types yet. `AWS::ECS::Cluster`,
+  `AWS::ECS::TaskDefinition` and `AWS::ECS::Service` are reported as unsupported and skipped rather
+  than deployed.
 - Cluster and family names are validated to the 255 letters, numbers, hyphens and underscores real
   ECS accepts, but error messages differ from the real ones.
 - Account-wide limits do not exist, so no request fails for having registered too many task

--- a/docs/services/ecs/sim-ecs-create-service.example.ts
+++ b/docs/services/ecs/sim-ecs-create-service.example.ts
@@ -1,0 +1,64 @@
+/**
+ * Creating a simulated ECS service that keeps three tasks running.
+ */
+
+import {
+  CreateClusterCommand,
+  CreateServiceCommand,
+  DescribeServicesCommand,
+  ListTasksCommand,
+  RegisterTaskDefinitionCommand,
+} from "@aws-sdk/client-ecs";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const ecs = simAws.ecs();
+
+await ecs.createCluster(new CreateClusterCommand({ clusterName: "orders" }));
+
+ecs.bindContainer({
+  family: "checkout",
+  containerName: "app",
+  run: async () => {
+    await handleOneRequest();
+  },
+});
+
+await ecs.registerTaskDefinition(
+  new RegisterTaskDefinitionCommand({
+    family: "checkout",
+    containerDefinitions: [{ name: "app", image: "checkout:1" }],
+  }),
+);
+
+const created = await ecs.createService(
+  new CreateServiceCommand({
+    cluster: "orders",
+    serviceName: "checkout",
+    taskDefinition: "checkout",
+    desiredCount: 3,
+  }),
+);
+
+console.log(created.service?.desiredCount); // 3
+console.log(created.service?.runningCount); // 0, as real ECS answers one
+
+// The tasks come up in the background, as they do on real ECS.
+await simAws.backgroundTasksComplete();
+
+const described = await ecs.describeServices(
+  new DescribeServicesCommand({ cluster: "orders", services: ["checkout"] }),
+);
+
+console.log(described.services?.[0]?.runningCount); // 3
+
+const listed = await ecs.listTasks(
+  new ListTasksCommand({ cluster: "orders", serviceName: "checkout" }),
+);
+
+console.log(listed.taskArns?.length); // 3
+
+async function handleOneRequest(): Promise<void> {
+  await Promise.resolve();
+}

--- a/docs/services/ecs/sim-ecs-delete-service.example.ts
+++ b/docs/services/ecs/sim-ecs-delete-service.example.ts
@@ -1,0 +1,56 @@
+/**
+ * Deleting a simulated ECS service and the tasks it was keeping running.
+ */
+
+import {
+  CreateClusterCommand,
+  CreateServiceCommand,
+  DeleteServiceCommand,
+  DescribeServicesCommand,
+  ListTasksCommand,
+  RegisterTaskDefinitionCommand,
+} from "@aws-sdk/client-ecs";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const ecs = simAws.ecs();
+
+await ecs.createCluster(new CreateClusterCommand({ clusterName: "orders" }));
+await ecs.registerTaskDefinition(
+  new RegisterTaskDefinitionCommand({
+    family: "checkout",
+    containerDefinitions: [{ name: "app", image: "checkout:1" }],
+  }),
+);
+await ecs.createService(
+  new CreateServiceCommand({
+    cluster: "orders",
+    serviceName: "checkout",
+    taskDefinition: "checkout",
+    desiredCount: 2,
+  }),
+);
+await simAws.backgroundTasksComplete();
+
+const deleted = await ecs.deleteService(
+  new DeleteServiceCommand({
+    cluster: "orders",
+    service: "checkout",
+    force: true,
+  }),
+);
+
+console.log(deleted.service?.status); // "INACTIVE"
+
+const listed = await ecs.listTasks(
+  new ListTasksCommand({ cluster: "orders", serviceName: "checkout" }),
+);
+
+console.log(listed.taskArns?.length); // 0
+
+const described = await ecs.describeServices(
+  new DescribeServicesCommand({ cluster: "orders", services: ["checkout"] }),
+);
+
+console.log(described.services?.[0]?.runningCount); // 0

--- a/docs/services/ecs/sim-ecs-update-service.example.ts
+++ b/docs/services/ecs/sim-ecs-update-service.example.ts
@@ -1,0 +1,69 @@
+/**
+ * Scaling a simulated ECS service and moving it to a new revision.
+ */
+
+import {
+  CreateClusterCommand,
+  CreateServiceCommand,
+  ListTasksCommand,
+  RegisterTaskDefinitionCommand,
+  UpdateServiceCommand,
+} from "@aws-sdk/client-ecs";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const ecs = simAws.ecs();
+
+await ecs.createCluster(new CreateClusterCommand({ clusterName: "orders" }));
+await ecs.registerTaskDefinition(
+  new RegisterTaskDefinitionCommand({
+    family: "checkout",
+    containerDefinitions: [{ name: "app", image: "checkout:1" }],
+  }),
+);
+await ecs.createService(
+  new CreateServiceCommand({
+    cluster: "orders",
+    serviceName: "checkout",
+    taskDefinition: "checkout",
+    desiredCount: 1,
+  }),
+);
+
+const scaled = await ecs.updateService(
+  new UpdateServiceCommand({
+    cluster: "orders",
+    service: "checkout",
+    desiredCount: 4,
+  }),
+);
+
+console.log(scaled.service?.desiredCount); // 4
+
+const second = await ecs.registerTaskDefinition(
+  new RegisterTaskDefinitionCommand({
+    family: "checkout",
+    containerDefinitions: [{ name: "app", image: "checkout:2" }],
+  }),
+);
+
+const deployed = await ecs.updateService(
+  new UpdateServiceCommand({
+    cluster: "orders",
+    service: "checkout",
+    taskDefinition: "checkout:2",
+  }),
+);
+
+console.log(
+  deployed.service?.taskDefinition === second.taskDefinition?.taskDefinitionArn,
+); // true
+
+await simAws.backgroundTasksComplete();
+
+const listed = await ecs.listTasks(
+  new ListTasksCommand({ cluster: "orders", serviceName: "checkout" }),
+);
+
+console.log(listed.taskArns?.length); // 4, all of them on the new revision

--- a/src/service/ecs/README.md
+++ b/src/service/ecs/README.md
@@ -34,8 +34,9 @@ the only two fields it looks at are `name`, which is how everything else refers 
 - `sim-ecs.ts` is the main in-memory service object for one account/region scope.
 - `index.ts` exports the public ECS simulator API for `@kensio/yulin/ecs`.
 
-A `SimEcs` instance owns a `SimEcsClusterStore`, a `SimEcsTaskDefinitionStore`, a `SimEcsTaskStore`
-and the `SimEcsContainerBindings` for its scope. All of them are scoped to an account and region
+A `SimEcs` instance owns a `SimEcsClusterStore`, a `SimEcsTaskDefinitionStore`, a `SimEcsTaskStore`,
+a `SimEcsServiceStore` and the `SimEcsContainerBindings` for its scope, all of them through
+`SimEcsCommands`. All of them are scoped to an account and region
 because ECS scopes them that way: a cluster ARN, a task definition ARN and a task ARN all name their
 region, and a cluster name is unique within one account and region rather than globally. Bindings
 follow the task definitions they target, so a binding made in one scope reaches no container in
@@ -185,11 +186,47 @@ behind it, so a task a rule started is the same task as one a caller started: th
 same refusals, and the same IAM decision against `ecs:RunTask` for the role the target carries. What
 neither service holds is a second answer to whether that role may run the task.
 
+## Service model
+
+Service state lives under `service/`, and what keeps a service's tasks running lives under
+`service/run/`.
+
+A service is the first ECS thing here that keeps running rather than running and finishing, and one
+decision settles what that means. A desired count of three cannot be three copies of one in-process
+handler, because Yulin runs in a single Node.js process and there are no containers to copy. The
+count is therefore kept as state: `SimEcsServiceTasks` starts that many simulated tasks, they are
+reported as running, and the handler bound to a container is called once per request or per poll
+rather than once per task. That divergence is stated in the usage docs as well as here, because a
+test could otherwise read a running count of three as three things happening at once.
+
+`SimEcsService` splits into `SimEcsServiceIdentity`, which is what the service is, and what the
+service is being kept at, which is the only part that changes. The tasks it is keeping are held in a
+`SimEcsServiceTaskSet` of its own, because the running and pending counts are read from them and
+because a task it has stopped leaves the set while staying in the task store. Nothing in the service
+schedules anything: whatever starts and stops tasks takes them from the set to stop them.
+
+`SimEcsServiceTasks` is that whatever. It reconciles a service to its desired count, replaces every
+task when the service moves to another revision, and stops the lot when the service is deleted or the
+simulated environment is closed. Starting goes through `SimEcsServiceTaskStarter`, which puts a task
+in the store straight away and schedules it to reach `RUNNING` on the simulator's background
+scheduler, so a task is listed as soon as the request is answered and a service deleted in between
+brings nothing up. Stopping is immediate, because there is nothing here to drain.
+
+`SimEcsServiceContainers` brings one task's containers up, which is where a service container differs
+from a task container: no handler is called. A bound container is marked running and left available
+for whatever reaches it, and an unbound one records the same not-simulated reason a run task's
+container does, so the wording is shared with `SimEcsContainerRunner` rather than repeated.
+
+`SimEcsServiceStore` keys services by cluster and name together, because a service name is unique
+within a cluster on real ECS rather than across an Account.
+
 ## Command handling
 
 AWS SDK-style operations are implemented under `command/`, one directory per operation, so the
-`SimEcs` facade stays a delegation. `command/sim-ecs-command-context.ts` holds what each kind of
-handler is built with, split between the cluster operations and the task definition ones.
+`SimEcs` facade stays a delegation. `SimEcsCommands` builds the state and the handlers, which leaves
+the facade with one method per operation and nothing else; it is also what `SimEcs.close()` reaches
+to stop what the services are running. `command/sim-ecs-command-context.ts` holds what each kind of
+handler is built with, split between the cluster, task definition, task and service operations.
 
 `SimEcsCommandHandler` is what each handler extends. Every operation starts the same way: it refuses
 the inputs it does not hold, waits at the simulator's sequencing point, and authorizes the caller.
@@ -212,6 +249,8 @@ command instances.
   that is;
 - `DescribeTasks` and `StopTask` authorize against the task's ARN, and `DescribeTasks` authorizes
   each task it was given separately, so a policy can name one task;
+- the service operations authorize against the service's ARN, `CreateService` against the ARN the
+  service is about to have, and `DescribeServices` authorizes each service it was given separately;
 - everything else authorizes against `*`, because real ECS gives the task definition operations no
   resource type at all, and gives `CreateCluster`, `ListClusters` and `ListTasks` none either. A
   policy naming a task definition ARN grants none of those, here as on AWS.
@@ -239,6 +278,13 @@ command instances.
 - A task with no bound container stops with `TaskFailedToStart` rather than
   `EssentialContainerExited`. Nothing started, and saying so is what makes a binding that matches
   nothing visible.
+- A service's desired count is state rather than concurrency, and nothing calls a service container's
+  handler yet. The container is treated as running and left available for whatever reaches it.
+- `CreateService` refuses a name an active service of the cluster already has, which is the opposite
+  of what `CreateCluster` does with a name already taken. Real ECS refuses each of them that way.
+- `DeleteService` refuses a service still scaled above zero unless the request forces it, as real ECS
+  does. Deleting a cluster still holding services does not refuse, which real ECS would.
+- A service's tasks are `startedBy` `ecs-svc/` and the service name, where real ECS uses a number.
 - `SimEcsContainerDefinitionType` carries no index signature. One would stop a real SDK
   `RegisterTaskDefinitionCommand` input being assignable to it, which is the whole point of the
   structural types. A field it does not name is stored and reported back all the same.

--- a/src/service/ecs/command/authorize/sim-ecs-authorizer.ts
+++ b/src/service/ecs/command/authorize/sim-ecs-authorizer.ts
@@ -24,7 +24,8 @@ interface SimEcsAuthorizerProperties {
  *
  * ECS splits its operations by the resource type each action takes.
  * `DescribeClusters` and `DeleteCluster` take a cluster, `RunTask` takes the
- * task definition it runs, and `DescribeTasks` and `StopTask` take the task.
+ * task definition it runs, `DescribeTasks` and `StopTask` take the task, and
+ * the service operations take the service.
  * The operations that read or write a task definition, along with
  * `CreateCluster`, `ListClusters` and `ListTasks`, have no resource type at
  * all, so they authorize against `*`.
@@ -67,6 +68,21 @@ export class SimEcsAuthorizer {
     options?: SimEcsRequestOptions,
   ): SimAwsResolvedCaller {
     return this.authorizeResource(action, taskArn, options);
+  }
+
+  /**
+   * Ensure the caller may perform an action on a service, named by its ARN.
+   *
+   * The service need not exist, as the cluster need not for a cluster action.
+   * `CreateService` authorizes against the ARN the service is about to have,
+   * which is what real ECS does with it.
+   */
+  authorizeService(
+    action: string,
+    serviceArn: string,
+    options?: SimEcsRequestOptions,
+  ): SimAwsResolvedCaller {
+    return this.authorizeResource(action, serviceArn, options);
   }
 
   /**

--- a/src/service/ecs/command/authorize/sim-ecs-iam.iso.test.ts
+++ b/src/service/ecs/command/authorize/sim-ecs-iam.iso.test.ts
@@ -1,6 +1,8 @@
 import {
   CreateClusterCommand,
+  CreateServiceCommand,
   DeleteClusterCommand,
+  DeleteServiceCommand,
   DescribeClustersCommand,
   DescribeTaskDefinitionCommand,
   ListTaskDefinitionsCommand,
@@ -16,7 +18,9 @@ import {
 import { describe, it } from "vitest";
 import { SimAws } from "../../../aws/sim-aws.js";
 import { simIamRoleWithPolicyFactory } from "../../../iam/role/sim-iam-role-with-policy.factory.js";
+import { simEcsClusterFactory } from "../../cluster/sim-ecs-cluster.factory.js";
 import { SimEcsAccessDeniedException } from "../../error/sim-ecs.error.js";
+import { simEcsRegisteredTaskDefinitionFactory } from "../../task-definition/sim-ecs-registered-task-definition.factory.js";
 
 describe("Authorizing simulated ECS requests", () => {
   it("allows a caller whose policy permits the registration", async () => {
@@ -171,6 +175,75 @@ describe("Authorizing simulated ECS requests", () => {
 
     assertInstanceOf(error, SimEcsAccessDeniedException);
     assertStringIncludes(error.message, "cluster/batch");
+  });
+
+  it("authorizes a service operation against the service ARN", async () => {
+    // Given a Role allowed to create one named service.
+    const simAws = new SimAws();
+    const serviceArn = `arn:aws:ecs:${simAws.defaultRegionName}:${simAws.defaultAccountId}:service/default/checkout`;
+    const role = await simIamRoleWithPolicyFactory.make(
+      {
+        roleName: "Deployer",
+        actions: ["ecs:CreateService"],
+        resource: serviceArn,
+      },
+      simAws,
+    );
+    await simEcsClusterFactory.make({}, simAws);
+    await simEcsRegisteredTaskDefinitionFactory.make({}, simAws);
+
+    // When it creates that service.
+    const created = await simAws.ecs().createService(
+      new CreateServiceCommand({
+        serviceName: "checkout",
+        taskDefinition: "checkout",
+        desiredCount: 1,
+      }),
+      { caller: { kind: "arn", arn: role.Arn } },
+    );
+
+    // Then it is allowed, and the service records who created it.
+    assertIdentical(created.service?.createdBy, role.Arn);
+
+    // And a service its policy does not name is refused.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.ecs().createService(
+        new CreateServiceCommand({
+          serviceName: "orders",
+          taskDefinition: "checkout",
+          desiredCount: 1,
+        }),
+        { caller: { kind: "arn", arn: role.Arn } },
+      ),
+    );
+
+    assertInstanceOf(error, SimEcsAccessDeniedException);
+    assertStringIncludes(error.message, "service/default/orders");
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("refuses a service deletion before finding out if it is there", async () => {
+    // Given a Role allowed nothing in ECS.
+    const simAws = new SimAws();
+    const role = await simIamRoleWithPolicyFactory.make(
+      { roleName: "Nobody", actions: ["s3:GetObject"] },
+      simAws,
+    );
+
+    // When it deletes a service that does not exist.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws
+        .ecs()
+        .deleteService(new DeleteServiceCommand({ service: "checkout" }), {
+          caller: { kind: "arn", arn: role.Arn },
+        }),
+    );
+
+    // Then the answer is the access denial, so nothing is learned about what
+    // the cluster holds.
+    assertInstanceOf(error, SimEcsAccessDeniedException);
+    assertStringIncludes(error.message, "ecs:DeleteService");
   });
 
   it("refuses a cluster deletion before finding out if it is there", async () => {

--- a/src/service/ecs/command/create-service/create-service-request.ts
+++ b/src/service/ecs/command/create-service/create-service-request.ts
@@ -1,0 +1,69 @@
+import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
+import { SimEcsInvalidParameterException } from "../../error/sim-ecs.error.js";
+import { simEcsDesiredCount } from "../../service/sim-ecs-desired-count.js";
+import { simEcsReplicaSchedulingStrategy } from "../../service/sim-ecs-service.js";
+import { requiredSimEcsName } from "../../sim-ecs-name.js";
+import { SimEcsTaskDefinitionId } from "../../task-definition/sim-ecs-task-definition-id.js";
+import type { SimCreateServiceCommandInput } from "./create-service.command.js";
+
+/**
+ * What one `CreateService` request asked for.
+ *
+ * This is the part of the request that can be read before anything is looked
+ * up: what the service is called, which task definition it runs and how many
+ * tasks of it to keep. A malformed request is malformed whoever made it and
+ * whatever state there is, so it is read first and refused first.
+ */
+export class SimEcsCreateServiceRequest {
+  public readonly serviceName: string;
+  public readonly taskDefinitionId: SimEcsTaskDefinitionId;
+  public readonly desiredCount: number;
+
+  constructor(
+    input: SimCreateServiceCommandInput,
+    accountRegionScope: SimAwsAccountRegionScope,
+  ) {
+    SimEcsCreateServiceRequest.acceptedStrategy(input.schedulingStrategy);
+    this.serviceName = requiredSimEcsName(input.serviceName, "service name");
+    this.taskDefinitionId = SimEcsTaskDefinitionId.parse(
+      input.taskDefinition,
+      accountRegionScope,
+    );
+    this.desiredCount = simEcsDesiredCount(
+      SimEcsCreateServiceRequest.requiredCount(input.desiredCount),
+    );
+  }
+
+  /**
+   * The scheduling strategy the request asked for, which has to be `REPLICA`.
+   *
+   * `DAEMON` runs one task on every container instance in the cluster. There
+   * are no instances here to run one each, so answering it as though it had
+   * been applied would be reporting a replica service under another name.
+   */
+  private static acceptedStrategy(strategy: string | undefined): void {
+    if (
+      strategy !== undefined &&
+      strategy !== simEcsReplicaSchedulingStrategy
+    ) {
+      throw new SimEcsInvalidParameterException(
+        `schedulingStrategy ${strategy} is not simulated. There are no ` +
+          `container instances here for a task to be placed on each of.`,
+      );
+    }
+  }
+
+  /**
+   * How many tasks the request asked for, which a replica service needs.
+   */
+  private static requiredCount(count: number | undefined): number {
+    if (count === undefined) {
+      throw new SimEcsInvalidParameterException(
+        "CreateService needs a desiredCount, which is how many tasks the " +
+          "service keeps running.",
+      );
+    }
+
+    return count;
+  }
+}

--- a/src/service/ecs/command/create-service/create-service-secrets.iso.test.ts
+++ b/src/service/ecs/command/create-service/create-service-secrets.iso.test.ts
@@ -1,0 +1,137 @@
+import {
+  CreateServiceCommand,
+  DescribeServicesCommand,
+  DescribeTasksCommand,
+  ListTasksCommand,
+  RegisterTaskDefinitionCommand,
+} from "@aws-sdk/client-ecs";
+import { CreateSecretCommand } from "@aws-sdk/client-secrets-manager";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertStringIncludes,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { simIamRoleWithPolicyFactory } from "../../../iam/role/sim-iam-role-with-policy.factory.js";
+import { simEcsClusterFactory } from "../../cluster/sim-ecs-cluster.factory.js";
+
+describe("A simulated ECS service whose containers declare secrets", () => {
+  it("brings its tasks up once their secrets can be read", async () => {
+    // Given a secret and a task definition reading it as its execution Role.
+    const simAws = new SimAws();
+    const ecs = simAws.ecs();
+    await simEcsClusterFactory.make({}, simAws);
+
+    const secret = await simAws
+      .secretsManager()
+      .createSecret(
+        new CreateSecretCommand({ Name: "orders/db", SecretString: "hunter2" }),
+      );
+    const executionRole = await simIamRoleWithPolicyFactory.make(
+      { roleName: "Execution", actions: ["secretsmanager:GetSecretValue"] },
+      simAws,
+    );
+
+    await ecs.registerTaskDefinition(
+      new RegisterTaskDefinitionCommand({
+        family: "checkout",
+        executionRoleArn: executionRole.Arn,
+        containerDefinitions: [
+          {
+            name: "app",
+            image: "checkout:1",
+            secrets: [{ name: "DB_PASSWORD", valueFrom: secret.ARN }],
+          },
+        ],
+      }),
+    );
+
+    // When a service is created from it.
+    await ecs.createService(
+      new CreateServiceCommand({
+        serviceName: "checkout",
+        taskDefinition: "checkout",
+        desiredCount: 2,
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // Then its tasks are running, as they are for a definition with no secret
+    // to read at all.
+    const described = await ecs.describeServices(
+      new DescribeServicesCommand({ services: ["checkout"] }),
+    );
+
+    assertIdentical(described.services?.[0]?.runningCount, 2);
+  });
+
+  it("stops a task whose secret cannot be read", async () => {
+    // Given a container declaring a secret that is not there.
+    const simAws = new SimAws();
+    const ecs = simAws.ecs();
+    await simEcsClusterFactory.make({}, simAws);
+    const executionRole = await simIamRoleWithPolicyFactory.make(
+      { roleName: "Execution", actions: ["secretsmanager:GetSecretValue"] },
+      simAws,
+    );
+    await ecs.registerTaskDefinition(
+      new RegisterTaskDefinitionCommand({
+        family: "checkout",
+        executionRoleArn: executionRole.Arn,
+        containerDefinitions: [
+          {
+            name: "app",
+            image: "checkout:1",
+            secrets: [
+              {
+                name: "DB_PASSWORD",
+                valueFrom: `arn:aws:secretsmanager:${simAws.defaultRegionName}:${simAws.defaultAccountId}:secret:orders/db-AbCdEf`,
+              },
+            ],
+          },
+        ],
+      }),
+    );
+
+    // When a service is created from it.
+    await ecs.createService(
+      new CreateServiceCommand({
+        serviceName: "checkout",
+        taskDefinition: "checkout",
+        desiredCount: 1,
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // Then the task it started stopped before anything of it ran, as one
+    // started by `RunTask` does, rather than the service reporting it running.
+    const stopped = await ecs.listTasks(
+      new ListTasksCommand({
+        serviceName: "checkout",
+        desiredStatus: "STOPPED",
+      }),
+    );
+
+    assertArrayLength(stopped.taskArns, 1);
+
+    const described = await ecs.describeTasks(
+      new DescribeTasksCommand({ tasks: [stopped.taskArns[0]] }),
+    );
+
+    assertIdentical(described.tasks?.[0]?.stopCode, "TaskFailedToStart");
+    assertStringIncludes(
+      described.tasks[0].stoppedReason ?? "",
+      "ResourceInitializationError",
+    );
+
+    // And the service reports the running count it actually has, rather than
+    // starting replacements the way real ECS keeps retrying.
+    const services = await ecs.describeServices(
+      new DescribeServicesCommand({ services: ["checkout"] }),
+    );
+
+    assertIdentical(services.services?.[0]?.runningCount, 0);
+    assertIdentical(services.services[0].desiredCount, 1);
+  });
+});

--- a/src/service/ecs/command/create-service/create-service-validation.iso.test.ts
+++ b/src/service/ecs/command/create-service/create-service-validation.iso.test.ts
@@ -1,0 +1,208 @@
+import {
+  CreateServiceCommand,
+  DeregisterTaskDefinitionCommand,
+} from "@aws-sdk/client-ecs";
+import {
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { simEcsClusterFactory } from "../../cluster/sim-ecs-cluster.factory.js";
+import {
+  SimEcsClientException,
+  SimEcsClusterNotFoundException,
+  SimEcsInvalidParameterException,
+} from "../../error/sim-ecs.error.js";
+import { simEcsRegisteredTaskDefinitionFactory } from "../../task-definition/sim-ecs-registered-task-definition.factory.js";
+import { simEcsServiceFactory } from "../../service/sim-ecs-service.factory.js";
+
+describe("Refusing a simulated ECS CreateService request", () => {
+  it("refuses an input this simulation does not hold", async () => {
+    // Given a registered task definition.
+    const simAws = new SimAws();
+    await simEcsClusterFactory.make({}, simAws);
+    await simEcsRegisteredTaskDefinitionFactory.make({}, simAws);
+
+    // When a service is created behind a load balancer.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.ecs().createService(
+        new CreateServiceCommand({
+          serviceName: "checkout",
+          taskDefinition: "checkout",
+          desiredCount: 1,
+          loadBalancers: [{ containerName: "app", containerPort: 8080 }],
+        }),
+      ),
+    );
+
+    // Then it is refused rather than dropped, since nothing here would send it
+    // a request.
+    assertInstanceOf(error, SimEcsClientException);
+    assertStringIncludes(error.message, "loadBalancers");
+    assertStringIncludes(error.message, "not simulated");
+  });
+
+  it("refuses a scheduling strategy of DAEMON", async () => {
+    // Given a registered task definition.
+    const simAws = new SimAws();
+    await simEcsClusterFactory.make({}, simAws);
+    await simEcsRegisteredTaskDefinitionFactory.make({}, simAws);
+
+    // When a daemon service is created.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.ecs().createService(
+        new CreateServiceCommand({
+          serviceName: "checkout",
+          taskDefinition: "checkout",
+          desiredCount: 1,
+          schedulingStrategy: "DAEMON",
+        }),
+      ),
+    );
+
+    // Then it is refused, because there are no container instances here to
+    // place one task on each of.
+    assertInstanceOf(error, SimEcsInvalidParameterException);
+    assertStringIncludes(error.message, "DAEMON");
+  });
+
+  it("refuses a request that does not say how many tasks to keep", async () => {
+    // Given a registered task definition.
+    const simAws = new SimAws();
+    await simEcsClusterFactory.make({}, simAws);
+    await simEcsRegisteredTaskDefinitionFactory.make({}, simAws);
+
+    // When a service is created without a desired count.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.ecs().createService(
+        new CreateServiceCommand({
+          serviceName: "checkout",
+          taskDefinition: "checkout",
+        }),
+      ),
+    );
+
+    // Then it is refused, as real ECS refuses a replica service without one.
+    assertInstanceOf(error, SimEcsInvalidParameterException);
+    assertStringIncludes(error.message, "desiredCount");
+  });
+
+  it("refuses a desired count that is not a whole number of tasks", async () => {
+    // Given a registered task definition.
+    const simAws = new SimAws();
+    await simEcsClusterFactory.make({}, simAws);
+    await simEcsRegisteredTaskDefinitionFactory.make({}, simAws);
+
+    // When a service is created with a negative desired count.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.ecs().createService(
+        new CreateServiceCommand({
+          serviceName: "checkout",
+          taskDefinition: "checkout",
+          desiredCount: -1,
+        }),
+      ),
+    );
+
+    // Then it is refused rather than kept as state nothing could reach.
+    assertInstanceOf(error, SimEcsInvalidParameterException);
+    assertStringIncludes(error.message, "whole number");
+  });
+
+  it("refuses a service name real ECS would not accept", async () => {
+    // Given a registered task definition.
+    const simAws = new SimAws();
+    await simEcsClusterFactory.make({}, simAws);
+    await simEcsRegisteredTaskDefinitionFactory.make({}, simAws);
+
+    // When a service is created with a name holding a slash.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.ecs().createService(
+        new CreateServiceCommand({
+          serviceName: "checkout/api",
+          taskDefinition: "checkout",
+          desiredCount: 1,
+        }),
+      ),
+    );
+
+    // Then it is refused here rather than on deployment.
+    assertInstanceOf(error, SimEcsClientException);
+    assertStringIncludes(error.message, "service name");
+  });
+
+  it("refuses a name an active service of the cluster already has", async () => {
+    // Given a service that is already there.
+    const simAws = new SimAws();
+    await simEcsClusterFactory.make({}, simAws);
+    await simEcsRegisteredTaskDefinitionFactory.make({}, simAws);
+    await simEcsServiceFactory.make({}, simAws);
+
+    // When another of the same name is created in the same cluster.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.ecs().createService(
+        new CreateServiceCommand({
+          serviceName: "checkout",
+          taskDefinition: "checkout",
+          desiredCount: 1,
+        }),
+      ),
+    );
+
+    // Then it is refused rather than handed the existing one, as real ECS
+    // refuses it.
+    assertInstanceOf(error, SimEcsInvalidParameterException);
+    assertStringIncludes(error.message, "already holds an active service");
+  });
+
+  it("refuses a revision that has been deregistered", async () => {
+    // Given a task definition whose only revision has been deregistered.
+    const simAws = new SimAws();
+    await simEcsClusterFactory.make({}, simAws);
+    await simEcsRegisteredTaskDefinitionFactory.make({}, simAws);
+    await simAws
+      .ecs()
+      .deregisterTaskDefinition(
+        new DeregisterTaskDefinitionCommand({ taskDefinition: "checkout:1" }),
+      );
+
+    // When a service is created from it.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.ecs().createService(
+        new CreateServiceCommand({
+          serviceName: "checkout",
+          taskDefinition: "checkout:1",
+          desiredCount: 1,
+        }),
+      ),
+    );
+
+    // Then it is refused, because a deregistered revision is one nothing is
+    // meant to start from any more.
+    assertInstanceOf(error, SimEcsClientException);
+    assertStringIncludes(error.message, "INACTIVE");
+  });
+
+  it("refuses a cluster that is not there", async () => {
+    // Given a registered task definition and no cluster.
+    const simAws = new SimAws();
+    await simEcsRegisteredTaskDefinitionFactory.make({}, simAws);
+
+    // When a service is created.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.ecs().createService(
+        new CreateServiceCommand({
+          serviceName: "checkout",
+          taskDefinition: "checkout",
+          desiredCount: 1,
+        }),
+      ),
+    );
+
+    // Then it is refused, because Yulin creates no cluster of its own.
+    assertInstanceOf(error, SimEcsClusterNotFoundException);
+    assertStringIncludes(error.message, "default");
+  });
+});

--- a/src/service/ecs/command/create-service/create-service.command.ts
+++ b/src/service/ecs/command/create-service/create-service.command.ts
@@ -1,0 +1,31 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type { SimEcsServiceDetail } from "../../service/sim-ecs-service-detail.js";
+
+/**
+ * Minimal structural sim ECS CreateService command.
+ */
+export interface SimCreateServiceCommand {
+  readonly input: SimCreateServiceCommandInput;
+}
+
+/**
+ * Minimal structural sim ECS CreateService input.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/ecs/command/CreateServiceCommand/
+ */
+export interface SimCreateServiceCommandInput {
+  readonly cluster?: string | undefined;
+  readonly serviceName?: string | undefined;
+  readonly taskDefinition?: string | undefined;
+  readonly desiredCount?: number | undefined;
+  readonly launchType?: string | undefined;
+  readonly schedulingStrategy?: string | undefined;
+}
+
+/**
+ * Minimal structural sim ECS CreateService output.
+ */
+export interface SimCreateServiceCommandOutput {
+  readonly service?: SimEcsServiceDetail | undefined;
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/ecs/command/create-service/create-service.handler.ts
+++ b/src/service/ecs/command/create-service/create-service.handler.ts
@@ -1,0 +1,129 @@
+import type { CommandHandler } from "../../../../command/command-handler.js";
+import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
+import type { SimEcsCluster } from "../../cluster/sim-ecs-cluster.js";
+import { SimEcsInvalidParameterException } from "../../error/sim-ecs.error.js";
+import type { SimEcsServiceTasks } from "../../service/run/sim-ecs-service-tasks.js";
+import type { SimEcsServiceArn } from "../../service/sim-ecs-service-arn.js";
+import type { SimEcsServiceStore } from "../../service/sim-ecs-service-store.js";
+import { SimEcsService } from "../../service/sim-ecs-service.js";
+import { requiredRunnableTaskDefinition } from "../../task-definition/sim-ecs-runnable-task-definition.js";
+import type { SimEcsTaskDefinitionStore } from "../../task-definition/sim-ecs-task-definition-store.js";
+import type { SimEcsServiceCommandContext } from "../sim-ecs-command-context.js";
+import { SimEcsCommandHandler } from "../sim-ecs-command-handler.js";
+import type { SimEcsRequestOptions } from "../sim-ecs-request-options.js";
+import { SimEcsRequestedCluster } from "../sim-ecs-requested-cluster.js";
+import { SimEcsCreateServiceRequest } from "./create-service-request.js";
+import type {
+  SimCreateServiceCommand,
+  SimCreateServiceCommandOutput,
+} from "./create-service.command.js";
+
+const acceptedInput: readonly string[] = [
+  "cluster",
+  "serviceName",
+  "taskDefinition",
+  "desiredCount",
+  "launchType",
+  "schedulingStrategy",
+];
+
+/**
+ * Simulated ECS CreateServiceCommand handler.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/ecs/command/CreateServiceCommand/
+ */
+export class CreateServiceCommandHandler
+  extends SimEcsCommandHandler
+  implements
+    CommandHandler<SimCreateServiceCommand, SimCreateServiceCommandOutput>
+{
+  private readonly accountRegionScope: SimAwsAccountRegionScope;
+  private readonly taskDefinitions: SimEcsTaskDefinitionStore;
+  private readonly services: SimEcsServiceStore;
+  private readonly serviceArn: SimEcsServiceArn;
+  private readonly serviceTasks: SimEcsServiceTasks;
+  private readonly requestedCluster: SimEcsRequestedCluster;
+
+  constructor(context: SimEcsServiceCommandContext) {
+    super(context, "CreateService", acceptedInput);
+    this.accountRegionScope = context.accountRegionScope;
+    this.taskDefinitions = context.taskDefinitions;
+    this.services = context.services;
+    this.serviceArn = context.serviceArn;
+    this.serviceTasks = context.serviceTasks;
+    this.requestedCluster = new SimEcsRequestedCluster(context);
+  }
+
+  /**
+   * Create a service, and start the tasks it keeps running.
+   *
+   * The service is answered with the counts it has as the request is answered,
+   * which is a desired count and nothing running yet, as real ECS answers one.
+   * Its tasks reach `RUNNING` on the simulator's background work.
+   */
+  async handle(
+    command: SimCreateServiceCommand,
+    options?: SimEcsRequestOptions,
+  ): Promise<SimCreateServiceCommandOutput> {
+    this.refuseUnaccepted(command.input);
+
+    const request = new SimEcsCreateServiceRequest(
+      command.input,
+      this.accountRegionScope,
+    );
+
+    await this.sequence();
+
+    const cluster = this.requestedCluster.active(command.input.cluster);
+    const taskDefinition = requiredRunnableTaskDefinition(
+      this.taskDefinitions.resolve(request.taskDefinitionId),
+    );
+    const serviceArn = this.serviceArn.make(
+      cluster.clusterName,
+      request.serviceName,
+    );
+    const caller = this.authorizer.authorizeService(
+      "ecs:CreateService",
+      serviceArn,
+      options,
+    );
+
+    this.refuseExisting(cluster, request.serviceName);
+
+    const service = new SimEcsService({
+      serviceArn,
+      serviceName: request.serviceName,
+      clusterArn: cluster.clusterArn,
+      clusterName: cluster.clusterName,
+      taskDefinitionArn: taskDefinition.taskDefinitionArn,
+      desiredCount: request.desiredCount,
+      createdAt: this.background.now(),
+      launchType: command.input.launchType,
+      createdBy: caller.arn,
+    });
+
+    this.services.put(service);
+    this.serviceTasks.reconcile({ service, cluster, taskDefinition });
+
+    return { $metadata: {}, service: service.toOutput() };
+  }
+
+  /**
+   * Refuse a name an active service of the cluster already has.
+   *
+   * Real ECS reports this rather than handing the existing service back, which
+   * is the opposite of what `CreateCluster` does with a name already taken. A
+   * deleted service's name is free again, and creating it replaces the deleted
+   * one.
+   */
+  private refuseExisting(cluster: SimEcsCluster, serviceName: string): void {
+    if (
+      this.services.findActive(cluster.clusterName, serviceName) !== undefined
+    ) {
+      throw new SimEcsInvalidParameterException(
+        `The cluster ${cluster.clusterName} already holds an active service ` +
+          `${serviceName}.`,
+      );
+    }
+  }
+}

--- a/src/service/ecs/command/create-service/create-service.iso.test.ts
+++ b/src/service/ecs/command/create-service/create-service.iso.test.ts
@@ -1,0 +1,274 @@
+import {
+  CreateServiceCommand,
+  DescribeServicesCommand,
+  DescribeTasksCommand,
+  ListTasksCommand,
+  RegisterTaskDefinitionCommand,
+} from "@aws-sdk/client-ecs";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertSetSize,
+  assertStringIncludes,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { simEcsClusterFactory } from "../../cluster/sim-ecs-cluster.factory.js";
+
+describe("ECS CreateServiceCommand", () => {
+  it("keeps the number of tasks the service asked for", async () => {
+    // Given a task definition whose container is bound to a handler.
+    const simAws = new SimAws();
+    const ecs = simAws.ecs();
+    await simEcsClusterFactory.make({}, simAws);
+    ecs.bindContainer({
+      family: "checkout",
+      containerName: "app",
+      run: () => {
+        // A service container is available to be called rather than run once.
+      },
+    });
+    await ecs.registerTaskDefinition(
+      new RegisterTaskDefinitionCommand({
+        family: "checkout",
+        containerDefinitions: [{ name: "app", image: "checkout:1" }],
+      }),
+    );
+
+    // When a service is created with a desired count of three.
+    const created = await ecs.createService(
+      new CreateServiceCommand({
+        serviceName: "checkout",
+        taskDefinition: "checkout",
+        desiredCount: 3,
+      }),
+    );
+
+    // Then it is answered before its tasks have started, as real ECS answers
+    // one.
+    assertIdentical(created.service?.status, "ACTIVE");
+    assertIdentical(created.service.desiredCount, 3);
+    assertIdentical(created.service.runningCount, 0);
+    assertIdentical(created.service.pendingCount, 3);
+    assertIdentical(created.service.schedulingStrategy, "REPLICA");
+
+    // And once the simulation's background work is done, three tasks of it are
+    // running.
+    await simAws.backgroundTasksComplete();
+
+    const listed = await ecs.listTasks(
+      new ListTasksCommand({ serviceName: "checkout" }),
+    );
+
+    assertArrayLength(listed.taskArns, 3);
+    assertSetSize(new Set(listed.taskArns), 3);
+
+    const described = await ecs.describeServices(
+      new DescribeServicesCommand({ services: ["checkout"] }),
+    );
+
+    assertIdentical(described.services?.[0]?.runningCount, 3);
+    assertIdentical(described.services[0].pendingCount, 0);
+    assertIdentical(described.services[0].desiredCount, 3);
+  });
+
+  it("describes each of the tasks it is keeping running", async () => {
+    // Given a service created from a bound task definition.
+    const simAws = new SimAws();
+    const ecs = simAws.ecs();
+    await simEcsClusterFactory.make({}, simAws);
+    ecs.bindContainer({
+      family: "checkout",
+      containerName: "app",
+      run: () => {
+        // Nothing is called while the service is only being kept running.
+      },
+    });
+    await ecs.registerTaskDefinition(
+      new RegisterTaskDefinitionCommand({
+        family: "checkout",
+        containerDefinitions: [{ name: "app", image: "checkout:1" }],
+      }),
+    );
+    await ecs.createService(
+      new CreateServiceCommand({
+        serviceName: "checkout",
+        taskDefinition: "checkout",
+        desiredCount: 2,
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // When the tasks the service keeps are described.
+    const listed = await ecs.listTasks(
+      new ListTasksCommand({ serviceName: "checkout" }),
+    );
+    const described = await ecs.describeTasks(
+      new DescribeTasksCommand({ tasks: [...(listed.taskArns ?? [])] }),
+    );
+
+    // Then each of them is running, with its bound container running and
+    // carrying no exit code, because nothing has ended.
+    assertArrayLength(described.tasks, 2);
+    assertIdentical(described.tasks[0].lastStatus, "RUNNING");
+    assertIdentical(described.tasks[0].desiredStatus, "RUNNING");
+    assertIdentical(described.tasks[0].group, "service:checkout");
+    assertIdentical(described.tasks[0].startedBy, "ecs-svc/checkout");
+    assertIdentical(described.tasks[0].containers?.[0]?.lastStatus, "RUNNING");
+    assertUndefined(described.tasks[0].containers[0].exitCode);
+  });
+
+  it("creates a service whose containers are all unbound", async () => {
+    // Given a task definition with no binding at all.
+    const simAws = new SimAws();
+    const ecs = simAws.ecs();
+    await simEcsClusterFactory.make({}, simAws);
+    await ecs.registerTaskDefinition(
+      new RegisterTaskDefinitionCommand({
+        family: "checkout",
+        containerDefinitions: [
+          { name: "app", image: "checkout:1" },
+          { name: "log-router", image: "aws-for-fluent-bit:latest" },
+        ],
+      }),
+    );
+
+    // When a service is created from it.
+    await ecs.createService(
+      new CreateServiceCommand({
+        serviceName: "checkout",
+        taskDefinition: "checkout",
+        desiredCount: 2,
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // Then the service reports its counts all the same, and its containers
+    // record that nothing here simulates them.
+    const described = await ecs.describeServices(
+      new DescribeServicesCommand({ services: ["checkout"] }),
+    );
+
+    assertIdentical(described.services?.[0]?.runningCount, 2);
+
+    const listed = await ecs.listTasks(
+      new ListTasksCommand({ serviceName: "checkout" }),
+    );
+    const tasks = await ecs.describeTasks(
+      new DescribeTasksCommand({ tasks: [...(listed.taskArns ?? [])] }),
+    );
+    const containers = tasks.tasks?.[0]?.containers ?? [];
+
+    assertArrayLength(containers, 2);
+    assertIdentical(containers[0].lastStatus, "STOPPED");
+    assertStringIncludes(containers[0].reason ?? "", "Not simulated");
+    assertStringIncludes(containers[1].reason ?? "", "Not simulated");
+    assertIdentical(tasks.tasks?.[0]?.lastStatus, "RUNNING");
+  });
+
+  it("creates a service that is keeping nothing running", async () => {
+    // Given a registered task definition.
+    const simAws = new SimAws();
+    const ecs = simAws.ecs();
+    await simEcsClusterFactory.make({}, simAws);
+    await ecs.registerTaskDefinition(
+      new RegisterTaskDefinitionCommand({
+        family: "checkout",
+        containerDefinitions: [{ name: "app", image: "checkout:1" }],
+      }),
+    );
+
+    // When a service is created with a desired count of zero.
+    const created = await ecs.createService(
+      new CreateServiceCommand({
+        serviceName: "checkout",
+        taskDefinition: "checkout",
+        desiredCount: 0,
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // Then it exists and runs nothing, which is what scaling one to nothing
+    // leaves behind.
+    assertIdentical(created.service?.desiredCount, 0);
+
+    const listed = await ecs.listTasks(
+      new ListTasksCommand({ serviceName: "checkout" }),
+    );
+
+    assertArrayLength(listed.taskArns, 0);
+  });
+
+  it("reports the launch type the service was created with", async () => {
+    // Given a registered task definition.
+    const simAws = new SimAws();
+    const ecs = simAws.ecs();
+    await simEcsClusterFactory.make({}, simAws);
+    await ecs.registerTaskDefinition(
+      new RegisterTaskDefinitionCommand({
+        family: "checkout",
+        containerDefinitions: [{ name: "app", image: "checkout:1" }],
+      }),
+    );
+
+    // When a service is created on Fargate.
+    const created = await ecs.createService(
+      new CreateServiceCommand({
+        serviceName: "checkout",
+        taskDefinition: "checkout",
+        desiredCount: 1,
+        launchType: "FARGATE",
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // Then the service reports it, and so do the tasks it is keeping.
+    assertIdentical(created.service?.launchType, "FARGATE");
+
+    const listed = await ecs.listTasks(
+      new ListTasksCommand({ serviceName: "checkout", launchType: "FARGATE" }),
+    );
+
+    assertArrayLength(listed.taskArns, 1);
+  });
+
+  it("names the service by the cluster it was created in", async () => {
+    // Given a registered task definition and two clusters.
+    const simAws = new SimAws();
+    const ecs = simAws.ecs();
+    await simEcsClusterFactory.make({}, simAws);
+    await simEcsClusterFactory.make({ clusterName: "services" }, simAws);
+    await ecs.registerTaskDefinition(
+      new RegisterTaskDefinitionCommand({
+        family: "checkout",
+        containerDefinitions: [{ name: "app", image: "checkout:1" }],
+      }),
+    );
+
+    // When a service is created in that cluster.
+    const created = await ecs.createService(
+      new CreateServiceCommand({
+        cluster: "services",
+        serviceName: "checkout",
+        taskDefinition: "checkout",
+        desiredCount: 1,
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // Then its ARN names the cluster, as a real service ARN does, and a
+    // describe against another cluster reports nothing.
+    assertStringIncludes(
+      created.service?.serviceArn ?? "",
+      ":service/services/checkout",
+    );
+
+    const described = await ecs.describeServices(
+      new DescribeServicesCommand({ services: ["checkout"] }),
+    );
+
+    assertArrayLength(described.services, 0);
+    assertArrayLength(described.failures, 1);
+  });
+});

--- a/src/service/ecs/command/delete-service/deletable-service.ts
+++ b/src/service/ecs/command/delete-service/deletable-service.ts
@@ -1,0 +1,23 @@
+import { SimEcsInvalidParameterException } from "../../error/sim-ecs.error.js";
+import type { SimEcsService } from "../../service/sim-ecs-service.js";
+
+/**
+ * Take a service to delete, refusing one still keeping tasks running.
+ *
+ * Real ECS refuses this unless the request forces it, and the refusal is worth
+ * having: scaling a service to zero before deleting it is the ordinary way
+ * round, and a test that skips it is a test whose deployment would fail.
+ */
+export function requiredDeletableService(
+  service: SimEcsService,
+  force: boolean | undefined,
+): SimEcsService {
+  if (force === true || service.desiredCount === 0) {
+    return service;
+  }
+
+  throw new SimEcsInvalidParameterException(
+    `The service ${service.serviceName} cannot be deleted while it is scaled ` +
+      `above zero. Scale it to zero first, or delete it with force.`,
+  );
+}

--- a/src/service/ecs/command/delete-service/delete-service.command.ts
+++ b/src/service/ecs/command/delete-service/delete-service.command.ts
@@ -1,0 +1,28 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type { SimEcsServiceDetail } from "../../service/sim-ecs-service-detail.js";
+
+/**
+ * Minimal structural sim ECS DeleteService command.
+ */
+export interface SimDeleteServiceCommand {
+  readonly input: SimDeleteServiceCommandInput;
+}
+
+/**
+ * Minimal structural sim ECS DeleteService input.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/ecs/command/DeleteServiceCommand/
+ */
+export interface SimDeleteServiceCommandInput {
+  readonly cluster?: string | undefined;
+  readonly service?: string | undefined;
+  readonly force?: boolean | undefined;
+}
+
+/**
+ * Minimal structural sim ECS DeleteService output.
+ */
+export interface SimDeleteServiceCommandOutput {
+  readonly service?: SimEcsServiceDetail | undefined;
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/ecs/command/delete-service/delete-service.handler.ts
+++ b/src/service/ecs/command/delete-service/delete-service.handler.ts
@@ -1,0 +1,79 @@
+import type { CommandHandler } from "../../../../command/command-handler.js";
+import type { SimEcsServiceTasks } from "../../service/run/sim-ecs-service-tasks.js";
+import type { SimEcsServiceCommandContext } from "../sim-ecs-command-context.js";
+import { SimEcsCommandHandler } from "../sim-ecs-command-handler.js";
+import type { SimEcsRequestOptions } from "../sim-ecs-request-options.js";
+import { SimEcsRequestedCluster } from "../sim-ecs-requested-cluster.js";
+import { SimEcsRequestedService } from "../sim-ecs-requested-service.js";
+import { requiredDeletableService } from "./deletable-service.js";
+import type {
+  SimDeleteServiceCommand,
+  SimDeleteServiceCommandOutput,
+} from "./delete-service.command.js";
+
+const acceptedInput: readonly string[] = ["cluster", "service", "force"];
+
+/**
+ * Why a task of a deleted service stopped.
+ */
+const deletedReason = "Task stopped by the service being deleted.";
+
+/**
+ * Simulated ECS DeleteServiceCommand handler.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/ecs/command/DeleteServiceCommand/
+ */
+export class DeleteServiceCommandHandler
+  extends SimEcsCommandHandler
+  implements
+    CommandHandler<SimDeleteServiceCommand, SimDeleteServiceCommandOutput>
+{
+  private readonly serviceTasks: SimEcsServiceTasks;
+  private readonly requestedCluster: SimEcsRequestedCluster;
+  private readonly requestedService: SimEcsRequestedService;
+
+  constructor(context: SimEcsServiceCommandContext) {
+    super(context, "DeleteService", acceptedInput);
+    this.serviceTasks = context.serviceTasks;
+    this.requestedCluster = new SimEcsRequestedCluster(context);
+    this.requestedService = new SimEcsRequestedService(context);
+  }
+
+  /**
+   * Delete a service, stopping everything it was running.
+   *
+   * The service is marked `INACTIVE` rather than removed, as real ECS leaves a
+   * deleted one, so something holding its ARN can still find out what became of
+   * it. Its tasks stop at once and drop out of a `ListTasks` of running tasks.
+   */
+  async handle(
+    command: SimDeleteServiceCommand,
+    options?: SimEcsRequestOptions,
+  ): Promise<SimDeleteServiceCommandOutput> {
+    this.refuseUnaccepted(command.input);
+
+    const named = this.requestedService.named(
+      command.input.service,
+      "DeleteService",
+    );
+
+    await this.sequence();
+
+    const clusterName = this.requestedCluster.name(command.input.cluster);
+
+    this.authorizer.authorizeService(
+      "ecs:DeleteService",
+      this.requestedService.arn(named, clusterName),
+      options,
+    );
+
+    const cluster = this.requestedCluster.active(command.input.cluster);
+    const service = this.requestedService.active(named, cluster.clusterName);
+
+    requiredDeletableService(service, command.input.force);
+    this.serviceTasks.stopAll(service, deletedReason);
+    service.markDeleted();
+
+    return { $metadata: {}, service: service.toOutput() };
+  }
+}

--- a/src/service/ecs/command/delete-service/delete-service.iso.test.ts
+++ b/src/service/ecs/command/delete-service/delete-service.iso.test.ts
@@ -1,0 +1,198 @@
+import {
+  DeleteServiceCommand,
+  DescribeServicesCommand,
+  DescribeTasksCommand,
+  ListTasksCommand,
+  UpdateServiceCommand,
+} from "@aws-sdk/client-ecs";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { simEcsClusterFactory } from "../../cluster/sim-ecs-cluster.factory.js";
+import {
+  SimEcsInvalidParameterException,
+  SimEcsServiceNotFoundException,
+} from "../../error/sim-ecs.error.js";
+import { simEcsRegisteredTaskDefinitionFactory } from "../../task-definition/sim-ecs-registered-task-definition.factory.js";
+import { simEcsServiceFactory } from "../../service/sim-ecs-service.factory.js";
+
+describe("ECS DeleteServiceCommand", () => {
+  it("stops the tasks of a service it was forced to delete", async () => {
+    // Given a service running three tasks.
+    const simAws = new SimAws();
+    const ecs = simAws.ecs();
+    await simEcsClusterFactory.make({}, simAws);
+    await simEcsRegisteredTaskDefinitionFactory.make({}, simAws);
+    await simEcsServiceFactory.make({ desiredCount: 3 }, simAws);
+    await simAws.backgroundTasksComplete();
+
+    const before = await ecs.listTasks(
+      new ListTasksCommand({ serviceName: "checkout" }),
+    );
+
+    assertArrayLength(before.taskArns, 3);
+
+    // When it is deleted with force, without being scaled down first.
+    const deleted = await ecs.deleteService(
+      new DeleteServiceCommand({ service: "checkout", force: true }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // Then the service is INACTIVE and its tasks are no longer listed.
+    assertIdentical(deleted.service?.status, "INACTIVE");
+    assertIdentical(deleted.service.desiredCount, 0);
+    assertIdentical(deleted.service.runningCount, 0);
+
+    const after = await ecs.listTasks(
+      new ListTasksCommand({ serviceName: "checkout" }),
+    );
+
+    assertArrayLength(after.taskArns, 0);
+
+    // And each stopped task says the service being deleted stopped it.
+    const stopped = await ecs.describeTasks(
+      new DescribeTasksCommand({ tasks: [before.taskArns[0]] }),
+    );
+
+    assertIdentical(stopped.tasks?.[0]?.lastStatus, "STOPPED");
+    assertStringIncludes(stopped.tasks[0].stoppedReason ?? "", "being deleted");
+  });
+
+  it("deletes a service that has been scaled to nothing", async () => {
+    // Given a service scaled to zero.
+    const simAws = new SimAws();
+    const ecs = simAws.ecs();
+    await simEcsClusterFactory.make({}, simAws);
+    await simEcsRegisteredTaskDefinitionFactory.make({}, simAws);
+    await simEcsServiceFactory.make({ desiredCount: 2 }, simAws);
+    await ecs.updateService(
+      new UpdateServiceCommand({ service: "checkout", desiredCount: 0 }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // When it is deleted without force.
+    const deleted = await ecs.deleteService(
+      new DeleteServiceCommand({ service: "checkout" }),
+    );
+
+    // Then it goes, which is the ordinary way round.
+    assertIdentical(deleted.service?.status, "INACTIVE");
+  });
+
+  it("refuses to delete a service that is still scaled up", async () => {
+    // Given a service running one task.
+    const simAws = new SimAws();
+    await simEcsClusterFactory.make({}, simAws);
+    await simEcsRegisteredTaskDefinitionFactory.make({}, simAws);
+    await simEcsServiceFactory.make({}, simAws);
+    await simAws.backgroundTasksComplete();
+
+    // When it is deleted without force.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws
+        .ecs()
+        .deleteService(new DeleteServiceCommand({ service: "checkout" })),
+    );
+
+    // Then it is refused, as real ECS refuses it: scaling to zero first is the
+    // ordinary way round, and a test that skips it would fail on deployment.
+    assertInstanceOf(error, SimEcsInvalidParameterException);
+    assertStringIncludes(error.message, "scaled above zero");
+  });
+
+  it("still describes a deleted service", async () => {
+    // Given a deleted service.
+    const simAws = new SimAws();
+    const ecs = simAws.ecs();
+    await simEcsClusterFactory.make({}, simAws);
+    await simEcsRegisteredTaskDefinitionFactory.make({}, simAws);
+    await simEcsServiceFactory.make({}, simAws);
+    await simAws.backgroundTasksComplete();
+    await ecs.deleteService(
+      new DeleteServiceCommand({ service: "checkout", force: true }),
+    );
+
+    // When it is described.
+    const described = await ecs.describeServices(
+      new DescribeServicesCommand({ services: ["checkout"] }),
+    );
+
+    // Then it is still there as INACTIVE, so something holding its ARN can find
+    // out what became of it.
+    assertIdentical(described.services?.[0]?.status, "INACTIVE");
+    assertArrayLength(described.failures, 0);
+  });
+
+  it("frees the name a deleted service had", async () => {
+    // Given a deleted service.
+    const simAws = new SimAws();
+    const ecs = simAws.ecs();
+    await simEcsClusterFactory.make({}, simAws);
+    await simEcsRegisteredTaskDefinitionFactory.make({}, simAws);
+    await simEcsServiceFactory.make({}, simAws);
+    await ecs.deleteService(
+      new DeleteServiceCommand({ service: "checkout", force: true }),
+    );
+
+    // When a service of the same name is created again.
+    const created = await simEcsServiceFactory.make(
+      { desiredCount: 2 },
+      simAws,
+    );
+    await simAws.backgroundTasksComplete();
+
+    // Then it takes the deleted one's place as an active service.
+    assertIdentical(created.status, "ACTIVE");
+
+    const described = await ecs.describeServices(
+      new DescribeServicesCommand({ services: ["checkout"] }),
+    );
+
+    assertIdentical(described.services?.[0]?.status, "ACTIVE");
+    assertIdentical(described.services[0].runningCount, 2);
+  });
+
+  it("refuses a service the cluster does not hold", async () => {
+    // Given a cluster with no service in it.
+    const simAws = new SimAws();
+    await simEcsClusterFactory.make({}, simAws);
+
+    // When a service of it is deleted.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws
+        .ecs()
+        .deleteService(new DeleteServiceCommand({ service: "checkout" })),
+    );
+
+    // Then it is ECS's own service not found error.
+    assertInstanceOf(error, SimEcsServiceNotFoundException);
+    assertStringIncludes(error.message, "checkout");
+  });
+
+  it("refuses a service ARN naming another cluster", async () => {
+    // Given a service in the default cluster.
+    const simAws = new SimAws();
+    await simEcsClusterFactory.make({}, simAws);
+    await simEcsRegisteredTaskDefinitionFactory.make({}, simAws);
+    await simEcsServiceFactory.make({ desiredCount: 0 }, simAws);
+
+    // When it is deleted by an ARN naming a different cluster.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.ecs().deleteService(
+        new DeleteServiceCommand({
+          service: `arn:aws:ecs:${simAws.defaultRegionName}:${simAws.defaultAccountId}:service/services/checkout`,
+        }),
+      ),
+    );
+
+    // Then it names nothing, because a service belongs to the cluster it was
+    // created in.
+    assertInstanceOf(error, SimEcsServiceNotFoundException);
+  });
+});

--- a/src/service/ecs/command/describe-services/describe-services.command.ts
+++ b/src/service/ecs/command/describe-services/describe-services.command.ts
@@ -1,0 +1,29 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type { SimEcsServiceDetail } from "../../service/sim-ecs-service-detail.js";
+import type { SimEcsFailure } from "../describe-clusters/describe-clusters.command.js";
+
+/**
+ * Minimal structural sim ECS DescribeServices command.
+ */
+export interface SimDescribeServicesCommand {
+  readonly input: SimDescribeServicesCommandInput;
+}
+
+/**
+ * Minimal structural sim ECS DescribeServices input.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/ecs/command/DescribeServicesCommand/
+ */
+export interface SimDescribeServicesCommandInput {
+  readonly cluster?: string | undefined;
+  readonly services?: readonly string[] | undefined;
+}
+
+/**
+ * Minimal structural sim ECS DescribeServices output.
+ */
+export interface SimDescribeServicesCommandOutput {
+  readonly services?: readonly SimEcsServiceDetail[] | undefined;
+  readonly failures?: readonly SimEcsFailure[] | undefined;
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/ecs/command/describe-services/describe-services.handler.ts
+++ b/src/service/ecs/command/describe-services/describe-services.handler.ts
@@ -1,0 +1,121 @@
+import type { CommandHandler } from "../../../../command/command-handler.js";
+import { SimEcsClientException } from "../../error/sim-ecs.error.js";
+import type { SimEcsServiceArn } from "../../service/sim-ecs-service-arn.js";
+import type { SimEcsServiceCommandContext } from "../sim-ecs-command-context.js";
+import { SimEcsCommandHandler } from "../sim-ecs-command-handler.js";
+import type { SimEcsRequestOptions } from "../sim-ecs-request-options.js";
+import { SimEcsRequestedCluster } from "../sim-ecs-requested-cluster.js";
+import { DescribedServices } from "./described-services.js";
+import type {
+  SimDescribeServicesCommand,
+  SimDescribeServicesCommandOutput,
+} from "./describe-services.command.js";
+
+const acceptedInput: readonly string[] = ["cluster", "services"];
+
+/**
+ * How many services one request may name, as real ECS limits it.
+ */
+const maxServices = 10;
+
+/**
+ * Simulated ECS DescribeServicesCommand handler.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/ecs/command/DescribeServicesCommand/
+ */
+export class DescribeServicesCommandHandler
+  extends SimEcsCommandHandler
+  implements
+    CommandHandler<
+      SimDescribeServicesCommand,
+      SimDescribeServicesCommandOutput
+    >
+{
+  private readonly serviceArn: SimEcsServiceArn;
+  private readonly requestedCluster: SimEcsRequestedCluster;
+  private readonly described: DescribedServices;
+
+  constructor(context: SimEcsServiceCommandContext) {
+    super(context, "DescribeServices", acceptedInput);
+    this.serviceArn = context.serviceArn;
+    this.requestedCluster = new SimEcsRequestedCluster(context);
+    this.described = new DescribedServices(context);
+  }
+
+  /**
+   * The services the request named, which it has to name at least one of.
+   */
+  private static requestedServices(
+    services: readonly string[] | undefined,
+  ): readonly string[] {
+    if (services === undefined || services.length === 0) {
+      throw new SimEcsClientException(
+        "DescribeServices needs at least one service, named by its name or " +
+          "its full ARN.",
+      );
+    }
+
+    if (services.length > maxServices) {
+      throw new SimEcsClientException(
+        `DescribeServices takes at most ${String(maxServices)} services in ` +
+          `one request.`,
+      );
+    }
+
+    return services;
+  }
+
+  /**
+   * Describe each service the request named, reporting the rest as failures.
+   *
+   * Each named service is authorized separately, against the ARN it has in the
+   * cluster the request named, so a policy naming one service grants that
+   * service and no other. The service need not exist to be authorized against.
+   */
+  async handle(
+    command: SimDescribeServicesCommand,
+    options?: SimEcsRequestOptions,
+  ): Promise<SimDescribeServicesCommandOutput> {
+    this.refuseUnaccepted(command.input);
+
+    const identifiers = DescribeServicesCommandHandler.requestedServices(
+      command.input.services,
+    );
+
+    await this.sequence();
+
+    const clusterName = this.requestedCluster.name(command.input.cluster);
+    this.authorizeEach(identifiers, clusterName, options);
+
+    // Raises for a cluster that is not there, as real ECS does, rather than
+    // reporting every service in it as missing.
+    this.requestedCluster.active(command.input.cluster);
+
+    const described = this.described.describe(identifiers, clusterName);
+
+    return {
+      $metadata: {},
+      services: described.services,
+      failures: described.failures,
+    };
+  }
+
+  private authorizeEach(
+    identifiers: readonly string[],
+    clusterName: string,
+    options: SimEcsRequestOptions | undefined,
+  ): void {
+    for (const identifier of identifiers) {
+      const named = this.serviceArn.namedService(identifier);
+      const arn =
+        named === undefined
+          ? identifier
+          : this.serviceArn.make(
+              named.clusterName ?? clusterName,
+              named.serviceName,
+            );
+
+      this.authorizer.authorizeService("ecs:DescribeServices", arn, options);
+    }
+  }
+}

--- a/src/service/ecs/command/describe-services/describe-services.iso.test.ts
+++ b/src/service/ecs/command/describe-services/describe-services.iso.test.ts
@@ -1,0 +1,197 @@
+import { DescribeServicesCommand } from "@aws-sdk/client-ecs";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { simEcsClusterFactory } from "../../cluster/sim-ecs-cluster.factory.js";
+import {
+  SimEcsClientException,
+  SimEcsClusterNotFoundException,
+} from "../../error/sim-ecs.error.js";
+import { simEcsRegisteredTaskDefinitionFactory } from "../../task-definition/sim-ecs-registered-task-definition.factory.js";
+import { simEcsServiceFactory } from "../../service/sim-ecs-service.factory.js";
+
+describe("ECS DescribeServicesCommand", () => {
+  it("describes a service by its name and by its ARN", async () => {
+    // Given a service.
+    const simAws = new SimAws();
+    const ecs = simAws.ecs();
+    await simEcsClusterFactory.make({}, simAws);
+    await simEcsRegisteredTaskDefinitionFactory.make({}, simAws);
+    const created = await simEcsServiceFactory.make({}, simAws);
+    await simAws.backgroundTasksComplete();
+
+    // When it is described both ways.
+    const described = await ecs.describeServices(
+      new DescribeServicesCommand({
+        services: ["checkout", created.serviceArn ?? ""],
+      }),
+    );
+
+    // Then both name the same service, since the two forms are interchangeable
+    // wherever ECS takes one.
+    assertArrayLength(described.services, 2);
+    assertIdentical(described.services[0].serviceArn, created.serviceArn);
+    assertIdentical(described.services[1].serviceArn, created.serviceArn);
+    assertIdentical(described.services[0].clusterArn, created.clusterArn);
+    assertStringIncludes(
+      described.services[0].taskDefinition ?? "",
+      "task-definition/checkout:1",
+    );
+  });
+
+  it("reports a service it cannot find as a failure", async () => {
+    // Given a cluster holding one service.
+    const simAws = new SimAws();
+    const ecs = simAws.ecs();
+    await simEcsClusterFactory.make({}, simAws);
+    await simEcsRegisteredTaskDefinitionFactory.make({}, simAws);
+    await simEcsServiceFactory.make({}, simAws);
+    await simAws.backgroundTasksComplete();
+
+    // When two services are described, one of which is not there.
+    const described = await ecs.describeServices(
+      new DescribeServicesCommand({ services: ["checkout", "orders"] }),
+    );
+
+    // Then the one that is there is described and the other is a failure entry
+    // rather than an error.
+    assertArrayLength(described.services, 1);
+    assertArrayLength(described.failures, 1);
+    assertIdentical(described.failures[0].reason, "MISSING");
+    assertStringIncludes(
+      described.failures[0].arn ?? "",
+      ":service/default/orders",
+    );
+  });
+
+  it("describes a service named by an ARN in the older format", async () => {
+    // Given a service.
+    const simAws = new SimAws();
+    await simEcsClusterFactory.make({}, simAws);
+    await simEcsRegisteredTaskDefinitionFactory.make({}, simAws);
+    await simEcsServiceFactory.make({}, simAws);
+    await simAws.backgroundTasksComplete();
+
+    // When it is described by an ARN that leaves the cluster out, which is the
+    // format ECS used before it named the cluster in one.
+    const described = await simAws.ecs().describeServices(
+      new DescribeServicesCommand({
+        services: [
+          `arn:aws:ecs:${simAws.defaultRegionName}:${simAws.defaultAccountId}:service/checkout`,
+        ],
+      }),
+    );
+
+    // Then it names the service in the cluster the request meant.
+    assertArrayLength(described.services, 1);
+    assertIdentical(described.services[0].serviceName, "checkout");
+  });
+
+  it("reports a service ARN naming another cluster as a failure", async () => {
+    // Given a service in the default cluster.
+    const simAws = new SimAws();
+    await simEcsClusterFactory.make({}, simAws);
+    await simEcsRegisteredTaskDefinitionFactory.make({}, simAws);
+    await simEcsServiceFactory.make({}, simAws);
+    await simAws.backgroundTasksComplete();
+
+    // When it is described by an ARN naming a different cluster.
+    const described = await simAws.ecs().describeServices(
+      new DescribeServicesCommand({
+        services: [
+          `arn:aws:ecs:${simAws.defaultRegionName}:${simAws.defaultAccountId}:service/services/checkout`,
+        ],
+      }),
+    );
+
+    // Then it names nothing, because a service belongs to the cluster it was
+    // created in.
+    assertArrayLength(described.services, 0);
+    assertArrayLength(described.failures, 1);
+  });
+
+  it("reports a service ARN from another region as a failure", async () => {
+    // Given a service.
+    const simAws = new SimAws();
+    await simEcsClusterFactory.make({}, simAws);
+    await simEcsRegisteredTaskDefinitionFactory.make({}, simAws);
+    await simEcsServiceFactory.make({}, simAws);
+
+    // When it is described by an ARN belonging to another Region.
+    const described = await simAws.ecs().describeServices(
+      new DescribeServicesCommand({
+        services: [
+          `arn:aws:ecs:eu-central-1:${simAws.defaultAccountId}:service/default/checkout`,
+        ],
+      }),
+    );
+
+    // Then it names nothing here, because it names a service somewhere else on
+    // real AWS.
+    assertArrayLength(described.services, 0);
+    assertArrayLength(described.failures, 1);
+  });
+
+  it("refuses a request naming no service", async () => {
+    // Given a cluster.
+    const simAws = new SimAws();
+    await simEcsClusterFactory.make({}, simAws);
+
+    // When services are described without naming any.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws
+        .ecs()
+        .describeServices(new DescribeServicesCommand({ services: [] })),
+    );
+
+    // Then it is refused, as real ECS refuses it.
+    assertInstanceOf(error, SimEcsClientException);
+    assertStringIncludes(error.message, "at least one service");
+  });
+
+  it("refuses more services than one request may name", async () => {
+    // Given a cluster.
+    const simAws = new SimAws();
+    await simEcsClusterFactory.make({}, simAws);
+
+    // When eleven services are described in one request.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.ecs().describeServices(
+        new DescribeServicesCommand({
+          services: Array.from(
+            { length: 11 },
+            (_, index) => `s${String(index)}`,
+          ),
+        }),
+      ),
+    );
+
+    // Then it is refused at the limit real ECS applies.
+    assertInstanceOf(error, SimEcsClientException);
+    assertStringIncludes(error.message, "at most 10");
+  });
+
+  it("raises for a cluster that is not there", async () => {
+    // Given no cluster at all.
+    const simAws = new SimAws();
+
+    // When a service of one is described.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws
+        .ecs()
+        .describeServices(
+          new DescribeServicesCommand({ services: ["checkout"] }),
+        ),
+    );
+
+    // Then the cluster is reported rather than every service in it being
+    // reported as missing.
+    assertInstanceOf(error, SimEcsClusterNotFoundException);
+  });
+});

--- a/src/service/ecs/command/describe-services/described-services.ts
+++ b/src/service/ecs/command/describe-services/described-services.ts
@@ -1,0 +1,103 @@
+import type { SimEcsServiceArn } from "../../service/sim-ecs-service-arn.js";
+import type { SimEcsServiceStore } from "../../service/sim-ecs-service-store.js";
+import type { SimEcsServiceDetail } from "../../service/sim-ecs-service-detail.js";
+import type { SimEcsFailure } from "../describe-clusters/describe-clusters.command.js";
+import type { SimEcsServiceCommandContext } from "../sim-ecs-command-context.js";
+
+/**
+ * What ECS reports for a service it cannot find.
+ */
+const missingReason = "MISSING";
+
+/**
+ * What a `DescribeServices` request answers with.
+ */
+export interface DescribedServicesOutput {
+  readonly services: readonly SimEcsServiceDetail[];
+  readonly failures: readonly SimEcsFailure[];
+}
+
+/**
+ * Describes the services one request named, splitting answers from failures.
+ *
+ * A service ECS cannot find is a failure entry rather than an error, so one
+ * request naming several services answers for each of them. A service of
+ * another cluster is one it cannot find: a service belongs to the cluster it
+ * was created in, and naming it under a different one names nothing.
+ *
+ * A deleted service is described as `INACTIVE` rather than reported missing,
+ * which is what real ECS does with one for a while after it is deleted.
+ */
+export class DescribedServices {
+  private readonly services: SimEcsServiceStore;
+  private readonly serviceArn: SimEcsServiceArn;
+
+  constructor(context: SimEcsServiceCommandContext) {
+    this.services = context.services;
+    this.serviceArn = context.serviceArn;
+  }
+
+  /**
+   * Describe each service a request named, in the order it named them.
+   */
+  describe(
+    identifiers: readonly string[],
+    clusterName: string,
+  ): DescribedServicesOutput {
+    const services: SimEcsServiceDetail[] = [];
+    const failures: SimEcsFailure[] = [];
+
+    for (const identifier of identifiers) {
+      const described = this.describeOne(identifier, clusterName);
+
+      if (described === undefined) {
+        failures.push(this.failureFor(identifier, clusterName));
+        continue;
+      }
+
+      services.push(described);
+    }
+
+    return { services, failures };
+  }
+
+  private describeOne(
+    identifier: string,
+    clusterName: string,
+  ): SimEcsServiceDetail | undefined {
+    const named = this.serviceArn.namedService(identifier);
+
+    if (named === undefined) {
+      return undefined;
+    }
+
+    if (named.clusterName !== undefined && named.clusterName !== clusterName) {
+      return undefined;
+    }
+
+    return this.services.find(clusterName, named.serviceName)?.toOutput();
+  }
+
+  /**
+   * The failure entry for a service that is not there.
+   *
+   * ECS reports the ARN of the service it looked for, so an identifier given as
+   * a name is reported as the ARN it would have had in the cluster the request
+   * named. One that is not a service identifier at all is reported as it came.
+   */
+  private failureFor(identifier: string, clusterName: string): SimEcsFailure {
+    const named = this.serviceArn.namedService(identifier);
+
+    if (named === undefined) {
+      return { arn: identifier, reason: missingReason };
+    }
+
+    return {
+      arn: this.serviceArn.make(
+        named.clusterName ?? clusterName,
+        named.serviceName,
+      ),
+      reason: missingReason,
+    };
+  }
+}

--- a/src/service/ecs/command/list-tasks/list-tasks.command.ts
+++ b/src/service/ecs/command/list-tasks/list-tasks.command.ts
@@ -17,6 +17,7 @@ export interface SimListTasksCommandInput {
   readonly cluster?: string | undefined;
   readonly family?: string | undefined;
   readonly desiredStatus?: string | undefined;
+  readonly serviceName?: string | undefined;
   readonly startedBy?: string | undefined;
   readonly launchType?: string | undefined;
   readonly maxResults?: number | undefined;

--- a/src/service/ecs/command/list-tasks/list-tasks.handler.ts
+++ b/src/service/ecs/command/list-tasks/list-tasks.handler.ts
@@ -16,6 +16,7 @@ const acceptedInput: readonly string[] = [
   "cluster",
   "family",
   "desiredStatus",
+  "serviceName",
   "startedBy",
   "launchType",
   "maxResults",
@@ -63,6 +64,7 @@ export class ListTasksCommandHandler
       clusterName: cluster.clusterName,
       desiredStatus,
       family: command.input.family,
+      serviceName: command.input.serviceName,
       startedBy: command.input.startedBy,
       launchType: command.input.launchType,
     });

--- a/src/service/ecs/command/list-tasks/list-tasks.iso.test.ts
+++ b/src/service/ecs/command/list-tasks/list-tasks.iso.test.ts
@@ -67,8 +67,11 @@ describe("ECS ListTasksCommand", () => {
     await simEcsClusterFactory.make({}, simAws);
     await simEcsRegisteredTaskDefinitionFactory.make({}, simAws);
     await simEcsServiceFactory.make({ desiredCount: 2 }, simAws);
-    await ecs.runTask(new RunTaskCommand({ taskDefinition: "checkout" }));
     await simAws.backgroundTasksComplete();
+
+    // And the one run on its own still wanted running, so that a listing that
+    // ignored the service would answer with all three.
+    await ecs.runTask(new RunTaskCommand({ taskDefinition: "checkout" }));
 
     // When the tasks of the service are listed.
     const ofService = await ecs.listTasks(
@@ -78,10 +81,12 @@ describe("ECS ListTasksCommand", () => {
       new ListTasksCommand({ family: "checkout" }),
     );
 
-    // Then only the ones it is keeping running are listed, while the family
-    // holds those two and no more, since the one run on its own has stopped.
+    // Then only the two the service is keeping are listed, out of the three
+    // the family has running.
     assertArrayLength(ofService.taskArns, 2);
-    assertArrayLength(ofFamily.taskArns, 2);
+    assertArrayLength(ofFamily.taskArns, 3);
+
+    await simAws.backgroundTasksComplete();
   });
 
   it("filters by family and by what started the task", async () => {

--- a/src/service/ecs/command/list-tasks/list-tasks.iso.test.ts
+++ b/src/service/ecs/command/list-tasks/list-tasks.iso.test.ts
@@ -12,6 +12,7 @@ import { SimAws } from "../../../aws/sim-aws.js";
 import { simEcsClusterFactory } from "../../cluster/sim-ecs-cluster.factory.js";
 import { SimEcsInvalidParameterException } from "../../error/sim-ecs.error.js";
 import { simEcsRegisteredTaskDefinitionFactory } from "../../task-definition/sim-ecs-registered-task-definition.factory.js";
+import { simEcsServiceFactory } from "../../service/sim-ecs-service.factory.js";
 
 describe("ECS ListTasksCommand", () => {
   it("lists the tasks that are meant to be running", async () => {
@@ -56,6 +57,31 @@ describe("ECS ListTasksCommand", () => {
       .listTasks(new ListTasksCommand({ desiredStatus: "STOPPED" }));
 
     assertArrayLength(stopped.taskArns, 1);
+  });
+
+  it("filters by the service keeping the task running", async () => {
+    // Given a service running two tasks and a task run on its own from the
+    // same family.
+    const simAws = new SimAws();
+    const ecs = simAws.ecs();
+    await simEcsClusterFactory.make({}, simAws);
+    await simEcsRegisteredTaskDefinitionFactory.make({}, simAws);
+    await simEcsServiceFactory.make({ desiredCount: 2 }, simAws);
+    await ecs.runTask(new RunTaskCommand({ taskDefinition: "checkout" }));
+    await simAws.backgroundTasksComplete();
+
+    // When the tasks of the service are listed.
+    const ofService = await ecs.listTasks(
+      new ListTasksCommand({ serviceName: "checkout" }),
+    );
+    const ofFamily = await ecs.listTasks(
+      new ListTasksCommand({ family: "checkout" }),
+    );
+
+    // Then only the ones it is keeping running are listed, while the family
+    // holds those two and no more, since the one run on its own has stopped.
+    assertArrayLength(ofService.taskArns, 2);
+    assertArrayLength(ofFamily.taskArns, 2);
   });
 
   it("filters by family and by what started the task", async () => {

--- a/src/service/ecs/command/run-task/run-task.handler.ts
+++ b/src/service/ecs/command/run-task/run-task.handler.ts
@@ -1,11 +1,11 @@
 import type { CommandHandler } from "../../../../command/command-handler.js";
 import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
 import type { SimEcsCluster } from "../../cluster/sim-ecs-cluster.js";
-import { SimEcsClientException } from "../../error/sim-ecs.error.js";
 import { SimEcsTaskRunner } from "../../task/run/sim-ecs-task-runner.js";
 import { SimEcsTaskFactory } from "../../task/sim-ecs-task-factory.js";
 import type { SimEcsTaskStore } from "../../task/sim-ecs-task-store.js";
 import type { SimEcsTask } from "../../task/sim-ecs-task.js";
+import { requiredRunnableTaskDefinition } from "../../task-definition/sim-ecs-runnable-task-definition.js";
 import type { SimEcsTaskDefinitionStore } from "../../task-definition/sim-ecs-task-definition-store.js";
 import type { SimEcsTaskDefinition } from "../../task-definition/sim-ecs-task-definition.js";
 import type { SimEcsRunTaskCommandContext } from "../sim-ecs-command-context.js";
@@ -95,7 +95,7 @@ export class RunTaskCommandHandler
     await this.sequence();
 
     const cluster = this.requestedCluster.active(command.input.cluster);
-    const taskDefinition = this.runnable(
+    const taskDefinition = requiredRunnableTaskDefinition(
       this.taskDefinitions.resolve(request.taskDefinitionId),
     );
     request.overrides.refuseUnknownContainers(taskDefinition.containers);
@@ -138,24 +138,5 @@ export class RunTaskCommandHandler
     });
 
     return task;
-  }
-
-  /**
-   * The revision to run, which has to be one that is still registered.
-   *
-   * Real ECS refuses to run a revision that has been deregistered, and it is
-   * worth refusing here: a deregistered revision is one nothing is meant to
-   * start from any more.
-   */
-  private runnable(taskDefinition: SimEcsTaskDefinition): SimEcsTaskDefinition {
-    if (!taskDefinition.isActive()) {
-      throw new SimEcsClientException(
-        `Task definition ${taskDefinition.family}:` +
-          `${String(taskDefinition.revision)} is INACTIVE, so no task can be ` +
-          `run from it.`,
-      );
-    }
-
-    return taskDefinition;
   }
 }

--- a/src/service/ecs/command/sim-ecs-command-context.ts
+++ b/src/service/ecs/command/sim-ecs-command-context.ts
@@ -4,6 +4,9 @@ import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-
 import type { SimEcsContainerBindings } from "../bind/sim-ecs-container-bindings.js";
 import type { SimEcsClusterArn } from "../cluster/sim-ecs-cluster-arn.js";
 import type { SimEcsClusterStore } from "../cluster/sim-ecs-cluster-store.js";
+import type { SimEcsServiceTasks } from "../service/run/sim-ecs-service-tasks.js";
+import type { SimEcsServiceArn } from "../service/sim-ecs-service-arn.js";
+import type { SimEcsServiceStore } from "../service/sim-ecs-service-store.js";
 import type { SimEcsSecretStores } from "../task/run/secret/sim-ecs-secret-stores.js";
 import type { SimEcsTaskArn } from "../task/sim-ecs-task-arn.js";
 import type { SimEcsTaskStore } from "../task/sim-ecs-task-store.js";
@@ -67,4 +70,21 @@ export interface SimEcsRunTaskCommandContext extends SimEcsTaskCommandContext {
   readonly bindings: SimEcsContainerBindings;
   readonly runAsOwner: SimAwsRunAsOwner;
   readonly secretStores: SimEcsSecretStores;
+}
+
+/**
+ * What a simulated ECS service command handler is built with.
+ *
+ * A service operation reaches the task state a task operation does, because a
+ * service is a number of tasks kept running, and the task definitions because
+ * that is what it keeps running. What starts and stops those tasks is built
+ * once and shared, since the service that is closed holds the same tasks the
+ * one that was updated does.
+ */
+export interface SimEcsServiceCommandContext extends SimEcsTaskCommandContext {
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+  readonly taskDefinitions: SimEcsTaskDefinitionStore;
+  readonly services: SimEcsServiceStore;
+  readonly serviceArn: SimEcsServiceArn;
+  readonly serviceTasks: SimEcsServiceTasks;
 }

--- a/src/service/ecs/command/sim-ecs-command-contexts.ts
+++ b/src/service/ecs/command/sim-ecs-command-contexts.ts
@@ -4,6 +4,9 @@ import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-
 import type { SimEcsContainerBindings } from "../bind/sim-ecs-container-bindings.js";
 import { SimEcsClusterArn } from "../cluster/sim-ecs-cluster-arn.js";
 import type { SimEcsClusterStore } from "../cluster/sim-ecs-cluster-store.js";
+import { SimEcsServiceTasks } from "../service/run/sim-ecs-service-tasks.js";
+import { SimEcsServiceArn } from "../service/sim-ecs-service-arn.js";
+import type { SimEcsServiceStore } from "../service/sim-ecs-service-store.js";
 import type { SimEcsSecretStores } from "../task/run/secret/sim-ecs-secret-stores.js";
 import { SimEcsTaskArn } from "../task/sim-ecs-task-arn.js";
 import type { SimEcsTaskStore } from "../task/sim-ecs-task-store.js";
@@ -13,6 +16,7 @@ import type { SimEcsAuthorizer } from "./authorize/sim-ecs-authorizer.js";
 import type {
   SimEcsClusterCommandContext,
   SimEcsRunTaskCommandContext,
+  SimEcsServiceCommandContext,
   SimEcsTaskCommandContext,
   SimEcsTaskDefinitionCommandContext,
 } from "./sim-ecs-command-context.js";
@@ -25,6 +29,7 @@ interface SimEcsCommandContextsProperties {
   readonly clusters: SimEcsClusterStore;
   readonly taskDefinitions: SimEcsTaskDefinitionStore;
   readonly tasks: SimEcsTaskStore;
+  readonly services: SimEcsServiceStore;
   readonly bindings: SimEcsContainerBindings;
   readonly secretStores: SimEcsSecretStores;
 }
@@ -42,6 +47,7 @@ export class SimEcsCommandContexts {
   public readonly taskDefinition: SimEcsTaskDefinitionCommandContext;
   public readonly task: SimEcsTaskCommandContext;
   public readonly runTask: SimEcsRunTaskCommandContext;
+  public readonly service: SimEcsServiceCommandContext;
 
   constructor(properties: SimEcsCommandContextsProperties) {
     const { accountRegionScope, authorizer, background } = properties;
@@ -72,6 +78,20 @@ export class SimEcsCommandContexts {
       bindings: properties.bindings,
       runAsOwner: properties.runAsOwner,
       secretStores: properties.secretStores,
+    };
+    this.service = {
+      ...this.task,
+      accountRegionScope,
+      taskDefinitions: properties.taskDefinitions,
+      services: properties.services,
+      serviceArn: new SimEcsServiceArn(accountRegionScope),
+      serviceTasks: new SimEcsServiceTasks({
+        tasks: properties.tasks,
+        taskArn: this.task.taskArn,
+        bindings: properties.bindings,
+        secretStores: properties.secretStores,
+        background,
+      }),
     };
   }
 }

--- a/src/service/ecs/command/sim-ecs-command.types.ts
+++ b/src/service/ecs/command/sim-ecs-command.types.ts
@@ -67,3 +67,23 @@ export type {
   SimStopTaskCommandInput,
   SimStopTaskCommandOutput,
 } from "./stop-task/stop-task.command.js";
+export type {
+  SimCreateServiceCommand,
+  SimCreateServiceCommandInput,
+  SimCreateServiceCommandOutput,
+} from "./create-service/create-service.command.js";
+export type {
+  SimUpdateServiceCommand,
+  SimUpdateServiceCommandInput,
+  SimUpdateServiceCommandOutput,
+} from "./update-service/update-service.command.js";
+export type {
+  SimDescribeServicesCommand,
+  SimDescribeServicesCommandInput,
+  SimDescribeServicesCommandOutput,
+} from "./describe-services/describe-services.command.js";
+export type {
+  SimDeleteServiceCommand,
+  SimDeleteServiceCommandInput,
+  SimDeleteServiceCommandOutput,
+} from "./delete-service/delete-service.command.js";

--- a/src/service/ecs/command/sim-ecs-requested-service.ts
+++ b/src/service/ecs/command/sim-ecs-requested-service.ts
@@ -1,0 +1,84 @@
+import {
+  SimEcsClientException,
+  SimEcsServiceNotFoundException,
+} from "../error/sim-ecs.error.js";
+import type {
+  SimEcsNamedService,
+  SimEcsServiceArn,
+} from "../service/sim-ecs-service-arn.js";
+import type { SimEcsServiceStore } from "../service/sim-ecs-service-store.js";
+import type { SimEcsService } from "../service/sim-ecs-service.js";
+
+interface SimEcsRequestedServiceProperties {
+  readonly services: SimEcsServiceStore;
+  readonly serviceArn: SimEcsServiceArn;
+}
+
+/**
+ * The service an operation is about.
+ *
+ * `UpdateService` and `DeleteService` both take a service the request has to
+ * name, by name or by ARN, and both raise `ServiceNotFoundException` for one
+ * that is not there. `DescribeServices` reports a missing one as a failure
+ * entry instead, so it reads the store itself rather than through here.
+ */
+export class SimEcsRequestedService {
+  private readonly services: SimEcsServiceStore;
+  private readonly serviceArn: SimEcsServiceArn;
+
+  constructor(properties: SimEcsRequestedServiceProperties) {
+    this.services = properties.services;
+    this.serviceArn = properties.serviceArn;
+  }
+
+  /**
+   * The service the request named, which it has to name.
+   */
+  named(identifier: string | undefined, operation: string): SimEcsNamedService {
+    const named =
+      identifier === undefined || identifier === ""
+        ? undefined
+        : this.serviceArn.namedService(identifier);
+
+    if (named === undefined) {
+      throw new SimEcsClientException(
+        `${operation} needs the service, named by its name or its full ARN.`,
+      );
+    }
+
+    return named;
+  }
+
+  /**
+   * The ARN the request's service has in the cluster it named.
+   *
+   * The cluster comes from the request rather than from the identifier, so an
+   * ARN naming another cluster authorizes against the cluster it named and is
+   * then found in neither.
+   */
+  arn(named: SimEcsNamedService, clusterName: string): string {
+    return this.serviceArn.make(
+      named.clusterName ?? clusterName,
+      named.serviceName,
+    );
+  }
+
+  /**
+   * The active service the request named, in the cluster it named.
+   */
+  active(named: SimEcsNamedService, clusterName: string): SimEcsService {
+    const service =
+      named.clusterName === undefined || named.clusterName === clusterName
+        ? this.services.findActive(clusterName, named.serviceName)
+        : undefined;
+
+    if (service === undefined) {
+      throw new SimEcsServiceNotFoundException(
+        `The cluster ${clusterName} holds no active service ` +
+          `${named.serviceName}.`,
+      );
+    }
+
+    return service;
+  }
+}

--- a/src/service/ecs/command/update-service/update-service-request.ts
+++ b/src/service/ecs/command/update-service/update-service-request.ts
@@ -1,0 +1,48 @@
+import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
+import { SimEcsClientException } from "../../error/sim-ecs.error.js";
+import { simEcsDesiredCount } from "../../service/sim-ecs-desired-count.js";
+import { SimEcsTaskDefinitionId } from "../../task-definition/sim-ecs-task-definition-id.js";
+import type { SimUpdateServiceCommandInput } from "./update-service.command.js";
+
+/**
+ * What one `UpdateService` request asked to change.
+ *
+ * Both changes are optional on real ECS, and a request making neither is
+ * refused here rather than answered with the service unchanged: an update that
+ * changes nothing is a request that has lost what it meant to say.
+ */
+export class SimEcsUpdateServiceRequest {
+  public readonly taskDefinitionId: SimEcsTaskDefinitionId | undefined;
+  public readonly desiredCount: number | undefined;
+
+  constructor(
+    input: SimUpdateServiceCommandInput,
+    accountRegionScope: SimAwsAccountRegionScope,
+  ) {
+    this.taskDefinitionId =
+      input.taskDefinition === undefined
+        ? undefined
+        : SimEcsTaskDefinitionId.parse(
+            input.taskDefinition,
+            accountRegionScope,
+          );
+    this.desiredCount =
+      input.desiredCount === undefined
+        ? undefined
+        : simEcsDesiredCount(input.desiredCount);
+
+    this.refuseEmpty();
+  }
+
+  private refuseEmpty(): void {
+    if (
+      this.taskDefinitionId === undefined &&
+      this.desiredCount === undefined
+    ) {
+      throw new SimEcsClientException(
+        "UpdateService needs a desiredCount, a taskDefinition, or both. " +
+          "Nothing else about a service is simulated.",
+      );
+    }
+  }
+}

--- a/src/service/ecs/command/update-service/update-service.command.ts
+++ b/src/service/ecs/command/update-service/update-service.command.ts
@@ -1,0 +1,29 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type { SimEcsServiceDetail } from "../../service/sim-ecs-service-detail.js";
+
+/**
+ * Minimal structural sim ECS UpdateService command.
+ */
+export interface SimUpdateServiceCommand {
+  readonly input: SimUpdateServiceCommandInput;
+}
+
+/**
+ * Minimal structural sim ECS UpdateService input.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/ecs/command/UpdateServiceCommand/
+ */
+export interface SimUpdateServiceCommandInput {
+  readonly cluster?: string | undefined;
+  readonly service?: string | undefined;
+  readonly taskDefinition?: string | undefined;
+  readonly desiredCount?: number | undefined;
+}
+
+/**
+ * Minimal structural sim ECS UpdateService output.
+ */
+export interface SimUpdateServiceCommandOutput {
+  readonly service?: SimEcsServiceDetail | undefined;
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/ecs/command/update-service/update-service.handler.ts
+++ b/src/service/ecs/command/update-service/update-service.handler.ts
@@ -1,0 +1,85 @@
+import type { CommandHandler } from "../../../../command/command-handler.js";
+import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
+import type { SimEcsServiceCommandContext } from "../sim-ecs-command-context.js";
+import { SimEcsCommandHandler } from "../sim-ecs-command-handler.js";
+import type { SimEcsRequestOptions } from "../sim-ecs-request-options.js";
+import { SimEcsRequestedCluster } from "../sim-ecs-requested-cluster.js";
+import { SimEcsRequestedService } from "../sim-ecs-requested-service.js";
+import { SimEcsUpdateServiceRequest } from "./update-service-request.js";
+import { SimEcsUpdatedService } from "./updated-service.js";
+import type {
+  SimUpdateServiceCommand,
+  SimUpdateServiceCommandOutput,
+} from "./update-service.command.js";
+
+const acceptedInput: readonly string[] = [
+  "cluster",
+  "service",
+  "taskDefinition",
+  "desiredCount",
+];
+
+/**
+ * Simulated ECS UpdateServiceCommand handler.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/ecs/command/UpdateServiceCommand/
+ */
+export class UpdateServiceCommandHandler
+  extends SimEcsCommandHandler
+  implements
+    CommandHandler<SimUpdateServiceCommand, SimUpdateServiceCommandOutput>
+{
+  private readonly accountRegionScope: SimAwsAccountRegionScope;
+  private readonly requestedCluster: SimEcsRequestedCluster;
+  private readonly requestedService: SimEcsRequestedService;
+  private readonly updated: SimEcsUpdatedService;
+
+  constructor(context: SimEcsServiceCommandContext) {
+    super(context, "UpdateService", acceptedInput);
+    this.accountRegionScope = context.accountRegionScope;
+    this.requestedCluster = new SimEcsRequestedCluster(context);
+    this.requestedService = new SimEcsRequestedService(context);
+    this.updated = new SimEcsUpdatedService(context);
+  }
+
+  /**
+   * Change what a service is keeping running.
+   *
+   * A new desired count starts or stops tasks to reach it. A new task
+   * definition moves the service onto that revision, which replaces every task
+   * it is running: real ECS replaces them a few at a time under a deployment
+   * configuration, and nothing here takes any time to start.
+   */
+  async handle(
+    command: SimUpdateServiceCommand,
+    options?: SimEcsRequestOptions,
+  ): Promise<SimUpdateServiceCommandOutput> {
+    this.refuseUnaccepted(command.input);
+
+    const named = this.requestedService.named(
+      command.input.service,
+      "UpdateService",
+    );
+    const request = new SimEcsUpdateServiceRequest(
+      command.input,
+      this.accountRegionScope,
+    );
+
+    await this.sequence();
+
+    const clusterName = this.requestedCluster.name(command.input.cluster);
+
+    this.authorizer.authorizeService(
+      "ecs:UpdateService",
+      this.requestedService.arn(named, clusterName),
+      options,
+    );
+
+    const cluster = this.requestedCluster.active(command.input.cluster);
+    const service = this.requestedService.active(named, cluster.clusterName);
+
+    this.updated.apply(service, cluster, request);
+
+    return { $metadata: {}, service: service.toOutput() };
+  }
+}

--- a/src/service/ecs/command/update-service/update-service.iso.test.ts
+++ b/src/service/ecs/command/update-service/update-service.iso.test.ts
@@ -1,0 +1,236 @@
+import {
+  DescribeServicesCommand,
+  DescribeTasksCommand,
+  ListTasksCommand,
+  RegisterTaskDefinitionCommand,
+  UpdateServiceCommand,
+} from "@aws-sdk/client-ecs";
+import {
+  assertArrayLength,
+  assertFalse,
+  assertIdentical,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { simEcsClusterFactory } from "../../cluster/sim-ecs-cluster.factory.js";
+import {
+  SimEcsClientException,
+  SimEcsServiceNotFoundException,
+} from "../../error/sim-ecs.error.js";
+import { simEcsRegisteredTaskDefinitionFactory } from "../../task-definition/sim-ecs-registered-task-definition.factory.js";
+import { simEcsServiceFactory } from "../../service/sim-ecs-service.factory.js";
+
+describe("ECS UpdateServiceCommand", () => {
+  it("scales a service out to the count it was given", async () => {
+    // Given a service running one task.
+    const simAws = new SimAws();
+    const ecs = simAws.ecs();
+    await simEcsClusterFactory.make({}, simAws);
+    await simEcsRegisteredTaskDefinitionFactory.make({}, simAws);
+    await simEcsServiceFactory.make({}, simAws);
+    await simAws.backgroundTasksComplete();
+
+    // When it is scaled out to four.
+    const updated = await ecs.updateService(
+      new UpdateServiceCommand({ service: "checkout", desiredCount: 4 }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // Then it keeps four tasks running, the one it already had among them.
+    assertIdentical(updated.service?.desiredCount, 4);
+
+    const listed = await ecs.listTasks(
+      new ListTasksCommand({ serviceName: "checkout" }),
+    );
+
+    assertArrayLength(listed.taskArns, 4);
+
+    const described = await ecs.describeServices(
+      new DescribeServicesCommand({ services: ["checkout"] }),
+    );
+
+    assertIdentical(described.services?.[0]?.runningCount, 4);
+  });
+
+  it("scales a service in, stopping the tasks it no longer keeps", async () => {
+    // Given a service running three tasks.
+    const simAws = new SimAws();
+    const ecs = simAws.ecs();
+    await simEcsClusterFactory.make({}, simAws);
+    await simEcsRegisteredTaskDefinitionFactory.make({}, simAws);
+    await simEcsServiceFactory.make({ desiredCount: 3 }, simAws);
+    await simAws.backgroundTasksComplete();
+
+    const before = await ecs.listTasks(
+      new ListTasksCommand({ serviceName: "checkout" }),
+    );
+
+    // When it is scaled in to one.
+    await ecs.updateService(
+      new UpdateServiceCommand({ service: "checkout", desiredCount: 1 }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // Then one task is left running, and it is the first of the three.
+    const after = await ecs.listTasks(
+      new ListTasksCommand({ serviceName: "checkout" }),
+    );
+
+    assertArrayLength(after.taskArns, 1);
+    assertIdentical(after.taskArns[0], before.taskArns?.[0]);
+
+    // And the two that were stopped say why.
+    const stopped = await ecs.describeTasks(
+      new DescribeTasksCommand({ tasks: [before.taskArns?.[2] ?? ""] }),
+    );
+
+    assertIdentical(stopped.tasks?.[0]?.lastStatus, "STOPPED");
+    assertIdentical(stopped.tasks[0].stopCode, "UserInitiated");
+    assertStringIncludes(stopped.tasks[0].stoppedReason ?? "", "scaling in");
+  });
+
+  it("moves a service onto another task definition revision", async () => {
+    // Given a service running the first revision of its family.
+    const simAws = new SimAws();
+    const ecs = simAws.ecs();
+    await simEcsClusterFactory.make({}, simAws);
+    await simEcsRegisteredTaskDefinitionFactory.make({}, simAws);
+    await simEcsServiceFactory.make({ desiredCount: 2 }, simAws);
+    await simAws.backgroundTasksComplete();
+
+    const before = await ecs.listTasks(
+      new ListTasksCommand({ serviceName: "checkout" }),
+    );
+    const second = await ecs.registerTaskDefinition(
+      new RegisterTaskDefinitionCommand({
+        family: "checkout",
+        containerDefinitions: [{ name: "app", image: "checkout:2" }],
+      }),
+    );
+
+    // When it is updated onto the second revision.
+    const updated = await ecs.updateService(
+      new UpdateServiceCommand({
+        service: "checkout",
+        taskDefinition: "checkout:2",
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // Then the service is on the new revision, and its tasks are new ones from
+    // it rather than the ones it was running.
+    assertIdentical(
+      updated.service?.taskDefinition,
+      second.taskDefinition?.taskDefinitionArn,
+    );
+
+    const after = await ecs.listTasks(
+      new ListTasksCommand({ serviceName: "checkout" }),
+    );
+
+    assertArrayLength(after.taskArns, 2);
+    assertFalse(
+      after.taskArns.some((arn) => before.taskArns?.includes(arn) === true),
+    );
+
+    const described = await ecs.describeTasks(
+      new DescribeTasksCommand({ tasks: [after.taskArns[0]] }),
+    );
+
+    assertIdentical(
+      described.tasks?.[0]?.taskDefinitionArn,
+      second.taskDefinition?.taskDefinitionArn,
+    );
+  });
+
+  it("leaves the tasks alone when the revision is the one it is on", async () => {
+    // Given a service running two tasks.
+    const simAws = new SimAws();
+    const ecs = simAws.ecs();
+    await simEcsClusterFactory.make({}, simAws);
+    await simEcsRegisteredTaskDefinitionFactory.make({}, simAws);
+    await simEcsServiceFactory.make({ desiredCount: 2 }, simAws);
+    await simAws.backgroundTasksComplete();
+
+    const before = await ecs.listTasks(
+      new ListTasksCommand({ serviceName: "checkout" }),
+    );
+
+    // When it is updated onto the revision it is already running.
+    await ecs.updateService(
+      new UpdateServiceCommand({
+        service: "checkout",
+        taskDefinition: "checkout:1",
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // Then nothing is replaced, since there is no rolling deployment here for
+    // it to be worth starting again.
+    const after = await ecs.listTasks(
+      new ListTasksCommand({ serviceName: "checkout" }),
+    );
+
+    assertIdentical(after.taskArns?.join(","), before.taskArns?.join(","));
+  });
+
+  it("refuses an update that changes nothing", async () => {
+    // Given a service.
+    const simAws = new SimAws();
+    await simEcsClusterFactory.make({}, simAws);
+    await simEcsRegisteredTaskDefinitionFactory.make({}, simAws);
+    await simEcsServiceFactory.make({}, simAws);
+
+    // When it is updated with neither a count nor a task definition.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws
+        .ecs()
+        .updateService(new UpdateServiceCommand({ service: "checkout" })),
+    );
+
+    // Then it is refused rather than answered with the service unchanged.
+    assertInstanceOf(error, SimEcsClientException);
+    assertStringIncludes(error.message, "desiredCount");
+  });
+
+  it("refuses a service the cluster does not hold", async () => {
+    // Given a cluster with no service in it.
+    const simAws = new SimAws();
+    await simEcsClusterFactory.make({}, simAws);
+
+    // When a service of it is updated.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws
+        .ecs()
+        .updateService(
+          new UpdateServiceCommand({ service: "checkout", desiredCount: 2 }),
+        ),
+    );
+
+    // Then it is ECS's own service not found error.
+    assertInstanceOf(error, SimEcsServiceNotFoundException);
+    assertIdentical(error.name, "ServiceNotFoundException");
+  });
+
+  it("refuses a request naming no service", async () => {
+    // Given a cluster.
+    const simAws = new SimAws();
+    await simEcsClusterFactory.make({}, simAws);
+
+    // When a service is updated without naming one.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws
+        .ecs()
+        .updateService(
+          new UpdateServiceCommand({ service: "", desiredCount: 2 }),
+        ),
+    );
+
+    // Then it is refused, since there is nothing for the update to be about.
+    assertInstanceOf(error, SimEcsClientException);
+    assertStringIncludes(error.message, "UpdateService needs the service");
+  });
+});

--- a/src/service/ecs/command/update-service/update-service.iso.test.ts
+++ b/src/service/ecs/command/update-service/update-service.iso.test.ts
@@ -82,7 +82,7 @@ describe("ECS UpdateServiceCommand", () => {
     assertArrayLength(after.taskArns, 1);
     assertIdentical(after.taskArns[0], before.taskArns?.[0]);
 
-    // And the two that were stopped say why.
+    // And the last of the two that were stopped says why.
     const stopped = await ecs.describeTasks(
       new DescribeTasksCommand({ tasks: [before.taskArns?.[2] ?? ""] }),
     );

--- a/src/service/ecs/command/update-service/updated-service.ts
+++ b/src/service/ecs/command/update-service/updated-service.ts
@@ -1,0 +1,80 @@
+import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
+import type { SimEcsCluster } from "../../cluster/sim-ecs-cluster.js";
+import type { SimEcsServiceTasks } from "../../service/run/sim-ecs-service-tasks.js";
+import type { SimEcsService } from "../../service/sim-ecs-service.js";
+import { requiredRunnableTaskDefinition } from "../../task-definition/sim-ecs-runnable-task-definition.js";
+import { SimEcsTaskDefinitionId } from "../../task-definition/sim-ecs-task-definition-id.js";
+import type { SimEcsTaskDefinitionStore } from "../../task-definition/sim-ecs-task-definition-store.js";
+import type { SimEcsTaskDefinition } from "../../task-definition/sim-ecs-task-definition.js";
+import type { SimEcsServiceCommandContext } from "../sim-ecs-command-context.js";
+import type { SimEcsUpdateServiceRequest } from "./update-service-request.js";
+
+/**
+ * Applies what an `UpdateService` request asked for to a service.
+ *
+ * The two changes are not independent. A new desired count is reached by
+ * starting or stopping tasks, while a new revision replaces every task the
+ * service holds, so the count has to be settled before the tasks are brought to
+ * it.
+ */
+export class SimEcsUpdatedService {
+  private readonly accountRegionScope: SimAwsAccountRegionScope;
+  private readonly taskDefinitions: SimEcsTaskDefinitionStore;
+  private readonly serviceTasks: SimEcsServiceTasks;
+
+  constructor(context: SimEcsServiceCommandContext) {
+    this.accountRegionScope = context.accountRegionScope;
+    this.taskDefinitions = context.taskDefinitions;
+    this.serviceTasks = context.serviceTasks;
+  }
+
+  /**
+   * Apply an update to a service, and bring its tasks to what it now wants.
+   */
+  apply(
+    service: SimEcsService,
+    cluster: SimEcsCluster,
+    request: SimEcsUpdateServiceRequest,
+  ): void {
+    const taskDefinition = this.revisionFor(service, request);
+    const deployment = { service, cluster, taskDefinition };
+
+    if (request.desiredCount !== undefined) {
+      service.scaleTo(request.desiredCount);
+    }
+
+    if (taskDefinition.taskDefinitionArn === service.taskDefinitionArn) {
+      this.serviceTasks.reconcile(deployment);
+      return;
+    }
+
+    service.moveTo(taskDefinition.taskDefinitionArn);
+    this.serviceTasks.redeploy(deployment);
+  }
+
+  /**
+   * The revision the service runs once this update has been applied.
+   *
+   * A request naming none leaves the service where it is, which is read back
+   * from the ARN it holds rather than resolved again from the family: the
+   * latest active revision may have moved on since, and scaling a service out
+   * is not a deployment.
+   */
+  private revisionFor(
+    service: SimEcsService,
+    request: SimEcsUpdateServiceRequest,
+  ): SimEcsTaskDefinition {
+    if (request.taskDefinitionId === undefined) {
+      return this.taskDefinitions.resolve(
+        SimEcsTaskDefinitionId.parse(
+          service.taskDefinitionArn,
+          this.accountRegionScope,
+        ),
+      );
+    }
+
+    return requiredRunnableTaskDefinition(
+      this.taskDefinitions.resolve(request.taskDefinitionId),
+    );
+  }
+}

--- a/src/service/ecs/error/sim-ecs.error.ts
+++ b/src/service/ecs/error/sim-ecs.error.ts
@@ -54,6 +54,17 @@ export class SimEcsClusterNotFoundException extends SimEcsError {
 }
 
 /**
+ * Simulated ECS ServiceNotFoundException error.
+ */
+export class SimEcsServiceNotFoundException extends SimEcsError {
+  public override readonly name = "ServiceNotFoundException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
  * Simulated ECS AccessDeniedException error.
  */
 export class SimEcsAccessDeniedException extends SimEcsError {

--- a/src/service/ecs/index.ts
+++ b/src/service/ecs/index.ts
@@ -85,6 +85,22 @@ export {
   type SimEcsTaskListing,
 } from "./task/sim-ecs-task-store.js";
 export {
+  simEcsReplicaSchedulingStrategy,
+  SimEcsService,
+} from "./service/sim-ecs-service.js";
+export type {
+  SimEcsServiceDetail,
+  SimEcsServiceStatus,
+} from "./service/sim-ecs-service-detail.js";
+export { SimEcsServiceTaskSet } from "./service/sim-ecs-service-task-set.js";
+export {
+  SimEcsServiceArn,
+  type SimEcsNamedService,
+} from "./service/sim-ecs-service-arn.js";
+export { SimEcsServiceStore } from "./service/sim-ecs-service-store.js";
+export { SimEcsServiceTasks } from "./service/run/sim-ecs-service-tasks.js";
+export type { SimEcsServiceDeployment } from "./service/run/sim-ecs-service-deployment.js";
+export {
   SimEcsTaskOverrides,
   type SimEcsContainerOverrideType,
   type SimEcsTaskOverrideType,
@@ -104,4 +120,5 @@ export {
   SimEcsClusterNotFoundException,
   SimEcsError,
   SimEcsInvalidParameterException,
+  SimEcsServiceNotFoundException,
 } from "./error/sim-ecs.error.js";

--- a/src/service/ecs/sdk/sim-ecs-sdk-command-router.ts
+++ b/src/service/ecs/sdk/sim-ecs-sdk-command-router.ts
@@ -118,6 +118,38 @@ export class SimEcsSdkCommandRouter implements SimSdkCommandRouter {
             simSdkCallerOptions(context),
           ),
       ],
+      [
+        "CreateServiceCommand",
+        async (command, context): Promise<unknown> =>
+          await simEcs.createService(
+            command as simEcsCommands.SimCreateServiceCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "UpdateServiceCommand",
+        async (command, context): Promise<unknown> =>
+          await simEcs.updateService(
+            command as simEcsCommands.SimUpdateServiceCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "DescribeServicesCommand",
+        async (command, context): Promise<unknown> =>
+          await simEcs.describeServices(
+            command as simEcsCommands.SimDescribeServicesCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "DeleteServiceCommand",
+        async (command, context): Promise<unknown> =>
+          await simEcs.deleteService(
+            command as simEcsCommands.SimDeleteServiceCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
     ]);
   }
 

--- a/src/service/ecs/sdk/sim-ecs-sdk-routing.iso.test.ts
+++ b/src/service/ecs/sdk/sim-ecs-sdk-routing.iso.test.ts
@@ -1,8 +1,11 @@
 import {
   CreateClusterCommand,
+  CreateServiceCommand,
   DeleteClusterCommand,
+  DeleteServiceCommand,
   DeregisterTaskDefinitionCommand,
   DescribeClustersCommand,
+  DescribeServicesCommand,
   DescribeTaskDefinitionCommand,
   DescribeTasksCommand,
   ECSClient,
@@ -13,6 +16,7 @@ import {
   RegisterTaskDefinitionCommand,
   RunTaskCommand,
   StopTaskCommand,
+  UpdateServiceCommand,
 } from "@aws-sdk/client-ecs";
 import {
   assertArrayIncludesAll,
@@ -142,6 +146,59 @@ describe("ECS SDK interception", () => {
     await simSdk.simAws.backgroundTasksComplete();
   });
 
+  it("routes the service operations to simulated ECS", async () => {
+    // Given an intercepted ECS SDK client with a cluster and a definition.
+    using simSdk = new SimSdk();
+    simSdk.intercept(ECSClient);
+
+    const ecs = new ECSClient({ region: "eu-west-2" });
+    await ecs.send(new CreateClusterCommand({ clusterName: "services" }));
+    await ecs.send(
+      new RegisterTaskDefinitionCommand({
+        family: "checkout",
+        containerDefinitions: [{ name: "app", image: "checkout:1" }],
+      }),
+    );
+
+    // When ordinary SDK code creates a service, scales it and deletes it.
+    const created = await ecs.send(
+      new CreateServiceCommand({
+        cluster: "services",
+        serviceName: "checkout",
+        taskDefinition: "checkout",
+        desiredCount: 1,
+      }),
+    );
+    const updated = await ecs.send(
+      new UpdateServiceCommand({
+        cluster: "services",
+        service: "checkout",
+        desiredCount: 2,
+      }),
+    );
+    await simSdk.simAws.backgroundTasksComplete();
+
+    const described = await ecs.send(
+      new DescribeServicesCommand({
+        cluster: "services",
+        services: ["checkout"],
+      }),
+    );
+    const deleted = await ecs.send(
+      new DeleteServiceCommand({
+        cluster: "services",
+        service: "checkout",
+        force: true,
+      }),
+    );
+
+    // Then each one is answered by the simulation.
+    assertIdentical(created.service?.desiredCount, 1);
+    assertIdentical(updated.service?.desiredCount, 2);
+    assertIdentical(described.services?.[0]?.runningCount, 2);
+    assertIdentical(deleted.service?.status, "INACTIVE");
+  });
+
   it("supports every ECS operation this service simulates", () => {
     // Given simulated ECS.
     const simEcs = new SimEcs();
@@ -164,6 +221,10 @@ describe("ECS SDK interception", () => {
       DescribeTasksCommand.name,
       ListTasksCommand.name,
       StopTaskCommand.name,
+      CreateServiceCommand.name,
+      UpdateServiceCommand.name,
+      DescribeServicesCommand.name,
+      DeleteServiceCommand.name,
     ]);
   });
 
@@ -172,7 +233,7 @@ describe("ECS SDK interception", () => {
     const simEcs = new SimEcs();
 
     // When a command it does not handle is looked up.
-    const route = simEcs.sdkCommandRouter().route("CreateServiceCommand");
+    const route = simEcs.sdkCommandRouter().route("ListServicesCommand");
 
     // Then there is no route for it, so interception reports it as
     // unsupported rather than answering with nothing.

--- a/src/service/ecs/service/run/sim-ecs-service-containers.ts
+++ b/src/service/ecs/service/run/sim-ecs-service-containers.ts
@@ -1,0 +1,81 @@
+import type { BackgroundScheduler } from "../../../../util/background/background.js";
+import type { SimEcsContainerBindings } from "../../bind/sim-ecs-container-bindings.js";
+import { simEcsNotSimulatedContainerReason } from "../../task/run/sim-ecs-container-runner.js";
+import type { SimEcsSecretStores } from "../../task/run/secret/sim-ecs-secret-stores.js";
+import { SimEcsTaskSecrets } from "../../task/run/secret/sim-ecs-task-secrets.js";
+import type { SimEcsTask } from "../../task/sim-ecs-task.js";
+import type { SimEcsTaskDefinition } from "../../task-definition/sim-ecs-task-definition.js";
+
+interface SimEcsServiceContainersProperties {
+  readonly bindings: SimEcsContainerBindings;
+  readonly secretStores: SimEcsSecretStores;
+  readonly background: BackgroundScheduler;
+}
+
+/**
+ * Brings the containers of one task of a service up.
+ *
+ * No handler is called here, which is the difference between a service
+ * container and one of a task started by `RunTask`. A service container is
+ * treated as running from this point, and what calls its handler is whatever
+ * reaches it: a request served to it, or a poll it makes. A container with no
+ * binding is recorded as not simulated instead, exactly as one of a run task is.
+ *
+ * A task's secrets are still resolved before it starts, as a real task agent
+ * pulls them while the task is provisioning. Nothing reads the values until a
+ * handler is called, but a secret that cannot be read stops the task here as it
+ * stops a run task, so a service naming one that is not there says so rather
+ * than reporting a task running against it.
+ */
+export class SimEcsServiceContainers {
+  private readonly bindings: SimEcsContainerBindings;
+  private readonly background: BackgroundScheduler;
+  private readonly secrets: SimEcsTaskSecrets;
+
+  constructor(properties: SimEcsServiceContainersProperties) {
+    this.bindings = properties.bindings;
+    this.background = properties.background;
+    this.secrets = new SimEcsTaskSecrets({ stores: properties.secretStores });
+  }
+
+  /**
+   * Mark a task, and the containers something is bound to, as running.
+   *
+   * A task asked to stop before this reached it stays stopped, so a service
+   * deleted between the request and the background work brings nothing up.
+   */
+  async start(
+    task: SimEcsTask,
+    taskDefinition: SimEcsTaskDefinition,
+  ): Promise<void> {
+    if (task.isStopRequested) {
+      return;
+    }
+
+    const secrets = await this.secrets.resolve(taskDefinition);
+
+    if (!secrets.isResolved) {
+      task.failToStart(this.background.now(), secrets.failureReason);
+      return;
+    }
+
+    task.start(this.background.now());
+    this.markContainers(task, taskDefinition);
+  }
+
+  private markContainers(
+    task: SimEcsTask,
+    taskDefinition: SimEcsTaskDefinition,
+  ): void {
+    for (const declared of taskDefinition.containers.all()) {
+      const container = task.container(declared.name);
+
+      if (this.bindings.find(task.family, declared) === undefined) {
+        container.neverStarted(simEcsNotSimulatedContainerReason);
+        continue;
+      }
+
+      container.start();
+    }
+  }
+}

--- a/src/service/ecs/service/run/sim-ecs-service-deployment.ts
+++ b/src/service/ecs/service/run/sim-ecs-service-deployment.ts
@@ -1,0 +1,16 @@
+import type { SimEcsCluster } from "../../cluster/sim-ecs-cluster.js";
+import type { SimEcsTaskDefinition } from "../../task-definition/sim-ecs-task-definition.js";
+import type { SimEcsService } from "../sim-ecs-service.js";
+
+/**
+ * What a service is keeping running, and the revision it is running.
+ *
+ * The revision travels with the service rather than being read back from it,
+ * because an update carries the one the service is moving to while the service
+ * is still on the one it had.
+ */
+export interface SimEcsServiceDeployment {
+  readonly service: SimEcsService;
+  readonly cluster: SimEcsCluster;
+  readonly taskDefinition: SimEcsTaskDefinition;
+}

--- a/src/service/ecs/service/run/sim-ecs-service-task-starter.ts
+++ b/src/service/ecs/service/run/sim-ecs-service-task-starter.ts
@@ -1,0 +1,70 @@
+import type { BackgroundScheduler } from "../../../../util/background/background.js";
+import type { SimEcsContainerBindings } from "../../bind/sim-ecs-container-bindings.js";
+import type { SimEcsSecretStores } from "../../task/run/secret/sim-ecs-secret-stores.js";
+import type { SimEcsTaskArn } from "../../task/sim-ecs-task-arn.js";
+import { SimEcsTaskFactory } from "../../task/sim-ecs-task-factory.js";
+import type { SimEcsTaskStore } from "../../task/sim-ecs-task-store.js";
+import { SimEcsServiceContainers } from "./sim-ecs-service-containers.js";
+import type { SimEcsServiceDeployment } from "./sim-ecs-service-deployment.js";
+
+interface SimEcsServiceTaskStarterProperties {
+  readonly tasks: SimEcsTaskStore;
+  readonly taskArn: SimEcsTaskArn;
+  readonly bindings: SimEcsContainerBindings;
+  readonly secretStores: SimEcsSecretStores;
+  readonly background: BackgroundScheduler;
+}
+
+/**
+ * Starts the tasks a simulated ECS service keeps running.
+ *
+ * A task exists as soon as the request that asked for it is answered, so it is
+ * listed straight away, and reaches `RUNNING` on the simulator's background
+ * work. That is what real ECS does with a service that has just been created or
+ * scaled out, and it is what makes a service deleted in between bring nothing
+ * up.
+ *
+ * A service's tasks carry the group and the `startedBy` real ECS gives one, so
+ * a listing can be narrowed to the service that is keeping them.
+ */
+export class SimEcsServiceTaskStarter {
+  private readonly tasks: SimEcsTaskStore;
+  private readonly background: BackgroundScheduler;
+  private readonly taskFactory: SimEcsTaskFactory;
+  private readonly containers: SimEcsServiceContainers;
+
+  constructor(properties: SimEcsServiceTaskStarterProperties) {
+    this.tasks = properties.tasks;
+    this.background = properties.background;
+    this.taskFactory = new SimEcsTaskFactory(properties.taskArn);
+    this.containers = new SimEcsServiceContainers(properties);
+  }
+
+  /**
+   * Start a number of tasks for a service, and hand them to it.
+   */
+  start(deployment: SimEcsServiceDeployment, count: number): void {
+    for (let started = 0; started < count; started += 1) {
+      this.startOne(deployment);
+    }
+  }
+
+  private startOne(deployment: SimEcsServiceDeployment): void {
+    const { service, cluster, taskDefinition } = deployment;
+    const task = this.taskFactory.make({
+      cluster,
+      taskDefinition,
+      createdAt: this.background.now(),
+      group: `service:${service.serviceName}`,
+      startedBy: `ecs-svc/${service.serviceName}`,
+      serviceName: service.serviceName,
+      launchType: service.launchType,
+    });
+
+    this.tasks.put(task);
+    service.tasks.add(task);
+    this.background.schedule(async () => {
+      await this.containers.start(task, taskDefinition);
+    });
+  }
+}

--- a/src/service/ecs/service/run/sim-ecs-service-tasks.ts
+++ b/src/service/ecs/service/run/sim-ecs-service-tasks.ts
@@ -1,0 +1,96 @@
+import type { BackgroundScheduler } from "../../../../util/background/background.js";
+import type { SimEcsContainerBindings } from "../../bind/sim-ecs-container-bindings.js";
+import type { SimEcsSecretStores } from "../../task/run/secret/sim-ecs-secret-stores.js";
+import type { SimEcsTaskArn } from "../../task/sim-ecs-task-arn.js";
+import type { SimEcsTaskStore } from "../../task/sim-ecs-task-store.js";
+import type { SimEcsTask } from "../../task/sim-ecs-task.js";
+import type { SimEcsService } from "../sim-ecs-service.js";
+import type { SimEcsServiceDeployment } from "./sim-ecs-service-deployment.js";
+import { SimEcsServiceTaskStarter } from "./sim-ecs-service-task-starter.js";
+
+interface SimEcsServiceTasksProperties {
+  readonly tasks: SimEcsTaskStore;
+  readonly taskArn: SimEcsTaskArn;
+  readonly bindings: SimEcsContainerBindings;
+  readonly secretStores: SimEcsSecretStores;
+  readonly background: BackgroundScheduler;
+}
+
+/**
+ * Why a task of a service stopped, in each of the ways one does.
+ */
+const stoppedReasons = {
+  scaledIn: "Task stopped by the service scaling in.",
+  redeployed: "Task stopped by the service moving to another task definition.",
+} as const;
+
+/**
+ * Keeps a simulated ECS service's tasks at the count it wants.
+ *
+ * This is where the modelling decision that runs through simulated services
+ * lives. A desired count of three cannot mean three copies of one in-process
+ * handler, because Yulin runs in a single Node.js process and there are no
+ * containers to copy, so the count is kept as state: three tasks exist, are
+ * reported as running, and hold a record of every container their definition
+ * declares. The handler bound to a container is called once per request or per
+ * poll rather than once per task.
+ *
+ * Starting a task takes until the simulator's background work reaches it, as it
+ * does on real ECS. Stopping one is immediate, because there is nothing here to
+ * drain.
+ */
+export class SimEcsServiceTasks {
+  private readonly background: BackgroundScheduler;
+  private readonly starter: SimEcsServiceTaskStarter;
+
+  constructor(properties: SimEcsServiceTasksProperties) {
+    this.background = properties.background;
+    this.starter = new SimEcsServiceTaskStarter(properties);
+  }
+
+  /**
+   * Bring a service's tasks to the count it wants, starting or stopping them.
+   */
+  reconcile(deployment: SimEcsServiceDeployment): void {
+    const { service } = deployment;
+    const shortfall = service.desiredCount - service.tasks.count;
+
+    if (shortfall > 0) {
+      this.starter.start(deployment, shortfall);
+      return;
+    }
+
+    this.stopEach(
+      service.tasks.takeNewest(-shortfall),
+      stoppedReasons.scaledIn,
+    );
+  }
+
+  /**
+   * Replace every task with one started from the revision the service is on.
+   *
+   * Real ECS replaces them a few at a time under a deployment configuration,
+   * bringing new ones up before old ones go down. Nothing is served here yet
+   * and nothing takes any time to start, so the replacement happens at once.
+   */
+  redeploy(deployment: SimEcsServiceDeployment): void {
+    this.stopAll(deployment.service, stoppedReasons.redeployed);
+    this.reconcile(deployment);
+  }
+
+  /**
+   * Stop every task a service is running, and give up holding them.
+   */
+  stopAll(service: SimEcsService, reason: string): void {
+    this.stopEach(service.tasks.takeAll(), reason);
+  }
+
+  private stopEach(tasks: readonly SimEcsTask[], reason: string): void {
+    const at = this.background.now();
+
+    for (const task of tasks) {
+      task.requestStop(reason);
+      task.stop({ at, stopCode: "UserInitiated", reason });
+    }
+  }
+}

--- a/src/service/ecs/service/sim-ecs-desired-count.ts
+++ b/src/service/ecs/service/sim-ecs-desired-count.ts
@@ -1,0 +1,27 @@
+import { SimEcsInvalidParameterException } from "../error/sim-ecs.error.js";
+
+/**
+ * How many tasks one service may be kept at, as real ECS limits it.
+ *
+ * Every one of them is a simulated task object in this process, so a test
+ * asking for the whole quota gets what it asked for and pays for it in memory.
+ */
+const maxDesiredCount = 5000;
+
+/**
+ * Take the number of tasks a service is to be kept at.
+ *
+ * Zero is allowed and means a service that exists and runs nothing, which is
+ * what scaling a service to nothing leaves and what `DeleteService` wants
+ * before it will delete one.
+ */
+export function simEcsDesiredCount(count: number): number {
+  if (!Number.isSafeInteger(count) || count < 0 || count > maxDesiredCount) {
+    throw new SimEcsInvalidParameterException(
+      `desiredCount must be a whole number from 0 to ` +
+        `${String(maxDesiredCount)}.`,
+    );
+  }
+
+  return count;
+}

--- a/src/service/ecs/service/sim-ecs-service-arn.ts
+++ b/src/service/ecs/service/sim-ecs-service-arn.ts
@@ -1,0 +1,87 @@
+import type { SimArn } from "../../aws/arn.js";
+import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+import { parseSimEcsArn } from "../sim-ecs-arn.js";
+
+/**
+ * What a request named when it named a service.
+ *
+ * A service ARN carries the cluster the service runs in, so an ARN says which
+ * cluster it belongs to while a bare name says nothing about one.
+ */
+export interface SimEcsNamedService {
+  readonly serviceName: string;
+  readonly clusterName: string | undefined;
+}
+
+/**
+ * Builds and reads simulated ECS service ARNs for one Account and Region.
+ *
+ * A service is named either by its name or by its full ARN, as it is on real
+ * ECS, and the two are interchangeable wherever a request names one. An ARN
+ * belonging to another Account or Region names no service here, because it
+ * names a service somewhere else on real AWS.
+ */
+export class SimEcsServiceArn {
+  private readonly accountRegionScope: SimAwsAccountRegionScope;
+
+  constructor(accountRegionScope: SimAwsAccountRegionScope) {
+    this.accountRegionScope = accountRegionScope;
+  }
+
+  /**
+   * Read the `cluster/name` an ECS service ARN carries.
+   *
+   * The older ARN format left the cluster out, so a resource part with no
+   * separator is the service name on its own.
+   */
+  private static splitResourceId(resourceId: string): SimEcsNamedService {
+    const separatorIndex = resourceId.indexOf("/");
+
+    if (separatorIndex === -1) {
+      return { serviceName: resourceId, clusterName: undefined };
+    }
+
+    return {
+      clusterName: resourceId.slice(0, separatorIndex),
+      serviceName: resourceId.slice(separatorIndex + 1),
+    };
+  }
+
+  /**
+   * The ARN a service of this name has in a cluster in this Account and Region.
+   */
+  make(clusterName: string, serviceName: string): SimArn {
+    const { regionName, accountId } = this.accountRegionScope;
+    const resource = `${clusterName}/${serviceName}`;
+
+    return `arn:aws:ecs:${regionName}:${accountId}:service/${resource}`;
+  }
+
+  /**
+   * Read the service an identifier names, whether it is a name or a full ARN.
+   *
+   * Undefined covers every way an identifier names no service in this scope: it
+   * is not an ARN of the right shape, it is an ARN of something else, or it is
+   * an ECS service ARN belonging to another Account or Region. Callers report
+   * that in their own terms, since `DescribeServices` reports a service it
+   * cannot find as a failure while `UpdateService` raises.
+   */
+  namedService(identifier: string): SimEcsNamedService | undefined {
+    if (!identifier.startsWith("arn:")) {
+      return { serviceName: identifier, clusterName: undefined };
+    }
+
+    const arn = parseSimEcsArn(identifier);
+    const { regionName, accountId } = this.accountRegionScope;
+
+    if (
+      arn?.resourceType !== "service" ||
+      arn.region !== regionName ||
+      arn.accountId !== accountId
+    ) {
+      return undefined;
+    }
+
+    return SimEcsServiceArn.splitResourceId(arn.resourceId);
+  }
+}

--- a/src/service/ecs/service/sim-ecs-service-detail.ts
+++ b/src/service/ecs/service/sim-ecs-service-detail.ts
@@ -1,0 +1,32 @@
+import type { SimArn } from "../../aws/arn.js";
+
+/**
+ * The states a simulated ECS service can be in.
+ *
+ * Real ECS also has `DRAINING`, which a service passes through while its tasks
+ * are being replaced. Nothing here takes any time to drain, so a service is
+ * either the one requests reach or the one that has been deleted.
+ */
+export type SimEcsServiceStatus = "ACTIVE" | "INACTIVE";
+
+/**
+ * Minimal structural sim ECS described service.
+ *
+ * https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_Service.html
+ */
+export interface SimEcsServiceDetail {
+  readonly serviceArn?: SimArn | undefined;
+  readonly serviceName?: string | undefined;
+  readonly clusterArn?: SimArn | undefined;
+  readonly status?: SimEcsServiceStatus | undefined;
+  readonly desiredCount?: number | undefined;
+  readonly runningCount?: number | undefined;
+  readonly pendingCount?: number | undefined;
+  readonly taskDefinition?: SimArn | undefined;
+  readonly launchType?: string | undefined;
+  readonly schedulingStrategy?: string | undefined;
+  readonly loadBalancers?: readonly object[] | undefined;
+  readonly serviceRegistries?: readonly object[] | undefined;
+  readonly createdAt?: Date | undefined;
+  readonly createdBy?: string | undefined;
+}

--- a/src/service/ecs/service/sim-ecs-service-identity.ts
+++ b/src/service/ecs/service/sim-ecs-service-identity.ts
@@ -1,0 +1,73 @@
+import type { SimArn } from "../../aws/arn.js";
+import type { SimEcsServiceDetail } from "./sim-ecs-service-detail.js";
+
+/**
+ * What a service is, as opposed to what it is being kept at.
+ */
+export interface SimEcsServiceIdentityProperties {
+  readonly serviceArn: SimArn;
+  readonly serviceName: string;
+  readonly clusterArn: SimArn;
+  readonly clusterName: string;
+  readonly createdAt: Date;
+  readonly launchType?: string | undefined;
+  readonly createdBy?: string | undefined;
+}
+
+/**
+ * The part of a described service that never changes.
+ */
+type SimEcsServiceIdentityDetail = Omit<
+  SimEcsServiceDetail,
+  "status" | "desiredCount" | "runningCount" | "pendingCount" | "taskDefinition"
+>;
+
+/**
+ * What one simulated ECS service is.
+ *
+ * A service is named by the cluster it was created in, and neither that nor
+ * who created it nor when ever changes. Keeping it apart from what the service
+ * is being kept at is what leaves the service itself with only the second.
+ */
+export class SimEcsServiceIdentity {
+  public readonly serviceArn: SimArn;
+  public readonly serviceName: string;
+  public readonly clusterArn: SimArn;
+  public readonly clusterName: string;
+  public readonly launchType: string | undefined;
+
+  private readonly declared: SimEcsServiceIdentityProperties;
+
+  constructor(declared: SimEcsServiceIdentityProperties) {
+    this.declared = declared;
+    this.serviceArn = declared.serviceArn;
+    this.serviceName = declared.serviceName;
+    this.clusterArn = declared.clusterArn;
+    this.clusterName = declared.clusterName;
+    this.launchType = declared.launchType;
+  }
+
+  /**
+   * This part of the service as `DescribeServices` reports it.
+   *
+   * The load balancers and service registries are honestly empty rather than
+   * left out: a service registers with neither here, and reporting nothing at
+   * all would read as a service that had not been asked about them.
+   */
+  toOutput(): SimEcsServiceIdentityDetail {
+    const { serviceArn, serviceName, clusterArn, createdAt } = this.declared;
+
+    return {
+      serviceArn,
+      serviceName,
+      clusterArn,
+      createdAt,
+      loadBalancers: [],
+      serviceRegistries: [],
+      ...(this.launchType !== undefined && { launchType: this.launchType }),
+      ...(this.declared.createdBy !== undefined && {
+        createdBy: this.declared.createdBy,
+      }),
+    };
+  }
+}

--- a/src/service/ecs/service/sim-ecs-service-lifecycle.iso.test.ts
+++ b/src/service/ecs/service/sim-ecs-service-lifecycle.iso.test.ts
@@ -1,0 +1,122 @@
+import {
+  DeleteServiceCommand,
+  DescribeTasksCommand,
+  ListTasksCommand,
+} from "@aws-sdk/client-ecs";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertStringIncludes,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { BackgroundTasks } from "../../../util/background/background.js";
+import { SimAws } from "../../aws/sim-aws.js";
+import { simEcsClusterFactory } from "../cluster/sim-ecs-cluster.factory.js";
+import { simEcsRegisteredTaskDefinitionFactory } from "../task-definition/sim-ecs-registered-task-definition.factory.js";
+import { simEcsServiceFactory } from "./sim-ecs-service.factory.js";
+
+describe("What a simulated ECS service leaves running", () => {
+  it("leaves nothing scheduled once its tasks are up", async () => {
+    // Given a simulated environment whose background work can be counted.
+    const background = new BackgroundTasks();
+    const simAws = new SimAws({ background });
+    await simEcsClusterFactory.make({}, simAws);
+    await simEcsRegisteredTaskDefinitionFactory.make({}, simAws);
+
+    // When a service is created and its tasks come up.
+    await simEcsServiceFactory.make({ desiredCount: 3 }, simAws);
+    await simAws.backgroundTasksComplete();
+
+    // Then nothing is left scheduled, so discarding the environment leaves
+    // nothing behind: a service is kept as state rather than by a timer.
+    assertIdentical(background.pendingTaskCount, 0);
+    assertIdentical(background.dueTaskCount, 0);
+  });
+
+  it("stops the tasks of every service when the environment closes", async () => {
+    // Given a service running two tasks.
+    const background = new BackgroundTasks();
+    const simAws = new SimAws({ background });
+    const ecs = simAws.ecs();
+    await simEcsClusterFactory.make({}, simAws);
+    await simEcsRegisteredTaskDefinitionFactory.make({}, simAws);
+    await simEcsServiceFactory.make({ desiredCount: 2 }, simAws);
+    await simAws.backgroundTasksComplete();
+
+    const before = await ecs.listTasks(
+      new ListTasksCommand({ serviceName: "checkout" }),
+    );
+
+    assertArrayLength(before.taskArns, 2);
+
+    // When the environment is closed.
+    await simAws.close();
+
+    // Then the tasks it was keeping have stopped, and nothing is scheduled.
+    const after = await ecs.listTasks(
+      new ListTasksCommand({ serviceName: "checkout" }),
+    );
+
+    assertArrayLength(after.taskArns, 0);
+    assertIdentical(background.pendingTaskCount, 0);
+    assertIdentical(background.dueTaskCount, 0);
+
+    const stopped = await ecs.describeTasks(
+      new DescribeTasksCommand({ tasks: [before.taskArns[0]] }),
+    );
+
+    assertIdentical(stopped.tasks?.[0]?.lastStatus, "STOPPED");
+    assertStringIncludes(
+      stopped.tasks[0].stoppedReason ?? "",
+      "environment closing",
+    );
+  });
+
+  it("closes again without doing anything again", async () => {
+    // Given an environment that has already been closed.
+    const simAws = new SimAws();
+    await simEcsClusterFactory.make({}, simAws);
+    await simEcsRegisteredTaskDefinitionFactory.make({}, simAws);
+    await simEcsServiceFactory.make({}, simAws);
+    await simAws.backgroundTasksComplete();
+    await simAws.close();
+
+    // When it is closed again.
+    await simAws.close();
+
+    // Then there is still nothing running, and nothing raised.
+    const listed = await simAws
+      .ecs()
+      .listTasks(new ListTasksCommand({ serviceName: "checkout" }));
+
+    assertArrayLength(listed.taskArns, 0);
+  });
+
+  it("brings nothing up for a service deleted before its tasks start", async () => {
+    // Given a service whose tasks have not reached the background work yet.
+    const simAws = new SimAws();
+    const ecs = simAws.ecs();
+    await simEcsClusterFactory.make({}, simAws);
+    await simEcsRegisteredTaskDefinitionFactory.make({}, simAws);
+    await simEcsServiceFactory.make({ desiredCount: 2 }, simAws);
+
+    const started = await ecs.listTasks(
+      new ListTasksCommand({ serviceName: "checkout" }),
+    );
+
+    // When it is deleted before that work runs.
+    await ecs.deleteService(
+      new DeleteServiceCommand({ service: "checkout", force: true }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // Then the tasks stay stopped rather than being brought up afterwards.
+    const described = await ecs.describeTasks(
+      new DescribeTasksCommand({ tasks: [...(started.taskArns ?? [])] }),
+    );
+
+    assertArrayLength(described.tasks, 2);
+    assertIdentical(described.tasks[0].lastStatus, "STOPPED");
+    assertIdentical(described.tasks[1].lastStatus, "STOPPED");
+  });
+});

--- a/src/service/ecs/service/sim-ecs-service-store.ts
+++ b/src/service/ecs/service/sim-ecs-service-store.ts
@@ -1,0 +1,69 @@
+import type { SimEcsService } from "./sim-ecs-service.js";
+
+/**
+ * The simulated ECS services one Account and Region holds.
+ *
+ * Services are keyed by cluster and name together, because a service name is
+ * unique within a cluster on real ECS rather than across an Account: two
+ * clusters may each hold a service called `checkout`, and they are two
+ * services.
+ *
+ * A deleted service is kept rather than removed. It is still describable as
+ * `INACTIVE`, as it is on real ECS, and creating a service with its name again
+ * replaces it with a new active one.
+ */
+export class SimEcsServiceStore {
+  private readonly services = new Map<string, SimEcsService>();
+
+  private static keyFor(clusterName: string, serviceName: string): string {
+    return `${clusterName}/${serviceName}`;
+  }
+
+  /**
+   * Hold a service, replacing any earlier one of the same name in its cluster.
+   */
+  put(service: SimEcsService): void {
+    const key = SimEcsServiceStore.keyFor(
+      service.clusterName,
+      service.serviceName,
+    );
+
+    this.services.delete(key);
+    this.services.set(key, service);
+  }
+
+  /**
+   * Find a service of a cluster by name, whether it is active or deleted.
+   */
+  find(clusterName: string, serviceName: string): SimEcsService | undefined {
+    return this.services.get(
+      SimEcsServiceStore.keyFor(clusterName, serviceName),
+    );
+  }
+
+  /**
+   * Find an active service of a cluster by name.
+   */
+  findActive(
+    clusterName: string,
+    serviceName: string,
+  ): SimEcsService | undefined {
+    const service = this.find(clusterName, serviceName);
+
+    if (service?.isActive() !== true) {
+      return undefined;
+    }
+
+    return service;
+  }
+
+  /**
+   * The active services of this Account and Region, in creation order.
+   */
+  active(): readonly SimEcsService[] {
+    return this.services
+      .values()
+      .filter((service) => service.isActive())
+      .toArray();
+  }
+}

--- a/src/service/ecs/service/sim-ecs-service-task-set.ts
+++ b/src/service/ecs/service/sim-ecs-service-task-set.ts
@@ -1,0 +1,60 @@
+import type { SimEcsTask } from "../task/sim-ecs-task.js";
+
+/**
+ * The tasks one simulated ECS service is keeping running.
+ *
+ * A service holds its tasks rather than looking them up, because the counts it
+ * reports are read from them and because the ones it is keeping are not the
+ * same as the ones the cluster has ever held: a task it stopped stays in the
+ * task store and leaves here.
+ *
+ * Whatever starts and stops tasks takes them from here to stop them, so this
+ * knows nothing about how a task is started or what stopping one means.
+ */
+export class SimEcsServiceTaskSet {
+  readonly #tasks: SimEcsTask[] = [];
+
+  /** How many tasks are held, started or not. */
+  get count(): number {
+    return this.#tasks.length;
+  }
+
+  /** How many of them have reached `RUNNING`. */
+  get runningCount(): number {
+    return this.countOf("RUNNING");
+  }
+
+  /** How many of them have yet to start. */
+  get pendingCount(): number {
+    return this.countOf("PROVISIONING");
+  }
+
+  /**
+   * Take on a task started for the service.
+   */
+  add(task: SimEcsTask): void {
+    this.#tasks.push(task);
+  }
+
+  /**
+   * Give up the newest tasks held, so they can be stopped.
+   *
+   * The newest go first because they are the ones a scale-in is undoing, and
+   * because a test that read about a service's tasks expects the ones it has
+   * already seen to be the ones still there.
+   */
+  takeNewest(count: number): readonly SimEcsTask[] {
+    return this.#tasks.splice(Math.max(this.#tasks.length - count, 0));
+  }
+
+  /**
+   * Give up every task held, so they can be stopped.
+   */
+  takeAll(): readonly SimEcsTask[] {
+    return this.takeNewest(this.#tasks.length);
+  }
+
+  private countOf(status: string): number {
+    return this.#tasks.filter((task) => task.lastStatus === status).length;
+  }
+}

--- a/src/service/ecs/service/sim-ecs-service.factory.ts
+++ b/src/service/ecs/service/sim-ecs-service.factory.ts
@@ -1,0 +1,57 @@
+import { AsyncMappedFactory } from "@kensio/part-factory";
+import { assertDefined } from "../../../util/type-guard/defined.js";
+import type { SimAws } from "../../aws/sim-aws.js";
+import type { SimEcsServiceDetail } from "./sim-ecs-service-detail.js";
+
+/**
+ * What a test asks for when it wants a service already created.
+ */
+export interface SimEcsCreatedServiceInput {
+  readonly clusterName: string;
+  readonly serviceName: string;
+  readonly taskDefinition: string;
+  readonly desiredCount: number;
+}
+
+/**
+ * Creates one ECS service.
+ *
+ * The defaults line up with the cluster and task definition factories, so a
+ * test wanting a service to update, describe or delete asks all three for
+ * their defaults and gets a service running one task:
+ *
+ * ```typescript
+ * await simEcsClusterFactory.make({}, simAws);
+ * await simEcsRegisteredTaskDefinitionFactory.make({}, simAws);
+ * const service = await simEcsServiceFactory.make({}, simAws);
+ * ```
+ */
+export const simEcsServiceFactory = new AsyncMappedFactory<
+  SimEcsCreatedServiceInput,
+  SimEcsServiceDetail,
+  SimAws
+>(
+  () => ({
+    clusterName: "default",
+    serviceName: "checkout",
+    taskDefinition: "checkout",
+    desiredCount: 1,
+  }),
+  async (input, simAws) => {
+    const creation = await simAws.ecs().createService({
+      input: {
+        cluster: input.clusterName,
+        serviceName: input.serviceName,
+        taskDefinition: input.taskDefinition,
+        desiredCount: input.desiredCount,
+      },
+    });
+
+    assertDefined(
+      creation.service,
+      "Creating a sim ECS service gave none back",
+    );
+
+    return creation.service;
+  },
+);

--- a/src/service/ecs/service/sim-ecs-service.ts
+++ b/src/service/ecs/service/sim-ecs-service.ts
@@ -1,0 +1,129 @@
+import type { SimArn } from "../../aws/arn.js";
+import type {
+  SimEcsServiceDetail,
+  SimEcsServiceStatus,
+} from "./sim-ecs-service-detail.js";
+import {
+  SimEcsServiceIdentity,
+  type SimEcsServiceIdentityProperties,
+} from "./sim-ecs-service-identity.js";
+import { SimEcsServiceTaskSet } from "./sim-ecs-service-task-set.js";
+
+interface SimEcsServiceProperties extends SimEcsServiceIdentityProperties {
+  readonly taskDefinitionArn: SimArn;
+  readonly desiredCount: number;
+}
+
+/**
+ * The scheduling strategy every simulated service runs under.
+ *
+ * `DAEMON` means one task per container instance, and there are no instances
+ * here to have one each, so a request asking for it is refused rather than run
+ * as a replica service under another name.
+ */
+export const simEcsReplicaSchedulingStrategy = "REPLICA";
+
+/**
+ * One simulated ECS service.
+ *
+ * A service is a desired count of tasks from a task definition, kept running in
+ * a cluster. The count is state rather than concurrency: Yulin runs in one
+ * Node.js process and there are no containers to copy, so a desired count of
+ * three means three simulated tasks reported as running, while the handler
+ * bound to a container is called once per request or per poll.
+ *
+ * What the service is and what it is being kept at are kept apart, in its
+ * identity and here, because only the second of them ever changes. The tasks it
+ * is keeping are held in its own task set, which is where the running and
+ * pending counts are read from: whatever starts and stops them hands them over
+ * and takes them back, so nothing here schedules anything.
+ */
+export class SimEcsService {
+  public readonly tasks = new SimEcsServiceTaskSet();
+
+  #taskDefinitionArn: SimArn;
+  #desiredCount: number;
+  #status: SimEcsServiceStatus = "ACTIVE";
+
+  private readonly identity: SimEcsServiceIdentity;
+
+  constructor(properties: SimEcsServiceProperties) {
+    this.identity = new SimEcsServiceIdentity(properties);
+    this.#taskDefinitionArn = properties.taskDefinitionArn;
+    this.#desiredCount = properties.desiredCount;
+  }
+
+  /** The name this service is named by within its cluster. */
+  get serviceName(): string {
+    return this.identity.serviceName;
+  }
+
+  /** The cluster this service runs in. */
+  get clusterName(): string {
+    return this.identity.clusterName;
+  }
+
+  /** The launch type this service was created with, where one was given. */
+  get launchType(): string | undefined {
+    return this.identity.launchType;
+  }
+
+  /** The revision this service is currently running. */
+  get taskDefinitionArn(): SimArn {
+    return this.#taskDefinitionArn;
+  }
+
+  /** How many tasks this service is being kept at. */
+  get desiredCount(): number {
+    return this.#desiredCount;
+  }
+
+  /**
+   * Whether this service is still the one a request naming it reaches.
+   */
+  isActive(): boolean {
+    return this.#status === "ACTIVE";
+  }
+
+  /**
+   * Keep this service at a different number of tasks.
+   */
+  scaleTo(desiredCount: number): void {
+    this.#desiredCount = desiredCount;
+  }
+
+  /**
+   * Move this service onto another task definition revision.
+   */
+  moveTo(taskDefinitionArn: SimArn): void {
+    this.#taskDefinitionArn = taskDefinitionArn;
+  }
+
+  /**
+   * Mark this service deleted.
+   *
+   * It stays describable as `INACTIVE` rather than being removed, which is what
+   * real ECS does with a deleted service: something holding its ARN can still
+   * find out what became of it. Its desired count goes to zero, because a
+   * deleted service is keeping nothing running.
+   */
+  markDeleted(): void {
+    this.#status = "INACTIVE";
+    this.#desiredCount = 0;
+  }
+
+  /**
+   * This service as `DescribeServices` reports it.
+   */
+  toOutput(): SimEcsServiceDetail {
+    return {
+      ...this.identity.toOutput(),
+      status: this.#status,
+      desiredCount: this.#desiredCount,
+      runningCount: this.tasks.runningCount,
+      pendingCount: this.tasks.pendingCount,
+      taskDefinition: this.#taskDefinitionArn,
+      schedulingStrategy: simEcsReplicaSchedulingStrategy,
+    };
+  }
+}

--- a/src/service/ecs/sim-ecs-commands.ts
+++ b/src/service/ecs/sim-ecs-commands.ts
@@ -1,0 +1,148 @@
+import { BackgroundTasks } from "../../util/background/background.js";
+import type { SimAwsRunAsOwner } from "../aws/caller/sim-aws-run-as-context.js";
+import { simAwsAccountRegionScopeFactory } from "../aws/sim-aws-account-region-scope.factory.js";
+import { SimIamAllowAllAuth } from "../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { SimEcsContainerBindings } from "./bind/sim-ecs-container-bindings.js";
+import { SimEcsClusterStore } from "./cluster/sim-ecs-cluster-store.js";
+import { SimEcsAuthorizer } from "./command/authorize/sim-ecs-authorizer.js";
+import { SimEcsCommandContexts } from "./command/sim-ecs-command-contexts.js";
+import { CreateClusterCommandHandler } from "./command/create-cluster/create-cluster.handler.js";
+import { CreateServiceCommandHandler } from "./command/create-service/create-service.handler.js";
+import { DeleteClusterCommandHandler } from "./command/delete-cluster/delete-cluster.handler.js";
+import { DeleteServiceCommandHandler } from "./command/delete-service/delete-service.handler.js";
+import { DeregisterTaskDefinitionCommandHandler } from "./command/deregister-task-definition/deregister-task-definition.handler.js";
+import { DescribeClustersCommandHandler } from "./command/describe-clusters/describe-clusters.handler.js";
+import { DescribeServicesCommandHandler } from "./command/describe-services/describe-services.handler.js";
+import { DescribeTaskDefinitionCommandHandler } from "./command/describe-task-definition/describe-task-definition.handler.js";
+import { DescribeTasksCommandHandler } from "./command/describe-tasks/describe-tasks.handler.js";
+import { ListClustersCommandHandler } from "./command/list-clusters/list-clusters.handler.js";
+import { ListTaskDefinitionFamiliesCommandHandler } from "./command/list-task-definition-families/list-task-definition-families.handler.js";
+import { ListTaskDefinitionsCommandHandler } from "./command/list-task-definitions/list-task-definitions.handler.js";
+import { ListTasksCommandHandler } from "./command/list-tasks/list-tasks.handler.js";
+import { RegisterTaskDefinitionCommandHandler } from "./command/register-task-definition/register-task-definition.handler.js";
+import { RunTaskCommandHandler } from "./command/run-task/run-task.handler.js";
+import { StopTaskCommandHandler } from "./command/stop-task/stop-task.handler.js";
+import { UpdateServiceCommandHandler } from "./command/update-service/update-service.handler.js";
+import type { SimEcsServiceTasks } from "./service/run/sim-ecs-service-tasks.js";
+import { SimEcsServiceStore } from "./service/sim-ecs-service-store.js";
+import type { SimEcsProperties } from "./sim-ecs-properties.js";
+import { SimEcsUnreachableSecretStores } from "./task/run/secret/sim-ecs-secret-stores.js";
+import { SimEcsTaskStore } from "./task/sim-ecs-task-store.js";
+import { SimEcsTaskDefinitionStore } from "./task-definition/sim-ecs-task-definition-store.js";
+
+/**
+ * What the handlers of one simulated ECS scope are built with.
+ *
+ * The owner a task Role runs as is settled by the facade, which is its own
+ * owner when nothing else made it, so it arrives here already decided.
+ */
+interface SimEcsCommandsProperties extends SimEcsProperties {
+  readonly runAsOwner: SimAwsRunAsOwner;
+}
+
+/**
+ * Why a service's tasks stopped when the simulated environment was closed.
+ */
+const closedReason = "Task stopped by the simulated environment closing.";
+
+/**
+ * The state and command handlers of one simulated ECS scope.
+ *
+ * Everything simulated ECS holds is built here, so the `SimEcs` facade stays a
+ * delegation to a handler per operation. The stores are private because nothing
+ * outside a handler reads them; the bindings are not, because binding a
+ * container is something a test does directly.
+ */
+export class SimEcsCommands {
+  public readonly bindings = new SimEcsContainerBindings();
+
+  public readonly createCluster: CreateClusterCommandHandler;
+  public readonly describeClusters: DescribeClustersCommandHandler;
+  public readonly deleteCluster: DeleteClusterCommandHandler;
+  public readonly listClusters: ListClustersCommandHandler;
+  public readonly registerTaskDefinition: RegisterTaskDefinitionCommandHandler;
+  public readonly deregisterTaskDefinition: DeregisterTaskDefinitionCommandHandler;
+  public readonly describeTaskDefinition: DescribeTaskDefinitionCommandHandler;
+  public readonly listTaskDefinitions: ListTaskDefinitionsCommandHandler;
+  public readonly listTaskDefinitionFamilies: ListTaskDefinitionFamiliesCommandHandler;
+  public readonly runTask: RunTaskCommandHandler;
+  public readonly describeTasks: DescribeTasksCommandHandler;
+  public readonly listTasks: ListTasksCommandHandler;
+  public readonly stopTask: StopTaskCommandHandler;
+  public readonly createService: CreateServiceCommandHandler;
+  public readonly updateService: UpdateServiceCommandHandler;
+  public readonly describeServices: DescribeServicesCommandHandler;
+  public readonly deleteService: DeleteServiceCommandHandler;
+
+  private readonly services = new SimEcsServiceStore();
+  private readonly serviceTasks: SimEcsServiceTasks;
+
+  constructor(properties: SimEcsCommandsProperties) {
+    const {
+      accountRegionScope = simAwsAccountRegionScopeFactory.make(),
+      iam = new SimIamAllowAllAuth(),
+      background = new BackgroundTasks(),
+      runAsOwner,
+      secretStores = new SimEcsUnreachableSecretStores(),
+    } = properties;
+
+    const contexts = new SimEcsCommandContexts({
+      accountRegionScope,
+      authorizer: new SimEcsAuthorizer({ iam }),
+      background,
+      runAsOwner,
+      clusters: new SimEcsClusterStore(),
+      taskDefinitions: new SimEcsTaskDefinitionStore(),
+      tasks: new SimEcsTaskStore(),
+      services: this.services,
+      bindings: this.bindings,
+      secretStores,
+    });
+    const { cluster, taskDefinition, task, service } = contexts;
+
+    this.serviceTasks = service.serviceTasks;
+
+    this.createCluster = new CreateClusterCommandHandler(cluster);
+    this.describeClusters = new DescribeClustersCommandHandler(cluster);
+    this.deleteCluster = new DeleteClusterCommandHandler(cluster);
+    this.listClusters = new ListClustersCommandHandler(cluster);
+
+    this.registerTaskDefinition = new RegisterTaskDefinitionCommandHandler(
+      taskDefinition,
+    );
+    this.deregisterTaskDefinition = new DeregisterTaskDefinitionCommandHandler(
+      taskDefinition,
+    );
+    this.describeTaskDefinition = new DescribeTaskDefinitionCommandHandler(
+      taskDefinition,
+    );
+    this.listTaskDefinitions = new ListTaskDefinitionsCommandHandler(
+      taskDefinition,
+    );
+    this.listTaskDefinitionFamilies =
+      new ListTaskDefinitionFamiliesCommandHandler(taskDefinition);
+
+    this.runTask = new RunTaskCommandHandler(contexts.runTask);
+    this.describeTasks = new DescribeTasksCommandHandler(task);
+    this.listTasks = new ListTasksCommandHandler(task);
+    this.stopTask = new StopTaskCommandHandler(task);
+
+    this.createService = new CreateServiceCommandHandler(service);
+    this.updateService = new UpdateServiceCommandHandler(service);
+    this.describeServices = new DescribeServicesCommandHandler(service);
+    this.deleteService = new DeleteServiceCommandHandler(service);
+  }
+
+  /**
+   * Stop everything the services in this scope are keeping running.
+   *
+   * The services themselves stay as they were, describable with the desired
+   * count they had. Doing it again does nothing again, since the second time
+   * round there is nothing running to stop.
+   */
+  closeServices(): void {
+    for (const service of this.services.active()) {
+      this.serviceTasks.stopAll(service, closedReason);
+    }
+  }
+}

--- a/src/service/ecs/sim-ecs.ts
+++ b/src/service/ecs/sim-ecs.ts
@@ -1,39 +1,17 @@
-import { BackgroundTasks } from "../../util/background/background.js";
 import type { SimSdkCommandRouter } from "../../sdk/router/sim-sdk-command-router.type.js";
-import { simAwsAccountRegionScopeFactory } from "../aws/sim-aws-account-region-scope.factory.js";
-import { SimIamAllowAllAuth } from "../iam/authorize/sim-iam-inter-service-auth-z.js";
-import { SimEcsContainerBindings } from "./bind/sim-ecs-container-bindings.js";
 import type { SimEcsContainerBinding } from "./bind/sim-ecs-container-binding.type.js";
-import { SimEcsClusterStore } from "./cluster/sim-ecs-cluster-store.js";
-import { SimEcsAuthorizer } from "./command/authorize/sim-ecs-authorizer.js";
-import { SimEcsCommandContexts } from "./command/sim-ecs-command-contexts.js";
-import { CreateClusterCommandHandler } from "./command/create-cluster/create-cluster.handler.js";
-import { DeleteClusterCommandHandler } from "./command/delete-cluster/delete-cluster.handler.js";
-import { DeregisterTaskDefinitionCommandHandler } from "./command/deregister-task-definition/deregister-task-definition.handler.js";
-import { DescribeClustersCommandHandler } from "./command/describe-clusters/describe-clusters.handler.js";
-import { DescribeTaskDefinitionCommandHandler } from "./command/describe-task-definition/describe-task-definition.handler.js";
-import { DescribeTasksCommandHandler } from "./command/describe-tasks/describe-tasks.handler.js";
-import { ListClustersCommandHandler } from "./command/list-clusters/list-clusters.handler.js";
-import { ListTaskDefinitionFamiliesCommandHandler } from "./command/list-task-definition-families/list-task-definition-families.handler.js";
-import { ListTaskDefinitionsCommandHandler } from "./command/list-task-definitions/list-task-definitions.handler.js";
-import { ListTasksCommandHandler } from "./command/list-tasks/list-tasks.handler.js";
-import { RegisterTaskDefinitionCommandHandler } from "./command/register-task-definition/register-task-definition.handler.js";
-import { RunTaskCommandHandler } from "./command/run-task/run-task.handler.js";
-import { StopTaskCommandHandler } from "./command/stop-task/stop-task.handler.js";
 import type * as simEcsCommands from "./command/sim-ecs-command.types.js";
 import type { SimEcsRequestOptions } from "./command/sim-ecs-request-options.js";
 import { SimEcsSdkCommandRouter } from "./sdk/sim-ecs-sdk-command-router.js";
+import { SimEcsCommands } from "./sim-ecs-commands.js";
 import type { SimEcsProperties } from "./sim-ecs-properties.js";
-import { SimEcsUnreachableSecretStores } from "./task/run/secret/sim-ecs-secret-stores.js";
-import { SimEcsTaskStore } from "./task/sim-ecs-task-store.js";
-import { SimEcsTaskDefinitionStore } from "./task-definition/sim-ecs-task-definition-store.js";
 
 /**
  * Simulated ECS. Handles SDK commands. Emulates AWS behaviour and state.
  *
- * Clusters and task definitions are scoped to an account and region, as they
- * are on real AWS: both ARNs name the region, and a cluster name is unique
- * within one account and region rather than globally.
+ * Clusters, task definitions and services are scoped to an account and region,
+ * as they are on real AWS: their ARNs name the region, and a cluster name is
+ * unique within one account and region rather than globally.
  *
  * A task runs the handlers bound to the containers its task definition
  * declares. Nothing else runs: Yulin never looks inside a container image, so
@@ -41,68 +19,14 @@ import { SimEcsTaskDefinitionStore } from "./task-definition/sim-ecs-task-defini
  * failing anything.
  */
 export class SimEcs {
-  private readonly clusters = new SimEcsClusterStore();
-  private readonly taskDefinitions = new SimEcsTaskDefinitionStore();
-  private readonly tasks = new SimEcsTaskStore();
-  private readonly bindings = new SimEcsContainerBindings();
-
-  private readonly createClusterCommand: CreateClusterCommandHandler;
-  private readonly describeClustersCommand: DescribeClustersCommandHandler;
-  private readonly deleteClusterCommand: DeleteClusterCommandHandler;
-  private readonly listClustersCommand: ListClustersCommandHandler;
-  private readonly registerTaskDefinitionCommand: RegisterTaskDefinitionCommandHandler;
-  private readonly deregisterTaskDefinitionCommand: DeregisterTaskDefinitionCommandHandler;
-  private readonly describeTaskDefinitionCommand: DescribeTaskDefinitionCommandHandler;
-  private readonly listTaskDefinitionsCommand: ListTaskDefinitionsCommandHandler;
-  private readonly listTaskDefinitionFamiliesCommand: ListTaskDefinitionFamiliesCommandHandler;
-  private readonly runTaskCommand: RunTaskCommandHandler;
-  private readonly describeTasksCommand: DescribeTasksCommandHandler;
-  private readonly listTasksCommand: ListTasksCommandHandler;
-  private readonly stopTaskCommand: StopTaskCommandHandler;
+  private readonly commands: SimEcsCommands;
   private readonly sdkRouter = new SimEcsSdkCommandRouter(this);
 
   constructor(properties: SimEcsProperties = {}) {
-    const {
-      accountRegionScope = simAwsAccountRegionScopeFactory.make(),
-      iam = new SimIamAllowAllAuth(),
-      background = new BackgroundTasks(),
-      runAsOwner = this,
-      secretStores = new SimEcsUnreachableSecretStores(),
-    } = properties;
-
-    const contexts = new SimEcsCommandContexts({
-      accountRegionScope,
-      authorizer: new SimEcsAuthorizer({ iam }),
-      background,
-      runAsOwner,
-      clusters: this.clusters,
-      taskDefinitions: this.taskDefinitions,
-      tasks: this.tasks,
-      bindings: this.bindings,
-      secretStores,
+    this.commands = new SimEcsCommands({
+      ...properties,
+      runAsOwner: properties.runAsOwner ?? this,
     });
-    const { cluster, taskDefinition, task } = contexts;
-
-    this.runTaskCommand = new RunTaskCommandHandler(contexts.runTask);
-    this.describeTasksCommand = new DescribeTasksCommandHandler(task);
-    this.listTasksCommand = new ListTasksCommandHandler(task);
-    this.stopTaskCommand = new StopTaskCommandHandler(task);
-
-    this.createClusterCommand = new CreateClusterCommandHandler(cluster);
-    this.describeClustersCommand = new DescribeClustersCommandHandler(cluster);
-    this.deleteClusterCommand = new DeleteClusterCommandHandler(cluster);
-    this.listClustersCommand = new ListClustersCommandHandler(cluster);
-    this.registerTaskDefinitionCommand =
-      new RegisterTaskDefinitionCommandHandler(taskDefinition);
-    this.deregisterTaskDefinitionCommand =
-      new DeregisterTaskDefinitionCommandHandler(taskDefinition);
-    this.describeTaskDefinitionCommand =
-      new DescribeTaskDefinitionCommandHandler(taskDefinition);
-    this.listTaskDefinitionsCommand = new ListTaskDefinitionsCommandHandler(
-      taskDefinition,
-    );
-    this.listTaskDefinitionFamiliesCommand =
-      new ListTaskDefinitionFamiliesCommandHandler(taskDefinition);
   }
 
   /**
@@ -112,7 +36,7 @@ export class SimEcs {
     command: simEcsCommands.SimCreateClusterCommand,
     options?: SimEcsRequestOptions,
   ): Promise<simEcsCommands.SimCreateClusterCommandOutput> {
-    return await this.createClusterCommand.handle(command, options);
+    return await this.commands.createCluster.handle(command, options);
   }
 
   /**
@@ -122,7 +46,7 @@ export class SimEcs {
     command: simEcsCommands.SimDescribeClustersCommand,
     options?: SimEcsRequestOptions,
   ): Promise<simEcsCommands.SimDescribeClustersCommandOutput> {
-    return await this.describeClustersCommand.handle(command, options);
+    return await this.commands.describeClusters.handle(command, options);
   }
 
   /**
@@ -132,7 +56,7 @@ export class SimEcs {
     command: simEcsCommands.SimDeleteClusterCommand,
     options?: SimEcsRequestOptions,
   ): Promise<simEcsCommands.SimDeleteClusterCommandOutput> {
-    return await this.deleteClusterCommand.handle(command, options);
+    return await this.commands.deleteCluster.handle(command, options);
   }
 
   /**
@@ -142,7 +66,7 @@ export class SimEcs {
     command: simEcsCommands.SimListClustersCommand,
     options?: SimEcsRequestOptions,
   ): Promise<simEcsCommands.SimListClustersCommandOutput> {
-    return await this.listClustersCommand.handle(command, options);
+    return await this.commands.listClusters.handle(command, options);
   }
 
   /**
@@ -152,7 +76,7 @@ export class SimEcs {
     command: simEcsCommands.SimRegisterTaskDefinitionCommand,
     options?: SimEcsRequestOptions,
   ): Promise<simEcsCommands.SimRegisterTaskDefinitionCommandOutput> {
-    return await this.registerTaskDefinitionCommand.handle(command, options);
+    return await this.commands.registerTaskDefinition.handle(command, options);
   }
 
   /**
@@ -162,7 +86,10 @@ export class SimEcs {
     command: simEcsCommands.SimDeregisterTaskDefinitionCommand,
     options?: SimEcsRequestOptions,
   ): Promise<simEcsCommands.SimDeregisterTaskDefinitionCommandOutput> {
-    return await this.deregisterTaskDefinitionCommand.handle(command, options);
+    return await this.commands.deregisterTaskDefinition.handle(
+      command,
+      options,
+    );
   }
 
   /**
@@ -172,7 +99,7 @@ export class SimEcs {
     command: simEcsCommands.SimDescribeTaskDefinitionCommand,
     options?: SimEcsRequestOptions,
   ): Promise<simEcsCommands.SimDescribeTaskDefinitionCommandOutput> {
-    return await this.describeTaskDefinitionCommand.handle(command, options);
+    return await this.commands.describeTaskDefinition.handle(command, options);
   }
 
   /**
@@ -182,7 +109,7 @@ export class SimEcs {
     command: simEcsCommands.SimListTaskDefinitionsCommand,
     options?: SimEcsRequestOptions,
   ): Promise<simEcsCommands.SimListTaskDefinitionsCommandOutput> {
-    return await this.listTaskDefinitionsCommand.handle(command, options);
+    return await this.commands.listTaskDefinitions.handle(command, options);
   }
 
   /**
@@ -192,7 +119,7 @@ export class SimEcs {
     command: simEcsCommands.SimListTaskDefinitionFamiliesCommand,
     options?: SimEcsRequestOptions,
   ): Promise<simEcsCommands.SimListTaskDefinitionFamiliesCommandOutput> {
-    return await this.listTaskDefinitionFamiliesCommand.handle(
+    return await this.commands.listTaskDefinitionFamilies.handle(
       command,
       options,
     );
@@ -205,7 +132,7 @@ export class SimEcs {
     command: simEcsCommands.SimRunTaskCommand,
     options?: SimEcsRequestOptions,
   ): Promise<simEcsCommands.SimRunTaskCommandOutput> {
-    return await this.runTaskCommand.handle(command, options);
+    return await this.commands.runTask.handle(command, options);
   }
 
   /**
@@ -215,7 +142,7 @@ export class SimEcs {
     command: simEcsCommands.SimDescribeTasksCommand,
     options?: SimEcsRequestOptions,
   ): Promise<simEcsCommands.SimDescribeTasksCommandOutput> {
-    return await this.describeTasksCommand.handle(command, options);
+    return await this.commands.describeTasks.handle(command, options);
   }
 
   /**
@@ -225,7 +152,7 @@ export class SimEcs {
     command: simEcsCommands.SimListTasksCommand,
     options?: SimEcsRequestOptions,
   ): Promise<simEcsCommands.SimListTasksCommandOutput> {
-    return await this.listTasksCommand.handle(command, options);
+    return await this.commands.listTasks.handle(command, options);
   }
 
   /**
@@ -235,7 +162,63 @@ export class SimEcs {
     command: simEcsCommands.SimStopTaskCommand,
     options?: SimEcsRequestOptions,
   ): Promise<simEcsCommands.SimStopTaskCommandOutput> {
-    return await this.stopTaskCommand.handle(command, options);
+    return await this.commands.stopTask.handle(command, options);
+  }
+
+  /**
+   * Handle a CreateService Command from the SDK.
+   */
+  async createService(
+    command: simEcsCommands.SimCreateServiceCommand,
+    options?: SimEcsRequestOptions,
+  ): Promise<simEcsCommands.SimCreateServiceCommandOutput> {
+    return await this.commands.createService.handle(command, options);
+  }
+
+  /**
+   * Handle an UpdateService Command from the SDK.
+   */
+  async updateService(
+    command: simEcsCommands.SimUpdateServiceCommand,
+    options?: SimEcsRequestOptions,
+  ): Promise<simEcsCommands.SimUpdateServiceCommandOutput> {
+    return await this.commands.updateService.handle(command, options);
+  }
+
+  /**
+   * Handle a DescribeServices Command from the SDK.
+   */
+  async describeServices(
+    command: simEcsCommands.SimDescribeServicesCommand,
+    options?: SimEcsRequestOptions,
+  ): Promise<simEcsCommands.SimDescribeServicesCommandOutput> {
+    return await this.commands.describeServices.handle(command, options);
+  }
+
+  /**
+   * Handle a DeleteService Command from the SDK.
+   */
+  async deleteService(
+    command: simEcsCommands.SimDeleteServiceCommand,
+    options?: SimEcsRequestOptions,
+  ): Promise<simEcsCommands.SimDeleteServiceCommandOutput> {
+    return await this.commands.deleteService.handle(command, options);
+  }
+
+  /**
+   * Stop everything the services in this scope are keeping running.
+   *
+   * A service is the one thing simulated ECS keeps running rather than runs and
+   * finishes, so this is what a simulated environment being finished with comes
+   * down to here: every service's tasks stop, and nothing is left scheduled.
+   * The services themselves stay as they were, describable with the desired
+   * count they had.
+   *
+   * Closing again does nothing again, since the second time round there is
+   * nothing running to stop.
+   */
+  close(): void {
+    this.commands.closeServices();
   }
 
   /**
@@ -261,7 +244,7 @@ export class SimEcs {
    * definition is registered.
    */
   bindContainer(binding: SimEcsContainerBinding): void {
-    this.bindings.add(binding);
+    this.commands.bindings.add(binding);
   }
 
   /**

--- a/src/service/ecs/task-definition/sim-ecs-runnable-task-definition.ts
+++ b/src/service/ecs/task-definition/sim-ecs-runnable-task-definition.ts
@@ -1,0 +1,24 @@
+import { SimEcsClientException } from "../error/sim-ecs.error.js";
+import type { SimEcsTaskDefinition } from "./sim-ecs-task-definition.js";
+
+/**
+ * Take a revision to start tasks from, refusing a deregistered one.
+ *
+ * Real ECS refuses to run a revision that has been deregistered, and it is
+ * worth refusing here: a deregistered revision is one nothing is meant to start
+ * from any more. `RunTask`, `CreateService` and `UpdateService` all start tasks
+ * from a revision, so the rule is here rather than in each of them.
+ */
+export function requiredRunnableTaskDefinition(
+  taskDefinition: SimEcsTaskDefinition,
+): SimEcsTaskDefinition {
+  if (!taskDefinition.isActive()) {
+    throw new SimEcsClientException(
+      `Task definition ${taskDefinition.family}:` +
+        `${String(taskDefinition.revision)} is INACTIVE, so no task can be ` +
+        `run from it.`,
+    );
+  }
+
+  return taskDefinition;
+}

--- a/src/service/ecs/task/run/sim-ecs-container-runner.ts
+++ b/src/service/ecs/task/run/sim-ecs-container-runner.ts
@@ -9,8 +9,12 @@ import type { SimEcsTaskOverrides } from "./sim-ecs-task-overrides.js";
 
 /**
  * What a container with no executable binding records instead of running.
+ *
+ * It is shared with the containers a service keeps running, because it is the
+ * same thing happening to them: nothing here matches the container, so nothing
+ * here runs it.
  */
-const notSimulatedReason =
+export const simEcsNotSimulatedContainerReason =
   "Not simulated: no executable binding matches this container, so Yulin " +
   "did not run it.";
 
@@ -84,7 +88,7 @@ export class SimEcsContainerRunner {
     const bound = this.bindings.find(task.family, declared);
 
     if (bound === undefined) {
-      container.neverStarted(notSimulatedReason);
+      container.neverStarted(simEcsNotSimulatedContainerReason);
       return;
     }
 

--- a/src/service/ecs/task/sim-ecs-task-factory.ts
+++ b/src/service/ecs/task/sim-ecs-task-factory.ts
@@ -12,6 +12,7 @@ interface SimEcsStartingTask {
   readonly group?: string | undefined;
   readonly startedBy?: string | undefined;
   readonly launchType?: string | undefined;
+  readonly serviceName?: string | undefined;
 }
 
 /**
@@ -48,6 +49,7 @@ export class SimEcsTaskFactory {
       createdAt: starting.createdAt,
       launchType: starting.launchType,
       startedBy: starting.startedBy,
+      serviceName: starting.serviceName,
     });
   }
 

--- a/src/service/ecs/task/sim-ecs-task-identity.ts
+++ b/src/service/ecs/task/sim-ecs-task-identity.ts
@@ -15,6 +15,15 @@ export interface SimEcsTaskIdentityProperties {
   readonly createdAt: Date;
   readonly launchType?: string | undefined;
   readonly startedBy?: string | undefined;
+  /**
+   * The service keeping this task running, where one is.
+   *
+   * It is not something a described task reports, since real ECS says which
+   * service a task belongs to through its `group` and `startedBy`. It is here
+   * because `ListTasks` filters on a service name, and matching on the shape of
+   * a group string would be reading a label rather than knowing the answer.
+   */
+  readonly serviceName?: string | undefined;
 }
 
 /**
@@ -45,6 +54,7 @@ export class SimEcsTaskIdentity {
   public readonly family: string;
   public readonly launchType: string | undefined;
   public readonly startedBy: string | undefined;
+  public readonly serviceName: string | undefined;
 
   private readonly declared: SimEcsTaskIdentityProperties;
 
@@ -56,6 +66,7 @@ export class SimEcsTaskIdentity {
     this.family = declared.family;
     this.launchType = declared.launchType;
     this.startedBy = declared.startedBy;
+    this.serviceName = declared.serviceName;
   }
 
   /**

--- a/src/service/ecs/task/sim-ecs-task-lifecycle.ts
+++ b/src/service/ecs/task/sim-ecs-task-lifecycle.ts
@@ -50,6 +50,13 @@ export class SimEcsTaskLifecycle {
   }
 
   /**
+   * Where the task has actually got to.
+   */
+  get lastStatus(): SimEcsTaskStatus {
+    return this.#lastStatus;
+  }
+
+  /**
    * Whether the task has already finished.
    */
   get isStopped(): boolean {

--- a/src/service/ecs/task/sim-ecs-task-store.ts
+++ b/src/service/ecs/task/sim-ecs-task-store.ts
@@ -14,6 +14,7 @@ export interface SimEcsTaskListing {
   readonly family?: string | undefined;
   readonly startedBy?: string | undefined;
   readonly launchType?: string | undefined;
+  readonly serviceName?: string | undefined;
 }
 
 /**
@@ -36,7 +37,8 @@ export class SimEcsTaskStore {
       task.desiredStatus === listing.desiredStatus &&
       this.matchesOptional(task.family, listing.family) &&
       this.matchesOptional(task.startedBy, listing.startedBy) &&
-      this.matchesOptional(task.launchType, listing.launchType)
+      this.matchesOptional(task.launchType, listing.launchType) &&
+      this.matchesOptional(task.serviceName, listing.serviceName)
     );
   }
 

--- a/src/service/ecs/task/sim-ecs-task.ts
+++ b/src/service/ecs/task/sim-ecs-task.ts
@@ -4,6 +4,7 @@ import type { SimEcsTaskContainer } from "./sim-ecs-task-container.js";
 import type {
   SimEcsTaskDesiredStatus,
   SimEcsTaskDetail,
+  SimEcsTaskStatus,
 } from "./sim-ecs-task-detail.js";
 import {
   SimEcsTaskIdentity,
@@ -69,9 +70,19 @@ export class SimEcsTask {
     return this.identity.launchType;
   }
 
+  /** The service keeping this task running, where one is. */
+  get serviceName(): string | undefined {
+    return this.identity.serviceName;
+  }
+
   /** The state this task is being kept in. */
   get desiredStatus(): SimEcsTaskDesiredStatus {
     return this.lifecycle.desiredStatus;
+  }
+
+  /** Where this task has actually got to. */
+  get lastStatus(): SimEcsTaskStatus {
+    return this.lifecycle.lastStatus;
   }
 
   /**


### PR DESCRIPTION
`CreateService` creates a named service in a cluster running a task definition at a desired count, and its containers are treated as running from that point until the service is deleted or its `SimAws` is closed. Task state reflects the count, so `ListTasks` returns that many task ARNs (and now filters by `serviceName`), `DescribeTasks` describes each of them, and `DescribeServices` reports running and desired counts; `UpdateService` changes the count or moves the service onto another revision, and `DeleteService` stops the service and its tasks, refusing a service still scaled above zero unless the request forces it as real ECS does. The desired count is simulated as state rather than concurrency, because Yulin runs in one Node.js process and there are no containers to copy, so the bound handler runs once per request or per poll rather than once per task; that divergence, and the fact that nothing calls a service container's handler until the load balancer and queue-polling work lands, are both stated in the documented limitations. Nothing repeating is scheduled, so a discarded `SimAws` leaves nothing behind, and closing one stops every service's tasks.

Resolves https://github.com/KensioSoftware/yulin/issues/558

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added simulated ECS service lifecycle support, including service creation, updates, scaling, descriptions, and deletion.
  * Added service task reconciliation, background startup, redeployment, shutdown handling, and lifecycle tracking.
  * Added service-based task filtering and service-specific authorization.
* **Documentation**
  * Expanded ECS documentation with service behavior, limitations, authorization, lifecycle details, and CloudFormation coverage.
  * Added examples for creating, updating, and deleting simulated services.
* **Bug Fixes**
  * Improved validation for runnable task definitions, desired counts, service identifiers, and deletion requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->