### PR TITLE
feat: serve an ECS service through a target group

### DIFF
--- a/docs/services/ecs/README.md
+++ b/docs/services/ecs/README.md
@@ -1901,9 +1901,10 @@ Current documented limitations:
 - A service whose tasks fail to start does not start replacements for them. Real ECS keeps trying,
   which would be an endless retry in a test rather than a result to assert on, so the service
   reports the running count it actually has.
-- A `loadBalancers` entry needs a `targetGroupArn`, a `containerName` and a `containerPort`, and the
-  target group has to be an `ip` one in the service's own account and region. A `loadBalancerName`,
-  which is the Classic Load Balancer form, is refused, and so is a target group that is not there.
+- A `loadBalancers` entry needs a `targetGroupArn`, a `containerName` and a `containerPort` between
+  1 and 65535, and the target group has to be an `ip` one in the service's own account and region. A
+  `loadBalancerName`, which is the Classic Load Balancer form, is refused, and so is a target group
+  that is not there.
 - Which container of a task a request reaches diverges from real ECS on purpose. Real ECS routes to
   the container the registration names, on the port it names; here the request goes to a container
   that is bound, which is the one the registration names where it is bound, otherwise the bound

--- a/docs/services/ecs/README.md
+++ b/docs/services/ecs/README.md
@@ -430,8 +430,8 @@ where both would match, and binding the same container again replaces what it ru
 
 The other shape a binding can take is `http`, a fetch-style
 `(request: Request) => Response | Promise<Response>` for a service container behind a load balancer.
