### PR TITLE
fix: reach simulated AWS from a bundled SDK

### DIFF
--- a/docs/services/lambda/README.md
+++ b/docs/services/lambda/README.md
@@ -383,7 +383,34 @@ denial surfaces inside the handler.
 A client constructed without a region defaults to the function's account and region scope, as the
 real runtime's `AWS_REGION` provides; an explicit region on the client wins. The archive always
 takes precedence: a package bundled under the archive's `node_modules/` is used as-is rather than
-being intercepted.
+being intercepted, and reaches the simulation through the transport below instead.
+
+### Function code that bundles the SDK
+
+Some deployment packages inline the SDK rather than relying on the runtime to provide it, which is
+what CDK's `NodejsFunction` does when given `bundling: { externalModules: [] }`. There is then no
+`@aws-sdk/*` module left for the runtime to provide, so nothing to intercept.
+
+Those functions reach the simulation anyway. The runtime provides their HTTP transport, `node:http`
+and `node:https`, and a request addressed to an AWS API endpoint is answered from the same
+simulated services, as the same execution role, instead of going to the network. The execution
+role credentials are in the function's environment, as real Lambda puts them there, so the SDK
+resolves credentials without looking outside the sandbox rather than failing with
+`CredentialsProviderError`.
+
+A serialized request states which operation it is and carries its input for the services using the
+AWS JSON protocol, which is what can be read back without the operation's schema:
+
+ACM, CloudWatch Logs, Cognito Identity Provider, DynamoDB, DynamoDB Streams, ECS, EventBridge, KMS,
+Rekognition, Secrets Manager, SQS and SSM.
+
+A bundled call to any other simulated service, such as S3, SNS, SES or Lambda itself, fails with an
+error naming the service rather than reaching it. Leaving the SDK out of that archive puts it back
+on the module interception path above, which every simulated service is reachable through.
+
+Values the JSON protocols encode travel in their encoded form: a binary attribute written through a
+bundled SDK is stored base64-encoded and decodes correctly when the same path reads it back, but an
+in-process intercepted client reading it sees the encoded string rather than the bytes.
 
 ## Invocation types
 
@@ -1571,7 +1598,11 @@ giving the ARN. A synthesized CDK app deploys either way with no special casing.
 
 A function can declare its own environment variables with `Environment.Variables`, as on real
 Lambda. While the function runs, its code reads those variables from `process.env`, alongside the
