### PR TITLE
feat: deploy sim ECS from CloudFormation

### DIFF
--- a/docs/services/ecs/README.md
+++ b/docs/services/ecs/README.md
@@ -1490,6 +1490,10 @@ Current documented limitations:
 - A deploy-time binding is checked against the template as the stack is built, so a family, a
   container name or an image repository built from another Resource's attribute rather than written
   as a string resolves to nothing and fails the deployment.
+- A `TaskRoleArn` or `ExecutionRoleArn` given as a `Ref` to a role resolves to the role name, which
+  is turned into the ARN that name would have at the default path. A role declaring a `Path` of its
+  own therefore resolves to an ARN without it. This is what an `AWS::Lambda::Function` `Role` already
+  does, so the two agree, and naming the role by `Fn::GetAtt` `Arn` gets the real ARN either way.
 - Cluster and family names are validated to the 255 letters, numbers, hyphens and underscores real
   ECS accepts, but error messages differ from the real ones.
 - Account-wide limits do not exist, so no request fails for having registered too many task

--- a/docs/services/ecs/README.md
+++ b/docs/services/ecs/README.md
@@ -997,6 +997,190 @@ Closing the simulated environment with `simAws.close()` stops the tasks of every
 nothing is left scheduled either way: a service is kept as state rather than by a timer, so a test
 that finishes with a service running leaves nothing behind it.
 
+## Deploying ECS from CloudFormation
+
+`AWS::ECS::Cluster` creates a simulated cluster, and `AWS::ECS::TaskDefinition` registers a
+simulated task definition revision, so a test can start from the stack the application is actually
+defined in rather than from `RegisterTaskDefinition` calls written for the test.
+
+`Ref` on a cluster returns the cluster name and `Fn::GetAtt` `Arn` returns its ARN. `Ref` on a task
+definition returns the task definition ARN, revision and all, which is also what `Fn::GetAtt`
+`TaskDefinitionArn` returns. Each deployment registers a new revision, as real CloudFormation does,
+because a revision is immutable and a changed one is a new revision of the same family.
+
+Containers are stored as declared, whatever their image, and what makes one of them run is an
+executable binding supplied at deploy time, in the same `bindings` list a Lambda function handler is
+supplied in. A container binding targets a container by family and container name, by the logical ID
+of the task definition that declares it, or by the repository its image comes from.
+
+```typescript sim-ecs-cloudformation-task-definition
+/**
+ * Deploying an ECS stack and binding a handler to one of its containers.
+ */
+
+import { RunTaskCommand } from "@aws-sdk/client-ecs";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+const processedOrders: string[] = [];
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "orders",
+  template: {
+    Resources: {
+      OrdersCluster: {
+        Type: "AWS::ECS::Cluster",
+        Properties: { ClusterName: "orders" },
+      },
+      WorkerTaskDefinition: {
+        Type: "AWS::ECS::TaskDefinition",
+        Properties: {
+          Family: "orders-worker",
+          Cpu: "512",
+          Memory: "1024",
+          NetworkMode: "awsvpc",
+          RequiresCompatibilities: ["FARGATE"],
+          ContainerDefinitions: [
+            {
+              Name: "app",
+              Image: "example.dkr.ecr.eu-west-2.amazonaws.com/orders-worker:1",
+              Essential: true,
+              Environment: [{ Name: "LOG_LEVEL", Value: "debug" }],
+            },
+          ],
+        },
+      },
+    },
+    Outputs: {
+      TaskDefinition: { Value: { Ref: "WorkerTaskDefinition" } },
+    },
+  },
+  bindings: [
+    {
+      family: "orders-worker",
+      containerName: "app",
+      run: async (): Promise<void> => {
+        await Promise.resolve();
+        processedOrders.push("outstanding orders");
+      },
+    },
+  ],
+});
+
+await stack.waitForDeployComplete();
+
+console.log(stack.outputs.get("TaskDefinition")?.value);
+// "arn:aws:ecs:us-east-1:888888888888:task-definition/orders-worker:1"
+
+// Running a task from the deployed task definition runs the bound handler.
+await simAws
+  .ecs()
+  .runTask(
+    new RunTaskCommand({ cluster: "orders", taskDefinition: "orders-worker" }),
+  );
+
+await simAws.backgroundTasksComplete();
+
+console.log(processedOrders); // ["outstanding orders"]
+```
+
+A binding can name the task definition Resource instead, which is what a CDK stack gives a test to
+name: the construct ID is accepted as well as the synthesized logical ID, and the container name can
+be left out where the task definition declares one container. A binding naming an image repository
+matches any container running an image from it, whichever family declares it, which covers a tag
+that changes with every build.
+
+```typescript sim-ecs-cloudformation-binding-targets
+/**
+ * Binding a container by the task definition Resource and by its repository.
+ */
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "orders",
+  template: {
+    Resources: {
+      WorkerTaskDefinition: {
+        Type: "AWS::ECS::TaskDefinition",
+        Metadata: { "aws:cdk:path": "OrdersStack/WorkerTask/Resource" },
+        Properties: {
+          Family: "orders-worker",
+          ContainerDefinitions: [
+            {
+              Name: "app",
+              Image: "example.dkr.ecr.eu-west-2.amazonaws.com/orders-worker:1",
+            },
+            {
+              Name: "log-router",
+              Image: "public.ecr.aws/aws-observability/aws-for-fluent-bit:1",
+            },
+          ],
+        },
+      },
+      CheckoutTaskDefinition: {
+        Type: "AWS::ECS::TaskDefinition",
+        Properties: {
+          Family: "orders-checkout",
+          ContainerDefinitions: [
+            {
+              Name: "app",
+              Image: "example.dkr.ecr.eu-west-2.amazonaws.com/checkout:9f21c0",
+            },
+          ],
+        },
+      },
+    },
+  },
+  bindings: [
+    // The CDK construct ID, naming the container because this task definition
+    // declares more than one.
+    {
+      logicalId: "WorkerTask",
+      containerName: "app",
+      run: (): void => {
+        // Whatever the worker does.
+      },
+    },
+    // Any container running an image from this repository, whatever its tag.
+    {
+      imageRepository: "example.dkr.ecr.eu-west-2.amazonaws.com/checkout",
+      run: (): void => {
+        // Whatever the checkout container does.
+      },
+    },
+  ],
+});
+
+await stack.waitForDeployComplete();
+
+console.log(simAws.ecs().taskDefinition("orders-worker").revision); // 1
+```
+
+A binding that resolves to no Resource in the stack fails the deployment naming the binding, since
+the usual cause is a container renamed in the template and not in the test. A container with no
+binding is a different thing: the stack deploys, the container is stored as declared, and it is
+recorded as not simulated when a task runs, which is what lets a task definition holding a log
+router and an observability agent alongside the application deploy and run.
+
+A task definition's `TaskRoleArn` and `ExecutionRoleArn` resolve whether the template gives an ARN
+or a `Ref` to an `AWS::IAM::Role` of the same stack, so a container's AWS calls are authorized as
+the role the stack deploys.
+
+Everything else the two Resource types declare is stored as declared, or recorded as ignored where
+this simulation has nothing to act on it with. `CapacityProviders`,
+`DefaultCapacityProviderStrategy` and `ServiceConnectDefaults` on a cluster, and
+`InferenceAccelerators` and `EnableFaultInjection` on a task definition, are read and ignored rather
+than failing the stack, and each one is reported on the Resource:
+
+```typescript
+console.log(stack.resources.get("OrdersCluster")?.ignoredProperties);
+```
+
 ## Authorization
 
 Every operation is authorized by simulated IAM against the real ECS action.
@@ -1162,6 +1346,11 @@ console.log(described.taskDefinition?.revision); // 1
 - `DescribeServicesCommand` and `DeleteServiceCommand`, with the `force` a scaled-up service needs
 - `ListTasks` filtering by `serviceName`, so a service's tasks can be listed on their own
 - `bindContainer`, targeting a container by family and container name or by image repository
+- `AWS::ECS::Cluster`, answering `Ref` with the cluster name and `Fn::GetAtt` with `Arn`
+- `AWS::ECS::TaskDefinition`, registering a revision and answering `Ref` with its ARN
+- Deploy-time container bindings, targeting a container by family and container name, by the task
+  definition's logical ID or CDK construct ID, or by its image repository
+- Task and execution roles resolved from a `Ref` to a same-stack role or from an ARN
 - Container environment variables and `RunTask` container overrides, through `process.env`
 - Container AWS calls authorized as the task role, including a `RunTask` `taskRoleArn` override
 - Container `secrets` resolved from simulated Secrets Manager and SSM Parameter Store as the
@@ -1279,9 +1468,28 @@ Current documented limitations:
   `DescribeServices` and `ListTasks` are what report those.
 - Task definition and cluster tags are stored and reported, but `TagResource`,
   `UntagResource` and `ListTagsForResource` are not simulated.
-- There are no ECS CloudFormation resource types yet. `AWS::ECS::Cluster`,
-  `AWS::ECS::TaskDefinition` and `AWS::ECS::Service` are reported as unsupported and skipped rather
-  than deployed.
+- `AWS::ECS::Service` is not deployed yet. A template declaring one is reported as unsupported and
+  skipped rather than failing the stack.
+- A cluster or task definition the template does not name gets a name composed from the stack name
+  and the logical ID, without the random part real CloudFormation adds, so a test can predict it. A
+  stack deployed twice under different names therefore gets two different families.
+- An update replaces a task definition Resource rather than updating it in place, so it registers a
+  new revision and deregisters the one it replaced. The family accumulates revisions with only the
+  newest one `ACTIVE`, where real CloudFormation leaves the earlier revisions active.
+- A stack teardown deletes its cluster, leaving it `INACTIVE`, and deregisters the revision it
+  registered, leaving that `INACTIVE`. Neither is removed, and revision numbers are not freed.
+- CloudFormation property names are translated to the API's by lowering the first letter of each of
+  them, all the way down, apart from `EFSVolumeConfiguration`,
+  `FSxWindowsFileServerVolumeConfiguration` and `ProxyConfigurationProperties`, which the API spells
+  differently. `DockerLabels`, `Options`, `DriverOpts` and `Labels` hold keys the template wrote, so
+  those are left alone. A name outside all of that is stored under the name lowering gives it.
+- `CapacityProviders`, `DefaultCapacityProviderStrategy` and `ServiceConnectDefaults` on a cluster,
+  and `InferenceAccelerators` and `EnableFaultInjection` on a task definition, are read and recorded
+  as ignored rather than refused, where the equivalent SDK request is refused. A stack that will not
+  deploy is worth less to a test than a Resource without a property nothing here acts on.
+- A deploy-time binding is checked against the template as the stack is built, so a family, a
+  container name or an image repository built from another Resource's attribute rather than written
+  as a string resolves to nothing and fails the deployment.
 - Cluster and family names are validated to the 255 letters, numbers, hyphens and underscores real
   ECS accepts, but error messages differ from the real ones.
 - Account-wide limits do not exist, so no request fails for having registered too many task

--- a/docs/services/ecs/sim-ecs-cloudformation-binding-targets.example.ts
+++ b/docs/services/ecs/sim-ecs-cloudformation-binding-targets.example.ts
@@ -1,0 +1,66 @@
+/**
+ * Binding a container by the task definition Resource and by its repository.
+ */
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "orders",
+  template: {
+    Resources: {
+      WorkerTaskDefinition: {
+        Type: "AWS::ECS::TaskDefinition",
+        Metadata: { "aws:cdk:path": "OrdersStack/WorkerTask/Resource" },
+        Properties: {
+          Family: "orders-worker",
+          ContainerDefinitions: [
+            {
+              Name: "app",
+              Image: "example.dkr.ecr.eu-west-2.amazonaws.com/orders-worker:1",
+            },
+            {
+              Name: "log-router",
+              Image: "public.ecr.aws/aws-observability/aws-for-fluent-bit:1",
+            },
+          ],
+        },
+      },
+      CheckoutTaskDefinition: {
+        Type: "AWS::ECS::TaskDefinition",
+        Properties: {
+          Family: "orders-checkout",
+          ContainerDefinitions: [
+            {
+              Name: "app",
+              Image: "example.dkr.ecr.eu-west-2.amazonaws.com/checkout:9f21c0",
+            },
+          ],
+        },
+      },
+    },
+  },
+  bindings: [
+    // The CDK construct ID, naming the container because this task definition
+    // declares more than one.
+    {
+      logicalId: "WorkerTask",
+      containerName: "app",
+      run: (): void => {
+        // Whatever the worker does.
+      },
+    },
+    // Any container running an image from this repository, whatever its tag.
+    {
+      imageRepository: "example.dkr.ecr.eu-west-2.amazonaws.com/checkout",
+      run: (): void => {
+        // Whatever the checkout container does.
+      },
+    },
+  ],
+});
+
+await stack.waitForDeployComplete();
+
+console.log(simAws.ecs().taskDefinition("orders-worker").revision); // 1

--- a/docs/services/ecs/sim-ecs-cloudformation-task-definition.example.ts
+++ b/docs/services/ecs/sim-ecs-cloudformation-task-definition.example.ts
@@ -1,0 +1,70 @@
+/**
+ * Deploying an ECS stack and binding a handler to one of its containers.
+ */
+
+import { RunTaskCommand } from "@aws-sdk/client-ecs";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+const processedOrders: string[] = [];
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "orders",
+  template: {
+    Resources: {
+      OrdersCluster: {
+        Type: "AWS::ECS::Cluster",
+        Properties: { ClusterName: "orders" },
+      },
+      WorkerTaskDefinition: {
+        Type: "AWS::ECS::TaskDefinition",
+        Properties: {
+          Family: "orders-worker",
+          Cpu: "512",
+          Memory: "1024",
+          NetworkMode: "awsvpc",
+          RequiresCompatibilities: ["FARGATE"],
+          ContainerDefinitions: [
+            {
+              Name: "app",
+              Image: "example.dkr.ecr.eu-west-2.amazonaws.com/orders-worker:1",
+              Essential: true,
+              Environment: [{ Name: "LOG_LEVEL", Value: "debug" }],
+            },
+          ],
+        },
+      },
+    },
+    Outputs: {
+      TaskDefinition: { Value: { Ref: "WorkerTaskDefinition" } },
+    },
+  },
+  bindings: [
+    {
+      family: "orders-worker",
+      containerName: "app",
+      run: async (): Promise<void> => {
+        await Promise.resolve();
+        processedOrders.push("outstanding orders");
+      },
+    },
+  ],
+});
+
+await stack.waitForDeployComplete();
+
+console.log(stack.outputs.get("TaskDefinition")?.value);
+// "arn:aws:ecs:us-east-1:888888888888:task-definition/orders-worker:1"
+
+// Running a task from the deployed task definition runs the bound handler.
+await simAws
+  .ecs()
+  .runTask(
+    new RunTaskCommand({ cluster: "orders", taskDefinition: "orders-worker" }),
+  );
+
+await simAws.backgroundTasksComplete();
+
+console.log(processedOrders); // ["outstanding orders"]

--- a/src/service/cloudformation/README.md
+++ b/src/service/cloudformation/README.md
@@ -36,7 +36,8 @@ familiar CloudFormation/CDK outputs.
   `update/`.
 - `cdk/` contains CDK-specific integration support, including synthesized output context and custom
   resource implementations.
-- `bind/` contains executable resource binding types used by CDK/custom-resource simulation.
+- `bind/` contains the binding types a deployment supplies real in-process handlers through, and
+  what checks each one against the Stack it was given for.
 - `error/` contains CloudFormation-specific AWS-like errors.
 
 A `SimCloudFormation` instance owns a map of stacks for one account/region scope.
@@ -157,6 +158,18 @@ The deployer is also where extra deployment context can enter the stack creation
 - `SimCdkOutContext`, used by CDK-oriented resources that need access to synthesized output files.
 - executable resource bindings, used by custom-resource simulation that needs to connect a template
   resource to local executable behaviour.
+
+`SimCfnDeployBinding` is what one entry of that list may be, and there are two kinds because there
+are two kinds of thing a Stack declares that Yulin can run. An executable Resource, which is a Lambda
+function or a CloudFront Function, is one handler and carries it as `handler`. An ECS task definition
+declares containers, so its binding names a container and carries what that container does. They are
+one list because a Stack is deployed once and a realistic Stack holds both, and the handler is what
+tells them apart, since the two kinds share some of their target names.
+
+`validateSimCfnExecutableResourceBindings` checks every binding resolves to a Resource of the Stack
+before anything is created, sending each kind to its own matcher. The container matcher lives with
+simulated ECS, because deciding whether a binding names a container a task definition declares means
+reading an `AWS::ECS::TaskDefinition`, and no service's schema belongs in the engine.
 
 The important design point is that these helpers do not bypass stack/resource lifecycle. They feed
 additional context into the normal CloudFormation creation pipeline.
@@ -631,6 +644,7 @@ The resolver currently supports factories for:
 - `AWS::CloudFormation::*`
 - `AWS::S3::*`
 - `AWS::CloudFront::*`
+- `AWS::ECS::*`
 - selected `Custom::*` CDK-oriented resources
 
 Unsupported providers, services, custom resources, or resource types are skipped to improve

--- a/src/service/cloudformation/bind/sim-cfn-deploy-binding.ts
+++ b/src/service/cloudformation/bind/sim-cfn-deploy-binding.ts
@@ -1,0 +1,40 @@
+import type { SimCfnEcsContainerBinding } from "../../ecs/cfn/bind/sim-cfn-ecs-container-binding.type.js";
+import type { SimCfnExecutableResourceBinding } from "./sim-cfn-exec-binding.type.js";
+
+/**
+ * A real in-process handler a deployment binds to a Resource of its Stack.
+ *
+ * There are two kinds, because there are two kinds of thing a Stack declares
+ * that Yulin can run. An executable Resource, which is a Lambda function or a
+ * CloudFront Function, is one handler and is bound with `handler`. An ECS task
+ * definition declares containers, so its binding names a container and carries
+ * what that container does.
+ *
+ * They are one list because a Stack is deployed once, and a realistic Stack
+ * holds both.
+ */
+export type SimCfnDeployBinding =
+  | SimCfnExecutableResourceBinding
+  | SimCfnEcsContainerBinding;
+
+/**
+ * Whether a binding backs an executable Resource with one handler.
+ *
+ * The handler is what tells the two kinds apart, since only an executable
+ * Resource binding carries one. Everything else in a binding is a target, and
+ * the two kinds share some of their target names.
+ */
+export function simCfnIsExecutableBinding(
+  binding: SimCfnDeployBinding,
+): binding is SimCfnExecutableResourceBinding {
+  return "handler" in binding;
+}
+
+/**
+ * Whether a binding targets a container an ECS task definition declares.
+ */
+export function simCfnIsContainerBinding(
+  binding: SimCfnDeployBinding,
+): binding is SimCfnEcsContainerBinding {
+  return !simCfnIsExecutableBinding(binding);
+}

