### PR TITLE
feat: deploy CloudWatch alarms from a template

### DIFF
--- a/docs/services/cloudformation/README.md
+++ b/docs/services/cloudformation/README.md
@@ -2046,6 +2046,7 @@ The resource types it creates are:
 - `AWS::CloudFormation::WaitConditionHandle`
 - `AWS::CloudFront::Distribution`, `AWS::CloudFront::Function` and
   `AWS::CloudFront::ResponseHeadersPolicy`
+- `AWS::CloudWatch::Alarm`
 - `AWS::Cognito::UserPool`, `AWS::Cognito::UserPoolClient` and
   `AWS::Cognito::UserPoolGroup`
 - `AWS::DynamoDB::Table` and `AWS::DynamoDB::GlobalTable`

--- a/docs/services/cloudwatch/README.md
+++ b/docs/services/cloudwatch/README.md
@@ -255,6 +255,55 @@ state either way. Keeping the failure is what stops a subscriber's queue being m
   a test pass while the thing the alarm exists to do never happened.
 - Composite alarms, anomaly detection and metric math alarms are all refused.
 
+## Declaring an alarm in a template
+
+Alarms are nearly always declared in infrastructure rather than created through the SDK, so
+`AWS::CloudWatch::Alarm` is deployed by simulated CloudFormation. The alarm a stack creates is the
+same thing `PutMetricAlarm` creates: it evaluates on the clock, fires on a transition, and refuses
+what the command refuses.
+
+```yaml
+OrdersFailing:
+  Type: AWS::CloudWatch::Alarm
+  Properties:
+    AlarmName: OrdersFailing
+    Namespace: Orders
+    MetricName: Failed
+    Statistic: Sum
+    Period: 60
+    EvaluationPeriods: 3
+    DatapointsToAlarm: 2
+    Threshold: 5
+    ComparisonOperator: GreaterThanThreshold
+    AlarmActions:
+      - !Ref Alerts
+```
+
+`Ref` resolves to the alarm name and `Fn::GetAtt Arn` to the alarm ARN. An `AlarmActions` entry
+holding a `Ref` to an `AWS::SNS::Topic` in the same stack resolves to that topic's ARN, so a test can
+deploy the stack, publish a breaching datapoint, advance the clock and read the notification off
+whatever is subscribed. Deleting the stack deletes the alarm and takes its scheduled evaluation back
+off the clock with it.
+
+`AlarmName` may be left out, and the alarm is then named after the stack and the logical ID, as real
+CloudFormation names one, so a test still has a name to pass to `DescribeAlarms`.
+
+These are the properties acted on: `AlarmName`, `AlarmDescription`, `ActionsEnabled`, `AlarmActions`,
+`OKActions`, `InsufficientDataActions`, `Namespace`, `MetricName`, `Dimensions`, `Statistic`, `Unit`,
+`Period`, `EvaluationPeriods`, `DatapointsToAlarm`, `Threshold`, `ComparisonOperator` and
+`TreatMissingData`.
+
+`Metrics`, `ThresholdMetricId`, `ExtendedStatistic` and `EvaluateLowSampleCountPercentile` are
+refused, in the same words `PutMetricAlarm` refuses them with: each of them changes what the alarm
+watches or how it decides, so an alarm deployed with one ignored would sit in a test looking
+configured and evaluating something else. `Tags` is the one difference from the command, which
+refuses it. A template's tags are usually the whole stack's rather than the alarm's, so they are
+recorded as an ignored property instead of taking the deploy down over something the alarm behaves no
+differently for having.
+
+`AWS::CloudWatch::CompositeAlarm`, `AWS::CloudWatch::Dashboard` and
+`AWS::CloudWatch::AnomalyDetector` are not deployed, and are recorded as gaps in the stack.
+
 ## Permissions
 
 CloudWatch metrics have no ARN, so there is nothing for a policy to name: every metric action here is
