### PR TITLE
feat: simulate CloudWatch Logs groups and events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 # Logs
-logs
+# Anchored to the root: unanchored, this matches any directory named `logs` at
+# any depth, which silently excludes src/service/logs and docs/services/logs.
+/logs/
 *.log
 npm-debug.log*
 yarn-debug.log*

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ npm i -D @kensio/yulin
 - [IAM](./docs/services/iam "Simulated IAM docs")
 - [KMS](./docs/services/kms "Simulated KMS docs")
 - [Lambda](./docs/services/lambda "Simulated Lambda docs")
+- [CloudWatch Logs](./docs/services/logs "Simulated CloudWatch Logs docs")
 - [Rekognition](./docs/services/rekognition "Simulated Rekognition docs")
 - [Route53](./docs/services/route53 "Simulated Route53 docs")
 - [S3](./docs/services/s3 "Simulated S3 docs")

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,6 +18,7 @@ behaviour and includes example code that can be copied into tests or local devel
 - [IAM](./services/iam/ "Simulated IAM usage docs")
 - [KMS](./services/kms/ "Simulated KMS usage docs")
 - [Lambda](./services/lambda/ "Simulated Lambda usage docs")
+- [CloudWatch Logs](./services/logs/ "Simulated CloudWatch Logs usage docs")
 - [Rekognition](./services/rekognition/ "Simulated Rekognition usage docs")
 - [Route53](./services/route53/ "Simulated Route53 usage docs")
 - [S3](./services/s3/ "Simulated S3 usage docs")