--- a/src/service/cloudformation/bind/validate/sim-cfn-exec-binding-finder.ts
+++ b/src/service/cloudformation/bind/validate/sim-cfn-exec-binding-finder.ts
@@ -1,3 +1,7 @@
+import {
+  type SimCfnDeployBinding,
+  simCfnIsExecutableBinding,
+} from "../sim-cfn-deploy-binding.js";
 import type {
   SimCfnExecutableResource,
   SimCfnExecutableResourceBinding,
@@ -8,7 +12,7 @@ import type { SimCfnResource } from "../../resource/sim-cfn-resource.js";
 
 interface SimCfnExecBindingFinderProperties {
   readonly resource: SimCfnResource;
-  readonly bindings?: readonly SimCfnExecutableResourceBinding[] | undefined;
+  readonly bindings?: readonly SimCfnDeployBinding[] | undefined;
 }
 
 /**
@@ -53,7 +57,13 @@ export class SimCfnExecBindingFinder<
   constructor(properties: SimCfnExecBindingFinderProperties) {
     this.resource = properties.resource;
     this.cdkPath = new SimCfnResourceCdkPath(properties.resource);
-    this.bindings = properties.bindings;
+    // A deployment's bindings are one list holding both kinds, and a container
+    // binding can name a logical ID as an executable one can. Dropping them
+    // here is what stops a container binding backing a function that happens
+    // to share the task definition's logical ID.
+    this.bindings = properties.bindings?.filter((binding) =>
+      simCfnIsExecutableBinding(binding),
+    );
   }
 
   /**

--- a/src/service/cloudformation/bind/validate/sim-cfn-exec-binding-validator.ts
+++ b/src/service/cloudformation/bind/validate/sim-cfn-exec-binding-validator.ts
@@ -1,34 +1,64 @@
+import { SimCfnEcsContainerBindingMatcher } from "../../../ecs/cfn/bind/sim-cfn-ecs-container-binding-matcher.js";
+import {
+  type SimCfnDeployBinding,
+  simCfnIsExecutableBinding,
+} from "../sim-cfn-deploy-binding.js";
 import type { SimCfnExecutableResourceBinding } from "../sim-cfn-exec-binding.type.js";
 import type { SimCfnResource } from "../../resource/sim-cfn-resource.js";
 import { SimCfnExecutableResourceBindingMatcher } from "./sim-cfn-exec-binding-matcher.js";
 
 /**
- * Validate that every executable binding targets a Resource in the Stack.
+ * Validate that every binding a deployment supplied targets a Resource in the
+ * Stack.
  *
  * The validator owns the high-level validation contract: each supplied binding
  * must resolve to a synthesized CloudFormation Resource. The detailed matching
- * rules live in `SimCfnExecutableResourceBindingMatcher`, which keeps this file
- * small and focused on reporting actionable validation errors.
+ * rules live with whichever kind of binding it is, in
+ * `SimCfnExecutableResourceBindingMatcher` for a handler backing an executable
+ * Resource and in `SimCfnEcsContainerBindingMatcher` for a container an ECS
+ * task definition declares, which keeps this file small and focused on
+ * reporting actionable validation errors.
  */
 export function validateSimCfnExecutableResourceBindings(properties: {
   readonly stackName: string;
   readonly resources: ReadonlyMap<string, SimCfnResource>;
-  readonly bindings?: readonly SimCfnExecutableResourceBinding[] | undefined;
+  readonly bindings?: readonly SimCfnDeployBinding[] | undefined;
 }): void {
   const bindings = properties.bindings ?? [];
   const matcher = new SimCfnExecutableResourceBindingMatcher(
     properties.resources,
   );
+  const containerMatcher = new SimCfnEcsContainerBindingMatcher(
+    properties.resources,
+  );
 
   for (const binding of bindings) {
+    if (!simCfnIsExecutableBinding(binding)) {
+      if (containerMatcher.matches(binding)) {
+        continue;
+      }
+
+      throw unresolvedBindingError(
+        properties.stackName,
+        SimCfnEcsContainerBindingMatcher.describe(binding),
+      );
+    }
+
     if (matcher.matches(binding)) {
       continue;
     }
 
-    throw new Error(
-      `Invalid sim CloudFormation executable binding in Stack ${properties.stackName}: ${describeBinding(binding)} does not resolve to a Resource in the Stack`,
+    throw unresolvedBindingError(
+      properties.stackName,
+      describeBinding(binding),
     );
   }
+}
+
+function unresolvedBindingError(stackName: string, described: string): Error {
+  return new Error(
+    `Invalid sim CloudFormation executable binding in Stack ${stackName}: ${described} does not resolve to a Resource in the Stack`,
+  );
 }
 
 function describeBinding(binding: SimCfnExecutableResourceBinding): string {

--- a/src/service/cloudformation/command/create-stack/create-stack.handler.ts
+++ b/src/service/cloudformation/command/create-stack/create-stack.handler.ts
@@ -22,7 +22,7 @@ import {
 import { SimCfnParameters } from "../../parameters/sim-cfn-parameters.js";
 import type { JSONString } from "../../../../util/type-guard/json.js";
 import type { SimCdkOutContext } from "../../cdk/sim-cdk-out-context.js";
-import type { SimCfnExecutableResourceBinding } from "../../bind/sim-cfn-exec-binding.type.js";
+import type { SimCfnDeployBinding } from "../../bind/sim-cfn-deploy-binding.js";
 
 interface CreateStackCommandHandlerProperties {
   readonly simAws: SimAws;
@@ -30,7 +30,7 @@ interface CreateStackCommandHandlerProperties {
   readonly stacks: Map<SimCloudFormationStackName, SimCfnStack>;
   readonly background: BackgroundScheduler & BackgroundCompleter;
   readonly cdkOutContext?: SimCdkOutContext | undefined;
-  readonly bindings?: readonly SimCfnExecutableResourceBinding[] | undefined;
+  readonly bindings?: readonly SimCfnDeployBinding[] | undefined;
 }
 
 /**
@@ -47,9 +47,7 @@ export class CreateStackCommandHandler implements CommandHandler<
   private readonly stacks: Map<SimCloudFormationStackName, SimCfnStack>;
   private readonly background: BackgroundScheduler & BackgroundCompleter;
   private readonly cdkOutContext: SimCdkOutContext | undefined;
-  private readonly bindings:
-    | readonly SimCfnExecutableResourceBinding[]
-    | undefined;
+  private readonly bindings: readonly SimCfnDeployBinding[] | undefined;
 
   constructor(properties: CreateStackCommandHandlerProperties) {
     const {

--- a/src/service/cloudformation/deploy/sim-cfn-template-deployer.ts
+++ b/src/service/cloudformation/deploy/sim-cfn-template-deployer.ts
@@ -16,7 +16,7 @@ import {
 import { SimCfnTemplateFileUpdater } from "./sim-cfn-template-file-updater.js";
 import { simCfnTemplateFileDeployment } from "./sim-cfn-template-file-deployment.js";
 import { SimCfnTemplateFileWatches } from "../watch/sim-cfn-template-file-watches.js";
-import type { SimCfnExecutableResourceBinding } from "../bind/sim-cfn-exec-binding.type.js";
+import type { SimCfnDeployBinding } from "../bind/sim-cfn-deploy-binding.js";
 import type { SimAws } from "../../aws/sim-aws.js";
 import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
 import type {
@@ -31,7 +31,7 @@ export interface SimCloudFormationCreateStackProperties {
   readonly stackName?: SimCloudFormationStackName | string;
   readonly template: CfnTemplateBodyRecord;
   readonly parameters?: Record<string, string> | undefined;
-  readonly bindings?: readonly SimCfnExecutableResourceBinding[] | undefined;
+  readonly bindings?: readonly SimCfnDeployBinding[] | undefined;
 
   /**
    * The synthesized CDK template file this in-memory template stands in for.
@@ -156,7 +156,7 @@ export class SimCloudFormationTemplateDeployer {
     readonly stackName: SimCloudFormationStackName | string;
     readonly template: CfnTemplateBodyRecord;
     readonly parameters?: Record<string, string> | undefined;
-    readonly bindings?: readonly SimCfnExecutableResourceBinding[] | undefined;
+    readonly bindings?: readonly SimCfnDeployBinding[] | undefined;
     readonly cdkOutContext?: SimCdkOutContext | undefined;
   }): Promise<SimCfnStack> {
     await this.createStackWithContext(
@@ -201,7 +201,7 @@ export class SimCloudFormationTemplateDeployer {
       };
     },
     cdkOutContext?: SimCdkOutContext,
-    bindings?: readonly SimCfnExecutableResourceBinding[],
+    bindings?: readonly SimCfnDeployBinding[],
   ): Promise<SimCreateStackCommandOutput> {
     const handler = new CreateStackCommandHandler({
       simAws: this.simAws,

--- a/src/service/cloudformation/deploy/sim-cfn-template-file-loader.ts
+++ b/src/service/cloudformation/deploy/sim-cfn-template-file-loader.ts
@@ -7,7 +7,7 @@ import {
   loadSiblingCdkAssetsManifest,
   type SimCdkOutContext,
 } from "../cdk/sim-cdk-out-context.js";
-import type { SimCfnExecutableResourceBinding } from "../bind/sim-cfn-exec-binding.type.js";
+import type { SimCfnDeployBinding } from "../bind/sim-cfn-deploy-binding.js";
 import { simWatch } from "../../../watch/sim-watch-runtime.js";
 import type { SimCfnTemplateFileWatchOptions } from "../watch/sim-cfn-template-watch.type.js";
 import { simCfnTemplateFileDeployment } from "./sim-cfn-template-file-deployment.js";
@@ -20,7 +20,7 @@ export interface SimCloudFormationDeployTemplateFileProperties {
   readonly templatePath: string;
   readonly stackName?: SimCloudFormationStackName | string | undefined;
   readonly parameters?: Record<string, string> | undefined;
-  readonly bindings?: readonly SimCfnExecutableResourceBinding[] | undefined;
+  readonly bindings?: readonly SimCfnDeployBinding[] | undefined;
 
   /**
    * Adapt the parsed template before it is deployed, and again every time a
@@ -56,7 +56,7 @@ export interface SimCfnLoadedTemplateFile {
   readonly stackName: SimCloudFormationStackName | string;
   readonly template: CfnTemplateBodyRecord;
   readonly parameters?: Record<string, string> | undefined;
-  readonly bindings?: readonly SimCfnExecutableResourceBinding[] | undefined;
+  readonly bindings?: readonly SimCfnDeployBinding[] | undefined;
   readonly cdkOutContext?: SimCdkOutContext | undefined;
 }
 

--- a/src/service/cloudformation/resource/cfn/ecs/sim-ecs-cfn-value-adapter.ts
+++ b/src/service/cloudformation/resource/cfn/ecs/sim-ecs-cfn-value-adapter.ts
@@ -1,0 +1,33 @@
+import { SimEcsCluster } from "../../../../ecs/cluster/sim-ecs-cluster.js";
+import { SimEcsTaskDefinition } from "../../../../ecs/task-definition/sim-ecs-task-definition.js";
+import type {
+  SimCfnResourceValueAdapterProperties,
+  SimCfnServiceValueAdapter,
+} from "../sim-cfn-resource-value-adapter.js";
+import { SimEcsClusterCfn } from "./sim-ecs-cluster-cfn.js";
+import { SimEcsTaskDefinitionCfn } from "./sim-ecs-task-definition-cfn.js";
+
+/**
+ * The CloudFormation-facing value adapter for a simulated ECS Resource.
+ */
+export function ecsValueAdapter(
+  properties: SimCfnResourceValueAdapterProperties,
+): SimCfnServiceValueAdapter {
+  if (
+    properties.type === "AWS::ECS::Cluster" &&
+    properties.simResource instanceof SimEcsCluster
+  ) {
+    return new SimEcsClusterCfn({ cluster: properties.simResource });
+  }
+
+  if (
+    properties.type === "AWS::ECS::TaskDefinition" &&
+    properties.simResource instanceof SimEcsTaskDefinition
+  ) {
+    return new SimEcsTaskDefinitionCfn({
+      taskDefinition: properties.simResource,
+    });
+  }
+
+  return undefined;
+}

--- a/src/service/cloudformation/resource/cfn/ecs/sim-ecs-cluster-cfn.ts
+++ b/src/service/cloudformation/resource/cfn/ecs/sim-ecs-cluster-cfn.ts
@@ -1,0 +1,41 @@
+import type { SimEcsCluster } from "../../../../ecs/cluster/sim-ecs-cluster.js";
+import type { SimCfnTemplateValue } from "../../../template/value/sim-cfn-template-value.js";
+import type { SimCfnResourceValueAdapter } from "../sim-cfn-resource-value-adapter.js";
+
+interface SimEcsClusterCfnProperties {
+  readonly cluster: SimEcsCluster;
+}
+
+/**
+ * CloudFormation-facing values for a simulated ECS cluster.
+ */
+export class SimEcsClusterCfn implements SimCfnResourceValueAdapter {
+  private readonly cluster: SimEcsCluster;
+
+  constructor(properties: SimEcsClusterCfnProperties) {
+    this.cluster = properties.cluster;
+  }
+
+  /**
+   * AWS::ECS::Cluster Ref returns the cluster name.
+   */
+  refValue(): SimCfnTemplateValue {
+    return this.cluster.clusterName;
+  }
+
+  /**
+   * AWS::ECS::Cluster attributes.
+   *
+   * The ARN is the only one, and it is what a service, a task and an IAM
+   * policy all name the cluster by.
+   */
+  attributeValue(attributeName: string): SimCfnTemplateValue {
+    if (attributeName !== "Arn") {
+      throw new Error(
+        `Unsupported AWS::ECS::Cluster attribute ${attributeName}`,
+      );
+    }
+
+    return this.cluster.clusterArn;
+  }
+}

--- a/src/service/cloudformation/resource/cfn/ecs/sim-ecs-task-definition-cfn.ts
+++ b/src/service/cloudformation/resource/cfn/ecs/sim-ecs-task-definition-cfn.ts
@@ -1,0 +1,47 @@
+import type { SimEcsTaskDefinition } from "../../../../ecs/task-definition/sim-ecs-task-definition.js";
+import type { SimCfnTemplateValue } from "../../../template/value/sim-cfn-template-value.js";
+import type { SimCfnResourceValueAdapter } from "../sim-cfn-resource-value-adapter.js";
+
+interface SimEcsTaskDefinitionCfnProperties {
+  readonly taskDefinition: SimEcsTaskDefinition;
+}
+
+/**
+ * CloudFormation-facing values for a simulated ECS task definition.
+ */
+export class SimEcsTaskDefinitionCfn implements SimCfnResourceValueAdapter {
+  private readonly taskDefinition: SimEcsTaskDefinition;
+
+  constructor(properties: SimEcsTaskDefinitionCfnProperties) {
+    this.taskDefinition = properties.taskDefinition;
+  }
+
+  /**
+   * AWS::ECS::TaskDefinition Ref returns the task definition ARN, revision and
+   * all.
+   *
+   * The revision is the point of it. A service or a scheduled task naming the
+   * family alone would follow the latest revision, where a Ref pins what the
+   * stack deployed, which is what makes an update of the stack a change of
+   * what runs.
+   */
+  refValue(): SimCfnTemplateValue {
+    return this.taskDefinition.taskDefinitionArn;
+  }
+
+  /**
+   * AWS::ECS::TaskDefinition attributes.
+   *
+   * `TaskDefinitionArn` is the only one, and it answers with the same ARN Ref
+   * does.
+   */
+  attributeValue(attributeName: string): SimCfnTemplateValue {
+    if (attributeName !== "TaskDefinitionArn") {
+      throw new Error(
+        `Unsupported AWS::ECS::TaskDefinition attribute ${attributeName}`,
+      );
+    }
+
+    return this.taskDefinition.taskDefinitionArn;
+  }
+}

--- a/src/service/cloudformation/resource/cfn/sim-cfn-resource-value-adapter.ts
+++ b/src/service/cloudformation/resource/cfn/sim-cfn-resource-value-adapter.ts
@@ -5,6 +5,7 @@ import { cloudFrontValueAdapter } from "./cloudfront/sim-cloudfront-cfn-value-ad
 import { cognitoValueAdapter } from "./cognito/sim-cognito-cfn-value-adapter.js";
 import { dynamoDbValueAdapter } from "./dynamodb/sim-dynamodb-cfn-value-adapter.js";
 import { ecrValueAdapter } from "./ecr/sim-ecr-cfn-value-adapter.js";
+import { ecsValueAdapter } from "./ecs/sim-ecs-cfn-value-adapter.js";
 import { eventBridgeValueAdapter } from "./events/sim-event-bridge-cfn-value-adapter.js";
 import { iamValueAdapter } from "./iam/sim-iam-cfn-value-adapter.js";
 import { kmsValueAdapter } from "./kms/sim-kms-cfn-value-adapter.js";
@@ -58,6 +59,7 @@ export function simCfnResourceValueAdapter(
     cognitoValueAdapter(properties) ??
     dynamoDbValueAdapter(properties) ??
     ecrValueAdapter(properties) ??
+    ecsValueAdapter(properties) ??
     eventBridgeValueAdapter(properties) ??
     iamValueAdapter(properties) ??
     kmsValueAdapter(properties) ??

--- a/src/service/cloudformation/resource/resolve/service/sim-cfn-service-factories.ts
+++ b/src/service/cloudformation/resource/resolve/service/sim-cfn-service-factories.ts
@@ -65,6 +65,11 @@ export const simCfnServiceResourceFactories: ReadonlyMap<
       scopedAws.ecr().cfnResourceFactory(),
   ],
   [
+    "ECS",
+    (scopedAws): SimCfnServiceResourceFactory =>
+      scopedAws.ecs().cfnResourceFactory(),
+  ],
+  [
     "IAM",
     (scopedAws): SimCfnServiceResourceFactory =>
       scopedAws.iam().cfnResourceFactory(),

--- a/src/service/cloudformation/resource/sim-cfn-resource.type.ts
+++ b/src/service/cloudformation/resource/sim-cfn-resource.type.ts
@@ -5,7 +5,7 @@ import type { SimCfnServiceResourceFactory } from "./factory/sim-cfn-resource-fa
 import type { SimCfnTemplateValueRecord } from "../template/value/sim-cfn-template-value.js";
 import type { SimCfnParameters } from "../parameters/sim-cfn-parameters.js";
 import type { SimCdkOutContext } from "../cdk/sim-cdk-out-context.js";
-import type { SimCfnExecutableResourceBinding } from "../bind/sim-cfn-exec-binding.type.js";
+import type { SimCfnDeployBinding } from "../bind/sim-cfn-deploy-binding.js";
 import type { SimCfnResource } from "./sim-cfn-resource.js";
 
 export interface SimCloudFormationResourceProperties {
@@ -54,7 +54,7 @@ export interface SimCloudFormationResourceCreateContext {
   readonly resources: ReadonlyMap<string, SimCfnResource>;
   readonly resolvedProperties?: SimCfnTemplateValueRecord | undefined;
   readonly cdkOutContext?: SimCdkOutContext | undefined;
-  readonly bindings?: readonly SimCfnExecutableResourceBinding[] | undefined;
+  readonly bindings?: readonly SimCfnDeployBinding[] | undefined;
 }
 
 /**

--- a/src/service/cloudformation/sim-cloudformation.ts
+++ b/src/service/cloudformation/sim-cloudformation.ts
@@ -35,7 +35,7 @@ import {
   SimCloudFormationTemplateDeployer,
 } from "./deploy/sim-cfn-template-deployer.js";
 import type { SimCloudFormationDeployTemplateFileProperties as SimCloudFormationDeployTemplateFileProperties } from "./deploy/sim-cfn-template-file-loader.js";
-import type { SimCfnExecutableResourceBinding } from "./bind/sim-cfn-exec-binding.type.js";
+import type { SimCfnDeployBinding } from "./bind/sim-cfn-deploy-binding.js";
 import { simAwsAccountRegionScopeFactory } from "../aws/sim-aws-account-region-scope.factory.js";
 import { SimCloudFormationSdkCommandRouter } from "./sdk/sim-cloudformation-sdk-command-router.js";
 import type { SimSdkCommandRouter } from "../../sdk/index.js";
@@ -280,7 +280,7 @@ export class SimCloudFormation {
   private async createStackWithContext(
     command: SimCreateStackCommand,
     cdkOutContext?: SimCdkOutContext,
-    bindings?: readonly SimCfnExecutableResourceBinding[],
+    bindings?: readonly SimCfnDeployBinding[],
   ): Promise<SimCreateStackCommandOutput> {
     const handler = new CreateStackCommandHandler({
       simAws: this.simAws,

--- a/src/service/cloudformation/stack/deploy/sim-cfn-stack-resource-batch-creator.ts
+++ b/src/service/cloudformation/stack/deploy/sim-cfn-stack-resource-batch-creator.ts
@@ -1,5 +1,5 @@
 import type { SimAws } from "../../../aws/sim-aws.js";
-import type { SimCfnExecutableResourceBinding } from "../../bind/sim-cfn-exec-binding.type.js";
+import type { SimCfnDeployBinding } from "../../bind/sim-cfn-deploy-binding.js";
 import type { SimCdkOutContext } from "../../cdk/sim-cdk-out-context.js";
 import type { SimCfnResource } from "../../resource/sim-cfn-resource.js";
 
@@ -7,7 +7,7 @@ interface SimCfnStackResourceBatchCreatorProperties {
   readonly simAws: SimAws;
   readonly resources: ReadonlyMap<string, SimCfnResource>;
   readonly cdkOutContext?: SimCdkOutContext | undefined;
-  readonly bindings?: readonly SimCfnExecutableResourceBinding[] | undefined;
+  readonly bindings?: readonly SimCfnDeployBinding[] | undefined;
 }
 
 /**
@@ -28,9 +28,7 @@ export class SimCfnStackResourceBatchCreator {
   private readonly simAws: SimAws;
   private readonly resources: ReadonlyMap<string, SimCfnResource>;
   private readonly cdkOutContext: SimCdkOutContext | undefined;
-  private readonly bindings:
-    | readonly SimCfnExecutableResourceBinding[]
-    | undefined;
+  private readonly bindings: readonly SimCfnDeployBinding[] | undefined;
 
   constructor(properties: SimCfnStackResourceBatchCreatorProperties) {
     const { simAws, resources, cdkOutContext, bindings } = properties;

--- a/src/service/cloudformation/stack/deploy/sim-cfn-stack-resource-creator.ts
+++ b/src/service/cloudformation/stack/deploy/sim-cfn-stack-resource-creator.ts
@@ -1,7 +1,7 @@
 import type { SimAws } from "../../../aws/sim-aws.js";
 import type { SimCfnResource } from "../../resource/sim-cfn-resource.js";
 import type { SimCdkOutContext } from "../../cdk/sim-cdk-out-context.js";
-import type { SimCfnExecutableResourceBinding } from "../../bind/sim-cfn-exec-binding.type.js";
+import type { SimCfnDeployBinding } from "../../bind/sim-cfn-deploy-binding.js";
 import { SimCfnStackResourceBatchCreator } from "./sim-cfn-stack-resource-batch-creator.js";
 import { SimCfnStackPendingResources } from "./sim-cfn-stack-pending-resources.js";
 
@@ -10,7 +10,7 @@ interface SimCfnStackResourceCreatorProperties {
   readonly resources: ReadonlyMap<string, SimCfnResource>;
   readonly stackName: string;
   readonly cdkOutContext?: SimCdkOutContext | undefined;
-  readonly bindings?: readonly SimCfnExecutableResourceBinding[] | undefined;
+  readonly bindings?: readonly SimCfnDeployBinding[] | undefined;
 }
 
 /**

--- a/src/service/cloudformation/stack/sim-cfn-stack-resource-operations.ts
+++ b/src/service/cloudformation/stack/sim-cfn-stack-resource-operations.ts
@@ -1,7 +1,7 @@
 import type { BackgroundScheduler } from "../../../util/background/background.js";
 import type { SimAws } from "../../aws/sim-aws.js";
 import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
-import type { SimCfnExecutableResourceBinding } from "../bind/sim-cfn-exec-binding.type.js";
+import type { SimCfnDeployBinding } from "../bind/sim-cfn-deploy-binding.js";
 import type { SimCdkOutContext } from "../cdk/sim-cdk-out-context.js";
 import { SimCdkAssetsPublisher } from "../cdk/assets/sim-cdk-assets-publisher.js";
 import type { SimCfnResource } from "../resource/sim-cfn-resource.js";
@@ -23,7 +23,7 @@ interface SimCfnStackResourceOperationsProperties {
   readonly accountRegionScope: SimAwsAccountRegionScope;
   readonly stackName: SimCloudFormationStackName;
   readonly cdkOutContext?: SimCdkOutContext | undefined;
-  readonly bindings?: readonly SimCfnExecutableResourceBinding[] | undefined;
+  readonly bindings?: readonly SimCfnDeployBinding[] | undefined;
 }
 
 /**
@@ -43,9 +43,7 @@ export class SimCfnStackResourceOperations {
   private readonly simAws: SimAws;
   private readonly accountRegionScope: SimAwsAccountRegionScope;
   private readonly stackName: SimCloudFormationStackName;
-  private readonly bindings:
-    | readonly SimCfnExecutableResourceBinding[]
-    | undefined;
+  private readonly bindings: readonly SimCfnDeployBinding[] | undefined;
   private cdkOutContext: SimCdkOutContext | undefined;
 
   constructor(properties: SimCfnStackResourceOperationsProperties) {

--- a/src/service/cloudformation/stack/sim-cfn-stack.ts
+++ b/src/service/cloudformation/stack/sim-cfn-stack.ts
@@ -17,7 +17,7 @@ import { SimCfnStackDeploymentLifecycle } from "./deploy/sim-cfn-stack-deploymen
 import { SimCfnStackResourceOperations } from "./sim-cfn-stack-resource-operations.js";
 import { SimCfnStackUpdateLifecycle } from "./update/sim-cfn-stack-update-lifecycle.js";
 import type { SimCdkOutContext } from "../cdk/sim-cdk-out-context.js";
-import type { SimCfnExecutableResourceBinding } from "../bind/sim-cfn-exec-binding.type.js";
+import type { SimCfnDeployBinding } from "../bind/sim-cfn-deploy-binding.js";
 import type { SimCfnStackOutput } from "./output/sim-cfn-stack-output.js";
 import { SimCfnStackOutputResolver } from "./output/sim-cfn-stack-output-resolver.js";
 import { SimCfnStackResourceReport } from "./report/sim-cfn-stack-resource-report.js";
@@ -58,7 +58,7 @@ interface SimCloudFormationStackProperties {
   readonly stackName: SimCloudFormationStackName;
   readonly template: SimCfnTemplate;
   readonly cdkOutContext?: SimCdkOutContext | undefined;
-  readonly bindings?: readonly SimCfnExecutableResourceBinding[] | undefined;
+  readonly bindings?: readonly SimCfnDeployBinding[] | undefined;
 }
 
 /**

--- a/src/service/cloudformation/stack/teardown/sim-cfn-stack-teardown.iso.test.ts
+++ b/src/service/cloudformation/stack/teardown/sim-cfn-stack-teardown.iso.test.ts
@@ -106,7 +106,7 @@ describe("SimCfnStack teardown", () => {
       template: {
         Resources: {
           Handle: { Type: "AWS::CloudFormation::WaitConditionHandle" },
-          Cluster: { Type: "AWS::ECS::Cluster" },
+          Network: { Type: "AWS::EC2::VPC" },
         },
       },
     });
@@ -119,7 +119,7 @@ describe("SimCfnStack teardown", () => {
 
     // Then the skipped Resource is delete-complete without any service being
     // asked to delete something it never made.
-    assertIdentical(stack.resources.get("Cluster")?.status, "DELETE_COMPLETE");
+    assertIdentical(stack.resources.get("Network")?.status, "DELETE_COMPLETE");
     assertArrayLength(stack.skippedResourceDeletions, 0);
   });
 

--- a/src/service/cloudfront/cfn/cff/sim-cfn-cff-binding-lookup.ts
+++ b/src/service/cloudfront/cfn/cff/sim-cfn-cff-binding-lookup.ts
@@ -1,14 +1,12 @@
-import type {
-  SimCfnCfBinding,
-  SimCfnExecutableResourceBinding,
-} from "../../../cloudformation/bind/sim-cfn-exec-binding.type.js";
+import type { SimCfnDeployBinding } from "../../../cloudformation/bind/sim-cfn-deploy-binding.js";
+import type { SimCfnCfBinding } from "../../../cloudformation/bind/sim-cfn-exec-binding.type.js";
 import { SimCfnExecBindingFinder } from "../../../cloudformation/bind/validate/sim-cfn-exec-binding-finder.js";
 import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
 import type { CloudFrontFunction } from "../../index.js";
 
 interface SimCfnCffBindingLookupProperties {
   readonly resource: SimCfnResource;
-  readonly bindings?: readonly SimCfnExecutableResourceBinding[] | undefined;
+  readonly bindings?: readonly SimCfnDeployBinding[] | undefined;
   readonly cffName: string;
 }
 

--- a/src/service/cloudfront/cfn/cff/sim-cfn-cff-create-input-builder.ts
+++ b/src/service/cloudfront/cfn/cff/sim-cfn-cff-create-input-builder.ts
@@ -2,7 +2,7 @@ import {
   assertDefined,
   assertNotNull,
 } from "../../../../util/type-guard/defined.js";
-import type { SimCfnExecutableResourceBinding } from "../../../cloudformation/bind/sim-cfn-exec-binding.type.js";
+import type { SimCfnDeployBinding } from "../../../cloudformation/bind/sim-cfn-deploy-binding.js";
 import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
 import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
 import { makeCffFunctionCodeInput } from "../../cff/function-code-input/cff-function-code-input.js";
@@ -15,7 +15,7 @@ import { findSimCfnCffBinding } from "./sim-cfn-cff-binding-lookup.js";
 interface SimCfnCfFunctionCreateInputBuilderProperties {
   readonly resource: SimCfnResource;
   readonly properties: SimCfnTemplateValueRecord;
-  readonly bindings?: readonly SimCfnExecutableResourceBinding[] | undefined;
+  readonly bindings?: readonly SimCfnDeployBinding[] | undefined;
 }
 
 interface SimCfnCfFunctionCreateInput {
@@ -43,9 +43,7 @@ interface SimCfnCfFunctionCreateInput {
 export class SimCfnCffCreateInputBuilder {
   private readonly resource: SimCfnResource;
   private readonly properties: SimCfnTemplateValueRecord;
-  private readonly bindings:
-    | readonly SimCfnExecutableResourceBinding[]
-    | undefined;
+  private readonly bindings: readonly SimCfnDeployBinding[] | undefined;
 
   constructor(properties: SimCfnCfFunctionCreateInputBuilderProperties) {
     this.resource = properties.resource;

--- a/src/service/ecs/README.md
+++ b/src/service/ecs/README.md
@@ -255,6 +255,35 @@ command instances.
   resource type at all, and gives `CreateCluster`, `ListClusters` and `ListTasks` none either. A
   policy naming a task definition ARN grants none of those, here as on AWS.
 
+## CloudFormation
+
+`cfn/` holds what deploys `AWS::ECS::Cluster` and `AWS::ECS::TaskDefinition`, under the rule the
+CloudFormation engine works by: CloudFormation orchestrates and the service creates. Both go through
+the ordinary `CreateCluster` and `RegisterTaskDefinition` commands rather than constructing state
+directly, so a Resource a template deployed is the same thing an SDK caller would have got, refusals
+included.
+
+`property/sim-cfn-ecs-api-shape.ts` is the piece with the most in it. CloudFormation writes an ECS
+declaration in the API's own shape with the first letter of every name upper cased, so translating
+one is mechanical, and doing it in one place is what lets a container definition, a cluster
+configuration and a task definition's volumes all be stored as declared without anything reading what
+they mean. What it cannot be mechanical about is named there: the handful of names the API spells
+differently, and the maps whose keys the user wrote.
+
+`SimCfnEcsDeclaredTaskDefinition` reads a task definition Resource before anything has been created
+from it. A Stack checks its bindings as it is built, so a binding naming a family or an image
+repository has to be matched against the template rather than against simulated ECS, and the family a
+template does not name is worked out the same way there as it is at creation.
+
+`SimCfnEcsContainerBindings` applies the bindings a deployment supplied. A binding naming a family or
+a repository already says everything simulated ECS needs and is handed over unchanged; a binding
+naming the task definition Resource is turned into the family the registration made, since a logical
+ID means nothing to ECS. Only bindings that target this Resource are applied, so a stack declaring
+several task definitions does not bind one handler to all of them.
+
+The two Resource types' `Ref` and `Fn::GetAtt` answers live with the other services' value adapters,
+under `cloudformation/resource/cfn/ecs/`, as the CloudFormation engine's own design has them.
+
 ## Divergences worth knowing
 
 - `ListClusters` leaves out a deleted cluster. It is still describable by name or ARN as `INACTIVE`.
@@ -288,4 +317,10 @@ command instances.
 - `SimEcsContainerDefinitionType` carries no index signature. One would stop a real SDK
   `RegisterTaskDefinitionCommand` input being assignable to it, which is the whole point of the
   structural types. A field it does not name is stored and reported back all the same.
+- `AWS::ECS::Service` has no factory yet, so a template declaring one is skipped.
+- A cluster or task definition a template does not name gets a name composed from the stack name and
+  the logical ID, without the random part real CloudFormation adds, so a test can predict it.
+- A cluster property or task definition property `CreateCluster` or `RegisterTaskDefinition` would
+  refuse is recorded as ignored rather than refused, so the stack deploys. A declaration nothing acts
+  on is worth less than a stack that will not come up.
 - The full list is in [docs/services/ecs](../../../docs/services/ecs/).

--- a/src/service/ecs/cfn/bind/sim-cfn-ecs-container-binding-matcher.ts
+++ b/src/service/ecs/cfn/bind/sim-cfn-ecs-container-binding-matcher.ts
@@ -1,0 +1,100 @@
+import { SimCfnImageRepositoryTarget } from "../../../cloudformation/bind/validate/sim-cfn-image-repository-target.js";
+import { SimCfnResourceCdkPath } from "../../../cloudformation/bind/validate/sim-cfn-resource-cdk-path.js";
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import { SimCfnEcsDeclaredTaskDefinition } from "../task-definition/sim-cfn-ecs-declared-task-definition.js";
+import type { SimCfnEcsContainerBinding } from "./sim-cfn-ecs-container-binding.type.js";
+
+/**
+ * Matches container bindings against the task definitions a Stack declares.
+ *
+ * A binding is checked as the Stack is built, before anything is created, so
+ * everything it is matched on is read from the template rather than from
+ * simulated ECS. That is the point: a binding naming a container the Stack
+ * does not declare is a mistake in the test, and saying so at the deployment
+ * is where the mistake is.
+ */
+export class SimCfnEcsContainerBindingMatcher {
+  private readonly taskDefinitions: readonly SimCfnEcsDeclaredTaskDefinition[];
+
+  constructor(resources: ReadonlyMap<string, SimCfnResource>) {
+    this.taskDefinitions = SimCfnEcsDeclaredTaskDefinition.of(resources);
+  }
+
+  /**
+   * How a binding that resolved to nothing is named in the refusal.
+   */
+  static describe(binding: SimCfnEcsContainerBinding): string {
+    if (binding.logicalId !== undefined) {
+      return `container binding for logicalId ${JSON.stringify(binding.logicalId)}`;
+    }
+
+    if (binding.imageRepository !== undefined) {
+      return `container binding for imageRepository ${JSON.stringify(binding.imageRepository)}`;
+    }
+
+    return (
+      `container binding for family ${JSON.stringify(binding.family)} ` +
+      `container ${JSON.stringify(binding.containerName)}`
+    );
+  }
+
+  /**
+   * Whether this binding targets a container the Stack declares.
+   */
+  matches(binding: SimCfnEcsContainerBinding): boolean {
+    return this.taskDefinitions.some((taskDefinition) =>
+      simCfnEcsBindingTargets(binding, taskDefinition),
+    );
+  }
+}
+
+/**
+ * Whether one binding targets one declared task definition.
+ *
+ * The three target forms are checked in the order they are declared in, since
+ * a binding carries exactly one of them.
+ */
+export function simCfnEcsBindingTargets(
+  binding: SimCfnEcsContainerBinding,
+  taskDefinition: SimCfnEcsDeclaredTaskDefinition,
+): boolean {
+  if (binding.logicalId !== undefined) {
+    return simCfnEcsResourceIsNamed(
+      taskDefinition.declaredBy,
+      binding.logicalId,
+    );
+  }
+
+  if (binding.imageRepository !== undefined) {
+    const target = new SimCfnImageRepositoryTarget(binding.imageRepository);
+
+    return taskDefinition
+      .containers()
+      .some((container) => target.matchesImageUri(container.image));
+  }
+
+  return (
+    taskDefinition.family() === binding.family &&
+    taskDefinition
+      .containers()
+      .some((container) => container.name === binding.containerName)
+  );
+}
+
+/**
+ * Whether a Resource answers to this logical ID.
+ *
+ * CDK generates a logical ID from a construct path and a hash, which is not
+ * something a test wants to write out, so the construct ID from the Resource's
+ * CDK metadata answers to it too. This is the same rule an executable Resource
+ * binding is matched by.
+ */
+export function simCfnEcsResourceIsNamed(
+  resource: SimCfnResource,
+  logicalId: string,
+): boolean {
+  return (
+    resource.logicalId === logicalId ||
+    new SimCfnResourceCdkPath(resource).constructId() === logicalId
+  );
+}

--- a/src/service/ecs/cfn/bind/sim-cfn-ecs-container-binding.type.ts
+++ b/src/service/ecs/cfn/bind/sim-cfn-ecs-container-binding.type.ts
@@ -1,0 +1,57 @@
+import type {
+  SimEcsContainerBindingHandler,
+  SimEcsContainerBindingTarget,
+} from "../../bind/sim-ecs-container-binding.type.js";
+
+/**
+ * A binding targeting a container through the Resource that declares it.
+ *
+ * A template names its task definition by logical ID, and CDK generates that
+ * logical ID from a construct path and a hash, so the construct ID is accepted
+ * as well. The container name may be left out where the task definition
+ * declares one container, since there is then nothing to choose between.
+ */
+export interface SimCfnEcsTaskDefinitionBindingTarget {
+  readonly logicalId: string;
+  readonly containerName?: string | undefined;
+  readonly family?: never;
+  readonly imageRepository?: never;
+}
+
+/**
+ * Which container a binding supplied at deploy time targets.
+ *
+ * The two forms simulated ECS already takes, a family with a container name
+ * and an image repository, mean the same here as they do when a container is
+ * bound directly. The third names the task definition Resource, which is what
+ * a template has and a `RegisterTaskDefinition` call does not.
+ */
+export type SimCfnEcsContainerBindingTarget =
+  | (SimEcsContainerBindingTarget & { readonly logicalId?: never })
+  | SimCfnEcsTaskDefinitionBindingTarget;
+
+/**
+ * A real in-process handler bound at deploy time to a container an
+ * `AWS::ECS::TaskDefinition` declares.
+ *
+ * ```typescript
+ * await simAws.cloudFormation().deployTemplateFile({
+ *   stackName: "orders",
+ *   templateFile: "cdk.out/OrdersStack.template.json",
+ *   bindings: [
+ *     {
+ *       family: "orders-worker",
+ *       containerName: "app",
+ *       run: async () => {
+ *         await processOutstandingOrders();
+ *       },
+ *     },
+ *   ],
+ * });
+ * ```
+ *
+ * A binding that resolves is held by the simulated ECS scope the Stack
+ * deployed into, so a task run from that task definition runs the handler.
+ */
+export type SimCfnEcsContainerBinding = SimCfnEcsContainerBindingTarget &
+  SimEcsContainerBindingHandler;

--- a/src/service/ecs/cfn/bind/sim-cfn-ecs-container-bindings.ts
+++ b/src/service/ecs/cfn/bind/sim-cfn-ecs-container-bindings.ts
@@ -1,0 +1,146 @@
+import {
+  type SimCfnDeployBinding,
+  simCfnIsContainerBinding,
+} from "../../../cloudformation/bind/sim-cfn-deploy-binding.js";
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimEcsTaskDefinition } from "../../task-definition/sim-ecs-task-definition.js";
+import type { SimEcs } from "../../sim-ecs.js";
+import { simCfnEcsPropertyError } from "../property/sim-cfn-ecs-property-error.js";
+import { SimCfnEcsDeclaredTaskDefinition } from "../task-definition/sim-cfn-ecs-declared-task-definition.js";
+import { simCfnEcsBindingTargets } from "./sim-cfn-ecs-container-binding-matcher.js";
+import type { SimCfnEcsContainerBinding } from "./sim-cfn-ecs-container-binding.type.js";
+
+interface SimCfnEcsContainerBindingsProperties {
+  readonly resource: SimCfnResource;
+  readonly bindings?: readonly SimCfnDeployBinding[] | undefined;
+}
+
+/**
+ * The bindings a deployment supplied for one task definition Resource.
+ *
+ * A binding naming a family or an image repository already says everything
+ * simulated ECS needs, so it is handed over as it was written. A binding
+ * naming the task definition Resource is the one this has work to do for: the
+ * logical ID means nothing to ECS, which knows families, so it is turned into
+ * the family the Resource registered under.
+ *
+ * A binding is applied only to the task definition it targets, so a Stack
+ * declaring several of them does not bind a handler to all of them.
+ */
+export class SimCfnEcsContainerBindings {
+  private readonly declared: SimCfnEcsDeclaredTaskDefinition;
+  private readonly bindings: readonly SimCfnEcsContainerBinding[];
+
+  constructor(properties: SimCfnEcsContainerBindingsProperties) {
+    this.declared = new SimCfnEcsDeclaredTaskDefinition(properties.resource);
+    this.bindings = (properties.bindings ?? []).filter((binding) =>
+      simCfnIsContainerBinding(binding),
+    );
+  }
+
+  /**
+   * Bind what this deployment supplied for the revision just registered.
+   */
+  applyTo(ecs: SimEcs, taskDefinition: SimEcsTaskDefinition): void {
+    for (const binding of this.bindings) {
+      if (!simCfnEcsBindingTargets(binding, this.declared)) {
+        continue;
+      }
+
+      this.bind(ecs, binding, taskDefinition);
+    }
+  }
+
+  private bind(
+    ecs: SimEcs,
+    binding: SimCfnEcsContainerBinding,
+    taskDefinition: SimEcsTaskDefinition,
+  ): void {
+    if (binding.logicalId === undefined) {
+      ecs.bindContainer(binding);
+
+      return;
+    }
+
+    this.bindNamedContainer(ecs, binding, taskDefinition);
+  }
+
+  /**
+   * Bind a Resource-targeted binding to the container it means.
+   */
+  private bindNamedContainer(
+    ecs: SimEcs,
+    binding: SimCfnEcsContainerBinding,
+    taskDefinition: SimEcsTaskDefinition,
+  ): void {
+    const target = {
+      family: taskDefinition.family,
+      containerName: this.containerName(binding, taskDefinition),
+    };
+
+    if (binding.run !== undefined) {
+      ecs.bindContainer({ ...target, run: binding.run });
+
+      return;
+    }
+
+    ecs.bindContainer({ ...target, http: binding.http });
+  }
+
+  /**
+   * Which container of the revision a Resource-targeted binding means.
+   *
+   * A binding that names one has to name one the revision declares, and a
+   * binding that names none means the only container there is. A revision
+   * declaring several containers has nothing to choose between them by, and
+   * the usual cause is a log router or an agent alongside the application, so
+   * the refusal lists what the revision declares.
+   */
+  private containerName(
+    binding: SimCfnEcsContainerBinding,
+    taskDefinition: SimEcsTaskDefinition,
+  ): string {
+    if (binding.containerName === undefined) {
+      return this.soleContainerName(taskDefinition);
+    }
+
+    if (!taskDefinition.containers.has(binding.containerName)) {
+      throw this.refuse(
+        `a binding names container ${binding.containerName}, which family ${taskDefinition.family} does not declare: ${simCfnEcsContainerNames(taskDefinition)}`,
+      );
+    }
+
+    return binding.containerName;
+  }
+
+  /**
+   * The one container a binding naming no container can only have meant.
+   */
+  private soleContainerName(taskDefinition: SimEcsTaskDefinition): string {
+    const containers = taskDefinition.containers.all();
+    const sole = containers.at(0);
+
+    if (sole !== undefined && containers.length === 1) {
+      return sole.name;
+    }
+
+    throw this.refuse(
+      `a binding naming this task definition needs a containerName, because ` +
+        `family ${taskDefinition.family} declares ${String(containers.length)} containers: ${simCfnEcsContainerNames(taskDefinition)}`,
+    );
+  }
+
+  private refuse(reason: string): Error {
+    return simCfnEcsPropertyError(this.declared.declaredBy.logicalId, reason);
+  }
+}
+
+/**
+ * The containers a revision declares, for a refusal to name.
+ */
+function simCfnEcsContainerNames(taskDefinition: SimEcsTaskDefinition): string {
+  return taskDefinition.containers
+    .all()
+    .map((container) => container.name)
+    .join(", ");
+}

--- a/src/service/ecs/cfn/bind/sim-cfn-ecs-container-bindings.ts
+++ b/src/service/ecs/cfn/bind/sim-cfn-ecs-container-bindings.ts
@@ -3,7 +3,6 @@ import {
   simCfnIsContainerBinding,
 } from "../../../cloudformation/bind/sim-cfn-deploy-binding.js";
 import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
-import type { SimEcsTaskDefinition } from "../../task-definition/sim-ecs-task-definition.js";
 import type { SimEcs } from "../../sim-ecs.js";
 import { simCfnEcsPropertyError } from "../property/sim-cfn-ecs-property-error.js";
 import { SimCfnEcsDeclaredTaskDefinition } from "../task-definition/sim-cfn-ecs-declared-task-definition.js";
@@ -16,16 +15,34 @@ interface SimCfnEcsContainerBindingsProperties {
 }
 
 /**
+ * What a task definition Resource is about to register, as far as a binding
+ * needs to know: which family, and which containers it names.
+ */
+export interface SimCfnEcsRegistration {
+  readonly family: string;
+  readonly containerNames: readonly string[];
+}
+
+/**
  * The bindings a deployment supplied for one task definition Resource.
  *
  * A binding naming a family or an image repository already says everything
  * simulated ECS needs, so it is handed over as it was written. A binding
  * naming the task definition Resource is the one this has work to do for: the
  * logical ID means nothing to ECS, which knows families, so it is turned into
- * the family the Resource registered under.
+ * the family the Resource is registering under.
  *
  * A binding is applied only to the task definition it targets, so a Stack
  * declaring several of them does not bind a handler to all of them.
+ *
+ * The bindings are applied before the registration is made, from what the
+ * registration is going to say rather than from the revision it made. A
+ * binding is refused for naming a container the declaration does not hold, and
+ * doing that first is what stops a refusal leaving an active revision behind
+ * it: there is nothing to take back, because nothing has been registered. A
+ * binding held for a family that is then never registered reaches no
+ * container, which is what a binding made before its task definition already
+ * is.
  */
 export class SimCfnEcsContainerBindings {
   private readonly declared: SimCfnEcsDeclaredTaskDefinition;
@@ -39,22 +56,22 @@ export class SimCfnEcsContainerBindings {
   }
 
   /**
-   * Bind what this deployment supplied for the revision just registered.
+   * Bind what this deployment supplied for the registration about to be made.
    */
-  applyTo(ecs: SimEcs, taskDefinition: SimEcsTaskDefinition): void {
+  applyTo(ecs: SimEcs, registration: SimCfnEcsRegistration): void {
     for (const binding of this.bindings) {
       if (!simCfnEcsBindingTargets(binding, this.declared)) {
         continue;
       }
 
-      this.bind(ecs, binding, taskDefinition);
+      this.bind(ecs, binding, registration);
     }
   }
 
   private bind(
     ecs: SimEcs,
     binding: SimCfnEcsContainerBinding,
-    taskDefinition: SimEcsTaskDefinition,
+    registration: SimCfnEcsRegistration,
   ): void {
     if (binding.logicalId === undefined) {
       ecs.bindContainer(binding);
@@ -62,7 +79,7 @@ export class SimCfnEcsContainerBindings {
       return;
     }
 
-    this.bindNamedContainer(ecs, binding, taskDefinition);
+    this.bindNamedContainer(ecs, binding, registration);
   }
 
   /**
@@ -71,11 +88,11 @@ export class SimCfnEcsContainerBindings {
   private bindNamedContainer(
     ecs: SimEcs,
     binding: SimCfnEcsContainerBinding,
-    taskDefinition: SimEcsTaskDefinition,
+    registration: SimCfnEcsRegistration,
   ): void {
     const target = {
-      family: taskDefinition.family,
-      containerName: this.containerName(binding, taskDefinition),
+      family: registration.family,
+      containerName: this.containerName(binding, registration),
     };
 
     if (binding.run !== undefined) {
@@ -88,25 +105,27 @@ export class SimCfnEcsContainerBindings {
   }
 
   /**
-   * Which container of the revision a Resource-targeted binding means.
+   * Which container of the registration a Resource-targeted binding means.
    *
-   * A binding that names one has to name one the revision declares, and a
-   * binding that names none means the only container there is. A revision
+   * A binding that names one has to name one the registration declares, and a
+   * binding that names none means the only container there is. A registration
    * declaring several containers has nothing to choose between them by, and
    * the usual cause is a log router or an agent alongside the application, so
-   * the refusal lists what the revision declares.
+   * the refusal lists what the registration declares.
    */
   private containerName(
     binding: SimCfnEcsContainerBinding,
-    taskDefinition: SimEcsTaskDefinition,
+    registration: SimCfnEcsRegistration,
   ): string {
     if (binding.containerName === undefined) {
-      return this.soleContainerName(taskDefinition);
+      return this.soleContainerName(registration);
     }
 
-    if (!taskDefinition.containers.has(binding.containerName)) {
+    const declaredNames = registration.containerNames;
+
+    if (!declaredNames.includes(binding.containerName)) {
       throw this.refuse(
-        `a binding names container ${binding.containerName}, which family ${taskDefinition.family} does not declare: ${simCfnEcsContainerNames(taskDefinition)}`,
+        `a binding names container ${binding.containerName}, which family ${registration.family} does not declare: ${declaredNames.join(", ")}`,
       );
     }
 
@@ -116,31 +135,21 @@ export class SimCfnEcsContainerBindings {
   /**
    * The one container a binding naming no container can only have meant.
    */
-  private soleContainerName(taskDefinition: SimEcsTaskDefinition): string {
-    const containers = taskDefinition.containers.all();
-    const sole = containers.at(0);
+  private soleContainerName(registration: SimCfnEcsRegistration): string {
+    const declaredNames = registration.containerNames;
+    const sole = declaredNames.at(0);
 
-    if (sole !== undefined && containers.length === 1) {
-      return sole.name;
+    if (sole !== undefined && declaredNames.length === 1) {
+      return sole;
     }
 
     throw this.refuse(
       `a binding naming this task definition needs a containerName, because ` +
-        `family ${taskDefinition.family} declares ${String(containers.length)} containers: ${simCfnEcsContainerNames(taskDefinition)}`,
+        `family ${registration.family} declares ${String(declaredNames.length)} containers: ${declaredNames.join(", ")}`,
     );
   }
 
   private refuse(reason: string): Error {
     return simCfnEcsPropertyError(this.declared.declaredBy.logicalId, reason);
   }
-}
-
-/**
- * The containers a revision declares, for a refusal to name.
- */
-function simCfnEcsContainerNames(taskDefinition: SimEcsTaskDefinition): string {
-  return taskDefinition.containers
-    .all()
-    .map((container) => container.name)
-    .join(", ");
 }

--- a/src/service/ecs/cfn/cluster/sim-cfn-ecs-cluster-creator.ts
+++ b/src/service/ecs/cfn/cluster/sim-cfn-ecs-cluster-creator.ts
@@ -1,0 +1,58 @@
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimEcsCluster } from "../../cluster/sim-ecs-cluster.js";
+import type { SimEcs } from "../../sim-ecs.js";
+import { SimCfnEcsClusterProperties } from "./sim-cfn-ecs-cluster-properties.js";
+
+interface SimCfnEcsClusterCreatorProperties {
+  readonly ecs: SimEcs;
+}
+
+/**
+ * Creates simulated clusters from AWS::ECS::Cluster Resources.
+ *
+ * The cluster is created through the ordinary CreateCluster command rather
+ * than constructed directly, so a cluster a template deployed is the same
+ * thing an SDK caller would have got: the same name validation, and the same
+ * answer for a name an active cluster already holds.
+ */
+export class SimCfnEcsClusterCreator {
+  private readonly ecs: SimEcs;
+
+  constructor(properties: SimCfnEcsClusterCreatorProperties) {
+    this.ecs = properties.ecs;
+  }
+
+  /**
+   * Create a cluster from an AWS::ECS::Cluster Resource.
+   */
+  async create(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): Promise<SimEcsCluster> {
+    const clusterProperties = new SimCfnEcsClusterProperties({
+      resource,
+      properties,
+    });
+    const input = clusterProperties.createClusterInput();
+
+    clusterProperties.recordIgnoredProperties();
+
+    await this.ecs.createCluster({ input });
+
+    return this.ecs.cluster(clusterProperties.clusterName());
+  }
+
+  /**
+   * Delete a cluster created from an AWS::ECS::Cluster Resource.
+   *
+   * Deleting marks the cluster `INACTIVE` rather than removing it, as
+   * `DeleteCluster` does, so something still holding its ARN can find out what
+   * became of it after the stack has gone.
+   */
+  async delete(cluster: SimEcsCluster): Promise<void> {
+    await this.ecs.deleteCluster({
+      input: { cluster: cluster.clusterName },
+    });
+  }
+}

--- a/src/service/ecs/cfn/cluster/sim-cfn-ecs-cluster-name.ts
+++ b/src/service/ecs/cfn/cluster/sim-cfn-ecs-cluster-name.ts
@@ -1,0 +1,37 @@
+import { SimCfnGeneratedResourceName } from "../../../cloudformation/resource/name/sim-cfn-generated-resource-name.js";
+
+/**
+ * How long an ECS cluster name may be.
+ */
+const maximumNameLength = 255;
+
+interface SimCfnEcsClusterNameProperties {
+  readonly stackName: string | undefined;
+  readonly logicalId: string;
+}
+
+/**
+ * The name CloudFormation gives a cluster whose template does not name it.
+ *
+ * A cluster name is at most 255 characters, so a long stack name and logical ID
+ * together are trimmed to fit, the same way every other service's generated
+ * name is.
+ */
+export class SimCfnEcsClusterName {
+  private readonly generated: SimCfnGeneratedResourceName;
+
+  constructor(properties: SimCfnEcsClusterNameProperties) {
+    this.generated = new SimCfnGeneratedResourceName({
+      stackName: properties.stackName,
+      logicalId: properties.logicalId,
+      maximumLength: maximumNameLength,
+    });
+  }
+
+  /**
+   * The generated cluster name.
+   */
+  get value(): string {
+    return this.generated.value;
+  }
+}

--- a/src/service/ecs/cfn/cluster/sim-cfn-ecs-cluster-properties.ts
+++ b/src/service/ecs/cfn/cluster/sim-cfn-ecs-cluster-properties.ts
@@ -1,0 +1,73 @@
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimCreateClusterCommandInput } from "../../command/create-cluster/create-cluster.command.js";
+import type { SimEcsClusterSetting } from "../../cluster/sim-ecs-cluster.js";
+import type { SimEcsTag } from "../../task-definition/sim-ecs-task-definition-parts.js";
+import { SimCfnEcsPropertyReader } from "../property/sim-cfn-ecs-property-reader.js";
+import { SimCfnEcsClusterName } from "./sim-cfn-ecs-cluster-name.js";
+import { SimCfnEcsClusterPropertyRules } from "./sim-cfn-ecs-cluster-property-rules.js";
+
+interface SimCfnEcsClusterPropertiesProperties {
+  readonly resource: SimCfnResource;
+  readonly properties: SimCfnTemplateValueRecord;
+}
+
+/**
+ * Reads AWS::ECS::Cluster CloudFormation properties into CreateCluster input.
+ *
+ * A cluster is the simplest thing ECS has, so this is mostly translation: what
+ * the template declared, spelled the way the SDK spells it, and the name
+ * CloudFormation would have generated where the template left it out.
+ */
+export class SimCfnEcsClusterProperties {
+  private readonly resource: SimCfnResource;
+  private readonly reader: SimCfnEcsPropertyReader;
+  private readonly rules: SimCfnEcsClusterPropertyRules;
+
+  constructor(properties: SimCfnEcsClusterPropertiesProperties) {
+    this.resource = properties.resource;
+    this.reader = new SimCfnEcsPropertyReader(properties);
+    this.rules = new SimCfnEcsClusterPropertyRules({
+      properties: properties.properties,
+      ignorer: properties.resource,
+    });
+  }
+
+  /**
+   * The CreateCluster input this Resource declares.
+   */
+  createClusterInput(): SimCreateClusterCommandInput {
+    return {
+      clusterName: this.clusterName(),
+      settings: this.reader.apiList<SimEcsClusterSetting>("ClusterSettings"),
+      configuration: this.reader.apiRecord<object>("Configuration"),
+      tags: this.reader.apiList<SimEcsTag>("Tags"),
+    };
+  }
+
+  /**
+   * The cluster name.
+   *
+   * An unnamed cluster is named after the stack and the logical ID, as real
+   * CloudFormation names one. It is deliberately not `default`: a template
+   * declaring a cluster asks for a cluster of its own, and taking the
+   * account's default one would put every unnamed cluster of every stack in
+   * the same place.
+   */
+  clusterName(): string {
+    return (
+      this.reader.text("ClusterName") ??
+      new SimCfnEcsClusterName({
+        stackName: this.resource.stackName,
+        logicalId: this.resource.logicalId,
+      }).value
+    );
+  }
+
+  /**
+   * Record the properties the cluster is created without acting on.
+   */
+  recordIgnoredProperties(): void {
+    this.rules.apply();
+  }
+}

--- a/src/service/ecs/cfn/cluster/sim-cfn-ecs-cluster-property-rules.ts
+++ b/src/service/ecs/cfn/cluster/sim-cfn-ecs-cluster-property-rules.ts
@@ -1,0 +1,88 @@
+import type { SimCfnPropertyIgnorer } from "../../../cloudformation/resource/ignore/sim-cfn-ignored-property.type.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+
+/**
+ * The properties a cluster is created with.
+ */
+const actedOnProperties: ReadonlySet<string> = new Set([
+  "ClusterName",
+  "ClusterSettings",
+  "Configuration",
+  "Tags",
+]);
+
+/**
+ * The real AWS::ECS::Cluster properties this simulation has nothing to act on,
+ * and why.
+ *
+ * `CreateCluster` refuses all three, because there is no capacity and no
+ * service discovery here to attach them to. A template carrying one is
+ * deployed without it all the same: a stack that will not deploy is worth less
+ * to a test than a cluster that holds no capacity it was never going to hold.
+ */
+const unsimulatedPropertyReasons: ReadonlyMap<string, string> = new Map([
+  [
+    "CapacityProviders",
+    "a simulated task runs in this process rather than on capacity, so there " +
+      "is nothing for a capacity provider to place it on",
+  ],
+  [
+    "DefaultCapacityProviderStrategy",
+    "there are no capacity providers, so nothing chooses between them",
+  ],
+  [
+    "ServiceConnectDefaults",
+    "service discovery is not simulated, so nothing resolves a service by name",
+  ],
+]);
+
+interface SimCfnEcsClusterPropertyRulesProperties {
+  readonly properties: SimCfnTemplateValueRecord;
+  readonly ignorer: SimCfnPropertyIgnorer;
+}
+
+/**
+ * What a cluster Resource is created without acting on.
+ */
+export class SimCfnEcsClusterPropertyRules {
+  private readonly properties: SimCfnTemplateValueRecord;
+  private readonly ignorer: SimCfnPropertyIgnorer;
+
+  constructor(properties: SimCfnEcsClusterPropertyRulesProperties) {
+    this.properties = properties.properties;
+    this.ignorer = properties.ignorer;
+  }
+
+  /**
+   * Record every property the cluster is created without.
+   */
+  apply(): void {
+    for (const name of Object.keys(this.properties)) {
+      this.applyToProperty(name);
+    }
+  }
+
+  private applyToProperty(name: string): void {
+    if (actedOnProperties.has(name)) {
+      return;
+    }
+
+    const unsimulatedReason = unsimulatedPropertyReasons.get(name);
+
+    if (unsimulatedReason === undefined) {
+      this.ignorer.ignoreProperty(
+        name,
+        `${name} is not a property simulated ECS knows about, so the cluster ` +
+          `is created without it`,
+      );
+
+      return;
+    }
+
+    this.ignorer.ignoreProperty(
+      name,
+      `${name} is a real AWS::ECS::Cluster property simulated ECS does not ` +
+        `act on: ${unsimulatedReason}`,
+    );
+  }
+}

--- a/src/service/ecs/cfn/property/sim-cfn-ecs-api-shape.ts
+++ b/src/service/ecs/cfn/property/sim-cfn-ecs-api-shape.ts
@@ -1,0 +1,86 @@
+import { isRecord } from "../../../../util/type-guard/record.js";
+
+/**
+ * The property names whose value is a map the user wrote, rather than a
+ * structure ECS names the fields of.
+ *
+ * A Docker label, a log driver option and a volume driver option are all keys
+ * the user chose, so lowering them would change the declaration rather than
+ * translate it.
+ */
+const freeFormMapProperties: ReadonlySet<string> = new Set([
+  "DockerLabels",
+  "DriverOpts",
+  "Labels",
+  "Options",
+]);
+
+/**
+ * The property names the ECS API does not simply lower the first letter of.
+ *
+ * They are the whole list this simulation knows about, and they are all in the
+ * parts of a task definition nothing here acts on. A name not in it and not
+ * covered by lowering the first letter is stored under the name lowering gives
+ * it, which is why the mapping is a documented limitation rather than a claim
+ * to be complete.
+ */
+const renamedProperties: ReadonlyMap<string, string> = new Map([
+  ["EFSVolumeConfiguration", "efsVolumeConfiguration"],
+  [
+    "FSxWindowsFileServerVolumeConfiguration",
+    "fsxWindowsFileServerVolumeConfiguration",
+  ],
+  ["ProxyConfigurationProperties", "properties"],
+]);
+
+/**
+ * A CloudFormation property value as the ECS API spells it.
+ *
+ * CloudFormation writes an ECS declaration in the API's own shape with the
+ * first letter of every name upper cased, so translating is mechanical: lower
+ * the first letter of each key, all the way down. The two exceptions are the
+ * handful of names the API spells differently and the maps whose keys the user
+ * wrote, both of which are named above.
+ *
+ * Nothing here reads the meaning of what it translates. A task definition is a
+ * declaration, and the point of translating it is that a described revision
+ * reports what the template declared in the words the SDK would have used.
+ */
+export function simCfnEcsApiShape(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((entry) => simCfnEcsApiShape(entry));
+  }
+
+  if (!isRecord(value)) {
+    return value;
+  }
+
+  return Object.fromEntries(
+    Object.entries(value).map(([name, entry]) => [
+      simCfnEcsApiPropertyName(name),
+      simCfnEcsApiPropertyValue(name, entry),
+    ]),
+  );
+}
+
+/**
+ * One property name as the ECS API spells it.
+ */
+function simCfnEcsApiPropertyName(name: string): string {
+  return (
+    renamedProperties.get(name) ??
+    `${name.charAt(0).toLowerCase()}${name.slice(1)}`
+  );
+}
+
+/**
+ * One property value, translated unless the property holds a map of the user's
+ * own keys.
+ */
+function simCfnEcsApiPropertyValue(name: string, value: unknown): unknown {
+  if (freeFormMapProperties.has(name)) {
+    return value;
+  }
+
+  return simCfnEcsApiShape(value);
+}

--- a/src/service/ecs/cfn/property/sim-cfn-ecs-property-error.ts
+++ b/src/service/ecs/cfn/property/sim-cfn-ecs-property-error.ts
@@ -1,0 +1,15 @@
+/**
+ * A refusal naming the Resource whose properties could not be read.
+ *
+ * Every refusal from this factory carries the logical ID, because a stack
+ * holding several task definitions gives a reader nothing else to tell them
+ * apart by.
+ */
+export function simCfnEcsPropertyError(
+  logicalId: string,
+  reason: string,
+): Error {
+  return new Error(
+    `Invalid sim ECS CloudFormation Resource ${logicalId}: ${reason}`,
+  );
+}

--- a/src/service/ecs/cfn/property/sim-cfn-ecs-property-reader.ts
+++ b/src/service/ecs/cfn/property/sim-cfn-ecs-property-reader.ts
@@ -1,0 +1,130 @@
+import { isRecord } from "../../../../util/type-guard/record.js";
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type {
+  SimCfnTemplateValue,
+  SimCfnTemplateValueRecord,
+} from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import { simCfnEcsApiShape } from "./sim-cfn-ecs-api-shape.js";
+import { simCfnEcsPropertyError } from "./sim-cfn-ecs-property-error.js";
+
+interface SimCfnEcsPropertyReaderProperties {
+  readonly resource: SimCfnResource;
+  readonly properties: SimCfnTemplateValueRecord;
+}
+
+/**
+ * Reads the property shapes an ECS Resource template can hold.
+ *
+ * A template is written by hand as often as it is synthesized, so a property
+ * of the wrong shape is refused naming both the property and the Resource
+ * rather than being coerced into something that would deploy.
+ *
+ * The `api` readers do the same and then translate what they read into the
+ * spelling the ECS API uses, which is what a task definition and a cluster are
+ * mostly made of.
+ */
+export class SimCfnEcsPropertyReader {
+  private readonly resource: SimCfnResource;
+  private readonly properties: SimCfnTemplateValueRecord;
+
+  constructor(properties: SimCfnEcsPropertyReaderProperties) {
+    this.resource = properties.resource;
+    this.properties = properties.properties;
+  }
+
+  /**
+   * A property that is a string, where the template declared one.
+   */
+  text(name: string): string | undefined {
+    const value = this.declared(name);
+
+    if (value === undefined) {
+      return undefined;
+    }
+
+    if (typeof value !== "string") {
+      throw this.refuse(`${name} is a string`);
+    }
+
+    return value;
+  }
+
+  /**
+   * A property that is a list of strings, where the template declared one.
+   */
+  textList(name: string): readonly string[] | undefined {
+    return this.list(name)?.map((entry, index) => {
+      if (typeof entry !== "string") {
+        throw this.refuse(`${name} entry ${String(index)} is a string`);
+      }
+
+      return entry;
+    });
+  }
+
+  /**
+   * A property that is a list, where the template declared one.
+   */
+  list(name: string): readonly SimCfnTemplateValue[] | undefined {
+    const value = this.declared(name);
+
+    if (value === undefined) {
+      return undefined;
+    }
+
+    if (!Array.isArray(value)) {
+      throw this.refuse(`${name} is a list`);
+    }
+
+    return value;
+  }
+
+  /**
+   * A property that is an object, where the template declared one.
+   */
+  record(name: string): Record<string, unknown> | undefined {
+    const value = this.declared(name);
+
+    if (value === undefined) {
+      return undefined;
+    }
+
+    if (!isRecord(value)) {
+      throw this.refuse(`${name} is an object`);
+    }
+
+    return value;
+  }
+
+  /**
+   * A declared list, in the spelling the ECS API uses.
+   */
+  apiList<T>(name: string): readonly T[] | undefined {
+    return simCfnEcsApiShape(this.list(name)) as readonly T[] | undefined;
+  }
+
+  /**
+   * A declared object, in the spelling the ECS API uses.
+   */
+  apiRecord<T>(name: string): T | undefined {
+    return simCfnEcsApiShape(this.record(name)) as T | undefined;
+  }
+
+  /**
+   * A refusal naming this Resource.
+   */
+  refuse(reason: string): Error {
+    return simCfnEcsPropertyError(this.resource.logicalId, reason);
+  }
+
+  /**
+   * The value the template wrote for a property, whatever shape it is.
+   *
+   * The name always comes from this service's own fixed list of the properties
+   * an ECS Resource has, never from the template.
+   */
+  private declared(name: string): SimCfnTemplateValue | undefined {
+    // oxlint-disable-next-line security/detect-object-injection -- fixed property names.
+    return this.properties[name];
+  }
+}

--- a/src/service/ecs/cfn/sim-cfn-ecs-binding-targets.iso.test.ts
+++ b/src/service/ecs/cfn/sim-cfn-ecs-binding-targets.iso.test.ts
@@ -3,6 +3,7 @@ import { InvokeCommand } from "@aws-sdk/client-lambda";
 import {
   assertIdentical,
   assertStringIncludes,
+  assertThrowsError,
   assertThrowsErrorAsync,
 } from "@kensio/smartass";
 import { describe, it } from "vitest";
@@ -250,6 +251,35 @@ describe("ECS CloudFormation binding targets", () => {
     });
 
     assertStringIncludes(error.message, "does not resolve to a Resource");
+  });
+
+  it("registers nothing when a binding is refused", async () => {
+    // Given a binding naming a container the task definition does not declare.
+    const simAws = new SimAws();
+
+    // When the template is deployed, then the deployment is refused.
+    await assertThrowsErrorAsync(async () => {
+      return await simAws.cloudFormation().deployTemplate({
+        stackName: "orders-stack",
+        template: twoFamilies,
+        bindings: [
+          {
+            logicalId: "WorkerTaskDefinition",
+            containerName: "worker",
+            run: () => undefined,
+          },
+        ],
+      });
+    });
+
+    // And no revision is left behind, because the binding is read before the
+    // registration is made rather than after it. A revision is immutable once
+    // registered, so one made here could only have been deregistered.
+    const error = assertThrowsError(() =>
+      simAws.ecs().taskDefinition("orders-worker"),
+    );
+
+    assertStringIncludes(error.message, "orders-worker");
   });
 
   it("keeps a Lambda binding and a container binding apart", async () => {

--- a/src/service/ecs/cfn/sim-cfn-ecs-binding-targets.iso.test.ts
+++ b/src/service/ecs/cfn/sim-cfn-ecs-binding-targets.iso.test.ts
@@ -1,0 +1,313 @@
+import { RunTaskCommand } from "@aws-sdk/client-ecs";
+import { InvokeCommand } from "@aws-sdk/client-lambda";
+import {
+  assertIdentical,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+
+const workerImage = "example.dkr.ecr.eu-west-2.amazonaws.com/orders-worker:1";
+const checkoutImage = "example.dkr.ecr.eu-west-2.amazonaws.com/checkout:1";
+
+const twoFamilies = {
+  Resources: {
+    OrdersCluster: {
+      Type: "AWS::ECS::Cluster",
+      Properties: { ClusterName: "orders" },
+    },
+    WorkerTaskDefinition: {
+      Type: "AWS::ECS::TaskDefinition",
+      Properties: {
+        Family: "orders-worker",
+        ContainerDefinitions: [{ Name: "app", Image: workerImage }],
+      },
+    },
+    CheckoutTaskDefinition: {
+      Type: "AWS::ECS::TaskDefinition",
+      Properties: {
+        Family: "orders-checkout",
+        ContainerDefinitions: [{ Name: "app", Image: checkoutImage }],
+      },
+    },
+  },
+};
+
+describe("ECS CloudFormation binding targets", () => {
+  it("binds only the task definition a binding targets", async () => {
+    // Given a stack declaring two task definitions, each with a container
+    // called app, and a binding naming one of them.
+    const simAws = new SimAws();
+    let runs = 0;
+
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: twoFamilies,
+      bindings: [
+        {
+          family: "orders-worker",
+          containerName: "app",
+          run: () => {
+            runs += 1;
+          },
+        },
+      ],
+    });
+
+    await stack.waitForDeployComplete();
+
+    // When a task is run from the family the binding did not name.
+    await simAws.ecs().runTask(
+      new RunTaskCommand({
+        cluster: "orders",
+        taskDefinition: "orders-checkout",
+      }),
+    );
+
+    await simAws.backgroundTasksComplete();
+
+    // Then nothing ran, because the binding belongs to the other family.
+    assertIdentical(runs, 0);
+
+    // And when a task is run from the family it did name, the handler runs.
+    await simAws.ecs().runTask(
+      new RunTaskCommand({
+        cluster: "orders",
+        taskDefinition: "orders-worker",
+      }),
+    );
+
+    await simAws.backgroundTasksComplete();
+
+    assertIdentical(runs, 1);
+  });
+
+  it("binds a task definition by the family CloudFormation generated", async () => {
+    // Given a task definition the template names no family for, so the family
+    // is the one CloudFormation would have generated.
+    const simAws = new SimAws();
+    let runs = 0;
+
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: {
+        Resources: {
+          OrdersCluster: {
+            Type: "AWS::ECS::Cluster",
+            Properties: { ClusterName: "orders" },
+          },
+          WorkerTaskDefinition: {
+            Type: "AWS::ECS::TaskDefinition",
+            Properties: {
+              ContainerDefinitions: [{ Name: "app", Image: workerImage }],
+            },
+          },
+        },
+      },
+      bindings: [
+        {
+          family: "orders-stack-WorkerTaskDefinition",
+          containerName: "app",
+          run: () => {
+            runs += 1;
+          },
+        },
+      ],
+    });
+
+    await stack.waitForDeployComplete();
+
+    // When a task is run from it.
+    await simAws.ecs().runTask(
+      new RunTaskCommand({
+        cluster: "orders",
+        taskDefinition: "orders-stack-WorkerTaskDefinition",
+      }),
+    );
+
+    await simAws.backgroundTasksComplete();
+
+    // Then the handler ran, so a binding can name a family the template did
+    // not.
+    assertIdentical(runs, 1);
+  });
+
+  it("refuses an http binding naming the task definition Resource", async () => {
+    // Given a binding naming the Resource and carrying the HTTP shape a
+    // service container will take.
+    const simAws = new SimAws();
+
+    // When the template is deployed, then the binding is refused rather than
+    // held and never called.
+    const error = await assertThrowsErrorAsync(async () => {
+      return await simAws.cloudFormation().deployTemplate({
+        stackName: "orders-stack",
+        template: twoFamilies,
+        bindings: [
+          {
+            logicalId: "WorkerTaskDefinition",
+            http: () => new Response("ok"),
+          },
+        ],
+      });
+    });
+
+    assertStringIncludes(error.message, "an http handler is not simulated");
+  });
+
+  it("refuses a Resource binding naming no task definition of the stack", async () => {
+    // Given a binding naming a logical ID the stack does not hold.
+    const simAws = new SimAws();
+
+    // When the template is deployed, then the deployment is refused naming the
+    // binding.
+    const error = await assertThrowsErrorAsync(async () => {
+      return await simAws.cloudFormation().deployTemplate({
+        stackName: "orders-stack",
+        template: twoFamilies,
+        bindings: [
+          { logicalId: "PickingTaskDefinition", run: () => undefined },
+        ],
+      });
+    });
+
+    assertStringIncludes(
+      error.message,
+      'container binding for logicalId "PickingTaskDefinition"',
+    );
+  });
+
+  it("refuses a repository binding no container runs an image from", async () => {
+    // Given a binding naming a repository, and a container that declares no
+    // image for it to match, which real ECS would refuse the registration of.
+    const simAws = new SimAws();
+
+    // When the template is deployed, then the deployment is refused naming the
+    // repository rather than registering a task definition that could never
+    // run.
+    const error = await assertThrowsErrorAsync(async () => {
+      return await simAws.cloudFormation().deployTemplate({
+        stackName: "orders-stack",
+        template: {
+          Resources: {
+            WorkerTaskDefinition: {
+              Type: "AWS::ECS::TaskDefinition",
+              Properties: {
+                Family: "orders-worker",
+                ContainerDefinitions: [{ Name: "app" }],
+              },
+            },
+          },
+        },
+        bindings: [
+          {
+            imageRepository:
+              "example.dkr.ecr.eu-west-2.amazonaws.com/orders-worker",
+            run: () => undefined,
+          },
+        ],
+      });
+    });
+
+    assertStringIncludes(
+      error.message,
+      'container binding for imageRepository "example.dkr.ecr.eu-west-2.amazonaws.com/orders-worker"',
+    );
+  });
+
+  it("refuses a repository binding against a malformed container list", async () => {
+    // Given a template whose ContainerDefinitions is one container rather than
+    // a list of them, and a binding naming a repository.
+    const simAws = new SimAws();
+
+    // When the template is deployed, then the binding is refused first, since
+    // a Stack checks its bindings as it is built and there is no container
+    // list there to match against.
+    const error = await assertThrowsErrorAsync(async () => {
+      return await simAws.cloudFormation().deployTemplate({
+        stackName: "orders-stack",
+        template: {
+          Resources: {
+            WorkerTaskDefinition: {
+              Type: "AWS::ECS::TaskDefinition",
+              Properties: {
+                Family: "orders-worker",
+                ContainerDefinitions: { Name: "app", Image: workerImage },
+              },
+            },
+          },
+        },
+        bindings: [
+          {
+            imageRepository:
+              "example.dkr.ecr.eu-west-2.amazonaws.com/orders-worker",
+            run: () => undefined,
+          },
+        ],
+      });
+    });
+
+    assertStringIncludes(error.message, "does not resolve to a Resource");
+  });
+
+  it("keeps a Lambda binding and a container binding apart", async () => {
+    // Given one deployment binding both a Lambda function and a container, the
+    // Lambda one naming the task definition's logical ID is what would go
+    // wrong if the two kinds were not told apart.
+    const simAws = new SimAws();
+    let containerRuns = 0;
+
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: {
+        Resources: {
+          ...twoFamilies.Resources,
+          OrdersFunction: {
+            Type: "AWS::Lambda::Function",
+            Properties: {
+              FunctionName: "orders",
+              Role: `arn:aws:iam::${simAws.defaultAccountId}:role/OrdersRole`,
+            },
+          },
+        },
+      },
+      bindings: [
+        { functionName: "orders", handler: () => "ran the function" },
+        {
+          logicalId: "WorkerTaskDefinition",
+          run: () => {
+            containerRuns += 1;
+          },
+        },
+      ],
+    });
+
+    await stack.waitForDeployComplete();
+
+    // When a task is run from the bound task definition.
+    await simAws.ecs().runTask(
+      new RunTaskCommand({
+        cluster: "orders",
+        taskDefinition: "orders-worker",
+      }),
+    );
+
+    await simAws.backgroundTasksComplete();
+
+    // Then the container ran its own handler, and invoking the function runs
+    // the handler its own binding supplied.
+    assertIdentical(containerRuns, 1);
+
+    const invoked = await simAws
+      .lambda()
+      .invoke(new InvokeCommand({ FunctionName: "orders" }));
+
+    assertIdentical(invoked.StatusCode, 200);
+    assertStringIncludes(
+      Buffer.from(invoked.Payload ?? new Uint8Array()).toString(),
+      "ran the function",
+    );
+  });
+});

--- a/src/service/ecs/cfn/sim-cfn-ecs-bindings.iso.test.ts
+++ b/src/service/ecs/cfn/sim-cfn-ecs-bindings.iso.test.ts
@@ -1,0 +1,319 @@
+import { DescribeTasksCommand, RunTaskCommand } from "@aws-sdk/client-ecs";
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import type { CfnTemplateBodyRecord } from "../../cloudformation/template/sim-cfn-template.js";
+import type {
+  SimCfnTemplateValue,
+  SimCfnTemplateValueRecord,
+} from "../../cloudformation/template/value/sim-cfn-template-value.js";
+
+const imageUri =
+  "example.dkr.ecr.eu-west-2.amazonaws.com/orders-worker:build-7";
+
+function workerTemplate(
+  containers: SimCfnTemplateValue[],
+  metadata?: SimCfnTemplateValueRecord,
+): CfnTemplateBodyRecord {
+  return {
+    Resources: {
+      OrdersCluster: {
+        Type: "AWS::ECS::Cluster",
+        Properties: { ClusterName: "orders" },
+      },
+      WorkerTaskDefinition: {
+        Type: "AWS::ECS::TaskDefinition",
+        ...(metadata !== undefined && { Metadata: metadata }),
+        Properties: {
+          Family: "orders-worker",
+          ContainerDefinitions: containers,
+        },
+      },
+    },
+  };
+}
+
+const appContainer = { Name: "app", Image: imageUri };
+const logRouterContainer = {
+  Name: "log-router",
+  Image: "public.ecr.aws/aws-observability/aws-for-fluent-bit:stable",
+};
+
+/**
+ * Run one task of the deployed family and let the simulation finish it.
+ */
+async function runWorkerTask(simAws: SimAws): Promise<string> {
+  const run = await simAws.ecs().runTask(
+    new RunTaskCommand({
+      cluster: "orders",
+      taskDefinition: "orders-worker",
+    }),
+  );
+
+  await simAws.backgroundTasksComplete();
+
+  const taskArn = run.tasks?.[0]?.taskArn;
+  assertNonNullable(taskArn);
+
+  return taskArn;
+}
+
+describe("ECS CloudFormation container bindings", () => {
+  it("runs a container bound by family and container name", async () => {
+    // Given a handler bound at deploy time to a container of a family.
+    const simAws = new SimAws();
+    let runs = 0;
+
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: workerTemplate([appContainer]),
+      bindings: [
+        {
+          family: "orders-worker",
+          containerName: "app",
+          run: () => {
+            runs += 1;
+          },
+        },
+      ],
+    });
+
+    await stack.waitForDeployComplete();
+
+    // When a task is run from the deployed task definition.
+    await runWorkerTask(simAws);
+
+    // Then the bound handler ran, in this process, as the task's container.
+    assertIdentical(runs, 1);
+  });
+
+  it("runs a container bound by the task definition's logical ID", async () => {
+    // Given a handler bound to the Resource rather than to the family, which
+    // is what a template gives a test to name.
+    const simAws = new SimAws();
+    let runs = 0;
+
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: workerTemplate([appContainer]),
+      bindings: [
+        {
+          logicalId: "WorkerTaskDefinition",
+          run: () => {
+            runs += 1;
+          },
+        },
+      ],
+    });
+
+    await stack.waitForDeployComplete();
+
+    // When a task is run.
+    await runWorkerTask(simAws);
+
+    // Then the one container the task definition declares ran the handler,
+    // since a binding naming no container can only have meant that one.
+    assertIdentical(runs, 1);
+  });
+
+  it("runs a container bound by the CDK construct ID", async () => {
+    // Given a synthesized task definition carrying its CDK construct path, and
+    // a binding naming the construct rather than the generated logical ID.
+    const simAws = new SimAws();
+    let runs = 0;
+
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: workerTemplate([appContainer, logRouterContainer], {
+        "aws:cdk:path": "OrdersStack/WorkerTask/Resource",
+      }),
+      bindings: [
+        {
+          logicalId: "WorkerTask",
+          containerName: "app",
+          run: () => {
+            runs += 1;
+          },
+        },
+      ],
+    });
+
+    await stack.waitForDeployComplete();
+
+    // When a task is run.
+    await runWorkerTask(simAws);
+
+    // Then the named container ran the handler.
+    assertIdentical(runs, 1);
+  });
+
+  it("runs a container bound by its image repository", async () => {
+    // Given a binding naming the repository the container's image comes from,
+    // which is what covers an image tag that changes with every build.
+    const simAws = new SimAws();
+    let runs = 0;
+
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: workerTemplate([appContainer, logRouterContainer]),
+      bindings: [
+        {
+          imageRepository:
+            "example.dkr.ecr.eu-west-2.amazonaws.com/orders-worker",
+          run: () => {
+            runs += 1;
+          },
+        },
+      ],
+    });
+
+    await stack.waitForDeployComplete();
+
+    // When a task is run.
+    await runWorkerTask(simAws);
+
+    // Then the container running that image ran the handler, and the log
+    // router, which runs another image, did not.
+    assertIdentical(runs, 1);
+  });
+
+  it("deploys a container it cannot run, recording it as not simulated", async () => {
+    // Given a task definition holding an application container and a log
+    // router, with only the application bound, which is the ordinary shape of
+    // a real one.
+    const simAws = new SimAws();
+
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: workerTemplate([appContainer, logRouterContainer]),
+      bindings: [
+        {
+          family: "orders-worker",
+          containerName: "app",
+          run: () => undefined,
+        },
+      ],
+    });
+
+    // Then the stack deploys rather than failing for the container Yulin
+    // cannot run.
+    await stack.waitForDeployComplete();
+
+    assertIdentical(
+      stack.resources.get("WorkerTaskDefinition")?.status,
+      "CREATE_COMPLETE",
+    );
+
+    // And when a task is run, the unbound container is recorded as not
+    // simulated rather than as one that failed.
+    const taskArn = await runWorkerTask(simAws);
+    const described = await simAws
+      .ecs()
+      .describeTasks(
+        new DescribeTasksCommand({ cluster: "orders", tasks: [taskArn] }),
+      );
+
+    const logRouter = described.tasks?.[0]?.containers?.[1];
+    assertNonNullable(logRouter);
+    assertIdentical(logRouter.name, "log-router");
+    assertStringIncludes(logRouter.reason ?? "", "Not simulated");
+  });
+
+  it("refuses a binding that resolves to no Resource in the stack", async () => {
+    // Given a binding naming a family the stack does not declare, which is
+    // most often a container renamed in the template and not in the test.
+    const simAws = new SimAws();
+
+    // When the template is deployed, then the deployment is refused naming the
+    // binding.
+    const error = await assertThrowsErrorAsync(async () => {
+      return await simAws.cloudFormation().deployTemplate({
+        stackName: "orders-stack",
+        template: workerTemplate([appContainer]),
+        bindings: [
+          {
+            family: "orders-checkout",
+            containerName: "app",
+            run: () => undefined,
+          },
+        ],
+      });
+    });
+
+    assertStringIncludes(error.message, "orders-checkout");
+    assertStringIncludes(error.message, "does not resolve to a Resource");
+  });
+
+  it("refuses a Resource binding naming a container it does not declare", async () => {
+    // Given a binding naming the Resource and a container name the task
+    // definition does not declare.
+    const simAws = new SimAws();
+
+    // When the template is deployed, then the deployment is refused listing
+    // the containers the revision does declare.
+    const error = await assertThrowsErrorAsync(async () => {
+      return await simAws.cloudFormation().deployTemplate({
+        stackName: "orders-stack",
+        template: workerTemplate([appContainer, logRouterContainer]),
+        bindings: [
+          {
+            logicalId: "WorkerTaskDefinition",
+            containerName: "worker",
+            run: () => undefined,
+          },
+        ],
+      });
+    });
+
+    assertStringIncludes(error.message, "which family orders-worker does not");
+    assertStringIncludes(error.message, "app, log-router");
+  });
+
+  it("refuses a Resource binding with nothing to choose a container by", async () => {
+    // Given a binding naming the Resource of a task definition that declares
+    // more than one container, and no container name.
+    const simAws = new SimAws();
+
+    // When the template is deployed, then the deployment is refused, since
+    // there is nothing here to choose between them.
+    const error = await assertThrowsErrorAsync(async () => {
+      return await simAws.cloudFormation().deployTemplate({
+        stackName: "orders-stack",
+        template: workerTemplate([appContainer, logRouterContainer]),
+        bindings: [{ logicalId: "WorkerTaskDefinition", run: () => undefined }],
+      });
+    });
+
+    assertStringIncludes(error.message, "needs a containerName");
+    assertStringIncludes(error.message, "declares 2 containers");
+  });
+
+  it("refuses an http container binding, which nothing serves yet", async () => {
+    // Given a binding carrying the HTTP shape a service container will take.
+    const simAws = new SimAws();
+
+    // When the template is deployed, then the binding is refused rather than
+    // held and never called.
+    const error = await assertThrowsErrorAsync(async () => {
+      return await simAws.cloudFormation().deployTemplate({
+        stackName: "orders-stack",
+        template: workerTemplate([appContainer]),
+        bindings: [
+          {
+            family: "orders-worker",
+            containerName: "app",
+            http: () => new Response("ok"),
+          },
+        ],
+      });
+    });
+
+    assertStringIncludes(error.message, "an http handler is not simulated");
+  });
+});

