### PR TITLE
feat: record Lambda handler output in its log group

### DIFF
--- a/docs/services/lambda/README.md
+++ b/docs/services/lambda/README.md
@@ -178,20 +178,39 @@ That is what AWS Lambda Powertools' `Logger` does, at module scope, so a bundled
 runs here. Its `Metrics` writes its embedded metric format document to standard output, so the
 metrics a handler emitted can be read back the same way its log lines can.
 
-What a handler prints reaches the matching host stream, standard output to standard output and
-standard error to standard error, which is where a test or a `pnpm run dev` session already sees
-output. A test that wants to assert on it captures that host stream:
+What a handler prints is recorded into the function's log group in
+[simulated CloudWatch Logs](../logs/ "Simulated CloudWatch Logs usage docs"), at
+`/aws/lambda/<function name>`, so a test asserts on it by searching that group rather than by
+capturing process output:
 
 ```typescript
-const written: string[] = [];
-vi.spyOn(process.stdout, "write").mockImplementation((chunk): boolean => {
-  written.push(String(chunk));
-  return true;
-});
+const found = await simAws.logs().filterLogEvents(
+  new FilterLogEventsCommand({
+    logGroupName: "/aws/lambda/orders",
+    filterPattern: "ERROR",
+  }),
+);
 ```
 
-That captures standard output, which is where log lines and EMF metric documents go. Spy on
-`process.stderr` the same way for what a handler wrote there, including its `console.error`.
+One line becomes one log event, as it does in an account, so a handler printing a multi-line object
+gets several events and a search for one of those lines finds it. EMF metric documents go to the
+same place, since Powertools' `Metrics` writes them to standard output.
+
+Each invocation also reaches the matching host stream, standard output to standard output and
+standard error to standard error, which is where a test or a `pnpm run dev` session already sees
+output. That is a tee rather than a redirect: real Lambda sends output to CloudWatch Logs and
+nowhere else, but a test tool that swallowed it would make a failing test harder to debug than it is
+with none of this.
+
+`context.logGroupName` and `context.logStreamName` name the group and stream that were actually
+written to, and stream names use the real `YYYY/MM/DD/[$LATEST]<hash>` format. The hash identifies
+the execution environment rather than the request, so match the shape rather than the value.
+
+Only zip-packaged code is recorded. A function backed by a handler function reference, including one
+bound to a container image, is an ordinary function closing over the test's own module scope: its
+`console.log` reaches the host console directly, and there is nothing to intercept without patching
+a global the whole test run shares. Capturing the host stream is still the way to assert on one of
+those.
 
 ## Function code from S3
 
@@ -2017,9 +2036,13 @@ Current documented limitations:
 - Function versions, aliases, and qualifiers are not simulated (`Version` is always `$LATEST`).
 - The vm runtime supports CommonJS function code only; ES module source (`.mjs` / `export`
   syntax) is not supported yet.
-- Handler output goes to the host process's standard output and error. There is no simulated
-  CloudWatch Logs, so nothing holds a function's output for a test to read back per function or per
-  invocation. See [What a handler prints](#what-a-handler-prints).
+- Only zip-packaged code has its output recorded into a log group. A function backed by a handler
+  function reference, including a container image binding, writes to the host console directly and
+  is not recorded, so a test asserting on its output still has to capture the host stream. See
+  [What a handler prints](#what-a-handler-prints).
+- Nothing writes the platform `START`, `END` and `REPORT` lines a real log stream carries, and
+  execution environments are never recycled, so a function keeps one log stream for as long as it
+  exists.
 - Container image functions are not run. Yulin never reads a container image, and stays Docker-free.
   A function with `PackageType: Image` is skipped, or refused on `CreateFunction`, unless a real
   in-process handler stands in for its image: one bound to it, or one registered in the

--- a/docs/services/logs/README.md
+++ b/docs/services/logs/README.md
@@ -209,6 +209,68 @@ console.log(
 );
 ```
 
+## Lambda handler output
+
+A zip-packaged Lambda function's output is recorded into `/aws/lambda/<function name>` as it runs,
+so a test can assert on what a handler logged by searching its log group rather than by capturing
+process output.
+
+```typescript sim-logs-lambda-output
+/**
+ * Asserting on what a simulated Lambda handler logged.
+ */
+
+import { FilterLogEventsCommand } from "@aws-sdk/client-cloudwatch-logs";
+import { CreateFunctionCommand, InvokeCommand } from "@aws-sdk/client-lambda";
+
+import { SimAws } from "@kensio/yulin";
+import { makeLambdaCodeZip } from "@kensio/yulin/lambda";
+
+const simAws = new SimAws();
+
+await simAws.lambda().createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "orders",
+    Role: `arn:aws:iam::${simAws.defaultAccountId}:role/OrdersRole`,
+    Handler: "index.handler",
+    Code: {
+      ZipFile: makeLambdaCodeZip({
+        "index.js":
+          "exports.handler = async () => {\n" +
+          '  console.error("ERROR order has no items");\n' +
+          "};\n",
+      }),
+    },
+  }),
+);
+
+await simAws.backgroundTasksComplete();
+await simAws.lambda().invoke(new InvokeCommand({ FunctionName: "orders" }));
+
+const found = await simAws.logs().filterLogEvents(
+  new FilterLogEventsCommand({
+    logGroupName: "/aws/lambda/orders",
+    filterPattern: "ERROR",
+  }),
+);
+
+console.log(found.events?.[0]?.message);
+```
+
+The output still reaches the terminal as well. Real Lambda sends it to CloudWatch Logs and nowhere
+else, but a test tool that swallowed it would make a failing test harder to debug than it is with
+none of this, so recording is a tee rather than a redirect.
+
+Each invocation's `context.logGroupName` and `context.logStreamName` name the group and stream that
+were actually written to. Stream names use the real `YYYY/MM/DD/[$LATEST]<hash>` format, and the
+hash identifies the execution environment rather than the request, so a test should match the shape
+rather than the value.
+
+Nothing is authorized on this path. A real function needs `logs:CreateLogGroup` and
+`logs:PutLogEvents` on its execution Role, and one without them produces no logs at all, in silence.
+Simulating that would mean nearly every function in a test logged nothing with no failure to explain
+why, so writing here is unconditional.
+
 ## Permissions
 
 Every operation goes through simulated IAM. An operation on a named log group authorizes against
@@ -331,6 +393,6 @@ console.log(described.logGroups?.[0]?.logGroupArn);
   behaves differently in an account.
 - **Per-stream `storedBytes`.** Always zero, which matches real CloudWatch Logs: it stopped
   reporting the figure per stream in 2019. `DescribeLogGroups` reports the bytes a group holds.
-- **Automatic log capture.** Nothing writes to a log group by itself yet. A simulated Lambda
-  invocation still forwards its handler's output to the host's standard streams, so a group holds
-  only what something put there through `PutLogEvents`.
+- **Log capture from anything but zip-packaged Lambda code.** A function backed by a handler
+  function reference, including a container image binding, writes to the host console directly and
+  is not recorded. See the Lambda docs for why.

--- a/docs/services/logs/sim-logs-lambda-output.example.ts
+++ b/docs/services/logs/sim-logs-lambda-output.example.ts
@@ -1,0 +1,39 @@
+/**
+ * Asserting on what a simulated Lambda handler logged.
+ */
+
+import { FilterLogEventsCommand } from "@aws-sdk/client-cloudwatch-logs";
+import { CreateFunctionCommand, InvokeCommand } from "@aws-sdk/client-lambda";
+
+import { SimAws } from "@kensio/yulin";
+import { makeLambdaCodeZip } from "@kensio/yulin/lambda";
+
+const simAws = new SimAws();
+
+await simAws.lambda().createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "orders",
+    Role: `arn:aws:iam::${simAws.defaultAccountId}:role/OrdersRole`,
+    Handler: "index.handler",
+    Code: {
+      ZipFile: makeLambdaCodeZip({
+        "index.js":
+          "exports.handler = async () => {\n" +
+          '  console.error("ERROR order has no items");\n' +
+          "};\n",
+      }),
+    },
+  }),
+);
+
+await simAws.backgroundTasksComplete();
+await simAws.lambda().invoke(new InvokeCommand({ FunctionName: "orders" }));
+
+const found = await simAws.logs().filterLogEvents(
+  new FilterLogEventsCommand({
+    logGroupName: "/aws/lambda/orders",
+    filterPattern: "ERROR",
+  }),
+);
+
+console.log(found.events?.[0]?.message);

--- a/src/service/aws/factory/sim-aws-lambda-collaborators.ts
+++ b/src/service/aws/factory/sim-aws-lambda-collaborators.ts
@@ -4,6 +4,7 @@ import { SimEcrLambdaContainerImages } from "../../lambda/function/code/image/si
 import { SimS3LambdaCodeStore } from "../../lambda/function/code/store/sim-s3-lambda-code-store.js";
 import { SimSdkLambdaVmModuleProvider } from "../../lambda/function/code/vm/sdk/sim-sdk-lambda-vm-module-provider.js";
 import type { SimLambdaUrlRegistry } from "../../lambda/registry/sim-lambda-url-registry.js";
+import type { SimLogsServiceWriter } from "../../logs/write/sim-logs-service-writer.js";
 import type { SimAwsScopedServiceRegistries } from "./sim-aws-scoped-service-registries.js";
 import type { SimAwsAccountRegionContainer } from "../sim-aws-account-region-scope.js";
 import type { SimAws } from "../sim-aws.js";
@@ -26,6 +27,7 @@ interface SimAwsLambdaCollaborators {
   readonly eventSourceQueues: SimSqsEventSourceQueues;
   readonly eventSourceStreams: SimDynamoDbEventSourceStreams;
   readonly vmSdkModuleProvider: SimSdkLambdaVmModuleProvider;
+  readonly logs: SimLogsServiceWriter;
 }
 
 /**
@@ -44,6 +46,10 @@ interface SimAwsLambdaCollaborators {
  * A container image function's image is resolved in the whole simulation's ECR
  * rather than this scope's, because an image URI names the Account and Region
  * its registry is in, which need not be this one.
+ *
+ * Handler output is recorded to the same Account/Region scope's simulated
+ * CloudWatch Logs, since that is where `/aws/lambda/<name>` lives for a
+ * function in this scope.
  */
 export function simAwsLambdaCollaborators(
   properties: SimAwsLambdaCollaboratorsProperties,
@@ -52,6 +58,7 @@ export function simAwsLambdaCollaborators(
 
   return {
     runAsOwner: simAws,
+    logs: scope.logs().serviceWriter(),
     urlRegistry: properties.urlRegistry,
     codeStore: new SimS3LambdaCodeStore({ s3: scope.s3() }),
     containerImages: new SimEcrLambdaContainerImages({

--- a/src/service/lambda/README.md
+++ b/src/service/lambda/README.md
@@ -133,11 +133,34 @@ The sandbox has writable standard streams (`SimLambdaVmOutputStream`), and its `
 over them as the real runtime's is. Both matter: a library that builds its own console over
 `process.stdout` and `process.stderr` rather than using the global one, as AWS Lambda Powertools'
 logger does at module scope, throws `ERR_CONSOLE_WRITABLE_STREAM` at import without the streams and
