### PR TITLE
feat: deploy SES identities and templates from a template

### DIFF
--- a/docs/services/ses/README.md
+++ b/docs/services/ses/README.md
@@ -240,6 +240,105 @@ Naming both is refused, because which of them real SES renders is not something 
 knows, and recording the message under a template it was not rendered from would be worse than
 failing.
 
+## Deploying identities and templates with CloudFormation
+
+`AWS::SES::EmailIdentity` and `AWS::SES::Template` deploy into simulated SES, so a project that
+declares them in CDK or CloudFormation can deploy the same template its application deploys rather
+than creating them by hand in test setup.
+
+```typescript sim-ses-cloudformation
+/**
+ * Deploying an SES identity and template, then sending from them.
+ */
+
+import { SendEmailCommand } from "@aws-sdk/client-sesv2";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+await simAws.cloudFormation().deployTemplate({
+  stackName: "orders",
+  template: {
+    Resources: {
+      SenderIdentity: {
+        Type: "AWS::SES::EmailIdentity",
+        Properties: { EmailIdentity: "example.com" },
+      },
+      WelcomeEmail: {
+        Type: "AWS::SES::Template",
+        Properties: {
+          Template: {
+            TemplateName: "welcome",
+            SubjectPart: "Welcome, {{name}}",
+            TextPart: "Hi {{name}}",
+          },
+        },
+      },
+    },
+  },
+});
+
+const ses = simAws.sesV2();
+
+// The stack leaves the identity unverified, as a real deploy does. Verifying
+// finds the one the stack made rather than creating a second.
+ses.verifyIdentity("example.com");
+ses.verifyIdentity("example.org");
+
+await ses.sendEmail(
+  new SendEmailCommand({
+    FromEmailAddress: "hello@example.com",
+    Destination: { ToAddresses: ["someone@example.org"] },
+    Content: {
+      Template: { TemplateName: "welcome", TemplateData: '{"name":"Ada"}' },
+    },
+  }),
+);
+
+// "Welcome, Ada"
+console.log(ses.sentEmails()[0]?.subject);
+```
+
+An identity deploys **unverified**. That is what a real deploy leaves behind: the confirmation link
+or the DKIM records still have to be dealt with out of band. Verify it afterwards with
+`verifyIdentity`, in that order: verifying first and deploying second fails the deploy, because
+CloudFormation is creating an identity that is already there.
+
+`Ref` on an identity returns the address or domain itself, which is directly usable as a
+`FromEmailAddress`. `Ref` on a template, and its `Id` attribute, both return the template name.
+
+Deleting the stack removes both.
+
+### DKIM tokens
+
+`Fn::GetAtt` on an identity reads the six DKIM token attributes, and this simulator answers them
+with tokens it made up. They are derived from the identity's own name, so they are the same on every
+run, and they are not real: nothing here signs a message.
+
+They exist because `ses.Identity.publicHostedZone()` in CDK emits three `AWS::Route53::RecordSet`
+Resources reading exactly these attributes. Refusing them would take an ordinary CDK stack down over
+records nothing in this simulation reads, so the stack deploys with records of the right shape
+pointing at nothing.
+
+### What an identity Resource is deployed without
+
+`EmailIdentity` is the only property acted on. `DkimAttributes`, `DkimSigningAttributes`,
+`MailFromAttributes`, `FeedbackAttributes`, `ConfigurationSetAttributes` and `Tags` are recorded as
+ignored and the identity is created without them, because an identity without any of them still does
+the one thing an identity does here: exist to be verified, and let a send from it through.
+
+`stack.ignoredProperties` is where they are reported, each with the reason it was not acted on, so
+nothing is dropped in silence.
+
+The SDK path is stricter on purpose. `CreateEmailIdentity` refuses `DkimSigningAttributes` outright,
+because a caller reaching for it directly is asking for that behaviour and should be told it is not
+there. A template is a whole document, and one property in it should not sink the deploy.
+
+A template Resource has no such list: everything `AWS::SES::Template` can say is wording, and all of
+it is acted on. A template carrying Handlebars this simulator does not render fails the deploy rather
+than sitting in the stack waiting to fail at the first send.
+
 ## The sandbox
 
 An account starts in the SES sandbox, where **both** the sender and every recipient have to be
@@ -511,8 +610,10 @@ Anything else refuses on send with `SimSdkUnsupportedCommandError` rather than m
 - **Nothing is delivered, and nothing bounces.** There are no bounce or complaint events, no
   suppression list, no configuration sets and no event destinations. A configuration set named on a
   send is kept on the record so a test can assert the right one was used, and does nothing else.
-- **No `AWS::SES::*` CloudFormation resources yet.** Identities and templates have to be created
-  through the API, or an identity through `verifyIdentity`.
+- **DKIM tokens on `AWS::SES::EmailIdentity` are made up.** They are stable per identity so a test
+  can assert on them, and they prove nothing.
+- **Only `AWS::SES::EmailIdentity` and `AWS::SES::Template` deploy.** `AWS::SES::ConfigurationSet`,
+  `AWS::SES::ContactList`, `AWS::SES::ReceiptRule` and the rest are not simulated.
 - **SES v2 only.** The older `@aws-sdk/client-ses` API is not simulated.
 - **DKIM, MAIL FROM domains and sending authorization policies are not simulated.** An identity
   created with `DkimSigningAttributes` is refused rather than reported as configured.

