### PR TITLE
feat: deploy a sim ECS service from CloudFormation

### DIFF
--- a/docs/services/ecs/README.md
+++ b/docs/services/ecs/README.md
@@ -1804,7 +1804,8 @@ Current documented limitations:
   predict it. A stack deployed twice under different names therefore gets two different families.
 - A service that declares no `DesiredCount` keeps one task running, which is the default real
   CloudFormation documents for a new service. A `DesiredCount` written as the text of a number is
-  taken as that number, since a String Parameter resolves to text, and anything else is refused.
+  taken as that number, since a String Parameter resolves to text, and anything else is refused
+  naming the Resource and the property, a fraction of a task included.
 - An update replaces a task definition Resource rather than updating it in place, so it registers a
   new revision and deregisters the one it replaced. The family accumulates revisions with only the
   newest one `ACTIVE`, where real CloudFormation leaves the earlier revisions active.

--- a/docs/services/ecs/README.md
+++ b/docs/services/ecs/README.md
@@ -1192,9 +1192,10 @@ that finishes with a service running leaves nothing behind it.
 
 ## Deploying ECS from CloudFormation
 
-`AWS::ECS::Cluster` creates a simulated cluster, and `AWS::ECS::TaskDefinition` registers a
-simulated task definition revision, so a test can start from the stack the application is actually
-defined in rather than from `RegisterTaskDefinition` calls written for the test.
+`AWS::ECS::Cluster` creates a simulated cluster, `AWS::ECS::TaskDefinition` registers a simulated
+task definition revision, and `AWS::ECS::Service` creates a simulated service running it, so a test
+can start from the stack the application is actually defined in rather than from
+`RegisterTaskDefinition` and `CreateService` calls written for the test.
 
 `Ref` on a cluster returns the cluster name and `Fn::GetAtt` `Arn` returns its ARN. `Ref` on a task
 definition returns the task definition ARN, revision and all, which is also what `Fn::GetAtt`
@@ -1364,11 +1365,119 @@ A task definition's `TaskRoleArn` and `ExecutionRoleArn` resolve whether the tem
 or a `Ref` to an `AWS::IAM::Role` of the same stack, so a container's AWS calls are authorized as
 the role the stack deploys.
 
-Everything else the two Resource types declare is stored as declared, or recorded as ignored where
+### Deploying a service
+
+`AWS::ECS::Service` creates a service in its cluster, keeping `DesiredCount` tasks of the task
+definition it names running. `Cluster` takes a `Ref` to a cluster of the same stack or a cluster
+ARN, and `TaskDefinition` takes a `Ref` to a task definition of the same stack, which pins the
+revision the deployment registered, or an ARN, or a family. A container bound at deploy time is
+running once the stack has deployed, because the service names the task definition and is created
+after it.
+
+`Ref` on a service returns the service ARN, which is also what `Fn::GetAtt` `ServiceArn` returns,
+and `Fn::GetAtt` `Name` returns the service name. `simAws.ecs().service(name, cluster)` reads the
+simulated service itself, by name in a cluster or by its full ARN.
+
+```typescript sim-ecs-cloudformation-service
+/**
+ * Deploying an ECS service and reading what it is keeping running.
+ */
+
+import { ListTasksCommand } from "@aws-sdk/client-ecs";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "orders",
+  template: {
+    Resources: {
+      OrdersCluster: {
+        Type: "AWS::ECS::Cluster",
+        Properties: { ClusterName: "orders" },
+      },
+      WorkerTaskDefinition: {
+        Type: "AWS::ECS::TaskDefinition",
+        Properties: {
+          Family: "orders-worker",
+          ContainerDefinitions: [
+            {
+              Name: "app",
+              Image: "example.dkr.ecr.eu-west-2.amazonaws.com/orders-worker:1",
+            },
+          ],
+        },
+      },
+      WorkerService: {
+        Type: "AWS::ECS::Service",
+        Properties: {
+          ServiceName: "orders-worker",
+          Cluster: { Ref: "OrdersCluster" },
+          TaskDefinition: { Ref: "WorkerTaskDefinition" },
+          DesiredCount: 2,
+          LaunchType: "FARGATE",
+        },
+      },
+    },
+    Outputs: {
+      Service: { Value: { Ref: "WorkerService" } },
+      ServiceName: { Value: { "Fn::GetAtt": ["WorkerService", "Name"] } },
+    },
+  },
+  bindings: [
+    {
+      logicalId: "WorkerTaskDefinition",
+      run: (): void => {
+        // Whatever the worker container does when something reaches it.
+      },
+    },
+  ],
+});
+
+await stack.waitForDeployComplete();
+await simAws.backgroundTasksComplete();
+
+console.log(stack.outputs.get("Service")?.value);
+// "arn:aws:ecs:us-east-1:888888888888:service/orders/orders-worker"
+console.log(stack.outputs.get("ServiceName")?.value); // "orders-worker"
+
+const service = simAws.ecs().service("orders-worker", "orders");
+
+console.log(service.desiredCount); // 2
+
+const listed = await simAws
+  .ecs()
+  .listTasks(
+    new ListTasksCommand({ cluster: "orders", serviceName: "orders-worker" }),
+  );
+
+console.log(listed.taskArns?.length); // 2
+```
+
+A service the template does not name is named after the stack and the logical ID, as a cluster and a
+family are, and a service declaring no `DesiredCount` keeps one task running, which is what real
+CloudFormation gives a new service.
+
+Updating the stack moves the service: a changed `DesiredCount` scales it, and a changed task
+definition moves it onto the revision the update registered, replacing the tasks it was keeping.
+Tearing the stack down deletes the service, stopping its tasks and leaving it `INACTIVE`, whatever
+it was scaled to.
+
+`LoadBalancers` is recorded on the service rather than acted on, since nothing here sends a service
+container a request yet. What the template declared is readable, which is what a target group needs
+to find the service and container that answer for it:
+
+```typescript
+console.log(simAws.ecs().service("orders-worker", "orders").loadBalancers);
+```
+
+Everything else the three Resource types declare is stored as declared, or recorded as ignored where
 this simulation has nothing to act on it with. `CapacityProviders`,
