### PR TITLE
feat: accept MfaConfiguration on a user pool

### DIFF
--- a/docs/services/cognito/README.md
+++ b/docs/services/cognito/README.md
@@ -2950,6 +2950,8 @@ Current documented limitations:
 - `SetUserPoolMfaConfig` accepts `SoftwareTokenMfaConfiguration` alone. `SmsMfaConfiguration` and
   `EmailMfaConfiguration` are refused, because a pool here has neither the `SmsConfiguration` nor
   the `EmailConfiguration` real Cognito wants before it will deliver either message.
+  `WebAuthnConfiguration` is refused because a passkey is presented through the `USER_AUTH` flow,
+  which is refused as a flow of its own.
 - `UpdateUserPool` replaces a pool's settings rather than merging into them, as real Cognito does, so
   a setting the request leaves out goes back to the default `CreateUserPool` would have given it. It
   covers the settings this simulation models: `Policies.PasswordPolicy`, `DeletionProtection`,

--- a/docs/services/cognito/README.md
+++ b/docs/services/cognito/README.md
@@ -2242,12 +2242,15 @@ the secret with `DescribeUserPoolClient`, which reports it here as it does on re
 The properties each type reads are the ones this simulation models:
 
 - `AWS::Cognito::UserPool`: `UserPoolName`, `Policies`, `DeletionProtection`, `LambdaConfig`,
-  `AdminCreateUserConfig`, `AutoVerifiedAttributes`, `MfaConfiguration`, `UserPoolTier`,
-  `AccountRecoverySetting`, `EmailVerificationMessage`, `EmailVerificationSubject`,
+  `AdminCreateUserConfig`, `AutoVerifiedAttributes`, `MfaConfiguration`, `EnabledMfas`,
+  `UserPoolTier`, `AccountRecoverySetting`, `EmailVerificationMessage`, `EmailVerificationSubject`,
   `SmsVerificationMessage` and `VerificationMessageTemplate`. `LambdaConfig` is read a trigger at a
   time, so a template naming a trigger this simulation runs deploys and one naming a trigger it
-  does not fails the stack. The last six are accepted at one value each and refused at any other,
-  as `CreateUserPool` refuses them.
+  does not fails the stack. `MfaConfiguration` and `EnabledMfas` are deployed in a
+  `SetUserPoolMfaConfig` call once the pool exists, which is how real CloudFormation deploys them
+  and why a stack declaring MFA needs `cognito-idp:SetUserPoolMfaConfig` on its execution role. A
+  template asking for neither makes no such call. The last five are accepted at one value each and
+  refused at any other, as `CreateUserPool` refuses them.
 - `AWS::Cognito::UserPoolClient`: `UserPoolId`, `ClientName`, `GenerateSecret`, `ExplicitAuthFlows`,
   `PreventUserExistenceErrors`, `AccessTokenValidity`, `IdTokenValidity`, `RefreshTokenValidity`,
   `TokenValidityUnits`, `AllowedOAuthFlowsUserPoolClient`, `AllowedOAuthFlows`,
@@ -2639,12 +2642,121 @@ Real Cognito wants an `UpdateUserPool` request deactivating the protection befor
 and so does this. Send an `UpdateUserPool` with `DeletionProtection: "INACTIVE"` first, then delete
 the pool.
 
+## Multi-factor authentication
+
+A pool can be created with an `MfaConfiguration` of `OFF`, `OPTIONAL` or `ON`, and reports back what
+it was asked for. `SetUserPoolMfaConfig` sets which factors are behind that setting, and
+`GetUserPoolMfaConfig` reads both back, as they do on real Cognito. `SOFTWARE_TOKEN_MFA` is the
+factor this simulation accepts. A second factor sent by SMS or by email is refused, because a pool
+here has neither the `SmsConfiguration` nor the `EmailConfiguration` real Cognito wants before it
+will deliver one.
+
+No sign-in is ever challenged for a second factor. A pool configured `OPTIONAL` challenges only the
+users that have registered a factor, and nothing here registers one, so a sign-in to such a pool
+hands out tokens as it does on real Cognito for a user that never set one up. That is what makes a
+pool declaring optional MFA testable: everything that is not MFA behaves as it would in a
+deployment.
+
+A pool configured `ON` is the one that differs. Real Cognito answers every sign-in to it with an MFA
+challenge, so `InitiateAuth`, `AdminInitiateAuth` and the new password challenge response are
+refused with `InvalidParameterException` where that challenge would have been, rather than handing
+out tokens a deployment would not.
+
+```typescript sim-cognito-mfa
+/**
+ * A user pool that offers multi-factor authentication.
+ */
+
+import {
+  ConfirmSignUpCommand,
+  CreateUserPoolClientCommand,
+  CreateUserPoolCommand,
+  DescribeUserPoolCommand,
+  GetUserPoolMfaConfigCommand,
+  InitiateAuthCommand,
+  SetUserPoolMfaConfigCommand,
+  SignUpCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+
+import { SimAws } from "@kensio/yulin";
+
+const cognito = new SimAws().cognitoIdentityProvider();
+
+const pool = await cognito.createUserPool(
+  new CreateUserPoolCommand({
+    PoolName: "myapp-users",
+    MfaConfiguration: "OPTIONAL",
+  }),
+);
+const userPoolId = pool.UserPool!.Id!;
+
+// Which factors the pool offers is set separately, as it is on real Cognito.
+await cognito.setUserPoolMfaConfig(
+  new SetUserPoolMfaConfigCommand({
+    UserPoolId: userPoolId,
+    MfaConfiguration: "OPTIONAL",
+    SoftwareTokenMfaConfiguration: { Enabled: true },
+  }),
+);
+
+const described = await cognito.describeUserPool(
+  new DescribeUserPoolCommand({ UserPoolId: userPoolId }),
+);
+
+console.log(described.UserPool?.MfaConfiguration); // "OPTIONAL"
+
+const mfa = await cognito.getUserPoolMfaConfig(
+  new GetUserPoolMfaConfigCommand({ UserPoolId: userPoolId }),
+);
+
+console.log(mfa.SoftwareTokenMfaConfiguration?.Enabled); // true
+
+// A user of the pool signs up and signs in with a password alone, because no
+// user here has registered a second factor.
+const appClient = await cognito.createUserPoolClient(
+  new CreateUserPoolClientCommand({
+    UserPoolId: userPoolId,
+    ClientName: "web",
+    ExplicitAuthFlows: ["ALLOW_USER_PASSWORD_AUTH"],
+  }),
+);
+const clientId = appClient.UserPoolClient!.ClientId!;
+
+await cognito.signUp(
+  new SignUpCommand({
+    ClientId: clientId,
+    Username: "alice",
+    Password: "Sup3rSecret!",
+  }),
+);
+
+await cognito.confirmSignUp(
+  new ConfirmSignUpCommand({
+    ClientId: clientId,
+    Username: "alice",
+    ConfirmationCode: cognito.userPool(userPoolId).confirmationCode("alice"),
+  }),
+);
+
+const signedIn = await cognito.initiateAuth(
+  new InitiateAuthCommand({
+    ClientId: clientId,
+    AuthFlow: "USER_PASSWORD_AUTH",
+    AuthParameters: { USERNAME: "alice", PASSWORD: "Sup3rSecret!" },
+  }),
+);
+
+console.log(typeof signedIn.AuthenticationResult?.AccessToken); // "string"
+```
+
 ## Available functionality
 
 Sim Cognito currently supports:
 
 - `CreateUserPoolCommand`, `DescribeUserPoolCommand`, `UpdateUserPoolCommand`,
   `DeleteUserPoolCommand` and `ListUserPoolsCommand`
+- `SetUserPoolMfaConfigCommand` and `GetUserPoolMfaConfigCommand`, which record what a pool offers
+  as a second factor without any sign-in being challenged for one
 - `CreateUserPoolClientCommand`, `DescribeUserPoolClientCommand`, `UpdateUserPoolClientCommand`,
   `DeleteUserPoolClientCommand` and `ListUserPoolClientsCommand`
 - `AdminCreateUserCommand`, `AdminGetUserCommand`, `AdminDeleteUserCommand`,
@@ -2723,7 +2835,8 @@ Current documented limitations:
   `USER_AUTH` choice-based sign-in, custom authentication and device tracking are not simulated, and
   an `AuthFlow` naming one of them is refused rather than run as a flow that is.
 - `NEW_PASSWORD_REQUIRED` is the only challenge issued, so MFA and custom challenges cannot be
-  reached. A `ChallengeName` this simulation does not issue is refused.
+  reached. A `ChallengeName` this simulation does not issue is refused, and a sign-in to a pool
+  whose `MfaConfiguration` is `ON` is refused where the MFA challenge would have been.
 - `GetTokensFromRefreshToken` and `RevokeToken` are not implemented, and `RefreshTokenRotation` is
   refused on an app client. Refreshing goes through `REFRESH_TOKEN_AUTH`, which issues no new
   refresh token.
@@ -2828,13 +2941,21 @@ Current documented limitations:
   implemented, so an attribute can be changed but not removed.
 - `EstimatedNumberOfUsers` is how many users the pool holds now. Real Cognito refreshes that number
   periodically rather than on each write, so it can lag there in a way it never does here.
-- MFA is not simulated, so `AdminGetUser` reports no `UserMFASettingList`, `PreferredMfaSetting` or
-  `MFAOptions`.
+- A pool records its `MfaConfiguration` and the factors behind it, and no sign-in is ever challenged
+  for a second factor. Nothing registers a factor for a user, so `AdminGetUser` reports no
+  `UserMFASettingList`, `PreferredMfaSetting` or `MFAOptions`, and `AssociateSoftwareToken`,
+  `VerifySoftwareToken`, `SetUserMFAPreference` and `AdminSetUserMFAPreference` are not implemented.
+  A sign-in to a pool configured `ON` is refused, because real Cognito answers every one of those
+  with a challenge.
+- `SetUserPoolMfaConfig` accepts `SoftwareTokenMfaConfiguration` alone. `SmsMfaConfiguration` and
+  `EmailMfaConfiguration` are refused, because a pool here has neither the `SmsConfiguration` nor
+  the `EmailConfiguration` real Cognito wants before it will deliver either message.
 - `UpdateUserPool` replaces a pool's settings rather than merging into them, as real Cognito does, so
   a setting the request leaves out goes back to the default `CreateUserPool` would have given it. It
   covers the settings this simulation models: `Policies.PasswordPolicy`, `DeletionProtection`,
-  `AdminCreateUserConfig.AllowAdminCreateUserOnly`, `AutoVerifiedAttributes`, `LambdaConfig` and the
-  verification wording.
+  `AdminCreateUserConfig.AllowAdminCreateUserOnly`, `AutoVerifiedAttributes`, `LambdaConfig`,
+  `MfaConfiguration` and the verification wording. An update carries no factor configuration, so the
+  factors a `SetUserPoolMfaConfig` request set are left alone, as real Cognito leaves them.
   `PoolName` is refused, so a pool cannot be renamed, and every input `CreateUserPool` refuses is
   refused here too, in the same words.
 - `UpdateUserPoolClient` replaces an app client's settings the same way, so a setting the request
@@ -2896,8 +3017,8 @@ Current documented limitations:
   `AliasAttributes`, `Schema`, `UsernameConfiguration`,
   `UserAttributeUpdateSettings`, `DeviceConfiguration`, `UserPoolAddOns`, `KeyConfiguration`,
   `IssuerConfiguration`, `UserPoolTags`, the email and SMS configurations, an
-  `SmsAuthenticationMessage`, an `MfaConfiguration` other than `OFF`, a `UserPoolTier` other than
-  `ESSENTIALS`, a `SignInPolicy`, and a `PasswordHistorySize`.
+  `SmsAuthenticationMessage`, a `UserPoolTier` other than `ESSENTIALS`, a `SignInPolicy`, and a
+  `PasswordHistorySize`.
 - `AccountRecoverySetting` is accepted at one value and refused at any other. Nothing here reads it,
   because there is no `ForgotPassword`. It is accepted so a CDK stack deploys, and reported back by
   `DescribeUserPool` so what the template declared stays visible. The accepted value is in
@@ -2964,7 +3085,7 @@ Current documented limitations:
   can fetch the keys they point at. A token's `iss` claim still names the real
   `https://cognito-idp.<region>.amazonaws.com/<userPoolId>`, so the two disagree here and agree on
   real Cognito.
-- Resource servers, MFA configuration and risk configuration are not simulated.
+- Resource servers and risk configuration are not simulated.
 - Tags are not simulated. `UserPoolTags` is refused, and `TagResource`, `UntagResource` and
   `ListTagsForResource` are not implemented.
 - Listings carry no filtering, and are in creation order rather than any order real Cognito chooses.