-The shape is settled, but nothing serves a container yet, so binding one is refused rather than
-accepted and never called.
+It is called once for each request routed to the container, and is covered under
+[serving requests behind a load balancer](#serving-requests-behind-a-load-balancer).
 
 ## What a container sees while it runs
 
@@ -848,8 +848,8 @@ running three things at once. A test that needs concurrency is a test about your
 ECS.
 
 A container of a service that has come up is treated as running from that point, and what calls it
-is whatever reaches it: a queue it consumes, or a load balancer sending it a request. Consuming a
-queue is covered below; being served a request follows separately.
+is whatever reaches it: a queue it consumes, or a load balancer sending it a request. Both are
+covered below.
 
 ### Consuming a queue
 
@@ -1043,6 +1043,151 @@ and share the queue between them, which comes to the same messages being handled
 A consuming container is the one kind a `RunTask` task cannot run. It has no handler that ends, and a
 task has to end, so a task started from the same definition records the container as not simulated
 with a reason saying to create a service instead.
+
+### Serving requests behind a load balancer
+
+A service container that answers HTTP requests declares `http` instead of `run` or `consumes`. The
+handler is fetch-style: it is given a `Request` and answers with a `Response`, which is the same
+shape a simulated load balancer already answers a served request with.
+
+What reaches it is a request routed through simulated [Elastic Load Balancing](../elbv2/). A service
+declares `loadBalancers` naming a target group, a container and a container port; creating the
+service registers each of its tasks into that target group, and a request the load balancer forwards
+there reaches the bound container's handler.
+
+```typescript sim-ecs-serve-load-balancer
+/**
+ * A simulated ECS service answering requests behind a load balancer.
+ */
+
+import {
+  CreateClusterCommand,
+  CreateServiceCommand,
+  RegisterTaskDefinitionCommand,
+} from "@aws-sdk/client-ecs";
+import {
+  CreateListenerCommand,
+  CreateLoadBalancerCommand,
+  CreateTargetGroupCommand,
+} from "@aws-sdk/client-elastic-load-balancing-v2";
+
+import { SimAws } from "@kensio/yulin";
+import { simElbV2Fetch } from "@kensio/yulin/elbv2";
+
+const simAws = new SimAws();
+const ecs = simAws.ecs();
+const elbV2 = simAws.elbV2();
+
+const targetGroup = await elbV2.createTargetGroup(
+  new CreateTargetGroupCommand({
+    Name: "orders-tg",
+    TargetType: "ip",
+    Protocol: "HTTP",
+    Port: 8080,
+  }),
+);
+
+const targetGroupArn = targetGroup.TargetGroups?.[0]?.TargetGroupArn;
+
+const loadBalancer = await elbV2.createLoadBalancer(
+  new CreateLoadBalancerCommand({ Name: "orders-alb" }),
+);
+
+await elbV2.createListener(
+  new CreateListenerCommand({
+    LoadBalancerArn: loadBalancer.LoadBalancers?.[0]?.LoadBalancerArn,
+    Protocol: "HTTP",
+    Port: 80,
+    DefaultActions: [{ Type: "forward", TargetGroupArn: targetGroupArn }],
+  }),
+);
+
+await ecs.createCluster(new CreateClusterCommand({ clusterName: "orders" }));
+
+ecs.bindContainer({
+  family: "orders-api",
+  containerName: "app",
+  http: (request) => {
+    const { pathname } = new URL(request.url);
+
+    return Response.json({ path: pathname }, { status: 200 });
+  },
+});
+
+await ecs.registerTaskDefinition(
+  new RegisterTaskDefinitionCommand({
+    family: "orders-api",
+    containerDefinitions: [
+      {
+        name: "app",
+        image: "orders-api:1",
+        portMappings: [{ containerPort: 8080 }],
+      },
+    ],
+  }),
+);
+
+await ecs.createService(
+  new CreateServiceCommand({
+    cluster: "orders",
+    serviceName: "orders-api",
+    taskDefinition: "orders-api",
+    desiredCount: 2,
+    loadBalancers: [
+      { targetGroupArn, containerName: "app", containerPort: 8080 },
+    ],
+  }),
+);
+
+// The tasks come up in the background, as they do on real ECS, and each of
+// them is registered in the target group as it starts.
+await simAws.backgroundTasksComplete();
+
+const dnsName = loadBalancer.LoadBalancers?.[0]?.DNSName;
+const response = await simElbV2Fetch(simAws, `http://${dnsName}/orders/42`);
+
+console.log(response.status); // 200
+console.log(await response.json()); // { path: "/orders/42" }
+```
+
+The handler runs as the task role, with the container's environment applied, exactly as a container
+consuming a queue or one run by `RunTask` does. So application code inside it builds an SDK client
+from `process.env` and is authorized by simulated IAM against the role the task definition declared.
+
+The container sees the request the client made, with the headers a load balancer writes in front of
+a target: the `host` the client asked for, `x-forwarded-for`, `x-forwarded-proto`, `x-forwarded-port`
+and `x-amzn-trace-id`. The URL is the AWS-facing one, so `new URL(request.url)` reads the name the
+client asked for rather than a localhost one.
+
+#### Which container of a task answers
+
+Real ECS sends the request to the container the registration names, on the port it names. Yulin
+diverges from that on purpose, and it is worth knowing why.
+
+A great many deployed services put a proxy container, usually nginx, on the port the service
+registers, with the application listening behind it. Yulin has nothing to run in place of that proxy:
+there is no image to run and nothing a test could bind to it. Routing strictly by name and port would
+therefore send every request to a container that does not exist here, and the service would answer
+nothing however carefully it was set up.
+
+So the request goes to a container that is bound:
+
+- the container the registration names, when that container is bound;
+- otherwise the bound container that declared the registration's `containerPort`, which is what
+  chooses between two containers that both answer;
+- otherwise the first bound container of the task.
+
+```typescript
+// A registration naming the proxy still reaches the application behind it.
+loadBalancers: [{ targetGroupArn, containerName: "nginx", containerPort: 80 }];
+```
+
+A target group whose service has no bound container at all is answered with a 503 by the load
+balancer, which is the honest answer: the tasks are registered and there is nothing behind them.
+
+`RunTask` cannot run a serving container, for the same reason it cannot run a consuming one. It has
+no handler that ends and no request to send it, so a task started from the same definition records
+the container as not simulated with a reason saying to create a service instead.
 
 ### Updating and deleting a service
 
@@ -1464,9 +1609,10 @@ definition moves it onto the revision the update registered, replacing the tasks
 Tearing the stack down deletes the service, stopping its tasks and leaving it `INACTIVE`, whatever
 it was scaled to.
 
-`LoadBalancers` is recorded on the service rather than acted on, since nothing here sends a service
-container a request yet. What the template declared is readable, which is what a target group needs
-to find the service and container that answer for it:
+`LoadBalancers` registers the service's tasks into the target group it names, so a template that
+declares a load balancer, a target group and a service deploys something that answers. The target
+group has to exist and hold addresses, or the deployment fails naming it, and what the template
+declared is readable on the simulated service:
 
 ```typescript
 console.log(simAws.ecs().service("orders-worker", "orders").loadBalancers);
@@ -1656,7 +1802,11 @@ console.log(described.taskDefinition?.revision); // 1
   answering `Ref` with the service ARN and `Fn::GetAtt` with `Name` and `ServiceArn`
 - A stack update that scales a service or moves it onto a new revision, and a teardown that deletes
   it
-- `LoadBalancers` on a service, recorded as declared and readable on the simulated service
+- A container binding that answers `http` requests, called once per request a load balancer routes
+  to the container
+- `loadBalancers` on a service, registering each of its tasks into the target group it names and
+  deregistering them as they stop
+- `LoadBalancers` on an `AWS::ECS::Service`, deploying into the same registration
 - `simAws.ecs().service()`, reading a simulated service by name in a cluster or by its ARN
 - Deploy-time container bindings, targeting a container by family and container name, by the task
   definition's logical ID or CDK construct ID, or by its image repository, and declaring `run` or
@@ -1727,10 +1877,9 @@ Current documented limitations:
 - A service's desired count is simulated as state rather than as concurrency. Three tasks exist and
   are reported as running, and the handler bound to a container is called once per request or per
   poll rather than once per task. Yulin runs in one Node.js process, so there is nothing to copy.
-- Nothing serves a service container a request yet. A bound container of a service is treated as
-  running and stays available until the service is deleted or its `SimAws` is closed; consuming a
-  queue is what calls its handler so far, and a load balancer sending it a request follows
-  separately.
+- A bound container of a service is treated as running and stays available until the service is
+  deleted or its `SimAws` is closed. What calls its handler is whatever reaches it: a queue it
+  consumes, or a request a load balancer routes to it.
 - A consuming container's loop is Yulin's rather than the container's. A binding supplies what
   happens to a batch, and nothing tries to run a polling loop written inside your own container code,
   because an endless loop in a single Node.js process never yields to the test running it.
@@ -1744,23 +1893,37 @@ Current documented limitations:
   there is something to poll for, so there is nothing to set.
 - A consuming container handles a batch all or nothing. There is no partial batch response, which is
   a Lambda event source feature rather than something a worker container has.
-- A consuming container of a task started by `RunTask` records the same not-simulated reason an
-  unbound container does, since it has no handler that ends and a run task has to end.
+- A consuming or serving container of a task started by `RunTask` records the same not-simulated
+  reason an unbound container does. Neither has a handler that ends, and a run task has to end.
 - A service's tasks come up all at once and are replaced all at once. There are no deployments,
   deployment controllers, circuit breakers or rolling replacement, so `DescribeServices` reports no
   `deployments` and no `events`, and `UpdateService` refuses `forceNewDeployment`.
 - A service whose tasks fail to start does not start replacements for them. Real ECS keeps trying,
   which would be an endless retry in a test rather than a result to assert on, so the service
   reports the running count it actually has.
-- `CreateService` takes `loadBalancers` and records them without acting on them, since nothing here
-  sends a service container a request yet. The declaration is reported back and readable on the
-  simulated service, which is what a load balancer target group has to read to find the service that
-  answers for it.
+- A `loadBalancers` entry needs a `targetGroupArn`, a `containerName` and a `containerPort`, and the
+  target group has to be an `ip` one in the service's own account and region. A `loadBalancerName`,
+  which is the Classic Load Balancer form, is refused, and so is a target group that is not there.
+- Which container of a task a request reaches diverges from real ECS on purpose. Real ECS routes to
+  the container the registration names, on the port it names; here the request goes to a container
+  that is bound, which is the one the registration names where it is bound, otherwise the bound
+  container declaring the registration's port, otherwise the first bound one. The common real task
+  puts an unsimulated proxy on the registered port, and routing strictly would reach a container
+  that does not exist here.
+- A service registered into a target group with no bound container is answered with a 503 by the
+  load balancer. The tasks are registered and there is nothing behind them.
+- A task is registered as a target as soon as the service starts it and deregistered as soon as it
+  stops. There are no health checks, no target health states, no deregistration delay and no
+  connection draining, and the address a task is registered under is counted rather than taken from
+  a network interface that does not exist.
+- Requests are not shared between a service's tasks. The desired count is state rather than
+  concurrency, so a target group holding three targets calls one handler.
 - `CreateService` refuses `serviceRegistries`, `networkConfiguration`, `deploymentConfiguration`,
-  `capacityProviderStrategy` and the rest of what it takes. There is no network here, and nothing
-  serves a service container yet.
-- `UpdateService` changes the desired count and the task definition and nothing else, so a load
-  balancer a service was created with stays as it was declared.
+  `capacityProviderStrategy` and the rest of what it takes. There is no network or capacity here for
+  any of them to apply to.
+- `UpdateService` changes the desired count and the task definition and nothing else, so a service's
+  load balancer registration stays as it was created. Its tasks are registered and deregistered as
+  the count changes.
 - `CreateService` refuses a `schedulingStrategy` of `DAEMON`, which places one task on each container
   instance. There are no container instances here to place one on each of.
 - `CreateService` needs a `desiredCount`, as a replica service does on real ECS, and it can be zero.

--- a/docs/services/ecs/sim-ecs-serve-load-balancer.example.ts
+++ b/docs/services/ecs/sim-ecs-serve-load-balancer.example.ts
@@ -1,0 +1,92 @@
+/**
+ * A simulated ECS service answering requests behind a load balancer.
+ */
+
+import {
+  CreateClusterCommand,
+  CreateServiceCommand,
+  RegisterTaskDefinitionCommand,
+} from "@aws-sdk/client-ecs";
+import {
+  CreateListenerCommand,
+  CreateLoadBalancerCommand,
+  CreateTargetGroupCommand,
+} from "@aws-sdk/client-elastic-load-balancing-v2";
+
+import { SimAws } from "@kensio/yulin";
+import { simElbV2Fetch } from "@kensio/yulin/elbv2";
+
+const simAws = new SimAws();
+const ecs = simAws.ecs();
+const elbV2 = simAws.elbV2();
+
+const targetGroup = await elbV2.createTargetGroup(
+  new CreateTargetGroupCommand({
+    Name: "orders-tg",
+    TargetType: "ip",
+    Protocol: "HTTP",
+    Port: 8080,
+  }),
+);
+
+const targetGroupArn = targetGroup.TargetGroups?.[0]?.TargetGroupArn;
+
+const loadBalancer = await elbV2.createLoadBalancer(
+  new CreateLoadBalancerCommand({ Name: "orders-alb" }),
+);
+
+await elbV2.createListener(
+  new CreateListenerCommand({
+    LoadBalancerArn: loadBalancer.LoadBalancers?.[0]?.LoadBalancerArn,
+    Protocol: "HTTP",
+    Port: 80,
+    DefaultActions: [{ Type: "forward", TargetGroupArn: targetGroupArn }],
+  }),
+);
+
+await ecs.createCluster(new CreateClusterCommand({ clusterName: "orders" }));
+
+ecs.bindContainer({
+  family: "orders-api",
+  containerName: "app",
+  http: (request) => {
+    const { pathname } = new URL(request.url);
+
+    return Response.json({ path: pathname }, { status: 200 });
+  },
+});
+
+await ecs.registerTaskDefinition(
+  new RegisterTaskDefinitionCommand({
+    family: "orders-api",
+    containerDefinitions: [
+      {
+        name: "app",
+        image: "orders-api:1",
+        portMappings: [{ containerPort: 8080 }],
+      },
+    ],
+  }),
+);
+
+await ecs.createService(
+  new CreateServiceCommand({
+    cluster: "orders",
+    serviceName: "orders-api",
+    taskDefinition: "orders-api",
+    desiredCount: 2,
+    loadBalancers: [
+      { targetGroupArn, containerName: "app", containerPort: 8080 },
+    ],
+  }),
+);
+
+// The tasks come up in the background, as they do on real ECS, and each of
+// them is registered in the target group as it starts.
+await simAws.backgroundTasksComplete();
+
+const dnsName = loadBalancer.LoadBalancers?.[0]?.DNSName;
+const response = await simElbV2Fetch(simAws, `http://${dnsName}/orders/42`);
+
+console.log(response.status); // 200
+console.log(await response.json()); // { path: "/orders/42" }

--- a/docs/services/elbv2/README.md
+++ b/docs/services/elbv2/README.md
@@ -951,6 +951,249 @@ nothing but 502s. Real ELB refuses to register a Lambda target at all until the 
 here the permission is checked when the request arrives instead, so a target group can be built in
 any order and a policy that is later removed stops the requests.
 
+## Carrying a request to an ECS service
+
+An `ip` target group is answered by the simulated [ECS](../ecs/) service registered into it. A
+service declares `loadBalancers` naming a target group, a container and a container port; each task
+it keeps running is registered into that group as an address, and a request forwarded there reaches
+the handler bound to the service's container.
+
+That is the whole path an application takes: a client asks for a name, Route53 resolves it to the
+load balancer, a rule picks the target group, and the container's own code answers. This is a stack
+deployed from a template, which is how one usually arrives.
+
+```typescript sim-elbv2-serve-ecs-service
+/**
+ * A request reaching an ECS service's container through a load balancer.
+ */
+
+import {
+  DynamoDBClient,
+  GetItemCommand,
+  PutItemCommand,
+} from "@aws-sdk/client-dynamodb";
+
+import { SimSdk } from "@kensio/yulin/sdk";
+import { SimAwsHttp } from "@kensio/yulin/serve";
+
+using simSdk = new SimSdk();
+const { simAws } = simSdk;
+
+// The application's own SDK clients, intercepted as they would be in any test.
+simSdk.intercept(DynamoDBClient);
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "orders",
+  template: {
+    Resources: {
+      OrdersTable: {
+        Type: "AWS::DynamoDB::Table",
+        Properties: {
+          TableName: "orders",
+          BillingMode: "PAY_PER_REQUEST",
+          AttributeDefinitions: [
+            { AttributeName: "orderId", AttributeType: "S" },
+          ],
+          KeySchema: [{ AttributeName: "orderId", KeyType: "HASH" }],
+        },
+      },
+      OrdersTaskRole: {
+        Type: "AWS::IAM::Role",
+        Properties: {
+          RoleName: "OrdersTaskRole",
+          AssumeRolePolicyDocument: {
+            Version: "2012-10-17",
+            Statement: [
+              {
+                Effect: "Allow",
+                Principal: { Service: "ecs-tasks.amazonaws.com" },
+                Action: "sts:AssumeRole",
+              },
+            ],
+          },
+          Policies: [
+            {
+              PolicyName: "ReadWriteOrders",
+              PolicyDocument: {
+                Version: "2012-10-17",
+                Statement: [
+                  {
+                    Effect: "Allow",
+                    Action: ["dynamodb:PutItem", "dynamodb:GetItem"],
+                    Resource: { "Fn::GetAtt": ["OrdersTable", "Arn"] },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
+      OrdersAlb: {
+        Type: "AWS::ElasticLoadBalancingV2::LoadBalancer",
+        Properties: { Name: "orders-alb", Scheme: "internet-facing" },
+      },
+      OrdersTargetGroup: {
+        Type: "AWS::ElasticLoadBalancingV2::TargetGroup",
+        Properties: {
+          Name: "orders-tg",
+          TargetType: "ip",
+          Protocol: "HTTP",
+          Port: 80,
+        },
+      },
+      HttpListener: {
+        Type: "AWS::ElasticLoadBalancingV2::Listener",
+        Properties: {
+          LoadBalancerArn: { Ref: "OrdersAlb" },
+          Protocol: "HTTP",
+          Port: 80,
+          DefaultActions: [
+            { Type: "forward", TargetGroupArn: { Ref: "OrdersTargetGroup" } },
+          ],
+        },
+      },
+      OrdersZone: {
+        Type: "AWS::Route53::HostedZone",
+        Properties: { Name: "example.test" },
+      },
+      OrdersRecord: {
+        Type: "AWS::Route53::RecordSet",
+        Properties: {
+          HostedZoneId: { Ref: "OrdersZone" },
+          Name: "orders.example.test",
+          Type: "A",
+          AliasTarget: {
+            DNSName: { "Fn::GetAtt": ["OrdersAlb", "DNSName"] },
+            HostedZoneId: {
+              "Fn::GetAtt": ["OrdersAlb", "CanonicalHostedZoneID"],
+            },
+          },
+        },
+      },
+      OrdersCluster: {
+        Type: "AWS::ECS::Cluster",
+        Properties: { ClusterName: "orders" },
+      },
+      OrdersTaskDefinition: {
+        Type: "AWS::ECS::TaskDefinition",
+        Properties: {
+          Family: "orders-api",
+          NetworkMode: "awsvpc",
+          TaskRoleArn: { "Fn::GetAtt": ["OrdersTaskRole", "Arn"] },
+          ContainerDefinitions: [
+            // The proxy the service registers, which Yulin has nothing to run.
+            {
+              Name: "nginx",
+              Image: "public.ecr.aws/nginx/nginx:1.27",
+              PortMappings: [{ ContainerPort: 80 }],
+            },
+            {
+              Name: "app",
+              Image: "example.dkr.ecr.eu-west-2.amazonaws.com/orders-api:1",
+              PortMappings: [{ ContainerPort: 8080 }],
+              Environment: [{ Name: "ORDERS_TABLE", Value: "orders" }],
+            },
+          ],
+        },
+      },
+      OrdersService: {
+        Type: "AWS::ECS::Service",
+        Properties: {
+          ServiceName: "orders-api",
+          Cluster: { Ref: "OrdersCluster" },
+          TaskDefinition: { Ref: "OrdersTaskDefinition" },
+          DesiredCount: 2,
+          LaunchType: "FARGATE",
+          LoadBalancers: [
+            {
+              TargetGroupArn: { Ref: "OrdersTargetGroup" },
+              ContainerName: "nginx",
+              ContainerPort: 80,
+            },
+          ],
+        },
+      },
+    },
+  },
+  bindings: [
+    {
+      logicalId: "OrdersTaskDefinition",
+      containerName: "app",
+      http: async (request: Request): Promise<Response> => {
+        const dynamoDb = new DynamoDBClient({});
+        const orderId = new URL(request.url).pathname.split("/").at(-1) ?? "";
+
+        if (request.method === "POST") {
+          await dynamoDb.send(
+            new PutItemCommand({
+              TableName: process.env["ORDERS_TABLE"],
+              Item: { orderId: { S: orderId }, item: { S: "flat white" } },
+            }),
+          );
+
+          return new Response("", { status: 201 });
+        }
+
+        const read = await dynamoDb.send(
+          new GetItemCommand({
+            TableName: process.env["ORDERS_TABLE"],
+            Key: { orderId: { S: orderId } },
+          }),
+        );
+
+        return Response.json({ item: read.Item?.["item"]?.S ?? null });
+      },
+    },
+  ],
+});
+
+await stack.waitForDeployComplete();
+await simAws.backgroundTasksComplete();
+
+// The name Route53 answers for, reached in process rather than over a socket.
+const client = new SimAwsHttp({ simAws });
+const url = "http://orders.example.test.sim-aws.localhost:52341/orders/42";
+
+const placed = await client.fetch(url, { method: "POST" });
+
+console.log(placed.status); // 201
+
+const read = await client.fetch(url);
+
+console.log(await read.json()); // { item: "flat white" }
+```
+
+The container's own AWS calls are authorized as the task role the task definition declared, so a
+policy that would break the deployed service breaks the test. Everything in the handler is ordinary
+application code: an SDK client, `process.env`, a route and a response.
+
+### What the container is given
+
+The request is the one the client made, with the headers a load balancer writes in front of a
+target: the `host` the client asked for, `x-forwarded-for`, `x-forwarded-proto`, `x-forwarded-port`
+and `x-amzn-trace-id`. Its URL is the AWS-facing one, carrying the listener's scheme and port, so a
+container reading `request.url` sees the name a client asked for rather than the localhost one a
+served request arrived at. A Lambda target behind the same listener gets the same values in its
+event, since both are written by the same rules.
+
+### Which container answers, and when nothing does
+
+Which container of a task a request reaches is a deliberate divergence, documented in full under
+[the ECS service docs](../ecs/#which-container-of-a-task-answers). Briefly: real ECS routes to the
+container the registration names on the port it names, the common real task puts an unsimulated
+proxy on that port, so the request goes to a container that is bound instead.
+
+Three things are all the same 503 real ELB answers when no target is in service:
+
+- a target group with nothing registered in it;
+- a target group whose registered service has no container bound to an HTTP handler;
+- an address registered by hand, since nothing in this simulation listens on an address and only an
+  ECS service registration puts something behind one.
+
+A container whose handler throws is a 502, as a Lambda target that throws is, and so is one that
+answers with something that is not a `Response`. The error goes no further than the load balancer,
+which is where it goes on real AWS too.
+
 ## Reaching a load balancer by name
 
 A load balancer's DNS name resolves through simulated [Route53](../route53/), so a record pointing at
@@ -1549,6 +1792,8 @@ console.log(created.LoadBalancers?.[0]?.DNSName);
   request only when all of its conditions hold.
 - `forward` to a `lambda` target group, which invokes its function with an ALB-shaped event, and the
   `fixed-response` and `redirect` actions, which the load balancer answers itself.
+- `forward` to an `ip` target group, which reaches the container of the simulated ECS service
+  registered into it, with the request carrying the forwarding headers a load balancer writes.
 - The load balancer's own 503, 502 and 413, and the invoke permission the function's resource policy
   has to grant `elasticloadbalancing.amazonaws.com`.
 - Deploying `AWS::ElasticLoadBalancingV2::LoadBalancer`, `TargetGroup`, `Listener` and
@@ -1570,9 +1815,16 @@ console.log(created.LoadBalancers?.[0]?.DNSName);
   name in the URL. On real AWS those are the same thing, because DNS is what brought the request to
   the load balancer. A request served under the Yulin-local suffix is matched against the name inside
   that suffix, so `api.example.test.sim-aws.localhost` is matched as `api.example.test`.
-- A `forward` action is carried out only to a `lambda` target group. An `ip` target group and a
-  `ForwardConfig` naming several target groups by weight are each refused when the request arrives
-  rather than answered with something else.
+- A `ForwardConfig` naming several target groups by weight is refused when the request arrives rather
+  than answered with something else. Nothing here reads the weights, so which group takes a request
+  is not a question this can answer.
+- An `ip` target group is answered by the simulated ECS service registered into it, and by nothing
+  else. An address registered by hand is a 503, since nothing in this simulation listens on an
+  address for one to name.
+- Requests are not shared between the targets of a group. An ECS service's desired count is state
+  rather than concurrency, so a group holding three targets calls one container handler.
+- Which container of an ECS task a request reaches diverges from real ECS on purpose, and is
+  documented under [the ECS docs](../ecs/#which-container-of-a-task-answers).
 - A redirect is not checked against the listener it is on, so redirecting HTTPS to HTTP is accepted
   where real ELB refuses it. Nothing here performs TLS, so the listener's protocol is not something a
   request can be trusted to have arrived over.
@@ -1615,9 +1867,8 @@ console.log(created.LoadBalancers?.[0]?.DNSName);
   single-value `headers` and `queryStringParameters` fields. A repeated query string key keeps its
   last value, as real ELB does with the attribute off, while repeated request headers arrive already
   joined with commas rather than reduced to the last one.
-- Health check requests are never sent to a Lambda target, so a handler will not see the
-  `ELB-HealthChecker/2.0` event real ELB sends when health checks are enabled on a `lambda` target
-  group.
+- Health check requests are never sent to a target, so neither a Lambda function nor a container will
+  see the `ELB-HealthChecker/2.0` request real ELB sends when health checks are enabled.
 - Network and gateway load balancers are not simulated. `Type: "network"` and `"gateway"` are
   refused, as are the `TCP`, `TLS`, `UDP`, `TCP_UDP` and `GENEVE` protocols.
 - `TargetType: "instance"` and `"alb"` are refused rather than accepted and ignored, and a target

--- a/docs/services/elbv2/sim-elbv2-serve-ecs-service.example.ts
+++ b/docs/services/elbv2/sim-elbv2-serve-ecs-service.example.ts
@@ -1,0 +1,198 @@
+/**
+ * A request reaching an ECS service's container through a load balancer.
+ */
+
+import {
+  DynamoDBClient,
+  GetItemCommand,
+  PutItemCommand,
+} from "@aws-sdk/client-dynamodb";
+
+import { SimSdk } from "@kensio/yulin/sdk";
+import { SimAwsHttp } from "@kensio/yulin/serve";
+
+using simSdk = new SimSdk();
+const { simAws } = simSdk;
+
+// The application's own SDK clients, intercepted as they would be in any test.
+simSdk.intercept(DynamoDBClient);
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "orders",
+  template: {
+    Resources: {
+      OrdersTable: {
+        Type: "AWS::DynamoDB::Table",
+        Properties: {
+          TableName: "orders",
+          BillingMode: "PAY_PER_REQUEST",
+          AttributeDefinitions: [
+            { AttributeName: "orderId", AttributeType: "S" },
+          ],
+          KeySchema: [{ AttributeName: "orderId", KeyType: "HASH" }],
+        },
+      },
+      OrdersTaskRole: {
+        Type: "AWS::IAM::Role",
+        Properties: {
+          RoleName: "OrdersTaskRole",
+          AssumeRolePolicyDocument: {
+            Version: "2012-10-17",
+            Statement: [
+              {
+                Effect: "Allow",
+                Principal: { Service: "ecs-tasks.amazonaws.com" },
+                Action: "sts:AssumeRole",
+              },
+            ],
+          },
+          Policies: [
+            {
+              PolicyName: "ReadWriteOrders",
+              PolicyDocument: {
+                Version: "2012-10-17",
+                Statement: [
+                  {
+                    Effect: "Allow",
+                    Action: ["dynamodb:PutItem", "dynamodb:GetItem"],
+                    Resource: { "Fn::GetAtt": ["OrdersTable", "Arn"] },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
+      OrdersAlb: {
+        Type: "AWS::ElasticLoadBalancingV2::LoadBalancer",
+        Properties: { Name: "orders-alb", Scheme: "internet-facing" },
+      },
+      OrdersTargetGroup: {
+        Type: "AWS::ElasticLoadBalancingV2::TargetGroup",
+        Properties: {
+          Name: "orders-tg",
+          TargetType: "ip",
+          Protocol: "HTTP",
+          Port: 80,
+        },
+      },
+      HttpListener: {
+        Type: "AWS::ElasticLoadBalancingV2::Listener",
+        Properties: {
+          LoadBalancerArn: { Ref: "OrdersAlb" },
+          Protocol: "HTTP",
+          Port: 80,
+          DefaultActions: [
+            { Type: "forward", TargetGroupArn: { Ref: "OrdersTargetGroup" } },
+          ],
+        },
+      },
+      OrdersZone: {
+        Type: "AWS::Route53::HostedZone",
+        Properties: { Name: "example.test" },
+      },
+      OrdersRecord: {
+        Type: "AWS::Route53::RecordSet",
+        Properties: {
+          HostedZoneId: { Ref: "OrdersZone" },
+          Name: "orders.example.test",
+          Type: "A",
+          AliasTarget: {
+            DNSName: { "Fn::GetAtt": ["OrdersAlb", "DNSName"] },
+            HostedZoneId: {
+              "Fn::GetAtt": ["OrdersAlb", "CanonicalHostedZoneID"],
+            },
+          },
+        },
+      },
+      OrdersCluster: {
+        Type: "AWS::ECS::Cluster",
+        Properties: { ClusterName: "orders" },
+      },
+      OrdersTaskDefinition: {
+        Type: "AWS::ECS::TaskDefinition",
+        Properties: {
+          Family: "orders-api",
+          NetworkMode: "awsvpc",
+          TaskRoleArn: { "Fn::GetAtt": ["OrdersTaskRole", "Arn"] },
+          ContainerDefinitions: [
+            // The proxy the service registers, which Yulin has nothing to run.
+            {
+              Name: "nginx",
+              Image: "public.ecr.aws/nginx/nginx:1.27",
+              PortMappings: [{ ContainerPort: 80 }],
+            },
+            {
+              Name: "app",
+              Image: "example.dkr.ecr.eu-west-2.amazonaws.com/orders-api:1",
+              PortMappings: [{ ContainerPort: 8080 }],
+              Environment: [{ Name: "ORDERS_TABLE", Value: "orders" }],
+            },
+          ],
+        },
+      },
+      OrdersService: {
+        Type: "AWS::ECS::Service",
+        Properties: {
+          ServiceName: "orders-api",
+          Cluster: { Ref: "OrdersCluster" },
+          TaskDefinition: { Ref: "OrdersTaskDefinition" },
+          DesiredCount: 2,
+          LaunchType: "FARGATE",
+          LoadBalancers: [
+            {
+              TargetGroupArn: { Ref: "OrdersTargetGroup" },
+              ContainerName: "nginx",
+              ContainerPort: 80,
+            },
+          ],
+        },
+      },
+    },
+  },
+  bindings: [
+    {
+      logicalId: "OrdersTaskDefinition",
+      containerName: "app",
+      http: async (request: Request): Promise<Response> => {
+        const dynamoDb = new DynamoDBClient({});
+        const orderId = new URL(request.url).pathname.split("/").at(-1) ?? "";
+
+        if (request.method === "POST") {
+          await dynamoDb.send(
+            new PutItemCommand({
+              TableName: process.env["ORDERS_TABLE"],
+              Item: { orderId: { S: orderId }, item: { S: "flat white" } },
+            }),
+          );
+
+          return new Response("", { status: 201 });
+        }
+
+        const read = await dynamoDb.send(
+          new GetItemCommand({
+            TableName: process.env["ORDERS_TABLE"],
+            Key: { orderId: { S: orderId } },
+          }),
+        );
+
+        return Response.json({ item: read.Item?.["item"]?.S ?? null });
+      },
+    },
+  ],
+});
+
+await stack.waitForDeployComplete();
+await simAws.backgroundTasksComplete();
+
+// The name Route53 answers for, reached in process rather than over a socket.
+const client = new SimAwsHttp({ simAws });
+const url = "http://orders.example.test.sim-aws.localhost:52341/orders/42";
+
+const placed = await client.fetch(url, { method: "POST" });
+
+console.log(placed.status); // 201
+
+const read = await client.fetch(url);
+
+console.log(await read.json()); // { item: "flat white" }

--- a/src/service/aws/factory/sim-aws-ecs-collaborators.ts
+++ b/src/service/aws/factory/sim-aws-ecs-collaborators.ts
@@ -1,3 +1,4 @@
+import { SimAwsEcsTargetGroups } from "../../ecs/service/load-balancer/sim-aws-ecs-target-groups.js";
 import { SimAwsEcsSecretStores } from "../../ecs/task/run/secret/sim-aws-ecs-secret-stores.js";
 import { SimSqsCommandPollQueues } from "../../sqs/poll/sim-sqs-command-poll-queues.js";
 import type { SimAwsAccountRegionContainer } from "../sim-aws-account-region-scope.js";
@@ -10,6 +11,7 @@ interface SimAwsEcsCollaborators {
   readonly runAsOwner: SimAws;
   readonly secretStores: SimAwsEcsSecretStores;
   readonly consumerQueues: SimSqsCommandPollQueues;
+  readonly targetGroups: SimAwsEcsTargetGroups;
 }
 
 /**
@@ -24,6 +26,11 @@ interface SimAwsEcsCollaborators {
  *
  * A container bound to consume a queue polls this scope's own SQS, as a real
  * task reads a queue in the Account and Region it runs in.
+ *
+ * A service registers its tasks into a target group of the whole simulation,
+ * looked for where its ARN says it is. A service is refused a target group
+ * outside its own Account and Region before it gets that far, so the two come
+ * to the same place by different routes.
  */
 export function simAwsEcsCollaborators(
   simAws: SimAws,
@@ -36,5 +43,6 @@ export function simAwsEcsCollaborators(
       accountRegionScope: scope.accountRegionScope,
     }),
     consumerQueues: new SimSqsCommandPollQueues({ sqs: scope.sqs() }),
+    targetGroups: new SimAwsEcsTargetGroups({ simAws }),
   };
 }

--- a/src/service/ecs/README.md
+++ b/src/service/ecs/README.md
@@ -293,8 +293,8 @@ routes to the container the registration names, on the port it names, and the co
 a proxy such as nginx on that port with the application behind it. Yulin has nothing to run in place
 of the proxy, so routing strictly by name and port would send every request to a container that does
 not exist here. The request goes to a bound container instead: the one the registration names where
-it is bound, otherwise the one that declared the registration's port, otherwise the only one there
-is. A service with no bound container at all is nothing, which the load balancer answers 503 for.
+it is bound, otherwise the one that declared the registration's port, otherwise the first one the
+task definition declares. A service with no bound container at all is nothing, which the load balancer answers 503 for.
 
 ## Registering a service's tasks
 

--- a/src/service/ecs/README.md
+++ b/src/service/ecs/README.md
@@ -24,10 +24,12 @@ Where this genuinely does not work is a sidecar the application depends on, such
 database in the same task. That is not simulated and should not be. The application's connection
 details are ordinary environment variables, so a user who wants a real one points at their own.
 
-The consequence for the code here is that nothing reads a container definition's meaning.
-`SimEcsContainerDefinition` keeps the declaration as it was made and hands it back unchanged, and
-the only two fields it looks at are `name`, which is how everything else refers to a container, and
-`image`, which is the identifier a binding is matched on.
+The consequence for the code here is that almost nothing reads a container definition's meaning.
+`SimEcsContainerDefinition` keeps the declaration as it was made and hands it back unchanged. It
+looks at `name`, which is how everything else refers to a container, and `image`, which is the
+identifier a binding is matched on. The one addition is `portMappings`, read for a single question:
+which container of a task a load balancer's declared container port means, where more than one of
+them is bound.
 
 ## Entry points
 
@@ -87,11 +89,9 @@ Executable bindings live under `bind/`.
 
 `SimEcsContainerBinding` is the shape a user writes. It targets a container either by family and
 container name or by image repository, and carries one of three things: a `run` handler, a `consumes`
-declaration, or an `http` handler. The HTTP shape is settled here even though nothing serves a
-container yet, so that a service container behind a load balancer does not have to renegotiate it: it
-is fetch-style, matching what `SimAwsServiceController` already answers a served request with.
-Binding one is refused rather than held, since a binding that is never called is worse than one that
-says so.
+declaration, or an `http` handler. The HTTP shape is fetch-style, matching what
+`SimAwsServiceController` already answers a served request with, so a container and a Lambda function
+behind the same listener answer in the same terms.
 
 `SimEcsBoundContainerWork` is what the binding says the container does, read once as it is made.
 `SimEcsBoundQueueConsumer` is the `consumes` half: the queue URL turned into the ARN everything else
@@ -99,9 +99,10 @@ names a queue by, a batch size SQS would actually hand out, and the handler. All
 binding time because binding is what a test does while setting up, and a consuming container that
 could never poll would otherwise poll for the whole test and deliver nothing.
 
-A consuming binding has no `run` handler, which is why `SimEcsBoundContainer.runHandler` refuses
-rather than answering with nothing: what a consuming binding supplies is the body of a loop, and a
-run task has nothing to do with a loop.
+Neither a consuming nor a serving binding has a `run` handler, which is why
+`SimEcsBoundContainer.runHandler` refuses rather than answering with nothing: what one supplies is
+the body of a loop and the other an answer to a request, and a run task has neither a loop nor a
+request.
 
 `SimEcsBoundContainer` reads a binding once, as it is made, and refuses one that could never match.
 Binding is something a test does while setting up, so the mistake is worth reporting there rather
@@ -227,10 +228,10 @@ brings nothing up. Stopping is immediate, because there is nothing here to drain
 from a task container: no handler is run to completion. A bound container is marked running and left
 available for whatever reaches it, and an unbound one records the same not-simulated reason a run
 task's container does, from the shared `sim-ecs-container-reason.ts` rather than a second copy of the
-wording. `SimEcsServiceConsumption` is the one thing a service container starts of its own, which is
-the polling behind a `consumes` binding. It runs here because this is where the task's secrets have
-just been resolved, so a consuming container's handler reads the same environment a run task's
-container would.
+wording. `SimEcsServiceConsumption` and `SimEcsServiceServing` are what a bound container is then
+handed to, the first starting the polling behind a `consumes` binding and the second taking on an
+`http` one as a container that answers. Both run here because this is where the task's secrets have
+just been resolved, so either handler reads the same environment a run task's container would.
 
 ## Consuming a queue
 
@@ -265,6 +266,59 @@ container there says what is missing rather than polling nothing.
 
 `SimEcsServiceStore` keys services by cluster and name together, because a service name is unique
 within a cluster on real ECS rather than across an Account.
+
+## Answering a request
+
+What a service container answers a request with lives under `service/serve/`.
+
+`SimEcsContainerServer` is one container of a running service, holding what it needs to answer:
+the handler, the environment the task's secrets resolved to, and the task Role. It answers as that
+Role, through `simAwsRunAsContext`, exactly as a run task's container and a consuming container do,
+so a served request's AWS calls are authorized the way the deployed container's would be.
+
+`SimEcsServiceServers` holds one per service and container rather than one per task, for the same
+reason `SimEcsServiceConsumers` does: the desired count is state rather than concurrency, so a
+handler is called once per request however many tasks are reported running. They are held here
+rather than on the service because a service is state a request can read and a server is the running
+thing behind it, which is what gives deleting or scaling in a service somewhere to take them away.
+
+`SimEcsTargetGroupContainers` is the hop a load balancer makes, from a target group ARN to the
+container that answers for it. Which service that is comes from reading the services back rather
+than from a record kept on the target group, for the same reason simulated ELBv2 reads back which
+load balancers forward to a group: a record the service could change without the group hearing about
+it would go stale.
+
+Which container of that service answers is the deliberate divergence this part exists for. Real ECS
+routes to the container the registration names, on the port it names, and the common real task puts
+a proxy such as nginx on that port with the application behind it. Yulin has nothing to run in place
+of the proxy, so routing strictly by name and port would send every request to a container that does
+not exist here. The request goes to a bound container instead: the one the registration names where
+it is bound, otherwise the one that declared the registration's port, otherwise the only one there
+is. A service with no bound container at all is nothing, which the load balancer answers 503 for.
+
+## Registering a service's tasks
+
+What puts a service's tasks in a target group lives under `service/load-balancer/`.
+
+`SimEcsServiceRegistration` is one `loadBalancers` entry read once, as the request is read and
+before anything is looked up. It requires the three things real ECS requires, refuses the Classic
+Load Balancer form, and refuses a target group outside the service's own Account and Region. That
+last one is what makes the registration reachable from both ends: the tasks go into that scope's
+target group, and a request routed to that group finds this service in the same place.
+
+`SimEcsServiceTargets` registers a task as the service starts it and takes it out again as it stops,
+which is what leaves a scaled-in or deleted service's target group with nothing in it. The address a
+task is registered under is held here rather than on the task, because it is the load balancer's way
+of naming a task rather than anything ECS reports about one, and `SimEcsTaskAddresses` counts them
+out of the private range as simulated ELBv2 counts its ARN ids.
+
+`SimEcsTargetGroups` is the seam to ELBv2, and it is a lookup rather than an operation:
+`SimAwsEcsTargetGroups` writes the targets to the target group itself rather than sending
+`RegisterTargets`. There is no caller to send one as. Real ECS registers a task through the
+service-linked role, which is not something a test creates or could take away, so there would be
+nothing for simulated IAM to decide. `SimEcsUnreachableTargetGroups` is what a simulated ECS built on
+its own gets, so a service declaring a load balancer there says what is missing rather than being
+created with a registration that could never carry a request.
 
 ## Command handling
 
@@ -330,9 +384,9 @@ several task definitions does not bind one handler to all of them.
 `service/` deploys `AWS::ECS::Service`. A service is mostly the two things it names, and both arrive
 already resolved: a `Ref` to a cluster is its name and a `Ref` to a task definition is the ARN of the
 revision the deployment registered, which is why the service pins that revision rather than following
-the family. `LoadBalancers` is read and held on the service without being acted on, since nothing
-serves a service container a request yet, and the rest of what a real service declares is recorded as
-ignored rather than failing the stack.
+the family. `LoadBalancers` goes through as the `CreateService` input it is, so a template's
+registration is the same registration an SDK caller would have made, refusals included, and the rest
+of what a real service declares is recorded as ignored rather than failing the stack.
 
 The three Resource types' `Ref` and `Fn::GetAtt` answers live with the other services' value
 adapters, under `cloudformation/resource/cfn/ecs/`, as the CloudFormation engine's own design has
@@ -362,12 +416,16 @@ them.
   `EssentialContainerExited`. Nothing started, and saying so is what makes a binding that matches
   nothing visible.
 - A service's desired count is state rather than concurrency. A consuming container is polled for
-  once per service rather than once per task, and nothing serves a service container a request yet.
+  once per service rather than once per task, and a serving container answers once per request
+  however many tasks are running.
+- A request reaching a target group goes to a container that is bound, rather than strictly to the
+  one the registration names. The declared port chooses between several bound containers and is
+  otherwise not required to match, because the container it usually names is an unsimulated proxy.
 - A consuming container's loop is Yulin's rather than the container's, so the binding supplies what
   happens to a batch and nothing tries to run a loop written inside the user's own code. A container
   can consume only a simulated SQS queue, in its own Account and Region.
-- A consuming container of a `RunTask` task records a not-simulated reason rather than running. It
-  has no handler that ends, and a run task has to end.
+- A consuming or serving container of a `RunTask` task records a not-simulated reason rather than
+  running. Neither has a handler that ends, and a run task has to end.
 - `CreateService` refuses a name an active service of the cluster already has, which is the opposite
   of what `CreateCluster` does with a name already taken. Real ECS refuses each of them that way.
 - `DeleteService` refuses a service still scaled above zero unless the request forces it, as real ECS
@@ -376,7 +434,6 @@ them.
 - `SimEcsContainerDefinitionType` carries no index signature. One would stop a real SDK
   `RegisterTaskDefinitionCommand` input being assignable to it, which is the whole point of the
   structural types. A field it does not name is stored and reported back all the same.
-- `AWS::ECS::Service` has no factory yet, so a template declaring one is skipped.
 - A cluster or task definition a template does not name gets a name composed from the stack name and
   the logical ID, without the random part real CloudFormation adds, so a test can predict it.
 - A cluster property or task definition property `CreateCluster` or `RegisterTaskDefinition` would

--- a/src/service/ecs/bind/sim-ecs-bound-container-work.ts
+++ b/src/service/ecs/bind/sim-ecs-bound-container-work.ts
@@ -1,33 +1,35 @@
 import { SimEcsBoundQueueConsumer } from "./sim-ecs-bound-queue-consumer.js";
 import type {
   SimEcsContainerBinding,
+  SimEcsContainerHttpHandler,
   SimEcsContainerRunHandler,
 } from "./sim-ecs-container-binding.type.js";
 
 /**
  * What a bound container actually does, read once as the binding is made.
  *
- * A binding says one of three things, and only two of them are simulated. A
- * `run` handler is a job container that does its work and exits. A `consumes`
- * declaration is a worker container, whose real image would sit in an endless
- * receive-handle-delete loop; Yulin runs that loop and the binding supplies its
- * body, because an endless loop in a single Node.js process would never yield
- * to the test running it.
- *
- * An `http` handler is refused rather than held. The shape it takes is settled,
- * so a service container behind a load balancer will not have to renegotiate
- * it, but nothing serves one yet and a binding that is never called is worse
- * than one that says so.
+ * A binding says one of three things. A `run` handler is a job container that
+ * does its work and exits. A `consumes` declaration is a worker container,
+ * whose real image would sit in an endless receive-handle-delete loop; Yulin
+ * runs that loop and the binding supplies its body, because an endless loop in
+ * a single Node.js process would never yield to the test running it. An `http`
+ * handler is a service container behind a load balancer, called once per
+ * request that reaches it.
  */
 export class SimEcsBoundContainerWork {
   public readonly run: SimEcsContainerRunHandler | undefined;
   public readonly consumes: SimEcsBoundQueueConsumer | undefined;
+  public readonly serves: SimEcsContainerHttpHandler | undefined;
 
   constructor(binding: SimEcsContainerBinding) {
-    SimEcsBoundContainerWork.refuseHttpBinding(binding);
-
     if (binding.consumes !== undefined) {
       this.consumes = new SimEcsBoundQueueConsumer(binding.consumes);
+
+      return;
+    }
+
+    if (binding.http !== undefined) {
+      this.serves = SimEcsBoundContainerWork.httpHandlerOf(binding.http);
 
       return;
     }
@@ -35,16 +37,17 @@ export class SimEcsBoundContainerWork {
     this.run = SimEcsBoundContainerWork.runHandlerOf(binding);
   }
 
-  private static refuseHttpBinding(binding: SimEcsContainerBinding): void {
-    if (binding.http === undefined) {
-      return;
+  private static httpHandlerOf(
+    handler: SimEcsContainerHttpHandler,
+  ): SimEcsContainerHttpHandler {
+    if (typeof handler !== "function") {
+      throw new TypeError(
+        "Invalid sim ECS container binding: a serving container needs an " +
+          "http handler, which is what it answers a request with.",
+      );
     }
 
-    throw new Error(
-      "Invalid sim ECS container binding: an http handler is not simulated " +
-        "yet, since nothing serves a container. Bind a run handler and run " +
-        "the task with RunTask.",
-    );
+    return handler;
   }
 
   private static runHandlerOf(

--- a/src/service/ecs/bind/sim-ecs-bound-container.ts
+++ b/src/service/ecs/bind/sim-ecs-bound-container.ts
@@ -3,7 +3,10 @@ import { SimCfnImageRepositoryTarget } from "../../cloudformation/bind/validate/
 import type { SimEcsContainerDefinition } from "../task-definition/container/sim-ecs-container-definition.js";
 import { SimEcsBoundContainerWork } from "./sim-ecs-bound-container-work.js";
 import type { SimEcsBoundQueueConsumer } from "./sim-ecs-bound-queue-consumer.js";
-import type { SimEcsContainerBinding } from "./sim-ecs-container-binding.type.js";
+import type {
+  SimEcsContainerBinding,
+  SimEcsContainerHttpHandler,
+} from "./sim-ecs-container-binding.type.js";
 
 /**
  * One executable binding, read once and ready to be matched against.
@@ -59,6 +62,17 @@ export class SimEcsBoundContainer {
   }
 
   /**
+   * The handler this binding answers a request with, where it serves one.
+   *
+   * A serving container is the other thing a service runs and a run task does
+   * not: what it supplies is an answer to a request, and a run task has nothing
+   * to send it.
+   */
+  get serves(): SimEcsContainerHttpHandler | undefined {
+    return this.work.serves;
+  }
+
+  /**
    * Whether this binding targets a container declared by a family.
    *
    * A binding naming the family and the container name matches only that
@@ -86,17 +100,18 @@ export class SimEcsBoundContainer {
   /**
    * Run this binding's handler.
    *
-   * A consuming binding has none: what it supplies is the body of a loop
-   * something else drives, so there is nothing here for a task to run.
+   * A consuming or serving binding has none: what each supplies is the body of
+   * something else, a loop Yulin drives or a request something else brings, so
+   * there is nothing here for a task to run.
    */
   async runHandler(): Promise<void> {
     const { run } = this.work;
 
     assertDefined(
       run,
-      "This sim ECS container binding consumes a queue, so it has no run " +
-        "handler. Create a service from the task definition to have Yulin " +
-        "poll the queue.",
+      "This sim ECS container binding consumes a queue or serves requests, " +
+        "so it has no run handler. Create a service from the task definition " +
+        "to have Yulin poll the queue or send the container a request.",
     );
 
     await run();

--- a/src/service/ecs/bind/sim-ecs-container-binding.type.ts
+++ b/src/service/ecs/bind/sim-ecs-container-binding.type.ts
@@ -50,8 +50,9 @@ export type SimEcsContainerRunHandler = () => void | Promise<void>;
  * answers a served request with, so a container and a Lambda function behind
  * the same listener answer in the same terms.
  *
- * The shape is settled here, but nothing runs it yet. Binding one is refused
- * rather than accepted and quietly never called.
+ * The handler is called once per request a load balancer routes to the
+ * container, with the container's environment and the task Role, rather than
+ * once per task the service is keeping running.
  */
 export type SimEcsContainerHttpHandler = (
   request: Request,
@@ -84,7 +85,8 @@ export type SimEcsContainerBindingTarget =
  * `consumes` declaration is a worker container, which a real image would put in
  * an endless receive-handle-delete loop. Yulin runs that loop and the binding
  * supplies its body, because an endless loop in a single Node.js process would
- * never yield to the test running it.
+ * never yield to the test running it. An `http` handler is a service container
+ * behind a load balancer, which answers the requests routed to it.
  */
 export type SimEcsContainerBindingHandler =
   | {

--- a/src/service/ecs/bind/sim-ecs-container-bindings.iso.test.ts
+++ b/src/service/ecs/bind/sim-ecs-container-bindings.iso.test.ts
@@ -1,5 +1,6 @@
 import {
   assertIdentical,
+  assertNonNullable,
   assertStringIncludes,
   assertThrowsError,
   assertUndefined,
@@ -127,21 +128,41 @@ describe("Matching a simulated ECS container binding", () => {
 });
 
 describe("Refusing a simulated ECS container binding", () => {
-  it("refuses an http handler, which nothing serves yet", () => {
+  it("holds an http handler for a service container to answer with", () => {
     // Given the bindings for a scope.
     const bindings = new SimEcsContainerBindings();
 
     // When a container is bound to an HTTP handler.
+    bindings.add({
+      family: "checkout",
+      containerName: "app",
+      http: () => new Response("hello"),
+    });
+
+    // Then the binding serves rather than running, since what calls it is a
+    // request a load balancer routes to the container.
+    const found = bindings.find("checkout", appContainer);
+
+    assertNonNullable(found?.serves, "The binding serves requests");
+    assertUndefined(found.consumes);
+  });
+
+  it("refuses an http handler that is not a function", () => {
+    // Given the bindings for a scope.
+    const bindings = new SimEcsContainerBindings();
+
+    // When a container is bound to something that cannot answer a request.
     const error = assertThrowsError(() => {
       bindings.add({
         family: "checkout",
         containerName: "app",
-        http: () => new Response("hello"),
+        http: "hello" as unknown as () => Response,
       });
     });
 
-    // Then it says so rather than accepting a handler nothing would call.
-    assertStringIncludes(error.message, "http handler is not simulated");
+    // Then it is refused where the mistake is, rather than at the first
+    // request that reaches the container.
+    assertStringIncludes(error.message, "needs an http handler");
   });
 
   it("refuses a binding that targets nothing", () => {

--- a/src/service/ecs/cfn/sim-cfn-ecs-binding-targets.iso.test.ts
+++ b/src/service/ecs/cfn/sim-cfn-ecs-binding-targets.iso.test.ts
@@ -135,29 +135,6 @@ describe("ECS CloudFormation binding targets", () => {
     assertIdentical(runs, 1);
   });
 
-  it("refuses an http binding naming the task definition Resource", async () => {
-    // Given a binding naming the Resource and carrying the HTTP shape a
-    // service container will take.
-    const simAws = new SimAws();
-
-    // When the template is deployed, then the binding is refused rather than
-    // held and never called.
-    const error = await assertThrowsErrorAsync(async () => {
-      return await simAws.cloudFormation().deployTemplate({
-        stackName: "orders-stack",
-        template: twoFamilies,
-        bindings: [
-          {
-            logicalId: "WorkerTaskDefinition",
-            http: () => new Response("ok"),
-          },
-        ],
-      });
-    });
-
-    assertStringIncludes(error.message, "an http handler is not simulated");
-  });
-
   it("refuses a Resource binding naming no task definition of the stack", async () => {
     // Given a binding naming a logical ID the stack does not hold.
     const simAws = new SimAws();

--- a/src/service/ecs/cfn/sim-cfn-ecs-bindings.iso.test.ts
+++ b/src/service/ecs/cfn/sim-cfn-ecs-bindings.iso.test.ts
@@ -293,27 +293,4 @@ describe("ECS CloudFormation container bindings", () => {
     assertStringIncludes(error.message, "needs a containerName");
     assertStringIncludes(error.message, "declares 2 containers");
   });
-
-  it("refuses an http container binding, which nothing serves yet", async () => {
-    // Given a binding carrying the HTTP shape a service container will take.
-    const simAws = new SimAws();
-
-    // When the template is deployed, then the binding is refused rather than
-    // held and never called.
-    const error = await assertThrowsErrorAsync(async () => {
-      return await simAws.cloudFormation().deployTemplate({
-        stackName: "orders-stack",
-        template: workerTemplate([appContainer]),
-        bindings: [
-          {
-            family: "orders-worker",
-            containerName: "app",
-            http: () => new Response("ok"),
-          },
-        ],
-      });
-    });
-
-    assertStringIncludes(error.message, "an http handler is not simulated");
-  });
 });

--- a/src/service/ecs/cfn/sim-cfn-ecs-service-properties.iso.test.ts
+++ b/src/service/ecs/cfn/sim-cfn-ecs-service-properties.iso.test.ts
@@ -6,6 +6,7 @@ import {
   assertStringIncludes,
   assertThrowsErrorAsync,
   assertTrue,
+  assertTypeString,
 } from "@kensio/smartass";
 import { describe, it } from "vitest";
 
@@ -18,16 +19,23 @@ import type {
 
 const imageUri = "example.dkr.ecr.eu-west-2.amazonaws.com/orders-worker:1";
 
-const targetGroupArn =
-  "arn:aws:elasticloadbalancing:us-east-1:888888888888:targetgroup/orders/73e2d6bc";
-
 /**
- * The cluster and task definition a service needs before it is anything.
+ * The cluster, task definition and target group a service needs before it is
+ * anything.
  */
 const workerResources: Record<string, SimCfnTemplateValue> = {
   OrdersCluster: {
     Type: "AWS::ECS::Cluster",
     Properties: { ClusterName: "orders" },
+  },
+  WorkerTargetGroup: {
+    Type: "AWS::ElasticLoadBalancingV2::TargetGroup",
+    Properties: {
+      Name: "orders-tg",
+      TargetType: "ip",
+      Protocol: "HTTP",
+      Port: 8080,
+    },
   },
   WorkerTaskDefinition: {
     Type: "AWS::ECS::TaskDefinition",
@@ -56,6 +64,7 @@ function serviceTemplate(
         },
       },
     },
+    Outputs: { TargetGroup: { Value: { Ref: "WorkerTargetGroup" } } },
   };
 }
 
@@ -109,9 +118,8 @@ describe("AWS::ECS::Service properties", () => {
     );
   });
 
-  it("records the load balancers a service declares", async () => {
-    // Given a template whose service declares a load balancer target group,
-    // which nothing here routes to yet.
+  it("registers a service's tasks into the target group it declares", async () => {
+    // Given a template whose service declares a target group of the stack.
     const simAws = new SimAws();
 
     // When it is deployed.
@@ -119,10 +127,10 @@ describe("AWS::ECS::Service properties", () => {
       stackName: "orders-stack",
       template: serviceTemplate({
         ServiceName: "orders-worker",
-        DesiredCount: 1,
+        DesiredCount: 2,
         LoadBalancers: [
           {
-            TargetGroupArn: targetGroupArn,
+            TargetGroupArn: { Ref: "WorkerTargetGroup" },
             ContainerName: "app",
             ContainerPort: 8080,
           },
@@ -133,8 +141,11 @@ describe("AWS::ECS::Service properties", () => {
     await stack.waitForDeployComplete();
     await simAws.backgroundTasksComplete();
 
-    // Then the declaration is readable on the simulated service, so a target
-    // group can find the service and the container that answer for it.
+    // Then the declaration is readable on the simulated service, and each task
+    // it keeps running is registered in the target group on the declared port.
+    const targetGroupArn = stack.outputs.get("TargetGroup")?.value;
+
+    assertTypeString(targetGroupArn);
     const service = simAws.ecs().service("orders-worker", "orders");
 
     assertArrayLength(service.loadBalancers, 1);
@@ -142,7 +153,14 @@ describe("AWS::ECS::Service properties", () => {
     assertIdentical(service.loadBalancers[0].containerName, "app");
     assertIdentical(service.loadBalancers[0].containerPort, 8080);
 
-    // And DescribeServices reports it in the spelling the SDK uses.
+    const health = await simAws
+      .elbV2()
+      .describeTargetHealth({ input: { TargetGroupArn: targetGroupArn } });
+
+    assertArrayLength(health.TargetHealthDescriptions, 2);
+    assertIdentical(health.TargetHealthDescriptions[0].Target.Port, 8080);
+
+    // And DescribeServices reports the registration in the SDK's spelling.
     const described = await simAws.ecs().describeServices(
       new DescribeServicesCommand({
         cluster: "orders",

--- a/src/service/ecs/command/create-service/create-service-request.ts
+++ b/src/service/ecs/command/create-service/create-service-request.ts
@@ -1,6 +1,8 @@
 import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
 import { SimEcsInvalidParameterException } from "../../error/sim-ecs.error.js";
+import { SimEcsServiceRegistration } from "../../service/load-balancer/sim-ecs-service-registration.js";
 import { simEcsDesiredCount } from "../../service/sim-ecs-desired-count.js";
+import type { SimEcsServiceLoadBalancer } from "../../service/sim-ecs-service-detail.js";
 import { simEcsReplicaSchedulingStrategy } from "../../service/sim-ecs-service.js";
 import { requiredSimEcsName } from "../../sim-ecs-name.js";
 import { SimEcsTaskDefinitionId } from "../../task-definition/sim-ecs-task-definition-id.js";
@@ -10,14 +12,18 @@ import type { SimCreateServiceCommandInput } from "./create-service.command.js";
  * What one `CreateService` request asked for.
  *
  * This is the part of the request that can be read before anything is looked
- * up: what the service is called, which task definition it runs and how many
- * tasks of it to keep. A malformed request is malformed whoever made it and
- * whatever state there is, so it is read first and refused first.
+ * up: what the service is called, which task definition it runs, how many tasks
+ * of it to keep and which target groups those tasks are registered into. A
+ * malformed request is malformed whoever made it and whatever state there is,
+ * so it is read first and refused first. Whether the target groups it names are
+ * there is a different question, answered once there is state to answer it
+ * from.
  */
 export class SimEcsCreateServiceRequest {
   public readonly serviceName: string;
   public readonly taskDefinitionId: SimEcsTaskDefinitionId;
   public readonly desiredCount: number;
+  public readonly registrations: readonly SimEcsServiceRegistration[];
 
   constructor(
     input: SimCreateServiceCommandInput,
@@ -31,6 +37,23 @@ export class SimEcsCreateServiceRequest {
     );
     this.desiredCount = simEcsDesiredCount(
       SimEcsCreateServiceRequest.requiredCount(input.desiredCount),
+    );
+    this.registrations = SimEcsCreateServiceRequest.registrationsOf(
+      input.loadBalancers ?? [],
+      accountRegionScope,
+    );
+  }
+
+  /**
+   * The load balancer registrations the request declared.
+   */
+  private static registrationsOf(
+    declared: readonly SimEcsServiceLoadBalancer[],
+    accountRegionScope: SimAwsAccountRegionScope,
+  ): readonly SimEcsServiceRegistration[] {
+    return declared.map(
+      (loadBalancer) =>
+        new SimEcsServiceRegistration(loadBalancer, accountRegionScope),
     );
   }
 

--- a/src/service/ecs/command/create-service/create-service.handler.ts
+++ b/src/service/ecs/command/create-service/create-service.handler.ts
@@ -2,6 +2,7 @@ import type { CommandHandler } from "../../../../command/command-handler.js";
 import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
 import type { SimEcsCluster } from "../../cluster/sim-ecs-cluster.js";
 import { SimEcsInvalidParameterException } from "../../error/sim-ecs.error.js";
+import type { SimEcsServiceTargets } from "../../service/load-balancer/sim-ecs-service-targets.js";
 import type { SimEcsServiceTasks } from "../../service/run/sim-ecs-service-tasks.js";
 import type { SimEcsServiceArn } from "../../service/sim-ecs-service-arn.js";
 import type { SimEcsServiceStore } from "../../service/sim-ecs-service-store.js";
@@ -43,6 +44,7 @@ export class CreateServiceCommandHandler
   private readonly services: SimEcsServiceStore;
   private readonly serviceArn: SimEcsServiceArn;
   private readonly serviceTasks: SimEcsServiceTasks;
+  private readonly serviceTargets: SimEcsServiceTargets;
   private readonly requestedCluster: SimEcsRequestedCluster;
 
   constructor(context: SimEcsServiceCommandContext) {
@@ -52,6 +54,7 @@ export class CreateServiceCommandHandler
     this.services = context.services;
     this.serviceArn = context.serviceArn;
     this.serviceTasks = context.serviceTasks;
+    this.serviceTargets = context.serviceTargets;
     this.requestedCluster = new SimEcsRequestedCluster(context);
   }
 
@@ -62,10 +65,9 @@ export class CreateServiceCommandHandler
    * which is a desired count and nothing running yet, as real ECS answers one.
    * Its tasks reach `RUNNING` on the simulator's background work.
    *
-   * A load balancer the request declares is recorded on the service and not
-   * acted on. Nothing here sends a service container a request yet, so the
-   * declaration is what a target group has to read to find the service that
-   * answers for it.
+   * A load balancer the request declares is a registration: the target group
+   * has to be there and hold addresses, which is checked before the service is
+   * created, and each task the service starts is registered into it.
    */
   async handle(
     command: SimCreateServiceCommand,
@@ -95,6 +97,7 @@ export class CreateServiceCommandHandler
     );
 
     this.refuseExisting(cluster, request.serviceName);
+    this.serviceTargets.requireRegistrable(request.registrations);
 
     const service = new SimEcsService({
       serviceArn,
@@ -106,7 +109,7 @@ export class CreateServiceCommandHandler
       createdAt: this.background.now(),
       launchType: command.input.launchType,
       createdBy: caller.arn,
-      loadBalancers: command.input.loadBalancers,
+      registrations: request.registrations,
     });
 
     this.services.put(service);

--- a/src/service/ecs/command/create-service/create-service.iso.test.ts
+++ b/src/service/ecs/command/create-service/create-service.iso.test.ts
@@ -14,6 +14,7 @@ import {
 } from "@kensio/smartass";
 import { describe, it } from "vitest";
 import { SimAws } from "../../../aws/sim-aws.js";
+import { createFixtureIpTargetGroup } from "../../../elbv2/sim-elbv2.fixture.js";
 import { simEcsClusterFactory } from "../../cluster/sim-ecs-cluster.factory.js";
 
 describe("ECS CreateServiceCommand", () => {
@@ -233,8 +234,8 @@ describe("ECS CreateServiceCommand", () => {
     assertArrayLength(listed.taskArns, 1);
   });
 
-  it("records the load balancers the service was created with", async () => {
-    // Given a registered task definition.
+  it("registers the service's tasks with the load balancer it was created with", async () => {
+    // Given a registered task definition and a target group of addresses.
     const simAws = new SimAws();
     const ecs = simAws.ecs();
     await simEcsClusterFactory.make({}, simAws);
@@ -245,14 +246,14 @@ describe("ECS CreateServiceCommand", () => {
       }),
     );
 
-    // When a service is created behind a load balancer target group.
-    const targetGroupArn =
-      "arn:aws:elasticloadbalancing:us-east-1:888888888888:targetgroup/checkout/73e2d6bc";
+    const targetGroupArn = await createFixtureIpTargetGroup(simAws.elbV2());
+
+    // When a service is created behind that target group.
     const created = await ecs.createService(
       new CreateServiceCommand({
         serviceName: "checkout",
         taskDefinition: "checkout",
-        desiredCount: 1,
+        desiredCount: 2,
         loadBalancers: [
           { targetGroupArn, containerName: "app", containerPort: 8080 },
         ],
@@ -260,8 +261,7 @@ describe("ECS CreateServiceCommand", () => {
     );
     await simAws.backgroundTasksComplete();
 
-    // Then the declaration is reported back and held on the service, since
-    // nothing here sends a service container a request yet.
+    // Then the declaration is reported back and held on the service.
     assertIdentical(
       created.service?.loadBalancers?.[0]?.targetGroupArn,
       targetGroupArn,
@@ -269,6 +269,19 @@ describe("ECS CreateServiceCommand", () => {
     assertIdentical(
       ecs.service("checkout").loadBalancers[0]?.containerPort,
       8080,
+    );
+
+    // And each task the service keeps running is a target of the group, on
+    // the port the registration named.
+    const health = await simAws
+      .elbV2()
+      .describeTargetHealth({ input: { TargetGroupArn: targetGroupArn } });
+
+    assertArrayLength(health.TargetHealthDescriptions, 2);
+    assertIdentical(health.TargetHealthDescriptions[0].Target.Port, 8080);
+    assertIdentical(
+      health.TargetHealthDescriptions[0].TargetHealth.State,
+      "healthy",
     );
   });
 

--- a/src/service/ecs/command/sim-ecs-command-context.ts
+++ b/src/service/ecs/command/sim-ecs-command-context.ts
@@ -4,6 +4,7 @@ import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-
 import type { SimEcsContainerBindings } from "../bind/sim-ecs-container-bindings.js";
 import type { SimEcsClusterArn } from "../cluster/sim-ecs-cluster-arn.js";
 import type { SimEcsClusterStore } from "../cluster/sim-ecs-cluster-store.js";
+import type { SimEcsServiceTargets } from "../service/load-balancer/sim-ecs-service-targets.js";
 import type { SimEcsServiceTasks } from "../service/run/sim-ecs-service-tasks.js";
 import type { SimEcsServiceArn } from "../service/sim-ecs-service-arn.js";
 import type { SimEcsServiceStore } from "../service/sim-ecs-service-store.js";
@@ -87,4 +88,5 @@ export interface SimEcsServiceCommandContext extends SimEcsTaskCommandContext {
   readonly services: SimEcsServiceStore;
   readonly serviceArn: SimEcsServiceArn;
   readonly serviceTasks: SimEcsServiceTasks;
+  readonly serviceTargets: SimEcsServiceTargets;
 }

--- a/src/service/ecs/command/sim-ecs-command-contexts.ts
+++ b/src/service/ecs/command/sim-ecs-command-contexts.ts
@@ -5,7 +5,11 @@ import type { SimEcsContainerBindings } from "../bind/sim-ecs-container-bindings
 import { SimEcsClusterArn } from "../cluster/sim-ecs-cluster-arn.js";
 import type { SimEcsClusterStore } from "../cluster/sim-ecs-cluster-store.js";
 import { SimEcsServiceConsumers } from "../service/consume/sim-ecs-service-consumers.js";
+import { SimEcsServiceTargets } from "../service/load-balancer/sim-ecs-service-targets.js";
+import type { SimEcsTargetGroups } from "../service/load-balancer/sim-ecs-target-groups.js";
 import { SimEcsServiceTasks } from "../service/run/sim-ecs-service-tasks.js";
+import { SimEcsServiceServers } from "../service/serve/sim-ecs-service-servers.js";
+import { SimEcsTargetGroupContainers } from "../service/serve/sim-ecs-target-group-containers.js";
 import { SimEcsServiceArn } from "../service/sim-ecs-service-arn.js";
 import type { SimEcsServiceStore } from "../service/sim-ecs-service-store.js";
 import type { SimSqsPollQueues } from "../../sqs/poll/sim-sqs-poll-queues.js";
@@ -35,6 +39,7 @@ interface SimEcsCommandContextsProperties {
   readonly bindings: SimEcsContainerBindings;
   readonly secretStores: SimEcsSecretStores;
   readonly consumerQueues: SimSqsPollQueues;
+  readonly targetGroups: SimEcsTargetGroups;
 }
 
 /**
@@ -44,6 +49,11 @@ interface SimEcsCommandContextsProperties {
  * contexts overlap because the operations do: a task operation needs the
  * clusters a cluster operation needs, and running a task needs everything.
  * Building them in one place is what keeps the service facade a delegation.
+ *
+ * The containers a target group reaches are built here too, though no command
+ * handler takes them. They read the same services and the same running
+ * containers the service operations work on, and building them anywhere else
+ * would be a second set of both.
  */
 export class SimEcsCommandContexts {
   public readonly cluster: SimEcsClusterCommandContext;
@@ -51,10 +61,15 @@ export class SimEcsCommandContexts {
   public readonly task: SimEcsTaskCommandContext;
   public readonly runTask: SimEcsRunTaskCommandContext;
   public readonly service: SimEcsServiceCommandContext;
+  public readonly targetGroupContainers: SimEcsTargetGroupContainers;
 
   constructor(properties: SimEcsCommandContextsProperties) {
     const { accountRegionScope, authorizer, background } = properties;
     const shared = { authorizer, background };
+    const servers = new SimEcsServiceServers();
+    const serviceTargets = new SimEcsServiceTargets({
+      targetGroups: properties.targetGroups,
+    });
 
     this.cluster = {
       ...shared,
@@ -88,19 +103,27 @@ export class SimEcsCommandContexts {
       taskDefinitions: properties.taskDefinitions,
       services: properties.services,
       serviceArn: new SimEcsServiceArn(accountRegionScope),
+      serviceTargets,
       serviceTasks: new SimEcsServiceTasks({
         tasks: properties.tasks,
         taskArn: this.task.taskArn,
         bindings: properties.bindings,
         secretStores: properties.secretStores,
         regionName: accountRegionScope.regionName,
+        runAsOwner: properties.runAsOwner,
         consumers: new SimEcsServiceConsumers({
           queues: properties.consumerQueues,
           runAsOwner: properties.runAsOwner,
           background,
         }),
+        servers,
+        targets: serviceTargets,
         background,
       }),
     };
+    this.targetGroupContainers = new SimEcsTargetGroupContainers({
+      services: properties.services,
+      servers,
+    });
   }
 }

--- a/src/service/ecs/index.ts
+++ b/src/service/ecs/index.ts
@@ -111,6 +111,18 @@ export {
 export { SimEcsServiceStore } from "./service/sim-ecs-service-store.js";
 export { SimEcsServiceTasks } from "./service/run/sim-ecs-service-tasks.js";
 export { SimEcsServiceConsumers } from "./service/consume/sim-ecs-service-consumers.js";
+export { SimEcsContainerServer } from "./service/serve/sim-ecs-container-server.js";
+export { SimEcsServiceServers } from "./service/serve/sim-ecs-service-servers.js";
+export { SimEcsTargetGroupContainers } from "./service/serve/sim-ecs-target-group-containers.js";
+export { SimEcsServiceRegistration } from "./service/load-balancer/sim-ecs-service-registration.js";
+export { SimEcsServiceTargets } from "./service/load-balancer/sim-ecs-service-targets.js";
+export {
+  SimEcsUnreachableTargetGroups,
+  type SimEcsRegistrableTargetGroup,
+  type SimEcsTargetGroups,
+  type SimEcsTaskTarget,
+} from "./service/load-balancer/sim-ecs-target-groups.js";
+export { SimAwsEcsTargetGroups } from "./service/load-balancer/sim-aws-ecs-target-groups.js";
 export type { SimEcsServiceDeployment } from "./service/run/sim-ecs-service-deployment.js";
 export {
   SimEcsTaskOverrides,

--- a/src/service/ecs/service/load-balancer/sim-aws-ecs-target-groups.ts
+++ b/src/service/ecs/service/load-balancer/sim-aws-ecs-target-groups.ts
@@ -1,0 +1,84 @@
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import { parseSimArn } from "../../../aws/arn.js";
+import type { SimAws } from "../../../aws/sim-aws.js";
+import type { SimElbV2TargetGroup } from "../../../elbv2/target-group/sim-elbv2-target-group.js";
+import type {
+  SimEcsRegistrableTargetGroup,
+  SimEcsTargetGroups,
+  SimEcsTaskTarget,
+} from "./sim-ecs-target-groups.js";
+
+interface SimAwsEcsTargetGroupsProperties {
+  readonly simAws: SimAws;
+}
+
+/**
+ * One simulated ELBv2 target group, as a service registers its tasks into it.
+ *
+ * The targets are written to the group itself rather than sent as a
+ * `RegisterTargets` request, because there is no caller: real ECS registers a
+ * task through the service-linked role, which is not something a test holds.
+ * What the group would refuse, it still refuses, since registering is the
+ * target group's own operation either way.
+ */
+class SimAwsEcsRegistrableTargetGroup implements SimEcsRegistrableTargetGroup {
+  public readonly targetType: string;
+
+  private readonly targetGroup: SimElbV2TargetGroup;
+
+  constructor(targetGroup: SimElbV2TargetGroup) {
+    this.targetGroup = targetGroup;
+    this.targetType = targetGroup.targetType.value;
+  }
+
+  register(target: SimEcsTaskTarget): void {
+    this.targetGroup.register([{ Id: target.address, Port: target.port }]);
+  }
+
+  deregister(target: SimEcsTaskTarget): void {
+    this.targetGroup.deregister([{ Id: target.address, Port: target.port }]);
+  }
+}
+
+/**
+ * The simulated ELBv2 target groups of one simulated AWS instance, as the
+ * places a service's tasks are registered.
+ *
+ * ELBv2 is reached when a service is created or a task starts, never when this
+ * is built, for the same reason simulated ECS reaches its secret stores that
+ * way: reaching another service while this one is being constructed is a cycle
+ * with no bottom to it.
+ *
+ * A target group is looked for in the Account and Region its own ARN names.
+ * Nothing else would be right for an ARN, and a service is refused a target
+ * group outside its own scope before it ever gets here.
+ */
+export class SimAwsEcsTargetGroups implements SimEcsTargetGroups {
+  private readonly simAws: SimAws;
+
+  constructor(properties: SimAwsEcsTargetGroupsProperties) {
+    this.simAws = properties.simAws;
+  }
+
+  /**
+   * The target group an ARN names, where this simulation holds one.
+   */
+  find(targetGroupArn: string): SimEcsRegistrableTargetGroup | undefined {
+    const parts = parseSimArn(targetGroupArn);
+
+    // A service reads its registrations before it is created, and one naming
+    // anything but a target group ARN of its own scope is refused there.
+    assertDefined(parts, `'${targetGroupArn}' is not a target group ARN`);
+
+    const targetGroup = this.simAws
+      .accountRegionScope(parts.accountId, parts.region)
+      .elbV2()
+      .findTargetGroupByArn(targetGroupArn);
+
+    if (targetGroup === undefined) {
+      return undefined;
+    }
+
+    return new SimAwsEcsRegistrableTargetGroup(targetGroup);
+  }
+}

--- a/src/service/ecs/service/load-balancer/sim-ecs-service-registration.ts
+++ b/src/service/ecs/service/load-balancer/sim-ecs-service-registration.ts
@@ -1,0 +1,146 @@
+import { parseSimArn } from "../../../aws/arn.js";
+import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
+import { SimEcsInvalidParameterException } from "../../error/sim-ecs.error.js";
+import type { SimEcsServiceLoadBalancer } from "../sim-ecs-service-detail.js";
+
+/**
+ * The service an ARN has to name for a service to register into it.
+ */
+const targetGroupResourceType = "targetgroup";
+
+/**
+ * One load balancer registration a service was created with, read once.
+ *
+ * A registration is three things together: the target group tasks are
+ * registered into, the container that answers for it, and the port that
+ * container was declared to listen on. Real ECS requires all three, and each
+ * is refused here when it is missing rather than leaving a service that looks
+ * registered and answers nothing.
+ *
+ * The target group has to be in the service's own Account and Region. Real ECS
+ * requires that too, and here it is what makes the registration reachable from
+ * both ends: the tasks are registered into that scope's target group, and a
+ * request routed to that target group finds this service in the same place.
+ */
+export class SimEcsServiceRegistration {
+  public readonly targetGroupArn: string;
+  public readonly containerName: string;
+  public readonly containerPort: number;
+
+  constructor(
+    declared: SimEcsServiceLoadBalancer,
+    accountRegionScope: SimAwsAccountRegionScope,
+  ) {
+    SimEcsServiceRegistration.refuseLoadBalancerName(declared);
+    this.targetGroupArn = SimEcsServiceRegistration.requiredTargetGroupArn(
+      declared,
+      accountRegionScope,
+    );
+    this.containerName = SimEcsServiceRegistration.requiredContainerName(
+      declared,
+      this.targetGroupArn,
+    );
+    this.containerPort = SimEcsServiceRegistration.requiredContainerPort(
+      declared,
+      this.targetGroupArn,
+    );
+  }
+
+  /**
+   * Refuse a registration with a Classic Load Balancer.
+   *
+   * `loadBalancerName` is the Classic Load Balancer form, which routes below
+   * the Application Load Balancer this simulation has, so a service naming one
+   * is refused rather than registered into something else.
+   */
+  private static refuseLoadBalancerName(
+    declared: SimEcsServiceLoadBalancer,
+  ): void {
+    if (declared.loadBalancerName !== undefined) {
+      throw new SimEcsInvalidParameterException(
+        `A service load balancer naming loadBalancerName ` +
+          `'${declared.loadBalancerName}' registers with a Classic Load ` +
+          `Balancer, which is not simulated. Name a targetGroupArn instead.`,
+      );
+    }
+  }
+
+  private static requiredTargetGroupArn(
+    declared: SimEcsServiceLoadBalancer,
+    accountRegionScope: SimAwsAccountRegionScope,
+  ): string {
+    const { targetGroupArn } = declared;
+
+    if (targetGroupArn === undefined || targetGroupArn === "") {
+      throw new SimEcsInvalidParameterException(
+        "A service load balancer needs a targetGroupArn, which is the target " +
+          "group its tasks are registered into.",
+      );
+    }
+
+    const parts = parseSimArn(targetGroupArn);
+
+    if (parts?.resourceType !== targetGroupResourceType) {
+      throw new SimEcsInvalidParameterException(
+        `'${targetGroupArn}' is not a target group ARN.`,
+      );
+    }
+
+    if (
+      parts.accountId !== accountRegionScope.accountId ||
+      parts.region !== accountRegionScope.regionName
+    ) {
+      throw new SimEcsInvalidParameterException(
+        `The target group ${targetGroupArn} is in another Account or Region ` +
+          `than the service, which is ${accountRegionScope.accountId} in ` +
+          `${accountRegionScope.regionName}. A service registers into a ` +
+          `target group of its own Account and Region.`,
+      );
+    }
+
+    return targetGroupArn;
+  }
+
+  private static requiredContainerName(
+    declared: SimEcsServiceLoadBalancer,
+    targetGroupArn: string,
+  ): string {
+    const { containerName } = declared;
+
+    if (containerName === undefined || containerName === "") {
+      throw new SimEcsInvalidParameterException(
+        `The registration into ${targetGroupArn} needs a containerName, ` +
+          `which is the container of the task that answers for it.`,
+      );
+    }
+
+    return containerName;
+  }
+
+  private static requiredContainerPort(
+    declared: SimEcsServiceLoadBalancer,
+    targetGroupArn: string,
+  ): number {
+    const { containerPort } = declared;
+
+    if (containerPort === undefined) {
+      throw new SimEcsInvalidParameterException(
+        `The registration into ${targetGroupArn} needs a containerPort, ` +
+          `which is the port its tasks are registered on.`,
+      );
+    }
+
+    return containerPort;
+  }
+
+  /**
+   * This registration as a described service reports it.
+   */
+  toOutput(): SimEcsServiceLoadBalancer {
+    return {
+      targetGroupArn: this.targetGroupArn,
+      containerName: this.containerName,
+      containerPort: this.containerPort,
+    };
+  }
+}

--- a/src/service/ecs/service/load-balancer/sim-ecs-service-registration.ts
+++ b/src/service/ecs/service/load-balancer/sim-ecs-service-registration.ts
@@ -9,6 +9,11 @@ import type { SimEcsServiceLoadBalancer } from "../sim-ecs-service-detail.js";
 const targetGroupResourceType = "targetgroup";
 
 /**
+ * The ports a target can be registered on, which are every port there is.
+ */
+const portRange = { lowest: 1, highest: 65_535 } as const;
+
+/**
  * One load balancer registration a service was created with, read once.
  *
  * A registration is three things together: the target group tasks are
@@ -127,6 +132,20 @@ export class SimEcsServiceRegistration {
       throw new SimEcsInvalidParameterException(
         `The registration into ${targetGroupArn} needs a containerPort, ` +
           `which is the port its tasks are registered on.`,
+      );
+    }
+
+    if (
+      !Number.isSafeInteger(containerPort) ||
+      containerPort < portRange.lowest ||
+      containerPort > portRange.highest
+    ) {
+      throw new SimEcsInvalidParameterException(
+        `The registration into ${targetGroupArn} states a containerPort of ` +
+          `${String(containerPort)}, which is not a port between ` +
+          `${String(portRange.lowest)} and ${String(portRange.highest)}. ` +
+          `A target is registered on the port, so a port nothing could ` +
+          `listen on registers nothing.`,
       );
     }
 

--- a/src/service/ecs/service/load-balancer/sim-ecs-service-targets.ts
+++ b/src/service/ecs/service/load-balancer/sim-ecs-service-targets.ts
@@ -1,0 +1,134 @@
+import { SimEcsInvalidParameterException } from "../../error/sim-ecs.error.js";
+import type { SimEcsTask } from "../../task/sim-ecs-task.js";
+import type { SimEcsService } from "../sim-ecs-service.js";
+import type { SimEcsServiceRegistration } from "./sim-ecs-service-registration.js";
+import { SimEcsTaskAddresses } from "./sim-ecs-task-addresses.js";
+import type { SimEcsTargetGroups } from "./sim-ecs-target-groups.js";
+
+/**
+ * The target type a service's tasks are registered as.
+ *
+ * Real ECS registers an `awsvpc` task by the address of its network interface,
+ * which is an `ip` target. A target group of any other type is refused when the
+ * service is created, as real ECS refuses one.
+ */
+const registeredTargetType = "ip";
+
+interface SimEcsServiceTargetsProperties {
+  readonly targetGroups: SimEcsTargetGroups;
+}
+
+/**
+ * Registers the tasks of the services in one simulated ECS scope as load
+ * balancer targets.
+ *
+ * A task is a target from the moment the service starts it until the moment it
+ * stops, which is what makes a service scaled to nothing, or deleted, leave a
+ * target group with nothing in it to answer for. Registration is immediate at
+ * both ends: real ECS waits for a health check before a new task takes traffic
+ * and drains connections before an old one goes, and neither of those exists
+ * here.
+ *
+ * The address a task is registered under is held here rather than on the task,
+ * because it is the load balancer's way of naming a task rather than anything
+ * ECS reports about one.
+ */
+export class SimEcsServiceTargets {
+  private readonly targetGroups: SimEcsTargetGroups;
+  private readonly addresses = new SimEcsTaskAddresses();
+  private readonly registered = new Map<string, string>();
+
+  constructor(properties: SimEcsServiceTargetsProperties) {
+    this.targetGroups = properties.targetGroups;
+  }
+
+  /**
+   * Refuse the registrations a service could not be created with.
+   *
+   * This is what a target group that is not there, or that holds something
+   * other than addresses, is reported by. Real ECS refuses `CreateService` for
+   * both, and refusing here is what stops a service being created registered
+   * with something that could never carry it a request.
+   */
+  requireRegistrable(
+    registrations: readonly SimEcsServiceRegistration[],
+  ): void {
+    for (const registration of registrations) {
+      this.requireRegistrableGroup(registration);
+    }
+  }
+
+  /**
+   * Register a task the service has started into every target group it named.
+   */
+  register(service: SimEcsService, task: SimEcsTask): void {
+    const { registrations } = service;
+
+    if (registrations.length === 0) {
+      return;
+    }
+
+    const address = this.addresses.take();
+
+    this.registered.set(task.taskArn, address);
+
+    for (const registration of registrations) {
+      this.targetGroups
+        .find(registration.targetGroupArn)
+        ?.register({ address, port: registration.containerPort });
+    }
+  }
+
+  /**
+   * Take the tasks a service has stopped out of every target group it named.
+   */
+  deregisterAll(service: SimEcsService, tasks: readonly SimEcsTask[]): void {
+    for (const task of tasks) {
+      this.deregister(service, task);
+    }
+  }
+
+  /**
+   * Take one stopped task out of every target group the service named.
+   *
+   * A target group something else has deleted in the meantime is left alone
+   * rather than reported, since the targets went with it and there is nothing
+   * a stopping task could do about it.
+   */
+  private deregister(service: SimEcsService, task: SimEcsTask): void {
+    const address = this.registered.get(task.taskArn);
+
+    if (address === undefined) {
+      return;
+    }
+
+    this.registered.delete(task.taskArn);
+
+    for (const registration of service.registrations) {
+      this.targetGroups
+        .find(registration.targetGroupArn)
+        ?.deregister({ address, port: registration.containerPort });
+    }
+  }
+
+  private requireRegistrableGroup(
+    registration: SimEcsServiceRegistration,
+  ): void {
+    const targetGroup = this.targetGroups.find(registration.targetGroupArn);
+
+    if (targetGroup === undefined) {
+      throw new SimEcsInvalidParameterException(
+        `${registration.targetGroupArn} names no simulated target group, so ` +
+          `the service has nothing to register its tasks into.`,
+      );
+    }
+
+    if (targetGroup.targetType !== registeredTargetType) {
+      throw new SimEcsInvalidParameterException(
+        `${registration.targetGroupArn} holds ${targetGroup.targetType} ` +
+          `targets. A service registers its tasks by address, so it needs a ` +
+          `target group of the ${registeredTargetType} type.`,
+      );
+    }
+  }
+}

--- a/src/service/ecs/service/load-balancer/sim-ecs-target-groups.ts
+++ b/src/service/ecs/service/load-balancer/sim-ecs-target-groups.ts
@@ -1,0 +1,62 @@
+import { SimEcsInvalidParameterException } from "../../error/sim-ecs.error.js";
+
+/**
+ * One task of a service as a target group holds it.
+ *
+ * The address stands in for the task's own network interface address, which is
+ * what real ECS registers for an `awsvpc` task, and the port is the one the
+ * service's registration named.
+ */
+export interface SimEcsTaskTarget {
+  readonly address: string;
+  readonly port: number;
+}
+
+/**
+ * One target group a service registers its tasks into.
+ *
+ * Registering goes straight to the target group rather than through
+ * `RegisterTargets`, because nothing here is making the request: real ECS
+ * registers a task through its service-linked role, which is not something a
+ * test creates or could take away, so there is no caller for simulated IAM to
+ * decide about.
+ */
+export interface SimEcsRegistrableTargetGroup {
+  /** What the target group holds, which has to be addresses. */
+  readonly targetType: string;
+
+  register(target: SimEcsTaskTarget): void;
+
+  deregister(target: SimEcsTaskTarget): void;
+}
+
+/**
+ * Where a simulated ECS service's tasks are registered as load balancer
+ * targets.
+ *
+ * A target group is looked for when a service is created and again as each of
+ * its tasks starts and stops, rather than held from the first of those, because
+ * a target group is a resource of its own that something else may have deleted
+ * in between.
+ */
+export interface SimEcsTargetGroups {
+  find(targetGroupArn: string): SimEcsRegistrableTargetGroup | undefined;
+}
+
+/**
+ * The target groups a simulated ECS built on its own can reach, which is none.
+ *
+ * Simulated ECS is usually built through a SimAws instance, which hands it that
+ * simulation's ELBv2. One built by itself has none to reach, so a service
+ * declaring a load balancer says so rather than being created with a
+ * registration that could never carry a request.
+ */
+export class SimEcsUnreachableTargetGroups implements SimEcsTargetGroups {
+  find(targetGroupArn: string): SimEcsRegistrableTargetGroup | undefined {
+    throw new SimEcsInvalidParameterException(
+      `${targetGroupArn} cannot be registered into, because this simulated ` +
+        `ECS reaches no simulated Elastic Load Balancing. Build it through a ` +
+        `SimAws instance to register a service with a target group.`,
+    );
+  }
+}

--- a/src/service/ecs/service/load-balancer/sim-ecs-task-addresses.ts
+++ b/src/service/ecs/service/load-balancer/sim-ecs-task-addresses.ts
@@ -14,7 +14,11 @@ const octet = 256;
  * a random one can only be read back.
  *
  * They count within one Account and Region, because a task addresses nothing
- * outside its own scope and nothing outside it addresses a task.
+ * outside its own scope and nothing outside it addresses a task. An address is
+ * never reused, as a real interface address is not handed back the moment a
+ * task stops, and the whole of 10.0.0.0/8 is counted through before one could
+ * be: a simulation would have to start sixteen million tasks in one scope to
+ * reach the end of it.
  */
 export class SimEcsTaskAddresses {
   #issued = 0;
@@ -25,8 +29,9 @@ export class SimEcsTaskAddresses {
   take(): string {
     this.#issued += 1;
 
+    const second = Math.floor(this.#issued / (octet * octet)) % octet;
     const third = Math.floor(this.#issued / octet) % octet;
 
-    return `10.0.${String(third)}.${String(this.#issued % octet)}`;
+    return `10.${String(second)}.${String(third)}.${String(this.#issued % octet)}`;
   }
 }

--- a/src/service/ecs/service/load-balancer/sim-ecs-task-addresses.ts
+++ b/src/service/ecs/service/load-balancer/sim-ecs-task-addresses.ts
@@ -1,0 +1,32 @@
+/**
+ * How many addresses one octet holds.
+ */
+const octet = 256;
+
+/**
+ * The addresses the tasks of one simulated ECS scope are registered under.
+ *
+ * A real `awsvpc` task gets a private address on its own network interface, and
+ * that address is what its service registers into a target group. There is no
+ * network here to take one from, so they are counted out of the private range
+ * instead, which is what simulated ELBv2 does with its ARN ids and DNS name
+ * suffixes: a counted value is the real shape and a test can predict it, where
+ * a random one can only be read back.
+ *
+ * They count within one Account and Region, because a task addresses nothing
+ * outside its own scope and nothing outside it addresses a task.
+ */
+export class SimEcsTaskAddresses {
+  #issued = 0;
+
+  /**
+   * The address the next task of this scope is registered under.
+   */
+  take(): string {
+    this.#issued += 1;
+
+    const third = Math.floor(this.#issued / octet) % octet;
+
+    return `10.0.${String(third)}.${String(this.#issued % octet)}`;
+  }
+}

--- a/src/service/ecs/service/run/sim-ecs-service-containers.ts
+++ b/src/service/ecs/service/run/sim-ecs-service-containers.ts
@@ -1,5 +1,8 @@
 import type { BackgroundScheduler } from "../../../../util/background/background.js";
+import type { SimAwsRunAsOwner } from "../../../aws/caller/sim-aws-run-as-context.js";
 import type { SimEcsContainerBindings } from "../../bind/sim-ecs-container-bindings.js";
+import type { SimEcsServiceServers } from "../serve/sim-ecs-service-servers.js";
+import { SimEcsServiceServing } from "../serve/sim-ecs-service-serving.js";
 import { simEcsNotSimulatedContainerReason } from "../../task/run/sim-ecs-container-reason.js";
 import type { SimEcsResolvedSecrets } from "../../task/run/secret/sim-ecs-resolved-secrets.js";
 import type { SimEcsSecretStores } from "../../task/run/secret/sim-ecs-secret-stores.js";
@@ -13,6 +16,8 @@ interface SimEcsServiceContainersProperties {
   readonly bindings: SimEcsContainerBindings;
   readonly secretStores: SimEcsSecretStores;
   readonly consumers: SimEcsServiceConsumers;
+  readonly servers: SimEcsServiceServers;
+  readonly runAsOwner: SimAwsRunAsOwner;
   readonly regionName: string;
   readonly background: BackgroundScheduler;
 }
@@ -38,12 +43,14 @@ export class SimEcsServiceContainers {
   private readonly background: BackgroundScheduler;
   private readonly secrets: SimEcsTaskSecrets;
   private readonly consumption: SimEcsServiceConsumption;
+  private readonly serving: SimEcsServiceServing;
 
   constructor(properties: SimEcsServiceContainersProperties) {
     this.bindings = properties.bindings;
     this.background = properties.background;
     this.secrets = new SimEcsTaskSecrets({ stores: properties.secretStores });
     this.consumption = new SimEcsServiceConsumption(properties);
+    this.serving = new SimEcsServiceServing(properties);
   }
 
   /**
@@ -87,6 +94,7 @@ export class SimEcsServiceContainers {
 
       container.start();
       this.consumption.begin({ deployment, declared, bound, secrets });
+      this.serving.begin({ deployment, declared, bound, secrets });
     }
   }
 }

--- a/src/service/ecs/service/run/sim-ecs-service-task-starter.ts
+++ b/src/service/ecs/service/run/sim-ecs-service-task-starter.ts
@@ -1,5 +1,8 @@
 import type { BackgroundScheduler } from "../../../../util/background/background.js";
+import type { SimAwsRunAsOwner } from "../../../aws/caller/sim-aws-run-as-context.js";
 import type { SimEcsContainerBindings } from "../../bind/sim-ecs-container-bindings.js";
+import type { SimEcsServiceTargets } from "../load-balancer/sim-ecs-service-targets.js";
+import type { SimEcsServiceServers } from "../serve/sim-ecs-service-servers.js";
 import type { SimEcsSecretStores } from "../../task/run/secret/sim-ecs-secret-stores.js";
 import type { SimEcsTaskArn } from "../../task/sim-ecs-task-arn.js";
 import { SimEcsTaskFactory } from "../../task/sim-ecs-task-factory.js";
@@ -8,12 +11,22 @@ import type { SimEcsServiceConsumers } from "../consume/sim-ecs-service-consumer
 import { SimEcsServiceContainers } from "./sim-ecs-service-containers.js";
 import type { SimEcsServiceDeployment } from "./sim-ecs-service-deployment.js";
 
-interface SimEcsServiceTaskStarterProperties {
+/**
+ * What starting and stopping a service's tasks is done with.
+ *
+ * It is exported because `SimEcsServiceTasks` is built with exactly this: it
+ * holds the starter, and everything it does itself is done with the same
+ * collaborators.
+ */
+export interface SimEcsServiceTaskStarterProperties {
   readonly tasks: SimEcsTaskStore;
   readonly taskArn: SimEcsTaskArn;
   readonly bindings: SimEcsContainerBindings;
   readonly secretStores: SimEcsSecretStores;
   readonly consumers: SimEcsServiceConsumers;
+  readonly servers: SimEcsServiceServers;
+  readonly targets: SimEcsServiceTargets;
+  readonly runAsOwner: SimAwsRunAsOwner;
   readonly regionName: string;
   readonly background: BackgroundScheduler;
 }
@@ -29,16 +42,23 @@ interface SimEcsServiceTaskStarterProperties {
  *
  * A service's tasks carry the group and the `startedBy` real ECS gives one, so
  * a listing can be narrowed to the service that is keeping them.
+ *
+ * A task is registered as a load balancer target as it is started rather than
+ * once it is running, because there is no health check here for a target to
+ * pass: real ECS registers a task as soon as it has an address, and waits for
+ * the target to be healthy before sending it anything.
  */
 export class SimEcsServiceTaskStarter {
   private readonly tasks: SimEcsTaskStore;
   private readonly background: BackgroundScheduler;
   private readonly taskFactory: SimEcsTaskFactory;
   private readonly containers: SimEcsServiceContainers;
+  private readonly targets: SimEcsServiceTargets;
 
   constructor(properties: SimEcsServiceTaskStarterProperties) {
     this.tasks = properties.tasks;
     this.background = properties.background;
+    this.targets = properties.targets;
     this.taskFactory = new SimEcsTaskFactory(properties.taskArn);
     this.containers = new SimEcsServiceContainers(properties);
   }
@@ -66,6 +86,7 @@ export class SimEcsServiceTaskStarter {
 
     this.tasks.put(task);
     service.tasks.add(task);
+    this.targets.register(service, task);
     this.background.schedule(async () => {
       await this.containers.start(task, deployment);
     });

--- a/src/service/ecs/service/run/sim-ecs-service-tasks.ts
+++ b/src/service/ecs/service/run/sim-ecs-service-tasks.ts
@@ -1,23 +1,20 @@
 import type { BackgroundScheduler } from "../../../../util/background/background.js";
-import type { SimEcsContainerBindings } from "../../bind/sim-ecs-container-bindings.js";
-import type { SimEcsSecretStores } from "../../task/run/secret/sim-ecs-secret-stores.js";
-import type { SimEcsTaskArn } from "../../task/sim-ecs-task-arn.js";
-import type { SimEcsTaskStore } from "../../task/sim-ecs-task-store.js";
+import type { SimEcsServiceTargets } from "../load-balancer/sim-ecs-service-targets.js";
+import type { SimEcsServiceServers } from "../serve/sim-ecs-service-servers.js";
 import type { SimEcsTask } from "../../task/sim-ecs-task.js";
 import type { SimEcsServiceConsumers } from "../consume/sim-ecs-service-consumers.js";
 import type { SimEcsService } from "../sim-ecs-service.js";
 import type { SimEcsServiceDeployment } from "./sim-ecs-service-deployment.js";
-import { SimEcsServiceTaskStarter } from "./sim-ecs-service-task-starter.js";
+import {
+  SimEcsServiceTaskStarter,
+  type SimEcsServiceTaskStarterProperties,
+} from "./sim-ecs-service-task-starter.js";
 
-interface SimEcsServiceTasksProperties {
-  readonly tasks: SimEcsTaskStore;
-  readonly taskArn: SimEcsTaskArn;
-  readonly bindings: SimEcsContainerBindings;
-  readonly secretStores: SimEcsSecretStores;
-  readonly consumers: SimEcsServiceConsumers;
-  readonly regionName: string;
-  readonly background: BackgroundScheduler;
-}
+/**
+ * What keeping a service's tasks running takes, which is what starting one
+ * takes: everything here beyond the starter is done with the same things.
+ */
+type SimEcsServiceTasksProperties = SimEcsServiceTaskStarterProperties;
 
 /**
  * Why a task of a service stopped, in each of the ways one does.
@@ -46,19 +43,24 @@ export class SimEcsServiceTasks {
   private readonly background: BackgroundScheduler;
   private readonly starter: SimEcsServiceTaskStarter;
   private readonly consumers: SimEcsServiceConsumers;
+  private readonly servers: SimEcsServiceServers;
+  private readonly targets: SimEcsServiceTargets;
 
   constructor(properties: SimEcsServiceTasksProperties) {
     this.background = properties.background;
     this.starter = new SimEcsServiceTaskStarter(properties);
     this.consumers = properties.consumers;
+    this.servers = properties.servers;
+    this.targets = properties.targets;
   }
 
   /**
    * Bring a service's tasks to the count it wants, starting or stopping them.
    *
-   * A service scaled to nothing stops consuming as well, since there is no
-   * container left to be doing it. Scaling back out starts it again, because
-   * the task that comes up asks for polling as any first task does.
+   * A service scaled to nothing stops consuming and serving as well, since
+   * there is no container left to be doing either. Scaling back out starts them
+   * again, because the task that comes up brings its containers up as any first
+   * task does.
    */
   reconcile(deployment: SimEcsServiceDeployment): void {
     const { service } = deployment;
@@ -70,12 +72,13 @@ export class SimEcsServiceTasks {
     }
 
     this.stopEach(
+      service,
       service.tasks.takeNewest(-shortfall),
       stoppedReasons.scaledIn,
     );
 
     if (service.tasks.count === 0) {
-      this.consumers.stop(service);
+      this.stopContainers(service);
     }
   }
 
@@ -94,22 +97,35 @@ export class SimEcsServiceTasks {
   /**
    * Stop every task a service is running, and give up holding them.
    *
-   * The queue polling its containers were doing stops with them. A redeploy
-   * comes back through here and then starts again from the revision the
-   * service moved to, so a container that stopped consuming, or started, in the
-   * new revision is polled for accordingly.
+   * The queue polling its containers were doing stops with them, the containers
+   * that were answering requests stop answering, and the tasks leave the target
+   * groups they were registered into. A redeploy comes back through here and
+   * then starts again from the revision the service moved to, so a container
+   * that stopped consuming or serving, or started, in the new revision is
+   * treated accordingly.
    */
   stopAll(service: SimEcsService, reason: string): void {
-    this.consumers.stop(service);
-    this.stopEach(service.tasks.takeAll(), reason);
+    this.stopContainers(service);
+    this.stopEach(service, service.tasks.takeAll(), reason);
   }
 
-  private stopEach(tasks: readonly SimEcsTask[], reason: string): void {
+  private stopContainers(service: SimEcsService): void {
+    this.consumers.stop(service);
+    this.servers.stop(service);
+  }
+
+  private stopEach(
+    service: SimEcsService,
+    tasks: readonly SimEcsTask[],
+    reason: string,
+  ): void {
     const at = this.background.now();
 
     for (const task of tasks) {
       task.requestStop(reason);
       task.stop({ at, stopCode: "UserInitiated", reason });
     }
+
+    this.targets.deregisterAll(service, tasks);
   }
 }

--- a/src/service/ecs/service/serve/sim-ecs-container-server.ts
+++ b/src/service/ecs/service/serve/sim-ecs-container-server.ts
@@ -1,0 +1,72 @@
+import type { SimAwsRunAsOwner } from "../../../aws/caller/sim-aws-run-as-context.js";
+import { simAwsRunAsContext } from "../../../aws/caller/sim-aws-run-as-context.js";
+import type { SimEcsContainerHttpHandler } from "../../bind/sim-ecs-container-binding.type.js";
+import type { SimEcsContainerDefinition } from "../../task-definition/container/sim-ecs-container-definition.js";
+import type { SimEcsContainerEnvironment } from "../../task/run/sim-ecs-container-environment.js";
+import { simEcsTaskPrincipal } from "../../task/run/sim-ecs-task-principal.js";
+
+interface SimEcsContainerServerProperties {
+  readonly declared: SimEcsContainerDefinition;
+  readonly handler: SimEcsContainerHttpHandler;
+  readonly environment: SimEcsContainerEnvironment;
+  readonly taskRoleArn: string | undefined;
+  readonly runAsOwner: SimAwsRunAsOwner;
+}
+
+/**
+ * One container of a running service, answering the requests routed to it.
+ *
+ * The handler is called once per request rather than once per task, which
+ * follows the decision a service's desired count already rests on: the count is
+ * state rather than concurrency, so there are no copies of the container to
+ * share requests between.
+ *
+ * A request is answered as the task Role, with the container's environment
+ * applied, exactly as a container consuming a queue handles a batch and as a
+ * container of a run task runs its handler. That is what makes a service
+ * container's AWS calls authorized the way the deployed one's would be, rather
+ * than as whoever sent the request.
+ */
+export class SimEcsContainerServer {
+  public readonly containerName: string;
+
+  private readonly declared: SimEcsContainerDefinition;
+  private readonly handler: SimEcsContainerHttpHandler;
+  private readonly environment: SimEcsContainerEnvironment;
+  private readonly taskRoleArn: string | undefined;
+  private readonly runAsOwner: SimAwsRunAsOwner;
+
+  constructor(properties: SimEcsContainerServerProperties) {
+    this.declared = properties.declared;
+    this.containerName = properties.declared.name;
+    this.handler = properties.handler;
+    this.environment = properties.environment;
+    this.taskRoleArn = properties.taskRoleArn;
+    this.runAsOwner = properties.runAsOwner;
+  }
+
+  /**
+   * Whether this container declared it listens on a port.
+   *
+   * That is what tells two bound containers of the same task apart when a load
+   * balancer registration names a port rather than one of them.
+   */
+  listensOn(port: number): boolean {
+    return this.declared.containerPorts.includes(port);
+  }
+
+  /**
+   * Answer one request with this container's handler.
+   *
+   * Whatever the handler throws is left to the load balancer, which is what
+   * turns it into the status a real one sends when a target fails.
+   */
+  async handle(request: Request): Promise<Response> {
+    return await simAwsRunAsContext.run(
+      this.runAsOwner,
+      simEcsTaskPrincipal(this.taskRoleArn),
+      async () =>
+        await this.environment.runWith(async () => await this.handler(request)),
+    );
+  }
+}

--- a/src/service/ecs/service/serve/sim-ecs-service-servers.ts
+++ b/src/service/ecs/service/serve/sim-ecs-service-servers.ts
@@ -1,0 +1,92 @@
+import type { SimEcsContainerServer } from "./sim-ecs-container-server.js";
+
+/**
+ * What a service names the containers of it that answer requests.
+ */
+export interface SimEcsServedService {
+  readonly clusterName: string;
+  readonly serviceName: string;
+}
+
+/**
+ * The containers of the running services in one simulated ECS scope that
+ * answer requests.
+ *
+ * One server per service and container, rather than one per task, for the same
+ * reason a consuming container is polled for once per service: a desired count
+ * of three is three simulated tasks reported as running rather than three
+ * copies of one in-process handler. Every task of the service reaches this as
+ * it comes up, and the second one finds the first one's server.
+ *
+ * They are held here rather than on the service because a service is state a
+ * request can read and a server is the running thing behind it. That is what
+ * gives deleting a service somewhere to take its containers away, and it is
+ * what makes a target group with a service registered and nothing serving it
+ * answer for itself.
+ */
+export class SimEcsServiceServers {
+  private readonly servers = new Map<
+    string,
+    Map<string, SimEcsContainerServer>
+  >();
+
+  private static keyFor(service: SimEcsServedService): string {
+    return `${service.clusterName}/${service.serviceName}`;
+  }
+
+  /**
+   * Take on a container of a service that has come up, unless the service is
+   * already serving from a container of that name.
+   */
+  ensure(service: SimEcsServedService, server: SimEcsContainerServer): void {
+    const containers = this.containersOf(service);
+
+    if (containers.has(server.containerName)) {
+      return;
+    }
+
+    containers.set(server.containerName, server);
+  }
+
+  /**
+   * The containers of a service that answer requests, in declaration order.
+   *
+   * A service with none is one nothing can be routed to, which is what a
+   * target group holding it has to be able to tell.
+   */
+  of(service: SimEcsServedService): readonly SimEcsContainerServer[] {
+    return (
+      this.servers
+        .get(SimEcsServiceServers.keyFor(service))
+        ?.values()
+        .toArray() ?? []
+    );
+  }
+
+  /**
+   * Give up the containers a service was serving from, as deleting it does.
+   *
+   * A redeploy comes back through here and then takes on the containers of the
+   * revision the service moved to, so a container that stopped serving, or
+   * started, in the new revision is answered for accordingly.
+   */
+  stop(service: SimEcsServedService): void {
+    this.servers.delete(SimEcsServiceServers.keyFor(service));
+  }
+
+  private containersOf(
+    service: SimEcsServedService,
+  ): Map<string, SimEcsContainerServer> {
+    const key = SimEcsServiceServers.keyFor(service);
+    const held = this.servers.get(key);
+
+    if (held !== undefined) {
+      return held;
+    }
+
+    const containers = new Map<string, SimEcsContainerServer>();
+    this.servers.set(key, containers);
+
+    return containers;
+  }
+}

--- a/src/service/ecs/service/serve/sim-ecs-service-serving.iso.test.ts
+++ b/src/service/ecs/service/serve/sim-ecs-service-serving.iso.test.ts
@@ -7,6 +7,7 @@ import {
 } from "@aws-sdk/client-ecs";
 import {
   assertArrayLength,
+  assertFalse,
   assertIdentical,
   assertStringIncludes,
   assertThrowsErrorAsync,
@@ -144,13 +145,13 @@ describe("Registering a simulated ECS service with a target group", () => {
     );
 
     // Then neither the task that started nor the tasks that stopped had
-    // anywhere to be registered, and nothing failed over it.
-    assertIdentical(
+    // anywhere to be registered, and neither the scale nor the delete failed
+    // over it.
+    assertFalse(
       simAws
         .ecs()
         .service(servedServiceNames.service, servedServiceNames.cluster)
-        .desiredCount,
-      0,
+        .isActive(),
     );
   });
 });

--- a/src/service/ecs/service/serve/sim-ecs-service-serving.iso.test.ts
+++ b/src/service/ecs/service/serve/sim-ecs-service-serving.iso.test.ts
@@ -1,0 +1,328 @@
+import {
+  CreateServiceCommand,
+  DeleteServiceCommand,
+  RegisterTaskDefinitionCommand,
+  RunTaskCommand,
+  UpdateServiceCommand,
+} from "@aws-sdk/client-ecs";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import {
+  makeServedTargetGroup,
+  servedServiceNames,
+  simAwsWithServedService,
+} from "../../../../../test/ecs/served-service-fixture.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { simAwsAccountRegionScopeFactory } from "../../../aws/sim-aws-account-region-scope.factory.js";
+import { createFixtureLambdaTargetGroup } from "../../../elbv2/sim-elbv2.fixture.js";
+import { SimEcs } from "../../sim-ecs.js";
+import { simEcsClusterFactory } from "../../cluster/sim-ecs-cluster.factory.js";
+
+/**
+ * How many targets a target group holds.
+ */
+async function registeredTargets(
+  simAws: SimAws,
+  targetGroupArn: string,
+): Promise<number> {
+  const health = await simAws
+    .elbV2()
+    .describeTargetHealth({ input: { TargetGroupArn: targetGroupArn } });
+
+  return health.TargetHealthDescriptions?.length ?? 0;
+}
+
+describe("Registering a simulated ECS service with a target group", () => {
+  it("registers one target for each task the service keeps running", async () => {
+    // Given a service keeping two tasks running behind a target group.
+    const { simAws, targetGroupArn } = await simAwsWithServedService({
+      desiredCount: 2,
+      withoutLoadBalancer: true,
+    });
+
+    // When the target group's health is described.
+    const health = await simAws
+      .elbV2()
+      .describeTargetHealth({ input: { TargetGroupArn: targetGroupArn } });
+
+    // Then each task is a target, on the port the registration named, at an
+    // address of its own.
+    assertArrayLength(health.TargetHealthDescriptions, 2);
+    assertIdentical(health.TargetHealthDescriptions[0].Target.Id, "10.0.0.1");
+    assertIdentical(health.TargetHealthDescriptions[1].Target.Id, "10.0.0.2");
+    assertIdentical(
+      health.TargetHealthDescriptions[0].Target.Port,
+      servedServiceNames.containerPort,
+    );
+  });
+
+  it("takes the targets out again when the service is deleted", async () => {
+    // Given a service registered into a target group.
+    const { simAws, targetGroupArn } = await simAwsWithServedService({
+      withoutLoadBalancer: true,
+    });
+
+    // When the service is deleted.
+    await simAws.ecs().deleteService(
+      new DeleteServiceCommand({
+        cluster: servedServiceNames.cluster,
+        service: servedServiceNames.service,
+        force: true,
+      }),
+    );
+
+    // Then the group holds nothing, because the tasks that were its targets
+    // have stopped.
+    assertIdentical(await registeredTargets(simAws, targetGroupArn), 0);
+  });
+
+  it("follows the desired count as the service is scaled", async () => {
+    // Given a service keeping one task running behind a target group.
+    const { simAws, targetGroupArn } = await simAwsWithServedService({
+      withoutLoadBalancer: true,
+    });
+    const ecs = simAws.ecs();
+
+    // When it is scaled out and then back in.
+    await ecs.updateService(
+      new UpdateServiceCommand({
+        cluster: servedServiceNames.cluster,
+        service: servedServiceNames.service,
+        desiredCount: 3,
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    const scaledOut = await registeredTargets(simAws, targetGroupArn);
+
+    await ecs.updateService(
+      new UpdateServiceCommand({
+        cluster: servedServiceNames.cluster,
+        service: servedServiceNames.service,
+        desiredCount: 1,
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // Then the targets are the tasks the service is keeping, at each point.
+    assertIdentical(scaledOut, 3);
+    assertIdentical(await registeredTargets(simAws, targetGroupArn), 1);
+  });
+
+  it("leaves a target group that has been deleted alone", async () => {
+    // Given a service registered into a target group that is then deleted,
+    // which takes its targets with it.
+    const { simAws, targetGroupArn } = await simAwsWithServedService({
+      withoutLoadBalancer: true,
+    });
+
+    await simAws
+      .elbV2()
+      .deleteTargetGroup({ input: { TargetGroupArn: targetGroupArn } });
+
+    // When the service is scaled out and then deleted.
+    await simAws.ecs().updateService(
+      new UpdateServiceCommand({
+        cluster: servedServiceNames.cluster,
+        service: servedServiceNames.service,
+        desiredCount: 2,
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+    await simAws.ecs().deleteService(
+      new DeleteServiceCommand({
+        cluster: servedServiceNames.cluster,
+        service: servedServiceNames.service,
+        force: true,
+      }),
+    );
+
+    // Then neither the task that started nor the tasks that stopped had
+    // anywhere to be registered, and nothing failed over it.
+    assertIdentical(
+      simAws
+        .ecs()
+        .service(servedServiceNames.service, servedServiceNames.cluster)
+        .desiredCount,
+      0,
+    );
+  });
+});
+
+describe("Refusing a simulated ECS service load balancer", () => {
+  it("refuses a target group nothing holds", async () => {
+    // Given a registered task definition and no target group.
+    const simAws = new SimAws();
+    const ecs = simAws.ecs();
+    await simEcsClusterFactory.make({}, simAws);
+    await ecs.registerTaskDefinition(
+      new RegisterTaskDefinitionCommand({
+        family: "checkout",
+        containerDefinitions: [{ name: "app", image: "checkout:1" }],
+      }),
+    );
+
+    // When a service names one anyway, then it says so rather than being
+    // created registered with nothing.
+    const error = await assertThrowsErrorAsync(async () => {
+      return await ecs.createService(
+        new CreateServiceCommand({
+          serviceName: "checkout",
+          taskDefinition: "checkout",
+          desiredCount: 1,
+          loadBalancers: [
+            {
+              targetGroupArn:
+                "arn:aws:elasticloadbalancing:us-east-1:888888888888:targetgroup/gone/0000000000000001",
+              containerName: "app",
+              containerPort: 8080,
+            },
+          ],
+        }),
+      );
+    });
+
+    assertStringIncludes(error.message, "names no simulated target group");
+  });
+
+  it("refuses a target group that holds functions", async () => {
+    // Given a registered task definition and a lambda target group.
+    const simAws = new SimAws();
+    const ecs = simAws.ecs();
+    await simEcsClusterFactory.make({}, simAws);
+    await ecs.registerTaskDefinition(
+      new RegisterTaskDefinitionCommand({
+        family: "checkout",
+        containerDefinitions: [{ name: "app", image: "checkout:1" }],
+      }),
+    );
+
+    const targetGroupArn = await createFixtureLambdaTargetGroup(simAws.elbV2());
+
+    // When a service names it, then it says what a service registers as.
+    const error = await assertThrowsErrorAsync(async () => {
+      return await ecs.createService(
+        new CreateServiceCommand({
+          serviceName: "checkout",
+          taskDefinition: "checkout",
+          desiredCount: 1,
+          loadBalancers: [
+            { targetGroupArn, containerName: "app", containerPort: 8080 },
+          ],
+        }),
+      );
+    });
+
+    assertStringIncludes(error.message, "holds lambda targets");
+  });
+
+  it("says what is missing when simulated ECS reaches no load balancing", async () => {
+    // Given a simulated ECS built on its own, which has no ELBv2 to reach.
+    const accountRegionScope = simAwsAccountRegionScopeFactory.make();
+    const ecs = new SimEcs({ accountRegionScope });
+    const targetGroupArn = `arn:aws:elasticloadbalancing:${accountRegionScope.regionName}:${accountRegionScope.accountId}:targetgroup/checkout-tg/0000000000000001`;
+    await ecs.createCluster({ input: { clusterName: "orders" } });
+    await ecs.registerTaskDefinition({
+      input: {
+        family: "checkout",
+        containerDefinitions: [{ name: "app", image: "checkout:1" }],
+      },
+    });
+
+    // When a service names a target group, then it says how to reach one
+    // rather than registering with nothing.
+    const error = await assertThrowsErrorAsync(async () => {
+      return await ecs.createService({
+        input: {
+          cluster: "orders",
+          serviceName: "checkout",
+          taskDefinition: "checkout",
+          desiredCount: 1,
+          loadBalancers: [
+            { targetGroupArn, containerName: "app", containerPort: 8080 },
+          ],
+        },
+      });
+    });
+
+    assertStringIncludes(error.message, "reaches no simulated Elastic Load");
+  });
+
+  it("refuses a target group of another Account or Region", async () => {
+    // Given a registered task definition and a target group in another Region.
+    const simAws = new SimAws();
+    const ecs = simAws.ecs();
+    await simEcsClusterFactory.make({}, simAws);
+    await ecs.registerTaskDefinition(
+      new RegisterTaskDefinitionCommand({
+        family: "checkout",
+        containerDefinitions: [{ name: "app", image: "checkout:1" }],
+      }),
+    );
+
+    const elsewhere = simAws.account("888888888888").region("eu-west-1");
+    const targetGroupArn = await makeServedTargetGroup(
+      simAws,
+      elsewhere.elbV2(),
+    );
+
+    // When a service names it, then it says where a service registers.
+    const error = await assertThrowsErrorAsync(async () => {
+      return await ecs.createService(
+        new CreateServiceCommand({
+          serviceName: "checkout",
+          taskDefinition: "checkout",
+          desiredCount: 1,
+          loadBalancers: [
+            { targetGroupArn, containerName: "app", containerPort: 8080 },
+          ],
+        }),
+      );
+    });
+
+    assertStringIncludes(error.message, "in another Account or Region");
+  });
+
+  it("records a serving container of a run task as not simulated", async () => {
+    // Given a task definition whose container answers requests.
+    const simAws = new SimAws();
+    const ecs = simAws.ecs();
+    await makeServedTargetGroup(simAws);
+    await simEcsClusterFactory.make({}, simAws);
+    ecs.bindContainer({
+      family: "checkout",
+      containerName: "app",
+      http: () => new Response("checkout"),
+    });
+    await ecs.registerTaskDefinition(
+      new RegisterTaskDefinitionCommand({
+        family: "checkout",
+        containerDefinitions: [{ name: "app", image: "checkout:1" }],
+      }),
+    );
+
+    // When a task is run from it rather than a service created.
+    const run = await ecs.runTask(
+      new RunTaskCommand({ taskDefinition: "checkout" }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // Then the container says where it does run, rather than being called
+    // with no request to answer.
+    const task = simAws.ecs();
+    const described = await task.describeTasks({
+      input: { tasks: [run.tasks?.[0]?.taskArn ?? ""] },
+    });
+
+    assertStringIncludes(
+      described.tasks?.[0]?.containers?.[0]?.reason ?? "",
+      "answers HTTP requests",
+    );
+  });
+});

--- a/src/service/ecs/service/serve/sim-ecs-service-serving.iso.test.ts
+++ b/src/service/ecs/service/serve/sim-ecs-service-serving.iso.test.ts
@@ -255,6 +255,38 @@ describe("Refusing a simulated ECS service load balancer", () => {
     assertStringIncludes(error.message, "reaches no simulated Elastic Load");
   });
 
+  it("refuses a container port nothing could listen on", async () => {
+    // Given a registered task definition and a target group of addresses.
+    const simAws = new SimAws();
+    const ecs = simAws.ecs();
+    await simEcsClusterFactory.make({}, simAws);
+    await ecs.registerTaskDefinition(
+      new RegisterTaskDefinitionCommand({
+        family: "checkout",
+        containerDefinitions: [{ name: "app", image: "checkout:1" }],
+      }),
+    );
+
+    const targetGroupArn = await makeServedTargetGroup(simAws);
+
+    // When a service registers on a port outside the range a target takes,
+    // then it says so rather than registering a target nothing could reach.
+    const error = await assertThrowsErrorAsync(async () => {
+      return await ecs.createService(
+        new CreateServiceCommand({
+          serviceName: "checkout",
+          taskDefinition: "checkout",
+          desiredCount: 1,
+          loadBalancers: [
+            { targetGroupArn, containerName: "app", containerPort: 70_000 },
+          ],
+        }),
+      );
+    });
+
+    assertStringIncludes(error.message, "not a port between 1 and 65535");
+  });
+
   it("refuses a target group of another Account or Region", async () => {
     // Given a registered task definition and a target group in another Region.
     const simAws = new SimAws();

--- a/src/service/ecs/service/serve/sim-ecs-service-serving.ts
+++ b/src/service/ecs/service/serve/sim-ecs-service-serving.ts
@@ -1,0 +1,67 @@
+import type { SimAwsRunAsOwner } from "../../../aws/caller/sim-aws-run-as-context.js";
+import { SimEcsContainerEnvironments } from "../../task/run/sim-ecs-container-environments.js";
+import { SimEcsTaskOverrides } from "../../task/run/sim-ecs-task-overrides.js";
+import type { SimEcsStartingServiceContainer } from "../run/sim-ecs-service-consumption.js";
+import { SimEcsContainerServer } from "./sim-ecs-container-server.js";
+import type { SimEcsServiceServers } from "./sim-ecs-service-servers.js";
+
+interface SimEcsServiceServingProperties {
+  readonly servers: SimEcsServiceServers;
+  readonly runAsOwner: SimAwsRunAsOwner;
+  readonly regionName: string;
+}
+
+/**
+ * Takes on the containers of a service that answer requests, as its tasks come
+ * up.
+ *
+ * A container bound to an HTTP handler starts nothing of its own, unlike one
+ * that consumes a queue: what reaches it is a request a load balancer routes to
+ * the target group its service registered into. What has to happen as a task
+ * comes up is only that the container becomes reachable, with the environment
+ * the task's secrets have just resolved to, so a served request reads the same
+ * variables a run task's container would.
+ */
+export class SimEcsServiceServing {
+  private readonly servers: SimEcsServiceServers;
+  private readonly runAsOwner: SimAwsRunAsOwner;
+  private readonly environments: SimEcsContainerEnvironments;
+
+  constructor(properties: SimEcsServiceServingProperties) {
+    this.servers = properties.servers;
+    this.runAsOwner = properties.runAsOwner;
+    this.environments = new SimEcsContainerEnvironments({
+      regionName: properties.regionName,
+      overrides: new SimEcsTaskOverrides(undefined),
+    });
+  }
+
+  /**
+   * Have this container answer for its service, if it serves requests.
+   */
+  begin(starting: SimEcsStartingServiceContainer): void {
+    const { serves } = starting.bound;
+
+    if (serves === undefined) {
+      return;
+    }
+
+    const { service, taskDefinition } = starting.deployment;
+    const { declared } = starting;
+    const environment = this.environments.for(
+      declared,
+      starting.secrets.forContainer(declared.name),
+    );
+
+    this.servers.ensure(
+      service,
+      new SimEcsContainerServer({
+        declared,
+        handler: serves,
+        environment,
+        taskRoleArn: taskDefinition.settings.taskRoleArn,
+        runAsOwner: this.runAsOwner,
+      }),
+    );
+  }
+}

--- a/src/service/ecs/service/serve/sim-ecs-serving-container-context.iso.test.ts
+++ b/src/service/ecs/service/serve/sim-ecs-serving-container-context.iso.test.ts
@@ -1,0 +1,90 @@
+import { GetParameterCommand, SSMClient } from "@aws-sdk/client-ssm";
+import { assertIdentical, assertStringIncludes } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import {
+  servedServiceAsRole,
+  simAwsWithServedService,
+} from "../../../../../test/ecs/served-service-fixture.js";
+import { SimSdk } from "../../../../sdk/index.js";
+import { simElbV2Fetch } from "../../../elbv2/serve/sim-elbv2-fetch.js";
+
+describe("What a simulated ECS container answering a request may do", () => {
+  it("attributes the container's own AWS calls to the task Role", async () => {
+    // Given a served container that writes a parameter, and a task Role that
+    // may write it.
+    using simSdk = new SimSdk();
+
+    simSdk.intercept(SSMClient);
+
+    const { simAws } = simSdk;
+    const hostname = await servedServiceAsRole(simAws, ["ssm:PutParameter"]);
+
+    // When a request reaches the container.
+    const response = await simElbV2Fetch(simAws, `http://${hostname}/orders`, {
+      method: "POST",
+      body: "order-1",
+    });
+
+    // Then simulated IAM allowed the write, so the parameter is there: the
+    // call was made as the task Role rather than as whoever sent the request.
+    assertIdentical(await response.text(), "written");
+
+    const read = await simAws
+      .ssm()
+      .getParameter(new GetParameterCommand({ Name: "/orders/last-handled" }));
+
+    assertIdentical(read.Parameter?.Value, "order-1");
+  });
+
+  it("refuses an AWS call the task Role has no policy for", async () => {
+    // Given the same container and a task Role that may read nothing.
+    using simSdk = new SimSdk();
+
+    simSdk.intercept(SSMClient);
+
+    const { simAws } = simSdk;
+    const hostname = await servedServiceAsRole(simAws, ["ssm:GetParameter"]);
+
+    // When a request reaches the container.
+    const response = await simElbV2Fetch(simAws, `http://${hostname}/orders`, {
+      method: "POST",
+      body: "order-1",
+    });
+
+    // Then the write was denied, naming the Role the deployed container would
+    // have been running as.
+    assertIdentical(response.status, 500);
+    assertStringIncludes(await response.text(), "ssm:PutParameter");
+  });
+
+  it("gives the container the environment its definition declared", async () => {
+    // Given a served container declaring an environment variable, as a real
+    // one takes its table name or its endpoint.
+    const { simAws, hostname } = await simAwsWithServedService({
+      containers: [
+        {
+          name: "app",
+          ports: [8080],
+          environment: [{ name: "ORDERS_TABLE", value: "orders" }],
+          handler: (): Response =>
+            new Response(
+              `${process.env["ORDERS_TABLE"] ?? ""} ${
+                process.env["AWS_REGION"] ?? ""
+              }`,
+            ),
+        },
+      ],
+    });
+
+    // When a request reaches it.
+    const response = await simElbV2Fetch(simAws, `http://${hostname}/orders`);
+
+    // Then the handler read it out of process.env, along with the Region
+    // variables a task agent sets, exactly as a run task's container does.
+    assertIdentical(
+      await response.text(),
+      `orders ${simAws.defaultRegionName}`,
+    );
+  });
+});

--- a/src/service/ecs/service/serve/sim-ecs-target-group-containers.ts
+++ b/src/service/ecs/service/serve/sim-ecs-target-group-containers.ts
@@ -1,0 +1,123 @@
+import type { SimEcsServiceRegistration } from "../load-balancer/sim-ecs-service-registration.js";
+import type { SimEcsService } from "../sim-ecs-service.js";
+import type { SimEcsServiceStore } from "../sim-ecs-service-store.js";
+import type { SimEcsContainerServer } from "./sim-ecs-container-server.js";
+import type { SimEcsServiceServers } from "./sim-ecs-service-servers.js";
+
+interface SimEcsTargetGroupContainersProperties {
+  readonly services: SimEcsServiceStore;
+  readonly servers: SimEcsServiceServers;
+}
+
+/**
+ * A service registered into a target group, and what it registered.
+ */
+interface SimEcsRegisteredService {
+  readonly service: SimEcsService;
+  readonly registration: SimEcsServiceRegistration;
+}
+
+/**
+ * Finds the container answering for a target group.
+ *
+ * Which service that is comes from reading the services back rather than from a
+ * record kept on the target group, for the same reason simulated ELBv2 reads
+ * back which load balancers forward to a group: the registration is the
+ * service's, and a service deleted or replaced without the target group hearing
+ * about it would leave a record that had gone stale.
+ *
+ * Which container of that service answers is a deliberate divergence, and it is
+ * the reason this class exists rather than the lookup being a line somewhere
+ * else. Real ECS sends the request to the container the registration names, on
+ * the port it names. The common real task puts a proxy such as nginx on that
+ * port with the application behind it, and Yulin cannot run the proxy: nothing
+ * is bound to it, because there is nothing a test could bind. Routing strictly
+ * by name and port would therefore send every request to a container that does
+ * not exist here. So the request goes to a bound container: the one the
+ * registration names where that container is bound, and otherwise the one that
+ * declared the registration's port, and otherwise the only one there is.
+ */
+export class SimEcsTargetGroupContainers {
+  private readonly services: SimEcsServiceStore;
+  private readonly servers: SimEcsServiceServers;
+
+  constructor(properties: SimEcsTargetGroupContainersProperties) {
+    this.services = properties.services;
+    this.servers = properties.servers;
+  }
+
+  /**
+   * The container answering for a target group, where one is.
+   *
+   * Nothing at all means there is nothing to serve the request: no active
+   * service registered into the group, or one whose containers are none of
+   * them bound to an HTTP handler.
+   */
+  find(targetGroupArn: string): SimEcsContainerServer | undefined {
+    const registered = this.registeredService(targetGroupArn);
+
+    if (registered === undefined) {
+      return undefined;
+    }
+
+    return this.containerOf(registered);
+  }
+
+  /**
+   * The active service registered into a target group.
+   *
+   * The first of them, where more than one registered into the same group.
+   * Real ECS lets two services share a target group and shares the requests
+   * between their tasks, which is load balancing across targets, and that is
+   * not simulated.
+   */
+  private registeredService(
+    targetGroupArn: string,
+  ): SimEcsRegisteredService | undefined {
+    for (const service of this.services.active()) {
+      const registration = service.registrations.find(
+        (candidate) => candidate.targetGroupArn === targetGroupArn,
+      );
+
+      if (registration !== undefined) {
+        return { service, registration };
+      }
+    }
+
+    return undefined;
+  }
+
+  private containerOf(
+    registered: SimEcsRegisteredService,
+  ): SimEcsContainerServer | undefined {
+    const serving = this.servers.of(registered.service);
+    const named = serving.find(
+      (server) =>
+        server.containerName === registered.registration.containerName,
+    );
+
+    return named ?? this.byPort(serving, registered.registration.containerPort);
+  }
+
+  /**
+   * The bound container the registration's port means.
+   *
+   * A single bound container takes the request whatever port the registration
+   * named, which is the proxy-in-front case: the port belongs to a container
+   * Yulin has nothing to run. The port only chooses where there is a choice to
+   * make, and a task whose bound containers declared none of it falls back to
+   * the first, since one of them is still nearer to right than a 503.
+   */
+  private byPort(
+    serving: readonly SimEcsContainerServer[],
+    containerPort: number,
+  ): SimEcsContainerServer | undefined {
+    if (serving.length <= 1) {
+      return serving[0];
+    }
+
+    return (
+      serving.find((server) => server.listensOn(containerPort)) ?? serving[0]
+    );
+  }
+}

--- a/src/service/ecs/service/serve/sim-ecs-target-group-containers.ts
+++ b/src/service/ecs/service/serve/sim-ecs-target-group-containers.ts
@@ -35,7 +35,8 @@ interface SimEcsRegisteredService {
  * by name and port would therefore send every request to a container that does
  * not exist here. So the request goes to a bound container: the one the
  * registration names where that container is bound, and otherwise the one that
- * declared the registration's port, and otherwise the only one there is.
+ * declared the registration's port, and otherwise the first one the task
+ * definition declares.
  */
 export class SimEcsTargetGroupContainers {
   private readonly services: SimEcsServiceStore;

--- a/src/service/ecs/service/sim-ecs-service-identity.ts
+++ b/src/service/ecs/service/sim-ecs-service-identity.ts
@@ -1,4 +1,5 @@
 import type { SimArn } from "../../aws/arn.js";
+import type { SimEcsServiceRegistration } from "./load-balancer/sim-ecs-service-registration.js";
 import type {
   SimEcsServiceDetail,
   SimEcsServiceLoadBalancer,
@@ -15,7 +16,7 @@ export interface SimEcsServiceIdentityProperties {
   readonly createdAt: Date;
   readonly launchType?: string | undefined;
   readonly createdBy?: string | undefined;
-  readonly loadBalancers?: readonly SimEcsServiceLoadBalancer[] | undefined;
+  readonly registrations?: readonly SimEcsServiceRegistration[] | undefined;
 }
 
 /**
@@ -39,7 +40,7 @@ export class SimEcsServiceIdentity {
   public readonly clusterArn: SimArn;
   public readonly clusterName: string;
   public readonly launchType: string | undefined;
-  public readonly loadBalancers: readonly SimEcsServiceLoadBalancer[];
+  public readonly registrations: readonly SimEcsServiceRegistration[];
 
   private readonly declared: SimEcsServiceIdentityProperties;
 
@@ -50,17 +51,24 @@ export class SimEcsServiceIdentity {
     this.clusterArn = declared.clusterArn;
     this.clusterName = declared.clusterName;
     this.launchType = declared.launchType;
-    this.loadBalancers = declared.loadBalancers ?? [];
+    this.registrations = declared.registrations ?? [];
+  }
+
+  /**
+   * The load balancers this service is registered with, as it declared them.
+   */
+  get loadBalancers(): readonly SimEcsServiceLoadBalancer[] {
+    return this.registrations.map((registration) => registration.toOutput());
   }
 
   /**
    * This part of the service as `DescribeServices` reports it.
    *
-   * The load balancers are the ones the service was created with, held as they
-   * were declared, because nothing here sends a service a request yet. The
-   * service registries are honestly empty rather than left out: a service
-   * registers with none here, and reporting nothing at all would read as a
-   * service that had not been asked about them.
+   * The load balancers are the registrations the service was created with, read
+   * back in the shape they were declared in. The service registries are
+   * honestly empty rather than left out: a service registers with none here,
+   * and reporting nothing at all would read as a service that had not been
+   * asked about them.
    */
   toOutput(): SimEcsServiceIdentityDetail {
     const { serviceArn, serviceName, clusterArn, createdAt } = this.declared;

--- a/src/service/ecs/service/sim-ecs-service.ts
+++ b/src/service/ecs/service/sim-ecs-service.ts
@@ -1,4 +1,5 @@
 import type { SimArn } from "../../aws/arn.js";
+import type { SimEcsServiceRegistration } from "./load-balancer/sim-ecs-service-registration.js";
 import type {
   SimEcsServiceDetail,
   SimEcsServiceLoadBalancer,
@@ -75,14 +76,22 @@ export class SimEcsService {
   }
 
   /**
-   * The load balancers this service was created with.
-   *
-   * Held as they were declared and not acted on: nothing here sends a service
-   * container a request yet, so this is what a target group reads to find the
-   * service that is meant to answer for it.
+   * The load balancers this service was created with, as it declared them.
    */
   get loadBalancers(): readonly SimEcsServiceLoadBalancer[] {
     return this.identity.loadBalancers;
+  }
+
+  /**
+   * The target groups this service registers its tasks into.
+   *
+   * This is the same declaration read once and checked, and it is what both
+   * ends of a served request go through: the tasks are registered into these
+   * target groups as they start, and a request routed to one of those groups
+   * finds this service by reading them back.
+   */
+  get registrations(): readonly SimEcsServiceRegistration[] {
+    return this.identity.registrations;
   }
 
   /** The revision this service is currently running. */

--- a/src/service/ecs/sim-ecs-commands.ts
+++ b/src/service/ecs/sim-ecs-commands.ts
@@ -4,6 +4,9 @@ import { simAwsAccountRegionScopeFactory } from "../aws/sim-aws-account-region-s
 import { SimIamAllowAllAuth } from "../iam/authorize/sim-iam-inter-service-auth-z.js";
 import { SimEcsContainerBindings } from "./bind/sim-ecs-container-bindings.js";
 import { SimEcsUnreachableConsumerQueues } from "./service/consume/sim-ecs-consumer-queues.js";
+import { SimEcsUnreachableTargetGroups } from "./service/load-balancer/sim-ecs-target-groups.js";
+import type { SimEcsTargetGroupContainers } from "./service/serve/sim-ecs-target-group-containers.js";
+import type { SimEcsContainerServer } from "./service/serve/sim-ecs-container-server.js";
 import { SimEcsClusterStore } from "./cluster/sim-ecs-cluster-store.js";
 import { SimEcsAuthorizer } from "./command/authorize/sim-ecs-authorizer.js";
 import { SimEcsCommandContexts } from "./command/sim-ecs-command-contexts.js";
@@ -82,6 +85,7 @@ export class SimEcsCommands {
   private readonly taskDefinitions = new SimEcsTaskDefinitionStore();
   private readonly services = new SimEcsServiceStore();
   private readonly serviceTasks: SimEcsServiceTasks;
+  private readonly targetGroupContainers: SimEcsTargetGroupContainers;
 
   constructor(properties: SimEcsCommandsProperties) {
     const {
@@ -91,6 +95,7 @@ export class SimEcsCommands {
       runAsOwner,
       secretStores = new SimEcsUnreachableSecretStores(),
       consumerQueues = new SimEcsUnreachableConsumerQueues(),
+      targetGroups = new SimEcsUnreachableTargetGroups(),
     } = properties;
 
     const contexts = new SimEcsCommandContexts({
@@ -105,10 +110,12 @@ export class SimEcsCommands {
       bindings: this.bindings,
       secretStores,
       consumerQueues,
+      targetGroups,
     });
     const { cluster, taskDefinition, task, service } = contexts;
 
     this.serviceTasks = service.serviceTasks;
+    this.targetGroupContainers = contexts.targetGroupContainers;
     this.lookup = new SimEcsLookup({
       accountRegionScope,
       clusters: this.clusters,
@@ -146,6 +153,13 @@ export class SimEcsCommands {
     this.updateService = new UpdateServiceCommandHandler(service);
     this.describeServices = new DescribeServicesCommandHandler(service);
     this.deleteService = new DeleteServiceCommandHandler(service);
+  }
+
+  /**
+   * The container answering for a target group, where a service registered one.
+   */
+  servingContainer(targetGroupArn: string): SimEcsContainerServer | undefined {
+    return this.targetGroupContainers.find(targetGroupArn);
   }
 
   /**

--- a/src/service/ecs/sim-ecs-properties.ts
+++ b/src/service/ecs/sim-ecs-properties.ts
@@ -3,6 +3,7 @@ import type { SimAwsRunAsOwner } from "../aws/caller/sim-aws-run-as-context.js";
 import type { SimAwsAccountRegionScope } from "../aws/sim-aws-account-region-scope.js";
 import type { SimIamInterServiceAuthZ } from "../iam/authorize/sim-iam-inter-service-auth-z.js";
 import type { SimSqsPollQueues } from "../sqs/poll/sim-sqs-poll-queues.js";
+import type { SimEcsTargetGroups } from "./service/load-balancer/sim-ecs-target-groups.js";
 import type { SimEcsSecretStores } from "./task/run/secret/sim-ecs-secret-stores.js";
 
 /**
@@ -46,4 +47,14 @@ export interface SimEcsProperties {
    * consuming container says so rather than polling nothing forever.
    */
   readonly consumerQueues?: SimSqsPollQueues;
+
+  /**
+   * The target groups a service registers its tasks into.
+   *
+   * This is the surrounding simulation's ELBv2 when ECS was built through a
+   * SimAws instance. Simulated ECS built on its own reaches none, so a service
+   * declaring a load balancer says so rather than being created registered with
+   * nothing.
+   */
+  readonly targetGroups?: SimEcsTargetGroups;
 }

--- a/src/service/ecs/sim-ecs.ts
+++ b/src/service/ecs/sim-ecs.ts
@@ -6,6 +6,7 @@ import type { SimEcsCluster } from "./cluster/sim-ecs-cluster.js";
 import type * as simEcsCommands from "./command/sim-ecs-command.types.js";
 import type { SimEcsRequestOptions } from "./command/sim-ecs-request-options.js";
 import { SimEcsSdkCommandRouter } from "./sdk/sim-ecs-sdk-command-router.js";
+import type { SimEcsContainerServer } from "./service/serve/sim-ecs-container-server.js";
 import type { SimEcsService } from "./service/sim-ecs-service.js";
 import { SimEcsCommands } from "./sim-ecs-commands.js";
 import type { SimEcsProperties } from "./sim-ecs-properties.js";
@@ -215,9 +216,9 @@ export class SimEcs {
    *
    * A service is the one thing simulated ECS keeps running rather than runs and
    * finishes, so this is what a simulated environment being finished with comes
-   * down to: every service's tasks stop and nothing is left scheduled, while
-   * the services stay describable with the desired count they had. Closing
-   * again does nothing again, since there is then nothing running to stop.
+   * down to: every service's tasks stop, leaving the target groups they were
+   * registered into, and nothing is left scheduled, while the services stay
+   * describable with the desired count they had.
    */
   close(): void {
     this.commands.closeServices();
@@ -227,25 +228,15 @@ export class SimEcs {
    * Bind a real in-process handler to a container a task definition declares.
    *
    * The container is named either by its family and container name or by the
-   * repository its image comes from. A task run from that definition runs the
-   * bound handler in this process, with the container's environment variables
-   * and the task Role.
-   *
-   * ```typescript
-   * simAws.ecs().bindContainer({
-   *   family: "orders-worker",
-   *   containerName: "app",
-   *   run: async () => {
-   *     await processOutstandingOrders();
-   *   },
-   * });
-   * ```
+   * repository its image comes from, as `SimEcsContainerBinding` shows. A task
+   * run from that definition runs the bound handler in this process, with the
+   * container's environment variables and the task Role.
    *
    * A container that consumes a queue declares `consumes` instead of `run`,
-   * with a `queueUrl` and a `handler` for a batch of messages. Yulin drives the
-   * polling loop while a service is running the container and the binding
-   * supplies its body, so the batch is deleted when the handler returns and
-   * left on the queue when it throws. Polling is done as the task Role.
+   * with a `queueUrl` and a `handler` for a batch of messages: Yulin drives the
+   * polling loop and the binding supplies its body. One behind a load balancer
+   * declares `http` instead, and its handler answers each request routed to it.
+   * Both are called as the task Role while a service is running the container.
    *
    * Bindings belong to the Account and Region they were made in, as the task
    * definitions they target do, and can be made before or after the task
@@ -259,33 +250,40 @@ export class SimEcs {
    * The cluster of this name, whether it is active or deleted.
    *
    * A lookup rather than an operation, for a test or a CloudFormation Resource
-   * that needs the thing itself rather than a description of it. An identifier
-   * nothing holds is refused, here and in the two lookups below, since the
-   * caller asked for the thing rather than for whether there is one.
+   * that needs the thing itself. An identifier nothing holds is refused, here
+   * and in the two lookups below, since the caller asked for the thing rather
+   * than for whether there is one.
    */
   cluster(clusterName: string): SimEcsCluster {
     return this.commands.lookup.cluster(clusterName);
   }
 
   /**
-   * The task definition revision a family, `family:revision` or ARN names.
-   *
-   * A family on its own means its latest active revision, as it does
-   * everywhere else in ECS.
+   * The task definition revision a family, `family:revision` or ARN names. A
+   * family on its own means its latest active revision, as it does elsewhere.
    */
   taskDefinition(identifier: string): SimEcsTaskDefinition {
     return this.commands.lookup.taskDefinition(identifier);
   }
 
   /**
-   * The service a name in a cluster, or a full service ARN, names, whether it
-   * is active or deleted.
-   *
-   * A name given without a cluster is looked for in the `default` one, as an
-   * ECS request naming no cluster means that one.
+   * The service a name in a cluster, or a full service ARN, names, active or
+   * deleted. A name given without a cluster is looked for in the `default` one.
    */
   service(identifier: string, clusterName?: string): SimEcsService {
     return this.commands.lookup.service(identifier, clusterName);
+  }
+
+  /**
+   * The container of a running service that answers for a target group.
+   *
+   * This is how a request routed to a target group reaches the handler bound to
+   * a service's container. It answers with nothing where nothing can serve the
+   * request: no active service registered into the group, or one whose
+   * containers are none of them bound to an HTTP handler.
+   */
+  servingContainer(targetGroupArn: string): SimEcsContainerServer | undefined {
+    return this.commands.servingContainer(targetGroupArn);
   }
 
   /** Get this service's CloudFormation Resource factory. */

--- a/src/service/ecs/task-definition/container/sim-ecs-container-definition.ts
+++ b/src/service/ecs/task-definition/container/sim-ecs-container-definition.ts
@@ -1,4 +1,7 @@
-import { SimEcsClientException } from "../../error/sim-ecs.error.js";
+import {
+  requiredSimEcsContainerImage,
+  requiredSimEcsContainerName,
+} from "./sim-ecs-container-identity.js";
 import type {
   SimEcsContainerDependency,
   SimEcsHealthCheck,
@@ -9,6 +12,7 @@ import type {
   SimEcsSecret,
   SimEcsUlimit,
 } from "./sim-ecs-container-parts.js";
+import { simEcsContainerPorts } from "./sim-ecs-container-ports.js";
 
 /**
  * Minimal structural sim ECS container definition.
@@ -62,45 +66,11 @@ export class SimEcsContainerDefinition {
   private readonly declared: SimEcsContainerDefinitionType;
 
   constructor(declared: SimEcsContainerDefinitionType) {
-    this.name = SimEcsContainerDefinition.requiredName(declared);
-    this.image = SimEcsContainerDefinition.requiredImage(declared, this.name);
+    this.name = requiredSimEcsContainerName(declared.name);
+    this.image = requiredSimEcsContainerImage(declared.image, this.name);
     // Copied rather than held by reference, since the caller owns the object
     // it passed in and may reuse it for the next registration.
     this.declared = structuredClone(declared);
-  }
-
-  private static requiredName(declared: SimEcsContainerDefinitionType): string {
-    const { name } = declared;
-
-    if (name === undefined || name === "") {
-      throw new SimEcsClientException(
-        "Container.name should not be null or empty.",
-      );
-    }
-
-    return name;
-  }
-
-  /**
-   * The image URI the container declared.
-   *
-   * It is required here as it is on real ECS. Nothing pulls it or reads it,
-   * but it is the identifier a simulated task run matches an executable
-   * binding against, so a definition without one could never run.
-   */
-  private static requiredImage(
-    declared: SimEcsContainerDefinitionType,
-    name: string,
-  ): string {
-    const { image } = declared;
-
-    if (image === undefined || image === "") {
-      throw new SimEcsClientException(
-        `Container.image should not be null or empty for container ${name}.`,
-      );
-    }
-
-    return image;
   }
 
   /**
@@ -123,6 +93,17 @@ export class SimEcsContainerDefinition {
    */
   get secrets(): readonly SimEcsSecret[] {
     return this.declared.secrets ?? [];
+  }
+
+  /**
+   * The ports this container declared it listens on.
+   *
+   * This is the one part of a container definition beyond its name and image
+   * whose meaning anything here reads, and what reads it is a load balancer
+   * working out which container of a task its registration meant.
+   */
+  get containerPorts(): readonly number[] {
+    return simEcsContainerPorts(this.declared.portMappings);
   }
 
   /**

--- a/src/service/ecs/task-definition/container/sim-ecs-container-identity.ts
+++ b/src/service/ecs/task-definition/container/sim-ecs-container-identity.ts
@@ -1,0 +1,38 @@
+import { SimEcsClientException } from "../../error/sim-ecs.error.js";
+
+/**
+ * The name a container definition is referred to by everywhere else.
+ *
+ * Required here as it is on real ECS: a task's containers are recorded by name,
+ * an override names one, and a binding matches one, so a definition without a
+ * name could not take part in any of it.
+ */
+export function requiredSimEcsContainerName(name: string | undefined): string {
+  if (name === undefined || name === "") {
+    throw new SimEcsClientException(
+      "Container.name should not be null or empty.",
+    );
+  }
+
+  return name;
+}
+
+/**
+ * The image URI a container definition declared.
+ *
+ * Required here as it is on real ECS. Nothing pulls it or reads it, but it is
+ * the identifier a simulated task run matches an executable binding against, so
+ * a definition without one could never run.
+ */
+export function requiredSimEcsContainerImage(
+  image: string | undefined,
+  name: string,
+): string {
+  if (image === undefined || image === "") {
+    throw new SimEcsClientException(
+      `Container.image should not be null or empty for container ${name}.`,
+    );
+  }
+
+  return image;
+}

--- a/src/service/ecs/task-definition/container/sim-ecs-container-ports.ts
+++ b/src/service/ecs/task-definition/container/sim-ecs-container-ports.ts
@@ -1,0 +1,21 @@
+import type { SimEcsPortMapping } from "./sim-ecs-container-parts.js";
+
+/**
+ * The ports a container's `portMappings` declared it listens on.
+ *
+ * This is the one part of a container definition beyond its name and image that
+ * anything here reads the meaning of, and it is read for one question: which of
+ * a task's containers a load balancer's declared container port means, where
+ * more than one of them is bound to a handler.
+ *
+ * A mapping declaring a `containerPortRange` rather than a `containerPort` is
+ * left out. A range says the container listens on many ports, and choosing one
+ * of them to compare against would be inventing what the declaration meant.
+ */
+export function simEcsContainerPorts(
+  mappings: readonly SimEcsPortMapping[] | undefined,
+): readonly number[] {
+  return (mappings ?? [])
+    .map((mapping) => mapping.containerPort)
+    .filter((port) => port !== undefined);
+}

--- a/src/service/ecs/task/run/sim-ecs-container-reason.ts
+++ b/src/service/ecs/task/run/sim-ecs-container-reason.ts
@@ -22,6 +22,20 @@ export const simEcsConsumingContainerReason =
   "polls for a running service. Create a service from this task definition.";
 
 /**
+ * What a container serving requests records instead of running in a task.
+ *
+ * A serving binding answers a request rather than doing something that ends,
+ * and a run task has neither a request to send it nor an end to wait for. A
+ * service is what puts the container behind a load balancer, so a task started
+ * from the same definition says so rather than calling the handler with
+ * nothing.
+ */
+export const simEcsServingContainerReason =
+  "Not simulated in a run task: this container answers HTTP requests, which " +
+  "reach it through a load balancer while a service is running it. Create a " +
+  "service from this task definition.";
+
+/**
  * What a container reports as the reason it stopped.
  */
 export function simEcsContainerFailureReason(error: unknown): string {

--- a/src/service/ecs/task/run/sim-ecs-container-runner.ts
+++ b/src/service/ecs/task/run/sim-ecs-container-runner.ts
@@ -8,6 +8,7 @@ import {
   simEcsConsumingContainerReason,
   simEcsContainerFailureReason,
   simEcsNotSimulatedContainerReason,
+  simEcsServingContainerReason,
 } from "./sim-ecs-container-reason.js";
 import type { SimEcsTaskOverrides } from "./sim-ecs-task-overrides.js";
 import { simEcsTaskPrincipal } from "./sim-ecs-task-principal.js";
@@ -75,6 +76,11 @@ export class SimEcsContainerRunner {
 
     if (bound.consumes !== undefined) {
       container.neverStarted(simEcsConsumingContainerReason);
+      return;
+    }
+
+    if (bound.serves !== undefined) {
+      container.neverStarted(simEcsServingContainerReason);
       return;
     }
 

--- a/src/service/elbv2/README.md
+++ b/src/service/elbv2/README.md
@@ -134,14 +134,26 @@ is refused at runtime with an explanation rather than by the type checker with n
   target and are written by the load balancer itself, which is why a listener holding one serves with
   nothing registered behind it. `sim-elbv2-redirect-location.ts` is separate because building the URI
   is where the reserved keywords and the components a redirect leaves alone live.
-- `sim-elbv2-forward-target.ts` gets from a `forward` action to the target group it names, which so
-  far has to be a `lambda` one. What it cannot carry out is refused here rather than answered with
-  something else, because a load balancer that quietly sends a request somewhere its configuration
-  did not say is worse than one that says it cannot.
-- `sim-elbv2-lambda-target-invocation.ts` owns what the load balancer answers itself. An empty target
-  group is a 503 and everything after that is a 502, which is the same collapse real ELB makes: the
-  difference between a missing permission, a missing function and a thrown handler is only in the
-  load balancer's own logs.
+- `sim-elbv2-forward-target.ts` gets from a `forward` action to the target group it names. What it
+  cannot carry out, which is a weighted forward to several groups, is refused here rather than
+  answered with something else, because a load balancer that quietly sends a request somewhere its
+  configuration did not say is worse than one that says it cannot.
+- `sim-elbv2-target-invocations.ts` picks how the group is reached, which is the one place anything
+  branches on the target type: a `lambda` group holds a function to invoke and an `ip` group holds
+  the addresses of an ECS service's tasks.
+- `sim-elbv2-lambda-target-invocation.ts` owns what the load balancer answers itself for a function.
+  An empty target group is a 503 and everything after that is a 502, which is the same collapse real
+  ELB makes: the difference between a missing permission, a missing function and a thrown handler is
+  only in the load balancer's own logs.
+- `sim-elbv2-container-target-invocation.ts` does the same for a container. Three things are the same
+  503: an empty group, a registered service with no container bound to an HTTP handler, and an
+  address registered by hand, since nothing here listens on an address and only a service
+  registration puts something behind one. A container that throws is a 502, as a function that throws
+  is.
+- `sim-elbv2-forwarded-request.ts` builds the request a container is handed, through the same
+  `SimElbV2RequestParts` the event builder uses, so a container and a function behind one listener do
+  not disagree about what the client asked for. The URL is rewritten to the AWS-facing one, carrying
+  the listener's scheme and port.
 - `sim-elbv2-event-builder.ts` and `sim-elbv2-response-builder.ts` hold the ALB shapes, which are
   ELB's own rather than either API Gateway payload format. `sim-elbv2-body-encoding.ts` is separate
   because its list of text media types is ELB's too, and is shorter than API Gateway's.
@@ -204,6 +216,10 @@ There is no resource policy support here, and none to add: ELBv2 has none on rea
   minutes, which every test would wait out for no behaviour it could observe.
 - Every registered target is `healthy`. No health check is ever performed, so health check settings
   are held and reported and nothing acts on them.
+- An `ip` target group is answered by the simulated ECS service registered into it, and reaching it
+  is simulated ECS's question rather than this service's: which service registered, and which of its
+  containers can answer, are both decided there. Nothing is shared between the targets of a group,
+  since a service's desired count is state rather than concurrency.
 - `CanonicalHostedZoneId` is one value everywhere rather than the real per-region table, because
   simulated Route53 resolves an alias by looking the target up rather than by its zone id.
 - Deregistration is immediate, where real ELB drains connections first, because there are no

--- a/src/service/elbv2/serve/sim-elbv2-action-performer.ts
+++ b/src/service/elbv2/serve/sim-elbv2-action-performer.ts
@@ -2,7 +2,7 @@ import type { SimElbV2Listener } from "../listener/sim-elbv2-listener.js";
 import type { SimElbV2 } from "../sim-elbv2.js";
 import { SimElbV2FixedResponse } from "./sim-elbv2-fixed-response.js";
 import { SimElbV2ForwardTarget } from "./sim-elbv2-forward-target.js";
-import type { SimElbV2LambdaTargetInvocation } from "./sim-elbv2-lambda-target-invocation.js";
+import type { SimElbV2TargetInvocations } from "./sim-elbv2-target-invocations.js";
 import { SimElbV2RedirectResponse } from "./sim-elbv2-redirect-response.js";
 import type { SimElbV2MatchedAction } from "./sim-elbv2-rule-evaluation.js";
 
@@ -25,7 +25,7 @@ export class SimElbV2ActionPerformer {
   private readonly fixedResponse = new SimElbV2FixedResponse();
   private readonly redirect = new SimElbV2RedirectResponse();
 
-  constructor(private readonly invocation: SimElbV2LambdaTargetInvocation) {}
+  constructor(private readonly invocations: SimElbV2TargetInvocations) {}
 
   /**
    * Answer one request with one matched action.
@@ -51,7 +51,7 @@ export class SimElbV2ActionPerformer {
   private async forward(
     input: SimElbV2PerformedActionInput,
   ): Promise<Response> {
-    return await this.invocation.invoke({
+    return await this.invocations.invoke({
       listener: input.listener,
       targetGroup: new SimElbV2ForwardTarget(input.elbV2).resolve(
         input.matched,

--- a/src/service/elbv2/serve/sim-elbv2-container-target-invocation.ts
+++ b/src/service/elbv2/serve/sim-elbv2-container-target-invocation.ts
@@ -1,0 +1,84 @@
+import type { SimClock } from "../../../util/clock/sim-clock.js";
+import { SimElbV2ErrorResponse } from "./sim-elbv2-error-response.js";
+import { SimElbV2ForwardedRequest } from "./sim-elbv2-forwarded-request.js";
+import type { SimElbV2Router } from "./sim-elbv2-router.js";
+import type {
+  SimElbV2TargetInvocation,
+  SimElbV2TargetInvocationInput,
+} from "./sim-elbv2-target-invocation.js";
+
+interface SimElbV2ContainerTargetInvocationProperties {
+  readonly router: SimElbV2Router;
+  /** Clock the forwarded request's trace id is stamped with. */
+  readonly clock: SimClock;
+}
+
+/**
+ * Carries a request to the container of the simulated ECS service registered
+ * into an address target group.
+ *
+ * There are three ways for this to have nothing to send the request to, and all
+ * three are the same 503 real ELB answers when no target is in service. A group
+ * with nothing registered has no target at all. A group whose registered
+ * service has no container bound to an HTTP handler has a target with nothing
+ * behind it, which is what a real load balancer sees when a task's container is
+ * not answering. An address registered by hand is the same case: nothing in
+ * this simulation listens on an address, so only a service registration puts
+ * something behind one.
+ *
+ * A container that throws is a 502, as a Lambda target that throws is. The
+ * error goes no further than the load balancer, which is also where it goes on
+ * real AWS: what the client sees is the status.
+ */
+export class SimElbV2ContainerTargetInvocation implements SimElbV2TargetInvocation {
+  private readonly router: SimElbV2Router;
+  private readonly forwardedRequest: SimElbV2ForwardedRequest;
+  private readonly errorResponse = new SimElbV2ErrorResponse();
+
+  constructor(properties: SimElbV2ContainerTargetInvocationProperties) {
+    this.router = properties.router;
+    this.forwardedRequest = new SimElbV2ForwardedRequest({
+      clock: properties.clock,
+    });
+  }
+
+  /**
+   * Send one request to the target group's container.
+   */
+  async invoke(input: SimElbV2TargetInvocationInput): Promise<Response> {
+    const { targetGroup } = input;
+
+    if (targetGroup.registeredTargets.length === 0) {
+      return this.errorResponse.serviceUnavailable();
+    }
+
+    const container = this.router.containerFor(targetGroup);
+
+    if (container === undefined) {
+      return this.errorResponse.serviceUnavailable();
+    }
+
+    try {
+      return this.answered(
+        await container.handle(this.forwardedRequest.build(input)),
+      );
+    } catch {
+      return this.errorResponse.badGateway();
+    }
+  }
+
+  /**
+   * What the container answered, where it answered with a response at all.
+   *
+   * A handler that returns something else is the same 502 a Lambda target's
+   * unusable result is. The binding's type says a response, so this is for a
+   * handler written in JavaScript, where nothing checked.
+   */
+  private answered(answer: Response): Response {
+    if (answer instanceof Response) {
+      return answer;
+    }
+
+    return this.errorResponse.badGateway();
+  }
+}

--- a/src/service/elbv2/serve/sim-elbv2-controller.ts
+++ b/src/service/elbv2/serve/sim-elbv2-controller.ts
@@ -5,7 +5,7 @@ import type {
 import { SimAws } from "../../aws/sim-aws.js";
 import { SimElbV2ConnectionRefusedError } from "../error/sim-elbv2.error.js";
 import { SimElbV2ActionPerformer } from "./sim-elbv2-action-performer.js";
-import { SimElbV2LambdaTargetInvocation } from "./sim-elbv2-lambda-target-invocation.js";
+import { SimElbV2TargetInvocations } from "./sim-elbv2-target-invocations.js";
 import { requireSimElbV2Listener } from "./sim-elbv2-listener-match.js";
 import {
   type SimElbV2LoadBalancerRoute,
@@ -34,9 +34,10 @@ export class SimElbV2ServiceController implements SimAwsServiceController {
     const { simAws = new SimAws() } = properties;
     this.router = properties.router ?? new SimElbV2Router({ simAws });
     // The clock is taken from the router rather than from properties, so a
-    // supplied router and the event timestamps belong to the same simulation.
+    // supplied router and the forwarded timestamps belong to the same
+    // simulation.
     this.actions = new SimElbV2ActionPerformer(
-      new SimElbV2LambdaTargetInvocation({
+      new SimElbV2TargetInvocations({
         router: this.router,
         clock: this.router.simAws,
       }),

--- a/src/service/elbv2/serve/sim-elbv2-forward-target.ts
+++ b/src/service/elbv2/serve/sim-elbv2-forward-target.ts
@@ -9,10 +9,12 @@ import type { SimElbV2MatchedAction } from "./sim-elbv2-rule-evaluation.js";
  *
  * The action is stored when the listener or rule is written and performed here,
  * and the two are not the same thing: a forward this simulation cannot carry
- * out is one that was accepted and cannot serve. Each of those is refused when
- * the request arrives rather than answered with something else, because a load
+ * out is one that was accepted and cannot serve. That is refused when the
+ * request arrives rather than answered with something else, because a load
  * balancer that quietly sends a request somewhere its configuration did not say
- * is worse than one that says it cannot.
+ * is worse than one that says it cannot. What the group holds is not one of
+ * those refusals: both simulated target types answer a request, in their own
+ * ways.
  */
 export class SimElbV2ForwardTarget {
   constructor(private readonly elbV2: SimElbV2) {}
@@ -21,23 +23,6 @@ export class SimElbV2ForwardTarget {
    * The target group a matched forward action sends a request to.
    */
   resolve(matched: SimElbV2MatchedAction): SimElbV2TargetGroup {
-    const targetGroup = this.forwardedTargetGroup(matched);
-
-    if (targetGroup.targetType.value !== "lambda") {
-      throw new SimElbV2UnsimulatedInputException(
-        `Target group '${targetGroup.name}' holds ${targetGroup.targetType.value} ` +
-          `targets, and only a lambda target group answers a request here. ` +
-          `Nothing listens on an address in this simulation for an ip target ` +
-          `to name.`,
-      );
-    }
-
-    return targetGroup;
-  }
-
-  private forwardedTargetGroup(
-    matched: SimElbV2MatchedAction,
-  ): SimElbV2TargetGroup {
     const { action, source } = matched;
 
     if (action.targetGroupArns.length > 1) {

--- a/src/service/elbv2/serve/sim-elbv2-forwarded-request.ts
+++ b/src/service/elbv2/serve/sim-elbv2-forwarded-request.ts
@@ -1,0 +1,83 @@
+import {
+  simAwsProxiedSourceIp,
+  simAwsProxiedTraceId,
+} from "../../../serve/http/sim-aws-proxied-connection.js";
+import { simAwsRequestHostname } from "../../../serve/http/url/sim-aws-request-hostname.js";
+import type { SimClock } from "../../../util/clock/sim-clock.js";
+import type { SimElbV2Listener } from "../listener/sim-elbv2-listener.js";
+import { SimElbV2RequestParts } from "./sim-elbv2-request-parts.js";
+
+interface SimElbV2ForwardedRequestProperties {
+  /** Clock the forwarded trace id is stamped with. */
+  readonly clock: SimClock;
+}
+
+interface SimElbV2ForwardedRequestInput {
+  readonly request: Request;
+  readonly listener: SimElbV2Listener;
+}
+
+/**
+ * Builds the request a load balancer forwards to a container target.
+ *
+ * A Lambda target gets an event, and a container gets the request itself, so
+ * this is the container's half of what the event builder does: the same host
+ * name, the same trace id and the same forwarding headers, applied to a request
+ * rather than gathered into a payload. Keeping the rules in
+ * `SimElbV2RequestParts` for both is what stops a container and a function
+ * behind the same listener disagreeing about what the client asked for.
+ *
+ * The URL is rewritten to the AWS-facing one, so a container reading
+ * `request.url` sees the name the client asked for rather than the localhost
+ * one a served request arrived at, and sees the listener's scheme and port
+ * rather than the local server's.
+ */
+export class SimElbV2ForwardedRequest {
+  private readonly requestParts = new SimElbV2RequestParts();
+  private readonly clock: SimClock;
+
+  constructor(properties: SimElbV2ForwardedRequestProperties) {
+    this.clock = properties.clock;
+  }
+
+  /**
+   * Build the request one container target is handed.
+   */
+  build(input: SimElbV2ForwardedRequestInput): Request {
+    const { request, listener } = input;
+    const forwarded = new Request(this.urlFor(input), request);
+    const headers = this.requestParts.headers({
+      request,
+      port: listener.port,
+      protocol: listener.protocol,
+      traceId: simAwsProxiedTraceId(this.clock.now()),
+      sourceIp: simAwsProxiedSourceIp,
+    });
+
+    for (const [name, value] of Object.entries(headers)) {
+      forwarded.headers.set(name, value);
+    }
+
+    return forwarded;
+  }
+
+  /**
+   * The URL the forwarded request carries.
+   *
+   * A port the listener's own scheme is served on drops out of its own accord,
+   * as it does in any URL, so a listener on 80 forwards a request to
+   * `http://name/path` rather than to `http://name:80/path`.
+   */
+  private urlFor(input: SimElbV2ForwardedRequestInput): string {
+    const { request, listener } = input;
+    const scheme = listener.protocol.toLowerCase();
+    const forwarded = new URL(`${scheme}://${simAwsRequestHostname(request)}/`);
+    const asked = new URL(request.url);
+
+    forwarded.port = String(listener.port);
+    forwarded.pathname = asked.pathname;
+    forwarded.search = asked.search;
+
+    return forwarded.href;
+  }
+}

--- a/src/service/elbv2/serve/sim-elbv2-lambda-target-invocation.ts
+++ b/src/service/elbv2/serve/sim-elbv2-lambda-target-invocation.ts
@@ -1,5 +1,4 @@
 import type { SimClock } from "../../../util/clock/sim-clock.js";
-import type { SimElbV2Listener } from "../listener/sim-elbv2-listener.js";
 import type { SimElbV2TargetGroup } from "../target-group/sim-elbv2-target-group.js";
 import { SimElbV2ErrorResponse } from "./sim-elbv2-error-response.js";
 import { SimElbV2EventBuilder } from "./sim-elbv2-event-builder.js";
@@ -9,6 +8,10 @@ import type {
   SimElbV2FunctionTarget,
   SimElbV2Router,
 } from "./sim-elbv2-router.js";
+import type {
+  SimElbV2TargetInvocation,
+  SimElbV2TargetInvocationInput,
+} from "./sim-elbv2-target-invocation.js";
 
 /**
  * The largest request body real ELB sends to a Lambda target.
@@ -19,12 +22,6 @@ interface SimElbV2LambdaTargetInvocationProperties {
   readonly router: SimElbV2Router;
   /** Clock the invocation event is stamped with. */
   readonly clock: SimClock;
-}
-
-interface SimElbV2LambdaTargetInvocationInput {
-  readonly listener: SimElbV2Listener;
-  readonly targetGroup: SimElbV2TargetGroup;
-  readonly request: Request;
 }
 
 /**
@@ -38,7 +35,7 @@ interface SimElbV2LambdaTargetInvocationInput {
  * too, and it is why the load balancer's own logs are the only place the
  * difference between them shows.
  */
-export class SimElbV2LambdaTargetInvocation {
+export class SimElbV2LambdaTargetInvocation implements SimElbV2TargetInvocation {
   private readonly router: SimElbV2Router;
   private readonly eventBuilder: SimElbV2EventBuilder;
   private readonly responseBuilder = new SimElbV2ResponseBuilder();
@@ -54,7 +51,7 @@ export class SimElbV2LambdaTargetInvocation {
   /**
    * Invoke the target group's function for one request.
    */
-  async invoke(input: SimElbV2LambdaTargetInvocationInput): Promise<Response> {
+  async invoke(input: SimElbV2TargetInvocationInput): Promise<Response> {
     const { targetGroup } = input;
 
     if (targetGroup.registeredTargets.length === 0) {
@@ -85,7 +82,7 @@ export class SimElbV2LambdaTargetInvocation {
   }
 
   private async run(
-    input: SimElbV2LambdaTargetInvocationInput,
+    input: SimElbV2TargetInvocationInput,
     target: SimElbV2FunctionTarget,
   ): Promise<Response> {
     const { listener, targetGroup, request } = input;

--- a/src/service/elbv2/serve/sim-elbv2-router.ts
+++ b/src/service/elbv2/serve/sim-elbv2-router.ts
@@ -1,6 +1,7 @@
 import type { SimAwsServiceTarget } from "../../../serve/controller/sim-service-controller.js";
 import { assertDefined } from "../../../util/type-guard/defined.js";
 import type { SimAws } from "../../aws/sim-aws.js";
+import type { SimEcsContainerServer } from "../../ecs/service/serve/sim-ecs-container-server.js";
 import type { SimIamInterServiceAuthZ } from "../../iam/authorize/sim-iam-inter-service-auth-z.js";
 import { parseSimLambdaFunctionArn } from "../../lambda/function/sim-lambda-function-arn-parts.js";
 import type { SimLambdaFunction } from "../../lambda/function/sim-lambda-function.js";
@@ -39,13 +40,14 @@ export interface SimElbV2FunctionTarget {
 
 /**
  * Routes a request to the load balancer behind its host name, and a target
- * group to the function behind that.
+ * group to the function or container behind that.
  *
  * A host name names nothing but itself, while simulated ELBv2 state is per
- * Account and Region, and the registry is the hop between the two. The function
- * is not a second hop: real ELB
- * requires a Lambda target to be in the same Account and Region as its target
- * group, so that is the only scope it is looked for in.
+ * Account and Region, and the registry is the hop between the two. What a
+ * target group holds is not a second hop: real ELB requires a Lambda target to
+ * be in the same Account and Region as its target group, and simulated ECS
+ * refuses a service a target group outside its own, so the target group's own
+ * scope is the only one either is looked for in.
  */
 export class SimElbV2Router {
   /**
@@ -133,5 +135,25 @@ export class SimElbV2Router {
     }
 
     return { simFunction, iam: scope.iam() };
+  }
+
+  /**
+   * Find the container of a simulated ECS service that answers for a target
+   * group.
+   *
+   * Which service that is, and which of its containers, is simulated ECS's
+   * question rather than this one's: a service is what registered into the
+   * group, and what is bound to its containers is what decides whether any of
+   * them can answer.
+   */
+  containerFor(
+    targetGroup: SimElbV2TargetGroup,
+  ): SimEcsContainerServer | undefined {
+    const { accountId, regionName } = targetGroup.accountRegionScope;
+
+    return this.simAws
+      .accountRegionScope(accountId, regionName)
+      .ecs()
+      .servingContainer(targetGroup.arn);
   }
 }

--- a/src/service/elbv2/serve/sim-elbv2-serve-ecs-service.iso.test.ts
+++ b/src/service/elbv2/serve/sim-elbv2-serve-ecs-service.iso.test.ts
@@ -1,0 +1,287 @@
+import { DeleteServiceCommand } from "@aws-sdk/client-ecs";
+import {
+  assertIdentical,
+  assertResponseStatus,
+  assertStringIncludes,
+} from "@kensio/smartass";
+import { describe, expect, it } from "vitest";
+
+import {
+  servedServiceNames,
+  simAwsWithServedService,
+} from "../../../../test/ecs/served-service-fixture.js";
+import type { SimAws } from "../../aws/sim-aws.js";
+import { simElbV2Fetch } from "./sim-elbv2-fetch.js";
+
+/**
+ * The service the fixture builds, deleted, which is what leaves a target group
+ * with nothing behind it.
+ */
+async function deleteServedService(simAws: SimAws): Promise<void> {
+  await simAws.ecs().deleteService(
+    new DeleteServiceCommand({
+      cluster: servedServiceNames.cluster,
+      service: servedServiceNames.service,
+      force: true,
+    }),
+  );
+}
+
+describe("Serving a request through a simulated ECS service", () => {
+  it("answers with what the service's bound container returned", async () => {
+    // Given a load balancer forwarding to a target group an ECS service
+    // registered its tasks into.
+    const { simAws, hostname } = await simAwsWithServedService({
+      containers: [
+        {
+          name: "app",
+          ports: [8080],
+          handler: async (request: Request): Promise<Response> =>
+            Response.json(
+              {
+                method: request.method,
+                path: new URL(request.url).pathname,
+                body: await request.text(),
+              },
+              { status: 201, headers: { "content-type": "application/json" } },
+            ),
+        },
+      ],
+    });
+
+    // When a request reaches the load balancer.
+    const response = await simElbV2Fetch(simAws, `http://${hostname}/orders`, {
+      method: "POST",
+      body: "one flat white",
+    });
+
+    // Then the container's own response is what the client gets, request body
+    // and all.
+    assertResponseStatus(response, 201);
+    expect(await response.json()).toStrictEqual({
+      method: "POST",
+      path: "/orders",
+      body: "one flat white",
+    });
+  });
+
+  it("hands the container the forwarding headers a load balancer writes", async () => {
+    // Given a service whose container answers with what it was sent.
+    const { simAws, hostname } = await simAwsWithServedService({
+      containers: [
+        {
+          name: "app",
+          ports: [8080],
+          handler: (request: Request): Response =>
+            new Response(
+              [
+                request.url,
+                request.headers.get("host"),
+                request.headers.get("x-forwarded-proto"),
+                request.headers.get("x-forwarded-port"),
+                request.headers.get("x-forwarded-for"),
+                request.headers.get("x-amzn-trace-id")?.slice(0, 6),
+              ].join(" "),
+            ),
+        },
+      ],
+    });
+
+    // When a request reaches the load balancer.
+    const response = await simElbV2Fetch(simAws, `http://${hostname}/orders`);
+
+    // Then the container sees the name the client asked for and the listener
+    // the request arrived on, as a container behind a real load balancer does.
+    assertIdentical(
+      await response.text(),
+      `http://${hostname}/orders ${hostname} http 80 127.0.0.1 Root=1`,
+    );
+  });
+
+  it("answers 503 when the target group holds no service tasks", async () => {
+    // Given a load balancer whose target group had a service and no longer
+    // does.
+    const { simAws, hostname } = await simAwsWithServedService();
+    await deleteServedService(simAws);
+
+    // When a request reaches it.
+    const response = await simElbV2Fetch(simAws, `http://${hostname}/orders`);
+
+    // Then there is no target to send it to, which is what real ELB answers
+    // for a group with nothing in service.
+    assertResponseStatus(response, 503);
+    assertStringIncludes(await response.text(), "503 Service Unavailable");
+  });
+
+  it("answers 503 when the service has no container that serves", async () => {
+    // Given a service whose only container is one Yulin has nothing to run,
+    // as an unbound proxy image is.
+    const { simAws, hostname } = await simAwsWithServedService({
+      containers: [{ name: "nginx", ports: [80] }],
+      registration: { containerName: "nginx", containerPort: 80 },
+    });
+
+    // When a request reaches the load balancer.
+    const response = await simElbV2Fetch(simAws, `http://${hostname}/orders`);
+
+    // Then the tasks are registered and there is nothing behind them, which is
+    // the honest answer rather than an empty 200.
+    assertResponseStatus(response, 503);
+  });
+
+  it("answers 502 when the container's handler throws", async () => {
+    // Given a service whose container fails on the request.
+    const { simAws, hostname } = await simAwsWithServedService({
+      containers: [
+        {
+          name: "app",
+          ports: [8080],
+          handler: (): Response => {
+            throw new Error("no database connection");
+          },
+        },
+      ],
+    });
+
+    // When a request reaches the load balancer.
+    const response = await simElbV2Fetch(simAws, `http://${hostname}/orders`);
+
+    // Then the load balancer answers for it, and the error goes no further
+    // than the container, as it does on real AWS.
+    assertResponseStatus(response, 502);
+  });
+
+  it("answers 502 when the container answers with something else", async () => {
+    // Given a container whose handler answers with something that is not a
+    // response, which only JavaScript with nothing checking it can do.
+    const { simAws, hostname } = await simAwsWithServedService({
+      containers: [
+        {
+          name: "app",
+          ports: [8080],
+          handler: (): Response => "ok" as unknown as Response,
+        },
+      ],
+    });
+
+    // When a request reaches the load balancer.
+    const response = await simElbV2Fetch(simAws, `http://${hostname}/orders`);
+
+    // Then the load balancer answers for it, as it does for a Lambda target
+    // whose result it cannot use.
+    assertResponseStatus(response, 502);
+  });
+
+  it("answers 503 for an address registered with no service behind it", async () => {
+    // Given a target group holding an address nothing in the simulation
+    // listens on.
+    const { simAws, hostname, targetGroupArn } =
+      await simAwsWithServedService();
+    await deleteServedService(simAws);
+    await simAws.elbV2().registerTargets({
+      input: { TargetGroupArn: targetGroupArn, Targets: [{ Id: "10.0.9.9" }] },
+    });
+
+    // When a request reaches the load balancer.
+    const response = await simElbV2Fetch(simAws, `http://${hostname}/orders`);
+
+    // Then there is still nothing to serve it: an address is something an ECS
+    // service registers, rather than something anything answers on.
+    assertResponseStatus(response, 503);
+  });
+});
+
+describe("Choosing the container of a task a request reaches", () => {
+  it("routes to the bound container when the declared one is a proxy", async () => {
+    // Given the common real shape: a proxy on the declared port, with the
+    // application behind it, and only the application bound.
+    const { simAws, hostname } = await simAwsWithServedService({
+      containers: [
+        { name: "nginx", ports: [80] },
+        {
+          name: "app",
+          ports: [8080],
+          handler: (): Response => new Response("app"),
+        },
+      ],
+      registration: { containerName: "nginx", containerPort: 80 },
+    });
+
+    // When a request reaches the load balancer.
+    const response = await simElbV2Fetch(simAws, `http://${hostname}/orders`);
+
+    // Then the application answered, rather than the request being routed
+    // strictly to a container that does not exist here.
+    assertIdentical(await response.text(), "app");
+  });
+
+  it("chooses between bound containers by the declared container port", async () => {
+    // Given a task whose two containers both answer requests.
+    const { simAws, hostname } = await simAwsWithServedService({
+      containers: [
+        {
+          name: "admin",
+          ports: [9000],
+          handler: (): Response => new Response("admin"),
+        },
+        {
+          name: "app",
+          ports: [8080],
+          handler: (): Response => new Response("app"),
+        },
+      ],
+      registration: { containerName: "nginx", containerPort: 9000 },
+    });
+
+    // When a request reaches the load balancer.
+    const response = await simElbV2Fetch(simAws, `http://${hostname}/orders`);
+
+    // Then the port the registration named is what chose between them.
+    assertIdentical(await response.text(), "admin");
+  });
+
+  it("routes to the container the registration names", async () => {
+    // Given a task whose two containers both answer, and a registration naming
+    // one of them.
+    const { simAws, hostname } = await simAwsWithServedService({
+      containers: [
+        {
+          name: "admin",
+          ports: [9000],
+          handler: (): Response => new Response("admin"),
+        },
+        {
+          name: "app",
+          ports: [8080],
+          handler: (): Response => new Response("app"),
+        },
+      ],
+      registration: { containerName: "app", containerPort: 9000 },
+    });
+
+    // When a request reaches the load balancer.
+    const response = await simElbV2Fetch(simAws, `http://${hostname}/orders`);
+
+    // Then the container it names answered, whatever port it was registered
+    // on, since naming a container is the more exact of the two.
+    assertIdentical(await response.text(), "app");
+  });
+
+  it("routes to the first bound container when the port names none of them", async () => {
+    // Given two bound containers, neither declaring the registered port.
+    const { simAws, hostname } = await simAwsWithServedService({
+      containers: [
+        { name: "admin", handler: (): Response => new Response("admin") },
+        { name: "app", handler: (): Response => new Response("app") },
+      ],
+      registration: { containerName: "nginx", containerPort: 80 },
+    });
+
+    // When a request reaches the load balancer.
+    const response = await simElbV2Fetch(simAws, `http://${hostname}/orders`);
+
+    // Then the first of them answers, since one of the containers that could
+    // answer is nearer to the deployed behaviour than a 503.
+    assertIdentical(await response.text(), "admin");
+  });
+});

--- a/src/service/elbv2/serve/sim-elbv2-serve-refusals.iso.test.ts
+++ b/src/service/elbv2/serve/sim-elbv2-serve-refusals.iso.test.ts
@@ -6,43 +6,6 @@ import { simElbV2Fetch } from "./sim-elbv2-fetch.js";
 import { simElbV2LambdaTargetFactory } from "./sim-elbv2-lambda-target.factory.js";
 
 describe("What a sim ELBv2 load balancer will not carry a request through", () => {
-  it("refuses a listener forwarding to an ip target group", async () => {
-    // Given a load balancer with a listener
-    const simAws = new SimAws();
-    const loadBalancer = await simElbV2LambdaTargetFactory.make({}, simAws);
-    const elbV2 = simAws.elbV2();
-
-    // And that listener forwarding to a group of addresses
-    const addresses = await elbV2.createTargetGroup({
-      input: {
-        Name: "web-tg",
-        TargetType: "ip",
-        Protocol: "HTTP",
-        Port: 8080,
-      },
-    });
-    await elbV2.modifyListener({
-      input: {
-        ListenerArn: elbV2.findListenerOnPort(loadBalancer.arn, 80)?.arn,
-        DefaultActions: [
-          {
-            Type: "forward",
-            TargetGroupArn: addresses.TargetGroups?.[0]?.TargetGroupArn,
-          },
-        ],
-      },
-    });
-
-    // When a request reaches it
-    const request = simElbV2Fetch(
-      simAws,
-      `http://${loadBalancer.dnsName}/orders`,
-    );
-
-    // Then there is nothing listening on an address here for it to reach
-    await expect(request).rejects.toThrow("holds ip targets");
-  });
-
   it("refuses a listener forwarding to several target groups by weight", async () => {
     // Given a load balancer with a listener, and a second target group
     const simAws = new SimAws();

--- a/src/service/elbv2/serve/sim-elbv2-target-invocation.ts
+++ b/src/service/elbv2/serve/sim-elbv2-target-invocation.ts
@@ -1,0 +1,24 @@
+import type { SimElbV2Listener } from "../listener/sim-elbv2-listener.js";
+import type { SimElbV2TargetGroup } from "../target-group/sim-elbv2-target-group.js";
+
+/**
+ * One request, and the configuration that sent it to a target group.
+ */
+export interface SimElbV2TargetInvocationInput {
+  readonly listener: SimElbV2Listener;
+  readonly targetGroup: SimElbV2TargetGroup;
+  readonly request: Request;
+}
+
+/**
+ * What carries a request from a target group to whatever is registered in it.
+ *
+ * There is one of these per kind of target, because the two kinds have nothing
+ * in common past this point: a function is invoked with an event and answers
+ * with a result, and a container is handed the request and answers with the
+ * response. What they do share is which failures the load balancer answers for
+ * itself, and both of them answer those the same way.
+ */
+export interface SimElbV2TargetInvocation {
+  invoke(input: SimElbV2TargetInvocationInput): Promise<Response>;
+}

--- a/src/service/elbv2/serve/sim-elbv2-target-invocations.ts
+++ b/src/service/elbv2/serve/sim-elbv2-target-invocations.ts
@@ -1,0 +1,45 @@
+import type { SimClock } from "../../../util/clock/sim-clock.js";
+import { SimElbV2ContainerTargetInvocation } from "./sim-elbv2-container-target-invocation.js";
+import { SimElbV2LambdaTargetInvocation } from "./sim-elbv2-lambda-target-invocation.js";
+import type { SimElbV2Router } from "./sim-elbv2-router.js";
+import type { SimElbV2TargetInvocationInput } from "./sim-elbv2-target-invocation.js";
+
+interface SimElbV2TargetInvocationsProperties {
+  readonly router: SimElbV2Router;
+  readonly clock: SimClock;
+}
+
+/**
+ * The target type whose targets are invoked as functions.
+ */
+const lambdaTargetType = "lambda";
+
+/**
+ * Sends a request to a target group by what the group holds.
+ *
+ * The two simulated target types are reached in entirely different ways, and
+ * the target type is the only thing that decides which: a `lambda` group holds
+ * a function to invoke, and an `ip` group holds the addresses of an ECS
+ * service's tasks, whose bound container answers the request itself. Nothing
+ * else in the serving path branches on it.
+ */
+export class SimElbV2TargetInvocations {
+  private readonly lambda: SimElbV2LambdaTargetInvocation;
+  private readonly container: SimElbV2ContainerTargetInvocation;
+
+  constructor(properties: SimElbV2TargetInvocationsProperties) {
+    this.lambda = new SimElbV2LambdaTargetInvocation(properties);
+    this.container = new SimElbV2ContainerTargetInvocation(properties);
+  }
+
+  /**
+   * Send one request to whatever the target group holds.
+   */
+  async invoke(input: SimElbV2TargetInvocationInput): Promise<Response> {
+    if (input.targetGroup.targetType.value === lambdaTargetType) {
+      return await this.lambda.invoke(input);
+    }
+
+    return await this.container.invoke(input);
+  }
+}

--- a/src/system/README.md
+++ b/src/system/README.md
@@ -19,6 +19,12 @@ a fictional application rather than a simulated AWS resource. The reusable ones 
 as `simIamPolicyDocumentFactory` and `simCognitoSignedInFactory`, live in `src/` and ship with the
 package, and these use them.
 
+## The systems here
+
+- [The image upload pipeline](#the-image-upload-pipeline), an API and the processing behind it.
+- [A load balanced service](#a-load-balanced-service), a request reaching application code in a
+  container.
+
 ## The image upload pipeline
 
 [image-upload-pipeline.iso.test.ts](image-upload-pipeline.iso.test.ts) covers an application that
@@ -52,3 +58,25 @@ A test stands the whole thing up in one call:
 const simAws = new SimAws();
 const { client } = await mediaPipelineFactory.make({}, simAws);
 ```
+
+## A load balanced service
+
+[load-balanced-service.iso.test.ts](load-balanced-service.iso.test.ts) covers the other way an
+application is deployed: not a function behind an API, but a container behind a load balancer. The
+system is built by [test/orders-service](../../test/orders-service), which deploys one
+CloudFormation stack.
+
+**CloudFormation** deploys the lot, and one request then passes through four more services:
+
+1. A client asks for `orders.example.test`, which **Route53** resolves to the **load balancer** the
+   stack created, through an alias record.
+2. The listener forwards the request to a target group, which the **ECS** service registered its
+   tasks into when the stack deployed.
+3. The service's task carries an nginx container on the registered port and the application behind
+   it. Only the application is bound, so that is what answers, which is the divergence the ECS docs
+   set out.
+4. The application reads and writes a **DynamoDB** table with an ordinary SDK client, authorized as
+   the task role the template declared.
+
+Scaling the service to nothing takes its tasks out of the target group, and the load balancer then
+answers 503, which is what a real one answers when no target is in service.

--- a/src/system/load-balanced-service.iso.test.ts
+++ b/src/system/load-balanced-service.iso.test.ts
@@ -1,0 +1,106 @@
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import { UpdateServiceCommand } from "@aws-sdk/client-ecs";
+import {
+  assertIdentical,
+  assertResponseStatus,
+  assertStringIncludes,
+} from "@kensio/smartass";
+import { describe, expect, it } from "vitest";
+
+import { ordersServiceFactory } from "../../test/orders-service/orders-service.factory.js";
+import { ordersServiceNames } from "../../test/orders-service/orders-service-names.js";
+import { SimAwsHttp } from "../serve/http/sim-aws-http.js";
+import { SimSdk } from "../sdk/index.js";
+
+/**
+ * The port the local server would be listening on. Nothing binds it here: the
+ * requests go through the in-process HTTP entry point, and the port is part of
+ * the Yulin-local host name a client would use against a served simulation.
+ */
+const localPort = 52_341;
+
+/**
+ * The URL a client asks for, which is the Route53 name with the local suffix.
+ */
+function ordersUrl(path: string): string {
+  return `http://${ordersServiceNames.hostname}.sim-aws.localhost:${String(localPort)}${path}`;
+}
+
+describe("An orders service behind a load balancer", () => {
+  it("takes an order at its own host name and reads it back", async () => {
+    // Given the stack deployed, with the application container bound and its
+    // AWS SDK clients intercepted, as an application's own would be.
+    using simSdk = new SimSdk();
+
+    simSdk.intercept(DynamoDBClient);
+
+    const { simAws } = await ordersServiceFactory.make({}, simSdk.simAws);
+    const client = new SimAwsHttp({ simAws });
+
+    // When a client places an order at the name Route53 answers for.
+    const placed = await client.fetch(ordersUrl("/orders"), {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ orderId: "order-1", item: "one flat white" }),
+    });
+
+    // Then the load balancer routed it by host name to the target group, the
+    // target group to the service's container, and the container wrote the
+    // order to the Table as the task Role.
+    assertResponseStatus(placed, 201);
+    assertIdentical(placed.headers.get("location"), "/orders/order-1");
+
+    const read = await simAws.dynamoDb().getItem({
+      input: {
+        TableName: ordersServiceNames.table,
+        Key: { orderId: { S: "order-1" } },
+      },
+    });
+
+    assertIdentical(read.Item?.["item"]?.S, "one flat white");
+
+    // And the same application reads it back on the next request.
+    const fetched = await client.fetch(ordersUrl("/orders/order-1"));
+
+    assertResponseStatus(fetched, 200);
+    expect(await fetched.json()).toStrictEqual({
+      orderId: "order-1",
+      item: "one flat white",
+    });
+
+    // And an order nobody placed is the application's own answer, rather than
+    // anything the load balancer wrote.
+    const missing = await client.fetch(ordersUrl("/orders/order-2"));
+
+    assertResponseStatus(missing, 404);
+    assertIdentical(await missing.text(), "no such order");
+  });
+
+  it("answers 503 when the service is scaled to nothing", async () => {
+    // Given the deployed stack, answering requests.
+    using simSdk = new SimSdk();
+
+    simSdk.intercept(DynamoDBClient);
+
+    const { simAws } = await ordersServiceFactory.make({}, simSdk.simAws);
+
+    // When the service is scaled in, as it would be to take it out of use.
+    await simAws.ecs().updateService(
+      new UpdateServiceCommand({
+        cluster: ordersServiceNames.cluster,
+        service: ordersServiceNames.service,
+        desiredCount: 0,
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // Then its tasks left the target group with it, so the load balancer has
+    // nothing to send the request to and answers for itself.
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      ordersUrl("/orders/order-1"),
+    );
+
+    assertResponseStatus(response, 503);
+    assertStringIncludes(await response.text(), "503 Service Unavailable");
+  });
+});

--- a/test/ecs/served-service-fixture.ts
+++ b/test/ecs/served-service-fixture.ts
@@ -1,0 +1,276 @@
+/**
+ * The parts a test needs before it can say anything about an ECS container
+ * answering a request: a target group of addresses, a load balancer forwarding
+ * to it, a task definition whose containers are bound to handlers, and a
+ * service registered into the target group.
+ *
+ * These live under `test/` for the same reason as the consuming service
+ * fixture: the lint rules reject a test file exporting helpers alongside its
+ * own `describe` calls.
+ */
+
+import {
+  CreateServiceCommand,
+  RegisterTaskDefinitionCommand,
+} from "@aws-sdk/client-ecs";
+import { PutParameterCommand, SSMClient } from "@aws-sdk/client-ssm";
+import {
+  CreateListenerCommand,
+  CreateLoadBalancerCommand,
+  CreateTargetGroupCommand,
+} from "@aws-sdk/client-elastic-load-balancing-v2";
+import { assertNonNullable } from "@kensio/smartass";
+
+import { SimAws } from "../../src/service/aws/sim-aws.js";
+import { simEcsClusterFactory } from "../../src/service/ecs/cluster/sim-ecs-cluster.factory.js";
+import type { SimEcsContainerHttpHandler } from "../../src/service/ecs/index.js";
+import { simIamRoleWithPolicyFactory } from "../../src/service/iam/role/sim-iam-role-with-policy.factory.js";
+
+/**
+ * The names a served service is built under, so a test asserting on one has a
+ * single place to read it from.
+ */
+export const servedServiceNames = {
+  cluster: "orders",
+  family: "checkout",
+  service: "checkout",
+  targetGroup: "checkout-tg",
+  loadBalancer: "shop-alb",
+  container: "app",
+  containerPort: 8080,
+  listenerPort: 80,
+} as const;
+
+/**
+ * One container of the served task definition.
+ *
+ * A container with no handler is one Yulin has nothing to run, which is what a
+ * proxy or a log router in a real task definition is.
+ */
+export interface ServedContainer {
+  readonly name: string;
+  readonly ports?: readonly number[];
+  readonly handler?: SimEcsContainerHttpHandler;
+  readonly environment?: readonly { name: string; value: string }[];
+}
+
+interface ServedServiceOptions {
+  readonly simAws?: SimAws;
+  readonly containers?: readonly ServedContainer[];
+  /** The container and port the service registers into the target group. */
+  readonly registration?: { containerName: string; containerPort: number };
+  readonly desiredCount?: number;
+  readonly taskRoleArn?: string;
+  /** Leave the load balancer out, for a test only about the registration. */
+  readonly withoutLoadBalancer?: boolean;
+}
+
+/**
+ * One simulated AWS with a service answering behind a load balancer.
+ */
+export interface SimEcsServedServiceFixture {
+  readonly simAws: SimAws;
+  readonly targetGroupArn: string;
+  /** The host name a request reaches the load balancer on. */
+  readonly hostname: string;
+}
+
+/**
+ * The container a test gets when it does not say, which answers with its own
+ * name so a test can tell which container took the request.
+ */
+function defaultContainers(): readonly ServedContainer[] {
+  return [
+    {
+      name: servedServiceNames.container,
+      ports: [servedServiceNames.containerPort],
+      handler: (): Response => new Response(servedServiceNames.container),
+    },
+  ];
+}
+
+/**
+ * Create the target group a service registers into, and answer with its ARN.
+ */
+export async function makeServedTargetGroup(
+  simAws: SimAws,
+  elbV2 = simAws.elbV2(),
+): Promise<string> {
+  const created = await elbV2.createTargetGroup(
+    new CreateTargetGroupCommand({
+      Name: servedServiceNames.targetGroup,
+      TargetType: "ip",
+      Protocol: "HTTP",
+      Port: servedServiceNames.containerPort,
+    }),
+  );
+  const targetGroupArn = created.TargetGroups?.[0]?.TargetGroupArn;
+
+  assertNonNullable(targetGroupArn, "CreateTargetGroup answered with an ARN");
+
+  return targetGroupArn;
+}
+
+/**
+ * Create a load balancer forwarding everything to a target group, and answer
+ * with the host name it answers on.
+ */
+async function makeLoadBalancer(
+  simAws: SimAws,
+  targetGroupArn: string,
+): Promise<string> {
+  const elbV2 = simAws.elbV2();
+  const created = await elbV2.createLoadBalancer(
+    new CreateLoadBalancerCommand({ Name: servedServiceNames.loadBalancer }),
+  );
+  const loadBalancer = created.LoadBalancers?.[0];
+
+  assertNonNullable(loadBalancer?.DNSName, "CreateLoadBalancer answered");
+
+  await elbV2.createListener(
+    new CreateListenerCommand({
+      LoadBalancerArn: loadBalancer.LoadBalancerArn,
+      Protocol: "HTTP",
+      Port: servedServiceNames.listenerPort,
+      DefaultActions: [{ Type: "forward", TargetGroupArn: targetGroupArn }],
+    }),
+  );
+
+  return loadBalancer.DNSName;
+}
+
+/**
+ * Make a simulated AWS with a load balancer routing to a running service.
+ *
+ * The service is up and its containers are answering by the time this answers,
+ * so a test can send a request and assert on what came back.
+ */
+export async function simAwsWithServedService(
+  options: ServedServiceOptions = {},
+): Promise<SimEcsServedServiceFixture> {
+  const simAws = options.simAws ?? new SimAws();
+  const containers = options.containers ?? defaultContainers();
+  const ecs = simAws.ecs();
+  const targetGroupArn = await makeServedTargetGroup(simAws);
+  const hostname =
+    options.withoutLoadBalancer === true
+      ? ""
+      : await makeLoadBalancer(simAws, targetGroupArn);
+
+  for (const container of containers) {
+    bindServedContainer(simAws, container);
+  }
+
+  await simEcsClusterFactory.make(
+    { clusterName: servedServiceNames.cluster },
+    simAws,
+  );
+  await ecs.registerTaskDefinition(
+    new RegisterTaskDefinitionCommand({
+      family: servedServiceNames.family,
+      ...(options.taskRoleArn !== undefined && {
+        taskRoleArn: options.taskRoleArn,
+      }),
+      containerDefinitions: containers.map((container) => ({
+        name: container.name,
+        image: `${container.name}:1`,
+        portMappings: (container.ports ?? []).map((port) => ({
+          containerPort: port,
+        })),
+        ...(container.environment !== undefined && {
+          environment: [...container.environment],
+        }),
+      })),
+    }),
+  );
+  await ecs.createService(
+    new CreateServiceCommand({
+      cluster: servedServiceNames.cluster,
+      serviceName: servedServiceNames.service,
+      taskDefinition: servedServiceNames.family,
+      desiredCount: options.desiredCount ?? 1,
+      loadBalancers: [
+        {
+          targetGroupArn,
+          containerName:
+            options.registration?.containerName ?? servedServiceNames.container,
+          containerPort:
+            options.registration?.containerPort ??
+            servedServiceNames.containerPort,
+        },
+      ],
+    }),
+  );
+  await simAws.backgroundTasksComplete();
+
+  return { simAws, targetGroupArn, hostname };
+}
+
+/**
+ * Bind a container that has a handler, and leave one that has none alone.
+ */
+function bindServedContainer(simAws: SimAws, container: ServedContainer): void {
+  if (container.handler === undefined) {
+    return;
+  }
+
+  simAws.ecs().bindContainer({
+    family: servedServiceNames.family,
+    containerName: container.name,
+    http: container.handler,
+  });
+}
+
+/**
+ * What a served container does with a request when the test is about what it
+ * is allowed to do: write what it was sent to a parameter, through an ordinary
+ * SDK client, and answer with what happened.
+ *
+ * A denial comes back as the response rather than as a thrown error, so a test
+ * can read what simulated IAM said rather than only the 502 the load balancer
+ * would turn it into.
+ */
+export async function writeLastOrder(request: Request): Promise<Response> {
+  try {
+    await new SSMClient({}).send(
+      new PutParameterCommand({
+        Name: "/orders/last-handled",
+        Value: await request.text(),
+        Type: "String",
+      }),
+    );
+  } catch (error) {
+    return new Response(error instanceof Error ? error.message : "", {
+      status: 500,
+    });
+  }
+
+  return new Response("written");
+}
+
+/**
+ * A served service whose container writes a parameter, running as a task Role
+ * allowed the actions it is given and nothing else.
+ */
+export async function servedServiceAsRole(
+  simAws: SimAws,
+  actions: readonly string[],
+): Promise<string> {
+  const taskRole = await simIamRoleWithPolicyFactory.make(
+    { roleName: "OrdersTaskRole", actions },
+    simAws,
+  );
+  const { hostname } = await simAwsWithServedService({
+    simAws,
+    taskRoleArn: taskRole.Arn,
+    containers: [
+      {
+        name: servedServiceNames.container,
+        ports: [servedServiceNames.containerPort],
+        handler: writeLastOrder,
+      },
+    ],
+  });
+
+  return hostname;
+}

--- a/test/orders-service/orders-service-handler.ts
+++ b/test/orders-service/orders-service-handler.ts
@@ -1,0 +1,78 @@
+import {
+  DynamoDBClient,
+  GetItemCommand,
+  PutItemCommand,
+} from "@aws-sdk/client-dynamodb";
+
+/**
+ * The application the orders container runs.
+ *
+ * It is ordinary code: an SDK client built from the environment the task
+ * definition declared, a route or two, and a response. Nothing in it knows it
+ * is running under a simulator, which is the point of the whole scenario.
+ */
+export async function handleOrdersRequest(request: Request): Promise<Response> {
+  const tableName = process.env["ORDERS_TABLE"];
+  const { pathname } = new URL(request.url);
+
+  if (request.method === "POST") {
+    return await placeOrder(request, tableName);
+  }
+
+  return await readOrder(pathname.split("/").at(-1) ?? "", tableName);
+}
+
+/**
+ * Record an order and answer with where it can be read back.
+ */
+async function placeOrder(
+  request: Request,
+  tableName: string | undefined,
+): Promise<Response> {
+  const order = (await request.json()) as { orderId: string; item: string };
+
+  await new DynamoDBClient({}).send(
+    new PutItemCommand({
+      TableName: tableName,
+      Item: {
+        orderId: { S: order.orderId },
+        item: { S: order.item },
+      },
+    }),
+  );
+
+  return Response.json(
+    { orderId: order.orderId },
+    {
+      status: 201,
+      headers: {
+        "content-type": "application/json",
+        location: `/orders/${order.orderId}`,
+      },
+    },
+  );
+}
+
+/**
+ * Read one order back, or say there is no such order.
+ */
+async function readOrder(
+  orderId: string,
+  tableName: string | undefined,
+): Promise<Response> {
+  const read = await new DynamoDBClient({}).send(
+    new GetItemCommand({
+      TableName: tableName,
+      Key: { orderId: { S: orderId } },
+    }),
+  );
+
+  if (read.Item === undefined) {
+    return new Response("no such order", { status: 404 });
+  }
+
+  return Response.json(
+    { orderId, item: read.Item["item"]?.S ?? "" },
+    { status: 200, headers: { "content-type": "application/json" } },
+  );
+}

--- a/test/orders-service/orders-service-names.ts
+++ b/test/orders-service/orders-service-names.ts
@@ -1,0 +1,22 @@
+/**
+ * The names the orders service is deployed under.
+ *
+ * They are here rather than in the template so that a test asserting on one
+ * reads it from the same place the template writes it.
+ */
+export const ordersServiceNames = {
+  stack: "orders",
+  table: "orders",
+  cluster: "orders",
+  family: "orders-api",
+  service: "orders-api",
+  /** The container the application runs in, alongside an unsimulated proxy. */
+  container: "app",
+  proxy: "nginx",
+  /** The port the proxy listens on, which is the one the service registers. */
+  proxyPort: 80,
+  /** The port the application listens on behind the proxy. */
+  applicationPort: 8080,
+  zone: "example.test",
+  hostname: "orders.example.test",
+} as const;

--- a/test/orders-service/orders-service-template.ts
+++ b/test/orders-service/orders-service-template.ts
@@ -1,0 +1,172 @@
+import type { CfnTemplateBodyRecord } from "../../src/service/cloudformation/template/sim-cfn-template.js";
+import { ordersServiceNames } from "./orders-service-names.js";
+
+const names = ordersServiceNames;
+
+/**
+ * The table the application reads and writes, and the Role it does it as.
+ */
+const dataResources: CfnTemplateBodyRecord["Resources"] = {
+  OrdersTable: {
+    Type: "AWS::DynamoDB::Table",
+    Properties: {
+      TableName: names.table,
+      BillingMode: "PAY_PER_REQUEST",
+      AttributeDefinitions: [{ AttributeName: "orderId", AttributeType: "S" }],
+      KeySchema: [{ AttributeName: "orderId", KeyType: "HASH" }],
+    },
+  },
+  OrdersTaskRole: {
+    Type: "AWS::IAM::Role",
+    Properties: {
+      RoleName: "OrdersTaskRole",
+      AssumeRolePolicyDocument: {
+        Version: "2012-10-17",
+        Statement: [
+          {
+            Effect: "Allow",
+            Principal: { Service: "ecs-tasks.amazonaws.com" },
+            Action: "sts:AssumeRole",
+          },
+        ],
+      },
+      Policies: [
+        {
+          PolicyName: "ReadWriteOrders",
+          PolicyDocument: {
+            Version: "2012-10-17",
+            Statement: [
+              {
+                Effect: "Allow",
+                Action: ["dynamodb:PutItem", "dynamodb:GetItem"],
+                Resource: { "Fn::GetAtt": ["OrdersTable", "Arn"] },
+              },
+            ],
+          },
+        },
+      ],
+    },
+  },
+};
+
+/**
+ * The load balancer the requests arrive at, and the name it answers on.
+ */
+const frontDoorResources: CfnTemplateBodyRecord["Resources"] = {
+  OrdersAlb: {
+    Type: "AWS::ElasticLoadBalancingV2::LoadBalancer",
+    Properties: {
+      Name: "orders-alb",
+      Scheme: "internet-facing",
+      Subnets: ["subnet-1111", "subnet-2222"],
+    },
+  },
+  OrdersTargetGroup: {
+    Type: "AWS::ElasticLoadBalancingV2::TargetGroup",
+    Properties: {
+      Name: "orders-tg",
+      TargetType: "ip",
+      Protocol: "HTTP",
+      Port: names.proxyPort,
+    },
+  },
+  HttpListener: {
+    Type: "AWS::ElasticLoadBalancingV2::Listener",
+    Properties: {
+      LoadBalancerArn: { Ref: "OrdersAlb" },
+      Protocol: "HTTP",
+      Port: 80,
+      DefaultActions: [
+        { Type: "forward", TargetGroupArn: { Ref: "OrdersTargetGroup" } },
+      ],
+    },
+  },
+  OrdersZone: {
+    Type: "AWS::Route53::HostedZone",
+    Properties: { Name: names.zone },
+  },
+  OrdersRecord: {
+    Type: "AWS::Route53::RecordSet",
+    Properties: {
+      HostedZoneId: { Ref: "OrdersZone" },
+      Name: names.hostname,
+      Type: "A",
+      AliasTarget: {
+        DNSName: { "Fn::GetAtt": ["OrdersAlb", "DNSName"] },
+        HostedZoneId: { "Fn::GetAtt": ["OrdersAlb", "CanonicalHostedZoneID"] },
+      },
+    },
+  },
+};
+
+/**
+ * The service that answers, with the proxy container a real task carries in
+ * front of the application.
+ */
+const serviceResources: CfnTemplateBodyRecord["Resources"] = {
+  OrdersCluster: {
+    Type: "AWS::ECS::Cluster",
+    Properties: { ClusterName: names.cluster },
+  },
+  OrdersTaskDefinition: {
+    Type: "AWS::ECS::TaskDefinition",
+    Properties: {
+      Family: names.family,
+      TaskRoleArn: { "Fn::GetAtt": ["OrdersTaskRole", "Arn"] },
+      NetworkMode: "awsvpc",
+      ContainerDefinitions: [
+        {
+          Name: names.proxy,
+          Image: "public.ecr.aws/nginx/nginx:1.27",
+          PortMappings: [{ ContainerPort: names.proxyPort }],
+        },
+        {
+          Name: names.container,
+          Image: "example.dkr.ecr.eu-west-2.amazonaws.com/orders-api:1",
+          PortMappings: [{ ContainerPort: names.applicationPort }],
+          Environment: [
+            { Name: "ORDERS_TABLE", Value: { Ref: "OrdersTable" } },
+          ],
+        },
+      ],
+    },
+  },
+  OrdersService: {
+    Type: "AWS::ECS::Service",
+    Properties: {
+      ServiceName: names.service,
+      Cluster: { Ref: "OrdersCluster" },
+      TaskDefinition: { Ref: "OrdersTaskDefinition" },
+      DesiredCount: 2,
+      LaunchType: "FARGATE",
+      LoadBalancers: [
+        {
+          TargetGroupArn: { Ref: "OrdersTargetGroup" },
+          ContainerName: names.proxy,
+          ContainerPort: names.proxyPort,
+        },
+      ],
+    },
+  },
+};
+
+/**
+ * The stack the orders service is deployed from.
+ *
+ * It is the shape a real one has: a table, a task Role that may read and write
+ * it, a cluster and task definition, a service registered into a target group,
+ * and a load balancer behind a Route53 name. The one thing worth pointing at is
+ * the task definition, which declares an nginx container on the port the
+ * service registers and the application behind it on another, which is what a
+ * great many deployed services look like.
+ */
+export const ordersServiceTemplate: CfnTemplateBodyRecord = {
+  Resources: {
+    ...dataResources,
+    ...frontDoorResources,
+    ...serviceResources,
+  },
+  Outputs: {
+    TargetGroup: { Value: { Ref: "OrdersTargetGroup" } },
+  },
+};

--- a/test/orders-service/orders-service.factory.ts
+++ b/test/orders-service/orders-service.factory.ts
@@ -1,0 +1,60 @@
+import { AsyncMappedFactory } from "@kensio/part-factory";
+
+import type { SimAws } from "../../src/service/aws/sim-aws.js";
+import type { SimCfnStack } from "../../src/service/cloudformation/stack/sim-cfn-stack.js";
+import { handleOrdersRequest } from "./orders-service-handler.js";
+import { ordersServiceNames } from "./orders-service-names.js";
+import { ordersServiceTemplate } from "./orders-service-template.js";
+
+/**
+ * What a test asks for when it wants the orders service standing up.
+ *
+ * There is nothing to choose: the whole point of the scenario is the ordinary
+ * deployment, so what a test varies is the requests it then makes.
+ */
+export type OrdersServiceInput = Record<string, never>;
+
+/**
+ * A deployed orders service, and where to reach it.
+ */
+export interface OrdersService {
+  readonly simAws: SimAws;
+  readonly stack: SimCfnStack;
+  /** The Route53 name the load balancer answers on. */
+  readonly hostname: string;
+}
+
+/**
+ * Deploys the orders service from its CloudFormation template.
+ *
+ * The application container is bound by the logical ID of the task definition
+ * Resource, which is what a template has and a `RegisterTaskDefinition` call
+ * does not. The nginx container in front of it is left unbound, because there
+ * is no nginx here to run: what answers is the application, as the load
+ * balancer routes to a container that is actually there.
+ */
+export const ordersServiceFactory = new AsyncMappedFactory<
+  OrdersServiceInput,
+  OrdersService,
+  SimAws
+>(
+  () => ({}),
+  async (_input, simAws) => {
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: ordersServiceNames.stack,
+      template: ordersServiceTemplate,
+      bindings: [
+        {
+          logicalId: "OrdersTaskDefinition",
+          containerName: ordersServiceNames.container,
+          http: handleOrdersRequest,
+        },
+      ],
+    });
+
+    await stack.waitForDeployComplete();
+    await simAws.backgroundTasksComplete();
+
+    return { simAws, stack, hostname: ordersServiceNames.hostname };
+  },
+);


### PR DESCRIPTION
An ECS service’s `loadBalancers` declaration is now a registration rather than a record: creating the service puts each of its tasks into the target group it names, deleting or scaling it takes them out again, and a request the load balancer forwards there reaches the handler bound to the service’s container, answered as the task role with the container’s environment applied. Which container of a task answers diverges from real ECS on purpose, because the common real task puts an unsimulated proxy on the registered port with the application behind it, so the request goes to a container that is bound and the declared port only chooses between several of them; that is documented in the limitations on both pages and covered by a test of the proxy-in-front shape. A target group whose service has no bound container is a 503, as an empty one already was, and a system test deploys one stack and reaches application code that reads and writes a DynamoDB table through a Route53 name.

Resolves https://github.com/KensioSoftware/yulin/issues/568

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * ECS services can now serve HTTP requests through load balancers.
  * Load balancers can route requests to ECS containers using IP target groups.
  * Service tasks automatically register and deregister as targets during scaling and shutdown.
  * Container handlers receive configured environment variables and task-role permissions.
  * Added complete ECS/load-balancer examples, including an orders service backed by DynamoDB.
* **Bug Fixes**
  * Improved handling of unavailable targets, returning 503 responses.
  * Handler failures or invalid responses now produce 502 responses.
* **Documentation**
  * Updated ECS and load-balancer guidance, limitations, routing behavior, and CloudFormation requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->