-never runs. What is written is forwarded to the matching host stream, the sandbox's standard output
-to the host's standard output and its standard error to the host's standard error, so a handler's
-output arrives there whether it printed through the console or wrote to the stream itself, and a
-test reads it by capturing that host stream. Powertools' metrics print their EMF document to
-standard output, so that is how a test reads the metrics a handler emitted.
+never runs. What is written is both recorded into the function's log group and forwarded to the
+matching host stream, so a handler's output arrives in simulated CloudWatch Logs whether it printed
+through the console or wrote to the stream itself. Powertools' metrics print their EMF document to
+standard output, so that is where a test reads the metrics a handler emitted too.
+
+## Recording handler output
+
+`function/logging/` is where an invocation's output becomes log events.
+
+`SimLambdaFunctionLogging` is what a function holds. It exists so the function does not have to
+carry both the case where something is recording and the case where nothing is: a function built
+standalone, outside a SimAws instance, still reports a group and stream name to its handler, because
+real Lambda derives both from the function and its execution environment whether or not the group
+exists. Both names are settled once, on the first invocation, which is what an execution environment
+cold starting does; Yulin never recycles one, so a function keeps its stream for as long as it
+exists.
+
+The recording is on the streams rather than on the sandbox console built over them, which is what
+makes a logger that builds its own `Console` over `process.stdout` reach the log group as well.
+`SimLambdaLogWriter` splits what arrives into lines, because a line is what a log event is, and
+holds back whatever follows the last newline until the write that completes it, so a line written in
+two calls is one event rather than two. What is still unterminated when the invocation ends is
+recorded then, whether the handler returned or threw.
+
+`SimLambdaExecutableCode.recordOutputTo` is the seam. `SimLambdaVmZipCode` passes the sink to the
+sandbox streams; `SimLambdaHandlerReferenceCode` implements it as a no-op, because a referenced
+handler is an ordinary function closing over the test's own module scope and has no streams of its
+own to tee. Capturing the host stream is still how a test asserts on one of those.
 
 `SimLambdaVmModules` provides a CommonJS module system over the archive: relative requires between
 archived files, Node.js built-ins from the host (as the real runtime provides them), and a minimal

--- a/src/service/lambda/command/create-function/create-function.handler.ts
+++ b/src/service/lambda/command/create-function/create-function.handler.ts
@@ -16,6 +16,7 @@ import { SimLambdaCodeResolver } from "../../function/code/sim-lambda-code-resol
 import type { SimLambdaContainerImages } from "../../function/code/image/sim-lambda-container-images.js";
 import type { SimLambdaCodeStore } from "../../function/code/store/sim-lambda-code-store.js";
 import type { SimLambdaVmSdkModuleProvider } from "../../function/code/vm/sdk/sim-lambda-vm-sdk-module-provider.js";
+import type { SimLogsServiceWriter } from "../../../logs/write/sim-logs-service-writer.js";
 import { SimLambdaEnvironmentConflicts } from "../../function/environment/sim-lambda-environment-conflicts.js";
 import { SimLambdaEnvironment } from "../../function/environment/sim-lambda-environment.js";
 import {
@@ -45,6 +46,7 @@ interface CreateFunctionCommandHandlerProperties {
   containerImages?: SimLambdaContainerImages | undefined;
   vmSdkModuleProvider?: SimLambdaVmSdkModuleProvider | undefined;
   environmentConflicts?: SimLambdaEnvironmentConflicts;
+  logs?: SimLogsServiceWriter | undefined;
 }
 
 interface CreateFunctionCommandHandlerOptions {
@@ -67,6 +69,7 @@ export class CreateFunctionCommandHandler implements CommandHandler<
   private readonly background: BackgroundScheduler;
   private readonly codeResolver: SimLambdaCodeResolver;
   private readonly environmentConflicts: SimLambdaEnvironmentConflicts;
+  private readonly logs: SimLogsServiceWriter | undefined;
 
   constructor(properties: CreateFunctionCommandHandlerProperties) {
     const {
@@ -79,6 +82,7 @@ export class CreateFunctionCommandHandler implements CommandHandler<
       containerImages,
       vmSdkModuleProvider,
       environmentConflicts = new SimLambdaEnvironmentConflicts(),
+      logs,
     } = properties;
     this.accountRegionScope = accountRegionScope;
     this.functions = functions;
@@ -94,6 +98,7 @@ export class CreateFunctionCommandHandler implements CommandHandler<
       clock: background,
     });
     this.environmentConflicts = environmentConflicts;
+    this.logs = logs;
   }
 
   /**
@@ -138,6 +143,7 @@ export class CreateFunctionCommandHandler implements CommandHandler<
       accountRegionScope: this.accountRegionScope,
       runAsOwner: this.runAsOwner,
       clock: this.background,
+      logs: this.logs,
     });
 
     this.functions.set(simFunction.name, simFunction);

--- a/src/service/lambda/command/function/sim-lambda-function-commands.ts
+++ b/src/service/lambda/command/function/sim-lambda-function-commands.ts
@@ -6,6 +6,7 @@ import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-int
 import type { SimLambdaContainerImages } from "../../function/code/image/sim-lambda-container-images.js";
 import type { SimLambdaCodeStore } from "../../function/code/store/sim-lambda-code-store.js";
 import type { SimLambdaVmSdkModuleProvider } from "../../function/code/vm/sdk/sim-lambda-vm-sdk-module-provider.js";
+import type { SimLogsServiceWriter } from "../../../logs/write/sim-logs-service-writer.js";
 import type { SimLambdaEnvironmentConflicts } from "../../function/environment/sim-lambda-environment-conflicts.js";
 import type { SimLambdaFunctionMap } from "../../function/sim-lambda-function.js";
 import type { SimLambdaFunctionUrlStore } from "../../function/url/sim-lambda-function-url-store.js";
@@ -41,6 +42,7 @@ interface SimLambdaFunctionCommandsProperties {
   readonly codeStore?: SimLambdaCodeStore | undefined;
   readonly containerImages?: SimLambdaContainerImages | undefined;
   readonly vmSdkModuleProvider?: SimLambdaVmSdkModuleProvider | undefined;
+  readonly logs?: SimLogsServiceWriter | undefined;
 }
 
 interface SimLambdaFunctionCommandOptions {

--- a/src/service/lambda/function/code/sim-lambda-executable-code.ts
+++ b/src/service/lambda/function/code/sim-lambda-executable-code.ts
@@ -1,3 +1,4 @@
+import type { SimLambdaOutputSink } from "../logging/sim-lambda-output-sink.js";
 import type { SimLambdaHandler } from "../sim-lambda-handler.type.js";
 
 /**
@@ -19,6 +20,12 @@ export interface SimLambdaExecutableCode {
    */
   readonly runsInHostScope: boolean;
 