-`DefaultCapacityProviderStrategy` and `ServiceConnectDefaults` on a cluster, and
-`InferenceAccelerators` and `EnableFaultInjection` on a task definition, are read and ignored rather
-than failing the stack, and each one is reported on the Resource:
+`DefaultCapacityProviderStrategy` and `ServiceConnectDefaults` on a cluster, `InferenceAccelerators`
+and `EnableFaultInjection` on a task definition, and a service's `NetworkConfiguration`,
+`CapacityProviderStrategy`, `DeploymentConfiguration` and `ServiceRegistries` among the rest, are
+read and ignored rather than failing the stack, and each one is reported on the Resource:
 
 ```typescript
 console.log(stack.resources.get("OrdersCluster")?.ignoredProperties);
@@ -1543,6 +1652,12 @@ console.log(described.taskDefinition?.revision); // 1
   the simulated clock while the service is running
 - `AWS::ECS::Cluster`, answering `Ref` with the cluster name and `Fn::GetAtt` with `Arn`
 - `AWS::ECS::TaskDefinition`, registering a revision and answering `Ref` with its ARN
+- `AWS::ECS::Service`, running the task definition it names at the desired count it declares, and
+  answering `Ref` with the service ARN and `Fn::GetAtt` with `Name` and `ServiceArn`
+- A stack update that scales a service or moves it onto a new revision, and a teardown that deletes
+  it
+- `LoadBalancers` on a service, recorded as declared and readable on the simulated service
+- `simAws.ecs().service()`, reading a simulated service by name in a cluster or by its ARN
 - Deploy-time container bindings, targeting a container by family and container name, by the task
   definition's logical ID or CDK construct ID, or by its image repository, and declaring `run` or
   `consumes` as a directly bound container does
@@ -1637,9 +1752,15 @@ Current documented limitations:
 - A service whose tasks fail to start does not start replacements for them. Real ECS keeps trying,
   which would be an endless retry in a test rather than a result to assert on, so the service
   reports the running count it actually has.
-- `CreateService` refuses `loadBalancers`, `serviceRegistries`, `networkConfiguration`,
-  `deploymentConfiguration`, `capacityProviderStrategy` and the rest of what it takes. There is no
-  network here, and nothing serves a service container yet.
+- `CreateService` takes `loadBalancers` and records them without acting on them, since nothing here
+  sends a service container a request yet. The declaration is reported back and readable on the
+  simulated service, which is what a load balancer target group has to read to find the service that
+  answers for it.
+- `CreateService` refuses `serviceRegistries`, `networkConfiguration`, `deploymentConfiguration`,
+  `capacityProviderStrategy` and the rest of what it takes. There is no network here, and nothing
+  serves a service container yet.
+- `UpdateService` changes the desired count and the task definition and nothing else, so a load
+  balancer a service was created with stays as it was declared.
 - `CreateService` refuses a `schedulingStrategy` of `DAEMON`, which places one task on each container
   instance. There are no container instances here to place one on each of.
 - `CreateService` needs a `desiredCount`, as a replica service does on real ECS, and it can be zero.
@@ -1678,25 +1799,33 @@ Current documented limitations:
   `DescribeServices` and `ListTasks` are what report those.
 - Task definition and cluster tags are stored and reported, but `TagResource`,
   `UntagResource` and `ListTagsForResource` are not simulated.
-- `AWS::ECS::Service` is not deployed yet. A template declaring one is reported as unsupported and
-  skipped rather than failing the stack.
-- A cluster or task definition the template does not name gets a name composed from the stack name
-  and the logical ID, without the random part real CloudFormation adds, so a test can predict it. A
-  stack deployed twice under different names therefore gets two different families.
+- A cluster, task definition or service the template does not name gets a name composed from the
+  stack name and the logical ID, without the random part real CloudFormation adds, so a test can
+  predict it. A stack deployed twice under different names therefore gets two different families.
+- A service that declares no `DesiredCount` keeps one task running, which is the default real
+  CloudFormation documents for a new service. A `DesiredCount` written as the text of a number is
+  taken as that number, since a String Parameter resolves to text, and anything else is refused.
 - An update replaces a task definition Resource rather than updating it in place, so it registers a
   new revision and deregisters the one it replaced. The family accumulates revisions with only the
   newest one `ACTIVE`, where real CloudFormation leaves the earlier revisions active.
-- A stack teardown deletes its cluster, leaving it `INACTIVE`, and deregisters the revision it
-  registered, leaving that `INACTIVE`. Neither is removed, and revision numbers are not freed.
+- An update replaces a service Resource as well, so a scaled or redeployed service is deleted and
+  created again rather than updated. Its tasks stop and new ones start, and its ARN is unchanged as
+  long as its name is, since a service ARN is its cluster and its name.
+- A stack teardown deletes its cluster, leaving it `INACTIVE`, deregisters the revision it
+  registered, leaving that `INACTIVE`, and deletes its service, leaving that `INACTIVE` too. None of
+  them is removed, and revision numbers are not freed. The service is deleted with force, because
+  real CloudFormation scales one to zero on its way out and nothing here needs the time that takes.
 - CloudFormation property names are translated to the API's by lowering the first letter of each of
   them, all the way down, apart from `EFSVolumeConfiguration`,
   `FSxWindowsFileServerVolumeConfiguration` and `ProxyConfigurationProperties`, which the API spells
   differently. `DockerLabels`, `Options`, `DriverOpts` and `Labels` hold keys the template wrote, so
   those are left alone. A name outside all of that is stored under the name lowering gives it.
 - `CapacityProviders`, `DefaultCapacityProviderStrategy` and `ServiceConnectDefaults` on a cluster,
-  and `InferenceAccelerators` and `EnableFaultInjection` on a task definition, are read and recorded
-  as ignored rather than refused, where the equivalent SDK request is refused. A stack that will not
-  deploy is worth less to a test than a Resource without a property nothing here acts on.
+  `InferenceAccelerators` and `EnableFaultInjection` on a task definition, and everything a service
+  declares beyond its cluster, task definition, count, launch type, scheduling strategy and load
+  balancers, are read and recorded as ignored rather than refused, where the equivalent SDK request
+  is refused. A stack that will not deploy is worth less to a test than a Resource without a
+  property nothing here acts on.
 - A deploy-time binding is checked against the template as the stack is built, so a family, a
   container name or an image repository built from another Resource's attribute rather than written
   as a string resolves to nothing and fails the deployment.

--- a/docs/services/ecs/sim-ecs-cloudformation-service.example.ts
+++ b/docs/services/ecs/sim-ecs-cloudformation-service.example.ts
@@ -1,0 +1,74 @@
+/**
+ * Deploying an ECS service and reading what it is keeping running.
+ */
+
+import { ListTasksCommand } from "@aws-sdk/client-ecs";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "orders",
+  template: {
+    Resources: {
+      OrdersCluster: {
+        Type: "AWS::ECS::Cluster",
+        Properties: { ClusterName: "orders" },
+      },
+      WorkerTaskDefinition: {
+        Type: "AWS::ECS::TaskDefinition",
+        Properties: {
+          Family: "orders-worker",
+          ContainerDefinitions: [
+            {
+              Name: "app",
+              Image: "example.dkr.ecr.eu-west-2.amazonaws.com/orders-worker:1",
+            },
+          ],
+        },
+      },
+      WorkerService: {
+        Type: "AWS::ECS::Service",
+        Properties: {
+          ServiceName: "orders-worker",
+          Cluster: { Ref: "OrdersCluster" },
+          TaskDefinition: { Ref: "WorkerTaskDefinition" },
+          DesiredCount: 2,
+          LaunchType: "FARGATE",
+        },
+      },
+    },
+    Outputs: {
+      Service: { Value: { Ref: "WorkerService" } },
+      ServiceName: { Value: { "Fn::GetAtt": ["WorkerService", "Name"] } },
+    },
+  },
+  bindings: [
+    {
+      logicalId: "WorkerTaskDefinition",
+      run: (): void => {
+        // Whatever the worker container does when something reaches it.
+      },
+    },
+  ],
+});
+
+await stack.waitForDeployComplete();
+await simAws.backgroundTasksComplete();
+
+console.log(stack.outputs.get("Service")?.value);
+// "arn:aws:ecs:us-east-1:888888888888:service/orders/orders-worker"
+console.log(stack.outputs.get("ServiceName")?.value); // "orders-worker"
+
+const service = simAws.ecs().service("orders-worker", "orders");
+
+console.log(service.desiredCount); // 2
+
+const listed = await simAws
+  .ecs()
+  .listTasks(
+    new ListTasksCommand({ cluster: "orders", serviceName: "orders-worker" }),
+  );
+
+console.log(listed.taskArns?.length); // 2

--- a/src/service/cloudformation/resource/cfn/ecs/sim-ecs-cfn-value-adapter.ts
+++ b/src/service/cloudformation/resource/cfn/ecs/sim-ecs-cfn-value-adapter.ts
@@ -1,10 +1,12 @@
 import { SimEcsCluster } from "../../../../ecs/cluster/sim-ecs-cluster.js";
+import { SimEcsService } from "../../../../ecs/service/sim-ecs-service.js";
 import { SimEcsTaskDefinition } from "../../../../ecs/task-definition/sim-ecs-task-definition.js";
 import type {
   SimCfnResourceValueAdapterProperties,
   SimCfnServiceValueAdapter,
 } from "../sim-cfn-resource-value-adapter.js";
 import { SimEcsClusterCfn } from "./sim-ecs-cluster-cfn.js";
+import { SimEcsServiceCfn } from "./sim-ecs-service-cfn.js";
 import { SimEcsTaskDefinitionCfn } from "./sim-ecs-task-definition-cfn.js";
 
 /**
@@ -27,6 +29,13 @@ export function ecsValueAdapter(
     return new SimEcsTaskDefinitionCfn({
       taskDefinition: properties.simResource,
     });
+  }
+
+  if (
+    properties.type === "AWS::ECS::Service" &&
+    properties.simResource instanceof SimEcsService
+  ) {
+    return new SimEcsServiceCfn({ service: properties.simResource });
   }
 
   return undefined;

--- a/src/service/cloudformation/resource/cfn/ecs/sim-ecs-service-cfn.ts
+++ b/src/service/cloudformation/resource/cfn/ecs/sim-ecs-service-cfn.ts
@@ -1,0 +1,47 @@
+import type { SimEcsService } from "../../../../ecs/service/sim-ecs-service.js";
+import type { SimCfnTemplateValue } from "../../../template/value/sim-cfn-template-value.js";
+import type { SimCfnResourceValueAdapter } from "../sim-cfn-resource-value-adapter.js";
+
+interface SimEcsServiceCfnProperties {
+  readonly service: SimEcsService;
+}
+
+/**
+ * CloudFormation-facing values for a simulated ECS service.
+ */
+export class SimEcsServiceCfn implements SimCfnResourceValueAdapter {
+  private readonly service: SimEcsService;
+
+  constructor(properties: SimEcsServiceCfnProperties) {
+    this.service = properties.service;
+  }
+
+  /**
+   * AWS::ECS::Service Ref returns the service ARN.
+   *
+   * The ARN carries the cluster the service belongs to, which is what makes it
+   * enough on its own: a service name means a different service in each
+   * cluster that holds one.
+   */
+  refValue(): SimCfnTemplateValue {
+    return this.service.serviceArn;
+  }
+
+  /**
+   * AWS::ECS::Service attributes.
+   *
+   * `Name` is the service name within its cluster, and `ServiceArn` answers
+   * with the same ARN Ref does.
+   */
+  attributeValue(attributeName: string): SimCfnTemplateValue {
+    if (attributeName === "Name") {
+      return this.service.serviceName;
+    }
+
+    if (attributeName === "ServiceArn") {
+      return this.service.serviceArn;
+    }
+
+    throw new Error(`Unsupported AWS::ECS::Service attribute ${attributeName}`);
+  }
+}

--- a/src/service/ecs/README.md
+++ b/src/service/ecs/README.md
@@ -303,11 +303,11 @@ command instances.
 
 ## CloudFormation
 
-`cfn/` holds what deploys `AWS::ECS::Cluster` and `AWS::ECS::TaskDefinition`, under the rule the
-CloudFormation engine works by: CloudFormation orchestrates and the service creates. Both go through
-the ordinary `CreateCluster` and `RegisterTaskDefinition` commands rather than constructing state
-directly, so a Resource a template deployed is the same thing an SDK caller would have got, refusals
-included.
+`cfn/` holds what deploys `AWS::ECS::Cluster`, `AWS::ECS::TaskDefinition` and `AWS::ECS::Service`,
+under the rule the CloudFormation engine works by: CloudFormation orchestrates and the service
+creates. All three go through the ordinary `CreateCluster`, `RegisterTaskDefinition` and
+`CreateService` commands rather than constructing state directly, so a Resource a template deployed
+is the same thing an SDK caller would have got, refusals included.
 
 `property/sim-cfn-ecs-api-shape.ts` is the piece with the most in it. CloudFormation writes an ECS
 declaration in the API's own shape with the first letter of every name upper cased, so translating
@@ -327,8 +327,16 @@ naming the task definition Resource is turned into the family the registration m
 ID means nothing to ECS. Only bindings that target this Resource are applied, so a stack declaring
 several task definitions does not bind one handler to all of them.
 
-The two Resource types' `Ref` and `Fn::GetAtt` answers live with the other services' value adapters,
-under `cloudformation/resource/cfn/ecs/`, as the CloudFormation engine's own design has them.
+`service/` deploys `AWS::ECS::Service`. A service is mostly the two things it names, and both arrive
+already resolved: a `Ref` to a cluster is its name and a `Ref` to a task definition is the ARN of the
+revision the deployment registered, which is why the service pins that revision rather than following
+the family. `LoadBalancers` is read and held on the service without being acted on, since nothing
+serves a service container a request yet, and the rest of what a real service declares is recorded as
+ignored rather than failing the stack.
+
+The three Resource types' `Ref` and `Fn::GetAtt` answers live with the other services' value
+adapters, under `cloudformation/resource/cfn/ecs/`, as the CloudFormation engine's own design has
+them.
 
 ## Divergences worth knowing
 

--- a/src/service/ecs/cfn/property/sim-cfn-ecs-property-reader.ts
+++ b/src/service/ecs/cfn/property/sim-cfn-ecs-property-reader.ts
@@ -54,7 +54,9 @@ export class SimCfnEcsPropertyReader {
    *
    * A template may write a count as a number or as the text of one, since a
    * String Parameter resolves to text whatever it holds, and CloudFormation
-   * takes either. Anything else is refused rather than counted as zero.
+   * takes either. Anything else is refused rather than counted as zero, a
+   * fraction included: what these properties count is tasks, and there is no
+   * half of one to keep running.
    */
   wholeNumber(name: string): number | undefined {
     const value = this.declared(name);
@@ -63,15 +65,13 @@ export class SimCfnEcsPropertyReader {
       return undefined;
     }
 
-    if (typeof value === "number") {
-      return value;
+    const declared = simCfnEcsWholeNumber(value);
+
+    if (declared === undefined) {
+      throw this.refuse(`${name} is a whole number`);
     }
 
-    if (typeof value === "string" && /^-?\d+$/u.test(value)) {
-      return Number(value);
-    }
-
-    throw this.refuse(`${name} is a whole number`);
+    return declared;
   }
 
   /**
@@ -152,4 +152,42 @@ export class SimCfnEcsPropertyReader {
     // oxlint-disable-next-line security/detect-object-injection -- fixed property names.
     return this.properties[name];
   }
+}
+
+/**
+ * A declared value read as a whole number, or nothing where it is not one.
+ *
+ * The text of a number counts, since a String Parameter resolves to text
+ * whatever it holds. A fraction does not, and neither does a whole number too
+ * large to be held exactly, which would count something other than what the
+ * template wrote.
+ */
+function simCfnEcsWholeNumber(value: SimCfnTemplateValue): number | undefined {
+  const declared = simCfnEcsDeclaredNumber(value);
+
+  if (declared === undefined || !Number.isSafeInteger(declared)) {
+    return undefined;
+  }
+
+  return declared;
+}
+
+/**
+ * A declared value read as a number, however the template wrote it.
+ *
+ * Text is read only where it is digits, so an empty string and a hexadecimal
+ * literal are not numbers here, whatever `Number` would make of them.
+ */
+function simCfnEcsDeclaredNumber(
+  value: SimCfnTemplateValue,
+): number | undefined {
+  if (typeof value === "number") {
+    return value;
+  }
+
+  if (typeof value === "string" && /^-?\d+$/u.test(value)) {
+    return Number(value);
+  }
+
+  return undefined;
 }

--- a/src/service/ecs/cfn/property/sim-cfn-ecs-property-reader.ts
+++ b/src/service/ecs/cfn/property/sim-cfn-ecs-property-reader.ts
@@ -50,6 +50,31 @@ export class SimCfnEcsPropertyReader {
   }
 
   /**
+   * A property that is a whole number, where the template declared one.
+   *
+   * A template may write a count as a number or as the text of one, since a
+   * String Parameter resolves to text whatever it holds, and CloudFormation
+   * takes either. Anything else is refused rather than counted as zero.
+   */
+  wholeNumber(name: string): number | undefined {
+    const value = this.declared(name);
+
+    if (value === undefined) {
+      return undefined;
+    }
+
+    if (typeof value === "number") {
+      return value;
+    }
+
+    if (typeof value === "string" && /^-?\d+$/u.test(value)) {
+      return Number(value);
+    }
+
+    throw this.refuse(`${name} is a whole number`);
+  }
+
+  /**
    * A property that is a list of strings, where the template declared one.
    */
   textList(name: string): readonly string[] | undefined {

--- a/src/service/ecs/cfn/service/sim-cfn-ecs-service-creator.ts
+++ b/src/service/ecs/cfn/service/sim-cfn-ecs-service-creator.ts
@@ -1,0 +1,77 @@
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimEcsService } from "../../service/sim-ecs-service.js";
+import type { SimEcs } from "../../sim-ecs.js";
+import { SimCfnEcsServiceProperties } from "./sim-cfn-ecs-service-properties.js";
+
+interface SimCfnEcsServiceCreatorProperties {
+  readonly ecs: SimEcs;
+}
+
+/**
+ * Creates simulated services from AWS::ECS::Service Resources.
+ *
+ * The service is created through the ordinary CreateService command rather
+ * than constructed directly, so a service a template deployed is the same
+ * thing an SDK caller would have got: the same cluster and revision lookups,
+ * the same refusal for a name the cluster already holds, and the same tasks
+ * started for the desired count.
+ *
+ * The handlers a deployment bound to the task definition's containers are
+ * already held by then, because the service names the task definition and is
+ * therefore created after it, so a bound container of the service is running
+ * once the stack has deployed.
+ */
+export class SimCfnEcsServiceCreator {
+  private readonly ecs: SimEcs;
+
+  constructor(properties: SimCfnEcsServiceCreatorProperties) {
+    this.ecs = properties.ecs;
+  }
+
+  /**
+   * Create a service from an AWS::ECS::Service Resource.
+   */
+  async create(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): Promise<SimEcsService> {
+    const serviceProperties = new SimCfnEcsServiceProperties({
+      resource,
+      properties,
+    });
+    const input = serviceProperties.createServiceInput();
+
+    serviceProperties.recordIgnoredProperties();
+
+    const created = await this.ecs.createService({ input });
+    const serviceArn = created.service?.serviceArn;
+
+    assertDefined(
+      serviceArn,
+      `sim ECS service ARN for CloudFormation Resource ${resource.logicalId}`,
+    );
+
+    return this.ecs.service(serviceArn);
+  }
+
+  /**
+   * Delete a service created from an AWS::ECS::Service Resource.
+   *
+   * The deletion is forced, since a service is deleted here while it is still
+   * keeping its tasks running. Real CloudFormation scales the service to zero
+   * on its way out rather than deleting a running one, and the two come to the
+   * same thing: the tasks stop, and the service is left `INACTIVE` rather than
+   * removed, so something holding its ARN can still find out what became of it.
+   */
+  async delete(service: SimEcsService): Promise<void> {
+    await this.ecs.deleteService({
+      input: {
+        cluster: service.clusterName,
+        service: service.serviceName,
+        force: true,
+      },
+    });
+  }
+}

--- a/src/service/ecs/cfn/service/sim-cfn-ecs-service-name.ts
+++ b/src/service/ecs/cfn/service/sim-cfn-ecs-service-name.ts
@@ -1,0 +1,39 @@
+import { SimCfnGeneratedResourceName } from "../../../cloudformation/resource/name/sim-cfn-generated-resource-name.js";
+
+/**
+ * How long an ECS service name may be.
+ */
+const maximumNameLength = 255;
+
+interface SimCfnEcsServiceNameProperties {
+  readonly stackName: string | undefined;
+  readonly logicalId: string;
+}
+
+/**
+ * The name CloudFormation gives a service whose template does not name it.
+ *
+ * Real CloudFormation composes it from the stack name, the logical ID and a
+ * random part, which is why a template leaving `ServiceName` out is a template
+ * whose service nothing can predict. The random part is left out here so a
+ * test can name the service it got, the same way a generated cluster name and
+ * task definition family are composed.
+ */
+export class SimCfnEcsServiceName {
+  private readonly generated: SimCfnGeneratedResourceName;
+
+  constructor(properties: SimCfnEcsServiceNameProperties) {
+    this.generated = new SimCfnGeneratedResourceName({
+      stackName: properties.stackName,
+      logicalId: properties.logicalId,
+      maximumLength: maximumNameLength,
+    });
+  }
+
+  /**
+   * The generated service name.
+   */
+  get value(): string {
+    return this.generated.value;
+  }
+}

--- a/src/service/ecs/cfn/service/sim-cfn-ecs-service-properties.ts
+++ b/src/service/ecs/cfn/service/sim-cfn-ecs-service-properties.ts
@@ -1,0 +1,94 @@
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimCreateServiceCommandInput } from "../../command/create-service/create-service.command.js";
+import type { SimEcsServiceLoadBalancer } from "../../service/sim-ecs-service-detail.js";
+import { SimCfnEcsPropertyReader } from "../property/sim-cfn-ecs-property-reader.js";
+import { SimCfnEcsServiceName } from "./sim-cfn-ecs-service-name.js";
+import { SimCfnEcsServicePropertyRules } from "./sim-cfn-ecs-service-property-rules.js";
+
+/**
+ * How many tasks a service that declares no count keeps running.
+ *
+ * Real CloudFormation documents one task for a new service that leaves
+ * `DesiredCount` out, so a template that leaves it out gets a service that is
+ * running rather than one scaled to nothing.
+ */
+const defaultDesiredCount = 1;
+
+interface SimCfnEcsServicePropertiesProperties {
+  readonly resource: SimCfnResource;
+  readonly properties: SimCfnTemplateValueRecord;
+}
+
+/**
+ * Reads AWS::ECS::Service CloudFormation properties into CreateService input.
+ *
+ * Both of the things a service is made of arrive as strings that have already
+ * been resolved: `Cluster` is a `Ref` to a cluster, which is its name, or an
+ * ARN, and `TaskDefinition` is a `Ref` to a task definition, which is the ARN
+ * of the revision the stack registered, or an ARN, or a family. Simulated ECS
+ * takes each of those forms already, so both are passed on as they resolved
+ * rather than being taken apart here.
+ */
+export class SimCfnEcsServiceProperties {
+  private readonly resource: SimCfnResource;
+  private readonly reader: SimCfnEcsPropertyReader;
+  private readonly rules: SimCfnEcsServicePropertyRules;
+
+  constructor(properties: SimCfnEcsServicePropertiesProperties) {
+    this.resource = properties.resource;
+    this.reader = new SimCfnEcsPropertyReader(properties);
+    this.rules = new SimCfnEcsServicePropertyRules({
+      properties: properties.properties,
+      ignorer: properties.resource,
+    });
+  }
+
+  /**
+   * The CreateService input this Resource declares.
+   */
+  createServiceInput(): SimCreateServiceCommandInput {
+    const reader = this.reader;
+
+    return {
+      cluster: reader.text("Cluster"),
+      serviceName: this.serviceName(),
+      taskDefinition: reader.text("TaskDefinition"),
+      desiredCount: this.desiredCount(),
+      launchType: reader.text("LaunchType"),
+      schedulingStrategy: reader.text("SchedulingStrategy"),
+      loadBalancers: reader.apiList<SimEcsServiceLoadBalancer>("LoadBalancers"),
+    };
+  }
+
+  /**
+   * The service name.
+   *
+   * An unnamed service is named after the stack and the logical ID, as real
+   * CloudFormation names one, so a test can find the service the stack it
+   * deployed created.
+   */
+  serviceName(): string {
+    return (
+      this.reader.text("ServiceName") ??
+      new SimCfnEcsServiceName({
+        stackName: this.resource.stackName,
+        logicalId: this.resource.logicalId,
+      }).value
+    );
+  }
+
+  /**
+   * How many tasks the service keeps running.
+   */
+  desiredCount(): number {
+    return this.reader.wholeNumber("DesiredCount") ?? defaultDesiredCount;
+  }
+
+  /**
+   * Record the properties the service is created without acting on.
+   */
+  recordIgnoredProperties(): void {
+    this.rules.apply();
+  }
+}

--- a/src/service/ecs/cfn/service/sim-cfn-ecs-service-property-rules.ts
+++ b/src/service/ecs/cfn/service/sim-cfn-ecs-service-property-rules.ts
@@ -1,0 +1,71 @@
+import type { SimCfnPropertyIgnorer } from "../../../cloudformation/resource/ignore/sim-cfn-ignored-property.type.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import { simCfnEcsServiceUnsimulatedReasons } from "./sim-cfn-ecs-service-unsimulated-properties.js";
+
+/**
+ * The properties a service is created with.
+ *
+ * `LoadBalancers` is here because the declaration is held on the service, not
+ * because anything routes to it yet: a target group has to be able to read
+ * which service and container answer for it before it can send one a request.
+ */
+const actedOnProperties: ReadonlySet<string> = new Set([
+  "Cluster",
+  "ServiceName",
+  "TaskDefinition",
+  "DesiredCount",
+  "LaunchType",
+  "SchedulingStrategy",
+  "LoadBalancers",
+]);
+
+interface SimCfnEcsServicePropertyRulesProperties {
+  readonly properties: SimCfnTemplateValueRecord;
+  readonly ignorer: SimCfnPropertyIgnorer;
+}
+
+/**
+ * What a service Resource is created without acting on.
+ */
+export class SimCfnEcsServicePropertyRules {
+  private readonly properties: SimCfnTemplateValueRecord;
+  private readonly ignorer: SimCfnPropertyIgnorer;
+
+  constructor(properties: SimCfnEcsServicePropertyRulesProperties) {
+    this.properties = properties.properties;
+    this.ignorer = properties.ignorer;
+  }
+
+  /**
+   * Record every property the service is created without.
+   */
+  apply(): void {
+    for (const name of Object.keys(this.properties)) {
+      this.applyToProperty(name);
+    }
+  }
+
+  private applyToProperty(name: string): void {
+    if (actedOnProperties.has(name)) {
+      return;
+    }
+
+    const unsimulatedReason = simCfnEcsServiceUnsimulatedReasons.get(name);
+
+    if (unsimulatedReason === undefined) {
+      this.ignorer.ignoreProperty(
+        name,
+        `${name} is not a property simulated ECS knows about, so the service ` +
+          `is created without it`,
+      );
+
+      return;
+    }
+
+    this.ignorer.ignoreProperty(
+      name,
+      `${name} is a real AWS::ECS::Service property simulated ECS does not ` +
+        `act on: ${unsimulatedReason}`,
+    );
+  }
+}

--- a/src/service/ecs/cfn/service/sim-cfn-ecs-service-unsimulated-properties.ts
+++ b/src/service/ecs/cfn/service/sim-cfn-ecs-service-unsimulated-properties.ts
@@ -1,0 +1,90 @@
+/**
+ * The real AWS::ECS::Service properties this simulation has nothing to act on,
+ * and why.
+ *
+ * `CreateService` refuses all of them, because a setting it does not hold would
+ * go missing from the service it made. A template carrying one is deployed
+ * without it all the same: a stack that will not deploy is worth less to a test
+ * than a service running the task definition the stack declared.
+ *
+ * They are a list on their own because they are a list and nothing else. What
+ * reads them is next door, and a property added here changes what a deployment
+ * reports without changing anything that runs.
+ */
+export const simCfnEcsServiceUnsimulatedReasons: ReadonlyMap<string, string> =
+  new Map([
+    [
+      "NetworkConfiguration",
+      "there is no network here, so a subnet, a security group and a public " +
+        "IP reach nothing",
+    ],
+    [
+      "CapacityProviderStrategy",
+      "a simulated task runs in this process rather than on capacity, so " +
+        "there is nothing for a capacity provider to place it on",
+    ],
+    [
+      "DeploymentConfiguration",
+      "a service's tasks come up all at once and are replaced all at once, so " +
+        "there is no rollout for a percentage or a circuit breaker to govern",
+    ],
+    [
+      "DeploymentController",
+      "there are no deployments here to be controlled by ECS, CodeDeploy or " +
+        "an external controller",
+    ],
+    [
+      "ServiceRegistries",
+      "service discovery is not simulated, so nothing resolves a service by " +
+        "name",
+    ],
+    [
+      "ServiceConnectConfiguration",
+      "service discovery is not simulated, so nothing resolves a service by " +
+        "name",
+    ],
+    [
+      "PlatformVersion",
+      "there is no Fargate platform here to run one version of",
+    ],
+    [
+      "HealthCheckGracePeriodSeconds",
+      "nothing checks the health of a simulated task, so there is no grace " +
+        "period to hold one through",
+    ],
+    [
+      "PlacementConstraints",
+      "there are no container instances here for a task to be placed on",
+    ],
+    [
+      "PlacementStrategies",
+      "there are no container instances here to spread or pack tasks across",
+    ],
+    [
+      "AvailabilityZoneRebalancing",
+      "there are no Availability Zones here for tasks to be moved between",
+    ],
+    [
+      "Role",
+      "the service role is what registers tasks with a classic load balancer, " +
+        "and nothing here registers anything",
+    ],
+    [
+      "EnableExecuteCommand",
+      "there is no container process here to open a session into",
+    ],
+    [
+      "EnableECSManagedTags",
+      "a simulated service holds no tags for ECS to manage",
+    ],
+    ["PropagateTags", "a simulated service and its tasks hold no tags"],
+    ["Tags", "a simulated service holds no tags"],
+    [
+      "VolumeConfigurations",
+      "there is no volume to attach, since a container is an in-process handler",
+    ],
+    [
+      "VpcLatticeConfigurations",
+      "there is no VPC here for a Lattice target group to reach a task through",
+    ],
+  ]);

--- a/src/service/ecs/cfn/sim-cfn-ecs-properties.iso.test.ts
+++ b/src/service/ecs/cfn/sim-cfn-ecs-properties.iso.test.ts
@@ -291,8 +291,8 @@ describe("ECS CloudFormation property reading", () => {
     );
   });
 
-  it("skips an ECS Resource type nothing creates yet", async () => {
-    // Given a template declaring a service, which follows separately.
+  it("skips an ECS Resource type nothing creates", async () => {
+    // Given a template declaring capacity, which there is none of here.
     const simAws = new SimAws();
 
     // When it is deployed.
@@ -300,9 +300,9 @@ describe("ECS CloudFormation property reading", () => {
       stackName: "orders-stack",
       template: {
         Resources: {
-          OrdersService: {
-            Type: "AWS::ECS::Service",
-            Properties: { ServiceName: "orders" },
+          OrdersCapacity: {
+            Type: "AWS::ECS::CapacityProvider",
+            Properties: { Name: "orders" },
           },
         },
       },
@@ -314,14 +314,14 @@ describe("ECS CloudFormation property reading", () => {
     // teardown steps over it.
     assertArrayLength(stack.skippedResources, 1);
     assertStringIncludes(
-      stack.resources.get("OrdersService")?.skippedReason ?? "",
-      "Unsupported sim ECS CloudFormation Resource Service",
+      stack.resources.get("OrdersCapacity")?.skippedReason ?? "",
+      "Unsupported sim ECS CloudFormation Resource CapacityProvider",
     );
 
     await stack.teardown();
 
     assertIdentical(
-      stack.resources.get("OrdersService")?.status,
+      stack.resources.get("OrdersCapacity")?.status,
       "DELETE_COMPLETE",
     );
   });
@@ -331,8 +331,8 @@ describe("ECS CloudFormation property reading", () => {
     // would have skipped rather than created.
     const simAws = new SimAws();
     const resource = new SimCfnResource({
-      logicalId: "OrdersService",
-      template: { Type: "AWS::ECS::Service" },
+      logicalId: "OrdersCapacity",
+      template: { Type: "AWS::ECS::CapacityProvider" },
     });
 
     // When its deletion is asked for directly, then it is refused, which is
@@ -341,12 +341,12 @@ describe("ECS CloudFormation property reading", () => {
       await simAws
         .ecs()
         .cfnResourceFactory()
-        .delete("Service", resource, { simAws, resources: new Map() });
+        .delete("CapacityProvider", resource, { simAws, resources: new Map() });
     });
 
     assertStringIncludes(
       error.message,
-      "Unsupported sim ECS CloudFormation Resource Service deletion",
+      "Unsupported sim ECS CloudFormation Resource CapacityProvider deletion",
     );
   });
 

--- a/src/service/ecs/cfn/sim-cfn-ecs-service-properties.iso.test.ts
+++ b/src/service/ecs/cfn/sim-cfn-ecs-service-properties.iso.test.ts
@@ -218,6 +218,27 @@ describe("AWS::ECS::Service properties", () => {
     await simAws.backgroundTasksComplete();
   });
 
+  it("refuses a fraction of a task", async () => {
+    // Given a template asking for half a task more than it can have.
+    const simAws = new SimAws();
+
+    // When it is deployed, then the deployment fails naming the property,
+    // rather than rounding to a count nothing asked for.
+    const error = await assertThrowsErrorAsync(async () => {
+      return await simAws.cloudFormation().deployTemplate({
+        stackName: "orders-stack",
+        template: serviceTemplate({
+          ServiceName: "orders-worker",
+          DesiredCount: 1.5,
+        }),
+      });
+    });
+
+    assertStringIncludes(error.message, "DesiredCount is a whole number");
+
+    await simAws.backgroundTasksComplete();
+  });
+
   it("refuses an attribute a service does not have", async () => {
     // Given a template reading an attribute AWS::ECS::Service has no answer
     // for.

--- a/src/service/ecs/cfn/sim-cfn-ecs-service-properties.iso.test.ts
+++ b/src/service/ecs/cfn/sim-cfn-ecs-service-properties.iso.test.ts
@@ -1,0 +1,246 @@
+import { DescribeServicesCommand } from "@aws-sdk/client-ecs";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertTrue,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import type { CfnTemplateBodyRecord } from "../../cloudformation/template/sim-cfn-template.js";
+import type {
+  SimCfnTemplateValue,
+  SimCfnTemplateValueRecord,
+} from "../../cloudformation/template/value/sim-cfn-template-value.js";
+
+const imageUri = "example.dkr.ecr.eu-west-2.amazonaws.com/orders-worker:1";
+
+const targetGroupArn =
+  "arn:aws:elasticloadbalancing:us-east-1:888888888888:targetgroup/orders/73e2d6bc";
+
+/**
+ * The cluster and task definition a service needs before it is anything.
+ */
+const workerResources: Record<string, SimCfnTemplateValue> = {
+  OrdersCluster: {
+    Type: "AWS::ECS::Cluster",
+    Properties: { ClusterName: "orders" },
+  },
+  WorkerTaskDefinition: {
+    Type: "AWS::ECS::TaskDefinition",
+    Properties: {
+      Family: "orders-worker",
+      ContainerDefinitions: [{ Name: "app", Image: imageUri }],
+    },
+  },
+};
+
+/**
+ * A stack whose service declares whatever the test is about.
+ */
+function serviceTemplate(
+  properties: SimCfnTemplateValueRecord,
+): CfnTemplateBodyRecord {
+  return {
+    Resources: {
+      ...workerResources,
+      WorkerService: {
+        Type: "AWS::ECS::Service",
+        Properties: {
+          Cluster: { Ref: "OrdersCluster" },
+          TaskDefinition: { Ref: "WorkerTaskDefinition" },
+          ...properties,
+        },
+      },
+    },
+  };
+}
+
+describe("AWS::ECS::Service properties", () => {
+  it("names an unnamed service after the stack and logical ID", async () => {
+    // Given a template declaring a service without a name or a desired count,
+    // which real CloudFormation fills both of in.
+    const simAws = new SimAws();
+
+    // When it is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: serviceTemplate({}),
+    });
+
+    await stack.waitForDeployComplete();
+    await simAws.backgroundTasksComplete();
+
+    // Then the service is named from the stack and the logical ID, without the
+    // random part real CloudFormation adds, and it keeps the one task real
+    // CloudFormation gives a new service that declares no count.
+    const service = simAws
+      .ecs()
+      .service("orders-stack-WorkerService", "orders");
+
+    assertTrue(service.isActive());
+    assertIdentical(service.desiredCount, 1);
+  });
+
+  it("takes a desired count written as text", async () => {
+    // Given a template whose DesiredCount is the text of a number, which is
+    // what a String Parameter resolves to.
+    const simAws = new SimAws();
+
+    // When it is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: serviceTemplate({
+        ServiceName: "orders-worker",
+        DesiredCount: "3",
+      }),
+    });
+
+    await stack.waitForDeployComplete();
+    await simAws.backgroundTasksComplete();
+
+    // Then the service keeps that many tasks running.
+    assertIdentical(
+      simAws.ecs().service("orders-worker", "orders").desiredCount,
+      3,
+    );
+  });
+
+  it("records the load balancers a service declares", async () => {
+    // Given a template whose service declares a load balancer target group,
+    // which nothing here routes to yet.
+    const simAws = new SimAws();
+
+    // When it is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: serviceTemplate({
+        ServiceName: "orders-worker",
+        DesiredCount: 1,
+        LoadBalancers: [
+          {
+            TargetGroupArn: targetGroupArn,
+            ContainerName: "app",
+            ContainerPort: 8080,
+          },
+        ],
+      }),
+    });
+
+    await stack.waitForDeployComplete();
+    await simAws.backgroundTasksComplete();
+
+    // Then the declaration is readable on the simulated service, so a target
+    // group can find the service and the container that answer for it.
+    const service = simAws.ecs().service("orders-worker", "orders");
+
+    assertArrayLength(service.loadBalancers, 1);
+    assertIdentical(service.loadBalancers[0].targetGroupArn, targetGroupArn);
+    assertIdentical(service.loadBalancers[0].containerName, "app");
+    assertIdentical(service.loadBalancers[0].containerPort, 8080);
+
+    // And DescribeServices reports it in the spelling the SDK uses.
+    const described = await simAws.ecs().describeServices(
+      new DescribeServicesCommand({
+        cluster: "orders",
+        services: ["orders-worker"],
+      }),
+    );
+
+    assertIdentical(
+      described.services?.[0]?.loadBalancers?.[0]?.targetGroupArn,
+      targetGroupArn,
+    );
+  });
+
+  it("deploys a service declaring a network, without one", async () => {
+    // Given a template declaring the network and the rollout a service has,
+    // which there is neither of here, and a property ECS has never had.
+    const simAws = new SimAws();
+
+    // When it is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: serviceTemplate({
+        ServiceName: "orders-worker",
+        DesiredCount: 1,
+        NetworkConfiguration: {
+          AwsvpcConfiguration: { Subnets: ["subnet-0e1f2a3b"] },
+        },
+        DeploymentConfiguration: { MinimumHealthyPercent: 100 },
+        Speed: "quick",
+      }),
+    });
+
+    await stack.waitForDeployComplete();
+    await simAws.backgroundTasksComplete();
+
+    // Then the service is created without them, and each is recorded so a
+    // reader can see what the deployed service is not doing.
+    assertTrue(simAws.ecs().service("orders-worker", "orders").isActive());
+
+    const ignored = stack.resources.get("WorkerService")?.ignoredProperties;
+
+    assertNonNullable(ignored);
+    assertArrayLength(ignored, 3);
+
+    const reasons = ignored.map((property) => property.reason).join(" ");
+
+    assertStringIncludes(reasons, "there is no network here");
+    assertStringIncludes(
+      reasons,
+      "Speed is not a property simulated ECS knows about",
+    );
+  });
+
+  it("refuses a desired count that is not a whole number", async () => {
+    // Given a template whose DesiredCount is text that counts nothing.
+    const simAws = new SimAws();
+
+    // When it is deployed, then the deployment fails, naming the Resource and
+    // the property.
+    const error = await assertThrowsErrorAsync(async () => {
+      return await simAws.cloudFormation().deployTemplate({
+        stackName: "orders-stack",
+        template: serviceTemplate({
+          ServiceName: "orders-worker",
+          DesiredCount: "as many as it takes",
+        }),
+      });
+    });
+
+    assertStringIncludes(error.message, "WorkerService");
+    assertStringIncludes(error.message, "DesiredCount is a whole number");
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("refuses an attribute a service does not have", async () => {
+    // Given a template reading an attribute AWS::ECS::Service has no answer
+    // for.
+    const simAws = new SimAws();
+
+    // When it is deployed, then the deployment fails naming the attribute.
+    const error = await assertThrowsErrorAsync(async () => {
+      return await simAws.cloudFormation().deployTemplate({
+        stackName: "orders-stack",
+        template: {
+          ...serviceTemplate({ ServiceName: "orders-worker" }),
+          Outputs: {
+            Nonsense: { Value: { "Fn::GetAtt": ["WorkerService", "Tasks"] } },
+          },
+        },
+      });
+    });
+
+    assertStringIncludes(
+      error.message,
+      "Unsupported AWS::ECS::Service attribute Tasks",
+    );
+
+    await simAws.backgroundTasksComplete();
+  });
+});

--- a/src/service/ecs/cfn/sim-cfn-ecs-service-update.iso.test.ts
+++ b/src/service/ecs/cfn/sim-cfn-ecs-service-update.iso.test.ts
@@ -1,0 +1,151 @@
+import { UpdateStackCommand } from "@aws-sdk/client-cloudformation";
+import { ListTasksCommand } from "@aws-sdk/client-ecs";
+import {
+  assertArrayLength,
+  assertFalse,
+  assertIdentical,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { jsonStringify } from "../../../util/type-guard/json.js";
+import { SimAws } from "../../aws/sim-aws.js";
+import type { CfnTemplateBodyRecord } from "../../cloudformation/template/sim-cfn-template.js";
+
+const imageUri = "example.dkr.ecr.eu-west-2.amazonaws.com/orders-worker";
+
+/**
+ * The stack a test updates, with the two things an update changes left open.
+ */
+function ordersTemplate(properties: {
+  readonly desiredCount: number;
+  readonly imageTag: string;
+}): CfnTemplateBodyRecord {
+  return {
+    Resources: {
+      OrdersCluster: {
+        Type: "AWS::ECS::Cluster",
+        Properties: { ClusterName: "orders" },
+      },
+      WorkerTaskDefinition: {
+        Type: "AWS::ECS::TaskDefinition",
+        Properties: {
+          Family: "orders-worker",
+          ContainerDefinitions: [
+            { Name: "app", Image: `${imageUri}:${properties.imageTag}` },
+          ],
+        },
+      },
+      WorkerService: {
+        Type: "AWS::ECS::Service",
+        Properties: {
+          ServiceName: "orders-worker",
+          Cluster: { Ref: "OrdersCluster" },
+          TaskDefinition: { Ref: "WorkerTaskDefinition" },
+          DesiredCount: properties.desiredCount,
+        },
+      },
+    },
+  };
+}
+
+/**
+ * Deploy the stack every test here starts from, keeping one task running.
+ */
+async function deployedOrdersStack(simAws: SimAws): Promise<void> {
+  const stack = await simAws.cloudFormation().deployTemplate({
+    stackName: "orders-stack",
+    template: ordersTemplate({ desiredCount: 1, imageTag: "1" }),
+  });
+
+  await stack.waitForDeployComplete();
+  await simAws.backgroundTasksComplete();
+}
+
+/**
+ * Apply a changed template to the stack, as an SDK caller updates one.
+ */
+async function updateOrdersStack(
+  simAws: SimAws,
+  template: CfnTemplateBodyRecord,
+): Promise<void> {
+  const cloudFormation = simAws.cloudFormation();
+
+  await cloudFormation.updateStack(
+    new UpdateStackCommand({
+      StackName: "orders-stack",
+      TemplateBody: jsonStringify(template),
+    }),
+  );
+  await cloudFormation.waitForStackUpdateComplete("orders-stack");
+  await simAws.backgroundTasksComplete();
+}
+
+describe("An AWS::ECS::Service a stack update changes", () => {
+  it("keeps the number of tasks the new template asks for", async () => {
+    // Given a deployed service keeping one task running.
+    const simAws = new SimAws();
+    await deployedOrdersStack(simAws);
+
+    // When the stack is updated with a higher desired count.
+    await updateOrdersStack(
+      simAws,
+      ordersTemplate({ desiredCount: 3, imageTag: "1" }),
+    );
+
+    // Then the simulated service is keeping that many tasks running.
+    const service = simAws.ecs().service("orders-worker", "orders");
+
+    assertIdentical(service.desiredCount, 3);
+
+    const listed = await simAws.ecs().listTasks(
+      new ListTasksCommand({
+        cluster: "orders",
+        serviceName: "orders-worker",
+      }),
+    );
+
+    assertArrayLength(listed.taskArns, 3);
+  });
+
+  it("moves onto the revision the new template registers", async () => {
+    // Given a deployed service running revision one of its family.
+    const simAws = new SimAws();
+    await deployedOrdersStack(simAws);
+
+    assertIdentical(
+      simAws.ecs().service("orders-worker", "orders").taskDefinitionArn,
+      simAws.ecs().taskDefinition("orders-worker:1").taskDefinitionArn,
+    );
+
+    // When the stack is updated with a changed container image, which
+    // registers a new revision.
+    await updateOrdersStack(
+      simAws,
+      ordersTemplate({ desiredCount: 1, imageTag: "2" }),
+    );
+
+    // Then the service runs the revision the update registered, and the tasks
+    // it is keeping are running that one.
+    const service = simAws.ecs().service("orders-worker", "orders");
+    const secondRevision = simAws
+      .ecs()
+      .taskDefinition("orders-worker").taskDefinitionArn;
+
+    assertIdentical(simAws.ecs().taskDefinition("orders-worker").revision, 2);
+    assertIdentical(service.taskDefinitionArn, secondRevision);
+
+    const listed = await simAws.ecs().listTasks(
+      new ListTasksCommand({
+        cluster: "orders",
+        serviceName: "orders-worker",
+        family: "orders-worker",
+      }),
+    );
+
+    assertArrayLength(listed.taskArns, 1);
+    assertIdentical(service.desiredCount, 1);
+
+    // And the revision it was running is the one the update deregistered.
+    assertFalse(simAws.ecs().taskDefinition("orders-worker:1").isActive());
+  });
+});

--- a/src/service/ecs/cfn/sim-cfn-ecs-service.iso.test.ts
+++ b/src/service/ecs/cfn/sim-cfn-ecs-service.iso.test.ts
@@ -1,0 +1,219 @@
+import {
+  DescribeServicesCommand,
+  DescribeTasksCommand,
+  ListTasksCommand,
+} from "@aws-sdk/client-ecs";
+import {
+  assertArrayLength,
+  assertFalse,
+  assertIdentical,
+  assertTrue,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import type { CfnTemplateBodyRecord } from "../../cloudformation/template/sim-cfn-template.js";
+import type { SimCfnTemplateValue } from "../../cloudformation/template/value/sim-cfn-template-value.js";
+
+const imageUri = "example.dkr.ecr.eu-west-2.amazonaws.com/orders-worker:1";
+
+/**
+ * The cluster and task definition a service needs before it is anything.
+ */
+const workerResources: Record<string, SimCfnTemplateValue> = {
+  OrdersCluster: {
+    Type: "AWS::ECS::Cluster",
+    Properties: { ClusterName: "orders" },
+  },
+  WorkerTaskDefinition: {
+    Type: "AWS::ECS::TaskDefinition",
+    Properties: {
+      Family: "orders-worker",
+      ContainerDefinitions: [{ Name: "app", Image: imageUri }],
+    },
+  },
+};
+
+const serviceTemplate: CfnTemplateBodyRecord = {
+  Resources: {
+    ...workerResources,
+    WorkerService: {
+      Type: "AWS::ECS::Service",
+      Properties: {
+        ServiceName: "orders-worker",
+        Cluster: { Ref: "OrdersCluster" },
+        TaskDefinition: { Ref: "WorkerTaskDefinition" },
+        DesiredCount: 2,
+        LaunchType: "FARGATE",
+      },
+    },
+  },
+  Outputs: {
+    ServiceRef: { Value: { Ref: "WorkerService" } },
+    ServiceName: { Value: { "Fn::GetAtt": ["WorkerService", "Name"] } },
+    ServiceArn: { Value: { "Fn::GetAtt": ["WorkerService", "ServiceArn"] } },
+  },
+};
+
+describe("AWS::ECS::Service", () => {
+  it("creates a simulated service the template declares", async () => {
+    // Given a template declaring a cluster, a task definition and a service of
+    // two tasks.
+    const simAws = new SimAws();
+
+    // When it is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: serviceTemplate,
+    });
+
+    await stack.waitForDeployComplete();
+    await simAws.backgroundTasksComplete();
+
+    // Then the cluster holds the service, running the revision the stack
+    // registered, and the Resource answers Ref and Fn::GetAtt ServiceArn with
+    // the service ARN and Fn::GetAtt Name with the service name.
+    const service = simAws.ecs().service("orders-worker", "orders");
+
+    assertTrue(service.isActive());
+    assertIdentical(service.desiredCount, 2);
+    assertIdentical(
+      service.taskDefinitionArn,
+      simAws.ecs().taskDefinition("orders-worker").taskDefinitionArn,
+    );
+    assertIdentical(stack.outputs.get("ServiceRef")?.value, service.serviceArn);
+    assertIdentical(stack.outputs.get("ServiceArn")?.value, service.serviceArn);
+    assertIdentical(stack.outputs.get("ServiceName")?.value, "orders-worker");
+
+    // And it is keeping the number of tasks it declared running.
+    const listed = await simAws.ecs().listTasks(
+      new ListTasksCommand({
+        cluster: "orders",
+        serviceName: "orders-worker",
+      }),
+    );
+
+    assertArrayLength(listed.taskArns, 2);
+  });
+
+  it("runs a task definition the template names by ARN", async () => {
+    // Given a revision registered by another stack, named by its ARN rather
+    // than by a Ref to a Resource of the same stack.
+    const simAws = new SimAws();
+    const registered = await simAws.cloudFormation().deployTemplate({
+      stackName: "worker-stack",
+      template: { Resources: workerResources },
+    });
+
+    await registered.waitForDeployComplete();
+
+    const taskDefinitionArn = simAws
+      .ecs()
+      .taskDefinition("orders-worker").taskDefinitionArn;
+
+    // When a service naming that ARN is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: {
+        Resources: {
+          WorkerService: {
+            Type: "AWS::ECS::Service",
+            Properties: {
+              ServiceName: "orders-worker",
+              Cluster: "orders",
+              TaskDefinition: taskDefinitionArn,
+              DesiredCount: 1,
+            },
+          },
+        },
+      },
+    });
+
+    await stack.waitForDeployComplete();
+    await simAws.backgroundTasksComplete();
+
+    // Then the service runs that revision.
+    assertIdentical(
+      simAws.ecs().service("orders-worker", "orders").taskDefinitionArn,
+      taskDefinitionArn,
+    );
+  });
+
+  it("runs the container a deploy-time binding names", async () => {
+    // Given a template whose service runs a task definition with one
+    // container.
+    const simAws = new SimAws();
+
+    // When it is deployed with a binding for that container.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: serviceTemplate,
+      bindings: [
+        {
+          logicalId: "WorkerTaskDefinition",
+          run: (): void => {
+            // A service container is available to be called rather than run
+            // once, so nothing calls this until something reaches it.
+          },
+        },
+      ],
+    });
+
+    await stack.waitForDeployComplete();
+    await simAws.backgroundTasksComplete();
+
+    // Then the bound container of each of the service's tasks is running.
+    const described = await simAws.ecs().describeServices(
+      new DescribeServicesCommand({
+        cluster: "orders",
+        services: ["orders-worker"],
+      }),
+    );
+
+    assertIdentical(described.services?.[0]?.runningCount, 2);
+
+    const listed = await simAws.ecs().listTasks(
+      new ListTasksCommand({
+        cluster: "orders",
+        serviceName: "orders-worker",
+      }),
+    );
+    const describedTasks = await simAws.ecs().describeTasks(
+      new DescribeTasksCommand({
+        cluster: "orders",
+        tasks: [...(listed.taskArns ?? [])],
+      }),
+    );
+
+    assertArrayLength(describedTasks.tasks, 2);
+    assertIdentical(
+      describedTasks.tasks[0].containers?.[0]?.lastStatus,
+      "RUNNING",
+    );
+  });
+
+  it("deletes the service when the stack is torn down", async () => {
+    // Given a deployed service keeping two tasks running.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: serviceTemplate,
+    });
+
+    await stack.waitForDeployComplete();
+    await simAws.backgroundTasksComplete();
+
+    // When the stack is deleted.
+    await stack.delete();
+    await simAws.backgroundTasksComplete();
+
+    // Then the service is INACTIVE rather than gone, and it is keeping
+    // nothing running: it was deleted while it was still scaled up, rather
+    // than having to be scaled to zero first.
+    const service = simAws.ecs().service("orders-worker", "orders");
+
+    assertFalse(service.isActive());
+    assertIdentical(service.desiredCount, 0);
+    assertIdentical(service.tasks.count, 0);
+  });
+});

--- a/src/service/ecs/cfn/sim-ecs-cfn-resource-factory.ts
+++ b/src/service/ecs/cfn/sim-ecs-cfn-resource-factory.ts
@@ -5,9 +5,11 @@ import type {
   SimCloudFormationResourceCreateContext,
 } from "../../cloudformation/resource/sim-cfn-resource.js";
 import type { SimEcsCluster } from "../cluster/sim-ecs-cluster.js";
+import type { SimEcsService } from "../service/sim-ecs-service.js";
 import type { SimEcsTaskDefinition } from "../task-definition/sim-ecs-task-definition.js";
 import type { SimEcs } from "../sim-ecs.js";
 import { SimCfnEcsClusterCreator } from "./cluster/sim-cfn-ecs-cluster-creator.js";
+import { SimCfnEcsServiceCreator } from "./service/sim-cfn-ecs-service-creator.js";
 import { SimCfnEcsTaskDefinitionCreator } from "./task-definition/sim-cfn-ecs-task-definition-creator.js";
 
 interface SimEcsCfnResourceFactoryProperties {
@@ -17,21 +19,23 @@ interface SimEcsCfnResourceFactoryProperties {
 /**
  * CloudFormation Resource factory for simulated ECS resources.
  *
- * `AWS::ECS::Cluster` and `AWS::ECS::TaskDefinition` are the two Resource
- * types a stack has to have before anything else about ECS can be deployed:
- * one is where tasks run, and the other is what they run. `AWS::ECS::Service`
- * follows separately, and until it does a template declaring one deploys with
- * the service recorded as unsupported.
+ * The three Resource types are the three things ECS is made of: a cluster is
+ * where tasks run, a task definition is what they run, and a service is what
+ * keeps them running. A stack declaring all three deploys into a simulated
+ * service running the revision it registered, which is what an application
+ * defined in CloudFormation comes down to.
  */
 export class SimEcsCfnResourceFactory implements SimCfnServiceResourceFactory {
   private readonly clusterCreator: SimCfnEcsClusterCreator;
   private readonly taskDefinitionCreator: SimCfnEcsTaskDefinitionCreator;
+  private readonly serviceCreator: SimCfnEcsServiceCreator;
 
   constructor(properties: SimEcsCfnResourceFactoryProperties) {
     this.clusterCreator = new SimCfnEcsClusterCreator({ ecs: properties.ecs });
     this.taskDefinitionCreator = new SimCfnEcsTaskDefinitionCreator({
       ecs: properties.ecs,
     });
+    this.serviceCreator = new SimCfnEcsServiceCreator({ ecs: properties.ecs });
   }
 
   /**
@@ -54,6 +58,9 @@ export class SimEcsCfnResourceFactory implements SimCfnServiceResourceFactory {
           properties,
           context.bindings,
         );
+      }
+      case "Service": {
+        return await this.serviceCreator.create(resource, properties);
       }
       default: {
         throw new Error(
@@ -84,6 +91,13 @@ export class SimEcsCfnResourceFactory implements SimCfnServiceResourceFactory {
             resource,
             "task definition",
           ),
+        );
+
+        return;
+      }
+      case "Service": {
+        await this.serviceCreator.delete(
+          simCfnEcsCreatedResource<SimEcsService>(resource, "service"),
         );
 
         return;

--- a/src/service/ecs/command/create-service/create-service-validation.iso.test.ts
+++ b/src/service/ecs/command/create-service/create-service-validation.iso.test.ts
@@ -25,22 +25,22 @@ describe("Refusing a simulated ECS CreateService request", () => {
     await simEcsClusterFactory.make({}, simAws);
     await simEcsRegisteredTaskDefinitionFactory.make({}, simAws);
 
-    // When a service is created behind a load balancer.
+    // When a service is created registered with service discovery.
     const error = await assertThrowsErrorAsync(async () =>
       simAws.ecs().createService(
         new CreateServiceCommand({
           serviceName: "checkout",
           taskDefinition: "checkout",
           desiredCount: 1,
-          loadBalancers: [{ containerName: "app", containerPort: 8080 }],
+          serviceRegistries: [{ containerName: "app", containerPort: 8080 }],
         }),
       ),
     );
 
-    // Then it is refused rather than dropped, since nothing here would send it
-    // a request.
+    // Then it is refused rather than dropped, since nothing here resolves a
+    // service by name.
     assertInstanceOf(error, SimEcsClientException);
-    assertStringIncludes(error.message, "loadBalancers");
+    assertStringIncludes(error.message, "serviceRegistries");
     assertStringIncludes(error.message, "not simulated");
   });
 

--- a/src/service/ecs/command/create-service/create-service.command.ts
+++ b/src/service/ecs/command/create-service/create-service.command.ts
@@ -1,5 +1,8 @@
 import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
-import type { SimEcsServiceDetail } from "../../service/sim-ecs-service-detail.js";
+import type {
+  SimEcsServiceDetail,
+  SimEcsServiceLoadBalancer,
+} from "../../service/sim-ecs-service-detail.js";
 
 /**
  * Minimal structural sim ECS CreateService command.
@@ -20,6 +23,7 @@ export interface SimCreateServiceCommandInput {
   readonly desiredCount?: number | undefined;
   readonly launchType?: string | undefined;
   readonly schedulingStrategy?: string | undefined;
+  readonly loadBalancers?: readonly SimEcsServiceLoadBalancer[] | undefined;
 }
 
 /**

--- a/src/service/ecs/command/create-service/create-service.handler.ts
+++ b/src/service/ecs/command/create-service/create-service.handler.ts
@@ -25,6 +25,7 @@ const acceptedInput: readonly string[] = [
   "desiredCount",
   "launchType",
   "schedulingStrategy",
+  "loadBalancers",
 ];
 
 /**
@@ -60,6 +61,11 @@ export class CreateServiceCommandHandler
    * The service is answered with the counts it has as the request is answered,
    * which is a desired count and nothing running yet, as real ECS answers one.
    * Its tasks reach `RUNNING` on the simulator's background work.
+   *
+   * A load balancer the request declares is recorded on the service and not
+   * acted on. Nothing here sends a service container a request yet, so the
+   * declaration is what a target group has to read to find the service that
+   * answers for it.
    */
   async handle(
     command: SimCreateServiceCommand,
@@ -100,6 +106,7 @@ export class CreateServiceCommandHandler
       createdAt: this.background.now(),
       launchType: command.input.launchType,
       createdBy: caller.arn,
+      loadBalancers: command.input.loadBalancers,
     });
 
     this.services.put(service);

--- a/src/service/ecs/command/create-service/create-service.iso.test.ts
+++ b/src/service/ecs/command/create-service/create-service.iso.test.ts
@@ -233,6 +233,45 @@ describe("ECS CreateServiceCommand", () => {
     assertArrayLength(listed.taskArns, 1);
   });
 
+  it("records the load balancers the service was created with", async () => {
+    // Given a registered task definition.
+    const simAws = new SimAws();
+    const ecs = simAws.ecs();
+    await simEcsClusterFactory.make({}, simAws);
+    await ecs.registerTaskDefinition(
+      new RegisterTaskDefinitionCommand({
+        family: "checkout",
+        containerDefinitions: [{ name: "app", image: "checkout:1" }],
+      }),
+    );
+
+    // When a service is created behind a load balancer target group.
+    const targetGroupArn =
+      "arn:aws:elasticloadbalancing:us-east-1:888888888888:targetgroup/checkout/73e2d6bc";
+    const created = await ecs.createService(
+      new CreateServiceCommand({
+        serviceName: "checkout",
+        taskDefinition: "checkout",
+        desiredCount: 1,
+        loadBalancers: [
+          { targetGroupArn, containerName: "app", containerPort: 8080 },
+        ],
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // Then the declaration is reported back and held on the service, since
+    // nothing here sends a service container a request yet.
+    assertIdentical(
+      created.service?.loadBalancers?.[0]?.targetGroupArn,
+      targetGroupArn,
+    );
+    assertIdentical(
+      ecs.service("checkout").loadBalancers[0]?.containerPort,
+      8080,
+    );
+  });
+
   it("names the service by the cluster it was created in", async () => {
     // Given a registered task definition and two clusters.
     const simAws = new SimAws();

--- a/src/service/ecs/index.ts
+++ b/src/service/ecs/index.ts
@@ -100,6 +100,7 @@ export {
 } from "./service/sim-ecs-service.js";
 export type {
   SimEcsServiceDetail,
+  SimEcsServiceLoadBalancer,
   SimEcsServiceStatus,
 } from "./service/sim-ecs-service-detail.js";
 export { SimEcsServiceTaskSet } from "./service/sim-ecs-service-task-set.js";

--- a/src/service/ecs/service/sim-ecs-service-detail.ts
+++ b/src/service/ecs/service/sim-ecs-service-detail.ts
@@ -10,6 +10,22 @@ import type { SimArn } from "../../aws/arn.js";
 export type SimEcsServiceStatus = "ACTIVE" | "INACTIVE";
 
 /**
+ * One load balancer a service declared it is registered with.
+ *
+ * Nothing here sends a service a request yet, so this is held as it was
+ * declared rather than acted on: it is what a load balancer target group has
+ * to read to find the service that answers for it.
+ *
+ * https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_LoadBalancer.html
+ */
+export interface SimEcsServiceLoadBalancer {
+  readonly targetGroupArn?: string | undefined;
+  readonly loadBalancerName?: string | undefined;
+  readonly containerName?: string | undefined;
+  readonly containerPort?: number | undefined;
+}
+
+/**
  * Minimal structural sim ECS described service.
  *
  * https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_Service.html
@@ -25,7 +41,7 @@ export interface SimEcsServiceDetail {
   readonly taskDefinition?: SimArn | undefined;
   readonly launchType?: string | undefined;
   readonly schedulingStrategy?: string | undefined;
-  readonly loadBalancers?: readonly object[] | undefined;
+  readonly loadBalancers?: readonly SimEcsServiceLoadBalancer[] | undefined;
   readonly serviceRegistries?: readonly object[] | undefined;
   readonly createdAt?: Date | undefined;
   readonly createdBy?: string | undefined;

--- a/src/service/ecs/service/sim-ecs-service-identity.ts
+++ b/src/service/ecs/service/sim-ecs-service-identity.ts
@@ -1,5 +1,8 @@
 import type { SimArn } from "../../aws/arn.js";
-import type { SimEcsServiceDetail } from "./sim-ecs-service-detail.js";
+import type {
+  SimEcsServiceDetail,
+  SimEcsServiceLoadBalancer,
+} from "./sim-ecs-service-detail.js";
 
 /**
  * What a service is, as opposed to what it is being kept at.
@@ -12,6 +15,7 @@ export interface SimEcsServiceIdentityProperties {
   readonly createdAt: Date;
   readonly launchType?: string | undefined;
   readonly createdBy?: string | undefined;
+  readonly loadBalancers?: readonly SimEcsServiceLoadBalancer[] | undefined;
 }
 
 /**
@@ -35,6 +39,7 @@ export class SimEcsServiceIdentity {
   public readonly clusterArn: SimArn;
   public readonly clusterName: string;
   public readonly launchType: string | undefined;
+  public readonly loadBalancers: readonly SimEcsServiceLoadBalancer[];
 
   private readonly declared: SimEcsServiceIdentityProperties;
 
@@ -45,14 +50,17 @@ export class SimEcsServiceIdentity {
     this.clusterArn = declared.clusterArn;
     this.clusterName = declared.clusterName;
     this.launchType = declared.launchType;
+    this.loadBalancers = declared.loadBalancers ?? [];
   }
 
   /**
    * This part of the service as `DescribeServices` reports it.
    *
-   * The load balancers and service registries are honestly empty rather than
-   * left out: a service registers with neither here, and reporting nothing at
-   * all would read as a service that had not been asked about them.
+   * The load balancers are the ones the service was created with, held as they
+   * were declared, because nothing here sends a service a request yet. The
+   * service registries are honestly empty rather than left out: a service
+   * registers with none here, and reporting nothing at all would read as a
+   * service that had not been asked about them.
    */
   toOutput(): SimEcsServiceIdentityDetail {
     const { serviceArn, serviceName, clusterArn, createdAt } = this.declared;
@@ -62,7 +70,7 @@ export class SimEcsServiceIdentity {
       serviceName,
       clusterArn,
       createdAt,
-      loadBalancers: [],
+      loadBalancers: this.loadBalancers,
       serviceRegistries: [],
       ...(this.launchType !== undefined && { launchType: this.launchType }),
       ...(this.declared.createdBy !== undefined && {

--- a/src/service/ecs/service/sim-ecs-service.ts
+++ b/src/service/ecs/service/sim-ecs-service.ts
@@ -1,6 +1,7 @@
 import type { SimArn } from "../../aws/arn.js";
 import type {
   SimEcsServiceDetail,
+  SimEcsServiceLoadBalancer,
   SimEcsServiceStatus,
 } from "./sim-ecs-service-detail.js";
 import {
@@ -58,6 +59,11 @@ export class SimEcsService {
     return this.identity.serviceName;
   }
 
+  /** The ARN this service is named by anywhere outside its cluster. */
+  get serviceArn(): SimArn {
+    return this.identity.serviceArn;
+  }
+
   /** The cluster this service runs in. */
   get clusterName(): string {
     return this.identity.clusterName;
@@ -66,6 +72,17 @@ export class SimEcsService {
   /** The launch type this service was created with, where one was given. */
   get launchType(): string | undefined {
     return this.identity.launchType;
+  }
+
+  /**
+   * The load balancers this service was created with.
+   *
+   * Held as they were declared and not acted on: nothing here sends a service
+   * container a request yet, so this is what a target group reads to find the
+   * service that is meant to answer for it.
+   */
+  get loadBalancers(): readonly SimEcsServiceLoadBalancer[] {
+    return this.identity.loadBalancers;
   }
 
   /** The revision this service is currently running. */

--- a/src/service/ecs/sim-ecs-commands.ts
+++ b/src/service/ecs/sim-ecs-commands.ts
@@ -93,12 +93,6 @@ export class SimEcsCommands {
       consumerQueues = new SimEcsUnreachableConsumerQueues(),
     } = properties;
 
-    this.lookup = new SimEcsLookup({
-      accountRegionScope,
-      clusters: this.clusters,
-      taskDefinitions: this.taskDefinitions,
-    });
-
     const contexts = new SimEcsCommandContexts({
       accountRegionScope,
       authorizer: new SimEcsAuthorizer({ iam }),
@@ -115,6 +109,13 @@ export class SimEcsCommands {
     const { cluster, taskDefinition, task, service } = contexts;
 
     this.serviceTasks = service.serviceTasks;
+    this.lookup = new SimEcsLookup({
+      accountRegionScope,
+      clusters: this.clusters,
+      taskDefinitions: this.taskDefinitions,
+      services: this.services,
+      serviceArn: service.serviceArn,
+    });
 
     this.createCluster = new CreateClusterCommandHandler(cluster);
     this.describeClusters = new DescribeClustersCommandHandler(cluster);

--- a/src/service/ecs/sim-ecs-lookup.ts
+++ b/src/service/ecs/sim-ecs-lookup.ts
@@ -1,7 +1,14 @@
 import type { SimAwsAccountRegionScope } from "../aws/sim-aws-account-region-scope.js";
+import { simEcsDefaultClusterName } from "./cluster/sim-ecs-cluster-arn.js";
 import type { SimEcsCluster } from "./cluster/sim-ecs-cluster.js";
 import type { SimEcsClusterStore } from "./cluster/sim-ecs-cluster-store.js";
-import { SimEcsClusterNotFoundException } from "./error/sim-ecs.error.js";
+import {
+  SimEcsClusterNotFoundException,
+  SimEcsServiceNotFoundException,
+} from "./error/sim-ecs.error.js";
+import type { SimEcsServiceArn } from "./service/sim-ecs-service-arn.js";
+import type { SimEcsServiceStore } from "./service/sim-ecs-service-store.js";
+import type { SimEcsService } from "./service/sim-ecs-service.js";
 import { SimEcsTaskDefinitionId } from "./task-definition/sim-ecs-task-definition-id.js";
 import type { SimEcsTaskDefinitionStore } from "./task-definition/sim-ecs-task-definition-store.js";
 import type { SimEcsTaskDefinition } from "./task-definition/sim-ecs-task-definition.js";
@@ -10,6 +17,8 @@ interface SimEcsLookupProperties {
   readonly accountRegionScope: SimAwsAccountRegionScope;
   readonly clusters: SimEcsClusterStore;
   readonly taskDefinitions: SimEcsTaskDefinitionStore;
+  readonly services: SimEcsServiceStore;
+  readonly serviceArn: SimEcsServiceArn;
 }
 
 /**
@@ -25,11 +34,15 @@ export class SimEcsLookup {
   private readonly accountRegionScope: SimAwsAccountRegionScope;
   private readonly clusters: SimEcsClusterStore;
   private readonly taskDefinitions: SimEcsTaskDefinitionStore;
+  private readonly services: SimEcsServiceStore;
+  private readonly serviceArn: SimEcsServiceArn;
 
   constructor(properties: SimEcsLookupProperties) {
     this.accountRegionScope = properties.accountRegionScope;
     this.clusters = properties.clusters;
     this.taskDefinitions = properties.taskDefinitions;
+    this.services = properties.services;
+    this.serviceArn = properties.serviceArn;
   }
 
   /**
@@ -48,6 +61,37 @@ export class SimEcsLookup {
     }
 
     return cluster;
+  }
+
+  /**
+   * The service a name or a full ARN names, active or deleted.
+   *
+   * A service belongs to a cluster, so a name on its own is looked for in the
+   * cluster given alongside it, and in the `default` one when none is. An ARN
+   * carries its own cluster and is looked for there, whatever else was given.
+   */
+  service(
+    identifier: string,
+    clusterName: string = simEcsDefaultClusterName,
+  ): SimEcsService {
+    const named = this.serviceArn.namedService(identifier);
+
+    if (named === undefined) {
+      throw new SimEcsServiceNotFoundException(
+        `${identifier} names no service in this simulated Account and Region.`,
+      );
+    }
+
+    const inCluster = named.clusterName ?? clusterName;
+    const service = this.services.find(inCluster, named.serviceName);
+
+    if (service === undefined) {
+      throw new SimEcsServiceNotFoundException(
+        `The cluster ${inCluster} holds no service ${named.serviceName}.`,
+      );
+    }
+
+    return service;
   }
 
   /**

--- a/src/service/ecs/sim-ecs-service-lookup.iso.test.ts
+++ b/src/service/ecs/sim-ecs-service-lookup.iso.test.ts
@@ -1,0 +1,99 @@
+import {
+  DeleteServiceCommand,
+  UpdateServiceCommand,
+} from "@aws-sdk/client-ecs";
+import {
+  assertFalse,
+  assertIdentical,
+  assertStringIncludes,
+  assertThrowsError,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../aws/sim-aws.js";
+import { simEcsClusterFactory } from "./cluster/sim-ecs-cluster.factory.js";
+import { simEcsServiceFactory } from "./service/sim-ecs-service.factory.js";
+import { simEcsRegisteredTaskDefinitionFactory } from "./task-definition/sim-ecs-registered-task-definition.factory.js";
+
+/**
+ * Create the default service of the default cluster.
+ */
+async function createdService(simAws: SimAws): Promise<string> {
+  await simEcsClusterFactory.make({}, simAws);
+  await simEcsRegisteredTaskDefinitionFactory.make({}, simAws);
+
+  const created = await simEcsServiceFactory.make({}, simAws);
+
+  return created.serviceArn ?? "";
+}
+
+describe("Looking a simulated ECS service up", () => {
+  it("finds a service by its name and by its ARN", async () => {
+    // Given a created service.
+    const simAws = new SimAws();
+    const serviceArn = await createdService(simAws);
+
+    await simAws.backgroundTasksComplete();
+
+    // When it is looked up both ways.
+    const byName = simAws.ecs().service("checkout", "default");
+    const byArn = simAws.ecs().service(serviceArn);
+
+    // Then both give the same service, since the ARN carries the cluster the
+    // name has to be given alongside.
+    assertIdentical(byName, byArn);
+    assertIdentical(byName.serviceName, "checkout");
+  });
+
+  it("finds a deleted service", async () => {
+    // Given a service that has been scaled to nothing and deleted.
+    const simAws = new SimAws();
+    await createdService(simAws);
+    await simAws
+      .ecs()
+      .updateService(
+        new UpdateServiceCommand({ service: "checkout", desiredCount: 0 }),
+      );
+    await simAws
+      .ecs()
+      .deleteService(new DeleteServiceCommand({ service: "checkout" }));
+    await simAws.backgroundTasksComplete();
+
+    // When it is looked up.
+    const service = simAws.ecs().service("checkout");
+
+    // Then it is answered as the INACTIVE service it now is, rather than
+    // reported missing, which is what real ECS leaves behind a deletion.
+    assertFalse(service.isActive());
+  });
+
+  it("refuses a service name nothing holds", async () => {
+    // Given a simulated ECS holding one service.
+    const simAws = new SimAws();
+    await createdService(simAws);
+    await simAws.backgroundTasksComplete();
+
+    // When another name is looked up, then it is refused rather than answered
+    // with nothing.
+    const error = assertThrowsError(() => simAws.ecs().service("orders"));
+
+    assertStringIncludes(error.message, "holds no service orders");
+  });
+
+  it("refuses an identifier that names no service at all", async () => {
+    // Given a simulated ECS holding one service.
+    const simAws = new SimAws();
+    await createdService(simAws);
+    await simAws.backgroundTasksComplete();
+
+    // When something that is not a service ARN is looked up, then it is
+    // refused naming what was asked for.
+    const error = assertThrowsError(() =>
+      simAws
+        .ecs()
+        .service("arn:aws:ecs:us-east-1:888888888888:cluster/default"),
+    );
+
+    assertStringIncludes(error.message, "names no service");
+  });
+});

--- a/src/service/ecs/sim-ecs.ts
+++ b/src/service/ecs/sim-ecs.ts
@@ -6,6 +6,7 @@ import type { SimEcsCluster } from "./cluster/sim-ecs-cluster.js";
 import type * as simEcsCommands from "./command/sim-ecs-command.types.js";
 import type { SimEcsRequestOptions } from "./command/sim-ecs-request-options.js";
 import { SimEcsSdkCommandRouter } from "./sdk/sim-ecs-sdk-command-router.js";
+import type { SimEcsService } from "./service/sim-ecs-service.js";
 import { SimEcsCommands } from "./sim-ecs-commands.js";
 import type { SimEcsProperties } from "./sim-ecs-properties.js";
 import type { SimEcsTaskDefinition } from "./task-definition/sim-ecs-task-definition.js";
@@ -214,12 +215,9 @@ export class SimEcs {
    *
    * A service is the one thing simulated ECS keeps running rather than runs and
    * finishes, so this is what a simulated environment being finished with comes
-   * down to here: every service's tasks stop, and nothing is left scheduled.
-   * The services themselves stay as they were, describable with the desired
-   * count they had.
-   *
-   * Closing again does nothing again, since the second time round there is
-   * nothing running to stop.
+   * down to: every service's tasks stop and nothing is left scheduled, while
+   * the services stay describable with the desired count they had. Closing
+   * again does nothing again, since there is then nothing running to stop.
    */
   close(): void {
     this.commands.closeServices();
@@ -261,8 +259,9 @@ export class SimEcs {
    * The cluster of this name, whether it is active or deleted.
    *
    * A lookup rather than an operation, for a test or a CloudFormation Resource
-   * that needs the cluster itself rather than a description of it. A name
-   * nothing holds is refused, since the caller asked for a cluster.
+   * that needs the thing itself rather than a description of it. An identifier
+   * nothing holds is refused, here and in the two lookups below, since the
+   * caller asked for the thing rather than for whether there is one.
    */
   cluster(clusterName: string): SimEcsCluster {
     return this.commands.lookup.cluster(clusterName);
@@ -279,15 +278,22 @@ export class SimEcs {
   }
 
   /**
-   * Get this service's CloudFormation Resource factory.
+   * The service a name in a cluster, or a full service ARN, names, whether it
+   * is active or deleted.
+   *
+   * A name given without a cluster is looked for in the `default` one, as an
+   * ECS request naming no cluster means that one.
    */
+  service(identifier: string, clusterName?: string): SimEcsService {
+    return this.commands.lookup.service(identifier, clusterName);
+  }
+
+  /** Get this service's CloudFormation Resource factory. */
   cfnResourceFactory(): SimCfnServiceResourceFactory {
     return new SimEcsCfnResourceFactory({ ecs: this });
   }
 
-  /**
-   * Get this service's SDK Command router for SDK client interception.
-   */
+  /** Get this service's SDK Command router for SDK client interception. */
   sdkCommandRouter(): SimSdkCommandRouter {
     return this.sdkRouter;
   }


### PR DESCRIPTION
`AWS::ECS::Service` creates a simulated service in its cluster through the ordinary `CreateService` command, keeping the declared desired count of tasks running from the task definition it names, whether that is a `Ref` to a same-stack task definition or an ARN, with deploy-time container bindings resolving as they already do for a task definition. `Ref` answers with the service ARN and `Fn::GetAtt` with `Name` and `ServiceArn`, an update scales the service or moves it onto the revision it registered, and a teardown deletes it, leaving it `INACTIVE`. `LoadBalancers` is recorded on the service and readable rather than acted on, since nothing sends a service container a request yet, and the network configuration, capacity provider strategy, deployment configuration and service discovery a real service declares are read and recorded as ignored rather than failing the stack.

Resolves https://github.com/KensioSoftware/yulin/issues/560

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CloudFormation support for deploying and managing ECS services.
  * ECS services now support desired task counts, updates, teardown, references, attributes, and load balancer configuration.
  * Added service lookup by name or ARN, including inactive services.
  * Added an end-to-end ECS service deployment example and expanded documentation.

* **Bug Fixes**
  * Improved validation and reporting for unsupported ECS service properties and invalid desired counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->