--- a/src/service/ecs/cfn/sim-cfn-ecs-cluster.iso.test.ts
+++ b/src/service/ecs/cfn/sim-cfn-ecs-cluster.iso.test.ts
@@ -1,0 +1,232 @@
+import { DescribeClustersCommand } from "@aws-sdk/client-ecs";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertFalse,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertTrue,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+
+const clusterTemplate = {
+  Resources: {
+    OrdersCluster: {
+      Type: "AWS::ECS::Cluster",
+      Properties: {
+        ClusterName: "orders",
+        ClusterSettings: [{ Name: "containerInsights", Value: "enabled" }],
+        Tags: [{ Key: "Team", Value: "payments" }],
+      },
+    },
+  },
+  Outputs: {
+    ClusterRef: { Value: { Ref: "OrdersCluster" } },
+    ClusterArn: { Value: { "Fn::GetAtt": ["OrdersCluster", "Arn"] } },
+  },
+};
+
+describe("AWS::ECS::Cluster", () => {
+  it("creates a simulated cluster the template declares", async () => {
+    // Given a template declaring a cluster.
+    const simAws = new SimAws();
+
+    // When it is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: clusterTemplate,
+    });
+
+    await stack.waitForDeployComplete();
+
+    // Then simulated ECS holds the cluster, and the Resource answers Ref with
+    // its name and Fn::GetAtt Arn with its ARN.
+    const cluster = simAws.ecs().cluster("orders");
+
+    assertTrue(cluster.isActive());
+    assertIdentical(stack.outputs.get("ClusterRef")?.value, "orders");
+    assertIdentical(stack.outputs.get("ClusterArn")?.value, cluster.clusterArn);
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("reports the settings and tags the template declared", async () => {
+    // Given a deployed cluster declaring settings and tags in the
+    // CloudFormation spelling of them.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: clusterTemplate,
+    });
+
+    await stack.waitForDeployComplete();
+
+    // When it is described asking for both.
+    const described = await simAws.ecs().describeClusters(
+      new DescribeClustersCommand({
+        clusters: ["orders"],
+        include: ["SETTINGS", "TAGS"],
+      }),
+    );
+
+    // Then they are reported in the spelling the SDK uses, since a template
+    // upper cases the first letter of every name the API has.
+    assertArrayLength(described.clusters, 1);
+    assertIdentical(
+      described.clusters[0].settings?.[0]?.name,
+      "containerInsights",
+    );
+    assertIdentical(described.clusters[0].settings[0].value, "enabled");
+    assertIdentical(described.clusters[0].tags?.[0]?.key, "Team");
+    assertIdentical(described.clusters[0].tags[0].value, "payments");
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("names an unnamed cluster after the stack and logical ID", async () => {
+    // Given a template declaring a cluster without a name, which real
+    // CloudFormation would generate one for.
+    const simAws = new SimAws();
+
+    // When it is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: {
+        Resources: { OrdersCluster: { Type: "AWS::ECS::Cluster" } },
+        Outputs: { ClusterRef: { Value: { Ref: "OrdersCluster" } } },
+      },
+    });
+
+    await stack.waitForDeployComplete();
+
+    // Then the cluster is named from the stack and the logical ID, without the
+    // random part real CloudFormation adds, so a test can predict it.
+    assertIdentical(
+      stack.outputs.get("ClusterRef")?.value,
+      "orders-stack-OrdersCluster",
+    );
+    assertTrue(simAws.ecs().cluster("orders-stack-OrdersCluster").isActive());
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("deploys a cluster declaring capacity providers, without them", async () => {
+    // Given a template declaring the capacity a cluster has, which there is
+    // none of here.
+    const simAws = new SimAws();
+
+    // When it is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: {
+        Resources: {
+          OrdersCluster: {
+            Type: "AWS::ECS::Cluster",
+            Properties: {
+              ClusterName: "orders",
+              CapacityProviders: ["FARGATE"],
+              ServiceConnectDefaults: { Namespace: "orders" },
+            },
+          },
+        },
+      },
+    });
+
+    await stack.waitForDeployComplete();
+
+    // Then the cluster is created without them, and both are recorded so a
+    // reader can see what the deployed cluster is not doing.
+    assertTrue(simAws.ecs().cluster("orders").isActive());
+
+    const ignored = stack.resources.get("OrdersCluster")?.ignoredProperties;
+    assertNonNullable(ignored);
+    assertArrayLength(ignored, 2);
+    assertStringIncludes(
+      ignored.map((property) => property.reason).join(" "),
+      "there is nothing for a capacity provider to place it on",
+    );
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("refuses a cluster name that is not a string", async () => {
+    // Given a template whose ClusterName is an object rather than a name.
+    const simAws = new SimAws();
+
+    // When it is deployed, then the deployment fails, naming the Resource and
+    // the property.
+    const error = await assertThrowsErrorAsync(async () => {
+      return await simAws.cloudFormation().deployTemplate({
+        stackName: "orders-stack",
+        template: {
+          Resources: {
+            OrdersCluster: {
+              Type: "AWS::ECS::Cluster",
+              Properties: { ClusterName: { Name: "orders" } },
+            },
+          },
+        },
+      });
+    });
+
+    assertStringIncludes(error.message, "OrdersCluster");
+    assertStringIncludes(error.message, "ClusterName is a string");
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("refuses an attribute a cluster does not have", async () => {
+    // Given a template reading an attribute AWS::ECS::Cluster has no answer
+    // for.
+    const simAws = new SimAws();
+
+    // When it is deployed, then the deployment fails naming the attribute.
+    const error = await assertThrowsErrorAsync(async () => {
+      return await simAws.cloudFormation().deployTemplate({
+        stackName: "orders-stack",
+        template: {
+          Resources: {
+            OrdersCluster: {
+              Type: "AWS::ECS::Cluster",
+              Properties: { ClusterName: "orders" },
+            },
+          },
+          Outputs: {
+            Nonsense: {
+              Value: { "Fn::GetAtt": ["OrdersCluster", "Capacity"] },
+            },
+          },
+        },
+      });
+    });
+
+    assertStringIncludes(
+      error.message,
+      "Unsupported AWS::ECS::Cluster attribute Capacity",
+    );
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("marks a cluster INACTIVE when the stack is torn down", async () => {
+    // Given a deployed cluster.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: clusterTemplate,
+    });
+
+    await stack.waitForDeployComplete();
+
+    // When the stack is deleted.
+    await stack.delete();
+    await simAws.backgroundTasksComplete();
+
+    // Then the cluster is INACTIVE rather than gone, so something holding its
+    // ARN can still find out what became of it.
+    assertFalse(simAws.ecs().cluster("orders").isActive());
+  });
+});

