### PR TITLE
feat: render simulated SES email templates

### DIFF
--- a/docs/services/ses/README.md
+++ b/docs/services/ses/README.md
@@ -121,6 +121,119 @@ so `Sales@example.com` and `sales@example.com` are two identities.
 records that proved it stop resolving. That gives a test somewhere to go when it wants to see
 sending fail after it once worked.
 
+## Email templates
+
+The assertion a test usually wants is not "the email said this prose", which changes whenever
+someone rewords it. It is "the welcome email went to this address, from this template, with these
+substitutions". Storing the template in SES and sending from it by name is what makes that
+assertion possible.
+
+Templates are managed with `CreateEmailTemplate`, `GetEmailTemplate`, `UpdateEmailTemplate`,
+`ListEmailTemplates` and `DeleteEmailTemplate`. A send carrying `Content.Template` renders the
+stored wording against the JSON in `TemplateData`, and the recorded send carries the template name
+and the parsed data alongside the rendered result, so a test can assert on either.
+
+```typescript sim-ses-templates
+/**
+ * Sending from a stored template and asserting on the substitutions.
+ */
+
+import {
+  CreateEmailTemplateCommand,
+  SendEmailCommand,
+} from "@aws-sdk/client-sesv2";
+
+import { SimAws } from "@kensio/yulin";
+
+const ses = new SimAws().sesV2();
+
+ses.verifyIdentity("hello@example.com");
+ses.verifyIdentity("someone@example.org");
+
+await ses.createEmailTemplate(
+  new CreateEmailTemplateCommand({
+    TemplateName: "welcome",
+    TemplateContent: {
+      Subject: "Welcome, {{name}}",
+      Text: "Hi {{name}}, thanks for signing up.",
+      Html: "<p>Hi {{name}}, thanks for signing up.</p>",
+    },
+  }),
+);
+
+await ses.sendEmail(
+  new SendEmailCommand({
+    FromEmailAddress: "hello@example.com",
+    Destination: { ToAddresses: ["someone@example.org"] },
+    Content: {
+      Template: { TemplateName: "welcome", TemplateData: '{"name":"Ada"}' },
+    },
+  }),
+);
+
+const [email] = ses.sentEmails();
+
+// "welcome" { name: "Ada" } "Welcome, Ada"
+console.log(email?.templateName, email?.templateData, email?.subject);
+```
+
+A message written out in full reports `undefined` for both, so a test can tell the two kinds of send
+apart.
+
+### What the substitution does
+
+Real SES renders templates with Handlebars, and this simulator renders the substitution part of it:
+`{{name}}`, and dotted paths like `{{order.id}}`.
+
+A placeholder naming something the data does not have renders as an empty string rather than
+failing. That is what real SES does, and it is much the commonest surprise in an SES template: the
+message goes out with a hole in it and nothing reports a problem. Asserting on the rendered body is
+how that gets caught.
+
+`{{name}}` HTML-escapes its value and `{{{name}}}` does not, again following Handlebars. The
+escaping applies to the text part as well as the HTML one, because Handlebars renders a string
+without knowing what it is for, so a plain text email carrying an ampersand comes out with
+`&amp;` in it.
+
+Everything else Handlebars can do is refused where the template is written, rather than left in
+place:
+
+```typescript sim-ses-template-refusals
+/**
+ * The Handlebars this simulator will not render, refused at the template.
+ */
+
+import { CreateEmailTemplateCommand } from "@aws-sdk/client-sesv2";
+
+import { SimAws } from "@kensio/yulin";
+import { SimSesUnsupportedOperationException } from "@kensio/yulin/ses";
+
+const ses = new SimAws().sesV2();
+
+try {
+  await ses.createEmailTemplate(
+    new CreateEmailTemplateCommand({
+      TemplateName: "welcome",
+      TemplateContent: {
+        Subject: "Welcome",
+        Text: "{{#if premium}}Thanks for subscribing{{/if}}",
+      },
+    }),
+  );
+} catch (error) {
+  // true: block helpers, partials and comments are not rendered here, and a
+  // template carrying one is refused rather than sent with it still in place.
+  console.log(error instanceof SimSesUnsupportedOperationException);
+}
+```
+
+Refusing at the template rather than at the send is deliberate: it fails where the mistake is
+written, and a template surviving into a sent message with `{{#if premium}}` still in it would make
+a test pass on a message no real SES would produce.
+
+Malformed `TemplateData`, or data that is not a JSON object, is refused too. A send with no
+`TemplateData` at all renders every placeholder empty, which is how real SES treats it.
+
 ## The sandbox
 
 An account starts in the SES sandbox, where **both** the sender and every recipient have to be
@@ -360,11 +473,16 @@ window sees the count fall the way an account's would.
 
 | Command               | Notes                                                                                      |
 | --------------------- | ------------------------------------------------------------------------------------------ |
-| `SendEmail`           | `Content.Simple` only. Recorded rather than delivered.                                     |
+| `SendEmail`           | `Content.Simple` and `Content.Template`. Recorded rather than delivered.                   |
 | `CreateEmailIdentity` | Starts unverified. `Tags`, `DkimSigningAttributes` and `ConfigurationSetName` are refused. |
 | `GetEmailIdentity`    |                                                                                            |
 | `ListEmailIdentities` | Paged with `PageSize` and `NextToken`.                                                     |
 | `DeleteEmailIdentity` |                                                                                            |
+| `CreateEmailTemplate` | Substitution only. `Tags` are refused.                                                     |
+| `GetEmailTemplate`    | Reports the wording with its placeholders unrendered.                                      |
+| `UpdateEmailTemplate` | Replaces the wording outright, keeping the creation time.                                  |
+| `ListEmailTemplates`  | Names and creation times only, paged.                                                      |
+| `DeleteEmailTemplate` |                                                                                            |
 | `GetAccount`          |                                                                                            |
 | `PutAccountDetails`   | `MailType` and `WebsiteURL` are required, as on real SES.                                  |
 
@@ -378,13 +496,17 @@ Anything else refuses on send with `SimSdkUnsupportedCommandError` rather than m
 - **Production access is granted on request.** Real SES has a human review it first.
 - **Send quotas are reported, not enforced.** A send past the daily figure still succeeds, and
   nothing here takes real time to respect a per-second rate.
-- **Only `Content.Simple` is read.** `Content.Raw` and `Content.Template` are refused by name.
-  Templates are a separate piece of work.
+- **`Content.Raw` is refused by name.** A raw MIME message would have to be parsed to say anything
+  about its subject or body.
+- **Only Handlebars substitution is rendered.** Block helpers, partials and comments are refused at
+  the template. Template data holding an object where the template wants a value is refused too,
+  rather than rendering `[object Object]` the way real Handlebars would.
+- **`SendBulkEmail` is not simulated**, so there is no per-recipient replacement data.
 - **Nothing is delivered, and nothing bounces.** There are no bounce or complaint events, no
   suppression list, no configuration sets and no event destinations. A configuration set named on a
   send is kept on the record so a test can assert the right one was used, and does nothing else.
-- **No `AWS::SES::*` CloudFormation resources yet.** Identities have to be created through the API
-  or through `verifyIdentity`.
+- **No `AWS::SES::*` CloudFormation resources yet.** Identities and templates have to be created
+  through the API, or an identity through `verifyIdentity`.
 - **SES v2 only.** The older `@aws-sdk/client-ses` API is not simulated.
 - **DKIM, MAIL FROM domains and sending authorization policies are not simulated.** An identity
   created with `DkimSigningAttributes` is refused rather than reported as configured.

--- a/docs/services/ses/README.md
+++ b/docs/services/ses/README.md
@@ -231,8 +231,14 @@ Refusing at the template rather than at the send is deliberate: it fails where t
 written, and a template surviving into a sent message with `{{#if premium}}` still in it would make
 a test pass on a message no real SES would produce.
 
-Malformed `TemplateData`, or data that is not a JSON object, is refused too. A send with no
-`TemplateData` at all renders every placeholder empty, which is how real SES treats it.
+`TemplateData` is checked only when a send carries it: malformed JSON, or JSON that is not an
+object, is refused. A send with no `TemplateData` at all is accepted and renders every placeholder
+empty, which is how real SES treats it.
+
+A send may name a stored template or write its wording out in `TemplateContent`, but not both.
+Naming both is refused, because which of them real SES renders is not something this simulator
+knows, and recording the message under a template it was not rendered from would be worse than
+failing.
 
 ## The sandbox
 

--- a/docs/services/ses/sim-ses-template-refusals.example.ts
+++ b/docs/services/ses/sim-ses-template-refusals.example.ts
@@ -1,0 +1,26 @@
+/**
+ * The Handlebars this simulator will not render, refused at the template.
+ */
+
+import { CreateEmailTemplateCommand } from "@aws-sdk/client-sesv2";
+
+import { SimAws } from "@kensio/yulin";
+import { SimSesUnsupportedOperationException } from "@kensio/yulin/ses";
+
+const ses = new SimAws().sesV2();
+
+try {
+  await ses.createEmailTemplate(
+    new CreateEmailTemplateCommand({
+      TemplateName: "welcome",
+      TemplateContent: {
+        Subject: "Welcome",
+        Text: "{{#if premium}}Thanks for subscribing{{/if}}",
+      },
+    }),
+  );
+} catch (error) {
+  // true: block helpers, partials and comments are not rendered here, and a
+  // template carrying one is refused rather than sent with it still in place.
+  console.log(error instanceof SimSesUnsupportedOperationException);
+}

--- a/docs/services/ses/sim-ses-templates.example.ts
+++ b/docs/services/ses/sim-ses-templates.example.ts
@@ -1,0 +1,41 @@
+/**
+ * Sending from a stored template and asserting on the substitutions.
+ */
+
+import {
+  CreateEmailTemplateCommand,
+  SendEmailCommand,
+} from "@aws-sdk/client-sesv2";
+
+import { SimAws } from "@kensio/yulin";
+
+const ses = new SimAws().sesV2();
+
+ses.verifyIdentity("hello@example.com");
+ses.verifyIdentity("someone@example.org");
+
+await ses.createEmailTemplate(
+  new CreateEmailTemplateCommand({
+    TemplateName: "welcome",
+    TemplateContent: {
+      Subject: "Welcome, {{name}}",
+      Text: "Hi {{name}}, thanks for signing up.",
+      Html: "<p>Hi {{name}}, thanks for signing up.</p>",
+    },
+  }),
+);
+
+await ses.sendEmail(
+  new SendEmailCommand({
+    FromEmailAddress: "hello@example.com",
+    Destination: { ToAddresses: ["someone@example.org"] },
+    Content: {
+      Template: { TemplateName: "welcome", TemplateData: '{"name":"Ada"}' },
+    },
+  }),
+);
+
+const [email] = ses.sentEmails();
+
+// "welcome" { name: "Ada" } "Welcome, Ada"
+console.log(email?.templateName, email?.templateData, email?.subject);

--- a/src/service/ses/README.md
+++ b/src/service/ses/README.md
@@ -71,10 +71,39 @@ reported one at a time, because real SES names every identity that failed in a s
 asserting a bcc was a bcc still can, and the body keeps text and HTML apart so a test asserting on
 the text of an HTML-only message finds nothing rather than the markup.
 
-Only `Content.Simple` is read. `Content.Raw` and `Content.Template` are refused by name: a raw MIME
-message would have to be parsed to say anything about its subject or body, and templates are not
-here yet. Refusing is the honest answer, since a recorded message with nothing in it would make a
-test pass for a reason unrelated to what it asserts.
+`SimSesContentReader` dispatches the three kinds of content. `Simple` and `Template` are both read;
+`Raw` is refused by name, since a raw MIME message would have to be parsed to say anything about its
+subject or body and a recorded message with nothing in it would make a test pass for a reason
+unrelated to what it asserts.
+
+## Template model
+
+Template state lives under `template/`, and the send-side rendering under `command/send/`.
+
+`SimSesTemplate` holds the wording with its placeholders still in it. That separation is the reason
+templates are worth having in a simulator at all: a test can assert which template went out and what
+was substituted into it, rather than matching against rendered prose that changes whenever someone
+rewords the email. `SimSesSentEmail` therefore carries `templateName` and `templateData` as well as
+the rendered result.
+
+`sim-ses-render.ts` does the substitution. Real SES renders with Handlebars and this renders the
+substitution part of it: `{{name}}`, dotted paths, `{{{name}}}` for an unescaped value, and HTML
+escaping otherwise. Two decisions in there are worth knowing about.
+
+Escaping is applied to the text part as well as the HTML one, because Handlebars escapes without
+knowing what the string is for. If that turns out not to match real SES it is a one-line change, and
+the direction was chosen on which way round the error is cheaper: escaping when SES does not gives a
+test that fails for a visible, documented reason, while not escaping when SES does gives a test that
+passes on a message that would go out with `&lt;b&gt;` in it.
+
+A value that is not a string, number or boolean is refused rather than rendered. Real Handlebars
+would put `[object Object]` in the message, which nobody means to send, so naming the placeholder is
+more use than reproducing it.
+
+`readSimSesTemplateContent` refuses everything Handlebars can do beyond substitution, and it does so
+at `CreateEmailTemplate` and `UpdateEmailTemplate` rather than at the send. That fails where the
+mistake is written, and follows the house pattern of refusing an unsimulated input at the command
+that carries it.
 
 ## Account model
 

--- a/src/service/ses/command/authorize/sim-ses-authorizer.ts
+++ b/src/service/ses/command/authorize/sim-ses-authorizer.ts
@@ -3,16 +3,16 @@ import type { SimAwsResolvedCaller } from "../../../aws/caller/sim-aws-caller-re
 import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
 import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
 import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
-import { simSesIdentityArn } from "../../identity/sim-ses-arn.js";
+import { simSesIdentityArn, simSesTemplateArn } from "../../sim-ses-arn.js";
 
 /**
  * The resource an action with no resource type authorizes against.
  *
- * Real SES gives `ses:ListEmailIdentities`, `ses:GetAccount` and
+ * Real SES gives the two listings, `ses:GetAccount` and
  * `ses:PutAccountDetails` no resource type at all, so IAM evaluates them
  * against `*` and only a policy whose Resource is `*` allows them. A policy
- * naming an identity ARN allows none of them, not even one written against
- * every identity in the Account and Region, here as on AWS.
+ * naming an identity or template ARN allows none of them, not even one written
+ * against every identity in the Account and Region, here as on AWS.
  */
 const noResource = "*";
 
