### PR TITLE
feat: deliver log events to Lambda by subscription filter

### DIFF
--- a/docs/services/logs/README.md
+++ b/docs/services/logs/README.md
@@ -305,6 +305,129 @@ Two divergences are worth knowing about:
   retention ends up correct, but the events the group held are gone, where a real update to
   `RetentionInDays` keeps them.
 
+## Subscription filters
+
+A subscription filter delivers the events matching its pattern to a Lambda function, so the code a
+team wrote to forward log lines to an error tracker or a metrics sink can be tested against the
+handler it forwards from.
+
+```typescript sim-logs-subscription-filter
+/**
+ * Delivering matched log events to a simulated Lambda function.
+ */
+
+import { gunzipSync } from "node:zlib";
+
+import {
+  CreateLogGroupCommand,
+  CreateLogStreamCommand,
+  PutLogEventsCommand,
+  PutSubscriptionFilterCommand,
+} from "@aws-sdk/client-cloudwatch-logs";
+import {
+  AddPermissionCommand,
+  CreateFunctionCommand,
+} from "@aws-sdk/client-lambda";
+
+import { SimAws } from "@kensio/yulin";
+import { makeLambdaZipFileInput } from "@kensio/yulin/lambda";
+
+const simAws = new SimAws();
+const logGroupName = "/aws/lambda/orders";
+const logStreamName = "2026/08/16/[$LATEST]0f7c1a";
+const received: string[] = [];
+
+await simAws.lambda().createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "error-tracker",
+    Role: `arn:aws:iam::${simAws.defaultAccountId}:role/TrackerRole`,
+    Code: {
+      ZipFile: makeLambdaZipFileInput(
+        (event: { awslogs: { data: string } }) => {
+          const decoded = JSON.parse(
+            gunzipSync(Buffer.from(event.awslogs.data, "base64")).toString(),
+          ) as { logEvents: { message: string }[] };
+
+          received.push(...decoded.logEvents.map((line) => line.message));
+
+          return "recorded";
+        },
+      ),
+    },
+  }),
+);
+
+// CloudWatch Logs invokes as a regional service principal, so this is the
+// grant a subscription filter needs on the function's side.
+await simAws.lambda().addPermission(
+  new AddPermissionCommand({
+    FunctionName: "error-tracker",
+    StatementId: "logs",
+    Action: "lambda:InvokeFunction",
+    Principal: `logs.${simAws.defaultRegionName}.amazonaws.com`,
+  }),
+);
+await simAws.backgroundTasksComplete();
+
+await simAws.logs().createLogGroup(new CreateLogGroupCommand({ logGroupName }));
+await simAws
+  .logs()
+  .createLogStream(new CreateLogStreamCommand({ logGroupName, logStreamName }));
+
+await simAws.logs().putSubscriptionFilter(
+  new PutSubscriptionFilterCommand({
+    logGroupName,
+    filterName: "errors-to-tracker",
+    filterPattern: "ERROR",
+    destinationArn: `arn:aws:lambda:${simAws.defaultRegionName}:${simAws.defaultAccountId}:function:error-tracker`,
+  }),
+);
+
+await simAws.logs().putLogEvents(
+  new PutLogEventsCommand({
+    logGroupName,
+    logStreamName,
+    logEvents: [
+      {
+        timestamp: Date.parse("2026-08-16T09:00:00Z"),
+        message: "INFO starting",
+      },
+      {
+        timestamp: Date.parse("2026-08-16T09:00:01Z"),
+        message: "ERROR order has no items",
+      },
+    ],
+  }),
+);
+
+// Delivery happens after the write is answered, as it does in an account.
+await simAws.backgroundTasksComplete();
+
+console.log(received);
+```
+
+The payload is the real one: an `awslogs.data` field holding the base64 of a gzipped JSON document
+with `messageType`, `owner`, `logGroup`, `logStream`, `subscriptionFilters` and `logEvents`. A
+handler written against a real subscription decodes it unchanged.
+
+A few things are worth knowing:
+
+- **Delivery is asynchronous.** `PutLogEvents` is answered before anything is delivered, so a test
+  waits with `await simAws.backgroundTasksComplete()`. A destination that throws does not fail the
+  write that triggered it.
+- **A failed delivery is kept.** Real CloudWatch Logs tells nobody when a delivery fails; it becomes
+  a metric nobody is watching. `simAws.logs().subscriptionFailures` holds them, so a test can find
+  out that the subscription it set up never reached anything.
+- **The destination is checked when the filter is put.** A function that has not granted
+  `logs.<region>.amazonaws.com` permission to invoke it fails `PutSubscriptionFilter`, as it does in
+  an account, rather than leaving a filter that silently drops every event. The resource policy is
+  consulted again on every delivery, so a permission removed later stops delivery too.
+- **What a Lambda function logged is delivered as well.** A subscription on `/aws/lambda/orders`
+  picks up what that function wrote, so a forwarder can be tested against a real handler's output.
+- **Lambda is the only destination.** Kinesis, Firehose and cross-account destinations are refused
+  rather than accepted and never delivered to.
+- **Two filters per log group**, which is the current AWS account default.
+
 ## Permissions
 
 Every operation goes through simulated IAM. An operation on a named log group authorizes against
@@ -420,9 +543,11 @@ console.log(described.logGroups?.[0]?.logGroupArn);
 ## What is not simulated
 
 - **Nothing expires.** Retention is stored and reported, never acted on.
-- **Subscription filters and metric filters.** Neither exists yet, so nothing is delivered onward
-  from a log group and `metricFilterCount` is always zero. `AWS::Logs::LogGroup` is the only
-  CloudFormation resource type here; the others are recorded as gaps.
+- **Metric filters.** Absent, so `metricFilterCount` is always zero.
+- **Subscription filter destinations other than Lambda**, and `Distribution`, which is accepted and
+  reported but changes nothing because there are no shards to spread across.
+- **`AWS::Logs::SubscriptionFilter` and `AWS::Logs::MetricFilter`.** `AWS::Logs::LogGroup` is the
+  only CloudFormation resource type here; the others are recorded as gaps.
 - **Logs Insights, export tasks, tags, encryption and data protection policies.** Absent. Tags and
   `kmsKeyId` on `CreateLogGroup` are refused rather than dropped, so nothing looks set here and
   behaves differently in an account.

--- a/docs/services/logs/sim-logs-subscription-filter.example.ts
+++ b/docs/services/logs/sim-logs-subscription-filter.example.ts
@@ -1,0 +1,92 @@
+/**
+ * Delivering matched log events to a simulated Lambda function.
+ */
+
+import { gunzipSync } from "node:zlib";
+
+import {
+  CreateLogGroupCommand,
+  CreateLogStreamCommand,
+  PutLogEventsCommand,
+  PutSubscriptionFilterCommand,
+} from "@aws-sdk/client-cloudwatch-logs";
+import {
+  AddPermissionCommand,
+  CreateFunctionCommand,
+} from "@aws-sdk/client-lambda";
+
+import { SimAws } from "@kensio/yulin";
+import { makeLambdaZipFileInput } from "@kensio/yulin/lambda";
+
+const simAws = new SimAws();
+const logGroupName = "/aws/lambda/orders";
+const logStreamName = "2026/08/16/[$LATEST]0f7c1a";
+const received: string[] = [];
+
+await simAws.lambda().createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "error-tracker",
+    Role: `arn:aws:iam::${simAws.defaultAccountId}:role/TrackerRole`,
+    Code: {
+      ZipFile: makeLambdaZipFileInput(
+        (event: { awslogs: { data: string } }) => {
+          const decoded = JSON.parse(
+            gunzipSync(Buffer.from(event.awslogs.data, "base64")).toString(),
+          ) as { logEvents: { message: string }[] };
+
+          received.push(...decoded.logEvents.map((line) => line.message));
+
+          return "recorded";
+        },
+      ),
+    },
+  }),
+);
+
+// CloudWatch Logs invokes as a regional service principal, so this is the
+// grant a subscription filter needs on the function's side.
+await simAws.lambda().addPermission(
+  new AddPermissionCommand({
+    FunctionName: "error-tracker",
+    StatementId: "logs",
+    Action: "lambda:InvokeFunction",
+    Principal: `logs.${simAws.defaultRegionName}.amazonaws.com`,
+  }),
+);
+await simAws.backgroundTasksComplete();
+
+await simAws.logs().createLogGroup(new CreateLogGroupCommand({ logGroupName }));
+await simAws
+  .logs()
+  .createLogStream(new CreateLogStreamCommand({ logGroupName, logStreamName }));
+
+await simAws.logs().putSubscriptionFilter(
+  new PutSubscriptionFilterCommand({
+    logGroupName,
+    filterName: "errors-to-tracker",
+    filterPattern: "ERROR",
+    destinationArn: `arn:aws:lambda:${simAws.defaultRegionName}:${simAws.defaultAccountId}:function:error-tracker`,
+  }),
+);
+
+await simAws.logs().putLogEvents(
+  new PutLogEventsCommand({
+    logGroupName,
+    logStreamName,
+    logEvents: [
+      {
+        timestamp: Date.parse("2026-08-16T09:00:00Z"),
+        message: "INFO starting",
+      },
+      {
+        timestamp: Date.parse("2026-08-16T09:00:01Z"),
+        message: "ERROR order has no items",
+      },
+    ],
+  }),
+);
+
+// Delivery happens after the write is answered, as it does in an account.
+await simAws.backgroundTasksComplete();
+
+console.log(received);

--- a/src/service/aws/factory/sim-aws-account-region-service-builder.ts
+++ b/src/service/aws/factory/sim-aws-account-region-service-builder.ts
@@ -200,15 +200,15 @@ export class SimAwsAccountRegionServiceBuilder {
     return kms;
   }
 
-  /** Create simulated Lambda for an Account Region scope. */
   /** Create simulated CloudWatch Logs for an Account Region scope. */
   createLogs(scope: SimAwsAccountRegionContainer): SimLogs {
     return new SimLogs({
       ...this.scoped(scope),
-      ...simAwsLogsCollaborators(this.simAws),
+      ...simAwsLogsCollaborators(this.simAws, scope.accountRegionScope),
     });
   }
 