--- a/src/service/ecs/cfn/sim-cfn-ecs-properties.iso.test.ts
+++ b/src/service/ecs/cfn/sim-cfn-ecs-properties.iso.test.ts
@@ -1,0 +1,361 @@
+import {
+  DescribeClustersCommand,
+  DescribeTaskDefinitionCommand,
+} from "@aws-sdk/client-ecs";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertObjectEquals,
+  assertStringIncludes,
+  assertThrowsError,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import type { CfnTemplateBodyRecord } from "../../cloudformation/template/sim-cfn-template.js";
+import { SimCfnResource } from "../../cloudformation/resource/sim-cfn-resource.js";
+
+const appContainer = {
+  Name: "app",
+  Image: "example.dkr.ecr.eu-west-2.amazonaws.com/orders-worker:1",
+};
+
+/**
+ * A stack holding one task definition with the properties under test.
+ */
+function taskDefinitionTemplate(properties: object): CfnTemplateBodyRecord {
+  return {
+    Resources: {
+      WorkerTaskDefinition: {
+        Type: "AWS::ECS::TaskDefinition",
+        Properties: {
+          Family: "orders-worker",
+          ContainerDefinitions: [appContainer],
+          ...properties,
+        },
+      },
+    },
+  };
+}
+
+describe("ECS CloudFormation property reading", () => {
+  it("translates the structures a task definition declares", async () => {
+    // Given a template declaring the volumes, placement and platform a real
+    // Fargate task definition carries, in CloudFormation's spelling.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: taskDefinitionTemplate({
+        Volumes: [
+          {
+            Name: "state",
+            EFSVolumeConfiguration: {
+              FilesystemId: "fs-1",
+              RootDirectory: "/",
+            },
+          },
+        ],
+        PlacementConstraints: [{ Type: "memberOf", Expression: "attribute:x" }],
+        RuntimePlatform: {
+          CpuArchitecture: "ARM64",
+          OperatingSystemFamily: "LINUX",
+        },
+        EphemeralStorage: { SizeInGiB: 40 },
+        ProxyConfiguration: {
+          Type: "APPMESH",
+          ContainerName: "envoy",
+          ProxyConfigurationProperties: [{ Name: "IgnoredUID", Value: "1337" }],
+        },
+      }),
+    });
+
+    await stack.waitForDeployComplete();
+
+    // When the revision is described.
+    const described = await simAws
+      .ecs()
+      .describeTaskDefinition(
+        new DescribeTaskDefinitionCommand({ taskDefinition: "orders-worker" }),
+      );
+    const taskDefinition = described.taskDefinition;
+    assertNonNullable(taskDefinition);
+
+    // Then each of them reads back in the SDK's spelling, including the two
+    // names the ECS API does not simply lower the first letter of.
+    assertObjectEquals(taskDefinition.volumes?.[0]?.efsVolumeConfiguration, {
+      filesystemId: "fs-1",
+      rootDirectory: "/",
+    });
+    assertIdentical(
+      taskDefinition.placementConstraints?.[0]?.expression,
+      "attribute:x",
+    );
+    assertIdentical(taskDefinition.runtimePlatform?.cpuArchitecture, "ARM64");
+    assertIdentical(taskDefinition.ephemeralStorage?.sizeInGiB, 40);
+    assertObjectEquals(taskDefinition.proxyConfiguration?.properties?.[0], {
+      name: "IgnoredUID",
+      value: "1337",
+    });
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("translates a cluster's configuration", async () => {
+    // Given a template declaring a cluster configuration.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: {
+        Resources: {
+          OrdersCluster: {
+            Type: "AWS::ECS::Cluster",
+            Properties: {
+              ClusterName: "orders",
+              Configuration: {
+                ExecuteCommandConfiguration: { Logging: "DEFAULT" },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    await stack.waitForDeployComplete();
+
+    // When the cluster is described asking for it.
+    const described = await simAws.ecs().describeClusters(
+      new DescribeClustersCommand({
+        clusters: ["orders"],
+        include: ["CONFIGURATIONS"],
+      }),
+    );
+
+    // Then it reads back in the SDK's spelling.
+    assertObjectEquals(described.clusters?.[0]?.configuration, {
+      executeCommandConfiguration: { logging: "DEFAULT" },
+    });
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("records a task definition property simulated ECS knows nothing of", async () => {
+    // Given a template carrying a property no version of ECS has, which is
+    // usually a typo in a hand-written template.
+    const simAws = new SimAws();
+
+    // When it is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: taskDefinitionTemplate({ NetworkModes: ["awsvpc"] }),
+    });
+
+    await stack.waitForDeployComplete();
+
+    // Then the revision is registered without it, and it is recorded.
+    const ignored = stack.resources.get(
+      "WorkerTaskDefinition",
+    )?.ignoredProperties;
+    assertNonNullable(ignored);
+    assertArrayLength(ignored, 1);
+    assertStringIncludes(
+      ignored[0].reason,
+      "not a property simulated ECS knows about",
+    );
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("records a cluster property simulated ECS knows nothing of", async () => {
+    // Given the same mistake on a cluster.
+    const simAws = new SimAws();
+
+    // When it is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: {
+        Resources: {
+          OrdersCluster: {
+            Type: "AWS::ECS::Cluster",
+            Properties: { ClusterName: "orders", ClusterSetting: [] },
+          },
+        },
+      },
+    });
+
+    await stack.waitForDeployComplete();
+
+    // Then the cluster is created without it, and it is recorded.
+    const ignored = stack.resources.get("OrdersCluster")?.ignoredProperties;
+    assertNonNullable(ignored);
+    assertArrayLength(ignored, 1);
+    assertStringIncludes(
+      ignored[0].reason,
+      "not a property simulated ECS knows about",
+    );
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("refuses a list of compatibilities holding something that is not one", async () => {
+    // Given a template whose RequiresCompatibilities holds an object.
+    const simAws = new SimAws();
+
+    // When it is deployed, then the deployment fails naming the entry.
+    const error = await assertThrowsErrorAsync(async () => {
+      return await simAws.cloudFormation().deployTemplate({
+        stackName: "orders-stack",
+        template: taskDefinitionTemplate({
+          RequiresCompatibilities: [{ LaunchType: "FARGATE" }],
+        }),
+      });
+    });
+
+    assertStringIncludes(
+      error.message,
+      "RequiresCompatibilities entry 0 is a string",
+    );
+  });
+
+  it("refuses a runtime platform that is not an object", async () => {
+    // Given a template whose RuntimePlatform is a string.
+    const simAws = new SimAws();
+
+    // When it is deployed, then the deployment fails naming the property.
+    const error = await assertThrowsErrorAsync(async () => {
+      return await simAws.cloudFormation().deployTemplate({
+        stackName: "orders-stack",
+        template: taskDefinitionTemplate({ RuntimePlatform: "ARM64" }),
+      });
+    });
+
+    assertStringIncludes(error.message, "RuntimePlatform is an object");
+  });
+
+  it("refuses a container definition that is not an object", async () => {
+    // Given a template whose ContainerDefinitions holds a container name
+    // rather than a container.
+    const simAws = new SimAws();
+
+    // When it is deployed, then the deployment fails naming the entry.
+    const error = await assertThrowsErrorAsync(async () => {
+      return await simAws.cloudFormation().deployTemplate({
+        stackName: "orders-stack",
+        template: {
+          Resources: {
+            WorkerTaskDefinition: {
+              Type: "AWS::ECS::TaskDefinition",
+              Properties: {
+                Family: "orders-worker",
+                ContainerDefinitions: ["app"],
+              },
+            },
+          },
+        },
+      });
+    });
+
+    assertStringIncludes(
+      error.message,
+      "ContainerDefinitions entry 0 is an object",
+    );
+  });
+
+  it("refuses a task definition declaring no containers, as ECS does", async () => {
+    // Given a template declaring no ContainerDefinitions at all.
+    const simAws = new SimAws();
+
+    // When it is deployed, then RegisterTaskDefinition refuses it in the same
+    // words it refuses an SDK caller, since the Resource is registered by
+    // calling it.
+    const error = await assertThrowsErrorAsync(async () => {
+      return await simAws.cloudFormation().deployTemplate({
+        stackName: "orders-stack",
+        template: {
+          Resources: {
+            WorkerTaskDefinition: {
+              Type: "AWS::ECS::TaskDefinition",
+              Properties: { Family: "orders-worker" },
+            },
+          },
+        },
+      });
+    });
+
+    assertStringIncludes(
+      error.message,
+      "must declare at least one container definition",
+    );
+  });
+
+  it("skips an ECS Resource type nothing creates yet", async () => {
+    // Given a template declaring a service, which follows separately.
+    const simAws = new SimAws();
+
+    // When it is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: {
+        Resources: {
+          OrdersService: {
+            Type: "AWS::ECS::Service",
+            Properties: { ServiceName: "orders" },
+          },
+        },
+      },
+    });
+
+    await stack.waitForDeployComplete();
+
+    // Then the Resource is skipped rather than failing the stack, and the
+    // teardown steps over it.
+    assertArrayLength(stack.skippedResources, 1);
+    assertStringIncludes(
+      stack.resources.get("OrdersService")?.skippedReason ?? "",
+      "Unsupported sim ECS CloudFormation Resource Service",
+    );
+
+    await stack.teardown();
+
+    assertIdentical(
+      stack.resources.get("OrdersService")?.status,
+      "DELETE_COMPLETE",
+    );
+  });
+
+  it("refuses to delete a Resource type it does not create", async () => {
+    // Given a Resource type simulated ECS has no factory for, which a Stack
+    // would have skipped rather than created.
+    const simAws = new SimAws();
+    const resource = new SimCfnResource({
+      logicalId: "OrdersService",
+      template: { Type: "AWS::ECS::Service" },
+    });
+
+    // When its deletion is asked for directly, then it is refused, which is
+    // what a teardown records as a skipped deletion.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws
+        .ecs()
+        .cfnResourceFactory()
+        .delete("Service", resource, { simAws, resources: new Map() });
+    });
+
+    assertStringIncludes(
+      error.message,
+      "Unsupported sim ECS CloudFormation Resource Service deletion",
+    );
+  });
+
+  it("refuses a cluster name nothing holds", () => {
+    // Given a simulated ECS with no clusters in it.
+    const simAws = new SimAws();
+
+    // When a cluster is looked up by name, then it is refused rather than
+    // answered with nothing.
+    const error = assertThrowsError(() => simAws.ecs().cluster("orders"));
+
+    assertStringIncludes(error.message, "hold no cluster orders");
+  });
+});

