### PR TITLE
feat: resolve load balancer names in Route53

### DIFF
--- a/docs/services/elbv2/README.md
+++ b/docs/services/elbv2/README.md
@@ -5,12 +5,12 @@ balancers, target groups, listeners and listener rules are held in memory and ev
 authorized by simulated IAM. ELBv2-specific types are imported from the `@kensio/yulin/elbv2`
 subpath.
 
-A load balancer created here has a DNS name of the shape real ELB issues, so a
-[Route53](../route53/) alias or a [CloudFront](../cloudfront/) origin has something of the right form
-to point at. It also carries a request: a request is matched to a listener by port and then to one of
-that listener's rules, and a `forward` action sends it to a target group, where a registered
-[Lambda](../lambda/) function is invoked with the request and its response becomes the HTTP
-response.
+A load balancer created here has a DNS name of the shape real ELB issues, and a
+[Route53](../route53/) record pointing at that name resolves to it, so a request made to your own
+hostname reaches the load balancer as it would deployed. A request is matched to a listener by port
+and then to one of that listener's rules, and a `forward` action sends it to a target group, where a
+registered [Lambda](../lambda/) function is invoked with the request and its response becomes the
+HTTP response.
 
 Only the application load balancer is simulated. A network or gateway load balancer routes below
 HTTP, which nothing here speaks, so `Type: "network"` is refused rather than created as an
