### PR TITLE
fix: give sandboxed Lambda code standard streams

### DIFF
--- a/docs/services/lambda/README.md
+++ b/docs/services/lambda/README.md
@@ -147,6 +147,8 @@ The vm runtime models the real Node.js runtime closely:
   modules, and use dependencies bundled under the archive's `node_modules/`.
 - The sandbox provides an AWS-like `process.env` with the standard runtime variables
   (`AWS_REGION`, `AWS_LAMBDA_FUNCTION_NAME`, `AWS_LAMBDA_FUNCTION_MEMORY_SIZE`, ...).
+- The sandbox provides writable `process.stdout` and `process.stderr`, with its `console` built
+  over them, as the real runtime does. See [What a handler prints](#what-a-handler-prints).
 - Import and handler problems surface as invocation errors rather than failing creation, with the
   real runtime error types (`Runtime.ImportModuleError`, `Runtime.HandlerNotFound`,
   `Runtime.UserCodeSyntaxError`, `Runtime.MalformedHandlerName`).
@@ -159,6 +161,34 @@ not a real zip archive are rejected at creation with the AWS-like
 The archives are real zip files, so they interoperate with real tooling in both directions: a zip
 built by any other tool works as `Code.ZipFile` input, and `makeLambdaCodeZip` output can be
 unzipped normally.
+
+### What a handler prints
+
+The sandbox has writable standard streams, so `process.stdout.write(...)` and
+`process.stderr.write(...)` work inside a handler, and its `console` is built over them as the real
+runtime's is. A logging library that builds its own console rather than using the global one works
+too:
+
+```javascript
+const { Console } = require("node:console");
+const logger = new Console({ stdout: process.stdout, stderr: process.stderr });
+```
+
+That is what AWS Lambda Powertools' `Logger` does, at module scope, so a bundled Powertools handler
+runs here. Its `Metrics` writes its embedded metric format document to standard output, so the
+metrics a handler emitted can be read back the same way its log lines can.
+
+Everything a handler prints reaches the host process's standard output or standard error, which is
+where a test or a `pnpm run dev` session already sees output. A test that wants to assert on it
+captures the host stream:
+
+```typescript
+const written: string[] = [];
+vi.spyOn(process.stdout, "write").mockImplementation((chunk): boolean => {
+  written.push(String(chunk));
+  return true;
+});
+```
 
 ## Function code from S3
 
@@ -1931,7 +1961,9 @@ Sim Lambda currently supports:
   - an in-process handler function passed via `makeLambdaZipFileInput(...)`
   - zip archive bytes on `Code.ZipFile` (build them with `makeLambdaCodeZip(...)`)
   - a zip object stored in sim S3 via `Code.S3Bucket`/`S3Key`
-- A Node.js `vm` runtime for zip-packaged code, with warm module state across invocations
+- A Node.js `vm` runtime for zip-packaged code, with warm module state across invocations, and
+  writable standard streams for handler output, including a bundled AWS Lambda Powertools logger's
+  own console
 - Per-function environment variables with `Environment.Variables`
 - Runtime-provided `@aws-sdk/*` packages inside function code, routed into the owning simulated AWS
   environment
@@ -1976,6 +2008,9 @@ Current documented limitations:
 - Function versions, aliases, and qualifiers are not simulated (`Version` is always `$LATEST`).
 - The vm runtime supports CommonJS function code only; ES module source (`.mjs` / `export`
   syntax) is not supported yet.
+- Handler output goes to the host process's standard output and error. There is no simulated
+  CloudWatch Logs, so nothing holds a function's output for a test to read back per function or per
+  invocation. See [What a handler prints](#what-a-handler-prints).
 - Container image functions are not run. Yulin never reads a container image, and stays Docker-free.
   A function with `PackageType: Image` is skipped, or refused on `CreateFunction`, unless a real
   in-process handler stands in for its image: one bound to it, or one registered in the

--- a/docs/services/lambda/README.md
+++ b/docs/services/lambda/README.md
@@ -178,9 +178,9 @@ That is what AWS Lambda Powertools' `Logger` does, at module scope, so a bundled
 runs here. Its `Metrics` writes its embedded metric format document to standard output, so the
 metrics a handler emitted can be read back the same way its log lines can.
 
-Everything a handler prints reaches the host process's standard output or standard error, which is
-where a test or a `pnpm run dev` session already sees output. A test that wants to assert on it
-captures the host stream:
+What a handler prints reaches the matching host stream, standard output to standard output and
+standard error to standard error, which is where a test or a `pnpm run dev` session already sees
+output. A test that wants to assert on it captures that host stream:
 
 ```typescript
 const written: string[] = [];
@@ -189,6 +189,9 @@ vi.spyOn(process.stdout, "write").mockImplementation((chunk): boolean => {
   return true;
 });
 ```
+
+That captures standard output, which is where log lines and EMF metric documents go. Spy on
+`process.stderr` the same way for what a handler wrote there, including its `console.error`.
 
 ## Function code from S3
 

--- a/package.json
+++ b/package.json
@@ -163,6 +163,8 @@
   "packageManager": "pnpm@11.17.0+sha512.cca3cea332ad254bb84145f966d19f4879615210346fc92c79a047f23a0d7b3cca3c3792f0076ba1f1831d277efbcf0a9119b31a9a60eca7fb3d6231f331ef72",
   "devDependencies": {
     "@aws-crypto/sha256-js": "^5.2.0",
+    "@aws-lambda-powertools/logger": "^2.34.0",
+    "@aws-lambda-powertools/metrics": "^2.34.0",
     "@aws-sdk/client-acm": "^3.1101.0",
     "@aws-sdk/client-apigatewayv2": "^3.1101.0",
     "@aws-sdk/client-cloudformation": "^3.1101.0",
@@ -204,6 +206,7 @@
     "aws-sdk-client-mock": "^4.1.0",
     "constructs": "^10.8.0",
     "conventional-changelog-conventionalcommits": "9.3.1",
+    "esbuild": "^0.28.2",
     "eslint": "^10.8.0",
     "eslint-plugin-jsdoc": "^63.3.2",
     "eslint-plugin-no-secrets": "^2.3.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,6 +21,12 @@ importers:
       '@aws-crypto/sha256-js':
         specifier: ^5.2.0
         version: 5.2.0
+      '@aws-lambda-powertools/logger':
+        specifier: ^2.34.0
+        version: 2.34.0
+      '@aws-lambda-powertools/metrics':
+        specifier: ^2.34.0
+        version: 2.34.0
       '@aws-sdk/client-acm':
         specifier: ^3.1101.0
         version: 3.1105.0
@@ -144,6 +150,9 @@ importers:
       conventional-changelog-conventionalcommits:
         specifier: 9.3.1
         version: 9.3.1
+      esbuild:
+        specifier: ^0.28.2
+        version: 0.28.2
       eslint:
         specifier: ^10.8.0
         version: 10.8.1(jiti@2.7.0)(supports-color@7.2.0)
@@ -223,6 +232,28 @@ packages:
 
   '@aws-crypto/util@5.2.0':
     resolution: {integrity: sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==}
+
+  '@aws-lambda-powertools/commons@2.34.0':
+    resolution: {integrity: sha512-ga89L3UznCwkApsrVAYGywifAh9PpccXZAVE053B6IdKvZrwjv+L+ja1WyzU9sy9UR3wPEdh0LFiUCRZRhTfvQ==}
+
+  '@aws-lambda-powertools/logger@2.34.0':
+    resolution: {integrity: sha512-FIWQcdX/dqfKE+4H8N9w7y7/3/ANmDpKDgMlMc+yPNx2XDpKK6Ou1zLFYoNt5mV6dOZunFQcKbRWUy6zIDdE0w==}
+    peerDependencies:
+      '@aws-lambda-powertools/jmespath': 2.34.0
+      '@middy/core': 4.x || 5.x || 6.x || 7.x
+    peerDependenciesMeta:
+      '@aws-lambda-powertools/jmespath':
+        optional: true
+      '@middy/core':
+        optional: true
+
+  '@aws-lambda-powertools/metrics@2.34.0':
+    resolution: {integrity: sha512-nY2ZdyoZVV5jsa9boeDhDn18pff0K/RBsj6mpb44jiA3IRCTMx5va6AY1SMskjFS1GzF9FIOV4NprQP9YsFL2g==}
+    peerDependencies:
+      '@middy/core': 4.x || 5.x || 6.x || 7.x
+    peerDependenciesMeta:
+      '@middy/core':
+        optional: true
 
   '@aws-sdk/checksums@3.1000.27':
     resolution: {integrity: sha512-insWOqKKNUrbN/dohEG7BJ0U5GkyqhjbMb/NHNaLUtq+7my2M8C4EnZZZoxMmXRqCC+P9dEr+KyJA2JGGzoKLg==}
@@ -3394,6 +3425,20 @@ snapshots:
       '@aws-sdk/types': 3.974.2
       '@smithy/util-utf8': 2.3.0
       tslib: 2.8.1
+
+  '@aws-lambda-powertools/commons@2.34.0':
+    dependencies:
+      '@aws/lambda-invoke-store': 0.3.0
+
+  '@aws-lambda-powertools/logger@2.34.0':
+    dependencies:
+      '@aws-lambda-powertools/commons': 2.34.0
+      '@aws/lambda-invoke-store': 0.3.0
+
+  '@aws-lambda-powertools/metrics@2.34.0':
+    dependencies:
+      '@aws-lambda-powertools/commons': 2.34.0
+      '@aws/lambda-invoke-store': 0.3.0
 
   '@aws-sdk/checksums@3.1000.27':
     dependencies:

--- a/src/service/lambda/README.md
+++ b/src/service/lambda/README.md
@@ -133,10 +133,11 @@ The sandbox has writable standard streams (`SimLambdaVmOutputStream`), and its `
 over them as the real runtime's is. Both matter: a library that builds its own console over
 `process.stdout` and `process.stderr` rather than using the global one, as AWS Lambda Powertools'
 logger does at module scope, throws `ERR_CONSOLE_WRITABLE_STREAM` at import without the streams and
-never runs. What is written is forwarded to the host stream, so everything a handler prints goes to
-one place whether it printed through the console or wrote to the stream itself, and a test captures
-it by capturing the host stream. Powertools' metrics print their EMF document to standard output,
-so that is how a test reads the metrics a handler emitted.
+never runs. What is written is forwarded to the matching host stream, the sandbox's standard output
+to the host's standard output and its standard error to the host's standard error, so a handler's
+output arrives there whether it printed through the console or wrote to the stream itself, and a
+test reads it by capturing that host stream. Powertools' metrics print their EMF document to
+standard output, so that is how a test reads the metrics a handler emitted.
 
 `SimLambdaVmModules` provides a CommonJS module system over the archive: relative requires between
 archived files, Node.js built-ins from the host (as the real runtime provides them), and a minimal

--- a/src/service/lambda/README.md
+++ b/src/service/lambda/README.md
@@ -129,6 +129,15 @@ Import and handler problems surface as invocation errors with the real runtime e
 `Runtime.ImportModuleError`, `Runtime.HandlerNotFound`, `Runtime.UserCodeSyntaxError`,
 `Runtime.MalformedHandlerName` — rather than failing creation.
 
+The sandbox has writable standard streams (`SimLambdaVmOutputStream`), and its `console` is built
+over them as the real runtime's is. Both matter: a library that builds its own console over
+`process.stdout` and `process.stderr` rather than using the global one, as AWS Lambda Powertools'
+logger does at module scope, throws `ERR_CONSOLE_WRITABLE_STREAM` at import without the streams and
+never runs. What is written is forwarded to the host stream, so everything a handler prints goes to
+one place whether it printed through the console or wrote to the stream itself, and a test captures
+it by capturing the host stream. Powertools' metrics print their EMF document to standard output,
+so that is how a test reads the metrics a handler emitted.
+
 `SimLambdaVmModules` provides a CommonJS module system over the archive: relative requires between
 archived files, Node.js built-ins from the host (as the real runtime provides them), and a minimal
 `node_modules` lookup for dependencies bundled into the archive. The `Handler` string selects the

--- a/src/service/lambda/function/code/vm/sim-lambda-vm-context.ts
+++ b/src/service/lambda/function/code/vm/sim-lambda-vm-context.ts
@@ -1,3 +1,4 @@
+import { Console } from "node:console";
 import vm from "node:vm";
 import { makeSimClockDate } from "../../../../../util/clock/sim-clock-date.js";
 import {
@@ -5,13 +6,15 @@ import {
   SimRealClock,
 } from "../../../../../util/clock/sim-clock.js";
 import type { SimLambdaEnvironment } from "../../environment/sim-lambda-environment.js";
+import { SimLambdaVmOutputStream } from "./sim-lambda-vm-output-stream.js";
 
 /**
  * Create the sandbox vm context that sim Lambda function code runs in.
  *
  * The context provides the common globals a Node.js Lambda runtime offers,
  * including an AWS-like process.env holding the standard runtime variables
- * and any variables declared for the function. Everything else must be part
+ * and any variables declared for the function, and the writable standard
+ * streams function code writes its output to. Everything else must be part
  * of the deployed function code archive, as on real Lambda.
  *
  * Zip code needs nothing like the process.env and Date handling the
@@ -23,11 +26,22 @@ export function makeSimLambdaVmContext(
   environment: SimLambdaEnvironment,
   clock: SimClock = new SimRealClock(),
 ): vm.Context {
+  // Writable standard streams, as the real runtime provides. Code that builds
+  // its own console over them, as AWS Lambda Powertools' logger does, throws
+  // at module load without them.
+  const stdout = new SimLambdaVmOutputStream(() => process.stdout);
+  const stderr = new SimLambdaVmOutputStream(() => process.stderr);
+
   return vm.createContext({
-    console,
+    // The sandbox's console is built over those streams, as the real
+    // runtime's is, so everything function code prints goes to one place
+    // whether it printed through the console or wrote to the stream itself.
+    console: new Console({ stdout, stderr }),
     Buffer,
     process: {
       env: environment.variables(),
+      stdout,
+      stderr,
     },
     // Function code asking JavaScript for the time gets the simulation's
     // time, so a frozen or advanced clock reaches the code under test.

--- a/src/service/lambda/function/code/vm/sim-lambda-vm-output-stream.ts
+++ b/src/service/lambda/function/code/vm/sim-lambda-vm-output-stream.ts
@@ -1,0 +1,38 @@
+import { Writable } from "node:stream";
+
+/**
+ * One of the standard output streams the sim Lambda vm sandbox gives function
+ * code as `process.stdout` and `process.stderr`.
+ *
+ * Real Lambda gives function code writable standard streams, and libraries
+ * build their own console over them rather than the global one, so that
+ * console patching cannot affect their output. AWS Lambda Powertools' logger
+ * does exactly that, at module scope:
+ *
+ * ```javascript
+ * new Console({ stdout: process.stdout, stderr: process.stderr })
+ * ```
+ *
+ * Without the streams that construction throws
+ * (`ERR_CONSOLE_WRITABLE_STREAM`) before the handler runs.
+ *
+ * What function code writes is forwarded to the host stream, which is where a
+ * handler's own console output already goes, so the two end up in the same
+ * place instead of one of them disappearing. The host stream is read per
+ * write, so a test that starts capturing host output after the function has
+ * cold-started still sees what the handler writes.
+ */
+export class SimLambdaVmOutputStream extends Writable {
+  constructor(private readonly hostStream: () => NodeJS.WritableStream) {
+    super();
+  }
+
+  override _write(
+    chunk: Buffer,
+    _encoding: BufferEncoding,
+    done: (error?: Error) => void,
+  ): void {
+    this.hostStream().write(chunk);
+    done();
+  }
+}

--- a/src/service/lambda/function/code/vm/sim-lambda-vm-output-stream.ts
+++ b/src/service/lambda/function/code/vm/sim-lambda-vm-output-stream.ts
@@ -16,17 +16,28 @@ import { Writable } from "node:stream";
  * Without the streams that construction throws
  * (`ERR_CONSOLE_WRITABLE_STREAM`) before the handler runs.
  *
- * What function code writes is forwarded to the host stream, which is where a
- * handler's own console output already goes, so the two end up in the same
- * place instead of one of them disappearing. The host stream is read per
- * write, so a test that starts capturing host output after the function has
- * cold-started still sees what the handler writes.
+ * What function code writes is forwarded to the matching host stream,
+ * standard output to standard output and standard error to standard error.
+ * The sandbox's own console is built over these streams too, so a handler's
+ * output arrives there whether it printed through the console or wrote to the
+ * stream itself, instead of one of the two disappearing. The host stream is
+ * read per write, so a test that starts capturing host output after the
+ * function has cold-started still sees what the handler writes.
  */
 export class SimLambdaVmOutputStream extends Writable {
   constructor(private readonly hostStream: () => NodeJS.WritableStream) {
     super();
   }
 
+  /**
+   * The write is handed on and reported as done without waiting for the host
+   * stream, as Node.js's own console hands writes to process.stdout. Waiting
+   * would make a failed log write fail the code that logged: reporting the
+   * host's error here destroys this stream, and with nothing listening for
+   * its error the process goes down over a lost line. It would also mean a
+   * test capturing host output had to complete the write it captured, and the
+   * ordinary way to capture it does not.
+   */
   override _write(
     chunk: Buffer,
     _encoding: BufferEncoding,

--- a/src/service/lambda/function/code/vm/sim-lambda-vm-output.iso.test.ts
+++ b/src/service/lambda/function/code/vm/sim-lambda-vm-output.iso.test.ts
@@ -1,0 +1,156 @@
+import {
+  assertIdentical,
+  assertStringIncludes,
+  assertTrue,
+} from "@kensio/smartass";
+import { describe, it, vi } from "vitest";
+import { simLambdaVmZipFunctionFactory } from "../sim-lambda-vm-zip-function.factory.js";
+
+/**
+ * A handler building its own console over the standard streams at module
+ * scope, as AWS Lambda Powertools' logger does so that a warm container
+ * reuses it and console patching cannot affect its output.
+ */
+const powertoolsStyleLoggerSource = `
+  const { Console } = require("node:console");
+  const logger = new Console({
+    stdout: process.stdout,
+    stderr: process.stderr,
+  });
+
+  exports.handler = async (event) => {
+    logger.log("logged " + event.name);
+    return { logged: event.name };
+  };
+`;
+
+describe("sim Lambda vm code output streams", () => {
+  it("runs a handler that builds its own console, as Powertools does", async () => {
+    // Given a function whose module scope constructs a node:console Console
+    // over process.stdout and process.stderr, like Powertools' logger.
+    const simFunction = simLambdaVmZipFunctionFactory.make({
+      code: powertoolsStyleLoggerSource,
+    });
+    captureHostStdout();
+
+    // When the function is invoked.
+    const result = await simFunction.invoke({ name: "powertools" });
+
+    // Then the module loaded and the handler ran, rather than the import
+    // failing with ERR_CONSOLE_WRITABLE_STREAM. The result is cloned because
+    // vm result objects belong to the vm realm.
+    const returned = structuredClone(result) as Record<string, unknown>;
+    assertIdentical(returned["logged"], "powertools");
+  });
+
+  it("sends what that console logs where console.log already goes", async () => {
+    // Given a function logging through its own console and the global one.
+    const simFunction = simLambdaVmZipFunctionFactory.make({
+      code: `
+        const { Console } = require("node:console");
+        const logger = new Console({
+          stdout: process.stdout,
+          stderr: process.stderr,
+        });
+
+        exports.handler = async () => {
+          logger.log("logged by its own console");
+          console.log("logged by the global console");
+          return null;
+        };
+      `,
+    });
+    const written = captureHostStdout();
+
+    // When the function is invoked.
+    await simFunction.invoke({});
+
+    // Then both went to the host's standard output, so neither is lost.
+    assertStringIncludes(written.join(""), "logged by its own console");
+    assertStringIncludes(written.join(""), "logged by the global console");
+  });
+
+  it("captures what function code writes to process.stdout", async () => {
+    // Given a function writing to the standard output stream directly, as
+    // Powertools' metrics does to emit EMF.
+    const simFunction = simLambdaVmZipFunctionFactory.make({
+      code: String.raw`
+        exports.handler = async (event) => {
+          process.stdout.write(JSON.stringify(event) + "\n");
+          return null;
+        };
+      `,
+    });
+    const written = captureHostStdout();
+
+    // When the function is invoked.
+    await simFunction.invoke({ metric: "orders", value: 3 });
+
+    // Then the write reached the host's standard output, where a test can
+    // read it.
+    assertStringIncludes(written.join(""), '{"metric":"orders","value":3}');
+  });
+
+  it("captures what function code writes to process.stderr", async () => {
+    // Given a function writing to the standard error stream, both directly
+    // and through the console the sandbox provides.
+    const simFunction = simLambdaVmZipFunctionFactory.make({
+      code: String.raw`
+        exports.handler = async () => {
+          process.stderr.write("written to the stream\n");
+          console.error("logged through the console");
+          return null;
+        };
+      `,
+    });
+    const written = captureHostStderr();
+
+    // When the function is invoked.
+    await simFunction.invoke({});
+
+    // Then both reached the host's standard error, separately from its
+    // standard output.
+    assertStringIncludes(written.join(""), "written to the stream");
+    assertStringIncludes(written.join(""), "logged through the console");
+  });
+
+  it("reports the write as accepted, so code awaiting a drain continues", async () => {
+    // Given a function reading what the stream says about its write.
+    const simFunction = simLambdaVmZipFunctionFactory.make({
+      code: String.raw`
+        exports.handler = async () =>
+          process.stdout.write("accepted\n");
+      `,
+    });
+    captureHostStdout();
+
+    // When the function is invoked.
+    const accepted = await simFunction.invoke({});
+
+    // Then the stream accepted it, as an unfilled buffer does.
+    assertTrue(accepted);
+  });
+});
+
+function captureHostStdout(): string[] {
+  return captureHostStream(process.stdout);
+}
+
+function captureHostStderr(): string[] {
+  return captureHostStream(process.stderr);
+}
+
+/**
+ * Capture what reaches a host standard stream, which is where the simulator
+ * sends a handler's output, keeping the test run's own output clean.
+ */
+function captureHostStream(stream: NodeJS.WriteStream): string[] {
+  const written: string[] = [];
+
+  vi.spyOn(stream, "write").mockImplementation((chunk): boolean => {
+    written.push(String(chunk));
+    return true;
+  });
+
+  return written;
+}

--- a/src/service/lambda/function/code/vm/sim-lambda-vm-powertools.loc.test.ts
+++ b/src/service/lambda/function/code/vm/sim-lambda-vm-powertools.loc.test.ts
@@ -1,0 +1,112 @@
+import { build } from "esbuild";
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+} from "@kensio/smartass";
+import { describe, it, vi } from "vitest";
+import { simLambdaVmZipFunctionFactory } from "../sim-lambda-vm-zip-function.factory.js";
+
+/**
+ * A handler using AWS Lambda Powertools the way a deployed one does: the
+ * logger and the metrics are constructed at module scope, so a warm container
+ * reuses them, and both are bundled into the deployment package rather than
+ * provided by the runtime.
+ *
+ * The logger builds its own console over process.stdout and process.stderr,
+ * and the metrics write their EMF document to stdout, so this exercises the
+ * real library against the sandbox's standard streams.
+ */
+const handlerSource = `
+import { Logger } from "@aws-lambda-powertools/logger";
+import { Metrics, MetricUnit } from "@aws-lambda-powertools/metrics";
+
+const logger = new Logger({ serviceName: "orders" });
+const metrics = new Metrics({ namespace: "Orders", serviceName: "orders" });
+
+export const handler = async (event: { orderId: string }) => {
+  logger.info("order handled", { orderId: event.orderId });
+  metrics.addMetric("OrdersHandled", MetricUnit.Count, 1);
+  metrics.publishStoredMetrics();
+  return { handled: event.orderId };
+};
+`;
+
+describe("sim Lambda vm code with AWS Lambda Powertools", () => {
+  it("runs a handler whose logger and metrics are Powertools", async () => {
+    // Given a function whose deployment package bundles Powertools, as a
+    // CDK NodejsFunction build produces.
+    const simFunction = simLambdaVmZipFunctionFactory.make({
+      code: await bundleHandler(),
+    });
+    const written = captureHostStdout();
+
+    // When the function is invoked.
+    const result = await simFunction.invoke({ orderId: "order-1" });
+
+    // Then the module loaded and the handler ran, rather than the logger's
+    // console construction failing the import. The result is cloned because
+    // vm result objects belong to the vm realm.
+    const returned = structuredClone(result) as Record<string, unknown>;
+    assertIdentical(returned["handled"], "order-1");
+
+    // And what the logger logged is where a test can read it.
+    const output = written.join("");
+    assertStringIncludes(output, '"message":"order handled"');
+    assertStringIncludes(output, '"orderId":"order-1"');
+
+    // And so is the EMF document the metrics printed.
+    const emf = embeddedMetric(output);
+    assertIdentical(emf["OrdersHandled"], 1);
+    assertStringIncludes(JSON.stringify(emf["_aws"]), '"Namespace":"Orders"');
+  });
+});
+
+/**
+ * Bundle the handler into one CommonJS module, as a deployment package build
+ * does, so the archive carries Powertools rather than the runtime providing
+ * it.
+ */
+async function bundleHandler(): Promise<string> {
+  const bundled = await build({
+    stdin: {
+      contents: handlerSource,
+      loader: "ts",
+      resolveDir: import.meta.dirname,
+      sourcefile: "index.ts",
+    },
+    bundle: true,
+    write: false,
+    platform: "node",
+    target: "node24",
+    format: "cjs",
+  });
+
+  const output = bundled.outputFiles[0];
+  assertNonNullable(output);
+
+  return output.text;
+}
+
+/**
+ * Read the embedded metric format document out of what was printed.
+ */
+function embeddedMetric(output: string): Record<string, unknown> {
+  const line = output
+    .split("\n")
+    .find((candidate) => candidate.includes('"_aws"'));
+  assertNonNullable(line);
+
+  return JSON.parse(line) as Record<string, unknown>;
+}
+
+function captureHostStdout(): string[] {
+  const written: string[] = [];
+
+  vi.spyOn(process.stdout, "write").mockImplementation((chunk): boolean => {
+    written.push(String(chunk));
+    return true;
+  });
+
+  return written;
+}


### PR DESCRIPTION
A simulated Lambda's process had no stdout and no stderr, so function code building its own console over them threw ERR_CONSOLE_WRITABLE_STREAM at module load and the handler never ran. That is what AWS Lambda Powertools' logger does, at module scope, so no handler bundling Powertools could run in the vm sandbox at all. The sandbox now provides writable standard streams and builds its console over them as the real runtime does, so everything a handler prints reaches the host stream a test already reads its console output from, including the EMF documents Powertools' metrics print.

The tests cover the hand-rolled console construction that reproduces the crash, a write to each stream, and an end to end case running a real bundled Powertools `Logger` and `Metrics`. That last one is why `@aws-lambda-powertools/logger`, `@aws-lambda-powertools/metrics` and `esbuild` are added as dev dependencies: it bundles the handler the way a CDK `NodejsFunction` build does, so the archive carries Powertools rather than the runtime providing it.

There is no simulated CloudWatch Logs, so nothing holds a function's output per function or per invocation. A test that wants to assert on what a handler printed captures the host stream, which is documented alongside the limitation.

Resolves https://github.com/KensioSoftware/yulin/issues/595


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Simulated Lambda handlers can now write to standard output and error streams.
  - Console output, custom consoles, structured logs, and metrics are forwarded to host streams for capture during tests.
  - Added support coverage for AWS Lambda Powertools logging and metrics output.

- **Documentation**
  - Documented handler output behavior, stream visibility, test capture, and CloudWatch Logs limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->