### PR TITLE
feat: terminate HTTPS on a sim ALB listener

### DIFF
--- a/docs/services/elbv2/README.md
+++ b/docs/services/elbv2/README.md
@@ -361,8 +361,10 @@ A certificate that is still `PENDING_VALIDATION` is refused the same way, since 
 one could serve nothing. That is what makes a test of the whole issuance path worth writing: the
 certificate has to have been validated for the listener that uses it to be created.
 
-An HTTPS listener with no certificate at all is refused, and a listener that is not HTTPS holds none,
-so moving one to HTTP drops its certificates rather than carrying certificates nothing would present.
+An HTTPS listener with no certificate at all is refused, and so is a listener that names a
+certificate and speaks something other than HTTPS, which would otherwise look configured for HTTPS
+while answering plain HTTP. Moving a listener to HTTP without naming a certificate drops the ones it
+was carrying, since nothing would present them.
 
 ### The certificate list
 

--- a/docs/services/elbv2/README.md
+++ b/docs/services/elbv2/README.md
@@ -269,6 +269,203 @@ rules about is `SetRulePriorities`, which reorders a whole listener, and which j
 against the order it would leave behind rather than the one it started from, so two rules can swap
 places in one request.
 
+## HTTPS listeners and certificates
+
+A listener on `HTTPS` carries a certificate from simulated ACM. The certificate has to be one that
+exists and has been issued, and one in the load balancer's own account and region, or the listener is
+refused with the reason. That refusal is the point of connecting the two simulations: a test can
+prove that a stack's certificate and its listener line up, rather than the stack finding out at
+deploy time.
+
+**No TLS is performed here.** Nothing is encrypted, no handshake happens, and no certificate is
+presented to anything. What is simulated is the configuration relationship between a listener and a
+certificate, and the protocol a request is treated as having arrived on.
+
+```typescript sim-elbv2-https-listener
+/**
+ * An HTTPS listener presenting a certificate simulated ACM issued.
+ */
+
+import { RequestCertificateCommand } from "@aws-sdk/client-acm";
+import {
+  type Action,
+  CreateListenerCommand,
+  CreateLoadBalancerCommand,
+  CreateTargetGroupCommand,
+} from "@aws-sdk/client-elastic-load-balancing-v2";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const elbV2 = simAws.elbV2();
+
+const certificate = await simAws
+  .acm()
+  .requestCertificate(
+    new RequestCertificateCommand({ DomainName: "shop.example.com" }),
+  );
+
+// A certificate no hosted zone covers issues on its own, once the simulation's
+// background work has run.
+await simAws.backgroundTasksComplete();
+
+const loadBalancer = await elbV2.createLoadBalancer(
+  new CreateLoadBalancerCommand({ Name: "shop-alb" }),
+);
+const targetGroup = await elbV2.createTargetGroup(
+  new CreateTargetGroupCommand({ Name: "checkout-tg", TargetType: "lambda" }),
+);
+
+const loadBalancerArn = loadBalancer.LoadBalancers?.[0]?.LoadBalancerArn;
+const forward: Action = {
+  Type: "forward",
+  TargetGroupArn: targetGroup.TargetGroups?.[0]?.TargetGroupArn,
+};
+
+const listener = await elbV2.createListener(
+  new CreateListenerCommand({
+    LoadBalancerArn: loadBalancerArn,
+    Protocol: "HTTPS",
+    Port: 443,
+    Certificates: [{ CertificateArn: certificate.CertificateArn }],
+    DefaultActions: [forward],
+  }),
+);
+
+// A listener that named no security policy gets the one real ELB gives it.
+console.log(listener.Listeners?.[0]?.SslPolicy); // "ELBSecurityPolicy-2016-08"
+
+try {
+  await elbV2.createListener(
+    new CreateListenerCommand({
+      LoadBalancerArn: loadBalancerArn,
+      Protocol: "HTTPS",
+      Port: 8443,
+      Certificates: [
+        {
+          CertificateArn:
+            "arn:aws:acm:us-east-1:888888888888:certificate/00000009",
+        },
+      ],
+      DefaultActions: [forward],
+    }),
+  );
+} catch (error) {
+  // Certificate arn:aws:acm:us-east-1:888888888888:certificate/00000009 was
+  // not found in simulated ACM
+  console.log((error as Error).message);
+}
+```
+
+A certificate that is still `PENDING_VALIDATION` is refused the same way, since a listener presenting
+one could serve nothing. That is what makes a test of the whole issuance path worth writing: the
+certificate has to have been validated for the listener that uses it to be created.
+
+An HTTPS listener with no certificate at all is refused, and a listener that is not HTTPS holds none,
+so moving one to HTTP drops its certificates rather than carrying certificates nothing would present.
+
+### The certificate list
+
+A listener's default certificate is the one `CreateListener` and `ModifyListener` name, and it is the
+one a described listener reports. The rest of the list is `AddListenerCertificates`,
+`RemoveListenerCertificates` and `DescribeListenerCertificates`, which are the certificates a real
+listener would choose between by the host name a client asked for.
+
+```typescript sim-elbv2-listener-certificates
+/**
+ * The certificates a listener carries beyond its default one.
+ */
+
+import { RequestCertificateCommand } from "@aws-sdk/client-acm";
+import {
+  AddListenerCertificatesCommand,
+  CreateListenerCommand,
+  CreateLoadBalancerCommand,
+  CreateTargetGroupCommand,
+  DescribeListenerCertificatesCommand,
+  RemoveListenerCertificatesCommand,
+} from "@aws-sdk/client-elastic-load-balancing-v2";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const acm = simAws.acm();
+const elbV2 = simAws.elbV2();
+
+async function issuedCertificateArn(domainName: string): Promise<string> {
+  const requested = await acm.requestCertificate(
+    new RequestCertificateCommand({ DomainName: domainName }),
+  );
+
+  await simAws.backgroundTasksComplete();
+
+  return requested.CertificateArn ?? "";
+}
+
+const shop = await issuedCertificateArn("shop.example.com");
+const admin = await issuedCertificateArn("admin.example.com");
+
+const loadBalancer = await elbV2.createLoadBalancer(
+  new CreateLoadBalancerCommand({ Name: "shop-alb" }),
+);
+const targetGroup = await elbV2.createTargetGroup(
+  new CreateTargetGroupCommand({ Name: "checkout-tg", TargetType: "lambda" }),
+);
+
+const listener = await elbV2.createListener(
+  new CreateListenerCommand({
+    LoadBalancerArn: loadBalancer.LoadBalancers?.[0]?.LoadBalancerArn,
+    Protocol: "HTTPS",
+    Port: 443,
+    Certificates: [{ CertificateArn: shop }],
+    DefaultActions: [
+      {
+        Type: "forward",
+        TargetGroupArn: targetGroup.TargetGroups?.[0]?.TargetGroupArn,
+      },
+    ],
+  }),
+);
+
+const listenerArn = listener.Listeners?.[0]?.ListenerArn;
+
+await elbV2.addListenerCertificates(
+  new AddListenerCertificatesCommand({
+    ListenerArn: listenerArn,
+    Certificates: [{ CertificateArn: admin }],
+  }),
+);
+
+const carried = await elbV2.describeListenerCertificates(
+  new DescribeListenerCertificatesCommand({ ListenerArn: listenerArn }),
+);
+
+// The default certificate comes first and is the only one flagged as such.
+console.log(carried.Certificates?.map((each) => each.IsDefault)); // [true, false]
+
+await elbV2.removeListenerCertificates(
+  new RemoveListenerCertificatesCommand({
+    ListenerArn: listenerArn,
+    Certificates: [{ CertificateArn: admin }],
+  }),
+);
+```
+
+The default certificate cannot be removed this way. Replacing it is `ModifyListener`, as on real ELB,
+and trying to remove it is refused with that named.
+
+### Serving a request over HTTPS
+
+A request to `https://<dns-name>/orders` reaches the listener on port 443, and from there it is the
+same request as any other: the same rules are evaluated in the same order, and the same target groups
+answer. The listener's protocol is what the target is told the request arrived on, so a function
+behind an HTTPS listener sees `x-forwarded-proto: https` and `x-forwarded-port: 443`.
+
+Because no TLS happens, the URL scheme is not checked against the listener it reaches. What decides
+the listener is the port, and what decides the protocol in the event is the listener. A test can
+therefore conclude that a request treated as arriving over HTTPS is routed and forwarded the way the
+configuration says, and cannot conclude anything about certificates, ciphers or a handshake.
+
 ## Carrying a request to a Lambda function
 
 `simElbV2Fetch` sends a request to whichever load balancer its host name names, in process and
@@ -1074,6 +1271,10 @@ console.log(created.LoadBalancers?.[0]?.DNSName);
   `lambda` and `ip` target types.
 - `RegisterTargets`, `DeregisterTargets` and `DescribeTargetHealth`.
 - `CreateListener`, `DescribeListeners`, `ModifyListener` and `DeleteListener`, on HTTP and HTTPS.
+- An HTTPS listener's default certificate resolved against simulated ACM, refusing one that does not
+  exist, one that is not `ISSUED`, and one outside the load balancer's own account and region.
+- `AddListenerCertificates`, `RemoveListenerCertificates` and `DescribeListenerCertificates`, with
+  the default certificate reported first and refused removal.
 - `CreateRule`, `DescribeRules`, `ModifyRule`, `DeleteRule` and `SetRulePriorities`, with priorities
   unique within a listener and the listener's default rule reported last.
 - `forward`, `fixed-response` and `redirect` actions, and `host-header` and `path-pattern`
@@ -1113,6 +1314,26 @@ console.log(created.LoadBalancers?.[0]?.DNSName);
 - A redirect is not checked against the listener it is on, so redirecting HTTPS to HTTP is accepted
   where real ELB refuses it. Nothing here performs TLS, so the listener's protocol is not something a
   request can be trusted to have arrived over.
+- No TLS is performed on an HTTPS listener. Nothing is encrypted, no handshake happens, and no
+  certificate is presented to a client. What a test can conclude is that a listener's certificate
+  exists, was issued, and is in the load balancer's account and region, and that a request treated as
+  arriving over HTTPS is routed and forwarded the way the configuration says. What it cannot conclude
+  is anything about a client trusting the certificate, about expiry, about protocol versions or
+  ciphers, or about a request having really arrived over a secure connection.
+- The URL scheme a request is written with is not checked against the listener it reaches. The port
+  decides the listener, and the listener decides the protocol the event and the forwarding headers
+  report, so `http://<dns-name>:443/` reaching an HTTPS listener is served as an HTTPS request rather
+  than refused as a failed handshake.
+- SNI certificate selection by host name is not simulated. The certificates beyond the default are
+  held and reported, and nothing chooses between them when a request arrives, since there is no
+  handshake to choose in. The default certificate is the one every request is served under.
+- Security policies and cipher suites are accepted and ignored. A listener that names no `SslPolicy`
+  is given the one real ELB defaults to, the value is reported back, and nothing acts on it.
+- `IsDefault` is ignored on `AddListenerCertificates`, as real ELB documents that it should not be
+  set there. The default certificate is replaced with `ModifyListener`, which drops the certificate
+  that was the default rather than moving it into the rest of the list.
+- A certificate is only ever an ACM one. `ImportCertificate` and IAM server certificates are not
+  simulated, and neither is mutual TLS, so there is no trust store to give a listener.
 - The length limits real ELB puts on a fixed response's message body and a redirect's components are
   not enforced. A condition value is held to ELB's own 128 characters.
 - A request served under the Yulin-local suffix reaches the listener on port 80, or on 443 for an
@@ -1123,9 +1344,6 @@ console.log(created.LoadBalancers?.[0]?.DNSName);
 - A DNS lookup for a name pointing at a load balancer that has been deleted still answers with the
   local server address, because a load balancer host name is recognised by its shape. The request
   that follows is the thing that fails, naming the host name nothing answers on.
-- No TLS is performed. `simElbV2Fetch` reads only the port out of a URL, so an `https:` URL reaches
-  the listener on 443 without a handshake and without being checked against that listener's
-  protocol. HTTPS listeners and their certificates follow separately.
 - The invoke permission is checked when the request arrives, where real ELB checks it when a Lambda
   target is registered and refuses `RegisterTargets` without it. A target naming a function in
   another Account or Region is registered here and then answers 502, where real ELB refuses the
@@ -1159,7 +1377,7 @@ console.log(created.LoadBalancers?.[0]?.DNSName);
   exchange, and treating one as a plain forward would quietly skip authentication. Since those are
   the only actions that may precede a routing action, a listener or rule takes exactly one action
   here and a longer list is refused.
-- Load balancer and target group attributes, access logs, listener certificates as a separate
-  resource, trust stores, and tags as a readable resource are not simulated.
+- Load balancer and target group attributes, access logs, and tags as a readable resource are not
+  simulated.
 - There is no CloudFormation support yet, so `AWS::ElasticLoadBalancingV2::*` resources in a template
   are not deployed.

--- a/docs/services/elbv2/README.md
+++ b/docs/services/elbv2/README.md
@@ -16,6 +16,11 @@ Only the application load balancer is simulated. A network or gateway load balan
 HTTP, which nothing here speaks, so `Type: "network"` is refused rather than created as an
 application load balancer in disguise.
 
