### PR TITLE
fix: require lambda:InvokeFunction for OAC origin

### DIFF
--- a/docs/services/cloudfront/README.md
+++ b/docs/services/cloudfront/README.md
@@ -1275,18 +1275,38 @@ Origin works out who it is reading as per request instead.
 
 ### A Lambda Function URL Origin
 
-A Function URL with `AuthType: AWS_IAM` admits only a caller allowed `lambda:InvokeFunctionUrl` on
-the function, so putting one behind a Distribution takes three things: the origin access control
-with `OriginAccessControlOriginType: lambda`, a custom Origin naming it whose `DomainName` is the
-Function URL's hostname, and an `AWS::Lambda::Permission` granting `lambda:InvokeFunctionUrl` to
-`cloudfront.amazonaws.com` for that Distribution. That is what CDK's
-`FunctionUrlOrigin.withOriginAccessControl` synthesizes, and it is the only way to serve a Function
-URL through CloudFront without leaving the Function URL open to anyone who finds its endpoint.
+Putting a Function URL with `AuthType: AWS_IAM` behind a Distribution takes the origin access
+control with `OriginAccessControlOriginType: lambda`, a custom Origin naming it whose `DomainName`
+is the Function URL's hostname, and two `AWS::Lambda::Permission` Resources granting
+`cloudfront.amazonaws.com` for that Distribution. It is the only way to serve a Function URL through
+CloudFront without leaving the Function URL open to anyone who finds its endpoint.
+
+Both permissions are needed. One grants `lambda:InvokeFunctionUrl` and the other
+`lambda:InvokeFunction`, to the same principal with the same `SourceArn`, as
+[Restrict access to an AWS Lambda function URL origin](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-restricting-access-to-lambda.html)
+sets out. CDK's `FunctionUrlOrigin.withOriginAccessControl` writes only the first, so a CDK app has
+to add the second itself:
+
+```typescript
+greeterFunction.addPermission("InvokeFunctionFromCloudFront", {
+  principal: new iam.ServicePrincipal("cloudfront.amazonaws.com"),
+  action: "lambda:InvokeFunction",
+  sourceArn: cdk.Fn.join("", [
+    "arn:",
+    cdk.Aws.PARTITION,
+    ":cloudfront::",
+    cdk.Aws.ACCOUNT_ID,
+    ":distribution/",
+    distribution.distributionId,
+  ]),
+});
+```
 
 The Origin request is made as the `cloudfront.amazonaws.com` service principal carrying the
 Distribution's ARN, the same pair an S3 Origin read carries, and the function's resource policy is
