### PR TITLE
feat: sign users in by email or phone number

### DIFF
--- a/docs/services/cognito/README.md
+++ b/docs/services/cognito/README.md
@@ -158,6 +158,115 @@ Attributes come back under `Attributes` from `AdminCreateUser` and `ListUsers`, 
 `AdminDisableUser` sets `Enabled` to `false` without changing the user's status, and
 `AdminEnableUser` sets it back.
 
+## Signing in by email or phone number
+
+A pool created with `UsernameAttributes` signs its users in by that attribute rather than by a
+username they chose. Cognito generates a UUID as the username for such a user, and the value the
+request called the username goes into the attribute the pool signs in by. That generated username
+is what `AdminGetUser` reports and what the `cognito:username` claim carries, so an application
+reading "the username" off such a pool reads a UUID.
+
+A CDK `UserPool` with `signInAliases: { email: true }` emits `UsernameAttributes: ["email"]`, which
+is the usual way to build an email sign-in pool.
+
+```typescript sim-cognito-sign-in-by-email
+/**
+ * A simulated pool that signs its users in by email address.
+ */
+
+import {
+  AdminConfirmSignUpCommand,
+  AdminGetUserCommand,
+  CreateUserPoolClientCommand,
+  CreateUserPoolCommand,
+  InitiateAuthCommand,
+  SignUpCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const cognito = simAws.cognitoIdentityProvider();
+
+const pool = await cognito.createUserPool(
+  new CreateUserPoolCommand({
+    PoolName: "myapp-users",
+    UsernameAttributes: ["email"],
+  }),
+);
+const userPoolId = pool.UserPool?.Id;
+
+const client = await cognito.createUserPoolClient(
+  new CreateUserPoolClientCommand({
+    UserPoolId: userPoolId,
+    ClientName: "web",
+    ExplicitAuthFlows: ["ALLOW_USER_PASSWORD_AUTH"],
+  }),
+);
+const clientId = client.UserPoolClient?.ClientId;
+
+await cognito.signUp(
+  new SignUpCommand({
+    ClientId: clientId,
+    Username: "alice@example.com",
+    Password: "Sup3rSecret!",
+  }),
+);
+
+await cognito.adminConfirmSignUp(
+  new AdminConfirmSignUpCommand({
+    UserPoolId: userPoolId,
+    // Naming the user by the address reaches it, as it does on real Cognito.
+    Username: "alice@example.com",
+  }),
+);
+
+const read = await cognito.adminGetUser(
+  new AdminGetUserCommand({
+    UserPoolId: userPoolId,
+    Username: "alice@example.com",
+  }),
+);
+
+console.log(read.Username); // A UUID, and not "alice@example.com"
+console.log(read.UserAttributes?.find((each) => each.Name === "email")?.Value);
+// "alice@example.com"
+
+const signedIn = await cognito.initiateAuth(
+  new InitiateAuthCommand({
+    ClientId: clientId,
+    AuthFlow: "USER_PASSWORD_AUTH",
+    AuthParameters: {
+      USERNAME: "alice@example.com",
+      PASSWORD: "Sup3rSecret!",
+    },
+  }),
+);
+
+console.log(signedIn.AuthenticationResult?.IdToken !== undefined); // true
+// The id token's cognito:username claim is the generated username above.
+```
+
+The address goes on reaching the user. The admin operations and the sign-in flows resolve it to the
+user holding it, as real Cognito resolves it, so `AdminGetUser`, `ConfirmSignUp`, `InitiateAuth` and
+`AdminInitiateAuth` all take the address as well as the generated username.
+
+A `SECRET_HASH` covers the value the request itself carries. A sign-up or a sign-in naming the
+address computes it over the address. `REFRESH_TOKEN_AUTH` names no user, so its hash is computed
+over the username the token was issued to, which is the generated one.
+
+Two users cannot sign in by the same address. A second sign-up with one is refused with
+`UsernameExistsException`, and an `AdminUpdateUserAttributes` request setting one another user
+already holds is refused with `AliasExistsException`. A username that is not written the way the
+attribute's values are, such
+as a plain name on a pool signing in by email, is refused too, because a user created that way
+could never sign in. A request naming one address as the username and a different one as the
+attribute is refused rather than resolved in favour of either.
+
+`UsernameAttributes` takes `email` and `phone_number`, and a pool can name both. It is settled when
+the pool is created: real `UpdateUserPool` has no such input, and a request carrying one here is
+refused.
+
 ## Custom attributes
 
 A pool holds the standard OpenID Connect attributes, and the ones its `Schema` declares beside them.
@@ -2356,11 +2465,15 @@ the secret with `DescribeUserPoolClient`, which reports it here as it does on re
 The properties each type reads are the ones this simulation models:
 
 - `AWS::Cognito::UserPool`: `UserPoolName`, `Policies`, `DeletionProtection`, `LambdaConfig`,
-  `AdminCreateUserConfig`, `AutoVerifiedAttributes`, `Schema`, `MfaConfiguration`, `EnabledMfas`,
+  `AdminCreateUserConfig`, `AutoVerifiedAttributes`, `UsernameAttributes`, `Schema`,
+  `MfaConfiguration`, `EnabledMfas`,
   `UserPoolTier`, `AccountRecoverySetting`, `EmailVerificationMessage`, `EmailVerificationSubject`,
   `SmsVerificationMessage` and `VerificationMessageTemplate`. `LambdaConfig` is read a trigger at a
   time, so a template naming a trigger this simulation runs deploys and one naming a trigger it