--- a/docs/services/cognito/sim-cognito-mfa.example.ts
+++ b/docs/services/cognito/sim-cognito-mfa.example.ts
@@ -1,0 +1,84 @@
+/**
+ * A user pool that offers multi-factor authentication.
+ */
+
+import {
+  ConfirmSignUpCommand,
+  CreateUserPoolClientCommand,
+  CreateUserPoolCommand,
+  DescribeUserPoolCommand,
+  GetUserPoolMfaConfigCommand,
+  InitiateAuthCommand,
+  SetUserPoolMfaConfigCommand,
+  SignUpCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+
+import { SimAws } from "@kensio/yulin";
+
+const cognito = new SimAws().cognitoIdentityProvider();
+
+const pool = await cognito.createUserPool(
+  new CreateUserPoolCommand({
+    PoolName: "myapp-users",
+    MfaConfiguration: "OPTIONAL",
+  }),
+);
+const userPoolId = pool.UserPool!.Id!;
+
+// Which factors the pool offers is set separately, as it is on real Cognito.
+await cognito.setUserPoolMfaConfig(
+  new SetUserPoolMfaConfigCommand({
+    UserPoolId: userPoolId,
+    MfaConfiguration: "OPTIONAL",
+    SoftwareTokenMfaConfiguration: { Enabled: true },
+  }),
+);
+
+const described = await cognito.describeUserPool(
+  new DescribeUserPoolCommand({ UserPoolId: userPoolId }),
+);
+
+console.log(described.UserPool?.MfaConfiguration); // "OPTIONAL"
+
+const mfa = await cognito.getUserPoolMfaConfig(
+  new GetUserPoolMfaConfigCommand({ UserPoolId: userPoolId }),
+);
+
+console.log(mfa.SoftwareTokenMfaConfiguration?.Enabled); // true
+
+// A user of the pool signs up and signs in with a password alone, because no
+// user here has registered a second factor.
+const appClient = await cognito.createUserPoolClient(
+  new CreateUserPoolClientCommand({
+    UserPoolId: userPoolId,
+    ClientName: "web",
+    ExplicitAuthFlows: ["ALLOW_USER_PASSWORD_AUTH"],
+  }),
+);
+const clientId = appClient.UserPoolClient!.ClientId!;
+
+await cognito.signUp(
+  new SignUpCommand({
+    ClientId: clientId,
+    Username: "alice",
+    Password: "Sup3rSecret!",
+  }),
+);
+
+await cognito.confirmSignUp(
+  new ConfirmSignUpCommand({
+    ClientId: clientId,
+    Username: "alice",
+    ConfirmationCode: cognito.userPool(userPoolId).confirmationCode("alice"),
+  }),
+);
+
+const signedIn = await cognito.initiateAuth(
+  new InitiateAuthCommand({
+    ClientId: clientId,
+    AuthFlow: "USER_PASSWORD_AUTH",
+    AuthParameters: { USERNAME: "alice", PASSWORD: "Sup3rSecret!" },
+  }),
+);
+
+console.log(typeof signedIn.AuthenticationResult?.AccessToken); // "string"

--- a/src/service/cloudformation/cdk/cognito/sim-cdk-cognito-user-pool.loc.test.ts
+++ b/src/service/cloudformation/cdk/cognito/sim-cdk-cognito-user-pool.loc.test.ts
@@ -6,6 +6,7 @@ import {
   ConfirmSignUpCommand,
   DescribeUserPoolClientCommand,
   DescribeUserPoolCommand,
+  GetUserPoolMfaConfigCommand,
   InitiateAuthCommand,
   SignUpCommand,
 } from "@aws-sdk/client-cognito-identity-provider";
@@ -165,8 +166,9 @@ app.synth();
   });
 
   it("deploys a CDK user pool a user signs itself up in", async () => {
-    // Given a CDK stack with a user pool that lets users sign themselves up
-    // and verifies the email address they sign up with.
+    // Given a CDK stack with a user pool that lets users sign themselves up,
+    // verifies the email address they sign up with, and offers multi-factor
+    // authentication to the users that want it.
     const cdkProject = new TestCdkProject();
     await cdkProject.writeCdkAppFile(
       `
@@ -181,6 +183,8 @@ const stack = new cdk.Stack(app, "TestStack", {
 const pool = new cognito.UserPool(stack, "Pool", {
   selfSignUpEnabled: true,
   autoVerify: { email: true },
+  mfa: cognito.Mfa.OPTIONAL,
+  mfaSecondFactor: { sms: false, otp: true },
 });
 const client = pool.addClient("Client", {
   disableOAuth: true,
@@ -214,6 +218,16 @@ app.synth();
     assertTypeString(clientId);
 
     const cognito = scoped.cognitoIdentityProvider();
+
+    // And the MfaConfiguration and EnabledMfas the construct emits reached the
+    // pool, through the SetUserPoolMfaConfig call CloudFormation makes once
+    // the pool exists.
+    const mfa = await cognito.getUserPoolMfaConfig(
+      new GetUserPoolMfaConfigCommand({ UserPoolId: userPoolId }),
+    );
+
+    assertIdentical(mfa.MfaConfiguration, "OPTIONAL");
+    assertTrue(mfa.SoftwareTokenMfaConfiguration?.Enabled);
 
     await cognito.signUp(
       new SignUpCommand({

--- a/src/service/cognito/README.md
+++ b/src/service/cognito/README.md
@@ -6,12 +6,13 @@ which exchange a token for AWS credentials, are a separate service and are not s
 The pool, the app client, the users and groups in it, self-service sign-up, the sign-in flows on
 both sides of the API, the domain and identity providers a federated sign-in runs through, the
 messages it would have sent, the tokens it issues and the authorizer are all here. SRP, managed
-login, MFA, password resets and device tracking are not.
+login, MFA challenges, password resets and device tracking are not.
 
 ## Entry points
 
 - `sim-cognito-identity-provider.ts` is the main in-memory service object for one account/region
-  scope. It holds the pool and app client operations, and extends `sim-cognito-federation.ts`,
+  scope. It holds the pool operations, and extends `sim-cognito-app-clients.ts`, which holds the
+  app client ones, and extends `sim-cognito-federation.ts`,
   which holds the domain and identity provider ones and the three hosted endpoints, and extends
   `sim-cognito-user-directory.ts`, which holds the user and group ones and extends
   `sim-cognito-authentication.ts`, which holds signing in and signing out. A caller sees one service
@@ -35,10 +36,22 @@ pool that issued it.
 
 `SimCognitoUserPoolSettings` holds the settings a request can change: the password policy, the
 deletion protection, whether users may sign themselves up, what confirming a sign-up verifies, the
-Lambda triggers the pool runs, and what its messages say. `CreateUserPool` and `UpdateUserPool` both
+Lambda triggers the pool runs, whether it asks for a second factor, and what its messages say. `CreateUserPool` and `UpdateUserPool` both
 build one out of their own request, and an update swaps the pool's for it. That is what makes an
 update replace rather than merge, and it is where the pool's `LastModifiedDate` moves. Each takes the
 operation name, so a refusal from inside the settings names the request it came from.
+
+`SimCognitoUserPoolMfa` under `user-pool/mfa/` is the multi-factor authentication one pool is
+configured for: a `SimCognitoMfaConfiguration`, which is whether it challenges, and the factors
+behind it. It is one of the settings because `CreateUserPool` and `UpdateUserPool` both carry the
+configuration, and it is the one setting an update does not wholly replace: only
+`SetUserPoolMfaConfig` says which factors a challenge could use, and it changes them in place, so
+`keepFactorsOf` carries them onto the settings replacing them, as real Cognito keeps them.
+
+Nothing here challenges, so the whole of it is state a pool reports rather than acts on. The one
+place it is read is `SimCognitoMfaChallenge`, which refuses a sign-in to a pool configured `ON`,
+because real Cognito answers every one of those with a challenge and would never issue the tokens
+this simulation otherwise would.
 
 `makeSimCognitoUserPoolId` builds the `<region>_<nine characters>` form. The region is part of the id
 rather than decoration: SDK code splits a pool id on the underscore to work out which region to talk
@@ -304,12 +317,18 @@ A properties class per type turns the template's properties into that Command's 
 `SimCfnCognitoPropertyParser` and the `SimCfnCognitoValueParser` it extends read the property
 shapes, accepting the quoted forms CloudFormation carries numbers and booleans in.
 
-Each type states the properties it simulates, and every other property is refused. That is an
-allow-list rather than a list of known-unsimulated properties, because CloudFormation has properties
-the Cognito API does not, `EnabledMfas` among them, and those would otherwise be dropped on the way
-to a Command that has nowhere to refuse them. Properties the API does know, such as
-`MfaConfiguration`, are passed through instead, so the refusal that reaches the reader is the one
-that says why.
+Each type states the properties it simulates, and every other property is recorded against the
+Resource and left out of what is created. That is an allow-list rather than a list of
+known-unsimulated properties, because CloudFormation has properties the Cognito API does not, and
+those would otherwise be dropped on the way to a Command that has nowhere to record them.
+
+`MfaConfiguration` and `EnabledMfas` are the two that do not reach `CreateUserPool` at all.
+`SimCfnCognitoUserPoolCreator` sets them in a `SetUserPoolMfaConfig` call once the pool exists,
+which is the shape real CloudFormation deploys them in: a stack declaring MFA needs
+`cognito-idp:SetUserPoolMfaConfig` on its execution role for exactly that reason.
+`SimCfnCognitoUserPoolMfa` turns the template's factor names into the configurations that Command
+takes, so which of them are simulated is decided in one place rather than two. A template asking
+for no MFA makes no second call, here or on real AWS.
 
 A property whose only accepted value is one particular value counts as simulated at this layer and
 is judged by the Command that receives it, so the value is judged in one place rather than two.
@@ -423,7 +442,8 @@ AWS SDK-style operations are implemented under `command/`, grouped by the collab
 rather than one class per command, so the `SimCognitoIdentityProvider` facade stays a delegation:
 
 - `command/user-pool/`: the pool commands, their structural input/output types and their output
-  views
+  views, with the two that set and read a pool's MFA kept apart in
+  `SimCognitoUserPoolMfaCommands`, because what they act on is not one of the pool's settings
 - `command/client/`: the same for app clients
 - `command/user/`: the same for users, split between the commands that create, read and delete one,
   the commands that change one afterwards, and the commands a user signs itself up with. The
@@ -546,6 +566,12 @@ resource, here or on real AWS.
 - The password and refresh flows run on both sides of the API, and only `NEW_PASSWORD_REQUIRED` is
   issued. SRP, `USER_AUTH`, custom authentication, MFA challenges and device tracking are refused
   rather than treated as a flow or challenge that is simulated.
+- A pool records its `MfaConfiguration` and the factors behind it, and challenges for none of them.
+  A pool configured `OPTIONAL` behaves as a real one does for a user that never registered a factor,
+  because nothing here registers one. A sign-in to a pool configured `ON` is refused, as every one
+  of those is answered with a challenge on real Cognito. `SetUserPoolMfaConfig` accepts
+  `SoftwareTokenMfaConfiguration` alone, and the operations that register a factor for a user are
+  not implemented.
 - A `PreTokenGeneration` response is refused where real Cognito would quietly drop part of it: a
   reserved claim, any `cognito:` claim in `claimsToAddOrOverride`, a claim value that is not a
   string, and a group override naming IAM roles. The trigger runs at `V1_0` only, so

--- a/src/service/cognito/cfn/sim-cfn-cognito-user-pool-mfa.iso.test.ts
+++ b/src/service/cognito/cfn/sim-cfn-cognito-user-pool-mfa.iso.test.ts
@@ -1,0 +1,164 @@
+import {
+  ConfirmSignUpCommand,
+  DescribeUserPoolCommand,
+  GetUserPoolMfaConfigCommand,
+  InitiateAuthCommand,
+  SignUpCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertTrue,
+  assertTypeString,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import {
+  deploySuccess,
+  simAwsInEuWest2,
+} from "../../../../test/cognito/cfn-deploy.js";
+
+const password = "Sup3rSecret!";
+
+/**
+ * The AWS::Cognito::UserPool properties `aws-cdk-lib` 2.263.0 emits for a
+ * `UserPool` construct asking for optional MFA with a time-based one-time
+ * password as the second factor, alongside a client-side app client.
+ *
+ * That is an ordinary product decision to record in a stack: users may turn a
+ * second factor on, and the pool offers an authenticator app rather than SMS.
+ * None of the sign-up and sign-in flows below involve a second factor.
+ */
+const verificationMessage =
+  "The verification code to your new account is {####}";
+
+const mfaPoolResources = {
+  SiteUserPool: {
+    Type: "AWS::Cognito::UserPool",
+    Properties: {
+      UserPoolName: "myapp-users",
+      AccountRecoverySetting: {
+        RecoveryMechanisms: [
+          { Name: "verified_phone_number", Priority: 1 },
+          { Name: "verified_email", Priority: 2 },
+        ],
+      },
+      AdminCreateUserConfig: { AllowAdminCreateUserOnly: false },
+      AutoVerifiedAttributes: ["email"],
+      EmailVerificationMessage: verificationMessage,
+      EmailVerificationSubject: "Verify your new account",
+      EnabledMfas: ["SOFTWARE_TOKEN_MFA"],
+      MfaConfiguration: "OPTIONAL",
+      SmsVerificationMessage: verificationMessage,
+    },
+  },
+  SiteUserPoolClient: {
+    Type: "AWS::Cognito::UserPoolClient",
+    Properties: {
+      UserPoolId: { Ref: "SiteUserPool" },
+      ClientName: "web",
+      ExplicitAuthFlows: ["ALLOW_USER_PASSWORD_AUTH"],
+    },
+  },
+};
+
+const mfaPoolOutputs = {
+  PoolId: { Value: { Ref: "SiteUserPool" } },
+  ClientId: { Value: { Ref: "SiteUserPoolClient" } },
+};
+
+describe("Cognito CloudFormation user pool MFA", () => {
+  it("deploys a pool declaring optional MFA and signs a user up in it", async () => {
+    // Given a stack whose pool offers optional MFA through an authenticator
+    // app.
+    const simAws = simAwsInEuWest2();
+
+    // When it is deployed.
+    const stack = await deploySuccess(simAws, mfaPoolResources, mfaPoolOutputs);
+
+    // Then the pool deployed, rather than the MFA declaration taking the whole
+    // stack down.
+    const userPoolId = stack.outputs.get("PoolId")?.value;
+    const clientId = stack.outputs.get("ClientId")?.value;
+    assertTypeString(userPoolId);
+    assertTypeString(clientId);
+    assertArrayLength(stack.ignoredProperties, 0);
+
+    // And the pool reports the setting the template asked for, with the factor
+    // behind it, which real CloudFormation configures in a second call once
+    // the pool exists.
+    const cognito = simAws.cognitoIdentityProvider();
+    const described = await cognito.describeUserPool(
+      new DescribeUserPoolCommand({ UserPoolId: userPoolId }),
+    );
+    assertIdentical(described.UserPool?.MfaConfiguration, "OPTIONAL");
+
+    const mfa = await cognito.getUserPoolMfaConfig(
+      new GetUserPoolMfaConfigCommand({ UserPoolId: userPoolId }),
+    );
+    assertIdentical(mfa.MfaConfiguration, "OPTIONAL");
+    assertTrue(mfa.SoftwareTokenMfaConfiguration?.Enabled);
+
+    // And everything that is not MFA goes on working against it: a user signs
+    // itself up, confirms, and signs in with a password alone.
+    await cognito.signUp(
+      new SignUpCommand({
+        ClientId: clientId,
+        Username: "alice",
+        Password: password,
+        UserAttributes: [{ Name: "email", Value: "alice@example.com" }],
+      }),
+    );
+    await cognito.confirmSignUp(
+      new ConfirmSignUpCommand({
+        ClientId: clientId,
+        Username: "alice",
+        ConfirmationCode: cognito
+          .userPool(userPoolId)
+          .confirmationCode("alice"),
+      }),
+    );
+
+    const signedIn = await cognito.initiateAuth(
+      new InitiateAuthCommand({
+        ClientId: clientId,
+        AuthFlow: "USER_PASSWORD_AUTH",
+        AuthParameters: { USERNAME: "alice", PASSWORD: password },
+      }),
+    );
+
+    assertNonNullable(signedIn.AuthenticationResult?.AccessToken);
+  });
+
+  it("leaves a pool that says nothing about MFA unconfigured", async () => {
+    // Given a template declaring a pool with no MFA at all.
+    const simAws = simAwsInEuWest2();
+
+    // When it is deployed.
+    const stack = await deploySuccess(
+      simAws,
+      {
+        AppPool: {
+          Type: "AWS::Cognito::UserPool",
+          Properties: { UserPoolName: "myapp-users" },
+        },
+      },
+      { PoolId: { Value: { Ref: "AppPool" } } },
+    );
+    const userPoolId = stack.outputs.get("PoolId")?.value;
+    assertTypeString(userPoolId);
+
+    // Then the pool has MFA off and no factor was configured for it, because
+    // no SetUserPoolMfaConfig call was made at all.
+    const mfa = await simAws
+      .cognitoIdentityProvider()
+      .getUserPoolMfaConfig(
+        new GetUserPoolMfaConfigCommand({ UserPoolId: userPoolId }),
+      );
+
+    assertIdentical(mfa.MfaConfiguration, "OFF");
+    assertUndefined(mfa.SoftwareTokenMfaConfiguration);
+  });
+});

--- a/src/service/cognito/cfn/sim-cfn-cognito-validation.iso.test.ts
+++ b/src/service/cognito/cfn/sim-cfn-cognito-validation.iso.test.ts
@@ -142,7 +142,8 @@ describe("Cognito CloudFormation validation", () => {
   });
 
   it("refuses a pool feature the Cognito API refuses", async () => {
-    // Given a template asking for MFA, which CreateUserPool does not simulate.
+    // Given a template asking for a feature plan CreateUserPool does not
+    // simulate.
     const simAws = simAwsInEuWest2();
 
     // When it is deployed.
@@ -151,7 +152,7 @@ describe("Cognito CloudFormation validation", () => {
         Type: "AWS::Cognito::UserPool",
         Properties: {
           UserPoolName: "myapp-users",
-          MfaConfiguration: "ON",
+          UserPoolTier: "PLUS",
         },
       },
     });
@@ -161,7 +162,56 @@ describe("Cognito CloudFormation validation", () => {
     assertStringIncludes(error.message, "AppPool");
     assertStringIncludes(
       error.message,
-      "CreateUserPool MfaConfiguration 'ON' is not simulated",
+      "CreateUserPool UserPoolTier 'PLUS' is not simulated",
+    );
+  });
+
+  it("refuses a second factor the pool could not deliver a message for", async () => {
+    // Given a template asking for MFA over SMS, which needs an SmsConfiguration
+    // that CreateUserPool refuses.
+    const simAws = simAwsInEuWest2();
+
+    // When it is deployed.
+    const error = await deployFailure(simAws, {
+      AppPool: {
+        Type: "AWS::Cognito::UserPool",
+        Properties: {
+          UserPoolName: "myapp-users",
+          MfaConfiguration: "OPTIONAL",
+          EnabledMfas: ["SMS_MFA"],
+        },
+      },
+    });
+
+    // Then the refusal comes from the second call the pool's MFA is set in,
+    // saying which factor it was.
+    assertStringIncludes(error.message, "AppPool");
+    assertStringIncludes(
+      error.message,
+      "SetUserPoolMfaConfig SmsMfaConfiguration is not simulated",
+    );
+  });
+
+  it("refuses a second factor Cognito does not have", async () => {
+    // Given a template naming a factor that is not one of Cognito's.
+    const simAws = simAwsInEuWest2();
+
+    // When it is deployed.
+    const error = await deployFailure(simAws, {
+      AppPool: {
+        Type: "AWS::Cognito::UserPool",
+        Properties: {
+          UserPoolName: "myapp-users",
+          EnabledMfas: ["FINGERPRINT"],
+        },
+      },
+    });
+
+    // Then the refusal names the property and the factors Cognito does have.
+    assertStringIncludes(error.message, "AppPool");
+    assertStringIncludes(
+      error.message,
+      "EnabledMfas[0] must be one of SMS_MFA, SOFTWARE_TOKEN_MFA, EMAIL_OTP",
     );
   });
 

--- a/src/service/cognito/cfn/user-pool/sim-cfn-cognito-user-pool-creator.ts
+++ b/src/service/cognito/cfn/user-pool/sim-cfn-cognito-user-pool-creator.ts
@@ -47,6 +47,29 @@ export class SimCfnCognitoUserPoolCreator {
       `sim Cognito user pool id after CloudFormation creation for ${resource.logicalId}`,
     );
 
+    await this.setMfaConfig(poolProperties, userPoolId);
+
     return this.cognito.userPool(userPoolId);
+  }
+
+  /**
+   * Configure the pool's MFA, where the template asked for any.
+   *
+   * This is the second call real CloudFormation makes for a pool declaring
+   * `MfaConfiguration` or `EnabledMfas`, rather than a property of the
+   * creation, so a stack that deploys here needs the same
+   * `cognito-idp:SetUserPoolMfaConfig` permission it needs on real AWS.
+   */
+  private async setMfaConfig(
+    poolProperties: SimCfnCognitoUserPoolProperties,
+    userPoolId: string,
+  ): Promise<void> {
+    const input = poolProperties.setUserPoolMfaConfigInput(userPoolId);
+
+    if (input === undefined) {
+      return;
+    }
+
+    await this.cognito.setUserPoolMfaConfig({ input });
   }
 }

--- a/src/service/cognito/cfn/user-pool/sim-cfn-cognito-user-pool-mfa.ts
+++ b/src/service/cognito/cfn/user-pool/sim-cfn-cognito-user-pool-mfa.ts
@@ -1,0 +1,120 @@
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type {
+  SimCfnTemplateValue,
+  SimCfnTemplateValueRecord,
+} from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimSetUserPoolMfaConfigCommandInput } from "../../command/user-pool/user-pool-mfa.command.js";
+import type { SimCfnCognitoPropertyParser } from "../sim-cfn-cognito-property-parser.js";
+
+/**
+ * The second factors CloudFormation can name in `EnabledMfas`.
+ */
+const enabledMfaValues = ["SMS_MFA", "SOFTWARE_TOKEN_MFA", "EMAIL_OTP"];
+
+/**
+ * The factor configurations an `EnabledMfas` list turns into.
+ */
+type SimCfnCognitoMfaFactors = Omit<
+  SimSetUserPoolMfaConfigCommandInput,
+  "UserPoolId" | "MfaConfiguration"
+>;
+
+interface SimCfnCognitoUserPoolMfaProperties {
+  readonly resource: SimCfnResource;
+  readonly propertyParser: SimCfnCognitoPropertyParser;
+}
+
+/**
+ * Reads the MFA properties of an AWS::Cognito::UserPool Resource into the
+ * SetUserPoolMfaConfig input they are deployed with.
+ *
+ * Neither reaches `CreateUserPool`. Real CloudFormation configures a pool's
+ * MFA in a second call once the pool exists, which is why a stack deploying
+ * one needs `cognito-idp:SetUserPoolMfaConfig` as well as
+ * `cognito-idp:CreateUserPool`.
+ *
+ * `EnabledMfas` is a CloudFormation property with no equivalent on the Cognito
+ * API, which names each factor by its own configuration instead. Turning the
+ * list into those configurations is what lets `SetUserPoolMfaConfig` decide
+ * which of them are simulated, so the two factors this simulation cannot
+ * deliver a message for are refused in one place rather than two.
+ */
+export class SimCfnCognitoUserPoolMfa {
+  private readonly resource: SimCfnResource;
+  private readonly propertyParser: SimCfnCognitoPropertyParser;
+
+  constructor(properties: SimCfnCognitoUserPoolMfaProperties) {
+    this.resource = properties.resource;
+    this.propertyParser = properties.propertyParser;
+  }
+
+  /**
+   * The call the pool's MFA is configured in, or nothing where the template
+   * says nothing about MFA. A template asking for none makes no such call,
+   * here or on real AWS.
+   */
+  parse(
+    userPoolId: string,
+    properties: SimCfnTemplateValueRecord,
+  ): SimSetUserPoolMfaConfigCommandInput | undefined {
+    const configuration = this.propertyParser.optionalString(
+      this.resource,
+      properties["MfaConfiguration"],
+      "MfaConfiguration",
+    );
+    const factors = this.factors(properties["EnabledMfas"]);
+
+    if (configuration === undefined && Object.keys(factors).length === 0) {
+      return undefined;
+    }
+
+    return {
+      UserPoolId: userPoolId,
+      ...(configuration !== undefined && { MfaConfiguration: configuration }),
+      ...factors,
+    };
+  }
+
+  /**
+   * The factors the template asks for, or nothing where it names none.
+   */
+  private factors(
+    value: SimCfnTemplateValue | undefined,
+  ): SimCfnCognitoMfaFactors {
+    const names = this.propertyParser.optionalStringArray(
+      this.resource,
+      value,
+      "EnabledMfas",
+    );
+
+    if (names === undefined) {
+      return {};
+    }
+
+    this.requireKnownFactors(names);
+
+    return {
+      ...(names.includes("SOFTWARE_TOKEN_MFA") && {
+        SoftwareTokenMfaConfiguration: { Enabled: true },
+      }),
+      ...(names.includes("SMS_MFA") && { SmsMfaConfiguration: {} }),
+      ...(names.includes("EMAIL_OTP") && { EmailMfaConfiguration: {} }),
+    };
+  }
+
+  /**
+   * Refuse a factor name Cognito does not have, before the pool is created
+   * with a factor list that means nothing.
+   */
+  private requireKnownFactors(names: readonly string[]): void {
+    for (const [index, name] of names.entries()) {
+      if (!enabledMfaValues.includes(name)) {
+        throw this.propertyParser.invalidPropertyError(
+          this.resource,
+          `EnabledMfas[${String(index)}]`,
+          `one of ${enabledMfaValues.join(", ")}`,
+        );
+      }
+    }
+  }
+}

--- a/src/service/cognito/cfn/user-pool/sim-cfn-cognito-user-pool-properties.ts
+++ b/src/service/cognito/cfn/user-pool/sim-cfn-cognito-user-pool-properties.ts
@@ -3,19 +3,26 @@ import type {
   SimCfnTemplateValue,
   SimCfnTemplateValueRecord,
 } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimSetUserPoolMfaConfigCommandInput } from "../../command/user-pool/user-pool-mfa.command.js";
 import type { SimCreateUserPoolCommandInput } from "../../command/user-pool/user-pool.command.js";
 import { SimCfnCognitoGeneratedName } from "../sim-cfn-cognito-generated-name.js";
 import { SimCfnCognitoPropertyParser } from "../sim-cfn-cognito-property-parser.js";
 import { SimCfnCognitoAdminCreateUserConfig } from "./sim-cfn-cognito-admin-create-user-config.js";
+import { SimCfnCognitoUserPoolMfa } from "./sim-cfn-cognito-user-pool-mfa.js";
 import { SimCfnCognitoPolicies } from "./sim-cfn-cognito-policies.js";
 
 /**
  * The AWS::Cognito::UserPool properties this simulation deploys.
  *
- * `MfaConfiguration` and `UserPoolTier` are here because CreateUserPool
- * accepts each at its AWS default and refuses it otherwise, in words that say
- * why. A CDK stack states both routinely, and a pool created without either
- * would be reported as behaving differently when it does not.
+ * `MfaConfiguration` and `EnabledMfas` are here because a pool records what it
+ * was asked for and reports it back. They do not reach CreateUserPool: real
+ * CloudFormation sets a pool's MFA in a SetUserPoolMfaConfig call after the
+ * pool exists, and this deploys them the same way.
+ *
+ * `UserPoolTier` is here because CreateUserPool accepts it at its AWS default
+ * and refuses it otherwise, in words that say why. A CDK stack states it
+ * routinely, and a pool created without it would be reported as behaving
+ * differently when it does not.
  *
  * `AdminCreateUserConfig` and `AutoVerifiedAttributes` are the two a
  * `selfSignUpEnabled` CDK pool turns on, and both are acted on: the first
@@ -40,6 +47,7 @@ const simulatedProperties = [
   "DeletionProtection",
   "LambdaConfig",
   "MfaConfiguration",
+  "EnabledMfas",
   "UserPoolTier",
   "AdminCreateUserConfig",
   "AutoVerifiedAttributes",
@@ -99,10 +107,6 @@ export class SimCfnCognitoUserPoolProperties {
         this.properties["LambdaConfig"],
         "LambdaConfig",
       ),
-      MfaConfiguration: this.string(
-        this.properties["MfaConfiguration"],
-        "MfaConfiguration",
-      ),
       UserPoolTier: this.string(
         this.properties["UserPoolTier"],
         "UserPoolTier",
@@ -137,6 +141,20 @@ export class SimCfnCognitoUserPoolProperties {
         "SmsVerificationMessage",
       ),
     };
+  }
+
+  /**
+   * The SetUserPoolMfaConfig input this Resource asks for, or nothing where
+   * the template says nothing about MFA. That call is a second one after the
+   * pool exists, as it is on real CloudFormation.
+   */
+  setUserPoolMfaConfigInput(
+    userPoolId: string,
+  ): SimSetUserPoolMfaConfigCommandInput | undefined {
+    return new SimCfnCognitoUserPoolMfa({
+      resource: this.resource,
+      propertyParser: this.propertyParser,
+    }).parse(userPoolId, this.properties);
   }
 
   /**

--- a/src/service/cognito/command/auth/sim-cognito-mfa-challenge.ts
+++ b/src/service/cognito/command/auth/sim-cognito-mfa-challenge.ts
@@ -1,0 +1,40 @@
+import { SimCognitoInvalidParameterException } from "../../error/sim-cognito.error.js";
+import type { SimCognitoUserPool } from "../../user-pool/sim-cognito-user-pool.js";
+
+/**
+ * The multi-factor challenge a pool would answer a sign-in with, which this
+ * simulation cannot issue.
+ *
+ * A pool configured `ON` challenges every user on real Cognito, whether or not
+ * that user has registered a factor: one that has is sent
+ * `SOFTWARE_TOKEN_MFA` or `SMS_MFA`, and one that has not is sent `MFA_SETUP`.
+ * Either way the request that carried the password is answered with a
+ * challenge rather than with tokens, so signing the user in here would hand
+ * out tokens a real deployment would not.
+ *
+ * A pool configured `OPTIONAL` challenges only the users that registered a
+ * factor. Nothing here registers one, so no user of such a pool has one, and
+ * signing in without a challenge is what real Cognito does with it too.
+ *
+ * This is the refusal `CreateUserPool` used to make. It is here instead
+ * because this is where the difference shows: a pool that records the setting
+ * and never challenges on it is honest for everything but a sign-in.
+ */
+export class SimCognitoMfaChallenge {
+  /**
+   * Refuse a sign-in that real Cognito would answer with an MFA challenge.
+   */
+  refuseIn(pool: SimCognitoUserPool): void {
+    if (!pool.settings.mfa.configuration.challengesEverySignIn) {
+      return;
+    }
+
+    throw new SimCognitoInvalidParameterException(
+      `User pool ${pool.id} has an MfaConfiguration of 'ON', so real ` +
+        `Cognito would answer this sign-in with an MFA challenge, and ` +
+        `multi-factor authentication is not simulated. Set the pool's ` +
+        `MfaConfiguration to 'OPTIONAL' or 'OFF' to sign in with a password ` +
+        `alone.`,
+    );
+  }
+}