@@ -58,6 +58,26 @@ export class SimSesAuthorizer {
     return this.authorizeResource(
       action,
       simSesIdentityArn(this.#accountRegionScope, emailIdentity),
+      caller,
+    );
+  }
+
+  /**
+   * Ensure the caller may perform an action on one email template.
+   *
+   * The template need not exist, for the same reason an identity need not:
+   * real IAM decides a request before the service looks at it, so
+   * CreateEmailTemplate authorizes against the ARN the template is about to
+   * have.
+   */
+  authorizeTemplate(
+    action: string,
+    templateName: string,
+    caller?: SimAwsCaller,
+  ): SimAwsResolvedCaller {
+    return this.authorizeResource(
+      action,
+      simSesTemplateArn(this.#accountRegionScope, templateName),
       caller,
     );
   }

--- a/src/service/ses/command/authorize/sim-ses-template-iam.iso.test.ts
+++ b/src/service/ses/command/authorize/sim-ses-template-iam.iso.test.ts
@@ -1,0 +1,156 @@
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import {
+  CreateEmailTemplateCommand,
+  ListEmailTemplatesCommand,
+  SendEmailCommand,
+} from "@aws-sdk/client-sesv2";
+import {
+  assertArrayLength,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+import { simIamPolicyDocumentFactory } from "../../../iam/policy/sim-iam-policy-document.factory.js";
+
+const accountIdOneOnes = "111111111111";
+
+/** A simulation with one Role carrying whatever policy statement is wanted. */
+async function simAwsWithRole(policyStatement: object): Promise<SimAws> {
+  const simAws = new SimAws({ defaultAccountId: accountIdOneOnes });
+
+  await simAws.iam().createRole(
+    new CreateRoleCommand({
+      RoleName: "SignUpFunctionRole",
+      AssumeRolePolicyDocument: simIamPolicyDocumentFactory.make({
+        Statement: {
+          Principal: { Service: "lambda.amazonaws.com" },
+          Action: "sts:AssumeRole",
+        },
+      }),
+    }),
+  );
+
+  await simAws.iam().putRolePolicy(
+    new PutRolePolicyCommand({
+      RoleName: "SignUpFunctionRole",
+      PolicyName: "ManageTemplates",
+      PolicyDocument: simIamPolicyDocumentFactory.make({
+        Statement: policyStatement,
+      }),
+    }),
+  );
+
+  return simAws;
+}
+
+/** The request options that make a call arrive as the Role. */
+const asRole = {
+  caller: {
+    kind: "arn",
+    arn: `arn:aws:iam::${accountIdOneOnes}:role/SignUpFunctionRole`,
+  },
+} as const;
+
+const welcome = new CreateEmailTemplateCommand({
+  TemplateName: "welcome",
+  TemplateContent: { Subject: "Welcome", Text: "Hi {{name}}" },
+});
+
+describe("SES template IAM authorization", () => {
+  it("allows a template operation the policy names", async () => {
+    // Given a Role allowed to create one template by name.
+    const simAws = await simAwsWithRole({
+      Action: "ses:CreateEmailTemplate",
+      Resource: `arn:aws:ses:us-east-1:${accountIdOneOnes}:template/welcome`,
+    });
+
+    // When it creates that template.
+    await simAws.sesV2().createEmailTemplate(welcome, asRole);
+
+    assertArrayLength(simAws.sesV2().allTemplates(), 1);
+  });
+
+  it("refuses a template operation on another template", async () => {
+    // Given a Role allowed to create one template only.
+    const simAws = await simAwsWithRole({
+      Action: "ses:CreateEmailTemplate",
+      Resource: `arn:aws:ses:us-east-1:${accountIdOneOnes}:template/receipt`,
+    });
+
+    // When it creates a different one.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.sesV2().createEmailTemplate(welcome, asRole);
+    });
+
+    // Then IAM refuses it, naming the template ARN it authorized against.
+    assertInstanceOf(error, SimIamAccessDenied);
+    assertStringIncludes(error.message, "template/welcome");
+  });
+
+  it("needs a policy on every resource to list templates", async () => {
+    // Given a Role allowed to list on `*`, which is the only resource real SES
+    // gives that action.
+    const simAws = await simAwsWithRole({
+      Action: "ses:ListEmailTemplates",
+      Resource: "*",
+    });
+
+    // When it lists them.
+    const listed = await simAws
+      .sesV2()
+      .listEmailTemplates(new ListEmailTemplatesCommand({}), asRole);
+
+    assertArrayLength(listed.TemplatesMetadata ?? [], 0);
+  });
+
+  it("refuses a listing to a policy naming template ARNs", async () => {
+    // Given a Role allowed to list, on every template in the Account.
+    const simAws = await simAwsWithRole({
+      Action: "ses:ListEmailTemplates",
+      Resource: `arn:aws:ses:us-east-1:${accountIdOneOnes}:template/*`,
+    });
+
+    // When it lists them.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws
+        .sesV2()
+        .listEmailTemplates(new ListEmailTemplatesCommand({}), asRole);
+    });
+
+    assertInstanceOf(error, SimIamAccessDenied);
+  });
+
+  it("authorizes a template send against the identity, not the template", async () => {
+    // Given a Role allowed to send from one identity and to do nothing at all
+    // with templates.
+    const simAws = await simAwsWithRole({
+      Action: "ses:SendEmail",
+      Resource: `arn:aws:ses:us-east-1:${accountIdOneOnes}:identity/example.com`,
+    });
+    const ses = simAws.sesV2();
+
+    ses.verifyIdentity("example.com");
+    ses.verifyIdentity("example.org");
+    await ses.createEmailTemplate(welcome);
+
+    // When it sends from the template.
+    await ses.sendEmail(
+      new SendEmailCommand({
+        FromEmailAddress: "hello@example.com",
+        Destination: { ToAddresses: ["someone@example.org"] },
+        Content: {
+          Template: { TemplateName: "welcome", TemplateData: '{"name":"Ada"}' },
+        },
+      }),
+      asRole,
+    );
+
+    // Then the send is allowed. Real SES gives SendEmail no template resource
+    // type, so a caller that may send may send from any template it can name.
+    assertArrayLength(ses.sentEmails(), 1);
+  });
+});

--- a/src/service/ses/command/send/send.command.ts
+++ b/src/service/ses/command/send/send.command.ts
@@ -1,4 +1,5 @@
 import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type { SimSesEmailTemplateContent } from "../template/template.command.js";
 
 /**
  * One part of a message: its subject line, or one representation of its body.
@@ -25,15 +26,19 @@ export interface SimSesRawMessage {
 }
 
 /**
- * The template branch of a message, which this issue's scope does not render.
+ * The template branch of a message.
  *
- * It is typed here so a send carrying one can be told apart from a malformed
- * request and refused with a message saying so.
+ * The wording comes either from a template stored under `TemplateName` or from
+ * one written into `TemplateContent` on the request itself, both of which real
+ * SES accepts. `TemplateData` is the JSON its placeholders are filled from.
  */
 export interface SimSesTemplate {
   readonly TemplateName?: string | undefined;
   readonly TemplateArn?: string | undefined;
+  readonly TemplateContent?: SimSesEmailTemplateContent | undefined;
   readonly TemplateData?: string | undefined;
+  readonly Headers?: readonly unknown[] | undefined;
+  readonly Attachments?: readonly unknown[] | undefined;
 }
 
 export interface SimSesEmailContent {

--- a/src/service/ses/command/send/sim-ses-content.ts
+++ b/src/service/ses/command/send/sim-ses-content.ts
@@ -1,0 +1,62 @@
+import {
+  SimSesBadRequestException,
+  SimSesUnsupportedOperationException,
+} from "../../error/sim-ses.error.js";
+import type { SimSesTemplateStore } from "../../template/sim-ses-template-store.js";
+import type { SimSesReadContent } from "./sim-ses-read-content.js";
+import { readSimSesSimpleMessage } from "./sim-ses-simple-content.js";
+import { SimSesTemplateSendReader } from "./sim-ses-template-send.js";
+import type { SimSesEmailContent } from "./send.command.js";
+
+interface SimSesContentReaderProperties {
+  readonly templates: SimSesTemplateStore;
+}
+
+/**
+ * Reads whichever of the three kinds of content a send carried.
+ *
+ * `Simple` and `Template` are both read. `Raw` is refused by name: a raw MIME
+ * message would have to be parsed to say anything about its subject or body,
+ * and recording one with nothing in it would make a test pass for a reason
+ * unrelated to what it asserts.
+ */
+export class SimSesContentReader {
+  readonly #templateSends: SimSesTemplateSendReader;
+
+  constructor(properties: SimSesContentReaderProperties) {
+    this.#templateSends = new SimSesTemplateSendReader({
+      templates: properties.templates,
+    });
+  }
+
+  /**
+   * Read the content of a send, refusing what SES would refuse.
+   */
+  read(content: SimSesEmailContent | undefined): SimSesReadContent {
+    if (content === undefined) {
+      throw new SimSesBadRequestException(
+        "1 validation error detected: Value at 'content' failed to satisfy " +
+          "constraint: Member must not be null",
+      );
+    }
+
+    if (content.Raw !== undefined) {
+      throw new SimSesUnsupportedOperationException(
+        "Raw MIME content is not simulated, so SendEmail refuses Content.Raw " +
+          "rather than recording a message it has not read",
+      );
+    }
+
+    if (content.Template !== undefined) {
+      return this.#templateSends.read(content.Template);
+    }
+
+    if (content.Simple === undefined) {
+      throw new SimSesBadRequestException(
+        "Content must specify one of Simple, Raw or Template.",
+      );
+    }
+
+    return readSimSesSimpleMessage(content.Simple);
+  }
+}

--- a/src/service/ses/command/send/sim-ses-read-content.ts
+++ b/src/service/ses/command/send/sim-ses-read-content.ts
@@ -1,0 +1,21 @@
+import type { SimSesSentEmailBody } from "../../email/sim-ses-sent-email.js";
+
+/**
+ * What a message says, read out of the content of a send.
+ *
+ * A simple message carries its own wording; a template one carries the name of
+ * the template that produced it and the data that filled it, so a test can
+ * assert on either the rendered prose or on what went into it. Asserting on
+ * the template and its substitutions is usually the better test: it survives
+ * someone rewording the email.
+ */
+export interface SimSesReadContent {
+  readonly subject: string;
+  readonly body: SimSesSentEmailBody;
+
+  /** The template this was rendered from, if it was rendered from a stored one. */
+  readonly templateName: string | undefined;
+
+  /** The data the placeholders were filled from, parsed out of the JSON. */
+  readonly templateData: Readonly<Record<string, unknown>> | undefined;
+}

--- a/src/service/ses/command/send/sim-ses-send-email.ts
+++ b/src/service/ses/command/send/sim-ses-send-email.ts
@@ -17,12 +17,13 @@ import type {
   SimSendEmailCommandOutput,
   SimSesDestination,
 } from "./send.command.js";