--- a/src/service/ecs/cfn/sim-cfn-ecs-properties.iso.test.ts
+++ b/src/service/ecs/cfn/sim-cfn-ecs-properties.iso.test.ts
@@ -1,9 +1,11 @@
+import { UpdateStackCommand } from "@aws-sdk/client-cloudformation";
 import {
   DescribeClustersCommand,
   DescribeTaskDefinitionCommand,
 } from "@aws-sdk/client-ecs";
 import {
   assertArrayLength,
+  assertFalse,
   assertIdentical,
   assertNonNullable,
   assertObjectEquals,
@@ -346,6 +348,42 @@ describe("ECS CloudFormation property reading", () => {
       error.message,
       "Unsupported sim ECS CloudFormation Resource Service deletion",
     );
+  });
+
+  it("registers a new revision when the stack is updated", async () => {
+    // Given a deployed task definition.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: taskDefinitionTemplate({}),
+    });
+
+    await stack.waitForDeployComplete();
+
+    // When the stack is updated with a changed container image.
+    const updated = taskDefinitionTemplate({
+      ContainerDefinitions: [
+        {
+          Name: "app",
+          Image: "example.dkr.ecr.eu-west-2.amazonaws.com/orders-worker:2",
+        },
+      ],
+    });
+
+    await simAws.cloudFormation().updateStack(
+      new UpdateStackCommand({
+        StackName: "orders-stack",
+        TemplateBody: JSON.stringify(updated),
+      }),
+    );
+
+    await simAws.backgroundTasksComplete();
+
+    // Then a second revision is registered, and the one it replaced is
+    // INACTIVE, because sim CloudFormation replaces a changed Resource rather
+    // than updating it in place.
+    assertIdentical(simAws.ecs().taskDefinition("orders-worker").revision, 2);
+    assertFalse(simAws.ecs().taskDefinition("orders-worker:1").isActive());
   });
 
   it("refuses a cluster name nothing holds", () => {

--- a/src/service/ecs/cfn/sim-cfn-ecs-task-definition.iso.test.ts
+++ b/src/service/ecs/cfn/sim-cfn-ecs-task-definition.iso.test.ts
@@ -1,0 +1,373 @@
+import { DescribeTaskDefinitionCommand } from "@aws-sdk/client-ecs";
+import {
+  assertArrayLength,
+  assertFalse,
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsError,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+
+const workerContainer = {
+  Name: "app",
+  Image: "example.dkr.ecr.eu-west-2.amazonaws.com/orders-worker:1",
+  Essential: true,
+  Cpu: 256,
+  PortMappings: [{ ContainerPort: 8080, Protocol: "tcp" }],
+  Environment: [{ Name: "LOG_LEVEL", Value: "debug" }],
+  Secrets: [
+    {
+      Name: "API_KEY",
+      ValueFrom: "arn:aws:secretsmanager:eu-west-2:000000000000:secret:orders",
+    },
+  ],
+  DockerLabels: { "com.example.Team": "payments" },
+  LogConfiguration: {
+    LogDriver: "awslogs",
+    Options: { "awslogs-group": "/ecs/orders" },
+  },
+};
+
+const taskDefinitionTemplate = {
+  Resources: {
+    WorkerTaskDefinition: {
+      Type: "AWS::ECS::TaskDefinition",
+      Properties: {
+        Family: "orders-worker",
+        Cpu: "512",
+        Memory: "1024",
+        NetworkMode: "awsvpc",
+        RequiresCompatibilities: ["FARGATE"],
+        TaskRoleArn: { "Fn::GetAtt": ["WorkerTaskRole", "Arn"] },
+        ExecutionRoleArn: { Ref: "WorkerExecutionRole" },
+        ContainerDefinitions: [workerContainer],
+        Tags: [{ Key: "Team", Value: "payments" }],
+      },
+    },
+    WorkerTaskRole: {
+      Type: "AWS::IAM::Role",
+      Properties: {
+        RoleName: "orders-worker-task",
+        AssumeRolePolicyDocument: {
+          Version: "2012-10-17",
+          Statement: [
+            {
+              Effect: "Allow",
+              Principal: { Service: "ecs-tasks.amazonaws.com" },
+              Action: "sts:AssumeRole",
+            },
+          ],
+        },
+      },
+    },
+    WorkerExecutionRole: {
+      Type: "AWS::IAM::Role",
+      Properties: {
+        RoleName: "orders-worker-execution",
+        AssumeRolePolicyDocument: {
+          Version: "2012-10-17",
+          Statement: [
+            {
+              Effect: "Allow",
+              Principal: { Service: "ecs-tasks.amazonaws.com" },
+              Action: "sts:AssumeRole",
+            },
+          ],
+        },
+      },
+    },
+  },
+  Outputs: {
+    TaskDefinitionRef: { Value: { Ref: "WorkerTaskDefinition" } },
+    TaskDefinitionArn: {
+      Value: { "Fn::GetAtt": ["WorkerTaskDefinition", "TaskDefinitionArn"] },
+    },
+  },
+};
+
+describe("AWS::ECS::TaskDefinition", () => {
+  it("registers a revision the template declares", async () => {
+    // Given a template declaring a task definition.
+    const simAws = new SimAws();
+
+    // When it is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: taskDefinitionTemplate,
+    });
+
+    await stack.waitForDeployComplete();
+
+    // Then simulated ECS holds revision one of the family, and both Ref and
+    // Fn::GetAtt TaskDefinitionArn answer with the ARN, revision and all.
+    const taskDefinition = simAws.ecs().taskDefinition("orders-worker");
+
+    assertIdentical(taskDefinition.revision, 1);
+    assertStringIncludes(taskDefinition.taskDefinitionArn, "orders-worker:1");
+    assertIdentical(
+      stack.outputs.get("TaskDefinitionRef")?.value,
+      taskDefinition.taskDefinitionArn,
+    );
+    assertIdentical(
+      stack.outputs.get("TaskDefinitionArn")?.value,
+      taskDefinition.taskDefinitionArn,
+    );
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("stores the container definitions as they were declared", async () => {
+    // Given a deployed task definition whose container declares more than
+    // anything here reads.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: taskDefinitionTemplate,
+    });
+
+    await stack.waitForDeployComplete();
+
+    // When the revision is described.
+    const described = await simAws
+      .ecs()
+      .describeTaskDefinition(
+        new DescribeTaskDefinitionCommand({ taskDefinition: "orders-worker" }),
+      );
+
+    // Then the container reads back in the spelling the SDK uses, with the
+    // maps whose keys the template wrote left as they were written.
+    const container = described.taskDefinition?.containerDefinitions?.[0];
+    assertNonNullable(container);
+    assertIdentical(container.name, "app");
+    assertIdentical(
+      container.image,
+      "example.dkr.ecr.eu-west-2.amazonaws.com/orders-worker:1",
+    );
+    assertIdentical(container.cpu, 256);
+    assertIdentical(container.portMappings?.[0]?.containerPort, 8080);
+    assertIdentical(container.environment?.[0]?.name, "LOG_LEVEL");
+    assertIdentical(container.secrets?.[0]?.name, "API_KEY");
+    assertIdentical(
+      container.logConfiguration?.options?.["awslogs-group"],
+      "/ecs/orders",
+    );
+    assertIdentical(container.dockerLabels?.["com.example.Team"], "payments");
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("resolves a task Role by ARN and an execution Role by Ref", async () => {
+    // Given a template naming its task Role by Fn::GetAtt Arn and its
+    // execution Role by Ref, which resolves to the Role name.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: taskDefinitionTemplate,
+    });
+
+    await stack.waitForDeployComplete();
+
+    // When the revision is read back.
+    const taskDefinition = simAws.ecs().taskDefinition("orders-worker");
+
+    // Then both are held as ARNs, so a running task attributes its AWS calls
+    // to a Role rather than to a name that names nobody.
+    assertIdentical(
+      taskDefinition.settings.taskRoleArn,
+      `arn:aws:iam::${simAws.defaultAccountId}:role/orders-worker-task`,
+    );
+    assertIdentical(
+      taskDefinition.settings.executionRoleArn,
+      `arn:aws:iam::${simAws.defaultAccountId}:role/orders-worker-execution`,
+    );
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("reports the settings and tags the template declared", async () => {
+    // Given a deployed task definition declaring what a Fargate one carries.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: taskDefinitionTemplate,
+    });
+
+    await stack.waitForDeployComplete();
+
+    // When it is described asking for its tags.
+    const described = await simAws.ecs().describeTaskDefinition(
+      new DescribeTaskDefinitionCommand({
+        taskDefinition: "orders-worker",
+        include: ["TAGS"],
+      }),
+    );
+
+    // Then the settings and the tags read back as declared.
+    assertIdentical(described.taskDefinition?.cpu, "512");
+    assertIdentical(described.taskDefinition.memory, "1024");
+    assertIdentical(described.taskDefinition.networkMode, "awsvpc");
+    assertArrayLength(described.taskDefinition.requiresCompatibilities, 1);
+    assertIdentical(described.tags?.[0]?.key, "Team");
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("names an unnamed task definition after the stack and logical ID", async () => {
+    // Given a template declaring no Family, which real CloudFormation would
+    // generate one for.
+    const simAws = new SimAws();
+
+    // When it is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: {
+        Resources: {
+          WorkerTaskDefinition: {
+            Type: "AWS::ECS::TaskDefinition",
+            Properties: { ContainerDefinitions: [workerContainer] },
+          },
+        },
+      },
+    });
+
+    await stack.waitForDeployComplete();
+
+    // Then the family comes from the stack and the logical ID, without the
+    // random part real CloudFormation adds, so a test can predict it.
+    assertIdentical(
+      simAws.ecs().taskDefinition("orders-stack-WorkerTaskDefinition").revision,
+      1,
+    );
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("deploys a task definition declaring fault injection, without it", async () => {
+    // Given a template declaring a property RegisterTaskDefinition refuses.
+    const simAws = new SimAws();
+
+    // When it is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: {
+        Resources: {
+          WorkerTaskDefinition: {
+            Type: "AWS::ECS::TaskDefinition",
+            Properties: {
+              Family: "orders-worker",
+              EnableFaultInjection: true,
+              ContainerDefinitions: [workerContainer],
+            },
+          },
+        },
+      },
+    });
+
+    await stack.waitForDeployComplete();
+
+    // Then the revision is registered without it, and it is recorded rather
+    // than failing the stack.
+    assertIdentical(simAws.ecs().taskDefinition("orders-worker").revision, 1);
+
+    const ignored = stack.resources.get(
+      "WorkerTaskDefinition",
+    )?.ignoredProperties;
+    assertNonNullable(ignored);
+    assertArrayLength(ignored, 1);
+    assertStringIncludes(
+      ignored[0].reason,
+      "nothing injects a fault into a simulated task",
+    );
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("refuses container definitions that are not a list", async () => {
+    // Given a template whose ContainerDefinitions is one object rather than a
+    // list of them, which is an easy thing to write by hand.
+    const simAws = new SimAws();
+
+    // When it is deployed, then the deployment fails naming the property.
+    const error = await assertThrowsErrorAsync(async () => {
+      return await simAws.cloudFormation().deployTemplate({
+        stackName: "orders-stack",
+        template: {
+          Resources: {
+            WorkerTaskDefinition: {
+              Type: "AWS::ECS::TaskDefinition",
+              Properties: {
+                Family: "orders-worker",
+                ContainerDefinitions: workerContainer,
+              },
+            },
+          },
+        },
+      });
+    });
+
+    assertStringIncludes(error.message, "WorkerTaskDefinition");
+    assertStringIncludes(error.message, "ContainerDefinitions is a list");
+  });
+
+  it("refuses an attribute a task definition does not have", async () => {
+    // Given a template reading an attribute AWS::ECS::TaskDefinition has no
+    // answer for.
+    const simAws = new SimAws();
+
+    // When it is deployed, then the deployment fails naming the attribute.
+    const error = await assertThrowsErrorAsync(async () => {
+      return await simAws.cloudFormation().deployTemplate({
+        stackName: "orders-stack",
+        template: {
+          Resources: {
+            WorkerTaskDefinition: {
+              Type: "AWS::ECS::TaskDefinition",
+              Properties: {
+                Family: "orders-worker",
+                ContainerDefinitions: [workerContainer],
+              },
+            },
+          },
+          Outputs: {
+            Nonsense: {
+              Value: { "Fn::GetAtt": ["WorkerTaskDefinition", "Family"] },
+            },
+          },
+        },
+      });
+    });
+
+    assertStringIncludes(
+      error.message,
+      "Unsupported AWS::ECS::TaskDefinition attribute Family",
+    );
+  });
+
+  it("deregisters the revision when the stack is torn down", async () => {
+    // Given a deployed task definition.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: taskDefinitionTemplate,
+    });
+
+    await stack.waitForDeployComplete();
+
+    // When the stack is deleted.
+    await stack.delete();
+    await simAws.backgroundTasksComplete();
+
+    // Then the revision is INACTIVE rather than gone, and the family it left
+    // behind resolves to nothing, since nothing active is left in it.
+    assertFalse(simAws.ecs().taskDefinition("orders-worker:1").isActive());
+
+    const error = assertThrowsError(() =>
+      simAws.ecs().taskDefinition("orders-worker"),
+    );
+    assertStringIncludes(error.message, "orders-worker");
+  });
+});

