### PR TITLE
feat: deploy sim ELBv2 from CloudFormation

### DIFF
--- a/docs/services/elbv2/README.md
+++ b/docs/services/elbv2/README.md
@@ -1167,6 +1167,253 @@ try {
 }
 ```
 
+## Deploying a load balancer from CloudFormation
+
+`AWS::ElasticLoadBalancingV2::LoadBalancer`, `TargetGroup`, `Listener` and `ListenerRule` create
+their simulated counterparts, so a test can start from the stack the routing is actually defined in.
+Each one goes through the same command an SDK caller would use, so a template's listener rule matches
+requests the way the same rule created by hand does, and a declaration real ELB would refuse fails
+the deployment rather than deploying as something else.
+
+`Ref` returns the ARN of all four, which is what a listener's `LoadBalancerArn`, a rule's
+`ListenerArn` and a forward action's `TargetGroupArn` each take. `Fn::GetAtt` answers with:
+
+- `DNSName`, `LoadBalancerName`, `LoadBalancerFullName` and `CanonicalHostedZoneID` on a load
+  balancer
+- `TargetGroupArn`, `TargetGroupName` and `TargetGroupFullName` on a target group
+- `ListenerArn` on a listener, and `RuleArn` and `IsDefault` on a rule
+
+A load balancer or target group the template does not name is named after the stack and the logical
+ID, trimmed to the 32 characters ELB allows. A target group declaring `Targets` has them registered
+as part of creating it, so the group routes as soon as the stack has deployed.
+
+```typescript sim-elbv2-cloudformation
+/**
+ * Deploying a load balancer, target group, listener and rule from a template.
+ */
+
+import { SimAws } from "@kensio/yulin";
+import type { SimElbV2Event, SimElbV2Result } from "@kensio/yulin/elbv2";
+import { simElbV2Fetch } from "@kensio/yulin/elbv2";
+
+const simAws = new SimAws();
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "shop",
+  template: {
+    Resources: {
+      CheckoutFunction: {
+        Type: "AWS::Lambda::Function",
+        Properties: {
+          FunctionName: "checkout",
+          Role: "arn:aws:iam::888888888888:role/CheckoutRole",
+        },
+      },
+      ShopAlb: {
+        Type: "AWS::ElasticLoadBalancingV2::LoadBalancer",
+        Properties: {
+          Name: "shop-alb",
+          Scheme: "internet-facing",
+          // Accepted and left out: there is no VPC here to place one in.
+          Subnets: ["subnet-1111", "subnet-2222"],
+        },
+      },
+      CheckoutTargets: {
+        Type: "AWS::ElasticLoadBalancingV2::TargetGroup",
+        Properties: {
+          Name: "checkout-tg",
+          TargetType: "lambda",
+          // Registered at deploy time, so the group routes straight away.
+          Targets: [{ Id: { "Fn::GetAtt": ["CheckoutFunction", "Arn"] } }],
+        },
+      },
+      InvokePermission: {
+        Type: "AWS::Lambda::Permission",
+        Properties: {
+          FunctionName: { Ref: "CheckoutFunction" },
+          Action: "lambda:InvokeFunction",
+          Principal: "elasticloadbalancing.amazonaws.com",
+          SourceArn: { Ref: "CheckoutTargets" },
+        },
+      },
+      HttpListener: {
+        Type: "AWS::ElasticLoadBalancingV2::Listener",
+        Properties: {
+          LoadBalancerArn: { Ref: "ShopAlb" },
+          Protocol: "HTTP",
+          Port: 80,
+          DefaultActions: [
+            {
+              Type: "fixed-response",
+              FixedResponseConfig: {
+                StatusCode: "404",
+                ContentType: "text/plain",
+                MessageBody: "no such site",
+              },
+            },
+          ],
+        },
+      },
+      CheckoutRule: {
+        Type: "AWS::ElasticLoadBalancingV2::ListenerRule",
+        Properties: {
+          ListenerArn: { Ref: "HttpListener" },
+          Priority: 10,
+          Conditions: [{ Field: "path-pattern", Values: ["/checkout*"] }],
+          Actions: [
+            { Type: "forward", TargetGroupArn: { Ref: "CheckoutTargets" } },
+          ],
+        },
+      },
+    },
+    Outputs: {
+      DnsName: { Value: { "Fn::GetAtt": ["ShopAlb", "DNSName"] } },
+      FullName: {
+        Value: { "Fn::GetAtt": ["ShopAlb", "LoadBalancerFullName"] },
+      },
+    },
+  },
+  bindings: [
+    {
+      logicalId: "CheckoutFunction",
+      handler: (event: SimElbV2Event): SimElbV2Result => ({
+        statusCode: 200,
+        statusDescription: "200 OK",
+        headers: { "content-type": "text/plain" },
+        body: `checkout ${event.path}`,
+        isBase64Encoded: false,
+      }),
+    },
+  ],
+});
+
+await stack.waitForDeployComplete();
+await simAws.backgroundTasksComplete();
+
+const dnsName = stack.outputs.get("DnsName")?.value as string;
+
+console.log(dnsName); // "shop-alb-0000000001.us-east-1.elb.amazonaws.com"
+console.log(stack.outputs.get("FullName")?.value);
+// "app/shop-alb/0000000001"
+
+const claimed = await simElbV2Fetch(simAws, `http://${dnsName}/checkout/42`);
+
+console.log(claimed.status); // 200
+console.log(await claimed.text()); // "checkout /checkout/42"
+
+// A request no rule claims falls through to the listener's default action.
+const unclaimed = await simElbV2Fetch(simAws, `http://${dnsName}/other`);
+
+console.log(unclaimed.status); // 404
+```
+
+A listener's `Certificates` resolves against simulated [ACM](../acm/), so a stack that creates a
+certificate and attaches it to an HTTPS listener works end to end. A certificate that was never
+issued, or that belongs to another account or region, fails the deployment rather than leaving a
+listener that could not serve. A `Fn::GetAtt` on `DNSName` is a name a Route53 alias in the same
+stack can point at and reach.
+
+```typescript sim-elbv2-cloudformation-certificate
+/**
+ * An HTTPS listener holding a certificate the same stack created.
+ */
+
+import { DescribeListenersCommand } from "@aws-sdk/client-elastic-load-balancing-v2";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "shop",
+  template: {
+    Resources: {
+      ShopZone: {
+        Type: "AWS::Route53::HostedZone",
+        Properties: { Name: "example.test" },
+      },
+      SiteCertificate: {
+        Type: "AWS::CertificateManager::Certificate",
+        Properties: {
+          DomainName: "shop.example.test",
+          ValidationMethod: "DNS",
+        },
+      },
+      ShopAlb: {
+        Type: "AWS::ElasticLoadBalancingV2::LoadBalancer",
+        Properties: { Name: "shop-alb" },
+      },
+      HttpsListener: {
+        Type: "AWS::ElasticLoadBalancingV2::Listener",
+        Properties: {
+          LoadBalancerArn: { Ref: "ShopAlb" },
+          Protocol: "HTTPS",
+          Port: 443,
+          Certificates: [{ CertificateArn: { Ref: "SiteCertificate" } }],
+          DefaultActions: [
+            {
+              Type: "fixed-response",
+              FixedResponseConfig: {
+                StatusCode: "200",
+                ContentType: "text/plain",
+                MessageBody: "shop",
+              },
+            },
+          ],
+        },
+      },
+      ShopRecord: {
+        Type: "AWS::Route53::RecordSet",
+        Properties: {
+          HostedZoneId: { Ref: "ShopZone" },
+          Name: "shop.example.test",
+          Type: "A",
+          AliasTarget: {
+            DNSName: { "Fn::GetAtt": ["ShopAlb", "DNSName"] },
+            HostedZoneId: {
+              "Fn::GetAtt": ["ShopAlb", "CanonicalHostedZoneID"],
+            },
+          },
+        },
+      },
+    },
+    Outputs: {
+      ListenerArn: { Value: { Ref: "HttpsListener" } },
+    },
+  },
+});
+
+await stack.waitForDeployComplete();
+await simAws.backgroundTasksComplete();
+
+const listenerArn = stack.outputs.get("ListenerArn")?.value as string;
+
+const described = await simAws
+  .elbV2()
+  .describeListeners(
+    new DescribeListenersCommand({ ListenerArns: [listenerArn] }),
+  );
+
+const listener = described.Listeners?.[0];
+
+console.log(listener?.Certificates[0]?.CertificateArn);
+// the ARN of the certificate the stack created
+
+console.log(listener?.SslPolicy); // "ELBSecurityPolicy-2016-08"
+```
+
+Properties Yulin has nothing to act on are read and left out rather than failing the stack. Subnets,
+security groups, load balancer and target group attributes, listener attributes, mutual
+authentication and health check configuration are all in that group, and each one is recorded on the
+Resource so a reader can see what the deployed load balancer is not doing:
+
+```typescript
+const ignored = stack.resources.get("ShopAlb")?.ignoredProperties;
+```
+
+Tearing the stack down removes all four in reverse dependency order, so a rule comes down before its
+listener, a listener before its load balancer, and a target group after everything forwarding to it.
+
 ## IAM authorization
 
 Every operation is authorized by simulated [IAM](../iam/) as the caller making it, against the
@@ -1304,6 +1551,11 @@ console.log(created.LoadBalancers?.[0]?.DNSName);
   `fixed-response` and `redirect` actions, which the load balancer answers itself.
 - The load balancer's own 503, 502 and 413, and the invoke permission the function's resource policy
   has to grant `elasticloadbalancing.amazonaws.com`.
+- Deploying `AWS::ElasticLoadBalancingV2::LoadBalancer`, `TargetGroup`, `Listener` and
+  `ListenerRule` from a CloudFormation template, with `Ref` returning ARNs, `Fn::GetAtt` answering
+  `DNSName`, `LoadBalancerFullName` and `TargetGroupFullName` among others, a listener's
+  `Certificates` resolved against simulated ACM, and a target group's `Targets` registered at deploy
+  time.
 - IAM authorization against the ARN of whatever an operation names.
 - SDK interception of `ElasticLoadBalancingV2Client`.
 
@@ -1389,5 +1641,14 @@ console.log(created.LoadBalancers?.[0]?.DNSName);
   here and a longer list is refused.
 - Load balancer and target group attributes, access logs, and tags as a readable resource are not
   simulated.
-- There is no CloudFormation support yet, so `AWS::ElasticLoadBalancingV2::*` resources in a template
-  are not deployed.
+- `AWS::ElasticLoadBalancingV2::TrustStore`, `TrustStoreRevocation` and `ListenerCertificate` are not
+  deployed, and a stack declaring one records it as unsupported and carries on. The first two have
+  nothing to attach to, since mutual TLS is not simulated, and a listener's additional certificates
+  are added with `AddListenerCertificates` instead.
+- `Fn::GetAtt` `SecurityGroups` on a load balancer and `LoadBalancerArns` on a target group are
+  refused rather than answered. Nothing places a simulated load balancer behind a security group, and
+  nothing records on a target group which load balancers forward to it, which `DescribeTargetGroups`
+  reads back out of the listeners instead.
+- Sim CloudFormation has no in-place resource update, so a changed load balancer, target group,
+  listener or rule is deleted and created again, and everything naming it is replaced too. A replaced
+  load balancer gets a new DNS name.

--- a/docs/services/elbv2/README.md
+++ b/docs/services/elbv2/README.md
@@ -1178,8 +1178,8 @@ the deployment rather than deploying as something else.
 `Ref` returns the ARN of all four, which is what a listener's `LoadBalancerArn`, a rule's
 `ListenerArn` and a forward action's `TargetGroupArn` each take. `Fn::GetAtt` answers with:
 
-- `DNSName`, `LoadBalancerName`, `LoadBalancerFullName` and `CanonicalHostedZoneID` on a load
-  balancer
+- `DNSName`, `LoadBalancerArn`, `LoadBalancerName`, `LoadBalancerFullName` and
+  `CanonicalHostedZoneID` on a load balancer
 - `TargetGroupArn`, `TargetGroupName` and `TargetGroupFullName` on a target group
 - `ListenerArn` on a listener, and `RuleArn` and `IsDefault` on a rule
 

--- a/docs/services/elbv2/sim-elbv2-cloudformation-certificate.example.ts
+++ b/docs/services/elbv2/sim-elbv2-cloudformation-certificate.example.ts
@@ -1,0 +1,86 @@
+/**
+ * An HTTPS listener holding a certificate the same stack created.
+ */
+
+import { DescribeListenersCommand } from "@aws-sdk/client-elastic-load-balancing-v2";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "shop",
+  template: {
+    Resources: {
+      ShopZone: {
+        Type: "AWS::Route53::HostedZone",
+        Properties: { Name: "example.test" },
+      },
+      SiteCertificate: {
+        Type: "AWS::CertificateManager::Certificate",
+        Properties: {
+          DomainName: "shop.example.test",
+          ValidationMethod: "DNS",
+        },
+      },
+      ShopAlb: {
+        Type: "AWS::ElasticLoadBalancingV2::LoadBalancer",
+        Properties: { Name: "shop-alb" },
+      },
+      HttpsListener: {
+        Type: "AWS::ElasticLoadBalancingV2::Listener",
+        Properties: {
+          LoadBalancerArn: { Ref: "ShopAlb" },
+          Protocol: "HTTPS",
+          Port: 443,
+          Certificates: [{ CertificateArn: { Ref: "SiteCertificate" } }],
+          DefaultActions: [
+            {
+              Type: "fixed-response",
+              FixedResponseConfig: {
+                StatusCode: "200",
+                ContentType: "text/plain",
+                MessageBody: "shop",
+              },
+            },
+          ],
+        },
+      },
+      ShopRecord: {
+        Type: "AWS::Route53::RecordSet",
+        Properties: {
+          HostedZoneId: { Ref: "ShopZone" },
+          Name: "shop.example.test",
+          Type: "A",
+          AliasTarget: {
+            DNSName: { "Fn::GetAtt": ["ShopAlb", "DNSName"] },
+            HostedZoneId: {
+              "Fn::GetAtt": ["ShopAlb", "CanonicalHostedZoneID"],
+            },
+          },
+        },
+      },
+    },
+    Outputs: {
+      ListenerArn: { Value: { Ref: "HttpsListener" } },
+    },
+  },
+});
+
+await stack.waitForDeployComplete();
+await simAws.backgroundTasksComplete();
+
+const listenerArn = stack.outputs.get("ListenerArn")?.value as string;
+
+const described = await simAws
+  .elbV2()
+  .describeListeners(
+    new DescribeListenersCommand({ ListenerArns: [listenerArn] }),
+  );
+
+const listener = described.Listeners?.[0];
+
+console.log(listener?.Certificates[0]?.CertificateArn);
+// the ARN of the certificate the stack created
+
+console.log(listener?.SslPolicy); // "ELBSecurityPolicy-2016-08"

--- a/docs/services/elbv2/sim-elbv2-cloudformation.example.ts
+++ b/docs/services/elbv2/sim-elbv2-cloudformation.example.ts
@@ -1,0 +1,117 @@
+/**
+ * Deploying a load balancer, target group, listener and rule from a template.
+ */
+
+import { SimAws } from "@kensio/yulin";
+import type { SimElbV2Event, SimElbV2Result } from "@kensio/yulin/elbv2";
+import { simElbV2Fetch } from "@kensio/yulin/elbv2";
+
+const simAws = new SimAws();
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "shop",
+  template: {
+    Resources: {
+      CheckoutFunction: {
+        Type: "AWS::Lambda::Function",
+        Properties: {
+          FunctionName: "checkout",
+          Role: "arn:aws:iam::888888888888:role/CheckoutRole",
+        },
+      },
+      ShopAlb: {
+        Type: "AWS::ElasticLoadBalancingV2::LoadBalancer",
+        Properties: {
+          Name: "shop-alb",
+          Scheme: "internet-facing",
+          // Accepted and left out: there is no VPC here to place one in.
+          Subnets: ["subnet-1111", "subnet-2222"],
+        },
+      },
+      CheckoutTargets: {
+        Type: "AWS::ElasticLoadBalancingV2::TargetGroup",
+        Properties: {
+          Name: "checkout-tg",
+          TargetType: "lambda",
+          // Registered at deploy time, so the group routes straight away.
+          Targets: [{ Id: { "Fn::GetAtt": ["CheckoutFunction", "Arn"] } }],
+        },
+      },
+      InvokePermission: {
+        Type: "AWS::Lambda::Permission",
+        Properties: {
+          FunctionName: { Ref: "CheckoutFunction" },
+          Action: "lambda:InvokeFunction",
+          Principal: "elasticloadbalancing.amazonaws.com",
+          SourceArn: { Ref: "CheckoutTargets" },
+        },
+      },
+      HttpListener: {
+        Type: "AWS::ElasticLoadBalancingV2::Listener",
+        Properties: {
+          LoadBalancerArn: { Ref: "ShopAlb" },
+          Protocol: "HTTP",
+          Port: 80,
+          DefaultActions: [
+            {
+              Type: "fixed-response",
+              FixedResponseConfig: {
+                StatusCode: "404",
+                ContentType: "text/plain",
+                MessageBody: "no such site",
+              },
+            },
+          ],
+        },
+      },
+      CheckoutRule: {
+        Type: "AWS::ElasticLoadBalancingV2::ListenerRule",
+        Properties: {
+          ListenerArn: { Ref: "HttpListener" },
+          Priority: 10,
+          Conditions: [{ Field: "path-pattern", Values: ["/checkout*"] }],
+          Actions: [
+            { Type: "forward", TargetGroupArn: { Ref: "CheckoutTargets" } },
+          ],
+        },
+      },
+    },
+    Outputs: {
+      DnsName: { Value: { "Fn::GetAtt": ["ShopAlb", "DNSName"] } },
+      FullName: {
+        Value: { "Fn::GetAtt": ["ShopAlb", "LoadBalancerFullName"] },
+      },
+    },
+  },
+  bindings: [
+    {
+      logicalId: "CheckoutFunction",
+      handler: (event: SimElbV2Event): SimElbV2Result => ({
+        statusCode: 200,
+        statusDescription: "200 OK",
+        headers: { "content-type": "text/plain" },
+        body: `checkout ${event.path}`,
+        isBase64Encoded: false,
+      }),
+    },
+  ],
+});
+
+await stack.waitForDeployComplete();
+await simAws.backgroundTasksComplete();
+
+const dnsName = stack.outputs.get("DnsName")?.value as string;
+
+console.log(dnsName); // "shop-alb-0000000001.us-east-1.elb.amazonaws.com"
+console.log(stack.outputs.get("FullName")?.value);
+// "app/shop-alb/0000000001"
+
+const claimed = await simElbV2Fetch(simAws, `http://${dnsName}/checkout/42`);
+
+console.log(claimed.status); // 200
+console.log(await claimed.text()); // "checkout /checkout/42"
+
+// A request no rule claims falls through to the listener's default action.
+const unclaimed = await simElbV2Fetch(simAws, `http://${dnsName}/other`);
+
+console.log(unclaimed.status); // 404