-  does not fails the stack. `Schema` is what a CDK `UserPool` emits for its `customAttributes` and
+  does not fails the stack. `UsernameAttributes` is what a CDK `UserPool` emits for its
+  `signInAliases`, so a stack building an email sign-in pool deploys one that
+  [identifies its users](#signing-in-by-email-or-phone-number) the way a deployed one would.
+  `Schema` is what a CDK `UserPool` emits for its `customAttributes` and
   its `standardAttributes`, so a stack keying its own data on a `custom:` attribute deploys and the
   sign-up it was built for works. `MfaConfiguration` and `EnabledMfas` are deployed in a
   `SetUserPoolMfaConfig` call once the pool exists, which is how real CloudFormation deploys them
@@ -3469,8 +3582,8 @@ Current documented limitations:
 - A `CustomMessage` event reports `CLIENT_ID_NOT_APPLICABLE` as its `callerContext.clientId` for an
   `AdminCreateUser`, as real Cognito does for an admin operation, and names the app client for the
   two occasions that come through one.
-- Unsimulated `CreateUserPool` inputs are refused rather than ignored: `UsernameAttributes`,
-  `AliasAttributes`, `UsernameConfiguration`,
+- Unsimulated `CreateUserPool` inputs are refused rather than ignored: `AliasAttributes`,
+  `UsernameConfiguration`,
   `UserAttributeUpdateSettings`, `DeviceConfiguration`, `UserPoolAddOns`, `KeyConfiguration`,
   `IssuerConfiguration`, `UserPoolTags`, the email and SMS configurations, an
   `SmsAuthenticationMessage`, a `UserPoolTier` other than `ESSENTIALS`, a `SignInPolicy`, and a
@@ -3484,9 +3597,12 @@ Current documented limitations:
   refused. `InviteMessageTemplate` is the wording of the invitation, and a pool cannot set its own
   yet, so an invitation is recorded at Cognito's default wording. `UnusedAccountValidityDays`
   expires a temporary password, and nothing here expires one.
-- `UsernameAttributes` is worth calling out among those. A pool that signs users in by email or phone
-  number stores a generated UUID as the username, so a pool created here without that would answer
-  with the wrong username and the right one on real AWS.
+- `UsernameAttributes` is simulated, and `AliasAttributes` is not. The two differ in what the
+  username is: a `UsernameAttributes` pool generates one, which is what this stores, and an
+  `AliasAttributes` pool keeps the username the request chose and takes the attribute as a second
+  way of naming the user, which is not modelled.
+- A `UsernameAttributes` pool resolves the address for its admin operations and its sign-ins, and
+  refuses a second user holding an address another user already signs in by.
 - Unsimulated `CreateUserPoolClient` inputs are refused the same way: a `ClientSecret` of your own,
   `AnalyticsConfiguration`, `AuthSessionValidity`, `EnablePropagateAdditionalUserContextData`,
   `RefreshTokenRotation`, `ReadAttributes`, `WriteAttributes`, and an `EnableTokenRevocation` of

--- a/docs/services/cognito/sim-cognito-sign-in-by-email.example.ts
+++ b/docs/services/cognito/sim-cognito-sign-in-by-email.example.ts
@@ -1,0 +1,75 @@
+/**
+ * A simulated pool that signs its users in by email address.
+ */
+
+import {
+  AdminConfirmSignUpCommand,
+  AdminGetUserCommand,
+  CreateUserPoolClientCommand,
+  CreateUserPoolCommand,
+  InitiateAuthCommand,
+  SignUpCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const cognito = simAws.cognitoIdentityProvider();
+
+const pool = await cognito.createUserPool(
+  new CreateUserPoolCommand({
+    PoolName: "myapp-users",
+    UsernameAttributes: ["email"],
+  }),
+);
+const userPoolId = pool.UserPool?.Id;
+
+const client = await cognito.createUserPoolClient(
+  new CreateUserPoolClientCommand({
+    UserPoolId: userPoolId,
+    ClientName: "web",
+    ExplicitAuthFlows: ["ALLOW_USER_PASSWORD_AUTH"],
+  }),
+);
+const clientId = client.UserPoolClient?.ClientId;
+
+await cognito.signUp(
+  new SignUpCommand({
+    ClientId: clientId,
+    Username: "alice@example.com",
+    Password: "Sup3rSecret!",
+  }),
+);
+
+await cognito.adminConfirmSignUp(
+  new AdminConfirmSignUpCommand({
+    UserPoolId: userPoolId,
+    // Naming the user by the address reaches it, as it does on real Cognito.
+    Username: "alice@example.com",
+  }),
+);
+
+const read = await cognito.adminGetUser(
+  new AdminGetUserCommand({
+    UserPoolId: userPoolId,
+    Username: "alice@example.com",
+  }),
+);
+
+console.log(read.Username); // A UUID, and not "alice@example.com"
+console.log(read.UserAttributes?.find((each) => each.Name === "email")?.Value);
+// "alice@example.com"
+
+const signedIn = await cognito.initiateAuth(
+  new InitiateAuthCommand({
+    ClientId: clientId,
+    AuthFlow: "USER_PASSWORD_AUTH",
+    AuthParameters: {
+      USERNAME: "alice@example.com",
+      PASSWORD: "Sup3rSecret!",
+    },
+  }),
+);
+
+console.log(signedIn.AuthenticationResult?.IdToken !== undefined); // true
+// The id token's cognito:username claim is the generated username above.

--- a/src/service/cognito/README.md
+++ b/src/service/cognito/README.md
@@ -41,9 +41,17 @@ attributes the pool holds on a user, the Lambda triggers the pool runs, whether 
 factor, how it recovers an account, and what its messages say. `CreateUserPool` and `UpdateUserPool` both
 build one out of their own request, and an update swaps the pool's for it. That is what makes an
 update replace rather than merge, and it is where the pool's `LastModifiedDate` moves. Each takes the
-operation name, so a refusal from inside the settings names the request it came from. The schema is
-the one setting an update cannot replace, so `keepSchemaOf` carries it onto the settings replacing
-it, as it has to: only `CreateUserPool` declares one.
+operation name, so a refusal from inside the settings names the request it came from. The schema and
+the attributes the pool signs users in by are the settings an update cannot replace, so
+`keepCreationSettingsOf` carries them onto the settings replacing them, as it has to: only
+`CreateUserPool` declares either.
+
+`SimCognitoUsernameAttributes` is what a pool signs its users in by, from its `UsernameAttributes`.
+A pool that names one generates a UUID username for each new user and puts the value the request
+called the username into that attribute, which is what real Cognito stores. It also resolves the
+address back to the user, which `SimCognitoUserStore` asks it to do for every lookup, so an admin
+operation or a sign-in naming the address reaches the same user the generated username reaches.
+`SimCognitoSignInAttribute` beside it is one such attribute, and holds the form its values take.
 
 `SimCognitoUserPoolMfa` under `user-pool/mfa/` is the multi-factor authentication one pool is
 configured for: a `SimCognitoMfaConfiguration`, which is whether it challenges, and the factors
@@ -599,9 +607,10 @@ resource, here or on real AWS.
   client's `PreventUserExistenceErrors` says. That setting is honoured for sign-in only.
 - Every unsimulated `CreateUserPool`, `UpdateUserPool`, `CreateUserPoolClient` and
   `UpdateUserPoolClient` input is refused rather than ignored.
-  `UsernameAttributes` is the one that matters most: a pool signing users in by email stores a
-  generated UUID as the username, so a pool quietly created without it would answer with the wrong
-  username here and the right one on real AWS.
+- A pool created with `UsernameAttributes` stores a generated UUID as each user's username and
+  resolves the address to the user, as a real one does. `AliasAttributes` is refused, because there
+  the username is still the one the request chose and the attribute is a second way of naming the
+  user.
 - A pool created with `DeletionProtection: ACTIVE` refuses `DeleteUserPool` until an `UpdateUserPool`
   request deactivates the protection, as real Cognito refuses it.
 - `UpdateUserPool` replaces a pool's settings rather than merging into them, so a setting the request

--- a/src/service/cognito/cfn/sim-cfn-cognito-user-pool.iso.test.ts
+++ b/src/service/cognito/cfn/sim-cfn-cognito-user-pool.iso.test.ts
@@ -1,6 +1,7 @@
 import {
   AdminAddUserToGroupCommand,
   AdminCreateUserCommand,
+  AdminGetUserCommand,
   AdminInitiateAuthCommand,
   AdminListGroupsForUserCommand,
   AdminSetUserPasswordCommand,
@@ -12,6 +13,7 @@ import {
   assertNonNullable,
   assertStringStartsWith,
   assertTypeString,
+  assertUuidV4,
 } from "@kensio/smartass";
 import { describe, it } from "vitest";
 
@@ -216,5 +218,53 @@ describe("Cognito CloudFormation user pool deployment", () => {
       }),
     );
     assertIdentical(groups.Groups?.[0]?.GroupName, "admins");
+  });
+
+  it("deploys a pool that signs its users in by email", async () => {
+    // Given a template asking for a pool that signs users in by email, which
+    // is what a CDK UserPool with signInAliases: { email: true } emits.
+    const simAws = simAwsInEuWest2();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "email-stack",
+      template: {
+        Resources: {
+          AppPool: {
+            Type: "AWS::Cognito::UserPool",
+            Properties: {
+              UserPoolName: "myapp-users",
+              UsernameAttributes: ["email"],
+            },
+          },
+        },
+        Outputs: { PoolId: { Value: { Ref: "AppPool" } } },
+      },
+    });
+    await stack.waitForDeployComplete();
+
+    const userPoolId = output(stack, "PoolId");
+    const cognito = simAws.cognitoIdentityProvider();
+
+    // When a user is created in the deployed pool by its address.
+    const created = await cognito.adminCreateUser(
+      new AdminCreateUserCommand({
+        UserPoolId: userPoolId,
+        Username: "alice@example.com",
+      }),
+    );
+
+    // Then the pool it deployed identifies that user the way a deployed one
+    // would: a generated UUID username, with the address as an attribute
+    // reaching the same user.
+    assertNonNullable(created.User?.Username);
+    assertUuidV4(created.User.Username);
+
+    const found = await cognito.adminGetUser(
+      new AdminGetUserCommand({
+        UserPoolId: userPoolId,
+        Username: "alice@example.com",
+      }),
+    );
+
+    assertIdentical(found.Username, created.User.Username);
   });
 });