-import { readSimSesContent } from "./sim-ses-simple-content.js";
+import type { SimSesContentReader } from "./sim-ses-content.js";
 import { refuseUnsimulatedSendInput } from "./sim-ses-unsimulated-send-input.js";
 import type { SimSesVerifiedIdentityCheck } from "./sim-ses-verified-identities.js";
 
 interface SimSesSendEmailProperties {
   readonly identities: SimSesIdentityStore;
+  readonly content: SimSesContentReader;
   readonly sent: SimSesSentEmailStore;
   readonly identityCheck: SimSesVerifiedIdentityCheck;
   readonly authorizer: SimSesAuthorizer;
@@ -41,6 +42,7 @@ interface SimSesSendEmailProperties {
  */
 export class SimSesSendEmail {
   readonly #identities: SimSesIdentityStore;
+  readonly #content: SimSesContentReader;
   readonly #sent: SimSesSentEmailStore;
   readonly #identityCheck: SimSesVerifiedIdentityCheck;
   readonly #authorizer: SimSesAuthorizer;
@@ -48,6 +50,7 @@ export class SimSesSendEmail {
 
   constructor(properties: SimSesSendEmailProperties) {
     this.#identities = properties.identities;
+    this.#content = properties.content;
     this.#sent = properties.sent;
     this.#identityCheck = properties.identityCheck;
     this.#authorizer = properties.authorizer;
@@ -82,7 +85,7 @@ export class SimSesSendEmail {
       );
     }
 
-    const content = readSimSesContent(input.Content);
+    const content = this.#content.read(input.Content);
 
     this.#identityCheck.check({ fromEmailAddress, recipients });
 
@@ -96,6 +99,8 @@ export class SimSesSendEmail {
         replyToAddresses: [...(input.ReplyToAddresses ?? [])],
         subject: content.subject,
         body: content.body,
+        templateName: content.templateName,
+        templateData: content.templateData,
         configurationSetName: input.ConfigurationSetName,
         sentDate: this.#clock.now(),
       }),

--- a/src/service/ses/command/send/sim-ses-simple-content.ts
+++ b/src/service/ses/command/send/sim-ses-simple-content.ts
@@ -2,61 +2,20 @@ import {
   SimSesBadRequestException,
   SimSesUnsupportedOperationException,
 } from "../../error/sim-ses.error.js";
-import type { SimSesSentEmailBody } from "../../email/sim-ses-sent-email.js";
-import type { SimSesEmailContent, SimSesMessage } from "./send.command.js";
+import type { SimSesReadContent } from "./sim-ses-read-content.js";
+import type { SimSesMessage } from "./send.command.js";
 
 /**
- * What a message says, read out of the `Simple` content of a send.
- */
-export interface SimSesReadContent {
-  readonly subject: string;
-  readonly body: SimSesSentEmailBody;
-}
-
-/**
- * Read the content of a send, refusing the shapes this simulation does not
- * model and the ones real SES would not accept.
+ * Read a message a send wrote out in full, refusing what real SES refuses and
+ * what this simulation does not model.
  *
- * Only `Simple` content is read. A raw MIME message would have to be parsed to
- * say anything about its subject or body, and a template one needs templates,
- * which are not here yet. Both are refused by name so a caller finds out which
- * of the three branches it used rather than getting a recorded message with
- * nothing in it.
+ * The subject and a body are both required, as they are on real SES, so a send
+ * missing either fails here rather than recording a message an account would
+ * not have accepted.
  */
-export function readSimSesContent(
-  content: SimSesEmailContent | undefined,
+export function readSimSesSimpleMessage(
+  message: SimSesMessage,
 ): SimSesReadContent {
-  if (content === undefined) {
-    throw new SimSesBadRequestException(
-      "1 validation error detected: Value at 'content' failed to satisfy " +
-        "constraint: Member must not be null",
-    );
-  }
-
-  if (content.Raw !== undefined) {
-    throw new SimSesUnsupportedOperationException(
-      "Raw MIME content is not simulated, so SendEmail refuses Content.Raw " +
-        "rather than recording a message it has not read",
-    );
-  }
-
-  if (content.Template !== undefined) {
-    throw new SimSesUnsupportedOperationException(
-      "Email templates are not simulated yet, so SendEmail refuses " +
-        "Content.Template rather than recording a message it cannot render",
-    );
-  }
-
-  if (content.Simple === undefined) {
-    throw new SimSesBadRequestException(
-      "Content must specify one of Simple, Raw or Template.",
-    );
-  }
-
-  return readSimpleMessage(content.Simple);
-}
-
-function readSimpleMessage(message: SimSesMessage): SimSesReadContent {
   if (message.Attachments !== undefined) {
     throw new SimSesUnsupportedOperationException(
       "Attachments are not simulated, so SendEmail refuses them rather than " +
@@ -83,5 +42,10 @@ function readSimpleMessage(message: SimSesMessage): SimSesReadContent {
     );
   }
 
-  return { subject, body: { text, html } };
+  return {
+    subject,
+    body: { text, html },
+    templateName: undefined,
+    templateData: undefined,
+  };
 }

--- a/src/service/ses/command/send/sim-ses-template-send.ts
+++ b/src/service/ses/command/send/sim-ses-template-send.ts
@@ -64,9 +64,21 @@ export class SimSesTemplateSendReader {
   /**
    * The wording to render: the stored template's, or the one the send wrote
    * out in full.
+   *
+   * A send naming both is refused rather than picking one. Which of them real
+   * SES prefers is not something this simulator knows, and rendering the
+   * inline wording while recording the stored template's name would put a
+   * message in the record under a template it was not rendered from.
    */
   private resolveContent(template: SimSesTemplate): SimSesTemplateContent {
     if (template.TemplateContent !== undefined) {
+      if (template.TemplateName !== undefined) {
+        throw new SimSesUnsupportedOperationException(
+          "A send naming both TemplateName and TemplateContent is refused: " +
+            "which of them real SES renders is not simulated here",
+        );
+      }
+
       return readSimSesTemplateContent(template.TemplateContent);
     }
 

--- a/src/service/ses/command/send/sim-ses-template-send.ts
+++ b/src/service/ses/command/send/sim-ses-template-send.ts
@@ -1,0 +1,133 @@
+import {
+  SimSesBadRequestException,
+  SimSesUnsupportedOperationException,
+} from "../../error/sim-ses.error.js";
+import { renderSimSesTemplatePart } from "../../template/sim-ses-render.js";
+import { readSimSesTemplateContent } from "../../template/sim-ses-template-content.js";
+import type { SimSesTemplateContent } from "../../template/sim-ses-template-content.js";
+import type { SimSesTemplateStore } from "../../template/sim-ses-template-store.js";
+import type { SimSesReadContent } from "./sim-ses-read-content.js";
+import type { SimSesTemplate } from "./send.command.js";
+
+interface SimSesTemplateSendReaderProperties {
+  readonly templates: SimSesTemplateStore;
+}
+
+/**
+ * Renders the template branch of a send.
+ *
+ * The wording comes either from a template stored under a name or from one
+ * written into the request itself, both of which real SES accepts. What comes
+ * back is the rendered message plus the name and data it was rendered from, so
+ * the recorded send can carry all three.
+ */
+export class SimSesTemplateSendReader {
+  readonly #templates: SimSesTemplateStore;
+
+  constructor(properties: SimSesTemplateSendReaderProperties) {
+    this.#templates = properties.templates;
+  }
+
+  /**
+   * Render a template send, refusing one SES would refuse.
+   */
+  read(template: SimSesTemplate): SimSesReadContent {
+    if (template.TemplateArn !== undefined) {
+      throw new SimSesUnsupportedOperationException(
+        "Sending another Account's shared template is not simulated, so " +
+          "SendEmail refuses TemplateArn rather than rendering a template it " +
+          "cannot read",
+      );
+    }
+
+    if (template.Attachments !== undefined || template.Headers !== undefined) {
+      throw new SimSesUnsupportedOperationException(
+        "Attachments and custom headers are not simulated, so SendEmail " +
+          "refuses them rather than recording a message without them",
+      );
+    }
+
+    const content = this.resolveContent(template);
+    const data = readTemplateData(template.TemplateData);
+
+    return {
+      subject: render(content.subject, data),
+      body: {
+        text: renderOptional(content.text, data),
+        html: renderOptional(content.html, data),
+      },
+      templateName: template.TemplateName,
+      templateData: data,
+    };
+  }
+
+  /**
+   * The wording to render: the stored template's, or the one the send wrote
+   * out in full.
+   */
+  private resolveContent(template: SimSesTemplate): SimSesTemplateContent {
+    if (template.TemplateContent !== undefined) {
+      return readSimSesTemplateContent(template.TemplateContent);
+    }
+
+    if (template.TemplateName === undefined) {
+      throw new SimSesBadRequestException(
+        "1 validation error detected: Value at 'content.template' failed to " +
+          "satisfy constraint: Member must specify TemplateName or " +
+          "TemplateContent",
+      );
+    }
+
+    return this.#templates.require(template.TemplateName).content;
+  }
+}
+
+/**
+ * Read the JSON a send fills its placeholders from.
+ *
+ * An absent `TemplateData` is an empty object rather than a failure, which is
+ * how real SES treats it: every placeholder then renders empty.
+ */
+function readTemplateData(
+  templateData: string | undefined,
+): Readonly<Record<string, unknown>> {
+  if (templateData === undefined) {
+    return {};
+  }
+
+  const parsed: unknown = parseJson(templateData);
+
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    throw new SimSesBadRequestException(
+      "The template data is not a JSON object.",
+    );
+  }
+
+  return parsed as Record<string, unknown>;
+}
+
+function parseJson(templateData: string): unknown {
+  try {
+    return JSON.parse(templateData);
+  } catch {
+    throw new SimSesBadRequestException("The template data is invalid JSON.");
+  }
+}
+
+/**
+ * A template with no subject renders an empty one, which is what a message
+ * sent without a Subject header amounts to.
+ */
+function render(
+  part: string | undefined,
+  data: Readonly<Record<string, unknown>>,
+): string {
+  return part === undefined ? "" : renderSimSesTemplatePart(part, data);
+}
+
+function renderOptional(
+  part: string | undefined,
+  data: Readonly<Record<string, unknown>>,
+): string | undefined {
+  return part === undefined ? undefined : renderSimSesTemplatePart(part, data);
+}

--- a/src/service/ses/command/sim-ses-command.types.ts
+++ b/src/service/ses/command/sim-ses-command.types.ts
@@ -38,3 +38,22 @@ export type {
   SimSesAccountDetailsOutput,
   SimSesSendQuotaDetail,
 } from "./account/account.command.js";
+export type {
+  SimCreateEmailTemplateCommand,
+  SimCreateEmailTemplateCommandInput,
+  SimCreateEmailTemplateCommandOutput,
+  SimDeleteEmailTemplateCommand,
+  SimDeleteEmailTemplateCommandInput,
+  SimDeleteEmailTemplateCommandOutput,
+  SimGetEmailTemplateCommand,
+  SimGetEmailTemplateCommandInput,
+  SimGetEmailTemplateCommandOutput,
+  SimListEmailTemplatesCommand,
+  SimListEmailTemplatesCommandInput,
+  SimListEmailTemplatesCommandOutput,
+  SimSesEmailTemplateContent,
+  SimSesTemplateMetadata,
+  SimUpdateEmailTemplateCommand,
+  SimUpdateEmailTemplateCommandInput,
+  SimUpdateEmailTemplateCommandOutput,
+} from "./template/template.command.js";

--- a/src/service/ses/command/template/sim-ses-template-commands.ts
+++ b/src/service/ses/command/template/sim-ses-template-commands.ts
@@ -1,0 +1,174 @@
+import type { SimClock } from "../../../../util/clock/sim-clock.js";
+import { readSimSesTemplateContent } from "../../template/sim-ses-template-content.js";
+import {
+  requiredSimSesTemplateName,
+  type SimSesTemplateStore,
+} from "../../template/sim-ses-template-store.js";
+import type { SimSesAuthorizer } from "../authorize/sim-ses-authorizer.js";
+import { SimSesPage } from "../sim-ses-page.js";
+import type { SimSesRequestOptions } from "../sim-ses-request-options.js";
+import {
+  refuseSimSesTemplateTags,
+  simSesTemplateMetadata,
+} from "./sim-ses-template-reporting.js";
+import type {
+  SimCreateEmailTemplateCommand,
+  SimCreateEmailTemplateCommandOutput,
+  SimDeleteEmailTemplateCommand,
+  SimDeleteEmailTemplateCommandOutput,
+  SimGetEmailTemplateCommand,
+  SimGetEmailTemplateCommandOutput,
+  SimListEmailTemplatesCommand,
+  SimListEmailTemplatesCommandOutput,
+  SimUpdateEmailTemplateCommand,
+  SimUpdateEmailTemplateCommandOutput,
+} from "./template.command.js";
+
+interface SimSesTemplateCommandsProperties {
+  readonly templates: SimSesTemplateStore;
+  readonly authorizer: SimSesAuthorizer;
+  readonly clock: SimClock;
+}
+
+/**
+ * The commands that make, read, list, change and remove email templates.
+ *
+ * Every one of them but the listing names a template, and each authorizes
+ * against that template's ARN, so a policy can allow a caller to manage one
+ * template and not the others.
+ */
+export class SimSesTemplateCommands {
+  readonly #templates: SimSesTemplateStore;
+  readonly #authorizer: SimSesAuthorizer;
+  readonly #clock: SimClock;
+
+  constructor(properties: SimSesTemplateCommandsProperties) {
+    this.#templates = properties.templates;
+    this.#authorizer = properties.authorizer;
+    this.#clock = properties.clock;
+  }
+
+  /**
+   * Store a template.
+   */
+  createEmailTemplate(
+    command: SimCreateEmailTemplateCommand,
+    options?: SimSesRequestOptions,
+  ): SimCreateEmailTemplateCommandOutput {
+    refuseSimSesTemplateTags(command.input.Tags);
+
+    this.#templates.create(
+      this.named("ses:CreateEmailTemplate", command.input, options),
+      readSimSesTemplateContent(command.input.TemplateContent ?? {}),
+      this.#clock.now(),
+    );
+
+    return { $metadata: {} };
+  }
+
+  /**
+   * Read a template's wording, with its placeholders unrendered.
+   */
+  getEmailTemplate(
+    command: SimGetEmailTemplateCommand,
+    options?: SimSesRequestOptions,
+  ): SimGetEmailTemplateCommandOutput {
+    const template = this.#templates.require(
+      this.named("ses:GetEmailTemplate", command.input, options),
+    );
+
+    return {
+      $metadata: {},
+      TemplateName: template.templateName,
+      TemplateContent: {
+        Subject: template.content.subject,
+        Text: template.content.text,
+        Html: template.content.html,
+      },
+    };
+  }
+
+  /**
+   * Replace a template's wording, refusing one that is not there.
+   */
+  updateEmailTemplate(
+    command: SimUpdateEmailTemplateCommand,
+    options?: SimSesRequestOptions,
+  ): SimUpdateEmailTemplateCommandOutput {
+    this.#templates
+      .require(this.named("ses:UpdateEmailTemplate", command.input, options))
+      .update(readSimSesTemplateContent(command.input.TemplateContent ?? {}));
+
+    return { $metadata: {} };
+  }
+
+  /**
+   * List the templates in this scope, in the order they were created.
+   *
+   * Real SES gives this action no resource type, so it authorizes against `*`
+   * as the other listings do.
+   */
+  listEmailTemplates(
+    command: SimListEmailTemplatesCommand,
+    options?: SimSesRequestOptions,
+  ): SimListEmailTemplatesCommandOutput {
+    this.#authorizer.authorizeNoResource(
+      "ses:ListEmailTemplates",
+      options?.caller,
+    );
+
+    const page = new SimSesPage({
+      listed: this.#templates.all,
+      pageSize: command.input.PageSize,
+      nextToken: command.input.NextToken,
+    });
+
+    return {
+      $metadata: {},
+      TemplatesMetadata: page.items.map((template) =>
+        simSesTemplateMetadata(template),
+      ),
+      NextToken: page.nextToken,
+    };
+  }
+
+  /**
+   * Remove a template, refusing one that is not there.
+   */
+  deleteEmailTemplate(
+    command: SimDeleteEmailTemplateCommand,
+    options?: SimSesRequestOptions,
+  ): SimDeleteEmailTemplateCommandOutput {
+    const templateName = this.named(
+      "ses:DeleteEmailTemplate",
+      command.input,
+      options,
+    );
+
+    this.#templates.require(templateName);
+    this.#templates.delete(templateName);
+
+    return { $metadata: {} };
+  }
+
+  /**
+   * The template name a request carries, once it is one SES would accept and
+   * the caller is allowed to act on it.
+   *
+   * The template need not exist. Real IAM decides a request before the service
+   * looks at it, so CreateEmailTemplate authorizes against the ARN the
+   * template is about to have, and the rest refuse a caller with no permission
+   * whether or not the template is there.
+   */
+  private named(
+    action: string,
+    input: { readonly TemplateName?: string | undefined },
+    options: SimSesRequestOptions | undefined,
+  ): string {
+    const templateName = requiredSimSesTemplateName(input.TemplateName);
+
+    this.#authorizer.authorizeTemplate(action, templateName, options?.caller);
+
+    return templateName;
+  }
+}

--- a/src/service/ses/command/template/sim-ses-template-reporting.ts
+++ b/src/service/ses/command/template/sim-ses-template-reporting.ts
@@ -1,0 +1,32 @@
+import { SimSesUnsupportedOperationException } from "../../error/sim-ses.error.js";
+import type { SimSesTemplate } from "../../template/sim-ses-template.js";
+import type { SimSesTemplateMetadata } from "./template.command.js";
+
+/**
+ * What ListEmailTemplates reports about one template.
+ */
+export function simSesTemplateMetadata(
+  template: SimSesTemplate,
+): SimSesTemplateMetadata {
+  return {
+    TemplateName: template.templateName,
+    CreatedTimestamp: template.createdDate,
+  };
+}
+
+/**
+ * Refuse tags on a template, which this simulation does not hold.
+ *
+ * An empty list is accepted: code that always passes its tags is not using the
+ * feature when it has none.
+ */
+export function refuseSimSesTemplateTags(
+  tags: readonly unknown[] | undefined,
+): void {
+  if (tags !== undefined && tags.length > 0) {
+    throw new SimSesUnsupportedOperationException(
+      "Email template tags are not simulated, so CreateEmailTemplate " +
+        "refuses them rather than dropping them",
+    );
+  }
+}

--- a/src/service/ses/command/template/template.command.ts
+++ b/src/service/ses/command/template/template.command.ts
@@ -1,0 +1,114 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+
+/**
+ * The wording of a template, as the SES v2 API carries it.
+ */
+export interface SimSesEmailTemplateContent {
+  readonly Subject?: string | undefined;
+  readonly Text?: string | undefined;
+  readonly Html?: string | undefined;
+}
+
+/**
+ * Minimal structural sim SES v2 CreateEmailTemplate command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/sesv2/command/CreateEmailTemplateCommand/
+ */
+export interface SimCreateEmailTemplateCommand {
+  readonly input: SimCreateEmailTemplateCommandInput;
+}
+
+export interface SimCreateEmailTemplateCommandInput {
+  readonly TemplateName?: string | undefined;
+  readonly TemplateContent?: SimSesEmailTemplateContent | undefined;
+  readonly Tags?: readonly unknown[] | undefined;
+}
+
+export interface SimCreateEmailTemplateCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim SES v2 GetEmailTemplate command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/sesv2/command/GetEmailTemplateCommand/
+ */
+export interface SimGetEmailTemplateCommand {
+  readonly input: SimGetEmailTemplateCommandInput;
+}
+
+export interface SimGetEmailTemplateCommandInput {
+  readonly TemplateName?: string | undefined;
+}
+
+export interface SimGetEmailTemplateCommandOutput {
+  readonly TemplateName?: string | undefined;
+  readonly TemplateContent?: SimSesEmailTemplateContent | undefined;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim SES v2 UpdateEmailTemplate command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/sesv2/command/UpdateEmailTemplateCommand/
+ */
+export interface SimUpdateEmailTemplateCommand {
+  readonly input: SimUpdateEmailTemplateCommandInput;
+}
+
+export interface SimUpdateEmailTemplateCommandInput {
+  readonly TemplateName?: string | undefined;
+  readonly TemplateContent?: SimSesEmailTemplateContent | undefined;
+}
+
+export interface SimUpdateEmailTemplateCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim SES v2 DeleteEmailTemplate command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/sesv2/command/DeleteEmailTemplateCommand/
+ */
+export interface SimDeleteEmailTemplateCommand {
+  readonly input: SimDeleteEmailTemplateCommandInput;
+}
+
+export interface SimDeleteEmailTemplateCommandInput {
+  readonly TemplateName?: string | undefined;
+}
+
+export interface SimDeleteEmailTemplateCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim SES v2 ListEmailTemplates command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/sesv2/command/ListEmailTemplatesCommand/
+ */
+export interface SimListEmailTemplatesCommand {
+  readonly input: SimListEmailTemplatesCommandInput;
+}
+
+export interface SimListEmailTemplatesCommandInput {
+  readonly PageSize?: number | undefined;
+  readonly NextToken?: string | undefined;
+}
+
+export interface SimListEmailTemplatesCommandOutput {
+  readonly TemplatesMetadata?: readonly SimSesTemplateMetadata[] | undefined;
+  readonly NextToken?: string | undefined;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * What ListEmailTemplates reports about one template.
+ *
+ * Only the name and the time it was made: the wording is not listed, and has
+ * to be read one template at a time with GetEmailTemplate.
+ */
+export interface SimSesTemplateMetadata {
+  readonly TemplateName: string;
+  readonly CreatedTimestamp: Date;
+}

--- a/src/service/ses/email/sim-ses-sent-email.ts
+++ b/src/service/ses/email/sim-ses-sent-email.ts
@@ -28,6 +28,8 @@ interface SimSesSentEmailProperties {
   readonly replyToAddresses: readonly string[];
   readonly subject: string;
   readonly body: SimSesSentEmailBody;
+  readonly templateName: string | undefined;
+  readonly templateData: Readonly<Record<string, unknown>> | undefined;
   readonly configurationSetName: string | undefined;
   readonly sentDate: Date;
 }
@@ -59,6 +61,22 @@ export class SimSesSentEmail {
 
   public readonly body: SimSesSentEmailBody;
 
+  /**
+   * The template this message was rendered from, if it was rendered from a
+   * stored one. A message written out in full has none, and so does one
+   * rendered from a template the send wrote inline.
+   */
+  public readonly templateName: string | undefined;
+
+  /**
+   * What the template's placeholders were filled from, parsed out of the JSON
+   * the send carried.
+   *
+   * This is usually the better thing for a test to assert on than the rendered
+   * body: it survives someone rewording the email.
+   */
+  public readonly templateData: Readonly<Record<string, unknown>> | undefined;
+
   public readonly configurationSetName: string | undefined;
 
   public readonly sentDate: Date;
@@ -70,6 +88,8 @@ export class SimSesSentEmail {
     this.replyToAddresses = properties.replyToAddresses;
     this.subject = properties.subject;
     this.body = properties.body;
+    this.templateName = properties.templateName;
+    this.templateData = properties.templateData;
     this.configurationSetName = properties.configurationSetName;
     this.sentDate = properties.sentDate;
   }

--- a/src/service/ses/identity/sim-ses-identity.ts
+++ b/src/service/ses/identity/sim-ses-identity.ts
@@ -1,5 +1,5 @@
 import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
-import { simSesIdentityArn } from "./sim-ses-arn.js";
+import { simSesIdentityArn } from "../sim-ses-arn.js";
 import {
   simSesIdentityKey,
   simSesIdentityType,

--- a/src/service/ses/index.ts
+++ b/src/service/ses/index.ts
@@ -13,7 +13,7 @@ export {
   type SimSesIdentityType,
   simSesIdentityType,
 } from "./identity/sim-ses-identity-name.js";
-export { simSesArnPrefix, simSesIdentityArn } from "./identity/sim-ses-arn.js";
+export { simSesArnPrefix, simSesIdentityArn } from "./sim-ses-arn.js";
 export {
   SimSesSentEmail,
   type SimSesSentEmailBody,

--- a/src/service/ses/sdk/sim-ses-sdk-command-router.ts
+++ b/src/service/ses/sdk/sim-ses-sdk-command-router.ts
@@ -14,6 +14,13 @@ import type {
   SimListEmailIdentitiesCommand,
 } from "../command/identity/identity.command.js";
 import type { SimSendEmailCommand } from "../command/send/send.command.js";
+import type {
+  SimCreateEmailTemplateCommand,
+  SimDeleteEmailTemplateCommand,
+  SimGetEmailTemplateCommand,
+  SimListEmailTemplatesCommand,
+  SimUpdateEmailTemplateCommand,
+} from "../command/template/template.command.js";
 import type { SimSesV2 } from "../sim-ses-v2.js";
 
 /**
@@ -53,6 +60,46 @@ export class SimSesSdkCommandRouter implements SimSdkCommandRouter {
         async (command, context): Promise<unknown> =>
           await simSes.deleteEmailIdentity(
             command as SimDeleteEmailIdentityCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "CreateEmailTemplateCommand",
+        async (command, context): Promise<unknown> =>
+          await simSes.createEmailTemplate(
+            command as SimCreateEmailTemplateCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "GetEmailTemplateCommand",
+        async (command, context): Promise<unknown> =>
+          await simSes.getEmailTemplate(
+            command as SimGetEmailTemplateCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "UpdateEmailTemplateCommand",
+        async (command, context): Promise<unknown> =>
+          await simSes.updateEmailTemplate(
+            command as SimUpdateEmailTemplateCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "ListEmailTemplatesCommand",
+        async (command, context): Promise<unknown> =>
+          await simSes.listEmailTemplates(
+            command as SimListEmailTemplatesCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "DeleteEmailTemplateCommand",
+        async (command, context): Promise<unknown> =>
+          await simSes.deleteEmailTemplate(
+            command as SimDeleteEmailTemplateCommand,
             simSdkCallerOptions(context),
           ),
       ],

--- a/src/service/ses/sdk/sim-ses-sdk-routing.iso.test.ts
+++ b/src/service/ses/sdk/sim-ses-sdk-routing.iso.test.ts
@@ -2,12 +2,17 @@ import {
   CreateEmailIdentityCommand,
   CreateEmailTemplateCommand,
   DeleteEmailIdentityCommand,
+  DeleteEmailTemplateCommand,
   GetAccountCommand,
   GetEmailIdentityCommand,
+  GetEmailTemplateCommand,
   ListEmailIdentitiesCommand,
+  ListEmailTemplatesCommand,
   PutAccountDetailsCommand,
+  SendBulkEmailCommand,
   SendEmailCommand,
   SESv2Client,
+  UpdateEmailTemplateCommand,
 } from "@aws-sdk/client-sesv2";
 import {
   assertArrayEquals,
@@ -43,6 +48,11 @@ describe("SimSesSdkCommandRouter", () => {
       "SendEmailCommand",
       "GetAccountCommand",
       "PutAccountDetailsCommand",
+      "CreateEmailTemplateCommand",
+      "GetEmailTemplateCommand",
+      "UpdateEmailTemplateCommand",
+      "ListEmailTemplatesCommand",
+      "DeleteEmailTemplateCommand",
     ]);
   });
 
@@ -54,7 +64,7 @@ describe("SimSesSdkCommandRouter", () => {
     const route = simAws
       .sesV2()
       .sdkCommandRouter()
-      .route("CreateEmailTemplateCommand");
+      .route("SendBulkEmailCommand");
 
     // Then there is no route for it.
     assertUndefined(route);
@@ -138,6 +148,66 @@ describe("SES SDK interception", () => {
     assertArrayLength(afterDelete.EmailIdentities ?? [], 0);
   });
 
+  it("routes a template send through the intercepted client", async () => {
+    // Given an intercepted client with a verified sender and a template.
+    using simSdk = new SimSdk();
+    simSdk.intercept(SESv2Client);
+
+    const client = new SESv2Client({ region: "eu-west-2" });
+    const scoped = simSdk.simAws.accountRegionScope(
+      simSdk.simAws.defaultAccountId,
+      "eu-west-2",
+    );
+
+    scoped.sesV2().verifyIdentity("example.com");
+    scoped.sesV2().verifyIdentity("example.org");
+
+    await client.send(
+      new CreateEmailTemplateCommand({
+        TemplateName: "welcome",
+        TemplateContent: { Subject: "Welcome, {{name}}", Text: "Hi {{name}}" },
+      }),
+    );
+
+    // When ordinary SDK code sends from it.
+    await client.send(
+      new SendEmailCommand({
+        FromEmailAddress: "hello@example.com",
+        Destination: { ToAddresses: ["someone@example.org"] },
+        Content: {
+          Template: { TemplateName: "welcome", TemplateData: '{"name":"Ada"}' },
+        },
+      }),
+    );
+
+    // Then the message was rendered and recorded with what filled it.
+    const [email] = scoped.sesV2().sentEmails();
+
+    assertNonNullable(email);
+    assertIdentical(email.subject, "Welcome, Ada");
+    assertIdentical(email.templateName, "welcome");
+
+    // And the template commands round-trip through the client too.
+    const read = await client.send(
+      new GetEmailTemplateCommand({ TemplateName: "welcome" }),
+    );
+    const listed = await client.send(new ListEmailTemplatesCommand({}));
+
+    await client.send(
+      new UpdateEmailTemplateCommand({
+        TemplateName: "welcome",
+        TemplateContent: { Subject: "Hello", Text: "Hello" },
+      }),
+    );
+    await client.send(
+      new DeleteEmailTemplateCommand({ TemplateName: "welcome" }),
+    );
+
+    assertIdentical(read.TemplateContent?.Subject, "Welcome, {{name}}");
+    assertArrayLength(listed.TemplatesMetadata ?? [], 1);
+    assertArrayLength(scoped.sesV2().allTemplates(), 0);
+  });
+
   it("keeps sends in one Region out of another", async () => {
     // Given two intercepted clients in different Regions, each with the
     // identities that Region needs.
@@ -194,9 +264,11 @@ describe("SES SDK interception", () => {
     // When a Command outside what is simulated is sent.
     const error = await assertThrowsErrorAsync(async () => {
       await client.send(
-        new CreateEmailTemplateCommand({
-          TemplateName: "welcome",
-          TemplateContent: { Subject: "Welcome" },
+        new SendBulkEmailCommand({
+          DefaultContent: { Template: { TemplateName: "welcome" } },
+          BulkEmailEntries: [
+            { Destination: { ToAddresses: ["someone@example.org"] } },
+          ],
         }),
       );
     });
@@ -204,6 +276,6 @@ describe("SES SDK interception", () => {
     // Then it is refused on send, naming the Command, rather than reaching the
     // network or quietly doing nothing.
     assertInstanceOf(error, SimSdkUnsupportedCommandError);
-    assertStringIncludes(error.message, "CreateEmailTemplateCommand");
+    assertStringIncludes(error.message, "SendBulkEmailCommand");
   });
 });

--- a/src/service/ses/sim-ses-arn.ts
+++ b/src/service/ses/sim-ses-arn.ts
@@ -1,4 +1,4 @@
-import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+import type { SimAwsAccountRegionScope } from "../aws/sim-aws-account-region-scope.js";
 
 /**
  * The start of every SES ARN in one account and region.
@@ -18,4 +18,17 @@ export function simSesIdentityArn(
   emailIdentity: string,
 ): string {
   return `${simSesArnPrefix(scope)}identity/${emailIdentity}`;
+}
+
+/**
+ * The ARN of an email template.
+ *
+ * This is the resource IAM evaluates a template operation against, so a policy
+ * can allow a caller to manage one template and not the others.
+ */
+export function simSesTemplateArn(
+  scope: SimAwsAccountRegionScope,
+  templateName: string,
+): string {
+  return `${simSesArnPrefix(scope)}template/${templateName}`;
 }

--- a/src/service/ses/sim-ses-commands.ts
+++ b/src/service/ses/sim-ses-commands.ts
@@ -12,10 +12,13 @@ import { SimSesAccount } from "./account/sim-ses-account.js";
 import { SimSesAccountCommands } from "./command/account/sim-ses-account-commands.js";
 import { SimSesAuthorizer } from "./command/authorize/sim-ses-authorizer.js";
 import { SimSesIdentityCommands } from "./command/identity/sim-ses-identity-commands.js";
+import { SimSesContentReader } from "./command/send/sim-ses-content.js";
 import { SimSesSendEmail } from "./command/send/sim-ses-send-email.js";
 import { SimSesVerifiedIdentityCheck } from "./command/send/sim-ses-verified-identities.js";
 import { SimSesSentEmailStore } from "./email/sim-ses-sent-email-store.js";
 import { SimSesIdentityStore } from "./identity/sim-ses-identity-store.js";
+import { SimSesTemplateCommands } from "./command/template/sim-ses-template-commands.js";
+import { SimSesTemplateStore } from "./template/sim-ses-template-store.js";
 
 export interface SimSesV2Properties {
   readonly accountRegionScope?: SimAwsAccountRegionScope;
@@ -33,9 +36,11 @@ export interface SimSesV2Properties {
  */
 export class SimSesCommands {
   readonly identities: SimSesIdentityStore;
+  readonly templates: SimSesTemplateStore;
   readonly sent: SimSesSentEmailStore;
   readonly account: SimSesAccount;
   readonly identityCommands: SimSesIdentityCommands;
+  readonly templateCommands: SimSesTemplateCommands;
   readonly sendEmail: SimSesSendEmail;
   readonly accountCommands: SimSesAccountCommands;
   readonly background: BackgroundScheduler;
@@ -49,11 +54,13 @@ export class SimSesCommands {
 
     const authorizer = new SimSesAuthorizer({ iam, accountRegionScope });
     const identities = new SimSesIdentityStore({ accountRegionScope });
+    const templates = new SimSesTemplateStore({ accountRegionScope });
     const sent = new SimSesSentEmailStore();
     const account = new SimSesAccount();
 
     this.background = background;
     this.identities = identities;
+    this.templates = templates;
     this.sent = sent;
     this.account = account;
     this.identityCommands = new SimSesIdentityCommands({
@@ -61,8 +68,14 @@ export class SimSesCommands {
       authorizer,
       clock: background,
     });
+    this.templateCommands = new SimSesTemplateCommands({
+      templates,
+      authorizer,
+      clock: background,
+    });
     this.sendEmail = new SimSesSendEmail({
       identities,
+      content: new SimSesContentReader({ templates }),
       sent,
       identityCheck: new SimSesVerifiedIdentityCheck({
         identities,

--- a/src/service/ses/sim-ses-send-refusals.iso.test.ts
+++ b/src/service/ses/sim-ses-send-refusals.iso.test.ts
@@ -143,29 +143,6 @@ describe("SimSesV2 SendEmail refusals", () => {
     assertStringIncludes(error.message, "Content.Raw");
   });
 
-  it("refuses template content by name", async () => {
-    // Given a simulated SES that would otherwise accept the message.
-    const ses = await sendingSes();
-
-    // When a message is sent from a template.
-    const error = await assertThrowsErrorAsync(async () => {
-      await ses.sendEmail(
-        new SendEmailCommand({
-          ...welcome,
-          Content: {
-            Template: {
-              TemplateName: "welcome",
-              TemplateData: '{"name":"Ada"}',
-            },
-          },
-        }),
-      );
-    });
-
-    assertInstanceOf(error, SimSesUnsupportedOperationException);
-    assertStringIncludes(error.message, "Content.Template");
-  });
-
   it("refuses a message with attachments", async () => {
     // Given a simulated SES that would otherwise accept the message.
     const ses = await sendingSes();

--- a/src/service/ses/sim-ses-template-refusals.iso.test.ts
+++ b/src/service/ses/sim-ses-template-refusals.iso.test.ts
@@ -2,11 +2,9 @@ import {
   CreateEmailTemplateCommand,
   DeleteEmailTemplateCommand,
   GetEmailTemplateCommand,
-  SendEmailCommand,
   UpdateEmailTemplateCommand,
 } from "@aws-sdk/client-sesv2";
 import {
-  assertArrayLength,
   assertIdentical,
   assertInstanceOf,
   assertStringIncludes,
@@ -21,87 +19,8 @@ import {
   SimSesNotFoundException,
   SimSesUnsupportedOperationException,
 } from "./error/sim-ses.error.js";
-import type { SimSesV2 } from "./sim-ses-v2.js";
-
-/** A simulated SES with both ends verified, so a send reaches the rendering. */
-function sendingSes(): SimSesV2 {
-  const ses = new SimAws().sesV2();
-
-  ses.verifyIdentity("hello@example.com");
-  ses.verifyIdentity("someone@example.org");
-
-  return ses;
-}
-
-function templatedSend(
-  templateName: string,
-  templateData?: string,
-): SendEmailCommand {
-  return new SendEmailCommand({
-    FromEmailAddress: "hello@example.com",
-    Destination: { ToAddresses: ["someone@example.org"] },
-    Content: {
-      Template: { TemplateName: templateName, TemplateData: templateData },
-    },
-  });
-}
 
 describe("SimSesV2 template refusals", () => {
-  it("refuses a send naming a template that is not there", async () => {
-    // Given a simulated SES with no templates.
-    const ses = sendingSes();
-
-    // When a message is sent from one.
-    const error = await assertThrowsErrorAsync(async () => {
-      await ses.sendEmail(templatedSend("welcome", "{}"));
-    });
-
-    // Then it fails rather than sending an empty message, and nothing is
-    // recorded.
-    assertInstanceOf(error, SimSesNotFoundException);
-    assertArrayLength(ses.sentEmails(), 0);
-  });
-
-  it("refuses template data that is not JSON", async () => {
-    // Given a simulated SES with a template.
-    const ses = sendingSes();
-
-    await ses.createEmailTemplate(
-      new CreateEmailTemplateCommand({
-        TemplateName: "welcome",
-        TemplateContent: { Subject: "Hi {{name}}", Text: "Hi {{name}}" },
-      }),
-    );
-
-    // When a message is sent with malformed data.
-    const error = await assertThrowsErrorAsync(async () => {
-      await ses.sendEmail(templatedSend("welcome", "{not json"));
-    });
-
-    // Then it is refused rather than silently rendering nothing.
-    assertInstanceOf(error, SimSesBadRequestException);
-  });
-
-  it("refuses template data that is not a JSON object", async () => {
-    // Given a simulated SES with a template.
-    const ses = sendingSes();
-
-    await ses.createEmailTemplate(
-      new CreateEmailTemplateCommand({
-        TemplateName: "welcome",
-        TemplateContent: { Subject: "Hi {{name}}", Text: "Hi {{name}}" },
-      }),
-    );
-
-    // When a message is sent with a JSON array rather than an object.
-    const error = await assertThrowsErrorAsync(async () => {
-      await ses.sendEmail(templatedSend("welcome", '["Ada"]'));
-    });
-
-    // Then it is refused: placeholders are read off an object.
-    assertInstanceOf(error, SimSesBadRequestException);
-  });
-
   it("refuses a template containing a block helper", async () => {
     // Given a simulated SES.
     const ses = new SimAws().sesV2();
@@ -258,77 +177,12 @@ describe("SimSesV2 template refusals", () => {
     assertInstanceOf(deleted, SimSesNotFoundException);
   });
 
-  it("refuses template data holding something that cannot go in a message", async () => {
-    // Given a template naming a value.
-    const ses = sendingSes();
-
-    await ses.createEmailTemplate(
-      new CreateEmailTemplateCommand({
-        TemplateName: "welcome",
-        TemplateContent: { Subject: "Hi", Text: "Hi {{customer}}" },
-      }),
-    );
-
-    // When the data has an object where the template wants a name.
-    const error = await assertThrowsErrorAsync(async () => {
-      await ses.sendEmail(
-        templatedSend("welcome", '{"customer":{"name":"Ada"}}'),
-      );
-    });
-
-    // Then it says so. Real Handlebars would put `[object Object]` in the
-    // message, which nobody means to send.
-    assertInstanceOf(error, SimSesUnsupportedOperationException);
-    assertStringIncludes(error.message, "{{customer}}");
-  });
-
-  it("refuses a template send naming neither a template nor its content", async () => {
-    // Given a simulated SES with both ends verified.
-    const ses = sendingSes();
-
-    // When a send carries an empty template branch.
-    const error = await assertThrowsErrorAsync(async () => {
-      await ses.sendEmail(
-        new SendEmailCommand({
-          FromEmailAddress: "hello@example.com",
-          Destination: { ToAddresses: ["someone@example.org"] },
-          Content: { Template: {} },
-        }),
-      );
-    });
-
-    assertInstanceOf(error, SimSesBadRequestException);
-  });
-
-  it("refuses sending another Account's shared template", async () => {
-    // Given a simulated SES with both ends verified.
-    const ses = sendingSes();
-
-    // When a send names a template by ARN rather than by name.
-    const error = await assertThrowsErrorAsync(async () => {
-      await ses.sendEmail(
-        new SendEmailCommand({
-          FromEmailAddress: "hello@example.com",
-          Destination: { ToAddresses: ["someone@example.org"] },
-          Content: {
-            Template: {
-              TemplateArn:
-                "arn:aws:ses:us-east-1:222222222222:template/welcome",
-            },
-          },
-        }),
-      );
-    });
-
-    assertInstanceOf(error, SimSesUnsupportedOperationException);
-  });
-
-  it("refuses template tags and attachments, which are not simulated", async () => {
-    // Given a simulated SES with both ends verified.
-    const ses = sendingSes();
+  it("refuses template tags, which are not simulated", async () => {
+    // Given a simulated SES.
+    const ses = new SimAws().sesV2();
 
     // When a template is created with tags.
-    const tagged = await assertThrowsErrorAsync(async () => {
+    const error = await assertThrowsErrorAsync(async () => {
       await ses.createEmailTemplate(
         new CreateEmailTemplateCommand({
           TemplateName: "welcome",
@@ -338,26 +192,7 @@ describe("SimSesV2 template refusals", () => {
       );
     });
 
-    // And when a template send carries an attachment.
-    const attached = await assertThrowsErrorAsync(async () => {
-      await ses.sendEmail(
-        new SendEmailCommand({
-          FromEmailAddress: "hello@example.com",
-          Destination: { ToAddresses: ["someone@example.org"] },
-          Content: {
-            Template: {
-              TemplateContent: { Text: "Hi" },
-              Attachments: [
-                { FileName: "terms.pdf", RawContent: new Uint8Array([1]) },
-              ],
-            },
-          },
-        }),
-      );
-    });
-
-    assertInstanceOf(tagged, SimSesUnsupportedOperationException);
-    assertInstanceOf(attached, SimSesUnsupportedOperationException);
+    assertInstanceOf(error, SimSesUnsupportedOperationException);
   });
 
   it("refuses a template carrying no content at all", async () => {

--- a/src/service/ses/sim-ses-template-refusals.iso.test.ts
+++ b/src/service/ses/sim-ses-template-refusals.iso.test.ts
@@ -1,0 +1,388 @@
+import {
+  CreateEmailTemplateCommand,
+  DeleteEmailTemplateCommand,
+  GetEmailTemplateCommand,
+  SendEmailCommand,
+  UpdateEmailTemplateCommand,
+} from "@aws-sdk/client-sesv2";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../aws/sim-aws.js";
+import {
+  SimSesAlreadyExistsException,
+  SimSesBadRequestException,
+  SimSesNotFoundException,
+  SimSesUnsupportedOperationException,
+} from "./error/sim-ses.error.js";
+import type { SimSesV2 } from "./sim-ses-v2.js";
+
+/** A simulated SES with both ends verified, so a send reaches the rendering. */
+function sendingSes(): SimSesV2 {
+  const ses = new SimAws().sesV2();
+
+  ses.verifyIdentity("hello@example.com");
+  ses.verifyIdentity("someone@example.org");
+
+  return ses;
+}
+
+function templatedSend(
+  templateName: string,
+  templateData?: string,
+): SendEmailCommand {
+  return new SendEmailCommand({
+    FromEmailAddress: "hello@example.com",
+    Destination: { ToAddresses: ["someone@example.org"] },
+    Content: {
+      Template: { TemplateName: templateName, TemplateData: templateData },
+    },
+  });
+}
+
+describe("SimSesV2 template refusals", () => {
+  it("refuses a send naming a template that is not there", async () => {
+    // Given a simulated SES with no templates.
+    const ses = sendingSes();
+
+    // When a message is sent from one.
+    const error = await assertThrowsErrorAsync(async () => {
+      await ses.sendEmail(templatedSend("welcome", "{}"));
+    });
+
+    // Then it fails rather than sending an empty message, and nothing is
+    // recorded.
+    assertInstanceOf(error, SimSesNotFoundException);
+    assertArrayLength(ses.sentEmails(), 0);
+  });
+
+  it("refuses template data that is not JSON", async () => {
+    // Given a simulated SES with a template.
+    const ses = sendingSes();
+
+    await ses.createEmailTemplate(
+      new CreateEmailTemplateCommand({
+        TemplateName: "welcome",
+        TemplateContent: { Subject: "Hi {{name}}", Text: "Hi {{name}}" },
+      }),
+    );
+
+    // When a message is sent with malformed data.
+    const error = await assertThrowsErrorAsync(async () => {
+      await ses.sendEmail(templatedSend("welcome", "{not json"));
+    });
+
+    // Then it is refused rather than silently rendering nothing.
+    assertInstanceOf(error, SimSesBadRequestException);
+  });
+
+  it("refuses template data that is not a JSON object", async () => {
+    // Given a simulated SES with a template.
+    const ses = sendingSes();
+
+    await ses.createEmailTemplate(
+      new CreateEmailTemplateCommand({
+        TemplateName: "welcome",
+        TemplateContent: { Subject: "Hi {{name}}", Text: "Hi {{name}}" },
+      }),
+    );
+
+    // When a message is sent with a JSON array rather than an object.
+    const error = await assertThrowsErrorAsync(async () => {
+      await ses.sendEmail(templatedSend("welcome", '["Ada"]'));
+    });
+
+    // Then it is refused: placeholders are read off an object.
+    assertInstanceOf(error, SimSesBadRequestException);
+  });
+
+  it("refuses a template containing a block helper", async () => {
+    // Given a simulated SES.
+    const ses = new SimAws().sesV2();
+
+    // When a template uses Handlebars beyond plain substitution.
+    const error = await assertThrowsErrorAsync(async () => {
+      await ses.createEmailTemplate(
+        new CreateEmailTemplateCommand({
+          TemplateName: "welcome",
+          TemplateContent: {
+            Subject: "Welcome",
+            Text: "{{#if premium}}Thanks for subscribing{{/if}}",
+          },
+        }),
+      );
+    });
+
+    // Then it is refused where the template is written, rather than left in
+    // place to survive into a sent message no real SES would produce.
+    assertInstanceOf(error, SimSesUnsupportedOperationException);
+    assertStringIncludes(error.message, "block helper");
+  });
+
+  it("refuses an update that introduces a block helper", async () => {
+    // Given a template that renders.
+    const ses = new SimAws().sesV2();
+
+    await ses.createEmailTemplate(
+      new CreateEmailTemplateCommand({
+        TemplateName: "welcome",
+        TemplateContent: { Subject: "Welcome", Text: "Hi {{name}}" },
+      }),
+    );
+
+    // When it is reworded to use one.
+    const error = await assertThrowsErrorAsync(async () => {
+      await ses.updateEmailTemplate(
+        new UpdateEmailTemplateCommand({
+          TemplateName: "welcome",
+          TemplateContent: {
+            Subject: "Welcome",
+            Text: "{{#each items}}{{this}}{{/each}}",
+          },
+        }),
+      );
+    });
+
+    assertInstanceOf(error, SimSesUnsupportedOperationException);
+
+    // And the template it had is untouched.
+    const read = await ses.getEmailTemplate(
+      new GetEmailTemplateCommand({ TemplateName: "welcome" }),
+    );
+
+    assertIdentical(read.TemplateContent?.Text, "Hi {{name}}");
+  });
+
+  it("refuses a template with none of its three parts", async () => {
+    // Given a simulated SES.
+    const ses = new SimAws().sesV2();
+
+    // When a template is created with nothing to say.
+    const error = await assertThrowsErrorAsync(async () => {
+      await ses.createEmailTemplate(
+        new CreateEmailTemplateCommand({
+          TemplateName: "welcome",
+          TemplateContent: {},
+        }),
+      );
+    });
+
+    assertInstanceOf(error, SimSesBadRequestException);
+  });
+
+  it("refuses a template with no name", async () => {
+    // Given a simulated SES.
+    const ses = new SimAws().sesV2();
+
+    // When a template is created without one.
+    const error = await assertThrowsErrorAsync(async () => {
+      await ses.createEmailTemplate(
+        new CreateEmailTemplateCommand({
+          TemplateName: "",
+          TemplateContent: { Text: "Hi" },
+        }),
+      );
+    });
+
+    assertInstanceOf(error, SimSesBadRequestException);
+  });
+
+  it("refuses a template name longer than SES accepts", async () => {
+    // Given a simulated SES.
+    const ses = new SimAws().sesV2();
+
+    // When a template is created with a name past the length limit.
+    const error = await assertThrowsErrorAsync(async () => {
+      await ses.createEmailTemplate(
+        new CreateEmailTemplateCommand({
+          TemplateName: "a".repeat(65),
+          TemplateContent: { Text: "Hi" },
+        }),
+      );
+    });
+
+    assertInstanceOf(error, SimSesBadRequestException);
+  });
+
+  it("refuses a template that already exists", async () => {
+    // Given a template that has been created.
+    const ses = new SimAws().sesV2();
+    const command = new CreateEmailTemplateCommand({
+      TemplateName: "welcome",
+      TemplateContent: { Text: "Hi" },
+    });
+
+    await ses.createEmailTemplate(command);
+
+    // When the same one is created again.
+    const error = await assertThrowsErrorAsync(async () => {
+      await ses.createEmailTemplate(command);
+    });
+
+    assertInstanceOf(error, SimSesAlreadyExistsException);
+  });
+
+  it("refuses reading, updating or deleting a template that is not there", async () => {
+    // Given a simulated SES with no templates.
+    const ses = new SimAws().sesV2();
+
+    // When each of the three is tried on one.
+    const read = await assertThrowsErrorAsync(async () => {
+      await ses.getEmailTemplate(
+        new GetEmailTemplateCommand({ TemplateName: "welcome" }),
+      );
+    });
+    const updated = await assertThrowsErrorAsync(async () => {
+      await ses.updateEmailTemplate(
+        new UpdateEmailTemplateCommand({
+          TemplateName: "welcome",
+          TemplateContent: { Text: "Hi" },
+        }),
+      );
+    });
+    const deleted = await assertThrowsErrorAsync(async () => {
+      await ses.deleteEmailTemplate(
+        new DeleteEmailTemplateCommand({ TemplateName: "welcome" }),
+      );
+    });
+
+    // Then each is a NotFoundException, as it is on real SES.
+    assertInstanceOf(read, SimSesNotFoundException);
+    assertInstanceOf(updated, SimSesNotFoundException);
+    assertInstanceOf(deleted, SimSesNotFoundException);
+  });
+
+  it("refuses template data holding something that cannot go in a message", async () => {
+    // Given a template naming a value.
+    const ses = sendingSes();
+
+    await ses.createEmailTemplate(
+      new CreateEmailTemplateCommand({
+        TemplateName: "welcome",
+        TemplateContent: { Subject: "Hi", Text: "Hi {{customer}}" },
+      }),
+    );
+
+    // When the data has an object where the template wants a name.
+    const error = await assertThrowsErrorAsync(async () => {
+      await ses.sendEmail(
+        templatedSend("welcome", '{"customer":{"name":"Ada"}}'),
+      );
+    });
+
+    // Then it says so. Real Handlebars would put `[object Object]` in the
+    // message, which nobody means to send.
+    assertInstanceOf(error, SimSesUnsupportedOperationException);
+    assertStringIncludes(error.message, "{{customer}}");
+  });
+
+  it("refuses a template send naming neither a template nor its content", async () => {
+    // Given a simulated SES with both ends verified.
+    const ses = sendingSes();
+
+    // When a send carries an empty template branch.
+    const error = await assertThrowsErrorAsync(async () => {
+      await ses.sendEmail(
+        new SendEmailCommand({
+          FromEmailAddress: "hello@example.com",
+          Destination: { ToAddresses: ["someone@example.org"] },
+          Content: { Template: {} },
+        }),
+      );
+    });
+
+    assertInstanceOf(error, SimSesBadRequestException);
+  });
+
+  it("refuses sending another Account's shared template", async () => {
+    // Given a simulated SES with both ends verified.
+    const ses = sendingSes();
+
+    // When a send names a template by ARN rather than by name.
+    const error = await assertThrowsErrorAsync(async () => {
+      await ses.sendEmail(
+        new SendEmailCommand({
+          FromEmailAddress: "hello@example.com",
+          Destination: { ToAddresses: ["someone@example.org"] },
+          Content: {
+            Template: {
+              TemplateArn:
+                "arn:aws:ses:us-east-1:222222222222:template/welcome",
+            },
+          },
+        }),
+      );
+    });
+
+    assertInstanceOf(error, SimSesUnsupportedOperationException);
+  });
+
+  it("refuses template tags and attachments, which are not simulated", async () => {
+    // Given a simulated SES with both ends verified.
+    const ses = sendingSes();
+
+    // When a template is created with tags.
+    const tagged = await assertThrowsErrorAsync(async () => {
+      await ses.createEmailTemplate(
+        new CreateEmailTemplateCommand({
+          TemplateName: "welcome",
+          TemplateContent: { Text: "Hi" },
+          Tags: [{ Key: "team", Value: "orders" }],
+        }),
+      );
+    });
+
+    // And when a template send carries an attachment.
+    const attached = await assertThrowsErrorAsync(async () => {
+      await ses.sendEmail(
+        new SendEmailCommand({
+          FromEmailAddress: "hello@example.com",
+          Destination: { ToAddresses: ["someone@example.org"] },
+          Content: {
+            Template: {
+              TemplateContent: { Text: "Hi" },
+              Attachments: [
+                { FileName: "terms.pdf", RawContent: new Uint8Array([1]) },
+              ],
+            },
+          },
+        }),
+      );
+    });
+
+    assertInstanceOf(tagged, SimSesUnsupportedOperationException);
+    assertInstanceOf(attached, SimSesUnsupportedOperationException);
+  });
+
+  it("refuses a template carrying no content at all", async () => {
+    // Given a template that has been created.
+    const ses = new SimAws().sesV2();
+
+    await ses.createEmailTemplate(
+      new CreateEmailTemplateCommand({
+        TemplateName: "welcome",
+        TemplateContent: { Text: "Hi" },
+      }),
+    );
+
+    // When one is created, and another updated, with TemplateContent left out
+    // of the request entirely. The SDK types make that unsayable, so these are
+    // written as the bare Command shape a caller in JavaScript can still send.
+    const created = await assertThrowsErrorAsync(async () => {
+      await ses.createEmailTemplate({ input: { TemplateName: "receipt" } });
+    });
+    const updated = await assertThrowsErrorAsync(async () => {
+      await ses.updateEmailTemplate({ input: { TemplateName: "welcome" } });
+    });
+
+    // Then both are refused: TemplateContent is required on real SES.
+    assertInstanceOf(created, SimSesBadRequestException);
+    assertInstanceOf(updated, SimSesBadRequestException);
+  });
+});

--- a/src/service/ses/sim-ses-template-send-refusals.iso.test.ts
+++ b/src/service/ses/sim-ses-template-send-refusals.iso.test.ts
@@ -1,0 +1,221 @@
+import {
+  CreateEmailTemplateCommand,
+  SendEmailCommand,
+} from "@aws-sdk/client-sesv2";
+import {
+  assertArrayLength,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../aws/sim-aws.js";
+import {
+  SimSesBadRequestException,
+  SimSesNotFoundException,
+  SimSesUnsupportedOperationException,
+} from "./error/sim-ses.error.js";
+import type { SimSesV2 } from "./sim-ses-v2.js";
+
+/** A simulated SES with both ends verified, so a send reaches the rendering. */
+function sendingSes(): SimSesV2 {
+  const ses = new SimAws().sesV2();
+
+  ses.verifyIdentity("hello@example.com");
+  ses.verifyIdentity("someone@example.org");
+
+  return ses;
+}
+
+/** A send from a stored template, with whatever data the test wants. */
+function templatedSend(
+  templateName: string,
+  templateData?: string,
+): SendEmailCommand {
+  return new SendEmailCommand({
+    FromEmailAddress: "hello@example.com",
+    Destination: { ToAddresses: ["someone@example.org"] },
+    Content: {
+      Template: { TemplateName: templateName, TemplateData: templateData },
+    },
+  });
+}
+
+describe("SimSesV2 template send refusals", () => {
+  it("refuses a send naming a template that is not there", async () => {
+    // Given a simulated SES with no templates.
+    const ses = sendingSes();
+
+    // When a message is sent from one.
+    const error = await assertThrowsErrorAsync(async () => {
+      await ses.sendEmail(templatedSend("welcome", "{}"));
+    });
+
+    // Then it fails rather than sending an empty message, and nothing is
+    // recorded.
+    assertInstanceOf(error, SimSesNotFoundException);
+    assertArrayLength(ses.sentEmails(), 0);
+  });
+
+  it("refuses template data that is not JSON", async () => {
+    // Given a simulated SES with a template.
+    const ses = sendingSes();
+
+    await ses.createEmailTemplate(
+      new CreateEmailTemplateCommand({
+        TemplateName: "welcome",
+        TemplateContent: { Subject: "Hi {{name}}", Text: "Hi {{name}}" },
+      }),
+    );
+
+    // When a message is sent with malformed data.
+    const error = await assertThrowsErrorAsync(async () => {
+      await ses.sendEmail(templatedSend("welcome", "{not json"));
+    });
+
+    // Then it is refused rather than silently rendering nothing.
+    assertInstanceOf(error, SimSesBadRequestException);
+  });
+
+  it("refuses template data that is not a JSON object", async () => {
+    // Given a simulated SES with a template.
+    const ses = sendingSes();
+
+    await ses.createEmailTemplate(
+      new CreateEmailTemplateCommand({
+        TemplateName: "welcome",
+        TemplateContent: { Subject: "Hi {{name}}", Text: "Hi {{name}}" },
+      }),
+    );
+
+    // When a message is sent with a JSON array rather than an object.
+    const error = await assertThrowsErrorAsync(async () => {
+      await ses.sendEmail(templatedSend("welcome", '["Ada"]'));
+    });
+
+    // Then it is refused: placeholders are read off an object.
+    assertInstanceOf(error, SimSesBadRequestException);
+  });
+  it("refuses template data holding something that cannot go in a message", async () => {
+    // Given a template naming a value.
+    const ses = sendingSes();
+
+    await ses.createEmailTemplate(
+      new CreateEmailTemplateCommand({
+        TemplateName: "welcome",
+        TemplateContent: { Subject: "Hi", Text: "Hi {{customer}}" },
+      }),
+    );
+
+    // When the data has an object where the template wants a name.
+    const error = await assertThrowsErrorAsync(async () => {
+      await ses.sendEmail(
+        templatedSend("welcome", '{"customer":{"name":"Ada"}}'),
+      );
+    });
+
+    // Then it says so. Real Handlebars would put `[object Object]` in the
+    // message, which nobody means to send.
+    assertInstanceOf(error, SimSesUnsupportedOperationException);
+    assertStringIncludes(error.message, "{{customer}}");
+  });
+
+  it("refuses a template send naming neither a template nor its content", async () => {
+    // Given a simulated SES with both ends verified.
+    const ses = sendingSes();
+
+    // When a send carries an empty template branch.
+    const error = await assertThrowsErrorAsync(async () => {
+      await ses.sendEmail(
+        new SendEmailCommand({
+          FromEmailAddress: "hello@example.com",
+          Destination: { ToAddresses: ["someone@example.org"] },
+          Content: { Template: {} },
+        }),
+      );
+    });
+
+    assertInstanceOf(error, SimSesBadRequestException);
+  });
+
+  it("refuses sending another Account's shared template", async () => {
+    // Given a simulated SES with both ends verified.
+    const ses = sendingSes();
+
+    // When a send names a template by ARN rather than by name.
+    const error = await assertThrowsErrorAsync(async () => {
+      await ses.sendEmail(
+        new SendEmailCommand({
+          FromEmailAddress: "hello@example.com",
+          Destination: { ToAddresses: ["someone@example.org"] },
+          Content: {
+            Template: {
+              TemplateArn:
+                "arn:aws:ses:us-east-1:222222222222:template/welcome",
+            },
+          },
+        }),
+      );
+    });
+
+    assertInstanceOf(error, SimSesUnsupportedOperationException);
+  });
+  it("refuses a send naming both a template and its content", async () => {
+    // Given a simulated SES with a stored template.
+    const ses = sendingSes();
+
+    await ses.createEmailTemplate(
+      new CreateEmailTemplateCommand({
+        TemplateName: "welcome",
+        TemplateContent: { Subject: "Stored", Text: "Stored" },
+      }),
+    );
+
+    // When a send names that template and also writes wording out inline.
+    const error = await assertThrowsErrorAsync(async () => {
+      await ses.sendEmail(
+        new SendEmailCommand({
+          FromEmailAddress: "hello@example.com",
+          Destination: { ToAddresses: ["someone@example.org"] },
+          Content: {
+            Template: {
+              TemplateName: "welcome",
+              TemplateContent: { Subject: "Inline", Text: "Inline" },
+            },
+          },
+        }),
+      );
+    });
+
+    // Then it is refused rather than rendering one and recording the other,
+    // which would file the message under a template it never came from.
+    assertInstanceOf(error, SimSesUnsupportedOperationException);
+    assertArrayLength(ses.sentEmails(), 0);
+  });
+
+  it("refuses attachments on a template send", async () => {
+    // Given a simulated SES with both ends verified.
+    const ses = sendingSes();
+
+    // When a template send carries an attachment.
+    const error = await assertThrowsErrorAsync(async () => {
+      await ses.sendEmail(
+        new SendEmailCommand({
+          FromEmailAddress: "hello@example.com",
+          Destination: { ToAddresses: ["someone@example.org"] },
+          Content: {
+            Template: {
+              TemplateContent: { Text: "Hi" },
+              Attachments: [
+                { FileName: "terms.pdf", RawContent: new Uint8Array([1]) },
+              ],
+            },
+          },
+        }),
+      );
+    });
+
+    assertInstanceOf(error, SimSesUnsupportedOperationException);
+  });
+});

--- a/src/service/ses/sim-ses-template-send.iso.test.ts
+++ b/src/service/ses/sim-ses-template-send.iso.test.ts
@@ -1,0 +1,270 @@
+import {
+  CreateEmailTemplateCommand,
+  SendEmailCommand,
+  UpdateEmailTemplateCommand,
+} from "@aws-sdk/client-sesv2";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertObjectEquals,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../aws/sim-aws.js";
+import type { SimSesV2 } from "./sim-ses-v2.js";
+
+/** The template most of these tests render. */
+const welcomeContent: Readonly<Record<string, string>> = {
+  Subject: "Welcome, {{name}}",
+  Text: "Hi {{name}}, thanks for signing up.",
+  Html: "<p>Hi {{name}}</p>",
+};
+
+/**
+ * A simulated SES with both ends verified and one template stored, so a test
+ * here is about the rendering rather than the identity checks.
+ */
+async function templatedSes(
+  content: Readonly<Record<string, string>> = welcomeContent,
+): Promise<SimSesV2> {
+  const ses = new SimAws().sesV2();
+
+  ses.verifyIdentity("hello@example.com");
+  ses.verifyIdentity("someone@example.org");
+
+  await ses.createEmailTemplate(
+    new CreateEmailTemplateCommand({
+      TemplateName: "welcome",
+      TemplateContent: content,
+    }),
+  );
+
+  return ses;
+}
+
+/** A send from the stored template, with whatever data the test wants. */
+function templatedSend(templateData?: string): SendEmailCommand {
+  return new SendEmailCommand({
+    FromEmailAddress: "hello@example.com",
+    Destination: { ToAddresses: ["someone@example.org"] },
+    Content: {
+      Template: { TemplateName: "welcome", TemplateData: templateData },
+    },
+  });
+}
+
+describe("SimSesV2 template sends", () => {
+  it("renders the subject, text and HTML from the template data", async () => {
+    // Given a simulated SES with a template.
+    const ses = await templatedSes();
+
+    // When a message is sent from it.
+    await ses.sendEmail(templatedSend('{"name":"Ada"}'));
+
+    // Then every part was rendered against the data.
+    const [email] = ses.sentEmails();
+
+    assertNonNullable(email);
+    assertIdentical(email.subject, "Welcome, Ada");
+    assertIdentical(email.body.text, "Hi Ada, thanks for signing up.");
+    assertIdentical(email.body.html, "<p>Hi Ada</p>");
+  });
+
+  it("records the template name and the data that filled it", async () => {
+    // Given a simulated SES with a template.
+    const ses = await templatedSes();
+
+    // When a message is sent from it.
+    await ses.sendEmail(templatedSend('{"name":"Ada"}'));
+
+    // Then the record carries both, which is the better thing to assert on:
+    // it survives someone rewording the email.
+    const [email] = ses.sentEmails();
+
+    assertNonNullable(email);
+    assertIdentical(email.templateName, "welcome");
+    assertObjectEquals(email.templateData, { name: "Ada" });
+  });
+
+  it("records no template for a message written out in full", async () => {
+    // Given a simulated SES with both ends verified.
+    const ses = await templatedSes();
+
+    // When a message is sent without a template.
+    await ses.sendEmail(
+      new SendEmailCommand({
+        FromEmailAddress: "hello@example.com",
+        Destination: { ToAddresses: ["someone@example.org"] },
+        Content: {
+          Simple: {
+            Subject: { Data: "Welcome" },
+            Body: { Text: { Data: "Hi there" } },
+          },
+        },
+      }),
+    );
+
+    // Then there is no template to report, so a test can tell the two kinds of
+    // send apart.
+    const [email] = ses.sentEmails();
+
+    assertNonNullable(email);
+    assertUndefined(email.templateName);
+    assertUndefined(email.templateData);
+  });
+
+  it("renders a placeholder the data does not have as nothing", async () => {
+    // Given a template whose data is missing one of its placeholders.
+    const ses = await templatedSes({
+      Subject: "Welcome",
+      Text: "Hi {{name}}, your order {{orderId}} is on its way.",
+    });
+
+    // When a message is sent with only some of them filled.
+    await ses.sendEmail(templatedSend('{"name":"Ada"}'));
+
+    // Then the hole is silent, as it is on real SES. This is much the
+    // commonest surprise in an SES template, and asserting on the rendered
+    // body is how it gets caught.
+    assertIdentical(
+      ses.sentEmails().at(0)?.body.text,
+      "Hi Ada, your order  is on its way.",
+    );
+  });
+
+  it("renders every placeholder empty when a send carries no data", async () => {
+    // Given a template with placeholders.
+    const ses = await templatedSes();
+
+    // When a message is sent with no TemplateData at all.
+    await ses.sendEmail(templatedSend());
+
+    // Then it renders as though the data were empty, which is how real SES
+    // treats a missing TemplateData.
+    const [email] = ses.sentEmails();
+
+    assertNonNullable(email);
+    assertIdentical(email.subject, "Welcome, ");
+    assertObjectEquals(email.templateData, {});
+  });
+
+  it("reads a dotted path into the template data", async () => {
+    // Given a template naming a nested value.
+    const ses = await templatedSes({
+      Subject: "Order {{order.id}}",
+      Text: "Hi {{customer.name}}",
+    });
+
+    // When a message is sent with nested data.
+    await ses.sendEmail(
+      templatedSend('{"order":{"id":"A-1"},"customer":{"name":"Ada"}}'),
+    );
+
+    // Then each path was walked, as Handlebars walks it.
+    const [email] = ses.sentEmails();
+
+    assertNonNullable(email);
+    assertIdentical(email.subject, "Order A-1");
+    assertIdentical(email.body.text, "Hi Ada");
+  });
+
+  it("renders a path that runs off the end of the data as nothing", async () => {
+    // Given a template naming a nested value.
+    const ses = await templatedSes({ Subject: "S", Text: "Hi {{a.b.c}}" });
+
+    // When the data stops short of it.
+    await ses.sendEmail(templatedSend('{"a":{"b":"not an object"}}'));
+
+    assertIdentical(ses.sentEmails().at(0)?.body.text, "Hi ");
+  });
+
+  it("does not reach up the prototype chain", async () => {
+    // Given a template naming something every object inherits.
+    const ses = await templatedSes({
+      Subject: "S",
+      Text: "Hi {{constructor}}",
+    });
+
+    // When a message is sent.
+    await ses.sendEmail(templatedSend("{}"));
+
+    // Then it renders as nothing rather than reaching Object's own property.
+    assertIdentical(ses.sentEmails().at(0)?.body.text, "Hi ");
+  });
+
+  it("renders numbers and booleans as well as strings", async () => {
+    // Given a template naming values that are not strings.
+    const ses = await templatedSes({
+      Subject: "S",
+      Text: "{{count}} items, gift {{isGift}}",
+    });
+
+    // When a message is sent with them.
+    await ses.sendEmail(templatedSend('{"count":3,"isGift":true}'));
+
+    assertIdentical(ses.sentEmails().at(0)?.body.text, "3 items, gift true");
+  });
+
+  it("picks up a template's new wording after an update", async () => {
+    // Given a template a message has already been sent from.
+    const ses = await templatedSes();
+
+    await ses.sendEmail(templatedSend('{"name":"Ada"}'));
+
+    // When the template is reworded and another message goes out.
+    await ses.updateEmailTemplate(
+      new UpdateEmailTemplateCommand({
+        TemplateName: "welcome",
+        TemplateContent: { Subject: "Hello {{name}}", Text: "Hello {{name}}" },
+      }),
+    );
+    await ses.sendEmail(templatedSend('{"name":"Grace"}'));
+
+    // Then the second one used the new wording, as it would on real SES: an
+    // update replaces the template rather than making a new one.
+    assertArrayLength(ses.sentEmails(), 2);
+    assertIdentical(ses.sentEmails().at(0)?.subject, "Welcome, Ada");
+    assertIdentical(ses.sentEmails().at(1)?.subject, "Hello Grace");
+  });
+
+  it("renders an empty subject for a template that has none", async () => {
+    // Given a template with a body and no subject.
+    const ses = await templatedSes({ Text: "Hi {{name}}" });
+
+    // When a message is sent from it.
+    await ses.sendEmail(templatedSend('{"name":"Ada"}'));
+
+    // Then the message has no subject to speak of, which is what a message
+    // sent without a Subject header amounts to.
+    assertIdentical(ses.sentEmails().at(0)?.subject, "");
+  });
+
+  it("renders a template written into the send itself", async () => {
+    // Given a simulated SES with both ends verified.
+    const ses = await templatedSes();
+
+    // When a message is sent with the wording inline rather than by name.
+    await ses.sendEmail(
+      new SendEmailCommand({
+        FromEmailAddress: "hello@example.com",
+        Destination: { ToAddresses: ["someone@example.org"] },
+        Content: {
+          Template: {
+            TemplateContent: { Subject: "Hi {{name}}", Text: "Hi {{name}}" },
+            TemplateData: '{"name":"Ada"}',
+          },
+        },
+      }),
+    );
+
+    // Then it rendered without a stored template, and there is no template
+    // name to report because none was named.
+    const [email] = ses.sentEmails();
+
+    assertNonNullable(email);
+    assertIdentical(email.subject, "Hi Ada");
+    assertUndefined(email.templateName);
+  });
+});

--- a/src/service/ses/sim-ses-templates.iso.test.ts
+++ b/src/service/ses/sim-ses-templates.iso.test.ts
@@ -1,0 +1,249 @@
+import {
+  CreateEmailTemplateCommand,
+  DeleteEmailTemplateCommand,
+  GetEmailTemplateCommand,
+  ListEmailTemplatesCommand,
+  UpdateEmailTemplateCommand,
+} from "@aws-sdk/client-sesv2";
+import {
+  assertArrayEquals,
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimFixedClock } from "../../util/clock/sim-clock.js";
+import type { SimAwsAccountId } from "../aws/sim-aws-account.js";
+import { SimAws } from "../aws/sim-aws.js";
+
+const accountIdTwoTwos = "222222222222" as SimAwsAccountId;
+const createdAt = new Date("2026-08-16T09:00:00.000Z");
+
+const welcomeTemplate = {
+  TemplateName: "welcome",
+  TemplateContent: {
+    Subject: "Welcome, {{name}}",
+    Text: "Hi {{name}}, thanks for signing up.",
+    Html: "<p>Hi {{name}}</p>",
+  },
+};
+
+describe("SimSesV2 email templates", () => {
+  it("stores a template with its placeholders unrendered", async () => {
+    // Given a simulated SES with a fixed clock.
+    const ses = new SimAws({ clock: new SimFixedClock(createdAt) }).sesV2();
+
+    // When a template is created and read back.
+    await ses.createEmailTemplate(
+      new CreateEmailTemplateCommand(welcomeTemplate),
+    );
+    const read = await ses.getEmailTemplate(
+      new GetEmailTemplateCommand({ TemplateName: "welcome" }),
+    );
+
+    // Then the wording comes back as it went in, placeholders and all: a
+    // template is stored unrendered and filled in at send time.
+    assertIdentical(read.TemplateName, "welcome");
+    assertNonNullable(read.TemplateContent);
+    assertIdentical(read.TemplateContent.Subject, "Welcome, {{name}}");
+    assertIdentical(read.TemplateContent.Html, "<p>Hi {{name}}</p>");
+  });
+
+  it("stores a template with only one part", async () => {
+    // Given a simulated SES.
+    const ses = new SimAws().sesV2();
+
+    // When a template is created with a body and nothing else.
+    await ses.createEmailTemplate(
+      new CreateEmailTemplateCommand({
+        TemplateName: "reminder",
+        TemplateContent: { Text: "Your order is on its way." },
+      }),
+    );
+    const read = await ses.getEmailTemplate(
+      new GetEmailTemplateCommand({ TemplateName: "reminder" }),
+    );
+
+    // Then the parts it does not have are absent rather than empty.
+    assertNonNullable(read.TemplateContent);
+    assertIdentical(read.TemplateContent.Text, "Your order is on its way.");
+    assertUndefined(read.TemplateContent.Subject);
+    assertUndefined(read.TemplateContent.Html);
+  });
+
+  it("names a template by the account and region it is in", async () => {
+    // Given a template in one account and region.
+    const ses = new SimAws()
+      .accountRegionScope(accountIdTwoTwos, "us-east-1")
+      .sesV2();
+
+    await ses.createEmailTemplate(
+      new CreateEmailTemplateCommand(welcomeTemplate),
+    );
+
+    // When its ARN is read.
+    const template = ses.findTemplate("welcome");
+
+    // Then the ARN names that account and region.
+    assertNonNullable(template);
+    assertIdentical(
+      template.arn,
+      "arn:aws:ses:us-east-1:222222222222:template/welcome",
+    );
+  });
+
+  it("creates a template in one region and not in another", async () => {
+    // Given a template created in one region.
+    const simAws = new SimAws();
+
+    await simAws
+      .accountRegionScope(simAws.defaultAccountId, "us-east-1")
+      .sesV2()
+      .createEmailTemplate(new CreateEmailTemplateCommand(welcomeTemplate));
+
+    // When another region is asked for it.
+    const elsewhere = simAws
+      .accountRegionScope(simAws.defaultAccountId, "eu-west-2")
+      .sesV2()
+      .findTemplate("welcome");
+
+    // Then it is not there, as it would not be on real SES.
+    assertUndefined(elsewhere);
+  });
+
+  it("tells two templates whose names differ only in case apart", async () => {
+    // Given a template.
+    const ses = new SimAws().sesV2();
+
+    await ses.createEmailTemplate(
+      new CreateEmailTemplateCommand(welcomeTemplate),
+    );
+
+    // When one differing only in case is created.
+    await ses.createEmailTemplate(
+      new CreateEmailTemplateCommand({
+        ...welcomeTemplate,
+        TemplateName: "Welcome",
+      }),
+    );
+
+    // Then both are there. A template name is matched exactly, unlike an
+    // identity, which has a domain to fold the case of.
+    assertArrayLength(ses.allTemplates(), 2);
+  });
+
+  it("replaces a template's wording without moving its creation time", async () => {
+    // Given a template that has been created.
+    const ses = new SimAws({ clock: new SimFixedClock(createdAt) }).sesV2();
+
+    await ses.createEmailTemplate(
+      new CreateEmailTemplateCommand(welcomeTemplate),
+    );
+
+    // When it is updated.
+    await ses.updateEmailTemplate(
+      new UpdateEmailTemplateCommand({
+        TemplateName: "welcome",
+        TemplateContent: { Subject: "Hello, {{name}}", Text: "Hello" },
+      }),
+    );
+    const read = await ses.getEmailTemplate(
+      new GetEmailTemplateCommand({ TemplateName: "welcome" }),
+    );
+
+    // Then the wording is replaced outright rather than merged, and the
+    // template is the same one it was: real SES updates in place.
+    assertNonNullable(read.TemplateContent);
+    assertIdentical(read.TemplateContent.Subject, "Hello, {{name}}");
+    assertUndefined(read.TemplateContent.Html);
+    assertIdentical(
+      ses.findTemplate("welcome")?.createdDate.getTime(),
+      createdAt.getTime(),
+    );
+  });
+
+  it("lists templates with the time each was made", async () => {
+    // Given two templates.
+    const ses = new SimAws({ clock: new SimFixedClock(createdAt) }).sesV2();
+
+    await ses.createEmailTemplate(
+      new CreateEmailTemplateCommand(welcomeTemplate),
+    );
+    await ses.createEmailTemplate(
+      new CreateEmailTemplateCommand({
+        TemplateName: "receipt",
+        TemplateContent: { Subject: "Your receipt", Text: "Thanks" },
+      }),
+    );
+
+    // When they are listed.
+    const listed = await ses.listEmailTemplates(
+      new ListEmailTemplatesCommand({}),
+    );
+
+    // Then each is reported by name and creation time, in creation order. The
+    // wording is not listed: that needs GetEmailTemplate, one at a time.
+    assertNonNullable(listed.TemplatesMetadata);
+    assertArrayEquals(
+      listed.TemplatesMetadata.map((template) => template.TemplateName),
+      ["welcome", "receipt"],
+    );
+    assertIdentical(
+      listed.TemplatesMetadata[0]?.CreatedTimestamp.getTime(),
+      createdAt.getTime(),
+    );
+  });
+
+  it("pages a listing of templates", async () => {
+    // Given more templates than one page holds.
+    const ses = new SimAws().sesV2();
+
+    for (const name of ["one", "two", "three"]) {
+      // oxlint-disable-next-line no-await-in-loop
+      await ses.createEmailTemplate(
+        new CreateEmailTemplateCommand({
+          TemplateName: name,
+          TemplateContent: { Text: name },
+        }),
+      );
+    }
+
+    // When they are read a page at a time.
+    const first = await ses.listEmailTemplates(
+      new ListEmailTemplatesCommand({ PageSize: 2 }),
+    );
+    const second = await ses.listEmailTemplates(
+      new ListEmailTemplatesCommand({
+        PageSize: 2,
+        NextToken: first.NextToken,
+      }),
+    );
+
+    // Then the token from the first page reaches the rest.
+    assertArrayLength(first.TemplatesMetadata ?? [], 2);
+    assertArrayEquals(
+      second.TemplatesMetadata?.map((template) => template.TemplateName),
+      ["three"],
+    );
+    assertUndefined(second.NextToken);
+  });
+
+  it("deletes a template", async () => {
+    // Given a template.
+    const ses = new SimAws().sesV2();
+
+    await ses.createEmailTemplate(
+      new CreateEmailTemplateCommand(welcomeTemplate),
+    );
+
+    // When it is deleted.
+    await ses.deleteEmailTemplate(
+      new DeleteEmailTemplateCommand({ TemplateName: "welcome" }),
+    );
+
+    // Then it is gone.
+    assertArrayLength(ses.allTemplates(), 0);
+  });
+});

--- a/src/service/ses/sim-ses-v2.ts
+++ b/src/service/ses/sim-ses-v2.ts
@@ -3,6 +3,7 @@ import type * as simSesCommands from "./command/sim-ses-command.types.js";
 import type { SimSesRequestOptions } from "./command/sim-ses-request-options.js";
 import type { SimSesSentEmail } from "./email/sim-ses-sent-email.js";
 import type { SimSesIdentity } from "./identity/sim-ses-identity.js";
+import type { SimSesTemplate } from "./template/sim-ses-template.js";
 import { SimSesSdkCommandRouter } from "./sdk/sim-ses-sdk-command-router.js";
 import { SimSesCommands, type SimSesV2Properties } from "./sim-ses-commands.js";
 
@@ -90,6 +91,23 @@ export class SimSesV2 {
   }
 
   /**
+   * Find a template by name.
+   *
+   * The simulator's own accessor, for tests seeding or inspecting template
+   * state without going through a Command and its authorization.
+   */
+  findTemplate(templateName: string): SimSesTemplate | undefined {
+    return this.#commands.templates.find(templateName);
+  }
+
+  /**
+   * Every template in this scope, in the order they were created.
+   */
+  allTemplates(): readonly SimSesTemplate[] {
+    return this.#commands.templates.all;
+  }
+
+  /**
    * Whether this account is still in the SES sandbox, where every recipient
    * has to be verified as well as the sender.
    */
@@ -145,6 +163,70 @@ export class SimSesV2 {
   ): Promise<simSesCommands.SimDeleteEmailIdentityCommandOutput> {
     await this.#commands.background.sequence();
     return this.#commands.identityCommands.deleteEmailIdentity(
+      command,
+      options,
+    );
+  }
+
+  /**
+   * Handle a CreateEmailTemplate Command from the SDK.
+   */
+  async createEmailTemplate(
+    command: simSesCommands.SimCreateEmailTemplateCommand,
+    options?: SimSesRequestOptions,
+  ): Promise<simSesCommands.SimCreateEmailTemplateCommandOutput> {
+    await this.#commands.background.sequence();
+    return this.#commands.templateCommands.createEmailTemplate(
+      command,
+      options,
+    );
+  }
+
+  /**
+   * Handle a GetEmailTemplate Command from the SDK.
+   */
+  async getEmailTemplate(
+    command: simSesCommands.SimGetEmailTemplateCommand,
+    options?: SimSesRequestOptions,
+  ): Promise<simSesCommands.SimGetEmailTemplateCommandOutput> {
+    await this.#commands.background.sequence();
+    return this.#commands.templateCommands.getEmailTemplate(command, options);
+  }
+
+  /**
+   * Handle an UpdateEmailTemplate Command from the SDK.
+   */
+  async updateEmailTemplate(
+    command: simSesCommands.SimUpdateEmailTemplateCommand,
+    options?: SimSesRequestOptions,
+  ): Promise<simSesCommands.SimUpdateEmailTemplateCommandOutput> {
+    await this.#commands.background.sequence();
+    return this.#commands.templateCommands.updateEmailTemplate(
+      command,
+      options,
+    );
+  }
+
+  /**
+   * Handle a ListEmailTemplates Command from the SDK.
+   */
+  async listEmailTemplates(
+    command: simSesCommands.SimListEmailTemplatesCommand,
+    options?: SimSesRequestOptions,
+  ): Promise<simSesCommands.SimListEmailTemplatesCommandOutput> {
+    await this.#commands.background.sequence();
+    return this.#commands.templateCommands.listEmailTemplates(command, options);
+  }
+
+  /**
+   * Handle a DeleteEmailTemplate Command from the SDK.
+   */
+  async deleteEmailTemplate(
+    command: simSesCommands.SimDeleteEmailTemplateCommand,
+    options?: SimSesRequestOptions,
+  ): Promise<simSesCommands.SimDeleteEmailTemplateCommandOutput> {
+    await this.#commands.background.sequence();
+    return this.#commands.templateCommands.deleteEmailTemplate(
       command,
       options,
     );

--- a/src/service/ses/template/sim-ses-render.iso.test.ts
+++ b/src/service/ses/template/sim-ses-render.iso.test.ts
@@ -1,0 +1,76 @@
+import { assertIdentical } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { renderSimSesTemplatePart } from "./sim-ses-render.js";
+
+describe("renderSimSesTemplatePart", () => {
+  it("substitutes a value where the placeholder is", () => {
+    // Given a part with a placeholder in the middle of it.
+    const part = "Hi {{name}}, welcome.";
+
+    // When it is rendered.
+    const rendered = renderSimSesTemplatePart(part, { name: "Ada" });
+
+    assertIdentical(rendered, "Hi Ada, welcome.");
+  });
+
+  it("ignores whitespace inside the braces", () => {
+    // Given a placeholder written with spaces, as Handlebars allows.
+    const rendered = renderSimSesTemplatePart("Hi {{  name  }}", {
+      name: "Ada",
+    });
+
+    assertIdentical(rendered, "Hi Ada");
+  });
+
+  it("substitutes the same placeholder everywhere it appears", () => {
+    // Given a part naming one value twice.
+    const rendered = renderSimSesTemplatePart("{{name}} and {{name}}", {
+      name: "Ada",
+    });
+
+    assertIdentical(rendered, "Ada and Ada");
+  });
+
+  it("HTML-escapes a substituted value", () => {
+    // Given data carrying markup.
+    const rendered = renderSimSesTemplatePart("<p>{{name}}</p>", {
+      name: "<b>Ada</b> & co",
+    });
+
+    // Then the value is escaped and the template's own markup is not. Real SES
+    // renders with Handlebars, whose `{{ }}` escapes, so a value that looks
+    // like markup arrives as text.
+    assertIdentical(rendered, "<p>&lt;b&gt;Ada&lt;/b&gt; &amp; co</p>");
+  });
+
+  it("does not escape a triple stache", () => {
+    // Given a placeholder written `{{{ }}}`, which is how Handlebars asks for
+    // a value to go in as it stands.
+    const rendered = renderSimSesTemplatePart("<p>{{{markup}}}</p>", {
+      markup: "<b>Ada</b>",
+    });
+
+    assertIdentical(rendered, "<p><b>Ada</b></p>");
+  });
+
+  it("escapes the text part as well as the HTML one", () => {
+    // Given a text part carrying an ampersand.
+    const rendered = renderSimSesTemplatePart("Ada {{company}}", {
+      company: "Lovelace & Co",
+    });
+
+    // Then it is escaped there too: Handlebars renders a string without
+    // knowing what it is for, so this is a real divergence to watch for in a
+    // plain text email.
+    assertIdentical(rendered, "Ada Lovelace &amp; Co");
+  });
+
+  it("leaves a part with no placeholders alone", () => {
+    const rendered = renderSimSesTemplatePart("Nothing to fill in.", {
+      name: "Ada",
+    });
+
+    assertIdentical(rendered, "Nothing to fill in.");
+  });
+});

--- a/src/service/ses/template/sim-ses-render.ts
+++ b/src/service/ses/template/sim-ses-render.ts
@@ -1,0 +1,112 @@
+import { SimSesUnsupportedOperationException } from "../error/sim-ses.error.js";
+import { simSesTemplateExpression } from "./sim-ses-template-content.js";
+
+/**
+ * What Handlebars replaces when it escapes a value.
+ */
+const htmlEscapes: ReadonlyMap<string, string> = new Map([
+  ["&", "&amp;"],
+  ["<", "&lt;"],
+  [">", "&gt;"],
+  ['"', "&quot;"],
+  ["'", "&#x27;"],
+  ["`", "&#x60;"],
+  ["=", "&#x3D;"],
+]);
+
+/**
+ * Render one part of a template against the data a send carried.
+ *
+ * A placeholder naming something the data does not have becomes an empty
+ * string rather than a failure. That is what Handlebars does and so what real
+ * SES does, and it is much the commonest surprise in an SES template: the
+ * message goes out with a hole in it and nothing reports a problem. A test
+ * asserting on the rendered body is how that gets caught.
+ *
+ * `{{ name }}` HTML-escapes its value and `{{{ name }}}` does not, again
+ * following Handlebars, which is the template engine real SES renders with.
+ * The escaping applies to the text part as well as the HTML one, because
+ * Handlebars renders a string without knowing what it is for.
+ */
+export function renderSimSesTemplatePart(
+  part: string,
+  data: Readonly<Record<string, unknown>>,
+): string {
+  return part.replaceAll(
+    simSesTemplateExpression,
+    (_match: string, unescaped: string, expression: string) => {
+      const value = readTemplateValue(data, expression.trim());
+
+      return unescaped === "{" ? value : escapeHtml(value);
+    },
+  );
+}
+
+/**
+ * Read a dotted path out of the template data.
+ *
+ * Own properties only, walked with a descriptor rather than an index, so
+ * `{{constructor}}` reaches nothing rather than reaching up the prototype
+ * chain.
+ */
+function readTemplateValue(
+  data: Readonly<Record<string, unknown>>,
+  expression: string,
+): string {
+  let value: unknown = data;
+
+  for (const segment of expression.split(".")) {
+    if (typeof value !== "object" || value === null) {
+      return "";
+    }
+
+    value = Object.getOwnPropertyDescriptor(value, segment)?.value;
+  }
+
+  return substituted(value, expression);
+}
+
+/**
+ * What a resolved value becomes in the rendered message.
+ *
+ * A value that is not a primitive is refused rather than guessed at. Real
+ * Handlebars would put `[object Object]` in the message, which is a mistake
+ * worth reporting rather than reproducing: nobody means to send it, and a test
+ * whose data has an object where the template wants a name should find out
+ * where the mistake is.
+ */
+function substituted(value: unknown, expression: string): string {
+  if (value === null || value === undefined) {
+    return "";
+  }
+
+  if (typeof value === "string") {
+    return value;
+  }
+
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+
+  throw new SimSesUnsupportedOperationException(
+    `Template data for {{${expression}}} is not a value that can go into a ` +
+      `message. Substitution renders strings, numbers and booleans.`,
+  );
+}
+
+/**
+ * Escape a value the way Handlebars does.
+ *
+ * Built a character at a time rather than by replacing each escapable
+ * character in turn across the whole string, so an ampersand introduced by one
+ * replacement is not escaped again by the next.
+ */
+function escapeHtml(value: string): string {
+  let escaped = "";
+
+  for (const character of value) {
+    escaped += htmlEscapes.get(character) ?? character;
+  }
+
+  return escaped;
+}

--- a/src/service/ses/template/sim-ses-template-content.ts
+++ b/src/service/ses/template/sim-ses-template-content.ts
@@ -1,0 +1,103 @@
+import {
+  SimSesBadRequestException,
+  SimSesUnsupportedOperationException,
+} from "../error/sim-ses.error.js";
+
+/**
+ * What a template says, with its placeholders still in it.
+ *
+ * All three parts are optional on real SES, and a template needs at least one
+ * of them to be worth sending.
+ */
+export interface SimSesTemplateContent {
+  readonly subject: string | undefined;
+  readonly text: string | undefined;
+  readonly html: string | undefined;
+}
+
+/**
+ * Every `{{ }}` expression in a template, triple stache included.
+ *
+ * The first group is `{` when the expression was written `{{{ like this }}}`,
+ * which is how Handlebars asks for a value to go in unescaped.
+ */
+export const simSesTemplateExpression = /\{\{(\{?)([^{}]*)\}?\}\}/g;
+
+/**
+ * What one segment of a substitution path may be made of.
+ */
+const pathSegment = /^[A-Za-z0-9_]+$/;
+
+const braces = /[{}]/g;
+
+/**
+ * Read the content a template is being given, refusing what real SES refuses
+ * and what this simulator does not render.
+ */
+export function readSimSesTemplateContent(content: {
+  readonly Subject?: string | undefined;
+  readonly Text?: string | undefined;
+  readonly Html?: string | undefined;
+}): SimSesTemplateContent {
+  const { Subject: subject, Text: text, Html: html } = content;
+
+  if (subject === undefined && text === undefined && html === undefined) {
+    throw new SimSesBadRequestException(
+      "1 validation error detected: Value at 'templateContent' failed to " +
+        "satisfy constraint: Member must specify Subject, Text or Html",
+    );
+  }
+
+  for (const part of [subject, text, html]) {
+    refuseUnrenderableExpressions(part);
+  }
+
+  return { subject, text, html };
+}
+
+/**
+ * Refuse the Handlebars this simulator does not render.
+ *
+ * Real SES renders templates with Handlebars, which has block helpers,
+ * partials and comments as well as plain substitution. Only substitution is
+ * rendered here, and the rest is refused where the template is written rather
+ * than left in place: a `{{#if premium}}` silently surviving into the sent
+ * message would make a test pass on a message no real SES would produce.
+ */
+function refuseUnrenderableExpressions(part: string | undefined): void {
+  if (part === undefined) {
+    return;
+  }
+
+  for (const match of part.matchAll(simSesTemplateExpression)) {
+    // The braces around the expression, stripped back off. Read from the whole
+    // match rather than the capture group, which is always there but not
+    // typed that way.
+    const expression = match[0].replaceAll(braces, "").trim();
+
+    if (!isSubstitutionPath(expression)) {
+      throw new SimSesUnsupportedOperationException(
+        `Only Handlebars substitution is simulated, so this template is ` +
+          `refused rather than rendered wrongly: {{${expression}}} is a ` +
+          `block helper, partial or comment`,
+      );
+    }
+  }
+}
+
+/**
+ * Whether an expression is a plain substitution: a name, or a dotted path into
+ * the template data.
+ *
+ * Checked segment by segment rather than with one pattern over the whole path,
+ * for the same reason a domain is: a pattern for a repeated group of repeated
+ * characters backtracks badly on a long near miss.
+ */
+function isSubstitutionPath(expression: string): boolean {
+  const segments = expression.split(".");
+
+  return (
+    segments.length > 0 &&
+    segments.every((segment) => pathSegment.test(segment))
+  );
+}

--- a/src/service/ses/template/sim-ses-template-store.ts
+++ b/src/service/ses/template/sim-ses-template-store.ts
@@ -1,0 +1,118 @@
+import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+import {
+  SimSesAlreadyExistsException,
+  SimSesBadRequestException,
+  SimSesNotFoundException,
+} from "../error/sim-ses.error.js";
+import type { SimSesTemplateContent } from "./sim-ses-template-content.js";
+import { SimSesTemplate } from "./sim-ses-template.js";
+
+const maximumNameLength = 64;
+
+interface SimSesTemplateStoreProperties {
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+}
+
+/**
+ * The email templates of one simulated SES scope.
+ *
+ * Templates are region scoped on real SES, as identities are: a template
+ * created in one region cannot be sent from another, which is a mistake worth
+ * reproducing rather than smoothing over.
+ */
+export class SimSesTemplateStore {
+  readonly #accountRegionScope: SimAwsAccountRegionScope;
+  readonly #templates = new Map<string, SimSesTemplate>();
+
+  constructor(properties: SimSesTemplateStoreProperties) {
+    this.#accountRegionScope = properties.accountRegionScope;
+  }
+
+  /**
+   * Every template in this scope, in the order they were created.
+   */
+  get all(): readonly SimSesTemplate[] {
+    return this.#templates.values().toArray();
+  }
+
+  /**
+   * Make a template, refusing a name that is taken.
+   */
+  create(
+    templateName: string,
+    content: SimSesTemplateContent,
+    createdDate: Date,
+  ): SimSesTemplate {
+    if (this.#templates.has(templateName)) {
+      throw new SimSesAlreadyExistsException(
+        `Email template ${templateName} already exists.`,
+      );
+    }
+
+    const template = new SimSesTemplate({
+      templateName,
+      content,
+      accountRegionScope: this.#accountRegionScope,
+      createdDate,
+    });
+
+    this.#templates.set(templateName, template);
+
+    return template;
+  }
+
+  /**
+   * Find a template by name.
+   */
+  find(templateName: string): SimSesTemplate | undefined {
+    return this.#templates.get(templateName);
+  }
+
+  /**
+   * Get a template, refusing one that is not there.
+   */
+  require(templateName: string): SimSesTemplate {
+    const template = this.find(templateName);
+
+    if (template === undefined) {
+      throw new SimSesNotFoundException(
+        `Email template ${templateName} does not exist.`,
+      );
+    }
+
+    return template;
+  }
+
+  /**
+   * Remove a template.
+   */
+  delete(templateName: string): void {
+    this.#templates.delete(templateName);
+  }
+}
+
+/**
+ * Read a template name, refusing one real SES would refuse.
+ *
+ * Template names are matched exactly, unlike identities: there is no case
+ * folding and no domain to fall back on, so `Welcome` and `welcome` are two
+ * templates.
+ */
+export function requiredSimSesTemplateName(templateName?: string): string {
+  if (templateName === undefined || templateName.length === 0) {
+    throw new SimSesBadRequestException(
+      "1 validation error detected: Value at 'templateName' failed to " +
+        "satisfy constraint: Member must not be null",
+    );
+  }
+
+  if (templateName.length > maximumNameLength) {
+    throw new SimSesBadRequestException(
+      `1 validation error detected: Value at 'templateName' failed to ` +
+        `satisfy constraint: Member must have length less than or equal to ` +
+        `${maximumNameLength}`,
+    );
+  }
+
+  return templateName;
+}

--- a/src/service/ses/template/sim-ses-template.ts
+++ b/src/service/ses/template/sim-ses-template.ts
@@ -1,0 +1,57 @@
+import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+import { simSesTemplateArn } from "../sim-ses-arn.js";
+import type { SimSesTemplateContent } from "./sim-ses-template-content.js";
+
+interface SimSesTemplateProperties {
+  readonly templateName: string;
+  readonly content: SimSesTemplateContent;
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+  readonly createdDate: Date;
+}
+
+/**
+ * One stored email template.
+ *
+ * A template is the wording of a message with its placeholders still in it,
+ * kept apart from the data that fills them. That separation is the reason a
+ * test wants templates at all: it can assert which template went out and what
+ * was substituted into it, rather than matching against rendered prose that
+ * changes whenever someone rewords the email.
+ */
+export class SimSesTemplate {
+  public readonly templateName: string;
+
+  public readonly arn: string;
+
+  public readonly createdDate: Date;
+
+  #content: SimSesTemplateContent;
+
+  constructor(properties: SimSesTemplateProperties) {
+    this.templateName = properties.templateName;
+    this.#content = properties.content;
+    this.arn = simSesTemplateArn(
+      properties.accountRegionScope,
+      properties.templateName,
+    );
+    this.createdDate = properties.createdDate;
+  }
+
+  /**
+   * The wording as it stands, with its placeholders unrendered.
+   */
+  get content(): SimSesTemplateContent {
+    return this.#content;
+  }
+
+  /**
+   * Replace the wording, keeping the name and the time it was created.
+   *
+   * Real SES updates a template in place rather than making a new one, so its
+   * `CreatedTimestamp` does not move and a send that already named it picks up
+   * the new wording.
+   */
+  update(content: SimSesTemplateContent): void {
+    this.#content = content;
+  }
+}


### PR DESCRIPTION
Adds email templates to simulated SES: the five template commands, and `Content.Template` on SendEmail rendering the stored wording against the JSON in TemplateData. The recorded send carries the template name and the parsed data alongside the rendered result, so a test can assert that the welcome email went from this template with these substitutions rather than matching against prose that changes whenever someone rewords it. Rendering covers the substitution part of Handlebars, which is what real SES renders with: dotted paths, a missing placeholder rendering empty, and `{{ }}` HTML-escaping where `{{{ }}}` does not. Block helpers, partials and comments are refused at the template rather than left in place to survive into a sent message.

Resolves #633

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added SES email-template support, including create, retrieve, update, list, and delete operations.
  * Added template-based email sending with variable substitution, nested values, HTML escaping, and rendered content.
  * Recorded template names and substitution data with sent emails.
  * Added pagination, regional isolation, validation, and IAM authorization for templates.
* **Bug Fixes**
  * Added clear handling for malformed data and unsupported template features, tags, attachments, and raw content.
* **Documentation**
  * Updated SES documentation and examples for template creation, sending, rendering, and limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->