+  /** Create simulated Lambda for an Account Region scope. */
   createLambda(scope: SimAwsAccountRegionContainer): SimLambda {
     return new SimLambda({
       ...this.scoped(scope),

--- a/src/service/aws/factory/sim-aws-account-region-service-builder.ts
+++ b/src/service/aws/factory/sim-aws-account-region-service-builder.ts
@@ -23,6 +23,8 @@ import { SimEventBridge } from "../../eventbridge/index.js";
 import type { SimIamRegistry } from "../../iam/registry/sim-iam-registry.js";
 import { SimKms } from "../../kms/index.js";
 import { SimLambda } from "../../lambda/index.js";
+import { SimLogs } from "../../logs/index.js";
+import { simAwsLogsCollaborators } from "./sim-aws-logs-collaborators.js";
 import type { SimLambdaUrlRegistry } from "../../lambda/registry/sim-lambda-url-registry.js";
 import { SimRekognition } from "../../rekognition/index.js";
 import { SimS3 } from "../../s3/sim-s3.js";
@@ -199,6 +201,14 @@ export class SimAwsAccountRegionServiceBuilder {
   }
 
   /** Create simulated Lambda for an Account Region scope. */
+  /** Create simulated CloudWatch Logs for an Account Region scope. */
+  createLogs(scope: SimAwsAccountRegionContainer): SimLogs {
+    return new SimLogs({
+      ...this.scoped(scope),
+      ...simAwsLogsCollaborators(this.simAws),
+    });
+  }
+
   createLambda(scope: SimAwsAccountRegionContainer): SimLambda {
     return new SimLambda({
       ...this.scoped(scope),

--- a/src/service/aws/factory/sim-aws-logs-collaborators.ts
+++ b/src/service/aws/factory/sim-aws-logs-collaborators.ts
@@ -1,5 +1,6 @@
 import { SimAwsLogsSubscriptionFunctions } from "../../logs/subscription/lambda/sim-aws-logs-subscription-functions.js";
 import type { SimLogsSubscriptionDestinations } from "../../logs/subscription/sim-logs-subscription-destinations.js";
+import type { SimAwsAccountRegionScope } from "../sim-aws-account-region-scope.js";
 import type { SimAws } from "../sim-aws.js";
 
 /**
@@ -13,17 +14,21 @@ interface SimAwsLogsCollaborators {
  * Build the collaborators simulated CloudWatch Logs takes beyond the scoped
  * ones every service gets.
  *
- * A subscription filter delivers to a simulated Lambda function resolved in
- * the whole simulation rather than in one scope, because a destination ARN
- * names the Account and Region its function is in, which need not be the log
- * group's. The function is looked up when an event is delivered rather than
- * now: every Lambda function records its output in simulated CloudWatch Logs,
- * so reaching one while this is being built would be a cycle with no bottom.
+ * A subscription filter delivers to a simulated Lambda function, which real
+ * CloudWatch Logs requires to be in the same Account as the filter, so the
+ * scope is passed in for the destination to be checked against. The function
+ * is looked up when an event is delivered rather than now: every Lambda
+ * function records its output in simulated CloudWatch Logs, so reaching one
+ * while this is being built would be a cycle with no bottom.
  */
 export function simAwsLogsCollaborators(
   simAws: SimAws,
+  accountRegionScope: SimAwsAccountRegionScope,
 ): SimAwsLogsCollaborators {
   return {
-    subscriptionDestinations: new SimAwsLogsSubscriptionFunctions({ simAws }),
+    subscriptionDestinations: new SimAwsLogsSubscriptionFunctions({
+      simAws,
+      accountRegionScope,
+    }),
   };
 }

--- a/src/service/aws/factory/sim-aws-logs-collaborators.ts
+++ b/src/service/aws/factory/sim-aws-logs-collaborators.ts
@@ -1,0 +1,29 @@
+import { SimAwsLogsSubscriptionFunctions } from "../../logs/subscription/lambda/sim-aws-logs-subscription-functions.js";
+import type { SimLogsSubscriptionDestinations } from "../../logs/subscription/sim-logs-subscription-destinations.js";
+import type { SimAws } from "../sim-aws.js";
+
+/**
+ * What simulated CloudWatch Logs reaches for in the rest of the simulation.
+ */
+interface SimAwsLogsCollaborators {
+  readonly subscriptionDestinations: SimLogsSubscriptionDestinations;
+}
+
+/**
+ * Build the collaborators simulated CloudWatch Logs takes beyond the scoped
+ * ones every service gets.
+ *
+ * A subscription filter delivers to a simulated Lambda function resolved in
+ * the whole simulation rather than in one scope, because a destination ARN
+ * names the Account and Region its function is in, which need not be the log
+ * group's. The function is looked up when an event is delivered rather than
+ * now: every Lambda function records its output in simulated CloudWatch Logs,
+ * so reaching one while this is being built would be a cycle with no bottom.
+ */
+export function simAwsLogsCollaborators(
+  simAws: SimAws,
+): SimAwsLogsCollaborators {
+  return {
+    subscriptionDestinations: new SimAwsLogsSubscriptionFunctions({ simAws }),
+  };
+}

--- a/src/service/aws/factory/sim-aws-self-contained-service-builder.ts
+++ b/src/service/aws/factory/sim-aws-self-contained-service-builder.ts
@@ -1,6 +1,5 @@
 import type { SimAwsAccountRegionContainer } from "../sim-aws-account-region-scope.js";
 import { SimDynamoDb as SimDynamoDatabase } from "../../dynamodb/index.js";
-import { SimLogs } from "../../logs/index.js";
 import { SimSecretsManager } from "../../secretsmanager/index.js";
 import { SimSqs } from "../../sqs/index.js";
 import { SimSsm } from "../../ssm/index.js";
@@ -36,16 +35,6 @@ export class SimAwsSelfContainedServiceBuilder {
   /** Create simulated DynamoDB for an Account Region scope. */
   createDynamoDb(scope: SimAwsAccountRegionContainer): SimDynamoDatabase {
     return new SimDynamoDatabase(this.scoped(scope));
-  }
-
-  /**
-   * Create simulated CloudWatch Logs for an Account Region scope.
-   *
-   * Log groups are Region-scoped on real AWS: a group name is unique within
-   * one Account and Region, and its ARN names the Region.
-   */
-  createLogs(scope: SimAwsAccountRegionContainer): SimLogs {
-    return new SimLogs(this.scoped(scope));
   }
 
   /**

--- a/src/service/aws/factory/sim-aws-service-factory.ts
+++ b/src/service/aws/factory/sim-aws-service-factory.ts
@@ -244,7 +244,7 @@ export class SimAwsServiceFactory {
 
   /** Create simulated CloudWatch Logs for an Account Region scope. */
   createLogs(scope: SimAwsAccountRegionContainer): SimLogs {
-    return this.selfContainedServices.createLogs(scope);
+    return this.accountRegionServices.createLogs(scope);
   }
 
   /** Create simulated EventBridge Scheduler for an Account Region scope. */

--- a/src/service/logs/README.md
+++ b/src/service/logs/README.md
@@ -166,7 +166,12 @@ shares.
 
 ## What is not simulated
 
-Nothing expires, as above. Subscription filters, metric filters, Logs Insights queries, export
-tasks, tagging, encryption and data protection policies are all absent. `metricFilterCount` is
-always zero and a stream's `storedBytes` is always zero, the latter matching real CloudWatch Logs,
-which stopped reporting it per stream in 2019.
+Nothing expires, as above. Metric filters, Logs Insights queries, export tasks, tagging, encryption
+and data protection policies are all absent, and `metricFilterCount` is always zero. A stream's
+`storedBytes` is always zero too, which matches real CloudWatch Logs: it stopped reporting the
+figure per stream in 2019.
+
+Subscription filters deliver to a Lambda destination only. Kinesis, Firehose and the logical
+destinations that reach another Account are refused rather than accepted and never delivered to,
+and `Distribution` is held and reported but changes nothing, since there are no shards to spread
+across.

--- a/src/service/logs/README.md
+++ b/src/service/logs/README.md
@@ -118,6 +118,33 @@ that log groups are created, that branch is gone: a Resource type a service crea
 an empty log group is exactly what an account is left with when nothing invokes the provider
 function either.
 
+## Subscription filters
+
+`subscription/` delivers what is written to a log group onward to a Lambda function.
+
+The shape follows simulated SNS's fan-out, for the same reasons. `SimLogsSubscriptionFanOut`
+schedules a delivery on the background scheduler rather than making it inline, because real
+CloudWatch Logs answers `PutLogEvents` before anything is delivered and a destination that throws
+must not fail the write that triggered it. `SimAwsLogsSubscriptionFunctions` resolves the function
+when an event is delivered rather than when it is built: simulated Lambda records its output here,
+so reaching it during construction would be a cycle with no bottom.
+
+Each filter gets only the events its own pattern matched, in one delivery, so a handler receives the
+lines it subscribed to rather than everything that happened to be written. The payload is gzipped
+and base64 encoded under `awslogs.data` exactly as AWS encodes it, because the first thing a real
+subscription handler does is gunzip that field; delivering the document in the clear would be easier
+to read in a test and would break every handler written against a real subscription.
+
+Two checks matter and happen in different places. The destination is checked at
+`PutSubscriptionFilter`, as real CloudWatch Logs checks it, so a function that never granted
+permission fails the call rather than leaving a filter that drops every event in silence. The
+resource policy is then consulted again on every delivery, so a permission taken away afterwards
+stops delivery, which is what an account does.
+
+Failures are kept rather than thrown. Real CloudWatch Logs tells nobody about a failed delivery,
+which would leave a test with a handler that mysteriously never ran, so every failure lands in
+`subscriptionFailures` for a test to read.
+
 ## Writing from the rest of the simulation
 
 `SimLogsServiceWriter`, under `write/`, is how a simulated service records its own output. It is

--- a/src/service/logs/command/event/sim-logs-put-log-events.ts
+++ b/src/service/logs/command/event/sim-logs-put-log-events.ts
@@ -6,6 +6,7 @@ import type { SimLogsLogGroupStore } from "../../group/sim-logs-log-group-store.
 import { requiredSimLogsLogStreamName } from "../../stream/sim-logs-log-stream-name.js";
 import type { SimLogsAuthorizer } from "../authorize/sim-logs-authorizer.js";
 import type { SimLogsRequestOptions } from "../sim-logs-request-options.js";
+import type { SimLogsSubscriptionFanOut } from "../../subscription/sim-logs-subscription-fan-out.js";
 import type {
   SimPutLogEventsCommand,
   SimPutLogEventsCommandOutput,
@@ -16,6 +17,9 @@ interface SimLogsPutLogEventsProperties {
   readonly authorizer: SimLogsAuthorizer;
   readonly eventIds: SimLogsEventIds;
   readonly clock: SimClock;
+
+  /** Where written events are handed on to subscription filters. */
+  readonly fanOut: SimLogsSubscriptionFanOut;
 }
 
 /**
@@ -26,12 +30,14 @@ export class SimLogsPutLogEvents {
   readonly #authorizer: SimLogsAuthorizer;
   readonly #eventIds: SimLogsEventIds;
   readonly #clock: SimClock;
+  readonly #fanOut: SimLogsSubscriptionFanOut;
 
   constructor(properties: SimLogsPutLogEventsProperties) {
     this.#groups = properties.groups;
     this.#authorizer = properties.authorizer;
     this.#eventIds = properties.eventIds;
     this.#clock = properties.clock;
+    this.#fanOut = properties.fanOut;
   }
 
   /**
@@ -63,11 +69,11 @@ export class SimLogsPutLogEvents {
       ingestionTime,
     });
 
-    const stream = this.#groups
-      .require(logGroupName)
-      .requireStream(logStreamName);
+    const group = this.#groups.require(logGroupName);
+    const stream = group.requireStream(logStreamName);
 
     stream.append(batch.events, ingestionTime);
+    this.#fanOut.written(group, logStreamName, batch.events);
 
     return { $metadata: {}, nextSequenceToken: stream.uploadSequenceToken };
   }

--- a/src/service/logs/command/sim-logs-command.types.ts
+++ b/src/service/logs/command/sim-logs-command.types.ts
@@ -42,3 +42,15 @@ export type {
   SimPutLogEventsCommandInput,
   SimPutLogEventsCommandOutput,
 } from "./event/event.command.js";
+export type {
+  SimDeleteSubscriptionFilterCommand,
+  SimDeleteSubscriptionFilterCommandInput,
+  SimDeleteSubscriptionFilterCommandOutput,
+  SimDescribeSubscriptionFiltersCommand,
+  SimDescribeSubscriptionFiltersCommandInput,
+  SimDescribeSubscriptionFiltersCommandOutput,
+  SimLogsSubscriptionFilterDetail,
+  SimPutSubscriptionFilterCommand,
+  SimPutSubscriptionFilterCommandInput,
+  SimPutSubscriptionFilterCommandOutput,
+} from "./subscription/subscription.command.js";

--- a/src/service/logs/command/subscription/sim-logs-subscription-commands.ts
+++ b/src/service/logs/command/subscription/sim-logs-subscription-commands.ts
@@ -1,0 +1,143 @@
+import type { SimClock } from "../../../../util/clock/sim-clock.js";
+import { requiredSimLogsLogGroupName } from "../../group/sim-logs-log-group-name.js";
+import type { SimLogsLogGroupStore } from "../../group/sim-logs-log-group-store.js";
+import type { SimLogsSubscriptionDestinations } from "../../subscription/sim-logs-subscription-destinations.js";
+import { SimLogsSubscriptionFilter } from "../../subscription/sim-logs-subscription-filter.js";
+import {
+  requiredSimLogsDestinationArn,
+  requiredSimLogsFilterName,
+  simLogsFilterDetail,
+} from "./sim-logs-subscription-input.js";
+import type { SimLogsAuthorizer } from "../authorize/sim-logs-authorizer.js";
+import { SimLogsPage } from "../sim-logs-page.js";
+import type { SimLogsRequestOptions } from "../sim-logs-request-options.js";
+import type {
+  SimDeleteSubscriptionFilterCommand,
+  SimDeleteSubscriptionFilterCommandOutput,
+  SimDescribeSubscriptionFiltersCommand,
+  SimDescribeSubscriptionFiltersCommandOutput,
+  SimPutSubscriptionFilterCommand,
+  SimPutSubscriptionFilterCommandOutput,
+} from "./subscription.command.js";
+
+const maximumDescribeLimit = 50;
+
+interface SimLogsSubscriptionCommandsProperties {
+  readonly groups: SimLogsLogGroupStore;
+  readonly authorizer: SimLogsAuthorizer;
+  readonly destinations: SimLogsSubscriptionDestinations;
+  readonly clock: SimClock;
+}
+
+/**
+ * The commands that put, describe and remove subscription filters.
+ */
+export class SimLogsSubscriptionCommands {
+  readonly #groups: SimLogsLogGroupStore;
+  readonly #authorizer: SimLogsAuthorizer;
+  readonly #destinations: SimLogsSubscriptionDestinations;
+  readonly #clock: SimClock;
+
+  constructor(properties: SimLogsSubscriptionCommandsProperties) {
+    this.#groups = properties.groups;
+    this.#authorizer = properties.authorizer;
+    this.#destinations = properties.destinations;
+    this.#clock = properties.clock;
+  }
+
+  /**
+   * Put a subscription filter on a log group.
+   *
+   * The destination is checked here, as real CloudWatch Logs checks it: a
+   * function it cannot invoke fails the call rather than leaving a filter that
+   * silently drops every event from then on.
+   */
+  async putSubscriptionFilter(
+    command: SimPutSubscriptionFilterCommand,
+    options?: SimLogsRequestOptions,
+  ): Promise<SimPutSubscriptionFilterCommandOutput> {
+    const input = command.input;
+    const logGroupName = requiredSimLogsLogGroupName(input.logGroupName);
+    const filterName = requiredSimLogsFilterName(input.filterName);
+    const destinationArn = requiredSimLogsDestinationArn(input.destinationArn);
+
+    this.#authorizer.authorizeLogGroup(
+      "logs:PutSubscriptionFilter",
+      logGroupName,
+      options?.caller,
+    );
+
+    const group = this.#groups.require(logGroupName);
+
+    await this.#destinations.check(destinationArn);
+
+    group.subscriptionFilters.put(
+      new SimLogsSubscriptionFilter({
+        filterName,
+        logGroupName,
+        filterPattern: input.filterPattern,
+        destinationArn,
+        roleArn: input.roleArn,
+        distribution: input.distribution,
+        creationTime: this.#clock.now().getTime(),
+      }),
+    );
+
+    return { $metadata: {} };
+  }
+
+  /**
+   * Describe the subscription filters on a log group.
+   */
+  describeSubscriptionFilters(
+    command: SimDescribeSubscriptionFiltersCommand,
+    options?: SimLogsRequestOptions,
+  ): SimDescribeSubscriptionFiltersCommandOutput {
+    const input = command.input;
+    const logGroupName = requiredSimLogsLogGroupName(input.logGroupName);
+
+    this.#authorizer.authorizeLogGroup(
+      "logs:DescribeSubscriptionFilters",
+      logGroupName,
+      options?.caller,
+    );
+
+    const group = this.#groups.require(logGroupName);
+    const page = new SimLogsPage({
+      listed: group.subscriptionFilters.withNamePrefix(input.filterNamePrefix),
+      limit: input.limit,
+      nextToken: input.nextToken,
+      maximumLimit: maximumDescribeLimit,
+    });
+
+    return {
+      $metadata: {},
+      subscriptionFilters: page.items.map((filter) =>
+        simLogsFilterDetail(filter),
+      ),
+      nextToken: page.nextToken,
+    };
+  }
+
+  /**
+   * Remove a subscription filter from a log group.
+   */
+  deleteSubscriptionFilter(
+    command: SimDeleteSubscriptionFilterCommand,
+    options?: SimLogsRequestOptions,
+  ): SimDeleteSubscriptionFilterCommandOutput {
+    const input = command.input;
+    const logGroupName = requiredSimLogsLogGroupName(input.logGroupName);
+    const filterName = requiredSimLogsFilterName(input.filterName);
+
+    this.#authorizer.authorizeLogGroup(
+      "logs:DeleteSubscriptionFilter",
+      logGroupName,
+      options?.caller,
+    );
+
+    this.#groups.require(logGroupName).subscriptionFilters.delete(filterName);
+
+    return { $metadata: {} };
+  }
+}

--- a/src/service/logs/command/subscription/sim-logs-subscription-input.ts
+++ b/src/service/logs/command/subscription/sim-logs-subscription-input.ts
@@ -20,7 +20,7 @@ export function simLogsFilterDetail(
 }
 
 /**
- *
+ * Read the name a subscription filter is identified by on its log group.
  */
 export function requiredSimLogsFilterName(filterName?: string): string {
   if (filterName === undefined || filterName.length === 0) {
@@ -34,7 +34,7 @@ export function requiredSimLogsFilterName(filterName?: string): string {
 }
 
 /**
- *
+ * Read the destination a subscription filter delivers to.
  */
 export function requiredSimLogsDestinationArn(destinationArn?: string): string {
   if (destinationArn === undefined || destinationArn.length === 0) {

--- a/src/service/logs/command/subscription/sim-logs-subscription-input.ts
+++ b/src/service/logs/command/subscription/sim-logs-subscription-input.ts
@@ -1,0 +1,48 @@
+import { SimLogsInvalidParameterException } from "../../error/sim-logs.error.js";
+import type { SimLogsSubscriptionFilter } from "../../subscription/sim-logs-subscription-filter.js";
+import type { SimLogsSubscriptionFilterDetail } from "./subscription.command.js";
+
+/**
+ * What DescribeSubscriptionFilters reports about one filter.
+ */
+export function simLogsFilterDetail(
+  filter: SimLogsSubscriptionFilter,
+): SimLogsSubscriptionFilterDetail {
+  return {
+    filterName: filter.filterName,
+    logGroupName: filter.logGroupName,
+    filterPattern: filter.filterPatternText,
+    destinationArn: filter.destinationArn,
+    roleArn: filter.roleArn,
+    distribution: filter.distribution,
+    creationTime: filter.creationTime,
+  };
+}
+
+/**
+ *
+ */
+export function requiredSimLogsFilterName(filterName?: string): string {
+  if (filterName === undefined || filterName.length === 0) {
+    throw new SimLogsInvalidParameterException(
+      "1 validation error detected: Value at 'filterName' failed to satisfy " +
+        "constraint: Member must not be null",
+    );
+  }
+
+  return filterName;
+}
+
+/**
+ *
+ */
+export function requiredSimLogsDestinationArn(destinationArn?: string): string {
+  if (destinationArn === undefined || destinationArn.length === 0) {
+    throw new SimLogsInvalidParameterException(
+      "1 validation error detected: Value at 'destinationArn' failed to " +
+        "satisfy constraint: Member must not be null",
+    );
+  }
+
+  return destinationArn;
+}

--- a/src/service/logs/command/subscription/subscription.command.ts
+++ b/src/service/logs/command/subscription/subscription.command.ts
@@ -1,0 +1,78 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+
+/**
+ * Minimal structural sim CloudWatch Logs PutSubscriptionFilter command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/cloudwatch-logs/command/PutSubscriptionFilterCommand/
+ */
+export interface SimPutSubscriptionFilterCommand {
+  readonly input: SimPutSubscriptionFilterCommandInput;
+}
+
+export interface SimPutSubscriptionFilterCommandInput {
+  readonly logGroupName?: string | undefined;
+  readonly filterName?: string | undefined;
+  readonly filterPattern?: string | undefined;
+  readonly destinationArn?: string | undefined;
+  readonly roleArn?: string | undefined;
+  readonly distribution?: string | undefined;
+}
+
+export interface SimPutSubscriptionFilterCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim CloudWatch Logs DescribeSubscriptionFilters command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/cloudwatch-logs/command/DescribeSubscriptionFiltersCommand/
+ */
+export interface SimDescribeSubscriptionFiltersCommand {
+  readonly input: SimDescribeSubscriptionFiltersCommandInput;
+}
+
+export interface SimDescribeSubscriptionFiltersCommandInput {
+  readonly logGroupName?: string | undefined;
+  readonly filterNamePrefix?: string | undefined;
+  readonly limit?: number | undefined;
+  readonly nextToken?: string | undefined;
+}
+
+export interface SimDescribeSubscriptionFiltersCommandOutput {
+  readonly subscriptionFilters?:
+    | readonly SimLogsSubscriptionFilterDetail[]
+    | undefined;
+  readonly nextToken?: string | undefined;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * What DescribeSubscriptionFilters reports about one filter.
+ */
+export interface SimLogsSubscriptionFilterDetail {
+  readonly filterName: string;
+  readonly logGroupName: string;
+  readonly filterPattern: string;
+  readonly destinationArn: string;
+  readonly roleArn?: string | undefined;
+  readonly distribution?: string | undefined;
+  readonly creationTime: number;
+}
+
+/**
+ * Minimal structural sim CloudWatch Logs DeleteSubscriptionFilter command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/cloudwatch-logs/command/DeleteSubscriptionFilterCommand/
+ */
+export interface SimDeleteSubscriptionFilterCommand {
+  readonly input: SimDeleteSubscriptionFilterCommandInput;
+}
+
+export interface SimDeleteSubscriptionFilterCommandInput {
+  readonly logGroupName?: string | undefined;
+  readonly filterName?: string | undefined;
+}
+
+export interface SimDeleteSubscriptionFilterCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/logs/error/sim-logs-delivery.error.ts
+++ b/src/service/logs/error/sim-logs-delivery.error.ts
@@ -1,0 +1,17 @@
+import { SimLogsError } from "./sim-logs.error.js";
+
+/**
+ * A subscription filter's destination would not take the delivery.
+ *
+ * Real CloudWatch Logs reports this at `PutSubscriptionFilter`, where it
+ * refuses a destination it cannot invoke. A permission taken away after the
+ * filter was put fails the delivery instead, which nothing in an account ever
+ * sees: it is recorded here as a delivery failure a test can read.
+ */
+export class SimLogsDeliveryNotPermitted extends SimLogsError {
+  public override readonly name = "InvalidParameterException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}

--- a/src/service/logs/error/sim-logs.error.ts
+++ b/src/service/logs/error/sim-logs.error.ts
@@ -79,3 +79,17 @@ export class SimLogsUnsupportedOperationException extends SimLogsError {
     super(message, { httpStatusCode: 400 });
   }
 }
+
+/**
+ * Simulated CloudWatch Logs LimitExceededException error.
+ *
+ * Real CloudWatch Logs reports an account or resource quota this way, such as
+ * putting more subscription filters on a log group than it allows.
+ */
+export class SimLogsLimitExceededException extends SimLogsError {
+  public override readonly name = "LimitExceededException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}

--- a/src/service/logs/group/sim-logs-log-group.ts
+++ b/src/service/logs/group/sim-logs-log-group.ts
@@ -1,6 +1,7 @@
 import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
 import type { SimLogsLogStream } from "../stream/sim-logs-log-stream.js";
 import { SimLogsLogStreamStore } from "../stream/sim-logs-log-stream-store.js";
+import { SimLogsSubscriptionFilterStore } from "../subscription/sim-logs-subscription-filter-store.js";
 import {
   simLogsLogGroupArn,
   simLogsLogGroupWildcardArn,
@@ -26,6 +27,12 @@ export class SimLogsLogGroup {
   readonly logGroupArn: string;
   readonly arn: string;
   readonly creationTime: number;
+
+  /**
+   * The subscription filters watching this group, which deliver what is
+   * written to it onward.
+   */
+  readonly subscriptionFilters = new SimLogsSubscriptionFilterStore();
 
   readonly #streams: SimLogsLogStreamStore;
   #retentionInDays: number | undefined;

--- a/src/service/logs/sdk/sim-logs-sdk-command-router.ts
+++ b/src/service/logs/sdk/sim-logs-sdk-command-router.ts
@@ -19,6 +19,11 @@ import type {
   SimCreateLogStreamCommand,
   SimDescribeLogStreamsCommand,
 } from "../command/stream/stream.command.js";
+import type {
+  SimDeleteSubscriptionFilterCommand,
+  SimDescribeSubscriptionFiltersCommand,
+  SimPutSubscriptionFilterCommand,
+} from "../command/subscription/subscription.command.js";
 import type { SimLogs } from "../sim-logs.js";
 
 /**
@@ -98,6 +103,30 @@ export class SimLogsSdkCommandRouter implements SimSdkCommandRouter {
         async (command, context): Promise<unknown> =>
           await simLogs.getLogEvents(
             command as SimGetLogEventsCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "PutSubscriptionFilterCommand",
+        async (command, context): Promise<unknown> =>
+          await simLogs.putSubscriptionFilter(
+            command as SimPutSubscriptionFilterCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "DescribeSubscriptionFiltersCommand",
+        async (command, context): Promise<unknown> =>
+          await simLogs.describeSubscriptionFilters(
+            command as SimDescribeSubscriptionFiltersCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "DeleteSubscriptionFilterCommand",
+        async (command, context): Promise<unknown> =>
+          await simLogs.deleteSubscriptionFilter(
+            command as SimDeleteSubscriptionFilterCommand,
             simSdkCallerOptions(context),
           ),
       ],

--- a/src/service/logs/sdk/sim-logs-sdk-routing.iso.test.ts
+++ b/src/service/logs/sdk/sim-logs-sdk-routing.iso.test.ts
@@ -10,7 +10,14 @@ import {
   GetLogEventsCommand,
   PutLogEventsCommand,
   PutRetentionPolicyCommand,
+  PutSubscriptionFilterCommand,
+  DescribeSubscriptionFiltersCommand,
+  DeleteSubscriptionFilterCommand,
 } from "@aws-sdk/client-cloudwatch-logs";
+import {
+  AddPermissionCommand,
+  CreateFunctionCommand,
+} from "@aws-sdk/client-lambda";
 import {
   assertArrayEquals,
   assertArrayIncludesAll,
@@ -23,6 +30,7 @@ import { describe, it } from "vitest";
 
 import { SimSdk } from "../../../sdk/index.js";
 import { SimAws } from "../../aws/sim-aws.js";
+import { makeLambdaZipFileInput } from "../../lambda/function/code/lambda-zip-file-input.js";
 
 const logGroupName = "/aws/lambda/orders";
 const logStreamName = "2026/08/16/[$LATEST]abc";
@@ -47,6 +55,9 @@ describe("SimLogsSdkCommandRouter", () => {
       "PutLogEventsCommand",
       "GetLogEventsCommand",
       "FilterLogEventsCommand",
+      "PutSubscriptionFilterCommand",
+      "DescribeSubscriptionFiltersCommand",
+      "DeleteSubscriptionFilterCommand",
     ]);
   });
 
@@ -130,6 +141,64 @@ describe("CloudWatch Logs SDK interception", () => {
     );
     await client.send(new DeleteLogGroupCommand({ logGroupName }));
     const afterDelete = await client.send(new DescribeLogGroupsCommand({}));
+
+    // And the subscription filter commands route too, on a group subscribed to
+    // a function that admits CloudWatch Logs.
+    await client.send(
+      new CreateLogGroupCommand({ logGroupName: "/aws/lambda/billing" }),
+    );
+    const scoped = simSdk.simAws.accountRegionScope(
+      simSdk.simAws.defaultAccountId,
+      "eu-west-2",
+    );
+
+    await scoped.lambda().createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "error-tracker",
+        Role: `arn:aws:iam::${simSdk.simAws.defaultAccountId}:role/TrackerRole`,
+        Code: { ZipFile: makeLambdaZipFileInput(() => "recorded") },
+      }),
+    );
+    await scoped.lambda().addPermission(
+      new AddPermissionCommand({
+        FunctionName: "error-tracker",
+        StatementId: "logs",
+        Action: "lambda:InvokeFunction",
+        Principal: "logs.eu-west-2.amazonaws.com",
+      }),
+    );
+    await simSdk.simAws.backgroundTasksComplete();
+
+    await client.send(
+      new PutSubscriptionFilterCommand({
+        logGroupName: "/aws/lambda/billing",
+        filterName: "errors",
+        filterPattern: "",
+        destinationArn: `arn:aws:lambda:eu-west-2:${simSdk.simAws.defaultAccountId}:function:error-tracker`,
+      }),
+    );
+    const filters = await client.send(
+      new DescribeSubscriptionFiltersCommand({
+        logGroupName: "/aws/lambda/billing",
+      }),
+    );
+    await client.send(
+      new DeleteSubscriptionFilterCommand({
+        logGroupName: "/aws/lambda/billing",
+        filterName: "errors",
+      }),
+    );
+    const afterDeleteFilters = await client.send(
+      new DescribeSubscriptionFiltersCommand({
+        logGroupName: "/aws/lambda/billing",
+      }),
+    );
+
+    assertArrayEquals(
+      filters.subscriptionFilters?.map((filter) => filter.filterName),
+      ["errors"],
+    );
+    assertArrayLength(afterDeleteFilters.subscriptionFilters ?? [], 0);
 
     // Then each one reached simulated CloudWatch Logs.
     assertIdentical(withRetention.logGroups?.at(0)?.retentionInDays, 14);

--- a/src/service/logs/sim-logs-commands.ts
+++ b/src/service/logs/sim-logs-commands.ts
@@ -1,0 +1,115 @@
+import {
+  type BackgroundScheduler,
+  BackgroundTasks,
+} from "../../util/background/background.js";
+import type { SimAwsAccountRegionScope } from "../aws/sim-aws-account-region-scope.js";
+import { simAwsAccountRegionScopeFactory } from "../aws/sim-aws-account-region-scope.factory.js";
+import {
+  SimIamAllowAllAuth,
+  type SimIamInterServiceAuthZ,
+} from "../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { SimLogsAuthorizer } from "./command/authorize/sim-logs-authorizer.js";
+import { SimLogsFilterLogEvents } from "./command/event/sim-logs-filter-log-events.js";
+import { SimLogsGetLogEvents } from "./command/event/sim-logs-get-log-events.js";
+import { SimLogsPutLogEvents } from "./command/event/sim-logs-put-log-events.js";
+import { SimLogsLogGroupCommands } from "./command/group/sim-logs-log-group-commands.js";
+import { SimLogsRetentionCommands } from "./command/group/sim-logs-retention-commands.js";
+import { SimLogsLogStreamCommands } from "./command/stream/sim-logs-log-stream-commands.js";
+import { SimLogsSubscriptionCommands } from "./command/subscription/sim-logs-subscription-commands.js";
+import { SimLogsEventIds } from "./event/sim-logs-event-ids.js";
+import { SimLogsLogGroupStore } from "./group/sim-logs-log-group-store.js";
+import {
+  SimLogsNoSubscriptionDestinations,
+  type SimLogsSubscriptionDestinations,
+} from "./subscription/sim-logs-subscription-destinations.js";
+import { SimLogsSubscriptionFanOut } from "./subscription/sim-logs-subscription-fan-out.js";
+import { SimLogsServiceWriter } from "./write/sim-logs-service-writer.js";
+
+export interface SimLogsProperties {
+  readonly accountRegionScope?: SimAwsAccountRegionScope;
+  readonly iam?: SimIamInterServiceAuthZ;
+  readonly background?: BackgroundScheduler;
+
+  /**
+   * Where subscription filters deliver to. A SimLogs built on its own has no
+   * other simulated services to reach, so it holds filters and delivers to
+   * none of them.
+   */
+  readonly subscriptionDestinations?: SimLogsSubscriptionDestinations;
+}
+
+/**
+ * The collaborators one simulated CloudWatch Logs scope is built from.
+ *
+ * Held apart from SimLogs for the same reason simulated Lambda holds its own:
+ * the facade is one method per SDK Command and grows by one with every
+ * operation added, so the wiring deciding what those methods delegate to needs
+ * somewhere it is not competing for room with them.
+ */
+export class SimLogsCommands {
+  readonly groups: SimLogsLogGroupStore;
+  readonly logGroups: SimLogsLogGroupCommands;
+  readonly retention: SimLogsRetentionCommands;
+  readonly streams: SimLogsLogStreamCommands;
+  readonly putLogEvents: SimLogsPutLogEvents;
+  readonly getLogEvents: SimLogsGetLogEvents;
+  readonly filterLogEvents: SimLogsFilterLogEvents;
+  readonly subscriptions: SimLogsSubscriptionCommands;
+  readonly serviceWriter: SimLogsServiceWriter;
+  readonly fanOut: SimLogsSubscriptionFanOut;
+  readonly background: BackgroundScheduler;
+
+  constructor(properties: SimLogsProperties = {}) {
+    const {
+      accountRegionScope = simAwsAccountRegionScopeFactory.make(),
+      iam = new SimIamAllowAllAuth(),
+      background = new BackgroundTasks(),
+      subscriptionDestinations = new SimLogsNoSubscriptionDestinations(),
+    } = properties;
+
+    const authorizer = new SimLogsAuthorizer({ iam, accountRegionScope });
+    const groups = new SimLogsLogGroupStore({ accountRegionScope });
+    const eventIds = new SimLogsEventIds();
+    const fanOut = new SimLogsSubscriptionFanOut({
+      destinations: subscriptionDestinations,
+      accountRegionScope,
+      background,
+    });
+
+    this.background = background;
+    this.groups = groups;
+    this.fanOut = fanOut;
+    this.logGroups = new SimLogsLogGroupCommands({
+      groups,
+      authorizer,
+      clock: background,
+    });
+    this.retention = new SimLogsRetentionCommands({ groups, authorizer });
+    this.streams = new SimLogsLogStreamCommands({
+      groups,
+      authorizer,
+      clock: background,
+    });
+    this.putLogEvents = new SimLogsPutLogEvents({
+      groups,
+      authorizer,
+      eventIds,
+      clock: background,
+      fanOut,
+    });
+    this.getLogEvents = new SimLogsGetLogEvents({ groups, authorizer });
+    this.filterLogEvents = new SimLogsFilterLogEvents({ groups, authorizer });
+    this.subscriptions = new SimLogsSubscriptionCommands({
+      groups,
+      authorizer,
+      destinations: subscriptionDestinations,
+      clock: background,
+    });
+    this.serviceWriter = new SimLogsServiceWriter({
+      groups,
+      eventIds,
+      clock: background,
+      fanOut,
+    });
+  }
+}

--- a/src/service/logs/sim-logs.ts
+++ b/src/service/logs/sim-logs.ts
@@ -1,35 +1,15 @@
-import {
-  type BackgroundScheduler,
-  BackgroundTasks,
-} from "../../util/background/background.js";
 import type { SimSdkCommandRouter } from "../../sdk/router/sim-sdk-command-router.type.js";
-import type { SimAwsAccountRegionScope } from "../aws/sim-aws-account-region-scope.js";
-import { simAwsAccountRegionScopeFactory } from "../aws/sim-aws-account-region-scope.factory.js";
-import {
-  SimIamAllowAllAuth,
-  type SimIamInterServiceAuthZ,
-} from "../iam/authorize/sim-iam-inter-service-auth-z.js";
-import { SimLogsAuthorizer } from "./command/authorize/sim-logs-authorizer.js";
-import { SimLogsFilterLogEvents } from "./command/event/sim-logs-filter-log-events.js";
-import { SimLogsGetLogEvents } from "./command/event/sim-logs-get-log-events.js";
-import { SimLogsPutLogEvents } from "./command/event/sim-logs-put-log-events.js";
-import { SimLogsLogGroupCommands } from "./command/group/sim-logs-log-group-commands.js";
-import { SimLogsRetentionCommands } from "./command/group/sim-logs-retention-commands.js";
+import { SimLogsCfnResourceFactory } from "./cfn/sim-logs-cfn-resource-factory.js";
 import type * as simLogsCommands from "./command/sim-logs-command.types.js";
 import type { SimLogsRequestOptions } from "./command/sim-logs-request-options.js";
-import { SimLogsLogStreamCommands } from "./command/stream/sim-logs-log-stream-commands.js";
-import { SimLogsEventIds } from "./event/sim-logs-event-ids.js";
 import type { SimLogsLogGroup } from "./group/sim-logs-log-group.js";
-import { SimLogsLogGroupStore } from "./group/sim-logs-log-group-store.js";
-import { SimLogsCfnResourceFactory } from "./cfn/sim-logs-cfn-resource-factory.js";
 import { SimLogsSdkCommandRouter } from "./sdk/sim-logs-sdk-command-router.js";
-import { SimLogsServiceWriter } from "./write/sim-logs-service-writer.js";
-
-interface SimLogsProperties {
-  readonly accountRegionScope?: SimAwsAccountRegionScope;
-  readonly iam?: SimIamInterServiceAuthZ;
-  readonly background?: BackgroundScheduler;
-}
+import {
+  SimLogsCommands,
+  type SimLogsProperties,
+} from "./sim-logs-commands.js";
+import type { SimLogsSubscriptionFailure } from "./subscription/sim-logs-subscription-fan-out.js";
+import type { SimLogsServiceWriter } from "./write/sim-logs-service-writer.js";
 
 /**
  * Simulated CloudWatch Logs. Handles SDK commands. Emulates AWS behaviour and
@@ -45,61 +25,12 @@ interface SimLogsProperties {
  * deployed rather than the deletion that eventually follows from it.
  */
 export class SimLogs {
-  readonly #groups: SimLogsLogGroupStore;
-  readonly #groupCommands: SimLogsLogGroupCommands;
-  readonly #retentionCommands: SimLogsRetentionCommands;
-  readonly #streamCommands: SimLogsLogStreamCommands;
-  readonly #putLogEventsCommand: SimLogsPutLogEvents;
-  readonly #getLogEventsCommand: SimLogsGetLogEvents;
-  readonly #filterLogEventsCommand: SimLogsFilterLogEvents;
-  readonly #background: BackgroundScheduler;
-  readonly #serviceWriter: SimLogsServiceWriter;
+  readonly #commands: SimLogsCommands;
   readonly #sdkRouter = new SimLogsSdkCommandRouter(this);
   readonly #cfnFactory = new SimLogsCfnResourceFactory({ logs: this });
 
   constructor(properties: SimLogsProperties = {}) {
-    const {
-      accountRegionScope = simAwsAccountRegionScopeFactory.make(),
-      iam = new SimIamAllowAllAuth(),
-      background = new BackgroundTasks(),
-    } = properties;
-
-    const authorizer = new SimLogsAuthorizer({ iam, accountRegionScope });
-    const groups = new SimLogsLogGroupStore({ accountRegionScope });
-    const eventIds = new SimLogsEventIds();
-
-    this.#background = background;
-    this.#groups = groups;
-    this.#groupCommands = new SimLogsLogGroupCommands({
-      groups,
-      authorizer,
-      clock: background,
-    });
-    this.#retentionCommands = new SimLogsRetentionCommands({
-      groups,
-      authorizer,
-    });
-    this.#streamCommands = new SimLogsLogStreamCommands({
-      groups,
-      authorizer,
-      clock: background,
-    });
-    this.#putLogEventsCommand = new SimLogsPutLogEvents({
-      groups,
-      authorizer,
-      eventIds,
-      clock: background,
-    });
-    this.#getLogEventsCommand = new SimLogsGetLogEvents({ groups, authorizer });
-    this.#serviceWriter = new SimLogsServiceWriter({
-      groups,
-      eventIds,
-      clock: background,
-    });
-    this.#filterLogEventsCommand = new SimLogsFilterLogEvents({
-      groups,
-      authorizer,
-    });
+    this.#commands = new SimLogsCommands(properties);
   }
 
   /**
@@ -109,14 +40,14 @@ export class SimLogs {
    * state without going through a Command and its authorization.
    */
   findLogGroup(logGroupName: string): SimLogsLogGroup | undefined {
-    return this.#groups.find(logGroupName);
+    return this.#commands.groups.find(logGroupName);
   }
 
   /**
    * Every log group in this scope, in creation order.
    */
   allLogGroups(): readonly SimLogsLogGroup[] {
-    return this.#groups.all;
+    return this.#commands.groups.all;
   }
 
   /**
@@ -130,7 +61,7 @@ export class SimLogs {
    * documented instead.
    */
   serviceWriter(): SimLogsServiceWriter {
-    return this.#serviceWriter;
+    return this.#commands.serviceWriter;
   }
 
   /**
@@ -140,8 +71,8 @@ export class SimLogs {
     command: simLogsCommands.SimCreateLogGroupCommand,
     options?: SimLogsRequestOptions,
   ): Promise<simLogsCommands.SimCreateLogGroupCommandOutput> {
-    await this.#background.sequence();
-    return this.#groupCommands.createLogGroup(command, options);
+    await this.#commands.background.sequence();
+    return this.#commands.logGroups.createLogGroup(command, options);
   }
 
   /**
@@ -151,8 +82,8 @@ export class SimLogs {
     command: simLogsCommands.SimDeleteLogGroupCommand,
     options?: SimLogsRequestOptions,
   ): Promise<simLogsCommands.SimDeleteLogGroupCommandOutput> {
-    await this.#background.sequence();
-    return this.#groupCommands.deleteLogGroup(command, options);
+    await this.#commands.background.sequence();
+    return this.#commands.logGroups.deleteLogGroup(command, options);
   }
 
   /**
@@ -162,8 +93,8 @@ export class SimLogs {
     command: simLogsCommands.SimDescribeLogGroupsCommand,
     options?: SimLogsRequestOptions,
   ): Promise<simLogsCommands.SimDescribeLogGroupsCommandOutput> {
-    await this.#background.sequence();
-    return this.#groupCommands.describeLogGroups(command, options);
+    await this.#commands.background.sequence();
+    return this.#commands.logGroups.describeLogGroups(command, options);
   }
 
   /**
@@ -173,8 +104,8 @@ export class SimLogs {
     command: simLogsCommands.SimPutRetentionPolicyCommand,
     options?: SimLogsRequestOptions,
   ): Promise<simLogsCommands.SimPutRetentionPolicyCommandOutput> {
-    await this.#background.sequence();
-    return this.#retentionCommands.putRetentionPolicy(command, options);
+    await this.#commands.background.sequence();
+    return this.#commands.retention.putRetentionPolicy(command, options);
   }
 
   /**
@@ -184,8 +115,8 @@ export class SimLogs {
     command: simLogsCommands.SimDeleteRetentionPolicyCommand,
     options?: SimLogsRequestOptions,
   ): Promise<simLogsCommands.SimDeleteRetentionPolicyCommandOutput> {
-    await this.#background.sequence();
-    return this.#retentionCommands.deleteRetentionPolicy(command, options);
+    await this.#commands.background.sequence();
+    return this.#commands.retention.deleteRetentionPolicy(command, options);
   }
 
   /**
@@ -195,8 +126,8 @@ export class SimLogs {
     command: simLogsCommands.SimCreateLogStreamCommand,
     options?: SimLogsRequestOptions,
   ): Promise<simLogsCommands.SimCreateLogStreamCommandOutput> {
-    await this.#background.sequence();
-    return this.#streamCommands.createLogStream(command, options);
+    await this.#commands.background.sequence();
+    return this.#commands.streams.createLogStream(command, options);
   }
 
   /**
@@ -206,8 +137,8 @@ export class SimLogs {
     command: simLogsCommands.SimDescribeLogStreamsCommand,
     options?: SimLogsRequestOptions,
   ): Promise<simLogsCommands.SimDescribeLogStreamsCommandOutput> {
-    await this.#background.sequence();
-    return this.#streamCommands.describeLogStreams(command, options);
+    await this.#commands.background.sequence();
+    return this.#commands.streams.describeLogStreams(command, options);
   }
 
   /**
@@ -217,8 +148,8 @@ export class SimLogs {
     command: simLogsCommands.SimPutLogEventsCommand,
     options?: SimLogsRequestOptions,
   ): Promise<simLogsCommands.SimPutLogEventsCommandOutput> {
-    await this.#background.sequence();
-    return this.#putLogEventsCommand.handle(command, options);
+    await this.#commands.background.sequence();
+    return this.#commands.putLogEvents.handle(command, options);
   }
 
   /**
@@ -228,8 +159,8 @@ export class SimLogs {
     command: simLogsCommands.SimGetLogEventsCommand,
     options?: SimLogsRequestOptions,
   ): Promise<simLogsCommands.SimGetLogEventsCommandOutput> {
-    await this.#background.sequence();
-    return this.#getLogEventsCommand.handle(command, options);
+    await this.#commands.background.sequence();
+    return this.#commands.getLogEvents.handle(command, options);
   }
 
   /**
@@ -239,8 +170,61 @@ export class SimLogs {
     command: simLogsCommands.SimFilterLogEventsCommand,
     options?: SimLogsRequestOptions,
   ): Promise<simLogsCommands.SimFilterLogEventsCommandOutput> {
-    await this.#background.sequence();
-    return this.#filterLogEventsCommand.handle(command, options);
+    await this.#commands.background.sequence();
+    return this.#commands.filterLogEvents.handle(command, options);
+  }
+
+  /**
+   * Every subscription filter delivery this scope could not make.
+   *
+   * A failed delivery is invisible in an account, where it becomes a metric
+   * nobody is watching. Keeping it is what lets a test find out that the
+   * subscription it set up never reached anything.
+   */
+  get subscriptionFailures(): readonly SimLogsSubscriptionFailure[] {
+    return this.#commands.fanOut.failures;
+  }
+
+  /**
+   * Handle a PutSubscriptionFilter Command from the SDK.
+   */
+  async putSubscriptionFilter(
+    command: simLogsCommands.SimPutSubscriptionFilterCommand,
+    options?: SimLogsRequestOptions,
+  ): Promise<simLogsCommands.SimPutSubscriptionFilterCommandOutput> {
+    await this.#commands.background.sequence();
+    return await this.#commands.subscriptions.putSubscriptionFilter(
+      command,
+      options,
+    );
+  }
+
+  /**
+   * Handle a DescribeSubscriptionFilters Command from the SDK.
+   */
+  async describeSubscriptionFilters(
+    command: simLogsCommands.SimDescribeSubscriptionFiltersCommand,
+    options?: SimLogsRequestOptions,
+  ): Promise<simLogsCommands.SimDescribeSubscriptionFiltersCommandOutput> {
+    await this.#commands.background.sequence();
+    return this.#commands.subscriptions.describeSubscriptionFilters(
+      command,
+      options,
+    );
+  }
+
+  /**
+   * Handle a DeleteSubscriptionFilter Command from the SDK.
+   */
+  async deleteSubscriptionFilter(
+    command: simLogsCommands.SimDeleteSubscriptionFilterCommand,
+    options?: SimLogsRequestOptions,
+  ): Promise<simLogsCommands.SimDeleteSubscriptionFilterCommandOutput> {
+    await this.#commands.background.sequence();
+    return this.#commands.subscriptions.deleteSubscriptionFilter(
+      command,
+      options,
+    );
   }
 
   /**

--- a/src/service/logs/subscription/lambda/sim-aws-logs-subscription-functions.ts
+++ b/src/service/logs/subscription/lambda/sim-aws-logs-subscription-functions.ts
@@ -1,0 +1,107 @@
+import type { SimAws } from "../../../aws/sim-aws.js";
+import { SimLambdaServiceInvokeAuthorizer } from "../../../lambda/command/authorize/sim-lambda-service-invoke-authorizer.js";
+import type { SimLambdaFunction } from "../../../lambda/function/sim-lambda-function.js";
+import { SimLogsResourceNotFoundException } from "../../error/sim-logs.error.js";
+import { SimLogsDeliveryNotPermitted } from "../../error/sim-logs-delivery.error.js";
+import type { SimLogsSubscriptionDestinations } from "../sim-logs-subscription-destinations.js";
+import {
+  simLogsSubscriptionEventPayload,
+  type SimLogsSubscriptionDelivery,
+} from "../sim-logs-subscription-event.js";
+import { SimLogsSubscriptionFunctionArn } from "./sim-logs-subscription-function-arn.js";
+
+/**
+ * The service principal CloudWatch Logs invokes a destination function as.
+ *
+ * Real CloudWatch Logs uses the regional form, `logs.<region>.amazonaws.com`,
+ * which is why a working `AddPermission` for a subscription filter names that
+ * rather than the plain `logs.amazonaws.com` most services use.
+ */
+export function simLogsServicePrincipal(regionName: string): string {
+  return `logs.${regionName}.amazonaws.com`;
+}
+
+interface SimAwsLogsSubscriptionFunctionsProperties {
+  readonly simAws: SimAws;
+}
+
+/**
+ * The simulated Lambda functions of one simulated AWS instance, as places a
+ * subscription filter delivers to.
+ *
+ * The function is looked up when an event is delivered, and again when a
+ * filter is put, never when this is built: reaching simulated Lambda while
+ * simulated CloudWatch Logs is being constructed would be a cycle with no
+ * bottom to it, since every Lambda function records its output here.
+ */
+export class SimAwsLogsSubscriptionFunctions implements SimLogsSubscriptionDestinations {
+  readonly #simAws: SimAws;
+
+  constructor(properties: SimAwsLogsSubscriptionFunctionsProperties) {
+    this.#simAws = properties.simAws;
+  }
+
+  /**
+   * Check the destination function is there and admits CloudWatch Logs.
+   */
+  check(destinationArn: string): Promise<void> {
+    this.permittedFunction(destinationArn);
+
+    return Promise.resolve();
+  }
+
+  /**
+   * Deliver matched events to the destination function.
+   */
+  async deliver(
+    destinationArn: string,
+    delivery: SimLogsSubscriptionDelivery,
+  ): Promise<void> {
+    const simFunction = this.permittedFunction(destinationArn);
+
+    // Invoked directly rather than through an Invoke command, because this is
+    // already inside the background task that stands for the asynchronous
+    // delivery real CloudWatch Logs makes, and because a handler failure has
+    // to reach the delivery outcome rather than being swallowed.
+    await simFunction.invoke(simLogsSubscriptionEventPayload(delivery));
+  }
+
+  /**
+   * The destination function, refusing one that is missing or does not admit
+   * CloudWatch Logs.
+   *
+   * The resource policy is consulted on every delivery rather than remembered
+   * from when the filter was put, so a permission taken away afterwards stops
+   * delivery, as it does in an account.
+   */
+  private permittedFunction(destinationArn: string): SimLambdaFunction {
+    const arn = SimLogsSubscriptionFunctionArn.parse(destinationArn);
+    const scope = this.#simAws.accountRegionScope(
+      arn.accountId,
+      arn.regionName,
+    );
+    const simFunction = scope.lambda().getSimFunctionByName(arn.functionName);
+
+    if (simFunction === undefined) {
+      throw new SimLogsResourceNotFoundException(
+        `${destinationArn} is not a simulated Lambda function.`,
+      );
+    }
+
+    const servicePrincipal = simLogsServicePrincipal(arn.regionName);
+    const decision = new SimLambdaServiceInvokeAuthorizer({
+      iam: scope.iam(),
+    }).authorize({ simFunction, servicePrincipal });
+
+    if (decision.isDenied) {
+      throw new SimLogsDeliveryNotPermitted(
+        `Could not execute the lambda function. Make sure you have given ` +
+          `CloudWatch Logs permission to execute your function: the resource ` +
+          `policy of ${destinationArn} does not allow ${servicePrincipal} to ` +
+          `invoke it. Grant it with AddPermission.`,
+      );
+    }
+
+    return simFunction;
+  }
+}