@@ -336,6 +385,8 @@ await simAws.cloudWatch().putMetricData(
   with evaluation on the simulation's clock and SNS notifications on a state change.
 - IAM authorization on each action, including the `cloudwatch:namespace` condition key and
   alarm-ARN resources.
+- `AWS::CloudWatch::Alarm` in simulated CloudFormation, deployed through `PutMetricAlarm` and taken
+  down with the stack.
 
 ## What is not, and how it says so
 

--- a/docs/services/cloudwatch/README.md
+++ b/docs/services/cloudwatch/README.md
@@ -285,8 +285,10 @@ deploy the stack, publish a breaching datapoint, advance the clock and read the 
 whatever is subscribed. Deleting the stack deletes the alarm and takes its scheduled evaluation back
 off the clock with it.
 
-`AlarmName` may be left out, and the alarm is then named after the stack and the logical ID, as real
-CloudFormation names one, so a test still has a name to pass to `DescribeAlarms`.
+`AlarmName` may be left out, and the alarm is then named after the stack and the logical ID, so a
+test still has a name to pass to `DescribeAlarms`. Real CloudFormation generates a physical ID of the
+same shape with a random tail on the end, which is left off here so the name is one a test can
+predict.
 
 These are the properties acted on: `AlarmName`, `AlarmDescription`, `ActionsEnabled`, `AlarmActions`,
 `OKActions`, `InsufficientDataActions`, `Namespace`, `MetricName`, `Dimensions`, `Statistic`, `Unit`,
@@ -296,10 +298,12 @@ These are the properties acted on: `AlarmName`, `AlarmDescription`, `ActionsEnab
 `Metrics`, `ThresholdMetricId`, `ExtendedStatistic` and `EvaluateLowSampleCountPercentile` are
 refused, in the same words `PutMetricAlarm` refuses them with: each of them changes what the alarm
 watches or how it decides, so an alarm deployed with one ignored would sit in a test looking
-configured and evaluating something else. `Tags` is the one difference from the command, which
-refuses it. A template's tags are usually the whole stack's rather than the alarm's, so they are
-recorded as an ignored property instead of taking the deploy down over something the alarm behaves no
-differently for having.
+configured and evaluating something else.
+
+`Tags` is the one difference from the command, which refuses it. Real CloudFormation does tag the
+alarm it creates, and nothing here does: a template's tags are usually the whole stack's rather than
+the alarm's, so they are recorded as an ignored property instead of taking the deploy down. Nothing
+reads them back, so an alarm deployed with tags behaves as though the template had never named them.
 
 `AWS::CloudWatch::CompositeAlarm`, `AWS::CloudWatch::Dashboard` and
 `AWS::CloudWatch::AnomalyDetector` are not deployed, and are recorded as gaps in the stack.

--- a/src/service/cloudformation/cdk/provider/sim-cdk-provider-scaffolding.iso.test.ts
+++ b/src/service/cloudformation/cdk/provider/sim-cdk-provider-scaffolding.iso.test.ts
@@ -119,12 +119,12 @@ describe("CDK custom Resource provider scaffolding [iso]", () => {
           Prune: false,
         },
       },
-      AlarmRule: { Type: "AWS::CloudWatch::Alarm" },
+      WebServer: { Type: "AWS::EC2::Instance" },
     });
 
     // Then it deploys like any other, and the scaffolding around the two that
     // do name a provider is still recognised.
-    assertArrayEquals(logicalIdsOf(stack.skippedResources), ["AlarmRule"]);
+    assertArrayEquals(logicalIdsOf(stack.skippedResources), ["WebServer"]);
     assertArrayEquals(logicalIdsOf(stack.inertResources), [
       "BucketDeploymentProvider",
       "Deploy0AwsCliLayer",

--- a/src/service/cloudformation/resource/cfn/cloudwatch/sim-cloudwatch-alarm-cfn.ts
+++ b/src/service/cloudformation/resource/cfn/cloudwatch/sim-cloudwatch-alarm-cfn.ts
@@ -1,0 +1,41 @@
+import type { SimCloudWatchAlarm } from "../../../../cloudwatch/alarm/sim-cloudwatch-alarm.js";
+import type { SimCfnTemplateValue } from "../../../template/value/sim-cfn-template-value.js";
+import type { SimCfnResourceValueAdapter } from "../sim-cfn-resource-value-adapter.js";
+
+interface SimCloudWatchAlarmCfnProperties {
+  readonly alarm: SimCloudWatchAlarm;
+}
+
+/**
+ * CloudFormation-facing values for a simulated CloudWatch alarm.
+ */
+export class SimCloudWatchAlarmCfn implements SimCfnResourceValueAdapter {
+  readonly #alarm: SimCloudWatchAlarm;
+
+  constructor(properties: SimCloudWatchAlarmCfnProperties) {
+    this.#alarm = properties.alarm;
+  }
+
+  /**
+   * AWS::CloudWatch::Alarm Ref returns the alarm name.
+   */
+  refValue(): SimCfnTemplateValue {
+    return this.#alarm.name;
+  }
+
+  /**
+   * AWS::CloudWatch::Alarm attributes.
+   *
+   * `Arn` is the only one the Resource publishes, and it is the form an SNS
+   * topic policy names when it grants CloudWatch permission to publish.
+   */
+  attributeValue(attributeName: string): SimCfnTemplateValue {
+    if (attributeName === "Arn") {
+      return this.#alarm.arn;
+    }
+
+    throw new Error(
+      `Unsupported AWS::CloudWatch::Alarm attribute ${attributeName}`,
+    );
+  }
+}

--- a/src/service/cloudformation/resource/cfn/cloudwatch/sim-cloudwatch-cfn-value-adapter.ts
+++ b/src/service/cloudformation/resource/cfn/cloudwatch/sim-cloudwatch-cfn-value-adapter.ts
@@ -1,0 +1,22 @@
+import { SimCloudWatchAlarm } from "../../../../cloudwatch/alarm/sim-cloudwatch-alarm.js";
+import type {
+  SimCfnResourceValueAdapterProperties,
+  SimCfnServiceValueAdapter,
+} from "../sim-cfn-resource-value-adapter.js";
+import { SimCloudWatchAlarmCfn } from "./sim-cloudwatch-alarm-cfn.js";
+
+/**
+ * The CloudFormation-facing value adapter for a simulated CloudWatch Resource.
+ */
+export function cloudWatchValueAdapter(
+  properties: SimCfnResourceValueAdapterProperties,
+): SimCfnServiceValueAdapter {
+  if (
+    properties.type === "AWS::CloudWatch::Alarm" &&
+    properties.simResource instanceof SimCloudWatchAlarm
+  ) {
+    return new SimCloudWatchAlarmCfn({ alarm: properties.simResource });
+  }
+
+  return undefined;
+}

--- a/src/service/cloudformation/resource/cfn/sim-cfn-default-resource-value-adapter.iso.test.ts
+++ b/src/service/cloudformation/resource/cfn/sim-cfn-default-resource-value-adapter.iso.test.ts
@@ -12,15 +12,15 @@ import type { CfnTemplateBodyRecord } from "../../template/sim-cfn-template.js";
  * A template whose only Resource is one no service claims, referenced both
  * ways, so a test can read what a skipped Resource answers with.
  */
-const skippedAlarmTemplate: CfnTemplateBodyRecord = {
+const skippedInstanceTemplate: CfnTemplateBodyRecord = {
   Resources: {
-    AlarmRule: {
-      Type: "AWS::CloudWatch::Alarm",
+    WebServer: {
+      Type: "AWS::EC2::Instance",
     },
   },
   Outputs: {
-    AlarmRef: { Value: { Ref: "AlarmRule" } },
-    AlarmArn: { Value: { "Fn::GetAtt": ["AlarmRule", "Arn"] } },
+    InstanceRef: { Value: { Ref: "WebServer" } },
+    InstanceArn: { Value: { "Fn::GetAtt": ["WebServer", "Arn"] } },
   },
 };
 
@@ -32,13 +32,13 @@ describe("skipped CloudFormation Resource values", () => {
     // When the template is deployed.
     const stack = await simAws.cloudFormation().deployTemplate({
       stackName: "stand-in-stack",
-      template: skippedAlarmTemplate,
+      template: skippedInstanceTemplate,
     });
     await stack.waitForDeployComplete();
 
     // Then the Ref resolved to the logical ID rather than failing the
     // Resources that hold it.
-    assertIdentical(stack.outputs.get("AlarmRef")?.value, "AlarmRule");
+    assertIdentical(stack.outputs.get("InstanceRef")?.value, "WebServer");
   });
 
   it("answers an Fn::GetAtt with the logical ID and attribute name", async () => {
@@ -49,13 +49,13 @@ describe("skipped CloudFormation Resource values", () => {
     // When the template is deployed.
     const stack = await simAws.cloudFormation().deployTemplate({
       stackName: "stand-in-stack",
-      template: skippedAlarmTemplate,
+      template: skippedInstanceTemplate,
     });
     await stack.waitForDeployComplete();
 
     // Then the attribute resolved to a stand-in that is deliberately not
     // ARN-shaped, so it fails closed wherever it is read as one.
-    assertIdentical(stack.outputs.get("AlarmArn")?.value, "AlarmRule.Arn");
+    assertIdentical(stack.outputs.get("InstanceArn")?.value, "WebServer.Arn");
   });
 
   it("records the skip the stand-ins came from", async () => {
@@ -65,7 +65,7 @@ describe("skipped CloudFormation Resource values", () => {
     // When the template is deployed.
     const stack = await simAws.cloudFormation().deployTemplate({
       stackName: "stand-in-stack",
-      template: skippedAlarmTemplate,
+      template: skippedInstanceTemplate,
     });
     await stack.waitForDeployComplete();
 
@@ -73,8 +73,8 @@ describe("skipped CloudFormation Resource values", () => {
     // reader finds out a value they got was a stand-in.
     assertArrayLength(stack.skippedResources, 1);
     assertStringIncludes(
-      stack.getResource("AlarmRule")?.skippedReason ?? "",
-      "Unsupported sim CloudFormation Resource service CloudWatch",
+      stack.getResource("WebServer")?.skippedReason ?? "",
+      "Unsupported sim CloudFormation Resource service EC2",
     );
   });
 });

--- a/src/service/cloudformation/resource/cfn/sim-cfn-service-value-adapters.ts
+++ b/src/service/cloudformation/resource/cfn/sim-cfn-service-value-adapters.ts
@@ -1,6 +1,7 @@
 import { acmValueAdapter } from "./acm/sim-acm-cfn-value-adapter.js";
 import { apiGatewayV2ValueAdapter } from "./apigatewayv2/sim-api-gateway-v2-cfn-value-adapter.js";
 import { cloudFrontValueAdapter } from "./cloudfront/sim-cloudfront-cfn-value-adapter.js";
+import { cloudWatchValueAdapter } from "./cloudwatch/sim-cloudwatch-cfn-value-adapter.js";
 import { cognitoValueAdapter } from "./cognito/sim-cognito-cfn-value-adapter.js";
 import { dynamoDbValueAdapter } from "./dynamodb/sim-dynamodb-cfn-value-adapter.js";
 import { ecrValueAdapter } from "./ecr/sim-ecr-cfn-value-adapter.js";
@@ -38,6 +39,7 @@ export const simCfnServiceValueAdapters: readonly ((
   acmValueAdapter,
   apiGatewayV2ValueAdapter,
   cloudFrontValueAdapter,
+  cloudWatchValueAdapter,
   cognitoValueAdapter,
   dynamoDbValueAdapter,
   ecrValueAdapter,

--- a/src/service/cloudformation/resource/resolve/service/sim-cfn-service-factories.ts
+++ b/src/service/cloudformation/resource/resolve/service/sim-cfn-service-factories.ts
@@ -50,6 +50,11 @@ export const simCfnServiceResourceFactories: ReadonlyMap<
       scopedAws.cloudFront().cfnResourceFactory(),
   ],
   [
+    "CloudWatch",
+    (scopedAws): SimCfnServiceResourceFactory =>
+      scopedAws.cloudWatch().cfnResourceFactory(),
+  ],
+  [
     "Cognito",
     (scopedAws): SimCfnServiceResourceFactory =>
       scopedAws.cognitoIdentityProvider().cfnResourceFactory(),

--- a/src/service/cloudformation/resource/resolve/service/sim-cfn-service-resolver.iso.test.ts
+++ b/src/service/cloudformation/resource/resolve/service/sim-cfn-service-resolver.iso.test.ts
@@ -105,8 +105,8 @@ describe("resolveSimCloudFormationServiceResourceFactory", () => {
         accountRegionScope,
         {
           providerName: "AWS",
-          serviceName: "CloudWatch",
-          resourceTypeName: "Rule",
+          serviceName: "EC2",
+          resourceTypeName: "Instance",
         },
       ),
     );
@@ -114,7 +114,7 @@ describe("resolveSimCloudFormationServiceResourceFactory", () => {
     // Then the unsupported service name is included for diagnosis.
     assertIdentical(
       error.message,
-      "Unsupported sim CloudFormation Resource service CloudWatch",
+      "Unsupported sim CloudFormation Resource service EC2",
     );
   });
 

--- a/src/service/cloudformation/stack/sim-cfn-stack.iso.test.ts
+++ b/src/service/cloudformation/stack/sim-cfn-stack.iso.test.ts
@@ -228,8 +228,8 @@ describe("SimCfnStack", () => {
       stackName: "TestStack",
       template: {
         Resources: {
-          TestRule: {
-            Type: "AWS::CloudWatch::Alarm",
+          TestInstance: {
+            Type: "AWS::EC2::Instance",
           },
         },
       },
@@ -240,11 +240,11 @@ describe("SimCfnStack", () => {
     assertIdentical(stack.lifecycle.status, "CREATE_COMPLETE");
     assertArrayLength(stack.skippedResources, 1);
     assertNonNullable(skippedResource);
-    assertIdentical(skippedResource.logicalId, "TestRule");
+    assertIdentical(skippedResource.logicalId, "TestInstance");
     assertTrue(skippedResource.skipped);
     assertIdentical(
       skippedResource.skippedReason,
-      "Unsupported sim CloudFormation Resource service CloudWatch",
+      "Unsupported sim CloudFormation Resource service EC2",
     );
   });
 

--- a/src/service/cloudwatch/cfn/alarm/sim-cfn-alarm-creator.ts
+++ b/src/service/cloudwatch/cfn/alarm/sim-cfn-alarm-creator.ts
@@ -1,0 +1,64 @@
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimCloudWatchAlarm } from "../../alarm/sim-cloudwatch-alarm.js";
+import type { SimCloudWatch } from "../../sim-cloudwatch.js";
+import { SimCfnAlarmProperties } from "./sim-cfn-alarm-properties.js";
+
+interface SimCfnAlarmCreatorProperties {
+  readonly cloudWatch: SimCloudWatch;
+}
+
+/**
+ * Creates simulated alarms from AWS::CloudWatch::Alarm Resources.
+ *
+ * The alarm is created through the ordinary PutMetricAlarm command rather than
+ * constructed directly, so an alarm a template deployed is the same thing an
+ * SDK caller would have got: the same validation, the same refusals, and the
+ * same clock-driven evaluation from the next period boundary.
+ */
+export class SimCfnAlarmCreator {
+  readonly #cloudWatch: SimCloudWatch;
+
+  constructor(properties: SimCfnAlarmCreatorProperties) {
+    this.#cloudWatch = properties.cloudWatch;
+  }
+
+  /**
+   * Create an alarm from an AWS::CloudWatch::Alarm Resource.
+   */
+  async create(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): Promise<SimCloudWatchAlarm> {
+    const alarmProperties = new SimCfnAlarmProperties({ resource, properties });
+    const input = alarmProperties.input();
+
+    alarmProperties.recordIgnoredProperties();
+
+    await this.#cloudWatch.putMetricAlarm({ input });
+
+    const alarmName = String(input.AlarmName);
+    const alarm = this.#cloudWatch.findAlarm(alarmName);
+
+    assertDefined(
+      alarm,
+      `sim CloudWatch alarm ${alarmName} after CloudFormation creation`,
+    );
+
+    return alarm;
+  }
+
+  /**
+   * Delete an alarm created from an AWS::CloudWatch::Alarm Resource.
+   *
+   * DeleteAlarms takes its scheduled evaluation back off the clock as well as
+   * removing it, which is what lets a torn-down stack settle rather than
+   * leaving an alarm waking up to read a metric nothing watches.
+   */
+  async delete(alarm: SimCloudWatchAlarm): Promise<void> {
+    await this.#cloudWatch.deleteAlarms({
+      input: { AlarmNames: [alarm.name] },
+    });
+  }
+}

--- a/src/service/cloudwatch/cfn/alarm/sim-cfn-alarm-creator.ts
+++ b/src/service/cloudwatch/cfn/alarm/sim-cfn-alarm-creator.ts
@@ -32,13 +32,12 @@ export class SimCfnAlarmCreator {
     properties: SimCfnTemplateValueRecord,
   ): Promise<SimCloudWatchAlarm> {
     const alarmProperties = new SimCfnAlarmProperties({ resource, properties });
-    const input = alarmProperties.input();
+    const alarmName = alarmProperties.alarmName();
 
     alarmProperties.recordIgnoredProperties();
 
-    await this.#cloudWatch.putMetricAlarm({ input });
+    await this.#cloudWatch.putMetricAlarm({ input: alarmProperties.input() });
 
-    const alarmName = String(input.AlarmName);
     const alarm = this.#cloudWatch.findAlarm(alarmName);
 
     assertDefined(

--- a/src/service/cloudwatch/cfn/alarm/sim-cfn-alarm-properties.ts
+++ b/src/service/cloudwatch/cfn/alarm/sim-cfn-alarm-properties.ts
@@ -1,0 +1,95 @@
+import { SimCfnGeneratedResourceName } from "../../../cloudformation/resource/name/sim-cfn-generated-resource-name.js";
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimPutMetricAlarmCommandInput } from "../../command/alarm/alarm.command.js";
+import { simCloudWatchMaximumNameLength } from "../../metric/sim-cloudwatch-name.js";
+import { SimCfnAlarmPropertyRules } from "./sim-cfn-alarm-property-rules.js";
+import { SimCfnAlarmValues } from "./sim-cfn-alarm-values.js";
+
+interface SimCfnAlarmPropertiesProperties {
+  readonly resource: SimCfnResource;
+  readonly properties: SimCfnTemplateValueRecord;
+}
+
+/**
+ * Reads AWS::CloudWatch::Alarm CloudFormation properties into the request
+ * PutMetricAlarm takes.
+ *
+ * Nothing is decided here beyond the shapes the template wrote. An alarm a
+ * stack deployed is created through the ordinary command, so it evaluates,
+ * fires and refuses exactly as one an SDK caller asked for.
+ */
+export class SimCfnAlarmProperties {
+  readonly #resource: SimCfnResource;
+  readonly #values: SimCfnAlarmValues;
+  readonly #rules: SimCfnAlarmPropertyRules;
+
+  constructor(properties: SimCfnAlarmPropertiesProperties) {
+    this.#resource = properties.resource;
+    this.#values = new SimCfnAlarmValues({
+      logicalId: properties.resource.logicalId,
+      properties: properties.properties,
+    });
+    this.#rules = new SimCfnAlarmPropertyRules({
+      properties: properties.properties,
+      ignorer: properties.resource,
+    });
+  }
+
+  /**
+   * The PutMetricAlarm request this Resource declares.
+   */
+  input(): SimPutMetricAlarmCommandInput {
+    return {
+      AlarmName: this.alarmName(),
+      AlarmDescription: this.#values.string("AlarmDescription"),
+      ActionsEnabled: this.#values.boolean("ActionsEnabled"),
+      OKActions: this.#values.strings("OKActions"),
+      AlarmActions: this.#values.strings("AlarmActions"),
+      InsufficientDataActions: this.#values.strings("InsufficientDataActions"),
+      Namespace: this.#values.string("Namespace"),
+      MetricName: this.#values.string("MetricName"),
+      Dimensions: this.#values.dimensions(),
+      Statistic: this.#values.string("Statistic"),
+      Unit: this.#values.string("Unit"),
+      Period: this.#values.number("Period"),
+      EvaluationPeriods: this.#values.number("EvaluationPeriods"),
+      DatapointsToAlarm: this.#values.number("DatapointsToAlarm"),
+      Threshold: this.#values.number("Threshold"),
+      ComparisonOperator: this.#values.string("ComparisonOperator"),
+      TreatMissingData: this.#values.string("TreatMissingData"),
+      Metrics: this.#values.list("Metrics"),
+      ThresholdMetricId: this.#values.string("ThresholdMetricId"),
+      ExtendedStatistic: this.#values.string("ExtendedStatistic"),
+      EvaluateLowSampleCountPercentile: this.#values.string(
+        "EvaluateLowSampleCountPercentile",
+      ),
+    };
+  }
+
+  /**
+   * Record the properties the alarm is created without acting on.
+   */
+  recordIgnoredProperties(): void {
+    this.#rules.apply();
+  }
+
+  /**
+   * The alarm name.
+   *
+   * An unnamed alarm is named after the stack and the logical ID, as real
+   * CloudFormation names one. An alarm name is the whole of its identity in a
+   * region, so a template that leaves it out still has to deploy something a
+   * test can name in `DescribeAlarms`.
+   */
+  private alarmName(): string {
+    return (
+      this.#values.string("AlarmName") ??
+      new SimCfnGeneratedResourceName({
+        stackName: this.#resource.stackName,
+        logicalId: this.#resource.logicalId,
+        maximumLength: simCloudWatchMaximumNameLength,
+      }).value
+    );
+  }
+}

--- a/src/service/cloudwatch/cfn/alarm/sim-cfn-alarm-properties.ts
+++ b/src/service/cloudwatch/cfn/alarm/sim-cfn-alarm-properties.ts
@@ -78,11 +78,12 @@ export class SimCfnAlarmProperties {
    * The alarm name.
    *
    * An unnamed alarm is named after the stack and the logical ID, as real
-   * CloudFormation names one. An alarm name is the whole of its identity in a
-   * region, so a template that leaves it out still has to deploy something a
-   * test can name in `DescribeAlarms`.
+   * CloudFormation names one, without the random tail a real physical ID
+   * carries. An alarm name is the whole of its identity in a region, so a
+   * template that leaves it out still has to deploy something a test can name
+   * in `DescribeAlarms`.
    */
-  private alarmName(): string {
+  alarmName(): string {
     return (
       this.#values.string("AlarmName") ??
       new SimCfnGeneratedResourceName({

--- a/src/service/cloudwatch/cfn/alarm/sim-cfn-alarm-property-rules.ts
+++ b/src/service/cloudwatch/cfn/alarm/sim-cfn-alarm-property-rules.ts
@@ -1,0 +1,102 @@
+import type { SimCfnPropertyIgnorer } from "../../../cloudformation/resource/ignore/sim-cfn-ignored-property.type.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+
+/**
+ * The properties an alarm Resource is read from.
+ *
+ * The last four are read only to be refused. They go to PutMetricAlarm as the
+ * template wrote them, so a template asking for metric math or an anomaly band
+ * is turned down in the same words an SDK caller gets.
+ */
+const readProperties = new Set([
+  "ActionsEnabled",
+  "AlarmActions",
+  "AlarmDescription",
+  "AlarmName",
+  "ComparisonOperator",
+  "DatapointsToAlarm",
+  "Dimensions",
+  "EvaluationPeriods",
+  "InsufficientDataActions",
+  "MetricName",
+  "Namespace",
+  "OKActions",
+  "Period",
+  "Statistic",
+  "Threshold",
+  "TreatMissingData",
+  "Unit",
+  "EvaluateLowSampleCountPercentile",
+  "ExtendedStatistic",
+  "Metrics",
+  "ThresholdMetricId",
+]);
+
+/**
+ * The AWS::CloudWatch::Alarm properties this simulation has nothing to act on,
+ * and why.
+ *
+ * `Tags` is the whole list, and it is recorded rather than refused, unlike the
+ * same parameter on PutMetricAlarm. An SDK caller passing tags asked for them;
+ * a template's tags are usually the stack's, applied to every Resource in it,
+ * and failing a deploy over one would take down an alarm that behaves no
+ * differently for having it.
+ */
+const unsimulatedPropertyReasons: ReadonlyMap<string, string> = new Map([
+  [
+    "Tags",
+    "alarm tags are not simulated, so nothing reads them back and nothing is " +
+      "grouped or billed by them",
+  ],
+]);
+
+interface SimCfnAlarmPropertyRulesProperties {
+  readonly properties: SimCfnTemplateValueRecord;
+  readonly ignorer: SimCfnPropertyIgnorer;
+}
+
+/**
+ * What an alarm Resource is created without acting on.
+ */
+export class SimCfnAlarmPropertyRules {
+  readonly #properties: SimCfnTemplateValueRecord;
+  readonly #ignorer: SimCfnPropertyIgnorer;
+
+  constructor(properties: SimCfnAlarmPropertyRulesProperties) {
+    this.#properties = properties.properties;
+    this.#ignorer = properties.ignorer;
+  }
+
+  /**
+   * Record every property the alarm is created without.
+   */
+  apply(): void {
+    for (const name of Object.keys(this.#properties)) {
+      this.applyToProperty(name);
+    }
+  }
+
+  private applyToProperty(name: string): void {
+    if (readProperties.has(name)) {
+      return;
+    }
+
+    const unsimulatedReason = unsimulatedPropertyReasons.get(name);
+
+    if (unsimulatedReason === undefined) {
+      this.#ignorer.ignoreProperty(
+        name,
+        `${name} is not a property simulated CloudWatch knows about, so the ` +
+          `alarm is created without it`,
+      );
+
+      return;
+    }
+
+    this.#ignorer.ignoreProperty(
+      name,
+      `${name} is a real AWS::CloudWatch::Alarm property simulated ` +
+        `CloudWatch does not act on: ${unsimulatedReason}`,
+    );
+  }
+}

--- a/src/service/cloudwatch/cfn/alarm/sim-cfn-alarm-values.ts
+++ b/src/service/cloudwatch/cfn/alarm/sim-cfn-alarm-values.ts
@@ -1,0 +1,137 @@
+import type {
+  SimCfnTemplateValue,
+  SimCfnTemplateValueRecord,
+} from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import { SimCfnValueShape } from "../../../cloudformation/template/value/sim-cfn-value-shape.js";
+import type { SimCloudWatchDimensionInput } from "../../metric/sim-cloudwatch-dimension.js";
+
+/** The two halves of an AWS::CloudWatch::Alarm Dimension entry. */
+const dimensionKeys = new Set(["Name", "Value"]);
+
+/**
+ * A refusal naming the Resource whose properties could not be read.
+ */
+export function alarmPropertyError(logicalId: string, reason: string): Error {
+  return new Error(
+    `Invalid sim CloudWatch CloudFormation Resource ${logicalId}: ${reason}`,
+  );
+}
+
+interface SimCfnAlarmValuesProperties {
+  readonly logicalId: string;
+  readonly properties: SimCfnTemplateValueRecord;
+}
+
+/**
+ * Reads the shapes an AWS::CloudWatch::Alarm property can take.
+ *
+ * Only the template's own shape is checked here: a number where a number
+ * belongs, a list where a list belongs. What a value is allowed to mean is left
+ * to PutMetricAlarm, so an alarm a template declared is refused in the same
+ * words as one an SDK caller asked for.
+ */
+export class SimCfnAlarmValues {
+  readonly #logicalId: string;
+  readonly #entries: ReadonlyMap<string, SimCfnTemplateValue>;
+  readonly #shape: SimCfnValueShape;
+
+  constructor(properties: SimCfnAlarmValuesProperties) {
+    this.#logicalId = properties.logicalId;
+    this.#entries = new Map(Object.entries(properties.properties));
+    this.#shape = new SimCfnValueShape((reason) =>
+      alarmPropertyError(this.#logicalId, reason),
+    );
+  }
+
+  /**
+   * A property holding a string, where the template may leave it out.
+   */
+  string(name: string): string | undefined {
+    return this.#shape.present(this.#entries.get(name), (value) =>
+      this.#shape.string(value, name),
+    );
+  }
+
+  /**
+   * A property holding a list of strings, such as one of the action lists.
+   */
+  strings(name: string): readonly string[] | undefined {
+    return this.#shape.present(this.#entries.get(name), (value) =>
+      this.#shape
+        .list(value, name)
+        .map((entry, index) =>
+          this.#shape.string(entry, `${name}.${index.toString()}`),
+        ),
+    );
+  }
+
+  /**
+   * A property holding a list, handed on for another reader to refuse.
+   */
+  list(name: string): readonly SimCfnTemplateValue[] | undefined {
+    return this.#shape.present(this.#entries.get(name), (value) =>
+      this.#shape.list(value, name),
+    );
+  }
+
+  /**
+   * A property holding a number.
+   *
+   * CloudFormation carries template numbers as strings in places, a Parameter
+   * value most of all, so a string holding a number is read as that number.
+   */
+  number(name: string): number | undefined {
+    return this.#shape.present(this.#entries.get(name), (value) => {
+      const parsed = typeof value === "string" ? Number(value.trim()) : value;
+
+      if (typeof parsed !== "number" || !Number.isFinite(parsed)) {
+        throw alarmPropertyError(this.#logicalId, `${name} must be a number`);
+      }
+
+      return parsed;
+    });
+  }
+
+  /**
+   * A property holding a boolean, in either of the forms CloudFormation
+   * carries one.
+   */
+  boolean(name: string): boolean | undefined {
+    return this.#shape.present(this.#entries.get(name), (value) => {
+      if (typeof value === "boolean") {
+        return value;
+      }
+
+      if (value === "true" || value === "false") {
+        return value === "true";
+      }
+
+      throw alarmPropertyError(this.#logicalId, `${name} must be a boolean`);
+    });
+  }
+
+  /**
+   * The dimensions narrowing which metric the alarm watches.
+   *
+   * A key that is not `Name` or `Value` is refused rather than dropped: a
+   * misspelled half of a dimension would otherwise leave the alarm watching a
+   * different metric from the one the template meant.
+   */
+  dimensions(): readonly SimCloudWatchDimensionInput[] | undefined {
+    return this.list("Dimensions")?.map((entry, index) => {
+      const path = `Dimensions.${index.toString()}`;
+      const dimension = this.#shape.record(entry, path);
+
+      this.#shape.knownKeys(dimension, dimensionKeys, "Dimension");
+
+      return {
+        Name: this.#shape.present(dimension["Name"], (value) =>
+          this.#shape.string(value, `${path}.Name`),
+        ),
+        Value: this.#shape.present(dimension["Value"], (value) =>
+          this.#shape.string(value, `${path}.Value`),
+        ),
+      };
+    });
+  }
+}

--- a/src/service/cloudwatch/cfn/alarm/sim-cfn-alarm-values.ts
+++ b/src/service/cloudwatch/cfn/alarm/sim-cfn-alarm-values.ts
@@ -82,7 +82,7 @@ export class SimCfnAlarmValues {
    */
   number(name: string): number | undefined {
     return this.#shape.present(this.#entries.get(name), (value) => {
-      const parsed = typeof value === "string" ? Number(value.trim()) : value;
+      const parsed = typeof value === "string" ? numberHeldBy(value) : value;
 
       if (typeof parsed !== "number" || !Number.isFinite(parsed)) {
         throw alarmPropertyError(this.#logicalId, `${name} must be a number`);
@@ -134,4 +134,17 @@ export class SimCfnAlarmValues {
       };
     });
   }
+}
+
+/**
+ * The number a template string holds, or NaN where it holds none.
+ *
+ * An empty string is not a zero, though `Number("")` is: a Parameter that
+ * arrived empty would otherwise deploy an alarm with a threshold of nought,
+ * which is a threshold nearly everything breaches.
+ */
+function numberHeldBy(value: string): number {
+  const trimmed = value.trim();
+
+  return trimmed === "" ? NaN : Number(trimmed);
 }

--- a/src/service/cloudwatch/cfn/sim-cfn-alarm-validation.iso.test.ts
+++ b/src/service/cloudwatch/cfn/sim-cfn-alarm-validation.iso.test.ts
@@ -99,9 +99,11 @@ describe("AWS::CloudWatch::Alarm validation", () => {
   });
 
   it("refuses properties whose types the template got wrong", async () => {
-    // Given templates giving properties values of the wrong shape.
+    // Given templates giving properties values of the wrong shape, including a
+    // Parameter that arrived empty, which is nothing rather than nought.
     const name = await refusalFor({ AlarmName: { Ref: "Nothing" } });
     const period = await refusalFor({ Period: "often" });
+    const blank = await refusalFor({ Threshold: "  " });
     const enabled = await refusalFor({ ActionsEnabled: "sometimes" });
     const actions = await refusalFor({ AlarmActions: "one-topic" });
     const action = await refusalFor({ AlarmActions: [{ Ref: "Nothing" }] });
@@ -111,6 +113,7 @@ describe("AWS::CloudWatch::Alarm validation", () => {
     assertStringIncludes(name.message, "Resource OrdersAlarm");
     assertStringIncludes(name.message, "AlarmName must be a string");
     assertStringIncludes(period.message, "Period must be a number");
+    assertStringIncludes(blank.message, "Threshold must be a number");
     assertStringIncludes(enabled.message, "ActionsEnabled must be a boolean");
     assertStringIncludes(actions.message, "AlarmActions must be a list");
     assertStringIncludes(action.message, "AlarmActions.0 must be a string");

--- a/src/service/cloudwatch/cfn/sim-cfn-alarm-validation.iso.test.ts
+++ b/src/service/cloudwatch/cfn/sim-cfn-alarm-validation.iso.test.ts
@@ -1,0 +1,137 @@
+import { assertStringIncludes, assertThrowsErrorAsync } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import type { SimCfnTemplateValueRecord } from "../../cloudformation/template/value/sim-cfn-template-value.js";
+
+/**
+ * An alarm that fires on one breaching minute, for a refusal to be added to.
+ */
+const failingOrders: SimCfnTemplateValueRecord = {
+  AlarmName: "OrdersFailing",
+  Namespace: "Orders",
+  MetricName: "Failed",
+  Statistic: "Sum",
+  Period: 60,
+  EvaluationPeriods: 1,
+  Threshold: 5,
+  ComparisonOperator: "GreaterThanThreshold",
+};
+
+/**
+ * Deploy one AWS::CloudWatch::Alarm and hand back whatever the deployment
+ * failed with.
+ *
+ * A refusal has to fail the Resource rather than skip it. Sim CloudFormation
+ * steps over a Resource whose error reads as unsupported, and stepping over an
+ * alarm leaves a stack that looks deployed with nothing watching anything.
+ */
+async function refusalFor(
+  properties: SimCfnTemplateValueRecord,
+): Promise<Error> {
+  return await assertThrowsErrorAsync(async () => {
+    await new SimAws().cloudFormation().deployTemplate({
+      stackName: "orders",
+      template: {
+        Resources: {
+          OrdersAlarm: {
+            Type: "AWS::CloudWatch::Alarm",
+            Properties: { ...failingOrders, ...properties },
+          },
+        },
+      },
+    });
+  });
+}
+
+describe("AWS::CloudWatch::Alarm validation", () => {
+  it("refuses the alarm forms it does not evaluate", async () => {
+    // Given templates asking for metric math, an anomaly band, a percentile
+    // and the sample-count rule that only a percentile alarm has.
+    const metrics = await refusalFor({
+      Metrics: [{ Id: "e1", Expression: "m1/m2" }],
+    });
+    const anomaly = await refusalFor({ ThresholdMetricId: "ad1" });
+    const percentile = await refusalFor({ ExtendedStatistic: "p99" });
+    const sampleCount = await refusalFor({
+      EvaluateLowSampleCountPercentile: "ignore",
+    });
+
+    // Then each is refused in the words PutMetricAlarm refuses it with, rather
+    // than deploying an alarm that watches something else entirely.
+    assertStringIncludes(
+      metrics.message,
+      "The parameter Metrics is not simulated",
+    );
+    assertStringIncludes(
+      anomaly.message,
+      "The parameter ThresholdMetricId is not simulated",
+    );
+    assertStringIncludes(
+      percentile.message,
+      "The parameter ExtendedStatistic is not simulated",
+    );
+    assertStringIncludes(
+      sampleCount.message,
+      "The parameter EvaluateLowSampleCountPercentile is not simulated",
+    );
+  });
+
+  it("refuses an action target that is not an SNS topic", async () => {
+    // Given a template asking the alarm to scale a group, as a real one can.
+    const error = await refusalFor({
+      AlarmActions: [
+        "arn:aws:autoscaling:eu-west-2:111111111111:scalingPolicy",
+      ],
+    });
+
+    // Then the deploy fails rather than leaving a test asserting its alarm
+    // fired while the thing the alarm exists to do never happened.
+    assertStringIncludes(error.message, "is not simulated: an alarm here");
+  });
+
+  it("refuses a period real CloudWatch would refuse", async () => {
+    // Given a template asking for a period shorter than a minute.
+    const error = await refusalFor({ Period: 30 });
+
+    // Then the deploy fails here rather than on a real one later.
+    assertStringIncludes(error.message, "The parameter Period must be");
+  });
+
+  it("refuses properties whose types the template got wrong", async () => {
+    // Given templates giving properties values of the wrong shape.
+    const name = await refusalFor({ AlarmName: { Ref: "Nothing" } });
+    const period = await refusalFor({ Period: "often" });
+    const enabled = await refusalFor({ ActionsEnabled: "sometimes" });
+    const actions = await refusalFor({ AlarmActions: "one-topic" });
+    const action = await refusalFor({ AlarmActions: [{ Ref: "Nothing" }] });
+
+    // Then each says which property was wrong, naming the Resource it is on,
+    // rather than deploying an alarm configured as something else.
+    assertStringIncludes(name.message, "Resource OrdersAlarm");
+    assertStringIncludes(name.message, "AlarmName must be a string");
+    assertStringIncludes(period.message, "Period must be a number");
+    assertStringIncludes(enabled.message, "ActionsEnabled must be a boolean");
+    assertStringIncludes(actions.message, "AlarmActions must be a list");
+    assertStringIncludes(action.message, "AlarmActions.0 must be a string");
+  });
+
+  it("refuses a dimension the template got wrong", async () => {
+    // Given templates misspelling half of a dimension, leaving one out, and
+    // writing a dimension as something other than an object.
+    const misspelled = await refusalFor({
+      Dimensions: [{ Name: "Service", Vaule: "checkout" }],
+    });
+    const missing = await refusalFor({ Dimensions: [{ Name: "Service" }] });
+    const shape = await refusalFor({ Dimensions: ["Service=checkout"] });
+
+    // Then each is refused rather than dropped, which would leave the alarm
+    // watching a different metric from the one the template named.
+    assertStringIncludes(
+      misspelled.message,
+      "Vaule is not a Dimension property this simulation reads",
+    );
+    assertStringIncludes(missing.message, "Dimension.Value must be present");
+    assertStringIncludes(shape.message, "Dimensions.0 must be an object");
+  });
+});

--- a/src/service/cloudwatch/cfn/sim-cfn-alarm.iso.test.ts
+++ b/src/service/cloudwatch/cfn/sim-cfn-alarm.iso.test.ts
@@ -1,0 +1,371 @@
+import { DeleteStackCommand } from "@aws-sdk/client-cloudformation";
+import {
+  DescribeAlarmsCommand,
+  PutMetricDataCommand,
+} from "@aws-sdk/client-cloudwatch";
+import { ReceiveMessageCommand } from "@aws-sdk/client-sqs";
+import {
+  assertArrayEquals,
+  assertArrayLength,
+  assertFalse,
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertTypeString,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { BackgroundTasks } from "../../../util/background/background.js";
+import { SimAws } from "../../aws/sim-aws.js";
+import type { SimCfnStack } from "../../cloudformation/stack/sim-cfn-stack.js";
+import type { SimCfnTemplateValueRecord } from "../../cloudformation/template/value/sim-cfn-template-value.js";
+
+const startedAt = new Date("2026-08-16T09:00:00.000Z");
+
+/**
+ * The properties of an alarm that fires on one breaching minute.
+ */
+const unnamedFailingOrders: SimCfnTemplateValueRecord = {
+  Namespace: "Orders",
+  MetricName: "Failed",
+  Statistic: "Sum",
+  Period: 60,
+  EvaluationPeriods: 1,
+  Threshold: 5,
+  ComparisonOperator: "GreaterThanThreshold",
+};
+
+/** The same alarm, named, which is how most of these declare it. */
+const failingOrders: SimCfnTemplateValueRecord = {
+  ...unnamedFailingOrders,
+  AlarmName: "OrdersFailing",
+};
+
+async function deployAlarm(
+  properties: SimCfnTemplateValueRecord,
+  simAws: SimAws = new SimAws(),
+): Promise<{ readonly simAws: SimAws; readonly stack: SimCfnStack }> {
+  const stack = await simAws.cloudFormation().deployTemplate({
+    stackName: "orders",
+    template: {
+      Resources: {
+        OrdersAlarm: { Type: "AWS::CloudWatch::Alarm", Properties: properties },
+      },
+      Outputs: {
+        AlarmName: { Value: { Ref: "OrdersAlarm" } },
+        AlarmArn: { Value: { "Fn::GetAtt": ["OrdersAlarm", "Arn"] } },
+      },
+    },
+  });
+
+  return { simAws, stack };
+}
+
+/**
+ * Whether the deployed alarm would publish anything on a state change.
+ */
+function actionsEnabledOn(simAws: SimAws): boolean | undefined {
+  return simAws.cloudWatch().findAlarm("OrdersFailing")?.definition
+    .actionsEnabled;
+}
+
+/**
+ * Publish a breaching minute into `Orders`/`Failed`, then let the alarm
+ * evaluate the period it landed in.
+ */
+async function breachFor(simAws: SimAws): Promise<void> {
+  await simAws.cloudWatch().putMetricData(
+    new PutMetricDataCommand({
+      Namespace: "Orders",
+      MetricData: [{ MetricName: "Failed", Value: 10 }],
+    }),
+  );
+  await simAws.clock().advanceBy({ minutes: 1 });
+}
+
+describe("AWS::CloudWatch::Alarm", () => {
+  it("creates an alarm a template declares", async () => {
+    // Given a template declaring an alarm.
+    const { simAws } = await deployAlarm({
+      ...failingOrders,
+      AlarmDescription: "Orders are failing",
+      DatapointsToAlarm: 1,
+      TreatMissingData: "notBreaching",
+      Dimensions: [{ Name: "Service", Value: "checkout" }],
+    });
+
+    // When the alarms are described.
+    const described = await simAws
+      .cloudWatch()
+      .describeAlarms(new DescribeAlarmsCommand({}));
+    const alarm = described.MetricAlarms?.at(0);
+
+    // Then it is there, watching what the template said it watches.
+    assertNonNullable(alarm);
+    assertIdentical(alarm.AlarmName, "OrdersFailing");
+    assertIdentical(alarm.AlarmDescription, "Orders are failing");
+    assertIdentical(alarm.Threshold, 5);
+    assertIdentical(alarm.TreatMissingData, "notBreaching");
+    assertArrayEquals(
+      alarm.Dimensions.map(
+        (dimension) => `${String(dimension.Name)}=${String(dimension.Value)}`,
+      ),
+      ["Service=checkout"],
+    );
+  });
+
+  it("evaluates a declared alarm on the clock as any other alarm", async () => {
+    // Given a deployed alarm over a metric nothing has published into.
+    const { simAws } = await deployAlarm(failingOrders);
+
+    // When a breaching minute passes.
+    await breachFor(simAws);
+
+    // Then it fired, which is the whole point of deploying one rather than
+    // recreating it by hand in test setup.
+    assertIdentical(
+      simAws.cloudWatch().findAlarm("OrdersFailing")?.state,
+      "ALARM",
+    );
+  });
+
+  it("names an unnamed alarm after the stack and logical ID", async () => {
+    // Given a template that declares an alarm without naming it.
+    const { simAws } = await deployAlarm(unnamedFailingOrders);
+
+    // Then CloudFormation named it, as real CloudFormation does, so a test
+    // still has a name to describe it by.
+    const alarms = simAws.cloudWatch().allAlarms();
+
+    assertArrayLength(alarms, 1);
+    assertIdentical(alarms.at(0)?.name, "orders-OrdersAlarm");
+  });
+
+  it("resolves Ref to the name and Fn::GetAtt Arn to the alarm ARN", async () => {
+    // Given a template whose outputs name the alarm both ways.
+    const { simAws, stack } = await deployAlarm(failingOrders);
+
+    // Then Ref is the name and the attribute is the ARN a policy names.
+    const alarmArn = stack.outputs.get("AlarmArn")?.value;
+
+    assertIdentical(stack.outputs.get("AlarmName")?.value, "OrdersFailing");
+    assertTypeString(alarmArn);
+    assertIdentical(
+      alarmArn,
+      `arn:aws:cloudwatch:${simAws.defaultRegionName}:` +
+        `${simAws.defaultAccountId}:alarm:OrdersFailing`,
+    );
+  });
+
+  it("publishes to a topic the same stack declares", async () => {
+    // Given a stack holding an alarm, the topic it notifies, and a queue
+    // subscribed to that topic, with the alarm naming the topic by Ref.
+    const simAws = new SimAws();
+
+    await simAws.clock().setTo(startedAt);
+    await simAws.cloudFormation().deployTemplate({
+      stackName: "orders",
+      template: {
+        Resources: {
+          Alerts: {
+            Type: "AWS::SNS::Topic",
+            Properties: {
+              TopicName: "orders-alerts",
+              Subscription: [
+                {
+                  Protocol: "sqs",
+                  Endpoint: { "Fn::GetAtt": ["AlertQueue", "Arn"] },
+                },
+              ],
+            },
+          },
+          AlertQueue: {
+            Type: "AWS::SQS::Queue",
+            Properties: { QueueName: "alerts" },
+          },
+          // A subscription alone does not let a topic send to a queue, here or
+          // in an account: the queue's own policy has to admit SNS.
+          AlertQueuePolicy: {
+            Type: "AWS::SQS::QueuePolicy",
+            Properties: {
+              Queues: [{ Ref: "AlertQueue" }],
+              PolicyDocument: {
+                Version: "2012-10-17",
+                Statement: [
+                  {
+                    Effect: "Allow",
+                    Principal: { Service: "sns.amazonaws.com" },
+                    Action: "sqs:SendMessage",
+                    Resource: { "Fn::GetAtt": ["AlertQueue", "Arn"] },
+                  },
+                ],
+              },
+            },
+          },
+          OrdersAlarm: {
+            Type: "AWS::CloudWatch::Alarm",
+            Properties: {
+              ...failingOrders,
+              AlarmActions: [{ Ref: "Alerts" }],
+            },
+          },
+        },
+      },
+    });
+
+    // When a breaching minute passes.
+    await breachFor(simAws);
+
+    // Then the notification reached the queue, so the template's wiring is
+    // what the test proved rather than what it assumed.
+    const received = await simAws.sqs().receiveMessage(
+      new ReceiveMessageCommand({
+        QueueUrl: `https://sqs.${simAws.defaultRegionName}.amazonaws.com/${simAws.defaultAccountId}/alerts`,
+      }),
+    );
+
+    assertArrayLength(received.Messages ?? [], 1);
+    assertStringIncludes(received.Messages?.at(0)?.Body ?? "", "OrdersFailing");
+  });
+
+  it("reads a boolean in either form a template carries one", async () => {
+    // Given templates turning the alarm's actions off as a literal and as the
+    // string a CloudFormation Parameter value arrives as.
+    const literal = await deployAlarm({
+      ...failingOrders,
+      ActionsEnabled: false,
+    });
+    const carried = await deployAlarm({
+      ...failingOrders,
+      ActionsEnabled: "false",
+    });
+
+    // Then both alarms evaluate and record state while publishing nothing.
+    assertFalse(actionsEnabledOn(literal.simAws));
+    assertFalse(actionsEnabledOn(carried.simAws));
+  });
+
+  it("reads a number a template carried as a string", async () => {
+    // Given a template whose numbers arrived as strings, as a CloudFormation
+    // Parameter value does.
+    const { simAws } = await deployAlarm({
+      ...failingOrders,
+      Period: "60",
+      EvaluationPeriods: "2",
+      Threshold: "5",
+    });
+
+    // Then they are read as the numbers they hold rather than refused.
+    const definition = simAws
+      .cloudWatch()
+      .findAlarm("OrdersFailing")?.definition;
+
+    assertNonNullable(definition);
+    assertIdentical(definition.period, 60);
+    assertIdentical(definition.evaluationPeriods, 2);
+    assertIdentical(definition.threshold, 5);
+  });
+
+  it("records the properties it does not act on", async () => {
+    // Given a template setting a real property this simulation has nothing to
+    // do with, and one CloudWatch has never had.
+    const { stack } = await deployAlarm({
+      ...failingOrders,
+      Tags: [{ Key: "team", Value: "platform" }],
+      Nonsense: true,
+    });
+
+    // Then both are recorded, told apart, so a reader can see what a deployed
+    // alarm is not doing without a stack failing over a tag it carries because
+    // every Resource in it does.
+    const ignored = stack.getResource("OrdersAlarm")?.ignoredProperties ?? [];
+
+    assertArrayEquals(
+      ignored
+        .map((property) => property.path)
+        .toSorted((left, right) => left.localeCompare(right)),
+      ["Nonsense", "Tags"],
+    );
+    assertStringIncludes(
+      ignored.find((property) => property.path === "Tags")?.reason ?? "",
+      "does not act on",
+    );
+    assertStringIncludes(
+      ignored.find((property) => property.path === "Nonsense")?.reason ?? "",
+      "not a property simulated",
+    );
+  });
+
+  it("refuses an alarm attribute CloudFormation does not have", async () => {
+    // Given a template reading an attribute the Resource does not publish.
+    const error = await assertThrowsErrorAsync(async () => {
+      await new SimAws().cloudFormation().deployTemplate({
+        stackName: "orders",
+        template: {
+          Resources: {
+            OrdersAlarm: {
+              Type: "AWS::CloudWatch::Alarm",
+              Properties: failingOrders,
+            },
+          },
+          Outputs: {
+            State: { Value: { "Fn::GetAtt": ["OrdersAlarm", "StateValue"] } },
+          },
+        },
+      });
+    });
+
+    // Then it says which attribute, rather than leaving an Output that quietly
+    // says undefined.
+    assertStringIncludes(
+      error.message,
+      "Unsupported AWS::CloudWatch::Alarm attribute StateValue",
+    );
+  });
+
+  it("reports a CloudWatch Resource type it does not simulate", async () => {
+    // Given the CloudWatch Resource factory.
+    const factory = new SimAws().cloudWatch().cfnResourceFactory();
+
+    // When a Resource type this simulation has none for is created or deleted.
+    const created = await assertThrowsErrorAsync(async () =>
+      factory.create("Dashboard", {} as never, {} as never),
+    );
+    const deleted = await assertThrowsErrorAsync(async () =>
+      factory.delete("Dashboard", {} as never),
+    );
+
+    // Then both are reported as unsupported, which the Stack records as a skip
+    // rather than a failure.
+    assertIdentical(
+      created.message,
+      "Unsupported sim CloudWatch CloudFormation Resource Dashboard",
+    );
+    assertIdentical(
+      deleted.message,
+      "Unsupported sim CloudWatch CloudFormation Resource Dashboard deletion",
+    );
+  });
+
+  it("takes the alarm down with the stack and stops evaluating it", async () => {
+    // Given a deployed alarm that would fire on every period.
+    const background = new BackgroundTasks();
+    const { simAws } = await deployAlarm(
+      { ...failingOrders, TreatMissingData: "breaching" },
+      new SimAws({ background }),
+    );
+
+    // When the stack is torn down.
+    await simAws
+      .cloudFormation()
+      .deleteStack(new DeleteStackCommand({ StackName: "orders" }));
+    await simAws.backgroundTasksComplete();
+
+    // Then the alarm went with it and nothing is left waiting on the clock,
+    // which is what lets the simulation settle rather than keeping an alarm
+    // waking up to read a metric nothing watches.
+    assertArrayLength(simAws.cloudWatch().allAlarms(), 0);
+    assertIdentical(background.dueTaskCount, 0);
+  });
+});

