### PR TITLE
feat: sign a Function URL Origin with origin access control

### DIFF
--- a/docs/services/cloudfront/README.md
+++ b/docs/services/cloudfront/README.md
@@ -571,8 +571,10 @@ A few things follow from the request never leaving the process:
   domain, rather than a real request being made to it. External HTTP Origins are not supported.
 - The settings inside `CustomOriginConfig` describe how CloudFront connects over the network, so
   the protocol policy, ports, SSL protocols and timeouts are accepted and ignored.
-- The Origin is reached anonymously, as CloudFront reaches an Origin with no Origin Access Control.
-  A Function URL or an HTTP API route authorizing with `AWS_IAM` therefore refuses the request.
+- The Origin is reached anonymously unless it has an origin access control, as CloudFront reaches an
+  Origin it has nothing to sign for. A Function URL or an HTTP API route authorizing with `AWS_IAM`
+  therefore refuses the request. [Origin access controls](#origin-access-controls) covers the
+  Function URL that admits the Distribution and nothing else.
 
 ## Viewer certificates
 
@@ -1132,11 +1134,17 @@ Behavior.
 
 ## Origin access controls
 
-An origin access control is how a Distribution authenticates to a private S3 Bucket. Declare one as
+An origin access control is how a Distribution authenticates to a private Origin, so that the Origin
+admits the Distribution and nothing else. Declare one as
 `AWS::CloudFront::OriginAccessControl` and point an Origin's `OriginAccessControlId` at it with a
 `Ref`, which is what CDK's `S3BucketOrigin.withOriginAccessControl` synthesizes.
 
-An Origin whose origin access control signs reads its Bucket as the `cloudfront.amazonaws.com`
+An `OriginAccessControlOriginType` of `s3` signs for an S3 Bucket Origin, and one of `lambda` signs
+for a Lambda Function URL Origin. The origin type has to match the Origin it is attached to: an `s3`
+origin access control on a custom Origin, or a `lambda` one on an S3 Origin, fails the Stack when
+the Distribution is created, as CloudFront refuses it.
+
+An S3 Origin whose origin access control signs reads its Bucket as the `cloudfront.amazonaws.com`
 service principal, carrying the Distribution's ARN as `aws:SourceArn`. The Bucket policy is then the
 whole decision, so the Bucket needs a statement granting `s3:GetObject` to that principal,
 conditioned on the Distribution allowed to read it. That is the policy CDK writes. A condition
@@ -1265,19 +1273,159 @@ inside `Fn::Join` is the dependency CloudFormation orders the Stack by. Nothing 
 settled when the Distribution is created, because the policy deciding it does not exist yet. The
 Origin works out who it is reading as per request instead.
 
+### A Lambda Function URL Origin
+
+A Function URL with `AuthType: AWS_IAM` admits only a caller allowed `lambda:InvokeFunctionUrl` on
+the function, so putting one behind a Distribution takes three things: the origin access control
+with `OriginAccessControlOriginType: lambda`, a custom Origin naming it whose `DomainName` is the
+Function URL's hostname, and an `AWS::Lambda::Permission` granting `lambda:InvokeFunctionUrl` to
+`cloudfront.amazonaws.com` for that Distribution. That is what CDK's
+`FunctionUrlOrigin.withOriginAccessControl` synthesizes, and it is the only way to serve a Function
+URL through CloudFront without leaving the Function URL open to anyone who finds its endpoint.
+
+The Origin request is made as the `cloudfront.amazonaws.com` service principal carrying the
+Distribution's ARN, the same pair an S3 Origin read carries, and the function's resource policy is
+the whole decision. A Stack without the permission, or with one naming a different Distribution,
+deploys and then answers 403 through the Distribution, which is what the real deployment does.
+
+```typescript sim-cloudfront-function-url-origin-access-control
+/**
+ * Serving a private Lambda Function URL through an origin access control.
+ */
+
+import { SimAws } from "@kensio/yulin";
+import { serveSimAws } from "@kensio/yulin/serve";
+
+const simAws = new SimAws();
+const srv = await serveSimAws({ simAws });
+
+try {
+  const stack = await simAws.cloudFormation().deployTemplate({
+    stackName: "greeter-stack",
+    template: {
+      Resources: {
+        GreeterFunction: {
+          Type: "AWS::Lambda::Function",
+          Properties: {
+            FunctionName: "greeter",
+            Role: "arn:aws:iam::888888888888:role/GreeterRole",
+            Handler: "index.handler",
+            Runtime: "nodejs22.x",
+            Code: {
+              ZipFile:
+                "exports.handler = async () => " +
+                "({ statusCode: 200, body: 'Hello from behind CloudFront' });",
+            },
+          },
+        },
+        GreeterUrl: {
+          Type: "AWS::Lambda::Url",
+          Properties: {
+            TargetFunctionArn: { "Fn::GetAtt": ["GreeterFunction", "Arn"] },
+            AuthType: "AWS_IAM",
+          },
+        },
+        GreeterOac: {
+          Type: "AWS::CloudFront::OriginAccessControl",
+          Properties: {
+            OriginAccessControlConfig: {
+              Name: "greeter-oac",
+              OriginAccessControlOriginType: "lambda",
+              SigningBehavior: "always",
+              SigningProtocol: "sigv4",
+            },
+          },
+        },
+        GreeterDistribution: {
+          Type: "AWS::CloudFront::Distribution",
+          Properties: {
+            DistributionConfig: {
+              Enabled: true,
+              Origins: [
+                {
+                  Id: "GreeterOrigin",
+                  // An Origin takes a domain name, and the Function URL
+                  // attribute is a URL, so the host comes out of it.
+                  DomainName: {
+                    "Fn::Select": [
+                      2,
+                      {
+                        "Fn::Split": [
+                          "/",
+                          { "Fn::GetAtt": ["GreeterUrl", "FunctionUrl"] },
+                        ],
+                      },
+                    ],
+                  },
+                  CustomOriginConfig: { OriginProtocolPolicy: "https-only" },
+                  OriginAccessControlId: { Ref: "GreeterOac" },
+                },
+              ],
+              DefaultCacheBehavior: {
+                TargetOriginId: "GreeterOrigin",
+                ViewerProtocolPolicy: "allow-all",
+              },
+            },
+          },
+        },
+        // Nothing but this Distribution may invoke the Function URL, which is
+        // what the condition on the Distribution's ARN says.
+        InvokeFromCloudFront: {
+          Type: "AWS::Lambda::Permission",
+          Properties: {
+            FunctionName: { "Fn::GetAtt": ["GreeterFunction", "Arn"] },
+            Action: "lambda:InvokeFunctionUrl",
+            Principal: "cloudfront.amazonaws.com",
+            SourceArn: {
+              "Fn::Join": [
+                "",
+                [
+                  "arn:aws:cloudfront::",
+                  { Ref: "AWS::AccountId" },
+                  ":distribution/",
+                  { Ref: "GreeterDistribution" },
+                ],
+              ],
+            },
+          },
+        },
+      },
+      Outputs: {
+        SiteHostname: {
+          Value: { "Fn::GetAtt": ["GreeterDistribution", "DomainName"] },
+        },
+      },
+    },
+  });
+
+  await stack.waitForDeployComplete();
+
+  const siteHostname = stack.outputs.get("SiteHostname")?.value as string;
+  const greeting = await fetch(srv.localUrl(`http://${siteHostname}/greeting`));
+
+  console.log(await greeting.text()); // Hello from behind CloudFront
+} finally {
+  await srv.close();
+}
+```
+
+The Function URL is reachable directly as well, on its own endpoint, and it refuses a request that
+arrives there without the permission the Distribution has. That is the point of the auth type: the
+endpoint exists, and only the Distribution may use it.
+
 `SigningBehavior` takes any of `always`, `never` and `no-override`. `always` and `no-override` both
 sign, since nothing here sends a pre-signed viewer request to an Origin for `no-override` to pass
-through. `never` turns the origin access control off without removing it, so the Origin reads
-anonymously and needs a Bucket policy allowing that, as an Origin with no origin access control
-does.
+through. `never` turns the origin access control off without removing it, so the Origin is reached
+anonymously, as an Origin with no origin access control is. An S3 Origin then needs a Bucket policy
+allowing that, and an `AWS_IAM` Function URL refuses the request outright.
 
 `Ref` and `Fn::GetAtt` on `Id` both return the ID, so either resolves an Origin's
 `OriginAccessControlId`. An Origin naming an ID no origin access control holds is refused with
 `InvalidOriginAccessControl` when the Distribution is created, rather than created without one.
 Tearing the Stack down removes the origin access control, and its name is free again.
 
-`OriginAccessControlOriginType` must be `s3` and `SigningProtocol` must be `sigv4`. Any other value
-fails the Stack by name.
+`OriginAccessControlOriginType` must be `s3` or `lambda`, and `SigningProtocol` must be `sigv4`. Any
+other value fails the Stack by name.
 
 There is no `CreateOriginAccessControl` command here, so a CloudFormation template is the only way
 to make one.
@@ -1547,15 +1695,17 @@ Where sim CloudFront knowingly behaves differently from AWS:
   the Origin request as a CloudFront canonical user nothing here models, so a Bucket policy written
   for one would deny the read and say nothing about why.
 - **A signed Origin request is not really signed.** An Origin whose origin access control signs
-  reads the Bucket as the `cloudfront.amazonaws.com` service principal carrying the Distribution's
-  ARN, which is what the Bucket policy is evaluated against, but no SigV4 signature is computed or
-  checked. Nothing else here signs a simulated request either, so a test cannot assert anything
-  about the signature itself.
-- **An origin access control is only accepted for an S3 Origin with SigV4.** CloudFront also signs for
-  MediaStore, MediaPackage V2 and Lambda Function URL Origins, and none of those is modelled. An
-  `OriginAccessControlOriginType` other than `s3`, or a `SigningProtocol` other than `sigv4`, fails
-  the Stack by naming the value, rather than deploying and behaving like an S3 one. For the same
-  reason, a custom Origin naming an origin access control is refused.
+  reaches the Origin as the `cloudfront.amazonaws.com` service principal carrying the Distribution's
+  ARN, which is what the Bucket policy or the function's resource policy is evaluated against, but
+  no SigV4 signature is computed or checked. A Function URL Origin is told who the request is from
+  at the simulated HTTP boundary instead, the same way anything else calling into simulated AWS in
+  process says who it is. Nothing else here signs a simulated request either, so a test cannot
+  assert anything about the signature itself.
+- **An origin access control signs for an S3 or Lambda Function URL Origin only.** CloudFront also
+  signs for MediaStore and MediaPackage V2 Origins, and neither is modelled. An
+  `OriginAccessControlOriginType` other than `s3` or `lambda`, or a `SigningProtocol` other than
+  `sigv4`, fails the Stack by naming the value rather than deploying and behaving like one of the
+  two.
 - **An origin access control name is unique, but nothing else about it is checked.** A second one
   claiming a name is refused with `OriginAccessControlAlreadyExists`, as CloudFront refuses one.
 - **There is no command surface for an origin access control.** `CreateOriginAccessControl` and its

--- a/docs/services/cloudfront/sim-cloudfront-function-url-origin-access-control.example.ts
+++ b/docs/services/cloudfront/sim-cloudfront-function-url-origin-access-control.example.ts
@@ -1,0 +1,118 @@
+/**
+ * Serving a private Lambda Function URL through an origin access control.
+ */
+
+import { SimAws } from "@kensio/yulin";
+import { serveSimAws } from "@kensio/yulin/serve";
+
+const simAws = new SimAws();
+const srv = await serveSimAws({ simAws });
+
+try {
+  const stack = await simAws.cloudFormation().deployTemplate({
+    stackName: "greeter-stack",
+    template: {
+      Resources: {
+        GreeterFunction: {
+          Type: "AWS::Lambda::Function",
+          Properties: {
+            FunctionName: "greeter",
+            Role: "arn:aws:iam::888888888888:role/GreeterRole",
+            Handler: "index.handler",
+            Runtime: "nodejs22.x",
+            Code: {
+              ZipFile:
+                "exports.handler = async () => " +
+                "({ statusCode: 200, body: 'Hello from behind CloudFront' });",
+            },
+          },
+        },
+        GreeterUrl: {
+          Type: "AWS::Lambda::Url",
+          Properties: {
+            TargetFunctionArn: { "Fn::GetAtt": ["GreeterFunction", "Arn"] },
+            AuthType: "AWS_IAM",
+          },
+        },
+        GreeterOac: {
+          Type: "AWS::CloudFront::OriginAccessControl",
+          Properties: {
+            OriginAccessControlConfig: {
+              Name: "greeter-oac",
+              OriginAccessControlOriginType: "lambda",
+              SigningBehavior: "always",
+              SigningProtocol: "sigv4",
+            },
+          },
+        },
+        GreeterDistribution: {
+          Type: "AWS::CloudFront::Distribution",
+          Properties: {
+            DistributionConfig: {
+              Enabled: true,
+              Origins: [
+                {
+                  Id: "GreeterOrigin",
+                  // An Origin takes a domain name, and the Function URL
+                  // attribute is a URL, so the host comes out of it.
+                  DomainName: {
+                    "Fn::Select": [
+                      2,
+                      {
+                        "Fn::Split": [
+                          "/",
+                          { "Fn::GetAtt": ["GreeterUrl", "FunctionUrl"] },
+                        ],
+                      },
+                    ],
+                  },
+                  CustomOriginConfig: { OriginProtocolPolicy: "https-only" },
+                  OriginAccessControlId: { Ref: "GreeterOac" },
+                },
+              ],
+              DefaultCacheBehavior: {
+                TargetOriginId: "GreeterOrigin",
+                ViewerProtocolPolicy: "allow-all",
+              },
+            },
+          },
+        },
+        // Nothing but this Distribution may invoke the Function URL, which is
+        // what the condition on the Distribution's ARN says.
+        InvokeFromCloudFront: {
+          Type: "AWS::Lambda::Permission",
+          Properties: {
+            FunctionName: { "Fn::GetAtt": ["GreeterFunction", "Arn"] },
+            Action: "lambda:InvokeFunctionUrl",
+            Principal: "cloudfront.amazonaws.com",
+            SourceArn: {
+              "Fn::Join": [
+                "",
+                [
+                  "arn:aws:cloudfront::",
+                  { Ref: "AWS::AccountId" },
+                  ":distribution/",
+                  { Ref: "GreeterDistribution" },
+                ],
+              ],
+            },
+          },
+        },
+      },
+      Outputs: {
+        SiteHostname: {
+          Value: { "Fn::GetAtt": ["GreeterDistribution", "DomainName"] },
+        },
+      },
+    },
+  });
+
+  await stack.waitForDeployComplete();
+
+  const siteHostname = stack.outputs.get("SiteHostname")?.value as string;
+  const greeting = await fetch(srv.localUrl(`http://${siteHostname}/greeting`));
+
+  console.log(await greeting.text()); // Hello from behind CloudFront
+} finally {
+  await srv.close();
+}

