### PR TITLE
feat: record and query custom CloudWatch metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ npm i -D @kensio/yulin
 - [API Gateway HTTP APIs](./docs/services/apigatewayv2 "Simulated API Gateway HTTP API docs")
 - [CloudFormation](./docs/services/cloudformation "Simulated CloudFormation docs")
 - [CloudFront](./docs/services/cloudfront "Simulated CloudFront docs")
+- [CloudWatch metrics](./docs/services/cloudwatch "Simulated CloudWatch metrics docs")
 - [Cognito user pools](./docs/services/cognito "Simulated Cognito user pools docs")
 - [DynamoDB](./docs/services/dynamodb "Simulated DynamoDB docs")
 - [ECR](./docs/services/ecr "Simulated ECR docs")

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,7 @@ behaviour and includes example code that can be copied into tests or local devel
 - [API Gateway HTTP APIs](./services/apigatewayv2/ "Simulated API Gateway HTTP API usage docs")
 - [CloudFormation](./services/cloudformation/ "Simulated CloudFormation usage docs")
 - [CloudFront](./services/cloudfront/ "Simulated CloudFront usage docs")
+- [CloudWatch metrics](./services/cloudwatch/ "Simulated CloudWatch metrics usage docs")
 - [Cognito user pools](./services/cognito/ "Simulated Cognito user pools usage docs")
 - [DynamoDB](./services/dynamodb/ "Simulated DynamoDB usage docs")
 - [ECR](./services/ecr/ "Simulated ECR usage docs")

--- a/docs/services/cloudwatch/README.md
+++ b/docs/services/cloudwatch/README.md
@@ -1,0 +1,238 @@
+# Simulated CloudWatch metrics
+
+Yulin includes a simulated Amazon CloudWatch for tests and local development. It holds custom
+metrics: the datapoints `PutMetricData` publishes, and the statistics `GetMetricStatistics` and
+`GetMetricData` read back from them, without an AWS account.
+
+That is what this service is for. Code that publishes a business metric is code teams already have,
+and until now the only way to test it was to assert that the SDK client had been called, which
+proves the call was made and nothing about what it measured.
+
+Only custom metrics live here. Nothing in this simulation publishes into the `AWS/` namespaces, so a
+query for `AWS/Lambda` `Invocations` finds nothing rather than a number that was never measured.
+
+CloudWatch specific types are imported from the `@kensio/yulin/cloudwatch` subpath.
+
+## Publishing and reading back a metric
+
+A metric is identified by its namespace, its name and its dimensions together. Publishing a value
+and asking for it back at a period is the whole loop:
+
+```typescript sim-cloudwatch-publish-and-read
+/**
+ * Publishing a custom metric and reading it back as statistics.
+ */
+
+import {
+  GetMetricStatisticsCommand,
+  PutMetricDataCommand,
+} from "@aws-sdk/client-cloudwatch";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const metrics = simAws.cloudWatch();
+
+await metrics.putMetricData(
+  new PutMetricDataCommand({
+    Namespace: "Orders",
+    MetricData: [
+      {
+        MetricName: "Failed",
+        Value: 1,
+        Unit: "Count",
+        Timestamp: new Date("2026-08-16T09:00:10.000Z"),
+        Dimensions: [{ Name: "Channel", Value: "web" }],
+      },
+    ],
+  }),
+);
+
+const read = await metrics.getMetricStatistics(
+  new GetMetricStatisticsCommand({
+    Namespace: "Orders",
+    MetricName: "Failed",
+    Dimensions: [{ Name: "Channel", Value: "web" }],
+    StartTime: new Date("2026-08-16T09:00:00.000Z"),
+    EndTime: new Date("2026-08-16T09:05:00.000Z"),
+    Period: 60,
+    Statistics: ["Sum", "SampleCount"],
+  }),
+);
+
+// One datapoint, stamped with the start of the minute the value fell in.
+console.log(read.Datapoints?.at(0)?.Sum);
+```
+
+A datum may state its values as a plain `Value`, as a `StatisticValues` summary, or as `Values` with
+matching `Counts`. All three answer the same statistics, so a metric published one way reads back
+like a metric published another.
+
+## Metrics are identified by their dimensions
+
+Real CloudWatch does not roll a custom metric up across its dimensions, and neither does this. The
+same metric name published under two channels is two metrics, and a read naming no dimensions
+reaches the metric that was published with none rather than the total of all of them.
+
+That is the behaviour teams most often get wrong, so it is worth a test of its own: a dashboard
+query written against a metric name alone finds nothing at all if every publish carried a dimension.
+
+## Metrics and simulated time
+
+A datum carrying no `Timestamp` is stamped from the simulation's clock, not the host's. A test with a
+frozen clock therefore gets timestamps it can assert on exactly, and one that moves time on gets
+datapoints in the period it moved to:
+
+```typescript sim-cloudwatch-simulated-time
+/**
+ * Publishing metrics across simulated minutes, and reading a value per minute.
+ */
+
+import {
+  GetMetricDataCommand,
+  PutMetricDataCommand,
+} from "@aws-sdk/client-cloudwatch";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const metrics = simAws.cloudWatch();
+const startedAt = new Date("2026-08-16T09:00:00.000Z");
+
+await simAws.clock().setTo(startedAt);
+
+// Three failures, one a minute, without waiting three real minutes.
+for (let minute = 0; minute < 3; minute++) {
+  await metrics.putMetricData(
+    new PutMetricDataCommand({
+      Namespace: "Orders",
+      MetricData: [{ MetricName: "Failed", Value: 1 }],
+    }),
+  );
+  await simAws.clock().advanceBy({ minutes: 1 });
+}
+
+const read = await metrics.getMetricData(
+  new GetMetricDataCommand({
+    MetricDataQueries: [
+      {
+        Id: "failed",
+        MetricStat: {
+          Metric: { Namespace: "Orders", MetricName: "Failed" },
+          Period: 60,
+          Stat: "Sum",
+        },
+      },
+    ],
+    StartTime: startedAt,
+    EndTime: new Date("2026-08-16T09:03:00.000Z"),
+    ScanBy: "TimestampAscending",
+  }),
+);
+
+// [1, 1, 1]: one failure in each of the three simulated minutes.
+console.log(read.MetricDataResults?.at(0)?.Values);
+```
+
+`ListMetrics` reads `RecentlyActive: "PT3H"` against the same clock, so advancing time past the
+window drops a metric out of the listing without anything having to expire it.
+
+## Permissions
+
+CloudWatch metrics have no ARN, so there is nothing for a policy to name: every action here is
+granted on `*`. A policy written against something like
+`arn:aws:cloudwatch:eu-west-2:111111111111:metric/Orders/Failed` reaches nothing, here and in an
+account.
+
+The one way to narrow publishing is the `cloudwatch:namespace` condition key:
+
+```typescript sim-cloudwatch-permissions
+/**
+ * A simulated IAM policy allowing a Role to publish into one namespace only.
+ */
+
+import { PutMetricDataCommand } from "@aws-sdk/client-cloudwatch";
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+const role = await simAws.iam().createRole(
+  new CreateRoleCommand({
+    RoleName: "OrdersFunctionRole",
+    AssumeRolePolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Principal: { Service: "lambda.amazonaws.com" },
+        Action: "sts:AssumeRole",
+      },
+    }),
+  }),
+);
+
+await simAws.iam().putRolePolicy(
+  new PutRolePolicyCommand({
+    RoleName: "OrdersFunctionRole",
+    PolicyName: "PublishOrdersMetrics",
+    PolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Action: "cloudwatch:PutMetricData",
+        // Metrics have no ARN, so the namespace condition is what scopes this.
+        Resource: "*",
+        Condition: { StringEquals: { "cloudwatch:namespace": "Orders" } },
+      },
+    }),
+  }),
+);
+
+const asRole = { caller: { kind: "arn", arn: role.Role.Arn } } as const;
+
+await simAws.cloudWatch().putMetricData(
+  new PutMetricDataCommand({
+    Namespace: "Orders",
+    MetricData: [{ MetricName: "Failed", Value: 1 }],
+  }),
+  asRole,
+);
+
+// Publishing into any other namespace as this Role is denied.
+```
+
+## What is simulated
+
+- `PutMetricData`, with `Value`, `StatisticValues` and `Values`/`Counts`.
+- `ListMetrics`, filtered by namespace, metric name and dimensions, with `RecentlyActive` and
+  `NextToken` paging.
+- `GetMetricStatistics`, with `SampleCount`, `Average`, `Sum`, `Minimum` and `Maximum` over periods
+  of a whole number of minutes, filtered by `Unit`.
+- `GetMetricData`, with `MetricStat` queries, `ScanBy` and `ReturnData`.
+- IAM authorization on each action, including the `cloudwatch:namespace` condition key.
+
+## What is not, and how it says so
+
+Anything real CloudWatch would accept and this does not carry out is refused with a message saying
+so, rather than accepted and ignored. A silently dropped filter is worse than a failure, because the
+test still passes and no longer means what it says.
+
+- **Alarms.** Nothing here evaluates a threshold or fires an action yet.
+- **Metric math.** A `GetMetricData` query carrying an `Expression` is refused.
+- **Percentiles and other extended statistics.** They need the individual values behind a period,
+  which a `StatisticValues` datum never carries, so CloudWatch itself cannot report one for a metric
+  published that way.
+- **High-resolution metrics.** `StorageResolution: 1` is refused; every period here is a whole
+  number of minutes.
+- **`MaxDatapoints`.** Real CloudWatch answers it by widening the period, and every result here comes
+  back at the period its query asked for.
+- **Cross-account metrics.** `IncludeLinkedAccounts` and `OwningAccount` are refused; there is no
+  monitoring account.
+- **Metrics AWS publishes.** No simulated service writes its own `AWS/` metrics.
+
+Two divergences are deliberate rather than refusals. Real CloudWatch rejects a datapoint more than
+two weeks old or more than two hours in the future, and this accepts any timestamp, so that a test
+can seed a window without arranging the clock around it. And datapoints come back earliest first,
+which real CloudWatch's contract permits but does not promise, because a test reading the third
+period of five needs an order it can rely on.

--- a/docs/services/cloudwatch/README.md
+++ b/docs/services/cloudwatch/README.md
@@ -68,6 +68,12 @@ A datum may state its values as a plain `Value`, as a `StatisticValues` summary,
 matching `Counts`. All three answer the same statistics, so a metric published one way reads back
 like a metric published another.
 
+Values are checked the way real CloudWatch checks them: within -2^360 to 2^360, never `NaN` or an
+infinity, at most 150 unique values in one datum, and `Counts` only alongside the `Values` it counts.
+`Unit` is the closed `StandardUnit` set rather than free text, on the way in and on the way out, so a
+query naming a unit CloudWatch does not have fails here as it would in an account rather than
+quietly matching nothing.
+
 ## Metrics are identified by their dimensions
 
 Real CloudWatch does not roll a custom metric up across its dimensions, and neither does this. The

--- a/docs/services/cloudwatch/sim-cloudwatch-permissions.example.ts
+++ b/docs/services/cloudwatch/sim-cloudwatch-permissions.example.ts
@@ -1,0 +1,53 @@
+/**
+ * A simulated IAM policy allowing a Role to publish into one namespace only.
+ */
+
+import { PutMetricDataCommand } from "@aws-sdk/client-cloudwatch";
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+const role = await simAws.iam().createRole(
+  new CreateRoleCommand({
+    RoleName: "OrdersFunctionRole",
+    AssumeRolePolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Principal: { Service: "lambda.amazonaws.com" },
+        Action: "sts:AssumeRole",
+      },
+    }),
+  }),
+);
+
+await simAws.iam().putRolePolicy(
+  new PutRolePolicyCommand({
+    RoleName: "OrdersFunctionRole",
+    PolicyName: "PublishOrdersMetrics",
+    PolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Action: "cloudwatch:PutMetricData",
+        // Metrics have no ARN, so the namespace condition is what scopes this.
+        Resource: "*",
+        Condition: { StringEquals: { "cloudwatch:namespace": "Orders" } },
+      },
+    }),
+  }),
+);
+
+const asRole = { caller: { kind: "arn", arn: role.Role.Arn } } as const;
+
+await simAws.cloudWatch().putMetricData(
+  new PutMetricDataCommand({
+    Namespace: "Orders",
+    MetricData: [{ MetricName: "Failed", Value: 1 }],
+  }),
+  asRole,
+);
+
+// Publishing into any other namespace as this Role is denied.

--- a/docs/services/cloudwatch/sim-cloudwatch-publish-and-read.example.ts
+++ b/docs/services/cloudwatch/sim-cloudwatch-publish-and-read.example.ts
@@ -1,0 +1,43 @@
+/**
+ * Publishing a custom metric and reading it back as statistics.
+ */
+
+import {
+  GetMetricStatisticsCommand,
+  PutMetricDataCommand,
+} from "@aws-sdk/client-cloudwatch";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const metrics = simAws.cloudWatch();
+
+await metrics.putMetricData(
+  new PutMetricDataCommand({
+    Namespace: "Orders",
+    MetricData: [
+      {
+        MetricName: "Failed",
+        Value: 1,
+        Unit: "Count",
+        Timestamp: new Date("2026-08-16T09:00:10.000Z"),
+        Dimensions: [{ Name: "Channel", Value: "web" }],
+      },
+    ],
+  }),
+);
+
+const read = await metrics.getMetricStatistics(
+  new GetMetricStatisticsCommand({
+    Namespace: "Orders",
+    MetricName: "Failed",
+    Dimensions: [{ Name: "Channel", Value: "web" }],
+    StartTime: new Date("2026-08-16T09:00:00.000Z"),
+    EndTime: new Date("2026-08-16T09:05:00.000Z"),
+    Period: 60,
+    Statistics: ["Sum", "SampleCount"],
+  }),
+);
+
+// One datapoint, stamped with the start of the minute the value fell in.
+console.log(read.Datapoints?.at(0)?.Sum);

--- a/docs/services/cloudwatch/sim-cloudwatch-simulated-time.example.ts
+++ b/docs/services/cloudwatch/sim-cloudwatch-simulated-time.example.ts
@@ -1,0 +1,48 @@
+/**
+ * Publishing metrics across simulated minutes, and reading a value per minute.
+ */
+
+import {
+  GetMetricDataCommand,
+  PutMetricDataCommand,
+} from "@aws-sdk/client-cloudwatch";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const metrics = simAws.cloudWatch();
+const startedAt = new Date("2026-08-16T09:00:00.000Z");
+
+await simAws.clock().setTo(startedAt);
+
+// Three failures, one a minute, without waiting three real minutes.
+for (let minute = 0; minute < 3; minute++) {
+  await metrics.putMetricData(
+    new PutMetricDataCommand({
+      Namespace: "Orders",
+      MetricData: [{ MetricName: "Failed", Value: 1 }],
+    }),
+  );
+  await simAws.clock().advanceBy({ minutes: 1 });
+}
+
+const read = await metrics.getMetricData(
+  new GetMetricDataCommand({
+    MetricDataQueries: [
+      {
+        Id: "failed",
+        MetricStat: {
+          Metric: { Namespace: "Orders", MetricName: "Failed" },
+          Period: 60,
+          Stat: "Sum",
+        },
+      },
+    ],
+    StartTime: startedAt,
+    EndTime: new Date("2026-08-16T09:03:00.000Z"),
+    ScanBy: "TimestampAscending",
+  }),
+);
+
+// [1, 1, 1]: one failure in each of the three simulated minutes.
+console.log(read.MetricDataResults?.at(0)?.Values);

--- a/package.json
+++ b/package.json
@@ -62,6 +62,10 @@
       "import": "./dist/service/cloudfront/globals.js",
       "types": "./dist/service/cloudfront/globals.d.ts"
     },