--- a/src/service/cloudwatch/cfn/sim-cloudwatch-cfn-resource-factory.ts
+++ b/src/service/cloudwatch/cfn/sim-cloudwatch-cfn-resource-factory.ts
@@ -1,0 +1,78 @@
+import { assertDefined } from "../../../util/type-guard/defined.js";
+import type { SimCfnServiceResourceFactory } from "../../cloudformation/resource/factory/sim-cfn-resource-factory.type.js";
+import type {
+  SimCfnResource,
+  SimCloudFormationResourceCreateContext,
+} from "../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCloudWatchAlarm } from "../alarm/sim-cloudwatch-alarm.js";
+import type { SimCloudWatch } from "../sim-cloudwatch.js";
+import { SimCfnAlarmCreator } from "./alarm/sim-cfn-alarm-creator.js";
+
+const alarmResourceTypeName = "Alarm";
+
+interface SimCloudWatchCfnResourceFactoryProperties {
+  readonly cloudWatch: SimCloudWatch;
+}
+
+/**
+ * CloudFormation Resource factory for simulated CloudWatch resources.
+ *
+ * AWS::CloudWatch::Alarm is the only Resource type here. A composite alarm
+ * watches other alarms, an anomaly detector needs a trained model, and a
+ * dashboard is a picture nothing in a test can read, so none of the three has
+ * anything to be here yet.
+ */
+export class SimCloudWatchCfnResourceFactory implements SimCfnServiceResourceFactory {
+  readonly #alarmCreator: SimCfnAlarmCreator;
+
+  constructor(properties: SimCloudWatchCfnResourceFactoryProperties) {
+    this.#alarmCreator = new SimCfnAlarmCreator({
+      cloudWatch: properties.cloudWatch,
+    });
+  }
+
+  /**
+   * Create a simulated CloudWatch resource from a CloudFormation Resource.
+   */
+  create(
+    resourceTypeName: string,
+    resource: SimCfnResource,
+    context: SimCloudFormationResourceCreateContext,
+  ): Promise<object | undefined> {
+    requireAlarmResourceType(resourceTypeName, "");
+
+    return this.#alarmCreator.create(
+      resource,
+      context.resolvedProperties ?? resource.properties,
+    );
+  }
+
+  /**
+   * Delete a simulated CloudWatch resource created from a CloudFormation
+   * Resource.
+   */
+  delete(resourceTypeName: string, resource: SimCfnResource): Promise<void> {
+    requireAlarmResourceType(resourceTypeName, " deletion");
+
+    const alarm = resource.simResource as SimCloudWatchAlarm | undefined;
+
+    assertDefined(
+      alarm,
+      `sim CloudWatch alarm for CloudFormation Resource ${resource.logicalId}`,
+    );
+
+    return this.#alarmCreator.delete(alarm);
+  }
+}
+
+function requireAlarmResourceType(
+  resourceTypeName: string,
+  operationSuffix: string,
+): void {
+  if (resourceTypeName !== alarmResourceTypeName) {
+    throw new Error(
+      `Unsupported sim CloudWatch CloudFormation Resource ` +
+        `${resourceTypeName}${operationSuffix}`,
+    );
+  }
+}