--- a/src/service/cognito/command/auth/sim-cognito-mfa-sign-in.iso.test.ts
+++ b/src/service/cognito/command/auth/sim-cognito-mfa-sign-in.iso.test.ts
@@ -1,0 +1,212 @@
+import type { UserPoolMfaType } from "@aws-sdk/client-cognito-identity-provider";
+import {
+  AdminInitiateAuthCommand,
+  AdminRespondToAuthChallengeCommand,
+  ConfirmSignUpCommand,
+  CreateUserPoolClientCommand,
+  CreateUserPoolCommand,
+  InitiateAuthCommand,
+  SignUpCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimCognitoInvalidParameterException } from "../../error/sim-cognito.error.js";
+import type { SimCognitoIdentityProvider } from "../../sim-cognito-identity-provider.js";
+
+const password = "Sup3rSecret!";
+
+interface SimCognitoWithClient {
+  readonly cognito: SimCognitoIdentityProvider;
+  readonly userPoolId: string;
+  readonly clientId: string;
+}
+
+/**
+ * A pool with the MFA configuration the test is about, and an app client both
+ * sign-in flows can be run through.
+ */
+async function simCognitoWithClient(
+  mfaConfiguration: UserPoolMfaType,
+): Promise<SimCognitoWithClient> {
+  const cognito = new SimAws().cognitoIdentityProvider();
+  const pool = await cognito.createUserPool(
+    new CreateUserPoolCommand({
+      PoolName: "myapp-users",
+      MfaConfiguration: mfaConfiguration,
+    }),
+  );
+
+  assertNonNullable(pool.UserPool?.Id);
+
+  const client = await cognito.createUserPoolClient(
+    new CreateUserPoolClientCommand({
+      UserPoolId: pool.UserPool.Id,
+      ClientName: "web",
+      ExplicitAuthFlows: [
+        "ALLOW_USER_PASSWORD_AUTH",
+        "ALLOW_ADMIN_USER_PASSWORD_AUTH",
+      ],
+    }),
+  );
+
+  assertNonNullable(client.UserPoolClient?.ClientId);
+
+  return {
+    cognito,
+    userPoolId: pool.UserPool.Id,
+    clientId: client.UserPoolClient.ClientId,
+  };
+}
+
+/**
+ * Sign a user up and confirm it, which is the flow a pool offering MFA is
+ * built for.
+ */
+async function signUpAlice(
+  cognito: SimCognitoIdentityProvider,
+  userPoolId: string,
+  clientId: string,
+): Promise<void> {
+  await cognito.signUp(
+    new SignUpCommand({
+      ClientId: clientId,
+      Username: "alice",
+      Password: password,
+      UserAttributes: [{ Name: "email", Value: "alice@example.com" }],
+    }),
+  );
+
+  await cognito.confirmSignUp(
+    new ConfirmSignUpCommand({
+      ClientId: clientId,
+      Username: "alice",
+      ConfirmationCode: cognito.userPool(userPoolId).confirmationCode("alice"),
+    }),
+  );
+}
+
+describe("sim Cognito sign-in to a pool offering MFA", () => {
+  it("signs a user of a pool offering MFA in with a password", async () => {
+    // Given a pool offering MFA to users that ask for it, with a user that
+    // signed itself up. Nothing here registers a second factor, so this user
+    // has none, and neither would it on real Cognito.
+    const { cognito, userPoolId, clientId } =
+      await simCognitoWithClient("OPTIONAL");
+
+    await signUpAlice(cognito, userPoolId, clientId);
+
+    // When it signs in on both sides of the API.
+    const admin = await cognito.adminInitiateAuth(
+      new AdminInitiateAuthCommand({
+        UserPoolId: userPoolId,
+        ClientId: clientId,
+        AuthFlow: "ADMIN_USER_PASSWORD_AUTH",
+        AuthParameters: { USERNAME: "alice", PASSWORD: password },
+      }),
+    );
+    const client = await cognito.initiateAuth(
+      new InitiateAuthCommand({
+        ClientId: clientId,
+        AuthFlow: "USER_PASSWORD_AUTH",
+        AuthParameters: { USERNAME: "alice", PASSWORD: password },
+      }),
+    );
+
+    // Then both hand out tokens, with no challenge in the way.
+    assertNonNullable(admin.AuthenticationResult?.AccessToken);
+    assertNonNullable(client.AuthenticationResult?.AccessToken);
+  });
+
+  it("refuses a sign-in a pool requiring MFA would challenge", async () => {
+    // Given a pool that requires MFA of every user, with a confirmed user.
+    const { cognito, userPoolId, clientId } = await simCognitoWithClient("ON");
+
+    await signUpAlice(cognito, userPoolId, clientId);
+
+    // When that user signs in on either side of the API.
+    const admin = await assertThrowsErrorAsync(async () => {
+      await cognito.adminInitiateAuth(
+        new AdminInitiateAuthCommand({
+          UserPoolId: userPoolId,
+          ClientId: clientId,
+          AuthFlow: "ADMIN_USER_PASSWORD_AUTH",
+          AuthParameters: { USERNAME: "alice", PASSWORD: password },
+        }),
+      );
+    });
+    const client = await assertThrowsErrorAsync(async () => {
+      await cognito.initiateAuth(
+        new InitiateAuthCommand({
+          ClientId: clientId,
+          AuthFlow: "USER_PASSWORD_AUTH",
+          AuthParameters: { USERNAME: "alice", PASSWORD: password },
+        }),
+      );
+    });
+
+    // Then both are refused where real Cognito would answer with the MFA
+    // challenge, saying what it was that could not be done.
+    for (const error of [admin, client]) {
+      assertInstanceOf(error, SimCognitoInvalidParameterException);
+      assertStringIncludes(error.message, userPoolId);
+      assertStringIncludes(error.message, "would answer this sign-in with an");
+      assertStringIncludes(error.message, "MFA challenge");
+      assertStringIncludes(error.message, "not simulated");
+    }
+  });
+
+  it("refuses a new password answered to a pool requiring MFA", async () => {
+    // Given a pool requiring MFA, with a user that has to change its password
+    // before it can sign in.
+    const { cognito, userPoolId, clientId } = await simCognitoWithClient("ON");
+
+    await cognito.adminCreateUser({
+      input: {
+        UserPoolId: userPoolId,
+        Username: "alice",
+        TemporaryPassword: "Temp0rary!",
+      },
+    });
+
+    const challenged = await cognito.adminInitiateAuth(
+      new AdminInitiateAuthCommand({
+        UserPoolId: userPoolId,
+        ClientId: clientId,
+        AuthFlow: "ADMIN_USER_PASSWORD_AUTH",
+        AuthParameters: { USERNAME: "alice", PASSWORD: "Temp0rary!" },
+      }),
+    );
+
+    // Then the challenge it is answered with is the one this simulation does
+    // issue, because real Cognito issues that one first.
+    assertIdentical(challenged.ChallengeName, "NEW_PASSWORD_REQUIRED");
+
+    // When the new password is sent back, which real Cognito answers with the
+    // MFA challenge rather than with tokens.
+    const error = await assertThrowsErrorAsync(async () => {
+      await cognito.adminRespondToAuthChallenge(
+        new AdminRespondToAuthChallengeCommand({
+          UserPoolId: userPoolId,
+          ClientId: clientId,
+          ChallengeName: "NEW_PASSWORD_REQUIRED",
+          Session: challenged.Session,
+          ChallengeResponses: {
+            USERNAME: "alice",
+            NEW_PASSWORD: password,
+          },
+        }),
+      );
+    });
+
+    // Then it is refused there instead.
+    assertInstanceOf(error, SimCognitoInvalidParameterException);
+    assertStringIncludes(error.message, "MFA challenge");
+  });
+});

