### PR TITLE
chore: add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,20 @@
+Brief, concise description of the change:
+
+<!-- One paragraph of prose, no headings or bullet lists. CodeRabbit will fill
+     in a more detailed description once this is open. -->
+
+<!-- If there is an issue, link it here:
+     Resolves https://github.com/KensioSoftware/yulin/issues/N -->
+
+- [ ] Conventional commit message, used as the title
+
+- [ ] Conventional branch name, like `feat/concise-description`
+- [ ] Full check with `pnpm run check` passed
+- [ ] Rebased off latest main
+- [ ] User-facing behaviour is documented in `docs/`
+
+See https://www.conventionalcommits.org/en/v1.0.0/
+
+<!-- One exception to that spec: no `!` in the title and no `BREAKING CHANGE:`
+     footer. Major versions are published by hand here, so the release run
+     refuses one rather than shipping it. -->


### PR DESCRIPTION
A pull request opened from the web UI or a bare `gh pr create` now starts from a template asking for one paragraph of prose and a short checklist, rather than whatever shape its author reaches for. The paragraph is deliberately the whole description, since CodeRabbit posts a structured summary of its own once the pull request is open and a hand-written file list or test plan beside it is duplicated work that goes stale. The checklist covers what nothing else catches at the moment it matters: a conventional title, which becomes the commit subject on main and so decides the version bump and the release notes; a conventional branch name; a local `pnpm run check`, which runs the `examples:check` that the PR workflow does not; a rebase; and documentation, the one item no tooling verifies at all. A comment under the spec link records where this repo departs from it, a `!` or a `BREAKING CHANGE:` footer being refused by the release run rather than published as a major.

- [x] Conventional commit message, used as the title
- [ ] Conventional branch name, like `feat/concise-description`
- [x] Full check with `pnpm run check` passed
- [x] Rebased off latest main
- [ ] User-facing behaviour is documented in `docs/`

The branch name is the one this session was created on, so it predates the convention this pull request is adding. Nothing validates branch names, so it is cosmetic. No `docs/` change: the template governs how the repo is contributed to and ships nothing to consumers, which is also why the type is `chore` and this releases no version.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a pull request template with structured prompts for change summaries, issue references, commit conventions, validation checks, rebasing, and user-facing documentation.
  * Documented the exception for breaking changes in conventional commits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->