--- a/src/service/cloudwatch/sim-cloudwatch.ts
+++ b/src/service/cloudwatch/sim-cloudwatch.ts
@@ -1,4 +1,5 @@
 import type { SimSdkCommandRouter } from "../../sdk/router/sim-sdk-command-router.type.js";
+import { SimCloudWatchCfnResourceFactory } from "./cfn/sim-cloudwatch-cfn-resource-factory.js";
 import type * as simCloudWatchCommands from "./command/sim-cloudwatch-command.types.js";
 import type { SimCloudWatchRequestOptions } from "./command/sim-cloudwatch-request-options.js";
 import type { SimCloudWatchAlarmActionFailure } from "./alarm/action/sim-cloudwatch-alarm-action-failures.js";
@@ -25,6 +26,9 @@ import {
 export class SimCloudWatch {
   readonly #commands: SimCloudWatchCommands;
   readonly #sdkRouter = new SimCloudWatchSdkCommandRouter(this);
+  readonly #cfnFactory = new SimCloudWatchCfnResourceFactory({
+    cloudWatch: this,
+  });
 
   constructor(properties: SimCloudWatchProperties = {}) {
     this.#commands = new SimCloudWatchCommands(properties);
@@ -48,6 +52,16 @@ export class SimCloudWatch {
    */
   allAlarms(): readonly SimCloudWatchAlarm[] {
     return this.#commands.alarms.all;
+  }
+
+  /**
+   * Find an alarm by name.
+   *
+   * This is the simulator's own accessor, for tests inspecting one alarm
+   * without going through a Command and its authorization.
+   */
+  findAlarm(alarmName: string): SimCloudWatchAlarm | undefined {
+    return this.#commands.alarms.find(alarmName);
   }
 
   /**
@@ -158,6 +172,13 @@ export class SimCloudWatch {
   ): Promise<simCloudWatchCommands.SimDescribeAlarmHistoryCommandOutput> {
     await this.#commands.background.sequence();
     return this.#commands.alarmReads.describeAlarmHistory(command, options);
+  }
+
+  /**
+   * Get the CloudFormation Resource factory for AWS::CloudWatch::* Resources.
+   */
+  cfnResourceFactory(): SimCloudWatchCfnResourceFactory {
+    return this.#cfnFactory;
   }
 
   /**


### PR DESCRIPTION
An AWS::CloudWatch::Alarm Resource now creates a real simulated alarm, so a test can deploy the stack that declares its alarms and then watch one fire rather than recreating it by hand in setup. The Resource is created through the ordinary PutMetricAlarm command, so a declared alarm evaluates on the clock, notifies its topic and refuses metric math and anomaly detection exactly as one an SDK caller asked for; `Ref` resolves to the alarm name, `Fn::GetAtt Arn` to its ARN, an `AlarmActions` entry holding a `Ref` to a topic in the same stack reaches that topic, and deleting the stack deletes the alarm and takes its scheduled evaluation back off the clock. `Tags` is the one place this differs from the command, which refuses it: a template's tags are usually the whole stack's, so they are recorded as an ignored property rather than taking the deploy down. `AWS::CloudWatch::Alarm` was the stand-in for an unsimulated Resource type in four CloudFormation tests, which now use `AWS::EC2::Instance` instead.

Resolves https://github.com/KensioSoftware/yulin/issues/624

- [x] Conventional commit message, used as the title

- [x] Conventional branch name, like `feat/concise-description`
- [x] Full check with `pnpm run check` passed
- [x] Rebased off latest main
- [x] User-facing behaviour is documented in `docs/`

See https://www.conventionalcommits.org/en/v1.0.0/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for deploying simulated `AWS::CloudWatch::Alarm` resources through CloudFormation.
  * Supports alarm evaluation, notification actions, generated names, property mapping, and stack cleanup.
  * Supports `Ref` and `Fn::GetAtt` resolution for alarm names and ARNs.
  * Added validation for unsupported properties, invalid values, and malformed metric dimensions.
* **Documentation**
  * Added CloudFormation usage documentation, supported properties, limitations, and lifecycle behavior for CloudWatch alarms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->