### PR TITLE
feat: challenge a sign-in for a second factor

### DIFF
--- a/docs/services/cognito/README.md
+++ b/docs/services/cognito/README.md
@@ -2768,12 +2768,17 @@ has the `EmailConfiguration` real Cognito wants before it will send one, and so 
 `SmsConfiguration` inside an `SmsMfaConfiguration`: no message is delivered here, so the IAM role
 that would send one is never assumed.
 
-No sign-in is ever challenged for a second factor yet. A pool configured `OPTIONAL` challenges only
-the users that have registered a factor, so a sign-in by a user that has not registered one hands
-out tokens as it does on real Cognito. A pool configured `ON` is the one that differs. Real Cognito
-answers every sign-in to it with an MFA challenge, so `InitiateAuth`, `AdminInitiateAuth` and the
-new password challenge response are refused with `InvalidParameterException` where that challenge
-would have been, rather than handing out tokens a deployment would not.
+A pool configured `OPTIONAL` challenges the users that have registered a factor, and one configured
+`ON` challenges every user. A pool configured `OFF` challenges nobody. What a user registered is
+covered in [Registering a second factor for a user](#registering-a-second-factor-for-a-user) below,
+and being challenged for it in [Signing in with a second
+factor](#signing-in-with-a-second-factor) after that.
+
+The one sign-in still refused is by a user of an `ON` pool that has registered no factor at all.
+Real Cognito answers that one with `MFA_SETUP`, which registers a factor mid-sign-in, so
+`InitiateAuth`, `AdminInitiateAuth` and the new password challenge response are refused with
+`InvalidParameterException` where that challenge would have been, rather than handing out tokens a
+deployment would not.
 
 ```typescript sim-cognito-mfa
 /**
@@ -2992,14 +2997,138 @@ console.log(user.UserMFASettingList); // ["SOFTWARE_TOKEN_MFA"]
 console.log(user.PreferredMfaSetting); // "SOFTWARE_TOKEN_MFA"
 ```
 
+### Signing in with a second factor
+
+A sign-in by a user that has registered a factor is answered with `SMS_MFA` or `SOFTWARE_TOKEN_MFA`
+and a `Session` rather than with tokens, on `InitiateAuth` and `AdminInitiateAuth` alike, and after
+a `NEW_PASSWORD_REQUIRED` response as well: one challenge follows the other. The code goes back
+through `RespondToAuthChallenge` or `AdminRespondToAuthChallenge` as `SMS_MFA_CODE` or
+`SOFTWARE_TOKEN_MFA_CODE`, and that request is what hands out the tokens.
+
+An `SMS_MFA` challenge carries `CODE_DELIVERY_DELIVERY_MEDIUM` and a masked
+`CODE_DELIVERY_DESTINATION` in its `ChallengeParameters`, as real Cognito does, and the pool records
+the message it would have texted, on an occasion of `Authentication`. That is where a test reads the
+code from, the way it reads a sign-up confirmation code. A `SOFTWARE_TOKEN_MFA` challenge sends
+nothing anywhere: the code is whatever the user's authenticator app is showing, so a test computes
+it from the `SecretCode` or reads it off the pool.
+
+The code goes to the user's `phone_number` whatever the pool's `AutoVerifiedAttributes` say, and to
+the phone number rather than the email address of a user that has both, because the phone is the
+factor.
+
+A wrong code is refused with `CodeMismatchException` and leaves the challenge standing, so the user
+can be asked to type it again. A session lasts the three minutes an app client's
+`AuthSessionValidity` gives it, and one that has run out, one already spent, and one issued for a
+different challenge are each refused with `NotAuthorizedException`. `PostAuthentication` runs where
+the tokens are issued, which is the response rather than the sign-in that was challenged.
+
+A user with both factors enabled and neither preferred is refused: real Cognito answers that
+sign-in with `SELECT_MFA_TYPE`, which is a challenge of its own. `SetUserMFAPreference` naming one
+of them as `PreferredMfa` is what settles it.
+
+```typescript sim-cognito-mfa-sign-in
+/**
+ * Signing in with a code texted to the user's phone.
+ */
+
+import {
+  AdminCreateUserCommand,
+  AdminSetUserPasswordCommand,
+  CreateUserPoolClientCommand,
+  CreateUserPoolCommand,
+  InitiateAuthCommand,
+  RespondToAuthChallengeCommand,
+  SetUserMFAPreferenceCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+
+import { SimAws } from "@kensio/yulin";
+
+const cognito = new SimAws().cognitoIdentityProvider();
+
+const pool = await cognito.createUserPool(
+  new CreateUserPoolCommand({
+    PoolName: "myapp-users",
+    MfaConfiguration: "OPTIONAL",
+  }),
+);
+const userPoolId = pool.UserPool!.Id!;
+
+const appClient = await cognito.createUserPoolClient(
+  new CreateUserPoolClientCommand({
+    UserPoolId: userPoolId,
+    ClientName: "web",
+    ExplicitAuthFlows: ["ALLOW_USER_PASSWORD_AUTH"],
+  }),
+);
+const ClientId = appClient.UserPoolClient!.ClientId!;
+
+// The code has somewhere to go, which is what enabling SMS_MFA needs.
+await cognito.adminCreateUser(
+  new AdminCreateUserCommand({
+    UserPoolId: userPoolId,
+    Username: "alice",
+    UserAttributes: [{ Name: "phone_number", Value: "+441632960123" }],
+  }),
+);
+await cognito.adminSetUserPassword(
+  new AdminSetUserPasswordCommand({
+    UserPoolId: userPoolId,
+    Username: "alice",
+    Password: "Sup3rSecret!",
+    Permanent: true,
+  }),
+);
+
+const signIn = new InitiateAuthCommand({
+  ClientId,
+  AuthFlow: "USER_PASSWORD_AUTH",
+  AuthParameters: { USERNAME: "alice", PASSWORD: "Sup3rSecret!" },
+});
+
+// This sign-in is not challenged: the user has registered no factor yet.
+const first = await cognito.initiateAuth(signIn);
+
+await cognito.setUserMFAPreference(
+  new SetUserMFAPreferenceCommand({
+    AccessToken: first.AuthenticationResult!.AccessToken,
+    SMSMfaSettings: { Enabled: true, PreferredMfa: true },
+  }),
+);
+
+const challenged = await cognito.initiateAuth(signIn);
+
+console.log(challenged.ChallengeName); // "SMS_MFA"
+console.log(challenged.ChallengeParameters?.["CODE_DELIVERY_DESTINATION"]);
+// "+*******0123"
+
+// Nothing is delivered, so the code is read out of the message the pool
+// recorded, as a sign-up confirmation code is.
+const texted = cognito
+  .userPool(userPoolId)
+  .sentMessages()
+  .find((message) => message.occasion === "Authentication");
+const code = /\d{6}/.exec(texted!.body)![0];
+
+const signedIn = await cognito.respondToAuthChallenge(
+  new RespondToAuthChallengeCommand({
+    ClientId,
+    ChallengeName: "SMS_MFA",
+    Session: challenged.Session,
+    ChallengeResponses: { USERNAME: "alice", SMS_MFA_CODE: code },
+  }),
+);
+
+console.log(typeof signedIn.AuthenticationResult?.AccessToken); // "string"
+```
+
 ## Available functionality
 
 Sim Cognito currently supports:
 
 - `CreateUserPoolCommand`, `DescribeUserPoolCommand`, `UpdateUserPoolCommand`,
   `DeleteUserPoolCommand` and `ListUserPoolsCommand`
-- `SetUserPoolMfaConfigCommand` and `GetUserPoolMfaConfigCommand`, which record what a pool offers
-  as a second factor without any sign-in being challenged for one
+- `SetUserPoolMfaConfigCommand` and `GetUserPoolMfaConfigCommand`, which set and read what a pool
+  offers as a second factor
 - `CreateUserPoolClientCommand`, `DescribeUserPoolClientCommand`, `UpdateUserPoolClientCommand`,
   `DeleteUserPoolClientCommand` and `ListUserPoolClientsCommand`
 - `AdminCreateUserCommand`, `AdminGetUserCommand`, `AdminDeleteUserCommand`,
@@ -3009,6 +3138,9 @@ Sim Cognito currently supports:
 - `AssociateSoftwareTokenCommand`, `VerifySoftwareTokenCommand` and `SetUserMFAPreferenceCommand`,
   which register an authenticator app for the signed-in user, and
   `AdminSetUserMFAPreferenceCommand`, which sets a named user's factors
+- The `SMS_MFA` and `SOFTWARE_TOKEN_MFA` challenges, issued to a user that has registered the
+  factor and answered through `RespondToAuthChallengeCommand` or
+  `AdminRespondToAuthChallengeCommand`, with the texted code recorded as a message on the pool
 - `SignUpCommand`, `ConfirmSignUpCommand` and `ResendConfirmationCodeCommand`, authorized by no IAM
   policy as they are on real Cognito, and `AdminConfirmSignUpCommand`, which is authorized like the
   other admin operations
@@ -3084,9 +3216,9 @@ Current documented limitations:
   `AdminInitiateAuth`, and `USER_PASSWORD_AUTH` and `REFRESH_TOKEN_AUTH` through `InitiateAuth`. SRP,
   `USER_AUTH` choice-based sign-in, custom authentication and device tracking are not simulated, and
   an `AuthFlow` naming one of them is refused rather than run as a flow that is.
-- `NEW_PASSWORD_REQUIRED` is the only challenge issued, so MFA and custom challenges cannot be
-  reached. A `ChallengeName` this simulation does not issue is refused, and a sign-in to a pool
-  whose `MfaConfiguration` is `ON` is refused where the MFA challenge would have been.
+- `NEW_PASSWORD_REQUIRED`, `SMS_MFA` and `SOFTWARE_TOKEN_MFA` are the challenges issued, so
+  `MFA_SETUP`, `SELECT_MFA_TYPE` and the custom authentication challenges cannot be reached. A
+  `ChallengeName` this simulation does not issue is refused rather than answered as one it does.
 - `GetTokensFromRefreshToken` and `RevokeToken` are not implemented, and `RefreshTokenRotation` is
   refused on an app client. Refreshing goes through `REFRESH_TOKEN_AUTH`, which issues no new
   refresh token.
@@ -3194,9 +3326,15 @@ Current documented limitations:
   and sets every attribute the pool holds.
 - `EstimatedNumberOfUsers` is how many users the pool holds now. Real Cognito refreshes that number
   periodically rather than on each write, so it can lag there in a way it never does here.
-- A pool records its `MfaConfiguration` and the factors behind it, a user registers factors of its
-  own, and no sign-in is ever challenged for one yet. A sign-in to a pool configured `ON` is
-  refused, because real Cognito answers every one of those with a challenge.
+- A sign-in by a user of an `ON` pool that has registered no factor is refused, because real Cognito
+  answers that one with the `MFA_SETUP` challenge, which registers a factor mid-sign-in and is not
+  simulated. A user with both factors enabled and neither preferred is refused for the same kind of
+  reason: real Cognito answers that with `SELECT_MFA_TYPE`.
+- An MFA code is texted to the user's `phone_number` whatever the pool's `AutoVerifiedAttributes`
+  say, and the pool records it as a message with an occasion of `Authentication`, which is where a
+  test reads it from. Real Cognito delivers it and reports it to nobody.
+- A `SOFTWARE_TOKEN_MFA` challenge carries no `FRIENDLY_DEVICE_NAME` in its `ChallengeParameters`,
+  because no device is remembered here.
 - A user's software token secret is a real RFC 6238 shared secret, and the pool reports the code the
   user's authenticator app would be showing through `SimCognitoUserPool.softwareTokenCode`. Real
   Cognito reports that to nobody: the code is on the user's own device, in the way a confirmation

--- a/docs/services/cognito/README.md
+++ b/docs/services/cognito/README.md
@@ -3017,10 +3017,16 @@ the phone number rather than the email address of a user that has both, because 
 factor.
 
 A wrong code is refused with `CodeMismatchException` and leaves the challenge standing, so the user
-can be asked to type it again. A session lasts the three minutes an app client's
-`AuthSessionValidity` gives it, and one that has run out, one already spent, and one issued for a
-different challenge are each refused with `NotAuthorizedException`. `PostAuthentication` runs where
-the tokens are issued, which is the response rather than the sign-in that was challenged.
+can be asked to type it again. Every session lasts three minutes, which is what real Cognito gives
+an app client that names no `AuthSessionValidity` of its own, and that input is refused here. A
+session that has run out, one already spent, and one issued for a different challenge are each
+refused with `NotAuthorizedException`.
+
+`PostAuthentication` runs where the tokens are issued, which is the response rather than the sign-in
+that was challenged. `PreTokenGeneration` runs there too, reporting
+`TokenGeneration_Authentication`, including for a sign-in that answered the new password challenge
+before this one; which source real Cognito reports for that pair of challenges was not checked
+against a live account.
 
 A user with both factors enabled and neither preferred is refused: real Cognito answers that
 sign-in with `SELECT_MFA_TYPE`, which is a challenge of its own. `SetUserMFAPreference` naming one

--- a/docs/services/cognito/sim-cognito-mfa-sign-in.example.ts
+++ b/docs/services/cognito/sim-cognito-mfa-sign-in.example.ts
@@ -1,0 +1,92 @@
+/**
+ * Signing in with a code texted to the user's phone.
+ */
+
+import {
+  AdminCreateUserCommand,
+  AdminSetUserPasswordCommand,
+  CreateUserPoolClientCommand,
+  CreateUserPoolCommand,
+  InitiateAuthCommand,
+  RespondToAuthChallengeCommand,
+  SetUserMFAPreferenceCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+
+import { SimAws } from "@kensio/yulin";
+
+const cognito = new SimAws().cognitoIdentityProvider();
+
+const pool = await cognito.createUserPool(
+  new CreateUserPoolCommand({
+    PoolName: "myapp-users",
+    MfaConfiguration: "OPTIONAL",
+  }),
+);
+const userPoolId = pool.UserPool!.Id!;
+
+const appClient = await cognito.createUserPoolClient(
+  new CreateUserPoolClientCommand({
+    UserPoolId: userPoolId,
+    ClientName: "web",
+    ExplicitAuthFlows: ["ALLOW_USER_PASSWORD_AUTH"],
+  }),
+);
+const ClientId = appClient.UserPoolClient!.ClientId!;
+
+// The code has somewhere to go, which is what enabling SMS_MFA needs.
+await cognito.adminCreateUser(
+  new AdminCreateUserCommand({
+    UserPoolId: userPoolId,
+    Username: "alice",
+    UserAttributes: [{ Name: "phone_number", Value: "+441632960123" }],
+  }),
+);
+await cognito.adminSetUserPassword(
+  new AdminSetUserPasswordCommand({
+    UserPoolId: userPoolId,
+    Username: "alice",
+    Password: "Sup3rSecret!",
+    Permanent: true,
+  }),
+);
+
+const signIn = new InitiateAuthCommand({
+  ClientId,
+  AuthFlow: "USER_PASSWORD_AUTH",
+  AuthParameters: { USERNAME: "alice", PASSWORD: "Sup3rSecret!" },
+});
+
+// This sign-in is not challenged: the user has registered no factor yet.
+const first = await cognito.initiateAuth(signIn);
+
+await cognito.setUserMFAPreference(
+  new SetUserMFAPreferenceCommand({
+    AccessToken: first.AuthenticationResult!.AccessToken,
+    SMSMfaSettings: { Enabled: true, PreferredMfa: true },
+  }),
+);
+
+const challenged = await cognito.initiateAuth(signIn);
+
+console.log(challenged.ChallengeName); // "SMS_MFA"
+console.log(challenged.ChallengeParameters?.["CODE_DELIVERY_DESTINATION"]);
+// "+*******0123"
+
+// Nothing is delivered, so the code is read out of the message the pool
+// recorded, as a sign-up confirmation code is.
+const texted = cognito
+  .userPool(userPoolId)
+  .sentMessages()
+  .find((message) => message.occasion === "Authentication");
+const code = /\d{6}/.exec(texted!.body)![0];
+
+const signedIn = await cognito.respondToAuthChallenge(
+  new RespondToAuthChallengeCommand({
+    ClientId,
+    ChallengeName: "SMS_MFA",
+    Session: challenged.Session,
+    ChallengeResponses: { USERNAME: "alice", SMS_MFA_CODE: code },
+  }),
+);
+
+console.log(typeof signedIn.AuthenticationResult?.AccessToken); // "string"

--- a/src/service/cognito/README.md
+++ b/src/service/cognito/README.md
@@ -6,8 +6,7 @@ which exchange a token for AWS credentials, are a separate service and are not s
 The pool, the app client, the users and groups in it, self-service sign-up, the second factors a
 user registers, the sign-in flows on both sides of the API, the domain and identity providers a
 federated sign-in runs through, the messages it would have sent, the tokens it issues and the
-authorizer are all here. SRP, managed login, MFA challenges, password resets and device tracking are
-not.
+authorizer are all here. SRP, managed login, password resets and device tracking are not.
 
 ## Entry points
 
@@ -53,12 +52,13 @@ configuration, and it is the one setting an update does not wholly replace: only
 `SetUserPoolMfaConfig` says which factors a challenge could use, and it changes them in place, so
 `keepFactorsOf` carries them onto the settings replacing them, as real Cognito keeps them.
 
-Nothing here challenges yet, so what the pool holds is state it reports rather than acts on. The one
-place it is read is `SimCognitoMfaChallenge`, which refuses a sign-in to a pool configured `ON`,
-because real Cognito answers every one of those with a challenge and would never issue the tokens
-this simulation otherwise would. The wording an SMS factor carries is held to the same rules as the
-verification wording, through `requireSimCognitoVerificationWording`, because it is a message with a
-code in it either way.
+A sign-in reads this to decide whether the user owes a second factor, through
+`simCognitoChallengeFactor`, which also refuses the two sign-ins real Cognito answers with a
+challenge this simulation does not issue: a user of an `ON` pool with no factor, which gets
+`MFA_SETUP` there, and a user with both factors enabled and neither preferred, which gets
+`SELECT_MFA_TYPE`. The wording an SMS factor carries is held to the same rules as the verification
+wording, through `requireSimCognitoVerificationWording`, because it is a message with a code in it
+either way.
 
 `makeSimCognitoUserPoolId` builds the `<region>_<nine characters>` form. The region is part of the id
 rather than decoration: SDK code splits a pool id on the underscore to work out which region to talk
@@ -134,9 +134,9 @@ statuses belong to password resets and federation, neither of which is simulated
 `SimCognitoUserMfa` under `user-pool/user/mfa/` is the second factors one user has registered: the
 software token secret it is registering, the one it has registered, which factors are enabled and
 which is preferred. It is the user's own state rather than the pool's, because the pool decides what
-it offers and the user decides what it has. Registering and being challenged are two things, and
-this is the first: `SetUserMFAPreference` is what enables a factor, and verifying a token only
-registers it.
+it offers and the user decides what it has. `SetUserMFAPreference` is what enables a factor, and
+verifying a token only registers it. `challengeFactor` is what a sign-in reads: the preferred
+factor, or the single enabled one where the user named no preference.
 
 `SimCognitoSoftwareToken` is one shared secret, and `sim-cognito-totp.ts` computes the code from it.
 The codes are real RFC 6238 time-based one-time passwords rather than a stand-in, so an
@@ -433,8 +433,10 @@ and because keeping them here leaves `SimCognitoUserPool` as what it is elsewher
 holding its contents.
 
 `SimCognitoAuthSession` is what an unfinished authentication carries between the request that started
-it and the response that completes it. A session is opaque, single use, tied to its user and app
-client, and lasts the three minutes real Cognito gives one.
+it and the response that completes it. A session is opaque, single use, tied to its user, its app
+client and the one challenge it was issued for, and lasts the three minutes real Cognito gives one.
+It also holds the code an `SMS_MFA` challenge texted, because that code belongs to that challenge:
+it goes when the session goes.
 
 `SimCognitoIssuedToken` is a token the pool has handed out, and `SimCognitoIssuedTokenStore` holds
 them. A refresh token is kept because the pool is what exchanges it later, and an access token
@@ -524,10 +526,18 @@ The four sign-in commands are thin because the parts they share are collaborator
 entry it replaced; `SimCognitoAuthFlows` is the set one entry point runs, which is why
 `ADMIN_USER_PASSWORD_AUTH` is refused for `InitiateAuth` as it is on real Cognito.
 `SimCognitoAuthFlowRunner` runs the resolved flow through `SimCognitoPasswordSignIn` or
-`SimCognitoRefreshSignIn`, and `SimCognitoNewPasswordResponse` is the body both challenge responses
-share, and refuses a user disabled since the challenge was issued, because a disabled user cannot
-finish a sign-in any more than it can start one. What is left in each command is how it reaches the
-pool and what it is allowed to run.
+`SimCognitoRefreshSignIn`. `SimCognitoChallengeResponses` sends a response to whichever challenge it
+answers, `SimCognitoNewPasswordResponse` or `SimCognitoMfaResponse`, and both refuse a user disabled
+since the challenge was issued, because a disabled user cannot finish a sign-in any more than it can
+start one. What is left in each command is how it reaches the pool and what it is allowed to run.
+
+`SimCognitoSignInCompletion` is where every sign-in ends, wherever it got to: it issues the tokens
+and runs `PostAuthentication`, and its `challengeOrComplete` is what answers with the MFA challenge
+instead for a user that still owes a factor. Having one of those means the password sign-in and the
+new password response cannot forget the second factor, and that `PostAuthentication` fires once per
+sign-in rather than once per request. `SimCognitoMfaChallenge` issues the challenge and texts the
+code, and `SimCognitoMfaCodeCheck` is what a response is held to: the texted code against the
+session, and an authenticator app's against the secret the user registered.
 
 `SimCognitoRequestResolver` is what every user and group operation starts with: authorize against
 the pool's ARN, then find the pool. Neither a user nor a group has an ARN of its own, so the pool's
@@ -627,14 +637,17 @@ resource, here or on real AWS.
   against, so the two disagree here and agree on real Cognito. Its `authorization_endpoint`,
   `token_endpoint` and `end_session_endpoint` name the pool's domain, once it has one, at that
   domain's local hostname. It names no `userinfo_endpoint`, which is not served.
-- The password and refresh flows run on both sides of the API, and only `NEW_PASSWORD_REQUIRED` is
-  issued. SRP, `USER_AUTH`, custom authentication, MFA challenges and device tracking are refused
-  rather than treated as a flow or challenge that is simulated.
-- A pool records its `MfaConfiguration` and the factors behind it, a user registers factors of its
-  own, and nothing challenges for either yet. A sign-in to a pool configured `ON` is refused, as
-  every one of those is answered with a challenge on real Cognito. `SetUserPoolMfaConfig` accepts
-  `SoftwareTokenMfaConfiguration` and `SmsMfaConfiguration`, and refuses the `SmsConfiguration`
-  inside the second one in the same words `CreateUserPool` refuses the pool's own.
+- The password and refresh flows run on both sides of the API, and `NEW_PASSWORD_REQUIRED`,
+  `SMS_MFA` and `SOFTWARE_TOKEN_MFA` are the challenges issued. SRP, `USER_AUTH`, custom
+  authentication and device tracking are refused rather than treated as a flow or challenge that is
+  simulated, and so are the `MFA_SETUP` and `SELECT_MFA_TYPE` challenges.
+- A sign-in by a user of an `ON` pool that has registered no factor is refused, as real Cognito
+  answers that one with `MFA_SETUP`. `SetUserPoolMfaConfig` accepts `SoftwareTokenMfaConfiguration`
+  and `SmsMfaConfiguration`, and refuses the `SmsConfiguration` inside the second one in the same
+  words `CreateUserPool` refuses the pool's own.
+- An MFA code is recorded as a sent message with an occasion of `Authentication`, and goes to the
+  user's `phone_number` whatever the pool verifies automatically. Real Cognito texts it and reports
+  it to nobody.
 - A user pool reports the code a user's authenticator app is showing, through
   `SimCognitoUserPool.softwareTokenCode`, which real Cognito reports to nobody. It is the same
   divergence `confirmationCode` is, for the same reason: the code is on the user's own device. A

--- a/src/service/cognito/command/auth/sim-cognito-admin-respond-to-challenge.iso.test.ts
+++ b/src/service/cognito/command/auth/sim-cognito-admin-respond-to-challenge.iso.test.ts
@@ -306,20 +306,20 @@ describe("sim Cognito AdminRespondToAuthChallenge", () => {
     const { cognito, userPoolId, clientId, session } =
       await simCognitoChallenged();
 
-    // When an SMS challenge is answered instead.
+    // When a challenge nothing here issues is answered instead.
     const error = await assertThrowsErrorAsync(async () => {
       await cognito.adminRespondToAuthChallenge(
         new AdminRespondToAuthChallengeCommand({
           UserPoolId: userPoolId,
           ClientId: clientId,
-          ChallengeName: "SMS_MFA",
+          ChallengeName: "MFA_SETUP",
           Session: session,
-          ChallengeResponses: { USERNAME: "alice", SMS_MFA_CODE: "123456" },
+          ChallengeResponses: { USERNAME: "alice" },
         }),
       );
     });
 
-    // Then it is refused rather than treated as the one challenge simulated.
+    // Then it is refused rather than treated as one of the simulated ones.
     assertStringIncludes(error.message, "is not simulated");
   });
 });

--- a/src/service/cognito/command/auth/sim-cognito-admin-respond-to-challenge.ts
+++ b/src/service/cognito/command/auth/sim-cognito-admin-respond-to-challenge.ts
@@ -1,8 +1,7 @@
 import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
 import { SimCognitoAuthParameters } from "./sim-cognito-auth-parameters.js";
 import type { SimCognitoAuthResolver } from "./sim-cognito-auth-resolver.js";
-import { requireSimCognitoNewPasswordChallenge } from "./sim-cognito-auth-challenge.js";
-import type { SimCognitoNewPasswordResponse } from "./sim-cognito-new-password-response.js";
+import type { SimCognitoChallengeResponses } from "./sim-cognito-challenge-responses.js";
 import { SimCognitoUnsimulatedAuthOptions } from "./sim-cognito-unsimulated-auth-options.js";
 import type {
   SimAdminRespondToAuthChallengeCommand,
@@ -11,7 +10,7 @@ import type {
 
 interface SimCognitoAdminRespondToChallengeProperties {
   readonly authResolver: SimCognitoAuthResolver;
-  readonly newPassword: SimCognitoNewPasswordResponse;
+  readonly responses: SimCognitoChallengeResponses;
 }
 
 interface SimCognitoCommandOptions {
@@ -21,17 +20,18 @@ interface SimCognitoCommandOptions {
 /**
  * The AdminRespondToAuthChallenge command.
  *
- * Only `NEW_PASSWORD_REQUIRED` is answered, and the caller needs the
- * `cognito-idp:AdminRespondToAuthChallenge` permission on the pool.
+ * `NEW_PASSWORD_REQUIRED` and the two MFA challenges are answered, and the
+ * caller needs the `cognito-idp:AdminRespondToAuthChallenge` permission on the
+ * pool.
  */
 export class SimCognitoAdminRespondToChallenge {
   private readonly authResolver: SimCognitoAuthResolver;
-  private readonly newPassword: SimCognitoNewPasswordResponse;
+  private readonly responses: SimCognitoChallengeResponses;
   private readonly unsimulatedOptions = new SimCognitoUnsimulatedAuthOptions();
 
   constructor(properties: SimCognitoAdminRespondToChallengeProperties) {
     this.authResolver = properties.authResolver;
-    this.newPassword = properties.newPassword;
+    this.responses = properties.responses;
   }
 
   /**
@@ -49,9 +49,7 @@ export class SimCognitoAdminRespondToChallenge {
     );
 
     this.unsimulatedOptions.refuseInAdminResponse(input);
-    requireSimCognitoNewPasswordChallenge(input.ChallengeName);
-
-    return await this.newPassword.handle({
+    return await this.responses.handle(input.ChallengeName, {
       pool,
       client,
       parameters: new SimCognitoAuthParameters(

--- a/src/service/cognito/command/auth/sim-cognito-auth-challenge.ts
+++ b/src/service/cognito/command/auth/sim-cognito-auth-challenge.ts
@@ -1,26 +1,48 @@
 import { SimCognitoInvalidParameterException } from "../../error/sim-cognito.error.js";
+import {
+  simCognitoSmsMfa,
+  simCognitoSoftwareTokenMfa,
+} from "../../user-pool/user/mfa/sim-cognito-mfa-factors.js";
 
 /**
- * The challenge this simulation can answer.
+ * The challenge a user with a temporary password is answered with.
  */
 export const newPasswordRequiredChallenge = "NEW_PASSWORD_REQUIRED";
 
 /**
+ * The challenges this simulation issues and can be answered with.
+ *
+ * The two MFA challenges are named after the factors they are for, which is
+ * how Cognito names them: a user registered for a software token is
+ * challenged with `SOFTWARE_TOKEN_MFA` and answers with a
+ * `SOFTWARE_TOKEN_MFA_CODE`.
+ */
+const answerableChallenges: readonly string[] = [
+  newPasswordRequiredChallenge,
+  simCognitoSmsMfa,
+  simCognitoSoftwareTokenMfa,
+];
+
+/**
  * Refuse a challenge this simulation cannot answer.
  *
- * MFA and custom authentication challenges are refused rather than answered as
- * this one, because what a caller has to send back is different for each.
+ * `MFA_SETUP` and the custom authentication challenges are refused rather than
+ * answered as one of these, because what a caller has to send back is
+ * different for each.
  */
-export function requireSimCognitoNewPasswordChallenge(
+export function requireSimCognitoChallengeName(
   challengeName: string | undefined,
-): void {
-  if (challengeName === newPasswordRequiredChallenge) {
-    return;
+): string {
+  if (
+    challengeName !== undefined &&
+    answerableChallenges.includes(challengeName)
+  ) {
+    return challengeName;
   }
 
   throw new SimCognitoInvalidParameterException(
     `ChallengeName '${String(challengeName)}' is not simulated: ` +
-      `${newPasswordRequiredChallenge} is the only challenge this ` +
+      `${answerableChallenges.join(", ")} are the challenges this ` +
       `simulation issues.`,
   );
 }

--- a/src/service/cognito/command/auth/sim-cognito-auth-commands.ts
+++ b/src/service/cognito/command/auth/sim-cognito-auth-commands.ts
@@ -1,4 +1,5 @@
 import type { SimClock } from "../../../../util/clock/sim-clock.js";
+import type { SimCognitoPoolMessenger } from "../../user-pool/message/sim-cognito-pool-messenger.js";
 import type { SimCognitoUserPoolStore } from "../../user-pool/sim-cognito-user-pool-store.js";
 import type { SimCognitoTokenIssuer } from "../../user-pool/token/sim-cognito-token-issuer.js";
 import type { SimCognitoUserPoolTriggers } from "../../user-pool/trigger/sim-cognito-user-pool-triggers.js";
@@ -7,12 +8,16 @@ import { SimCognitoAdminInitiateAuth } from "./sim-cognito-admin-initiate-auth.j
 import { SimCognitoAdminRespondToChallenge } from "./sim-cognito-admin-respond-to-challenge.js";
 import { SimCognitoAuthFlowRunner } from "./sim-cognito-auth-flow-runner.js";
 import type { SimCognitoAuthResolver } from "./sim-cognito-auth-resolver.js";
+import { SimCognitoChallengeResponses } from "./sim-cognito-challenge-responses.js";
 import { SimCognitoInitiateAuth } from "./sim-cognito-initiate-auth.js";
+import { SimCognitoMfaChallenge } from "./sim-cognito-mfa-challenge.js";
+import { SimCognitoMfaResponse } from "./sim-cognito-mfa-response.js";
 import { SimCognitoNewPasswordChallenge } from "./sim-cognito-new-password-challenge.js";
 import { SimCognitoNewPasswordResponse } from "./sim-cognito-new-password-response.js";
 import { SimCognitoPasswordSignIn } from "./sim-cognito-password-sign-in.js";
 import { SimCognitoRefreshSignIn } from "./sim-cognito-refresh-sign-in.js";
 import { SimCognitoRespondToChallenge } from "./sim-cognito-respond-to-challenge.js";
+import { SimCognitoSignInCompletion } from "./sim-cognito-sign-in-completion.js";
 import { SimCognitoSignOutCommands } from "./sim-cognito-sign-out.js";
 
 interface SimCognitoAuthCommandsProperties {
@@ -27,6 +32,13 @@ interface SimCognitoAuthCommandsProperties {
    * pool's hosted endpoints so both hand out the same thing.
    */
   readonly tokenIssuer: SimCognitoTokenIssuer;
+
+  /**
+   * What records the message a pool would have texted an MFA code in, shared
+   * with the sign-up and user commands so every message a pool sends is
+   * recorded the same way.
+   */
+  readonly messenger: SimCognitoPoolMessenger;
 }
 
 /**
@@ -48,22 +60,39 @@ export class SimCognitoAuthCommands {
   public readonly signOut: SimCognitoSignOutCommands;
 
   constructor(properties: SimCognitoAuthCommandsProperties) {
-    const { resolver, authResolver, pools, clock, triggers, tokenIssuer } =
-      properties;
+    const {
+      resolver,
+      authResolver,
+      pools,
+      clock,
+      triggers,
+      tokenIssuer,
+      messenger,
+    } = properties;
+    // Every sign-in ends the same way, wherever it finished: with the second
+    // factor where the user owes one, and with the tokens and the
+    // PostAuthentication trigger where it does not.
+    const completion = new SimCognitoSignInCompletion({
+      tokenIssuer,
+      triggers,
+      mfaChallenge: new SimCognitoMfaChallenge({ messenger, clock }),
+    });
     const flowRunner = new SimCognitoAuthFlowRunner({
       passwordSignIn: new SimCognitoPasswordSignIn({
         authResolver,
-        tokenIssuer,
+        completion,
         challenge: new SimCognitoNewPasswordChallenge({ clock }),
         triggers,
       }),
       refreshSignIn: new SimCognitoRefreshSignIn({ tokenIssuer, clock }),
     });
-    const newPassword = new SimCognitoNewPasswordResponse({
-      authResolver,
-      tokenIssuer,
-      triggers,
-      clock,
+    const responses = new SimCognitoChallengeResponses({
+      newPassword: new SimCognitoNewPasswordResponse({
+        authResolver,
+        completion,
+        clock,
+      }),
+      mfa: new SimCognitoMfaResponse({ authResolver, completion, clock }),
     });
 
     this.adminInitiateAuth = new SimCognitoAdminInitiateAuth({
@@ -72,7 +101,7 @@ export class SimCognitoAuthCommands {
     });
     this.adminRespondToChallenge = new SimCognitoAdminRespondToChallenge({
       authResolver,
-      newPassword,
+      responses,
     });
     this.initiateAuth = new SimCognitoInitiateAuth({
       authResolver,
@@ -80,7 +109,7 @@ export class SimCognitoAuthCommands {
     });
     this.respondToChallenge = new SimCognitoRespondToChallenge({
       authResolver,
-      newPassword,
+      responses,
     });
     this.signOut = new SimCognitoSignOutCommands({ resolver, pools, clock });
   }

--- a/src/service/cognito/command/auth/sim-cognito-challenge-responses.ts
+++ b/src/service/cognito/command/auth/sim-cognito-challenge-responses.ts
@@ -1,0 +1,49 @@
+import {
+  newPasswordRequiredChallenge,
+  requireSimCognitoChallengeName,
+} from "./sim-cognito-auth-challenge.js";
+import type { SimCognitoMfaResponse } from "./sim-cognito-mfa-response.js";
+import type {
+  SimCognitoChallengeResponseRequest,
+  SimCognitoNewPasswordResponse,
+} from "./sim-cognito-new-password-response.js";
+import type { SimCognitoAuthenticationOutput } from "./auth.command.js";
+
+interface SimCognitoChallengeResponsesProperties {
+  readonly newPassword: SimCognitoNewPasswordResponse;
+  readonly mfa: SimCognitoMfaResponse;
+}
+
+/**
+ * Sends a challenge response to whichever challenge it is answering.
+ *
+ * `RespondToAuthChallenge` and `AdminRespondToAuthChallenge` both arrive here,
+ * because the two differ in how they reach the pool and in nothing after that:
+ * the same response completes the same challenge either way.
+ */
+export class SimCognitoChallengeResponses {
+  private readonly newPassword: SimCognitoNewPasswordResponse;
+  private readonly mfa: SimCognitoMfaResponse;
+
+  constructor(properties: SimCognitoChallengeResponsesProperties) {
+    this.newPassword = properties.newPassword;
+    this.mfa = properties.mfa;
+  }
+
+  /**
+   * Answer the challenge the request names, or refuse a challenge this
+   * simulation does not issue.
+   */
+  async handle(
+    challengeName: string | undefined,
+    request: SimCognitoChallengeResponseRequest,
+  ): Promise<SimCognitoAuthenticationOutput> {
+    const challenge = requireSimCognitoChallengeName(challengeName);
+
+    if (challenge === newPasswordRequiredChallenge) {
+      return await this.newPassword.handle(request);
+    }
+
+    return await this.mfa.handle({ ...request, challengeName: challenge });
+  }
+}

--- a/src/service/cognito/command/auth/sim-cognito-mfa-challenge.iso.test.ts
+++ b/src/service/cognito/command/auth/sim-cognito-mfa-challenge.iso.test.ts
@@ -1,0 +1,197 @@
+import {
+  AdminInitiateAuthCommand,
+  AdminRespondToAuthChallengeCommand,
+  InitiateAuthCommand,
+  RespondToAuthChallengeCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertTypeString,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import {
+  simCognitoPhoneNumber,
+  simCognitoSmsMfaCode,
+  simCognitoSoftwareTokenCode,
+  simCognitoWithSmsFactor,
+  simCognitoWithSoftwareToken,
+} from "../../../../../test/cognito/mfa-fixture.js";
+import type { SimCognitoSignedInSetUp } from "../../../../../test/cognito/signed-in-fixture.js";
+import {
+  simCognitoPassword,
+  simCognitoUsername,
+} from "../../../../../test/cognito/signed-in-fixture.js";
+import type { SimCognitoAuthenticationOutput } from "./auth.command.js";
+
+/**
+ * Sign in with the password, which is the request a registered factor is
+ * answered to with a challenge.
+ */
+async function signIn(
+  setUp: SimCognitoSignedInSetUp,
+): Promise<SimCognitoAuthenticationOutput> {
+  return await setUp.cognito.initiateAuth(
+    new InitiateAuthCommand({
+      ClientId: setUp.clientId,
+      AuthFlow: "USER_PASSWORD_AUTH",
+      AuthParameters: {
+        USERNAME: simCognitoUsername,
+        PASSWORD: simCognitoPassword,
+      },
+    }),
+  );
+}
+
+describe("sim Cognito MFA challenge", () => {
+  it("challenges a user registered for SMS, and texts it the code", async () => {
+    // Given a user of a pool offering MFA, registered for a texted code.
+    const setUp = await simCognitoWithSmsFactor();
+
+    // When it signs in with its password.
+    const challenged = await signIn(setUp);
+
+    // Then it is answered with the challenge rather than with tokens, saying
+    // where the code went without giving the whole number away.
+    assertIdentical(challenged.ChallengeName, "SMS_MFA");
+    assertTypeString(challenged.Session);
+    assertUndefined(challenged.AuthenticationResult);
+    assertNonNullable(challenged.ChallengeParameters);
+    assertIdentical(
+      challenged.ChallengeParameters["CODE_DELIVERY_DELIVERY_MEDIUM"],
+      "SMS",
+    );
+    assertIdentical(
+      challenged.ChallengeParameters["CODE_DELIVERY_DESTINATION"],
+      "+*******0123",
+    );
+
+    // And the pool recorded the message it would have texted, on an occasion
+    // of its own, which is where a test reads the code from.
+    const messages = setUp.cognito
+      .userPool(setUp.userPoolId)
+      .sentMessages()
+      .filter((message) => message.occasion === "Authentication");
+
+    assertArrayLength(messages, 1);
+    assertNonNullable(messages[0]);
+    assertIdentical(messages[0].medium, "SMS");
+    assertIdentical(messages[0].recipient, simCognitoPhoneNumber);
+    assertStringIncludes(messages[0].body, "authentication code is");
+  });
+
+  it("signs the user in when the texted code is sent back", async () => {
+    // Given a user challenged for its texted code.
+    const setUp = await simCognitoWithSmsFactor();
+    const challenged = await signIn(setUp);
+
+    // When the code is sent back.
+    const signedIn = await setUp.cognito.respondToAuthChallenge(
+      new RespondToAuthChallengeCommand({
+        ClientId: setUp.clientId,
+        ChallengeName: "SMS_MFA",
+        Session: challenged.Session,
+        ChallengeResponses: {
+          USERNAME: simCognitoUsername,
+          SMS_MFA_CODE: simCognitoSmsMfaCode(setUp.cognito, setUp.userPoolId),
+        },
+      }),
+    );
+
+    // Then the sign-in finishes with the tokens the password alone did not
+    // hand out.
+    assertNonNullable(signedIn.AuthenticationResult?.AccessToken);
+    assertNonNullable(signedIn.AuthenticationResult.IdToken);
+    assertNonNullable(signedIn.AuthenticationResult.RefreshToken);
+    assertUndefined(signedIn.ChallengeName);
+  });
+
+  it("challenges a user registered for an authenticator app", async () => {
+    // Given a user of a pool offering MFA, registered for an authenticator
+    // app rather than a phone number.
+    const setUp = await simCognitoWithSoftwareToken();
+
+    // When it signs in with its password.
+    const challenged = await signIn(setUp);
+
+    // Then it is challenged for the app's code, and nothing was sent
+    // anywhere: the code is on the user's own device.
+    assertIdentical(challenged.ChallengeName, "SOFTWARE_TOKEN_MFA");
+    assertTypeString(challenged.Session);
+    assertNonNullable(challenged.ChallengeParameters);
+    assertUndefined(
+      challenged.ChallengeParameters["CODE_DELIVERY_DELIVERY_MEDIUM"],
+    );
+    assertArrayLength(
+      setUp.cognito.userPool(setUp.userPoolId).sentMessages(),
+      0,
+    );
+  });
+
+  it("signs the user in when the app's code is sent back", async () => {
+    // Given a user challenged for its authenticator app's code.
+    const setUp = await simCognitoWithSoftwareToken();
+    const challenged = await signIn(setUp);
+
+    // When the code that app is showing is sent back. A test computing it from
+    // the SecretCode it was given gets the same value, because the secret is a
+    // real one.
+    const signedIn = await setUp.cognito.respondToAuthChallenge(
+      new RespondToAuthChallengeCommand({
+        ClientId: setUp.clientId,
+        ChallengeName: "SOFTWARE_TOKEN_MFA",
+        Session: challenged.Session,
+        ChallengeResponses: {
+          USERNAME: simCognitoUsername,
+          SOFTWARE_TOKEN_MFA_CODE: simCognitoSoftwareTokenCode(
+            setUp.cognito,
+            setUp.userPoolId,
+          ),
+        },
+      }),
+    );
+
+    // Then the sign-in finishes.
+    assertNonNullable(signedIn.AuthenticationResult?.AccessToken);
+  });
+
+  it("challenges an administrator's sign-in the same way", async () => {
+    // Given a user registered for a texted code.
+    const setUp = await simCognitoWithSmsFactor();
+
+    // When an administrator signs it in.
+    const challenged = await setUp.cognito.adminInitiateAuth(
+      new AdminInitiateAuthCommand({
+        UserPoolId: setUp.userPoolId,
+        ClientId: setUp.clientId,
+        AuthFlow: "ADMIN_USER_PASSWORD_AUTH",
+        AuthParameters: {
+          USERNAME: simCognitoUsername,
+          PASSWORD: simCognitoPassword,
+        },
+      }),
+    );
+
+    // Then that sign-in is challenged too, and answering it hands out tokens.
+    assertIdentical(challenged.ChallengeName, "SMS_MFA");
+
+    const signedIn = await setUp.cognito.adminRespondToAuthChallenge(
+      new AdminRespondToAuthChallengeCommand({
+        UserPoolId: setUp.userPoolId,
+        ClientId: setUp.clientId,
+        ChallengeName: "SMS_MFA",
+        Session: challenged.Session,
+        ChallengeResponses: {
+          USERNAME: simCognitoUsername,
+          SMS_MFA_CODE: simCognitoSmsMfaCode(setUp.cognito, setUp.userPoolId),
+        },
+      }),
+    );
+
+    assertNonNullable(signedIn.AuthenticationResult?.AccessToken);
+  });
+});

--- a/src/service/cognito/command/auth/sim-cognito-mfa-challenge.ts
+++ b/src/service/cognito/command/auth/sim-cognito-mfa-challenge.ts
@@ -1,40 +1,128 @@
-import { SimCognitoInvalidParameterException } from "../../error/sim-cognito.error.js";
+import type { SimClock } from "../../../../util/clock/sim-clock.js";
+import { SimCognitoAuthSession } from "../../user-pool/auth/sim-cognito-auth-session.js";
+import type { SimCognitoUserPoolClient } from "../../user-pool/client/sim-cognito-user-pool-client.js";
+import type { SimCognitoPoolMessenger } from "../../user-pool/message/sim-cognito-pool-messenger.js";
 import type { SimCognitoUserPool } from "../../user-pool/sim-cognito-user-pool.js";
+import { simCognitoSmsMfa } from "../../user-pool/user/mfa/sim-cognito-mfa-factors.js";
+import type { SimCognitoUser } from "../../user-pool/user/sim-cognito-user.js";
+import { simCognitoChallengeFactor } from "./sim-cognito-mfa-factor-choice.js";
+import {
+  simCognitoMaskedDestination,
+  simCognitoMfaCode,
+} from "./sim-cognito-mfa-code.js";
+import type { SimCognitoAuthenticationOutput } from "./auth.command.js";
+
+interface SimCognitoMfaChallengeProperties {
+  readonly messenger: SimCognitoPoolMessenger;
+  readonly clock: SimClock;
+}
 
 /**
- * The multi-factor challenge a pool would answer a sign-in with, which this
- * simulation cannot issue.
+ * A sign-in that has got past the password and may have a factor to answer
+ * for.
+ */
+interface SimCognitoMfaChallengeRequest {
+  readonly pool: SimCognitoUserPool;
+  readonly client: SimCognitoUserPoolClient;
+  readonly user: SimCognitoUser;
+  readonly clientMetadata?: Readonly<Record<string, string>> | undefined;
+}
+
+/**
+ * The multi-factor challenge a pool answers a sign-in with.
  *
- * A pool configured `ON` challenges every user on real Cognito, whether or not
- * that user has registered a factor: one that has is sent
- * `SOFTWARE_TOKEN_MFA` or `SMS_MFA`, and one that has not is sent `MFA_SETUP`.
- * Either way the request that carried the password is answered with a
- * challenge rather than with tokens, so signing the user in here would hand
- * out tokens a real deployment would not.
+ * A user that has registered a factor is challenged for it: `SMS_MFA` for a
+ * phone number, which the pool texts a code to, and `SOFTWARE_TOKEN_MFA` for
+ * an authenticator app, whose code the user reads off its own device. Either
+ * way the request that carried the password is answered with a challenge and a
+ * session rather than with tokens, and `SimCognitoMfaResponse` is what
+ * completes it.
  *
- * A pool configured `OPTIONAL` challenges only the users that registered a
- * factor. Nothing here registers one, so no user of such a pool has one, and
- * signing in without a challenge is what real Cognito does with it too.
- *
- * This is the refusal `CreateUserPool` used to make. It is here instead
- * because this is where the difference shows: a pool that records the setting
- * and never challenges on it is honest for everything but a sign-in.
+ * A pool configured `OFF` challenges nobody. One configured `OPTIONAL`
+ * challenges the users that registered a factor, and one configured `ON`
+ * challenges every user, which is the case this simulation still cannot serve
+ * in full: real Cognito answers a user with no factor with `MFA_SETUP`, which
+ * registers one mid-sign-in, so that sign-in is refused here rather than
+ * handed tokens a deployment would not have handed out.
  */
 export class SimCognitoMfaChallenge {
+  private readonly messenger: SimCognitoPoolMessenger;
+  private readonly clock: SimClock;
+
+  constructor(properties: SimCognitoMfaChallengeProperties) {
+    this.messenger = properties.messenger;
+    this.clock = properties.clock;
+  }
+
   /**
-   * Refuse a sign-in that real Cognito would answer with an MFA challenge.
+   * Where the code went, for the factor that sends one.
+   *
+   * Real Cognito reports the medium and a masked destination on an `SMS_MFA`
+   * challenge, and neither on a `SOFTWARE_TOKEN_MFA` one, because nothing was
+   * sent anywhere for that.
    */
-  refuseIn(pool: SimCognitoUserPool): void {
-    if (!pool.settings.mfa.configuration.challengesEverySignIn) {
-      return;
+  private static deliveryParameters(
+    factor: string,
+    user: SimCognitoUser,
+  ): Record<string, string> {
+    const destination = user.attributeValues.get("phone_number");
+
+    if (factor !== simCognitoSmsMfa || destination === undefined) {
+      return {};
     }
 
-    throw new SimCognitoInvalidParameterException(
-      `User pool ${pool.id} has an MfaConfiguration of 'ON', so real ` +
-        `Cognito would answer this sign-in with an MFA challenge, and ` +
-        `multi-factor authentication is not simulated. Set the pool's ` +
-        `MfaConfiguration to 'OPTIONAL' or 'OFF' to sign in with a password ` +
-        `alone.`,
-    );
+    return {
+      CODE_DELIVERY_DELIVERY_MEDIUM: "SMS",
+      CODE_DELIVERY_DESTINATION: simCognitoMaskedDestination(destination),
+    };
+  }
+
+  /**
+   * The challenge this user has to get past, or nothing where it has none.
+   *
+   * A sign-in that gets nothing back from here is one that can be answered
+   * with tokens.
+   */
+  async issueFor(
+    request: SimCognitoMfaChallengeRequest,
+  ): Promise<SimCognitoAuthenticationOutput | undefined> {
+    const factor = simCognitoChallengeFactor(request.pool, request.user);
+
+    if (factor === undefined) {
+      return undefined;
+    }
+
+    const { pool, client, user } = request;
+    const code = factor === simCognitoSmsMfa ? simCognitoMfaCode() : undefined;
+    const session = new SimCognitoAuthSession({
+      username: user.username,
+      clientId: client.id,
+      challengeName: factor,
+      code,
+      issuedAt: this.clock.now(),
+    });
+
+    pool.auth.addSession(session);
+
+    if (code !== undefined) {
+      await this.messenger.send({
+        pool,
+        client,
+        user,
+        occasion: "Authentication",
+        code,
+        clientMetadata: request.clientMetadata,
+      });
+    }
+
+    return {
+      $metadata: {},
+      ChallengeName: factor,
+      Session: session.id,
+      ChallengeParameters: {
+        USER_ID_FOR_SRP: user.username,
+        ...SimCognitoMfaChallenge.deliveryParameters(factor, user),
+      },
+    };
   }
 }

--- a/src/service/cognito/command/auth/sim-cognito-mfa-code-check.ts
+++ b/src/service/cognito/command/auth/sim-cognito-mfa-code-check.ts
@@ -1,0 +1,57 @@
+import type { SimClock } from "../../../../util/clock/sim-clock.js";
+import { SimCognitoCodeMismatchException } from "../../error/sim-cognito.error.js";
+import type { SimCognitoAuthSession } from "../../user-pool/auth/sim-cognito-auth-session.js";
+import { simCognitoSmsMfa } from "../../user-pool/user/mfa/sim-cognito-mfa-factors.js";
+import type { SimCognitoUser } from "../../user-pool/user/sim-cognito-user.js";
+import type { SimCognitoAuthParameters } from "./sim-cognito-auth-parameters.js";
+
+/**
+ * What a challenge response has to carry the right code for.
+ */
+interface SimCognitoMfaCodeRequest {
+  readonly user: SimCognitoUser;
+  readonly session: SimCognitoAuthSession;
+  readonly parameters: SimCognitoAuthParameters;
+}
+
+/**
+ * Whether a challenge response carries the code its challenge is waiting for.
+ *
+ * A texted code is compared with the one the pool sent, which the session
+ * holds. An authenticator app's code is computed from the secret the user
+ * registered, which is what makes a code from that secret work here as it
+ * would against a deployment.
+ */
+export class SimCognitoMfaCodeCheck {
+  private readonly clock: SimClock;
+
+  constructor(clock: SimClock) {
+    this.clock = clock;
+  }
+
+  /**
+   * Refuse a code that is not the one this challenge is waiting for.
+   */
+  require(request: SimCognitoMfaCodeRequest): void {
+    if (this.matches(request)) {
+      return;
+    }
+
+    throw new SimCognitoCodeMismatchException("Invalid code received for user");
+  }
+
+  private matches(request: SimCognitoMfaCodeRequest): boolean {
+    const { user, session, parameters } = request;
+
+    if (session.challengeName === simCognitoSmsMfa) {
+      return parameters.require("SMS_MFA_CODE") === session.code;
+    }
+
+    return (
+      user.mfa.softwareToken?.matches(
+        parameters.require("SOFTWARE_TOKEN_MFA_CODE"),
+        this.clock.now(),
+      ) ?? false
+    );
+  }
+}

--- a/src/service/cognito/command/auth/sim-cognito-mfa-code.ts
+++ b/src/service/cognito/command/auth/sim-cognito-mfa-code.ts
@@ -1,0 +1,39 @@
+import { randomInt } from "node:crypto";
+
+/**
+ * How many digits an MFA code has, which is what a confirmation code has too.
+ */
+const codeDigits = 6;
+
+/**
+ * How many characters of a destination Cognito leaves readable.
+ */
+const readableCharacters = 4;
+
+/**
+ * The mask Cognito puts in front of them.
+ */
+const maskLength = 7;
+
+/**
+ * Issue the code a pool texts a user it is challenging.
+ *
+ * Leading zeros are kept, because a real code has them and a test treating the
+ * value as a number would lose them.
+ */
+export function simCognitoMfaCode(): string {
+  return String(randomInt(0, 10 ** codeDigits)).padStart(codeDigits, "0");
+}
+
+/**
+ * A destination as `CODE_DELIVERY_DESTINATION` reports it.
+ *
+ * Cognito never tells a caller the whole phone number it sent a code to: the
+ * challenge carries the last few characters behind a fixed run of asterisks,
+ * which is enough for an application to say which number it went to and not
+ * enough to learn one. The mask is a fixed length there rather than the length
+ * of what it hides, so a number's length cannot be read off it either.
+ */
+export function simCognitoMaskedDestination(destination: string): string {
+  return `+${"*".repeat(maskLength)}${destination.slice(-readableCharacters)}`;
+}

--- a/src/service/cognito/command/auth/sim-cognito-mfa-factor-choice.ts
+++ b/src/service/cognito/command/auth/sim-cognito-mfa-factor-choice.ts
@@ -1,0 +1,64 @@
+import { SimCognitoInvalidParameterException } from "../../error/sim-cognito.error.js";
+import type { SimCognitoUserPool } from "../../user-pool/sim-cognito-user-pool.js";
+import type { SimCognitoUser } from "../../user-pool/user/sim-cognito-user.js";
+
+/**
+ * Which factor a sign-in is challenged for, and nothing where the sign-in
+ * carries on without a challenge.
+ *
+ * A pool configured `OFF` challenges nobody, whatever its users have
+ * registered. One configured `OPTIONAL` challenges the users that registered a
+ * factor, and one configured `ON` challenges every user.
+ */
+export function simCognitoChallengeFactor(
+  pool: SimCognitoUserPool,
+  user: SimCognitoUser,
+): string | undefined {
+  if (!pool.settings.mfa.configuration.challengesAnySignIn) {
+    return undefined;
+  }
+
+  const factor = user.mfa.challengeFactor;
+
+  if (factor !== undefined) {
+    return factor;
+  }
+
+  refuseUnchallengeable(pool, user);
+
+  return undefined;
+}
+
+/**
+ * Refuse a sign-in real Cognito would answer with a challenge this simulation
+ * does not issue.
+ *
+ * A user with two factors enabled and no preference between them is answered
+ * with `SELECT_MFA_TYPE`, and a user of an `ON` pool with no factor at all
+ * with `MFA_SETUP`. Both choose or register something mid-sign-in, which is a
+ * flow of its own, so the sign-in is refused here rather than handed tokens a
+ * deployment would not have handed out.
+ */
+function refuseUnchallengeable(
+  pool: SimCognitoUserPool,
+  user: SimCognitoUser,
+): void {
+  if (user.mfa.settings.length > 1) {
+    throw new SimCognitoInvalidParameterException(
+      `User ${user.username} has ${user.mfa.settings.join(" and ")} enabled ` +
+        `and prefers neither, so real Cognito would answer this sign-in with ` +
+        `a SELECT_MFA_TYPE challenge, which is not simulated. Prefer one of ` +
+        `them with SetUserMFAPreference.`,
+    );
+  }
+
+  if (pool.settings.mfa.configuration.challengesEverySignIn) {
+    throw new SimCognitoInvalidParameterException(
+      `User pool ${pool.id} has an MfaConfiguration of 'ON' and user ` +
+        `${user.username} has registered no second factor, so real Cognito ` +
+        `would answer this sign-in with an MFA_SETUP challenge, which is not ` +
+        `simulated. Register a factor for the user, or set the pool's ` +
+        `MfaConfiguration to 'OPTIONAL' or 'OFF'.`,
+    );
+  }
+}

--- a/src/service/cognito/command/auth/sim-cognito-mfa-response.iso.test.ts
+++ b/src/service/cognito/command/auth/sim-cognito-mfa-response.iso.test.ts
@@ -1,0 +1,257 @@
+import {
+  AssociateSoftwareTokenCommand,
+  InitiateAuthCommand,
+  RespondToAuthChallengeCommand,
+  SetUserMFAPreferenceCommand,
+  VerifySoftwareTokenCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import {
+  simCognitoSmsMfaCode,
+  simCognitoWithSmsFactor,
+  simCognitoWithSoftwareToken,
+} from "../../../../../test/cognito/mfa-fixture.js";
+import type { SimCognitoSignedInSetUp } from "../../../../../test/cognito/signed-in-fixture.js";
+import {
+  simCognitoPassword,
+  simCognitoUsername,
+} from "../../../../../test/cognito/signed-in-fixture.js";
+import {
+  SimCognitoCodeMismatchException,
+  SimCognitoNotAuthorizedException,
+} from "../../error/sim-cognito.error.js";
+import type { SimCognitoAuthenticationOutput } from "./auth.command.js";
+
+/**
+ * Sign in with the password and be challenged for the second factor.
+ */
+async function challenged(
+  setUp: SimCognitoSignedInSetUp,
+): Promise<SimCognitoAuthenticationOutput> {
+  return await setUp.cognito.initiateAuth(
+    new InitiateAuthCommand({
+      ClientId: setUp.clientId,
+      AuthFlow: "USER_PASSWORD_AUTH",
+      AuthParameters: {
+        USERNAME: simCognitoUsername,
+        PASSWORD: simCognitoPassword,
+      },
+    }),
+  );
+}
+
+/**
+ * Answer an `SMS_MFA` challenge with the code given.
+ */
+async function answerWith(
+  setUp: SimCognitoSignedInSetUp,
+  session: string | undefined,
+  code: string,
+): Promise<SimCognitoAuthenticationOutput> {
+  return await setUp.cognito.respondToAuthChallenge(
+    new RespondToAuthChallengeCommand({
+      ClientId: setUp.clientId,
+      ChallengeName: "SMS_MFA",
+      Session: session,
+      ChallengeResponses: { USERNAME: simCognitoUsername, SMS_MFA_CODE: code },
+    }),
+  );
+}
+
+describe("sim Cognito MFA challenge response", () => {
+  it("refuses a code that is not the one the pool sent", async () => {
+    // Given a user challenged for its texted code.
+    const setUp = await simCognitoWithSmsFactor();
+    const started = await challenged(setUp);
+
+    // When the wrong code is sent back.
+    const error = await assertThrowsErrorAsync(async () => {
+      await answerWith(setUp, started.Session, "000000");
+    });
+
+    // Then it is refused as a code mismatch, and the challenge is still
+    // standing: a user that mistyped a code gets to type it again, as it does
+    // on real Cognito.
+    assertInstanceOf(error, SimCognitoCodeMismatchException);
+
+    const signedIn = await answerWith(
+      setUp,
+      started.Session,
+      simCognitoSmsMfaCode(setUp.cognito, setUp.userPoolId),
+    );
+
+    assertNonNullable(signedIn.AuthenticationResult?.AccessToken);
+  });
+
+  it("refuses a code the wrong authenticator app computed", async () => {
+    // Given a user challenged for its app's code.
+    const setUp = await simCognitoWithSoftwareToken();
+    const started = await challenged(setUp);
+
+    // When a code from some other secret is sent back.
+    const error = await assertThrowsErrorAsync(async () => {
+      await setUp.cognito.respondToAuthChallenge(
+        new RespondToAuthChallengeCommand({
+          ClientId: setUp.clientId,
+          ChallengeName: "SOFTWARE_TOKEN_MFA",
+          Session: started.Session,
+          ChallengeResponses: {
+            USERNAME: simCognitoUsername,
+            SOFTWARE_TOKEN_MFA_CODE: "000000",
+          },
+        }),
+      );
+    });
+
+    // Then it is refused.
+    assertInstanceOf(error, SimCognitoCodeMismatchException);
+  });
+
+  it("spends the session the code was accepted with", async () => {
+    // Given a user that has answered its challenge.
+    const setUp = await simCognitoWithSmsFactor();
+    const started = await challenged(setUp);
+    const code = simCognitoSmsMfaCode(setUp.cognito, setUp.userPoolId);
+
+    await answerWith(setUp, started.Session, code);
+
+    // When the same code and session are sent again.
+    const error = await assertThrowsErrorAsync(async () => {
+      await answerWith(setUp, started.Session, code);
+    });
+
+    // Then it signs nobody in a second time: a code is single use, as its
+    // session is.
+    assertInstanceOf(error, SimCognitoNotAuthorizedException);
+    assertStringIncludes(error.message, "Invalid session for the user");
+  });
+
+  it("refuses a session that has run out", async () => {
+    // Given a user challenged for its texted code.
+    const setUp = await simCognitoWithSmsFactor();
+    const started = await challenged(setUp);
+    const code = simCognitoSmsMfaCode(setUp.cognito, setUp.userPoolId);
+
+    // When it answers after the three minutes a session lasts.
+    await setUp.simAws.clock().advanceBy({ minutes: 4 });
+
+    const error = await assertThrowsErrorAsync(async () => {
+      await answerWith(setUp, started.Session, code);
+    });
+
+    // Then the session is refused rather than the code checked.
+    assertInstanceOf(error, SimCognitoNotAuthorizedException);
+  });
+
+  it("refuses a session issued for another challenge", async () => {
+    // Given a user challenged for its app's code.
+    const setUp = await simCognitoWithSoftwareToken();
+    const started = await challenged(setUp);
+
+    // When that session is used to answer the other MFA challenge.
+    const error = await assertThrowsErrorAsync(async () => {
+      await answerWith(setUp, started.Session, "123456");
+    });
+
+    // Then it is refused: a session carries the one challenge it was issued
+    // for.
+    assertInstanceOf(error, SimCognitoNotAuthorizedException);
+  });
+
+  it("refuses a sign-in by a user that prefers neither of its factors", async () => {
+    // Given a user with both factors enabled and no preference between them,
+    // which is the state SetUserMFAPreference leaves when a request enables
+    // both and prefers neither.
+    const setUp = await simCognitoWithSmsFactor();
+
+    await setUp.cognito.associateSoftwareToken(
+      new AssociateSoftwareTokenCommand({ AccessToken: setUp.accessToken }),
+    );
+    await setUp.cognito.verifySoftwareToken(
+      new VerifySoftwareTokenCommand({
+        AccessToken: setUp.accessToken,
+        UserCode: setUp.cognito
+          .userPool(setUp.userPoolId)
+          .softwareTokenCode(simCognitoUsername),
+      }),
+    );
+    await setUp.cognito.setUserMFAPreference(
+      new SetUserMFAPreferenceCommand({
+        AccessToken: setUp.accessToken,
+        SMSMfaSettings: { Enabled: true },
+        SoftwareTokenMfaSettings: { Enabled: true },
+      }),
+    );
+
+    // When it signs in.
+    const error = await assertThrowsErrorAsync(async () => {
+      await challenged(setUp);
+    });
+
+    // Then it is refused where real Cognito would answer with the challenge
+    // that asks which factor to use, saying how to get past it.
+    assertStringIncludes(error.message, "SELECT_MFA_TYPE");
+    assertStringIncludes(error.message, "SetUserMFAPreference");
+  });
+
+  it("challenges for a factor after the new password challenge", async () => {
+    // Given a user registered for a texted code, whose password an
+    // administrator has reset to a temporary one.
+    const setUp = await simCognitoWithSmsFactor();
+
+    await setUp.cognito.adminSetUserPassword({
+      input: {
+        UserPoolId: setUp.userPoolId,
+        Username: simCognitoUsername,
+        Password: "Temp0rary!",
+        Permanent: false,
+      },
+    });
+
+    // When it signs in and answers the new password challenge.
+    const first = await setUp.cognito.initiateAuth(
+      new InitiateAuthCommand({
+        ClientId: setUp.clientId,
+        AuthFlow: "USER_PASSWORD_AUTH",
+        AuthParameters: {
+          USERNAME: simCognitoUsername,
+          PASSWORD: "Temp0rary!",
+        },
+      }),
+    );
+
+    assertIdentical(first.ChallengeName, "NEW_PASSWORD_REQUIRED");
+
+    const second = await setUp.cognito.respondToAuthChallenge(
+      new RespondToAuthChallengeCommand({
+        ClientId: setUp.clientId,
+        ChallengeName: "NEW_PASSWORD_REQUIRED",
+        Session: first.Session,
+        ChallengeResponses: {
+          USERNAME: simCognitoUsername,
+          NEW_PASSWORD: simCognitoPassword,
+        },
+      }),
+    );
+
+    // Then the second factor is challenged for before any token is issued, as
+    // real Cognito challenges one challenge after the other.
+    assertIdentical(second.ChallengeName, "SMS_MFA");
+
+    const signedIn = await answerWith(
+      setUp,
+      second.Session,
+      simCognitoSmsMfaCode(setUp.cognito, setUp.userPoolId),
+    );
+
+    assertNonNullable(signedIn.AuthenticationResult?.AccessToken);
+  });
+});

--- a/src/service/cognito/command/auth/sim-cognito-mfa-response.ts
+++ b/src/service/cognito/command/auth/sim-cognito-mfa-response.ts
@@ -1,0 +1,92 @@
+import type { SimClock } from "../../../../util/clock/sim-clock.js";
+import {
+  requireSimCognitoEnabled,
+  requireSimCognitoSignInUser,
+} from "../../user-pool/auth/sim-cognito-sign-in.js";
+import { SimCognitoTriggerOccasion } from "../../user-pool/trigger/sim-cognito-trigger-occasion.js";
+import type { SimCognitoAuthResolver } from "./sim-cognito-auth-resolver.js";
+import { SimCognitoMfaCodeCheck } from "./sim-cognito-mfa-code-check.js";
+import type { SimCognitoChallengeResponseRequest } from "./sim-cognito-new-password-response.js";
+import type { SimCognitoSignInCompletion } from "./sim-cognito-sign-in-completion.js";
+import type { SimCognitoAuthenticationOutput } from "./auth.command.js";
+
+interface SimCognitoMfaResponseProperties {
+  readonly authResolver: SimCognitoAuthResolver;
+  readonly completion: SimCognitoSignInCompletion;
+  readonly clock: SimClock;
+}
+
+/**
+ * A response to one of the two MFA challenges.
+ */
+export interface SimCognitoMfaResponseRequest extends SimCognitoChallengeResponseRequest {
+  /** Which challenge is being answered, which its session has to match. */
+  readonly challengeName: string;
+}
+
+/**
+ * Answering an `SMS_MFA` or `SOFTWARE_TOKEN_MFA` challenge.
+ *
+ * The code is checked against whatever issued it: a texted code against the
+ * one the challenge sent, which the session holds, and an authenticator app's
+ * code against the secret the user registered. A wrong code leaves the session
+ * alone, so the caller can read the next code off its app or ask the user to
+ * retype the one it was sent, as real Cognito lets it. A right one spends the
+ * session, so the same code cannot sign in twice.
+ *
+ * This is the body of both `AdminRespondToAuthChallenge` and
+ * `RespondToAuthChallenge`, which differ only in how they reach the pool.
+ */
+export class SimCognitoMfaResponse {
+  private readonly authResolver: SimCognitoAuthResolver;
+  private readonly completion: SimCognitoSignInCompletion;
+  private readonly clock: SimClock;
+  private readonly codeCheck: SimCognitoMfaCodeCheck;
+
+  constructor(properties: SimCognitoMfaResponseProperties) {
+    this.authResolver = properties.authResolver;
+    this.completion = properties.completion;
+    this.clock = properties.clock;
+    this.codeCheck = new SimCognitoMfaCodeCheck(properties.clock);
+  }
+
+  /**
+   * Complete the challenge, and sign the user in.
+   *
+   * This is where the sign-in the challenge interrupted finishes, so it is
+   * where `PostAuthentication` runs and where the tokens are issued.
+   * `PreAuthentication` does not run again: it ran when the password was
+   * checked, and real Cognito fires it once per sign-in rather than once per
+   * request.
+   */
+  async handle(
+    request: SimCognitoMfaResponseRequest,
+  ): Promise<SimCognitoAuthenticationOutput> {
+    const { pool, client, parameters, challengeName } = request;
+    const username = this.authResolver.username(client, parameters);
+    const session = pool.auth.requireSession({
+      sessionId: request.session,
+      username,
+      clientId: client.id,
+      challengeName,
+      now: this.clock.now(),
+    });
+    const user = requireSimCognitoSignInUser(pool, client, username);
+
+    // A user disabled between the challenge and this response cannot finish
+    // the sign-in, as it cannot start one.
+    requireSimCognitoEnabled(user);
+
+    this.codeCheck.require({ user, session, parameters });
+    pool.auth.removeSession(session);
+
+    return await this.completion.complete({
+      pool,
+      client,
+      user,
+      occasion: SimCognitoTriggerOccasion.tokenGeneration,
+      tokenClientMetadata: request.clientMetadata,
+      clientMetadata: request.clientMetadata,
+    });
+  }
+}

--- a/src/service/cognito/command/auth/sim-cognito-mfa-sign-in.iso.test.ts
+++ b/src/service/cognito/command/auth/sim-cognito-mfa-sign-in.iso.test.ts
@@ -124,8 +124,9 @@ describe("sim Cognito sign-in to a pool offering MFA", () => {
     assertNonNullable(client.AuthenticationResult?.AccessToken);
   });
 
-  it("refuses a sign-in a pool requiring MFA would challenge", async () => {
-    // Given a pool that requires MFA of every user, with a confirmed user.
+  it("refuses a sign-in by a user of an ON pool with no factor", async () => {
+    // Given a pool that requires MFA of every user, with a confirmed user that
+    // has registered no second factor.
     const { cognito, userPoolId, clientId } = await simCognitoWithClient("ON");
 
     await signUpAlice(cognito, userPoolId, clientId);
@@ -151,20 +152,21 @@ describe("sim Cognito sign-in to a pool offering MFA", () => {
       );
     });
 
-    // Then both are refused where real Cognito would answer with the MFA
-    // challenge, saying what it was that could not be done.
+    // Then both are refused where real Cognito would answer with the
+    // MFA_SETUP challenge that registers a factor mid-sign-in, saying what it
+    // was that could not be done.
     for (const error of [admin, client]) {
       assertInstanceOf(error, SimCognitoInvalidParameterException);
       assertStringIncludes(error.message, userPoolId);
       assertStringIncludes(error.message, "would answer this sign-in with an");
-      assertStringIncludes(error.message, "MFA challenge");
+      assertStringIncludes(error.message, "MFA_SETUP challenge");
       assertStringIncludes(error.message, "not simulated");
     }
   });
 
-  it("refuses a new password answered to a pool requiring MFA", async () => {
+  it("refuses a new password answered by a user of an ON pool with no factor", async () => {
     // Given a pool requiring MFA, with a user that has to change its password
-    // before it can sign in.
+    // before it can sign in and has registered no second factor.
     const { cognito, userPoolId, clientId } = await simCognitoWithClient("ON");
 
     await cognito.adminCreateUser({
@@ -207,6 +209,6 @@ describe("sim Cognito sign-in to a pool offering MFA", () => {
 
     // Then it is refused there instead.
     assertInstanceOf(error, SimCognitoInvalidParameterException);
-    assertStringIncludes(error.message, "MFA challenge");
+    assertStringIncludes(error.message, "MFA_SETUP challenge");
   });
 });

--- a/src/service/cognito/command/auth/sim-cognito-new-password-response.ts
+++ b/src/service/cognito/command/auth/sim-cognito-new-password-response.ts
@@ -4,19 +4,16 @@ import {
   requireSimCognitoSignInUser,
 } from "../../user-pool/auth/sim-cognito-sign-in.js";
 import { SimCognitoPasswordCheck } from "../../user-pool/sim-cognito-password-check.js";
-import type { SimCognitoTokenIssuer } from "../../user-pool/token/sim-cognito-token-issuer.js";
 import { SimCognitoTriggerOccasion } from "../../user-pool/trigger/sim-cognito-trigger-occasion.js";
-import type { SimCognitoUserPoolTriggers } from "../../user-pool/trigger/sim-cognito-user-pool-triggers.js";
-import { SimCognitoAuthenticationResult } from "./sim-cognito-authentication-result.js";
+import { newPasswordRequiredChallenge } from "./sim-cognito-auth-challenge.js";
 import type { SimCognitoAuthResolver } from "./sim-cognito-auth-resolver.js";
-import { SimCognitoMfaChallenge } from "./sim-cognito-mfa-challenge.js";
+import type { SimCognitoSignInCompletion } from "./sim-cognito-sign-in-completion.js";
 import type { SimCognitoAuthRequest } from "./sim-cognito-password-sign-in.js";
 import type { SimCognitoAuthenticationOutput } from "./auth.command.js";
 
 interface SimCognitoNewPasswordResponseProperties {
   readonly authResolver: SimCognitoAuthResolver;
-  readonly tokenIssuer: SimCognitoTokenIssuer;
-  readonly triggers: SimCognitoUserPoolTriggers;
+  readonly completion: SimCognitoSignInCompletion;
   readonly clock: SimClock;
 }
 
@@ -39,16 +36,12 @@ export interface SimCognitoChallengeResponseRequest extends SimCognitoAuthReques
  */
 export class SimCognitoNewPasswordResponse {
   private readonly authResolver: SimCognitoAuthResolver;
-  private readonly tokenIssuer: SimCognitoTokenIssuer;
-  private readonly triggers: SimCognitoUserPoolTriggers;
+  private readonly completion: SimCognitoSignInCompletion;
   private readonly clock: SimClock;
-  private readonly result = new SimCognitoAuthenticationResult();
-  private readonly mfaChallenge = new SimCognitoMfaChallenge();
 
   constructor(properties: SimCognitoNewPasswordResponseProperties) {
     this.authResolver = properties.authResolver;
-    this.tokenIssuer = properties.tokenIssuer;
-    this.triggers = properties.triggers;
+    this.completion = properties.completion;
     this.clock = properties.clock;
   }
 
@@ -71,6 +64,7 @@ export class SimCognitoNewPasswordResponse {
       sessionId: request.session,
       username,
       clientId: client.id,
+      challengeName: newPasswordRequiredChallenge,
       now: this.clock.now(),
     });
     const user = requireSimCognitoSignInUser(pool, client, username);
@@ -89,34 +83,20 @@ export class SimCognitoNewPasswordResponse {
 
     pool.auth.removeSession(session);
 
-    // A pool that challenges every user answers the new password with an MFA
-    // challenge rather than with tokens, and this simulation has none to
-    // issue.
-    this.mfaChallenge.refuseIn(pool);
-
+    // A user that has registered a second factor answers for it before the
+    // sign-in this challenge interrupted can finish, as it would on real
+    // Cognito: one challenge follows the other.
+    //
     // This is the one occasion real Cognito passes a request's `ClientMetadata`
     // to the token trigger, so it travels with the tokens here and nowhere
     // else.
-    const authenticated = {
-      $metadata: {},
-      AuthenticationResult: this.result.of(
-        await this.tokenIssuer.issue({
-          pool,
-          client,
-          user,
-          occasion: SimCognitoTriggerOccasion.newPasswordTokenGeneration,
-          clientMetadata: request.clientMetadata,
-        }),
-      ),
-    };
-
-    await this.triggers.postAuthentication({
+    return await this.completion.challengeOrComplete({
       pool,
       client,
       user,
+      occasion: SimCognitoTriggerOccasion.newPasswordTokenGeneration,
+      tokenClientMetadata: request.clientMetadata,
       clientMetadata: request.clientMetadata,
     });
-
-    return authenticated;
   }
 }

--- a/src/service/cognito/command/auth/sim-cognito-password-sign-in.ts
+++ b/src/service/cognito/command/auth/sim-cognito-password-sign-in.ts
@@ -5,11 +5,9 @@ import {
 } from "../../user-pool/auth/sim-cognito-sign-in.js";
 import type { SimCognitoUserPoolClient } from "../../user-pool/client/sim-cognito-user-pool-client.js";
 import type { SimCognitoUserPool } from "../../user-pool/sim-cognito-user-pool.js";
-import type { SimCognitoTokenIssuer } from "../../user-pool/token/sim-cognito-token-issuer.js";
 import { SimCognitoTriggerOccasion } from "../../user-pool/trigger/sim-cognito-trigger-occasion.js";
 import type { SimCognitoUserPoolTriggers } from "../../user-pool/trigger/sim-cognito-user-pool-triggers.js";
-import { SimCognitoAuthenticationResult } from "./sim-cognito-authentication-result.js";
-import { SimCognitoMfaChallenge } from "./sim-cognito-mfa-challenge.js";
+import type { SimCognitoSignInCompletion } from "./sim-cognito-sign-in-completion.js";
 import type { SimCognitoAuthParameters } from "./sim-cognito-auth-parameters.js";
 import type { SimCognitoAuthResolver } from "./sim-cognito-auth-resolver.js";
 import type { SimCognitoNewPasswordChallenge } from "./sim-cognito-new-password-challenge.js";
@@ -17,7 +15,7 @@ import type { SimCognitoAuthenticationOutput } from "./auth.command.js";
 
 interface SimCognitoPasswordSignInProperties {
   readonly authResolver: SimCognitoAuthResolver;
-  readonly tokenIssuer: SimCognitoTokenIssuer;
+  readonly completion: SimCognitoSignInCompletion;
   readonly challenge: SimCognitoNewPasswordChallenge;
   readonly triggers: SimCognitoUserPoolTriggers;
 }
@@ -48,15 +46,13 @@ export interface SimCognitoAuthRequest {
  */
 export class SimCognitoPasswordSignIn {
   private readonly authResolver: SimCognitoAuthResolver;
-  private readonly tokenIssuer: SimCognitoTokenIssuer;
+  private readonly completion: SimCognitoSignInCompletion;
   private readonly challenge: SimCognitoNewPasswordChallenge;
   private readonly triggers: SimCognitoUserPoolTriggers;
-  private readonly result = new SimCognitoAuthenticationResult();
-  private readonly mfaChallenge = new SimCognitoMfaChallenge();
 
   constructor(properties: SimCognitoPasswordSignInProperties) {
     this.authResolver = properties.authResolver;
-    this.tokenIssuer = properties.tokenIssuer;
+    this.completion = properties.completion;
     this.challenge = properties.challenge;
     this.triggers = properties.triggers;
   }
@@ -95,33 +91,19 @@ export class SimCognitoPasswordSignIn {
       return this.challenge.issue({ pool, clientId: client.id, user });
     }
 
-    // A pool that challenges every user would answer with an MFA challenge
-    // here rather than with tokens, and this simulation has no challenge to
-    // issue, so it refuses where the challenge would have been.
-    this.mfaChallenge.refuseIn(pool);
-
+    // A user that has registered a second factor is challenged for it here
+    // rather than answered with tokens, which is what the pool's
+    // MfaConfiguration decides.
+    //
     // `ClientMetadata` reaches PreAuthentication and PostAuthentication, and
     // not the token trigger: real Cognito does not pass an InitiateAuth or
     // AdminInitiateAuth request's on to that one.
-    const authenticated = {
-      $metadata: {},
-      AuthenticationResult: this.result.of(
-        await this.tokenIssuer.issue({
-          pool,
-          client,
-          user,
-          occasion: SimCognitoTriggerOccasion.tokenGeneration,
-        }),
-      ),
-    };
-
-    await this.triggers.postAuthentication({
+    return await this.completion.challengeOrComplete({
       pool,
       client,
       user,
+      occasion: SimCognitoTriggerOccasion.tokenGeneration,
       clientMetadata,
     });
-
-    return authenticated;
   }
 }

--- a/src/service/cognito/command/auth/sim-cognito-respond-to-challenge.iso.test.ts
+++ b/src/service/cognito/command/auth/sim-cognito-respond-to-challenge.iso.test.ts
@@ -167,20 +167,20 @@ describe("sim Cognito RespondToAuthChallenge", () => {
     // Given a user challenged for a new password.
     const { cognito, clientId, session } = await simCognitoChallenged();
 
-    // When an MFA challenge is answered instead.
+    // When a challenge nothing here issues is answered instead.
     const error = await assertThrowsErrorAsync(async () => {
       await cognito.respondToAuthChallenge(
         new RespondToAuthChallengeCommand({
           ClientId: clientId,
-          ChallengeName: "SMS_MFA",
+          ChallengeName: "MFA_SETUP",
           Session: session,
-          ChallengeResponses: { USERNAME: "alice", SMS_MFA_CODE: "123456" },
+          ChallengeResponses: { USERNAME: "alice" },
         }),
       );
     });
 
-    // Then it is refused rather than answered as the one challenge that is
-    // simulated.
+    // Then it is refused rather than answered as one of the challenges that
+    // are simulated.
     assertInstanceOf(error, SimCognitoInvalidParameterException);
     assertStringIncludes(error.message, "is not simulated");
   });

--- a/src/service/cognito/command/auth/sim-cognito-respond-to-challenge.ts
+++ b/src/service/cognito/command/auth/sim-cognito-respond-to-challenge.ts
@@ -1,7 +1,6 @@
 import { SimCognitoAuthParameters } from "./sim-cognito-auth-parameters.js";
 import type { SimCognitoAuthResolver } from "./sim-cognito-auth-resolver.js";
-import { requireSimCognitoNewPasswordChallenge } from "./sim-cognito-auth-challenge.js";
-import type { SimCognitoNewPasswordResponse } from "./sim-cognito-new-password-response.js";
+import type { SimCognitoChallengeResponses } from "./sim-cognito-challenge-responses.js";
 import { SimCognitoUnsimulatedAuthOptions } from "./sim-cognito-unsimulated-auth-options.js";
 import type {
   SimRespondToAuthChallengeCommand,
@@ -10,7 +9,7 @@ import type {
 
 interface SimCognitoRespondToChallengeProperties {
   readonly authResolver: SimCognitoAuthResolver;
-  readonly newPassword: SimCognitoNewPasswordResponse;
+  readonly responses: SimCognitoChallengeResponses;
 }
 
 /**
@@ -22,12 +21,12 @@ interface SimCognitoRespondToChallengeProperties {
  */
 export class SimCognitoRespondToChallenge {
   private readonly authResolver: SimCognitoAuthResolver;
-  private readonly newPassword: SimCognitoNewPasswordResponse;
+  private readonly responses: SimCognitoChallengeResponses;
   private readonly unsimulatedOptions = new SimCognitoUnsimulatedAuthOptions();
 
   constructor(properties: SimCognitoRespondToChallengeProperties) {
     this.authResolver = properties.authResolver;
-    this.newPassword = properties.newPassword;
+    this.responses = properties.responses;
   }
 
   /**
@@ -40,9 +39,7 @@ export class SimCognitoRespondToChallenge {
     const { pool, client } = this.authResolver.client(input.ClientId);
 
     this.unsimulatedOptions.refuseInResponse(input);
-    requireSimCognitoNewPasswordChallenge(input.ChallengeName);
-
-    return await this.newPassword.handle({
+    return await this.responses.handle(input.ChallengeName, {
       pool,
       client,
       parameters: new SimCognitoAuthParameters(

--- a/src/service/cognito/command/auth/sim-cognito-sign-in-completion.ts
+++ b/src/service/cognito/command/auth/sim-cognito-sign-in-completion.ts
@@ -1,0 +1,118 @@
+import type { SimCognitoUserPoolClient } from "../../user-pool/client/sim-cognito-user-pool-client.js";
+import type { SimCognitoUserPool } from "../../user-pool/sim-cognito-user-pool.js";
+import type { SimCognitoTokenIssuer } from "../../user-pool/token/sim-cognito-token-issuer.js";
+import type { SimCognitoTriggerOccasion } from "../../user-pool/trigger/sim-cognito-trigger-occasion.js";
+import type { SimCognitoUserPoolTriggers } from "../../user-pool/trigger/sim-cognito-user-pool-triggers.js";
+import type { SimCognitoUser } from "../../user-pool/user/sim-cognito-user.js";
+import { SimCognitoAuthenticationResult } from "./sim-cognito-authentication-result.js";
+import type { SimCognitoMfaChallenge } from "./sim-cognito-mfa-challenge.js";
+import type { SimCognitoAuthenticationOutput } from "./auth.command.js";
+
+interface SimCognitoSignInCompletionProperties {
+  readonly tokenIssuer: SimCognitoTokenIssuer;
+  readonly triggers: SimCognitoUserPoolTriggers;
+
+  /** The second factor a user may still owe before it is signed in. */
+  readonly mfaChallenge: SimCognitoMfaChallenge;
+}
+
+/**
+ * A sign-in with nothing left in its way.
+ */
+interface SimCognitoCompletedSignIn {
+  readonly pool: SimCognitoUserPool;
+  readonly client: SimCognitoUserPoolClient;
+  readonly user: SimCognitoUser;
+
+  /**
+   * The `PreTokenGeneration` occasion these tokens are issued on, which says
+   * which request finished the sign-in.
+   */
+  readonly occasion: SimCognitoTriggerOccasion;
+
+  /**
+   * The `ClientMetadata` to pass on to the token trigger, which only the
+   * challenge responses have: real Cognito does not pass an `InitiateAuth`
+   * request's on to that one.
+   */
+  readonly tokenClientMetadata?: Readonly<Record<string, string>> | undefined;
+
+  /** The `ClientMetadata` `PostAuthentication` reads, which every request has. */
+  readonly clientMetadata?: Readonly<Record<string, string>> | undefined;
+}
+
+/**
+ * The last thing every finished sign-in does: issue the tokens, and run the
+ * pool's `PostAuthentication` trigger.
+ *
+ * A sign-in can finish at the password, at the new password challenge or at an
+ * MFA challenge, and all three end the same way, so they end in one place. The
+ * order matters and is real Cognito's: the tokens are issued first, and the
+ * trigger runs after them, so a handler that throws does not stop the tokens
+ * being handed out.
+ *
+ * The two that finish before the second factor go through
+ * `challengeOrComplete`, which is where a user that registered one is
+ * challenged instead.
+ */
+export class SimCognitoSignInCompletion {
+  private readonly tokenIssuer: SimCognitoTokenIssuer;
+  private readonly triggers: SimCognitoUserPoolTriggers;
+  private readonly mfaChallenge: SimCognitoMfaChallenge;
+  private readonly result = new SimCognitoAuthenticationResult();
+
+  constructor(properties: SimCognitoSignInCompletionProperties) {
+    this.tokenIssuer = properties.tokenIssuer;
+    this.triggers = properties.triggers;
+    this.mfaChallenge = properties.mfaChallenge;
+  }
+
+  /**
+   * Answer with the MFA challenge this user still owes, or with the tokens
+   * where it owes none.
+   */
+  async challengeOrComplete(
+    request: SimCognitoCompletedSignIn,
+  ): Promise<SimCognitoAuthenticationOutput> {
+    const { pool, client, user, clientMetadata } = request;
+
+    return (
+      (await this.mfaChallenge.issueFor({
+        pool,
+        client,
+        user,
+        clientMetadata,
+      })) ?? (await this.complete(request))
+    );
+  }
+
+  /**
+   * Answer with the tokens this sign-in earned.
+   */
+  async complete(
+    request: SimCognitoCompletedSignIn,
+  ): Promise<SimCognitoAuthenticationOutput> {
+    const { pool, client, user, clientMetadata } = request;
+    const authenticated = {
+      $metadata: {},
+      AuthenticationResult: this.result.of(
+        await this.tokenIssuer.issue({
+          pool,
+          client,
+          user,
+          occasion: request.occasion,
+          clientMetadata: request.tokenClientMetadata,
+        }),
+      ),
+    };
+
+    await this.triggers.postAuthentication({
+      pool,
+      client,
+      user,
+      clientMetadata,
+    });
+
+    return authenticated;
+  }
+}

--- a/src/service/cognito/command/auth/sim-cognito-sign-in-completion.ts
+++ b/src/service/cognito/command/auth/sim-cognito-sign-in-completion.ts
@@ -47,9 +47,10 @@ interface SimCognitoCompletedSignIn {
  *
  * A sign-in can finish at the password, at the new password challenge or at an
  * MFA challenge, and all three end the same way, so they end in one place. The
- * order matters and is real Cognito's: the tokens are issued first, and the
- * trigger runs after them, so a handler that throws does not stop the tokens
- * being handed out.
+ * order matters and is real Cognito's: the tokens are issued first and the
+ * trigger runs after them, so a handler that throws leaves the sign-in it was
+ * told about standing. The request itself still fails on the trigger, and the
+ * caller is answered with the failure rather than with the tokens.
  *
  * The two that finish before the second factor go through
  * `challengeOrComplete`, which is where a user that registered one is

--- a/src/service/cognito/command/sim-cognito-commands.ts
+++ b/src/service/cognito/command/sim-cognito-commands.ts
@@ -141,6 +141,7 @@ export class SimCognitoCommands {
       clock,
       triggers,
       tokenIssuer,
+      messenger,
     });
     this.domains = new SimCognitoDomainCommands({
       pools,

--- a/src/service/cognito/user-pool/auth/sim-cognito-auth-session-store.ts
+++ b/src/service/cognito/user-pool/auth/sim-cognito-auth-session-store.ts
@@ -8,6 +8,9 @@ export interface SimCognitoAuthSessionRequest {
   readonly sessionId: string | undefined;
   readonly username: string;
   readonly clientId: string;
+
+  /** The challenge the response is answering, which the session carries. */
+  readonly challengeName: string;
   readonly now: Date;
 }
 
@@ -47,8 +50,8 @@ export class SimCognitoAuthSessionStore {
    * Resolve the session a challenge response carries, or refuse.
    *
    * A session this pool never issued, one already used, one for another user
-   * or app client, and one that has run out all fail the same way, as they do
-   * on real Cognito.
+   * or app client, one issued for a different challenge, and one that has run
+   * out all fail the same way, as they do on real Cognito.
    */
   require(request: SimCognitoAuthSessionRequest): SimCognitoAuthSession {
     const session = this.find(request.sessionId);
@@ -56,6 +59,7 @@ export class SimCognitoAuthSessionStore {
     if (
       session === undefined ||
       !session.belongsTo(request.username, request.clientId) ||
+      !session.answers(request.challengeName) ||
       session.isExpiredAt(request.now)
     ) {
       throw new SimCognitoNotAuthorizedException(

--- a/src/service/cognito/user-pool/auth/sim-cognito-auth-session.ts
+++ b/src/service/cognito/user-pool/auth/sim-cognito-auth-session.ts
@@ -16,6 +16,17 @@ interface SimCognitoAuthSessionProperties {
   readonly clientId: string;
   readonly challengeName: string;
   readonly issuedAt: Date;
+
+  /**
+   * The code the challenge sent the user, for a challenge that sent one.
+   *
+   * An `SMS_MFA` code lives here rather than on the user because it belongs to
+   * this one challenge: it goes when the session goes, so a code from an
+   * abandoned sign-in cannot complete a later one. A `SOFTWARE_TOKEN_MFA`
+   * challenge has none, because the code is whatever the user's authenticator
+   * app is showing.
+   */
+  readonly code?: string | undefined;
 }
 
 /**
@@ -32,12 +43,16 @@ export class SimCognitoAuthSession {
   public readonly challengeName: string;
   public readonly issuedAt: Date;
 
+  /** The code this challenge sent, where it sent one. */
+  public readonly code: string | undefined;
+
   constructor(properties: SimCognitoAuthSessionProperties) {
     this.id = randomBytes(sessionBytes).toString("base64url");
     this.username = properties.username;
     this.clientId = properties.clientId;
     this.challengeName = properties.challengeName;
     this.issuedAt = properties.issuedAt;
+    this.code = properties.code;
   }
 
   /**
@@ -56,5 +71,16 @@ export class SimCognitoAuthSession {
    */
   belongsTo(username: string, clientId: string): boolean {
     return this.username === username && this.clientId === clientId;
+  }
+
+  /**
+   * Whether this session was issued for the challenge being answered.
+   *
+   * A session carries one challenge, so answering an `SMS_MFA` challenge with
+   * the session from a `NEW_PASSWORD_REQUIRED` one is no more a valid session
+   * than one from another user.
+   */
+  answers(challengeName: string): boolean {
+    return this.challengeName === challengeName;
   }
 }

--- a/src/service/cognito/user-pool/message/sim-cognito-message-delivery.ts
+++ b/src/service/cognito/user-pool/message/sim-cognito-message-delivery.ts
@@ -51,7 +51,7 @@ export class SimCognitoMessageDelivery {
     user: SimCognitoUser,
     occasion: SimCognitoMessageOccasion,
   ): SimCognitoMessageDelivery | undefined {
-    for (const [name, medium] of deliverableAttributes) {
+    for (const [name, medium] of this.attributesFor(occasion)) {
       const value = user.attributeValues.get(name);
 
       if (value !== undefined && this.writable(pool, occasion, name)) {
@@ -62,6 +62,32 @@ export class SimCognitoMessageDelivery {
     return undefined;
   }
 
+  /**
+   * The attributes this occasion could write to, in the order Cognito prefers
+   * them.
+   *
+   * An MFA code goes to the user's phone number and nowhere else, because the
+   * phone is the factor: a user with an email address as well is still
+   * challenged by text message, where every other occasion would have written
+   * to the address.
+   */
+  private static attributesFor(
+    occasion: SimCognitoMessageOccasion,
+  ): readonly (readonly [string, SimCognitoMessageMedium])[] {
+    if (occasion === "Authentication") {
+      return [["phone_number", "SMS"]];
+    }
+
+    return deliverableAttributes;
+  }
+
+  /**
+   * A verification message goes only to an attribute the pool verifies
+   * automatically, because that is the address it is trying to prove belongs
+   * to the user. An invitation goes wherever the user can be reached, and so
+   * does an MFA code: the user registered that phone number as its second
+   * factor, whatever the pool verifies.
+   */
   private static writable(
     pool: SimCognitoUserPool,
     occasion: SimCognitoMessageOccasion,
@@ -69,6 +95,7 @@ export class SimCognitoMessageDelivery {
   ): boolean {
     return (
       occasion === "AdminCreateUser" ||
+      occasion === "Authentication" ||
       pool.settings.autoVerifiedAttributes.names.includes(name)
     );
   }

--- a/src/service/cognito/user-pool/message/sim-cognito-message-occasion.ts
+++ b/src/service/cognito/user-pool/message/sim-cognito-message-occasion.ts
@@ -1,10 +1,11 @@
 /**
  * What made a simulated user pool send a message.
  *
- * These are the three occasions this simulation reaches: a user signing itself
- * up, that user asking for another code, and an administrator creating a user.
- * Real Cognito sends on more of them, password reset and MFA among them, and
- * neither of those is simulated here.
+ * These are the four occasions this simulation reaches: a user signing itself
+ * up, that user asking for another code, an administrator creating a user, and
+ * a sign-in being challenged for a code sent by text message. Real Cognito
+ * sends on more of them, a password reset among them, which is not simulated
+ * here.
  *
  * `SimCognitoTriggerOccasion.customMessage` turns one of these into the
  * occasion the `CustomMessage` trigger fires for.
@@ -12,4 +13,5 @@
 export type SimCognitoMessageOccasion =
   | "SignUp"
   | "ResendCode"
-  | "AdminCreateUser";
+  | "AdminCreateUser"
+  | "Authentication";

--- a/src/service/cognito/user-pool/message/sim-cognito-occasion-wording.ts
+++ b/src/service/cognito/user-pool/message/sim-cognito-occasion-wording.ts
@@ -17,6 +17,15 @@ const invitationMessage =
   "Your username is {username} and temporary password is {####}.";
 
 /**
+ * The wording real Cognito sends an MFA code with when the pool asked for
+ * none.
+ *
+ * `SmsAuthenticationMessage` is what a pool sets its own with, and that input
+ * is refused here, so this is the wording every MFA code goes out under.
+ */
+const authenticationMessage = "Your authentication code is {####}. ";
+
+/**
  * What a pool says on the occasion it is sending on.
  *
  * The invitation an administrator's user is sent is the pool's own wording as
@@ -28,6 +37,10 @@ export function simCognitoOccasionWording(
   occasion: SimCognitoMessageOccasion,
   medium: SimCognitoMessageMedium,
 ): SimCognitoMessageWording {
+  if (occasion === "Authentication") {
+    return new SimCognitoMessageWording({ body: authenticationMessage });
+  }
+
   if (occasion !== "AdminCreateUser") {
     return pool.settings.verificationMessages.wording(medium);
   }

--- a/src/service/cognito/user-pool/message/sim-cognito-occasion-wording.ts
+++ b/src/service/cognito/user-pool/message/sim-cognito-occasion-wording.ts
@@ -23,7 +23,7 @@ const invitationMessage =
  * `SmsAuthenticationMessage` is what a pool sets its own with, and that input
  * is refused here, so this is the wording every MFA code goes out under.
  */
-const authenticationMessage = "Your authentication code is {####}. ";
+const authenticationMessage = "Your authentication code is {####}.";
 
 /**
  * What a pool says on the occasion it is sending on.

--- a/src/service/cognito/user-pool/mfa/sim-cognito-mfa-configuration.ts
+++ b/src/service/cognito/user-pool/mfa/sim-cognito-mfa-configuration.ts
@@ -12,12 +12,11 @@ const mfaConfigurationValues: ReadonlySet<SimCognitoMfaConfigurationValue> =
  * `OPTIONAL` challenges only the users that have registered a factor, and `ON`
  * challenges every user.
  *
- * The setting is kept and reported rather than acted on: nothing here
- * registers a factor for a user, so no user of an `OPTIONAL` pool has one, and
- * a sign-in to such a pool goes through without a challenge, as it does on real
- * Cognito for a user that never registered one. An `ON` pool is the one that
- * differs, so a sign-in to that is refused where the challenge would have been
- * issued rather than at pool creation.
+ * The setting is acted on: a sign-in by a user of an `OPTIONAL` or `ON` pool
+ * that has registered a factor is answered with the challenge for it. The one
+ * case left is a user of an `ON` pool that has registered none, which real
+ * Cognito answers with `MFA_SETUP`, and that sign-in is refused where the
+ * challenge would have been issued rather than at pool creation.
  */
 export class SimCognitoMfaConfiguration {
   public readonly value: SimCognitoMfaConfigurationValue;
@@ -41,12 +40,22 @@ export class SimCognitoMfaConfiguration {
   }
 
   /**
+   * Whether any sign-in to the pool could be challenged for a second factor.
+   *
+   * A pool configured `OFF` challenges nobody, whatever factors its users
+   * have registered, so a sign-in to one goes straight to tokens.
+   */
+  get challengesAnySignIn(): boolean {
+    return this.value !== "OFF";
+  }
+
+  /**
    * Whether every sign-in to the pool has to get past a second factor.
    *
-   * This is the one setting no sign-in here can honour. A user of an `ON` pool
-   * is answered with an MFA challenge on real Cognito whether or not it has
-   * registered a factor, so tokens are never issued by the request that sent
-   * the password.
+   * A user of an `ON` pool is answered with a challenge on real Cognito
+   * whether or not it has registered a factor: one that has is challenged for
+   * it, and one that has not is answered with `MFA_SETUP`, which is the
+   * challenge this simulation does not issue.
    */
   get challengesEverySignIn(): boolean {
     return this.value === "ON";

--- a/src/service/cognito/user-pool/mfa/sim-cognito-user-pool-mfa.ts
+++ b/src/service/cognito/user-pool/mfa/sim-cognito-user-pool-mfa.ts
@@ -99,10 +99,10 @@ function smsIn(
  * also why an update replaces the challenging and leaves the factors where they
  * were.
  *
- * Nothing here challenges for a factor, so this is state a pool reports rather
- * than acts on. The one place it is read is a sign-in to a pool configured
- * `ON`, which real Cognito answers with a challenge and this simulation
- * refuses.
+ * A sign-in reads this to decide whether the user owes a second factor, and
+ * `GetUserPoolMfaConfig` reports it. The factors it lists are what a pool
+ * offers rather than what any one user registered: a challenge is issued for
+ * the factor the user itself enabled.
  */
 export class SimCognitoUserPoolMfa {
   #configuration: SimCognitoMfaConfiguration;

--- a/src/service/cognito/user-pool/trigger/sim-cognito-auth-triggers.iso.test.ts
+++ b/src/service/cognito/user-pool/trigger/sim-cognito-auth-triggers.iso.test.ts
@@ -1,6 +1,10 @@
 import {
   AdminInitiateAuthCommand,
+  AssociateSoftwareTokenCommand,
   InitiateAuthCommand,
+  RespondToAuthChallengeCommand,
+  SetUserMFAPreferenceCommand,
+  VerifySoftwareTokenCommand,
 } from "@aws-sdk/client-cognito-identity-provider";
 import {
   assertArrayEquals,
@@ -10,6 +14,7 @@ import {
 } from "@kensio/smartass";
 import { describe, it } from "vitest";
 
+import { simCognitoSoftwareTokenCode } from "../../../../../test/cognito/mfa-fixture.js";
 import {
   makeTriggerPool,
   makeTriggerUser,
@@ -85,6 +90,84 @@ describe("sim Cognito user pool authentication triggers", () => {
     // And the sign-in still answered with the tokens it issued before the
     // second one ran.
     assertNonNullable(signedIn.AuthenticationResult?.IdToken);
+  });
+
+  it("runs PostAuthentication only once an MFA challenge is answered", async () => {
+    // Given a pool that challenges for a second factor, with both triggers on
+    // it, and a user that has registered an authenticator app.
+    const events: unknown[] = [];
+    const pool = await makeTriggerPool({
+      triggers: {
+        PreAuthentication: triggerFunctionArn,
+        PostAuthentication: triggerFunctionArn,
+      },
+      handler: recordingTriggerHandler(events),
+      mfaConfiguration: "OPTIONAL",
+    });
+
+    await makeTriggerUser(pool);
+
+    const registering = await pool.cognito.initiateAuth(signIn(pool.clientId));
+    const accessToken = registering.AuthenticationResult?.AccessToken;
+
+    assertNonNullable(accessToken);
+
+    await pool.cognito.associateSoftwareToken(
+      new AssociateSoftwareTokenCommand({ AccessToken: accessToken }),
+    );
+    await pool.cognito.verifySoftwareToken(
+      new VerifySoftwareTokenCommand({
+        AccessToken: accessToken,
+        UserCode: pool.cognito
+          .userPool(pool.userPoolId)
+          .softwareTokenCode("alice"),
+      }),
+    );
+    await pool.cognito.setUserMFAPreference(
+      new SetUserMFAPreferenceCommand({
+        AccessToken: accessToken,
+        SoftwareTokenMfaSettings: { Enabled: true, PreferredMfa: true },
+      }),
+    );
+
+    // Registering the factor took a sign-in of its own, so what that fired is
+    // not what this test is about.
+    events.length = 0;
+
+    // When the user signs in again and is challenged for the factor.
+    const challenged = await pool.cognito.initiateAuth(signIn(pool.clientId));
+
+    // Then the password has been checked and no token has been issued, so
+    // PreAuthentication has run and PostAuthentication has not.
+    assertUndefined(challenged.AuthenticationResult);
+    assertArrayEquals(
+      events.map((event) => (event as { triggerSource: string }).triggerSource),
+      ["PreAuthentication_Authentication"],
+    );
+
+    // And answering the challenge is what runs the second trigger, because
+    // that is where the tokens are issued.
+    const signedIn = await pool.cognito.respondToAuthChallenge(
+      new RespondToAuthChallengeCommand({
+        ClientId: pool.clientId,
+        ChallengeName: "SOFTWARE_TOKEN_MFA",
+        Session: challenged.Session,
+        ChallengeResponses: {
+          USERNAME: "alice",
+          SOFTWARE_TOKEN_MFA_CODE: simCognitoSoftwareTokenCode(
+            pool.cognito,
+            pool.userPoolId,
+            "alice",
+          ),
+        },
+      }),
+    );
+
+    assertNonNullable(signedIn.AuthenticationResult?.AccessToken);
+    assertArrayEquals(
+      events.map((event) => (event as { triggerSource: string }).triggerSource),
+      ["PreAuthentication_Authentication", "PostAuthentication_Authentication"],
+    );
   });
 
   it("passes ClientMetadata to each trigger under the name it reads", async () => {

--- a/src/service/cognito/user-pool/trigger/sim-cognito-trigger-occasion.ts
+++ b/src/service/cognito/user-pool/trigger/sim-cognito-trigger-occasion.ts
@@ -119,6 +119,15 @@ export class SimCognitoTriggerOccasion {
       "CustomMessage_AdminCreateUser",
     );
 
+  /**
+   * The code a sign-in challenged for a second factor is sent.
+   */
+  public static readonly customMessageAuthentication =
+    new SimCognitoTriggerOccasion(
+      "CustomMessage",
+      "CustomMessage_Authentication",
+    );
+
   public readonly trigger: SimCognitoTriggerName;
   public readonly source: string;
 
@@ -146,6 +155,9 @@ export class SimCognitoTriggerOccasion {
       }
       case "AdminCreateUser": {
         return this.customMessageAdminCreateUser;
+      }
+      case "Authentication": {
+        return this.customMessageAuthentication;
       }
     }
   }

--- a/src/service/cognito/user-pool/user/mfa/sim-cognito-user-mfa.ts
+++ b/src/service/cognito/user-pool/user/mfa/sim-cognito-user-mfa.ts
@@ -24,10 +24,10 @@ interface SimCognitoUserMfaProperties {
 /**
  * The second factors one simulated user has registered.
  *
- * Registering one and being challenged for it are separate: this is what
- * `AssociateSoftwareToken`, `VerifySoftwareToken` and the two MFA preference
- * operations change, and what `AdminGetUser` and `GetUser` report as
- * `UserMFASettingList` and `PreferredMfaSetting`.
+ * This is what `AssociateSoftwareToken`, `VerifySoftwareToken` and the two MFA
+ * preference operations change, what `AdminGetUser` and `GetUser` report as
+ * `UserMFASettingList` and `PreferredMfaSetting`, and what a sign-in reads to
+ * decide which challenge to answer with.
  *
  * A software token is registered in two steps, as real Cognito registers one:
  * a secret is associated, and a code computed from it shows that the user's
@@ -88,6 +88,26 @@ export class SimCognitoUserMfa {
    */
   get preferred(): string | undefined {
     return this.preference;
+  }
+
+  /**
+   * The factor a sign-in would be challenged for, and nothing where this user
+   * has none to be challenged for.
+   *
+   * A user with one factor enabled is challenged for it whether or not it
+   * named a preference, and a user with two is challenged for the one it
+   * preferred. Real Cognito answers a user with two and no preference with
+   * `SELECT_MFA_TYPE`, which is a challenge of its own, so there is nothing to
+   * choose here and the caller says so.
+   */
+  get challengeFactor(): string | undefined {
+    if (this.preference !== undefined) {
+      return this.preference;
+    }
+
+    const enabled = this.settings;
+
+    return enabled.length === 1 ? enabled[0] : undefined;
   }
 
   /**

--- a/test/cognito/mfa-fixture.ts
+++ b/test/cognito/mfa-fixture.ts
@@ -1,0 +1,132 @@
+/**
+ * The arrangement the MFA sign-in test files share: a pool that challenges for
+ * a second factor, and a user that has registered one.
+ *
+ * It lives under `test/` for the same reasons as `test/cognito/cfn-deploy.ts`:
+ * a test file cannot export helpers alongside its own `describe` calls, and
+ * `test/**` is type-checked with everything else and excluded from the
+ * published build.
+ */
+
+import type { ExplicitAuthFlowsType } from "@aws-sdk/client-cognito-identity-provider";
+import {
+  AssociateSoftwareTokenCommand,
+  SetUserMFAPreferenceCommand,
+  VerifySoftwareTokenCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import { assertNonNullable } from "@kensio/smartass";
+
+import type { SimCognitoIdentityProvider } from "../../src/service/cognito/index.js";
+import type { SimCognitoSignedInSetUp } from "./signed-in-fixture.js";
+import { simCognitoSignedIn, simCognitoUsername } from "./signed-in-fixture.js";
+
+/**
+ * The number the pool texts an `SMS_MFA` code to.
+ */
+export const simCognitoPhoneNumber = "+441632960123";
+
+/**
+ * The authentication flows the MFA tests need, which are both password flows:
+ * a challenge is issued on either side of the API.
+ */
+const bothPasswordFlows: ExplicitAuthFlowsType[] = [
+  "ALLOW_USER_PASSWORD_AUTH",
+  "ALLOW_ADMIN_USER_PASSWORD_AUTH",
+];
+
+/**
+ * A user of an `OPTIONAL` pool with a phone number, registered for `SMS_MFA`.
+ *
+ * The access token the fixture carries is the one from the sign-in before the
+ * factor was registered, which is what a real application would have been
+ * holding when it turned MFA on.
+ */
+export async function simCognitoWithSmsFactor(): Promise<SimCognitoSignedInSetUp> {
+  const setUp = await simCognitoSignedIn({
+    mfaConfiguration: "OPTIONAL",
+    explicitAuthFlows: bothPasswordFlows,
+    attributes: [{ Name: "phone_number", Value: simCognitoPhoneNumber }],
+  });
+
+  await setUp.cognito.setUserMFAPreference(
+    new SetUserMFAPreferenceCommand({
+      AccessToken: setUp.accessToken,
+      SMSMfaSettings: { Enabled: true, PreferredMfa: true },
+    }),
+  );
+
+  return setUp;
+}
+
+/**
+ * A user of an `OPTIONAL` pool registered for `SOFTWARE_TOKEN_MFA`, through
+ * the three steps Cognito documents.
+ */
+export async function simCognitoWithSoftwareToken(): Promise<SimCognitoSignedInSetUp> {
+  const setUp = await simCognitoSignedIn({
+    mfaConfiguration: "OPTIONAL",
+    explicitAuthFlows: bothPasswordFlows,
+  });
+  const { cognito, userPoolId, accessToken } = setUp;
+
+  await cognito.associateSoftwareToken(
+    new AssociateSoftwareTokenCommand({ AccessToken: accessToken }),
+  );
+  await cognito.verifySoftwareToken(
+    new VerifySoftwareTokenCommand({
+      AccessToken: accessToken,
+      UserCode: cognito
+        .userPool(userPoolId)
+        .softwareTokenCode(simCognitoUsername),
+    }),
+  );
+  await cognito.setUserMFAPreference(
+    new SetUserMFAPreferenceCommand({
+      AccessToken: accessToken,
+      SoftwareTokenMfaSettings: { Enabled: true, PreferredMfa: true },
+    }),
+  );
+
+  return setUp;
+}
+
+/**
+ * The code the user's authenticator app is showing now.
+ *
+ * A test computing it from the `SecretCode` it was given gets the same value,
+ * because the secret is a real one. Reading it off the pool is the shorter way
+ * to say the same thing.
+ */
+export function simCognitoSoftwareTokenCode(
+  cognito: SimCognitoIdentityProvider,
+  userPoolId: string,
+  username: string = simCognitoUsername,
+): string {
+  const code = cognito.userPool(userPoolId).softwareTokenCode(username);
+
+  assertNonNullable(code);
+
+  return code;
+}
+
+/**
+ * The code the pool texted the user for the challenge it has just issued.
+ *
+ * Real Cognito delivers it and reports it to nobody, so a test reads it out of
+ * the message the pool recorded, which is how a sign-up confirmation code is
+ * read here too.
+ */
+export function simCognitoSmsMfaCode(
+  cognito: SimCognitoIdentityProvider,
+  userPoolId: string,
+): string {
+  const messages = cognito
+    .userPool(userPoolId)
+    .sentMessages()
+    .filter((message) => message.occasion === "Authentication");
+  const code = /\d{6}/.exec(messages.at(-1)?.body ?? "")?.[0];
+
+  assertNonNullable(code);
+
+  return code;
+}

--- a/test/cognito/signed-in-fixture.ts
+++ b/test/cognito/signed-in-fixture.ts
@@ -8,7 +8,11 @@
  * published build.
  */
 
-import type { AttributeType } from "@aws-sdk/client-cognito-identity-provider";
+import type {
+  AttributeType,
+  ExplicitAuthFlowsType,
+  UserPoolMfaType,
+} from "@aws-sdk/client-cognito-identity-provider";
 import {
   AdminCreateUserCommand,
   AdminSetUserPasswordCommand,
@@ -42,6 +46,21 @@ export interface SimCognitoSignedInSetUp {
 export interface SimCognitoSignedInOptions {
   /** The attributes the user is created with, none by default. */
   readonly attributes?: AttributeType[];
+
+  /**
+   * What the pool asks of a second factor, `OFF` by default.
+   *
+   * A pool created `OPTIONAL` challenges the users that go on to register a
+   * factor, and the user here has none when it is signed in, so the sign-in
+   * this fixture ends with is answered with tokens either way.
+   */
+  readonly mfaConfiguration?: UserPoolMfaType;
+
+  /**
+   * The authentication flows the app client supports, the client-side password
+   * flow by default.
+   */
+  readonly explicitAuthFlows?: ExplicitAuthFlowsType[];
 }
 
 /**
@@ -53,7 +72,12 @@ export async function simCognitoSignedIn(
   const simAws = new SimAws({ defaultRegionName: "eu-west-2" });
   const cognito = simAws.cognitoIdentityProvider();
   const pool = await cognito.createUserPool(
-    new CreateUserPoolCommand({ PoolName: "myapp-users" }),
+    new CreateUserPoolCommand({
+      PoolName: "myapp-users",
+      ...(options.mfaConfiguration !== undefined && {
+        MfaConfiguration: options.mfaConfiguration,
+      }),
+    }),
   );
 
   assertNonNullable(pool.UserPool?.Id);
@@ -63,7 +87,9 @@ export async function simCognitoSignedIn(
     new CreateUserPoolClientCommand({
       UserPoolId: userPoolId,
       ClientName: "web",
-      ExplicitAuthFlows: ["ALLOW_USER_PASSWORD_AUTH"],
+      ExplicitAuthFlows: options.explicitAuthFlows ?? [
+        "ALLOW_USER_PASSWORD_AUTH",
+      ],
     }),
   );
 

--- a/test/cognito/trigger-fixture.ts
+++ b/test/cognito/trigger-fixture.ts
@@ -16,6 +16,7 @@ import {
   CreateUserPoolCommand,
   SignUpCommand,
   type SignUpCommandInput,
+  type UserPoolMfaType,
   type VerifiedAttributeType,
 } from "@aws-sdk/client-cognito-identity-provider";
 import {
@@ -94,6 +95,9 @@ export interface SimCognitoTriggerPoolInput {
   readonly autoVerifiedAttributes?:
     | readonly VerifiedAttributeType[]
     | undefined;
+
+  /** What the pool asks of a second factor, `OFF` by default. */
+  readonly mfaConfiguration?: UserPoolMfaType | undefined;
 }
 
 /**
@@ -156,6 +160,9 @@ export async function makeTriggerPool(
       LambdaConfig: input.triggers,
       ...(input.autoVerifiedAttributes !== undefined && {
         AutoVerifiedAttributes: [...input.autoVerifiedAttributes],
+      }),
+      ...(input.mfaConfiguration !== undefined && {
+        MfaConfiguration: input.mfaConfiguration,
       }),
     }),
   );


### PR DESCRIPTION
A user that has registered a factor is now challenged for it: SMS_MFA for a phone number, which the pool texts a code to and records the message it would have sent, and SOFTWARE_TOKEN_MFA for an authenticator app, whose code the user reads off its own device. Both initiate operations issue the challenge, the new password response issues it after its own challenge, and both respond operations complete it and hand out the tokens, with PostAuthentication running there rather than at the sign-in that was challenged. A wrong code is refused with CodeMismatchException and leaves the challenge standing, and a session that has run out, one already spent and one issued for another challenge are each refused with NotAuthorizedException. The refusal a pool configured ON used to give every sign-in now narrows to a user with no factor registered, which real Cognito answers with MFA_SETUP, and a user that prefers neither of two enabled factors is refused in the same way for SELECT_MFA_TYPE.

Resolves https://github.com/KensioSoftware/yulin/issues/605

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added simulated Cognito sign-in challenges for SMS and software-token MFA.
  - Supports MFA responses for both client and administrator authentication flows, including after required password changes.
  - Added SMS code delivery records, masked destinations, session validation, expiration, single-use handling, and code verification.
  - Authentication triggers now run at the appropriate stages of MFA sign-in.

- **Documentation**
  - Updated supported functionality, limitations, and MFA behavior documentation.
  - Added an SMS MFA sign-in example.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->