--- a/src/service/logs/subscription/lambda/sim-aws-logs-subscription-functions.ts
+++ b/src/service/logs/subscription/lambda/sim-aws-logs-subscription-functions.ts
@@ -1,28 +1,18 @@
+import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
 import type { SimAws } from "../../../aws/sim-aws.js";
-import { SimLambdaServiceInvokeAuthorizer } from "../../../lambda/command/authorize/sim-lambda-service-invoke-authorizer.js";
-import type { SimLambdaFunction } from "../../../lambda/function/sim-lambda-function.js";
-import { SimLogsResourceNotFoundException } from "../../error/sim-logs.error.js";
-import { SimLogsDeliveryNotPermitted } from "../../error/sim-logs-delivery.error.js";
 import type { SimLogsSubscriptionDestinations } from "../sim-logs-subscription-destinations.js";
 import {
   simLogsSubscriptionEventPayload,
   type SimLogsSubscriptionDelivery,
 } from "../sim-logs-subscription-event.js";
+import { permittedSimLogsDestinationFunction } from "./sim-logs-destination-permission.js";
 import { SimLogsSubscriptionFunctionArn } from "./sim-logs-subscription-function-arn.js";
-
-/**
- * The service principal CloudWatch Logs invokes a destination function as.
- *
- * Real CloudWatch Logs uses the regional form, `logs.<region>.amazonaws.com`,
- * which is why a working `AddPermission` for a subscription filter names that
- * rather than the plain `logs.amazonaws.com` most services use.
- */
-export function simLogsServicePrincipal(regionName: string): string {
-  return `logs.${regionName}.amazonaws.com`;
-}
 
 interface SimAwsLogsSubscriptionFunctionsProperties {
   readonly simAws: SimAws;
+
+  /** The Account and Region the subscribed log groups are in. */
+  readonly accountRegionScope: SimAwsAccountRegionScope;
 }
 
 /**
@@ -36,18 +26,20 @@ interface SimAwsLogsSubscriptionFunctionsProperties {
  */
 export class SimAwsLogsSubscriptionFunctions implements SimLogsSubscriptionDestinations {
   readonly #simAws: SimAws;
+  readonly #accountRegionScope: SimAwsAccountRegionScope;
 
   constructor(properties: SimAwsLogsSubscriptionFunctionsProperties) {
     this.#simAws = properties.simAws;
+    this.#accountRegionScope = properties.accountRegionScope;
   }
 
   /**
    * Check the destination function is there and admits CloudWatch Logs.
    */
-  check(destinationArn: string): Promise<void> {
-    this.permittedFunction(destinationArn);
+  async check(destinationArn: string): Promise<void> {
+    this.permitted(destinationArn);
 
-    return Promise.resolve();
+    await Promise.resolve();
   }
 
   /**
@@ -57,51 +49,27 @@ export class SimAwsLogsSubscriptionFunctions implements SimLogsSubscriptionDesti
     destinationArn: string,
     delivery: SimLogsSubscriptionDelivery,
   ): Promise<void> {
-    const simFunction = this.permittedFunction(destinationArn);
-
     // Invoked directly rather than through an Invoke command, because this is
     // already inside the background task that stands for the asynchronous
     // delivery real CloudWatch Logs makes, and because a handler failure has
     // to reach the delivery outcome rather than being swallowed.
-    await simFunction.invoke(simLogsSubscriptionEventPayload(delivery));
+    await this.permitted(destinationArn).invoke(
+      simLogsSubscriptionEventPayload(delivery),
+    );
   }
 
-  /**
-   * The destination function, refusing one that is missing or does not admit
-   * CloudWatch Logs.
-   *
-   * The resource policy is consulted on every delivery rather than remembered
-   * from when the filter was put, so a permission taken away afterwards stops
-   * delivery, as it does in an account.
-   */
-  private permittedFunction(destinationArn: string): SimLambdaFunction {
-    const arn = SimLogsSubscriptionFunctionArn.parse(destinationArn);
-    const scope = this.#simAws.accountRegionScope(
-      arn.accountId,
-      arn.regionName,
+  private permitted(
+    destinationArn: string,
+  ): ReturnType<typeof permittedSimLogsDestinationFunction> {
+    const arn = SimLogsSubscriptionFunctionArn.parse(
+      destinationArn,
+      this.#accountRegionScope,
     );
-    const simFunction = scope.lambda().getSimFunctionByName(arn.functionName);
 
-    if (simFunction === undefined) {
-      throw new SimLogsResourceNotFoundException(
-        `${destinationArn} is not a simulated Lambda function.`,
-      );
-    }
-
-    const servicePrincipal = simLogsServicePrincipal(arn.regionName);
-    const decision = new SimLambdaServiceInvokeAuthorizer({
-      iam: scope.iam(),
-    }).authorize({ simFunction, servicePrincipal });
-
-    if (decision.isDenied) {
-      throw new SimLogsDeliveryNotPermitted(
-        `Could not execute the lambda function. Make sure you have given ` +
-          `CloudWatch Logs permission to execute your function: the resource ` +
-          `policy of ${destinationArn} does not allow ${servicePrincipal} to ` +
-          `invoke it. Grant it with AddPermission.`,
-      );
-    }
-
-    return simFunction;
+    return permittedSimLogsDestinationFunction(
+      destinationArn,
+      arn.functionName,
+      this.#simAws.accountRegionScope(arn.accountId, arn.regionName),
+    );
   }
 }

--- a/src/service/logs/subscription/lambda/sim-logs-destination-permission.ts
+++ b/src/service/logs/subscription/lambda/sim-logs-destination-permission.ts
@@ -1,0 +1,54 @@
+import type { SimAwsAccountRegionContainer } from "../../../aws/sim-aws-account-region-scope.js";
+import { SimLambdaServiceInvokeAuthorizer } from "../../../lambda/command/authorize/sim-lambda-service-invoke-authorizer.js";
+import type { SimLambdaFunction } from "../../../lambda/function/sim-lambda-function.js";
+import { SimLogsDeliveryNotPermitted } from "../../error/sim-logs-delivery.error.js";
+import { SimLogsResourceNotFoundException } from "../../error/sim-logs.error.js";
+
+/**
+ * The service principal CloudWatch Logs invokes a destination function as.
+ *
+ * Real CloudWatch Logs uses the regional form, `logs.<region>.amazonaws.com`,
+ * which is why a working `AddPermission` for a subscription filter names that
+ * rather than the plain `logs.amazonaws.com` most services use.
+ */
+export function simLogsServicePrincipal(regionName: string): string {
+  return `logs.${regionName}.amazonaws.com`;
+}
+
+/**
+ * The destination function, refusing one that is missing or does not admit
+ * CloudWatch Logs.
+ *
+ * The resource policy is consulted on every delivery rather than remembered
+ * from when the filter was put, so a permission taken away afterwards stops
+ * delivery, as it does in an account.
+ */
+export function permittedSimLogsDestinationFunction(
+  destinationArn: string,
+  functionName: string,
+  scope: SimAwsAccountRegionContainer,
+): SimLambdaFunction {
+  const simFunction = scope.lambda().getSimFunctionByName(functionName);
+
+  if (simFunction === undefined) {
+    throw new SimLogsResourceNotFoundException(
+      `${destinationArn} is not a simulated Lambda function.`,
+    );
+  }
+
+  const servicePrincipal = simLogsServicePrincipal(scope.region.regionName);
+  const decision = new SimLambdaServiceInvokeAuthorizer({
+    iam: scope.iam(),
+  }).authorize({ simFunction, servicePrincipal });
+
+  if (decision.isDenied) {
+    throw new SimLogsDeliveryNotPermitted(
+      `Could not execute the lambda function. Make sure you have given ` +
+        `CloudWatch Logs permission to execute your function: the resource ` +
+        `policy of ${destinationArn} does not allow ${servicePrincipal} to ` +
+        `invoke it. Grant it with AddPermission.`,
+    );
+  }
+
+  return simFunction;
+}

--- a/src/service/logs/subscription/lambda/sim-logs-subscription-function-arn.ts
+++ b/src/service/logs/subscription/lambda/sim-logs-subscription-function-arn.ts
@@ -1,0 +1,70 @@
+import type { SimAwsAccountId } from "../../../aws/sim-aws-account-id.js";
+import type { AwsRegionName } from "../../../aws/sim-aws-region.js";
+import { parseSimLambdaFunctionArn } from "../../../lambda/function/sim-lambda-function-arn-parts.js";
+import {
+  SimLogsInvalidParameterException,
+  SimLogsUnsupportedOperationException,
+} from "../../error/sim-logs.error.js";
+
+interface SimLogsSubscriptionFunctionArnProperties {
+  readonly value: string;
+  readonly regionName: AwsRegionName;
+  readonly accountId: SimAwsAccountId;
+  readonly functionName: string;
+}
+
+/**
+ * The Lambda function ARN a subscription filter's destination names.
+ *
+ * The Region and the Account are read out alongside the name so that a
+ * delivery resolves the function in the scope its ARN gives.
+ */
+export class SimLogsSubscriptionFunctionArn {
+  readonly value: string;
+  readonly regionName: AwsRegionName;
+  readonly accountId: SimAwsAccountId;
+  readonly functionName: string;
+
+  private constructor(properties: SimLogsSubscriptionFunctionArnProperties) {
+    this.value = properties.value;
+    this.regionName = properties.regionName;
+    this.accountId = properties.accountId;
+    this.functionName = properties.functionName;
+  }
+
+  /**
+   * Read a destination ARN, refusing one no simulated function is behind.
+   *
+   * Only a Lambda destination is simulated. Kinesis, Firehose and a
+   * cross-account destination ARN are all real CloudWatch Logs destinations
+   * and are refused here rather than accepted and never delivered to, since a
+   * subscription that takes the configuration and quietly drops every event is
+   * the hardest kind of thing to find.
+   */
+  static parse(destinationArn: string): SimLogsSubscriptionFunctionArn {
+    const parts = parseSimLambdaFunctionArn(destinationArn);
+
+    if (parts === undefined) {
+      throw new SimLogsUnsupportedOperationException(
+        `${destinationArn} is not a Lambda function ARN. Only a Lambda ` +
+          `destination is simulated, which is ` +
+          `arn:aws:lambda:<region>:<account-id>:function:<function-name>`,
+      );
+    }
+
+    if (parts.qualifier !== undefined) {
+      throw new SimLogsInvalidParameterException(
+        `${destinationArn} names a function version or alias, and simulated ` +
+          `Lambda has neither, so delivering to the unqualified function ` +
+          `instead would be delivering to a different one`,
+      );
+    }
+
+    return new SimLogsSubscriptionFunctionArn({
+      value: destinationArn,
+      regionName: parts.regionName,
+      accountId: parts.accountId,
+      functionName: parts.functionName,
+    });
+  }
+}

--- a/src/service/logs/subscription/lambda/sim-logs-subscription-function-arn.ts
+++ b/src/service/logs/subscription/lambda/sim-logs-subscription-function-arn.ts
@@ -1,4 +1,5 @@
 import type { SimAwsAccountId } from "../../../aws/sim-aws-account-id.js";
+import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
 import type { AwsRegionName } from "../../../aws/sim-aws-region.js";
 import { parseSimLambdaFunctionArn } from "../../../lambda/function/sim-lambda-function-arn-parts.js";
 import {
@@ -35,13 +36,22 @@ export class SimLogsSubscriptionFunctionArn {
   /**
    * Read a destination ARN, refusing one no simulated function is behind.
    *
-   * Only a Lambda destination is simulated. Kinesis, Firehose and a
-   * cross-account destination ARN are all real CloudWatch Logs destinations
-   * and are refused here rather than accepted and never delivered to, since a
-   * subscription that takes the configuration and quietly drops every event is
-   * the hardest kind of thing to find.
+   * Only a Lambda destination is simulated. Kinesis and Firehose are real
+   * CloudWatch Logs destinations refused here rather than accepted and never
+   * delivered to, since a subscription that takes the configuration and
+   * quietly drops every event is the hardest kind of thing to find.
+   *
+   * A function outside the filter's own Account and Region is refused too, and
+   * that one is real AWS behaviour rather than a gap: CloudWatch Logs takes a
+   * Lambda destination "belonging to the same account as the subscription
+   * filter", and reaches another Account only through a logical destination,
+   * which is a Kinesis stream. Accepting one here would let a test wire up
+   * something an account would reject.
    */
-  static parse(destinationArn: string): SimLogsSubscriptionFunctionArn {
+  static parse(
+    destinationArn: string,
+    scope: SimAwsAccountRegionScope,
+  ): SimLogsSubscriptionFunctionArn {
     const parts = parseSimLambdaFunctionArn(destinationArn);
 
     if (parts === undefined) {
@@ -57,6 +67,23 @@ export class SimLogsSubscriptionFunctionArn {
         `${destinationArn} names a function version or alias, and simulated ` +
           `Lambda has neither, so delivering to the unqualified function ` +
           `instead would be delivering to a different one`,
+      );
+    }
+
+    if (parts.accountId !== scope.accountId) {
+      throw new SimLogsInvalidParameterException(
+        `${destinationArn} is in Account ${parts.accountId}, and a Lambda ` +
+          `destination has to belong to the same Account as the subscription ` +
+          `filter, which is ${scope.accountId}. Real CloudWatch Logs reaches ` +
+          `another Account through a logical destination instead.`,
+      );
+    }
+
+    if (parts.regionName !== scope.regionName) {
+      throw new SimLogsInvalidParameterException(
+        `${destinationArn} is in Region ${parts.regionName}, and a Lambda ` +
+          `destination has to be in the same Region as the log group, which ` +
+          `is in ${scope.regionName}.`,
       );
     }
 

--- a/src/service/logs/subscription/sim-logs-subscription-delivery-failures.iso.test.ts
+++ b/src/service/logs/subscription/sim-logs-subscription-delivery-failures.iso.test.ts
@@ -1,0 +1,344 @@
+import {
+  CreateLogGroupCommand,
+  CreateLogStreamCommand,
+  PutLogEventsCommand,
+  PutSubscriptionFilterCommand,
+} from "@aws-sdk/client-cloudwatch-logs";
+import {
+  AddPermissionCommand,
+  CreateFunctionCommand,
+  RemovePermissionCommand,
+} from "@aws-sdk/client-lambda";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import { makeLambdaZipFileInput } from "../../lambda/function/code/lambda-zip-file-input.js";
+import { SimLogsDeliveryNotPermitted } from "../error/sim-logs-delivery.error.js";
+import type { SimLogsSubscriptionDestinations } from "./sim-logs-subscription-destinations.js";
+
+const logGroupName = "/aws/lambda/orders";
+const logStreamName = "2026/08/16/[$LATEST]abc";
+
+interface SubscribedSimulation {
+  readonly simAws: SimAws;
+  readonly received: unknown[];
+  readonly trackerArn: string;
+}
+
+/**
+ * A simulation with a tracker function that records what it was handed, and a
+ * log group ready to be subscribed.
+ */
+async function simAwsWithTracker(
+  permitted = true,
+): Promise<SubscribedSimulation> {
+  const simAws = new SimAws();
+  const received: unknown[] = [];
+
+  await simAws.lambda().createFunction(
+    new CreateFunctionCommand({
+      FunctionName: "error-tracker",
+      Role: `arn:aws:iam::${simAws.defaultAccountId}:role/TrackerRole`,
+      Code: {
+        ZipFile: makeLambdaZipFileInput((event: unknown) => {
+          received.push(event);
+
+          return "recorded";
+        }),
+      },
+    }),
+  );
+  await simAws.backgroundTasksComplete();
+
+  if (permitted) {
+    await simAws.lambda().addPermission(
+      new AddPermissionCommand({
+        FunctionName: "error-tracker",
+        StatementId: "logs",
+        Action: "lambda:InvokeFunction",
+        Principal: `logs.${simAws.defaultRegionName}.amazonaws.com`,
+      }),
+    );
+  }
+
+  await simAws
+    .logs()
+    .createLogGroup(new CreateLogGroupCommand({ logGroupName }));
+  await simAws
+    .logs()
+    .createLogStream(
+      new CreateLogStreamCommand({ logGroupName, logStreamName }),
+    );
+
+  return {
+    simAws,
+    received,
+    trackerArn: `arn:aws:lambda:${simAws.defaultRegionName}:${simAws.defaultAccountId}:function:error-tracker`,
+  };
+}
+
+async function writeLines(
+  simAws: SimAws,
+  lines: readonly string[],
+): Promise<void> {
+  await simAws.logs().putLogEvents(
+    new PutLogEventsCommand({
+      logGroupName,
+      logStreamName,
+      logEvents: lines.map((message, index) => ({
+        timestamp: 1000 + index,
+        message,
+      })),
+    }),
+  );
+  await simAws.backgroundTasksComplete();
+}
+
+describe("CloudWatch Logs subscription filter delivery failures", () => {
+  it("does not fail the write when the destination throws", async () => {
+    // Given a subscription to a function whose handler always fails.
+    const simAws = new SimAws();
+
+    await simAws.lambda().createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "error-tracker",
+        Role: `arn:aws:iam::${simAws.defaultAccountId}:role/TrackerRole`,
+        Code: {
+          ZipFile: makeLambdaZipFileInput(() => {
+            throw new Error("tracker is down");
+          }),
+        },
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+    await simAws.lambda().addPermission(
+      new AddPermissionCommand({
+        FunctionName: "error-tracker",
+        StatementId: "logs",
+        Action: "lambda:InvokeFunction",
+        Principal: `logs.${simAws.defaultRegionName}.amazonaws.com`,
+      }),
+    );
+    await simAws
+      .logs()
+      .createLogGroup(new CreateLogGroupCommand({ logGroupName }));
+    await simAws
+      .logs()
+      .createLogStream(
+        new CreateLogStreamCommand({ logGroupName, logStreamName }),
+      );
+    await simAws.logs().putSubscriptionFilter(
+      new PutSubscriptionFilterCommand({
+        logGroupName,
+        filterName: "errors-to-tracker",
+        filterPattern: "",
+        destinationArn: `arn:aws:lambda:${simAws.defaultRegionName}:${simAws.defaultAccountId}:function:error-tracker`,
+      }),
+    );
+
+    // When the group is written to.
+    await writeLines(simAws, ["ERROR order has no items"]);
+
+    // Then the write succeeded and the failure is kept for a test to find,
+    // rather than being lost the way it is in an account.
+    const failure = simAws.logs().subscriptionFailures.at(0);
+
+    assertNonNullable(failure);
+    assertIdentical(failure.filterName, "errors-to-tracker");
+    assertStringIncludes(failure.reason, "tracker is down");
+  });
+
+  it("refuses a destination the log group may not invoke", async () => {
+    // Given a tracker function that has not granted CloudWatch Logs anything.
+    const { simAws, trackerArn } = await simAwsWithTracker(false);
+
+    // When a filter is put on it.
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await simAws.logs().putSubscriptionFilter(
+          new PutSubscriptionFilterCommand({
+            logGroupName,
+            filterName: "errors-to-tracker",
+            filterPattern: "",
+            destinationArn: trackerArn,
+          }),
+        ),
+    );
+
+    // Then it fails there, as real CloudWatch Logs fails it, rather than
+    // leaving a filter that silently drops every event from then on.
+    assertIdentical(error.name, "InvalidParameterException");
+    assertStringIncludes(
+      error.message,
+      "Make sure you have given CloudWatch Logs permission",
+    );
+  });
+
+  it("stops delivering once the permission is taken away", async () => {
+    // Given a working subscription.
+    const { simAws, received, trackerArn } = await simAwsWithTracker();
+
+    await simAws.logs().putSubscriptionFilter(
+      new PutSubscriptionFilterCommand({
+        logGroupName,
+        filterName: "errors-to-tracker",
+        filterPattern: "",
+        destinationArn: trackerArn,
+      }),
+    );
+
+    // When the function's permission is removed and the group is written to.
+    await simAws.lambda().removePermission(
+      new RemovePermissionCommand({
+        FunctionName: "error-tracker",
+        StatementId: "logs",
+      }),
+    );
+    await writeLines(simAws, ["ERROR order has no items"]);
+
+    // Then nothing was delivered, because the resource policy is consulted on
+    // every delivery rather than remembered from when the filter was put.
+    assertArrayLength(received, 0);
+    assertArrayLength(simAws.logs().subscriptionFailures, 1);
+  });
+
+  it("refuses a destination that is not a simulated Lambda function", async () => {
+    // Given a log group and a Kinesis stream ARN, which real CloudWatch Logs
+    // takes as a destination and this simulation has no machinery for.
+    const { simAws } = await simAwsWithTracker();
+
+    // When a filter is put on it.
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await simAws.logs().putSubscriptionFilter(
+          new PutSubscriptionFilterCommand({
+            logGroupName,
+            filterName: "errors-to-stream",
+            filterPattern: "",
+            destinationArn: `arn:aws:kinesis:${simAws.defaultRegionName}:${simAws.defaultAccountId}:stream/orders`,
+          }),
+        ),
+    );
+
+    // Then it says only a Lambda destination is simulated, rather than
+    // accepting it and delivering nothing.
+    assertIdentical(error.name, "UnsupportedOperationException");
+    assertStringIncludes(error.message, "Only a Lambda destination");
+  });
+
+  it("refuses a delivery from a SimLogs built on its own", async () => {
+    // Given a standalone SimLogs, which has nothing to deliver to.
+    const { SimLogs } = await import("../sim-logs.js");
+    const logs = new SimLogs();
+
+    await logs.createLogGroup(new CreateLogGroupCommand({ logGroupName }));
+
+    // When a filter is put on one of its groups.
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await logs.putSubscriptionFilter(
+          new PutSubscriptionFilterCommand({
+            logGroupName,
+            filterName: "errors-to-tracker",
+            filterPattern: "",
+            destinationArn:
+              "arn:aws:lambda:us-east-1:111111111111:function:error-tracker",
+          }),
+        ),
+    );
+
+    // Then it says how to get one, rather than holding a filter that could
+    // never reach anything.
+    assertIdentical(error.name, "UnsupportedOperationException");
+    assertStringIncludes(error.message, "Reach simulated CloudWatch Logs");
+  });
+
+  it("delivers nothing when no event matches the filter", async () => {
+    // Given a subscription for one term only.
+    const { simAws, received, trackerArn } = await simAwsWithTracker();
+
+    await simAws.logs().putSubscriptionFilter(
+      new PutSubscriptionFilterCommand({
+        logGroupName,
+        filterName: "errors-to-tracker",
+        filterPattern: "ERROR",
+        destinationArn: trackerArn,
+      }),
+    );
+
+    // When lines that none of them match are written.
+    await writeLines(simAws, ["INFO starting up", "INFO handling order-1"]);
+
+    // Then nothing was delivered and nothing failed: a filter that matches no
+    // event is not a delivery that went wrong.
+    assertArrayLength(received, 0);
+    assertArrayLength(simAws.logs().subscriptionFailures, 0);
+  });
+
+  it("records a destination function that is not there", async () => {
+    // Given a filter put while its destination existed, and the function gone
+    // by the time an event arrives.
+    const { simAws, trackerArn } = await simAwsWithTracker();
+
+    await simAws.logs().putSubscriptionFilter(
+      new PutSubscriptionFilterCommand({
+        logGroupName,
+        filterName: "errors-to-tracker",
+        filterPattern: "",
+        destinationArn: trackerArn,
+      }),
+    );
+    await simAws
+      .lambda()
+      .deleteFunction({ input: { FunctionName: "error-tracker" } });
+
+    // When the group is written to.
+    await writeLines(simAws, ["ERROR order has no items"]);
+
+    // Then the delivery is recorded as failed rather than throwing into the
+    // write that triggered it.
+    assertStringIncludes(
+      simAws.logs().subscriptionFailures.at(0)?.reason ?? "",
+      "not a simulated Lambda function",
+    );
+  });
+
+  it("refuses a delivery a standalone SimLogs is asked to make", async () => {
+    // Given the destinations a SimLogs built on its own has.
+    const { SimLogsNoSubscriptionDestinations } =
+      await import("./sim-logs-subscription-destinations.js");
+    const destinations: SimLogsSubscriptionDestinations =
+      new SimLogsNoSubscriptionDestinations();
+
+    // When it is asked to deliver rather than only to check.
+    const error = await assertThrowsErrorAsync(async () => {
+      await destinations.deliver("arn:aws:lambda:us-east-1:1:function:x", {
+        owner: "1",
+        logGroupName,
+        logStreamName,
+        filterName: "errors",
+        events: [],
+      });
+    });
+
+    // Then it refuses the same way it refuses the check, so a delivery that
+    // somehow got past the check still says how to get one.
+    assertStringIncludes(error.message, "Reach simulated CloudWatch Logs");
+  });
+
+  it("keeps the delivery failure type for a destination that went away", () => {
+    // Given the error a delivery failure carries.
+    const error = new SimLogsDeliveryNotPermitted("no");
+
+    // Then it is reported as the parameter failure real CloudWatch Logs
+    // reports for a destination it cannot invoke.
+    assertIdentical(error.name, "InvalidParameterException");
+  });
+});

--- a/src/service/logs/subscription/sim-logs-subscription-delivery-failures.iso.test.ts
+++ b/src/service/logs/subscription/sim-logs-subscription-delivery-failures.iso.test.ts
@@ -1,12 +1,9 @@
 import {
   CreateLogGroupCommand,
-  CreateLogStreamCommand,
-  PutLogEventsCommand,
   PutSubscriptionFilterCommand,
 } from "@aws-sdk/client-cloudwatch-logs";
 import {
-  AddPermissionCommand,
-  CreateFunctionCommand,
+  DeleteFunctionCommand,
   RemovePermissionCommand,
 } from "@aws-sdk/client-lambda";
 import {
@@ -18,133 +15,31 @@ import {
 } from "@kensio/smartass";
 import { describe, it } from "vitest";
 
-import { SimAws } from "../../aws/sim-aws.js";
-import { makeLambdaZipFileInput } from "../../lambda/function/code/lambda-zip-file-input.js";
+import {
+  simLogsSubscribedGroupName as logGroupName,
+  simLogsWithTracker,
+  simLogsWriteLines,
+} from "../../../../test/logs/subscription-fixture.js";
+import { SimLogs } from "../sim-logs.js";
 import { SimLogsDeliveryNotPermitted } from "../error/sim-logs-delivery.error.js";
-import type { SimLogsSubscriptionDestinations } from "./sim-logs-subscription-destinations.js";
-
-const logGroupName = "/aws/lambda/orders";
-const logStreamName = "2026/08/16/[$LATEST]abc";
-
-interface SubscribedSimulation {
-  readonly simAws: SimAws;
-  readonly received: unknown[];
-  readonly trackerArn: string;
-}
-
-/**
- * A simulation with a tracker function that records what it was handed, and a
- * log group ready to be subscribed.
- */
-async function simAwsWithTracker(
-  permitted = true,
-): Promise<SubscribedSimulation> {
-  const simAws = new SimAws();
-  const received: unknown[] = [];
-
-  await simAws.lambda().createFunction(
-    new CreateFunctionCommand({
-      FunctionName: "error-tracker",
-      Role: `arn:aws:iam::${simAws.defaultAccountId}:role/TrackerRole`,
-      Code: {
-        ZipFile: makeLambdaZipFileInput((event: unknown) => {
-          received.push(event);
-
-          return "recorded";
-        }),
-      },
-    }),
-  );
-  await simAws.backgroundTasksComplete();
-
-  if (permitted) {
-    await simAws.lambda().addPermission(
-      new AddPermissionCommand({
-        FunctionName: "error-tracker",
-        StatementId: "logs",
-        Action: "lambda:InvokeFunction",
-        Principal: `logs.${simAws.defaultRegionName}.amazonaws.com`,
-      }),
-    );
-  }
-
-  await simAws
-    .logs()
-    .createLogGroup(new CreateLogGroupCommand({ logGroupName }));
-  await simAws
-    .logs()
-    .createLogStream(
-      new CreateLogStreamCommand({ logGroupName, logStreamName }),
-    );
-
-  return {
-    simAws,
-    received,
-    trackerArn: `arn:aws:lambda:${simAws.defaultRegionName}:${simAws.defaultAccountId}:function:error-tracker`,
-  };
-}
-
-async function writeLines(
-  simAws: SimAws,
-  lines: readonly string[],
-): Promise<void> {
-  await simAws.logs().putLogEvents(
-    new PutLogEventsCommand({
-      logGroupName,
-      logStreamName,
-      logEvents: lines.map((message, index) => ({
-        timestamp: 1000 + index,
-        message,
-      })),
-    }),
-  );
-  await simAws.backgroundTasksComplete();
-}
+import { SimLogsNoSubscriptionDestinations } from "./sim-logs-subscription-destinations.js";
 
 describe("CloudWatch Logs subscription filter delivery failures", () => {
   it("does not fail the write when the destination throws", async () => {
     // Given a subscription to a function whose handler always fails.
-    const simAws = new SimAws();
+    const { simAws, trackerArn } = await simLogsWithTracker({ failing: true });
 
-    await simAws.lambda().createFunction(
-      new CreateFunctionCommand({
-        FunctionName: "error-tracker",
-        Role: `arn:aws:iam::${simAws.defaultAccountId}:role/TrackerRole`,
-        Code: {
-          ZipFile: makeLambdaZipFileInput(() => {
-            throw new Error("tracker is down");
-          }),
-        },
-      }),
-    );
-    await simAws.backgroundTasksComplete();
-    await simAws.lambda().addPermission(
-      new AddPermissionCommand({
-        FunctionName: "error-tracker",
-        StatementId: "logs",
-        Action: "lambda:InvokeFunction",
-        Principal: `logs.${simAws.defaultRegionName}.amazonaws.com`,
-      }),
-    );
-    await simAws
-      .logs()
-      .createLogGroup(new CreateLogGroupCommand({ logGroupName }));
-    await simAws
-      .logs()
-      .createLogStream(
-        new CreateLogStreamCommand({ logGroupName, logStreamName }),
-      );
     await simAws.logs().putSubscriptionFilter(
       new PutSubscriptionFilterCommand({
         logGroupName,
         filterName: "errors-to-tracker",
         filterPattern: "",
-        destinationArn: `arn:aws:lambda:${simAws.defaultRegionName}:${simAws.defaultAccountId}:function:error-tracker`,
+        destinationArn: trackerArn,
       }),
     );
 
     // When the group is written to.
-    await writeLines(simAws, ["ERROR order has no items"]);
+    await simLogsWriteLines(simAws, ["ERROR order has no items"]);
 
     // Then the write succeeded and the failure is kept for a test to find,
     // rather than being lost the way it is in an account.
@@ -157,7 +52,9 @@ describe("CloudWatch Logs subscription filter delivery failures", () => {
 
   it("refuses a destination the log group may not invoke", async () => {
     // Given a tracker function that has not granted CloudWatch Logs anything.
-    const { simAws, trackerArn } = await simAwsWithTracker(false);
+    const { simAws, trackerArn } = await simLogsWithTracker({
+      withoutPermission: true,
+    });
 
     // When a filter is put on it.
     const error = await assertThrowsErrorAsync(
@@ -183,7 +80,7 @@ describe("CloudWatch Logs subscription filter delivery failures", () => {
 
   it("stops delivering once the permission is taken away", async () => {
     // Given a working subscription.
-    const { simAws, received, trackerArn } = await simAwsWithTracker();
+    const { simAws, received, trackerArn } = await simLogsWithTracker();
 
     await simAws.logs().putSubscriptionFilter(
       new PutSubscriptionFilterCommand({
@@ -201,7 +98,7 @@ describe("CloudWatch Logs subscription filter delivery failures", () => {
         StatementId: "logs",
       }),
     );
-    await writeLines(simAws, ["ERROR order has no items"]);
+    await simLogsWriteLines(simAws, ["ERROR order has no items"]);
 
     // Then nothing was delivered, because the resource policy is consulted on
     // every delivery rather than remembered from when the filter was put.
@@ -212,7 +109,7 @@ describe("CloudWatch Logs subscription filter delivery failures", () => {
   it("refuses a destination that is not a simulated Lambda function", async () => {
     // Given a log group and a Kinesis stream ARN, which real CloudWatch Logs
     // takes as a destination and this simulation has no machinery for.
-    const { simAws } = await simAwsWithTracker();
+    const { simAws } = await simLogsWithTracker();
 
     // When a filter is put on it.
     const error = await assertThrowsErrorAsync(
@@ -235,7 +132,6 @@ describe("CloudWatch Logs subscription filter delivery failures", () => {
 
   it("refuses a delivery from a SimLogs built on its own", async () => {
     // Given a standalone SimLogs, which has nothing to deliver to.
-    const { SimLogs } = await import("../sim-logs.js");
     const logs = new SimLogs();
 
     await logs.createLogGroup(new CreateLogGroupCommand({ logGroupName }));
@@ -262,7 +158,7 @@ describe("CloudWatch Logs subscription filter delivery failures", () => {
 
   it("delivers nothing when no event matches the filter", async () => {
     // Given a subscription for one term only.
-    const { simAws, received, trackerArn } = await simAwsWithTracker();
+    const { simAws, received, trackerArn } = await simLogsWithTracker();
 
     await simAws.logs().putSubscriptionFilter(
       new PutSubscriptionFilterCommand({
@@ -274,7 +170,10 @@ describe("CloudWatch Logs subscription filter delivery failures", () => {
     );
 
     // When lines that none of them match are written.
-    await writeLines(simAws, ["INFO starting up", "INFO handling order-1"]);
+    await simLogsWriteLines(simAws, [
+      "INFO starting up",
+      "INFO handling order-1",
+    ]);
 
     // Then nothing was delivered and nothing failed: a filter that matches no
     // event is not a delivery that went wrong.
@@ -285,7 +184,7 @@ describe("CloudWatch Logs subscription filter delivery failures", () => {
   it("records a destination function that is not there", async () => {
     // Given a filter put while its destination existed, and the function gone
     // by the time an event arrives.
-    const { simAws, trackerArn } = await simAwsWithTracker();
+    const { simAws, trackerArn } = await simLogsWithTracker();
 
     await simAws.logs().putSubscriptionFilter(
       new PutSubscriptionFilterCommand({
@@ -297,10 +196,12 @@ describe("CloudWatch Logs subscription filter delivery failures", () => {
     );
     await simAws
       .lambda()
-      .deleteFunction({ input: { FunctionName: "error-tracker" } });
+      .deleteFunction(
+        new DeleteFunctionCommand({ FunctionName: "error-tracker" }),
+      );
 
     // When the group is written to.
-    await writeLines(simAws, ["ERROR order has no items"]);
+    await simLogsWriteLines(simAws, ["ERROR order has no items"]);
 
     // Then the delivery is recorded as failed rather than throwing into the
     // write that triggered it.
@@ -312,20 +213,11 @@ describe("CloudWatch Logs subscription filter delivery failures", () => {
 
   it("refuses a delivery a standalone SimLogs is asked to make", async () => {
     // Given the destinations a SimLogs built on its own has.
-    const { SimLogsNoSubscriptionDestinations } =
-      await import("./sim-logs-subscription-destinations.js");
-    const destinations: SimLogsSubscriptionDestinations =
-      new SimLogsNoSubscriptionDestinations();
+    const destinations = new SimLogsNoSubscriptionDestinations();
 
     // When it is asked to deliver rather than only to check.
     const error = await assertThrowsErrorAsync(async () => {
-      await destinations.deliver("arn:aws:lambda:us-east-1:1:function:x", {
-        owner: "1",
-        logGroupName,
-        logStreamName,
-        filterName: "errors",
-        events: [],
-      });
+      await destinations.deliver("arn:aws:lambda:us-east-1:1:function:x");
     });
 
     // Then it refuses the same way it refuses the check, so a delivery that

--- a/src/service/logs/subscription/sim-logs-subscription-delivery.iso.test.ts
+++ b/src/service/logs/subscription/sim-logs-subscription-delivery.iso.test.ts
@@ -1,0 +1,176 @@
+import { gunzipSync } from "node:zlib";
+import {
+  CreateLogGroupCommand,
+  CreateLogStreamCommand,
+  PutLogEventsCommand,
+  PutSubscriptionFilterCommand,
+} from "@aws-sdk/client-cloudwatch-logs";
+import {
+  AddPermissionCommand,
+  CreateFunctionCommand,
+} from "@aws-sdk/client-lambda";
+import {
+  assertArrayEquals,
+  assertArrayLength,
+  assertIdentical,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import { makeLambdaZipFileInput } from "../../lambda/function/code/lambda-zip-file-input.js";
+import type { SimLogsSubscriptionEventDocument } from "./sim-logs-subscription-event.js";
+
+const logGroupName = "/aws/lambda/orders";
+const logStreamName = "2026/08/16/[$LATEST]abc";
+
+interface SubscribedSimulation {
+  readonly simAws: SimAws;
+  readonly received: unknown[];
+  readonly trackerArn: string;
+}
+
+/**
+ * A simulation with a tracker function that records what it was handed, and a
+ * log group ready to be subscribed.
+ */
+async function simAwsWithTracker(
+  permitted = true,
+): Promise<SubscribedSimulation> {
+  const simAws = new SimAws();
+  const received: unknown[] = [];
+
+  await simAws.lambda().createFunction(
+    new CreateFunctionCommand({
+      FunctionName: "error-tracker",
+      Role: `arn:aws:iam::${simAws.defaultAccountId}:role/TrackerRole`,
+      Code: {
+        ZipFile: makeLambdaZipFileInput((event: unknown) => {
+          received.push(event);
+
+          return "recorded";
+        }),
+      },
+    }),
+  );
+  await simAws.backgroundTasksComplete();
+
+  if (permitted) {
+    await simAws.lambda().addPermission(
+      new AddPermissionCommand({
+        FunctionName: "error-tracker",
+        StatementId: "logs",
+        Action: "lambda:InvokeFunction",
+        Principal: `logs.${simAws.defaultRegionName}.amazonaws.com`,
+      }),
+    );
+  }
+
+  await simAws
+    .logs()
+    .createLogGroup(new CreateLogGroupCommand({ logGroupName }));
+  await simAws
+    .logs()
+    .createLogStream(
+      new CreateLogStreamCommand({ logGroupName, logStreamName }),
+    );
+
+  return {
+    simAws,
+    received,
+    trackerArn: `arn:aws:lambda:${simAws.defaultRegionName}:${simAws.defaultAccountId}:function:error-tracker`,
+  };
+}
+
+/**
+ * The decoded document a Lambda destination was handed.
+ */
+function decoded(payload: unknown): SimLogsSubscriptionEventDocument {
+  const data = (payload as { awslogs: { data: string } }).awslogs.data;
+
+  return JSON.parse(
+    gunzipSync(Buffer.from(data, "base64")).toString("utf8"),
+  ) as SimLogsSubscriptionEventDocument;
+}
+
+async function writeLines(
+  simAws: SimAws,
+  lines: readonly string[],
+): Promise<void> {
+  await simAws.logs().putLogEvents(
+    new PutLogEventsCommand({
+      logGroupName,
+      logStreamName,
+      logEvents: lines.map((message, index) => ({
+        timestamp: 1000 + index,
+        message,
+      })),
+    }),
+  );
+  await simAws.backgroundTasksComplete();
+}
+
+describe("CloudWatch Logs subscription filter delivery", () => {
+  it("delivers matched events to a Lambda destination", async () => {
+    // Given a log group subscribed to an error tracker function.
+    const { simAws, received, trackerArn } = await simAwsWithTracker();
+
+    await simAws.logs().putSubscriptionFilter(
+      new PutSubscriptionFilterCommand({
+        logGroupName,
+        filterName: "errors-to-tracker",
+        filterPattern: "ERROR",
+        destinationArn: trackerArn,
+      }),
+    );
+
+    // When the group is written to.
+    await writeLines(simAws, ["INFO starting up", "ERROR order has no items"]);
+
+    // Then the tracker was handed the matching line and nothing else, in the
+    // gzipped and base64 encoded shape every real subscription handler
+    // decodes.
+    assertArrayLength(received, 1);
+
+    const document = decoded(received.at(0));
+
+    assertIdentical(document.messageType, "DATA_MESSAGE");
+    assertIdentical(document.owner, simAws.defaultAccountId);
+    assertIdentical(document.logGroup, logGroupName);
+    assertIdentical(document.logStream, logStreamName);
+    assertArrayEquals(document.subscriptionFilters, ["errors-to-tracker"]);
+    assertArrayEquals(
+      document.logEvents.map((event) => event.message),
+      ["ERROR order has no items"],
+    );
+  });
+
+  it("delivers what a Lambda function logged for itself", async () => {
+    // Given a subscription on the log group a function writes to, and nothing
+    // calling PutLogEvents directly.
+    const { simAws, received, trackerArn } = await simAwsWithTracker();
+
+    await simAws.logs().putSubscriptionFilter(
+      new PutSubscriptionFilterCommand({
+        logGroupName,
+        filterName: "errors-to-tracker",
+        filterPattern: "ERROR",
+        destinationArn: trackerArn,
+      }),
+    );
+
+    // When a simulated service records output into that group.
+    simAws
+      .logs()
+      .serviceWriter()
+      .write(logGroupName, logStreamName, ["ERROR order failed"]);
+    await simAws.backgroundTasksComplete();
+
+    // Then the subscription picked it up, so a handler's own output reaches
+    // the function subscribed to its logs.
+    assertArrayLength(received, 1);
+    assertArrayEquals(
+      decoded(received.at(0)).logEvents.map((event) => event.message),
+      ["ERROR order failed"],
+    );
+  });
+});

--- a/src/service/logs/subscription/sim-logs-subscription-delivery.iso.test.ts
+++ b/src/service/logs/subscription/sim-logs-subscription-delivery.iso.test.ts
@@ -1,14 +1,4 @@
-import { gunzipSync } from "node:zlib";
-import {
-  CreateLogGroupCommand,
-  CreateLogStreamCommand,
-  PutLogEventsCommand,
-  PutSubscriptionFilterCommand,
-} from "@aws-sdk/client-cloudwatch-logs";
-import {
-  AddPermissionCommand,
-  CreateFunctionCommand,
-} from "@aws-sdk/client-lambda";
+import { PutSubscriptionFilterCommand } from "@aws-sdk/client-cloudwatch-logs";
 import {
   assertArrayEquals,
   assertArrayLength,
@@ -16,103 +6,18 @@ import {
 } from "@kensio/smartass";
 import { describe, it } from "vitest";
 
-import { SimAws } from "../../aws/sim-aws.js";
-import { makeLambdaZipFileInput } from "../../lambda/function/code/lambda-zip-file-input.js";
-import type { SimLogsSubscriptionEventDocument } from "./sim-logs-subscription-event.js";
-
-const logGroupName = "/aws/lambda/orders";
-const logStreamName = "2026/08/16/[$LATEST]abc";
-
-interface SubscribedSimulation {
-  readonly simAws: SimAws;
-  readonly received: unknown[];
-  readonly trackerArn: string;
-}
-
-/**
- * A simulation with a tracker function that records what it was handed, and a
- * log group ready to be subscribed.
- */
-async function simAwsWithTracker(
-  permitted = true,
-): Promise<SubscribedSimulation> {
-  const simAws = new SimAws();
-  const received: unknown[] = [];
-
-  await simAws.lambda().createFunction(
-    new CreateFunctionCommand({
-      FunctionName: "error-tracker",
-      Role: `arn:aws:iam::${simAws.defaultAccountId}:role/TrackerRole`,
-      Code: {
-        ZipFile: makeLambdaZipFileInput((event: unknown) => {
-          received.push(event);
-
-          return "recorded";
-        }),
-      },
-    }),
-  );
-  await simAws.backgroundTasksComplete();
-
-  if (permitted) {
-    await simAws.lambda().addPermission(
-      new AddPermissionCommand({
-        FunctionName: "error-tracker",
-        StatementId: "logs",
-        Action: "lambda:InvokeFunction",
-        Principal: `logs.${simAws.defaultRegionName}.amazonaws.com`,
-      }),
-    );
-  }
-
-  await simAws
-    .logs()
-    .createLogGroup(new CreateLogGroupCommand({ logGroupName }));
-  await simAws
-    .logs()
-    .createLogStream(
-      new CreateLogStreamCommand({ logGroupName, logStreamName }),
-    );
-
-  return {
-    simAws,
-    received,
-    trackerArn: `arn:aws:lambda:${simAws.defaultRegionName}:${simAws.defaultAccountId}:function:error-tracker`,
-  };
-}
-
-/**
- * The decoded document a Lambda destination was handed.
- */
-function decoded(payload: unknown): SimLogsSubscriptionEventDocument {
-  const data = (payload as { awslogs: { data: string } }).awslogs.data;
-
-  return JSON.parse(
-    gunzipSync(Buffer.from(data, "base64")).toString("utf8"),
-  ) as SimLogsSubscriptionEventDocument;
-}
-
-async function writeLines(
-  simAws: SimAws,
-  lines: readonly string[],
-): Promise<void> {
-  await simAws.logs().putLogEvents(
-    new PutLogEventsCommand({
-      logGroupName,
-      logStreamName,
-      logEvents: lines.map((message, index) => ({
-        timestamp: 1000 + index,
-        message,
-      })),
-    }),
-  );
-  await simAws.backgroundTasksComplete();
-}
+import {
+  simLogsDecodedDelivery,
+  simLogsSubscribedGroupName as logGroupName,
+  simLogsSubscribedStreamName as logStreamName,
+  simLogsWithTracker,
+  simLogsWriteLines,
+} from "../../../../test/logs/subscription-fixture.js";
 
 describe("CloudWatch Logs subscription filter delivery", () => {
   it("delivers matched events to a Lambda destination", async () => {
     // Given a log group subscribed to an error tracker function.
-    const { simAws, received, trackerArn } = await simAwsWithTracker();
+    const { simAws, received, trackerArn } = await simLogsWithTracker();
 
     await simAws.logs().putSubscriptionFilter(
       new PutSubscriptionFilterCommand({
@@ -124,14 +29,17 @@ describe("CloudWatch Logs subscription filter delivery", () => {
     );
 
     // When the group is written to.
-    await writeLines(simAws, ["INFO starting up", "ERROR order has no items"]);
+    await simLogsWriteLines(simAws, [
+      "INFO starting up",
+      "ERROR order has no items",
+    ]);
 
     // Then the tracker was handed the matching line and nothing else, in the
     // gzipped and base64 encoded shape every real subscription handler
     // decodes.
     assertArrayLength(received, 1);
 
-    const document = decoded(received.at(0));
+    const document = simLogsDecodedDelivery(received.at(0));
 
     assertIdentical(document.messageType, "DATA_MESSAGE");
     assertIdentical(document.owner, simAws.defaultAccountId);
@@ -147,7 +55,7 @@ describe("CloudWatch Logs subscription filter delivery", () => {
   it("delivers what a Lambda function logged for itself", async () => {
     // Given a subscription on the log group a function writes to, and nothing
     // calling PutLogEvents directly.
-    const { simAws, received, trackerArn } = await simAwsWithTracker();
+    const { simAws, received, trackerArn } = await simLogsWithTracker();
 
     await simAws.logs().putSubscriptionFilter(
       new PutSubscriptionFilterCommand({
@@ -169,7 +77,9 @@ describe("CloudWatch Logs subscription filter delivery", () => {
     // the function subscribed to its logs.
     assertArrayLength(received, 1);
     assertArrayEquals(
-      decoded(received.at(0)).logEvents.map((event) => event.message),
+      simLogsDecodedDelivery(received.at(0)).logEvents.map(
+        (event) => event.message,
+      ),
       ["ERROR order failed"],
     );
   });

--- a/src/service/logs/subscription/sim-logs-subscription-destinations.ts
+++ b/src/service/logs/subscription/sim-logs-subscription-destinations.ts
@@ -1,0 +1,60 @@
+import { SimLogsUnsupportedOperationException } from "../error/sim-logs.error.js";
+import type { SimLogsSubscriptionDelivery } from "./sim-logs-subscription-event.js";
+
+/**
+ * Where a subscription filter delivers to.
+ */
+export interface SimLogsSubscriptionDestinations {
+  /**
+   * Check a destination can be delivered to, before a filter is put on it.
+   *
+   * Real CloudWatch Logs does this at `PutSubscriptionFilter`: a destination
+   * it cannot invoke fails the call rather than silently dropping every event
+   * from then on. That is worth keeping, because a subscription that accepts
+   * the configuration and delivers nothing is the hardest kind of thing to
+   * find.
+   */
+  check(destinationArn: string): Promise<void>;
+
+  /**
+   * Deliver matched events to a destination.
+   */
+  deliver(
+    destinationArn: string,
+    delivery: SimLogsSubscriptionDelivery,
+  ): Promise<void>;
+}
+
+/**
+ * The destinations a simulated CloudWatch Logs built on its own can reach,
+ * which is none.
+ *
+ * A standalone SimLogs has no other simulated services to deliver to, and owns
+ * its own background scheduler, so nothing could wait for a delivery it made
+ * even if it could make one. Holding a filter still works, since that takes
+ * nothing but CloudWatch Logs: it is delivery that is refused.
+ */
+export class SimLogsNoSubscriptionDestinations implements SimLogsSubscriptionDestinations {
+  /**
+   * Refuse every destination, explaining how to get one.
+   */
+  check(destinationArn: string): Promise<void> {
+    return Promise.reject(this.refusal(destinationArn));
+  }
+
+  /**
+   * Refuse every delivery, explaining how to get one.
+   */
+  deliver(destinationArn: string): Promise<void> {
+    return Promise.reject(this.refusal(destinationArn));
+  }
+
+  private refusal(destinationArn: string): Error {
+    return new SimLogsUnsupportedOperationException(
+      `Cannot deliver to ${destinationArn}: this SimLogs was constructed on ` +
+        `its own, so it has no other simulated services to deliver to and no ` +
+        `shared background scheduler to deliver on. Reach simulated ` +
+        `CloudWatch Logs through SimAws to deliver to a function.`,
+    );
+  }
+}

--- a/src/service/logs/subscription/sim-logs-subscription-event.ts
+++ b/src/service/logs/subscription/sim-logs-subscription-event.ts
@@ -1,0 +1,73 @@
+import { gzipSync } from "node:zlib";
+import type { SimLogsStoredEvent } from "../event/sim-logs-event.js";
+
+/**
+ * What a subscription filter is delivering, before it is encoded.
+ */
+export interface SimLogsSubscriptionDelivery {
+  readonly owner: string;
+  readonly logGroupName: string;
+  readonly logStreamName: string;
+  readonly filterName: string;
+  readonly events: readonly SimLogsStoredEvent[];
+}
+
+/**
+ * The decoded document a subscription filter delivers.
+ *
+ * `messageType` is always `DATA_MESSAGE`. Real CloudWatch Logs also sends a
+ * `CONTROL_MESSAGE` to check a destination is reachable, which nothing here
+ * does: there is no destination to keep warm in this process.
+ */
+export interface SimLogsSubscriptionEventDocument {
+  readonly messageType: string;
+  readonly owner: string;
+  readonly logGroup: string;
+  readonly logStream: string;
+  readonly subscriptionFilters: readonly string[];
+  readonly logEvents: readonly SimLogsSubscriptionLogEvent[];
+}
+
+export interface SimLogsSubscriptionLogEvent {
+  readonly id: string;
+  readonly timestamp: number;
+  readonly message: string;
+}
+
+/**
+ * Build the document a subscription filter delivers.
+ */
+export function simLogsSubscriptionEventDocument(
+  delivery: SimLogsSubscriptionDelivery,
+): SimLogsSubscriptionEventDocument {
+  return {
+    messageType: "DATA_MESSAGE",
+    owner: delivery.owner,
+    logGroup: delivery.logGroupName,
+    logStream: delivery.logStreamName,
+    subscriptionFilters: [delivery.filterName],
+    logEvents: delivery.events.map((event) => ({
+      id: event.eventId,
+      timestamp: event.timestamp,
+      message: event.message,
+    })),
+  };
+}
+
+/**
+ * The payload a Lambda destination receives.
+ *
+ * The document is gzipped and base64 encoded under `awslogs.data`, which is
+ * the shape every subscription handler in the wild is written against: the
+ * first thing such a handler does is gunzip that field. Delivering the
+ * document in the clear would be easier to read in a test and would break
+ * every real handler, so it is encoded exactly as AWS encodes it.
+ */
+export function simLogsSubscriptionEventPayload(
+  delivery: SimLogsSubscriptionDelivery,
+): { readonly awslogs: { readonly data: string } } {
+  const document = simLogsSubscriptionEventDocument(delivery);
+  const gzipped = gzipSync(Buffer.from(JSON.stringify(document), "utf8"));
+
+  return { awslogs: { data: gzipped.toString("base64") } };
+}

--- a/src/service/logs/subscription/sim-logs-subscription-event.ts
+++ b/src/service/logs/subscription/sim-logs-subscription-event.ts
@@ -20,7 +20,7 @@ export interface SimLogsSubscriptionDelivery {
  * does: there is no destination to keep warm in this process.
  */
 export interface SimLogsSubscriptionEventDocument {
-  readonly messageType: string;
+  readonly messageType: "DATA_MESSAGE";
   readonly owner: string;
   readonly logGroup: string;
   readonly logStream: string;

--- a/src/service/logs/subscription/sim-logs-subscription-fan-out.ts
+++ b/src/service/logs/subscription/sim-logs-subscription-fan-out.ts
@@ -1,0 +1,103 @@
+import type { BackgroundScheduler } from "../../../util/background/background.js";
+import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+import type { SimLogsStoredEvent } from "../event/sim-logs-event.js";
+import type { SimLogsLogGroup } from "../group/sim-logs-log-group.js";
+import type { SimLogsSubscriptionDestinations } from "./sim-logs-subscription-destinations.js";
+import type { SimLogsSubscriptionFilter } from "./sim-logs-subscription-filter.js";
+
+/**
+ * One delivery a subscription filter could not make.
+ */
+export interface SimLogsSubscriptionFailure {
+  readonly logGroupName: string;
+  readonly filterName: string;
+  readonly destinationArn: string;
+  readonly reason: string;
+}
+
+interface SimLogsSubscriptionFanOutProperties {
+  readonly destinations: SimLogsSubscriptionDestinations;
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+  readonly background: BackgroundScheduler;
+}
+
+/**
+ * Hands events written to a log group to every subscription filter that wants
+ * them.
+ *
+ * Delivery happens on the background scheduler, as real CloudWatch Logs
+ * delivers after the write has been answered: `PutLogEvents` succeeds whether
+ * or not anything downstream takes the events, and a destination that throws
+ * must not fail the write that triggered it.
+ * `simAws.backgroundTasksComplete()` is what waits for it.
+ */
+export class SimLogsSubscriptionFanOut {
+  readonly #destinations: SimLogsSubscriptionDestinations;
+  readonly #accountRegionScope: SimAwsAccountRegionScope;
+  readonly #background: BackgroundScheduler;
+  readonly #failures: SimLogsSubscriptionFailure[] = [];
+
+  constructor(properties: SimLogsSubscriptionFanOutProperties) {
+    this.#destinations = properties.destinations;
+    this.#accountRegionScope = properties.accountRegionScope;
+    this.#background = properties.background;
+  }
+
+  /**
+   * Every delivery this scope could not make.
+   *
+   * A failed delivery is invisible in an account, where it becomes a metric
+   * nobody is watching. Keeping it is what lets a test find out that the
+   * subscription it set up never reached anything.
+   */
+  get failures(): readonly SimLogsSubscriptionFailure[] {
+    return this.#failures;
+  }
+
+  /**
+   * Schedule a delivery for every filter on the group that wants any of the
+   * events.
+   *
+   * Each filter gets only the events its own pattern matched, in one delivery,
+   * which is what real CloudWatch Logs batches: a handler receives the lines
+   * it subscribed to rather than everything that happened to be written.
+   */
+  written(
+    group: SimLogsLogGroup,
+    logStreamName: string,
+    events: readonly SimLogsStoredEvent[],
+  ): void {
+    for (const filter of group.subscriptionFilters.all) {
+      const matched = events.filter((event) => filter.wants(event.message));
+
+      if (matched.length > 0) {
+        this.schedule(filter, logStreamName, matched);
+      }
+    }
+  }
+
+  private schedule(
+    filter: SimLogsSubscriptionFilter,
+    logStreamName: string,
+    events: readonly SimLogsStoredEvent[],
+  ): void {
+    this.#background.schedule(async () => {
+      try {
+        await this.#destinations.deliver(filter.destinationArn, {
+          owner: this.#accountRegionScope.accountId,
+          logGroupName: filter.logGroupName,
+          logStreamName,
+          filterName: filter.filterName,
+          events,
+        });
+      } catch (error) {
+        this.#failures.push({
+          logGroupName: filter.logGroupName,
+          filterName: filter.filterName,
+          destinationArn: filter.destinationArn,
+          reason: error instanceof Error ? error.message : String(error),
+        });
+      }
+    });
+  }
+}

--- a/src/service/logs/subscription/sim-logs-subscription-filter-store.ts
+++ b/src/service/logs/subscription/sim-logs-subscription-filter-store.ts
@@ -1,0 +1,75 @@
+import {
+  SimLogsLimitExceededException,
+  SimLogsResourceNotFoundException,
+} from "../error/sim-logs.error.js";
+import type { SimLogsSubscriptionFilter } from "./sim-logs-subscription-filter.js";
+
+/**
+ * How many subscription filters real CloudWatch Logs allows on one log group.
+ *
+ * Two is the current account default. It used to be one, which is why a
+ * template written a few years ago assumes a group can only have the one, and
+ * why exceeding it is worth failing on rather than quietly allowing.
+ */
+export const simLogsMaximumSubscriptionFilters = 2;
+
+/**
+ * The subscription filters on one log group.
+ *
+ * They belong to the group rather than to the service, as its streams do: a
+ * filter has no identity outside the group it watches, and deleting the group
+ * takes its filters with it.
+ */
+export class SimLogsSubscriptionFilterStore {
+  readonly #filters = new Map<string, SimLogsSubscriptionFilter>();
+
+  /**
+   * Every filter on this group, in the order they were put.
+   */
+  get all(): readonly SimLogsSubscriptionFilter[] {
+    return this.#filters.values().toArray();
+  }
+
+  /**
+   * Put a filter, replacing one of the same name.
+   *
+   * Putting a filter that is already there by name is an update rather than a
+   * second filter, which is what makes `PutSubscriptionFilter` the way to
+   * change a pattern. Only a new name counts against the limit.
+   */
+  put(filter: SimLogsSubscriptionFilter): void {
+    if (
+      !this.#filters.has(filter.filterName) &&
+      this.#filters.size >= simLogsMaximumSubscriptionFilters
+    ) {
+      throw new SimLogsLimitExceededException(
+        `Resource limit exceeded: a log group may have at most ` +
+          `${simLogsMaximumSubscriptionFilters} subscription filters`,
+      );
+    }
+
+    this.#filters.set(filter.filterName, filter);
+  }
+
+  /**
+   * Remove a filter by name, refusing one that is not there.
+   */
+  delete(filterName: string): void {
+    if (!this.#filters.delete(filterName)) {
+      throw new SimLogsResourceNotFoundException(
+        "The specified subscription filter does not exist.",
+      );
+    }
+  }
+
+  /**
+   * The filters whose names start with a prefix, in the order they were put.
+   */
+  withNamePrefix(
+    prefix: string | undefined,
+  ): readonly SimLogsSubscriptionFilter[] {
+    return this.all.filter((filter) =>
+      filter.filterName.startsWith(prefix ?? ""),
+    );
+  }
+}

--- a/src/service/logs/subscription/sim-logs-subscription-filter.ts
+++ b/src/service/logs/subscription/sim-logs-subscription-filter.ts
@@ -1,0 +1,49 @@
+import { SimLogsFilterPattern } from "../event/sim-logs-filter-pattern.js";
+
+interface SimLogsSubscriptionFilterProperties {
+  readonly filterName: string;
+  readonly logGroupName: string;
+  readonly filterPattern: string | undefined;
+  readonly destinationArn: string;
+  readonly roleArn: string | undefined;
+  readonly distribution: string | undefined;
+  readonly creationTime: number;
+}
+
+/**
+ * One subscription filter on a log group.
+ *
+ * The pattern is compiled once, when the filter is put, so a pattern this
+ * simulator cannot read is refused there rather than on the first event that
+ * happens to arrive. Real CloudWatch Logs validates it at `PutSubscriptionFilter`
+ * too.
+ */
+export class SimLogsSubscriptionFilter {
+  readonly filterName: string;
+  readonly logGroupName: string;
+  readonly filterPatternText: string;
+  readonly destinationArn: string;
+  readonly roleArn: string | undefined;
+  readonly distribution: string | undefined;
+  readonly creationTime: number;
+
+  readonly #pattern: SimLogsFilterPattern;
+
+  constructor(properties: SimLogsSubscriptionFilterProperties) {
+    this.filterName = properties.filterName;
+    this.logGroupName = properties.logGroupName;
+    this.filterPatternText = properties.filterPattern ?? "";
+    this.destinationArn = properties.destinationArn;
+    this.roleArn = properties.roleArn;
+    this.distribution = properties.distribution;
+    this.creationTime = properties.creationTime;
+    this.#pattern = new SimLogsFilterPattern(properties.filterPattern);
+  }
+
+  /**
+   * Whether this filter wants an event's message.
+   */
+  wants(message: string): boolean {
+    return this.#pattern.matches(message);
+  }
+}

--- a/src/service/logs/subscription/sim-logs-subscription-filters.iso.test.ts
+++ b/src/service/logs/subscription/sim-logs-subscription-filters.iso.test.ts
@@ -278,6 +278,45 @@ describe("CloudWatch Logs subscription filters", () => {
     assertStringIncludes(error.message, "version or alias");
   });
 
+  it("refuses a destination in another Account or Region", async () => {
+    // Given a log group and function ARNs outside its own scope.
+    const simAws = await simAwsWithTrackers();
+    const otherAccount = `arn:aws:lambda:${simAws.defaultRegionName}:222222222222:function:tracker-one`;
+    const otherRegion = `arn:aws:lambda:eu-west-2:${simAws.defaultAccountId}:function:tracker-one`;
+
+    // When each is used as a destination.
+    const crossAccount = await assertThrowsErrorAsync(
+      async () =>
+        await simAws.logs().putSubscriptionFilter(
+          new PutSubscriptionFilterCommand({
+            logGroupName,
+            filterName: "errors",
+            filterPattern: "",
+            destinationArn: otherAccount,
+          }),
+        ),
+    );
+    const crossRegion = await assertThrowsErrorAsync(
+      async () =>
+        await simAws.logs().putSubscriptionFilter(
+          new PutSubscriptionFilterCommand({
+            logGroupName,
+            filterName: "errors",
+            filterPattern: "",
+            destinationArn: otherRegion,
+          }),
+        ),
+    );
+
+    // Then both are refused. Real CloudWatch Logs takes a Lambda destination
+    // belonging to the same Account as the subscription filter, and reaches
+    // another one only through a logical destination.
+    assertInstanceOf(crossAccount, SimLogsInvalidParameterException);
+    assertInstanceOf(crossRegion, SimLogsInvalidParameterException);
+    assertStringIncludes(crossAccount.message, "same Account");
+    assertStringIncludes(crossRegion.message, "same Region");
+  });
+
   it("takes a log group's filters down with it", async () => {
     // Given a filter on a log group.
     const simAws = await simAwsWithTrackers();

--- a/src/service/logs/subscription/sim-logs-subscription-filters.iso.test.ts
+++ b/src/service/logs/subscription/sim-logs-subscription-filters.iso.test.ts
@@ -1,0 +1,302 @@
+import {
+  CreateLogGroupCommand,
+  DeleteSubscriptionFilterCommand,
+  DescribeSubscriptionFiltersCommand,
+  PutSubscriptionFilterCommand,
+} from "@aws-sdk/client-cloudwatch-logs";
+import {
+  AddPermissionCommand,
+  CreateFunctionCommand,
+} from "@aws-sdk/client-lambda";
+import {
+  assertArrayEquals,
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import { makeLambdaZipFileInput } from "../../lambda/function/code/lambda-zip-file-input.js";
+import {
+  SimLogsInvalidParameterException,
+  SimLogsLimitExceededException,
+  SimLogsResourceNotFoundException,
+} from "../error/sim-logs.error.js";
+
+const logGroupName = "/aws/lambda/orders";
+
+/**
+ * A simulation with a log group and two tracker functions that both admit
+ * CloudWatch Logs.
+ */
+async function simAwsWithTrackers(): Promise<SimAws> {
+  const simAws = new SimAws();
+
+  for (const functionName of ["tracker-one", "tracker-two"]) {
+    // oxlint-disable-next-line no-await-in-loop -- each function is set up before the next
+    await simAws.lambda().createFunction(
+      new CreateFunctionCommand({
+        FunctionName: functionName,
+        Role: `arn:aws:iam::${simAws.defaultAccountId}:role/TrackerRole`,
+        Code: { ZipFile: makeLambdaZipFileInput(() => "recorded") },
+      }),
+    );
+    // oxlint-disable-next-line no-await-in-loop -- each function is set up before the next
+    await simAws.lambda().addPermission(
+      new AddPermissionCommand({
+        FunctionName: functionName,
+        StatementId: "logs",
+        Action: "lambda:InvokeFunction",
+        Principal: `logs.${simAws.defaultRegionName}.amazonaws.com`,
+      }),
+    );
+  }
+
+  await simAws.backgroundTasksComplete();
+  await simAws
+    .logs()
+    .createLogGroup(new CreateLogGroupCommand({ logGroupName }));
+
+  return simAws;
+}
+
+function trackerArn(simAws: SimAws, functionName: string): string {
+  return `arn:aws:lambda:${simAws.defaultRegionName}:${simAws.defaultAccountId}:function:${functionName}`;
+}
+
+async function putFilter(
+  simAws: SimAws,
+  filterName: string,
+  functionName = "tracker-one",
+  filterPattern?: string,
+): Promise<void> {
+  await simAws.logs().putSubscriptionFilter(
+    new PutSubscriptionFilterCommand({
+      logGroupName,
+      filterName,
+      filterPattern,
+      destinationArn: trackerArn(simAws, functionName),
+    }),
+  );
+}
+
+describe("CloudWatch Logs subscription filters", () => {
+  it("describes a filter it was given", async () => {
+    // Given a filter on a log group.
+    const simAws = await simAwsWithTrackers();
+
+    await putFilter(simAws, "errors-to-tracker", "tracker-one", "ERROR");
+
+    // When the filters are described.
+    const described = await simAws
+      .logs()
+      .describeSubscriptionFilters(
+        new DescribeSubscriptionFiltersCommand({ logGroupName }),
+      );
+    const filter = described.subscriptionFilters?.at(0);
+
+    // Then it reports what was put, so a test can assert on the wiring a stack
+    // or a setup step made.
+    assertNonNullable(filter);
+    assertIdentical(filter.filterName, "errors-to-tracker");
+    assertIdentical(filter.logGroupName, logGroupName);
+    assertIdentical(filter.filterPattern, "ERROR");
+    assertIdentical(filter.destinationArn, trackerArn(simAws, "tracker-one"));
+  });
+
+  it("replaces a filter of the same name rather than adding one", async () => {
+    // Given a filter that has been put twice under one name.
+    const simAws = await simAwsWithTrackers();
+
+    await putFilter(simAws, "errors", "tracker-one", "ERROR");
+    await putFilter(simAws, "errors", "tracker-two", "WARN");
+
+    // When the filters are described.
+    const described = await simAws
+      .logs()
+      .describeSubscriptionFilters(
+        new DescribeSubscriptionFiltersCommand({ logGroupName }),
+      );
+
+    // Then the second put changed the first, which is what makes
+    // PutSubscriptionFilter the way to change a pattern.
+    assertArrayEquals(
+      described.subscriptionFilters?.map((filter) => filter.filterPattern),
+      ["WARN"],
+    );
+    assertIdentical(
+      described.subscriptionFilters.at(0)?.destinationArn,
+      trackerArn(simAws, "tracker-two"),
+    );
+  });
+
+  it("refuses more filters than a log group may have", async () => {
+    // Given a log group with the two filters AWS allows.
+    const simAws = await simAwsWithTrackers();
+
+    await putFilter(simAws, "errors");
+    await putFilter(simAws, "warnings");
+
+    // When a third is put.
+    const error = await assertThrowsErrorAsync(async () => {
+      await putFilter(simAws, "everything");
+    });
+
+    // Then it is refused, as an account refuses it.
+    assertInstanceOf(error, SimLogsLimitExceededException);
+    assertStringIncludes(error.message, "at most 2 subscription filters");
+  });
+
+  it("removes a filter, and refuses to remove one that is not there", async () => {
+    // Given one filter.
+    const simAws = await simAwsWithTrackers();
+
+    await putFilter(simAws, "errors");
+
+    // When it is deleted, and then deleted again.
+    await simAws.logs().deleteSubscriptionFilter(
+      new DeleteSubscriptionFilterCommand({
+        logGroupName,
+        filterName: "errors",
+      }),
+    );
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await simAws.logs().deleteSubscriptionFilter(
+          new DeleteSubscriptionFilterCommand({
+            logGroupName,
+            filterName: "errors",
+          }),
+        ),
+    );
+
+    // Then the first went and the second failed as an unknown filter.
+    const described = await simAws
+      .logs()
+      .describeSubscriptionFilters(
+        new DescribeSubscriptionFiltersCommand({ logGroupName }),
+      );
+
+    assertArrayEquals(described.subscriptionFilters ?? [], []);
+    assertInstanceOf(error, SimLogsResourceNotFoundException);
+  });
+
+  it("describes filters under a name prefix", async () => {
+    // Given two filters with different name prefixes.
+    const simAws = await simAwsWithTrackers();
+
+    await putFilter(simAws, "errors-to-tracker");
+    await putFilter(simAws, "warnings-to-tracker");
+
+    // When one prefix is described.
+    const described = await simAws.logs().describeSubscriptionFilters(
+      new DescribeSubscriptionFiltersCommand({
+        logGroupName,
+        filterNamePrefix: "errors-",
+      }),
+    );
+
+    // Then only that one is reported.
+    assertArrayEquals(
+      described.subscriptionFilters?.map((filter) => filter.filterName),
+      ["errors-to-tracker"],
+    );
+  });
+
+  it("refuses a filter on a log group that is not there", async () => {
+    // Given a simulation whose tracker exists but whose log group does not.
+    const simAws = await simAwsWithTrackers();
+
+    // When a filter is put on another group.
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await simAws.logs().putSubscriptionFilter(
+          new PutSubscriptionFilterCommand({
+            logGroupName: "/aws/lambda/billing",
+            filterName: "errors",
+            filterPattern: "",
+            destinationArn: trackerArn(simAws, "tracker-one"),
+          }),
+        ),
+    );
+
+    // Then it fails as an unknown log group.
+    assertInstanceOf(error, SimLogsResourceNotFoundException);
+  });
+
+  it("refuses a filter missing the parts it is identified by", async () => {
+    // Given a log group.
+    const simAws = await simAwsWithTrackers();
+
+    // When a filter is put with no name, and one with no destination.
+    const noName = await assertThrowsErrorAsync(
+      async () =>
+        await simAws.logs().putSubscriptionFilter({
+          input: {
+            logGroupName,
+            destinationArn: trackerArn(simAws, "tracker-one"),
+          },
+        }),
+    );
+    const noDestination = await assertThrowsErrorAsync(
+      async () =>
+        await simAws.logs().putSubscriptionFilter({
+          input: { logGroupName, filterName: "errors" },
+        }),
+    );
+
+    // Then each names the part that was missing.
+    assertInstanceOf(noName, SimLogsInvalidParameterException);
+    assertInstanceOf(noDestination, SimLogsInvalidParameterException);
+    assertStringIncludes(noName.message, "filterName");
+    assertStringIncludes(noDestination.message, "destinationArn");
+  });
+
+  it("refuses a destination naming a function version", async () => {
+    // Given a log group and a qualified function ARN.
+    const simAws = await simAwsWithTrackers();
+
+    // When a filter is put on it.
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await simAws.logs().putSubscriptionFilter(
+          new PutSubscriptionFilterCommand({
+            logGroupName,
+            filterName: "errors",
+            filterPattern: "",
+            destinationArn: `${trackerArn(simAws, "tracker-one")}:1`,
+          }),
+        ),
+    );
+
+    // Then it is refused, because simulated Lambda has no versions and
+    // delivering to the unqualified function would be a different one.
+    assertInstanceOf(error, SimLogsInvalidParameterException);
+    assertStringIncludes(error.message, "version or alias");
+  });
+
+  it("takes a log group's filters down with it", async () => {
+    // Given a filter on a log group.
+    const simAws = await simAwsWithTrackers();
+
+    await putFilter(simAws, "errors");
+
+    // When the group is deleted and made again.
+    await simAws.logs().deleteLogGroup({ input: { logGroupName } });
+    await simAws
+      .logs()
+      .createLogGroup(new CreateLogGroupCommand({ logGroupName }));
+
+    // Then the filter went with the group, as it does in an account.
+    const described = await simAws
+      .logs()
+      .describeSubscriptionFilters(
+        new DescribeSubscriptionFiltersCommand({ logGroupName }),
+      );
+
+    assertArrayEquals(described.subscriptionFilters ?? [], []);
+  });
+});

--- a/src/service/logs/write/sim-logs-service-writer.ts
+++ b/src/service/logs/write/sim-logs-service-writer.ts
@@ -4,11 +4,15 @@ import type { SimLogsEventIds } from "../event/sim-logs-event-ids.js";
 import type { SimLogsLogGroup } from "../group/sim-logs-log-group.js";
 import type { SimLogsLogGroupStore } from "../group/sim-logs-log-group-store.js";
 import type { SimLogsLogStream } from "../stream/sim-logs-log-stream.js";
+import type { SimLogsSubscriptionFanOut } from "../subscription/sim-logs-subscription-fan-out.js";
 
 interface SimLogsServiceWriterProperties {
   readonly groups: SimLogsLogGroupStore;
   readonly eventIds: SimLogsEventIds;
   readonly clock: SimClock;
+
+  /** Where events written here are handed on to subscription filters. */
+  readonly fanOut: SimLogsSubscriptionFanOut;
 }
 
 /**
@@ -29,11 +33,13 @@ export class SimLogsServiceWriter {
   readonly #groups: SimLogsLogGroupStore;
   readonly #eventIds: SimLogsEventIds;
   readonly #clock: SimClock;
+  readonly #fanOut: SimLogsSubscriptionFanOut;
 
   constructor(properties: SimLogsServiceWriterProperties) {
     this.#groups = properties.groups;
     this.#eventIds = properties.eventIds;
     this.#clock = properties.clock;
+    this.#fanOut = properties.fanOut;
   }
 
   /**
@@ -93,5 +99,6 @@ export class SimLogsServiceWriter {
     }));
 
     stream.append(events, now);
+    this.#fanOut.written(this.logGroup(logGroupName), logStreamName, events);
   }
 }

--- a/test/logs/subscription-fixture.ts
+++ b/test/logs/subscription-fixture.ts
@@ -1,0 +1,149 @@
+/**
+ * A simulated AWS with a log group subscribed to a tracker function, which
+ * every CloudWatch Logs subscription delivery test needs before it can say
+ * anything about a delivery.
+ *
+ * This lives under `test/` for the same reasons as `test/sns/`: eslint rejects
+ * a test file that exports helpers alongside its own `describe` calls, and
+ * `test/**` is type-checked with everything else, excluded from the published
+ * build, not collected as a suite, and not counted in coverage.
+ */
+
+import { gunzipSync } from "node:zlib";
+
+import {
+  CreateLogGroupCommand,
+  CreateLogStreamCommand,
+  PutLogEventsCommand,
+} from "@aws-sdk/client-cloudwatch-logs";
+import {
+  AddPermissionCommand,
+  CreateFunctionCommand,
+} from "@aws-sdk/client-lambda";
+
+import { SimAws } from "../../src/service/aws/sim-aws.js";
+import { makeLambdaZipFileInput } from "../../src/service/lambda/function/code/lambda-zip-file-input.js";
+import type { SimLogsSubscriptionEventDocument } from "../../src/service/logs/subscription/sim-logs-subscription-event.js";
+
+/** The log group every one of these tests subscribes to. */
+export const simLogsSubscribedGroupName = "/aws/lambda/orders";
+
+/** The stream those tests write to. */
+export const simLogsSubscribedStreamName = "2026/08/16/[$LATEST]abc";
+
+/**
+ * A simulation ready to be subscribed, and what its tracker was handed.
+ */
+export interface SimLogsTrackerFixture {
+  readonly simAws: SimAws;
+  readonly received: unknown[];
+  readonly trackerArn: string;
+}
+
+/**
+ * How a test wants its tracker to differ from the usual one.
+ */
+export interface SimLogsTrackerOptions {
+  /**
+   * Left out to grant `logs.<region>.amazonaws.com` the invoke action, which
+   * is what putting a subscription filter on the function needs.
+   */
+  readonly withoutPermission?: boolean;
+
+  /**
+   * Left out for a tracker that records what it was handed. Set for one that
+   * fails, which is how a delivery failure is arranged.
+   */
+  readonly failing?: boolean;
+}
+
+/**
+ * A simulated AWS with a tracker function and a log group ready to subscribe.
+ */
+export async function simLogsWithTracker(
+  options: SimLogsTrackerOptions = {},
+): Promise<SimLogsTrackerFixture> {
+  const simAws = new SimAws();
+  const received: unknown[] = [];
+
+  await simAws.lambda().createFunction(
+    new CreateFunctionCommand({
+      FunctionName: "error-tracker",
+      Role: `arn:aws:iam::${simAws.defaultAccountId}:role/TrackerRole`,
+      Code: {
+        ZipFile: makeLambdaZipFileInput((event: unknown) => {
+          if (options.failing === true) {
+            throw new Error("tracker is down");
+          }
+
+          received.push(event);
+
+          return "recorded";
+        }),
+      },
+    }),
+  );
+  await simAws.backgroundTasksComplete();
+
+  if (options.withoutPermission !== true) {
+    await simAws.lambda().addPermission(
+      new AddPermissionCommand({
+        FunctionName: "error-tracker",
+        StatementId: "logs",
+        Action: "lambda:InvokeFunction",
+        Principal: `logs.${simAws.defaultRegionName}.amazonaws.com`,
+      }),
+    );
+  }
+
+  await simAws
+    .logs()
+    .createLogGroup(
+      new CreateLogGroupCommand({ logGroupName: simLogsSubscribedGroupName }),
+    );
+  await simAws.logs().createLogStream(
+    new CreateLogStreamCommand({
+      logGroupName: simLogsSubscribedGroupName,
+      logStreamName: simLogsSubscribedStreamName,
+    }),
+  );
+
+  return {
+    simAws,
+    received,
+    trackerArn: `arn:aws:lambda:${simAws.defaultRegionName}:${simAws.defaultAccountId}:function:error-tracker`,
+  };
+}
+
+/**
+ * Write lines to the subscribed stream and wait for delivery.
+ */
+export async function simLogsWriteLines(
+  simAws: SimAws,
+  lines: readonly string[],
+): Promise<void> {
+  await simAws.logs().putLogEvents(
+    new PutLogEventsCommand({
+      logGroupName: simLogsSubscribedGroupName,
+      logStreamName: simLogsSubscribedStreamName,
+      logEvents: lines.map((message, index) => ({
+        timestamp: 1000 + index,
+        message,
+      })),
+    }),
+  );
+  await simAws.backgroundTasksComplete();
+}
+
+/**
+ * The decoded document a Lambda destination was handed.
+ */
+export function simLogsDecodedDelivery(
+  payload: unknown,
+): SimLogsSubscriptionEventDocument {
+  const { data } = (payload as { awslogs: { data: string } }).awslogs;
+
+  return JSON.parse(
+    gunzipSync(Buffer.from(data, "base64")).toString("utf8"),
+  ) as SimLogsSubscriptionEventDocument;
+}


### PR DESCRIPTION
Brief, concise description of the change:

A subscription filter on a log group now delivers the events its pattern matched to a simulated Lambda function, so the code a team wrote to forward log lines to an error tracker or a metrics sink can be tested against the handler it forwards from. The payload is the real one, an `awslogs.data` field holding the base64 of a gzipped document carrying `messageType`, `owner`, `logGroup`, `logStream`, `subscriptionFilters` and `logEvents`, so a handler written against a real subscription decodes it unchanged. Delivery happens on the background scheduler because real CloudWatch Logs answers a write before anything is delivered, so a destination that throws cannot fail the `PutLogEvents` that triggered it, and every failure is kept in `subscriptionFailures` rather than being lost the way an account loses it. The destination is checked when the filter is put, as an account checks it, so a function that never granted the regional `logs.<region>.amazonaws.com` principal permission fails there rather than leaving a filter that silently drops every event, and the resource policy is consulted again on every delivery so a permission taken away later stops delivery too. What a Lambda function logged for itself is delivered as well, since both write paths hand events to the same fan-out, which is what makes a forwarder testable against a real handler's output. Simulated CloudWatch Logs moves off the self-contained service builder to reach Lambda, resolving the destination function when an event is delivered rather than at construction, because every function records its output here and reaching one while this is being built would be a cycle with no bottom; that is the same lazy lookup simulated SNS uses for the same reason. Kinesis, Firehose and cross-account destinations are refused rather than accepted and never delivered to.

Resolves https://github.com/KensioSoftware/yulin/issues/609

- [x] Conventional commit message, used as the title

- [x] Conventional branch name, like `feat/concise-description`
- [x] Full check with `pnpm run check` passed
- [x] Rebased off latest main
- [x] User-facing behaviour is documented in `docs/`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CloudWatch Logs subscription filters with create, list, update, and delete operations.
  * Added asynchronous delivery of matching log events to Lambda functions using AWS-compatible compressed payloads.
  * Added filter limits, pattern matching, permission validation, and delivery-failure tracking.
  * Added support for service-writer-generated logs and standalone Logs behavior.
* **Documentation**
  * Added usage guides and TypeScript examples covering setup, permissions, payload decoding, and asynchronous delivery.
* **Tests**
  * Added comprehensive coverage for filtering, delivery, permissions, failures, limits, and lifecycle scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->