--- a/src/service/cloudformation/README.md
+++ b/src/service/cloudformation/README.md
@@ -645,6 +645,7 @@ The resolver currently supports factories for:
 - `AWS::S3::*`
 - `AWS::CloudFront::*`
 - `AWS::ECS::*`
+- `AWS::ElasticLoadBalancingV2::*`
 - selected `Custom::*` CDK-oriented resources
 
 Unsupported providers, services, custom resources, or resource types are skipped to improve

--- a/src/service/cloudformation/README.md
+++ b/src/service/cloudformation/README.md
@@ -803,6 +803,7 @@ CloudFormation currently integrates with a small set of service simulators:
 - CloudFormation-native test resources such as `WaitConditionHandle`
 - S3 resources implemented by the S3 simulator
 - CloudFront resources implemented by the CloudFront simulator
+- ELBv2 resources implemented by the ELBv2 simulator
 - selected CDK custom resources
 
 The CloudFormation engine itself should not know the detailed schema or behaviour of

--- a/src/service/cloudformation/resource/cfn/elasticloadbalancingv2/sim-elbv2-cfn-value-adapter.ts
+++ b/src/service/cloudformation/resource/cfn/elasticloadbalancingv2/sim-elbv2-cfn-value-adapter.ts
@@ -1,0 +1,53 @@
+import { SimElbV2ListenerRule } from "../../../../elbv2/listener/rule/sim-elbv2-listener-rule.js";
+import { SimElbV2Listener } from "../../../../elbv2/listener/sim-elbv2-listener.js";
+import { SimElbV2LoadBalancer } from "../../../../elbv2/load-balancer/sim-elbv2-load-balancer.js";
+import { SimElbV2TargetGroup } from "../../../../elbv2/target-group/sim-elbv2-target-group.js";
+import type {
+  SimCfnResourceValueAdapterProperties,
+  SimCfnServiceValueAdapter,
+} from "../sim-cfn-resource-value-adapter.js";
+import {
+  SimElbV2ListenerCfn,
+  SimElbV2ListenerRuleCfn,
+} from "./sim-elbv2-listener-cfn.js";
+import { SimElbV2LoadBalancerCfn } from "./sim-elbv2-load-balancer-cfn.js";
+import { SimElbV2TargetGroupCfn } from "./sim-elbv2-target-group-cfn.js";
+
+/**
+ * The CloudFormation-facing value adapter for a simulated ELBv2 Resource.
+ */
+export function elbV2ValueAdapter(
+  properties: SimCfnResourceValueAdapterProperties,
+): SimCfnServiceValueAdapter {
+  const { simResource } = properties;
+
+  if (
+    properties.type === "AWS::ElasticLoadBalancingV2::LoadBalancer" &&
+    simResource instanceof SimElbV2LoadBalancer
+  ) {
+    return new SimElbV2LoadBalancerCfn({ loadBalancer: simResource });
+  }
+
+  if (
+    properties.type === "AWS::ElasticLoadBalancingV2::TargetGroup" &&
+    simResource instanceof SimElbV2TargetGroup
+  ) {
+    return new SimElbV2TargetGroupCfn({ targetGroup: simResource });
+  }
+
+  if (
+    properties.type === "AWS::ElasticLoadBalancingV2::Listener" &&
+    simResource instanceof SimElbV2Listener
+  ) {
+    return new SimElbV2ListenerCfn({ listener: simResource });
+  }
+
+  if (
+    properties.type === "AWS::ElasticLoadBalancingV2::ListenerRule" &&
+    simResource instanceof SimElbV2ListenerRule
+  ) {
+    return new SimElbV2ListenerRuleCfn({ rule: simResource });
+  }
+
+  return undefined;
+}

--- a/src/service/cloudformation/resource/cfn/elasticloadbalancingv2/sim-elbv2-listener-cfn.ts
+++ b/src/service/cloudformation/resource/cfn/elasticloadbalancingv2/sim-elbv2-listener-cfn.ts
@@ -1,0 +1,96 @@
+import type { SimElbV2ListenerRule } from "../../../../elbv2/listener/rule/sim-elbv2-listener-rule.js";
+import type { SimElbV2Listener } from "../../../../elbv2/listener/sim-elbv2-listener.js";
+import type { SimCfnTemplateValue } from "../../../template/value/sim-cfn-template-value.js";
+import type { SimCfnResourceValueAdapter } from "../sim-cfn-resource-value-adapter.js";
+
+interface SimElbV2ListenerCfnProperties {
+  readonly listener: SimElbV2Listener;
+}
+
+/**
+ * CloudFormation-facing values for a simulated listener.
+ */
+export class SimElbV2ListenerCfn implements SimCfnResourceValueAdapter {
+  private readonly listener: SimElbV2Listener;
+
+  constructor(properties: SimElbV2ListenerCfnProperties) {
+    this.listener = properties.listener;
+  }
+
+  /**
+   * AWS::ElasticLoadBalancingV2::Listener Ref returns the ARN.
+   *
+   * That is what a rule's `ListenerArn` takes, so a stack declaring rules on a
+   * listener refers to it this way.
+   */
+  refValue(): SimCfnTemplateValue {
+    return this.listener.arn;
+  }
+
+  /**
+   * AWS::ElasticLoadBalancingV2::Listener attributes.
+   *
+   * `ListenerArn` is the only one, and it answers with the same ARN Ref does.
+   */
+  attributeValue(attributeName: string): SimCfnTemplateValue {
+    if (attributeName !== "ListenerArn") {
+      throw new Error(
+        `Unsupported AWS::ElasticLoadBalancingV2::Listener attribute ${
+          attributeName
+        }`,
+      );
+    }
+
+    return this.listener.arn;
+  }
+}
+
+interface SimElbV2ListenerRuleCfnProperties {
+  readonly rule: SimElbV2ListenerRule;
+}
+
+/**
+ * CloudFormation-facing values for a simulated listener rule.
+ *
+ * It sits beside the listener adapter because the two are the same three lines
+ * about the same ARN, and a rule has nothing else a template can read.
+ */
+export class SimElbV2ListenerRuleCfn implements SimCfnResourceValueAdapter {
+  private readonly rule: SimElbV2ListenerRule;
+
+  constructor(properties: SimElbV2ListenerRuleCfnProperties) {
+    this.rule = properties.rule;
+  }
+
+  /**
+   * AWS::ElasticLoadBalancingV2::ListenerRule Ref returns the ARN.
+   */
+  refValue(): SimCfnTemplateValue {
+    return this.rule.arn;
+  }
+
+  /**
+   * AWS::ElasticLoadBalancingV2::ListenerRule attributes.
+   *
+   * `IsDefault` is always false. A listener's default action is the listener
+   * rather than a rule, so nothing a template declares as a ListenerRule can
+   * be the default one.
+   */
+  attributeValue(attributeName: string): SimCfnTemplateValue {
+    switch (attributeName) {
+      case "RuleArn": {
+        return this.rule.arn;
+      }
+      case "IsDefault": {
+        return false;
+      }
+      default: {
+        throw new Error(
+          `Unsupported AWS::ElasticLoadBalancingV2::ListenerRule attribute ${
+            attributeName
+          }`,
+        );
+      }
+    }
+  }
+}

--- a/src/service/cloudformation/resource/cfn/elasticloadbalancingv2/sim-elbv2-load-balancer-cfn.ts
+++ b/src/service/cloudformation/resource/cfn/elasticloadbalancingv2/sim-elbv2-load-balancer-cfn.ts
@@ -1,0 +1,81 @@
+import type { SimElbV2LoadBalancer } from "../../../../elbv2/load-balancer/sim-elbv2-load-balancer.js";
+import { simElbV2CanonicalHostedZoneId } from "../../../../elbv2/load-balancer/sim-elbv2-load-balancer-arn.js";
+import type { SimCfnTemplateValue } from "../../../template/value/sim-cfn-template-value.js";
+import type { SimCfnResourceValueAdapter } from "../sim-cfn-resource-value-adapter.js";
+
+interface SimElbV2LoadBalancerCfnProperties {
+  readonly loadBalancer: SimElbV2LoadBalancer;
+}
+
+/**
+ * CloudFormation-facing values for a simulated load balancer.
+ */
+export class SimElbV2LoadBalancerCfn implements SimCfnResourceValueAdapter {
+  private readonly loadBalancer: SimElbV2LoadBalancer;
+
+  constructor(properties: SimElbV2LoadBalancerCfnProperties) {
+    this.loadBalancer = properties.loadBalancer;
+  }
+
+  /**
+   * AWS::ElasticLoadBalancingV2::LoadBalancer Ref returns the ARN.
+   *
+   * That is what a listener's `LoadBalancerArn` takes, which is the reference
+   * nearly every load balancer stack carries.
+   */
+  refValue(): SimCfnTemplateValue {
+    return this.loadBalancer.arn;
+  }
+
+  /**
+   * AWS::ElasticLoadBalancingV2::LoadBalancer attributes.
+   *
+   * `DNSName` is the one a stack does something with: a Route53 alias or a
+   * CloudFront origin points at it, and here as on AWS that name is the only
+   * way a request reaches the load balancer.
+   *
+   * `SecurityGroups` is a real attribute this cannot answer, because nothing
+   * places a simulated load balancer behind a security group. It is refused
+   * rather than answered with an empty list, which would read as a load
+   * balancer that has none.
+   */
+  attributeValue(attributeName: string): SimCfnTemplateValue {
+    switch (attributeName) {
+      case "DNSName": {
+        return this.loadBalancer.dnsName;
+      }
+      case "LoadBalancerName": {
+        return this.loadBalancer.name;
+      }
+      case "LoadBalancerFullName": {
+        return simElbV2LoadBalancerFullName(this.loadBalancer);
+      }
+      case "CanonicalHostedZoneID": {
+        return simElbV2CanonicalHostedZoneId;
+      }
+      default: {
+        throw new Error(
+          `Unsupported AWS::ElasticLoadBalancingV2::LoadBalancer attribute ${
+            attributeName
+          }`,
+        );
+      }
+    }
+  }
+}
+
+/**
+ * The full name of a load balancer, which is the part of its ARN that names
+ * it: `app/<name>/<id>`.
+ *
+ * It is what a CloudWatch metric dimension and an access log prefix carry,
+ * where the ARN itself would not fit, so a stack reads it rather than building
+ * it out of the name.
+ */
+function simElbV2LoadBalancerFullName(
+  loadBalancer: SimElbV2LoadBalancer,
+): string {
+  const [, resource = ""] = loadBalancer.arn.split(":loadbalancer/", 2);
+
+  return resource;
+}