--- a/src/service/ecs/cfn/sim-ecs-cfn-resource-factory.ts
+++ b/src/service/ecs/cfn/sim-ecs-cfn-resource-factory.ts
@@ -1,0 +1,116 @@
+import { assertDefined } from "../../../util/type-guard/defined.js";
+import type { SimCfnServiceResourceFactory } from "../../cloudformation/resource/factory/sim-cfn-resource-factory.type.js";
+import type {
+  SimCfnResource,
+  SimCloudFormationResourceCreateContext,
+} from "../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimEcsCluster } from "../cluster/sim-ecs-cluster.js";
+import type { SimEcsTaskDefinition } from "../task-definition/sim-ecs-task-definition.js";
+import type { SimEcs } from "../sim-ecs.js";
+import { SimCfnEcsClusterCreator } from "./cluster/sim-cfn-ecs-cluster-creator.js";
+import { SimCfnEcsTaskDefinitionCreator } from "./task-definition/sim-cfn-ecs-task-definition-creator.js";
+
+interface SimEcsCfnResourceFactoryProperties {
+  readonly ecs: SimEcs;
+}
+
+/**
+ * CloudFormation Resource factory for simulated ECS resources.
+ *
+ * `AWS::ECS::Cluster` and `AWS::ECS::TaskDefinition` are the two Resource
+ * types a stack has to have before anything else about ECS can be deployed:
+ * one is where tasks run, and the other is what they run. `AWS::ECS::Service`
+ * follows separately, and until it does a template declaring one deploys with
+ * the service recorded as unsupported.
+ */
+export class SimEcsCfnResourceFactory implements SimCfnServiceResourceFactory {
+  private readonly clusterCreator: SimCfnEcsClusterCreator;
+  private readonly taskDefinitionCreator: SimCfnEcsTaskDefinitionCreator;
+
+  constructor(properties: SimEcsCfnResourceFactoryProperties) {
+    this.clusterCreator = new SimCfnEcsClusterCreator({ ecs: properties.ecs });
+    this.taskDefinitionCreator = new SimCfnEcsTaskDefinitionCreator({
+      ecs: properties.ecs,
+    });
+  }
+
+  /**
+   * Create a simulated ECS resource from a CloudFormation Resource.
+   */
+  async create(
+    resourceTypeName: string,
+    resource: SimCfnResource,
+    context: SimCloudFormationResourceCreateContext,
+  ): Promise<object | undefined> {
+    const properties = context.resolvedProperties ?? resource.properties;
+
+    switch (resourceTypeName) {
+      case "Cluster": {
+        return await this.clusterCreator.create(resource, properties);
+      }
+      case "TaskDefinition": {
+        return await this.taskDefinitionCreator.create(
+          resource,
+          properties,
+          context.bindings,
+        );
+      }
+      default: {
+        throw new Error(
+          `Unsupported sim ECS CloudFormation Resource ${resourceTypeName}`,
+        );
+      }
+    }
+  }
+
+  /**
+   * Delete a simulated ECS resource created from a CloudFormation Resource.
+   */
+  async delete(
+    resourceTypeName: string,
+    resource: SimCfnResource,
+  ): Promise<void> {
+    switch (resourceTypeName) {
+      case "Cluster": {
+        await this.clusterCreator.delete(
+          simCfnEcsCreatedResource<SimEcsCluster>(resource, "cluster"),
+        );
+
+        return;
+      }
+      case "TaskDefinition": {
+        await this.taskDefinitionCreator.delete(
+          simCfnEcsCreatedResource<SimEcsTaskDefinition>(
+            resource,
+            "task definition",
+          ),
+        );
+
+        return;
+      }
+      default: {
+        throw new Error(
+          `Unsupported sim ECS CloudFormation Resource ${resourceTypeName} ` +
+            `deletion`,
+        );
+      }
+    }
+  }
+}
+
+/**
+ * The simulated resource a Resource created, which a teardown reaches it by.
+ */
+function simCfnEcsCreatedResource<T extends object>(
+  resource: SimCfnResource,
+  described: string,
+): T {
+  const created = resource.simResource as T | undefined;
+
+  assertDefined(
+    created,
+    `sim ECS ${described} for CloudFormation Resource ${resource.logicalId}`,
+  );
+
+  return created;
+}