@@ -22,8 +22,8 @@ application load balancer in disguise.
 /**
  * Creating a load balancer and reading the DNS name it is issued.
  *
- * Nothing answers on that name yet: it is the name a Route53 alias or a
- * CloudFront origin would point at.
+ * That name is what a Route53 alias points at, and what a request reaching the
+ * load balancer is addressed to.
  */
 
 import {
@@ -743,6 +743,141 @@ nothing but 502s. Real ELB refuses to register a Lambda target at all until the 
 here the permission is checked when the request arrives instead, so a target group can be built in
 any order and a policy that is later removed stops the requests.
 
+## Reaching a load balancer by name
+
+A load balancer's DNS name resolves through simulated [Route53](../route53/), so a record pointing at
+it reaches its listeners and rules. An alias record is the usual way, and a CNAME below the apex
+works too, the same as on real AWS. The record's value is `DNSName` exactly as a describe reported
+it, with nothing to rewrite.
+
+A `host-header` condition then sees the name the request was made to, rather than the load balancer's
+own, so a rule on `api.example.test` claims a request that a Route53 record for `api.example.test`
+brought to the load balancer. Host-based routing and DNS agree, which is what makes a stack with one
+load balancer behind several names behave here as it does deployed.
+
+Under `serveSimAws` the same name is served over real localhost HTTP, and a DNS lookup for it answers
+with the address the local server listens on. A request made under the Yulin-local suffix reaches the
+listener on port 80, since the port such a request carries is the local server's rather than one a
+client chose.
+
+```typescript sim-elbv2-route53-alias
+/**
+ * Reaching a load balancer through the Route53 name pointing at it.
+ */
+
+import {
+  CreateListenerCommand,
+  CreateLoadBalancerCommand,
+  CreateRuleCommand,
+} from "@aws-sdk/client-elastic-load-balancing-v2";
+import {
+  ChangeResourceRecordSetsCommand,
+  CreateHostedZoneCommand,
+} from "@aws-sdk/client-route-53";
+
+import { SimAws } from "@kensio/yulin";
+import { serveSimAws } from "@kensio/yulin/serve";
+
+const simAws = new SimAws();
+const elbV2 = simAws.elbV2();
+
+const created = await elbV2.createLoadBalancer(
+  new CreateLoadBalancerCommand({ Name: "shop-alb" }),
+);
+
+const loadBalancerArn = created.LoadBalancers?.[0]?.LoadBalancerArn;
+const dnsName = created.LoadBalancers?.[0]?.DNSName;
+
+const listener = await elbV2.createListener(
+  new CreateListenerCommand({
+    LoadBalancerArn: loadBalancerArn,
+    Protocol: "HTTP",
+    Port: 80,
+    DefaultActions: [
+      {
+        Type: "fixed-response",
+        FixedResponseConfig: {
+          StatusCode: "404",
+          ContentType: "text/plain",
+          MessageBody: "no such site",
+        },
+      },
+    ],
+  }),
+);
+
+// The rule matches on the name a client asks for, not on the load balancer's.
+await elbV2.createRule(
+  new CreateRuleCommand({
+    ListenerArn: listener.Listeners?.[0]?.ListenerArn,
+    Priority: 10,
+    Conditions: [{ Field: "host-header", Values: ["api.example.test"] }],
+    Actions: [
+      {
+        Type: "fixed-response",
+        FixedResponseConfig: {
+          StatusCode: "200",
+          ContentType: "text/plain",
+          MessageBody: "orders",
+        },
+      },
+    ],
+  }),
+);
+
+const zone = await simAws.route53().createHostedZone(
+  new CreateHostedZoneCommand({
+    Name: "example.test",
+    CallerReference: "shop-zone",
+  }),
+);
+
+await simAws.route53().changeResourceRecordSets(
+  new ChangeResourceRecordSetsCommand({
+    HostedZoneId: zone.HostedZone?.Id,
+    ChangeBatch: {
+      Changes: [
+        {
+          Action: "CREATE",
+          ResourceRecordSet: {
+            Name: "api.example.test",
+            Type: "A",
+            AliasTarget: {
+              DNSName: dnsName,
+              // The load balancer's CanonicalHostedZoneId, which sim Route53
+              // does not resolve by.
+              HostedZoneId: "Z0000000000000",
+              EvaluateTargetHealth: false,
+            },
+          },
+        },
+      ],
+    },
+  }),
+);
+
+await simAws.backgroundTasksComplete();
+
+const srv = await serveSimAws({ simAws });
+
+try {
+  const response = await fetch(srv.localUrl("http://api.example.test/orders"));
+
+  console.log(response.status); // 200
+  console.log(await response.text()); // "orders"
+
+  // The same name answers a DNS lookup with the address serving it.
+  console.log(`dig @127.0.0.1 -p ${srv.dnsPort} api.example.test`);
+} finally {
+  await srv.close();
+}
+```
+
+A name pointing at a load balancer that has since been deleted fails rather than answering: nothing
+holds that host name any more, and the failure names it. A DNS lookup for the name still answers,
+because the shape of a load balancer host name is what a lookup recognises, in the same way a lookup
+for a deleted bucket's website name does.
+
 ## Deleting
 
 Deleting a load balancer takes its listeners and their rules with it, and leaves its target groups
@@ -946,6 +1081,11 @@ console.log(created.LoadBalancers?.[0]?.DNSName);
 - Paged describes with `PageSize` and `Marker`.
 - Carrying a request through `simElbV2Fetch`: a listener matched by port, its rules evaluated in
   priority order with the first match winning, and a fall through to the default action.
+- Resolving a load balancer's DNS name through sim Route53, so an alias record or a CNAME pointing at
+  it reaches its listeners and rules, and a `host-header` condition sees the name the request was
+  made to.
+- Serving a load balancer under `serveSimAws`, over real localhost HTTP and with a DNS lookup for the
+  name answering with the address the local server listens on.
 - `host-header` and `path-pattern` matching with ELB's own wildcard semantics, and a rule claiming a
   request only when all of its conditions hold.
 - `forward` to a `lambda` target group, which invokes its function with an ALB-shaped event, and the
@@ -964,7 +1104,8 @@ console.log(created.LoadBalancers?.[0]?.DNSName);
   matched either.
 - A `host-header` condition is matched against the request's Host header, falling back to the host
   name in the URL. On real AWS those are the same thing, because DNS is what brought the request to
-  the load balancer, and here a request reaches one at its own DNS name.
+  the load balancer. A request served under the Yulin-local suffix is matched against the name inside
+  that suffix, so `api.example.test.sim-aws.localhost` is matched as `api.example.test`.
 - A `forward` action is carried out only to a `lambda` target group. An `ip` target group and a
   `ForwardConfig` naming several target groups by weight are each refused when the request arrives
   rather than answered with something else.
@@ -973,8 +1114,14 @@ console.log(created.LoadBalancers?.[0]?.DNSName);
   request can be trusted to have arrived over.
 - The length limits real ELB puts on a fixed response's message body and a redirect's components are
   not enforced. A condition value is held to ELB's own 128 characters.
-- A request only reaches a load balancer through `simElbV2Fetch`. Nothing resolves a load balancer's
-  DNS name yet, so `serveSimAws` does not serve one and a Route53 alias to one does not answer.
+- A request served under the Yulin-local suffix reaches the listener on port 80, or on 443 for an
+  `https:` URL. The port such a request carries is the local server's rather than one a client chose,
+  so it cannot say which listener it is for. To reach a listener on another port over localhost,
+  serve on that port and request the hostname without the suffix, which needs a resolver pointed at
+  the simulator as described in [Route53](../route53/README.md#ports).
+- A DNS lookup for a name pointing at a load balancer that has been deleted still answers with the
+  local server address, because a load balancer host name is recognised by its shape. The request
+  that follows is the thing that fails, naming the host name nothing answers on.
 - No TLS is performed. `simElbV2Fetch` reads only the port out of a URL, so an `https:` URL reaches
   the listener on 443 without a handshake and without being checked against that listener's
   protocol. HTTPS listeners and their certificates follow separately.

--- a/docs/services/elbv2/README.md
+++ b/docs/services/elbv2/README.md
@@ -22,8 +22,9 @@ application load balancer in disguise.
 /**
  * Creating a load balancer and reading the DNS name it is issued.
  *
- * That name is what a Route53 alias points at, and what a request reaching the
- * load balancer is addressed to.
+ * That name is what a Route53 record points at, and what a request addressed
+ * to the load balancer directly names. A request that a Route53 record brought
+ * here names the record instead.
  */
 
 import {

--- a/docs/services/elbv2/sim-elbv2-create-load-balancer.example.ts
+++ b/docs/services/elbv2/sim-elbv2-create-load-balancer.example.ts
@@ -1,8 +1,9 @@
 /**
  * Creating a load balancer and reading the DNS name it is issued.
  *
- * That name is what a Route53 alias points at, and what a request reaching the
- * load balancer is addressed to.
+ * That name is what a Route53 record points at, and what a request addressed
+ * to the load balancer directly names. A request that a Route53 record brought
+ * here names the record instead.
  */
 
 import {

--- a/docs/services/elbv2/sim-elbv2-create-load-balancer.example.ts
+++ b/docs/services/elbv2/sim-elbv2-create-load-balancer.example.ts
@@ -1,8 +1,8 @@
 /**
  * Creating a load balancer and reading the DNS name it is issued.
  *
- * Nothing answers on that name yet: it is the name a Route53 alias or a
- * CloudFront origin would point at.
+ * That name is what a Route53 alias points at, and what a request reaching the
+ * load balancer is addressed to.
  */
 
 import {

--- a/docs/services/elbv2/sim-elbv2-route53-alias.example.ts
+++ b/docs/services/elbv2/sim-elbv2-route53-alias.example.ts
@@ -1,0 +1,110 @@
+/**
+ * Reaching a load balancer through the Route53 name pointing at it.
+ */
+
+import {
+  CreateListenerCommand,
+  CreateLoadBalancerCommand,
+  CreateRuleCommand,
+} from "@aws-sdk/client-elastic-load-balancing-v2";
+import {
+  ChangeResourceRecordSetsCommand,
+  CreateHostedZoneCommand,
+} from "@aws-sdk/client-route-53";
+
+import { SimAws } from "@kensio/yulin";
+import { serveSimAws } from "@kensio/yulin/serve";
+
+const simAws = new SimAws();
+const elbV2 = simAws.elbV2();
+
+const created = await elbV2.createLoadBalancer(
+  new CreateLoadBalancerCommand({ Name: "shop-alb" }),
+);
+
+const loadBalancerArn = created.LoadBalancers?.[0]?.LoadBalancerArn;
+const dnsName = created.LoadBalancers?.[0]?.DNSName;
+
+const listener = await elbV2.createListener(
+  new CreateListenerCommand({
+    LoadBalancerArn: loadBalancerArn,
+    Protocol: "HTTP",
+    Port: 80,
+    DefaultActions: [
+      {
+        Type: "fixed-response",
+        FixedResponseConfig: {
+          StatusCode: "404",
+          ContentType: "text/plain",
+          MessageBody: "no such site",
+        },
+      },
+    ],
+  }),
+);
+
+// The rule matches on the name a client asks for, not on the load balancer's.
+await elbV2.createRule(
+  new CreateRuleCommand({
+    ListenerArn: listener.Listeners?.[0]?.ListenerArn,
+    Priority: 10,
+    Conditions: [{ Field: "host-header", Values: ["api.example.test"] }],
+    Actions: [
+      {
+        Type: "fixed-response",
+        FixedResponseConfig: {
+          StatusCode: "200",
+          ContentType: "text/plain",
+          MessageBody: "orders",
+        },
+      },
+    ],
+  }),
+);
+
+const zone = await simAws.route53().createHostedZone(
+  new CreateHostedZoneCommand({
+    Name: "example.test",
+    CallerReference: "shop-zone",
+  }),
+);
+
+await simAws.route53().changeResourceRecordSets(
+  new ChangeResourceRecordSetsCommand({
+    HostedZoneId: zone.HostedZone?.Id,
+    ChangeBatch: {
+      Changes: [
+        {
+          Action: "CREATE",
+          ResourceRecordSet: {
+            Name: "api.example.test",
+            Type: "A",
+            AliasTarget: {
+              DNSName: dnsName,
+              // The load balancer's CanonicalHostedZoneId, which sim Route53
+              // does not resolve by.
+              HostedZoneId: "Z0000000000000",
+              EvaluateTargetHealth: false,
+            },
+          },
+        },
+      ],
+    },
+  }),
+);
+
+await simAws.backgroundTasksComplete();
+
+const srv = await serveSimAws({ simAws });
+
+try {
+  const response = await fetch(srv.localUrl("http://api.example.test/orders"));
+
+  console.log(response.status); // 200
+  console.log(await response.text()); // "orders"
+
+  // The same name answers a DNS lookup with the address serving it.
+  console.log(`dig @127.0.0.1 -p ${srv.dnsPort} api.example.test`);
+} finally {
+  await srv.close();
+}

--- a/docs/services/route53/README.md
+++ b/docs/services/route53/README.md
@@ -270,8 +270,9 @@ await simAws.backgroundTasksComplete();
 ## Alias records
 
 Alias records store the alias target DNS name as the simulated record value. This is useful when a
-Route53 record should point to another simulated service hostname, such as a CloudFront
-distribution.
+Route53 record should point to another simulated service hostname, such as a CloudFront distribution
+or a load balancer. See [What a name can resolve to](#what-a-name-can-resolve-to) for the hostnames a
+record can point at.
 
 ```typescript sim-route53-alias-record
 /**
@@ -944,6 +945,122 @@ try {
 You can also call `srv.localUrl(...)` with a URL that contains the simulated hostname when you want
 the server to adapt it to the selected local port.
 
+### What a name can resolve to
+
+A record chain ends when it reaches a hostname a simulated service owns. Those are recognised by
+their shape, so the value to point a record at is whatever the service reported:
+
+| Hostname                                 | What it reaches                               |
+| ---------------------------------------- | --------------------------------------------- |
+| `<distribution-id>.cloudfront.net`       | a [CloudFront](../cloudfront/) distribution   |
+| `<name>-<id>.<region>.elb.amazonaws.com` | an [ELBv2](../elbv2/) load balancer           |
+| `<bucket>.s3-website.<region>`           | an [S3](../s3/) bucket website                |
+| `<bucket>.s3.<region>`                   | the S3 REST endpoint                          |
+| `<url-id>.lambda-url.<region>`           | a [Lambda](../lambda/) Function URL           |
+| `<api-id>.execute-api.<region>`          | an [API Gateway](../apigatewayv2/) HTTP API   |
+| `cognito-idp.<region>`                   | the [Cognito](../cognito/) user pool endpoint |
+
+The hostnames the AWS SDK talks to are written without their `.amazonaws.com` or `.on.aws` tail,
+which is the same rewriting Yulin applies to an SDK endpoint. A load balancer's name keeps its whole
+domain, because nothing rewrites it: `DNSName` is what a record points at and what a client asks for.
+
+A name pointing at a load balancer resolves to it, so a request to that name reaches the load
+balancer's listeners and rules, and a `host-header` condition on a rule sees the name the request was
+made to rather than the load balancer's own:
+
+```typescript sim-route53-elbv2-alias
+/**
+ * Resolving a name to a simulated load balancer, over HTTP and over DNS.
+ */
+
+import { Resolver } from "node:dns/promises";
+
+import {
+  CreateListenerCommand,
+  CreateLoadBalancerCommand,
+} from "@aws-sdk/client-elastic-load-balancing-v2";
+import {
+  ChangeResourceRecordSetsCommand,
+  CreateHostedZoneCommand,
+} from "@aws-sdk/client-route-53";
+
+import { SimAws } from "@kensio/yulin";
+import { serveSimAws } from "@kensio/yulin/serve";
+
+const simAws = new SimAws();
+const elbV2 = simAws.elbV2();
+
+const created = await elbV2.createLoadBalancer(
+  new CreateLoadBalancerCommand({ Name: "shop-alb" }),
+);
+
+await elbV2.createListener(
+  new CreateListenerCommand({
+    LoadBalancerArn: created.LoadBalancers?.[0]?.LoadBalancerArn,
+    Protocol: "HTTP",
+    Port: 80,
+    DefaultActions: [
+      {
+        Type: "fixed-response",
+        FixedResponseConfig: {
+          StatusCode: "200",
+          ContentType: "text/plain",
+          MessageBody: "orders",
+        },
+      },
+    ],
+  }),
+);
+
+const zone = await simAws.route53().createHostedZone(
+  new CreateHostedZoneCommand({
+    Name: "example.test",
+    CallerReference: "shop-zone",
+  }),
+);
+
+// A CNAME below the apex reaches a load balancer as an alias record does.
+await simAws.route53().changeResourceRecordSets(
+  new ChangeResourceRecordSetsCommand({
+    HostedZoneId: zone.HostedZone?.Id,
+    ChangeBatch: {
+      Changes: [
+        {
+          Action: "CREATE",
+          ResourceRecordSet: {
+            Name: "api.example.test",
+            Type: "CNAME",
+            TTL: 300,
+            ResourceRecords: [{ Value: created.LoadBalancers?.[0]?.DNSName }],
+          },
+        },
+      ],
+    },
+  }),
+);
+
+await simAws.backgroundTasksComplete();
+
+const srv = await serveSimAws({ simAws });
+
+try {
+  const response = await fetch(srv.localUrl("http://api.example.test/orders"));
+
+  console.log(await response.text()); // "orders"
+
+  const resolver = new Resolver({ timeout: 1000, tries: 1 });
+  resolver.setServers([`127.0.0.1:${srv.dnsPort}`]);
+
+  console.log(await resolver.resolve4("api.example.test")); // [ '127.0.0.1' ]
+} finally {
+  await srv.close();
+}
+```
+
+A request served under the suffix reaches the listener on port 80, since the port such a request
+carries is the local server's rather than one a client chose. See
+[Simulated Elastic Load Balancing](../elbv2/) for what happens once the request is there.
+
 ## DNSSEC
 
 A Hosted Zone can be signed. Signing needs a key-signing key, and a key-signing key needs a KMS
@@ -1430,6 +1547,9 @@ Sim Route53 currently supports:
 - Local HTTP hostname routing through `CNAME` records that point to simulated service hostnames
 - Alias records, with `AliasTarget.DNSName` stored as the record value
 - Local hostname resolution, with or without the `sim-aws.localhost` suffix on the requested hostname
+- Names resolving to simulated S3 websites and buckets, CloudFront distributions, ELBv2 load
+  balancers, Lambda Function URLs, HTTP APIs and the Cognito user pool endpoint, listed under
+  [What a name can resolve to](#what-a-name-can-resolve-to)
 - A browser-viewable hosted zone and record summary at `dns.sim-aws.localhost`
 - DNS answers over UDP for `A`, `AAAA`, `CNAME`, `TXT`, `NS` and `SOA`, so those records can be
   queried with `dig` or any DNS client

--- a/docs/services/route53/sim-route53-elbv2-alias.example.ts
+++ b/docs/services/route53/sim-route53-elbv2-alias.example.ts
@@ -1,0 +1,86 @@
+/**
+ * Resolving a name to a simulated load balancer, over HTTP and over DNS.
+ */
+
+import { Resolver } from "node:dns/promises";
+
+import {
+  CreateListenerCommand,
+  CreateLoadBalancerCommand,
+} from "@aws-sdk/client-elastic-load-balancing-v2";
+import {
+  ChangeResourceRecordSetsCommand,
+  CreateHostedZoneCommand,
+} from "@aws-sdk/client-route-53";
+
+import { SimAws } from "@kensio/yulin";
+import { serveSimAws } from "@kensio/yulin/serve";
+
+const simAws = new SimAws();
+const elbV2 = simAws.elbV2();
+
+const created = await elbV2.createLoadBalancer(
+  new CreateLoadBalancerCommand({ Name: "shop-alb" }),
+);
+
+await elbV2.createListener(
+  new CreateListenerCommand({
+    LoadBalancerArn: created.LoadBalancers?.[0]?.LoadBalancerArn,
+    Protocol: "HTTP",
+    Port: 80,
+    DefaultActions: [
+      {
+        Type: "fixed-response",
+        FixedResponseConfig: {
+          StatusCode: "200",
+          ContentType: "text/plain",
+          MessageBody: "orders",
+        },
+      },
+    ],
+  }),
+);
+
+const zone = await simAws.route53().createHostedZone(
+  new CreateHostedZoneCommand({
+    Name: "example.test",
+    CallerReference: "shop-zone",
+  }),
+);
+
+// A CNAME below the apex reaches a load balancer as an alias record does.
+await simAws.route53().changeResourceRecordSets(
+  new ChangeResourceRecordSetsCommand({
+    HostedZoneId: zone.HostedZone?.Id,
+    ChangeBatch: {
+      Changes: [
+        {
+          Action: "CREATE",
+          ResourceRecordSet: {
+            Name: "api.example.test",
+            Type: "CNAME",
+            TTL: 300,
+            ResourceRecords: [{ Value: created.LoadBalancers?.[0]?.DNSName }],
+          },
+        },
+      ],
+    },
+  }),
+);
+
+await simAws.backgroundTasksComplete();
+
+const srv = await serveSimAws({ simAws });
+
+try {
+  const response = await fetch(srv.localUrl("http://api.example.test/orders"));
+
+  console.log(await response.text()); // "orders"
+
+  const resolver = new Resolver({ timeout: 1000, tries: 1 });
+  resolver.setServers([`127.0.0.1:${srv.dnsPort}`]);
+
+  console.log(await resolver.resolve4("api.example.test")); // [ '127.0.0.1' ]
+} finally {
+  await srv.close();
+}

--- a/src/serve/http/url/sim-aws-request-hostname.iso.test.ts
+++ b/src/serve/http/url/sim-aws-request-hostname.iso.test.ts
@@ -1,6 +1,9 @@
 import { describe, it } from "vitest";
-import { assertIdentical } from "@kensio/smartass";
-import { simAwsRequestHostname } from "./sim-aws-request-hostname.js";
+import { assertFalse, assertIdentical, assertTrue } from "@kensio/smartass";
+import {
+  isSimAwsLocalRequest,
+  simAwsRequestHostname,
+} from "./sim-aws-request-hostname.js";
 
 describe("AWS-facing hostname of a request", () => {
   it("drops the localhost suffix and the local server port", () => {
@@ -23,5 +26,38 @@ describe("AWS-facing hostname of a request", () => {
     });
 
     assertIdentical(simAwsRequestHostname(request), "cdn.example.test");
+  });
+});
+
+describe("Whether a request reached the local server under its suffix", () => {
+  it("reports a request carrying the localhost suffix", () => {
+    // Given a request made to a simulated hostname under the local suffix
+    const request = new Request(
+      "http://api.example.test.sim-aws.localhost:52341/orders",
+    );
+
+    // Then the port it carries is the local server's rather than one the
+    // client chose
+    assertTrue(isSimAwsLocalRequest(request));
+  });
+
+  it("reports a request made to the hostname itself", () => {
+    // Given a request made to the hostname an application really uses, which
+    // is what a resolver pointed at the simulator makes possible
+    const request = new Request("http://api.example.test:8080/orders");
+
+    // Then the port it carries is the client's own
+    assertFalse(isSimAwsLocalRequest(request));
+  });
+
+  it("reads the Host header a client sent", () => {
+    // Given a request whose URL names an address and whose Host header names
+    // the local hostname, as a served request does
+    const request = new Request("http://127.0.0.1:52341/orders", {
+      headers: { host: "api.example.test.sim-aws.localhost:52341" },
+    });
+
+    // Then the header decides it, as it does for the hostname itself
+    assertTrue(isSimAwsLocalRequest(request));
   });
 });

--- a/src/serve/http/url/sim-aws-request-hostname.ts
+++ b/src/serve/http/url/sim-aws-request-hostname.ts
@@ -12,9 +12,29 @@ import { SimAwsLocalUrl } from "./sim-aws-local-url.js";
  * client sends and what AWS itself routes on.
  */
 export function simAwsRequestHostname(request: Request): string {
-  const requestHost = request.headers.get("host") ?? new URL(request.url).host;
-
   return new SimAwsLocalUrl({
-    input: `http://${requestHost}/`,
+    input: `http://${simAwsRequestHost(request)}/`,
   }).withoutLocalhostSuffix().hostname;
+}
+
+/**
+ * Whether a request reached the local server under the Yulin-local suffix.
+ *
+ * A request that did carries the local server's port rather than the port the
+ * client asked for, because the suffix is how a client reaches localhost while
+ * nothing resolves the name it is really after. Anything reading a port out of
+ * a request has to know that, which is why the suffix is reported here rather
+ * than being taken apart again wherever it matters.
+ */
+export function isSimAwsLocalRequest(request: Request): boolean {
+  const { hostname } = new URL(`http://${simAwsRequestHost(request)}/`);
+
+  return hostname.endsWith(SimAwsLocalUrl.localhostSuffix);
+}
+
+/**
+ * The host a request named, which is its Host header when it sent one.
+ */
+function simAwsRequestHost(request: Request): string {
+  return request.headers.get("host") ?? new URL(request.url).host;
 }

--- a/src/service/elbv2/README.md
+++ b/src/service/elbv2/README.md
@@ -29,7 +29,9 @@ ELB does, since a replacement load balancer's listeners forward to the same grou
 
 `SimElbV2LoadBalancer` is the DNS name above all. That is the only way anything reaches a load
 balancer on real AWS, and it is what a Route53 alias or a CloudFront origin points at.
-`sim-elbv2-load-balancer-arn.ts` builds both it and the ARN, and owns the `internal-` prefix an
+`sim-elbv2-load-balancer-arn.ts` builds the ARN, and `sim-elbv2-load-balancer-host.ts` both writes
+the DNS name and reads one back. Writing and reading it are in one file because they have to agree:
+what `DNSName` reports is what Route53 resolution recognises. It also owns the `internal-` prefix an
 internal load balancer's host name carries, which is why that prefix is refused in a load balancer's
 own name.
 
@@ -96,15 +98,17 @@ is refused at runtime with an explanation rather than by the type checker with n
 `serve/` is where a request becomes a response, and it is a chain of one decision each:
 
 - `sim-elbv2-fetch.ts` turns a URL into a service request, taking the load balancer's DNS name from
-  the host name. It exists because nothing resolves that name to a load balancer yet, and it is what
-  the DNS and local serving work will sit on top of rather than replace.
+  the host name. It is the in-process way in, alongside the served one: a request arriving at the
+  local server is resolved by simulated Route53 and reaches the same controller.
 - `sim-elbv2-router.ts` gets from a DNS name to the load balancer answering on it, and from a target
   group to the function registered in it. Neither hop is local: a DNS name says nothing about the
   Account, which is what `registry/sim-elbv2-registry.ts` answers, and a function is looked for in
   the target group's own Account and Region, which is where real ELB requires a Lambda target to be.
 - `sim-elbv2-controller.ts` and `sim-elbv2-listener-match.ts` match the port to a listener. A port no
   listener holds throws rather than answering, because on real AWS the connection is refused and
-  there is no status to send.
+  there is no status to send. `sim-elbv2-request-port.ts` is what decides which port that is: a
+  request served under the Yulin-local suffix carries the local server's port rather than one a
+  client chose, so the scheme's own port is used for it.
 - `sim-elbv2-rule-evaluation.ts` picks the action answering the request. Rules are evaluated in
   priority order and the first match wins, and a request no rule claims falls through to the
   listener's default action. What comes out carries the rule or listener it came from, so a refusal
@@ -128,8 +132,12 @@ is refused at runtime with an explanation rather than by the type checker with n
   function, supplying the target group as the source ARN. Who may invoke a function is Lambda's rule,
   so the decision is made there and only the ELB-shaped part of the question is here.
 
-`SimElbV2ServiceController` implements `SimAwsServiceController`, so the localhost serving layer can
-route to it once a load balancer's DNS name is resolved. Nothing resolves one yet.
+`SimElbV2ServiceController` implements `SimAwsServiceController`, and simulated Route53 resolves a
+load balancer's DNS name to it, so a Route53 record pointing at that name is served over localhost
+like any other simulated host. What the load balancer sees as the request's host name is the
+AWS-facing one, which `simAwsRequestHostname` reads: that is the name a `host-header` condition is
+matched against and the `host` header an invocation event carries, so routing by name and the event
+agree with what a client asked for.
 
 ## Authorization
 
@@ -169,10 +177,11 @@ There is no resource policy support here, and none to add: ELBv2 has none on rea
 - Only `host-header` and `path-pattern` conditions exist here. The other four fields real ELB has are
   refused when the rule is written, since a stored condition nothing matches would leave a rule that
   looks configured and never claims a request.
-- A rule is matched against the request's own Host header, falling back to the host name in the URL.
-  On real AWS those are the same thing, because DNS is what brought the request to the load balancer.
-  Here a request reaches one at its own DNS name, so sending a Host header is how a test says which
-  name the client asked for.
+- A rule is matched against the request's own Host header, falling back to the host name in the URL,
+  with the Yulin-local suffix and the local server's port taken off. On real AWS the header and the
+  URL are the same thing, because DNS is what brought the request to the load balancer. Here a
+  request reaches one at its own DNS name or at a Route53 name pointing at it, and sending a Host
+  header is how an in-process test says which name the client asked for.
 - What a request carries in is copied when it is stored, so a caller mutating the command input it
   sent cannot change a listener or rule afterwards. Real ELB reads the request off the wire and is
   immune to that by construction.

--- a/src/service/elbv2/index.ts
+++ b/src/service/elbv2/index.ts
@@ -5,8 +5,12 @@ export type { SimElbV2LoadBalancerView } from "./load-balancer/sim-elbv2-load-ba
 export {
   simElbV2CanonicalHostedZoneId,
   simElbV2LoadBalancerArn,
-  simElbV2LoadBalancerDnsName,
 } from "./load-balancer/sim-elbv2-load-balancer-arn.js";
+export {
+  readSimElbV2LoadBalancerHost,
+  simElbV2LoadBalancerDnsName,
+} from "./load-balancer/sim-elbv2-load-balancer-host.js";
+export type { SimElbV2LoadBalancerHost } from "./load-balancer/sim-elbv2-load-balancer-host.js";
 export type { SimElbV2LoadBalancerScheme } from "./load-balancer/sim-elbv2-load-balancer-scheme.js";
 export { SimElbV2TargetGroup } from "./target-group/sim-elbv2-target-group.js";
 export type { SimElbV2TargetGroupView } from "./target-group/sim-elbv2-target-group.js";

--- a/src/service/elbv2/listener/rule/match/sim-elbv2-matchable-request.ts
+++ b/src/service/elbv2/listener/rule/match/sim-elbv2-matchable-request.ts
@@ -1,3 +1,5 @@
+import { simAwsRequestHostname } from "../../../../../serve/http/url/sim-aws-request-hostname.js";
+
 /**
  * The parts of a request a listener rule is matched against.
  *
@@ -13,34 +15,28 @@ export interface SimElbV2MatchableRequest {
 }
 
 /**
- * A host name with any port taken off.
- *
- * A `host-header` condition value cannot carry a port on real ELB, so the port
- * a client wrote is not part of the comparison. An IPv6 host keeps its
- * brackets, since the port is what follows them.
- */
-function hostName(host: string): string {
-  return host.replace(/:\d+$/u, "");
-}
-
-/**
  * Read the parts of an HTTP request that listener rules match on.
  *
  * The Host header is what real ELB compares a `host-header` condition against,
  * so it wins over the host name in the URL. They are the same thing on real
- * AWS, where DNS is what brought the request here. In this simulation a request
- * reaches a load balancer at its own DNS name, so sending a Host header is how
- * a test says which name the client asked for.
+ * AWS, where DNS is what brought the request here.
+ *
+ * The host name is the AWS-facing one, so a request served under the
+ * Yulin-local suffix is matched against the name the client asked for rather
+ * than against the localhost name it reached the server at. That is what makes
+ * host-based routing agree with what Route53 resolved: a request to
+ * `api.example.test.sim-aws.localhost` is claimed by a rule on
+ * `api.example.test`, the same rule a browser resolving that name would meet.
+ * A condition value cannot carry a port on real ELB, and the AWS-facing host
+ * name has none either.
  */
 export function simElbV2MatchableRequest(
   request: Request,
 ): SimElbV2MatchableRequest {
-  const url = new URL(request.url);
-
   return {
-    host: hostName(request.headers.get("host") ?? url.host),
+    host: simAwsRequestHostname(request),
     // The pathname excludes the query string, which is what real ELB compares
     // a path pattern against.
-    path: url.pathname,
+    path: new URL(request.url).pathname,
   };
 }

--- a/src/service/elbv2/load-balancer/sim-elbv2-load-balancer-arn.ts
+++ b/src/service/elbv2/load-balancer/sim-elbv2-load-balancer-arn.ts
@@ -1,5 +1,4 @@
 import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
-import type { SimElbV2LoadBalancerScheme } from "./sim-elbv2-load-balancer-scheme.js";
 
 /**
  * The ARN of one simulated Application Load Balancer.
@@ -19,26 +18,6 @@ export function simElbV2LoadBalancerArn(
     `arn:aws:elasticloadbalancing:${scope.regionName}:${scope.accountId}:` +
     `loadbalancer/app/${name}/${id}`
   );
-}
-
-/**
- * The DNS name real ELB issues for a load balancer.
- *
- * This is the whole point of creating one here: a Route53 alias or a CloudFront
- * origin needs a host name of the right shape to point at, and it is the only
- * name by which anything reaches a load balancer on real AWS. An internal load
- * balancer's name carries the `internal-` prefix real ELB gives it, which is
- * why that prefix is refused in a load balancer's own name.
- */
-export function simElbV2LoadBalancerDnsName(
-  name: string,
-  suffix: string,
-  scheme: SimElbV2LoadBalancerScheme,
-  scope: SimAwsAccountRegionScope,
-): string {
-  const prefix = scheme === "internal" ? "internal-" : "";
-
-  return `${prefix}${name}-${suffix}.${scope.regionName}.elb.amazonaws.com`;
 }
 
 /**

--- a/src/service/elbv2/load-balancer/sim-elbv2-load-balancer-host.iso.test.ts
+++ b/src/service/elbv2/load-balancer/sim-elbv2-load-balancer-host.iso.test.ts
@@ -1,0 +1,80 @@
+import { assertIdentical, assertUndefined } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { assertDefined } from "../../../util/type-guard/defined.js";
+import { readSimElbV2LoadBalancerHost } from "./sim-elbv2-load-balancer-host.js";
+
+describe("Reading a sim ELBv2 load balancer host name", () => {
+  it("reads the load balancer host name real ELB issues", () => {
+    // Given the DNS name of an internet-facing load balancer
+
+    // When it is read as a host name
+    const host = readSimElbV2LoadBalancerHost(
+      "shop-alb-0000000001.eu-west-1.elb.amazonaws.com",
+    );
+
+    // Then it names a load balancer in the Region the name carries
+    assertDefined(host, "A load balancer DNS name was not recognised");
+    assertIdentical(
+      host.dnsName,
+      "shop-alb-0000000001.eu-west-1.elb.amazonaws.com",
+    );
+    assertIdentical(host.regionName, "eu-west-1");
+  });
+
+  it("reads an internal load balancer host name", () => {
+    // Given the DNS name of an internal load balancer, which carries the
+    // prefix real ELB reserves for one
+
+    // When it is read as a host name
+    const host = readSimElbV2LoadBalancerHost(
+      "internal-shop-alb-0000000002.us-east-1.elb.amazonaws.com",
+    );
+
+    // Then it names a load balancer as an internet-facing one does
+    assertDefined(
+      host,
+      "An internal load balancer DNS name was not recognised",
+    );
+    assertIdentical(host.regionName, "us-east-1");
+  });
+
+  it("reads a host name in the case host names are compared in", () => {
+    // Given the same name written in upper case, as a DNS client may send it
+
+    // When it is read as a host name
+    const host = readSimElbV2LoadBalancerHost(
+      "SHOP-ALB-0000000001.EU-WEST-1.ELB.AMAZONAWS.COM",
+    );
+
+    // Then it names the same load balancer, since host names are not case
+    // sensitive
+    assertDefined(host, "An upper case load balancer DNS name was not read");
+    assertIdentical(
+      host.dnsName,
+      "shop-alb-0000000001.eu-west-1.elb.amazonaws.com",
+    );
+  });
+
+  it("reads nothing from a host name of another shape", () => {
+    // Given host names that are not the one ELB issues: another domain, the
+    // ELB domain with no Region label, one with a label too many, and one with
+    // no load balancer label at all
+    const others = [
+      "shop-alb-0000000001.eu-west-1.elb.example.com",
+      "shop-alb-0000000001.elb.amazonaws.com",
+      "shop.alb-0000000001.eu-west-1.elb.amazonaws.com",
+      "eu-west-1.elb.amazonaws.com",
+      "d111111abcdef8.cloudfront.net",
+    ];
+
+    // When each is read as a load balancer host name
+    // Then none of them names one
+    for (const other of others) {
+      assertUndefined(
+        readSimElbV2LoadBalancerHost(other),
+        `${other} was read as a load balancer host name`,
+      );
+    }
+  });
+});

--- a/src/service/elbv2/load-balancer/sim-elbv2-load-balancer-host.ts
+++ b/src/service/elbv2/load-balancer/sim-elbv2-load-balancer-host.ts
@@ -1,0 +1,89 @@
+import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+import type { SimElbV2LoadBalancerScheme } from "./sim-elbv2-load-balancer-scheme.js";
+
+/**
+ * The DNS label ELB puts between the Region and the AWS domain in the host
+ * name it issues for a load balancer:
+ *
+ *   <name>-<id>.<region>.elb.amazonaws.com
+ */
+export const simElbV2HostLabel = "elb";
+
+/**
+ * The real AWS domain load balancer host names live under.
+ *
+ * Unlike the endpoints the SDK talks to, this domain is not dropped when the
+ * name is served locally. Nothing signs a request to a load balancer, so the
+ * host name a client writes is the one `DNSName` reported, and reading it back
+ * is what lets a Route53 alias be written with that value unchanged.
+ */
+export const simElbV2HostDomain = "amazonaws.com";
+
+/**
+ * The prefix real ELB puts on the DNS name of an internal load balancer.
+ */
+const internalPrefix = "internal-";
+
+/**
+ * A load balancer host name taken apart.
+ */
+export interface SimElbV2LoadBalancerHost {
+  /** The host name, in the lower case host names are compared in. */
+  readonly dnsName: string;
+  /** The Region label the host name carries. */
+  readonly regionName: string;
+}
+
+/**
+ * The shape of a load balancer host name: the load balancer's own label, the
+ * Region, and the ELB domain.
+ */
+const loadBalancerHost =
+  /^[\da-z][\da-z-]*\.(?<regionName>[\da-z-]+)\.elb\.amazonaws\.com$/u;
+
+/**
+ * The DNS name real ELB issues for a load balancer.
+ *
+ * This is the whole point of creating one here: a Route53 alias or a CloudFront
+ * origin needs a host name of the right shape to point at, and it is the only
+ * name by which anything reaches a load balancer on real AWS. An internal load
+ * balancer's name carries the `internal-` prefix real ELB gives it, which is
+ * why that prefix is refused in a load balancer's own name.
+ */
+export function simElbV2LoadBalancerDnsName(
+  name: string,
+  suffix: string,
+  scheme: SimElbV2LoadBalancerScheme,
+  scope: SimAwsAccountRegionScope,
+): string {
+  const prefix = scheme === "internal" ? internalPrefix : "";
+
+  return (
+    `${prefix}${name}-${suffix}.${scope.regionName}.` +
+    `${simElbV2HostLabel}.${simElbV2HostDomain}`
+  );
+}
+
+/**
+ * Read a host name that names a load balancer, or nothing if it names
+ * something else.
+ *
+ * This is the reading half of `simElbV2LoadBalancerDnsName`, and it is what
+ * tells Route53 resolution that a name is a load balancer's rather than
+ * another service's. It says only that the name has the shape ELB issues: which
+ * load balancer answers on it, and whether one still does, is the registry's
+ * answer rather than this one's, the same as for every other simulated service
+ * host name.
+ */
+export function readSimElbV2LoadBalancerHost(
+  hostname: string,
+): SimElbV2LoadBalancerHost | undefined {
+  const dnsName = hostname.toLowerCase();
+  const regionName = loadBalancerHost.exec(dnsName)?.groups?.["regionName"];
+
+  if (regionName === undefined) {
+    return undefined;
+  }
+
+  return { dnsName, regionName };
+}

--- a/src/service/elbv2/load-balancer/sim-elbv2-load-balancer.ts
+++ b/src/service/elbv2/load-balancer/sim-elbv2-load-balancer.ts
@@ -2,8 +2,8 @@ import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-
 import {
   simElbV2CanonicalHostedZoneId,
   simElbV2LoadBalancerArn,
-  simElbV2LoadBalancerDnsName,
 } from "./sim-elbv2-load-balancer-arn.js";
+import { simElbV2LoadBalancerDnsName } from "./sim-elbv2-load-balancer-host.js";
 import type { SimElbV2LoadBalancerScheme } from "./sim-elbv2-load-balancer-scheme.js";
 
 interface SimElbV2LoadBalancerProperties {

--- a/src/service/elbv2/serve/sim-elbv2-action-performer.ts
+++ b/src/service/elbv2/serve/sim-elbv2-action-performer.ts
@@ -1,5 +1,4 @@
 import type { SimElbV2Listener } from "../listener/sim-elbv2-listener.js";
-import type { SimElbV2LoadBalancer } from "../load-balancer/sim-elbv2-load-balancer.js";
 import type { SimElbV2 } from "../sim-elbv2.js";
 import { SimElbV2FixedResponse } from "./sim-elbv2-fixed-response.js";
 import { SimElbV2ForwardTarget } from "./sim-elbv2-forward-target.js";
@@ -9,7 +8,6 @@ import type { SimElbV2MatchedAction } from "./sim-elbv2-rule-evaluation.js";
 
 interface SimElbV2PerformedActionInput {
   readonly matched: SimElbV2MatchedAction;
-  readonly loadBalancer: SimElbV2LoadBalancer;
   readonly listener: SimElbV2Listener;
   readonly elbV2: SimElbV2;
   readonly request: Request;
@@ -54,7 +52,6 @@ export class SimElbV2ActionPerformer {
     input: SimElbV2PerformedActionInput,
   ): Promise<Response> {
     return await this.invocation.invoke({
-      loadBalancer: input.loadBalancer,
       listener: input.listener,
       targetGroup: new SimElbV2ForwardTarget(input.elbV2).resolve(
         input.matched,

--- a/src/service/elbv2/serve/sim-elbv2-controller.ts
+++ b/src/service/elbv2/serve/sim-elbv2-controller.ts
@@ -63,12 +63,11 @@ export class SimElbV2ServiceController implements SimAwsServiceController {
     route: SimElbV2LoadBalancerRoute,
     request: Request,
   ): Promise<Response> {
-    const { loadBalancer, elbV2 } = route;
+    const { elbV2 } = route;
     const listener = requireSimElbV2Listener(route, request);
 
     return await this.actions.perform({
       matched: new SimElbV2RuleEvaluation(elbV2).actionFor(listener, request),
-      loadBalancer,
       listener,
       elbV2,
       request,

--- a/src/service/elbv2/serve/sim-elbv2-event-builder.ts
+++ b/src/service/elbv2/serve/sim-elbv2-event-builder.ts
@@ -21,8 +21,6 @@ interface SimElbV2EventInput {
   readonly bytes: Uint8Array;
   /** The target group the listener forwarded to. */
   readonly targetGroupArn: string;
-  /** The DNS name of the load balancer the request reached. */
-  readonly dnsName: string;
   /** The port the listener taking the request answers on. */
   readonly port: number;
   /** The protocol that listener speaks. */
@@ -62,7 +60,6 @@ export class SimElbV2EventBuilder {
       queryStringParameters: this.requestParts.queryStringParameters(url),
       headers: this.requestParts.headers({
         request,
-        dnsName: input.dnsName,
         port: input.port,
         protocol: input.protocol,
         traceId: simAwsProxiedTraceId(this.clock.now()),

--- a/src/service/elbv2/serve/sim-elbv2-lambda-target-invocation.ts
+++ b/src/service/elbv2/serve/sim-elbv2-lambda-target-invocation.ts
@@ -1,6 +1,5 @@
 import type { SimClock } from "../../../util/clock/sim-clock.js";
 import type { SimElbV2Listener } from "../listener/sim-elbv2-listener.js";
-import type { SimElbV2LoadBalancer } from "../load-balancer/sim-elbv2-load-balancer.js";
 import type { SimElbV2TargetGroup } from "../target-group/sim-elbv2-target-group.js";
 import { SimElbV2ErrorResponse } from "./sim-elbv2-error-response.js";
 import { SimElbV2EventBuilder } from "./sim-elbv2-event-builder.js";
@@ -23,7 +22,6 @@ interface SimElbV2LambdaTargetInvocationProperties {
 }
 
 interface SimElbV2LambdaTargetInvocationInput {
-  readonly loadBalancer: SimElbV2LoadBalancer;
   readonly listener: SimElbV2Listener;
   readonly targetGroup: SimElbV2TargetGroup;
   readonly request: Request;
@@ -90,7 +88,7 @@ export class SimElbV2LambdaTargetInvocation {
     input: SimElbV2LambdaTargetInvocationInput,
     target: SimElbV2FunctionTarget,
   ): Promise<Response> {
-    const { loadBalancer, listener, targetGroup, request } = input;
+    const { listener, targetGroup, request } = input;
 
     try {
       const bytes = new Uint8Array(await request.arrayBuffer());
@@ -103,7 +101,6 @@ export class SimElbV2LambdaTargetInvocation {
         request,
         bytes,
         targetGroupArn: targetGroup.arn,
-        dnsName: loadBalancer.dnsName,
         port: listener.port,
         protocol: listener.protocol,
       });

--- a/src/service/elbv2/serve/sim-elbv2-listener-match.ts
+++ b/src/service/elbv2/serve/sim-elbv2-listener-match.ts
@@ -14,7 +14,7 @@ export function requireSimElbV2Listener(
   request: Request,
 ): SimElbV2Listener {
   const { loadBalancer, elbV2 } = route;
-  const port = simElbV2RequestPort(new URL(request.url));
+  const port = simElbV2RequestPort(request);
   const listener = elbV2.findListenerOnPort(loadBalancer.arn, port);
 
   if (listener === undefined) {

--- a/src/service/elbv2/serve/sim-elbv2-request-parts.ts
+++ b/src/service/elbv2/serve/sim-elbv2-request-parts.ts
@@ -1,7 +1,7 @@
+import { simAwsRequestHostname } from "../../../serve/http/url/sim-aws-request-hostname.js";
+
 interface SimElbV2ProxiedRequest {
   readonly request: Request;
-  /** The DNS name of the load balancer the request reached. */
-  readonly dnsName: string;
   /** The port the listener taking the request answers on. */
   readonly port: number;
   /** The protocol that listener speaks, lowercased for the header. */
@@ -37,9 +37,10 @@ export class SimElbV2RequestParts {
       headers.set(name, value);
     });
 
-    // The load balancer's own DNS name, not the localhost one the request
-    // arrived at, because that is the host name the request named on real AWS.
-    headers.set("host", proxied.dnsName);
+    // The host name the request named on real AWS, which is the load balancer's
+    // own DNS name or whatever Route53 name resolved to it, rather than the
+    // localhost one a served request arrived at.
+    headers.set("host", simAwsRequestHostname(proxied.request));
     headers.set("x-amzn-trace-id", proxied.traceId);
     headers.set("x-forwarded-for", this.forwardedFor(headers, proxied));
     headers.set("x-forwarded-port", String(proxied.port));

--- a/src/service/elbv2/serve/sim-elbv2-request-port.ts
+++ b/src/service/elbv2/serve/sim-elbv2-request-port.ts
@@ -1,14 +1,36 @@
+import { isSimAwsLocalRequest } from "../../../serve/http/url/sim-aws-request-hostname.js";
+
 /**
  * The port a request reached a load balancer on.
  *
  * A URL naming no port means the scheme's own, which is what decides between
  * an HTTP listener on 80 and an HTTPS one on 443 when a client writes neither.
+ *
+ * A request served under the Yulin-local suffix names the local server's port
+ * instead, which is a port no listener holds and which the client did not
+ * choose. That port belongs to the local transport rather than to the load
+ * balancer, so the scheme's own port is used for it too, and a request to
+ * `http://api.example.test.sim-aws.localhost:<port>/` reaches the listener on
+ * 80 as a request to `http://api.example.test/` would.
  */
-export function simElbV2RequestPort(url: URL): number {
+export function simElbV2RequestPort(request: Request): number {
+  const url = new URL(request.url);
+
+  if (isSimAwsLocalRequest(request)) {
+    return schemePort(url);
+  }
+
   if (url.port !== "") {
     return Number(url.port);
   }
 
+  return schemePort(url);
+}
+
+/**
+ * The port a URL's scheme is served on when it names none of its own.
+ */
+function schemePort(url: URL): number {
   if (url.protocol === "https:") {
     return 443;
   }

--- a/src/service/elbv2/serve/sim-elbv2-serve-hostname.iso.test.ts
+++ b/src/service/elbv2/serve/sim-elbv2-serve-hostname.iso.test.ts
@@ -1,0 +1,168 @@
+import {
+  assertIdentical,
+  assertResponseStatus,
+  assertStringIncludes,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAwsHttp } from "../../../serve/http/sim-aws-http.js";
+import { SimAws } from "../../aws/sim-aws.js";
+import type { SimElbV2LoadBalancer } from "../load-balancer/sim-elbv2-load-balancer.js";
+import type { SimElbV2Event, SimElbV2Result } from "./sim-elbv2-event.type.js";
+import { simElbV2LambdaTargetFactory } from "./sim-elbv2-lambda-target.factory.js";
+import { simElbV2ServingTargetGroupFactory } from "./sim-elbv2-serving-target-group.factory.js";
+
+/**
+ * A load balancer whose target answers with the host name and forwarded port
+ * the request reached it under.
+ */
+async function makeLoadBalancer(simAws: SimAws): Promise<SimElbV2LoadBalancer> {
+  return await simElbV2LambdaTargetFactory.make(
+    {
+      handler: (event: SimElbV2Event): SimElbV2Result => ({
+        statusCode: 200,
+        body: `${event.headers["host"] ?? ""} ${
+          event.headers["x-forwarded-port"] ?? ""
+        }`,
+      }),
+    },
+    simAws,
+  );
+}
+
+/**
+ * Point a name at a load balancer with an alias record, as a stack does.
+ */
+async function aliasTo(
+  simAws: SimAws,
+  name: string,
+  loadBalancer: SimElbV2LoadBalancer,
+): Promise<void> {
+  const creation = await simAws.route53().createHostedZone({
+    input: { Name: "example.test", CallerReference: "elbv2-serve-zone" },
+  });
+
+  await simAws.route53().changeResourceRecordSets({
+    input: {
+      HostedZoneId: creation.HostedZone?.Id,
+      ChangeBatch: {
+        Changes: [
+          {
+            Action: "CREATE",
+            ResourceRecordSet: {
+              Name: name,
+              Type: "A",
+              AliasTarget: {
+                DNSName: loadBalancer.dnsName,
+                HostedZoneId: "Z0000000000000",
+                EvaluateTargetHealth: false,
+              },
+            },
+          },
+        ],
+      },
+    },
+  });
+
+  await simAws.backgroundTasksComplete();
+}
+
+/**
+ * Add a rule claiming requests for one host name.
+ */
+async function addHostRule(
+  simAws: SimAws,
+  loadBalancer: SimElbV2LoadBalancer,
+  hostHeader: string,
+  answer: string,
+): Promise<void> {
+  const elbV2 = simAws.elbV2();
+  const targetGroup = await simElbV2ServingTargetGroupFactory.make(
+    {
+      name: answer,
+      handler: (): SimElbV2Result => ({ statusCode: 200, body: answer }),
+    },
+    simAws,
+  );
+  const listener = elbV2.findListenerOnPort(loadBalancer.arn, 80);
+
+  await elbV2.createRule({
+    input: {
+      ListenerArn: listener?.arn,
+      Priority: 10,
+      Conditions: [{ Field: "host-header", Values: [hostHeader] }],
+      Actions: [{ Type: "forward", TargetGroupArn: targetGroup.arn }],
+    },
+  });
+}
+
+describe("Reaching a sim ELBv2 load balancer by the name it answers on", () => {
+  it("carries a request made to an alias record to the load balancer", async () => {
+    // Given a name pointing at a load balancer with an alias record
+    const simAws = new SimAws();
+    const loadBalancer = await makeLoadBalancer(simAws);
+    await aliasTo(simAws, "api.example.test", loadBalancer);
+
+    // When that name is requested at the local server, which carries the
+    // Yulin-local suffix and the local server's port
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      "http://api.example.test.sim-aws.localhost:52341/orders",
+    );
+
+    // Then the load balancer's target answered, seeing the name the request was
+    // made to rather than the localhost one it arrived at, and the listener's
+    // own port rather than the local server's
+    assertResponseStatus(response, 200);
+    assertIdentical(await response.text(), "api.example.test 80");
+  });
+
+  it("matches a host header rule against the name the request was made to", async () => {
+    // Given two names pointing at one load balancer, and a rule claiming one
+    const simAws = new SimAws();
+    const loadBalancer = await makeLoadBalancer(simAws);
+    await aliasTo(simAws, "api.example.test", loadBalancer);
+    await addHostRule(simAws, loadBalancer, "api.example.test", "api");
+
+    const simAwsHttp = new SimAwsHttp({ simAws });
+
+    // When requests arrive under the alias and under the load balancer's own
+    // DNS name
+    const claimed = await simAwsHttp.fetch(
+      "http://api.example.test.sim-aws.localhost:52341/orders",
+    );
+    const missed = await simAwsHttp.fetch(
+      `http://${loadBalancer.dnsName}.sim-aws.localhost:52341/orders`,
+    );
+
+    // Then the rule claimed the request made to the name it names, so
+    // host-based routing and what Route53 resolved agree, and the request made
+    // to the load balancer's own name fell through to the default action
+    assertIdentical(await claimed.text(), "api");
+    assertIdentical(await missed.text(), `${loadBalancer.dnsName} 80`);
+  });
+
+  it("says so when the name points at a load balancer that has been deleted", async () => {
+    // Given a name pointing at a load balancer that has since been deleted
+    const simAws = new SimAws();
+    const loadBalancer = await makeLoadBalancer(simAws);
+    await aliasTo(simAws, "api.example.test", loadBalancer);
+    await simAws
+      .elbV2()
+      .deleteLoadBalancer({ input: { LoadBalancerArn: loadBalancer.arn } });
+
+    // When the name is requested
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      "http://api.example.test.sim-aws.localhost:52341/orders",
+    );
+
+    // Then the failure names the host name nothing answers on, rather than
+    // reporting the name as one the simulator knows nothing about. There is no
+    // load balancer to answer with a status of its own, so the served request
+    // fails rather than being answered by anything ELB would have.
+    assertResponseStatus(response, 500);
+    assertStringIncludes(
+      await response.text(),
+      `No simulated load balancer answers on '${loadBalancer.dnsName}'`,
+    );
+  });
+});

--- a/src/service/elbv2/serve/sim-elbv2-serve-hostname.loc.test.ts
+++ b/src/service/elbv2/serve/sim-elbv2-serve-hostname.loc.test.ts
@@ -1,0 +1,117 @@
+import { Resolver } from "node:dns/promises";
+
+import {
+  ChangeResourceRecordSetsCommand,
+  CreateHostedZoneCommand,
+} from "@aws-sdk/client-route-53";
+import {
+  assertArrayEquals,
+  assertIdentical,
+  assertResponseStatus,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { serveSimAws } from "../../../serve/index.js";
+import { SimAws } from "../../aws/sim-aws.js";
+import type { SimElbV2LoadBalancer } from "../load-balancer/sim-elbv2-load-balancer.js";
+import type { SimElbV2Event, SimElbV2Result } from "./sim-elbv2-event.type.js";
+import { simElbV2LambdaTargetFactory } from "./sim-elbv2-lambda-target.factory.js";
+
+/**
+ * A load balancer whose target answers with the host name it was reached
+ * under, and a hosted zone pointing `api.example.test` at it with an alias
+ * record.
+ */
+async function makeAliasedLoadBalancer(
+  simAws: SimAws,
+): Promise<SimElbV2LoadBalancer> {
+  const loadBalancer = await simElbV2LambdaTargetFactory.make(
+    {
+      handler: (event: SimElbV2Event): SimElbV2Result => ({
+        statusCode: 200,
+        headers: { "content-type": "text/plain" },
+        body: `orders for ${event.headers["host"] ?? ""}`,
+      }),
+    },
+    simAws,
+  );
+
+  const zone = await simAws.route53().createHostedZone(
+    new CreateHostedZoneCommand({
+      Name: "example.test",
+      CallerReference: "elbv2-serve-zone",
+    }),
+  );
+
+  await simAws.route53().changeResourceRecordSets(
+    new ChangeResourceRecordSetsCommand({
+      HostedZoneId: zone.HostedZone?.Id,
+      ChangeBatch: {
+        Changes: [
+          {
+            Action: "CREATE",
+            ResourceRecordSet: {
+              Name: "api.example.test",
+              Type: "A",
+              AliasTarget: {
+                DNSName: loadBalancer.dnsName,
+                HostedZoneId: "Z0000000000000",
+                EvaluateTargetHealth: false,
+              },
+            },
+          },
+        ],
+      },
+    }),
+  );
+
+  await simAws.backgroundTasksComplete();
+
+  return loadBalancer;
+}
+
+describe("Serving a sim ELBv2 load balancer on localhost", () => {
+  it("carries a real localhost request to the load balancer the name aliases", async () => {
+    // Given a load balancer a Route53 alias record points at
+    const simAws = new SimAws();
+    await makeAliasedLoadBalancer(simAws);
+
+    // And the simulation served on localhost
+    const srv = await serveSimAws({ simAws });
+
+    try {
+      // When the record's name is fetched over real localhost HTTP
+      const response = await fetch(
+        srv.localUrl("http://api.example.test/orders"),
+      );
+
+      // Then the load balancer's target handled the real HTTP request, seeing
+      // the name it was made to rather than the localhost one it arrived at
+      assertResponseStatus(response, 200);
+      assertIdentical(await response.text(), "orders for api.example.test");
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it("answers a DNS lookup for the name with the local server address", async () => {
+    // Given the same load balancer and alias record, served on localhost
+    const simAws = new SimAws();
+    await makeAliasedLoadBalancer(simAws);
+    const srv = await serveSimAws({ simAws });
+
+    try {
+      // When a DNS client looks the record's name up
+      const resolver = new Resolver({ timeout: 1000, tries: 1 });
+      resolver.setServers([`127.0.0.1:${srv.dnsPort}`]);
+
+      const addresses = await resolver.resolve4("api.example.test");
+
+      // Then it answers with the address the local server listens on, so the
+      // name a lookup returns is one an HTTP request actually reaches
+      assertArrayEquals(addresses, ["127.0.0.1"]);
+    } finally {
+      await srv.close();
+    }
+  });
+});

--- a/src/service/route53/README.md
+++ b/src/service/route53/README.md
@@ -328,6 +328,14 @@ Built-in targets currently include:
 - S3 static website hostnames, resolved to service `"s3"` with bucket/resource name and region
 - CloudFront distribution hostnames, resolved to service `"cloudFront"` with distribution/resource
   ID
+- ELBv2 load balancer hostnames, resolved to service `"elbV2"` with the DNS name as the resource
+  name, which is what the ELBv2 registry routes by
+
+`SimRoute53S3ServiceTargets` and `SimRoute53RegionalServiceTargets` hold the shapes with something in
+common: S3's two endpoints and two hostname styles, and the SDK endpoints whose last label is a
+Region because the local URL rewriting dropped the AWS domain. A load balancer's hostname keeps its
+domain, since nothing rewrites it on the way in, and its shape is read by
+`readSimElbV2LoadBalancerHost` so that writing the name and reading it back are one file's answer.
 
 If the incoming hostname is already a built-in simulated service hostname, the resolver returns the
 target directly. Otherwise, it looks for a `CNAME` record matching the logical name and follows the

--- a/src/service/route53/resolve/sim-r53-regional-service-target.ts
+++ b/src/service/route53/resolve/sim-r53-regional-service-target.ts
@@ -1,0 +1,113 @@
+import type { SimAwsServiceTarget } from "../../../serve/controller/sim-service-controller.js";
+import { executeApiHostLabel } from "../../apigatewayv2/api/sim-http-api-host.js";
+import type { AwsRegionName } from "../../aws/sim-aws-region.js";
+import { lambdaFunctionUrlHostLabel } from "../../lambda/function/url/sim-lambda-function-url-host.js";
+
+const cognitoIdpServiceLabel = "cognito-idp";
+
+/**
+ * Maps the Yulin-local hostnames whose last label is a Region to simulated
+ * service targets.
+ *
+ * These are the endpoints the AWS SDK talks to, and the local URL rewriting
+ * drops the AWS domain from each of them, which is what leaves the Region as
+ * the last label. Grouping them here keeps that one rule in one place, and
+ * leaves the resolver with the hostnames that keep their own domain.
+ */
+export class SimRoute53RegionalServiceTargets {
+  /**
+   * Convert a logical hostname ending in a Region into a service target.
+   */
+  resolve(logicalName: string): SimAwsServiceTarget | undefined {
+    const labels = logicalName.split(".");
+
+    return this.cognitoIdpTarget(labels) ?? this.resourceEndpointTarget(labels);
+  }
+
+  /**
+   * Resolve Cognito user pool endpoint hostnames.
+   *
+   * Simulated Cognito hostnames use:
+   *
+   *   cognito-idp.<region>
+   *
+   * The hostname names the regional Cognito endpoint rather than one pool, as
+   * the real `cognito-idp.<region>.amazonaws.com` does, and the pool id is the
+   * first path segment. The resource name is therefore empty, in the same way
+   * it is for the path-style S3 endpoint.
+   */
+  private cognitoIdpTarget(
+    labels: readonly string[],
+  ): SimAwsServiceTarget | undefined {
+    if (labels.length !== 2) {
+      return undefined;
+    }
+
+    const [service, regionName] = labels;
+
+    if (service !== cognitoIdpServiceLabel || regionName === undefined) {
+      return undefined;
+    }
+
+    return {
+      service: "cognitoIdentityProvider",
+      resourceName: "",
+      regionName: regionName as AwsRegionName,
+    };
+  }
+
+  /**
+   * Resolve the endpoints one resource is issued, which name that resource in
+   * their first label:
+   *
+   *   <url-id>.lambda-url.<region>    a Lambda Function URL
+   *   <api-id>.execute-api.<region>   an API Gateway HTTP API
+   *
+   * The real AWS endpoints end `.on.aws` and `.amazonaws.com`, which the local
+   * URL rewriting drops in the same way it drops `.amazonaws.com` from S3
+   * endpoints. Both ids are one DNS label, so the label count here is exact.
+   */
+  private resourceEndpointTarget(
+    labels: readonly string[],
+  ): SimAwsServiceTarget | undefined {
+    if (labels.length !== 3) {
+      return undefined;
+    }
+
+    const [resourceName, service, regionName] = labels;
+
+    /* v8 ignore if -- empty labels are rejected before resolution */
+    if (resourceName === undefined || regionName === undefined) {
+      return undefined;
+    }
+
+    const endpointService = this.endpointService(service);
+
+    if (endpointService === undefined) {
+      return undefined;
+    }
+
+    return {
+      service: endpointService,
+      resourceName,
+      regionName: regionName as AwsRegionName,
+    };
+  }
+
+  /**
+   * Which service issues an endpoint hostname carrying a service label.
+   */
+  private endpointService(
+    service: string | undefined,
+  ): SimAwsServiceTarget["service"] | undefined {
+    if (service === lambdaFunctionUrlHostLabel) {
+      return "lambda";
+    }
+
+    if (service === executeApiHostLabel) {
+      return "apiGatewayV2";
+    }
+
+    return undefined;
+  }
+}

--- a/src/service/route53/resolve/sim-r53-service-target-resolver.ts
+++ b/src/service/route53/resolve/sim-r53-service-target-resolver.ts
@@ -1,13 +1,12 @@
 import type { SimAwsServiceTarget } from "../../../serve/controller/sim-service-controller.js";
-import { executeApiHostLabel } from "../../apigatewayv2/api/sim-http-api-host.js";
 import type { AwsRegionName } from "../../aws/sim-aws-region.js";
-import { lambdaFunctionUrlHostLabel } from "../../lambda/function/url/sim-lambda-function-url-host.js";
+import { readSimElbV2LoadBalancerHost } from "../../elbv2/load-balancer/sim-elbv2-load-balancer-host.js";
 import { simRoute53LogicalName } from "../local-name/sim-route53-local-name.js";
 import { simRoute53DnsHostName } from "../serve/sim-route53-dns-host.js";
+import { SimRoute53RegionalServiceTargets } from "./sim-r53-regional-service-target.js";
 import { SimRoute53S3ServiceTargets } from "./sim-r53-s3-service-target.js";
 
 const cloudFrontServiceLabel = "cloudfront";
-const cognitoIdpServiceLabel = "cognito-idp";
 
 /**
  * Maps Yulin-local service hostnames to simulated AWS service targets.
@@ -25,6 +24,7 @@ const cognitoIdpServiceLabel = "cognito-idp";
  */
 export class SimRoute53ServiceTargetResolver {
   private readonly s3Targets = new SimRoute53S3ServiceTargets();
+  private readonly regionalTargets = new SimRoute53RegionalServiceTargets();
 
   /**
    * Convert a Yulin-local hostname into a simulated service target.
@@ -44,9 +44,8 @@ export class SimRoute53ServiceTargetResolver {
       this.route53DnsServiceTarget(logicalName) ??
       this.s3Targets.resolve(logicalName) ??
       this.cloudFrontServiceTarget(logicalName) ??
-      this.lambdaFunctionUrlServiceTarget(logicalName) ??
-      this.httpApiServiceTarget(logicalName) ??
-      this.cognitoIdpServiceTarget(logicalName)
+      this.loadBalancerServiceTarget(logicalName) ??
+      this.regionalTargets.resolve(logicalName)
     );
   }
 
@@ -107,117 +106,34 @@ export class SimRoute53ServiceTargetResolver {
   }
 
   /**
-   * Resolve Lambda Function URL hostnames.
+   * Resolve Application Load Balancer hostnames.
    *
-   * Simulated Function URL hostnames use:
+   * Simulated load balancer hostnames use the name real ELB issues, whole:
    *
-   *   <url-id>.lambda-url.<region>
+   *   <name>-<id>.<region>.elb.amazonaws.com
    *
-   * The real AWS endpoint ends `.on.aws`, which the local URL rewriting drops
-   * in the same way it drops `.amazonaws.com` from S3 endpoints. The URL id is
-   * one DNS label, so the label count here is exact.
+   * The AWS domain is kept rather than dropped, unlike the SDK endpoints,
+   * because nothing rewrites this name on its way in: `DNSName` is what a
+   * Route53 alias points at and what a client asks for, so it is also what is
+   * recognised here.
+   *
+   * The name says only that a load balancer would answer on it. Whether one
+   * still does is answered when the request is routed, so a name pointing at a
+   * deleted load balancer says that rather than resolving to nothing at all.
    */
-  private lambdaFunctionUrlServiceTarget(
+  private loadBalancerServiceTarget(
     logicalName: string,
   ): SimAwsServiceTarget | undefined {
-    const labels = logicalName.split(".");
+    const host = readSimElbV2LoadBalancerHost(logicalName);
 
-    if (labels.length !== 3) {
-      return undefined;
-    }
-
-    const [urlId, service, regionName] = labels;
-
-    if (service !== lambdaFunctionUrlHostLabel || regionName === undefined) {
-      return undefined;
-    }
-
-    /* v8 ignore if -- defensive check */
-    if (urlId === undefined || urlId.length === 0) {
+    if (host === undefined) {
       return undefined;
     }
 
     return {
-      service: "lambda",
-      resourceName: urlId,
-      regionName: regionName as AwsRegionName,
-    };
-  }
-
-  /**
-   * Resolve API Gateway HTTP API endpoint hostnames.
-   *
-   * Simulated HTTP API hostnames use:
-   *
-   *   <api-id>.execute-api.<region>
-   *
-   * The real AWS endpoint ends `.amazonaws.com`, which the local URL rewriting
-   * drops in the same way it drops it from S3 endpoints. The API id is one DNS
-   * label, so the label count here is exact.
-   */
-  private httpApiServiceTarget(
-    logicalName: string,
-  ): SimAwsServiceTarget | undefined {
-    const labels = logicalName.split(".");
-
-    if (labels.length !== 3) {
-      return undefined;
-    }
-
-    const [apiId, service, regionName] = labels;
-
-    if (service !== executeApiHostLabel || regionName === undefined) {
-      return undefined;
-    }
-
-    /* v8 ignore if -- defensive check */
-    if (apiId === undefined || apiId.length === 0) {
-      return undefined;
-    }
-
-    return {
-      service: "apiGatewayV2",
-      resourceName: apiId,
-      regionName: regionName as AwsRegionName,
-    };
-  }
-
-  /**
-   * Resolve Cognito user pool endpoint hostnames.
-   *
-   * Simulated Cognito hostnames use:
-   *
-   *   cognito-idp.<region>
-   *
-   * The hostname names the regional Cognito endpoint rather than one pool, as
-   * the real `cognito-idp.<region>.amazonaws.com` does, and the pool id is the
-   * first path segment. The resource name is therefore empty, in the same way
-   * it is for the path-style S3 endpoint.
-   */
-  private cognitoIdpServiceTarget(
-    logicalName: string,
-  ): SimAwsServiceTarget | undefined {
-    const labels = logicalName.split(".");
-
-    if (labels.length !== 2) {
-      return undefined;
-    }
-
-    const [service, regionName] = labels;
-
-    if (service !== cognitoIdpServiceLabel || regionName === undefined) {
-      return undefined;
-    }
-
-    /* v8 ignore if -- empty labels are rejected before resolution */
-    if (regionName.length === 0) {
-      return undefined;
-    }
-
-    return {
-      service: "cognitoIdentityProvider",
-      resourceName: "",
-      regionName: regionName as AwsRegionName,
+      service: "elbV2",
+      resourceName: host.dnsName,
+      regionName: host.regionName as AwsRegionName,
     };
   }
 }

--- a/src/service/route53/resolve/sim-route53-resolve-elbv2.iso.test.ts
+++ b/src/service/route53/resolve/sim-route53-resolve-elbv2.iso.test.ts
@@ -1,0 +1,180 @@
+import { assertObjectMatches, assertUndefined } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import type { SimElbV2LoadBalancer } from "../../elbv2/load-balancer/sim-elbv2-load-balancer.js";
+import { simElbV2LambdaTargetFactory } from "../../elbv2/serve/sim-elbv2-lambda-target.factory.js";
+import { simRoute53LocalName } from "../local-name/sim-route53-local-name.js";
+
+/**
+ * A hosted zone for `example.test`, and its id.
+ */
+async function createZone(simAws: SimAws): Promise<string> {
+  const creation = await simAws.route53().createHostedZone({
+    input: { Name: "example.test", CallerReference: "elbv2-zone" },
+  });
+
+  await simAws.backgroundTasksComplete();
+
+  return creation.HostedZone?.Id ?? "";
+}
+
+/**
+ * Point a name at a load balancer with an alias A record, as a stack does.
+ */
+async function createAlias(
+  simAws: SimAws,
+  name: string,
+  dnsName: string,
+): Promise<void> {
+  await simAws.route53().changeResourceRecordSets({
+    input: {
+      HostedZoneId: await createZone(simAws),
+      ChangeBatch: {
+        Changes: [
+          {
+            Action: "CREATE",
+            ResourceRecordSet: {
+              Name: name,
+              Type: "A",
+              AliasTarget: {
+                DNSName: dnsName,
+                HostedZoneId: "Z0000000000000",
+                EvaluateTargetHealth: false,
+              },
+            },
+          },
+        ],
+      },
+    },
+  });
+
+  await simAws.backgroundTasksComplete();
+}
+
+/**
+ * A load balancer that answers, whose DNS name a record can point at.
+ */
+async function makeLoadBalancer(simAws: SimAws): Promise<SimElbV2LoadBalancer> {
+  return await simElbV2LambdaTargetFactory.make({}, simAws);
+}
+
+describe("Resolving a name to a sim ELBv2 load balancer", () => {
+  it("resolves a load balancer DNS name to the load balancer", async () => {
+    // Given a load balancer
+    const simAws = new SimAws();
+    const loadBalancer = await makeLoadBalancer(simAws);
+
+    // When its own DNS name is resolved
+    const target = simAws
+      .route53()
+      .resolveHttpHost(simRoute53LocalName(loadBalancer.dnsName));
+
+    // Then it names the load balancer, in the Region its host name carries
+    assertObjectMatches(target, {
+      service: "elbV2",
+      resourceName: loadBalancer.dnsName,
+      regionName: "us-east-1",
+    });
+  });
+
+  it("resolves an alias record to the load balancer it points at", async () => {
+    // Given a hosted zone with an alias record pointing at a load balancer
+    const simAws = new SimAws();
+    const loadBalancer = await makeLoadBalancer(simAws);
+    await createAlias(simAws, "api.example.test", loadBalancer.dnsName);
+
+    // When the record's name is resolved
+    const target = simAws
+      .route53()
+      .resolveHttpHost(simRoute53LocalName("api.example.test"));
+
+    // Then it routes to the load balancer the alias names
+    assertObjectMatches(target, {
+      service: "elbV2",
+      resourceName: loadBalancer.dnsName,
+    });
+  });
+
+  it("resolves a CNAME record to the load balancer it points at", async () => {
+    // Given a hosted zone with a CNAME pointing at a load balancer, which is
+    // how a name below the apex reaches one without an alias
+    const simAws = new SimAws();
+    const loadBalancer = await makeLoadBalancer(simAws);
+    const hostedZoneId = await createZone(simAws);
+
+    await simAws.route53().changeResourceRecordSets({
+      input: {
+        HostedZoneId: hostedZoneId,
+        ChangeBatch: {
+          Changes: [
+            {
+              Action: "CREATE",
+              ResourceRecordSet: {
+                Name: "www.example.test",
+                Type: "CNAME",
+                TTL: 300,
+                ResourceRecords: [{ Value: loadBalancer.dnsName }],
+              },
+            },
+          ],
+        },
+      },
+    });
+    await simAws.backgroundTasksComplete();
+
+    // When the record's name is resolved
+    const target = simAws
+      .route53()
+      .resolveHttpHost(simRoute53LocalName("www.example.test"));
+
+    // Then it routes to the same load balancer the alias would have
+    assertObjectMatches(target, {
+      service: "elbV2",
+      resourceName: loadBalancer.dnsName,
+    });
+  });
+
+  it("resolves a name pointing at a load balancer that has been deleted", async () => {
+    // Given an alias record whose load balancer has since been deleted
+    const simAws = new SimAws();
+    const loadBalancer = await makeLoadBalancer(simAws);
+    await createAlias(simAws, "api.example.test", loadBalancer.dnsName);
+    await simAws
+      .elbV2()
+      .deleteLoadBalancer({ input: { LoadBalancerArn: loadBalancer.arn } });
+
+    // When the record's name is resolved
+    const target = simAws
+      .route53()
+      .resolveHttpHost(simRoute53LocalName("api.example.test"));
+
+    // Then the name still names a load balancer, because the shape of the host
+    // name is what says so. Whether one still answers on it is settled when the
+    // request is routed, which is what makes a deleted load balancer a refusal
+    // naming the host name rather than an unknown host.
+    assertObjectMatches(target, {
+      service: "elbV2",
+      resourceName: loadBalancer.dnsName,
+    });
+  });
+
+  it("resolves nothing for a name of another shape under the ELB domain", async () => {
+    // Given a record pointing at a host name that is not one ELB issues
+    const simAws = new SimAws();
+    await createAlias(
+      simAws,
+      "api.example.test",
+      "shop-alb-0000000001.elb.amazonaws.com",
+    );
+
+    // When the record's name is resolved
+    const target = simAws
+      .route53()
+      .resolveHttpHost(simRoute53LocalName("api.example.test"));
+
+    // Then nothing simulated owns it, rather than a load balancer being
+    // assumed behind any name under the AWS domain
+    assertUndefined(target);
+  });
+});


### PR DESCRIPTION
A load balancer's DNS name is now recognised as a simulated service target, so a Route53 alias record or a CNAME pointing at it resolves and a request to that name reaches the load balancer's listeners and rules. A `host-header` condition is matched against the AWS-facing name the request was made to, so host-based routing and DNS agree, and the invocation event carries that name as its host header rather than the load balancer's own. Under `serveSimAws` the name is reachable over real localhost HTTP and a DNS lookup for it answers with the address the local server listens on, with a request made under the local suffix reaching the listener on the scheme's port since the port such a request carries is the local server's rather than one a client chose. A name pointing at a load balancer that has been deleted fails naming the host name nothing answers on, rather than resolving to nothing at all. The load balancer host name is written and read back in one file, the region-tailed SDK endpoint shapes moved out of the Route53 resolver into a collaborator to keep it under the complexity threshold, and both docs pages gained a worked example.

Resolves https://github.com/KensioSoftware/yulin/issues/567

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Route 53 can now resolve simulated ELBv2 load-balancer hostnames, aliases, and CNAMEs.
  * Access load balancers locally using custom hostnames, host-header routing, and listener ports.
  * Added support for internet-facing and internal load-balancer hostname parsing.
  * Requests routed to deleted load balancers now return a descriptive error.
  * Added examples demonstrating Route 53 aliases, DNS lookups, and HTTP serving.

* **Documentation**
  * Expanded ELBv2 and Route 53 guides with hostname resolution, routing behavior, supported targets, and limitations.

* **Bug Fixes**
  * Improved hostname detection and handling of Host headers, local suffixes, and request ports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->