-AWS-provided runtime variables (`AWS_REGION`, `AWS_LAMBDA_FUNCTION_NAME`, and the rest).
+AWS-provided runtime variables (`AWS_REGION`, `AWS_LAMBDA_FUNCTION_NAME`, and the rest). Those
+include placeholder execution role credentials in `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` and
+`AWS_SESSION_TOKEN`, which is where an AWS SDK in the function code finds credentials, as it does
+on real Lambda. Nothing authorizes against their values: a call from function code is attributed to
+the execution Role because the invocation is running as it.
 
 ```typescript sim-lambda-environment-variables
 /**

--- a/docs/services/lambda/README.md
+++ b/docs/services/lambda/README.md
@@ -412,6 +412,10 @@ Values the JSON protocols encode travel in their encoded form: a binary attribut
 bundled SDK is stored base64-encoded and decodes correctly when the same path reads it back, but an
 in-process intercepted client reading it sees the encoded string rather than the bytes.
 
+Only service API endpoints are answered this way. A request to the endpoint of one resource, such
+as a Lambda Function URL or an API Gateway HTTP API, is an ordinary HTTP request rather than a
+serialized Command, and goes wherever it was addressed.
+
 ## Invocation types
 
 `InvokeCommand` supports the three AWS invocation types. `RequestResponse` (the default) awaits

--- a/src/sdk/error/sim-sdk.error.ts
+++ b/src/sdk/error/sim-sdk.error.ts
@@ -51,6 +51,17 @@ export class SimSdkCallbackNotSupportedError extends SimSdkError {
 }
 
 /**
+ * A serialized AWS API request cannot be routed into the simulation.
+ *
+ * Raised for a request from an SDK bundled into the code it runs, where there
+ * is no Command object left to intercept and the request itself is all there
+ * is to route.
+ */
+export class SimSdkUnbridgedWireRequestError extends SimSdkError {
+  public override readonly name = "SimSdkUnbridgedWireRequestError";
+}
+
+/**
  * A simulated SDK stream body was consumed more than once.
  */
 export class SimSdkStreamAlreadyConsumedError extends SimSdkError {

--- a/src/sdk/index.ts
+++ b/src/sdk/index.ts
@@ -25,6 +25,7 @@ export {
   SimSdkCommandNotInterceptedError,
   SimSdkInvalidClientError,
   SimSdkStreamAlreadyConsumedError,
+  SimSdkUnbridgedWireRequestError,
   SimSdkUnknownServiceError,
   SimSdkUnsupportedCommandError,
 } from "./error/sim-sdk.error.js";

--- a/src/sdk/wire/sim-sdk-wire-command.ts
+++ b/src/sdk/wire/sim-sdk-wire-command.ts
@@ -1,0 +1,35 @@
+/**
+ * Build the SDK Command a wire request was serialized from.
+ *
+ * Command routing is by Command class name and Command input, so a Command
+ * rebuilt with the name the request named and the input it carried routes to
+ * exactly the operation the real Command would have. Constructing the SDK's own
+ * Command class instead would mean requiring the client package for every
+ * service a bundled function might call, to end up at the same two values.
+ */
+export function makeSimSdkWireCommand(
+  commandName: string,
+  input: unknown,
+): object {
+  class SimSdkWireCommand {
+    constructor(public readonly input: unknown) {}
+  }
+  Object.defineProperty(SimSdkWireCommand, "name", { value: commandName });
+
+  return new SimSdkWireCommand(input);
+}
+
+/**
+ * Build the SDK client a wire request would have been sent by.
+ *
+ * The dispatcher reads only the resolved service identity and Region from a
+ * client, which the request states itself: the service in its operation header
+ * and the Region in its credential scope. Nothing else about a client survives
+ * serialization, and nothing else is needed.
+ */
+export function makeSimSdkWireClient(
+  serviceId: string,
+  regionName: string,
+): object {
+  return { config: { serviceId, region: regionName } };
+}

--- a/src/sdk/wire/sim-sdk-wire-dispatcher.iso.test.ts
+++ b/src/sdk/wire/sim-sdk-wire-dispatcher.iso.test.ts
@@ -1,0 +1,311 @@
+import { CreateTableCommand, PutItemCommand } from "@aws-sdk/client-dynamodb";
+import {
+  assertIdentical,
+  assertObjectMatches,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertTypeNumber,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../service/aws/sim-aws.js";
+import { SimSdkWireDispatcher } from "./sim-sdk-wire-dispatcher.js";
+import type {
+  SimSdkWireRequest,
+  SimSdkWireResponse,
+} from "./sim-sdk-wire.types.js";
+
+/**
+ * A signed request as an AWS SDK puts one on the wire.
+ *
+ * The Authorization header carries the credential scope, which is where the
+ * request says the Region and the service it was signed for.
+ */
+function wireRequest(
+  target: string,
+  input: unknown,
+  regionName = "eu-west-2",
+  signingName = "dynamodb",
+): SimSdkWireRequest {
+  return {
+    method: "POST",
+    hostname: `${signingName}.${regionName}.amazonaws.com`,
+    path: "/",
+    headers: Object.fromEntries([
+      ["x-amz-target", target],
+      ["content-type", "application/x-amz-json-1.0"],
+      [
+        "authorization",
+        "AWS4-HMAC-SHA256 Credential=ASIAEXAMPLE/20260817/" +
+          `${regionName}/${signingName}/aws4_request, SignedHeaders=host, ` +
+          "Signature=abc123",
+      ],
+    ]),
+    body: Buffer.from(JSON.stringify(input)),
+  };
+}
+
+function responseBody(response: SimSdkWireResponse): Record<string, unknown> {
+  return JSON.parse(Buffer.from(response.body).toString()) as Record<
+    string,
+    unknown
+  >;
+}
+
+async function simAwsWithOrder(): Promise<SimAws> {
+  const simAws = new SimAws({ defaultRegionName: "eu-west-2" });
+  await simAws.dynamoDb().createTable(
+    new CreateTableCommand({
+      TableName: "orders",
+      AttributeDefinitions: [{ AttributeName: "orderId", AttributeType: "S" }],
+      KeySchema: [{ AttributeName: "orderId", KeyType: "HASH" }],
+      BillingMode: "PAY_PER_REQUEST",
+    }),
+  );
+  await simAws.dynamoDb().putItem(
+    new PutItemCommand({
+      TableName: "orders",
+      Item: { orderId: { S: "order-1" }, total: { N: "42" } },
+    }),
+  );
+
+  return simAws;
+}
+
+describe("simulated AWS SDK wire dispatch", () => {
+  it("answers a serialized Command from the simulation", async () => {
+    // Given a simulated table holding an item.
+    const simAws = await simAwsWithOrder();
+    const dispatcher = new SimSdkWireDispatcher(simAws);
+
+    // When the request an SDK would have serialized for it is dispatched.
+    const response = await dispatcher.dispatch(
+      wireRequest("DynamoDB_20120810.GetItem", {
+        TableName: "orders",
+        Key: { orderId: { S: "order-1" } },
+      }),
+    );
+
+    // Then the operation answered as the service would have on the wire.
+    assertIdentical(response.statusCode, 200);
+    assertIdentical(
+      response.headers["content-type"],
+      "application/x-amz-json-1.0",
+    );
+    assertObjectMatches(responseBody(response), {
+      Item: { orderId: { S: "order-1" }, total: { N: "42" } },
+    });
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("answers a refused operation as the failure the SDK reads", async () => {
+    // Given a simulation with no such table.
+    const simAws = new SimAws({ defaultRegionName: "eu-west-2" });
+    const dispatcher = new SimSdkWireDispatcher(simAws);
+
+    // When an operation the service refuses is dispatched.
+    const response = await dispatcher.dispatch(
+      wireRequest("DynamoDB_20120810.GetItem", {
+        TableName: "missing",
+        Key: { orderId: { S: "order-1" } },
+      }),
+    );
+
+    // Then the response carries the exception name in both places the SDK
+    // looks for it, with the status real DynamoDB answers.
+    assertIdentical(response.statusCode, 400);
+    assertIdentical(
+      response.headers["x-amzn-errortype"],
+      "ResourceNotFoundException",
+    );
+    assertObjectMatches(responseBody(response), {
+      __type: "ResourceNotFoundException",
+    });
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("reads an operation that sends no request body", async () => {
+    // Given a simulation with a table in it.
+    const simAws = await simAwsWithOrder();
+    const dispatcher = new SimSdkWireDispatcher(simAws);
+
+    // When an operation taking no input is dispatched, which an SDK sends
+    // with an empty body.
+    const response = await dispatcher.dispatch({
+      ...wireRequest("DynamoDB_20120810.ListTables", {}),
+      body: new Uint8Array(),
+    });
+
+    // Then the empty body read as the empty input it stands for.
+    assertIdentical(response.statusCode, 200);
+    assertObjectMatches(responseBody(response), { TableNames: ["orders"] });
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("answers an operation the simulated service does not support", async () => {
+    // Given a simulation.
+    const simAws = new SimAws({ defaultRegionName: "eu-west-2" });
+    const dispatcher = new SimSdkWireDispatcher(simAws);
+
+    // When a request naming an operation nothing routes is dispatched.
+    const response = await dispatcher.dispatch(
+      wireRequest("DynamoDB_20120810.ExportTableToPointInTime", {}),
+    );
+
+    // Then the SDK reads back an error naming the unsupported Command.
+    assertIdentical(response.statusCode, 400);
+    assertStringIncludes(
+      String(responseBody(response)["message"]),
+      "ExportTableToPointInTimeCommand",
+    );
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("dispatches to the Region the request was signed for", async () => {
+    // Given a table in a Region that is not the simulation's default.
+    const simAws = new SimAws({ defaultRegionName: "eu-west-2" });
+    await simAws
+      .accountRegionScope(undefined, "us-east-1")
+      .dynamoDb()
+      .createTable(
+        new CreateTableCommand({
+          TableName: "orders",
+          AttributeDefinitions: [
+            { AttributeName: "orderId", AttributeType: "S" },
+          ],
+          KeySchema: [{ AttributeName: "orderId", KeyType: "HASH" }],
+          BillingMode: "PAY_PER_REQUEST",
+        }),
+      );
+    const dispatcher = new SimSdkWireDispatcher(simAws);
+
+    // When a request signed for that Region is dispatched.
+    const response = await dispatcher.dispatch(
+      wireRequest(
+        "DynamoDB_20120810.DescribeTable",
+        { TableName: "orders" },
+        "us-east-1",
+      ),
+    );
+
+    // Then it reached the table there rather than the default Region's.
+    assertIdentical(response.statusCode, 200);
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("dispatches an unsigned request to the Region it was given", async () => {
+    // Given a dispatcher told which Region the code sending requests runs in.
+    const simAws = await simAwsWithOrder();
+    const dispatcher = new SimSdkWireDispatcher(simAws, "eu-west-2");
+
+    // When a request carrying no signature to read a scope from arrives.
+    const response = await dispatcher.dispatch({
+      ...wireRequest("DynamoDB_20120810.ListTables", {}),
+      headers: Object.fromEntries([
+        ["x-amz-target", "DynamoDB_20120810.ListTables"],
+      ]),
+    });
+
+    // Then it was answered in that Region.
+    assertObjectMatches(responseBody(response), { TableNames: ["orders"] });
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("encodes timestamps and binary as the protocol carries them", async () => {
+    // Given an item with a binary attribute, and a table with a creation time.
+    const simAws = await simAwsWithOrder();
+    await simAws.dynamoDb().putItem(
+      new PutItemCommand({
+        TableName: "orders",
+        Item: {
+          orderId: { S: "order-2" },
+          receipt: { B: new Uint8Array([1, 2, 3]) },
+        },
+      }),
+    );
+    const dispatcher = new SimSdkWireDispatcher(simAws);
+
+    // When the item and the table are read over the wire.
+    const item = responseBody(
+      await dispatcher.dispatch(
+        wireRequest("DynamoDB_20120810.GetItem", {
+          TableName: "orders",
+          Key: { orderId: { S: "order-2" } },
+        }),
+      ),
+    );
+    const table = responseBody(
+      await dispatcher.dispatch(
+        wireRequest("DynamoDB_20120810.DescribeTable", {
+          TableName: "orders",
+        }),
+      ),
+    );
+
+    // Then binary is base64 and the timestamp is epoch seconds, which is what
+    // the SDK reading this back decodes them from.
+    assertObjectMatches(item, { Item: { receipt: { B: "AQID" } } });
+    const creationTime = (table["Table"] as Record<string, unknown>)[
+      "CreationDateTime"
+    ];
+    assertTypeNumber(creationTime);
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("refuses a request whose service has no serialized routing", async () => {
+    // Given a simulation.
+    const simAws = new SimAws({ defaultRegionName: "eu-west-2" });
+    const dispatcher = new SimSdkWireDispatcher(simAws);
+
+    // When a request carrying no operation header is dispatched, as every
+    // protocol other than the AWS JSON ones sends.
+    const request: SimSdkWireRequest = {
+      ...wireRequest("unused", {}, "eu-west-2", "s3"),
+      headers: Object.fromEntries([
+        [
+          "authorization",
+          "AWS4-HMAC-SHA256 Credential=ASIAEXAMPLE/20260817/eu-west-2/s3/" +
+            "aws4_request, SignedHeaders=host, Signature=abc123",
+        ],
+      ]),
+    };
+    const error = await assertThrowsErrorAsync(
+      async () => await dispatcher.dispatch(request),
+    );
+
+    // Then the refusal names the service and says what to do instead.
+    assertStringIncludes(error.message, "s3");
+    assertStringIncludes(error.message, "AWS JSON protocol");
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("names the endpoint when an unroutable request is not signed", async () => {
+    // Given a simulation.
+    const simAws = new SimAws({ defaultRegionName: "eu-west-2" });
+    const dispatcher = new SimSdkWireDispatcher(simAws);
+
+    // When an unsigned request the bridge cannot route is dispatched.
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await dispatcher.dispatch({
+          method: "GET",
+          hostname: "sts.eu-west-2.amazonaws.com",
+          path: "/",
+          headers: {},
+          body: new Uint8Array(),
+        }),
+    );
+
+    // Then the endpoint stands in for the service the scope would have named.
+    assertStringIncludes(error.message, "sts.eu-west-2.amazonaws.com");
+
+    await simAws.backgroundTasksComplete();
+  });
+});

--- a/src/sdk/wire/sim-sdk-wire-dispatcher.ts
+++ b/src/sdk/wire/sim-sdk-wire-dispatcher.ts
@@ -1,0 +1,99 @@
+import type { AwsRegionName } from "../../service/aws/sim-aws-region.js";
+import type { SimAws } from "../../service/aws/sim-aws.js";
+import { SimSdkCommandDispatcher } from "../sim-sdk-command-dispatcher.js";
+import {
+  makeSimSdkWireClient,
+  makeSimSdkWireCommand,
+} from "./sim-sdk-wire-command.js";
+import { readSimSdkWireInput } from "./sim-sdk-wire-json.js";
+import {
+  readSimSdkWireCredentialScope,
+  readSimSdkWireOperation,
+  type SimSdkWireOperation,
+} from "./sim-sdk-wire-operation.js";
+import {
+  simSdkWireErrorResponse,
+  simSdkWireOutputResponse,
+} from "./sim-sdk-wire-response.js";
+import { simSdkUnbridgedWireRequest } from "./sim-sdk-wire-unbridged.js";
+import type {
+  SimSdkWireRequest,
+  SimSdkWireResponse,
+} from "./sim-sdk-wire.types.js";
+
+/**
+ * Dispatches AWS API requests to simulated AWS service operations.
+ *
+ * This is SDK interception below the module boundary: where the module
+ * interceptor patches a client class before the SDK serializes anything, this
+ * reads a request the SDK has already serialized and signed, and routes it to
+ * the same simulated operation. That is what a deployment package bundling the
+ * SDK leaves available, and it is also closer to how the real thing works, in
+ * that the simulation answers a request rather than replacing a client.
+ *
+ * The Account/Region scope and the caller are resolved per request by the same
+ * dispatcher an intercepted client uses, so an ambient caller such as a sim
+ * Lambda execution role applies here in exactly the same way.
+ */
+export class SimSdkWireDispatcher {
+  private readonly dispatcher: SimSdkCommandDispatcher;
+  private readonly regionName: AwsRegionName;
+
+  /**
+   * The fallback Region answers a request whose credential scope names none,
+   * and is the Region the code making the request is running in.
+   */
+  constructor(simAws: SimAws, fallbackRegionName?: AwsRegionName) {
+    this.dispatcher = new SimSdkCommandDispatcher(simAws);
+    this.regionName = fallbackRegionName ?? simAws.defaultRegionName;
+  }
+
+  /**
+   * Answer one AWS API request from the simulation.
+   *
+   * A request the simulation refuses comes back as the failure response real
+   * AWS would send, because that is an answer: the SDK that sent it will turn
+   * it back into the exception the calling code expects to catch. Only a
+   * request that cannot be routed at all is thrown, since there is no response
+   * that would mean what happened.
+   */
+  async dispatch(request: SimSdkWireRequest): Promise<SimSdkWireResponse> {
+    const operation = readSimSdkWireOperation(request);
+    if (operation === undefined) {
+      throw simSdkUnbridgedWireRequest(request);
+    }
+
+    const contentType = request.headers["content-type"];
+    try {
+      return simSdkWireOutputResponse(
+        await this.route(request, operation),
+        contentType,
+      );
+    } catch (error) {
+      return simSdkWireErrorResponse(error, contentType);
+    }
+  }
+
+  /**
+   * Route a request to the operation it names, in the Region it was signed
+   * for or, unsigned, the Region of the code that sent it.
+   */
+  private async route(
+    request: SimSdkWireRequest,
+    operation: SimSdkWireOperation,
+  ): Promise<unknown> {
+    const scope = readSimSdkWireCredentialScope(request);
+
+    return await this.dispatcher.dispatch(
+      makeSimSdkWireCommand(
+        operation.commandName,
+        readSimSdkWireInput(request.body),
+      ),
+      makeSimSdkWireClient(
+        operation.serviceId,
+        scope?.regionName ?? this.regionName,
+      ),
+      undefined,
+    );
+  }
+}

--- a/src/sdk/wire/sim-sdk-wire-json.ts
+++ b/src/sdk/wire/sim-sdk-wire-json.ts
@@ -1,0 +1,64 @@
+import { isRecord } from "../../util/type-guard/record.js";
+
+/**
+ * Read an AWS JSON protocol request body as the Command input it was
+ * serialized from.
+ *
+ * An operation taking no input sends an empty body, which is the input `{}`.
+ *
+ * The wire shapes of the JSON protocols are the Command input shapes, member
+ * for member, which is what makes this readable without the operation's
+ * schema. The two exceptions are the shapes the JSON encoding cannot carry:
+ * blobs travel base64-encoded and timestamps as epoch seconds, and only the
+ * schema says which members those are. A value written and read back through
+ * this bridge round-trips regardless, because both directions leave it
+ * untouched.
+ */
+export function readSimSdkWireInput(body: Uint8Array): unknown {
+  if (body.byteLength === 0) {
+    return {};
+  }
+
+  return JSON.parse(Buffer.from(body).toString()) as unknown;
+}
+
+/**
+ * Serialize a simulated service operation output as an AWS JSON protocol
+ * response body.
+ *
+ * Blobs and timestamps are encoded as the protocol carries them, because the
+ * SDK that will read this back decodes them by schema: an ISO date string
+ * where it expects epoch seconds fails to parse, rather than arriving as the
+ * wrong value.
+ */
+export function simSdkWireJsonBody(value: unknown): Uint8Array {
+  return Buffer.from(JSON.stringify(wireJsonValue(value) ?? {}));
+}
+
+/**
+ * Encode the values whose JavaScript form differs from their wire form.
+ *
+ * This is done before serializing rather than while serializing, because
+ * JSON.stringify applies toJSON on the way past: a Date would already have
+ * become an ISO string by the time anything got to look at it.
+ */
+function wireJsonValue(value: unknown): unknown {
+  if (value instanceof Date) {
+    return value.getTime() / 1000;
+  }
+  if (value instanceof Uint8Array) {
+    return Buffer.from(value).toString("base64");
+  }
+  if (Array.isArray(value)) {
+    return value.map((member) => wireJsonValue(member));
+  }
+  if (isRecord(value)) {
+    return Object.fromEntries(
+      Object.entries(value).map(([name, member]) => [
+        name,
+        wireJsonValue(member),
+      ]),
+    );
+  }
+  return value;
+}

--- a/src/sdk/wire/sim-sdk-wire-operation.iso.test.ts
+++ b/src/sdk/wire/sim-sdk-wire-operation.iso.test.ts
@@ -1,0 +1,92 @@
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import {
+  readSimSdkWireCredentialScope,
+  readSimSdkWireOperation,
+} from "./sim-sdk-wire-operation.js";
+import type { SimSdkWireRequest } from "./sim-sdk-wire.types.js";
+
+function requestWithHeaders(
+  headers: Record<string, string>,
+): SimSdkWireRequest {
+  return {
+    method: "POST",
+    hostname: "dynamodb.eu-west-2.amazonaws.com",
+    path: "/",
+    headers,
+    body: new Uint8Array(),
+  };
+}
+
+function requestForTarget(target: string): SimSdkWireRequest {
+  return requestWithHeaders(Object.fromEntries([["x-amz-target", target]]));
+}
+
+describe("simulated AWS SDK wire operation", () => {
+  it("reads the service and Command a JSON protocol request names", () => {
+    // Given a request as an AWS JSON protocol service is sent.
+    // When its operation is read.
+    const operation = readSimSdkWireOperation(
+      requestForTarget("AWSCognitoIdentityProviderService.InitiateAuth"),
+    );
+
+    // Then it names the same service and Command an intercepted client would
+    // have reported for the call.
+    assertNonNullable(operation);
+    assertIdentical(operation.serviceId, "Cognito Identity Provider");
+    assertIdentical(operation.commandName, "InitiateAuthCommand");
+  });
+
+  it("reads nothing from a request that names no operation", () => {
+    // Given requests that name no operation this can route.
+    // Then none of them yields one.
+    assertUndefined(readSimSdkWireOperation(requestWithHeaders({})));
+    assertUndefined(readSimSdkWireOperation(requestForTarget("NoSeparator")));
+    assertUndefined(readSimSdkWireOperation(requestForTarget(".GetItem")));
+    assertUndefined(
+      readSimSdkWireOperation(requestForTarget("DynamoDB_20120810.")),
+    );
+    assertUndefined(
+      readSimSdkWireOperation(requestForTarget("UnsimulatedService.DoThing")),
+    );
+  });
+
+  it("reads the Region and service a request was signed for", () => {
+    // Given a signed request.
+    // When its credential scope is read.
+    const scope = readSimSdkWireCredentialScope(
+      requestWithHeaders(
+        Object.fromEntries([
+          [
+            "authorization",
+            "AWS4-HMAC-SHA256 Credential=ASIAEXAMPLE/20260817/us-east-1/" +
+              "sqs/aws4_request, SignedHeaders=host;x-amz-date, " +
+              "Signature=abc123",
+          ],
+        ]),
+      ),
+    );
+
+    // Then it says which Region and which service the signature covers.
+    assertNonNullable(scope);
+    assertIdentical(scope.regionName, "us-east-1");
+    assertIdentical(scope.signingName, "sqs");
+  });
+
+  it("reads nothing from a request that is not signed", () => {
+    // Given requests carrying no usable credential scope.
+    const bearerHeaders = Object.fromEntries([
+      ["authorization", "Bearer a-token"],
+    ]);
+
+    // Then neither yields one.
+    assertUndefined(readSimSdkWireCredentialScope(requestWithHeaders({})));
+    assertUndefined(
+      readSimSdkWireCredentialScope(requestWithHeaders(bearerHeaders)),
+    );
+  });
+});

--- a/src/sdk/wire/sim-sdk-wire-operation.ts
+++ b/src/sdk/wire/sim-sdk-wire-operation.ts
@@ -1,0 +1,113 @@
+import type { SimSdkWireRequest } from "./sim-sdk-wire.types.js";
+
+/**
+ * The AWS JSON protocol operation header.
+ *
+ * Every AWS JSON protocol request carries `<service target>.<operation>` here,
+ * and no request of any other protocol carries it at all, so its presence is
+ * what says a request can be read back into a Command without a schema.
+ */
+const operationHeaderName = "x-amz-target";
+
+/**
+ * The service target each AWS JSON protocol service stamps on its requests,
+ * mapped to the SDK service id the Command routers are keyed by.
+ *
+ * The keys are the `serviceTarget` values in the SDK client packages, which is
+ * the Smithy service shape name and does not change with the SDK version. The
+ * values are `config.serviceId`, which is what an intercepted client would have
+ * reported for the same call.
+ *
+ * Only JSON protocol services appear here. The other protocols the SDK speaks
+ * (REST-JSON, Query, REST-XML) put the operation and its input in the method,
+ * path, query string and an XML or form-encoded body, which cannot be read
+ * back into a Command input without the operation's schema.
+ */
+const jsonProtocolServiceIds: ReadonlyMap<string, string> = new Map([
+  ["AWSCognitoIdentityProviderService", "Cognito Identity Provider"],
+  ["AWSEvents", "EventBridge"],
+  ["AmazonEC2ContainerServiceV20141113", "ECS"],
+  ["AmazonSQS", "SQS"],
+  ["AmazonSSM", "SSM"],
+  ["CertificateManager", "ACM"],
+  ["DynamoDBStreams_20120810", "DynamoDB Streams"],
+  ["DynamoDB_20120810", "DynamoDB"],
+  ["Logs_20140328", "CloudWatch Logs"],
+  ["RekognitionService", "Rekognition"],
+  ["TrentService", "KMS"],
+  ["secretsmanager", "Secrets Manager"],
+]);
+
+/**
+ * Which simulated service operation a wire request is asking for.
+ */
+export interface SimSdkWireOperation {
+  /** The SDK `config.serviceId` of the service the request is addressed to. */
+  readonly serviceId: string;
+  /** The SDK Command class name the request would have been sent as. */
+  readonly commandName: string;
+}
+
+/**
+ * Read the operation an AWS JSON protocol request is asking for.
+ *
+ * Returns undefined for a request of any other protocol, and for a JSON
+ * protocol request addressed to a service with no simulated equivalent, since
+ * neither can be answered from the simulation.
+ */
+export function readSimSdkWireOperation(
+  request: SimSdkWireRequest,
+): SimSdkWireOperation | undefined {
+  // oxlint-disable-next-line security/detect-object-injection -- this module's own fixed header name.
+  const target = request.headers[operationHeaderName];
+  if (target === undefined) {
+    return undefined;
+  }
+
+  const separator = target.lastIndexOf(".");
+  if (separator <= 0) {
+    return undefined;
+  }
+
+  const serviceId = jsonProtocolServiceIds.get(target.slice(0, separator));
+  const operationName = target.slice(separator + 1);
+  if (serviceId === undefined || operationName.length === 0) {
+    return undefined;
+  }
+
+  return { serviceId, commandName: `${operationName}Command` };
+}
+
+/**
+ * The credential scope of a SigV4-signed request: the Region and the signing
+ * service name the request was signed for.
+ */
+export interface SimSdkWireCredentialScope {
+  readonly regionName: string;
+  readonly signingName: string;
+}
+
+/**
+ * Read the credential scope out of a signed request's Authorization header.
+ *
+ * The scope is `<date>/<region>/<signing name>/aws4_request`, which is where
+ * the request itself says which Region and which service it was signed for.
+ * That is more reliable than the endpoint hostname, which a client can be
+ * pointed anywhere, and it is present whatever protocol the service speaks, so
+ * an unsupported request can still say which service it was for.
+ */
+export function readSimSdkWireCredentialScope(
+  request: SimSdkWireRequest,
+): SimSdkWireCredentialScope | undefined {
+  const authorization = request.headers["authorization"];
+  const credential = /Credential=[^/]*\/(?<scope>[^,\s]+)/.exec(
+    authorization ?? "",
+  )?.groups?.["scope"];
+
+  const [, regionName, signingName] = credential?.split("/") ?? [];
+  if (regionName === undefined || signingName === undefined) {
+    return undefined;
+  }
+
+  return { regionName, signingName };
+}

--- a/src/sdk/wire/sim-sdk-wire-response.iso.test.ts
+++ b/src/sdk/wire/sim-sdk-wire-response.iso.test.ts
@@ -31,13 +31,14 @@ describe("simulated AWS SDK wire response", () => {
   });
 
   it("answers a failure that is not an Error as an internal one", () => {
-    // Given something thrown that is not an Error at all.
+    // Given something thrown that is not an Error at all, which means the
+    // simulator went wrong rather than the request.
     // When its response is built.
     const response = simSdkWireErrorResponse("something went wrong");
 
-    // Then it is reported as a fault with what was thrown, rather than
-    // leaving the SDK with nothing to report.
-    assertIdentical(response.statusCode, 400);
+    // Then it is reported as the server fault it is, with what was thrown,
+    // rather than leaving the SDK with nothing to report.
+    assertIdentical(response.statusCode, 500);
     assertIdentical(response.headers["x-amzn-errortype"], "InternalFailure");
     assertObjectMatches(responseBody(response), {
       __type: "InternalFailure",

--- a/src/sdk/wire/sim-sdk-wire-response.iso.test.ts
+++ b/src/sdk/wire/sim-sdk-wire-response.iso.test.ts
@@ -1,0 +1,47 @@
+import { assertIdentical, assertObjectMatches } from "@kensio/smartass";
+import { describe, it } from "vitest";
+import {
+  simSdkWireErrorResponse,
+  simSdkWireOutputResponse,
+} from "./sim-sdk-wire-response.js";
+import type { SimSdkWireResponse } from "./sim-sdk-wire.types.js";
+
+function responseBody(response: SimSdkWireResponse): Record<string, unknown> {
+  return JSON.parse(Buffer.from(response.body).toString()) as Record<
+    string,
+    unknown
+  >;
+}
+
+describe("simulated AWS SDK wire response", () => {
+  it("answers an operation that returned nothing with an empty document", () => {
+    // Given an operation whose simulated implementation returns nothing, as
+    // one with no output members may.
+    // When its response is built.
+    const response = simSdkWireOutputResponse(undefined);
+
+    // Then the SDK reads an empty document rather than an empty body, which
+    // is what the protocol carries for an output with no members.
+    assertIdentical(response.statusCode, 200);
+    assertIdentical(Buffer.from(response.body).toString(), "{}");
+    assertIdentical(
+      response.headers["content-type"],
+      "application/x-amz-json-1.0",
+    );
+  });
+
+  it("answers a failure that is not an Error as an internal one", () => {
+    // Given something thrown that is not an Error at all.
+    // When its response is built.
+    const response = simSdkWireErrorResponse("something went wrong");
+
+    // Then it is reported as a fault with what was thrown, rather than
+    // leaving the SDK with nothing to report.
+    assertIdentical(response.statusCode, 400);
+    assertIdentical(response.headers["x-amzn-errortype"], "InternalFailure");
+    assertObjectMatches(responseBody(response), {
+      __type: "InternalFailure",
+      message: "something went wrong",
+    });
+  });
+});

--- a/src/sdk/wire/sim-sdk-wire-response.ts
+++ b/src/sdk/wire/sim-sdk-wire-response.ts
@@ -58,15 +58,19 @@ export function simSdkWireErrorResponse(
  * The status a simulated service error is answered with.
  *
  * Simulated services state the status real AWS uses in their error metadata.
- * A bridge error that states none is a client error rather than a fault: the
- * request was understood and refused, so retrying it would only fail again.
+ * An error that states none is a client error rather than a fault: the request
+ * was understood and refused, so retrying it would only fail again.
+ *
+ * Something thrown that is not an Error at all is the exception. It is
+ * reported as InternalFailure, which real AWS answers with a server status,
+ * and it means the simulator itself went wrong rather than the request.
  */
 function errorStatusCode(error: unknown): number {
-  if (!isRecord(error)) {
-    return 400;
+  if (!(error instanceof Error)) {
+    return 500;
   }
 
-  const metadata = error["$metadata"];
+  const metadata = (error as { $metadata?: unknown }).$metadata;
   const statusCode = isRecord(metadata)
     ? metadata["httpStatusCode"]
     : undefined;

--- a/src/sdk/wire/sim-sdk-wire-response.ts
+++ b/src/sdk/wire/sim-sdk-wire-response.ts
@@ -1,0 +1,79 @@
+import { isRecord } from "../../util/type-guard/record.js";
+import { simSdkWireJsonBody } from "./sim-sdk-wire-json.js";
+import type { SimSdkWireResponse } from "./sim-sdk-wire.types.js";
+
+/**
+ * The JSON protocol version a request was sent with, echoed back on the
+ * response as real AWS echoes it.
+ */
+const defaultContentType = "application/x-amz-json-1.0";
+
+/**
+ * Build the response for an operation the simulated service answered.
+ */
+export function simSdkWireOutputResponse(
+  output: unknown,
+  contentType: string = defaultContentType,
+): SimSdkWireResponse {
+  return {
+    statusCode: 200,
+    headers: responseHeaders(contentType),
+    body: simSdkWireJsonBody(output),
+  };
+}
+
+/**
+ * Build the response for an operation the simulated service refused.
+ *
+ * AWS JSON protocol errors are a failure status with the exception name in
+ * `__type` and in the error type header, which is what the SDK reads to decide
+ * which exception class to throw. Simulated service errors already carry the
+ * AWS exception name and the status real AWS answers with, so a handler
+ * catching `ResourceNotFoundException` catches the same thing here as in
+ * production.
+ */
+export function simSdkWireErrorResponse(
+  error: unknown,
+  contentType: string = defaultContentType,
+): SimSdkWireResponse {
+  const errorType = error instanceof Error ? error.name : "InternalFailure";
+  const message = error instanceof Error ? error.message : String(error);
+
+  return {
+    statusCode: errorStatusCode(error),
+    headers: {
+      ...responseHeaders(contentType),
+      ...Object.fromEntries([["x-amzn-errortype", errorType]]),
+    },
+    body: simSdkWireJsonBody(
+      Object.fromEntries([
+        ["__type", errorType],
+        ["message", message],
+      ]),
+    ),
+  };
+}
+
+/**
+ * The status a simulated service error is answered with.
+ *
+ * Simulated services state the status real AWS uses in their error metadata.
+ * A bridge error that states none is a client error rather than a fault: the
+ * request was understood and refused, so retrying it would only fail again.
+ */
+function errorStatusCode(error: unknown): number {
+  if (!isRecord(error)) {
+    return 400;
+  }
+
+  const metadata = error["$metadata"];
+  const statusCode = isRecord(metadata)
+    ? metadata["httpStatusCode"]
+    : undefined;
+
+  return typeof statusCode === "number" ? statusCode : 400;
+}
+
+function responseHeaders(contentType: string): Record<string, string> {
+  return Object.fromEntries([["content-type", contentType]]);
+}

--- a/src/sdk/wire/sim-sdk-wire-unbridged.ts
+++ b/src/sdk/wire/sim-sdk-wire-unbridged.ts
@@ -1,0 +1,32 @@
+import { SimSdkUnbridgedWireRequestError } from "../error/sim-sdk.error.js";
+import { readSimSdkWireCredentialScope } from "./sim-sdk-wire-operation.js";
+import type { SimSdkWireRequest } from "./sim-sdk-wire.types.js";
+
+/**
+ * Explain a serialized AWS API request the simulation cannot route.
+ *
+ * The message names the service, because the reason is always the service:
+ * either it speaks a protocol whose requests cannot be read back into a
+ * Command without the operation's schema, or the simulator has no simulated
+ * version of it. A signed request says which service it is for in its
+ * credential scope; an unsigned one is left to say so with its endpoint.
+ *
+ * Saying it plainly is the whole point of raising this. The alternative is an
+ * SDK reporting that it could not find credentials, or waiting on an endpoint
+ * that nothing answers, neither of which is about what actually went wrong.
+ */
+export function simSdkUnbridgedWireRequest(
+  request: SimSdkWireRequest,
+): SimSdkUnbridgedWireRequestError {
+  const service =
+    readSimSdkWireCredentialScope(request)?.signingName ?? request.hostname;
+
+  return new SimSdkUnbridgedWireRequestError(
+    `Cannot answer a request to ${service} from the simulation: a ` +
+      "serialized AWS API request can only be routed for a service using " +
+      "the AWS JSON protocol. Where this is an AWS SDK bundled into " +
+      "function code, leaving the SDK out of the deployment package puts it " +
+      "back on the module interception path, which every simulated service " +
+      "is reachable through.",
+  );
+}

--- a/src/sdk/wire/sim-sdk-wire.types.ts
+++ b/src/sdk/wire/sim-sdk-wire.types.ts
@@ -1,0 +1,35 @@
+/**
+ * One AWS API request as it appears on the wire, after the SDK has serialized
+ * and signed it.
+ *
+ * This is what is left of an SDK Command once a deployment package bundles the
+ * SDK: the Command object never crosses a module boundary the simulator can
+ * intercept, so the request itself is the only thing there is to work with.
+ */
+export interface SimSdkWireRequest {
+  readonly method: string;
+  readonly hostname: string;
+  readonly path: string;
+  /**
+   * Request headers, with lower-cased names, as HTTP header names are
+   * case-insensitive and the SDK is not consistent about which case it sends.
+   */
+  readonly headers: Readonly<Record<string, string>>;
+  readonly body: Uint8Array;
+}
+
+/**
+ * One AWS API response as the SDK expects to read it off the wire.
+ */
+export interface SimSdkWireResponse {
+  readonly statusCode: number;
+  readonly headers: Readonly<Record<string, string>>;
+  readonly body: Uint8Array;
+}
+
+/**
+ * Answer an AWS API request from a simulated AWS environment.
+ */
+export type SimSdkWireHandler = (
+  request: SimSdkWireRequest,
+) => Promise<SimSdkWireResponse>;

--- a/src/service/lambda/function/code/vm/http/sim-lambda-vm-http-module.iso.test.ts
+++ b/src/service/lambda/function/code/vm/http/sim-lambda-vm-http-module.iso.test.ts
@@ -1,0 +1,213 @@
+import type { IncomingMessage } from "node:http";
+import type { Readable, Writable } from "node:stream";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import type {
+  SimSdkWireRequest,
+  SimSdkWireResponse,
+} from "../../../../../../sdk/wire/sim-sdk-wire.types.js";
+import { makeSimLambdaVmHttpModule } from "./sim-lambda-vm-http-module.js";
+
+/**
+ * A host module stub, so what the wrapper passes through is observable without
+ * anything reaching the network.
+ */
+function hostModuleStub(calls: unknown[][]): Record<string, unknown> {
+  const record =
+    (name: string) =>
+    (...callArguments: unknown[]): string => {
+      calls.push([name, ...callArguments]);
+      return name;
+    };
+
+  return {
+    request: record("request"),
+    get: record("get"),
+    STATUS_CODES: { 200: "OK" },
+  };
+}
+
+function respondWith(
+  requests: SimSdkWireRequest[],
+  body = '{"answered":true}',
+): (request: SimSdkWireRequest) => Promise<SimSdkWireResponse> {
+  return (request): Promise<SimSdkWireResponse> => {
+    requests.push(request);
+
+    return Promise.resolve({
+      statusCode: 200,
+      headers: Object.fromEntries([["content-type", "application/json"]]),
+      body: Buffer.from(body),
+    });
+  };
+}
+
+async function readResponse(message: IncomingMessage): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of message as unknown as Readable) {
+    chunks.push(Buffer.from(chunk as Uint8Array));
+  }
+
+  return Buffer.concat(chunks).toString();
+}
+
+describe("sim Lambda vm HTTP module", () => {
+  it("keeps everything the host module exports", () => {
+    // Given a wrapped host module.
+    const module = makeSimLambdaVmHttpModule(
+      hostModuleStub([]),
+      respondWith([]),
+    );
+
+    // Then what a client library reaches for besides the request functions is
+    // the host module's own.
+    assertIdentical(
+      (module["STATUS_CODES"] as Record<string, string>)["200"],
+      "OK",
+    );
+  });
+
+  it("answers a request to an AWS endpoint from the simulation", async () => {
+    // Given a wrapped module over a simulation that answers.
+    const dispatched: SimSdkWireRequest[] = [];
+    const calls: unknown[][] = [];
+    const module = makeSimLambdaVmHttpModule(
+      hostModuleStub(calls),
+      respondWith(dispatched),
+    );
+    const request = module["request"] as (...a: unknown[]) => Writable;
+
+    // When a request to an AWS endpoint is made and its body written.
+    const response = await new Promise<IncomingMessage>((resolve) => {
+      const outgoing = request(
+        {
+          host: "dynamodb.eu-west-2.amazonaws.com",
+          method: "POST",
+          path: "/",
+          headers: Object.fromEntries([
+            ["x-amz-target", "DynamoDB_20120810.GetItem"],
+          ]),
+        },
+        resolve,
+      );
+      outgoing.end('{"TableName":"orders"}');
+    });
+
+    // Then the simulation received the request as it was written.
+    assertArrayLength(dispatched, 1);
+    const [dispatchedRequest] = dispatched;
+    assertNonNullable(dispatchedRequest);
+    assertIdentical(
+      Buffer.from(dispatchedRequest.body).toString(),
+      '{"TableName":"orders"}',
+    );
+
+    // And the answer reads back as an HTTP response.
+    assertIdentical(response.statusCode, 200);
+    assertIdentical(response.headers["content-type"], "application/json");
+    assertIdentical(await readResponse(response), '{"answered":true}');
+
+    // And nothing reached the host module.
+    assertArrayLength(calls, 0);
+  });
+
+  it("fails the request when the simulation cannot route it", async () => {
+    // Given a wrapped module over a simulation that refuses.
+    const module = makeSimLambdaVmHttpModule(hostModuleStub([]), async () => {
+      await Promise.resolve();
+      throw new Error("Cannot route this");
+    });
+    const request = module["request"] as (...a: unknown[]) => Writable;
+
+    // When a request to an AWS endpoint is made.
+    const error = await new Promise<Error>((resolve) => {
+      const outgoing = request({ host: "sqs.eu-west-2.amazonaws.com" });
+      outgoing.on("error", resolve);
+      outgoing.end();
+    });
+
+    // Then the refusal arrives as the error event a client listens for.
+    assertStringIncludes(error.message, "Cannot route this");
+  });
+
+  it("accepts the socket controls a client sets on a request", () => {
+    // Given a request the simulation will answer.
+    const module = makeSimLambdaVmHttpModule(
+      hostModuleStub([]),
+      respondWith([]),
+    );
+    const outgoing = (module["request"] as (...a: unknown[]) => Writable)({
+      host: "kms.eu-west-2.amazonaws.com",
+    }) as Writable & {
+      setTimeout: () => unknown;
+      setNoDelay: () => unknown;
+      setSocketKeepAlive: () => unknown;
+    };
+
+    // Then the socket settings an HTTP client library reaches for are there
+    // and chainable, with no socket for them to act on.
+    assertIdentical(outgoing.setTimeout(), outgoing);
+    assertIdentical(outgoing.setNoDelay(), outgoing);
+    assertIdentical(outgoing.setSocketKeepAlive(), outgoing);
+    outgoing.destroy();
+  });
+
+  it("leaves requests to anywhere else to the host module", () => {
+    // Given a wrapped module.
+    const calls: unknown[][] = [];
+    const module = makeSimLambdaVmHttpModule(
+      hostModuleStub(calls),
+      respondWith([]),
+    );
+
+    // When requests to a non-AWS host are made both ways.
+    const requested = (module["request"] as (...a: unknown[]) => unknown)({
+      host: "api.example.com",
+    });
+    const fetched = (module["get"] as (...a: unknown[]) => unknown)(
+      "https://api.example.com/status",
+    );
+
+    // Then the host module made them, with the arguments it was given.
+    assertIdentical(requested, "request");
+    assertIdentical(fetched, "get");
+    assertArrayLength(calls, 2);
+    assertStringIncludes(JSON.stringify(calls[1]), "api.example.com/status");
+  });
+
+  it("ends the body of a simulated get, as the host module does", async () => {
+    // Given a wrapped module over a simulation that answers.
+    const dispatched: SimSdkWireRequest[] = [];
+    const module = makeSimLambdaVmHttpModule(
+      hostModuleStub([]),
+      respondWith(dispatched),
+    );
+
+    // When a get to an AWS endpoint is made with nothing written to it.
+    await new Promise<IncomingMessage>((resolve) => {
+      (module["get"] as (...a: unknown[]) => unknown)(
+        "https://logs.eu-west-2.amazonaws.com/",
+        Object.fromEntries([
+          [
+            "headers",
+            Object.fromEntries([
+              ["x-amz-target", "Logs_20140328.PutLogEvents"],
+            ]),
+          ],
+        ]),
+        resolve,
+      );
+    });
+
+    // Then it was answered without the caller ending it.
+    assertArrayLength(dispatched, 1);
+    const [dispatchedRequest] = dispatched;
+    assertNonNullable(dispatchedRequest);
+    assertIdentical(dispatchedRequest.method, "GET");
+  });
+});

--- a/src/service/lambda/function/code/vm/http/sim-lambda-vm-http-module.ts
+++ b/src/service/lambda/function/code/vm/http/sim-lambda-vm-http-module.ts
@@ -1,0 +1,105 @@
+import type { SimSdkWireHandler } from "../../../../../../sdk/wire/sim-sdk-wire.types.js";
+import {
+  isSimAwsEndpointHostname,
+  readSimLambdaVmHttpTarget,
+} from "./sim-lambda-vm-http-target.js";
+import { SimLambdaVmWireRequest } from "./sim-lambda-vm-wire-request.js";
+
+/**
+ * A `node:http` or `node:https` module, as far as this needs to know.
+ */
+type NodeHttpModule = Record<string, unknown>;
+
+/**
+ * The transport modules an SDK bundled into the function code archive reaches
+ * the network through, named as both a bundler and a hand-written require may
+ * ask for them.
+ */
+const httpModuleSpecifiers: ReadonlySet<string> = new Set([
+  "http",
+  "https",
+  "node:http",
+  "node:https",
+]);
+
+/**
+ * Whether a module specifier names an HTTP transport module.
+ */
+export function isSimLambdaVmHttpModuleSpecifier(specifier: string): boolean {
+  return httpModuleSpecifiers.has(specifier);
+}
+
+type RequestFunction = (...callArguments: unknown[]) => unknown;
+
+/**
+ * Build the `node:http` or `node:https` module sim Lambda function code is
+ * given.
+ *
+ * Everything the real module exports is kept, and only the two functions that
+ * start a request are replaced, so a client library that reaches for an Agent,
+ * a status code table or anything else finds the real thing. A request to an
+ * AWS API endpoint is answered by the simulation; every other request is the
+ * host module's, made exactly as it was asked for.
+ *
+ * This is where a deployment package that bundles the AWS SDK is reached. The
+ * bundled SDK resolves no module specifier the simulator can intercept, but it
+ * still asks the runtime for its HTTP transport, and that is a module the
+ * runtime provides.
+ */
+export function makeSimLambdaVmHttpModule(
+  hostModule: NodeHttpModule,
+  handler: SimSdkWireHandler,
+): NodeHttpModule {
+  const hostRequest = hostModule["request"] as RequestFunction;
+  const hostGet = hostModule["get"] as RequestFunction;
+
+  const request = (...callArguments: unknown[]): unknown => {
+    const simulated = simulatedRequest(callArguments, handler);
+
+    return simulated ?? hostRequest(...callArguments);
+  };
+
+  return {
+    ...hostModule,
+    request,
+    /**
+     * `get` is `request` with the body ended immediately, which is the whole
+     * of the difference for a request the simulation answers.
+     */
+    get: (...callArguments: unknown[]): unknown => {
+      const simulated = simulatedRequest(callArguments, handler);
+      if (simulated === undefined) {
+        return hostGet(...callArguments);
+      }
+
+      simulated.end();
+      return simulated;
+    },
+  };
+}
+
+/**
+ * Start a simulated request, for a call addressed to an AWS API endpoint.
+ *
+ * The response callback a caller passed is attached to the `response` event,
+ * as the real module attaches it, so a caller using either receives the
+ * response.
+ */
+function simulatedRequest(
+  callArguments: readonly unknown[],
+  handler: SimSdkWireHandler,
+): SimLambdaVmWireRequest | undefined {
+  const target = readSimLambdaVmHttpTarget(callArguments);
+  if (target === undefined || !isSimAwsEndpointHostname(target.hostname)) {
+    return undefined;
+  }
+
+  const request = new SimLambdaVmWireRequest(target, handler);
+
+  const callback = callArguments.at(-1);
+  if (typeof callback === "function") {
+    request.on("response", callback as (response: unknown) => void);
+  }
+
+  return request;
+}

--- a/src/service/lambda/function/code/vm/http/sim-lambda-vm-http-target.iso.test.ts
+++ b/src/service/lambda/function/code/vm/http/sim-lambda-vm-http-target.iso.test.ts
@@ -25,6 +25,20 @@ describe("sim Lambda vm HTTP request target", () => {
     assertFalse(isSimAwsEndpointHostname("notamazonaws.com"));
   });
 
+  it("leaves the endpoints of one resource to the transport", () => {
+    // Given the endpoints AWS issues for a single resource rather than for a
+    // service API, which carry an HTTP request rather than a Command.
+    // Then a Lambda Function URL is not a service API endpoint.
+    assertFalse(
+      isSimAwsEndpointHostname("abcdefg1234.lambda-url.eu-west-2.on.aws"),
+    );
+
+    // And neither is an API Gateway HTTP API endpoint.
+    assertFalse(
+      isSimAwsEndpointHostname("abc123.execute-api.eu-west-2.amazonaws.com"),
+    );
+  });
+
   it("reads a request made with an options object", () => {
     // Given the options an SDK's HTTP handler passes.
     // When the target is read.

--- a/src/service/lambda/function/code/vm/http/sim-lambda-vm-http-target.iso.test.ts
+++ b/src/service/lambda/function/code/vm/http/sim-lambda-vm-http-target.iso.test.ts
@@ -1,0 +1,106 @@
+import {
+  assertFalse,
+  assertIdentical,
+  assertNonNullable,
+  assertTrue,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import {
+  isSimAwsEndpointHostname,
+  readSimLambdaVmHttpTarget,
+} from "./sim-lambda-vm-http-target.js";
+
+describe("sim Lambda vm HTTP request target", () => {
+  it("recognises the hostnames AWS issues its endpoints under", () => {
+    // Given the endpoint hostnames an SDK resolves for AWS services.
+    // Then each is an AWS endpoint.
+    assertTrue(isSimAwsEndpointHostname("dynamodb.eu-west-2.amazonaws.com"));
+    assertTrue(isSimAwsEndpointHostname("DynamoDB.eu-west-2.amazonaws.com"));
+    assertTrue(isSimAwsEndpointHostname("s3.cn-north-1.amazonaws.com.cn"));
+    assertTrue(isSimAwsEndpointHostname("scheduler.eu-west-2.api.aws"));
+
+    // And a hostname of the application's own is not.
+    assertFalse(isSimAwsEndpointHostname("api.example.com"));
+    assertFalse(isSimAwsEndpointHostname("notamazonaws.com"));
+  });
+
+  it("reads a request made with an options object", () => {
+    // Given the options an SDK's HTTP handler passes.
+    // When the target is read.
+    const target = readSimLambdaVmHttpTarget([
+      {
+        host: "dynamodb.eu-west-2.amazonaws.com",
+        method: "POST",
+        path: "/",
+        headers: { "X-Amz-Target": "DynamoDB_20120810.GetItem" },
+      },
+      (): void => undefined,
+    ]);
+
+    // Then it names where the request is addressed, with header names in one
+    // case whatever case they were given in.
+    assertNonNullable(target);
+    assertIdentical(target.hostname, "dynamodb.eu-west-2.amazonaws.com");
+    assertIdentical(target.method, "POST");
+    assertIdentical(target.path, "/");
+    assertIdentical(
+      target.headers["x-amz-target"],
+      "DynamoDB_20120810.GetItem",
+    );
+  });
+
+  it("reads a request made with a URL and options", () => {
+    // Given a request made the other way `http.request` accepts.
+    // When the target is read.
+    const target = readSimLambdaVmHttpTarget([
+      "https://sqs.eu-west-2.amazonaws.com/queue?limit=1",
+      { method: "PUT", headers: { Accept: ["a", "b"], "x-count": 2 } },
+    ]);
+
+    // Then the URL supplies what the options do not, query string included.
+    assertNonNullable(target);
+    assertIdentical(target.hostname, "sqs.eu-west-2.amazonaws.com");
+    assertIdentical(target.path, "/queue?limit=1");
+    assertIdentical(target.method, "PUT");
+    assertIdentical(target.headers["accept"], "a,b");
+    assertIdentical(target.headers["x-count"], "2");
+  });
+
+  it("drops the port a host option carries", () => {
+    // Given options naming a host with a port, as `host` may.
+    // When the target is read.
+    const target = readSimLambdaVmHttpTarget([
+      { host: "localhost:4566", headers: undefined },
+    ]);
+
+    // Then the hostname is left without it, and the defaults stand in for
+    // what was not said.
+    assertNonNullable(target);
+    assertIdentical(target.hostname, "localhost");
+    assertIdentical(target.method, "GET");
+    assertIdentical(target.path, "/");
+  });
+
+  it("reads a request made with a URL object", () => {
+    // Given a request addressed with a URL instance.
+    // When the target is read.
+    const target = readSimLambdaVmHttpTarget([
+      new URL("https://kms.eu-west-2.amazonaws.com/keys"),
+    ]);
+
+    // Then it is read from the URL alone.
+    assertNonNullable(target);
+    assertIdentical(target.hostname, "kms.eu-west-2.amazonaws.com");
+    assertIdentical(target.path, "/keys");
+  });
+
+  it("reads nothing from arguments naming no host", () => {
+    // Given arguments that name no host at all.
+    // When the target is read.
+    // Then there is nothing to route, and the host module can say so itself.
+    assertUndefined(readSimLambdaVmHttpTarget(["not a url"]));
+    assertUndefined(readSimLambdaVmHttpTarget([{ method: "GET" }]));
+    assertUndefined(readSimLambdaVmHttpTarget([]));
+  });
+});

--- a/src/service/lambda/function/code/vm/http/sim-lambda-vm-http-target.ts
+++ b/src/service/lambda/function/code/vm/http/sim-lambda-vm-http-target.ts
@@ -1,18 +1,31 @@
 import { isRecord } from "../../../../../../util/type-guard/record.js";
 
 /**
- * The hostname suffixes AWS issues its API endpoints under.
+ * The hostname suffixes AWS issues its service API endpoints under.
  *
- * A request to one of these is a request to AWS whoever sent it, so it belongs
- * to the simulation rather than the network. Everything else a function asks
- * for still goes wherever it was addressed.
+ * A request to one of these is a request to an AWS service API whoever sent
+ * it, so it belongs to the simulation rather than the network. Everything else
+ * a function asks for still goes wherever it was addressed.
+ *
+ * `.on.aws` is not among them: what AWS issues under it is Lambda Function
+ * URLs, which are the endpoint of one function rather than a service API.
  */
 const awsEndpointSuffixes: readonly string[] = [
   ".amazonaws.com",
   ".amazonaws.com.cn",
   ".api.aws",
-  ".on.aws",
 ];
+
+/**
+ * The label an endpoint hostname carries when it names one resource rather
+ * than a service API: an API Gateway HTTP API, under `.amazonaws.com`.
+ *
+ * A request to one of these is an ordinary HTTP request to something the
+ * simulation may be running, not a serialized Command, so there is nothing
+ * here to route it as. It goes where it was addressed, as it did before this
+ * ran at all.
+ */
+const resourceEndpointLabel = ".execute-api.";
 
 /**
  * Where an outgoing HTTP request from sim Lambda function code is addressed.
@@ -25,10 +38,14 @@ export interface SimLambdaVmHttpTarget {
 }
 
 /**
- * Whether a hostname is an AWS API endpoint.
+ * Whether a hostname is an AWS service API endpoint.
  */
 export function isSimAwsEndpointHostname(hostname: string): boolean {
   const name = hostname.toLowerCase();
+
+  if (name.includes(resourceEndpointLabel)) {
+    return false;
+  }
 
   return awsEndpointSuffixes.some((suffix) => name.endsWith(suffix));
 }

--- a/src/service/lambda/function/code/vm/http/sim-lambda-vm-http-target.ts
+++ b/src/service/lambda/function/code/vm/http/sim-lambda-vm-http-target.ts
@@ -1,0 +1,128 @@
+import { isRecord } from "../../../../../../util/type-guard/record.js";
+
+/**
+ * The hostname suffixes AWS issues its API endpoints under.
+ *
+ * A request to one of these is a request to AWS whoever sent it, so it belongs
+ * to the simulation rather than the network. Everything else a function asks
+ * for still goes wherever it was addressed.
+ */
+const awsEndpointSuffixes: readonly string[] = [
+  ".amazonaws.com",
+  ".amazonaws.com.cn",
+  ".api.aws",
+  ".on.aws",
+];
+
+/**
+ * Where an outgoing HTTP request from sim Lambda function code is addressed.
+ */
+export interface SimLambdaVmHttpTarget {
+  readonly hostname: string;
+  readonly path: string;
+  readonly method: string;
+  readonly headers: Record<string, string>;
+}
+
+/**
+ * Whether a hostname is an AWS API endpoint.
+ */
+export function isSimAwsEndpointHostname(hostname: string): boolean {
+  const name = hostname.toLowerCase();
+
+  return awsEndpointSuffixes.some((suffix) => name.endsWith(suffix));
+}
+
+/**
+ * Read where a call to `http.request` or `https.request` is addressed.
+ *
+ * Both accept a URL, an options object, or a URL followed by an options
+ * object, so all three are understood here. Arguments that make sense to
+ * neither form read as undefined, which leaves the request to the host module
+ * and its own error message rather than inventing one.
+ */
+export function readSimLambdaVmHttpTarget(
+  callArguments: readonly unknown[],
+): SimLambdaVmHttpTarget | undefined {
+  const [first, second] = callArguments;
+  const url = requestUrl(first);
+  const optionsArgument = url === undefined ? first : second;
+  const options = isRecord(optionsArgument) ? optionsArgument : undefined;
+
+  const hostname = targetHostname(options, url);
+  if (hostname === undefined) {
+    return undefined;
+  }
+
+  return {
+    hostname,
+    path: stringOption(options, "path") ?? urlPath(url),
+    method: stringOption(options, "method") ?? "GET",
+    headers: targetHeaders(options),
+  };
+}
+
+function urlPath(url: URL | undefined): string {
+  return url === undefined ? "/" : `${url.pathname}${url.search}`;
+}
+
+function requestUrl(value: unknown): URL | undefined {
+  if (value instanceof URL) {
+    return value;
+  }
+
+  return typeof value === "string"
+    ? (URL.parse(value) ?? undefined)
+    : undefined;
+}
+
+/**
+ * The hostname a request names, from the URL or from the options.
+ *
+ * `host` carries a port where `hostname` does not, and the two are otherwise
+ * interchangeable, so the port is dropped to leave a name either way.
+ */
+function targetHostname(
+  options: unknown,
+  url: URL | undefined,
+): string | undefined {
+  const hostname =
+    stringOption(options, "hostname") ?? stringOption(options, "host");
+  if (hostname !== undefined) {
+    return hostname.replace(/:\d+$/, "");
+  }
+
+  return url?.hostname;
+}
+
+/**
+ * The request headers, named in lower case.
+ *
+ * HTTP header names are case-insensitive, and what reads them here looks each
+ * one up by name, so the case a caller happened to use is settled once.
+ */
+function targetHeaders(options: unknown): Record<string, string> {
+  const headers = isRecord(options) ? options["headers"] : undefined;
+  if (!isRecord(headers)) {
+    return {};
+  }
+
+  return Object.fromEntries(
+    Object.entries(headers)
+      .filter(([, value]) => value !== undefined && value !== null)
+      .map(([name, value]) => [
+        name.toLowerCase(),
+        Array.isArray(value) ? value.join(",") : String(value),
+      ]),
+  );
+}
+
+function stringOption(options: unknown, name: string): string | undefined {
+  if (!isRecord(options)) {
+    return undefined;
+  }
+
+  // oxlint-disable-next-line security/detect-object-injection -- one of this module's own literal option names.
+  const value = options[name];
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}

--- a/src/service/lambda/function/code/vm/http/sim-lambda-vm-wire-request.ts
+++ b/src/service/lambda/function/code/vm/http/sim-lambda-vm-wire-request.ts
@@ -1,0 +1,109 @@
+import { STATUS_CODES } from "node:http";
+import { Readable, Writable } from "node:stream";
+import type {
+  SimSdkWireHandler,
+  SimSdkWireResponse,
+} from "../../../../../../sdk/wire/sim-sdk-wire.types.js";
+import type { SimLambdaVmHttpTarget } from "./sim-lambda-vm-http-target.js";
+
+/**
+ * What an HTTP client library reads off a response.
+ */
+interface SimLambdaVmWireResponseMessage extends Readable {
+  statusCode: number;
+  statusMessage: string;
+  headers: Record<string, string>;
+}
+
+/**
+ * The outgoing request object `http.request` hands back, for a request the
+ * simulation answers instead of the network.
+ *
+ * It is a writable stream, which is what an HTTP client library expects: it
+ * writes the request body and ends the stream, and the response arrives on the
+ * `response` event. Nothing is connected to anything, so the request is
+ * answered when the body is complete, and the timeout and socket controls a
+ * client may reach for do nothing rather than being absent, since there is no
+ * socket to time out.
+ */
+export class SimLambdaVmWireRequest extends Writable {
+  private readonly chunks: Buffer[] = [];
+
+  constructor(
+    private readonly target: SimLambdaVmHttpTarget,
+    private readonly handler: SimSdkWireHandler,
+  ) {
+    super();
+  }
+
+  override _write(
+    chunk: unknown,
+    _encoding: BufferEncoding,
+    callback: (error?: Error | null) => void,
+  ): void {
+    this.chunks.push(Buffer.from(chunk as Uint8Array));
+    callback();
+  }
+
+  /**
+   * Answer the request once its body is complete.
+   *
+   * A request the simulation cannot route fails the stream, which is the same
+   * `error` event a client would see from a connection that went nowhere, and
+   * carries the explanation with it.
+   */
+  override _final(callback: (error?: Error | null) => void): void {
+    void this.answer(callback);
+  }
+
+  /**
+   * Accept the socket timeout a client sets, with no socket to apply it to.
+   */
+  setTimeout(): this {
+    return this;
+  }
+
+  setNoDelay(): this {
+    return this;
+  }
+
+  setSocketKeepAlive(): this {
+    return this;
+  }
+
+  private async answer(
+    callback: (error?: Error | null) => void,
+  ): Promise<void> {
+    try {
+      const response = await this.handler({
+        method: this.target.method,
+        hostname: this.target.hostname,
+        path: this.target.path,
+        headers: this.target.headers,
+        body: Buffer.concat(this.chunks),
+      });
+
+      this.emit("response", wireResponseMessage(response));
+      callback();
+    } catch (error) {
+      callback(error as Error);
+    }
+  }
+}
+
+/**
+ * Present a simulated response as the incoming message an HTTP client reads.
+ */
+function wireResponseMessage(
+  response: SimSdkWireResponse,
+): SimLambdaVmWireResponseMessage {
+  const message = Readable.from([Buffer.from(response.body)], {
+    objectMode: false,
+  }) as SimLambdaVmWireResponseMessage;
+
+  message.statusCode = response.statusCode;
+  message.statusMessage = STATUS_CODES[response.statusCode] ?? "";
+  message.headers = { ...response.headers };
+
+  return message;
+}

--- a/src/service/lambda/function/code/vm/sdk/sim-lambda-vm-sdk-module-provider.ts
+++ b/src/service/lambda/function/code/vm/sdk/sim-lambda-vm-sdk-module-provider.ts
@@ -11,9 +11,11 @@ export const awsSdkPackagePrefix = "@aws-sdk/";
  *
  * The vm module system asks a provider for bare specifiers the code archive
  * cannot resolve, mirroring how the real Lambda Node.js runtime provides the
- * AWS SDK without it being bundled in the deployment package. A provider
- * returns undefined for specifiers it does not serve, so the original
- * archive resolution error is reported.
+ * AWS SDK without it being bundled in the deployment package, and for the
+ * Node.js built-ins, which the runtime provides whatever the package contains.
+ * A provider returns undefined for specifiers it does not serve, so a built-in
+ * falls through to the host's and a bare specifier is reported with the
+ * original archive resolution error.
  */
 export interface SimLambdaVmSdkModuleProvider {
   provideModule(specifier: string): unknown;

--- a/src/service/lambda/function/code/vm/sdk/sim-sdk-lambda-vm-module-provider.iso.test.ts
+++ b/src/service/lambda/function/code/vm/sdk/sim-sdk-lambda-vm-module-provider.iso.test.ts
@@ -1,3 +1,5 @@
+import http from "node:http";
+import https from "node:https";
 import { GetObjectCommand, S3Client } from "@aws-sdk/client-s3";
 import {
   assertFalse,
@@ -19,6 +21,13 @@ import { SimSdkLambdaVmModuleProvider } from "./sim-sdk-lambda-vm-module-provide
 function makeModuleNotFoundError(specifier: string): Error {
   const error = new Error(`Cannot find module '${specifier}'`);
   return Object.assign(error, { code: "MODULE_NOT_FOUND" });
+}
+
+function providedModule(
+  provider: SimSdkLambdaVmModuleProvider,
+  specifier: string,
+): Record<string, unknown> {
+  return provider.provideModule(specifier) as Record<string, unknown>;
 }
 
 describe("SimSdkLambdaVmModuleProvider", () => {
@@ -63,6 +72,30 @@ describe("SimSdkLambdaVmModuleProvider", () => {
     // When a non-SDK package is requested, then the provider declines so the
     // archive resolution error is reported instead.
     assertUndefined(provider.provideModule("left-pad"));
+
+    // And a built-in it has nothing to do with is left to the host's own.
+    assertUndefined(provider.provideModule("node:fs"));
+  });
+
+  it("provides the HTTP transport modules a bundled SDK reaches for", () => {
+    // Given a provider for a simulated AWS environment.
+    const provider = new SimSdkLambdaVmModuleProvider({ simAws: new SimAws() });
+
+    // When the transport modules are requested, by both the names a bundler
+    // and a hand-written require use.
+    const plainHttp = providedModule(provider, "http");
+    const nodeHttp = providedModule(provider, "node:http");
+    const plainHttps = providedModule(provider, "https");
+    const nodeHttps = providedModule(provider, "node:https");
+
+    // Then each is the module of the same name, with only the function that
+    // starts a request replaced.
+    assertIdentical(plainHttp["Agent"], http.Agent);
+    assertIdentical(nodeHttp["Agent"], http.Agent);
+    assertIdentical(plainHttps["Agent"], https.Agent);
+    assertIdentical(nodeHttps["Agent"], https.Agent);
+    assertFalse(nodeHttp["request"] === http.request);
+    assertFalse(nodeHttps["request"] === https.request);
   });
 
   it("reports an uninstalled AWS SDK package helpfully", () => {

--- a/src/service/lambda/function/code/vm/sdk/sim-sdk-lambda-vm-module-provider.ts
+++ b/src/service/lambda/function/code/vm/sdk/sim-sdk-lambda-vm-module-provider.ts
@@ -2,8 +2,13 @@ import { createRequire } from "node:module";
 import path from "node:path";
 import { SimSdkModuleClientInterceptor } from "../../../../../../sdk/module/sim-sdk-module-client-interceptor.js";
 import { SimSdkCommandDispatcher } from "../../../../../../sdk/sim-sdk-command-dispatcher.js";
+import { SimSdkWireDispatcher } from "../../../../../../sdk/wire/sim-sdk-wire-dispatcher.js";
 import type { AwsRegionName } from "../../../../../aws/sim-aws-region.js";
 import type { SimAws } from "../../../../../aws/sim-aws.js";
+import {
+  isSimLambdaVmHttpModuleSpecifier,
+  makeSimLambdaVmHttpModule,
+} from "../http/sim-lambda-vm-http-module.js";
 import {
   awsSdkPackagePrefix,
   type SimLambdaVmSdkModuleProvider,
@@ -30,9 +35,17 @@ interface SimSdkLambdaVmModuleProviderProperties {
  * Calls made by the function code are routed per send, so the ambient
  * execution-role caller applies and simulated IAM authorizes them, just as
  * the real Lambda runtime's bundled SDK operates as the execution role.
+ *
+ * A deployment package that bundles the SDK asks for no SDK module at all, so
+ * there is nothing there to intercept. Such a package still gets its HTTP
+ * transport from the runtime, and the modules provided for it answer requests
+ * to AWS API endpoints from the same simulation, by the same routing. Which of
+ * the two paths a function takes is then only a question of how it was
+ * packaged, rather than of whether it works.
  */
 export class SimSdkLambdaVmModuleProvider implements SimLambdaVmSdkModuleProvider {
   private readonly interceptor: SimSdkModuleClientInterceptor;
+  private readonly wireDispatcher: SimSdkWireDispatcher;
   private readonly requireModule: (specifier: string) => unknown;
   private readonly providedModules = new Map<string, unknown>();
 
@@ -43,15 +56,20 @@ export class SimSdkLambdaVmModuleProvider implements SimLambdaVmSdkModuleProvide
         dispatcher.dispatch(command, client, undefined),
       defaultRegionName: properties.regionName,
     });
+    this.wireDispatcher = new SimSdkWireDispatcher(
+      properties.simAws,
+      properties.regionName,
+    );
     this.requireModule = properties.requireModule ?? requireHostModule;
   }
 
   /**
-   * Provide an intercepted AWS SDK package module, or undefined for other
-   * specifiers.
+   * Provide an intercepted AWS SDK package or HTTP transport module, or
+   * undefined for other specifiers.
    */
   provideModule(specifier: string): unknown {
-    if (!specifier.startsWith(awsSdkPackagePrefix)) {
+    const isTransport = isSimLambdaVmHttpModuleSpecifier(specifier);
+    if (!isTransport && !specifier.startsWith(awsSdkPackagePrefix)) {
       return undefined;
     }
 
@@ -60,11 +78,15 @@ export class SimSdkLambdaVmModuleProvider implements SimLambdaVmSdkModuleProvide
       return provided;
     }
 
-    const intercepted = this.interceptor.interceptModule(
-      this.hostModuleExports(specifier),
-    );
-    this.providedModules.set(specifier, intercepted);
-    return intercepted;
+    const hostExports = this.hostModuleExports(specifier);
+    const module = isTransport
+      ? makeSimLambdaVmHttpModule(
+          hostExports as Record<string, unknown>,
+          async (request) => await this.wireDispatcher.dispatch(request),
+        )
+      : this.interceptor.interceptModule(hostExports);
+    this.providedModules.set(specifier, module);
+    return module;
   }
 
   private hostModuleExports(specifier: string): object {

--- a/src/service/lambda/function/code/vm/sim-lambda-vm-bundled-sdk.loc.test.ts
+++ b/src/service/lambda/function/code/vm/sim-lambda-vm-bundled-sdk.loc.test.ts
@@ -1,0 +1,197 @@
+import { CreateTableCommand, PutItemCommand } from "@aws-sdk/client-dynamodb";
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import { CreateFunctionCommand, InvokeCommand } from "@aws-sdk/client-lambda";
+import { build } from "esbuild";
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../../aws/sim-aws.js";
+import { simIamPolicyDocumentFactory } from "../../../../iam/policy/sim-iam-policy-document.factory.js";
+import { makeLambdaCodeZip } from "../make-lambda-code-zip.js";
+
+/**
+ * A handler that reads DynamoDB with an SDK client it constructs itself, with
+ * no endpoint or credentials configured, exactly as a deployed one does.
+ */
+const readItemHandlerSource = `
+import { DynamoDBClient, GetItemCommand } from "@aws-sdk/client-dynamodb";
+
+const dynamoDb = new DynamoDBClient({});
+
+export const handler = async (event: { orderId: string }) => {
+  const output = await dynamoDb.send(
+    new GetItemCommand({
+      TableName: "orders",
+      Key: { orderId: { S: event.orderId } },
+    }),
+  );
+
+  return { total: output.Item?.total?.N };
+};
+`;
+
+/**
+ * A handler reading an S3 object, which is the same shape of call to a service
+ * whose requests carry no operation header.
+ */
+const readObjectHandlerSource = `
+import { S3Client, GetObjectCommand } from "@aws-sdk/client-s3";
+
+const s3 = new S3Client({});
+
+export const handler = async () => {
+  await s3.send(new GetObjectCommand({ Bucket: "data", Key: "greeting.txt" }));
+
+  return "unreachable";
+};
+`;
+
+describe("sim Lambda vm code with a bundled AWS SDK", () => {
+  it("reads simulated DynamoDB from a handler that bundles the SDK", async () => {
+    // Given a simulated table holding an order.
+    const simAws = new SimAws();
+    await simAws.dynamoDb().createTable(
+      new CreateTableCommand({
+        TableName: "orders",
+        AttributeDefinitions: [
+          { AttributeName: "orderId", AttributeType: "S" },
+        ],
+        KeySchema: [{ AttributeName: "orderId", KeyType: "HASH" }],
+        BillingMode: "PAY_PER_REQUEST",
+      }),
+    );
+    await simAws.dynamoDb().putItem(
+      new PutItemCommand({
+        TableName: "orders",
+        Item: { orderId: { S: "order-1" }, total: { N: "42" } },
+      }),
+    );
+
+    // And an execution role allowed to read it.
+    const roleArn = await readerRoleArn(simAws);
+
+    // And a function whose deployment package bundles the SDK, as a CDK
+    // NodejsFunction with no external modules produces.
+    const zipFile = makeLambdaCodeZip(await bundle(readItemHandlerSource));
+    await simAws.lambda().createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "reader",
+        Role: roleArn,
+        Handler: "index.handler",
+        Code: { ZipFile: zipFile },
+      }),
+    );
+
+    // When the function is invoked.
+    const output = await simAws.lambda().invoke(
+      new InvokeCommand({
+        FunctionName: "reader",
+        Payload: JSON.stringify({ orderId: "order-1" }),
+      }),
+    );
+
+    // Then the bundled SDK reached the simulated table rather than failing to
+    // find credentials for the real one.
+    assertUndefined(output.FunctionError);
+    assertIdentical(payload(output.Payload), '{"total":"42"}');
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("reports a service whose requests cannot be routed", async () => {
+    // Given a function bundling an SDK client for a service that does not use
+    // the AWS JSON protocol.
+    const simAws = new SimAws();
+    const zipFile = makeLambdaCodeZip(await bundle(readObjectHandlerSource));
+    await simAws.lambda().createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "object-reader",
+        Role: "arn:aws:iam::111111111111:role/ObjectReaderRole",
+        Handler: "index.handler",
+        Code: { ZipFile: zipFile },
+      }),
+    );
+
+    // When the function is invoked.
+    const output = await simAws
+      .lambda()
+      .invoke(new InvokeCommand({ FunctionName: "object-reader" }));
+
+    // Then the failure names the service and what to do about it, rather than
+    // reporting missing credentials or hanging on an endpoint.
+    assertIdentical(output.FunctionError, "Unhandled");
+    const errorMessage = payload(output.Payload);
+    assertStringIncludes(errorMessage, "request to s3");
+    assertStringIncludes(errorMessage, "AWS JSON protocol");
+    assertStringIncludes(errorMessage, "leaving the SDK out");
+
+    await simAws.backgroundTasksComplete();
+  });
+});
+
+/**
+ * Create an execution role allowed to read the table, so what the handler does
+ * is authorized as the role rather than as anything ambient.
+ */
+async function readerRoleArn(simAws: SimAws): Promise<string> {
+  const creation = await simAws.iam().createRole(
+    new CreateRoleCommand({
+      RoleName: "ReaderRole",
+      AssumeRolePolicyDocument: simIamPolicyDocumentFactory.make({
+        Statement: {
+          Principal: { Service: "lambda.amazonaws.com" },
+          Action: "sts:AssumeRole",
+        },
+      }),
+    }),
+  );
+  await simAws.iam().putRolePolicy(
+    new PutRolePolicyCommand({
+      RoleName: "ReaderRole",
+      PolicyName: "ReadOrders",
+      PolicyDocument: simIamPolicyDocumentFactory.make({
+        Statement: {
+          Action: "dynamodb:GetItem",
+          Resource: "arn:aws:dynamodb:*:*:table/orders",
+        },
+      }),
+    }),
+  );
+
+  return creation.Role.Arn;
+}
+
+function payload(payloadBytes: Uint8Array | undefined): string {
+  assertNonNullable(payloadBytes);
+
+  return Buffer.from(payloadBytes).toString();
+}
+
+/**
+ * Bundle a handler into one CommonJS module with its dependencies inlined, as
+ * a deployment package build with no external modules produces.
+ */
+async function bundle(source: string): Promise<string> {
+  const bundled = await build({
+    stdin: {
+      contents: source,
+      loader: "ts",
+      resolveDir: import.meta.dirname,
+      sourcefile: "index.ts",
+    },
+    bundle: true,
+    write: false,
+    platform: "node",
+    target: "node24",
+    format: "cjs",
+  });
+
+  const output = bundled.outputFiles[0];
+  assertNonNullable(output);
+
+  return output.text;
+}

--- a/src/service/lambda/function/code/vm/sim-lambda-vm-module.types.ts
+++ b/src/service/lambda/function/code/vm/sim-lambda-vm-module.types.ts
@@ -1,0 +1,18 @@
+/**
+ * One module in a sim Lambda vm module system, holding what it exported.
+ */
+export interface SimLambdaVmModule {
+  exports: unknown;
+}
+
+/**
+ * The function a compiled CommonJS module is, once its source has been wrapped
+ * in the parameters Node.js gives every module.
+ */
+export type SimLambdaVmCommonJsModule = (
+  exports: unknown,
+  require: (specifier: string) => unknown,
+  module: SimLambdaVmModule,
+  filename: string,
+  dirname: string,
+) => void;

--- a/src/service/lambda/function/code/vm/sim-lambda-vm-modules.ts
+++ b/src/service/lambda/function/code/vm/sim-lambda-vm-modules.ts
@@ -4,6 +4,10 @@ import vm from "node:vm";
 import type { SimZipArchive } from "../../../../../util/zip/zip-archive.js";
 import type { SimLambdaVmSdkModuleProvider } from "./sdk/sim-lambda-vm-sdk-module-provider.js";
 import { loadJsonModule } from "./sim-lambda-vm-json-module.js";
+import type {
+  SimLambdaVmCommonJsModule,
+  SimLambdaVmModule,
+} from "./sim-lambda-vm-module.types.js";
 import { SimLambdaVmModuleResolver } from "./sim-lambda-vm-module-resolver.js";
 import { userCodeSyntaxError } from "./sim-lambda-vm-syntax-error.js";
 
@@ -21,18 +25,6 @@ interface SimLambdaVmModulesProperties {
   readonly sdkModuleProvider: SimLambdaVmSdkModuleProvider;
 }
 
-interface VmModule {
-  exports: unknown;
-}
-
-type CommonJsModuleFunction = (
-  exports: unknown,
-  require: (specifier: string) => unknown,
-  module: VmModule,
-  filename: string,
-  dirname: string,
-) => void;
-
 /**
  * A CommonJS module system over a sim Lambda function code zip archive.
  *
@@ -42,7 +34,7 @@ type CommonJsModuleFunction = (
  * the archive.
  */
 export class SimLambdaVmModules {
-  private readonly modules = new Map<string, VmModule>();
+  private readonly modules = new Map<string, SimLambdaVmModule>();
   private readonly resolver: SimLambdaVmModuleResolver;
 
   constructor(private readonly properties: SimLambdaVmModulesProperties) {
@@ -53,8 +45,14 @@ export class SimLambdaVmModules {
    * Require a module by specifier, as CommonJS code in the archive would.
    */
   requireModule(specifier: string, fromDirectory = "."): unknown {
+    // A built-in is the only thing a deployment package that bundles its
+    // dependencies still asks the runtime for, so the provider is offered
+    // those too. Anything it declines is the host built-in itself.
     if (isBuiltin(specifier)) {
-      return hostRequire(specifier);
+      return (
+        this.properties.sdkModuleProvider.provideModule(specifier) ??
+        hostRequire(specifier)
+      );
     }
 
     let filePath: string;
@@ -87,16 +85,16 @@ export class SimLambdaVmModules {
     return provided;
   }
 
-  private loadModule(filePath: string): VmModule {
+  private loadModule(filePath: string): SimLambdaVmModule {
     if (filePath.endsWith(".json")) {
-      const jsonModule: VmModule = {
+      const jsonModule: SimLambdaVmModule = {
         exports: loadJsonModule(this.properties.archive, filePath),
       };
       this.modules.set(filePath, jsonModule);
       return jsonModule;
     }
 
-    const module: VmModule = { exports: {} };
+    const module: SimLambdaVmModule = { exports: {} };
     // Register before evaluation so require cycles observe partial exports,
     // as in Node.js.
     this.modules.set(filePath, module);
@@ -119,7 +117,7 @@ export class SimLambdaVmModules {
     return module;
   }
 
-  private compileModule(filePath: string): CommonJsModuleFunction {
+  private compileModule(filePath: string): SimLambdaVmCommonJsModule {
     const source = this.properties.archive.file(filePath).toString();
     const wrapped = `(function (exports, require, module, __filename, __dirname) {\n${
       source
@@ -135,6 +133,6 @@ export class SimLambdaVmModules {
     return script.runInContext(this.properties.context, {
       timeout: moduleEvaluationTimeoutMs,
       breakOnSigint: true,
-    }) as CommonJsModuleFunction;
+    }) as SimLambdaVmCommonJsModule;
   }
 }

