### PR TITLE
feat: evaluate CloudWatch alarms and notify an SNS topic

### DIFF
--- a/docs/services/cloudwatch/README.md
+++ b/docs/services/cloudwatch/README.md
@@ -1,8 +1,9 @@
-# Simulated CloudWatch metrics
+# Simulated CloudWatch metrics and alarms
 
 Yulin includes a simulated Amazon CloudWatch for tests and local development. It holds custom
 metrics: the datapoints `PutMetricData` publishes, and the statistics `GetMetricStatistics` and
-`GetMetricData` read back from them, without an AWS account.
+`GetMetricData` read back from them, without an AWS account. It also holds alarms over those
+metrics, which evaluate on the simulation's clock and notify an SNS topic when they change state.
 
 That is what this service is for. Code that publishes a business metric is code teams already have,
 and until now the only way to test it was to assert that the SDK client had been called, which
@@ -143,12 +144,127 @@ console.log(read.MetricDataResults?.at(0)?.Values);
 `ListMetrics` reads `RecentlyActive: "PT3H"` against the same clock, so advancing time past the
 window drops a metric out of the listing without anything having to expire it.
 
+## Alarms
+
+An alarm watches one metric and changes state on the simulation's clock. Nothing here uses a real
+timer: each evaluation is scheduled at the next period boundary, so a frozen clock evaluates nothing
+and advancing time by twenty minutes walks twenty one-minute evaluations and settles before the next
+line of the test runs.
+
+```typescript sim-cloudwatch-alarm
+/**
+ * An alarm that fires into an SNS topic once two of three minutes breach.
+ */
+
+import {
+  DescribeAlarmsCommand,
+  PutMetricAlarmCommand,
+  PutMetricDataCommand,
+} from "@aws-sdk/client-cloudwatch";
+import { CreateTopicCommand } from "@aws-sdk/client-sns";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const metrics = simAws.cloudWatch();
+
+await simAws.clock().setTo(new Date("2026-08-16T09:00:00.000Z"));
+
+const topic = await simAws
+  .sns()
+  .createTopic(new CreateTopicCommand({ Name: "orders-alerts" }));
+
+await metrics.putMetricAlarm(
+  new PutMetricAlarmCommand({
+    AlarmName: "OrdersFailing",
+    Namespace: "Orders",
+    MetricName: "Failed",
+    Statistic: "Sum",
+    Period: 60,
+    EvaluationPeriods: 3,
+    DatapointsToAlarm: 2,
+    Threshold: 5,
+    ComparisonOperator: "GreaterThanThreshold",
+    AlarmActions: [String(topic.TopicArn)],
+  }),
+);
+
+// Two breaching minutes, without waiting two real minutes.
+for (let minute = 0; minute < 2; minute++) {
+  await metrics.putMetricData(
+    new PutMetricDataCommand({
+      Namespace: "Orders",
+      MetricData: [{ MetricName: "Failed", Value: 10 }],
+    }),
+  );
+  await simAws.clock().advanceBy({ minutes: 1 });
+}
+
+const described = await metrics.describeAlarms(
+  new DescribeAlarmsCommand({ AlarmNames: ["OrdersFailing"] }),
+);
+
+// "ALARM", and anything subscribed to the topic has the notification.
+console.log(described.MetricAlarms?.at(0)?.StateValue);
+```
+
+A new alarm is in `INSUFFICIENT_DATA` until it has evaluated a period, as on real CloudWatch. The
+window it looks back over reaches behind the moment the alarm was created, so an alarm over a metric
+nothing publishes into, with `TreatMissingData: "breaching"`, fires on its first evaluation rather
+than waiting for the periods to accumulate. That is what an account does too.
+
+### Reaching a subscriber
+
+An alarm notifies through the ordinary `Publish` path, so a notification fans out to the topic's
+subscriptions exactly as an SDK caller's message would, with the JSON body real CloudWatch sends:
+`AlarmName`, `NewStateValue`, `OldStateValue`, `NewStateReason`, `StateChangeTime` and `Trigger`.
+Only a change fires anything, so an alarm that stays in `ALARM` across ten periods notifies once.
+
+`SetAlarmState` forces a transition and fires its actions, which is how a test exercises a
+subscriber without arranging for a metric to breach at all.
+
+The topic has to be in the same account and region as the alarm, as real CloudWatch requires. An
+action that reaches nothing is recorded rather than passing quietly:
+
+```typescript sim-cloudwatch-alarm-failures
+/**
+ * Finding out that an alarm action reached nothing.
+ */
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+// ...after an alarm with a bad action ARN has fired:
+for (const failure of simAws.cloudWatch().alarmActionFailures) {
+  console.log(failure.alarmName, failure.actionArn, failure.reason);
+}
+```
+
+Real CloudWatch tells nobody when an alarm action fails, and neither does this: the alarm changes
+state either way. Keeping the failure is what stops a subscriber's queue being mysteriously empty.
+
+### What an alarm can watch and do
+
+- The four threshold comparison operators, `DatapointsToAlarm` for M-of-N evaluation, and all four
+  `TreatMissingData` treatments including `ignore`, which leaves the alarm where it is.
+- `ActionsEnabled: false` still evaluates and records state; it just publishes nothing.
+- `DescribeAlarmHistory` reports the state changes with the simulated time each happened at.
+- An SNS topic ARN is the only action target. Auto Scaling, EC2, Systems Manager and Lambda actions
+  are refused rather than stored and ignored, because an alarm that fired and did nothing would let
+  a test pass while the thing the alarm exists to do never happened.
+- Composite alarms, anomaly detection and metric math alarms are all refused.
+
 ## Permissions
 
-CloudWatch metrics have no ARN, so there is nothing for a policy to name: every action here is
+CloudWatch metrics have no ARN, so there is nothing for a policy to name: every metric action here is
 granted on `*`. A policy written against something like
 `arn:aws:cloudwatch:eu-west-2:111111111111:metric/Orders/Failed` reaches nothing, here and in an
 account.
+
+Alarms are the exception, and do have an ARN. `PutMetricAlarm`, `DeleteAlarms` and `SetAlarmState`
+authorize against `arn:aws:cloudwatch:<region>:<account>:alarm:<name>`, while `DescribeAlarms` and
+`DescribeAlarmHistory` take no resource-level permission at all, exactly as on real CloudWatch.
 
 The one way to narrow publishing is the `cloudwatch:namespace` condition key:
 
@@ -216,7 +332,10 @@ await simAws.cloudWatch().putMetricData(
 - `GetMetricStatistics`, with `SampleCount`, `Average`, `Sum`, `Minimum` and `Maximum` over periods
   of a whole number of minutes, filtered by `Unit`.
 - `GetMetricData`, with `MetricStat` queries, `ScanBy` and `ReturnData`.
-- IAM authorization on each action, including the `cloudwatch:namespace` condition key.
+- `PutMetricAlarm`, `DescribeAlarms`, `DeleteAlarms`, `SetAlarmState` and `DescribeAlarmHistory`,
+  with evaluation on the simulation's clock and SNS notifications on a state change.
+- IAM authorization on each action, including the `cloudwatch:namespace` condition key and
+  alarm-ARN resources.
 
 ## What is not, and how it says so
 
@@ -224,7 +343,8 @@ Anything real CloudWatch would accept and this does not carry out is refused wit
 so, rather than accepted and ignored. A silently dropped filter is worse than a failure, because the
 test still passes and no longer means what it says.
 
-- **Alarms.** Nothing here evaluates a threshold or fires an action yet.
+- **Composite and anomaly detection alarms.** `Metrics` and `ThresholdMetricId` on `PutMetricAlarm`
+  are refused; there is no trained model here for an anomaly band to come from.
 - **Metric math.** A `GetMetricData` query carrying an `Expression` is refused.
 - **Percentiles and other extended statistics.** They need the individual values behind a period,
   which a `StatisticValues` datum never carries, so CloudWatch itself cannot report one for a metric

--- a/docs/services/cloudwatch/sim-cloudwatch-alarm-failures.example.ts
+++ b/docs/services/cloudwatch/sim-cloudwatch-alarm-failures.example.ts
@@ -1,0 +1,12 @@
+/**
+ * Finding out that an alarm action reached nothing.
+ */
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+// ...after an alarm with a bad action ARN has fired:
+for (const failure of simAws.cloudWatch().alarmActionFailures) {
+  console.log(failure.alarmName, failure.actionArn, failure.reason);
+}

--- a/docs/services/cloudwatch/sim-cloudwatch-alarm.example.ts
+++ b/docs/services/cloudwatch/sim-cloudwatch-alarm.example.ts
@@ -1,0 +1,54 @@
+/**
+ * An alarm that fires into an SNS topic once two of three minutes breach.
+ */
+
+import {
+  DescribeAlarmsCommand,
+  PutMetricAlarmCommand,
+  PutMetricDataCommand,
+} from "@aws-sdk/client-cloudwatch";
+import { CreateTopicCommand } from "@aws-sdk/client-sns";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const metrics = simAws.cloudWatch();
+
+await simAws.clock().setTo(new Date("2026-08-16T09:00:00.000Z"));
+
+const topic = await simAws
+  .sns()
+  .createTopic(new CreateTopicCommand({ Name: "orders-alerts" }));
+
+await metrics.putMetricAlarm(
+  new PutMetricAlarmCommand({
+    AlarmName: "OrdersFailing",
+    Namespace: "Orders",
+    MetricName: "Failed",
+    Statistic: "Sum",
+    Period: 60,
+    EvaluationPeriods: 3,
+    DatapointsToAlarm: 2,
+    Threshold: 5,
+    ComparisonOperator: "GreaterThanThreshold",
+    AlarmActions: [String(topic.TopicArn)],
+  }),
+);
+
+// Two breaching minutes, without waiting two real minutes.
+for (let minute = 0; minute < 2; minute++) {
+  await metrics.putMetricData(
+    new PutMetricDataCommand({
+      Namespace: "Orders",
+      MetricData: [{ MetricName: "Failed", Value: 10 }],
+    }),
+  );
+  await simAws.clock().advanceBy({ minutes: 1 });
+}
+
+const described = await metrics.describeAlarms(
+  new DescribeAlarmsCommand({ AlarmNames: ["OrdersFailing"] }),
+);
+
+// "ALARM", and anything subscribed to the topic has the notification.
+console.log(described.MetricAlarms?.at(0)?.StateValue);

--- a/src/service/aws/factory/sim-aws-account-region-service-builder.ts
+++ b/src/service/aws/factory/sim-aws-account-region-service-builder.ts
@@ -4,24 +4,19 @@ import type {
 } from "../../../util/background/background.js";
 import type { SimAwsAccountRegionContainer } from "../sim-aws-account-region-scope.js";
 import type { SimAws } from "../sim-aws.js";
-import { SimAcm } from "../../acm/sim-acm.js";
-import { SimApiGatewayV2 } from "../../apigatewayv2/index.js";
 import {
-  simAwsAcmDnsRecords,
   simAwsEventBridgeDeliveryTargets,
-  simAwsHttpApiJwtIssuerKeys,
   simAwsRekognitionImages,
   simAwsSchedulerDeliveryTargets,
 } from "./sim-aws-cross-account-collaborators.js";
 import { SimCloudFormation } from "../../cloudformation/index.js";
+import { SimCloudWatch } from "../../cloudwatch/index.js";
+import { simAwsCloudWatchCollaborators } from "./sim-aws-cloudwatch-collaborators.js";
 import { SimCognitoIdentityProvider } from "../../cognito/index.js";
-import { SimEcr } from "../../ecr/index.js";
 import { SimEcs } from "../../ecs/index.js";
 import { simAwsCognitoTriggerFunctions } from "../../cognito/user-pool/trigger/sim-aws-cognito-trigger-functions.js";
-import { SimElbV2 } from "../../elbv2/index.js";
 import { SimEventBridge } from "../../eventbridge/index.js";
 import type { SimIamRegistry } from "../../iam/registry/sim-iam-registry.js";
-import { SimKms } from "../../kms/index.js";
 import { SimLambda } from "../../lambda/index.js";
 import { SimLogs } from "../../logs/index.js";
 import { simAwsLogsCollaborators } from "./sim-aws-logs-collaborators.js";
@@ -88,37 +83,27 @@ export class SimAwsAccountRegionServiceBuilder {
   }
 
   /** Create simulated ACM for an Account Region scope. */
-  createAcm(scope: SimAwsAccountRegionContainer): SimAcm {
-    const acm = new SimAcm({
-      ...this.scoped(scope),
-      dnsRecords: simAwsAcmDnsRecords(this.registries),
-    });
-    this.registries.acm.register(scope.accountRegionScope, acm);
-
-    return acm;
-  }
-
-  /**
-   * Create simulated API Gateway v2 for an Account Region scope.
-   *
-   * HTTP APIs are Region-scoped on real AWS: the endpoint API Gateway
-   * generates names the Region, and an API cannot be reached from another one.
-   */
-  createApiGatewayV2(scope: SimAwsAccountRegionContainer): SimApiGatewayV2 {
-    return new SimApiGatewayV2({
-      ...this.scoped(scope),
-      // API ids are unique across the simulation, and an API is reachable by
-      // id alone from the serving layer, whichever scope created it.
-      registry: this.registries.httpApi,
-      jwtIssuerKeys: simAwsHttpApiJwtIssuerKeys(this.registries),
-    });
-  }
-
   /** Create simulated CloudFormation for an Account Region scope. */
   createCloudFormation(scope: SimAwsAccountRegionContainer): SimCloudFormation {
     return new SimCloudFormation({
       ...this.scoped(scope),
       simAws: this.simAws,
+    });
+  }
+
+  /**
+   * Create simulated CloudWatch metrics and alarms for an Account Region
+   * scope.
+   *
+   * Metrics are Region-scoped on real AWS: a metric published in one Region is
+   * invisible from another, and there is no ARN by which to reach one across
+   * the boundary. An alarm's SNS topic has to be in that Region too, which is
+   * what this reaches the rest of the simulation for.
+   */
+  createCloudWatch(scope: SimAwsAccountRegionContainer): SimCloudWatch {
+    return new SimCloudWatch({
+      ...this.scoped(scope),
+      ...simAwsCloudWatchCollaborators(this.simAws, scope.accountRegionScope),
     });
   }
 
@@ -136,21 +121,6 @@ export class SimAwsAccountRegionServiceBuilder {
       userPoolRegistry: this.registries.cognito,
       domainRegistry: this.registries.cognitoDomains,
       triggerFunctions: simAwsCognitoTriggerFunctions(this.simAws),
-    });
-  }
-
-  /**
-   * Create simulated ECR for an Account Region scope.
-   *
-   * Repositories are Region-scoped on real AWS: a repository ARN names the
-   * Region, and the registry host in an image URI carries the Account and the
-   * Region both. It is registered because a container image function holds
-   * nothing but that URI, and the function need not be in this scope.
-   */
-  createEcr(scope: SimAwsAccountRegionContainer): SimEcr {
-    return new SimEcr({
-      accountRegionScope: scope.accountRegionScope,
-      registry: this.registries.ecr,
     });
   }
 
@@ -173,31 +143,6 @@ export class SimAwsAccountRegionServiceBuilder {
       ...this.scoped(scope),
       deliveryTargets: simAwsEventBridgeDeliveryTargets(this.simAws),
     });
-  }
-
-  /**
-   * Create simulated Elastic Load Balancing v2 for an Account Region scope.
-   *
-   * The registries are the hops from a name to a scope: a load balancer's DNS
-   * name to the Account holding it, and a listener's certificate ARN to ACM.
-   */
-  createElbV2(scope: SimAwsAccountRegionContainer): SimElbV2 {
-    const { elbV2: registry, acm: acmRegistry } = this.registries;
-
-    return new SimElbV2({ ...this.scoped(scope), registry, acmRegistry });
-  }
-
-  /**
-   * Create simulated KMS for an Account Region scope.
-   *
-   * KMS keys are Region-scoped on real AWS: a key ARN names its Region, and a
-   * ciphertext produced in one Region cannot be decrypted in another. That is
-   * why it is registered: a key ARN carries the Region another service needs.
-   */
-  createKms(scope: SimAwsAccountRegionContainer): SimKms {
-    const kms = new SimKms(this.scoped(scope));
-    this.registries.kms.register(scope.accountRegionScope, kms);
-    return kms;
   }
 
   /** Create simulated CloudWatch Logs for an Account Region scope. */

--- a/src/service/aws/factory/sim-aws-cloudwatch-collaborators.ts
+++ b/src/service/aws/factory/sim-aws-cloudwatch-collaborators.ts
@@ -1,0 +1,33 @@
+import { SimAwsCloudWatchAlarmTopics } from "../../cloudwatch/alarm/action/sim-aws-cloudwatch-alarm-topics.js";
+import type { SimCloudWatchAlarmTargets } from "../../cloudwatch/alarm/action/sim-cloudwatch-alarm-targets.js";
+import type { SimAwsAccountRegionScope } from "../sim-aws-account-region-scope.js";
+import type { SimAws } from "../sim-aws.js";
+
+/**
+ * What simulated CloudWatch reaches for in the rest of the simulation.
+ */
+interface SimAwsCloudWatchCollaborators {
+  readonly alarmTargets: SimCloudWatchAlarmTargets;
+}
+
+/**
+ * Build the collaborators simulated CloudWatch takes beyond the scoped ones
+ * every service gets.
+ *
+ * An alarm notifies an SNS topic, which real CloudWatch requires to be in the
+ * same Account and Region as the alarm, so the scope is passed in for the
+ * topic to be checked against. The topic is looked up when the alarm fires
+ * rather than now, so that an alarm can name a topic created after it, and so
+ * that building CloudWatch never reaches another service as it is built.
+ */
+export function simAwsCloudWatchCollaborators(
+  simAws: SimAws,
+  accountRegionScope: SimAwsAccountRegionScope,
+): SimAwsCloudWatchCollaborators {
+  return {
+    alarmTargets: new SimAwsCloudWatchAlarmTopics({
+      simAws,
+      accountRegionScope,
+    }),
+  };
+}

--- a/src/service/aws/factory/sim-aws-registered-service-builder.ts
+++ b/src/service/aws/factory/sim-aws-registered-service-builder.ts
@@ -1,0 +1,119 @@
+import type { SimAwsAccountRegionContainer } from "../sim-aws-account-region-scope.js";
+import { SimAcm } from "../../acm/sim-acm.js";
+import { SimApiGatewayV2 } from "../../apigatewayv2/index.js";
+import {
+  simAwsAcmDnsRecords,
+  simAwsHttpApiJwtIssuerKeys,
+} from "./sim-aws-cross-account-collaborators.js";
+import { SimEcr } from "../../ecr/index.js";
+import { SimElbV2 } from "../../elbv2/index.js";
+import { SimKms } from "../../kms/index.js";
+import type { SimAwsAccountServiceCache } from "./sim-aws-account-service-cache.js";
+import type { SimAwsScopedServiceProperties } from "./sim-aws-scoped-service-properties.js";
+import type { SimAwsScopedServiceRegistries } from "./sim-aws-scoped-service-registries.js";
+
+interface SimAwsRegisteredServiceBuilderProperties {
+  readonly registries: SimAwsScopedServiceRegistries;
+  readonly accountServices: SimAwsAccountServiceCache;
+}
+
+/**
+ * Builder for the simulated services whose wiring is a simulation-wide
+ * registry.
+ *
+ * These are the services something outside their own scope has to find by a
+ * name that carries no scope: a load balancer's DNS name, an API id, the
+ * registry host in an image URI, a KMS key ARN. Each registers itself as it is
+ * built, or reads a registry another service registered into, and takes
+ * nothing else beyond the collaborators every scoped service gets.
+ *
+ * That is what keeps them apart from SimAwsAccountRegionServiceBuilder, which
+ * is left holding the services that reach the rest of the simulation for
+ * something live rather than for a lookup. Both grow by one method per
+ * simulated service, and that file has twice now been at its line limit with a
+ * service waiting to go into it.
+ */
+export class SimAwsRegisteredServiceBuilder {
+  private readonly registries: SimAwsScopedServiceRegistries;
+  private readonly accountServices: SimAwsAccountServiceCache;
+
+  constructor(properties: SimAwsRegisteredServiceBuilderProperties) {
+    this.registries = properties.registries;
+    this.accountServices = properties.accountServices;
+  }
+
+  createAcm(scope: SimAwsAccountRegionContainer): SimAcm {
+    const acm = new SimAcm({
+      ...this.scoped(scope),
+      dnsRecords: simAwsAcmDnsRecords(this.registries),
+    });
+    this.registries.acm.register(scope.accountRegionScope, acm);
+
+    return acm;
+  }
+
+  /**
+   * Create simulated API Gateway v2 for an Account Region scope.
+   *
+   * HTTP APIs are Region-scoped on real AWS: the endpoint API Gateway
+   * generates names the Region, and an API cannot be reached from another one.
+   */
+  createApiGatewayV2(scope: SimAwsAccountRegionContainer): SimApiGatewayV2 {
+    return new SimApiGatewayV2({
+      ...this.scoped(scope),
+      // API ids are unique across the simulation, and an API is reachable by
+      // id alone from the serving layer, whichever scope created it.
+      registry: this.registries.httpApi,
+      jwtIssuerKeys: simAwsHttpApiJwtIssuerKeys(this.registries),
+    });
+  }
+
+  /**
+   * Create simulated ECR for an Account Region scope.
+   *
+   * Repositories are Region-scoped on real AWS: a repository ARN names the
+   * Region, and the registry host in an image URI carries the Account and the
+   * Region both. It is registered because a container image function holds
+   * nothing but that URI, and the function need not be in this scope.
+   */
+  createEcr(scope: SimAwsAccountRegionContainer): SimEcr {
+    return new SimEcr({
+      accountRegionScope: scope.accountRegionScope,
+      registry: this.registries.ecr,
+    });
+  }
+
+  /**
+   * Create simulated Elastic Load Balancing v2 for an Account Region scope.
+   *
+   * The registries are the hops from a name to a scope: a load balancer's DNS
+   * name to the Account holding it, and a listener's certificate ARN to ACM.
+   */
+  createElbV2(scope: SimAwsAccountRegionContainer): SimElbV2 {
+    const { elbV2: registry, acm: acmRegistry } = this.registries;
+
+    return new SimElbV2({ ...this.scoped(scope), registry, acmRegistry });
+  }
+
+  /**
+   * Create simulated KMS for an Account Region scope.
+   *
+   * KMS keys are Region-scoped on real AWS: a key ARN names its Region, and a
+   * ciphertext produced in one Region cannot be decrypted in another. That is
+   * why it is registered: a key ARN carries the Region another service needs.
+   */
+  createKms(scope: SimAwsAccountRegionContainer): SimKms {
+    const kms = new SimKms(this.scoped(scope));
+    this.registries.kms.register(scope.accountRegionScope, kms);
+    return kms;
+  }
+
+  /**
+   * The collaborators every service built here takes.
+   */
+  private scoped(
+    scope: SimAwsAccountRegionContainer,
+  ): SimAwsScopedServiceProperties {
+    return this.accountServices.scopedServiceProperties(scope);
+  }
+}

--- a/src/service/aws/factory/sim-aws-self-contained-service-builder.ts
+++ b/src/service/aws/factory/sim-aws-self-contained-service-builder.ts
@@ -1,5 +1,4 @@
 import type { SimAwsAccountRegionContainer } from "../sim-aws-account-region-scope.js";
-import { SimCloudWatch } from "../../cloudwatch/index.js";
 import { SimDynamoDb as SimDynamoDatabase } from "../../dynamodb/index.js";
 import { SimSecretsManager } from "../../secretsmanager/index.js";
 import { SimSqs } from "../../sqs/index.js";