--- a/src/service/cloudformation/resource/cfn/elasticloadbalancingv2/sim-elbv2-load-balancer-cfn.ts
+++ b/src/service/cloudformation/resource/cfn/elasticloadbalancingv2/sim-elbv2-load-balancer-cfn.ts
@@ -34,6 +34,9 @@ export class SimElbV2LoadBalancerCfn implements SimCfnResourceValueAdapter {
    * CloudFront origin points at it, and here as on AWS that name is the only
    * way a request reaches the load balancer.
    *
+   * `LoadBalancerArn` answers with the same ARN Ref does, which is the pair
+   * real CloudFormation has for this Resource.
+   *
    * `SecurityGroups` is a real attribute this cannot answer, because nothing
    * places a simulated load balancer behind a security group. It is refused
    * rather than answered with an empty list, which would read as a load
@@ -43,6 +46,9 @@ export class SimElbV2LoadBalancerCfn implements SimCfnResourceValueAdapter {
     switch (attributeName) {
       case "DNSName": {
         return this.loadBalancer.dnsName;
+      }
+      case "LoadBalancerArn": {
+        return this.loadBalancer.arn;
       }
       case "LoadBalancerName": {
         return this.loadBalancer.name;

--- a/src/service/cloudformation/resource/cfn/elasticloadbalancingv2/sim-elbv2-target-group-cfn.ts
+++ b/src/service/cloudformation/resource/cfn/elasticloadbalancingv2/sim-elbv2-target-group-cfn.ts
@@ -1,0 +1,71 @@
+import type { SimElbV2TargetGroup } from "../../../../elbv2/target-group/sim-elbv2-target-group.js";
+import type { SimCfnTemplateValue } from "../../../template/value/sim-cfn-template-value.js";
+import type { SimCfnResourceValueAdapter } from "../sim-cfn-resource-value-adapter.js";
+
+interface SimElbV2TargetGroupCfnProperties {
+  readonly targetGroup: SimElbV2TargetGroup;
+}
+
+/**
+ * CloudFormation-facing values for a simulated target group.
+ */
+export class SimElbV2TargetGroupCfn implements SimCfnResourceValueAdapter {
+  private readonly targetGroup: SimElbV2TargetGroup;
+
+  constructor(properties: SimElbV2TargetGroupCfnProperties) {
+    this.targetGroup = properties.targetGroup;
+  }
+
+  /**
+   * AWS::ElasticLoadBalancingV2::TargetGroup Ref returns the ARN.
+   *
+   * That is what a forward action names, which is how a listener or a rule
+   * reaches a target group.
+   */
+  refValue(): SimCfnTemplateValue {
+    return this.targetGroup.arn;
+  }
+
+  /**
+   * AWS::ElasticLoadBalancingV2::TargetGroup attributes.
+   *
+   * `LoadBalancerArns` is a real attribute this cannot answer. Nothing records
+   * on a target group which load balancers forward to it, because a rule can
+   * be written and deleted without the group hearing about it, and the answer
+   * is read back out of the listeners instead. `DescribeTargetGroups` reports
+   * it, so a test that wants it has somewhere to read it.
+   */
+  attributeValue(attributeName: string): SimCfnTemplateValue {
+    switch (attributeName) {
+      case "TargetGroupArn": {
+        return this.targetGroup.arn;
+      }
+      case "TargetGroupName": {
+        return this.targetGroup.name;
+      }
+      case "TargetGroupFullName": {
+        return simElbV2TargetGroupFullName(this.targetGroup);
+      }
+      default: {
+        throw new Error(
+          `Unsupported AWS::ElasticLoadBalancingV2::TargetGroup attribute ${
+            attributeName
+          }`,
+        );
+      }
+    }
+  }
+}
+
+/**
+ * The full name of a target group, which is the part of its ARN that names it:
+ * `targetgroup/<name>/<id>`.
+ *
+ * It is the other half of the CloudWatch metric dimension a load balancer's
+ * full name is one half of.
+ */
+function simElbV2TargetGroupFullName(targetGroup: SimElbV2TargetGroup): string {
+  const [, resource = ""] = targetGroup.arn.split(":targetgroup/", 2);
+
+  return `targetgroup/${resource}`;
+}

--- a/src/service/cloudformation/resource/cfn/sim-cfn-resource-value-adapter.ts
+++ b/src/service/cloudformation/resource/cfn/sim-cfn-resource-value-adapter.ts
@@ -6,6 +6,7 @@ import { cognitoValueAdapter } from "./cognito/sim-cognito-cfn-value-adapter.js"
 import { dynamoDbValueAdapter } from "./dynamodb/sim-dynamodb-cfn-value-adapter.js";
 import { ecrValueAdapter } from "./ecr/sim-ecr-cfn-value-adapter.js";
 import { ecsValueAdapter } from "./ecs/sim-ecs-cfn-value-adapter.js";
+import { elbV2ValueAdapter } from "./elasticloadbalancingv2/sim-elbv2-cfn-value-adapter.js";
 import { eventBridgeValueAdapter } from "./events/sim-event-bridge-cfn-value-adapter.js";
 import { iamValueAdapter } from "./iam/sim-iam-cfn-value-adapter.js";
 import { kmsValueAdapter } from "./kms/sim-kms-cfn-value-adapter.js";
@@ -60,6 +61,7 @@ export function simCfnResourceValueAdapter(
     dynamoDbValueAdapter(properties) ??
     ecrValueAdapter(properties) ??
     ecsValueAdapter(properties) ??
+    elbV2ValueAdapter(properties) ??
     eventBridgeValueAdapter(properties) ??
     iamValueAdapter(properties) ??
     kmsValueAdapter(properties) ??

--- a/src/service/cloudformation/resource/resolve/service/sim-cfn-service-factories.ts
+++ b/src/service/cloudformation/resource/resolve/service/sim-cfn-service-factories.ts
@@ -70,6 +70,11 @@ export const simCfnServiceResourceFactories: ReadonlyMap<
       scopedAws.ecs().cfnResourceFactory(),
   ],
   [
+    "ElasticLoadBalancingV2",
+    (scopedAws): SimCfnServiceResourceFactory =>
+      scopedAws.elbV2().cfnResourceFactory(),
+  ],
+  [
     "IAM",
     (scopedAws): SimCfnServiceResourceFactory =>
       scopedAws.iam().cfnResourceFactory(),

--- a/src/service/elbv2/README.md
+++ b/src/service/elbv2/README.md
@@ -13,6 +13,7 @@ is the part that does it.
 
 - `sim-elbv2.ts` is the main in-memory service object for one account/region scope.
 - `serve/sim-elbv2-fetch.ts` is how a request reaches a load balancer.
+- `cfn/sim-elbv2-cfn-resource-factory.ts` is how a CloudFormation Stack creates one.
 - `index.ts` exports the public ELBv2 simulator API for `@kensio/yulin/elbv2`.
 
 A `SimElbV2` instance owns a `SimElbV2Stores` holding its four resources. The simulator is scoped to
@@ -154,6 +155,39 @@ like any other simulated host. What the load balancer sees as the request's host
 AWS-facing one, which `simAwsRequestHostname` reads: that is the name a `host-header` condition is
 matched against and the `host` header an invocation event carries, so routing by name and the event
 agree with what a client asked for.
+
+## Deploying from CloudFormation
+
+`cfn/` owns the four `AWS::ElasticLoadBalancingV2::*` Resource types, as the architecture requires:
+CloudFormation orchestrates and the service creates. Each Resource type has a creator that reads its
+properties and then calls the ordinary command, so a template's listener is the same listener an SDK
+caller would have created, refusals included. That is what makes a rule declared in a template match
+requests the way the same rule made by hand does: there is no second model of an action or a
+condition, only the one `SimElbV2Action` and `SimElbV2RuleCondition` read.
+
+CloudFormation spells every ELBv2 property the way the API spells it, so nothing translates names.
+`SimCfnElbV2PropertyReader` checks that a declared value is the shape the property takes and hands it
+on, which is why a declared `DefaultActions` list can go straight into `CreateListener` input.
+Numbers and booleans are read rather than passed through, because a template carries either as a
+string when it came from a Parameter. Targets are read entry by entry for the same reason: a target
+registered on the string `"80"` would be a different target from one registered on `80`.
+
+`SimCfnElbV2PropertyRules` is one class taking two lists per Resource type, since all four have the
+same shape of question and only the answers differ. What a Resource declares and this simulation has
+no network to apply is recorded and left out rather than failing the stack.
+
+`SimElbV2CfnResourceDeleter` is held apart from the factory because the two dispatch over the same
+four Resource types, and one file doing both scores higher on complexity than anything else in the
+service without saying anything either half does not. Nothing there cascades: the stack tears down in
+reverse dependency order, so a rule is gone before its listener and a target group after everything
+forwarding to it.
+
+The Ref and Fn::GetAtt answers live with simulated CloudFormation, under
+`resource/cfn/elasticloadbalancingv2/`, as every service's do. `LoadBalancerFullName` and
+`TargetGroupFullName` are read back off the ARN rather than stored, since the ARN is where they
+already are. `SecurityGroups` and `LoadBalancerArns` are refused rather than answered with an empty
+list, which would read as a load balancer that has no security groups rather than a simulation that
+has none.
 
 ## Authorization
 

--- a/src/service/elbv2/cfn/listener/sim-cfn-elbv2-listener-creator.ts
+++ b/src/service/elbv2/cfn/listener/sim-cfn-elbv2-listener-creator.ts
@@ -1,0 +1,71 @@
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimElbV2Listener } from "../../listener/sim-elbv2-listener.js";
+import type { SimElbV2 } from "../../sim-elbv2.js";
+import type { SimElbV2Stores } from "../../sim-elbv2-stores.js";
+import { SimCfnElbV2ListenerProperties } from "./sim-cfn-elbv2-listener-properties.js";
+
+interface SimCfnElbV2ListenerCreatorProperties {
+  readonly elbV2: SimElbV2;
+  readonly stores: SimElbV2Stores;
+}
+
+/**
+ * Creates simulated listeners from AWS::ElasticLoadBalancingV2::Listener
+ * Resources.
+ *
+ * A declared `Certificates` list goes through CreateListener, so a certificate
+ * an AWS::CertificateManager::Certificate in the same stack created is
+ * resolved against simulated ACM the same way an SDK caller's is: one that was
+ * never issued, or that belongs to another Account or Region, fails the
+ * deployment rather than leaving a listener that could not serve.
+ */
+export class SimCfnElbV2ListenerCreator {
+  private readonly elbV2: SimElbV2;
+  private readonly stores: SimElbV2Stores;
+
+  constructor(properties: SimCfnElbV2ListenerCreatorProperties) {
+    this.elbV2 = properties.elbV2;
+    this.stores = properties.stores;
+  }
+
+  /**
+   * Create a listener from a Listener Resource.
+   */
+  async create(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): Promise<SimElbV2Listener> {
+    const declared = new SimCfnElbV2ListenerProperties({
+      resource,
+      properties,
+    });
+    const input = declared.createListenerInput();
+
+    declared.recordIgnoredProperties();
+
+    const created = await this.elbV2.createListener({ input });
+    const listenerArn = created.Listeners?.[0]?.ListenerArn;
+
+    assertDefined(
+      listenerArn,
+      `sim ELBv2 listener ARN after CloudFormation creation for ${
+        resource.logicalId
+      }`,
+    );
+
+    return this.stores.listeners.requireByArn(listenerArn);
+  }
+
+  /**
+   * Delete a listener created from a Listener Resource.
+   *
+   * Its rules come down with it, as they do on real ELB.
+   */
+  async delete(listener: SimElbV2Listener): Promise<void> {
+    await this.elbV2.deleteListener({
+      input: { ListenerArn: listener.arn },
+    });
+  }
+}

--- a/src/service/elbv2/cfn/listener/sim-cfn-elbv2-listener-properties.ts
+++ b/src/service/elbv2/cfn/listener/sim-cfn-elbv2-listener-properties.ts
@@ -1,0 +1,99 @@
+import type { SimCreateListenerCommandInput } from "../../command/listener/listener.command.js";
+import type {
+  SimElbV2ActionInput,
+  SimElbV2Certificate,
+  SimElbV2Tag,
+} from "../../command/sim-elbv2-shared.command.js";
+import type { SimCfnElbV2DeclaredResource } from "../property/sim-cfn-elbv2-declared-resource.js";
+import { SimCfnElbV2PropertyReader } from "../property/sim-cfn-elbv2-property-reader.js";
+import { SimCfnElbV2PropertyRules } from "../property/sim-cfn-elbv2-property-rules.js";
+
+/**
+ * The properties a listener is created with.
+ */
+const actedOnProperties: ReadonlySet<string> = new Set([
+  "LoadBalancerArn",
+  "Protocol",
+  "Port",
+  "SslPolicy",
+  "Certificates",
+  "DefaultActions",
+  "Tags",
+]);
+
+/**
+ * The real AWS::ElasticLoadBalancingV2::Listener properties this simulation
+ * has nothing to act on, and why.
+ *
+ * All three are about the TLS handshake or the connection under it, and no
+ * handshake happens here: a listener's protocol says how a request is treated
+ * rather than how it arrived.
+ */
+const unsimulatedPropertyReasons: ReadonlyMap<string, string> = new Map([
+  [
+    "AlpnPolicy",
+    "no TLS handshake happens here, so nothing negotiates a protocol with a " +
+      "client",
+  ],
+  [
+    "MutualAuthentication",
+    "no TLS handshake happens here, so no client certificate is asked for " +
+      "or verified",
+  ],
+  [
+    "ListenerAttributes",
+    "the attributes change how a real listener handles connections, and " +
+      "there are no connections here to handle",
+  ],
+]);
+
+/**
+ * Reads AWS::ElasticLoadBalancingV2::Listener properties into CreateListener
+ * input.
+ *
+ * `DefaultActions` and `Certificates` are handed on in the shape the template
+ * wrote them, which is the shape the API takes, so a template's default action
+ * is read by the same model an SDK caller's is and refused for the same
+ * reasons.
+ */
+export class SimCfnElbV2ListenerProperties {
+  private readonly reader: SimCfnElbV2PropertyReader;
+  private readonly rules: SimCfnElbV2PropertyRules;
+
+  constructor(declared: SimCfnElbV2DeclaredResource) {
+    const { resource, properties } = declared;
+
+    this.reader = new SimCfnElbV2PropertyReader({ resource, properties });
+    this.rules = new SimCfnElbV2PropertyRules({
+      resourceTypeName: "Listener",
+      described: "listener",
+      properties,
+      ignorer: resource,
+      actedOn: actedOnProperties,
+      unsimulated: unsimulatedPropertyReasons,
+    });
+  }
+
+  /**
+   * The CreateListener input this Resource declares.
+   */
+  createListenerInput(): SimCreateListenerCommandInput {
+    return {
+      LoadBalancerArn: this.reader.text("LoadBalancerArn"),
+      Protocol: this.reader.text("Protocol"),
+      Port: this.reader.number("Port"),
+      SslPolicy: this.reader.text("SslPolicy"),
+      Certificates: this.reader.structures<SimElbV2Certificate>("Certificates"),
+      DefaultActions:
+        this.reader.structures<SimElbV2ActionInput>("DefaultActions"),
+      Tags: this.reader.structures<SimElbV2Tag>("Tags"),
+    };
+  }
+
+  /**
+   * Record the properties the listener is created without acting on.
+   */
+  recordIgnoredProperties(): void {
+    this.rules.apply();
+  }
+}

--- a/src/service/elbv2/cfn/load-balancer/sim-cfn-elbv2-load-balancer-creator.ts
+++ b/src/service/elbv2/cfn/load-balancer/sim-cfn-elbv2-load-balancer-creator.ts
@@ -1,0 +1,63 @@
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimElbV2LoadBalancer } from "../../load-balancer/sim-elbv2-load-balancer.js";
+import type { SimElbV2 } from "../../sim-elbv2.js";
+import type { SimElbV2Stores } from "../../sim-elbv2-stores.js";
+import { SimCfnElbV2LoadBalancerProperties } from "./sim-cfn-elbv2-load-balancer-properties.js";
+
+interface SimCfnElbV2LoadBalancerCreatorProperties {
+  readonly elbV2: SimElbV2;
+  readonly stores: SimElbV2Stores;
+}
+
+/**
+ * Creates simulated load balancers from
+ * AWS::ElasticLoadBalancingV2::LoadBalancer Resources.
+ *
+ * The load balancer is created through the ordinary CreateLoadBalancer command
+ * rather than constructed directly, so one a template deployed is the same
+ * thing an SDK caller would have got: the same name rules, the same refusal of
+ * a network load balancer, and the same DNS name.
+ */
+export class SimCfnElbV2LoadBalancerCreator {
+  private readonly elbV2: SimElbV2;
+  private readonly stores: SimElbV2Stores;
+
+  constructor(properties: SimCfnElbV2LoadBalancerCreatorProperties) {
+    this.elbV2 = properties.elbV2;
+    this.stores = properties.stores;
+  }
+
+  /**
+   * Create a load balancer from a LoadBalancer Resource.
+   */
+  async create(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): Promise<SimElbV2LoadBalancer> {
+    const declared = new SimCfnElbV2LoadBalancerProperties({
+      resource,
+      properties,
+    });
+    const input = declared.createLoadBalancerInput();
+
+    declared.recordIgnoredProperties();
+
+    await this.elbV2.createLoadBalancer({ input });
+
+    return this.stores.loadBalancers.requireByName(declared.name());
+  }
+
+  /**
+   * Delete a load balancer created from a LoadBalancer Resource.
+   *
+   * Its listeners and rules come down with it, as they do on real ELB. The
+   * teardown has already deleted them itself, since each of them names the
+   * load balancer, so what this removes is usually the load balancer alone.
+   */
+  async delete(loadBalancer: SimElbV2LoadBalancer): Promise<void> {
+    await this.elbV2.deleteLoadBalancer({
+      input: { LoadBalancerArn: loadBalancer.arn },
+    });
+  }
+}

--- a/src/service/elbv2/cfn/load-balancer/sim-cfn-elbv2-load-balancer-properties.ts
+++ b/src/service/elbv2/cfn/load-balancer/sim-cfn-elbv2-load-balancer-properties.ts
@@ -1,0 +1,113 @@
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCreateLoadBalancerCommandInput } from "../../command/load-balancer/load-balancer.command.js";
+import type { SimElbV2Tag } from "../../command/sim-elbv2-shared.command.js";
+import { simCfnElbV2GeneratedName } from "../name/sim-cfn-elbv2-name.js";
+import type { SimCfnElbV2DeclaredResource } from "../property/sim-cfn-elbv2-declared-resource.js";
+import { SimCfnElbV2PropertyReader } from "../property/sim-cfn-elbv2-property-reader.js";
+import { SimCfnElbV2PropertyRules } from "../property/sim-cfn-elbv2-property-rules.js";
+
+/**
+ * The properties a load balancer is created with.
+ */
+const actedOnProperties: ReadonlySet<string> = new Set([
+  "Name",
+  "Scheme",
+  "Type",
+  "IpAddressType",
+  "Tags",
+]);
+
+/**
+ * The real AWS::ElasticLoadBalancingV2::LoadBalancer properties this
+ * simulation has nothing to act on, and why.
+ *
+ * All of them describe where a load balancer sits on a network, and there is
+ * no network here for it to sit on. A load balancer here is reached by its DNS
+ * name and nothing else, so a subnet or a security group would be held and
+ * never consulted.
+ */
+const unsimulatedPropertyReasons: ReadonlyMap<string, string> = new Map([
+  [
+    "Subnets",
+    "there is no VPC here, so a load balancer answers on its DNS name " +
+      "rather than in a subnet",
+  ],
+  [
+    "SubnetMappings",
+    "there is no VPC here, so nothing places a load balancer in a subnet or " +
+      "gives it an address there",
+  ],
+  [
+    "SecurityGroups",
+    "nothing filters traffic reaching a simulated load balancer, so a " +
+      "security group would allow and deny nothing",
+  ],
+  [
+    "LoadBalancerAttributes",
+    "the attributes change how a real load balancer handles connections, " +
+      "and there are no connections here to handle",
+  ],
+  [
+    "EnforceSecurityGroupInboundRulesOnPrivateLinkTraffic",
+    "there are no security groups and no PrivateLink traffic here",
+  ],
+]);
+
+/**
+ * Reads AWS::ElasticLoadBalancingV2::LoadBalancer properties into
+ * CreateLoadBalancer input.
+ *
+ * CloudFormation spells these the way the API does, so this is the name a
+ * template left out and a check that what it did declare is the right shape.
+ */
+export class SimCfnElbV2LoadBalancerProperties {
+  private readonly resource: SimCfnResource;
+  private readonly reader: SimCfnElbV2PropertyReader;
+  private readonly rules: SimCfnElbV2PropertyRules;
+
+  constructor(declared: SimCfnElbV2DeclaredResource) {
+    const { resource, properties } = declared;
+
+    this.resource = resource;
+    this.reader = new SimCfnElbV2PropertyReader({ resource, properties });
+    this.rules = new SimCfnElbV2PropertyRules({
+      resourceTypeName: "LoadBalancer",
+      described: "load balancer",
+      properties,
+      ignorer: resource,
+      actedOn: actedOnProperties,
+      unsimulated: unsimulatedPropertyReasons,
+    });
+  }
+
+  /**
+   * The CreateLoadBalancer input this Resource declares.
+   */
+  createLoadBalancerInput(): SimCreateLoadBalancerCommandInput {
+    return {
+      Name: this.name(),
+      Scheme: this.reader.text("Scheme"),
+      Type: this.reader.text("Type"),
+      IpAddressType: this.reader.text("IpAddressType"),
+      Tags: this.reader.structures<SimElbV2Tag>("Tags"),
+    };
+  }
+
+  /**
+   * The load balancer name.
+   *
+   * An unnamed load balancer is named after the stack and the logical ID, as
+   * real CloudFormation names one, minus the random part so a test can predict
+   * it.
+   */
+  name(): string {
+    return this.reader.text("Name") ?? simCfnElbV2GeneratedName(this.resource);
+  }
+
+  /**
+   * Record the properties the load balancer is created without acting on.
+   */
+  recordIgnoredProperties(): void {
+    this.rules.apply();
+  }
+}

--- a/src/service/elbv2/cfn/name/sim-cfn-elbv2-name.ts
+++ b/src/service/elbv2/cfn/name/sim-cfn-elbv2-name.ts
@@ -1,0 +1,20 @@
+import { SimCfnGeneratedResourceName } from "../../../cloudformation/resource/name/sim-cfn-generated-resource-name.js";
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import { maximumSimElbV2NameLength } from "../../sim-elbv2-resource-name.js";
+
+/**
+ * The name CloudFormation gives a load balancer or target group whose template
+ * does not name it.
+ *
+ * Both are named under the same rules, so both generate a name the same way.
+ * Thirty-two characters is short for a name made of a stack name and a logical
+ * ID, so the trimming `SimCfnGeneratedResourceName` does is the usual case
+ * here rather than the exception.
+ */
+export function simCfnElbV2GeneratedName(resource: SimCfnResource): string {
+  return new SimCfnGeneratedResourceName({
+    stackName: resource.stackName,
+    logicalId: resource.logicalId,
+    maximumLength: maximumSimElbV2NameLength,
+  }).value;
+}

--- a/src/service/elbv2/cfn/property/sim-cfn-elbv2-declared-resource.ts
+++ b/src/service/elbv2/cfn/property/sim-cfn-elbv2-declared-resource.ts
@@ -1,0 +1,14 @@
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+
+/**
+ * One ELBv2 Resource of a template, and the properties it declared.
+ *
+ * The two travel together everywhere in here: the properties are what is read,
+ * and the Resource is what a refusal names and what an ignored property is
+ * recorded against.
+ */
+export interface SimCfnElbV2DeclaredResource {
+  readonly resource: SimCfnResource;
+  readonly properties: SimCfnTemplateValueRecord;
+}

--- a/src/service/elbv2/cfn/property/sim-cfn-elbv2-property-error.ts
+++ b/src/service/elbv2/cfn/property/sim-cfn-elbv2-property-error.ts
@@ -1,0 +1,15 @@
+/**
+ * A refusal naming the Resource whose properties could not be read.
+ *
+ * Every refusal from this factory carries the logical ID, because a stack
+ * holding several listeners and target groups gives a reader nothing else to
+ * tell them apart by.
+ */
+export function simCfnElbV2PropertyError(
+  logicalId: string,
+  reason: string,
+): Error {
+  return new Error(
+    `Invalid sim ELBv2 CloudFormation Resource ${logicalId}: ${reason}`,
+  );
+}

--- a/src/service/elbv2/cfn/property/sim-cfn-elbv2-property-reader.ts
+++ b/src/service/elbv2/cfn/property/sim-cfn-elbv2-property-reader.ts
@@ -1,0 +1,174 @@
+import { isRecord } from "../../../../util/type-guard/record.js";
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type {
+  SimCfnTemplateValue,
+  SimCfnTemplateValueRecord,
+} from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimCfnElbV2DeclaredResource } from "./sim-cfn-elbv2-declared-resource.js";
+import { simCfnElbV2PropertyError } from "./sim-cfn-elbv2-property-error.js";
+
+/**
+ * Reads the property shapes an ELBv2 Resource template can hold.
+ *
+ * CloudFormation spells every ELBv2 property the way the API spells it, so
+ * nothing here translates names. What it does is check that a declared value
+ * is the shape the property takes, and refuse one that is not, naming the
+ * Resource and the property rather than letting the ELBv2 command refuse
+ * something it cannot say where came from.
+ *
+ * A list of structures is read as a list of objects and handed on unchanged,
+ * so a listener's actions and a rule's conditions reach the same model an SDK
+ * caller's would.
+ */
+export class SimCfnElbV2PropertyReader {
+  private readonly resource: SimCfnResource;
+  private readonly properties: SimCfnTemplateValueRecord;
+
+  constructor(declared: SimCfnElbV2DeclaredResource) {
+    this.resource = declared.resource;
+    this.properties = declared.properties;
+  }
+
+  /**
+   * A property that is a string, where the template declared one.
+   */
+  text(name: string): string | undefined {
+    const value = this.declared(name);
+
+    if (value === undefined) {
+      return undefined;
+    }
+
+    if (typeof value !== "string") {
+      throw this.refuse(`${name} is a string`);
+    }
+
+    return value;
+  }
+
+  /**
+   * A property that is a number, where the template declared one.
+   *
+   * CloudFormation carries a number as a string when it came from a template
+   * Parameter, so a numeric string reads as the number it spells.
+   */
+  number(name: string): number | undefined {
+    const value = this.declared(name);
+
+    if (value === undefined) {
+      return undefined;
+    }
+
+    const parsed = readSimCfnElbV2Number(value);
+
+    if (parsed === undefined) {
+      throw this.refuse(`${name} is a number`);
+    }
+
+    return parsed;
+  }
+
+  /**
+   * A property that is a boolean, where the template declared one.
+   */
+  boolean(name: string): boolean | undefined {
+    const value = this.declared(name);
+
+    if (value === undefined) {
+      return undefined;
+    }
+
+    if (value === true || value === "true") {
+      return true;
+    }
+
+    if (value === false || value === "false") {
+      return false;
+    }
+
+    throw this.refuse(`${name} is a boolean`);
+  }
+
+  /**
+   * A property that is a list of structures, where the template declared one.
+   *
+   * The entries are handed on in the shape the template wrote them, which is
+   * the shape the ELBv2 command takes, so a declared action or condition is
+   * read by the same code an SDK caller's is.
+   */
+  structures<T>(name: string): readonly T[] | undefined {
+    const value = this.declared(name);
+
+    if (value === undefined) {
+      return undefined;
+    }
+
+    if (!Array.isArray(value)) {
+      throw this.refuse(`${name} is a list`);
+    }
+
+    return value.map((entry, index) => {
+      if (!isRecord(entry)) {
+        throw this.refuse(`${name} entry ${String(index)} is an object`);
+      }
+
+      return entry as T;
+    });
+  }
+
+  /**
+   * A property that is a structure, where the template declared one.
+   */
+  structure<T>(name: string): T | undefined {
+    const value = this.declared(name);
+
+    if (value === undefined) {
+      return undefined;
+    }
+
+    if (!isRecord(value)) {
+      throw this.refuse(`${name} is an object`);
+    }
+
+    return value as T;
+  }
+
+  /**
+   * A refusal naming this Resource.
+   */
+  refuse(reason: string): Error {
+    return simCfnElbV2PropertyError(this.resource.logicalId, reason);
+  }
+
+  /**
+   * The value the template wrote for a property, whatever shape it is.
+   *
+   * The name always comes from this service's own fixed list of the properties
+   * an ELBv2 Resource has, never from the template.
+   */
+  private declared(name: string): SimCfnTemplateValue | undefined {
+    // oxlint-disable-next-line security/detect-object-injection -- fixed property names.
+    return this.properties[name];
+  }
+}
+
+/**
+ * Read a template value as a number, or as nothing when it is not one.
+ */
+function readSimCfnElbV2Number(value: SimCfnTemplateValue): number | undefined {
+  if (typeof value === "number") {
+    return value;
+  }
+
+  if (typeof value !== "string" || value.trim() === "") {
+    return undefined;
+  }
+
+  const parsed = Number(value);
+
+  if (Number.isNaN(parsed)) {
+    return undefined;
+  }
+
+  return parsed;
+}

--- a/src/service/elbv2/cfn/property/sim-cfn-elbv2-property-rules.ts
+++ b/src/service/elbv2/cfn/property/sim-cfn-elbv2-property-rules.ts
@@ -1,0 +1,77 @@
+import type { SimCfnPropertyIgnorer } from "../../../cloudformation/resource/ignore/sim-cfn-ignored-property.type.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+
+interface SimCfnElbV2PropertyRulesProperties {
+  /** The Resource type these rules are about, e.g. `LoadBalancer`. */
+  readonly resourceTypeName: string;
+  /** What that Resource is called in a sentence, e.g. `load balancer`. */
+  readonly described: string;
+  readonly properties: SimCfnTemplateValueRecord;
+  readonly ignorer: SimCfnPropertyIgnorer;
+  /** The properties the Resource is created with. */
+  readonly actedOn: ReadonlySet<string>;
+  /** The real properties this simulation has nothing to act on, and why. */
+  readonly unsimulated: ReadonlyMap<string, string>;
+}
+
+/**
+ * What an ELBv2 Resource is created without acting on.
+ *
+ * The four ELBv2 Resource types each declare plenty this simulation has no
+ * network to apply, so each of them names its own two lists and the walk over
+ * a template's properties is written once here.
+ *
+ * A declared property is never a reason to fail a deployment. A stack that
+ * will not deploy is worth less to a test than a load balancer that holds no
+ * subnets it was never going to hold, so what is not acted on is recorded and
+ * the Resource is created without it.
+ */
+export class SimCfnElbV2PropertyRules {
+  private readonly resourceTypeName: string;
+  private readonly described: string;
+  private readonly properties: SimCfnTemplateValueRecord;
+  private readonly ignorer: SimCfnPropertyIgnorer;
+  private readonly actedOn: ReadonlySet<string>;
+  private readonly unsimulated: ReadonlyMap<string, string>;
+
+  constructor(properties: SimCfnElbV2PropertyRulesProperties) {
+    this.resourceTypeName = properties.resourceTypeName;
+    this.described = properties.described;
+    this.properties = properties.properties;
+    this.ignorer = properties.ignorer;
+    this.actedOn = properties.actedOn;
+    this.unsimulated = properties.unsimulated;
+  }
+
+  /**
+   * Record every property the Resource is created without.
+   */
+  apply(): void {
+    for (const name of Object.keys(this.properties)) {
+      this.applyToProperty(name);
+    }
+  }
+
+  private applyToProperty(name: string): void {
+    if (this.actedOn.has(name)) {
+      return;
+    }
+
+    const unsimulatedReason = this.unsimulated.get(name);
+
+    if (unsimulatedReason === undefined) {
+      this.ignorer.ignoreProperty(
+        name,
+        `${name} is not a property simulated ELBv2 knows about, so the ` +
+          `${this.described} is created without it`,
+      );
+
+      return;
+    }
+
+    this.ignorer.ignoreProperty(
+      name,
+      `${name} is a real AWS::ElasticLoadBalancingV2::${this.resourceTypeName} property simulated ELBv2 does not act on: ${unsimulatedReason}`,
+    );
+  }
+}

--- a/src/service/elbv2/cfn/rule/sim-cfn-elbv2-listener-rule-creator.ts
+++ b/src/service/elbv2/cfn/rule/sim-cfn-elbv2-listener-rule-creator.ts
@@ -1,0 +1,66 @@
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimElbV2ListenerRule } from "../../listener/rule/sim-elbv2-listener-rule.js";
+import type { SimElbV2 } from "../../sim-elbv2.js";
+import type { SimElbV2Stores } from "../../sim-elbv2-stores.js";
+import { SimCfnElbV2ListenerRuleProperties } from "./sim-cfn-elbv2-listener-rule-properties.js";
+
+interface SimCfnElbV2ListenerRuleCreatorProperties {
+  readonly elbV2: SimElbV2;
+  readonly stores: SimElbV2Stores;
+}
+
+/**
+ * Creates simulated rules from AWS::ElasticLoadBalancingV2::ListenerRule
+ * Resources.
+ *
+ * Two rules on one listener at the same priority are refused, as they are
+ * through the SDK, because priority is what decides which of two matching
+ * rules claims a request. A stack that declares both is a stack whose routing
+ * has no defined outcome.
+ */
+export class SimCfnElbV2ListenerRuleCreator {
+  private readonly elbV2: SimElbV2;
+  private readonly stores: SimElbV2Stores;
+
+  constructor(properties: SimCfnElbV2ListenerRuleCreatorProperties) {
+    this.elbV2 = properties.elbV2;
+    this.stores = properties.stores;
+  }
+
+  /**
+   * Create a rule from a ListenerRule Resource.
+   */
+  async create(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): Promise<SimElbV2ListenerRule> {
+    const declared = new SimCfnElbV2ListenerRuleProperties({
+      resource,
+      properties,
+    });
+    const input = declared.createRuleInput();
+
+    declared.recordIgnoredProperties();
+
+    const created = await this.elbV2.createRule({ input });
+    const ruleArn = created.Rules?.[0]?.RuleArn;
+
+    assertDefined(
+      ruleArn,
+      `sim ELBv2 rule ARN after CloudFormation creation for ${
+        resource.logicalId
+      }`,
+    );
+
+    return this.stores.rules.requireByArn(ruleArn);
+  }
+
+  /**
+   * Delete a rule created from a ListenerRule Resource.
+   */
+  async delete(rule: SimElbV2ListenerRule): Promise<void> {
+    await this.elbV2.deleteRule({ input: { RuleArn: rule.arn } });
+  }
+}