--- a/src/service/lambda/function/environment/sim-lambda-environment.iso.test.ts
+++ b/src/service/lambda/function/environment/sim-lambda-environment.iso.test.ts
@@ -20,13 +20,17 @@ describe("sim Lambda environment", () => {
     // When its variables are read.
     const variables = environment.variables();
 
-    // Then only the AWS-provided runtime variables are there.
+    // Then only the AWS-provided runtime variables are there, including the
+    // execution role credentials an SDK in the function code looks for.
     assertObjectEquals(variables, {
       AWS_REGION: "eu-west-2",
       AWS_DEFAULT_REGION: "eu-west-2",
       AWS_LAMBDA_FUNCTION_NAME: "greeter",
       AWS_LAMBDA_FUNCTION_MEMORY_SIZE: "256",
       AWS_LAMBDA_FUNCTION_VERSION: "$LATEST",
+      AWS_ACCESS_KEY_ID: "ASIAYULINSIMULATED00",
+      AWS_SECRET_ACCESS_KEY: "yulinSimulatedSecretAccessKeyValue000000",
+      AWS_SESSION_TOKEN: "yulin-simulated-session-token",
     });
     assertFalse(environment.hasDeclaredVariables);
   });

--- a/src/service/lambda/function/environment/sim-lambda-environment.ts
+++ b/src/service/lambda/function/environment/sim-lambda-environment.ts
@@ -1,4 +1,5 @@
 import { simProcessEnvironment } from "../../../../util/process/sim-process-environment.js";