--- a/docs/services/logs/README.md
+++ b/docs/services/logs/README.md
@@ -46,7 +46,10 @@ await logs.putLogEvents(
     logGroupName,
     logStreamName,
     logEvents: [
-      { timestamp: Date.parse("2026-08-16T09:00:00Z"), message: "INFO handling order-1" },
+      {
+        timestamp: Date.parse("2026-08-16T09:00:00Z"),
+        message: "INFO handling order-1",
+      },
       {
         timestamp: Date.parse("2026-08-16T09:00:01Z"),
         message: "ERROR order has no items",
@@ -73,13 +76,13 @@ The plain text filter pattern syntax is supported: terms are matched as case sen
 every unprefixed term must appear, a `-` prefix excludes a term, a `?` prefix makes a term one of a
 set of alternatives, and a quoted phrase matches with its spaces intact.
 
-| Pattern | Matches |
-| --- | --- |
-| `ERROR` | messages containing `ERROR` |
-| `ERROR orders` | messages containing both terms |
-| `?ERROR ?WARN` | messages containing either term |
-| `ERROR -Throttling` | messages containing `ERROR` but not `Throttling` |
-| `"order has no items"` | messages containing that exact phrase |
+| Pattern                | Matches                                          |
+| ---------------------- | ------------------------------------------------ |
+| `ERROR`                | messages containing `ERROR`                      |
+| `ERROR orders`         | messages containing both terms                   |
+| `?ERROR ?WARN`         | messages containing either term                  |
+| `ERROR -Throttling`    | messages containing `ERROR` but not `Throttling` |
+| `"order has no items"` | messages containing that exact phrase            |
 
 An omitted or empty pattern matches everything.
 
@@ -99,6 +102,10 @@ back rather than nothing, so a caller polling a stream keeps it and asks again.
 
 Both readers narrow to a half open time window: an event whose timestamp equals `startTime` is
 included, and one whose timestamp equals `endTime` is not.
+
+A token is an offset into the events the request selected, so keep `startTime` and `endTime` the
+same across a walk. Changing the window part-way through means the offset is counted against a
+different set of events, and the page you get back will not be the one you expected.
 
 ```typescript sim-logs-read-a-stream
 /**

--- a/docs/services/logs/README.md
+++ b/docs/services/logs/README.md
@@ -1,0 +1,329 @@
+# Simulated CloudWatch Logs
+
+Yulin includes a simulated Amazon CloudWatch Logs for tests and local development. It holds log
+groups, the streams inside them and the events written to those streams, so a test can put log
+events and read them back with `GetLogEvents` or search them with `FilterLogEvents` without an AWS
+account.
+
+That is what this service is for: making log data addressable. Code that writes to CloudWatch Logs
+is code teams already have, and until now a test could only observe it by capturing process output.
+
+CloudWatch Logs specific types are imported from the `@kensio/yulin/logs` subpath.
+
+## Writing and searching log events
+
+A log group holds streams, a stream holds events, and `FilterLogEvents` searches across every
+stream in a group. That last part is what makes an assertion practical: the test names the group,
+not the stream, so it does not need to know which execution environment wrote the line.
+
+```typescript sim-logs-write-and-search
+/**
+ * Writing log events to a simulated log group and searching for one.
+ */
+
+import {
+  CreateLogGroupCommand,
+  CreateLogStreamCommand,
+  FilterLogEventsCommand,
+  PutLogEventsCommand,
+} from "@aws-sdk/client-cloudwatch-logs";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const logs = simAws.logs();
+
+const logGroupName = "/aws/lambda/orders";
+const logStreamName = "2026/08/16/[$LATEST]0f7c1a";
+
+await logs.createLogGroup(new CreateLogGroupCommand({ logGroupName }));
+await logs.createLogStream(
+  new CreateLogStreamCommand({ logGroupName, logStreamName }),
+);
+
+await logs.putLogEvents(
+  new PutLogEventsCommand({
+    logGroupName,
+    logStreamName,
+    logEvents: [
+      { timestamp: Date.parse("2026-08-16T09:00:00Z"), message: "INFO handling order-1" },
+      {
+        timestamp: Date.parse("2026-08-16T09:00:01Z"),
+        message: "ERROR order has no items",
+      },
+    ],
+  }),
+);
+
+const found = await logs.filterLogEvents(
+  new FilterLogEventsCommand({ logGroupName, filterPattern: "ERROR" }),
+);
+
+// One event, from the stream that wrote it.
+console.log(found.events?.length, found.events?.[0]?.logStreamName);
+```
+
+Neither the group nor the stream is created on the way. Real CloudWatch Logs refuses a write to
+either one that is not there, which is what makes a missing `logs:CreateLogStream` permission show
+up as a failure rather than as logs that quietly never appear.
+
+## Filter patterns
+
+The plain text filter pattern syntax is supported: terms are matched as case sensitive substrings,
+every unprefixed term must appear, a `-` prefix excludes a term, a `?` prefix makes a term one of a
+set of alternatives, and a quoted phrase matches with its spaces intact.
+
+| Pattern | Matches |
+| --- | --- |
+| `ERROR` | messages containing `ERROR` |
+| `ERROR orders` | messages containing both terms |
+| `?ERROR ?WARN` | messages containing either term |
+| `ERROR -Throttling` | messages containing `ERROR` but not `Throttling` |
+| `"order has no items"` | messages containing that exact phrase |
+
+An omitted or empty pattern matches everything.
+
+The structured pattern syntaxes are refused rather than approximated. A JSON property pattern
+(`{ $.level = "ERROR" }`), a space delimited field pattern (`[level=ERROR, message]`) and a regular
+expression term (`%ERROR|WARN%`) each raise `SimLogsUnsupportedOperationException`. That is
+deliberate: a pattern quietly treated as matching everything would turn an assertion about one log
+line into an assertion about any log line at all, and the test would keep passing while testing
+nothing.
+
+## Reading one stream
+
+`GetLogEvents` reads a single stream and pages in both directions. With no token it answers with
+the newest events, as real CloudWatch Logs does; `startFromHead` starts at the oldest instead.
+Following `nextForwardToken` walks towards newer events, and reaching the end gives the same token
+back rather than nothing, so a caller polling a stream keeps it and asks again.
+
+Both readers narrow to a half open time window: an event whose timestamp equals `startTime` is
+included, and one whose timestamp equals `endTime` is not.
+
+```typescript sim-logs-read-a-stream
+/**
+ * Paging through one simulated log stream from the oldest event.
+ */
+
+import {
+  CreateLogGroupCommand,
+  CreateLogStreamCommand,
+  GetLogEventsCommand,
+  PutLogEventsCommand,
+} from "@aws-sdk/client-cloudwatch-logs";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const logs = simAws.logs();
+
+const logGroupName = "/aws/lambda/orders";
+const logStreamName = "2026/08/16/[$LATEST]0f7c1a";
+
+await logs.createLogGroup(new CreateLogGroupCommand({ logGroupName }));
+await logs.createLogStream(
+  new CreateLogStreamCommand({ logGroupName, logStreamName }),
+);
+await logs.putLogEvents(
+  new PutLogEventsCommand({
+    logGroupName,
+    logStreamName,
+    logEvents: [1, 2, 3, 4, 5].map((second) => ({
+      timestamp: Date.parse("2026-08-16T09:00:00Z") + second * 1000,
+      message: `line ${second}`,
+    })),
+  }),
+);
+
+let nextToken: string | undefined;
+const read: string[] = [];
+
+for (;;) {
+  const page = await logs.getLogEvents(
+    new GetLogEventsCommand({
+      logGroupName,
+      logStreamName,
+      startFromHead: true,
+      limit: 2,
+      nextToken,
+    }),
+  );
+
+  if (page.events === undefined || page.events.length === 0) break;
+
+  read.push(...page.events.map((event) => event.message));
+  nextToken = page.nextForwardToken;
+}
+
+console.log(read);
+```
+
+## Retention
+
+Retention is held as a property to assert on. Nothing expires here: a test would have to move the
+clock by months to see an event go, and what teams get wrong about retention is the value they
+deployed rather than the deletion that eventually follows from it. A log group with no retention
+keeps its events forever, which is the AWS default.
+
+The set of accepted values is fixed rather than a range, so a reasonable-looking
+`retentionInDays: 10` is refused here exactly as it is by an account.
+
+```typescript sim-logs-retention
+/**
+ * Asserting on the retention a simulated log group was given.
+ */
+
+import {
+  CreateLogGroupCommand,
+  DescribeLogGroupsCommand,
+  PutRetentionPolicyCommand,
+} from "@aws-sdk/client-cloudwatch-logs";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const logs = simAws.logs();
+
+const logGroupName = "/aws/lambda/orders";
+
+await logs.createLogGroup(new CreateLogGroupCommand({ logGroupName }));
+await logs.putRetentionPolicy(
+  new PutRetentionPolicyCommand({ logGroupName, retentionInDays: 14 }),
+);
+
+const described = await logs.describeLogGroups(
+  new DescribeLogGroupsCommand({ logGroupNamePrefix: "/aws/lambda/" }),
+);
+
+// 14, and the ARN form a policy is written against.
+console.log(
+  described.logGroups?.[0]?.retentionInDays,
+  described.logGroups?.[0]?.arn,
+);
+```
+
+## Permissions
+
+Every operation goes through simulated IAM. An operation on a named log group authorizes against
+that group's ARN with the trailing `:*`, which is the form CloudWatch Logs policies are written in:
+granting `logs:PutLogEvents` on a group grants it on the streams inside, and the wildcard is what
+covers them. A policy naming `log-group:/aws/lambda/orders` without it reaches nothing here, exactly
+as it reaches nothing on real AWS.
+
+`DescribeLogGroups` names no particular group, so it authorizes against every log group in the
+account and region. A policy scoped to one group cannot describe them all.
+
+```typescript sim-logs-permissions
+/**
+ * A simulated IAM policy allowing a Role to write one function's logs.
+ */
+
+import {
+  CreateLogGroupCommand,
+  CreateLogStreamCommand,
+} from "@aws-sdk/client-cloudwatch-logs";
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const accountId = simAws.defaultAccountId;
+const regionName = simAws.defaultRegionName;
+const logGroupName = "/aws/lambda/orders";
+
+const role = await simAws.iam().createRole(
+  new CreateRoleCommand({
+    RoleName: "OrdersFunctionRole",
+    AssumeRolePolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Principal: { Service: "lambda.amazonaws.com" },
+        Action: "sts:AssumeRole",
+      },
+    }),
+  }),
+);
+
+await simAws.iam().putRolePolicy(
+  new PutRolePolicyCommand({
+    RoleName: "OrdersFunctionRole",
+    PolicyName: "WriteOwnLogs",
+    PolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Action: [
+          "logs:CreateLogGroup",
+          "logs:CreateLogStream",
+          "logs:PutLogEvents",
+        ],
+        // The trailing wildcard covers the streams inside the group.
+        Resource: `arn:aws:logs:${regionName}:${accountId}:log-group:${logGroupName}:*`,
+      },
+    }),
+  }),
+);
+
+const asRole = { caller: { kind: "arn", arn: role.Role.Arn } } as const;
+
+await simAws
+  .logs()
+  .createLogGroup(new CreateLogGroupCommand({ logGroupName }), asRole);
+await simAws.logs().createLogStream(
+  new CreateLogStreamCommand({
+    logGroupName,
+    logStreamName: "2026/08/16/[$LATEST]0f7c1a",
+  }),
+  asRole,
+);
+
+console.log(simAws.logs().findLogGroup(logGroupName)?.logGroupArn);
+```
+
+## Through an intercepted SDK client
+
+Application code that constructs its own `CloudWatchLogsClient` reaches the simulator through SDK
+interception, with nothing to change in the code under test.
+
+```typescript sim-logs-sdk-interception
+/**
+ * Reaching simulated CloudWatch Logs through an intercepted SDK client.
+ */
+
+import {
+  CloudWatchLogsClient,
+  CreateLogGroupCommand,
+  DescribeLogGroupsCommand,
+} from "@aws-sdk/client-cloudwatch-logs";
+
+import { SimSdk } from "@kensio/yulin/sdk";
+
+using simSdk = new SimSdk();
+simSdk.intercept(CloudWatchLogsClient);
+
+const client = new CloudWatchLogsClient({ region: "eu-west-2" });
+
+await client.send(
+  new CreateLogGroupCommand({ logGroupName: "/aws/lambda/orders" }),
+);
+
+const described = await client.send(new DescribeLogGroupsCommand({}));
+
+// The ARN names the Region the client was configured for.
+console.log(described.logGroups?.[0]?.logGroupArn);
+```
+
+## What is not simulated
+
+- **Nothing expires.** Retention is stored and reported, never acted on.
+- **Subscription filters and metric filters.** Neither exists yet, so nothing is delivered onward
+  from a log group and `metricFilterCount` is always zero.
+- **Logs Insights, export tasks, tags, encryption and data protection policies.** Absent. Tags and
+  `kmsKeyId` on `CreateLogGroup` are refused rather than dropped, so nothing looks set here and
+  behaves differently in an account.
+- **Per-stream `storedBytes`.** Always zero, which matches real CloudWatch Logs: it stopped
+  reporting the figure per stream in 2019. `DescribeLogGroups` reports the bytes a group holds.
+- **Automatic log capture.** Nothing writes to a log group by itself yet. A simulated Lambda
+  invocation still forwards its handler's output to the host's standard streams, so a group holds
+  only what something put there through `PutLogEvents`.

--- a/docs/services/logs/sim-logs-permissions.example.ts
+++ b/docs/services/logs/sim-logs-permissions.example.ts
@@ -1,0 +1,65 @@
+/**
+ * A simulated IAM policy allowing a Role to write one function's logs.
+ */
+
+import {
+  CreateLogGroupCommand,
+  CreateLogStreamCommand,
+} from "@aws-sdk/client-cloudwatch-logs";
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const accountId = simAws.defaultAccountId;
+const regionName = simAws.defaultRegionName;
+const logGroupName = "/aws/lambda/orders";
+
+const role = await simAws.iam().createRole(
+  new CreateRoleCommand({
+    RoleName: "OrdersFunctionRole",
+    AssumeRolePolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Principal: { Service: "lambda.amazonaws.com" },
+        Action: "sts:AssumeRole",
+      },
+    }),
+  }),
+);
+
+await simAws.iam().putRolePolicy(
+  new PutRolePolicyCommand({
+    RoleName: "OrdersFunctionRole",
+    PolicyName: "WriteOwnLogs",
+    PolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Action: [
+          "logs:CreateLogGroup",
+          "logs:CreateLogStream",
+          "logs:PutLogEvents",
+        ],
+        // The trailing wildcard covers the streams inside the group.
+        Resource: `arn:aws:logs:${regionName}:${accountId}:log-group:${logGroupName}:*`,
+      },
+    }),
+  }),
+);
+
+const asRole = { caller: { kind: "arn", arn: role.Role.Arn } } as const;
+
+await simAws
+  .logs()
+  .createLogGroup(new CreateLogGroupCommand({ logGroupName }), asRole);
+await simAws.logs().createLogStream(
+  new CreateLogStreamCommand({
+    logGroupName,
+    logStreamName: "2026/08/16/[$LATEST]0f7c1a",
+  }),
+  asRole,
+);
+
+console.log(simAws.logs().findLogGroup(logGroupName)?.logGroupArn);

--- a/docs/services/logs/sim-logs-read-a-stream.example.ts
+++ b/docs/services/logs/sim-logs-read-a-stream.example.ts
@@ -1,0 +1,55 @@
+/**
+ * Paging through one simulated log stream from the oldest event.
+ */
+
+import {
+  CreateLogGroupCommand,
+  CreateLogStreamCommand,
+  GetLogEventsCommand,
+  PutLogEventsCommand,
+} from "@aws-sdk/client-cloudwatch-logs";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const logs = simAws.logs();
+
+const logGroupName = "/aws/lambda/orders";
+const logStreamName = "2026/08/16/[$LATEST]0f7c1a";
+
+await logs.createLogGroup(new CreateLogGroupCommand({ logGroupName }));
+await logs.createLogStream(
+  new CreateLogStreamCommand({ logGroupName, logStreamName }),
+);
+await logs.putLogEvents(
+  new PutLogEventsCommand({
+    logGroupName,
+    logStreamName,
+    logEvents: [1, 2, 3, 4, 5].map((second) => ({
+      timestamp: Date.parse("2026-08-16T09:00:00Z") + second * 1000,
+      message: `line ${second}`,
+    })),
+  }),
+);
+
+let nextToken: string | undefined;
+const read: string[] = [];
+
+for (;;) {
+  const page = await logs.getLogEvents(
+    new GetLogEventsCommand({
+      logGroupName,
+      logStreamName,
+      startFromHead: true,
+      limit: 2,
+      nextToken,
+    }),
+  );
+
+  if (page.events === undefined || page.events.length === 0) break;
+
+  read.push(...page.events.map((event) => event.message));
+  nextToken = page.nextForwardToken;
+}
+
+console.log(read);

--- a/docs/services/logs/sim-logs-retention.example.ts
+++ b/docs/services/logs/sim-logs-retention.example.ts
@@ -1,0 +1,31 @@
+/**
+ * Asserting on the retention a simulated log group was given.
+ */
+
+import {
+  CreateLogGroupCommand,
+  DescribeLogGroupsCommand,
+  PutRetentionPolicyCommand,
+} from "@aws-sdk/client-cloudwatch-logs";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const logs = simAws.logs();
+
+const logGroupName = "/aws/lambda/orders";
+
+await logs.createLogGroup(new CreateLogGroupCommand({ logGroupName }));
+await logs.putRetentionPolicy(
+  new PutRetentionPolicyCommand({ logGroupName, retentionInDays: 14 }),
+);
+
+const described = await logs.describeLogGroups(
+  new DescribeLogGroupsCommand({ logGroupNamePrefix: "/aws/lambda/" }),
+);
+
+// 14, and the ARN form a policy is written against.
+console.log(
+  described.logGroups?.[0]?.retentionInDays,
+  described.logGroups?.[0]?.arn,
+);

--- a/docs/services/logs/sim-logs-sdk-interception.example.ts
+++ b/docs/services/logs/sim-logs-sdk-interception.example.ts
@@ -1,0 +1,25 @@
+/**
+ * Reaching simulated CloudWatch Logs through an intercepted SDK client.
+ */
+
+import {
+  CloudWatchLogsClient,
+  CreateLogGroupCommand,
+  DescribeLogGroupsCommand,
+} from "@aws-sdk/client-cloudwatch-logs";
+
+import { SimSdk } from "@kensio/yulin/sdk";
+
+using simSdk = new SimSdk();
+simSdk.intercept(CloudWatchLogsClient);
+
+const client = new CloudWatchLogsClient({ region: "eu-west-2" });
+
+await client.send(
+  new CreateLogGroupCommand({ logGroupName: "/aws/lambda/orders" }),
+);
+
+const described = await client.send(new DescribeLogGroupsCommand({}));
+
+// The ARN names the Region the client was configured for.
+console.log(described.logGroups?.[0]?.logGroupArn);

--- a/docs/services/logs/sim-logs-write-and-search.example.ts
+++ b/docs/services/logs/sim-logs-write-and-search.example.ts
@@ -27,7 +27,10 @@ await logs.putLogEvents(
     logGroupName,
     logStreamName,
     logEvents: [
-      { timestamp: Date.parse("2026-08-16T09:00:00Z"), message: "INFO handling order-1" },
+      {
+        timestamp: Date.parse("2026-08-16T09:00:00Z"),
+        message: "INFO handling order-1",
+      },
       {
         timestamp: Date.parse("2026-08-16T09:00:01Z"),
         message: "ERROR order has no items",

--- a/docs/services/logs/sim-logs-write-and-search.example.ts
+++ b/docs/services/logs/sim-logs-write-and-search.example.ts
@@ -1,0 +1,44 @@
+/**
+ * Writing log events to a simulated log group and searching for one.
+ */
+
+import {
+  CreateLogGroupCommand,
+  CreateLogStreamCommand,
+  FilterLogEventsCommand,
+  PutLogEventsCommand,
+} from "@aws-sdk/client-cloudwatch-logs";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const logs = simAws.logs();
+
+const logGroupName = "/aws/lambda/orders";
+const logStreamName = "2026/08/16/[$LATEST]0f7c1a";
+
+await logs.createLogGroup(new CreateLogGroupCommand({ logGroupName }));
+await logs.createLogStream(
+  new CreateLogStreamCommand({ logGroupName, logStreamName }),
+);
+
+await logs.putLogEvents(
+  new PutLogEventsCommand({
+    logGroupName,
+    logStreamName,
+    logEvents: [
+      { timestamp: Date.parse("2026-08-16T09:00:00Z"), message: "INFO handling order-1" },
+      {
+        timestamp: Date.parse("2026-08-16T09:00:01Z"),
+        message: "ERROR order has no items",
+      },
+    ],
+  }),
+);
+
+const found = await logs.filterLogEvents(
+  new FilterLogEventsCommand({ logGroupName, filterPattern: "ERROR" }),
+);
+
+// One event, from the stream that wrote it.
+console.log(found.events?.length, found.events?.[0]?.logStreamName);

--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -20,6 +20,7 @@
       "@kensio/yulin/iam": ["../src/service/iam/index.ts"],
       "@kensio/yulin/kms": ["../src/service/kms/index.ts"],
       "@kensio/yulin/lambda": ["../src/service/lambda/index.ts"],
+      "@kensio/yulin/logs": ["../src/service/logs/index.ts"],
       "@kensio/yulin/oxlint": ["../src/config/oxlint/index.ts"],
       "@kensio/yulin/rekognition": ["../src/service/rekognition/index.ts"],
       "@kensio/yulin/route53": ["../src/service/route53/index.ts"],

--- a/package.json
+++ b/package.json
@@ -102,6 +102,10 @@
       "import": "./dist/service/lambda/index.js",
       "types": "./dist/service/lambda/index.d.ts"
     },
+    "./logs": {
+      "import": "./dist/service/logs/index.js",
+      "types": "./dist/service/logs/index.d.ts"
+    },
     "./oxlint": {
       "import": "./dist/config/oxlint/index.js",
       "types": "./dist/config/oxlint/index.d.ts"
@@ -170,6 +174,7 @@
     "@aws-sdk/client-cloudformation": "^3.1101.0",
     "@aws-sdk/client-cloudfront": "^3.1101.0",
     "@aws-sdk/client-cloudfront-keyvaluestore": "^3.1108.0",
+    "@aws-sdk/client-cloudwatch-logs": "^3.1101.0",
     "@aws-sdk/client-cognito-identity-provider": "^3.1101.0",
     "@aws-sdk/client-dynamodb": "^3.1101.0",
     "@aws-sdk/client-dynamodb-streams": "^3.1101.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,6 +42,9 @@ importers:
       '@aws-sdk/client-cloudfront-keyvaluestore':
         specifier: ^3.1108.0
         version: 3.1108.0
+      '@aws-sdk/client-cloudwatch-logs':
+        specifier: ^3.1101.0
+        version: 3.1111.0
       '@aws-sdk/client-cognito-identity-provider':
         specifier: ^3.1101.0
         version: 3.1105.0
@@ -279,6 +282,10 @@ packages:
     resolution: {integrity: sha512-gk9lVWVJ85qwxRjQ0GntkvXvAseg942Yui82o68sPYEJAcL9HW9zDHhBQwderTxfwtE/ZeyYlcbIyEZ0Impbkw==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/client-cloudwatch-logs@3.1111.0':
+    resolution: {integrity: sha512-IO2wKucjHIduO2z263JCMAezA5YCpFrSj4QN1u4FPZTVjUxWlE9DGGYbCuR2/1zGOp2Y3uvuk+GD0Gj7HrhpJQ==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/client-cognito-identity-provider@3.1105.0':
     resolution: {integrity: sha512-LsFDeuFsY2S5dRM+UTSQc+GtMQ6geGw8qKInlsgDJJnOqZmBPYQ6ZPLVuEpFKOObZd1DjcV959wKnALp1x+PHg==}
     engines: {node: '>=20.0.0'}
@@ -355,36 +362,72 @@ packages:
     resolution: {integrity: sha512-I88Iov89NVmjSmJLKSv7Cn9M2J+a2942OkA8nZCbz+sl4ZeY4zEOcoLOrbt1GRfQ8zEQKnjAJdXixA3J/p1fDQ==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/core@3.977.8':
+    resolution: {integrity: sha512-7+Kcrkvrk9lM/m7jRhHpT4jCdvzGHsuaSRbF8TdzzkY1mRzp/Ogwf9c7H29k4gGhey0BBWhCWr16+t0J61gwmg==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-env@3.972.68':
     resolution: {integrity: sha512-2a20A/IdNOwUvaDq91iqqS7BA0XlNMfW3iLGZGZLJv0EbUqhSxB0PIx4rQQqssvWj1uXImb3/UCCdHz/+1dOiA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-env@3.972.69':
+    resolution: {integrity: sha512-AreCFzcB4kH2HF9031Ot0jSJr3KXvRg6e8uDeub20JEVdZU3Bv0sTq1plc7VsT3KiqutlzH7l0j50UcCWHUioA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-http@3.972.70':
     resolution: {integrity: sha512-0yRem2Fs52r/Nn6UAqIlpjexfaYj8ziEozOe9tamtAVT/5bzFLKx8O2r7MaRqgS3hGKHIa1Jij9nKHSsNnb04A==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-http@3.972.71':
+    resolution: {integrity: sha512-A8ObcqVmDMnk4F9NozZ7JwmUu9Q4xyBJkmyq1C5U+wNM9ht9J7+EuuyabsLWXZnOoTqFaJuYBYTKf5CTipkEjA==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-ini@3.973.13':
     resolution: {integrity: sha512-2M39DE02XpYYaSWYk/4AsImXYUU/1L2xmTMLUpMMWq7DfLv191/vCRy3baKtdr45AkJQyVgSjmuVOLm15SwrRQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-ini@3.973.14':
+    resolution: {integrity: sha512-7c+Wti2LsERNWMfm7ySz3/6RPopFW3Nmn7s63Xpcq6R/tRuY5hpvkHA2xVgi5ukJbvok9l0IDtVEvqTtg+X7dw==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-login@3.972.75':
     resolution: {integrity: sha512-jaTESuJlQsoUZ44f/i2puyPt8VlF/dMMJ9HM3cStYtk7eKX4N9UWi83OLixUkoOJH3BwWlPLCq9YIK9nfWhVBg==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-login@3.972.76':
+    resolution: {integrity: sha512-LVixwOnEJfrrfKHeZjBA8pIMTZjNDq8ak8VpcoWUuCJDrSnBNU8POJksULMgvN089P0MXtQYH2Zs627/MK1K0g==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-node@3.972.79':
     resolution: {integrity: sha512-RIw5dof1EHkWubrZzPC941CDtnFG1iAXsxbFgLkhdYZXHc4icU13c/uxSMI0J5eUx9bxa7LjfpdjfClBB1QsDA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-node@3.972.80':
+    resolution: {integrity: sha512-bE2qh8ww4iClO1jHsBXdOE8FUgzDbdxbyorNjSCoPSkQd51k3jODItuPZfuwcLHZqDXsH+bI4AMHhqtuyR7mSg==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-process@3.972.68':
     resolution: {integrity: sha512-nLP3Pda2MQTFJ25hKBMmUuB9Uv+bTZQNlufbeCwklP549Vwnkd8bRLJoCKp5k6xjmdyptrPrOfGOhN0mKuca8A==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-process@3.972.69':
+    resolution: {integrity: sha512-9kpTNdZTrcqXTfhxM7fgl9Z68ek3Fu5oe3Yf+A/pJGibEqpgZxz2tSY7SinmyCIU2PJ+ygY4FPoBBnLpocMtrQ==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-sso@3.973.12':
     resolution: {integrity: sha512-EmgyyHn+f9WCcelp3L/vci+LGbX8GigWaVphRArjVo5Pktkr9YnLy/mQ6VDkDyBD72dtfRNTgHmD2ts4rTDXKQ==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-sso@3.973.13':
+    resolution: {integrity: sha512-Oc81qauMPzUoTnAS2YKpNwY6sY/LUyQTEeaf6yP197WMxkEBQfcKLR1MFpD7+pNTubXnfkH6gwpji+Gc7iyD2Q==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-web-identity@3.972.74':
     resolution: {integrity: sha512-0YfczxGXF3RjGj8z7QG/Ho2HnLGKDHfPSHiTs47UU1U/+mmwISDN+rvGKt2zh+3FX8NdT4xd95LGBGyhQw2dgQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.75':
+    resolution: {integrity: sha512-YPN6uoGDgjjjeVFZrcOeCJqmB6zpXoeeNgIjqe+DexJaWqdjVfCCe+VAZwli9Z2h8KhFW8oxkO39emQ1tyz/Mw==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/dynamodb-codec@3.973.42':
@@ -421,6 +464,10 @@ packages:
     resolution: {integrity: sha512-XWRyon2MTHXD/zMoo0Mbge6Vwf+iE0qQaM/RyGO6NfZ9WukCFiQL27nQVZjYy2JwSIg+iXZxKOX95OBXqlSM4w==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/nested-clients@3.997.43':
+    resolution: {integrity: sha512-bit+VpqWNyi3wHxFoTsTliNXimCSL2r2OeDTm7ZrG+YsTZ2D7ofDJ6r/t9PVBn80i6/v0X2h9Tgw6QP2MAKfPw==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/s3-request-presigner@3.1105.0':
     resolution: {integrity: sha512-BaWEMVBsVHsJwpVnBmkzwzF7127hjELPNldXfJ0qiBvuco45ADDF1NbmaCrs93iFpSlFEhf+7mu4HmXS9nIlyw==}
     engines: {node: '>=20.0.0'}
@@ -429,8 +476,16 @@ packages:
     resolution: {integrity: sha512-ZSfQ35Qn4MhSY+A0Whyr+KBx+wJKZUyBsOrjB2pSHOafRzbFe47T8XcXM8hZqUAC69qnqIy0C9ArxTuud0CC2w==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/signature-v4-multi-region@3.996.45':
+    resolution: {integrity: sha512-bBuyztukzXq6plzFGHAWiQt0QXo+HL8b8lX5cFTzkez/74PtS1c0qPFCIVuHkyoT+miH2qOjAcm1/yoro2ESPA==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/token-providers@3.1108.0':
     resolution: {integrity: sha512-rI80zxDxGJ6904eC/YbjkdjY6JdaZvQ01kOmrMvw7cFQGIHo27fhnIVbMSVDS4T6foQImjxYSRoOu/uSJscXDw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1111.0':
+    resolution: {integrity: sha512-JfljgoVtl+s3Qy21n9a7Z48uCQaOXcN74KJ3TEQfPoB293GrXFSt6HSQJF1sTZ8c/5QedEvd3NjJQMO4u9qa5A==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/types@3.974.2':
@@ -441,6 +496,10 @@ packages:
     resolution: {integrity: sha512-ECAqfpNsef+7MO8qtR0h9KcFIBAygaE7Cm6UOiQl+ft+uVap+1G7bNEjs4mdJE2OnA4m6k7i8peH8uGIAsOMGw==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/types@3.974.4':
+    resolution: {integrity: sha512-dSFDNG00MEz0/xl5gxL62giLd1iYyJsTxZ1I1DOj6lC+bbgLB4TRsYClJg3b62dhXT1uATzsTNXPnC+33EJV3A==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/util-dynamodb@3.996.8':
     resolution: {integrity: sha512-zg9Scj7J5MCQS4XeEkvKwPN6Crw3oYjFBICxfPpcrIurEKhckL1o/Co8cNKC2WxsYwKmaywFTB8cxpmJqSUx5Q==}
     engines: {node: '>=20.0.0'}
@@ -449,6 +508,10 @@ packages:
 
   '@aws-sdk/xml-builder@3.972.38':
     resolution: {integrity: sha512-grf7mzfVxBS5AlsuTvBN7uDpzqohFww9fRPCO+EBSUdvtsYMcPSKdz54h/7XiscqNcUM1Ae1MF7JLHmiYYuzbQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/xml-builder@3.972.39':
+    resolution: {integrity: sha512-FTti8DS5MMWXNUWiRwXAJeYS+0GHHiMy0+7XOhcwk63ILHmfS2UFy2z/HNpZCSOJJ3P3dnWY6hfYNW3DF0nXUA==}
     engines: {node: '>=20.0.0'}
 
   '@aws/lambda-invoke-store@0.3.0':
@@ -3504,6 +3567,17 @@ snapshots:
       '@smithy/types': 4.17.0
       tslib: 2.8.1
 
+  '@aws-sdk/client-cloudwatch-logs@3.1111.0':
+    dependencies:
+      '@aws-sdk/core': 3.977.8
+      '@aws-sdk/credential-provider-node': 3.972.80
+      '@aws-sdk/types': 3.974.4
+      '@smithy/core': 3.32.0
+      '@smithy/fetch-http-handler': 5.7.0
+      '@smithy/node-http-handler': 4.10.0
+      '@smithy/types': 4.17.0
+      tslib: 2.8.1
+
   '@aws-sdk/client-cognito-identity-provider@3.1105.0':
     dependencies:
       '@aws-sdk/core': 3.977.7
@@ -3722,6 +3796,17 @@ snapshots:
       bowser: 2.14.1
       tslib: 2.8.1
 
+  '@aws-sdk/core@3.977.8':
+    dependencies:
+      '@aws-sdk/types': 3.974.4
+      '@aws-sdk/xml-builder': 3.972.39
+      '@aws/lambda-invoke-store': 0.3.0
+      '@smithy/core': 3.32.0
+      '@smithy/signature-v4': 5.7.0
+      '@smithy/types': 4.17.0
+      bowser: 2.14.1
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-env@3.972.68':
     dependencies:
       '@aws-sdk/core': 3.977.7
@@ -3730,10 +3815,28 @@ snapshots:
       '@smithy/types': 4.17.0
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-env@3.972.69':
+    dependencies:
+      '@aws-sdk/core': 3.977.8
+      '@aws-sdk/types': 3.974.4
+      '@smithy/core': 3.32.0
+      '@smithy/types': 4.17.0
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-http@3.972.70':
     dependencies:
       '@aws-sdk/core': 3.977.7
       '@aws-sdk/types': 3.974.3
+      '@smithy/core': 3.32.0
+      '@smithy/fetch-http-handler': 5.7.0
+      '@smithy/node-http-handler': 4.10.0
+      '@smithy/types': 4.17.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.71':
+    dependencies:
+      '@aws-sdk/core': 3.977.8
+      '@aws-sdk/types': 3.974.4
       '@smithy/core': 3.32.0
       '@smithy/fetch-http-handler': 5.7.0
       '@smithy/node-http-handler': 4.10.0
@@ -3756,11 +3859,36 @@ snapshots:
       '@smithy/types': 4.17.0
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-ini@3.973.14':
+    dependencies:
+      '@aws-sdk/core': 3.977.8
+      '@aws-sdk/credential-provider-env': 3.972.69
+      '@aws-sdk/credential-provider-http': 3.972.71
+      '@aws-sdk/credential-provider-login': 3.972.76
+      '@aws-sdk/credential-provider-process': 3.972.69
+      '@aws-sdk/credential-provider-sso': 3.973.13
+      '@aws-sdk/credential-provider-web-identity': 3.972.75
+      '@aws-sdk/nested-clients': 3.997.43
+      '@aws-sdk/types': 3.974.4
+      '@smithy/core': 3.32.0
+      '@smithy/credential-provider-imds': 4.5.0
+      '@smithy/types': 4.17.0
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-login@3.972.75':
     dependencies:
       '@aws-sdk/core': 3.977.7
       '@aws-sdk/nested-clients': 3.997.42
       '@aws-sdk/types': 3.974.3
+      '@smithy/core': 3.32.0
+      '@smithy/types': 4.17.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-login@3.972.76':
+    dependencies:
+      '@aws-sdk/core': 3.977.8
+      '@aws-sdk/nested-clients': 3.997.43
+      '@aws-sdk/types': 3.974.4
       '@smithy/core': 3.32.0
       '@smithy/types': 4.17.0
       tslib: 2.8.1
@@ -3779,10 +3907,32 @@ snapshots:
       '@smithy/types': 4.17.0
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-node@3.972.80':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.69
+      '@aws-sdk/credential-provider-http': 3.972.71
+      '@aws-sdk/credential-provider-ini': 3.973.14
+      '@aws-sdk/credential-provider-process': 3.972.69
+      '@aws-sdk/credential-provider-sso': 3.973.13
+      '@aws-sdk/credential-provider-web-identity': 3.972.75
+      '@aws-sdk/types': 3.974.4
+      '@smithy/core': 3.32.0
+      '@smithy/credential-provider-imds': 4.5.0
+      '@smithy/types': 4.17.0
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-process@3.972.68':
     dependencies:
       '@aws-sdk/core': 3.977.7
       '@aws-sdk/types': 3.974.3
+      '@smithy/core': 3.32.0
+      '@smithy/types': 4.17.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-process@3.972.69':
+    dependencies:
+      '@aws-sdk/core': 3.977.8
+      '@aws-sdk/types': 3.974.4
       '@smithy/core': 3.32.0
       '@smithy/types': 4.17.0
       tslib: 2.8.1
@@ -3797,11 +3947,30 @@ snapshots:
       '@smithy/types': 4.17.0
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-sso@3.973.13':
+    dependencies:
+      '@aws-sdk/core': 3.977.8
+      '@aws-sdk/nested-clients': 3.997.43
+      '@aws-sdk/token-providers': 3.1111.0
+      '@aws-sdk/types': 3.974.4
+      '@smithy/core': 3.32.0
+      '@smithy/types': 4.17.0
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-web-identity@3.972.74':
     dependencies:
       '@aws-sdk/core': 3.977.7
       '@aws-sdk/nested-clients': 3.997.42
       '@aws-sdk/types': 3.974.3
+      '@smithy/core': 3.32.0
+      '@smithy/types': 4.17.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-web-identity@3.972.75':
+    dependencies:
+      '@aws-sdk/core': 3.977.8
+      '@aws-sdk/nested-clients': 3.997.43
+      '@aws-sdk/types': 3.974.4
       '@smithy/core': 3.32.0
       '@smithy/types': 4.17.0
       tslib: 2.8.1
@@ -3868,6 +4037,17 @@ snapshots:
       '@smithy/types': 4.17.0
       tslib: 2.8.1
 
+  '@aws-sdk/nested-clients@3.997.43':
+    dependencies:
+      '@aws-sdk/core': 3.977.8
+      '@aws-sdk/signature-v4-multi-region': 3.996.45
+      '@aws-sdk/types': 3.974.4
+      '@smithy/core': 3.32.0
+      '@smithy/fetch-http-handler': 5.7.0
+      '@smithy/node-http-handler': 4.10.0
+      '@smithy/types': 4.17.0
+      tslib: 2.8.1
+
   '@aws-sdk/s3-request-presigner@3.1105.0':
     dependencies:
       '@aws-sdk/core': 3.977.7
@@ -3884,11 +4064,27 @@ snapshots:
       '@smithy/types': 4.17.0
       tslib: 2.8.1
 
+  '@aws-sdk/signature-v4-multi-region@3.996.45':
+    dependencies:
+      '@aws-sdk/types': 3.974.4
+      '@smithy/signature-v4': 5.7.0
+      '@smithy/types': 4.17.0
+      tslib: 2.8.1
+
   '@aws-sdk/token-providers@3.1108.0':
     dependencies:
       '@aws-sdk/core': 3.977.7
       '@aws-sdk/nested-clients': 3.997.42
       '@aws-sdk/types': 3.974.3
+      '@smithy/core': 3.32.0
+      '@smithy/types': 4.17.0
+      tslib: 2.8.1
+
+  '@aws-sdk/token-providers@3.1111.0':
+    dependencies:
+      '@aws-sdk/core': 3.977.8
+      '@aws-sdk/nested-clients': 3.997.43
+      '@aws-sdk/types': 3.974.4
       '@smithy/core': 3.32.0
       '@smithy/types': 4.17.0
       tslib: 2.8.1
@@ -3903,12 +4099,22 @@ snapshots:
       '@smithy/types': 4.17.0
       tslib: 2.8.1
 
+  '@aws-sdk/types@3.974.4':
+    dependencies:
+      '@smithy/types': 4.17.0
+      tslib: 2.8.1
+
   '@aws-sdk/util-dynamodb@3.996.8(@aws-sdk/client-dynamodb@3.1105.0)':
     dependencies:
       '@aws-sdk/client-dynamodb': 3.1105.0
       tslib: 2.8.1
 
   '@aws-sdk/xml-builder@3.972.38':
+    dependencies:
+      '@smithy/types': 4.17.0
+      tslib: 2.8.1
+
+  '@aws-sdk/xml-builder@3.972.39':
     dependencies:
       '@smithy/types': 4.17.0
       tslib: 2.8.1

--- a/src/sdk/router/resolve-sim-sdk-command-router.ts
+++ b/src/sdk/router/resolve-sim-sdk-command-router.ts
@@ -75,6 +75,10 @@ const scopedRouters: ReadonlyMap<string, SimSdkScopedRouter> = new Map<
     (scoped): SimSdkCommandRouter => scoped.lambda().sdkCommandRouter(),
   ],
   [
+    "CloudWatch Logs",
+    (scoped): SimSdkCommandRouter => scoped.logs().sdkCommandRouter(),
+  ],
+  [
     "Rekognition",
     (scoped): SimSdkCommandRouter => scoped.rekognition().sdkCommandRouter(),
   ],

--- a/src/service/aws/factory/sim-aws-self-contained-service-builder.ts
+++ b/src/service/aws/factory/sim-aws-self-contained-service-builder.ts
@@ -1,5 +1,6 @@
 import type { SimAwsAccountRegionContainer } from "../sim-aws-account-region-scope.js";
 import { SimDynamoDb as SimDynamoDatabase } from "../../dynamodb/index.js";
+import { SimLogs } from "../../logs/index.js";
 import { SimSecretsManager } from "../../secretsmanager/index.js";
 import { SimSqs } from "../../sqs/index.js";
 import { SimSsm } from "../../ssm/index.js";
@@ -35,6 +36,16 @@ export class SimAwsSelfContainedServiceBuilder {
   /** Create simulated DynamoDB for an Account Region scope. */
   createDynamoDb(scope: SimAwsAccountRegionContainer): SimDynamoDatabase {
     return new SimDynamoDatabase(this.scoped(scope));
+  }
+
+  /**
+   * Create simulated CloudWatch Logs for an Account Region scope.
+   *
+   * Log groups are Region-scoped on real AWS: a group name is unique within
+   * one Account and Region, and its ARN names the Region.
+   */
+  createLogs(scope: SimAwsAccountRegionContainer): SimLogs {
+    return new SimLogs(this.scoped(scope));
   }
 
   /**

--- a/src/service/aws/factory/sim-aws-service-factory.ts
+++ b/src/service/aws/factory/sim-aws-service-factory.ts
@@ -25,6 +25,7 @@ import { SimIamRegistry } from "../../iam/registry/sim-iam-registry.js";
 import type { SimKms } from "../../kms/index.js";
 import type { SimLambda } from "../../lambda/index.js";
 import { SimLambdaUrlRegistry } from "../../lambda/registry/sim-lambda-url-registry.js";
+import type { SimLogs } from "../../logs/index.js";
 import type { SimSecretsManager } from "../../secretsmanager/index.js";
 import type { SimEventBridge } from "../../eventbridge/index.js";
 import type { SimSns } from "../../sns/index.js";
@@ -239,6 +240,11 @@ export class SimAwsServiceFactory {
   /** Create simulated Secrets Manager for an Account Region scope. */
   createSecretsManager(scope: SimAwsAccountRegionContainer): SimSecretsManager {
     return this.selfContainedServices.createSecretsManager(scope);
+  }
+
+  /** Create simulated CloudWatch Logs for an Account Region scope. */
+  createLogs(scope: SimAwsAccountRegionContainer): SimLogs {
+    return this.selfContainedServices.createLogs(scope);
   }
 
   /** Create simulated EventBridge Scheduler for an Account Region scope. */

--- a/src/service/aws/sim-aws-account-region-scope.ts
+++ b/src/service/aws/sim-aws-account-region-scope.ts
@@ -24,6 +24,7 @@ import type { SimElbV2 } from "../elbv2/index.js";
 import type { SimIam } from "../iam/index.js";
 import type { SimKms } from "../kms/index.js";
 import type { SimLambda } from "../lambda/index.js";
+import type { SimLogs } from "../logs/index.js";
 import type { SimSecretsManager } from "../secretsmanager/index.js";
 import type { SimSns } from "../sns/index.js";
 import type { SimSqs } from "../sqs/index.js";
@@ -192,6 +193,11 @@ export class SimAwsAccountRegionContainer {
   /** Get simulated S3 for this account and region. */
   s3(): SimS3 {
     return this.memo.getOrCreate("s3", () => this.factory.createS3(this));
+  }
+
+  /** Get simulated CloudWatch Logs for this account and region. */
+  logs(): SimLogs {
+    return this.memo.getOrCreate("logs", () => this.factory.createLogs(this));
   }
 
   /** Get simulated Secrets Manager for this account and region. */

--- a/src/service/aws/sim-aws-service-accessors.ts
+++ b/src/service/aws/sim-aws-service-accessors.ts
@@ -15,6 +15,7 @@ import type { SimElbV2 } from "../elbv2/index.js";
 import type { SimIam } from "../iam/index.js";
 import type { SimKms } from "../kms/index.js";
 import type { SimLambda } from "../lambda/index.js";
+import type { SimLogs } from "../logs/index.js";
 import type { SimRekognition } from "../rekognition/index.js";
 import type { SimRoute53 } from "../route53/index.js";
 import type { SimS3 } from "../s3/sim-s3.js";
@@ -120,6 +121,11 @@ export abstract class SimAwsServiceAccessors {
   /** Get simulated Lambda in the default Account Region scope. */
   lambda(): SimLambda {
     return this.defaultAccountRegionScope().lambda();
+  }
+
+  /** Get simulated CloudWatch Logs in the default Account Region scope. */
+  logs(): SimLogs {
+    return this.defaultAccountRegionScope().logs();
   }
 
   /** Get simulated Rekognition in the default Account Region scope. */

--- a/src/service/logs/README.md
+++ b/src/service/logs/README.md
@@ -1,0 +1,111 @@
+# Simulated CloudWatch Logs implementation
+
+This directory contains the simulated CloudWatch Logs service implementation. Log groups, log
+streams, the events in them, and retention as a property to assert on.
+
+The guiding decision here is that nothing expires. Retention is stored and reported rather than
+acted on, because a test would have to move the clock by months to see an event expire, and what
+teams actually get wrong about retention is the value they deployed rather than the deletion that
+eventually follows from it. A log group with no retention keeps its events forever, which is both
+the AWS default and the mistake worth catching.
+
+## Entry points
+
+- `sim-logs.ts` is the main in-memory service object for one account/region scope.
+- `index.ts` exports the public CloudWatch Logs simulator API for `@kensio/yulin/logs`.
+
+A `SimLogs` instance owns a `SimLogsLogGroupStore` holding its log groups. The simulator is scoped
+to an account and region because real log groups are: a group name is unique within one account and
+region, and its ARN names the region.
+
+## Log group model
+
+Group state lives under `group/`.
+
+`SimLogsLogGroup` is the stored resource: its name, its two ARNs, when it was made, its retention,
+and the streams inside it. The group owns its streams rather than a service-wide stream table
+owning them, because a stream has no identity outside the group it belongs to: two groups may hold
+streams of the same name, and deleting a group takes its streams with it.
+
+`sim-logs-arn.ts` builds every ARN this service reports or authorizes against. There are two forms
+of a log group ARN and both matter. `simLogsLogGroupArn` names the group alone, which is what
+`DescribeLogGroups` reports as `logGroupArn`. `simLogsLogGroupWildcardArn` appends `:*`, which is
+what it reports as `arn` and, more importantly, what IAM policies are written against: granting
+`logs:PutLogEvents` on a group means granting it on the streams inside, and the wildcard is what
+covers them. A policy leaving it off reaches nothing, here and on real AWS.
+
+The separator before the name is a colon rather than a slash, so a Lambda log group gives an ARN
+with two colons in a row. That is how real CloudWatch Logs writes it, and it is why `parseSimArn`
+is no use for these.
+
+`SimLogsRetention` holds the fixed set of retention periods real CloudWatch Logs accepts. It is a
+set rather than a range, which is the part that surprises people: `RetentionInDays: 10` looks
+reasonable and is refused.
+
+## Stream and event model
+
+Stream state lives under `stream/`, and what a stream holds lives under `event/`.
+
+`SimLogsLogStream` keeps its events in the order they arrived and reads them back oldest first.
+Real CloudWatch Logs only requires a single batch to be in ascending timestamp order, so a later
+batch may carry older events than one already accepted, and reading is where the two are put back
+together. `compareSimLogsEvents` breaks a tie on the event ID, which increases with ingestion, so
+two events sharing a millisecond come back in the order they were written rather than in whatever
+order the streams happened to be walked.
+
+`SimLogsEventIds` belongs to the service rather than to a stream, so an event ID is unique across
+the whole simulated service the way the real one is unique across an account. The format is a
+zero-padded counter rather than the long opaque number AWS generates: sortable and unique is
+everything a caller can rely on about the real one.
+
+`SimLogsEventBatch` is where a batch is checked. The chronological rule is the one worth having,
+because the obvious way to build a batch is to collect lines from several places and send them in
+whatever order they were collected, and an account refuses exactly that. The size limit counts the
+26 bytes per event that AWS counts, so a batch refused here is a batch that would be refused there.
+
+`sim-logs-event-window.ts` narrows events to a time range. The range is half open: `startTime` is
+included and `endTime` is not. That asymmetry is easy to get wrong from either side, which is why
+it lives in one place both readers share.
+
+## Filter patterns
+
+`SimLogsFilterPattern` reads the plain text pattern syntax: terms are case sensitive substrings,
+all unprefixed terms must appear, `-` excludes, and `?` makes a term one of a set of alternatives.
+`simLogsFilterTerms` does the reading, which needs a scanner rather than a split because a quoted
+phrase may carry spaces and escaped quotes.
+
+The structured syntaxes are refused rather than approximated. A JSON property pattern, a space
+delimited field pattern and a regular expression term each raise
+`SimLogsUnsupportedOperationException`, because a filter quietly treated as matching everything
+turns an assertion about one log line into an assertion about any log line at all: the test still
+passes, and it no longer tests anything.
+
+## Commands
+
+Command handling lives under `command/`, grouped by what it acts on rather than by operation, so
+that the commands sharing a store and a set of rules sit together.
+
+`SimLogsAuthorizer` is the only thing that reaches IAM. An operation on a named group authorizes
+against that group's wildcard ARN; `DescribeLogGroups` names no particular group, so it authorizes
+against `log-group:*` in the account and region, which is the resource it actually reaches. A
+policy scoped to one group therefore fails to describe them all, as it would in an account.
+
+`SimLogsPage` is shared by the three listings that page on an offset. `SimLogsEventCursor` is
+separate because `GetLogEvents` pages in both directions and answers with two tokens: reaching
+either end gives the same token back rather than nothing, which is how a caller polling a stream
+knows to keep it and ask again.
+
+`refuseUnsimulatedLogGroupInput` refuses tags, `kmsKeyId` and a non-standard log group class rather
+than dropping them, following the same rule as the rest of the simulator: something accepted and
+ignored here would be applied in an account.
+
+## What is not simulated
+
+Nothing expires, as above. Subscription filters, metric filters, Logs Insights queries, export
+tasks, tagging, encryption and data protection policies are all absent. `metricFilterCount` is
+always zero and a stream's `storedBytes` is always zero, the latter matching real CloudWatch Logs,
+which stopped reporting it per stream in 2019.
+
+Nothing writes to a log group by itself yet either. A simulated Lambda invocation still forwards
+its handler's output to the host's streams, so a group only holds what something put there through
+`PutLogEvents`.

--- a/src/service/logs/command/authorize/sim-logs-authorizer.ts
+++ b/src/service/logs/command/authorize/sim-logs-authorizer.ts
@@ -1,0 +1,91 @@
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimAwsResolvedCaller } from "../../../aws/caller/sim-aws-caller-resolver.js";
+import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
+import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+import {
+  simLogsAnyLogGroupArn,
+  simLogsLogGroupWildcardArn,
+} from "../../group/sim-logs-arn.js";
+
+interface SimLogsAuthorizerProperties {
+  readonly iam: SimIamInterServiceAuthZ;
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+}
+
+/**
+ * Applies simulated IAM authorization to CloudWatch Logs requests.
+ *
+ * An operation on one log group authorizes against that group's ARN with the
+ * trailing `:*`, which is the form CloudWatch Logs policies are written in:
+ * granting a function permission to write its own logs grants it on the
+ * streams inside the group, and the wildcard is what covers them. A policy
+ * naming `log-group:/aws/lambda/orders` without it therefore reaches nothing
+ * here, exactly as it reaches nothing on real AWS.
+ */
+export class SimLogsAuthorizer {
+  readonly #iam: SimIamInterServiceAuthZ;
+  readonly #accountRegionScope: SimAwsAccountRegionScope;
+
+  constructor(properties: SimLogsAuthorizerProperties) {
+    this.#iam = properties.iam;
+    this.#accountRegionScope = properties.accountRegionScope;
+  }
+
+  /**
+   * Ensure the caller may perform an action on a log group.
+   *
+   * The group need not exist. Real IAM evaluates a request before the service
+   * handles it, so a caller with no permission is refused whether or not the
+   * group is there, and CreateLogGroup authorizes against the ARN the group is
+   * about to have.
+   */
+  authorizeLogGroup(
+    action: string,
+    logGroupName: string,
+    caller?: SimAwsCaller,
+  ): SimAwsResolvedCaller {
+    return this.authorizeResource(
+      action,
+      simLogsLogGroupWildcardArn(this.#accountRegionScope, logGroupName),
+      caller,
+    );
+  }
+
+  /**
+   * Ensure the caller may perform an action that names no particular log
+   * group, such as describing them all.
+   *
+   * The resource is every log group in this account and region, which is what
+   * such a request actually reaches. A policy scoped to one group does not
+   * cover it, and one written against `*` or the log group wildcard does.
+   */
+  authorizeAnyLogGroup(
+    action: string,
+    caller?: SimAwsCaller,
+  ): SimAwsResolvedCaller {
+    return this.authorizeResource(
+      action,
+      simLogsAnyLogGroupArn(this.#accountRegionScope),
+      caller,
+    );
+  }
+
+  private authorizeResource(
+    action: string,
+    resource: string,
+    caller: SimAwsCaller | undefined,
+  ): SimAwsResolvedCaller {
+    const decision = this.#iam.authorize({ action, resource, caller });
+
+    if (decision.isDenied) {
+      throw new SimIamAccessDenied({
+        principal: decision.caller.principal,
+        action,
+        resource,
+      });
+    }
+
+    return decision.caller;
+  }
+}

--- a/src/service/logs/command/authorize/sim-logs-iam.iso.test.ts
+++ b/src/service/logs/command/authorize/sim-logs-iam.iso.test.ts
@@ -1,0 +1,214 @@
+import {
+  CreateLogGroupCommand,
+  CreateLogStreamCommand,
+  DescribeLogGroupsCommand,
+  FilterLogEventsCommand,
+  PutLogEventsCommand,
+} from "@aws-sdk/client-cloudwatch-logs";
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+import { simIamPolicyDocumentFactory } from "../../../iam/policy/sim-iam-policy-document.factory.js";
+
+const accountIdOneOnes = "111111111111";
+const logGroupName = "/aws/lambda/orders";
+const logStreamName = "2026/08/16/[$LATEST]abc";
+
+/**
+ * A simulation with one Role, and whatever policy statement the test wants it
+ * to have.
+ */
+async function simAwsWithRole(policyStatement?: object): Promise<SimAws> {
+  const simAws = new SimAws({ defaultAccountId: accountIdOneOnes });
+
+  await simAws.iam().createRole(
+    new CreateRoleCommand({
+      RoleName: "OrdersFunctionRole",
+      AssumeRolePolicyDocument: simIamPolicyDocumentFactory.make({
+        Statement: {
+          Principal: { Service: "lambda.amazonaws.com" },
+          Action: "sts:AssumeRole",
+        },
+      }),
+    }),
+  );
+
+  if (policyStatement !== undefined) {
+    await simAws.iam().putRolePolicy(
+      new PutRolePolicyCommand({
+        RoleName: "OrdersFunctionRole",
+        PolicyName: "WriteOwnLogs",
+        PolicyDocument: simIamPolicyDocumentFactory.make({
+          Statement: policyStatement,
+        }),
+      }),
+    );
+  }
+
+  return simAws;
+}
+
+/** The request options that make a call arrive as the Role. */
+const asRole = {
+  caller: {
+    kind: "arn",
+    arn: `arn:aws:iam::${accountIdOneOnes}:role/OrdersFunctionRole`,
+  },
+} as const;
+
+describe("CloudWatch Logs IAM authorization", () => {
+  it("allows a function to write its own log group", async () => {
+    // Given a Role with the policy CDK writes for a function's own logs, which
+    // names the group with the wildcard covering its streams.
+    const simAws = await simAwsWithRole({
+      Action: ["logs:CreateLogGroup", "logs:CreateLogStream", "logs:PutLogEvents"],
+      Resource: `arn:aws:logs:us-east-1:${accountIdOneOnes}:log-group:${logGroupName}:*`,
+    });
+
+    // When it creates the group and stream and writes an event.
+    await simAws
+      .logs()
+      .createLogGroup(new CreateLogGroupCommand({ logGroupName }), asRole);
+    await simAws
+      .logs()
+      .createLogStream(
+        new CreateLogStreamCommand({ logGroupName, logStreamName }),
+        asRole,
+      );
+    await simAws.logs().putLogEvents(
+      new PutLogEventsCommand({
+        logGroupName,
+        logStreamName,
+        logEvents: [{ timestamp: 1000, message: "order failed" }],
+      }),
+      asRole,
+    );
+
+    // Then each call is allowed.
+    const found = await simAws
+      .logs()
+      .filterLogEvents(new FilterLogEventsCommand({ logGroupName }));
+
+    assertArrayLength(found.events ?? [], 1);
+  });
+
+  it("denies a policy that leaves off the wildcard covering the streams", async () => {
+    // Given a Role whose policy names the log group the way it is easy to
+    // write it, without the trailing wildcard.
+    const simAws = await simAwsWithRole({
+      Action: "logs:CreateLogGroup",
+      Resource: `arn:aws:logs:us-east-1:${accountIdOneOnes}:log-group:${logGroupName}`,
+    });
+
+    // When it creates the group.
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await simAws
+          .logs()
+          .createLogGroup(
+            new CreateLogGroupCommand({ logGroupName }),
+            asRole,
+          ),
+    );
+
+    // Then it is denied here, as it would be on real AWS.
+    assertInstanceOf(error, SimIamAccessDenied);
+  });
+
+  it("denies a write the caller's policy does not cover", async () => {
+    // Given a Role allowed to write one function's logs, and another group.
+    const simAws = await simAwsWithRole({
+      Action: ["logs:CreateLogStream", "logs:PutLogEvents"],
+      Resource: `arn:aws:logs:us-east-1:${accountIdOneOnes}:log-group:${logGroupName}:*`,
+    });
+
+    await simAws
+      .logs()
+      .createLogGroup(
+        new CreateLogGroupCommand({ logGroupName: "/aws/lambda/billing" }),
+      );
+
+    // When it writes to the other group.
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await simAws.logs().createLogStream(
+          new CreateLogStreamCommand({
+            logGroupName: "/aws/lambda/billing",
+            logStreamName,
+          }),
+          asRole,
+        ),
+    );
+
+    // Then it is denied rather than writing logs it has no permission for.
+    assertInstanceOf(error, SimIamAccessDenied);
+    assertIdentical(error.name, "AccessDenied");
+  });
+
+  it("denies describing every log group to a policy scoped to one", async () => {
+    // Given a Role allowed to read one log group only.
+    const simAws = await simAwsWithRole({
+      Action: "logs:DescribeLogGroups",
+      Resource: `arn:aws:logs:us-east-1:${accountIdOneOnes}:log-group:${logGroupName}:*`,
+    });
+
+    // When it describes the log groups in the account and region.
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await simAws
+          .logs()
+          .describeLogGroups(new DescribeLogGroupsCommand({}), asRole),
+    );
+
+    // Then it is denied: describing names no particular group, so it
+    // authorizes against every one of them.
+    assertInstanceOf(error, SimIamAccessDenied);
+  });
+
+  it("allows describing every log group to a policy that covers them all", async () => {
+    // Given a Role allowed to describe log groups across the account.
+    const simAws = await simAwsWithRole({
+      Action: "logs:DescribeLogGroups",
+      Resource: `arn:aws:logs:us-east-1:${accountIdOneOnes}:log-group:*`,
+    });
+
+    await simAws
+      .logs()
+      .createLogGroup(new CreateLogGroupCommand({ logGroupName }));
+
+    // When it describes them.
+    const described = await simAws
+      .logs()
+      .describeLogGroups(new DescribeLogGroupsCommand({}), asRole);
+
+    // Then the read is allowed.
+    assertArrayLength(described.logGroups ?? [], 1);
+  });
+
+  it("denies a caller with no CloudWatch Logs permissions at all", async () => {
+    // Given a Role with no policy.
+    const simAws = await simAwsWithRole();
+
+    // When it searches a log group.
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await simAws
+          .logs()
+          .filterLogEvents(
+            new FilterLogEventsCommand({ logGroupName }),
+            asRole,
+          ),
+    );
+
+    // Then it is denied before the missing group is ever looked for.
+    assertInstanceOf(error, SimIamAccessDenied);
+  });
+});

--- a/src/service/logs/command/authorize/sim-logs-iam.iso.test.ts
+++ b/src/service/logs/command/authorize/sim-logs-iam.iso.test.ts
@@ -69,7 +69,11 @@ describe("CloudWatch Logs IAM authorization", () => {
     // Given a Role with the policy CDK writes for a function's own logs, which
     // names the group with the wildcard covering its streams.
     const simAws = await simAwsWithRole({
-      Action: ["logs:CreateLogGroup", "logs:CreateLogStream", "logs:PutLogEvents"],
+      Action: [
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents",
+      ],
       Resource: `arn:aws:logs:us-east-1:${accountIdOneOnes}:log-group:${logGroupName}:*`,
     });
 
@@ -113,10 +117,7 @@ describe("CloudWatch Logs IAM authorization", () => {
       async () =>
         await simAws
           .logs()
-          .createLogGroup(
-            new CreateLogGroupCommand({ logGroupName }),
-            asRole,
-          ),
+          .createLogGroup(new CreateLogGroupCommand({ logGroupName }), asRole),
     );
 
     // Then it is denied here, as it would be on real AWS.

--- a/src/service/logs/command/event/event.command.ts
+++ b/src/service/logs/command/event/event.command.ts
@@ -1,0 +1,98 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+
+/**
+ * Minimal structural sim CloudWatch Logs PutLogEvents command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/cloudwatch-logs/command/PutLogEventsCommand/
+ */
+export interface SimPutLogEventsCommand {
+  readonly input: SimPutLogEventsCommandInput;
+}
+
+export interface SimPutLogEventsCommandInput {
+  readonly logGroupName?: string | undefined;
+  readonly logStreamName?: string | undefined;
+  readonly logEvents?: readonly SimLogsInputLogEvent[] | undefined;
+
+  /**
+   * Real CloudWatch Logs stopped requiring this in 2023 and ignores whatever
+   * is sent, so this takes it and ignores it too.
+   */
+  readonly sequenceToken?: string | undefined;
+}
+
+export interface SimLogsInputLogEvent {
+  readonly timestamp?: number | undefined;
+  readonly message?: string | undefined;
+}
+
+export interface SimPutLogEventsCommandOutput {
+  readonly nextSequenceToken?: string | undefined;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim CloudWatch Logs GetLogEvents command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/cloudwatch-logs/command/GetLogEventsCommand/
+ */
+export interface SimGetLogEventsCommand {
+  readonly input: SimGetLogEventsCommandInput;
+}
+
+export interface SimGetLogEventsCommandInput {
+  readonly logGroupName?: string | undefined;
+  readonly logStreamName?: string | undefined;
+  readonly startTime?: number | undefined;
+  readonly endTime?: number | undefined;
+  readonly limit?: number | undefined;
+  readonly startFromHead?: boolean | undefined;
+  readonly nextToken?: string | undefined;
+}
+
+export interface SimGetLogEventsCommandOutput {
+  readonly events?: readonly SimLogsOutputLogEvent[] | undefined;
+  readonly nextForwardToken?: string | undefined;
+  readonly nextBackwardToken?: string | undefined;
+  readonly $metadata: SimResponseMetadata;
+}
+
+export interface SimLogsOutputLogEvent {
+  readonly timestamp: number;
+  readonly ingestionTime: number;
+  readonly message: string;
+}
+
+/**
+ * Minimal structural sim CloudWatch Logs FilterLogEvents command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/cloudwatch-logs/command/FilterLogEventsCommand/
+ */
+export interface SimFilterLogEventsCommand {
+  readonly input: SimFilterLogEventsCommandInput;
+}
+
+export interface SimFilterLogEventsCommandInput {
+  readonly logGroupName?: string | undefined;
+  readonly logStreamNames?: readonly string[] | undefined;
+  readonly logStreamNamePrefix?: string | undefined;
+  readonly filterPattern?: string | undefined;
+  readonly startTime?: number | undefined;
+  readonly endTime?: number | undefined;
+  readonly limit?: number | undefined;
+  readonly nextToken?: string | undefined;
+}
+
+export interface SimFilterLogEventsCommandOutput {
+  readonly events?: readonly SimLogsFilteredLogEvent[] | undefined;
+  readonly nextToken?: string | undefined;
+  readonly $metadata: SimResponseMetadata;
+}
+
+export interface SimLogsFilteredLogEvent {
+  readonly logStreamName: string;
+  readonly timestamp: number;
+  readonly ingestionTime: number;
+  readonly message: string;
+  readonly eventId: string;
+}

--- a/src/service/logs/command/event/sim-logs-event-cursor.ts
+++ b/src/service/logs/command/event/sim-logs-event-cursor.ts
@@ -31,7 +31,10 @@ export class SimLogsEventCursor {
         : tokenPage(nextToken, limit, eventCount);
 
     this.startIndex = Math.max(0, Math.min(bounds.startIndex, eventCount));
-    this.endIndex = Math.max(this.startIndex, Math.min(bounds.endIndex, eventCount));
+    this.endIndex = Math.max(
+      this.startIndex,
+      Math.min(bounds.endIndex, eventCount),
+    );
   }
 
   /**

--- a/src/service/logs/command/event/sim-logs-event-cursor.ts
+++ b/src/service/logs/command/event/sim-logs-event-cursor.ts
@@ -1,0 +1,103 @@
+import { SimLogsInvalidParameterException } from "../../error/sim-logs.error.js";
+
+const forwardPrefix = "f/";
+const backwardPrefix = "b/";
+
+interface SimLogsEventCursorProperties {
+  readonly eventCount: number;
+  readonly limit: number;
+  readonly startFromHead: boolean;
+  readonly nextToken?: string | undefined;
+}
+
+/**
+ * Where one page of a GetLogEvents read starts and ends.
+ *
+ * GetLogEvents pages in both directions, which is why it answers with two
+ * tokens rather than one: a caller following `nextForwardToken` walks towards
+ * newer events and one following `nextBackwardToken` walks towards older ones.
+ * Reaching either end gives the same token back rather than nothing, which is
+ * how a caller polling a stream knows to keep the token and ask again.
+ */
+export class SimLogsEventCursor {
+  readonly startIndex: number;
+  readonly endIndex: number;
+
+  constructor(properties: SimLogsEventCursorProperties) {
+    const { eventCount, limit, nextToken } = properties;
+    const bounds =
+      nextToken === undefined
+        ? firstPage(properties)
+        : tokenPage(nextToken, limit, eventCount);
+
+    this.startIndex = Math.max(0, Math.min(bounds.startIndex, eventCount));
+    this.endIndex = Math.max(this.startIndex, Math.min(bounds.endIndex, eventCount));
+  }
+
+  /**
+   * The token that reaches the events after this page.
+   */
+  get nextForwardToken(): string {
+    return `${forwardPrefix}${this.endIndex}`;
+  }
+
+  /**
+   * The token that reaches the events before this page.
+   */
+  get nextBackwardToken(): string {
+    return `${backwardPrefix}${this.startIndex}`;
+  }
+}
+
+interface SimLogsEventCursorBounds {
+  readonly startIndex: number;
+  readonly endIndex: number;
+}
+
+/**
+ * Where a read with no token starts.
+ *
+ * Real CloudWatch Logs starts at the newest events unless asked to start from
+ * the head, so an unpaged read of a busy stream answers with the end of it.
+ */
+function firstPage(
+  properties: SimLogsEventCursorProperties,
+): SimLogsEventCursorBounds {
+  const { eventCount, limit, startFromHead } = properties;
+
+  return startFromHead
+    ? { startIndex: 0, endIndex: limit }
+    : { startIndex: eventCount - limit, endIndex: eventCount };
+}
+
+function tokenPage(
+  nextToken: string,
+  limit: number,
+  eventCount: number,
+): SimLogsEventCursorBounds {
+  const index = tokenIndex(nextToken, eventCount);
+
+  return nextToken.startsWith(backwardPrefix)
+    ? { startIndex: index - limit, endIndex: index }
+    : { startIndex: index, endIndex: index + limit };
+}
+
+function tokenIndex(nextToken: string, eventCount: number): number {
+  const prefix = nextToken.slice(0, 2);
+  const offset = nextToken.slice(2);
+  const index = Number(offset);
+
+  if (
+    (prefix !== forwardPrefix && prefix !== backwardPrefix) ||
+    !Number.isSafeInteger(index) ||
+    index < 0 ||
+    index > eventCount ||
+    String(index) !== offset
+  ) {
+    throw new SimLogsInvalidParameterException(
+      "The specified nextToken is not a token this simulation issued",
+    );
+  }
+
+  return index;
+}

--- a/src/service/logs/command/event/sim-logs-filter-log-events.ts
+++ b/src/service/logs/command/event/sim-logs-filter-log-events.ts
@@ -1,19 +1,17 @@
-import { SimLogsInvalidParameterException } from "../../error/sim-logs.error.js";
 import { compareSimLogsEvents } from "../../event/sim-logs-event.js";
-import { simLogsEventsInWindow } from "../../event/sim-logs-event-window.js";
 import { SimLogsFilterPattern } from "../../event/sim-logs-filter-pattern.js";
-import type { SimLogsLogGroup } from "../../group/sim-logs-log-group.js";
 import { requiredSimLogsLogGroupName } from "../../group/sim-logs-log-group-name.js";
 import type { SimLogsLogGroupStore } from "../../group/sim-logs-log-group-store.js";
-import type { SimLogsLogStream } from "../../stream/sim-logs-log-stream.js";
 import type { SimLogsAuthorizer } from "../authorize/sim-logs-authorizer.js";
 import { SimLogsPage } from "../sim-logs-page.js";
 import type { SimLogsRequestOptions } from "../sim-logs-request-options.js";
+import {
+  filteredSimLogsEvents,
+  searchedSimLogsStreams,
+} from "./sim-logs-searched-events.js";
 import type {
   SimFilterLogEventsCommand,
-  SimFilterLogEventsCommandInput,
   SimFilterLogEventsCommandOutput,
-  SimLogsFilteredLogEvent,
 } from "./event.command.js";
 
 const maximumLimit = 10_000;
@@ -57,9 +55,9 @@ export class SimLogsFilterLogEvents {
 
     const pattern = new SimLogsFilterPattern(input.filterPattern);
     const group = this.#groups.require(logGroupName);
-    const matched = searchedStreams(group, input)
-      .flatMap((stream) => filteredEvents(stream, input, pattern))
-      .sort((left, right) => compareSimLogsEvents(left, right));
+    const matched = searchedSimLogsStreams(group, input)
+      .flatMap((stream) => filteredSimLogsEvents(stream, input, pattern))
+      .toSorted((left, right) => compareSimLogsEvents(left, right));
 
     const page = new SimLogsPage({
       listed: matched,
@@ -68,57 +66,6 @@ export class SimLogsFilterLogEvents {
       maximumLimit,
     });
 
-    return {
-      $metadata: {},
-      events: page.items,
-      nextToken: page.nextToken,
-    };
+    return { $metadata: {}, events: page.items, nextToken: page.nextToken };
   }
-}
-
-/**
- * The streams a request searches: named ones, ones under a prefix, or all of
- * them.
- *
- * Real CloudWatch Logs refuses both selectors at once rather than deciding
- * which wins, so this does too. A name in `logStreamNames` that no stream has
- * is not an error there either; it simply contributes nothing.
- */
-function searchedStreams(
-  group: SimLogsLogGroup,
-  input: SimFilterLogEventsCommandInput,
-): readonly SimLogsLogStream[] {
-  const { logStreamNames, logStreamNamePrefix } = input;
-
-  if (logStreamNames !== undefined && logStreamNamePrefix !== undefined) {
-    throw new SimLogsInvalidParameterException(
-      "Only one of logStreamNames or logStreamNamePrefix can be specified.",
-    );
-  }
-
-  if (logStreamNames !== undefined) {
-    return group.streams.filter((stream) =>
-      logStreamNames.includes(stream.logStreamName),
-    );
-  }
-
-  return group.streams.filter((stream) =>
-    stream.logStreamName.startsWith(logStreamNamePrefix ?? ""),
-  );
-}
-
-function filteredEvents(
-  stream: SimLogsLogStream,
-  input: SimFilterLogEventsCommandInput,
-  pattern: SimLogsFilterPattern,
-): readonly SimLogsFilteredLogEvent[] {
-  return simLogsEventsInWindow(stream.events, input)
-    .filter((event) => pattern.matches(event.message))
-    .map((event) => ({
-      logStreamName: stream.logStreamName,
-      timestamp: event.timestamp,
-      ingestionTime: event.ingestionTime,
-      message: event.message,
-      eventId: event.eventId,
-    }));
 }

--- a/src/service/logs/command/event/sim-logs-filter-log-events.ts
+++ b/src/service/logs/command/event/sim-logs-filter-log-events.ts
@@ -1,0 +1,124 @@
+import { SimLogsInvalidParameterException } from "../../error/sim-logs.error.js";
+import { compareSimLogsEvents } from "../../event/sim-logs-event.js";
+import { simLogsEventsInWindow } from "../../event/sim-logs-event-window.js";
+import { SimLogsFilterPattern } from "../../event/sim-logs-filter-pattern.js";
+import type { SimLogsLogGroup } from "../../group/sim-logs-log-group.js";
+import { requiredSimLogsLogGroupName } from "../../group/sim-logs-log-group-name.js";
+import type { SimLogsLogGroupStore } from "../../group/sim-logs-log-group-store.js";
+import type { SimLogsLogStream } from "../../stream/sim-logs-log-stream.js";
+import type { SimLogsAuthorizer } from "../authorize/sim-logs-authorizer.js";
+import { SimLogsPage } from "../sim-logs-page.js";
+import type { SimLogsRequestOptions } from "../sim-logs-request-options.js";
+import type {
+  SimFilterLogEventsCommand,
+  SimFilterLogEventsCommandInput,
+  SimFilterLogEventsCommandOutput,
+  SimLogsFilteredLogEvent,
+} from "./event.command.js";
+
+const maximumLimit = 10_000;
+
+interface SimLogsFilterLogEventsProperties {
+  readonly groups: SimLogsLogGroupStore;
+  readonly authorizer: SimLogsAuthorizer;
+}
+
+/**
+ * The command that searches a log group's events across its streams.
+ *
+ * This is the one a test reaches for: it names the group rather than a stream,
+ * so an assertion about what a function logged does not have to know which
+ * execution environment wrote it.
+ */
+export class SimLogsFilterLogEvents {
+  readonly #groups: SimLogsLogGroupStore;
+  readonly #authorizer: SimLogsAuthorizer;
+
+  constructor(properties: SimLogsFilterLogEventsProperties) {
+    this.#groups = properties.groups;
+    this.#authorizer = properties.authorizer;
+  }
+
+  /**
+   * Search a log group's events, oldest first.
+   */
+  handle(
+    command: SimFilterLogEventsCommand,
+    options?: SimLogsRequestOptions,
+  ): SimFilterLogEventsCommandOutput {
+    const input = command.input;
+    const logGroupName = requiredSimLogsLogGroupName(input.logGroupName);
+
+    this.#authorizer.authorizeLogGroup(
+      "logs:FilterLogEvents",
+      logGroupName,
+      options?.caller,
+    );
+
+    const pattern = new SimLogsFilterPattern(input.filterPattern);
+    const group = this.#groups.require(logGroupName);
+    const matched = searchedStreams(group, input)
+      .flatMap((stream) => filteredEvents(stream, input, pattern))
+      .sort((left, right) => compareSimLogsEvents(left, right));
+
+    const page = new SimLogsPage({
+      listed: matched,
+      limit: input.limit,
+      nextToken: input.nextToken,
+      maximumLimit,
+    });
+
+    return {
+      $metadata: {},
+      events: page.items,
+      nextToken: page.nextToken,
+    };
+  }
+}
+
+/**
+ * The streams a request searches: named ones, ones under a prefix, or all of
+ * them.
+ *
+ * Real CloudWatch Logs refuses both selectors at once rather than deciding
+ * which wins, so this does too. A name in `logStreamNames` that no stream has
+ * is not an error there either; it simply contributes nothing.
+ */
+function searchedStreams(
+  group: SimLogsLogGroup,
+  input: SimFilterLogEventsCommandInput,
+): readonly SimLogsLogStream[] {
+  const { logStreamNames, logStreamNamePrefix } = input;
+
+  if (logStreamNames !== undefined && logStreamNamePrefix !== undefined) {
+    throw new SimLogsInvalidParameterException(
+      "Only one of logStreamNames or logStreamNamePrefix can be specified.",
+    );
+  }
+
+  if (logStreamNames !== undefined) {
+    return group.streams.filter((stream) =>
+      logStreamNames.includes(stream.logStreamName),
+    );
+  }
+
+  return group.streams.filter((stream) =>
+    stream.logStreamName.startsWith(logStreamNamePrefix ?? ""),
+  );
+}
+
+function filteredEvents(
+  stream: SimLogsLogStream,
+  input: SimFilterLogEventsCommandInput,
+  pattern: SimLogsFilterPattern,
+): readonly SimLogsFilteredLogEvent[] {
+  return simLogsEventsInWindow(stream.events, input)
+    .filter((event) => pattern.matches(event.message))
+    .map((event) => ({
+      logStreamName: stream.logStreamName,
+      timestamp: event.timestamp,
+      ingestionTime: event.ingestionTime,
+      message: event.message,
+      eventId: event.eventId,
+    }));
+}

--- a/src/service/logs/command/event/sim-logs-get-log-events.ts
+++ b/src/service/logs/command/event/sim-logs-get-log-events.ts
@@ -1,10 +1,10 @@
-import { SimLogsInvalidParameterException } from "../../error/sim-logs.error.js";
 import { simLogsEventsInWindow } from "../../event/sim-logs-event-window.js";
 import { requiredSimLogsLogGroupName } from "../../group/sim-logs-log-group-name.js";
 import type { SimLogsLogGroupStore } from "../../group/sim-logs-log-group-store.js";
 import { requiredSimLogsLogStreamName } from "../../stream/sim-logs-log-stream-name.js";
 import type { SimLogsAuthorizer } from "../authorize/sim-logs-authorizer.js";
 import type { SimLogsRequestOptions } from "../sim-logs-request-options.js";
+import { requiredSimLogsLimit } from "../sim-logs-limit.js";
 import { SimLogsEventCursor } from "./sim-logs-event-cursor.js";
 import type {
   SimGetLogEventsCommand,
@@ -54,7 +54,7 @@ export class SimLogsGetLogEvents {
     const events = simLogsEventsInWindow(stream.events, input);
     const cursor = new SimLogsEventCursor({
       eventCount: events.length,
-      limit: requiredLimit(input.limit),
+      limit: requiredSimLogsLimit(input.limit, maximumLimit),
       startFromHead: input.startFromHead ?? false,
       nextToken: input.nextToken,
     });
@@ -72,18 +72,4 @@ export class SimLogsGetLogEvents {
       nextBackwardToken: cursor.nextBackwardToken,
     };
   }
-}
-
-function requiredLimit(requested: number | undefined): number {
-  const limit = requested ?? maximumLimit;
-
-  if (!Number.isSafeInteger(limit) || limit < 1 || limit > maximumLimit) {
-    throw new SimLogsInvalidParameterException(
-      `1 validation error detected: Value '${String(requested)}' at 'limit' ` +
-        `failed to satisfy constraint: Member must be between 1 and ` +
-        `${maximumLimit}`,
-    );
-  }
-
-  return limit;
 }

--- a/src/service/logs/command/event/sim-logs-get-log-events.ts
+++ b/src/service/logs/command/event/sim-logs-get-log-events.ts
@@ -1,0 +1,89 @@
+import { SimLogsInvalidParameterException } from "../../error/sim-logs.error.js";
+import { simLogsEventsInWindow } from "../../event/sim-logs-event-window.js";
+import { requiredSimLogsLogGroupName } from "../../group/sim-logs-log-group-name.js";
+import type { SimLogsLogGroupStore } from "../../group/sim-logs-log-group-store.js";
+import { requiredSimLogsLogStreamName } from "../../stream/sim-logs-log-stream-name.js";
+import type { SimLogsAuthorizer } from "../authorize/sim-logs-authorizer.js";
+import type { SimLogsRequestOptions } from "../sim-logs-request-options.js";
+import { SimLogsEventCursor } from "./sim-logs-event-cursor.js";
+import type {
+  SimGetLogEventsCommand,
+  SimGetLogEventsCommandOutput,
+} from "./event.command.js";
+
+const maximumLimit = 10_000;
+
+interface SimLogsGetLogEventsProperties {
+  readonly groups: SimLogsLogGroupStore;
+  readonly authorizer: SimLogsAuthorizer;
+}
+
+/**
+ * The command that reads the events of one log stream.
+ */
+export class SimLogsGetLogEvents {
+  readonly #groups: SimLogsLogGroupStore;
+  readonly #authorizer: SimLogsAuthorizer;
+
+  constructor(properties: SimLogsGetLogEventsProperties) {
+    this.#groups = properties.groups;
+    this.#authorizer = properties.authorizer;
+  }
+
+  /**
+   * Read one stream's events, oldest first.
+   */
+  handle(
+    command: SimGetLogEventsCommand,
+    options?: SimLogsRequestOptions,
+  ): SimGetLogEventsCommandOutput {
+    const input = command.input;
+    const logGroupName = requiredSimLogsLogGroupName(input.logGroupName);
+    const logStreamName = requiredSimLogsLogStreamName(input.logStreamName);
+
+    this.#authorizer.authorizeLogGroup(
+      "logs:GetLogEvents",
+      logGroupName,
+      options?.caller,
+    );
+
+    const stream = this.#groups
+      .require(logGroupName)
+      .requireStream(logStreamName);
+
+    const events = simLogsEventsInWindow(stream.events, input);
+    const cursor = new SimLogsEventCursor({
+      eventCount: events.length,
+      limit: requiredLimit(input.limit),
+      startFromHead: input.startFromHead ?? false,
+      nextToken: input.nextToken,
+    });
+
+    return {
+      $metadata: {},
+      events: events
+        .slice(cursor.startIndex, cursor.endIndex)
+        .map(({ timestamp, ingestionTime, message }) => ({
+          timestamp,
+          ingestionTime,
+          message,
+        })),
+      nextForwardToken: cursor.nextForwardToken,
+      nextBackwardToken: cursor.nextBackwardToken,
+    };
+  }
+}
+
+function requiredLimit(requested: number | undefined): number {
+  const limit = requested ?? maximumLimit;
+
+  if (!Number.isSafeInteger(limit) || limit < 1 || limit > maximumLimit) {
+    throw new SimLogsInvalidParameterException(
+      `1 validation error detected: Value '${String(requested)}' at 'limit' ` +
+        `failed to satisfy constraint: Member must be between 1 and ` +
+        `${maximumLimit}`,
+    );
+  }
+
+  return limit;
+}

--- a/src/service/logs/command/event/sim-logs-put-log-events.ts
+++ b/src/service/logs/command/event/sim-logs-put-log-events.ts
@@ -1,0 +1,74 @@
+import type { SimClock } from "../../../../util/clock/sim-clock.js";
+import { SimLogsEventBatch } from "../../event/sim-logs-event-batch.js";
+import type { SimLogsEventIds } from "../../event/sim-logs-event-ids.js";
+import { requiredSimLogsLogGroupName } from "../../group/sim-logs-log-group-name.js";
+import type { SimLogsLogGroupStore } from "../../group/sim-logs-log-group-store.js";
+import { requiredSimLogsLogStreamName } from "../../stream/sim-logs-log-stream-name.js";
+import type { SimLogsAuthorizer } from "../authorize/sim-logs-authorizer.js";
+import type { SimLogsRequestOptions } from "../sim-logs-request-options.js";
+import type {
+  SimPutLogEventsCommand,
+  SimPutLogEventsCommandOutput,
+} from "./event.command.js";
+
+interface SimLogsPutLogEventsProperties {
+  readonly groups: SimLogsLogGroupStore;
+  readonly authorizer: SimLogsAuthorizer;
+  readonly eventIds: SimLogsEventIds;
+  readonly clock: SimClock;
+}
+
+/**
+ * The command that writes log events to a stream.
+ */
+export class SimLogsPutLogEvents {
+  readonly #groups: SimLogsLogGroupStore;
+  readonly #authorizer: SimLogsAuthorizer;
+  readonly #eventIds: SimLogsEventIds;
+  readonly #clock: SimClock;
+
+  constructor(properties: SimLogsPutLogEventsProperties) {
+    this.#groups = properties.groups;
+    this.#authorizer = properties.authorizer;
+    this.#eventIds = properties.eventIds;
+    this.#clock = properties.clock;
+  }
+
+  /**
+   * Write a batch of events to a stream in a log group.
+   *
+   * Neither the group nor the stream is made on the way: real CloudWatch Logs
+   * refuses a write to either one that is not there, which is what makes a
+   * missing `logs:CreateLogStream` permission show up as a failure rather than
+   * as logs that quietly never appear.
+   */
+  handle(
+    command: SimPutLogEventsCommand,
+    options?: SimLogsRequestOptions,
+  ): SimPutLogEventsCommandOutput {
+    const input = command.input;
+    const logGroupName = requiredSimLogsLogGroupName(input.logGroupName);
+    const logStreamName = requiredSimLogsLogStreamName(input.logStreamName);
+
+    this.#authorizer.authorizeLogGroup(
+      "logs:PutLogEvents",
+      logGroupName,
+      options?.caller,
+    );
+
+    const ingestionTime = this.#clock.now().getTime();
+    const batch = new SimLogsEventBatch({
+      events: input.logEvents,
+      eventIds: this.#eventIds,
+      ingestionTime,
+    });
+
+    const stream = this.#groups
+      .require(logGroupName)
+      .requireStream(logStreamName);
+
+    stream.append(batch.events, ingestionTime);
+
+    return { $metadata: {}, nextSequenceToken: stream.uploadSequenceToken };
+  }
+}

--- a/src/service/logs/command/event/sim-logs-searched-events.ts
+++ b/src/service/logs/command/event/sim-logs-searched-events.ts
@@ -1,0 +1,75 @@
+import { SimLogsInvalidParameterException } from "../../error/sim-logs.error.js";
+import { simLogsEventsInWindow } from "../../event/sim-logs-event-window.js";
+import type { SimLogsFilterPattern } from "../../event/sim-logs-filter-pattern.js";
+import type { SimLogsLogGroup } from "../../group/sim-logs-log-group.js";
+import type { SimLogsLogStream } from "../../stream/sim-logs-log-stream.js";
+import type {
+  SimFilterLogEventsCommandInput,
+  SimLogsFilteredLogEvent,
+} from "./event.command.js";
+
+/**
+ * The streams a FilterLogEvents request searches: named ones, ones under a
+ * prefix, or all of them.
+ *
+ * Real CloudWatch Logs refuses both selectors at once rather than deciding
+ * which wins, so this does too, and it refuses an empty list of names rather
+ * than searching nothing: a caller that built the list dynamically would
+ * otherwise get an empty page back and read it as nothing having matched.
+ *
+ * A name in the list that no stream has is not an error there or here; it
+ * simply contributes nothing.
+ */
+export function searchedSimLogsStreams(
+  group: SimLogsLogGroup,
+  input: SimFilterLogEventsCommandInput,
+): readonly SimLogsLogStream[] {
+  const { logStreamNames, logStreamNamePrefix } = input;
+
+  if (logStreamNames !== undefined && logStreamNamePrefix !== undefined) {
+    throw new SimLogsInvalidParameterException(
+      "Only one of logStreamNames or logStreamNamePrefix can be specified.",
+    );
+  }
+
+  if (logStreamNames !== undefined) {
+    refuseEmptyNames(logStreamNames);
+
+    return group.streams.filter((stream) =>
+      logStreamNames.includes(stream.logStreamName),
+    );
+  }
+
+  return group.streams.filter((stream) =>
+    stream.logStreamName.startsWith(logStreamNamePrefix ?? ""),
+  );
+}
+
+/**
+ * The events of one stream that a request's window and pattern both admit.
+ */
+export function filteredSimLogsEvents(
+  stream: SimLogsLogStream,
+  input: SimFilterLogEventsCommandInput,
+  pattern: SimLogsFilterPattern,
+): readonly SimLogsFilteredLogEvent[] {
+  return simLogsEventsInWindow(stream.events, input)
+    .filter((event) => pattern.matches(event.message))
+    .map((event) => ({
+      logStreamName: stream.logStreamName,
+      timestamp: event.timestamp,
+      ingestionTime: event.ingestionTime,
+      message: event.message,
+      eventId: event.eventId,
+    }));
+}
+
+function refuseEmptyNames(logStreamNames: readonly string[]): void {
+  if (logStreamNames.length === 0) {
+    throw new SimLogsInvalidParameterException(
+      "1 validation error detected: Value at 'logStreamNames' failed to " +
+        "satisfy constraint: Member must have length greater than or equal " +
+        "to 1",
+    );
+  }
+}

--- a/src/service/logs/command/group/group.command.ts
+++ b/src/service/logs/command/group/group.command.ts
@@ -1,0 +1,111 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+
+/**
+ * Minimal structural sim CloudWatch Logs CreateLogGroup command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/cloudwatch-logs/command/CreateLogGroupCommand/
+ */
+export interface SimCreateLogGroupCommand {
+  readonly input: SimCreateLogGroupCommandInput;
+}
+
+export interface SimCreateLogGroupCommandInput {
+  readonly logGroupName?: string | undefined;
+  readonly kmsKeyId?: string | undefined;
+  readonly tags?: Readonly<Record<string, string>> | undefined;
+  readonly logGroupClass?: string | undefined;
+}
+
+export interface SimCreateLogGroupCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim CloudWatch Logs DeleteLogGroup command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/cloudwatch-logs/command/DeleteLogGroupCommand/
+ */
+export interface SimDeleteLogGroupCommand {
+  readonly input: SimDeleteLogGroupCommandInput;
+}
+
+export interface SimDeleteLogGroupCommandInput {
+  readonly logGroupName?: string | undefined;
+}
+
+export interface SimDeleteLogGroupCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim CloudWatch Logs DescribeLogGroups command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/cloudwatch-logs/command/DescribeLogGroupsCommand/
+ */
+export interface SimDescribeLogGroupsCommand {
+  readonly input: SimDescribeLogGroupsCommandInput;
+}
+
+export interface SimDescribeLogGroupsCommandInput {
+  readonly logGroupNamePrefix?: string | undefined;
+  readonly limit?: number | undefined;
+  readonly nextToken?: string | undefined;
+}
+
+export interface SimDescribeLogGroupsCommandOutput {
+  readonly logGroups?: readonly SimLogsLogGroupDetail[] | undefined;
+  readonly nextToken?: string | undefined;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * What DescribeLogGroups reports about one log group.
+ */
+export interface SimLogsLogGroupDetail {
+  readonly logGroupName: string;
+  readonly creationTime: number;
+  readonly retentionInDays?: number | undefined;
+  readonly metricFilterCount: number;
+  readonly storedBytes: number;
+
+  /** The ARN with the trailing wildcard, as real CloudWatch Logs reports it. */
+  readonly arn: string;
+
+  /** The ARN of the group alone, without the trailing wildcard. */
+  readonly logGroupArn: string;
+}
+
+/**
+ * Minimal structural sim CloudWatch Logs PutRetentionPolicy command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/cloudwatch-logs/command/PutRetentionPolicyCommand/
+ */
+export interface SimPutRetentionPolicyCommand {
+  readonly input: SimPutRetentionPolicyCommandInput;
+}
+
+export interface SimPutRetentionPolicyCommandInput {
+  readonly logGroupName?: string | undefined;
+  readonly retentionInDays?: number | undefined;
+}
+
+export interface SimPutRetentionPolicyCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim CloudWatch Logs DeleteRetentionPolicy command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/cloudwatch-logs/command/DeleteRetentionPolicyCommand/
+ */
+export interface SimDeleteRetentionPolicyCommand {
+  readonly input: SimDeleteRetentionPolicyCommandInput;
+}
+
+export interface SimDeleteRetentionPolicyCommandInput {
+  readonly logGroupName?: string | undefined;
+}
+
+export interface SimDeleteRetentionPolicyCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/logs/command/group/sim-logs-log-group-commands.ts
+++ b/src/service/logs/command/group/sim-logs-log-group-commands.ts
@@ -48,7 +48,9 @@ export class SimLogsLogGroupCommands {
     command: SimCreateLogGroupCommand,
     options?: SimLogsRequestOptions,
   ): SimCreateLogGroupCommandOutput {
-    const logGroupName = requiredSimLogsLogGroupName(command.input.logGroupName);
+    const logGroupName = requiredSimLogsLogGroupName(
+      command.input.logGroupName,
+    );
 
     refuseUnsimulatedLogGroupInput(command.input);
     this.#authorizer.authorizeLogGroup(
@@ -69,7 +71,9 @@ export class SimLogsLogGroupCommands {
     command: SimDeleteLogGroupCommand,
     options?: SimLogsRequestOptions,
   ): SimDeleteLogGroupCommandOutput {
-    const logGroupName = requiredSimLogsLogGroupName(command.input.logGroupName);
+    const logGroupName = requiredSimLogsLogGroupName(
+      command.input.logGroupName,
+    );
 
     this.#authorizer.authorizeLogGroup(
       "logs:DeleteLogGroup",

--- a/src/service/logs/command/group/sim-logs-log-group-commands.ts
+++ b/src/service/logs/command/group/sim-logs-log-group-commands.ts
@@ -1,0 +1,135 @@
+import type { SimClock } from "../../../../util/clock/sim-clock.js";
+import type { SimLogsLogGroup } from "../../group/sim-logs-log-group.js";
+import { requiredSimLogsLogGroupName } from "../../group/sim-logs-log-group-name.js";
+import type { SimLogsLogGroupStore } from "../../group/sim-logs-log-group-store.js";
+import type { SimLogsAuthorizer } from "../authorize/sim-logs-authorizer.js";
+import { SimLogsPage } from "../sim-logs-page.js";
+import type { SimLogsRequestOptions } from "../sim-logs-request-options.js";
+import type {
+  SimCreateLogGroupCommand,
+  SimCreateLogGroupCommandOutput,
+  SimDeleteLogGroupCommand,
+  SimDeleteLogGroupCommandOutput,
+  SimDescribeLogGroupsCommand,
+  SimDescribeLogGroupsCommandOutput,
+  SimLogsLogGroupDetail,
+} from "./group.command.js";
+import { refuseUnsimulatedLogGroupInput } from "./sim-logs-unsimulated-group-input.js";
+
+const maximumDescribeLimit = 50;
+
+interface SimLogsLogGroupCommandsProperties {
+  readonly groups: SimLogsLogGroupStore;
+  readonly authorizer: SimLogsAuthorizer;
+  readonly clock: SimClock;
+}
+
+/**
+ * The commands that make, remove and describe log groups.
+ */
+export class SimLogsLogGroupCommands {
+  readonly #groups: SimLogsLogGroupStore;
+  readonly #authorizer: SimLogsAuthorizer;
+  readonly #clock: SimClock;
+
+  constructor(properties: SimLogsLogGroupCommandsProperties) {
+    this.#groups = properties.groups;
+    this.#authorizer = properties.authorizer;
+    this.#clock = properties.clock;
+  }
+
+  /**
+   * Make a log group.
+   *
+   * Creation is not idempotent on real CloudWatch Logs, so a name already in
+   * use fails rather than answering with the group that is there.
+   */
+  createLogGroup(
+    command: SimCreateLogGroupCommand,
+    options?: SimLogsRequestOptions,
+  ): SimCreateLogGroupCommandOutput {
+    const logGroupName = requiredSimLogsLogGroupName(command.input.logGroupName);
+
+    refuseUnsimulatedLogGroupInput(command.input);
+    this.#authorizer.authorizeLogGroup(
+      "logs:CreateLogGroup",
+      logGroupName,
+      options?.caller,
+    );
+
+    this.#groups.create(logGroupName, this.#clock.now().getTime());
+
+    return { $metadata: {} };
+  }
+
+  /**
+   * Remove a log group, and the streams and events it holds with it.
+   */
+  deleteLogGroup(
+    command: SimDeleteLogGroupCommand,
+    options?: SimLogsRequestOptions,
+  ): SimDeleteLogGroupCommandOutput {
+    const logGroupName = requiredSimLogsLogGroupName(command.input.logGroupName);
+
+    this.#authorizer.authorizeLogGroup(
+      "logs:DeleteLogGroup",
+      logGroupName,
+      options?.caller,
+    );
+
+    this.#groups.require(logGroupName);
+    this.#groups.delete(logGroupName);
+
+    return { $metadata: {} };
+  }
+
+  /**
+   * Describe the log groups in this scope, oldest first.
+   *
+   * Real CloudWatch Logs gives this action no group-level permission worth
+   * scoping, so it authorizes against every log group in the account and
+   * region rather than against each one it reports.
+   */
+  describeLogGroups(
+    command: SimDescribeLogGroupsCommand,
+    options?: SimLogsRequestOptions,
+  ): SimDescribeLogGroupsCommandOutput {
+    const input = command.input;
+
+    this.#authorizer.authorizeAnyLogGroup(
+      "logs:DescribeLogGroups",
+      options?.caller,
+    );
+
+    const page = new SimLogsPage({
+      listed: this.#groups.withNamePrefix(input.logGroupNamePrefix),
+      limit: input.limit,
+      nextToken: input.nextToken,
+      maximumLimit: maximumDescribeLimit,
+    });
+
+    return {
+      $metadata: {},
+      logGroups: page.items.map((group) => logGroupDetail(group)),
+      nextToken: page.nextToken,
+    };
+  }
+}
+
+/**
+ * What DescribeLogGroups reports about one log group.
+ *
+ * `metricFilterCount` is always zero: metric filters are a CloudWatch metrics
+ * feature, and no simulated CloudWatch Logs operation here creates one.
+ */
+function logGroupDetail(group: SimLogsLogGroup): SimLogsLogGroupDetail {
+  return {
+    logGroupName: group.logGroupName,
+    creationTime: group.creationTime,
+    retentionInDays: group.retentionInDays,
+    metricFilterCount: 0,
+    storedBytes: group.storedBytes,
+    arn: group.arn,
+    logGroupArn: group.logGroupArn,
+  };
+}

--- a/src/service/logs/command/group/sim-logs-retention-commands.ts
+++ b/src/service/logs/command/group/sim-logs-retention-commands.ts
@@ -1,0 +1,78 @@
+import { requiredSimLogsLogGroupName } from "../../group/sim-logs-log-group-name.js";
+import type { SimLogsLogGroupStore } from "../../group/sim-logs-log-group-store.js";
+import { requiredSimLogsRetentionDays } from "../../group/sim-logs-retention.js";
+import type { SimLogsAuthorizer } from "../authorize/sim-logs-authorizer.js";
+import type { SimLogsRequestOptions } from "../sim-logs-request-options.js";
+import type {
+  SimDeleteRetentionPolicyCommand,
+  SimDeleteRetentionPolicyCommandOutput,
+  SimPutRetentionPolicyCommand,
+  SimPutRetentionPolicyCommandOutput,
+} from "./group.command.js";
+
+interface SimLogsRetentionCommandsProperties {
+  readonly groups: SimLogsLogGroupStore;
+  readonly authorizer: SimLogsAuthorizer;
+}
+
+/**
+ * The commands that set and clear how long a log group keeps its events.
+ *
+ * Nothing here expires anything. Retention is held so a test can assert on
+ * what a stack set, which is the mistake worth catching: a group deployed with
+ * the wrong retention, or with none at all, costs money quietly for years.
+ * Simulating the expiry itself would need a test to move the clock by months
+ * to see any effect.
+ */
+export class SimLogsRetentionCommands {
+  readonly #groups: SimLogsLogGroupStore;
+  readonly #authorizer: SimLogsAuthorizer;
+
+  constructor(properties: SimLogsRetentionCommandsProperties) {
+    this.#groups = properties.groups;
+    this.#authorizer = properties.authorizer;
+  }
+
+  /**
+   * Set how long a log group keeps its events.
+   */
+  putRetentionPolicy(
+    command: SimPutRetentionPolicyCommand,
+    options?: SimLogsRequestOptions,
+  ): SimPutRetentionPolicyCommandOutput {
+    const logGroupName = requiredSimLogsLogGroupName(command.input.logGroupName);
+    const retentionInDays = requiredSimLogsRetentionDays(
+      command.input.retentionInDays,
+    );
+
+    this.#authorizer.authorizeLogGroup(
+      "logs:PutRetentionPolicy",
+      logGroupName,
+      options?.caller,
+    );
+
+    this.#groups.require(logGroupName).setRetention(retentionInDays);
+
+    return { $metadata: {} };
+  }
+
+  /**
+   * Clear a log group's retention, putting it back to keeping events forever.
+   */
+  deleteRetentionPolicy(
+    command: SimDeleteRetentionPolicyCommand,
+    options?: SimLogsRequestOptions,
+  ): SimDeleteRetentionPolicyCommandOutput {
+    const logGroupName = requiredSimLogsLogGroupName(command.input.logGroupName);
+
+    this.#authorizer.authorizeLogGroup(
+      "logs:DeleteRetentionPolicy",
+      logGroupName,
+      options?.caller,
+    );
+
+    this.#groups.require(logGroupName).setRetention(undefined);
+
+    return { $metadata: {} };
+  }
+}

--- a/src/service/logs/command/group/sim-logs-retention-commands.ts
+++ b/src/service/logs/command/group/sim-logs-retention-commands.ts
@@ -40,7 +40,9 @@ export class SimLogsRetentionCommands {
     command: SimPutRetentionPolicyCommand,
     options?: SimLogsRequestOptions,
   ): SimPutRetentionPolicyCommandOutput {
-    const logGroupName = requiredSimLogsLogGroupName(command.input.logGroupName);
+    const logGroupName = requiredSimLogsLogGroupName(
+      command.input.logGroupName,
+    );
     const retentionInDays = requiredSimLogsRetentionDays(
       command.input.retentionInDays,
     );
@@ -63,7 +65,9 @@ export class SimLogsRetentionCommands {
     command: SimDeleteRetentionPolicyCommand,
     options?: SimLogsRequestOptions,
   ): SimDeleteRetentionPolicyCommandOutput {
-    const logGroupName = requiredSimLogsLogGroupName(command.input.logGroupName);
+    const logGroupName = requiredSimLogsLogGroupName(
+      command.input.logGroupName,
+    );
 
     this.#authorizer.authorizeLogGroup(
       "logs:DeleteRetentionPolicy",

--- a/src/service/logs/command/group/sim-logs-unsimulated-group-input.ts
+++ b/src/service/logs/command/group/sim-logs-unsimulated-group-input.ts
@@ -1,0 +1,47 @@
+import { SimLogsUnsupportedOperationException } from "../../error/sim-logs.error.js";
+import type { SimCreateLogGroupCommandInput } from "./group.command.js";
+
+/**
+ * The only log group class this simulation holds events for.
+ *
+ * The others change where events are stored and which operations reach them on
+ * real CloudWatch Logs, and none of that is modelled here.
+ */
+export const simLogsStandardLogGroupClass = "STANDARD";
+
+/**
+ * Refuse the CreateLogGroup inputs this simulation does not model.
+ *
+ * Each of these changes what the log group does on real AWS, so accepting one
+ * and dropping it would let a request succeed here and behave differently in
+ * an account. A tag is the clearest case: the group would look tagged to the
+ * request that made it and untagged to everything else.
+ */
+export function refuseUnsimulatedLogGroupInput(
+  input: SimCreateLogGroupCommandInput,
+): void {
+  if (input.tags !== undefined) {
+    throw new SimLogsUnsupportedOperationException(
+      "Log group tags are not simulated, so CreateLogGroup refuses them " +
+        "rather than dropping them",
+    );
+  }
+
+  if (input.kmsKeyId !== undefined) {
+    throw new SimLogsUnsupportedOperationException(
+      "Log group encryption is not simulated, so CreateLogGroup refuses " +
+        "kmsKeyId rather than storing events a key was meant to protect",
+    );
+  }
+
+  if (
+    input.logGroupClass !== undefined &&
+    input.logGroupClass !== simLogsStandardLogGroupClass
+  ) {
+    throw new SimLogsUnsupportedOperationException(
+      `Log group class '${input.logGroupClass}' is not simulated: only ` +
+        `${simLogsStandardLogGroupClass} is, which is the class every ` +
+        `operation here behaves as`,
+    );
+  }
+}

--- a/src/service/logs/command/sim-logs-command.types.ts
+++ b/src/service/logs/command/sim-logs-command.types.ts
@@ -1,0 +1,44 @@
+/**
+ * The sim CloudWatch Logs Command types, gathered for the service facade.
+ */
+export type {
+  SimCreateLogGroupCommand,
+  SimCreateLogGroupCommandInput,
+  SimCreateLogGroupCommandOutput,
+  SimDeleteLogGroupCommand,
+  SimDeleteLogGroupCommandInput,
+  SimDeleteLogGroupCommandOutput,
+  SimDeleteRetentionPolicyCommand,
+  SimDeleteRetentionPolicyCommandInput,
+  SimDeleteRetentionPolicyCommandOutput,
+  SimDescribeLogGroupsCommand,
+  SimDescribeLogGroupsCommandInput,
+  SimDescribeLogGroupsCommandOutput,
+  SimLogsLogGroupDetail,
+  SimPutRetentionPolicyCommand,
+  SimPutRetentionPolicyCommandInput,
+  SimPutRetentionPolicyCommandOutput,
+} from "./group/group.command.js";
+export type {
+  SimCreateLogStreamCommand,
+  SimCreateLogStreamCommandInput,
+  SimCreateLogStreamCommandOutput,
+  SimDescribeLogStreamsCommand,
+  SimDescribeLogStreamsCommandInput,
+  SimDescribeLogStreamsCommandOutput,
+  SimLogsLogStreamDetail,
+} from "./stream/stream.command.js";
+export type {
+  SimFilterLogEventsCommand,
+  SimFilterLogEventsCommandInput,
+  SimFilterLogEventsCommandOutput,
+  SimGetLogEventsCommand,
+  SimGetLogEventsCommandInput,
+  SimGetLogEventsCommandOutput,
+  SimLogsFilteredLogEvent,
+  SimLogsInputLogEvent,
+  SimLogsOutputLogEvent,
+  SimPutLogEventsCommand,
+  SimPutLogEventsCommandInput,
+  SimPutLogEventsCommandOutput,
+} from "./event/event.command.js";

--- a/src/service/logs/command/sim-logs-limit.ts
+++ b/src/service/logs/command/sim-logs-limit.ts
@@ -1,0 +1,26 @@
+import { SimLogsInvalidParameterException } from "../error/sim-logs.error.js";
+
+/**
+ * Read the page size a request asked for, refusing one the operation does not
+ * offer.
+ *
+ * Every paged CloudWatch Logs operation here has the same shape of limit and
+ * differs only in how large it may be, so the maximum is passed in and the
+ * check is written once.
+ */
+export function requiredSimLogsLimit(
+  requested: number | undefined,
+  maximumLimit: number,
+): number {
+  const limit = requested ?? maximumLimit;
+
+  if (!Number.isSafeInteger(limit) || limit < 1 || limit > maximumLimit) {
+    throw new SimLogsInvalidParameterException(
+      `1 validation error detected: Value '${String(requested)}' at 'limit' ` +
+        `failed to satisfy constraint: Member must be between 1 and ` +
+        `${maximumLimit}`,
+    );
+  }
+
+  return limit;
+}

--- a/src/service/logs/command/sim-logs-page.ts
+++ b/src/service/logs/command/sim-logs-page.ts
@@ -1,4 +1,5 @@
 import { SimLogsInvalidParameterException } from "../error/sim-logs.error.js";
+import { requiredSimLogsLimit } from "./sim-logs-limit.js";
 
 interface SimLogsPageProperties<T> {
   /** Everything the request selected, before paging. */
@@ -18,37 +19,30 @@ interface SimLogsPageProperties<T> {
  * into what the request selected. Tokens are the canonical representation of
  * that offset, so a token from somewhere else is refused rather than quietly
  * starting again from the beginning.
+ *
+ * An offset is only meaningful against the selection it was issued for, so a
+ * token carried over to a request with a different prefix, filter or time
+ * window reaches a different place. That is the same bargain simulated SQS
+ * makes with its own listings, and it is documented rather than defended
+ * against: there is no security boundary between a test and the simulator it
+ * is calling.
  */
 export class SimLogsPage<T> {
   readonly items: readonly T[];
   readonly nextToken: string | undefined;
 
   constructor(properties: SimLogsPageProperties<T>) {
-    const { listed, maximumLimit } = properties;
-    const limit = pageLimit(properties.limit, maximumLimit);
+    const { listed } = properties;
+    const limit = requiredSimLogsLimit(
+      properties.limit,
+      properties.maximumLimit,
+    );
     const startIndex = pageStartIndex(properties.nextToken, listed.length);
     const nextIndex = startIndex + limit;
 
     this.items = listed.slice(startIndex, nextIndex);
     this.nextToken = nextIndex >= listed.length ? undefined : String(nextIndex);
   }
-}
-
-function pageLimit(
-  requested: number | undefined,
-  maximumLimit: number,
-): number {
-  const limit = requested ?? maximumLimit;
-
-  if (!Number.isSafeInteger(limit) || limit < 1 || limit > maximumLimit) {
-    throw new SimLogsInvalidParameterException(
-      `1 validation error detected: Value '${String(requested)}' at 'limit' ` +
-        `failed to satisfy constraint: Member must be between 1 and ` +
-        `${maximumLimit}`,
-    );
-  }
-
-  return limit;
 }
 
 function pageStartIndex(

--- a/src/service/logs/command/sim-logs-page.ts
+++ b/src/service/logs/command/sim-logs-page.ts
@@ -1,0 +1,76 @@
+import { SimLogsInvalidParameterException } from "../error/sim-logs.error.js";
+
+interface SimLogsPageProperties<T> {
+  /** Everything the request selected, before paging. */
+  readonly listed: readonly T[];
+
+  readonly limit?: number | undefined;
+  readonly nextToken?: string | undefined;
+
+  /** The largest page size this operation offers. */
+  readonly maximumLimit: number;
+}
+
+/**
+ * One page of a listing, and the token that reaches the next one.
+ *
+ * Every paged CloudWatch Logs operation here pages the same way, on an offset
+ * into what the request selected. Tokens are the canonical representation of
+ * that offset, so a token from somewhere else is refused rather than quietly
+ * starting again from the beginning.
+ */
+export class SimLogsPage<T> {
+  readonly items: readonly T[];
+  readonly nextToken: string | undefined;
+
+  constructor(properties: SimLogsPageProperties<T>) {
+    const { listed, maximumLimit } = properties;
+    const limit = pageLimit(properties.limit, maximumLimit);
+    const startIndex = pageStartIndex(properties.nextToken, listed.length);
+    const nextIndex = startIndex + limit;
+
+    this.items = listed.slice(startIndex, nextIndex);
+    this.nextToken = nextIndex >= listed.length ? undefined : String(nextIndex);
+  }
+}
+
+function pageLimit(
+  requested: number | undefined,
+  maximumLimit: number,
+): number {
+  const limit = requested ?? maximumLimit;
+
+  if (!Number.isSafeInteger(limit) || limit < 1 || limit > maximumLimit) {
+    throw new SimLogsInvalidParameterException(
+      `1 validation error detected: Value '${String(requested)}' at 'limit' ` +
+        `failed to satisfy constraint: Member must be between 1 and ` +
+        `${maximumLimit}`,
+    );
+  }
+
+  return limit;
+}
+
+function pageStartIndex(
+  nextToken: string | undefined,
+  listedCount: number,
+): number {
+  if (nextToken === undefined) {
+    return 0;
+  }
+
+  const startIndex = Number(nextToken);
+
+  if (
+    !Number.isSafeInteger(startIndex) ||
+    startIndex < 0 ||
+    startIndex >= listedCount ||
+    String(startIndex) !== nextToken
+  ) {
+    throw new SimLogsInvalidParameterException(
+      "The specified nextToken is not a token this simulation issued",
+    );
+  }
+
+  return startIndex;
+}

--- a/src/service/logs/command/sim-logs-request-options.ts
+++ b/src/service/logs/command/sim-logs-request-options.ts
@@ -1,0 +1,12 @@
+import type { SimAwsCaller } from "../../aws/caller/sim-aws-caller.js";
+
+/**
+ * What a simulated CloudWatch Logs request carries besides its command input.
+ */
+export interface SimLogsRequestOptions {
+  /**
+   * Who is making the request. An omitted caller is the Account root, as it is
+   * everywhere else in the simulation.
+   */
+  readonly caller?: SimAwsCaller;
+}

--- a/src/service/logs/command/stream/sim-logs-log-stream-commands.ts
+++ b/src/service/logs/command/stream/sim-logs-log-stream-commands.ts
@@ -1,0 +1,112 @@
+import type { SimClock } from "../../../../util/clock/sim-clock.js";
+import { requiredSimLogsLogGroupName } from "../../group/sim-logs-log-group-name.js";
+import type { SimLogsLogGroupStore } from "../../group/sim-logs-log-group-store.js";
+import type { SimLogsLogStream } from "../../stream/sim-logs-log-stream.js";
+import { requiredSimLogsLogStreamName } from "../../stream/sim-logs-log-stream-name.js";
+import type { SimLogsAuthorizer } from "../authorize/sim-logs-authorizer.js";
+import { SimLogsPage } from "../sim-logs-page.js";
+import type { SimLogsRequestOptions } from "../sim-logs-request-options.js";
+import { orderedSimLogsLogStreams } from "./sim-logs-log-stream-order.js";
+import type {
+  SimCreateLogStreamCommand,
+  SimCreateLogStreamCommandOutput,
+  SimDescribeLogStreamsCommand,
+  SimDescribeLogStreamsCommandOutput,
+  SimLogsLogStreamDetail,
+} from "./stream.command.js";
+
+const maximumDescribeLimit = 50;
+
+interface SimLogsLogStreamCommandsProperties {
+  readonly groups: SimLogsLogGroupStore;
+  readonly authorizer: SimLogsAuthorizer;
+  readonly clock: SimClock;
+}
+
+/**
+ * The commands that make and describe log streams.
+ */
+export class SimLogsLogStreamCommands {
+  readonly #groups: SimLogsLogGroupStore;
+  readonly #authorizer: SimLogsAuthorizer;
+  readonly #clock: SimClock;
+
+  constructor(properties: SimLogsLogStreamCommandsProperties) {
+    this.#groups = properties.groups;
+    this.#authorizer = properties.authorizer;
+    this.#clock = properties.clock;
+  }
+
+  /**
+   * Make a stream in a log group.
+   */
+  createLogStream(
+    command: SimCreateLogStreamCommand,
+    options?: SimLogsRequestOptions,
+  ): SimCreateLogStreamCommandOutput {
+    const logGroupName = requiredSimLogsLogGroupName(command.input.logGroupName);
+    const logStreamName = requiredSimLogsLogStreamName(
+      command.input.logStreamName,
+    );
+
+    this.#authorizer.authorizeLogGroup(
+      "logs:CreateLogStream",
+      logGroupName,
+      options?.caller,
+    );
+
+    this.#groups
+      .require(logGroupName)
+      .createStream(logStreamName, this.#clock.now().getTime());
+
+    return { $metadata: {} };
+  }
+
+  /**
+   * Describe the streams in a log group.
+   */
+  describeLogStreams(
+    command: SimDescribeLogStreamsCommand,
+    options?: SimLogsRequestOptions,
+  ): SimDescribeLogStreamsCommandOutput {
+    const input = command.input;
+    const logGroupName = requiredSimLogsLogGroupName(input.logGroupName);
+
+    this.#authorizer.authorizeLogGroup(
+      "logs:DescribeLogStreams",
+      logGroupName,
+      options?.caller,
+    );
+
+    const group = this.#groups.require(logGroupName);
+    const matching = group.streams.filter((stream) =>
+      stream.logStreamName.startsWith(input.logStreamNamePrefix ?? ""),
+    );
+
+    const page = new SimLogsPage({
+      listed: orderedSimLogsLogStreams(matching, input),
+      limit: input.limit,
+      nextToken: input.nextToken,
+      maximumLimit: maximumDescribeLimit,
+    });
+
+    return {
+      $metadata: {},
+      logStreams: page.items.map((stream) => logStreamDetail(stream)),
+      nextToken: page.nextToken,
+    };
+  }
+}
+
+function logStreamDetail(stream: SimLogsLogStream): SimLogsLogStreamDetail {
+  return {
+    logStreamName: stream.logStreamName,
+    creationTime: stream.creationTime,
+    firstEventTimestamp: stream.firstEventTimestamp,
+    lastEventTimestamp: stream.lastEventTimestamp,
+    lastIngestionTime: stream.lastIngestionTime,
+    uploadSequenceToken: stream.uploadSequenceToken,
+    arn: stream.arn,
+    storedBytes: 0,
+  };
+}

--- a/src/service/logs/command/stream/sim-logs-log-stream-commands.ts
+++ b/src/service/logs/command/stream/sim-logs-log-stream-commands.ts
@@ -44,7 +44,9 @@ export class SimLogsLogStreamCommands {
     command: SimCreateLogStreamCommand,
     options?: SimLogsRequestOptions,
   ): SimCreateLogStreamCommandOutput {
-    const logGroupName = requiredSimLogsLogGroupName(command.input.logGroupName);
+    const logGroupName = requiredSimLogsLogGroupName(
+      command.input.logGroupName,
+    );
     const logStreamName = requiredSimLogsLogStreamName(
       command.input.logStreamName,
     );

--- a/src/service/logs/command/stream/sim-logs-log-stream-order.ts
+++ b/src/service/logs/command/stream/sim-logs-log-stream-order.ts
@@ -27,25 +27,32 @@ export function orderedSimLogsLogStreams(
     );
   }
 
-  if (orderBy === orderByLastEventTime && input.logStreamNamePrefix !== undefined) {
+  if (
+    orderBy === orderByLastEventTime &&
+    input.logStreamNamePrefix !== undefined
+  ) {
     throw new SimLogsInvalidParameterException(
       "Cannot order by LastEventTime with a logStreamNamePrefix.",
     );
   }
 
-  const ordered = [...streams].sort((left, right) =>
+  const ordered = streams.toSorted((left, right) =>
     orderBy === orderByLastEventTime
       ? lastEventTime(left) - lastEventTime(right)
       : left.logStreamName.localeCompare(right.logStreamName),
   );
 
-  return input.descending === true ? ordered.reverse() : ordered;
+  return input.descending === true ? ordered.toReversed() : ordered;
 }
 
 /**
  * When a stream last had an event, treating one that has never had an event as
- * the oldest so it sorts before the streams that have.
+ * older than any timestamp so it sorts before the streams that have.
+ *
+ * Zero would not do it: that is a real timestamp, so a stream carrying an event
+ * from the epoch would tie with one carrying nothing, and the order between
+ * them would fall back to whichever happened to be created first.
  */
 function lastEventTime(stream: SimLogsLogStream): number {
-  return stream.lastEventTimestamp ?? 0;
+  return stream.lastEventTimestamp ?? -Infinity;
 }

--- a/src/service/logs/command/stream/sim-logs-log-stream-order.ts
+++ b/src/service/logs/command/stream/sim-logs-log-stream-order.ts
@@ -1,0 +1,51 @@
+import { SimLogsInvalidParameterException } from "../../error/sim-logs.error.js";
+import type { SimLogsLogStream } from "../../stream/sim-logs-log-stream.js";
+import type { SimDescribeLogStreamsCommandInput } from "./stream.command.js";
+
+const orderByLogStreamName = "LogStreamName";
+const orderByLastEventTime = "LastEventTime";
+
+/**
+ * Put the streams of a log group in the order a DescribeLogStreams request
+ * asked for.
+ *
+ * Real CloudWatch Logs orders by stream name unless asked for last event time,
+ * and refuses a name prefix alongside that ordering, because the two ask it to
+ * read the same index in two different ways.
+ */
+export function orderedSimLogsLogStreams(
+  streams: readonly SimLogsLogStream[],
+  input: SimDescribeLogStreamsCommandInput,
+): readonly SimLogsLogStream[] {
+  const orderBy = input.orderBy ?? orderByLogStreamName;
+
+  if (orderBy !== orderByLogStreamName && orderBy !== orderByLastEventTime) {
+    throw new SimLogsInvalidParameterException(
+      `1 validation error detected: Value '${orderBy}' at 'orderBy' failed ` +
+        `to satisfy constraint: Member must satisfy enum value set: ` +
+        `[${orderByLogStreamName}, ${orderByLastEventTime}]`,
+    );
+  }
+
+  if (orderBy === orderByLastEventTime && input.logStreamNamePrefix !== undefined) {
+    throw new SimLogsInvalidParameterException(
+      "Cannot order by LastEventTime with a logStreamNamePrefix.",
+    );
+  }
+
+  const ordered = [...streams].sort((left, right) =>
+    orderBy === orderByLastEventTime
+      ? lastEventTime(left) - lastEventTime(right)
+      : left.logStreamName.localeCompare(right.logStreamName),
+  );
+
+  return input.descending === true ? ordered.reverse() : ordered;
+}
+
+/**
+ * When a stream last had an event, treating one that has never had an event as
+ * the oldest so it sorts before the streams that have.
+ */
+function lastEventTime(stream: SimLogsLogStream): number {
+  return stream.lastEventTimestamp ?? 0;
+}

--- a/src/service/logs/command/stream/stream.command.ts
+++ b/src/service/logs/command/stream/stream.command.ts
@@ -1,0 +1,63 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+
+/**
+ * Minimal structural sim CloudWatch Logs CreateLogStream command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/cloudwatch-logs/command/CreateLogStreamCommand/
+ */
+export interface SimCreateLogStreamCommand {
+  readonly input: SimCreateLogStreamCommandInput;
+}
+
+export interface SimCreateLogStreamCommandInput {
+  readonly logGroupName?: string | undefined;
+  readonly logStreamName?: string | undefined;
+}
+
+export interface SimCreateLogStreamCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim CloudWatch Logs DescribeLogStreams command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/cloudwatch-logs/command/DescribeLogStreamsCommand/
+ */
+export interface SimDescribeLogStreamsCommand {
+  readonly input: SimDescribeLogStreamsCommandInput;
+}
+
+export interface SimDescribeLogStreamsCommandInput {
+  readonly logGroupName?: string | undefined;
+  readonly logStreamNamePrefix?: string | undefined;
+  readonly orderBy?: string | undefined;
+  readonly descending?: boolean | undefined;
+  readonly limit?: number | undefined;
+  readonly nextToken?: string | undefined;
+}
+
+export interface SimDescribeLogStreamsCommandOutput {
+  readonly logStreams?: readonly SimLogsLogStreamDetail[] | undefined;
+  readonly nextToken?: string | undefined;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * What DescribeLogStreams reports about one log stream.
+ */
+export interface SimLogsLogStreamDetail {
+  readonly logStreamName: string;
+  readonly creationTime: number;
+  readonly firstEventTimestamp?: number | undefined;
+  readonly lastEventTimestamp?: number | undefined;
+  readonly lastIngestionTime?: number | undefined;
+  readonly uploadSequenceToken?: string | undefined;
+  readonly arn: string;
+
+  /**
+   * Real CloudWatch Logs stopped reporting this per stream in 2019 and has
+   * answered zero ever since, so this does too. The bytes a group holds are
+   * reported by DescribeLogGroups.
+   */
+  readonly storedBytes: number;
+}

--- a/src/service/logs/error/sim-logs.error.ts
+++ b/src/service/logs/error/sim-logs.error.ts
@@ -1,0 +1,81 @@
+/**
+ * Minimal metadata shape for simulated CloudWatch Logs errors.
+ */
+export interface SimLogsErrorMetadata {
+  readonly httpStatusCode?: number;
+}
+
+/**
+ * Base class for simulated CloudWatch Logs errors.
+ */
+export class SimLogsError extends Error {
+  constructor(
+    message: string,
+    public readonly $metadata: SimLogsErrorMetadata = {},
+  ) {
+    super(message);
+  }
+}
+
+/**
+ * Simulated CloudWatch Logs ResourceNotFoundException error.
+ *
+ * Real CloudWatch Logs reports an unknown log group or log stream this way,
+ * including on a write: putting events to a stream that was never created
+ * fails rather than creating it.
+ */
+export class SimLogsResourceNotFoundException extends SimLogsError {
+  public override readonly name = "ResourceNotFoundException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
+ * Simulated CloudWatch Logs ResourceAlreadyExistsException error.
+ *
+ * This is what creating a log group or log stream that is already there
+ * produces. Creation is not idempotent on real CloudWatch Logs, so a test that
+ * creates the same group twice should see the same failure it would see in an
+ * account.
+ */
+export class SimLogsResourceAlreadyExistsException extends SimLogsError {
+  public override readonly name = "ResourceAlreadyExistsException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
+ * Simulated CloudWatch Logs InvalidParameterException error.
+ *
+ * Real CloudWatch Logs reports a malformed name, a retention value outside the
+ * set it accepts, a batch of events out of order and a filter pattern it
+ * cannot read all this way.
+ */
+export class SimLogsInvalidParameterException extends SimLogsError {
+  public override readonly name = "InvalidParameterException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
+ * Simulated CloudWatch Logs UnsupportedOperationException error.
+ *
+ * This one is Yulin reporting a request real CloudWatch Logs would accept and
+ * this simulator does not carry out, rather than a failure an account would
+ * produce. Refusing is the honest answer: a filter pattern quietly treated as
+ * matching everything would make a test pass for a reason that has nothing to
+ * do with what it asserts.
+ */
+export class SimLogsUnsupportedOperationException extends SimLogsError {
+  public override readonly name = "UnsupportedOperationException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}

--- a/src/service/logs/event/sim-logs-event-batch.ts
+++ b/src/service/logs/event/sim-logs-event-batch.ts
@@ -1,5 +1,8 @@
 import { SimLogsInvalidParameterException } from "../error/sim-logs.error.js";
-import { simLogsEventSizeBytes, type SimLogsStoredEvent } from "./sim-logs-event.js";
+import {
+  simLogsEventSizeBytes,
+  type SimLogsStoredEvent,
+} from "./sim-logs-event.js";
 import type { SimLogsEventIds } from "./sim-logs-event-ids.js";
 
 /** What real CloudWatch Logs accepts in one PutLogEvents batch. */

--- a/src/service/logs/event/sim-logs-event-batch.ts
+++ b/src/service/logs/event/sim-logs-event-batch.ts
@@ -1,0 +1,122 @@
+import { SimLogsInvalidParameterException } from "../error/sim-logs.error.js";
+import { simLogsEventSizeBytes, type SimLogsStoredEvent } from "./sim-logs-event.js";
+import type { SimLogsEventIds } from "./sim-logs-event-ids.js";
+
+/** What real CloudWatch Logs accepts in one PutLogEvents batch. */
+const maximumBatchEvents = 10_000;
+const maximumBatchBytes = 1_048_576;
+
+/**
+ * A log event as a caller sends it, before it is accepted onto a stream.
+ */
+export interface SimLogsInputEvent {
+  readonly timestamp?: number | undefined;
+  readonly message?: string | undefined;
+}
+
+interface SimLogsEventBatchProperties {
+  readonly events: readonly SimLogsInputEvent[] | undefined;
+  readonly eventIds: SimLogsEventIds;
+  readonly ingestionTime: number;
+}
+
+/**
+ * One batch of log events, checked the way real CloudWatch Logs checks it.
+ *
+ * The chronological rule is the one worth having: a batch whose events are not
+ * in ascending order is refused by an account and is easy to send by accident,
+ * because the obvious way to build a batch is to collect lines from several
+ * places and send them in whatever order they were collected.
+ */
+export class SimLogsEventBatch {
+  readonly events: readonly SimLogsStoredEvent[];
+
+  constructor(properties: SimLogsEventBatchProperties) {
+    const events = requiredBatch(properties.events);
+
+    this.events = events.map((event, index) => ({
+      eventId: properties.eventIds.next(),
+      timestamp: requiredTimestamp(event, index, events),
+      ingestionTime: properties.ingestionTime,
+      message: requiredMessage(event),
+    }));
+  }
+}
+
+function requiredBatch(
+  events: readonly SimLogsInputEvent[] | undefined,
+): readonly SimLogsInputEvent[] {
+  if (events === undefined || events.length === 0) {
+    throw new SimLogsInvalidParameterException(
+      "1 validation error detected: Value at 'logEvents' failed to satisfy " +
+        "constraint: Member must have length greater than or equal to 1",
+    );
+  }
+
+  if (events.length > maximumBatchEvents) {
+    throw new SimLogsInvalidParameterException(
+      `1 validation error detected: Value at 'logEvents' failed to satisfy ` +
+        `constraint: Member must have length less than or equal to ` +
+        `${maximumBatchEvents}`,
+    );
+  }
+
+  refuseOversizedBatch(events);
+
+  return events;
+}
+
+/**
+ * Refuse a batch over the size limit, counting the per-event overhead real
+ * CloudWatch Logs counts.
+ */
+function refuseOversizedBatch(events: readonly SimLogsInputEvent[]): void {
+  const totalBytes = events.reduce(
+    (total, event) => total + simLogsEventSizeBytes(event.message ?? ""),
+    0,
+  );
+
+  if (totalBytes > maximumBatchBytes) {
+    throw new SimLogsInvalidParameterException(
+      `Log event batch of ${totalBytes} bytes exceeds the ` +
+        `${maximumBatchBytes} byte limit`,
+    );
+  }
+}
+
+function requiredMessage(event: SimLogsInputEvent): string {
+  if (event.message === undefined || event.message.length === 0) {
+    throw new SimLogsInvalidParameterException(
+      "1 validation error detected: Value at 'logEvents.message' failed to " +
+        "satisfy constraint: Member must have length greater than or equal to 1",
+    );
+  }
+
+  return event.message;
+}
+
+function requiredTimestamp(
+  event: SimLogsInputEvent,
+  index: number,
+  events: readonly SimLogsInputEvent[],
+): number {
+  const { timestamp } = event;
+
+  if (timestamp === undefined || !Number.isSafeInteger(timestamp)) {
+    throw new SimLogsInvalidParameterException(
+      "1 validation error detected: Value at 'logEvents.timestamp' failed " +
+        "to satisfy constraint: Member must not be null",
+    );
+  }
+
+  const previous = events[index - 1]?.timestamp;
+
+  if (previous !== undefined && timestamp < previous) {
+    throw new SimLogsInvalidParameterException(
+      "Log events in a single PutLogEvents request must be in chronological " +
+        "order.",
+    );
+  }
+
+  return timestamp;
+}

--- a/src/service/logs/event/sim-logs-event-ids.ts
+++ b/src/service/logs/event/sim-logs-event-ids.ts
@@ -1,0 +1,23 @@
+const eventIdDigits = 20;
+
+/**
+ * Source of the identifiers log events are reported under.
+ *
+ * One of these belongs to a simulated CloudWatch Logs rather than to a stream,
+ * so an event ID is unique across the whole service the way the real one is
+ * unique across an account. Zero padding keeps them sortable as strings, which
+ * is what lets two events sharing a timestamp be read back in the order they
+ * arrived.
+ */
+export class SimLogsEventIds {
+  #issued = 0;
+
+  /**
+   * The next event ID.
+   */
+  next(): string {
+    this.#issued += 1;
+
+    return String(this.#issued).padStart(eventIdDigits, "0");
+  }
+}

--- a/src/service/logs/event/sim-logs-event-window.ts
+++ b/src/service/logs/event/sim-logs-event-window.ts
@@ -1,0 +1,31 @@
+import type { SimLogsStoredEvent } from "./sim-logs-event.js";
+
+/**
+ * The time range a read of log events asked for.
+ */
+export interface SimLogsEventWindowInput {
+  readonly startTime?: number | undefined;
+  readonly endTime?: number | undefined;
+}
+
+/**
+ * Narrow events to the time range a request asked for.
+ *
+ * The range is half open, as real CloudWatch Logs documents it: an event whose
+ * timestamp equals `startTime` is included and one whose timestamp equals
+ * `endTime` is not. That asymmetry is easy to get wrong from either side, so a
+ * test paging by time here sees the same boundaries it would see in an
+ * account.
+ */
+export function simLogsEventsInWindow(
+  events: readonly SimLogsStoredEvent[],
+  window: SimLogsEventWindowInput,
+): readonly SimLogsStoredEvent[] {
+  const { startTime, endTime } = window;
+
+  return events.filter(
+    (event) =>
+      (startTime === undefined || event.timestamp >= startTime) &&
+      (endTime === undefined || event.timestamp < endTime),
+  );
+}

--- a/src/service/logs/event/sim-logs-event.ts
+++ b/src/service/logs/event/sim-logs-event.ts
@@ -1,0 +1,50 @@
+/**
+ * What real CloudWatch Logs adds to each event when it measures a batch.
+ *
+ * A batch is limited by its size in bytes, and the limit counts 26 bytes of
+ * overhead per event on top of the message. Counting it here is what makes the
+ * simulator refuse the same batch an account would.
+ */
+export const simLogsEventOverheadBytes = 26;
+
+/**
+ * One log event held in a simulated log stream.
+ */
+export interface SimLogsStoredEvent {
+  /**
+   * The identifier `FilterLogEvents` reports for the event.
+   *
+   * Real CloudWatch Logs generates a long opaque number here. This one is a
+   * zero-padded counter, unique within a simulation and increasing with
+   * ingestion, which is everything a caller can rely on about the real one.
+   */
+  readonly eventId: string;
+
+  /** When the event happened, as the caller reported it. */
+  readonly timestamp: number;
+
+  /** When CloudWatch Logs accepted it. */
+  readonly ingestionTime: number;
+
+  readonly message: string;
+}
+
+/**
+ * The size a log event counts as against a batch limit.
+ */
+export function simLogsEventSizeBytes(message: string): number {
+  return Buffer.byteLength(message, "utf8") + simLogsEventOverheadBytes;
+}
+
+/**
+ * Order events the way CloudWatch Logs reads them back: oldest first, and
+ * ingestion order between two events that carry the same timestamp.
+ */
+export function compareSimLogsEvents(
+  left: SimLogsStoredEvent,
+  right: SimLogsStoredEvent,
+): number {
+  return (
+    left.timestamp - right.timestamp || left.eventId.localeCompare(right.eventId)
+  );
+}

--- a/src/service/logs/event/sim-logs-event.ts
+++ b/src/service/logs/event/sim-logs-event.ts
@@ -45,6 +45,7 @@ export function compareSimLogsEvents(
   right: SimLogsStoredEvent,
 ): number {
   return (
-    left.timestamp - right.timestamp || left.eventId.localeCompare(right.eventId)
+    left.timestamp - right.timestamp ||
+    left.eventId.localeCompare(right.eventId)
   );
 }

--- a/src/service/logs/event/sim-logs-filter-pattern.iso.test.ts
+++ b/src/service/logs/event/sim-logs-filter-pattern.iso.test.ts
@@ -1,0 +1,117 @@
+import {
+  assertFalse,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsError,
+  assertTrue,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import {
+  SimLogsInvalidParameterException,
+  SimLogsUnsupportedOperationException,
+} from "../error/sim-logs.error.js";
+import { SimLogsFilterPattern } from "./sim-logs-filter-pattern.js";
+
+describe("SimLogsFilterPattern", () => {
+  it("matches everything when there is no pattern", () => {
+    // Given no pattern, and an empty one.
+    const none = new SimLogsFilterPattern();
+    const empty = new SimLogsFilterPattern("   ");
+
+    // Then both match any message, as an omitted filter pattern does.
+    assertTrue(none.matches("anything at all"));
+    assertTrue(empty.matches("anything at all"));
+  });
+
+  it("matches a term as a case sensitive substring", () => {
+    // Given a single term.
+    const pattern = new SimLogsFilterPattern("ERROR");
+
+    // Then it matches a message containing it, in that case only.
+    assertTrue(pattern.matches("2026-08-16 ERROR order failed"));
+    assertFalse(pattern.matches("2026-08-16 error order failed"));
+    assertFalse(pattern.matches("everything is fine"));
+  });
+
+  it("requires every term where several are given", () => {
+    // Given two terms with nothing between them.
+    const pattern = new SimLogsFilterPattern("ERROR orders");
+
+    // Then a message has to carry both.
+    assertTrue(pattern.matches("ERROR in orders service"));
+    assertFalse(pattern.matches("ERROR in billing service"));
+  });
+
+  it("matches any alternative where terms are prefixed with a question mark", () => {
+    // Given two alternatives.
+    const pattern = new SimLogsFilterPattern("?ERROR ?WARN");
+
+    // Then either one is enough, and neither is not.
+    assertTrue(pattern.matches("ERROR order failed"));
+    assertTrue(pattern.matches("WARN retrying"));
+    assertFalse(pattern.matches("INFO all good"));
+  });
+
+  it("excludes a term prefixed with a hyphen", () => {
+    // Given a required term and an excluded one.
+    const pattern = new SimLogsFilterPattern("ERROR -Throttling");
+
+    // Then the excluded term keeps a message out however well it otherwise
+    // matches.
+    assertTrue(pattern.matches("ERROR order failed"));
+    assertFalse(pattern.matches("ERROR Throttling from downstream"));
+  });
+
+  it("matches a quoted phrase, spaces and all", () => {
+    // Given a phrase and an escaped quote inside one.
+    const phrase = new SimLogsFilterPattern('"order has no items"');
+    const quoted = new SimLogsFilterPattern('"say \\"hello\\""');
+
+    // Then the whole phrase has to appear, rather than its words separately.
+    assertTrue(phrase.matches("ValidationError: order has no items"));
+    assertFalse(phrase.matches("order is fine, has no problems, no items"));
+    assertTrue(quoted.matches('the handler logged say "hello" once'));
+  });
+
+  it("refuses a quoted term that was never closed", () => {
+    // When a pattern opens a quote and does not close it.
+    const error = assertThrowsError(
+      () => new SimLogsFilterPattern('"order has no items'),
+    );
+
+    // Then it is refused rather than read as whatever is left.
+    assertInstanceOf(error, SimLogsInvalidParameterException);
+  });
+
+  it("refuses a term with nothing in it", () => {
+    // When a prefix is given with no term after it.
+    const error = assertThrowsError(() => new SimLogsFilterPattern("ERROR -"));
+
+    // Then it is refused.
+    assertInstanceOf(error, SimLogsInvalidParameterException);
+  });
+
+  it("refuses the pattern syntaxes it cannot read, rather than matching everything", () => {
+    // When a JSON property pattern, a space delimited field pattern and a
+    // regular expression term are given.
+    const json = assertThrowsError(
+      () => new SimLogsFilterPattern('{ $.level = "ERROR" }'),
+    );
+    const fields = assertThrowsError(
+      () => new SimLogsFilterPattern("[level=ERROR, message]"),
+    );
+    const regex = assertThrowsError(
+      () => new SimLogsFilterPattern("%ERROR|WARN%"),
+    );
+
+    // Then each says what is not supported, so a filter never silently turns
+    // into one that matches any log line at all.
+    assertInstanceOf(json, SimLogsUnsupportedOperationException);
+    assertInstanceOf(fields, SimLogsUnsupportedOperationException);
+    assertInstanceOf(regex, SimLogsUnsupportedOperationException);
+    assertStringIncludes(json.message, "JSON property");
+    assertStringIncludes(fields.message, "space delimited field");
+    assertStringIncludes(regex.message, "regular expression");
+  });
+});

--- a/src/service/logs/event/sim-logs-filter-pattern.iso.test.ts
+++ b/src/service/logs/event/sim-logs-filter-pattern.iso.test.ts
@@ -17,7 +17,7 @@ describe("SimLogsFilterPattern", () => {
   it("matches everything when there is no pattern", () => {
     // Given no pattern, and an empty one.
     const none = new SimLogsFilterPattern();
-    const empty = new SimLogsFilterPattern("   ");
+    const empty = new SimLogsFilterPattern(" ".repeat(3));
 
     // Then both match any message, as an omitted filter pattern does.
     assertTrue(none.matches("anything at all"));
@@ -66,7 +66,7 @@ describe("SimLogsFilterPattern", () => {
   it("matches a quoted phrase, spaces and all", () => {
     // Given a phrase and an escaped quote inside one.
     const phrase = new SimLogsFilterPattern('"order has no items"');
-    const quoted = new SimLogsFilterPattern('"say \\"hello\\""');
+    const quoted = new SimLogsFilterPattern(String.raw`"say \"hello\""`);
 
     // Then the whole phrase has to appear, rather than its words separately.
     assertTrue(phrase.matches("ValidationError: order has no items"));

--- a/src/service/logs/event/sim-logs-filter-pattern.ts
+++ b/src/service/logs/event/sim-logs-filter-pattern.ts
@@ -1,0 +1,87 @@
+import { SimLogsUnsupportedOperationException } from "../error/sim-logs.error.js";
+import {
+  simLogsFilterTerms,
+  type SimLogsFilterTerm,
+} from "./sim-logs-filter-terms.js";
+
+/**
+ * The two pattern syntaxes real CloudWatch Logs reads structurally rather than
+ * as text, recognised by the character they open with.
+ */
+const structuredPatternOpeners = new Map<string, string>([
+  ["{", "JSON property"],
+  ["[", "space delimited field"],
+]);
+
+/**
+ * A plain text CloudWatch Logs filter pattern, and what it matches.
+ *
+ * Terms are matched as case sensitive substrings, which is how real CloudWatch
+ * Logs matches them. Required terms must all appear, excluded terms must not
+ * appear, and where the pattern carries `?` alternatives at least one of them
+ * must appear.
+ *
+ * The structured syntaxes are refused rather than approximated. A pattern this
+ * simulator cannot read is worth failing on: a filter quietly treated as
+ * matching everything turns an assertion about one log line into an assertion
+ * about any log line at all.
+ */
+export class SimLogsFilterPattern {
+  readonly #terms: readonly SimLogsFilterTerm[];
+
+  constructor(pattern?: string) {
+    this.#terms = simLogsFilterTerms(refuseStructured(pattern ?? "").trim());
+  }
+
+  /**
+   * Whether a log event message matches this pattern.
+   *
+   * A pattern with no terms matches everything, as an omitted or empty filter
+   * pattern does on real CloudWatch Logs.
+   */
+  matches(message: string): boolean {
+    return (
+      this.every("required", (term) => message.includes(term)) &&
+      this.every("excluded", (term) => !message.includes(term)) &&
+      this.someAlternative(message)
+    );
+  }
+
+  private every(
+    kind: SimLogsFilterTerm["kind"],
+    holds: (text: string) => boolean,
+  ): boolean {
+    return this.textOf(kind).every((text) => holds(text));
+  }
+
+  private someAlternative(message: string): boolean {
+    const alternatives = this.textOf("optional");
+
+    return (
+      alternatives.length === 0 ||
+      alternatives.some((text) => message.includes(text))
+    );
+  }
+
+  private textOf(kind: SimLogsFilterTerm["kind"]): readonly string[] {
+    return this.#terms
+      .filter((term) => term.kind === kind)
+      .map((term) => term.text);
+  }
+}
+
+/**
+ * Refuse a pattern written in one of the structured syntaxes.
+ */
+function refuseStructured(pattern: string): string {
+  const opener = structuredPatternOpeners.get(pattern.trim().charAt(0));
+
+  if (opener !== undefined) {
+    throw new SimLogsUnsupportedOperationException(
+      `Simulated CloudWatch Logs does not support ${opener} filter patterns ` +
+        `yet: ${pattern}`,
+    );
+  }
+
+  return pattern;
+}

--- a/src/service/logs/event/sim-logs-filter-terms.ts
+++ b/src/service/logs/event/sim-logs-filter-terms.ts
@@ -15,27 +15,39 @@ const termKindsByPrefix = new Map<string, SimLogsFilterTermKind>([
   ["-", "excluded"],
 ]);
 
+const quote = '"';
+const escape = "\\";
+
 /**
  * Read the terms out of a plain text CloudWatch Logs filter pattern.
  *
  * A term is a bare word or a quoted phrase, optionally prefixed with `?` to
  * make it one of the alternatives or `-` to exclude it. Whitespace separates
  * terms, and only a quoted phrase may carry a space of its own.
+ *
+ * The scan reads characters with `charAt` rather than by index, which answers
+ * with the empty string past the end instead of undefined. That keeps the
+ * whole of this file free of both the assertions and the bounds checks an
+ * indexed scan would need for a position the loop conditions already rule out.
  */
-export function simLogsFilterTerms(pattern: string): readonly SimLogsFilterTerm[] {
+export function simLogsFilterTerms(
+  pattern: string,
+): readonly SimLogsFilterTerm[] {
   const terms: SimLogsFilterTerm[] = [];
   let index = 0;
 
   while (index < pattern.length) {
-    if (pattern[index] === undefined || /\s/.test(pattern[index] as string)) {
+    const character = pattern.charAt(index);
+
+    if (/\s/.test(character)) {
       index += 1;
       continue;
     }
 
-    const kind = termKindsByPrefix.get(pattern[index] as string);
+    const kind = termKindsByPrefix.get(character);
     const start = kind === undefined ? index : index + 1;
     const read =
-      pattern[start] === '"'
+      pattern.charAt(start) === quote
         ? readQuoted(pattern, start)
         : readBare(pattern, start);
 
@@ -59,15 +71,15 @@ function readQuoted(pattern: string, start: number): SimLogsFilterTermRead {
   let index = start + 1;
 
   while (index < pattern.length) {
-    const character = pattern[index] as string;
+    const character = pattern.charAt(index);
 
-    if (character === "\\" && pattern[index + 1] !== undefined) {
-      text += pattern[index + 1] as string;
+    if (character === escape && index + 1 < pattern.length) {
+      text += pattern.charAt(index + 1);
       index += 2;
       continue;
     }
 
-    if (character === '"') {
+    if (character === quote) {
       return { text, next: index + 1 };
     }
 

--- a/src/service/logs/event/sim-logs-filter-terms.ts
+++ b/src/service/logs/event/sim-logs-filter-terms.ts
@@ -1,0 +1,116 @@
+import {
+  SimLogsInvalidParameterException,
+  SimLogsUnsupportedOperationException,
+} from "../error/sim-logs.error.js";
+
+export type SimLogsFilterTermKind = "required" | "optional" | "excluded";
+
+export interface SimLogsFilterTerm {
+  readonly kind: SimLogsFilterTermKind;
+  readonly text: string;
+}
+
+const termKindsByPrefix = new Map<string, SimLogsFilterTermKind>([
+  ["?", "optional"],
+  ["-", "excluded"],
+]);
+
+/**
+ * Read the terms out of a plain text CloudWatch Logs filter pattern.
+ *
+ * A term is a bare word or a quoted phrase, optionally prefixed with `?` to
+ * make it one of the alternatives or `-` to exclude it. Whitespace separates
+ * terms, and only a quoted phrase may carry a space of its own.
+ */
+export function simLogsFilterTerms(pattern: string): readonly SimLogsFilterTerm[] {
+  const terms: SimLogsFilterTerm[] = [];
+  let index = 0;
+
+  while (index < pattern.length) {
+    if (pattern[index] === undefined || /\s/.test(pattern[index] as string)) {
+      index += 1;
+      continue;
+    }
+
+    const kind = termKindsByPrefix.get(pattern[index] as string);
+    const start = kind === undefined ? index : index + 1;
+    const read =
+      pattern[start] === '"'
+        ? readQuoted(pattern, start)
+        : readBare(pattern, start);
+
+    terms.push({ kind: kind ?? "required", text: refuseUnreadable(read.text) });
+    index = read.next;
+  }
+
+  return terms;
+}
+
+interface SimLogsFilterTermRead {
+  readonly text: string;
+  readonly next: number;
+}
+
+/**
+ * Read a quoted phrase, which may hold spaces and escaped quotes.
+ */
+function readQuoted(pattern: string, start: number): SimLogsFilterTermRead {
+  let text = "";
+  let index = start + 1;
+
+  while (index < pattern.length) {
+    const character = pattern[index] as string;
+
+    if (character === "\\" && pattern[index + 1] !== undefined) {
+      text += pattern[index + 1] as string;
+      index += 2;
+      continue;
+    }
+
+    if (character === '"') {
+      return { text, next: index + 1 };
+    }
+
+    text += character;
+    index += 1;
+  }
+
+  throw new SimLogsInvalidParameterException(
+    "Invalid filter pattern: a quoted term was not closed",
+  );
+}
+
+/**
+ * Read a bare word, which runs to the next space.
+ */
+function readBare(pattern: string, start: number): SimLogsFilterTermRead {
+  const remainder = pattern.slice(start);
+  const length = remainder.search(/\s/);
+  const text = length === -1 ? remainder : remainder.slice(0, length);
+
+  return { text, next: start + text.length };
+}
+
+/**
+ * Refuse a term this simulator would otherwise match on the wrong terms.
+ *
+ * A regular expression term is the one piece of plain text pattern syntax that
+ * is not a substring match, so treating it as one would match the wrong events
+ * rather than fewer of them.
+ */
+function refuseUnreadable(text: string): string {
+  if (text.length === 0) {
+    throw new SimLogsInvalidParameterException(
+      "Invalid filter pattern: a term was empty",
+    );
+  }
+
+  if (text.length > 1 && text.startsWith("%") && text.endsWith("%")) {
+    throw new SimLogsUnsupportedOperationException(
+      `Simulated CloudWatch Logs does not support regular expression filter ` +
+        `terms yet: ${text}`,
+    );
+  }
+
+  return text;
+}

--- a/src/service/logs/group/sim-logs-arn.ts
+++ b/src/service/logs/group/sim-logs-arn.ts
@@ -1,0 +1,62 @@
+import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+
+/**
+ * The start of every CloudWatch Logs ARN in one account and region.
+ */
+export function simLogsArnPrefix(scope: SimAwsAccountRegionScope): string {
+  return `arn:aws:logs:${scope.regionName}:${scope.accountId}:`;
+}
+
+/**
+ * The ARN of a log group, without the trailing wildcard.
+ *
+ * This is what `DescribeLogGroups` reports as `logGroupArn`. The separator
+ * before the name is a colon rather than a slash, so a name that starts with
+ * one, as every Lambda log group does, gives an ARN with two of them in a row.
+ * That is how real CloudWatch Logs writes it.
+ */
+export function simLogsLogGroupArn(
+  scope: SimAwsAccountRegionScope,
+  logGroupName: string,
+): string {
+  return `${simLogsArnPrefix(scope)}log-group:${logGroupName}`;
+}
+
+/**
+ * The ARN of a log group with the trailing wildcard that covers the streams
+ * inside it.
+ *
+ * Real CloudWatch Logs reports this as the `arn` field, and it is the form IAM
+ * policies are written against: granting `logs:PutLogEvents` on a log group
+ * means granting it on the streams the group holds, so the resource a write
+ * authorizes against ends in `:*`.
+ */
+export function simLogsLogGroupWildcardArn(
+  scope: SimAwsAccountRegionScope,
+  logGroupName: string,
+): string {
+  return `${simLogsLogGroupArn(scope, logGroupName)}:*`;
+}
+
+/**
+ * The ARN of every log group in one account and region.
+ *
+ * An operation that names no particular group authorizes against this, since
+ * that is the resource it actually reaches.
+ */
+export function simLogsAnyLogGroupArn(scope: SimAwsAccountRegionScope): string {
+  return `${simLogsArnPrefix(scope)}log-group:*`;
+}
+
+/**
+ * The ARN of a log stream inside a log group.
+ */
+export function simLogsLogStreamArn(
+  scope: SimAwsAccountRegionScope,
+  logGroupName: string,
+  logStreamName: string,
+): string {
+  return (
+    `${simLogsLogGroupArn(scope, logGroupName)}:log-stream:${logStreamName}`
+  );
+}

--- a/src/service/logs/group/sim-logs-arn.ts
+++ b/src/service/logs/group/sim-logs-arn.ts
@@ -56,7 +56,5 @@ export function simLogsLogStreamArn(
   logGroupName: string,
   logStreamName: string,
 ): string {
-  return (
-    `${simLogsLogGroupArn(scope, logGroupName)}:log-stream:${logStreamName}`
-  );
+  return `${simLogsLogGroupArn(scope, logGroupName)}:log-stream:${logStreamName}`;
 }

--- a/src/service/logs/group/sim-logs-log-group-name.ts
+++ b/src/service/logs/group/sim-logs-log-group-name.ts
@@ -8,6 +8,9 @@ const maximumLength = 512;
  */
 const logGroupNamePattern = /^[.\-_/#A-Za-z0-9]+$/;
 
+/** How real CloudWatch Logs writes that pattern when it refuses a name. */
+const reportedNamePattern = String.raw`[\.\-_/#A-Za-z0-9]+`;
+
 /**
  * Read a log group name, refusing one real CloudWatch Logs would refuse.
  *
@@ -33,9 +36,9 @@ export function requiredSimLogsLogGroupName(logGroupName?: string): string {
 
   if (!logGroupNamePattern.test(logGroupName)) {
     throw new SimLogsInvalidParameterException(
-      "1 validation error detected: Value at 'logGroupName' failed to " +
-        "satisfy constraint: Member must satisfy regular expression " +
-        "pattern: [\\.\\-_/#A-Za-z0-9]+",
+      `1 validation error detected: Value at 'logGroupName' failed to ` +
+        `satisfy constraint: Member must satisfy regular expression ` +
+        `pattern: ${reportedNamePattern}`,
     );
   }
 

--- a/src/service/logs/group/sim-logs-log-group-name.ts
+++ b/src/service/logs/group/sim-logs-log-group-name.ts
@@ -1,0 +1,43 @@
+import { SimLogsInvalidParameterException } from "../error/sim-logs.error.js";
+
+const maximumLength = 512;
+
+/**
+ * What real CloudWatch Logs accepts in a log group name: letters, numbers,
+ * underscore, hyphen, forward slash, period and number sign.
+ */
+const logGroupNamePattern = /^[.\-_/#A-Za-z0-9]+$/;
+
+/**
+ * Read a log group name, refusing one real CloudWatch Logs would refuse.
+ *
+ * The leading slash of a name like `/aws/lambda/orders` is part of the name and
+ * is kept, unlike an SSM parameter name, whose slash is dropped on the way into
+ * its ARN. A log group ARN carries the name exactly as it was given.
+ */
+export function requiredSimLogsLogGroupName(logGroupName?: string): string {
+  if (logGroupName === undefined || logGroupName.length === 0) {
+    throw new SimLogsInvalidParameterException(
+      "1 validation error detected: Value at 'logGroupName' failed to " +
+        "satisfy constraint: Member must not be null",
+    );
+  }
+
+  if (logGroupName.length > maximumLength) {
+    throw new SimLogsInvalidParameterException(
+      `1 validation error detected: Value at 'logGroupName' failed to ` +
+        `satisfy constraint: Member must have length less than or equal to ` +
+        `${maximumLength}`,
+    );
+  }
+
+  if (!logGroupNamePattern.test(logGroupName)) {
+    throw new SimLogsInvalidParameterException(
+      "1 validation error detected: Value at 'logGroupName' failed to " +
+        "satisfy constraint: Member must satisfy regular expression " +
+        "pattern: [\\.\\-_/#A-Za-z0-9]+",
+    );
+  }
+
+  return logGroupName;
+}

--- a/src/service/logs/group/sim-logs-log-group-store.ts
+++ b/src/service/logs/group/sim-logs-log-group-store.ts
@@ -1,0 +1,91 @@
+import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+import {
+  SimLogsResourceAlreadyExistsException,
+  SimLogsResourceNotFoundException,
+} from "../error/sim-logs.error.js";
+import { SimLogsLogGroup } from "./sim-logs-log-group.js";
+
+interface SimLogsLogGroupStoreProperties {
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+}
+
+/**
+ * The log groups of one simulated CloudWatch Logs scope.
+ *
+ * Groups are keyed by name, which is the whole of their identity: the name is
+ * unique within one account and region, and it is what the ARN carries.
+ */
+export class SimLogsLogGroupStore {
+  readonly #accountRegionScope: SimAwsAccountRegionScope;
+  readonly #groups = new Map<string, SimLogsLogGroup>();
+
+  constructor(properties: SimLogsLogGroupStoreProperties) {
+    this.#accountRegionScope = properties.accountRegionScope;
+  }
+
+  /**
+   * Every log group in this scope, in creation order.
+   */
+  get all(): readonly SimLogsLogGroup[] {
+    return this.#groups.values().toArray();
+  }
+
+  /**
+   * Make a log group, refusing a name that is taken.
+   */
+  create(logGroupName: string, creationTime: number): SimLogsLogGroup {
+    if (this.#groups.has(logGroupName)) {
+      throw new SimLogsResourceAlreadyExistsException(
+        "The specified log group already exists",
+      );
+    }
+
+    const group = new SimLogsLogGroup({
+      logGroupName,
+      accountRegionScope: this.#accountRegionScope,
+      creationTime,
+    });
+
+    this.#groups.set(logGroupName, group);
+
+    return group;
+  }
+
+  /**
+   * Find a log group by name.
+   */
+  find(logGroupName: string): SimLogsLogGroup | undefined {
+    return this.#groups.get(logGroupName);
+  }
+
+  /**
+   * Get a log group by name, refusing one that is not there.
+   */
+  require(logGroupName: string): SimLogsLogGroup {
+    const group = this.find(logGroupName);
+
+    if (group === undefined) {
+      throw new SimLogsResourceNotFoundException(
+        "The specified log group does not exist.",
+      );
+    }
+
+    return group;
+  }
+
+  /**
+   * The log groups whose names start with a prefix, in creation order.
+   */
+  withNamePrefix(prefix: string | undefined): readonly SimLogsLogGroup[] {
+    return this.all.filter((group) =>
+      group.logGroupName.startsWith(prefix ?? ""),
+    );
+  }
+
+  /**
+   * Remove a log group, and the streams and events it holds with it.
+   */
+  delete(logGroupName: string): void {
+    this.#groups.delete(logGroupName);
+  }
+}

--- a/src/service/logs/group/sim-logs-log-group.ts
+++ b/src/service/logs/group/sim-logs-log-group.ts
@@ -1,0 +1,126 @@
+import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+import {
+  SimLogsResourceAlreadyExistsException,
+  SimLogsResourceNotFoundException,
+} from "../error/sim-logs.error.js";
+import { SimLogsLogStream } from "../stream/sim-logs-log-stream.js";
+import {
+  simLogsLogGroupArn,
+  simLogsLogGroupWildcardArn,
+  simLogsLogStreamArn,
+} from "./sim-logs-arn.js";
+
+interface SimLogsLogGroupProperties {
+  readonly logGroupName: string;
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+  readonly creationTime: number;
+}
+
+/**
+ * One log group in a simulated CloudWatch Logs, and the streams it holds.
+ *
+ * A group carries two ARNs because real CloudWatch Logs reports two. The one
+ * ending in `:*` is what `DescribeLogGroups` has always returned as `arn` and
+ * what a policy is written against; `logGroupArn` is the later field that names
+ * the group alone.
+ */
+export class SimLogsLogGroup {
+  readonly logGroupName: string;
+  readonly logGroupArn: string;
+  readonly arn: string;
+  readonly creationTime: number;
+
+  readonly #accountRegionScope: SimAwsAccountRegionScope;
+  readonly #streams = new Map<string, SimLogsLogStream>();
+  #retentionInDays: number | undefined;
+
+  constructor(properties: SimLogsLogGroupProperties) {
+    const { logGroupName, accountRegionScope } = properties;
+
+    this.logGroupName = logGroupName;
+    this.#accountRegionScope = accountRegionScope;
+    this.creationTime = properties.creationTime;
+    this.logGroupArn = simLogsLogGroupArn(accountRegionScope, logGroupName);
+    this.arn = simLogsLogGroupWildcardArn(accountRegionScope, logGroupName);
+  }
+
+  /**
+   * How long events in this group are kept, or undefined where nothing has set
+   * it and they are kept forever.
+   */
+  get retentionInDays(): number | undefined {
+    return this.#retentionInDays;
+  }
+
+  /**
+   * Every stream in this group, in creation order.
+   */
+  get streams(): readonly SimLogsLogStream[] {
+    return this.#streams.values().toArray();
+  }
+
+  /**
+   * How many bytes of log data this group holds across its streams.
+   */
+  get storedBytes(): number {
+    return this.streams.reduce((total, stream) => total + stream.storedBytes, 0);
+  }
+
+  /**
+   * Set how long events in this group are kept.
+   */
+  setRetention(retentionInDays: number | undefined): void {
+    this.#retentionInDays = retentionInDays;
+  }
+
+  /**
+   * Make a stream in this group.
+   */
+  createStream(logStreamName: string, creationTime: number): SimLogsLogStream {
+    if (this.#streams.has(logStreamName)) {
+      throw new SimLogsResourceAlreadyExistsException(
+        "The specified log stream already exists",
+      );
+    }
+
+    const stream = new SimLogsLogStream({
+      logStreamName,
+      arn: simLogsLogStreamArn(
+        this.#accountRegionScope,
+        this.logGroupName,
+        logStreamName,
+      ),
+      creationTime,
+    });
+
+    this.#streams.set(logStreamName, stream);
+
+    return stream;
+  }
+
+  /**
+   * Find a stream in this group by name.
+   */
+  findStream(logStreamName: string): SimLogsLogStream | undefined {
+    return this.#streams.get(logStreamName);
+  }
+
+  /**
+   * Get a stream in this group, refusing one that is not there.
+   *
+   * Real CloudWatch Logs does not create a stream on a write, so putting
+   * events to a name nothing created fails here the way it fails in an
+   * account.
+   */
+  requireStream(logStreamName: string): SimLogsLogStream {
+    const stream = this.findStream(logStreamName);
+
+    if (stream === undefined) {
+      throw new SimLogsResourceNotFoundException(
+        "The specified log stream does not exist.",
+      );
+    }
+
+    return stream;
+  }
+}

--- a/src/service/logs/group/sim-logs-log-group.ts
+++ b/src/service/logs/group/sim-logs-log-group.ts
@@ -1,9 +1,6 @@
 import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
-import {
-  SimLogsResourceAlreadyExistsException,
-  SimLogsResourceNotFoundException,
-} from "../error/sim-logs.error.js";
-import { SimLogsLogStream } from "../stream/sim-logs-log-stream.js";
+import type { SimLogsLogStream } from "../stream/sim-logs-log-stream.js";
+import { SimLogsLogStreamStore } from "../stream/sim-logs-log-stream-store.js";
 import {
   simLogsLogGroupArn,
   simLogsLogGroupWildcardArn,
@@ -30,18 +27,20 @@ export class SimLogsLogGroup {
   readonly arn: string;
   readonly creationTime: number;
 
-  readonly #accountRegionScope: SimAwsAccountRegionScope;
-  readonly #streams = new Map<string, SimLogsLogStream>();
+  readonly #streams: SimLogsLogStreamStore;
   #retentionInDays: number | undefined;
 
   constructor(properties: SimLogsLogGroupProperties) {
     const { logGroupName, accountRegionScope } = properties;
 
     this.logGroupName = logGroupName;
-    this.#accountRegionScope = accountRegionScope;
     this.creationTime = properties.creationTime;
     this.logGroupArn = simLogsLogGroupArn(accountRegionScope, logGroupName);
     this.arn = simLogsLogGroupWildcardArn(accountRegionScope, logGroupName);
+    this.#streams = new SimLogsLogStreamStore({
+      arnOf: (logStreamName): string =>
+        simLogsLogStreamArn(accountRegionScope, logGroupName, logStreamName),
+    });
   }
 
   /**
@@ -56,14 +55,17 @@ export class SimLogsLogGroup {
    * Every stream in this group, in creation order.
    */
   get streams(): readonly SimLogsLogStream[] {
-    return this.#streams.values().toArray();
+    return this.#streams.all;
   }
 
   /**
    * How many bytes of log data this group holds across its streams.
    */
   get storedBytes(): number {
-    return this.streams.reduce((total, stream) => total + stream.storedBytes, 0);
+    return this.streams.reduce(
+      (total, stream) => total + stream.storedBytes,
+      0,
+    );
   }
 
   /**
@@ -77,50 +79,20 @@ export class SimLogsLogGroup {
    * Make a stream in this group.
    */
   createStream(logStreamName: string, creationTime: number): SimLogsLogStream {
-    if (this.#streams.has(logStreamName)) {
-      throw new SimLogsResourceAlreadyExistsException(
-        "The specified log stream already exists",
-      );
-    }
-
-    const stream = new SimLogsLogStream({
-      logStreamName,
-      arn: simLogsLogStreamArn(
-        this.#accountRegionScope,
-        this.logGroupName,
-        logStreamName,
-      ),
-      creationTime,
-    });
-
-    this.#streams.set(logStreamName, stream);
-
-    return stream;
+    return this.#streams.create(logStreamName, creationTime);
   }
 
   /**
    * Find a stream in this group by name.
    */
   findStream(logStreamName: string): SimLogsLogStream | undefined {
-    return this.#streams.get(logStreamName);
+    return this.#streams.find(logStreamName);
   }
 
   /**
    * Get a stream in this group, refusing one that is not there.
-   *
-   * Real CloudWatch Logs does not create a stream on a write, so putting
-   * events to a name nothing created fails here the way it fails in an
-   * account.
    */
   requireStream(logStreamName: string): SimLogsLogStream {
-    const stream = this.findStream(logStreamName);
-
-    if (stream === undefined) {
-      throw new SimLogsResourceNotFoundException(
-        "The specified log stream does not exist.",
-      );
-    }
-
-    return stream;
+    return this.#streams.require(logStreamName);
   }
 }

--- a/src/service/logs/group/sim-logs-retention.ts
+++ b/src/service/logs/group/sim-logs-retention.ts
@@ -1,0 +1,34 @@
+import { SimLogsInvalidParameterException } from "../error/sim-logs.error.js";
+
+/**
+ * The retention periods real CloudWatch Logs accepts, in days.
+ *
+ * It is a fixed set rather than a range, which is the part teams get wrong:
+ * `RetentionInDays: 10` looks reasonable and is refused. A simulator that took
+ * any number would let that mistake through to the account.
+ */
+export const simLogsRetentionDays: readonly number[] = [
+  1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1096, 1827,
+  2192, 2557, 2922, 3288, 3653,
+];
+
+/**
+ * Read a retention period, refusing one real CloudWatch Logs would refuse.
+ *
+ * A log group with no retention set keeps its events forever, which is the
+ * default and the reason retention is worth asserting on at all.
+ */
+export function requiredSimLogsRetentionDays(retentionInDays?: number): number {
+  if (
+    retentionInDays === undefined ||
+    !simLogsRetentionDays.includes(retentionInDays)
+  ) {
+    throw new SimLogsInvalidParameterException(
+      `1 validation error detected: Value '${String(retentionInDays)}' at ` +
+        `'retentionInDays' failed to satisfy constraint: Member must be one ` +
+        `of ${simLogsRetentionDays.join(", ")}`,
+    );
+  }
+
+  return retentionInDays;
+}

--- a/src/service/logs/index.ts
+++ b/src/service/logs/index.ts
@@ -1,0 +1,35 @@
+export { SimLogs } from "./sim-logs.js";
+export type { SimLogsRequestOptions } from "./command/sim-logs-request-options.js";
+export { SimLogsLogGroup } from "./group/sim-logs-log-group.js";
+export { SimLogsLogGroupStore } from "./group/sim-logs-log-group-store.js";
+export { requiredSimLogsLogGroupName } from "./group/sim-logs-log-group-name.js";
+export {
+  requiredSimLogsRetentionDays,
+  simLogsRetentionDays,
+} from "./group/sim-logs-retention.js";
+export {
+  simLogsAnyLogGroupArn,
+  simLogsArnPrefix,
+  simLogsLogGroupArn,
+  simLogsLogGroupWildcardArn,
+  simLogsLogStreamArn,
+} from "./group/sim-logs-arn.js";
+export { SimLogsLogStream } from "./stream/sim-logs-log-stream.js";
+export { requiredSimLogsLogStreamName } from "./stream/sim-logs-log-stream-name.js";
+export {
+  compareSimLogsEvents,
+  simLogsEventOverheadBytes,
+  simLogsEventSizeBytes,
+  type SimLogsStoredEvent,
+} from "./event/sim-logs-event.js";
+export { SimLogsEventIds } from "./event/sim-logs-event-ids.js";
+export { SimLogsFilterPattern } from "./event/sim-logs-filter-pattern.js";
+export { simLogsStandardLogGroupClass } from "./command/group/sim-logs-unsimulated-group-input.js";
+export {
+  SimLogsError,
+  type SimLogsErrorMetadata,
+  SimLogsInvalidParameterException,
+  SimLogsResourceAlreadyExistsException,
+  SimLogsResourceNotFoundException,
+  SimLogsUnsupportedOperationException,
+} from "./error/sim-logs.error.js";

--- a/src/service/logs/sdk/sim-logs-sdk-command-router.ts
+++ b/src/service/logs/sdk/sim-logs-sdk-command-router.ts
@@ -1,0 +1,129 @@
+import {
+  simSdkCallerOptions,
+  type SimSdkCommandRoute,
+  type SimSdkCommandRouter,
+} from "../../../sdk/index.js";
+import type {
+  SimFilterLogEventsCommand,
+  SimGetLogEventsCommand,
+  SimPutLogEventsCommand,
+} from "../command/event/event.command.js";
+import type {
+  SimCreateLogGroupCommand,
+  SimDeleteLogGroupCommand,
+  SimDeleteRetentionPolicyCommand,
+  SimDescribeLogGroupsCommand,
+  SimPutRetentionPolicyCommand,
+} from "../command/group/group.command.js";
+import type {
+  SimCreateLogStreamCommand,
+  SimDescribeLogStreamsCommand,
+} from "../command/stream/stream.command.js";
+import type { SimLogs } from "../sim-logs.js";
+
+/**
+ * Routes intercepted SDK Commands to one scoped simulated CloudWatch Logs.
+ */
+export class SimLogsSdkCommandRouter implements SimSdkCommandRouter {
+  readonly #routes: ReadonlyMap<string, SimSdkCommandRoute>;
+
+  constructor(simLogs: SimLogs) {
+    this.#routes = new Map<string, SimSdkCommandRoute>([
+      [
+        "CreateLogGroupCommand",
+        async (command, context): Promise<unknown> =>
+          await simLogs.createLogGroup(
+            command as SimCreateLogGroupCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "DeleteLogGroupCommand",
+        async (command, context): Promise<unknown> =>
+          await simLogs.deleteLogGroup(
+            command as SimDeleteLogGroupCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "DescribeLogGroupsCommand",
+        async (command, context): Promise<unknown> =>
+          await simLogs.describeLogGroups(
+            command as SimDescribeLogGroupsCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "PutRetentionPolicyCommand",
+        async (command, context): Promise<unknown> =>
+          await simLogs.putRetentionPolicy(
+            command as SimPutRetentionPolicyCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "DeleteRetentionPolicyCommand",
+        async (command, context): Promise<unknown> =>
+          await simLogs.deleteRetentionPolicy(
+            command as SimDeleteRetentionPolicyCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "CreateLogStreamCommand",
+        async (command, context): Promise<unknown> =>
+          await simLogs.createLogStream(
+            command as SimCreateLogStreamCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "DescribeLogStreamsCommand",
+        async (command, context): Promise<unknown> =>
+          await simLogs.describeLogStreams(
+            command as SimDescribeLogStreamsCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "PutLogEventsCommand",
+        async (command, context): Promise<unknown> =>
+          await simLogs.putLogEvents(
+            command as SimPutLogEventsCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "GetLogEventsCommand",
+        async (command, context): Promise<unknown> =>
+          await simLogs.getLogEvents(
+            command as SimGetLogEventsCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "FilterLogEventsCommand",
+        async (command, context): Promise<unknown> =>
+          await simLogs.filterLogEvents(
+            command as SimFilterLogEventsCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+    ]);
+  }
+
+  /**
+   * The SDK Command names simulated CloudWatch Logs can handle.
+   */
+  supportedCommandNames(): readonly string[] {
+    return this.#routes.keys().toArray();
+  }
+
+  /**
+   * Get the route for an SDK Command name, if simulated CloudWatch Logs
+   * supports it.
+   */
+  route(commandName: string): SimSdkCommandRoute | undefined {
+    return this.#routes.get(commandName);
+  }
+}

--- a/src/service/logs/sdk/sim-logs-sdk-routing.iso.test.ts
+++ b/src/service/logs/sdk/sim-logs-sdk-routing.iso.test.ts
@@ -1,0 +1,148 @@
+import {
+  CloudWatchLogsClient,
+  CreateLogGroupCommand,
+  CreateLogStreamCommand,
+  DeleteLogGroupCommand,
+  DeleteRetentionPolicyCommand,
+  DescribeLogGroupsCommand,
+  DescribeLogStreamsCommand,
+  FilterLogEventsCommand,
+  GetLogEventsCommand,
+  PutLogEventsCommand,
+  PutRetentionPolicyCommand,
+} from "@aws-sdk/client-cloudwatch-logs";
+import {
+  assertArrayEquals,
+  assertArrayIncludesAll,
+  assertArrayLength,
+  assertIdentical,
+  assertStringIncludes,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimSdk } from "../../../sdk/index.js";
+import { SimAws } from "../../aws/sim-aws.js";
+
+const logGroupName = "/aws/lambda/orders";
+const logStreamName = "2026/08/16/[$LATEST]abc";
+
+describe("SimLogsSdkCommandRouter", () => {
+  it("names every Command simulated CloudWatch Logs handles", () => {
+    // Given a scoped simulated CloudWatch Logs.
+    const simAws = new SimAws();
+
+    // When its supported Command names are asked for.
+    const names = simAws.logs().sdkCommandRouter().supportedCommandNames();
+
+    // Then each simulated operation is routable by SDK Command name.
+    assertArrayIncludesAll(names, [
+      "CreateLogGroupCommand",
+      "DeleteLogGroupCommand",
+      "DescribeLogGroupsCommand",
+      "PutRetentionPolicyCommand",
+      "DeleteRetentionPolicyCommand",
+      "CreateLogStreamCommand",
+      "DescribeLogStreamsCommand",
+      "PutLogEventsCommand",
+      "GetLogEventsCommand",
+      "FilterLogEventsCommand",
+    ]);
+  });
+
+  it("has no route for a Command it does not handle", () => {
+    // Given a scoped simulated CloudWatch Logs.
+    const simAws = new SimAws();
+
+    // When a CloudWatch Logs Command outside what is simulated is looked up.
+    const route = simAws.logs().sdkCommandRouter().route("StartQueryCommand");
+
+    // Then there is no route for it.
+    assertUndefined(route);
+  });
+});
+
+describe("CloudWatch Logs SDK interception", () => {
+  it("routes an intercepted CloudWatchLogsClient to simulated CloudWatch Logs", async () => {
+    // Given an intercepted CloudWatch Logs SDK client.
+    using simSdk = new SimSdk();
+    simSdk.intercept(CloudWatchLogsClient);
+
+    const client = new CloudWatchLogsClient({ region: "eu-west-2" });
+
+    // When ordinary SDK code writes a log line and searches for it.
+    await client.send(new CreateLogGroupCommand({ logGroupName }));
+    await client.send(
+      new CreateLogStreamCommand({ logGroupName, logStreamName }),
+    );
+    await client.send(
+      new PutLogEventsCommand({
+        logGroupName,
+        logStreamName,
+        logEvents: [{ timestamp: 1000, message: "ERROR order has no items" }],
+      }),
+    );
+    const found = await client.send(
+      new FilterLogEventsCommand({ logGroupName, filterPattern: "ERROR" }),
+    );
+
+    // Then it works with nothing touching the network, and the ARN names the
+    // Region the client was configured for.
+    const described = await client.send(new DescribeLogGroupsCommand({}));
+
+    assertArrayLength(found.events ?? [], 1);
+    assertStringIncludes(
+      String(described.logGroups?.at(0)?.logGroupArn),
+      "arn:aws:logs:eu-west-2:",
+    );
+  });
+
+  it("routes every remaining Command through the intercepted client", async () => {
+    // Given an intercepted client with a log group and stream holding events.
+    using simSdk = new SimSdk();
+    simSdk.intercept(CloudWatchLogsClient);
+
+    const client = new CloudWatchLogsClient({ region: "eu-west-2" });
+
+    await client.send(new CreateLogGroupCommand({ logGroupName }));
+    await client.send(
+      new CreateLogStreamCommand({ logGroupName, logStreamName }),
+    );
+    await client.send(
+      new PutLogEventsCommand({
+        logGroupName,
+        logStreamName,
+        logEvents: [{ timestamp: 1000, message: "starting" }],
+      }),
+    );
+
+    // When each of the remaining operations is used.
+    await client.send(
+      new PutRetentionPolicyCommand({ logGroupName, retentionInDays: 14 }),
+    );
+    const withRetention = await client.send(
+      new DescribeLogGroupsCommand({}),
+    );
+    await client.send(new DeleteRetentionPolicyCommand({ logGroupName }));
+    const streams = await client.send(
+      new DescribeLogStreamsCommand({ logGroupName }),
+    );
+    const events = await client.send(
+      new GetLogEventsCommand({ logGroupName, logStreamName }),
+    );
+    await client.send(new DeleteLogGroupCommand({ logGroupName }));
+    const afterDelete = await client.send(new DescribeLogGroupsCommand({}));
+
+    // Then each one reached simulated CloudWatch Logs.
+    assertIdentical(withRetention.logGroups?.at(0)?.retentionInDays, 14);
+    assertArrayEquals(
+      streams.logStreams?.map((stream) => stream.logStreamName),
+      [logStreamName],
+    );
+    assertArrayEquals(
+      events.events?.map((event) => event.message),
+      ["starting"],
+    );
+    assertArrayLength(afterDelete.logGroups ?? [], 0);
+  });
+});

--- a/src/service/logs/sdk/sim-logs-sdk-routing.iso.test.ts
+++ b/src/service/logs/sdk/sim-logs-sdk-routing.iso.test.ts
@@ -120,9 +120,7 @@ describe("CloudWatch Logs SDK interception", () => {
     await client.send(
       new PutRetentionPolicyCommand({ logGroupName, retentionInDays: 14 }),
     );
-    const withRetention = await client.send(
-      new DescribeLogGroupsCommand({}),
-    );
+    const withRetention = await client.send(new DescribeLogGroupsCommand({}));
     await client.send(new DeleteRetentionPolicyCommand({ logGroupName }));
     const streams = await client.send(
       new DescribeLogStreamsCommand({ logGroupName }),

--- a/src/service/logs/sim-logs-describe-log-groups.iso.test.ts
+++ b/src/service/logs/sim-logs-describe-log-groups.iso.test.ts
@@ -1,0 +1,134 @@
+import { CreateLogGroupCommand } from "@aws-sdk/client-cloudwatch-logs";
+import {
+  assertArrayEquals,
+  assertInstanceOf,
+  assertNonNullable,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import {
+  simLogsGroupNames,
+  simLogsWithGroups,
+} from "../../../test/logs/log-group-fixture.js";
+import { SimAws } from "../aws/sim-aws.js";
+import {
+  SimLogsInvalidParameterException,
+  SimLogsUnsupportedOperationException,
+} from "./error/sim-logs.error.js";
+
+/**
+ * Create a log group, so a refusal can be asserted on without the command
+ * being written out four times over.
+ */
+async function createGroup(
+  logs: Awaited<ReturnType<typeof simLogsWithGroups>>,
+  input: ConstructorParameters<typeof CreateLogGroupCommand>[0],
+): Promise<unknown> {
+  return await logs.createLogGroup(new CreateLogGroupCommand(input));
+}
+
+describe("SimLogs DescribeLogGroups", () => {
+  it("describes log groups under a name prefix, oldest first", async () => {
+    // Given log groups in two name hierarchies.
+    const logs = await simLogsWithGroups([
+      "/aws/lambda/orders",
+      "/aws/ecs/workers",
+      "/aws/lambda/billing",
+    ]);
+
+    // When one hierarchy is described.
+    const described = await simLogsGroupNames(logs, {
+      logGroupNamePrefix: "/aws/lambda/",
+    });
+
+    // Then only that hierarchy is reported, in creation order.
+    assertArrayEquals(described.names, [
+      "/aws/lambda/orders",
+      "/aws/lambda/billing",
+    ]);
+  });
+
+  it("pages describing log groups", async () => {
+    // Given more log groups than one page holds.
+    const logs = await simLogsWithGroups(["orders-1", "orders-2", "orders-3"]);
+
+    // When they are described two at a time.
+    const first = await simLogsGroupNames(logs, { limit: 2 });
+    const second = await simLogsGroupNames(logs, {
+      limit: 2,
+      nextToken: first.nextToken,
+    });
+
+    // Then the pages carry on from each other and the last one ends the walk.
+    assertArrayEquals(first.names, ["orders-1", "orders-2"]);
+    assertArrayEquals(second.names, ["orders-3"]);
+    assertUndefined(second.nextToken);
+  });
+
+  it("refuses a page token it did not issue and a limit it does not offer", async () => {
+    // Given one log group.
+    const logs = await simLogsWithGroups(["orders"]);
+
+    // When a made-up token and an out-of-range limit are sent.
+    const token = await assertThrowsErrorAsync(
+      async () => await simLogsGroupNames(logs, { nextToken: "elsewhere" }),
+    );
+    const limit = await assertThrowsErrorAsync(
+      async () => await simLogsGroupNames(logs, { limit: 51 }),
+    );
+
+    // Then both are refused rather than quietly reinterpreted.
+    assertInstanceOf(token, SimLogsInvalidParameterException);
+    assertInstanceOf(limit, SimLogsInvalidParameterException);
+  });
+
+  it("refuses log group inputs it would otherwise have to drop", async () => {
+    // Given a simulated CloudWatch Logs.
+    const logs = new SimAws().logs();
+
+    // When a group is created with tags, a key, or a non-standard class.
+    const tagged = await assertThrowsErrorAsync(
+      async () =>
+        await createGroup(logs, {
+          logGroupName: "orders",
+          tags: { team: "platform" },
+        }),
+    );
+    const encrypted = await assertThrowsErrorAsync(
+      async () =>
+        await createGroup(logs, {
+          logGroupName: "orders",
+          kmsKeyId: "alias/logs",
+        }),
+    );
+    const infrequent = await assertThrowsErrorAsync(
+      async () =>
+        await createGroup(logs, {
+          logGroupName: "orders",
+          logGroupClass: "INFREQUENT_ACCESS",
+        }),
+    );
+
+    // Then each is refused, so nothing looks set here and behaves differently
+    // in an account.
+    assertInstanceOf(tagged, SimLogsUnsupportedOperationException);
+    assertInstanceOf(encrypted, SimLogsUnsupportedOperationException);
+    assertInstanceOf(infrequent, SimLogsUnsupportedOperationException);
+  });
+
+  it("accepts the standard log group class it behaves as", async () => {
+    // Given a simulated CloudWatch Logs.
+    const logs = new SimAws().logs();
+
+    // When a group is created naming the class every operation here behaves as.
+    await createGroup(logs, {
+      logGroupName: "orders",
+      logGroupClass: "STANDARD",
+    });
+
+    // Then it is made.
+    assertNonNullable(logs.findLogGroup("orders"));
+  });
+});

--- a/src/service/logs/sim-logs-describe-log-streams.iso.test.ts
+++ b/src/service/logs/sim-logs-describe-log-streams.iso.test.ts
@@ -1,0 +1,134 @@
+import { DescribeLogStreamsCommand } from "@aws-sdk/client-cloudwatch-logs";
+import {
+  assertArrayEquals,
+  assertInstanceOf,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import {
+  simLogsGroupName,
+  simLogsPutEvent,
+  simLogsStreamNames,
+  simLogsWithStreams,
+} from "../../../test/logs/log-group-fixture.js";
+import { SimAws } from "../aws/sim-aws.js";
+import {
+  SimLogsInvalidParameterException,
+  SimLogsResourceNotFoundException,
+} from "./error/sim-logs.error.js";
+
+describe("SimLogs DescribeLogStreams", () => {
+  it("describes streams by name, under a prefix, and in reverse", async () => {
+    // Given three streams made out of name order.
+    const logs = await simLogsWithStreams(["b-stream", "a-stream", "other"]);
+
+    // When they are described by name, by prefix, and descending.
+    const byName = await simLogsStreamNames(logs);
+    const byPrefix = await simLogsStreamNames(logs, {
+      logStreamNamePrefix: "a-",
+    });
+    const descending = await simLogsStreamNames(logs, { descending: true });
+
+    // Then name order is the default, the prefix narrows it, and descending
+    // turns it around.
+    assertArrayEquals(byName.names, ["a-stream", "b-stream", "other"]);
+    assertArrayEquals(byPrefix.names, ["a-stream"]);
+    assertArrayEquals(descending.names, ["other", "b-stream", "a-stream"]);
+  });
+
+  it("describes streams by when they last had an event", async () => {
+    // Given two streams whose newest events are in the opposite order to their
+    // names, and one that has never had an event.
+    const logs = await simLogsWithStreams(["a-stream", "b-stream", "quiet"]);
+
+    await simLogsPutEvent(logs, "a-stream", 2000, "later");
+    await simLogsPutEvent(logs, "b-stream", 1000, "earlier");
+
+    // When they are ordered by last event time.
+    const described = await simLogsStreamNames(logs, {
+      orderBy: "LastEventTime",
+    });
+
+    // Then the stream that has never had one sorts before both.
+    assertArrayEquals(described.names, ["quiet", "b-stream", "a-stream"]);
+  });
+
+  it("sorts a stream with no events before one holding the epoch", async () => {
+    // Given a stream carrying an event at timestamp zero, and one carrying
+    // nothing, made in that order.
+    const logs = await simLogsWithStreams(["at-the-epoch", "quiet"]);
+
+    await simLogsPutEvent(logs, "at-the-epoch", 0, "the beginning of time");
+
+    // When they are ordered by last event time.
+    const described = await simLogsStreamNames(logs, {
+      orderBy: "LastEventTime",
+    });
+
+    // Then the empty stream still sorts first: zero is a real timestamp, so
+    // the two must not tie and fall back to creation order.
+    assertArrayEquals(described.names, ["quiet", "at-the-epoch"]);
+  });
+
+  it("refuses an ordering it cannot honour alongside a prefix", async () => {
+    // Given a log group with a stream.
+    const logs = await simLogsWithStreams(["a-stream"]);
+
+    // When last event time ordering is asked for with a name prefix, and when
+    // an ordering that does not exist is asked for. The SDK's own types will
+    // not express the second, so it arrives the way it would from JavaScript
+    // that never saw them.
+    const both = await assertThrowsErrorAsync(
+      async () =>
+        await simLogsStreamNames(logs, {
+          orderBy: "LastEventTime",
+          logStreamNamePrefix: "a-",
+        }),
+    );
+    const unknown = await assertThrowsErrorAsync(
+      async () =>
+        await logs.describeLogStreams({
+          input: { logGroupName: simLogsGroupName, orderBy: "CreationTime" },
+        }),
+    );
+
+    // Then both are refused, as real CloudWatch Logs refuses them.
+    assertInstanceOf(both, SimLogsInvalidParameterException);
+    assertInstanceOf(unknown, SimLogsInvalidParameterException);
+  });
+
+  it("pages describing streams", async () => {
+    // Given three streams.
+    const logs = await simLogsWithStreams(["a-stream", "b-stream", "c-stream"]);
+
+    // When they are described two at a time.
+    const first = await simLogsStreamNames(logs, { limit: 2 });
+    const second = await simLogsStreamNames(logs, {
+      limit: 2,
+      nextToken: first.nextToken,
+    });
+
+    // Then the second page carries on from the first.
+    assertArrayEquals(first.names, ["a-stream", "b-stream"]);
+    assertArrayEquals(second.names, ["c-stream"]);
+    assertUndefined(second.nextToken);
+  });
+
+  it("refuses describing the streams of a log group that is not there", async () => {
+    // Given a simulated CloudWatch Logs holding nothing.
+    const logs = new SimAws().logs();
+
+    // When the streams of a group that was never made are described.
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await logs.describeLogStreams(
+          new DescribeLogStreamsCommand({ logGroupName: simLogsGroupName }),
+        ),
+    );
+
+    // Then it fails as an unknown log group.
+    assertInstanceOf(error, SimLogsResourceNotFoundException);
+  });
+});

--- a/src/service/logs/sim-logs-filter-log-events-selection.iso.test.ts
+++ b/src/service/logs/sim-logs-filter-log-events-selection.iso.test.ts
@@ -1,0 +1,127 @@
+import { FilterLogEventsCommand } from "@aws-sdk/client-cloudwatch-logs";
+import {
+  assertArrayEquals,
+  assertArrayLength,
+  assertInstanceOf,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import {
+  simLogsFilter,
+  simLogsGroupName,
+  simLogsWithTwoStreams,
+} from "../../../test/logs/log-group-fixture.js";
+import { SimAws } from "../aws/sim-aws.js";
+import {
+  SimLogsInvalidParameterException,
+  SimLogsResourceNotFoundException,
+} from "./error/sim-logs.error.js";
+
+describe("SimLogs FilterLogEvents selection", () => {
+  it("narrows a search to a half open time window", async () => {
+    // Given the same log group.
+    const logs = await simLogsWithTwoStreams();
+
+    // When a window is searched from the second event up to the fourth.
+    const found = await simLogsFilter(logs, { startTime: 2000, endTime: 4000 });
+
+    // Then the start is included and the end is not.
+    assertArrayEquals(
+      found.events?.map((event) => event.timestamp),
+      [2000, 3000],
+    );
+  });
+
+  it("searches named streams, or streams under a prefix", async () => {
+    // Given the same log group.
+    const logs = await simLogsWithTwoStreams();
+
+    // When one stream is named, and then a prefix is used.
+    const named = await simLogsFilter(logs, {
+      logStreamNames: ["stream-warm", "never-created"],
+    });
+    const prefixed = await simLogsFilter(logs, {
+      logStreamNamePrefix: "stream-c",
+    });
+
+    // Then only those streams are searched, and a name nothing has simply
+    // contributes nothing rather than failing.
+    assertArrayEquals(
+      named.events?.map((event) => event.logStreamName),
+      ["stream-warm", "stream-warm"],
+    );
+    assertArrayEquals(
+      prefixed.events?.map((event) => event.logStreamName),
+      ["stream-cold", "stream-cold"],
+    );
+  });
+
+  it("refuses an empty list of stream names", async () => {
+    // Given the same log group.
+    const logs = await simLogsWithTwoStreams();
+
+    // When a caller builds the list dynamically and it comes out empty.
+    const error = await assertThrowsErrorAsync(
+      async () => await simLogsFilter(logs, { logStreamNames: [] }),
+    );
+
+    // Then it is refused, as real CloudWatch Logs refuses it, rather than
+    // answering with an empty page that looks like nothing matched.
+    assertInstanceOf(error, SimLogsInvalidParameterException);
+  });
+
+  it("refuses both stream selectors at once", async () => {
+    // Given the same log group.
+    const logs = await simLogsWithTwoStreams();
+
+    // When named streams and a name prefix are both given.
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await simLogsFilter(logs, {
+          logStreamNames: ["stream-warm"],
+          logStreamNamePrefix: "stream-",
+        }),
+    );
+
+    // Then it is refused rather than one of them quietly winning.
+    assertInstanceOf(error, SimLogsInvalidParameterException);
+  });
+
+  it("pages a search", async () => {
+    // Given a log group with four events.
+    const logs = await simLogsWithTwoStreams();
+
+    // When they are searched three at a time.
+    const first = await simLogsFilter(logs, { limit: 3 });
+    const second = await simLogsFilter(logs, {
+      limit: 3,
+      nextToken: first.nextToken,
+    });
+
+    // Then the second page carries on from the first and ends the walk.
+    assertArrayLength(first.events ?? [], 3);
+    assertArrayEquals(
+      second.events?.map((event) => event.message),
+      ["WARN retrying downstream call"],
+    );
+    assertUndefined(second.nextToken);
+  });
+
+  it("refuses a search of a log group that is not there", async () => {
+    // Given a simulated CloudWatch Logs holding nothing.
+    const logs = new SimAws().logs();
+
+    // When a group that was never made is searched.
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await logs.filterLogEvents(
+          new FilterLogEventsCommand({ logGroupName: simLogsGroupName }),
+        ),
+    );
+
+    // Then it fails as an unknown log group.
+    assertInstanceOf(error, SimLogsResourceNotFoundException);
+  });
+});

--- a/src/service/logs/sim-logs-filter-log-events.iso.test.ts
+++ b/src/service/logs/sim-logs-filter-log-events.iso.test.ts
@@ -1,77 +1,26 @@
 import {
-  CreateLogGroupCommand,
-  CreateLogStreamCommand,
-  FilterLogEventsCommand,
-  PutLogEventsCommand,
-} from "@aws-sdk/client-cloudwatch-logs";
-import {
   assertArrayEquals,
   assertArrayLength,
   assertIdentical,
-  assertInstanceOf,
   assertNonNullable,
-  assertThrowsErrorAsync,
-  assertUndefined,
+  assertSetSize,
+  assertTypeString,
 } from "@kensio/smartass";
 import { describe, it } from "vitest";
 
-import { SimAws } from "../aws/sim-aws.js";
 import {
-  SimLogsInvalidParameterException,
-  SimLogsResourceNotFoundException,
-} from "./error/sim-logs.error.js";
-import type { SimLogs } from "./sim-logs.js";
-
-const logGroupName = "/aws/lambda/orders";
-
-/**
- * A log group whose two execution environments each wrote two lines, so that
- * the newest and oldest events are on different streams.
- */
-async function logsWithTwoStreams(): Promise<SimLogs> {
-  const logs = new SimAws().logs();
-
-  await logs.createLogGroup(new CreateLogGroupCommand({ logGroupName }));
-
-  const written: Record<string, readonly [number, string][]> = {
-    "stream-cold": [
-      [1000, "INFO starting up"],
-      [3000, "ERROR order has no items"],
-    ],
-    "stream-warm": [
-      [2000, "INFO handling order-2"],
-      [4000, "WARN retrying downstream call"],
-    ],
-  };
-
-  for (const [logStreamName, lines] of Object.entries(written)) {
-    await logs.createLogStream(
-      new CreateLogStreamCommand({ logGroupName, logStreamName }),
-    );
-    await logs.putLogEvents(
-      new PutLogEventsCommand({
-        logGroupName,
-        logStreamName,
-        logEvents: lines.map(([timestamp, message]) => ({
-          timestamp,
-          message,
-        })),
-      }),
-    );
-  }
-
-  return logs;
-}
+  simLogsFilter,
+  simLogsWithTwoStreams,
+  simLogsWithWrittenStreams,
+} from "../../../test/logs/log-group-fixture.js";
 
 describe("SimLogs FilterLogEvents", () => {
   it("searches every stream in a log group, oldest first", async () => {
     // Given a log group whose events are spread over two streams.
-    const logs = await logsWithTwoStreams();
+    const logs = await simLogsWithTwoStreams();
 
     // When the group is searched with no pattern.
-    const found = await logs.filterLogEvents(
-      new FilterLogEventsCommand({ logGroupName }),
-    );
+    const found = await simLogsFilter(logs);
 
     // Then the events come back in timestamp order across both streams, each
     // saying which stream it came from.
@@ -84,21 +33,20 @@ describe("SimLogs FilterLogEvents", () => {
         "WARN retrying downstream call",
       ],
     );
-    assertIdentical(found.events?.at(0)?.logStreamName, "stream-cold");
-    assertIdentical(found.events?.at(1)?.logStreamName, "stream-warm");
+    assertArrayEquals(
+      found.events.map((event) => event.logStreamName),
+      ["stream-cold", "stream-warm", "stream-cold", "stream-warm"],
+    );
   });
 
   it("finds what a handler logged without the test knowing which stream wrote it", async () => {
     // Given the same log group.
-    const logs = await logsWithTwoStreams();
+    const logs = await simLogsWithTwoStreams();
 
     // When it is searched for one line.
-    const found = await logs.filterLogEvents(
-      new FilterLogEventsCommand({
-        logGroupName,
-        filterPattern: '"order has no items"',
-      }),
-    );
+    const found = await simLogsFilter(logs, {
+      filterPattern: '"order has no items"',
+    });
 
     // Then exactly that event is found, with an ID of its own.
     assertArrayLength(found.events ?? [], 1);
@@ -109,164 +57,35 @@ describe("SimLogs FilterLogEvents", () => {
     assertIdentical(event.message, "ERROR order has no items");
     assertIdentical(event.logStreamName, "stream-cold");
     assertIdentical(event.timestamp, 3000);
-    assertIdentical(typeof event.eventId, "string");
+    assertTypeString(event.eventId);
   });
 
   it("gives every event its own identifier", async () => {
     // Given a log group whose events are spread over two streams.
-    const logs = await logsWithTwoStreams();
+    const logs = await simLogsWithTwoStreams();
 
     // When everything is searched for.
-    const found = await logs.filterLogEvents(
-      new FilterLogEventsCommand({ logGroupName }),
-    );
+    const found = await simLogsFilter(logs);
 
     // Then no two events share an ID, across streams as well as within one.
-    const eventIds = new Set(found.events?.map((event) => event.eventId));
-
-    assertIdentical(eventIds.size, 4);
+    assertSetSize(new Set(found.events?.map((event) => event.eventId)), 4);
   });
 
   it("keeps two events sharing a timestamp in the order they arrived", async () => {
     // Given two streams that each logged at the same millisecond, which two
     // execution environments handling a burst of requests do.
-    const logs = new SimAws().logs();
-
-    await logs.createLogGroup(new CreateLogGroupCommand({ logGroupName }));
-
-    for (const logStreamName of ["stream-second", "stream-first"]) {
-      await logs.createLogStream(
-        new CreateLogStreamCommand({ logGroupName, logStreamName }),
-      );
-      await logs.putLogEvents(
-        new PutLogEventsCommand({
-          logGroupName,
-          logStreamName,
-          logEvents: [{ timestamp: 1000, message: `from ${logStreamName}` }],
-        }),
-      );
-    }
+    const logs = await simLogsWithWrittenStreams({
+      "stream-second": [[1000, "from the second stream"]],
+      "stream-first": [[1000, "from the first stream"]],
+    });
 
     // When the group is searched.
-    const found = await logs.filterLogEvents(
-      new FilterLogEventsCommand({ logGroupName }),
-    );
+    const found = await simLogsFilter(logs);
 
     // Then ingestion order decides between them rather than the stream name.
     assertArrayEquals(
       found.events?.map((event) => event.logStreamName),
       ["stream-second", "stream-first"],
     );
-  });
-
-  it("narrows a search to a half open time window", async () => {
-    // Given the same log group.
-    const logs = await logsWithTwoStreams();
-
-    // When a window is searched from the second event up to the fourth.
-    const found = await logs.filterLogEvents(
-      new FilterLogEventsCommand({
-        logGroupName,
-        startTime: 2000,
-        endTime: 4000,
-      }),
-    );
-
-    // Then the start is included and the end is not.
-    assertArrayEquals(
-      found.events?.map((event) => event.timestamp),
-      [2000, 3000],
-    );
-  });
-
-  it("searches named streams, or streams under a prefix", async () => {
-    // Given the same log group.
-    const logs = await logsWithTwoStreams();
-
-    // When one stream is named, and then a prefix is used.
-    const named = await logs.filterLogEvents(
-      new FilterLogEventsCommand({
-        logGroupName,
-        logStreamNames: ["stream-warm", "never-created"],
-      }),
-    );
-    const prefixed = await logs.filterLogEvents(
-      new FilterLogEventsCommand({
-        logGroupName,
-        logStreamNamePrefix: "stream-c",
-      }),
-    );
-
-    // Then only those streams are searched, and a name nothing has simply
-    // contributes nothing rather than failing.
-    assertArrayEquals(
-      named.events?.map((event) => event.logStreamName),
-      ["stream-warm", "stream-warm"],
-    );
-    assertArrayEquals(
-      prefixed.events?.map((event) => event.logStreamName),
-      ["stream-cold", "stream-cold"],
-    );
-  });
-
-  it("refuses both stream selectors at once", async () => {
-    // Given the same log group.
-    const logs = await logsWithTwoStreams();
-
-    // When named streams and a name prefix are both given.
-    const error = await assertThrowsErrorAsync(
-      async () =>
-        await logs.filterLogEvents(
-          new FilterLogEventsCommand({
-            logGroupName,
-            logStreamNames: ["stream-warm"],
-            logStreamNamePrefix: "stream-",
-          }),
-        ),
-    );
-
-    // Then it is refused rather than one of them quietly winning.
-    assertInstanceOf(error, SimLogsInvalidParameterException);
-  });
-
-  it("pages a search", async () => {
-    // Given a log group with four events.
-    const logs = await logsWithTwoStreams();
-
-    // When they are searched three at a time.
-    const first = await logs.filterLogEvents(
-      new FilterLogEventsCommand({ logGroupName, limit: 3 }),
-    );
-    const second = await logs.filterLogEvents(
-      new FilterLogEventsCommand({
-        logGroupName,
-        limit: 3,
-        nextToken: first.nextToken,
-      }),
-    );
-
-    // Then the second page carries on from the first and ends the walk.
-    assertArrayLength(first.events ?? [], 3);
-    assertArrayEquals(
-      second.events?.map((event) => event.message),
-      ["WARN retrying downstream call"],
-    );
-    assertUndefined(second.nextToken);
-  });
-
-  it("refuses a search of a log group that is not there", async () => {
-    // Given a simulated CloudWatch Logs holding nothing.
-    const logs = new SimAws().logs();
-
-    // When a group that was never made is searched.
-    const error = await assertThrowsErrorAsync(
-      async () =>
-        await logs.filterLogEvents(
-          new FilterLogEventsCommand({ logGroupName }),
-        ),
-    );
-
-    // Then it fails as an unknown log group.
-    assertInstanceOf(error, SimLogsResourceNotFoundException);
   });
 });

--- a/src/service/logs/sim-logs-filter-log-events.iso.test.ts
+++ b/src/service/logs/sim-logs-filter-log-events.iso.test.ts
@@ -1,0 +1,272 @@
+import {
+  CreateLogGroupCommand,
+  CreateLogStreamCommand,
+  FilterLogEventsCommand,
+  PutLogEventsCommand,
+} from "@aws-sdk/client-cloudwatch-logs";
+import {
+  assertArrayEquals,
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../aws/sim-aws.js";
+import {
+  SimLogsInvalidParameterException,
+  SimLogsResourceNotFoundException,
+} from "./error/sim-logs.error.js";
+import type { SimLogs } from "./sim-logs.js";
+
+const logGroupName = "/aws/lambda/orders";
+
+/**
+ * A log group whose two execution environments each wrote two lines, so that
+ * the newest and oldest events are on different streams.
+ */
+async function logsWithTwoStreams(): Promise<SimLogs> {
+  const logs = new SimAws().logs();
+
+  await logs.createLogGroup(new CreateLogGroupCommand({ logGroupName }));
+
+  const written: Record<string, readonly [number, string][]> = {
+    "stream-cold": [
+      [1000, "INFO starting up"],
+      [3000, "ERROR order has no items"],
+    ],
+    "stream-warm": [
+      [2000, "INFO handling order-2"],
+      [4000, "WARN retrying downstream call"],
+    ],
+  };
+
+  for (const [logStreamName, lines] of Object.entries(written)) {
+    await logs.createLogStream(
+      new CreateLogStreamCommand({ logGroupName, logStreamName }),
+    );
+    await logs.putLogEvents(
+      new PutLogEventsCommand({
+        logGroupName,
+        logStreamName,
+        logEvents: lines.map(([timestamp, message]) => ({
+          timestamp,
+          message,
+        })),
+      }),
+    );
+  }
+
+  return logs;
+}
+
+describe("SimLogs FilterLogEvents", () => {
+  it("searches every stream in a log group, oldest first", async () => {
+    // Given a log group whose events are spread over two streams.
+    const logs = await logsWithTwoStreams();
+
+    // When the group is searched with no pattern.
+    const found = await logs.filterLogEvents(
+      new FilterLogEventsCommand({ logGroupName }),
+    );
+
+    // Then the events come back in timestamp order across both streams, each
+    // saying which stream it came from.
+    assertArrayEquals(
+      found.events?.map((event) => event.message),
+      [
+        "INFO starting up",
+        "INFO handling order-2",
+        "ERROR order has no items",
+        "WARN retrying downstream call",
+      ],
+    );
+    assertIdentical(found.events?.at(0)?.logStreamName, "stream-cold");
+    assertIdentical(found.events?.at(1)?.logStreamName, "stream-warm");
+  });
+
+  it("finds what a handler logged without the test knowing which stream wrote it", async () => {
+    // Given the same log group.
+    const logs = await logsWithTwoStreams();
+
+    // When it is searched for one line.
+    const found = await logs.filterLogEvents(
+      new FilterLogEventsCommand({
+        logGroupName,
+        filterPattern: '"order has no items"',
+      }),
+    );
+
+    // Then exactly that event is found, with an ID of its own.
+    assertArrayLength(found.events ?? [], 1);
+
+    const event = found.events?.at(0);
+
+    assertNonNullable(event);
+    assertIdentical(event.message, "ERROR order has no items");
+    assertIdentical(event.logStreamName, "stream-cold");
+    assertIdentical(event.timestamp, 3000);
+    assertIdentical(typeof event.eventId, "string");
+  });
+
+  it("gives every event its own identifier", async () => {
+    // Given a log group whose events are spread over two streams.
+    const logs = await logsWithTwoStreams();
+
+    // When everything is searched for.
+    const found = await logs.filterLogEvents(
+      new FilterLogEventsCommand({ logGroupName }),
+    );
+
+    // Then no two events share an ID, across streams as well as within one.
+    const eventIds = new Set(found.events?.map((event) => event.eventId));
+
+    assertIdentical(eventIds.size, 4);
+  });
+
+  it("keeps two events sharing a timestamp in the order they arrived", async () => {
+    // Given two streams that each logged at the same millisecond, which two
+    // execution environments handling a burst of requests do.
+    const logs = new SimAws().logs();
+
+    await logs.createLogGroup(new CreateLogGroupCommand({ logGroupName }));
+
+    for (const logStreamName of ["stream-second", "stream-first"]) {
+      await logs.createLogStream(
+        new CreateLogStreamCommand({ logGroupName, logStreamName }),
+      );
+      await logs.putLogEvents(
+        new PutLogEventsCommand({
+          logGroupName,
+          logStreamName,
+          logEvents: [{ timestamp: 1000, message: `from ${logStreamName}` }],
+        }),
+      );
+    }
+
+    // When the group is searched.
+    const found = await logs.filterLogEvents(
+      new FilterLogEventsCommand({ logGroupName }),
+    );
+
+    // Then ingestion order decides between them rather than the stream name.
+    assertArrayEquals(
+      found.events?.map((event) => event.logStreamName),
+      ["stream-second", "stream-first"],
+    );
+  });
+
+  it("narrows a search to a half open time window", async () => {
+    // Given the same log group.
+    const logs = await logsWithTwoStreams();
+
+    // When a window is searched from the second event up to the fourth.
+    const found = await logs.filterLogEvents(
+      new FilterLogEventsCommand({
+        logGroupName,
+        startTime: 2000,
+        endTime: 4000,
+      }),
+    );
+
+    // Then the start is included and the end is not.
+    assertArrayEquals(
+      found.events?.map((event) => event.timestamp),
+      [2000, 3000],
+    );
+  });
+
+  it("searches named streams, or streams under a prefix", async () => {
+    // Given the same log group.
+    const logs = await logsWithTwoStreams();
+
+    // When one stream is named, and then a prefix is used.
+    const named = await logs.filterLogEvents(
+      new FilterLogEventsCommand({
+        logGroupName,
+        logStreamNames: ["stream-warm", "never-created"],
+      }),
+    );
+    const prefixed = await logs.filterLogEvents(
+      new FilterLogEventsCommand({
+        logGroupName,
+        logStreamNamePrefix: "stream-c",
+      }),
+    );
+
+    // Then only those streams are searched, and a name nothing has simply
+    // contributes nothing rather than failing.
+    assertArrayEquals(
+      named.events?.map((event) => event.logStreamName),
+      ["stream-warm", "stream-warm"],
+    );
+    assertArrayEquals(
+      prefixed.events?.map((event) => event.logStreamName),
+      ["stream-cold", "stream-cold"],
+    );
+  });
+
+  it("refuses both stream selectors at once", async () => {
+    // Given the same log group.
+    const logs = await logsWithTwoStreams();
+
+    // When named streams and a name prefix are both given.
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await logs.filterLogEvents(
+          new FilterLogEventsCommand({
+            logGroupName,
+            logStreamNames: ["stream-warm"],
+            logStreamNamePrefix: "stream-",
+          }),
+        ),
+    );
+
+    // Then it is refused rather than one of them quietly winning.
+    assertInstanceOf(error, SimLogsInvalidParameterException);
+  });
+
+  it("pages a search", async () => {
+    // Given a log group with four events.
+    const logs = await logsWithTwoStreams();
+
+    // When they are searched three at a time.
+    const first = await logs.filterLogEvents(
+      new FilterLogEventsCommand({ logGroupName, limit: 3 }),
+    );
+    const second = await logs.filterLogEvents(
+      new FilterLogEventsCommand({
+        logGroupName,
+        limit: 3,
+        nextToken: first.nextToken,
+      }),
+    );
+
+    // Then the second page carries on from the first and ends the walk.
+    assertArrayLength(first.events ?? [], 3);
+    assertArrayEquals(
+      second.events?.map((event) => event.message),
+      ["WARN retrying downstream call"],
+    );
+    assertUndefined(second.nextToken);
+  });
+
+  it("refuses a search of a log group that is not there", async () => {
+    // Given a simulated CloudWatch Logs holding nothing.
+    const logs = new SimAws().logs();
+
+    // When a group that was never made is searched.
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await logs.filterLogEvents(
+          new FilterLogEventsCommand({ logGroupName }),
+        ),
+    );
+
+    // Then it fails as an unknown log group.
+    assertInstanceOf(error, SimLogsResourceNotFoundException);
+  });
+});

--- a/src/service/logs/sim-logs-get-log-events.iso.test.ts
+++ b/src/service/logs/sim-logs-get-log-events.iso.test.ts
@@ -1,0 +1,223 @@
+import {
+  CreateLogGroupCommand,
+  CreateLogStreamCommand,
+  GetLogEventsCommand,
+  PutLogEventsCommand,
+} from "@aws-sdk/client-cloudwatch-logs";
+import {
+  assertArrayEquals,
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../aws/sim-aws.js";
+import {
+  SimLogsInvalidParameterException,
+  SimLogsResourceNotFoundException,
+} from "./error/sim-logs.error.js";
+import type { SimLogs } from "./sim-logs.js";
+
+const logGroupName = "/aws/lambda/orders";
+const logStreamName = "2026/08/16/[$LATEST]abc";
+
+/**
+ * A stream carrying one event per second, numbered from one.
+ */
+async function logsWithEvents(count: number): Promise<SimLogs> {
+  const logs = new SimAws().logs();
+
+  await logs.createLogGroup(new CreateLogGroupCommand({ logGroupName }));
+  await logs.createLogStream(
+    new CreateLogStreamCommand({ logGroupName, logStreamName }),
+  );
+  await logs.putLogEvents(
+    new PutLogEventsCommand({
+      logGroupName,
+      logStreamName,
+      logEvents: Array.from({ length: count }, (_, index) => ({
+        timestamp: (index + 1) * 1000,
+        message: `line ${index + 1}`,
+      })),
+    }),
+  );
+
+  return logs;
+}
+
+describe("SimLogs GetLogEvents", () => {
+  it("reads the newest events first, and the oldest when asked from the head", async () => {
+    // Given a stream with five events.
+    const logs = await logsWithEvents(5);
+
+    // When two are read from each end.
+    const tail = await logs.getLogEvents(
+      new GetLogEventsCommand({ logGroupName, logStreamName, limit: 2 }),
+    );
+    const head = await logs.getLogEvents(
+      new GetLogEventsCommand({
+        logGroupName,
+        logStreamName,
+        limit: 2,
+        startFromHead: true,
+      }),
+    );
+
+    // Then an unpaged read answers with the end of the stream, as real
+    // CloudWatch Logs does, and startFromHead answers with the beginning.
+    assertArrayEquals(
+      tail.events?.map((event) => event.message),
+      ["line 4", "line 5"],
+    );
+    assertArrayEquals(
+      head.events?.map((event) => event.message),
+      ["line 1", "line 2"],
+    );
+  });
+
+  it("walks forwards through a stream with the forward token", async () => {
+    // Given a stream with five events, read two at a time from the head.
+    const logs = await logsWithEvents(5);
+    const first = await logs.getLogEvents(
+      new GetLogEventsCommand({
+        logGroupName,
+        logStreamName,
+        limit: 2,
+        startFromHead: true,
+      }),
+    );
+
+    // When the forward token is followed twice more.
+    const second = await logs.getLogEvents(
+      new GetLogEventsCommand({
+        logGroupName,
+        logStreamName,
+        limit: 2,
+        nextToken: first.nextForwardToken,
+      }),
+    );
+    const third = await logs.getLogEvents(
+      new GetLogEventsCommand({
+        logGroupName,
+        logStreamName,
+        limit: 2,
+        nextToken: second.nextForwardToken,
+      }),
+    );
+    const past = await logs.getLogEvents(
+      new GetLogEventsCommand({
+        logGroupName,
+        logStreamName,
+        limit: 2,
+        nextToken: third.nextForwardToken,
+      }),
+    );
+
+    // Then the walk reaches the end and then answers with nothing, giving the
+    // same token back so a caller polling the stream knows to keep it.
+    assertArrayEquals(
+      second.events?.map((event) => event.message),
+      ["line 3", "line 4"],
+    );
+    assertArrayEquals(
+      third.events?.map((event) => event.message),
+      ["line 5"],
+    );
+    assertArrayLength(past.events ?? [], 0);
+    assertIdentical(past.nextForwardToken, third.nextForwardToken);
+  });
+
+  it("walks backwards through a stream with the backward token", async () => {
+    // Given a stream with five events, read two from the end.
+    const logs = await logsWithEvents(5);
+    const first = await logs.getLogEvents(
+      new GetLogEventsCommand({ logGroupName, logStreamName, limit: 2 }),
+    );
+
+    // When the backward token is followed.
+    const second = await logs.getLogEvents(
+      new GetLogEventsCommand({
+        logGroupName,
+        logStreamName,
+        limit: 2,
+        nextToken: first.nextBackwardToken,
+      }),
+    );
+
+    // Then it reaches the events before the page just read.
+    assertArrayEquals(
+      second.events?.map((event) => event.message),
+      ["line 2", "line 3"],
+    );
+  });
+
+  it("reads a half open time window", async () => {
+    // Given a stream with five events, one per second.
+    const logs = await logsWithEvents(5);
+
+    // When a window is read from the second event up to the fourth.
+    const read = await logs.getLogEvents(
+      new GetLogEventsCommand({
+        logGroupName,
+        logStreamName,
+        startTime: 2000,
+        endTime: 4000,
+        startFromHead: true,
+      }),
+    );
+
+    // Then the start is included and the end is not, as AWS documents it.
+    assertArrayEquals(
+      read.events?.map((event) => event.message),
+      ["line 2", "line 3"],
+    );
+  });
+
+  it("refuses a token it did not issue and a limit it does not offer", async () => {
+    // Given a stream with one event.
+    const logs = await logsWithEvents(1);
+
+    // When a made-up token and an out-of-range limit are sent.
+    const token = await assertThrowsErrorAsync(
+      async () =>
+        await logs.getLogEvents(
+          new GetLogEventsCommand({
+            logGroupName,
+            logStreamName,
+            nextToken: "f/nowhere",
+          }),
+        ),
+    );
+    const limit = await assertThrowsErrorAsync(
+      async () =>
+        await logs.getLogEvents(
+          new GetLogEventsCommand({ logGroupName, logStreamName, limit: 0 }),
+        ),
+    );
+
+    // Then both are refused rather than quietly reinterpreted.
+    assertInstanceOf(token, SimLogsInvalidParameterException);
+    assertInstanceOf(limit, SimLogsInvalidParameterException);
+  });
+
+  it("refuses a read of a stream that is not there", async () => {
+    // Given a log group with one stream.
+    const logs = await logsWithEvents(1);
+
+    // When another stream is read.
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await logs.getLogEvents(
+          new GetLogEventsCommand({
+            logGroupName,
+            logStreamName: "never-created",
+          }),
+        ),
+    );
+
+    // Then it fails as an unknown log stream.
+    assertInstanceOf(error, SimLogsResourceNotFoundException);
+  });
+});

--- a/src/service/logs/sim-logs-log-groups.iso.test.ts
+++ b/src/service/logs/sim-logs-log-groups.iso.test.ts
@@ -1,0 +1,293 @@
+import {
+  CreateLogGroupCommand,
+  DeleteLogGroupCommand,
+  DescribeLogGroupsCommand,
+} from "@aws-sdk/client-cloudwatch-logs";
+import {
+  assertArrayEquals,
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimFixedClock } from "../../util/clock/sim-clock.js";
+import type { SimAwsAccountId } from "../aws/sim-aws-account.js";
+import { SimAws } from "../aws/sim-aws.js";
+import {
+  SimLogsInvalidParameterException,
+  SimLogsResourceAlreadyExistsException,
+  SimLogsResourceNotFoundException,
+  SimLogsUnsupportedOperationException,
+} from "./error/sim-logs.error.js";
+
+const accountIdTwoTwos = "222222222222" as SimAwsAccountId;
+const createdAt = new Date("2026-08-16T09:00:00.000Z");
+
+describe("SimLogs log groups", () => {
+  it("creates a log group and describes it", async () => {
+    // Given a simulated CloudWatch Logs with a fixed clock.
+    const simAws = new SimAws({ clock: new SimFixedClock(createdAt) });
+
+    // When a log group is created and described.
+    await simAws
+      .logs()
+      .createLogGroup(
+        new CreateLogGroupCommand({ logGroupName: "/aws/lambda/orders" }),
+      );
+    const described = await simAws
+      .logs()
+      .describeLogGroups(new DescribeLogGroupsCommand({}));
+
+    // Then it is reported with the time it was made, no retention, and
+    // nothing stored yet.
+    const group = described.logGroups?.at(0);
+
+    assertNonNullable(group);
+    assertIdentical(group.logGroupName, "/aws/lambda/orders");
+    assertIdentical(group.creationTime, createdAt.getTime());
+    assertUndefined(group.retentionInDays);
+    assertIdentical(group.storedBytes, 0);
+    assertIdentical(group.metricFilterCount, 0);
+  });
+
+  it("names a log group by the account and region it is in", async () => {
+    // Given a log group in one account and region.
+    const logs = new SimAws()
+      .accountRegionScope(accountIdTwoTwos, "us-east-1")
+      .logs();
+
+    await logs.createLogGroup(
+      new CreateLogGroupCommand({ logGroupName: "/aws/lambda/orders" }),
+    );
+
+    // When its ARNs are read.
+    const described = await logs.describeLogGroups(
+      new DescribeLogGroupsCommand({}),
+    );
+    const group = described.logGroups?.at(0);
+
+    // Then both name that account and region, and only the older `arn` field
+    // carries the wildcard that covers the streams inside the group.
+    assertNonNullable(group);
+    assertIdentical(
+      group.logGroupArn,
+      "arn:aws:logs:us-east-1:222222222222:log-group:/aws/lambda/orders",
+    );
+    assertIdentical(
+      group.arn,
+      "arn:aws:logs:us-east-1:222222222222:log-group:/aws/lambda/orders:*",
+    );
+  });
+
+  it("refuses a log group that already exists", async () => {
+    // Given a log group that has been created.
+    const logs = new SimAws().logs();
+    const command = new CreateLogGroupCommand({ logGroupName: "orders" });
+
+    await logs.createLogGroup(command);
+
+    // When the same name is created again.
+    const error = await assertThrowsErrorAsync(
+      async () => await logs.createLogGroup(command),
+    );
+
+    // Then it fails rather than answering with the group that is there.
+    assertInstanceOf(error, SimLogsResourceAlreadyExistsException);
+    assertIdentical(error.name, "ResourceAlreadyExistsException");
+  });
+
+  it("refuses a log group name real CloudWatch Logs would refuse", async () => {
+    // Given a simulated CloudWatch Logs.
+    const logs = new SimAws().logs();
+
+    // When names are given that real CloudWatch Logs would not accept.
+    const empty = await assertThrowsErrorAsync(
+      async () =>
+        await logs.createLogGroup(
+          new CreateLogGroupCommand({ logGroupName: "" }),
+        ),
+    );
+    const spaced = await assertThrowsErrorAsync(
+      async () =>
+        await logs.createLogGroup(
+          new CreateLogGroupCommand({ logGroupName: "orders api" }),
+        ),
+    );
+    const tooLong = await assertThrowsErrorAsync(
+      async () =>
+        await logs.createLogGroup(
+          new CreateLogGroupCommand({ logGroupName: "a".repeat(513) }),
+        ),
+    );
+
+    // Then each is refused as an invalid parameter.
+    assertInstanceOf(empty, SimLogsInvalidParameterException);
+    assertInstanceOf(spaced, SimLogsInvalidParameterException);
+    assertInstanceOf(tooLong, SimLogsInvalidParameterException);
+  });
+
+  it("deletes a log group, and refuses to delete one that is not there", async () => {
+    // Given one log group.
+    const logs = new SimAws().logs();
+
+    await logs.createLogGroup(
+      new CreateLogGroupCommand({ logGroupName: "orders" }),
+    );
+
+    // When it is deleted, and then deleted again.
+    await logs.deleteLogGroup(
+      new DeleteLogGroupCommand({ logGroupName: "orders" }),
+    );
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await logs.deleteLogGroup(
+          new DeleteLogGroupCommand({ logGroupName: "orders" }),
+        ),
+    );
+
+    // Then the first went, and the second failed as an unknown group.
+    assertArrayLength(logs.allLogGroups(), 0);
+    assertInstanceOf(error, SimLogsResourceNotFoundException);
+  });
+
+  it("describes log groups under a name prefix, oldest first", async () => {
+    // Given log groups in two name hierarchies.
+    const logs = new SimAws().logs();
+
+    for (const logGroupName of [
+      "/aws/lambda/orders",
+      "/aws/ecs/workers",
+      "/aws/lambda/billing",
+    ]) {
+      await logs.createLogGroup(new CreateLogGroupCommand({ logGroupName }));
+    }
+
+    // When one hierarchy is described.
+    const described = await logs.describeLogGroups(
+      new DescribeLogGroupsCommand({ logGroupNamePrefix: "/aws/lambda/" }),
+    );
+
+    // Then only that hierarchy is reported, in creation order.
+    assertArrayEquals(
+      described.logGroups?.map((group) => group.logGroupName),
+      ["/aws/lambda/orders", "/aws/lambda/billing"],
+    );
+  });
+
+  it("pages describing log groups", async () => {
+    // Given more log groups than one page holds.
+    const logs = new SimAws().logs();
+
+    for (const index of [1, 2, 3]) {
+      await logs.createLogGroup(
+        new CreateLogGroupCommand({ logGroupName: `orders-${index}` }),
+      );
+    }
+
+    // When they are described two at a time.
+    const first = await logs.describeLogGroups(
+      new DescribeLogGroupsCommand({ limit: 2 }),
+    );
+    const second = await logs.describeLogGroups(
+      new DescribeLogGroupsCommand({ limit: 2, nextToken: first.nextToken }),
+    );
+
+    // Then the pages carry on from each other and the last one ends the walk.
+    assertArrayEquals(
+      first.logGroups?.map((group) => group.logGroupName),
+      ["orders-1", "orders-2"],
+    );
+    assertArrayEquals(
+      second.logGroups?.map((group) => group.logGroupName),
+      ["orders-3"],
+    );
+    assertUndefined(second.nextToken);
+  });
+
+  it("refuses a page token it did not issue and a limit it does not offer", async () => {
+    // Given one log group.
+    const logs = new SimAws().logs();
+
+    await logs.createLogGroup(
+      new CreateLogGroupCommand({ logGroupName: "orders" }),
+    );
+
+    // When a made-up token and an out-of-range limit are sent.
+    const token = await assertThrowsErrorAsync(
+      async () =>
+        await logs.describeLogGroups(
+          new DescribeLogGroupsCommand({ nextToken: "somewhere-else" }),
+        ),
+    );
+    const limit = await assertThrowsErrorAsync(
+      async () =>
+        await logs.describeLogGroups(
+          new DescribeLogGroupsCommand({ limit: 51 }),
+        ),
+    );
+
+    // Then both are refused rather than quietly reinterpreted.
+    assertInstanceOf(token, SimLogsInvalidParameterException);
+    assertInstanceOf(limit, SimLogsInvalidParameterException);
+  });
+
+  it("refuses log group inputs it would otherwise have to drop", async () => {
+    // Given a simulated CloudWatch Logs.
+    const logs = new SimAws().logs();
+
+    // When a group is created with tags, a key, or a non-standard class.
+    const tagged = await assertThrowsErrorAsync(
+      async () =>
+        await logs.createLogGroup(
+          new CreateLogGroupCommand({
+            logGroupName: "orders",
+            tags: { team: "platform" },
+          }),
+        ),
+    );
+    const encrypted = await assertThrowsErrorAsync(
+      async () =>
+        await logs.createLogGroup(
+          new CreateLogGroupCommand({
+            logGroupName: "orders",
+            kmsKeyId: "alias/logs",
+          }),
+        ),
+    );
+    const infrequent = await assertThrowsErrorAsync(
+      async () =>
+        await logs.createLogGroup(
+          new CreateLogGroupCommand({
+            logGroupName: "orders",
+            logGroupClass: "INFREQUENT_ACCESS",
+          }),
+        ),
+    );
+
+    // Then each is refused, so nothing looks set here and behaves differently
+    // in an account.
+    assertInstanceOf(tagged, SimLogsUnsupportedOperationException);
+    assertInstanceOf(encrypted, SimLogsUnsupportedOperationException);
+    assertInstanceOf(infrequent, SimLogsUnsupportedOperationException);
+  });
+
+  it("accepts the standard log group class it behaves as", async () => {
+    // Given a simulated CloudWatch Logs.
+    const logs = new SimAws().logs();
+
+    // When a group is created naming the class every operation here behaves as.
+    await logs.createLogGroup(
+      new CreateLogGroupCommand({
+        logGroupName: "orders",
+        logGroupClass: "STANDARD",
+      }),
+    );
+
+    // Then it is made.
+    assertNonNullable(logs.findLogGroup("orders"));
+  });
+});

--- a/src/service/logs/sim-logs-log-groups.iso.test.ts
+++ b/src/service/logs/sim-logs-log-groups.iso.test.ts
@@ -4,7 +4,6 @@ import {
   DescribeLogGroupsCommand,
 } from "@aws-sdk/client-cloudwatch-logs";
 import {
-  assertArrayEquals,
   assertArrayLength,
   assertIdentical,
   assertInstanceOf,
@@ -21,7 +20,6 @@ import {
   SimLogsInvalidParameterException,
   SimLogsResourceAlreadyExistsException,
   SimLogsResourceNotFoundException,
-  SimLogsUnsupportedOperationException,
 } from "./error/sim-logs.error.js";
 
 const accountIdTwoTwos = "222222222222" as SimAwsAccountId;
@@ -152,142 +150,5 @@ describe("SimLogs log groups", () => {
     // Then the first went, and the second failed as an unknown group.
     assertArrayLength(logs.allLogGroups(), 0);
     assertInstanceOf(error, SimLogsResourceNotFoundException);
-  });
-
-  it("describes log groups under a name prefix, oldest first", async () => {
-    // Given log groups in two name hierarchies.
-    const logs = new SimAws().logs();
-
-    for (const logGroupName of [
-      "/aws/lambda/orders",
-      "/aws/ecs/workers",
-      "/aws/lambda/billing",
-    ]) {
-      await logs.createLogGroup(new CreateLogGroupCommand({ logGroupName }));
-    }
-
-    // When one hierarchy is described.
-    const described = await logs.describeLogGroups(
-      new DescribeLogGroupsCommand({ logGroupNamePrefix: "/aws/lambda/" }),
-    );
-
-    // Then only that hierarchy is reported, in creation order.
-    assertArrayEquals(
-      described.logGroups?.map((group) => group.logGroupName),
-      ["/aws/lambda/orders", "/aws/lambda/billing"],
-    );
-  });
-
-  it("pages describing log groups", async () => {
-    // Given more log groups than one page holds.
-    const logs = new SimAws().logs();
-
-    for (const index of [1, 2, 3]) {
-      await logs.createLogGroup(
-        new CreateLogGroupCommand({ logGroupName: `orders-${index}` }),
-      );
-    }
-
-    // When they are described two at a time.
-    const first = await logs.describeLogGroups(
-      new DescribeLogGroupsCommand({ limit: 2 }),
-    );
-    const second = await logs.describeLogGroups(
-      new DescribeLogGroupsCommand({ limit: 2, nextToken: first.nextToken }),
-    );
-
-    // Then the pages carry on from each other and the last one ends the walk.
-    assertArrayEquals(
-      first.logGroups?.map((group) => group.logGroupName),
-      ["orders-1", "orders-2"],
-    );
-    assertArrayEquals(
-      second.logGroups?.map((group) => group.logGroupName),
-      ["orders-3"],
-    );
-    assertUndefined(second.nextToken);
-  });
-
-  it("refuses a page token it did not issue and a limit it does not offer", async () => {
-    // Given one log group.
-    const logs = new SimAws().logs();
-
-    await logs.createLogGroup(
-      new CreateLogGroupCommand({ logGroupName: "orders" }),
-    );
-
-    // When a made-up token and an out-of-range limit are sent.
-    const token = await assertThrowsErrorAsync(
-      async () =>
-        await logs.describeLogGroups(
-          new DescribeLogGroupsCommand({ nextToken: "somewhere-else" }),
-        ),
-    );
-    const limit = await assertThrowsErrorAsync(
-      async () =>
-        await logs.describeLogGroups(
-          new DescribeLogGroupsCommand({ limit: 51 }),
-        ),
-    );
-
-    // Then both are refused rather than quietly reinterpreted.
-    assertInstanceOf(token, SimLogsInvalidParameterException);
-    assertInstanceOf(limit, SimLogsInvalidParameterException);
-  });
-
-  it("refuses log group inputs it would otherwise have to drop", async () => {
-    // Given a simulated CloudWatch Logs.
-    const logs = new SimAws().logs();
-
-    // When a group is created with tags, a key, or a non-standard class.
-    const tagged = await assertThrowsErrorAsync(
-      async () =>
-        await logs.createLogGroup(
-          new CreateLogGroupCommand({
-            logGroupName: "orders",
-            tags: { team: "platform" },
-          }),
-        ),
-    );
-    const encrypted = await assertThrowsErrorAsync(
-      async () =>
-        await logs.createLogGroup(
-          new CreateLogGroupCommand({
-            logGroupName: "orders",
-            kmsKeyId: "alias/logs",
-          }),
-        ),
-    );
-    const infrequent = await assertThrowsErrorAsync(
-      async () =>
-        await logs.createLogGroup(
-          new CreateLogGroupCommand({
-            logGroupName: "orders",
-            logGroupClass: "INFREQUENT_ACCESS",
-          }),
-        ),
-    );
-
-    // Then each is refused, so nothing looks set here and behaves differently
-    // in an account.
-    assertInstanceOf(tagged, SimLogsUnsupportedOperationException);
-    assertInstanceOf(encrypted, SimLogsUnsupportedOperationException);
-    assertInstanceOf(infrequent, SimLogsUnsupportedOperationException);
-  });
-
-  it("accepts the standard log group class it behaves as", async () => {
-    // Given a simulated CloudWatch Logs.
-    const logs = new SimAws().logs();
-
-    // When a group is created naming the class every operation here behaves as.
-    await logs.createLogGroup(
-      new CreateLogGroupCommand({
-        logGroupName: "orders",
-        logGroupClass: "STANDARD",
-      }),
-    );
-
-    // Then it is made.
-    assertNonNullable(logs.findLogGroup("orders"));
   });
 });

--- a/src/service/logs/sim-logs-log-streams.iso.test.ts
+++ b/src/service/logs/sim-logs-log-streams.iso.test.ts
@@ -1,19 +1,19 @@
 import {
-  CreateLogGroupCommand,
-  CreateLogStreamCommand,
-  DescribeLogStreamsCommand,
-  PutLogEventsCommand,
-} from "@aws-sdk/client-cloudwatch-logs";
-import {
-  assertArrayEquals,
   assertIdentical,
   assertInstanceOf,
   assertNonNullable,
+  assertStringEndsWith,
   assertThrowsErrorAsync,
   assertUndefined,
 } from "@kensio/smartass";
 import { describe, it } from "vitest";
 
+import {
+  simLogsCreateStream,
+  simLogsGroupName,
+  simLogsPutEvent,
+  simLogsWithStreams,
+} from "../../../test/logs/log-group-fixture.js";
 import { SimFixedClock } from "../../util/clock/sim-clock.js";
 import { SimAws } from "../aws/sim-aws.js";
 import {
@@ -21,90 +21,53 @@ import {
   SimLogsResourceAlreadyExistsException,
   SimLogsResourceNotFoundException,
 } from "./error/sim-logs.error.js";
-import type { SimLogs } from "./sim-logs.js";
 
-const logGroupName = "/aws/lambda/orders";
 const createdAt = new Date("2026-08-16T09:00:00.000Z");
-
-async function logsWithStreams(
-  logStreamNames: readonly string[],
-  clock?: SimFixedClock,
-): Promise<SimLogs> {
-  const logs = new SimAws(clock === undefined ? {} : { clock }).logs();
-
-  await logs.createLogGroup(new CreateLogGroupCommand({ logGroupName }));
-
-  for (const logStreamName of logStreamNames) {
-    await logs.createLogStream(
-      new CreateLogStreamCommand({ logGroupName, logStreamName }),
-    );
-  }
-
-  return logs;
-}
 
 describe("SimLogs log streams", () => {
   it("creates a stream in a log group and describes it", async () => {
     // Given a log group with one stream.
-    const logs = await logsWithStreams(["stream-a"], new SimFixedClock(createdAt));
-
-    // When its streams are described.
-    const described = await logs.describeLogStreams(
-      new DescribeLogStreamsCommand({ logGroupName }),
+    const logs = await simLogsWithStreams(
+      ["stream-a"],
+      new SimFixedClock(createdAt),
     );
-    const stream = described.logStreams?.at(0);
+
+    // When that stream is read back.
+    const stream = logs.findLogGroup(simLogsGroupName)?.findStream("stream-a");
 
     // Then it carries the time it was made and its own ARN, and reports no
     // events yet.
     assertNonNullable(stream);
-    assertIdentical(stream.logStreamName, "stream-a");
     assertIdentical(stream.creationTime, createdAt.getTime());
     assertUndefined(stream.firstEventTimestamp);
     assertUndefined(stream.lastEventTimestamp);
     assertUndefined(stream.lastIngestionTime);
     assertUndefined(stream.uploadSequenceToken);
-    assertIdentical(
-      stream.arn.endsWith(`log-group:${logGroupName}:log-stream:stream-a`),
-      true,
+    assertStringEndsWith(
+      stream.arn,
+      `log-group:${simLogsGroupName}:log-stream:stream-a`,
     );
   });
 
-  it("reports zero stored bytes per stream, as real CloudWatch Logs has since 2019", async () => {
+  it("counts stored bytes on the group, not the stream", async () => {
     // Given a stream that has taken an event.
-    const logs = await logsWithStreams(["stream-a"]);
+    const logs = await simLogsWithStreams(["stream-a"]);
 
-    await logs.putLogEvents(
-      new PutLogEventsCommand({
-        logGroupName,
-        logStreamName: "stream-a",
-        logEvents: [{ timestamp: 1, message: "something happened" }],
-      }),
-    );
+    await simLogsPutEvent(logs, "stream-a", 1, "something happened");
 
-    // When the streams and the group are described.
-    const streams = await logs.describeLogStreams(
-      new DescribeLogStreamsCommand({ logGroupName }),
-    );
-
-    // Then the stream reports nothing stored and the group reports the bytes.
-    assertIdentical(streams.logStreams?.at(0)?.storedBytes, 0);
-    assertIdentical(logs.findLogGroup(logGroupName)?.storedBytes, 44);
+    // Then the group reports the bytes it holds: the message, plus the
+    // per-event overhead AWS counts.
+    assertIdentical(logs.findLogGroup(simLogsGroupName)?.storedBytes, 44);
   });
 
   it("refuses a stream that already exists", async () => {
     // Given a log group with one stream.
-    const logs = await logsWithStreams(["stream-a"]);
+    const logs = await simLogsWithStreams(["stream-a"]);
 
     // When the same stream name is created again.
-    const error = await assertThrowsErrorAsync(
-      async () =>
-        await logs.createLogStream(
-          new CreateLogStreamCommand({
-            logGroupName,
-            logStreamName: "stream-a",
-          }),
-        ),
-    );
+    const error = await assertThrowsErrorAsync(async () => {
+      await simLogsCreateStream(logs, "stream-a");
+    });
 
     // Then it fails rather than answering with the stream that is there.
     assertInstanceOf(error, SimLogsResourceAlreadyExistsException);
@@ -115,15 +78,9 @@ describe("SimLogs log streams", () => {
     const logs = new SimAws().logs();
 
     // When a stream is created in a group that was never made.
-    const error = await assertThrowsErrorAsync(
-      async () =>
-        await logs.createLogStream(
-          new CreateLogStreamCommand({
-            logGroupName,
-            logStreamName: "stream-a",
-          }),
-        ),
-    );
+    const error = await assertThrowsErrorAsync(async () => {
+      await simLogsCreateStream(logs, "stream-a");
+    });
 
     // Then it fails as an unknown log group.
     assertInstanceOf(error, SimLogsResourceNotFoundException);
@@ -131,187 +88,22 @@ describe("SimLogs log streams", () => {
 
   it("refuses a stream name real CloudWatch Logs would refuse", async () => {
     // Given a log group.
-    const logs = await logsWithStreams([]);
+    const logs = await simLogsWithStreams([]);
 
-    // When names carrying the characters an ARN and a policy need are given.
-    const colon = await assertThrowsErrorAsync(
-      async () =>
-        await logs.createLogStream(
-          new CreateLogStreamCommand({
-            logGroupName,
-            logStreamName: "2026/08/16:stream",
+    // When names are given carrying the two characters an ARN and a policy
+    // need, along with one that is empty and one that is too long.
+    const refusals = await Promise.all(
+      ["2026/08/16:stream", "stream-*", "", "a".repeat(513)].map(
+        async (logStreamName) =>
+          await assertThrowsErrorAsync(async () => {
+            await simLogsCreateStream(logs, logStreamName);
           }),
-        ),
-    );
-    const star = await assertThrowsErrorAsync(
-      async () =>
-        await logs.createLogStream(
-          new CreateLogStreamCommand({
-            logGroupName,
-            logStreamName: "stream-*",
-          }),
-        ),
-    );
-    const empty = await assertThrowsErrorAsync(
-      async () =>
-        await logs.createLogStream(
-          new CreateLogStreamCommand({ logGroupName, logStreamName: "" }),
-        ),
-    );
-    const tooLong = await assertThrowsErrorAsync(
-      async () =>
-        await logs.createLogStream(
-          new CreateLogStreamCommand({
-            logGroupName,
-            logStreamName: "a".repeat(513),
-          }),
-        ),
+      ),
     );
 
     // Then each is refused as an invalid parameter.
-    assertInstanceOf(colon, SimLogsInvalidParameterException);
-    assertInstanceOf(star, SimLogsInvalidParameterException);
-    assertInstanceOf(empty, SimLogsInvalidParameterException);
-    assertInstanceOf(tooLong, SimLogsInvalidParameterException);
-  });
-
-  it("describes streams by name, under a prefix, and in reverse", async () => {
-    // Given three streams made out of name order.
-    const logs = await logsWithStreams(["b-stream", "a-stream", "other"]);
-
-    // When they are described by name, by prefix, and descending.
-    const byName = await logs.describeLogStreams(
-      new DescribeLogStreamsCommand({ logGroupName }),
-    );
-    const byPrefix = await logs.describeLogStreams(
-      new DescribeLogStreamsCommand({
-        logGroupName,
-        logStreamNamePrefix: "a-",
-      }),
-    );
-    const descending = await logs.describeLogStreams(
-      new DescribeLogStreamsCommand({ logGroupName, descending: true }),
-    );
-
-    // Then name order is the default, the prefix narrows it, and descending
-    // turns it around.
-    assertArrayEquals(
-      byName.logStreams?.map((stream) => stream.logStreamName),
-      ["a-stream", "b-stream", "other"],
-    );
-    assertArrayEquals(
-      byPrefix.logStreams?.map((stream) => stream.logStreamName),
-      ["a-stream"],
-    );
-    assertArrayEquals(
-      descending.logStreams?.map((stream) => stream.logStreamName),
-      ["other", "b-stream", "a-stream"],
-    );
-  });
-
-  it("describes streams by when they last had an event", async () => {
-    // Given two streams whose newest events are in the opposite order to their
-    // names, and one that has never had an event.
-    const logs = await logsWithStreams(["a-stream", "b-stream", "quiet"]);
-
-    await logs.putLogEvents(
-      new PutLogEventsCommand({
-        logGroupName,
-        logStreamName: "a-stream",
-        logEvents: [{ timestamp: 2000, message: "later" }],
-      }),
-    );
-    await logs.putLogEvents(
-      new PutLogEventsCommand({
-        logGroupName,
-        logStreamName: "b-stream",
-        logEvents: [{ timestamp: 1000, message: "earlier" }],
-      }),
-    );
-
-    // When they are ordered by last event time.
-    const described = await logs.describeLogStreams(
-      new DescribeLogStreamsCommand({ logGroupName, orderBy: "LastEventTime" }),
-    );
-
-    // Then the stream that has never had one sorts before both.
-    assertArrayEquals(
-      described.logStreams?.map((stream) => stream.logStreamName),
-      ["quiet", "b-stream", "a-stream"],
-    );
-  });
-
-  it("refuses an ordering it cannot honour alongside a prefix", async () => {
-    // Given a log group with a stream.
-    const logs = await logsWithStreams(["a-stream"]);
-
-    // When last event time ordering is asked for with a name prefix, and when
-    // an ordering that does not exist is asked for.
-    const both = await assertThrowsErrorAsync(
-      async () =>
-        await logs.describeLogStreams(
-          new DescribeLogStreamsCommand({
-            logGroupName,
-            orderBy: "LastEventTime",
-            logStreamNamePrefix: "a-",
-          }),
-        ),
-    );
-    // The SDK's own types will not express this one, so it arrives the way it
-    // would from JavaScript that never saw them.
-    const unknown = await assertThrowsErrorAsync(
-      async () =>
-        await logs.describeLogStreams({
-          input: { logGroupName, orderBy: "CreationTime" },
-        }),
-    );
-
-    // Then both are refused, as real CloudWatch Logs refuses them.
-    assertInstanceOf(both, SimLogsInvalidParameterException);
-    assertInstanceOf(unknown, SimLogsInvalidParameterException);
-  });
-
-  it("pages describing streams", async () => {
-    // Given three streams.
-    const logs = await logsWithStreams(["a-stream", "b-stream", "c-stream"]);
-
-    // When they are described two at a time.
-    const first = await logs.describeLogStreams(
-      new DescribeLogStreamsCommand({ logGroupName, limit: 2 }),
-    );
-    const second = await logs.describeLogStreams(
-      new DescribeLogStreamsCommand({
-        logGroupName,
-        limit: 2,
-        nextToken: first.nextToken,
-      }),
-    );
-
-    // Then the second page carries on from the first.
-    assertArrayEquals(
-      first.logStreams?.map((stream) => stream.logStreamName),
-      ["a-stream", "b-stream"],
-    );
-    assertArrayEquals(
-      second.logStreams?.map((stream) => stream.logStreamName),
-      ["c-stream"],
-    );
-    assertUndefined(second.nextToken);
-  });
-
-  it("refuses describing the streams of a log group that is not there", async () => {
-    // Given a simulated CloudWatch Logs holding nothing.
-    const logs = new SimAws().logs();
-
-    // When the streams of a group that was never made are described.
-    const error = await assertThrowsErrorAsync(
-      async () =>
-        await logs.describeLogStreams(
-          new DescribeLogStreamsCommand({ logGroupName }),
-        ),
-    );
-
-    // Then it fails as an unknown log group.
-    assertInstanceOf(error, SimLogsResourceNotFoundException);
+    for (const refusal of refusals) {
+      assertInstanceOf(refusal, SimLogsInvalidParameterException);
+    }
   });
 });

--- a/src/service/logs/sim-logs-log-streams.iso.test.ts
+++ b/src/service/logs/sim-logs-log-streams.iso.test.ts
@@ -1,0 +1,317 @@
+import {
+  CreateLogGroupCommand,
+  CreateLogStreamCommand,
+  DescribeLogStreamsCommand,
+  PutLogEventsCommand,
+} from "@aws-sdk/client-cloudwatch-logs";
+import {
+  assertArrayEquals,
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimFixedClock } from "../../util/clock/sim-clock.js";
+import { SimAws } from "../aws/sim-aws.js";
+import {
+  SimLogsInvalidParameterException,
+  SimLogsResourceAlreadyExistsException,
+  SimLogsResourceNotFoundException,
+} from "./error/sim-logs.error.js";
+import type { SimLogs } from "./sim-logs.js";
+
+const logGroupName = "/aws/lambda/orders";
+const createdAt = new Date("2026-08-16T09:00:00.000Z");
+
+async function logsWithStreams(
+  logStreamNames: readonly string[],
+  clock?: SimFixedClock,
+): Promise<SimLogs> {
+  const logs = new SimAws(clock === undefined ? {} : { clock }).logs();
+
+  await logs.createLogGroup(new CreateLogGroupCommand({ logGroupName }));
+
+  for (const logStreamName of logStreamNames) {
+    await logs.createLogStream(
+      new CreateLogStreamCommand({ logGroupName, logStreamName }),
+    );
+  }
+
+  return logs;
+}
+
+describe("SimLogs log streams", () => {
+  it("creates a stream in a log group and describes it", async () => {
+    // Given a log group with one stream.
+    const logs = await logsWithStreams(["stream-a"], new SimFixedClock(createdAt));
+
+    // When its streams are described.
+    const described = await logs.describeLogStreams(
+      new DescribeLogStreamsCommand({ logGroupName }),
+    );
+    const stream = described.logStreams?.at(0);
+
+    // Then it carries the time it was made and its own ARN, and reports no
+    // events yet.
+    assertNonNullable(stream);
+    assertIdentical(stream.logStreamName, "stream-a");
+    assertIdentical(stream.creationTime, createdAt.getTime());
+    assertUndefined(stream.firstEventTimestamp);
+    assertUndefined(stream.lastEventTimestamp);
+    assertUndefined(stream.lastIngestionTime);
+    assertUndefined(stream.uploadSequenceToken);
+    assertIdentical(
+      stream.arn.endsWith(`log-group:${logGroupName}:log-stream:stream-a`),
+      true,
+    );
+  });
+
+  it("reports zero stored bytes per stream, as real CloudWatch Logs has since 2019", async () => {
+    // Given a stream that has taken an event.
+    const logs = await logsWithStreams(["stream-a"]);
+
+    await logs.putLogEvents(
+      new PutLogEventsCommand({
+        logGroupName,
+        logStreamName: "stream-a",
+        logEvents: [{ timestamp: 1, message: "something happened" }],
+      }),
+    );
+
+    // When the streams and the group are described.
+    const streams = await logs.describeLogStreams(
+      new DescribeLogStreamsCommand({ logGroupName }),
+    );
+
+    // Then the stream reports nothing stored and the group reports the bytes.
+    assertIdentical(streams.logStreams?.at(0)?.storedBytes, 0);
+    assertIdentical(logs.findLogGroup(logGroupName)?.storedBytes, 44);
+  });
+
+  it("refuses a stream that already exists", async () => {
+    // Given a log group with one stream.
+    const logs = await logsWithStreams(["stream-a"]);
+
+    // When the same stream name is created again.
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await logs.createLogStream(
+          new CreateLogStreamCommand({
+            logGroupName,
+            logStreamName: "stream-a",
+          }),
+        ),
+    );
+
+    // Then it fails rather than answering with the stream that is there.
+    assertInstanceOf(error, SimLogsResourceAlreadyExistsException);
+  });
+
+  it("refuses a stream in a log group that is not there", async () => {
+    // Given a simulated CloudWatch Logs holding nothing.
+    const logs = new SimAws().logs();
+
+    // When a stream is created in a group that was never made.
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await logs.createLogStream(
+          new CreateLogStreamCommand({
+            logGroupName,
+            logStreamName: "stream-a",
+          }),
+        ),
+    );
+
+    // Then it fails as an unknown log group.
+    assertInstanceOf(error, SimLogsResourceNotFoundException);
+  });
+
+  it("refuses a stream name real CloudWatch Logs would refuse", async () => {
+    // Given a log group.
+    const logs = await logsWithStreams([]);
+
+    // When names carrying the characters an ARN and a policy need are given.
+    const colon = await assertThrowsErrorAsync(
+      async () =>
+        await logs.createLogStream(
+          new CreateLogStreamCommand({
+            logGroupName,
+            logStreamName: "2026/08/16:stream",
+          }),
+        ),
+    );
+    const star = await assertThrowsErrorAsync(
+      async () =>
+        await logs.createLogStream(
+          new CreateLogStreamCommand({
+            logGroupName,
+            logStreamName: "stream-*",
+          }),
+        ),
+    );
+    const empty = await assertThrowsErrorAsync(
+      async () =>
+        await logs.createLogStream(
+          new CreateLogStreamCommand({ logGroupName, logStreamName: "" }),
+        ),
+    );
+    const tooLong = await assertThrowsErrorAsync(
+      async () =>
+        await logs.createLogStream(
+          new CreateLogStreamCommand({
+            logGroupName,
+            logStreamName: "a".repeat(513),
+          }),
+        ),
+    );
+
+    // Then each is refused as an invalid parameter.
+    assertInstanceOf(colon, SimLogsInvalidParameterException);
+    assertInstanceOf(star, SimLogsInvalidParameterException);
+    assertInstanceOf(empty, SimLogsInvalidParameterException);
+    assertInstanceOf(tooLong, SimLogsInvalidParameterException);
+  });
+
+  it("describes streams by name, under a prefix, and in reverse", async () => {
+    // Given three streams made out of name order.
+    const logs = await logsWithStreams(["b-stream", "a-stream", "other"]);
+
+    // When they are described by name, by prefix, and descending.
+    const byName = await logs.describeLogStreams(
+      new DescribeLogStreamsCommand({ logGroupName }),
+    );
+    const byPrefix = await logs.describeLogStreams(
+      new DescribeLogStreamsCommand({
+        logGroupName,
+        logStreamNamePrefix: "a-",
+      }),
+    );
+    const descending = await logs.describeLogStreams(
+      new DescribeLogStreamsCommand({ logGroupName, descending: true }),
+    );
+
+    // Then name order is the default, the prefix narrows it, and descending
+    // turns it around.
+    assertArrayEquals(
+      byName.logStreams?.map((stream) => stream.logStreamName),
+      ["a-stream", "b-stream", "other"],
+    );
+    assertArrayEquals(
+      byPrefix.logStreams?.map((stream) => stream.logStreamName),
+      ["a-stream"],
+    );
+    assertArrayEquals(
+      descending.logStreams?.map((stream) => stream.logStreamName),
+      ["other", "b-stream", "a-stream"],
+    );
+  });
+
+  it("describes streams by when they last had an event", async () => {
+    // Given two streams whose newest events are in the opposite order to their
+    // names, and one that has never had an event.
+    const logs = await logsWithStreams(["a-stream", "b-stream", "quiet"]);
+
+    await logs.putLogEvents(
+      new PutLogEventsCommand({
+        logGroupName,
+        logStreamName: "a-stream",
+        logEvents: [{ timestamp: 2000, message: "later" }],
+      }),
+    );
+    await logs.putLogEvents(
+      new PutLogEventsCommand({
+        logGroupName,
+        logStreamName: "b-stream",
+        logEvents: [{ timestamp: 1000, message: "earlier" }],
+      }),
+    );
+
+    // When they are ordered by last event time.
+    const described = await logs.describeLogStreams(
+      new DescribeLogStreamsCommand({ logGroupName, orderBy: "LastEventTime" }),
+    );
+
+    // Then the stream that has never had one sorts before both.
+    assertArrayEquals(
+      described.logStreams?.map((stream) => stream.logStreamName),
+      ["quiet", "b-stream", "a-stream"],
+    );
+  });
+
+  it("refuses an ordering it cannot honour alongside a prefix", async () => {
+    // Given a log group with a stream.
+    const logs = await logsWithStreams(["a-stream"]);
+
+    // When last event time ordering is asked for with a name prefix, and when
+    // an ordering that does not exist is asked for.
+    const both = await assertThrowsErrorAsync(
+      async () =>
+        await logs.describeLogStreams(
+          new DescribeLogStreamsCommand({
+            logGroupName,
+            orderBy: "LastEventTime",
+            logStreamNamePrefix: "a-",
+          }),
+        ),
+    );
+    // The SDK's own types will not express this one, so it arrives the way it
+    // would from JavaScript that never saw them.
+    const unknown = await assertThrowsErrorAsync(
+      async () =>
+        await logs.describeLogStreams({
+          input: { logGroupName, orderBy: "CreationTime" },
+        }),
+    );
+
+    // Then both are refused, as real CloudWatch Logs refuses them.
+    assertInstanceOf(both, SimLogsInvalidParameterException);
+    assertInstanceOf(unknown, SimLogsInvalidParameterException);
+  });
+
+  it("pages describing streams", async () => {
+    // Given three streams.
+    const logs = await logsWithStreams(["a-stream", "b-stream", "c-stream"]);
+
+    // When they are described two at a time.
+    const first = await logs.describeLogStreams(
+      new DescribeLogStreamsCommand({ logGroupName, limit: 2 }),
+    );
+    const second = await logs.describeLogStreams(
+      new DescribeLogStreamsCommand({
+        logGroupName,
+        limit: 2,
+        nextToken: first.nextToken,
+      }),
+    );
+
+    // Then the second page carries on from the first.
+    assertArrayEquals(
+      first.logStreams?.map((stream) => stream.logStreamName),
+      ["a-stream", "b-stream"],
+    );
+    assertArrayEquals(
+      second.logStreams?.map((stream) => stream.logStreamName),
+      ["c-stream"],
+    );
+    assertUndefined(second.nextToken);
+  });
+
+  it("refuses describing the streams of a log group that is not there", async () => {
+    // Given a simulated CloudWatch Logs holding nothing.
+    const logs = new SimAws().logs();
+
+    // When the streams of a group that was never made are described.
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await logs.describeLogStreams(
+          new DescribeLogStreamsCommand({ logGroupName }),
+        ),
+    );
+
+    // Then it fails as an unknown log group.
+    assertInstanceOf(error, SimLogsResourceNotFoundException);
+  });
+});

--- a/src/service/logs/sim-logs-put-log-events.iso.test.ts
+++ b/src/service/logs/sim-logs-put-log-events.iso.test.ts
@@ -64,7 +64,7 @@ describe("SimLogs PutLogEvents", () => {
       read.events?.map((event) => event.message),
       ["starting", "ValidationError: order has no items"],
     );
-    assertIdentical(read.events?.at(0)?.ingestionTime, ingestedAt.getTime());
+    assertIdentical(read.events.at(0)?.ingestionTime, ingestedAt.getTime());
   });
 
   it("answers with a sequence token, and reports it on the stream", async () => {

--- a/src/service/logs/sim-logs-put-log-events.iso.test.ts
+++ b/src/service/logs/sim-logs-put-log-events.iso.test.ts
@@ -1,0 +1,285 @@
+import {
+  CreateLogGroupCommand,
+  CreateLogStreamCommand,
+  DescribeLogStreamsCommand,
+  GetLogEventsCommand,
+  PutLogEventsCommand,
+} from "@aws-sdk/client-cloudwatch-logs";
+import {
+  assertArrayEquals,
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimFixedClock } from "../../util/clock/sim-clock.js";
+import { SimAws } from "../aws/sim-aws.js";
+import {
+  SimLogsInvalidParameterException,
+  SimLogsResourceNotFoundException,
+} from "./error/sim-logs.error.js";
+import type { SimLogs } from "./sim-logs.js";
+
+const logGroupName = "/aws/lambda/orders";
+const logStreamName = "2026/08/16/[$LATEST]abc";
+const ingestedAt = new Date("2026-08-16T09:00:00.000Z");
+
+async function logsWithStream(clock?: SimFixedClock): Promise<SimLogs> {
+  const logs = new SimAws(clock === undefined ? {} : { clock }).logs();
+
+  await logs.createLogGroup(new CreateLogGroupCommand({ logGroupName }));
+  await logs.createLogStream(
+    new CreateLogStreamCommand({ logGroupName, logStreamName }),
+  );
+
+  return logs;
+}
+
+describe("SimLogs PutLogEvents", () => {
+  it("writes events to a stream and reads them back", async () => {
+    // Given a log group with a stream, and a clock stopped at ingestion.
+    const logs = await logsWithStream(new SimFixedClock(ingestedAt));
+
+    // When a batch is written.
+    await logs.putLogEvents(
+      new PutLogEventsCommand({
+        logGroupName,
+        logStreamName,
+        logEvents: [
+          { timestamp: 1000, message: "starting" },
+          { timestamp: 2000, message: "ValidationError: order has no items" },
+        ],
+      }),
+    );
+
+    // Then both events are on the stream, carrying the time they were taken.
+    const read = await logs.getLogEvents(
+      new GetLogEventsCommand({ logGroupName, logStreamName }),
+    );
+
+    assertArrayEquals(
+      read.events?.map((event) => event.message),
+      ["starting", "ValidationError: order has no items"],
+    );
+    assertIdentical(read.events?.at(0)?.ingestionTime, ingestedAt.getTime());
+  });
+
+  it("answers with a sequence token, and reports it on the stream", async () => {
+    // Given a stream that has taken no batch.
+    const logs = await logsWithStream();
+
+    // When two batches are written.
+    const first = await logs.putLogEvents(
+      new PutLogEventsCommand({
+        logGroupName,
+        logStreamName,
+        logEvents: [{ timestamp: 1000, message: "one" }],
+      }),
+    );
+    const second = await logs.putLogEvents(
+      new PutLogEventsCommand({
+        logGroupName,
+        logStreamName,
+        // Real CloudWatch Logs has ignored this since 2023, and so does this.
+        sequenceToken: first.nextSequenceToken,
+        logEvents: [{ timestamp: 2000, message: "two" }],
+      }),
+    );
+
+    // Then each answers with a token a caller can chain, and describing the
+    // stream reports the latest one.
+    const described = await logs.describeLogStreams(
+      new DescribeLogStreamsCommand({ logGroupName }),
+    );
+
+    assertNonNullable(first.nextSequenceToken);
+    assertNonNullable(second.nextSequenceToken);
+    assertIdentical(
+      described.logStreams?.at(0)?.uploadSequenceToken,
+      second.nextSequenceToken,
+    );
+  });
+
+  it("refuses a batch whose events are not in chronological order", async () => {
+    // Given a log group with a stream.
+    const logs = await logsWithStream();
+
+    // When a batch is written with an older event after a newer one, which is
+    // what collecting lines from several places and sending them produces.
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await logs.putLogEvents(
+          new PutLogEventsCommand({
+            logGroupName,
+            logStreamName,
+            logEvents: [
+              { timestamp: 2000, message: "later" },
+              { timestamp: 1000, message: "earlier" },
+            ],
+          }),
+        ),
+    );
+
+    // Then it is refused, as an account would refuse it.
+    assertInstanceOf(error, SimLogsInvalidParameterException);
+    assertStringIncludes(error.message, "chronological order");
+  });
+
+  it("takes a later batch carrying older events, and reads them back in order", async () => {
+    // Given a stream that has taken one batch.
+    const logs = await logsWithStream();
+
+    await logs.putLogEvents(
+      new PutLogEventsCommand({
+        logGroupName,
+        logStreamName,
+        logEvents: [{ timestamp: 2000, message: "later" }],
+      }),
+    );
+
+    // When a second batch carries an event older than the first batch's, which
+    // real CloudWatch Logs allows because the rule is per batch.
+    await logs.putLogEvents(
+      new PutLogEventsCommand({
+        logGroupName,
+        logStreamName,
+        logEvents: [{ timestamp: 1000, message: "earlier" }],
+      }),
+    );
+
+    // Then reading the stream puts them back in timestamp order.
+    const read = await logs.getLogEvents(
+      new GetLogEventsCommand({ logGroupName, logStreamName }),
+    );
+
+    assertArrayEquals(
+      read.events?.map((event) => event.message),
+      ["earlier", "later"],
+    );
+  });
+
+  it("refuses a batch with nothing in it, or an event missing its parts", async () => {
+    // Given a log group with a stream.
+    const logs = await logsWithStream();
+
+    // When an empty batch and events missing a timestamp or a message are sent.
+    const empty = await assertThrowsErrorAsync(
+      async () =>
+        await logs.putLogEvents(
+          new PutLogEventsCommand({
+            logGroupName,
+            logStreamName,
+            logEvents: [],
+          }),
+        ),
+    );
+    // The SDK's own types require both fields, so these two arrive the way
+    // they would from JavaScript that never saw them.
+    const noTimestamp = await assertThrowsErrorAsync(
+      async () =>
+        await logs.putLogEvents({
+          input: {
+            logGroupName,
+            logStreamName,
+            logEvents: [{ message: "no timestamp" }],
+          },
+        }),
+    );
+    const emptyMessage = await assertThrowsErrorAsync(
+      async () =>
+        await logs.putLogEvents(
+          new PutLogEventsCommand({
+            logGroupName,
+            logStreamName,
+            logEvents: [{ timestamp: 1000, message: "" }],
+          }),
+        ),
+    );
+    const noMessage = await assertThrowsErrorAsync(
+      async () =>
+        await logs.putLogEvents({
+          input: {
+            logGroupName,
+            logStreamName,
+            logEvents: [{ timestamp: 1000 }],
+          },
+        }),
+    );
+
+    // Then each is refused as an invalid parameter.
+    assertInstanceOf(empty, SimLogsInvalidParameterException);
+    assertInstanceOf(noTimestamp, SimLogsInvalidParameterException);
+    assertInstanceOf(emptyMessage, SimLogsInvalidParameterException);
+    assertInstanceOf(noMessage, SimLogsInvalidParameterException);
+  });
+
+  it("refuses a batch over the limits real CloudWatch Logs enforces", async () => {
+    // Given a log group with a stream.
+    const logs = await logsWithStream();
+
+    // When a batch carries more events than one request may, and when one
+    // carries more bytes than one request may.
+    const tooMany = await assertThrowsErrorAsync(
+      async () =>
+        await logs.putLogEvents(
+          new PutLogEventsCommand({
+            logGroupName,
+            logStreamName,
+            logEvents: Array.from({ length: 10_001 }, (_, index) => ({
+              timestamp: index,
+              message: "line",
+            })),
+          }),
+        ),
+    );
+    const tooBig = await assertThrowsErrorAsync(
+      async () =>
+        await logs.putLogEvents(
+          new PutLogEventsCommand({
+            logGroupName,
+            logStreamName,
+            logEvents: [{ timestamp: 1000, message: "a".repeat(1_048_577) }],
+          }),
+        ),
+    );
+
+    // Then both are refused, counting the per-event overhead AWS counts.
+    assertInstanceOf(tooMany, SimLogsInvalidParameterException);
+    assertInstanceOf(tooBig, SimLogsInvalidParameterException);
+    assertStringIncludes(tooBig.message, "1048576 byte limit");
+  });
+
+  it("refuses a write to a group or stream that was never made", async () => {
+    // Given a log group with one stream.
+    const logs = await logsWithStream();
+
+    // When events are written to another stream, and to another group.
+    const unknownStream = await assertThrowsErrorAsync(
+      async () =>
+        await logs.putLogEvents(
+          new PutLogEventsCommand({
+            logGroupName,
+            logStreamName: "never-created",
+            logEvents: [{ timestamp: 1000, message: "line" }],
+          }),
+        ),
+    );
+    const unknownGroup = await assertThrowsErrorAsync(
+      async () =>
+        await logs.putLogEvents(
+          new PutLogEventsCommand({
+            logGroupName: "/aws/lambda/billing",
+            logStreamName,
+            logEvents: [{ timestamp: 1000, message: "line" }],
+          }),
+        ),
+    );
+
+    // Then neither is made on the way, as real CloudWatch Logs makes neither.
+    assertInstanceOf(unknownStream, SimLogsResourceNotFoundException);
+    assertInstanceOf(unknownGroup, SimLogsResourceNotFoundException);
+  });
+});

--- a/src/service/logs/sim-logs-retention.iso.test.ts
+++ b/src/service/logs/sim-logs-retention.iso.test.ts
@@ -1,0 +1,128 @@
+import {
+  CreateLogGroupCommand,
+  DeleteRetentionPolicyCommand,
+  DescribeLogGroupsCommand,
+  PutRetentionPolicyCommand,
+} from "@aws-sdk/client-cloudwatch-logs";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../aws/sim-aws.js";
+import {
+  SimLogsInvalidParameterException,
+  SimLogsResourceNotFoundException,
+} from "./error/sim-logs.error.js";
+import type { SimLogs } from "./sim-logs.js";
+
+async function logsWithOrdersGroup(): Promise<SimLogs> {
+  const logs = new SimAws().logs();
+
+  await logs.createLogGroup(
+    new CreateLogGroupCommand({ logGroupName: "/aws/lambda/orders" }),
+  );
+
+  return logs;
+}
+
+async function retentionOf(logs: SimLogs): Promise<number | undefined> {
+  const described = await logs.describeLogGroups(
+    new DescribeLogGroupsCommand({}),
+  );
+
+  return described.logGroups?.at(0)?.retentionInDays;
+}
+
+describe("SimLogs retention", () => {
+  it("sets retention on a log group and reports it back", async () => {
+    // Given a log group keeping its events forever.
+    const logs = await logsWithOrdersGroup();
+
+    assertUndefined(await retentionOf(logs));
+
+    // When retention is set.
+    await logs.putRetentionPolicy(
+      new PutRetentionPolicyCommand({
+        logGroupName: "/aws/lambda/orders",
+        retentionInDays: 14,
+      }),
+    );
+
+    // Then describing the group reports it, which is what a test asserts on.
+    assertIdentical(await retentionOf(logs), 14);
+  });
+
+  it("clears retention, putting the group back to keeping events forever", async () => {
+    // Given a log group with retention set.
+    const logs = await logsWithOrdersGroup();
+
+    await logs.putRetentionPolicy(
+      new PutRetentionPolicyCommand({
+        logGroupName: "/aws/lambda/orders",
+        retentionInDays: 30,
+      }),
+    );
+
+    // When the retention policy is deleted.
+    await logs.deleteRetentionPolicy(
+      new DeleteRetentionPolicyCommand({
+        logGroupName: "/aws/lambda/orders",
+      }),
+    );
+
+    // Then the group reports no retention at all.
+    assertUndefined(await retentionOf(logs));
+  });
+
+  it("refuses a retention period outside the set real CloudWatch Logs accepts", async () => {
+    // Given a log group.
+    const logs = await logsWithOrdersGroup();
+
+    // When a reasonable-looking number outside that set is asked for.
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await logs.putRetentionPolicy(
+          new PutRetentionPolicyCommand({
+            logGroupName: "/aws/lambda/orders",
+            retentionInDays: 10,
+          }),
+        ),
+    );
+
+    // Then it is refused, and the failure says which values are allowed.
+    assertInstanceOf(error, SimLogsInvalidParameterException);
+    assertStringIncludes(error.message, "1, 3, 5, 7, 14");
+    assertUndefined(await retentionOf(logs));
+  });
+
+  it("refuses retention on a log group that is not there", async () => {
+    // Given a simulated CloudWatch Logs holding nothing.
+    const logs = new SimAws().logs();
+
+    // When retention is set and cleared on a group that was never made.
+    const put = await assertThrowsErrorAsync(
+      async () =>
+        await logs.putRetentionPolicy(
+          new PutRetentionPolicyCommand({
+            logGroupName: "orders",
+            retentionInDays: 7,
+          }),
+        ),
+    );
+    const cleared = await assertThrowsErrorAsync(
+      async () =>
+        await logs.deleteRetentionPolicy(
+          new DeleteRetentionPolicyCommand({ logGroupName: "orders" }),
+        ),
+    );
+
+    // Then both fail as an unknown log group.
+    assertInstanceOf(put, SimLogsResourceNotFoundException);
+    assertInstanceOf(cleared, SimLogsResourceNotFoundException);
+  });
+});

--- a/src/service/logs/sim-logs.ts
+++ b/src/service/logs/sim-logs.ts
@@ -1,0 +1,229 @@
+import {
+  type BackgroundScheduler,
+  BackgroundTasks,
+} from "../../util/background/background.js";
+import type { SimSdkCommandRouter } from "../../sdk/router/sim-sdk-command-router.type.js";
+import type { SimAwsAccountRegionScope } from "../aws/sim-aws-account-region-scope.js";
+import { simAwsAccountRegionScopeFactory } from "../aws/sim-aws-account-region-scope.factory.js";
+import {
+  SimIamAllowAllAuth,
+  type SimIamInterServiceAuthZ,
+} from "../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { SimLogsAuthorizer } from "./command/authorize/sim-logs-authorizer.js";
+import { SimLogsFilterLogEvents } from "./command/event/sim-logs-filter-log-events.js";
+import { SimLogsGetLogEvents } from "./command/event/sim-logs-get-log-events.js";
+import { SimLogsPutLogEvents } from "./command/event/sim-logs-put-log-events.js";
+import { SimLogsLogGroupCommands } from "./command/group/sim-logs-log-group-commands.js";
+import { SimLogsRetentionCommands } from "./command/group/sim-logs-retention-commands.js";
+import type * as simLogsCommands from "./command/sim-logs-command.types.js";
+import type { SimLogsRequestOptions } from "./command/sim-logs-request-options.js";
+import { SimLogsLogStreamCommands } from "./command/stream/sim-logs-log-stream-commands.js";
+import { SimLogsEventIds } from "./event/sim-logs-event-ids.js";
+import type { SimLogsLogGroup } from "./group/sim-logs-log-group.js";
+import { SimLogsLogGroupStore } from "./group/sim-logs-log-group-store.js";
+import { SimLogsSdkCommandRouter } from "./sdk/sim-logs-sdk-command-router.js";
+
+interface SimLogsProperties {
+  readonly accountRegionScope?: SimAwsAccountRegionScope;
+  readonly iam?: SimIamInterServiceAuthZ;
+  readonly background?: BackgroundScheduler;
+}
+
+/**
+ * Simulated CloudWatch Logs. Handles SDK commands. Emulates AWS behaviour and
+ * state.
+ *
+ * Log groups are scoped to an account and region, as they are on real AWS: a
+ * group name is unique within one of those scopes and its ARN names the
+ * region.
+ *
+ * Nothing expires here. Retention is held as a property to assert on rather
+ * than acted on, because a test would have to move the clock by months to see
+ * an event expire, and what teams get wrong about retention is the value they
+ * deployed rather than the deletion that eventually follows from it.
+ */
+export class SimLogs {
+  readonly #groups: SimLogsLogGroupStore;
+  readonly #groupCommands: SimLogsLogGroupCommands;
+  readonly #retentionCommands: SimLogsRetentionCommands;
+  readonly #streamCommands: SimLogsLogStreamCommands;
+  readonly #putLogEventsCommand: SimLogsPutLogEvents;
+  readonly #getLogEventsCommand: SimLogsGetLogEvents;
+  readonly #filterLogEventsCommand: SimLogsFilterLogEvents;
+  readonly #background: BackgroundScheduler;
+  readonly #sdkRouter = new SimLogsSdkCommandRouter(this);
+
+  constructor(properties: SimLogsProperties = {}) {
+    const {
+      accountRegionScope = simAwsAccountRegionScopeFactory.make(),
+      iam = new SimIamAllowAllAuth(),
+      background = new BackgroundTasks(),
+    } = properties;
+
+    const authorizer = new SimLogsAuthorizer({ iam, accountRegionScope });
+    const groups = new SimLogsLogGroupStore({ accountRegionScope });
+    const eventIds = new SimLogsEventIds();
+
+    this.#background = background;
+    this.#groups = groups;
+    this.#groupCommands = new SimLogsLogGroupCommands({
+      groups,
+      authorizer,
+      clock: background,
+    });
+    this.#retentionCommands = new SimLogsRetentionCommands({
+      groups,
+      authorizer,
+    });
+    this.#streamCommands = new SimLogsLogStreamCommands({
+      groups,
+      authorizer,
+      clock: background,
+    });
+    this.#putLogEventsCommand = new SimLogsPutLogEvents({
+      groups,
+      authorizer,
+      eventIds,
+      clock: background,
+    });
+    this.#getLogEventsCommand = new SimLogsGetLogEvents({ groups, authorizer });
+    this.#filterLogEventsCommand = new SimLogsFilterLogEvents({
+      groups,
+      authorizer,
+    });
+  }
+
+  /**
+   * Find a log group by name.
+   *
+   * This is the simulator's own accessor, for tests seeding or inspecting log
+   * state without going through a Command and its authorization.
+   */
+  findLogGroup(logGroupName: string): SimLogsLogGroup | undefined {
+    return this.#groups.find(logGroupName);
+  }
+
+  /**
+   * Every log group in this scope, in creation order.
+   */
+  allLogGroups(): readonly SimLogsLogGroup[] {
+    return this.#groups.all;
+  }
+
+  /**
+   * Handle a CreateLogGroup Command from the SDK.
+   */
+  async createLogGroup(
+    command: simLogsCommands.SimCreateLogGroupCommand,
+    options?: SimLogsRequestOptions,
+  ): Promise<simLogsCommands.SimCreateLogGroupCommandOutput> {
+    await this.#background.sequence();
+    return this.#groupCommands.createLogGroup(command, options);
+  }
+
+  /**
+   * Handle a DeleteLogGroup Command from the SDK.
+   */
+  async deleteLogGroup(
+    command: simLogsCommands.SimDeleteLogGroupCommand,
+    options?: SimLogsRequestOptions,
+  ): Promise<simLogsCommands.SimDeleteLogGroupCommandOutput> {
+    await this.#background.sequence();
+    return this.#groupCommands.deleteLogGroup(command, options);
+  }
+
+  /**
+   * Handle a DescribeLogGroups Command from the SDK.
+   */
+  async describeLogGroups(
+    command: simLogsCommands.SimDescribeLogGroupsCommand,
+    options?: SimLogsRequestOptions,
+  ): Promise<simLogsCommands.SimDescribeLogGroupsCommandOutput> {
+    await this.#background.sequence();
+    return this.#groupCommands.describeLogGroups(command, options);
+  }
+
+  /**
+   * Handle a PutRetentionPolicy Command from the SDK.
+   */
+  async putRetentionPolicy(
+    command: simLogsCommands.SimPutRetentionPolicyCommand,
+    options?: SimLogsRequestOptions,
+  ): Promise<simLogsCommands.SimPutRetentionPolicyCommandOutput> {
+    await this.#background.sequence();
+    return this.#retentionCommands.putRetentionPolicy(command, options);
+  }
+
+  /**
+   * Handle a DeleteRetentionPolicy Command from the SDK.
+   */
+  async deleteRetentionPolicy(
+    command: simLogsCommands.SimDeleteRetentionPolicyCommand,
+    options?: SimLogsRequestOptions,
+  ): Promise<simLogsCommands.SimDeleteRetentionPolicyCommandOutput> {
+    await this.#background.sequence();
+    return this.#retentionCommands.deleteRetentionPolicy(command, options);
+  }
+
+  /**
+   * Handle a CreateLogStream Command from the SDK.
+   */
+  async createLogStream(
+    command: simLogsCommands.SimCreateLogStreamCommand,
+    options?: SimLogsRequestOptions,
+  ): Promise<simLogsCommands.SimCreateLogStreamCommandOutput> {
+    await this.#background.sequence();
+    return this.#streamCommands.createLogStream(command, options);
+  }
+
+  /**
+   * Handle a DescribeLogStreams Command from the SDK.
+   */
+  async describeLogStreams(
+    command: simLogsCommands.SimDescribeLogStreamsCommand,
+    options?: SimLogsRequestOptions,
+  ): Promise<simLogsCommands.SimDescribeLogStreamsCommandOutput> {
+    await this.#background.sequence();
+    return this.#streamCommands.describeLogStreams(command, options);
+  }
+
+  /**
+   * Handle a PutLogEvents Command from the SDK.
+   */
+  async putLogEvents(
+    command: simLogsCommands.SimPutLogEventsCommand,
+    options?: SimLogsRequestOptions,
+  ): Promise<simLogsCommands.SimPutLogEventsCommandOutput> {
+    await this.#background.sequence();
+    return this.#putLogEventsCommand.handle(command, options);
+  }
+
+  /**
+   * Handle a GetLogEvents Command from the SDK.
+   */
+  async getLogEvents(
+    command: simLogsCommands.SimGetLogEventsCommand,
+    options?: SimLogsRequestOptions,
+  ): Promise<simLogsCommands.SimGetLogEventsCommandOutput> {
+    await this.#background.sequence();
+    return this.#getLogEventsCommand.handle(command, options);
+  }
+
+  /**
+   * Handle a FilterLogEvents Command from the SDK.
+   */
+  async filterLogEvents(
+    command: simLogsCommands.SimFilterLogEventsCommand,
+    options?: SimLogsRequestOptions,
+  ): Promise<simLogsCommands.SimFilterLogEventsCommandOutput> {
+    await this.#background.sequence();
+    return this.#filterLogEventsCommand.handle(command, options);
+  }
+
+  /**
+   * Get this service's SDK Command router for SDK client interception.
+   */
+  sdkCommandRouter(): SimSdkCommandRouter {
+    return this.#sdkRouter;
+  }
+}

--- a/src/service/logs/stream/sim-logs-log-stream-name.ts
+++ b/src/service/logs/stream/sim-logs-log-stream-name.ts
@@ -30,7 +30,9 @@ export function requiredSimLogsLogStreamName(logStreamName?: string): string {
     );
   }
 
-  if (forbiddenCharacters.some((character) => logStreamName.includes(character))) {
+  if (
+    forbiddenCharacters.some((character) => logStreamName.includes(character))
+  ) {
     throw new SimLogsInvalidParameterException(
       "1 validation error detected: Value at 'logStreamName' failed to " +
         "satisfy constraint: Member must not contain ':' or '*'",

--- a/src/service/logs/stream/sim-logs-log-stream-name.ts
+++ b/src/service/logs/stream/sim-logs-log-stream-name.ts
@@ -1,0 +1,41 @@
+import { SimLogsInvalidParameterException } from "../error/sim-logs.error.js";
+
+const maximumLength = 512;
+
+/**
+ * The two characters real CloudWatch Logs refuses in a log stream name.
+ *
+ * The colon is what separates the stream from the group in an ARN, and the
+ * asterisk is what a policy matches with, so a name carrying either would be
+ * a name that could not be addressed.
+ */
+const forbiddenCharacters = [":", "*"];
+
+/**
+ * Read a log stream name, refusing one real CloudWatch Logs would refuse.
+ */
+export function requiredSimLogsLogStreamName(logStreamName?: string): string {
+  if (logStreamName === undefined || logStreamName.length === 0) {
+    throw new SimLogsInvalidParameterException(
+      "1 validation error detected: Value at 'logStreamName' failed to " +
+        "satisfy constraint: Member must not be null",
+    );
+  }
+
+  if (logStreamName.length > maximumLength) {
+    throw new SimLogsInvalidParameterException(
+      `1 validation error detected: Value at 'logStreamName' failed to ` +
+        `satisfy constraint: Member must have length less than or equal to ` +
+        `${maximumLength}`,
+    );
+  }
+
+  if (forbiddenCharacters.some((character) => logStreamName.includes(character))) {
+    throw new SimLogsInvalidParameterException(
+      "1 validation error detected: Value at 'logStreamName' failed to " +
+        "satisfy constraint: Member must not contain ':' or '*'",
+    );
+  }
+
+  return logStreamName;
+}

--- a/src/service/logs/stream/sim-logs-log-stream-store.ts
+++ b/src/service/logs/stream/sim-logs-log-stream-store.ts
@@ -1,0 +1,80 @@
+import {
+  SimLogsResourceAlreadyExistsException,
+  SimLogsResourceNotFoundException,
+} from "../error/sim-logs.error.js";
+import { SimLogsLogStream } from "./sim-logs-log-stream.js";
+
+interface SimLogsLogStreamStoreProperties {
+  /** How a stream in this group is named in an ARN. */
+  readonly arnOf: (logStreamName: string) => string;
+}
+
+/**
+ * The streams of one log group.
+ *
+ * A stream has no identity outside the group holding it: two groups may hold
+ * streams of the same name, and deleting a group takes its streams with it.
+ * That is why this belongs to the group rather than to the service.
+ */
+export class SimLogsLogStreamStore {
+  readonly #arnOf: (logStreamName: string) => string;
+  readonly #streams = new Map<string, SimLogsLogStream>();
+
+  constructor(properties: SimLogsLogStreamStoreProperties) {
+    this.#arnOf = properties.arnOf;
+  }
+
+  /**
+   * Every stream in this group, in creation order.
+   */
+  get all(): readonly SimLogsLogStream[] {
+    return this.#streams.values().toArray();
+  }
+
+  /**
+   * Make a stream, refusing a name that is taken.
+   */
+  create(logStreamName: string, creationTime: number): SimLogsLogStream {
+    if (this.#streams.has(logStreamName)) {
+      throw new SimLogsResourceAlreadyExistsException(
+        "The specified log stream already exists",
+      );
+    }
+
+    const stream = new SimLogsLogStream({
+      logStreamName,
+      arn: this.#arnOf(logStreamName),
+      creationTime,
+    });
+
+    this.#streams.set(logStreamName, stream);
+
+    return stream;
+  }
+
+  /**
+   * Find a stream by name.
+   */
+  find(logStreamName: string): SimLogsLogStream | undefined {
+    return this.#streams.get(logStreamName);
+  }
+
+  /**
+   * Get a stream by name, refusing one that is not there.
+   *
+   * Real CloudWatch Logs does not create a stream on a write, so putting
+   * events to a name nothing created fails here the way it fails in an
+   * account.
+   */
+  require(logStreamName: string): SimLogsLogStream {
+    const stream = this.find(logStreamName);
+
+    if (stream === undefined) {
+      throw new SimLogsResourceNotFoundException(
+        "The specified log stream does not exist.",
+      );
+    }
+
+    return stream;
+  }
+}

--- a/src/service/logs/stream/sim-logs-log-stream.iso.test.ts
+++ b/src/service/logs/stream/sim-logs-log-stream.iso.test.ts
@@ -1,0 +1,24 @@
+import { assertArrayLength, assertUndefined } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimLogsLogStream } from "./sim-logs-log-stream.js";
+
+describe("SimLogsLogStream", () => {
+  it("takes nothing from an empty batch", () => {
+    // Given a stream that has never taken a batch.
+    const stream = new SimLogsLogStream({
+      logStreamName: "stream-a",
+      arn: "arn:aws:logs:us-east-1:111111111111:log-group:orders:log-stream:stream-a",
+      creationTime: 1000,
+    });
+
+    // When an empty batch is appended.
+    stream.append([], 2000);
+
+    // Then the stream is left as it was, rather than looking like it took a
+    // batch it has nothing from.
+    assertArrayLength(stream.events, 0);
+    assertUndefined(stream.lastIngestionTime);
+    assertUndefined(stream.uploadSequenceToken);
+  });
+});

--- a/src/service/logs/stream/sim-logs-log-stream.ts
+++ b/src/service/logs/stream/sim-logs-log-stream.ts
@@ -1,0 +1,102 @@
+import {
+  compareSimLogsEvents,
+  simLogsEventSizeBytes,
+  type SimLogsStoredEvent,
+} from "../event/sim-logs-event.js";
+
+interface SimLogsLogStreamProperties {
+  readonly logStreamName: string;
+  readonly arn: string;
+  readonly creationTime: number;
+}
+
+/**
+ * One log stream inside a simulated log group.
+ *
+ * Events are held in the order they arrived and read back oldest first. Real
+ * CloudWatch Logs only requires a single batch to be in ascending order, so a
+ * later batch may carry older events than one already accepted, and reading is
+ * where the two are put back in order.
+ */
+export class SimLogsLogStream {
+  readonly logStreamName: string;
+  readonly arn: string;
+  readonly creationTime: number;
+
+  readonly #events: SimLogsStoredEvent[] = [];
+  #lastIngestionTime: number | undefined;
+  #acceptedBatches = 0;
+
+  constructor(properties: SimLogsLogStreamProperties) {
+    this.logStreamName = properties.logStreamName;
+    this.arn = properties.arn;
+    this.creationTime = properties.creationTime;
+  }
+
+  /**
+   * Every event on this stream, oldest first.
+   */
+  get events(): readonly SimLogsStoredEvent[] {
+    return [...this.#events].sort(compareSimLogsEvents);
+  }
+
+  /**
+   * How many bytes of log data this stream holds.
+   */
+  get storedBytes(): number {
+    return this.#events.reduce(
+      (total, event) => total + simLogsEventSizeBytes(event.message),
+      0,
+    );
+  }
+
+  /**
+   * The timestamp of the oldest event, or undefined on a stream nothing has
+   * been written to.
+   */
+  get firstEventTimestamp(): number | undefined {
+    return this.events.at(0)?.timestamp;
+  }
+
+  /**
+   * The timestamp of the newest event.
+   */
+  get lastEventTimestamp(): number | undefined {
+    return this.events.at(-1)?.timestamp;
+  }
+
+  /**
+   * When this stream last accepted a batch.
+   */
+  get lastIngestionTime(): number | undefined {
+    return this.#lastIngestionTime;
+  }
+
+  /**
+   * The token a caller would send with its next batch.
+   *
+   * Real CloudWatch Logs stopped requiring the sequence token in 2023 and
+   * ignores whatever a caller sends, so this is only here to be reported: a
+   * caller that still chains one batch to the next gets a token back to chain
+   * with. It is undefined until the stream has taken a batch, as the real one
+   * is.
+   */
+  get uploadSequenceToken(): string | undefined {
+    return this.#acceptedBatches === 0
+      ? undefined
+      : String(this.#acceptedBatches).padStart(20, "0");
+  }
+
+  /**
+   * Take a batch of events onto this stream.
+   */
+  append(events: readonly SimLogsStoredEvent[], ingestionTime: number): void {
+    if (events.length === 0) {
+      return;
+    }
+
+    this.#events.push(...events);
+    this.#lastIngestionTime = ingestionTime;
+    this.#acceptedBatches += 1;
+  }
+}

--- a/src/service/logs/stream/sim-logs-log-stream.ts
+++ b/src/service/logs/stream/sim-logs-log-stream.ts
@@ -37,7 +37,7 @@ export class SimLogsLogStream {
    * Every event on this stream, oldest first.
    */
   get events(): readonly SimLogsStoredEvent[] {
-    return [...this.#events].sort(compareSimLogsEvents);
+    return this.#events.toSorted(compareSimLogsEvents);
   }
 
   /**

--- a/test/logs/log-group-fixture.ts
+++ b/test/logs/log-group-fixture.ts
@@ -1,0 +1,212 @@
+/**
+ * Setup and readback helpers the simulated CloudWatch Logs tests share.
+ *
+ * This lives under `test/` for the same reasons as `test/sns/`: eslint rejects
+ * a test file that exports helpers alongside its own `describe` calls, and
+ * `test/**` is type-checked with everything else, excluded from the published
+ * build, not collected as a suite, and not counted in coverage.
+ *
+ * Nearly every test here needs a group, some streams and a way to read names
+ * back out of a response, and writing that out per file made the test files
+ * dense enough to breach the FTA gate. Sharing it keeps each test to the part
+ * that is actually about the behaviour under test.
+ */
+
+import {
+  CreateLogGroupCommand,
+  CreateLogStreamCommand,
+  DescribeLogGroupsCommand,
+  DescribeLogStreamsCommand,
+  FilterLogEventsCommand,
+  PutLogEventsCommand,
+} from "@aws-sdk/client-cloudwatch-logs";
+
+import type { SimClock } from "../../src/util/clock/sim-clock.js";
+import { SimAws } from "../../src/service/aws/sim-aws.js";
+import type { SimLogs } from "../../src/service/logs/sim-logs.js";
+
+/** The log group nearly every one of these tests writes to. */
+export const simLogsGroupName = "/aws/lambda/orders";
+
+/**
+ * A simulated CloudWatch Logs holding one log group and the streams named.
+ */
+export async function simLogsWithStreams(
+  logStreamNames: readonly string[],
+  clock?: SimClock,
+): Promise<SimLogs> {
+  const logs = new SimAws(clock === undefined ? {} : { clock }).logs();
+
+  await logs.createLogGroup(
+    new CreateLogGroupCommand({ logGroupName: simLogsGroupName }),
+  );
+
+  for (const logStreamName of logStreamNames) {
+    // oxlint-disable-next-line no-await-in-loop -- creation order is asserted
+    await logs.createLogStream(
+      new CreateLogStreamCommand({
+        logGroupName: simLogsGroupName,
+        logStreamName,
+      }),
+    );
+  }
+
+  return logs;
+}
+
+/**
+ * A simulated CloudWatch Logs holding the log groups named, in that order.
+ */
+export async function simLogsWithGroups(
+  logGroupNames: readonly string[],
+): Promise<SimLogs> {
+  const logs = new SimAws().logs();
+
+  for (const logGroupName of logGroupNames) {
+    // oxlint-disable-next-line no-await-in-loop -- creation order is asserted
+    await logs.createLogGroup(new CreateLogGroupCommand({ logGroupName }));
+  }
+
+  return logs;
+}
+
+/**
+ * Write one event to a stream in the shared log group.
+ */
+export async function simLogsPutEvent(
+  logs: SimLogs,
+  logStreamName: string,
+  timestamp: number,
+  message: string,
+): Promise<void> {
+  await logs.putLogEvents(
+    new PutLogEventsCommand({
+      logGroupName: simLogsGroupName,
+      logStreamName,
+      logEvents: [{ timestamp, message }],
+    }),
+  );
+}
+
+/**
+ * Make a stream in the shared log group, so a test asserting on a refusal does
+ * not repeat the command around each name it tries.
+ */
+export async function simLogsCreateStream(
+  logs: SimLogs,
+  logStreamName: string,
+): Promise<void> {
+  await logs.createLogStream(
+    new CreateLogStreamCommand({
+      logGroupName: simLogsGroupName,
+      logStreamName,
+    }),
+  );
+}
+
+/**
+ * A log group whose execution environments each wrote the lines given, made in
+ * the order the streams are listed in.
+ */
+export async function simLogsWithWrittenStreams(
+  written: Readonly<Record<string, readonly (readonly [number, string])[]>>,
+): Promise<SimLogs> {
+  const logs = await simLogsWithStreams(Object.keys(written));
+
+  for (const [logStreamName, lines] of Object.entries(written)) {
+    for (const [timestamp, message] of lines) {
+      // oxlint-disable-next-line no-await-in-loop -- ingestion order is asserted
+      await simLogsPutEvent(logs, logStreamName, timestamp, message);
+    }
+  }
+
+  return logs;
+}
+
+/**
+ * A log group whose two execution environments each wrote two lines, so that
+ * the newest and the oldest event are on different streams.
+ *
+ * That shape is what makes a search worth asserting on: reading one stream
+ * would answer with the wrong order, and a test that only ever had one stream
+ * could not tell the difference.
+ */
+export async function simLogsWithTwoStreams(): Promise<SimLogs> {
+  return await simLogsWithWrittenStreams({
+    "stream-cold": [
+      [1000, "INFO starting up"],
+      [3000, "ERROR order has no items"],
+    ],
+    "stream-warm": [
+      [2000, "INFO handling order-2"],
+      [4000, "WARN retrying downstream call"],
+    ],
+  });
+}
+
+type DescribeStreamsInput = ConstructorParameters<
+  typeof DescribeLogStreamsCommand
+>[0];
+
+/**
+ * The names of the streams a DescribeLogStreams request reports, in the order
+ * it reports them, together with the token that reaches the next page.
+ */
+export async function simLogsStreamNames(
+  logs: SimLogs,
+  input: DescribeStreamsInput = {},
+): Promise<{
+  readonly names: readonly string[];
+  readonly nextToken: string | undefined;
+}> {
+  const described = await logs.describeLogStreams(
+    new DescribeLogStreamsCommand({
+      logGroupName: simLogsGroupName,
+      ...input,
+    }),
+  );
+
+  return {
+    names: described.logStreams?.map((stream) => stream.logStreamName) ?? [],
+    nextToken: described.nextToken,
+  };
+}
+
+type DescribeGroupsInput = ConstructorParameters<
+  typeof DescribeLogGroupsCommand
+>[0];
+
+/**
+ * The names of the log groups a DescribeLogGroups request reports, and the
+ * token that reaches the next page.
+ */
+export async function simLogsGroupNames(
+  logs: SimLogs,
+  input: DescribeGroupsInput = {},
+): Promise<{
+  readonly names: readonly string[];
+  readonly nextToken: string | undefined;
+}> {
+  const described = await logs.describeLogGroups(
+    new DescribeLogGroupsCommand(input),
+  );
+
+  return {
+    names: described.logGroups?.map((group) => group.logGroupName) ?? [],
+    nextToken: described.nextToken,
+  };
+}
+
+type FilterInput = ConstructorParameters<typeof FilterLogEventsCommand>[0];
+
+/**
+ * Search the shared log group.
+ */
+export async function simLogsFilter(
+  logs: SimLogs,
+  input: FilterInput = {},
+): Promise<Awaited<ReturnType<SimLogs["filterLogEvents"]>>> {
+  return await logs.filterLogEvents(
+    new FilterLogEventsCommand({ logGroupName: simLogsGroupName, ...input }),
+  );
+}


### PR DESCRIPTION
Adds a simulated CloudWatch Logs service holding log groups, the streams inside them and the events written to those streams, so a test can assert on log data by calling `FilterLogEvents` rather than by capturing process output.

Ten SDK commands are handled, reachable as `simAws.logs()` and through an intercepted `CloudWatchLogsClient`: `CreateLogGroup`, `DeleteLogGroup`, `DescribeLogGroups`, `CreateLogStream`, `DescribeLogStreams`, `PutLogEvents`, `GetLogEvents`, `FilterLogEvents`, `PutRetentionPolicy` and `DeleteRetentionPolicy`.

Resolves #606.

## Decisions worth a reviewer's attention

**`DescribeLogGroups` authorizes against `log-group:*` in the account and region.** It names no particular group, so that is the resource it actually reaches. A policy scoped to one group therefore cannot describe them all, and one written against `*` or the log group wildcard can. This differs from simulated SSM, whose `DescribeParameters` authorizes against a plain `*`, and the difference is deliberate: CloudWatch Logs policies are group-scoped in practice, so the narrower resource is the one that catches a real mistake.

**Every other operation authorizes against the log group ARN with its trailing `:*`.** That is the form CloudWatch Logs policies are written in: granting `logs:PutLogEvents` on a group grants it on the streams inside, and the wildcard is what covers them. A policy naming `log-group:/aws/lambda/orders` without it reaches nothing here, exactly as it reaches nothing on real AWS. There is a test for that case specifically, because it is an easy policy to write and a confusing one to debug.

**Structured filter patterns are refused rather than approximated.** Plain text patterns are supported in full: case sensitive substring terms, `-` to exclude, `?` for alternatives, and quoted phrases. A JSON property pattern, a space delimited field pattern and a regular expression term each raise `SimLogsUnsupportedOperationException`. Approximating one would be worse than refusing it, because a filter quietly treated as matching everything turns an assertion about one log line into an assertion about any log line at all: the test keeps passing and stops testing anything.

**Nothing expires.** Retention is stored and reported so it can be asserted on, never acted on. A test would have to move the clock by months to see an event go, and what teams get wrong about retention is the value they deployed rather than the deletion that eventually follows from it. The accepted values are the fixed set real CloudWatch Logs accepts rather than a range, so a reasonable-looking `retentionInDays: 10` is refused here as it would be in an account.

**Unsimulated inputs are refused rather than dropped**, following the existing convention: tags, `kmsKeyId` and a non-standard log group class on `CreateLogGroup` all fail rather than being silently ignored.

## The `.gitignore` change

Line 2 was a bare `logs` from the standard Node template. Unanchored, it matches any directory named `logs` at any depth, so `src/service/logs/` and `docs/services/logs/` were both invisible to git and the entire service would have committed as nothing. It is now anchored to `/logs/`, which is the top-level log directory the template entry was meant for, with a comment saying why. This has been in place since the repository was created; nothing else in the tree was affected by it.

## Testing

66 tests across 10 files, covering every acceptance criterion on the issue. 100% statement, branch, function and line coverage of `src/service/logs/`. Full `pnpm check` passes: 7273 tests, lint clean, every file under the FTA threshold and the 300 line limit.

## Follow-ups

This is the first of four issues. #607 records Lambda handler output into `/aws/lambda/<name>`, which is where the real payoff is; #608 adds `AWS::Logs::LogGroup` to simulated CloudFormation; #609 adds subscription filters delivering to Lambda. Nothing writes to a log group by itself yet, and both the service README and the usage docs say so.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a simulated CloudWatch Logs service with log groups, streams, event ingestion, retrieval, filtering, pagination, retention policies, ARNs, and IAM authorization.
  * Added AWS SDK interception support for CloudWatch Logs operations.
  * Added a public package export and service access through account and region scopes.
* **Documentation**
  * Added comprehensive CloudWatch Logs documentation, usage examples, supported filter syntax, retention behavior, and limitations.
* **Tests**
  * Added extensive coverage for log groups, streams, events, filtering, pagination, retention, authorization, and SDK interception.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->