### PR TITLE
chore: add fta score_cap as a failsafe gate

### DIFF
--- a/fta.json
+++ b/fta.json
@@ -1,3 +1,4 @@
 {
-  "exclude_filenames": []
+  "exclude_filenames": [],
+  "score_cap": 50
 }

--- a/scripts/sh/fta.sh
+++ b/scripts/sh/fta.sh
@@ -7,12 +7,19 @@ SRC_DIR="${ROOT_DIR}/src"
 
 THRESHOLD=50
 
+# fta.json sets score_cap as a failsafe for anyone running fta directly, but it
+# is too blunt to use here: it aborts on the first breaching file and writes
+# nothing to stdout, which would suppress both the table below and the --json
+# payload the gate depends on. Override it back to the fta default so this
+# script keeps reporting every breach, not just the first one fta happens to
+# reach. The jq gate below is the stricter of the two anyway (>= vs >).
+#
 # Always print the normal FTA table output for humans / CI logs.
-fta "${SRC_DIR}" --config-path "${ROOT_DIR}/fta.json"
+fta "${SRC_DIR}" --config-path "${ROOT_DIR}/fta.json" --score-cap 1000
 
 # Use JSON output to find files that violate the threshold.
 FINDINGS="$(
-  fta "${SRC_DIR}" --config-path "${ROOT_DIR}/fta.json" --json |
+  fta "${SRC_DIR}" --config-path "${ROOT_DIR}/fta.json" --score-cap 1000 --json |
     jq --argjson threshold "${THRESHOLD}" '
       map(select(.fta_score >= $threshold))
       | sort_by(.fta_score)


### PR DESCRIPTION
`fta.json` carried no `score_cap` key, so it silently inherited fta's own default of 1000 and the mechanism gated nothing. This sets it to 50 as a failsafe, so that if `scripts/sh/fta.sh` is ever bypassed — someone runs `fta` directly, or the jq pipeline breaks — fta itself still refuses scores over the cap. The shell script stays the primary gate.

## The failsafe is a no-op today, as intended

`score_cap` throws only when a score is *strictly greater* than the cap, whereas the script's jq gate fails at `>= 50`. So `score_cap: 50` is strictly looser and can never fire first. Confirmed against the current tree: the top score in `src/` is **49.999** (`service/secretsmanager/cfn/sim-cfn-secrets-manager-property-parser.ts`), with the next four also in the 49.9x band. `pnpm fta` exits 0, `fta src --config-path fta.json` exits 0, and `pnpm run check` exits 0.

Worth noting how little headroom there is: five files sit within 0.07 of the threshold, so a breach is a realistic event rather than a hypothetical one. That shaped the second half of this change.

## The early-abort problem is worse than just losing the table

The concern raised was that under `set -euo pipefail` the first plain `fta` call would abort the script before the friendly "Found N file(s)" report printed. Testing shows the behaviour is more destructive than that: `score_cap` does not run to completion and then exit non-zero — it **aborts on the first breaching file and writes nothing to stdout at all**. Verified with a deliberately low cap:

```
File notification/....iso.test.ts has a score of 10.15, which is beyond the score cap of 5, exiting.
```

stdout: 0 bytes. Critically, `--json` behaves identically — also 0 bytes. That means the suggested `|| true` on the table invocation is **not sufficient**: it lets the script past line 11, but the `--json` call then aborts too, and under `pipefail` the command substitution fails and `set -e` kills the script before the jq report is ever built.

I verified both alternatives in place by lowering the threshold to 45 to force a real breach:

| Approach | Exit | Table | Findings report |
|---|---|---|---|
| `score_cap` alone (naive) | 1 | ✗ | ✗ — one file named on stderr |
| `score_cap` + `\|\| true` on the table call | 1 | ✗ | ✗ |
| **`score_cap` + `--score-cap 1000` override (this PR)** | 1 | ✓ | ✓ — all 574 files listed |

So rather than `|| true`, the script now passes `--score-cap 1000` (fta's default) on both invocations. The CLI flag overrides the config file — verified — which keeps the config's failsafe role for direct invocations while leaving the script's richer gate fully in charge. This also avoids `|| true`, which would have masked genuine fta failures such as a parse error or a missing directory, weakening `set -e` for no benefit.

## Scope mismatch between the two gates

Flagging this since the two gates cover different file sets depending on the path given.

Pointed at `src/`, they match exactly — both analyse the same 3730 files, test files included (1147 of them; the highest-scoring test file is `cli/yulin.loc.test.ts` at 49.93). No mismatch there.

But `score_cap` applies to whatever path fta is given, and a bare `fta .` at the repo root analyses **4153** files, pulling in `docs/` and `test/` — which the script never gates. Several of those breach 50:

| Score | File |
|---|---|
| 59.62 | `docs/services/cognito/sim-cognito-sign-up-triggers.example.ts` |
| 58.06 | `test/cognito/trigger-fixture.ts` |
| 57.60 | `test/lambda/event-source-fixture.ts` |

So the failsafe is only equivalent to the real gate when pointed at `src/`; run against the repo root it fails on files that were never in scope. I have deliberately not added `exclude_directories` to `fta.json` to paper over this — whether docs examples and test fixtures *should* be complexity-gated is a separate decision, and quietly widening the config's exclusions would pre-empt it. Raising this for visibility instead.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated validation behavior so reports continue to include all files, even when individual scores exceed the default threshold.
  * Preserved the existing threshold check used to determine whether validation passes or fails.

* **Configuration**
  * Added a default score cap of 50 while allowing report generation to accommodate scores up to 1,000.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->