+import { simLambdaExecutionCredentials } from "./sim-lambda-execution-credentials.js";
 
 /**
  * The function details the AWS-provided runtime environment variables are
@@ -122,6 +123,7 @@ export class SimLambdaEnvironment {
       ["AWS_LAMBDA_FUNCTION_NAME", functionName],
       ["AWS_LAMBDA_FUNCTION_MEMORY_SIZE", String(memorySizeMb)],
       ["AWS_LAMBDA_FUNCTION_VERSION", "$LATEST"],
+      ...simLambdaExecutionCredentials,
     ]);
   }
 }

--- a/src/service/lambda/function/environment/sim-lambda-execution-credentials.ts
+++ b/src/service/lambda/function/environment/sim-lambda-execution-credentials.ts
@@ -1,0 +1,22 @@
+/**
+ * The execution role credentials the Lambda runtime puts in the environment.
+ *
+ * Real Lambda sets these to the temporary credentials of the function's
+ * execution Role, and an AWS SDK in the function code finds them there before
+ * it looks anywhere else. Function code that bundles the SDK needs them for
+ * the same reason: without them the first call fails while resolving
+ * credentials, long before anything the simulation could answer.
+ *
+ * The values are placeholders, and deliberately say so. Nothing in the
+ * simulation authorizes against them: a call from function code is attributed
+ * to the execution Role because the invocation is running as it, which is what
+ * the credentials would have identified anyway.
+ */
+export const simLambdaExecutionCredentials: readonly (readonly [
+  string,
+  string,
+])[] = [
+  ["AWS_ACCESS_KEY_ID", "ASIAYULINSIMULATED00"],
+  ["AWS_SECRET_ACCESS_KEY", "yulinSimulatedSecretAccessKeyValue000000"],
+  ["AWS_SESSION_TOKEN", "yulin-simulated-session-token"],
+];