--- a/src/service/cognito/command/auth/sim-cognito-new-password-response.ts
+++ b/src/service/cognito/command/auth/sim-cognito-new-password-response.ts
@@ -9,6 +9,7 @@ import { SimCognitoTriggerOccasion } from "../../user-pool/trigger/sim-cognito-t
 import type { SimCognitoUserPoolTriggers } from "../../user-pool/trigger/sim-cognito-user-pool-triggers.js";
 import { SimCognitoAuthenticationResult } from "./sim-cognito-authentication-result.js";
 import type { SimCognitoAuthResolver } from "./sim-cognito-auth-resolver.js";
+import { SimCognitoMfaChallenge } from "./sim-cognito-mfa-challenge.js";
 import type { SimCognitoAuthRequest } from "./sim-cognito-password-sign-in.js";
 import type { SimCognitoAuthenticationOutput } from "./auth.command.js";
 
@@ -42,6 +43,7 @@ export class SimCognitoNewPasswordResponse {
   private readonly triggers: SimCognitoUserPoolTriggers;
   private readonly clock: SimClock;
   private readonly result = new SimCognitoAuthenticationResult();
+  private readonly mfaChallenge = new SimCognitoMfaChallenge();
 
   constructor(properties: SimCognitoNewPasswordResponseProperties) {
     this.authResolver = properties.authResolver;
@@ -86,6 +88,11 @@ export class SimCognitoNewPasswordResponse {
     );
 
     pool.auth.removeSession(session);
+
+    // A pool that challenges every user answers the new password with an MFA
+    // challenge rather than with tokens, and this simulation has none to
+    // issue.
+    this.mfaChallenge.refuseIn(pool);
 
     // This is the one occasion real Cognito passes a request's `ClientMetadata`
     // to the token trigger, so it travels with the tokens here and nowhere

--- a/src/service/cognito/command/auth/sim-cognito-password-sign-in.ts
+++ b/src/service/cognito/command/auth/sim-cognito-password-sign-in.ts
@@ -9,6 +9,7 @@ import type { SimCognitoTokenIssuer } from "../../user-pool/token/sim-cognito-to
 import { SimCognitoTriggerOccasion } from "../../user-pool/trigger/sim-cognito-trigger-occasion.js";
 import type { SimCognitoUserPoolTriggers } from "../../user-pool/trigger/sim-cognito-user-pool-triggers.js";
 import { SimCognitoAuthenticationResult } from "./sim-cognito-authentication-result.js";
+import { SimCognitoMfaChallenge } from "./sim-cognito-mfa-challenge.js";
 import type { SimCognitoAuthParameters } from "./sim-cognito-auth-parameters.js";
 import type { SimCognitoAuthResolver } from "./sim-cognito-auth-resolver.js";
 import type { SimCognitoNewPasswordChallenge } from "./sim-cognito-new-password-challenge.js";
@@ -51,6 +52,7 @@ export class SimCognitoPasswordSignIn {
   private readonly challenge: SimCognitoNewPasswordChallenge;
   private readonly triggers: SimCognitoUserPoolTriggers;
   private readonly result = new SimCognitoAuthenticationResult();
+  private readonly mfaChallenge = new SimCognitoMfaChallenge();
 
   constructor(properties: SimCognitoPasswordSignInProperties) {
     this.authResolver = properties.authResolver;
@@ -92,6 +94,11 @@ export class SimCognitoPasswordSignIn {
     if (user.status.mustChangePassword) {
       return this.challenge.issue({ pool, clientId: client.id, user });
     }
+
+    // A pool that challenges every user would answer with an MFA challenge
+    // here rather than with tokens, and this simulation has no challenge to
+    // issue, so it refuses where the challenge would have been.
+    this.mfaChallenge.refuseIn(pool);
 
     // `ClientMetadata` reaches PreAuthentication and PostAuthentication, and
     // not the token trigger: real Cognito does not pass an InitiateAuth or

--- a/src/service/cognito/command/authorize/sim-cognito-user-pool-update-iam.iso.test.ts
+++ b/src/service/cognito/command/authorize/sim-cognito-user-pool-update-iam.iso.test.ts
@@ -1,6 +1,8 @@
 import {
   CreateUserPoolCommand,
   DescribeUserPoolCommand,
+  GetUserPoolMfaConfigCommand,
+  SetUserPoolMfaConfigCommand,
   UpdateUserPoolCommand,
 } from "@aws-sdk/client-cognito-identity-provider";
 import {
@@ -130,6 +132,69 @@ describe("sim Cognito UpdateUserPool authorization", () => {
     });
 
     // Then it is denied, because UpdateUserPool is its own IAM action.
+    assertInstanceOf(error, SimIamAccessDenied);
+  });
+
+  it("authorizes setting and reading a pool's MFA against the pool's ARN", async () => {
+    // Given a Role allowed to set and read the MFA of that pool alone. A stack
+    // deploying a pool with MFA needs both actions, because CloudFormation
+    // configures MFA in a call of its own after the pool exists.
+    const { simAws, userPoolId } = await simAwsWithPool();
+    const role = await simIamRoleWithPolicyFactory.make(
+      {
+        roleName: "PoolMfaAdministrator",
+        actions: [
+          "cognito-idp:SetUserPoolMfaConfig",
+          "cognito-idp:GetUserPoolMfaConfig",
+        ],
+        resource: userPoolArn(userPoolId),
+      },
+      simAws,
+    );
+    const caller = { caller: { kind: "arn", arn: role.Arn } } as const;
+    const cognito = simAws.cognitoIdentityProvider();
+
+    // When that Role configures the pool's MFA and reads it back.
+    await cognito.setUserPoolMfaConfig(
+      new SetUserPoolMfaConfigCommand({
+        UserPoolId: userPoolId,
+        MfaConfiguration: "OPTIONAL",
+      }),
+      caller,
+    );
+    const read = await cognito.getUserPoolMfaConfig(
+      new GetUserPoolMfaConfigCommand({ UserPoolId: userPoolId }),
+      caller,
+    );
+
+    // Then both are allowed.
+    assertIdentical(read.MfaConfiguration, "OPTIONAL");
+  });
+
+  it("denies setting a pool's MFA to a caller that may only update it", async () => {
+    // Given a Role allowed to update any pool and nothing else.
+    const { simAws, userPoolId } = await simAwsWithPool();
+    const role = await simIamRoleWithPolicyFactory.make(
+      {
+        roleName: "PoolUpdater",
+        actions: ["cognito-idp:UpdateUserPool"],
+        resource: userPoolArn("*"),
+      },
+      simAws,
+    );
+
+    // When that Role configures the pool's MFA.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.cognitoIdentityProvider().setUserPoolMfaConfig(
+        new SetUserPoolMfaConfigCommand({
+          UserPoolId: userPoolId,
+          MfaConfiguration: "OPTIONAL",
+        }),
+        { caller: { kind: "arn", arn: role.Arn } },
+      );
+    });
+
+    // Then it is denied, because SetUserPoolMfaConfig is its own IAM action.
     assertInstanceOf(error, SimIamAccessDenied);
   });
 });