--- a/src/service/cognito/cfn/sim-cfn-cognito-validation.iso.test.ts
+++ b/src/service/cognito/cfn/sim-cfn-cognito-validation.iso.test.ts
@@ -85,7 +85,8 @@ describe("Cognito CloudFormation validation", () => {
   });
 
   it("creates a user pool without a property it does not simulate", async () => {
-    // Given a template asking for a pool that signs users in by email.
+    // Given a template asking for a pool that tracks the devices its users
+    // sign in from.
     const simAws = simAwsInEuWest2();
 
     // When it is deployed.
@@ -94,7 +95,7 @@ describe("Cognito CloudFormation validation", () => {
         Type: "AWS::Cognito::UserPool",
         Properties: {
           UserPoolName: "myapp-users",
-          UsernameAttributes: ["email"],
+          DeviceConfiguration: { ChallengeRequiredOnNewDevice: true },
         },
       },
     });
@@ -107,7 +108,7 @@ describe("Cognito CloudFormation validation", () => {
     const [reason] = ignoredReasons(stack);
     assertNonNullable(reason);
     assertStringIncludes(reason, "AppPool");
-    assertStringIncludes(reason, "UsernameAttributes is not simulated");
+    assertStringIncludes(reason, "DeviceConfiguration is not simulated");
     assertStringIncludes(reason, "The simulated properties are");
   });
 

--- a/src/service/cognito/cfn/user-pool/sim-cfn-cognito-user-pool-properties.ts
+++ b/src/service/cognito/cfn/user-pool/sim-cfn-cognito-user-pool-properties.ts
@@ -31,6 +31,11 @@ import { SimCfnCognitoPolicies } from "./sim-cfn-cognito-policies.js";
  * decides whether `SignUp` is allowed at all, and the second decides which
  * attributes confirming a sign-up marks as verified.
  *
+ * `UsernameAttributes` is here because the pool signs its users in by what it
+ * names, and stores the generated UUID username that comes with that. A CDK
+ * `UserPool` with `signInAliases: { email: true }` emits it, so a stack built
+ * that way deploys a pool identifying its users the way a deployed one would.
+ *
  * `Schema` is here because the pool holds the attributes it declares. A CDK
  * `UserPool` emits one for its `customAttributes` and for any
  * `standardAttributes` entry, so a stack keying its own data on a `custom:`
@@ -62,6 +67,7 @@ const simulatedProperties = [
   "UserPoolTier",
   "AdminCreateUserConfig",
   "AutoVerifiedAttributes",
+  "UsernameAttributes",
   "Schema",
   "AccountRecoverySetting",
   "EmailVerificationMessage",
@@ -135,6 +141,11 @@ export class SimCfnCognitoUserPoolProperties {
         this.resource,
         this.properties["AutoVerifiedAttributes"],
         "AutoVerifiedAttributes",
+      ),
+      UsernameAttributes: this.propertyParser.optionalStringArray(
+        this.resource,
+        this.properties["UsernameAttributes"],
+        "UsernameAttributes",
       ),
       Schema: new SimCfnCognitoUserPoolSchema({
         resource: this.resource,

--- a/src/service/cognito/command/user-pool/sim-cognito-unsimulated-pool-identity.ts
+++ b/src/service/cognito/command/user-pool/sim-cognito-unsimulated-pool-identity.ts
@@ -1,17 +1,18 @@
-import { SimCognitoInvalidParameterException } from "../../error/sim-cognito.error.js";
 import { SimCognitoUnsimulatedInput } from "../sim-cognito-unsimulated-input.js";
 import type { SimCreateUserPoolCommandInput } from "./user-pool.command.js";
 
 /**
- * Refuses the inputs deciding how a pool identifies its users.
+ * Refuses the inputs deciding how a pool identifies its users that this
+ * simulation does not model.
  *
- * These three are `CreateUserPool` inputs only. Real Cognito fixes each of
- * them when the pool is made and has no `UpdateUserPool` input for any of
- * them, so the refusals only ever name creation.
+ * Both are `CreateUserPool` inputs only. Real Cognito fixes each of them when
+ * the pool is made and has no `UpdateUserPool` input for either, so the
+ * refusals only ever name creation.
  *
- * `Schema` is the fourth such input and is not refused: a pool takes the
- * attributes it declares. `UsernameAttributes` is the one that would hurt
- * most, and it gets its own refusal saying why.
+ * `Schema` and `UsernameAttributes` are the other two such inputs and are not
+ * refused: a pool takes the attributes it declares, and a pool that signs
+ * users in by one of them stores the generated UUID username real Cognito
+ * would have stored.
  */
 export class SimCognitoUnsimulatedUserPoolIdentity {
   private readonly unsimulated = new SimCognitoUnsimulatedInput(
@@ -22,8 +23,6 @@ export class SimCognitoUnsimulatedUserPoolIdentity {
    * Refuse a request choosing how its users are identified.
    */
   refuseIn(input: SimCreateUserPoolCommandInput): void {
-    this.refuseUsernameAttributes(input.UsernameAttributes);
-
     this.unsimulated.refuse(
       "AliasAttributes",
       input.AliasAttributes,
@@ -33,29 +32,6 @@ export class SimCognitoUnsimulatedUserPoolIdentity {
       "UsernameConfiguration",
       input.UsernameConfiguration,
       "case-insensitive usernames",
-    );
-  }
-
-  /**
-   * Refuse a pool that signs users in by an attribute rather than by
-   * username.
-   *
-   * Such a pool stores a generated UUID as the username, so code written
-   * against it looks users up by something this simulation would not have
-   * given them.
-   */
-  private refuseUsernameAttributes(
-    attributes: readonly string[] | undefined,
-  ): void {
-    if (attributes === undefined) {
-      return;
-    }
-
-    throw new SimCognitoInvalidParameterException(
-      "CreateUserPool UsernameAttributes is not simulated: a pool that signs " +
-        "users in by email or phone number stores a generated UUID as the " +
-        "username, so simulating the pool without that would answer with the " +
-        "wrong username here and the right one on real AWS",
     );
   }
 }

--- a/src/service/cognito/command/user-pool/sim-cognito-unsimulated-pool-updates.ts
+++ b/src/service/cognito/command/user-pool/sim-cognito-unsimulated-pool-updates.ts
@@ -14,9 +14,10 @@ import type { SimUpdateUserPoolCommandInput } from "./user-pool.command.js";
  * carrying one is refused rather than answered with a pool still under its
  * old name.
  *
- * `Schema` is refused for a different reason: real `UpdateUserPool` has no
- * such input at all, and a request carrying one would change a pool's
- * attributes here and nothing on AWS.
+ * `Schema` and `UsernameAttributes` are refused for a different reason: real
+ * `UpdateUserPool` has neither input at all, and a request carrying one would
+ * change a pool's attributes, or how it identifies its users, here and
+ * nothing on AWS.
  */
 export class SimCognitoUnsimulatedUserPoolUpdates {
   private readonly unsimulated = new SimCognitoUnsimulatedInput(
@@ -46,12 +47,35 @@ export class SimCognitoUnsimulatedUserPoolUpdates {
   }
 
   /**
+   * Refuse an update changing how the pool identifies its users.
+   *
+   * What a pool signs users in by is fixed when the pool is created, on real
+   * Cognito as here, and its users were created under the usernames that
+   * choice gave them.
+   */
+  private static refuseUsernameAttributes(
+    attributes: readonly string[] | undefined,
+  ): void {
+    if (attributes === undefined) {
+      return;
+    }
+
+    throw new SimCognitoInvalidParameterException(
+      "UpdateUserPool UsernameAttributes is not an input real Cognito has: " +
+        "what a pool signs its users in by is fixed when the pool is created",
+    );
+  }
+
+  /**
    * Refuse an update carrying an input this simulation cannot honour.
    */
   refuseIn(input: SimUpdateUserPoolCommandInput): void {
     this.unsimulated.refuse("PoolName", input.PoolName, "renaming a pool");
 
     SimCognitoUnsimulatedUserPoolUpdates.refuseSchema(input.Schema);
+    SimCognitoUnsimulatedUserPoolUpdates.refuseUsernameAttributes(
+      input.UsernameAttributes,
+    );
     this.options.refuseIn(input);
   }
 }

--- a/src/service/cognito/command/user-pool/sim-cognito-user-pool-commands.ts
+++ b/src/service/cognito/command/user-pool/sim-cognito-user-pool-commands.ts
@@ -115,10 +115,11 @@ export class SimCognitoUserPoolCommands {
     // Cognito.
     settings.mfa.keepFactorsOf(pool.settings.mfa);
 
-    // An update declares no schema, and one that tried was refused above, so
-    // the pool keeps the attributes it was created with rather than dropping
-    // back to the standard ones.
-    settings.keepSchemaOf(pool.settings);
+    // An update declares neither a schema nor the attributes the pool signs
+    // users in by, and one that tried either was refused above, so the pool
+    // keeps what it was created with rather than dropping back to the
+    // standard attributes and to signing in by username.
+    settings.keepCreationSettingsOf(pool.settings);
     pool.update(settings);
 
     return { $metadata: {} };

--- a/src/service/cognito/command/user-pool/sim-cognito-user-pool-validation.iso.test.ts
+++ b/src/service/cognito/command/user-pool/sim-cognito-user-pool-validation.iso.test.ts
@@ -29,11 +29,6 @@ interface RefusedInput {
  */
 const refusedInputs: readonly RefusedInput[] = [
   {
-    label: "UsernameAttributes",
-    input: { UsernameAttributes: ["email"] },
-    says: "stores a generated UUID as the username",
-  },
-  {
     label: "UserPoolTier",
     input: { UserPoolTier: "PLUS" },
     says: "the Lite and Plus feature plans",

--- a/src/service/cognito/command/user-pool/sim-cognito-user-pool-view.ts
+++ b/src/service/cognito/command/user-pool/sim-cognito-user-pool-view.ts
@@ -26,6 +26,9 @@ export class SimCognitoUserPoolView {
    * offers is not reported here on real Cognito either:
    * `GetUserPoolMfaConfig` is what reports those.
    *
+   * `UsernameAttributes` is reported only by a pool that signs its users in
+   * by one, and is what says why that pool's usernames are UUIDs.
+   *
    * `SchemaAttributes` is every attribute the pool holds on a user: the
    * standard ones and the `custom:` ones its `Schema` declared, each under the
    * name Cognito gave it.
@@ -50,6 +53,7 @@ export class SimCognitoUserPoolView {
       MfaConfiguration: pool.settings.mfa.configuration.value,
       AdminCreateUserConfig: pool.settings.adminCreateUserConfig.toOutput(),
       AutoVerifiedAttributes: pool.settings.autoVerifiedAttributes.toOutput(),
+      UsernameAttributes: pool.settings.usernameAttributes.toOutput(),
       SchemaAttributes: pool.settings.schema.toOutput(),
       EstimatedNumberOfUsers: pool.userCount,
       CreationDate: pool.creationDate,

--- a/src/service/cognito/command/user-pool/user-pool.command.ts
+++ b/src/service/cognito/command/user-pool/user-pool.command.ts
@@ -31,6 +31,7 @@ export interface SimCognitoUserPoolType extends SimCognitoVerificationMessagesTy
     | SimCognitoAdminCreateUserConfigType
     | undefined;
   readonly AutoVerifiedAttributes?: readonly string[] | undefined;
+  readonly UsernameAttributes?: readonly string[] | undefined;
   readonly SchemaAttributes?:
     | readonly SimCognitoSchemaAttributeType[]
     | undefined;
@@ -63,19 +64,19 @@ export interface SimCognitoUserPoolCommandInput extends SimCognitoUserPoolSettin
 /**
  * The CreateUserPool inputs this simulation reads, and the ones it refuses.
  *
- * The three beside the shared ones are the inputs only a creation carries.
- * They decide how a pool identifies its users, and none of them can be
- * changed afterwards on real Cognito either.
+ * The two beside the shared ones are the inputs only a creation carries that
+ * this simulation refuses. They decide how a pool identifies its users, and
+ * neither can be changed afterwards on real Cognito either.
  *
- * `Schema` is a creation-only input too, and is named among the shared
- * settings because it is a pool's schema that is built from it.
+ * `Schema` and `UsernameAttributes` are creation-only inputs too, and are
+ * named among the shared settings because it is a pool's settings that are
+ * built from them.
  *
  * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/cognito-identity-provider/command/CreateUserPoolCommand/
  */
 export interface SimCreateUserPoolCommandInput extends SimCognitoUserPoolCommandInput {
   readonly PoolName?: string | undefined;
   readonly AliasAttributes?: readonly string[] | undefined;
-  readonly UsernameAttributes?: readonly string[] | undefined;
   readonly UsernameConfiguration?: object | undefined;
 }
 

--- a/src/service/cognito/command/user/sim-cognito-sign-in-value-check.ts
+++ b/src/service/cognito/command/user/sim-cognito-sign-in-value-check.ts
@@ -1,0 +1,64 @@
+import { SimCognitoAliasExistsException } from "../../error/sim-cognito.error.js";
+import type { SimCognitoUserPool } from "../../user-pool/sim-cognito-user-pool.js";
+import type { SimCognitoUser } from "../../user-pool/user/sim-cognito-user.js";
+import type { SimCognitoAttributeType } from "../../user-pool/user/sim-cognito-user-attributes.js";
+
+/**
+ * Refuses an attribute update taking a value another user of the pool signs
+ * in by.
+ *
+ * A pool with `UsernameAttributes` identifies its users by that attribute, so
+ * two users holding the same value would leave a sign-in naming an account
+ * the pool has two of. Real Cognito answers `AliasExistsException` here, and
+ * so does this. A pool that signs users in by username has nothing to check:
+ * the attribute names nothing there.
+ */
+export class SimCognitoSignInValueCheck {
+  private readonly pool: SimCognitoUserPool;
+
+  constructor(pool: SimCognitoUserPool) {
+    this.pool = pool;
+  }
+
+  /**
+   * Check an update before any of its attributes is written, so a refused one
+   * changes nothing.
+   *
+   * A user setting the value it already signs in by is left alone, because
+   * the user the value reaches is that same user.
+   */
+  requireFreeFor(
+    user: SimCognitoUser,
+    requested: readonly SimCognitoAttributeType[] | undefined,
+  ): void {
+    const signInBy = this.pool.settings.usernameAttributes;
+    const attributes = requested ?? [];
+
+    for (const attribute of attributes) {
+      const { Name: name, Value: value } = attribute;
+
+      if (
+        name === undefined ||
+        value === undefined ||
+        !signInBy.names.includes(name)
+      ) {
+        continue;
+      }
+
+      this.requireFree(user, name, value);
+    }
+  }
+
+  /**
+   * Refuse one value another user of the pool holds.
+   */
+  private requireFree(user: SimCognitoUser, name: string, value: string): void {
+    const held = this.pool.findUser(value);
+
+    if (held !== undefined && held !== user) {
+      throw new SimCognitoAliasExistsException(
+        `An account with the given ${name} already exists.`,
+      );
+    }
+  }
+}

--- a/src/service/cognito/command/user/sim-cognito-sign-up-commands.ts
+++ b/src/service/cognito/command/user/sim-cognito-sign-up-commands.ts
@@ -94,13 +94,21 @@ export class SimCognitoSignUpCommands {
     this.unsimulatedOptions.refuseInSignUp(input);
     pool.settings.adminCreateUserConfig.requireSelfServiceSignUp();
 
-    const username = requireSimCognitoUsername(input.Username);
+    const requested = requireSimCognitoUsername(input.Username);
 
-    requireSimCognitoSecretHash(username, client, input.SecretHash);
+    requireSimCognitoSecretHash(requested, client, input.SecretHash);
+
+    // A pool signing users in by email or phone number stores a generated
+    // UUID as the username and the value the request called the username as
+    // the attribute it signs in by, as real Cognito does.
+    const identity = pool.settings.usernameAttributes.identify(
+      requested,
+      input.UserAttributes,
+    );
 
     const user = this.userFactory.signUp({
-      username,
-      attributes: input.UserAttributes,
+      username: identity.username,
+      attributes: identity.attributes,
       schema: pool.settings.schema,
       password: input.Password,
       passwordPolicy: pool.settings.passwordPolicy,

--- a/src/service/cognito/command/user/sim-cognito-user-commands.ts
+++ b/src/service/cognito/command/user/sim-cognito-user-commands.ts
@@ -92,13 +92,21 @@ export class SimCognitoUserCommands {
       input.UserPoolId,
       options,
     );
-    const username = requireSimCognitoUsername(input.Username);
+    const requested = requireSimCognitoUsername(input.Username);
 
     this.unsimulatedOptions.refuseInCreate(input);
 
+    // A pool signing users in by email or phone number stores a generated
+    // UUID as the username here too, so an admin-created user and one that
+    // signed itself up are identified the same way.
+    const identity = pool.settings.usernameAttributes.identify(
+      requested,
+      input.UserAttributes,
+    );
+
     const user = this.userFactory.make({
-      username,
-      attributes: input.UserAttributes,
+      username: identity.username,
+      attributes: identity.attributes,
       schema: pool.settings.schema,
       temporaryPassword: input.TemporaryPassword,
       passwordPolicy: pool.settings.passwordPolicy,

--- a/src/service/cognito/command/user/sim-cognito-user-update-commands.ts
+++ b/src/service/cognito/command/user/sim-cognito-user-update-commands.ts
@@ -1,5 +1,6 @@
 import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
 import { SimCognitoPasswordCheck } from "../../user-pool/sim-cognito-password-check.js";
+import { SimCognitoSignInValueCheck } from "./sim-cognito-sign-in-value-check.js";
 import { SimCognitoUnsimulatedUserOptions } from "./sim-cognito-unsimulated-user-options.js";
 import type { SimCognitoRequestResolver } from "../sim-cognito-request-resolver.js";
 import type {
@@ -75,13 +76,17 @@ export class SimCognitoUserUpdateCommands {
     options?: SimCognitoCommandOptions,
   ): SimAdminUpdateUserAttributesCommandOutput {
     const { input } = command;
-    const user = this.resolver.user(
+    const { pool, user } = this.resolver.poolUser(
       "cognito-idp:AdminUpdateUserAttributes",
       input,
       options,
     );
 
     this.unsimulatedOptions.refuseInUpdate(input);
+    new SimCognitoSignInValueCheck(pool).requireFreeFor(
+      user,
+      input.UserAttributes,
+    );
 
     user.updateAttributes(input.UserAttributes);
 

--- a/src/service/cognito/error/sim-cognito.error.ts
+++ b/src/service/cognito/error/sim-cognito.error.ts
@@ -60,6 +60,20 @@ export class SimCognitoUsernameExistsException extends SimCognitoError {
 }
 
 /**
+ * Simulated Cognito AliasExistsException error.
+ *
+ * Real Cognito reports an attribute update this way when the value it sets is
+ * one another user of the pool already signs in by.
+ */
+export class SimCognitoAliasExistsException extends SimCognitoError {
+  public override readonly name = "AliasExistsException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
  * Simulated Cognito GroupExistsException error.
  *
  * Real Cognito reports a second group created with a name the pool already

--- a/src/service/cognito/index.ts
+++ b/src/service/cognito/index.ts
@@ -138,6 +138,7 @@ export {
   type SimCognitoOAuthErrorCode,
 } from "./error/sim-cognito-oauth.error.js";
 export {
+  SimCognitoAliasExistsException,
   SimCognitoCodeMismatchException,
   SimCognitoDuplicateProviderException,
   SimCognitoEnableSoftwareTokenMfaException,

--- a/src/service/cognito/user-pool/sim-cognito-sign-in-attribute.ts
+++ b/src/service/cognito/user-pool/sim-cognito-sign-in-attribute.ts
@@ -1,0 +1,68 @@
+import { SimCognitoInvalidParameterException } from "../error/sim-cognito.error.js";
+
+/**
+ * How each attribute a pool can sign users in by is written, and how a
+ * refusal describes it.
+ *
+ * These are the two Cognito allows in `UsernameAttributes`, and they are the
+ * same two it can send a confirmation code to.
+ */
+const signInAttributeForms = new Map<string, SimCognitoSignInAttributeForm>([
+  [
+    "email",
+    { description: "an email", pattern: /^[^\s@]+@[^\s@]+\.[^\s@]+$/u },
+  ],
+  [
+    "phone_number",
+    { description: "a phone number", pattern: /^\+[1-9]\d{1,14}$/u },
+  ],
+]);
+
+interface SimCognitoSignInAttributeForm {
+  /** How a refusal names this attribute's values, such as `an email`. */
+  readonly description: string;
+
+  /** The shape a value has to take to be one of this attribute's. */
+  readonly pattern: RegExp;
+}
+
+/**
+ * One attribute a pool signs its users in by.
+ *
+ * Real Cognito holds the value a `UsernameAttributes` pool is signed in with
+ * to the form of the attribute it fills, and refuses a `SignUp` carrying
+ * anything else, so the form is checked here rather than left to reach the
+ * pool as a username that could never sign in.
+ */
+export class SimCognitoSignInAttribute {
+  public readonly name: string;
+  private readonly form: SimCognitoSignInAttributeForm;
+
+  constructor(name: string) {
+    const form = signInAttributeForms.get(name);
+
+    if (form === undefined) {
+      throw new SimCognitoInvalidParameterException(
+        `UsernameAttributes '${name}' is not an attribute Cognito can sign ` +
+          `users in by. Only ${signInAttributeForms.keys().toArray().join(" and ")} can be`,
+      );
+    }
+
+    this.name = name;
+    this.form = form;
+  }
+
+  /**
+   * How a refusal names the values of this attribute.
+   */
+  get description(): string {
+    return this.form.description;
+  }
+
+  /**
+   * Whether a value is written the way this attribute's values are.
+   */
+  holds(value: string): boolean {
+    return this.form.pattern.test(value);
+  }
+}

--- a/src/service/cognito/user-pool/sim-cognito-user-pool-settings.ts
+++ b/src/service/cognito/user-pool/sim-cognito-user-pool-settings.ts
@@ -20,6 +20,7 @@ import {
 } from "./message/sim-cognito-verification-messages.js";
 import type { SimCognitoSchemaAttributeType } from "./schema/sim-cognito-schema-attribute.js";
 import { SimCognitoUserPoolSchema } from "./schema/sim-cognito-user-pool-schema.js";
+import { SimCognitoUsernameAttributes } from "./sim-cognito-username-attributes.js";
 import { SimCognitoLambdaConfig } from "./trigger/sim-cognito-lambda-config.js";
 
 /**
@@ -50,6 +51,15 @@ export interface SimCognitoUserPoolSettingsInput extends SimCognitoVerificationM
    * users written against it.
    */
   readonly Schema?: readonly SimCognitoSchemaAttributeType[] | undefined;
+
+  /**
+   * The attributes the pool signs its users in by, rather than by username.
+   *
+   * Only `CreateUserPool` carries it, for the same reason `Schema` is here:
+   * it is the pool's settings that hold it, and `UpdateUserPool` refuses one
+   * rather than changing how a pool with users already in it identifies them.
+   */
+  readonly UsernameAttributes?: readonly string[] | undefined;
 }
 
 interface SimCognitoUserPoolSettingsProperties {
@@ -78,9 +88,10 @@ interface SimCognitoUserPoolSettingsProperties {
  * request, and the pool swaps to it, so a setting the update is silent about
  * goes back to its default rather than staying as it was.
  *
- * The schema is the exception. Only `CreateUserPool` declares one, so an
- * update takes on the schema of the settings it replaces rather than dropping
- * the pool back to the standard attributes.
+ * The schema and the attributes the pool signs users in by are the
+ * exceptions. Only `CreateUserPool` declares either, so an update takes both
+ * on from the settings it replaces rather than dropping the pool back to the
+ * standard attributes and to signing in by username.
  */
 export class SimCognitoUserPoolSettings {
   public readonly passwordPolicy: SimCognitoPasswordPolicy;
@@ -117,6 +128,7 @@ export class SimCognitoUserPoolSettings {
   public readonly accountRecovery: SimCognitoAccountRecovery;
 
   #schema: SimCognitoUserPoolSchema;
+  #usernameAttributes: SimCognitoUsernameAttributes;
 
   constructor(properties: SimCognitoUserPoolSettingsProperties) {
     const { input, operation } = properties;
@@ -146,6 +158,9 @@ export class SimCognitoUserPoolSettings {
       operation,
     );
     this.#schema = new SimCognitoUserPoolSchema(input.Schema);
+    this.#usernameAttributes = new SimCognitoUsernameAttributes(
+      input.UsernameAttributes,
+    );
   }
 
   /**
@@ -157,14 +172,25 @@ export class SimCognitoUserPoolSettings {
   }
 
   /**
-   * Take on the schema of the settings this set replaces.
-   *
-   * `UpdateUserPool` has no `Schema` input on real Cognito, so an update
-   * changes nothing about the attributes a pool holds. Carrying the schema
-   * across is what keeps that true here, where an update otherwise replaces
-   * every setting with the default of the one it left out.
+   * The attributes the pool signs its users in by, from its
+   * `UsernameAttributes`. A pool created without any signs users in by
+   * username.
    */
-  keepSchemaOf(replaced: SimCognitoUserPoolSettings): void {
+  get usernameAttributes(): SimCognitoUsernameAttributes {
+    return this.#usernameAttributes;
+  }
+
+  /**
+   * Take on the settings only a creation declares from the ones this set
+   * replaces: the pool's schema, and what it signs its users in by.
+   *
+   * Real `UpdateUserPool` has neither input, so an update changes nothing
+   * about the attributes a pool holds or how it identifies its users.
+   * Carrying them across is what keeps that true here, where an update
+   * otherwise replaces every setting with the default of the one it left out.
+   */
+  keepCreationSettingsOf(replaced: SimCognitoUserPoolSettings): void {
     this.#schema = replaced.schema;
+    this.#usernameAttributes = replaced.usernameAttributes;
   }
 }

--- a/src/service/cognito/user-pool/sim-cognito-user-pool.ts
+++ b/src/service/cognito/user-pool/sim-cognito-user-pool.ts
@@ -63,7 +63,7 @@ export class SimCognitoUserPool {
 
   private readonly clock: SimClock;
   private readonly clientStore = new SimCognitoUserPoolClientStore();
-  private readonly userStore = new SimCognitoUserStore();
+  private readonly userStore: SimCognitoUserStore;
   private readonly groupStore = new SimCognitoGroupStore();
   private readonly keys = new SimCognitoPoolKeys();
 
@@ -75,6 +75,9 @@ export class SimCognitoUserPool {
     this.arn = properties.arn;
     this.name = properties.name.value;
     this.#settings = properties.settings;
+    this.userStore = new SimCognitoUserStore(
+      properties.settings.usernameAttributes,
+    );
     this.clock = properties.clock;
     this.creationDate = this.clock.now();
     this.#modifiedDate = this.creationDate;

--- a/src/service/cognito/user-pool/sim-cognito-username-attributes-validation.iso.test.ts
+++ b/src/service/cognito/user-pool/sim-cognito-username-attributes-validation.iso.test.ts
@@ -1,0 +1,274 @@
+import {
+  AdminCreateUserCommand,
+  AdminUpdateUserAttributesCommand,
+  InitiateAuthCommand,
+  SignUpCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import {
+  assertInstanceOf,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import {
+  simCognitoAliasEmail,
+  simCognitoAliasPassword,
+  simCognitoAliasPool,
+  simCognitoAliasUser,
+} from "../../../../test/cognito/sign-in-alias-fixture.js";
+import { SimAws } from "../../aws/sim-aws.js";
+import {
+  SimCognitoAliasExistsException,
+  SimCognitoInvalidParameterException,
+  SimCognitoNotAuthorizedException,
+  SimCognitoUsernameExistsException,
+} from "../error/sim-cognito.error.js";
+import { simCognitoSecretHash } from "./auth/sim-cognito-secret-hash.js";
+
+describe("sim Cognito sign-in attribute validation", () => {
+  it("computes a refresh SECRET_HASH over the generated username", async () => {
+    // Given a confirmed user of a pool that signs users in by email, signed
+    // in through an app client holding a secret.
+    const setUp = await simCognitoAliasPool({ generateSecret: true });
+    const { cognito, clientId, clientSecret } = setUp;
+    assertNonNullable(clientSecret);
+
+    const username = await simCognitoAliasUser(setUp);
+    const signedIn = await cognito.initiateAuth(
+      new InitiateAuthCommand({
+        ClientId: clientId,
+        AuthFlow: "USER_PASSWORD_AUTH",
+        AuthParameters: {
+          USERNAME: simCognitoAliasEmail,
+          PASSWORD: simCognitoAliasPassword,
+          SECRET_HASH: simCognitoSecretHash(
+            simCognitoAliasEmail,
+            clientId,
+            clientSecret,
+          ),
+        },
+      }),
+    );
+
+    assertNonNullable(signedIn.AuthenticationResult?.RefreshToken);
+    const refreshToken = signedIn.AuthenticationResult.RefreshToken;
+
+    // When the session is refreshed with a hash computed over the address the
+    // sign-in named.
+    const error = await assertThrowsErrorAsync(async () => {
+      await cognito.initiateAuth(
+        new InitiateAuthCommand({
+          ClientId: clientId,
+          AuthFlow: "REFRESH_TOKEN_AUTH",
+          AuthParameters: {
+            REFRESH_TOKEN: refreshToken,
+            SECRET_HASH: simCognitoSecretHash(
+              simCognitoAliasEmail,
+              clientId,
+              clientSecret,
+            ),
+          },
+        }),
+      );
+    });
+
+    // Then it is refused. A refresh names no user, so the hash has to cover
+    // the username the token was issued to, which is the generated one.
+    assertInstanceOf(error, SimCognitoNotAuthorizedException);
+    assertStringIncludes(error.message, "Unable to verify secret hash");
+
+    // And the same refresh with the generated username in the hash is
+    // answered with new tokens.
+    const refreshed = await cognito.initiateAuth(
+      new InitiateAuthCommand({
+        ClientId: clientId,
+        AuthFlow: "REFRESH_TOKEN_AUTH",
+        AuthParameters: {
+          REFRESH_TOKEN: refreshToken,
+          SECRET_HASH: simCognitoSecretHash(username, clientId, clientSecret),
+        },
+      }),
+    );
+
+    assertNonNullable(refreshed.AuthenticationResult?.AccessToken);
+  });
+
+  it("refuses a second account signing in by the same address", async () => {
+    // Given a user of a pool that signs users in by email.
+    const setUp = await simCognitoAliasPool();
+    await simCognitoAliasUser(setUp);
+
+    // When someone signs up with the same address.
+    const error = await assertThrowsErrorAsync(async () => {
+      await setUp.cognito.signUp(
+        new SignUpCommand({
+          ClientId: setUp.clientId,
+          Username: simCognitoAliasEmail,
+          Password: simCognitoAliasPassword,
+        }),
+      );
+    });
+
+    // Then it is refused. The address identifies the account on such a pool,
+    // so two users holding it would leave a sign-in naming an account the
+    // pool has two of.
+    assertInstanceOf(error, SimCognitoUsernameExistsException);
+    assertStringIncludes(
+      error.message,
+      "An account with the given email already exists.",
+    );
+  });
+
+  it("refuses an attribute update taking an address another user has", async () => {
+    // Given two users of a pool that signs users in by email.
+    const setUp = await simCognitoAliasPool();
+    await simCognitoAliasUser(setUp);
+    const other = await simCognitoAliasUser(setUp, "bob@example.com");
+
+    // When the second is given the first one's address.
+    const error = await assertThrowsErrorAsync(async () => {
+      await setUp.cognito.adminUpdateUserAttributes(
+        new AdminUpdateUserAttributesCommand({
+          UserPoolId: setUp.userPoolId,
+          Username: other,
+          UserAttributes: [{ Name: "email", Value: simCognitoAliasEmail }],
+        }),
+      );
+    });
+
+    // Then it is refused as real Cognito refuses it, rather than leaving the
+    // pool with two users a sign-in by that address could mean.
+    assertInstanceOf(error, SimCognitoAliasExistsException);
+    assertStringIncludes(
+      error.message,
+      "An account with the given email already exists.",
+    );
+
+    // And setting the address a user already signs in by is left alone.
+    await setUp.cognito.adminUpdateUserAttributes(
+      new AdminUpdateUserAttributesCommand({
+        UserPoolId: setUp.userPoolId,
+        Username: other,
+        UserAttributes: [{ Name: "email", Value: "bob@example.com" }],
+      }),
+    );
+  });
+
+  it("refuses a username that is not the address the pool signs in by", async () => {
+    // Given a pool that signs its users in by email.
+    const setUp = await simCognitoAliasPool();
+
+    // When someone signs up with a username of their own.
+    const error = await assertThrowsErrorAsync(async () => {
+      await setUp.cognito.signUp(
+        new SignUpCommand({
+          ClientId: setUp.clientId,
+          Username: "alice",
+          Password: simCognitoAliasPassword,
+        }),
+      );
+    });
+
+    // Then it is refused, as real Cognito refuses one: a user created that
+    // way could never sign in.
+    assertInstanceOf(error, SimCognitoInvalidParameterException);
+    assertStringIncludes(error.message, "Username should be an email.");
+  });
+
+  it("names both forms where the pool signs users in by either", async () => {
+    // Given a pool that signs its users in by email or by phone number.
+    const setUp = await simCognitoAliasPool({
+      usernameAttributes: ["email", "phone_number"],
+    });
+
+    // When a user is created under a username that is neither.
+    const error = await assertThrowsErrorAsync(async () => {
+      await setUp.cognito.adminCreateUser(
+        new AdminCreateUserCommand({
+          UserPoolId: setUp.userPoolId,
+          Username: "07700900000",
+        }),
+      );
+    });
+
+    // Then the refusal names both forms it would have taken.
+    assertInstanceOf(error, SimCognitoInvalidParameterException);
+    assertStringIncludes(
+      error.message,
+      "Username should be either an email or a phone number.",
+    );
+  });
+
+  it("refuses an attribute Cognito cannot sign users in by", async () => {
+    // Given a request for a pool signing users in by an ordinary attribute.
+    const cognito = new SimAws().cognitoIdentityProvider();
+
+    // When it is made. The SDK's own type names the two attributes Cognito
+    // takes, so a request for anything else is built by hand.
+    const error = await assertThrowsErrorAsync(async () => {
+      await cognito.createUserPool({
+        input: {
+          PoolName: "myapp-users",
+          UsernameAttributes: ["preferred_username"],
+        },
+      });
+    });
+
+    // Then the refusal names the two attributes Cognito does sign users in
+    // by.
+    assertInstanceOf(error, SimCognitoInvalidParameterException);
+    assertStringIncludes(
+      error.message,
+      "UsernameAttributes 'preferred_username' is not an attribute Cognito " +
+        "can sign users in by",
+    );
+    assertStringIncludes(error.message, "email and phone_number");
+  });
+
+  it("refuses a sign-up whose email attribute is not its username", async () => {
+    // Given a pool that signs its users in by email.
+    const setUp = await simCognitoAliasPool();
+
+    // When someone signs up naming one address as the username and another as
+    // the email attribute.
+    const error = await assertThrowsErrorAsync(async () => {
+      await setUp.cognito.signUp(
+        new SignUpCommand({
+          ClientId: setUp.clientId,
+          Username: simCognitoAliasEmail,
+          Password: simCognitoAliasPassword,
+          UserAttributes: [{ Name: "email", Value: "bob@example.com" }],
+        }),
+      );
+    });
+
+    // Then it is refused rather than resolved in favour of either: the pool
+    // signs the user in by one of them, and code written against the other
+    // would look up a user that is not there.
+    assertInstanceOf(error, SimCognitoInvalidParameterException);
+    assertStringIncludes(error.message, "name different accounts");
+  });
+
+  it("refuses an update changing what the pool signs users in by", async () => {
+    // Given a pool that signs its users in by email.
+    const { cognito, userPoolId } = await simCognitoAliasPool();
+
+    // When an update asks for something else. Real UpdateUserPool has no such
+    // input, so the SDK's own type does not carry it and the request is built
+    // by hand.
+    const error = await assertThrowsErrorAsync(async () => {
+      await cognito.updateUserPool({
+        input: { UserPoolId: userPoolId, UsernameAttributes: ["phone_number"] },
+      });
+    });
+
+    // Then it is refused, saying that what a pool signs its users in by is
+    // settled when the pool is created.
+    assertInstanceOf(error, SimCognitoInvalidParameterException);
+    assertStringIncludes(
+      error.message,
+      "UpdateUserPool UsernameAttributes is not an input real Cognito has",
+    );
+  });
+});

--- a/src/service/cognito/user-pool/sim-cognito-username-attributes.iso.test.ts
+++ b/src/service/cognito/user-pool/sim-cognito-username-attributes.iso.test.ts
@@ -1,0 +1,286 @@
+import {
+  AdminCreateUserCommand,
+  AdminGetUserCommand,
+  AdminUpdateUserAttributesCommand,
+  ConfirmSignUpCommand,
+  DescribeUserPoolCommand,
+  InitiateAuthCommand,
+  SignUpCommand,
+  UpdateUserPoolCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import {
+  assertArrayEquals,
+  assertIdentical,
+  assertNonNullable,
+  assertStringNotIncludes,
+  assertUndefined,
+  assertUuidV4,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import {
+  simCognitoAliasEmail,
+  simCognitoAliasPassword,
+  simCognitoAliasPool,
+  simCognitoAliasUser,
+} from "../../../../test/cognito/sign-in-alias-fixture.js";
+import type { JSONObject } from "../../../util/type-guard/json.js";
+import type { SimCognitoAttributeType } from "./user/sim-cognito-user-attributes.js";
+
+/**
+ * Read the claims of a JWT, which are base64url encoded JSON.
+ */
+function tokenClaims(token: string): JSONObject {
+  const [, claims] = token.split(".", 2);
+
+  return JSON.parse(
+    Buffer.from(claims ?? "", "base64url").toString("utf8"),
+  ) as JSONObject;
+}
+
+/**
+ * The value of one attribute of a described user.
+ */
+function attributeOf(
+  attributes: readonly SimCognitoAttributeType[] | undefined,
+  name: string,
+): string | undefined {
+  return attributes?.find((attribute) => attribute.Name === name)?.Value;
+}
+
+describe("sim Cognito pools that sign users in by an attribute", () => {
+  it("stores a generated username and the address it was signed up by", async () => {
+    // Given a pool that signs its users in by email.
+    const setUp = await simCognitoAliasPool();
+
+    // When someone signs up with their address as the username.
+    const username = await simCognitoAliasUser(setUp);
+
+    // Then the username the pool holds is a UUID it generated rather than the
+    // address, which is what a real pool created this way stores.
+    assertUuidV4(username);
+    assertStringNotIncludes(username, "@");
+
+    // And the address is the user's email attribute, so nothing about it was
+    // lost.
+    const found = await setUp.cognito.adminGetUser(
+      new AdminGetUserCommand({
+        UserPoolId: setUp.userPoolId,
+        Username: username,
+      }),
+    );
+
+    assertIdentical(
+      attributeOf(found.UserAttributes, "email"),
+      simCognitoAliasEmail,
+    );
+  });
+
+  it("resolves an admin operation naming the user by its address", async () => {
+    // Given a user of a pool that signs users in by email.
+    const setUp = await simCognitoAliasPool();
+    const username = await simCognitoAliasUser(setUp);
+
+    // When an admin operation names that user by its address rather than by
+    // the username the pool generated.
+    await setUp.cognito.adminUpdateUserAttributes(
+      new AdminUpdateUserAttributesCommand({
+        UserPoolId: setUp.userPoolId,
+        Username: simCognitoAliasEmail,
+        UserAttributes: [{ Name: "name", Value: "Alice" }],
+      }),
+    );
+
+    // Then it reached the same user, which is the alias resolution real
+    // Cognito does for its admin operations.
+    const found = await setUp.cognito.adminGetUser(
+      new AdminGetUserCommand({
+        UserPoolId: setUp.userPoolId,
+        Username: username,
+      }),
+    );
+
+    assertIdentical(attributeOf(found.UserAttributes, "name"), "Alice");
+  });
+
+  it("confirms a sign-up named by the address it was made with", async () => {
+    // Given someone who has signed up by their address.
+    const { cognito, userPoolId, clientId } = await simCognitoAliasPool();
+
+    await cognito.signUp(
+      new SignUpCommand({
+        ClientId: clientId,
+        Username: simCognitoAliasEmail,
+        Password: simCognitoAliasPassword,
+      }),
+    );
+
+    // When they confirm with the code the pool issued, naming themselves by
+    // the address as the sign-up did.
+    const code = cognito
+      .userPool(userPoolId)
+      .confirmationCode(simCognitoAliasEmail);
+
+    await cognito.confirmSignUp(
+      new ConfirmSignUpCommand({
+        ClientId: clientId,
+        Username: simCognitoAliasEmail,
+        ConfirmationCode: code,
+      }),
+    );
+
+    // Then the user is confirmed, so the client-side sign-up flow works
+    // throughout without the caller ever knowing the generated username.
+    const found = await cognito.adminGetUser(
+      new AdminGetUserCommand({
+        UserPoolId: userPoolId,
+        Username: simCognitoAliasEmail,
+      }),
+    );
+
+    assertIdentical(found.UserStatus, "CONFIRMED");
+  });
+
+  it("names the generated username in the tokens a sign-in answers with", async () => {
+    // Given a confirmed user of a pool that signs users in by email.
+    const setUp = await simCognitoAliasPool();
+    const username = await simCognitoAliasUser(setUp);
+
+    // When the user signs in with its address.
+    const signedIn = await setUp.cognito.initiateAuth(
+      new InitiateAuthCommand({
+        ClientId: setUp.clientId,
+        AuthFlow: "USER_PASSWORD_AUTH",
+        AuthParameters: {
+          USERNAME: simCognitoAliasEmail,
+          PASSWORD: simCognitoAliasPassword,
+        },
+      }),
+    );
+
+    // Then the tokens name the generated username rather than the address, so
+    // an application storing what it reads there stores what a deployment
+    // would have given it.
+    assertNonNullable(signedIn.AuthenticationResult?.IdToken);
+    assertNonNullable(signedIn.AuthenticationResult.AccessToken);
+
+    const idClaims = tokenClaims(signedIn.AuthenticationResult.IdToken);
+    const accessClaims = tokenClaims(signedIn.AuthenticationResult.AccessToken);
+
+    assertIdentical(idClaims["cognito:username"], username);
+    assertIdentical(accessClaims["username"], username);
+
+    // And the address is on the id token as the email claim, which is where
+    // an application reads it from.
+    assertIdentical(idClaims["email"], simCognitoAliasEmail);
+  });
+
+  it("gives an admin-created user a generated username too", async () => {
+    // Given a pool that signs its users in by email.
+    const { cognito, userPoolId } = await simCognitoAliasPool();
+
+    // When an administrator creates a user with an address as the username.
+    const created = await cognito.adminCreateUser(
+      new AdminCreateUserCommand({
+        UserPoolId: userPoolId,
+        Username: "bob@example.com",
+        TemporaryPassword: simCognitoAliasPassword,
+      }),
+    );
+
+    // Then that user was stored under a generated username as well, with the
+    // address as its email attribute.
+    assertNonNullable(created.User?.Username);
+    assertUuidV4(created.User.Username);
+    assertIdentical(
+      attributeOf(created.User.Attributes, "email"),
+      "bob@example.com",
+    );
+  });
+
+  it("keeps a signed-up address as the email attribute the request set", async () => {
+    // Given a pool that signs its users in by email.
+    const { cognito, userPoolId } = await simCognitoAliasPool();
+
+    // When a user is created naming the same address twice, as an application
+    // that always sends its attributes does.
+    const created = await cognito.adminCreateUser(
+      new AdminCreateUserCommand({
+        UserPoolId: userPoolId,
+        Username: simCognitoAliasEmail,
+        TemporaryPassword: simCognitoAliasPassword,
+        UserAttributes: [
+          { Name: "email", Value: simCognitoAliasEmail },
+          { Name: "email_verified", Value: "true" },
+        ],
+      }),
+    );
+
+    // Then the attributes the request set are the user's, rather than the
+    // address being written over them.
+    assertNonNullable(created.User?.Username);
+    assertIdentical(
+      attributeOf(created.User.Attributes, "email"),
+      simCognitoAliasEmail,
+    );
+    assertIdentical(
+      attributeOf(created.User.Attributes, "email_verified"),
+      "true",
+    );
+  });
+
+  it("reports what the pool signs users in by, and keeps it through an update", async () => {
+    // Given a pool that signs its users in by phone number.
+    const { cognito, userPoolId } = await simCognitoAliasPool({
+      usernameAttributes: ["phone_number"],
+    });
+
+    // When the pool is described, and then updated without saying anything
+    // about it.
+    const described = await cognito.describeUserPool(
+      new DescribeUserPoolCommand({ UserPoolId: userPoolId }),
+    );
+
+    await cognito.updateUserPool(
+      new UpdateUserPoolCommand({
+        UserPoolId: userPoolId,
+        DeletionProtection: "INACTIVE",
+      }),
+    );
+
+    const updated = await cognito.describeUserPool(
+      new DescribeUserPoolCommand({ UserPoolId: userPoolId }),
+    );
+
+    // Then both report it. What a pool signs its users in by is fixed when
+    // the pool is created, so an update that replaces every other setting
+    // leaves this one alone.
+    assertArrayEquals(described.UserPool?.UsernameAttributes, ["phone_number"]);
+    assertArrayEquals(updated.UserPool?.UsernameAttributes, ["phone_number"]);
+  });
+
+  it("signs users in by username where the pool names no attribute", async () => {
+    // Given a pool created without any, which is the default.
+    const { cognito, userPoolId } = await simCognitoAliasPool({
+      usernameAttributes: [],
+    });
+
+    // When a user is created under a username of its own.
+    const created = await cognito.adminCreateUser(
+      new AdminCreateUserCommand({
+        UserPoolId: userPoolId,
+        Username: "alice",
+        TemporaryPassword: simCognitoAliasPassword,
+      }),
+    );
+
+    // Then the username is the one the request asked for, and the pool
+    // reports no sign-in attributes at all rather than an empty list.
+    assertIdentical(created.User?.Username, "alice");
+
+    const described = await cognito.describeUserPool(
+      new DescribeUserPoolCommand({ UserPoolId: userPoolId }),
+    );
+
+    assertUndefined(described.UserPool?.UsernameAttributes);
+  });
+});

--- a/src/service/cognito/user-pool/sim-cognito-username-attributes.ts
+++ b/src/service/cognito/user-pool/sim-cognito-username-attributes.ts
@@ -1,0 +1,198 @@
+import { randomUUID } from "node:crypto";
+import { SimCognitoInvalidParameterException } from "../error/sim-cognito.error.js";
+import { SimCognitoSignInAttribute } from "./sim-cognito-sign-in-attribute.js";
+import type { SimCognitoAttributeType } from "./user/sim-cognito-user-attributes.js";
+import {
+  requireSimCognitoUsername,
+  type SimCognitoUsername,
+} from "./user/sim-cognito-username.js";
+
+/**
+ * What a new user of a pool is stored as: the username it is keyed by, and
+ * the attributes it starts with.
+ */
+export interface SimCognitoNewUserIdentity {
+  readonly username: SimCognitoUsername;
+  readonly attributes: readonly SimCognitoAttributeType[] | undefined;
+}
+
+/**
+ * The attributes a pool signs its users in by, from its `UsernameAttributes`.
+ *
+ * A pool created without any is signed in by username, and a request naming a
+ * user names the username it was created with. A pool created with them works
+ * the other way round: the caller signs in by email or by phone number, and
+ * the username is a UUID Cognito generates that no caller ever chose. That is
+ * what an application built against such a pool sees in `cognito:username` and
+ * in `AdminGetUser`, so it is what this simulation stores.
+ *
+ * The address itself stays reachable. It goes into the attribute the pool
+ * signs in by, and a request naming a user by that address resolves the same
+ * user, which is the alias resolution real Cognito does for its admin
+ * operations and its sign-ins.
+ */
+export class SimCognitoUsernameAttributes {
+  private readonly attributes: readonly SimCognitoSignInAttribute[];
+
+  constructor(requested?: readonly string[]) {
+    this.attributes = (requested ?? []).map(
+      (name) => new SimCognitoSignInAttribute(name),
+    );
+  }
+
+  /**
+   * The attribute a new user's own value goes into, alongside the attributes
+   * the request asked for.
+   *
+   * A request that set the attribute itself keeps its own value, as long as
+   * it is the one the username says. The two naming different accounts is
+   * refused rather than resolved in favour of either, because real Cognito
+   * signs the user in by only one of them and code written against the other
+   * would look up a user that is not there.
+   */
+  private static withSignInValue(
+    attribute: SimCognitoSignInAttribute,
+    value: string,
+    attributes: readonly SimCognitoAttributeType[] | undefined,
+  ): readonly SimCognitoAttributeType[] {
+    const requested = attributes ?? [];
+    const given = requested.find((entry) => entry.Name === attribute.name);
+
+    if (given === undefined) {
+      return [...requested, { Name: attribute.name, Value: value }];
+    }
+
+    if (given.Value !== value) {
+      throw new SimCognitoInvalidParameterException(
+        `Username '${value}' and the ${attribute.name} attribute ` +
+          `'${String(given.Value)}' name different accounts: a pool that ` +
+          `signs users in by ${attribute.name} takes the username as that ` +
+          `attribute's value`,
+      );
+    }
+
+    return requested;
+  }
+
+  /**
+   * Whether the pool signs users in by username, which is the default.
+   */
+  get isEmpty(): boolean {
+    return this.attributes.length === 0;
+  }
+
+  /**
+   * The attribute names, as the request gave them.
+   */
+  get names(): readonly string[] {
+    return this.attributes.map((attribute) => attribute.name);
+  }
+
+  /**
+   * These attributes as a described pool reports them, or nothing where the
+   * pool signs users in by username.
+   */
+  toOutput(): readonly string[] | undefined {
+    if (this.isEmpty) {
+      return undefined;
+    }
+
+    return this.names;
+  }
+
+  /**
+   * The username and attributes a user being created is stored with.
+   *
+   * A pool signing users in by username stores what the request asked for. A
+   * pool signing them in by an attribute stores a generated UUID instead, and
+   * puts the value the request called the username into the attribute it
+   * signs in by, which is what real Cognito does with it.
+   */
+  identify(
+    requested: SimCognitoUsername,
+    attributes: readonly SimCognitoAttributeType[] | undefined,
+  ): SimCognitoNewUserIdentity {
+    if (this.isEmpty) {
+      return { username: requested, attributes };
+    }
+
+    const attribute = this.requireSignInAttribute(requested);
+
+    return {
+      username: requireSimCognitoUsername(randomUUID()),
+      attributes: SimCognitoUsernameAttributes.withSignInValue(
+        attribute,
+        requested,
+        attributes,
+      ),
+    };
+  }
+
+  /**
+   * The values a user can be signed in by, by the attribute each is held in.
+   *
+   * A user missing the attribute has no value for it, which is how a
+   * federated user reaches a pool that signs its own users in by email: the
+   * provider's mapping may not carry one.
+   */
+  signInValues(
+    attributes: ReadonlyMap<string, string>,
+  ): ReadonlyMap<string, string> {
+    const values = new Map<string, string>();
+
+    for (const attribute of this.attributes) {
+      const value = attributes.get(attribute.name);
+
+      if (value !== undefined) {
+        values.set(attribute.name, value);
+      }
+    }
+
+    return values;
+  }
+
+  /**
+   * Whether a user holding these attributes is the one a value names.
+   */
+  matches(attributes: ReadonlyMap<string, string>, value: string): boolean {
+    return this.attributes.some(
+      (attribute) => attributes.get(attribute.name) === value,
+    );
+  }
+
+  /**
+   * The attribute a username fills, or a refusal saying what the pool signs
+   * users in by.
+   *
+   * Real Cognito refuses a username of the wrong form here rather than
+   * creating a user nobody could sign in as.
+   */
+  private requireSignInAttribute(username: string): SimCognitoSignInAttribute {
+    const attribute = this.attributes.find((candidate) =>
+      candidate.holds(username),
+    );
+
+    if (attribute === undefined) {
+      throw new SimCognitoInvalidParameterException(
+        `Username should be ${this.describeForms()}.`,
+      );
+    }
+
+    return attribute;
+  }
+
+  /**
+   * How a refusal describes what this pool's usernames have to look like.
+   */
+  private describeForms(): string {
+    const descriptions = this.attributes.map(
+      (attribute) => attribute.description,
+    );
+
+    if (descriptions.length > 1) {
+      return `either ${descriptions.join(" or ")}`;
+    }
+
+    return descriptions.join(" or ");
+  }
+}

--- a/src/service/cognito/user-pool/user/sim-cognito-user-store.ts
+++ b/src/service/cognito/user-pool/user/sim-cognito-user-store.ts
@@ -2,6 +2,7 @@ import {
   SimCognitoUsernameExistsException,
   SimCognitoUserNotFoundException,
 } from "../../error/sim-cognito.error.js";
+import type { SimCognitoUsernameAttributes } from "../sim-cognito-username-attributes.js";
 import type { SimCognitoUser } from "./sim-cognito-user.js";
 import type { SimCognitoUsername } from "./sim-cognito-username.js";
 
@@ -11,9 +12,21 @@ import type { SimCognitoUsername } from "./sim-cognito-username.js";
  * Users are keyed by username, which is what every admin operation names one
  * by. Usernames are case sensitive here, as they are on a pool created without
  * a `UsernameConfiguration`, which this simulation refuses.
+ *
+ * A pool that signs its users in by an attribute keys them by the UUID
+ * username Cognito generated, and reaches them by that attribute's value as
+ * well: real Cognito resolves the alias for its admin operations and its
+ * sign-ins, so a request naming a user by its email finds the same user a
+ * request naming the UUID finds. What a pool signs users in by is fixed when
+ * the pool is created, which is why this is settled once here.
  */
 export class SimCognitoUserStore {
   private readonly users = new Map<string, SimCognitoUser>();
+  private readonly signInBy: SimCognitoUsernameAttributes;
+
+  constructor(signInBy: SimCognitoUsernameAttributes) {
+    this.signInBy = signInBy;
+  }
 
   /**
    * Every user in this pool, in creation order.
@@ -31,6 +44,11 @@ export class SimCognitoUserStore {
 
   /**
    * Store a newly created user, refusing a username the pool already holds.
+   *
+   * A pool signing users in by an attribute refuses a second user holding a
+   * value another user signs in by too. That value identifies the account
+   * there, so allowing two would leave a sign-in naming an account this pool
+   * has two of.
    */
   add(user: SimCognitoUser): void {
     if (this.users.has(user.username)) {
@@ -39,6 +57,7 @@ export class SimCognitoUserStore {
       );
     }
 
+    this.requireSignInValuesFree(user);
     this.users.set(user.username, user);
   }
 
@@ -50,10 +69,10 @@ export class SimCognitoUserStore {
   }
 
   /**
-   * Find a user by username.
+   * Find a user by username, or by a value the pool signs users in by.
    */
   find(username: string): SimCognitoUser | undefined {
-    return this.users.get(username);
+    return this.users.get(username) ?? this.findBySignInValue(username);
   }
 
   /**
@@ -67,6 +86,35 @@ export class SimCognitoUserStore {
     }
 
     return found;
+  }
+
+  /**
+   * Find the user signing in by a value, where the pool signs users in by an
+   * attribute at all.
+   */
+  private findBySignInValue(value: string): SimCognitoUser | undefined {
+    if (this.signInBy.isEmpty) {
+      return undefined;
+    }
+
+    return this.all.find((user) =>
+      this.signInBy.matches(user.attributeValues, value),
+    );
+  }
+
+  /**
+   * Refuse a user signing in by a value another user already signs in by.
+   */
+  private requireSignInValuesFree(user: SimCognitoUser): void {
+    for (const [name, value] of this.signInBy.signInValues(
+      user.attributeValues,
+    )) {
+      if (this.findBySignInValue(value) !== undefined) {
+        throw new SimCognitoUsernameExistsException(
+          `An account with the given ${name} already exists.`,
+        );
+      }
+    }
   }
 
   /**

--- a/test/cognito/sign-in-alias-fixture.ts
+++ b/test/cognito/sign-in-alias-fixture.ts
@@ -1,0 +1,153 @@
+/**
+ * The arrangement the sign-in-by-attribute test files share: a pool created
+ * with `UsernameAttributes`, an app client, and a confirmed user signed up by
+ * its email address.
+ *
+ * It lives under `test/` for the same reasons as `test/cognito/cfn-deploy.ts`:
+ * a test file cannot export helpers alongside its own `describe` calls, and
+ * `test/**` is type-checked with everything else and excluded from the
+ * published build.
+ */
+
+import type {
+  ExplicitAuthFlowsType,
+  UsernameAttributeType,
+} from "@aws-sdk/client-cognito-identity-provider";
+import {
+  AdminConfirmSignUpCommand,
+  AdminGetUserCommand,
+  CreateUserPoolClientCommand,
+  CreateUserPoolCommand,
+  SignUpCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import { assertNonNullable } from "@kensio/smartass";
+
+import { SimAws } from "../../src/service/aws/sim-aws.js";
+import type { SimCognitoIdentityProvider } from "../../src/service/cognito/index.js";
+import { simCognitoSecretHash } from "../../src/service/cognito/user-pool/auth/sim-cognito-secret-hash.js";
+
+/**
+ * The password the users in these tests sign in with.
+ */
+export const simCognitoAliasPassword = "Sup3rSecret!";
+
+/**
+ * The address the user in these tests signs in by.
+ */
+export const simCognitoAliasEmail = "alice@example.com";
+
+export interface SimCognitoAliasPoolSetUp {
+  readonly cognito: SimCognitoIdentityProvider;
+  readonly userPoolId: string;
+  readonly clientId: string;
+
+  /** The app client's secret, for a pool asked for a confidential client. */
+  readonly clientSecret: string | undefined;
+}
+
+export interface SimCognitoAliasPoolOptions {
+  /** What the pool signs its users in by, its email address by default. */
+  readonly usernameAttributes?: readonly UsernameAttributeType[];
+
+  /** Whether the app client holds a secret, which it does not by default. */
+  readonly generateSecret?: boolean;
+
+  /** The flows the app client allows, the password and refresh ones by default. */
+  readonly authFlows?: ExplicitAuthFlowsType[];
+}
+
+/**
+ * A pool that signs its users in by an attribute, with an app client.
+ */
+export async function simCognitoAliasPool(
+  options: SimCognitoAliasPoolOptions = {},
+): Promise<SimCognitoAliasPoolSetUp> {
+  const cognito = new SimAws().cognitoIdentityProvider();
+  const pool = await cognito.createUserPool(
+    new CreateUserPoolCommand({
+      PoolName: "myapp-users",
+      UsernameAttributes: [...(options.usernameAttributes ?? ["email"])],
+    }),
+  );
+
+  assertNonNullable(pool.UserPool?.Id);
+
+  const client = await cognito.createUserPoolClient(
+    new CreateUserPoolClientCommand({
+      UserPoolId: pool.UserPool.Id,
+      ClientName: "web",
+      GenerateSecret: options.generateSecret,
+      ExplicitAuthFlows: options.authFlows ?? [
+        "ALLOW_USER_PASSWORD_AUTH",
+        "ALLOW_REFRESH_TOKEN_AUTH",
+      ],
+    }),
+  );
+
+  assertNonNullable(client.UserPoolClient?.ClientId);
+
+  return {
+    cognito,
+    userPoolId: pool.UserPool.Id,
+    clientId: client.UserPoolClient.ClientId,
+    clientSecret: client.UserPoolClient.ClientSecret,
+  };
+}
+
+/**
+ * The `SECRET_HASH` a request naming a value has to carry, or nothing where
+ * the app client holds no secret.
+ */
+export function simCognitoAliasSecretHash(
+  setUp: SimCognitoAliasPoolSetUp,
+  username: string,
+): string | undefined {
+  const { clientId, clientSecret } = setUp;
+
+  if (clientSecret === undefined) {
+    return undefined;
+  }
+
+  return simCognitoSecretHash(username, clientId, clientSecret);
+}
+
+/**
+ * Sign a user up by an address and confirm it, answering with the username
+ * the pool generated for it.
+ *
+ * The username is read back through `AdminGetUser`, which is the operation an
+ * application would find it with, and which resolves the address to the user
+ * on the way.
+ */
+export async function simCognitoAliasUser(
+  setUp: SimCognitoAliasPoolSetUp,
+  address: string = simCognitoAliasEmail,
+): Promise<string> {
+  const { cognito, userPoolId, clientId } = setUp;
+
+  await cognito.signUp(
+    new SignUpCommand({
+      ClientId: clientId,
+      Username: address,
+      Password: simCognitoAliasPassword,
+      // The hash covers the username the request carries, which is the
+      // address here rather than the username the pool goes on to generate.
+      SecretHash: simCognitoAliasSecretHash(setUp, address),
+    }),
+  );
+
+  await cognito.adminConfirmSignUp(
+    new AdminConfirmSignUpCommand({
+      UserPoolId: userPoolId,
+      Username: address,
+    }),
+  );
+
+  const found = await cognito.adminGetUser(
+    new AdminGetUserCommand({ UserPoolId: userPoolId, Username: address }),
+  );
+
+  assertNonNullable(found.Username);
+
+  return found.Username;
+}


### PR DESCRIPTION
A pool created with `UsernameAttributes` now stores the generated UUID username real Cognito stores, and puts the address the request called the username into the attribute the pool signs in by, so `AdminGetUser` and the `cognito:username` claim report what a deployment would have given them rather than the address. Requests naming a user by that address still reach it, because the user store resolves the value the way real Cognito resolves an alias for its admin operations and its sign-ins, and a `SECRET_HASH` goes on covering the value each request carries, which means a `REFRESH_TOKEN_AUTH` request needs one computed over the generated username. `CreateUserPool` no longer refuses the input, and the `AWS::Cognito::UserPool` property is deployed, so a CDK pool built with `signInAliases: { email: true }` identifies its users here the way the deployed one does. Two refusals come with it, both because the address would otherwise name an account the pool has two of: a second user signing in by an address another user holds is refused, on creation and on `AdminUpdateUserAttributes`, and a request naming one address as the username and a different one as the attribute is refused rather than one of them silently winning. `AliasAttributes` stays refused, because it is a different thing: the username there is still the one the caller chose.

Resolves https://github.com/KensioSoftware/yulin/issues/636

- [x] Conventional commit message, used as the title

- [ ] Conventional branch name, like `feat/concise-description`
- [x] Full check with `pnpm run check` passed
- [ ] Rebased off latest main
- [x] User-facing behaviour is documented in `docs/`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for Cognito email- and phone-based sign-in pools.
  - Users can sign up and sign in using configured email or phone attributes while receiving generated usernames.
  - Added lookup by sign-in attribute and duplicate-value validation.
  - Preserved sign-in settings during pool updates and exposed them in pool descriptions.
  - Added clear errors for conflicting sign-in attributes and unsupported configuration changes.

- **Documentation**
  - Expanded Cognito documentation with configuration behavior, limitations, secret-hash handling, and examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->