--- a/src/service/ecs/cfn/task-definition/sim-cfn-ecs-container-definitions.ts
+++ b/src/service/ecs/cfn/task-definition/sim-cfn-ecs-container-definitions.ts
@@ -1,0 +1,30 @@
+import { isRecord } from "../../../../util/type-guard/record.js";
+import type { SimEcsContainerDefinitionType } from "../../task-definition/container/sim-ecs-container-definition.js";
+import { simCfnEcsApiShape } from "../property/sim-cfn-ecs-api-shape.js";
+import type { SimCfnEcsPropertyReader } from "../property/sim-cfn-ecs-property-reader.js";
+
+/**
+ * Read the `ContainerDefinitions` an AWS::ECS::TaskDefinition declares.
+ *
+ * Each definition is translated into the shape the ECS API uses and stored as
+ * it was declared, whatever image it names. Nothing here reads what a
+ * container means, for the reason nothing anywhere else in simulated ECS does:
+ * Yulin never looks inside a container image, so the declaration is the whole
+ * of what there is to hold.
+ *
+ * A missing list is left to `RegisterTaskDefinition` to refuse, so a template
+ * and an SDK call are refused in the same words for the same mistake.
+ */
+export function simCfnEcsContainerDefinitions(
+  reader: SimCfnEcsPropertyReader,
+): readonly SimEcsContainerDefinitionType[] | undefined {
+  return reader.list("ContainerDefinitions")?.map((definition, index) => {
+    if (!isRecord(definition)) {
+      throw reader.refuse(
+        `ContainerDefinitions entry ${String(index)} is an object`,
+      );
+    }
+
+    return simCfnEcsApiShape(definition) as SimEcsContainerDefinitionType;
+  });
+}

--- a/src/service/ecs/cfn/task-definition/sim-cfn-ecs-declared-task-definition.ts
+++ b/src/service/ecs/cfn/task-definition/sim-cfn-ecs-declared-task-definition.ts
@@ -1,0 +1,107 @@
+import { isRecord } from "../../../../util/type-guard/record.js";
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import { SimCfnEcsTaskDefinitionFamily } from "./sim-cfn-ecs-task-definition-family.js";
+
+/**
+ * The CloudFormation Resource type a task definition is declared as.
+ */
+export const simCfnEcsTaskDefinitionType = "AWS::ECS::TaskDefinition";
+
+/**
+ * One container, as a template declares it.
+ */
+export interface SimCfnEcsDeclaredContainer {
+  readonly name: string | undefined;
+  readonly image: string | undefined;
+}
+
+/**
+ * What an AWS::ECS::TaskDefinition Resource says it will register.
+ *
+ * This reads a Resource before anything has been created from it, which is
+ * what a binding supplied at deploy time has to be checked against: the Stack
+ * validates its bindings as it is built, long before a task definition
+ * exists to look one up in.
+ *
+ * Properties have already had Parameters and intrinsic functions resolved by
+ * then, so a family or an image built by `Fn::Sub` reads here as the string it
+ * resolved to. A value that is still an expression names nothing, as it does
+ * for an executable Resource binding.
+ */
+export class SimCfnEcsDeclaredTaskDefinition {
+  private readonly resource: SimCfnResource;
+
+  constructor(resource: SimCfnResource) {
+    this.resource = resource;
+  }
+
+  /**
+   * The task definition Resources of a Stack.
+   */
+  static of(
+    resources: ReadonlyMap<string, SimCfnResource>,
+  ): readonly SimCfnEcsDeclaredTaskDefinition[] {
+    return resources
+      .values()
+      .filter((resource) => resource.type === simCfnEcsTaskDefinitionType)
+      .map((resource) => new SimCfnEcsDeclaredTaskDefinition(resource))
+      .toArray();
+  }
+
+  /**
+   * The Resource this task definition is declared by.
+   */
+  get declaredBy(): SimCfnResource {
+    return this.resource;
+  }
+
+  /**
+   * The family this Resource will register under.
+   *
+   * A template that names no family gets the one CloudFormation would have
+   * generated, so a binding naming that family resolves the same way it will
+   * when the Resource is created.
+   */
+  family(): string {
+    const declared = this.resource.properties["Family"];
+
+    if (typeof declared === "string" && declared !== "") {
+      return declared;
+    }
+
+    return new SimCfnEcsTaskDefinitionFamily({
+      stackName: this.resource.stackName,
+      logicalId: this.resource.logicalId,
+    }).value;
+  }
+
+  /**
+   * The containers this Resource declares, by the two fields a binding is
+   * matched on.
+   */
+  containers(): readonly SimCfnEcsDeclaredContainer[] {
+    const declared = this.resource.properties["ContainerDefinitions"];
+
+    if (!Array.isArray(declared)) {
+      return [];
+    }
+
+    return declared
+      .filter((container) => isRecord(container))
+      .map((container) => ({
+        name: simCfnEcsDeclaredText(container["Name"]),
+        image: simCfnEcsDeclaredText(container["Image"]),
+      }));
+  }
+}
+
+/**
+ * A declared value where the template wrote a string for it.
+ */
+function simCfnEcsDeclaredText(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+
+  return value;
+}

--- a/src/service/ecs/cfn/task-definition/sim-cfn-ecs-role-arn.ts
+++ b/src/service/ecs/cfn/task-definition/sim-cfn-ecs-role-arn.ts
@@ -1,0 +1,35 @@
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import { makeSimRoleArn } from "../../../iam/role/arn/sim-iam-role-arn.js";
+import type { SimIamRoleName } from "../../../iam/role/sim-iam-role.js";
+
+/**
+ * The Role a task definition property names, resolved to an ARN.
+ *
+ * A template names a Role either as an ARN or as a `Ref` to an
+ * `AWS::IAM::Role` of the same stack, and a `Ref` to a Role resolves to the
+ * Role name rather than its ARN. A plain name is therefore mapped to the ARN it
+ * would have at the default path, which is what `Fn::GetAtt Role.Arn` would
+ * have resolved to.
+ *
+ * This is the same resolution an `AWS::Lambda::Function` `Role` goes through,
+ * and for the same reason: a task definition holding a Role name rather than a
+ * Role ARN would attribute a container's AWS calls to nobody.
+ */
+export function simCfnEcsRoleArn(
+  resource: SimCfnResource,
+  role: string | undefined,
+): string | undefined {
+  if (role === undefined) {
+    return undefined;
+  }
+
+  if (role.startsWith("arn:")) {
+    return role;
+  }
+
+  return makeSimRoleArn({
+    accountId: resource.accountRegionScope.accountId,
+    path: "/",
+    roleName: role as SimIamRoleName,
+  });
+}