-the whole decision. A Stack without the permission, or with one naming a different Distribution,
-deploys and then answers 403 through the Distribution, which is what the real deployment does.
+the whole decision. A Stack missing either permission, or with one naming a different Distribution,
+deploys and then answers 403 through the Distribution, which is what the real deployment does. The
+function is never invoked, so it writes no logs to look at either.
 
 ```typescript sim-cloudfront-function-url-origin-access-control
 /**
@@ -1369,12 +1389,32 @@ try {
           },
         },
         // Nothing but this Distribution may invoke the Function URL, which is
-        // what the condition on the Distribution's ARN says.
-        InvokeFromCloudFront: {
+        // what the condition on the Distribution's ARN says. Reaching the URL
+        // takes both actions, so leaving either one out is a 403.
+        InvokeFunctionUrlFromCloudFront: {
           Type: "AWS::Lambda::Permission",
           Properties: {
             FunctionName: { "Fn::GetAtt": ["GreeterFunction", "Arn"] },
             Action: "lambda:InvokeFunctionUrl",
+            Principal: "cloudfront.amazonaws.com",
+            SourceArn: {
+              "Fn::Join": [
+                "",
+                [
+                  "arn:aws:cloudfront::",
+                  { Ref: "AWS::AccountId" },
+                  ":distribution/",
+                  { Ref: "GreeterDistribution" },
+                ],
+              ],
+            },
+          },
+        },
+        InvokeFunctionFromCloudFront: {
+          Type: "AWS::Lambda::Permission",
+          Properties: {
+            FunctionName: { "Fn::GetAtt": ["GreeterFunction", "Arn"] },
+            Action: "lambda:InvokeFunction",
             Principal: "cloudfront.amazonaws.com",
             SourceArn: {
               "Fn::Join": [

--- a/docs/services/cloudfront/sim-cloudfront-function-url-origin-access-control.example.ts
+++ b/docs/services/cloudfront/sim-cloudfront-function-url-origin-access-control.example.ts
@@ -78,12 +78,32 @@ try {
           },
         },
         // Nothing but this Distribution may invoke the Function URL, which is
-        // what the condition on the Distribution's ARN says.
-        InvokeFromCloudFront: {
+        // what the condition on the Distribution's ARN says. Reaching the URL
+        // takes both actions, so leaving either one out is a 403.
+        InvokeFunctionUrlFromCloudFront: {
           Type: "AWS::Lambda::Permission",
           Properties: {
             FunctionName: { "Fn::GetAtt": ["GreeterFunction", "Arn"] },
             Action: "lambda:InvokeFunctionUrl",
+            Principal: "cloudfront.amazonaws.com",
+            SourceArn: {
+              "Fn::Join": [
+                "",
+                [
+                  "arn:aws:cloudfront::",
+                  { Ref: "AWS::AccountId" },
+                  ":distribution/",
+                  { Ref: "GreeterDistribution" },
+                ],
+              ],
+            },
+          },
+        },
+        InvokeFunctionFromCloudFront: {
+          Type: "AWS::Lambda::Permission",
+          Properties: {
+            FunctionName: { "Fn::GetAtt": ["GreeterFunction", "Arn"] },
+            Action: "lambda:InvokeFunction",
             Principal: "cloudfront.amazonaws.com",
             SourceArn: {
               "Fn::Join": [

--- a/docs/services/lambda/README.md
+++ b/docs/services/lambda/README.md
@@ -1156,6 +1156,11 @@ origin access control, so a Function URL behind a Distribution runs for that Dis
 refuses everything else. See
 [origin access controls](../cloudfront/README.md#origin-access-controls) in the CloudFront docs.
 
+CloudFront is the exception to the two actions being separate. A request from
+`cloudfront.amazonaws.com` is authorized against `lambda:InvokeFunctionUrl` and
+`lambda:InvokeFunction`, and needs a grant for both, which is what real Lambda asks an origin access
+control for. A caller signing its own request still needs only `lambda:InvokeFunctionUrl`.
+
 An `AWS_IAM` invocation carries its caller into the event as
 `requestContext.authorizer.iam`, which is the part a handler reads. The `authorizer` block is absent
 for a `NONE` invocation, as it is on real AWS, and `requestContext.accountId` is the caller's Account
@@ -1948,7 +1953,8 @@ Sim Lambda currently supports:
 - Function URLs, created with `CreateFunctionUrlConfigCommand` and served over HTTP on localhost
   with `serveSimAws`
 - `AuthType: "AWS_IAM"` Function URLs, authorizing `lambda:InvokeFunctionUrl` against the caller
-  resolved from the request
+  resolved from the request, and `lambda:InvokeFunction` as well for a CloudFront origin access
+  control
 - `AddPermissionCommand`, `RemovePermissionCommand` and `GetPolicyCommand`, for resource-based
   policies evaluated alongside identity policies
 - SQS and DynamoDB stream event source mappings, created with `CreateEventSourceMappingCommand` and

--- a/src/service/cloudformation/cdk/cloudfront/sim-cdk-cf-function-url-oac.loc.test.ts
+++ b/src/service/cloudformation/cdk/cloudfront/sim-cdk-cf-function-url-oac.loc.test.ts
@@ -23,23 +23,36 @@ exports.handler = async () => ({
 `;
 
 /**
- * Slower local integration test. Calls the real CDK CLI to synth the output
- * template file and deploys the synthesized Function URL, origin access control,
- * Distribution and Lambda permission through sim CloudFormation.
+ * The grant CDK does not write.
  *
- * This is the shape `origins.FunctionUrlOrigin.withOriginAccessControl()` has,
- * and the only way to put a Function URL behind a Distribution without leaving
- * the Function URL open to anyone who finds its endpoint.
+ * `FunctionUrlOrigin.withOriginAccessControl()` writes one `CfnPermission`,
+ * for `lambda:InvokeFunctionUrl`. Reaching the URL also takes
+ * `lambda:InvokeFunction` for the same principal and the same Distribution, so
+ * a CDK app has to add this itself.
  */
