### PR TITLE
feat: send email through simulated SES

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ npm i -D @kensio/yulin
 - [S3](./docs/services/s3 "Simulated S3 docs")
 - [Scheduler](./docs/services/scheduler "Simulated EventBridge Scheduler docs")
 - [Secrets Manager](./docs/services/secretsmanager "Simulated Secrets Manager docs")
+- [SES](./docs/services/ses "Simulated SES docs")
 - [SNS](./docs/services/sns "Simulated SNS docs")
 - [SQS](./docs/services/sqs "Simulated SQS docs")
 - [SSM Parameter Store](./docs/services/ssm "Simulated SSM Parameter Store docs")

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,6 +25,7 @@ behaviour and includes example code that can be copied into tests or local devel
 - [S3](./services/s3/ "Simulated S3 usage docs")
 - [Scheduler](./services/scheduler/ "Simulated EventBridge Scheduler usage docs")
 - [Secrets Manager](./services/secretsmanager/ "Simulated Secrets Manager usage docs")
+- [SES](./services/ses/ "Simulated SES usage docs")
 - [SNS](./services/sns/ "Simulated SNS usage docs")
 - [SQS](./services/sqs/ "Simulated SQS usage docs")
 - [SSM Parameter Store](./services/ssm/ "Simulated SSM Parameter Store usage docs")

--- a/docs/sdk/README.md
+++ b/docs/sdk/README.md
@@ -242,9 +242,10 @@ which descriptors is in
 
 ## Supported services and Commands
 
-All simulated services support SDK interception: ACM, API Gateway v2, CloudFormation, CloudFront,
-Cognito, DynamoDB, DynamoDB Streams, IAM, KMS, Lambda, Rekognition, Route53, S3, Secrets Manager,
-SQS, SSM and STS. Each service's own docs under
+These simulated services support SDK interception: ACM, API Gateway v2, CloudFormation, CloudFront,
+CloudWatch, CloudWatch Logs, Cognito, DynamoDB, DynamoDB Streams, ECS, Elastic Load Balancing v2,
+EventBridge, EventBridge Scheduler, IAM, KMS, Lambda, Rekognition, Route53, S3, Secrets Manager,
+SES, SNS, SQS, SSM and STS. Each service's own docs under
 [docs/services](../services/) list the Commands it simulates.
 
 Both kinds of gap are refused on send rather than misbehaving silently, with a different error each:

--- a/docs/services/ses/README.md
+++ b/docs/services/ses/README.md
@@ -1,0 +1,390 @@
+# Simulated SES
+
+Yulin includes a simulated Amazon SES for tests and local development, through the SES v2 API. It
+holds email identities, applies the sandbox rules, and keeps a record of every message it would have
+sent, so a test can assert that signing someone up produced a welcome email addressed to them,
+without an AWS account and without a mailbox to read.
+
+There is no delivery to simulate. A message SES accepts leaves AWS for a mail system, so the whole
+of the observable AWS behaviour is whether SES would have accepted the message and what it would
+have sent. That is what makes this service small and what makes it useful.
+
+SES specific types are imported from the `@kensio/yulin/ses` subpath.
+
+## Asserting on a message that was sent
+
+`sentEmails()` hands over the record. Each message carries who it was from, the three recipient
+lists, the subject, the body and the message id SES answered with.
+
+```typescript sim-ses-send-and-assert
+/**
+ * Sending a welcome email through simulated SES and asserting on it.
+ */
+
+import { SendEmailCommand } from "@aws-sdk/client-sesv2";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const ses = simAws.sesV2();
+
+// Both ends have to be verified in the sandbox, which is where an account
+// starts.
+ses.verifyIdentity("hello@example.com");
+ses.verifyIdentity("someone@example.org");
+
+await ses.sendEmail(
+  new SendEmailCommand({
+    FromEmailAddress: "hello@example.com",
+    Destination: { ToAddresses: ["someone@example.org"] },
+    Content: {
+      Simple: {
+        Subject: { Data: "Welcome" },
+        Body: { Text: { Data: "Hi there, thanks for signing up." } },
+      },
+    },
+  }),
+);
+
+const [email] = ses.sentEmails();
+
+// "Welcome" someone@example.org
+console.log(email?.subject, email?.destination.toAddresses[0]);
+```
+
+Messages come back in the order they were sent, so the first message of a flow is the first one
+read. The three recipient lists stay apart, so a test asserting a bcc was a bcc still can, and
+`recipients` gathers all three when it does not matter which was which.
+
+`body` keeps `text` and `html` apart too. A message sent with only an HTML body reports `undefined`
+for its text rather than handing back the markup.
+
+## Verifying identities
+
+Real SES verifies an email address by emailing it a link and a domain by looking for DNS records.
+Neither can happen inside a test process, so verification here is the simulator's own operation
+rather than an API call. `verifyIdentity` performs it, creating the identity if it is not already
+there.
+
+Everything else about identities is the ordinary SES API. `CreateEmailIdentity` starts one, and it
+starts unverified, exactly as a real one does:
+
+```typescript sim-ses-identities
+/**
+ * Creating an email identity, and verifying it the way only a simulator can.
+ */
+
+import {
+  CreateEmailIdentityCommand,
+  GetEmailIdentityCommand,
+} from "@aws-sdk/client-sesv2";
+
+import { SimAws } from "@kensio/yulin";
+
+const ses = new SimAws().sesV2();
+
+await ses.createEmailIdentity(
+  new CreateEmailIdentityCommand({ EmailIdentity: "example.com" }),
+);
+
+const pending = await ses.getEmailIdentity(
+  new GetEmailIdentityCommand({ EmailIdentity: "example.com" }),
+);
+
+// "DOMAIN" "PENDING" false
+console.log(
+  pending.IdentityType,
+  pending.VerificationStatus,
+  pending.VerifiedForSendingStatus,
+);
+
+// Standing in for the DNS records a real domain identity waits on.
+ses.verifyIdentity("example.com");
+
+const verified = await ses.getEmailIdentity(
+  new GetEmailIdentityCommand({ EmailIdentity: "example.com" }),
+);
+
+// "SUCCESS" true
+console.log(verified.VerificationStatus, verified.VerifiedForSendingStatus);
+```
+
+Whether an identity is an address or a domain follows from whether the name has an `@` in it, which
+is how SES itself decides: there is no parameter saying which is meant.
+
+A verified domain covers every address at it, which is the whole reason domain identities exist. It
+does not cover a subdomain: `example.com` does nothing for `orders@mail.example.com`, here or on
+real SES. Domains match without regard to case; the local part of an address does not, per RFC 5321,
+so `Sales@example.com` and `sales@example.com` are two identities.
+
+`unverify()` on an identity puts it back to `PENDING`, which is what a real one does when the
+records that proved it stop resolving. That gives a test somewhere to go when it wants to see
+sending fail after it once worked.
+
+## The sandbox
+
+An account starts in the SES sandbox, where **both** the sender and every recipient have to be
+verified. That is the state most tests should be written against: it is the configuration that
+refuses to mail an address nobody verified, and catching that refusal in a test is much better than
+catching it in an account.
+
+Outside the sandbox only the sender is checked. `PutAccountDetails` with `ProductionAccessEnabled`
+is how an account gets there:
+
+```typescript sim-ses-sandbox
+/**
+ * The sandbox rules, and leaving the sandbox.
+ */
+
+import {
+  PutAccountDetailsCommand,
+  SendEmailCommand,
+} from "@aws-sdk/client-sesv2";
+
+import { SimAws } from "@kensio/yulin";
+import { SimSesMessageRejected } from "@kensio/yulin/ses";
+
+const ses = new SimAws().sesV2();
+
+ses.verifyIdentity("hello@example.com");
+
+const message = new SendEmailCommand({
+  FromEmailAddress: "hello@example.com",
+  Destination: { ToAddresses: ["someone@example.org"] },
+  Content: {
+    Simple: {
+      Subject: { Data: "Welcome" },
+      Body: { Text: { Data: "Hi there" } },
+    },
+  },
+});
+
+try {
+  await ses.sendEmail(message);
+} catch (error) {
+  // MessageRejected: the recipient is not verified and this account is still
+  // in the sandbox.
+  console.log(error instanceof SimSesMessageRejected, ses.isInSandbox());
+}
+
+await ses.putAccountDetails(
+  new PutAccountDetailsCommand({
+    MailType: "TRANSACTIONAL",
+    WebsiteURL: "https://example.com",
+    ProductionAccessEnabled: true,
+  }),
+);
+
+await ses.sendEmail(message);
+
+// 1
+console.log(ses.sentEmails().length);
+```
+
+A rejection names every identity that failed the check in one message, the way real SES does, so a
+caller finds out everything it has to verify from one failure rather than several:
+
+```
+Email address is not verified. The following identities failed the check in region US-EAST-1: someone@example.org
+```
+
+Real SES treats `ProductionAccessEnabled` as a request that a human at AWS then reviews, so an
+account does not leave the sandbox the moment the call returns. Granting it immediately is a
+deliberate divergence: the alternative is a simulator no test can get out of the sandbox in, and
+waiting for a review is not behaviour a test can assert on anyway.
+
+## Permissions
+
+Every command authorizes through simulated IAM. A send authorizes against the identity being sent
+**from**; recipients never enter into it, which is worth knowing when a policy looks like it should
+cover a send and does not.
+
+```typescript sim-ses-permissions
+/**
+ * A Role that may only send from one domain.
+ */
+
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import { SendEmailCommand } from "@aws-sdk/client-sesv2";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws({ defaultAccountId: "111111111111" });
+const ses = simAws.sesV2();
+
+ses.verifyIdentity("example.com");
+
+await simAws.iam().createRole(
+  new CreateRoleCommand({
+    RoleName: "SignUpFunctionRole",
+    AssumeRolePolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: [
+        {
+          Effect: "Allow",
+          Principal: { Service: "lambda.amazonaws.com" },
+          Action: "sts:AssumeRole",
+        },
+      ],
+    }),
+  }),
+);
+
+await simAws.iam().putRolePolicy(
+  new PutRolePolicyCommand({
+    RoleName: "SignUpFunctionRole",
+    PolicyName: "SendWelcomeEmail",
+    PolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: [
+        {
+          Effect: "Allow",
+          Action: "ses:SendEmail",
+          Resource: "arn:aws:ses:us-east-1:111111111111:identity/example.com",
+        },
+      ],
+    }),
+  }),
+);
+
+await ses.sendEmail(
+  new SendEmailCommand({
+    FromEmailAddress: "anything@example.com",
+    Destination: { ToAddresses: ["someone@example.com"] },
+    Content: {
+      Simple: {
+        Subject: { Data: "Welcome" },
+        Body: { Text: { Data: "Hi there" } },
+      },
+    },
+  }),
+  {
+    caller: {
+      kind: "arn",
+      arn: "arn:aws:iam::111111111111:role/SignUpFunctionRole",
+    },
+  },
+);
+
+// 1
+console.log(ses.sentEmails().length);
+```
+
+The more specific identity wins when both exist. A policy naming `identity/example.com` covers a
+send from any address at the domain, unless that address is an identity in its own right, in which
+case the send authorizes against `identity/hello@example.com` instead.
+
+`ses:ListEmailIdentities` reaches every identity in the account and region, so it authorizes against
+`identity/*` and a policy naming one identity does not allow it. `ses:GetAccount` and
+`ses:PutAccountDetails` have no resource type at all on real SES, so only a policy written against
+`*` allows them.
+
+IAM is evaluated before the identity check, as it is on real AWS. A caller with no permission is
+refused whether or not its identities are verified, which means the error a test sees says which of
+the two is wrong.
+
+## SDK interception
+
+An intercepted `SESv2Client` reaches simulated SES with nothing touching the network:
+
+```typescript sim-ses-sdk-interception
+/**
+ * Application code sending through an intercepted SES client.
+ */
+
+import { SendEmailCommand, SESv2Client } from "@aws-sdk/client-sesv2";
+
+import { SimSdk } from "@kensio/yulin/sdk";
+
+using simSdk = new SimSdk();
+simSdk.intercept(SESv2Client);
+
+const scoped = simSdk.simAws.accountRegionScope(
+  simSdk.simAws.defaultAccountId,
+  "eu-west-2",
+);
+
+scoped.sesV2().verifyIdentity("example.com");
+scoped.sesV2().verifyIdentity("example.org");
+
+// Ordinary application code, unaware it is not talking to AWS.
+const client = new SESv2Client({ region: "eu-west-2" });
+
+await client.send(
+  new SendEmailCommand({
+    FromEmailAddress: "hello@example.com",
+    Destination: { ToAddresses: ["someone@example.org"] },
+    Content: {
+      Simple: {
+        Subject: { Data: "Welcome" },
+        Body: { Text: { Data: "Hi there" } },
+      },
+    },
+  }),
+);
+
+// "Welcome"
+console.log(scoped.sesV2().sentEmails()[0]?.subject);
+```
+
+## Reading the account
+
+`GetAccount` reports whether the account has production access and what it may send:
+
+```typescript sim-ses-account
+/**
+ * Reading the sandbox state and the sending limits.
+ */
+
+import { GetAccountCommand } from "@aws-sdk/client-sesv2";
+
+import { SimAws } from "@kensio/yulin";
+
+const account = await new SimAws()
+  .sesV2()
+  .getAccount(new GetAccountCommand({}));
+
+// false 200 1
+console.log(
+  account.ProductionAccessEnabled,
+  account.SendQuota?.Max24HourSend,
+  account.SendQuota?.MaxSendRate,
+);
+```
+
+The quota figures are the real sandbox and production ones, and neither is enforced. `SentLast24Hours`
+counts what was actually sent, on the simulated clock, so a test that moves time forward past the
+window sees the count fall the way an account's would.
+
+## Simulated commands
+
+| Command               | Notes                                                                                      |
+| --------------------- | ------------------------------------------------------------------------------------------ |
+| `SendEmail`           | `Content.Simple` only. Recorded rather than delivered.                                     |
+| `CreateEmailIdentity` | Starts unverified. `Tags`, `DkimSigningAttributes` and `ConfigurationSetName` are refused. |
+| `GetEmailIdentity`    |                                                                                            |
+| `ListEmailIdentities` | Paged with `PageSize` and `NextToken`.                                                     |
+| `DeleteEmailIdentity` |                                                                                            |
+| `GetAccount`          |                                                                                            |
+| `PutAccountDetails`   | `MailType` and `WebsiteURL` are required, as on real SES.                                  |
+
+Anything else refuses on send with `SimSdkUnsupportedCommandError` rather than misbehaving quietly.
+
+## Divergences and limitations
+
+- **Verification is a simulator call.** `verifyIdentity` has no counterpart on AWS. It is the only
+  way an identity becomes verified here, because the real mechanisms are an emailed link and a DNS
+  record.
+- **Production access is granted on request.** Real SES has a human review it first.
+- **Send quotas are reported, not enforced.** A send past the daily figure still succeeds, and
+  nothing here takes real time to respect a per-second rate.
+- **Only `Content.Simple` is read.** `Content.Raw` and `Content.Template` are refused by name.
+  Templates are a separate piece of work.
+- **Nothing is delivered, and nothing bounces.** There are no bounce or complaint events, no
+  suppression list, no configuration sets and no event destinations. A configuration set named on a
+  send is kept on the record so a test can assert the right one was used, and does nothing else.
+- **No `AWS::SES::*` CloudFormation resources yet.** Identities have to be created through the API
+  or through `verifyIdentity`.
+- **SES v2 only.** The older `@aws-sdk/client-ses` API is not simulated.
+- **DKIM, MAIL FROM domains and sending authorization policies are not simulated.** An identity
+  created with `DkimSigningAttributes` is refused rather than reported as configured.

--- a/docs/services/ses/README.md
+++ b/docs/services/ses/README.md
@@ -184,7 +184,7 @@ console.log(ses.sentEmails().length);
 A rejection names every identity that failed the check in one message, the way real SES does, so a
 caller finds out everything it has to verify from one failure rather than several:
 
-```
+```text
 Email address is not verified. The following identities failed the check in region US-EAST-1: someone@example.org
 ```
 
@@ -274,10 +274,10 @@ The more specific identity wins when both exist. A policy naming `identity/examp
 send from any address at the domain, unless that address is an identity in its own right, in which
 case the send authorizes against `identity/hello@example.com` instead.
 
-`ses:ListEmailIdentities` reaches every identity in the account and region, so it authorizes against
-`identity/*` and a policy naming one identity does not allow it. `ses:GetAccount` and
-`ses:PutAccountDetails` have no resource type at all on real SES, so only a policy written against
-`*` allows them.
+`ses:ListEmailIdentities`, `ses:GetAccount` and `ses:PutAccountDetails` have no resource type at all
+on real SES, so only a policy written against `*` allows them. A policy scoped to identity ARNs
+allows none of the three, not even one written against `identity/*`, which is the intuitive reading
+and the wrong one.
 
 IAM is evaluated before the identity check, as it is on real AWS. A caller with no permission is
 refused whether or not its identities are verified, which means the error a test sees says which of

--- a/docs/services/ses/sim-ses-account.example.ts
+++ b/docs/services/ses/sim-ses-account.example.ts
@@ -1,0 +1,18 @@
+/**
+ * Reading the sandbox state and the sending limits.
+ */
+
+import { GetAccountCommand } from "@aws-sdk/client-sesv2";
+
+import { SimAws } from "@kensio/yulin";
+
+const account = await new SimAws()
+  .sesV2()
+  .getAccount(new GetAccountCommand({}));
+
+// false 200 1
+console.log(
+  account.ProductionAccessEnabled,
+  account.SendQuota?.Max24HourSend,
+  account.SendQuota?.MaxSendRate,
+);

--- a/docs/services/ses/sim-ses-identities.example.ts
+++ b/docs/services/ses/sim-ses-identities.example.ts
@@ -1,0 +1,37 @@
+/**
+ * Creating an email identity, and verifying it the way only a simulator can.
+ */
+
+import {
+  CreateEmailIdentityCommand,
+  GetEmailIdentityCommand,
+} from "@aws-sdk/client-sesv2";
+
+import { SimAws } from "@kensio/yulin";
+
+const ses = new SimAws().sesV2();
+
+await ses.createEmailIdentity(
+  new CreateEmailIdentityCommand({ EmailIdentity: "example.com" }),
+);
+
+const pending = await ses.getEmailIdentity(
+  new GetEmailIdentityCommand({ EmailIdentity: "example.com" }),
+);
+
+// "DOMAIN" "PENDING" false
+console.log(
+  pending.IdentityType,
+  pending.VerificationStatus,
+  pending.VerifiedForSendingStatus,
+);
+
+// Standing in for the DNS records a real domain identity waits on.
+ses.verifyIdentity("example.com");
+
+const verified = await ses.getEmailIdentity(
+  new GetEmailIdentityCommand({ EmailIdentity: "example.com" }),
+);
+
+// "SUCCESS" true
+console.log(verified.VerificationStatus, verified.VerifiedForSendingStatus);

--- a/docs/services/ses/sim-ses-permissions.example.ts
+++ b/docs/services/ses/sim-ses-permissions.example.ts
@@ -1,0 +1,68 @@
+/**
+ * A Role that may only send from one domain.
+ */
+
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import { SendEmailCommand } from "@aws-sdk/client-sesv2";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws({ defaultAccountId: "111111111111" });
+const ses = simAws.sesV2();
+
+ses.verifyIdentity("example.com");
+
+await simAws.iam().createRole(
+  new CreateRoleCommand({
+    RoleName: "SignUpFunctionRole",
+    AssumeRolePolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: [
+        {
+          Effect: "Allow",
+          Principal: { Service: "lambda.amazonaws.com" },
+          Action: "sts:AssumeRole",
+        },
+      ],
+    }),
+  }),
+);
+
+await simAws.iam().putRolePolicy(
+  new PutRolePolicyCommand({
+    RoleName: "SignUpFunctionRole",
+    PolicyName: "SendWelcomeEmail",
+    PolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: [
+        {
+          Effect: "Allow",
+          Action: "ses:SendEmail",
+          Resource: "arn:aws:ses:us-east-1:111111111111:identity/example.com",
+        },
+      ],
+    }),
+  }),
+);
+
+await ses.sendEmail(
+  new SendEmailCommand({
+    FromEmailAddress: "anything@example.com",
+    Destination: { ToAddresses: ["someone@example.com"] },
+    Content: {
+      Simple: {
+        Subject: { Data: "Welcome" },
+        Body: { Text: { Data: "Hi there" } },
+      },
+    },
+  }),
+  {
+    caller: {
+      kind: "arn",
+      arn: "arn:aws:iam::111111111111:role/SignUpFunctionRole",
+    },
+  },
+);
+
+// 1
+console.log(ses.sentEmails().length);

--- a/docs/services/ses/sim-ses-sandbox.example.ts
+++ b/docs/services/ses/sim-ses-sandbox.example.ts
@@ -1,0 +1,47 @@
+/**
+ * The sandbox rules, and leaving the sandbox.
+ */
+
+import {
+  PutAccountDetailsCommand,
+  SendEmailCommand,
+} from "@aws-sdk/client-sesv2";
+
+import { SimAws } from "@kensio/yulin";
+import { SimSesMessageRejected } from "@kensio/yulin/ses";
+
+const ses = new SimAws().sesV2();
+
+ses.verifyIdentity("hello@example.com");
+
+const message = new SendEmailCommand({
+  FromEmailAddress: "hello@example.com",
+  Destination: { ToAddresses: ["someone@example.org"] },
+  Content: {
+    Simple: {
+      Subject: { Data: "Welcome" },
+      Body: { Text: { Data: "Hi there" } },
+    },
+  },
+});
+
+try {
+  await ses.sendEmail(message);
+} catch (error) {
+  // MessageRejected: the recipient is not verified and this account is still
+  // in the sandbox.
+  console.log(error instanceof SimSesMessageRejected, ses.isInSandbox());
+}
+
+await ses.putAccountDetails(
+  new PutAccountDetailsCommand({
+    MailType: "TRANSACTIONAL",
+    WebsiteURL: "https://example.com",
+    ProductionAccessEnabled: true,
+  }),
+);
+
+await ses.sendEmail(message);
+
+// 1
+console.log(ses.sentEmails().length);

--- a/docs/services/ses/sim-ses-sdk-interception.example.ts
+++ b/docs/services/ses/sim-ses-sdk-interception.example.ts
@@ -1,0 +1,37 @@
+/**
+ * Application code sending through an intercepted SES client.
+ */
+
+import { SendEmailCommand, SESv2Client } from "@aws-sdk/client-sesv2";
+
+import { SimSdk } from "@kensio/yulin/sdk";
+
+using simSdk = new SimSdk();
+simSdk.intercept(SESv2Client);
+
+const scoped = simSdk.simAws.accountRegionScope(
+  simSdk.simAws.defaultAccountId,
+  "eu-west-2",
+);
+
+scoped.sesV2().verifyIdentity("example.com");
+scoped.sesV2().verifyIdentity("example.org");
+
+// Ordinary application code, unaware it is not talking to AWS.
+const client = new SESv2Client({ region: "eu-west-2" });
+
+await client.send(
+  new SendEmailCommand({
+    FromEmailAddress: "hello@example.com",
+    Destination: { ToAddresses: ["someone@example.org"] },
+    Content: {
+      Simple: {
+        Subject: { Data: "Welcome" },
+        Body: { Text: { Data: "Hi there" } },
+      },
+    },
+  }),
+);
+
+// "Welcome"
+console.log(scoped.sesV2().sentEmails()[0]?.subject);

--- a/docs/services/ses/sim-ses-send-and-assert.example.ts
+++ b/docs/services/ses/sim-ses-send-and-assert.example.ts
@@ -1,0 +1,33 @@
+/**
+ * Sending a welcome email through simulated SES and asserting on it.
+ */
+
+import { SendEmailCommand } from "@aws-sdk/client-sesv2";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const ses = simAws.sesV2();
+
+// Both ends have to be verified in the sandbox, which is where an account
+// starts.
+ses.verifyIdentity("hello@example.com");
+ses.verifyIdentity("someone@example.org");
+
+await ses.sendEmail(
+  new SendEmailCommand({
+    FromEmailAddress: "hello@example.com",
+    Destination: { ToAddresses: ["someone@example.org"] },
+    Content: {
+      Simple: {
+        Subject: { Data: "Welcome" },
+        Body: { Text: { Data: "Hi there, thanks for signing up." } },
+      },
+    },
+  }),
+);
+
+const [email] = ses.sentEmails();
+
+// "Welcome" someone@example.org
+console.log(email?.subject, email?.destination.toAddresses[0]);

--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -30,6 +30,7 @@
         "../src/service/secretsmanager/index.ts"
       ],
       "@kensio/yulin/serve": ["../src/serve/index.ts"],
+      "@kensio/yulin/ses": ["../src/service/ses/index.ts"],
       "@kensio/yulin/sns": ["../src/service/sns/index.ts"],
       "@kensio/yulin/sqs": ["../src/service/sqs/index.ts"],
       "@kensio/yulin/watch": ["../src/watch/index.ts"]

--- a/package.json
+++ b/package.json
@@ -140,6 +140,10 @@
       "import": "./dist/service/secretsmanager/index.js",
       "types": "./dist/service/secretsmanager/index.d.ts"
     },
