### PR TITLE
feat: create AWS::Logs::LogGroup from a template

### DIFF
--- a/docs/services/cloudformation/README.md
+++ b/docs/services/cloudformation/README.md
@@ -2051,6 +2051,7 @@ The resource types it creates are:
 - `AWS::IAM::Role`, `AWS::IAM::ManagedPolicy` and `AWS::IAM::Policy`
 - `AWS::KMS::Key` and `AWS::KMS::Alias`
 - `AWS::Lambda::Function`, `AWS::Lambda::Url` and `AWS::Lambda::Permission`
+- `AWS::Logs::LogGroup`
 - `AWS::Route53::HostedZone`, `AWS::Route53::RecordSet`, `AWS::Route53::KeySigningKey` and
   `AWS::Route53::DNSSEC`
 - `AWS::S3::Bucket` and `AWS::S3::BucketPolicy`

--- a/docs/services/cloudformation/README.md
+++ b/docs/services/cloudformation/README.md
@@ -1335,8 +1335,10 @@ builds it as a singleton.
 
 None of those three do anything here. Yulin makes the copy itself, so the function is never invoked,
 the Layer it would have loaded the CLI from is never read, and nothing is ever written to the log
-group. They are reported in [`stack.inertResources`](#resources-deliberately-left-out) rather than
-as skipped resources, so a stack whose deployments all worked reports no gaps at all.
+group. The function and the Layer are reported in
+[`stack.inertResources`](#resources-deliberately-left-out) rather than as skipped resources, so a
+stack whose deployments all worked reports no gaps at all. The log group is created like any other,
+and stays empty, which is what an account is left with too.
 
 That matters beyond tidiness. Sim Lambda declines the provider on its Python runtime with a message
 saying to [bind a real in-process handler](#lambda-function-bindings) to the function, which is sound
@@ -1869,7 +1871,8 @@ Two things make a Resource inert. Its type can be one no simulated service reads
 - `AWS::CDK::Metadata`, the construct-library analytics CDK adds to every synthesized stack.
 
 Or the stack around it can: the provider Lambda function for a CDK custom resource the simulator
-carries out itself is inert, and so is that function's log group. See
+carries out itself is inert. Its log group is not, because log groups are created: an empty one is
+what an account is left with when nothing invokes the provider either. See
 [the provider CDK synthesizes](#the-provider-cdk-synthesizes).
 
 ## Properties a Resource was created without
@@ -2077,9 +2080,11 @@ Each service's own docs describe what its resource types support.
   `stack.inertResources` instead, and are listed under
   [resources deliberately left out](#resources-deliberately-left-out). Read both when accounting for
   every resource in a template.
-- `AWS::Logs::LogGroup` is not simulated. The one CDK writes for a custom resource provider is
-  reported as inert, because that provider is never invoked, but a log group a stack declares for
-  itself is skipped like any other unsupported resource type, and nothing simulated writes to it.
+- `AWS::Logs::LogGroup` is created, including the one CDK writes for a custom resource provider,
+  which is left empty because that provider is never invoked. A log group a stack declares for a
+  Lambda function is the same group that function writes to, and a group already there is taken over
+  rather than failing the deploy the way real CloudFormation does. See the
+  [simulated CloudWatch Logs docs](../logs/ "Simulated CloudWatch Logs usage docs").
 - A resource property that is not simulated is left out and recorded in `stack.ignoredProperties`
   rather than failing the stack, so the resource is created behaving differently to the one the
   template describes. See

--- a/docs/services/logs/README.md
+++ b/docs/services/logs/README.md
@@ -271,6 +271,40 @@ Nothing is authorized on this path. A real function needs `logs:CreateLogGroup` 
 Simulating that would mean nearly every function in a test logged nothing with no failure to explain
 why, so writing here is unconditional.
 
+## Declaring a log group in a template
+
+`AWS::Logs::LogGroup` is deployed by simulated CloudFormation, so a test can assert on the retention
+a stack gave a group rather than reading it off the template.
+
+```yaml
+OrdersLogs:
+  Type: AWS::Logs::LogGroup
+  Properties:
+    LogGroupName: /aws/lambda/orders
+    RetentionInDays: 14
+```
+
+`Ref` resolves to the log group name and `Fn::GetAtt Arn` to the ARN with its trailing `:*`, which is
+the form a policy has to name, so a template granting a function permission on its own log group
+gets a resource that reaches the streams inside it.
+
+`LogGroupName` and `RetentionInDays` are the two properties acted on. A `RetentionInDays` outside the
+set AWS accepts fails the deploy, which is the point: it would otherwise only be found on a real one.
+Everything else is recorded as an ignored property rather than refused, so a reader can see what a
+deployed group is not doing without a whole stack failing over a property that changes nothing about
+what the test asserts.
+
+Two divergences are worth knowing about:
+
+- **A group that already exists is taken over rather than refused.** Real CloudFormation fails a
+  deploy that declares a log group already in the account. That is a genuine misconfiguration there
+  and pure noise here, where a Lambda function that logged during test setup has already created
+  `/aws/lambda/orders`.
+- **An update replaces the group rather than changing it in place.** Simulated CloudFormation has no
+  in-place update at all: any resource whose template entry changed is deleted and created again. The
+  retention ends up correct, but the events the group held are gone, where a real update to
+  `RetentionInDays` keeps them.
+
 ## Permissions
 
 Every operation goes through simulated IAM. An operation on a named log group authorizes against
@@ -387,7 +421,8 @@ console.log(described.logGroups?.[0]?.logGroupArn);
 
 - **Nothing expires.** Retention is stored and reported, never acted on.
 - **Subscription filters and metric filters.** Neither exists yet, so nothing is delivered onward
-  from a log group and `metricFilterCount` is always zero.
+  from a log group and `metricFilterCount` is always zero. `AWS::Logs::LogGroup` is the only
+  CloudFormation resource type here; the others are recorded as gaps.
 - **Logs Insights, export tasks, tags, encryption and data protection policies.** Absent. Tags and
   `kmsKeyId` on `CreateLogGroup` are refused rather than dropped, so nothing looks set here and
   behaves differently in an account.

--- a/src/service/cloudformation/cdk/provider/sim-cdk-provider-scaffolding.iso.test.ts
+++ b/src/service/cloudformation/cdk/provider/sim-cdk-provider-scaffolding.iso.test.ts
@@ -34,9 +34,11 @@ describe("CDK custom Resource provider scaffolding [iso]", () => {
     assertArrayEquals(logicalIdsOf(stack.skippedResources), []);
 
     // And the Resources it stood in for are reported as deliberately left out.
+    // The provider's log group is not among them: simulated CloudWatch Logs
+    // creates it like any other, and an empty log group is what an account is
+    // left with when nothing invokes the function either.
     assertArrayEquals(logicalIdsOf(stack.inertResources), [
       "BucketDeploymentProvider",
-      "BucketDeploymentProviderLogGroup",
       "Deploy0AwsCliLayer",
       "Deploy1AwsCliLayer",
     ]);
@@ -46,16 +48,12 @@ describe("CDK custom Resource provider scaffolding [iso]", () => {
     // Given the same Stack.
     const stack = await deployScaffoldedStack();
 
-    // Then the provider function and its log group name the custom Resource
-    // this simulator carried out in their place, rather than telling the reader
-    // to bind a handler to a function nothing will ever invoke.
+    // Then the provider function names the custom Resource this simulator
+    // carried out in its place, rather than telling the reader to bind a
+    // handler to a function nothing will ever invoke.
     assertStringIncludes(
       stack.getResource("BucketDeploymentProvider")?.inertReason,
       "sim CloudFormation carries out Custom::CDKBucketDeployment itself",
-    );
-    assertStringIncludes(
-      stack.getResource("BucketDeploymentProviderLogGroup")?.inertReason,
-      "nothing is ever written to it",
     );
 
     // And a Layer says what it would take for one to start mattering, since it
@@ -66,7 +64,7 @@ describe("CDK custom Resource provider scaffolding [iso]", () => {
     );
   });
 
-  it("still reports a function and a log group of the reader's own as skipped", async () => {
+  it("still reports a function of the reader's own as skipped", async () => {
     // Given the same Stack with a Python function of the app's own beside the
     // scaffolding, and a log group for it.
     const stack = await deployScaffoldedStack({
@@ -100,12 +98,11 @@ describe("CDK custom Resource provider scaffolding [iso]", () => {
       },
     });
 
-    // Then those two are still gaps, because a test written against either of
-    // them would find it missing. Only the scaffolding is quietened.
-    assertArrayEquals(logicalIdsOf(stack.skippedResources), [
-      "Thumbnailer",
-      "ThumbnailerLogGroup",
-    ]);
+    // Then the Python function is still a gap, because a test written against
+    // it would find it missing. Its log group is not: that one deploys for
+    // real now, so a test can assert on the retention it was given even though
+    // nothing will ever write to it.
+    assertArrayEquals(logicalIdsOf(stack.skippedResources), ["Thumbnailer"]);
   });
 
   it("carries on past a hand-written deployment that names no provider", async () => {
@@ -130,7 +127,6 @@ describe("CDK custom Resource provider scaffolding [iso]", () => {
     assertArrayEquals(logicalIdsOf(stack.skippedResources), ["AlarmRule"]);
     assertArrayEquals(logicalIdsOf(stack.inertResources), [
       "BucketDeploymentProvider",
-      "BucketDeploymentProviderLogGroup",
       "Deploy0AwsCliLayer",
       "Deploy1AwsCliLayer",
     ]);

--- a/src/service/cloudformation/cdk/provider/sim-cdk-provider-scaffolding.loc.test.ts
+++ b/src/service/cloudformation/cdk/provider/sim-cdk-provider-scaffolding.loc.test.ts
@@ -79,14 +79,16 @@ app.synth();
 
     // And nothing is reported as a gap. The provider CDK synthesized to do that
     // copying is reported as deliberately left out instead, along with the AWS
-    // CLI Layer each construct brings and the provider's log group.
+    // CLI Layer each construct brings. Its log group is not among them:
+    // simulated CloudWatch Logs creates that like any other, and an empty log
+    // group is what an account is left with when nothing invokes the provider
+    // either.
     assertArrayEquals(resourceTypesOf(stack.skippedResources), []);
     assertArrayEquals(resourceTypesOf(stack.inertResources), [
       "AWS::CDK::Metadata",
       "AWS::Lambda::Function",
       "AWS::Lambda::LayerVersion",
       "AWS::Lambda::LayerVersion",
-      "AWS::Logs::LogGroup",
     ]);
   });
 });

--- a/src/service/cloudformation/cdk/provider/sim-cdk-provider-scaffolding.ts
+++ b/src/service/cloudformation/cdk/provider/sim-cdk-provider-scaffolding.ts
@@ -4,7 +4,6 @@ import { parseSimCfnNode } from "../../template/parse/node/sim-cfn-node-parser.j
 
 const customResourceTypePrefix = "Custom::";
 const lambdaFunctionResourceType = "AWS::Lambda::Function";
-const logGroupResourceType = "AWS::Logs::LogGroup";
 
 /**
  * The Resources in a Stack that exist only to run a CDK custom Resource sim
@@ -14,8 +13,14 @@ const logGroupResourceType = "AWS::Logs::LogGroup";
  * `Custom::` Resource and a Lambda function to answer it. Where this simulator
  * creates that custom Resource directly, as it does for `BucketDeployment` and
  * Bucket notifications, the function is left holding nothing: it is never
- * invoked, so its code is never loaded and its log group never written to. The
- * work is already done by the time anything would have called it.
+ * invoked and its code is never loaded. The work is already done by the time
+ * anything would have called it.
+ *
+ * Only the function is recognised here. A newer CDK writes the provider's log
+ * group into the template too, and simulated CloudWatch Logs creates that like
+ * any other log group: an empty log group is exactly what an account is left
+ * with when nothing invokes the function, so creating it says more than
+ * reporting it as deliberately left out ever did.
  *
  * That makes the function and its log group Resources no test can tell apart
  * from ones that were created, which is the same reason a Resource type nothing
@@ -44,10 +49,7 @@ export class SimCdkProviderScaffolding {
    * already carried out, or undefined when it is not.
    */
   reasonFor(resource: SimCfnResource): string | undefined {
-    return (
-      this.providerFunctionReason(resource) ??
-      this.providerLogGroupReason(resource)
-    );
+    return this.providerFunctionReason(resource);
   }
 
   /**
@@ -63,35 +65,6 @@ export class SimCdkProviderScaffolding {
     return (
       `sim CloudFormation carries out ${customResourceType} itself, so CDK's ` +
       `provider function for it is never invoked`
-    );
-  }
-
-  /**
-   * The Resource is the log group of a provider function.
-   *
-   * A newer CDK writes the provider function's log group into the template
-   * rather than leaving Lambda to create it, and names the function in it, so
-   * the same association finds it. Only a log group is looked for this way: the
-   * provider's IAM Role and Policy name it too, and those this simulator
-   * creates for real.
-   */
-  private providerLogGroupReason(resource: SimCfnResource): string | undefined {
-    if (resource.type !== logGroupResourceType) {
-      return undefined;
-    }
-
-    const customResourceType = resource
-      .dependencies()
-      .map((logicalId) => this.#providerFunctions.get(logicalId))
-      .find((found) => found !== undefined);
-
-    if (customResourceType === undefined) {
-      return undefined;
-    }
-
-    return (
-      `the log group of CDK's ${customResourceType} provider function, which ` +
-      `sim CloudFormation never invokes, so nothing is ever written to it`
     );
   }
 

--- a/src/service/cloudformation/resource/cfn/logs/sim-logs-cfn-value-adapter.ts
+++ b/src/service/cloudformation/resource/cfn/logs/sim-logs-cfn-value-adapter.ts
@@ -1,0 +1,23 @@
+import { SimLogsLogGroup } from "../../../../logs/group/sim-logs-log-group.js";
+import type {
+  SimCfnResourceValueAdapterProperties,
+  SimCfnServiceValueAdapter,
+} from "../sim-cfn-resource-value-adapter.js";
+import { SimLogsLogGroupCfn } from "./sim-logs-log-group-cfn.js";
+
+/**
+ * The CloudFormation-facing value adapter for a simulated CloudWatch Logs
+ * Resource.
+ */
+export function logsValueAdapter(
+  properties: SimCfnResourceValueAdapterProperties,
+): SimCfnServiceValueAdapter {
+  if (
+    properties.type === "AWS::Logs::LogGroup" &&
+    properties.simResource instanceof SimLogsLogGroup
+  ) {
+    return new SimLogsLogGroupCfn({ group: properties.simResource });
+  }
+
+  return undefined;
+}

--- a/src/service/cloudformation/resource/cfn/logs/sim-logs-log-group-cfn.ts
+++ b/src/service/cloudformation/resource/cfn/logs/sim-logs-log-group-cfn.ts
@@ -1,0 +1,44 @@
+import type { SimLogsLogGroup } from "../../../../logs/group/sim-logs-log-group.js";
+import type { SimCfnTemplateValue } from "../../../template/value/sim-cfn-template-value.js";
+import type { SimCfnResourceValueAdapter } from "../sim-cfn-resource-value-adapter.js";
+
+interface SimLogsLogGroupCfnProperties {
+  readonly group: SimLogsLogGroup;
+}
+
+/**
+ * CloudFormation-facing values for a simulated CloudWatch Logs log group.
+ */
+export class SimLogsLogGroupCfn implements SimCfnResourceValueAdapter {
+  readonly #group: SimLogsLogGroup;
+
+  constructor(properties: SimLogsLogGroupCfnProperties) {
+    this.#group = properties.group;
+  }
+
+  /**
+   * AWS::Logs::LogGroup Ref returns the log group name.
+   */
+  refValue(): SimCfnTemplateValue {
+    return this.#group.logGroupName;
+  }
+
+  /**
+   * AWS::Logs::LogGroup attributes.
+   *
+   * The ARN carries the trailing `:*` that covers the streams inside the
+   * group, which is the form CloudFormation returns and the form a policy is
+   * written against. A template granting a function permission on its own log
+   * group through `Fn::GetAtt` therefore gets a resource that reaches the
+   * streams, which is what makes the grant work.
+   */
+  attributeValue(attributeName: string): SimCfnTemplateValue {
+    if (attributeName === "Arn") {
+      return this.#group.arn;
+    }
+
+    throw new Error(
+      `Unsupported AWS::Logs::LogGroup attribute ${attributeName}`,
+    );
+  }
+}

--- a/src/service/cloudformation/resource/cfn/sim-cfn-resource-value-adapter.ts
+++ b/src/service/cloudformation/resource/cfn/sim-cfn-resource-value-adapter.ts
@@ -1,24 +1,6 @@
 import type { SimCfnTemplateValue } from "../../template/value/sim-cfn-template-value.js";
-import { acmValueAdapter } from "./acm/sim-acm-cfn-value-adapter.js";
-import { apiGatewayV2ValueAdapter } from "./apigatewayv2/sim-api-gateway-v2-cfn-value-adapter.js";
-import { cloudFrontValueAdapter } from "./cloudfront/sim-cloudfront-cfn-value-adapter.js";
-import { cognitoValueAdapter } from "./cognito/sim-cognito-cfn-value-adapter.js";
-import { dynamoDbValueAdapter } from "./dynamodb/sim-dynamodb-cfn-value-adapter.js";
-import { ecrValueAdapter } from "./ecr/sim-ecr-cfn-value-adapter.js";
-import { ecsValueAdapter } from "./ecs/sim-ecs-cfn-value-adapter.js";
-import { elbV2ValueAdapter } from "./elasticloadbalancingv2/sim-elbv2-cfn-value-adapter.js";
-import { eventBridgeValueAdapter } from "./events/sim-event-bridge-cfn-value-adapter.js";
-import { iamValueAdapter } from "./iam/sim-iam-cfn-value-adapter.js";
-import { kmsValueAdapter } from "./kms/sim-kms-cfn-value-adapter.js";
-import { lambdaValueAdapter } from "./lambda/sim-lambda-cfn-value-adapter.js";
-import { route53ValueAdapter } from "./route53/sim-route53-cfn-value-adapter.js";
-import { s3ValueAdapter } from "./s3/sim-s3-cfn-value-adapter.js";
-import { schedulerValueAdapter } from "./scheduler/sim-scheduler-cfn-value-adapter.js";
-import { secretsManagerValueAdapter } from "./secretsmanager/sim-secrets-manager-cfn-value-adapter.js";
-import { snsValueAdapter } from "./sns/sim-sns-cfn-value-adapter.js";
-import { sqsValueAdapter } from "./sqs/sim-sqs-cfn-value-adapter.js";
-import { ssmValueAdapter } from "./ssm/sim-ssm-cfn-value-adapter.js";
 import { SimCfnDefaultResourceValueAdapter } from "./sim-cfn-default-resource-value-adapter.js";
+import { simCfnServiceValueAdapters } from "./sim-cfn-service-value-adapters.js";
 
 export interface SimCfnResourceValueAdapter {
   refValue(): SimCfnTemplateValue;
@@ -53,28 +35,15 @@ export type SimCfnServiceValueAdapter = SimCfnResourceValueAdapter | undefined;
 export function simCfnResourceValueAdapter(
   properties: SimCfnResourceValueAdapterProperties,
 ): SimCfnResourceValueAdapter {
-  return (
-    acmValueAdapter(properties) ??
-    apiGatewayV2ValueAdapter(properties) ??
-    cloudFrontValueAdapter(properties) ??
-    cognitoValueAdapter(properties) ??
-    dynamoDbValueAdapter(properties) ??
-    ecrValueAdapter(properties) ??
-    ecsValueAdapter(properties) ??
-    elbV2ValueAdapter(properties) ??
-    eventBridgeValueAdapter(properties) ??
-    iamValueAdapter(properties) ??
-    kmsValueAdapter(properties) ??
-    lambdaValueAdapter(properties) ??
-    route53ValueAdapter(properties) ??
-    s3ValueAdapter(properties) ??
-    schedulerValueAdapter(properties) ??
-    secretsManagerValueAdapter(properties) ??
-    snsValueAdapter(properties) ??
-    sqsValueAdapter(properties) ??
-    ssmValueAdapter(properties) ??
-    new SimCfnDefaultResourceValueAdapter({
-      logicalId: properties.logicalId,
-    })
-  );
+  for (const serviceAdapter of simCfnServiceValueAdapters) {
+    const adapter = serviceAdapter(properties);
+
+    if (adapter !== undefined) {
+      return adapter;
+    }
+  }
+
+  return new SimCfnDefaultResourceValueAdapter({
+    logicalId: properties.logicalId,
+  });
 }

--- a/src/service/cloudformation/resource/cfn/sim-cfn-service-value-adapters.ts
+++ b/src/service/cloudformation/resource/cfn/sim-cfn-service-value-adapters.ts
@@ -1,0 +1,58 @@
+import { acmValueAdapter } from "./acm/sim-acm-cfn-value-adapter.js";
+import { apiGatewayV2ValueAdapter } from "./apigatewayv2/sim-api-gateway-v2-cfn-value-adapter.js";
+import { cloudFrontValueAdapter } from "./cloudfront/sim-cloudfront-cfn-value-adapter.js";
+import { cognitoValueAdapter } from "./cognito/sim-cognito-cfn-value-adapter.js";
+import { dynamoDbValueAdapter } from "./dynamodb/sim-dynamodb-cfn-value-adapter.js";
+import { ecrValueAdapter } from "./ecr/sim-ecr-cfn-value-adapter.js";
+import { logsValueAdapter } from "./logs/sim-logs-cfn-value-adapter.js";
+import { ecsValueAdapter } from "./ecs/sim-ecs-cfn-value-adapter.js";
+import { elbV2ValueAdapter } from "./elasticloadbalancingv2/sim-elbv2-cfn-value-adapter.js";
+import { eventBridgeValueAdapter } from "./events/sim-event-bridge-cfn-value-adapter.js";
+import { iamValueAdapter } from "./iam/sim-iam-cfn-value-adapter.js";
+import { kmsValueAdapter } from "./kms/sim-kms-cfn-value-adapter.js";
+import { lambdaValueAdapter } from "./lambda/sim-lambda-cfn-value-adapter.js";
+import { route53ValueAdapter } from "./route53/sim-route53-cfn-value-adapter.js";
+import { s3ValueAdapter } from "./s3/sim-s3-cfn-value-adapter.js";
+import { schedulerValueAdapter } from "./scheduler/sim-scheduler-cfn-value-adapter.js";
+import { secretsManagerValueAdapter } from "./secretsmanager/sim-secrets-manager-cfn-value-adapter.js";
+import { snsValueAdapter } from "./sns/sim-sns-cfn-value-adapter.js";
+import { sqsValueAdapter } from "./sqs/sim-sqs-cfn-value-adapter.js";
+import { ssmValueAdapter } from "./ssm/sim-ssm-cfn-value-adapter.js";
+import type {
+  SimCfnResourceValueAdapterProperties,
+  SimCfnServiceValueAdapter,
+} from "./sim-cfn-resource-value-adapter.js";
+
+/**
+ * Every service that claims Resource types of its own, in the order they are
+ * asked.
+ *
+ * A list rather than a chain of `??`. Each entry is the same one-line
+ * delegation and the list only grows, so a chain over it became the most
+ * complex expression in the CloudFormation engine without saying anything a
+ * list does not, in the same way the service Resource factories are a map.
+ */
+export const simCfnServiceValueAdapters: readonly ((
+  properties: SimCfnResourceValueAdapterProperties,
+) => SimCfnServiceValueAdapter)[] = [
+  acmValueAdapter,
+  apiGatewayV2ValueAdapter,
+  cloudFrontValueAdapter,
+  cognitoValueAdapter,
+  dynamoDbValueAdapter,
+  ecrValueAdapter,
+  logsValueAdapter,
+  ecsValueAdapter,
+  elbV2ValueAdapter,
+  eventBridgeValueAdapter,
+  iamValueAdapter,
+  kmsValueAdapter,
+  lambdaValueAdapter,
+  route53ValueAdapter,
+  s3ValueAdapter,
+  schedulerValueAdapter,
+  secretsManagerValueAdapter,
+  snsValueAdapter,
+  sqsValueAdapter,
+  ssmValueAdapter,
+];

--- a/src/service/cloudformation/resource/resolve/service/sim-cfn-service-factories.ts
+++ b/src/service/cloudformation/resource/resolve/service/sim-cfn-service-factories.ts
@@ -90,6 +90,11 @@ export const simCfnServiceResourceFactories: ReadonlyMap<
       scopedAws.lambda().cfnResourceFactory(),
   ],
   [
+    "Logs",
+    (scopedAws): SimCfnServiceResourceFactory =>
+      scopedAws.logs().cfnResourceFactory(),
+  ],
+  [
     "Route53",
     (scopedAws): SimCfnServiceResourceFactory =>
       scopedAws.route53().cfnResourceFactory(),

--- a/src/service/logs/README.md
+++ b/src/service/logs/README.md
@@ -99,6 +99,25 @@ knows to keep it and ask again.
 than dropping them, following the same rule as the rest of the simulator: something accepted and
 ignored here would be applied in an account.
 
+## CloudFormation
+
+`cfn/` creates `AWS::Logs::LogGroup` from a template, following the shape every other service's
+resource factory has. `SimCfnLogGroupProperties` reads the two properties this simulation acts on
+and `SimCfnLogGroupPropertyRules` records the rest, so a reader can tell a real property this
+simulation chose not to act on from one CloudWatch Logs has never had.
+
+Creation goes through the service writer rather than the command layer, which is what makes a
+declared group and one a Lambda function made for itself the same thing. Real CloudFormation fails a
+deploy that declares a group already in the account; here that is the ordinary case, because a
+function that logged during test setup has already created `/aws/lambda/orders`.
+
+Registering the service had one consequence worth recording. `SimCdkProviderScaffolding` used to
+recognise a CDK provider function's log group and report it as deliberately left out, because
+nothing simulated log groups and reporting it as a gap would have read as a missing feature. Now
+that log groups are created, that branch is gone: a Resource type a service creates is created, and
+an empty log group is exactly what an account is left with when nothing invokes the provider
+function either.
+
 ## Writing from the rest of the simulation
 
 `SimLogsServiceWriter`, under `write/`, is how a simulated service records its own output. It is

--- a/src/service/logs/cfn/group/sim-cfn-log-group-creator.ts
+++ b/src/service/logs/cfn/group/sim-cfn-log-group-creator.ts
@@ -1,0 +1,60 @@
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimLogsLogGroup } from "../../group/sim-logs-log-group.js";
+import type { SimLogs } from "../../sim-logs.js";
+import { SimCfnLogGroupProperties } from "./sim-cfn-log-group-properties.js";
+
+interface SimCfnLogGroupCreatorProperties {
+  readonly logs: SimLogs;
+}
+
+/**
+ * Creates simulated log groups from AWS::Logs::LogGroup Resources.
+ *
+ * A declared log group and one a Lambda function made for itself are the same
+ * thing, which is why creating one that is already there is not an error here
+ * the way `CreateLogGroup` is. A template naming `/aws/lambda/orders` is
+ * usually saying what retention that function's logs should have, and it is
+ * ordinary for the function to have logged first: real CloudFormation fails
+ * that deploy, which is a genuine misconfiguration in an account and pure
+ * noise in a test whose function ran during setup.
+ */
+export class SimCfnLogGroupCreator {
+  readonly #logs: SimLogs;
+
+  constructor(properties: SimCfnLogGroupCreatorProperties) {
+    this.#logs = properties.logs;
+  }
+
+  /**
+   * Create a log group from an AWS::Logs::LogGroup Resource.
+   */
+  create(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): SimLogsLogGroup {
+    const logGroupProperties = new SimCfnLogGroupProperties({
+      resource,
+      properties,
+    });
+    const logGroupName = logGroupProperties.logGroupName();
+    const retentionInDays = logGroupProperties.retentionInDays();
+
+    logGroupProperties.recordIgnoredProperties();
+
+    const group = this.#logs.serviceWriter().logGroup(logGroupName);
+
+    group.setRetention(retentionInDays);
+
+    return group;
+  }
+
+  /**
+   * Delete a log group created from an AWS::Logs::LogGroup Resource.
+   *
+   * The events go with it, as they do in an account.
+   */
+  delete(group: SimLogsLogGroup): void {
+    this.#logs.serviceWriter().deleteLogGroup(group.logGroupName);
+  }
+}

--- a/src/service/logs/cfn/group/sim-cfn-log-group-properties.ts
+++ b/src/service/logs/cfn/group/sim-cfn-log-group-properties.ts
@@ -1,0 +1,103 @@
+import { SimCfnGeneratedResourceName } from "../../../cloudformation/resource/name/sim-cfn-generated-resource-name.js";
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import { requiredSimLogsRetentionDays } from "../../group/sim-logs-retention.js";
+import { SimCfnLogGroupPropertyRules } from "./sim-cfn-log-group-property-rules.js";
+
+const maximumNameLength = 512;
+
+/**
+ * A refusal naming the Resource whose properties could not be read.
+ */
+export function logGroupPropertyError(
+  logicalId: string,
+  reason: string,
+): Error {
+  return new Error(
+    `Invalid sim CloudWatch Logs CloudFormation Resource ${logicalId}: ${reason}`,
+  );
+}
+
+interface SimCfnLogGroupPropertiesProperties {
+  readonly resource: SimCfnResource;
+  readonly properties: SimCfnTemplateValueRecord;
+}
+
+/**
+ * Reads AWS::Logs::LogGroup CloudFormation properties.
+ */
+export class SimCfnLogGroupProperties {
+  readonly #resource: SimCfnResource;
+  readonly #properties: SimCfnTemplateValueRecord;
+  readonly #rules: SimCfnLogGroupPropertyRules;
+
+  constructor(properties: SimCfnLogGroupPropertiesProperties) {
+    this.#resource = properties.resource;
+    this.#properties = properties.properties;
+    this.#rules = new SimCfnLogGroupPropertyRules({
+      properties: properties.properties,
+      ignorer: properties.resource,
+    });
+  }
+
+  /**
+   * The log group name.
+   *
+   * An unnamed log group is named after the stack and the logical ID, as real
+   * CloudFormation names one. Nothing lower cases it, unlike a repository
+   * name: a log group name keeps whatever case it was given.
+   */
+  logGroupName(): string {
+    const name = this.#properties["LogGroupName"];
+
+    if (name === undefined) {
+      return new SimCfnGeneratedResourceName({
+        stackName: this.#resource.stackName,
+        logicalId: this.#resource.logicalId,
+        maximumLength: maximumNameLength,
+      }).value;
+    }
+
+    if (typeof name !== "string") {
+      throw logGroupPropertyError(
+        this.#resource.logicalId,
+        "LogGroupName must be a string",
+      );
+    }
+
+    return name;
+  }
+
+  /**
+   * How long the log group keeps its events, or undefined where the template
+   * sets no retention and they are kept forever.
+   *
+   * A value outside the set real CloudWatch Logs accepts fails the Resource.
+   * That is the mistake this property exists to catch: `RetentionInDays: 10`
+   * looks reasonable, is refused by an account, and would otherwise only be
+   * found on a real deploy.
+   */
+  retentionInDays(): number | undefined {
+    const retention = this.#properties["RetentionInDays"];
+
+    if (retention === undefined) {
+      return undefined;
+    }
+
+    if (typeof retention !== "number") {
+      throw logGroupPropertyError(
+        this.#resource.logicalId,
+        "RetentionInDays must be a number",
+      );
+    }
+
+    return requiredSimLogsRetentionDays(retention);
+  }
+
+  /**
+   * Record the properties the log group is created without acting on.
+   */
+  recordIgnoredProperties(): void {
+    this.#rules.apply();
+  }
+}

--- a/src/service/logs/cfn/group/sim-cfn-log-group-property-rules.ts
+++ b/src/service/logs/cfn/group/sim-cfn-log-group-property-rules.ts
@@ -1,0 +1,62 @@
+import type { SimCfnPropertyIgnorer } from "../../../cloudformation/resource/ignore/sim-cfn-ignored-property.type.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import { unsimulatedPropertyReasons } from "./sim-cfn-log-group-unsimulated-properties.js";
+
+/** The properties a log group Resource is actually created from. */
+const actedOnProperties = new Set(["LogGroupName", "RetentionInDays"]);
+
+interface SimCfnLogGroupPropertyRulesProperties {
+  readonly properties: SimCfnTemplateValueRecord;
+  readonly ignorer: SimCfnPropertyIgnorer;
+}
+
+/**
+ * What a log group Resource is created without acting on.
+ *
+ * The name and the retention are the two properties this simulation reads,
+ * because they are the two a test asserts on. Everything else, whether
+ * CloudWatch Logs has it or not, is recorded so a reader can see what a
+ * deployed log group is not doing.
+ */
+export class SimCfnLogGroupPropertyRules {
+  readonly #properties: SimCfnTemplateValueRecord;
+  readonly #ignorer: SimCfnPropertyIgnorer;
+
+  constructor(properties: SimCfnLogGroupPropertyRulesProperties) {
+    this.#properties = properties.properties;
+    this.#ignorer = properties.ignorer;
+  }
+
+  /**
+   * Record every property the log group is created without.
+   */
+  apply(): void {
+    for (const name of Object.keys(this.#properties)) {
+      this.applyToProperty(name);
+    }
+  }
+
+  private applyToProperty(name: string): void {
+    if (actedOnProperties.has(name)) {
+      return;
+    }
+
+    const unsimulatedReason = unsimulatedPropertyReasons.get(name);
+
+    if (unsimulatedReason === undefined) {
+      this.#ignorer.ignoreProperty(
+        name,
+        `${name} is not a property simulated CloudWatch Logs knows about, so ` +
+          `the log group is created without it`,
+      );
+
+      return;
+    }
+
+    this.#ignorer.ignoreProperty(
+      name,
+      `${name} is a real AWS::Logs::LogGroup property simulated CloudWatch ` +
+        `Logs does not act on: ${unsimulatedReason}`,
+    );
+  }
+}

--- a/src/service/logs/cfn/group/sim-cfn-log-group-unsimulated-properties.ts
+++ b/src/service/logs/cfn/group/sim-cfn-log-group-unsimulated-properties.ts
@@ -1,0 +1,37 @@
+/**
+ * The AWS::Logs::LogGroup properties this simulation has nothing to act on,
+ * and why.
+ *
+ * They are recorded as ignored rather than refused, because a log group
+ * without any of them still does the one thing a log group does here: hold the
+ * events written to it, under a name and with a retention a test can assert
+ * on. Refusing would take a whole stack down over a property that changes
+ * nothing about what the test is checking.
+ */
+export const unsimulatedPropertyReasons: ReadonlyMap<string, string> = new Map([
+  [
+    "KmsKeyId",
+    "log group encryption is not simulated, so events are held in this " +
+      "process either way and no key is ever used",
+  ],
+  [
+    "DataProtectionPolicy",
+    "data protection is not simulated, so nothing masks or audits a value an " +
+      "event carries",
+  ],
+  [
+    "FieldIndexPolicies",
+    "field indexes only change how Logs Insights queries are served, and " +
+      "there are no Logs Insights queries here",
+  ],
+  [
+    "Tags",
+    "log group tags are not simulated, so nothing reads them back and " +
+      "nothing is billed or grouped by them",
+  ],
+  [
+    "LogGroupClass",
+    "only the standard class is simulated, which is what every operation " +
+      "here behaves as",
+  ],
+]);

--- a/src/service/logs/cfn/sim-cfn-log-group.iso.test.ts
+++ b/src/service/logs/cfn/sim-cfn-log-group.iso.test.ts
@@ -1,0 +1,338 @@
+import {
+  DeleteStackCommand,
+  UpdateStackCommand,
+} from "@aws-sdk/client-cloudformation";
+import { DescribeLogGroupsCommand } from "@aws-sdk/client-cloudwatch-logs";
+import {
+  assertArrayEquals,
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertTypeString,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import type { SimCfnTemplateValueRecord } from "../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimCfnStack } from "../../cloudformation/stack/sim-cfn-stack.js";
+import { SimAws } from "../../aws/sim-aws.js";
+import { jsonStringify } from "../../../util/type-guard/json.js";
+
+const logGroupName = "/aws/lambda/orders";
+
+async function deployLogGroup(
+  properties: SimCfnTemplateValueRecord,
+  simAws: SimAws = new SimAws(),
+): Promise<{ readonly simAws: SimAws; readonly stack: SimCfnStack }> {
+  const stack = await simAws.cloudFormation().deployTemplate({
+    stackName: "orders",
+    template: {
+      Resources: {
+        OrdersLogs: { Type: "AWS::Logs::LogGroup", Properties: properties },
+      },
+      Outputs: {
+        GroupName: { Value: { Ref: "OrdersLogs" } },
+        GroupArn: { Value: { "Fn::GetAtt": ["OrdersLogs", "Arn"] } },
+      },
+    },
+  });
+
+  return { simAws, stack };
+}
+
+describe("AWS::Logs::LogGroup", () => {
+  it("creates a log group a template declares", async () => {
+    // Given a template declaring a log group with retention.
+    const { simAws } = await deployLogGroup({
+      LogGroupName: logGroupName,
+      RetentionInDays: 14,
+    });
+
+    // When the log groups are described.
+    const described = await simAws
+      .logs()
+      .describeLogGroups(new DescribeLogGroupsCommand({}));
+    const group = described.logGroups?.at(0);
+
+    // Then it is there, with the retention the template asked for, which is
+    // the property worth asserting on: a group deployed with the wrong one
+    // costs money quietly for years.
+    assertNonNullable(group);
+    assertIdentical(group.logGroupName, logGroupName);
+    assertIdentical(group.retentionInDays, 14);
+  });
+
+  it("keeps events forever where the template sets no retention", async () => {
+    // Given a template declaring a log group and nothing else.
+    const { simAws } = await deployLogGroup({ LogGroupName: logGroupName });
+
+    // Then it has no retention at all, which is the AWS default.
+    assertUndefined(simAws.logs().findLogGroup(logGroupName)?.retentionInDays);
+  });
+
+  it("names an unnamed log group after the stack and logical ID", async () => {
+    // Given a template that declares a log group without naming it.
+    const { simAws } = await deployLogGroup({ RetentionInDays: 7 });
+
+    // Then CloudFormation named it, as real CloudFormation does.
+    const groups = simAws.logs().allLogGroups();
+
+    assertArrayLength(groups, 1);
+    assertStringIncludes(groups.at(0)?.logGroupName ?? "", "orders");
+    assertStringIncludes(groups.at(0)?.logGroupName ?? "", "OrdersLogs");
+  });
+
+  it("resolves Ref to the name and Fn::GetAtt Arn to the policy ARN", async () => {
+    // Given a template whose outputs name the log group both ways.
+    const { stack } = await deployLogGroup({
+      LogGroupName: logGroupName,
+      RetentionInDays: 30,
+    });
+
+    // Then Ref is the name, and the ARN carries the trailing wildcard that
+    // covers the streams inside, which is what a policy has to name.
+    const groupArn = stack.outputs.get("GroupArn")?.value;
+
+    assertIdentical(stack.outputs.get("GroupName")?.value, logGroupName);
+    assertTypeString(groupArn);
+    assertStringIncludes(groupArn, `:log-group:${logGroupName}:*`);
+  });
+
+  it("refuses a retention period real CloudWatch Logs would refuse", async () => {
+    // Given a template asking for a reasonable-looking retention outside the
+    // set AWS accepts.
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await deployLogGroup({
+          LogGroupName: logGroupName,
+          RetentionInDays: 10,
+        }),
+    );
+
+    // Then the deploy fails here rather than on a real one later.
+    assertStringIncludes(error.message, "retentionInDays");
+  });
+
+  it("refuses properties whose types the template got wrong", async () => {
+    // Given templates giving the two properties this simulation reads values
+    // of the wrong type.
+    const name = await assertThrowsErrorAsync(
+      async () => await deployLogGroup({ LogGroupName: { Ref: "Nothing" } }),
+    );
+    const retention = await assertThrowsErrorAsync(
+      async () =>
+        await deployLogGroup({
+          LogGroupName: logGroupName,
+          RetentionInDays: "14",
+        }),
+    );
+
+    // Then each says which property was wrong rather than deploying a group
+    // named or kept for something other than what the template said.
+    assertStringIncludes(name.message, "LogGroupName must be a string");
+    assertStringIncludes(retention.message, "RetentionInDays must be a number");
+  });
+
+  it("records a property CloudWatch Logs has never had", async () => {
+    // Given a template setting something that is not a log group property at
+    // all, as a hand-written template can.
+    const { stack } = await deployLogGroup({
+      LogGroupName: logGroupName,
+      Nonsense: true,
+    });
+
+    // Then it is recorded as unknown rather than as a real property this
+    // simulation chose not to act on, which are different things to a reader.
+    const ignored = stack
+      .getResource("OrdersLogs")
+      ?.ignoredProperties.find((property) => property.path === "Nonsense");
+
+    assertNonNullable(ignored);
+    assertStringIncludes(ignored.reason, "not a property simulated");
+  });
+
+  it("reports a CloudWatch Logs Resource type it does not simulate", async () => {
+    // Given a template declaring a log group and a subscription filter, which
+    // this simulation has no machinery for yet.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders",
+      template: {
+        Resources: {
+          OrdersLogs: {
+            Type: "AWS::Logs::LogGroup",
+            Properties: { LogGroupName: logGroupName },
+          },
+          OrdersFilter: {
+            Type: "AWS::Logs::SubscriptionFilter",
+            Properties: { LogGroupName: logGroupName, FilterPattern: "ERROR" },
+          },
+        },
+      },
+    });
+
+    // Then the group deploys and the filter is recorded as a gap, rather than
+    // the whole stack failing over the one Resource type that is missing.
+    assertNonNullable(simAws.logs().findLogGroup(logGroupName));
+    assertArrayEquals(
+      stack.skippedResources.map((resource) => resource.logicalId),
+      ["OrdersFilter"],
+    );
+  });
+
+  it("refuses a CloudWatch Logs Resource type it does not simulate", async () => {
+    // Given the CloudWatch Logs Resource factory.
+    const factory = new SimAws().logs().cfnResourceFactory();
+
+    // When a Resource type this simulation has none for is created or deleted.
+    const created = await assertThrowsErrorAsync(async () =>
+      factory.create("MetricFilter", {} as never, {} as never),
+    );
+    const deleted = await assertThrowsErrorAsync(async () =>
+      factory.delete("MetricFilter", {} as never),
+    );
+
+    // Then both are reported as unsupported, which the Stack records as a
+    // skip rather than a failure.
+    assertIdentical(
+      created.message,
+      "Unsupported sim CloudWatch Logs CloudFormation Resource MetricFilter",
+    );
+    assertIdentical(
+      deleted.message,
+      "Unsupported sim CloudWatch Logs CloudFormation Resource MetricFilter " +
+        "deletion",
+    );
+  });
+
+  it("refuses a log group attribute CloudFormation does not have", async () => {
+    // Given a template reading an attribute off the log group that
+    // AWS::Logs::LogGroup does not publish.
+    const error = await assertThrowsErrorAsync(async () => {
+      await new SimAws().cloudFormation().deployTemplate({
+        stackName: "orders",
+        template: {
+          Resources: {
+            OrdersLogs: {
+              Type: "AWS::Logs::LogGroup",
+              Properties: { LogGroupName: logGroupName },
+            },
+          },
+          Outputs: {
+            Retention: {
+              Value: { "Fn::GetAtt": ["OrdersLogs", "RetentionInDays"] },
+            },
+          },
+        },
+      });
+    });
+
+    // Then it says which attribute, rather than resolving to nothing and
+    // leaving an Output that quietly says undefined.
+    assertStringIncludes(
+      error.message,
+      "Unsupported AWS::Logs::LogGroup attribute RetentionInDays",
+    );
+  });
+
+  it("takes over a log group a function already made for itself", async () => {
+    // Given a log group a Lambda function created by logging during setup.
+    const simAws = new SimAws();
+
+    simAws.logs().serviceWriter().write(logGroupName, "stream-a", ["ran"]);
+
+    // When a template declaring that same group is deployed.
+    await deployLogGroup(
+      { LogGroupName: logGroupName, RetentionInDays: 14 },
+      simAws,
+    );
+
+    // Then the deploy sets its retention rather than failing over a group that
+    // is already there. Real CloudFormation fails that deploy, which is a
+    // genuine misconfiguration in an account and pure noise in a test whose
+    // function ran first.
+    const group = simAws.logs().findLogGroup(logGroupName);
+
+    assertNonNullable(group);
+    assertIdentical(group.retentionInDays, 14);
+    assertArrayEquals(
+      group.findStream("stream-a")?.events.map((event) => event.message),
+      ["ran"],
+    );
+  });
+
+  it("records the properties it does not act on", async () => {
+    // Given a template setting properties this simulation has nothing to do.
+    const { stack } = await deployLogGroup({
+      LogGroupName: logGroupName,
+      KmsKeyId: "alias/logs",
+      Tags: [{ Key: "team", Value: "platform" }],
+    });
+
+    // Then the group is deployed and a reader can see what it is not doing,
+    // rather than the whole stack failing over a property that changes nothing
+    // about what a test asserts.
+    const resource = stack.getResource("OrdersLogs");
+
+    assertNonNullable(resource);
+    assertArrayEquals(
+      resource.ignoredProperties
+        .map((ignored) => ignored.path)
+        .toSorted((left, right) => left.localeCompare(right)),
+      ["KmsKeyId", "Tags"],
+    );
+  });
+
+  it("ends an update with the retention the new template asks for", async () => {
+    // Given a deployed log group holding an event.
+    const { simAws } = await deployLogGroup({
+      LogGroupName: logGroupName,
+      RetentionInDays: 14,
+    });
+
+    simAws.logs().serviceWriter().write(logGroupName, "stream-a", ["ran"]);
+
+    // When the stack is updated with a different retention.
+    await simAws.cloudFormation().updateStack(
+      new UpdateStackCommand({
+        StackName: "orders",
+        TemplateBody: jsonStringify({
+          Resources: {
+            OrdersLogs: {
+              Type: "AWS::Logs::LogGroup",
+              Properties: { LogGroupName: logGroupName, RetentionInDays: 30 },
+            },
+          },
+        }),
+      }),
+    );
+    await simAws.cloudFormation().waitForStackUpdateComplete("orders");
+
+    // Then the retention is the new one. The events are gone with it, because
+    // sim CloudFormation has no in-place update and replaces any Resource
+    // whose template entry changed. Real CloudFormation updates retention in
+    // place and keeps the events, so a test that logs, updates a stack, and
+    // then reads the logs back sees less here than it would in an account.
+    const group = simAws.logs().findLogGroup(logGroupName);
+
+    assertNonNullable(group);
+    assertIdentical(group.retentionInDays, 30);
+    assertArrayLength(group.streams, 0);
+  });
+
+  it("takes the log group down with the stack", async () => {
+    // Given a deployed log group.
+    const { simAws } = await deployLogGroup({ LogGroupName: logGroupName });
+
+    // When the stack is torn down.
+    await simAws
+      .cloudFormation()
+      .deleteStack(new DeleteStackCommand({ StackName: "orders" }));
+    await simAws.backgroundTasksComplete();
+
+    // Then the group and everything in it went with it, as in an account.
+    assertArrayLength(simAws.logs().allLogGroups(), 0);
+  });
+});

--- a/src/service/logs/cfn/sim-logs-cfn-resource-factory.ts
+++ b/src/service/logs/cfn/sim-logs-cfn-resource-factory.ts
@@ -1,0 +1,82 @@
+import { assertDefined } from "../../../util/type-guard/defined.js";
+import type { SimCfnServiceResourceFactory } from "../../cloudformation/resource/factory/sim-cfn-resource-factory.type.js";
+import type {
+  SimCfnResource,
+  SimCloudFormationResourceCreateContext,
+} from "../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimLogsLogGroup } from "../group/sim-logs-log-group.js";
+import type { SimLogs } from "../sim-logs.js";
+import { SimCfnLogGroupCreator } from "./group/sim-cfn-log-group-creator.js";
+
+const logGroupResourceTypeName = "LogGroup";
+
+interface SimLogsCfnResourceFactoryProperties {
+  readonly logs: SimLogs;
+}
+
+/**
+ * CloudFormation Resource factory for simulated CloudWatch Logs resources.
+ *
+ * AWS::Logs::LogGroup is the only Resource type here so far. The others,
+ * subscription filters and metric filters most of all, need machinery this
+ * simulation does not have yet.
+ */
+export class SimLogsCfnResourceFactory implements SimCfnServiceResourceFactory {
+  readonly #logGroupCreator: SimCfnLogGroupCreator;
+
+  constructor(properties: SimLogsCfnResourceFactoryProperties) {
+    this.#logGroupCreator = new SimCfnLogGroupCreator({
+      logs: properties.logs,
+    });
+  }
+
+  /**
+   * Create a simulated CloudWatch Logs resource from a CloudFormation
+   * Resource.
+   */
+  create(
+    resourceTypeName: string,
+    resource: SimCfnResource,
+    context: SimCloudFormationResourceCreateContext,
+  ): Promise<object | undefined> {
+    requireLogGroupResourceType(resourceTypeName, "");
+
+    return Promise.resolve(
+      this.#logGroupCreator.create(
+        resource,
+        context.resolvedProperties ?? resource.properties,
+      ),
+    );
+  }
+
+  /**
+   * Delete a simulated CloudWatch Logs resource created from a CloudFormation
+   * Resource.
+   */
+  delete(resourceTypeName: string, resource: SimCfnResource): Promise<void> {
+    requireLogGroupResourceType(resourceTypeName, " deletion");
+
+    const group = resource.simResource as SimLogsLogGroup | undefined;
+
+    assertDefined(
+      group,
+      `sim CloudWatch Logs log group for CloudFormation Resource ${resource.logicalId}`,
+    );
+
+    this.#logGroupCreator.delete(group);
+
+    return Promise.resolve();
+  }
+}
+
+function requireLogGroupResourceType(
+  resourceTypeName: string,
+  operationSuffix: string,
+): void {
+  if (resourceTypeName !== logGroupResourceTypeName) {
+    throw new Error(
+      `Unsupported sim CloudWatch Logs CloudFormation Resource ` +
+        `${resourceTypeName}${operationSuffix}`,
+    );
+  }
+}

--- a/src/service/logs/sim-logs.ts
+++ b/src/service/logs/sim-logs.ts
@@ -21,6 +21,7 @@ import { SimLogsLogStreamCommands } from "./command/stream/sim-logs-log-stream-c
 import { SimLogsEventIds } from "./event/sim-logs-event-ids.js";
 import type { SimLogsLogGroup } from "./group/sim-logs-log-group.js";
 import { SimLogsLogGroupStore } from "./group/sim-logs-log-group-store.js";
+import { SimLogsCfnResourceFactory } from "./cfn/sim-logs-cfn-resource-factory.js";
 import { SimLogsSdkCommandRouter } from "./sdk/sim-logs-sdk-command-router.js";
 import { SimLogsServiceWriter } from "./write/sim-logs-service-writer.js";
 
@@ -54,6 +55,7 @@ export class SimLogs {
   readonly #background: BackgroundScheduler;
   readonly #serviceWriter: SimLogsServiceWriter;
   readonly #sdkRouter = new SimLogsSdkCommandRouter(this);
+  readonly #cfnFactory = new SimLogsCfnResourceFactory({ logs: this });
 
   constructor(properties: SimLogsProperties = {}) {
     const {
@@ -239,6 +241,13 @@ export class SimLogs {
   ): Promise<simLogsCommands.SimFilterLogEventsCommandOutput> {
     await this.#background.sequence();
     return this.#filterLogEventsCommand.handle(command, options);
+  }
+
+  /**
+   * Get the CloudFormation Resource factory for AWS::Logs::* Resources.
+   */
+  cfnResourceFactory(): SimLogsCfnResourceFactory {
+    return this.#cfnFactory;
   }
 
   /**

--- a/src/service/logs/write/sim-logs-service-writer.ts
+++ b/src/service/logs/write/sim-logs-service-writer.ts
@@ -1,6 +1,7 @@
 import type { SimClock } from "../../../util/clock/sim-clock.js";
 import type { SimLogsStoredEvent } from "../event/sim-logs-event.js";
 import type { SimLogsEventIds } from "../event/sim-logs-event-ids.js";
+import type { SimLogsLogGroup } from "../group/sim-logs-log-group.js";
 import type { SimLogsLogGroupStore } from "../group/sim-logs-log-group-store.js";
 import type { SimLogsLogStream } from "../stream/sim-logs-log-stream.js";
 
@@ -36,17 +37,37 @@ export class SimLogsServiceWriter {
   }
 
   /**
+   * The log group of this name, made if nothing has made it yet.
+   *
+   * A declared log group and one a service made for itself are the same thing,
+   * so this answers with either. Real CloudFormation fails a deploy that
+   * declares a group already in the account, which is a genuine
+   * misconfiguration there and pure noise in a test whose Lambda function
+   * logged during setup.
+   */
+  logGroup(logGroupName: string): SimLogsLogGroup {
+    return this.#groups.ensure(logGroupName, this.#clock.now().getTime());
+  }
+
+  /**
+   * Remove a log group, and the streams and events it holds with it.
+   */
+  deleteLogGroup(logGroupName: string): void {
+    this.#groups.delete(logGroupName);
+  }
+
+  /**
    * Make sure a group and a stream in it both exist, without writing to them.
    *
    * A Lambda execution environment opens its stream as it cold starts, so a
    * function that logged nothing still shows the stream its invocation ran in.
    */
   openStream(logGroupName: string, logStreamName: string): SimLogsLogStream {
-    const now = this.#clock.now().getTime();
-    const group = this.#groups.ensure(logGroupName, now);
+    const group = this.logGroup(logGroupName);
 
     return (
-      group.findStream(logStreamName) ?? group.createStream(logStreamName, now)
+      group.findStream(logStreamName) ??
+      group.createStream(logStreamName, this.#clock.now().getTime())
     );
   }
 


### PR DESCRIPTION
Brief, concise description of the change:

Simulated CloudFormation now deploys `AWS::Logs::LogGroup`, so a test can assert on the retention a stack gave a group rather than reading it off the template, with `Ref` resolving to the name and `Fn::GetAtt Arn` to the ARN carrying the trailing `:*` a policy has to name. `LogGroupName` and `RetentionInDays` are acted on and everything else is recorded as an ignored property, so a stack does not fail over a property that changes nothing about what a test asserts, while a `RetentionInDays` outside the set AWS accepts fails the deploy rather than waiting for a real one. Three things diverge from the issue as written, each because of how the engine already works rather than by choice: a log group that already exists is taken over rather than refused, since a Lambda function that logged during setup has already created `/aws/lambda/orders` and the deploy that follows is saying what retention those logs should have; an update replaces the group rather than changing it in place, because simulated CloudFormation has no in-place update at all, so the retention ends up correct but the events the group held are gone; and `SimCdkProviderScaffolding`'s log group branch is removed rather than kept, because a Resource type a service creates is created whatever that class would have said, making the branch unreachable, and an empty log group is exactly what an account is left with when nothing invokes CDK's provider function either. All three are documented and pinned by tests. The value adapter registry also becomes a list rather than a chain of nullish coalescing, which the twentieth service pushed past the complexity limit.

Resolves https://github.com/KensioSoftware/yulin/issues/608

- [x] Conventional commit message, used as the title

- [x] Conventional branch name, like `feat/concise-description`
- [x] Full check with `pnpm run check` passed
- [x] Rebased off latest main
- [x] User-facing behaviour is documented in `docs/`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for simulating `AWS::Logs::LogGroup` resources through CloudFormation.
  * Supports custom or generated names, retention settings, updates, deletion, and reuse of existing log groups.
  * Added `Ref` and `Fn::GetAtt` resolution for log group names and ARNs.
  * Provider log groups are now created and testable as standard simulated resources, including unused providers.

* **Documentation**
  * Documented supported properties, ignored features, validation, lifecycle behavior, and simulation differences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->