--- a/docs/services/iam/README.md
+++ b/docs/services/iam/README.md
@@ -524,6 +524,33 @@ try {
 }
 ```
 
+### Naming what the request is for
+
+When one AWS service calls another it says which of your resources it is calling for, and IAM
+supplies that as `aws:SourceArn` and `aws:SourceAccount`. A resource policy granting a service
+principal is usually conditioned on them, so that a Bucket policy or a function's resource policy
+admits one Distribution rather than every CloudFront customer. Two more headers say the same thing
+over HTTP:
+
+| Header                     | Condition key       |
+| -------------------------- | ------------------- |
+| `x-sim-aws-source-arn`     | `aws:SourceArn`     |
+| `x-sim-aws-source-account` | `aws:SourceAccount` |
+
+```bash
+curl -H 'x-sim-aws-caller: service:cloudfront.amazonaws.com' \
+  -H 'x-sim-aws-source-arn: arn:aws:cloudfront::111111111111:distribution/E1EXAMPLE12345' \
+  http://abc123.lambda-url.us-east-1.sim-aws.localhost:4566/
+```
+
+A request that states neither has no source at all, rather than an empty one, so a statement
+conditioned on either key does not match instead of matching an empty string. Both headers are
+stripped before the request reaches the simulated service, as the caller header is.
+
+Sim CloudFront sends these itself when a Distribution reaches a custom Origin through an origin
+access control, which is what an `AWS_IAM` Lambda Function URL behind CloudFront is admitted by.
+Simulated Lambda Function URLs are the only endpoint evaluating them so far.
+
 ### Signed requests
 
 A request signed with credentials from `CreateAccessKeyCommand` or from an STS `AssumeRoleCommand`
@@ -920,7 +947,8 @@ Sim IAM currently supports:
   service-supplied resource policies, and policy conditions with explicit-deny precedence
 - IAM authorization at simulated service boundaries, such as Route53 actions
 - Resolving the caller of an HTTP request, from an `x-sim-aws-caller` header or a verified SigV4
-  signature, defaulting to anonymous
+  signature, defaulting to anonymous, and the resource it is made on behalf of from
+  `x-sim-aws-source-arn` and `x-sim-aws-source-account`
 - Temporary Role sessions through simulated STS `AssumeRoleCommand`, evaluated against Role trust
   policies
 - The `AWS::IAM::Role`, `AWS::IAM::ManagedPolicy` and `AWS::IAM::Policy` CloudFormation resources

--- a/docs/services/lambda/README.md
+++ b/docs/services/lambda/README.md
@@ -1116,6 +1116,13 @@ header naming a principal directly. A request that offers neither is anonymous, 
 is refused. See [callers of HTTP requests](../iam/#callers-of-http-requests) in the IAM docs for how
 that resolution works and how to sign a served request.
 
+A grant conditioned on `AWS:SourceArn` or `AWS:SourceAccount` is evaluated against what the request
+says it is being made for, which is how a permission granting `cloudfront.amazonaws.com` names one
+Distribution. Sim CloudFront states that itself when it reaches a Function URL Origin through an
+origin access control, so a Function URL behind a Distribution runs for that Distribution and
+refuses everything else. See
+[origin access controls](../cloudfront/README.md#origin-access-controls) in the CloudFront docs.
+
 An `AWS_IAM` invocation carries its caller into the event as
 `requestContext.authorizer.iam`, which is the part a handler reads. The `authorizer` block is absent
 for a `NONE` invocation, as it is on real AWS, and `requestContext.accountId` is the caller's Account

--- a/src/serve/controller/sim-service-controller.ts
+++ b/src/serve/controller/sim-service-controller.ts
@@ -1,6 +1,7 @@
 import type { AwsRegionName } from "../../service/aws/sim-aws-region.js";
 import type { SimAws } from "../../service/aws/sim-aws.js";
 import { SimAwsRequestCaller } from "../../service/iam/request/sim-aws-request-caller.js";
+import type { SimAwsRequestSource } from "../../service/iam/request/sim-aws-request-source.js";
 
 /**
  * Which of a service's endpoints a hostname named.
@@ -34,6 +35,7 @@ interface SimAwsServiceRequestProperties {
   readonly target: SimAwsServiceTarget;
   readonly request: Request;
   readonly caller?: SimAwsRequestCaller | undefined;
+  readonly source?: SimAwsRequestSource | undefined;
   readonly body?: Uint8Array | undefined;
 }
 
@@ -53,6 +55,12 @@ export class SimAwsServiceRequest {
   public readonly target: SimAwsServiceTarget;
   public readonly request: Request;
   public readonly caller: SimAwsRequestCaller;
+  /**
+   * The resource the caller is making this request on behalf of, when it said
+   * it was making one for anything. This is what a service principal's grant is
+   * conditioned on, and most requests state none.
+   */
+  public readonly source: SimAwsRequestSource | undefined;
   public readonly body?: Uint8Array | undefined;
 
   constructor(properties: SimAwsServiceRequestProperties) {
@@ -60,6 +68,7 @@ export class SimAwsServiceRequest {
     this.request = properties.request;
     // An unattributed request is anonymous, never the Account root.
     this.caller = properties.caller ?? SimAwsRequestCaller.anonymous();
+    this.source = properties.source;
     this.body = properties.body;
   }
 }

--- a/src/serve/http/request/sim-aws-received-request.ts
+++ b/src/serve/http/request/sim-aws-received-request.ts
@@ -1,18 +1,4 @@
-import { simAwsCallerHeaderName } from "../../../service/iam/request/sim-aws-caller-header.js";
-import {
-  simAwsSourceAccountHeaderName,
-  simAwsSourceArnHeaderName,
-} from "../../../service/iam/request/sim-aws-request-source.js";
-
-/**
- * Header names that are instructions to the simulator rather than part of the
- * request being simulated.
- */
-const controlHeaderNames = [
-  simAwsCallerHeaderName,
-  simAwsSourceArnHeaderName,
-  simAwsSourceAccountHeaderName,
-];
+import { stripSimAwsControlHeaders } from "../../../service/iam/request/sim-aws-control-headers.js";
 
 /**
  * An HTTP request as it arrived at the simulated AWS boundary.
@@ -57,9 +43,7 @@ export class SimAwsReceivedRequest {
   forService(): Request {
     const headers = new Headers(this.received.headers);
 
-    for (const name of controlHeaderNames) {
-      headers.delete(name);
-    }
+    stripSimAwsControlHeaders(headers);
 
     return new Request(this.received.url, {
       method: this.received.method,

--- a/src/serve/http/request/sim-aws-received-request.ts
+++ b/src/serve/http/request/sim-aws-received-request.ts
@@ -1,10 +1,18 @@
 import { simAwsCallerHeaderName } from "../../../service/iam/request/sim-aws-caller-header.js";
+import {
+  simAwsSourceAccountHeaderName,
+  simAwsSourceArnHeaderName,
+} from "../../../service/iam/request/sim-aws-request-source.js";
 
 /**
  * Header names that are instructions to the simulator rather than part of the
  * request being simulated.
  */
-const controlHeaderNames = [simAwsCallerHeaderName];
+const controlHeaderNames = [
+  simAwsCallerHeaderName,
+  simAwsSourceArnHeaderName,
+  simAwsSourceAccountHeaderName,
+];
 
 /**
  * An HTTP request as it arrived at the simulated AWS boundary.

--- a/src/serve/http/request/sim-aws-request-authenticator.ts
+++ b/src/serve/http/request/sim-aws-request-authenticator.ts
@@ -4,6 +4,7 @@ import {
   SimAwsServiceRequest,
   type SimAwsServiceTarget,
 } from "../../controller/sim-service-controller.js";
+import { SimAwsRequestSource } from "../../../service/iam/request/sim-aws-request-source.js";
 import { SimAwsReceivedRequest } from "./sim-aws-received-request.js";
 
 interface SimAwsRequestAuthenticatorProperties {
@@ -17,6 +18,10 @@ interface SimAwsRequestAuthenticatorProperties {
  * once, the principal is resolved by IAM, and the result is the request a
  * controller is given. Controllers therefore never see an unattributed
  * request, and never have to decide for themselves what an unsigned one means.
+ *
+ * A request that states the resource it is being made on behalf of carries that
+ * through as well, since a resource policy granting a service principal is
+ * usually conditioned on it.
  */
 export class SimAwsRequestAuthenticator {
   private readonly simAws: SimAws;
@@ -50,10 +55,13 @@ export class SimAwsRequestAuthenticator {
       },
     });
 
+    const source = SimAwsRequestSource.fromHeaders(request.headers);
+
     return new SimAwsServiceRequest({
       target,
       request: received.forService(),
       caller,
+      ...(source !== undefined && { source }),
       body: received.body,
     });
   }

--- a/src/serve/http/sim-aws-http-caller.iso.test.ts
+++ b/src/serve/http/sim-aws-http-caller.iso.test.ts
@@ -9,6 +9,10 @@ import { createSigner } from "../../../test/sigv4/sim-signer.js";
 import { SimAws } from "../../service/aws/sim-aws.js";
 import { makeLambdaZipFileInput } from "../../service/lambda/function/code/lambda-zip-file-input.js";
 import { simAwsCallerHeaderName } from "../../service/iam/request/sim-aws-caller-header.js";
+import {
+  simAwsSourceAccountHeaderName,
+  simAwsSourceArnHeaderName,
+} from "../../service/iam/request/sim-aws-request-source.js";
 import type { SimLambdaFunctionUrlEvent } from "../../service/lambda/serve/event/sim-lambda-url-event.type.js";
 import { SimAwsHttp } from "./sim-aws-http.js";
 import {
@@ -92,15 +96,19 @@ describe("The caller of a served simulated AWS request", () => {
     );
   });
 
-  it("hides the caller header from the simulated service", async () => {
+  it("hides the control headers from the simulated service", async () => {
     // Given a Function URL whose handler echoes the headers it receives
     const simAws = new SimAws();
     const url = await serveHeaderEcho(simAws);
 
-    // When it is requested with a caller header
+    // When it is requested with a caller header, and with the resource the
+    // call is being made on behalf of
     const response = await new SimAwsHttp({ simAws }).fetch(url, {
       headers: {
         [simAwsCallerHeaderName]: "arn:aws:iam::111111111111:role/Reporter",
+        [simAwsSourceArnHeaderName]:
+          "arn:aws:cloudfront::111111111111:distribution/E1EXAMPLE12345",
+        [simAwsSourceAccountHeaderName]: "111111111111",
         "x-application": "kept",
       },
     });
@@ -111,6 +119,8 @@ describe("The caller of a served simulated AWS request", () => {
       Object.entries((await response.json()) as Record<string, string>),
     );
     expect(seen.has(simAwsCallerHeaderName)).toBe(false);
+    expect(seen.has(simAwsSourceArnHeaderName)).toBe(false);
+    expect(seen.has(simAwsSourceAccountHeaderName)).toBe(false);
     expect(seen.get("x-application")).toBe("kept");
   });
 

--- a/src/service/cloudformation/cdk/cloudfront/sim-cdk-cf-function-url-oac.loc.test.ts
+++ b/src/service/cloudformation/cdk/cloudfront/sim-cdk-cf-function-url-oac.loc.test.ts
@@ -1,0 +1,103 @@
+import path from "node:path";
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertResponseStatus,
+  describeResponse,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { simCfSiteRequest } from "../../../../../test/cloudfront/site-fixture.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { TestCdkProject } from "../../../../util/filesystem/test-cdk-project.js";
+
+/**
+ * Inline function code, as CDK packages Code.fromInline source.
+ */
+const greeterHandlerSource = `
+exports.handler = async () => ({
+  statusCode: 200,
+  headers: { "content-type": "text/plain" },
+  body: "Hello from behind CloudFront",
+});
+`;
+
+/**
+ * Slower local integration test. Calls the real CDK CLI to synth the output
+ * template file and deploys the synthesized Function URL, origin access control,
+ * Distribution and Lambda permission through sim CloudFormation.
+ *
+ * This is the shape `origins.FunctionUrlOrigin.withOriginAccessControl()` has,
+ * and the only way to put a Function URL behind a Distribution without leaving
+ * the Function URL open to anyone who finds its endpoint.
+ */
+describe("Sim CDK CloudFront Function URL origin access control local integration", () => {
+  it("serves an AWS_IAM Function URL through a Distribution CDK gave an origin access control", async () => {
+    // Given a CDK stack whose Distribution reaches a private Function URL with
+    // an origin access control, which writes the invoke permission granting
+    // CloudFront.
+    const cdkProject = new TestCdkProject();
+
+    await cdkProject.writeCdkAppFile(`
+import * as cdk from "aws-cdk-lib";
+import * as lambda from "aws-cdk-lib/aws-lambda";
+import * as cloudfront from "aws-cdk-lib/aws-cloudfront";
+import * as origins from "aws-cdk-lib/aws-cloudfront-origins";
+
+const app = new cdk.App();
+const stack = new cdk.Stack(app, "TestStack", {
+  env: { account: "111111111111", region: "eu-west-2" },
+});
+
+const greeterFunction = new lambda.Function(stack, "GreeterFunction", {
+  functionName: "cdk-greeter",
+  runtime: lambda.Runtime.NODEJS_20_X,
+  handler: "index.handler",
+  code: lambda.Code.fromInline(${JSON.stringify(greeterHandlerSource)}),
+});
+
+const greeterUrl = greeterFunction.addFunctionUrl({
+  authType: lambda.FunctionUrlAuthType.AWS_IAM,
+});
+
+const distribution = new cloudfront.Distribution(stack, "SiteDistribution", {
+  defaultBehavior: {
+    origin: origins.FunctionUrlOrigin.withOriginAccessControl(greeterUrl),
+  },
+});
+
+new cdk.CfnOutput(stack, "DistributionId", {
+  value: distribution.distributionId,
+});
+
+app.synth();
+`);
+
+    // And the CDK app is synthesized to a CloudFormation template.
+    const cdkOutDirectory = await cdkProject.synth();
+
+    // When the synthesized template is deployed through sim CloudFormation.
+    const simAws = new SimAws();
+    const stack = await simAws
+      .cloudFormation()
+      .deployTemplateFile(
+        path.join(cdkOutDirectory, "TestStack.template.json"),
+      );
+
+    await stack.waitForDeployComplete();
+
+    const distributionId = stack.outputs.get("DistributionId")?.value;
+    assertNonNullable(distributionId);
+
+    const response = await simCfSiteRequest(
+      simAws,
+      distributionId as string,
+      "/greeting",
+    );
+
+    // Then the permission CDK wrote admits the Origin request and the handler
+    // runs, with nothing but the Distribution able to invoke the URL.
+    assertResponseStatus(response, 200, await describeResponse(response));
+    assertIdentical(await response.text(), "Hello from behind CloudFront");
+  });
+});

--- a/src/service/cloudformation/resource/cfn/cloudfront/sim-cloudfront-oac-cfn.iso.test.ts
+++ b/src/service/cloudformation/resource/cfn/cloudfront/sim-cloudfront-oac-cfn.iso.test.ts
@@ -8,6 +8,7 @@ import { SimCloudFrontOriginAccessControlCfn } from "./sim-cloudfront-oac-cfn.js
 describe("SimCloudFrontOriginAccessControlCfn", () => {
   const originAccessControl = new SimCloudFrontOriginAccessControl({
     name: "site-oac",
+    originType: "s3",
     signingBehavior: "always",
   });
   const adapter = new SimCloudFrontOriginAccessControlCfn({

--- a/src/service/cloudfront/README.md
+++ b/src/service/cloudfront/README.md
@@ -277,6 +277,12 @@ what an `AWS_IAM` Function URL evaluates its `lambda:InvokeFunctionUrl` permissi
 being admitted anyway. The headers are stripped at the boundary, so the function's event shows the
 request its viewer sent.
 
+A viewer's own control headers are dropped from the Origin request before the Origin's are applied,
+so who the Origin request is from is the Origin's decision and never the viewer's. The HTTP boundary
+has already stripped them from a request that arrived that way, and a request handed straight to the
+controller in process has not, so `simCfCustomOriginRequest` strips them rather than relying on
+where the request came from.
+
 That resolution is per request rather than per Origin because an Origin does not know its
 Distribution until one fetches through it. Deciding it earlier would be wrong anyway: in a CDK stack
 the Bucket policy is created after the Distribution, since it names the Distribution's ARN.

--- a/src/service/cloudfront/README.md
+++ b/src/service/cloudfront/README.md
@@ -247,23 +247,35 @@ it.
 
 `origin-access-control/` holds the model and its registry, laid out the same way as the response
 headers policies above. A `SimCloudFrontOriginAccessControl` is a name, an ID, an optional
-description and a signing behaviour. The origin type and signing protocol are fixed at `s3` and
-`sigv4`, because `cfn/origin-access-control/` refuses any other value by name rather than storing
-one the simulator would then treat as an S3 origin access control. There is no
+description, an origin type and a signing behaviour. The origin type is `s3` or `lambda`, the two
+CloudFront signs for that are modelled here; MediaStore and MediaPackage V2 are refused by name in
+`cfn/origin-access-control/` rather than stored as something the simulator would then treat like one
+of the two. The signing protocol is fixed at `sigv4`, the only one CloudFront offers. There is no
 CreateOriginAccessControl command, so a template is the only thing that makes one.
 
 `SimCloudFrontOriginConfigurator` resolves an Origin's `OriginAccessControlId` through the registry
-when the Distribution is created, and stores the result on the `SimCloudFrontS3Origin`. An ID
-nothing created is `SimCloudFrontInvalidOriginAccessControl`, as CloudFront refuses the whole
-CreateDistribution. `SimCloudFrontBehaviorConfigurator` resolves a Behavior's
-`ResponseHeadersPolicyId` the same eager way, for the same reason: CloudFront checks both at creation
-rather than when a request arrives.
+when the Distribution is created, and stores the result on the `SimCloudFrontS3Origin` or
+`SimCloudFrontCustomOrigin`. An ID nothing created is `SimCloudFrontInvalidOriginAccessControl`, as
+CloudFront refuses the whole CreateDistribution, and so is an origin type that does not match the
+Origin it was named on: `assertSimCfOacOriginType` checks that in both directions, since an origin
+access control for a Bucket signs nothing a Function URL will admit.
+`SimCloudFrontBehaviorConfigurator` resolves a Behavior's `ResponseHeadersPolicyId` the same eager
+way, for the same reason: CloudFront checks both at creation rather than when a request arrives.
 
 `SimCfS3OriginSigner` reads the stored origin access control on every Origin fetch. One whose
 `signs` getter is true makes the read a request from the `cloudfront.amazonaws.com` service
 principal, carrying the Distribution's ARN as `aws:SourceArn` and its Account as
 `aws:SourceAccount`, which is the pair a Bucket policy written for an origin access control is
 conditioned on. A `never` signing behaviour reads anonymously, as an Origin with none does.
+
+`SimCfCustomOriginSigner` is the same idea for a custom Origin, and says the same three things a
+different way. A custom Origin request leaves CloudFront over the simulated HTTP boundary, so it
+carries them as the `x-sim-aws-caller` and `x-sim-aws-source-arn`/`x-sim-aws-source-account` control
+headers, which is how anything else calling into simulated AWS in process states who it is. That is
+what an `AWS_IAM` Function URL evaluates its `lambda:InvokeFunctionUrl` permission for
+`cloudfront.amazonaws.com` against, so a template omitting the permission answers 403 rather than
+being admitted anyway. The headers are stripped at the boundary, so the function's event shows the
+request its viewer sent.
 
 That resolution is per request rather than per Origin because an Origin does not know its
 Distribution until one fetches through it. Deciding it earlier would be wrong anyway: in a CDK stack

--- a/src/service/cloudfront/cfn/origin-access-control/sim-cfn-cf-oac-config.iso.test.ts
+++ b/src/service/cloudfront/cfn/origin-access-control/sim-cfn-cf-oac-config.iso.test.ts
@@ -72,11 +72,23 @@ describe("SimCfnCfOriginAccessControlConfig", () => {
     }
   });
 
-  it("refuses an origin type it does not sign for", () => {
-    // Given a config for a Lambda Function URL Origin, which CloudFront signs
-    // for and this simulation does not.
-    const message = refusalFrom({
+  it("reads the config CDK synthesizes for a Function URL origin", () => {
+    // Given the config CDK emits for
+    // FunctionUrlOrigin.withOriginAccessControl.
+    const originAccessControl = originAccessControlFrom({
       OriginAccessControlOriginType: "lambda",
+    });
+
+    // Then it signs for a Lambda Function URL rather than for a Bucket.
+    assertIdentical(originAccessControl.originType, "lambda");
+    assertIdentical(originAccessControl.signingBehavior, "always");
+  });
+
+  it("refuses an origin type it does not sign for", () => {
+    // Given a config for a MediaStore Origin, which CloudFront signs for and
+    // this simulation does not.
+    const message = refusalFrom({
+      OriginAccessControlOriginType: "mediastore",
     });
 
     // Then it is refused by name, rather than stored and treated as an S3
@@ -85,7 +97,8 @@ describe("SimCfnCfOriginAccessControlConfig", () => {
       message,
       "Invalid AWS::CloudFront::OriginAccessControl SiteOac",
     );
-    assertStringIncludes(message, "OriginAccessControlOriginType lambda");
+    assertStringIncludes(message, "OriginAccessControlOriginType mediastore");
+    assertStringIncludes(message, "s3, lambda");
   });
 
   it("refuses a missing origin type", () => {

--- a/src/service/cloudfront/cfn/origin-access-control/sim-cfn-cf-oac-config.ts
+++ b/src/service/cloudfront/cfn/origin-access-control/sim-cfn-cf-oac-config.ts
@@ -3,21 +3,25 @@ import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-re
 import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
 import {
   SimCloudFrontOriginAccessControl,
+  type SimCloudFrontOriginAccessControlOriginType,
   type SimCloudFrontOriginAccessControlSigningBehavior,
 } from "../../origin-access-control/sim-cf-origin-access-control.js";
 
 /**
- * The config values a simulated origin access control is fixed to.
+ * The values a simulated origin access control accepts for each field of the
+ * config that names one of a fixed set.
  *
- * CloudFront also signs for MediaStore, MediaPackage V2 and Lambda Function URL
- * Origins, and none of those is modelled. SigV4 is the only protocol CloudFront
- * offers. Anything else is refused by name rather than stored and treated as
- * though it behaved like these.
+ * CloudFront also signs for MediaStore and MediaPackage V2 Origins, and neither
+ * is modelled, so neither is an origin type here. SigV4 is the only protocol
+ * CloudFront offers. Anything else is refused by name rather than stored and
+ * treated as though it behaved like one of these.
  */
-const fixedValues = {
-  OriginAccessControlOriginType: "s3",
-  SigningProtocol: "sigv4",
-};
+const originTypes: readonly SimCloudFrontOriginAccessControlOriginType[] = [
+  "s3",
+  "lambda",
+];
+
+const signingProtocols = ["sigv4"] as const;
 
 const signingBehaviors: readonly SimCloudFrontOriginAccessControlSigningBehavior[] =
   ["always", "never", "no-override"];
@@ -48,7 +52,10 @@ export class SimCfnCfOriginAccessControlConfig {
   build(): SimCloudFrontOriginAccessControl {
     const config = this.originAccessControlConfig();
 
-    this.assertFixedValues(config);
+    // The protocol is checked and then dropped: SigV4 is the only one
+    // CloudFront offers, so there is nothing for the origin access control to
+    // remember about it.
+    this.oneOf(config, "SigningProtocol", signingProtocols);
 
     const description = this.text(config, "Description");
 
@@ -56,7 +63,12 @@ export class SimCfnCfOriginAccessControlConfig {
       name:
         this.text(config, "Name") ??
         this.refuse("OriginAccessControlConfig Name must be a string"),
-      signingBehavior: this.signingBehavior(config),
+      originType: this.oneOf(
+        config,
+        "OriginAccessControlOriginType",
+        originTypes,
+      ),
+      signingBehavior: this.oneOf(config, "SigningBehavior", signingBehaviors),
       ...(description !== undefined && { description }),
     });
   }
@@ -72,21 +84,27 @@ export class SimCfnCfOriginAccessControlConfig {
   }
 
   /**
-   * Refuse a config asking for anything but the one origin type and protocol a
-   * simulated origin access control signs.
+   * One field of the config naming a value from a fixed set.
+   *
+   * A value outside the set is refused by name, along with the set it should
+   * have come from, rather than stored and treated as one of them.
    */
-  private assertFixedValues(config: Record<string, unknown>): void {
-    for (const [key, fixed] of Object.entries(fixedValues)) {
-      // oxlint-disable-next-line security/detect-object-injection
-      const value = config[key];
+  private oneOf<Value extends string>(
+    config: Record<string, unknown>,
+    key: string,
+    values: readonly Value[],
+  ): Value {
+    // oxlint-disable-next-line security/detect-object-injection
+    const value = config[key];
 
-      if (value !== fixed) {
-        this.refuse(
-          `${key} ${String(value)} is not modelled by simulated origin ` +
-            `access controls, which only sign an ${fixedValues.OriginAccessControlOriginType} Origin with ${fixedValues.SigningProtocol}`,
-        );
-      }
+    if (!values.includes(value as Value)) {
+      this.refuse(
+        `${key} ${String(value)} is not modelled by simulated origin access ` +
+          `controls, which accept ${values.join(", ")}`,
+      );
     }
+
+    return value as Value;
   }
 
   /**
@@ -110,22 +128,6 @@ export class SimCfnCfOriginAccessControlConfig {
     return value;
   }
 
-  private signingBehavior(
-    config: Record<string, unknown>,
-  ): SimCloudFrontOriginAccessControlSigningBehavior {
-    const value = config["SigningBehavior"];
-
-    if (!isSigningBehavior(value)) {
-      this.refuse(
-        `SigningBehavior ${String(value)} is not one of ${signingBehaviors.join(
-          ", ",
-        )}`,
-      );
-    }
-
-    return value;
-  }
-
   /**
    * Refuse this Resource, saying which part of it could not be read.
    */
@@ -134,12 +136,4 @@ export class SimCfnCfOriginAccessControlConfig {
       `Invalid AWS::CloudFront::OriginAccessControl ${this.resource.logicalId}: ${detail}`,
     );
   }
-}
-
-function isSigningBehavior(
-  value: unknown,
-): value is SimCloudFrontOriginAccessControlSigningBehavior {
-  return signingBehaviors.includes(
-    value as SimCloudFrontOriginAccessControlSigningBehavior,
-  );
 }

--- a/src/service/cloudfront/cfn/origin-access-control/sim-cfn-cf-oac-refusals.iso.test.ts
+++ b/src/service/cloudfront/cfn/origin-access-control/sim-cfn-cf-oac-refusals.iso.test.ts
@@ -64,9 +64,9 @@ describe("AWS::CloudFront::OriginAccessControl refusals", () => {
     assertStringIncludes(error.message, "does not exist");
   });
 
-  it("refuses an origin access control on a custom Origin", async () => {
-    // Given a custom Origin naming an origin access control, which every one
-    // here signs for an S3 Origin rather than a custom one.
+  it("refuses an S3 origin access control on a custom Origin", async () => {
+    // Given an origin access control signing for an S3 Origin, which is not
+    // the kind of Origin a custom Origin is.
     const simAws = new SimAws();
     const stack = await simAws.cloudFormation().deployTemplate({
       stackName: "oac-stack",
@@ -127,6 +127,64 @@ describe("AWS::CloudFront::OriginAccessControl refusals", () => {
     // Then it is refused rather than attached to an Origin it cannot sign for.
     assertStringIncludes(error.message, "custom Origin SiteOrigin");
     assertStringIncludes(error.message, "site-oac");
+    assertStringIncludes(error.message, "origin type is s3 rather than lambda");
+  });
+
+  it("refuses a Function URL origin access control on an S3 Origin", async () => {
+    // Given an origin access control signing for a Lambda Function URL.
+    const simAws = new SimAws();
+
+    // When a Distribution attaches it to an S3 Origin.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.cloudFormation().deployTemplate({
+        stackName: "site-stack",
+        template: {
+          Resources: {
+            SiteBucket: {
+              Type: "AWS::S3::Bucket",
+              Properties: { BucketName: "site-bucket" },
+            },
+            SiteOac: {
+              Type: "AWS::CloudFront::OriginAccessControl",
+              Properties: {
+                OriginAccessControlConfig: {
+                  Name: "site-oac",
+                  OriginAccessControlOriginType: "lambda",
+                  SigningBehavior: "always",
+                  SigningProtocol: "sigv4",
+                },
+              },
+            },
+            SiteDistribution: {
+              Type: "AWS::CloudFront::Distribution",
+              DependsOn: ["SiteBucket", "SiteOac"],
+              Properties: {
+                DistributionConfig: {
+                  Enabled: true,
+                  Origins: [
+                    {
+                      Id: "SiteOrigin",
+                      DomainName: "site-bucket.s3.amazonaws.com",
+                      S3OriginConfig: {},
+                      OriginAccessControlId: { Ref: "SiteOac" },
+                    },
+                  ],
+                  DefaultCacheBehavior: {
+                    TargetOriginId: "SiteOrigin",
+                    ViewerProtocolPolicy: "redirect-to-https",
+                  },
+                },
+              },
+            },
+          },
+        },
+      });
+    });
+
+    // Then it is refused in that direction too, as CloudFront refuses either
+    // mismatch rather than only one.
+    assertStringIncludes(error.message, "S3 Origin SiteOrigin");
+    assertStringIncludes(error.message, "origin type is lambda rather than s3");
   });
 
   it("refuses a second origin access control claiming a name", async () => {
@@ -171,7 +229,7 @@ describe("AWS::CloudFront::OriginAccessControl refusals", () => {
   });
 
   it("refuses an origin type it does not sign for", async () => {
-    // Given a template asking for a Lambda Function URL origin access control.
+    // Given a template asking for a MediaStore origin access control.
     const simAws = new SimAws();
 
     const error = await assertThrowsErrorAsync(async () => {
@@ -184,7 +242,7 @@ describe("AWS::CloudFront::OriginAccessControl refusals", () => {
               Properties: {
                 OriginAccessControlConfig: {
                   Name: "api-oac",
-                  OriginAccessControlOriginType: "lambda",
+                  OriginAccessControlOriginType: "mediastore",
                   SigningBehavior: "always",
                   SigningProtocol: "sigv4",
                 },
@@ -201,6 +259,9 @@ describe("AWS::CloudFront::OriginAccessControl refusals", () => {
       error.message,
       "Invalid AWS::CloudFront::OriginAccessControl ApiOac",
     );
-    assertStringIncludes(error.message, "OriginAccessControlOriginType lambda");
+    assertStringIncludes(
+      error.message,
+      "OriginAccessControlOriginType mediastore",
+    );
   });
 });

--- a/src/service/cloudfront/distribution/configurator/sim-cloud-front-origin-configurator.ts
+++ b/src/service/cloudfront/distribution/configurator/sim-cloud-front-origin-configurator.ts
@@ -10,6 +10,7 @@ import type { SimCfCustomOriginDispatcher } from "../../origin/custom/sim-cf-cus
 import { SimCloudFrontCustomOrigin } from "../../origin/custom/sim-cloudfront-custom-origin.js";
 import type { SimCloudFrontOriginAccessControl } from "../../origin-access-control/sim-cf-origin-access-control.js";
 import type { SimCloudFrontOriginAccessControlRegistry } from "../../origin-access-control/sim-cf-origin-access-control-registry.js";
+import { assertSimCfOacOriginType } from "../../origin-access-control/sim-cf-oac-origin-type.js";
 import { SimCloudFrontInvalidOriginAccessControl } from "../../error/sim-cloudfront.error.js";
 
 /**
@@ -46,6 +47,7 @@ export class SimCloudFrontOriginConfigurator {
 
     if (origin.S3OriginConfig !== undefined) {
       assertNoSimCfS3OriginAccessIdentity(origin.Id, origin.S3OriginConfig);
+      assertSimCfOacOriginType(origin.Id, "s3", originAccessControl);
 
       const originBucket = this.s3OriginResolver(origin.DomainName);
 
@@ -66,7 +68,9 @@ export class SimCloudFrontOriginConfigurator {
     }
 
     if (origin.CustomOriginConfig !== undefined) {
-      this.assertNoOriginAccessControl(origin.Id, originAccessControl);
+      // A custom Origin is reached over HTTP, so the only origin access control
+      // that can sign for one is the Lambda Function URL type.
+      assertSimCfOacOriginType(origin.Id, "lambda", originAccessControl);
 
       assertDefined(
         this.customOriginDispatcher,
@@ -80,6 +84,7 @@ export class SimCloudFrontOriginConfigurator {
           domainName: origin.DomainName,
           originPath: origin.OriginPath,
           dispatcher: this.customOriginDispatcher,
+          ...(originAccessControl !== undefined && { originAccessControl }),
         }),
       );
       return;
@@ -123,26 +128,5 @@ export class SimCloudFrontOriginConfigurator {
     }
 
     return originAccessControl;
-  }
-
-  /**
-   * Refuse an origin access control on a custom Origin.
-   *
-   * Every origin access control here signs for an S3 Origin, and CloudFront
-   * refuses one whose origin type does not match the Origin it is attached to.
-   */
-  private assertNoOriginAccessControl(
-    originId: string,
-    originAccessControl: SimCloudFrontOriginAccessControl | undefined,
-  ): void {
-    if (originAccessControl === undefined) {
-      return;
-    }
-
-    throw new SimCloudFrontInvalidOriginAccessControl(
-      `Sim CloudFront custom Origin ${originId} names origin access control ` +
-        `${originAccessControl.name}, which signs for an ` +
-        `${originAccessControl.originType} Origin`,
-    );
   }
 }

--- a/src/service/cloudfront/origin-access-control/sim-cf-oac-origin-type.ts
+++ b/src/service/cloudfront/origin-access-control/sim-cf-oac-origin-type.ts
@@ -1,0 +1,53 @@
+import { SimCloudFrontInvalidOriginAccessControl } from "../error/sim-cloudfront.error.js";
+import type {
+  SimCloudFrontOriginAccessControl,
+  SimCloudFrontOriginAccessControlOriginType,
+} from "./sim-cf-origin-access-control.js";
+
+/**
+ * The Origin an origin type belongs on, as a refusal names it.
+ *
+ * An `s3` origin access control signs an S3 Bucket read, and a `lambda` one
+ * signs a request to a Lambda Function URL, which is reached over HTTP and so
+ * is a custom Origin.
+ */
+function originDescription(
+  originType: SimCloudFrontOriginAccessControlOriginType,
+): string {
+  switch (originType) {
+    case "s3": {
+      return "S3 Origin";
+    }
+    case "lambda": {
+      return "custom Origin";
+    }
+  }
+}
+
+/**
+ * Refuse an origin access control whose origin type is not the one the Origin
+ * it was named on needs.
+ *
+ * CloudFront refuses that pairing, and it is worth reproducing: an origin
+ * access control signing for an S3 Bucket signs nothing a Function URL will
+ * admit, so a template pairing them wrongly would otherwise deploy here and
+ * fail on the real deployment.
+ */
+export function assertSimCfOacOriginType(
+  originId: string,
+  originType: SimCloudFrontOriginAccessControlOriginType,
+  originAccessControl: SimCloudFrontOriginAccessControl | undefined,
+): void {
+  if (
+    originAccessControl === undefined ||
+    originAccessControl.originType === originType
+  ) {
+    return;
+  }
+
+  throw new SimCloudFrontInvalidOriginAccessControl(
+    `Sim CloudFront ${originDescription(originType)} ${originId} names ` +
+      `origin access control ${originAccessControl.name}, whose origin type ` +
+      `is ${originAccessControl.originType} rather than ${originType}`,
+  );
+}

--- a/src/service/cloudfront/origin-access-control/sim-cf-origin-access-control-registry.iso.test.ts
+++ b/src/service/cloudfront/origin-access-control/sim-cf-origin-access-control-registry.iso.test.ts
@@ -15,6 +15,7 @@ describe("SimCloudFrontOriginAccessControlRegistry", () => {
   ): SimCloudFrontOriginAccessControl {
     return new SimCloudFrontOriginAccessControl({
       name,
+      originType: "s3",
       signingBehavior: "always",
     });
   }

--- a/src/service/cloudfront/origin-access-control/sim-cf-origin-access-control.iso.test.ts
+++ b/src/service/cloudfront/origin-access-control/sim-cf-origin-access-control.iso.test.ts
@@ -18,6 +18,7 @@ describe("SimCloudFrontOriginAccessControl", () => {
     // Given an origin access control created without an ID.
     const originAccessControl = new SimCloudFrontOriginAccessControl({
       name: "site-oac",
+      originType: "s3",
       signingBehavior: "always",
     });
 
@@ -31,6 +32,7 @@ describe("SimCloudFrontOriginAccessControl", () => {
     const originAccessControl = new SimCloudFrontOriginAccessControl({
       id: "E1EXAMPLE12345" as SimCloudFrontOriginAccessControlId,
       name: "site-oac",
+      originType: "s3",
       signingBehavior: "always",
     });
 
@@ -38,16 +40,33 @@ describe("SimCloudFrontOriginAccessControl", () => {
     assertIdentical(originAccessControl.id, "E1EXAMPLE12345");
   });
 
-  it("only signs for an S3 Origin with SigV4", () => {
-    // Given an origin access control.
-    const originAccessControl = new SimCloudFrontOriginAccessControl({
+  it("keeps the origin type it signs for", () => {
+    // Given origin access controls for each kind of Origin modelled.
+    const bucketOac = new SimCloudFrontOriginAccessControl({
       name: "site-oac",
+      originType: "s3",
+      signingBehavior: "always",
+    });
+    const functionUrlOac = new SimCloudFrontOriginAccessControl({
+      name: "api-oac",
+      originType: "lambda",
       signingBehavior: "always",
     });
 
-    // Then the origin type and signing protocol are the only ones modelled,
-    // rather than whatever the template happened to ask for.
-    assertIdentical(originAccessControl.originType, "s3");
+    // Then each says which Origin it signs for, which is what decides the
+    // Origin it may be attached to.
+    assertIdentical(bucketOac.originType, "s3");
+    assertIdentical(functionUrlOac.originType, "lambda");
+  });
+
+  it("signs with SigV4, the only protocol CloudFront offers", () => {
+    // Given an origin access control.
+    const originAccessControl = new SimCloudFrontOriginAccessControl({
+      name: "site-oac",
+      originType: "s3",
+      signingBehavior: "always",
+    });
+
     assertIdentical(originAccessControl.signingProtocol, "sigv4");
   });
 
@@ -55,6 +74,7 @@ describe("SimCloudFrontOriginAccessControl", () => {
     // Given an origin access control created without a description.
     const originAccessControl = new SimCloudFrontOriginAccessControl({
       name: "site-oac",
+      originType: "s3",
       signingBehavior: "always",
     });
 
@@ -65,6 +85,7 @@ describe("SimCloudFrontOriginAccessControl", () => {
     // Given an origin access control created with a description.
     const originAccessControl = new SimCloudFrontOriginAccessControl({
       name: "site-oac",
+      originType: "s3",
       description: "Signs reads of the site bucket",
       signingBehavior: "always",
     });
@@ -79,14 +100,17 @@ describe("SimCloudFrontOriginAccessControl", () => {
     // Given the three signing behaviours CloudFront offers.
     const always = new SimCloudFrontOriginAccessControl({
       name: "always-oac",
+      originType: "s3",
       signingBehavior: "always",
     });
     const noOverride = new SimCloudFrontOriginAccessControl({
       name: "no-override-oac",
+      originType: "s3",
       signingBehavior: "no-override",
     });
     const never = new SimCloudFrontOriginAccessControl({
       name: "never-oac",
+      originType: "s3",
       signingBehavior: "never",
     });
 

--- a/src/service/cloudfront/origin-access-control/sim-cf-origin-access-control.ts
+++ b/src/service/cloudfront/origin-access-control/sim-cf-origin-access-control.ts
@@ -19,10 +19,19 @@ export type SimCloudFrontOriginAccessControlSigningBehavior =
   | "never"
   | "no-override";
 
+/**
+ * The kind of Origin an origin access control signs for.
+ *
+ * CloudFront also signs for MediaStore and MediaPackage V2 Origins, neither of
+ * which is modelled, so neither is a value here.
+ */
+export type SimCloudFrontOriginAccessControlOriginType = "s3" | "lambda";
+
 interface SimCloudFrontOriginAccessControlProperties {
   readonly id?: SimCloudFrontOriginAccessControlId;
   readonly name: string;
   readonly description?: string;
+  readonly originType: SimCloudFrontOriginAccessControlOriginType;
   readonly signingBehavior: SimCloudFrontOriginAccessControlSigningBehavior;
 }
 
@@ -30,14 +39,14 @@ interface SimCloudFrontOriginAccessControlProperties {
  * Simulated CloudFront origin access control.
  *
  * An origin access control is attached to an Origin, and it is how a
- * Distribution authenticates to a private S3 Bucket: CloudFront signs the
- * Origin request with SigV4 as the CloudFront service principal, and the Bucket
- * policy grants that principal on the Distribution's ARN.
+ * Distribution authenticates to a private Origin: CloudFront signs the Origin
+ * request with SigV4 as the CloudFront service principal, and the Origin's own
+ * policy grants that principal on the Distribution's ARN. For an S3 Origin that
+ * policy is the Bucket policy, and for a Lambda Function URL it is the
+ * function's resource policy.
  *
- * Only an `s3` origin type signed with `sigv4` is modelled, so those are fixed
- * here rather than stored. Anything else is refused where the origin access
- * control is read, rather than kept and treated as though it behaved like the
- * supported values.
+ * `sigv4` is the only protocol CloudFront offers, so it is fixed here rather
+ * than stored.
  *
  * https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-restricting-access-to-s3.html
  */
@@ -49,8 +58,12 @@ export class SimCloudFrontOriginAccessControl {
 
   /**
    * The kind of Origin this origin access control signs for.
+   *
+   * CloudFront refuses an origin access control attached to an Origin its
+   * origin type does not match, so this is checked where an Origin names one
+   * rather than only described here.
    */
-  public readonly originType = "s3";
+  public readonly originType: SimCloudFrontOriginAccessControlOriginType;
 
   /**
    * The protocol CloudFront signs the Origin request with.
@@ -61,6 +74,7 @@ export class SimCloudFrontOriginAccessControl {
     this.id = properties.id ?? makeOriginAccessControlId();
     this.name = properties.name;
     this.description = properties.description;
+    this.originType = properties.originType;
     this.signingBehavior = properties.signingBehavior;
   }
 

--- a/src/service/cloudfront/origin/custom/sim-cf-custom-origin-oac.iso.test.ts
+++ b/src/service/cloudfront/origin/custom/sim-cf-custom-origin-oac.iso.test.ts
@@ -6,171 +6,31 @@ import {
 } from "@kensio/smartass";
 import { describe, it } from "vitest";
 
-import { SimAwsHttp } from "../../../../serve/http/sim-aws-http.js";
+import { SimAwsServiceRequest } from "../../../../serve/controller/sim-service-controller.js";
 import { SimAwsLocalUrl } from "../../../../serve/http/url/sim-aws-local-url.js";
 import { SimAws } from "../../../aws/sim-aws.js";
 import type { CfnTemplateBodyRecord } from "../../../cloudformation/template/sim-cfn-template.js";
-import type { SimCfnTemplateValue } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import { simAwsCallerHeaderName } from "../../../iam/request/sim-aws-caller-header.js";
+import {
+  simAwsSourceAccountHeaderName,
+  simAwsSourceArnHeaderName,
+} from "../../../iam/request/sim-aws-request-source.js";
+import { SimCloudFrontServiceController } from "../../controller/sim-cloudfront-controller.js";
+import { simCfFunctionUrlOriginTemplateFactory } from "./sim-cf-function-url-origin-template.factory.js";
 
-const assumeRolePolicyDocument = {
-  Version: "2012-10-17",
-  Statement: [
-    {
-      Effect: "Allow",
-      Principal: { Service: "lambda.amazonaws.com" },
-      Action: "sts:AssumeRole",
-    },
-  ],
-};
-
-/**
- * The ARN of the Distribution a Lambda permission is granted for, written the
- * way CDK writes it.
- */
-const distributionArn = {
-  "Fn::Join": [
-    "",
-    [
-      "arn:aws:cloudfront::",
-      { Ref: "AWS::AccountId" },
-      ":distribution/",
-      { Ref: "SiteDistribution" },
-    ],
-  ],
-};
-
-interface FunctionUrlOriginTemplateProperties {
-  /**
-   * How the origin access control signs, which is `always` in what CDK emits.
-   */
-  readonly signingBehavior?: string;
-  /**
-   * The permission admitting CloudFront, left out to deploy the shape a
-   * template that forgot it has.
-   */
-  readonly invokePermission?: Record<string, SimCfnTemplateValue> | undefined;
-}
-
-/**
- * The Stack CDK synthesizes for
- * `origins.FunctionUrlOrigin.withOriginAccessControl()`: an `AWS_IAM` Function
- * URL, an origin access control of origin type `lambda`, a Distribution
- * pointing at the Function URL's domain, and the permission letting CloudFront
- * invoke it.
- */
-function functionUrlOriginTemplate(
-  properties: FunctionUrlOriginTemplateProperties = {},
-): CfnTemplateBodyRecord {
-  const { signingBehavior = "always" } = properties;
-  const invokePermission =
-    properties.invokePermission === undefined
-      ? {}
-      : {
-          InvokeFromCloudFront: {
-            Type: "AWS::Lambda::Permission",
-            Properties: properties.invokePermission,
-          },
-        };
-
-  return {
-    Resources: {
-      GreeterRole: {
-        Type: "AWS::IAM::Role",
-        Properties: {
-          RoleName: "GreeterRole",
-          AssumeRolePolicyDocument: assumeRolePolicyDocument,
-        },
-      },
-      GreeterFunction: {
-        Type: "AWS::Lambda::Function",
-        Properties: {
-          FunctionName: "greeter",
-          Role: { "Fn::GetAtt": ["GreeterRole", "Arn"] },
-          Code: {
-            ZipFile:
-              "exports.handler = async () => " +
-              "({ statusCode: 200, body: 'Hello from behind CloudFront' });",
-          },
-          Handler: "index.handler",
-          Runtime: "nodejs22.x",
-        },
-      },
-      GreeterUrl: {
-        Type: "AWS::Lambda::Url",
-        Properties: {
-          TargetFunctionArn: { "Fn::GetAtt": ["GreeterFunction", "Arn"] },
-          AuthType: "AWS_IAM",
-        },
-      },
-      SiteOac: {
-        Type: "AWS::CloudFront::OriginAccessControl",
-        Properties: {
-          OriginAccessControlConfig: {
-            Name: "site-oac",
-            OriginAccessControlOriginType: "lambda",
-            SigningBehavior: signingBehavior,
-            SigningProtocol: "sigv4",
-          },
-        },
-      },
-      SiteDistribution: {
-        Type: "AWS::CloudFront::Distribution",
-        Properties: {
-          DistributionConfig: {
-            Enabled: true,
-            Origins: [
-              {
-                Id: "FunctionUrlOrigin",
-                // The Function URL endpoint is a URL, and an Origin takes a
-                // domain name, so CDK splits the host out of it.
-                DomainName: {
-                  "Fn::Select": [
-                    2,
-                    {
-                      "Fn::Split": [
-                        "/",
-                        { "Fn::GetAtt": ["GreeterUrl", "FunctionUrl"] },
-                      ],
-                    },
-                  ],
-                },
-                CustomOriginConfig: { OriginProtocolPolicy: "https-only" },
-                OriginAccessControlId: { Ref: "SiteOac" },
-              },
-            ],
-            DefaultCacheBehavior: {
-              TargetOriginId: "FunctionUrlOrigin",
-              ViewerProtocolPolicy: "redirect-to-https",
-            },
-          },
-        },
-      },
-      ...invokePermission,
-    },
-    Outputs: {
-      DistributionDomainName: {
-        Value: { "Fn::GetAtt": ["SiteDistribution", "DomainName"] },
-      },
-    },
-  };
-}
-
-/**
- * The permission CDK emits alongside the Distribution, granting CloudFront the
- * Function URL for that Distribution alone.
- */
-const cloudFrontInvokePermission = {
-  FunctionName: { "Fn::GetAtt": ["GreeterFunction", "Arn"] },
-  Action: "lambda:InvokeFunctionUrl",
-  Principal: "cloudfront.amazonaws.com",
-  SourceArn: distributionArn,
-};
+const accountId = "888888888888";
 
 /**
  * Deploy the Stack and fetch a path through the Distribution it created.
+ *
+ * The viewer's headers are built from the deployed Distribution's ARN, so a
+ * test about what a viewer may state can state the one thing that would work.
  */
 async function fetchThroughDistribution(
   template: CfnTemplateBodyRecord,
+  viewerHeaders: (
+    distributionArn: string,
+  ) => Record<string, string> = () => ({}),
 ): Promise<Response> {
   const simAws = new SimAws();
   const stack = await simAws
@@ -178,15 +38,27 @@ async function fetchThroughDistribution(
     .deployTemplate({ stackName: "site-stack", template });
   await stack.waitForDeployComplete();
 
-  const distributionDomainName = stack.outputs.get(
-    "DistributionDomainName",
-  )?.value;
-  assertTypeString(distributionDomainName);
+  const domainName = stack.outputs.get("DistributionDomainName")?.value;
+  const distributionArn = stack.outputs.get("DistributionArn")?.value;
+  assertTypeString(domainName);
+  assertTypeString(distributionArn);
 
-  return await new SimAwsHttp({ simAws }).fetch(
-    new SimAwsLocalUrl({
-      input: `https://${distributionDomainName}/greeting`,
-    }).toString(),
+  const url = new SimAwsLocalUrl({
+    input: `https://${domainName}/greeting`,
+  }).toString();
+  const request = new Request(url, {
+    headers: viewerHeaders(distributionArn),
+  });
+
+  // Straight to the CloudFront controller rather than through SimAwsHttp, so
+  // that the request arrives as written. The HTTP boundary strips the
+  // simulator's control headers, and a test about what a viewer can state to
+  // an Origin has to be able to send them.
+  return await new SimCloudFrontServiceController({ simAws }).handleRequest(
+    new SimAwsServiceRequest({
+      target: { service: "cloudFront", resourceName: "" },
+      request,
+    }),
   );
 }
 