+    "./ses": {
+      "import": "./dist/service/ses/index.js",
+      "types": "./dist/service/ses/index.d.ts"
+    },
     "./sns": {
       "import": "./dist/service/sns/index.js",
       "types": "./dist/service/sns/index.d.ts"
@@ -194,6 +198,7 @@
     "@aws-sdk/client-s3": "^3.1101.0",
     "@aws-sdk/client-scheduler": "^3.1109.0",
     "@aws-sdk/client-secrets-manager": "^3.1101.0",
+    "@aws-sdk/client-sesv2": "^3.1111.0",
     "@aws-sdk/client-sns": "^3.1104.0",
     "@aws-sdk/client-sqs": "^3.1101.0",
     "@aws-sdk/client-ssm": "^3.1101.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,6 +90,9 @@ importers:
       '@aws-sdk/client-secrets-manager':
         specifier: ^3.1101.0
         version: 3.1105.0
+      '@aws-sdk/client-sesv2':
+        specifier: ^3.1111.0
+        version: 3.1111.0
       '@aws-sdk/client-sns':
         specifier: ^3.1104.0
         version: 3.1105.0
@@ -347,6 +350,10 @@ packages:
 
   '@aws-sdk/client-secrets-manager@3.1105.0':
     resolution: {integrity: sha512-ig7eNIkCV6XcT932pKvVLfEdX/g58DIHmBs8zx8Fcm/k9mDtmjAs8Y2kOpV8U7hRKiup/4TDYVb/olVUDnzQuA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/client-sesv2@3.1111.0':
+    resolution: {integrity: sha512-RLraobtxTBIGOVNQzf9q6Irsx6OUSdLgmRw6cGTCoRZ5o8xrHbxA8KUgXLnoDRnVobSfxJaarqd+dS4DQl11rA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/client-sns@3.1105.0':
@@ -3765,6 +3772,18 @@ snapshots:
       '@smithy/types': 4.17.0
       tslib: 2.8.1
 
+  '@aws-sdk/client-sesv2@3.1111.0':
+    dependencies:
+      '@aws-sdk/core': 3.977.8
+      '@aws-sdk/credential-provider-node': 3.972.80
+      '@aws-sdk/signature-v4-multi-region': 3.996.45
+      '@aws-sdk/types': 3.974.4
+      '@smithy/core': 3.32.0
+      '@smithy/fetch-http-handler': 5.7.0
+      '@smithy/node-http-handler': 4.10.0
+      '@smithy/types': 4.17.0
+      tslib: 2.8.1
+
   '@aws-sdk/client-sns@3.1105.0':
     dependencies:
       '@aws-sdk/core': 3.977.7
@@ -4055,7 +4074,7 @@ snapshots:
   '@aws-sdk/nested-clients@3.997.42':
     dependencies:
       '@aws-sdk/core': 3.977.8
-      '@aws-sdk/signature-v4-multi-region': 3.996.44
+      '@aws-sdk/signature-v4-multi-region': 3.996.45
       '@aws-sdk/types': 3.974.4
       '@smithy/core': 3.32.0
       '@smithy/fetch-http-handler': 5.7.0

--- a/src/sdk/router/resolve-sim-sdk-command-router.ts
+++ b/src/sdk/router/resolve-sim-sdk-command-router.ts
@@ -99,6 +99,7 @@ const scopedRouters: ReadonlyMap<string, SimSdkScopedRouter> = new Map<
     "Secrets Manager",
     (scoped): SimSdkCommandRouter => scoped.secretsManager().sdkCommandRouter(),
   ],
+  ["SESv2", (scoped): SimSdkCommandRouter => scoped.sesV2().sdkCommandRouter()],
   ["SNS", (scoped): SimSdkCommandRouter => scoped.sns().sdkCommandRouter()],
   ["SQS", (scoped): SimSdkCommandRouter => scoped.sqs().sdkCommandRouter()],
   ["SSM", (scoped): SimSdkCommandRouter => scoped.ssm().sdkCommandRouter()],

--- a/src/service/aws/factory/sim-aws-self-contained-service-builder.ts
+++ b/src/service/aws/factory/sim-aws-self-contained-service-builder.ts
@@ -1,6 +1,7 @@
 import type { SimAwsAccountRegionContainer } from "../sim-aws-account-region-scope.js";
 import { SimDynamoDb as SimDynamoDatabase } from "../../dynamodb/index.js";
 import { SimSecretsManager } from "../../secretsmanager/index.js";
+import { SimSesV2 } from "../../ses/index.js";
 import { SimSqs } from "../../sqs/index.js";
 import { SimSsm } from "../../ssm/index.js";
 import type { SimAwsAccountServiceCache } from "./sim-aws-account-service-cache.js";
@@ -43,6 +44,17 @@ export class SimAwsSelfContainedServiceBuilder {
    */
   createSecretsManager(scope: SimAwsAccountRegionContainer): SimSecretsManager {
     return new SimSecretsManager({ ...this.scoped(scope), kms: scope.kms() });
+  }
+
+  /**
+   * Create simulated SES for an Account Region scope.
+   *
+   * Identities are Region-scoped on real SES: verifying an address in one
+   * Region verifies nothing in another, and a message sent through one Region
+   * is invisible from the next.
+   */
+  createSesV2(scope: SimAwsAccountRegionContainer): SimSesV2 {
+    return new SimSesV2(this.scoped(scope));
   }
 
   /**

--- a/src/service/aws/factory/sim-aws-service-factory.ts
+++ b/src/service/aws/factory/sim-aws-service-factory.ts
@@ -29,6 +29,7 @@ import { SimLambdaUrlRegistry } from "../../lambda/registry/sim-lambda-url-regis
 import type { SimLogs } from "../../logs/index.js";
 import type { SimSecretsManager } from "../../secretsmanager/index.js";
 import type { SimEventBridge } from "../../eventbridge/index.js";
+import type { SimSesV2 } from "../../ses/index.js";
 import type { SimSns } from "../../sns/index.js";
 import type { SimSqs } from "../../sqs/index.js";
 import type { SimSsm } from "../../ssm/index.js";
@@ -262,6 +263,11 @@ export class SimAwsServiceFactory {
   /** Create simulated EventBridge Scheduler for an Account Region scope. */
   createScheduler(scope: SimAwsAccountRegionContainer): SimScheduler {
     return this.accountRegionServices.createScheduler(scope);
+  }
+
+  /** Create simulated SES for an Account Region scope. */
+  createSesV2(scope: SimAwsAccountRegionContainer): SimSesV2 {
+    return this.selfContainedServices.createSesV2(scope);
   }
 
   /** Create simulated SNS for an Account Region scope. */

--- a/src/service/aws/sim-aws-account-region-scope.ts
+++ b/src/service/aws/sim-aws-account-region-scope.ts
@@ -27,6 +27,7 @@ import type { SimKms } from "../kms/index.js";
 import type { SimLambda } from "../lambda/index.js";
 import type { SimLogs } from "../logs/index.js";
 import type { SimSecretsManager } from "../secretsmanager/index.js";
+import type { SimSesV2 } from "../ses/index.js";
 import type { SimSns } from "../sns/index.js";
 import type { SimSqs } from "../sqs/index.js";
 import type { SimSsm } from "../ssm/index.js";
@@ -213,6 +214,11 @@ export class SimAwsAccountRegionContainer {
     return this.memo.getOrCreate("secretsManager", () =>
       this.factory.createSecretsManager(this),
     );
+  }
+
+  /** Get simulated SES for this account and region. */
+  sesV2(): SimSesV2 {
+    return this.memo.getOrCreate("sesV2", () => this.factory.createSesV2(this));
   }
 
   /** Get simulated SNS for this account and region. */

--- a/src/service/aws/sim-aws-service-accessors.ts
+++ b/src/service/aws/sim-aws-service-accessors.ts
@@ -23,6 +23,7 @@ import type { SimS3 } from "../s3/sim-s3.js";
 import type { SimScheduler } from "../scheduler/index.js";
 import type { SimSecretsManager } from "../secretsmanager/index.js";
 import type { SimEventBridge } from "../eventbridge/index.js";
+import type { SimSesV2 } from "../ses/index.js";
 import type { SimSns } from "../sns/index.js";
 import type { SimSqs } from "../sqs/index.js";
 import type { SimSsm } from "../ssm/index.js";
@@ -152,6 +153,11 @@ export abstract class SimAwsServiceAccessors {
   /** Get simulated Secrets Manager in the default Account Region scope. */
   secretsManager(): SimSecretsManager {
     return this.defaultAccountRegionScope().secretsManager();
+  }
+
+  /** Get simulated SES in the default Account Region scope. */
+  sesV2(): SimSesV2 {
+    return this.defaultAccountRegionScope().sesV2();
   }
 
   /** Get simulated SNS in the default Account Region scope. */

--- a/src/service/ses/README.md
+++ b/src/service/ses/README.md
@@ -1,0 +1,93 @@
+# Simulated SES implementation
+
+This directory contains the simulated Amazon SES implementation, through its v2 API. Email
+identities, the sandbox rules, and a record of every message SES would have sent.
+
+The guiding decision here is that there is nothing to deliver, and no delivery to build later
+either. A message SES accepts leaves AWS for a mail system, so the whole of the observable AWS
+behaviour is the decision of whether SES would have accepted it and a record of what it would have
+sent. That record is what a test asserts on, and it is the point of the service.
+
+## Entry points
+
+- `sim-ses-v2.ts` is the main in-memory service object for one account/region scope.
+- `index.ts` exports the public SES simulator API for `@kensio/yulin/ses`.
+
+The class is `SimSesV2` rather than `SimSes`, matching simulated ELBv2 and API Gateway v2: it
+answers the v2 API. The directory is `ses` rather than `sesv2` because the state is the service's
+rather than the API version's. SES has an older API over the same identities and the same account,
+and if that is ever simulated it belongs beside this and shares the stores, not in a directory of
+its own.
+
+A `SimSesV2` owns a `SimSesIdentityStore`, a `SimSesSentEmailStore` and a `SimSesAccount`. All three
+are region scoped because real SES state is: verifying an address in one region verifies nothing in
+another, and the sandbox is a per-region condition.
+
+## Identity model
+
+Identity state lives under `identity/`.
+
+`SimSesIdentity` is the stored resource: the address or domain, its type, its ARN and how far its
+verification has got. An identity starts `PENDING` and only a simulator-side call moves it to
+`SUCCESS`. That is the one deliberate divergence from AWS in this service, and an unavoidable one:
+real SES verifies an address by emailing it a link and a domain by looking for DNS records, and
+neither can happen inside a test process. `SimSesV2.verifyIdentity` is where a test performs it, and
+it creates the identity if it is not already there, because verifying is what setting up a mailbox
+in a test actually means.
+
+Which kind an identity is follows from whether the name has an `@` in it, exactly as SES decides it:
+there is no parameter saying which is meant. `simSesIdentityKey` is how two spellings of the same
+thing meet. Domains are keyed in lower case because they are case insensitive; the local part of an
+address is kept as given because per RFC 5321 it is not, so `Sales@example.com` and
+`sales@example.com` are two identities here.
+
+`SimSesIdentityStore.covering` and `SimSesIdentityStore.isAddressVerified` answer two different
+questions about the same address and are deliberately not the same function.
+
+- `covering` picks the identity IAM authorizes an operation against, and the more specific of the
+  two wins: an address identity over a domain one. A policy naming `identity/hello@example.com`
+  covers a send from that address; one naming `identity/example.com` covers a send from any address
+  at the domain, unless the address is an identity in its own right.
+- `isAddressVerified` asks whether either will do, because either will: an address identity still
+  waiting on its link sends anyway once its domain is verified.
+
+Neither treats a parent domain as covering a subdomain, here or on real SES.
+
+## Sending
+
+Send state lives under `email/`, and the command under `command/send/`.
+
+`SimSesSendEmail` decides a request in the order real SES does: IAM first, then the identity check,
+then the message is recorded. A caller with no permission is therefore refused whether or not its
+identities are verified, which is worth keeping in that order because the error a test sees says
+which of the two is wrong.
+
+`SimSesVerifiedIdentityCheck` holds both sandbox rules. The sender is checked in the sandbox and out
+of it, because SES will not send from an address nobody has proved they own. Recipients are checked
+only in the sandbox, and that is what the sandbox is actually for. Failures are gathered rather than
+reported one at a time, because real SES names every identity that failed in a single message.
+
+`SimSesSentEmail` is what the record keeps. The three recipient lists stay three lists so a test
+asserting a bcc was a bcc still can, and the body keeps text and HTML apart so a test asserting on
+the text of an HTML-only message finds nothing rather than the markup.
+
+Only `Content.Simple` is read. `Content.Raw` and `Content.Template` are refused by name: a raw MIME
+message would have to be parsed to say anything about its subject or body, and templates are not
+here yet. Refusing is the honest answer, since a recorded message with nothing in it would make a
+test pass for a reason unrelated to what it asserts.
+
+## Account model
+
+Account state lives under `account/`.
+
+`SimSesAccount` starts in the sandbox, which is where every real account starts and the state most
+tests should be written against. `PutAccountDetails` with `ProductionAccessEnabled` leaves it. Real
+SES treats that as a request a human at AWS then reviews, and granting it immediately is the
+divergence worth taking: the alternative is a simulator no test can get out of the sandbox in, and
+waiting for a review is not behaviour a test can assert on anyway.
+
+Neither send quota is enforced. Simulating the daily cap would mean a suite that sent two hundred
+messages started failing for a reason unrelated to what it asserts, and simulating the per-second
+rate would mean tests that take real time to run. The numbers `GetAccount` reports are the real
+sandbox and production ones, and `SentLast24Hours` counts what was actually sent, on the simulated
+clock, so moving time forward past the window drops the count the way an account's would.

--- a/src/service/ses/account/sim-ses-account.ts
+++ b/src/service/ses/account/sim-ses-account.ts
@@ -1,0 +1,96 @@
+/**
+ * How much an account may send, which is one of the two things leaving the
+ * sandbox changes.
+ */
+export interface SimSesSendQuota {
+  readonly max24HourSend: number;
+  readonly maxSendRate: number;
+}
+
+/**
+ * What a sandbox account may send. These are the real SES sandbox limits.
+ */
+const sandboxQuota: SimSesSendQuota = { max24HourSend: 200, maxSendRate: 1 };
+
+/**
+ * What an account with production access may send.
+ *
+ * Real SES sets these per account, raising them as sending reputation builds,
+ * so this is the starting point rather than a fixed ceiling.
+ */
+const productionQuota: SimSesSendQuota = {
+  max24HourSend: 50_000,
+  maxSendRate: 14,
+};
+
+/**
+ * The contact details `PutAccountDetails` carries, kept so `GetAccount` can
+ * report them back.
+ */
+export interface SimSesAccountContactDetails {
+  readonly mailType: string;
+  readonly websiteUrl: string;
+  readonly contactLanguage: string | undefined;
+  readonly useCaseDescription: string | undefined;
+  readonly additionalContactEmailAddresses: readonly string[] | undefined;
+}
+
+/**
+ * The account-wide SES settings of one region.
+ *
+ * An account starts in the sandbox, which is where every real one starts and
+ * the state most tests should be written against: it is the configuration that
+ * refuses to mail an address nobody verified, and that refusal is the whole
+ * point of having identities at all.
+ *
+ * Neither quota is enforced. Simulating the daily cap would mean a test suite
+ * that sent two hundred messages started failing for a reason unrelated to
+ * what it asserts, and simulating the per-second rate would mean tests that
+ * take real time to run. The numbers are reported so a caller reading them
+ * gets the shape it expects, and the divergence is documented rather than
+ * quietly enforced.
+ */
+export class SimSesAccount {
+  #productionAccessEnabled = false;
+  #contactDetails: SimSesAccountContactDetails | undefined;
+
+  /**
+   * Whether this account has left the sandbox.
+   */
+  get productionAccessEnabled(): boolean {
+    return this.#productionAccessEnabled;
+  }
+
+  /**
+   * Whether the sandbox rules apply, which is the same question the other way
+   * round. Sending code reads it this way, so it is named this way too.
+   */
+  get isInSandbox(): boolean {
+    return !this.#productionAccessEnabled;
+  }
+
+  get sendQuota(): SimSesSendQuota {
+    return this.#productionAccessEnabled ? productionQuota : sandboxQuota;
+  }
+
+  get contactDetails(): SimSesAccountContactDetails | undefined {
+    return this.#contactDetails;
+  }
+
+  /**
+   * Record the account details, and leave the sandbox if they ask to.
+   *
+   * Real SES treats `ProductionAccessEnabled` as a request that a human at AWS
+   * then reviews, so an account does not leave the sandbox the moment this
+   * returns. Granting it immediately is the divergence worth taking: the
+   * alternative is a simulator no test can get out of the sandbox in, and
+   * waiting for a review is not behaviour a test can assert on anyway.
+   */
+  putDetails(
+    details: SimSesAccountContactDetails,
+    productionAccessEnabled: boolean,
+  ): void {
+    this.#contactDetails = details;
+    this.#productionAccessEnabled = productionAccessEnabled;
+  }
+}

--- a/src/service/ses/command/account/account.command.ts
+++ b/src/service/ses/command/account/account.command.ts
@@ -1,0 +1,63 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+
+/**
+ * Minimal structural sim SES v2 GetAccount command.
+ *
+ * GetAccount takes no input at all, so its `input` is only here because every
+ * SDK Command has one.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/sesv2/command/GetAccountCommand/
+ */
+export interface SimGetAccountCommand {
+  readonly input?: object | undefined;
+}
+
+export interface SimSesSendQuotaDetail {
+  readonly Max24HourSend: number;
+  readonly MaxSendRate: number;
+  readonly SentLast24Hours: number;
+}
+
+export interface SimGetAccountCommandOutput {
+  readonly DedicatedIpAutoWarmupEnabled?: boolean | undefined;
+  readonly EnforcementStatus?: string | undefined;
+  readonly ProductionAccessEnabled?: boolean | undefined;
+  readonly SendQuota?: SimSesSendQuotaDetail | undefined;
+  readonly SendingEnabled?: boolean | undefined;
+  readonly Details?: SimSesAccountDetailsOutput | undefined;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * What GetAccount reports back of the details PutAccountDetails was given.
+ */
+export interface SimSesAccountDetailsOutput {
+  readonly MailType?: string | undefined;
+  readonly WebsiteURL?: string | undefined;
+  readonly ContactLanguage?: string | undefined;
+  readonly UseCaseDescription?: string | undefined;
+  readonly AdditionalContactEmailAddresses?: readonly string[] | undefined;
+  readonly ReviewDetails?: { readonly Status?: string | undefined } | undefined;
+}
+
+/**
+ * Minimal structural sim SES v2 PutAccountDetails command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/sesv2/command/PutAccountDetailsCommand/
+ */
+export interface SimPutAccountDetailsCommand {
+  readonly input: SimPutAccountDetailsCommandInput;
+}
+
+export interface SimPutAccountDetailsCommandInput {
+  readonly MailType?: string | undefined;
+  readonly WebsiteURL?: string | undefined;
+  readonly ContactLanguage?: string | undefined;
+  readonly UseCaseDescription?: string | undefined;
+  readonly AdditionalContactEmailAddresses?: readonly string[] | undefined;
+  readonly ProductionAccessEnabled?: boolean | undefined;
+}
+
+export interface SimPutAccountDetailsCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/ses/command/account/sim-ses-account-commands.ts
+++ b/src/service/ses/command/account/sim-ses-account-commands.ts
@@ -43,7 +43,7 @@ export class SimSesAccountCommands {
    * sandbox.
    */
   getAccount(options?: SimSesRequestOptions): SimGetAccountCommandOutput {
-    this.#authorizer.authorizeAccount("ses:GetAccount", options?.caller);
+    this.#authorizer.authorizeNoResource("ses:GetAccount", options?.caller);
 
     return simSesAccountReport({
       account: this.#account,
@@ -58,7 +58,10 @@ export class SimSesAccountCommands {
     command: SimPutAccountDetailsCommand,
     options?: SimSesRequestOptions,
   ): SimPutAccountDetailsCommandOutput {
-    this.#authorizer.authorizeAccount("ses:PutAccountDetails", options?.caller);
+    this.#authorizer.authorizeNoResource(
+      "ses:PutAccountDetails",
+      options?.caller,
+    );
 
     this.#account.putDetails(
       readSimSesAccountDetails(command.input),

--- a/src/service/ses/command/account/sim-ses-account-commands.ts
+++ b/src/service/ses/command/account/sim-ses-account-commands.ts
@@ -1,0 +1,70 @@
+import type { SimClock } from "../../../../util/clock/sim-clock.js";
+import type { SimSesAccount } from "../../account/sim-ses-account.js";
+import type { SimSesSentEmailStore } from "../../email/sim-ses-sent-email-store.js";
+import type { SimSesAuthorizer } from "../authorize/sim-ses-authorizer.js";
+import type { SimSesRequestOptions } from "../sim-ses-request-options.js";
+import type {
+  SimGetAccountCommandOutput,
+  SimPutAccountDetailsCommand,
+  SimPutAccountDetailsCommandOutput,
+} from "./account.command.js";
+import { readSimSesAccountDetails } from "./sim-ses-account-details-input.js";
+import { simSesAccountReport } from "./sim-ses-account-report.js";
+
+interface SimSesAccountCommandsProperties {
+  readonly account: SimSesAccount;
+  readonly sent: SimSesSentEmailStore;
+  readonly authorizer: SimSesAuthorizer;
+  readonly clock: SimClock;
+}
+
+/**
+ * The commands that read and change what a whole SES account may do.
+ *
+ * Both authorize against `*`, because real SES gives neither a resource type:
+ * only a policy written against every resource allows them, and one naming an
+ * identity ARN allows neither.
+ */
+export class SimSesAccountCommands {
+  readonly #account: SimSesAccount;
+  readonly #sent: SimSesSentEmailStore;
+  readonly #authorizer: SimSesAuthorizer;
+  readonly #clock: SimClock;
+
+  constructor(properties: SimSesAccountCommandsProperties) {
+    this.#account = properties.account;
+    this.#sent = properties.sent;
+    this.#authorizer = properties.authorizer;
+    this.#clock = properties.clock;
+  }
+
+  /**
+   * Report what this account may do, including whether it is still in the
+   * sandbox.
+   */
+  getAccount(options?: SimSesRequestOptions): SimGetAccountCommandOutput {
+    this.#authorizer.authorizeAccount("ses:GetAccount", options?.caller);
+
+    return simSesAccountReport({
+      account: this.#account,
+      sentLast24Hours: this.#sent.countSentSince(this.#clock.now()),
+    });
+  }
+
+  /**
+   * Record the account details, and leave the sandbox if they ask to.
+   */
+  putAccountDetails(
+    command: SimPutAccountDetailsCommand,
+    options?: SimSesRequestOptions,
+  ): SimPutAccountDetailsCommandOutput {
+    this.#authorizer.authorizeAccount("ses:PutAccountDetails", options?.caller);
+
+    this.#account.putDetails(
+      readSimSesAccountDetails(command.input),
+      command.input.ProductionAccessEnabled ?? false,
+    );
+
+    return { $metadata: {} };
+  }
+}

--- a/src/service/ses/command/account/sim-ses-account-details-input.ts
+++ b/src/service/ses/command/account/sim-ses-account-details-input.ts
@@ -1,0 +1,51 @@
+import type { SimSesAccountContactDetails } from "../../account/sim-ses-account.js";
+import { SimSesBadRequestException } from "../../error/sim-ses.error.js";
+import type { SimPutAccountDetailsCommandInput } from "./account.command.js";
+
+/**
+ * The mail types real SES accepts, and requires one of.
+ */
+const mailTypes = new Set(["MARKETING", "TRANSACTIONAL"]);
+
+/**
+ * Read the account details a request carries, refusing what real SES refuses.
+ *
+ * `MailType` and `WebsiteURL` are both required on real SES, which is easy to
+ * miss: the request that only wants to leave the sandbox still has to say what
+ * the account sends and where from.
+ */
+export function readSimSesAccountDetails(
+  input: SimPutAccountDetailsCommandInput,
+): SimSesAccountContactDetails {
+  return {
+    mailType: requiredMailType(input.MailType),
+    websiteUrl: requiredWebsiteUrl(input.WebsiteURL),
+    contactLanguage: input.ContactLanguage,
+    useCaseDescription: input.UseCaseDescription,
+    additionalContactEmailAddresses: input.AdditionalContactEmailAddresses,
+  };
+}
+
+function requiredMailType(mailType: string | undefined): string {
+  if (mailType === undefined || !mailTypes.has(mailType)) {
+    throw new SimSesBadRequestException(
+      `1 validation error detected: Value '${String(mailType)}' at ` +
+        `'mailType' failed to satisfy constraint: Member must be one of ${[
+          ...mailTypes,
+        ].join(", ")}`,
+    );
+  }
+
+  return mailType;
+}
+
+function requiredWebsiteUrl(websiteUrl: string | undefined): string {
+  if (websiteUrl === undefined || websiteUrl.length === 0) {
+    throw new SimSesBadRequestException(
+      "1 validation error detected: Value at 'websiteURL' failed to satisfy " +
+        "constraint: Member must not be null",
+    );
+  }
+
+  return websiteUrl;
+}

--- a/src/service/ses/command/account/sim-ses-account-details-input.ts
+++ b/src/service/ses/command/account/sim-ses-account-details-input.ts
@@ -8,6 +8,11 @@ import type { SimPutAccountDetailsCommandInput } from "./account.command.js";
 const mailTypes = new Set(["MARKETING", "TRANSACTIONAL"]);
 
 /**
+ * The two languages real SES will write to a contact in.
+ */
+const contactLanguages = new Set(["EN", "JA"]);
+
+/**
  * Read the account details a request carries, refusing what real SES refuses.
  *
  * `MailType` and `WebsiteURL` are both required on real SES, which is easy to
@@ -20,7 +25,7 @@ export function readSimSesAccountDetails(
   return {
     mailType: requiredMailType(input.MailType),
     websiteUrl: requiredWebsiteUrl(input.WebsiteURL),
-    contactLanguage: input.ContactLanguage,
+    contactLanguage: optionalContactLanguage(input.ContactLanguage),
     useCaseDescription: input.UseCaseDescription,
     additionalContactEmailAddresses: input.AdditionalContactEmailAddresses,
   };
@@ -37,6 +42,20 @@ function requiredMailType(mailType: string | undefined): string {
   }
 
   return mailType;
+}
+
+function optionalContactLanguage(
+  contactLanguage: string | undefined,
+): string | undefined {
+  if (contactLanguage !== undefined && !contactLanguages.has(contactLanguage)) {
+    throw new SimSesBadRequestException(
+      `1 validation error detected: Value '${contactLanguage}' at ` +
+        `'contactLanguage' failed to satisfy constraint: Member must be one ` +
+        `of ${[...contactLanguages].join(", ")}`,
+    );
+  }
+
+  return contactLanguage;
 }
 
 function requiredWebsiteUrl(websiteUrl: string | undefined): string {

--- a/src/service/ses/command/account/sim-ses-account-report.ts
+++ b/src/service/ses/command/account/sim-ses-account-report.ts
@@ -1,0 +1,65 @@
+import type { SimSesAccount } from "../../account/sim-ses-account.js";
+import type {
+  SimGetAccountCommandOutput,
+  SimSesAccountDetailsOutput,
+} from "./account.command.js";
+
+interface SimSesAccountReportInput {
+  readonly account: SimSesAccount;
+
+  /** How many messages this scope accepted in the last 24 hours. */
+  readonly sentLast24Hours: number;
+}
+
+/**
+ * What `GetAccount` reports about one simulated SES account.
+ *
+ * The quota figures are the real sandbox and production ones and nothing here
+ * enforces them: `SentLast24Hours` counts what was actually sent, and a send
+ * past the daily figure still succeeds.
+ *
+ * `EnforcementStatus` is always `HEALTHY` and `SendingEnabled` always true,
+ * because nothing here puts an account under enforcement or pauses its
+ * sending.
+ */
+export function simSesAccountReport(
+  input: SimSesAccountReportInput,
+): SimGetAccountCommandOutput {
+  const { account } = input;
+  const quota = account.sendQuota;
+
+  return {
+    $metadata: {},
+    DedicatedIpAutoWarmupEnabled: true,
+    EnforcementStatus: "HEALTHY",
+    ProductionAccessEnabled: account.productionAccessEnabled,
+    SendingEnabled: true,
+    SendQuota: {
+      Max24HourSend: quota.max24HourSend,
+      MaxSendRate: quota.maxSendRate,
+      SentLast24Hours: input.sentLast24Hours,
+    },
+    Details: accountDetails(account),
+  };
+}
+
+function accountDetails(
+  account: SimSesAccount,
+): SimSesAccountDetailsOutput | undefined {
+  const details = account.contactDetails;
+
+  if (details === undefined) {
+    return undefined;
+  }
+
+  return {
+    MailType: details.mailType,
+    WebsiteURL: details.websiteUrl,
+    ContactLanguage: details.contactLanguage,
+    UseCaseDescription: details.useCaseDescription,
+    AdditionalContactEmailAddresses: details.additionalContactEmailAddresses,
+    ReviewDetails: {
+      Status: account.productionAccessEnabled ? "GRANTED" : "PENDING",
+    },
+  };
+}

--- a/src/service/ses/command/authorize/sim-ses-authorizer.ts
+++ b/src/service/ses/command/authorize/sim-ses-authorizer.ts
@@ -1,0 +1,110 @@
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimAwsResolvedCaller } from "../../../aws/caller/sim-aws-caller-resolver.js";
+import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
+import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+import {
+  simSesAnyIdentityArn,
+  simSesIdentityArn,
+} from "../../identity/sim-ses-arn.js";
+
+/**
+ * The resource an action with no resource type authorizes against.
+ *
+ * Real SES gives `ses:GetAccount` and `ses:PutAccountDetails` no resource type
+ * at all, so IAM evaluates them against `*` and only a policy whose Resource
+ * is `*` allows them. A policy naming an identity ARN allows neither, here as
+ * on AWS.
+ */
+const noResource = "*";
+
+interface SimSesAuthorizerProperties {
+  readonly iam: SimIamInterServiceAuthZ;
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+}
+
+/**
+ * Applies simulated IAM authorization to SES requests.
+ *
+ * An SES operation on one identity authorizes against that identity's ARN,
+ * which is the form SES policies are written in: allowing `ses:SendEmail` on
+ * `arn:aws:ses:us-east-1:111111111111:identity/example.com` lets a caller send
+ * from any address at that domain, and lets it send from nothing else.
+ *
+ * A send authorizes against the identity being sent *from*. Recipients never
+ * enter into it, which is worth knowing when a policy looks like it should
+ * cover a send and does not.
+ */
+export class SimSesAuthorizer {
+  readonly #iam: SimIamInterServiceAuthZ;
+  readonly #accountRegionScope: SimAwsAccountRegionScope;
+
+  constructor(properties: SimSesAuthorizerProperties) {
+    this.#iam = properties.iam;
+    this.#accountRegionScope = properties.accountRegionScope;
+  }
+
+  /**
+   * Ensure the caller may perform an action on one email identity.
+   *
+   * The identity need not exist. Real IAM evaluates a request before the
+   * service handles it, so a caller with no permission is refused whether or
+   * not the identity is there, and CreateEmailIdentity authorizes against the
+   * ARN the identity is about to have.
+   */
+  authorizeIdentity(
+    action: string,
+    emailIdentity: string,
+    caller?: SimAwsCaller,
+  ): SimAwsResolvedCaller {
+    return this.authorizeResource(
+      action,
+      simSesIdentityArn(this.#accountRegionScope, emailIdentity),
+      caller,
+    );
+  }
+
+  /**
+   * Ensure the caller may perform an action reaching every identity in this
+   * account and region, such as listing them.
+   */
+  authorizeAnyIdentity(
+    action: string,
+    caller?: SimAwsCaller,
+  ): SimAwsResolvedCaller {
+    return this.authorizeResource(
+      action,
+      simSesAnyIdentityArn(this.#accountRegionScope),
+      caller,
+    );
+  }
+
+  /**
+   * Ensure the caller may perform an account-wide action, which real SES gives
+   * no resource type.
+   */
+  authorizeAccount(
+    action: string,
+    caller?: SimAwsCaller,
+  ): SimAwsResolvedCaller {
+    return this.authorizeResource(action, noResource, caller);
+  }
+
+  private authorizeResource(
+    action: string,
+    resource: string,
+    caller: SimAwsCaller | undefined,
+  ): SimAwsResolvedCaller {
+    const decision = this.#iam.authorize({ action, resource, caller });
+
+    if (decision.isDenied) {
+      throw new SimIamAccessDenied({
+        principal: decision.caller.principal,
+        action,
+        resource,
+      });
+    }
+
+    return decision.caller;
+  }
+}

--- a/src/service/ses/command/authorize/sim-ses-authorizer.ts
+++ b/src/service/ses/command/authorize/sim-ses-authorizer.ts
@@ -3,18 +3,16 @@ import type { SimAwsResolvedCaller } from "../../../aws/caller/sim-aws-caller-re
 import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
 import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
 import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
-import {
-  simSesAnyIdentityArn,
-  simSesIdentityArn,
-} from "../../identity/sim-ses-arn.js";
+import { simSesIdentityArn } from "../../identity/sim-ses-arn.js";
 
 /**
  * The resource an action with no resource type authorizes against.
  *
- * Real SES gives `ses:GetAccount` and `ses:PutAccountDetails` no resource type
- * at all, so IAM evaluates them against `*` and only a policy whose Resource
- * is `*` allows them. A policy naming an identity ARN allows neither, here as
- * on AWS.
+ * Real SES gives `ses:ListEmailIdentities`, `ses:GetAccount` and
+ * `ses:PutAccountDetails` no resource type at all, so IAM evaluates them
+ * against `*` and only a policy whose Resource is `*` allows them. A policy
+ * naming an identity ARN allows none of them, not even one written against
+ * every identity in the Account and Region, here as on AWS.
  */
 const noResource = "*";
 
@@ -65,25 +63,15 @@ export class SimSesAuthorizer {
   }
 
   /**
-   * Ensure the caller may perform an action reaching every identity in this
-   * account and region, such as listing them.
+   * Ensure the caller may perform an action real SES gives no resource type,
+   * such as listing identities or reading the account.
+   *
+   * The resource is `*`, which is the only thing such an action can be granted
+   * on. Writing the listing's resource as every identity in the Account and
+   * Region would be the intuitive reading and the wrong one: a policy scoped
+   * that way allows no listing on AWS, and should allow none here.
    */
-  authorizeAnyIdentity(
-    action: string,
-    caller?: SimAwsCaller,
-  ): SimAwsResolvedCaller {
-    return this.authorizeResource(
-      action,
-      simSesAnyIdentityArn(this.#accountRegionScope),
-      caller,
-    );
-  }
-
-  /**
-   * Ensure the caller may perform an account-wide action, which real SES gives
-   * no resource type.
-   */
-  authorizeAccount(
+  authorizeNoResource(
     action: string,
     caller?: SimAwsCaller,
   ): SimAwsResolvedCaller {

--- a/src/service/ses/command/authorize/sim-ses-iam.iso.test.ts
+++ b/src/service/ses/command/authorize/sim-ses-iam.iso.test.ts
@@ -214,11 +214,12 @@ describe("SES IAM authorization", () => {
     assertInstanceOf(error, SimIamAccessDenied);
   });
 
-  it("needs the identity wildcard to list identities", async () => {
-    // Given a Role allowed to list, on every identity in the account.
+  it("needs a policy on every resource to list identities", async () => {
+    // Given a Role allowed to list on `*`, which is the only resource real SES
+    // gives that action.
     const simAws = await simAwsWithRole({
       Action: "ses:ListEmailIdentities",
-      Resource: `arn:aws:ses:us-east-1:${accountIdOneOnes}:identity/*`,
+      Resource: "*",
     });
     const ses = simAws.sesV2();
 
@@ -230,16 +231,14 @@ describe("SES IAM authorization", () => {
       asRole,
     );
 
-    // Then the listing is allowed. A listing reaches every identity, so that
-    // is the resource it authorizes against.
     assertArrayLength(listed.EmailIdentities ?? [], 1);
   });
 
-  it("refuses a listing to a policy naming one identity", async () => {
-    // Given a Role allowed to list, but only on one identity.
+  it("refuses a listing to a policy naming identity ARNs", async () => {
+    // Given a Role allowed to list, on every identity in the Account.
     const simAws = await simAwsWithRole({
       Action: "ses:ListEmailIdentities",
-      Resource: `arn:aws:ses:us-east-1:${accountIdOneOnes}:identity/example.com`,
+      Resource: `arn:aws:ses:us-east-1:${accountIdOneOnes}:identity/*`,
     });
 
     // When it lists them.
@@ -249,8 +248,9 @@ describe("SES IAM authorization", () => {
         .listEmailIdentities(new ListEmailIdentitiesCommand({}), asRole);
     });
 
-    // Then it is refused, as it is on AWS: the request reaches more than the
-    // policy allows.
+    // Then it is refused. Real SES gives ListEmailIdentities no resource type,
+    // so a policy scoped to identity ARNs allows no listing however broadly
+    // those ARNs are written, which is the intuitive reading and the wrong one.
     assertInstanceOf(error, SimIamAccessDenied);
   });
 

--- a/src/service/ses/command/authorize/sim-ses-iam.iso.test.ts
+++ b/src/service/ses/command/authorize/sim-ses-iam.iso.test.ts
@@ -1,0 +1,289 @@
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import {
+  CreateEmailIdentityCommand,
+  GetAccountCommand,
+  ListEmailIdentitiesCommand,
+  SendEmailCommand,
+  type SendEmailCommandInput,
+} from "@aws-sdk/client-sesv2";
+import {
+  assertArrayLength,
+  assertFalse,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+import { simIamPolicyDocumentFactory } from "../../../iam/policy/sim-iam-policy-document.factory.js";
+
+const accountIdOneOnes = "111111111111";
+
+/**
+ * A simulation with one Role, and whatever policy statement the test wants it
+ * to have.
+ */
+async function simAwsWithRole(policyStatement?: object): Promise<SimAws> {
+  const simAws = new SimAws({ defaultAccountId: accountIdOneOnes });
+
+  await simAws.iam().createRole(
+    new CreateRoleCommand({
+      RoleName: "SignUpFunctionRole",
+      AssumeRolePolicyDocument: simIamPolicyDocumentFactory.make({
+        Statement: {
+          Principal: { Service: "lambda.amazonaws.com" },
+          Action: "sts:AssumeRole",
+        },
+      }),
+    }),
+  );
+
+  if (policyStatement !== undefined) {
+    await simAws.iam().putRolePolicy(
+      new PutRolePolicyCommand({
+        RoleName: "SignUpFunctionRole",
+        PolicyName: "SendWelcomeEmail",
+        PolicyDocument: simIamPolicyDocumentFactory.make({
+          Statement: policyStatement,
+        }),
+      }),
+    );
+  }
+
+  return simAws;
+}
+
+/** The request options that make a call arrive as the Role. */
+const asRole = {
+  caller: {
+    kind: "arn",
+    arn: `arn:aws:iam::${accountIdOneOnes}:role/SignUpFunctionRole`,
+  },
+} as const;
+
+const welcome = {
+  FromEmailAddress: "hello@example.com",
+  Destination: { ToAddresses: ["someone@example.org"] },
+  Content: {
+    Simple: {
+      Subject: { Data: "Welcome" },
+      Body: { Text: { Data: "Hi there" } },
+    },
+  },
+} satisfies SendEmailCommandInput;
+
+describe("SES IAM authorization", () => {
+  it("allows a send from an identity the policy names", async () => {
+    // Given a Role allowed to send from one domain.
+    const simAws = await simAwsWithRole({
+      Action: "ses:SendEmail",
+      Resource: `arn:aws:ses:us-east-1:${accountIdOneOnes}:identity/example.com`,
+    });
+    const ses = simAws.sesV2();
+
+    ses.verifyIdentity("example.com");
+    ses.verifyIdentity("example.org");
+
+    // When it sends from an address at that domain.
+    await ses.sendEmail(new SendEmailCommand(welcome), asRole);
+
+    // Then the message was accepted.
+    assertArrayLength(ses.sentEmails(), 1);
+  });
+
+  it("refuses a send from an identity the policy does not name", async () => {
+    // Given a Role allowed to send from one domain only.
+    const simAws = await simAwsWithRole({
+      Action: "ses:SendEmail",
+      Resource: `arn:aws:ses:us-east-1:${accountIdOneOnes}:identity/example.com`,
+    });
+    const ses = simAws.sesV2();
+
+    ses.verifyIdentity("example.net");
+    ses.verifyIdentity("example.org");
+
+    // When it sends from an address at another one.
+    const error = await assertThrowsErrorAsync(async () => {
+      await ses.sendEmail(
+        new SendEmailCommand({
+          ...welcome,
+          FromEmailAddress: "hello@example.net",
+        }),
+        asRole,
+      );
+    });
+
+    // Then IAM refuses it, naming the identity ARN it authorized against.
+    assertInstanceOf(error, SimIamAccessDenied);
+    assertStringIncludes(error.message, "ses:SendEmail");
+    assertArrayLength(ses.sentEmails(), 0);
+  });
+
+  it("prefers the address identity over the domain one", async () => {
+    // Given a Role allowed to send from a whole domain, where the address
+    // being sent from is also an identity in its own right.
+    const simAws = await simAwsWithRole({
+      Action: "ses:SendEmail",
+      Resource: `arn:aws:ses:us-east-1:${accountIdOneOnes}:identity/example.com`,
+    });
+    const ses = simAws.sesV2();
+
+    ses.verifyIdentity("example.com");
+    ses.verifyIdentity("hello@example.com");
+    ses.verifyIdentity("example.org");
+
+    // When it sends from that address.
+    const error = await assertThrowsErrorAsync(async () => {
+      await ses.sendEmail(new SendEmailCommand(welcome), asRole);
+    });
+
+    // Then the more specific identity is what the request authorized against,
+    // which the domain policy does not cover.
+    assertInstanceOf(error, SimIamAccessDenied);
+    assertStringIncludes(error.message, "identity/hello@example.com");
+  });
+
+  it("authorizes a send against the sender, not the recipients", async () => {
+    // Given a Role allowed to send from one address.
+    const simAws = await simAwsWithRole({
+      Action: "ses:SendEmail",
+      Resource: `arn:aws:ses:us-east-1:${accountIdOneOnes}:identity/hello@example.com`,
+    });
+    const ses = simAws.sesV2();
+
+    ses.verifyIdentity("hello@example.com");
+    ses.verifyIdentity("example.org");
+
+    // When it sends to an address its policy says nothing about.
+    await ses.sendEmail(new SendEmailCommand(welcome), asRole);
+
+    // Then the send is allowed: recipients never enter into the authorization,
+    // which is worth knowing when a policy looks like it should cover a send.
+    assertArrayLength(ses.sentEmails(), 1);
+  });
+
+  it("refuses a send from a Role with no policy at all", async () => {
+    // Given a Role with no permissions.
+    const simAws = await simAwsWithRole();
+    const ses = simAws.sesV2();
+
+    ses.verifyIdentity("example.com");
+    ses.verifyIdentity("example.org");
+
+    // When it sends.
+    const error = await assertThrowsErrorAsync(async () => {
+      await ses.sendEmail(new SendEmailCommand(welcome), asRole);
+    });
+
+    assertInstanceOf(error, SimIamAccessDenied);
+  });
+
+  it("refuses a send before the identity check", async () => {
+    // Given a Role with no permissions, and nothing verified either.
+    const simAws = await simAwsWithRole();
+
+    // When it sends.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.sesV2().sendEmail(new SendEmailCommand(welcome), asRole);
+    });
+
+    // Then IAM is what refused it. Real IAM decides a request before the
+    // service handles it, so an unverified identity is beside the point.
+    assertInstanceOf(error, SimIamAccessDenied);
+  });
+
+  it("refuses creating an identity the policy does not name", async () => {
+    // Given a Role allowed to create one identity.
+    const simAws = await simAwsWithRole({
+      Action: "ses:CreateEmailIdentity",
+      Resource: `arn:aws:ses:us-east-1:${accountIdOneOnes}:identity/example.com`,
+    });
+
+    // When it creates another.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws
+        .sesV2()
+        .createEmailIdentity(
+          new CreateEmailIdentityCommand({ EmailIdentity: "example.net" }),
+          asRole,
+        );
+    });
+
+    assertInstanceOf(error, SimIamAccessDenied);
+  });
+
+  it("needs the identity wildcard to list identities", async () => {
+    // Given a Role allowed to list, on every identity in the account.
+    const simAws = await simAwsWithRole({
+      Action: "ses:ListEmailIdentities",
+      Resource: `arn:aws:ses:us-east-1:${accountIdOneOnes}:identity/*`,
+    });
+    const ses = simAws.sesV2();
+
+    ses.verifyIdentity("example.com");
+
+    // When it lists them.
+    const listed = await ses.listEmailIdentities(
+      new ListEmailIdentitiesCommand({}),
+      asRole,
+    );
+
+    // Then the listing is allowed. A listing reaches every identity, so that
+    // is the resource it authorizes against.
+    assertArrayLength(listed.EmailIdentities ?? [], 1);
+  });
+
+  it("refuses a listing to a policy naming one identity", async () => {
+    // Given a Role allowed to list, but only on one identity.
+    const simAws = await simAwsWithRole({
+      Action: "ses:ListEmailIdentities",
+      Resource: `arn:aws:ses:us-east-1:${accountIdOneOnes}:identity/example.com`,
+    });
+
+    // When it lists them.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws
+        .sesV2()
+        .listEmailIdentities(new ListEmailIdentitiesCommand({}), asRole);
+    });
+
+    // Then it is refused, as it is on AWS: the request reaches more than the
+    // policy allows.
+    assertInstanceOf(error, SimIamAccessDenied);
+  });
+
+  it("needs a policy on every resource to read the account", async () => {
+    // Given a Role allowed to read the account on `*`, which is the only
+    // resource real SES gives that action.
+    const simAws = await simAwsWithRole({
+      Action: "ses:GetAccount",
+      Resource: "*",
+    });
+
+    // When it reads the account.
+    const account = await simAws
+      .sesV2()
+      .getAccount(new GetAccountCommand({}), asRole);
+
+    assertFalse(account.ProductionAccessEnabled);
+  });
+
+  it("refuses reading the account to a policy naming an identity", async () => {
+    // Given a Role whose policy names an identity ARN.
+    const simAws = await simAwsWithRole({
+      Action: "ses:GetAccount",
+      Resource: `arn:aws:ses:us-east-1:${accountIdOneOnes}:identity/example.com`,
+    });
+
+    // When it reads the account.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.sesV2().getAccount(new GetAccountCommand({}), asRole);
+    });
+
+    // Then it is refused: GetAccount has no resource type, so only a policy
+    // written against `*` allows it.
+    assertInstanceOf(error, SimIamAccessDenied);
+  });
+});

--- a/src/service/ses/command/identity/identity.command.ts
+++ b/src/service/ses/command/identity/identity.command.ts
@@ -1,0 +1,102 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+
+/**
+ * The verification states real SES reports, of which this simulator produces
+ * two: an identity is pending until something says it is verified.
+ */
+export type SimSesVerificationStatusValue =
+  | "FAILED"
+  | "NOT_STARTED"
+  | "PENDING"
+  | "SUCCESS"
+  | "TEMPORARY_FAILURE";
+
+/**
+ * Minimal structural sim SES v2 CreateEmailIdentity command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/sesv2/command/CreateEmailIdentityCommand/
+ */
+export interface SimCreateEmailIdentityCommand {
+  readonly input: SimCreateEmailIdentityCommandInput;
+}
+
+export interface SimCreateEmailIdentityCommandInput {
+  readonly EmailIdentity?: string | undefined;
+  readonly Tags?: readonly unknown[] | undefined;
+  readonly DkimSigningAttributes?: unknown;
+  readonly ConfigurationSetName?: string | undefined;
+}
+
+export interface SimCreateEmailIdentityCommandOutput {
+  readonly IdentityType?: string | undefined;
+  readonly VerifiedForSendingStatus?: boolean | undefined;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim SES v2 GetEmailIdentity command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/sesv2/command/GetEmailIdentityCommand/
+ */
+export interface SimGetEmailIdentityCommand {
+  readonly input: SimGetEmailIdentityCommandInput;
+}
+
+export interface SimGetEmailIdentityCommandInput {
+  readonly EmailIdentity?: string | undefined;
+}
+
+export interface SimGetEmailIdentityCommandOutput {
+  readonly IdentityType?: string | undefined;
+  readonly VerifiedForSendingStatus?: boolean | undefined;
+  readonly VerificationStatus?: SimSesVerificationStatusValue | undefined;
+  readonly FeedbackForwardingStatus?: boolean | undefined;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim SES v2 DeleteEmailIdentity command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/sesv2/command/DeleteEmailIdentityCommand/
+ */
+export interface SimDeleteEmailIdentityCommand {
+  readonly input: SimDeleteEmailIdentityCommandInput;
+}
+
+export interface SimDeleteEmailIdentityCommandInput {
+  readonly EmailIdentity?: string | undefined;
+}
+
+export interface SimDeleteEmailIdentityCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim SES v2 ListEmailIdentities command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/sesv2/command/ListEmailIdentitiesCommand/
+ */
+export interface SimListEmailIdentitiesCommand {
+  readonly input: SimListEmailIdentitiesCommandInput;
+}
+
+export interface SimListEmailIdentitiesCommandInput {
+  readonly PageSize?: number | undefined;
+  readonly NextToken?: string | undefined;
+}
+
+export interface SimListEmailIdentitiesCommandOutput {
+  readonly EmailIdentities?: readonly SimSesIdentityInfo[] | undefined;
+  readonly NextToken?: string | undefined;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * What ListEmailIdentities reports about one identity.
+ */
+export interface SimSesIdentityInfo {
+  readonly IdentityType: string;
+  readonly IdentityName: string;
+  readonly SendingEnabled: boolean;
+  readonly VerificationStatus: SimSesVerificationStatusValue;
+}

--- a/src/service/ses/command/identity/sim-ses-identity-commands.ts
+++ b/src/service/ses/command/identity/sim-ses-identity-commands.ts
@@ -1,0 +1,164 @@
+import type { SimClock } from "../../../../util/clock/sim-clock.js";
+import type { SimSesIdentityStore } from "../../identity/sim-ses-identity-store.js";
+import { requiredSimSesIdentityName } from "../../identity/sim-ses-identity-name.js";
+import type { SimSesIdentity } from "../../identity/sim-ses-identity.js";
+import type { SimSesAuthorizer } from "../authorize/sim-ses-authorizer.js";
+import { SimSesPage } from "../sim-ses-page.js";
+import type { SimSesRequestOptions } from "../sim-ses-request-options.js";
+import type {
+  SimCreateEmailIdentityCommand,
+  SimCreateEmailIdentityCommandOutput,
+  SimDeleteEmailIdentityCommand,
+  SimDeleteEmailIdentityCommandOutput,
+  SimGetEmailIdentityCommand,
+  SimGetEmailIdentityCommandOutput,
+  SimListEmailIdentitiesCommand,
+  SimListEmailIdentitiesCommandOutput,
+  SimSesIdentityInfo,
+} from "./identity.command.js";
+import { refuseUnsimulatedIdentityInput } from "./sim-ses-unsimulated-identity-input.js";
+
+interface SimSesIdentityCommandsProperties {
+  readonly identities: SimSesIdentityStore;
+  readonly authorizer: SimSesAuthorizer;
+  readonly clock: SimClock;
+}
+
+/**
+ * The commands that make, read, list and remove email identities.
+ *
+ * A new identity is never verified. Real SES starts one pending and waits on
+ * an emailed link or a DNS record, so a test that creates an identity and
+ * sends from it straight away should see the same refusal an account gives,
+ * rather than a simulator being helpful.
+ */
+export class SimSesIdentityCommands {
+  readonly #identities: SimSesIdentityStore;
+  readonly #authorizer: SimSesAuthorizer;
+  readonly #clock: SimClock;
+
+  constructor(properties: SimSesIdentityCommandsProperties) {
+    this.#identities = properties.identities;
+    this.#authorizer = properties.authorizer;
+    this.#clock = properties.clock;
+  }
+
+  /**
+   * Begin verifying an email address or a domain.
+   */
+  createEmailIdentity(
+    command: SimCreateEmailIdentityCommand,
+    options?: SimSesRequestOptions,
+  ): SimCreateEmailIdentityCommandOutput {
+    const emailIdentity = requiredSimSesIdentityName(
+      command.input.EmailIdentity,
+    );
+
+    refuseUnsimulatedIdentityInput(command.input);
+    this.#authorizer.authorizeIdentity(
+      "ses:CreateEmailIdentity",
+      emailIdentity,
+      options?.caller,
+    );
+
+    const identity = this.#identities.create(emailIdentity, this.#clock.now());
+
+    return {
+      $metadata: {},
+      IdentityType: identity.identityType,
+      VerifiedForSendingStatus: identity.isVerified,
+    };
+  }
+
+  /**
+   * Read one identity and how far its verification has got.
+   */
+  getEmailIdentity(
+    command: SimGetEmailIdentityCommand,
+    options?: SimSesRequestOptions,
+  ): SimGetEmailIdentityCommandOutput {
+    const emailIdentity = requiredSimSesIdentityName(
+      command.input.EmailIdentity,
+    );
+
+    this.#authorizer.authorizeIdentity(
+      "ses:GetEmailIdentity",
+      emailIdentity,
+      options?.caller,
+    );
+
+    const identity = this.#identities.require(emailIdentity);
+
+    return {
+      $metadata: {},
+      IdentityType: identity.identityType,
+      VerifiedForSendingStatus: identity.isVerified,
+      VerificationStatus: identity.verificationStatus,
+      FeedbackForwardingStatus: true,
+    };
+  }
+
+  /**
+   * List the identities in this scope, in the order they were created.
+   *
+   * Real SES gives this action no resource-level permission, so it authorizes
+   * against every identity in the account and region rather than against each
+   * one it reports.
+   */
+  listEmailIdentities(
+    command: SimListEmailIdentitiesCommand,
+    options?: SimSesRequestOptions,
+  ): SimListEmailIdentitiesCommandOutput {
+    this.#authorizer.authorizeAnyIdentity(
+      "ses:ListEmailIdentities",
+      options?.caller,
+    );
+
+    const page = new SimSesPage({
+      listed: this.#identities.all,
+      pageSize: command.input.PageSize,
+      nextToken: command.input.NextToken,
+    });
+
+    return {
+      $metadata: {},
+      EmailIdentities: page.items.map((identity) => identityInfo(identity)),
+      NextToken: page.nextToken,
+    };
+  }
+
+  /**
+   * Remove an identity, refusing one that is not there.
+   */
+  deleteEmailIdentity(
+    command: SimDeleteEmailIdentityCommand,
+    options?: SimSesRequestOptions,
+  ): SimDeleteEmailIdentityCommandOutput {
+    const emailIdentity = requiredSimSesIdentityName(
+      command.input.EmailIdentity,
+    );
+
+    this.#authorizer.authorizeIdentity(
+      "ses:DeleteEmailIdentity",
+      emailIdentity,
+      options?.caller,
+    );
+
+    this.#identities.require(emailIdentity);
+    this.#identities.delete(emailIdentity);
+
+    return { $metadata: {} };
+  }
+}
+
+/**
+ * What ListEmailIdentities reports about one identity.
+ */
+function identityInfo(identity: SimSesIdentity): SimSesIdentityInfo {
+  return {
+    IdentityType: identity.identityType,
+    IdentityName: identity.emailIdentity,
+    SendingEnabled: identity.isVerified,
+    VerificationStatus: identity.verificationStatus,
+  };
+}

--- a/src/service/ses/command/identity/sim-ses-identity-commands.ts
+++ b/src/service/ses/command/identity/sim-ses-identity-commands.ts
@@ -101,15 +101,15 @@ export class SimSesIdentityCommands {
   /**
    * List the identities in this scope, in the order they were created.
    *
-   * Real SES gives this action no resource-level permission, so it authorizes
-   * against every identity in the account and region rather than against each
-   * one it reports.
+   * Real SES gives this action no resource type at all, so it authorizes
+   * against `*`: a policy scoped to identity ARNs allows no listing, however
+   * broadly those ARNs are written.
    */
   listEmailIdentities(
     command: SimListEmailIdentitiesCommand,
     options?: SimSesRequestOptions,
   ): SimListEmailIdentitiesCommandOutput {
-    this.#authorizer.authorizeAnyIdentity(
+    this.#authorizer.authorizeNoResource(
       "ses:ListEmailIdentities",
       options?.caller,
     );

--- a/src/service/ses/command/identity/sim-ses-unsimulated-identity-input.ts
+++ b/src/service/ses/command/identity/sim-ses-unsimulated-identity-input.ts
@@ -1,0 +1,37 @@
+import { SimSesUnsupportedOperationException } from "../../error/sim-ses.error.js";
+import type { SimCreateEmailIdentityCommandInput } from "./identity.command.js";
+
+/**
+ * Refuse the CreateEmailIdentity inputs this simulation does not model.
+ *
+ * Each changes what the identity does on real SES, so accepting one and
+ * dropping it would let a request succeed here and behave differently in an
+ * account. DKIM signing attributes are the clearest case: an identity created
+ * with Bring Your Own DKIM would look configured to the request that made it
+ * and unconfigured to everything else.
+ */
+export function refuseUnsimulatedIdentityInput(
+  input: SimCreateEmailIdentityCommandInput,
+): void {
+  if (input.Tags !== undefined) {
+    throw new SimSesUnsupportedOperationException(
+      "Email identity tags are not simulated, so CreateEmailIdentity " +
+        "refuses them rather than dropping them",
+    );
+  }
+
+  if (input.DkimSigningAttributes !== undefined) {
+    throw new SimSesUnsupportedOperationException(
+      "DKIM signing is not simulated, so CreateEmailIdentity refuses " +
+        "DkimSigningAttributes rather than reporting a signing configuration " +
+        "no message here is signed with",
+    );
+  }
+
+  if (input.ConfigurationSetName !== undefined) {
+    throw new SimSesUnsupportedOperationException(
+      "Configuration sets are not simulated, so CreateEmailIdentity refuses " +
+        "ConfigurationSetName rather than naming one that does nothing",
+    );
+  }
+}

--- a/src/service/ses/command/identity/sim-ses-unsimulated-identity-input.ts
+++ b/src/service/ses/command/identity/sim-ses-unsimulated-identity-input.ts
@@ -13,7 +13,7 @@ import type { SimCreateEmailIdentityCommandInput } from "./identity.command.js";
 export function refuseUnsimulatedIdentityInput(
   input: SimCreateEmailIdentityCommandInput,
 ): void {
-  if (input.Tags !== undefined) {
+  if (input.Tags !== undefined && input.Tags.length > 0) {
     throw new SimSesUnsupportedOperationException(
       "Email identity tags are not simulated, so CreateEmailIdentity " +
         "refuses them rather than dropping them",

--- a/src/service/ses/command/send/send.command.ts
+++ b/src/service/ses/command/send/send.command.ts
@@ -1,0 +1,75 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+
+/**
+ * One part of a message: its subject line, or one representation of its body.
+ */
+export interface SimSesContent {
+  readonly Data?: string | undefined;
+  readonly Charset?: string | undefined;
+}
+
+export interface SimSesBody {
+  readonly Text?: SimSesContent | undefined;
+  readonly Html?: SimSesContent | undefined;
+}
+
+export interface SimSesMessage {
+  readonly Subject?: SimSesContent | undefined;
+  readonly Body?: SimSesBody | undefined;
+  readonly Headers?: readonly unknown[] | undefined;
+  readonly Attachments?: readonly unknown[] | undefined;
+}
+
+export interface SimSesRawMessage {
+  readonly Data?: Uint8Array | string | undefined;
+}
+
+/**
+ * The template branch of a message, which this issue's scope does not render.
+ *
+ * It is typed here so a send carrying one can be told apart from a malformed
+ * request and refused with a message saying so.
+ */
+export interface SimSesTemplate {
+  readonly TemplateName?: string | undefined;
+  readonly TemplateArn?: string | undefined;
+  readonly TemplateData?: string | undefined;
+}
+
+export interface SimSesEmailContent {
+  readonly Simple?: SimSesMessage | undefined;
+  readonly Raw?: SimSesRawMessage | undefined;
+  readonly Template?: SimSesTemplate | undefined;
+}
+
+export interface SimSesDestination {
+  readonly ToAddresses?: readonly string[] | undefined;
+  readonly CcAddresses?: readonly string[] | undefined;
+  readonly BccAddresses?: readonly string[] | undefined;
+}
+
+/**
+ * Minimal structural sim SES v2 SendEmail command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/sesv2/command/SendEmailCommand/
+ */
+export interface SimSendEmailCommand {
+  readonly input: SimSendEmailCommandInput;
+}
+
+export interface SimSendEmailCommandInput {
+  readonly FromEmailAddress?: string | undefined;
+  readonly FromEmailAddressIdentityArn?: string | undefined;
+  readonly Destination?: SimSesDestination | undefined;
+  readonly ReplyToAddresses?: readonly string[] | undefined;
+  readonly FeedbackForwardingEmailAddress?: string | undefined;
+  readonly Content?: SimSesEmailContent | undefined;
+  readonly EmailTags?: readonly unknown[] | undefined;
+  readonly ConfigurationSetName?: string | undefined;
+  readonly ListManagementOptions?: unknown;
+}
+
+export interface SimSendEmailCommandOutput {
+  readonly MessageId?: string | undefined;
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/ses/command/send/sim-ses-send-email.ts
+++ b/src/service/ses/command/send/sim-ses-send-email.ts
@@ -1,0 +1,129 @@
+import { randomUUID } from "node:crypto";
+
+import type { SimClock } from "../../../../util/clock/sim-clock.js";
+import {
+  requiredSimSesFromAddress,
+  simSesBareAddress,
+} from "../../email/sim-ses-address.js";
+import { SimSesSentEmail } from "../../email/sim-ses-sent-email.js";
+import type { SimSesSentEmailDestination } from "../../email/sim-ses-sent-email.js";
+import type { SimSesSentEmailStore } from "../../email/sim-ses-sent-email-store.js";
+import { SimSesBadRequestException } from "../../error/sim-ses.error.js";
+import type { SimSesIdentityStore } from "../../identity/sim-ses-identity-store.js";
+import type { SimSesAuthorizer } from "../authorize/sim-ses-authorizer.js";
+import type { SimSesRequestOptions } from "../sim-ses-request-options.js";
+import type {
+  SimSendEmailCommand,
+  SimSendEmailCommandOutput,
+  SimSesDestination,
+} from "./send.command.js";
+import { readSimSesContent } from "./sim-ses-simple-content.js";
+import { refuseUnsimulatedSendInput } from "./sim-ses-unsimulated-send-input.js";
+import type { SimSesVerifiedIdentityCheck } from "./sim-ses-verified-identities.js";
+
+interface SimSesSendEmailProperties {
+  readonly identities: SimSesIdentityStore;
+  readonly sent: SimSesSentEmailStore;
+  readonly identityCheck: SimSesVerifiedIdentityCheck;
+  readonly authorizer: SimSesAuthorizer;
+  readonly clock: SimClock;
+}
+
+/**
+ * The SendEmail command.
+ *
+ * Nothing is delivered, so what this does is decide whether SES would have
+ * accepted the message and, if it would, keep what it would have sent. The
+ * order matters and follows real SES: IAM decides the request before the
+ * service looks at it, then the identity check, then the message is recorded.
+ * A caller with no permission is therefore refused whether or not its
+ * identities are verified.
+ */
+export class SimSesSendEmail {
+  readonly #identities: SimSesIdentityStore;
+  readonly #sent: SimSesSentEmailStore;
+  readonly #identityCheck: SimSesVerifiedIdentityCheck;
+  readonly #authorizer: SimSesAuthorizer;
+  readonly #clock: SimClock;
+
+  constructor(properties: SimSesSendEmailProperties) {
+    this.#identities = properties.identities;
+    this.#sent = properties.sent;
+    this.#identityCheck = properties.identityCheck;
+    this.#authorizer = properties.authorizer;
+    this.#clock = properties.clock;
+  }
+
+  /**
+   * Accept a message, or refuse it the way SES would.
+   */
+  handle(
+    command: SimSendEmailCommand,
+    options?: SimSesRequestOptions,
+  ): SimSendEmailCommandOutput {
+    const input = command.input;
+    const fromEmailAddress = requiredSimSesFromAddress(input.FromEmailAddress);
+
+    refuseUnsimulatedSendInput(input);
+
+    this.#authorizer.authorizeIdentity(
+      "ses:SendEmail",
+      this.#identities.covering(simSesBareAddress(fromEmailAddress)),
+      options?.caller,
+    );
+
+    const destination = readDestination(input.Destination);
+    const recipients = allRecipients(destination);
+
+    if (recipients.length === 0) {
+      throw new SimSesBadRequestException(
+        "1 validation error detected: Value at 'destination' failed to " +
+          "satisfy constraint: Member must have at least one recipient",
+      );
+    }
+
+    const content = readSimSesContent(input.Content);
+
+    this.#identityCheck.check({ fromEmailAddress, recipients });
+
+    const messageId = randomUUID();
+
+    this.#sent.add(
+      new SimSesSentEmail({
+        messageId,
+        fromEmailAddress,
+        destination,
+        replyToAddresses: [...(input.ReplyToAddresses ?? [])],
+        subject: content.subject,
+        body: content.body,
+        configurationSetName: input.ConfigurationSetName,
+        sentDate: this.#clock.now(),
+      }),
+    );
+
+    return { $metadata: {}, MessageId: messageId };
+  }
+}
+
+/**
+ * Who the message is addressed to, with the three lists kept apart.
+ */
+function readDestination(
+  destination: SimSesDestination | undefined,
+): SimSesSentEmailDestination {
+  return {
+    toAddresses: [...(destination?.ToAddresses ?? [])],
+    ccAddresses: [...(destination?.CcAddresses ?? [])],
+    bccAddresses: [...(destination?.BccAddresses ?? [])],
+  };
+}
+
+function allRecipients(
+  destination: SimSesSentEmailDestination,
+): readonly string[] {
+  return [
+    ...destination.toAddresses,
+    ...destination.ccAddresses,
+    ...destination.bccAddresses,
+  ];
+}

--- a/src/service/ses/command/send/sim-ses-simple-content.ts
+++ b/src/service/ses/command/send/sim-ses-simple-content.ts
@@ -1,0 +1,78 @@
+import {
+  SimSesBadRequestException,
+  SimSesUnsupportedOperationException,
+} from "../../error/sim-ses.error.js";
+import type { SimSesSentEmailBody } from "../../email/sim-ses-sent-email.js";
+import type { SimSesEmailContent, SimSesMessage } from "./send.command.js";
+
+/**
+ * What a message says, read out of the `Simple` content of a send.
+ */
+export interface SimSesReadContent {
+  readonly subject: string | undefined;
+  readonly body: SimSesSentEmailBody;
+}
+
+/**
+ * Read the content of a send, refusing the shapes this simulation does not
+ * model.
+ *
+ * Only `Simple` content is read. A raw MIME message would have to be parsed to
+ * say anything about its subject or body, and a template one needs templates,
+ * which are not here yet. Both are refused by name so a caller finds out which
+ * of the three branches it used rather than getting a recorded message with
+ * nothing in it.
+ */
+export function readSimSesContent(
+  content: SimSesEmailContent | undefined,
+): SimSesReadContent {
+  if (content === undefined) {
+    throw new SimSesBadRequestException(
+      "1 validation error detected: Value at 'content' failed to satisfy " +
+        "constraint: Member must not be null",
+    );
+  }
+
+  if (content.Raw !== undefined) {
+    throw new SimSesUnsupportedOperationException(
+      "Raw MIME content is not simulated, so SendEmail refuses Content.Raw " +
+        "rather than recording a message it has not read",
+    );
+  }
+
+  if (content.Template !== undefined) {
+    throw new SimSesUnsupportedOperationException(
+      "Email templates are not simulated yet, so SendEmail refuses " +
+        "Content.Template rather than recording a message it cannot render",
+    );
+  }
+
+  if (content.Simple === undefined) {
+    throw new SimSesBadRequestException(
+      "Content must specify one of Simple, Raw or Template.",
+    );
+  }
+
+  return readSimpleMessage(content.Simple);
+}
+
+function readSimpleMessage(message: SimSesMessage): SimSesReadContent {
+  if (message.Attachments !== undefined) {
+    throw new SimSesUnsupportedOperationException(
+      "Attachments are not simulated, so SendEmail refuses them rather than " +
+        "recording a message without them",
+    );
+  }
+
+  const text = message.Body?.Text?.Data;
+  const html = message.Body?.Html?.Data;
+
+  if (text === undefined && html === undefined) {
+    throw new SimSesBadRequestException(
+      "1 validation error detected: Value at 'content.simple.body' failed " +
+        "to satisfy constraint: Member must specify Text or Html",
+    );
+  }
+
+  return { subject: message.Subject?.Data, body: { text, html } };
+}

--- a/src/service/ses/command/send/sim-ses-simple-content.ts
+++ b/src/service/ses/command/send/sim-ses-simple-content.ts
@@ -9,13 +9,13 @@ import type { SimSesEmailContent, SimSesMessage } from "./send.command.js";
  * What a message says, read out of the `Simple` content of a send.
  */
 export interface SimSesReadContent {
-  readonly subject: string | undefined;
+  readonly subject: string;
   readonly body: SimSesSentEmailBody;
 }
 
 /**
  * Read the content of a send, refusing the shapes this simulation does not
- * model.
+ * model and the ones real SES would not accept.
  *
  * Only `Simple` content is read. A raw MIME message would have to be parsed to
  * say anything about its subject or body, and a template one needs templates,
@@ -64,6 +64,15 @@ function readSimpleMessage(message: SimSesMessage): SimSesReadContent {
     );
   }
 
+  const subject = message.Subject?.Data;
+
+  if (subject === undefined) {
+    throw new SimSesBadRequestException(
+      "1 validation error detected: Value at 'content.simple.subject' " +
+        "failed to satisfy constraint: Member must not be null",
+    );
+  }
+
   const text = message.Body?.Text?.Data;
   const html = message.Body?.Html?.Data;
 
@@ -74,5 +83,5 @@ function readSimpleMessage(message: SimSesMessage): SimSesReadContent {
     );
   }
 
-  return { subject: message.Subject?.Data, body: { text, html } };
+  return { subject, body: { text, html } };
 }

--- a/src/service/ses/command/send/sim-ses-unsimulated-send-input.ts
+++ b/src/service/ses/command/send/sim-ses-unsimulated-send-input.ts
@@ -28,7 +28,7 @@ export function refuseUnsimulatedSendInput(
     );
   }
 
-  if (input.EmailTags !== undefined) {
+  if (input.EmailTags !== undefined && input.EmailTags.length > 0) {
     throw new SimSesUnsupportedOperationException(
       "Message tags are not simulated, so SendEmail refuses EmailTags " +
         "rather than dropping the dimensions they would be reported under",

--- a/src/service/ses/command/send/sim-ses-unsimulated-send-input.ts
+++ b/src/service/ses/command/send/sim-ses-unsimulated-send-input.ts
@@ -1,0 +1,37 @@
+import { SimSesUnsupportedOperationException } from "../../error/sim-ses.error.js";
+import type { SimSendEmailCommandInput } from "./send.command.js";
+
+/**
+ * Refuse the SendEmail inputs this simulation does not model.
+ *
+ * A configuration set is the exception: it names something this simulator does
+ * not have, but naming it changes nothing about the message, and a recorded
+ * send keeps the name so a test can still assert the right one was used. The
+ * rest change where a message goes or what it reports, so accepting one and
+ * dropping it would let a send behave differently in an account.
+ */
+export function refuseUnsimulatedSendInput(
+  input: SimSendEmailCommandInput,
+): void {
+  if (input.FromEmailAddressIdentityArn !== undefined) {
+    throw new SimSesUnsupportedOperationException(
+      "Sending authorization is not simulated, so SendEmail refuses " +
+        "FromEmailAddressIdentityArn rather than sending as an identity " +
+        "whose policy it has not read",
+    );
+  }
+
+  if (input.ListManagementOptions !== undefined) {
+    throw new SimSesUnsupportedOperationException(
+      "Contact lists are not simulated, so SendEmail refuses " +
+        "ListManagementOptions rather than sending to a list it cannot read",
+    );
+  }
+
+  if (input.EmailTags !== undefined) {
+    throw new SimSesUnsupportedOperationException(
+      "Message tags are not simulated, so SendEmail refuses EmailTags " +
+        "rather than dropping the dimensions they would be reported under",
+    );
+  }
+}

--- a/src/service/ses/command/send/sim-ses-verified-identities.ts
+++ b/src/service/ses/command/send/sim-ses-verified-identities.ts
@@ -1,0 +1,72 @@
+import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
+import type { SimSesAccount } from "../../account/sim-ses-account.js";
+import { simSesBareAddress } from "../../email/sim-ses-address.js";
+import { SimSesMessageRejected } from "../../error/sim-ses.error.js";
+import type { SimSesIdentityStore } from "../../identity/sim-ses-identity-store.js";
+
+interface SimSesVerifiedIdentityCheckProperties {
+  readonly identities: SimSesIdentityStore;
+  readonly account: SimSesAccount;
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+}
+
+interface SimSesCheckedSend {
+  readonly fromEmailAddress: string;
+  readonly recipients: readonly string[];
+}
+
+/**
+ * The identity check every send goes through.
+ *
+ * Two rules apply, and which of them apply depends on the account. The sender
+ * is always checked, in the sandbox and out of it: SES will not send from an
+ * address nobody has proved they own. Recipients are checked only in the
+ * sandbox, and that is the rule the sandbox is really for, since it is what
+ * stops a new account mailing the world.
+ *
+ * Failures are gathered rather than reported one at a time, because real SES
+ * names every identity that failed in a single message and a caller reading
+ * that message wants the whole list.
+ */
+export class SimSesVerifiedIdentityCheck {
+  readonly #identities: SimSesIdentityStore;
+  readonly #account: SimSesAccount;
+  readonly #accountRegionScope: SimAwsAccountRegionScope;
+
+  constructor(properties: SimSesVerifiedIdentityCheckProperties) {
+    this.#identities = properties.identities;
+    this.#account = properties.account;
+    this.#accountRegionScope = properties.accountRegionScope;
+  }
+
+  /**
+   * Refuse a send whose sender, or whose recipients in the sandbox, are not
+   * verified.
+   */
+  check(send: SimSesCheckedSend): void {
+    const checked = this.#account.isInSandbox
+      ? [send.fromEmailAddress, ...send.recipients]
+      : [send.fromEmailAddress];
+
+    const failed = checked
+      .map((address) => simSesBareAddress(address))
+      .filter((address) => !this.#identities.isAddressVerified(address));
+
+    if (failed.length === 0) {
+      return;
+    }
+
+    throw new SimSesMessageRejected(
+      `Email address is not verified. The following identities failed the ` +
+        `check in region ${this.#reportedRegion}: ${[...new Set(failed)].join(", ")}`,
+    );
+  }
+
+  /**
+   * How SES writes the region into that message: upper case, as in
+   * `US-EAST-1`.
+   */
+  get #reportedRegion(): string {
+    return this.#accountRegionScope.regionName.toUpperCase();
+  }
+}

--- a/src/service/ses/command/sim-ses-command.types.ts
+++ b/src/service/ses/command/sim-ses-command.types.ts
@@ -1,0 +1,40 @@
+/**
+ * The sim SES v2 Command types, gathered for the service facade.
+ */
+export type {
+  SimCreateEmailIdentityCommand,
+  SimCreateEmailIdentityCommandInput,
+  SimCreateEmailIdentityCommandOutput,
+  SimDeleteEmailIdentityCommand,
+  SimDeleteEmailIdentityCommandInput,
+  SimDeleteEmailIdentityCommandOutput,
+  SimGetEmailIdentityCommand,
+  SimGetEmailIdentityCommandInput,
+  SimGetEmailIdentityCommandOutput,
+  SimListEmailIdentitiesCommand,
+  SimListEmailIdentitiesCommandInput,
+  SimListEmailIdentitiesCommandOutput,
+  SimSesIdentityInfo,
+  SimSesVerificationStatusValue,
+} from "./identity/identity.command.js";
+export type {
+  SimSendEmailCommand,
+  SimSendEmailCommandInput,
+  SimSendEmailCommandOutput,
+  SimSesBody,
+  SimSesContent,
+  SimSesDestination,
+  SimSesEmailContent,
+  SimSesMessage,
+  SimSesRawMessage,
+  SimSesTemplate,
+} from "./send/send.command.js";
+export type {
+  SimGetAccountCommand,
+  SimGetAccountCommandOutput,
+  SimPutAccountDetailsCommand,
+  SimPutAccountDetailsCommandInput,
+  SimPutAccountDetailsCommandOutput,
+  SimSesAccountDetailsOutput,
+  SimSesSendQuotaDetail,
+} from "./account/account.command.js";

--- a/src/service/ses/command/sim-ses-page.ts
+++ b/src/service/ses/command/sim-ses-page.ts
@@ -1,0 +1,78 @@
+import { SimSesBadRequestException } from "../error/sim-ses.error.js";
+
+/**
+ * The largest page `ListEmailIdentities` will hand back.
+ */
+const maximumPageSize = 1000;
+
+interface SimSesPageProperties<T> {
+  /** Everything the request selected, before paging. */
+  readonly listed: readonly T[];
+
+  readonly pageSize?: number | undefined;
+  readonly nextToken?: string | undefined;
+}
+
+/**
+ * One page of an SES listing, and the token that reaches the next one.
+ *
+ * The token is an offset into what the request selected. That is only
+ * meaningful against the same selection, so a token issued elsewhere is
+ * refused rather than quietly starting again from the beginning.
+ */
+export class SimSesPage<T> {
+  readonly items: readonly T[];
+  readonly nextToken: string | undefined;
+
+  constructor(properties: SimSesPageProperties<T>) {
+    const { listed } = properties;
+    const pageSize = requiredPageSize(properties.pageSize);
+    const startIndex = pageStartIndex(properties.nextToken, listed.length);
+    const nextIndex = startIndex + pageSize;
+
+    this.items = listed.slice(startIndex, nextIndex);
+    this.nextToken = nextIndex >= listed.length ? undefined : String(nextIndex);
+  }
+}
+
+function requiredPageSize(requested: number | undefined): number {
+  const pageSize = requested ?? maximumPageSize;
+
+  if (
+    !Number.isSafeInteger(pageSize) ||
+    pageSize < 1 ||
+    pageSize > maximumPageSize
+  ) {
+    throw new SimSesBadRequestException(
+      `1 validation error detected: Value '${String(requested)}' at ` +
+        `'pageSize' failed to satisfy constraint: Member must be between 1 ` +
+        `and ${maximumPageSize}`,
+    );
+  }
+
+  return pageSize;
+}
+
+function pageStartIndex(
+  nextToken: string | undefined,
+  listedCount: number,
+): number {
+  if (nextToken === undefined) {
+    return 0;
+  }
+
+  const startIndex = Number(nextToken);
+
+  if (
+    !Number.isSafeInteger(startIndex) ||
+    startIndex < 0 ||
+    startIndex >= listedCount ||
+    String(startIndex) !== nextToken
+  ) {
+    throw new SimSesBadRequestException(
+      "The specified NextToken is not a token this simulation issued",
+    );
+  }
+
+  return startIndex;
+}

--- a/src/service/ses/command/sim-ses-request-options.ts
+++ b/src/service/ses/command/sim-ses-request-options.ts
@@ -1,0 +1,12 @@
+import type { SimAwsCaller } from "../../aws/caller/sim-aws-caller.js";
+
+/**
+ * What a simulated SES request carries besides its command input.
+ */
+export interface SimSesRequestOptions {
+  /**
+   * Who is making the request. An omitted caller is the Account root, as it is
+   * everywhere else in the simulation.
+   */
+  readonly caller?: SimAwsCaller;
+}

--- a/src/service/ses/email/sim-ses-address.ts
+++ b/src/service/ses/email/sim-ses-address.ts
@@ -1,0 +1,33 @@
+import { SimSesBadRequestException } from "../error/sim-ses.error.js";
+
+/**
+ * The address inside `Display Name <address@example.com>`, if it is written
+ * that way.
+ */
+const displayNamePattern = /<([^<>]+)>\s*$/;
+
+/**
+ * The bare address out of a header value.
+ *
+ * SES accepts both `orders@example.com` and `Orders <orders@example.com>`
+ * wherever an address goes, and the identity check applies to the address
+ * either way. What a recorded send keeps is the value as it was given, so a
+ * test asserting on the display name still can; this is only what the identity
+ * check reads.
+ */
+export function simSesBareAddress(address: string): string {
+  return (displayNamePattern.exec(address)?.[1] ?? address).trim();
+}
+
+/**
+ * Read an address SES is being asked to send from, refusing an empty one.
+ */
+export function requiredSimSesFromAddress(fromEmailAddress?: string): string {
+  const address = fromEmailAddress?.trim() ?? "";
+
+  if (address.length === 0) {
+    throw new SimSesBadRequestException("Missing required header 'From'.");
+  }
+
+  return address;
+}

--- a/src/service/ses/email/sim-ses-sent-email-store.ts
+++ b/src/service/ses/email/sim-ses-sent-email-store.ts
@@ -1,0 +1,48 @@
+import type { SimSesSentEmail } from "./sim-ses-sent-email.js";
+
+const hoursInADay = 24;
+const millisecondsInAnHour = 60 * 60 * 1000;
+
+/**
+ * The messages one simulated SES scope has accepted.
+ *
+ * Sends are kept in the order they were made, because the assertion a test
+ * usually wants is about the first message of a flow: signing up sends a
+ * welcome message, and whatever else follows is not what the test is looking
+ * at.
+ *
+ * Nothing here is ever discarded. A real account has no such record at all, so
+ * there is no retention behaviour to reproduce, and a test process is short
+ * enough that keeping every message costs nothing.
+ */
+export class SimSesSentEmailStore {
+  readonly #sent: SimSesSentEmail[] = [];
+
+  /**
+   * Every message this scope has accepted, oldest first.
+   */
+  get all(): readonly SimSesSentEmail[] {
+    return [...this.#sent];
+  }
+
+  /**
+   * Keep a message SES has accepted.
+   */
+  add(email: SimSesSentEmail): void {
+    this.#sent.push(email);
+  }
+
+  /**
+   * How many messages were accepted in the 24 hours up to an instant.
+   *
+   * This is what `GetAccount` reports as `SentLast24Hours`. It is counted from
+   * the simulated clock rather than the host's, so a test that moves time
+   * forward past the window sees the count fall the way an account's would.
+   */
+  countSentSince(now: Date): number {
+    const windowStart = now.getTime() - hoursInADay * millisecondsInAnHour;
+
+    return this.#sent.filter((email) => email.sentDate.getTime() > windowStart)
+      .length;
+  }
+}

--- a/src/service/ses/email/sim-ses-sent-email.ts
+++ b/src/service/ses/email/sim-ses-sent-email.ts
@@ -1,0 +1,87 @@
+/**
+ * Who a recorded message was addressed to, kept apart the way the request
+ * carried it: a test asserting a bcc was a bcc needs the three lists to stay
+ * three lists.
+ */
+export interface SimSesSentEmailDestination {
+  readonly toAddresses: readonly string[];
+  readonly ccAddresses: readonly string[];
+  readonly bccAddresses: readonly string[];
+}
+
+/**
+ * What a recorded message says.
+ *
+ * Both parts are optional because SES accepts a message with only one of them,
+ * and a test asserting on the text of an HTML-only message should find nothing
+ * rather than find the markup.
+ */
+export interface SimSesSentEmailBody {
+  readonly text: string | undefined;
+  readonly html: string | undefined;
+}
+
+interface SimSesSentEmailProperties {
+  readonly messageId: string;
+  readonly fromEmailAddress: string;
+  readonly destination: SimSesSentEmailDestination;
+  readonly replyToAddresses: readonly string[];
+  readonly subject: string | undefined;
+  readonly body: SimSesSentEmailBody;
+  readonly configurationSetName: string | undefined;
+  readonly sentDate: Date;
+}
+
+/**
+ * One message a simulated SES would have sent.
+ *
+ * Nothing is delivered. SES keeps what it would have sent instead, which is
+ * what lets a test assert that signing someone up produced a welcome message
+ * addressed to them, without a mailbox to read or a network to reach.
+ *
+ * There is no simulated delivery to add later either. Where a message goes
+ * after SES accepts it is a mail system rather than an AWS service, so the
+ * recorded send is the whole of the observable behaviour, not a stand-in for
+ * something not built yet.
+ */
+export class SimSesSentEmail {
+  /** What SendEmail answered with, and the only handle SES gives a message. */
+  public readonly messageId: string;
+
+  /** The From value as the request gave it, display name and all. */
+  public readonly fromEmailAddress: string;
+
+  public readonly destination: SimSesSentEmailDestination;
+
+  public readonly replyToAddresses: readonly string[];
+
+  public readonly subject: string | undefined;
+
+  public readonly body: SimSesSentEmailBody;
+
+  public readonly configurationSetName: string | undefined;
+
+  public readonly sentDate: Date;
+
+  constructor(properties: SimSesSentEmailProperties) {
+    this.messageId = properties.messageId;
+    this.fromEmailAddress = properties.fromEmailAddress;
+    this.destination = properties.destination;
+    this.replyToAddresses = properties.replyToAddresses;
+    this.subject = properties.subject;
+    this.body = properties.body;
+    this.configurationSetName = properties.configurationSetName;
+    this.sentDate = properties.sentDate;
+  }
+
+  /**
+   * Every address this message went to, across to, cc and bcc.
+   */
+  get recipients(): readonly string[] {
+    return [
+      ...this.destination.toAddresses,
+      ...this.destination.ccAddresses,
+      ...this.destination.bccAddresses,
+    ];
+  }
+}

--- a/src/service/ses/email/sim-ses-sent-email.ts
+++ b/src/service/ses/email/sim-ses-sent-email.ts
@@ -26,7 +26,7 @@ interface SimSesSentEmailProperties {
   readonly fromEmailAddress: string;
   readonly destination: SimSesSentEmailDestination;
   readonly replyToAddresses: readonly string[];
-  readonly subject: string | undefined;
+  readonly subject: string;
   readonly body: SimSesSentEmailBody;
   readonly configurationSetName: string | undefined;
   readonly sentDate: Date;
@@ -55,7 +55,7 @@ export class SimSesSentEmail {
 
   public readonly replyToAddresses: readonly string[];
 
-  public readonly subject: string | undefined;
+  public readonly subject: string;
 
   public readonly body: SimSesSentEmailBody;
 

--- a/src/service/ses/error/sim-ses.error.ts
+++ b/src/service/ses/error/sim-ses.error.ts
@@ -1,0 +1,94 @@
+/**
+ * Minimal metadata shape for simulated SES errors.
+ */
+export interface SimSesErrorMetadata {
+  readonly httpStatusCode?: number;
+}
+
+/**
+ * Base class for simulated SES errors.
+ */
+export class SimSesError extends Error {
+  constructor(
+    message: string,
+    public readonly $metadata: SimSesErrorMetadata = {},
+  ) {
+    super(message);
+  }
+}
+
+/**
+ * Simulated SES BadRequestException error.
+ *
+ * This is what the SES v2 API reports for input it will not accept, such as an
+ * identity that is neither an email address nor a domain.
+ */
+export class SimSesBadRequestException extends SimSesError {
+  public override readonly name = "BadRequestException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
+ * Simulated SES NotFoundException error.
+ *
+ * Reading or deleting an identity that is not there produces this, and so does
+ * sending with a template name that names nothing.
+ */
+export class SimSesNotFoundException extends SimSesError {
+  public override readonly name = "NotFoundException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 404 });
+  }
+}
+
+/**
+ * Simulated SES AlreadyExistsException error.
+ *
+ * Creating an identity that is already there fails rather than answering with
+ * the one that exists, so a test that verifies the same address twice sees the
+ * failure an account would give it.
+ */
+export class SimSesAlreadyExistsException extends SimSesError {
+  public override readonly name = "AlreadyExistsException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
+ * Simulated SES MessageRejected error.
+ *
+ * SES reports a message it will not accept this way, and an unverified
+ * identity is much the commonest reason for it. The message names the
+ * identities that failed the check, because that is the part a caller has to
+ * read to find out what to verify.
+ */
+export class SimSesMessageRejected extends SimSesError {
+  public override readonly name = "MessageRejected";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
+ * Simulated SES UnsupportedOperationException error.
+ *
+ * This one is Yulin reporting a request real SES would accept and this
+ * simulator does not carry out, rather than a failure an account would
+ * produce. Refusing is the honest answer: a raw MIME message quietly recorded
+ * with an empty body would make a test pass for a reason unrelated to what it
+ * asserts.
+ */
+export class SimSesUnsupportedOperationException extends SimSesError {
+  public override readonly name = "UnsupportedOperationException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}

--- a/src/service/ses/identity/sim-ses-arn.ts
+++ b/src/service/ses/identity/sim-ses-arn.ts
@@ -19,13 +19,3 @@ export function simSesIdentityArn(
 ): string {
   return `${simSesArnPrefix(scope)}identity/${emailIdentity}`;
 }
-
-/**
- * The ARN of every email identity in one account and region.
- *
- * An operation that names no particular identity authorizes against this,
- * since that is the resource it actually reaches.
- */
-export function simSesAnyIdentityArn(scope: SimAwsAccountRegionScope): string {
-  return `${simSesArnPrefix(scope)}identity/*`;
-}

--- a/src/service/ses/identity/sim-ses-arn.ts
+++ b/src/service/ses/identity/sim-ses-arn.ts
@@ -1,0 +1,31 @@
+import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+
+/**
+ * The start of every SES ARN in one account and region.
+ */
+export function simSesArnPrefix(scope: SimAwsAccountRegionScope): string {
+  return `arn:aws:ses:${scope.regionName}:${scope.accountId}:`;
+}
+
+/**
+ * The ARN of an email identity.
+ *
+ * This is the resource IAM evaluates an SES request against: a policy allowing
+ * `ses:SendEmail` names the identity being sent from, not the recipient.
+ */
+export function simSesIdentityArn(
+  scope: SimAwsAccountRegionScope,
+  emailIdentity: string,
+): string {
+  return `${simSesArnPrefix(scope)}identity/${emailIdentity}`;
+}
+
+/**
+ * The ARN of every email identity in one account and region.
+ *
+ * An operation that names no particular identity authorizes against this,
+ * since that is the resource it actually reaches.
+ */
+export function simSesAnyIdentityArn(scope: SimAwsAccountRegionScope): string {
+  return `${simSesArnPrefix(scope)}identity/*`;
+}

--- a/src/service/ses/identity/sim-ses-identity-name.ts
+++ b/src/service/ses/identity/sim-ses-identity-name.ts
@@ -1,0 +1,127 @@
+import { SimSesBadRequestException } from "../error/sim-ses.error.js";
+
+/**
+ * What kind of thing an SES identity names.
+ *
+ * Real SES has a third, `MANAGED_DOMAIN`, which only its own managed sending
+ * domains carry. Nothing here can create one, so nothing here reports one.
+ */
+export type SimSesIdentityType = "EMAIL_ADDRESS" | "DOMAIN";
+
+const maximumLength = 320;
+const maximumLabelLength = 63;
+
+/** What a domain label may be made of. */
+const labelCharacters = /^[a-z0-9-]+$/i;
+
+/** What a domain has to end with: a dot and at least two letters. */
+const topLevelLabel = /\.[a-z]{2,}$/i;
+
+/**
+ * Read an SES identity, refusing one real SES would refuse.
+ *
+ * An identity is either an email address or a domain, and which one it is
+ * follows from whether it has an `@` in it. That is how SES itself decides:
+ * there is no parameter saying which kind is meant.
+ */
+export function requiredSimSesIdentityName(emailIdentity?: string): string {
+  if (emailIdentity === undefined || emailIdentity.length === 0) {
+    throw new SimSesBadRequestException(
+      "1 validation error detected: Value at 'emailIdentity' failed to " +
+        "satisfy constraint: Member must not be null",
+    );
+  }
+
+  if (emailIdentity.length > maximumLength) {
+    throw new SimSesBadRequestException(
+      `1 validation error detected: Value at 'emailIdentity' failed to ` +
+        `satisfy constraint: Member must have length less than or equal to ` +
+        `${maximumLength}`,
+    );
+  }
+
+  if (!isSimSesIdentityName(emailIdentity)) {
+    throw new SimSesBadRequestException(
+      `Invalid identity: ${emailIdentity}. An identity is an email address ` +
+        `or a domain.`,
+    );
+  }
+
+  return emailIdentity;
+}
+
+/**
+ * Which kind of identity a name is.
+ */
+export function simSesIdentityType(emailIdentity: string): SimSesIdentityType {
+  return emailIdentity.includes("@") ? "EMAIL_ADDRESS" : "DOMAIN";
+}
+
+/**
+ * The domain part of an identity: the whole of a domain identity, and what
+ * follows the `@` of an address one.
+ */
+export function simSesIdentityDomain(emailIdentity: string): string {
+  return emailIdentity.slice(emailIdentity.lastIndexOf("@") + 1).toLowerCase();
+}
+
+/**
+ * How an identity is keyed, so that two spellings of the same thing meet.
+ *
+ * Domains are case insensitive, so they are keyed in lower case. The local
+ * part of an address is not, per RFC 5321, so it is keyed as it was given:
+ * `Sales@example.com` and `sales@example.com` are two identities here, as they
+ * are two mailboxes in principle, while `sales@EXAMPLE.com` is the same one.
+ */
+export function simSesIdentityKey(emailIdentity: string): string {
+  const domain = simSesIdentityDomain(emailIdentity);
+
+  if (simSesIdentityType(emailIdentity) === "DOMAIN") {
+    return domain;
+  }
+
+  return `${emailIdentity.slice(0, emailIdentity.lastIndexOf("@"))}@${domain}`;
+}
+
+function isSimSesIdentityName(emailIdentity: string): boolean {
+  if (!emailIdentity.includes("@")) {
+    return isDomain(emailIdentity);
+  }
+
+  const localPart = emailIdentity.slice(0, emailIdentity.lastIndexOf("@"));
+
+  return (
+    localPart.length > 0 &&
+    !localPart.includes("@") &&
+    isDomain(simSesIdentityDomain(emailIdentity))
+  );
+}
+
+/**
+ * Whether a name is a domain: two or more dot separated labels, the last of
+ * them alphabetic.
+ *
+ * Checked label by label rather than with one pattern covering the whole
+ * thing. A pattern for a repeated group of repeated characters backtracks
+ * badly on a long near miss, and splitting first is both linear and easier to
+ * read.
+ */
+function isDomain(value: string): boolean {
+  const labels = value.split(".");
+
+  return (
+    labels.length >= 2 &&
+    topLevelLabel.test(value) &&
+    labels.every((label) => isDomainLabel(label))
+  );
+}
+
+function isDomainLabel(label: string): boolean {
+  return (
+    label.length > 0 &&
+    label.length <= maximumLabelLength &&
+    labelCharacters.test(label) &&
+    !label.startsWith("-") &&
+    !label.endsWith("-")
+  );
+}

--- a/src/service/ses/identity/sim-ses-identity-store.ts
+++ b/src/service/ses/identity/sim-ses-identity-store.ts
@@ -1,0 +1,126 @@
+import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+import {
+  SimSesAlreadyExistsException,
+  SimSesNotFoundException,
+} from "../error/sim-ses.error.js";
+import {
+  simSesIdentityDomain,
+  simSesIdentityKey,
+} from "./sim-ses-identity-name.js";
+import { SimSesIdentity } from "./sim-ses-identity.js";
+
+interface SimSesIdentityStoreProperties {
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+}
+
+/**
+ * The email identities of one simulated SES scope.
+ *
+ * Identities are region scoped on real SES: verifying an address in one region
+ * verifies nothing in another, which is a mistake worth reproducing rather
+ * than smoothing over.
+ */
+export class SimSesIdentityStore {
+  readonly #accountRegionScope: SimAwsAccountRegionScope;
+  readonly #identities = new Map<string, SimSesIdentity>();
+
+  constructor(properties: SimSesIdentityStoreProperties) {
+    this.#accountRegionScope = properties.accountRegionScope;
+  }
+
+  /**
+   * Every identity in this scope, in the order they were created.
+   */
+  get all(): readonly SimSesIdentity[] {
+    return this.#identities.values().toArray();
+  }
+
+  /**
+   * Make an identity, refusing one that is already there.
+   */
+  create(emailIdentity: string, createdDate: Date): SimSesIdentity {
+    const key = simSesIdentityKey(emailIdentity);
+
+    if (this.#identities.has(key)) {
+      throw new SimSesAlreadyExistsException(
+        `Email identity ${emailIdentity} already exists.`,
+      );
+    }
+
+    const identity = new SimSesIdentity({
+      emailIdentity,
+      accountRegionScope: this.#accountRegionScope,
+      createdDate,
+    });
+
+    this.#identities.set(key, identity);
+
+    return identity;
+  }
+
+  /**
+   * Find an identity by the address or domain it names.
+   */
+  find(emailIdentity: string): SimSesIdentity | undefined {
+    return this.#identities.get(simSesIdentityKey(emailIdentity));
+  }
+
+  /**
+   * Get an identity, refusing one that is not there.
+   */
+  require(emailIdentity: string): SimSesIdentity {
+    const identity = this.find(emailIdentity);
+
+    if (identity === undefined) {
+      throw new SimSesNotFoundException(
+        `Email identity ${emailIdentity} does not exist.`,
+      );
+    }
+
+    return identity;
+  }
+
+  /**
+   * The identity an address belongs to, whether or not it is verified.
+   *
+   * This is what IAM authorizes an operation on an address against, and the
+   * more specific of the two wins: a policy naming `identity/hello@example.com`
+   * covers a send from that address, and one naming `identity/example.com`
+   * covers a send from any address at the domain. A parent domain does not
+   * cover a subdomain, here or on real SES.
+   *
+   * An address nothing covers falls back to the address itself, since IAM
+   * evaluates a request before the service looks at it and has to authorize
+   * against something either way.
+   */
+  covering(address: string): string {
+    return (
+      this.find(address)?.emailIdentity ??
+      this.find(simSesIdentityDomain(address))?.emailIdentity ??
+      address
+    );
+  }
+
+  /**
+   * Whether SES would accept mail from or to an address.
+   *
+   * An address is verified if an identity for the address itself is, or if one
+   * for its domain is: verifying `example.com` lets every mailbox at it send,
+   * which is the whole reason domain identities exist. Either will do, so an
+   * address identity still waiting on its link sends anyway once its domain is
+   * verified.
+   */
+  isAddressVerified(address: string): boolean {
+    return (
+      this.find(address)?.isVerified === true ||
+      this.find(simSesIdentityDomain(address))?.isVerified === true
+    );
+  }
+
+  /**
+   * Remove an identity.
+   */
+  delete(emailIdentity: string): void {
+    this.#identities.delete(simSesIdentityKey(emailIdentity));
+  }
+}

--- a/src/service/ses/identity/sim-ses-identity.ts
+++ b/src/service/ses/identity/sim-ses-identity.ts
@@ -1,0 +1,96 @@
+import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+import { simSesIdentityArn } from "./sim-ses-arn.js";
+import {
+  simSesIdentityKey,
+  simSesIdentityType,
+  type SimSesIdentityType,
+} from "./sim-ses-identity-name.js";
+
+/**
+ * How far along an identity's verification is, in SES's own vocabulary.
+ *
+ * Only two of the five real values occur here. Nothing in this simulator can
+ * fail a verification or leave one in a temporary failure, because nothing
+ * here does the checking that would fail: an identity is pending until a test
+ * says it is verified.
+ */
+export type SimSesVerificationStatus = "PENDING" | "SUCCESS";
+
+interface SimSesIdentityProperties {
+  readonly emailIdentity: string;
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+  readonly createdDate: Date;
+}
+
+/**
+ * One email address or domain SES has been asked to send from.
+ *
+ * An identity starts unverified and stays that way until something says
+ * otherwise. Real SES verifies an address by emailing it a link and a domain
+ * by looking for DNS records, and neither of those can happen inside a test
+ * process, so verification here is a simulator-side act rather than an API
+ * operation.
+ */
+export class SimSesIdentity {
+  /** The address or domain, spelled as it was given. */
+  public readonly emailIdentity: string;
+
+  /** How this identity is looked up, so two spellings of it meet. */
+  public readonly key: string;
+
+  public readonly identityType: SimSesIdentityType;
+
+  public readonly arn: string;
+
+  public readonly createdDate: Date;
+
+  #verificationStatus: SimSesVerificationStatus = "PENDING";
+
+  constructor(properties: SimSesIdentityProperties) {
+    this.emailIdentity = properties.emailIdentity;
+    this.key = simSesIdentityKey(properties.emailIdentity);
+    this.identityType = simSesIdentityType(properties.emailIdentity);
+    this.arn = simSesIdentityArn(
+      properties.accountRegionScope,
+      properties.emailIdentity,
+    );
+    this.createdDate = properties.createdDate;
+  }
+
+  get verificationStatus(): SimSesVerificationStatus {
+    return this.#verificationStatus;
+  }
+
+  /**
+   * Whether SES would let a message be sent from this identity.
+   *
+   * Real SES reports this separately from the verification status because an
+   * account under enforcement can hold a verified identity it may not send
+   * from. Nothing here puts an account under enforcement, so the two agree.
+   */
+  get isVerified(): boolean {
+    return this.#verificationStatus === "SUCCESS";
+  }
+
+  /**
+   * Treat this identity as having completed verification.
+   *
+   * This stands in for clicking the link SES emails, or for the DNS records a
+   * domain identity waits on. It is the simulator's own operation and no SES
+   * API call reaches it.
+   */
+  verify(): void {
+    this.#verificationStatus = "SUCCESS";
+  }
+
+  /**
+   * Put this identity back to waiting on its verification.
+   *
+   * Real SES moves an identity out of `SUCCESS` when the records that proved
+   * it stop resolving, so a test that wants to see sending fail after it once
+   * worked has somewhere to go.
+   */
+  unverify(): void {
+    this.#verificationStatus = "PENDING";
+  }
+}

--- a/src/service/ses/index.ts
+++ b/src/service/ses/index.ts
@@ -1,0 +1,44 @@
+export { SimSesV2 } from "./sim-ses-v2.js";
+export type { SimSesV2Properties } from "./sim-ses-commands.js";
+export type { SimSesRequestOptions } from "./command/sim-ses-request-options.js";
+export {
+  SimSesIdentity,
+  type SimSesVerificationStatus,
+} from "./identity/sim-ses-identity.js";
+export { SimSesIdentityStore } from "./identity/sim-ses-identity-store.js";
+export {
+  requiredSimSesIdentityName,
+  simSesIdentityDomain,
+  simSesIdentityKey,
+  type SimSesIdentityType,
+  simSesIdentityType,
+} from "./identity/sim-ses-identity-name.js";
+export {
+  simSesAnyIdentityArn,
+  simSesArnPrefix,
+  simSesIdentityArn,
+} from "./identity/sim-ses-arn.js";
+export {
+  SimSesSentEmail,
+  type SimSesSentEmailBody,
+  type SimSesSentEmailDestination,
+} from "./email/sim-ses-sent-email.js";
+export { SimSesSentEmailStore } from "./email/sim-ses-sent-email-store.js";
+export {
+  requiredSimSesFromAddress,
+  simSesBareAddress,
+} from "./email/sim-ses-address.js";
+export {
+  SimSesAccount,
+  type SimSesAccountContactDetails,
+  type SimSesSendQuota,
+} from "./account/sim-ses-account.js";
+export {
+  SimSesAlreadyExistsException,
+  SimSesBadRequestException,
+  SimSesError,
+  type SimSesErrorMetadata,
+  SimSesMessageRejected,
+  SimSesNotFoundException,
+  SimSesUnsupportedOperationException,
+} from "./error/sim-ses.error.js";

--- a/src/service/ses/index.ts
+++ b/src/service/ses/index.ts
@@ -13,11 +13,7 @@ export {
   type SimSesIdentityType,
   simSesIdentityType,
 } from "./identity/sim-ses-identity-name.js";
-export {
-  simSesAnyIdentityArn,
-  simSesArnPrefix,
-  simSesIdentityArn,
-} from "./identity/sim-ses-arn.js";
+export { simSesArnPrefix, simSesIdentityArn } from "./identity/sim-ses-arn.js";
 export {
   SimSesSentEmail,
   type SimSesSentEmailBody,

--- a/src/service/ses/sdk/sim-ses-sdk-command-router.ts
+++ b/src/service/ses/sdk/sim-ses-sdk-command-router.ts
@@ -1,0 +1,99 @@
+import {
+  simSdkCallerOptions,
+  type SimSdkCommandRoute,
+  type SimSdkCommandRouter,
+} from "../../../sdk/index.js";
+import type {
+  SimGetAccountCommand,
+  SimPutAccountDetailsCommand,
+} from "../command/account/account.command.js";
+import type {
+  SimCreateEmailIdentityCommand,
+  SimDeleteEmailIdentityCommand,
+  SimGetEmailIdentityCommand,
+  SimListEmailIdentitiesCommand,
+} from "../command/identity/identity.command.js";
+import type { SimSendEmailCommand } from "../command/send/send.command.js";
+import type { SimSesV2 } from "../sim-ses-v2.js";
+
+/**
+ * Routes intercepted SDK Commands to one scoped simulated SES.
+ */
+export class SimSesSdkCommandRouter implements SimSdkCommandRouter {
+  readonly #routes: ReadonlyMap<string, SimSdkCommandRoute>;
+
+  constructor(simSes: SimSesV2) {
+    this.#routes = new Map<string, SimSdkCommandRoute>([
+      [
+        "CreateEmailIdentityCommand",
+        async (command, context): Promise<unknown> =>
+          await simSes.createEmailIdentity(
+            command as SimCreateEmailIdentityCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "GetEmailIdentityCommand",
+        async (command, context): Promise<unknown> =>
+          await simSes.getEmailIdentity(
+            command as SimGetEmailIdentityCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "ListEmailIdentitiesCommand",
+        async (command, context): Promise<unknown> =>
+          await simSes.listEmailIdentities(
+            command as SimListEmailIdentitiesCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "DeleteEmailIdentityCommand",
+        async (command, context): Promise<unknown> =>
+          await simSes.deleteEmailIdentity(
+            command as SimDeleteEmailIdentityCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "SendEmailCommand",
+        async (command, context): Promise<unknown> =>
+          await simSes.sendEmail(
+            command as SimSendEmailCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "GetAccountCommand",
+        async (command, context): Promise<unknown> =>
+          await simSes.getAccount(
+            command as SimGetAccountCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "PutAccountDetailsCommand",
+        async (command, context): Promise<unknown> =>
+          await simSes.putAccountDetails(
+            command as SimPutAccountDetailsCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+    ]);
+  }
+
+  /**
+   * The SDK Command names simulated SES can handle.
+   */
+  supportedCommandNames(): readonly string[] {
+    return this.#routes.keys().toArray();
+  }
+
+  /**
+   * Get the route for an SDK Command name, if simulated SES supports it.
+   */
+  route(commandName: string): SimSdkCommandRoute | undefined {
+    return this.#routes.get(commandName);
+  }
+}

--- a/src/service/ses/sdk/sim-ses-sdk-routing.iso.test.ts
+++ b/src/service/ses/sdk/sim-ses-sdk-routing.iso.test.ts
@@ -1,0 +1,209 @@
+import {
+  CreateEmailIdentityCommand,
+  CreateEmailTemplateCommand,
+  DeleteEmailIdentityCommand,
+  GetAccountCommand,
+  GetEmailIdentityCommand,
+  ListEmailIdentitiesCommand,
+  PutAccountDetailsCommand,
+  SendEmailCommand,
+  SESv2Client,
+} from "@aws-sdk/client-sesv2";
+import {
+  assertArrayEquals,
+  assertArrayIncludesAll,
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertTrue,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimSdk, SimSdkUnsupportedCommandError } from "../../../sdk/index.js";
+import { SimAws } from "../../aws/sim-aws.js";
+
+describe("SimSesSdkCommandRouter", () => {
+  it("names every Command simulated SES handles", () => {
+    // Given a scoped simulated SES.
+    const simAws = new SimAws();
+
+    // When its supported Command names are asked for.
+    const names = simAws.sesV2().sdkCommandRouter().supportedCommandNames();
+
+    // Then each simulated operation is routable by SDK Command name.
+    assertArrayIncludesAll(names, [
+      "CreateEmailIdentityCommand",
+      "GetEmailIdentityCommand",
+      "ListEmailIdentitiesCommand",
+      "DeleteEmailIdentityCommand",
+      "SendEmailCommand",
+      "GetAccountCommand",
+      "PutAccountDetailsCommand",
+    ]);
+  });
+
+  it("has no route for a Command it does not handle", () => {
+    // Given a scoped simulated SES.
+    const simAws = new SimAws();
+
+    // When an SES Command outside what is simulated is looked up.
+    const route = simAws
+      .sesV2()
+      .sdkCommandRouter()
+      .route("CreateEmailTemplateCommand");
+
+    // Then there is no route for it.
+    assertUndefined(route);
+  });
+});
+
+describe("SES SDK interception", () => {
+  it("routes an intercepted SESv2Client to simulated SES", async () => {
+    // Given an intercepted SES SDK client with a verified sender.
+    using simSdk = new SimSdk();
+    simSdk.intercept(SESv2Client);
+
+    const client = new SESv2Client({ region: "eu-west-2" });
+    const scoped = simSdk.simAws.accountRegionScope(
+      simSdk.simAws.defaultAccountId,
+      "eu-west-2",
+    );
+
+    scoped.sesV2().verifyIdentity("example.com");
+    scoped.sesV2().verifyIdentity("example.org");
+
+    // When ordinary SDK code sends a welcome email.
+    const sent = await client.send(
+      new SendEmailCommand({
+        FromEmailAddress: "hello@example.com",
+        Destination: { ToAddresses: ["someone@example.org"] },
+        Content: {
+          Simple: {
+            Subject: { Data: "Welcome" },
+            Body: { Text: { Data: "Hi there" } },
+          },
+        },
+      }),
+    );
+
+    // Then it reached the simulated SES for the Region the client was
+    // configured for, with nothing touching the network.
+    const [email] = scoped.sesV2().sentEmails();
+
+    assertNonNullable(email);
+    assertIdentical(email.messageId, sent.MessageId);
+    assertIdentical(email.subject, "Welcome");
+    assertArrayEquals(email.destination.toAddresses, ["someone@example.org"]);
+  });
+
+  it("routes every remaining Command through the intercepted client", async () => {
+    // Given an intercepted client.
+    using simSdk = new SimSdk();
+    simSdk.intercept(SESv2Client);
+
+    const client = new SESv2Client({ region: "eu-west-2" });
+
+    // When each of the remaining operations is used.
+    const created = await client.send(
+      new CreateEmailIdentityCommand({ EmailIdentity: "example.com" }),
+    );
+    const read = await client.send(
+      new GetEmailIdentityCommand({ EmailIdentity: "example.com" }),
+    );
+    const listed = await client.send(new ListEmailIdentitiesCommand({}));
+
+    await client.send(
+      new PutAccountDetailsCommand({
+        MailType: "TRANSACTIONAL",
+        WebsiteURL: "https://example.com",
+        ProductionAccessEnabled: true,
+      }),
+    );
+    const account = await client.send(new GetAccountCommand({}));
+
+    await client.send(
+      new DeleteEmailIdentityCommand({ EmailIdentity: "example.com" }),
+    );
+    const afterDelete = await client.send(new ListEmailIdentitiesCommand({}));
+
+    // Then each one reached simulated SES.
+    assertIdentical(created.IdentityType, "DOMAIN");
+    assertIdentical(read.VerificationStatus, "PENDING");
+    assertArrayLength(listed.EmailIdentities ?? [], 1);
+    assertTrue(account.ProductionAccessEnabled);
+    assertArrayLength(afterDelete.EmailIdentities ?? [], 0);
+  });
+
+  it("keeps sends in one Region out of another", async () => {
+    // Given two intercepted clients in different Regions, each with the
+    // identities that Region needs.
+    using simSdk = new SimSdk();
+    simSdk.intercept(SESv2Client);
+
+    const accountId = simSdk.simAws.defaultAccountId;
+
+    for (const regionName of ["eu-west-2", "us-east-1"] as const) {
+      const scoped = simSdk.simAws.accountRegionScope(accountId, regionName);
+
+      scoped.sesV2().verifyIdentity("example.com");
+      scoped.sesV2().verifyIdentity("example.org");
+    }
+
+    // When a message is sent through one of them.
+    await new SESv2Client({ region: "eu-west-2" }).send(
+      new SendEmailCommand({
+        FromEmailAddress: "hello@example.com",
+        Destination: { ToAddresses: ["someone@example.org"] },
+        Content: {
+          Simple: {
+            Subject: { Data: "Welcome" },
+            Body: { Text: { Data: "Hi there" } },
+          },
+        },
+      }),
+    );
+
+    // Then the other Region has no record of it, as a real account would not.
+    assertArrayLength(
+      simSdk.simAws
+        .accountRegionScope(accountId, "us-east-1")
+        .sesV2()
+        .sentEmails(),
+      0,
+    );
+    assertArrayLength(
+      simSdk.simAws
+        .accountRegionScope(accountId, "eu-west-2")
+        .sesV2()
+        .sentEmails(),
+      1,
+    );
+  });
+
+  it("refuses an SES Command it does not simulate on send", async () => {
+    // Given an intercepted client.
+    using simSdk = new SimSdk();
+    simSdk.intercept(SESv2Client);
+
+    const client = new SESv2Client({ region: "eu-west-2" });
+
+    // When a Command outside what is simulated is sent.
+    const error = await assertThrowsErrorAsync(async () => {
+      await client.send(
+        new CreateEmailTemplateCommand({
+          TemplateName: "welcome",
+          TemplateContent: { Subject: "Welcome" },
+        }),
+      );
+    });
+
+    // Then it is refused on send, naming the Command, rather than reaching the
+    // network or quietly doing nothing.
+    assertInstanceOf(error, SimSdkUnsupportedCommandError);
+    assertStringIncludes(error.message, "CreateEmailTemplateCommand");
+  });
+});

--- a/src/service/ses/sim-ses-account.iso.test.ts
+++ b/src/service/ses/sim-ses-account.iso.test.ts
@@ -174,4 +174,39 @@ describe("SimSesV2 account", () => {
 
     assertInstanceOf(error, SimSesBadRequestException);
   });
+
+  it("keeps a contact language SES writes in", async () => {
+    // Given a simulated SES.
+    const ses = new SimAws().sesV2();
+
+    // When details name one of the two languages SES supports.
+    await ses.putAccountDetails(
+      new PutAccountDetailsCommand({
+        MailType: "TRANSACTIONAL",
+        WebsiteURL: "https://example.com",
+        ContactLanguage: "JA",
+      }),
+    );
+    const account = await ses.getAccount(new GetAccountCommand({}));
+
+    assertIdentical(account.Details?.ContactLanguage, "JA");
+  });
+
+  it("refuses a contact language SES does not write in", async () => {
+    // Given a simulated SES.
+    const ses = new SimAws().sesV2();
+
+    // When details name a language that is neither of the two SES accepts.
+    const error = await assertThrowsErrorAsync(async () => {
+      await ses.putAccountDetails(
+        new PutAccountDetailsCommand({
+          MailType: "TRANSACTIONAL",
+          WebsiteURL: "https://example.com",
+          ContactLanguage: "FR" as "EN",
+        }),
+      );
+    });
+
+    assertInstanceOf(error, SimSesBadRequestException);
+  });
 });

--- a/src/service/ses/sim-ses-account.iso.test.ts
+++ b/src/service/ses/sim-ses-account.iso.test.ts
@@ -1,0 +1,177 @@
+import {
+  GetAccountCommand,
+  PutAccountDetailsCommand,
+  SendEmailCommand,
+  type SendEmailCommandInput,
+} from "@aws-sdk/client-sesv2";
+import {
+  assertFalse,
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertThrowsErrorAsync,
+  assertTrue,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimFixedClock } from "../../util/clock/sim-clock.js";
+import { SimAws } from "../aws/sim-aws.js";
+import { SimSesBadRequestException } from "./error/sim-ses.error.js";
+
+const startedAt = new Date("2026-08-16T09:00:00.000Z");
+
+const welcome = {
+  FromEmailAddress: "hello@example.com",
+  Destination: { ToAddresses: ["someone@example.org"] },
+  Content: {
+    Simple: {
+      Subject: { Data: "Welcome" },
+      Body: { Text: { Data: "Hi there" } },
+    },
+  },
+} satisfies SendEmailCommandInput;
+
+describe("SimSesV2 account", () => {
+  it("reports a sandbox account and its sending limits", async () => {
+    // Given a simulated SES nobody has configured.
+    const ses = new SimAws().sesV2();
+
+    // When the account is read.
+    const account = await ses.getAccount(new GetAccountCommand({}));
+
+    // Then it is in the sandbox on the real sandbox limits, and has no
+    // details to report until something puts them.
+    assertFalse(account.ProductionAccessEnabled);
+    assertNonNullable(account.SendQuota);
+    assertIdentical(account.SendQuota.Max24HourSend, 200);
+    assertIdentical(account.SendQuota.MaxSendRate, 1);
+    assertTrue(account.SendingEnabled);
+    assertIdentical(account.EnforcementStatus, "HEALTHY");
+    assertUndefined(account.Details);
+  });
+
+  it("leaves the sandbox and reports the production limits", async () => {
+    // Given a simulated SES in the sandbox.
+    const ses = new SimAws().sesV2();
+
+    // When account details asking for production access are put.
+    await ses.putAccountDetails(
+      new PutAccountDetailsCommand({
+        MailType: "TRANSACTIONAL",
+        WebsiteURL: "https://example.com",
+        ProductionAccessEnabled: true,
+      }),
+    );
+    const account = await ses.getAccount(new GetAccountCommand({}));
+
+    // Then the account has production access on the higher limits. Real SES
+    // has a human review this first, which is not something a test can wait
+    // for, so the request is granted here.
+    assertTrue(account.ProductionAccessEnabled);
+    assertNonNullable(account.SendQuota);
+    assertIdentical(account.SendQuota.Max24HourSend, 50_000);
+    assertIdentical(account.SendQuota.MaxSendRate, 14);
+    assertNonNullable(account.Details);
+    assertIdentical(account.Details.MailType, "TRANSACTIONAL");
+    assertIdentical(account.Details.WebsiteURL, "https://example.com");
+    assertIdentical(account.Details.ReviewDetails?.Status, "GRANTED");
+  });
+
+  it("records details without granting production access", async () => {
+    // Given a simulated SES in the sandbox.
+    const ses = new SimAws().sesV2();
+
+    // When details are put without asking to leave the sandbox.
+    await ses.putAccountDetails(
+      new PutAccountDetailsCommand({
+        MailType: "MARKETING",
+        WebsiteURL: "https://example.com",
+      }),
+    );
+    const account = await ses.getAccount(new GetAccountCommand({}));
+
+    // Then the details are kept and the account is still in the sandbox.
+    assertNonNullable(account.Details);
+    assertIdentical(account.Details.MailType, "MARKETING");
+    assertFalse(account.ProductionAccessEnabled);
+    assertIdentical(account.Details.ReviewDetails?.Status, "PENDING");
+  });
+
+  it("counts what was sent in the last 24 hours", async () => {
+    // Given an account out of the sandbox that has sent a message.
+    const simAws = new SimAws({ clock: new SimFixedClock(startedAt) });
+    const ses = simAws.sesV2();
+
+    ses.verifyIdentity("hello@example.com");
+    await ses.putAccountDetails(
+      new PutAccountDetailsCommand({
+        MailType: "TRANSACTIONAL",
+        WebsiteURL: "https://example.com",
+        ProductionAccessEnabled: true,
+      }),
+    );
+    await ses.sendEmail(new SendEmailCommand(welcome));
+
+    const justSent = await ses.getAccount(new GetAccountCommand({}));
+
+    // When the clock moves past the 24 hour window.
+    await simAws.clock().advanceBy({ hours: 25 });
+
+    const later = await ses.getAccount(new GetAccountCommand({}));
+
+    // Then the count falls out of the window on simulated time, the way an
+    // account's would.
+    assertIdentical(justSent.SendQuota?.SentLast24Hours, 1);
+    assertIdentical(later.SendQuota?.SentLast24Hours, 0);
+  });
+
+  it("refuses account details with no mail type", async () => {
+    // Given a simulated SES.
+    const ses = new SimAws().sesV2();
+
+    // When details are put without the mail type real SES requires.
+    const error = await assertThrowsErrorAsync(async () => {
+      await ses.putAccountDetails(
+        new PutAccountDetailsCommand({
+          WebsiteURL: "https://example.com",
+        } as unknown as { MailType: "TRANSACTIONAL"; WebsiteURL: string }),
+      );
+    });
+
+    assertInstanceOf(error, SimSesBadRequestException);
+  });
+
+  it("refuses account details with no website", async () => {
+    // Given a simulated SES.
+    const ses = new SimAws().sesV2();
+
+    // When details are put without the website real SES requires.
+    const error = await assertThrowsErrorAsync(async () => {
+      await ses.putAccountDetails(
+        new PutAccountDetailsCommand({
+          MailType: "TRANSACTIONAL",
+        } as unknown as { MailType: "TRANSACTIONAL"; WebsiteURL: string }),
+      );
+    });
+
+    assertInstanceOf(error, SimSesBadRequestException);
+  });
+
+  it("refuses a mail type SES does not have", async () => {
+    // Given a simulated SES.
+    const ses = new SimAws().sesV2();
+
+    // When details name a mail type that is neither of the two SES accepts.
+    const error = await assertThrowsErrorAsync(async () => {
+      await ses.putAccountDetails(
+        new PutAccountDetailsCommand({
+          MailType: "NEWSLETTER" as "MARKETING",
+          WebsiteURL: "https://example.com",
+        }),
+      );
+    });
+
+    assertInstanceOf(error, SimSesBadRequestException);
+  });
+});

--- a/src/service/ses/sim-ses-commands.ts
+++ b/src/service/ses/sim-ses-commands.ts
@@ -1,0 +1,82 @@
+import {
+  type BackgroundScheduler,
+  BackgroundTasks,
+} from "../../util/background/background.js";
+import type { SimAwsAccountRegionScope } from "../aws/sim-aws-account-region-scope.js";
+import { simAwsAccountRegionScopeFactory } from "../aws/sim-aws-account-region-scope.factory.js";
+import {
+  SimIamAllowAllAuth,
+  type SimIamInterServiceAuthZ,
+} from "../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { SimSesAccount } from "./account/sim-ses-account.js";
+import { SimSesAccountCommands } from "./command/account/sim-ses-account-commands.js";
+import { SimSesAuthorizer } from "./command/authorize/sim-ses-authorizer.js";
+import { SimSesIdentityCommands } from "./command/identity/sim-ses-identity-commands.js";
+import { SimSesSendEmail } from "./command/send/sim-ses-send-email.js";
+import { SimSesVerifiedIdentityCheck } from "./command/send/sim-ses-verified-identities.js";
+import { SimSesSentEmailStore } from "./email/sim-ses-sent-email-store.js";
+import { SimSesIdentityStore } from "./identity/sim-ses-identity-store.js";
+
+export interface SimSesV2Properties {
+  readonly accountRegionScope?: SimAwsAccountRegionScope;
+  readonly iam?: SimIamInterServiceAuthZ;
+  readonly background?: BackgroundScheduler;
+}
+
+/**
+ * The collaborators one simulated SES scope is built from.
+ *
+ * Held apart from SimSesV2 for the same reason simulated CloudWatch Logs holds
+ * its own: the facade is one method per SDK Command and grows by one with
+ * every operation added, so the wiring deciding what those methods delegate to
+ * needs somewhere it is not competing for room with them.
+ */
+export class SimSesCommands {
+  readonly identities: SimSesIdentityStore;
+  readonly sent: SimSesSentEmailStore;
+  readonly account: SimSesAccount;
+  readonly identityCommands: SimSesIdentityCommands;
+  readonly sendEmail: SimSesSendEmail;
+  readonly accountCommands: SimSesAccountCommands;
+  readonly background: BackgroundScheduler;
+
+  constructor(properties: SimSesV2Properties = {}) {
+    const {
+      accountRegionScope = simAwsAccountRegionScopeFactory.make(),
+      iam = new SimIamAllowAllAuth(),
+      background = new BackgroundTasks(),
+    } = properties;
+
+    const authorizer = new SimSesAuthorizer({ iam, accountRegionScope });
+    const identities = new SimSesIdentityStore({ accountRegionScope });
+    const sent = new SimSesSentEmailStore();
+    const account = new SimSesAccount();
+
+    this.background = background;
+    this.identities = identities;
+    this.sent = sent;
+    this.account = account;
+    this.identityCommands = new SimSesIdentityCommands({
+      identities,
+      authorizer,
+      clock: background,
+    });
+    this.sendEmail = new SimSesSendEmail({
+      identities,
+      sent,
+      identityCheck: new SimSesVerifiedIdentityCheck({
+        identities,
+        account,
+        accountRegionScope,
+      }),
+      authorizer,
+      clock: background,
+    });
+    this.accountCommands = new SimSesAccountCommands({
+      account,
+      sent,
+      authorizer,
+      clock: background,
+    });
+  }
+}

--- a/src/service/ses/sim-ses-identities.iso.test.ts
+++ b/src/service/ses/sim-ses-identities.iso.test.ts
@@ -1,0 +1,276 @@
+import {
+  CreateEmailIdentityCommand,
+  DeleteEmailIdentityCommand,
+  GetEmailIdentityCommand,
+  ListEmailIdentitiesCommand,
+} from "@aws-sdk/client-sesv2";
+import {
+  assertArrayEquals,
+  assertArrayLength,
+  assertFalse,
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertThrowsErrorAsync,
+  assertTrue,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimFixedClock } from "../../util/clock/sim-clock.js";
+import type { SimAwsAccountId } from "../aws/sim-aws-account.js";
+import { SimAws } from "../aws/sim-aws.js";
+import { SimSesBadRequestException } from "./error/sim-ses.error.js";
+
+const accountIdTwoTwos = "222222222222" as SimAwsAccountId;
+const createdAt = new Date("2026-08-16T09:00:00.000Z");
+
+describe("SimSesV2 email identities", () => {
+  it("creates an address identity that is not yet verified", async () => {
+    // Given a simulated SES with a fixed clock.
+    const ses = new SimAws({ clock: new SimFixedClock(createdAt) }).sesV2();
+
+    // When an email address identity is created and read back.
+    const created = await ses.createEmailIdentity(
+      new CreateEmailIdentityCommand({ EmailIdentity: "hello@example.com" }),
+    );
+    const read = await ses.getEmailIdentity(
+      new GetEmailIdentityCommand({ EmailIdentity: "hello@example.com" }),
+    );
+
+    // Then it is an address identity still waiting on its verification, the
+    // way a real one waits on the link SES emails.
+    assertIdentical(created.IdentityType, "EMAIL_ADDRESS");
+    assertFalse(created.VerifiedForSendingStatus);
+    assertIdentical(read.VerificationStatus, "PENDING");
+    assertFalse(read.VerifiedForSendingStatus);
+  });
+
+  it("creates a domain identity from a name with no address in it", async () => {
+    // Given a simulated SES.
+    const ses = new SimAws().sesV2();
+
+    // When a domain is created as an identity.
+    const created = await ses.createEmailIdentity(
+      new CreateEmailIdentityCommand({ EmailIdentity: "example.com" }),
+    );
+
+    // Then SES took it as a domain, which it decides from the missing `@`
+    // rather than from a parameter saying so.
+    assertIdentical(created.IdentityType, "DOMAIN");
+  });
+
+  it("reports an identity as verified once the simulator verifies it", async () => {
+    // Given an identity waiting on its verification.
+    const ses = new SimAws().sesV2();
+
+    await ses.createEmailIdentity(
+      new CreateEmailIdentityCommand({ EmailIdentity: "hello@example.com" }),
+    );
+
+    // When the simulator stands in for the emailed link being clicked.
+    ses.verifyIdentity("hello@example.com");
+
+    const read = await ses.getEmailIdentity(
+      new GetEmailIdentityCommand({ EmailIdentity: "hello@example.com" }),
+    );
+
+    // Then SES reports it as verified and able to send.
+    assertIdentical(read.VerificationStatus, "SUCCESS");
+    assertTrue(read.VerifiedForSendingStatus);
+  });
+
+  it("verifies an identity that was never created", async () => {
+    // Given a simulated SES with nothing in it.
+    const ses = new SimAws().sesV2();
+
+    // When an identity is verified without being created first.
+    ses.verifyIdentity("hello@example.com");
+
+    // Then it is there and verified: setting up a mailbox in a test means
+    // both, and saying so twice buys nothing.
+    const read = await ses.getEmailIdentity(
+      new GetEmailIdentityCommand({ EmailIdentity: "hello@example.com" }),
+    );
+
+    assertTrue(read.VerifiedForSendingStatus);
+  });
+
+  it("puts a verified identity back to pending", () => {
+    // Given a verified identity.
+    const ses = new SimAws().sesV2();
+    const identity = ses.verifyIdentity("example.com");
+
+    // When whatever proved it stops holding.
+    identity.unverify();
+
+    // Then it is pending again, as a real one is when its records stop
+    // resolving.
+    assertIdentical(identity.verificationStatus, "PENDING");
+    assertFalse(identity.isVerified);
+  });
+
+  it("matches a domain identity without regard to case", async () => {
+    // Given a domain identity created in mixed case.
+    const ses = new SimAws().sesV2();
+
+    await ses.createEmailIdentity(
+      new CreateEmailIdentityCommand({ EmailIdentity: "Example.COM" }),
+    );
+
+    // When it is read back in another case.
+    const read = await ses.getEmailIdentity(
+      new GetEmailIdentityCommand({ EmailIdentity: "example.com" }),
+    );
+
+    // Then it is the same identity: domains are case insensitive.
+    assertIdentical(read.IdentityType, "DOMAIN");
+  });
+
+  it("keeps two addresses whose local parts differ only in case apart", async () => {
+    // Given an address identity.
+    const ses = new SimAws().sesV2();
+
+    await ses.createEmailIdentity(
+      new CreateEmailIdentityCommand({ EmailIdentity: "Sales@example.com" }),
+    );
+
+    // When one differing only in the case of its local part is created.
+    await ses.createEmailIdentity(
+      new CreateEmailIdentityCommand({ EmailIdentity: "sales@example.com" }),
+    );
+
+    // Then both are there. The local part of an address is case sensitive per
+    // RFC 5321, so these are two mailboxes in principle.
+    assertArrayLength(ses.allIdentities(), 2);
+  });
+
+  it("names an identity by the account and region it is in", async () => {
+    // Given an identity in one account and region.
+    const ses = new SimAws()
+      .accountRegionScope(accountIdTwoTwos, "us-east-1")
+      .sesV2();
+
+    await ses.createEmailIdentity(
+      new CreateEmailIdentityCommand({ EmailIdentity: "example.com" }),
+    );
+
+    // When its ARN is read.
+    const identity = ses.findIdentity("example.com");
+
+    // Then the ARN names that account and region.
+    assertNonNullable(identity);
+    assertIdentical(
+      identity.arn,
+      "arn:aws:ses:us-east-1:222222222222:identity/example.com",
+    );
+  });
+
+  it("verifies an identity in one region and not in another", () => {
+    // Given an identity verified in one region.
+    const simAws = new SimAws();
+
+    simAws
+      .accountRegionScope(simAws.defaultAccountId, "us-east-1")
+      .sesV2()
+      .verifyIdentity("example.com");
+
+    // When another region is asked for it.
+    const elsewhere = simAws
+      .accountRegionScope(simAws.defaultAccountId, "eu-west-2")
+      .sesV2()
+      .findIdentity("example.com");
+
+    // Then it is not there. Verifying in one region verifies nothing in
+    // another, on real SES as here.
+    assertUndefined(elsewhere);
+  });
+
+  it("lists identities in the order they were created", async () => {
+    // Given three identities.
+    const ses = new SimAws().sesV2();
+
+    ses.verifyIdentity("example.com");
+    ses.verifyIdentity("hello@example.com");
+    await ses.createEmailIdentity(
+      new CreateEmailIdentityCommand({ EmailIdentity: "example.org" }),
+    );
+
+    // When they are listed.
+    const listed = await ses.listEmailIdentities(
+      new ListEmailIdentitiesCommand({}),
+    );
+
+    // Then each is reported with whether it may send, in creation order.
+    assertNonNullable(listed.EmailIdentities);
+    assertArrayEquals(
+      listed.EmailIdentities.map((identity) => identity.IdentityName),
+      ["example.com", "hello@example.com", "example.org"],
+    );
+    assertArrayEquals(
+      listed.EmailIdentities.map((identity) => identity.SendingEnabled),
+      [true, true, false],
+    );
+  });
+
+  it("pages a listing of identities", async () => {
+    // Given more identities than one page holds.
+    const ses = new SimAws().sesV2();
+
+    ses.verifyIdentity("one.example.com");
+    ses.verifyIdentity("two.example.com");
+    ses.verifyIdentity("three.example.com");
+
+    // When they are read a page at a time.
+    const first = await ses.listEmailIdentities(
+      new ListEmailIdentitiesCommand({ PageSize: 2 }),
+    );
+    const second = await ses.listEmailIdentities(
+      new ListEmailIdentitiesCommand({
+        PageSize: 2,
+        NextToken: first.NextToken,
+      }),
+    );
+
+    // Then the token from the first page reaches the rest, and the last page
+    // offers none.
+    assertArrayLength(first.EmailIdentities ?? [], 2);
+    assertArrayEquals(
+      second.EmailIdentities?.map((identity) => identity.IdentityName),
+      ["three.example.com"],
+    );
+    assertUndefined(second.NextToken);
+  });
+
+  it("refuses a listing token this simulation did not issue", async () => {
+    // Given a simulated SES with one identity.
+    const ses = new SimAws().sesV2();
+
+    ses.verifyIdentity("example.com");
+
+    // When a listing is asked for with a token from somewhere else.
+    const error = await assertThrowsErrorAsync(async () => {
+      await ses.listEmailIdentities(
+        new ListEmailIdentitiesCommand({ NextToken: "not-a-token" }),
+      );
+    });
+
+    // Then it is refused rather than quietly starting again at the beginning.
+    assertInstanceOf(error, SimSesBadRequestException);
+  });
+
+  it("deletes an identity", async () => {
+    // Given an identity.
+    const ses = new SimAws().sesV2();
+
+    ses.verifyIdentity("hello@example.com");
+
+    // When it is deleted.
+    await ses.deleteEmailIdentity(
+      new DeleteEmailIdentityCommand({ EmailIdentity: "hello@example.com" }),
+    );
+
+    // Then it is gone.
+    assertArrayLength(ses.allIdentities(), 0);
+  });
+});

--- a/src/service/ses/sim-ses-identity-refusals.iso.test.ts
+++ b/src/service/ses/sim-ses-identity-refusals.iso.test.ts
@@ -4,7 +4,11 @@ import {
   GetEmailIdentityCommand,
   ListEmailIdentitiesCommand,
 } from "@aws-sdk/client-sesv2";
-import { assertInstanceOf, assertThrowsErrorAsync } from "@kensio/smartass";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
 import { describe, it } from "vitest";
 
 import { SimAws } from "../aws/sim-aws.js";
@@ -178,5 +182,21 @@ describe("SimSesV2 email identity refusals", () => {
     });
 
     assertInstanceOf(error, SimSesUnsupportedOperationException);
+  });
+
+  it("accepts an empty list of identity tags", async () => {
+    // Given a simulated SES.
+    const ses = new SimAws().sesV2();
+
+    // When an identity is created with a tag list with nothing in it.
+    const created = await ses.createEmailIdentity(
+      new CreateEmailIdentityCommand({
+        EmailIdentity: "example.com",
+        Tags: [],
+      }),
+    );
+
+    // Then it is accepted rather than refused for a feature it is not using.
+    assertIdentical(created.IdentityType, "DOMAIN");
   });
 });

--- a/src/service/ses/sim-ses-identity-refusals.iso.test.ts
+++ b/src/service/ses/sim-ses-identity-refusals.iso.test.ts
@@ -1,0 +1,182 @@
+import {
+  CreateEmailIdentityCommand,
+  DeleteEmailIdentityCommand,
+  GetEmailIdentityCommand,
+  ListEmailIdentitiesCommand,
+} from "@aws-sdk/client-sesv2";
+import { assertInstanceOf, assertThrowsErrorAsync } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../aws/sim-aws.js";
+import {
+  SimSesAlreadyExistsException,
+  SimSesBadRequestException,
+  SimSesNotFoundException,
+  SimSesUnsupportedOperationException,
+} from "./error/sim-ses.error.js";
+
+describe("SimSesV2 email identity refusals", () => {
+  it("refuses an identity that already exists", async () => {
+    // Given an identity that has been created.
+    const ses = new SimAws().sesV2();
+    const command = new CreateEmailIdentityCommand({
+      EmailIdentity: "hello@example.com",
+    });
+
+    await ses.createEmailIdentity(command);
+
+    // When the same one is created again.
+    const error = await assertThrowsErrorAsync(async () => {
+      await ses.createEmailIdentity(command);
+    });
+
+    // Then it fails, as creation is not idempotent on real SES.
+    assertInstanceOf(error, SimSesAlreadyExistsException);
+  });
+
+  it("refuses reading an identity that is not there", async () => {
+    // Given a simulated SES with nothing in it.
+    const ses = new SimAws().sesV2();
+
+    // When an identity nobody created is read.
+    const error = await assertThrowsErrorAsync(async () => {
+      await ses.getEmailIdentity(
+        new GetEmailIdentityCommand({ EmailIdentity: "hello@example.com" }),
+      );
+    });
+
+    // Then it is a NotFoundException, as it is on real SES.
+    assertInstanceOf(error, SimSesNotFoundException);
+  });
+
+  it("refuses deleting an identity that is not there", async () => {
+    // Given a simulated SES with nothing in it.
+    const ses = new SimAws().sesV2();
+
+    // When an identity nobody created is deleted.
+    const error = await assertThrowsErrorAsync(async () => {
+      await ses.deleteEmailIdentity(
+        new DeleteEmailIdentityCommand({ EmailIdentity: "example.com" }),
+      );
+    });
+
+    assertInstanceOf(error, SimSesNotFoundException);
+  });
+
+  it("refuses a name that is neither an address nor a domain", async () => {
+    // Given a simulated SES.
+    const ses = new SimAws().sesV2();
+
+    // When something that is neither is offered as an identity.
+    const error = await assertThrowsErrorAsync(async () => {
+      await ses.createEmailIdentity(
+        new CreateEmailIdentityCommand({ EmailIdentity: "not an identity" }),
+      );
+    });
+
+    assertInstanceOf(error, SimSesBadRequestException);
+  });
+
+  it("refuses an identity name longer than SES accepts", async () => {
+    // Given a simulated SES.
+    const ses = new SimAws().sesV2();
+
+    // When an identity is created with a name past the length limit.
+    const error = await assertThrowsErrorAsync(async () => {
+      await ses.createEmailIdentity(
+        new CreateEmailIdentityCommand({
+          EmailIdentity: `${"a".repeat(320)}@example.com`,
+        }),
+      );
+    });
+
+    assertInstanceOf(error, SimSesBadRequestException);
+  });
+
+  it("refuses a page size the operation does not offer", async () => {
+    // Given a simulated SES with one identity.
+    const ses = new SimAws().sesV2();
+
+    ses.verifyIdentity("example.com");
+
+    // When a listing asks for more than one page holds.
+    const error = await assertThrowsErrorAsync(async () => {
+      await ses.listEmailIdentities(
+        new ListEmailIdentitiesCommand({ PageSize: 5000 }),
+      );
+    });
+
+    assertInstanceOf(error, SimSesBadRequestException);
+  });
+
+  it("refuses an identity with no name", async () => {
+    // Given a simulated SES.
+    const ses = new SimAws().sesV2();
+
+    // When an identity is created with nothing to identify.
+    const error = await assertThrowsErrorAsync(async () => {
+      await ses.createEmailIdentity(
+        new CreateEmailIdentityCommand({ EmailIdentity: "" }),
+      );
+    });
+
+    assertInstanceOf(error, SimSesBadRequestException);
+  });
+
+  it("refuses the identity inputs that are not simulated", async () => {
+    // Given a simulated SES.
+    const ses = new SimAws().sesV2();
+
+    // When an identity is created with DKIM signing attributes.
+    const error = await assertThrowsErrorAsync(async () => {
+      await ses.createEmailIdentity(
+        new CreateEmailIdentityCommand({
+          EmailIdentity: "example.com",
+          DkimSigningAttributes: { DomainSigningSelector: "s1" },
+        }),
+      );
+    });
+
+    // Then it is refused by name rather than accepted and dropped, since an
+    // identity that looks configured to the request that made it and
+    // unconfigured to everything else is worse than a failure.
+    assertInstanceOf(error, SimSesUnsupportedOperationException);
+  });
+
+  it("refuses identity tags, which are not simulated", async () => {
+    // Given a simulated SES.
+    const ses = new SimAws().sesV2();
+
+    // When an identity is created with tags.
+    const error = await assertThrowsErrorAsync(async () => {
+      await ses.createEmailIdentity(
+        new CreateEmailIdentityCommand({
+          EmailIdentity: "example.com",
+          Tags: [{ Key: "team", Value: "orders" }],
+        }),
+      );
+    });
+
+    // Then it is refused rather than accepted and dropped, since an identity
+    // that looks tagged to the request that made it and untagged to everything
+    // else is worse than a failure.
+    assertInstanceOf(error, SimSesUnsupportedOperationException);
+  });
+
+  it("refuses a configuration set on an identity", async () => {
+    // Given a simulated SES.
+    const ses = new SimAws().sesV2();
+
+    // When an identity is created naming a default configuration set.
+    const error = await assertThrowsErrorAsync(async () => {
+      await ses.createEmailIdentity(
+        new CreateEmailIdentityCommand({
+          EmailIdentity: "example.com",
+          ConfigurationSetName: "transactional",
+        }),
+      );
+    });
+
+    assertInstanceOf(error, SimSesUnsupportedOperationException);
+  });
+});

--- a/src/service/ses/sim-ses-sandbox.iso.test.ts
+++ b/src/service/ses/sim-ses-sandbox.iso.test.ts
@@ -1,0 +1,254 @@
+import {
+  PutAccountDetailsCommand,
+  SendEmailCommand,
+  type SendEmailCommandInput,
+} from "@aws-sdk/client-sesv2";
+import {
+  assertArrayLength,
+  assertFalse,
+  assertInstanceOf,
+  assertTrue,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../aws/sim-aws.js";
+import { SimSesMessageRejected } from "./error/sim-ses.error.js";
+import type { SimSesV2 } from "./sim-ses-v2.js";
+
+const welcome = {
+  FromEmailAddress: "hello@example.com",
+  Destination: { ToAddresses: ["someone@example.org"] },
+  Content: {
+    Simple: {
+      Subject: { Data: "Welcome" },
+      Body: { Text: { Data: "Hi there" } },
+    },
+  },
+} satisfies SendEmailCommandInput;
+
+/** Take a simulated SES out of the sandbox. */
+async function leaveTheSandbox(ses: SimSesV2): Promise<void> {
+  await ses.putAccountDetails(
+    new PutAccountDetailsCommand({
+      MailType: "TRANSACTIONAL",
+      WebsiteURL: "https://example.com",
+      ProductionAccessEnabled: true,
+    }),
+  );
+}
+
+describe("SimSesV2 verified identities and the sandbox", () => {
+  it("starts an account in the sandbox", () => {
+    // Given a simulated SES nobody has configured.
+    const ses = new SimAws().sesV2();
+
+    // Then it is in the sandbox, which is where every real account starts.
+    assertTrue(ses.isInSandbox());
+  });
+
+  it("refuses a send from an unverified sender", async () => {
+    // Given a simulated SES where nothing is verified.
+    const ses = new SimAws().sesV2();
+
+    // When a message is sent.
+    const error = await assertThrowsErrorAsync(async () => {
+      await ses.sendEmail(new SendEmailCommand(welcome));
+    });
+
+    // Then SES rejects it, naming the identity that failed the check the way
+    // real SES names it.
+    assertInstanceOf(error, SimSesMessageRejected);
+    assertStringIncludes(error.message, "Email address is not verified");
+    assertStringIncludes(error.message, "hello@example.com");
+    assertArrayLength(ses.sentEmails(), 0);
+  });
+
+  it("names the region in the way SES writes it", async () => {
+    // Given a simulated SES in one region with nothing verified.
+    const simAws = new SimAws();
+    const ses = simAws
+      .accountRegionScope(simAws.defaultAccountId, "us-east-1")
+      .sesV2();
+
+    // When a send is refused.
+    const error = await assertThrowsErrorAsync(async () => {
+      await ses.sendEmail(new SendEmailCommand(welcome));
+    });
+
+    // Then the region is upper case in the message, as SES writes it.
+    assertStringIncludes(error.message, "in region US-EAST-1");
+  });
+
+  it("refuses a send from an unverified sender out of the sandbox too", async () => {
+    // Given a simulated SES with production access and nothing verified.
+    const ses = new SimAws().sesV2();
+
+    await leaveTheSandbox(ses);
+
+    // When a message is sent.
+    const error = await assertThrowsErrorAsync(async () => {
+      await ses.sendEmail(new SendEmailCommand(welcome));
+    });
+
+    // Then it is still refused. Leaving the sandbox stops the recipients being
+    // checked; the sender is checked either way.
+    assertInstanceOf(error, SimSesMessageRejected);
+    assertStringIncludes(error.message, "hello@example.com");
+  });
+
+  it("refuses a send to an unverified recipient in the sandbox", async () => {
+    // Given a sandbox account with the sender verified and the recipient not.
+    const ses = new SimAws().sesV2();
+
+    ses.verifyIdentity("hello@example.com");
+
+    // When a message is sent.
+    const error = await assertThrowsErrorAsync(async () => {
+      await ses.sendEmail(new SendEmailCommand(welcome));
+    });
+
+    // Then the recipient is what failed the check, which is the rule the
+    // sandbox exists for.
+    assertInstanceOf(error, SimSesMessageRejected);
+    assertStringIncludes(error.message, "someone@example.org");
+  });
+
+  it("accepts a send to an unverified recipient once production access is on", async () => {
+    // Given the same account with the sender verified.
+    const ses = new SimAws().sesV2();
+
+    ses.verifyIdentity("hello@example.com");
+
+    // When it leaves the sandbox and sends the same message.
+    await leaveTheSandbox(ses);
+    await ses.sendEmail(new SendEmailCommand(welcome));
+
+    // Then the message is accepted: outside the sandbox only the sender is
+    // checked.
+    assertArrayLength(ses.sentEmails(), 1);
+    assertFalse(ses.isInSandbox());
+  });
+
+  it("accepts a send in the sandbox when both ends are verified", async () => {
+    // Given a sandbox account with sender and recipient both verified.
+    const ses = new SimAws().sesV2();
+
+    ses.verifyIdentity("hello@example.com");
+    ses.verifyIdentity("someone@example.org");
+
+    // When a message is sent.
+    await ses.sendEmail(new SendEmailCommand(welcome));
+
+    // Then it is accepted.
+    assertArrayLength(ses.sentEmails(), 1);
+  });
+
+  it("covers every address at a verified domain", async () => {
+    // Given a verified domain rather than verified addresses.
+    const ses = new SimAws().sesV2();
+
+    ses.verifyIdentity("example.com");
+    ses.verifyIdentity("example.org");
+
+    // When a message goes from one address at it to another domain's.
+    await ses.sendEmail(
+      new SendEmailCommand({
+        ...welcome,
+        FromEmailAddress: "anything@example.com",
+        Destination: { ToAddresses: ["whoever@example.org"] },
+      }),
+    );
+
+    // Then both passed the check without an address identity of their own,
+    // which is what domain identities are for.
+    assertArrayLength(ses.sentEmails(), 1);
+  });
+
+  it("does not cover a subdomain with its parent domain", async () => {
+    // Given a verified parent domain.
+    const ses = new SimAws().sesV2();
+
+    ses.verifyIdentity("example.com");
+
+    // When a message is sent from an address at a subdomain of it.
+    const error = await assertThrowsErrorAsync(async () => {
+      await ses.sendEmail(
+        new SendEmailCommand({
+          ...welcome,
+          FromEmailAddress: "orders@mail.example.com",
+        }),
+      );
+    });
+
+    // Then it is refused, as it is on real SES: a subdomain is its own
+    // identity.
+    assertInstanceOf(error, SimSesMessageRejected);
+    assertStringIncludes(error.message, "orders@mail.example.com");
+  });
+
+  it("matches a verified domain without regard to case", async () => {
+    // Given a domain verified in lower case.
+    const ses = new SimAws().sesV2();
+
+    ses.verifyIdentity("example.com");
+
+    // When a message is sent from an address spelling it differently.
+    await ses.sendEmail(
+      new SendEmailCommand({
+        ...welcome,
+        FromEmailAddress: "hello@EXAMPLE.com",
+        Destination: { ToAddresses: ["someone@Example.COM"] },
+      }),
+    );
+
+    // Then both passed: a domain is case insensitive.
+    assertArrayLength(ses.sentEmails(), 1);
+  });
+
+  it("names every identity that failed the check at once", async () => {
+    // Given a sandbox account with nothing verified and two recipients.
+    const ses = new SimAws().sesV2();
+
+    // When a message is sent.
+    const error = await assertThrowsErrorAsync(async () => {
+      await ses.sendEmail(
+        new SendEmailCommand({
+          ...welcome,
+          Destination: {
+            ToAddresses: ["someone@example.org"],
+            CcAddresses: ["copied@example.org"],
+          },
+        }),
+      );
+    });
+
+    // Then the message names all three, so a caller finds out everything it
+    // has to verify from one failure rather than three.
+    assertStringIncludes(error.message, "hello@example.com");
+    assertStringIncludes(error.message, "someone@example.org");
+    assertStringIncludes(error.message, "copied@example.org");
+  });
+
+  it("refuses a send once a verified identity stops holding", async () => {
+    // Given an account that has sent successfully.
+    const ses = new SimAws().sesV2();
+    const sender = ses.verifyIdentity("hello@example.com");
+
+    ses.verifyIdentity("someone@example.org");
+    await ses.sendEmail(new SendEmailCommand(welcome));
+
+    // When the sender's verification stops holding.
+    sender.unverify();
+
+    // Then the next send is refused, as it would be when the records proving
+    // an identity stop resolving.
+    const error = await assertThrowsErrorAsync(async () => {
+      await ses.sendEmail(new SendEmailCommand(welcome));
+    });
+
+    assertInstanceOf(error, SimSesMessageRejected);
+    assertArrayLength(ses.sentEmails(), 1);
+  });
+});

--- a/src/service/ses/sim-ses-send-email.iso.test.ts
+++ b/src/service/ses/sim-ses-send-email.iso.test.ts
@@ -1,0 +1,245 @@
+import {
+  PutAccountDetailsCommand,
+  SendEmailCommand,
+  type SendEmailCommandInput,
+} from "@aws-sdk/client-sesv2";
+import {
+  assertArrayEquals,
+  assertArrayLength,
+  assertFalse,
+  assertIdentical,
+  assertNonNullable,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimFixedClock } from "../../util/clock/sim-clock.js";
+import { SimAws } from "../aws/sim-aws.js";
+import type { SimSesV2 } from "./sim-ses-v2.js";
+
+const sentAt = new Date("2026-08-16T09:00:00.000Z");
+
+/**
+ * A simulated SES out of the sandbox, with the sender verified, so a test can
+ * be about the message rather than about the identity checks.
+ */
+function sendingSes(clock?: SimFixedClock): SimSesV2 {
+  const ses = new SimAws(clock === undefined ? {} : { clock }).sesV2();
+
+  ses.verifyIdentity("hello@example.com");
+
+  return ses;
+}
+
+/** The smallest send that SES would accept. */
+const welcome = {
+  FromEmailAddress: "hello@example.com",
+  Destination: { ToAddresses: ["someone@example.org"] },
+  Content: {
+    Simple: {
+      Subject: { Data: "Welcome" },
+      Body: { Text: { Data: "Hi there" } },
+    },
+  },
+} satisfies SendEmailCommandInput;
+
+describe("SimSesV2 SendEmail", () => {
+  it("records a message rather than delivering it", async () => {
+    // Given a simulated SES with a verified sender and a fixed clock.
+    const ses = sendingSes(new SimFixedClock(sentAt));
+
+    ses.verifyIdentity("someone@example.org");
+
+    // When a message is sent.
+    const sent = await ses.sendEmail(new SendEmailCommand(welcome));
+
+    // Then SES answered with a message id, and kept what it would have sent.
+    const [email] = ses.sentEmails();
+
+    assertNonNullable(email);
+    assertIdentical(email.messageId, sent.MessageId);
+    assertIdentical(email.fromEmailAddress, "hello@example.com");
+    assertArrayEquals(email.destination.toAddresses, ["someone@example.org"]);
+    assertIdentical(email.subject, "Welcome");
+    assertIdentical(email.body.text, "Hi there");
+    assertIdentical(email.sentDate.getTime(), sentAt.getTime());
+  });
+
+  it("keeps the to, cc and bcc lists apart", async () => {
+    // Given a simulated SES out of the sandbox, where recipients need no
+    // identity of their own.
+    const ses = sendingSes();
+
+    await leaveTheSandbox(ses);
+
+    // When a message goes to all three kinds of recipient.
+    await ses.sendEmail(
+      new SendEmailCommand({
+        ...welcome,
+        Destination: {
+          ToAddresses: ["someone@example.org"],
+          CcAddresses: ["copied@example.org"],
+          BccAddresses: ["hidden@example.org"],
+        },
+      }),
+    );
+
+    // Then the record keeps them apart, so a test asserting a bcc was a bcc
+    // still can, and `recipients` gathers all three.
+    const [email] = ses.sentEmails();
+
+    assertNonNullable(email);
+    assertArrayEquals(email.destination.ccAddresses, ["copied@example.org"]);
+    assertArrayEquals(email.destination.bccAddresses, ["hidden@example.org"]);
+    assertArrayLength(email.recipients, 3);
+  });
+
+  it("records an HTML body and reports no text for it", async () => {
+    // Given a simulated SES out of the sandbox.
+    const ses = sendingSes();
+
+    await leaveTheSandbox(ses);
+
+    // When a message is sent with only an HTML body.
+    await ses.sendEmail(
+      new SendEmailCommand({
+        ...welcome,
+        Content: {
+          Simple: {
+            Subject: { Data: "Welcome" },
+            Body: { Html: { Data: "<p>Hi there</p>" } },
+          },
+        },
+      }),
+    );
+
+    // Then a test asserting on the text finds nothing rather than the markup.
+    const [email] = ses.sentEmails();
+
+    assertNonNullable(email);
+    assertIdentical(email.body.html, "<p>Hi there</p>");
+    assertUndefined(email.body.text);
+  });
+
+  it("records the reply-to addresses and the configuration set name", async () => {
+    // Given a simulated SES out of the sandbox.
+    const ses = sendingSes();
+
+    await leaveTheSandbox(ses);
+
+    // When a message names both.
+    await ses.sendEmail(
+      new SendEmailCommand({
+        ...welcome,
+        ReplyToAddresses: ["support@example.com"],
+        ConfigurationSetName: "transactional",
+      }),
+    );
+
+    // Then both are kept. A configuration set does nothing here, but the name
+    // is worth keeping so a test can assert the right one was used.
+    const [email] = ses.sentEmails();
+
+    assertNonNullable(email);
+    assertArrayEquals(email.replyToAddresses, ["support@example.com"]);
+    assertIdentical(email.configurationSetName, "transactional");
+  });
+
+  it("sends from an address written with a display name", async () => {
+    // Given a simulated SES out of the sandbox with the address verified.
+    const ses = sendingSes();
+
+    await leaveTheSandbox(ses);
+
+    // When the From value carries a display name around the address.
+    await ses.sendEmail(
+      new SendEmailCommand({
+        ...welcome,
+        FromEmailAddress: "Orders <hello@example.com>",
+      }),
+    );
+
+    // Then the identity check read the address out of it, and the record kept
+    // the value as it was given.
+    const [email] = ses.sentEmails();
+
+    assertNonNullable(email);
+    assertIdentical(email.fromEmailAddress, "Orders <hello@example.com>");
+  });
+
+  it("keeps sends in the order they were made", async () => {
+    // Given a simulated SES out of the sandbox.
+    const ses = sendingSes();
+
+    await leaveTheSandbox(ses);
+
+    // When two messages are sent.
+    await ses.sendEmail(new SendEmailCommand(welcome));
+    await ses.sendEmail(
+      new SendEmailCommand({
+        ...welcome,
+        Content: {
+          Simple: {
+            Subject: { Data: "Your order" },
+            Body: { Text: { Data: "On its way" } },
+          },
+        },
+      }),
+    );
+
+    // Then the first message of the flow is the first one read back, which is
+    // the assertion a test usually wants.
+    assertArrayEquals(
+      ses.sentEmails().map((email) => email.subject),
+      ["Welcome", "Your order"],
+    );
+  });
+
+  it("gives each message its own id", async () => {
+    // Given a simulated SES out of the sandbox.
+    const ses = sendingSes();
+
+    await leaveTheSandbox(ses);
+
+    // When the same message is sent twice.
+    const first = await ses.sendEmail(new SendEmailCommand(welcome));
+    const second = await ses.sendEmail(new SendEmailCommand(welcome));
+
+    // Then the two are told apart by their ids, as they would be on AWS.
+    assertNonNullable(first.MessageId);
+    assertFalse(first.MessageId === second.MessageId);
+  });
+
+  it("records nothing when a send is refused", async () => {
+    // Given a simulated SES out of the sandbox.
+    const ses = sendingSes();
+
+    await leaveTheSandbox(ses);
+
+    // When a send fails.
+    await assertThrowsErrorAsync(async () => {
+      await ses.sendEmail(
+        new SendEmailCommand({ ...welcome, Destination: {} }),
+      );
+    });
+
+    // Then nothing was recorded, so a test asserting no message went out is
+    // not fooled by one SES never accepted.
+    assertArrayLength(ses.sentEmails(), 0);
+  });
+});
+
+/**
+ * Take a simulated SES out of the sandbox, so a send is checked against its
+ * sender alone.
+ */
+async function leaveTheSandbox(ses: SimSesV2): Promise<void> {
+  await ses.putAccountDetails(
+    new PutAccountDetailsCommand({
+      MailType: "TRANSACTIONAL",
+      WebsiteURL: "https://example.com",
+      ProductionAccessEnabled: true,
+    }),
+  );
+}

--- a/src/service/ses/sim-ses-send-email.iso.test.ts
+++ b/src/service/ses/sim-ses-send-email.iso.test.ts
@@ -21,8 +21,8 @@ import type { SimSesV2 } from "./sim-ses-v2.js";
 const sentAt = new Date("2026-08-16T09:00:00.000Z");
 
 /**
- * A simulated SES out of the sandbox, with the sender verified, so a test can
- * be about the message rather than about the identity checks.
+ * A simulated SES with the sender verified. Still in the sandbox, so a test
+ * using it either verifies its recipients too or calls `leaveTheSandbox`.
  */
 function sendingSes(clock?: SimFixedClock): SimSesV2 {
   const ses = new SimAws(clock === undefined ? {} : { clock }).sesV2();

--- a/src/service/ses/sim-ses-send-refusals.iso.test.ts
+++ b/src/service/ses/sim-ses-send-refusals.iso.test.ts
@@ -1,0 +1,246 @@
+import {
+  PutAccountDetailsCommand,
+  SendEmailCommand,
+  type SendEmailCommandInput,
+} from "@aws-sdk/client-sesv2";
+import {
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../aws/sim-aws.js";
+import {
+  SimSesBadRequestException,
+  SimSesUnsupportedOperationException,
+} from "./error/sim-ses.error.js";
+import type { SimSesV2 } from "./sim-ses-v2.js";
+
+/** The smallest send that SES would accept. */
+const welcome = {
+  FromEmailAddress: "hello@example.com",
+  Destination: { ToAddresses: ["someone@example.org"] },
+  Content: {
+    Simple: {
+      Subject: { Data: "Welcome" },
+      Body: { Text: { Data: "Hi there" } },
+    },
+  },
+} satisfies SendEmailCommandInput;
+
+/**
+ * A simulated SES out of the sandbox with the sender verified, so what a test
+ * here sees refused is the input rather than an identity check.
+ */
+async function sendingSes(): Promise<SimSesV2> {
+  const ses = new SimAws().sesV2();
+
+  ses.verifyIdentity("hello@example.com");
+
+  await ses.putAccountDetails(
+    new PutAccountDetailsCommand({
+      MailType: "TRANSACTIONAL",
+      WebsiteURL: "https://example.com",
+      ProductionAccessEnabled: true,
+    }),
+  );
+
+  return ses;
+}
+
+describe("SimSesV2 SendEmail refusals", () => {
+  it("refuses a send with no recipients", async () => {
+    // Given a simulated SES that would otherwise accept the message.
+    const ses = await sendingSes();
+
+    // When a message is sent to nobody.
+    const error = await assertThrowsErrorAsync(async () => {
+      await ses.sendEmail(
+        new SendEmailCommand({ ...welcome, Destination: {} }),
+      );
+    });
+
+    assertInstanceOf(error, SimSesBadRequestException);
+  });
+
+  it("refuses a send with no From address", async () => {
+    // Given a simulated SES that would otherwise accept the message.
+    const ses = await sendingSes();
+
+    // When a message is sent without saying who it is from.
+    const error = await assertThrowsErrorAsync(async () => {
+      await ses.sendEmail(
+        new SendEmailCommand({ ...welcome, FromEmailAddress: undefined }),
+      );
+    });
+
+    assertInstanceOf(error, SimSesBadRequestException);
+    assertStringIncludes(error.message, "From");
+  });
+
+  it("refuses a message with neither a text nor an HTML body", async () => {
+    // Given a simulated SES that would otherwise accept the message.
+    const ses = await sendingSes();
+
+    // When a message is sent with a subject and nothing else.
+    const error = await assertThrowsErrorAsync(async () => {
+      await ses.sendEmail(
+        new SendEmailCommand({
+          ...welcome,
+          Content: { Simple: { Subject: { Data: "Welcome" }, Body: {} } },
+        }),
+      );
+    });
+
+    assertInstanceOf(error, SimSesBadRequestException);
+  });
+
+  it("refuses a send with no content at all", async () => {
+    // Given a simulated SES that would otherwise accept the message.
+    const ses = await sendingSes();
+
+    // When a message is sent with nothing to say.
+    const error = await assertThrowsErrorAsync(async () => {
+      await ses.sendEmail(
+        new SendEmailCommand({ ...welcome, Content: undefined }),
+      );
+    });
+
+    assertInstanceOf(error, SimSesBadRequestException);
+  });
+
+  it("refuses content naming none of the three branches", async () => {
+    // Given a simulated SES that would otherwise accept the message.
+    const ses = await sendingSes();
+
+    // When content is given with neither Simple, Raw nor Template in it.
+    const error = await assertThrowsErrorAsync(async () => {
+      await ses.sendEmail(new SendEmailCommand({ ...welcome, Content: {} }));
+    });
+
+    assertInstanceOf(error, SimSesBadRequestException);
+  });
+
+  it("refuses raw MIME content by name", async () => {
+    // Given a simulated SES that would otherwise accept the message.
+    const ses = await sendingSes();
+
+    // When a message is sent as raw MIME.
+    const error = await assertThrowsErrorAsync(async () => {
+      await ses.sendEmail(
+        new SendEmailCommand({
+          ...welcome,
+          Content: { Raw: { Data: new TextEncoder().encode("From: a@b.com") } },
+        }),
+      );
+    });
+
+    // Then it says which branch it was rather than recording a message it has
+    // not read.
+    assertInstanceOf(error, SimSesUnsupportedOperationException);
+    assertStringIncludes(error.message, "Content.Raw");
+  });
+
+  it("refuses template content by name", async () => {
+    // Given a simulated SES that would otherwise accept the message.
+    const ses = await sendingSes();
+
+    // When a message is sent from a template.
+    const error = await assertThrowsErrorAsync(async () => {
+      await ses.sendEmail(
+        new SendEmailCommand({
+          ...welcome,
+          Content: {
+            Template: {
+              TemplateName: "welcome",
+              TemplateData: '{"name":"Ada"}',
+            },
+          },
+        }),
+      );
+    });
+
+    assertInstanceOf(error, SimSesUnsupportedOperationException);
+    assertStringIncludes(error.message, "Content.Template");
+  });
+
+  it("refuses a message with attachments", async () => {
+    // Given a simulated SES that would otherwise accept the message.
+    const ses = await sendingSes();
+
+    // When a message carries an attachment.
+    const error = await assertThrowsErrorAsync(async () => {
+      await ses.sendEmail(
+        new SendEmailCommand({
+          ...welcome,
+          Content: {
+            Simple: {
+              Subject: { Data: "Welcome" },
+              Body: { Text: { Data: "Hi there" } },
+              Attachments: [
+                { FileName: "terms.pdf", RawContent: new Uint8Array([1]) },
+              ],
+            },
+          },
+        }),
+      );
+    });
+
+    assertInstanceOf(error, SimSesUnsupportedOperationException);
+  });
+
+  it("refuses message tags, which are not simulated", async () => {
+    // Given a simulated SES that would otherwise accept the message.
+    const ses = await sendingSes();
+
+    // When a message carries message tags.
+    const error = await assertThrowsErrorAsync(async () => {
+      await ses.sendEmail(
+        new SendEmailCommand({
+          ...welcome,
+          EmailTags: [{ Name: "campaign", Value: "welcome" }],
+        }),
+      );
+    });
+
+    assertInstanceOf(error, SimSesUnsupportedOperationException);
+  });
+
+  it("refuses sending authorization by another identity's ARN", async () => {
+    // Given a simulated SES that would otherwise accept the message.
+    const ses = await sendingSes();
+
+    // When a send asks to act under another identity's sending policy.
+    const error = await assertThrowsErrorAsync(async () => {
+      await ses.sendEmail(
+        new SendEmailCommand({
+          ...welcome,
+          FromEmailAddressIdentityArn:
+            "arn:aws:ses:us-east-1:222222222222:identity/example.com",
+        }),
+      );
+    });
+
+    // Then it is refused rather than sending as an identity whose policy this
+    // simulator has not read.
+    assertInstanceOf(error, SimSesUnsupportedOperationException);
+  });
+
+  it("refuses a send managed by a contact list", async () => {
+    // Given a simulated SES that would otherwise accept the message.
+    const ses = await sendingSes();
+
+    // When a send carries list management options.
+    const error = await assertThrowsErrorAsync(async () => {
+      await ses.sendEmail(
+        new SendEmailCommand({
+          ...welcome,
+          ListManagementOptions: { ContactListName: "subscribers" },
+        }),
+      );
+    });
+
+    assertInstanceOf(error, SimSesUnsupportedOperationException);
+  });
+});

--- a/src/service/ses/sim-ses-send-refusals.iso.test.ts
+++ b/src/service/ses/sim-ses-send-refusals.iso.test.ts
@@ -4,6 +4,7 @@ import {
   type SendEmailCommandInput,
 } from "@aws-sdk/client-sesv2";
 import {
+  assertArrayLength,
   assertInstanceOf,
   assertStringIncludes,
   assertThrowsErrorAsync,
@@ -242,5 +243,35 @@ describe("SimSesV2 SendEmail refusals", () => {
     });
 
     assertInstanceOf(error, SimSesUnsupportedOperationException);
+  });
+
+  it("refuses a message with no subject", async () => {
+    // Given a simulated SES that would otherwise accept the message.
+    const ses = await sendingSes();
+
+    // When a message is sent with a body and no subject.
+    const error = await assertThrowsErrorAsync(async () => {
+      await ses.sendEmail(
+        new SendEmailCommand({
+          ...welcome,
+          Content: { Simple: { Body: { Text: { Data: "Hi there" } } } },
+        } as SendEmailCommandInput),
+      );
+    });
+
+    // Then it is refused: SES marks the subject of a simple message required.
+    assertInstanceOf(error, SimSesBadRequestException);
+  });
+
+  it("accepts an empty list of message tags", async () => {
+    // Given a simulated SES that would otherwise accept the message.
+    const ses = await sendingSes();
+
+    // When a send carries a tag list with nothing in it, as code that always
+    // passes its tags does when there are none.
+    await ses.sendEmail(new SendEmailCommand({ ...welcome, EmailTags: [] }));
+
+    // Then it is accepted rather than refused for a feature it is not using.
+    assertArrayLength(ses.sentEmails(), 1);
   });
 });

--- a/src/service/ses/sim-ses-v2.ts
+++ b/src/service/ses/sim-ses-v2.ts
@@ -1,0 +1,192 @@
+import type { SimSdkCommandRouter } from "../../sdk/router/sim-sdk-command-router.type.js";
+import type * as simSesCommands from "./command/sim-ses-command.types.js";
+import type { SimSesRequestOptions } from "./command/sim-ses-request-options.js";
+import type { SimSesSentEmail } from "./email/sim-ses-sent-email.js";
+import type { SimSesIdentity } from "./identity/sim-ses-identity.js";
+import { SimSesSdkCommandRouter } from "./sdk/sim-ses-sdk-command-router.js";
+import { SimSesCommands, type SimSesV2Properties } from "./sim-ses-commands.js";
+
+/**
+ * Simulated Amazon SES, through its v2 API. Handles SDK commands. Emulates AWS
+ * behaviour and state.
+ *
+ * The class is named for the API rather than the service, as simulated ELBv2
+ * and API Gateway v2 are, because the v2 API is what it answers: SES has an
+ * older API over the same identities and the same account, and if that is ever
+ * simulated it belongs beside this in the same directory rather than replacing
+ * it.
+ *
+ * There is nothing to deliver. A message SES accepts leaves AWS for a mail
+ * system, so what a simulator can usefully hold is the decision of whether SES
+ * would have accepted it and a record of what it would have sent. That record
+ * is what `sentEmails` reads, and it is the point of the whole service: a test
+ * can assert that signing someone up produced a welcome message addressed to
+ * them.
+ *
+ * Identities and sends are region scoped, as they are on real SES: verifying
+ * an address in one region verifies nothing in another, and a message sent
+ * through one region is invisible from the next.
+ */
+export class SimSesV2 {
+  readonly #commands: SimSesCommands;
+  readonly #sdkRouter = new SimSesSdkCommandRouter(this);
+
+  constructor(properties: SimSesV2Properties = {}) {
+    this.#commands = new SimSesCommands(properties);
+  }
+
+  /**
+   * Every message this scope has accepted, oldest first.
+   *
+   * This is the simulator's own accessor rather than an SES operation. A real
+   * account keeps no such record, which is exactly why a test needs one.
+   */
+  sentEmails(): readonly SimSesSentEmail[] {
+    return this.#commands.sent.all;
+  }
+
+  /**
+   * Find an identity by the address or domain it names.
+   *
+   * The simulator's own accessor, for tests inspecting identity state without
+   * going through a Command and its authorization.
+   */
+  findIdentity(emailIdentity: string): SimSesIdentity | undefined {
+    return this.#commands.identities.find(emailIdentity);
+  }
+
+  /**
+   * Every identity in this scope, in the order they were created.
+   */
+  allIdentities(): readonly SimSesIdentity[] {
+    return this.#commands.identities.all;
+  }
+
+  /**
+   * Treat an identity as having completed verification, creating it if it is
+   * not there.
+   *
+   * This is a deliberate divergence from AWS, and the only way an identity
+   * becomes verified here. Real SES verifies an address by emailing it a link
+   * and a domain by looking for DNS records, neither of which can happen
+   * inside a test process, so the act of proving ownership is the simulator's
+   * to perform rather than an API operation to call.
+   *
+   * Creating a missing identity is the convenience part: verifying is what a
+   * test setting up a mailbox actually means, and making it say so in two
+   * calls buys nothing.
+   */
+  verifyIdentity(emailIdentity: string): SimSesIdentity {
+    const identity =
+      this.#commands.identities.find(emailIdentity) ??
+      this.#commands.identities.create(
+        emailIdentity,
+        this.#commands.background.now(),
+      );
+
+    identity.verify();
+
+    return identity;
+  }
+
+  /**
+   * Whether this account is still in the SES sandbox, where every recipient
+   * has to be verified as well as the sender.
+   */
+  isInSandbox(): boolean {
+    return this.#commands.account.isInSandbox;
+  }
+
+  /**
+   * Handle a CreateEmailIdentity Command from the SDK.
+   */
+  async createEmailIdentity(
+    command: simSesCommands.SimCreateEmailIdentityCommand,
+    options?: SimSesRequestOptions,
+  ): Promise<simSesCommands.SimCreateEmailIdentityCommandOutput> {
+    await this.#commands.background.sequence();
+    return this.#commands.identityCommands.createEmailIdentity(
+      command,
+      options,
+    );
+  }
+
+  /**
+   * Handle a GetEmailIdentity Command from the SDK.
+   */
+  async getEmailIdentity(
+    command: simSesCommands.SimGetEmailIdentityCommand,
+    options?: SimSesRequestOptions,
+  ): Promise<simSesCommands.SimGetEmailIdentityCommandOutput> {
+    await this.#commands.background.sequence();
+    return this.#commands.identityCommands.getEmailIdentity(command, options);
+  }
+
+  /**
+   * Handle a ListEmailIdentities Command from the SDK.
+   */
+  async listEmailIdentities(
+    command: simSesCommands.SimListEmailIdentitiesCommand,
+    options?: SimSesRequestOptions,
+  ): Promise<simSesCommands.SimListEmailIdentitiesCommandOutput> {
+    await this.#commands.background.sequence();
+    return this.#commands.identityCommands.listEmailIdentities(
+      command,
+      options,
+    );
+  }
+
+  /**
+   * Handle a DeleteEmailIdentity Command from the SDK.
+   */
+  async deleteEmailIdentity(
+    command: simSesCommands.SimDeleteEmailIdentityCommand,
+    options?: SimSesRequestOptions,
+  ): Promise<simSesCommands.SimDeleteEmailIdentityCommandOutput> {
+    await this.#commands.background.sequence();
+    return this.#commands.identityCommands.deleteEmailIdentity(
+      command,
+      options,
+    );
+  }
+
+  /**
+   * Handle a SendEmail Command from the SDK.
+   */
+  async sendEmail(
+    command: simSesCommands.SimSendEmailCommand,
+    options?: SimSesRequestOptions,
+  ): Promise<simSesCommands.SimSendEmailCommandOutput> {
+    await this.#commands.background.sequence();
+    return this.#commands.sendEmail.handle(command, options);
+  }
+
+  /**
+   * Handle a GetAccount Command from the SDK.
+   */
+  async getAccount(
+    _command?: simSesCommands.SimGetAccountCommand,
+    options?: SimSesRequestOptions,
+  ): Promise<simSesCommands.SimGetAccountCommandOutput> {
+    await this.#commands.background.sequence();
+    return this.#commands.accountCommands.getAccount(options);
+  }
+
+  /**
+   * Handle a PutAccountDetails Command from the SDK.
+   */
+  async putAccountDetails(
+    command: simSesCommands.SimPutAccountDetailsCommand,
+    options?: SimSesRequestOptions,
+  ): Promise<simSesCommands.SimPutAccountDetailsCommandOutput> {
+    await this.#commands.background.sequence();
+    return this.#commands.accountCommands.putAccountDetails(command, options);
+  }
+
+  /**
+   * Get this service's SDK Command router for SDK client interception.
+   */
+  sdkCommandRouter(): SimSdkCommandRouter {
+    return this.#sdkRouter;
+  }
+}


### PR DESCRIPTION
Adds a simulated Amazon SES through its v2 API: email identities, the sandbox rules, and a record of every message SES would have sent, so a test can assert that signing someone up produced a welcome email addressed to them without an AWS account. There is nothing to deliver, so the whole of the observable behaviour is whether SES would have accepted a message and what it would have sent, which `sentEmails()` reads back. Verification is a simulator-side call rather than an API operation, since real SES proves an identity by an emailed link or a DNS record and neither can happen inside a test process. SendEmail reads `Content.Simple` only, refusing raw MIME and template content by name, and every command authorizes through simulated IAM against the identity being sent from.

Resolves #632

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added simulated Amazon SES v2 support, including email sending, identity management, account details, sandbox behavior, production access, quotas, and sent-message inspection.
  * Added IAM authorization and SDK interception for supported SES commands.
  * Added examples demonstrating sending email, verifying identities, managing permissions, sandbox transitions, account inspection, and SDK interception.

* **Documentation**
  * Added comprehensive SES service documentation and linked it from the documentation indexes.
  * Expanded the list of supported SDK-intercepted services.

* **Tests**
  * Added coverage for SES sending, identity verification, sandbox rules, account behavior, authorization, validation, pagination, and SDK routing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->