--- a/src/service/elbv2/cfn/rule/sim-cfn-elbv2-listener-rule-properties.ts
+++ b/src/service/elbv2/cfn/rule/sim-cfn-elbv2-listener-rule-properties.ts
@@ -1,0 +1,70 @@
+import type { SimElbV2RuleConditionInput } from "../../command/rule/rule-condition.command.js";
+import type { SimCreateRuleCommandInput } from "../../command/rule/rule.command.js";
+import type { SimElbV2ActionInput } from "../../command/sim-elbv2-shared.command.js";
+import type { SimCfnElbV2DeclaredResource } from "../property/sim-cfn-elbv2-declared-resource.js";
+import { SimCfnElbV2PropertyReader } from "../property/sim-cfn-elbv2-property-reader.js";
+import { SimCfnElbV2PropertyRules } from "../property/sim-cfn-elbv2-property-rules.js";
+
+/**
+ * The properties a listener rule is created with, which is all of them.
+ */
+const actedOnProperties: ReadonlySet<string> = new Set([
+  "ListenerArn",
+  "Priority",
+  "Conditions",
+  "Actions",
+]);
+
+/**
+ * A listener rule declares nothing this simulation has to leave out.
+ */
+const unsimulatedPropertyReasons: ReadonlyMap<string, string> = new Map();
+
+/**
+ * Reads AWS::ElasticLoadBalancingV2::ListenerRule properties into CreateRule
+ * input.
+ *
+ * `Conditions` and `Actions` are handed on in the shape the template wrote
+ * them, so a declared condition is read by the same model an SDK caller's is.
+ * A field this simulation does not match on is refused there, which is what
+ * makes a template's rule behave the way the same rule created through the SDK
+ * would.
+ */
+export class SimCfnElbV2ListenerRuleProperties {
+  private readonly reader: SimCfnElbV2PropertyReader;
+  private readonly rules: SimCfnElbV2PropertyRules;
+
+  constructor(declared: SimCfnElbV2DeclaredResource) {
+    const { resource, properties } = declared;
+
+    this.reader = new SimCfnElbV2PropertyReader({ resource, properties });
+    this.rules = new SimCfnElbV2PropertyRules({
+      resourceTypeName: "ListenerRule",
+      described: "rule",
+      properties,
+      ignorer: resource,
+      actedOn: actedOnProperties,
+      unsimulated: unsimulatedPropertyReasons,
+    });
+  }
+
+  /**
+   * The CreateRule input this Resource declares.
+   */
+  createRuleInput(): SimCreateRuleCommandInput {
+    return {
+      ListenerArn: this.reader.text("ListenerArn"),
+      Priority: this.reader.number("Priority"),
+      Conditions:
+        this.reader.structures<SimElbV2RuleConditionInput>("Conditions"),
+      Actions: this.reader.structures<SimElbV2ActionInput>("Actions"),
+    };
+  }
+
+  /**
+   * Record the properties the rule is created without acting on.
+   */
+  recordIgnoredProperties(): void {
+    this.rules.apply();
+  }
+}