+  /**
+   * Record what this code writes to its standard streams, so an invocation's
+   * output reaches the function's log group.
+   */
+  recordOutputTo(sink: SimLambdaOutputSink): void;
+
   handlerFunction(): SimLambdaHandler;
 }
 
@@ -33,6 +40,18 @@ export class SimLambdaHandlerReferenceCode implements SimLambdaExecutableCode {
   readonly runsInHostScope = true;
 
   constructor(private readonly handler: SimLambdaHandler) {}
+
+  /**
+   * Record nothing.
+   *
+   * A referenced handler has no streams of its own to tee: it is an ordinary
+   * function closing over the test's own module scope, so its `console.log`
+   * reaches the host console directly and there is nothing here to intercept
+   * without patching a global the whole test run shares.
+   */
+  recordOutputTo(): void {
+    // Nothing to record from.
+  }
 
   /**
    * Get the referenced handler function.

--- a/src/service/lambda/function/code/sim-lambda-handler-name.ts
+++ b/src/service/lambda/function/code/sim-lambda-handler-name.ts
@@ -1,0 +1,31 @@
+import { SimLambdaRuntimeError } from "../../error/sim-lambda-runtime.error.js";
+
+export interface ParsedHandlerName {
+  readonly modulePath: string;
+  readonly exportName: string;
+}
+
+/**
+ * Parse an AWS Lambda handler identifier such as "index.handler" or
+ * "src/app.handler" into its module path and export name.
+ *
+ * The separator is the last period rather than the first, so a module in a
+ * directory and a module with a period in its name both resolve the way real
+ * Lambda resolves them: `src/app.service.handler` is the `handler` export of
+ * `src/app.service`.
+ */
+export function parseLambdaHandlerName(handlerName: string): ParsedHandlerName {
+  const separator = handlerName.lastIndexOf(".");
+
+  if (separator <= 0 || separator === handlerName.length - 1) {
+    throw new SimLambdaRuntimeError(
+      "Runtime.MalformedHandlerName",
+      `Bad handler '${handlerName}': expected format 'file.method'`,
+    );
+  }
+
+  return {
+    modulePath: handlerName.slice(0, separator),
+    exportName: handlerName.slice(separator + 1),
+  };
+}

--- a/src/service/lambda/function/code/sim-lambda-vm-zip-code-errors.iso.test.ts
+++ b/src/service/lambda/function/code/sim-lambda-vm-zip-code-errors.iso.test.ts
@@ -8,7 +8,7 @@ import {
 import { describe, it } from "vitest";
 import { simLambdaVmZipFunctionFactory } from "./sim-lambda-vm-zip-function.factory.js";
 import { SimLambdaRuntimeError } from "../../error/sim-lambda-runtime.error.js";
-import { parseLambdaHandlerName } from "./sim-lambda-vm-zip-code.js";
+import { parseLambdaHandlerName } from "./sim-lambda-handler-name.js";
 
 describe("sim Lambda vm zip code runtime errors", () => {
   it("reports a missing handler module as Runtime.ImportModuleError", async () => {

--- a/src/service/lambda/function/code/sim-lambda-vm-zip-code.ts
+++ b/src/service/lambda/function/code/sim-lambda-vm-zip-code.ts
@@ -8,7 +8,12 @@ import {
 } from "./vm/sdk/sim-lambda-vm-sdk-module-provider.js";
 import type { SimLambdaEnvironment } from "../environment/sim-lambda-environment.js";
 import type { SimLambdaExecutableCode } from "./sim-lambda-executable-code.js";
+import { parseLambdaHandlerName } from "./sim-lambda-handler-name.js";
 import { makeSimLambdaVmContext } from "./vm/sim-lambda-vm-context.js";
+import {
+  simLambdaNoOutputSink,
+  type SimLambdaOutputSink,
+} from "../logging/sim-lambda-output-sink.js";
 import { SimLambdaVmModules } from "./vm/sim-lambda-vm-modules.js";
 
 interface SimLambdaVmZipCodeProperties {
@@ -21,29 +26,6 @@ interface SimLambdaVmZipCodeProperties {
    * the time gets the simulation's time.
    */
   readonly clock?: SimClock | undefined;
-}
-
-interface ParsedHandlerName {
-  readonly modulePath: string;
-  readonly exportName: string;
-}
-
-/**
- * Parse an AWS Lambda handler identifier such as "index.handler" or
- * "src/app.handler" into its module path and export name.
- */
-export function parseLambdaHandlerName(handlerName: string): ParsedHandlerName {
-  const separator = handlerName.lastIndexOf(".");
-  if (separator <= 0 || separator === handlerName.length - 1) {
-    throw new SimLambdaRuntimeError(
-      "Runtime.MalformedHandlerName",
-      `Bad handler '${handlerName}': expected format 'file.method'`,
-    );
-  }
-  return {
-    modulePath: handlerName.slice(0, separator),
-    exportName: handlerName.slice(separator + 1),
-  };
 }
 
 /**
@@ -62,8 +44,20 @@ export class SimLambdaVmZipCode implements SimLambdaExecutableCode {
   readonly runsInHostScope = false;
 
   #handler: SimLambdaHandler | undefined;
+  #sink: SimLambdaOutputSink = simLambdaNoOutputSink;
 
   constructor(private readonly properties: SimLambdaVmZipCodeProperties) {}
+
+  /**
+   * Record what this code writes to its standard streams.
+   *
+   * The sandbox is built at cold start, and an invocation sets this before it
+   * asks for the handler, so the streams function code is handed already carry
+   * the sink by the time any of it runs.
+   */
+  recordOutputTo(sink: SimLambdaOutputSink): void {
+    this.#sink = sink;
+  }
 
   /**
    * Get the handler function, cold-starting the module code if needed.
@@ -80,7 +74,7 @@ export class SimLambdaVmZipCode implements SimLambdaExecutableCode {
 
     const modules = new SimLambdaVmModules({
       archive,
-      context: makeSimLambdaVmContext(environment, clock),
+      context: makeSimLambdaVmContext(environment, clock, this.#sink),
       sdkModuleProvider:
         sdkModuleProvider ?? new SimLambdaNoVmSdkModuleProvider(),
     });

--- a/src/service/lambda/function/code/vm/sim-lambda-vm-context.ts
+++ b/src/service/lambda/function/code/vm/sim-lambda-vm-context.ts
@@ -6,6 +6,10 @@ import {
   SimRealClock,
 } from "../../../../../util/clock/sim-clock.js";
 import type { SimLambdaEnvironment } from "../../environment/sim-lambda-environment.js";
+import {
+  simLambdaNoOutputSink,
+  type SimLambdaOutputSink,
+} from "../../logging/sim-lambda-output-sink.js";
 import { SimLambdaVmOutputStream } from "./sim-lambda-vm-output-stream.js";
 
 /**
@@ -25,12 +29,17 @@ import { SimLambdaVmOutputStream } from "./sim-lambda-vm-output-stream.js";
 export function makeSimLambdaVmContext(
   environment: SimLambdaEnvironment,
   clock: SimClock = new SimRealClock(),
+  sink: SimLambdaOutputSink = simLambdaNoOutputSink,
 ): vm.Context {
   // Writable standard streams, as the real runtime provides. Code that builds
   // its own console over them, as AWS Lambda Powertools' logger does, throws
   // at module load without them.
   const stdout = new SimLambdaVmOutputStream(() => process.stdout);
   const stderr = new SimLambdaVmOutputStream(() => process.stderr);
+
+  // What function code writes reaches the function's log group through here.
+  stdout.recordTo(sink);
+  stderr.recordTo(sink);
 
   return vm.createContext({
     // The sandbox's console is built over those streams, as the real

--- a/src/service/lambda/function/code/vm/sim-lambda-vm-output-stream.ts
+++ b/src/service/lambda/function/code/vm/sim-lambda-vm-output-stream.ts
@@ -1,4 +1,5 @@
 import { Writable } from "node:stream";
+import { StringDecoder } from "node:string_decoder";
 import {
   simLambdaNoOutputSink,
   type SimLambdaOutputSink,
@@ -36,6 +37,18 @@ import {
 export class SimLambdaVmOutputStream extends Writable {
   #sink: SimLambdaOutputSink = simLambdaNoOutputSink;
 
+  /**
+   * Decodes what is recorded, rather than each chunk being decoded on its own.
+   *
+   * A handler writing bytes it read in pieces can split a multibyte character
+   * across two writes, and decoding each Buffer separately would record a
+   * replacement character in place of both halves. The decoder holds the
+   * incomplete bytes until the write that completes them, which is also why it
+   * is never reset: an execution environment writes one continuous stream, so
+   * bytes left over at the end of an invocation belong to the next one.
+   */
+  readonly #decoder = new StringDecoder("utf8");
+
   constructor(private readonly hostStream: () => NodeJS.WritableStream) {
     super();
   }
@@ -61,7 +74,7 @@ export class SimLambdaVmOutputStream extends Writable {
     _encoding: BufferEncoding,
     done: (error?: Error) => void,
   ): void {
-    this.#sink.write(chunk.toString("utf8"));
+    this.#sink.write(this.#decoder.write(chunk));
     this.hostStream().write(chunk);
     done();
   }

--- a/src/service/lambda/function/code/vm/sim-lambda-vm-output-stream.ts
+++ b/src/service/lambda/function/code/vm/sim-lambda-vm-output-stream.ts
@@ -1,4 +1,8 @@
 import { Writable } from "node:stream";
+import {
+  simLambdaNoOutputSink,
+  type SimLambdaOutputSink,
+} from "../../logging/sim-lambda-output-sink.js";
 
 /**
  * One of the standard output streams the sim Lambda vm sandbox gives function
@@ -17,7 +21,12 @@ import { Writable } from "node:stream";
  * (`ERR_CONSOLE_WRITABLE_STREAM`) before the handler runs.
  *
  * What function code writes is forwarded to the matching host stream,
- * standard output to standard output and standard error to standard error.
+ * standard output to standard output and standard error to standard error, and
+ * recorded to the sink the code was given, which is what puts a handler's
+ * output in its log group. Forwarding to the host is a tee rather than a
+ * redirect: real Lambda sends output to CloudWatch Logs and nowhere else, but
+ * a test tool that swallowed it would make a failing test harder to debug than
+ * it is with none of this.
  * The sandbox's own console is built over these streams too, so a handler's
  * output arrives there whether it printed through the console or wrote to the
  * stream itself, instead of one of the two disappearing. The host stream is
@@ -25,8 +34,17 @@ import { Writable } from "node:stream";
  * function has cold-started still sees what the handler writes.
  */
 export class SimLambdaVmOutputStream extends Writable {
+  #sink: SimLambdaOutputSink = simLambdaNoOutputSink;
+
   constructor(private readonly hostStream: () => NodeJS.WritableStream) {
     super();
+  }
+
+  /**
+   * Record everything written here to a sink from now on.
+   */
+  recordTo(sink: SimLambdaOutputSink): void {
+    this.#sink = sink;
   }
 
   /**
@@ -43,6 +61,7 @@ export class SimLambdaVmOutputStream extends Writable {
     _encoding: BufferEncoding,
     done: (error?: Error) => void,
   ): void {
+    this.#sink.write(chunk.toString("utf8"));
     this.hostStream().write(chunk);
     done();
   }

--- a/src/service/lambda/function/invoke/sim-lambda-handler-runner.iso.test.ts
+++ b/src/service/lambda/function/invoke/sim-lambda-handler-runner.iso.test.ts
@@ -18,6 +18,8 @@ const contextBuilder = new SimLambdaInvokeContextBuilder({
     "arn:aws:lambda:eu-west-2:111111111111:function:runner-test",
   timeoutSeconds: 3,
   memorySizeMb: 128,
+  logGroupName: "/aws/lambda/test",
+  logStreamName: "2026/08/16/[$LATEST]abc",
 });
 
 async function yieldEventLoop(): Promise<void> {

--- a/src/service/lambda/function/invoke/sim-lambda-invoke-context-builder.ts
+++ b/src/service/lambda/function/invoke/sim-lambda-invoke-context-builder.ts
@@ -13,6 +13,10 @@ interface SimLambdaInvokeContextBuilderProperties {
   readonly invokedFunctionArn: string;
   readonly timeoutSeconds: number;
   readonly memorySizeMb: number;
+  readonly logGroupName: string;
+
+  /** The stream this invocation's execution environment writes to. */
+  readonly logStreamName: string;
   /**
    * Clock measuring how much of the invocation timeout is left. Reading the
    * remaining time from the simulation's clock means a stopped clock leaves a
@@ -41,6 +45,8 @@ export class SimLambdaInvokeContextBuilder {
       invokedFunctionArn,
       timeoutSeconds,
       memorySizeMb,
+      logGroupName,
+      logStreamName,
       clock = new SimRealClock(),
     } = this.properties;
     const startedAtMs = clock.now().getTime();
@@ -53,8 +59,8 @@ export class SimLambdaInvokeContextBuilder {
       invokedFunctionArn,
       memoryLimitInMB: String(memorySizeMb),
       awsRequestId,
-      logGroupName: `/aws/lambda/${functionName}`,
-      logStreamName: `[$LATEST]${awsRequestId}`,
+      logGroupName,
+      logStreamName,
       getRemainingTimeInMillis: (): number =>
         Math.max(
           0,

--- a/src/service/lambda/function/logging/sim-lambda-function-logging.ts
+++ b/src/service/lambda/function/logging/sim-lambda-function-logging.ts
@@ -1,0 +1,99 @@
+import type { SimClock } from "../../../../util/clock/sim-clock.js";
+import type { SimLogsServiceWriter } from "../../../logs/write/sim-logs-service-writer.js";
+import type { SimLambdaExecutableCode } from "../code/sim-lambda-executable-code.js";
+import { SimLambdaLogWriter } from "./sim-lambda-log-writer.js";
+import {
+  simLambdaLogGroupName,
+  simLambdaLogStreamName,
+} from "./sim-lambda-log-stream-name.js";
+
+interface SimLambdaFunctionLoggingProperties {
+  readonly functionName: string;
+  readonly clock: SimClock;
+
+  /**
+   * Where output is recorded. A function built standalone, outside a SimAws
+   * instance, has no simulated CloudWatch Logs to record to.
+   */
+  readonly logs?: SimLogsServiceWriter | undefined;
+}
+
+/**
+ * One function's side of writing its output to a log group.
+ *
+ * The group and stream names exist whether or not anything is recording, since
+ * real Lambda derives both from the function and its execution environment and
+ * a handler reads them from its context either way. What a missing simulated
+ * CloudWatch Logs changes is only whether a stream is opened behind them.
+ *
+ * Both names are settled once, on the first invocation, and reused after it.
+ * That is what an execution environment does: it cold starts, opens a stream,
+ * and keeps writing to it. Yulin does not recycle execution environments, so a
+ * function keeps one stream for as long as the function exists, and a new
+ * simulation opens a new one.
+ */
+export class SimLambdaFunctionLogging {
+  readonly logGroupName: string;
+
+  readonly #logs: SimLogsServiceWriter | undefined;
+  readonly #clock: SimClock;
+  #writer: SimLambdaLogWriter | undefined;
+  #logStreamName: string | undefined;
+
+  constructor(properties: SimLambdaFunctionLoggingProperties) {
+    this.logGroupName = simLambdaLogGroupName(properties.functionName);
+    this.#logs = properties.logs;
+    this.#clock = properties.clock;
+  }
+
+  /**
+   * The stream this function's execution environment writes to, opening it if
+   * this is the first invocation.
+   */
+  logStreamName(): string {
+    this.#logStreamName ??= this.coldStart();
+    return this.#logStreamName;
+  }
+
+  /**
+   * Have this function's code record what it writes.
+   */
+  recordFrom(code: SimLambdaExecutableCode): void {
+    const writer = this.#writer;
+
+    if (writer !== undefined) {
+      code.recordOutputTo(writer);
+    }
+  }
+
+  /**
+   * Run an invocation, recording whatever it left unterminated once it is
+   * over.
+   *
+   * The flush happens whether the handler returned or threw, because a handler
+   * that logged and then failed is the one a test most wants to read the logs
+   * of, and real Lambda records the output either way.
+   */
+  async around<T>(run: () => Promise<T>): Promise<T> {
+    try {
+      return await run();
+    } finally {
+      this.#writer?.flush();
+    }
+  }
+
+  private coldStart(): string {
+    const logStreamName = simLambdaLogStreamName(this.#clock);
+    const logs = this.#logs;
+
+    if (logs !== undefined) {
+      this.#writer = new SimLambdaLogWriter({
+        logGroupName: this.logGroupName,
+        logStreamName,
+        logs,
+      });
+    }
+
+    return logStreamName;
+  }
+}

--- a/src/service/lambda/function/logging/sim-lambda-function-logging.ts
+++ b/src/service/lambda/function/logging/sim-lambda-function-logging.ts
@@ -49,9 +49,17 @@ export class SimLambdaFunctionLogging {
   /**
    * The stream this function's execution environment writes to, opening it if
    * this is the first invocation.
+   *
+   * The group and stream are reopened on every invocation, not just the first.
+   * Opening is idempotent, and a test that deleted the log group in between
+   * would otherwise get it back only if the next handler happened to write
+   * something: real Lambda shows the stream for an invocation that logged
+   * nothing at all.
    */
   logStreamName(): string {
     this.#logStreamName ??= this.coldStart();
+    this.#logs?.openStream(this.logGroupName, this.#logStreamName);
+
     return this.#logStreamName;
   }
 

--- a/src/service/lambda/function/logging/sim-lambda-log-capture.iso.test.ts
+++ b/src/service/lambda/function/logging/sim-lambda-log-capture.iso.test.ts
@@ -1,0 +1,204 @@
+import { CreateFunctionCommand, InvokeCommand } from "@aws-sdk/client-lambda";
+import {
+  DeleteLogGroupCommand,
+  FilterLogEventsCommand,
+} from "@aws-sdk/client-cloudwatch-logs";
+import {
+  assertArrayEquals,
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertStringStartsWith,
+  assertTrue,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import { makeLambdaCodeZip } from "../code/make-lambda-code-zip.js";
+
+const logGroupName = "/aws/lambda/orders";
+
+/**
+ * A simulated AWS with one zip-code function whose handler writes the lines
+ * given, one call per line.
+ */
+async function simAwsWithLoggingFunction(handlerBody: string): Promise<SimAws> {
+  const simAws = new SimAws();
+
+  await simAws.lambda().createFunction(
+    new CreateFunctionCommand({
+      FunctionName: "orders",
+      Role: `arn:aws:iam::${simAws.defaultAccountId}:role/OrdersRole`,
+      Handler: "index.handler",
+      Code: {
+        ZipFile: makeLambdaCodeZip({
+          "index.js":
+            `exports.handler = async (event, context) => {\n` +
+            `${handlerBody}\n};\n`,
+        }),
+      },
+    }),
+  );
+
+  await simAws.backgroundTasksComplete();
+
+  return simAws;
+}
+
+async function messagesIn(simAws: SimAws): Promise<readonly string[]> {
+  const found = await simAws
+    .logs()
+    .filterLogEvents(new FilterLogEventsCommand({ logGroupName }));
+
+  return found.events?.map((event) => event.message) ?? [];
+}
+
+describe("Lambda handler output in CloudWatch Logs", () => {
+  it("records what a handler logged into its own log group", async () => {
+    // Given a function whose handler logs as it runs.
+    const simAws = await simAwsWithLoggingFunction(
+      '  console.log("INFO handling order-1");\n' +
+        '  console.error("ERROR order has no items");',
+    );
+
+    // When it is invoked.
+    await simAws.lambda().invoke(new InvokeCommand({ FunctionName: "orders" }));
+
+    // Then both lines are in the function's log group, and a test can search
+    // for one of them rather than capturing process output.
+    assertArrayEquals(await messagesIn(simAws), [
+      "INFO handling order-1",
+      "ERROR order has no items",
+    ]);
+  });
+
+  it("records a multi-line write as one event per line", async () => {
+    // Given a handler printing an object over several lines.
+    const simAws = await simAwsWithLoggingFunction(
+      '  console.log(JSON.stringify({ orderId: "order-1" }, null, 2));',
+    );
+
+    // When it is invoked.
+    await simAws.lambda().invoke(new InvokeCommand({ FunctionName: "orders" }));
+
+    // Then each line is its own event, as real CloudWatch Logs records them.
+    assertArrayEquals(await messagesIn(simAws), [
+      "{",
+      '  "orderId": "order-1"',
+      "}",
+    ]);
+  });
+
+  it("records a write that never sent a newline", async () => {
+    // Given a handler writing to the stream directly, without ending the line.
+    const simAws = await simAwsWithLoggingFunction(
+      '  process.stdout.write("no newline here");',
+    );
+
+    // When it is invoked.
+    await simAws.lambda().invoke(new InvokeCommand({ FunctionName: "orders" }));
+
+    // Then the invocation ending is what records it, rather than a line that
+    // never comes.
+    assertArrayEquals(await messagesIn(simAws), ["no newline here"]);
+  });
+
+  it("keeps a line written across two calls together", async () => {
+    // Given a handler building one line out of several writes.
+    const simAws = await simAwsWithLoggingFunction(
+      [
+        '  process.stdout.write("one ");',
+        String.raw`  process.stdout.write("line\n");`,
+      ].join("\n"),
+    );
+
+    // When it is invoked.
+    await simAws.lambda().invoke(new InvokeCommand({ FunctionName: "orders" }));
+
+    // Then it is one event, not one per write.
+    assertArrayEquals(await messagesIn(simAws), ["one line"]);
+  });
+
+  it("names the stream the way real Lambda names it, and tells the handler", async () => {
+    // Given a handler reporting where it thinks it is writing.
+    const simAws = await simAwsWithLoggingFunction(
+      "  console.log(context.logGroupName);\n" +
+        "  console.log(context.logStreamName);",
+    );
+
+    // When it is invoked.
+    await simAws.lambda().invoke(new InvokeCommand({ FunctionName: "orders" }));
+
+    // Then the group is the one it wrote to, and the stream name carries the
+    // date and the $LATEST marker real Lambda uses.
+    const messages = await messagesIn(simAws);
+
+    assertArrayLength(messages, 2);
+    assertIdentical(messages.at(0), logGroupName);
+    const logStreamName = messages.at(1);
+
+    assertNonNullable(logStreamName);
+    assertTrue(
+      /^\d{4}\/\d{2}\/\d{2}\/\[\$LATEST][\da-f]{32}$/.test(logStreamName),
+    );
+  });
+
+  it("makes the log group again when something deleted it mid-test", async () => {
+    // Given a function that has invoked once, and its log group deleted after.
+    const simAws = await simAwsWithLoggingFunction('  console.log("ran");');
+
+    await simAws.lambda().invoke(new InvokeCommand({ FunctionName: "orders" }));
+    await simAws
+      .logs()
+      .deleteLogGroup(new DeleteLogGroupCommand({ logGroupName }));
+
+    // When it is invoked again.
+    await simAws.lambda().invoke(new InvokeCommand({ FunctionName: "orders" }));
+
+    // Then the invocation makes the group again rather than failing over one
+    // that has gone, which is what real Lambda does.
+    assertArrayEquals(await messagesIn(simAws), ["ran"]);
+  });
+
+  it("records a logger that builds its own console over the streams", async () => {
+    // Given a handler using the pattern AWS Lambda Powertools' logger uses:
+    // its own Console over the runtime's streams rather than the global one.
+    const simAws = await simAwsWithLoggingFunction(
+      [
+        '  const { Console } = require("node:console");',
+        "  const own = new Console({",
+        "    stdout: process.stdout,",
+        "    stderr: process.stderr,",
+        "  });",
+        '  own.log(JSON.stringify({ level: "ERROR", message: "order failed" }));',
+      ].join("\n"),
+    );
+
+    // When it is invoked.
+    await simAws.lambda().invoke(new InvokeCommand({ FunctionName: "orders" }));
+
+    // Then its output is recorded too, because the recording is on the streams
+    // rather than on the sandbox console built over them.
+    assertArrayEquals(await messagesIn(simAws), [
+      '{"level":"ERROR","message":"order failed"}',
+    ]);
+  });
+
+  it("keeps one stream across invocations of a warm environment", async () => {
+    // Given a function invoked twice.
+    const simAws = await simAwsWithLoggingFunction('  console.log("ran");');
+
+    await simAws.lambda().invoke(new InvokeCommand({ FunctionName: "orders" }));
+    await simAws.lambda().invoke(new InvokeCommand({ FunctionName: "orders" }));
+
+    // When its streams are read.
+    const group = simAws.logs().findLogGroup(logGroupName);
+
+    // Then both invocations wrote to the one stream the environment opened,
+    // rather than each opening one of its own.
+    assertNonNullable(group);
+    assertArrayLength(group.streams, 1);
+    assertArrayEquals(await messagesIn(simAws), ["ran", "ran"]);
+    assertStringStartsWith(group.streams.at(0)?.logStreamName ?? "", "20");
+  });
+});

--- a/src/service/lambda/function/logging/sim-lambda-log-capture.iso.test.ts
+++ b/src/service/lambda/function/logging/sim-lambda-log-capture.iso.test.ts
@@ -119,6 +119,28 @@ describe("Lambda handler output in CloudWatch Logs", () => {
     assertArrayEquals(await messagesIn(simAws), ["one line"]);
   });
 
+  it("keeps a multibyte character written across two chunks whole", async () => {
+    // Given a handler writing one character as two Buffer writes, which is
+    // what streaming bytes read in pieces does.
+    const simAws = await simAwsWithLoggingFunction(
+      [
+        '  const bytes = Buffer.from("orders \u{65E5}\u{672C}\u{8A9E}\\n");',
+        "  process.stdout.write(bytes.subarray(0, 8));",
+        "  process.stdout.write(bytes.subarray(8));",
+      ].join("\n"),
+    );
+
+    // When it is invoked.
+    await simAws.lambda().invoke(new InvokeCommand({ FunctionName: "orders" }));
+
+    // Then the character split across the two writes is recorded as itself,
+    // rather than as the replacement character each half would decode to on
+    // its own.
+    assertArrayEquals(await messagesIn(simAws), [
+      "orders \u{65E5}\u{672C}\u{8A9E}",
+    ]);
+  });
+
   it("names the stream the way real Lambda names it, and tells the handler", async () => {
     // Given a handler reporting where it thinks it is writing.
     const simAws = await simAwsWithLoggingFunction(
@@ -158,6 +180,28 @@ describe("Lambda handler output in CloudWatch Logs", () => {
     // Then the invocation makes the group again rather than failing over one
     // that has gone, which is what real Lambda does.
     assertArrayEquals(await messagesIn(simAws), ["ran"]);
+  });
+
+  it("makes the log group again for an invocation that logs nothing", async () => {
+    // Given a function whose handler writes nothing at all, invoked once, and
+    // its log group deleted after.
+    const simAws = await simAwsWithLoggingFunction("  return 1;");
+
+    await simAws.lambda().invoke(new InvokeCommand({ FunctionName: "orders" }));
+    await simAws
+      .logs()
+      .deleteLogGroup(new DeleteLogGroupCommand({ logGroupName }));
+
+    // When it is invoked again.
+    await simAws.lambda().invoke(new InvokeCommand({ FunctionName: "orders" }));
+
+    // Then the environment opening its stream is what brings the group back,
+    // rather than the first line the handler happens to write. Real Lambda
+    // shows the stream for an invocation that logged nothing too.
+    const group = simAws.logs().findLogGroup(logGroupName);
+
+    assertNonNullable(group);
+    assertArrayLength(group.streams, 1);
   });
 
   it("records a logger that builds its own console over the streams", async () => {

--- a/src/service/lambda/function/logging/sim-lambda-log-stream-name.ts
+++ b/src/service/lambda/function/logging/sim-lambda-log-stream-name.ts
@@ -1,0 +1,33 @@
+import { randomUUID } from "node:crypto";
+import type { SimClock } from "../../../../util/clock/sim-clock.js";
+
+/**
+ * The log group a Lambda function writes to.
+ *
+ * Real Lambda derives it from the function name, and so does the value the
+ * runtime puts in `context.logGroupName`.
+ */
+export function simLambdaLogGroupName(functionName: string): string {
+  return `/aws/lambda/${functionName}`;
+}
+
+/**
+ * The name of the log stream one execution environment writes to.
+ *
+ * Real Lambda names it `YYYY/MM/DD/[$LATEST]<32 hex characters>`, dated by
+ * when the environment started rather than by the invocation, which is why a
+ * long-lived environment keeps writing to yesterday's stream. The date comes
+ * from the simulation's clock so a test that froze time gets the date it set.
+ *
+ * The hex part identifies the execution environment, not the request. A test
+ * asserting on a stream name should match the shape rather than the value, as
+ * it would have to against a real account.
+ */
+export function simLambdaLogStreamName(clock: SimClock): string {
+  const started = clock.now();
+  const year = started.getUTCFullYear();
+  const month = String(started.getUTCMonth() + 1).padStart(2, "0");
+  const day = String(started.getUTCDate()).padStart(2, "0");
+
+  return `${year}/${month}/${day}/[$LATEST]${randomUUID().replaceAll("-", "")}`;
+}

--- a/src/service/lambda/function/logging/sim-lambda-log-writer.ts
+++ b/src/service/lambda/function/logging/sim-lambda-log-writer.ts
@@ -1,0 +1,72 @@
+import type { SimLogsServiceWriter } from "../../../logs/write/sim-logs-service-writer.js";
+
+interface SimLambdaLogWriterProperties {
+  readonly logGroupName: string;
+  readonly logStreamName: string;
+  readonly logs: SimLogsServiceWriter;
+}
+
+/**
+ * Records one execution environment's output into its log stream.
+ *
+ * Output is written line by line because that is what a log event is. Real
+ * CloudWatch Logs records one event per line, so a handler printing a
+ * multi-line object gets several events, and a test filtering for one of those
+ * lines finds it.
+ */
+export class SimLambdaLogWriter {
+  readonly #logGroupName: string;
+  readonly #logStreamName: string;
+  readonly #logs: SimLogsServiceWriter;
+  #pending = "";
+
+  constructor(properties: SimLambdaLogWriterProperties) {
+    this.#logGroupName = properties.logGroupName;
+    this.#logStreamName = properties.logStreamName;
+    this.#logs = properties.logs;
+    this.#logs.openStream(this.#logGroupName, this.#logStreamName);
+  }
+
+  /**
+   * Record what the handler wrote.
+   *
+   * A chunk is whatever reached the stream, which need not be a whole line: a
+   * handler writing to `process.stdout` directly can send one line in several
+   * writes. What is left over after the last newline is held back until the
+   * write that completes it, so a line is never split across two events.
+   */
+  write(chunk: string): void {
+    const text = this.#pending + chunk;
+    const lastNewline = text.lastIndexOf("\n");
+
+    if (lastNewline === -1) {
+      this.#pending = text;
+      return;
+    }
+
+    this.#pending = text.slice(lastNewline + 1);
+    this.#logs.write(
+      this.#logGroupName,
+      this.#logStreamName,
+      text.slice(0, lastNewline).split("\n"),
+    );
+  }
+
+  /**
+   * Record anything written without a closing newline.
+   *
+   * Real Lambda records what the handler wrote when the invocation ends, so a
+   * `process.stdout.write("no newline")` still reaches the log group rather
+   * than waiting for a line that never comes.
+   */
+  flush(): void {
+    if (this.#pending.length === 0) {
+      return;
+    }
+
+    const pending = this.#pending;
+
+    this.#pending = "";
+    this.#logs.write(this.#logGroupName, this.#logStreamName, [pending]);
+  }
+}

--- a/src/service/lambda/function/logging/sim-lambda-output-sink.ts
+++ b/src/service/lambda/function/logging/sim-lambda-output-sink.ts
@@ -1,0 +1,26 @@
+/**
+ * Something that records what a Lambda handler writes to its standard streams.
+ *
+ * Executable code is given one of these before it cold starts, so the streams
+ * it hands function code tee into it. It is an interface rather than the log
+ * writer itself so that the code path does not have to know that what it is
+ * writing to is a log group.
+ */
+export interface SimLambdaOutputSink {
+  /**
+   * Record a chunk of output, which need not be a whole line.
+   */
+  write(chunk: string): void;
+}
+
+/**
+ * A sink that records nothing.
+ *
+ * Code that was never given one writes to the host streams and nowhere else,
+ * which is what a function built standalone, outside a SimAws instance, does.
+ */
+export const simLambdaNoOutputSink: SimLambdaOutputSink = {
+  write: (): void => {
+    // Nothing is recording.
+  },
+};

--- a/src/service/lambda/function/sim-lambda-function.ts
+++ b/src/service/lambda/function/sim-lambda-function.ts
@@ -8,6 +8,8 @@ import {
   SimLambdaHandlerReferenceCode,
 } from "./code/sim-lambda-executable-code.js";
 import { SimLambdaEnvironment } from "./environment/sim-lambda-environment.js";
+import { SimLambdaFunctionLogging } from "./logging/sim-lambda-function-logging.js";
+import type { SimLogsServiceWriter } from "../../logs/write/sim-logs-service-writer.js";
 import { SimLambdaFunctionPolicy } from "./policy/sim-lambda-function-policy.js";
 import { SimLambdaHandlerRunner } from "./invoke/sim-lambda-handler-runner.js";
 import { SimLambdaInvokeContextBuilder } from "./invoke/sim-lambda-invoke-context-builder.js";
@@ -88,6 +90,12 @@ interface SimLambdaFunctionProperties {
    * real clock.
    */
   clock?: SimClock | undefined;
+  /**
+   * Where this function's handler output is recorded. A function built
+   * standalone, outside a SimAws instance, has nowhere to record to and writes
+   * only to the host streams.
+   */
+  logs?: SimLogsServiceWriter | undefined;
 }
 
 /**
@@ -123,6 +131,7 @@ export class SimLambdaFunction {
   private readonly runAsOwner: SimAwsRunAsOwner;
   private readonly runner = new SimLambdaHandlerRunner();
   private readonly clock: SimClock;
+  private readonly logging: SimLambdaFunctionLogging;
 
   constructor(properties: SimLambdaFunctionProperties) {
     const {
@@ -140,6 +149,7 @@ export class SimLambdaFunction {
       environment,
       runAsOwner = this,
       clock = new SimRealClock(),
+      logs,
     } = properties;
     this.clock = clock;
     this.name = name as SimLambdaFunctionName;
@@ -160,6 +170,18 @@ export class SimLambdaFunction {
         memorySizeMb,
       });
     this.runAsOwner = runAsOwner;
+    this.logging = new SimLambdaFunctionLogging({
+      functionName: name,
+      logs,
+      clock,
+    });
+  }
+
+  /**
+   * The log group this function's output is recorded to.
+   */
+  get logGroupName(): string {
+    return this.logging.logGroupName;
   }
 
   /**
@@ -222,7 +244,11 @@ export class SimLambdaFunction {
       timeoutSeconds: this.timeoutSeconds,
       memorySizeMb: this.memorySizeMb,
       clock: this.clock,
+      logGroupName: this.logging.logGroupName,
+      logStreamName: this.logging.logStreamName(),
     });
+
+    this.logging.recordFrom(this.code);
 
     return await simAwsRunAsContext.run(
       this.runAsOwner,
@@ -232,10 +258,13 @@ export class SimLambdaFunction {
           async () =>
             await this.runWithSimulatedTime(
               async () =>
-                await this.runner.run(
-                  this.code.handlerFunction(),
-                  event,
-                  contextBuilder,
+                await this.logging.around(
+                  async () =>
+                    await this.runner.run(
+                      this.code.handlerFunction(),
+                      event,
+                      contextBuilder,
+                    ),
                 ),
             ),
         ),

--- a/src/service/lambda/sim-lambda-commands.ts
+++ b/src/service/lambda/sim-lambda-commands.ts
@@ -26,6 +26,7 @@ import {
 } from "./function/code/image/sim-lambda-container-images.js";
 import type { SimLambdaCodeStore } from "./function/code/store/sim-lambda-code-store.js";
 import type { SimLambdaVmSdkModuleProvider } from "./function/code/vm/sdk/sim-lambda-vm-sdk-module-provider.js";
+import type { SimLogsServiceWriter } from "../logs/write/sim-logs-service-writer.js";
 import { SimLambdaEnvironmentConflicts } from "./function/environment/sim-lambda-environment-conflicts.js";
 import type { SimLambdaFunctionMap } from "./function/sim-lambda-function.js";
 import { SimLambdaFunctionLookup } from "./function/url/sim-lambda-function-lookup.js";
@@ -43,6 +44,7 @@ export interface SimLambdaProperties {
   readonly codeStore?: SimLambdaCodeStore;
   readonly containerImages?: SimLambdaContainerImages;
   readonly vmSdkModuleProvider?: SimLambdaVmSdkModuleProvider;
+  readonly logs?: SimLogsServiceWriter | undefined;
   readonly urlRegistry?: SimLambdaUrlRegistry;
   readonly eventSourceQueues?: SimSqsPollQueues;
   readonly eventSourceStreams?: SimLambdaEventSourceStreams;
@@ -83,6 +85,7 @@ export class SimLambdaCommands {
       background = new BackgroundTasks(),
       codeStore,
       vmSdkModuleProvider,
+      logs,
       // A standalone SimLambda is not reachable over HTTP, so its own registry
       // is enough; a SimAws-created one shares the environment-wide registry
       // the serving layer routes with.
@@ -146,6 +149,7 @@ export class SimLambdaCommands {
       codeStore,
       containerImages,
       vmSdkModuleProvider,
+      logs,
     });
   }
 }

--- a/src/service/logs/README.md
+++ b/src/service/logs/README.md
@@ -99,13 +99,28 @@ knows to keep it and ask again.
 than dropping them, following the same rule as the rest of the simulator: something accepted and
 ignored here would be applied in an account.
 
+## Writing from the rest of the simulation
+
+`SimLogsServiceWriter`, under `write/`, is how a simulated service records its own output. It is
+deliberately not the command layer: nothing validates a batch, pages, or authorizes, because real
+CloudWatch Logs does not put a Lambda function's own output through `PutLogEvents` either.
+
+Nothing on that path fails. A group or stream that is not there is made rather than refused, so
+deleting a log group mid-test does not take the next invocation down with it, which is what real
+Lambda does when its group has gone.
+
+Authorization is the deliberate divergence. A real function needs `logs:CreateLogGroup` and
+`logs:PutLogEvents` on its execution Role, and one without them produces no logs at all, in silence.
+Simulating that faithfully would mean nearly every function in a test logged nothing with no failure
+to explain why, so writing is unconditional here.
+
+Only zip-packaged Lambda code reaches this. A handler function reference runs in the host scope with
+no streams of its own, so there is nothing to tee without patching a global the whole test run
+shares.
+
 ## What is not simulated
 
 Nothing expires, as above. Subscription filters, metric filters, Logs Insights queries, export
 tasks, tagging, encryption and data protection policies are all absent. `metricFilterCount` is
 always zero and a stream's `storedBytes` is always zero, the latter matching real CloudWatch Logs,
 which stopped reporting it per stream in 2019.
-
-Nothing writes to a log group by itself yet either. A simulated Lambda invocation still forwards
-its handler's output to the host's streams, so a group only holds what something put there through
-`PutLogEvents`.

--- a/src/service/logs/group/sim-logs-log-group-store.ts
+++ b/src/service/logs/group/sim-logs-log-group-store.ts
@@ -52,6 +52,19 @@ export class SimLogsLogGroupStore {
   }
 
   /**
+   * Make a log group, or answer with the one already under that name.
+   *
+   * This is not an operation the CloudWatch Logs API has. It is for the parts
+   * of the simulation that write to a group as a side effect of doing
+   * something else, where a name already in use is the ordinary case rather
+   * than a mistake: a Lambda function creates its own log group on its first
+   * invocation and finds it there on every one after.
+   */
+  ensure(logGroupName: string, creationTime: number): SimLogsLogGroup {
+    return this.find(logGroupName) ?? this.create(logGroupName, creationTime);
+  }
+
+  /**
    * Find a log group by name.
    */
   find(logGroupName: string): SimLogsLogGroup | undefined {

--- a/src/service/logs/sim-logs.ts
+++ b/src/service/logs/sim-logs.ts
@@ -22,6 +22,7 @@ import { SimLogsEventIds } from "./event/sim-logs-event-ids.js";
 import type { SimLogsLogGroup } from "./group/sim-logs-log-group.js";
 import { SimLogsLogGroupStore } from "./group/sim-logs-log-group-store.js";
 import { SimLogsSdkCommandRouter } from "./sdk/sim-logs-sdk-command-router.js";
+import { SimLogsServiceWriter } from "./write/sim-logs-service-writer.js";
 
 interface SimLogsProperties {
   readonly accountRegionScope?: SimAwsAccountRegionScope;
@@ -51,6 +52,7 @@ export class SimLogs {
   readonly #getLogEventsCommand: SimLogsGetLogEvents;
   readonly #filterLogEventsCommand: SimLogsFilterLogEvents;
   readonly #background: BackgroundScheduler;
+  readonly #serviceWriter: SimLogsServiceWriter;
   readonly #sdkRouter = new SimLogsSdkCommandRouter(this);
 
   constructor(properties: SimLogsProperties = {}) {
@@ -87,6 +89,11 @@ export class SimLogs {
       clock: background,
     });
     this.#getLogEventsCommand = new SimLogsGetLogEvents({ groups, authorizer });
+    this.#serviceWriter = new SimLogsServiceWriter({
+      groups,
+      eventIds,
+      clock: background,
+    });
     this.#filterLogEventsCommand = new SimLogsFilterLogEvents({
       groups,
       authorizer,
@@ -108,6 +115,20 @@ export class SimLogs {
    */
   allLogGroups(): readonly SimLogsLogGroup[] {
     return this.#groups.all;
+  }
+
+  /**
+   * How the rest of the simulation writes to a log group.
+   *
+   * Nothing authorizes on this path. A real Lambda function needs
+   * `logs:CreateLogGroup` and `logs:PutLogEvents` on its execution Role, and
+   * one without them produces no logs at all, in silence. Simulating that
+   * would mean nearly every function in a test logged nothing with no failure
+   * to explain why, so writing is unconditional and the divergence is
+   * documented instead.
+   */
+  serviceWriter(): SimLogsServiceWriter {
+    return this.#serviceWriter;
   }
 
   /**

--- a/src/service/logs/write/sim-logs-service-writer.iso.test.ts
+++ b/src/service/logs/write/sim-logs-service-writer.iso.test.ts
@@ -1,0 +1,80 @@
+import {
+  assertArrayEquals,
+  assertArrayLength,
+  assertNonNullable,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import type { SimLogs } from "../sim-logs.js";
+
+const logGroupName = "/aws/lambda/orders";
+const logStreamName = "2026/08/16/[$LATEST]abc";
+
+function messagesIn(logs: SimLogs): readonly string[] {
+  return (
+    logs
+      .findLogGroup(logGroupName)
+      ?.findStream(logStreamName)
+      ?.events.map((event) => event.message) ?? []
+  );
+}
+
+describe("SimLogsServiceWriter", () => {
+  it("makes the group and the stream on the way", () => {
+    // Given a simulated CloudWatch Logs holding nothing.
+    const logs = new SimAws().logs();
+
+    // When a simulated service writes to a group nothing created.
+    logs.serviceWriter().write(logGroupName, logStreamName, ["a line"]);
+
+    // Then both were made rather than the write being refused, which is what
+    // lets a Lambda function log without a test creating anything first.
+    assertArrayEquals(messagesIn(logs), ["a line"]);
+  });
+
+  it("opens a stream without writing to it", () => {
+    // Given a simulated CloudWatch Logs holding nothing.
+    const logs = new SimAws().logs();
+
+    // When a stream is opened, twice.
+    logs.serviceWriter().openStream(logGroupName, logStreamName);
+    logs.serviceWriter().openStream(logGroupName, logStreamName);
+
+    // Then it is there once and holds nothing, so an execution environment
+    // that logged nothing still shows the stream it ran in.
+    const group = logs.findLogGroup(logGroupName);
+
+    assertNonNullable(group);
+    assertArrayLength(group.streams, 1);
+    assertArrayLength(group.streams.at(0)?.events ?? [], 0);
+  });
+
+  it("writes nothing for no lines", () => {
+    // Given a simulated CloudWatch Logs holding nothing.
+    const logs = new SimAws().logs();
+
+    // When a write carries no lines at all.
+    logs.serviceWriter().write(logGroupName, logStreamName, []);
+
+    // Then nothing is made for it: a write with nothing in it should not be
+    // what brings a log group into existence.
+    assertUndefined(logs.findLogGroup(logGroupName));
+  });
+
+  it("appends to the stream a later write names again", () => {
+    // Given a stream that has been written to.
+    const logs = new SimAws().logs();
+
+    logs.serviceWriter().write(logGroupName, logStreamName, ["first"]);
+
+    // When more lines are written to the same stream.
+    logs
+      .serviceWriter()
+      .write(logGroupName, logStreamName, ["second", "third"]);
+
+    // Then they join the ones already there rather than replacing them.
+    assertArrayEquals(messagesIn(logs), ["first", "second", "third"]);
+  });
+});

--- a/src/service/logs/write/sim-logs-service-writer.ts
+++ b/src/service/logs/write/sim-logs-service-writer.ts
@@ -1,0 +1,76 @@
+import type { SimClock } from "../../../util/clock/sim-clock.js";
+import type { SimLogsStoredEvent } from "../event/sim-logs-event.js";
+import type { SimLogsEventIds } from "../event/sim-logs-event-ids.js";
+import type { SimLogsLogGroupStore } from "../group/sim-logs-log-group-store.js";
+import type { SimLogsLogStream } from "../stream/sim-logs-log-stream.js";
+
+interface SimLogsServiceWriterProperties {
+  readonly groups: SimLogsLogGroupStore;
+  readonly eventIds: SimLogsEventIds;
+  readonly clock: SimClock;
+}
+
+/**
+ * How the rest of the simulation writes to a log group.
+ *
+ * This is not the CloudWatch Logs API. A simulated service writing its own
+ * logs is the account's own machinery rather than a caller making a request,
+ * so nothing here validates a batch, pages, or authorizes: real CloudWatch
+ * Logs does not put a Lambda function's own output through PutLogEvents
+ * either.
+ *
+ * Nothing here fails, and that is the point. A group or stream that is not
+ * there is made rather than refused, so deleting a log group mid-test does not
+ * take the next invocation down with it, which is what real Lambda does when
+ * its group has gone.
+ */
+export class SimLogsServiceWriter {
+  readonly #groups: SimLogsLogGroupStore;
+  readonly #eventIds: SimLogsEventIds;
+  readonly #clock: SimClock;
+
+  constructor(properties: SimLogsServiceWriterProperties) {
+    this.#groups = properties.groups;
+    this.#eventIds = properties.eventIds;
+    this.#clock = properties.clock;
+  }
+
+  /**
+   * Make sure a group and a stream in it both exist, without writing to them.
+   *
+   * A Lambda execution environment opens its stream as it cold starts, so a
+   * function that logged nothing still shows the stream its invocation ran in.
+   */
+  openStream(logGroupName: string, logStreamName: string): SimLogsLogStream {
+    const now = this.#clock.now().getTime();
+    const group = this.#groups.ensure(logGroupName, now);
+
+    return (
+      group.findStream(logStreamName) ?? group.createStream(logStreamName, now)
+    );
+  }
+
+  /**
+   * Append lines to a stream, as events timestamped now.
+   */
+  write(
+    logGroupName: string,
+    logStreamName: string,
+    lines: readonly string[],
+  ): void {
+    if (lines.length === 0) {
+      return;
+    }
+
+    const now = this.#clock.now().getTime();
+    const stream = this.openStream(logGroupName, logStreamName);
+    const events: readonly SimLogsStoredEvent[] = lines.map((message) => ({
+      eventId: this.#eventIds.next(),
+      timestamp: now,
+      ingestionTime: now,
+      message,
+    }));
+
+    stream.append(events, now);
+  }
+}


### PR DESCRIPTION
Brief, concise description of the change:

A zip-packaged Lambda function's handler output is now recorded into `/aws/lambda/<name>` as it runs, so a test asserts on what a handler logged by searching its log group with `FilterLogEvents` rather than by capturing process output. Recording sits on the sandbox's standard streams rather than on the console built over them, so a logger that builds its own `Console` over `process.stdout`, as AWS Lambda Powertools' does, is recorded too; one line becomes one event, a line written across two calls stays one event, and anything left unterminated is recorded when the invocation ends whether the handler returned or threw. Stream names now use the real `YYYY/MM/DD/[$LATEST]<hash>` format and `context.logGroupName` and `context.logStreamName` name the group and stream actually written to, replacing a synthesised stream name that matched no AWS format. Output still reaches the host streams as well, because a test tool that swallowed it would be harder to debug than one without any of this. Two deliberate divergences are documented rather than simulated: nothing authorizes on the write path, since a function whose Role lacks `logs:` permissions produces no logs in silence on real AWS and simulating that would leave nearly every function in a test logging nothing with no failure to explain why; and a function backed by a handler function reference is not recorded, because it is an ordinary function closing over the test's own module scope with no streams to tee, and intercepting it would mean patching a global the whole test run shares.

Resolves https://github.com/KensioSoftware/yulin/issues/607

- [x] Conventional commit message, used as the title

- [x] Conventional branch name, like `feat/concise-description`
- [x] Full check with `pnpm run check` passed
- [x] Rebased off latest main
- [x] User-facing behaviour is documented in `docs/`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Lambda handler output is now captured in simulated CloudWatch Logs for zip-packaged functions.
  * Logs support multi-line output, partial writes, invocation flushing, and host-console streaming.
  * Log groups and streams are created automatically with stable, documented names.
  * Added an example showing how to invoke a function and filter its error logs.

* **Documentation**
  * Clarified logging behavior, invocation context metadata, limitations, and differences between packaged and in-process handlers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->