-describe("Sim CDK CloudFront Function URL origin access control local integration", () => {
-  it("serves an AWS_IAM Function URL through a Distribution CDK gave an origin access control", async () => {
-    // Given a CDK stack whose Distribution reaches a private Function URL with
-    // an origin access control, which writes the invoke permission granting
-    // CloudFront.
-    const cdkProject = new TestCdkProject();
+const invokeFunctionGrantSource = `
+greeterFunction.addPermission("InvokeFunctionFromCloudFront", {
+  principal: new iam.ServicePrincipal("cloudfront.amazonaws.com"),
+  action: "lambda:InvokeFunction",
+  sourceArn: cdk.Fn.join("", [
+    "arn:",
+    cdk.Aws.PARTITION,
+    ":cloudfront::",
+    cdk.Aws.ACCOUNT_ID,
+    ":distribution/",
+    distribution.distributionId,
+  ]),
+});
+`;
 
-    await cdkProject.writeCdkAppFile(`
+/**
+ * A CDK app putting a private Function URL behind a Distribution, with
+ * whatever the test adds after the Distribution exists.
+ */
+function cdkAppSource(afterDistribution: string): string {
+  return `
 import * as cdk from "aws-cdk-lib";
+import * as iam from "aws-cdk-lib/aws-iam";
 import * as lambda from "aws-cdk-lib/aws-lambda";
 import * as cloudfront from "aws-cdk-lib/aws-cloudfront";
 import * as origins from "aws-cdk-lib/aws-cloudfront-origins";
@@ -66,38 +79,71 @@ const distribution = new cloudfront.Distribution(stack, "SiteDistribution", {
   },
 });
 
+${afterDistribution}
+
 new cdk.CfnOutput(stack, "DistributionId", {
   value: distribution.distributionId,
 });
 
 app.synth();
-`);
+`;
+}
 
-    // And the CDK app is synthesized to a CloudFormation template.
-    const cdkOutDirectory = await cdkProject.synth();
+/**
+ * Synth the app, deploy it through sim CloudFormation and fetch a path through
+ * the Distribution it created.
+ */
+async function fetchThroughCdkDistribution(
+  afterDistribution: string,
+): Promise<Response> {
+  const cdkProject = new TestCdkProject();
+  await cdkProject.writeCdkAppFile(cdkAppSource(afterDistribution));
+  const cdkOutDirectory = await cdkProject.synth();
 
-    // When the synthesized template is deployed through sim CloudFormation.
-    const simAws = new SimAws();
-    const stack = await simAws
-      .cloudFormation()
-      .deployTemplateFile(
-        path.join(cdkOutDirectory, "TestStack.template.json"),
-      );
+  const simAws = new SimAws();
+  const stack = await simAws
+    .cloudFormation()
+    .deployTemplateFile(path.join(cdkOutDirectory, "TestStack.template.json"));
 
-    await stack.waitForDeployComplete();
+  await stack.waitForDeployComplete();
 
-    const distributionId = stack.outputs.get("DistributionId")?.value;
-    assertNonNullable(distributionId);
+  const distributionId = stack.outputs.get("DistributionId")?.value;
+  assertNonNullable(distributionId);
 
-    const response = await simCfSiteRequest(
-      simAws,
-      distributionId as string,
-      "/greeting",
+  return await simCfSiteRequest(simAws, distributionId as string, "/greeting");
+}
+
+/**
+ * Slower local integration test. Calls the real CDK CLI to synth the output
+ * template file and deploys the synthesized Function URL, origin access control,
+ * Distribution and Lambda permission through sim CloudFormation.
+ *
+ * This is the shape `origins.FunctionUrlOrigin.withOriginAccessControl()` has,
+ * and the only way to put a Function URL behind a Distribution without leaving
+ * the Function URL open to anyone who finds its endpoint.
+ */
+describe("Sim CDK CloudFront Function URL origin access control local integration", () => {
+  it("serves an AWS_IAM Function URL through a Distribution once both grants are written", async () => {
+    // Given the CDK stack for a Function URL Origin with an origin access
+    // control, plus the `lambda:InvokeFunction` grant CDK leaves out.
+    const response = await fetchThroughCdkDistribution(
+      invokeFunctionGrantSource,
     );
 
-    // Then the permission CDK wrote admits the Origin request and the handler
-    // runs, with nothing but the Distribution able to invoke the URL.
+    // Then the Origin request is admitted and the handler runs, with nothing
+    // but the Distribution able to invoke the URL.
     assertResponseStatus(response, 200, await describeResponse(response));
     assertIdentical(await response.text(), "Hello from behind CloudFront");
+  });
+
+  it("is refused when only the permission CDK writes is deployed", async () => {
+    // Given the same stack with nothing added, so the only permission is the
+    // `lambda:InvokeFunctionUrl` one CDK writes beside the Distribution.
+    const response = await fetchThroughCdkDistribution("");
+
+    // Then real Lambda refuses the Origin request, and so does this: the
+    // Stack deploys clean and the site answers 403 with no log stream to show
+    // for it, which is what makes the mistake so slow to find.
+    assertResponseStatus(response, 403, await describeResponse(response));
   });
 });

--- a/src/service/cloudfront/README.md
+++ b/src/service/cloudfront/README.md
@@ -272,10 +272,11 @@ conditioned on. A `never` signing behaviour reads anonymously, as an Origin with
 different way. A custom Origin request leaves CloudFront over the simulated HTTP boundary, so it
 carries them as the `x-sim-aws-caller` and `x-sim-aws-source-arn`/`x-sim-aws-source-account` control
 headers, which is how anything else calling into simulated AWS in process states who it is. That is
-what an `AWS_IAM` Function URL evaluates its `lambda:InvokeFunctionUrl` permission for
-`cloudfront.amazonaws.com` against, so a template omitting the permission answers 403 rather than
-being admitted anyway. The headers are stripped at the boundary, so the function's event shows the
-request its viewer sent.
+what an `AWS_IAM` Function URL evaluates its permissions for `cloudfront.amazonaws.com` against, so
+a template omitting one answers 403 rather than being admitted anyway. An origin access control
+takes two of them, `lambda:InvokeFunctionUrl` and `lambda:InvokeFunction`, which is what real Lambda
+asks for and what `SimLambdaUrlAuthorizer` requires of this principal. The headers are stripped at
+the boundary, so the function's event shows the request its viewer sent.
 
 A viewer's own control headers are dropped from the Origin request before the Origin's are applied,
 so who the Origin request is from is the Origin's decision and never the viewer's. The HTTP boundary

--- a/src/service/cloudfront/origin/custom/sim-cf-custom-origin-oac.iso.test.ts
+++ b/src/service/cloudfront/origin/custom/sim-cf-custom-origin-oac.iso.test.ts
@@ -1,5 +1,6 @@
 import {
   assertIdentical,
+  assertObjectEquals,
   assertResponseStatus,
   assertTypeString,
   describeResponse,
@@ -64,8 +65,8 @@ async function fetchThroughDistribution(
 
 describe("Simulated CloudFront custom Origin with an origin access control", () => {
   it("reaches an AWS_IAM Function URL as the CloudFront service principal", async () => {
-    // Given the Stack CDK synthesizes for a Function URL Origin behind an
-    // origin access control.
+    // Given a Stack putting a Function URL behind an origin access control,
+    // granting CloudFront both of the actions that takes.
     const response = await fetchThroughDistribution(
       simCfFunctionUrlOriginTemplateFactory.make({}),
     );
@@ -74,6 +75,39 @@ describe("Simulated CloudFront custom Origin with an origin access control", () 
     // get past the auth type to do.
     assertResponseStatus(response, 200, await describeResponse(response));
     assertIdentical(await response.text(), "Hello from behind CloudFront");
+  });
+
+  it("is refused when only the Function URL action is granted", async () => {
+    // Given a permission granting `lambda:InvokeFunctionUrl` and nothing else,
+    // which is what CDK writes and what reads as correctly configured
+    // everywhere a deployment can be inspected.
+    const response = await fetchThroughDistribution(
+      simCfFunctionUrlOriginTemplateFactory.make({
+        permittedActions: ["lambda:InvokeFunctionUrl"],
+      }),
+    );
+
+    // Then the Function URL refuses the Origin request, as real Lambda does
+    // without `lambda:InvokeFunction` as well, and says so in the body that is
+    // the only diagnostic a refused request leaves behind.
+    assertResponseStatus(response, 403, await describeResponse(response));
+    assertObjectEquals(await response.json(), {
+      Message:
+        "Forbidden. For troubleshooting Function URL authorization issues, " +
+        "see: https://docs.aws.amazon.com/lambda/latest/dg/urls-auth.html",
+    });
+  });
+
+  it("is refused when only the Invoke action is granted", async () => {
+    // Given the other half of the pair on its own.
+    const response = await fetchThroughDistribution(
+      simCfFunctionUrlOriginTemplateFactory.make({
+        permittedActions: ["lambda:InvokeFunction"],
+      }),
+    );
+
+    // Then the Function URL refuses it too: reaching the URL takes both.
+    assertResponseStatus(response, 403, await describeResponse(response));
   });
 
   it("is refused when nothing granted CloudFront the Function URL", async () => {

--- a/src/service/cloudfront/origin/custom/sim-cf-function-url-origin-fragments.ts
+++ b/src/service/cloudfront/origin/custom/sim-cf-function-url-origin-fragments.ts
@@ -4,10 +4,10 @@ import type {
 } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
 
 /**
- * What a test asks for when it wants the template CDK synthesizes for
- * `origins.FunctionUrlOrigin.withOriginAccessControl()`.
+ * What a test asks for when it wants a working version of the template
+ * `origins.FunctionUrlOrigin.withOriginAccessControl()` synthesizes.
  *
- * Five Resources stand between a test and a Function URL served through a
+ * Six Resources stand between a test and a Function URL served through a
  * Distribution, and each test about that shape is about one of them being
  * wrong, so each field here is one thing a template can get wrong on its own.
  */
@@ -20,10 +20,16 @@ export interface SimCfFunctionUrlOriginTemplateInput {
    */
   readonly originAccessControl: boolean;
   /**
-   * Whether the template grants CloudFront the Function URL, which CDK always
-   * does alongside the Distribution.
+   * Whether the template grants CloudFront the Function URL at all.
    */
   readonly permitted: boolean;
+  /**
+   * The actions the grant covers.
+   *
+   * Reaching a Function URL through an origin access control takes both of
+   * them, so a template granting one is one that deploys and then answers 403.
+   */
+  readonly permittedActions: readonly string[];
   /** The Distribution the permission is granted for. */
   readonly permissionSourceArn: SimCfnTemplateValue;
 }
@@ -31,10 +37,10 @@ export interface SimCfFunctionUrlOriginTemplateInput {
 /**
  * The parts of the template a template can leave out.
  *
- * Each is a Resource, or a property of one, that CDK always writes and that a
- * hand-written template can forget. The origin access control contributes two,
- * which are both there or both absent, since an Origin naming one nothing
- * created would be refused rather than reached.
+ * Each is a Resource, or a property of one, that a template can forget. The
+ * origin access control contributes two, which are both there or both absent,
+ * since an Origin naming one nothing created would be refused rather than
+ * reached. The permission contributes one Resource per action it grants.
  */
 export interface SimCfFunctionUrlOriginParts {
   readonly originAccessControl: SimCfnTemplateValueRecord;
@@ -65,20 +71,36 @@ export function simCfFunctionUrlOriginParts(
     originAccessControlId: included(input.originAccessControl, {
       OriginAccessControlId: { Ref: "SiteOac" },
     }),
-    // The permission CDK writes beside the Distribution, letting CloudFront
-    // invoke the Function URL for that Distribution alone.
-    invokePermission: included(input.permitted, {
-      InvokeFromCloudFront: {
+    // The permissions letting CloudFront invoke the Function URL for this
+    // Distribution alone. AWS takes one per action, and both of them.
+    invokePermission: included(input.permitted, invokePermissions(input)),
+  };
+}
+
+/**
+ * One `AWS::Lambda::Permission` per granted action.
+ *
+ * The statement id is derived from the action, so a template granting both
+ * carries two Resources rather than one overwriting the other, which is how
+ * the two `aws lambda add-permission` calls in the AWS documentation land.
+ */
+function invokePermissions(
+  input: SimCfFunctionUrlOriginTemplateInput,
+): SimCfnTemplateValueRecord {
+  return Object.fromEntries(
+    input.permittedActions.map((action) => [
+      `${action.replace("lambda:", "")}FromCloudFront`,
+      {
         Type: "AWS::Lambda::Permission",
         Properties: {
           FunctionName: { "Fn::GetAtt": ["GreeterFunction", "Arn"] },
-          Action: "lambda:InvokeFunctionUrl",
+          Action: action,
           Principal: "cloudfront.amazonaws.com",
           SourceArn: input.permissionSourceArn,
         },
       },
-    }),
-  };
+    ]),
+  );
 }
 
 /**

--- a/src/service/cloudfront/origin/custom/sim-cf-function-url-origin-template.factory.ts
+++ b/src/service/cloudfront/origin/custom/sim-cf-function-url-origin-template.factory.ts
@@ -56,6 +56,7 @@ export const simCfFunctionUrlOriginTemplateFactory = new MappedFactory<
     signingBehavior: "always",
     originAccessControl: true,
     permitted: true,
+    permittedActions: ["lambda:InvokeFunctionUrl", "lambda:InvokeFunction"],
     permissionSourceArn: simCfDistributionArn,
   }),
   (input) => ({

--- a/src/service/lambda/README.md
+++ b/src/service/lambda/README.md
@@ -427,6 +427,14 @@ Invoke command uses, as it is on AWS. The caller is passed to IAM as a `resolved
 assumed-role session is judged against the Role behind it; a request that carried no identity is
 anonymous, owns no policies, and is denied by the same evaluation.
 
+`sim-lambda-url-invoke-actions.ts` holds the one exception to that split.
+`cloudfront.amazonaws.com`, which is how a CloudFront origin access control reaches a Function URL
+Origin, has to be allowed `lambda:InvokeFunction` on top of the URL action, and is refused without
+it. That is real Lambda's rule, and CDK's `FunctionUrlOrigin.withOriginAccessControl` does not write
+the second grant, so a CDK app that has not added it deploys clean and then answers 403 with no log
+stream to look at. The refusal body is real Lambda's wording, since it is the only diagnostic such a
+deployment gets.
+
 Authorization is evaluated by the IAM of the Account that owns the function, against two policy
 sources: identity policies belonging to the caller, and the function's own resource policy, passed
 in by `command/authorize/sim-lambda-resource-policies.ts`. For a caller from another Account, IAM
@@ -441,7 +449,8 @@ puts `requestContext.authorizer.iam` there and leaves it out for `NONE`
 Role: who invoked it and what it runs as are separate questions.
 
 The endpoint's own error responses (403 for a denied caller, 404 for an unknown or deleted URL, 502
-for a handler error) are AWS-shaped JSON documents, though the exact wording is an approximation.
+for a handler error) are AWS-shaped JSON documents. The 403 body is real Lambda's wording; the other
+two are approximations.
 
 ### CloudFormation
 

--- a/src/service/lambda/serve/auth/sim-lambda-url-authorizer.ts
+++ b/src/service/lambda/serve/auth/sim-lambda-url-authorizer.ts
@@ -9,19 +9,14 @@ import {
   simLambdaSourceAccountConditionKey,
   simLambdaSourceArnConditionKey,
 } from "../../function/policy/sim-lambda-permission.js";
+import {
+  simLambdaInvokeFunctionAction,
+  simLambdaInvokeFunctionUrlAction,
+  simLambdaUrlRequiresInvokeFunction,
+} from "./sim-lambda-url-invoke-actions.js";
 import type { SimAwsRequestSource } from "../../../iam/request/sim-aws-request-source.js";
 import type { SimLambdaFunction } from "../../function/sim-lambda-function.js";
 import type { SimLambdaFunctionUrl } from "../../function/url/sim-lambda-function-url.js";
-
-/**
- * The IAM action a Function URL invocation is authorized against.
- *
- * This is deliberately not `lambda:InvokeFunction`, which is what the Invoke
- * API maps to. Real AWS separates the two so a policy can grant the HTTP
- * endpoint without granting the SDK operation, and a test asserting on that
- * distinction should see it hold here.
- */
-export const simLambdaInvokeFunctionUrlAction = "lambda:InvokeFunctionUrl";
 
 interface SimLambdaUrlAuthorizerProperties {
   readonly iam: SimIamInterServiceAuthZ;
@@ -57,7 +52,40 @@ export class SimLambdaUrlAuthorizer {
   }
 
   /**
-   * Evaluate `lambda:InvokeFunctionUrl` for a caller against a Function URL.
+   * Evaluate the actions reaching this Function URL takes.
+   *
+   * `lambda:InvokeFunctionUrl` is the one a caller signing its own request
+   * needs. CloudFront reaching the URL through an origin access control needs
+   * `lambda:InvokeFunction` on top of it, so a resource policy granting only
+   * the URL action is refused here as real Lambda refuses it.
+   *
+   * Every action is judged against the same request, so a permission
+   * conditioned on the Distribution applies to both.
+   */
+  authorize(
+    input: SimLambdaUrlAuthorizationInput,
+  ): SimIamAuthorizationDecision {
+    const urlDecision = this.decide(simLambdaInvokeFunctionUrlAction, input);
+
+    if (urlDecision.isDenied) {
+      return urlDecision;
+    }
+
+    if (!simLambdaUrlRequiresInvokeFunction(input.caller)) {
+      return urlDecision;
+    }
+
+    const invokeDecision = this.decide(simLambdaInvokeFunctionAction, input);
+
+    if (invokeDecision.isDenied) {
+      return invokeDecision;
+    }
+
+    return urlDecision;
+  }
+
+  /**
+   * Evaluate one action for a caller against a Function URL.
    *
    * The URL's auth type is supplied as `lambda:FunctionUrlAuthType`, which is
    * what a grant conditions on in practice: a permission granted for `AWS_IAM`
@@ -69,13 +97,14 @@ export class SimLambdaUrlAuthorizer {
    * no source supplies neither, so a permission conditioned on one does not
    * match rather than matching anything.
    */
-  authorize(
+  private decide(
+    action: string,
     input: SimLambdaUrlAuthorizationInput,
   ): SimIamAuthorizationDecision {
     const { source } = input;
 
     return this.iam.authorize({
-      action: simLambdaInvokeFunctionUrlAction,
+      action,
       resource: input.simFunction.arn,
       caller: input.caller,
       resourcePolicies: simLambdaResourcePolicies(input.simFunction),

--- a/src/service/lambda/serve/auth/sim-lambda-url-invoke-actions.iso.test.ts
+++ b/src/service/lambda/serve/auth/sim-lambda-url-invoke-actions.iso.test.ts
@@ -1,0 +1,68 @@
+import { assertFalse, assertTrue } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { simLambdaUrlRequiresInvokeFunction } from "./sim-lambda-url-invoke-actions.js";
+
+const cloudFrontPrincipal = {
+  kind: "service",
+  service: "cloudfront.amazonaws.com",
+} as const;
+
+describe("Actions a sim Lambda Function URL request is authorized against", () => {
+  it("takes lambda:InvokeFunction as well for CloudFront", () => {
+    // Given the caller an origin access control reaches a Function URL as,
+    // resolved at the HTTP boundary the way the controller passes it on.
+    const caller = {
+      kind: "resolved",
+      principal: cloudFrontPrincipal,
+      identityPolicyPrincipal: cloudFrontPrincipal,
+    } as const;
+
+    // Then the URL action on its own is not enough, as it is not on AWS.
+    assertTrue(simLambdaUrlRequiresInvokeFunction(caller));
+  });
+
+  it("takes lambda:InvokeFunction as well for a bare CloudFront principal", () => {
+    // Given the same service principal named directly rather than resolved.
+    assertTrue(simLambdaUrlRequiresInvokeFunction(cloudFrontPrincipal));
+  });
+
+  it("takes only the URL action for another service", () => {
+    // Given a service principal that is not CloudFront, which reaches a
+    // function through Invoke rather than through its URL.
+    const caller = {
+      kind: "service",
+      service: "s3.amazonaws.com",
+    } as const;
+
+    // Then nothing beyond the URL action is asked for.
+    assertFalse(simLambdaUrlRequiresInvokeFunction(caller));
+  });
+
+  it("takes only the URL action for a caller signing its own request", () => {
+    // Given a Role reaching the Function URL with a signature of its own.
+    const caller = {
+      kind: "arn",
+      arn: "arn:aws:iam::111111111111:role/ReaderRole",
+    } as const;
+
+    // Then the distinction between the two actions holds: a policy can grant
+    // the HTTP endpoint without granting the SDK operation.
+    assertFalse(simLambdaUrlRequiresInvokeFunction(caller));
+  });
+
+  it("takes only the URL action for credentials", () => {
+    // Given credentials, which name a principal only once IAM has
+    // authenticated them, and which no origin access control presents.
+    const caller = {
+      kind: "credentials",
+      credentials: {
+        accessKeyId: "AKIAEXAMPLE",
+        secretAccessKey: "example-secret",
+      },
+    } as const;
+
+    // Then the caller is judged on the URL action alone.
+    assertFalse(simLambdaUrlRequiresInvokeFunction(caller));
+  });
+});

--- a/src/service/lambda/serve/auth/sim-lambda-url-invoke-actions.ts
+++ b/src/service/lambda/serve/auth/sim-lambda-url-invoke-actions.ts
@@ -1,0 +1,77 @@
+import type {
+  SimAwsCaller,
+  SimAwsPrincipal,
+} from "../../../aws/caller/sim-aws-caller.js";
+
+/**
+ * The IAM action a Function URL invocation is authorized against.
+ *
+ * This is deliberately not `lambda:InvokeFunction`, which is what the Invoke
+ * API maps to. Real AWS separates the two so a policy can grant the HTTP
+ * endpoint without granting the SDK operation, and a test asserting on that
+ * distinction should see it hold here.
+ *
+ * That is the whole rule for a caller signing its own request. It is not the
+ * whole rule for a CloudFront origin access control, which needs
+ * `lambda:InvokeFunction` as well.
+ */
+export const simLambdaInvokeFunctionUrlAction = "lambda:InvokeFunctionUrl";
+
+/**
+ * The action the Invoke API maps to, which reaching a Function URL through a
+ * CloudFront origin access control takes on top of the URL action.
+ *
+ * Real Lambda answers an origin access control granted only the URL action
+ * with 403 and never runs the handler. Both grants go to the CloudFront
+ * service principal and both are conditioned on the Distribution, as described
+ * in [Restrict access to an AWS Lambda function URL
+ * origin](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-restricting-access-to-lambda.html).
+ */
+export const simLambdaInvokeFunctionAction = "lambda:InvokeFunction";
+
+/**
+ * The service principal CloudFront reaches an Origin as.
+ *
+ * Named here rather than imported from simulated CloudFront, so that simulated
+ * Lambda goes on depending on nothing in that service. What real Lambda wants
+ * the second action for is the principal, whatever is simulating it.
+ */
+const cloudFrontServicePrincipal = "cloudfront.amazonaws.com";
+
+/**
+ * Whether reaching this Function URL also takes `lambda:InvokeFunction`.
+ *
+ * True for CloudFront, and false for anything else, which is the distinction
+ * real Lambda draws: a caller signing the request itself needs the URL action
+ * alone.
+ */
+export function simLambdaUrlRequiresInvokeFunction(
+  caller: SimAwsCaller,
+): boolean {
+  const principal = callerPrincipal(caller);
+
+  if (principal.kind !== "service") {
+    return false;
+  }
+
+  return principal.service === cloudFrontServicePrincipal;
+}
+
+/**
+ * The principal a caller names.
+ *
+ * Credentials name one too, but only once IAM has authenticated them, and
+ * nothing reaching a Function URL as a service principal presents any: an
+ * origin access control states who it is at the boundary instead.
+ */
+function callerPrincipal(caller: SimAwsCaller): SimAwsPrincipal {
+  if (caller.kind === "resolved") {
+    return caller.principal;
+  }
+
+  if (caller.kind === "credentials") {
+    return { kind: "anonymous" };
+  }
+
+  return caller;
+}

--- a/src/service/lambda/serve/response/sim-lambda-url-error-response.ts
+++ b/src/service/lambda/serve/response/sim-lambda-url-error-response.ts
@@ -1,4 +1,15 @@
 /**
+ * What real Lambda says when it refuses a Function URL request.
+ *
+ * A refused request never reaches the handler and writes no log stream, so
+ * this body is the only thing a deployment has to go on. The wording is real
+ * Lambda's, down to the link, because that is what someone will be reading.
+ */
+export const simLambdaUrlForbiddenMessage =
+  "Forbidden. For troubleshooting Function URL authorization issues, see: " +
+  "https://docs.aws.amazon.com/lambda/latest/dg/urls-auth.html";
+
+/**
  * The error responses a Function URL endpoint returns itself, before or
  * instead of the function producing one.
  *
@@ -15,10 +26,10 @@ export class SimLambdaUrlErrorResponse {
   }
 
   /**
-   * The Function URL requires authentication the simulator cannot verify.
+   * The caller is not allowed to invoke this Function URL.
    */
   forbidden(): Response {
-    return this.jsonResponse(403, "Forbidden");
+    return this.jsonResponse(403, simLambdaUrlForbiddenMessage);
   }
 
   /**

--- a/src/service/lambda/serve/sim-lambda-url-iam-auth.iso.test.ts
+++ b/src/service/lambda/serve/sim-lambda-url-iam-auth.iso.test.ts
@@ -15,6 +15,7 @@ import { SimAwsLocalUrl } from "../../../serve/http/url/sim-aws-local-url.js";
 import { simIamPolicyDocumentFactory } from "../../iam/policy/sim-iam-policy-document.factory.js";
 import { SimAws } from "../../aws/sim-aws.js";
 import { makeLambdaZipFileInput } from "../function/code/lambda-zip-file-input.js";
+import { simLambdaUrlForbiddenMessage } from "./response/sim-lambda-url-error-response.js";
 import type { SimPayload2RequestContext } from "../../../serve/payload-2/sim-payload-2-event.type.js";
 import type { SimLambdaFunctionUrlEvent } from "./event/sim-lambda-url-event.type.js";
 
@@ -137,7 +138,9 @@ describe("Invoking an AWS_IAM Lambda Function URL as a signed caller", () => {
     // Then a sound signature is not enough: the request is authenticated but
     // not authorized
     expect(response.status).toBe(403);
-    expect(await response.json()).toStrictEqual({ Message: "Forbidden" });
+    expect(await response.json()).toStrictEqual({
+      Message: simLambdaUrlForbiddenMessage,
+    });
   });
 
   it("does not accept lambda:InvokeFunction as permission for the URL", async () => {

--- a/src/service/lambda/serve/sim-lambda-url-serve-errors.iso.test.ts
+++ b/src/service/lambda/serve/sim-lambda-url-serve-errors.iso.test.ts
@@ -10,6 +10,7 @@ import { SimAwsHttp } from "../../../serve/http/sim-aws-http.js";
 import { SimAwsLocalUrl } from "../../../serve/http/url/sim-aws-local-url.js";
 import { SimAws } from "../../aws/sim-aws.js";
 import { makeLambdaZipFileInput } from "../function/code/lambda-zip-file-input.js";
+import { simLambdaUrlForbiddenMessage } from "./response/sim-lambda-url-error-response.js";
 
 function localUrl(functionUrl: string): string {
   return new SimAwsLocalUrl({ input: functionUrl }).toString();
@@ -125,7 +126,9 @@ describe("Serving sim Lambda Function URL failures", () => {
 
     // Then the request is forbidden, as an unsigned request is on AWS.
     assertIdentical(response.status, 403);
-    assertObjectEquals(await response.json(), { Message: "Forbidden" });
+    assertObjectEquals(await response.json(), {
+      Message: simLambdaUrlForbiddenMessage,
+    });
   });
 
   it("returns 502 when the handler throws", async () => {


### PR DESCRIPTION
Reaching a Function URL through a CloudFront origin access control takes two resource policy statements on real AWS, `lambda:InvokeFunctionUrl` and `lambda:InvokeFunction`, both granting `cloudfront.amazonaws.com` for the Distribution. Yulin authorized only the first, so a template that real Lambda answers with 403 was served a 200 here. A request from the CloudFront service principal is now judged on both actions, while a caller signing its own request still needs only the URL action, and the refusal carries the wording real Lambda uses, since a refused request runs no handler and leaves no log stream to look at. CDK's `FunctionUrlOrigin.withOriginAccessControl` writes only the URL grant, so the local CDK test now covers both its output on its own, which is refused, and the same app with the second grant added.

Resolves https://github.com/KensioSoftware/yulin/issues/598

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * CloudFront access to private Lambda Function URLs now correctly requires both `lambda:InvokeFunctionUrl` and `lambda:InvokeFunction` permissions.
  * Requests missing either permission return a clear 403 authorization response instead of incorrectly reaching the function.

* **Documentation**
  * Updated CloudFront and Lambda guidance, examples, and authorization requirements.
  * Clarified that direct signed callers need only the Function URL permission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->