@@ -195,9 +67,7 @@ describe("Simulated CloudFront custom Origin with an origin access control", () 
     // Given the Stack CDK synthesizes for a Function URL Origin behind an
     // origin access control.
     const response = await fetchThroughDistribution(
-      functionUrlOriginTemplate({
-        invokePermission: cloudFrontInvokePermission,
-      }),
+      simCfFunctionUrlOriginTemplateFactory.make({}),
     );
 
     // Then the handler ran, which an Origin reached anonymously could never
@@ -210,7 +80,7 @@ describe("Simulated CloudFront custom Origin with an origin access control", () 
     // Given the same Stack without the AWS::Lambda::Permission, which is the
     // template mistake this is worth catching.
     const response = await fetchThroughDistribution(
-      functionUrlOriginTemplate(),
+      simCfFunctionUrlOriginTemplateFactory.make({ permitted: false }),
     );
 
     // Then the Function URL refuses the Origin request, and the refusal is
@@ -221,11 +91,8 @@ describe("Simulated CloudFront custom Origin with an origin access control", () 
   it("is refused when the permission names another Distribution", async () => {
     // Given a permission granted for a Distribution other than this one.
     const response = await fetchThroughDistribution(
-      functionUrlOriginTemplate({
-        invokePermission: {
-          ...cloudFrontInvokePermission,
-          SourceArn: "arn:aws:cloudfront::888888888888:distribution/E1OTHER123",
-        },
+      simCfFunctionUrlOriginTemplateFactory.make({
+        permissionSourceArn: `arn:aws:cloudfront::${accountId}:distribution/E1OTHER123`,
       }),
     );
 
@@ -234,14 +101,31 @@ describe("Simulated CloudFront custom Origin with an origin access control", () 
     assertResponseStatus(response, 403, await describeResponse(response));
   });
 
+  it("does not let a viewer state who the Origin request is from", async () => {
+    // Given a Distribution whose Origin has no origin access control, and a
+    // viewer claiming to be CloudFront reaching the Function URL for that
+    // Distribution, which is the one claim that would work if it got through.
+    const response = await fetchThroughDistribution(
+      simCfFunctionUrlOriginTemplateFactory.make({
+        originAccessControl: false,
+      }),
+      (distributionArn) => ({
+        [simAwsCallerHeaderName]: "service:cloudfront.amazonaws.com",
+        [simAwsSourceArnHeaderName]: distributionArn,
+        [simAwsSourceAccountHeaderName]: accountId,
+      }),
+    );
+
+    // Then the claim is dropped rather than forwarded, so the Origin request
+    // is the anonymous one the Origin really makes and the URL refuses it.
+    assertResponseStatus(response, 403, await describeResponse(response));
+  });
+
   it("reaches the Origin anonymously when the origin access control never signs", async () => {
     // Given an origin access control turned off with a `never` signing
     // behaviour, and the permission still in place.
     const response = await fetchThroughDistribution(
-      functionUrlOriginTemplate({
-        signingBehavior: "never",
-        invokePermission: cloudFrontInvokePermission,
-      }),
+      simCfFunctionUrlOriginTemplateFactory.make({ signingBehavior: "never" }),
     );
 
     // Then nothing states who the Origin request is from, so the AWS_IAM

--- a/src/service/cloudfront/origin/custom/sim-cf-custom-origin-oac.iso.test.ts
+++ b/src/service/cloudfront/origin/custom/sim-cf-custom-origin-oac.iso.test.ts
@@ -1,0 +1,251 @@
+import {
+  assertIdentical,
+  assertResponseStatus,
+  assertTypeString,
+  describeResponse,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAwsHttp } from "../../../../serve/http/sim-aws-http.js";
+import { SimAwsLocalUrl } from "../../../../serve/http/url/sim-aws-local-url.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+import type { CfnTemplateBodyRecord } from "../../../cloudformation/template/sim-cfn-template.js";
+import type { SimCfnTemplateValue } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+
+const assumeRolePolicyDocument = {
+  Version: "2012-10-17",
+  Statement: [
+    {
+      Effect: "Allow",
+      Principal: { Service: "lambda.amazonaws.com" },
+      Action: "sts:AssumeRole",
+    },
+  ],
+};
+
+/**
+ * The ARN of the Distribution a Lambda permission is granted for, written the
+ * way CDK writes it.
+ */
+const distributionArn = {
+  "Fn::Join": [
+    "",
+    [
+      "arn:aws:cloudfront::",
+      { Ref: "AWS::AccountId" },
+      ":distribution/",
+      { Ref: "SiteDistribution" },
+    ],
+  ],
+};
+
+interface FunctionUrlOriginTemplateProperties {
+  /**
+   * How the origin access control signs, which is `always` in what CDK emits.
+   */
+  readonly signingBehavior?: string;
+  /**
+   * The permission admitting CloudFront, left out to deploy the shape a
+   * template that forgot it has.
+   */
+  readonly invokePermission?: Record<string, SimCfnTemplateValue> | undefined;
+}
+
+/**
+ * The Stack CDK synthesizes for
+ * `origins.FunctionUrlOrigin.withOriginAccessControl()`: an `AWS_IAM` Function
+ * URL, an origin access control of origin type `lambda`, a Distribution
+ * pointing at the Function URL's domain, and the permission letting CloudFront
+ * invoke it.
+ */
+function functionUrlOriginTemplate(
+  properties: FunctionUrlOriginTemplateProperties = {},
+): CfnTemplateBodyRecord {
+  const { signingBehavior = "always" } = properties;
+  const invokePermission =
+    properties.invokePermission === undefined
+      ? {}
+      : {
+          InvokeFromCloudFront: {
+            Type: "AWS::Lambda::Permission",
+            Properties: properties.invokePermission,
+          },
+        };
+
+  return {
+    Resources: {
+      GreeterRole: {
+        Type: "AWS::IAM::Role",
+        Properties: {
+          RoleName: "GreeterRole",
+          AssumeRolePolicyDocument: assumeRolePolicyDocument,
+        },
+      },
+      GreeterFunction: {
+        Type: "AWS::Lambda::Function",
+        Properties: {
+          FunctionName: "greeter",
+          Role: { "Fn::GetAtt": ["GreeterRole", "Arn"] },
+          Code: {
+            ZipFile:
+              "exports.handler = async () => " +
+              "({ statusCode: 200, body: 'Hello from behind CloudFront' });",
+          },
+          Handler: "index.handler",
+          Runtime: "nodejs22.x",
+        },
+      },
+      GreeterUrl: {
+        Type: "AWS::Lambda::Url",
+        Properties: {
+          TargetFunctionArn: { "Fn::GetAtt": ["GreeterFunction", "Arn"] },
+          AuthType: "AWS_IAM",
+        },
+      },
+      SiteOac: {
+        Type: "AWS::CloudFront::OriginAccessControl",
+        Properties: {
+          OriginAccessControlConfig: {
+            Name: "site-oac",
+            OriginAccessControlOriginType: "lambda",
+            SigningBehavior: signingBehavior,
+            SigningProtocol: "sigv4",
+          },
+        },
+      },
+      SiteDistribution: {
+        Type: "AWS::CloudFront::Distribution",
+        Properties: {
+          DistributionConfig: {
+            Enabled: true,
+            Origins: [
+              {
+                Id: "FunctionUrlOrigin",
+                // The Function URL endpoint is a URL, and an Origin takes a
+                // domain name, so CDK splits the host out of it.
+                DomainName: {
+                  "Fn::Select": [
+                    2,
+                    {
+                      "Fn::Split": [
+                        "/",
+                        { "Fn::GetAtt": ["GreeterUrl", "FunctionUrl"] },
+                      ],
+                    },
+                  ],
+                },
+                CustomOriginConfig: { OriginProtocolPolicy: "https-only" },
+                OriginAccessControlId: { Ref: "SiteOac" },
+              },
+            ],
+            DefaultCacheBehavior: {
+              TargetOriginId: "FunctionUrlOrigin",
+              ViewerProtocolPolicy: "redirect-to-https",
+            },
+          },
+        },
+      },
+      ...invokePermission,
+    },
+    Outputs: {
+      DistributionDomainName: {
+        Value: { "Fn::GetAtt": ["SiteDistribution", "DomainName"] },
+      },
+    },
+  };
+}
+
+/**
+ * The permission CDK emits alongside the Distribution, granting CloudFront the
+ * Function URL for that Distribution alone.
+ */
+const cloudFrontInvokePermission = {
+  FunctionName: { "Fn::GetAtt": ["GreeterFunction", "Arn"] },
+  Action: "lambda:InvokeFunctionUrl",
+  Principal: "cloudfront.amazonaws.com",
+  SourceArn: distributionArn,
+};
+
+/**
+ * Deploy the Stack and fetch a path through the Distribution it created.
+ */
+async function fetchThroughDistribution(
+  template: CfnTemplateBodyRecord,
+): Promise<Response> {
+  const simAws = new SimAws();
+  const stack = await simAws
+    .cloudFormation()
+    .deployTemplate({ stackName: "site-stack", template });
+  await stack.waitForDeployComplete();
+
+  const distributionDomainName = stack.outputs.get(
+    "DistributionDomainName",
+  )?.value;
+  assertTypeString(distributionDomainName);
+
+  return await new SimAwsHttp({ simAws }).fetch(
+    new SimAwsLocalUrl({
+      input: `https://${distributionDomainName}/greeting`,
+    }).toString(),
+  );
+}
+
+describe("Simulated CloudFront custom Origin with an origin access control", () => {
+  it("reaches an AWS_IAM Function URL as the CloudFront service principal", async () => {
+    // Given the Stack CDK synthesizes for a Function URL Origin behind an
+    // origin access control.
+    const response = await fetchThroughDistribution(
+      functionUrlOriginTemplate({
+        invokePermission: cloudFrontInvokePermission,
+      }),
+    );
+
+    // Then the handler ran, which an Origin reached anonymously could never
+    // get past the auth type to do.
+    assertResponseStatus(response, 200, await describeResponse(response));
+    assertIdentical(await response.text(), "Hello from behind CloudFront");
+  });
+
+  it("is refused when nothing granted CloudFront the Function URL", async () => {
+    // Given the same Stack without the AWS::Lambda::Permission, which is the
+    // template mistake this is worth catching.
+    const response = await fetchThroughDistribution(
+      functionUrlOriginTemplate(),
+    );
+
+    // Then the Function URL refuses the Origin request, and the refusal is
+    // what the viewer sees, rather than the Distribution admitting it anyway.
+    assertResponseStatus(response, 403, await describeResponse(response));
+  });
+
+  it("is refused when the permission names another Distribution", async () => {
+    // Given a permission granted for a Distribution other than this one.
+    const response = await fetchThroughDistribution(
+      functionUrlOriginTemplate({
+        invokePermission: {
+          ...cloudFrontInvokePermission,
+          SourceArn: "arn:aws:cloudfront::888888888888:distribution/E1OTHER123",
+        },
+      }),
+    );
+
+    // Then the Origin request carries the Distribution it really came from, so
+    // the condition does not match and the Function URL refuses it.
+    assertResponseStatus(response, 403, await describeResponse(response));
+  });
+
+  it("reaches the Origin anonymously when the origin access control never signs", async () => {
+    // Given an origin access control turned off with a `never` signing
+    // behaviour, and the permission still in place.
+    const response = await fetchThroughDistribution(
+      functionUrlOriginTemplate({
+        signingBehavior: "never",
+        invokePermission: cloudFrontInvokePermission,
+      }),
+    );
+
+    // Then nothing states who the Origin request is from, so the AWS_IAM
+    // Function URL refuses it, as it refuses any anonymous request.
+    assertResponseStatus(response, 403, await describeResponse(response));
+  });
+});

--- a/src/service/cloudfront/origin/custom/sim-cf-custom-origin-request.ts
+++ b/src/service/cloudfront/origin/custom/sim-cf-custom-origin-request.ts
@@ -4,6 +4,11 @@ interface SimCfCustomOriginRequestProperties {
   readonly domainName: string;
   readonly originPath: string;
   readonly request: Request;
+  /**
+   * Headers stating who the Origin request is from, which an Origin whose
+   * origin access control signs carries and an anonymous one does not.
+   */
+  readonly signingHeaders?: Readonly<Record<string, string>> | undefined;
 }
 
 /**
@@ -32,6 +37,12 @@ export function simCfCustomOriginRequest(
 
   const headers = new Headers(request.headers);
   headers.set("host", originUrl.host);
+
+  const signingHeaders = Object.entries(properties.signingHeaders ?? {});
+
+  for (const [name, value] of signingHeaders) {
+    headers.set(name, value);
+  }
 
   const isBodyAllowed = !/^(?:get|head)$/iu.test(request.method);
 

--- a/src/service/cloudfront/origin/custom/sim-cf-custom-origin-request.ts
+++ b/src/service/cloudfront/origin/custom/sim-cf-custom-origin-request.ts
@@ -1,4 +1,5 @@
 import { SimAwsLocalUrl } from "../../../../serve/http/url/sim-aws-local-url.js";
+import { stripSimAwsControlHeaders } from "../../../iam/request/sim-aws-control-headers.js";
 
 interface SimCfCustomOriginRequestProperties {
   readonly domainName: string;
@@ -37,6 +38,13 @@ export function simCfCustomOriginRequest(
 
   const headers = new Headers(request.headers);
   headers.set("host", originUrl.host);
+
+  // Who the Origin request is from is the Origin's business, not the viewer's,
+  // so a viewer's own control headers are dropped before the Origin's are
+  // applied. A viewer reaching a Distribution through the HTTP boundary has
+  // had them stripped already; one reaching a controller in process has not,
+  // and either way an unsigned Origin should state nothing.
+  stripSimAwsControlHeaders(headers);
 
   const signingHeaders = Object.entries(properties.signingHeaders ?? {});
 

--- a/src/service/cloudfront/origin/custom/sim-cf-custom-origin-signer.ts
+++ b/src/service/cloudfront/origin/custom/sim-cf-custom-origin-signer.ts
@@ -1,0 +1,60 @@
+import {
+  simAwsCallerHeaderName,
+  simAwsCallerHeaderValue,
+} from "../../../iam/request/sim-aws-caller-header.js";
+import {
+  simAwsSourceAccountHeaderName,
+  simAwsSourceArnHeaderName,
+} from "../../../iam/request/sim-aws-request-source.js";
+import { simCloudFrontDistributionArn } from "../../distribution/sim-cf-distribution-view.js";
+import type { SimCloudFrontOriginAccessControl } from "../../origin-access-control/sim-cf-origin-access-control.js";
+import { simCloudFrontServicePrincipal } from "../../sim-cloudfront-service-principal.js";
+import type { SimCloudFrontOriginRequest } from "../sim-cloudfront-request-response.js";
+
+/**
+ * Who a CloudFront custom Origin is reached as.
+ *
+ * An origin access control that signs makes the Origin request one from the
+ * CloudFront service principal carrying the Distribution's ARN, which is the
+ * pair a Function URL's `lambda:InvokeFunctionUrl` permission for CloudFront is
+ * written against. Without one, or with a `SigningBehavior` of `never`, the
+ * Origin is reached anonymously, so a Function URL with `AWS_IAM` refuses it.
+ *
+ * Real CloudFront states that by signing the request with SigV4. Nothing here
+ * computes a signature, so it is stated at the simulated HTTP boundary instead,
+ * the same way anything else calling into simulated AWS in process says who it
+ * is.
+ *
+ * Which Distribution the request belongs to is only known per request, so this
+ * answers per fetch rather than when the Origin is built.
+ */
+export class SimCfCustomOriginSigner {
+  private readonly originAccessControl:
+    | SimCloudFrontOriginAccessControl
+    | undefined;
+
+  constructor(originAccessControl?: SimCloudFrontOriginAccessControl) {
+    this.originAccessControl = originAccessControl;
+  }
+
+  /**
+   * The headers stating who one Origin request is from, which are none when the
+   * Origin is reached anonymously.
+   */
+  forRequest(request: SimCloudFrontOriginRequest): Record<string, string> {
+    if (this.originAccessControl?.signs !== true) {
+      return {};
+    }
+
+    return {
+      [simAwsCallerHeaderName]: simAwsCallerHeaderValue({
+        kind: "service",
+        service: simCloudFrontServicePrincipal,
+      }),
+      [simAwsSourceArnHeaderName]: simCloudFrontDistributionArn(
+        request.distribution,
+      ),
+      [simAwsSourceAccountHeaderName]: request.distribution.accountId,
+    };
+  }
+}

--- a/src/service/cloudfront/origin/custom/sim-cf-function-url-origin-fragments.ts
+++ b/src/service/cloudfront/origin/custom/sim-cf-function-url-origin-fragments.ts
@@ -1,0 +1,96 @@
+import type {
+  SimCfnTemplateValue,
+  SimCfnTemplateValueRecord,
+} from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+
+/**
+ * What a test asks for when it wants the template CDK synthesizes for
+ * `origins.FunctionUrlOrigin.withOriginAccessControl()`.
+ *
+ * Five Resources stand between a test and a Function URL served through a
+ * Distribution, and each test about that shape is about one of them being
+ * wrong, so each field here is one thing a template can get wrong on its own.
+ */
+export interface SimCfFunctionUrlOriginTemplateInput {
+  /** How the origin access control signs, which is `always` in what CDK emits. */
+  readonly signingBehavior: string;
+  /**
+   * Whether the Origin has an origin access control at all, since an Origin
+   * without one is reached anonymously.
+   */
+  readonly originAccessControl: boolean;
+  /**
+   * Whether the template grants CloudFront the Function URL, which CDK always
+   * does alongside the Distribution.
+   */
+  readonly permitted: boolean;
+  /** The Distribution the permission is granted for. */
+  readonly permissionSourceArn: SimCfnTemplateValue;
+}
+
+/**
+ * The parts of the template a template can leave out.
+ *
+ * Each is a Resource, or a property of one, that CDK always writes and that a
+ * hand-written template can forget. The origin access control contributes two,
+ * which are both there or both absent, since an Origin naming one nothing
+ * created would be refused rather than reached.
+ */
+export interface SimCfFunctionUrlOriginParts {
+  readonly originAccessControl: SimCfnTemplateValueRecord;
+  readonly originAccessControlId: SimCfnTemplateValueRecord;
+  readonly invokePermission: SimCfnTemplateValueRecord;
+}
+
+/**
+ * Build the optional parts of a Function URL Origin template.
+ */
+export function simCfFunctionUrlOriginParts(
+  input: SimCfFunctionUrlOriginTemplateInput,
+): SimCfFunctionUrlOriginParts {
+  return {
+    originAccessControl: included(input.originAccessControl, {
+      SiteOac: {
+        Type: "AWS::CloudFront::OriginAccessControl",
+        Properties: {
+          OriginAccessControlConfig: {
+            Name: "site-oac",
+            OriginAccessControlOriginType: "lambda",
+            SigningBehavior: input.signingBehavior,
+            SigningProtocol: "sigv4",
+          },
+        },
+      },
+    }),
+    originAccessControlId: included(input.originAccessControl, {
+      OriginAccessControlId: { Ref: "SiteOac" },
+    }),
+    // The permission CDK writes beside the Distribution, letting CloudFront
+    // invoke the Function URL for that Distribution alone.
+    invokePermission: included(input.permitted, {
+      InvokeFromCloudFront: {
+        Type: "AWS::Lambda::Permission",
+        Properties: {
+          FunctionName: { "Fn::GetAtt": ["GreeterFunction", "Arn"] },
+          Action: "lambda:InvokeFunctionUrl",
+          Principal: "cloudfront.amazonaws.com",
+          SourceArn: input.permissionSourceArn,
+        },
+      },
+    }),
+  };
+}
+
+/**
+ * One fragment of the template, or nothing where the template omits it.
+ */
+function included(
+  present: boolean,
+  fragment: SimCfnTemplateValueRecord,
+): SimCfnTemplateValueRecord {
+  if (!present) {
+    return {};
+  }
+
+  return fragment;
+}

--- a/src/service/cloudfront/origin/custom/sim-cf-function-url-origin-template.factory.ts
+++ b/src/service/cloudfront/origin/custom/sim-cf-function-url-origin-template.factory.ts
@@ -1,0 +1,133 @@
+import { MappedFactory } from "@kensio/part-factory";
+
+import type { CfnTemplateBodyRecord } from "../../../cloudformation/template/sim-cfn-template.js";
+import type { SimCfnTemplateValue } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import {
+  type SimCfFunctionUrlOriginTemplateInput,
+  simCfFunctionUrlOriginParts,
+} from "./sim-cf-function-url-origin-fragments.js";
+
+const assumeRolePolicyDocument = {
+  Version: "2012-10-17",
+  Statement: [
+    {
+      Effect: "Allow",
+      Principal: { Service: "lambda.amazonaws.com" },
+      Action: "sts:AssumeRole",
+    },
+  ],
+};
+
+/**
+ * The ARN of the Distribution the template creates, written the way CDK writes
+ * it.
+ */
+export const simCfDistributionArn: SimCfnTemplateValue = {
+  "Fn::Join": [
+    "",
+    [
+      "arn:aws:cloudfront::",
+      { Ref: "AWS::AccountId" },
+      ":distribution/",
+      { Ref: "SiteDistribution" },
+    ],
+  ],
+};
+
+/**
+ * Builds the template for a Lambda Function URL served through a Distribution
+ * with an origin access control.
+ *
+ * ```typescript
+ * const stack = await simAws.cloudFormation().deployTemplate({
+ *   stackName: "site-stack",
+ *   template: simCfFunctionUrlOriginTemplateFactory.make({ permitted: false }),
+ * });
+ * ```
+ *
+ * The Function URL authorizes with `AWS_IAM`, which is the whole point of the
+ * shape: the endpoint exists, and only the Distribution may use it.
+ */
+export const simCfFunctionUrlOriginTemplateFactory = new MappedFactory<
+  SimCfFunctionUrlOriginTemplateInput,
+  CfnTemplateBodyRecord
+>(
+  () => ({
+    signingBehavior: "always",
+    originAccessControl: true,
+    permitted: true,
+    permissionSourceArn: simCfDistributionArn,
+  }),
+  (input) => ({
+    Resources: {
+      GreeterRole: {
+        Type: "AWS::IAM::Role",
+        Properties: {
+          RoleName: "GreeterRole",
+          AssumeRolePolicyDocument: assumeRolePolicyDocument,
+        },
+      },
+      GreeterFunction: {
+        Type: "AWS::Lambda::Function",
+        Properties: {
+          FunctionName: "greeter",
+          Role: { "Fn::GetAtt": ["GreeterRole", "Arn"] },
+          Code: {
+            ZipFile:
+              "exports.handler = async () => " +
+              "({ statusCode: 200, body: 'Hello from behind CloudFront' });",
+          },
+          Handler: "index.handler",
+          Runtime: "nodejs22.x",
+        },
+      },
+      GreeterUrl: {
+        Type: "AWS::Lambda::Url",
+        Properties: {
+          TargetFunctionArn: { "Fn::GetAtt": ["GreeterFunction", "Arn"] },
+          AuthType: "AWS_IAM",
+        },
+      },
+      ...simCfFunctionUrlOriginParts(input).originAccessControl,
+      SiteDistribution: {
+        Type: "AWS::CloudFront::Distribution",
+        Properties: {
+          DistributionConfig: {
+            Enabled: true,
+            Origins: [
+              {
+                Id: "FunctionUrlOrigin",
+                // The Function URL endpoint is a URL, and an Origin takes a
+                // domain name, so CDK splits the host out of it.
+                DomainName: {
+                  "Fn::Select": [
+                    2,
+                    {
+                      "Fn::Split": [
+                        "/",
+                        { "Fn::GetAtt": ["GreeterUrl", "FunctionUrl"] },
+                      ],
+                    },
+                  ],
+                },
+                CustomOriginConfig: { OriginProtocolPolicy: "https-only" },
+                ...simCfFunctionUrlOriginParts(input).originAccessControlId,
+              },
+            ],
+            DefaultCacheBehavior: {
+              TargetOriginId: "FunctionUrlOrigin",
+              ViewerProtocolPolicy: "redirect-to-https",
+            },
+          },
+        },
+      },
+      ...simCfFunctionUrlOriginParts(input).invokePermission,
+    },
+    Outputs: {
+      DistributionDomainName: {
+        Value: { "Fn::GetAtt": ["SiteDistribution", "DomainName"] },
+      },
+      DistributionArn: { Value: simCfDistributionArn },
+    },
+  }),
+);

--- a/src/service/cloudfront/origin/custom/sim-cloudfront-custom-origin.ts
+++ b/src/service/cloudfront/origin/custom/sim-cloudfront-custom-origin.ts
@@ -1,13 +1,16 @@
+import type { SimCloudFrontOriginAccessControl } from "../../origin-access-control/sim-cf-origin-access-control.js";
 import type { SimCloudFrontOrigin } from "../sim-cloudfront-origin.js";
 import type { SimCloudFrontOriginRequest } from "../sim-cloudfront-request-response.js";
 import type { SimCfCustomOriginDispatcher } from "./sim-cf-custom-origin-dispatcher.js";
 import { simCfCustomOriginRequest } from "./sim-cf-custom-origin-request.js";
+import { SimCfCustomOriginSigner } from "./sim-cf-custom-origin-signer.js";
 
 interface SimCloudFrontCustomOriginProperties {
   readonly originId: string;
   readonly domainName: string;
   readonly originPath?: string | undefined;
   readonly dispatcher: SimCfCustomOriginDispatcher;
+  readonly originAccessControl?: SimCloudFrontOriginAccessControl | undefined;
 }
 
 /**
@@ -18,21 +21,33 @@ interface SimCloudFrontCustomOriginProperties {
  * with an endpoint of its own: an HTTP API or a Lambda Function URL, or
  * anything a simulated Route53 record points at one of those.
  *
- * The Origin is reached anonymously, as CloudFront reaches an Origin it has no
- * Origin Access Control for, so a Function URL or route that authorizes with
- * `AWS_IAM` refuses the request.
+ * An Origin with no origin access control is reached anonymously, as CloudFront
+ * reaches one it has nothing to sign for, so a Function URL or route that
+ * authorizes with `AWS_IAM` refuses the request. One whose origin access
+ * control signs is reached as the CloudFront service principal instead, which
+ * is what a Function URL behind an origin access control admits.
  */
 export class SimCloudFrontCustomOrigin implements SimCloudFrontOrigin {
+  /**
+   * The origin access control this Origin was created with, if any.
+   */
+  public readonly originAccessControl:
+    | SimCloudFrontOriginAccessControl
+    | undefined;
+
   private readonly originId: string;
   private readonly domainName: string;
   private readonly originPath: string;
   private readonly dispatcher: SimCfCustomOriginDispatcher;
+  private readonly signer: SimCfCustomOriginSigner;
 
   constructor(properties: SimCloudFrontCustomOriginProperties) {
     this.originId = properties.originId;
     this.domainName = properties.domainName;
     this.originPath = properties.originPath ?? "";
     this.dispatcher = properties.dispatcher;
+    this.originAccessControl = properties.originAccessControl;
+    this.signer = new SimCfCustomOriginSigner(properties.originAccessControl);
   }
 
   /**
@@ -47,6 +62,7 @@ export class SimCloudFrontCustomOrigin implements SimCloudFrontOrigin {
       domainName: this.domainName,
       originPath: this.originPath,
       request: request.req,
+      signingHeaders: this.signer.forRequest(request),
     });
 
     const { hostname } = new URL(originRequest.url);

--- a/src/service/iam/index.ts
+++ b/src/service/iam/index.ts
@@ -22,6 +22,11 @@ export {
   SimAwsRequestCaller,
 } from "./request/sim-aws-request-caller.js";
 export {
+  SimAwsRequestSource,
+  simAwsSourceAccountHeaderName,
+  simAwsSourceArnHeaderName,
+} from "./request/sim-aws-request-source.js";
+export {
   isSimAwsRequestAuthFailure,
   SimAwsInvalidCallerHeader,
   type SimAwsRequestAuthFailure,

--- a/src/service/iam/request/sim-aws-control-headers.ts
+++ b/src/service/iam/request/sim-aws-control-headers.ts
@@ -1,0 +1,30 @@
+import { simAwsCallerHeaderName } from "./sim-aws-caller-header.js";
+import {
+  simAwsSourceAccountHeaderName,
+  simAwsSourceArnHeaderName,
+} from "./sim-aws-request-source.js";
+
+/**
+ * Header names that are instructions to the simulator rather than part of the
+ * request being simulated.
+ *
+ * They state who a request is from and what it is for, so anything passing a
+ * request on to a simulated service has to decide what to do with them rather
+ * than forward them by accident: the HTTP boundary strips them once the
+ * request has been attributed, and sim CloudFront strips a viewer's before
+ * deciding for itself what an Origin request says.
+ */
+export const simAwsControlHeaderNames: readonly string[] = [
+  simAwsCallerHeaderName,
+  simAwsSourceArnHeaderName,
+  simAwsSourceAccountHeaderName,
+];
+
+/**
+ * Remove the simulator's control headers from a set of request headers.
+ */
+export function stripSimAwsControlHeaders(headers: Headers): void {
+  for (const name of simAwsControlHeaderNames) {
+    headers.delete(name);
+  }
+}

--- a/src/service/iam/request/sim-aws-request-source.iso.test.ts
+++ b/src/service/iam/request/sim-aws-request-source.iso.test.ts
@@ -1,0 +1,59 @@
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import {
+  SimAwsRequestSource,
+  simAwsSourceAccountHeaderName,
+  simAwsSourceArnHeaderName,
+} from "./sim-aws-request-source.js";
+
+describe("SimAwsRequestSource", () => {
+  it("reads the resource a request is made on behalf of", () => {
+    // Given a request stating the Distribution it came from, as sim CloudFront
+    // states one reaching an Origin through an origin access control.
+    const source = SimAwsRequestSource.fromHeaders(
+      new Headers({
+        [simAwsSourceArnHeaderName]:
+          "arn:aws:cloudfront::888888888888:distribution/E1EXAMPLE12345",
+        [simAwsSourceAccountHeaderName]: "888888888888",
+      }),
+    );
+
+    // Then both are read, which is the pair a grant to a service principal is
+    // conditioned on.
+    assertNonNullable(source);
+    assertIdentical(
+      source.arn,
+      "arn:aws:cloudfront::888888888888:distribution/E1EXAMPLE12345",
+    );
+    assertIdentical(source.accountId, "888888888888");
+  });
+
+  it("has no Account when only the resource was stated", () => {
+    // Given a request naming the resource and not the Account, which is what
+    // a permission conditioned on the ARN alone needs.
+    const source = SimAwsRequestSource.fromHeaders(
+      new Headers({
+        [simAwsSourceArnHeaderName]:
+          "arn:aws:cloudfront::888888888888:distribution/E1EXAMPLE12345",
+      }),
+    );
+
+    assertUndefined(source?.accountId);
+  });
+
+  it("is nothing at all when the request stated no source", () => {
+    // Given an ordinary request, which is every request that is not one
+    // service calling another for a resource.
+    const source = SimAwsRequestSource.fromHeaders(new Headers());
+
+    // Then there is no source rather than an empty one, so a policy
+    // conditioned on either key fails to match instead of matching an empty
+    // string.
+    assertUndefined(source);
+  });
+});

--- a/src/service/iam/request/sim-aws-request-source.iso.test.ts
+++ b/src/service/iam/request/sim-aws-request-source.iso.test.ts
@@ -43,7 +43,28 @@ describe("SimAwsRequestSource", () => {
       }),
     );
 
-    assertUndefined(source?.accountId);
+    // Then there is a source, carrying the one thing it was told.
+    assertNonNullable(source);
+    assertIdentical(
+      source.arn,
+      "arn:aws:cloudfront::888888888888:distribution/E1EXAMPLE12345",
+    );
+    assertUndefined(source.accountId);
+  });
+
+  it("reads an empty header as no source at all", () => {
+    // Given a request carrying the headers with nothing in them, which is not
+    // a resource anything could be granted for.
+    const source = SimAwsRequestSource.fromHeaders(
+      new Headers({
+        [simAwsSourceArnHeaderName]: "",
+        [simAwsSourceAccountHeaderName]: "  ",
+      }),
+    );
+
+    // Then it is the same as saying nothing, rather than a source whose ARN
+    // is the empty string.
+    assertUndefined(source);
   });
 
   it("is nothing at all when the request stated no source", () => {

--- a/src/service/iam/request/sim-aws-request-source.ts
+++ b/src/service/iam/request/sim-aws-request-source.ts
@@ -1,0 +1,57 @@
+/**
+ * The header naming the AWS resource a request is being made on behalf of.
+ *
+ * When one AWS service calls another it says what it is calling for, and IAM
+ * supplies that as `aws:SourceArn`. A resource policy granting a service
+ * principal is normally conditioned on it, so that a Distribution or a Bucket
+ * can be granted rather than the whole service. Nothing about an HTTP request
+ * arriving in process says any of that, so the caller states it the same way it
+ * states who it is.
+ */
+export const simAwsSourceArnHeaderName = "x-sim-aws-source-arn";
+
+/**
+ * The header naming the Account owning the resource the request is made on
+ * behalf of, supplied by IAM as `aws:SourceAccount`.
+ */
+export const simAwsSourceAccountHeaderName = "x-sim-aws-source-account";
+
+interface SimAwsRequestSourceProperties {
+  readonly arn?: string | undefined;
+  readonly accountId?: string | undefined;
+}
+
+/**
+ * What a request says it is being made on behalf of.
+ *
+ * This is separate from the caller: the caller is who is asking, and this is
+ * which of their resources they are asking for. Only a service principal has
+ * one in practice, since that is the case AWS supplies the condition keys for.
+ */
+export class SimAwsRequestSource {
+  public readonly arn: string | undefined;
+  public readonly accountId: string | undefined;
+
+  constructor(properties: SimAwsRequestSourceProperties) {
+    this.arn = properties.arn;
+    this.accountId = properties.accountId;
+  }
+
+  /**
+   * Read the source a request states, or nothing when it states none.
+   *
+   * A request carrying neither header has no source rather than an empty one,
+   * so a policy conditioned on either fails to match instead of matching an
+   * empty string.
+   */
+  static fromHeaders(headers: Headers): SimAwsRequestSource | undefined {
+    const arn = headers.get(simAwsSourceArnHeaderName) ?? undefined;
+    const accountId = headers.get(simAwsSourceAccountHeaderName) ?? undefined;
+
+    if (arn === undefined && accountId === undefined) {
+      return undefined;
+    }
+
+    return new SimAwsRequestSource({ arn, accountId });
+  }
+}

--- a/src/service/iam/request/sim-aws-request-source.ts
+++ b/src/service/iam/request/sim-aws-request-source.ts
@@ -42,11 +42,13 @@ export class SimAwsRequestSource {
    *
    * A request carrying neither header has no source rather than an empty one,
    * so a policy conditioned on either fails to match instead of matching an
-   * empty string.
+   * empty string. A header present but empty is the same thing said a
+   * different way, and is read the same, since no AWS service names a resource
+   * by sending nothing.
    */
   static fromHeaders(headers: Headers): SimAwsRequestSource | undefined {
-    const arn = headers.get(simAwsSourceArnHeaderName) ?? undefined;
-    const accountId = headers.get(simAwsSourceAccountHeaderName) ?? undefined;
+    const arn = stated(headers.get(simAwsSourceArnHeaderName));
+    const accountId = stated(headers.get(simAwsSourceAccountHeaderName));
 
     if (arn === undefined && accountId === undefined) {
       return undefined;
@@ -54,4 +56,15 @@ export class SimAwsRequestSource {
 
     return new SimAwsRequestSource({ arn, accountId });
   }
+}
+
+/**
+ * One header value, or nothing when the request did not really state it.
+ */
+function stated(value: string | null): string | undefined {
+  if (value === null || value.trim().length === 0) {
+    return undefined;
+  }
+
+  return value;
 }

--- a/src/service/lambda/serve/auth/sim-lambda-url-authorizer.ts
+++ b/src/service/lambda/serve/auth/sim-lambda-url-authorizer.ts
@@ -4,7 +4,12 @@ import type {
   SimIamInterServiceAuthZ,
 } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
 import { simLambdaResourcePolicies } from "../../command/authorize/sim-lambda-resource-policies.js";
-import { simLambdaFunctionUrlAuthTypeConditionKey } from "../../function/policy/sim-lambda-permission.js";
+import {
+  simLambdaFunctionUrlAuthTypeConditionKey,
+  simLambdaSourceAccountConditionKey,
+  simLambdaSourceArnConditionKey,
+} from "../../function/policy/sim-lambda-permission.js";
+import type { SimAwsRequestSource } from "../../../iam/request/sim-aws-request-source.js";
 import type { SimLambdaFunction } from "../../function/sim-lambda-function.js";
 import type { SimLambdaFunctionUrl } from "../../function/url/sim-lambda-function-url.js";
 
@@ -26,6 +31,11 @@ interface SimLambdaUrlAuthorizationInput {
   readonly simFunction: SimLambdaFunction;
   readonly functionUrl: SimLambdaFunctionUrl;
   readonly caller: SimAwsCaller;
+  /**
+   * The resource the request said it was made on behalf of, such as the
+   * CloudFront Distribution reaching a Function URL Origin.
+   */
+  readonly source?: SimAwsRequestSource | undefined;
 }
 
 /**
@@ -52,10 +62,18 @@ export class SimLambdaUrlAuthorizer {
    * The URL's auth type is supplied as `lambda:FunctionUrlAuthType`, which is
    * what a grant conditions on in practice: a permission granted for `AWS_IAM`
    * should not also open a URL later switched to `NONE`.
+   *
+   * A request made on behalf of a resource supplies `AWS:SourceArn` and
+   * `AWS:SourceAccount` with it, which is what the permission granting
+   * `cloudfront.amazonaws.com` names its Distribution in. A request that states
+   * no source supplies neither, so a permission conditioned on one does not
+   * match rather than matching anything.
    */
   authorize(
     input: SimLambdaUrlAuthorizationInput,
   ): SimIamAuthorizationDecision {
+    const { source } = input;
+
     return this.iam.authorize({
       action: simLambdaInvokeFunctionUrlAction,
       resource: input.simFunction.arn,
@@ -63,6 +81,12 @@ export class SimLambdaUrlAuthorizer {
       resourcePolicies: simLambdaResourcePolicies(input.simFunction),
       conditionContext: {
         [simLambdaFunctionUrlAuthTypeConditionKey]: input.functionUrl.authType,
+        ...(source?.arn !== undefined && {
+          [simLambdaSourceArnConditionKey]: source.arn,
+        }),
+        ...(source?.accountId !== undefined && {
+          [simLambdaSourceAccountConditionKey]: source.accountId,
+        }),
       },
     });
   }

--- a/src/service/lambda/serve/sim-lambda-controller.ts
+++ b/src/service/lambda/serve/sim-lambda-controller.ts
@@ -73,6 +73,10 @@ export class SimLambdaServiceController implements SimAwsServiceController {
    * named principal, and is anonymous when the request offered neither.
    * Anonymous owns no policies, so an unsigned request is refused by the same
    * evaluation that admits a permitted one, rather than by a special case.
+   *
+   * What the request is being made on behalf of travels with it, so a
+   * CloudFront Distribution reaching this URL through an origin access control
+   * is judged against the Distribution the permission names.
    */
   private async invokeAuthenticated(
     route: SimLambdaFunctionUrlRoute,
@@ -83,6 +87,7 @@ export class SimLambdaServiceController implements SimAwsServiceController {
       simFunction: route.simFunction,
       functionUrl: route.functionUrl,
       caller: caller.toCaller(),
+      source: serviceRequest.source,
     });
 
     if (decision.isDenied) {


### PR DESCRIPTION
A CloudFront origin access control now carries the origin type it signs for, and accepts `lambda` alongside `s3`. A custom Origin may name one of origin type `lambda`, which makes the Origin request come from the CloudFront service principal carrying the Distribution's ARN, stated at the simulated HTTP boundary with the new `x-sim-aws-source-arn` and `x-sim-aws-source-account` headers. An `AWS_IAM` Lambda Function URL evaluates its `lambda:InvokeFunctionUrl` permission against that pair, so the Stack CDK synthesizes for
`origins.FunctionUrlOrigin.withOriginAccessControl()` deploys and serves, and one missing the permission or naming another Distribution answers 403 the way the real deployment does. An origin type that does not match the Origin it was named on is refused in both directions, as CloudFront refuses it.

Resolves https://github.com/KensioSoftware/yulin/issues/588

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CloudFront Origin Access Controls now support Lambda Function URL origins in addition to S3.
  * Added IAM-based authorization for CloudFront requests to protected Lambda Function URLs.
  * Added validation to prevent mismatched origin and access-control configurations.
* **Documentation**
  * Expanded CloudFront, IAM, and Lambda guidance with configuration examples, authorization behavior, and limitations.
* **Tests**
  * Added integration and coverage tests for successful, unauthorized, mismatched, and unsigned requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->