--- a/src/service/elbv2/cfn/sim-cfn-elbv2-listener-rule.iso.test.ts
+++ b/src/service/elbv2/cfn/sim-cfn-elbv2-listener-rule.iso.test.ts
@@ -1,0 +1,354 @@
+import { DescribeRulesCommand } from "@aws-sdk/client-elastic-load-balancing-v2";
+import {
+  assertArrayLength,
+  assertFalse,
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertTrue,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import { simElbV2Fetch } from "../serve/sim-elbv2-fetch.js";
+import { simCfnElbV2Output } from "./sim-cfn-elbv2.fixture.js";
+
+const notFound = {
+  Type: "fixed-response",
+  FixedResponseConfig: {
+    StatusCode: "404",
+    ContentType: "text/plain",
+    MessageBody: "no such site",
+  },
+};
+
+const orders = {
+  Type: "fixed-response",
+  FixedResponseConfig: {
+    StatusCode: "200",
+    ContentType: "text/plain",
+    MessageBody: "orders",
+  },
+};
+
+const routingResources = {
+  ShopAlb: {
+    Type: "AWS::ElasticLoadBalancingV2::LoadBalancer",
+    Properties: { Name: "shop-alb" },
+  },
+  HttpListener: {
+    Type: "AWS::ElasticLoadBalancingV2::Listener",
+    Properties: {
+      LoadBalancerArn: { Ref: "ShopAlb" },
+      Protocol: "HTTP",
+      Port: 80,
+      DefaultActions: [notFound],
+    },
+  },
+  OrdersRule: {
+    Type: "AWS::ElasticLoadBalancingV2::ListenerRule",
+    Properties: {
+      ListenerArn: { Ref: "HttpListener" },
+      Priority: 10,
+      Conditions: [{ Field: "path-pattern", Values: ["/orders/*"] }],
+      Actions: [orders],
+    },
+  },
+};
+
+const ruleTemplate = {
+  Resources: routingResources,
+  Outputs: {
+    Arn: { Value: { Ref: "OrdersRule" } },
+    AlsoArn: { Value: { "Fn::GetAtt": ["OrdersRule", "RuleArn"] } },
+    IsDefault: { Value: { "Fn::GetAtt": ["OrdersRule", "IsDefault"] } },
+    DnsName: { Value: { "Fn::GetAtt": ["ShopAlb", "DNSName"] } },
+  },
+};
+
+describe("AWS::ElasticLoadBalancingV2::ListenerRule", () => {
+  it("creates a rule on the listener the template names", async () => {
+    // Given a template declaring a load balancer, a listener and a rule.
+    const simAws = new SimAws();
+
+    // When it is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "shop-stack",
+      template: ruleTemplate,
+    });
+
+    await stack.waitForDeployComplete();
+
+    // Then the rule sits on the listener, and Ref, RuleArn and IsDefault each
+    // answer for it.
+    const alb = simAws.elbV2().findLoadBalancerByName("shop-alb");
+    assertNonNullable(alb);
+
+    const listener = simAws.elbV2().findListenerOnPort(alb.arn, 80);
+    assertNonNullable(listener);
+
+    const rules = simAws.elbV2().findRulesForListener(listener.arn);
+    assertArrayLength(rules, 1);
+
+    assertIdentical(simCfnElbV2Output(stack, "Arn"), rules[0].arn);
+    assertIdentical(simCfnElbV2Output(stack, "AlsoArn"), rules[0].arn);
+    assertFalse(stack.outputs.get("IsDefault")?.value);
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("matches a request the way the same rule made through the SDK would", async () => {
+    // Given a deployed load balancer whose rule claims one path prefix.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "shop-stack",
+      template: ruleTemplate,
+    });
+
+    await stack.waitForDeployComplete();
+    await simAws.backgroundTasksComplete();
+
+    const dnsName = simCfnElbV2Output(stack, "DnsName");
+
+    // When a request matching the rule arrives, and one that does not.
+    const claimed = await simElbV2Fetch(simAws, `http://${dnsName}/orders/42`);
+    const unclaimed = await simElbV2Fetch(simAws, `http://${dnsName}/other`);
+
+    // Then the rule answers the first and the listener's default action the
+    // second, which is what the same pair created through the SDK does.
+    assertIdentical(claimed.status, 200);
+    assertIdentical(await claimed.text(), "orders");
+    assertIdentical(unclaimed.status, 404);
+    assertIdentical(await unclaimed.text(), "no such site");
+  });
+
+  it("reports the conditions the template declared", async () => {
+    // Given a deployed rule matching on a host header.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "shop-stack",
+      template: {
+        Resources: {
+          ...routingResources,
+          OrdersRule: {
+            Type: "AWS::ElasticLoadBalancingV2::ListenerRule",
+            Properties: {
+              ListenerArn: { Ref: "HttpListener" },
+              Priority: "20",
+              Conditions: [
+                {
+                  Field: "host-header",
+                  HostHeaderConfig: { Values: ["api.example.test"] },
+                },
+              ],
+              Actions: [orders],
+            },
+          },
+        },
+        Outputs: { Arn: { Value: { Ref: "OrdersRule" } } },
+      },
+    });
+
+    await stack.waitForDeployComplete();
+
+    // When the rules are described.
+    const alb = simAws.elbV2().findLoadBalancerByName("shop-alb");
+    assertNonNullable(alb);
+
+    const listener = simAws.elbV2().findListenerOnPort(alb.arn, 80);
+    assertNonNullable(listener);
+
+    const described = await simAws
+      .elbV2()
+      .describeRules(new DescribeRulesCommand({ ListenerArn: listener.arn }));
+
+    // Then the rule reports the condition it was written with, and the
+    // priority the template carried as a string reads as a number.
+    assertArrayLength(described.Rules, 2);
+    assertIdentical(described.Rules[0].Priority, "20");
+    assertIdentical(described.Rules[0].Conditions[0]?.Field, "host-header");
+    assertTrue(described.Rules[1].IsDefault);
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("refuses a condition field this simulation does not match on", async () => {
+    // Given a rule matching on a query string, which nothing here reads.
+    const simAws = new SimAws();
+
+    // When it is deployed, then the deployment fails rather than leaving a
+    // rule that looks configured and claims nothing.
+    const error = await assertThrowsErrorAsync(async () => {
+      return await simAws.cloudFormation().deployTemplate({
+        stackName: "shop-stack",
+        template: {
+          Resources: {
+            ...routingResources,
+            OrdersRule: {
+              Type: "AWS::ElasticLoadBalancingV2::ListenerRule",
+              Properties: {
+                ListenerArn: { Ref: "HttpListener" },
+                Priority: 10,
+                Conditions: [
+                  {
+                    Field: "query-string",
+                    QueryStringConfig: { Values: [{ Key: "a", Value: "b" }] },
+                  },
+                ],
+                Actions: [orders],
+              },
+            },
+          },
+        },
+      });
+    });
+
+    assertStringIncludes(error.message, "query-string");
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("refuses two rules on one listener at the same priority", async () => {
+    // Given two rules declaring the same priority, which leaves no defined
+    // answer for a request both would claim.
+    const simAws = new SimAws();
+
+    // When it is deployed, then the deployment fails.
+    const error = await assertThrowsErrorAsync(async () => {
+      return await simAws.cloudFormation().deployTemplate({
+        stackName: "shop-stack",
+        template: {
+          Resources: {
+            ...routingResources,
+            OtherRule: {
+              Type: "AWS::ElasticLoadBalancingV2::ListenerRule",
+              Properties: {
+                ListenerArn: { Ref: "HttpListener" },
+                Priority: 10,
+                Conditions: [{ Field: "path-pattern", Values: ["/other/*"] }],
+                Actions: [orders],
+              },
+            },
+          },
+        },
+      });
+    });
+
+    assertStringIncludes(error.message, "10");
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("refuses a priority that is not a number", async () => {
+    // Given a rule whose Priority is a word.
+    const simAws = new SimAws();
+
+    // When it is deployed, then the deployment fails naming the property.
+    const error = await assertThrowsErrorAsync(async () => {
+      return await simAws.cloudFormation().deployTemplate({
+        stackName: "shop-stack",
+        template: {
+          Resources: {
+            ...routingResources,
+            OrdersRule: {
+              Type: "AWS::ElasticLoadBalancingV2::ListenerRule",
+              Properties: {
+                ListenerArn: { Ref: "HttpListener" },
+                Priority: "first",
+                Conditions: [{ Field: "path-pattern", Values: ["/orders/*"] }],
+                Actions: [orders],
+              },
+            },
+          },
+        },
+      });
+    });
+
+    assertStringIncludes(error.message, "Priority is a number");
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("records a property a rule is created without", async () => {
+    // Given a rule declaring something no AWS::ElasticLoadBalancingV2::
+    // ListenerRule property covers.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "shop-stack",
+      template: {
+        Resources: {
+          ...routingResources,
+          OrdersRule: {
+            Type: "AWS::ElasticLoadBalancingV2::ListenerRule",
+            Properties: {
+              ListenerArn: { Ref: "HttpListener" },
+              Priority: 10,
+              Conditions: [{ Field: "path-pattern", Values: ["/orders/*"] }],
+              Actions: [orders],
+              Tags: [{ Key: "Team", Value: "payments" }],
+            },
+          },
+        },
+      },
+    });
+
+    await stack.waitForDeployComplete();
+
+    // Then it is created without it, and the record says so.
+    const ignored = stack.resources.get("OrdersRule")?.ignoredProperties;
+    assertNonNullable(ignored);
+    assertArrayLength(ignored, 1);
+    assertStringIncludes(
+      ignored[0].reason,
+      "not a property simulated ELBv2 knows about",
+    );
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("refuses an attribute a rule does not answer", async () => {
+    // Given a template reading an attribute a rule has no answer for.
+    const simAws = new SimAws();
+
+    // When it is deployed, then the deployment fails naming the attribute.
+    const error = await assertThrowsErrorAsync(async () => {
+      return await simAws.cloudFormation().deployTemplate({
+        stackName: "shop-stack",
+        template: {
+          Resources: routingResources,
+          Outputs: {
+            Nonsense: { Value: { "Fn::GetAtt": ["OrdersRule", "Priority"] } },
+          },
+        },
+      });
+    });
+
+    assertStringIncludes(
+      error.message,
+      "Unsupported AWS::ElasticLoadBalancingV2::ListenerRule attribute " +
+        "Priority",
+    );
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("removes the rule when the stack is torn down", async () => {
+    // Given a deployed rule.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "shop-stack",
+      template: ruleTemplate,
+    });
+
+    await stack.waitForDeployComplete();
+
+    // When the stack is deleted, then the whole routing setup has gone with
+    // it, rules first.
+    await stack.delete();
+    await simAws.backgroundTasksComplete();
+
+    assertUndefined(simAws.elbV2().findLoadBalancerByName("shop-alb"));
+  });
+});

--- a/src/service/elbv2/cfn/sim-cfn-elbv2-listener.iso.test.ts
+++ b/src/service/elbv2/cfn/sim-cfn-elbv2-listener.iso.test.ts
@@ -1,0 +1,352 @@
+import { DescribeListenersCommand } from "@aws-sdk/client-elastic-load-balancing-v2";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertStringStartsWith,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import { simCfnElbV2Output } from "./sim-cfn-elbv2.fixture.js";
+
+const loadBalancer = {
+  Type: "AWS::ElasticLoadBalancingV2::LoadBalancer",
+  Properties: { Name: "shop-alb" },
+};
+
+const notFound = {
+  Type: "fixed-response",
+  FixedResponseConfig: {
+    StatusCode: "404",
+    ContentType: "text/plain",
+    MessageBody: "no such site",
+  },
+};
+
+const listenerTemplate = {
+  Resources: {
+    ShopAlb: loadBalancer,
+    HttpListener: {
+      Type: "AWS::ElasticLoadBalancingV2::Listener",
+      Properties: {
+        LoadBalancerArn: { Ref: "ShopAlb" },
+        Protocol: "HTTP",
+        Port: 80,
+        DefaultActions: [notFound],
+      },
+    },
+  },
+  Outputs: {
+    Arn: { Value: { Ref: "HttpListener" } },
+    AlsoArn: { Value: { "Fn::GetAtt": ["HttpListener", "ListenerArn"] } },
+  },
+};
+
+describe("AWS::ElasticLoadBalancingV2::Listener", () => {
+  it("creates a listener on the load balancer the template names", async () => {
+    // Given a template declaring a load balancer and an HTTP listener on it.
+    const simAws = new SimAws();
+
+    // When it is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "shop-stack",
+      template: listenerTemplate,
+    });
+
+    await stack.waitForDeployComplete();
+
+    // Then the listener is on the load balancer's port 80, and Ref and the
+    // ListenerArn attribute both answer with its ARN.
+    const alb = simAws.elbV2().findLoadBalancerByName("shop-alb");
+    assertNonNullable(alb);
+
+    const listener = simAws.elbV2().findListenerOnPort(alb.arn, 80);
+    assertNonNullable(listener);
+
+    assertIdentical(simCfnElbV2Output(stack, "Arn"), listener.arn);
+    assertIdentical(simCfnElbV2Output(stack, "AlsoArn"), listener.arn);
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("holds the default action the template declared", async () => {
+    // Given a deployed listener whose default action is a fixed response.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "shop-stack",
+      template: listenerTemplate,
+    });
+
+    await stack.waitForDeployComplete();
+
+    // When the listener is described.
+    const command = new DescribeListenersCommand({
+      ListenerArns: [simCfnElbV2Output(stack, "Arn")],
+    });
+    const described = await simAws.elbV2().describeListeners(command);
+
+    // Then the action is reported the way a listener created through the SDK
+    // reports it, because it went through the same model.
+    assertArrayLength(described.Listeners, 1);
+    assertArrayLength(described.Listeners[0].DefaultActions, 1);
+    assertIdentical(
+      described.Listeners[0].DefaultActions[0].Type,
+      "fixed-response",
+    );
+    assertIdentical(
+      described.Listeners[0].DefaultActions[0].FixedResponseConfig?.StatusCode,
+      "404",
+    );
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("resolves a certificate an ACM Resource in the same stack created", async () => {
+    // Given a template creating a certificate and attaching it to an HTTPS
+    // listener.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "shop-stack",
+      template: {
+        Resources: {
+          ShopAlb: loadBalancer,
+          SiteCertificate: {
+            Type: "AWS::CertificateManager::Certificate",
+            Properties: {
+              DomainName: "shop.example.test",
+              ValidationMethod: "DNS",
+            },
+          },
+          HttpsListener: {
+            Type: "AWS::ElasticLoadBalancingV2::Listener",
+            Properties: {
+              LoadBalancerArn: { Ref: "ShopAlb" },
+              Protocol: "HTTPS",
+              Port: 443,
+              Certificates: [{ CertificateArn: { Ref: "SiteCertificate" } }],
+              DefaultActions: [notFound],
+            },
+          },
+        },
+        Outputs: {
+          ListenerArn: { Value: { Ref: "HttpsListener" } },
+          CertificateArn: { Value: { Ref: "SiteCertificate" } },
+        },
+      },
+    });
+
+    await stack.waitForDeployComplete();
+
+    // Then the listener carries that certificate, and the security policy real
+    // ELB defaults an HTTPS listener to.
+    const command = new DescribeListenersCommand({
+      ListenerArns: [simCfnElbV2Output(stack, "ListenerArn")],
+    });
+    const described = await simAws.elbV2().describeListeners(command);
+
+    assertArrayLength(described.Listeners, 1);
+    assertArrayLength(described.Listeners[0].Certificates, 1);
+    assertIdentical(
+      described.Listeners[0].Certificates[0].CertificateArn,
+      simCfnElbV2Output(stack, "CertificateArn"),
+    );
+    assertStringStartsWith(
+      described.Listeners[0].SslPolicy,
+      "ELBSecurityPolicy",
+    );
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("fails the deployment for a certificate simulated ACM does not hold", async () => {
+    // Given an HTTPS listener naming a certificate ARN nothing issued.
+    const simAws = new SimAws();
+
+    // When it is deployed, then the deployment fails rather than leaving a
+    // listener that could not serve.
+    const error = await assertThrowsErrorAsync(async () => {
+      return await simAws.cloudFormation().deployTemplate({
+        stackName: "shop-stack",
+        template: {
+          Resources: {
+            ShopAlb: loadBalancer,
+            HttpsListener: {
+              Type: "AWS::ElasticLoadBalancingV2::Listener",
+              Properties: {
+                LoadBalancerArn: { Ref: "ShopAlb" },
+                Protocol: "HTTPS",
+                Port: 443,
+                Certificates: [
+                  {
+                    CertificateArn:
+                      "arn:aws:acm:us-east-1:888888888888:certificate/missing",
+                  },
+                ],
+                DefaultActions: [notFound],
+              },
+            },
+          },
+        },
+      });
+    });
+
+    assertStringIncludes(error.message, "was not found in simulated ACM");
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("deploys a listener declaring mutual authentication, without it", async () => {
+    // Given a template declaring the parts of TLS this simulation performs
+    // none of.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "shop-stack",
+      template: {
+        Resources: {
+          ShopAlb: loadBalancer,
+          HttpListener: {
+            Type: "AWS::ElasticLoadBalancingV2::Listener",
+            Properties: {
+              LoadBalancerArn: { Ref: "ShopAlb" },
+              Protocol: "HTTP",
+              Port: 80,
+              DefaultActions: [notFound],
+              MutualAuthentication: { Mode: "off" },
+              ListenerAttributes: [
+                {
+                  Key: "routing.http.request.x_amzn_mtls_clientcert",
+                  Value: "",
+                },
+              ],
+            },
+          },
+        },
+      },
+    });
+
+    await stack.waitForDeployComplete();
+
+    // Then the listener is created without them, and both are recorded.
+    const ignored = stack.resources.get("HttpListener")?.ignoredProperties;
+    assertNonNullable(ignored);
+    assertArrayLength(ignored, 2);
+    assertStringIncludes(
+      ignored.map((property) => property.reason).join(" "),
+      "no TLS handshake happens here",
+    );
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("refuses a default action this simulation cannot carry out", async () => {
+    // Given a listener whose default action authenticates against Cognito,
+    // which nothing here performs.
+    const simAws = new SimAws();
+
+    // When it is deployed, then the deployment fails rather than leaving a
+    // listener that would forward without authenticating.
+    const error = await assertThrowsErrorAsync(async () => {
+      return await simAws.cloudFormation().deployTemplate({
+        stackName: "shop-stack",
+        template: {
+          Resources: {
+            ShopAlb: loadBalancer,
+            HttpListener: {
+              Type: "AWS::ElasticLoadBalancingV2::Listener",
+              Properties: {
+                LoadBalancerArn: { Ref: "ShopAlb" },
+                Protocol: "HTTP",
+                Port: 80,
+                DefaultActions: [{ Type: "authenticate-cognito" }],
+              },
+            },
+          },
+        },
+      });
+    });
+
+    assertStringIncludes(error.message, "authenticate-cognito");
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("refuses a DefaultActions entry that is not an object", async () => {
+    // Given a template whose default action is a bare word.
+    const simAws = new SimAws();
+
+    // When it is deployed, then the deployment fails naming the entry.
+    const error = await assertThrowsErrorAsync(async () => {
+      return await simAws.cloudFormation().deployTemplate({
+        stackName: "shop-stack",
+        template: {
+          Resources: {
+            ShopAlb: loadBalancer,
+            HttpListener: {
+              Type: "AWS::ElasticLoadBalancingV2::Listener",
+              Properties: {
+                LoadBalancerArn: { Ref: "ShopAlb" },
+                Protocol: "HTTP",
+                Port: 80,
+                DefaultActions: ["forward"],
+              },
+            },
+          },
+        },
+      });
+    });
+
+    assertStringIncludes(error.message, "DefaultActions entry 0 is an object");
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("refuses an attribute a listener does not answer", async () => {
+    // Given a template reading an attribute a listener has no answer for.
+    const simAws = new SimAws();
+
+    // When it is deployed, then the deployment fails naming the attribute.
+    const error = await assertThrowsErrorAsync(async () => {
+      return await simAws.cloudFormation().deployTemplate({
+        stackName: "shop-stack",
+        template: {
+          ...listenerTemplate,
+          Outputs: {
+            Nonsense: { Value: { "Fn::GetAtt": ["HttpListener", "Port"] } },
+          },
+        },
+      });
+    });
+
+    assertStringIncludes(
+      error.message,
+      "Unsupported AWS::ElasticLoadBalancingV2::Listener attribute Port",
+    );
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("removes the listener when the stack is torn down", async () => {
+    // Given a deployed listener.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "shop-stack",
+      template: listenerTemplate,
+    });
+
+    await stack.waitForDeployComplete();
+
+    const alb = simAws.elbV2().findLoadBalancerByName("shop-alb");
+    assertNonNullable(alb);
+
+    // When the stack is deleted.
+    await stack.delete();
+    await simAws.backgroundTasksComplete();
+
+    // Then nothing listens on the port any more.
+    assertUndefined(simAws.elbV2().findListenerOnPort(alb.arn, 80));
+  });
+});

--- a/src/service/elbv2/cfn/sim-cfn-elbv2-load-balancer.iso.test.ts
+++ b/src/service/elbv2/cfn/sim-cfn-elbv2-load-balancer.iso.test.ts
@@ -1,0 +1,321 @@
+import { DescribeLoadBalancersCommand } from "@aws-sdk/client-elastic-load-balancing-v2";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertStringEndsWith,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import { simCfnElbV2Output } from "./sim-cfn-elbv2.fixture.js";
+
+const loadBalancerTemplate = {
+  Resources: {
+    ShopAlb: {
+      Type: "AWS::ElasticLoadBalancingV2::LoadBalancer",
+      Properties: {
+        Name: "shop-alb",
+        Scheme: "internet-facing",
+        Type: "application",
+        Tags: [{ Key: "Team", Value: "payments" }],
+      },
+    },
+  },
+  Outputs: {
+    Arn: { Value: { Ref: "ShopAlb" } },
+    DnsName: { Value: { "Fn::GetAtt": ["ShopAlb", "DNSName"] } },
+    FullName: { Value: { "Fn::GetAtt": ["ShopAlb", "LoadBalancerFullName"] } },
+    Name: { Value: { "Fn::GetAtt": ["ShopAlb", "LoadBalancerName"] } },
+    ZoneId: { Value: { "Fn::GetAtt": ["ShopAlb", "CanonicalHostedZoneID"] } },
+  },
+};
+
+describe("AWS::ElasticLoadBalancingV2::LoadBalancer", () => {
+  it("creates a simulated load balancer the template declares", async () => {
+    // Given a template declaring a load balancer.
+    const simAws = new SimAws();
+
+    // When it is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "shop-stack",
+      template: loadBalancerTemplate,
+    });
+
+    await stack.waitForDeployComplete();
+
+    // Then simulated ELBv2 holds it, Ref answers with its ARN, and the
+    // attributes answer with what the load balancer reports.
+    const loadBalancer = simAws.elbV2().findLoadBalancerByName("shop-alb");
+    assertNonNullable(loadBalancer);
+
+    assertIdentical(simCfnElbV2Output(stack, "Arn"), loadBalancer.arn);
+    assertIdentical(simCfnElbV2Output(stack, "DnsName"), loadBalancer.dnsName);
+    assertIdentical(stack.outputs.get("Name")?.value, "shop-alb");
+    assertIdentical(stack.outputs.get("ZoneId")?.value, "Z0000000000000");
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("answers LoadBalancerFullName with the ARN's own resource part", async () => {
+    // Given a deployed load balancer.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "shop-stack",
+      template: loadBalancerTemplate,
+    });
+
+    await stack.waitForDeployComplete();
+
+    // Then the full name is the part of the ARN that names it, which is what
+    // a CloudWatch metric dimension carries.
+    const fullName = simCfnElbV2Output(stack, "FullName");
+    assertStringIncludes(fullName, "app/shop-alb/");
+
+    const loadBalancer = simAws.elbV2().findLoadBalancerByName("shop-alb");
+    assertNonNullable(loadBalancer);
+    assertStringEndsWith(loadBalancer.arn, fullName);
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("reports the scheme and address type the template declared", async () => {
+    // Given a template declaring an internal load balancer on dualstack.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "shop-stack",
+      template: {
+        Resources: {
+          ShopAlb: {
+            Type: "AWS::ElasticLoadBalancingV2::LoadBalancer",
+            Properties: {
+              Name: "shop-alb",
+              Scheme: "internal",
+              IpAddressType: "dualstack",
+            },
+          },
+        },
+      },
+    });
+
+    await stack.waitForDeployComplete();
+
+    // When it is described, then both are reported, and an internal load
+    // balancer's DNS name carries the prefix real ELB gives one.
+    const described = await simAws
+      .elbV2()
+      .describeLoadBalancers(
+        new DescribeLoadBalancersCommand({ Names: ["shop-alb"] }),
+      );
+
+    assertArrayLength(described.LoadBalancers, 1);
+    assertIdentical(described.LoadBalancers[0].Scheme, "internal");
+    assertIdentical(described.LoadBalancers[0].IpAddressType, "dualstack");
+    assertStringIncludes(described.LoadBalancers[0].DNSName, "internal-");
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("names an unnamed load balancer after the stack and logical ID", async () => {
+    // Given a template declaring a load balancer without a name, which real
+    // CloudFormation would generate one for.
+    const simAws = new SimAws();
+
+    // When it is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "shop-stack",
+      template: {
+        Resources: {
+          ShopAlb: { Type: "AWS::ElasticLoadBalancingV2::LoadBalancer" },
+        },
+        Outputs: {
+          Name: { Value: { "Fn::GetAtt": ["ShopAlb", "LoadBalancerName"] } },
+        },
+      },
+    });
+
+    await stack.waitForDeployComplete();
+
+    // Then the name is the stack and the logical ID, without the random part
+    // real CloudFormation adds, so a test can predict it.
+    assertIdentical(stack.outputs.get("Name")?.value, "shop-stack-ShopAlb");
+    assertNonNullable(
+      simAws.elbV2().findLoadBalancerByName("shop-stack-ShopAlb"),
+    );
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("deploys a load balancer declaring subnets, without them", async () => {
+    // Given a template declaring the network a load balancer sits on, which
+    // there is none of here.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "shop-stack",
+      template: {
+        Resources: {
+          ShopAlb: {
+            Type: "AWS::ElasticLoadBalancingV2::LoadBalancer",
+            Properties: {
+              Name: "shop-alb",
+              Subnets: ["subnet-1111", "subnet-2222"],
+              SecurityGroups: ["sg-3333"],
+              LoadBalancerAttributes: [
+                { Key: "idle_timeout.timeout_seconds", Value: "120" },
+              ],
+            },
+          },
+        },
+      },
+    });
+
+    await stack.waitForDeployComplete();
+
+    // Then it is created without them, and each is recorded so a reader can
+    // see what the deployed load balancer is not doing.
+    assertNonNullable(simAws.elbV2().findLoadBalancerByName("shop-alb"));
+
+    const ignored = stack.resources.get("ShopAlb")?.ignoredProperties;
+    assertNonNullable(ignored);
+    assertArrayLength(ignored, 3);
+    assertStringIncludes(
+      ignored.map((property) => property.reason).join(" "),
+      "there is no VPC here",
+    );
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("records a property simulated ELBv2 knows nothing about", async () => {
+    // Given a template declaring a property this simulation has no list entry
+    // for at all.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "shop-stack",
+      template: {
+        Resources: {
+          ShopAlb: {
+            Type: "AWS::ElasticLoadBalancingV2::LoadBalancer",
+            Properties: { Name: "shop-alb", SomethingNew: "yes" },
+          },
+        },
+      },
+    });
+
+    await stack.waitForDeployComplete();
+
+    // Then the load balancer is created without it, and the record says so.
+    const ignored = stack.resources.get("ShopAlb")?.ignoredProperties;
+    assertNonNullable(ignored);
+    assertArrayLength(ignored, 1);
+    assertStringIncludes(
+      ignored[0].reason,
+      "not a property simulated ELBv2 knows about",
+    );
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("fails the deployment for a network load balancer", async () => {
+    // Given a template declaring a load balancer type this simulation refuses.
+    const simAws = new SimAws();
+
+    // When it is deployed, then the deployment fails saying why.
+    const error = await assertThrowsErrorAsync(async () => {
+      return await simAws.cloudFormation().deployTemplate({
+        stackName: "shop-stack",
+        template: {
+          Resources: {
+            ShopNlb: {
+              Type: "AWS::ElasticLoadBalancingV2::LoadBalancer",
+              Properties: { Name: "shop-nlb", Type: "network" },
+            },
+          },
+        },
+      });
+    });
+
+    assertStringIncludes(error.message, "is not simulated");
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("refuses a name that is not a string", async () => {
+    // Given a template whose Name is an object rather than a name.
+    const simAws = new SimAws();
+
+    // When it is deployed, then the deployment fails naming the Resource and
+    // the property.
+    const error = await assertThrowsErrorAsync(async () => {
+      return await simAws.cloudFormation().deployTemplate({
+        stackName: "shop-stack",
+        template: {
+          Resources: {
+            ShopAlb: {
+              Type: "AWS::ElasticLoadBalancingV2::LoadBalancer",
+              Properties: { Name: { Value: "shop-alb" } },
+            },
+          },
+        },
+      });
+    });
+
+    assertStringIncludes(error.message, "ShopAlb");
+    assertStringIncludes(error.message, "Name is a string");
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("refuses an attribute a load balancer does not answer", async () => {
+    // Given a template reading the security groups a simulated load balancer
+    // does not sit behind.
+    const simAws = new SimAws();
+
+    // When it is deployed, then the deployment fails naming the attribute.
+    const error = await assertThrowsErrorAsync(async () => {
+      return await simAws.cloudFormation().deployTemplate({
+        stackName: "shop-stack",
+        template: {
+          Resources: {
+            ShopAlb: {
+              Type: "AWS::ElasticLoadBalancingV2::LoadBalancer",
+              Properties: { Name: "shop-alb" },
+            },
+          },
+          Outputs: {
+            Groups: { Value: { "Fn::GetAtt": ["ShopAlb", "SecurityGroups"] } },
+          },
+        },
+      });
+    });
+
+    assertStringIncludes(
+      error.message,
+      "Unsupported AWS::ElasticLoadBalancingV2::LoadBalancer attribute " +
+        "SecurityGroups",
+    );
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("removes the load balancer when the stack is torn down", async () => {
+    // Given a deployed load balancer.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "shop-stack",
+      template: loadBalancerTemplate,
+    });
+
+    await stack.waitForDeployComplete();
+
+    // When the stack is deleted.
+    await stack.delete();
+    await simAws.backgroundTasksComplete();
+
+    // Then nothing answers on it any more.
+    assertUndefined(simAws.elbV2().findLoadBalancerByName("shop-alb"));
+  });
+});

--- a/src/service/elbv2/cfn/sim-cfn-elbv2-load-balancer.iso.test.ts
+++ b/src/service/elbv2/cfn/sim-cfn-elbv2-load-balancer.iso.test.ts
@@ -27,6 +27,7 @@ const loadBalancerTemplate = {
   },
   Outputs: {
     Arn: { Value: { Ref: "ShopAlb" } },
+    AlsoArn: { Value: { "Fn::GetAtt": ["ShopAlb", "LoadBalancerArn"] } },
     DnsName: { Value: { "Fn::GetAtt": ["ShopAlb", "DNSName"] } },
     FullName: { Value: { "Fn::GetAtt": ["ShopAlb", "LoadBalancerFullName"] } },
     Name: { Value: { "Fn::GetAtt": ["ShopAlb", "LoadBalancerName"] } },
@@ -47,12 +48,14 @@ describe("AWS::ElasticLoadBalancingV2::LoadBalancer", () => {
 
     await stack.waitForDeployComplete();
 
-    // Then simulated ELBv2 holds it, Ref answers with its ARN, and the
-    // attributes answer with what the load balancer reports.
+    // Then simulated ELBv2 holds it, Ref and the LoadBalancerArn attribute
+    // both answer with its ARN, and the rest answer with what the load
+    // balancer reports.
     const loadBalancer = simAws.elbV2().findLoadBalancerByName("shop-alb");
     assertNonNullable(loadBalancer);
 
     assertIdentical(simCfnElbV2Output(stack, "Arn"), loadBalancer.arn);
+    assertIdentical(simCfnElbV2Output(stack, "AlsoArn"), loadBalancer.arn);
     assertIdentical(simCfnElbV2Output(stack, "DnsName"), loadBalancer.dnsName);
     assertIdentical(stack.outputs.get("Name")?.value, "shop-alb");
     assertIdentical(stack.outputs.get("ZoneId")?.value, "Z0000000000000");

--- a/src/service/elbv2/cfn/sim-cfn-elbv2-properties.iso.test.ts
+++ b/src/service/elbv2/cfn/sim-cfn-elbv2-properties.iso.test.ts
@@ -1,0 +1,170 @@
+import { DescribeTargetGroupsCommand } from "@aws-sdk/client-elastic-load-balancing-v2";
+import {
+  assertArrayLength,
+  assertFalse,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import { SimCfnResource } from "../../cloudformation/resource/sim-cfn-resource.js";
+import type { CfnTemplateBodyRecord } from "../../cloudformation/template/sim-cfn-template.js";
+import type { SimCfnTemplateValueRecord } from "../../cloudformation/template/value/sim-cfn-template-value.js";
+import { SimElbV2 } from "../sim-elbv2.js";
+
+/**
+ * A template declaring one target group, which is the Resource carrying the
+ * widest set of property shapes: strings, numbers, booleans, a structure and a
+ * list of structures.
+ */
+function targetGroupTemplate(
+  properties: SimCfnTemplateValueRecord,
+): CfnTemplateBodyRecord {
+  return {
+    Resources: {
+      WebTargets: {
+        Type: "AWS::ElasticLoadBalancingV2::TargetGroup",
+        Properties: {
+          Name: "web-tg",
+          TargetType: "ip",
+          Protocol: "HTTP",
+          Port: 80,
+          ...properties,
+        },
+      },
+    },
+  };
+}
+
+describe("Reading ELBv2 CloudFormation properties", () => {
+  it("reads a boolean the template declared as false", async () => {
+    // Given a target group turning health checking off.
+    const simAws = new SimAws();
+
+    // When it is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "shop-stack",
+      template: targetGroupTemplate({ HealthCheckEnabled: false }),
+    });
+
+    await stack.waitForDeployComplete();
+
+    // Then the group holds it off, rather than falling back to the default.
+    const described = await simAws
+      .elbV2()
+      .describeTargetGroups(
+        new DescribeTargetGroupsCommand({ Names: ["web-tg"] }),
+      );
+
+    assertArrayLength(described.TargetGroups, 1);
+    assertFalse(described.TargetGroups[0].HealthCheckEnabled);
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("refuses a boolean property that is neither true nor false", async () => {
+    // Given a target group whose HealthCheckEnabled is a word.
+    const simAws = new SimAws();
+
+    // When it is deployed, then the deployment fails naming the property.
+    const error = await assertThrowsErrorAsync(async () => {
+      return await simAws.cloudFormation().deployTemplate({
+        stackName: "shop-stack",
+        template: targetGroupTemplate({ HealthCheckEnabled: "sometimes" }),
+      });
+    });
+
+    assertStringIncludes(error.message, "WebTargets");
+    assertStringIncludes(error.message, "HealthCheckEnabled is a boolean");
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("refuses a number property carried as a blank string", async () => {
+    // Given a target group whose Port is a string with nothing in it, which a
+    // template Parameter left unset can leave behind.
+    const simAws = new SimAws();
+
+    // When it is deployed, then the deployment fails naming the property.
+    const error = await assertThrowsErrorAsync(async () => {
+      return await simAws.cloudFormation().deployTemplate({
+        stackName: "shop-stack",
+        template: targetGroupTemplate({ Port: "  " }),
+      });
+    });
+
+    assertStringIncludes(error.message, "Port is a number");
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("refuses a structure property that is not an object", async () => {
+    // Given a target group whose Matcher is a status code rather than the
+    // structure holding one.
+    const simAws = new SimAws();
+
+    // When it is deployed, then the deployment fails naming the property.
+    const error = await assertThrowsErrorAsync(async () => {
+      return await simAws.cloudFormation().deployTemplate({
+        stackName: "shop-stack",
+        template: targetGroupTemplate({ Matcher: "200" }),
+      });
+    });
+
+    assertStringIncludes(error.message, "Matcher is an object");
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("skips an ELBv2 Resource type this simulation does not create", async () => {
+    // Given a template declaring a trust store, which nothing here simulates.
+    const simAws = new SimAws();
+
+    // When it is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "shop-stack",
+      template: {
+        Resources: {
+          ClientCerts: {
+            Type: "AWS::ElasticLoadBalancingV2::TrustStore",
+            Properties: { Name: "client-certs" },
+          },
+        },
+      },
+    });
+
+    await stack.waitForDeployComplete();
+
+    // Then the stack deploys with the Resource recorded as unsupported rather
+    // than failing, so the rest of a stack holding one is still usable.
+    const skipped = stack.skippedResources;
+    assertArrayLength(skipped, 1);
+    assertNonNullable(skipped[0].skippedReason);
+    assertStringIncludes(skipped[0].skippedReason, "TrustStore");
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("refuses to delete a Resource type it does not create", async () => {
+    // Given the factory and a Resource of a type it has no deleter for, which
+    // is the same refusal the create side makes.
+    const factory = new SimElbV2().cfnResourceFactory();
+    const resource = new SimCfnResource({
+      logicalId: "ClientCerts",
+      template: { Type: "AWS::ElasticLoadBalancingV2::TrustStore" },
+    });
+
+    // When it is asked to delete it, then it refuses naming the type, so the
+    // teardown records it and carries on.
+    const error = await assertThrowsErrorAsync(async () => {
+      await factory.delete("TrustStore", resource, {
+        simAws: new SimAws(),
+        resources: new Map(),
+      });
+    });
+
+    assertStringIncludes(error.message, "TrustStore deletion");
+  });
+});

--- a/src/service/elbv2/cfn/sim-cfn-elbv2-stack.iso.test.ts
+++ b/src/service/elbv2/cfn/sim-cfn-elbv2-stack.iso.test.ts
@@ -1,0 +1,212 @@
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertObjectMatches,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import { simRoute53LocalName } from "../../route53/local-name/sim-route53-local-name.js";
+import { simCfnElbV2Output } from "./sim-cfn-elbv2.fixture.js";
+import type {
+  SimElbV2Event,
+  SimElbV2Result,
+} from "../serve/sim-elbv2-event.type.js";
+import { simElbV2Fetch } from "../serve/sim-elbv2-fetch.js";
+
+/**
+ * A whole routing setup as a stack declares one: a load balancer, a target
+ * group holding a function, a listener forwarding to it, and a Route53 alias
+ * pointing at the name `Fn::GetAtt DNSName` gave.
+ */
+const shopTemplate = {
+  Resources: {
+    CheckoutFunction: {
+      Type: "AWS::Lambda::Function",
+      Properties: {
+        FunctionName: "checkout",
+        Role: "arn:aws:iam::888888888888:role/CheckoutRole",
+      },
+    },
+    ShopAlb: {
+      Type: "AWS::ElasticLoadBalancingV2::LoadBalancer",
+      Properties: { Name: "shop-alb", Subnets: ["subnet-1111"] },
+    },
+    CheckoutTargets: {
+      Type: "AWS::ElasticLoadBalancingV2::TargetGroup",
+      Properties: {
+        Name: "checkout-tg",
+        TargetType: "lambda",
+        Targets: [{ Id: { "Fn::GetAtt": ["CheckoutFunction", "Arn"] } }],
+      },
+    },
+    InvokePermission: {
+      Type: "AWS::Lambda::Permission",
+      Properties: {
+        FunctionName: { Ref: "CheckoutFunction" },
+        Action: "lambda:InvokeFunction",
+        Principal: "elasticloadbalancing.amazonaws.com",
+        SourceArn: { Ref: "CheckoutTargets" },
+      },
+    },
+    HttpListener: {
+      Type: "AWS::ElasticLoadBalancingV2::Listener",
+      Properties: {
+        LoadBalancerArn: { Ref: "ShopAlb" },
+        Protocol: "HTTP",
+        Port: 80,
+        DefaultActions: [
+          {
+            Type: "fixed-response",
+            FixedResponseConfig: {
+              StatusCode: "404",
+              ContentType: "text/plain",
+              MessageBody: "no such site",
+            },
+          },
+        ],
+      },
+    },
+    CheckoutRule: {
+      Type: "AWS::ElasticLoadBalancingV2::ListenerRule",
+      Properties: {
+        ListenerArn: { Ref: "HttpListener" },
+        Priority: 10,
+        Conditions: [{ Field: "path-pattern", Values: ["/checkout*"] }],
+        Actions: [
+          { Type: "forward", TargetGroupArn: { Ref: "CheckoutTargets" } },
+        ],
+      },
+    },
+    ShopZone: {
+      Type: "AWS::Route53::HostedZone",
+      Properties: { Name: "example.test" },
+    },
+    ShopRecord: {
+      Type: "AWS::Route53::RecordSet",
+      Properties: {
+        HostedZoneId: { Ref: "ShopZone" },
+        Name: "shop.example.test",
+        Type: "A",
+        AliasTarget: {
+          DNSName: { "Fn::GetAtt": ["ShopAlb", "DNSName"] },
+          HostedZoneId: {
+            "Fn::GetAtt": ["ShopAlb", "CanonicalHostedZoneID"],
+          },
+        },
+      },
+    },
+  },
+  Outputs: {
+    DnsName: { Value: { "Fn::GetAtt": ["ShopAlb", "DNSName"] } },
+  },
+};
+
+function checkoutHandler(event: SimElbV2Event): SimElbV2Result {
+  return {
+    statusCode: 200,
+    statusDescription: "200 OK",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ path: event.path, host: event.headers["host"] }),
+    isBase64Encoded: false,
+  };
+}
+
+describe("An ELBv2 routing stack", () => {
+  it("carries a request from the load balancer to the function", async () => {
+    // Given a deployed stack whose listener rule forwards to a target group
+    // holding a bound function.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "shop-stack",
+      template: shopTemplate,
+      bindings: [{ logicalId: "CheckoutFunction", handler: checkoutHandler }],
+    });
+
+    await stack.waitForDeployComplete();
+    await simAws.backgroundTasksComplete();
+
+    // When a request arrives at the load balancer's own DNS name.
+    const dnsName = simCfnElbV2Output(stack, "DnsName");
+    const response = await simElbV2Fetch(
+      simAws,
+      `http://${dnsName}/checkout/42`,
+    );
+
+    // Then the function answered it, so every hop the template declared is
+    // connected: the rule, the forward action, the registered target and the
+    // invoke permission.
+    assertIdentical(response.status, 200);
+    assertIdentical(
+      await response.text(),
+      JSON.stringify({ path: "/checkout/42", host: dnsName }),
+    );
+  });
+
+  it("reaches the load balancer through the Route53 alias in the stack", async () => {
+    // Given the same stack, whose alias record points at the name
+    // Fn::GetAtt DNSName gave.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "shop-stack",
+      template: shopTemplate,
+      bindings: [{ logicalId: "CheckoutFunction", handler: checkoutHandler }],
+    });
+
+    await stack.waitForDeployComplete();
+    await simAws.backgroundTasksComplete();
+
+    // When the alias name is resolved.
+    const target = simAws
+      .route53()
+      .resolveHttpHost(simRoute53LocalName("shop.example.test"));
+
+    // Then it names the load balancer the GetAtt gave the record.
+    const dnsName = simCfnElbV2Output(stack, "DnsName");
+    assertObjectMatches(target, {
+      service: "elbV2",
+      resourceName: dnsName,
+    });
+
+    // And a request arriving under that name is served, with the function
+    // seeing the name the client asked for rather than the load balancer's.
+    const response = await simElbV2Fetch(
+      simAws,
+      `http://${dnsName}/checkout/42`,
+      { headers: { host: "shop.example.test" } },
+    );
+
+    assertIdentical(response.status, 200);
+    assertIdentical(
+      await response.text(),
+      JSON.stringify({ path: "/checkout/42", host: "shop.example.test" }),
+    );
+  });
+
+  it("takes the whole routing setup down with the stack", async () => {
+    // Given the deployed stack.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "shop-stack",
+      template: shopTemplate,
+      bindings: [{ logicalId: "CheckoutFunction", handler: checkoutHandler }],
+    });
+
+    await stack.waitForDeployComplete();
+    await simAws.backgroundTasksComplete();
+
+    const alb = simAws.elbV2().findLoadBalancerByName("shop-alb");
+    assertNonNullable(alb);
+
+    // When the stack is deleted.
+    await stack.delete();
+    await simAws.backgroundTasksComplete();
+
+    // Then the target group came down after the listener forwarding to it,
+    // which is what the reverse dependency order arranges, and nothing is
+    // left behind.
+    assertUndefined(simAws.elbV2().findLoadBalancerByName("shop-alb"));
+    assertUndefined(simAws.elbV2().findListenerOnPort(alb.arn, 80));
+  });
+});

--- a/src/service/elbv2/cfn/sim-cfn-elbv2-target-group.iso.test.ts
+++ b/src/service/elbv2/cfn/sim-cfn-elbv2-target-group.iso.test.ts
@@ -1,0 +1,392 @@
+import {
+  DescribeTargetGroupsCommand,
+  DescribeTargetHealthCommand,
+} from "@aws-sdk/client-elastic-load-balancing-v2";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertStringEndsWith,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import { simCfnElbV2Output } from "./sim-cfn-elbv2.fixture.js";
+
+const functionArn = "arn:aws:lambda:us-east-1:123456789012:function:checkout";
+
+const targetGroupTemplate = {
+  Resources: {
+    CheckoutTargets: {
+      Type: "AWS::ElasticLoadBalancingV2::TargetGroup",
+      Properties: {
+        Name: "checkout-tg",
+        TargetType: "lambda",
+        Targets: [{ Id: functionArn }],
+      },
+    },
+  },
+  Outputs: {
+    Arn: { Value: { Ref: "CheckoutTargets" } },
+    FullName: {
+      Value: { "Fn::GetAtt": ["CheckoutTargets", "TargetGroupFullName"] },
+    },
+    Name: { Value: { "Fn::GetAtt": ["CheckoutTargets", "TargetGroupName"] } },
+    AlsoArn: {
+      Value: { "Fn::GetAtt": ["CheckoutTargets", "TargetGroupArn"] },
+    },
+  },
+};
+
+describe("AWS::ElasticLoadBalancingV2::TargetGroup", () => {
+  it("creates a target group and registers the targets declared", async () => {
+    // Given a template declaring a lambda target group holding one function.
+    const simAws = new SimAws();
+
+    // When it is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "shop-stack",
+      template: targetGroupTemplate,
+    });
+
+    await stack.waitForDeployComplete();
+
+    // Then the group exists with the target already registered, so it routes
+    // as soon as the stack has deployed.
+    const command = new DescribeTargetHealthCommand({
+      TargetGroupArn: simCfnElbV2Output(stack, "Arn"),
+    });
+    const health = await simAws.elbV2().describeTargetHealth(command);
+
+    assertArrayLength(health.TargetHealthDescriptions, 1);
+    assertIdentical(health.TargetHealthDescriptions[0].Target.Id, functionArn);
+    assertIdentical(
+      health.TargetHealthDescriptions[0].TargetHealth.State,
+      "healthy",
+    );
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("answers Ref and the ARN attribute with the same ARN", async () => {
+    // Given a deployed target group.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "shop-stack",
+      template: targetGroupTemplate,
+    });
+
+    await stack.waitForDeployComplete();
+
+    // Then Ref, TargetGroupArn, TargetGroupName and TargetGroupFullName each
+    // answer with what the group holds.
+    const arn = simCfnElbV2Output(stack, "Arn");
+
+    assertIdentical(simCfnElbV2Output(stack, "AlsoArn"), arn);
+    assertIdentical(simCfnElbV2Output(stack, "Name"), "checkout-tg");
+
+    const fullName = simCfnElbV2Output(stack, "FullName");
+    assertStringIncludes(fullName, "targetgroup/checkout-tg/");
+    assertStringEndsWith(arn, fullName);
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("holds the health check settings the template declared", async () => {
+    // Given a template declaring an ip target group with health checking.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "shop-stack",
+      template: {
+        Resources: {
+          WebTargets: {
+            Type: "AWS::ElasticLoadBalancingV2::TargetGroup",
+            Properties: {
+              Name: "web-tg",
+              TargetType: "ip",
+              Protocol: "HTTP",
+              Port: "8080",
+              VpcId: "vpc-1111",
+              HealthCheckEnabled: "true",
+              HealthCheckPath: "/healthz",
+              HealthCheckIntervalSeconds: 15,
+              HealthyThresholdCount: "3",
+              Matcher: { HttpCode: "200-299" },
+            },
+          },
+        },
+      },
+    });
+
+    await stack.waitForDeployComplete();
+
+    // When it is described, then the settings are reported back, and the port
+    // the template carried as a string reads as the number it spells.
+    const described = await simAws
+      .elbV2()
+      .describeTargetGroups(
+        new DescribeTargetGroupsCommand({ Names: ["web-tg"] }),
+      );
+
+    assertArrayLength(described.TargetGroups, 1);
+    assertIdentical(described.TargetGroups[0].Port, 8080);
+    assertIdentical(described.TargetGroups[0].HealthCheckPath, "/healthz");
+    assertIdentical(described.TargetGroups[0].HealthCheckIntervalSeconds, 15);
+    assertIdentical(described.TargetGroups[0].HealthyThresholdCount, 3);
+    assertIdentical(described.TargetGroups[0].Matcher?.HttpCode, "200-299");
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("registers an address target on the port it declares", async () => {
+    // Given a template declaring an ip target group with two targets, one of
+    // them on its own port carried as a string.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "shop-stack",
+      template: {
+        Resources: {
+          WebTargets: {
+            Type: "AWS::ElasticLoadBalancingV2::TargetGroup",
+            Properties: {
+              Name: "web-tg",
+              TargetType: "ip",
+              Protocol: "HTTP",
+              Port: 80,
+              Targets: [
+                { Id: "10.0.0.1" },
+                { Id: "10.0.0.2", Port: "8080", AvailabilityZone: "all" },
+                { Id: "10.0.0.3", Port: 9090 },
+              ],
+            },
+          },
+        },
+        Outputs: { Arn: { Value: { Ref: "WebTargets" } } },
+      },
+    });
+
+    await stack.waitForDeployComplete();
+
+    // Then all three are registered: the first takes the group's port, the
+    // second the number its own string spelled, and the third its own number.
+    const command = new DescribeTargetHealthCommand({
+      TargetGroupArn: simCfnElbV2Output(stack, "Arn"),
+    });
+    const health = await simAws.elbV2().describeTargetHealth(command);
+
+    assertArrayLength(health.TargetHealthDescriptions, 3);
+    assertIdentical(health.TargetHealthDescriptions[0].Target.Port, 80);
+    assertIdentical(health.TargetHealthDescriptions[1].Target.Port, 8080);
+    assertIdentical(health.TargetHealthDescriptions[2].Target.Port, 9090);
+    assertIdentical(
+      health.TargetHealthDescriptions[1].Target.AvailabilityZone,
+      "all",
+    );
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("deploys a target group declaring attributes, without them", async () => {
+    // Given a template declaring target group attributes, which change how a
+    // real load balancer holds connections.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "shop-stack",
+      template: {
+        Resources: {
+          CheckoutTargets: {
+            Type: "AWS::ElasticLoadBalancingV2::TargetGroup",
+            Properties: {
+              Name: "checkout-tg",
+              TargetType: "lambda",
+              TargetGroupAttributes: [
+                { Key: "lambda.multi_value_headers.enabled", Value: "true" },
+              ],
+            },
+          },
+        },
+      },
+    });
+
+    await stack.waitForDeployComplete();
+
+    // Then the group is created without them, and the record says why.
+    const ignored = stack.resources.get("CheckoutTargets")?.ignoredProperties;
+    assertNonNullable(ignored);
+    assertArrayLength(ignored, 1);
+    assertStringIncludes(ignored[0].reason, "invokes the target instead");
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("names an unnamed target group after the stack and logical ID", async () => {
+    // Given a template declaring a target group without a name.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "shop-stack",
+      template: {
+        Resources: {
+          Checkout: {
+            Type: "AWS::ElasticLoadBalancingV2::TargetGroup",
+            Properties: { TargetType: "lambda" },
+          },
+        },
+        Outputs: {
+          Name: { Value: { "Fn::GetAtt": ["Checkout", "TargetGroupName"] } },
+        },
+      },
+    });
+
+    await stack.waitForDeployComplete();
+
+    // Then it is named from the stack and the logical ID.
+    assertIdentical(simCfnElbV2Output(stack, "Name"), "shop-stack-Checkout");
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("refuses a target Id that is not a string", async () => {
+    // Given a template whose target Id is an object rather than an address.
+    const simAws = new SimAws();
+
+    // When it is deployed, then the deployment fails naming the entry.
+    const error = await assertThrowsErrorAsync(async () => {
+      return await simAws.cloudFormation().deployTemplate({
+        stackName: "shop-stack",
+        template: {
+          Resources: {
+            CheckoutTargets: {
+              Type: "AWS::ElasticLoadBalancingV2::TargetGroup",
+              Properties: {
+                Name: "checkout-tg",
+                TargetType: "lambda",
+                Targets: [{ Id: { Arn: functionArn } }],
+              },
+            },
+          },
+        },
+      });
+    });
+
+    assertStringIncludes(error.message, "Targets entry 0 Id is a string");
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("refuses a target Port that is not a number", async () => {
+    // Given a template whose target Port is a word.
+    const simAws = new SimAws();
+
+    // When it is deployed, then the deployment fails naming the entry.
+    const error = await assertThrowsErrorAsync(async () => {
+      return await simAws.cloudFormation().deployTemplate({
+        stackName: "shop-stack",
+        template: {
+          Resources: {
+            WebTargets: {
+              Type: "AWS::ElasticLoadBalancingV2::TargetGroup",
+              Properties: {
+                Name: "web-tg",
+                TargetType: "ip",
+                Protocol: "HTTP",
+                Port: 80,
+                Targets: [{ Id: "10.0.0.1", Port: "eighty" }],
+              },
+            },
+          },
+        },
+      });
+    });
+
+    assertStringIncludes(error.message, "Targets entry 0 Port is a number");
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("refuses a Targets list that is not a list", async () => {
+    // Given a template whose Targets is a single object.
+    const simAws = new SimAws();
+
+    // When it is deployed, then the deployment fails naming the property.
+    const error = await assertThrowsErrorAsync(async () => {
+      return await simAws.cloudFormation().deployTemplate({
+        stackName: "shop-stack",
+        template: {
+          Resources: {
+            CheckoutTargets: {
+              Type: "AWS::ElasticLoadBalancingV2::TargetGroup",
+              Properties: {
+                Name: "checkout-tg",
+                TargetType: "lambda",
+                Targets: { Id: functionArn },
+              },
+            },
+          },
+        },
+      });
+    });
+
+    assertStringIncludes(error.message, "Targets is a list");
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("refuses an attribute a target group does not answer", async () => {
+    // Given a template reading the load balancers forwarding to a group,
+    // which nothing records on the group itself.
+    const simAws = new SimAws();
+
+    // When it is deployed, then the deployment fails naming the attribute.
+    const error = await assertThrowsErrorAsync(async () => {
+      return await simAws.cloudFormation().deployTemplate({
+        stackName: "shop-stack",
+        template: {
+          Resources: {
+            CheckoutTargets: {
+              Type: "AWS::ElasticLoadBalancingV2::TargetGroup",
+              Properties: { Name: "checkout-tg", TargetType: "lambda" },
+            },
+          },
+          Outputs: {
+            Arns: {
+              Value: {
+                "Fn::GetAtt": ["CheckoutTargets", "LoadBalancerArns"],
+              },
+            },
+          },
+        },
+      });
+    });
+
+    assertStringIncludes(
+      error.message,
+      "Unsupported AWS::ElasticLoadBalancingV2::TargetGroup attribute " +
+        "LoadBalancerArns",
+    );
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("removes the target group when the stack is torn down", async () => {
+    // Given a deployed target group.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "shop-stack",
+      template: targetGroupTemplate,
+    });
+
+    await stack.waitForDeployComplete();
+
+    const arn = simCfnElbV2Output(stack, "Arn");
+
+    // When the stack is deleted.
+    await stack.delete();
+    await simAws.backgroundTasksComplete();
+
+    // Then the group has gone.
+    assertUndefined(simAws.elbV2().findTargetGroupByArn(arn));
+  });
+});

--- a/src/service/elbv2/cfn/sim-cfn-elbv2.fixture.ts
+++ b/src/service/elbv2/cfn/sim-cfn-elbv2.fixture.ts
@@ -1,0 +1,18 @@
+import { assertTypeString } from "@kensio/smartass";
+
+import type { SimCfnStack } from "../../cloudformation/stack/sim-cfn-stack.js";
+
+/**
+ * One stack Output, as the string an ELBv2 Resource answers with.
+ *
+ * Every value these tests read back is an ARN, a name or a host name, so
+ * asking for it as a string here keeps each assertion about the value rather
+ * than about what shape it came out in.
+ */
+export function simCfnElbV2Output(stack: SimCfnStack, name: string): string {
+  const value = stack.outputs.get(name)?.value;
+
+  assertTypeString(value);
+
+  return value;
+}

--- a/src/service/elbv2/cfn/sim-elbv2-cfn-resource-deleter.ts
+++ b/src/service/elbv2/cfn/sim-elbv2-cfn-resource-deleter.ts
@@ -1,0 +1,105 @@
+import { assertDefined } from "../../../util/type-guard/defined.js";
+import type { SimCfnResource } from "../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimElbV2ListenerRule } from "../listener/rule/sim-elbv2-listener-rule.js";
+import type { SimElbV2Listener } from "../listener/sim-elbv2-listener.js";
+import type { SimElbV2LoadBalancer } from "../load-balancer/sim-elbv2-load-balancer.js";
+import type { SimElbV2TargetGroup } from "../target-group/sim-elbv2-target-group.js";
+import type { SimCfnElbV2ListenerCreator } from "./listener/sim-cfn-elbv2-listener-creator.js";
+import type { SimCfnElbV2LoadBalancerCreator } from "./load-balancer/sim-cfn-elbv2-load-balancer-creator.js";
+import type { SimCfnElbV2ListenerRuleCreator } from "./rule/sim-cfn-elbv2-listener-rule-creator.js";
+import type { SimCfnElbV2TargetGroupCreator } from "./target-group/sim-cfn-elbv2-target-group-creator.js";
+
+interface SimElbV2CfnResourceDeleterProperties {
+  readonly loadBalancers: SimCfnElbV2LoadBalancerCreator;
+  readonly targetGroups: SimCfnElbV2TargetGroupCreator;
+  readonly listeners: SimCfnElbV2ListenerCreator;
+  readonly rules: SimCfnElbV2ListenerRuleCreator;
+}
+
+/**
+ * Removes the simulated ELBv2 resources a stack created.
+ *
+ * The teardown works in reverse dependency order, so a rule comes down before
+ * its listener, a listener before its load balancer, and a target group after
+ * everything that forwards to it. That is what makes each of these the plain
+ * delete command rather than a cascade written here.
+ *
+ * It is held apart from the factory because the two dispatch over the same
+ * four Resource types and one file doing both is the most complex thing in the
+ * service without saying anything either half does not.
+ */
+export class SimElbV2CfnResourceDeleter {
+  private readonly loadBalancers: SimCfnElbV2LoadBalancerCreator;
+  private readonly targetGroups: SimCfnElbV2TargetGroupCreator;
+  private readonly listeners: SimCfnElbV2ListenerCreator;
+  private readonly rules: SimCfnElbV2ListenerRuleCreator;
+
+  constructor(properties: SimElbV2CfnResourceDeleterProperties) {
+    this.loadBalancers = properties.loadBalancers;
+    this.targetGroups = properties.targetGroups;
+    this.listeners = properties.listeners;
+    this.rules = properties.rules;
+  }
+
+  /**
+   * Delete the simulated resource one Resource created.
+   */
+  async delete(
+    resourceTypeName: string,
+    resource: SimCfnResource,
+  ): Promise<void> {
+    switch (resourceTypeName) {
+      case "LoadBalancer": {
+        await this.loadBalancers.delete(
+          simCfnElbV2Created<SimElbV2LoadBalancer>(resource, "load balancer"),
+        );
+
+        return;
+      }
+      case "TargetGroup": {
+        await this.targetGroups.delete(
+          simCfnElbV2Created<SimElbV2TargetGroup>(resource, "target group"),
+        );
+
+        return;
+      }
+      case "Listener": {
+        await this.listeners.delete(
+          simCfnElbV2Created<SimElbV2Listener>(resource, "listener"),
+        );
+
+        return;
+      }
+      case "ListenerRule": {
+        await this.rules.delete(
+          simCfnElbV2Created<SimElbV2ListenerRule>(resource, "rule"),
+        );
+
+        return;
+      }
+      default: {
+        throw new Error(
+          `Unsupported sim ELBv2 CloudFormation Resource ` +
+            `${resourceTypeName} deletion`,
+        );
+      }
+    }
+  }
+}
+
+/**
+ * The simulated resource a Resource created, which a teardown reaches it by.
+ */
+function simCfnElbV2Created<T extends object>(
+  resource: SimCfnResource,
+  described: string,
+): T {
+  const created = resource.simResource as T | undefined;
+
+  assertDefined(
+    created,
+    `sim ELBv2 ${described} for CloudFormation Resource ${resource.logicalId}`,
+  );
+
+  return created;
+}

--- a/src/service/elbv2/cfn/sim-elbv2-cfn-resource-factory.ts
+++ b/src/service/elbv2/cfn/sim-elbv2-cfn-resource-factory.ts
@@ -1,0 +1,92 @@
+import type { SimCfnServiceResourceFactory } from "../../cloudformation/resource/factory/sim-cfn-resource-factory.type.js";
+import type {
+  SimCfnResource,
+  SimCloudFormationResourceCreateContext,
+} from "../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimElbV2 } from "../sim-elbv2.js";
+import type { SimElbV2Stores } from "../sim-elbv2-stores.js";
+import { SimCfnElbV2ListenerCreator } from "./listener/sim-cfn-elbv2-listener-creator.js";
+import { SimCfnElbV2LoadBalancerCreator } from "./load-balancer/sim-cfn-elbv2-load-balancer-creator.js";
+import { SimCfnElbV2ListenerRuleCreator } from "./rule/sim-cfn-elbv2-listener-rule-creator.js";
+import { SimCfnElbV2TargetGroupCreator } from "./target-group/sim-cfn-elbv2-target-group-creator.js";
+import { SimElbV2CfnResourceDeleter } from "./sim-elbv2-cfn-resource-deleter.js";
+
+interface SimElbV2CfnResourceFactoryProperties {
+  readonly elbV2: SimElbV2;
+  readonly stores: SimElbV2Stores;
+}
+
+/**
+ * CloudFormation Resource factory for simulated ELBv2 resources.
+ *
+ * The four Resource types are the whole of an Application Load Balancer a
+ * template declares: where requests arrive, what answers them, and which of
+ * them goes where. Each is created through its own ordinary command, so what a
+ * stack deploys is what an SDK caller would have created, down to the refusals.
+ *
+ * `AWS::ElasticLoadBalancingV2::TrustStore` and the Resource types belonging to
+ * a network or gateway load balancer are not created, because neither is
+ * simulated at all. A stack declaring one deploys with that Resource recorded
+ * as unsupported.
+ */
+export class SimElbV2CfnResourceFactory implements SimCfnServiceResourceFactory {
+  private readonly loadBalancerCreator: SimCfnElbV2LoadBalancerCreator;
+  private readonly targetGroupCreator: SimCfnElbV2TargetGroupCreator;
+  private readonly listenerCreator: SimCfnElbV2ListenerCreator;
+  private readonly ruleCreator: SimCfnElbV2ListenerRuleCreator;
+  private readonly deleter: SimElbV2CfnResourceDeleter;
+
+  constructor(properties: SimElbV2CfnResourceFactoryProperties) {
+    this.loadBalancerCreator = new SimCfnElbV2LoadBalancerCreator(properties);
+    this.targetGroupCreator = new SimCfnElbV2TargetGroupCreator(properties);
+    this.listenerCreator = new SimCfnElbV2ListenerCreator(properties);
+    this.ruleCreator = new SimCfnElbV2ListenerRuleCreator(properties);
+    this.deleter = new SimElbV2CfnResourceDeleter({
+      loadBalancers: this.loadBalancerCreator,
+      targetGroups: this.targetGroupCreator,
+      listeners: this.listenerCreator,
+      rules: this.ruleCreator,
+    });
+  }
+
+  /**
+   * Create a simulated ELBv2 resource from a CloudFormation Resource.
+   */
+  async create(
+    resourceTypeName: string,
+    resource: SimCfnResource,
+    context: SimCloudFormationResourceCreateContext,
+  ): Promise<object | undefined> {
+    const properties = context.resolvedProperties ?? resource.properties;
+
+    switch (resourceTypeName) {
+      case "LoadBalancer": {
+        return await this.loadBalancerCreator.create(resource, properties);
+      }
+      case "TargetGroup": {
+        return await this.targetGroupCreator.create(resource, properties);
+      }
+      case "Listener": {
+        return await this.listenerCreator.create(resource, properties);
+      }
+      case "ListenerRule": {
+        return await this.ruleCreator.create(resource, properties);
+      }
+      default: {
+        throw new Error(
+          `Unsupported sim ELBv2 CloudFormation Resource ${resourceTypeName}`,
+        );
+      }
+    }
+  }
+
+  /**
+   * Delete a simulated ELBv2 resource created from a CloudFormation Resource.
+   */
+  async delete(
+    resourceTypeName: string,
+    resource: SimCfnResource,
+  ): Promise<void> {
+    await this.deleter.delete(resourceTypeName, resource);
+  }
+}

--- a/src/service/elbv2/cfn/target-group/sim-cfn-elbv2-declared-targets.ts
+++ b/src/service/elbv2/cfn/target-group/sim-cfn-elbv2-declared-targets.ts
@@ -1,0 +1,98 @@
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimElbV2TargetDescription } from "../../target-group/sim-elbv2-target.js";
+import type { SimCfnElbV2PropertyReader } from "../property/sim-cfn-elbv2-property-reader.js";
+
+/**
+ * The targets a target group Resource declares, read one entry at a time.
+ *
+ * Each entry is read rather than handed on as it was written, because a
+ * target's `Port` is a number the template may have carried as a string, and a
+ * target registered on the string `"80"` would be a different target from one
+ * registered on `80`.
+ */
+export function simCfnElbV2DeclaredTargets(
+  reader: SimCfnElbV2PropertyReader,
+): readonly SimElbV2TargetDescription[] | undefined {
+  const declared = reader.structures<SimCfnTemplateValueRecord>("Targets");
+
+  if (declared === undefined) {
+    return undefined;
+  }
+
+  return declared.map((entry, index) =>
+    simCfnElbV2DeclaredTarget(reader, entry, index),
+  );
+}
+
+/**
+ * One declared target.
+ *
+ * An entry with no `Id` is left as it is rather than refused here, so the
+ * refusal comes from the same place an SDK caller's would.
+ */
+function simCfnElbV2DeclaredTarget(
+  reader: SimCfnElbV2PropertyReader,
+  entry: SimCfnTemplateValueRecord,
+  index: number,
+): SimElbV2TargetDescription {
+  const field = `Targets entry ${String(index)}`;
+
+  return {
+    Id: simCfnElbV2TargetText(reader, entry, field, "Id"),
+    Port: simCfnElbV2TargetPort(reader, entry, field),
+    AvailabilityZone: simCfnElbV2TargetText(
+      reader,
+      entry,
+      field,
+      "AvailabilityZone",
+    ),
+  };
+}
+
+/**
+ * One string field of a declared target, if it names one.
+ */
+function simCfnElbV2TargetText(
+  reader: SimCfnElbV2PropertyReader,
+  entry: SimCfnTemplateValueRecord,
+  field: string,
+  name: string,
+): string | undefined {
+  // oxlint-disable-next-line security/detect-object-injection -- fixed names.
+  const value = entry[name];
+
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (typeof value !== "string") {
+    throw reader.refuse(`${field} ${name} is a string`);
+  }
+
+  return value;
+}
+
+/**
+ * The port one declared target names, if it names one.
+ */
+function simCfnElbV2TargetPort(
+  reader: SimCfnElbV2PropertyReader,
+  entry: SimCfnTemplateValueRecord,
+  field: string,
+): number | undefined {
+  const port = entry["Port"];
+
+  if (port === undefined) {
+    return undefined;
+  }
+
+  if (typeof port === "number") {
+    return port;
+  }
+
+  if (typeof port === "string" && Number.isSafeInteger(Number(port))) {
+    return Number(port);
+  }
+
+  throw reader.refuse(`${field} Port is a number`);
+}

--- a/src/service/elbv2/cfn/target-group/sim-cfn-elbv2-health-check-properties.ts
+++ b/src/service/elbv2/cfn/target-group/sim-cfn-elbv2-health-check-properties.ts
@@ -1,0 +1,46 @@
+import type { SimElbV2Matcher } from "../../command/sim-elbv2-shared.command.js";
+import type { SimElbV2HealthCheckInput } from "../../target-group/sim-elbv2-health-check.js";
+import type { SimCfnElbV2PropertyReader } from "../property/sim-cfn-elbv2-property-reader.js";
+
+/**
+ * The health check properties a target group Resource can declare.
+ *
+ * They are listed here so the target group's own property rules can say they
+ * are acted on, and read here so the target group properties file stays about
+ * what a target group is.
+ */
+export const simCfnElbV2HealthCheckProperties: readonly string[] = [
+  "HealthCheckEnabled",
+  "HealthCheckIntervalSeconds",
+  "HealthCheckPath",
+  "HealthCheckPort",
+  "HealthCheckProtocol",
+  "HealthCheckTimeoutSeconds",
+  "HealthyThresholdCount",
+  "UnhealthyThresholdCount",
+  "Matcher",
+];
+
+/**
+ * The health check settings a target group Resource declares.
+ *
+ * Nothing here ever checks a target's health, and every registered target is
+ * healthy whatever these say. They are still read, because a stack declares
+ * them and a test comparing what it deployed against what it meant to deploy
+ * reads them back off the target group.
+ */
+export function simCfnElbV2HealthCheckInput(
+  reader: SimCfnElbV2PropertyReader,
+): SimElbV2HealthCheckInput {
+  return {
+    HealthCheckEnabled: reader.boolean("HealthCheckEnabled"),
+    HealthCheckProtocol: reader.text("HealthCheckProtocol"),
+    HealthCheckPort: reader.text("HealthCheckPort"),
+    HealthCheckPath: reader.text("HealthCheckPath"),
+    HealthCheckIntervalSeconds: reader.number("HealthCheckIntervalSeconds"),
+    HealthCheckTimeoutSeconds: reader.number("HealthCheckTimeoutSeconds"),
+    HealthyThresholdCount: reader.number("HealthyThresholdCount"),
+    UnhealthyThresholdCount: reader.number("UnhealthyThresholdCount"),
+    Matcher: reader.structure<SimElbV2Matcher>("Matcher"),
+  };
+}

--- a/src/service/elbv2/cfn/target-group/sim-cfn-elbv2-target-group-creator.ts
+++ b/src/service/elbv2/cfn/target-group/sim-cfn-elbv2-target-group-creator.ts
@@ -1,0 +1,84 @@
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimElbV2 } from "../../sim-elbv2.js";
+import type { SimElbV2Stores } from "../../sim-elbv2-stores.js";
+import type { SimElbV2TargetGroup } from "../../target-group/sim-elbv2-target-group.js";
+import type { SimElbV2TargetDescription } from "../../target-group/sim-elbv2-target.js";
+import { SimCfnElbV2TargetGroupProperties } from "./sim-cfn-elbv2-target-group-properties.js";
+
+interface SimCfnElbV2TargetGroupCreatorProperties {
+  readonly elbV2: SimElbV2;
+  readonly stores: SimElbV2Stores;
+}
+
+/**
+ * Creates simulated target groups from
+ * AWS::ElasticLoadBalancingV2::TargetGroup Resources.
+ *
+ * A declared `Targets` list is registered as part of creating the group, which
+ * is what real CloudFormation does, so a stack declaring a Lambda target has a
+ * group that routes as soon as it has deployed rather than one waiting for a
+ * RegisterTargets call the stack never makes.
+ */
+export class SimCfnElbV2TargetGroupCreator {
+  private readonly elbV2: SimElbV2;
+  private readonly stores: SimElbV2Stores;
+
+  constructor(properties: SimCfnElbV2TargetGroupCreatorProperties) {
+    this.elbV2 = properties.elbV2;
+    this.stores = properties.stores;
+  }
+
+  /**
+   * Create a target group from a TargetGroup Resource.
+   */
+  async create(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): Promise<SimElbV2TargetGroup> {
+    const declared = new SimCfnElbV2TargetGroupProperties({
+      resource,
+      properties,
+    });
+    const input = declared.createTargetGroupInput();
+
+    declared.recordIgnoredProperties();
+
+    await this.elbV2.createTargetGroup({ input });
+
+    const targetGroup = this.stores.targetGroups.requireByName(declared.name());
+
+    await this.registerTargets(targetGroup, declared.targets());
+
+    return targetGroup;
+  }
+
+  /**
+   * Delete a target group created from a TargetGroup Resource.
+   *
+   * DeleteTargetGroup refuses a group a listener or rule still forwards to, so
+   * a group comes down after the listeners naming it, which the teardown order
+   * arranges.
+   */
+  async delete(targetGroup: SimElbV2TargetGroup): Promise<void> {
+    await this.elbV2.deleteTargetGroup({
+      input: { TargetGroupArn: targetGroup.arn },
+    });
+  }
+
+  /**
+   * Register the targets the Resource declared, if it declared any.
+   */
+  private async registerTargets(
+    targetGroup: SimElbV2TargetGroup,
+    targets: readonly SimElbV2TargetDescription[] | undefined,
+  ): Promise<void> {
+    if (targets === undefined || targets.length === 0) {
+      return;
+    }
+
+    await this.elbV2.registerTargets({
+      input: { TargetGroupArn: targetGroup.arn, Targets: targets },
+    });
+  }
+}

--- a/src/service/elbv2/cfn/target-group/sim-cfn-elbv2-target-group-properties.ts
+++ b/src/service/elbv2/cfn/target-group/sim-cfn-elbv2-target-group-properties.ts
@@ -1,0 +1,109 @@
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCreateTargetGroupCommandInput } from "../../command/target-group/target-group.command.js";
+import type { SimElbV2Tag } from "../../command/sim-elbv2-shared.command.js";
+import type { SimElbV2TargetDescription } from "../../target-group/sim-elbv2-target.js";
+import { simCfnElbV2GeneratedName } from "../name/sim-cfn-elbv2-name.js";
+import type { SimCfnElbV2DeclaredResource } from "../property/sim-cfn-elbv2-declared-resource.js";
+import { SimCfnElbV2PropertyReader } from "../property/sim-cfn-elbv2-property-reader.js";
+import { SimCfnElbV2PropertyRules } from "../property/sim-cfn-elbv2-property-rules.js";
+import { simCfnElbV2DeclaredTargets } from "./sim-cfn-elbv2-declared-targets.js";
+import {
+  simCfnElbV2HealthCheckInput,
+  simCfnElbV2HealthCheckProperties,
+} from "./sim-cfn-elbv2-health-check-properties.js";
+
+/**
+ * The properties a target group is created with.
+ */
+const actedOnProperties: ReadonlySet<string> = new Set([
+  "Name",
+  "TargetType",
+  "Protocol",
+  "ProtocolVersion",
+  "Port",
+  "VpcId",
+  "IpAddressType",
+  "Targets",
+  "Tags",
+  ...simCfnElbV2HealthCheckProperties,
+]);
+
+/**
+ * The real AWS::ElasticLoadBalancingV2::TargetGroup properties this simulation
+ * has nothing to act on, and why.
+ */
+const unsimulatedPropertyReasons: ReadonlyMap<string, string> = new Map([
+  [
+    "TargetGroupAttributes",
+    "the attributes change how a real load balancer holds connections to a " +
+      "target, and a simulated one invokes the target instead",
+  ],
+]);
+
+/**
+ * Reads AWS::ElasticLoadBalancingV2::TargetGroup properties into
+ * CreateTargetGroup input.
+ */
+export class SimCfnElbV2TargetGroupProperties {
+  private readonly resource: SimCfnResource;
+  private readonly reader: SimCfnElbV2PropertyReader;
+  private readonly rules: SimCfnElbV2PropertyRules;
+
+  constructor(declared: SimCfnElbV2DeclaredResource) {
+    const { resource, properties } = declared;
+
+    this.resource = resource;
+    this.reader = new SimCfnElbV2PropertyReader({ resource, properties });
+    this.rules = new SimCfnElbV2PropertyRules({
+      resourceTypeName: "TargetGroup",
+      described: "target group",
+      properties,
+      ignorer: resource,
+      actedOn: actedOnProperties,
+      unsimulated: unsimulatedPropertyReasons,
+    });
+  }
+
+  /**
+   * The CreateTargetGroup input this Resource declares.
+   */
+  createTargetGroupInput(): SimCreateTargetGroupCommandInput {
+    return {
+      ...simCfnElbV2HealthCheckInput(this.reader),
+      Name: this.name(),
+      TargetType: this.reader.text("TargetType"),
+      Protocol: this.reader.text("Protocol"),
+      ProtocolVersion: this.reader.text("ProtocolVersion"),
+      Port: this.reader.number("Port"),
+      VpcId: this.reader.text("VpcId"),
+      IpAddressType: this.reader.text("IpAddressType"),
+      Tags: this.reader.structures<SimElbV2Tag>("Tags"),
+    };
+  }
+
+  /**
+   * The target group name.
+   */
+  name(): string {
+    return this.reader.text("Name") ?? simCfnElbV2GeneratedName(this.resource);
+  }
+
+  /**
+   * The targets this Resource declares, which are registered once the group
+   * exists.
+   *
+   * Real CloudFormation registers them as part of creating the group, so a
+   * stack that declares a Lambda target has a group that routes as soon as it
+   * deploys.
+   */
+  targets(): readonly SimElbV2TargetDescription[] | undefined {
+    return simCfnElbV2DeclaredTargets(this.reader);
+  }
+
+  /**
+   * Record the properties the target group is created without acting on.
+   */
+  recordIgnoredProperties(): void {
+    this.rules.apply();
+  }
+}

--- a/src/service/elbv2/sim-elbv2.ts
+++ b/src/service/elbv2/sim-elbv2.ts
@@ -1,7 +1,9 @@
 import { BackgroundTasks } from "../../util/background/background.js";
 import type { SimSdkCommandRouter } from "../../sdk/router/sim-sdk-command-router.type.js";
 import { simAwsAccountRegionScopeFactory } from "../aws/sim-aws-account-region-scope.factory.js";
+import type { SimCfnServiceResourceFactory } from "../cloudformation/resource/factory/sim-cfn-resource-factory.type.js";
 import { SimIamAllowAllAuth } from "../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { SimElbV2CfnResourceFactory } from "./cfn/sim-elbv2-cfn-resource-factory.js";
 import type * as elbV2 from "./command/sim-elbv2-command.types.js";
 import { SimElbV2Commands } from "./command/sim-elbv2-commands.js";
 import type { SimElbV2RequestOptions } from "./command/sim-elbv2-request-options.js";
@@ -22,10 +24,10 @@ import type { SimElbV2TargetGroup } from "./target-group/sim-elbv2-target-group.
  * load balancers route below HTTP, which nothing in this simulation speaks, so
  * they are refused rather than created as something they are not.
  *
- * What a load balancer here is, so far, is state: it has a DNS name of the
- * shape real ELB issues, so a Route53 alias or a CloudFront origin has
- * something to point at, and it has listeners, rules and target groups that
- * say what it would do with a request. Answering one is separate work.
+ * A load balancer has a DNS name of the shape real ELB issues, so a Route53
+ * alias or a CloudFront origin has something to point at, and listeners, rules
+ * and target groups saying what it does with a request. `serve/` is the part
+ * that does it.
  *
  * Load balancers are scoped to an account and region, as they are on real AWS:
  * a name is unique within one of those scopes and an ARN names the region.
@@ -287,5 +289,12 @@ export class SimElbV2 {
    */
   sdkCommandRouter(): SimSdkCommandRouter {
     return this.sdkRouter;
+  }
+
+  /**
+   * Get this service's CloudFormation Resource factory.
+   */
+  cfnResourceFactory(): SimCfnServiceResourceFactory {
+    return new SimElbV2CfnResourceFactory({ elbV2: this, stores: this.stores });
   }
 }


### PR DESCRIPTION
`AWS::ElasticLoadBalancingV2::LoadBalancer`, `TargetGroup`, `Listener` and `ListenerRule` now create their simulated counterparts, each through the ordinary command an SDK caller would use, so a template's listener rule matches requests the way the same rule made by hand does and a declaration real ELB would refuse fails the deployment rather than deploying as something else. `Ref` returns the ARN of all four, and `Fn::GetAtt` answers `DNSName`, `LoadBalancerFullName` and `TargetGroupFullName` among others, so a Route53 alias in the same stack can point at a load balancer and reach it. A listener's `Certificates` resolves against simulated ACM, a target group's `Targets` are registered at deploy time, and the properties Yulin has no network to apply, such as subnets, security groups and health check configuration, are recorded on the Resource and left out rather than failing the stack. Resolves https://github.com/KensioSoftware/yulin/issues/566

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CloudFormation support for simulated ELBv2 load balancers, target groups, listeners, and listener rules.
  * Enabled ARN references, resource attributes, target registration, HTTPS listeners with certificates, Route53 aliases, request routing, and stack cleanup.
  * Added validation and clear handling for unsupported properties and resources.
* **Documentation**
  * Added usage guides, limitations, and deployable examples for ELBv2 CloudFormation resources.
* **Tests**
  * Added comprehensive coverage for deployment, routing, validation, outputs, attributes, and deletion behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->