+No TLS is performed anywhere in this. An HTTPS listener holds a certificate and is checked against
+simulated ACM, and nothing is ever encrypted or handshaken. See
+[HTTPS listeners and certificates](#https-listeners-and-certificates) for what that leaves a test
+able to conclude.
+
 ## Creating a load balancer
 
 ```typescript sim-elbv2-create-load-balancer
@@ -283,7 +288,10 @@ certificate, and the protocol a request is treated as having arrived on.
 
 ```typescript sim-elbv2-https-listener
 /**
- * An HTTPS listener presenting a certificate simulated ACM issued.
+ * An HTTPS listener holding a certificate simulated ACM issued.
+ *
+ * No TLS is performed: the certificate is checked and held, and nothing is
+ * encrypted or presented to a client.
  */
 
 import { RequestCertificateCommand } from "@aws-sdk/client-acm";

--- a/docs/services/elbv2/sim-elbv2-https-listener.example.ts
+++ b/docs/services/elbv2/sim-elbv2-https-listener.example.ts
@@ -1,0 +1,73 @@
+/**
+ * An HTTPS listener presenting a certificate simulated ACM issued.
+ */
+
+import { RequestCertificateCommand } from "@aws-sdk/client-acm";
+import {
+  type Action,
+  CreateListenerCommand,
+  CreateLoadBalancerCommand,
+  CreateTargetGroupCommand,
+} from "@aws-sdk/client-elastic-load-balancing-v2";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const elbV2 = simAws.elbV2();
+
+const certificate = await simAws
+  .acm()
+  .requestCertificate(
+    new RequestCertificateCommand({ DomainName: "shop.example.com" }),
+  );
+
+// A certificate no hosted zone covers issues on its own, once the simulation's
+// background work has run.
+await simAws.backgroundTasksComplete();
+
+const loadBalancer = await elbV2.createLoadBalancer(
+  new CreateLoadBalancerCommand({ Name: "shop-alb" }),
+);
+const targetGroup = await elbV2.createTargetGroup(
+  new CreateTargetGroupCommand({ Name: "checkout-tg", TargetType: "lambda" }),
+);
+
+const loadBalancerArn = loadBalancer.LoadBalancers?.[0]?.LoadBalancerArn;
+const forward: Action = {
+  Type: "forward",
+  TargetGroupArn: targetGroup.TargetGroups?.[0]?.TargetGroupArn,
+};
+
+const listener = await elbV2.createListener(
+  new CreateListenerCommand({
+    LoadBalancerArn: loadBalancerArn,
+    Protocol: "HTTPS",
+    Port: 443,
+    Certificates: [{ CertificateArn: certificate.CertificateArn }],
+    DefaultActions: [forward],
+  }),
+);
+
+// A listener that named no security policy gets the one real ELB gives it.
+console.log(listener.Listeners?.[0]?.SslPolicy); // "ELBSecurityPolicy-2016-08"
+
+try {
+  await elbV2.createListener(
+    new CreateListenerCommand({
+      LoadBalancerArn: loadBalancerArn,
+      Protocol: "HTTPS",
+      Port: 8443,
+      Certificates: [
+        {
+          CertificateArn:
+            "arn:aws:acm:us-east-1:888888888888:certificate/00000009",
+        },
+      ],
+      DefaultActions: [forward],
+    }),
+  );
+} catch (error) {
+  // Certificate arn:aws:acm:us-east-1:888888888888:certificate/00000009 was
+  // not found in simulated ACM
+  console.log((error as Error).message);
+}

--- a/docs/services/elbv2/sim-elbv2-https-listener.example.ts
+++ b/docs/services/elbv2/sim-elbv2-https-listener.example.ts
@@ -1,5 +1,8 @@
 /**
- * An HTTPS listener presenting a certificate simulated ACM issued.
+ * An HTTPS listener holding a certificate simulated ACM issued.
+ *
+ * No TLS is performed: the certificate is checked and held, and nothing is
+ * encrypted or presented to a client.
  */
 
 import { RequestCertificateCommand } from "@aws-sdk/client-acm";

--- a/docs/services/elbv2/sim-elbv2-listener-certificates.example.ts
+++ b/docs/services/elbv2/sim-elbv2-listener-certificates.example.ts
@@ -1,0 +1,77 @@
+/**
+ * The certificates a listener carries beyond its default one.
+ */
+
+import { RequestCertificateCommand } from "@aws-sdk/client-acm";
+import {
+  AddListenerCertificatesCommand,
+  CreateListenerCommand,
+  CreateLoadBalancerCommand,
+  CreateTargetGroupCommand,
+  DescribeListenerCertificatesCommand,
+  RemoveListenerCertificatesCommand,
+} from "@aws-sdk/client-elastic-load-balancing-v2";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const acm = simAws.acm();
+const elbV2 = simAws.elbV2();
+
+async function issuedCertificateArn(domainName: string): Promise<string> {
+  const requested = await acm.requestCertificate(
+    new RequestCertificateCommand({ DomainName: domainName }),
+  );
+
+  await simAws.backgroundTasksComplete();
+
+  return requested.CertificateArn ?? "";
+}
+
+const shop = await issuedCertificateArn("shop.example.com");
+const admin = await issuedCertificateArn("admin.example.com");
+
+const loadBalancer = await elbV2.createLoadBalancer(
+  new CreateLoadBalancerCommand({ Name: "shop-alb" }),
+);
+const targetGroup = await elbV2.createTargetGroup(
+  new CreateTargetGroupCommand({ Name: "checkout-tg", TargetType: "lambda" }),
+);
+
+const listener = await elbV2.createListener(
+  new CreateListenerCommand({
+    LoadBalancerArn: loadBalancer.LoadBalancers?.[0]?.LoadBalancerArn,
+    Protocol: "HTTPS",
+    Port: 443,
+    Certificates: [{ CertificateArn: shop }],
+    DefaultActions: [
+      {
+        Type: "forward",
+        TargetGroupArn: targetGroup.TargetGroups?.[0]?.TargetGroupArn,
+      },
+    ],
+  }),
+);
+
+const listenerArn = listener.Listeners?.[0]?.ListenerArn;
+
+await elbV2.addListenerCertificates(
+  new AddListenerCertificatesCommand({
+    ListenerArn: listenerArn,
+    Certificates: [{ CertificateArn: admin }],
+  }),
+);
+
+const carried = await elbV2.describeListenerCertificates(
+  new DescribeListenerCertificatesCommand({ ListenerArn: listenerArn }),
+);
+
+// The default certificate comes first and is the only one flagged as such.
+console.log(carried.Certificates?.map((each) => each.IsDefault)); // [true, false]
+
+await elbV2.removeListenerCertificates(
+  new RemoveListenerCertificatesCommand({
+    ListenerArn: listenerArn,
+    Certificates: [{ CertificateArn: admin }],
+  }),
+);

--- a/src/service/aws/factory/sim-aws-account-region-service-builder.ts
+++ b/src/service/aws/factory/sim-aws-account-region-service-builder.ts
@@ -185,13 +185,13 @@ export class SimAwsAccountRegionServiceBuilder {
   /**
    * Create simulated Elastic Load Balancing v2 for an Account Region scope.
    *
-   * The registry is what gets a request from a load balancer's DNS name to the
-   * scope holding it, since a host name names neither an Account nor a Region.
+   * The registries are the hops from a name to a scope: a load balancer's DNS
+   * name to the Account holding it, and a listener's certificate ARN to ACM.
    */
   createElbV2(scope: SimAwsAccountRegionContainer): SimElbV2 {
-    const registry = this.registries.elbV2;
+    const { elbV2: registry, acm: acmRegistry } = this.registries;
 
-    return new SimElbV2({ ...this.scoped(scope), registry });
+    return new SimElbV2({ ...this.scoped(scope), registry, acmRegistry });
   }
 
   /**

--- a/src/service/elbv2/README.md
+++ b/src/service/elbv2/README.md
@@ -61,6 +61,20 @@ a request is the worst of the three outcomes. `SimElbV2WildcardPattern` is the w
 language, which is `*` and `?` compared against the whole value, and keeping it in one class is what
 makes the case sensitivity the only difference between a host name and a path.
 
+A listener's certificates are a `SimElbV2CertificateList` under `listener/certificate/` rather than
+the list a request sent. Everything that can be asked about a certificate depends on whether it is
+the default one, which is the certificate a described listener reports, the one `ModifyListener`
+replaces and the one `RemoveListenerCertificates` will not take away, so the default and the rest are
+held apart rather than told apart by a flag on each.
+
+`SimElbV2CertificateResolver` is the hop from a certificate ARN to the certificate it names, through
+`SimAcmRegistry`, which is the same route simulated CloudFront takes to check a viewer certificate. A
+certificate that does not exist, that is not `ISSUED`, or that is outside the load balancer's own
+Account and Region is refused when the listener is written, because that refusal is the thing worth
+having: nothing here performs TLS, so the configuration relationship is the whole of what a test can
+be written about. With no ACM registry, as in a standalone `SimElbV2`, there is no simulated ACM to
+ask and nothing is checked.
+
 `SimElbV2ListenerRuleStore` owns priority uniqueness, because it is a property of a listener's whole
 set of rules rather than of any one rule. `SetRulePriorities` judges a request against the order it
 would leave behind rather than the one it started from, which is what lets two rules swap places in
@@ -80,6 +94,8 @@ handler per operation, so the `SimElbV2` facade stays a list of delegations:
 - `command/target-group/` — the target group create, describe, modify and delete
 - `command/target/` — `RegisterTargets`, `DeregisterTargets`, `DescribeTargetHealth`
 - `command/listener/` — the listener create, describe, modify and delete
+- `command/listener-certificate/` — `AddListenerCertificates`, `RemoveListenerCertificates` and
+  `DescribeListenerCertificates`
 - `command/rule/` — the rule create, describe, modify and delete, and `SetRulePriorities`
 - `command/authorize/` — the shared IAM authorizer
 - `command/sim-elbv2-command-handler.ts` — the collaborators every handler holds
@@ -171,6 +187,13 @@ There is no resource policy support here, and none to add: ELBv2 has none on rea
   did not capture. The shape is the real one either way. The ARN id counts within one scope, because
   an ARN already names the Account; the DNS name counts across the whole simulation, because a host
   name names nothing but itself and two Accounts issued the same one could not both answer on it.
+- No TLS is performed on an HTTPS listener. Nothing is encrypted and no certificate is presented, so
+  what is simulated is the configuration relationship and the protocol a request is treated as
+  arriving on. The listener's protocol is what the forwarding headers report, the URL scheme is not
+  checked against it, and nothing selects between the certificates a listener carries, since there is
+  no handshake to select in.
+- A security policy is held and reported and nothing acts on it. A listener that names none gets the
+  one real ELB defaults to, so a test reading it back sees the real value.
 - A listener or rule takes exactly one action. Real ELB takes one routing action with an optional
   authentication action before it, and neither authentication action is simulated, so a longer list
   is refused rather than half honoured.

--- a/src/service/elbv2/command/listener-certificate/add-listener-certificates.handler.ts
+++ b/src/service/elbv2/command/listener-certificate/add-listener-certificates.handler.ts
@@ -1,0 +1,77 @@
+import type { CommandHandler } from "../../../../command/command-handler.js";
+import { SimElbV2ValidationError } from "../../error/sim-elbv2.error.js";
+import { simElbV2CertificateArns } from "../../listener/certificate/sim-elbv2-certificate-arns.js";
+import type { SimElbV2CertificateResolver } from "../../listener/certificate/sim-elbv2-certificate-resolver.js";
+import {
+  SimElbV2CommandHandler,
+  type SimElbV2CommandHandlerProperties,
+} from "../sim-elbv2-command-handler.js";
+import type { SimElbV2RequestOptions } from "../sim-elbv2-request-options.js";
+import type {
+  SimAddListenerCertificatesCommand,
+  SimAddListenerCertificatesCommandOutput,
+} from "./listener-certificate.command.js";
+
+interface AddListenerCertificatesCommandHandlerProperties extends SimElbV2CommandHandlerProperties {
+  readonly certificates: SimElbV2CertificateResolver;
+}
+
+/**
+ * Simulated ELBv2 AddListenerCertificatesCommand handler.
+ *
+ * https://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_AddListenerCertificates.html
+ */
+export class AddListenerCertificatesCommandHandler
+  extends SimElbV2CommandHandler
+  implements
+    CommandHandler<
+      SimAddListenerCertificatesCommand,
+      SimAddListenerCertificatesCommandOutput
+    >
+{
+  private readonly certificates: SimElbV2CertificateResolver;
+
+  constructor(properties: AddListenerCertificatesCommandHandlerProperties) {
+    super(properties);
+    this.certificates = properties.certificates;
+  }
+
+  /**
+   * Carry more certificates on a listener, beyond its default one.
+   *
+   * `IsDefault` is read from none of them, which is what real ELB documents:
+   * the default certificate is the one `ModifyListener` names, and this
+   * operation is the rest of the list.
+   */
+  async handle(
+    command: SimAddListenerCertificatesCommand,
+    options?: SimElbV2RequestOptions,
+  ): Promise<SimAddListenerCertificatesCommandOutput> {
+    const { input } = command;
+
+    if (input.ListenerArn === undefined) {
+      throw new SimElbV2ValidationError("ListenerArn is required");
+    }
+
+    const certificateArns = simElbV2CertificateArns(
+      input.Certificates,
+      "Certificates",
+    );
+
+    // Allow for potential non-deterministic sequencing of async events.
+    await this.background.sequence();
+
+    this.authorizer.authorize(
+      "AddListenerCertificates",
+      input.ListenerArn,
+      options,
+    );
+
+    const listener = this.stores.listeners.requireByArn(input.ListenerArn);
+
+    this.certificates.requireAllIssued(certificateArns);
+    listener.addCertificates(certificateArns);
+
+    return { $metadata: {}, Certificates: listener.certificates };
+  }
+}

--- a/src/service/elbv2/command/listener-certificate/describe-listener-certificates.handler.ts
+++ b/src/service/elbv2/command/listener-certificate/describe-listener-certificates.handler.ts
@@ -1,0 +1,62 @@
+import type { CommandHandler } from "../../../../command/command-handler.js";
+import { SimElbV2ValidationError } from "../../error/sim-elbv2.error.js";
+import { SimElbV2CommandHandler } from "../sim-elbv2-command-handler.js";
+import { SimElbV2Page } from "../sim-elbv2-page.js";
+import type { SimElbV2RequestOptions } from "../sim-elbv2-request-options.js";
+import type {
+  SimDescribeListenerCertificatesCommand,
+  SimDescribeListenerCertificatesCommandOutput,
+} from "./listener-certificate.command.js";
+
+/**
+ * Simulated ELBv2 DescribeListenerCertificatesCommand handler.
+ *
+ * https://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_DescribeListenerCertificates.html
+ */
+export class DescribeListenerCertificatesCommandHandler
+  extends SimElbV2CommandHandler
+  implements
+    CommandHandler<
+      SimDescribeListenerCertificatesCommand,
+      SimDescribeListenerCertificatesCommandOutput
+    >
+{
+  /**
+   * Report the certificates one listener carries.
+   *
+   * The default certificate comes first and is the only one flagged as such,
+   * so a reader can tell which certificate the listener would present to a
+   * client asking for no particular host name.
+   */
+  async handle(
+    command: SimDescribeListenerCertificatesCommand,
+    options?: SimElbV2RequestOptions,
+  ): Promise<SimDescribeListenerCertificatesCommandOutput> {
+    const { input } = command;
+
+    if (input.ListenerArn === undefined) {
+      throw new SimElbV2ValidationError("ListenerArn is required");
+    }
+
+    // Allow for potential non-deterministic sequencing of async events.
+    await this.background.sequence();
+
+    this.authorizer.authorizeAnyResource(
+      "DescribeListenerCertificates",
+      options,
+    );
+
+    const listener = this.stores.listeners.requireByArn(input.ListenerArn);
+    const page = new SimElbV2Page(
+      listener.certificates,
+      input.PageSize,
+      input.Marker,
+    );
+
+    return {
+      $metadata: {},
+      Certificates: page.items,
+      NextMarker: page.nextMarker,
+    };
+  }
+}

--- a/src/service/elbv2/command/listener-certificate/listener-certificate.command.ts
+++ b/src/service/elbv2/command/listener-certificate/listener-certificate.command.ts
@@ -1,0 +1,74 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type { SimElbV2Certificate } from "../sim-elbv2-shared.command.js";
+
+/**
+ * Minimal structural sim ELBv2 AddListenerCertificates command.
+ */
+export interface SimAddListenerCertificatesCommand {
+  readonly input: SimAddListenerCertificatesCommandInput;
+}
+
+/**
+ * Minimal structural sim ELBv2 AddListenerCertificates input.
+ *
+ * https://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_AddListenerCertificates.html
+ */
+export interface SimAddListenerCertificatesCommandInput {
+  readonly ListenerArn?: string | undefined;
+  readonly Certificates?: readonly SimElbV2Certificate[] | undefined;
+}
+
+/**
+ * Minimal structural sim ELBv2 AddListenerCertificates output.
+ */
+export interface SimAddListenerCertificatesCommandOutput {
+  readonly Certificates?: readonly SimElbV2Certificate[] | undefined;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim ELBv2 RemoveListenerCertificates command.
+ */
+export interface SimRemoveListenerCertificatesCommand {
+  readonly input: SimRemoveListenerCertificatesCommandInput;
+}
+
+/**
+ * Minimal structural sim ELBv2 RemoveListenerCertificates input.
+ */
+export interface SimRemoveListenerCertificatesCommandInput {
+  readonly ListenerArn?: string | undefined;
+  readonly Certificates?: readonly SimElbV2Certificate[] | undefined;
+}
+
+/**
+ * Minimal structural sim ELBv2 RemoveListenerCertificates output.
+ */
+export interface SimRemoveListenerCertificatesCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim ELBv2 DescribeListenerCertificates command.
+ */
+export interface SimDescribeListenerCertificatesCommand {
+  readonly input: SimDescribeListenerCertificatesCommandInput;
+}
+
+/**
+ * Minimal structural sim ELBv2 DescribeListenerCertificates input.
+ */
+export interface SimDescribeListenerCertificatesCommandInput {
+  readonly ListenerArn?: string | undefined;
+  readonly Marker?: string | undefined;
+  readonly PageSize?: number | undefined;
+}
+
+/**
+ * Minimal structural sim ELBv2 DescribeListenerCertificates output.
+ */
+export interface SimDescribeListenerCertificatesCommandOutput {
+  readonly Certificates?: readonly SimElbV2Certificate[] | undefined;
+  readonly NextMarker?: string | undefined;
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/elbv2/command/listener-certificate/listener-certificate.iso.test.ts
+++ b/src/service/elbv2/command/listener-certificate/listener-certificate.iso.test.ts
@@ -1,0 +1,319 @@
+import {
+  AddListenerCertificatesCommand,
+  DescribeListenerCertificatesCommand,
+  RemoveListenerCertificatesCommand,
+} from "@aws-sdk/client-elastic-load-balancing-v2";
+import {
+  assertArrayLength,
+  assertFalse,
+  assertIdentical,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertTrue,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import {
+  SimElbV2CertificateNotFoundException,
+  SimElbV2InvalidConfigurationRequestException,
+  SimElbV2ListenerNotFoundException,
+  SimElbV2OperationNotPermittedException,
+  SimElbV2ValidationError,
+} from "../../error/sim-elbv2.error.js";
+import type { SimElbV2 } from "../../sim-elbv2.js";
+import {
+  createFixtureCertificate,
+  createFixtureHttpsListener,
+  createFixtureLambdaTargetGroup,
+  createFixtureListener,
+  createFixtureLoadBalancer,
+} from "../../sim-elbv2.fixture.js";
+
+/**
+ * What a test about a listener's certificate list starts from.
+ */
+interface CertificateFixture {
+  readonly elbV2: SimElbV2;
+  readonly listenerArn: string;
+  readonly defaultCertificateArn: string;
+  readonly adminCertificateArn: string;
+}
+
+/**
+ * An HTTPS listener with one certificate on it, and a second issued
+ * certificate for a test to add.
+ */
+async function makeHttpsListener(simAws: SimAws): Promise<CertificateFixture> {
+  const elbV2 = simAws.elbV2();
+  const loadBalancerArn = await createFixtureLoadBalancer(elbV2);
+  const targetGroupArn = await createFixtureLambdaTargetGroup(elbV2);
+  const defaultCertificateArn = await createFixtureCertificate(simAws);
+  const adminCertificateArn = await createFixtureCertificate(
+    simAws,
+    simAws.acm(),
+    "admin.example.com",
+  );
+  const listenerArn = await createFixtureHttpsListener(
+    elbV2,
+    loadBalancerArn,
+    targetGroupArn,
+    defaultCertificateArn,
+  );
+
+  return { elbV2, listenerArn, defaultCertificateArn, adminCertificateArn };
+}
+
+describe("ELBv2 listener certificates", () => {
+  it("adds a certificate, reports it and takes it off again", async () => {
+    // Given an HTTPS listener with its default certificate.
+    const simAws = new SimAws();
+    const { elbV2, listenerArn, defaultCertificateArn, adminCertificateArn } =
+      await makeHttpsListener(simAws);
+
+    // When a second certificate is added, described and then removed.
+    await elbV2.addListenerCertificates(
+      new AddListenerCertificatesCommand({
+        ListenerArn: listenerArn,
+        Certificates: [{ CertificateArn: adminCertificateArn }],
+      }),
+    );
+    const carried = await elbV2.describeListenerCertificates(
+      new DescribeListenerCertificatesCommand({ ListenerArn: listenerArn }),
+    );
+
+    await elbV2.removeListenerCertificates(
+      new RemoveListenerCertificatesCommand({
+        ListenerArn: listenerArn,
+        Certificates: [{ CertificateArn: adminCertificateArn }],
+      }),
+    );
+
+    const remaining = await elbV2.describeListenerCertificates(
+      new DescribeListenerCertificatesCommand({ ListenerArn: listenerArn }),
+    );
+
+    // Then both were reported while it was on, the default one flagged as
+    // such, and the listener kept its default when the other came off.
+    assertArrayLength(carried.Certificates, 2);
+    assertIdentical(
+      carried.Certificates[0].CertificateArn,
+      defaultCertificateArn,
+    );
+    assertTrue(carried.Certificates[0].IsDefault);
+    assertIdentical(
+      carried.Certificates[1].CertificateArn,
+      adminCertificateArn,
+    );
+    assertFalse(carried.Certificates[1].IsDefault);
+    assertArrayLength(remaining.Certificates, 1);
+    assertIdentical(
+      remaining.Certificates[0].CertificateArn,
+      defaultCertificateArn,
+    );
+  });
+
+  it("carries a certificate added twice once", async () => {
+    // Given an HTTPS listener.
+    const simAws = new SimAws();
+    const { elbV2, listenerArn, defaultCertificateArn, adminCertificateArn } =
+      await makeHttpsListener(simAws);
+
+    // When the same certificate is added twice, and the default one is added
+    // to the list it is already the head of.
+    const add = new AddListenerCertificatesCommand({
+      ListenerArn: listenerArn,
+      Certificates: [{ CertificateArn: adminCertificateArn }],
+    });
+
+    await elbV2.addListenerCertificates(add);
+    await elbV2.addListenerCertificates(add);
+    await elbV2.addListenerCertificates(
+      new AddListenerCertificatesCommand({
+        ListenerArn: listenerArn,
+        Certificates: [{ CertificateArn: defaultCertificateArn }],
+      }),
+    );
+
+    const carried = await elbV2.describeListenerCertificates(
+      new DescribeListenerCertificatesCommand({ ListenerArn: listenerArn }),
+    );
+
+    // Then the listener carries each once, as real ELB answers the second
+    // request successfully without listing the certificate twice.
+    assertArrayLength(carried.Certificates, 2);
+    assertTrue(carried.Certificates[0].IsDefault);
+  });
+
+  it("refuses to take the default certificate off a listener", async () => {
+    // Given an HTTPS listener with its default certificate.
+    const simAws = new SimAws();
+    const { elbV2, listenerArn, defaultCertificateArn } =
+      await makeHttpsListener(simAws);
+
+    // When a request tries to remove it.
+    const error = await assertThrowsErrorAsync(async () => {
+      await elbV2.removeListenerCertificates(
+        new RemoveListenerCertificatesCommand({
+          ListenerArn: listenerArn,
+          Certificates: [{ CertificateArn: defaultCertificateArn }],
+        }),
+      );
+    });
+
+    assertInstanceOf(error, SimElbV2OperationNotPermittedException);
+
+    // Then it is refused, naming what replaces a default certificate instead.
+    assertStringIncludes(error.message, defaultCertificateArn);
+    assertStringIncludes(error.message, "ModifyListener");
+  });
+
+  it("refuses a certificate simulated ACM does not hold as issued", async () => {
+    // Given an HTTPS listener and a certificate still pending validation.
+    const simAws = new SimAws();
+    const { elbV2, listenerArn } = await makeHttpsListener(simAws);
+    const pending = await simAws
+      .acm()
+      .requireDnsValidation()
+      .requestCertificate({ input: { DomainName: "orders.example.com" } });
+
+    await simAws.backgroundTasksComplete();
+
+    // When each is added to the listener.
+    const missing = await assertThrowsErrorAsync(async () => {
+      await elbV2.addListenerCertificates(
+        new AddListenerCertificatesCommand({
+          ListenerArn: listenerArn,
+          Certificates: [
+            {
+              CertificateArn:
+                "arn:aws:acm:us-east-1:888888888888:certificate/00000009",
+            },
+          ],
+        }),
+      );
+    });
+
+    assertInstanceOf(missing, SimElbV2CertificateNotFoundException);
+
+    const notIssued = await assertThrowsErrorAsync(async () => {
+      await elbV2.addListenerCertificates(
+        new AddListenerCertificatesCommand({
+          ListenerArn: listenerArn,
+          Certificates: [{ CertificateArn: pending.CertificateArn }],
+        }),
+      );
+    });
+
+    assertInstanceOf(notIssued, SimElbV2InvalidConfigurationRequestException);
+
+    // Then both are refused, the same way a listener's own certificate is.
+    assertStringIncludes(missing.message, "not found in simulated ACM");
+    assertStringIncludes(notIssued.message, "not ISSUED");
+  });
+
+  it("refuses a certificate on a listener that speaks no TLS", async () => {
+    // Given an HTTP listener.
+    const simAws = new SimAws();
+    const elbV2 = simAws.elbV2();
+    const loadBalancerArn = await createFixtureLoadBalancer(elbV2);
+    const targetGroupArn = await createFixtureLambdaTargetGroup(elbV2);
+    const listenerArn = await createFixtureListener(
+      elbV2,
+      loadBalancerArn,
+      targetGroupArn,
+    );
+    const certificateArn = await createFixtureCertificate(simAws);
+
+    // When a certificate is added to it.
+    const error = await assertThrowsErrorAsync(async () => {
+      await elbV2.addListenerCertificates(
+        new AddListenerCertificatesCommand({
+          ListenerArn: listenerArn,
+          Certificates: [{ CertificateArn: certificateArn }],
+        }),
+      );
+    });
+
+    assertInstanceOf(error, SimElbV2InvalidConfigurationRequestException);
+
+    // Then it is refused rather than held where nothing would present it.
+    assertStringIncludes(error.message, "HTTPS listener");
+  });
+
+  it("reports no certificates for a listener carrying none", async () => {
+    // Given an HTTP listener.
+    const simAws = new SimAws();
+    const elbV2 = simAws.elbV2();
+    const loadBalancerArn = await createFixtureLoadBalancer(elbV2);
+    const targetGroupArn = await createFixtureLambdaTargetGroup(elbV2);
+    const listenerArn = await createFixtureListener(
+      elbV2,
+      loadBalancerArn,
+      targetGroupArn,
+    );
+
+    // When its certificates are described.
+    const output = await elbV2.describeListenerCertificates(
+      new DescribeListenerCertificatesCommand({ ListenerArn: listenerArn }),
+    );
+
+    // Then it carries none.
+    assertArrayLength(output.Certificates, 0);
+  });
+
+  it("refuses a request naming no listener or no certificate", async () => {
+    // Given an HTTPS listener.
+    const simAws = new SimAws();
+    const { elbV2, listenerArn, adminCertificateArn } =
+      await makeHttpsListener(simAws);
+
+    // When requests leave out the listener, the certificates, or name a
+    // listener that does not exist.
+    const noListener = await assertThrowsErrorAsync(async () => {
+      await elbV2.addListenerCertificates({
+        input: { Certificates: [{ CertificateArn: adminCertificateArn }] },
+      });
+    });
+
+    assertInstanceOf(noListener, SimElbV2ValidationError);
+
+    const noCertificates = await assertThrowsErrorAsync(async () => {
+      await elbV2.removeListenerCertificates({
+        input: { ListenerArn: listenerArn },
+      });
+    });
+
+    assertInstanceOf(noCertificates, SimElbV2ValidationError);
+
+    const noRemoveListener = await assertThrowsErrorAsync(async () => {
+      await elbV2.removeListenerCertificates({
+        input: { Certificates: [{ CertificateArn: adminCertificateArn }] },
+      });
+    });
+
+    assertInstanceOf(noRemoveListener, SimElbV2ValidationError);
+
+    const noDescribeListener = await assertThrowsErrorAsync(async () => {
+      await elbV2.describeListenerCertificates({ input: {} });
+    });
+
+    assertInstanceOf(noDescribeListener, SimElbV2ValidationError);
+
+    const unknown = await assertThrowsErrorAsync(async () => {
+      await elbV2.describeListenerCertificates(
+        new DescribeListenerCertificatesCommand({ ListenerArn: "arn:missing" }),
+      );
+    });
+
+    assertInstanceOf(unknown, SimElbV2ListenerNotFoundException);
+
+    // Then each is refused.
+    assertStringIncludes(noListener.message, "ListenerArn is required");
+    assertStringIncludes(noRemoveListener.message, "ListenerArn is required");
+    assertStringIncludes(noCertificates.message, "at least one certificate");
+    assertStringIncludes(noDescribeListener.message, "ListenerArn is required");
+    assertStringIncludes(unknown.message, "arn:missing");
+  });
+});

--- a/src/service/elbv2/command/listener-certificate/remove-listener-certificates.handler.ts
+++ b/src/service/elbv2/command/listener-certificate/remove-listener-certificates.handler.ts
@@ -1,0 +1,61 @@
+import type { CommandHandler } from "../../../../command/command-handler.js";
+import { SimElbV2ValidationError } from "../../error/sim-elbv2.error.js";
+import { simElbV2CertificateArns } from "../../listener/certificate/sim-elbv2-certificate-arns.js";
+import { SimElbV2CommandHandler } from "../sim-elbv2-command-handler.js";
+import type { SimElbV2RequestOptions } from "../sim-elbv2-request-options.js";
+import type {
+  SimRemoveListenerCertificatesCommand,
+  SimRemoveListenerCertificatesCommandOutput,
+} from "./listener-certificate.command.js";
+
+/**
+ * Simulated ELBv2 RemoveListenerCertificatesCommand handler.
+ *
+ * https://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_RemoveListenerCertificates.html
+ */
+export class RemoveListenerCertificatesCommandHandler
+  extends SimElbV2CommandHandler
+  implements
+    CommandHandler<
+      SimRemoveListenerCertificatesCommand,
+      SimRemoveListenerCertificatesCommandOutput
+    >
+{
+  /**
+   * Stop a listener carrying certificates.
+   *
+   * The certificates are not looked for in simulated ACM, only in the
+   * listener's own list: a certificate that has stopped being an issued one is
+   * exactly the certificate someone would be taking off a listener.
+   */
+  async handle(
+    command: SimRemoveListenerCertificatesCommand,
+    options?: SimElbV2RequestOptions,
+  ): Promise<SimRemoveListenerCertificatesCommandOutput> {
+    const { input } = command;
+
+    if (input.ListenerArn === undefined) {
+      throw new SimElbV2ValidationError("ListenerArn is required");
+    }
+
+    const certificateArns = simElbV2CertificateArns(
+      input.Certificates,
+      "Certificates",
+    );
+
+    // Allow for potential non-deterministic sequencing of async events.
+    await this.background.sequence();
+
+    this.authorizer.authorize(
+      "RemoveListenerCertificates",
+      input.ListenerArn,
+      options,
+    );
+
+    this.stores.listeners
+      .requireByArn(input.ListenerArn)
+      .removeCertificates(certificateArns);
+
+    return { $metadata: {} };
+  }
+}

--- a/src/service/elbv2/command/listener/create-listener-request.ts
+++ b/src/service/elbv2/command/listener/create-listener-request.ts
@@ -1,0 +1,71 @@
+import { SimElbV2Action } from "../../action/sim-elbv2-action.js";
+import { SimElbV2ValidationError } from "../../error/sim-elbv2.error.js";
+import { SimElbV2Listener } from "../../listener/sim-elbv2-listener.js";
+import { simElbV2Port, simElbV2Protocol } from "../../sim-elbv2-protocol.js";
+import type { SimElbV2Certificate } from "../sim-elbv2-shared.command.js";
+import type { SimCreateListenerCommandInput } from "./listener.command.js";
+
+/**
+ * What building a listener needs that the request itself does not carry.
+ */
+interface SimElbV2NewListenerProperties {
+  readonly loadBalancerArn: string;
+  readonly id: string;
+  readonly certificateArn: string | undefined;
+}
+
+/**
+ * What a CreateListener request asks for, read once and checked.
+ *
+ * Reading the request is held apart from carrying it out because the two answer
+ * to different things: this is the shape of the input real ELB takes, and the
+ * handler is the order the simulation does the work in. It also leaves the
+ * handler short enough to read in one go.
+ */
+export class SimElbV2CreateListenerRequest {
+  public readonly loadBalancerArn: string;
+  public readonly port: number;
+  public readonly protocol: string;
+  public readonly certificates: readonly SimElbV2Certificate[] | undefined;
+  public readonly defaultActions: readonly SimElbV2Action[];
+
+  private readonly sslPolicy: string | undefined;
+
+  constructor(input: SimCreateListenerCommandInput) {
+    if (input.LoadBalancerArn === undefined) {
+      throw new SimElbV2ValidationError("LoadBalancerArn is required");
+    }
+
+    if (input.Protocol === undefined || input.Port === undefined) {
+      throw new SimElbV2ValidationError(
+        "A listener requires a Protocol and a Port",
+      );
+    }
+
+    this.loadBalancerArn = input.LoadBalancerArn;
+    this.protocol = simElbV2Protocol("Protocol", input.Protocol);
+    this.port = simElbV2Port("Port", input.Port);
+    this.sslPolicy = input.SslPolicy;
+    this.certificates = input.Certificates;
+    this.defaultActions = SimElbV2Action.readAll(
+      input.DefaultActions,
+      "DefaultActions",
+    );
+  }
+
+  /**
+   * Build the listener this request asks for, once everything it names has been
+   * resolved.
+   */
+  listener(properties: SimElbV2NewListenerProperties): SimElbV2Listener {
+    return new SimElbV2Listener({
+      loadBalancerArn: properties.loadBalancerArn,
+      id: properties.id,
+      port: this.port,
+      protocol: this.protocol,
+      sslPolicy: this.sslPolicy,
+      certificateArn: properties.certificateArn,
+      defaultActions: this.defaultActions,
+    });
+  }
+}

--- a/src/service/elbv2/command/listener/create-listener.handler.ts
+++ b/src/service/elbv2/command/listener/create-listener.handler.ts
@@ -1,15 +1,13 @@
 import type { CommandHandler } from "../../../../command/command-handler.js";
-import { SimElbV2Action } from "../../action/sim-elbv2-action.js";
 import type { SimElbV2ActionTargets } from "../../action/sim-elbv2-action-targets.js";
-import { SimElbV2ValidationError } from "../../error/sim-elbv2.error.js";
-import { SimElbV2Listener } from "../../listener/sim-elbv2-listener.js";
-import { simElbV2Port, simElbV2Protocol } from "../../sim-elbv2-protocol.js";
+import type { SimElbV2CertificateResolver } from "../../listener/certificate/sim-elbv2-certificate-resolver.js";
 import { simElbV2ResourceId } from "../../sim-elbv2-resource-id.js";
 import {
   SimElbV2CommandHandler,
   type SimElbV2CommandHandlerProperties,
 } from "../sim-elbv2-command-handler.js";
 import type { SimElbV2RequestOptions } from "../sim-elbv2-request-options.js";
+import { SimElbV2CreateListenerRequest } from "./create-listener-request.js";
 import type {
   SimCreateListenerCommand,
   SimCreateListenerCommandOutput,
@@ -17,6 +15,7 @@ import type {
 
 interface CreateListenerCommandHandlerProperties extends SimElbV2CommandHandlerProperties {
   readonly actionTargets: SimElbV2ActionTargets;
+  readonly certificates: SimElbV2CertificateResolver;
 }
 
 /**
@@ -30,10 +29,12 @@ export class CreateListenerCommandHandler
     CommandHandler<SimCreateListenerCommand, SimCreateListenerCommandOutput>
 {
   private readonly actionTargets: SimElbV2ActionTargets;
+  private readonly certificates: SimElbV2CertificateResolver;
 
   constructor(properties: CreateListenerCommandHandlerProperties) {
     super(properties);
     this.actionTargets = properties.actionTargets;
+    this.certificates = properties.certificates;
   }
 
   /**
@@ -42,50 +43,40 @@ export class CreateListenerCommandHandler
    * The listener is authorized against the load balancer it goes on, because
    * that is the resource the request names and the resource an IAM policy
    * would be written about.
+   *
+   * A certificate is resolved against simulated ACM alongside the target groups
+   * a forward action names, since both are things the request points at that
+   * have to exist for the listener to serve anything.
    */
   async handle(
     command: SimCreateListenerCommand,
     options?: SimElbV2RequestOptions,
   ): Promise<SimCreateListenerCommandOutput> {
-    const { input } = command;
-
-    if (input.LoadBalancerArn === undefined) {
-      throw new SimElbV2ValidationError("LoadBalancerArn is required");
-    }
-
-    if (input.Protocol === undefined || input.Port === undefined) {
-      throw new SimElbV2ValidationError(
-        "A listener requires a Protocol and a Port",
-      );
-    }
-
-    const protocol = simElbV2Protocol("Protocol", input.Protocol);
-    const port = simElbV2Port("Port", input.Port);
-    const defaultActions = SimElbV2Action.readAll(
-      input.DefaultActions,
-      "DefaultActions",
-    );
+    const request = new SimElbV2CreateListenerRequest(command.input);
 
     // Allow for potential non-deterministic sequencing of async events.
     await this.background.sequence();
 
-    this.authorizer.authorize("CreateListener", input.LoadBalancerArn, options);
-
-    const loadBalancer = this.stores.loadBalancers.requireByArn(
-      input.LoadBalancerArn,
+    this.authorizer.authorize(
+      "CreateListener",
+      request.loadBalancerArn,
+      options,
     );
 
-    this.actionTargets.requireTargetGroups(defaultActions);
-    this.stores.listeners.requirePortAvailable(loadBalancer.arn, port);
+    const loadBalancer = this.stores.loadBalancers.requireByArn(
+      request.loadBalancerArn,
+    );
 
-    const listener = new SimElbV2Listener({
+    this.actionTargets.requireTargetGroups(request.defaultActions);
+    this.stores.listeners.requirePortAvailable(loadBalancer.arn, request.port);
+
+    const listener = request.listener({
       loadBalancerArn: loadBalancer.arn,
       id: simElbV2ResourceId(this.stores.listeners.nextSequence()),
-      port,
-      protocol,
-      sslPolicy: input.SslPolicy,
-      certificates: input.Certificates ?? [],
-      defaultActions,
+      certificateArn: this.certificates.resolveDefault(
+        request.certificates,
+        "Certificates",
+      ),
     });
 
     this.stores.listeners.put(listener);

--- a/src/service/elbv2/command/listener/https-listener.iso.test.ts
+++ b/src/service/elbv2/command/listener/https-listener.iso.test.ts
@@ -113,24 +113,66 @@ describe("An HTTPS listener's certificate", () => {
     assertStringIncludes(error.message, "not ISSUED");
   });
 
-  it("refuses a certificate from another Region", async () => {
-    // Given an issued certificate in a Region the load balancer is not in.
+  it("refuses a certificate from another Region or Account", async () => {
+    // Given issued certificates in a Region and an Account the load balancer
+    // is not in.
     const simAws = new SimAws();
-    const certificateArn = await createFixtureCertificate(
+    const elsewhere = await createFixtureCertificate(
       simAws,
       simAws.region("eu-west-2").acm(),
     );
+    const otherAccount = await createFixtureCertificate(
+      simAws,
+      simAws.account("555555555555").region("us-east-1").acm(),
+    );
 
-    // When an HTTPS listener in the default Region names it.
+    // When HTTPS listeners in the default scope name them.
+    const region = await assertThrowsErrorAsync(async () => {
+      await createHttpsListener(simAws, [elsewhere]);
+    });
+
+    assertInstanceOf(region, SimElbV2InvalidConfigurationRequestException);
+
+    const account = await assertThrowsErrorAsync(async () => {
+      await createHttpsListener(simAws, [otherAccount], "other-alb");
+    });
+
+    assertInstanceOf(account, SimElbV2InvalidConfigurationRequestException);
+
+    // Then both are refused, as real ELB refuses a certificate from elsewhere.
+    assertStringIncludes(region.message, "eu-west-2");
+    assertStringIncludes(region.message, "own Account and Region");
+    assertStringIncludes(account.message, "555555555555");
+    assertStringIncludes(account.message, "own Account and Region");
+  });
+
+  it("refuses a listener that names a certificate and speaks no TLS", async () => {
+    // Given an issued certificate.
+    const simAws = new SimAws();
+    const certificateArn = await createFixtureCertificate(simAws);
+    const elbV2 = simAws.elbV2();
+    const loadBalancerArn = await createFixtureLoadBalancer(elbV2);
+    const targetGroupArn = await createFixtureLambdaTargetGroup(elbV2);
+
+    // When an HTTP listener names it.
     const error = await assertThrowsErrorAsync(async () => {
-      await createHttpsListener(simAws, [certificateArn]);
+      await elbV2.createListener(
+        new CreateListenerCommand({
+          LoadBalancerArn: loadBalancerArn,
+          Protocol: "HTTP",
+          Port: 80,
+          Certificates: [{ CertificateArn: certificateArn }],
+          DefaultActions: [{ Type: "forward", TargetGroupArn: targetGroupArn }],
+        }),
+      );
     });
 
     assertInstanceOf(error, SimElbV2InvalidConfigurationRequestException);
 
-    // Then it is refused, as real ELB refuses a certificate from elsewhere.
-    assertStringIncludes(error.message, "eu-west-2");
-    assertStringIncludes(error.message, "own Account and Region");
+    // Then it is refused rather than created with the certificate quietly
+    // dropped, which would leave a listener looking configured for HTTPS and
+    // answering plain HTTP.
+    assertStringIncludes(error.message, "HTTPS listener");
   });
 
   it("refuses a listener naming more than one certificate", async () => {

--- a/src/service/elbv2/command/listener/https-listener.iso.test.ts
+++ b/src/service/elbv2/command/listener/https-listener.iso.test.ts
@@ -1,0 +1,207 @@
+import { CreateListenerCommand } from "@aws-sdk/client-elastic-load-balancing-v2";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertTrue,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import {
+  SimElbV2CertificateNotFoundException,
+  SimElbV2InvalidConfigurationRequestException,
+  SimElbV2ValidationError,
+} from "../../error/sim-elbv2.error.js";
+import { SimElbV2 } from "../../sim-elbv2.js";
+import {
+  createFixtureCertificate,
+  createFixtureLambdaTargetGroup,
+  createFixtureLoadBalancer,
+} from "../../sim-elbv2.fixture.js";
+import type { SimCreateListenerCommandOutput } from "./listener.command.js";
+
+/**
+ * A certificate ARN of the shape ACM issues, naming a certificate no simulated
+ * ACM holds.
+ */
+const missingCertificateArn =
+  "arn:aws:acm:us-east-1:888888888888:certificate/00000009";
+
+/**
+ * Create an HTTPS listener with the certificates a test names.
+ */
+async function createHttpsListener(
+  simAws: SimAws,
+  certificateArns: readonly (string | undefined)[],
+  name = "shop-alb",
+): Promise<SimCreateListenerCommandOutput> {
+  const elbV2 = simAws.elbV2();
+  const loadBalancerArn = await createFixtureLoadBalancer(elbV2, name);
+  const targetGroupArn = await createFixtureLambdaTargetGroup(
+    elbV2,
+    `${name}-tg`,
+  );
+
+  return await elbV2.createListener(
+    new CreateListenerCommand({
+      LoadBalancerArn: loadBalancerArn,
+      Protocol: "HTTPS",
+      Port: 443,
+      Certificates: certificateArns.map((arn) => ({ CertificateArn: arn })),
+      DefaultActions: [{ Type: "forward", TargetGroupArn: targetGroupArn }],
+    }),
+  );
+}
+
+describe("An HTTPS listener's certificate", () => {
+  it("takes an issued certificate from simulated ACM", async () => {
+    // Given an issued certificate.
+    const simAws = new SimAws();
+    const certificateArn = await createFixtureCertificate(simAws);
+
+    // When an HTTPS listener names it.
+    const output = await createHttpsListener(simAws, [certificateArn]);
+
+    // Then the listener holds it as its default certificate.
+    assertArrayLength(output.Listeners, 1);
+    assertArrayLength(output.Listeners[0].Certificates, 1);
+    assertIdentical(
+      output.Listeners[0].Certificates[0].CertificateArn,
+      certificateArn,
+    );
+    assertTrue(output.Listeners[0].Certificates[0].IsDefault);
+  });
+
+  it("refuses a certificate simulated ACM does not hold, naming it", async () => {
+    // Given simulated ACM holding no such certificate.
+    const simAws = new SimAws();
+
+    // When an HTTPS listener names one anyway.
+    const error = await assertThrowsErrorAsync(async () => {
+      await createHttpsListener(simAws, [missingCertificateArn]);
+    });
+
+    assertInstanceOf(error, SimElbV2CertificateNotFoundException);
+
+    // Then it is refused with the ARN a reader has to go and fix.
+    assertStringIncludes(error.message, missingCertificateArn);
+    assertStringIncludes(error.message, "not found in simulated ACM");
+  });
+
+  it("refuses a certificate that is pending validation rather than issued", async () => {
+    // Given a certificate waiting on a DNS validation record nothing wrote.
+    const simAws = new SimAws();
+    const acm = simAws.acm().requireDnsValidation();
+    const requested = await acm.requestCertificate({
+      input: { DomainName: "shop.example.com" },
+    });
+
+    await simAws.backgroundTasksComplete();
+
+    // When an HTTPS listener names it.
+    const error = await assertThrowsErrorAsync(async () => {
+      await createHttpsListener(simAws, [requested.CertificateArn]);
+    });
+
+    assertInstanceOf(error, SimElbV2InvalidConfigurationRequestException);
+
+    // Then it is refused, since a listener presenting it could serve nothing.
+    assertStringIncludes(error.message, "PENDING_VALIDATION");
+    assertStringIncludes(error.message, "not ISSUED");
+  });
+
+  it("refuses a certificate from another Region", async () => {
+    // Given an issued certificate in a Region the load balancer is not in.
+    const simAws = new SimAws();
+    const certificateArn = await createFixtureCertificate(
+      simAws,
+      simAws.region("eu-west-2").acm(),
+    );
+
+    // When an HTTPS listener in the default Region names it.
+    const error = await assertThrowsErrorAsync(async () => {
+      await createHttpsListener(simAws, [certificateArn]);
+    });
+
+    assertInstanceOf(error, SimElbV2InvalidConfigurationRequestException);
+
+    // Then it is refused, as real ELB refuses a certificate from elsewhere.
+    assertStringIncludes(error.message, "eu-west-2");
+    assertStringIncludes(error.message, "own Account and Region");
+  });
+
+  it("refuses a listener naming more than one certificate", async () => {
+    // Given two issued certificates.
+    const simAws = new SimAws();
+    const shop = await createFixtureCertificate(simAws);
+    const admin = await createFixtureCertificate(
+      simAws,
+      simAws.acm(),
+      "admin.example.com",
+    );
+
+    // When one listener names both as its default.
+    const error = await assertThrowsErrorAsync(async () => {
+      await createHttpsListener(simAws, [shop, admin]);
+    });
+
+    assertInstanceOf(error, SimElbV2InvalidConfigurationRequestException);
+
+    // Then it is refused, with the operation the rest of them go on with.
+    assertStringIncludes(error.message, "one default certificate");
+    assertStringIncludes(error.message, "AddListenerCertificates");
+  });
+
+  it("refuses a certificate carrying no ARN, or something that is not one", async () => {
+    // Given simulated ELBv2.
+    const simAws = new SimAws();
+
+    // When a listener names a certificate with nothing in it, and one naming
+    // something that is not an ARN at all.
+    const empty = await assertThrowsErrorAsync(async () => {
+      await createHttpsListener(simAws, [undefined]);
+    });
+
+    assertInstanceOf(empty, SimElbV2ValidationError);
+
+    const notAnArn = await assertThrowsErrorAsync(async () => {
+      await createHttpsListener(simAws, ["shop.example.com"], "other-alb");
+    });
+
+    assertInstanceOf(notAnArn, SimElbV2ValidationError);
+
+    // Then each is refused.
+    assertStringIncludes(empty.message, "requires a CertificateArn");
+    assertStringIncludes(notAnArn.message, "not an ACM certificate ARN");
+  });
+
+  it("checks nothing where there is no simulated ACM to check against", async () => {
+    // Given a standalone simulated ELBv2, which has no ACM beside it.
+    const elbV2 = new SimElbV2();
+    const loadBalancerArn = await createFixtureLoadBalancer(elbV2);
+    const targetGroupArn = await createFixtureLambdaTargetGroup(elbV2);
+
+    // When an HTTPS listener names a certificate nothing issued.
+    const output = await elbV2.createListener({
+      input: {
+        LoadBalancerArn: loadBalancerArn,
+        Protocol: "HTTPS",
+        Port: 443,
+        Certificates: [{ CertificateArn: missingCertificateArn }],
+        DefaultActions: [{ Type: "forward", TargetGroupArn: targetGroupArn }],
+      },
+    });
+
+    // Then it is held as given, since refusing it would be refusing a
+    // certificate this simulation has no way of knowing anything about.
+    assertArrayLength(output.Listeners, 1);
+    assertArrayLength(output.Listeners[0].Certificates, 1);
+    assertIdentical(
+      output.Listeners[0].Certificates[0].CertificateArn,
+      missingCertificateArn,
+    );
+  });
+});

--- a/src/service/elbv2/command/listener/listener.iso.test.ts
+++ b/src/service/elbv2/command/listener/listener.iso.test.ts
@@ -24,14 +24,12 @@ import {
   SimElbV2ValidationError,
 } from "../../error/sim-elbv2.error.js";
 import {
+  createFixtureCertificate,
   createFixtureLambdaTargetGroup,
   createFixtureListener,
   createFixtureLoadBalancer,
   createFixtureRule,
 } from "../../sim-elbv2.fixture.js";
-
-const certificateArn =
-  "arn:aws:acm:eu-west-1:888888888888:certificate/00000001";
 
 describe("ELBv2 listeners", () => {
   it("creates an HTTP listener whose ARN is built from its load balancer's", async () => {
@@ -67,11 +65,12 @@ describe("ELBv2 listeners", () => {
   });
 
   it("gives an HTTPS listener a security policy, and refuses one with no certificate", async () => {
-    // Given a load balancer and a target group.
+    // Given a load balancer, a target group and an issued certificate.
     const simAws = new SimAws();
     const elbV2 = simAws.elbV2();
     const loadBalancerArn = await createFixtureLoadBalancer(elbV2);
     const targetGroupArn = await createFixtureLambdaTargetGroup(elbV2);
+    const certificateArn = await createFixtureCertificate(simAws);
 
     // When an HTTPS listener is created with and without a certificate.
     const output = await elbV2.createListener(
@@ -100,6 +99,11 @@ describe("ELBv2 listeners", () => {
     // Then the one with a certificate got a policy and the other was refused.
     assertArrayLength(output.Listeners, 1);
     assertIdentical(output.Listeners[0].SslPolicy, "ELBSecurityPolicy-2016-08");
+    assertArrayLength(output.Listeners[0].Certificates, 1);
+    assertIdentical(
+      output.Listeners[0].Certificates[0].CertificateArn,
+      certificateArn,
+    );
     assertStringIncludes(error.message, "at least one certificate");
   });
 

--- a/src/service/elbv2/command/listener/modify-listener.handler.ts
+++ b/src/service/elbv2/command/listener/modify-listener.handler.ts
@@ -2,6 +2,7 @@ import type { CommandHandler } from "../../../../command/command-handler.js";
 import { SimElbV2Action } from "../../action/sim-elbv2-action.js";
 import type { SimElbV2ActionTargets } from "../../action/sim-elbv2-action-targets.js";
 import { SimElbV2ValidationError } from "../../error/sim-elbv2.error.js";
+import type { SimElbV2CertificateResolver } from "../../listener/certificate/sim-elbv2-certificate-resolver.js";
 import type { SimElbV2ListenerChanges } from "../../listener/sim-elbv2-listener.js";
 import { simElbV2Port, simElbV2Protocol } from "../../sim-elbv2-protocol.js";
 import {
@@ -17,6 +18,7 @@ import type {
 
 interface ModifyListenerCommandHandlerProperties extends SimElbV2CommandHandlerProperties {
   readonly actionTargets: SimElbV2ActionTargets;
+  readonly certificates: SimElbV2CertificateResolver;
 }
 
 /**
@@ -30,10 +32,12 @@ export class ModifyListenerCommandHandler
     CommandHandler<SimModifyListenerCommand, SimModifyListenerCommandOutput>
 {
   private readonly actionTargets: SimElbV2ActionTargets;
+  private readonly certificates: SimElbV2CertificateResolver;
 
   constructor(properties: ModifyListenerCommandHandlerProperties) {
     super(properties);
     this.actionTargets = properties.actionTargets;
+    this.certificates = properties.certificates;
   }
 
   private static readChanges(
@@ -47,7 +51,6 @@ export class ModifyListenerCommandHandler
           ? undefined
           : simElbV2Protocol("Protocol", input.Protocol),
       sslPolicy: input.SslPolicy,
-      certificates: input.Certificates,
       defaultActions:
         input.DefaultActions === undefined
           ? undefined
@@ -61,6 +64,9 @@ export class ModifyListenerCommandHandler
    * The port is checked against the other listeners on the same load balancer
    * before anything changes, so a request moving a listener onto a port
    * another one holds leaves both where they were.
+   *
+   * This is also how a listener's default certificate is replaced, which is
+   * what real ELB has for it: `AddListenerCertificates` carries the rest.
    */
   async handle(
     command: SimModifyListenerCommand,
@@ -91,7 +97,13 @@ export class ModifyListenerCommandHandler
       );
     }
 
-    listener.modify(changes);
+    listener.modify({
+      ...changes,
+      certificateArn: this.certificates.resolveDefault(
+        input.Certificates,
+        "Certificates",
+      ),
+    });
 
     return { $metadata: {}, Listeners: [listener.view()] };
   }

--- a/src/service/elbv2/command/listener/modify-listener.iso.test.ts
+++ b/src/service/elbv2/command/listener/modify-listener.iso.test.ts
@@ -8,13 +8,18 @@ import {
   assertInstanceOf,
   assertStringIncludes,
   assertThrowsErrorAsync,
+  assertUndefined,
 } from "@kensio/smartass";
 import { describe, it } from "vitest";
 
 import { SimAws } from "../../../aws/sim-aws.js";
-import { SimElbV2DuplicateListenerException } from "../../error/sim-elbv2.error.js";
+import {
+  SimElbV2DuplicateListenerException,
+  SimElbV2InvalidConfigurationRequestException,
+} from "../../error/sim-elbv2.error.js";
 import {
   createFixtureCertificate,
+  createFixtureHttpsListener,
   createFixtureLambdaTargetGroup,
   createFixtureListener,
   createFixtureLoadBalancer,
@@ -101,8 +106,57 @@ describe("ELBv2 ModifyListenerCommand", () => {
     assertIdentical(output.Listeners[0].Port, 443);
     assertIdentical(output.Listeners[0].Protocol, "HTTPS");
     assertArrayLength(output.Listeners[0].Certificates, 1);
+    assertIdentical(
+      output.Listeners[0].Certificates[0].CertificateArn,
+      certificateArn,
+    );
     assertArrayLength(output.Listeners[0].DefaultActions, 1);
     assertIdentical(output.Listeners[0].DefaultActions[0].Type, "forward");
+  });
+
+  it("drops a listener's certificates when it leaves HTTPS", async () => {
+    // Given an HTTPS listener with a certificate.
+    const simAws = new SimAws();
+    const elbV2 = simAws.elbV2();
+    const loadBalancerArn = await createFixtureLoadBalancer(elbV2);
+    const targetGroupArn = await createFixtureLambdaTargetGroup(elbV2);
+    const certificateArn = await createFixtureCertificate(simAws);
+    const listenerArn = await createFixtureHttpsListener(
+      elbV2,
+      loadBalancerArn,
+      targetGroupArn,
+      certificateArn,
+    );
+
+    // When it is moved to HTTP, and when a modify names a certificate and HTTP
+    // in the same request.
+    const output = await elbV2.modifyListener(
+      new ModifyListenerCommand({
+        ListenerArn: listenerArn,
+        Protocol: "HTTP",
+        Port: 80,
+      }),
+    );
+
+    const error = await assertThrowsErrorAsync(async () => {
+      await elbV2.modifyListener(
+        new ModifyListenerCommand({
+          ListenerArn: listenerArn,
+          Protocol: "HTTP",
+          Certificates: [{ CertificateArn: certificateArn }],
+        }),
+      );
+    });
+
+    assertInstanceOf(error, SimElbV2InvalidConfigurationRequestException);
+
+    // Then the move left it carrying nothing and no security policy, and the
+    // request contradicting itself was refused.
+    assertArrayLength(output.Listeners, 1);
+    assertIdentical(output.Listeners[0].Protocol, "HTTP");
+    assertArrayLength(output.Listeners[0].Certificates, 0);
+    assertUndefined(output.Listeners[0].SslPolicy);
+    assertStringIncludes(error.message, "HTTPS listener");
   });
 
   it("refuses a modify onto a port another listener holds", async () => {

--- a/src/service/elbv2/command/listener/modify-listener.iso.test.ts
+++ b/src/service/elbv2/command/listener/modify-listener.iso.test.ts
@@ -14,21 +14,20 @@ import { describe, it } from "vitest";
 import { SimAws } from "../../../aws/sim-aws.js";
 import { SimElbV2DuplicateListenerException } from "../../error/sim-elbv2.error.js";
 import {
+  createFixtureCertificate,
   createFixtureLambdaTargetGroup,
   createFixtureListener,
   createFixtureLoadBalancer,
 } from "../../sim-elbv2.fixture.js";
 
-const certificateArn =
-  "arn:aws:acm:eu-west-1:888888888888:certificate/00000001";
-
 describe("ELBv2 ModifyListenerCommand", () => {
   it("changes only what a modify names", async () => {
-    // Given an HTTP listener on port 80.
+    // Given an HTTP listener on port 80, and an issued certificate.
     const simAws = new SimAws();
     const elbV2 = simAws.elbV2();
     const loadBalancerArn = await createFixtureLoadBalancer(elbV2);
     const targetGroupArn = await createFixtureLambdaTargetGroup(elbV2);
+    const certificateArn = await createFixtureCertificate(simAws);
     const listenerArn = await createFixtureListener(
       elbV2,
       loadBalancerArn,
@@ -51,12 +50,15 @@ describe("ELBv2 ModifyListenerCommand", () => {
       }),
     );
 
-    // Then the change took, and its default actions came with it.
+    // Then the change took, and its default actions and certificate came with
+    // it.
     assertArrayLength(output.Listeners, 1);
 
     const listener = output.Listeners[0];
     assertIdentical(listener.Protocol, "HTTPS");
     assertIdentical(listener.Port, 443);
+    assertArrayLength(listener.Certificates, 1);
+    assertIdentical(listener.Certificates[0].CertificateArn, certificateArn);
     assertArrayLength(listener.DefaultActions, 1);
     assertIdentical(listener.DefaultActions[0].Type, "fixed-response");
   });
@@ -67,6 +69,7 @@ describe("ELBv2 ModifyListenerCommand", () => {
     const elbV2 = simAws.elbV2();
     const loadBalancerArn = await createFixtureLoadBalancer(elbV2);
     const targetGroupArn = await createFixtureLambdaTargetGroup(elbV2);
+    const certificateArn = await createFixtureCertificate(simAws);
     const created = await elbV2.createListener(
       new CreateListenerCommand({
         LoadBalancerArn: loadBalancerArn,
@@ -97,6 +100,7 @@ describe("ELBv2 ModifyListenerCommand", () => {
     );
     assertIdentical(output.Listeners[0].Port, 443);
     assertIdentical(output.Listeners[0].Protocol, "HTTPS");
+    assertArrayLength(output.Listeners[0].Certificates, 1);
     assertArrayLength(output.Listeners[0].DefaultActions, 1);
     assertIdentical(output.Listeners[0].DefaultActions[0].Type, "forward");
   });

--- a/src/service/elbv2/command/sim-elbv2-command.types.ts
+++ b/src/service/elbv2/command/sim-elbv2-command.types.ts
@@ -6,6 +6,7 @@
  * operation touches the area it belongs to rather than the top of the facade.
  */
 
+export type * from "./listener-certificate/listener-certificate.command.js";
 export type * from "./listener/listener.command.js";
 export type * from "./load-balancer/load-balancer.command.js";
 export type * from "./rule/rule.command.js";

--- a/src/service/elbv2/command/sim-elbv2-commands.ts
+++ b/src/service/elbv2/command/sim-elbv2-commands.ts
@@ -1,10 +1,15 @@
 import type { BackgroundScheduler } from "../../../util/background/background.js";
+import type { SimAcmRegistry } from "../../acm/registry/sim-acm-registry.js";
 import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
 import type { SimIamInterServiceAuthZ } from "../../iam/authorize/sim-iam-inter-service-auth-z.js";
 import { SimElbV2ActionTargets } from "../action/sim-elbv2-action-targets.js";
+import { SimElbV2CertificateResolver } from "../listener/certificate/sim-elbv2-certificate-resolver.js";
 import type { SimElbV2Stores } from "../sim-elbv2-stores.js";
 import { SimElbV2TargetGroupUsage } from "../target-group/sim-elbv2-target-group-usage.js";
 import { SimElbV2Authorizer } from "./authorize/sim-elbv2-authorizer.js";
+import { AddListenerCertificatesCommandHandler } from "./listener-certificate/add-listener-certificates.handler.js";
+import { DescribeListenerCertificatesCommandHandler } from "./listener-certificate/describe-listener-certificates.handler.js";
+import { RemoveListenerCertificatesCommandHandler } from "./listener-certificate/remove-listener-certificates.handler.js";
 import { CreateListenerCommandHandler } from "./listener/create-listener.handler.js";
 import { DeleteListenerCommandHandler } from "./listener/delete-listener.handler.js";
 import { DescribeListenersCommandHandler } from "./listener/describe-listeners.handler.js";
@@ -30,6 +35,7 @@ interface SimElbV2CommandsProperties {
   readonly iam: SimIamInterServiceAuthZ;
   readonly background: BackgroundScheduler;
   readonly accountRegionScope: SimAwsAccountRegionScope;
+  readonly acmRegistry?: SimAcmRegistry | undefined;
 }
 
 /**
@@ -59,14 +65,22 @@ export class SimElbV2Commands {
   public readonly modifyRule: ModifyRuleCommandHandler;
   public readonly deleteRule: DeleteRuleCommandHandler;
   public readonly setRulePriorities: SetRulePrioritiesCommandHandler;
+  public readonly addListenerCertificates: AddListenerCertificatesCommandHandler;
+  public readonly removeListenerCertificates: RemoveListenerCertificatesCommandHandler;
+  public readonly describeListenerCertificates: DescribeListenerCertificatesCommandHandler;
 
   constructor(properties: SimElbV2CommandsProperties) {
     const { stores, background, accountRegionScope } = properties;
     const authorizer = new SimElbV2Authorizer({ iam: properties.iam });
     const usage = new SimElbV2TargetGroupUsage(stores);
     const actionTargets = new SimElbV2ActionTargets(stores.targetGroups);
+    const certificates = new SimElbV2CertificateResolver({
+      accountRegionScope,
+      acmRegistry: properties.acmRegistry,
+    });
     const shared = { stores, authorizer, background };
-    const withTargets = { ...shared, actionTargets };
+    const withTargets = { ...shared, actionTargets, certificates };
+    const withCertificates = { ...shared, certificates };
     const withUsage = { ...shared, usage };
 
     this.createLoadBalancer = new CreateLoadBalancerCommandHandler({
@@ -98,5 +112,12 @@ export class SimElbV2Commands {
     this.modifyRule = new ModifyRuleCommandHandler(withTargets);
     this.deleteRule = new DeleteRuleCommandHandler(shared);
     this.setRulePriorities = new SetRulePrioritiesCommandHandler(shared);
+    this.addListenerCertificates = new AddListenerCertificatesCommandHandler(
+      withCertificates,
+    );
+    this.removeListenerCertificates =
+      new RemoveListenerCertificatesCommandHandler(shared);
+    this.describeListenerCertificates =
+      new DescribeListenerCertificatesCommandHandler(shared);
   }
 }

--- a/src/service/elbv2/error/sim-elbv2.error.ts
+++ b/src/service/elbv2/error/sim-elbv2.error.ts
@@ -175,6 +175,35 @@ export class SimElbV2ResourceInUseException extends SimElbV2Error {
 }
 
 /**
+ * Simulated ELBv2 CertificateNotFoundException.
+ *
+ * A listener certificate ARN naming no certificate simulated ACM holds. That is
+ * the refusal a stack whose certificate and listener do not line up runs into
+ * on real AWS too.
+ */
+export class SimElbV2CertificateNotFoundException extends SimElbV2Error {
+  public override readonly name = "CertificateNotFoundException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
+ * Simulated ELBv2 OperationNotPermittedException.
+ *
+ * An operation on a resource that exists which ELB does not allow, such as
+ * removing the default certificate from a listener.
+ */
+export class SimElbV2OperationNotPermittedException extends SimElbV2Error {
+  public override readonly name = "OperationNotPermittedException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
  * Simulated ELBv2 InvalidConfigurationRequestException.
  *
  * A request whose parts contradict each other, such as a `lambda` target group

--- a/src/service/elbv2/index.ts
+++ b/src/service/elbv2/index.ts
@@ -48,6 +48,7 @@ export {
 } from "./serve/sim-elbv2-serving-target-group.factory.js";
 export {
   SimElbV2AccessDeniedException,
+  SimElbV2CertificateNotFoundException,
   SimElbV2ConnectionRefusedError,
   SimElbV2DuplicateListenerException,
   SimElbV2DuplicateLoadBalancerNameException,
@@ -57,6 +58,7 @@ export {
   SimElbV2InvalidTargetException,
   SimElbV2ListenerNotFoundException,
   SimElbV2LoadBalancerNotFoundException,
+  SimElbV2OperationNotPermittedException,
   SimElbV2PriorityInUseException,
   SimElbV2ResourceInUseException,
   SimElbV2RuleNotFoundException,

--- a/src/service/elbv2/listener/certificate/sim-elbv2-certificate-arns.ts
+++ b/src/service/elbv2/listener/certificate/sim-elbv2-certificate-arns.ts
@@ -1,0 +1,49 @@
+import type { SimElbV2Certificate } from "../../command/sim-elbv2-shared.command.js";
+import { SimElbV2ValidationError } from "../../error/sim-elbv2.error.js";
+
+/**
+ * Reading the ARNs out of the certificate references a request carries.
+ *
+ * Four operations take the same `Certificates` list and all any of them wants
+ * from it is the ARNs, so taking it apart lives here rather than in each of
+ * them.
+ */
+
+/**
+ * Read the ARN one certificate reference names.
+ */
+export function simElbV2CertificateArn(
+  certificate: SimElbV2Certificate,
+  field: string,
+): string {
+  const arn = certificate.CertificateArn;
+
+  if (arn === undefined) {
+    throw new SimElbV2ValidationError(`${field} requires a CertificateArn`);
+  }
+
+  return arn;
+}
+
+/**
+ * Read the ARNs a request naming certificates carries, refusing one that names
+ * none.
+ *
+ * This is for the operations a certificate list is the whole subject of. A
+ * listener create naming no certificate is a different thing, since an HTTP
+ * listener has no use for one.
+ */
+export function simElbV2CertificateArns(
+  certificates: readonly SimElbV2Certificate[] | undefined,
+  field: string,
+): readonly string[] {
+  if (certificates === undefined || certificates.length === 0) {
+    throw new SimElbV2ValidationError(
+      `${field} requires at least one certificate`,
+    );
+  }
+
+  return certificates.map((certificate) =>
+    simElbV2CertificateArn(certificate, field),
+  );
+}

--- a/src/service/elbv2/listener/certificate/sim-elbv2-certificate-list.ts
+++ b/src/service/elbv2/listener/certificate/sim-elbv2-certificate-list.ts
@@ -18,7 +18,7 @@ export class SimElbV2CertificateList {
   #defaultArn: string | undefined;
   readonly #additional = new Set<string>();
 
-  /** The ARN of the certificate this listener presents by default. */
+  /** The ARN of the certificate this listener would present by default. */
   get defaultArn(): string | undefined {
     return this.#defaultArn;
   }

--- a/src/service/elbv2/listener/certificate/sim-elbv2-certificate-list.ts
+++ b/src/service/elbv2/listener/certificate/sim-elbv2-certificate-list.ts
@@ -1,0 +1,112 @@
+import type { SimElbV2Certificate } from "../../command/sim-elbv2-shared.command.js";
+import { SimElbV2OperationNotPermittedException } from "../../error/sim-elbv2.error.js";
+
+/**
+ * The certificates one listener carries.
+ *
+ * A listener has one default certificate and any number of additional ones,
+ * and the two are held apart here because everything that can be asked about a
+ * certificate list depends on which of the two a certificate is: the default is
+ * the one a described listener reports, the one `ModifyListener` replaces, and
+ * the one `RemoveListenerCertificates` will not take away.
+ *
+ * The additional ones are a set rather than a list, because adding a
+ * certificate already on a listener is a request real ELB answers successfully
+ * without carrying it twice.
+ */
+export class SimElbV2CertificateList {
+  #defaultArn: string | undefined;
+  readonly #additional = new Set<string>();
+
+  /** The ARN of the certificate this listener presents by default. */
+  get defaultArn(): string | undefined {
+    return this.#defaultArn;
+  }
+
+  /**
+   * Replace the default certificate.
+   *
+   * A certificate that was an additional one becomes the default rather than
+   * appearing twice, which is what real ELB reports for the same listener.
+   */
+  setDefault(arn: string): void {
+    this.#defaultArn = arn;
+    this.#additional.delete(arn);
+  }
+
+  /**
+   * Forget every certificate, which is what leaving HTTPS does to a listener.
+   */
+  clear(): void {
+    this.#defaultArn = undefined;
+    this.#additional.clear();
+  }
+
+  /**
+   * Carry more certificates beyond the default one.
+   */
+  add(arns: readonly string[]): void {
+    for (const arn of arns) {
+      if (arn !== this.#defaultArn) {
+        this.#additional.add(arn);
+      }
+    }
+  }
+
+  /**
+   * Stop carrying certificates, refusing to take away the default one.
+   */
+  remove(arns: readonly string[]): void {
+    for (const arn of arns) {
+      this.removeOne(arn);
+    }
+  }
+
+  /**
+   * The whole list, which is what `DescribeListenerCertificates` reports.
+   *
+   * The default comes first and is the only one flagged as such, so a reader
+   * can tell which certificate the listener would present to a client that
+   * asked for no particular host name.
+   */
+  list(): readonly SimElbV2Certificate[] {
+    const additional = [...this.#additional].map((arn) => ({
+      CertificateArn: arn,
+      IsDefault: false,
+    }));
+
+    if (this.#defaultArn === undefined) {
+      return additional;
+    }
+
+    return [
+      { CertificateArn: this.#defaultArn, IsDefault: true },
+      ...additional,
+    ];
+  }
+
+  /**
+   * The default certificate alone, which is what a described listener reports.
+   *
+   * Real ELB reports only the default in a listener's own `Certificates`, and
+   * the rest through `DescribeListenerCertificates`.
+   */
+  defaultOnly(): readonly SimElbV2Certificate[] {
+    if (this.#defaultArn === undefined) {
+      return [];
+    }
+
+    return [{ CertificateArn: this.#defaultArn, IsDefault: true }];
+  }
+
+  private removeOne(arn: string): void {
+    if (arn === this.#defaultArn) {
+      throw new SimElbV2OperationNotPermittedException(
+        `Certificate ${arn} is the default certificate of this listener, ` +
+          `which is replaced with ModifyListener rather than removed`,
+      );
+    }
+
+    this.#additional.delete(arn);
+  }
+}

--- a/src/service/elbv2/listener/certificate/sim-elbv2-certificate-resolver.ts
+++ b/src/service/elbv2/listener/certificate/sim-elbv2-certificate-resolver.ts
@@ -1,0 +1,163 @@
+import type { SimAcmCertificate } from "../../../acm/certificate/sim-acm-certificate.js";
+import type { SimAcmRegistry } from "../../../acm/registry/sim-acm-registry.js";
+import { parseSimArn } from "../../../aws/arn.js";
+import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
+import type { SimElbV2Certificate } from "../../command/sim-elbv2-shared.command.js";
+import {
+  SimElbV2CertificateNotFoundException,
+  SimElbV2InvalidConfigurationRequestException,
+  SimElbV2ValidationError,
+} from "../../error/sim-elbv2.error.js";
+import { simElbV2CertificateArn } from "./sim-elbv2-certificate-arns.js";
+
+interface SimElbV2CertificateResolverProperties {
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+  /**
+   * The simulation's index of ACM facades. With none there is no simulated ACM
+   * to check a certificate against, as in a standalone `SimElbV2`, and nothing
+   * is checked.
+   */
+  readonly acmRegistry?: SimAcmRegistry | undefined;
+}
+
+/**
+ * Gets from the certificates a request names to the ARNs a listener holds.
+ *
+ * A certificate that does not exist, or that is still pending validation, is
+ * refused here rather than held, which is the whole point of connecting these
+ * two simulations: a listener that says it is serving HTTPS with a certificate
+ * a stack never got issued would serve requests here and fail to deploy on real
+ * AWS.
+ *
+ * Nothing is decrypted or presented to a client, since no TLS is performed.
+ * What is checked is the configuration relationship, which is the part a test
+ * can be written about.
+ */
+export class SimElbV2CertificateResolver {
+  private readonly accountRegionScope: SimAwsAccountRegionScope;
+  private readonly acmRegistry: SimAcmRegistry | undefined;
+
+  constructor(properties: SimElbV2CertificateResolverProperties) {
+    this.accountRegionScope = properties.accountRegionScope;
+    this.acmRegistry = properties.acmRegistry;
+  }
+
+  /**
+   * The one certificate a listener request may name, if it names any.
+   */
+  private static onlyOne(
+    certificates: readonly SimElbV2Certificate[] | undefined,
+    field: string,
+  ): SimElbV2Certificate | undefined {
+    const [first, second] = certificates ?? [];
+
+    if (second !== undefined) {
+      throw new SimElbV2InvalidConfigurationRequestException(
+        `${field} names more than one certificate, and a listener takes one ` +
+          `default certificate. The rest go on with AddListenerCertificates.`,
+      );
+    }
+
+    return first;
+  }
+
+  /**
+   * Refuse a certificate that was not issued.
+   */
+  private static requireIssuedStatus(certificate: SimAcmCertificate): void {
+    if (certificate.status === "ISSUED") {
+      return;
+    }
+
+    throw new SimElbV2InvalidConfigurationRequestException(
+      `Certificate ${certificate.certificateArn} is ${certificate.status}, ` +
+        `not ISSUED, so a listener presenting it could not serve a request`,
+    );
+  }
+
+  /**
+   * Refuse any of these certificates simulated ACM does not hold as an issued
+   * one.
+   */
+  requireAllIssued(certificateArns: readonly string[]): void {
+    for (const arn of certificateArns) {
+      this.requireIssued(arn);
+    }
+  }
+
+  /**
+   * Read the default certificate a listener request names, if it names one.
+   *
+   * A listener takes exactly one default certificate, as real ELB does, so a
+   * request naming several is refused with the operation that carries the rest.
+   */
+  resolveDefault(
+    certificates: readonly SimElbV2Certificate[] | undefined,
+    field: string,
+  ): string | undefined {
+    const certificate = SimElbV2CertificateResolver.onlyOne(
+      certificates,
+      field,
+    );
+
+    if (certificate === undefined) {
+      return undefined;
+    }
+
+    const arn = simElbV2CertificateArn(certificate, field);
+    this.requireIssued(arn);
+
+    return arn;
+  }
+
+  /**
+   * Refuse a certificate simulated ACM does not hold as an issued one.
+   */
+  private requireIssued(arn: string): void {
+    const acmRegistry = this.acmRegistry;
+
+    if (acmRegistry === undefined) {
+      return;
+    }
+
+    this.requireOwnScope(arn);
+
+    const certificate = acmRegistry.certificate(arn);
+
+    if (certificate === undefined) {
+      throw new SimElbV2CertificateNotFoundException(
+        `Certificate ${arn} was not found in simulated ACM`,
+      );
+    }
+
+    SimElbV2CertificateResolver.requireIssuedStatus(certificate);
+  }
+
+  /**
+   * Refuse a certificate from another Account or Region.
+   *
+   * Real ELB takes a certificate from the load balancer's own Account and
+   * Region only, which is the same mistake CloudFront's us-east-1 rule catches
+   * and one a template can carry for a long time before it is deployed.
+   */
+  private requireOwnScope(arn: string): void {
+    const parsed = parseSimArn(arn);
+    const { accountId, regionName } = this.accountRegionScope;
+
+    if (parsed === undefined) {
+      throw new SimElbV2ValidationError(
+        `Certificate ${arn} is not an ACM certificate ARN`,
+      );
+    }
+
+    if (parsed.accountId === accountId && parsed.region === regionName) {
+      return;
+    }
+
+    throw new SimElbV2InvalidConfigurationRequestException(
+      `Certificate ${arn} is in ${parsed.accountId} ${parsed.region}, and a ` +
+        `listener takes a certificate from its load balancer's own Account ` +
+        `and Region, which is ${accountId} ${regionName}`,
+    );
+  }
+}

--- a/src/service/elbv2/listener/sim-elbv2-listener-security.ts
+++ b/src/service/elbv2/listener/sim-elbv2-listener-security.ts
@@ -1,4 +1,3 @@
-import type { SimElbV2Certificate } from "../command/sim-elbv2-shared.command.js";
 import { SimElbV2InvalidConfigurationRequestException } from "../error/sim-elbv2.error.js";
 
 /**
@@ -16,6 +15,9 @@ const defaultSslPolicy = "ELBSecurityPolicy-2016-08";
 
 /**
  * The security policy a listener holds, which is none unless it is HTTPS.
+ *
+ * The policy is held and reported and nothing acts on it, since no handshake
+ * is performed here for it to decide anything about.
  */
 export function simElbV2ListenerSslPolicy(
   protocol: string,
@@ -29,18 +31,41 @@ export function simElbV2ListenerSslPolicy(
 }
 
 /**
- * Refuse an HTTPS listener with no certificate.
+ * The default certificate a listener holds, which is none unless it is HTTPS.
  *
- * One could not complete a handshake, so real ELB refuses to create it and so
- * does this.
+ * An HTTPS listener with no certificate could not complete a handshake, so real
+ * ELB refuses to create one and so does this. A listener that is not HTTPS
+ * holds no certificate, so moving one to HTTP drops the certificates it was
+ * carrying rather than keeping ones nothing would present.
  */
-export function requireSimElbV2ListenerCertificate(
+export function simElbV2ListenerCertificate(
   protocol: string,
-  certificates: readonly SimElbV2Certificate[],
-): void {
-  if (protocol === "HTTPS" && certificates.length === 0) {
+  defaultCertificateArn: string | undefined,
+): string | undefined {
+  if (protocol !== "HTTPS") {
+    return undefined;
+  }
+
+  if (defaultCertificateArn === undefined) {
     throw new SimElbV2InvalidConfigurationRequestException(
       "An HTTPS listener requires at least one certificate",
+    );
+  }
+
+  return defaultCertificateArn;
+}
+
+/**
+ * Refuse a certificate on a listener that speaks no TLS.
+ *
+ * Real ELB has nothing for an HTTP listener to do with a certificate, so it
+ * refuses one rather than holding it, and a listener that looks configured for
+ * HTTPS while answering plain HTTP is exactly the state worth refusing.
+ */
+export function requireSimElbV2CertificateProtocol(protocol: string): void {
+  if (protocol !== "HTTPS") {
+    throw new SimElbV2InvalidConfigurationRequestException(
+      `Certificates go on an HTTPS listener, and this one speaks ${protocol}`,
     );
   }
 }

--- a/src/service/elbv2/listener/sim-elbv2-listener-security.ts
+++ b/src/service/elbv2/listener/sim-elbv2-listener-security.ts
@@ -31,28 +31,51 @@ export function simElbV2ListenerSslPolicy(
 }
 
 /**
+ * What a request names about a listener's default certificate, and what the
+ * listener already held.
+ */
+export interface SimElbV2ListenerCertificateChoice {
+  readonly protocol: string;
+  /** The certificate this request named, if it named one. */
+  readonly requested: string | undefined;
+  /** The certificate the listener already had, on a modify. */
+  readonly held?: string | undefined;
+}
+
+/**
  * The default certificate a listener holds, which is none unless it is HTTPS.
  *
  * An HTTPS listener with no certificate could not complete a handshake, so real
- * ELB refuses to create one and so does this. A listener that is not HTTPS
- * holds no certificate, so moving one to HTTP drops the certificates it was
- * carrying rather than keeping ones nothing would present.
+ * ELB refuses to create one and so does this. A request naming a certificate
+ * for a listener that speaks no TLS is refused for the other half of the same
+ * reason.
+ *
+ * What the request named and what the listener already had are separate,
+ * because the two lead to different answers on the same protocol: a listener
+ * moved to HTTP drops the certificate it was carrying, where a request that
+ * moves it to HTTP and names a certificate in the same breath contradicts
+ * itself and is refused.
  */
 export function simElbV2ListenerCertificate(
-  protocol: string,
-  defaultCertificateArn: string | undefined,
+  choice: SimElbV2ListenerCertificateChoice,
 ): string | undefined {
-  if (protocol !== "HTTPS") {
+  if (choice.requested !== undefined) {
+    requireSimElbV2CertificateProtocol(choice.protocol);
+  }
+
+  if (choice.protocol !== "HTTPS") {
     return undefined;
   }
 
-  if (defaultCertificateArn === undefined) {
+  const certificateArn = choice.requested ?? choice.held;
+
+  if (certificateArn === undefined) {
     throw new SimElbV2InvalidConfigurationRequestException(
       "An HTTPS listener requires at least one certificate",
     );
   }
 
-  return defaultCertificateArn;
+  return certificateArn;
 }
 
 /**

--- a/src/service/elbv2/listener/sim-elbv2-listener.ts
+++ b/src/service/elbv2/listener/sim-elbv2-listener.ts
@@ -16,7 +16,7 @@ interface SimElbV2ListenerProperties {
   readonly port: number;
   readonly protocol: string;
   readonly sslPolicy: string | undefined;
-  /** The ARN of the certificate an HTTPS listener presents by default. */
+  /** The ARN of the certificate an HTTPS listener would present by default. */
   readonly certificateArn: string | undefined;
   readonly defaultActions: readonly SimElbV2Action[];
 }

--- a/src/service/elbv2/listener/sim-elbv2-listener.ts
+++ b/src/service/elbv2/listener/sim-elbv2-listener.ts
@@ -78,10 +78,10 @@ export class SimElbV2Listener {
     this.currentDefaultActions = properties.defaultActions;
 
     this.holdCertificate(
-      simElbV2ListenerCertificate(
-        properties.protocol,
-        properties.certificateArn,
-      ),
+      simElbV2ListenerCertificate({
+        protocol: properties.protocol,
+        requested: properties.certificateArn,
+      }),
     );
   }
 
@@ -120,10 +120,11 @@ export class SimElbV2Listener {
    */
   modify(changes: SimElbV2ListenerChanges): void {
     const protocol = changes.protocol ?? this.currentProtocol;
-    const certificateArn = simElbV2ListenerCertificate(
+    const certificateArn = simElbV2ListenerCertificate({
       protocol,
-      changes.certificateArn ?? this.certificateList.defaultArn,
-    );
+      requested: changes.certificateArn,
+      held: this.certificateList.defaultArn,
+    });
 
     this.currentPort = changes.port ?? this.currentPort;
     this.currentProtocol = protocol;

--- a/src/service/elbv2/listener/sim-elbv2-listener.ts
+++ b/src/service/elbv2/listener/sim-elbv2-listener.ts
@@ -3,8 +3,10 @@ import type {
   SimElbV2ActionView,
   SimElbV2Certificate,
 } from "../command/sim-elbv2-shared.command.js";
+import { SimElbV2CertificateList } from "./certificate/sim-elbv2-certificate-list.js";
 import {
-  requireSimElbV2ListenerCertificate,
+  requireSimElbV2CertificateProtocol,
+  simElbV2ListenerCertificate,
   simElbV2ListenerSslPolicy,
 } from "./sim-elbv2-listener-security.js";
 
@@ -14,7 +16,8 @@ interface SimElbV2ListenerProperties {
   readonly port: number;
   readonly protocol: string;
   readonly sslPolicy: string | undefined;
-  readonly certificates: readonly SimElbV2Certificate[];
+  /** The ARN of the certificate an HTTPS listener presents by default. */
+  readonly certificateArn: string | undefined;
   readonly defaultActions: readonly SimElbV2Action[];
 }
 
@@ -25,7 +28,7 @@ export interface SimElbV2ListenerChanges {
   readonly port?: number | undefined;
   readonly protocol?: string | undefined;
   readonly sslPolicy?: string | undefined;
-  readonly certificates?: readonly SimElbV2Certificate[] | undefined;
+  readonly certificateArn?: string | undefined;
   readonly defaultActions?: readonly SimElbV2Action[] | undefined;
 }
 
@@ -54,10 +57,10 @@ export class SimElbV2Listener {
   public readonly arn: string;
   public readonly loadBalancerArn: string;
 
+  private readonly certificateList = new SimElbV2CertificateList();
   private currentPort: number;
   private currentProtocol: string;
   private currentSslPolicy: string | undefined;
-  private currentCertificates: readonly SimElbV2Certificate[];
   private currentDefaultActions: readonly SimElbV2Action[];
 
   constructor(properties: SimElbV2ListenerProperties) {
@@ -72,12 +75,14 @@ export class SimElbV2Listener {
       properties.protocol,
       properties.sslPolicy,
     );
-    // Copied for the same reason an action's input is: what a listener
-    // presents cannot change because a caller reused the array it sent.
-    this.currentCertificates = structuredClone(properties.certificates);
     this.currentDefaultActions = properties.defaultActions;
 
-    requireSimElbV2ListenerCertificate(properties.protocol, this.certificates);
+    this.holdCertificate(
+      simElbV2ListenerCertificate(
+        properties.protocol,
+        properties.certificateArn,
+      ),
+    );
   }
 
   /** The port this listener answers on. */
@@ -90,9 +95,14 @@ export class SimElbV2Listener {
     return this.currentProtocol;
   }
 
-  /** The certificates an HTTPS listener presents. */
+  /**
+   * Every certificate this listener carries, the default one first.
+   *
+   * This is what `DescribeListenerCertificates` reports, where a described
+   * listener reports its default certificate alone.
+   */
   get certificates(): readonly SimElbV2Certificate[] {
-    return this.currentCertificates;
+    return this.certificateList.list();
   }
 
   /** What this listener does with a request no rule claims. */
@@ -110,19 +120,40 @@ export class SimElbV2Listener {
    */
   modify(changes: SimElbV2ListenerChanges): void {
     const protocol = changes.protocol ?? this.currentProtocol;
-    const certificates = changes.certificates ?? this.currentCertificates;
-
-    requireSimElbV2ListenerCertificate(protocol, certificates);
+    const certificateArn = simElbV2ListenerCertificate(
+      protocol,
+      changes.certificateArn ?? this.certificateList.defaultArn,
+    );
 
     this.currentPort = changes.port ?? this.currentPort;
     this.currentProtocol = protocol;
-    this.currentCertificates = structuredClone(certificates);
     this.currentSslPolicy = simElbV2ListenerSslPolicy(
       protocol,
       changes.sslPolicy ?? this.currentSslPolicy,
     );
     this.currentDefaultActions =
       changes.defaultActions ?? this.currentDefaultActions;
+
+    this.holdCertificate(certificateArn);
+  }
+
+  /**
+   * Carry more certificates beyond the default one.
+   *
+   * These are the certificates a real listener would choose between by the host
+   * name a client asked for. Nothing selects one here, since no handshake
+   * happens, so what a test can prove is that the listener carries them.
+   */
+  addCertificates(certificateArns: readonly string[]): void {
+    requireSimElbV2CertificateProtocol(this.currentProtocol);
+    this.certificateList.add(certificateArns);
+  }
+
+  /**
+   * Stop carrying certificates, refusing to take away the default one.
+   */
+  removeCertificates(certificateArns: readonly string[]): void {
+    this.certificateList.remove(certificateArns);
   }
 
   /**
@@ -135,8 +166,25 @@ export class SimElbV2Listener {
       Port: this.port,
       Protocol: this.protocol,
       SslPolicy: this.currentSslPolicy,
-      Certificates: this.certificates,
+      Certificates: this.certificateList.defaultOnly(),
       DefaultActions: this.defaultActions.map((action) => action.view()),
     };
+  }
+
+  /**
+   * Hold the default certificate, or none at all where the protocol has no use
+   * for one.
+   *
+   * A listener left with no certificate drops its whole certificate list rather
+   * than carrying certificates it would never present, which is what real ELB
+   * leaves behind after the same change.
+   */
+  private holdCertificate(certificateArn: string | undefined): void {
+    if (certificateArn === undefined) {
+      this.certificateList.clear();
+      return;
+    }
+
+    this.certificateList.setDefault(certificateArn);
   }
 }

--- a/src/service/elbv2/sdk/sim-elbv2-sdk-command-router.ts
+++ b/src/service/elbv2/sdk/sim-elbv2-sdk-command-router.ts
@@ -131,6 +131,30 @@ export class SimElbV2SdkCommandRouter implements SimSdkCommandRouter {
           ),
       ],
       [
+        "AddListenerCertificatesCommand",
+        async (command, context): Promise<unknown> =>
+          await simElbV2.addListenerCertificates(
+            command as elbV2.SimAddListenerCertificatesCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "RemoveListenerCertificatesCommand",
+        async (command, context): Promise<unknown> =>
+          await simElbV2.removeListenerCertificates(
+            command as elbV2.SimRemoveListenerCertificatesCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "DescribeListenerCertificatesCommand",
+        async (command, context): Promise<unknown> =>
+          await simElbV2.describeListenerCertificates(
+            command as elbV2.SimDescribeListenerCertificatesCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
         "CreateRuleCommand",
         async (command, context): Promise<unknown> =>
           await simElbV2.createRule(

--- a/src/service/elbv2/sdk/sim-elbv2-sdk-routing.iso.test.ts
+++ b/src/service/elbv2/sdk/sim-elbv2-sdk-routing.iso.test.ts
@@ -1,4 +1,5 @@
 import {
+  AddListenerCertificatesCommand,
   CreateListenerCommand,
   CreateLoadBalancerCommand,
   CreateRuleCommand,
@@ -8,6 +9,7 @@ import {
   DeleteRuleCommand,
   DeleteTargetGroupCommand,
   DeregisterTargetsCommand,
+  DescribeListenerCertificatesCommand,
   DescribeListenersCommand,
   DescribeLoadBalancersCommand,
   DescribeRulesCommand,
@@ -18,6 +20,7 @@ import {
   ModifyRuleCommand,
   ModifyTargetGroupCommand,
   RegisterTargetsCommand,
+  RemoveListenerCertificatesCommand,
   SetRulePrioritiesCommand,
 } from "@aws-sdk/client-elastic-load-balancing-v2";
 import {
@@ -30,6 +33,7 @@ import { describe, it } from "vitest";
 
 import { SimAws } from "../../aws/sim-aws.js";
 import { SimSdk } from "../../../sdk/index.js";
+import { createFixtureCertificate } from "../sim-elbv2.fixture.js";
 
 const functionArn = "arn:aws:lambda:eu-west-2:888888888888:function:checkout";
 
@@ -65,6 +69,16 @@ describe("ELBv2 SDK interception", () => {
     simSdk.intercept(ElasticLoadBalancingV2Client);
 
     const client = new ElasticLoadBalancingV2Client({ region: "eu-west-2" });
+    const acm = simSdk.simAws.region("eu-west-2").acm();
+    const shopCertificateArn = await createFixtureCertificate(
+      simSdk.simAws,
+      acm,
+    );
+    const adminCertificateArn = await createFixtureCertificate(
+      simSdk.simAws,
+      acm,
+      "admin.example.com",
+    );
 
     const loadBalancer = await client.send(
       new CreateLoadBalancerCommand({ Name: "shop-alb" }),
@@ -161,6 +175,41 @@ describe("ELBv2 SDK interception", () => {
       new DescribeRulesCommand({ ListenerArn: listenerArn }),
     );
 
+    const https = await client.send(
+      new CreateListenerCommand({
+        LoadBalancerArn: loadBalancerArn,
+        Protocol: "HTTPS",
+        Port: 443,
+        Certificates: [{ CertificateArn: shopCertificateArn }],
+        DefaultActions: [{ Type: "forward", TargetGroupArn: targetGroupArn }],
+      }),
+    );
+    assertArrayLength(https.Listeners, 1);
+
+    const httpsListenerArn = https.Listeners[0].ListenerArn;
+    assertNonNullable(httpsListenerArn);
+
+    await client.send(
+      new AddListenerCertificatesCommand({
+        ListenerArn: httpsListenerArn,
+        Certificates: [{ CertificateArn: adminCertificateArn }],
+      }),
+    );
+    const certificates = await client.send(
+      new DescribeListenerCertificatesCommand({
+        ListenerArn: httpsListenerArn,
+      }),
+    );
+    await client.send(
+      new RemoveListenerCertificatesCommand({
+        ListenerArn: httpsListenerArn,
+        Certificates: [{ CertificateArn: adminCertificateArn }],
+      }),
+    );
+    await client.send(
+      new DeleteListenerCommand({ ListenerArn: httpsListenerArn }),
+    );
+
     await client.send(new DeleteRuleCommand({ RuleArn: ruleArn }));
     await client.send(new DeleteListenerCommand({ ListenerArn: listenerArn }));
     await client.send(
@@ -175,11 +224,12 @@ describe("ELBv2 SDK interception", () => {
     // Then every command simulated ELBv2 knows about was one of them.
     assertArrayLength(
       new SimAws().elbV2().sdkCommandRouter().supportedCommandNames(),
-      19,
+      22,
     );
 
     // Then each one reached the simulation and the stack was torn down.
     assertArrayLength(health.TargetHealthDescriptions, 1);
+    assertArrayLength(certificates.Certificates, 2);
     assertArrayLength(rules.Rules, 2);
     assertIdentical(rules.Rules[0].Priority, "20");
     assertArrayLength(remaining.LoadBalancers, 0);

--- a/src/service/elbv2/serve/sim-elbv2-serve-https.iso.test.ts
+++ b/src/service/elbv2/serve/sim-elbv2-serve-https.iso.test.ts
@@ -1,0 +1,145 @@
+import { assertIdentical } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { assertDefined } from "../../../util/type-guard/defined.js";
+import { SimAws } from "../../aws/sim-aws.js";
+import type { SimElbV2LoadBalancer } from "../load-balancer/sim-elbv2-load-balancer.js";
+import {
+  createFixtureCertificate,
+  createFixtureHttpsListener,
+  createFixtureListener,
+  createFixtureLoadBalancer,
+  createFixtureRule,
+} from "../sim-elbv2.fixture.js";
+import type { SimElbV2Event, SimElbV2Result } from "./sim-elbv2-event.type.js";
+import { simElbV2Fetch } from "./sim-elbv2-fetch.js";
+import { simElbV2ServingTargetGroupFactory } from "./sim-elbv2-serving-target-group.factory.js";
+
+/**
+ * Answer with the target group's own name, so a response says which one took
+ * the request.
+ */
+function namingHandler(name: string): () => SimElbV2Result {
+  return (): SimElbV2Result => ({ statusCode: 200, body: name });
+}
+
+/**
+ * Answer with the protocol and port the load balancer said the request arrived
+ * on.
+ */
+function forwardedHandler(event: SimElbV2Event): SimElbV2Result {
+  return {
+    statusCode: 200,
+    body: `${String(event.headers["x-forwarded-proto"])} ${String(
+      event.headers["x-forwarded-port"],
+    )}`,
+  };
+}
+
+/**
+ * A load balancer answering on both an HTTP and an HTTPS listener, each with
+ * the same default action and the same rule.
+ *
+ * The two listeners are what makes a test about HTTPS a comparison rather than
+ * an assertion on its own: whatever the HTTP one answers, the HTTPS one has to
+ * answer too.
+ */
+async function makeBothListeners(
+  simAws: SimAws,
+  handler: (event: SimElbV2Event) => SimElbV2Result,
+): Promise<SimElbV2LoadBalancer> {
+  const elbV2 = simAws.elbV2();
+  const checkout = await simElbV2ServingTargetGroupFactory.make(
+    { name: "checkout", handler: namingHandler("checkout") },
+    simAws,
+  );
+  const api = await simElbV2ServingTargetGroupFactory.make(
+    { name: "api", handler },
+    simAws,
+  );
+  const loadBalancerArn = await createFixtureLoadBalancer(elbV2);
+  const certificateArn = await createFixtureCertificate(simAws);
+
+  const http = await createFixtureListener(
+    elbV2,
+    loadBalancerArn,
+    checkout.arn,
+  );
+  const https = await createFixtureHttpsListener(
+    elbV2,
+    loadBalancerArn,
+    checkout.arn,
+    certificateArn,
+  );
+
+  await createFixtureRule(elbV2, http, 10, api.arn, "shop.example.com");
+  await createFixtureRule(elbV2, https, 10, api.arn, "shop.example.com");
+
+  const loadBalancer = elbV2.findLoadBalancerByName("shop-alb");
+  assertDefined(loadBalancer, "Sim ELBv2 created no load balancer shop-alb");
+
+  return loadBalancer;
+}
+
+describe("Serving a sim ELBv2 request over HTTPS", () => {
+  it("evaluates the same rules and reaches the same targets as HTTP", async () => {
+    // Given a load balancer with an HTTP and an HTTPS listener carrying the
+    // same rule
+    const simAws = new SimAws();
+    const loadBalancer = await makeBothListeners(simAws, namingHandler("api"));
+
+    // When the same request is sent to each of them
+    const insecure = await simElbV2Fetch(
+      simAws,
+      `http://${loadBalancer.dnsName}/orders`,
+      { headers: { host: "shop.example.com" } },
+    );
+    const secure = await simElbV2Fetch(
+      simAws,
+      `https://${loadBalancer.dnsName}/orders`,
+      { headers: { host: "shop.example.com" } },
+    );
+
+    // Then the rule claimed both, and the same target group answered
+    assertIdentical(await insecure.text(), "api");
+    assertIdentical(await secure.text(), "api");
+  });
+
+  it("falls through to the HTTPS listener's own default action", async () => {
+    // Given the same load balancer, whose rule is on one host name only
+    const simAws = new SimAws();
+    const loadBalancer = await makeBothListeners(simAws, namingHandler("api"));
+
+    // When a request no rule claims arrives on 443
+    const response = await simElbV2Fetch(
+      simAws,
+      `https://${loadBalancer.dnsName}/orders`,
+    );
+
+    // Then the listener's default action answered it
+    assertIdentical(await response.text(), "checkout");
+  });
+
+  it("tells the target the request arrived over HTTPS", async () => {
+    // Given a load balancer whose target reports the forwarding headers
+    const simAws = new SimAws();
+    const loadBalancer = await makeBothListeners(simAws, forwardedHandler);
+
+    // When a request reaches each listener
+    const insecure = await simElbV2Fetch(
+      simAws,
+      `http://${loadBalancer.dnsName}/orders`,
+      { headers: { host: "shop.example.com" } },
+    );
+    const secure = await simElbV2Fetch(
+      simAws,
+      `https://${loadBalancer.dnsName}/orders`,
+      { headers: { host: "shop.example.com" } },
+    );
+
+    // Then the protocol the event carries is the listener's own, since that is
+    // the protocol the request is treated as having arrived on
+    assertIdentical(await insecure.text(), "http 80");
+    assertIdentical(await secure.text(), "https 443");
+  });
+});

--- a/src/service/elbv2/sim-elbv2.fixture.ts
+++ b/src/service/elbv2/sim-elbv2.fixture.ts
@@ -1,4 +1,6 @@
 import { assertDefined } from "../../util/type-guard/defined.js";
+import type { SimAcm } from "../acm/sim-acm.js";
+import type { SimAws } from "../aws/sim-aws.js";
 import type { SimElbV2 } from "./sim-elbv2.js";
 
 /**
@@ -92,6 +94,57 @@ export async function createFixtureListener(
 
   const arn = output.Listeners?.[0]?.ListenerArn;
   assertDefined(arn, `Sim ELBv2 created no listener on port ${String(port)}`);
+
+  return arn;
+}
+
+/**
+ * Request a certificate from simulated ACM and answer with its ARN once it is
+ * issued.
+ *
+ * A certificate whose domain no hosted zone covers issues on its own, so this
+ * is an issued certificate: a test wanting one still pending validation asks
+ * ACM to require it instead.
+ */
+export async function createFixtureCertificate(
+  simAws: SimAws,
+  acm: SimAcm = simAws.acm(),
+  domainName = "shop.example.com",
+): Promise<string> {
+  const output = await acm.requestCertificate({
+    input: { DomainName: domainName },
+  });
+
+  await simAws.backgroundTasksComplete();
+
+  const arn = output.CertificateArn;
+  assertDefined(arn, `Sim ACM issued no certificate for ${domainName}`);
+
+  return arn;
+}
+
+/**
+ * Create an HTTPS listener on port 443 with a certificate, and answer with its
+ * ARN.
+ */
+export async function createFixtureHttpsListener(
+  elbV2: SimElbV2,
+  loadBalancerArn: string,
+  targetGroupArn: string,
+  certificateArn: string,
+): Promise<string> {
+  const output = await elbV2.createListener({
+    input: {
+      LoadBalancerArn: loadBalancerArn,
+      Protocol: "HTTPS",
+      Port: 443,
+      Certificates: [{ CertificateArn: certificateArn }],
+      DefaultActions: [{ Type: "forward", TargetGroupArn: targetGroupArn }],
+    },
+  });
+
+  const arn = output.Listeners?.[0]?.ListenerArn;
+  assertDefined(arn, "Sim ELBv2 created no HTTPS listener on port 443");
 
   return arn;
 }

--- a/src/service/elbv2/sim-elbv2.ts
+++ b/src/service/elbv2/sim-elbv2.ts
@@ -1,14 +1,7 @@
-import {
-  type BackgroundScheduler,
-  BackgroundTasks,
-} from "../../util/background/background.js";
+import { BackgroundTasks } from "../../util/background/background.js";
 import type { SimSdkCommandRouter } from "../../sdk/router/sim-sdk-command-router.type.js";
-import type { SimAwsAccountRegionScope } from "../aws/sim-aws-account-region-scope.js";
 import { simAwsAccountRegionScopeFactory } from "../aws/sim-aws-account-region-scope.factory.js";
-import {
-  SimIamAllowAllAuth,
-  type SimIamInterServiceAuthZ,
-} from "../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { SimIamAllowAllAuth } from "../iam/authorize/sim-iam-inter-service-auth-z.js";
 import type * as elbV2 from "./command/sim-elbv2-command.types.js";
 import { SimElbV2Commands } from "./command/sim-elbv2-commands.js";
 import type { SimElbV2RequestOptions } from "./command/sim-elbv2-request-options.js";
@@ -18,18 +11,8 @@ import type { SimElbV2LoadBalancer } from "./load-balancer/sim-elbv2-load-balanc
 import { SimElbV2Registry } from "./registry/sim-elbv2-registry.js";
 import { SimElbV2SdkCommandRouter } from "./sdk/sim-elbv2-sdk-command-router.js";
 import { SimElbV2Stores } from "./sim-elbv2-stores.js";
+import type { SimElbV2Properties } from "./sim-elbv2.types.js";
 import type { SimElbV2TargetGroup } from "./target-group/sim-elbv2-target-group.js";
-
-interface SimElbV2Properties {
-  readonly accountRegionScope?: SimAwsAccountRegionScope;
-  readonly iam?: SimIamInterServiceAuthZ;
-  readonly background?: BackgroundScheduler;
-  /**
-   * Cross-scope index of load balancer DNS names, which is how a request
-   * arriving at one finds the Account that owns it.
-   */
-  readonly registry?: SimElbV2Registry;
-}
 
 /**
  * Simulated Elastic Load Balancing v2. Handles SDK commands. Emulates AWS
@@ -66,6 +49,7 @@ export class SimElbV2 {
       iam,
       background,
       accountRegionScope,
+      acmRegistry: properties.acmRegistry,
     });
   }
 
@@ -226,6 +210,36 @@ export class SimElbV2 {
     options?: SimElbV2RequestOptions,
   ): Promise<elbV2.SimDeleteListenerCommandOutput> {
     return await this.commands.deleteListener.handle(command, options);
+  }
+
+  /** Handle an AddListenerCertificates Command from the SDK. */
+  async addListenerCertificates(
+    command: elbV2.SimAddListenerCertificatesCommand,
+    options?: SimElbV2RequestOptions,
+  ): Promise<elbV2.SimAddListenerCertificatesCommandOutput> {
+    return await this.commands.addListenerCertificates.handle(command, options);
+  }
+
+  /** Handle a RemoveListenerCertificates Command from the SDK. */
+  async removeListenerCertificates(
+    command: elbV2.SimRemoveListenerCertificatesCommand,
+    options?: SimElbV2RequestOptions,
+  ): Promise<elbV2.SimRemoveListenerCertificatesCommandOutput> {
+    return await this.commands.removeListenerCertificates.handle(
+      command,
+      options,
+    );
+  }
+
+  /** Handle a DescribeListenerCertificates Command from the SDK. */
+  async describeListenerCertificates(
+    command: elbV2.SimDescribeListenerCertificatesCommand,
+    options?: SimElbV2RequestOptions,
+  ): Promise<elbV2.SimDescribeListenerCertificatesCommandOutput> {
+    return await this.commands.describeListenerCertificates.handle(
+      command,
+      options,
+    );
   }
 
   /** Handle a CreateRule Command from the SDK. */

--- a/src/service/elbv2/sim-elbv2.types.ts
+++ b/src/service/elbv2/sim-elbv2.types.ts
@@ -1,0 +1,30 @@
+import type { BackgroundScheduler } from "../../util/background/background.js";
+import type { SimAcmRegistry } from "../acm/registry/sim-acm-registry.js";
+import type { SimAwsAccountRegionScope } from "../aws/sim-aws-account-region-scope.js";
+import type { SimIamInterServiceAuthZ } from "../iam/authorize/sim-iam-inter-service-auth-z.js";
+import type { SimElbV2Registry } from "./registry/sim-elbv2-registry.js";
+
+/**
+ * What one simulated ELBv2 scope is built with.
+ *
+ * This is held apart from the facade because that file grows by a delegating
+ * method per simulated operation and is close to the max-lines limit, which is
+ * the same reason simulated DynamoDB reads this way.
+ */
+export interface SimElbV2Properties {
+  readonly accountRegionScope?: SimAwsAccountRegionScope;
+  readonly iam?: SimIamInterServiceAuthZ;
+  readonly background?: BackgroundScheduler;
+  /**
+   * Cross-scope index of load balancer DNS names, which is how a request
+   * arriving at one finds the Account that owns it.
+   */
+  readonly registry?: SimElbV2Registry;
+  /**
+   * Cross-scope index of simulated ACM, which is how a listener gets from the
+   * certificate ARN it was given to the certificate that ARN names. With none,
+   * as in a standalone `SimElbV2`, there is no simulated ACM to check a
+   * listener's certificate against and nothing is checked.
+   */
+  readonly acmRegistry?: SimAcmRegistry;
+}


### PR DESCRIPTION
An HTTPS listener now carries a certificate resolved against simulated ACM through the shared registry, refusing one that does not exist, one that is not ISSUED, and one outside the load balancer's own Account and Region, so a test can prove that a stack's certificate and its listener line up. The certificates a listener carries beyond its default are managed with `AddListenerCertificates`, `RemoveListenerCertificates` and `DescribeListenerCertificates`, with the default reported first and refused removal. A request served over HTTPS reaches the same rules and the same targets as an HTTP one, and is forwarded as having arrived on the listener's protocol. No TLS is performed, which the docs say plainly along with what that leaves a test able to conclude.

Resolves https://github.com/KensioSoftware/yulin/issues/565

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added HTTPS listener support with ACM certificate validation.
  - Added management of default and additional listener certificates, including listing, adding, and removing certificates.
  - Added HTTPS request forwarding with protocol and port metadata.
  - Added validation for certificate status, account, region, listener protocol, and protected default certificates.
- **Documentation**
  - Added HTTPS listener behavior, certificate lifecycle, examples, and simulation limitations.
- **Tests**
  - Expanded coverage for certificate operations, HTTPS routing, validation, pagination, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->