### PR DESCRIPTION
A deployment package that inlines the AWS SDK leaves no module specifier for the runtime to intercept, so a handler reading DynamoDB or calling Cognito failed while resolving credentials rather than reaching the simulation around it. The sim Lambda vm runtime now provides the HTTP transport such a package still asks it for, and a request addressed to an AWS API endpoint is read back into the Command it was serialized from and routed to the same simulated service, as the same execution role, so whether a function bundles the SDK is a packaging question rather than a question of whether it works. The execution role credentials the real runtime puts in the environment are there too, so the SDK's credential chain resolves without looking outside the sandbox. Only the services using the AWS JSON protocol can be read back from a serialized request without the operation's schema; a call to any other says so, naming the service, instead of failing over credentials or waiting on an endpoint.

Resolves #638

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Bundled AWS SDK clients in Lambda packages can now communicate with supported simulated AWS services.
  * Added simulated HTTP/HTTPS transport for AWS requests, including request routing, response handling, and AWS-compatible errors.
  * Lambda environments now provide placeholder execution credentials while authorization continues to use the execution role.
  * Added support for AWS JSON request and response encoding, including dates and binary values.
  * Unsupported services and unroutable requests now fail with explicit errors.

* **Documentation**
  * Documented bundled SDK support, credential behavior, supported protocols, and service limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->