@@ -31,17 +30,6 @@ export class SimAwsSelfContainedServiceBuilder {
 
   constructor(properties: SimAwsSelfContainedServiceBuilderProperties) {
     this.accountServices = properties.accountServices;
-  }
-
-  /**
-   * Create simulated CloudWatch metrics for an Account Region scope.
-   *
-   * Metrics are Region-scoped on real AWS: a metric published in one Region is
-   * invisible from another, and there is no ARN by which to reach one across
-   * the boundary.
-   */
-  createCloudWatch(scope: SimAwsAccountRegionContainer): SimCloudWatch {
-    return new SimCloudWatch(this.scoped(scope));
   }
 
   /** Create simulated DynamoDB for an Account Region scope. */

--- a/src/service/aws/factory/sim-aws-service-factory.ts
+++ b/src/service/aws/factory/sim-aws-service-factory.ts
@@ -34,6 +34,7 @@ import type { SimSqs } from "../../sqs/index.js";
 import type { SimSsm } from "../../ssm/index.js";
 import type { SimSts } from "../../sts/sim-sts.js";
 import { SimAwsAccountRegionServiceBuilder } from "./sim-aws-account-region-service-builder.js";
+import { SimAwsRegisteredServiceBuilder } from "./sim-aws-registered-service-builder.js";
 import { SimAwsSelfContainedServiceBuilder } from "./sim-aws-self-contained-service-builder.js";
 import { SimAwsAccountServiceCache } from "./sim-aws-account-service-cache.js";
 import { SimAwsRequestAuthWiring } from "./sim-aws-request-auth-wiring.js";
@@ -103,6 +104,7 @@ export class SimAwsServiceFactory {
 
   private readonly accountServices: SimAwsAccountServiceCache;
   private readonly accountRegionServices: SimAwsAccountRegionServiceBuilder;
+  private readonly registeredServices: SimAwsRegisteredServiceBuilder;
   private readonly selfContainedServices: SimAwsSelfContainedServiceBuilder;
 
   constructor(properties: SimAwsServiceFactoryProperties) {
@@ -125,6 +127,10 @@ export class SimAwsServiceFactory {
       registries: this.registries,
       iamRegistry: this.iamRegistry,
       lambdaUrlRegistry: this.lambdaUrlRegistry,
+      accountServices: this.accountServices,
+    });
+    this.registeredServices = new SimAwsRegisteredServiceBuilder({
+      registries: this.registries,
       accountServices: this.accountServices,
     });
     this.selfContainedServices = new SimAwsSelfContainedServiceBuilder({
@@ -158,12 +164,12 @@ export class SimAwsServiceFactory {
 
   /** Create simulated ACM for an Account Region scope. */
   createAcm(scope: SimAwsAccountRegionContainer): SimAcm {
-    return this.accountRegionServices.createAcm(scope);
+    return this.registeredServices.createAcm(scope);
   }
 
   /** Create simulated API Gateway v2 for an Account Region scope. */
   createApiGatewayV2(scope: SimAwsAccountRegionContainer): SimApiGatewayV2 {
-    return this.accountRegionServices.createApiGatewayV2(scope);
+    return this.registeredServices.createApiGatewayV2(scope);
   }
 
   /** Create simulated CloudFormation for an Account Region scope. */
@@ -183,9 +189,9 @@ export class SimAwsServiceFactory {
     return this.accountRegionServices.createCognitoIdentityProvider(scope);
   }
 
-  /** Create simulated CloudWatch metrics for an Account Region scope. */
+  /** Create simulated CloudWatch metrics and alarms for an Account Region scope. */
   createCloudWatch(scope: SimAwsAccountRegionContainer): SimCloudWatch {
-    return this.selfContainedServices.createCloudWatch(scope);
+    return this.accountRegionServices.createCloudWatch(scope);
   }
 
   /** Create simulated DynamoDB for an Account Region scope. */
@@ -195,7 +201,7 @@ export class SimAwsServiceFactory {
 
   /** Create simulated ECR for an Account Region scope. */
   createEcr(scope: SimAwsAccountRegionContainer): SimEcr {
-    return this.accountRegionServices.createEcr(scope);
+    return this.registeredServices.createEcr(scope);
   }
 
   /** Create simulated ECS for an Account Region scope. */
@@ -210,7 +216,7 @@ export class SimAwsServiceFactory {
 
   /** Create simulated Elastic Load Balancing v2 for an Account Region scope. */
   createElbV2(scope: SimAwsAccountRegionContainer): SimElbV2 {
-    return this.accountRegionServices.createElbV2(scope);
+    return this.registeredServices.createElbV2(scope);
   }
 
   /** Create or get simulated IAM for an Account scope. */
@@ -220,7 +226,7 @@ export class SimAwsServiceFactory {
 
   /** Create simulated KMS for an Account Region scope. */
   createKms(scope: SimAwsAccountRegionContainer): SimKms {
-    return this.accountRegionServices.createKms(scope);
+    return this.registeredServices.createKms(scope);
   }
 
   /** Create simulated Lambda for an Account Region scope. */

--- a/src/service/cloudwatch/README.md
+++ b/src/service/cloudwatch/README.md
@@ -8,8 +8,10 @@ set together. Real CloudWatch does not roll a custom metric up across dimensions
 is what makes a test here worth writing: a query naming no dimensions reaches the metric published
 with none, not the total of every channel, which is exactly the mistake teams make on a dashboard.
 
-Alarms are not here. They are follow-on work, and they will need something this service does not
-have yet: a schedule on the simulation's clock.
+Alarms are here too, under `alarm/`. The decision that shapes them is that nothing uses a real
+timer: each alarm's next evaluation is scheduled on the background scheduler at the next period
+boundary, and every evaluation schedules the one after it. A frozen clock therefore evaluates
+nothing, and advancing time walks one evaluation per period and settles before the call returns.
 
 ## Entry points
 
@@ -61,12 +63,38 @@ period a test is likely to ask for.
 
 A window includes its start and excludes its end, which is how real CloudWatch reads the two.
 
+## Alarms
+
+`SimCloudWatchAlarmSchedule` owns the clock side. Each alarm keeps one task for its whole life,
+because taking a scheduled turn back off the clock is done by task identity: a fresh closure per
+evaluation could be scheduled and never cancelled, and a deleted alarm would keep waking up and keep
+the simulation from settling.
+
+Evaluation itself is a pure function in `sim-cloudwatch-alarm-evaluation.ts`, taking the periods and
+the definition and answering with a state. That is deliberate: the M-of-N rule and the four
+`TreatMissingData` treatments are the part worth reading and testing on their own, and none of it
+needs a clock or a store to do so.
+
+`sim-cloudwatch-alarm-periods.ts` decides which periods those are: the `evaluationPeriods` complete
+periods before the boundary, never the period the clock is standing in, which has not finished. The
+window reaches back before the alarm was created, and periods there are as missing as any other,
+which is why an alarm with `TreatMissingData: breaching` over a quiet metric fires immediately. Real
+CloudWatch does the same.
+
+An alarm's actions fire only on a transition, so an alarm sitting in ALARM across ten periods
+notifies once. A failing action never stops the others and never stops the alarm: the state has
+already changed by the time actions run, and real CloudWatch does not roll one back because a topic
+was missing.
+
 ## Authorization
 
-`command/authorize/sim-cloudwatch-authorizer.ts` authorizes every action against `*`, because
-CloudWatch metrics have no ARN. This is the one service here where a policy naming a resource is
-always wrong, and the authorizer is deliberately shaped so that it cannot accidentally start
-accepting one.
+`command/authorize/sim-cloudwatch-authorizer.ts` authorizes every metric action against `*`, because
+CloudWatch metrics have no ARN. A policy naming a metric resource is always wrong, and the
+authorizer is shaped so that it cannot accidentally start accepting one.
+
+Alarms are the exception: they do have an ARN, so `PutMetricAlarm`, `DeleteAlarms` and
+`SetAlarmState` authorize against it, while the two describe operations take no resource-level
+permission at all. That split is real CloudWatch's, not a simplification.
 
 `PutMetricData` additionally supplies the namespace to IAM as `cloudwatch:namespace`, which is the
 only way a policy can narrow publishing, and the way AWS's own documented policies do it.

--- a/src/service/cloudwatch/alarm/action/sim-aws-cloudwatch-alarm-topics.ts
+++ b/src/service/cloudwatch/alarm/action/sim-aws-cloudwatch-alarm-topics.ts
@@ -1,0 +1,70 @@
+import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
+import type { SimAws } from "../../../aws/sim-aws.js";
+import { parseSnsTopicArn } from "../../../sns/topic/sim-sns-topic-arn.js";
+import type {
+  SimCloudWatchAlarmNotification,
+  SimCloudWatchAlarmTargets,
+} from "./sim-cloudwatch-alarm-targets.js";
+
+interface SimAwsCloudWatchAlarmTopicsProperties {
+  readonly simAws: SimAws;
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+}
+
+/**
+ * The simulated SNS topics an alarm's actions reach.
+ *
+ * Real CloudWatch requires an alarm's SNS topic to be in the same Account and
+ * Region as the alarm, so a topic ARN naming another one reaches nothing here
+ * either, and says so rather than passing quietly.
+ *
+ * The topic is resolved when the alarm fires rather than when it is created,
+ * so a topic made after the alarm is one the alarm can still reach.
+ */
+export class SimAwsCloudWatchAlarmTopics implements SimCloudWatchAlarmTargets {
+  readonly #simAws: SimAws;
+  readonly #accountRegionScope: SimAwsAccountRegionScope;
+
+  constructor(properties: SimAwsCloudWatchAlarmTopicsProperties) {
+    this.#simAws = properties.simAws;
+    this.#accountRegionScope = properties.accountRegionScope;
+  }
+
+  /**
+   * Publish one notification to the topic an action names.
+   *
+   * It goes through the ordinary Publish path so a notification fans out to
+   * the topic's subscriptions exactly as an SDK caller's message would, and
+   * with no caller, so it arrives as the Account root. Real CloudWatch
+   * publishes as a service principal that a same-Account topic's default
+   * policy already admits; authorizing here as a principal that policy says
+   * nothing about would fail for requests an account takes.
+   */
+  async notify(notification: SimCloudWatchAlarmNotification): Promise<void> {
+    const scope = this.#accountRegionScope;
+    const location = parseSnsTopicArn(notification.topicArn);
+
+    if (
+      location === undefined ||
+      location.regionName !== scope.regionName ||
+      location.accountId !== scope.accountId
+    ) {
+      throw new Error(
+        `${notification.topicArn} is not a simulated SNS topic in ` +
+          `${scope.accountId} ${scope.regionName}: an alarm can only notify a ` +
+          `topic in its own Account and Region.`,
+      );
+    }
+
+    await this.#simAws
+      .accountRegionScope(scope.accountId, scope.regionName)
+      .sns()
+      .publish({
+        input: {
+          TopicArn: notification.topicArn,
+          Subject: notification.subject,
+          Message: notification.message,
+        },
+      });
+  }
+}

--- a/src/service/cloudwatch/alarm/action/sim-cloudwatch-alarm-action-failures.ts
+++ b/src/service/cloudwatch/alarm/action/sim-cloudwatch-alarm-action-failures.ts
@@ -1,0 +1,91 @@
+/**
+ * What one alarm action could not do.
+ */
+export interface SimCloudWatchAlarmActionFailureProperties {
+  readonly alarmName: string;
+  readonly alarmArn: string;
+  readonly actionArn: string;
+  readonly error: unknown;
+}
+
+/**
+ * One notification an alarm could not send.
+ */
+export class SimCloudWatchAlarmActionFailure {
+  readonly alarmName: string;
+  readonly alarmArn: string;
+  readonly actionArn: string;
+  readonly error: unknown;
+
+  constructor(properties: SimCloudWatchAlarmActionFailureProperties) {
+    this.alarmName = properties.alarmName;
+    this.alarmArn = properties.alarmArn;
+    this.actionArn = properties.actionArn;
+    this.error = properties.error;
+  }
+
+  /**
+   * What went wrong, in one line.
+   */
+  get reason(): string {
+    return this.error instanceof Error
+      ? this.error.message
+      : String(this.error);
+  }
+}
+
+/**
+ * What became of the notifications a simulated CloudWatch scope could not
+ * send.
+ *
+ * Real CloudWatch tells nobody when an alarm action fails: the alarm changes
+ * state either way and the failure is visible only in the absence of the
+ * notification. Neither does this, because a failing action must not stop an
+ * alarm evaluating. Swallowing it entirely would leave a queue mysteriously
+ * empty, which is the hardest kind of test to debug, so every failure is kept
+ * for inspection and warned about once.
+ */
+export class SimCloudWatchAlarmActionFailures {
+  readonly #failures: SimCloudWatchAlarmActionFailure[] = [];
+  readonly #warned = new Set<string>();
+
+  /**
+   * Every notification this scope could not send, oldest first.
+   */
+  get all(): readonly SimCloudWatchAlarmActionFailure[] {
+    return this.#failures;
+  }
+
+  /**
+   * Record a failed action.
+   */
+  record(properties: SimCloudWatchAlarmActionFailureProperties): void {
+    const failure = new SimCloudWatchAlarmActionFailure(properties);
+
+    this.#failures.push(failure);
+    this.warn(failure);
+  }
+
+  /**
+   * Warn about an action that failed, once per action and cause.
+   *
+   * Warnings go to the console because that is where a test runner surfaces
+   * them next to the failing expectation they explain; the simulator has no
+   * logger of its own to route them through.
+   */
+  private warn(failure: SimCloudWatchAlarmActionFailure): void {
+    const key = `${failure.actionArn}:${failure.reason}`;
+
+    if (this.#warned.has(key)) {
+      return;
+    }
+
+    this.#warned.add(key);
+
+    // oxlint-disable-next-line no-console
+    console.warn(
+      `Simulated CloudWatch alarm ${failure.alarmName} could not notify ` +
+        `${failure.actionArn}: ${failure.reason}`,
+    );
+  }
+}

--- a/src/service/cloudwatch/alarm/action/sim-cloudwatch-alarm-actions.ts
+++ b/src/service/cloudwatch/alarm/action/sim-cloudwatch-alarm-actions.ts
@@ -1,0 +1,82 @@
+import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
+import type {
+  SimCloudWatchAlarm,
+  SimCloudWatchAlarmTransition,
+} from "../sim-cloudwatch-alarm.js";
+import { simCloudWatchActionsFieldFor } from "../sim-cloudwatch-alarm-state.js";
+import { SimCloudWatchAlarmActionFailures } from "./sim-cloudwatch-alarm-action-failures.js";
+import {
+  simCloudWatchAlarmMessage,
+  simCloudWatchAlarmSubject,
+} from "./sim-cloudwatch-alarm-notification.js";
+import type { SimCloudWatchAlarmTargets } from "./sim-cloudwatch-alarm-targets.js";
+
+interface SimCloudWatchAlarmActionsProperties {
+  readonly targets: SimCloudWatchAlarmTargets;
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+}
+
+/**
+ * Fires an alarm's actions when it changes state.
+ *
+ * Only a change fires anything. An alarm that evaluates ten periods and stays
+ * in ALARM throughout notifies once, at the transition, which is what real
+ * CloudWatch does and what stops a test's queue filling with duplicates.
+ */
+export class SimCloudWatchAlarmActions {
+  readonly failures = new SimCloudWatchAlarmActionFailures();
+
+  readonly #targets: SimCloudWatchAlarmTargets;
+  readonly #accountRegionScope: SimAwsAccountRegionScope;
+
+  constructor(properties: SimCloudWatchAlarmActionsProperties) {
+    this.#targets = properties.targets;
+    this.#accountRegionScope = properties.accountRegionScope;
+  }
+
+  /**
+   * Notify everything the alarm's new state names.
+   *
+   * A failing action never stops the others, and never stops the alarm: the
+   * state has already changed by the time this runs, and real CloudWatch does
+   * not roll one back because a topic was missing.
+   */
+  async fire(
+    alarm: SimCloudWatchAlarm,
+    transition: SimCloudWatchAlarmTransition,
+  ): Promise<void> {
+    if (!alarm.definition.actionsEnabled) {
+      return;
+    }
+
+    const actions =
+      alarm.definition[simCloudWatchActionsFieldFor(transition.state)];
+    const message = {
+      subject: simCloudWatchAlarmSubject({
+        alarm,
+        transition,
+        accountRegionScope: this.#accountRegionScope,
+      }),
+      message: simCloudWatchAlarmMessage({
+        alarm,
+        transition,
+        accountRegionScope: this.#accountRegionScope,
+      }),
+    };
+
+    await Promise.all(
+      actions.map(async (actionArn) => {
+        try {
+          await this.#targets.notify({ ...message, topicArn: actionArn });
+        } catch (error) {
+          this.failures.record({
+            alarmName: alarm.name,
+            alarmArn: alarm.arn,
+            actionArn,
+            error,
+          });
+        }
+      }),
+    );
+  }
+}

--- a/src/service/cloudwatch/alarm/action/sim-cloudwatch-alarm-notification.ts
+++ b/src/service/cloudwatch/alarm/action/sim-cloudwatch-alarm-notification.ts
@@ -1,0 +1,73 @@
+import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
+import type { SimCloudWatchAlarm } from "../sim-cloudwatch-alarm.js";
+import type { SimCloudWatchAlarmTransition } from "../sim-cloudwatch-alarm.js";
+
+interface SimCloudWatchAlarmMessageProperties {
+  readonly alarm: SimCloudWatchAlarm;
+  readonly transition: SimCloudWatchAlarmTransition;
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+}
+
+/**
+ * The subject line real CloudWatch puts on an alarm notification.
+ */
+export function simCloudWatchAlarmSubject(
+  properties: SimCloudWatchAlarmMessageProperties,
+): string {
+  const { transition, accountRegionScope } = properties;
+  const name = properties.alarm.name;
+
+  return `${transition.state}: "${name}" in ${accountRegionScope.regionName}`;
+}
+
+/**
+ * The JSON body real CloudWatch publishes when an alarm changes state.
+ *
+ * The shape is what a subscriber parses, so it is worth matching: a Lambda
+ * function reading `NewStateValue` out of an SNS message is the code a test
+ * here is most likely to be exercising.
+ *
+ * `Region` carries the region code rather than the human name real CloudWatch
+ * uses ("eu-west-2" rather than "EU (London)"), because the simulation knows
+ * the code and nothing here maps one to the other.
+ */
+export function simCloudWatchAlarmMessage(
+  properties: SimCloudWatchAlarmMessageProperties,
+): string {
+  const { alarm, transition, accountRegionScope } = properties;
+  const definition = alarm.definition;
+
+  return JSON.stringify({
+    AlarmName: alarm.name,
+    AlarmDescription: definition.alarmDescription ?? null,
+    AWSAccountId: accountRegionScope.accountId,
+    AlarmConfigurationUpdatedTimestamp:
+      alarm.configurationUpdatedAt.toISOString(),
+    NewStateValue: transition.state,
+    NewStateReason: transition.reason,
+    StateChangeTime: transition.at.toISOString(),
+    Region: accountRegionScope.regionName,
+    AlarmArn: alarm.arn,
+    OldStateValue: transition.previousState,
+    OKActions: definition.okActions,
+    AlarmActions: definition.alarmActions,
+    InsufficientDataActions: definition.insufficientDataActions,
+    Trigger: {
+      MetricName: definition.metric.metricName,
+      Namespace: definition.metric.namespace,
+      StatisticType: "Statistic",
+      Statistic: definition.statistic.toUpperCase(),
+      Unit: definition.unit ?? null,
+      Dimensions: definition.metric.dimensions.map((dimension) => ({
+        value: dimension.value,
+        name: dimension.name,
+      })),
+      Period: definition.period,
+      EvaluationPeriods: definition.evaluationPeriods,
+      DatapointsToAlarm: definition.datapointsToAlarm,
+      ComparisonOperator: definition.comparisonOperator,
+      Threshold: definition.threshold,
+      TreatMissingData: definition.treatMissingData,
+    },
+  });
+}

--- a/src/service/cloudwatch/alarm/action/sim-cloudwatch-alarm-targets.ts
+++ b/src/service/cloudwatch/alarm/action/sim-cloudwatch-alarm-targets.ts
@@ -1,0 +1,46 @@
+/**
+ * One notification an alarm action sends.
+ */
+export interface SimCloudWatchAlarmNotification {
+  readonly topicArn: string;
+  readonly subject: string;
+  readonly message: string;
+}
+
+/**
+ * Where an alarm's actions reach.
+ *
+ * An alarm holds a topic ARN and nothing else, so what that ARN names is
+ * resolved when the alarm fires rather than when it is created: a topic made
+ * after the alarm is a topic the alarm can still reach, as it would be in an
+ * account.
+ */
+export interface SimCloudWatchAlarmTargets {
+  /**
+   * Send one notification, or throw saying why it could not be sent.
+   */
+  notify(notification: SimCloudWatchAlarmNotification): Promise<void>;
+}
+
+/**
+ * The targets a simulated CloudWatch built on its own has, which are none.
+ *
+ * Alarms still evaluate and change state without anything to notify. Firing at
+ * nothing is reported as a failure rather than passing quietly, because an
+ * alarm whose action reaches nowhere is exactly what a test setting one up is
+ * checking against.
+ */
+export class SimCloudWatchNoAlarmTargets implements SimCloudWatchAlarmTargets {
+  /**
+   * Refuse every notification, since there is nothing here to notify.
+   */
+  notify(notification: SimCloudWatchAlarmNotification): Promise<void> {
+    return Promise.reject(
+      new Error(
+        `${notification.topicArn} is not reachable: this simulated CloudWatch ` +
+          `was built without the rest of the simulation, so it has no SNS to ` +
+          `publish to.`,
+      ),
+    );
+  }
+}

--- a/src/service/cloudwatch/alarm/sim-cloudwatch-alarm-arn.ts
+++ b/src/service/cloudwatch/alarm/sim-cloudwatch-alarm-arn.ts
@@ -1,0 +1,15 @@
+import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+
+/**
+ * The ARN of an alarm.
+ *
+ * Alarms are the one thing in CloudWatch that has an ARN: a metric has none,
+ * which is why every metric action authorizes against `*`, while an alarm can
+ * be named by a policy and is what `DescribeAlarms` reports.
+ */
+export function simCloudWatchAlarmArn(
+  scope: SimAwsAccountRegionScope,
+  alarmName: string,
+): string {
+  return `arn:aws:cloudwatch:${scope.regionName}:${scope.accountId}:alarm:${alarmName}`;
+}

--- a/src/service/cloudwatch/alarm/sim-cloudwatch-alarm-definition.ts
+++ b/src/service/cloudwatch/alarm/sim-cloudwatch-alarm-definition.ts
@@ -1,0 +1,39 @@
+import type { SimCloudWatchMetricIdentity } from "../metric/sim-cloudwatch-metric.js";
+import type { SimCloudWatchStatistic } from "../metric/sim-cloudwatch-statistic.js";
+import type { SimCloudWatchUnit } from "../metric/sim-cloudwatch-unit.js";
+import type { SimCloudWatchComparisonOperator } from "./sim-cloudwatch-comparison.js";
+import type { SimCloudWatchMissingDataTreatment } from "./sim-cloudwatch-missing-data.js";
+
+/**
+ * What one alarm watches for, as PutMetricAlarm stated it.
+ *
+ * Held apart from the alarm itself because it is replaced wholesale: real
+ * PutMetricAlarm on a name that exists updates every one of these rather than
+ * merging, and the alarm keeps its state and history across the change.
+ */
+export interface SimCloudWatchAlarmDefinition {
+  readonly alarmName: string;
+  readonly alarmDescription: string | undefined;
+
+  readonly metric: SimCloudWatchMetricIdentity;
+  readonly statistic: SimCloudWatchStatistic;
+  readonly unit: SimCloudWatchUnit | undefined;
+
+  /** How long each evaluated period is, in seconds. */
+  readonly period: number;
+
+  /** How many periods back the alarm looks each time it evaluates. */
+  readonly evaluationPeriods: number;
+
+  /** How many of those must breach for the alarm to fire. */
+  readonly datapointsToAlarm: number;
+
+  readonly threshold: number;
+  readonly comparisonOperator: SimCloudWatchComparisonOperator;
+  readonly treatMissingData: SimCloudWatchMissingDataTreatment;
+
+  readonly actionsEnabled: boolean;
+  readonly alarmActions: readonly string[];
+  readonly okActions: readonly string[];
+  readonly insufficientDataActions: readonly string[];
+}

--- a/src/service/cloudwatch/alarm/sim-cloudwatch-alarm-evaluation.ts
+++ b/src/service/cloudwatch/alarm/sim-cloudwatch-alarm-evaluation.ts
@@ -1,0 +1,130 @@
+import type { SimCloudWatchAlarmDefinition } from "./sim-cloudwatch-alarm-definition.js";
+import type { SimCloudWatchAlarmState } from "./sim-cloudwatch-alarm-state.js";
+import { simCloudWatchBreaches } from "./sim-cloudwatch-comparison.js";
+
+/**
+ * What one evaluated period was worth to the alarm.
+ *
+ * A period is missing when nothing was published into it, which is a different
+ * thing from a period whose values happened to sum to zero.
+ */
+export type SimCloudWatchPeriodVerdict =
+  | "breaching"
+  | "notBreaching"
+  | "absent";
+
+/**
+ * What an evaluation decided, and why.
+ *
+ * `state` being undefined means the alarm keeps the state it has, which is
+ * what `TreatMissingData: ignore` asks for.
+ */
+export interface SimCloudWatchEvaluation {
+  readonly state: SimCloudWatchAlarmState | undefined;
+  readonly reason: string;
+}
+
+/**
+ * Decide what the periods an alarm just looked at make its state.
+ *
+ * The periods arrive oldest first and are as many as `evaluationPeriods`, with
+ * `undefined` for a period nothing was published into.
+ *
+ * This is CloudWatch's M-of-N rule: the alarm fires when at least
+ * `datapointsToAlarm` of the periods breach, whether or not they are
+ * consecutive. Everything else is OK, except that an alarm with nothing to go
+ * on reports INSUFFICIENT_DATA rather than guessing.
+ */
+export function evaluateSimCloudWatchAlarm(
+  values: readonly (number | undefined)[],
+  definition: SimCloudWatchAlarmDefinition,
+): SimCloudWatchEvaluation {
+  const verdicts = values.map((value) => verdictFor(value, definition));
+
+  if (keepsItsState(verdicts, definition)) {
+    return {
+      state: undefined,
+      reason:
+        "Insufficient Data: the alarm is configured to ignore missing data, " +
+        "so its state is unchanged",
+    };
+  }
+
+  const breaching = verdicts.filter(
+    (verdict) => verdict === "breaching",
+  ).length;
+
+  if (breaching >= definition.datapointsToAlarm) {
+    return { state: "ALARM", reason: reason(breaching, definition, "") };
+  }
+
+  if (verdicts.every((verdict) => verdict === "absent")) {
+    return {
+      state: "INSUFFICIENT_DATA",
+      reason: `Insufficient Data: ${String(values.length)} datapoints were unknown`,
+    };
+  }
+
+  return { state: "OK", reason: reason(breaching, definition, "only ") };
+}
+
+/**
+ * Whether the alarm was told to leave its state alone when data is missing.
+ */
+function keepsItsState(
+  verdicts: readonly SimCloudWatchPeriodVerdict[],
+  definition: SimCloudWatchAlarmDefinition,
+): boolean {
+  return (
+    definition.treatMissingData === "ignore" && verdicts.includes("absent")
+  );
+}
+
+/**
+ * What one period is worth, once missing data has been treated.
+ *
+ * `missing` leaves an absent period absent, so it counts towards neither side
+ * and only matters if every period is absent. The other two treatments turn it
+ * into a period with an opinion.
+ */
+function verdictFor(
+  value: number | undefined,
+  definition: SimCloudWatchAlarmDefinition,
+): SimCloudWatchPeriodVerdict {
+  if (value !== undefined) {
+    return simCloudWatchBreaches(
+      value,
+      definition.threshold,
+      definition.comparisonOperator,
+    )
+      ? "breaching"
+      : "notBreaching";
+  }
+
+  switch (definition.treatMissingData) {
+    case "breaching": {
+      return "breaching";
+    }
+    case "notBreaching": {
+      return "notBreaching";
+    }
+    // `missing` leaves the period absent so it counts towards neither side,
+    // and `ignore` never reaches here: an absent period under it stops the
+    // evaluation before any verdict is read.
+    case "missing":
+    case "ignore": {
+      return "absent";
+    }
+  }
+}
+
+/**
+ * Why the alarm decided what it did, in the shape real CloudWatch words it.
+ */
+function reason(
+  breaching: number,
+  definition: SimCloudWatchAlarmDefinition,
+  qualifier: string,
+): string {
+  return `Threshold Crossed: ${qualifier}${String(breaching)} out of the last ${String(definition.evaluationPeriods)} datapoints were ${definition.comparisonOperator} the threshold (${String(definition.threshold)})`;
+}

--- a/src/service/cloudwatch/alarm/sim-cloudwatch-alarm-history.ts
+++ b/src/service/cloudwatch/alarm/sim-cloudwatch-alarm-history.ts
@@ -1,0 +1,33 @@
+import type { SimCloudWatchAlarmState } from "./sim-cloudwatch-alarm-state.js";
+
+/**
+ * One thing that happened to an alarm.
+ *
+ * Only state changes are recorded. Real CloudWatch also records configuration
+ * updates and action invocations, and those say nothing a test could not read
+ * off the alarm itself, so the history here is the transitions.
+ */
+export interface SimCloudWatchAlarmHistoryItem {
+  readonly timestamp: Date;
+  readonly previousState: SimCloudWatchAlarmState;
+  readonly state: SimCloudWatchAlarmState;
+  readonly reason: string;
+}
+
+/**
+ * The state changes of one alarm, newest first.
+ *
+ * Newest first is how real DescribeAlarmHistory answers, and it is what a test
+ * asserting on the last transition wants to read.
+ */
+export class SimCloudWatchAlarmHistory {
+  readonly #items: SimCloudWatchAlarmHistoryItem[] = [];
+
+  get all(): readonly SimCloudWatchAlarmHistoryItem[] {
+    return this.#items;
+  }
+
+  record(item: SimCloudWatchAlarmHistoryItem): void {
+    this.#items.unshift(item);
+  }
+}

--- a/src/service/cloudwatch/alarm/sim-cloudwatch-alarm-periods.ts
+++ b/src/service/cloudwatch/alarm/sim-cloudwatch-alarm-periods.ts
@@ -1,0 +1,57 @@
+import type { SimCloudWatchMetricStore } from "../metric/sim-cloudwatch-metric-store.js";
+import { simCloudWatchPeriodAggregates } from "../metric/sim-cloudwatch-period.js";
+import { simCloudWatchStatisticValue } from "../metric/sim-cloudwatch-statistic.js";
+import type { SimCloudWatchAlarmDefinition } from "./sim-cloudwatch-alarm-definition.js";
+
+const millisecondsPerSecond = 1000;
+
+/**
+ * The instant the period after the one holding an instant begins.
+ *
+ * An alarm evaluates on period boundaries, so this is when it next has a
+ * complete period to look at.
+ */
+export function simCloudWatchNextPeriodBoundary(
+  now: Date,
+  periodSeconds: number,
+): Date {
+  const periodMilliseconds = periodSeconds * millisecondsPerSecond;
+  const elapsed = Math.floor(now.getTime() / periodMilliseconds);
+
+  return new Date((elapsed + 1) * periodMilliseconds);
+}
+
+/**
+ * Read the periods an alarm looks at when it evaluates at an instant, oldest
+ * first.
+ *
+ * The window is the `evaluationPeriods` complete periods before the boundary,
+ * so an alarm evaluating at 09:03 with three one-minute periods reads 09:00,
+ * 09:01 and 09:02 and not the minute it is standing on, which has not finished.
+ *
+ * A period nothing was published into comes back as `undefined` rather than
+ * being left out, because which period is missing is what `TreatMissingData`
+ * decides on.
+ */
+export function simCloudWatchAlarmPeriods(
+  metrics: SimCloudWatchMetricStore,
+  definition: SimCloudWatchAlarmDefinition,
+  boundary: Date,
+): readonly (number | undefined)[] {
+  const periodMilliseconds = definition.period * millisecondsPerSecond;
+  const endTime = boundary.getTime();
+  const startTime = endTime - definition.evaluationPeriods * periodMilliseconds;
+  const found = metrics.find(definition.metric);
+  const aggregates = simCloudWatchPeriodAggregates(
+    found?.within({ startTime, endTime, unit: definition.unit }) ?? [],
+    definition.period,
+  );
+
+  return Array.from({ length: definition.evaluationPeriods }, (_, index) =>
+    aggregates.get(startTime + index * periodMilliseconds),
+  ).map((aggregate) =>
+    aggregate === undefined
+      ? undefined
+      : simCloudWatchStatisticValue(aggregate, definition.statistic),
+  );
+}

--- a/src/service/cloudwatch/alarm/sim-cloudwatch-alarm-schedule.ts
+++ b/src/service/cloudwatch/alarm/sim-cloudwatch-alarm-schedule.ts
@@ -45,14 +45,14 @@ export class SimCloudWatchAlarmSchedule {
   /**
    * Start evaluating an alarm, from the next period boundary.
    *
-   * An alarm already being evaluated keeps its existing turn rather than
-   * gaining a second one, which is what makes PutMetricAlarm over an existing
-   * name safe to call repeatedly.
+   * An alarm already being evaluated has its existing turn taken back off the
+   * clock first, so it never gains a second one and never keeps a turn due at
+   * the boundary of a period it no longer has: an alarm moved from an hourly
+   * to a one-minute period would otherwise sit unevaluated until the hour it
+   * was first scheduled for came round.
    */
   start(alarm: SimCloudWatchAlarm): void {
-    if (this.#tasks.has(alarm.name)) {
-      return;
-    }
+    this.stop(alarm.name);
 
     const task = async (): Promise<void> => {
       await this.evaluate(alarm);

--- a/src/service/cloudwatch/alarm/sim-cloudwatch-alarm-schedule.ts
+++ b/src/service/cloudwatch/alarm/sim-cloudwatch-alarm-schedule.ts
@@ -1,0 +1,123 @@
+import type {
+  BackgroundScheduler,
+  BackgroundTask,
+} from "../../../util/background/background.js";
+import type { SimCloudWatchMetricStore } from "../metric/sim-cloudwatch-metric-store.js";
+import type { SimCloudWatchAlarmActions } from "./action/sim-cloudwatch-alarm-actions.js";
+import type { SimCloudWatchAlarm } from "./sim-cloudwatch-alarm.js";
+import { evaluateSimCloudWatchAlarm } from "./sim-cloudwatch-alarm-evaluation.js";
+import {
+  simCloudWatchAlarmPeriods,
+  simCloudWatchNextPeriodBoundary,
+} from "./sim-cloudwatch-alarm-periods.js";
+
+interface SimCloudWatchAlarmScheduleProperties {
+  readonly metrics: SimCloudWatchMetricStore;
+  readonly actions: SimCloudWatchAlarmActions;
+  readonly background: BackgroundScheduler;
+}
+
+/**
+ * Runs each alarm's evaluation on the simulation's clock.
+ *
+ * Nothing here uses a real timer. An alarm's next evaluation is scheduled on
+ * the background scheduler at the next period boundary, and every evaluation
+ * schedules the one after it, so a frozen clock evaluates nothing and
+ * `advanceBy({ minutes: 20 })` walks twenty one-minute evaluations and settles
+ * before the call returns.
+ *
+ * Each alarm keeps one task for its whole life, because taking a scheduled
+ * turn back off the clock is done by task identity: a fresh closure per
+ * evaluation could be scheduled but never cancelled.
+ */
+export class SimCloudWatchAlarmSchedule {
+  readonly #metrics: SimCloudWatchMetricStore;
+  readonly #actions: SimCloudWatchAlarmActions;
+  readonly #background: BackgroundScheduler;
+  readonly #tasks = new Map<string, BackgroundTask>();
+
+  constructor(properties: SimCloudWatchAlarmScheduleProperties) {
+    this.#metrics = properties.metrics;
+    this.#actions = properties.actions;
+    this.#background = properties.background;
+  }
+
+  /**
+   * Start evaluating an alarm, from the next period boundary.
+   *
+   * An alarm already being evaluated keeps its existing turn rather than
+   * gaining a second one, which is what makes PutMetricAlarm over an existing
+   * name safe to call repeatedly.
+   */
+  start(alarm: SimCloudWatchAlarm): void {
+    if (this.#tasks.has(alarm.name)) {
+      return;
+    }
+
+    const task = async (): Promise<void> => {
+      await this.evaluate(alarm);
+    };
+
+    this.#tasks.set(alarm.name, task);
+    this.scheduleNext(alarm, task);
+  }
+
+  /**
+   * Stop evaluating an alarm and take its scheduled turn back off the clock.
+   *
+   * Without this a deleted alarm would keep waking up, keep reading a metric
+   * nothing watches, and keep the simulation from settling.
+   */
+  stop(alarmName: string): void {
+    const task = this.#tasks.get(alarmName);
+
+    if (task === undefined) {
+      return;
+    }
+
+    this.#tasks.delete(alarmName);
+    this.#background.cancelScheduled(task);
+  }
+
+  /**
+   * Evaluate an alarm against the periods behind it, then schedule the next
+   * turn.
+   *
+   * The clock reads the boundary this turn was due at while this runs, so a
+   * transition is stamped with when it happened rather than with wherever time
+   * was eventually advanced to.
+   */
+  private async evaluate(alarm: SimCloudWatchAlarm): Promise<void> {
+    const task = this.#tasks.get(alarm.name);
+
+    if (task === undefined) {
+      return;
+    }
+
+    const now = this.#background.now();
+    const evaluation = evaluateSimCloudWatchAlarm(
+      simCloudWatchAlarmPeriods(this.#metrics, alarm.definition, now),
+      alarm.definition,
+    );
+    const transition =
+      evaluation.state === undefined
+        ? undefined
+        : alarm.moveTo(evaluation.state, evaluation.reason, now);
+
+    this.scheduleNext(alarm, task);
+
+    if (transition !== undefined) {
+      await this.#actions.fire(alarm, transition);
+    }
+  }
+
+  private scheduleNext(alarm: SimCloudWatchAlarm, task: BackgroundTask): void {
+    this.#background.scheduleAt(
+      simCloudWatchNextPeriodBoundary(
+        this.#background.now(),
+        alarm.definition.period,
+      ),
+      task,
+    );
+  }
+}

--- a/src/service/cloudwatch/alarm/sim-cloudwatch-alarm-state.ts
+++ b/src/service/cloudwatch/alarm/sim-cloudwatch-alarm-state.ts
@@ -1,0 +1,41 @@
+/**
+ * The three states a CloudWatch alarm can be in.
+ *
+ * `INSUFFICIENT_DATA` is a state rather than an absence of one: an alarm sits
+ * in it until enough periods have been evaluated to say, and it can fall back
+ * into it later if the metric stops being published.
+ */
+export const simCloudWatchAlarmStates = [
+  "OK",
+  "ALARM",
+  "INSUFFICIENT_DATA",
+] as const;
+
+export type SimCloudWatchAlarmState = (typeof simCloudWatchAlarmStates)[number];
+
+/**
+ * Which of an alarm's three action lists a state fires.
+ */
+export type SimCloudWatchAlarmActionsField =
+  | "alarmActions"
+  | "okActions"
+  | "insufficientDataActions";
+
+/**
+ * The actions a state change into each state fires.
+ */
+export function simCloudWatchActionsFieldFor(
+  state: SimCloudWatchAlarmState,
+): SimCloudWatchAlarmActionsField {
+  switch (state) {
+    case "ALARM": {
+      return "alarmActions";
+    }
+    case "OK": {
+      return "okActions";
+    }
+    case "INSUFFICIENT_DATA": {
+      return "insufficientDataActions";
+    }
+  }
+}

--- a/src/service/cloudwatch/alarm/sim-cloudwatch-alarm-store.ts
+++ b/src/service/cloudwatch/alarm/sim-cloudwatch-alarm-store.ts
@@ -1,0 +1,40 @@
+import type { SimCloudWatchAlarm } from "./sim-cloudwatch-alarm.js";
+
+/**
+ * The alarms of one simulated CloudWatch scope.
+ *
+ * Alarms are keyed by name, which is the whole of their identity: a name is
+ * unique within one account and region, and it is what the ARN carries.
+ */
+export class SimCloudWatchAlarmStore {
+  readonly #alarms = new Map<string, SimCloudWatchAlarm>();
+
+  /**
+   * Every alarm in this scope, in the order each was created.
+   */
+  get all(): readonly SimCloudWatchAlarm[] {
+    return this.#alarms.values().toArray();
+  }
+
+  find(alarmName: string): SimCloudWatchAlarm | undefined {
+    return this.#alarms.get(alarmName);
+  }
+
+  put(alarm: SimCloudWatchAlarm): void {
+    this.#alarms.set(alarm.name, alarm);
+  }
+
+  /**
+   * Remove an alarm, answering with it if it was there.
+   *
+   * Real DeleteAlarms says nothing about a name that is not there, so the
+   * caller decides what to make of it.
+   */
+  delete(alarmName: string): SimCloudWatchAlarm | undefined {
+    const alarm = this.#alarms.get(alarmName);
+
+    this.#alarms.delete(alarmName);
+
+    return alarm;
+  }
+}

--- a/src/service/cloudwatch/alarm/sim-cloudwatch-alarm.ts
+++ b/src/service/cloudwatch/alarm/sim-cloudwatch-alarm.ts
@@ -1,0 +1,123 @@
+import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+import { simCloudWatchAlarmArn } from "./sim-cloudwatch-alarm-arn.js";
+import type { SimCloudWatchAlarmDefinition } from "./sim-cloudwatch-alarm-definition.js";
+import { SimCloudWatchAlarmHistory } from "./sim-cloudwatch-alarm-history.js";
+import type { SimCloudWatchAlarmState } from "./sim-cloudwatch-alarm-state.js";
+
+interface SimCloudWatchAlarmProperties {
+  readonly definition: SimCloudWatchAlarmDefinition;
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+  readonly createdAt: Date;
+}
+
+/**
+ * What one state change did to an alarm.
+ */
+export interface SimCloudWatchAlarmTransition {
+  readonly previousState: SimCloudWatchAlarmState;
+  readonly state: SimCloudWatchAlarmState;
+  readonly reason: string;
+  readonly at: Date;
+}
+
+/**
+ * One alarm in a simulated CloudWatch scope: what it watches, where it stands,
+ * and how it got there.
+ *
+ * A new alarm is in INSUFFICIENT_DATA, as it is on real CloudWatch, because it
+ * has not evaluated a period yet. That is a real state and not a placeholder,
+ * so it is recorded as the state the first transition came from.
+ */
+export class SimCloudWatchAlarm {
+  readonly arn: string;
+  readonly history = new SimCloudWatchAlarmHistory();
+
+  #definition: SimCloudWatchAlarmDefinition;
+  #state: SimCloudWatchAlarmState = "INSUFFICIENT_DATA";
+  #stateReason = "Unchecked: initial alarm creation";
+  #stateUpdatedAt: Date;
+  #configurationUpdatedAt: Date;
+
+  constructor(properties: SimCloudWatchAlarmProperties) {
+    this.#definition = properties.definition;
+    this.#stateUpdatedAt = properties.createdAt;
+    this.#configurationUpdatedAt = properties.createdAt;
+    this.arn = simCloudWatchAlarmArn(
+      properties.accountRegionScope,
+      properties.definition.alarmName,
+    );
+  }
+
+  get definition(): SimCloudWatchAlarmDefinition {
+    return this.#definition;
+  }
+
+  get name(): string {
+    return this.#definition.alarmName;
+  }
+
+  get state(): SimCloudWatchAlarmState {
+    return this.#state;
+  }
+
+  get stateReason(): string {
+    return this.#stateReason;
+  }
+
+  get stateUpdatedAt(): Date {
+    return this.#stateUpdatedAt;
+  }
+
+  get configurationUpdatedAt(): Date {
+    return this.#configurationUpdatedAt;
+  }
+
+  /**
+   * Take a new configuration, keeping the state and history.
+   *
+   * Real PutMetricAlarm on an existing name updates the alarm rather than
+   * replacing it, and an alarm that was in ALARM stays there until it next
+   * evaluates.
+   */
+  redefine(definition: SimCloudWatchAlarmDefinition, at: Date): void {
+    this.#definition = definition;
+    this.#configurationUpdatedAt = at;
+  }
+
+  /**
+   * Move to a state, recording the transition, or do nothing if it is already
+   * there.
+   *
+   * Answering with the transition rather than firing anything keeps this about
+   * the alarm's own state: whether the change should reach an SNS topic is a
+   * question about actions, and the caller is what knows it.
+   */
+  moveTo(
+    state: SimCloudWatchAlarmState,
+    reason: string,
+    at: Date,
+  ): SimCloudWatchAlarmTransition | undefined {
+    if (state === this.#state) {
+      return undefined;
+    }
+
+    const transition = {
+      previousState: this.#state,
+      state,
+      reason,
+      at,
+    };
+
+    this.#state = state;
+    this.#stateReason = reason;
+    this.#stateUpdatedAt = at;
+    this.history.record({
+      timestamp: at,
+      previousState: transition.previousState,
+      state,
+      reason,
+    });
+
+    return transition;
+  }
+}

--- a/src/service/cloudwatch/alarm/sim-cloudwatch-comparison.ts
+++ b/src/service/cloudwatch/alarm/sim-cloudwatch-comparison.ts
@@ -1,0 +1,65 @@
+import { SimCloudWatchInvalidParameterValueException } from "../error/sim-cloudwatch.error.js";
+
+/**
+ * The threshold comparisons this simulation evaluates.
+ *
+ * Real CloudWatch has these four and a set of anomaly detection operators
+ * besides. The anomaly ones compare against a band a trained model produces
+ * rather than against a number, which there is nothing here to train, so they
+ * are refused rather than approximated.
+ */
+export const simCloudWatchComparisonOperators = [
+  "GreaterThanOrEqualToThreshold",
+  "GreaterThanThreshold",
+  "LessThanThreshold",
+  "LessThanOrEqualToThreshold",
+] as const;
+
+export type SimCloudWatchComparisonOperator =
+  (typeof simCloudWatchComparisonOperators)[number];
+
+/**
+ * Read a comparison operator, refusing one this simulation cannot evaluate.
+ */
+export function requiredSimCloudWatchComparisonOperator(
+  operator?: string,
+): SimCloudWatchComparisonOperator {
+  const found = simCloudWatchComparisonOperators.find(
+    (one) => one === operator,
+  );
+
+  if (found === undefined) {
+    throw new SimCloudWatchInvalidParameterValueException(
+      `The parameter ComparisonOperator must be one of ` +
+        `${simCloudWatchComparisonOperators.join(", ")}. Anomaly detection ` +
+        `operators are not simulated, because there is no trained model here ` +
+        `for a band to come from.`,
+    );
+  }
+
+  return found;
+}
+
+/**
+ * Whether one period's value breaches the threshold.
+ */
+export function simCloudWatchBreaches(
+  value: number,
+  threshold: number,
+  operator: SimCloudWatchComparisonOperator,
+): boolean {
+  switch (operator) {
+    case "GreaterThanOrEqualToThreshold": {
+      return value >= threshold;
+    }
+    case "GreaterThanThreshold": {
+      return value > threshold;
+    }
+    case "LessThanThreshold": {
+      return value < threshold;
+    }
+    case "LessThanOrEqualToThreshold": {
+      return value <= threshold;
+    }
+  }
+}

--- a/src/service/cloudwatch/alarm/sim-cloudwatch-missing-data.ts
+++ b/src/service/cloudwatch/alarm/sim-cloudwatch-missing-data.ts
@@ -1,0 +1,46 @@
+import { SimCloudWatchInvalidParameterValueException } from "../error/sim-cloudwatch.error.js";
+
+/**
+ * What an alarm makes of a period nothing was published into.
+ *
+ * `missing` is the default and means the period counts towards neither side:
+ * an alarm whose every period is missing has nothing to say and reports
+ * INSUFFICIENT_DATA. `ignore` is the one that is not about the period at all;
+ * it says the alarm keeps whatever state it already had.
+ */
+export const simCloudWatchMissingDataTreatments = [
+  "missing",
+  "notBreaching",
+  "breaching",
+  "ignore",
+] as const;
+
+export type SimCloudWatchMissingDataTreatment =
+  (typeof simCloudWatchMissingDataTreatments)[number];
+
+export const simCloudWatchDefaultMissingData: SimCloudWatchMissingDataTreatment =
+  "missing";
+
+/**
+ * Read how missing data should be treated, refusing an unknown treatment.
+ */
+export function simCloudWatchMissingDataOrDefault(
+  treatMissingData?: string,
+): SimCloudWatchMissingDataTreatment {
+  if (treatMissingData === undefined) {
+    return simCloudWatchDefaultMissingData;
+  }
+
+  const found = simCloudWatchMissingDataTreatments.find(
+    (one) => one === treatMissingData,
+  );
+
+  if (found === undefined) {
+    throw new SimCloudWatchInvalidParameterValueException(
+      `The parameter TreatMissingData must be one of ` +
+        `${simCloudWatchMissingDataTreatments.join(", ")}.`,
+    );
+  }
+
+  return found;
+}

--- a/src/service/cloudwatch/command/alarm/alarm.command.ts
+++ b/src/service/cloudwatch/command/alarm/alarm.command.ts
@@ -1,0 +1,173 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type { SimCloudWatchDimensionInput } from "../../metric/sim-cloudwatch-dimension.js";
+
+/**
+ * Minimal structural sim CloudWatch PutMetricAlarm command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/cloudwatch/command/PutMetricAlarmCommand/
+ */
+export interface SimPutMetricAlarmCommand {
+  readonly input: SimPutMetricAlarmCommandInput;
+}
+
+export interface SimPutMetricAlarmCommandInput {
+  readonly AlarmName?: string | undefined;
+  readonly AlarmDescription?: string | undefined;
+  readonly ActionsEnabled?: boolean | undefined;
+  readonly OKActions?: readonly string[] | undefined;
+  readonly AlarmActions?: readonly string[] | undefined;
+  readonly InsufficientDataActions?: readonly string[] | undefined;
+  readonly MetricName?: string | undefined;
+  readonly Namespace?: string | undefined;
+  readonly Statistic?: string | undefined;
+  readonly ExtendedStatistic?: string | undefined;
+  readonly Dimensions?: readonly SimCloudWatchDimensionInput[] | undefined;
+  readonly Period?: number | undefined;
+  readonly Unit?: string | undefined;
+  readonly EvaluationPeriods?: number | undefined;
+  readonly DatapointsToAlarm?: number | undefined;
+  readonly Threshold?: number | undefined;
+  readonly ComparisonOperator?: string | undefined;
+  readonly TreatMissingData?: string | undefined;
+  readonly Metrics?: readonly unknown[] | undefined;
+  readonly ThresholdMetricId?: string | undefined;
+  readonly EvaluateLowSampleCountPercentile?: string | undefined;
+  readonly Tags?: readonly unknown[] | undefined;
+}
+
+export interface SimPutMetricAlarmCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim CloudWatch DescribeAlarms command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/cloudwatch/command/DescribeAlarmsCommand/
+ */
+export interface SimDescribeAlarmsCommand {
+  readonly input: SimDescribeAlarmsCommandInput;
+}
+
+export interface SimDescribeAlarmsCommandInput {
+  readonly AlarmNames?: readonly string[] | undefined;
+  readonly AlarmNamePrefix?: string | undefined;
+  readonly StateValue?: string | undefined;
+  readonly ActionPrefix?: string | undefined;
+  readonly MaxRecords?: number | undefined;
+  readonly NextToken?: string | undefined;
+  readonly AlarmTypes?: readonly string[] | undefined;
+  readonly ChildrenOfAlarmName?: string | undefined;
+  readonly ParentsOfAlarmName?: string | undefined;
+}
+
+/**
+ * What DescribeAlarms reports about one alarm.
+ */
+export interface SimCloudWatchMetricAlarmDetail {
+  readonly AlarmName: string;
+  readonly AlarmArn: string;
+  readonly AlarmDescription?: string | undefined;
+  readonly AlarmConfigurationUpdatedTimestamp: Date;
+  readonly ActionsEnabled: boolean;
+  readonly OKActions: readonly string[];
+  readonly AlarmActions: readonly string[];
+  readonly InsufficientDataActions: readonly string[];
+  readonly StateValue: string;
+  readonly StateReason: string;
+  readonly StateUpdatedTimestamp: Date;
+  readonly MetricName: string;
+  readonly Namespace: string;
+  readonly Statistic: string;
+  readonly Dimensions: readonly SimCloudWatchDimensionInput[];
+  readonly Period: number;
+  readonly Unit?: string | undefined;
+  readonly EvaluationPeriods: number;
+  readonly DatapointsToAlarm: number;
+  readonly Threshold: number;
+  readonly ComparisonOperator: string;
+  readonly TreatMissingData: string;
+}
+
+export interface SimDescribeAlarmsCommandOutput {
+  readonly MetricAlarms?: readonly SimCloudWatchMetricAlarmDetail[] | undefined;
+  readonly CompositeAlarms?: readonly never[] | undefined;
+  readonly NextToken?: string | undefined;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim CloudWatch DeleteAlarms command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/cloudwatch/command/DeleteAlarmsCommand/
+ */
+export interface SimDeleteAlarmsCommand {
+  readonly input: SimDeleteAlarmsCommandInput;
+}
+
+export interface SimDeleteAlarmsCommandInput {
+  readonly AlarmNames?: readonly string[] | undefined;
+}
+
+export interface SimDeleteAlarmsCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim CloudWatch SetAlarmState command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/cloudwatch/command/SetAlarmStateCommand/
+ */
+export interface SimSetAlarmStateCommand {
+  readonly input: SimSetAlarmStateCommandInput;
+}
+
+export interface SimSetAlarmStateCommandInput {
+  readonly AlarmName?: string | undefined;
+  readonly StateValue?: string | undefined;
+  readonly StateReason?: string | undefined;
+  readonly StateReasonData?: string | undefined;
+}
+
+export interface SimSetAlarmStateCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim CloudWatch DescribeAlarmHistory command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/cloudwatch/command/DescribeAlarmHistoryCommand/
+ */
+export interface SimDescribeAlarmHistoryCommand {
+  readonly input: SimDescribeAlarmHistoryCommandInput;
+}
+
+export interface SimDescribeAlarmHistoryCommandInput {
+  readonly AlarmName?: string | undefined;
+  readonly HistoryItemType?: string | undefined;
+  readonly StartDate?: Date | undefined;
+  readonly EndDate?: Date | undefined;
+  readonly MaxRecords?: number | undefined;
+  readonly NextToken?: string | undefined;
+  readonly ScanBy?: string | undefined;
+  readonly AlarmTypes?: readonly string[] | undefined;
+}
+
+/**
+ * What DescribeAlarmHistory reports about one thing that happened.
+ */
+export interface SimCloudWatchAlarmHistoryItemDetail {
+  readonly AlarmName: string;
+  readonly AlarmType: string;
+  readonly Timestamp: Date;
+  readonly HistoryItemType: string;
+  readonly HistorySummary: string;
+  readonly HistoryData: string;
+}
+
+export interface SimDescribeAlarmHistoryCommandOutput {
+  readonly AlarmHistoryItems?:
+    | readonly SimCloudWatchAlarmHistoryItemDetail[]
+    | undefined;
+  readonly NextToken?: string | undefined;
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/cloudwatch/command/alarm/sim-cloudwatch-alarm-action-input.ts
+++ b/src/service/cloudwatch/command/alarm/sim-cloudwatch-alarm-action-input.ts
@@ -1,0 +1,92 @@
+import { SimCloudWatchInvalidParameterValueException } from "../../error/sim-cloudwatch.error.js";
+import type { SimPutMetricAlarmCommandInput } from "./alarm.command.js";
+
+/**
+ * How many actions real CloudWatch allows in one of an alarm's three lists.
+ */
+const maximumActions = 5;
+
+/**
+ * The only action target this simulation carries out.
+ */
+const snsArnPrefix = "arn:aws:sns:";
+
+/**
+ * Read one of an alarm's action lists.
+ *
+ * An action that is not an SNS topic is refused rather than stored and
+ * ignored. Real CloudWatch would scale a group or stop an instance, and an
+ * alarm here that quietly did nothing instead would let a test assert its
+ * alarm fired while the thing the alarm exists to do never happened.
+ */
+export function simCloudWatchAlarmActions(
+  field: string,
+  actions?: readonly string[],
+): readonly string[] {
+  if (actions === undefined) {
+    return [];
+  }
+
+  if (actions.length > maximumActions) {
+    throw new SimCloudWatchInvalidParameterValueException(
+      `The parameter ${field} may hold at most ${maximumActions} actions, ` +
+        `and ${actions.length} were given.`,
+    );
+  }
+
+  for (const action of actions) {
+    if (!action.startsWith(snsArnPrefix)) {
+      throw new SimCloudWatchInvalidParameterValueException(
+        `The action ${action} in ${field} is not simulated: an alarm here ` +
+          `notifies an SNS topic, and nothing else. Auto Scaling, EC2, ` +
+          `Systems Manager and Lambda actions are out of scope.`,
+      );
+    }
+  }
+
+  return actions;
+}
+
+/**
+ * Refuse the alarm inputs real CloudWatch accepts and this does not carry out.
+ *
+ * Every one of them changes what the alarm watches or how it decides, so an
+ * alarm that took one and ignored it would sit in a test looking configured
+ * and evaluating something else.
+ */
+export function refuseUnsimulatedSimCloudWatchAlarmInput(
+  input: SimPutMetricAlarmCommandInput,
+): void {
+  refuse(
+    "Metrics",
+    input.Metrics,
+    "metric math and multi-metric alarms are not simulated",
+  );
+  refuse(
+    "ThresholdMetricId",
+    input.ThresholdMetricId,
+    "anomaly detection alarms need a trained model, which there is none of here",
+  );
+  refuse(
+    "ExtendedStatistic",
+    input.ExtendedStatistic,
+    "percentiles need the individual values behind a period, which a " +
+      "StatisticValues datum never carries",
+  );
+  refuse(
+    "EvaluateLowSampleCountPercentile",
+    input.EvaluateLowSampleCountPercentile,
+    "it only applies to percentile alarms, which are not simulated",
+  );
+  refuse("Tags", input.Tags, "alarm tags are not simulated");
+}
+
+function refuse(field: string, value: unknown, because: string): void {
+  if (value === undefined) {
+    return;
+  }
+
+  throw new SimCloudWatchInvalidParameterValueException(
+    `The parameter ${field} is not simulated: ${because}.`,
+  );
+}

--- a/src/service/cloudwatch/command/alarm/sim-cloudwatch-alarm-context.ts
+++ b/src/service/cloudwatch/command/alarm/sim-cloudwatch-alarm-context.ts
@@ -1,0 +1,22 @@
+import type { SimClock } from "../../../../util/clock/sim-clock.js";
+import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
+import type { SimCloudWatchAlarmActions } from "../../alarm/action/sim-cloudwatch-alarm-actions.js";
+import type { SimCloudWatchAlarmSchedule } from "../../alarm/sim-cloudwatch-alarm-schedule.js";
+import type { SimCloudWatchAlarmStore } from "../../alarm/sim-cloudwatch-alarm-store.js";
+import type { SimCloudWatchAuthorizer } from "../authorize/sim-cloudwatch-authorizer.js";
+
+/**
+ * What every alarm command works from.
+ *
+ * The alarm commands all reach the same handful of collaborators, so they take
+ * them as one thing rather than each restating the list as a properties
+ * interface, five fields and five constructor assignments.
+ */
+export interface SimCloudWatchAlarmContext {
+  readonly alarms: SimCloudWatchAlarmStore;
+  readonly schedule: SimCloudWatchAlarmSchedule;
+  readonly actions: SimCloudWatchAlarmActions;
+  readonly authorizer: SimCloudWatchAuthorizer;
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+  readonly clock: SimClock;
+}

--- a/src/service/cloudwatch/command/alarm/sim-cloudwatch-alarm-detail.ts
+++ b/src/service/cloudwatch/command/alarm/sim-cloudwatch-alarm-detail.ts
@@ -1,0 +1,75 @@
+import type { SimCloudWatchAlarm } from "../../alarm/sim-cloudwatch-alarm.js";
+import type { SimCloudWatchAlarmHistoryItem } from "../../alarm/sim-cloudwatch-alarm-history.js";
+import type {
+  SimCloudWatchAlarmHistoryItemDetail,
+  SimCloudWatchMetricAlarmDetail,
+} from "./alarm.command.js";
+
+/**
+ * The one alarm type this simulation has. Composite alarms are out of scope,
+ * so every alarm reported is a metric alarm.
+ */
+const metricAlarmType = "MetricAlarm";
+
+/**
+ * What DescribeAlarms reports about one alarm.
+ */
+export function simCloudWatchMetricAlarmDetail(
+  alarm: SimCloudWatchAlarm,
+): SimCloudWatchMetricAlarmDetail {
+  const definition = alarm.definition;
+
+  return {
+    AlarmName: alarm.name,
+    AlarmArn: alarm.arn,
+    AlarmDescription: definition.alarmDescription,
+    AlarmConfigurationUpdatedTimestamp: alarm.configurationUpdatedAt,
+    ActionsEnabled: definition.actionsEnabled,
+    OKActions: definition.okActions,
+    AlarmActions: definition.alarmActions,
+    InsufficientDataActions: definition.insufficientDataActions,
+    StateValue: alarm.state,
+    StateReason: alarm.stateReason,
+    StateUpdatedTimestamp: alarm.stateUpdatedAt,
+    MetricName: definition.metric.metricName,
+    Namespace: definition.metric.namespace,
+    Statistic: definition.statistic,
+    Dimensions: definition.metric.dimensions.map((dimension) => ({
+      Name: dimension.name,
+      Value: dimension.value,
+    })),
+    Period: definition.period,
+    Unit: definition.unit,
+    EvaluationPeriods: definition.evaluationPeriods,
+    DatapointsToAlarm: definition.datapointsToAlarm,
+    Threshold: definition.threshold,
+    ComparisonOperator: definition.comparisonOperator,
+    TreatMissingData: definition.treatMissingData,
+  };
+}
+
+/**
+ * What DescribeAlarmHistory reports about one state change.
+ *
+ * `HistoryData` is the JSON real CloudWatch puts there, which is what a test
+ * reads to find why the alarm moved rather than just that it did.
+ */
+export function simCloudWatchAlarmHistoryDetail(
+  alarmName: string,
+  item: SimCloudWatchAlarmHistoryItem,
+): SimCloudWatchAlarmHistoryItemDetail {
+  return {
+    AlarmName: alarmName,
+    AlarmType: metricAlarmType,
+    Timestamp: item.timestamp,
+    HistoryItemType: "StateUpdate",
+    HistorySummary: `Alarm updated from ${item.previousState} to ${item.state}`,
+    HistoryData: JSON.stringify({
+      oldState: { stateValue: item.previousState },
+      newState: {
+        stateValue: item.state,
+        stateReason: item.reason,
+      },
+    }),
+  };
+}

--- a/src/service/cloudwatch/command/alarm/sim-cloudwatch-alarm-input.ts
+++ b/src/service/cloudwatch/command/alarm/sim-cloudwatch-alarm-input.ts
@@ -1,0 +1,66 @@
+import type { SimCloudWatchAlarmDefinition } from "../../alarm/sim-cloudwatch-alarm-definition.js";
+import { requiredSimCloudWatchComparisonOperator } from "../../alarm/sim-cloudwatch-comparison.js";
+import { simCloudWatchMissingDataOrDefault } from "../../alarm/sim-cloudwatch-missing-data.js";
+import { requiredSimCloudWatchDimensions } from "../../metric/sim-cloudwatch-dimension.js";
+import { requiredSimCloudWatchName } from "../../metric/sim-cloudwatch-name.js";
+import { requiredSimCloudWatchNamespace } from "../../metric/sim-cloudwatch-namespace.js";
+import { requiredSimCloudWatchPeriod } from "../../metric/sim-cloudwatch-period.js";
+import { requiredSimCloudWatchStatistic } from "../../metric/sim-cloudwatch-statistic.js";
+import { simCloudWatchUnitOrUndefined } from "../../metric/sim-cloudwatch-unit.js";
+import type { SimPutMetricAlarmCommandInput } from "./alarm.command.js";
+import {
+  refuseUnsimulatedSimCloudWatchAlarmInput,
+  simCloudWatchAlarmActions,
+} from "./sim-cloudwatch-alarm-action-input.js";
+import {
+  requiredSimCloudWatchThreshold,
+  requiredSimCloudWatchValue,
+  requiredSimCloudWatchWholeNumber,
+  simCloudWatchDatapointsToAlarm,
+} from "./sim-cloudwatch-alarm-numbers.js";
+
+/**
+ * Read what an alarm watches for, refusing what real CloudWatch would refuse.
+ */
+export function readSimCloudWatchAlarmDefinition(
+  input: SimPutMetricAlarmCommandInput,
+): SimCloudWatchAlarmDefinition {
+  refuseUnsimulatedSimCloudWatchAlarmInput(input);
+
+  const evaluationPeriods = requiredSimCloudWatchWholeNumber(
+    "EvaluationPeriods",
+    input.EvaluationPeriods,
+  );
+
+  return {
+    alarmName: requiredSimCloudWatchName("AlarmName", input.AlarmName),
+    alarmDescription: input.AlarmDescription,
+    metric: {
+      namespace: requiredSimCloudWatchNamespace(input.Namespace),
+      metricName: requiredSimCloudWatchName("MetricName", input.MetricName),
+      dimensions: requiredSimCloudWatchDimensions(input.Dimensions),
+    },
+    statistic: requiredSimCloudWatchStatistic(
+      requiredSimCloudWatchValue("Statistic", input.Statistic),
+    ),
+    unit: simCloudWatchUnitOrUndefined("Unit", input.Unit),
+    period: requiredSimCloudWatchPeriod(input.Period),
+    evaluationPeriods,
+    datapointsToAlarm: simCloudWatchDatapointsToAlarm(
+      input.DatapointsToAlarm,
+      evaluationPeriods,
+    ),
+    threshold: requiredSimCloudWatchThreshold(input.Threshold),
+    comparisonOperator: requiredSimCloudWatchComparisonOperator(
+      input.ComparisonOperator,
+    ),
+    treatMissingData: simCloudWatchMissingDataOrDefault(input.TreatMissingData),
+    actionsEnabled: input.ActionsEnabled ?? true,
+    alarmActions: simCloudWatchAlarmActions("AlarmActions", input.AlarmActions),
+    okActions: simCloudWatchAlarmActions("OKActions", input.OKActions),
+    insufficientDataActions: simCloudWatchAlarmActions(
+      "InsufficientDataActions",
+      input.InsufficientDataActions,
+    ),
+  };
+}

--- a/src/service/cloudwatch/command/alarm/sim-cloudwatch-alarm-numbers.ts
+++ b/src/service/cloudwatch/command/alarm/sim-cloudwatch-alarm-numbers.ts
@@ -1,0 +1,92 @@
+import {
+  SimCloudWatchInvalidParameterValueException,
+  SimCloudWatchMissingRequiredParameterException,
+} from "../../error/sim-cloudwatch.error.js";
+
+/**
+ * How many of the evaluated periods must breach for an alarm to fire.
+ *
+ * Left out, it is every one of them, which is what makes an alarm with three
+ * evaluation periods and no M-of-N fire only when all three breach.
+ */
+export function simCloudWatchDatapointsToAlarm(
+  datapointsToAlarm: number | undefined,
+  evaluationPeriods: number,
+): number {
+  if (datapointsToAlarm === undefined) {
+    return evaluationPeriods;
+  }
+
+  const wanted = requiredSimCloudWatchWholeNumber(
+    "DatapointsToAlarm",
+    datapointsToAlarm,
+  );
+
+  if (wanted > evaluationPeriods) {
+    throw new SimCloudWatchInvalidParameterValueException(
+      "The parameter DatapointsToAlarm must not be greater than " +
+        "EvaluationPeriods.",
+    );
+  }
+
+  return wanted;
+}
+
+/**
+ * Read the number an alarm compares its metric against.
+ */
+export function requiredSimCloudWatchThreshold(
+  threshold: number | undefined,
+): number {
+  if (threshold === undefined) {
+    throw new SimCloudWatchMissingRequiredParameterException(
+      "The parameter Threshold must be present.",
+    );
+  }
+
+  if (!Number.isFinite(threshold)) {
+    throw new SimCloudWatchInvalidParameterValueException(
+      "The parameter Threshold must be a finite number.",
+    );
+  }
+
+  return threshold;
+}
+
+/**
+ * Read a count of periods, which is a whole number of one or more.
+ */
+export function requiredSimCloudWatchWholeNumber(
+  field: string,
+  value: number | undefined,
+): number {
+  if (value === undefined) {
+    throw new SimCloudWatchMissingRequiredParameterException(
+      `The parameter ${field} must be present.`,
+    );
+  }
+
+  if (!Number.isSafeInteger(value) || value < 1) {
+    throw new SimCloudWatchInvalidParameterValueException(
+      `The parameter ${field} must be a whole number of one or more.`,
+    );
+  }
+
+  return value;
+}
+
+/**
+ * Read a value the caller had to supply.
+ */
+export function requiredSimCloudWatchValue(
+  field: string,
+  value: string | undefined,
+): string {
+  if (value === undefined) {
+    throw new SimCloudWatchMissingRequiredParameterException(
+      `The parameter ${field} must be present.`,
+    );
+  }
+
+  return value;
+}

--- a/src/service/cloudwatch/command/alarm/sim-cloudwatch-alarm-reads.ts
+++ b/src/service/cloudwatch/command/alarm/sim-cloudwatch-alarm-reads.ts
@@ -1,0 +1,128 @@
+import type { SimCloudWatchAlarm } from "../../alarm/sim-cloudwatch-alarm.js";
+import { SimCloudWatchPage } from "../sim-cloudwatch-page.js";
+import type { SimCloudWatchRequestOptions } from "../sim-cloudwatch-request-options.js";
+import type {
+  SimDescribeAlarmHistoryCommand,
+  SimDescribeAlarmHistoryCommandOutput,
+  SimDescribeAlarmsCommand,
+  SimDescribeAlarmsCommandOutput,
+} from "./alarm.command.js";
+import type { SimCloudWatchAlarmContext } from "./sim-cloudwatch-alarm-context.js";
+import {
+  simCloudWatchAlarmHistoryDetail,
+  simCloudWatchMetricAlarmDetail,
+} from "./sim-cloudwatch-alarm-detail.js";
+
+const describeAlarmsAction = "cloudwatch:DescribeAlarms";
+const describeAlarmHistoryAction = "cloudwatch:DescribeAlarmHistory";
+
+/**
+ * How many alarms, and how many history items, one page reports.
+ */
+const alarmsPerPage = 100;
+
+/**
+ * The commands that report what alarms exist and what has happened to them.
+ *
+ * Neither takes a resource-level permission on real CloudWatch, so both
+ * authorize against every alarm rather than against each one they report.
+ */
+export class SimCloudWatchAlarmReads {
+  readonly #context: SimCloudWatchAlarmContext;
+
+  constructor(context: SimCloudWatchAlarmContext) {
+    this.#context = context;
+  }
+
+  /**
+   * Describe the alarms a request selects, in the order each was created.
+   */
+  describeAlarms(
+    command: SimDescribeAlarmsCommand,
+    options?: SimCloudWatchRequestOptions,
+  ): SimDescribeAlarmsCommandOutput {
+    const input = command.input;
+
+    this.#context.authorizer.authorize(describeAlarmsAction, options?.caller);
+
+    const page = new SimCloudWatchPage({
+      listed: this.#context.alarms.all.filter((alarm) => selects(alarm, input)),
+      nextToken: input.NextToken,
+      pageSize: input.MaxRecords ?? alarmsPerPage,
+    });
+
+    return {
+      $metadata: {},
+      MetricAlarms: page.items.map((alarm) =>
+        simCloudWatchMetricAlarmDetail(alarm),
+      ),
+      CompositeAlarms: [],
+      NextToken: page.nextToken,
+    };
+  }
+
+  /**
+   * Report what has happened to an alarm, newest first.
+   *
+   * Left without an alarm name, this reports across every alarm in the scope,
+   * as real CloudWatch does.
+   */
+  describeAlarmHistory(
+    command: SimDescribeAlarmHistoryCommand,
+    options?: SimCloudWatchRequestOptions,
+  ): SimDescribeAlarmHistoryCommandOutput {
+    const input = command.input;
+
+    this.#context.authorizer.authorize(
+      describeAlarmHistoryAction,
+      options?.caller,
+    );
+
+    const items = this.#context.alarms.all
+      .filter(
+        (alarm) =>
+          input.AlarmName === undefined || alarm.name === input.AlarmName,
+      )
+      .flatMap((alarm) =>
+        alarm.history.all
+          .filter((item) => within(item.timestamp, input))
+          .map((item) => simCloudWatchAlarmHistoryDetail(alarm.name, item)),
+      );
+    const page = new SimCloudWatchPage({
+      listed: items,
+      nextToken: input.NextToken,
+      pageSize: input.MaxRecords ?? alarmsPerPage,
+    });
+
+    return {
+      $metadata: {},
+      AlarmHistoryItems: page.items,
+      NextToken: page.nextToken,
+    };
+  }
+}
+
+function selects(
+  alarm: SimCloudWatchAlarm,
+  input: SimDescribeAlarmsCommand["input"],
+): boolean {
+  return (
+    (input.AlarmNames === undefined || input.AlarmNames.includes(alarm.name)) &&
+    alarm.name.startsWith(input.AlarmNamePrefix ?? "") &&
+    (input.StateValue === undefined || alarm.state === input.StateValue) &&
+    (input.ActionPrefix === undefined ||
+      alarm.definition.alarmActions.some((action) =>
+        action.startsWith(input.ActionPrefix ?? ""),
+      ))
+  );
+}
+
+function within(
+  timestamp: Date,
+  input: SimDescribeAlarmHistoryCommand["input"],
+): boolean {
+  return (
+    (input.StartDate === undefined || timestamp >= input.StartDate) &&
+    (input.EndDate === undefined || timestamp < input.EndDate)
+  );
+}

--- a/src/service/cloudwatch/command/alarm/sim-cloudwatch-alarm-reads.ts
+++ b/src/service/cloudwatch/command/alarm/sim-cloudwatch-alarm-reads.ts
@@ -1,4 +1,3 @@
-import type { SimCloudWatchAlarm } from "../../alarm/sim-cloudwatch-alarm.js";
 import { SimCloudWatchPage } from "../sim-cloudwatch-page.js";
 import type { SimCloudWatchRequestOptions } from "../sim-cloudwatch-request-options.js";
 import type {
@@ -9,9 +8,10 @@ import type {
 } from "./alarm.command.js";
 import type { SimCloudWatchAlarmContext } from "./sim-cloudwatch-alarm-context.js";
 import {
-  simCloudWatchAlarmHistoryDetail,
-  simCloudWatchMetricAlarmDetail,
-} from "./sim-cloudwatch-alarm-detail.js";
+  selectsSimCloudWatchAlarm,
+  simCloudWatchAlarmHistory,
+} from "./sim-cloudwatch-alarm-selection.js";
+import { simCloudWatchMetricAlarmDetail } from "./sim-cloudwatch-alarm-detail.js";
 
 const describeAlarmsAction = "cloudwatch:DescribeAlarms";
 const describeAlarmHistoryAction = "cloudwatch:DescribeAlarmHistory";
@@ -46,7 +46,9 @@ export class SimCloudWatchAlarmReads {
     this.#context.authorizer.authorize(describeAlarmsAction, options?.caller);
 
     const page = new SimCloudWatchPage({
-      listed: this.#context.alarms.all.filter((alarm) => selects(alarm, input)),
+      listed: this.#context.alarms.all.filter((alarm) =>
+        selectsSimCloudWatchAlarm(alarm, input),
+      ),
       nextToken: input.NextToken,
       pageSize: input.MaxRecords ?? alarmsPerPage,
     });
@@ -78,18 +80,8 @@ export class SimCloudWatchAlarmReads {
       options?.caller,
     );
 
-    const items = this.#context.alarms.all
-      .filter(
-        (alarm) =>
-          input.AlarmName === undefined || alarm.name === input.AlarmName,
-      )
-      .flatMap((alarm) =>
-        alarm.history.all
-          .filter((item) => within(item.timestamp, input))
-          .map((item) => simCloudWatchAlarmHistoryDetail(alarm.name, item)),
-      );
     const page = new SimCloudWatchPage({
-      listed: items,
+      listed: simCloudWatchAlarmHistory(this.#context.alarms.all, input),
       nextToken: input.NextToken,
       pageSize: input.MaxRecords ?? alarmsPerPage,
     });
@@ -100,29 +92,4 @@ export class SimCloudWatchAlarmReads {
       NextToken: page.nextToken,
     };
   }
-}
-
-function selects(
-  alarm: SimCloudWatchAlarm,
-  input: SimDescribeAlarmsCommand["input"],
-): boolean {
-  return (
-    (input.AlarmNames === undefined || input.AlarmNames.includes(alarm.name)) &&
-    alarm.name.startsWith(input.AlarmNamePrefix ?? "") &&
-    (input.StateValue === undefined || alarm.state === input.StateValue) &&
-    (input.ActionPrefix === undefined ||
-      alarm.definition.alarmActions.some((action) =>
-        action.startsWith(input.ActionPrefix ?? ""),
-      ))
-  );
-}
-
-function within(
-  timestamp: Date,
-  input: SimDescribeAlarmHistoryCommand["input"],
-): boolean {
-  return (
-    (input.StartDate === undefined || timestamp >= input.StartDate) &&
-    (input.EndDate === undefined || timestamp < input.EndDate)
-  );
 }

--- a/src/service/cloudwatch/command/alarm/sim-cloudwatch-alarm-selection.ts
+++ b/src/service/cloudwatch/command/alarm/sim-cloudwatch-alarm-selection.ts
@@ -1,0 +1,104 @@
+import type { SimCloudWatchAlarm } from "../../alarm/sim-cloudwatch-alarm.js";
+import type {
+  SimCloudWatchAlarmHistoryItemDetail,
+  SimDescribeAlarmHistoryCommand,
+  SimDescribeAlarmsCommand,
+} from "./alarm.command.js";
+import { simCloudWatchAlarmHistoryDetail } from "./sim-cloudwatch-alarm-detail.js";
+
+/**
+ * Whether a DescribeAlarms request selects one alarm.
+ */
+export function selectsSimCloudWatchAlarm(
+  alarm: SimCloudWatchAlarm,
+  input: SimDescribeAlarmsCommand["input"],
+): boolean {
+  return (
+    (input.AlarmNames === undefined || input.AlarmNames.includes(alarm.name)) &&
+    alarm.name.startsWith(input.AlarmNamePrefix ?? "") &&
+    (input.StateValue === undefined || alarm.state === input.StateValue) &&
+    usesAction(alarm, input.ActionPrefix)
+  );
+}
+
+/**
+ * Whether an alarm carries an action starting with a prefix, in any of its
+ * three lists. Real CloudWatch filters on the actions an alarm uses, not on
+ * the ones it uses for one state.
+ */
+function usesAction(
+  alarm: SimCloudWatchAlarm,
+  actionPrefix: string | undefined,
+): boolean {
+  if (actionPrefix === undefined) {
+    return true;
+  }
+
+  const definition = alarm.definition;
+
+  return [
+    ...definition.alarmActions,
+    ...definition.okActions,
+    ...definition.insufficientDataActions,
+  ].some((action) => action.startsWith(actionPrefix));
+}
+
+/**
+ * The history items a DescribeAlarmHistory request selects, in the order it
+ * asked for.
+ */
+export function simCloudWatchAlarmHistory(
+  alarms: readonly SimCloudWatchAlarm[],
+  input: SimDescribeAlarmHistoryCommand["input"],
+): readonly SimCloudWatchAlarmHistoryItemDetail[] {
+  const items = alarms
+    .filter(
+      (alarm) =>
+        input.AlarmName === undefined || alarm.name === input.AlarmName,
+    )
+    .flatMap((alarm) =>
+      alarm.history.all
+        .filter((item) =>
+          withinSimCloudWatchHistoryWindow(item.timestamp, input),
+        )
+        .map((item) => simCloudWatchAlarmHistoryDetail(alarm.name, item)),
+    )
+    .filter(
+      (item) =>
+        input.HistoryItemType === undefined ||
+        item.HistoryItemType === input.HistoryItemType,
+    );
+
+  return orderedByTime(items, input.ScanBy);
+}
+
+/**
+ * History newest first, which is how real CloudWatch answers unless a request
+ * asks the other way. Items come from each alarm already in order, so an
+ * unfiltered read across several alarms has to be merged rather than
+ * concatenated.
+ */
+function orderedByTime(
+  items: readonly SimCloudWatchAlarmHistoryItemDetail[],
+  scanBy: string | undefined,
+): readonly SimCloudWatchAlarmHistoryItemDetail[] {
+  const ascending = items.toSorted(
+    (left, right) => left.Timestamp.getTime() - right.Timestamp.getTime(),
+  );
+
+  return scanBy === "TimestampAscending" ? ascending : ascending.toReversed();
+}
+
+/**
+ * Whether one history item falls in the window a request asked about, which
+ * includes its start and excludes its end as CloudWatch reads a range.
+ */
+function withinSimCloudWatchHistoryWindow(
+  timestamp: Date,
+  input: SimDescribeAlarmHistoryCommand["input"],
+): boolean {
+  return (
+    (input.StartDate === undefined || timestamp >= input.StartDate) &&
+    (input.EndDate === undefined || timestamp < input.EndDate)
+  );
+}

--- a/src/service/cloudwatch/command/alarm/sim-cloudwatch-alarm-writes.ts
+++ b/src/service/cloudwatch/command/alarm/sim-cloudwatch-alarm-writes.ts
@@ -1,0 +1,104 @@
+import { SimCloudWatchAlarm } from "../../alarm/sim-cloudwatch-alarm.js";
+import { SimCloudWatchMissingRequiredParameterException } from "../../error/sim-cloudwatch.error.js";
+import { requiredSimCloudWatchName } from "../../metric/sim-cloudwatch-name.js";
+import type { SimCloudWatchRequestOptions } from "../sim-cloudwatch-request-options.js";
+import type { SimCloudWatchAlarmContext } from "./sim-cloudwatch-alarm-context.js";
+import type {
+  SimDeleteAlarmsCommand,
+  SimDeleteAlarmsCommandOutput,
+  SimPutMetricAlarmCommand,
+  SimPutMetricAlarmCommandOutput,
+} from "./alarm.command.js";
+import { readSimCloudWatchAlarmDefinition } from "./sim-cloudwatch-alarm-input.js";
+
+const putMetricAlarmAction = "cloudwatch:PutMetricAlarm";
+const deleteAlarmsAction = "cloudwatch:DeleteAlarms";
+
+/**
+ * The commands that create and remove alarms.
+ */
+export class SimCloudWatchAlarmWrites {
+  readonly #context: SimCloudWatchAlarmContext;
+
+  constructor(context: SimCloudWatchAlarmContext) {
+    this.#context = context;
+  }
+
+  /**
+   * Create an alarm, or take a new configuration for one that exists.
+   *
+   * An existing alarm keeps its state and history across the change, as it
+   * does on real CloudWatch: an alarm in ALARM stays there until it next
+   * evaluates against whatever it now watches.
+   */
+  putMetricAlarm(
+    command: SimPutMetricAlarmCommand,
+    options?: SimCloudWatchRequestOptions,
+  ): SimPutMetricAlarmCommandOutput {
+    const definition = readSimCloudWatchAlarmDefinition(command.input);
+
+    this.#context.authorizer.authorizeAlarm(
+      putMetricAlarmAction,
+      definition.alarmName,
+      options?.caller,
+    );
+
+    const now = this.#context.clock.now();
+    const existing = this.#context.alarms.find(definition.alarmName);
+
+    if (existing === undefined) {
+      const alarm = new SimCloudWatchAlarm({
+        definition,
+        accountRegionScope: this.#context.accountRegionScope,
+        createdAt: now,
+      });
+
+      this.#context.alarms.put(alarm);
+      this.#context.schedule.start(alarm);
+    } else {
+      existing.redefine(definition, now);
+      this.#context.schedule.start(existing);
+    }
+
+    return { $metadata: {} };
+  }
+
+  /**
+   * Remove alarms, and stop evaluating them.
+   */
+  deleteAlarms(
+    command: SimDeleteAlarmsCommand,
+    options?: SimCloudWatchRequestOptions,
+  ): SimDeleteAlarmsCommandOutput {
+    const names = requiredAlarmNames(command.input.AlarmNames);
+
+    for (const alarmName of names) {
+      this.#context.authorizer.authorizeAlarm(
+        deleteAlarmsAction,
+        alarmName,
+        options?.caller,
+      );
+    }
+
+    for (const alarmName of names) {
+      this.#context.schedule.stop(alarmName);
+      this.#context.alarms.delete(alarmName);
+    }
+
+    return { $metadata: {} };
+  }
+}
+
+function requiredAlarmNames(
+  alarmNames: readonly string[] | undefined,
+): readonly string[] {
+  if (alarmNames === undefined || alarmNames.length === 0) {
+    throw new SimCloudWatchMissingRequiredParameterException(
+      "The parameter AlarmNames must be present and not empty.",
+    );
+  }
+
+  return alarmNames.map((alarmName) =>
+    requiredSimCloudWatchName("AlarmNames", alarmName),
+  );
+}

--- a/src/service/cloudwatch/command/alarm/sim-cloudwatch-set-alarm-state.ts
+++ b/src/service/cloudwatch/command/alarm/sim-cloudwatch-set-alarm-state.ts
@@ -4,6 +4,7 @@ import {
 } from "../../alarm/sim-cloudwatch-alarm-state.js";
 import { SimCloudWatchInvalidParameterValueException } from "../../error/sim-cloudwatch.error.js";
 import { requiredSimCloudWatchName } from "../../metric/sim-cloudwatch-name.js";
+import { requiredSimCloudWatchValue } from "./sim-cloudwatch-alarm-numbers.js";
 import type { SimCloudWatchRequestOptions } from "../sim-cloudwatch-request-options.js";
 import type { SimCloudWatchAlarmContext } from "./sim-cloudwatch-alarm-context.js";
 import type {
@@ -40,6 +41,13 @@ export class SimCloudWatchSetAlarmState {
     );
     const state = requiredAlarmState(command.input.StateValue);
 
+    // Real SetAlarmState requires a reason, so an alarm here never carries one
+    // this simulation made up on the caller's behalf.
+    const stateReason = requiredSimCloudWatchValue(
+      "StateReason",
+      command.input.StateReason,
+    );
+
     this.#context.authorizer.authorizeAlarm(
       setAlarmStateAction,
       alarmName,
@@ -56,7 +64,7 @@ export class SimCloudWatchSetAlarmState {
 
     const transition = alarm.moveTo(
       state,
-      command.input.StateReason ?? "Set by SetAlarmState",
+      stateReason,
       this.#context.clock.now(),
     );
 

--- a/src/service/cloudwatch/command/alarm/sim-cloudwatch-set-alarm-state.ts
+++ b/src/service/cloudwatch/command/alarm/sim-cloudwatch-set-alarm-state.ts
@@ -1,0 +1,82 @@
+import {
+  simCloudWatchAlarmStates,
+  type SimCloudWatchAlarmState,
+} from "../../alarm/sim-cloudwatch-alarm-state.js";
+import { SimCloudWatchInvalidParameterValueException } from "../../error/sim-cloudwatch.error.js";
+import { requiredSimCloudWatchName } from "../../metric/sim-cloudwatch-name.js";
+import type { SimCloudWatchRequestOptions } from "../sim-cloudwatch-request-options.js";
+import type { SimCloudWatchAlarmContext } from "./sim-cloudwatch-alarm-context.js";
+import type {
+  SimSetAlarmStateCommand,
+  SimSetAlarmStateCommandOutput,
+} from "./alarm.command.js";
+
+const setAlarmStateAction = "cloudwatch:SetAlarmState";
+
+/**
+ * The command that forces an alarm into a state, firing that state's actions.
+ *
+ * This is how a test exercises a subscriber without publishing a metric at
+ * all, and it is temporary on real CloudWatch too: the next evaluation
+ * overwrites whatever was set here.
+ */
+export class SimCloudWatchSetAlarmState {
+  readonly #context: SimCloudWatchAlarmContext;
+
+  constructor(context: SimCloudWatchAlarmContext) {
+    this.#context = context;
+  }
+
+  /**
+   * Move one alarm to a state, whatever its metric says.
+   */
+  async handle(
+    command: SimSetAlarmStateCommand,
+    options?: SimCloudWatchRequestOptions,
+  ): Promise<SimSetAlarmStateCommandOutput> {
+    const alarmName = requiredSimCloudWatchName(
+      "AlarmName",
+      command.input.AlarmName,
+    );
+    const state = requiredAlarmState(command.input.StateValue);
+
+    this.#context.authorizer.authorizeAlarm(
+      setAlarmStateAction,
+      alarmName,
+      options?.caller,
+    );
+
+    const alarm = this.#context.alarms.find(alarmName);
+
+    if (alarm === undefined) {
+      throw new SimCloudWatchInvalidParameterValueException(
+        `The alarm ${alarmName} does not exist in this account and region.`,
+      );
+    }
+
+    const transition = alarm.moveTo(
+      state,
+      command.input.StateReason ?? "Set by SetAlarmState",
+      this.#context.clock.now(),
+    );
+
+    if (transition !== undefined) {
+      await this.#context.actions.fire(alarm, transition);
+    }
+
+    return { $metadata: {} };
+  }
+}
+
+function requiredAlarmState(state?: string): SimCloudWatchAlarmState {
+  const found = simCloudWatchAlarmStates.find((one) => one === state);
+
+  if (found === undefined) {
+    throw new SimCloudWatchInvalidParameterValueException(
+      `The parameter StateValue must be one of ` +
+        `${simCloudWatchAlarmStates.join(", ")}.`,
+    );
+  }
+
+  return found;
+}

--- a/src/service/cloudwatch/command/authorize/sim-cloudwatch-authorizer.ts
+++ b/src/service/cloudwatch/command/authorize/sim-cloudwatch-authorizer.ts
@@ -1,8 +1,9 @@
 import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
 import type { SimAwsResolvedCaller } from "../../../aws/caller/sim-aws-caller-resolver.js";
 import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
-import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
-import { simCloudWatchNamespaceConditionKey } from "../sim-cloudwatch-request-options.js";
+import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
+import { simCloudWatchAlarmArn } from "../../alarm/sim-cloudwatch-alarm-arn.js";
+import { decideSimCloudWatchRequest } from "./sim-cloudwatch-decide.js";
 
 /**
  * The resource every CloudWatch metric action authorizes against.
@@ -15,6 +16,7 @@ const metricResource = "*";
 
 interface SimCloudWatchAuthorizerProperties {
   readonly iam: SimIamInterServiceAuthZ;
+  readonly accountRegionScope: SimAwsAccountRegionScope;
 }
 
 /**
@@ -26,16 +28,42 @@ interface SimCloudWatchAuthorizerProperties {
  */
 export class SimCloudWatchAuthorizer {
   readonly #iam: SimIamInterServiceAuthZ;
+  readonly #accountRegionScope: SimAwsAccountRegionScope;
 
   constructor(properties: SimCloudWatchAuthorizerProperties) {
     this.#iam = properties.iam;
+    this.#accountRegionScope = properties.accountRegionScope;
   }
 
   /**
    * Ensure the caller may perform an action on this scope's metrics.
    */
   authorize(action: string, caller?: SimAwsCaller): SimAwsResolvedCaller {
-    return this.decide(action, caller, undefined);
+    return decideSimCloudWatchRequest(this.#iam, {
+      action,
+      resource: metricResource,
+      caller,
+    });
+  }
+
+  /**
+   * Ensure the caller may perform an action on one alarm.
+   *
+   * Alarms are the one thing in CloudWatch a policy can name, so these
+   * authorize against the alarm's ARN rather than against `*`. The alarm need
+   * not exist: real IAM evaluates a request before the service handles it, so
+   * PutMetricAlarm authorizes against the ARN the alarm is about to have.
+   */
+  authorizeAlarm(
+    action: string,
+    alarmName: string,
+    caller?: SimAwsCaller,
+  ): SimAwsResolvedCaller {
+    return decideSimCloudWatchRequest(this.#iam, {
+      action,
+      resource: simCloudWatchAlarmArn(this.#accountRegionScope, alarmName),
+      caller,
+    });
   }
 
   /**
@@ -49,32 +77,11 @@ export class SimCloudWatchAuthorizer {
     namespace: string,
     caller?: SimAwsCaller,
   ): SimAwsResolvedCaller {
-    return this.decide(action, caller, namespace);
-  }
-
-  private decide(
-    action: string,
-    caller: SimAwsCaller | undefined,
-    namespace: string | undefined,
-  ): SimAwsResolvedCaller {
-    const decision = this.#iam.authorize({
+    return decideSimCloudWatchRequest(this.#iam, {
       action,
       resource: metricResource,
       caller,
-      conditionContext:
-        namespace === undefined
-          ? undefined
-          : { [simCloudWatchNamespaceConditionKey]: namespace },
+      namespace,
     });
-
-    if (decision.isDenied) {
-      throw new SimIamAccessDenied({
-        principal: decision.caller.principal,
-        action,
-        resource: metricResource,
-      });
-    }
-
-    return decision.caller;
   }
 }

--- a/src/service/cloudwatch/command/authorize/sim-cloudwatch-decide.ts
+++ b/src/service/cloudwatch/command/authorize/sim-cloudwatch-decide.ts
@@ -1,0 +1,50 @@
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimAwsResolvedCaller } from "../../../aws/caller/sim-aws-caller-resolver.js";
+import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+import { simCloudWatchNamespaceConditionKey } from "../sim-cloudwatch-request-options.js";
+
+/**
+ * One authorization question: what is being done, to what, by whom, and in
+ * which namespace where that narrows it.
+ */
+export interface SimCloudWatchAuthorization {
+  readonly action: string;
+  readonly resource: string;
+  readonly caller: SimAwsCaller | undefined;
+  readonly namespace?: string | undefined;
+}
+
+/**
+ * Put one CloudWatch request to simulated IAM, refusing it if the answer is no.
+ *
+ * The namespace, where there is one, goes in as `cloudwatch:namespace`, which
+ * is the condition key AWS's own documented publishing policies are written
+ * with and the only way a policy can narrow an action with no resource to
+ * name.
+ */
+export function decideSimCloudWatchRequest(
+  iam: SimIamInterServiceAuthZ,
+  request: SimCloudWatchAuthorization,
+): SimAwsResolvedCaller {
+  const { action, resource, namespace } = request;
+  const decision = iam.authorize({
+    action,
+    resource,
+    caller: request.caller,
+    conditionContext:
+      namespace === undefined
+        ? undefined
+        : { [simCloudWatchNamespaceConditionKey]: namespace },
+  });
+
+  if (decision.isDenied) {
+    throw new SimIamAccessDenied({
+      principal: decision.caller.principal,
+      action,
+      resource,
+    });
+  }
+
+  return decision.caller;
+}

--- a/src/service/cloudwatch/command/authorize/sim-cloudwatch-iam.iso.test.ts
+++ b/src/service/cloudwatch/command/authorize/sim-cloudwatch-iam.iso.test.ts
@@ -1,5 +1,8 @@
 import {
+  DeleteAlarmsCommand,
+  DescribeAlarmsCommand,
   ListMetricsCommand,
+  PutMetricAlarmCommand,
   PutMetricDataCommand,
 } from "@aws-sdk/client-cloudwatch";
 import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
@@ -147,5 +150,80 @@ describe("CloudWatch metrics IAM authorization", () => {
     // Then it is denied, as it would be in an account: metrics have no ARN, so
     // there is nothing for such a statement to match.
     assertInstanceOf(error, SimIamAccessDenied);
+  });
+});
+
+describe("CloudWatch alarm IAM authorization", () => {
+  const putAlarm = new PutMetricAlarmCommand({
+    AlarmName: "OrdersFailing",
+    Namespace: "Orders",
+    MetricName: "Failed",
+    Statistic: "Sum",
+    Period: 60,
+    EvaluationPeriods: 1,
+    Threshold: 5,
+    ComparisonOperator: "GreaterThanThreshold",
+  });
+
+  it("allows a Role granted the action on one alarm's ARN", async () => {
+    // Given a Role allowed to put exactly that alarm, which unlike a metric
+    // does have an ARN for a policy to name.
+    const simAws = await simAwsWithRole({
+      Action: "cloudwatch:PutMetricAlarm",
+      Resource: `arn:aws:cloudwatch:us-east-1:${accountIdOneOnes}:alarm:OrdersFailing`,
+    });
+
+    // When it creates the alarm.
+    await simAws.cloudWatch().putMetricAlarm(putAlarm, asRole);
+
+    // Then it was created.
+    assertArrayLength(simAws.cloudWatch().allAlarms(), 1);
+  });
+
+  it("denies a Role whose policy names another alarm", async () => {
+    // Given a Role allowed to put a different alarm.
+    const simAws = await simAwsWithRole({
+      Action: "cloudwatch:PutMetricAlarm",
+      Resource: `arn:aws:cloudwatch:us-east-1:${accountIdOneOnes}:alarm:SomethingElse`,
+    });
+
+    // When it tries to create this one.
+    const error = await assertThrowsErrorAsync(
+      async () => await simAws.cloudWatch().putMetricAlarm(putAlarm, asRole),
+    );
+
+    // Then it is denied, and nothing was created.
+    assertInstanceOf(error, SimIamAccessDenied);
+    assertIdentical(error.action, "cloudwatch:PutMetricAlarm");
+    assertArrayLength(simAws.cloudWatch().allAlarms(), 0);
+  });
+
+  it("denies deleting an alarm the policy does not cover, and describing needs no resource", async () => {
+    // Given a Role that may put and describe alarms but not delete them.
+    const simAws = await simAwsWithRole({
+      Action: ["cloudwatch:PutMetricAlarm", "cloudwatch:DescribeAlarms"],
+      Resource: "*",
+    });
+
+    await simAws.cloudWatch().putMetricAlarm(putAlarm, asRole);
+
+    // When it describes them, and then tries to delete one.
+    const described = await simAws
+      .cloudWatch()
+      .describeAlarms(new DescribeAlarmsCommand({}), asRole);
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await simAws
+          .cloudWatch()
+          .deleteAlarms(
+            new DeleteAlarmsCommand({ AlarmNames: ["OrdersFailing"] }),
+            asRole,
+          ),
+    );
+
+    // Then describing worked and deleting did not.
+    assertArrayLength(described.MetricAlarms ?? [], 1);
+    assertInstanceOf(error, SimIamAccessDenied);
+    assertArrayLength(simAws.cloudWatch().allAlarms(), 1);
   });
 });

--- a/src/service/cloudwatch/command/sim-cloudwatch-command.types.ts
+++ b/src/service/cloudwatch/command/sim-cloudwatch-command.types.ts
@@ -2,6 +2,25 @@
  * The sim CloudWatch Command types, gathered for the service facade.
  */
 export type {
+  SimCloudWatchAlarmHistoryItemDetail,
+  SimCloudWatchMetricAlarmDetail,
+  SimDeleteAlarmsCommand,
+  SimDeleteAlarmsCommandInput,
+  SimDeleteAlarmsCommandOutput,
+  SimDescribeAlarmHistoryCommand,
+  SimDescribeAlarmHistoryCommandInput,
+  SimDescribeAlarmHistoryCommandOutput,
+  SimDescribeAlarmsCommand,
+  SimDescribeAlarmsCommandInput,
+  SimDescribeAlarmsCommandOutput,
+  SimPutMetricAlarmCommand,
+  SimPutMetricAlarmCommandInput,
+  SimPutMetricAlarmCommandOutput,
+  SimSetAlarmStateCommand,
+  SimSetAlarmStateCommandInput,
+  SimSetAlarmStateCommandOutput,
+} from "./alarm/alarm.command.js";
+export type {
   SimCloudWatchMetricDatumInput,
   SimCloudWatchStatisticSetInput,
   SimPutMetricDataCommand,

--- a/src/service/cloudwatch/index.ts
+++ b/src/service/cloudwatch/index.ts
@@ -4,6 +4,53 @@ export {
   type SimCloudWatchRequestOptions,
 } from "./command/sim-cloudwatch-request-options.js";
 export {
+  SimCloudWatchAlarm,
+  type SimCloudWatchAlarmTransition,
+} from "./alarm/sim-cloudwatch-alarm.js";
+export type { SimCloudWatchAlarmDefinition } from "./alarm/sim-cloudwatch-alarm-definition.js";
+export {
+  SimCloudWatchAlarmHistory,
+  type SimCloudWatchAlarmHistoryItem,
+} from "./alarm/sim-cloudwatch-alarm-history.js";
+export { SimCloudWatchAlarmStore } from "./alarm/sim-cloudwatch-alarm-store.js";
+export {
+  simCloudWatchActionsFieldFor,
+  type SimCloudWatchAlarmActionsField,
+  type SimCloudWatchAlarmState,
+  simCloudWatchAlarmStates,
+} from "./alarm/sim-cloudwatch-alarm-state.js";
+export { simCloudWatchAlarmArn } from "./alarm/sim-cloudwatch-alarm-arn.js";
+export {
+  evaluateSimCloudWatchAlarm,
+  type SimCloudWatchEvaluation,
+  type SimCloudWatchPeriodVerdict,
+} from "./alarm/sim-cloudwatch-alarm-evaluation.js";
+export {
+  simCloudWatchAlarmPeriods,
+  simCloudWatchNextPeriodBoundary,
+} from "./alarm/sim-cloudwatch-alarm-periods.js";
+export {
+  requiredSimCloudWatchComparisonOperator,
+  simCloudWatchBreaches,
+  type SimCloudWatchComparisonOperator,
+  simCloudWatchComparisonOperators,
+} from "./alarm/sim-cloudwatch-comparison.js";
+export {
+  simCloudWatchDefaultMissingData,
+  type SimCloudWatchMissingDataTreatment,
+  simCloudWatchMissingDataOrDefault,
+  simCloudWatchMissingDataTreatments,
+} from "./alarm/sim-cloudwatch-missing-data.js";
+export {
+  SimCloudWatchAlarmActionFailure,
+  SimCloudWatchAlarmActionFailures,
+} from "./alarm/action/sim-cloudwatch-alarm-action-failures.js";
+export {
+  type SimCloudWatchAlarmNotification,
+  type SimCloudWatchAlarmTargets,
+  SimCloudWatchNoAlarmTargets,
+} from "./alarm/action/sim-cloudwatch-alarm-targets.js";
+export {
   aggregateSimCloudWatchDatapoints,
   type SimCloudWatchAggregate,
   type SimCloudWatchDatapoint,

--- a/src/service/cloudwatch/sdk/sim-cloudwatch-sdk-command-router.ts
+++ b/src/service/cloudwatch/sdk/sim-cloudwatch-sdk-command-router.ts
@@ -3,6 +3,13 @@ import {
   type SimSdkCommandRoute,
   type SimSdkCommandRouter,
 } from "../../../sdk/index.js";
+import type {
+  SimDeleteAlarmsCommand,
+  SimDescribeAlarmHistoryCommand,
+  SimDescribeAlarmsCommand,
+  SimPutMetricAlarmCommand,
+  SimSetAlarmStateCommand,
+} from "../command/alarm/alarm.command.js";
 import type { SimPutMetricDataCommand } from "../command/data/data.command.js";
 import type {
   SimGetMetricDataCommand,
@@ -48,6 +55,46 @@ export class SimCloudWatchSdkCommandRouter implements SimSdkCommandRouter {
         async (command, context): Promise<unknown> =>
           await simCloudWatch.getMetricData(
             command as SimGetMetricDataCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "PutMetricAlarmCommand",
+        async (command, context): Promise<unknown> =>
+          await simCloudWatch.putMetricAlarm(
+            command as SimPutMetricAlarmCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "DescribeAlarmsCommand",
+        async (command, context): Promise<unknown> =>
+          await simCloudWatch.describeAlarms(
+            command as SimDescribeAlarmsCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "DeleteAlarmsCommand",
+        async (command, context): Promise<unknown> =>
+          await simCloudWatch.deleteAlarms(
+            command as SimDeleteAlarmsCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "SetAlarmStateCommand",
+        async (command, context): Promise<unknown> =>
+          await simCloudWatch.setAlarmState(
+            command as SimSetAlarmStateCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "DescribeAlarmHistoryCommand",
+        async (command, context): Promise<unknown> =>
+          await simCloudWatch.describeAlarmHistory(
+            command as SimDescribeAlarmHistoryCommand,
             simSdkCallerOptions(context),
           ),
       ],

--- a/src/service/cloudwatch/sdk/sim-cloudwatch-sdk-routing.iso.test.ts
+++ b/src/service/cloudwatch/sdk/sim-cloudwatch-sdk-routing.iso.test.ts
@@ -1,13 +1,19 @@
 import {
   CloudWatchClient,
+  DeleteAlarmsCommand,
+  DescribeAlarmHistoryCommand,
+  DescribeAlarmsCommand,
   GetMetricDataCommand,
   GetMetricStatisticsCommand,
   ListMetricsCommand,
+  PutMetricAlarmCommand,
   PutMetricDataCommand,
+  SetAlarmStateCommand,
 } from "@aws-sdk/client-cloudwatch";
 import {
   assertArrayEquals,
   assertArrayIncludesAll,
+  assertArrayLength,
   assertIdentical,
   assertUndefined,
 } from "@kensio/smartass";
@@ -39,6 +45,11 @@ describe("SimCloudWatchSdkCommandRouter", () => {
       "ListMetricsCommand",
       "GetMetricStatisticsCommand",
       "GetMetricDataCommand",
+      "PutMetricAlarmCommand",
+      "DescribeAlarmsCommand",
+      "DeleteAlarmsCommand",
+      "SetAlarmStateCommand",
+      "DescribeAlarmHistoryCommand",
     ]);
   });
 
@@ -50,7 +61,7 @@ describe("SimCloudWatchSdkCommandRouter", () => {
     const route = simAws
       .cloudWatch()
       .sdkCommandRouter()
-      .route("PutMetricAlarmCommand");
+      .route("PutCompositeAlarmCommand");
 
     // Then there is no route for it.
     assertUndefined(route);
@@ -131,5 +142,51 @@ describe("CloudWatch SDK interception", () => {
 
     // Then it sees none of them, as it would in an account.
     assertArrayEquals(listed.Metrics ?? [], []);
+  });
+
+  it("routes every alarm Command through the intercepted client", async () => {
+    // Given an intercepted CloudWatch SDK client.
+    using simSdk = new SimSdk();
+    simSdk.intercept(CloudWatchClient);
+
+    const client = new CloudWatchClient({ region: "eu-west-2" });
+
+    // When ordinary SDK code creates an alarm and drives it through its whole
+    // life.
+    await client.send(
+      new PutMetricAlarmCommand({
+        AlarmName: "OrdersFailing",
+        Namespace: "Orders",
+        MetricName: "Failed",
+        Statistic: "Sum",
+        Period: 60,
+        EvaluationPeriods: 1,
+        Threshold: 5,
+        ComparisonOperator: "GreaterThanThreshold",
+      }),
+    );
+    await client.send(
+      new SetAlarmStateCommand({
+        AlarmName: "OrdersFailing",
+        StateValue: "ALARM",
+        StateReason: "Forced through the SDK",
+      }),
+    );
+
+    const described = await client.send(new DescribeAlarmsCommand({}));
+    const history = await client.send(
+      new DescribeAlarmHistoryCommand({ AlarmName: "OrdersFailing" }),
+    );
+
+    await client.send(
+      new DeleteAlarmsCommand({ AlarmNames: ["OrdersFailing"] }),
+    );
+
+    const afterDelete = await client.send(new DescribeAlarmsCommand({}));
+
+    // Then every operation reached the simulator.
+    assertIdentical(described.MetricAlarms?.at(0)?.StateValue, "ALARM");
+    assertArrayLength(history.AlarmHistoryItems ?? [], 1);
+    assertArrayLength(afterDelete.MetricAlarms ?? [], 0);
   });
 });

--- a/src/service/cloudwatch/sim-cloudwatch-alarm-action-failures.iso.test.ts
+++ b/src/service/cloudwatch/sim-cloudwatch-alarm-action-failures.iso.test.ts
@@ -4,7 +4,7 @@ import {
   assertNonNullable,
   assertStringIncludes,
 } from "@kensio/smartass";
-import { describe, it } from "vitest";
+import { describe, it, vi } from "vitest";
 
 import { SimAws } from "../aws/sim-aws.js";
 import type { SimPutMetricAlarmCommandInput } from "./command/sim-cloudwatch-command.types.js";
@@ -85,8 +85,17 @@ describe("SimCloudWatch alarm action failures", () => {
   });
 
   it("warns once about an action that keeps failing the same way", async () => {
-    // Given an alarm notifying a topic that is not there, driven back and
-    // forth so the same action fails twice.
+    // Given somewhere to catch what the simulator warns about, and an alarm
+    // notifying a topic that is not there, driven back and forth so the same
+    // action fails twice.
+    const warnings: string[] = [];
+
+    vi.spyOn(console, "warn").mockImplementation(
+      (...parts: unknown[]): void => {
+        warnings.push(parts.map(String).join(" "));
+      },
+    );
+
     const simAws = new SimAws();
     const gone = `arn:aws:sns:${simAws.defaultRegionName}:${simAws.defaultAccountId}:gone`;
 
@@ -107,9 +116,11 @@ describe("SimCloudWatch alarm action failures", () => {
 
     await simAws.backgroundTasksComplete();
 
-    // Then both failures are kept, so a test can find either of them, even
-    // though only the first was warned about.
+    // Then both failures are kept, so a test can find either of them, while
+    // the same action failing the same way is warned about only once.
     assertArrayLength(simAws.cloudWatch().alarmActionFailures, 2);
+    assertArrayLength(warnings, 1);
+    assertStringIncludes(String(warnings.at(0)), "could not notify");
   });
 
   it("says nothing about deleting an alarm that was never there", async () => {

--- a/src/service/cloudwatch/sim-cloudwatch-alarm-action-failures.iso.test.ts
+++ b/src/service/cloudwatch/sim-cloudwatch-alarm-action-failures.iso.test.ts
@@ -1,0 +1,127 @@
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../aws/sim-aws.js";
+import type { SimPutMetricAlarmCommandInput } from "./command/sim-cloudwatch-command.types.js";
+import { SimCloudWatch } from "./sim-cloudwatch.js";
+
+/**
+ * An alarm whose actions these tests point somewhere unreachable.
+ */
+const valid: SimPutMetricAlarmCommandInput = {
+  AlarmName: "OrdersFailing",
+  Namespace: "Orders",
+  MetricName: "Failed",
+  Statistic: "Sum",
+  Period: 60,
+  EvaluationPeriods: 3,
+  Threshold: 5,
+  ComparisonOperator: "GreaterThanThreshold",
+};
+
+describe("SimCloudWatch alarm action failures", () => {
+  it("records a topic in another region as unreachable", async () => {
+    // Given an alarm naming a topic in a different region, which real
+    // CloudWatch does not allow either.
+    const simAws = new SimAws();
+
+    await simAws.cloudWatch().putMetricAlarm({
+      input: {
+        ...valid,
+        AlarmActions: [
+          `arn:aws:sns:eu-west-2:${simAws.defaultAccountId}:elsewhere`,
+        ],
+      },
+    });
+
+    // When it fires.
+    await simAws.cloudWatch().setAlarmState({
+      input: {
+        AlarmName: "OrdersFailing",
+        StateValue: "ALARM",
+        StateReason: "Forced",
+      },
+    });
+    await simAws.backgroundTasksComplete();
+
+    // Then the failure is there to be found.
+    const failure = simAws.cloudWatch().alarmActionFailures.at(0);
+
+    assertNonNullable(failure);
+    assertStringIncludes(failure.reason, "its own Account and Region");
+  });
+
+  it("reports an action reaching nothing when built without the simulation", async () => {
+    // Given a simulated CloudWatch built on its own, with no SNS behind it.
+    const cloudWatch = new SimCloudWatch();
+
+    await cloudWatch.putMetricAlarm({
+      input: {
+        ...valid,
+        AlarmActions: ["arn:aws:sns:us-east-1:111111111111:alerts"],
+      },
+    });
+
+    // When an alarm fires.
+    await cloudWatch.setAlarmState({
+      input: {
+        AlarmName: "OrdersFailing",
+        StateValue: "ALARM",
+        StateReason: "Forced",
+      },
+    });
+
+    // Then it still changed state, and says why nothing was notified.
+    assertIdentical(cloudWatch.allAlarms().at(0)?.state, "ALARM");
+    assertStringIncludes(
+      String(cloudWatch.alarmActionFailures.at(0)?.reason),
+      "no SNS to publish to",
+    );
+  });
+
+  it("warns once about an action that keeps failing the same way", async () => {
+    // Given an alarm notifying a topic that is not there, driven back and
+    // forth so the same action fails twice.
+    const simAws = new SimAws();
+    const gone = `arn:aws:sns:${simAws.defaultRegionName}:${simAws.defaultAccountId}:gone`;
+
+    await simAws.cloudWatch().putMetricAlarm({
+      input: { ...valid, AlarmActions: [gone], OKActions: [gone] },
+    });
+
+    for (const StateValue of ["ALARM", "OK"]) {
+      // oxlint-disable-next-line no-await-in-loop
+      await simAws.cloudWatch().setAlarmState({
+        input: {
+          AlarmName: "OrdersFailing",
+          StateValue,
+          StateReason: "Forced",
+        },
+      });
+    }
+
+    await simAws.backgroundTasksComplete();
+
+    // Then both failures are kept, so a test can find either of them, even
+    // though only the first was warned about.
+    assertArrayLength(simAws.cloudWatch().alarmActionFailures, 2);
+  });
+
+  it("says nothing about deleting an alarm that was never there", async () => {
+    // Given a simulation with no alarms.
+    const simAws = new SimAws();
+
+    // When a delete names one anyway.
+    await simAws
+      .cloudWatch()
+      .deleteAlarms({ input: { AlarmNames: ["never-existed"] } });
+
+    // Then it is a no-op, as real DeleteAlarms is for an unknown name.
+    assertArrayLength(simAws.cloudWatch().allAlarms(), 0);
+  });
+});

--- a/src/service/cloudwatch/sim-cloudwatch-alarm-actions.iso.test.ts
+++ b/src/service/cloudwatch/sim-cloudwatch-alarm-actions.iso.test.ts
@@ -381,20 +381,4 @@ describe("SimCloudWatch alarm actions", () => {
       ["Channel"],
     );
   });
-
-  it("gives a forced state a reason of its own when none was supplied", async () => {
-    // Given an alarm forced into a state with no reason given.
-    const { simAws, topicArn } = await withSubscribedQueue();
-
-    await simAws.cloudWatch().putMetricAlarm(alarmNotifying(topicArn));
-    await simAws.cloudWatch().setAlarmState({
-      input: { AlarmName: "OrdersFailing", StateValue: "ALARM" },
-    });
-
-    // Then it still records why it moved.
-    const forced = simAws.cloudWatch().allAlarms().at(0);
-
-    assertNonNullable(forced);
-    assertIdentical(forced.stateReason, "Set by SetAlarmState");
-  });
 });

--- a/src/service/cloudwatch/sim-cloudwatch-alarm-actions.iso.test.ts
+++ b/src/service/cloudwatch/sim-cloudwatch-alarm-actions.iso.test.ts
@@ -1,0 +1,400 @@
+import {
+  PutMetricAlarmCommand,
+  PutMetricDataCommand,
+  SetAlarmStateCommand,
+} from "@aws-sdk/client-cloudwatch";
+import { CreateTopicCommand, SubscribeCommand } from "@aws-sdk/client-sns";
+import {
+  CreateQueueCommand,
+  ReceiveMessageCommand,
+  SetQueueAttributesCommand,
+} from "@aws-sdk/client-sqs";
+import {
+  assertArrayEquals,
+  assertArrayIncludes,
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../aws/sim-aws.js";
+
+/**
+ * The parts of an alarm notification these tests read.
+ */
+interface AlarmMessage {
+  readonly AlarmName: string;
+  readonly NewStateValue: string;
+  readonly OldStateValue: string;
+  readonly NewStateReason: string;
+  readonly StateChangeTime: string;
+  readonly Trigger: unknown;
+}
+
+interface SnsEnvelope {
+  readonly Subject: string;
+  readonly Message: string;
+}
+
+const startedAt = new Date("2026-08-16T09:00:00.000Z");
+
+/**
+ * A simulation with a queue subscribed to a topic, so that what an alarm
+ * publishes can be read back off the queue the way a real subscriber reads it.
+ */
+async function withSubscribedQueue(): Promise<{
+  simAws: SimAws;
+  topicArn: string;
+  queueUrl: string;
+}> {
+  const simAws = new SimAws();
+
+  await simAws.clock().setTo(startedAt);
+
+  const topic = await simAws
+    .sns()
+    .createTopic(new CreateTopicCommand({ Name: "orders-alerts" }));
+  const queue = await simAws
+    .sqs()
+    .createQueue(new CreateQueueCommand({ QueueName: "alerts" }));
+
+  assertNonNullable(topic.TopicArn);
+  assertNonNullable(queue.QueueUrl);
+
+  // The queue's own policy has to admit SNS, exactly as it does in an account:
+  // a subscription alone does not give a topic the right to send.
+  await simAws.sqs().setQueueAttributes(
+    new SetQueueAttributesCommand({
+      QueueUrl: queue.QueueUrl,
+      Attributes: {
+        Policy: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: [
+            {
+              Effect: "Allow",
+              Principal: { Service: "sns.amazonaws.com" },
+              Action: "sqs:SendMessage",
+              Resource: `arn:aws:sqs:${simAws.defaultRegionName}:${simAws.defaultAccountId}:alerts`,
+              Condition: { ArnEquals: { "aws:SourceArn": topic.TopicArn } },
+            },
+          ],
+        }),
+      },
+    }),
+  );
+
+  await simAws.sns().subscribe(
+    new SubscribeCommand({
+      TopicArn: topic.TopicArn,
+      Protocol: "sqs",
+      Endpoint: `arn:aws:sqs:${simAws.defaultRegionName}:${simAws.defaultAccountId}:alerts`,
+    }),
+  );
+
+  return { simAws, topicArn: topic.TopicArn, queueUrl: queue.QueueUrl };
+}
+
+async function alertsOn(
+  simAws: SimAws,
+  queueUrl: string,
+): Promise<readonly (string | undefined)[]> {
+  const received = await simAws.sqs().receiveMessage(
+    new ReceiveMessageCommand({
+      QueueUrl: queueUrl,
+      MaxNumberOfMessages: 10,
+    }),
+  );
+
+  return (received.Messages ?? []).map((message) => message.Body);
+}
+
+/**
+ * An alarm over `Orders`/`Failed` that fires on one breaching minute.
+ */
+function alarmNotifying(
+  topicArn: string,
+  overrides: Partial<PutMetricAlarmCommand["input"]> = {},
+): PutMetricAlarmCommand {
+  return new PutMetricAlarmCommand({
+    AlarmName: "OrdersFailing",
+    Namespace: "Orders",
+    MetricName: "Failed",
+    Statistic: "Sum",
+    Period: 60,
+    EvaluationPeriods: 1,
+    Threshold: 5,
+    ComparisonOperator: "GreaterThanThreshold",
+    AlarmActions: [topicArn],
+    ...overrides,
+  });
+}
+
+describe("SimCloudWatch alarm actions", () => {
+  it("notifies a subscribed queue when the alarm fires", async () => {
+    // Given an alarm notifying a topic a queue is subscribed to.
+    const { simAws, topicArn, queueUrl } = await withSubscribedQueue();
+
+    await simAws.cloudWatch().putMetricAlarm(alarmNotifying(topicArn));
+
+    // When a breaching minute passes.
+    await simAws.cloudWatch().putMetricData(
+      new PutMetricDataCommand({
+        Namespace: "Orders",
+        MetricData: [{ MetricName: "Failed", Value: 10 }],
+      }),
+    );
+    await simAws.clock().advanceBy({ minutes: 1 });
+
+    // Then the notification reached the queue, carrying what a subscriber
+    // reads out of it.
+    const bodies = await alertsOn(simAws, queueUrl);
+
+    assertArrayLength(bodies, 1);
+
+    const body = bodies.at(0);
+
+    assertNonNullable(body);
+
+    const notification = JSON.parse(body) as SnsEnvelope;
+    const alarm = JSON.parse(notification.Message) as AlarmMessage;
+
+    assertStringIncludes(notification.Subject, 'ALARM: "OrdersFailing"');
+    assertIdentical(alarm.AlarmName, "OrdersFailing");
+    assertIdentical(alarm.NewStateValue, "ALARM");
+    assertIdentical(alarm.OldStateValue, "INSUFFICIENT_DATA");
+    assertIdentical(alarm.StateChangeTime, "2026-08-16T09:01:00.000Z");
+    assertNonNullable(alarm.NewStateReason);
+    assertNonNullable(alarm.Trigger);
+  });
+
+  it("notifies once on the transition and not on every period after it", async () => {
+    // Given an alarm that has fired.
+    const { simAws, topicArn, queueUrl } = await withSubscribedQueue();
+
+    await simAws.cloudWatch().putMetricAlarm(alarmNotifying(topicArn));
+    await simAws.cloudWatch().putMetricData(
+      new PutMetricDataCommand({
+        Namespace: "Orders",
+        MetricData: [
+          { MetricName: "Failed", Value: 10 },
+          {
+            MetricName: "Failed",
+            Value: 10,
+            Timestamp: new Date("2026-08-16T09:01:30.000Z"),
+          },
+          {
+            MetricName: "Failed",
+            Value: 10,
+            Timestamp: new Date("2026-08-16T09:02:30.000Z"),
+          },
+        ],
+      }),
+    );
+
+    // When it stays breaching for three minutes.
+    await simAws.clock().advanceBy({ minutes: 3 });
+
+    // Then it notified once, when it changed, rather than once a period.
+    assertArrayLength(await alertsOn(simAws, queueUrl), 1);
+  });
+
+  it("notifies the OK actions when it recovers", async () => {
+    // Given an alarm with both lists pointed at the same topic.
+    const { simAws, topicArn, queueUrl } = await withSubscribedQueue();
+
+    await simAws
+      .cloudWatch()
+      .putMetricAlarm(alarmNotifying(topicArn, { OKActions: [topicArn] }));
+
+    // When it fires and then recovers.
+    await simAws.cloudWatch().putMetricData(
+      new PutMetricDataCommand({
+        Namespace: "Orders",
+        MetricData: [{ MetricName: "Failed", Value: 10 }],
+      }),
+    );
+    await simAws.clock().advanceBy({ minutes: 1 });
+    await simAws.cloudWatch().putMetricData(
+      new PutMetricDataCommand({
+        Namespace: "Orders",
+        MetricData: [{ MetricName: "Failed", Value: 1 }],
+      }),
+    );
+    await simAws.clock().advanceBy({ minutes: 1 });
+
+    // Then both transitions were notified.
+    const bodies = await alertsOn(simAws, queueUrl);
+    const states = bodies.map((body) => {
+      const notification = JSON.parse(String(body)) as SnsEnvelope;
+
+      return (JSON.parse(notification.Message) as AlarmMessage).NewStateValue;
+    });
+
+    assertArrayLength(states, 2);
+    assertArrayIncludes(states, "ALARM");
+    assertArrayIncludes(states, "OK");
+  });
+
+  it("evaluates but publishes nothing when actions are disabled", async () => {
+    // Given an alarm with its actions turned off.
+    const { simAws, topicArn, queueUrl } = await withSubscribedQueue();
+
+    await simAws
+      .cloudWatch()
+      .putMetricAlarm(alarmNotifying(topicArn, { ActionsEnabled: false }));
+
+    // When a breaching minute passes.
+    await simAws.cloudWatch().putMetricData(
+      new PutMetricDataCommand({
+        Namespace: "Orders",
+        MetricData: [{ MetricName: "Failed", Value: 10 }],
+      }),
+    );
+    await simAws.clock().advanceBy({ minutes: 1 });
+
+    // Then it still evaluated and changed state, and told nobody.
+    assertIdentical(simAws.cloudWatch().allAlarms().at(0)?.state, "ALARM");
+    assertArrayLength(await alertsOn(simAws, queueUrl), 0);
+  });
+
+  it("fires actions for a state forced with SetAlarmState", async () => {
+    // Given an alarm that has published no metrics at all.
+    const { simAws, topicArn, queueUrl } = await withSubscribedQueue();
+
+    await simAws.cloudWatch().putMetricAlarm(alarmNotifying(topicArn));
+
+    // When its state is forced.
+    await simAws.cloudWatch().setAlarmState(
+      new SetAlarmStateCommand({
+        AlarmName: "OrdersFailing",
+        StateValue: "ALARM",
+        StateReason: "Testing the runbook",
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // Then the subscriber heard about it, which is how a test exercises one
+    // without arranging a metric to breach.
+    const bodies = await alertsOn(simAws, queueUrl);
+    const body = bodies.at(0);
+
+    assertArrayLength(bodies, 1);
+    assertNonNullable(body);
+    assertStringIncludes(body, "Testing the runbook");
+  });
+
+  it("records an action that reached nothing rather than passing quietly", async () => {
+    // Given an alarm notifying a topic that does not exist.
+    const simAws = new SimAws();
+
+    await simAws.clock().setTo(startedAt);
+    await simAws
+      .cloudWatch()
+      .putMetricAlarm(
+        alarmNotifying(
+          `arn:aws:sns:${simAws.defaultRegionName}:${simAws.defaultAccountId}:gone`,
+        ),
+      );
+
+    // When it fires.
+    await simAws.cloudWatch().setAlarmState(
+      new SetAlarmStateCommand({
+        AlarmName: "OrdersFailing",
+        StateValue: "ALARM",
+        StateReason: "The topic this names is not there",
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // Then the alarm still changed state, and the failed notification is there
+    // to be found rather than being silence a test has to guess at.
+    const cloudWatch = simAws.cloudWatch();
+    const failure = cloudWatch.alarmActionFailures.at(0);
+
+    assertIdentical(cloudWatch.allAlarms().at(0)?.state, "ALARM");
+    assertArrayLength(cloudWatch.alarmActionFailures, 1);
+    assertNonNullable(failure);
+    assertStringIncludes(failure.reason, "Topic does not exist");
+  });
+
+  it("notifies the insufficient-data actions, and carries the alarm's own detail", async () => {
+    // Given an alarm with a description and a unit, notifying the same topic
+    // whichever state it lands in.
+    const { simAws, topicArn, queueUrl } = await withSubscribedQueue();
+
+    await simAws.cloudWatch().putMetricAlarm(
+      alarmNotifying(topicArn, {
+        AlarmDescription: "Orders are failing",
+        Unit: "Count",
+        Dimensions: [{ Name: "Channel", Value: "web" }],
+        InsufficientDataActions: [topicArn],
+      }),
+    );
+
+    // When it fires on real data and then the metric stops being published,
+    // so it falls back out of ALARM for want of anything to look at. Landing
+    // in a state it is already in is no transition, so it has to leave
+    // INSUFFICIENT_DATA before it can be notified about arriving there.
+    await simAws.cloudWatch().putMetricData(
+      new PutMetricDataCommand({
+        Namespace: "Orders",
+        MetricData: [
+          {
+            MetricName: "Failed",
+            Value: 10,
+            Unit: "Count",
+            Dimensions: [{ Name: "Channel", Value: "web" }],
+          },
+        ],
+      }),
+    );
+    await simAws.clock().advanceBy({ minutes: 3 });
+
+    // Then the insufficient-data list was notified, with the description and
+    // unit the alarm was given.
+    const bodies = await alertsOn(simAws, queueUrl);
+    const notifications = bodies.map((body) => {
+      const envelope = JSON.parse(String(body)) as SnsEnvelope;
+
+      return {
+        subject: envelope.Subject,
+        alarm: JSON.parse(envelope.Message) as AlarmMessage & {
+          AlarmDescription: string;
+          Trigger: {
+            Unit: string;
+            Dimensions: readonly { name: string; value: string }[];
+          };
+        },
+      };
+    });
+    const quiet = notifications.find((one) =>
+      one.subject.startsWith("INSUFFICIENT_DATA"),
+    );
+
+    assertNonNullable(quiet);
+    assertIdentical(quiet.alarm.AlarmDescription, "Orders are failing");
+    assertIdentical(quiet.alarm.Trigger.Unit, "Count");
+    assertArrayEquals(
+      quiet.alarm.Trigger.Dimensions.map((dimension) => dimension.name),
+      ["Channel"],
+    );
+  });
+
+  it("gives a forced state a reason of its own when none was supplied", async () => {
+    // Given an alarm forced into a state with no reason given.
+    const { simAws, topicArn } = await withSubscribedQueue();
+
+    await simAws.cloudWatch().putMetricAlarm(alarmNotifying(topicArn));
+    await simAws.cloudWatch().setAlarmState({
+      input: { AlarmName: "OrdersFailing", StateValue: "ALARM" },
+    });
+
+    // Then it still records why it moved.
+    const forced = simAws.cloudWatch().allAlarms().at(0);
+
+    assertNonNullable(forced);
+    assertIdentical(forced.stateReason, "Set by SetAlarmState");
+  });
+});

--- a/src/service/cloudwatch/sim-cloudwatch-alarm-evaluation.iso.test.ts
+++ b/src/service/cloudwatch/sim-cloudwatch-alarm-evaluation.iso.test.ts
@@ -1,0 +1,188 @@
+import {
+  DescribeAlarmsCommand,
+  PutMetricAlarmCommand,
+  PutMetricDataCommand,
+} from "@aws-sdk/client-cloudwatch";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../aws/sim-aws.js";
+
+const startedAt = new Date("2026-08-16T09:00:00.000Z");
+
+/**
+ * A simulation whose clock is stopped on a minute boundary, with one alarm
+ * over `Orders`/`Failed` watching for a sum above five.
+ */
+async function withAlarm(
+  overrides: Partial<PutMetricAlarmCommand["input"]> = {},
+): Promise<SimAws> {
+  const simAws = new SimAws();
+
+  await simAws.clock().setTo(startedAt);
+  await simAws.cloudWatch().putMetricAlarm(
+    new PutMetricAlarmCommand({
+      AlarmName: "OrdersFailing",
+      Namespace: "Orders",
+      MetricName: "Failed",
+      Statistic: "Sum",
+      Period: 60,
+      EvaluationPeriods: 3,
+      DatapointsToAlarm: 2,
+      Threshold: 5,
+      ComparisonOperator: "GreaterThanThreshold",
+      ...overrides,
+    }),
+  );
+
+  return simAws;
+}
+
+/**
+ * Publish one failure count into the minute the clock is standing in.
+ */
+async function publish(simAws: SimAws, value: number): Promise<void> {
+  await simAws.cloudWatch().putMetricData(
+    new PutMetricDataCommand({
+      Namespace: "Orders",
+      MetricData: [{ MetricName: "Failed", Value: value }],
+    }),
+  );
+}
+
+async function stateOf(simAws: SimAws): Promise<string> {
+  const described = await simAws
+    .cloudWatch()
+    .describeAlarms(
+      new DescribeAlarmsCommand({ AlarmNames: ["OrdersFailing"] }),
+    );
+  const alarm = described.MetricAlarms?.at(0);
+
+  assertNonNullable(alarm);
+
+  return alarm.StateValue;
+}
+
+describe("SimCloudWatch alarm evaluation", () => {
+  it("starts in INSUFFICIENT_DATA until it has evaluated", async () => {
+    // Given an alarm just created, with no time passed.
+    const simAws = await withAlarm();
+
+    // When its state is read.
+    // Then it has not evaluated anything yet, as on real CloudWatch.
+    assertIdentical(await stateOf(simAws), "INSUFFICIENT_DATA");
+  });
+
+  it("evaluates nothing while the clock stands still", async () => {
+    // Given an alarm and a breaching value published into the current minute.
+    const simAws = await withAlarm();
+
+    await publish(simAws, 10);
+    await publish(simAws, 10);
+    await simAws.backgroundTasksComplete();
+
+    // When no time passes.
+    // Then nothing has evaluated: an alarm here runs on the simulation's
+    // clock, so a frozen clock leaves it where it was.
+    assertIdentical(await stateOf(simAws), "INSUFFICIENT_DATA");
+  });
+
+  it("fires once two of three periods breach, and not before", async () => {
+    // Given an alarm wanting two breaching minutes out of three.
+    const simAws = await withAlarm();
+
+    // When one breaching minute passes.
+    await publish(simAws, 10);
+    await simAws.clock().advanceBy({ minutes: 1 });
+
+    const afterOne = await stateOf(simAws);
+
+    // And then a second.
+    await publish(simAws, 10);
+    await simAws.clock().advanceBy({ minutes: 1 });
+
+    // Then one breaching minute was not enough and two were.
+    assertIdentical(afterOne, "OK");
+    assertIdentical(await stateOf(simAws), "ALARM");
+  });
+
+  it("comes back to OK once the breaching periods fall out of the window", async () => {
+    // Given an alarm that has fired.
+    const simAws = await withAlarm();
+
+    await publish(simAws, 10);
+    await simAws.clock().advanceBy({ minutes: 1 });
+    await publish(simAws, 10);
+    await simAws.clock().advanceBy({ minutes: 1 });
+
+    const fired = await stateOf(simAws);
+
+    // When quiet minutes pass until the breaching ones are behind the window.
+    await publish(simAws, 1);
+    await simAws.clock().advanceBy({ minutes: 3 });
+
+    // Then it recovers on its own.
+    assertIdentical(fired, "ALARM");
+    assertIdentical(await stateOf(simAws), "OK");
+  });
+
+  it("records every transition with the simulated time it happened at", async () => {
+    // Given an alarm that fires two minutes in.
+    const simAws = await withAlarm();
+
+    await publish(simAws, 10);
+    await simAws.clock().advanceBy({ minutes: 1 });
+    await publish(simAws, 10);
+    await simAws.clock().advanceBy({ minutes: 1 });
+
+    // When its history is read.
+    const alarm = simAws.cloudWatch().allAlarms().at(0);
+
+    assertNonNullable(alarm);
+
+    // Then each transition is stamped with the boundary it was evaluated at,
+    // rather than with wherever time was eventually advanced to.
+    assertArrayLength(alarm.history.all, 2);
+    assertIdentical(
+      alarm.history.all.at(0)?.timestamp.toISOString(),
+      "2026-08-16T09:02:00.000Z",
+    );
+    assertIdentical(alarm.history.all.at(0)?.state, "ALARM");
+    assertIdentical(
+      alarm.history.all.at(1)?.timestamp.toISOString(),
+      "2026-08-16T09:01:00.000Z",
+    );
+    assertIdentical(alarm.history.all.at(1)?.state, "OK");
+  });
+
+  it("walks one evaluation per period across a long advance", async () => {
+    // Given an alarm over a metric nothing is publishing to, told to treat a
+    // missing period as breaching.
+    const simAws = await withAlarm({
+      TreatMissingData: "breaching",
+      DatapointsToAlarm: 3,
+    });
+
+    // When twenty minutes pass in one call.
+    await simAws.clock().advanceBy({ minutes: 20 });
+
+    // Then it evaluated its way there rather than jumping, and it fired once
+    // and stayed there. It fires on its first evaluation because the window a
+    // new alarm looks back over reaches before the alarm existed, and those
+    // periods are as missing as any other: real CloudWatch puts an alarm over
+    // a metric nothing publishes into ALARM straight away too.
+    const alarm = simAws.cloudWatch().allAlarms().at(0);
+
+    assertNonNullable(alarm);
+    assertIdentical(alarm.state, "ALARM");
+    assertArrayLength(alarm.history.all, 1);
+    assertIdentical(
+      alarm.history.all.at(0)?.timestamp.toISOString(),
+      "2026-08-16T09:01:00.000Z",
+    );
+  });
+});

--- a/src/service/cloudwatch/sim-cloudwatch-alarm-evaluation.iso.test.ts
+++ b/src/service/cloudwatch/sim-cloudwatch-alarm-evaluation.iso.test.ts
@@ -185,4 +185,37 @@ describe("SimCloudWatch alarm evaluation", () => {
       "2026-08-16T09:01:00.000Z",
     );
   });
+
+  it("evaluates on the new period when an alarm's period is changed", async () => {
+    // Given an alarm evaluating once an hour.
+    const simAws = await withAlarm({
+      Period: 3600,
+      EvaluationPeriods: 1,
+      DatapointsToAlarm: 1,
+      TreatMissingData: "breaching",
+    });
+
+    // When it is put again with a one-minute period, well before the hour it
+    // was first scheduled for.
+    await simAws.clock().advanceBy({ minutes: 5 });
+    await simAws.cloudWatch().putMetricAlarm(
+      new PutMetricAlarmCommand({
+        AlarmName: "OrdersFailing",
+        Namespace: "Orders",
+        MetricName: "Failed",
+        Statistic: "Sum",
+        Period: 60,
+        EvaluationPeriods: 1,
+        DatapointsToAlarm: 1,
+        Threshold: 5,
+        ComparisonOperator: "GreaterThanThreshold",
+        TreatMissingData: "breaching",
+      }),
+    );
+    await simAws.clock().advanceBy({ minutes: 1 });
+
+    // Then it evaluated on the minute it now watches, rather than holding the
+    // turn it had booked for the top of the hour.
+    assertIdentical(await stateOf(simAws), "ALARM");
+  });
 });

--- a/src/service/cloudwatch/sim-cloudwatch-alarm-invalid-input.iso.test.ts
+++ b/src/service/cloudwatch/sim-cloudwatch-alarm-invalid-input.iso.test.ts
@@ -1,5 +1,6 @@
 import {
   assertArrayLength,
+  assertIdentical,
   assertInstanceOf,
   assertStringIncludes,
   assertThrowsErrorAsync,
@@ -187,5 +188,27 @@ describe("SimCloudWatch invalid alarm input", () => {
     // Then it is refused rather than treated as nothing to do.
     assertInstanceOf(error, SimCloudWatchMissingRequiredParameterException);
     assertArrayLength(simAws.cloudWatch().allAlarms(), 1);
+  });
+
+  it("refuses to force a state without saying why", async () => {
+    // Given an alarm, and a request to force its state with no reason.
+    const simAws = new SimAws();
+
+    await simAws.cloudWatch().putMetricAlarm({ input: valid });
+
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await simAws.cloudWatch().setAlarmState({
+          input: { AlarmName: "OrdersFailing", StateValue: "ALARM" },
+        }),
+    );
+
+    // Then it is refused, as real SetAlarmState requires a reason, and the
+    // alarm has not moved.
+    assertInstanceOf(error, SimCloudWatchMissingRequiredParameterException);
+    assertIdentical(
+      simAws.cloudWatch().allAlarms().at(0)?.state,
+      "INSUFFICIENT_DATA",
+    );
   });
 });

--- a/src/service/cloudwatch/sim-cloudwatch-alarm-invalid-input.iso.test.ts
+++ b/src/service/cloudwatch/sim-cloudwatch-alarm-invalid-input.iso.test.ts
@@ -1,0 +1,191 @@
+import {
+  assertArrayLength,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../aws/sim-aws.js";
+import type {
+  SimPutMetricAlarmCommandInput,
+  SimSetAlarmStateCommandInput,
+} from "./command/sim-cloudwatch-command.types.js";
+import {
+  SimCloudWatchInvalidParameterValueException,
+  SimCloudWatchMissingRequiredParameterException,
+} from "./error/sim-cloudwatch.error.js";
+
+/**
+ * The alarm these tests vary one field of at a time. They are built as plain
+ * command shapes because the SDK's own types refuse most of these outright: a
+ * ComparisonOperator of "Sideways" does not compile.
+ */
+const valid: SimPutMetricAlarmCommandInput = {
+  AlarmName: "OrdersFailing",
+  Namespace: "Orders",
+  MetricName: "Failed",
+  Statistic: "Sum",
+  Period: 60,
+  EvaluationPeriods: 3,
+  Threshold: 5,
+  ComparisonOperator: "GreaterThanThreshold",
+};
+
+async function putting(
+  overrides: Partial<SimPutMetricAlarmCommandInput>,
+): Promise<Error> {
+  return await assertThrowsErrorAsync(
+    async () =>
+      await new SimAws()
+        .cloudWatch()
+        .putMetricAlarm({ input: { ...valid, ...overrides } }),
+  );
+}
+
+async function settingState(
+  input: SimSetAlarmStateCommandInput,
+): Promise<Error> {
+  const simAws = new SimAws();
+
+  await simAws.cloudWatch().putMetricAlarm({ input: valid });
+
+  return await assertThrowsErrorAsync(
+    async () => await simAws.cloudWatch().setAlarmState({ input }),
+  );
+}
+
+describe("SimCloudWatch invalid alarm input", () => {
+  it("refuses a comparison it cannot evaluate", async () => {
+    // Given operators outside the four this simulation compares with.
+    // When each is used.
+    const unknown = await putting({ ComparisonOperator: "Sideways" });
+    const anomaly = await putting({
+      ComparisonOperator: "LessThanLowerOrGreaterThanUpperThreshold",
+    });
+
+    // Then each is refused, the anomaly one saying why it cannot be
+    // approximated.
+    assertInstanceOf(unknown, SimCloudWatchInvalidParameterValueException);
+    assertInstanceOf(anomaly, SimCloudWatchInvalidParameterValueException);
+    assertStringIncludes(anomaly.message, "Anomaly detection");
+  });
+
+  it("refuses periods and a threshold that are not numbers it can use", async () => {
+    // Given counts and a threshold outside what an alarm can be built from.
+    // When each is used.
+    const zeroPeriods = await putting({ EvaluationPeriods: 0 });
+    const fractional = await putting({ EvaluationPeriods: 1.5 });
+    const missingPeriods = await putting({ EvaluationPeriods: undefined });
+    const tooManyDatapoints = await putting({ DatapointsToAlarm: 4 });
+    const missingThreshold = await putting({ Threshold: undefined });
+    const infiniteThreshold = await putting({
+      Threshold: Infinity,
+    });
+
+    // Then each is refused.
+    assertInstanceOf(zeroPeriods, SimCloudWatchInvalidParameterValueException);
+    assertInstanceOf(fractional, SimCloudWatchInvalidParameterValueException);
+    assertInstanceOf(
+      missingPeriods,
+      SimCloudWatchMissingRequiredParameterException,
+    );
+    assertInstanceOf(
+      tooManyDatapoints,
+      SimCloudWatchInvalidParameterValueException,
+    );
+    assertInstanceOf(
+      missingThreshold,
+      SimCloudWatchMissingRequiredParameterException,
+    );
+    assertInstanceOf(
+      infiniteThreshold,
+      SimCloudWatchInvalidParameterValueException,
+    );
+  });
+
+  it("refuses a missing statistic and an unknown missing-data treatment", async () => {
+    // Given an alarm with no statistic, and one with a treatment CloudWatch
+    // does not have.
+    // When each is used.
+    const noStatistic = await putting({ Statistic: undefined });
+    const treatment = await putting({ TreatMissingData: "shrug" });
+
+    // Then each is refused.
+    assertInstanceOf(
+      noStatistic,
+      SimCloudWatchMissingRequiredParameterException,
+    );
+    assertInstanceOf(treatment, SimCloudWatchInvalidParameterValueException);
+  });
+
+  it("refuses an action that is not an SNS topic, and too many of them", async () => {
+    // Given actions this simulation does not carry out.
+    // When each is used.
+    const scaling = await putting({
+      AlarmActions: [
+        "arn:aws:autoscaling:us-east-1:111111111111:scalingPolicy:abc",
+      ],
+    });
+    const tooMany = await putting({
+      OKActions: Array.from(
+        { length: 6 },
+        (_, index) => `arn:aws:sns:us-east-1:111111111111:topic-${index}`,
+      ),
+    });
+
+    // Then each is refused, rather than stored and silently never carried out.
+    assertInstanceOf(scaling, SimCloudWatchInvalidParameterValueException);
+    assertStringIncludes(scaling.message, "notifies an SNS topic");
+    assertInstanceOf(tooMany, SimCloudWatchInvalidParameterValueException);
+  });
+
+  it("refuses the alarm kinds it does not simulate", async () => {
+    // Given the inputs that make an alarm something other than a threshold
+    // over one metric.
+    // When each is used.
+    const math = await putting({ Metrics: [{}] });
+    const anomaly = await putting({ ThresholdMetricId: "ad1" });
+    const percentile = await putting({ ExtendedStatistic: "p99" });
+    const lowSample = await putting({
+      EvaluateLowSampleCountPercentile: "ignore",
+    });
+    const tags = await putting({ Tags: [{}] });
+
+    // Then each says it is not simulated rather than evaluating something
+    // other than what was asked for.
+    for (const error of [math, anomaly, percentile, lowSample, tags]) {
+      assertInstanceOf(error, SimCloudWatchInvalidParameterValueException);
+      assertStringIncludes(error.message, "not simulated");
+    }
+  });
+
+  it("refuses a state that is not one an alarm can be in", async () => {
+    // Given a state value outside the three.
+    // When it is forced.
+    const error = await settingState({
+      AlarmName: "OrdersFailing",
+      StateValue: "BROKEN",
+    });
+
+    // Then it is refused.
+    assertInstanceOf(error, SimCloudWatchInvalidParameterValueException);
+  });
+
+  it("refuses a delete naming no alarms", async () => {
+    // Given a simulation with an alarm.
+    const simAws = new SimAws();
+
+    await simAws.cloudWatch().putMetricAlarm({ input: valid });
+
+    // When a delete carries no names.
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await simAws.cloudWatch().deleteAlarms({ input: { AlarmNames: [] } }),
+    );
+
+    // Then it is refused rather than treated as nothing to do.
+    assertInstanceOf(error, SimCloudWatchMissingRequiredParameterException);
+    assertArrayLength(simAws.cloudWatch().allAlarms(), 1);
+  });
+});

--- a/src/service/cloudwatch/sim-cloudwatch-alarm-listings.iso.test.ts
+++ b/src/service/cloudwatch/sim-cloudwatch-alarm-listings.iso.test.ts
@@ -1,0 +1,291 @@
+import {
+  DescribeAlarmHistoryCommand,
+  DescribeAlarmsCommand,
+  PutMetricAlarmCommand,
+  PutMetricDataCommand,
+  SetAlarmStateCommand,
+} from "@aws-sdk/client-cloudwatch";
+import {
+  assertArrayEquals,
+  assertArrayIncludes,
+  assertArrayLength,
+  assertIdentical,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../aws/sim-aws.js";
+
+const startedAt = new Date("2026-08-16T09:00:00.000Z");
+
+function alarm(
+  AlarmName: string,
+  overrides: Partial<PutMetricAlarmCommand["input"]> = {},
+): PutMetricAlarmCommand {
+  return new PutMetricAlarmCommand({
+    AlarmName,
+    Namespace: "Orders",
+    MetricName: "Failed",
+    Statistic: "Sum",
+    Period: 60,
+    EvaluationPeriods: 1,
+    Threshold: 5,
+    ComparisonOperator: "GreaterThanThreshold",
+    ...overrides,
+  });
+}
+
+async function simulation(): Promise<SimAws> {
+  const simAws = new SimAws();
+
+  await simAws.clock().setTo(startedAt);
+
+  return simAws;
+}
+
+/**
+ * Force one alarm into a state, which is how these tests make a transition
+ * without arranging a metric to breach.
+ */
+async function forceState(
+  simAws: SimAws,
+  AlarmName: string,
+  StateValue: "ALARM" | "OK",
+): Promise<void> {
+  await simAws.cloudWatch().setAlarmState(
+    new SetAlarmStateCommand({
+      AlarmName,
+      StateValue,
+      StateReason: "Forced",
+    }),
+  );
+}
+
+/**
+ * When each item in a history answer happened.
+ */
+function timesIn(history: {
+  AlarmHistoryItems?: readonly { Timestamp: Date }[] | undefined;
+}): readonly number[] {
+  return (history.AlarmHistoryItems ?? []).map((item) =>
+    item.Timestamp.getTime(),
+  );
+}
+
+describe("SimCloudWatch alarm listings", () => {
+  it("selects alarms by the actions they carry, and history by date", async () => {
+    // Given two alarms notifying different topics, one of which transitions.
+    const simAws = await simulation();
+    const topicArn = `arn:aws:sns:${simAws.defaultRegionName}:${simAws.defaultAccountId}:paging`;
+
+    await simAws
+      .cloudWatch()
+      .putMetricAlarm(alarm("paged", { OKActions: [topicArn] }));
+    await simAws.cloudWatch().putMetricAlarm(alarm("quiet"));
+    await simAws.cloudWatch().setAlarmState(
+      new SetAlarmStateCommand({
+        AlarmName: "paged",
+        StateValue: "ALARM",
+        StateReason: "Forced",
+      }),
+    );
+
+    // When alarms are selected by action prefix, and history by a window that
+    // ends before the transition.
+    const paging = await simAws.cloudWatch().describeAlarms(
+      new DescribeAlarmsCommand({
+        ActionPrefix: `arn:aws:sns:${simAws.defaultRegionName}`,
+      }),
+    );
+    const before = await simAws
+      .cloudWatch()
+      .describeAlarmHistory(
+        new DescribeAlarmHistoryCommand({ EndDate: startedAt }),
+      );
+    const including = await simAws.cloudWatch().describeAlarmHistory(
+      new DescribeAlarmHistoryCommand({
+        StartDate: startedAt,
+        EndDate: new Date("2026-08-16T10:00:00.000Z"),
+      }),
+    );
+
+    // Then each filter selects what it names, including an alarm whose only
+    // action is on its OK list rather than its alarm list, and the history
+    // window excludes its end as CloudWatch reads one.
+    assertArrayEquals(
+      paging.MetricAlarms?.map((one) => one.AlarmName),
+      ["paged"],
+    );
+    assertArrayLength(before.AlarmHistoryItems ?? [], 0);
+    assertArrayLength(including.AlarmHistoryItems ?? [], 1);
+  });
+
+  it("merges the history of every alarm into one order, newest first", async () => {
+    // Given two alarms whose transitions interleave in time.
+    const simAws = await simulation();
+
+    await simAws.cloudWatch().putMetricAlarm(alarm("first"));
+    await simAws.cloudWatch().putMetricAlarm(alarm("second"));
+
+    await forceState(simAws, "first", "ALARM");
+    await simAws.clock().advanceBy({ minutes: 1 });
+    await forceState(simAws, "second", "ALARM");
+    await simAws.clock().advanceBy({ minutes: 1 });
+    await forceState(simAws, "first", "OK");
+    await simAws.clock().advanceBy({ minutes: 1 });
+
+    // When the whole scope's history is read, and then read the other way.
+    const newest = await simAws
+      .cloudWatch()
+      .describeAlarmHistory(new DescribeAlarmHistoryCommand({}));
+    const oldest = await simAws
+      .cloudWatch()
+      .describeAlarmHistory(
+        new DescribeAlarmHistoryCommand({ ScanBy: "TimestampAscending" }),
+      );
+
+    // Then it comes back in time order across both alarms rather than one
+    // alarm's whole history after the other's, and the other way round when
+    // asked to scan ascending.
+    const descending = timesIn(newest);
+
+    assertArrayEquals(
+      descending,
+      descending.toSorted((left, right) => right - left),
+    );
+    assertArrayEquals(timesIn(oldest), descending.toReversed());
+    assertArrayIncludes(
+      (newest.AlarmHistoryItems ?? []).map((item) => item.AlarmName),
+      "second",
+    );
+  });
+
+  it("selects alarms by name, prefix and state", async () => {
+    // Given three alarms, one of them fired.
+    const simAws = await simulation();
+
+    await simAws.cloudWatch().putMetricAlarm(alarm("orders-failing"));
+    await simAws.cloudWatch().putMetricAlarm(alarm("orders-slow"));
+    await simAws.cloudWatch().putMetricAlarm(alarm("billing-failing"));
+    await simAws.cloudWatch().setAlarmState(
+      new SetAlarmStateCommand({
+        AlarmName: "orders-slow",
+        StateValue: "ALARM",
+        StateReason: "Forced",
+      }),
+    );
+
+    // When each filter is applied.
+    const named = await simAws
+      .cloudWatch()
+      .describeAlarms(
+        new DescribeAlarmsCommand({ AlarmNames: ["billing-failing"] }),
+      );
+    const prefixed = await simAws
+      .cloudWatch()
+      .describeAlarms(
+        new DescribeAlarmsCommand({ AlarmNamePrefix: "orders-" }),
+      );
+    const firing = await simAws
+      .cloudWatch()
+      .describeAlarms(new DescribeAlarmsCommand({ StateValue: "ALARM" }));
+
+    // Then each selects what it names.
+    assertArrayLength(named.MetricAlarms ?? [], 1);
+    assertArrayLength(prefixed.MetricAlarms ?? [], 2);
+    assertArrayEquals(
+      firing.MetricAlarms?.map((one) => one.AlarmName),
+      ["orders-slow"],
+    );
+  });
+
+  it("reports the history of an alarm's state changes, newest first", async () => {
+    // Given an alarm driven through two transitions a minute apart.
+    const simAws = await simulation();
+
+    await simAws
+      .cloudWatch()
+      .putMetricAlarm(alarm("OrdersFailing", { EvaluationPeriods: 1 }));
+    await simAws.cloudWatch().putMetricData(
+      new PutMetricDataCommand({
+        Namespace: "Orders",
+        MetricData: [{ MetricName: "Failed", Value: 10 }],
+      }),
+    );
+    await simAws.clock().advanceBy({ minutes: 1 });
+    await simAws.cloudWatch().putMetricData(
+      new PutMetricDataCommand({
+        Namespace: "Orders",
+        MetricData: [{ MetricName: "Failed", Value: 1 }],
+      }),
+    );
+    await simAws.clock().advanceBy({ minutes: 1 });
+
+    // When the history is read.
+    const history = await simAws
+      .cloudWatch()
+      .describeAlarmHistory(
+        new DescribeAlarmHistoryCommand({ AlarmName: "OrdersFailing" }),
+      );
+    const items = history.AlarmHistoryItems ?? [];
+
+    // Then both transitions are there, newest first, stamped with the
+    // simulated time each happened at.
+    assertArrayLength(items, 2);
+    assertIdentical(items.at(0)?.HistoryItemType, "StateUpdate");
+    assertIdentical(
+      items.at(0)?.Timestamp.toISOString(),
+      "2026-08-16T09:02:00.000Z",
+    );
+    assertIdentical(
+      items.at(1)?.Timestamp.toISOString(),
+      "2026-08-16T09:01:00.000Z",
+    );
+    assertIdentical(
+      items.at(0)?.HistorySummary,
+      "Alarm updated from ALARM to OK",
+    );
+  });
+
+  it("selects history by the kind of item, of which there is one", async () => {
+    // Given an alarm that has changed state once.
+    const simAws = await simulation();
+
+    await simAws.cloudWatch().putMetricAlarm(alarm("OrdersFailing"));
+    await forceState(simAws, "OrdersFailing", "ALARM");
+
+    // When state updates are asked for, and then configuration updates, which
+    // this simulation does not record.
+    const updates = await simAws
+      .cloudWatch()
+      .describeAlarmHistory(
+        new DescribeAlarmHistoryCommand({ HistoryItemType: "StateUpdate" }),
+      );
+    const configuration = await simAws.cloudWatch().describeAlarmHistory(
+      new DescribeAlarmHistoryCommand({
+        HistoryItemType: "ConfigurationUpdate",
+      }),
+    );
+
+    // Then the filter selects rather than being ignored, so a request for a
+    // kind that is not recorded gets nothing instead of everything.
+    assertArrayLength(updates.AlarmHistoryItems ?? [], 1);
+    assertArrayLength(configuration.AlarmHistoryItems ?? [], 0);
+  });
+
+  it("records nothing when a state is forced to the one it is already in", async () => {
+    // Given an alarm already forced into ALARM.
+    const simAws = await simulation();
+
+    await simAws.cloudWatch().putMetricAlarm(alarm("OrdersFailing"));
+    await forceState(simAws, "OrdersFailing", "ALARM");
+    await forceState(simAws, "OrdersFailing", "ALARM");
+
+    // When its history is read.
+    const history = await simAws
+      .cloudWatch()
+      .describeAlarmHistory(new DescribeAlarmHistoryCommand({}));
+
+    // Then the second call recorded nothing, because it was not a change.
+    assertArrayLength(history.AlarmHistoryItems ?? [], 1);
+  });
+});

--- a/src/service/cloudwatch/sim-cloudwatch-alarm-management.iso.test.ts
+++ b/src/service/cloudwatch/sim-cloudwatch-alarm-management.iso.test.ts
@@ -1,0 +1,290 @@
+import {
+  DeleteAlarmsCommand,
+  DescribeAlarmHistoryCommand,
+  DescribeAlarmsCommand,
+  PutMetricAlarmCommand,
+  PutMetricDataCommand,
+  SetAlarmStateCommand,
+} from "@aws-sdk/client-cloudwatch";
+import {
+  assertArrayEquals,
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertThrowsErrorAsync,
+  assertTrue,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../aws/sim-aws.js";
+import { SimCloudWatchInvalidParameterValueException } from "./error/sim-cloudwatch.error.js";
+
+const startedAt = new Date("2026-08-16T09:00:00.000Z");
+
+function alarm(
+  AlarmName: string,
+  overrides: Partial<PutMetricAlarmCommand["input"]> = {},
+): PutMetricAlarmCommand {
+  return new PutMetricAlarmCommand({
+    AlarmName,
+    Namespace: "Orders",
+    MetricName: "Failed",
+    Statistic: "Sum",
+    Period: 60,
+    EvaluationPeriods: 1,
+    Threshold: 5,
+    ComparisonOperator: "GreaterThanThreshold",
+    ...overrides,
+  });
+}
+
+async function simulation(): Promise<SimAws> {
+  const simAws = new SimAws();
+
+  await simAws.clock().setTo(startedAt);
+
+  return simAws;
+}
+
+describe("SimCloudWatch alarm management", () => {
+  it("reports an alarm with everything it was configured with", async () => {
+    // Given an alarm created with a full configuration.
+    const simAws = await simulation();
+
+    await simAws.cloudWatch().putMetricAlarm(
+      alarm("OrdersFailing", {
+        AlarmDescription: "Orders are failing",
+        Dimensions: [{ Name: "Channel", Value: "web" }],
+        DatapointsToAlarm: 1,
+        TreatMissingData: "notBreaching",
+      }),
+    );
+
+    // When it is described.
+    const described = await simAws
+      .cloudWatch()
+      .describeAlarms(new DescribeAlarmsCommand({}));
+    const reported = described.MetricAlarms?.at(0);
+
+    // Then everything it was given comes back, with the ARN naming its
+    // account and region.
+    assertNonNullable(reported);
+    assertIdentical(reported.AlarmName, "OrdersFailing");
+    assertIdentical(reported.AlarmDescription, "Orders are failing");
+    assertIdentical(
+      reported.AlarmArn,
+      `arn:aws:cloudwatch:${simAws.defaultRegionName}:${simAws.defaultAccountId}:alarm:OrdersFailing`,
+    );
+    assertIdentical(reported.StateValue, "INSUFFICIENT_DATA");
+    assertIdentical(reported.DatapointsToAlarm, 1);
+    assertIdentical(reported.TreatMissingData, "notBreaching");
+    assertTrue(reported.ActionsEnabled);
+    assertArrayEquals(
+      reported.Dimensions.map((dimension) => dimension.Value),
+      ["web"],
+    );
+  });
+
+  it("selects alarms by name, prefix and state", async () => {
+    // Given three alarms, one of them fired.
+    const simAws = await simulation();
+
+    await simAws.cloudWatch().putMetricAlarm(alarm("orders-failing"));
+    await simAws.cloudWatch().putMetricAlarm(alarm("orders-slow"));
+    await simAws.cloudWatch().putMetricAlarm(alarm("billing-failing"));
+    await simAws.cloudWatch().setAlarmState(
+      new SetAlarmStateCommand({
+        AlarmName: "orders-slow",
+        StateValue: "ALARM",
+        StateReason: "Forced",
+      }),
+    );
+
+    // When each filter is applied.
+    const named = await simAws
+      .cloudWatch()
+      .describeAlarms(
+        new DescribeAlarmsCommand({ AlarmNames: ["billing-failing"] }),
+      );
+    const prefixed = await simAws
+      .cloudWatch()
+      .describeAlarms(
+        new DescribeAlarmsCommand({ AlarmNamePrefix: "orders-" }),
+      );
+    const firing = await simAws
+      .cloudWatch()
+      .describeAlarms(new DescribeAlarmsCommand({ StateValue: "ALARM" }));
+
+    // Then each selects what it names.
+    assertArrayLength(named.MetricAlarms ?? [], 1);
+    assertArrayLength(prefixed.MetricAlarms ?? [], 2);
+    assertArrayEquals(
+      firing.MetricAlarms?.map((one) => one.AlarmName),
+      ["orders-slow"],
+    );
+  });
+
+  it("keeps state and history when an alarm is reconfigured", async () => {
+    // Given an alarm that has fired.
+    const simAws = await simulation();
+
+    await simAws.cloudWatch().putMetricAlarm(alarm("OrdersFailing"));
+    await simAws.cloudWatch().setAlarmState(
+      new SetAlarmStateCommand({
+        AlarmName: "OrdersFailing",
+        StateValue: "ALARM",
+        StateReason: "Forced",
+      }),
+    );
+
+    // When it is put again with a different threshold.
+    await simAws
+      .cloudWatch()
+      .putMetricAlarm(alarm("OrdersFailing", { Threshold: 500 }));
+
+    // Then there is still one alarm, holding the state and history it had:
+    // real PutMetricAlarm updates an alarm rather than replacing it.
+    const alarms = simAws.cloudWatch().allAlarms();
+
+    assertArrayLength(alarms, 1);
+    assertIdentical(alarms.at(0)?.state, "ALARM");
+    assertIdentical(alarms.at(0)?.definition.threshold, 500);
+    assertArrayLength(alarms.at(0)?.history.all ?? [], 1);
+  });
+
+  it("stops evaluating an alarm once it is deleted", async () => {
+    // Given an alarm watching a metric that would fire it.
+    const simAws = await simulation();
+
+    await simAws
+      .cloudWatch()
+      .putMetricAlarm(
+        alarm("OrdersFailing", { TreatMissingData: "breaching" }),
+      );
+
+    // When it is deleted before any time passes, and then time passes.
+    await simAws
+      .cloudWatch()
+      .deleteAlarms(new DeleteAlarmsCommand({ AlarmNames: ["OrdersFailing"] }));
+    await simAws.clock().advanceBy({ minutes: 10 });
+
+    // Then it is gone and nothing kept evaluating it, which is what stops a
+    // deleted alarm holding the simulation open.
+    assertArrayLength(simAws.cloudWatch().allAlarms(), 0);
+  });
+
+  it("reports the history of an alarm's state changes, newest first", async () => {
+    // Given an alarm driven through two transitions a minute apart.
+    const simAws = await simulation();
+
+    await simAws
+      .cloudWatch()
+      .putMetricAlarm(alarm("OrdersFailing", { EvaluationPeriods: 1 }));
+    await simAws.cloudWatch().putMetricData(
+      new PutMetricDataCommand({
+        Namespace: "Orders",
+        MetricData: [{ MetricName: "Failed", Value: 10 }],
+      }),
+    );
+    await simAws.clock().advanceBy({ minutes: 1 });
+    await simAws.cloudWatch().putMetricData(
+      new PutMetricDataCommand({
+        Namespace: "Orders",
+        MetricData: [{ MetricName: "Failed", Value: 1 }],
+      }),
+    );
+    await simAws.clock().advanceBy({ minutes: 1 });
+
+    // When the history is read.
+    const history = await simAws
+      .cloudWatch()
+      .describeAlarmHistory(
+        new DescribeAlarmHistoryCommand({ AlarmName: "OrdersFailing" }),
+      );
+    const items = history.AlarmHistoryItems ?? [];
+
+    // Then both transitions are there, newest first, stamped with the
+    // simulated time each happened at.
+    assertArrayLength(items, 2);
+    assertIdentical(items.at(0)?.HistoryItemType, "StateUpdate");
+    assertIdentical(
+      items.at(0)?.Timestamp.toISOString(),
+      "2026-08-16T09:02:00.000Z",
+    );
+    assertIdentical(
+      items.at(1)?.Timestamp.toISOString(),
+      "2026-08-16T09:01:00.000Z",
+    );
+    assertIdentical(
+      items.at(0)?.HistorySummary,
+      "Alarm updated from ALARM to OK",
+    );
+  });
+
+  it("refuses to set the state of an alarm that is not there", async () => {
+    // Given a simulation with no alarms.
+    const simAws = await simulation();
+
+    // When a state is forced on a name that does not exist.
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await simAws.cloudWatch().setAlarmState(
+          new SetAlarmStateCommand({
+            AlarmName: "Missing",
+            StateValue: "ALARM",
+            StateReason: "Forced",
+          }),
+        ),
+    );
+
+    // Then it says so rather than quietly doing nothing.
+    assertInstanceOf(error, SimCloudWatchInvalidParameterValueException);
+  });
+
+  it("selects alarms by the actions they carry, and history by date", async () => {
+    // Given two alarms notifying different topics, one of which transitions.
+    const simAws = await simulation();
+    const topicArn = `arn:aws:sns:${simAws.defaultRegionName}:${simAws.defaultAccountId}:paging`;
+
+    await simAws
+      .cloudWatch()
+      .putMetricAlarm(alarm("paged", { AlarmActions: [topicArn] }));
+    await simAws.cloudWatch().putMetricAlarm(alarm("quiet"));
+    await simAws.cloudWatch().setAlarmState(
+      new SetAlarmStateCommand({
+        AlarmName: "paged",
+        StateValue: "ALARM",
+        StateReason: "Forced",
+      }),
+    );
+
+    // When alarms are selected by action prefix, and history by a window that
+    // ends before the transition.
+    const paging = await simAws.cloudWatch().describeAlarms(
+      new DescribeAlarmsCommand({
+        ActionPrefix: `arn:aws:sns:${simAws.defaultRegionName}`,
+      }),
+    );
+    const before = await simAws
+      .cloudWatch()
+      .describeAlarmHistory(
+        new DescribeAlarmHistoryCommand({ EndDate: startedAt }),
+      );
+    const including = await simAws.cloudWatch().describeAlarmHistory(
+      new DescribeAlarmHistoryCommand({
+        StartDate: startedAt,
+        EndDate: new Date("2026-08-16T10:00:00.000Z"),
+      }),
+    );
+
+    // Then each filter selects what it names, and the history window excludes
+    // its end as CloudWatch reads one.
+    assertArrayEquals(
+      paging.MetricAlarms?.map((one) => one.AlarmName),
+      ["paged"],
+    );
+    assertArrayLength(before.AlarmHistoryItems ?? [], 0);
+    assertArrayLength(including.AlarmHistoryItems ?? [], 1);
+  });
+});

--- a/src/service/cloudwatch/sim-cloudwatch-alarm-management.iso.test.ts
+++ b/src/service/cloudwatch/sim-cloudwatch-alarm-management.iso.test.ts
@@ -1,9 +1,7 @@
 import {
   DeleteAlarmsCommand,
-  DescribeAlarmHistoryCommand,
   DescribeAlarmsCommand,
   PutMetricAlarmCommand,
-  PutMetricDataCommand,
   SetAlarmStateCommand,
 } from "@aws-sdk/client-cloudwatch";
 import {
@@ -86,45 +84,6 @@ describe("SimCloudWatch alarm management", () => {
     );
   });
 
-  it("selects alarms by name, prefix and state", async () => {
-    // Given three alarms, one of them fired.
-    const simAws = await simulation();
-
-    await simAws.cloudWatch().putMetricAlarm(alarm("orders-failing"));
-    await simAws.cloudWatch().putMetricAlarm(alarm("orders-slow"));
-    await simAws.cloudWatch().putMetricAlarm(alarm("billing-failing"));
-    await simAws.cloudWatch().setAlarmState(
-      new SetAlarmStateCommand({
-        AlarmName: "orders-slow",
-        StateValue: "ALARM",
-        StateReason: "Forced",
-      }),
-    );
-
-    // When each filter is applied.
-    const named = await simAws
-      .cloudWatch()
-      .describeAlarms(
-        new DescribeAlarmsCommand({ AlarmNames: ["billing-failing"] }),
-      );
-    const prefixed = await simAws
-      .cloudWatch()
-      .describeAlarms(
-        new DescribeAlarmsCommand({ AlarmNamePrefix: "orders-" }),
-      );
-    const firing = await simAws
-      .cloudWatch()
-      .describeAlarms(new DescribeAlarmsCommand({ StateValue: "ALARM" }));
-
-    // Then each selects what it names.
-    assertArrayLength(named.MetricAlarms ?? [], 1);
-    assertArrayLength(prefixed.MetricAlarms ?? [], 2);
-    assertArrayEquals(
-      firing.MetricAlarms?.map((one) => one.AlarmName),
-      ["orders-slow"],
-    );
-  });
-
   it("keeps state and history when an alarm is reconfigured", async () => {
     // Given an alarm that has fired.
     const simAws = await simulation();
@@ -174,54 +133,6 @@ describe("SimCloudWatch alarm management", () => {
     assertArrayLength(simAws.cloudWatch().allAlarms(), 0);
   });
 
-  it("reports the history of an alarm's state changes, newest first", async () => {
-    // Given an alarm driven through two transitions a minute apart.
-    const simAws = await simulation();
-
-    await simAws
-      .cloudWatch()
-      .putMetricAlarm(alarm("OrdersFailing", { EvaluationPeriods: 1 }));
-    await simAws.cloudWatch().putMetricData(
-      new PutMetricDataCommand({
-        Namespace: "Orders",
-        MetricData: [{ MetricName: "Failed", Value: 10 }],
-      }),
-    );
-    await simAws.clock().advanceBy({ minutes: 1 });
-    await simAws.cloudWatch().putMetricData(
-      new PutMetricDataCommand({
-        Namespace: "Orders",
-        MetricData: [{ MetricName: "Failed", Value: 1 }],
-      }),
-    );
-    await simAws.clock().advanceBy({ minutes: 1 });
-
-    // When the history is read.
-    const history = await simAws
-      .cloudWatch()
-      .describeAlarmHistory(
-        new DescribeAlarmHistoryCommand({ AlarmName: "OrdersFailing" }),
-      );
-    const items = history.AlarmHistoryItems ?? [];
-
-    // Then both transitions are there, newest first, stamped with the
-    // simulated time each happened at.
-    assertArrayLength(items, 2);
-    assertIdentical(items.at(0)?.HistoryItemType, "StateUpdate");
-    assertIdentical(
-      items.at(0)?.Timestamp.toISOString(),
-      "2026-08-16T09:02:00.000Z",
-    );
-    assertIdentical(
-      items.at(1)?.Timestamp.toISOString(),
-      "2026-08-16T09:01:00.000Z",
-    );
-    assertIdentical(
-      items.at(0)?.HistorySummary,
-      "Alarm updated from ALARM to OK",
-    );
-  });
-
   it("refuses to set the state of an alarm that is not there", async () => {
     // Given a simulation with no alarms.
     const simAws = await simulation();
@@ -240,51 +151,5 @@ describe("SimCloudWatch alarm management", () => {
 
     // Then it says so rather than quietly doing nothing.
     assertInstanceOf(error, SimCloudWatchInvalidParameterValueException);
-  });
-
-  it("selects alarms by the actions they carry, and history by date", async () => {
-    // Given two alarms notifying different topics, one of which transitions.
-    const simAws = await simulation();
-    const topicArn = `arn:aws:sns:${simAws.defaultRegionName}:${simAws.defaultAccountId}:paging`;
-
-    await simAws
-      .cloudWatch()
-      .putMetricAlarm(alarm("paged", { AlarmActions: [topicArn] }));
-    await simAws.cloudWatch().putMetricAlarm(alarm("quiet"));
-    await simAws.cloudWatch().setAlarmState(
-      new SetAlarmStateCommand({
-        AlarmName: "paged",
-        StateValue: "ALARM",
-        StateReason: "Forced",
-      }),
-    );
-
-    // When alarms are selected by action prefix, and history by a window that
-    // ends before the transition.
-    const paging = await simAws.cloudWatch().describeAlarms(
-      new DescribeAlarmsCommand({
-        ActionPrefix: `arn:aws:sns:${simAws.defaultRegionName}`,
-      }),
-    );
-    const before = await simAws
-      .cloudWatch()
-      .describeAlarmHistory(
-        new DescribeAlarmHistoryCommand({ EndDate: startedAt }),
-      );
-    const including = await simAws.cloudWatch().describeAlarmHistory(
-      new DescribeAlarmHistoryCommand({
-        StartDate: startedAt,
-        EndDate: new Date("2026-08-16T10:00:00.000Z"),
-      }),
-    );
-
-    // Then each filter selects what it names, and the history window excludes
-    // its end as CloudWatch reads one.
-    assertArrayEquals(
-      paging.MetricAlarms?.map((one) => one.AlarmName),
-      ["paged"],
-    );
-    assertArrayLength(before.AlarmHistoryItems ?? [], 0);
-    assertArrayLength(including.AlarmHistoryItems ?? [], 1);
   });
 });

--- a/src/service/cloudwatch/sim-cloudwatch-alarm-missing-data.iso.test.ts
+++ b/src/service/cloudwatch/sim-cloudwatch-alarm-missing-data.iso.test.ts
@@ -1,0 +1,145 @@
+import {
+  PutMetricAlarmCommand,
+  PutMetricDataCommand,
+} from "@aws-sdk/client-cloudwatch";
+import {
+  assertArrayEquals,
+  assertIdentical,
+  assertNonNullable,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../aws/sim-aws.js";
+
+const startedAt = new Date("2026-08-16T09:00:00.000Z");
+
+/**
+ * An alarm over a metric nothing publishes into, watching two periods, with
+ * whatever treatment of missing data the test is about.
+ */
+async function withMissingData(
+  treatMissingData: string,
+  overrides: Partial<PutMetricAlarmCommand["input"]> = {},
+): Promise<SimAws> {
+  const simAws = new SimAws();
+
+  await simAws.clock().setTo(startedAt);
+  await simAws.cloudWatch().putMetricAlarm(
+    new PutMetricAlarmCommand({
+      AlarmName: "Quiet",
+      Namespace: "Orders",
+      MetricName: "Failed",
+      Statistic: "Sum",
+      Period: 60,
+      EvaluationPeriods: 2,
+      Threshold: 5,
+      ComparisonOperator: "GreaterThanThreshold",
+      TreatMissingData: treatMissingData,
+      ...overrides,
+    }),
+  );
+
+  return simAws;
+}
+
+function stateOf(simAws: SimAws): string {
+  const alarm = simAws.cloudWatch().allAlarms().at(0);
+
+  assertNonNullable(alarm);
+
+  return alarm.state;
+}
+
+describe("SimCloudWatch alarm missing data", () => {
+  it("reports INSUFFICIENT_DATA when periods are simply missing", async () => {
+    // Given an alarm treating missing data the default way.
+    const simAws = await withMissingData("missing");
+
+    // When two empty minutes pass.
+    await simAws.clock().advanceBy({ minutes: 2 });
+
+    // Then it has nothing to go on rather than an opinion.
+    assertIdentical(stateOf(simAws), "INSUFFICIENT_DATA");
+  });
+
+  it("stays OK when a missing period counts as not breaching", async () => {
+    // Given an alarm treating a quiet period as healthy.
+    const simAws = await withMissingData("notBreaching");
+
+    // When two empty minutes pass.
+    await simAws.clock().advanceBy({ minutes: 2 });
+
+    // Then it is satisfied rather than uncertain.
+    assertIdentical(stateOf(simAws), "OK");
+  });
+
+  it("fires when a missing period counts as breaching", async () => {
+    // Given an alarm treating silence as a problem, which is how a heartbeat
+    // metric is watched.
+    const simAws = await withMissingData("breaching");
+
+    // When two empty minutes pass.
+    await simAws.clock().advanceBy({ minutes: 2 });
+
+    // Then it fires on the silence.
+    assertIdentical(stateOf(simAws), "ALARM");
+  });
+
+  it("keeps whatever state it had when told to ignore missing periods", async () => {
+    // Given an alarm that has been driven into ALARM by real data.
+    const simAws = await withMissingData("ignore", { EvaluationPeriods: 1 });
+
+    await simAws.cloudWatch().putMetricData(
+      new PutMetricDataCommand({
+        Namespace: "Orders",
+        MetricData: [{ MetricName: "Failed", Value: 10 }],
+      }),
+    );
+    await simAws.clock().advanceBy({ minutes: 1 });
+
+    const fired = stateOf(simAws);
+
+    // When the metric stops being published entirely.
+    await simAws.clock().advanceBy({ minutes: 10 });
+
+    // Then it holds where it was rather than falling back to
+    // INSUFFICIENT_DATA, which is what `ignore` asks for.
+    assertIdentical(fired, "ALARM");
+    assertIdentical(stateOf(simAws), "ALARM");
+  });
+
+  it("compares each way real CloudWatch compares", async () => {
+    // Given the four threshold comparisons, each over a metric holding five.
+    const cases = [
+      { ComparisonOperator: "GreaterThanOrEqualToThreshold", fires: true },
+      { ComparisonOperator: "GreaterThanThreshold", fires: false },
+      { ComparisonOperator: "LessThanThreshold", fires: false },
+      { ComparisonOperator: "LessThanOrEqualToThreshold", fires: true },
+    ] as const;
+    const fired = await Promise.all(
+      cases.map(async (one) => {
+        const simAws = await withMissingData("missing", {
+          EvaluationPeriods: 1,
+          ComparisonOperator: one.ComparisonOperator,
+        });
+
+        await simAws.cloudWatch().putMetricData(
+          new PutMetricDataCommand({
+            Namespace: "Orders",
+            MetricData: [{ MetricName: "Failed", Value: 5 }],
+          }),
+        );
+        await simAws.clock().advanceBy({ minutes: 1 });
+
+        return stateOf(simAws) === "ALARM";
+      }),
+    );
+
+    // Then each fired exactly when a value equal to the threshold should make
+    // it: the two that include equality, and neither of the strict ones.
+    assertArrayEquals(
+      fired,
+      cases.map((one) => one.fires),
+    );
+  });
+});

--- a/src/service/cloudwatch/sim-cloudwatch-commands.ts
+++ b/src/service/cloudwatch/sim-cloudwatch-commands.ts
@@ -2,10 +2,22 @@ import {
   type BackgroundScheduler,
   BackgroundTasks,
 } from "../../util/background/background.js";
+import type { SimAwsAccountRegionScope } from "../aws/sim-aws-account-region-scope.js";
+import { simAwsAccountRegionScopeFactory } from "../aws/sim-aws-account-region-scope.factory.js";
 import {
   SimIamAllowAllAuth,
   type SimIamInterServiceAuthZ,
 } from "../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { SimCloudWatchAlarmActions } from "./alarm/action/sim-cloudwatch-alarm-actions.js";
+import {
+  SimCloudWatchNoAlarmTargets,
+  type SimCloudWatchAlarmTargets,
+} from "./alarm/action/sim-cloudwatch-alarm-targets.js";
+import { SimCloudWatchAlarmSchedule } from "./alarm/sim-cloudwatch-alarm-schedule.js";
+import { SimCloudWatchAlarmStore } from "./alarm/sim-cloudwatch-alarm-store.js";
+import { SimCloudWatchAlarmReads } from "./command/alarm/sim-cloudwatch-alarm-reads.js";
+import { SimCloudWatchAlarmWrites } from "./command/alarm/sim-cloudwatch-alarm-writes.js";
+import { SimCloudWatchSetAlarmState } from "./command/alarm/sim-cloudwatch-set-alarm-state.js";
 import { SimCloudWatchAuthorizer } from "./command/authorize/sim-cloudwatch-authorizer.js";
 import { SimCloudWatchPutMetricData } from "./command/data/sim-cloudwatch-put-metric-data.js";
 import { SimCloudWatchGetMetricData } from "./command/query/sim-cloudwatch-get-metric-data.js";
@@ -14,8 +26,15 @@ import { SimCloudWatchListMetrics } from "./command/query/sim-cloudwatch-list-me
 import { SimCloudWatchMetricStore } from "./metric/sim-cloudwatch-metric-store.js";
 
 export interface SimCloudWatchProperties {
+  readonly accountRegionScope?: SimAwsAccountRegionScope;
   readonly iam?: SimIamInterServiceAuthZ;
   readonly background?: BackgroundScheduler;
+
+  /**
+   * Where an alarm's actions reach. A SimCloudWatch built on its own has no
+   * other simulated services, so it holds alarms and notifies none of them.
+   */
+  readonly alarmTargets?: SimCloudWatchAlarmTargets;
 }
 
 /**
@@ -32,16 +51,33 @@ export class SimCloudWatchCommands {
   readonly listMetrics: SimCloudWatchListMetrics;
   readonly getMetricStatistics: SimCloudWatchGetMetricStatistics;
   readonly getMetricData: SimCloudWatchGetMetricData;
+  readonly alarms: SimCloudWatchAlarmStore;
+  readonly alarmWrites: SimCloudWatchAlarmWrites;
+  readonly alarmReads: SimCloudWatchAlarmReads;
+  readonly setAlarmState: SimCloudWatchSetAlarmState;
+  readonly alarmActions: SimCloudWatchAlarmActions;
   readonly background: BackgroundScheduler;
 
   constructor(properties: SimCloudWatchProperties = {}) {
     const {
+      accountRegionScope = simAwsAccountRegionScopeFactory.make(),
       iam = new SimIamAllowAllAuth(),
       background = new BackgroundTasks(),
+      alarmTargets = new SimCloudWatchNoAlarmTargets(),
     } = properties;
 
-    const authorizer = new SimCloudWatchAuthorizer({ iam });
+    const authorizer = new SimCloudWatchAuthorizer({ iam, accountRegionScope });
     const metrics = new SimCloudWatchMetricStore();
+    const alarms = new SimCloudWatchAlarmStore();
+    const alarmActions = new SimCloudWatchAlarmActions({
+      targets: alarmTargets,
+      accountRegionScope,
+    });
+    const schedule = new SimCloudWatchAlarmSchedule({
+      metrics,
+      actions: alarmActions,
+      background,
+    });
 
     this.background = background;
     this.metrics = metrics;
@@ -63,5 +99,19 @@ export class SimCloudWatchCommands {
       metrics,
       authorizer,
     });
+    this.alarms = alarms;
+    this.alarmActions = alarmActions;
+    const alarmContext = {
+      alarms,
+      schedule,
+      actions: alarmActions,
+      authorizer,
+      accountRegionScope,
+      clock: background,
+    };
+
+    this.alarmWrites = new SimCloudWatchAlarmWrites(alarmContext);
+    this.setAlarmState = new SimCloudWatchSetAlarmState(alarmContext);
+    this.alarmReads = new SimCloudWatchAlarmReads(alarmContext);
   }
 }

--- a/src/service/cloudwatch/sim-cloudwatch.ts
+++ b/src/service/cloudwatch/sim-cloudwatch.ts
@@ -1,6 +1,8 @@
 import type { SimSdkCommandRouter } from "../../sdk/router/sim-sdk-command-router.type.js";
 import type * as simCloudWatchCommands from "./command/sim-cloudwatch-command.types.js";
 import type { SimCloudWatchRequestOptions } from "./command/sim-cloudwatch-request-options.js";
+import type { SimCloudWatchAlarmActionFailure } from "./alarm/action/sim-cloudwatch-alarm-action-failures.js";
+import type { SimCloudWatchAlarm } from "./alarm/sim-cloudwatch-alarm.js";
 import type { SimCloudWatchMetric } from "./metric/sim-cloudwatch-metric.js";
 import { SimCloudWatchSdkCommandRouter } from "./sdk/sim-cloudwatch-sdk-command-router.js";
 import {
@@ -36,6 +38,27 @@ export class SimCloudWatch {
    */
   allMetrics(): readonly SimCloudWatchMetric[] {
     return this.#commands.metrics.all;
+  }
+
+  /**
+   * Every alarm in this scope, in the order each was created.
+   *
+   * This is the simulator's own accessor, for tests inspecting alarm state
+   * without going through a Command and its authorization.
+   */
+  allAlarms(): readonly SimCloudWatchAlarm[] {
+    return this.#commands.alarms.all;
+  }
+
+  /**
+   * Every alarm notification this scope could not send.
+   *
+   * A failed action is invisible on real CloudWatch: the alarm changes state
+   * either way and nothing reports the failure. Keeping it is what lets a test
+   * find out that the alarm it set up reached nothing.
+   */
+  get alarmActionFailures(): readonly SimCloudWatchAlarmActionFailure[] {
+    return this.#commands.alarmActions.failures.all;
   }
 
   /**
@@ -80,6 +103,61 @@ export class SimCloudWatch {
   ): Promise<simCloudWatchCommands.SimGetMetricDataCommandOutput> {
     await this.#commands.background.sequence();
     return this.#commands.getMetricData.handle(command, options);
+  }
+
+  /**
+   * Handle a PutMetricAlarm Command from the SDK.
+   */
+  async putMetricAlarm(
+    command: simCloudWatchCommands.SimPutMetricAlarmCommand,
+    options?: SimCloudWatchRequestOptions,
+  ): Promise<simCloudWatchCommands.SimPutMetricAlarmCommandOutput> {
+    await this.#commands.background.sequence();
+    return this.#commands.alarmWrites.putMetricAlarm(command, options);
+  }
+
+  /**
+   * Handle a DescribeAlarms Command from the SDK.
+   */
+  async describeAlarms(
+    command: simCloudWatchCommands.SimDescribeAlarmsCommand,
+    options?: SimCloudWatchRequestOptions,
+  ): Promise<simCloudWatchCommands.SimDescribeAlarmsCommandOutput> {
+    await this.#commands.background.sequence();
+    return this.#commands.alarmReads.describeAlarms(command, options);
+  }
+
+  /**
+   * Handle a DeleteAlarms Command from the SDK.
+   */
+  async deleteAlarms(
+    command: simCloudWatchCommands.SimDeleteAlarmsCommand,
+    options?: SimCloudWatchRequestOptions,
+  ): Promise<simCloudWatchCommands.SimDeleteAlarmsCommandOutput> {
+    await this.#commands.background.sequence();
+    return this.#commands.alarmWrites.deleteAlarms(command, options);
+  }
+
+  /**
+   * Handle a SetAlarmState Command from the SDK.
+   */
+  async setAlarmState(
+    command: simCloudWatchCommands.SimSetAlarmStateCommand,
+    options?: SimCloudWatchRequestOptions,
+  ): Promise<simCloudWatchCommands.SimSetAlarmStateCommandOutput> {
+    await this.#commands.background.sequence();
+    return await this.#commands.setAlarmState.handle(command, options);
+  }
+
+  /**
+   * Handle a DescribeAlarmHistory Command from the SDK.
+   */
+  async describeAlarmHistory(
+    command: simCloudWatchCommands.SimDescribeAlarmHistoryCommand,
+    options?: SimCloudWatchRequestOptions,
+  ): Promise<simCloudWatchCommands.SimDescribeAlarmHistoryCommandOutput> {
+    await this.#commands.background.sequence();
+    return this.#commands.alarmReads.describeAlarmHistory(command, options);
   }
 
   /**


### PR DESCRIPTION
Adds alarms to the simulated CloudWatch service, so a test can check that an alarm is configured to fire on the traffic it was written for rather than finding out during the incident. The requirement that shapes everything here is that evaluation runs on the simulation's clock: each alarm's next evaluation is scheduled on the background scheduler at the next period boundary and every evaluation schedules the one after it, so a frozen clock evaluates nothing and `advanceBy({ minutes: 20 })` walks twenty one-minute evaluations and settles before the next line of the test runs. A state change fires the alarm's actions into a simulated SNS topic through the ordinary publish path, so a notification fans out to the topic's subscriptions exactly as an SDK caller's message would, carrying the JSON body a real subscriber parses. Only a transition fires anything, so an alarm sitting in ALARM across ten periods notifies once. The set covers `PutMetricAlarm`, `DescribeAlarms`, `DeleteAlarms`, `SetAlarmState` and `DescribeAlarmHistory`, the four threshold comparisons, `DatapointsToAlarm` for M-of-N evaluation, all four `TreatMissingData` treatments, and `ActionsEnabled`. An SNS topic is the only action target this carries out, and every other kind is refused rather than stored and silently ignored, because an alarm that fired and did nothing would let a test pass while the thing the alarm exists to do never happened.

Resolves https://github.com/KensioSoftware/yulin/issues/623

Two things worth a reviewer's attention. The issue's implementation notes said disabling an alarm should take its scheduled turn off the clock, while its acceptance criteria said `ActionsEnabled: false` should still evaluate and record state and only publish nothing; those contradict, and this follows the acceptance criteria, which are also what real CloudWatch does. Separately, `SimAwsAccountRegionServiceBuilder` was one service short of its 300-line limit, so the five services whose wiring is nothing but a simulation-wide registry lookup (ACM, API Gateway, ECR, ELBv2, KMS) moved into a `SimAwsRegisteredServiceBuilder` of their own; that is a mechanical move with no behaviour change, and it leaves the original file holding the services that reach the rest of the simulation for something live.

Three branches remain uncovered, all defensive guards rather than untested behaviour: the race guard in the alarm scheduler for a task cancelled between being taken off the clock and running, the non-`Error` branch of a recorded failure's reason, and a pre-existing `?? 1` in the weighted-values reader that the length check makes unreachable.

- [x] Conventional commit message, used as the title

- [x] Conventional branch name, like `feat/concise-description`
- [x] Full check with `pnpm run check` passed
- [x] Rebased off latest main
- [x] User-facing behaviour is documented in `docs/`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added simulated CloudWatch metric alarms with configurable thresholds, evaluation periods, missing-data handling, and state transitions.
  * Added alarm creation, updates, deletion, state changes, filtering, pagination, and history retrieval.
  * Added SNS notifications for alarm transitions, including ALARM, OK, and INSUFFICIENT_DATA states.
  * Added alarm action-failure tracking and inspection.
  * Added account- and region-aware alarm authorization.
  * Added documentation and examples for alarm behavior and limitations.

* **Bug Fixes**
  * Invalid and unsupported alarm configurations now return clear validation errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->