+    "./cloudwatch": {
+      "import": "./dist/service/cloudwatch/index.js",
+      "types": "./dist/service/cloudwatch/index.d.ts"
+    },
     "./cognito": {
       "import": "./dist/service/cognito/index.js",
       "types": "./dist/service/cognito/index.d.ts"
@@ -174,6 +178,7 @@
     "@aws-sdk/client-cloudformation": "^3.1101.0",
     "@aws-sdk/client-cloudfront": "^3.1101.0",
     "@aws-sdk/client-cloudfront-keyvaluestore": "^3.1108.0",
+    "@aws-sdk/client-cloudwatch": "^3.1111.0",
     "@aws-sdk/client-cloudwatch-logs": "^3.1101.0",
     "@aws-sdk/client-cognito-identity-provider": "^3.1101.0",
     "@aws-sdk/client-dynamodb": "^3.1101.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,6 +42,9 @@ importers:
       '@aws-sdk/client-cloudfront-keyvaluestore':
         specifier: ^3.1108.0
         version: 3.1108.0
+      '@aws-sdk/client-cloudwatch':
+        specifier: ^3.1111.0
+        version: 3.1111.0
       '@aws-sdk/client-cloudwatch-logs':
         specifier: ^3.1101.0
         version: 3.1111.0
@@ -284,6 +287,10 @@ packages:
 
   '@aws-sdk/client-cloudwatch-logs@3.1111.0':
     resolution: {integrity: sha512-IO2wKucjHIduO2z263JCMAezA5YCpFrSj4QN1u4FPZTVjUxWlE9DGGYbCuR2/1zGOp2Y3uvuk+GD0Gj7HrhpJQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/client-cloudwatch@3.1111.0':
+    resolution: {integrity: sha512-UNZuzAPuramSJw1DDAq5I9+2llMqmKJ6ARj472WsD9n4h7ICw8z4rEeyl4OrPSUXsUz4jRNP40AAwaPD41YwpA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/client-cognito-identity-provider@3.1105.0':
@@ -1337,6 +1344,10 @@ packages:
     resolution: {integrity: sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==}
     engines: {node: '>=14.0.0'}
 
+  '@smithy/middleware-compression@4.6.0':
+    resolution: {integrity: sha512-IB8cmku2CGnBgoTxDmPu8idnSjXt8DTDMMz/GylqUNZZ4mT4RsOSI9BllVb7Ylf4MdvoGSxldaj0GMxoVWe7Rg==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/node-http-handler@4.10.0':
     resolution: {integrity: sha512-nrh7VxqzPQS/ip1hS293aI/OAWDWARQvjUxCfuKhyrfHa2gTdk28066RNeWLI1uuoHXaKAkOF8IcSAHuOp0+SA==}
     engines: {node: '>=18.0.0'}
@@ -2098,6 +2109,9 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  fflate@0.8.1:
+    resolution: {integrity: sha512-/exOvEuc+/iaUm105QIiOt4LpBdMTWsXxqR0HDF35vx3fmaKzw7354gTilCh5rkzEt8WYyG//ku3h3nRmd7CHQ==}
 
   figures@2.0.0:
     resolution: {integrity: sha512-Oa2M9atig69ZkfwiApY8F2Yy+tzMbazyvqv21R0NsSC8floSOC09BbT1ITWAdoMGQvJ/aZnR1KMwdx9tvHnTNA==}
@@ -3578,6 +3592,18 @@ snapshots:
       '@smithy/types': 4.17.0
       tslib: 2.8.1
 
+  '@aws-sdk/client-cloudwatch@3.1111.0':
+    dependencies:
+      '@aws-sdk/core': 3.977.8
+      '@aws-sdk/credential-provider-node': 3.972.80
+      '@aws-sdk/types': 3.974.4
+      '@smithy/core': 3.32.0
+      '@smithy/fetch-http-handler': 5.7.0
+      '@smithy/middleware-compression': 4.6.0
+      '@smithy/node-http-handler': 4.10.0
+      '@smithy/types': 4.17.0
+      tslib: 2.8.1
+
   '@aws-sdk/client-cognito-identity-provider@3.1105.0':
     dependencies:
       '@aws-sdk/core': 3.977.7
@@ -3809,8 +3835,8 @@ snapshots:
 
   '@aws-sdk/credential-provider-env@3.972.68':
     dependencies:
-      '@aws-sdk/core': 3.977.7
-      '@aws-sdk/types': 3.974.3
+      '@aws-sdk/core': 3.977.8
+      '@aws-sdk/types': 3.974.4
       '@smithy/core': 3.32.0
       '@smithy/types': 4.17.0
       tslib: 2.8.1
@@ -3825,8 +3851,8 @@ snapshots:
 
   '@aws-sdk/credential-provider-http@3.972.70':
     dependencies:
-      '@aws-sdk/core': 3.977.7
-      '@aws-sdk/types': 3.974.3
+      '@aws-sdk/core': 3.977.8
+      '@aws-sdk/types': 3.974.4
       '@smithy/core': 3.32.0
       '@smithy/fetch-http-handler': 5.7.0
       '@smithy/node-http-handler': 4.10.0
@@ -3845,7 +3871,7 @@ snapshots:
 
   '@aws-sdk/credential-provider-ini@3.973.13':
     dependencies:
-      '@aws-sdk/core': 3.977.7
+      '@aws-sdk/core': 3.977.8
       '@aws-sdk/credential-provider-env': 3.972.68
       '@aws-sdk/credential-provider-http': 3.972.70
       '@aws-sdk/credential-provider-login': 3.972.75
@@ -3853,7 +3879,7 @@ snapshots:
       '@aws-sdk/credential-provider-sso': 3.973.12
       '@aws-sdk/credential-provider-web-identity': 3.972.74
       '@aws-sdk/nested-clients': 3.997.42
-      '@aws-sdk/types': 3.974.3
+      '@aws-sdk/types': 3.974.4
       '@smithy/core': 3.32.0
       '@smithy/credential-provider-imds': 4.5.0
       '@smithy/types': 4.17.0
@@ -3877,9 +3903,9 @@ snapshots:
 
   '@aws-sdk/credential-provider-login@3.972.75':
     dependencies:
-      '@aws-sdk/core': 3.977.7
+      '@aws-sdk/core': 3.977.8
       '@aws-sdk/nested-clients': 3.997.42
-      '@aws-sdk/types': 3.974.3
+      '@aws-sdk/types': 3.974.4
       '@smithy/core': 3.32.0
       '@smithy/types': 4.17.0
       tslib: 2.8.1
@@ -3923,8 +3949,8 @@ snapshots:
 
   '@aws-sdk/credential-provider-process@3.972.68':
     dependencies:
-      '@aws-sdk/core': 3.977.7
-      '@aws-sdk/types': 3.974.3
+      '@aws-sdk/core': 3.977.8
+      '@aws-sdk/types': 3.974.4
       '@smithy/core': 3.32.0
       '@smithy/types': 4.17.0
       tslib: 2.8.1
@@ -3939,10 +3965,10 @@ snapshots:
 
   '@aws-sdk/credential-provider-sso@3.973.12':
     dependencies:
-      '@aws-sdk/core': 3.977.7
+      '@aws-sdk/core': 3.977.8
       '@aws-sdk/nested-clients': 3.997.42
       '@aws-sdk/token-providers': 3.1108.0
-      '@aws-sdk/types': 3.974.3
+      '@aws-sdk/types': 3.974.4
       '@smithy/core': 3.32.0
       '@smithy/types': 4.17.0
       tslib: 2.8.1
@@ -3959,9 +3985,9 @@ snapshots:
 
   '@aws-sdk/credential-provider-web-identity@3.972.74':
     dependencies:
-      '@aws-sdk/core': 3.977.7
+      '@aws-sdk/core': 3.977.8
       '@aws-sdk/nested-clients': 3.997.42
-      '@aws-sdk/types': 3.974.3
+      '@aws-sdk/types': 3.974.4
       '@smithy/core': 3.32.0
       '@smithy/types': 4.17.0
       tslib: 2.8.1
@@ -4028,9 +4054,9 @@ snapshots:
 
   '@aws-sdk/nested-clients@3.997.42':
     dependencies:
-      '@aws-sdk/core': 3.977.7
+      '@aws-sdk/core': 3.977.8
       '@aws-sdk/signature-v4-multi-region': 3.996.44
-      '@aws-sdk/types': 3.974.3
+      '@aws-sdk/types': 3.974.4
       '@smithy/core': 3.32.0
       '@smithy/fetch-http-handler': 5.7.0
       '@smithy/node-http-handler': 4.10.0
@@ -4073,9 +4099,9 @@ snapshots:
 
   '@aws-sdk/token-providers@3.1108.0':
     dependencies:
-      '@aws-sdk/core': 3.977.7
+      '@aws-sdk/core': 3.977.8
       '@aws-sdk/nested-clients': 3.997.42
-      '@aws-sdk/types': 3.974.3
+      '@aws-sdk/types': 3.974.4
       '@smithy/core': 3.32.0
       '@smithy/types': 4.17.0
       tslib: 2.8.1
@@ -4725,6 +4751,13 @@ snapshots:
 
   '@smithy/is-array-buffer@2.2.0':
     dependencies:
+      tslib: 2.8.1
+
+  '@smithy/middleware-compression@4.6.0':
+    dependencies:
+      '@smithy/core': 3.32.0
+      '@smithy/types': 4.17.0
+      fflate: 0.8.1
       tslib: 2.8.1
 
   '@smithy/node-http-handler@4.10.0':
@@ -5511,6 +5544,8 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.5):
     optionalDependencies:
       picomatch: 4.0.5
+
+  fflate@0.8.1: {}
 
   figures@2.0.0:
     dependencies:

--- a/src/sdk/router/resolve-sim-sdk-command-router.ts
+++ b/src/sdk/router/resolve-sim-sdk-command-router.ts
@@ -46,6 +46,10 @@ const scopedRouters: ReadonlyMap<string, SimSdkScopedRouter> = new Map<
       scoped.cloudFrontKeyValueStore().sdkCommandRouter(),
   ],
   [
+    "CloudWatch",
+    (scoped): SimSdkCommandRouter => scoped.cloudWatch().sdkCommandRouter(),
+  ],
+  [
     "Cognito Identity Provider",
     (scoped): SimSdkCommandRouter =>
       scoped.cognitoIdentityProvider().sdkCommandRouter(),

--- a/src/service/aws/factory/sim-aws-self-contained-service-builder.ts
+++ b/src/service/aws/factory/sim-aws-self-contained-service-builder.ts
@@ -1,4 +1,5 @@
 import type { SimAwsAccountRegionContainer } from "../sim-aws-account-region-scope.js";
+import { SimCloudWatch } from "../../cloudwatch/index.js";
 import { SimDynamoDb as SimDynamoDatabase } from "../../dynamodb/index.js";
 import { SimSecretsManager } from "../../secretsmanager/index.js";
 import { SimSqs } from "../../sqs/index.js";
@@ -30,6 +31,17 @@ export class SimAwsSelfContainedServiceBuilder {
 
   constructor(properties: SimAwsSelfContainedServiceBuilderProperties) {
     this.accountServices = properties.accountServices;
+  }
+
+  /**
+   * Create simulated CloudWatch metrics for an Account Region scope.
+   *
+   * Metrics are Region-scoped on real AWS: a metric published in one Region is
+   * invisible from another, and there is no ARN by which to reach one across
+   * the boundary.
+   */
+  createCloudWatch(scope: SimAwsAccountRegionContainer): SimCloudWatch {
+    return new SimCloudWatch(this.scoped(scope));
   }
 
   /** Create simulated DynamoDB for an Account Region scope. */

--- a/src/service/aws/factory/sim-aws-service-factory.ts
+++ b/src/service/aws/factory/sim-aws-service-factory.ts
@@ -11,6 +11,7 @@ import type { SimCloudFormation } from "../../cloudformation/index.js";
 import type { SimCognitoIdentityProvider } from "../../cognito/index.js";
 import { SimCloudFrontRegistry } from "../../cloudfront/registry/sim-cloud-front-registry.js";
 import type { SimCloudFront } from "../../cloudfront/sim-cloudfront.js";
+import type { SimCloudWatch } from "../../cloudwatch/index.js";
 import type { SimDynamoDb as SimDynamoDatabase } from "../../dynamodb/index.js";
 import type { SimEcr } from "../../ecr/index.js";
 import type { SimEcs } from "../../ecs/index.js";
@@ -180,6 +181,11 @@ export class SimAwsServiceFactory {
     scope: SimAwsAccountRegionContainer,
   ): SimCognitoIdentityProvider {
     return this.accountRegionServices.createCognitoIdentityProvider(scope);
+  }
+
+  /** Create simulated CloudWatch metrics for an Account Region scope. */
+  createCloudWatch(scope: SimAwsAccountRegionContainer): SimCloudWatch {
+    return this.selfContainedServices.createCloudWatch(scope);
   }
 
   /** Create simulated DynamoDB for an Account Region scope. */

--- a/src/service/aws/sim-aws-account-region-scope.ts
+++ b/src/service/aws/sim-aws-account-region-scope.ts
@@ -7,6 +7,7 @@ import type { SimS3 } from "../s3/sim-s3.js";
 import type { SimScheduler } from "../scheduler/index.js";
 import type { SimCloudFront } from "../cloudfront/sim-cloudfront.js";
 import type { SimCloudFrontKeyValueStoreApi } from "../cloudfront/sim-cloudfront-key-value-store.js";
+import type { SimCloudWatch } from "../cloudwatch/index.js";
 import type {
   SimDynamoDb as SimDynamoDatabase,
   SimDynamoDbStreams,
@@ -103,6 +104,13 @@ export class SimAwsAccountRegionContainer {
    */
   cloudFrontKeyValueStore(): SimCloudFrontKeyValueStoreApi {
     return this.cloudFront().keyValueStoreApi();
+  }
+
+  /** Get simulated CloudWatch metrics for this account and region. */
+  cloudWatch(): SimCloudWatch {
+    return this.memo.getOrCreate("cloudWatch", () =>
+      this.factory.createCloudWatch(this),
+    );
   }
 
   /** Get simulated Cognito user pools for this account and region. */

--- a/src/service/aws/sim-aws-service-accessors.ts
+++ b/src/service/aws/sim-aws-service-accessors.ts
@@ -4,6 +4,7 @@ import type { SimApiGatewayV2 } from "../apigatewayv2/index.js";
 import type { SimCloudFormation } from "../cloudformation/index.js";
 import type { SimCloudFront } from "../cloudfront/sim-cloudfront.js";
 import type { SimCloudFrontKeyValueStoreApi } from "../cloudfront/sim-cloudfront-key-value-store.js";
+import type { SimCloudWatch } from "../cloudwatch/index.js";
 import type { SimCognitoIdentityProvider } from "../cognito/index.js";
 import type {
   SimDynamoDb as SimDynamoDatabase,
@@ -66,6 +67,11 @@ export abstract class SimAwsServiceAccessors {
    */
   cloudFrontKeyValueStore(): SimCloudFrontKeyValueStoreApi {
     return this.defaultAccountRegionScope().cloudFrontKeyValueStore();
+  }
+
+  /** Get simulated CloudWatch metrics in the default Account Region scope. */
+  cloudWatch(): SimCloudWatch {
+    return this.defaultAccountRegionScope().cloudWatch();
   }
 
   /** Get simulated Cognito user pools in the default Account Region scope. */

--- a/src/service/cloudwatch/README.md
+++ b/src/service/cloudwatch/README.md
@@ -1,0 +1,73 @@
+# Simulated CloudWatch metrics implementation
+
+This directory contains the simulated CloudWatch metrics implementation: custom metrics, the
+datapoints published to them, and the statistics read back over periods.
+
+The guiding decision is that a metric's identity is its namespace, its name and its exact dimension
+set together. Real CloudWatch does not roll a custom metric up across dimensions, and following that
+is what makes a test here worth writing: a query naming no dimensions reaches the metric published
+with none, not the total of every channel, which is exactly the mistake teams make on a dashboard.
+
+Alarms are not here. They are follow-on work, and they will need something this service does not
+have yet: a schedule on the simulation's clock.
+
+## Entry points
+
+- `sim-cloudwatch.ts` is the main in-memory service object for one account/region scope.
+- `index.ts` exports the public CloudWatch simulator API for `@kensio/yulin/cloudwatch`.
+
+A `SimCloudWatch` owns a `SimCloudWatchMetricStore` holding its metrics. The simulator is scoped to
+an account and region because real metrics are: a metric published in one region is invisible from
+another, and there is no ARN by which to reach one across the boundary.
+
+`SimCloudWatchCommands` holds the wiring, as `SimLogsCommands` does for CloudWatch Logs, so the
+facade can stay one method per SDK Command.
+
+## The datapoint model
+
+Everything under `metric/` turns on one decision in `sim-cloudwatch-datapoint.ts`: a stored
+datapoint is a count, a total and the two extremes, never a list of values.
+
+That is not a shortcut. A `StatisticValues` datum summarises many observations and never carries the
+values behind them, so there is nothing to store individually even if we wanted to. The three input
+forms, `Value`, `StatisticValues` and `Values`/`Counts`, all reduce to the same shape in
+`command/data/sim-cloudwatch-metric-datum.ts`, and nothing downstream has to know which one was
+used.
+
+It also settles what cannot be answered. Percentiles need the individual values, so real CloudWatch
+cannot report one for a metric published as a statistic set either. Rather than answer for some
+metrics and not others, `ExtendedStatistics` is refused.
+
+## Periods
+
+`sim-cloudwatch-period.ts` floors a timestamp to a multiple of the period measured from the epoch,
+rather than from the request's start time, so the same observation lands in the same bucket whatever
+window is asked for. That matches real CloudWatch for every period dividing an hour, which is every
+period a test is likely to ask for.
+
+A window includes its start and excludes its end, which is how real CloudWatch reads the two.
+
+## Authorization
+
+`command/authorize/sim-cloudwatch-authorizer.ts` authorizes every action against `*`, because
+CloudWatch metrics have no ARN. This is the one service here where a policy naming a resource is
+always wrong, and the authorizer is deliberately shaped so that it cannot accidentally start
+accepting one.
+
+`PutMetricData` additionally supplies the namespace to IAM as `cloudwatch:namespace`, which is the
+only way a policy can narrow publishing, and the way AWS's own documented policies do it.
+
+## Refusing rather than ignoring
+
+Several inputs real CloudWatch accepts are refused here: metric math expressions, extended
+statistics, high-resolution storage, `MaxDatapoints`, and cross-account listing. Each throws
+`SimCloudWatchInvalidParameterValueException` with a message saying it is not simulated, which
+follows the same call simulated SSM makes for its unsimulated `PutParameter` options.
+
+The reason is the same each time. A dropped `MaxDatapoints` would hand back values at a resolution
+real AWS would have widened, and `SUM(errors)/SUM(calls)` quietly answered as `SUM(errors)` would
+make a test pass on a number nobody asked for.
+
+`SimCloudWatchInvalidParameterValueException` doing double duty, for both real refusals and
+unsimulated input, is deliberate: CloudWatch has no `UnsupportedOperationException` of its own, and
+inventing an error name the SDK has never seen would be a worse divergence than reusing this one.

--- a/src/service/cloudwatch/README.md
+++ b/src/service/cloudwatch/README.md
@@ -38,6 +38,20 @@ It also settles what cannot be answered. Percentiles need the individual values,
 cannot report one for a metric published as a statistic set either. Rather than answer for some
 metrics and not others, `ExtendedStatistics` is refused.
 
+## Names are checked loosely on purpose
+
+`sim-cloudwatch-name.ts` accepts any printable ASCII with at least one non-whitespace character,
+because that is what real CloudWatch documents for a namespace, a metric name and both halves of a
+dimension. A tighter whitelist is tempting and wrong: it refuses names an account accepts, and a
+simulator that fails a request AWS would have taken is worse than one that takes a request AWS would
+have failed. The narrow rules that do exist are per field, so the leading-colon refusal applies to a
+namespace and a dimension name and not to a dimension value.
+
+The same reasoning sets the value range at real CloudWatch's own -2^360 to 2^360. Enforcing it at
+the edge is also what makes a stored total safe: the widest batch accepted here is a thousand data
+of a hundred and fifty values, so nothing summed from values inside that range can overflow a
+double, and no aggregate downstream has to defend against one.
+
 ## Periods
 
 `sim-cloudwatch-period.ts` floors a timestamp to a multiple of the period measured from the epoch,

--- a/src/service/cloudwatch/command/authorize/sim-cloudwatch-authorizer.ts
+++ b/src/service/cloudwatch/command/authorize/sim-cloudwatch-authorizer.ts
@@ -1,0 +1,80 @@
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimAwsResolvedCaller } from "../../../aws/caller/sim-aws-caller-resolver.js";
+import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+import { simCloudWatchNamespaceConditionKey } from "../sim-cloudwatch-request-options.js";
+
+/**
+ * The resource every CloudWatch metric action authorizes against.
+ *
+ * Metrics have no ARN on real AWS. There is nothing for a policy to name, so
+ * every one of these actions is granted on `*` and narrowed, if at all, by
+ * condition rather than by resource.
+ */
+const metricResource = "*";
+
+interface SimCloudWatchAuthorizerProperties {
+  readonly iam: SimIamInterServiceAuthZ;
+}
+
+/**
+ * Applies simulated IAM authorization to CloudWatch metric requests.
+ *
+ * A policy written against a metric ARN is a policy that reaches nothing, here
+ * and in an account: teams reaching for one find out at this boundary rather
+ * than after a deployment.
+ */
+export class SimCloudWatchAuthorizer {
+  readonly #iam: SimIamInterServiceAuthZ;
+
+  constructor(properties: SimCloudWatchAuthorizerProperties) {
+    this.#iam = properties.iam;
+  }
+
+  /**
+   * Ensure the caller may perform an action on this scope's metrics.
+   */
+  authorize(action: string, caller?: SimAwsCaller): SimAwsResolvedCaller {
+    return this.decide(action, caller, undefined);
+  }
+
+  /**
+   * Ensure the caller may write into a namespace.
+   *
+   * The namespace is supplied to IAM as `cloudwatch:namespace`, which is the
+   * condition key AWS's own documented publishing policies are written with.
+   */
+  authorizeNamespace(
+    action: string,
+    namespace: string,
+    caller?: SimAwsCaller,
+  ): SimAwsResolvedCaller {
+    return this.decide(action, caller, namespace);
+  }
+
+  private decide(
+    action: string,
+    caller: SimAwsCaller | undefined,
+    namespace: string | undefined,
+  ): SimAwsResolvedCaller {
+    const decision = this.#iam.authorize({
+      action,
+      resource: metricResource,
+      caller,
+      conditionContext:
+        namespace === undefined
+          ? undefined
+          : { [simCloudWatchNamespaceConditionKey]: namespace },
+    });
+
+    if (decision.isDenied) {
+      throw new SimIamAccessDenied({
+        principal: decision.caller.principal,
+        action,
+        resource: metricResource,
+      });
+    }
+
+    return decision.caller;
+  }
+}

--- a/src/service/cloudwatch/command/authorize/sim-cloudwatch-iam.iso.test.ts
+++ b/src/service/cloudwatch/command/authorize/sim-cloudwatch-iam.iso.test.ts
@@ -1,0 +1,151 @@
+import {
+  ListMetricsCommand,
+  PutMetricDataCommand,
+} from "@aws-sdk/client-cloudwatch";
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+import { simIamPolicyDocumentFactory } from "../../../iam/policy/sim-iam-policy-document.factory.js";
+import { simCloudWatchNamespaceConditionKey } from "../sim-cloudwatch-request-options.js";
+
+const accountIdOneOnes = "111111111111";
+
+/**
+ * A simulation with one Role, and whatever policy statement the test wants it
+ * to have.
+ */
+async function simAwsWithRole(policyStatement?: object): Promise<SimAws> {
+  const simAws = new SimAws({ defaultAccountId: accountIdOneOnes });
+
+  await simAws.iam().createRole(
+    new CreateRoleCommand({
+      RoleName: "OrdersFunctionRole",
+      AssumeRolePolicyDocument: simIamPolicyDocumentFactory.make({
+        Statement: {
+          Principal: { Service: "lambda.amazonaws.com" },
+          Action: "sts:AssumeRole",
+        },
+      }),
+    }),
+  );
+
+  if (policyStatement !== undefined) {
+    await simAws.iam().putRolePolicy(
+      new PutRolePolicyCommand({
+        RoleName: "OrdersFunctionRole",
+        PolicyName: "PublishMetrics",
+        PolicyDocument: simIamPolicyDocumentFactory.make({
+          Statement: policyStatement,
+        }),
+      }),
+    );
+  }
+
+  return simAws;
+}
+
+/** The request options that make a call arrive as the Role. */
+const asRole = {
+  caller: {
+    kind: "arn",
+    arn: `arn:aws:iam::${accountIdOneOnes}:role/OrdersFunctionRole`,
+  },
+} as const;
+
+const publishOneFailure = new PutMetricDataCommand({
+  Namespace: "Orders",
+  MetricData: [{ MetricName: "Failed", Value: 1 }],
+});
+
+describe("CloudWatch metrics IAM authorization", () => {
+  it("allows a Role granted the action on every resource", async () => {
+    // Given a Role allowed to publish metrics, which has no resource to name
+    // because CloudWatch metrics have no ARN.
+    const simAws = await simAwsWithRole({
+      Action: "cloudwatch:PutMetricData",
+      Resource: "*",
+    });
+
+    // When it publishes.
+    await simAws.cloudWatch().putMetricData(publishOneFailure, asRole);
+
+    // Then the metric was recorded.
+    assertArrayLength(simAws.cloudWatch().allMetrics(), 1);
+  });
+
+  it("denies a Role with no policy for the action", async () => {
+    // Given a Role allowed to list metrics and nothing else.
+    const simAws = await simAwsWithRole({
+      Action: "cloudwatch:ListMetrics",
+      Resource: "*",
+    });
+
+    // When it tries to publish one.
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await simAws.cloudWatch().putMetricData(publishOneFailure, asRole),
+    );
+
+    // Then it is denied, and listing still works.
+    assertInstanceOf(error, SimIamAccessDenied);
+    assertIdentical(error.action, "cloudwatch:PutMetricData");
+    await simAws.cloudWatch().listMetrics(new ListMetricsCommand({}), asRole);
+  });
+
+  it("narrows publishing to one namespace by condition", async () => {
+    // Given a Role allowed to publish only into the Orders namespace, which is
+    // the only way a policy can scope this action.
+    const simAws = await simAwsWithRole({
+      Action: "cloudwatch:PutMetricData",
+      Resource: "*",
+      Condition: {
+        StringEquals: { [simCloudWatchNamespaceConditionKey]: "Orders" },
+      },
+    });
+
+    // When it publishes into that namespace, and then into another.
+    await simAws.cloudWatch().putMetricData(publishOneFailure, asRole);
+
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await simAws.cloudWatch().putMetricData(
+          new PutMetricDataCommand({
+            Namespace: "Billing",
+            MetricData: [{ MetricName: "Retried", Value: 1 }],
+          }),
+          asRole,
+        ),
+    );
+
+    // Then the first was recorded and the second denied.
+    assertArrayLength(simAws.cloudWatch().allMetrics(), 1);
+    assertInstanceOf(error, SimIamAccessDenied);
+  });
+
+  it("reaches nothing with a policy written against a metric ARN", async () => {
+    // Given a Role whose policy names a resource, as a policy for most other
+    // services would.
+    const simAws = await simAwsWithRole({
+      Action: "cloudwatch:PutMetricData",
+      Resource: `arn:aws:cloudwatch:us-east-1:${accountIdOneOnes}:metric/Orders/Failed`,
+    });
+
+    // When it publishes.
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await simAws.cloudWatch().putMetricData(publishOneFailure, asRole),
+    );
+
+    // Then it is denied, as it would be in an account: metrics have no ARN, so
+    // there is nothing for such a statement to match.
+    assertInstanceOf(error, SimIamAccessDenied);
+  });
+});

--- a/src/service/cloudwatch/command/data/data.command.ts
+++ b/src/service/cloudwatch/command/data/data.command.ts
@@ -1,0 +1,46 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type { SimCloudWatchDimensionInput } from "../../metric/sim-cloudwatch-dimension.js";
+
+/**
+ * The summary of many observations one metric datum may carry instead of a
+ * single value.
+ */
+export interface SimCloudWatchStatisticSetInput {
+  readonly SampleCount?: number | undefined;
+  readonly Sum?: number | undefined;
+  readonly Minimum?: number | undefined;
+  readonly Maximum?: number | undefined;
+}
+
+/**
+ * One metric's worth of data in a PutMetricData request.
+ */
+export interface SimCloudWatchMetricDatumInput {
+  readonly MetricName?: string | undefined;
+  readonly Dimensions?: readonly SimCloudWatchDimensionInput[] | undefined;
+  readonly Timestamp?: Date | undefined;
+  readonly Value?: number | undefined;
+  readonly StatisticValues?: SimCloudWatchStatisticSetInput | undefined;
+  readonly Values?: readonly number[] | undefined;
+  readonly Counts?: readonly number[] | undefined;
+  readonly Unit?: string | undefined;
+  readonly StorageResolution?: number | undefined;
+}
+
+/**
+ * Minimal structural sim CloudWatch PutMetricData command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/cloudwatch/command/PutMetricDataCommand/
+ */
+export interface SimPutMetricDataCommand {
+  readonly input: SimPutMetricDataCommandInput;
+}
+
+export interface SimPutMetricDataCommandInput {
+  readonly Namespace?: string | undefined;
+  readonly MetricData?: readonly SimCloudWatchMetricDatumInput[] | undefined;
+}
+
+export interface SimPutMetricDataCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/cloudwatch/command/data/sim-cloudwatch-metric-datum.ts
+++ b/src/service/cloudwatch/command/data/sim-cloudwatch-metric-datum.ts
@@ -4,13 +4,14 @@ import {
   SimCloudWatchMissingRequiredParameterException,
 } from "../../error/sim-cloudwatch.error.js";
 import type { SimCloudWatchDatapoint } from "../../metric/sim-cloudwatch-datapoint.js";
+import { simCloudWatchUnitOrUndefined } from "../../metric/sim-cloudwatch-unit.js";
 import type { SimCloudWatchMetricDatumInput } from "./data.command.js";
 import {
   readSimCloudWatchStatisticValues,
   readSimCloudWatchValue,
-  readSimCloudWatchValues,
   type SimCloudWatchObservation,
 } from "./sim-cloudwatch-observation.js";
+import { readSimCloudWatchValues } from "./sim-cloudwatch-weighted-values.js";
 
 /**
  * The storage resolution of a standard metric, in seconds. The other value
@@ -34,7 +35,7 @@ export function readSimCloudWatchDatapoint(
   return {
     ...readObservation(datum),
     timestamp: (datum.Timestamp ?? defaultTimestamp).getTime(),
-    unit: datum.Unit,
+    unit: simCloudWatchUnitOrUndefined("Unit", datum.Unit),
   };
 }
 
@@ -45,6 +46,15 @@ export function readSimCloudWatchDatapoint(
 function readObservation(
   datum: SimCloudWatchMetricDatumInput,
 ): SimCloudWatchObservation {
+  // Counts says how often each of Values occurred, so on its own it describes
+  // nothing. Real CloudWatch refuses the pair apart, and dropping it here
+  // would silently discard half of what the caller measured.
+  if (datum.Counts !== undefined && datum.Values === undefined) {
+    throw new SimCloudWatchInvalidParameterCombinationException(
+      "The parameter Counts may only be given with Values.",
+    );
+  }
+
   const forms = [
     datum.Value === undefined
       ? undefined

--- a/src/service/cloudwatch/command/data/sim-cloudwatch-metric-datum.ts
+++ b/src/service/cloudwatch/command/data/sim-cloudwatch-metric-datum.ts
@@ -1,0 +1,92 @@
+import {
+  SimCloudWatchInvalidParameterCombinationException,
+  SimCloudWatchInvalidParameterValueException,
+  SimCloudWatchMissingRequiredParameterException,
+} from "../../error/sim-cloudwatch.error.js";
+import type { SimCloudWatchDatapoint } from "../../metric/sim-cloudwatch-datapoint.js";
+import type { SimCloudWatchMetricDatumInput } from "./data.command.js";
+import {
+  readSimCloudWatchStatisticValues,
+  readSimCloudWatchValue,
+  readSimCloudWatchValues,
+  type SimCloudWatchObservation,
+} from "./sim-cloudwatch-observation.js";
+
+/**
+ * The storage resolution of a standard metric, in seconds. The other value
+ * real CloudWatch accepts, one second, makes a high-resolution metric.
+ */
+const standardStorageResolution = 60;
+
+/**
+ * Read the observation one metric datum carries.
+ *
+ * A datum states its values in one of three ways and every one of them reduces
+ * to the same count, total and extremes, so they are read into one shape here
+ * and the rest of the service never has to know which form was used.
+ */
+export function readSimCloudWatchDatapoint(
+  datum: SimCloudWatchMetricDatumInput,
+  defaultTimestamp: Date,
+): SimCloudWatchDatapoint {
+  refuseHighResolution(datum.StorageResolution);
+
+  return {
+    ...readObservation(datum),
+    timestamp: (datum.Timestamp ?? defaultTimestamp).getTime(),
+    unit: datum.Unit,
+  };
+}
+
+/**
+ * Read whichever of the three forms the datum used, refusing a datum using
+ * none of them or more than one.
+ */
+function readObservation(
+  datum: SimCloudWatchMetricDatumInput,
+): SimCloudWatchObservation {
+  const forms = [
+    datum.Value === undefined
+      ? undefined
+      : (): SimCloudWatchObservation => readSimCloudWatchValue(datum.Value),
+    datum.StatisticValues === undefined
+      ? undefined
+      : (): SimCloudWatchObservation =>
+          readSimCloudWatchStatisticValues(datum.StatisticValues),
+    datum.Values === undefined
+      ? undefined
+      : (): SimCloudWatchObservation =>
+          readSimCloudWatchValues(datum.Values, datum.Counts),
+  ].filter((form) => form !== undefined);
+
+  const only = forms.at(0);
+
+  if (only === undefined) {
+    throw new SimCloudWatchMissingRequiredParameterException(
+      "Each metric datum must carry Value, StatisticValues or Values.",
+    );
+  }
+
+  if (forms.length > 1) {
+    throw new SimCloudWatchInvalidParameterCombinationException(
+      "A metric datum must carry only one of Value, StatisticValues and " +
+        "Values.",
+    );
+  }
+
+  return only();
+}
+
+function refuseHighResolution(storageResolution: number | undefined): void {
+  if (
+    storageResolution !== undefined &&
+    storageResolution !== standardStorageResolution
+  ) {
+    throw new SimCloudWatchInvalidParameterValueException(
+      `StorageResolution ${storageResolution} is not simulated: only ` +
+        `standard ${standardStorageResolution} second resolution is, so a ` +
+        `high-resolution metric would be stored and queried here at a ` +
+        `resolution it does not have on real AWS.`,
+    );
+  }
+}

--- a/src/service/cloudwatch/command/data/sim-cloudwatch-metric-value.ts
+++ b/src/service/cloudwatch/command/data/sim-cloudwatch-metric-value.ts
@@ -1,0 +1,95 @@
+import {
+  SimCloudWatchInvalidParameterCombinationException,
+  SimCloudWatchInvalidParameterValueException,
+  SimCloudWatchMissingRequiredParameterException,
+} from "../../error/sim-cloudwatch.error.js";
+
+/**
+ * The largest magnitude real CloudWatch stores. Values outside it are refused,
+ * as are NaN and the infinities.
+ *
+ * Enforcing it at the edge is what keeps a stored total finite: the widest
+ * batch this simulation accepts is a thousand data of a hundred and fifty
+ * values each, so nothing summed from values inside this range can reach the
+ * top of a double, and no aggregate downstream has to defend against one.
+ */
+const maximumMagnitude = 2 ** 360;
+
+/**
+ * Read a number a metric may be measured in.
+ */
+export function requiredSimCloudWatchMetricValue(
+  field: string,
+  value: number | undefined,
+): number {
+  if (value === undefined) {
+    throw new SimCloudWatchMissingRequiredParameterException(
+      `The parameter ${field} must be present.`,
+    );
+  }
+
+  if (!Number.isFinite(value)) {
+    throw new SimCloudWatchInvalidParameterValueException(
+      `The parameter ${field} must be a number, and NaN and the infinities ` +
+        `are not supported.`,
+    );
+  }
+
+  if (Math.abs(value) > maximumMagnitude) {
+    throw new SimCloudWatchInvalidParameterValueException(
+      `The parameter ${field} must be within the range CloudWatch stores, ` +
+        `which is -2^360 to 2^360.`,
+    );
+  }
+
+  return value;
+}
+
+/**
+ * Read a number of times a value was observed, which cannot be none.
+ */
+export function requiredSimCloudWatchCount(
+  field: string,
+  value: number,
+): number {
+  if (requiredSimCloudWatchMetricValue(field, value) <= 0) {
+    throw new SimCloudWatchInvalidParameterValueException(
+      `The parameter ${field} must be greater than zero.`,
+    );
+  }
+
+  return value;
+}
+
+/**
+ * How many unique values one datum may list beside its counts.
+ */
+const maximumValues = 150;
+
+/**
+ * Refuse a Values array, and the Counts beside it, that real CloudWatch would
+ * refuse.
+ */
+export function refuseSimCloudWatchValuesShape(
+  values: readonly number[],
+  counts: readonly number[] | undefined,
+): void {
+  if (values.length === 0) {
+    throw new SimCloudWatchInvalidParameterValueException(
+      "The parameter Values must not be empty.",
+    );
+  }
+
+  if (values.length > maximumValues) {
+    throw new SimCloudWatchInvalidParameterValueException(
+      `The parameter Values may list at most ${maximumValues} unique values, ` +
+        `and ${values.length} were given.`,
+    );
+  }
+
+  if (counts !== undefined && counts.length !== values.length) {
+    throw new SimCloudWatchInvalidParameterCombinationException(
+      "The parameters Values and Counts must have the same number of entries.",
+    );
+  }
+}

--- a/src/service/cloudwatch/command/data/sim-cloudwatch-observation.ts
+++ b/src/service/cloudwatch/command/data/sim-cloudwatch-observation.ts
@@ -1,0 +1,129 @@
+import {
+  SimCloudWatchInvalidParameterCombinationException,
+  SimCloudWatchInvalidParameterValueException,
+  SimCloudWatchMissingRequiredParameterException,
+} from "../../error/sim-cloudwatch.error.js";
+import type { SimCloudWatchDatapoint } from "../../metric/sim-cloudwatch-datapoint.js";
+import type { SimCloudWatchStatisticSetInput } from "./data.command.js";
+
+/**
+ * What a metric datum measures, before it is placed in time.
+ */
+export type SimCloudWatchObservation = Omit<
+  SimCloudWatchDatapoint,
+  "timestamp" | "unit"
+>;
+
+/**
+ * Read a datum stating one measurement.
+ */
+export function readSimCloudWatchValue(
+  value: number | undefined,
+): SimCloudWatchObservation {
+  const measured = finiteNumber("Value", value);
+
+  return {
+    sampleCount: 1,
+    sum: measured,
+    minimum: measured,
+    maximum: measured,
+  };
+}
+
+/**
+ * Read a datum summarising measurements it does not carry.
+ */
+export function readSimCloudWatchStatisticValues(
+  statistics: SimCloudWatchStatisticSetInput | undefined,
+): SimCloudWatchObservation {
+  const observation = {
+    sampleCount: finiteNumber(
+      "StatisticValues.SampleCount",
+      statistics?.SampleCount,
+    ),
+    sum: finiteNumber("StatisticValues.Sum", statistics?.Sum),
+    minimum: finiteNumber("StatisticValues.Minimum", statistics?.Minimum),
+    maximum: finiteNumber("StatisticValues.Maximum", statistics?.Maximum),
+  };
+
+  if (observation.sampleCount <= 0) {
+    throw new SimCloudWatchInvalidParameterValueException(
+      "The parameter StatisticValues.SampleCount must be greater than zero.",
+    );
+  }
+
+  if (observation.minimum > observation.maximum) {
+    throw new SimCloudWatchInvalidParameterValueException(
+      "The parameter StatisticValues.Minimum must not be greater than " +
+        "StatisticValues.Maximum.",
+    );
+  }
+
+  return observation;
+}
+
+/**
+ * Read a datum stating measurements and how often each of them was seen.
+ *
+ * They collapse into one observation, because nothing this simulation reports
+ * could tell the individual measurements apart afterwards.
+ */
+export function readSimCloudWatchValues(
+  values: readonly number[] | undefined,
+  counts: readonly number[] | undefined,
+): SimCloudWatchObservation {
+  const measured = values ?? [];
+
+  if (measured.length === 0) {
+    throw new SimCloudWatchInvalidParameterValueException(
+      "The parameter Values must not be empty.",
+    );
+  }
+
+  if (counts !== undefined && counts.length !== measured.length) {
+    throw new SimCloudWatchInvalidParameterCombinationException(
+      "The parameters Values and Counts must have the same number of entries.",
+    );
+  }
+
+  return measured.entries().reduce<SimCloudWatchObservation>(
+    (observation, [index, value]) => {
+      const measure = finiteNumber("Values", value);
+      const count = positiveNumber("Counts", counts?.at(index) ?? 1);
+
+      return {
+        sampleCount: observation.sampleCount + count,
+        sum: observation.sum + measure * count,
+        minimum: Math.min(observation.minimum, measure),
+        maximum: Math.max(observation.maximum, measure),
+      };
+    },
+    { sampleCount: 0, sum: 0, minimum: Infinity, maximum: -Infinity },
+  );
+}
+
+function finiteNumber(field: string, value: number | undefined): number {
+  if (value === undefined) {
+    throw new SimCloudWatchMissingRequiredParameterException(
+      `The parameter ${field} must be present.`,
+    );
+  }
+
+  if (!Number.isFinite(value)) {
+    throw new SimCloudWatchInvalidParameterValueException(
+      `The parameter ${field} must be a finite number.`,
+    );
+  }
+
+  return value;
+}
+
+function positiveNumber(field: string, value: number): number {
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new SimCloudWatchInvalidParameterValueException(
+      `The parameter ${field} must be a finite number greater than zero.`,
+    );
+  }
+
+  return value;
+}

--- a/src/service/cloudwatch/command/data/sim-cloudwatch-observation.ts
+++ b/src/service/cloudwatch/command/data/sim-cloudwatch-observation.ts
@@ -1,10 +1,7 @@
-import {
-  SimCloudWatchInvalidParameterCombinationException,
-  SimCloudWatchInvalidParameterValueException,
-  SimCloudWatchMissingRequiredParameterException,
-} from "../../error/sim-cloudwatch.error.js";
+import { SimCloudWatchInvalidParameterValueException } from "../../error/sim-cloudwatch.error.js";
 import type { SimCloudWatchDatapoint } from "../../metric/sim-cloudwatch-datapoint.js";
 import type { SimCloudWatchStatisticSetInput } from "./data.command.js";
+import { requiredSimCloudWatchMetricValue } from "./sim-cloudwatch-metric-value.js";
 
 /**
  * What a metric datum measures, before it is placed in time.
@@ -20,7 +17,7 @@ export type SimCloudWatchObservation = Omit<
 export function readSimCloudWatchValue(
   value: number | undefined,
 ): SimCloudWatchObservation {
-  const measured = finiteNumber("Value", value);
+  const measured = requiredSimCloudWatchMetricValue("Value", value);
 
   return {
     sampleCount: 1,
@@ -37,13 +34,22 @@ export function readSimCloudWatchStatisticValues(
   statistics: SimCloudWatchStatisticSetInput | undefined,
 ): SimCloudWatchObservation {
   const observation = {
-    sampleCount: finiteNumber(
+    sampleCount: requiredSimCloudWatchMetricValue(
       "StatisticValues.SampleCount",
       statistics?.SampleCount,
     ),
-    sum: finiteNumber("StatisticValues.Sum", statistics?.Sum),
-    minimum: finiteNumber("StatisticValues.Minimum", statistics?.Minimum),
-    maximum: finiteNumber("StatisticValues.Maximum", statistics?.Maximum),
+    sum: requiredSimCloudWatchMetricValue(
+      "StatisticValues.Sum",
+      statistics?.Sum,
+    ),
+    minimum: requiredSimCloudWatchMetricValue(
+      "StatisticValues.Minimum",
+      statistics?.Minimum,
+    ),
+    maximum: requiredSimCloudWatchMetricValue(
+      "StatisticValues.Maximum",
+      statistics?.Maximum,
+    ),
   };
 
   if (observation.sampleCount <= 0) {
@@ -60,70 +66,4 @@ export function readSimCloudWatchStatisticValues(
   }
 
   return observation;
-}
-
-/**
- * Read a datum stating measurements and how often each of them was seen.
- *
- * They collapse into one observation, because nothing this simulation reports
- * could tell the individual measurements apart afterwards.
- */
-export function readSimCloudWatchValues(
-  values: readonly number[] | undefined,
-  counts: readonly number[] | undefined,
-): SimCloudWatchObservation {
-  const measured = values ?? [];
-
-  if (measured.length === 0) {
-    throw new SimCloudWatchInvalidParameterValueException(
-      "The parameter Values must not be empty.",
-    );
-  }
-
-  if (counts !== undefined && counts.length !== measured.length) {
-    throw new SimCloudWatchInvalidParameterCombinationException(
-      "The parameters Values and Counts must have the same number of entries.",
-    );
-  }
-
-  return measured.entries().reduce<SimCloudWatchObservation>(
-    (observation, [index, value]) => {
-      const measure = finiteNumber("Values", value);
-      const count = positiveNumber("Counts", counts?.at(index) ?? 1);
-
-      return {
-        sampleCount: observation.sampleCount + count,
-        sum: observation.sum + measure * count,
-        minimum: Math.min(observation.minimum, measure),
-        maximum: Math.max(observation.maximum, measure),
-      };
-    },
-    { sampleCount: 0, sum: 0, minimum: Infinity, maximum: -Infinity },
-  );
-}
-
-function finiteNumber(field: string, value: number | undefined): number {
-  if (value === undefined) {
-    throw new SimCloudWatchMissingRequiredParameterException(
-      `The parameter ${field} must be present.`,
-    );
-  }
-
-  if (!Number.isFinite(value)) {
-    throw new SimCloudWatchInvalidParameterValueException(
-      `The parameter ${field} must be a finite number.`,
-    );
-  }
-
-  return value;
-}
-
-function positiveNumber(field: string, value: number): number {
-  if (!Number.isFinite(value) || value <= 0) {
-    throw new SimCloudWatchInvalidParameterValueException(
-      `The parameter ${field} must be a finite number greater than zero.`,
-    );
-  }
-
-  return value;
 }

--- a/src/service/cloudwatch/command/data/sim-cloudwatch-put-metric-data.ts
+++ b/src/service/cloudwatch/command/data/sim-cloudwatch-put-metric-data.ts
@@ -1,0 +1,108 @@
+import type { SimClock } from "../../../../util/clock/sim-clock.js";
+import {
+  SimCloudWatchInvalidParameterValueException,
+  SimCloudWatchMissingRequiredParameterException,
+} from "../../error/sim-cloudwatch.error.js";
+import { requiredSimCloudWatchDimensions } from "../../metric/sim-cloudwatch-dimension.js";
+import type { SimCloudWatchMetricStore } from "../../metric/sim-cloudwatch-metric-store.js";
+import { requiredSimCloudWatchName } from "../../metric/sim-cloudwatch-name.js";
+import { requiredSimCloudWatchWritableNamespace } from "../../metric/sim-cloudwatch-namespace.js";
+import type { SimCloudWatchAuthorizer } from "../authorize/sim-cloudwatch-authorizer.js";
+import type { SimCloudWatchRequestOptions } from "../sim-cloudwatch-request-options.js";
+import type {
+  SimPutMetricDataCommand,
+  SimPutMetricDataCommandOutput,
+} from "./data.command.js";
+import { readSimCloudWatchDatapoint } from "./sim-cloudwatch-metric-datum.js";
+
+const putMetricDataAction = "cloudwatch:PutMetricData";
+
+/**
+ * How many metric data entries real CloudWatch takes in one request.
+ */
+const maximumMetricData = 1000;
+
+interface SimCloudWatchPutMetricDataProperties {
+  readonly metrics: SimCloudWatchMetricStore;
+  readonly authorizer: SimCloudWatchAuthorizer;
+  readonly clock: SimClock;
+}
+
+/**
+ * The command that records custom metric data.
+ *
+ * A datum carrying no timestamp is stamped from the simulation's clock rather
+ * than the host's, so a test with a frozen or advanced clock gets timestamps it
+ * can assert on exactly, and one that moves time on gets datapoints in the
+ * period it moved to.
+ */
+export class SimCloudWatchPutMetricData {
+  readonly #metrics: SimCloudWatchMetricStore;
+  readonly #authorizer: SimCloudWatchAuthorizer;
+  readonly #clock: SimClock;
+
+  constructor(properties: SimCloudWatchPutMetricDataProperties) {
+    this.#metrics = properties.metrics;
+    this.#authorizer = properties.authorizer;
+    this.#clock = properties.clock;
+  }
+
+  /**
+   * Record every datum in a request against the metric it names.
+   */
+  handle(
+    command: SimPutMetricDataCommand,
+    options?: SimCloudWatchRequestOptions,
+  ): SimPutMetricDataCommandOutput {
+    // The namespace is read first because authorization is conditioned on it,
+    // and authorization comes before the rest of the input is read, because
+    // real IAM decides a request before the service handles it.
+    const namespace = requiredSimCloudWatchWritableNamespace(
+      command.input.Namespace,
+    );
+
+    this.#authorizer.authorizeNamespace(
+      putMetricDataAction,
+      namespace,
+      options?.caller,
+    );
+
+    const data = requiredMetricData(command.input.MetricData);
+    const now = this.#clock.now();
+
+    // Every datum is read before any of them is stored, so a request holding
+    // one the simulator refuses records none of the others. Real CloudWatch
+    // validates the whole request the same way.
+    const recordings = data.map((datum) => ({
+      identity: {
+        namespace,
+        metricName: requiredSimCloudWatchName("MetricName", datum.MetricName),
+        dimensions: requiredSimCloudWatchDimensions(datum.Dimensions),
+      },
+      datapoint: readSimCloudWatchDatapoint(datum, now),
+    }));
+
+    for (const recording of recordings) {
+      this.#metrics.ensure(recording.identity).record(recording.datapoint);
+    }
+
+    return { $metadata: {} };
+  }
+}
+
+function requiredMetricData<T>(data: readonly T[] | undefined): readonly T[] {
+  if (data === undefined || data.length === 0) {
+    throw new SimCloudWatchMissingRequiredParameterException(
+      "The parameter MetricData must be present and not empty.",
+    );
+  }
+
+  if (data.length > maximumMetricData) {
+    throw new SimCloudWatchInvalidParameterValueException(
+      `The parameter MetricData must hold at most ${maximumMetricData} ` +
+        `entries, and ${data.length} were given.`,
+    );
+  }
+
+  return data;
+}

--- a/src/service/cloudwatch/command/data/sim-cloudwatch-weighted-values.ts
+++ b/src/service/cloudwatch/command/data/sim-cloudwatch-weighted-values.ts
@@ -1,0 +1,39 @@
+import {
+  refuseSimCloudWatchValuesShape,
+  requiredSimCloudWatchCount,
+  requiredSimCloudWatchMetricValue,
+} from "./sim-cloudwatch-metric-value.js";
+import type { SimCloudWatchObservation } from "./sim-cloudwatch-observation.js";
+
+/**
+ * Read a datum stating measurements and how often each of them was seen.
+ *
+ * They collapse into one observation, because nothing this simulation reports
+ * could tell the individual measurements apart afterwards.
+ */
+export function readSimCloudWatchValues(
+  values: readonly number[] | undefined,
+  counts: readonly number[] | undefined,
+): SimCloudWatchObservation {
+  const measured = values ?? [];
+
+  refuseSimCloudWatchValuesShape(measured, counts);
+
+  return measured.entries().reduce<SimCloudWatchObservation>(
+    (observation, [index, value]) => {
+      const measure = requiredSimCloudWatchMetricValue("Values", value);
+      const count = requiredSimCloudWatchCount(
+        "Counts",
+        counts?.at(index) ?? 1,
+      );
+
+      return {
+        sampleCount: observation.sampleCount + count,
+        sum: observation.sum + measure * count,
+        minimum: Math.min(observation.minimum, measure),
+        maximum: Math.max(observation.maximum, measure),
+      };
+    },
+    { sampleCount: 0, sum: 0, minimum: Infinity, maximum: -Infinity },
+  );
+}

--- a/src/service/cloudwatch/command/query/query.command.ts
+++ b/src/service/cloudwatch/command/query/query.command.ts
@@ -1,0 +1,154 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type { SimCloudWatchDimensionInput } from "../../metric/sim-cloudwatch-dimension.js";
+
+/**
+ * A dimension a listing selects on. A filter with no value matches whatever
+ * value a metric carries under that name.
+ */
+export interface SimCloudWatchDimensionFilterInput {
+  readonly Name?: string | undefined;
+  readonly Value?: string | undefined;
+}
+
+/**
+ * Minimal structural sim CloudWatch ListMetrics command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/cloudwatch/command/ListMetricsCommand/
+ */
+export interface SimListMetricsCommand {
+  readonly input: SimListMetricsCommandInput;
+}
+
+export interface SimListMetricsCommandInput {
+  readonly Namespace?: string | undefined;
+  readonly MetricName?: string | undefined;
+  readonly Dimensions?:
+    | readonly SimCloudWatchDimensionFilterInput[]
+    | undefined;
+  readonly NextToken?: string | undefined;
+  readonly RecentlyActive?: string | undefined;
+  readonly IncludeLinkedAccounts?: boolean | undefined;
+  readonly OwningAccount?: string | undefined;
+}
+
+/**
+ * What ListMetrics reports about one metric.
+ */
+export interface SimCloudWatchMetricDetail {
+  readonly Namespace: string;
+  readonly MetricName: string;
+  readonly Dimensions: readonly SimCloudWatchDimensionInput[];
+}
+
+export interface SimListMetricsCommandOutput {
+  readonly Metrics?: readonly SimCloudWatchMetricDetail[] | undefined;
+  readonly NextToken?: string | undefined;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim CloudWatch GetMetricStatistics command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/cloudwatch/command/GetMetricStatisticsCommand/
+ */
+export interface SimGetMetricStatisticsCommand {
+  readonly input: SimGetMetricStatisticsCommandInput;
+}
+
+export interface SimGetMetricStatisticsCommandInput {
+  readonly Namespace?: string | undefined;
+  readonly MetricName?: string | undefined;
+  readonly Dimensions?: readonly SimCloudWatchDimensionInput[] | undefined;
+  readonly StartTime?: Date | undefined;
+  readonly EndTime?: Date | undefined;
+  readonly Period?: number | undefined;
+  readonly Statistics?: readonly string[] | undefined;
+  readonly ExtendedStatistics?: readonly string[] | undefined;
+  readonly Unit?: string | undefined;
+}
+
+/**
+ * One period's worth of statistics, as GetMetricStatistics reports it.
+ *
+ * Only the statistics the request asked for are present, which is how real
+ * CloudWatch answers: a request for `Sum` alone gets no `Average` beside it.
+ */
+export interface SimCloudWatchDatapointDetail {
+  readonly Timestamp: Date;
+  readonly SampleCount?: number | undefined;
+  readonly Average?: number | undefined;
+  readonly Sum?: number | undefined;
+  readonly Minimum?: number | undefined;
+  readonly Maximum?: number | undefined;
+  readonly Unit?: string | undefined;
+}
+
+export interface SimGetMetricStatisticsCommandOutput {
+  readonly Label?: string | undefined;
+  readonly Datapoints?: readonly SimCloudWatchDatapointDetail[] | undefined;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * The metric one MetricStat query reads from.
+ */
+export interface SimCloudWatchMetricInput {
+  readonly Namespace?: string | undefined;
+  readonly MetricName?: string | undefined;
+  readonly Dimensions?: readonly SimCloudWatchDimensionInput[] | undefined;
+}
+
+export interface SimCloudWatchMetricStatInput {
+  readonly Metric?: SimCloudWatchMetricInput | undefined;
+  readonly Period?: number | undefined;
+  readonly Stat?: string | undefined;
+  readonly Unit?: string | undefined;
+}
+
+export interface SimCloudWatchMetricDataQueryInput {
+  readonly Id?: string | undefined;
+  readonly MetricStat?: SimCloudWatchMetricStatInput | undefined;
+  readonly Expression?: string | undefined;
+  readonly Label?: string | undefined;
+  readonly ReturnData?: boolean | undefined;
+  readonly Period?: number | undefined;
+  readonly AccountId?: string | undefined;
+}
+
+/**
+ * Minimal structural sim CloudWatch GetMetricData command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/cloudwatch/command/GetMetricDataCommand/
+ */
+export interface SimGetMetricDataCommand {
+  readonly input: SimGetMetricDataCommandInput;
+}
+
+export interface SimGetMetricDataCommandInput {
+  readonly MetricDataQueries?:
+    | readonly SimCloudWatchMetricDataQueryInput[]
+    | undefined;
+  readonly StartTime?: Date | undefined;
+  readonly EndTime?: Date | undefined;
+  readonly ScanBy?: string | undefined;
+  readonly MaxDatapoints?: number | undefined;
+  readonly NextToken?: string | undefined;
+}
+
+/**
+ * What GetMetricData reports for one query.
+ */
+export interface SimCloudWatchMetricDataResult {
+  readonly Id: string;
+  readonly Label: string;
+  readonly Timestamps: readonly Date[];
+  readonly Values: readonly number[];
+  readonly StatusCode: string;
+}
+
+export interface SimGetMetricDataCommandOutput {
+  readonly MetricDataResults?:
+    | readonly SimCloudWatchMetricDataResult[]
+    | undefined;
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/cloudwatch/command/query/sim-cloudwatch-get-metric-data.ts
+++ b/src/service/cloudwatch/command/query/sim-cloudwatch-get-metric-data.ts
@@ -1,0 +1,82 @@
+import type { SimCloudWatchMetricStore } from "../../metric/sim-cloudwatch-metric-store.js";
+import { requiredSimCloudWatchTimeRange } from "../../metric/sim-cloudwatch-time-range.js";
+import type { SimCloudWatchAuthorizer } from "../authorize/sim-cloudwatch-authorizer.js";
+import type { SimCloudWatchRequestOptions } from "../sim-cloudwatch-request-options.js";
+import type {
+  SimGetMetricDataCommand,
+  SimGetMetricDataCommandOutput,
+} from "./query.command.js";
+import { readSimCloudWatchMetricDataQuery } from "./sim-cloudwatch-metric-data-query.js";
+import {
+  refuseRepeatedSimCloudWatchQueryIds,
+  refuseUnsimulatedSimCloudWatchPaging,
+  requiredSimCloudWatchQueries,
+  simCloudWatchScansAscending,
+} from "./sim-cloudwatch-metric-data-request.js";
+import { simCloudWatchMetricDataResult } from "./sim-cloudwatch-metric-data-result.js";
+
+const getMetricDataAction = "cloudwatch:GetMetricData";
+
+interface SimCloudWatchGetMetricDataProperties {
+  readonly metrics: SimCloudWatchMetricStore;
+  readonly authorizer: SimCloudWatchAuthorizer;
+}
+
+/**
+ * The command that reads several metrics back in one request.
+ *
+ * Each query names its own metric, period and statistic, so this is the
+ * operation to reach for when a test wants two metrics compared over the same
+ * window. Metric math is not simulated, so every query here is a MetricStat.
+ */
+export class SimCloudWatchGetMetricData {
+  readonly #metrics: SimCloudWatchMetricStore;
+  readonly #authorizer: SimCloudWatchAuthorizer;
+
+  constructor(properties: SimCloudWatchGetMetricDataProperties) {
+    this.#metrics = properties.metrics;
+    this.#authorizer = properties.authorizer;
+  }
+
+  /**
+   * Answer one result per query that asked for its data back.
+   */
+  handle(
+    command: SimGetMetricDataCommand,
+    options?: SimCloudWatchRequestOptions,
+  ): SimGetMetricDataCommandOutput {
+    const input = command.input;
+
+    // Before the input is read, because real IAM decides a request before the
+    // service handles it.
+    this.#authorizer.authorize(getMetricDataAction, options?.caller);
+
+    refuseUnsimulatedSimCloudWatchPaging(input.MaxDatapoints, input.NextToken);
+
+    const queries = requiredSimCloudWatchQueries(input.MetricDataQueries).map(
+      (query) => readSimCloudWatchMetricDataQuery(query),
+    );
+
+    refuseRepeatedSimCloudWatchQueryIds(queries);
+
+    const range = requiredSimCloudWatchTimeRange(
+      input.StartTime,
+      input.EndTime,
+    );
+    const ascending = simCloudWatchScansAscending(input.ScanBy);
+
+    return {
+      $metadata: {},
+      MetricDataResults: queries
+        .filter((query) => query.returnData)
+        .map((query) =>
+          simCloudWatchMetricDataResult({
+            metrics: this.#metrics,
+            query,
+            range,
+            ascending,
+          }),
+        ),
+    };
+  }
+}

--- a/src/service/cloudwatch/command/query/sim-cloudwatch-get-metric-statistics.ts
+++ b/src/service/cloudwatch/command/query/sim-cloudwatch-get-metric-statistics.ts
@@ -1,0 +1,86 @@
+import { requiredSimCloudWatchDimensions } from "../../metric/sim-cloudwatch-dimension.js";
+import type { SimCloudWatchMetricStore } from "../../metric/sim-cloudwatch-metric-store.js";
+import { requiredSimCloudWatchName } from "../../metric/sim-cloudwatch-name.js";
+import { requiredSimCloudWatchNamespace } from "../../metric/sim-cloudwatch-namespace.js";
+import { requiredSimCloudWatchPeriod } from "../../metric/sim-cloudwatch-period.js";
+import { requiredSimCloudWatchTimeRange } from "../../metric/sim-cloudwatch-time-range.js";
+import type { SimCloudWatchAuthorizer } from "../authorize/sim-cloudwatch-authorizer.js";
+import type { SimCloudWatchRequestOptions } from "../sim-cloudwatch-request-options.js";
+import type {
+  SimGetMetricStatisticsCommand,
+  SimGetMetricStatisticsCommandOutput,
+} from "./query.command.js";
+import { requiredSimCloudWatchStatistics } from "./sim-cloudwatch-requested-statistics.js";
+import {
+  refuseTooManySimCloudWatchPeriods,
+  simCloudWatchStatisticDatapoints,
+} from "./sim-cloudwatch-statistic-datapoints.js";
+
+const getMetricStatisticsAction = "cloudwatch:GetMetricStatistics";
+
+interface SimCloudWatchGetMetricStatisticsProperties {
+  readonly metrics: SimCloudWatchMetricStore;
+  readonly authorizer: SimCloudWatchAuthorizer;
+}
+
+/**
+ * The command that reads one metric back as statistics over periods.
+ *
+ * A metric nothing has been written to is not an error: real CloudWatch answers
+ * a request for one with no datapoints rather than a failure, since a metric
+ * only exists once something publishes to it.
+ */
+export class SimCloudWatchGetMetricStatistics {
+  readonly #metrics: SimCloudWatchMetricStore;
+  readonly #authorizer: SimCloudWatchAuthorizer;
+
+  constructor(properties: SimCloudWatchGetMetricStatisticsProperties) {
+    this.#metrics = properties.metrics;
+    this.#authorizer = properties.authorizer;
+  }
+
+  /**
+   * Answer with one datapoint per period holding observations.
+   */
+  handle(
+    command: SimGetMetricStatisticsCommand,
+    options?: SimCloudWatchRequestOptions,
+  ): SimGetMetricStatisticsCommandOutput {
+    const input = command.input;
+
+    // Before the input is read, because real IAM decides a request before the
+    // service handles it: an unauthorized caller is refused whether or not
+    // what it sent would have been valid.
+    this.#authorizer.authorize(getMetricStatisticsAction, options?.caller);
+
+    const identity = {
+      namespace: requiredSimCloudWatchNamespace(input.Namespace),
+      metricName: requiredSimCloudWatchName("MetricName", input.MetricName),
+      dimensions: requiredSimCloudWatchDimensions(input.Dimensions),
+    };
+    const statistics = requiredSimCloudWatchStatistics(
+      input.Statistics,
+      input.ExtendedStatistics,
+    );
+    const range = requiredSimCloudWatchTimeRange(
+      input.StartTime,
+      input.EndTime,
+    );
+    const period = requiredSimCloudWatchPeriod(input.Period);
+
+    refuseTooManySimCloudWatchPeriods(range.endTime - range.startTime, period);
+
+    const found = this.#metrics.find(identity);
+    const selected = found?.within({ ...range, unit: input.Unit }) ?? [];
+
+    return {
+      $metadata: {},
+      Label: identity.metricName,
+      Datapoints: simCloudWatchStatisticDatapoints(
+        selected,
+        period,
+        statistics,
+      ),
+    };
+  }
+}

--- a/src/service/cloudwatch/command/query/sim-cloudwatch-get-metric-statistics.ts
+++ b/src/service/cloudwatch/command/query/sim-cloudwatch-get-metric-statistics.ts
@@ -4,6 +4,7 @@ import { requiredSimCloudWatchName } from "../../metric/sim-cloudwatch-name.js";
 import { requiredSimCloudWatchNamespace } from "../../metric/sim-cloudwatch-namespace.js";
 import { requiredSimCloudWatchPeriod } from "../../metric/sim-cloudwatch-period.js";
 import { requiredSimCloudWatchTimeRange } from "../../metric/sim-cloudwatch-time-range.js";
+import { simCloudWatchUnitOrUndefined } from "../../metric/sim-cloudwatch-unit.js";
 import type { SimCloudWatchAuthorizer } from "../authorize/sim-cloudwatch-authorizer.js";
 import type { SimCloudWatchRequestOptions } from "../sim-cloudwatch-request-options.js";
 import type {
@@ -68,10 +69,15 @@ export class SimCloudWatchGetMetricStatistics {
     );
     const period = requiredSimCloudWatchPeriod(input.Period);
 
+    // Read before the metric is looked up, so a unit CloudWatch does not have
+    // is refused whether or not anything has been published to the metric. It
+    // would otherwise be an empty answer for a request an account rejects.
+    const unit = simCloudWatchUnitOrUndefined("Unit", input.Unit);
+
     refuseTooManySimCloudWatchPeriods(range.endTime - range.startTime, period);
 
     const found = this.#metrics.find(identity);
-    const selected = found?.within({ ...range, unit: input.Unit }) ?? [];
+    const selected = found?.within({ ...range, unit }) ?? [];
 
     return {
       $metadata: {},

--- a/src/service/cloudwatch/command/query/sim-cloudwatch-list-metrics.ts
+++ b/src/service/cloudwatch/command/query/sim-cloudwatch-list-metrics.ts
@@ -1,0 +1,80 @@
+import type { SimClock } from "../../../../util/clock/sim-clock.js";
+import type { SimCloudWatchMetricStore } from "../../metric/sim-cloudwatch-metric-store.js";
+import type { SimCloudWatchAuthorizer } from "../authorize/sim-cloudwatch-authorizer.js";
+import { SimCloudWatchPage } from "../sim-cloudwatch-page.js";
+import type { SimCloudWatchRequestOptions } from "../sim-cloudwatch-request-options.js";
+import type {
+  SimListMetricsCommand,
+  SimListMetricsCommandOutput,
+} from "./query.command.js";
+import { simCloudWatchMetricFilter } from "./sim-cloudwatch-metric-filter.js";
+import {
+  isSimCloudWatchRecentlyActive,
+  refuseSimCloudWatchLinkedAccounts,
+  simCloudWatchMetricDetail,
+} from "./sim-cloudwatch-metric-listing.js";
+
+const listMetricsAction = "cloudwatch:ListMetrics";
+
+/**
+ * How many metrics real CloudWatch reports in one page of a listing.
+ */
+const metricsPerPage = 500;
+
+interface SimCloudWatchListMetricsProperties {
+  readonly metrics: SimCloudWatchMetricStore;
+  readonly authorizer: SimCloudWatchAuthorizer;
+  readonly clock: SimClock;
+}
+
+/**
+ * The command that reports which metrics exist, without their values.
+ */
+export class SimCloudWatchListMetrics {
+  readonly #metrics: SimCloudWatchMetricStore;
+  readonly #authorizer: SimCloudWatchAuthorizer;
+  readonly #clock: SimClock;
+
+  constructor(properties: SimCloudWatchListMetricsProperties) {
+    this.#metrics = properties.metrics;
+    this.#authorizer = properties.authorizer;
+    this.#clock = properties.clock;
+  }
+
+  /**
+   * List the metrics a request selects, in the order each was first written to.
+   */
+  handle(
+    command: SimListMetricsCommand,
+    options?: SimCloudWatchRequestOptions,
+  ): SimListMetricsCommandOutput {
+    const input = command.input;
+
+    // Before the input is read, because real IAM decides a request before the
+    // service handles it.
+    this.#authorizer.authorize(listMetricsAction, options?.caller);
+
+    refuseSimCloudWatchLinkedAccounts(
+      input.IncludeLinkedAccounts,
+      input.OwningAccount,
+    );
+
+    const now = this.#clock.now();
+    const selected = this.#metrics
+      .matching(simCloudWatchMetricFilter(input))
+      .filter((metric) =>
+        isSimCloudWatchRecentlyActive(metric, input.RecentlyActive, now),
+      );
+    const page = new SimCloudWatchPage({
+      listed: selected,
+      nextToken: input.NextToken,
+      pageSize: metricsPerPage,
+    });
+
+    return {
+      $metadata: {},
+      Metrics: page.items.map((metric) => simCloudWatchMetricDetail(metric)),
+      NextToken: page.nextToken,
+    };
+  }
+}

--- a/src/service/cloudwatch/command/query/sim-cloudwatch-metric-data-query.ts
+++ b/src/service/cloudwatch/command/query/sim-cloudwatch-metric-data-query.ts
@@ -1,0 +1,110 @@
+import {
+  SimCloudWatchInvalidParameterValueException,
+  SimCloudWatchMissingRequiredParameterException,
+} from "../../error/sim-cloudwatch.error.js";
+import { requiredSimCloudWatchDimensions } from "../../metric/sim-cloudwatch-dimension.js";
+import type { SimCloudWatchMetricIdentity } from "../../metric/sim-cloudwatch-metric.js";
+import { requiredSimCloudWatchName } from "../../metric/sim-cloudwatch-name.js";
+import { requiredSimCloudWatchNamespace } from "../../metric/sim-cloudwatch-namespace.js";
+import { requiredSimCloudWatchPeriod } from "../../metric/sim-cloudwatch-period.js";
+import {
+  requiredSimCloudWatchStatistic,
+  type SimCloudWatchStatistic,
+} from "../../metric/sim-cloudwatch-statistic.js";
+import type { SimCloudWatchMetricDataQueryInput } from "./query.command.js";
+
+/**
+ * What real CloudWatch accepts as a query id: a lower-case letter, then
+ * letters, digits and underscores.
+ */
+const queryIdPattern = /^[a-z][A-Za-z0-9_]*$/;
+
+/**
+ * One GetMetricData query, read into what it takes to answer it.
+ */
+export interface SimCloudWatchReadMetricDataQuery {
+  readonly id: string;
+  readonly label: string;
+  readonly identity: SimCloudWatchMetricIdentity;
+  readonly period: number;
+  readonly statistic: SimCloudWatchStatistic;
+  readonly unit: string | undefined;
+  readonly returnData: boolean;
+}
+
+/**
+ * Read one GetMetricData query.
+ *
+ * Only the MetricStat form is read. A metric math expression is refused rather
+ * than answered from the metric it happens to mention: `SUM(errors)/SUM(calls)`
+ * quietly reported as `SUM(errors)` would make a test pass on the wrong number.
+ */
+export function readSimCloudWatchMetricDataQuery(
+  query: SimCloudWatchMetricDataQueryInput,
+): SimCloudWatchReadMetricDataQuery {
+  const id = requiredQueryId(query.Id);
+
+  if (query.Expression !== undefined) {
+    throw new SimCloudWatchInvalidParameterValueException(
+      `The query ${id} carries an Expression, and metric math is not ` +
+        `simulated. Ask for the metric itself with MetricStat.`,
+    );
+  }
+
+  const metricStat = query.MetricStat;
+
+  if (metricStat === undefined) {
+    throw new SimCloudWatchMissingRequiredParameterException(
+      `The query ${id} must carry a MetricStat.`,
+    );
+  }
+
+  return {
+    id,
+    label: query.Label ?? requiredMetricName(metricStat.Metric?.MetricName),
+    identity: {
+      namespace: requiredSimCloudWatchNamespace(metricStat.Metric?.Namespace),
+      metricName: requiredMetricName(metricStat.Metric?.MetricName),
+      dimensions: requiredSimCloudWatchDimensions(
+        metricStat.Metric?.Dimensions,
+      ),
+    },
+    period: requiredSimCloudWatchPeriod(metricStat.Period),
+    statistic: requiredSimCloudWatchStatistic(
+      requiredStat(metricStat.Stat, id),
+    ),
+    unit: metricStat.Unit,
+    returnData: query.ReturnData ?? true,
+  };
+}
+
+function requiredMetricName(metricName: string | undefined): string {
+  return requiredSimCloudWatchName("MetricName", metricName);
+}
+
+function requiredStat(stat: string | undefined, id: string): string {
+  if (stat === undefined) {
+    throw new SimCloudWatchMissingRequiredParameterException(
+      `The query ${id} must carry a MetricStat.Stat.`,
+    );
+  }
+
+  return stat;
+}
+
+function requiredQueryId(id: string | undefined): string {
+  if (id === undefined) {
+    throw new SimCloudWatchMissingRequiredParameterException(
+      "Every metric data query must carry an Id.",
+    );
+  }
+
+  if (!queryIdPattern.test(id)) {
+    throw new SimCloudWatchInvalidParameterValueException(
+      `The query id ${id} must start with a lower-case letter and hold only ` +
+        `letters, digits and underscores.`,
+    );
+  }
+
+  return id;
+}

--- a/src/service/cloudwatch/command/query/sim-cloudwatch-metric-data-query.ts
+++ b/src/service/cloudwatch/command/query/sim-cloudwatch-metric-data-query.ts
@@ -11,6 +11,10 @@ import {
   requiredSimCloudWatchStatistic,
   type SimCloudWatchStatistic,
 } from "../../metric/sim-cloudwatch-statistic.js";
+import {
+  type SimCloudWatchUnit,
+  simCloudWatchUnitOrUndefined,
+} from "../../metric/sim-cloudwatch-unit.js";
 import type { SimCloudWatchMetricDataQueryInput } from "./query.command.js";
 
 /**
@@ -28,7 +32,7 @@ export interface SimCloudWatchReadMetricDataQuery {
   readonly identity: SimCloudWatchMetricIdentity;
   readonly period: number;
   readonly statistic: SimCloudWatchStatistic;
-  readonly unit: string | undefined;
+  readonly unit: SimCloudWatchUnit | undefined;
   readonly returnData: boolean;
 }
 
@@ -73,7 +77,7 @@ export function readSimCloudWatchMetricDataQuery(
     statistic: requiredSimCloudWatchStatistic(
       requiredStat(metricStat.Stat, id),
     ),
-    unit: metricStat.Unit,
+    unit: simCloudWatchUnitOrUndefined("MetricStat.Unit", metricStat.Unit),
     returnData: query.ReturnData ?? true,
   };
 }

--- a/src/service/cloudwatch/command/query/sim-cloudwatch-metric-data-request.ts
+++ b/src/service/cloudwatch/command/query/sim-cloudwatch-metric-data-request.ts
@@ -1,0 +1,94 @@
+import {
+  SimCloudWatchInvalidParameterValueException,
+  SimCloudWatchMissingRequiredParameterException,
+} from "../../error/sim-cloudwatch.error.js";
+import type { SimCloudWatchMetricDataQueryInput } from "./query.command.js";
+import type { SimCloudWatchReadMetricDataQuery } from "./sim-cloudwatch-metric-data-query.js";
+
+/**
+ * How real CloudWatch orders the values in a result when nothing says
+ * otherwise.
+ */
+const timestampDescending = "TimestampDescending";
+const timestampAscending = "TimestampAscending";
+
+/**
+ * Read the queries a request carries, refusing one that carries none.
+ */
+export function requiredSimCloudWatchQueries(
+  queries: readonly SimCloudWatchMetricDataQueryInput[] | undefined,
+): readonly SimCloudWatchMetricDataQueryInput[] {
+  if (queries === undefined || queries.length === 0) {
+    throw new SimCloudWatchMissingRequiredParameterException(
+      "The parameter MetricDataQueries must be present and not empty.",
+    );
+  }
+
+  return queries;
+}
+
+/**
+ * Refuse a request whose queries do not each have an id of their own, since a
+ * result is only findable by the id its query was given.
+ */
+export function refuseRepeatedSimCloudWatchQueryIds(
+  queries: readonly SimCloudWatchReadMetricDataQuery[],
+): void {
+  const ids = new Set(queries.map((query) => query.id));
+
+  if (ids.size !== queries.length) {
+    throw new SimCloudWatchInvalidParameterValueException(
+      "Every metric data query must carry an Id no other query in the same " +
+        "request uses.",
+    );
+  }
+}
+
+/**
+ * Whether the request asked for its values oldest first.
+ */
+export function simCloudWatchScansAscending(
+  scanBy: string | undefined,
+): boolean {
+  if (scanBy === undefined || scanBy === timestampDescending) {
+    return false;
+  }
+
+  if (scanBy === timestampAscending) {
+    return true;
+  }
+
+  throw new SimCloudWatchInvalidParameterValueException(
+    `The parameter ScanBy must be ${timestampAscending} or ` +
+      `${timestampDescending}.`,
+  );
+}
+
+/**
+ * Refuse the two ways a request asks for a resolution or a page this
+ * simulation does not produce.
+ *
+ * Real CloudWatch answers MaxDatapoints by widening the period until the
+ * result fits, so a request carrying one and getting the period it asked for
+ * back would be reading values at a resolution real AWS would not have given
+ * it. No result here is ever truncated, so no token is ever issued either.
+ */
+export function refuseUnsimulatedSimCloudWatchPaging(
+  maxDatapoints: number | undefined,
+  nextToken: string | undefined,
+): void {
+  if (maxDatapoints !== undefined) {
+    throw new SimCloudWatchInvalidParameterValueException(
+      "MaxDatapoints is not simulated: real CloudWatch answers it by " +
+        "widening the period, and every result here is returned at the " +
+        "period its query asked for.",
+    );
+  }
+
+  if (nextToken !== undefined) {
+    throw new SimCloudWatchInvalidParameterValueException(
+      "The parameter NextToken is not a token this simulation issued: " +
+        "GetMetricData answers every query in full here.",
+    );
+  }
+}

--- a/src/service/cloudwatch/command/query/sim-cloudwatch-metric-data-result.ts
+++ b/src/service/cloudwatch/command/query/sim-cloudwatch-metric-data-result.ts
@@ -1,6 +1,6 @@
-import { aggregateSimCloudWatchDatapoints } from "../../metric/sim-cloudwatch-datapoint.js";
+import type { SimCloudWatchDatapoint } from "../../metric/sim-cloudwatch-datapoint.js";
 import type { SimCloudWatchMetricStore } from "../../metric/sim-cloudwatch-metric-store.js";
-import { bucketSimCloudWatchDatapoints } from "../../metric/sim-cloudwatch-period.js";
+import { simCloudWatchPeriodAggregates } from "../../metric/sim-cloudwatch-period.js";
 import { simCloudWatchStatisticValue } from "../../metric/sim-cloudwatch-statistic.js";
 import type { SimCloudWatchTimeRange } from "../../metric/sim-cloudwatch-time-range.js";
 import type { SimCloudWatchMetricDataResult } from "./query.command.js";
@@ -54,22 +54,14 @@ export function simCloudWatchMetricDataResult(
 }
 
 function queryPeriods(
-  datapoints: Parameters<typeof bucketSimCloudWatchDatapoints>[0],
+  datapoints: readonly SimCloudWatchDatapoint[],
   query: SimCloudWatchReadMetricDataQuery,
 ): readonly SimCloudWatchQueryPeriod[] {
-  return bucketSimCloudWatchDatapoints(datapoints, query.period)
+  return simCloudWatchPeriodAggregates(datapoints, query.period)
     .entries()
-    .flatMap(([start, inPeriod]) => {
-      const aggregate = aggregateSimCloudWatchDatapoints(inPeriod);
-
-      return aggregate === undefined
-        ? []
-        : [
-            [
-              new Date(start),
-              simCloudWatchStatisticValue(aggregate, query.statistic),
-            ] as SimCloudWatchQueryPeriod,
-          ];
-    })
+    .map(([start, aggregate]): SimCloudWatchQueryPeriod => [
+      new Date(start),
+      simCloudWatchStatisticValue(aggregate, query.statistic),
+    ])
     .toArray();
 }

--- a/src/service/cloudwatch/command/query/sim-cloudwatch-metric-data-result.ts
+++ b/src/service/cloudwatch/command/query/sim-cloudwatch-metric-data-result.ts
@@ -1,0 +1,75 @@
+import { aggregateSimCloudWatchDatapoints } from "../../metric/sim-cloudwatch-datapoint.js";
+import type { SimCloudWatchMetricStore } from "../../metric/sim-cloudwatch-metric-store.js";
+import { bucketSimCloudWatchDatapoints } from "../../metric/sim-cloudwatch-period.js";
+import { simCloudWatchStatisticValue } from "../../metric/sim-cloudwatch-statistic.js";
+import type { SimCloudWatchTimeRange } from "../../metric/sim-cloudwatch-time-range.js";
+import type { SimCloudWatchMetricDataResult } from "./query.command.js";
+import type { SimCloudWatchReadMetricDataQuery } from "./sim-cloudwatch-metric-data-query.js";
+
+/**
+ * The status a result carries when the whole of its range was answered. Every
+ * result here is complete, because nothing truncates one.
+ */
+const completeStatus = "Complete";
+
+/**
+ * One period of a result: when it began and what the query's statistic makes
+ * of it.
+ */
+type SimCloudWatchQueryPeriod = readonly [Date, number];
+
+interface SimCloudWatchMetricDataResultProperties {
+  readonly metrics: SimCloudWatchMetricStore;
+  readonly query: SimCloudWatchReadMetricDataQuery;
+  readonly range: SimCloudWatchTimeRange;
+
+  /** Whether the request asked for its values oldest first. */
+  readonly ascending: boolean;
+}
+
+/**
+ * Answer one query with the values and timestamps a result reports.
+ *
+ * A metric nothing has been written to gets a result holding nothing, rather
+ * than no result at all: real CloudWatch answers every query it was given.
+ */
+export function simCloudWatchMetricDataResult(
+  properties: SimCloudWatchMetricDataResultProperties,
+): SimCloudWatchMetricDataResult {
+  const { metrics, query, range, ascending } = properties;
+  const found = metrics.find(query.identity);
+  const periods = queryPeriods(
+    found?.within({ ...range, unit: query.unit }) ?? [],
+    query,
+  );
+  const ordered = ascending ? periods : periods.toReversed();
+
+  return {
+    Id: query.id,
+    Label: query.label,
+    Timestamps: ordered.map(([timestamp]) => timestamp),
+    Values: ordered.map(([, value]) => value),
+    StatusCode: completeStatus,
+  };
+}
+
+function queryPeriods(
+  datapoints: Parameters<typeof bucketSimCloudWatchDatapoints>[0],
+  query: SimCloudWatchReadMetricDataQuery,
+): readonly SimCloudWatchQueryPeriod[] {
+  return bucketSimCloudWatchDatapoints(datapoints, query.period)
+    .entries()
+    .flatMap(([start, inPeriod]) => {
+      const aggregate = aggregateSimCloudWatchDatapoints(inPeriod);
+
+      return aggregate === undefined
+        ? []
+        : [
+            [
+              new Date(start),
+              simCloudWatchStatisticValue(aggregate, query.statistic),
+            ] as SimCloudWatchQueryPeriod,
+          ];
+    })
+    .toArray();
+}

--- a/src/service/cloudwatch/command/query/sim-cloudwatch-metric-filter.ts
+++ b/src/service/cloudwatch/command/query/sim-cloudwatch-metric-filter.ts
@@ -1,0 +1,48 @@
+import type {
+  SimCloudWatchDimensionFilter,
+  SimCloudWatchMetricFilter,
+} from "../../metric/sim-cloudwatch-metric-store.js";
+import { requiredSimCloudWatchName } from "../../metric/sim-cloudwatch-name.js";
+import { requiredSimCloudWatchNamespace } from "../../metric/sim-cloudwatch-namespace.js";
+import type {
+  SimCloudWatchDimensionFilterInput,
+  SimListMetricsCommandInput,
+} from "./query.command.js";
+
+/**
+ * Read which metrics a listing selects.
+ *
+ * Every part is optional, and an omitted one selects everything rather than
+ * nothing. The ones that are given are read as strictly as a published metric
+ * is, so a listing asking for a name real CloudWatch could not hold is refused
+ * rather than answered with nothing.
+ */
+export function simCloudWatchMetricFilter(
+  input: SimListMetricsCommandInput,
+): SimCloudWatchMetricFilter {
+  return {
+    namespace: optional(input.Namespace, requiredSimCloudWatchNamespace),
+    metricName: optional(input.MetricName, (value) =>
+      requiredSimCloudWatchName("MetricName", value),
+    ),
+    dimensions: dimensionFilters(input.Dimensions),
+  };
+}
+
+function dimensionFilters(
+  filters: readonly SimCloudWatchDimensionFilterInput[] | undefined,
+): readonly SimCloudWatchDimensionFilter[] | undefined {
+  return filters?.map((filter) => ({
+    name: requiredSimCloudWatchName("Dimension.Name", filter.Name),
+    value: optional(filter.Value, (value) =>
+      requiredSimCloudWatchName("Dimension.Value", value),
+    ),
+  }));
+}
+
+function optional(
+  value: string | undefined,
+  read: (value: string) => string,
+): string | undefined {
+  return value === undefined ? undefined : read(value);
+}

--- a/src/service/cloudwatch/command/query/sim-cloudwatch-metric-listing.ts
+++ b/src/service/cloudwatch/command/query/sim-cloudwatch-metric-listing.ts
@@ -1,0 +1,76 @@
+import { SimCloudWatchInvalidParameterValueException } from "../../error/sim-cloudwatch.error.js";
+import type { SimCloudWatchMetric } from "../../metric/sim-cloudwatch-metric.js";
+import type { SimCloudWatchMetricDetail } from "./query.command.js";
+
+/**
+ * The only window real CloudWatch's RecentlyActive filter offers, and how long
+ * it is in milliseconds.
+ */
+const recentlyActiveWindow = "PT3H";
+const recentlyActiveMilliseconds = 3 * 60 * 60 * 1000;
+
+/**
+ * What ListMetrics reports about one metric, which is its identity and none of
+ * its values.
+ */
+export function simCloudWatchMetricDetail(
+  metric: SimCloudWatchMetric,
+): SimCloudWatchMetricDetail {
+  return {
+    Namespace: metric.namespace,
+    MetricName: metric.metricName,
+    Dimensions: metric.dimensions.map((dimension) => ({
+      Name: dimension.name,
+      Value: dimension.value,
+    })),
+  };
+}
+
+/**
+ * Whether a metric was written to recently enough for the request.
+ *
+ * Recency is measured against the simulation's clock, so a test that moves time
+ * forward past the window sees a metric drop out of the listing without
+ * anything having to expire it.
+ */
+export function isSimCloudWatchRecentlyActive(
+  metric: SimCloudWatchMetric,
+  recentlyActive: string | undefined,
+  now: Date,
+): boolean {
+  if (recentlyActive === undefined) {
+    return true;
+  }
+
+  if (recentlyActive !== recentlyActiveWindow) {
+    throw new SimCloudWatchInvalidParameterValueException(
+      `The parameter RecentlyActive must be ${recentlyActiveWindow}, which ` +
+        `is the only window real CloudWatch offers.`,
+    );
+  }
+
+  const lastWrittenAt = metric.lastWrittenAt;
+
+  return (
+    lastWrittenAt !== undefined &&
+    now.getTime() - lastWrittenAt <= recentlyActiveMilliseconds
+  );
+}
+
+/**
+ * Refuse a listing reaching for metrics owned by another account.
+ */
+export function refuseSimCloudWatchLinkedAccounts(
+  includeLinkedAccounts: boolean | undefined,
+  owningAccount: string | undefined,
+): void {
+  if (includeLinkedAccounts !== true && owningAccount === undefined) {
+    return;
+  }
+
+  throw new SimCloudWatchInvalidParameterValueException(
+    "IncludeLinkedAccounts and OwningAccount are not simulated: there is no " +
+      "monitoring account here, and every listing reports the metrics of the " +
+      "account and region it was made in.",
+  );
+}

--- a/src/service/cloudwatch/command/query/sim-cloudwatch-requested-statistics.ts
+++ b/src/service/cloudwatch/command/query/sim-cloudwatch-requested-statistics.ts
@@ -1,0 +1,37 @@
+import {
+  SimCloudWatchInvalidParameterValueException,
+  SimCloudWatchMissingRequiredParameterException,
+} from "../../error/sim-cloudwatch.error.js";
+import {
+  requiredSimCloudWatchStatistic,
+  type SimCloudWatchStatistic,
+} from "../../metric/sim-cloudwatch-statistic.js";
+
+/**
+ * Read the statistics a GetMetricStatistics request asked for.
+ *
+ * Extended statistics are refused rather than dropped. They are the percentiles
+ * and trimmed means, and answering a request for `p99` with the plain values
+ * beside it would let a test assert on a number that is not the one it named.
+ */
+export function requiredSimCloudWatchStatistics(
+  statistics: readonly string[] | undefined,
+  extendedStatistics: readonly string[] | undefined,
+): readonly SimCloudWatchStatistic[] {
+  if (extendedStatistics !== undefined && extendedStatistics.length > 0) {
+    throw new SimCloudWatchInvalidParameterValueException(
+      "ExtendedStatistics is not simulated: percentiles need the individual " +
+        "values behind a period, which a StatisticValues datum never carries.",
+    );
+  }
+
+  if (statistics === undefined || statistics.length === 0) {
+    throw new SimCloudWatchMissingRequiredParameterException(
+      "The parameter Statistics must be present and not empty.",
+    );
+  }
+
+  return statistics.map((statistic) =>
+    requiredSimCloudWatchStatistic(statistic),
+  );
+}

--- a/src/service/cloudwatch/command/query/sim-cloudwatch-statistic-datapoints.ts
+++ b/src/service/cloudwatch/command/query/sim-cloudwatch-statistic-datapoints.ts
@@ -1,0 +1,82 @@
+import { SimCloudWatchInvalidParameterCombinationException } from "../../error/sim-cloudwatch.error.js";
+import {
+  aggregateSimCloudWatchDatapoints,
+  type SimCloudWatchAggregate,
+  type SimCloudWatchDatapoint,
+} from "../../metric/sim-cloudwatch-datapoint.js";
+import { bucketSimCloudWatchDatapoints } from "../../metric/sim-cloudwatch-period.js";
+import {
+  type SimCloudWatchStatistic,
+  simCloudWatchStatisticValue,
+} from "../../metric/sim-cloudwatch-statistic.js";
+import type { SimCloudWatchDatapointDetail } from "./query.command.js";
+
+/**
+ * How many datapoints real CloudWatch returns from one GetMetricStatistics.
+ */
+const maximumDatapoints = 1440;
+
+const millisecondsPerSecond = 1000;
+
+/**
+ * Report one datapoint per period holding observations, earliest first.
+ *
+ * Real CloudWatch returns datapoints in no particular order. Ordering them
+ * here is something that contract allows, and something a test reading the
+ * third period of five needs.
+ */
+export function simCloudWatchStatisticDatapoints(
+  datapoints: readonly SimCloudWatchDatapoint[],
+  period: number,
+  statistics: readonly SimCloudWatchStatistic[],
+): readonly SimCloudWatchDatapointDetail[] {
+  return bucketSimCloudWatchDatapoints(datapoints, period)
+    .entries()
+    .map(([start, inPeriod]) =>
+      detail(start, aggregateSimCloudWatchDatapoints(inPeriod), statistics),
+    )
+    .toArray();
+}
+
+/**
+ * Refuse a window and period that between them cover more periods than one
+ * response can report.
+ */
+export function refuseTooManySimCloudWatchPeriods(
+  milliseconds: number,
+  period: number,
+): void {
+  const periods = milliseconds / (period * millisecondsPerSecond);
+
+  if (periods > maximumDatapoints) {
+    throw new SimCloudWatchInvalidParameterCombinationException(
+      `The requested time range covers ${Math.ceil(periods)} periods of ` +
+        `${period} seconds, and at most ${maximumDatapoints} datapoints can ` +
+        `be returned. Ask for a shorter range or a longer period.`,
+    );
+  }
+}
+
+/**
+ * What one period reports, which is only the statistics that were asked for: a
+ * request for `Sum` alone gets no `Average` beside it, as on real CloudWatch.
+ */
+function detail(
+  start: number,
+  aggregate: SimCloudWatchAggregate | undefined,
+  statistics: readonly SimCloudWatchStatistic[],
+): SimCloudWatchDatapointDetail {
+  if (aggregate === undefined) {
+    return { Timestamp: new Date(start) };
+  }
+
+  const reported: Partial<Record<SimCloudWatchStatistic, number>> =
+    Object.fromEntries(
+      statistics.map((statistic) => [
+        statistic,
+        simCloudWatchStatisticValue(aggregate, statistic),
+      ]),
+    );
+
+  return { Timestamp: new Date(start), Unit: aggregate.unit, ...reported };
+}

--- a/src/service/cloudwatch/command/query/sim-cloudwatch-statistic-datapoints.ts
+++ b/src/service/cloudwatch/command/query/sim-cloudwatch-statistic-datapoints.ts
@@ -1,10 +1,9 @@
 import { SimCloudWatchInvalidParameterCombinationException } from "../../error/sim-cloudwatch.error.js";
-import {
-  aggregateSimCloudWatchDatapoints,
-  type SimCloudWatchAggregate,
-  type SimCloudWatchDatapoint,
+import type {
+  SimCloudWatchAggregate,
+  SimCloudWatchDatapoint,
 } from "../../metric/sim-cloudwatch-datapoint.js";
-import { bucketSimCloudWatchDatapoints } from "../../metric/sim-cloudwatch-period.js";
+import { simCloudWatchPeriodAggregates } from "../../metric/sim-cloudwatch-period.js";
 import {
   type SimCloudWatchStatistic,
   simCloudWatchStatisticValue,
@@ -30,11 +29,9 @@ export function simCloudWatchStatisticDatapoints(
   period: number,
   statistics: readonly SimCloudWatchStatistic[],
 ): readonly SimCloudWatchDatapointDetail[] {
-  return bucketSimCloudWatchDatapoints(datapoints, period)
+  return simCloudWatchPeriodAggregates(datapoints, period)
     .entries()
-    .map(([start, inPeriod]) =>
-      detail(start, aggregateSimCloudWatchDatapoints(inPeriod), statistics),
-    )
+    .map(([start, aggregate]) => detail(start, aggregate, statistics))
     .toArray();
 }
 
@@ -63,13 +60,9 @@ export function refuseTooManySimCloudWatchPeriods(
  */
 function detail(
   start: number,
-  aggregate: SimCloudWatchAggregate | undefined,
+  aggregate: SimCloudWatchAggregate,
   statistics: readonly SimCloudWatchStatistic[],
 ): SimCloudWatchDatapointDetail {
-  if (aggregate === undefined) {
-    return { Timestamp: new Date(start) };
-  }
-
   const reported: Partial<Record<SimCloudWatchStatistic, number>> =
     Object.fromEntries(
       statistics.map((statistic) => [

--- a/src/service/cloudwatch/command/sim-cloudwatch-command.types.ts
+++ b/src/service/cloudwatch/command/sim-cloudwatch-command.types.ts
@@ -1,0 +1,28 @@
+/**
+ * The sim CloudWatch Command types, gathered for the service facade.
+ */
+export type {
+  SimCloudWatchMetricDatumInput,
+  SimCloudWatchStatisticSetInput,
+  SimPutMetricDataCommand,
+  SimPutMetricDataCommandInput,
+  SimPutMetricDataCommandOutput,
+} from "./data/data.command.js";
+export type {
+  SimCloudWatchDatapointDetail,
+  SimCloudWatchDimensionFilterInput,
+  SimCloudWatchMetricDataQueryInput,
+  SimCloudWatchMetricDataResult,
+  SimCloudWatchMetricDetail,
+  SimCloudWatchMetricInput,
+  SimCloudWatchMetricStatInput,
+  SimGetMetricDataCommand,
+  SimGetMetricDataCommandInput,
+  SimGetMetricDataCommandOutput,
+  SimGetMetricStatisticsCommand,
+  SimGetMetricStatisticsCommandInput,
+  SimGetMetricStatisticsCommandOutput,
+  SimListMetricsCommand,
+  SimListMetricsCommandInput,
+  SimListMetricsCommandOutput,
+} from "./query/query.command.js";

--- a/src/service/cloudwatch/command/sim-cloudwatch-page.ts
+++ b/src/service/cloudwatch/command/sim-cloudwatch-page.ts
@@ -1,0 +1,59 @@
+import { SimCloudWatchInvalidParameterValueException } from "../error/sim-cloudwatch.error.js";
+
+interface SimCloudWatchPageProperties<T> {
+  /** Everything the request selected, before paging. */
+  readonly listed: readonly T[];
+
+  readonly nextToken?: string | undefined;
+
+  /** How many entries one page of this operation holds. */
+  readonly pageSize: number;
+}
+
+/**
+ * One page of a listing, and the token that reaches the next one.
+ *
+ * CloudWatch listings take no page size of their own, so a page is a fixed
+ * number of entries and the token is the offset of the next one. A token from
+ * somewhere else is refused rather than quietly starting again from the
+ * beginning, and an offset only means anything against the selection it was
+ * issued for: a token carried over to a request with different filters reaches
+ * a different place.
+ */
+export class SimCloudWatchPage<T> {
+  readonly items: readonly T[];
+  readonly nextToken: string | undefined;
+
+  constructor(properties: SimCloudWatchPageProperties<T>) {
+    const { listed, pageSize } = properties;
+    const startIndex = pageStartIndex(properties.nextToken, listed.length);
+    const nextIndex = startIndex + pageSize;
+
+    this.items = listed.slice(startIndex, nextIndex);
+    this.nextToken = nextIndex >= listed.length ? undefined : String(nextIndex);
+  }
+}
+
+function pageStartIndex(
+  nextToken: string | undefined,
+  listedCount: number,
+): number {
+  if (nextToken === undefined) {
+    return 0;
+  }
+
+  const startIndex = Number(nextToken);
+
+  if (
+    !Number.isSafeInteger(startIndex) ||
+    startIndex < 0 ||
+    startIndex >= listedCount ||
+    String(startIndex) !== nextToken
+  ) {
+    throw new SimCloudWatchInvalidParameterValueException(
+      "The parameter NextToken is not a token this simulation issued.",
+    );
+  }
+
+  return startIndex;
+}

--- a/src/service/cloudwatch/command/sim-cloudwatch-request-options.ts
+++ b/src/service/cloudwatch/command/sim-cloudwatch-request-options.ts
@@ -1,0 +1,22 @@
+import type { SimAwsCaller } from "../../aws/caller/sim-aws-caller.js";
+
+/**
+ * The condition key naming the namespace a PutMetricData request writes into.
+ *
+ * CloudWatch metrics have no ARN, so a policy cannot scope this action by
+ * resource. This key is what a policy narrows it with instead, and it is the
+ * only way to grant a principal the right to publish into one namespace and no
+ * other.
+ */
+export const simCloudWatchNamespaceConditionKey = "cloudwatch:namespace";
+
+/**
+ * What a simulated CloudWatch request carries besides its command input.
+ */
+export interface SimCloudWatchRequestOptions {
+  /**
+   * Who is making the request. An omitted caller is the Account root, as it is
+   * everywhere else in the simulation.
+   */
+  readonly caller?: SimAwsCaller;
+}

--- a/src/service/cloudwatch/error/sim-cloudwatch.error.ts
+++ b/src/service/cloudwatch/error/sim-cloudwatch.error.ts
@@ -1,0 +1,64 @@
+/**
+ * Minimal metadata shape for simulated CloudWatch errors.
+ */
+export interface SimCloudWatchErrorMetadata {
+  readonly httpStatusCode?: number;
+}
+
+/**
+ * Base class for simulated CloudWatch errors.
+ */
+export class SimCloudWatchError extends Error {
+  constructor(
+    message: string,
+    public readonly $metadata: SimCloudWatchErrorMetadata = {},
+  ) {
+    super(message);
+  }
+}
+
+/**
+ * Simulated CloudWatch InvalidParameterValueException error.
+ *
+ * Real CloudWatch reports a value it cannot accept this way: a reserved
+ * namespace, a metric datum carrying no value at all, a period that is not a
+ * multiple of sixty. Yulin also uses it for an input real CloudWatch would
+ * accept and this simulation does not carry out, with a message saying so,
+ * rather than inventing an error name the SDK has never seen.
+ */
+export class SimCloudWatchInvalidParameterValueException extends SimCloudWatchError {
+  public override readonly name = "InvalidParameterValueException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
+ * Simulated CloudWatch MissingRequiredParameterException error.
+ *
+ * This is what leaving out a parameter the operation cannot run without
+ * produces, such as a PutMetricData with no Namespace.
+ */
+export class SimCloudWatchMissingRequiredParameterException extends SimCloudWatchError {
+  public override readonly name = "MissingRequiredParameterException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
+ * Simulated CloudWatch InvalidParameterCombinationException error.
+ *
+ * Real CloudWatch reports parameters that are each valid but cannot be used
+ * together this way, such as a time range and period that between them would
+ * return more datapoints than one response holds.
+ */
+export class SimCloudWatchInvalidParameterCombinationException extends SimCloudWatchError {
+  public override readonly name = "InvalidParameterCombinationException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}

--- a/src/service/cloudwatch/index.ts
+++ b/src/service/cloudwatch/index.ts
@@ -1,0 +1,60 @@
+export { SimCloudWatch } from "./sim-cloudwatch.js";
+export {
+  simCloudWatchNamespaceConditionKey,
+  type SimCloudWatchRequestOptions,
+} from "./command/sim-cloudwatch-request-options.js";
+export {
+  aggregateSimCloudWatchDatapoints,
+  type SimCloudWatchAggregate,
+  type SimCloudWatchDatapoint,
+} from "./metric/sim-cloudwatch-datapoint.js";
+export {
+  type SimCloudWatchDimension,
+  type SimCloudWatchDimensionInput,
+  simCloudWatchDimensionsKey,
+  simCloudWatchDimensionsMatch,
+  simCloudWatchMaximumDimensions,
+  requiredSimCloudWatchDimensions,
+} from "./metric/sim-cloudwatch-dimension.js";
+export {
+  SimCloudWatchMetric,
+  type SimCloudWatchDatapointWindow,
+  type SimCloudWatchMetricIdentity,
+} from "./metric/sim-cloudwatch-metric.js";
+export {
+  type SimCloudWatchDimensionFilter,
+  type SimCloudWatchMetricFilter,
+  SimCloudWatchMetricStore,
+} from "./metric/sim-cloudwatch-metric-store.js";
+export {
+  requiredSimCloudWatchName,
+  simCloudWatchMaximumNameLength,
+} from "./metric/sim-cloudwatch-name.js";
+export {
+  requiredSimCloudWatchNamespace,
+  requiredSimCloudWatchWritableNamespace,
+  simCloudWatchReservedNamespacePrefix,
+} from "./metric/sim-cloudwatch-namespace.js";
+export {
+  bucketSimCloudWatchDatapoints,
+  requiredSimCloudWatchPeriod,
+  simCloudWatchMinimumPeriodSeconds,
+  simCloudWatchPeriodStart,
+} from "./metric/sim-cloudwatch-period.js";
+export {
+  requiredSimCloudWatchStatistic,
+  type SimCloudWatchStatistic,
+  simCloudWatchStatistics,
+  simCloudWatchStatisticValue,
+} from "./metric/sim-cloudwatch-statistic.js";
+export {
+  requiredSimCloudWatchTimeRange,
+  type SimCloudWatchTimeRange,
+} from "./metric/sim-cloudwatch-time-range.js";
+export {
+  SimCloudWatchError,
+  type SimCloudWatchErrorMetadata,
+  SimCloudWatchInvalidParameterCombinationException,
+  SimCloudWatchInvalidParameterValueException,
+  SimCloudWatchMissingRequiredParameterException,
+} from "./error/sim-cloudwatch.error.js";

--- a/src/service/cloudwatch/index.ts
+++ b/src/service/cloudwatch/index.ts
@@ -7,13 +7,14 @@ export {
   aggregateSimCloudWatchDatapoints,
   type SimCloudWatchAggregate,
   type SimCloudWatchDatapoint,
+  type SimCloudWatchObservations,
 } from "./metric/sim-cloudwatch-datapoint.js";
 export {
   type SimCloudWatchDimension,
   type SimCloudWatchDimensionInput,
   simCloudWatchDimensionsKey,
-  simCloudWatchDimensionsMatch,
   simCloudWatchMaximumDimensions,
+  requiredSimCloudWatchDimensionName,
   requiredSimCloudWatchDimensions,
 } from "./metric/sim-cloudwatch-dimension.js";
 export {
@@ -27,18 +28,24 @@ export {
   SimCloudWatchMetricStore,
 } from "./metric/sim-cloudwatch-metric-store.js";
 export {
+  refuseSimCloudWatchLeadingColon,
   requiredSimCloudWatchName,
   simCloudWatchMaximumNameLength,
 } from "./metric/sim-cloudwatch-name.js";
+export {
+  type SimCloudWatchUnit,
+  simCloudWatchUnitOrUndefined,
+  simCloudWatchUnits,
+} from "./metric/sim-cloudwatch-unit.js";
 export {
   requiredSimCloudWatchNamespace,
   requiredSimCloudWatchWritableNamespace,
   simCloudWatchReservedNamespacePrefix,
 } from "./metric/sim-cloudwatch-namespace.js";
 export {
-  bucketSimCloudWatchDatapoints,
   requiredSimCloudWatchPeriod,
   simCloudWatchMinimumPeriodSeconds,
+  simCloudWatchPeriodAggregates,
   simCloudWatchPeriodStart,
 } from "./metric/sim-cloudwatch-period.js";
 export {

--- a/src/service/cloudwatch/metric/sim-cloudwatch-datapoint.ts
+++ b/src/service/cloudwatch/metric/sim-cloudwatch-datapoint.ts
@@ -1,3 +1,5 @@
+import type { SimCloudWatchUnit } from "./sim-cloudwatch-unit.js";
+
 /**
  * One observation of a metric, held the way every statistic is read from.
  *
@@ -18,7 +20,7 @@ export interface SimCloudWatchDatapoint {
   readonly maximum: number;
 
   /** The unit given with the observation, if it carried one. */
-  readonly unit: string | undefined;
+  readonly unit: SimCloudWatchUnit | undefined;
 }
 
 /**
@@ -30,28 +32,34 @@ export interface SimCloudWatchAggregate {
   readonly minimum: number;
   readonly maximum: number;
   readonly average: number;
-  readonly unit: string | undefined;
+  readonly unit: SimCloudWatchUnit | undefined;
 }
 
 /**
- * Combine datapoints into the statistics CloudWatch reports for them.
+ * One or more observations of the same metric.
  *
- * An empty set has no statistics rather than zeroed ones: real CloudWatch
- * reports no datapoint at all for a period nothing was written into, which is
- * a different thing from a period whose values summed to zero.
+ * Aggregating takes this rather than a plain array because there are no
+ * statistics to report for no observations at all, and real CloudWatch reports
+ * no datapoint for a period nothing was written into rather than a zeroed one.
+ * Saying so in the type means the empty case cannot reach here to be guarded
+ * against.
+ */
+export type SimCloudWatchObservations = readonly [
+  SimCloudWatchDatapoint,
+  ...SimCloudWatchDatapoint[],
+];
+
+/**
+ * Combine observations into the statistics CloudWatch reports for them.
  *
  * The unit reported is the first one seen. Real CloudWatch keeps values of
  * different units apart within a metric, and a caller wanting one of them says
  * so with the `Unit` filter before the values reach here.
  */
 export function aggregateSimCloudWatchDatapoints(
-  datapoints: readonly SimCloudWatchDatapoint[],
-): SimCloudWatchAggregate | undefined {
-  const first = datapoints.at(0);
-
-  if (first === undefined) {
-    return undefined;
-  }
+  datapoints: SimCloudWatchObservations,
+): SimCloudWatchAggregate {
+  const [first] = datapoints;
 
   let sampleCount = 0;
   let sum = 0;

--- a/src/service/cloudwatch/metric/sim-cloudwatch-datapoint.ts
+++ b/src/service/cloudwatch/metric/sim-cloudwatch-datapoint.ts
@@ -1,0 +1,76 @@
+/**
+ * One observation of a metric, held the way every statistic is read from.
+ *
+ * A single `Value: 3` and a `StatisticValues` block describing a thousand
+ * requests are the same shape here, because that shape is what CloudWatch can
+ * answer every statistic from: a count, a total, and the two extremes. Storing
+ * individual values instead would answer no more questions and would make a
+ * `StatisticValues` datum impossible to store at all, since it never carries
+ * the values it summarises.
+ */
+export interface SimCloudWatchDatapoint {
+  /** When the observation was made, in milliseconds since the epoch. */
+  readonly timestamp: number;
+
+  readonly sampleCount: number;
+  readonly sum: number;
+  readonly minimum: number;
+  readonly maximum: number;
+
+  /** The unit given with the observation, if it carried one. */
+  readonly unit: string | undefined;
+}
+
+/**
+ * The statistics a set of datapoints answers with.
+ */
+export interface SimCloudWatchAggregate {
+  readonly sampleCount: number;
+  readonly sum: number;
+  readonly minimum: number;
+  readonly maximum: number;
+  readonly average: number;
+  readonly unit: string | undefined;
+}
+
+/**
+ * Combine datapoints into the statistics CloudWatch reports for them.
+ *
+ * An empty set has no statistics rather than zeroed ones: real CloudWatch
+ * reports no datapoint at all for a period nothing was written into, which is
+ * a different thing from a period whose values summed to zero.
+ *
+ * The unit reported is the first one seen. Real CloudWatch keeps values of
+ * different units apart within a metric, and a caller wanting one of them says
+ * so with the `Unit` filter before the values reach here.
+ */
+export function aggregateSimCloudWatchDatapoints(
+  datapoints: readonly SimCloudWatchDatapoint[],
+): SimCloudWatchAggregate | undefined {
+  const first = datapoints.at(0);
+
+  if (first === undefined) {
+    return undefined;
+  }
+
+  let sampleCount = 0;
+  let sum = 0;
+  let minimum = first.minimum;
+  let maximum = first.maximum;
+
+  for (const datapoint of datapoints) {
+    sampleCount += datapoint.sampleCount;
+    sum += datapoint.sum;
+    minimum = Math.min(minimum, datapoint.minimum);
+    maximum = Math.max(maximum, datapoint.maximum);
+  }
+
+  return {
+    sampleCount,
+    sum,
+    minimum,
+    maximum,
+    average: sum / sampleCount,
+    unit: datapoints.find((datapoint) => datapoint.unit !== undefined)?.unit,
+  };
+}

--- a/src/service/cloudwatch/metric/sim-cloudwatch-dimension.ts
+++ b/src/service/cloudwatch/metric/sim-cloudwatch-dimension.ts
@@ -1,0 +1,81 @@
+import { SimCloudWatchInvalidParameterValueException } from "../error/sim-cloudwatch.error.js";
+import { requiredSimCloudWatchName } from "./sim-cloudwatch-name.js";
+
+/**
+ * How many dimensions real CloudWatch allows on one metric.
+ */
+export const simCloudWatchMaximumDimensions = 30;
+
+/**
+ * One name/value pair narrowing what a metric measures.
+ */
+export interface SimCloudWatchDimension {
+  readonly name: string;
+  readonly value: string;
+}
+
+/**
+ * A dimension as it arrives on a command, before it has been read.
+ */
+export interface SimCloudWatchDimensionInput {
+  readonly Name?: string | undefined;
+  readonly Value?: string | undefined;
+}
+
+/**
+ * Read the dimensions of one metric, refusing what real CloudWatch would.
+ */
+export function requiredSimCloudWatchDimensions(
+  dimensions?: readonly SimCloudWatchDimensionInput[],
+): readonly SimCloudWatchDimension[] {
+  if (dimensions === undefined) {
+    return [];
+  }
+
+  if (dimensions.length > simCloudWatchMaximumDimensions) {
+    throw new SimCloudWatchInvalidParameterValueException(
+      `A metric may carry at most ${simCloudWatchMaximumDimensions} ` +
+        `dimensions, and ${dimensions.length} were given.`,
+    );
+  }
+
+  return dimensions.map((dimension) => ({
+    name: requiredSimCloudWatchName("Dimension.Name", dimension.Name),
+    value: requiredSimCloudWatchName("Dimension.Value", dimension.Value),
+  }));
+}
+
+/**
+ * Write a dimension set as the string that identifies it.
+ *
+ * Order does not distinguish two dimension sets on real CloudWatch, so the
+ * pairs are sorted by name before they are written. JSON does the writing
+ * because a dimension value may hold any of the characters a separator could
+ * be built from, and two different sets must never write the same key.
+ */
+export function simCloudWatchDimensionsKey(
+  dimensions: readonly SimCloudWatchDimension[],
+): string {
+  const sorted = dimensions.toSorted((left, right) =>
+    left.name.localeCompare(right.name),
+  );
+
+  return JSON.stringify(sorted.map((one) => [one.name, one.value]));
+}
+
+/**
+ * Whether a metric's dimensions are exactly the ones asked for.
+ *
+ * Real CloudWatch treats the dimension set as part of a metric's identity and
+ * does not roll up across it, so a query naming one of two dimensions reaches
+ * neither the two-dimension metric nor a metric with none.
+ */
+export function simCloudWatchDimensionsMatch(
+  dimensions: readonly SimCloudWatchDimension[],
+  wanted: readonly SimCloudWatchDimension[],
+): boolean {
+  return (
+    simCloudWatchDimensionsKey(dimensions) ===
+    simCloudWatchDimensionsKey(wanted)
+  );
+}

--- a/src/service/cloudwatch/metric/sim-cloudwatch-dimension.ts
+++ b/src/service/cloudwatch/metric/sim-cloudwatch-dimension.ts
@@ -1,5 +1,8 @@
 import { SimCloudWatchInvalidParameterValueException } from "../error/sim-cloudwatch.error.js";
-import { requiredSimCloudWatchName } from "./sim-cloudwatch-name.js";
+import {
+  refuseSimCloudWatchLeadingColon,
+  requiredSimCloudWatchName,
+} from "./sim-cloudwatch-name.js";
 
 /**
  * How many dimensions real CloudWatch allows on one metric.
@@ -40,9 +43,20 @@ export function requiredSimCloudWatchDimensions(
   }
 
   return dimensions.map((dimension) => ({
-    name: requiredSimCloudWatchName("Dimension.Name", dimension.Name),
+    name: requiredSimCloudWatchDimensionName(dimension.Name),
     value: requiredSimCloudWatchName("Dimension.Value", dimension.Value),
   }));
+}
+
+/**
+ * Read a dimension name, which real CloudWatch refuses to let start with a
+ * colon. A dimension value carries no such rule.
+ */
+export function requiredSimCloudWatchDimensionName(name?: string): string {
+  return refuseSimCloudWatchLeadingColon(
+    "Dimension.Name",
+    requiredSimCloudWatchName("Dimension.Name", name),
+  );
 }
 
 /**
@@ -61,21 +75,4 @@ export function simCloudWatchDimensionsKey(
   );
 
   return JSON.stringify(sorted.map((one) => [one.name, one.value]));
-}
-
-/**
- * Whether a metric's dimensions are exactly the ones asked for.
- *
- * Real CloudWatch treats the dimension set as part of a metric's identity and
- * does not roll up across it, so a query naming one of two dimensions reaches
- * neither the two-dimension metric nor a metric with none.
- */
-export function simCloudWatchDimensionsMatch(
-  dimensions: readonly SimCloudWatchDimension[],
-  wanted: readonly SimCloudWatchDimension[],
-): boolean {
-  return (
-    simCloudWatchDimensionsKey(dimensions) ===
-    simCloudWatchDimensionsKey(wanted)
-  );
 }

--- a/src/service/cloudwatch/metric/sim-cloudwatch-metric-store.ts
+++ b/src/service/cloudwatch/metric/sim-cloudwatch-metric-store.ts
@@ -1,0 +1,104 @@
+import type { SimCloudWatchDimension } from "./sim-cloudwatch-dimension.js";
+import { simCloudWatchDimensionsKey } from "./sim-cloudwatch-dimension.js";
+import {
+  SimCloudWatchMetric,
+  type SimCloudWatchMetricIdentity,
+} from "./sim-cloudwatch-metric.js";
+
+/**
+ * Which metrics a listing is asking for.
+ *
+ * A dimension filter carrying no value matches any value under that name,
+ * which is the one place CloudWatch does look at dimensions one at a time. It
+ * selects which metrics to report, never how their values are combined.
+ */
+export interface SimCloudWatchMetricFilter {
+  readonly namespace?: string | undefined;
+  readonly metricName?: string | undefined;
+  readonly dimensions?: readonly SimCloudWatchDimensionFilter[] | undefined;
+}
+
+export interface SimCloudWatchDimensionFilter {
+  readonly name: string;
+  readonly value?: string | undefined;
+}
+
+/**
+ * The metrics of one simulated CloudWatch scope.
+ *
+ * Metrics are keyed by namespace, name and dimension set together, because
+ * that triple is the whole of a metric's identity on real CloudWatch: writing
+ * the same metric name under a different dimension set makes a second metric
+ * rather than adding to the first.
+ */
+export class SimCloudWatchMetricStore {
+  readonly #metrics = new Map<string, SimCloudWatchMetric>();
+
+  /**
+   * Every metric in this scope, in the order each was first written to.
+   */
+  get all(): readonly SimCloudWatchMetric[] {
+    return this.#metrics.values().toArray();
+  }
+
+  /**
+   * Find a metric by its full identity.
+   */
+  find(identity: SimCloudWatchMetricIdentity): SimCloudWatchMetric | undefined {
+    return this.#metrics.get(metricKey(identity));
+  }
+
+  /**
+   * Get a metric by its full identity, making it if this is its first
+   * observation.
+   */
+  ensure(identity: SimCloudWatchMetricIdentity): SimCloudWatchMetric {
+    const key = metricKey(identity);
+    const found = this.#metrics.get(key);
+
+    if (found !== undefined) {
+      return found;
+    }
+
+    const metric = new SimCloudWatchMetric(identity);
+
+    this.#metrics.set(key, metric);
+
+    return metric;
+  }
+
+  /**
+   * The metrics a filter selects, in the order each was first written to.
+   */
+  matching(filter: SimCloudWatchMetricFilter): readonly SimCloudWatchMetric[] {
+    return this.all.filter(
+      (metric) =>
+        (filter.namespace === undefined ||
+          metric.namespace === filter.namespace) &&
+        (filter.metricName === undefined ||
+          metric.metricName === filter.metricName) &&
+        (filter.dimensions ?? []).every((wanted) =>
+          matchesDimension(metric.dimensions, wanted),
+        ),
+    );
+  }
+}
+
+function matchesDimension(
+  dimensions: readonly SimCloudWatchDimension[],
+  wanted: SimCloudWatchDimensionFilter,
+): boolean {
+  return dimensions.some(
+    (dimension) =>
+      dimension.name === wanted.name &&
+      (wanted.value === undefined || dimension.value === wanted.value),
+  );
+}
+
+function metricKey(identity: SimCloudWatchMetricIdentity): string {
+  return JSON.stringify([
+    identity.namespace,
+    identity.metricName,
+    simCloudWatchDimensionsKey(identity.dimensions),
+  ]);
+}

--- a/src/service/cloudwatch/metric/sim-cloudwatch-metric.ts
+++ b/src/service/cloudwatch/metric/sim-cloudwatch-metric.ts
@@ -1,0 +1,89 @@
+import type { SimCloudWatchDatapoint } from "./sim-cloudwatch-datapoint.js";
+import type { SimCloudWatchDimension } from "./sim-cloudwatch-dimension.js";
+
+/**
+ * What names one metric apart from every other.
+ *
+ * All three parts matter. Real CloudWatch treats a metric with one dimension
+ * and the same metric with two as different metrics entirely, and rolls nothing
+ * up between them.
+ */
+export interface SimCloudWatchMetricIdentity {
+  readonly namespace: string;
+  readonly metricName: string;
+  readonly dimensions: readonly SimCloudWatchDimension[];
+}
+
+/**
+ * Which observations of a metric a request is asking about.
+ */
+export interface SimCloudWatchDatapointWindow {
+  /** The first instant included, in milliseconds since the epoch. */
+  readonly startTime: number;
+
+  /** The first instant excluded, as real CloudWatch reads an end time. */
+  readonly endTime: number;
+
+  /** Keep only observations recorded in this unit, if one is named. */
+  readonly unit?: string | undefined;
+}
+
+/**
+ * One metric in a simulated CloudWatch scope, and everything written to it.
+ */
+export class SimCloudWatchMetric {
+  readonly namespace: string;
+  readonly metricName: string;
+  readonly dimensions: readonly SimCloudWatchDimension[];
+
+  readonly #datapoints: SimCloudWatchDatapoint[] = [];
+
+  constructor(identity: SimCloudWatchMetricIdentity) {
+    this.namespace = identity.namespace;
+    this.metricName = identity.metricName;
+    this.dimensions = identity.dimensions;
+  }
+
+  /**
+   * Every observation of this metric, in the order it was written.
+   */
+  get datapoints(): readonly SimCloudWatchDatapoint[] {
+    return this.#datapoints;
+  }
+
+  /**
+   * When this metric was last written to, if it ever was.
+   */
+  get lastWrittenAt(): number | undefined {
+    return this.#datapoints.reduce<number | undefined>(
+      (latest, datapoint) =>
+        latest === undefined || datapoint.timestamp > latest
+          ? datapoint.timestamp
+          : latest,
+      undefined,
+    );
+  }
+
+  /**
+   * Record one observation.
+   */
+  record(datapoint: SimCloudWatchDatapoint): void {
+    this.#datapoints.push(datapoint);
+  }
+
+  /**
+   * The observations falling in a window, earliest first.
+   */
+  within(
+    window: SimCloudWatchDatapointWindow,
+  ): readonly SimCloudWatchDatapoint[] {
+    return this.#datapoints
+      .filter(
+        (datapoint) =>
+          datapoint.timestamp >= window.startTime &&
+          datapoint.timestamp < window.endTime &&
+          (window.unit === undefined || datapoint.unit === window.unit),
+      )
+      .toSorted((left, right) => left.timestamp - right.timestamp);
+  }
+}

--- a/src/service/cloudwatch/metric/sim-cloudwatch-metric.ts
+++ b/src/service/cloudwatch/metric/sim-cloudwatch-metric.ts
@@ -1,5 +1,6 @@
 import type { SimCloudWatchDatapoint } from "./sim-cloudwatch-datapoint.js";
 import type { SimCloudWatchDimension } from "./sim-cloudwatch-dimension.js";
+import type { SimCloudWatchUnit } from "./sim-cloudwatch-unit.js";
 
 /**
  * What names one metric apart from every other.
@@ -25,7 +26,7 @@ export interface SimCloudWatchDatapointWindow {
   readonly endTime: number;
 
   /** Keep only observations recorded in this unit, if one is named. */
-  readonly unit?: string | undefined;
+  readonly unit?: SimCloudWatchUnit | undefined;
 }
 
 /**

--- a/src/service/cloudwatch/metric/sim-cloudwatch-name.ts
+++ b/src/service/cloudwatch/metric/sim-cloudwatch-name.ts
@@ -1,0 +1,52 @@
+import {
+  SimCloudWatchInvalidParameterValueException,
+  SimCloudWatchMissingRequiredParameterException,
+} from "../error/sim-cloudwatch.error.js";
+
+/**
+ * How long a namespace, metric name, dimension name or dimension value may be.
+ */
+export const simCloudWatchMaximumNameLength = 255;
+
+/**
+ * The characters real CloudWatch accepts in a namespace, metric name or
+ * dimension: alphanumerics, period, hyphen, underscore, forward slash, hash,
+ * colon and the space character.
+ */
+const namePattern = /^[A-Za-z0-9._/#: -]+$/;
+
+/** How this reads back when a name is refused for its characters. */
+const reportedNamePattern = "[A-Za-z0-9._/#: -]+";
+
+/**
+ * Read a name real CloudWatch would accept, refusing one it would not.
+ *
+ * Namespaces, metric names and both halves of a dimension share one character
+ * set and one length limit on real CloudWatch, so they share one reader here
+ * and differ only in the field named in the failure.
+ */
+export function requiredSimCloudWatchName(
+  field: string,
+  value?: string,
+): string {
+  if (value === undefined || value.length === 0) {
+    throw new SimCloudWatchMissingRequiredParameterException(
+      `The parameter ${field} must be present and not empty.`,
+    );
+  }
+
+  if (value.length > simCloudWatchMaximumNameLength) {
+    throw new SimCloudWatchInvalidParameterValueException(
+      `The parameter ${field} must have length less than or equal to ` +
+        `${simCloudWatchMaximumNameLength}.`,
+    );
+  }
+
+  if (!namePattern.test(value)) {
+    throw new SimCloudWatchInvalidParameterValueException(
+      `The parameter ${field} must satisfy the pattern ${reportedNamePattern}.`,
+    );
+  }
+
+  return value;
+}

--- a/src/service/cloudwatch/metric/sim-cloudwatch-name.ts
+++ b/src/service/cloudwatch/metric/sim-cloudwatch-name.ts
@@ -9,21 +9,23 @@ import {
 export const simCloudWatchMaximumNameLength = 255;
 
 /**
- * The characters real CloudWatch accepts in a namespace, metric name or
- * dimension: alphanumerics, period, hyphen, underscore, forward slash, hash,
- * colon and the space character.
+ * Anything outside printable ASCII, which is what real CloudWatch refuses in a
+ * namespace, a metric name or either half of a dimension: ASCII characters
+ * only, and control characters not supported.
+ *
+ * Written as the printable range rather than as the control characters
+ * themselves so the pattern carries no control character of its own.
  */
-const namePattern = /^[A-Za-z0-9._/#: -]+$/;
-
-/** How this reads back when a name is refused for its characters. */
-const reportedNamePattern = "[A-Za-z0-9._/#: -]+";
+const outsidePrintableAscii = /[^ -~]/;
 
 /**
  * Read a name real CloudWatch would accept, refusing one it would not.
  *
- * Namespaces, metric names and both halves of a dimension share one character
- * set and one length limit on real CloudWatch, so they share one reader here
- * and differ only in the field named in the failure.
+ * Namespaces, metric names and both halves of a dimension share one rule on
+ * real CloudWatch, so they share one reader here and differ only in the field
+ * named in the failure. The rule is deliberately wide: anything printable and
+ * not entirely whitespace. A tighter whitelist would refuse names an account
+ * accepts, which is the worse way for a simulator to be wrong.
  */
 export function requiredSimCloudWatchName(
   field: string,
@@ -42,9 +44,36 @@ export function requiredSimCloudWatchName(
     );
   }
 
-  if (!namePattern.test(value)) {
+  if (outsidePrintableAscii.test(value)) {
     throw new SimCloudWatchInvalidParameterValueException(
-      `The parameter ${field} must satisfy the pattern ${reportedNamePattern}.`,
+      `The parameter ${field} must hold only ASCII characters, and control ` +
+        `characters are not supported.`,
+    );
+  }
+
+  if (value.trim().length === 0) {
+    throw new SimCloudWatchInvalidParameterValueException(
+      `The parameter ${field} must include at least one non-whitespace ` +
+        `character.`,
+    );
+  }
+
+  return value;
+}
+
+/**
+ * Refuse a name that begins with a colon.
+ *
+ * Real CloudWatch applies this to a namespace and to a dimension name, and not
+ * to a dimension value.
+ */
+export function refuseSimCloudWatchLeadingColon(
+  field: string,
+  value: string,
+): string {
+  if (value.startsWith(":")) {
+    throw new SimCloudWatchInvalidParameterValueException(
+      `The parameter ${field} must not start with a colon.`,
     );
   }
 

--- a/src/service/cloudwatch/metric/sim-cloudwatch-namespace.ts
+++ b/src/service/cloudwatch/metric/sim-cloudwatch-namespace.ts
@@ -1,0 +1,50 @@
+import { SimCloudWatchInvalidParameterValueException } from "../error/sim-cloudwatch.error.js";
+import { requiredSimCloudWatchName } from "./sim-cloudwatch-name.js";
+
+/**
+ * The namespace prefix real CloudWatch keeps for the metrics AWS publishes
+ * itself, and refuses to let PutMetricData write into.
+ */
+export const simCloudWatchReservedNamespacePrefix = "AWS/";
+
+/**
+ * Read a namespace, refusing one real CloudWatch would refuse.
+ *
+ * A leading colon is refused on its own account: the API's own pattern for this
+ * field is anything whose first character is not a colon.
+ */
+export function requiredSimCloudWatchNamespace(namespace?: string): string {
+  const value = requiredSimCloudWatchName("Namespace", namespace);
+
+  if (value.startsWith(":")) {
+    throw new SimCloudWatchInvalidParameterValueException(
+      "The parameter Namespace must not start with a colon.",
+    );
+  }
+
+  return value;
+}
+
+/**
+ * Read a namespace a metric may be written into.
+ *
+ * Reserved namespaces are refused here rather than in the reader above,
+ * because reading a metric out of one is allowed and only writing into one is
+ * not. Nothing in this simulation publishes into `AWS/` either, so a namespace
+ * beginning that way holds no metrics at all here.
+ */
+export function requiredSimCloudWatchWritableNamespace(
+  namespace?: string,
+): string {
+  const value = requiredSimCloudWatchNamespace(namespace);
+
+  if (value.startsWith(simCloudWatchReservedNamespacePrefix)) {
+    throw new SimCloudWatchInvalidParameterValueException(
+      `The namespace ${value} is reserved: namespaces beginning ` +
+        `${simCloudWatchReservedNamespacePrefix} belong to the metrics AWS ` +
+        `publishes, and PutMetricData cannot write into one.`,
+    );
+  }
+
+  return value;
+}

--- a/src/service/cloudwatch/metric/sim-cloudwatch-namespace.ts
+++ b/src/service/cloudwatch/metric/sim-cloudwatch-namespace.ts
@@ -1,5 +1,8 @@
 import { SimCloudWatchInvalidParameterValueException } from "../error/sim-cloudwatch.error.js";
-import { requiredSimCloudWatchName } from "./sim-cloudwatch-name.js";
+import {
+  refuseSimCloudWatchLeadingColon,
+  requiredSimCloudWatchName,
+} from "./sim-cloudwatch-name.js";
 
 /**
  * The namespace prefix real CloudWatch keeps for the metrics AWS publishes
@@ -14,15 +17,10 @@ export const simCloudWatchReservedNamespacePrefix = "AWS/";
  * field is anything whose first character is not a colon.
  */
 export function requiredSimCloudWatchNamespace(namespace?: string): string {
-  const value = requiredSimCloudWatchName("Namespace", namespace);
-
-  if (value.startsWith(":")) {
-    throw new SimCloudWatchInvalidParameterValueException(
-      "The parameter Namespace must not start with a colon.",
-    );
-  }
-
-  return value;
+  return refuseSimCloudWatchLeadingColon(
+    "Namespace",
+    requiredSimCloudWatchName("Namespace", namespace),
+  );
 }
 
 /**

--- a/src/service/cloudwatch/metric/sim-cloudwatch-period.ts
+++ b/src/service/cloudwatch/metric/sim-cloudwatch-period.ts
@@ -1,0 +1,86 @@
+import {
+  SimCloudWatchInvalidParameterValueException,
+  SimCloudWatchMissingRequiredParameterException,
+} from "../error/sim-cloudwatch.error.js";
+import type { SimCloudWatchDatapoint } from "./sim-cloudwatch-datapoint.js";
+
+/**
+ * The shortest period real CloudWatch offers a standard-resolution metric.
+ */
+export const simCloudWatchMinimumPeriodSeconds = 60;
+
+const millisecondsPerSecond = 1000;
+
+/**
+ * Read a period, refusing one real CloudWatch would refuse.
+ *
+ * Anything shorter than a minute, or not a whole number of minutes, belongs to
+ * high-resolution metrics, which this simulation does not store.
+ */
+export function requiredSimCloudWatchPeriod(period?: number): number {
+  if (period === undefined) {
+    throw new SimCloudWatchMissingRequiredParameterException(
+      "The parameter Period must be present.",
+    );
+  }
+
+  if (
+    !Number.isSafeInteger(period) ||
+    period < simCloudWatchMinimumPeriodSeconds ||
+    period % simCloudWatchMinimumPeriodSeconds !== 0
+  ) {
+    throw new SimCloudWatchInvalidParameterValueException(
+      `The parameter Period must be a multiple of ` +
+        `${simCloudWatchMinimumPeriodSeconds} seconds and at least ` +
+        `${simCloudWatchMinimumPeriodSeconds}. High-resolution metrics are ` +
+        `not simulated.`,
+    );
+  }
+
+  return period;
+}
+
+/**
+ * The instant the period holding a timestamp begins.
+ *
+ * Periods are measured from the epoch rather than from the request's start
+ * time, so the same observation lands in the same bucket whatever window is
+ * asked for. That is what real CloudWatch does for every period that divides an
+ * hour, which is every period a test is likely to ask for.
+ */
+export function simCloudWatchPeriodStart(
+  timestamp: number,
+  periodSeconds: number,
+): number {
+  const periodMilliseconds = periodSeconds * millisecondsPerSecond;
+
+  return Math.floor(timestamp / periodMilliseconds) * periodMilliseconds;
+}
+
+/**
+ * Group datapoints by the period each of them falls in, earliest first.
+ */
+export function bucketSimCloudWatchDatapoints(
+  datapoints: readonly SimCloudWatchDatapoint[],
+  periodSeconds: number,
+): ReadonlyMap<number, readonly SimCloudWatchDatapoint[]> {
+  const buckets = new Map<number, SimCloudWatchDatapoint[]>();
+
+  for (const datapoint of datapoints) {
+    const start = simCloudWatchPeriodStart(datapoint.timestamp, periodSeconds);
+    const bucket = buckets.get(start);
+
+    if (bucket === undefined) {
+      buckets.set(start, [datapoint]);
+    } else {
+      bucket.push(datapoint);
+    }
+  }
+
+  return new Map(
+    buckets
+      .entries()
+      .toArray()
+      .toSorted(([left], [right]) => left - right),
+  );
+}

--- a/src/service/cloudwatch/metric/sim-cloudwatch-period.ts
+++ b/src/service/cloudwatch/metric/sim-cloudwatch-period.ts
@@ -2,7 +2,11 @@ import {
   SimCloudWatchInvalidParameterValueException,
   SimCloudWatchMissingRequiredParameterException,
 } from "../error/sim-cloudwatch.error.js";
-import type { SimCloudWatchDatapoint } from "./sim-cloudwatch-datapoint.js";
+import {
+  aggregateSimCloudWatchDatapoints,
+  type SimCloudWatchAggregate,
+  type SimCloudWatchDatapoint,
+} from "./sim-cloudwatch-datapoint.js";
 
 /**
  * The shortest period real CloudWatch offers a standard-resolution metric.
@@ -58,13 +62,22 @@ export function simCloudWatchPeriodStart(
 }
 
 /**
- * Group datapoints by the period each of them falls in, earliest first.
+ * Combine datapoints into one aggregate per period holding any, earliest
+ * first.
+ *
+ * Bucketing and combining are one step rather than two so that a period can
+ * only exist here because something was written into it. A caller therefore
+ * gets an aggregate for every period it is given, and has no empty case to
+ * handle that could never arise.
  */
-export function bucketSimCloudWatchDatapoints(
+export function simCloudWatchPeriodAggregates(
   datapoints: readonly SimCloudWatchDatapoint[],
   periodSeconds: number,
-): ReadonlyMap<number, readonly SimCloudWatchDatapoint[]> {
-  const buckets = new Map<number, SimCloudWatchDatapoint[]>();
+): ReadonlyMap<number, SimCloudWatchAggregate> {
+  const buckets = new Map<
+    number,
+    [SimCloudWatchDatapoint, ...SimCloudWatchDatapoint[]]
+  >();
 
   for (const datapoint of datapoints) {
     const start = simCloudWatchPeriodStart(datapoint.timestamp, periodSeconds);
@@ -81,6 +94,10 @@ export function bucketSimCloudWatchDatapoints(
     buckets
       .entries()
       .toArray()
-      .toSorted(([left], [right]) => left - right),
+      .toSorted(([left], [right]) => left - right)
+      .map(([start, inPeriod]) => [
+        start,
+        aggregateSimCloudWatchDatapoints(inPeriod),
+      ]),
   );
 }

--- a/src/service/cloudwatch/metric/sim-cloudwatch-statistic.ts
+++ b/src/service/cloudwatch/metric/sim-cloudwatch-statistic.ts
@@ -1,0 +1,65 @@
+import { SimCloudWatchInvalidParameterValueException } from "../error/sim-cloudwatch.error.js";
+import type { SimCloudWatchAggregate } from "./sim-cloudwatch-datapoint.js";
+
+/**
+ * The statistics real CloudWatch can answer from a stored metric.
+ *
+ * Percentiles are the notable absence. They need the individual values behind
+ * a period, which a `StatisticValues` datum never carries, so CloudWatch itself
+ * cannot report one for a metric published that way. Rather than answer for
+ * some metrics and not others, this simulation answers for none and says so.
+ */
+export const simCloudWatchStatistics = [
+  "SampleCount",
+  "Average",
+  "Sum",
+  "Minimum",
+  "Maximum",
+] as const;
+
+export type SimCloudWatchStatistic = (typeof simCloudWatchStatistics)[number];
+
+/**
+ * Read a statistic name, refusing one CloudWatch does not offer.
+ */
+export function requiredSimCloudWatchStatistic(
+  statistic: string,
+): SimCloudWatchStatistic {
+  const found = simCloudWatchStatistics.find((one) => one === statistic);
+
+  if (found === undefined) {
+    throw new SimCloudWatchInvalidParameterValueException(
+      `The statistic ${statistic} is not one this simulation reports. ` +
+        `Percentiles and other extended statistics are not simulated; use ` +
+        `one of ${simCloudWatchStatistics.join(", ")}.`,
+    );
+  }
+
+  return found;
+}
+
+/**
+ * Read one statistic out of a period's combined observations.
+ */
+export function simCloudWatchStatisticValue(
+  aggregate: SimCloudWatchAggregate,
+  statistic: SimCloudWatchStatistic,
+): number {
+  switch (statistic) {
+    case "SampleCount": {
+      return aggregate.sampleCount;
+    }
+    case "Average": {
+      return aggregate.average;
+    }
+    case "Sum": {
+      return aggregate.sum;
+    }
+    case "Minimum": {
+      return aggregate.minimum;
+    }
+    case "Maximum": {
+      return aggregate.maximum;
+    }
+  }
+}

--- a/src/service/cloudwatch/metric/sim-cloudwatch-time-range.ts
+++ b/src/service/cloudwatch/metric/sim-cloudwatch-time-range.ts
@@ -1,0 +1,55 @@
+import {
+  SimCloudWatchInvalidParameterValueException,
+  SimCloudWatchMissingRequiredParameterException,
+} from "../error/sim-cloudwatch.error.js";
+
+/**
+ * The window a metric query asks about, in milliseconds since the epoch.
+ *
+ * The start is included and the end is not, which is how real CloudWatch reads
+ * the two: a request ending on the minute does not pick up that minute's
+ * datapoint.
+ */
+export interface SimCloudWatchTimeRange {
+  readonly startTime: number;
+  readonly endTime: number;
+}
+
+/**
+ * Read the window a query asks about, refusing one real CloudWatch would.
+ */
+export function requiredSimCloudWatchTimeRange(
+  startTime?: Date,
+  endTime?: Date,
+): SimCloudWatchTimeRange {
+  const range = {
+    startTime: requiredTime("StartTime", startTime),
+    endTime: requiredTime("EndTime", endTime),
+  };
+
+  if (range.startTime >= range.endTime) {
+    throw new SimCloudWatchInvalidParameterValueException(
+      "The parameter StartTime must be earlier than EndTime.",
+    );
+  }
+
+  return range;
+}
+
+function requiredTime(field: string, time: Date | undefined): number {
+  if (time === undefined) {
+    throw new SimCloudWatchMissingRequiredParameterException(
+      `The parameter ${field} must be present.`,
+    );
+  }
+
+  const milliseconds = time.getTime();
+
+  if (Number.isNaN(milliseconds)) {
+    throw new SimCloudWatchInvalidParameterValueException(
+      `The parameter ${field} must be a valid date.`,
+    );
+  }
+
+  return milliseconds;
+}

--- a/src/service/cloudwatch/metric/sim-cloudwatch-unit.ts
+++ b/src/service/cloudwatch/metric/sim-cloudwatch-unit.ts
@@ -1,0 +1,67 @@
+import { SimCloudWatchInvalidParameterValueException } from "../error/sim-cloudwatch.error.js";
+
+/**
+ * The units real CloudWatch accepts, which are a closed set rather than free
+ * text: `StandardUnit` in the API model.
+ *
+ * A value outside it is refused rather than stored, because a metric published
+ * in a unit CloudWatch does not have would be refused in an account, and one
+ * read back by such a unit would match nothing here while failing there.
+ */
+export const simCloudWatchUnits = [
+  "Seconds",
+  "Microseconds",
+  "Milliseconds",
+  "Bytes",
+  "Kilobytes",
+  "Megabytes",
+  "Gigabytes",
+  "Terabytes",
+  "Bits",
+  "Kilobits",
+  "Megabits",
+  "Gigabits",
+  "Terabits",
+  "Percent",
+  "Count",
+  "Bytes/Second",
+  "Kilobytes/Second",
+  "Megabytes/Second",
+  "Gigabytes/Second",
+  "Terabytes/Second",
+  "Bits/Second",
+  "Kilobits/Second",
+  "Megabits/Second",
+  "Gigabits/Second",
+  "Terabits/Second",
+  "Count/Second",
+  "None",
+] as const;
+
+export type SimCloudWatchUnit = (typeof simCloudWatchUnits)[number];
+
+/**
+ * Read a unit, refusing one real CloudWatch does not have.
+ *
+ * An absent unit stays absent: a metric may be published without one, and a
+ * query naming none reads whatever units the metric holds.
+ */
+export function simCloudWatchUnitOrUndefined(
+  field: string,
+  unit?: string,
+): SimCloudWatchUnit | undefined {
+  if (unit === undefined) {
+    return undefined;
+  }
+
+  const found = simCloudWatchUnits.find((one) => one === unit);
+
+  if (found === undefined) {
+    throw new SimCloudWatchInvalidParameterValueException(
+      `The parameter ${field} must be one of the units CloudWatch has, and ` +
+        `${unit} is not one of them.`,
+    );
+  }
+
+  return found;
+}

--- a/src/service/cloudwatch/sdk/sim-cloudwatch-sdk-command-router.ts
+++ b/src/service/cloudwatch/sdk/sim-cloudwatch-sdk-command-router.ts
@@ -1,0 +1,70 @@
+import {
+  simSdkCallerOptions,
+  type SimSdkCommandRoute,
+  type SimSdkCommandRouter,
+} from "../../../sdk/index.js";
+import type { SimPutMetricDataCommand } from "../command/data/data.command.js";
+import type {
+  SimGetMetricDataCommand,
+  SimGetMetricStatisticsCommand,
+  SimListMetricsCommand,
+} from "../command/query/query.command.js";
+import type { SimCloudWatch } from "../sim-cloudwatch.js";
+
+/**
+ * Routes intercepted SDK Commands to one scoped simulated CloudWatch.
+ */
+export class SimCloudWatchSdkCommandRouter implements SimSdkCommandRouter {
+  readonly #routes: ReadonlyMap<string, SimSdkCommandRoute>;
+
+  constructor(simCloudWatch: SimCloudWatch) {
+    this.#routes = new Map<string, SimSdkCommandRoute>([
+      [
+        "PutMetricDataCommand",
+        async (command, context): Promise<unknown> =>
+          await simCloudWatch.putMetricData(
+            command as SimPutMetricDataCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "ListMetricsCommand",
+        async (command, context): Promise<unknown> =>
+          await simCloudWatch.listMetrics(
+            command as SimListMetricsCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "GetMetricStatisticsCommand",
+        async (command, context): Promise<unknown> =>
+          await simCloudWatch.getMetricStatistics(
+            command as SimGetMetricStatisticsCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "GetMetricDataCommand",
+        async (command, context): Promise<unknown> =>
+          await simCloudWatch.getMetricData(
+            command as SimGetMetricDataCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+    ]);
+  }
+
+  /**
+   * The SDK Command names simulated CloudWatch can handle.
+   */
+  supportedCommandNames(): readonly string[] {
+    return this.#routes.keys().toArray();
+  }
+
+  /**
+   * Get the route for an SDK Command name, if simulated CloudWatch supports it.
+   */
+  route(commandName: string): SimSdkCommandRoute | undefined {
+    return this.#routes.get(commandName);
+  }
+}

--- a/src/service/cloudwatch/sdk/sim-cloudwatch-sdk-routing.iso.test.ts
+++ b/src/service/cloudwatch/sdk/sim-cloudwatch-sdk-routing.iso.test.ts
@@ -1,0 +1,135 @@
+import {
+  CloudWatchClient,
+  GetMetricDataCommand,
+  GetMetricStatisticsCommand,
+  ListMetricsCommand,
+  PutMetricDataCommand,
+} from "@aws-sdk/client-cloudwatch";
+import {
+  assertArrayEquals,
+  assertArrayIncludesAll,
+  assertIdentical,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimSdk } from "../../../sdk/index.js";
+import { SimAws } from "../../aws/sim-aws.js";
+
+const publishedAt = new Date("2026-08-16T09:00:10.000Z");
+const window = {
+  StartTime: new Date("2026-08-16T09:00:00.000Z"),
+  EndTime: new Date("2026-08-16T09:01:00.000Z"),
+};
+
+describe("SimCloudWatchSdkCommandRouter", () => {
+  it("names every Command simulated CloudWatch handles", () => {
+    // Given a scoped simulated CloudWatch.
+    const simAws = new SimAws();
+
+    // When its supported Command names are asked for.
+    const names = simAws
+      .cloudWatch()
+      .sdkCommandRouter()
+      .supportedCommandNames();
+
+    // Then each simulated operation is routable by SDK Command name.
+    assertArrayIncludesAll(names, [
+      "PutMetricDataCommand",
+      "ListMetricsCommand",
+      "GetMetricStatisticsCommand",
+      "GetMetricDataCommand",
+    ]);
+  });
+
+  it("has no route for a Command it does not handle", () => {
+    // Given a scoped simulated CloudWatch.
+    const simAws = new SimAws();
+
+    // When a CloudWatch Command outside what is simulated is looked up.
+    const route = simAws
+      .cloudWatch()
+      .sdkCommandRouter()
+      .route("PutMetricAlarmCommand");
+
+    // Then there is no route for it.
+    assertUndefined(route);
+  });
+});
+
+describe("CloudWatch SDK interception", () => {
+  it("routes an intercepted CloudWatchClient to simulated CloudWatch", async () => {
+    // Given an intercepted CloudWatch SDK client.
+    using simSdk = new SimSdk();
+    simSdk.intercept(CloudWatchClient);
+
+    const client = new CloudWatchClient({ region: "eu-west-2" });
+
+    // When ordinary SDK code publishes a metric and reads it back every way it
+    // can.
+    await client.send(
+      new PutMetricDataCommand({
+        Namespace: "Orders",
+        MetricData: [
+          { MetricName: "Failed", Value: 4, Timestamp: publishedAt },
+        ],
+      }),
+    );
+
+    const listed = await client.send(new ListMetricsCommand({}));
+    const statistics = await client.send(
+      new GetMetricStatisticsCommand({
+        Namespace: "Orders",
+        MetricName: "Failed",
+        Statistics: ["Sum"],
+        Period: 60,
+        ...window,
+      }),
+    );
+    const data = await client.send(
+      new GetMetricDataCommand({
+        MetricDataQueries: [
+          {
+            Id: "failed",
+            MetricStat: {
+              Metric: { Namespace: "Orders", MetricName: "Failed" },
+              Period: 60,
+              Stat: "Sum",
+            },
+          },
+        ],
+        ...window,
+      }),
+    );
+
+    // Then every operation reached the simulator, with nothing touching the
+    // network.
+    assertArrayEquals(
+      listed.Metrics?.map((metric) => metric.MetricName),
+      ["Failed"],
+    );
+    assertIdentical(statistics.Datapoints?.at(0)?.Sum, 4);
+    assertArrayEquals(data.MetricDataResults?.at(0)?.Values, [4]);
+  });
+
+  it("keeps one Region's metrics out of another's", async () => {
+    // Given a metric published through a client in one Region.
+    using simSdk = new SimSdk();
+    simSdk.intercept(CloudWatchClient);
+
+    await new CloudWatchClient({ region: "eu-west-2" }).send(
+      new PutMetricDataCommand({
+        Namespace: "Orders",
+        MetricData: [{ MetricName: "Failed", Value: 1 }],
+      }),
+    );
+
+    // When another Region's client lists its metrics.
+    const listed = await new CloudWatchClient({ region: "us-east-1" }).send(
+      new ListMetricsCommand({}),
+    );
+
+    // Then it sees none of them, as it would in an account.
+    assertArrayEquals(listed.Metrics ?? [], []);
+  });
+});

--- a/src/service/cloudwatch/sim-cloudwatch-commands.ts
+++ b/src/service/cloudwatch/sim-cloudwatch-commands.ts
@@ -1,0 +1,67 @@
+import {
+  type BackgroundScheduler,
+  BackgroundTasks,
+} from "../../util/background/background.js";
+import {
+  SimIamAllowAllAuth,
+  type SimIamInterServiceAuthZ,
+} from "../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { SimCloudWatchAuthorizer } from "./command/authorize/sim-cloudwatch-authorizer.js";
+import { SimCloudWatchPutMetricData } from "./command/data/sim-cloudwatch-put-metric-data.js";
+import { SimCloudWatchGetMetricData } from "./command/query/sim-cloudwatch-get-metric-data.js";
+import { SimCloudWatchGetMetricStatistics } from "./command/query/sim-cloudwatch-get-metric-statistics.js";
+import { SimCloudWatchListMetrics } from "./command/query/sim-cloudwatch-list-metrics.js";
+import { SimCloudWatchMetricStore } from "./metric/sim-cloudwatch-metric-store.js";
+
+export interface SimCloudWatchProperties {
+  readonly iam?: SimIamInterServiceAuthZ;
+  readonly background?: BackgroundScheduler;
+}
+
+/**
+ * The collaborators one simulated CloudWatch scope is built from.
+ *
+ * Held apart from SimCloudWatch for the same reason simulated CloudWatch Logs
+ * holds its own: the facade is one method per SDK Command and grows by one with
+ * every operation added, so the wiring deciding what those methods delegate to
+ * needs somewhere it is not competing for room with them.
+ */
+export class SimCloudWatchCommands {
+  readonly metrics: SimCloudWatchMetricStore;
+  readonly putMetricData: SimCloudWatchPutMetricData;
+  readonly listMetrics: SimCloudWatchListMetrics;
+  readonly getMetricStatistics: SimCloudWatchGetMetricStatistics;
+  readonly getMetricData: SimCloudWatchGetMetricData;
+  readonly background: BackgroundScheduler;
+
+  constructor(properties: SimCloudWatchProperties = {}) {
+    const {
+      iam = new SimIamAllowAllAuth(),
+      background = new BackgroundTasks(),
+    } = properties;
+
+    const authorizer = new SimCloudWatchAuthorizer({ iam });
+    const metrics = new SimCloudWatchMetricStore();
+
+    this.background = background;
+    this.metrics = metrics;
+    this.putMetricData = new SimCloudWatchPutMetricData({
+      metrics,
+      authorizer,
+      clock: background,
+    });
+    this.listMetrics = new SimCloudWatchListMetrics({
+      metrics,
+      authorizer,
+      clock: background,
+    });
+    this.getMetricStatistics = new SimCloudWatchGetMetricStatistics({
+      metrics,
+      authorizer,
+    });
+    this.getMetricData = new SimCloudWatchGetMetricData({
+      metrics,
+      authorizer,
+    });
+  }
+}

--- a/src/service/cloudwatch/sim-cloudwatch-dimensions.iso.test.ts
+++ b/src/service/cloudwatch/sim-cloudwatch-dimensions.iso.test.ts
@@ -1,0 +1,143 @@
+import {
+  GetMetricStatisticsCommand,
+  PutMetricDataCommand,
+} from "@aws-sdk/client-cloudwatch";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../aws/sim-aws.js";
+import { SimCloudWatchInvalidParameterValueException } from "./error/sim-cloudwatch.error.js";
+import { simCloudWatchMaximumDimensions } from "./metric/sim-cloudwatch-dimension.js";
+import type { SimCloudWatch } from "./sim-cloudwatch.js";
+
+const window = {
+  StartTime: new Date("2026-08-16T09:00:00.000Z"),
+  EndTime: new Date("2026-08-16T09:15:00.000Z"),
+  Period: 900,
+};
+const at = new Date("2026-08-16T09:00:10.000Z");
+
+/**
+ * Read the total of `Orders`/`Failed` under exactly the dimensions given.
+ */
+async function sumUnder(
+  metrics: SimCloudWatch,
+  Dimensions: readonly { Name: string; Value: string }[],
+): Promise<number | undefined> {
+  const read = await metrics.getMetricStatistics(
+    new GetMetricStatisticsCommand({
+      Namespace: "Orders",
+      MetricName: "Failed",
+      Dimensions: [...Dimensions],
+      Statistics: ["Sum"],
+      ...window,
+    }),
+  );
+
+  return read.Datapoints?.at(0)?.Sum;
+}
+
+describe("SimCloudWatch metric dimensions", () => {
+  it("treats a different dimension set as a different metric", async () => {
+    // Given one metric name published under two channels and once with no
+    // dimensions at all.
+    const metrics = new SimAws().cloudWatch();
+
+    await metrics.putMetricData(
+      new PutMetricDataCommand({
+        Namespace: "Orders",
+        MetricData: [
+          {
+            MetricName: "Failed",
+            Value: 1,
+            Timestamp: at,
+            Dimensions: [{ Name: "Channel", Value: "web" }],
+          },
+          {
+            MetricName: "Failed",
+            Value: 10,
+            Timestamp: at,
+            Dimensions: [{ Name: "Channel", Value: "app" }],
+          },
+          { MetricName: "Failed", Value: 100, Timestamp: at },
+        ],
+      }),
+    );
+
+    // When each dimension set is read back.
+    // Then each answers for itself alone: real CloudWatch does not roll a
+    // custom metric up across its dimensions, so the undimensioned read gets
+    // the undimensioned value rather than the total of all three.
+    assertArrayLength(metrics.allMetrics(), 3);
+    assertIdentical(
+      await sumUnder(metrics, [{ Name: "Channel", Value: "web" }]),
+      1,
+    );
+    assertIdentical(
+      await sumUnder(metrics, [{ Name: "Channel", Value: "app" }]),
+      10,
+    );
+    assertIdentical(await sumUnder(metrics, []), 100);
+  });
+
+  it("does not mind the order dimensions were given in", async () => {
+    // Given a metric published with two dimensions.
+    const metrics = new SimAws().cloudWatch();
+
+    await metrics.putMetricData(
+      new PutMetricDataCommand({
+        Namespace: "Orders",
+        MetricData: [
+          {
+            MetricName: "Failed",
+            Value: 7,
+            Timestamp: at,
+            Dimensions: [
+              { Name: "Channel", Value: "web" },
+              { Name: "Region", Value: "eu" },
+            ],
+          },
+        ],
+      }),
+    );
+
+    // When it is read back with those dimensions the other way round.
+    const sum = await sumUnder(metrics, [
+      { Name: "Region", Value: "eu" },
+      { Name: "Channel", Value: "web" },
+    ]);
+
+    // Then it is the same metric, as it is on real CloudWatch.
+    assertIdentical(sum, 7);
+  });
+
+  it("refuses more dimensions than one metric may carry", async () => {
+    // Given a datum carrying one dimension more than CloudWatch allows.
+    const metrics = new SimAws().cloudWatch();
+    const tooMany = Array.from(
+      { length: simCloudWatchMaximumDimensions + 1 },
+      (_, index) => ({ Name: `Key${index}`, Value: "value" }),
+    );
+
+    // When it is published.
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await metrics.putMetricData(
+          new PutMetricDataCommand({
+            Namespace: "Orders",
+            MetricData: [
+              { MetricName: "Failed", Value: 1, Dimensions: tooMany },
+            ],
+          }),
+        ),
+    );
+
+    // Then it is refused.
+    assertInstanceOf(error, SimCloudWatchInvalidParameterValueException);
+  });
+});

--- a/src/service/cloudwatch/sim-cloudwatch-get-metric-data.iso.test.ts
+++ b/src/service/cloudwatch/sim-cloudwatch-get-metric-data.iso.test.ts
@@ -238,4 +238,88 @@ describe("SimCloudWatch GetMetricData", () => {
     // though it had widened it.
     assertInstanceOf(error, SimCloudWatchInvalidParameterValueException);
   });
+
+  it("refuses a query id and a scan order real CloudWatch would refuse", async () => {
+    // Given three minutes of failures.
+    const metrics = await withThreeMinutes();
+
+    // When a query with no id, one whose id does not start with a lower-case
+    // letter, one with no Stat, and an unknown scan order are asked for.
+    const noId = await assertThrowsErrorAsync(
+      async () =>
+        await metrics.getMetricData({
+          input: { MetricDataQueries: [{ MetricStat: {} }], ...window },
+        }),
+    );
+    const badId = await assertThrowsErrorAsync(
+      async () =>
+        await metrics.getMetricData(
+          new GetMetricDataCommand({
+            MetricDataQueries: [{ ...failuresPerMinute, Id: "Failed" }],
+            ...window,
+          }),
+        ),
+    );
+    const noStat = await assertThrowsErrorAsync(
+      async () =>
+        await metrics.getMetricData({
+          input: {
+            MetricDataQueries: [
+              {
+                Id: "failed",
+                MetricStat: {
+                  Metric: { Namespace: "Orders", MetricName: "Failed" },
+                  Period: 60,
+                },
+              },
+            ],
+            ...window,
+          },
+        }),
+    );
+    const scanBy = await assertThrowsErrorAsync(
+      async () =>
+        await metrics.getMetricData({
+          input: {
+            MetricDataQueries: [failuresPerMinute],
+            ScanBy: "Alphabetical",
+            ...window,
+          },
+        }),
+    );
+
+    // Then each is refused.
+    assertInstanceOf(noId, SimCloudWatchMissingRequiredParameterException);
+    assertInstanceOf(badId, SimCloudWatchInvalidParameterValueException);
+    assertInstanceOf(noStat, SimCloudWatchMissingRequiredParameterException);
+    assertInstanceOf(scanBy, SimCloudWatchInvalidParameterValueException);
+  });
+
+  it("refuses a request carrying no queries, and a token it never issued", async () => {
+    // Given three minutes of failures.
+    const metrics = await withThreeMinutes();
+
+    // When a request carries no queries, and another carries a next token.
+    const none = await assertThrowsErrorAsync(
+      async () =>
+        await metrics.getMetricData(
+          new GetMetricDataCommand({ MetricDataQueries: [], ...window }),
+        ),
+    );
+    const token = await assertThrowsErrorAsync(
+      async () =>
+        await metrics.getMetricData(
+          new GetMetricDataCommand({
+            MetricDataQueries: [failuresPerMinute],
+            NextToken: "10",
+            ...window,
+          }),
+        ),
+    );
+
+    // Then each is refused: every query here is answered in full, so no token
+    // is ever issued to come back with.
+    assertInstanceOf(none, SimCloudWatchMissingRequiredParameterException);
+    assertInstanceOf(token, SimCloudWatchInvalidParameterValueException);
+  });
 });

--- a/src/service/cloudwatch/sim-cloudwatch-get-metric-data.iso.test.ts
+++ b/src/service/cloudwatch/sim-cloudwatch-get-metric-data.iso.test.ts
@@ -1,0 +1,241 @@
+import {
+  GetMetricDataCommand,
+  PutMetricDataCommand,
+} from "@aws-sdk/client-cloudwatch";
+import {
+  assertArrayEquals,
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../aws/sim-aws.js";
+import {
+  SimCloudWatchInvalidParameterValueException,
+  SimCloudWatchMissingRequiredParameterException,
+} from "./error/sim-cloudwatch.error.js";
+import type { SimCloudWatch } from "./sim-cloudwatch.js";
+
+const window = {
+  StartTime: new Date("2026-08-16T09:00:00.000Z"),
+  EndTime: new Date("2026-08-16T09:03:00.000Z"),
+};
+
+/**
+ * A simulated CloudWatch holding one failure in each of three minutes, and one
+ * retry in the first of them.
+ */
+async function withThreeMinutes(): Promise<SimCloudWatch> {
+  const metrics = new SimAws().cloudWatch();
+
+  await metrics.putMetricData(
+    new PutMetricDataCommand({
+      Namespace: "Orders",
+      MetricData: [
+        {
+          MetricName: "Failed",
+          Value: 1,
+          Timestamp: new Date("2026-08-16T09:00:10.000Z"),
+        },
+        {
+          MetricName: "Failed",
+          Value: 2,
+          Timestamp: new Date("2026-08-16T09:01:10.000Z"),
+        },
+        {
+          MetricName: "Failed",
+          Value: 3,
+          Timestamp: new Date("2026-08-16T09:02:10.000Z"),
+        },
+        {
+          MetricName: "Retried",
+          Value: 9,
+          Timestamp: new Date("2026-08-16T09:00:20.000Z"),
+        },
+      ],
+    }),
+  );
+
+  return metrics;
+}
+
+const failuresPerMinute = {
+  Id: "failed",
+  MetricStat: {
+    Metric: { Namespace: "Orders", MetricName: "Failed" },
+    Period: 60,
+    Stat: "Sum",
+  },
+};
+
+describe("SimCloudWatch GetMetricData", () => {
+  it("answers a MetricStat query newest first", async () => {
+    // Given three minutes of failures.
+    const metrics = await withThreeMinutes();
+
+    // When they are read back.
+    const read = await metrics.getMetricData(
+      new GetMetricDataCommand({
+        MetricDataQueries: [failuresPerMinute],
+        ...window,
+      }),
+    );
+
+    // Then the values come back newest first, as real CloudWatch scans by
+    // default, with the timestamps beside them.
+    const result = read.MetricDataResults?.at(0);
+
+    assertNonNullable(result);
+    assertIdentical(result.Id, "failed");
+    assertIdentical(result.Label, "Failed");
+    assertIdentical(result.StatusCode, "Complete");
+    assertArrayEquals(result.Values, [3, 2, 1]);
+    assertArrayEquals(
+      result.Timestamps.map((timestamp) => timestamp.toISOString()),
+      [
+        "2026-08-16T09:02:00.000Z",
+        "2026-08-16T09:01:00.000Z",
+        "2026-08-16T09:00:00.000Z",
+      ],
+    );
+  });
+
+  it("scans oldest first when asked to", async () => {
+    // Given three minutes of failures.
+    const metrics = await withThreeMinutes();
+
+    // When they are read back the other way round.
+    const read = await metrics.getMetricData(
+      new GetMetricDataCommand({
+        MetricDataQueries: [failuresPerMinute],
+        ScanBy: "TimestampAscending",
+        ...window,
+      }),
+    );
+
+    // Then the values come back oldest first.
+    assertArrayEquals(read.MetricDataResults?.at(0)?.Values, [1, 2, 3]);
+  });
+
+  it("answers several metrics in one request, and leaves out what a query does not return", async () => {
+    // Given two metrics, one of which the request says it does not want back.
+    const metrics = await withThreeMinutes();
+
+    // When both are asked for in one request.
+    const read = await metrics.getMetricData(
+      new GetMetricDataCommand({
+        MetricDataQueries: [
+          failuresPerMinute,
+          {
+            Id: "retried",
+            Label: "Retries in the window",
+            MetricStat: {
+              Metric: { Namespace: "Orders", MetricName: "Retried" },
+              Period: 300,
+              Stat: "Maximum",
+            },
+          },
+          { ...failuresPerMinute, Id: "hidden", ReturnData: false },
+        ],
+        ...window,
+      }),
+    );
+
+    // Then each returning query gets a result with the label it asked for, and
+    // the one that returns no data gets none.
+    const retried = read.MetricDataResults?.at(1);
+
+    assertNonNullable(retried);
+    assertArrayEquals(
+      read.MetricDataResults?.map((result) => result.Id),
+      ["failed", "retried"],
+    );
+    assertIdentical(retried.Label, "Retries in the window");
+    assertArrayEquals(retried.Values, [9]);
+  });
+
+  it("answers a metric nothing has been written to with no values", async () => {
+    // Given a simulated CloudWatch with no metrics at all.
+    const metrics = new SimAws().cloudWatch();
+
+    // When one is asked for.
+    const read = await metrics.getMetricData(
+      new GetMetricDataCommand({
+        MetricDataQueries: [failuresPerMinute],
+        ...window,
+      }),
+    );
+
+    // Then there is a result for the query, holding nothing.
+    assertArrayLength(read.MetricDataResults ?? [], 1);
+    assertArrayLength(read.MetricDataResults?.at(0)?.Values ?? [], 0);
+  });
+
+  it("refuses metric math rather than answering from one of its metrics", async () => {
+    // Given three minutes of failures.
+    const metrics = await withThreeMinutes();
+
+    // When an expression, a repeated id and a query with no MetricStat are
+    // asked for.
+    const expression = await assertThrowsErrorAsync(
+      async () =>
+        await metrics.getMetricData(
+          new GetMetricDataCommand({
+            MetricDataQueries: [
+              failuresPerMinute,
+              { Id: "rate", Expression: "failed / 60" },
+            ],
+            ...window,
+          }),
+        ),
+    );
+    const repeated = await assertThrowsErrorAsync(
+      async () =>
+        await metrics.getMetricData(
+          new GetMetricDataCommand({
+            MetricDataQueries: [failuresPerMinute, failuresPerMinute],
+            ...window,
+          }),
+        ),
+    );
+    const bare = await assertThrowsErrorAsync(
+      async () =>
+        await metrics.getMetricData(
+          new GetMetricDataCommand({
+            MetricDataQueries: [{ Id: "failed" }],
+            ...window,
+          }),
+        ),
+    );
+
+    // Then each is refused rather than answered with a number the request did
+    // not ask for.
+    assertInstanceOf(expression, SimCloudWatchInvalidParameterValueException);
+    assertInstanceOf(repeated, SimCloudWatchInvalidParameterValueException);
+    assertInstanceOf(bare, SimCloudWatchMissingRequiredParameterException);
+  });
+
+  it("refuses a MaxDatapoints it would not honour", async () => {
+    // Given three minutes of failures.
+    const metrics = await withThreeMinutes();
+
+    // When a maximum number of datapoints is asked for.
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await metrics.getMetricData(
+          new GetMetricDataCommand({
+            MetricDataQueries: [failuresPerMinute],
+            MaxDatapoints: 2,
+            ...window,
+          }),
+        ),
+    );
+
+    // Then it says so, rather than returning the period the query asked for as
+    // though it had widened it.
+    assertInstanceOf(error, SimCloudWatchInvalidParameterValueException);
+  });
+});

--- a/src/service/cloudwatch/sim-cloudwatch-get-metric-statistics.iso.test.ts
+++ b/src/service/cloudwatch/sim-cloudwatch-get-metric-statistics.iso.test.ts
@@ -202,4 +202,49 @@ describe("SimCloudWatch GetMetricStatistics", () => {
       SimCloudWatchInvalidParameterCombinationException,
     );
   });
+
+  it("reads only the values recorded in the unit asked for", async () => {
+    // Given the same metric published in two units, which real CloudWatch
+    // keeps apart within one metric.
+    const metrics = new SimAws().cloudWatch();
+
+    await metrics.putMetricData(
+      new PutMetricDataCommand({
+        Namespace: namespace,
+        MetricData: [
+          {
+            MetricName: metricName,
+            Value: 3,
+            Unit: "Count",
+            Timestamp: new Date("2026-08-16T09:00:10.000Z"),
+          },
+          {
+            MetricName: metricName,
+            Value: 500,
+            Unit: "Milliseconds",
+            Timestamp: new Date("2026-08-16T09:00:20.000Z"),
+          },
+        ],
+      }),
+    );
+
+    // When one unit is named, and then neither.
+    const counted = await metrics.getMetricStatistics(
+      new GetMetricStatisticsCommand({
+        Namespace: namespace,
+        MetricName: metricName,
+        Statistics: ["Sum"],
+        Unit: "Count",
+        StartTime: new Date("2026-08-16T09:00:00.000Z"),
+        EndTime: new Date("2026-08-16T09:15:00.000Z"),
+        Period: 900,
+      }),
+    );
+    const both = await perMinuteSums(metrics);
+
+    // Then the filtered read sees only its own unit, and the unfiltered read
+    // sees everything written to the metric.
+    assertIdentical(counted.Datapoints?.at(0)?.Sum, 3);
+    assertIdentical(both.Datapoints?.at(0)?.Sum, 503);
+  });
 });

--- a/src/service/cloudwatch/sim-cloudwatch-get-metric-statistics.iso.test.ts
+++ b/src/service/cloudwatch/sim-cloudwatch-get-metric-statistics.iso.test.ts
@@ -1,0 +1,205 @@
+import {
+  GetMetricStatisticsCommand,
+  PutMetricDataCommand,
+} from "@aws-sdk/client-cloudwatch";
+import {
+  assertArrayEquals,
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../aws/sim-aws.js";
+import {
+  SimCloudWatchInvalidParameterCombinationException,
+  SimCloudWatchInvalidParameterValueException,
+} from "./error/sim-cloudwatch.error.js";
+import type { SimCloudWatch } from "./sim-cloudwatch.js";
+
+const namespace = "Orders";
+const metricName = "Failed";
+
+/**
+ * A simulated CloudWatch holding one value of `Orders`/`Failed` at each of the
+ * instants given.
+ */
+async function withValuesAt(
+  ...instants: readonly string[]
+): Promise<SimCloudWatch> {
+  const metrics = new SimAws().cloudWatch();
+
+  await metrics.putMetricData(
+    new PutMetricDataCommand({
+      Namespace: namespace,
+      MetricData: instants.map((instant, index) => ({
+        MetricName: metricName,
+        Value: index + 1,
+        Timestamp: new Date(instant),
+      })),
+    }),
+  );
+
+  return metrics;
+}
+
+/**
+ * A minute-by-minute read of `Orders`/`Failed` across one quarter of an hour.
+ */
+async function perMinuteSums(
+  metrics: SimCloudWatch,
+): Promise<ReturnType<SimCloudWatch["getMetricStatistics"]>> {
+  return await metrics.getMetricStatistics(
+    new GetMetricStatisticsCommand({
+      Namespace: namespace,
+      MetricName: metricName,
+      Statistics: ["Sum"],
+      StartTime: new Date("2026-08-16T09:00:00.000Z"),
+      EndTime: new Date("2026-08-16T09:15:00.000Z"),
+      Period: 60,
+    }),
+  );
+}
+
+describe("SimCloudWatch GetMetricStatistics", () => {
+  it("gathers observations into the period each of them falls in", async () => {
+    // Given three observations, two of them inside the same minute.
+    const metrics = await withValuesAt(
+      "2026-08-16T09:00:10.000Z",
+      "2026-08-16T09:00:50.000Z",
+      "2026-08-16T09:01:30.000Z",
+    );
+
+    // When they are read a minute at a time.
+    const read = await perMinuteSums(metrics);
+
+    // Then there is one datapoint per minute holding observations, stamped
+    // with the start of that minute rather than with any observation's time.
+    const datapoints = read.Datapoints ?? [];
+
+    assertArrayEquals(
+      datapoints.map((datapoint) => datapoint.Timestamp.toISOString()),
+      ["2026-08-16T09:00:00.000Z", "2026-08-16T09:01:00.000Z"],
+    );
+    assertArrayEquals(
+      datapoints.map((datapoint) => datapoint.Sum),
+      [3, 3],
+    );
+  });
+
+  it("reports only the statistics the request asked for", async () => {
+    // Given one observation.
+    const metrics = await withValuesAt("2026-08-16T09:00:10.000Z");
+
+    // When only the sum is asked for.
+    const read = await perMinuteSums(metrics);
+
+    // Then nothing else is reported beside it.
+    const datapoint = read.Datapoints?.at(0);
+
+    assertNonNullable(datapoint);
+    assertIdentical(datapoint.Sum, 1);
+    assertUndefined(datapoint.Average);
+    assertUndefined(datapoint.SampleCount);
+  });
+
+  it("leaves out a period nothing was written into", async () => {
+    // Given observations either side of an idle minute.
+    const metrics = await withValuesAt(
+      "2026-08-16T09:00:10.000Z",
+      "2026-08-16T09:02:10.000Z",
+    );
+
+    // When the three minutes are read.
+    const read = await perMinuteSums(metrics);
+
+    // Then the idle minute has no datapoint rather than a zeroed one.
+    assertArrayLength(read.Datapoints ?? [], 2);
+  });
+
+  it("includes the start of the window and excludes its end", async () => {
+    // Given observations on each boundary of a window.
+    const metrics = await withValuesAt(
+      "2026-08-16T09:00:00.000Z",
+      "2026-08-16T09:15:00.000Z",
+    );
+
+    // When the window is read.
+    const read = await perMinuteSums(metrics);
+
+    // Then only the one at the start is in it, as real CloudWatch reads an end
+    // time exclusively.
+    assertArrayEquals(
+      read.Datapoints?.map((datapoint) => datapoint.Timestamp.toISOString()),
+      ["2026-08-16T09:00:00.000Z"],
+    );
+  });
+
+  it("answers for a metric nothing has been written to", async () => {
+    // Given a simulated CloudWatch with no metrics at all.
+    const metrics = new SimAws().cloudWatch();
+
+    // When a metric is read.
+    const read = await perMinuteSums(metrics);
+
+    // Then it answers with no datapoints rather than failing, since a metric
+    // only exists on real CloudWatch once something publishes to it.
+    assertArrayLength(read.Datapoints ?? [], 0);
+  });
+
+  it("refuses a period, a statistic and a range real CloudWatch would refuse", async () => {
+    // Given one observation.
+    const metrics = await withValuesAt("2026-08-16T09:00:10.000Z");
+    const request = {
+      Namespace: namespace,
+      MetricName: metricName,
+      StartTime: new Date("2026-08-16T09:00:00.000Z"),
+      EndTime: new Date("2026-08-16T09:15:00.000Z"),
+    };
+
+    // When a sub-minute period, a percentile and a range covering more
+    // datapoints than one response holds are asked for.
+    const period = await assertThrowsErrorAsync(
+      async () =>
+        await metrics.getMetricStatistics(
+          new GetMetricStatisticsCommand({
+            ...request,
+            Statistics: ["Sum"],
+            Period: 30,
+          }),
+        ),
+    );
+    const percentile = await assertThrowsErrorAsync(
+      async () =>
+        await metrics.getMetricStatistics(
+          new GetMetricStatisticsCommand({
+            ...request,
+            ExtendedStatistics: ["p99"],
+            Period: 60,
+          }),
+        ),
+    );
+    const tooMany = await assertThrowsErrorAsync(
+      async () =>
+        await metrics.getMetricStatistics(
+          new GetMetricStatisticsCommand({
+            ...request,
+            EndTime: new Date("2026-08-18T09:00:00.000Z"),
+            Statistics: ["Sum"],
+            Period: 60,
+          }),
+        ),
+    );
+
+    // Then each is refused, and the range for the reason real CloudWatch gives.
+    assertInstanceOf(period, SimCloudWatchInvalidParameterValueException);
+    assertInstanceOf(percentile, SimCloudWatchInvalidParameterValueException);
+    assertInstanceOf(
+      tooMany,
+      SimCloudWatchInvalidParameterCombinationException,
+    );
+  });
+});

--- a/src/service/cloudwatch/sim-cloudwatch-invalid-input.iso.test.ts
+++ b/src/service/cloudwatch/sim-cloudwatch-invalid-input.iso.test.ts
@@ -1,0 +1,355 @@
+import {
+  assertArrayLength,
+  assertInstanceOf,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../aws/sim-aws.js";
+import type {
+  SimCloudWatchMetricDatumInput,
+  SimGetMetricStatisticsCommandInput,
+} from "./command/sim-cloudwatch-command.types.js";
+import {
+  SimCloudWatchInvalidParameterCombinationException,
+  SimCloudWatchInvalidParameterValueException,
+  SimCloudWatchMissingRequiredParameterException,
+} from "./error/sim-cloudwatch.error.js";
+import { simCloudWatchMaximumNameLength } from "./metric/sim-cloudwatch-name.js";
+
+/**
+ * These requests are built as plain command shapes rather than through the SDK
+ * command classes, because the SDK's own types refuse most of them outright: a
+ * MetricDatum without a MetricName does not compile. That makes these the
+ * requests reaching the simulator from JavaScript, or from a client that types
+ * its input more loosely than the SDK does.
+ */
+const window = {
+  StartTime: new Date("2026-08-16T09:00:00.000Z"),
+  EndTime: new Date("2026-08-16T09:15:00.000Z"),
+};
+
+/**
+ * Publish one batch of data, whatever shape the test wants to give it.
+ */
+async function publishing(
+  MetricData: readonly SimCloudWatchMetricDatumInput[],
+  Namespace = "Orders",
+): Promise<Error> {
+  return await assertThrowsErrorAsync(
+    async () =>
+      await new SimAws()
+        .cloudWatch()
+        .putMetricData({ input: { Namespace, MetricData } }),
+  );
+}
+
+/**
+ * Read a metric back, whatever shape the test wants to give the request.
+ */
+async function reading(
+  input: SimGetMetricStatisticsCommandInput,
+): Promise<Error> {
+  return await assertThrowsErrorAsync(
+    async () => await new SimAws().cloudWatch().getMetricStatistics({ input }),
+  );
+}
+
+describe("SimCloudWatch invalid PutMetricData", () => {
+  it("refuses a namespace or metric name real CloudWatch would refuse", async () => {
+    // Given names outside what real CloudWatch accepts.
+    // When each is published.
+    const leadingColon = await publishing(
+      [{ MetricName: "Failed", Value: 1 }],
+      ":Orders",
+    );
+    const tooLong = await publishing([
+      { MetricName: "a".repeat(simCloudWatchMaximumNameLength + 1), Value: 1 },
+    ]);
+    const controlCharacter = await publishing([
+      { MetricName: "Failed\u{7}", Value: 1 },
+    ]);
+    const allWhitespace = await publishing([{ MetricName: "  ", Value: 1 }]);
+    const missing = await publishing([{ Value: 1 }]);
+
+    // Then each is refused for what is wrong with it.
+    assertInstanceOf(leadingColon, SimCloudWatchInvalidParameterValueException);
+    assertInstanceOf(tooLong, SimCloudWatchInvalidParameterValueException);
+    assertInstanceOf(
+      controlCharacter,
+      SimCloudWatchInvalidParameterValueException,
+    );
+    assertInstanceOf(
+      allWhitespace,
+      SimCloudWatchInvalidParameterValueException,
+    );
+    assertInstanceOf(missing, SimCloudWatchMissingRequiredParameterException);
+  });
+
+  it("accepts the punctuation real CloudWatch accepts in a name", async () => {
+    // Given names holding punctuation outside the small set a stricter reader
+    // might allow, which real CloudWatch takes because it takes any printable
+    // ASCII.
+    const metrics = new SimAws().cloudWatch();
+
+    // When they are published.
+    await metrics.putMetricData({
+      input: {
+        Namespace: "Orders (web)",
+        MetricData: [
+          {
+            MetricName: "Failed+Retried",
+            Value: 1,
+            Dimensions: [{ Name: "Channel", Value: "orders@web" }],
+          },
+        ],
+      },
+    });
+
+    // Then the metric was recorded rather than refused.
+    assertArrayLength(metrics.allMetrics(), 1);
+  });
+
+  it("refuses a dimension name that starts with a colon", async () => {
+    // Given a dimension name real CloudWatch refuses, and a value with the
+    // same leading colon, which it allows.
+    const name = await publishing([
+      {
+        MetricName: "Failed",
+        Value: 1,
+        Dimensions: [{ Name: ":Channel", Value: "web" }],
+      },
+    ]);
+    const metrics = new SimAws().cloudWatch();
+
+    await metrics.putMetricData({
+      input: {
+        Namespace: "Orders",
+        MetricData: [
+          {
+            MetricName: "Failed",
+            Value: 1,
+            Dimensions: [{ Name: "Channel", Value: ":web" }],
+          },
+        ],
+      },
+    });
+
+    // Then the name is refused and the value is not: the colon rule is the
+    // name's alone.
+    assertInstanceOf(name, SimCloudWatchInvalidParameterValueException);
+    assertArrayLength(metrics.allMetrics(), 1);
+  });
+
+  it("refuses a value outside the range CloudWatch stores", async () => {
+    // Given values real CloudWatch will not hold.
+    // When each is published.
+    const tooLarge = await publishing([
+      { MetricName: "Failed", Value: 2 ** 361 },
+    ]);
+    const notANumber = await publishing([{ MetricName: "Failed", Value: NaN }]);
+    const summed = await publishing([
+      {
+        MetricName: "Failed",
+        StatisticValues: {
+          SampleCount: 1,
+          Sum: Number.MAX_VALUE,
+          Minimum: 0,
+          Maximum: Number.MAX_VALUE,
+        },
+      },
+    ]);
+
+    // Then each is refused, which is also what keeps a stored total finite: an
+    // out-of-range value can never be summed into one.
+    assertInstanceOf(tooLarge, SimCloudWatchInvalidParameterValueException);
+    assertInstanceOf(notANumber, SimCloudWatchInvalidParameterValueException);
+    assertInstanceOf(summed, SimCloudWatchInvalidParameterValueException);
+  });
+
+  it("refuses a unit CloudWatch does not have", async () => {
+    // Given a unit outside the set real CloudWatch offers.
+    // When it is published.
+    const error = await publishing([
+      { MetricName: "Failed", Value: 1, Unit: "Furlongs" },
+    ]);
+
+    // Then it is refused rather than stored as a unit nothing could query.
+    assertInstanceOf(error, SimCloudWatchInvalidParameterValueException);
+  });
+
+  it("refuses a request carrying no metric data at all", async () => {
+    // Given a request with an empty batch.
+    // When it is published.
+    const empty = await publishing([]);
+
+    // Then it is refused rather than treated as nothing to do.
+    assertInstanceOf(empty, SimCloudWatchMissingRequiredParameterException);
+  });
+
+  it("refuses a statistic set that could not have been measured", async () => {
+    // Given summaries that do not describe a real set of observations.
+    // When each is published.
+    const noSamples = await publishing([
+      {
+        MetricName: "Latency",
+        StatisticValues: { SampleCount: 0, Sum: 0, Minimum: 0, Maximum: 0 },
+      },
+    ]);
+    const inverted = await publishing([
+      {
+        MetricName: "Latency",
+        StatisticValues: { SampleCount: 2, Sum: 30, Minimum: 40, Maximum: 10 },
+      },
+    ]);
+    const incomplete = await publishing([
+      { MetricName: "Latency", StatisticValues: { SampleCount: 2, Sum: 30 } },
+    ]);
+
+    // Then each is refused: a summary of no observations, one whose extremes
+    // are the wrong way round, and one missing a half of itself.
+    assertInstanceOf(noSamples, SimCloudWatchInvalidParameterValueException);
+    assertInstanceOf(inverted, SimCloudWatchInvalidParameterValueException);
+    assertInstanceOf(
+      incomplete,
+      SimCloudWatchMissingRequiredParameterException,
+    );
+  });
+
+  it("refuses values that do not line up with their counts", async () => {
+    // Given weighted values that do not describe a real set of observations.
+    // When each is published.
+    const empty = await publishing([{ MetricName: "Size", Values: [] }]);
+    const countsAlone = await publishing([
+      { MetricName: "Size", Counts: [1, 2] },
+    ]);
+    const tooManyValues = await publishing([
+      {
+        MetricName: "Size",
+        Values: Array.from({ length: 151 }, (_, index) => index + 1),
+      },
+    ]);
+    const mismatched = await publishing([
+      { MetricName: "Size", Values: [1, 2], Counts: [1] },
+    ]);
+    const zeroCount = await publishing([
+      { MetricName: "Size", Values: [1, 2], Counts: [1, 0] },
+    ]);
+
+    // Then each is refused, including counts given with nothing to count,
+    // which describe nothing on their own.
+    assertInstanceOf(empty, SimCloudWatchInvalidParameterValueException);
+    assertInstanceOf(
+      countsAlone,
+      SimCloudWatchInvalidParameterCombinationException,
+    );
+    assertInstanceOf(
+      tooManyValues,
+      SimCloudWatchInvalidParameterValueException,
+    );
+    assertInstanceOf(
+      mismatched,
+      SimCloudWatchInvalidParameterCombinationException,
+    );
+    assertInstanceOf(zeroCount, SimCloudWatchInvalidParameterValueException);
+  });
+
+  it("refuses a batch larger than one request may carry", async () => {
+    // Given one datum more than real CloudWatch takes in a request.
+    const tooMany = Array.from({ length: 1001 }, (_, index) => ({
+      MetricName: "Failed",
+      Value: 1,
+      Dimensions: [{ Name: "Shard", Value: String(index) }],
+    }));
+
+    // When it is published.
+    const error = await publishing(tooMany);
+
+    // Then the whole batch is refused.
+    assertInstanceOf(error, SimCloudWatchInvalidParameterValueException);
+  });
+});
+
+describe("SimCloudWatch invalid GetMetricStatistics", () => {
+  const metric = { Namespace: "Orders", MetricName: "Failed" };
+
+  it("refuses a window that is not a window", async () => {
+    // Given times that do not describe one.
+    // When each is read.
+    const noStart = await reading({
+      ...metric,
+      Statistics: ["Sum"],
+      Period: 60,
+      EndTime: window.EndTime,
+    });
+    const backwards = await reading({
+      ...metric,
+      Statistics: ["Sum"],
+      Period: 60,
+      StartTime: window.EndTime,
+      EndTime: window.StartTime,
+    });
+    const notADate = await reading({
+      ...metric,
+      Statistics: ["Sum"],
+      Period: 60,
+      StartTime: window.StartTime,
+      EndTime: new Date("not a date"),
+    });
+
+    // Then each is refused.
+    assertInstanceOf(noStart, SimCloudWatchMissingRequiredParameterException);
+    assertInstanceOf(backwards, SimCloudWatchInvalidParameterValueException);
+    assertInstanceOf(notADate, SimCloudWatchInvalidParameterValueException);
+  });
+
+  it("refuses a period and a statistic it cannot answer", async () => {
+    // Given a period that is not whole minutes, a missing period, no
+    // statistics at all, and a statistic CloudWatch does not offer.
+    // When each is read.
+    const partMinute = await reading({
+      ...metric,
+      ...window,
+      Statistics: ["Sum"],
+      Period: 90,
+    });
+    const noPeriod = await reading({
+      ...metric,
+      ...window,
+      Statistics: ["Sum"],
+    });
+    const noStatistics = await reading({ ...metric, ...window, Period: 60 });
+    const unknown = await reading({
+      ...metric,
+      ...window,
+      Statistics: ["Median"],
+      Period: 60,
+    });
+
+    // Then each is refused.
+    assertInstanceOf(partMinute, SimCloudWatchInvalidParameterValueException);
+    assertInstanceOf(noPeriod, SimCloudWatchMissingRequiredParameterException);
+    assertInstanceOf(
+      noStatistics,
+      SimCloudWatchMissingRequiredParameterException,
+    );
+    assertInstanceOf(unknown, SimCloudWatchInvalidParameterValueException);
+  });
+
+  it("refuses a unit CloudWatch does not have before looking the metric up", async () => {
+    // Given a simulated CloudWatch holding no metrics at all, so a lookup
+    // would answer with nothing whatever unit was asked for.
+    // When one outside the set real CloudWatch offers is asked for.
+    const error = await reading({
+      ...metric,
+      ...window,
+      Statistics: ["Sum"],
+      Period: 60,
+      Unit: "Furlongs",
+    });
+
+    // Then it is refused rather than answered with an empty success, which is
+    // what an account would do.
+    assertInstanceOf(error, SimCloudWatchInvalidParameterValueException);
+  });
+});

--- a/src/service/cloudwatch/sim-cloudwatch-list-metrics.iso.test.ts
+++ b/src/service/cloudwatch/sim-cloudwatch-list-metrics.iso.test.ts
@@ -7,6 +7,7 @@ import {
   assertArrayLength,
   assertInstanceOf,
   assertThrowsErrorAsync,
+  assertUndefined,
 } from "@kensio/smartass";
 import { describe, it } from "vitest";
 
@@ -156,5 +157,74 @@ describe("SimCloudWatch ListMetrics", () => {
     // Then each is refused rather than quietly ignored.
     assertInstanceOf(window, SimCloudWatchInvalidParameterValueException);
     assertInstanceOf(linked, SimCloudWatchInvalidParameterValueException);
+  });
+
+  it("pages a listing longer than one page, and refuses a token it never issued", async () => {
+    // Given more metrics than one page of a listing holds.
+    const simAws = new SimAws();
+    const metrics = simAws.cloudWatch();
+
+    await metrics.putMetricData(
+      new PutMetricDataCommand({
+        Namespace: "Orders",
+        MetricData: Array.from({ length: 501 }, (_, index) => ({
+          MetricName: "Failed",
+          Value: 1,
+          Dimensions: [{ Name: "Shard", Value: String(index) }],
+        })),
+      }),
+    );
+
+    // When the first page is read, and then the one its token reaches.
+    const first = await metrics.listMetrics(new ListMetricsCommand({}));
+    const second = await metrics.listMetrics(
+      new ListMetricsCommand({ NextToken: first.NextToken }),
+    );
+    const bogus = await assertThrowsErrorAsync(
+      async () =>
+        await metrics.listMetrics(
+          new ListMetricsCommand({ NextToken: "not a token" }),
+        ),
+    );
+
+    // Then the listing came back in two pages, and the second ends it.
+    assertArrayLength(first.Metrics ?? [], 500);
+    assertArrayLength(second.Metrics ?? [], 1);
+    assertUndefined(second.NextToken);
+    assertInstanceOf(bogus, SimCloudWatchInvalidParameterValueException);
+  });
+
+  it("measures recency from the latest write, whatever order they arrived in", async () => {
+    // Given a metric written to twice, the second datum stamped earlier than
+    // the first, which is what a batch of buffered metrics looks like.
+    const simAws = new SimAws();
+    const metrics = simAws.cloudWatch();
+
+    await simAws.clock().setTo(startedAt);
+    await metrics.putMetricData(
+      new PutMetricDataCommand({
+        Namespace: "Orders",
+        MetricData: [
+          { MetricName: "Failed", Value: 1, Timestamp: startedAt },
+          {
+            MetricName: "Failed",
+            Value: 1,
+            Timestamp: new Date("2026-08-16T06:00:00.000Z"),
+          },
+        ],
+      }),
+    );
+
+    // When time moves on past the older write but not the newer.
+    await simAws.clock().advanceBy({ hours: 2 });
+
+    const listed = await listedNames(
+      metrics,
+      new ListMetricsCommand({ RecentlyActive: "PT3H" }),
+    );
+
+    // Then it still counts as recent, because recency is the latest write
+    // rather than the last one to arrive.
+    assertArrayLength(listed, 1);
   });
 });

--- a/src/service/cloudwatch/sim-cloudwatch-list-metrics.iso.test.ts
+++ b/src/service/cloudwatch/sim-cloudwatch-list-metrics.iso.test.ts
@@ -1,0 +1,160 @@
+import {
+  ListMetricsCommand,
+  PutMetricDataCommand,
+} from "@aws-sdk/client-cloudwatch";
+import {
+  assertArrayEquals,
+  assertArrayLength,
+  assertInstanceOf,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../aws/sim-aws.js";
+import { SimCloudWatchInvalidParameterValueException } from "./error/sim-cloudwatch.error.js";
+import type { SimCloudWatch } from "./sim-cloudwatch.js";
+
+const startedAt = new Date("2026-08-16T09:00:00.000Z");
+
+/**
+ * A simulation holding three metrics across two namespaces, published at the
+ * simulation's own start time.
+ */
+async function withThreeMetrics(): Promise<SimAws> {
+  const simAws = new SimAws();
+
+  await simAws.clock().setTo(startedAt);
+
+  await simAws.cloudWatch().putMetricData(
+    new PutMetricDataCommand({
+      Namespace: "Orders",
+      MetricData: [
+        {
+          MetricName: "Failed",
+          Value: 1,
+          Dimensions: [{ Name: "Channel", Value: "web" }],
+        },
+        {
+          MetricName: "Failed",
+          Value: 1,
+          Dimensions: [{ Name: "Channel", Value: "app" }],
+        },
+      ],
+    }),
+  );
+  await simAws.cloudWatch().putMetricData(
+    new PutMetricDataCommand({
+      Namespace: "Billing",
+      MetricData: [{ MetricName: "Retried", Value: 1 }],
+    }),
+  );
+
+  return simAws;
+}
+
+async function listedNames(
+  metrics: SimCloudWatch,
+  command: ListMetricsCommand,
+): Promise<readonly string[]> {
+  const listed = await metrics.listMetrics(command);
+
+  return (listed.Metrics ?? []).map(
+    (metric) => `${metric.Namespace}/${metric.MetricName}`,
+  );
+}
+
+describe("SimCloudWatch ListMetrics", () => {
+  it("reports every metric that has been published to", async () => {
+    // Given three metrics across two namespaces.
+    const simAws = await withThreeMetrics();
+    const metrics = simAws.cloudWatch();
+
+    // When they are all listed.
+    const names = await listedNames(metrics, new ListMetricsCommand({}));
+
+    // Then each dimension set is reported as a metric of its own.
+    assertArrayEquals(names, [
+      "Orders/Failed",
+      "Orders/Failed",
+      "Billing/Retried",
+    ]);
+  });
+
+  it("filters by namespace, metric name and dimension", async () => {
+    // Given three metrics across two namespaces.
+    const simAws = await withThreeMetrics();
+    const metrics = simAws.cloudWatch();
+
+    // When each filter is applied.
+    const byNamespace = await listedNames(
+      metrics,
+      new ListMetricsCommand({ Namespace: "Billing" }),
+    );
+    const byMetricName = await listedNames(
+      metrics,
+      new ListMetricsCommand({ MetricName: "Failed" }),
+    );
+    const byDimensionValue = await metrics.listMetrics(
+      new ListMetricsCommand({
+        Dimensions: [{ Name: "Channel", Value: "app" }],
+      }),
+    );
+    const byDimensionName = await metrics.listMetrics(
+      new ListMetricsCommand({ Dimensions: [{ Name: "Channel" }] }),
+    );
+
+    // Then each selects what it names, and a dimension filter with no value
+    // matches whatever value a metric carries under that name.
+    assertArrayEquals(byNamespace, ["Billing/Retried"]);
+    assertArrayEquals(byMetricName, ["Orders/Failed", "Orders/Failed"]);
+    assertArrayEquals(
+      byDimensionValue.Metrics?.flatMap((metric) =>
+        metric.Dimensions.map((dimension) => dimension.Value),
+      ),
+      ["app"],
+    );
+    assertArrayLength(byDimensionName.Metrics ?? [], 2);
+  });
+
+  it("measures RecentlyActive against the simulation's clock", async () => {
+    // Given metrics published at the simulation's start time.
+    const simAws = await withThreeMetrics();
+    const metrics = simAws.cloudWatch();
+    const recently = new ListMetricsCommand({ RecentlyActive: "PT3H" });
+
+    // When time is moved past the window CloudWatch counts as recent.
+    const before = await listedNames(metrics, recently);
+
+    await simAws.clock().advanceBy({ hours: 4 });
+
+    const after = await listedNames(metrics, recently);
+
+    // Then they drop out of the listing without anything having expired them.
+    assertArrayLength(before, 3);
+    assertArrayLength(after, 0);
+  });
+
+  it("refuses a recency window and an account reach it cannot honour", async () => {
+    // Given a simulation holding metrics.
+    const simAws = await withThreeMetrics();
+    const metrics = simAws.cloudWatch();
+
+    // When another recency window, and a cross-account listing, are asked for.
+    // The SDK's own types allow only PT3H, so the other window can only arrive
+    // from code that is not using them.
+    const window = await assertThrowsErrorAsync(
+      async () =>
+        await metrics.listMetrics({ input: { RecentlyActive: "PT1H" } }),
+    );
+    const linked = await assertThrowsErrorAsync(
+      async () =>
+        await metrics.listMetrics(
+          new ListMetricsCommand({ IncludeLinkedAccounts: true }),
+        ),
+    );
+
+    // Then each is refused rather than quietly ignored.
+    assertInstanceOf(window, SimCloudWatchInvalidParameterValueException);
+    assertInstanceOf(linked, SimCloudWatchInvalidParameterValueException);
+  });
+});

--- a/src/service/cloudwatch/sim-cloudwatch-put-metric-data.iso.test.ts
+++ b/src/service/cloudwatch/sim-cloudwatch-put-metric-data.iso.test.ts
@@ -235,4 +235,34 @@ describe("SimCloudWatch PutMetricData", () => {
     // Then neither was stored, as real CloudWatch validates the whole request.
     assertArrayLength(metrics.allMetrics(), 0);
   });
+
+  it("counts each value once when a datum lists values without counts", async () => {
+    // Given values published with no Counts beside them.
+    const metrics = cloudWatch();
+
+    await metrics.putMetricData(
+      new PutMetricDataCommand({
+        Namespace: "Orders",
+        MetricData: [{ MetricName: "Size", Values: [2, 5, 5] }],
+      }),
+    );
+
+    // When the metric is read back.
+    const read = await metrics.getMetricStatistics(
+      new GetMetricStatisticsCommand({
+        Namespace: "Orders",
+        MetricName: "Size",
+        Statistics: ["SampleCount", "Sum", "Maximum"],
+        ...window,
+      }),
+    );
+
+    // Then each value counted once, including the one listed twice.
+    const datapoint = read.Datapoints?.at(0);
+
+    assertNonNullable(datapoint);
+    assertIdentical(datapoint.SampleCount, 3);
+    assertIdentical(datapoint.Sum, 12);
+    assertIdentical(datapoint.Maximum, 5);
+  });
 });

--- a/src/service/cloudwatch/sim-cloudwatch-put-metric-data.iso.test.ts
+++ b/src/service/cloudwatch/sim-cloudwatch-put-metric-data.iso.test.ts
@@ -1,0 +1,238 @@
+import {
+  GetMetricStatisticsCommand,
+  PutMetricDataCommand,
+} from "@aws-sdk/client-cloudwatch";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimFixedClock } from "../../util/clock/sim-clock.js";
+import { SimAws } from "../aws/sim-aws.js";
+import {
+  SimCloudWatchInvalidParameterCombinationException,
+  SimCloudWatchInvalidParameterValueException,
+  SimCloudWatchMissingRequiredParameterException,
+} from "./error/sim-cloudwatch.error.js";
+import type { SimCloudWatch } from "./sim-cloudwatch.js";
+
+const publishedAt = new Date("2026-08-16T09:00:30.000Z");
+const window = {
+  StartTime: new Date("2026-08-16T09:00:00.000Z"),
+  EndTime: new Date("2026-08-16T09:01:00.000Z"),
+  Period: 60,
+};
+
+/**
+ * A simulated CloudWatch whose clock is stopped inside one minute.
+ */
+function cloudWatch(): SimCloudWatch {
+  return new SimAws({ clock: new SimFixedClock(publishedAt) }).cloudWatch();
+}
+
+describe("SimCloudWatch PutMetricData", () => {
+  it("records a plain value and reads it back as statistics", async () => {
+    // Given a simulated CloudWatch.
+    const metrics = cloudWatch();
+
+    // When a single value is published and the metric is read back.
+    await metrics.putMetricData(
+      new PutMetricDataCommand({
+        Namespace: "Orders",
+        MetricData: [{ MetricName: "Failed", Value: 3, Unit: "Count" }],
+      }),
+    );
+    const read = await metrics.getMetricStatistics(
+      new GetMetricStatisticsCommand({
+        Namespace: "Orders",
+        MetricName: "Failed",
+        Statistics: ["SampleCount", "Sum", "Average", "Minimum", "Maximum"],
+        ...window,
+      }),
+    );
+
+    // Then every statistic is answered from that one observation.
+    const datapoint = read.Datapoints?.at(0);
+
+    assertNonNullable(datapoint);
+    assertIdentical(datapoint.SampleCount, 1);
+    assertIdentical(datapoint.Sum, 3);
+    assertIdentical(datapoint.Average, 3);
+    assertIdentical(datapoint.Minimum, 3);
+    assertIdentical(datapoint.Maximum, 3);
+    assertIdentical(datapoint.Unit, "Count");
+    assertIdentical(read.Label, "Failed");
+  });
+
+  it("stamps a datum carrying no timestamp from the simulation's clock", async () => {
+    // Given a simulated CloudWatch whose clock is stopped part-way through a
+    // minute.
+    const metrics = cloudWatch();
+
+    // When a datum with no Timestamp is published.
+    await metrics.putMetricData(
+      new PutMetricDataCommand({
+        Namespace: "Orders",
+        MetricData: [{ MetricName: "Failed", Value: 1 }],
+      }),
+    );
+
+    // Then it was stamped from the simulation's clock rather than the host's.
+    const metric = metrics.allMetrics().at(0);
+
+    assertNonNullable(metric);
+    assertIdentical(metric.datapoints.at(0)?.timestamp, publishedAt.getTime());
+  });
+
+  it("summarises a statistic set and a set of values with counts", async () => {
+    // Given a simulated CloudWatch.
+    const metrics = cloudWatch();
+
+    // When one metric is published as a summary and another as weighted
+    // values.
+    await metrics.putMetricData(
+      new PutMetricDataCommand({
+        Namespace: "Orders",
+        MetricData: [
+          {
+            MetricName: "Latency",
+            StatisticValues: {
+              SampleCount: 4,
+              Sum: 100,
+              Minimum: 10,
+              Maximum: 40,
+            },
+          },
+          { MetricName: "Size", Values: [2, 5], Counts: [3, 1] },
+        ],
+      }),
+    );
+
+    const summarised = await metrics.getMetricStatistics(
+      new GetMetricStatisticsCommand({
+        Namespace: "Orders",
+        MetricName: "Latency",
+        Statistics: ["Average", "Minimum", "Maximum"],
+        ...window,
+      }),
+    );
+    const weighted = await metrics.getMetricStatistics(
+      new GetMetricStatisticsCommand({
+        Namespace: "Orders",
+        MetricName: "Size",
+        Statistics: ["SampleCount", "Sum"],
+        ...window,
+      }),
+    );
+
+    // Then both forms answer the statistics they describe.
+    const latency = summarised.Datapoints?.at(0);
+    const size = weighted.Datapoints?.at(0);
+
+    assertNonNullable(latency);
+    assertNonNullable(size);
+    assertIdentical(latency.Average, 25);
+    assertIdentical(latency.Minimum, 10);
+    assertIdentical(latency.Maximum, 40);
+    assertIdentical(size.SampleCount, 4);
+    assertIdentical(size.Sum, 11);
+  });
+
+  it("refuses to publish into a namespace AWS reserves", async () => {
+    // Given a simulated CloudWatch.
+    const metrics = cloudWatch();
+
+    // When a datum is published into an AWS namespace.
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await metrics.putMetricData(
+          new PutMetricDataCommand({
+            Namespace: "AWS/Lambda",
+            MetricData: [{ MetricName: "Invocations", Value: 1 }],
+          }),
+        ),
+    );
+
+    // Then it is refused, as real CloudWatch refuses it.
+    assertInstanceOf(error, SimCloudWatchInvalidParameterValueException);
+    assertIdentical(error.name, "InvalidParameterValueException");
+    assertArrayLength(metrics.allMetrics(), 0);
+  });
+
+  it("refuses a datum stating its values in no way, or in two", async () => {
+    // Given a simulated CloudWatch.
+    const metrics = cloudWatch();
+
+    // When a datum carries neither a value nor a summary, and another carries
+    // both.
+    const neither = await assertThrowsErrorAsync(
+      async () =>
+        await metrics.putMetricData(
+          new PutMetricDataCommand({
+            Namespace: "Orders",
+            MetricData: [{ MetricName: "Failed" }],
+          }),
+        ),
+    );
+    const both = await assertThrowsErrorAsync(
+      async () =>
+        await metrics.putMetricData(
+          new PutMetricDataCommand({
+            Namespace: "Orders",
+            MetricData: [{ MetricName: "Failed", Value: 1, Values: [1, 2] }],
+          }),
+        ),
+    );
+
+    // Then each is refused for the reason real CloudWatch gives.
+    assertInstanceOf(neither, SimCloudWatchMissingRequiredParameterException);
+    assertInstanceOf(both, SimCloudWatchInvalidParameterCombinationException);
+  });
+
+  it("refuses a high-resolution metric rather than storing it as standard", async () => {
+    // Given a simulated CloudWatch.
+    const metrics = cloudWatch();
+
+    // When a datum asks for one second storage resolution.
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await metrics.putMetricData(
+          new PutMetricDataCommand({
+            Namespace: "Orders",
+            MetricData: [
+              { MetricName: "Failed", Value: 1, StorageResolution: 1 },
+            ],
+          }),
+        ),
+    );
+
+    // Then it says so rather than storing it at a resolution it does not have.
+    assertInstanceOf(error, SimCloudWatchInvalidParameterValueException);
+  });
+
+  it("records nothing at all when one datum in a request is refused", async () => {
+    // Given a simulated CloudWatch.
+    const metrics = cloudWatch();
+
+    // When a request carries a good datum and a bad one.
+    await assertThrowsErrorAsync(
+      async () =>
+        await metrics.putMetricData(
+          new PutMetricDataCommand({
+            Namespace: "Orders",
+            MetricData: [
+              { MetricName: "Failed", Value: 1 },
+              { MetricName: "Failed", Value: NaN },
+            ],
+          }),
+        ),
+    );
+
+    // Then neither was stored, as real CloudWatch validates the whole request.
+    assertArrayLength(metrics.allMetrics(), 0);
+  });
+});

--- a/src/service/cloudwatch/sim-cloudwatch.ts
+++ b/src/service/cloudwatch/sim-cloudwatch.ts
@@ -1,0 +1,91 @@
+import type { SimSdkCommandRouter } from "../../sdk/router/sim-sdk-command-router.type.js";
+import type * as simCloudWatchCommands from "./command/sim-cloudwatch-command.types.js";
+import type { SimCloudWatchRequestOptions } from "./command/sim-cloudwatch-request-options.js";
+import type { SimCloudWatchMetric } from "./metric/sim-cloudwatch-metric.js";
+import { SimCloudWatchSdkCommandRouter } from "./sdk/sim-cloudwatch-sdk-command-router.js";
+import {
+  SimCloudWatchCommands,
+  type SimCloudWatchProperties,
+} from "./sim-cloudwatch-commands.js";
+
+/**
+ * Simulated CloudWatch metrics. Handles SDK commands. Emulates AWS behaviour
+ * and state.
+ *
+ * Metrics are scoped to an account and region, as they are on real AWS: a
+ * metric published in one region is invisible from another, and there is no
+ * ARN to reach one across the boundary.
+ *
+ * Only custom metrics live here. Nothing in this simulation publishes into the
+ * `AWS/` namespaces, so a query for `AWS/Lambda` `Invocations` finds nothing
+ * rather than a number that was never measured.
+ */
+export class SimCloudWatch {
+  readonly #commands: SimCloudWatchCommands;
+  readonly #sdkRouter = new SimCloudWatchSdkCommandRouter(this);
+
+  constructor(properties: SimCloudWatchProperties = {}) {
+    this.#commands = new SimCloudWatchCommands(properties);
+  }
+
+  /**
+   * Every metric in this scope, in the order each was first written to.
+   *
+   * This is the simulator's own accessor, for tests inspecting metric state
+   * without going through a Command and its authorization.
+   */
+  allMetrics(): readonly SimCloudWatchMetric[] {
+    return this.#commands.metrics.all;
+  }
+
+  /**
+   * Handle a PutMetricData Command from the SDK.
+   */
+  async putMetricData(
+    command: simCloudWatchCommands.SimPutMetricDataCommand,
+    options?: SimCloudWatchRequestOptions,
+  ): Promise<simCloudWatchCommands.SimPutMetricDataCommandOutput> {
+    await this.#commands.background.sequence();
+    return this.#commands.putMetricData.handle(command, options);
+  }
+
+  /**
+   * Handle a ListMetrics Command from the SDK.
+   */
+  async listMetrics(
+    command: simCloudWatchCommands.SimListMetricsCommand,
+    options?: SimCloudWatchRequestOptions,
+  ): Promise<simCloudWatchCommands.SimListMetricsCommandOutput> {
+    await this.#commands.background.sequence();
+    return this.#commands.listMetrics.handle(command, options);
+  }
+
+  /**
+   * Handle a GetMetricStatistics Command from the SDK.
+   */
+  async getMetricStatistics(
+    command: simCloudWatchCommands.SimGetMetricStatisticsCommand,
+    options?: SimCloudWatchRequestOptions,
+  ): Promise<simCloudWatchCommands.SimGetMetricStatisticsCommandOutput> {
+    await this.#commands.background.sequence();
+    return this.#commands.getMetricStatistics.handle(command, options);
+  }
+
+  /**
+   * Handle a GetMetricData Command from the SDK.
+   */
+  async getMetricData(
+    command: simCloudWatchCommands.SimGetMetricDataCommand,
+    options?: SimCloudWatchRequestOptions,
+  ): Promise<simCloudWatchCommands.SimGetMetricDataCommandOutput> {
+    await this.#commands.background.sequence();
+    return this.#commands.getMetricData.handle(command, options);
+  }
+
+  /**
+   * Get this service's SDK Command router for SDK client interception.
+   */
+  sdkCommandRouter(): SimSdkCommandRouter {
+    return this.#sdkRouter;
+  }
+}


### PR DESCRIPTION
Adds a simulated CloudWatch metrics service on a `cloudWatch()` accessor, covering `PutMetricData`, `ListMetrics`, `GetMetricStatistics` and the `MetricStat` form of `GetMetricData`, so a test can assert on the business metrics its own code publishes rather than on whether an SDK client was called. A metric is identified by its namespace, its name and its exact dimension set together, and nothing rolls up across dimensions, which is what real CloudWatch does and the thing teams most often get wrong on a dashboard. Metrics integrate with simulated time on both sides: a datum carrying no `Timestamp` is stamped from the simulation's clock, and `ListMetrics` measures `RecentlyActive` against it, so a test decides which period an observation lands in without waiting. Input real CloudWatch would accept but this does not carry out, namely metric math, extended statistics, high-resolution storage, `MaxDatapoints` and cross-account listing, is refused with a message saying it is not simulated rather than accepted and ignored. IAM authorizes every action against `*` because metrics have no ARN, with `cloudwatch:namespace` supplied on publish as the one way a policy can narrow it.

Resolves https://github.com/KensioSoftware/yulin/issues/622

Two judgement calls worth a reviewer's eye. Timestamps are not range-checked, where real CloudWatch rejects a datapoint more than two weeks old or two hours in the future; that follows what simulated `PutLogEvents` already does, so a test can seed a window without arranging the clock around it, and it is documented as a deliberate divergence rather than left silent. And `SimCloudWatchInvalidParameterValueException` does double duty for both real refusals and unsimulated input, because CloudWatch has no `UnsupportedOperationException` of its own, unlike CloudWatch Logs, so reusing it follows what simulated SSM does instead of inventing an error name the SDK has never seen.

Alarms and `AWS::CloudWatch::Alarm` are follow-on work, tracked as #623 and #624.

- [x] Conventional commit message, used as the title

- [x] Conventional branch name, like `feat/concise-description`
- [x] Full check with `pnpm run check` passed
- [x] Rebased off latest main
- [x] User-facing behaviour is documented in `docs/`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a simulated CloudWatch service for publishing and querying custom metrics.
  * Added support for metric listing, statistics, dimensions, period-based aggregation, and simulated-time timestamps.
  * Added IAM authorization, including namespace-scoped permissions.
  * Added SDK integration for supported CloudWatch operations.
* **Documentation**
  * Added CloudWatch service documentation, examples, usage guidance, and supported-operation details.
* **Validation**
  * Added CloudWatch-compatible validation and errors for invalid metrics, queries, periods, namespaces, and unsupported options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->