--- a/docs/services/ses/README.md
+++ b/docs/services/ses/README.md
@@ -335,9 +335,14 @@ The SDK path is stricter on purpose. `CreateEmailIdentity` refuses `DkimSigningA
 because a caller reaching for it directly is asking for that behaviour and should be told it is not
 there. A template is a whole document, and one property in it should not sink the deploy.
 
-A template Resource has no such list: everything `AWS::SES::Template` can say is wording, and all of
-it is acted on. A template carrying Handlebars this simulator does not render fails the deploy rather
-than sitting in the stack waiting to fail at the first send.
+A template Resource has no such list, because everything `AWS::SES::Template` can usefully say is
+wording and all of it is acted on. Anything else it says is still reported, at both levels: a
+property beside `Template`, and a part inside it that is not one of the four. In practice that
+catches a misspelling, which is worth catching, since `TextPart` written `Textpart` would otherwise
+send a message with no body and nothing to explain it.
+
+A template carrying Handlebars this simulator does not render is a different matter, and fails the
+deploy rather than sitting in the stack waiting to fail at the first send.
 
 ## The sandbox
 

--- a/docs/services/ses/sim-ses-cloudformation.example.ts
+++ b/docs/services/ses/sim-ses-cloudformation.example.ts
@@ -1,0 +1,51 @@
+/**
+ * Deploying an SES identity and template, then sending from them.
+ */
+
+import { SendEmailCommand } from "@aws-sdk/client-sesv2";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+await simAws.cloudFormation().deployTemplate({
+  stackName: "orders",
+  template: {
+    Resources: {
+      SenderIdentity: {
+        Type: "AWS::SES::EmailIdentity",
+        Properties: { EmailIdentity: "example.com" },
+      },
+      WelcomeEmail: {
+        Type: "AWS::SES::Template",
+        Properties: {
+          Template: {
+            TemplateName: "welcome",
+            SubjectPart: "Welcome, {{name}}",
+            TextPart: "Hi {{name}}",
+          },
+        },
+      },
+    },
+  },
+});
+
+const ses = simAws.sesV2();
+
+// The stack leaves the identity unverified, as a real deploy does. Verifying
+// finds the one the stack made rather than creating a second.
+ses.verifyIdentity("example.com");
+ses.verifyIdentity("example.org");
+
+await ses.sendEmail(
+  new SendEmailCommand({
+    FromEmailAddress: "hello@example.com",
+    Destination: { ToAddresses: ["someone@example.org"] },
+    Content: {
+      Template: { TemplateName: "welcome", TemplateData: '{"name":"Ada"}' },
+    },
+  }),
+);
+
+// "Welcome, Ada"
+console.log(ses.sentEmails()[0]?.subject);

--- a/src/service/cloudformation/resource/cfn/ses/sim-ses-cfn-value-adapter.ts
+++ b/src/service/cloudformation/resource/cfn/ses/sim-ses-cfn-value-adapter.ts
@@ -1,0 +1,31 @@
+import { SimSesIdentity } from "../../../../ses/identity/sim-ses-identity.js";
+import { SimSesTemplate } from "../../../../ses/template/sim-ses-template.js";
+import type {
+  SimCfnResourceValueAdapterProperties,
+  SimCfnServiceValueAdapter,
+} from "../sim-cfn-resource-value-adapter.js";
+import { SimSesIdentityCfn } from "./sim-ses-identity-cfn.js";
+import { SimSesTemplateCfn } from "./sim-ses-template-cfn.js";
+
+/**
+ * The CloudFormation-facing value adapter for a simulated SES Resource.
+ */
+export function sesValueAdapter(
+  properties: SimCfnResourceValueAdapterProperties,
+): SimCfnServiceValueAdapter {
+  if (
+    properties.type === "AWS::SES::EmailIdentity" &&
+    properties.simResource instanceof SimSesIdentity
+  ) {
+    return new SimSesIdentityCfn({ identity: properties.simResource });
+  }
+
+  if (
+    properties.type === "AWS::SES::Template" &&
+    properties.simResource instanceof SimSesTemplate
+  ) {
+    return new SimSesTemplateCfn({ template: properties.simResource });
+  }
+
+  return undefined;
+}

--- a/src/service/cloudformation/resource/cfn/ses/sim-ses-dkim-tokens.ts
+++ b/src/service/cloudformation/resource/cfn/ses/sim-ses-dkim-tokens.ts
@@ -1,0 +1,55 @@
+import { createHash } from "node:crypto";
+
+/** How long a real Easy DKIM token is. */
+const tokenLength = 32;
+
+/**
+ * The three DKIM tokens CloudFormation reports for an email identity.
+ *
+ * Real SES generates these when it sets up Easy DKIM, and a template publishes
+ * them as CNAME records so SES can find them. Nothing here signs or verifies
+ * anything, so there is no key to derive a token from and these are made up.
+ *
+ * They are made up deterministically, from the identity's own name, for the
+ * reason every generated name in this simulation is: a test that deploys the
+ * same template twice gets the same records, and two identities in one stack
+ * do not collide.
+ *
+ * Producing them at all is the deliberate part. The obvious alternative is to
+ * refuse a DKIM token attribute, but `ses.Identity.publicHostedZone()` in CDK
+ * emits three Route53 record sets reading exactly these, so refusing would
+ * take down an ordinary stack over records nothing in this simulation reads.
+ */
+export function simSesDkimTokens(emailIdentity: string): readonly string[] {
+  return [1, 2, 3].map((index) =>
+    createHash("sha256")
+      .update(`${emailIdentity}:dkim:${String(index)}`)
+      .digest("hex")
+      .slice(0, tokenLength),
+  );
+}
+
+/**
+ * The name of the CNAME record a DKIM token is published under.
+ */
+export function simSesDkimTokenName(
+  emailIdentity: string,
+  token: string,
+): string {
+  return `${token}._domainkey.${simSesDkimDomain(emailIdentity)}`;
+}
+
+/**
+ * What that record points at.
+ */
+export function simSesDkimTokenValue(token: string): string {
+  return `${token}.dkim.amazonses.com`;
+}
+
+/**
+ * The domain the records belong to, which for an address identity is the
+ * domain the address is at.
+ */
+function simSesDkimDomain(emailIdentity: string): string {
+  return emailIdentity.slice(emailIdentity.lastIndexOf("@") + 1);
+}

--- a/src/service/cloudformation/resource/cfn/ses/sim-ses-identity-cfn.ts
+++ b/src/service/cloudformation/resource/cfn/ses/sim-ses-identity-cfn.ts
@@ -1,0 +1,73 @@
+import { assertDefined } from "../../../../../util/type-guard/defined.js";
+import type { SimSesIdentity } from "../../../../ses/identity/sim-ses-identity.js";
+import type { SimCfnTemplateValue } from "../../../template/value/sim-cfn-template-value.js";
+import type { SimCfnResourceValueAdapter } from "../sim-cfn-resource-value-adapter.js";
+import {
+  simSesDkimTokenName,
+  simSesDkimTokens,
+  simSesDkimTokenValue,
+} from "./sim-ses-dkim-tokens.js";
+
+/**
+ * The DKIM token attributes, and which of the three tokens each one reads.
+ */
+const dkimTokenAttribute = /^DkimDNSToken(?<part>Name|Value)(?<index>[123])$/;
+
+interface SimSesIdentityCfnProperties {
+  readonly identity: SimSesIdentity;
+}
+
+/**
+ * CloudFormation-facing values for a simulated SES email identity.
+ */
+export class SimSesIdentityCfn implements SimCfnResourceValueAdapter {
+  readonly #identity: SimSesIdentity;
+
+  constructor(properties: SimSesIdentityCfnProperties) {
+    this.#identity = properties.identity;
+  }
+
+  /**
+   * AWS::SES::EmailIdentity Ref returns the address or domain itself.
+   *
+   * SES has no identifier for an identity other than what it names, so a Ref
+   * is directly usable as the `FromEmailAddress` of a send or as the identity
+   * an IAM policy names.
+   */
+  refValue(): SimCfnTemplateValue {
+    return this.#identity.emailIdentity;
+  }
+
+  /**
+   * AWS::SES::EmailIdentity attributes, all six of which are DKIM tokens.
+   *
+   * The tokens are made up, deterministically, because nothing here signs a
+   * message and there is no key to derive a real one from. They exist so that
+   * the Route53 records CDK writes alongside an identity can be deployed: what
+   * a test gets is records of the right shape pointing at nothing, rather than
+   * a stack that will not deploy.
+   */
+  attributeValue(attributeName: string): SimCfnTemplateValue {
+    const groups = dkimTokenAttribute.exec(attributeName)?.groups;
+
+    if (!groups) {
+      throw new Error(
+        `Unsupported AWS::SES::EmailIdentity attribute ${attributeName}`,
+      );
+    }
+
+    const index = groups["index"];
+
+    assertDefined(index, `DKIM token index in ${attributeName}`);
+
+    const token = simSesDkimTokens(this.#identity.emailIdentity)[
+      Number(index) - 1
+    ];
+
+    assertDefined(token, `DKIM token ${index} for ${attributeName}`);
+
+    return groups["part"] === "Name"
+      ? simSesDkimTokenName(this.#identity.emailIdentity, token)
+      : simSesDkimTokenValue(token);
+  }
+}

--- a/src/service/cloudformation/resource/cfn/ses/sim-ses-template-cfn.ts
+++ b/src/service/cloudformation/resource/cfn/ses/sim-ses-template-cfn.ts
@@ -1,0 +1,42 @@
+import type { SimSesTemplate } from "../../../../ses/template/sim-ses-template.js";
+import type { SimCfnTemplateValue } from "../../../template/value/sim-cfn-template-value.js";
+import type { SimCfnResourceValueAdapter } from "../sim-cfn-resource-value-adapter.js";
+
+interface SimSesTemplateCfnProperties {
+  readonly template: SimSesTemplate;
+}
+
+/**
+ * CloudFormation-facing values for a simulated SES email template.
+ */
+export class SimSesTemplateCfn implements SimCfnResourceValueAdapter {
+  readonly #template: SimSesTemplate;
+
+  constructor(properties: SimSesTemplateCfnProperties) {
+    this.#template = properties.template;
+  }
+
+  /**
+   * AWS::SES::Template Ref returns the template name.
+   *
+   * A template has no identifier apart from its name, so a Ref is directly
+   * usable as the `TemplateName` of a send. That is also what makes the `Id`
+   * attribute the same string.
+   */
+  refValue(): SimCfnTemplateValue {
+    return this.#template.templateName;
+  }
+
+  /**
+   * AWS::SES::Template attributes.
+   */
+  attributeValue(attributeName: string): SimCfnTemplateValue {
+    if (attributeName === "Id") {
+      return this.#template.templateName;
+    }
+
+    throw new Error(
+      `Unsupported AWS::SES::Template attribute ${attributeName}`,
+    );
+  }
+}

--- a/src/service/cloudformation/resource/cfn/sim-cfn-service-value-adapters.ts
+++ b/src/service/cloudformation/resource/cfn/sim-cfn-service-value-adapters.ts
@@ -16,6 +16,7 @@ import { route53ValueAdapter } from "./route53/sim-route53-cfn-value-adapter.js"
 import { s3ValueAdapter } from "./s3/sim-s3-cfn-value-adapter.js";
 import { schedulerValueAdapter } from "./scheduler/sim-scheduler-cfn-value-adapter.js";
 import { secretsManagerValueAdapter } from "./secretsmanager/sim-secrets-manager-cfn-value-adapter.js";
+import { sesValueAdapter } from "./ses/sim-ses-cfn-value-adapter.js";
 import { snsValueAdapter } from "./sns/sim-sns-cfn-value-adapter.js";
 import { sqsValueAdapter } from "./sqs/sim-sqs-cfn-value-adapter.js";
 import { ssmValueAdapter } from "./ssm/sim-ssm-cfn-value-adapter.js";
@@ -54,6 +55,7 @@ export const simCfnServiceValueAdapters: readonly ((
   s3ValueAdapter,
   schedulerValueAdapter,
   secretsManagerValueAdapter,
+  sesValueAdapter,
   snsValueAdapter,
   sqsValueAdapter,
   ssmValueAdapter,

--- a/src/service/cloudformation/resource/resolve/service/sim-cfn-service-factories.ts
+++ b/src/service/cloudformation/resource/resolve/service/sim-cfn-service-factories.ts
@@ -125,6 +125,11 @@ export const simCfnServiceResourceFactories: ReadonlyMap<
       scopedAws.scheduler().cfnResourceFactory(),
   ],
   [
+    "SES",
+    (scopedAws): SimCfnServiceResourceFactory =>
+      scopedAws.sesV2().cfnResourceFactory(),
+  ],
+  [
     "SNS",
     (scopedAws): SimCfnServiceResourceFactory =>
       scopedAws.sns().cfnResourceFactory(),

--- a/src/service/ses/README.md
+++ b/src/service/ses/README.md
@@ -105,6 +105,28 @@ at `CreateEmailTemplate` and `UpdateEmailTemplate` rather than at the send. That
 mistake is written, and follows the house pattern of refusing an unsimulated input at the command
 that carries it.
 
+## CloudFormation model
+
+Resource creation lives under `cfn/`, and the CloudFormation-facing Ref and GetAtt values under
+`src/service/cloudformation/resource/cfn/ses/`, beside every other service's.
+
+Both Resource types go through the ordinary SES commands rather than constructing state directly, so
+one a stack deployed is the same thing an SDK caller would have got, and a template carrying
+unrenderable Handlebars fails the deploy rather than sitting in the stack waiting to fail at the
+first send.
+
+The two resource types split on what an unsimulated property costs, which is the split the whole
+CloudFormation layer makes. An identity Resource records `DkimAttributes`, `MailFromAttributes` and
+the rest as ignored and creates the identity without them, because an identity without any of them
+still does everything an identity does here. A template Resource has no such list: everything it can
+say is wording, and wording it cannot render is a real failure.
+
+`sim-ses-dkim-tokens.ts` is the one piece of invention. `Fn::GetAtt` on an identity reads six DKIM
+tokens, and there is no key here to derive one from, so they are hashed from the identity name:
+stable per identity, and meaningless. Refusing them was the first thing tried and is the wrong
+answer, because `ses.Identity.publicHostedZone()` in CDK emits three Route53 record sets reading
+exactly those attributes, so refusing takes an ordinary stack down over records nothing reads.
+
 ## Account model
 
 Account state lives under `account/`.

--- a/src/service/ses/cfn/identity/sim-cfn-ses-identity-creator.ts
+++ b/src/service/ses/cfn/identity/sim-cfn-ses-identity-creator.ts
@@ -1,0 +1,78 @@
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimSesIdentity } from "../../identity/sim-ses-identity.js";
+import type { SimSesV2 } from "../../sim-ses-v2.js";
+import { simCfnSesResourceCreation } from "../sim-cfn-ses-resource-error.js";
+import { sesEmailIdentityResourceType } from "../sim-cfn-ses-resource-types.js";
+import { SimCfnSesIdentityProperties } from "./sim-cfn-ses-identity-properties.js";
+
+interface SimCfnSesIdentityCreatorProperties {
+  readonly ses: SimSesV2;
+}
+
+/**
+ * Creates simulated email identities from AWS::SES::EmailIdentity Resources.
+ *
+ * The identity is created through the ordinary CreateEmailIdentity command
+ * rather than constructed directly, so one a template deployed is the same
+ * thing an SDK caller would have got: the same validation of what an identity
+ * may be named, and the same refusal of a name that is neither an address nor
+ * a domain.
+ *
+ * It deploys unverified, which is what real CloudFormation leaves behind: the
+ * confirmation link or the DKIM records still have to be dealt with out of
+ * band. A test verifies it afterwards with `verifyIdentity`, which finds the
+ * one the stack made rather than creating a second.
+ */
+export class SimCfnSesIdentityCreator {
+  readonly #ses: SimSesV2;
+
+  constructor(properties: SimCfnSesIdentityCreatorProperties) {
+    this.#ses = properties.ses;
+  }
+
+  /**
+   * Create an identity from an AWS::SES::EmailIdentity Resource.
+   */
+  async create(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): Promise<SimSesIdentity> {
+    const identityProperties = new SimCfnSesIdentityProperties({
+      resource,
+      properties,
+    });
+    const emailIdentity = identityProperties.emailIdentity();
+
+    identityProperties.recordIgnoredProperties();
+
+    return await simCfnSesResourceCreation(
+      sesEmailIdentityResourceType,
+      resource.logicalId,
+      async () => {
+        await this.#ses.createEmailIdentity({
+          input: { EmailIdentity: emailIdentity },
+        });
+
+        const identity = this.#ses.findIdentity(emailIdentity);
+
+        assertDefined(
+          identity,
+          `sim SES identity ${emailIdentity} after CloudFormation creation`,
+        );
+
+        return identity;
+      },
+    );
+  }
+
+  /**
+   * Delete an identity created from an AWS::SES::EmailIdentity Resource.
+   */
+  async delete(identity: SimSesIdentity): Promise<void> {
+    await this.#ses.deleteEmailIdentity({
+      input: { EmailIdentity: identity.emailIdentity },
+    });
+  }
+}

--- a/src/service/ses/cfn/identity/sim-cfn-ses-identity-properties.ts
+++ b/src/service/ses/cfn/identity/sim-cfn-ses-identity-properties.ts
@@ -1,0 +1,89 @@
+import type { SimCfnPropertyIgnorer } from "../../../cloudformation/resource/ignore/sim-cfn-ignored-property.type.js";
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import { simCfnSesResourceError } from "../sim-cfn-ses-resource-error.js";
+import { sesEmailIdentityResourceType } from "../sim-cfn-ses-resource-types.js";
+import { unsimulatedIdentityPropertyReasons } from "./sim-cfn-ses-identity-unsimulated-properties.js";
+
+/** The one property an identity Resource is actually created from. */
+const emailIdentityPropertyName = "EmailIdentity";
+
+interface SimCfnSesIdentityPropertiesProperties {
+  readonly resource: SimCfnResource;
+  readonly properties: SimCfnTemplateValueRecord;
+}
+
+/**
+ * Reads AWS::SES::EmailIdentity CloudFormation properties.
+ *
+ * There is only one property to read. Everything else an identity Resource can
+ * say is about DKIM, a MAIL FROM domain, a configuration set or feedback
+ * forwarding, none of which this simulation acts on, so each is recorded as
+ * ignored and the identity is created without it.
+ */
+export class SimCfnSesIdentityProperties {
+  readonly #resource: SimCfnResource;
+  readonly #properties: SimCfnTemplateValueRecord;
+  readonly #ignorer: SimCfnPropertyIgnorer;
+
+  constructor(properties: SimCfnSesIdentityPropertiesProperties) {
+    this.#resource = properties.resource;
+    this.#properties = properties.properties;
+    this.#ignorer = properties.resource;
+  }
+
+  /**
+   * The address or domain the identity names.
+   *
+   * Required, and with no name to fall back on: unlike a topic or a log group,
+   * an identity is the thing it names, so CloudFormation cannot make one up.
+   */
+  emailIdentity(): string {
+    const emailIdentity = this.#properties["EmailIdentity"];
+
+    if (emailIdentity === undefined) {
+      throw this.propertyError(
+        `${emailIdentityPropertyName} is required, and there is no name ` +
+          `CloudFormation could generate for an identity`,
+      );
+    }
+
+    if (typeof emailIdentity !== "string") {
+      throw this.propertyError(`${emailIdentityPropertyName} must be a string`);
+    }
+
+    return emailIdentity;
+  }
+
+  /**
+   * Record the properties the identity is created without acting on.
+   *
+   * A property this Resource type does not have is recorded too, rather than
+   * refused. Real CloudFormation refuses one, but the alternative here is a
+   * stack that fails on a property AWS added after this was written, which is
+   * a worse way to find out.
+   */
+  recordIgnoredProperties(): void {
+    for (const name of Object.keys(this.#properties)) {
+      if (name === emailIdentityPropertyName) {
+        continue;
+      }
+
+      this.#ignorer.ignoreProperty(
+        name,
+        unsimulatedIdentityPropertyReasons.get(name) ??
+          `${name} is not a property simulated SES reads from ${
+            sesEmailIdentityResourceType
+          }`,
+      );
+    }
+  }
+
+  private propertyError(reason: string): Error {
+    return simCfnSesResourceError(
+      sesEmailIdentityResourceType,
+      this.#resource.logicalId,
+      reason,
+    );
+  }
+}

--- a/src/service/ses/cfn/identity/sim-cfn-ses-identity-unsimulated-properties.ts
+++ b/src/service/ses/cfn/identity/sim-cfn-ses-identity-unsimulated-properties.ts
@@ -1,0 +1,48 @@
+/**
+ * The AWS::SES::EmailIdentity properties this simulation has nothing to act
+ * on, and why.
+ *
+ * They are recorded as ignored rather than refused, because an identity
+ * without any of them still does the one thing an identity does here: exist to
+ * be verified, and let a send from it through. Refusing would take a whole
+ * stack down over a property that changes nothing about what a test is
+ * checking, and every one of these is something CDK writes readily.
+ *
+ * The SDK path is stricter, and deliberately so: `CreateEmailIdentity` refuses
+ * `DkimSigningAttributes` outright, because a caller reaching for it directly
+ * is asking for that behaviour and should be told it is not there. A template
+ * is a whole document, and one property in it should not sink the deploy.
+ */
+export const unsimulatedIdentityPropertyReasons: ReadonlyMap<string, string> =
+  new Map([
+    [
+      "DkimAttributes",
+      "DKIM is not simulated, so nothing signs a message and nothing checks a " +
+        "signature on one",
+    ],
+    [
+      "DkimSigningAttributes",
+      "DKIM signing is not simulated, so no key here signs anything and no " +
+        "selector is ever published",
+    ],
+    [
+      "ConfigurationSetAttributes",
+      "configuration sets are not simulated, so naming a default one changes " +
+        "nothing about a send from this identity",
+    ],
+    [
+      "MailFromAttributes",
+      "a custom MAIL FROM domain only changes the envelope sender, which no " +
+        "recorded send here carries",
+    ],
+    [
+      "FeedbackAttributes",
+      "bounce and complaint forwarding is not simulated, because nothing here " +
+        "bounces or complains",
+    ],
+    [
+      "Tags",
+      "email identity tags are not simulated, so nothing reads them back and " +
+        "nothing is billed or grouped by them",
+    ],
+  ]);

--- a/src/service/ses/cfn/sim-cfn-ses-cdk-defaults.iso.test.ts
+++ b/src/service/ses/cfn/sim-cfn-ses-cdk-defaults.iso.test.ts
@@ -1,0 +1,144 @@
+import { SendEmailCommand } from "@aws-sdk/client-sesv2";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertTypeString,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import type { SimCfnStack } from "../../cloudformation/stack/sim-cfn-stack.js";
+
+/**
+ * What `aws-cdk-lib` emits for an SES construct set.
+ *
+ * ```ts
+ * const identity = new ses.EmailIdentity(stack, "Identity", {
+ *   identity: ses.Identity.publicHostedZone(zone),
+ *   mailFromDomain: "mail.example.com",
+ * });
+ * new ses.CfnTemplate(stack, "Welcome", { template: { ... } });
+ * ```
+ *
+ * The Resources are written out here rather than synthesized, so this stays an
+ * isolated test. The shape that matters is the DKIM record set: CDK reads
+ * three token pairs off the identity to publish them, which is what makes
+ * those attributes worth answering rather than refusing.
+ */
+const cdkResources = {
+  Identity2D60E2CC: {
+    Type: "AWS::SES::EmailIdentity",
+    Properties: {
+      EmailIdentity: "example.com",
+      MailFromAttributes: { MailFromDomain: "mail.example.com" },
+    },
+  },
+  IdentityDkimDnsToken1: {
+    Type: "AWS::Route53::RecordSet",
+    Properties: {
+      HostedZoneId: "Z0123456789ABCDEFGHIJ",
+      Name: { "Fn::GetAtt": ["Identity2D60E2CC", "DkimDNSTokenName1"] },
+      ResourceRecords: [
+        { "Fn::GetAtt": ["Identity2D60E2CC", "DkimDNSTokenValue1"] },
+      ],
+      TTL: "1800",
+      Type: "CNAME",
+    },
+  },
+  WelcomeTemplate: {
+    Type: "AWS::SES::Template",
+    Properties: {
+      Template: {
+        TemplateName: "welcome",
+        SubjectPart: "Welcome, {{name}}",
+        TextPart: "Hi {{name}}",
+      },
+    },
+  },
+};
+
+async function deployCdkStack(): Promise<{
+  readonly simAws: SimAws;
+  readonly stack: SimCfnStack;
+}> {
+  const simAws = new SimAws();
+  const stack = await simAws.cloudFormation().deployTemplate({
+    stackName: "orders",
+    template: {
+      Resources: cdkResources,
+      Outputs: {
+        Sender: { Value: { Ref: "Identity2D60E2CC" } },
+        Template: { Value: { Ref: "WelcomeTemplate" } },
+        DkimName: {
+          Value: { "Fn::GetAtt": ["Identity2D60E2CC", "DkimDNSTokenName1"] },
+        },
+      },
+    },
+  });
+
+  return { simAws, stack };
+}
+
+describe("CDK-synthesised SES resources", () => {
+  it("deploys the identity, its DKIM records and a template together", async () => {
+    // Given the Resources CDK emits for an identity with a hosted zone and a
+    // template beside it.
+    const { simAws, stack } = await deployCdkStack();
+    const ses = simAws.sesV2();
+
+    // Then the identity and the template are both there, and the Route53
+    // record set that reads the DKIM tokens deployed rather than failing the
+    // stack.
+    assertNonNullable(ses.findIdentity("example.com"));
+    assertNonNullable(ses.findTemplate("welcome"));
+    assertIdentical(stack.outputs.get("Sender")?.value, "example.com");
+    assertIdentical(stack.outputs.get("Template")?.value, "welcome");
+
+    const dkimName = stack.outputs.get("DkimName")?.value;
+
+    assertTypeString(dkimName);
+    assertStringIncludes(dkimName, "._domainkey.example.com");
+  });
+
+  it("sends from what the CDK stack deployed", async () => {
+    // Given the deployed stack, with its identity verified out of band the way
+    // a real one is.
+    const { simAws } = await deployCdkStack();
+    const ses = simAws.sesV2();
+
+    ses.verifyIdentity("example.com");
+    ses.verifyIdentity("example.org");
+
+    // When a message is sent from the template the stack declared.
+    await ses.sendEmail(
+      new SendEmailCommand({
+        FromEmailAddress: "hello@example.com",
+        Destination: { ToAddresses: ["someone@example.org"] },
+        Content: {
+          Template: { TemplateName: "welcome", TemplateData: '{"name":"Ada"}' },
+        },
+      }),
+    );
+
+    // Then it rendered, which is the whole path from a CDK stack to an
+    // assertion about an email.
+    assertArrayLength(ses.sentEmails(), 1);
+    assertIdentical(ses.sentEmails().at(0)?.subject, "Welcome, Ada");
+  });
+
+  it("records the MAIL FROM domain it deployed without acting on", async () => {
+    // Given the deployed stack.
+    const { stack } = await deployCdkStack();
+
+    // Then the property CDK wrote and this simulation has nothing to do with
+    // is reported rather than passed over in silence.
+    const mailFrom = stack.ignoredProperties.find(
+      (property) => property.path === "MailFromAttributes",
+    );
+
+    assertNonNullable(mailFrom);
+    assertStringIncludes(mailFrom.reason, "envelope sender");
+  });
+});

--- a/src/service/ses/cfn/sim-cfn-ses-email-identity.iso.test.ts
+++ b/src/service/ses/cfn/sim-cfn-ses-email-identity.iso.test.ts
@@ -1,0 +1,285 @@
+import { DeleteStackCommand } from "@aws-sdk/client-cloudformation";
+import { SendEmailCommand } from "@aws-sdk/client-sesv2";
+import {
+  assertArrayLength,
+  assertFalse,
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertTrue,
+  assertTypeString,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import type { SimCfnStack } from "../../cloudformation/stack/sim-cfn-stack.js";
+import type { SimCfnTemplateValueRecord } from "../../cloudformation/template/value/sim-cfn-template-value.js";
+
+interface DeployedIdentity {
+  readonly simAws: SimAws;
+  readonly stack: SimCfnStack;
+}
+
+async function deployIdentity(
+  properties: SimCfnTemplateValueRecord,
+  simAws: SimAws = new SimAws(),
+): Promise<DeployedIdentity> {
+  const stack = await simAws.cloudFormation().deployTemplate({
+    stackName: "orders",
+    template: {
+      Resources: {
+        SenderIdentity: {
+          Type: "AWS::SES::EmailIdentity",
+          Properties: properties,
+        },
+      },
+      Outputs: { Sender: { Value: { Ref: "SenderIdentity" } } },
+    },
+  });
+
+  return { simAws, stack };
+}
+
+describe("AWS::SES::EmailIdentity", () => {
+  it("creates an identity a template declares, unverified", async () => {
+    // Given a template declaring a domain identity.
+    const { simAws } = await deployIdentity({ EmailIdentity: "example.com" });
+
+    // When simulated SES is asked for it.
+    const identity = simAws.sesV2().findIdentity("example.com");
+
+    // Then it is there and waiting on its verification, which is what a real
+    // deploy leaves behind: the DKIM records still have to be dealt with out
+    // of band.
+    assertNonNullable(identity);
+    assertIdentical(identity.identityType, "DOMAIN");
+    assertIdentical(identity.verificationStatus, "PENDING");
+    assertFalse(identity.isVerified);
+  });
+
+  it("verifies a deployed identity through the simulator accessor", async () => {
+    // Given a deployed identity.
+    const { simAws } = await deployIdentity({
+      EmailIdentity: "hello@example.com",
+    });
+    const ses = simAws.sesV2();
+
+    // When the test stands in for the emailed confirmation link.
+    ses.verifyIdentity("hello@example.com");
+
+    // Then the one the stack made is verified, rather than a second one
+    // appearing beside it.
+    assertArrayLength(ses.allIdentities(), 1);
+    assertTrue(ses.findIdentity("hello@example.com")?.isVerified);
+  });
+
+  it("sends from an identity a template declared", async () => {
+    // Given a deployed and verified identity.
+    const { simAws } = await deployIdentity({ EmailIdentity: "example.com" });
+    const ses = simAws.sesV2();
+
+    ses.verifyIdentity("example.com");
+    ses.verifyIdentity("example.org");
+
+    // When a message is sent from an address at it.
+    await ses.sendEmail(
+      new SendEmailCommand({
+        FromEmailAddress: "hello@example.com",
+        Destination: { ToAddresses: ["someone@example.org"] },
+        Content: {
+          Simple: {
+            Subject: { Data: "Welcome" },
+            Body: { Text: { Data: "Hi there" } },
+          },
+        },
+      }),
+    );
+
+    // Then it went, which is the whole point of deploying the identity.
+    assertArrayLength(ses.sentEmails(), 1);
+  });
+
+  it("answers a Ref with the address or domain itself", async () => {
+    // Given a deployed identity whose Ref is an output.
+    const { stack } = await deployIdentity({
+      EmailIdentity: "hello@example.com",
+    });
+
+    // Then the Ref is the identity, which is directly usable as a
+    // FromEmailAddress: SES has no other identifier for one.
+    assertIdentical(stack.outputs.get("Sender")?.value, "hello@example.com");
+  });
+
+  it("answers the DKIM token attributes CDK publishes as DNS records", async () => {
+    // Given a template reading the three DKIM tokens off the identity, which
+    // is what `ses.Identity.publicHostedZone()` in CDK emits Route53 records
+    // for.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders",
+      template: {
+        Resources: {
+          SenderIdentity: {
+            Type: "AWS::SES::EmailIdentity",
+            Properties: { EmailIdentity: "example.com" },
+          },
+        },
+        Outputs: {
+          Name1: {
+            Value: { "Fn::GetAtt": ["SenderIdentity", "DkimDNSTokenName1"] },
+          },
+          Value1: {
+            Value: { "Fn::GetAtt": ["SenderIdentity", "DkimDNSTokenValue1"] },
+          },
+          Name3: {
+            Value: { "Fn::GetAtt": ["SenderIdentity", "DkimDNSTokenName3"] },
+          },
+        },
+      },
+    });
+
+    // Then each is a record of the shape SES publishes, so the stack deploys.
+    // The tokens are made up: nothing here signs a message, and refusing would
+    // take down an ordinary CDK stack over records nothing reads.
+    const name1 = stack.outputs.get("Name1")?.value;
+    const name3 = stack.outputs.get("Name3")?.value;
+
+    assertTypeString(name1);
+    assertTypeString(name3);
+    const value1 = stack.outputs.get("Value1")?.value;
+
+    assertTypeString(value1);
+    assertStringIncludes(name1, "._domainkey.example.com");
+    assertStringIncludes(value1, ".dkim.amazonses.com");
+    assertFalse(name1 === name3);
+  });
+
+  it("makes the same DKIM tokens for the same identity every time", async () => {
+    // Given the same identity deployed into two simulations.
+    const first = await deployDkimTokenStack();
+    const second = await deployDkimTokenStack();
+
+    // Then the tokens match, so a test can assert on the records a stack
+    // publishes without them moving between runs.
+    assertIdentical(first, second);
+  });
+
+  it("refuses an attribute the Resource type does not have", async () => {
+    // Given a template reading something off the identity that is not a DKIM
+    // token.
+    const simAws = new SimAws();
+
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.cloudFormation().deployTemplate({
+        stackName: "orders",
+        template: {
+          Resources: {
+            SenderIdentity: {
+              Type: "AWS::SES::EmailIdentity",
+              Properties: { EmailIdentity: "example.com" },
+            },
+          },
+          Outputs: {
+            Arn: { Value: { "Fn::GetAtt": ["SenderIdentity", "Arn"] } },
+          },
+        },
+      });
+    });
+
+    assertStringIncludes(error.message, "Arn");
+  });
+
+  it("removes the identity when the stack is deleted", async () => {
+    // Given a deployed identity.
+    const { simAws } = await deployIdentity({ EmailIdentity: "example.com" });
+
+    // When the stack is deleted.
+    await simAws
+      .cloudFormation()
+      .deleteStack(new DeleteStackCommand({ StackName: "orders" }));
+    await simAws.backgroundTasksComplete();
+
+    // Then the identity went with it.
+    assertArrayLength(simAws.sesV2().allIdentities(), 0);
+  });
+
+  it("refuses a Resource with no EmailIdentity", async () => {
+    // Given a template declaring an identity that names nothing.
+    const error = await assertThrowsErrorAsync(async () => {
+      await deployIdentity({});
+    });
+
+    // Then it is refused. An identity is the thing it names, so unlike a topic
+    // or a log group there is no name CloudFormation could generate.
+    assertStringIncludes(error.message, "EmailIdentity is required");
+  });
+
+  it("refuses a Resource naming something that is not an identity", async () => {
+    // Given a template declaring an identity that is neither an address nor a
+    // domain.
+    const error = await assertThrowsErrorAsync(async () => {
+      await deployIdentity({ EmailIdentity: "not an identity" });
+    });
+
+    // Then simulated SES refused it, and the Resource is named in the message
+    // so a deploy failure says which one asked.
+    assertStringIncludes(error.message, "AWS::SES::EmailIdentity");
+    assertStringIncludes(error.message, "SenderIdentity");
+  });
+
+  it("deploys with DKIM and MAIL FROM properties, recording them as ignored", async () => {
+    // Given a template setting everything CDK readily writes on an identity.
+    const { simAws, stack } = await deployIdentity({
+      EmailIdentity: "example.com",
+      DkimAttributes: { SigningEnabled: true },
+      MailFromAttributes: {
+        MailFromDomain: "mail.example.com",
+        BehaviorOnMxFailure: "USE_DEFAULT_VALUE",
+      },
+      ConfigurationSetAttributes: { ConfigurationSetName: "transactional" },
+    });
+
+    // Then the identity is there, and each property it was deployed without
+    // acting on is recorded rather than passed over in silence.
+    assertNonNullable(simAws.sesV2().findIdentity("example.com"));
+
+    const ignored = stack.ignoredProperties.map((property) => property.path);
+
+    assertArrayLength(ignored, 3);
+    assertStringIncludes(
+      stack.ignoredProperties
+        .map((property) => `${property.path}: ${property.reason}`)
+        .join("\n"),
+      "DKIM is not simulated",
+    );
+  });
+});
+
+/**
+ * The first DKIM token name a fresh simulation reports for one identity.
+ */
+async function deployDkimTokenStack(): Promise<string> {
+  const stack = await new SimAws().cloudFormation().deployTemplate({
+    stackName: "orders",
+    template: {
+      Resources: {
+        SenderIdentity: {
+          Type: "AWS::SES::EmailIdentity",
+          Properties: { EmailIdentity: "example.com" },
+        },
+      },
+      Outputs: {
+        Name1: {
+          Value: { "Fn::GetAtt": ["SenderIdentity", "DkimDNSTokenName1"] },
+        },
+      },
+    },
+  });
+
+  const name1 = stack.outputs.get("Name1")?.value;
+
+  assertTypeString(name1);
+
+  return name1;
+}

--- a/src/service/ses/cfn/sim-cfn-ses-resource-error.ts
+++ b/src/service/ses/cfn/sim-cfn-ses-resource-error.ts
@@ -1,0 +1,54 @@
+import { SimSesError } from "../error/sim-ses.error.js";
+
+/**
+ * Build the error a Resource of a simulated SES type is refused with.
+ *
+ * The wording is deliberate. Sim CloudFormation reads an error saying a
+ * Resource is unsupported as one to record and step over, and stepping over an
+ * identity or a template that cannot be created as the template asked for it
+ * is the wrong answer: the Stack would look deployed while every send from it
+ * failed. So a refusal here says the Resource is invalid.
+ */
+export function simCfnSesResourceError(
+  resourceType: string,
+  logicalId: string,
+  reason: string,
+  cause?: unknown,
+): Error {
+  return new Error(`Invalid ${resourceType} Resource ${logicalId}: ${reason}`, {
+    cause,
+  });
+}
+
+/**
+ * Run the simulated SES commands one Resource is made of, naming the Resource
+ * in whatever they refuse.
+ *
+ * Every Resource type here goes through the ordinary SES commands, so what a
+ * template may ask for is decided once, by simulated SES, rather than again in
+ * the CloudFormation layer. What that leaves out is where the request came
+ * from: a deployment failing with `Only Handlebars substitution is simulated`
+ * says nothing about which Resource asked for it. Only SES's own errors are
+ * renamed, so a refusal the CloudFormation layer decided keeps the wording it
+ * was written with.
+ */
+export async function simCfnSesResourceCreation<T>(
+  resourceType: string,
+  logicalId: string,
+  create: () => Promise<T>,
+): Promise<T> {
+  try {
+    return await create();
+  } catch (error) {
+    if (error instanceof SimSesError) {
+      throw simCfnSesResourceError(
+        resourceType,
+        logicalId,
+        error.message,
+        error,
+      );
+    }
+
+    throw error;
+  }
+}

--- a/src/service/ses/cfn/sim-cfn-ses-resource-refusals.iso.test.ts
+++ b/src/service/ses/cfn/sim-cfn-ses-resource-refusals.iso.test.ts
@@ -1,0 +1,215 @@
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertUndefined,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import type { SimCfnResource } from "../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnStack } from "../../cloudformation/stack/sim-cfn-stack.js";
+import { SimSesNotFoundException } from "../error/sim-ses.error.js";
+import { simCfnSesResourceCreation } from "./sim-cfn-ses-resource-error.js";
+
+/** A stack with one deployed identity, and the Resource record behind it. */
+async function deployedIdentity(): Promise<{
+  readonly simAws: SimAws;
+  readonly stack: SimCfnStack;
+  readonly resource: SimCfnResource;
+}> {
+  const simAws = new SimAws();
+  const stack = await simAws.cloudFormation().deployTemplate({
+    stackName: "orders",
+    template: {
+      Resources: {
+        SenderIdentity: {
+          Type: "AWS::SES::EmailIdentity",
+          Properties: { EmailIdentity: "example.com" },
+        },
+      },
+    },
+  });
+  const resource = stack.resources.get("SenderIdentity");
+
+  assertNonNullable(resource);
+
+  return { simAws, stack, resource };
+}
+
+describe("simulated SES CloudFormation refusals", () => {
+  it("steps over an SES Resource type it does not simulate", async () => {
+    // Given a template declaring a configuration set, which is a real SES
+    // Resource type this simulation has no machinery for.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders",
+      template: {
+        Resources: {
+          Transactional: {
+            Type: "AWS::SES::ConfigurationSet",
+            Properties: { Name: "transactional" },
+          },
+        },
+      },
+    });
+
+    // Then the stack deployed with the Resource recorded as unsupported rather
+    // than treated as deployed, which is how CloudFormation here handles every
+    // Resource type no service claims.
+    const resource = stack.resources.get("Transactional");
+
+    assertNonNullable(resource);
+    assertUndefined(resource.simResource);
+  });
+
+  it("refuses deleting an SES Resource type it does not simulate", async () => {
+    // Given a deployed identity, and the factory that made it.
+    const { simAws, resource } = await deployedIdentity();
+
+    // When the factory is asked to delete a Resource type it never creates.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws
+        .sesV2()
+        .cfnResourceFactory()
+        .delete("ConfigurationSet", resource);
+    });
+
+    assertStringIncludes(
+      error.message,
+      "Unsupported sim SES CloudFormation Resource ConfigurationSet deletion",
+    );
+  });
+
+  it("refuses creating an SES Resource type it does not simulate", async () => {
+    // Given a deployed identity, and the factory that made it.
+    const { simAws, stack, resource } = await deployedIdentity();
+
+    // When the factory is asked to create a Resource type it does not know.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws
+        .sesV2()
+        .cfnResourceFactory()
+        .create("ContactList", resource, {
+          simAws,
+          resources: stack.resources,
+        });
+    });
+
+    assertStringIncludes(
+      error.message,
+      "Unsupported sim SES CloudFormation Resource ContactList",
+    );
+  });
+
+  it("names the Resource in a refusal simulated SES made", async () => {
+    // When an SES error is raised while a Resource is being created.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simCfnSesResourceCreation(
+        "AWS::SES::Template",
+        "WelcomeEmail",
+        () => {
+          throw new SimSesNotFoundException("Email template does not exist.");
+        },
+      );
+    });
+
+    // Then it is renamed to say which Resource asked, since SES's own message
+    // says nothing about where the request came from.
+    assertStringIncludes(
+      error.message,
+      "Invalid AWS::SES::Template Resource WelcomeEmail",
+    );
+    assertStringIncludes(error.message, "Email template does not exist.");
+  });
+
+  it("lets an error that is not SES's own through unchanged", async () => {
+    // Given something going wrong that simulated SES did not raise.
+    const raised = new TypeError("something else entirely");
+
+    const error = await assertThrowsErrorAsync(async () => {
+      await simCfnSesResourceCreation("AWS::SES::Template", "Welcome", () => {
+        throw raised;
+      });
+    });
+
+    // Then it is not renamed. Only SES's own refusals are worth attributing to
+    // a Resource; anything else is a bug and should read like one.
+    assertInstanceOf(error, TypeError);
+    assertIdentical(error, raised);
+  });
+
+  it("refuses an EmailIdentity that is not a string", async () => {
+    // Given a template whose identity is a number.
+    const simAws = new SimAws();
+
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.cloudFormation().deployTemplate({
+        stackName: "orders",
+        template: {
+          Resources: {
+            SenderIdentity: {
+              Type: "AWS::SES::EmailIdentity",
+              Properties: { EmailIdentity: 42 },
+            },
+          },
+        },
+      });
+    });
+
+    assertStringIncludes(error.message, "EmailIdentity must be a string");
+  });
+
+  it("refuses a Template property that is not an object", async () => {
+    // Given a template whose wording is a string rather than a record.
+    const simAws = new SimAws();
+
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.cloudFormation().deployTemplate({
+        stackName: "orders",
+        template: {
+          Resources: {
+            WelcomeEmail: {
+              Type: "AWS::SES::Template",
+              Properties: { Template: "welcome" },
+            },
+          },
+        },
+      });
+    });
+
+    assertStringIncludes(error.message, "Template must be an object");
+  });
+
+  it("refuses an attribute AWS::SES::Template does not have", async () => {
+    // Given a template reading something off an email template that is not its
+    // Id.
+    const simAws = new SimAws();
+
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.cloudFormation().deployTemplate({
+        stackName: "orders",
+        template: {
+          Resources: {
+            WelcomeEmail: {
+              Type: "AWS::SES::Template",
+              Properties: {
+                Template: { TemplateName: "welcome", TextPart: "Hi" },
+              },
+            },
+          },
+          Outputs: {
+            Arn: { Value: { "Fn::GetAtt": ["WelcomeEmail", "Arn"] } },
+          },
+        },
+      });
+    });
+
+    assertStringIncludes(
+      error.message,
+      "Unsupported AWS::SES::Template attribute Arn",
+    );
+  });
+});

--- a/src/service/ses/cfn/sim-cfn-ses-resource-types.ts
+++ b/src/service/ses/cfn/sim-cfn-ses-resource-types.ts
@@ -1,0 +1,15 @@
+/**
+ * The CloudFormation Resource types simulated SES creates.
+ *
+ * Named here rather than spelled out where they are used, because each one is
+ * written twice: once by the factory dispatching on it, and once by the
+ * refusals that quote it back to whoever wrote the template.
+ */
+export const sesEmailIdentityResourceType = "AWS::SES::EmailIdentity";
+
+export const sesTemplateResourceType = "AWS::SES::Template";
+
+/** The type name the CloudFormation layer dispatches on, without its prefix. */
+export const sesEmailIdentityResourceTypeName = "EmailIdentity";
+
+export const sesTemplateResourceTypeName = "Template";

--- a/src/service/ses/cfn/sim-cfn-ses-template.iso.test.ts
+++ b/src/service/ses/cfn/sim-cfn-ses-template.iso.test.ts
@@ -1,0 +1,191 @@
+import { DeleteStackCommand } from "@aws-sdk/client-cloudformation";
+import { SendEmailCommand } from "@aws-sdk/client-sesv2";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import type { SimCfnStack } from "../../cloudformation/stack/sim-cfn-stack.js";
+import type { SimCfnTemplateValueRecord } from "../../cloudformation/template/value/sim-cfn-template-value.js";
+
+interface DeployedTemplate {
+  readonly simAws: SimAws;
+  readonly stack: SimCfnStack;
+}
+
+const welcomeWording = {
+  TemplateName: "welcome",
+  SubjectPart: "Welcome, {{name}}",
+  TextPart: "Hi {{name}}, thanks for signing up.",
+  HtmlPart: "<p>Hi {{name}}</p>",
+};
+
+async function deployTemplate(
+  template: SimCfnTemplateValueRecord,
+  simAws: SimAws = new SimAws(),
+): Promise<DeployedTemplate> {
+  const stack = await simAws.cloudFormation().deployTemplate({
+    stackName: "orders",
+    template: {
+      Resources: {
+        WelcomeEmail: {
+          Type: "AWS::SES::Template",
+          Properties: { Template: template },
+        },
+      },
+      Outputs: {
+        Name: { Value: { Ref: "WelcomeEmail" } },
+        Id: { Value: { "Fn::GetAtt": ["WelcomeEmail", "Id"] } },
+      },
+    },
+  });
+
+  return { simAws, stack };
+}
+
+describe("AWS::SES::Template", () => {
+  it("creates a template a stack declares", async () => {
+    // Given a template declaring an email template.
+    const { simAws } = await deployTemplate(welcomeWording);
+
+    // When simulated SES is asked for it.
+    const template = simAws.sesV2().findTemplate("welcome");
+
+    // Then the wording is there with its placeholders unrendered, under the
+    // API's own names rather than the CloudFormation ones.
+    assertNonNullable(template);
+    assertIdentical(template.content.subject, "Welcome, {{name}}");
+    assertIdentical(template.content.html, "<p>Hi {{name}}</p>");
+  });
+
+  it("renders a send from a template a stack declared", async () => {
+    // Given a deployed template and a verified sender.
+    const { simAws } = await deployTemplate(welcomeWording);
+    const ses = simAws.sesV2();
+
+    ses.verifyIdentity("example.com");
+    ses.verifyIdentity("example.org");
+
+    // When a message is sent from it.
+    await ses.sendEmail(
+      new SendEmailCommand({
+        FromEmailAddress: "hello@example.com",
+        Destination: { ToAddresses: ["someone@example.org"] },
+        Content: {
+          Template: { TemplateName: "welcome", TemplateData: '{"name":"Ada"}' },
+        },
+      }),
+    );
+
+    // Then it rendered, which is what deploying the template was for.
+    const [email] = ses.sentEmails();
+
+    assertNonNullable(email);
+    assertIdentical(email.subject, "Welcome, Ada");
+    assertIdentical(email.templateName, "welcome");
+  });
+
+  it("answers a Ref and the Id attribute with the template name", async () => {
+    // Given a deployed template naming both in its outputs.
+    const { stack } = await deployTemplate(welcomeWording);
+
+    // Then both are the name, which is the only identifier SES gives a
+    // template and is directly usable as the TemplateName of a send.
+    assertIdentical(stack.outputs.get("Name")?.value, "welcome");
+    assertIdentical(stack.outputs.get("Id")?.value, "welcome");
+  });
+
+  it("names an unnamed template after the stack and logical ID", async () => {
+    // Given a template that does not name itself, as CDK often leaves one.
+    const { simAws, stack } = await deployTemplate({
+      SubjectPart: "Welcome",
+      TextPart: "Hi",
+    });
+
+    // Then CloudFormation named it, the way it names any unnamed Resource.
+    const name = stack.outputs.get("Name")?.value;
+
+    assertIdentical(name, "orders-WelcomeEmail");
+    assertNonNullable(simAws.sesV2().findTemplate("orders-WelcomeEmail"));
+  });
+
+  it("leaves out a part the template does not set", async () => {
+    // Given a template with a text body and no HTML one.
+    const { simAws } = await deployTemplate({
+      TemplateName: "reminder",
+      SubjectPart: "Your order",
+      TextPart: "On its way",
+    });
+
+    // Then the part it does not have is absent rather than empty, so a test
+    // asserting on the HTML of a text-only message finds nothing.
+    assertUndefined(simAws.sesV2().findTemplate("reminder")?.content.html);
+  });
+
+  it("removes the template when the stack is deleted", async () => {
+    // Given a deployed template.
+    const { simAws } = await deployTemplate(welcomeWording);
+
+    // When the stack is deleted.
+    await simAws
+      .cloudFormation()
+      .deleteStack(new DeleteStackCommand({ StackName: "orders" }));
+    await simAws.backgroundTasksComplete();
+
+    // Then the template went with it.
+    assertArrayLength(simAws.sesV2().allTemplates(), 0);
+  });
+
+  it("fails the deploy on Handlebars this simulation cannot render", async () => {
+    // Given a template carrying a block helper.
+    const error = await assertThrowsErrorAsync(async () => {
+      await deployTemplate({
+        TemplateName: "welcome",
+        SubjectPart: "Welcome",
+        TextPart: "{{#if premium}}Thanks for subscribing{{/if}}",
+      });
+    });
+
+    // Then the deploy fails rather than storing a template that would fail at
+    // the first send, and the Resource is named so it says which one asked.
+    assertStringIncludes(error.message, "AWS::SES::Template");
+    assertStringIncludes(error.message, "WelcomeEmail");
+    assertStringIncludes(error.message, "block helper");
+  });
+
+  it("refuses a Resource with no Template property", async () => {
+    // Given a template declaring an email template with nothing in it.
+    const simAws = new SimAws();
+
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.cloudFormation().deployTemplate({
+        stackName: "orders",
+        template: {
+          Resources: {
+            WelcomeEmail: { Type: "AWS::SES::Template", Properties: {} },
+          },
+        },
+      });
+    });
+
+    assertStringIncludes(error.message, "Template is required");
+  });
+
+  it("refuses a wording part that is not a string", async () => {
+    // Given a template whose subject is a number.
+    const error = await assertThrowsErrorAsync(async () => {
+      await deployTemplate({ TemplateName: "welcome", SubjectPart: 42 });
+    });
+
+    assertStringIncludes(
+      error.message,
+      "Template.SubjectPart must be a string",
+    );
+  });
+});

--- a/src/service/ses/cfn/sim-cfn-ses-template.iso.test.ts
+++ b/src/service/ses/cfn/sim-cfn-ses-template.iso.test.ts
@@ -188,4 +188,50 @@ describe("AWS::SES::Template", () => {
       "Template.SubjectPart must be a string",
     );
   });
+
+  it("records a misspelled wording part rather than dropping it", async () => {
+    // Given a template that misspells one of its parts, which is the mistake
+    // this reporting exists to catch.
+    const { simAws, stack } = await deployTemplate({
+      TemplateName: "welcome",
+      SubjectPart: "Welcome",
+      Textpart: "Hi there",
+    });
+
+    // Then the template deployed with no body, and the property it was created
+    // without is named rather than dropped in silence.
+    assertUndefined(simAws.sesV2().findTemplate("welcome")?.content.text);
+
+    const ignored = stack.ignoredProperties.find(
+      (property) => property.path === "Template.Textpart",
+    );
+
+    assertNonNullable(ignored);
+    assertStringIncludes(ignored.reason, "AWS::SES::Template");
+  });
+
+  it("records a property sitting beside Template", async () => {
+    // Given a template with a stray property outside the wording.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders",
+      template: {
+        Resources: {
+          WelcomeEmail: {
+            Type: "AWS::SES::Template",
+            Properties: {
+              Template: { TemplateName: "welcome", TextPart: "Hi" },
+              Tags: [{ Key: "team", Value: "orders" }],
+            },
+          },
+        },
+      },
+    });
+
+    // Then it is recorded too: a stray property can sit beside Template as
+    // well as inside it.
+    assertNonNullable(
+      stack.ignoredProperties.find((property) => property.path === "Tags"),
+    );
+  });
 });

--- a/src/service/ses/cfn/sim-ses-cfn-resource-factory.ts
+++ b/src/service/ses/cfn/sim-ses-cfn-resource-factory.ts
@@ -1,0 +1,114 @@
+import { assertDefined } from "../../../util/type-guard/defined.js";
+import type { SimCfnServiceResourceFactory } from "../../cloudformation/resource/factory/sim-cfn-resource-factory.type.js";
+import type {
+  SimCfnResource,
+  SimCloudFormationResourceCreateContext,
+} from "../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimSesIdentity } from "../identity/sim-ses-identity.js";
+import type { SimSesV2 } from "../sim-ses-v2.js";
+import type { SimSesTemplate } from "../template/sim-ses-template.js";
+import { SimCfnSesIdentityCreator } from "./identity/sim-cfn-ses-identity-creator.js";
+import {
+  sesEmailIdentityResourceTypeName,
+  sesTemplateResourceTypeName,
+} from "./sim-cfn-ses-resource-types.js";
+import { SimCfnSesTemplateCreator } from "./template/sim-cfn-ses-template-creator.js";
+
+interface SimSesCfnResourceFactoryProperties {
+  readonly ses: SimSesV2;
+}
+
+/**
+ * CloudFormation Resource factory for simulated SES resources.
+ *
+ * Email identities and templates are the two AWS::SES::* Resource types this
+ * simulation models. Configuration sets, contact lists and receipt rules need
+ * machinery it does not have, so a template declaring one is reported as
+ * unsupported rather than quietly treated as deployed.
+ */
+export class SimSesCfnResourceFactory implements SimCfnServiceResourceFactory {
+  readonly #identityCreator: SimCfnSesIdentityCreator;
+  readonly #templateCreator: SimCfnSesTemplateCreator;
+
+  constructor(properties: SimSesCfnResourceFactoryProperties) {
+    this.#identityCreator = new SimCfnSesIdentityCreator({
+      ses: properties.ses,
+    });
+    this.#templateCreator = new SimCfnSesTemplateCreator({
+      ses: properties.ses,
+    });
+  }
+
+  /**
+   * Create a simulated SES resource from a CloudFormation Resource.
+   */
+  async create(
+    resourceTypeName: string,
+    resource: SimCfnResource,
+    context: SimCloudFormationResourceCreateContext,
+  ): Promise<object | undefined> {
+    const properties = context.resolvedProperties ?? resource.properties;
+
+    switch (resourceTypeName) {
+      case sesEmailIdentityResourceTypeName: {
+        return await this.#identityCreator.create(resource, properties);
+      }
+      case sesTemplateResourceTypeName: {
+        return await this.#templateCreator.create(resource, properties);
+      }
+      default: {
+        throw unsupportedResourceType(resourceTypeName, "");
+      }
+    }
+  }
+
+  /**
+   * Delete a simulated SES resource created from a CloudFormation Resource.
+   */
+  async delete(
+    resourceTypeName: string,
+    resource: SimCfnResource,
+  ): Promise<void> {
+    switch (resourceTypeName) {
+      case sesEmailIdentityResourceTypeName: {
+        await this.#identityCreator.delete(
+          created<SimSesIdentity>(resource, "identity"),
+        );
+        return;
+      }
+      case sesTemplateResourceTypeName: {
+        await this.#templateCreator.delete(
+          created<SimSesTemplate>(resource, "template"),
+        );
+        return;
+      }
+      default: {
+        throw unsupportedResourceType(resourceTypeName, " deletion");
+      }
+    }
+  }
+}
+
+function created<T extends object>(
+  resource: SimCfnResource,
+  described: string,
+): T {
+  const simResource = resource.simResource as T | undefined;
+
+  assertDefined(
+    simResource,
+    `sim SES ${described} for CloudFormation Resource ${resource.logicalId}`,
+  );
+
+  return simResource;
+}
+
+function unsupportedResourceType(
+  resourceTypeName: string,
+  operationSuffix: string,
+): Error {
+  return new Error(
+    `Unsupported sim SES CloudFormation Resource ` +
+      `${resourceTypeName}${operationSuffix}`,
+  );
+}

--- a/src/service/ses/cfn/template/sim-cfn-ses-template-creator.ts
+++ b/src/service/ses/cfn/template/sim-cfn-ses-template-creator.ts
@@ -41,6 +41,8 @@ export class SimCfnSesTemplateCreator {
     const templateName = templateProperties.templateName();
     const content = templateProperties.content();
 
+    templateProperties.recordIgnoredProperties();
+
     return await simCfnSesResourceCreation(
       sesTemplateResourceType,
       resource.logicalId,

--- a/src/service/ses/cfn/template/sim-cfn-ses-template-creator.ts
+++ b/src/service/ses/cfn/template/sim-cfn-ses-template-creator.ts
@@ -1,0 +1,72 @@
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimSesV2 } from "../../sim-ses-v2.js";
+import type { SimSesTemplate } from "../../template/sim-ses-template.js";
+import { simCfnSesResourceCreation } from "../sim-cfn-ses-resource-error.js";
+import { sesTemplateResourceType } from "../sim-cfn-ses-resource-types.js";
+import { SimCfnSesTemplateProperties } from "./sim-cfn-ses-template-properties.js";
+
+interface SimCfnSesTemplateCreatorProperties {
+  readonly ses: SimSesV2;
+}
+
+/**
+ * Creates simulated email templates from AWS::SES::Template Resources.
+ *
+ * The template goes through the ordinary CreateEmailTemplate command, so one a
+ * stack deployed is rendered by exactly the same code as one an SDK caller
+ * made. That is what makes a template carrying Handlebars this simulation does
+ * not render fail the deploy rather than sit in the stack waiting to fail at
+ * the first send.
+ */
+export class SimCfnSesTemplateCreator {
+  readonly #ses: SimSesV2;
+
+  constructor(properties: SimCfnSesTemplateCreatorProperties) {
+    this.#ses = properties.ses;
+  }
+
+  /**
+   * Create a template from an AWS::SES::Template Resource.
+   */
+  async create(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): Promise<SimSesTemplate> {
+    const templateProperties = new SimCfnSesTemplateProperties({
+      resource,
+      properties,
+    });
+    const templateName = templateProperties.templateName();
+    const content = templateProperties.content();
+
+    return await simCfnSesResourceCreation(
+      sesTemplateResourceType,
+      resource.logicalId,
+      async () => {
+        await this.#ses.createEmailTemplate({
+          input: { TemplateName: templateName, TemplateContent: content },
+        });
+
+        const template = this.#ses.findTemplate(templateName);
+
+        assertDefined(
+          template,
+          `sim SES template ${templateName} after CloudFormation creation`,
+        );
+
+        return template;
+      },
+    );
+  }
+
+  /**
+   * Delete a template created from an AWS::SES::Template Resource.
+   */
+  async delete(template: SimSesTemplate): Promise<void> {
+    await this.#ses.deleteEmailTemplate({
+      input: { TemplateName: template.templateName },
+    });
+  }
+}

--- a/src/service/ses/cfn/template/sim-cfn-ses-template-properties.ts
+++ b/src/service/ses/cfn/template/sim-cfn-ses-template-properties.ts
@@ -1,0 +1,121 @@
+import { SimCfnGeneratedResourceName } from "../../../cloudformation/resource/name/sim-cfn-generated-resource-name.js";
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type {
+  SimCfnTemplateValue,
+  SimCfnTemplateValueRecord,
+} from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimSesEmailTemplateContent } from "../../command/template/template.command.js";
+import { simCfnSesResourceError } from "../sim-cfn-ses-resource-error.js";
+import { sesTemplateResourceType } from "../sim-cfn-ses-resource-types.js";
+
+const maximumNameLength = 64;
+
+interface SimCfnSesTemplatePropertiesProperties {
+  readonly resource: SimCfnResource;
+  readonly properties: SimCfnTemplateValueRecord;
+}
+
+/**
+ * Reads AWS::SES::Template CloudFormation properties into the shape
+ * CreateEmailTemplate takes.
+ *
+ * Everything a template Resource says is nested inside one `Template`
+ * property, which is unusual for a CloudFormation Resource and is why this
+ * reads a record out of a record.
+ */
+export class SimCfnSesTemplateProperties {
+  readonly #resource: SimCfnResource;
+  readonly #template: ReadonlyMap<string, SimCfnTemplateValue>;
+
+  constructor(properties: SimCfnSesTemplatePropertiesProperties) {
+    this.#resource = properties.resource;
+    this.#template = new Map(
+      Object.entries(this.readTemplate(properties.properties)),
+    );
+  }
+
+  /**
+   * The template name.
+   *
+   * An unnamed template is named after the stack and the logical ID, as real
+   * CloudFormation names one.
+   */
+  templateName(): string {
+    const name = this.stringPart("TemplateName");
+
+    if (name === undefined) {
+      return new SimCfnGeneratedResourceName({
+        stackName: this.#resource.stackName,
+        logicalId: this.#resource.logicalId,
+        maximumLength: maximumNameLength,
+      }).value;
+    }
+
+    return name;
+  }
+
+  /**
+   * The wording, in the shape CreateEmailTemplate takes it.
+   *
+   * A part the template does not set is left out rather than sent as an empty
+   * string, so a template with only a text body reports no HTML part rather
+   * than an empty one.
+   */
+  content(): SimSesEmailTemplateContent {
+    return {
+      Subject: this.stringPart("SubjectPart"),
+      Text: this.stringPart("TextPart"),
+      Html: this.stringPart("HtmlPart"),
+    };
+  }
+
+  /**
+   * One part of the wording, or nothing where the template does not set it.
+   *
+   * The names are mapped at the call sites above rather than through a table,
+   * because the two APIs disagree and it is worth being able to see which is
+   * which: `AWS::SES::Template` kept the names the older SES API used, so a
+   * template says `SubjectPart` where `CreateEmailTemplate` says `Subject`.
+   */
+  private stringPart(name: string): string | undefined {
+    const value = this.#template.get(name);
+
+    if (value === undefined) {
+      return undefined;
+    }
+
+    if (typeof value !== "string") {
+      throw this.propertyError(`Template.${name} must be a string`);
+    }
+
+    return value;
+  }
+
+  private readTemplate(
+    properties: SimCfnTemplateValueRecord,
+  ): SimCfnTemplateValueRecord {
+    const template = properties["Template"];
+
+    if (template === undefined) {
+      throw this.propertyError("Template is required");
+    }
+
+    if (
+      typeof template !== "object" ||
+      template === null ||
+      Array.isArray(template)
+    ) {
+      throw this.propertyError("Template must be an object");
+    }
+
+    return template;
+  }
+
+  private propertyError(reason: string): Error {
+    return simCfnSesResourceError(
+      sesTemplateResourceType,
+      this.#resource.logicalId,
+      reason,
+    );
+  }
+}

--- a/src/service/ses/cfn/template/sim-cfn-ses-template-properties.ts
+++ b/src/service/ses/cfn/template/sim-cfn-ses-template-properties.ts
@@ -1,4 +1,5 @@
 import { SimCfnGeneratedResourceName } from "../../../cloudformation/resource/name/sim-cfn-generated-resource-name.js";
+import type { SimCfnPropertyIgnorer } from "../../../cloudformation/resource/ignore/sim-cfn-ignored-property.type.js";
 import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
 import type {
   SimCfnTemplateValue,
@@ -9,6 +10,14 @@ import { simCfnSesResourceError } from "../sim-cfn-ses-resource-error.js";
 import { sesTemplateResourceType } from "../sim-cfn-ses-resource-types.js";
 
 const maximumNameLength = 64;
+
+/** The parts of the wording this Resource is actually created from. */
+const actedOnParts = new Set([
+  "TemplateName",
+  "SubjectPart",
+  "TextPart",
+  "HtmlPart",
+]);
 
 interface SimCfnSesTemplatePropertiesProperties {
   readonly resource: SimCfnResource;
@@ -25,13 +34,43 @@ interface SimCfnSesTemplatePropertiesProperties {
  */
 export class SimCfnSesTemplateProperties {
   readonly #resource: SimCfnResource;
+  readonly #properties: SimCfnTemplateValueRecord;
   readonly #template: ReadonlyMap<string, SimCfnTemplateValue>;
+  readonly #ignorer: SimCfnPropertyIgnorer;
 
   constructor(properties: SimCfnSesTemplatePropertiesProperties) {
     this.#resource = properties.resource;
+    this.#properties = properties.properties;
+    this.#ignorer = properties.resource;
     this.#template = new Map(
       Object.entries(this.readTemplate(properties.properties)),
     );
+  }
+
+  /**
+   * Record the properties the template is created without acting on.
+   *
+   * Everything a template Resource can usefully say is wording, so in practice
+   * this catches a misspelling: `TextPart` written `Textpart` would otherwise
+   * be dropped in silence and the message would go out with a missing body and
+   * nothing to explain it. Both levels are walked, since a stray property can
+   * sit beside `Template` as well as inside it.
+   */
+  recordIgnoredProperties(): void {
+    for (const name of Object.keys(this.#properties)) {
+      if (name !== "Template") {
+        this.#ignorer.ignoreProperty(name, this.unreadReason(name));
+      }
+    }
+
+    for (const name of this.#template.keys()) {
+      if (!actedOnParts.has(name)) {
+        this.#ignorer.ignoreProperty(
+          `Template.${name}`,
+          this.unreadReason(`Template.${name}`),
+        );
+      }
+    }
   }
 
   /**
@@ -89,6 +128,13 @@ export class SimCfnSesTemplateProperties {
     }
 
     return value;
+  }
+
+  private unreadReason(path: string): string {
+    return (
+      `${path} is not a property simulated SES reads from ` +
+      `${sesTemplateResourceType}, so the template is created without it`
+    );
   }
 
   private readTemplate(

--- a/src/service/ses/sim-ses-v2.ts
+++ b/src/service/ses/sim-ses-v2.ts
@@ -4,6 +4,7 @@ import type { SimSesRequestOptions } from "./command/sim-ses-request-options.js"
 import type { SimSesSentEmail } from "./email/sim-ses-sent-email.js";
 import type { SimSesIdentity } from "./identity/sim-ses-identity.js";
 import type { SimSesTemplate } from "./template/sim-ses-template.js";
+import { SimSesCfnResourceFactory } from "./cfn/sim-ses-cfn-resource-factory.js";
 import { SimSesSdkCommandRouter } from "./sdk/sim-ses-sdk-command-router.js";
 import { SimSesCommands, type SimSesV2Properties } from "./sim-ses-commands.js";
 
@@ -31,6 +32,7 @@ import { SimSesCommands, type SimSesV2Properties } from "./sim-ses-commands.js";
 export class SimSesV2 {
   readonly #commands: SimSesCommands;
   readonly #sdkRouter = new SimSesSdkCommandRouter(this);
+  readonly #cfnFactory = new SimSesCfnResourceFactory({ ses: this });
 
   constructor(properties: SimSesV2Properties = {}) {
     this.#commands = new SimSesCommands(properties);
@@ -263,6 +265,13 @@ export class SimSesV2 {
   ): Promise<simSesCommands.SimPutAccountDetailsCommandOutput> {
     await this.#commands.background.sequence();
     return this.#commands.accountCommands.putAccountDetails(command, options);
+  }
+
+  /**
+   * Get the CloudFormation Resource factory for AWS::SES::* Resources.
+   */
+  cfnResourceFactory(): SimSesCfnResourceFactory {
+    return this.#cfnFactory;
   }
 
   /**


### PR DESCRIPTION
Adds AWS::SES::EmailIdentity and AWS::SES::Template to simulated CloudFormation, so a project declaring them in CDK can deploy the same template its application deploys rather than creating them by hand in test setup. Both go through the ordinary SES commands, so a stack-deployed identity or template is the same thing an SDK caller would have got, and wording a template cannot render fails the deploy rather than waiting to fail at the first send. An identity deploys unverified, as a real one does. The DKIM token attributes are answered with deterministic made-up tokens rather than refused, because `ses.Identity.publicHostedZone` in CDK emits Route53 record sets reading them and refusing would take an ordinary stack down over records nothing here reads.

Resolves #634

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CloudFormation support for simulated SES email identities and templates.
  * Supports identity verification workflows, templated email sending, resource references, and DKIM token attributes.
  * Resources are removed when their CloudFormation stack is deleted.
  * Added validation for template rendering, required properties, unsupported attributes, and invalid values.

* **Documentation**
  * Added deployment examples and documented supported resource types, ignored properties, and deterministic DKIM behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->