--- a/src/service/ecs/cfn/task-definition/sim-cfn-ecs-task-definition-creator.ts
+++ b/src/service/ecs/cfn/task-definition/sim-cfn-ecs-task-definition-creator.ts
@@ -75,8 +75,9 @@ export class SimCfnEcsTaskDefinitionCreator {
    *
    * Deregistering marks the revision `INACTIVE` rather than removing it, as
    * `DeregisterTaskDefinition` does, and the revision number it used is not
-   * freed. The revisions earlier deployments of the same stack registered are
-   * left where they are, since this Resource only ever made the last one.
+   * freed. Only the revision this Resource registered is deregistered, which
+   * is also what an update does with the revision it replaces, since sim
+   * CloudFormation replaces a changed Resource rather than updating it.
    */
   async delete(taskDefinition: SimEcsTaskDefinition): Promise<void> {
     await this.ecs.deregisterTaskDefinition({

--- a/src/service/ecs/cfn/task-definition/sim-cfn-ecs-task-definition-creator.ts
+++ b/src/service/ecs/cfn/task-definition/sim-cfn-ecs-task-definition-creator.ts
@@ -1,0 +1,86 @@
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type { SimCfnDeployBinding } from "../../../cloudformation/bind/sim-cfn-deploy-binding.js";
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimEcsTaskDefinition } from "../../task-definition/sim-ecs-task-definition.js";
+import type { SimEcs } from "../../sim-ecs.js";
+import { SimCfnEcsContainerBindings } from "../bind/sim-cfn-ecs-container-bindings.js";
+import { SimCfnEcsTaskDefinitionProperties } from "./sim-cfn-ecs-task-definition-properties.js";
+
+interface SimCfnEcsTaskDefinitionCreatorProperties {
+  readonly ecs: SimEcs;
+}
+
+/**
+ * Registers simulated task definitions from AWS::ECS::TaskDefinition
+ * Resources.
+ *
+ * The revision is registered through the ordinary RegisterTaskDefinition
+ * command rather than constructed directly, so a revision a template deployed
+ * is the same thing an SDK caller would have got: the same container
+ * validation, the same revision numbering, and the same refusals.
+ *
+ * Each deployment of the template registers a new revision, as real
+ * CloudFormation does, because a task definition revision is immutable and an
+ * updated one is a new revision of the same family.
+ */
+export class SimCfnEcsTaskDefinitionCreator {
+  private readonly ecs: SimEcs;
+
+  constructor(properties: SimCfnEcsTaskDefinitionCreatorProperties) {
+    this.ecs = properties.ecs;
+  }
+
+  /**
+   * Register a revision from an AWS::ECS::TaskDefinition Resource.
+   *
+   * The bindings the deployment supplied are applied after the revision is
+   * registered, because a binding naming the Resource is bound by family and
+   * the family is only settled once the registration has been made.
+   */
+  async create(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+    bindings?: readonly SimCfnDeployBinding[],
+  ): Promise<SimEcsTaskDefinition> {
+    const taskDefinitionProperties = new SimCfnEcsTaskDefinitionProperties({
+      resource,
+      properties,
+    });
+    const input = taskDefinitionProperties.registerTaskDefinitionInput();
+
+    taskDefinitionProperties.recordIgnoredProperties();
+
+    const registered = await this.ecs.registerTaskDefinition({ input });
+    const taskDefinitionArn = registered.taskDefinition?.taskDefinitionArn;
+
+    assertDefined(
+      taskDefinitionArn,
+      `sim ECS task definition ARN for CloudFormation Resource ${resource.logicalId}`,
+    );
+
+    const taskDefinition = this.ecs.taskDefinition(taskDefinitionArn);
+
+    new SimCfnEcsContainerBindings({ resource, bindings }).applyTo(
+      this.ecs,
+      taskDefinition,
+    );
+
+    return taskDefinition;
+  }
+
+  /**
+   * Deregister a revision registered from an AWS::ECS::TaskDefinition
+   * Resource.
+   *
+   * Deregistering marks the revision `INACTIVE` rather than removing it, as
+   * `DeregisterTaskDefinition` does, and the revision number it used is not
+   * freed. The revisions earlier deployments of the same stack registered are
+   * left where they are, since this Resource only ever made the last one.
+   */
+  async delete(taskDefinition: SimEcsTaskDefinition): Promise<void> {
+    await this.ecs.deregisterTaskDefinition({
+      input: { taskDefinition: taskDefinition.taskDefinitionArn },
+    });
+  }
+}

--- a/src/service/ecs/cfn/task-definition/sim-cfn-ecs-task-definition-creator.ts
+++ b/src/service/ecs/cfn/task-definition/sim-cfn-ecs-task-definition-creator.ts
@@ -2,6 +2,7 @@ import { assertDefined } from "../../../../util/type-guard/defined.js";
 import type { SimCfnDeployBinding } from "../../../cloudformation/bind/sim-cfn-deploy-binding.js";
 import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
 import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimRegisterTaskDefinitionCommandInput } from "../../command/register-task-definition/register-task-definition.command.js";
 import type { SimEcsTaskDefinition } from "../../task-definition/sim-ecs-task-definition.js";
 import type { SimEcs } from "../../sim-ecs.js";
 import { SimCfnEcsContainerBindings } from "../bind/sim-cfn-ecs-container-bindings.js";
@@ -34,9 +35,12 @@ export class SimCfnEcsTaskDefinitionCreator {
   /**
    * Register a revision from an AWS::ECS::TaskDefinition Resource.
    *
-   * The bindings the deployment supplied are applied after the revision is
-   * registered, because a binding naming the Resource is bound by family and
-   * the family is only settled once the registration has been made.
+   * The bindings the deployment supplied are applied before the registration
+   * is made, from what the registration is going to say. A binding naming a
+   * container the declaration does not hold is refused, and refusing it first
+   * is what leaves nothing behind: a revision is immutable once registered, so
+   * one registered and then found to be unbindable could only be deregistered,
+   * and simulated CloudFormation rolls nothing back.
    */
   async create(
     resource: SimCfnResource,
@@ -51,6 +55,11 @@ export class SimCfnEcsTaskDefinitionCreator {
 
     taskDefinitionProperties.recordIgnoredProperties();
 
+    new SimCfnEcsContainerBindings({ resource, bindings }).applyTo(this.ecs, {
+      family: taskDefinitionProperties.family(),
+      containerNames: simCfnEcsDeclaredContainerNames(input),
+    });
+
     const registered = await this.ecs.registerTaskDefinition({ input });
     const taskDefinitionArn = registered.taskDefinition?.taskDefinitionArn;
 
@@ -59,14 +68,7 @@ export class SimCfnEcsTaskDefinitionCreator {
       `sim ECS task definition ARN for CloudFormation Resource ${resource.logicalId}`,
     );
 
-    const taskDefinition = this.ecs.taskDefinition(taskDefinitionArn);
-
-    new SimCfnEcsContainerBindings({ resource, bindings }).applyTo(
-      this.ecs,
-      taskDefinition,
-    );
-
-    return taskDefinition;
+    return this.ecs.taskDefinition(taskDefinitionArn);
   }
 
   /**
@@ -84,4 +86,19 @@ export class SimCfnEcsTaskDefinitionCreator {
       input: { taskDefinition: taskDefinition.taskDefinitionArn },
     });
   }
+}
+
+/**
+ * The container names the registration about to be made declares.
+ *
+ * A container declaring no name at all is left out, since
+ * `RegisterTaskDefinition` is about to refuse it, and naming it in a binding
+ * refusal would send a reader after the wrong thing.
+ */
+function simCfnEcsDeclaredContainerNames(
+  input: SimRegisterTaskDefinitionCommandInput,
+): readonly string[] {
+  return (input.containerDefinitions ?? [])
+    .map((container) => container.name)
+    .filter((name) => name !== undefined);
 }

--- a/src/service/ecs/cfn/task-definition/sim-cfn-ecs-task-definition-family.ts
+++ b/src/service/ecs/cfn/task-definition/sim-cfn-ecs-task-definition-family.ts
@@ -1,0 +1,40 @@
+import { SimCfnGeneratedResourceName } from "../../../cloudformation/resource/name/sim-cfn-generated-resource-name.js";
+
+/**
+ * How long an ECS task definition family may be.
+ */
+const maximumFamilyLength = 255;
+
+interface SimCfnEcsTaskDefinitionFamilyProperties {
+  readonly stackName: string | undefined;
+  readonly logicalId: string;
+}
+
+/**
+ * The family CloudFormation gives a task definition whose template does not
+ * name one.
+ *
+ * Real CloudFormation composes it from the stack name, the logical ID and a
+ * random part, which is why a template that leaves `Family` out is a template
+ * whose family nothing can predict. The random part is left out here so a test
+ * can name the family it got, and a binding that would rather not depend on
+ * that names the task definition's logical ID instead.
+ */
+export class SimCfnEcsTaskDefinitionFamily {
+  private readonly generated: SimCfnGeneratedResourceName;
+
+  constructor(properties: SimCfnEcsTaskDefinitionFamilyProperties) {
+    this.generated = new SimCfnGeneratedResourceName({
+      stackName: properties.stackName,
+      logicalId: properties.logicalId,
+      maximumLength: maximumFamilyLength,
+    });
+  }
+
+  /**
+   * The generated family.
+   */
+  get value(): string {
+    return this.generated.value;
+  }
+}

--- a/src/service/ecs/cfn/task-definition/sim-cfn-ecs-task-definition-properties.ts
+++ b/src/service/ecs/cfn/task-definition/sim-cfn-ecs-task-definition-properties.ts
@@ -1,0 +1,78 @@
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimRegisterTaskDefinitionCommandInput } from "../../command/register-task-definition/register-task-definition.command.js";
+import type { SimEcsTag } from "../../task-definition/sim-ecs-task-definition-parts.js";
+import { SimCfnEcsPropertyReader } from "../property/sim-cfn-ecs-property-reader.js";
+import { simCfnEcsContainerDefinitions } from "./sim-cfn-ecs-container-definitions.js";
+import { SimCfnEcsTaskDefinitionFamily } from "./sim-cfn-ecs-task-definition-family.js";
+import { SimCfnEcsTaskDefinitionPropertyRules } from "./sim-cfn-ecs-task-definition-property-rules.js";
+import { SimCfnEcsTaskDefinitionSettings } from "./sim-cfn-ecs-task-definition-settings.js";
+
+interface SimCfnEcsTaskDefinitionPropertiesProperties {
+  readonly resource: SimCfnResource;
+  readonly properties: SimCfnTemplateValueRecord;
+}
+
+/**
+ * Reads AWS::ECS::TaskDefinition CloudFormation properties into
+ * RegisterTaskDefinition input.
+ *
+ * The reading is split three ways because the property groups are three
+ * different jobs: the containers are a list to translate, the settings are a
+ * declaration to pass on with two Roles resolved out of it, and the rest is
+ * the family and the tags.
+ */
+export class SimCfnEcsTaskDefinitionProperties {
+  private readonly resource: SimCfnResource;
+  private readonly reader: SimCfnEcsPropertyReader;
+  private readonly settings: SimCfnEcsTaskDefinitionSettings;
+  private readonly rules: SimCfnEcsTaskDefinitionPropertyRules;
+
+  constructor(properties: SimCfnEcsTaskDefinitionPropertiesProperties) {
+    this.resource = properties.resource;
+    this.reader = new SimCfnEcsPropertyReader(properties);
+    this.settings = new SimCfnEcsTaskDefinitionSettings({
+      resource: properties.resource,
+      reader: this.reader,
+    });
+    this.rules = new SimCfnEcsTaskDefinitionPropertyRules({
+      properties: properties.properties,
+      ignorer: properties.resource,
+    });
+  }
+
+  /**
+   * The RegisterTaskDefinition input this Resource declares.
+   */
+  registerTaskDefinitionInput(): SimRegisterTaskDefinitionCommandInput {
+    return {
+      ...this.settings.declared(),
+      family: this.family(),
+      containerDefinitions: simCfnEcsContainerDefinitions(this.reader),
+      tags: this.reader.apiList<SimEcsTag>("Tags"),
+    };
+  }
+
+  /**
+   * The task definition family.
+   *
+   * An unnamed task definition takes a family from the stack and the logical
+   * ID, as real CloudFormation composes one from those and a random part.
+   */
+  family(): string {
+    return (
+      this.reader.text("Family") ??
+      new SimCfnEcsTaskDefinitionFamily({
+        stackName: this.resource.stackName,
+        logicalId: this.resource.logicalId,
+      }).value
+    );
+  }
+
+  /**
+   * Record the properties the revision is registered without acting on.
+   */
+  recordIgnoredProperties(): void {
+    this.rules.apply();
+  }
+}

--- a/src/service/ecs/cfn/task-definition/sim-cfn-ecs-task-definition-property-rules.ts
+++ b/src/service/ecs/cfn/task-definition/sim-cfn-ecs-task-definition-property-rules.ts
@@ -1,0 +1,101 @@
+import type { SimCfnPropertyIgnorer } from "../../../cloudformation/resource/ignore/sim-cfn-ignored-property.type.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+
+/**
+ * The properties a revision is registered with.
+ *
+ * Everything a registration holds is here, because a task definition is a
+ * declaration and a described revision reports it back. What a running task
+ * actually acts on is a much shorter list, and that difference belongs in the
+ * usage docs rather than in a property being dropped.
+ */
+const actedOnProperties: ReadonlySet<string> = new Set([
+  "Family",
+  "ContainerDefinitions",
+  "TaskRoleArn",
+  "ExecutionRoleArn",
+  "NetworkMode",
+  "Cpu",
+  "Memory",
+  "RequiresCompatibilities",
+  "Volumes",
+  "PlacementConstraints",
+  "RuntimePlatform",
+  "EphemeralStorage",
+  "ProxyConfiguration",
+  "PidMode",
+  "IpcMode",
+  "Tags",
+]);
+
+/**
+ * The real AWS::ECS::TaskDefinition properties this simulation has nothing to
+ * act on, and why.
+ *
+ * `RegisterTaskDefinition` refuses both, since a setting it does not hold
+ * would go missing from the revision it made. A template carrying one is
+ * deployed without it rather than failing the stack, because the rest of the
+ * task definition is still worth having.
+ */
+const unsimulatedPropertyReasons: ReadonlyMap<string, string> = new Map([
+  [
+    "InferenceAccelerators",
+    "there is no device to attach, since a container is an in-process handler",
+  ],
+  [
+    "EnableFaultInjection",
+    "nothing injects a fault into a simulated task, and no traffic passes " +
+      "through anything that could",
+  ],
+]);
+
+interface SimCfnEcsTaskDefinitionPropertyRulesProperties {
+  readonly properties: SimCfnTemplateValueRecord;
+  readonly ignorer: SimCfnPropertyIgnorer;
+}
+
+/**
+ * What a task definition Resource is registered without acting on.
+ */
+export class SimCfnEcsTaskDefinitionPropertyRules {
+  private readonly properties: SimCfnTemplateValueRecord;
+  private readonly ignorer: SimCfnPropertyIgnorer;
+
+  constructor(properties: SimCfnEcsTaskDefinitionPropertyRulesProperties) {
+    this.properties = properties.properties;
+    this.ignorer = properties.ignorer;
+  }
+
+  /**
+   * Record every property the revision is registered without.
+   */
+  apply(): void {
+    for (const name of Object.keys(this.properties)) {
+      this.applyToProperty(name);
+    }
+  }
+
+  private applyToProperty(name: string): void {
+    if (actedOnProperties.has(name)) {
+      return;
+    }
+
+    const unsimulatedReason = unsimulatedPropertyReasons.get(name);
+
+    if (unsimulatedReason === undefined) {
+      this.ignorer.ignoreProperty(
+        name,
+        `${name} is not a property simulated ECS knows about, so the task ` +
+          `definition is registered without it`,
+      );
+
+      return;
+    }
+
+    this.ignorer.ignoreProperty(
+      name,
+      `${name} is a real AWS::ECS::TaskDefinition property simulated ECS ` +
+        `does not act on: ${unsimulatedReason}`,
+    );
+  }
+}

--- a/src/service/ecs/cfn/task-definition/sim-cfn-ecs-task-definition-settings.ts
+++ b/src/service/ecs/cfn/task-definition/sim-cfn-ecs-task-definition-settings.ts
@@ -1,0 +1,68 @@
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type {
+  SimEcsEphemeralStorage,
+  SimEcsProxyConfiguration,
+  SimEcsRuntimePlatform,
+  SimEcsTaskDefinitionPlacementConstraint,
+  SimEcsVolume,
+} from "../../task-definition/sim-ecs-task-definition-parts.js";
+import type { SimEcsTaskDefinitionSettingsType } from "../../task-definition/sim-ecs-task-definition-settings.js";
+import type { SimCfnEcsPropertyReader } from "../property/sim-cfn-ecs-property-reader.js";
+import { simCfnEcsRoleArn } from "./sim-cfn-ecs-role-arn.js";
+
+interface SimCfnEcsTaskDefinitionSettingsProperties {
+  readonly resource: SimCfnResource;
+  readonly reader: SimCfnEcsPropertyReader;
+}
+
+/**
+ * Reads what an AWS::ECS::TaskDefinition declares besides its containers.
+ *
+ * These are the settings a registered revision holds, so they are translated
+ * and passed on rather than acted on. The two Roles are the exception: a
+ * running task uses them, and a template can name either of them by `Ref` to a
+ * Role of the same stack, so both go through the ARN resolution that turns a
+ * Role name into the ARN it would have.
+ */
+export class SimCfnEcsTaskDefinitionSettings {
+  private readonly resource: SimCfnResource;
+  private readonly reader: SimCfnEcsPropertyReader;
+
+  constructor(properties: SimCfnEcsTaskDefinitionSettingsProperties) {
+    this.resource = properties.resource;
+    this.reader = properties.reader;
+  }
+
+  /**
+   * The settings this Resource declares, as RegisterTaskDefinition takes them.
+   */
+  declared(): SimEcsTaskDefinitionSettingsType {
+    const reader = this.reader;
+
+    return {
+      taskRoleArn: this.roleArn("TaskRoleArn"),
+      executionRoleArn: this.roleArn("ExecutionRoleArn"),
+      networkMode: reader.text("NetworkMode"),
+      cpu: reader.text("Cpu"),
+      memory: reader.text("Memory"),
+      pidMode: reader.text("PidMode"),
+      ipcMode: reader.text("IpcMode"),
+      requiresCompatibilities: reader.textList("RequiresCompatibilities"),
+      volumes: reader.apiList<SimEcsVolume>("Volumes"),
+      placementConstraints:
+        reader.apiList<SimEcsTaskDefinitionPlacementConstraint>(
+          "PlacementConstraints",
+        ),
+      runtimePlatform:
+        reader.apiRecord<SimEcsRuntimePlatform>("RuntimePlatform"),
+      ephemeralStorage:
+        reader.apiRecord<SimEcsEphemeralStorage>("EphemeralStorage"),
+      proxyConfiguration:
+        reader.apiRecord<SimEcsProxyConfiguration>("ProxyConfiguration"),
+    };
+  }
+
+  private roleArn(name: string): string | undefined {
+    return simCfnEcsRoleArn(this.resource, this.reader.text(name));
+  }
+}

--- a/src/service/ecs/index.ts
+++ b/src/service/ecs/index.ts
@@ -64,6 +64,12 @@ export type {
 } from "./bind/sim-ecs-container-binding.type.js";
 export { SimEcsContainerBindings } from "./bind/sim-ecs-container-bindings.js";
 export { SimEcsBoundContainer } from "./bind/sim-ecs-bound-container.js";
+export type {
+  SimCfnEcsContainerBinding,
+  SimCfnEcsContainerBindingTarget,
+  SimCfnEcsTaskDefinitionBindingTarget,
+} from "./cfn/bind/sim-cfn-ecs-container-binding.type.js";
+export { SimEcsCfnResourceFactory } from "./cfn/sim-ecs-cfn-resource-factory.js";
 export { SimEcsTask } from "./task/sim-ecs-task.js";
 export type {
   SimEcsTaskDesiredStatus,

--- a/src/service/ecs/sim-ecs-commands.ts
+++ b/src/service/ecs/sim-ecs-commands.ts
@@ -25,6 +25,7 @@ import { StopTaskCommandHandler } from "./command/stop-task/stop-task.handler.js
 import { UpdateServiceCommandHandler } from "./command/update-service/update-service.handler.js";
 import type { SimEcsServiceTasks } from "./service/run/sim-ecs-service-tasks.js";
 import { SimEcsServiceStore } from "./service/sim-ecs-service-store.js";
+import { SimEcsLookup } from "./sim-ecs-lookup.js";
 import type { SimEcsProperties } from "./sim-ecs-properties.js";
 import { SimEcsUnreachableSecretStores } from "./task/run/secret/sim-ecs-secret-stores.js";
 import { SimEcsTaskStore } from "./task/sim-ecs-task-store.js";
@@ -74,6 +75,10 @@ export class SimEcsCommands {
   public readonly describeServices: DescribeServicesCommandHandler;
   public readonly deleteService: DeleteServiceCommandHandler;
 
+  public readonly lookup: SimEcsLookup;
+
+  private readonly clusters = new SimEcsClusterStore();
+  private readonly taskDefinitions = new SimEcsTaskDefinitionStore();
   private readonly services = new SimEcsServiceStore();
   private readonly serviceTasks: SimEcsServiceTasks;
 
@@ -86,13 +91,19 @@ export class SimEcsCommands {
       secretStores = new SimEcsUnreachableSecretStores(),
     } = properties;
 
+    this.lookup = new SimEcsLookup({
+      accountRegionScope,
+      clusters: this.clusters,
+      taskDefinitions: this.taskDefinitions,
+    });
+
     const contexts = new SimEcsCommandContexts({
       accountRegionScope,
       authorizer: new SimEcsAuthorizer({ iam }),
       background,
       runAsOwner,
-      clusters: new SimEcsClusterStore(),
-      taskDefinitions: new SimEcsTaskDefinitionStore(),
+      clusters: this.clusters,
+      taskDefinitions: this.taskDefinitions,
       tasks: new SimEcsTaskStore(),
       services: this.services,
       bindings: this.bindings,

--- a/src/service/ecs/sim-ecs-lookup.ts
+++ b/src/service/ecs/sim-ecs-lookup.ts
@@ -1,0 +1,61 @@
+import type { SimAwsAccountRegionScope } from "../aws/sim-aws-account-region-scope.js";
+import type { SimEcsCluster } from "./cluster/sim-ecs-cluster.js";
+import type { SimEcsClusterStore } from "./cluster/sim-ecs-cluster-store.js";
+import { SimEcsClusterNotFoundException } from "./error/sim-ecs.error.js";
+import { SimEcsTaskDefinitionId } from "./task-definition/sim-ecs-task-definition-id.js";
+import type { SimEcsTaskDefinitionStore } from "./task-definition/sim-ecs-task-definition-store.js";
+import type { SimEcsTaskDefinition } from "./task-definition/sim-ecs-task-definition.js";
+
+interface SimEcsLookupProperties {
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+  readonly clusters: SimEcsClusterStore;
+  readonly taskDefinitions: SimEcsTaskDefinitionStore;
+}
+
+/**
+ * What reads simulated ECS state without being an operation.
+ *
+ * A command handler answers with a description, which is what an SDK caller
+ * gets. A CloudFormation Resource needs the thing itself, so it can be what
+ * the Stack holds and what `Ref` and `Fn::GetAtt` answer from, and a test
+ * asserting on state wants the same. Both go through here rather than through
+ * the stores, so the way a name is read stays the way the commands read one.
+ */
+export class SimEcsLookup {
+  private readonly accountRegionScope: SimAwsAccountRegionScope;
+  private readonly clusters: SimEcsClusterStore;
+  private readonly taskDefinitions: SimEcsTaskDefinitionStore;
+
+  constructor(properties: SimEcsLookupProperties) {
+    this.accountRegionScope = properties.accountRegionScope;
+    this.clusters = properties.clusters;
+    this.taskDefinitions = properties.taskDefinitions;
+  }
+
+  /**
+   * The cluster of this name, active or deleted.
+   *
+   * A name nothing holds is refused, since the caller asked for a cluster
+   * rather than for whether there is one.
+   */
+  cluster(clusterName: string): SimEcsCluster {
+    const cluster = this.clusters.find(clusterName);
+
+    if (cluster === undefined) {
+      throw new SimEcsClusterNotFoundException(
+        `The simulated Account and Region hold no cluster ${clusterName}.`,
+      );
+    }
+
+    return cluster;
+  }
+
+  /**
+   * The task definition revision a family, `family:revision` or ARN names.
+   */
+  taskDefinition(identifier: string): SimEcsTaskDefinition {
+    return this.taskDefinitions.resolve(
+      SimEcsTaskDefinitionId.parse(identifier, this.accountRegionScope),
+    );
+  }
+}

--- a/src/service/ecs/sim-ecs.ts
+++ b/src/service/ecs/sim-ecs.ts
@@ -1,10 +1,14 @@
 import type { SimSdkCommandRouter } from "../../sdk/router/sim-sdk-command-router.type.js";
+import type { SimCfnServiceResourceFactory } from "../cloudformation/resource/factory/sim-cfn-resource-factory.type.js";
 import type { SimEcsContainerBinding } from "./bind/sim-ecs-container-binding.type.js";
+import { SimEcsCfnResourceFactory } from "./cfn/sim-ecs-cfn-resource-factory.js";
+import type { SimEcsCluster } from "./cluster/sim-ecs-cluster.js";
 import type * as simEcsCommands from "./command/sim-ecs-command.types.js";
 import type { SimEcsRequestOptions } from "./command/sim-ecs-request-options.js";
 import { SimEcsSdkCommandRouter } from "./sdk/sim-ecs-sdk-command-router.js";
 import { SimEcsCommands } from "./sim-ecs-commands.js";
 import type { SimEcsProperties } from "./sim-ecs-properties.js";
+import type { SimEcsTaskDefinition } from "./task-definition/sim-ecs-task-definition.js";
 
 /**
  * Simulated ECS. Handles SDK commands. Emulates AWS behaviour and state.
@@ -245,6 +249,34 @@ export class SimEcs {
    */
   bindContainer(binding: SimEcsContainerBinding): void {
     this.commands.bindings.add(binding);
+  }
+
+  /**
+   * The cluster of this name, whether it is active or deleted.
+   *
+   * A lookup rather than an operation, for a test or a CloudFormation Resource
+   * that needs the cluster itself rather than a description of it. A name
+   * nothing holds is refused, since the caller asked for a cluster.
+   */
+  cluster(clusterName: string): SimEcsCluster {
+    return this.commands.lookup.cluster(clusterName);
+  }
+
+  /**
+   * The task definition revision a family, `family:revision` or ARN names.
+   *
+   * A family on its own means its latest active revision, as it does
+   * everywhere else in ECS.
+   */
+  taskDefinition(identifier: string): SimEcsTaskDefinition {
+    return this.commands.lookup.taskDefinition(identifier);
+  }
+
+  /**
+   * Get this service's CloudFormation Resource factory.
+   */
+  cfnResourceFactory(): SimCfnServiceResourceFactory {
+    return new SimEcsCfnResourceFactory({ ecs: this });
   }
 
   /**

--- a/src/service/lambda/cfn/function/sim-cfn-lambda-code-input.ts
+++ b/src/service/lambda/cfn/function/sim-cfn-lambda-code-input.ts
@@ -1,4 +1,4 @@
-import type { SimCfnExecutableResourceBinding } from "../../../cloudformation/bind/sim-cfn-exec-binding.type.js";
+import type { SimCfnDeployBinding } from "../../../cloudformation/bind/sim-cfn-deploy-binding.js";
 import { SimCfnExecBindingFinder } from "../../../cloudformation/bind/validate/sim-cfn-exec-binding-finder.js";
 import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
 import type { SimLambdaFunctionCode } from "../../command/create-function/create-function.command.js";
@@ -11,7 +11,7 @@ import type { SimCfnLambdaFunctionProperties } from "./sim-cfn-lambda-function-p
 interface SimCfnLambdaCodeInputProperties {
   readonly resource: SimCfnResource;
   readonly functionProperties: SimCfnLambdaFunctionProperties;
-  readonly bindings?: readonly SimCfnExecutableResourceBinding[] | undefined;
+  readonly bindings?: readonly SimCfnDeployBinding[] | undefined;
   readonly containerImages: SimLambdaContainerImages;
 }
 

--- a/src/service/lambda/cfn/function/sim-cfn-lambda-function-creator.ts
+++ b/src/service/lambda/cfn/function/sim-cfn-lambda-function-creator.ts
@@ -1,4 +1,4 @@
-import type { SimCfnExecutableResourceBinding } from "../../../cloudformation/bind/sim-cfn-exec-binding.type.js";
+import type { SimCfnDeployBinding } from "../../../cloudformation/bind/sim-cfn-deploy-binding.js";
 import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
 import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
 import { assertDefined } from "../../../../util/type-guard/defined.js";
@@ -40,7 +40,7 @@ export class SimCfnLambdaFunctionCreator {
   async create(
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
-    bindings?: readonly SimCfnExecutableResourceBinding[],
+    bindings?: readonly SimCfnDeployBinding[],
   ): Promise<SimLambdaFunction> {
     const functionProperties = this.propertiesParser.parse(
       resource,


### PR DESCRIPTION
`AWS::ECS::Cluster` creates a simulated cluster and `AWS::ECS::TaskDefinition` registers a revision, both through the ordinary `CreateCluster` and `RegisterTaskDefinition` commands, so a Resource a template deployed is the same thing an SDK caller would have got. Container definitions are stored as declared, whatever their image, and what makes one run is an executable binding supplied at deploy time in the same `bindings` list a Lambda handler is, targeting a container by family and container name, by the task definition's logical ID or CDK construct ID, or by the repository its image comes from. Task and execution Roles resolve from a `Ref` to a same-stack Role or from an ARN, as a Lambda function's `Role` already does; a template declaring a container Yulin cannot run deploys with that container recorded as not simulated rather than failing the stack; and the cluster and task definition properties this simulation has nothing to act on are recorded as ignored rather than refused, so an ECS stack comes up.

Resolves https://github.com/KensioSoftware/yulin/issues/556

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added CloudFormation support for simulated ECS clusters and Fargate task definitions.
  - Supports cluster names, ARNs, task-definition revisions, roles, tags, settings, container definitions, and generated resource names.
  - Added ECS container bindings by logical ID, family/container name, image repository, or construct ID.
  - Added deployment-time handler execution and task-definition lifecycle management.
  - Added examples demonstrating orders processing, worker tasks, checkout handlers, and deployment outputs.

- **Bug Fixes**
  - Added clear validation errors for invalid, ambiguous, unsupported, or unresolved ECS configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->