--- a/src/service/cognito/command/sim-cognito-command.types.ts
+++ b/src/service/cognito/command/sim-cognito-command.types.ts
@@ -17,6 +17,14 @@ export type {
   SimUpdateUserPoolCommandOutput,
 } from "./user-pool/user-pool.command.js";
 export type {
+  SimGetUserPoolMfaConfigCommand,
+  SimGetUserPoolMfaConfigCommandInput,
+  SimGetUserPoolMfaConfigCommandOutput,
+  SimSetUserPoolMfaConfigCommand,
+  SimSetUserPoolMfaConfigCommandInput,
+  SimSetUserPoolMfaConfigCommandOutput,
+} from "./user-pool/user-pool-mfa.command.js";
+export type {
   SimCognitoUserPoolDescriptionType,
   SimListUserPoolsCommand,
   SimListUserPoolsCommandInput,

--- a/src/service/cognito/command/sim-cognito-commands.ts
+++ b/src/service/cognito/command/sim-cognito-commands.ts
@@ -29,6 +29,7 @@ import { SimCognitoRequestResolver } from "./sim-cognito-request-resolver.js";
 import { SimCognitoUserUpdateCommands } from "./user/sim-cognito-user-update-commands.js";
 import { SimCognitoListUserPools } from "./user-pool/sim-cognito-list-user-pools.js";
 import { SimCognitoUserPoolCommands } from "./user-pool/sim-cognito-user-pool-commands.js";
+import { SimCognitoUserPoolMfaCommands } from "./user-pool/sim-cognito-user-pool-mfa-commands.js";
 
 interface SimCognitoCommandsProperties {
   readonly accountRegionScope: SimAwsAccountRegionScope;
@@ -48,6 +49,7 @@ interface SimCognitoCommandsProperties {
  */
 export class SimCognitoCommands {
   public readonly userPools: SimCognitoUserPoolCommands;
+  public readonly userPoolMfa: SimCognitoUserPoolMfaCommands;
   public readonly listUserPools: SimCognitoListUserPools;
   public readonly clients: SimCognitoUserPoolClientCommands;
   public readonly listClients: SimCognitoListUserPoolClients;
@@ -91,6 +93,7 @@ export class SimCognitoCommands {
       }),
       authorizer,
     });
+    this.userPoolMfa = new SimCognitoUserPoolMfaCommands({ pools, authorizer });
     this.listUserPools = new SimCognitoListUserPools({ pools, authorizer });
     this.clients = new SimCognitoUserPoolClientCommands({
       pools,

--- a/src/service/cognito/command/user-pool/sim-cognito-unsimulated-pool-options.ts
+++ b/src/service/cognito/command/user-pool/sim-cognito-unsimulated-pool-options.ts
@@ -12,6 +12,11 @@ import type { SimCognitoUserPoolCommandInput } from "./user-pool.command.js";
  *
  * `CreateUserPool` and `UpdateUserPool` both carry them, so both refuse them,
  * each naming itself in the refusal.
+ *
+ * `MfaConfiguration` is not among them. A pool records what it was asked for
+ * and reports it back, and the sign-in that would have to answer a challenge
+ * is what refuses instead, where the refusal can say what it was that could
+ * not be done.
  */
 export class SimCognitoUnsimulatedUserPoolOptions {
   private readonly unsimulated: SimCognitoUnsimulatedInput;
@@ -28,12 +33,6 @@ export class SimCognitoUnsimulatedUserPoolOptions {
    * Refuse a request carrying an input this simulation cannot honour.
    */
   refuseIn(input: SimCognitoUserPoolCommandInput): void {
-    this.unsimulated.refuseUnless(
-      "MfaConfiguration",
-      input.MfaConfiguration,
-      "OFF",
-      "multi-factor authentication",
-    );
     this.unsimulated.refuseUnless(
       "UserPoolTier",
       input.UserPoolTier,

--- a/src/service/cognito/command/user-pool/sim-cognito-update-user-pool-validation.iso.test.ts
+++ b/src/service/cognito/command/user-pool/sim-cognito-update-user-pool-validation.iso.test.ts
@@ -36,11 +36,6 @@ const refusedInputs: readonly RefusedInput[] = [
     says: "renaming a pool",
   },
   {
-    label: "MfaConfiguration",
-    input: { MfaConfiguration: "OPTIONAL" },
-    says: "multi-factor authentication",
-  },
-  {
     label: "UserPoolTier",
     input: { UserPoolTier: "PLUS" },
     says: "the Lite and Plus feature plans",
@@ -194,7 +189,6 @@ describe("sim Cognito UpdateUserPool validation", () => {
     await cognito.updateUserPool(
       new UpdateUserPoolCommand({
         UserPoolId: userPoolId,
-        MfaConfiguration: "OFF",
         UserPoolTier: "ESSENTIALS",
         AdminCreateUserConfig: { AllowAdminCreateUserOnly: true },
       }),

--- a/src/service/cognito/command/user-pool/sim-cognito-user-pool-commands.ts
+++ b/src/service/cognito/command/user-pool/sim-cognito-user-pool-commands.ts
@@ -103,11 +103,18 @@ export class SimCognitoUserPoolCommands {
     );
     this.unsimulatedUpdates.refuseIn(input);
 
-    this.pools
-      .require(userPoolId)
-      .update(
-        new SimCognitoUserPoolSettings({ input, operation: "UpdateUserPool" }),
-      );
+    const pool = this.pools.require(userPoolId);
+    const settings = new SimCognitoUserPoolSettings({
+      input,
+      operation: "UpdateUserPool",
+    });
+
+    // An update carries whether the pool challenges for a second factor and
+    // nothing about the factors behind it, so the factors a
+    // SetUserPoolMfaConfig request configured survive it, as they do on real
+    // Cognito.
+    settings.mfa.keepFactorsOf(pool.settings.mfa);
+    pool.update(settings);
 
     return { $metadata: {} };
   }

--- a/src/service/cognito/command/user-pool/sim-cognito-user-pool-mfa-commands.ts
+++ b/src/service/cognito/command/user-pool/sim-cognito-user-pool-mfa-commands.ts
@@ -1,0 +1,116 @@
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import { requireSimCognitoUserPoolId } from "../../user-pool/sim-cognito-user-pool-id.js";
+import type { SimCognitoUserPoolStore } from "../../user-pool/sim-cognito-user-pool-store.js";
+import type { SimCognitoAuthorizer } from "../authorize/sim-cognito-authorizer.js";
+import { SimCognitoUnsimulatedInput } from "../sim-cognito-unsimulated-input.js";
+import type {
+  SimGetUserPoolMfaConfigCommand,
+  SimGetUserPoolMfaConfigCommandOutput,
+  SimSetUserPoolMfaConfigCommand,
+  SimSetUserPoolMfaConfigCommandInput,
+  SimSetUserPoolMfaConfigCommandOutput,
+} from "./user-pool-mfa.command.js";
+
+interface SimCognitoUserPoolMfaCommandsProperties {
+  readonly pools: SimCognitoUserPoolStore;
+  readonly authorizer: SimCognitoAuthorizer;
+}
+
+interface SimCognitoCommandOptions {
+  readonly caller?: SimAwsCaller;
+}
+
+/**
+ * The commands that set and read a pool's multi-factor authentication.
+ *
+ * They are separate from the pool commands because the configuration they act
+ * on is separate: `CreateUserPool` carries an `MfaConfiguration` and nothing
+ * about the factors behind it, and this is where a pool is told which factors
+ * it offers. CloudFormation deploys a pool with MFA in the same two steps.
+ *
+ * Neither command simulates a challenge. What they change is what
+ * `DescribeUserPool` and `GetUserPoolMfaConfig` report, and whether a sign-in
+ * to the pool is refused for a challenge this simulation cannot issue.
+ */
+export class SimCognitoUserPoolMfaCommands {
+  private readonly pools: SimCognitoUserPoolStore;
+  private readonly authorizer: SimCognitoAuthorizer;
+  private readonly unsimulated = new SimCognitoUnsimulatedInput(
+    "SetUserPoolMfaConfig",
+  );
+
+  constructor(properties: SimCognitoUserPoolMfaCommandsProperties) {
+    this.pools = properties.pools;
+    this.authorizer = properties.authorizer;
+  }
+
+  /**
+   * Set a pool's MFA configuration.
+   *
+   * The configuration is replaced rather than merged, as real Cognito replaces
+   * it: a factor the request leaves out goes back to being unconfigured.
+   */
+  set(
+    command: SimSetUserPoolMfaConfigCommand,
+    options?: SimCognitoCommandOptions,
+  ): SimSetUserPoolMfaConfigCommandOutput {
+    const { input } = command;
+    const userPoolId = requireSimCognitoUserPoolId(input.UserPoolId);
+
+    this.authorizer.authorizeUserPool(
+      "cognito-idp:SetUserPoolMfaConfig",
+      userPoolId,
+      options?.caller,
+    );
+    this.refuseUnsimulatedFactors(input);
+
+    const pool = this.pools.require(userPoolId);
+
+    pool.settings.mfa.set(input);
+
+    return { $metadata: {}, ...pool.settings.mfa.toOutput() };
+  }
+
+  /**
+   * Read a pool's MFA configuration.
+   */
+  get(
+    command: SimGetUserPoolMfaConfigCommand,
+    options?: SimCognitoCommandOptions,
+  ): SimGetUserPoolMfaConfigCommandOutput {
+    const userPoolId = requireSimCognitoUserPoolId(command.input.UserPoolId);
+
+    this.authorizer.authorizeUserPool(
+      "cognito-idp:GetUserPoolMfaConfig",
+      userPoolId,
+      options?.caller,
+    );
+
+    return {
+      $metadata: {},
+      ...this.pools.require(userPoolId).settings.mfa.toOutput(),
+    };
+  }
+
+  /**
+   * Refuse the two factors this simulation cannot deliver a message for.
+   *
+   * A pool here has neither an `SmsConfiguration` nor an `EmailConfiguration`,
+   * because `CreateUserPool` refuses both, so real Cognito would refuse either
+   * of these factors on a pool built the same way.
+   */
+  private refuseUnsimulatedFactors(
+    input: SimSetUserPoolMfaConfigCommandInput,
+  ): void {
+    this.unsimulated.refuse(
+      "SmsMfaConfiguration",
+      input.SmsMfaConfiguration,
+      "a second factor sent by SMS, which needs the pool's SmsConfiguration",
+    );
+    this.unsimulated.refuse(
+      "EmailMfaConfiguration",
+      input.EmailMfaConfiguration,
+      "a second factor sent by email, which needs the pool's EmailConfiguration",
+    );
+  }
+}

--- a/src/service/cognito/command/user-pool/sim-cognito-user-pool-mfa-commands.ts
+++ b/src/service/cognito/command/user-pool/sim-cognito-user-pool-mfa-commands.ts
@@ -93,11 +93,13 @@ export class SimCognitoUserPoolMfaCommands {
   }
 
   /**
-   * Refuse the two factors this simulation cannot deliver a message for.
+   * Refuse the factors this simulation has no way to present.
    *
    * A pool here has neither an `SmsConfiguration` nor an `EmailConfiguration`,
    * because `CreateUserPool` refuses both, so real Cognito would refuse either
-   * of these factors on a pool built the same way.
+   * of those factors on a pool built the same way. A passkey is presented
+   * through the `USER_AUTH` flow, which is refused as a flow of its own, so a
+   * pool configured for one here would never be asked for it.
    */
   private refuseUnsimulatedFactors(
     input: SimSetUserPoolMfaConfigCommandInput,
@@ -111,6 +113,11 @@ export class SimCognitoUserPoolMfaCommands {
       "EmailMfaConfiguration",
       input.EmailMfaConfiguration,
       "a second factor sent by email, which needs the pool's EmailConfiguration",
+    );
+    this.unsimulated.refuse(
+      "WebAuthnConfiguration",
+      input.WebAuthnConfiguration,
+      "signing in with a passkey, which the unsimulated USER_AUTH flow presents",
     );
   }
 }

--- a/src/service/cognito/command/user-pool/sim-cognito-user-pool-mfa.iso.test.ts
+++ b/src/service/cognito/command/user-pool/sim-cognito-user-pool-mfa.iso.test.ts
@@ -1,0 +1,276 @@
+import type { UserPoolMfaType } from "@aws-sdk/client-cognito-identity-provider";
+import {
+  CreateUserPoolCommand,
+  DescribeUserPoolCommand,
+  GetUserPoolMfaConfigCommand,
+  SetUserPoolMfaConfigCommand,
+  UpdateUserPoolCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import {
+  assertFalse,
+  assertIdentical,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertTrue,
+  assertTypeString,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimCognitoInvalidParameterException } from "../../error/sim-cognito.error.js";
+import type { SimCognitoIdentityProvider } from "../../sim-cognito-identity-provider.js";
+
+interface SimCognitoWithPool {
+  readonly cognito: SimCognitoIdentityProvider;
+  readonly userPoolId: string;
+}
+
+/**
+ * A pool created with the MFA configuration the test is about.
+ */
+async function poolWithMfa(
+  mfaConfiguration?: UserPoolMfaType,
+): Promise<SimCognitoWithPool> {
+  const cognito = new SimAws().cognitoIdentityProvider();
+  const created = await cognito.createUserPool(
+    new CreateUserPoolCommand({
+      PoolName: "myapp-users",
+      ...(mfaConfiguration !== undefined && {
+        MfaConfiguration: mfaConfiguration,
+      }),
+    }),
+  );
+  const userPoolId = created.UserPool?.Id;
+
+  assertTypeString(userPoolId);
+
+  return { cognito, userPoolId };
+}
+
+async function describedMfa(
+  cognito: SimCognitoIdentityProvider,
+  userPoolId: string,
+): Promise<string | undefined> {
+  const described = await cognito.describeUserPool(
+    new DescribeUserPoolCommand({ UserPoolId: userPoolId }),
+  );
+
+  return described.UserPool?.MfaConfiguration;
+}
+
+describe("sim Cognito user pool MFA configuration", () => {
+  it("creates a pool that offers MFA and reports the setting back", async () => {
+    // Given a pool created with optional MFA, which is an ordinary thing for a
+    // stack to declare.
+    const { cognito, userPoolId } = await poolWithMfa("OPTIONAL");
+
+    // When the pool is described.
+    const reported = await describedMfa(cognito, userPoolId);
+
+    // Then it reports what the request asked for rather than OFF.
+    assertIdentical(reported, "OPTIONAL");
+  });
+
+  it("creates a pool that requires MFA and reports the setting back", async () => {
+    // Given a pool created with MFA required of every user.
+    const { cognito, userPoolId } = await poolWithMfa("ON");
+
+    // When the pool is described.
+    const reported = await describedMfa(cognito, userPoolId);
+
+    // Then that is what it reports.
+    assertIdentical(reported, "ON");
+  });
+
+  it("creates a pool that says nothing about MFA with it off", async () => {
+    // Given a pool created without an MfaConfiguration.
+    const { cognito, userPoolId } = await poolWithMfa();
+
+    // When the pool is described.
+    const reported = await describedMfa(cognito, userPoolId);
+
+    // Then it is off, which is the default real Cognito applies.
+    assertIdentical(reported, "OFF");
+  });
+
+  it("refuses an MfaConfiguration Cognito does not have", async () => {
+    // Given simulated Cognito.
+    const cognito = new SimAws().cognitoIdentityProvider();
+
+    // When a pool asks for MFA in a word Cognito does not use.
+    // The SDK's own types allow only Cognito's three values, so this is the
+    // request as it reaches the simulator.
+    const error = await assertThrowsErrorAsync(async () => {
+      await cognito.createUserPool({
+        input: { PoolName: "myapp-users", MfaConfiguration: "REQUIRED" },
+      });
+    });
+
+    // Then it is refused, naming the values it could have used.
+    assertInstanceOf(error, SimCognitoInvalidParameterException);
+    assertStringIncludes(error.message, "use OFF, OPTIONAL or ON");
+  });
+
+  it("sets the factors behind a pool's MFA and reports them back", async () => {
+    // Given a pool with MFA on offer.
+    const { cognito, userPoolId } = await poolWithMfa();
+
+    // When it is configured for a time-based one-time password, which is the
+    // second call CloudFormation makes for a pool declaring MFA.
+    const set = await cognito.setUserPoolMfaConfig(
+      new SetUserPoolMfaConfigCommand({
+        UserPoolId: userPoolId,
+        MfaConfiguration: "OPTIONAL",
+        SoftwareTokenMfaConfiguration: { Enabled: true },
+      }),
+    );
+
+    // Then the call answers with the configuration the pool now has, and both
+    // GetUserPoolMfaConfig and DescribeUserPool report it.
+    assertIdentical(set.MfaConfiguration, "OPTIONAL");
+    assertTrue(set.SoftwareTokenMfaConfiguration?.Enabled);
+
+    const read = await cognito.getUserPoolMfaConfig(
+      new GetUserPoolMfaConfigCommand({ UserPoolId: userPoolId }),
+    );
+
+    assertIdentical(read.MfaConfiguration, "OPTIONAL");
+    assertTrue(read.SoftwareTokenMfaConfiguration?.Enabled);
+    assertIdentical(await describedMfa(cognito, userPoolId), "OPTIONAL");
+  });
+
+  it("reports no factors for a pool nothing has configured", async () => {
+    // Given a pool no SetUserPoolMfaConfig request has reached.
+    const { cognito, userPoolId } = await poolWithMfa("OPTIONAL");
+
+    // When its MFA configuration is read.
+    const read = await cognito.getUserPoolMfaConfig(
+      new GetUserPoolMfaConfigCommand({ UserPoolId: userPoolId }),
+    );
+
+    // Then it reports the setting it was created with and no factor at all,
+    // rather than a factor that was never asked about.
+    assertIdentical(read.MfaConfiguration, "OPTIONAL");
+    assertUndefined(read.SoftwareTokenMfaConfiguration);
+  });
+
+  it("reads a factor named without an Enabled as disabled", async () => {
+    // Given a pool.
+    const { cognito, userPoolId } = await poolWithMfa();
+
+    // When a request names the factor and says nothing about enabling it.
+    await cognito.setUserPoolMfaConfig(
+      new SetUserPoolMfaConfigCommand({
+        UserPoolId: userPoolId,
+        MfaConfiguration: "OPTIONAL",
+        SoftwareTokenMfaConfiguration: {},
+      }),
+    );
+
+    // Then it is disabled, as real Cognito reads one.
+    const read = await cognito.getUserPoolMfaConfig(
+      new GetUserPoolMfaConfigCommand({ UserPoolId: userPoolId }),
+    );
+
+    assertFalse(read.SoftwareTokenMfaConfiguration?.Enabled);
+  });
+
+  it("keeps a pool's factors through an update that says nothing about them", async () => {
+    // Given a pool configured for a time-based one-time password.
+    const { cognito, userPoolId } = await poolWithMfa();
+
+    await cognito.setUserPoolMfaConfig(
+      new SetUserPoolMfaConfigCommand({
+        UserPoolId: userPoolId,
+        MfaConfiguration: "OPTIONAL",
+        SoftwareTokenMfaConfiguration: { Enabled: true },
+      }),
+    );
+
+    // When an update changes whether the pool challenges. An UpdateUserPool
+    // request carries no factor configuration at all.
+    await cognito.updateUserPool(
+      new UpdateUserPoolCommand({
+        UserPoolId: userPoolId,
+        MfaConfiguration: "ON",
+      }),
+    );
+
+    // Then the challenging changes and the factor behind it is left alone.
+    const read = await cognito.getUserPoolMfaConfig(
+      new GetUserPoolMfaConfigCommand({ UserPoolId: userPoolId }),
+    );
+
+    assertIdentical(read.MfaConfiguration, "ON");
+    assertTrue(read.SoftwareTokenMfaConfiguration?.Enabled);
+  });
+
+  it("turns MFA off for an update that leaves the setting out", async () => {
+    // Given a pool created with optional MFA.
+    const { cognito, userPoolId } = await poolWithMfa("OPTIONAL");
+
+    // When an update names no MfaConfiguration. An update replaces a pool's
+    // settings rather than merging into them, here and on real Cognito.
+    await cognito.updateUserPool(
+      new UpdateUserPoolCommand({
+        UserPoolId: userPoolId,
+        DeletionProtection: "INACTIVE",
+      }),
+    );
+
+    // Then the pool goes back to the default a creation would have given it.
+    assertIdentical(await describedMfa(cognito, userPoolId), "OFF");
+  });
+
+  it("refuses the second factors it could not deliver a message for", async () => {
+    // Given a pool. No pool here has an SmsConfiguration or an
+    // EmailConfiguration, because CreateUserPool refuses both.
+    const { cognito, userPoolId } = await poolWithMfa();
+
+    // When a factor needing one of them is asked for.
+    const sms = await assertThrowsErrorAsync(async () => {
+      await cognito.setUserPoolMfaConfig(
+        new SetUserPoolMfaConfigCommand({
+          UserPoolId: userPoolId,
+          MfaConfiguration: "OPTIONAL",
+          SmsMfaConfiguration: { SmsAuthenticationMessage: "{####}" },
+        }),
+      );
+    });
+    const email = await assertThrowsErrorAsync(async () => {
+      await cognito.setUserPoolMfaConfig(
+        new SetUserPoolMfaConfigCommand({
+          UserPoolId: userPoolId,
+          MfaConfiguration: "OPTIONAL",
+          EmailMfaConfiguration: { Subject: "Your code" },
+        }),
+      );
+    });
+
+    // Then both are refused, saying what the pool would have needed.
+    assertStringIncludes(sms.message, "a second factor sent by SMS");
+    assertStringIncludes(sms.message, "SmsConfiguration");
+    assertStringIncludes(email.message, "a second factor sent by email");
+    assertStringIncludes(email.message, "EmailConfiguration");
+  });
+
+  it("refuses a request naming no pool", async () => {
+    // Given simulated Cognito.
+    const cognito = new SimAws().cognitoIdentityProvider();
+
+    // When the MFA configuration of no pool in particular is set and read.
+    const set = await assertThrowsErrorAsync(async () => {
+      await cognito.setUserPoolMfaConfig({ input: {} });
+    });
+    const read = await assertThrowsErrorAsync(async () => {
+      await cognito.getUserPoolMfaConfig({ input: {} });
+    });
+
+    // Then both fail as validation errors.
+    assertInstanceOf(set, SimCognitoInvalidParameterException);
+    assertStringIncludes(set.message, "UserPoolId is required");
+    assertInstanceOf(read, SimCognitoInvalidParameterException);
+    assertStringIncludes(read.message, "UserPoolId is required");
+  });
+});

--- a/src/service/cognito/command/user-pool/sim-cognito-user-pool-mfa.iso.test.ts
+++ b/src/service/cognito/command/user-pool/sim-cognito-user-pool-mfa.iso.test.ts
@@ -255,6 +255,26 @@ describe("sim Cognito user pool MFA configuration", () => {
     assertStringIncludes(email.message, "EmailConfiguration");
   });
 
+  it("refuses a passkey, which no flow here would ask for", async () => {
+    // Given a pool. A passkey is presented through the USER_AUTH flow, which
+    // this simulation refuses as a flow of its own.
+    const { cognito, userPoolId } = await poolWithMfa();
+
+    // When the pool is configured for one.
+    const error = await assertThrowsErrorAsync(async () => {
+      await cognito.setUserPoolMfaConfig(
+        new SetUserPoolMfaConfigCommand({
+          UserPoolId: userPoolId,
+          MfaConfiguration: "OPTIONAL",
+          WebAuthnConfiguration: { RelyingPartyId: "example.com" },
+        }),
+      );
+    });
+
+    // Then it is refused rather than accepted and never asked for.
+    assertStringIncludes(error.message, "signing in with a passkey");
+  });
+
   it("refuses a request naming no pool", async () => {
     // Given simulated Cognito.
     const cognito = new SimAws().cognitoIdentityProvider();

--- a/src/service/cognito/command/user-pool/sim-cognito-user-pool-validation.iso.test.ts
+++ b/src/service/cognito/command/user-pool/sim-cognito-user-pool-validation.iso.test.ts
@@ -34,11 +34,6 @@ const refusedInputs: readonly RefusedInput[] = [
     says: "stores a generated UUID as the username",
   },
   {
-    label: "MfaConfiguration",
-    input: { MfaConfiguration: "OPTIONAL" },
-    says: "multi-factor authentication",
-  },
-  {
     label: "UserPoolTier",
     input: { UserPoolTier: "PLUS" },
     says: "the Lite and Plus feature plans",
@@ -224,7 +219,6 @@ describe("sim Cognito user pool validation", () => {
     const created = await cognito.createUserPool(
       new CreateUserPoolCommand({
         PoolName: "myapp-users",
-        MfaConfiguration: "OFF",
         UserPoolTier: "ESSENTIALS",
       }),
     );

--- a/src/service/cognito/command/user-pool/sim-cognito-user-pool-view.ts
+++ b/src/service/cognito/command/user-pool/sim-cognito-user-pool-view.ts
@@ -20,7 +20,11 @@ export class SimCognitoUserPoolView {
    * `LambdaConfig` is reported only by a pool that was created with one, and
    * carries the triggers that pool runs.
    *
-   * `MfaConfiguration` is always `OFF` because MFA is not simulated.
+   * `MfaConfiguration` is what the pool was asked for, and no pool here
+   * challenges for a second factor whatever it says. Which factors a pool
+   * offers is not reported here on real Cognito either:
+   * `GetUserPoolMfaConfig` is what reports those.
+   *
    * `EstimatedNumberOfUsers` is how many users the pool holds now. Real
    * Cognito refreshes that number periodically rather than on each write, so
    * it can lag there in a way it never does here.
@@ -37,7 +41,7 @@ export class SimCognitoUserPoolView {
       Policies: { PasswordPolicy: pool.settings.passwordPolicy.toOutput() },
       DeletionProtection: pool.settings.deletionProtection.value,
       LambdaConfig: pool.settings.lambdaConfig.toOutput(),
-      MfaConfiguration: "OFF",
+      MfaConfiguration: pool.settings.mfa.configuration.value,
       AdminCreateUserConfig: pool.settings.adminCreateUserConfig.toOutput(),
       AutoVerifiedAttributes: pool.settings.autoVerifiedAttributes.toOutput(),
       EstimatedNumberOfUsers: pool.userCount,

--- a/src/service/cognito/command/user-pool/user-pool-mfa.command.ts
+++ b/src/service/cognito/command/user-pool/user-pool-mfa.command.ts
@@ -1,0 +1,49 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type { SimCognitoUserPoolMfaType } from "../../user-pool/mfa/sim-cognito-user-pool-mfa.js";
+
+/**
+ * The SetUserPoolMfaConfig inputs this simulation reads, and the ones it
+ * refuses.
+ *
+ * `SmsMfaConfiguration` and `EmailMfaConfiguration` are the refused two. A
+ * factor sent by SMS needs the pool's `SmsConfiguration` and one sent by email
+ * needs its `EmailConfiguration`, both of which are refused on
+ * `CreateUserPool`, so a pool here could not deliver either message.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/cognito-identity-provider/command/SetUserPoolMfaConfigCommand/
+ */
+export interface SimSetUserPoolMfaConfigCommandInput extends SimCognitoUserPoolMfaType {
+  readonly UserPoolId?: string | undefined;
+  readonly SmsMfaConfiguration?: object | undefined;
+  readonly EmailMfaConfiguration?: object | undefined;
+}
+
+/**
+ * Minimal structural sim Cognito SetUserPoolMfaConfig command.
+ */
+export interface SimSetUserPoolMfaConfigCommand {
+  readonly input: SimSetUserPoolMfaConfigCommandInput;
+}
+
+/**
+ * What `SetUserPoolMfaConfig` answers with, which is the configuration the
+ * pool now has, as real Cognito answers.
+ */
+export interface SimSetUserPoolMfaConfigCommandOutput extends SimCognitoUserPoolMfaType {
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim Cognito GetUserPoolMfaConfig command.
+ */
+export interface SimGetUserPoolMfaConfigCommand {
+  readonly input: SimGetUserPoolMfaConfigCommandInput;
+}
+
+export interface SimGetUserPoolMfaConfigCommandInput {
+  readonly UserPoolId?: string | undefined;
+}
+
+export interface SimGetUserPoolMfaConfigCommandOutput extends SimCognitoUserPoolMfaType {
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/cognito/command/user-pool/user-pool-mfa.command.ts
+++ b/src/service/cognito/command/user-pool/user-pool-mfa.command.ts
@@ -5,10 +5,13 @@ import type { SimCognitoUserPoolMfaType } from "../../user-pool/mfa/sim-cognito-
  * The SetUserPoolMfaConfig inputs this simulation reads, and the ones it
  * refuses.
  *
- * `SmsMfaConfiguration` and `EmailMfaConfiguration` are the refused two. A
+ * `SmsMfaConfiguration` and `EmailMfaConfiguration` are refused because a
  * factor sent by SMS needs the pool's `SmsConfiguration` and one sent by email
  * needs its `EmailConfiguration`, both of which are refused on
  * `CreateUserPool`, so a pool here could not deliver either message.
+ *
+ * `WebAuthnConfiguration` is refused because a passkey is presented through
+ * the `USER_AUTH` flow, which this simulation refuses as a flow of its own.
  *
  * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/cognito-identity-provider/command/SetUserPoolMfaConfigCommand/
  */
@@ -16,6 +19,7 @@ export interface SimSetUserPoolMfaConfigCommandInput extends SimCognitoUserPoolM
   readonly UserPoolId?: string | undefined;
   readonly SmsMfaConfiguration?: object | undefined;
   readonly EmailMfaConfiguration?: object | undefined;
+  readonly WebAuthnConfiguration?: object | undefined;
 }
 
 /**

--- a/src/service/cognito/command/user-pool/user-pool.command.ts
+++ b/src/service/cognito/command/user-pool/user-pool.command.ts
@@ -40,10 +40,10 @@ export interface SimCognitoUserPoolType
  *
  * Every input real Cognito accepts on both is named here, whether or not it
  * is simulated, so a request carrying one this simulation does not model can
- * be refused rather than silently ignored.
+ * be refused rather than silently ignored. The ones a pool acts on are on the
+ * settings input this extends, `MfaConfiguration` among them.
  */
 export interface SimCognitoUserPoolCommandInput extends SimCognitoUserPoolSettingsInput {
-  readonly MfaConfiguration?: string | undefined;
   readonly UserPoolTier?: string | undefined;
   readonly DeviceConfiguration?: object | undefined;
   readonly EmailConfiguration?: object | undefined;

--- a/src/service/cognito/index.ts
+++ b/src/service/cognito/index.ts
@@ -16,6 +16,15 @@ export {
   SimCognitoAdminCreateUserConfig,
   type SimCognitoAdminCreateUserConfigType,
 } from "./user-pool/sim-cognito-admin-create-user-config.js";
+export {
+  SimCognitoMfaConfiguration,
+  type SimCognitoMfaConfigurationValue,
+} from "./user-pool/mfa/sim-cognito-mfa-configuration.js";
+export {
+  SimCognitoUserPoolMfa,
+  type SimCognitoSoftwareTokenMfaConfigType,
+  type SimCognitoUserPoolMfaType,
+} from "./user-pool/mfa/sim-cognito-user-pool-mfa.js";
 export { SimCognitoAutoVerifiedAttributes } from "./user-pool/sim-cognito-auto-verified-attributes.js";
 export {
   SimCognitoPasswordPolicy,

--- a/src/service/cognito/sdk/sim-cognito-sdk-pool-routes.ts
+++ b/src/service/cognito/sdk/sim-cognito-sdk-pool-routes.ts
@@ -11,6 +11,10 @@ import type {
 } from "../command/client/user-pool-client.command.js";
 import type { SimListUserPoolsCommand } from "../command/user-pool/list-user-pools.command.js";
 import type {
+  SimGetUserPoolMfaConfigCommand,
+  SimSetUserPoolMfaConfigCommand,
+} from "../command/user-pool/user-pool-mfa.command.js";
+import type {
   SimCreateUserPoolCommand,
   SimDeleteUserPoolCommand,
   SimDescribeUserPoolCommand,
@@ -54,6 +58,22 @@ export function simCognitoSdkPoolRoutes(
       async (command, context): Promise<unknown> =>
         await simCognito.deleteUserPool(
           command as SimDeleteUserPoolCommand,
+          simSdkCallerOptions(context),
+        ),
+    ],
+    [
+      "SetUserPoolMfaConfigCommand",
+      async (command, context): Promise<unknown> =>
+        await simCognito.setUserPoolMfaConfig(
+          command as SimSetUserPoolMfaConfigCommand,
+          simSdkCallerOptions(context),
+        ),
+    ],
+    [
+      "GetUserPoolMfaConfigCommand",
+      async (command, context): Promise<unknown> =>
+        await simCognito.getUserPoolMfaConfig(
+          command as SimGetUserPoolMfaConfigCommand,
           simSdkCallerOptions(context),
         ),
     ],

--- a/src/service/cognito/sdk/sim-cognito-sdk-routing.iso.test.ts
+++ b/src/service/cognito/sdk/sim-cognito-sdk-routing.iso.test.ts
@@ -6,8 +6,10 @@ import {
   DeleteUserPoolCommand,
   DescribeUserPoolClientCommand,
   DescribeUserPoolCommand,
+  GetUserPoolMfaConfigCommand,
   ListUserPoolClientsCommand,
   ListUserPoolsCommand,
+  SetUserPoolMfaConfigCommand,
   UpdateUserPoolClientCommand,
   UpdateUserPoolCommand,
 } from "@aws-sdk/client-cognito-identity-provider";
@@ -183,6 +185,17 @@ describe("Cognito SDK interception", () => {
       }),
     );
 
+    await client.send(
+      new SetUserPoolMfaConfigCommand({
+        UserPoolId: userPoolId,
+        MfaConfiguration: "OPTIONAL",
+        SoftwareTokenMfaConfiguration: { Enabled: true },
+      }),
+    );
+    const readMfa = await client.send(
+      new GetUserPoolMfaConfigCommand({ UserPoolId: userPoolId }),
+    );
+
     const describedPool = await client.send(
       new DescribeUserPoolCommand({ UserPoolId: userPoolId }),
     );
@@ -209,9 +222,11 @@ describe("Cognito SDK interception", () => {
     assertIdentical(updatedClient.UserPoolClient?.AccessTokenValidity, 30);
     assertIdentical(describedClient.UserPoolClient?.ClientName, "web");
     assertIdentical(describedClient.UserPoolClient.AccessTokenValidity, 30);
+    assertIdentical(readMfa.MfaConfiguration, "OPTIONAL");
     assertArrayEquals(describedPool.UserPool?.AutoVerifiedAttributes, [
       "email",
     ]);
+    assertIdentical(describedPool.UserPool.MfaConfiguration, "OPTIONAL");
     assertArrayEquals(
       listedPools.UserPools?.map((listed) => listed.Name),
       ["myapp-users"],

--- a/src/service/cognito/sim-cognito-app-clients.ts
+++ b/src/service/cognito/sim-cognito-app-clients.ts
@@ -1,0 +1,81 @@
+import type { BackgroundScheduler } from "../../util/background/background.js";
+import type * as simCognitoCommands from "./command/sim-cognito-command.types.js";
+import type { SimCognitoCommands } from "./command/sim-cognito-commands.js";
+import { SimCognitoFederation } from "./sim-cognito-federation.js";
+import type { SimCognitoIdentityProviderRequestOptions } from "./sim-cognito-user-directory.js";
+
+export type { SimCognitoIdentityProviderRequestOptions } from "./sim-cognito-user-directory.js";
+
+interface SimCognitoAppClientsProperties {
+  readonly commands: SimCognitoCommands;
+  readonly background: BackgroundScheduler;
+}
+
+/**
+ * The app client operations of simulated Cognito.
+ *
+ * An app client is who an application is when it talks to a pool, and the pool
+ * settings around it are what the pool itself is, so the two are separate
+ * classes for the same reason the rest of the chain is: one class holding
+ * every Cognito operation had outgrown reading in one sitting.
+ */
+export abstract class SimCognitoAppClients extends SimCognitoFederation {
+  protected constructor(properties: SimCognitoAppClientsProperties) {
+    super(properties);
+  }
+
+  /**
+   * Handle a CreateUserPoolClient Command from the SDK.
+   */
+  async createUserPoolClient(
+    command: simCognitoCommands.SimCreateUserPoolClientCommand,
+    options?: SimCognitoIdentityProviderRequestOptions,
+  ): Promise<simCognitoCommands.SimCreateUserPoolClientCommandOutput> {
+    await this.background.sequence();
+    return this.commands.clients.create(command, options);
+  }
+
+  /**
+   * Handle a DescribeUserPoolClient Command from the SDK.
+   */
+  async describeUserPoolClient(
+    command: simCognitoCommands.SimDescribeUserPoolClientCommand,
+    options?: SimCognitoIdentityProviderRequestOptions,
+  ): Promise<simCognitoCommands.SimDescribeUserPoolClientCommandOutput> {
+    await this.background.sequence();
+    return this.commands.clients.describe(command, options);
+  }
+
+  /**
+   * Handle an UpdateUserPoolClient Command from the SDK.
+   */
+  async updateUserPoolClient(
+    command: simCognitoCommands.SimUpdateUserPoolClientCommand,
+    options?: SimCognitoIdentityProviderRequestOptions,
+  ): Promise<simCognitoCommands.SimUpdateUserPoolClientCommandOutput> {
+    await this.background.sequence();
+    return this.commands.clients.update(command, options);
+  }
+
+  /**
+   * Handle a DeleteUserPoolClient Command from the SDK.
+   */
+  async deleteUserPoolClient(
+    command: simCognitoCommands.SimDeleteUserPoolClientCommand,
+    options?: SimCognitoIdentityProviderRequestOptions,
+  ): Promise<simCognitoCommands.SimDeleteUserPoolClientCommandOutput> {
+    await this.background.sequence();
+    return this.commands.clients.delete(command, options);
+  }
+
+  /**
+   * Handle a ListUserPoolClients Command from the SDK.
+   */
+  async listUserPoolClients(
+    command: simCognitoCommands.SimListUserPoolClientsCommand,
+    options?: SimCognitoIdentityProviderRequestOptions,
+  ): Promise<simCognitoCommands.SimListUserPoolClientsCommandOutput> {
+    await this.background.sequence();
+    return this.commands.listClients.handle(command, options);
+  }
+}

--- a/src/service/cognito/sim-cognito-identity-provider.ts
+++ b/src/service/cognito/sim-cognito-identity-provider.ts
@@ -15,7 +15,7 @@ import { SimCognitoCommands } from "./command/sim-cognito-commands.js";
 import { SimCognitoDomainRegistry } from "./registry/sim-cognito-domain-registry.js";
 import { SimCognitoUserPoolRegistry } from "./registry/sim-cognito-user-pool-registry.js";
 import { SimCognitoSdkCommandRouter } from "./sdk/sim-cognito-sdk-command-router.js";
-import { SimCognitoFederation } from "./sim-cognito-federation.js";
+import { SimCognitoAppClients } from "./sim-cognito-app-clients.js";
 import type { SimCognitoIdentityProviderRequestOptions } from "./sim-cognito-user-directory.js";
 import type { SimCognitoUserPoolDomain } from "./user-pool/domain/sim-cognito-user-pool-domain.js";
 
@@ -68,14 +68,15 @@ interface SimCognitoIdentityProviderProperties {
  * id names the region it was created in, and an app client id is only
  * meaningful inside its pool.
  *
- * The pool and app client operations are here. The user and group operations
- * are on `SimCognitoUserDirectory`, which this extends, so a caller reaches
+ * The pool operations are here. The app client ones are on
+ * `SimCognitoAppClients` and the user and group ones on
+ * `SimCognitoUserDirectory`, both of which this extends, so a caller reaches
  * all of them on one service object.
  *
  * Only user pools are simulated. Cognito identity pools, which hand out AWS
  * credentials, are a different service and are not simulated at all.
  */
-export class SimCognitoIdentityProvider extends SimCognitoFederation {
+export class SimCognitoIdentityProvider extends SimCognitoAppClients {
   private readonly pools: SimCognitoUserPoolStore;
   private readonly userPoolRegistry: SimCognitoUserPoolRegistry;
   private readonly domainRegistry: SimCognitoDomainRegistry;
@@ -205,6 +206,32 @@ export class SimCognitoIdentityProvider extends SimCognitoFederation {
   }
 
   /**
+   * Handle a SetUserPoolMfaConfig Command from the SDK.
+   *
+   * This is the second call real CloudFormation makes when a template declares
+   * a pool with MFA, and the only place the factors behind an `MfaConfiguration`
+   * are set.
+   */
+  async setUserPoolMfaConfig(
+    command: simCognitoCommands.SimSetUserPoolMfaConfigCommand,
+    options?: SimCognitoIdentityProviderRequestOptions,
+  ): Promise<simCognitoCommands.SimSetUserPoolMfaConfigCommandOutput> {
+    await this.background.sequence();
+    return this.commands.userPoolMfa.set(command, options);
+  }
+
+  /**
+   * Handle a GetUserPoolMfaConfig Command from the SDK.
+   */
+  async getUserPoolMfaConfig(
+    command: simCognitoCommands.SimGetUserPoolMfaConfigCommand,
+    options?: SimCognitoIdentityProviderRequestOptions,
+  ): Promise<simCognitoCommands.SimGetUserPoolMfaConfigCommandOutput> {
+    await this.background.sequence();
+    return this.commands.userPoolMfa.get(command, options);
+  }
+
+  /**
    * Handle a ListUserPools Command from the SDK.
    */
   async listUserPools(
@@ -213,61 +240,6 @@ export class SimCognitoIdentityProvider extends SimCognitoFederation {
   ): Promise<simCognitoCommands.SimListUserPoolsCommandOutput> {
     await this.background.sequence();
     return this.commands.listUserPools.handle(command, options);
-  }
-
-  /**
-   * Handle a CreateUserPoolClient Command from the SDK.
-   */
-  async createUserPoolClient(
-    command: simCognitoCommands.SimCreateUserPoolClientCommand,
-    options?: SimCognitoIdentityProviderRequestOptions,
-  ): Promise<simCognitoCommands.SimCreateUserPoolClientCommandOutput> {
-    await this.background.sequence();
-    return this.commands.clients.create(command, options);
-  }
-
-  /**
-   * Handle a DescribeUserPoolClient Command from the SDK.
-   */
-  async describeUserPoolClient(
-    command: simCognitoCommands.SimDescribeUserPoolClientCommand,
-    options?: SimCognitoIdentityProviderRequestOptions,
-  ): Promise<simCognitoCommands.SimDescribeUserPoolClientCommandOutput> {
-    await this.background.sequence();
-    return this.commands.clients.describe(command, options);
-  }
-
-  /**
-   * Handle an UpdateUserPoolClient Command from the SDK.
-   */
-  async updateUserPoolClient(
-    command: simCognitoCommands.SimUpdateUserPoolClientCommand,
-    options?: SimCognitoIdentityProviderRequestOptions,
-  ): Promise<simCognitoCommands.SimUpdateUserPoolClientCommandOutput> {
-    await this.background.sequence();
-    return this.commands.clients.update(command, options);
-  }
-
-  /**
-   * Handle a DeleteUserPoolClient Command from the SDK.
-   */
-  async deleteUserPoolClient(
-    command: simCognitoCommands.SimDeleteUserPoolClientCommand,
-    options?: SimCognitoIdentityProviderRequestOptions,
-  ): Promise<simCognitoCommands.SimDeleteUserPoolClientCommandOutput> {
-    await this.background.sequence();
-    return this.commands.clients.delete(command, options);
-  }
-
-  /**
-   * Handle a ListUserPoolClients Command from the SDK.
-   */
-  async listUserPoolClients(
-    command: simCognitoCommands.SimListUserPoolClientsCommand,
-    options?: SimCognitoIdentityProviderRequestOptions,
-  ): Promise<simCognitoCommands.SimListUserPoolClientsCommandOutput> {
-    await this.background.sequence();
-    return this.commands.listClients.handle(command, options);
   }
 
   /**

--- a/src/service/cognito/user-pool/mfa/sim-cognito-mfa-configuration.ts
+++ b/src/service/cognito/user-pool/mfa/sim-cognito-mfa-configuration.ts
@@ -1,0 +1,54 @@
+import { SimCognitoInvalidParameterException } from "../../error/sim-cognito.error.js";
+
+export type SimCognitoMfaConfigurationValue = "OFF" | "ON" | "OPTIONAL";
+
+const mfaConfigurationValues: ReadonlySet<SimCognitoMfaConfigurationValue> =
+  new Set(["OFF", "ON", "OPTIONAL"]);
+
+/**
+ * Whether a user pool asks a user for a second factor when it signs in.
+ *
+ * A pool is created `OFF` unless the request asks for something else.
+ * `OPTIONAL` challenges only the users that have registered a factor, and `ON`
+ * challenges every user.
+ *
+ * The setting is kept and reported rather than acted on: nothing here
+ * registers a factor for a user, so no user of an `OPTIONAL` pool has one, and
+ * a sign-in to such a pool goes through without a challenge, as it does on real
+ * Cognito for a user that never registered one. An `ON` pool is the one that
+ * differs, so a sign-in to that is refused where the challenge would have been
+ * issued rather than at pool creation.
+ */
+export class SimCognitoMfaConfiguration {
+  public readonly value: SimCognitoMfaConfigurationValue;
+
+  constructor(requested: string | undefined) {
+    if (requested === undefined) {
+      this.value = "OFF";
+      return;
+    }
+
+    if (
+      !mfaConfigurationValues.has(requested as SimCognitoMfaConfigurationValue)
+    ) {
+      throw new SimCognitoInvalidParameterException(
+        `MfaConfiguration '${requested}' is not a Cognito MFA ` +
+          `configuration: use OFF, OPTIONAL or ON`,
+      );
+    }
+
+    this.value = requested as SimCognitoMfaConfigurationValue;
+  }
+
+  /**
+   * Whether every sign-in to the pool has to get past a second factor.
+   *
+   * This is the one setting no sign-in here can honour. A user of an `ON` pool
+   * is answered with an MFA challenge on real Cognito whether or not it has
+   * registered a factor, so tokens are never issued by the request that sent
+   * the password.
+   */
+  get challengesEverySignIn(): boolean {
+    return this.value === "ON";
+  }
+}

--- a/src/service/cognito/user-pool/mfa/sim-cognito-user-pool-mfa.ts
+++ b/src/service/cognito/user-pool/mfa/sim-cognito-user-pool-mfa.ts
@@ -1,0 +1,114 @@
+import { SimCognitoMfaConfiguration } from "./sim-cognito-mfa-configuration.js";
+
+/**
+ * Whether a pool offers a time-based one-time password as a second factor.
+ */
+export interface SimCognitoSoftwareTokenMfaConfigType {
+  readonly Enabled?: boolean | undefined;
+}
+
+/**
+ * The MFA configuration of a pool, in the shape `SetUserPoolMfaConfig` and
+ * `GetUserPoolMfaConfig` carry it.
+ *
+ * Real Cognito carries two more factor configurations here, one for SMS and
+ * one for email. Both need a delivery this simulation does not model, so both
+ * are refused by the command rather than reported back.
+ */
+export interface SimCognitoUserPoolMfaType {
+  readonly MfaConfiguration?: string | undefined;
+  readonly SoftwareTokenMfaConfiguration?:
+    | SimCognitoSoftwareTokenMfaConfigType
+    | undefined;
+}
+
+/**
+ * Whether a request asked for a time-based one-time password, and nothing
+ * where it named no such factor at all.
+ */
+function softwareTokenIn(
+  input: SimCognitoUserPoolMfaType,
+): boolean | undefined {
+  const requested = input.SoftwareTokenMfaConfiguration;
+
+  if (requested === undefined) {
+    return undefined;
+  }
+
+  return requested.Enabled ?? false;
+}
+
+/**
+ * The multi-factor authentication one simulated user pool is configured for:
+ * whether it challenges, and which factors it offers.
+ *
+ * The two arrive separately on real Cognito. `CreateUserPool` and
+ * `UpdateUserPool` carry the `MfaConfiguration` alone, and only
+ * `SetUserPoolMfaConfig` says which factors a challenge could use, which is why
+ * CloudFormation deploys a pool with MFA in two calls rather than one. That is
+ * also why an update replaces the challenging and leaves the factors where they
+ * were.
+ *
+ * Nothing here challenges for a factor, so this is state a pool reports rather
+ * than acts on. The one place it is read is a sign-in to a pool configured
+ * `ON`, which real Cognito answers with a challenge and this simulation
+ * refuses.
+ */
+export class SimCognitoUserPoolMfa {
+  #configuration: SimCognitoMfaConfiguration;
+
+  /**
+   * Whether a time-based one-time password is enabled, where a request said.
+   * A pool no `SetUserPoolMfaConfig` request has reached has no answer to give
+   * rather than a false one, which is what real Cognito reports for one.
+   */
+  #softwareToken: boolean | undefined;
+
+  constructor(configuration: SimCognitoMfaConfiguration) {
+    this.#configuration = configuration;
+  }
+
+  /**
+   * Whether the pool challenges, and which users it challenges.
+   */
+  get configuration(): SimCognitoMfaConfiguration {
+    return this.#configuration;
+  }
+
+  /**
+   * Replace the whole configuration, as `SetUserPoolMfaConfig` replaces it: a
+   * factor the request leaves out goes back to being unconfigured.
+   *
+   * A request naming `SoftwareTokenMfaConfiguration` without an `Enabled` is
+   * asking for it disabled, as real Cognito reads one.
+   */
+  set(input: SimCognitoUserPoolMfaType): void {
+    this.#configuration = new SimCognitoMfaConfiguration(
+      input.MfaConfiguration,
+    );
+    this.#softwareToken = softwareTokenIn(input);
+  }
+
+  /**
+   * Take on the factors of the configuration this one replaces.
+   *
+   * An `UpdateUserPool` request names an `MfaConfiguration` and no factor
+   * configuration at all, so an update changes whether the pool challenges and
+   * leaves what it would challenge with alone, as it does on real Cognito.
+   */
+  keepFactorsOf(replaced: SimCognitoUserPoolMfa): void {
+    this.#softwareToken = replaced.#softwareToken;
+  }
+
+  /**
+   * This configuration as `GetUserPoolMfaConfig` reports it.
+   */
+  toOutput(): SimCognitoUserPoolMfaType {
+    return {
+      MfaConfiguration: this.#configuration.value,
+      ...(this.#softwareToken !== undefined && {
+        SoftwareTokenMfaConfiguration: { Enabled: this.#softwareToken },
+      }),
+    };
+  }
+}

--- a/src/service/cognito/user-pool/sim-cognito-user-pool-settings.ts
+++ b/src/service/cognito/user-pool/sim-cognito-user-pool-settings.ts
@@ -4,6 +4,8 @@ import {
 } from "./sim-cognito-admin-create-user-config.js";
 import { SimCognitoAutoVerifiedAttributes } from "./sim-cognito-auto-verified-attributes.js";
 import { SimCognitoDeletionProtection } from "./sim-cognito-deletion-protection.js";
+import { SimCognitoMfaConfiguration } from "./mfa/sim-cognito-mfa-configuration.js";
+import { SimCognitoUserPoolMfa } from "./mfa/sim-cognito-user-pool-mfa.js";
 import {
   SimCognitoPasswordPolicy,
   type SimCognitoUserPoolPoliciesType,
@@ -30,6 +32,7 @@ export interface SimCognitoUserPoolSettingsInput
     SimCognitoVerificationMessagesType {
   readonly Policies?: SimCognitoUserPoolPoliciesType | undefined;
   readonly DeletionProtection?: string | undefined;
+  readonly MfaConfiguration?: string | undefined;
   readonly AdminCreateUserConfig?:
     | SimCognitoAdminCreateUserConfigType
     | undefined;
@@ -50,8 +53,8 @@ interface SimCognitoUserPoolSettingsProperties {
 /**
  * The settings of one simulated user pool that a request can change: the
  * password policy, the deletion protection, whether users may sign themselves
- * up, what confirming a sign-up verifies, the Lambda triggers the pool runs
- * and what its messages say.
+ * up, what confirming a sign-up verifies, the Lambda triggers the pool runs,
+ * whether it asks for a second factor and what its messages say.
  *
  * The pool's id, ARN and name are not among them. The first two identify the
  * pool, and renaming one is not simulated.
@@ -72,6 +75,18 @@ export class SimCognitoUserPoolSettings {
    * The Lambda triggers the pool runs, by the ARN of the function each names.
    */
   public readonly lambdaConfig: SimCognitoLambdaConfig;
+
+  /**
+   * Whether the pool challenges for a second factor, and which factors it
+   * offers.
+   *
+   * The `MfaConfiguration` is one of these settings because both pool requests
+   * carry it. The factors behind it are not: only `SetUserPoolMfaConfig` says
+   * what they are, and it changes them in place rather than through a whole
+   * new set of settings, so an update carries them across rather than
+   * replacing them.
+   */
+  public readonly mfa: SimCognitoUserPoolMfa;
 
   /**
    * What the pool says in the message it sends a user signing itself up.
@@ -102,6 +117,9 @@ export class SimCognitoUserPoolSettings {
     this.lambdaConfig = new SimCognitoLambdaConfig(
       input.LambdaConfig,
       operation,
+    );
+    this.mfa = new SimCognitoUserPoolMfa(
+      new SimCognitoMfaConfiguration(input.MfaConfiguration),
     );
     this.verificationMessages = new SimCognitoVerificationMessages(input);
     this.unsimulated = new SimCognitoUnsimulatedPoolSettings(input);


### PR DESCRIPTION
A pool can now be created with an `MfaConfiguration` of `OPTIONAL` or `ON`, and `DescribeUserPool` reports back what it was asked for. `SetUserPoolMfaConfig` and `GetUserPoolMfaConfig` set and read the factors behind it, `SOFTWARE_TOKEN_MFA` being the one this simulation accepts, and CloudFormation deploys `MfaConfiguration` and `EnabledMfas` in that second call once the pool exists, as real CloudFormation does and as a stack's `cognito-idp:SetUserPoolMfaConfig` permission implies. Nothing challenges for a second factor: a pool configured `OPTIONAL` behaves as a real one does for a user that never registered one, so sign-up and sign-in go on working against the pool a stack actually declares, and the refusal `CreateUserPool` used to make moves to the sign-in a pool configured `ON` would have challenged, where it can say what it was that could not be done.

Resolves https://github.com/KensioSoftware/yulin/issues/601

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added simulated Cognito MFA configuration with `OFF`, `OPTIONAL`, and `ON` modes.
  * Added software-token MFA support and APIs to set and retrieve pool MFA settings.
  * Added CloudFormation and SDK support for deploying and managing MFA configuration.
  * Added MFA behavior documentation and an end-to-end usage example.

* **Bug Fixes**
  * User-pool updates now preserve separately configured MFA factors.
  * Sign-ins requiring unsupported MFA challenges are rejected with clear errors.
  * Unsupported SMS and email MFA configurations now receive targeted validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->