### PR TITLE
docs: plain prose in four service READMEs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,6 @@
 Brief, concise description of the change:
 
-<!-- One paragraph of prose, no headings or bullet lists. CodeRabbit will fill
-     in a more detailed description once this is open. -->
+<!-- CodeRabbit will fill in a more detailed description once this is open. -->
 
 <!-- If there is an issue, link it here:
      Resolves https://github.com/KensioSoftware/yulin/issues/N -->

--- a/docs/services/apigatewayv2/README.md
+++ b/docs/services/apigatewayv2/README.md
@@ -1,11 +1,11 @@
 # Simulated API Gateway HTTP APIs
 
 Yulin includes a simulated API Gateway v2 service, reachable as `simAws.apiGatewayV2()`. It covers
-HTTP APIs with a Lambda proxy integration, so a handler that runs behind an HTTP API can be tested
-against a real HTTP request rather than against a hand-built event.
+HTTP APIs with a Lambda proxy integration. A handler that runs behind an HTTP API can be tested
+against a real HTTP request, with no hand-built event to keep in step.
 
-WebSocket APIs are not simulated, and neither are REST APIs, which are the older API Gateway v1
-service and a separate SDK client.
+This is HTTP APIs only. WebSocket APIs and REST APIs (the older API Gateway v1 service, on a
+separate SDK client) are outside it.
 
 ## Creating an API
 
@@ -46,20 +46,20 @@ The endpoint names the API id and the region, as a real one does:
 https://a1b2c3d4e5.execute-api.eu-west-1.amazonaws.com
 ```
 
-A name is not an identity here, as it is not on real AWS. Two APIs in one Account and Region may
-share a name, and only the id tells them apart.
+A name is a label here, as it is on real AWS. Two APIs in one Account and Region may share a name,
+and only the id tells them apart.
 
 ## Routing requests to a Lambda function
 
 An API needs three more resources before it serves anything: an integration naming the function, a
 route pointing at that integration, and a stage to serve it from. The function also has to allow API
-Gateway to invoke it, which is a permission on the function rather than anything on the API. See
+Gateway to invoke it. That grant is a permission on the function, not on the API. See
 [Granting the API permission to invoke the function](#granting-the-api-permission-to-invoke-the-function).
 Once all of that exists, `serveSimAws` answers requests to the generated endpoint by invoking the
 function.
 
-Pass the API endpoint through `srv.localUrl(...)`, which keeps the endpoint's hostname but sends the
-request to the local server, in the same way it adapts simulated S3 website and Lambda Function URL
+Pass the API endpoint through `srv.localUrl(...)`. It keeps the endpoint's hostname and sends the
+request to the local server, the way it adapts simulated S3 website and Lambda Function URL
 endpoints.
 
 ```typescript sim-apigatewayv2-lambda-proxy
@@ -146,23 +146,23 @@ console.log(await response.text());
 await srv.close();
 ```
 
-The `$default` route matches any method and path, so every request to the endpoint reaches the
+The `$default` route matches any method and path. Every request to the endpoint reaches the
 function. The integration URI is the function's ARN, and the function may be in another Account or
-Region: it is looked up where its ARN says it is.
+Region. It is looked up where its ARN says it is.
 
 ## Granting the API permission to invoke the function
 
-A Lambda proxy integration does not work until the function's resource policy allows
-`apigateway.amazonaws.com` to invoke it. The console adds that permission for you; an integration
-created through CloudFormation, the CLI or an SDK does not, which is what `AddPermissionCommand` in
-the example above is for. Without it the request is answered with a 500 and
-`{"message":"Internal Server Error"}`, and the handler does not run. CDK's
-`HttpLambdaIntegration` emits the same grant as an `AWS::Lambda::Permission`.
+A Lambda proxy integration works once the function's resource policy allows
+`apigateway.amazonaws.com` to invoke it. The console adds that permission for you. An integration
+created through CloudFormation, the CLI or an SDK leaves it to you. That is what
+`AddPermissionCommand` in the example above does. Without it the request is answered with a 500 and
+`{"message":"Internal Server Error"}`, and the handler never runs. CDK's `HttpLambdaIntegration`
+emits the same grant as an `AWS::Lambda::Permission`.
 
 Each request is authorized as `lambda:InvokeFunction` on the function ARN, with the caller being the
-service principal `apigateway.amazonaws.com`. The function's own resource policy is what decides: a
-service principal has no identity policies of its own. The route that matched is supplied as
-`AWS:SourceArn`, so a permission may be granted for one route and not another:
+service principal `apigateway.amazonaws.com`. The function's own resource policy is the whole
+decision. A service principal has no identity policies of its own. The route that matched is supplied
+as `AWS:SourceArn`. A permission may be granted for one route and withheld from another:
 
 ```text
 arn:aws:execute-api:<region>:<account>:<apiId>/<stage>/<METHOD>/<route path>
@@ -170,29 +170,28 @@ arn:aws:execute-api:<region>:<account>:<apiId>/<stage>/<METHOD>/<route path>
 
 - The Account and Region are the API's, not the function's.
 - The stage is the one that served the request, so `$default` for the default stage.
-- The method is the request's own, so a `GET` reaching a route keyed `ANY /orders` gives `GET`.
-- The path is the matched route key's template with its parameter braces intact, so a request to
+- The method is the request's own. A `GET` reaching a route keyed `ANY /orders` gives `GET`.
+- The path is the matched route key's template with its parameter braces intact. A request to
   `/orders/42` on the route `GET /orders/{orderId}` gives `orders/{orderId}`. A `SourceArn` is
-  written against route keys rather than against paths, and IAM treats a brace as an ordinary
-  character.
+  written against route keys, and IAM treats a brace as an ordinary character.
 - The `$default` route has no method and no path of its own, so both collapse into one `$default`
   segment: `<apiId>/<stage>/$default`.
 
-A `SourceArn` may wildcard any part of that, which is what the usual grant does:
-`<apiId>/*/*` allows every route of the API on every stage.
+A `SourceArn` may wildcard any part of that, and the usual grant does. `<apiId>/*/*` allows every
+route of the API on every stage.
 
-The API's own Account is supplied as `AWS:SourceAccount`, so a permission carrying a `SourceAccount`
+The API's own Account is supplied as `AWS:SourceAccount`. A permission carrying a `SourceAccount`
 matches when it names the Account the API belongs to. That is the Account the source ARN names, not
-the one owning the function, which matters for an integration reaching across Accounts. CDK writes
-both keys for some grants, and a permission carrying either or both is evaluated on what it says.
+the one owning the function, and the difference shows up on an integration reaching across Accounts.
+CDK writes both keys for some grants, and a permission carrying either or both is evaluated on what
+it says.
 
 `AWS:SourceArn` and `AWS:SourceAccount` are the only condition keys supplied here. A permission that
-also carries `PrincipalOrgID` or `InvokedViaFunctionUrl` never matches, since nothing gives those
-keys a value at request time, so the request is refused with the same 500.
+also carries `PrincipalOrgID` or `InvokedViaFunctionUrl` never matches, since those keys have no
+value at request time. The request is refused with the same 500.
 
-Neither the method nor the path is documented by AWS as the value API Gateway supplies. Both are
-inferred from the permission patterns AWS and CDK write, which is recorded next to the code that
-builds the ARN.
+AWS documents neither the method nor the path as the value API Gateway supplies. Both are inferred
+from the permission patterns AWS and CDK write. The code that builds the ARN records that.
 
 ## Route keys
 
@@ -217,16 +216,16 @@ A path is made of three kinds of segment:
   last segment, and it needs at least one segment to match, so `GET /pets/{proxy+}` matches
   `/pets/cat/1` but not `/pets`.
 
-A route key that cannot be read is refused by `CreateRoute` with a `BadRequestException`, which is
-where real API Gateway refuses it too. That covers a lower-case method, an unbalanced brace, and a
-greedy parameter anywhere but the end.
+A route key that cannot be read is refused by `CreateRoute` with a `BadRequestException`, the same
+place real API Gateway refuses it. That covers a lower-case method, an unbalanced brace, and a greedy
+parameter anywhere but the end.
 
-A parameter name is not part of a route's identity, so `GET /pets/{id}` and `GET /pets/{petId}` are
-the same route key and creating the second gives a `ConflictException`.
+A parameter name falls outside a route's identity, so `GET /pets/{id}` and `GET /pets/{petId}` are
+the same route key, and creating the second gives a `ConflictException`.
 
 One path may not name the same parameter twice, so `GET /pets/{id}/toys/{id}` is refused. A handler
-reads path parameters off one object, so only one of the two captures could arrive. Whether real API
-Gateway refuses it is not established, so this is stricter than AWS rather than known to match it.
+reads path parameters off one object, and only one of the two captures could arrive. Whether real API
+Gateway refuses it too is unestablished. This is stricter than AWS is known to be.
 
 ## Which route serves a request
 
@@ -240,7 +239,7 @@ More than one route may match a request, and the most specific one takes it. In 
    prefix win between two greedy routes, so `GET /pets/dog/{proxy+}` takes `/pets/dog/collars/1`
    ahead of `GET /pets/{proxy+}`.
 
-AWS's worked example, which is encoded as a test here:
+AWS's worked example, encoded as a test here:
 
 | Request           | Route selected       |
 | ----------------- | -------------------- |
@@ -252,19 +251,19 @@ AWS's worked example, which is encoded as a test here:
 from the routes `GET /pets/dog/1`, `GET /pets/dog/{id}`, `GET /pets/{proxy+}`, `ANY /{proxy+}` and
 `$default`.
 
-Rule 1 is documented by AWS, as is the literal-beating-parameter part of rule 3. Rule 2, the
-longest-literal-prefix part of rule 3, and the place of the method comparison above the path
-comparison rather than below it, are observed rather than documented. Each is marked in the code next
-to the rule it governs.
+Rule 1 is documented by AWS, as is the literal-beating-parameter part of rule 3. Three things here
+are observed rather than documented: rule 2, the longest-literal-prefix part of rule 3, and the
+placement of the method comparison above the path comparison. Each is marked in the code next to the
+rule it governs.
 
-A request whose path matches a route but whose method does not simply matches nothing. An API with no
+A request whose path matches a route with a different method matches no route at all. An API with no
 `ANY` route, no greedy route and no `$default` route to catch it answers 404, not 405.
 
 ## Path parameters and named stages
 
 What a route captured reaches the handler as `event.pathParameters`. A named stage is served under
-its own path segment, and stage selection runs before route selection, so the routes never see the
-stage name.
+its own path segment. Stage selection runs before route selection, and the routes never see the stage
+name.
 
 ```typescript sim-apigatewayv2-routes
 /**
@@ -361,7 +360,7 @@ console.log(await response.json());
 await srv.close();
 ```
 
-That handler reports four fields of its event, so the response body it produces is:
+That handler reports four fields of its event. The response body it produces is:
 
 ```json
 {
@@ -372,16 +371,16 @@ That handler reports four fields of its event, so the response body it produces 
 }
 ```
 
-`rawPath` and `requestContext.http.path` keep the stage segment, while `routeKey` and
-`pathParameters` come from the path the routes matched, which is `/pets/6`. The stage prefix in the
-path is corroborated by the documented `$context.path` access log variable, "the request path, for
-example `/{stage}/root/child`", rather than by the payload format page.
+`rawPath` and `requestContext.http.path` keep the stage segment. `routeKey` and `pathParameters` come
+from the path the routes matched, `/pets/6`. The stage prefix in the path is corroborated by the
+documented `$context.path` access log variable ("the request path, for example
+`/{stage}/root/child`"). The payload format page says nothing about it.
 
 A stage name is `$default`, or up to 128 alphanumerics, hyphens and underscores. The `$default` stage
-is served at the root of the endpoint instead of under a name, and both kinds can exist on one API at
-once. An explicit stage match wins over any route match: with a `$default` stage and a stage named
-`pets`, a request for `/pets/dog` is served by the stage `pets` on the route path `/dog`. A request
-reaching an API with no stage for it, and no `$default` stage, is a 404.
+is served at the root of the endpoint, and a named stage under its own segment. Both kinds can exist
+on one API at once. An explicit stage match wins over any route match. With a `$default` stage and a
+stage named `pets`, a request for `/pets/dog` is served by the stage `pets` on the route path `/dog`.
+A request reaching an API with no stage for it, and no `$default` stage, is a 404.
 
 `pathParameters` is left out of the event entirely when the matched route captured nothing, including
 on a `$default` match. `StageVariables` set on the stage arrive as `event.stageVariables`, and are
@@ -393,9 +392,9 @@ A JWT authorizer verifies a signed token before the integration is invoked. `Cre
 creates one, and a route asks for it with `AuthorizationType: "JWT"` and the authorizer's id.
 
 The issuer is a URL. Point it at a [simulated Cognito user pool](../cognito/ "Simulated Cognito docs")
-and the pool's own signing key verifies the token, so a token from
-`InitiateAuthCommand` or `AdminInitiateAuthCommand` reaches the route and nothing else does. The
-audience is the app client ids the authorizer admits.
+and the pool's own signing key verifies the token. A token from `InitiateAuthCommand` or
+`AdminInitiateAuthCommand` reaches the route, and anything else is turned away. The audience is the
+app client ids the authorizer admits.
 
 ```typescript sim-apigatewayv2-jwt-authorizer
 /**
@@ -561,34 +560,32 @@ await srv.close();
 ```
 
 The verification is real. The token is parsed, its `alg` has to be `RS256`, its `kid` has to name a
-key the issuer publishes, and the signature is checked against that key with `node:crypto`. Nothing
-is fetched over the network, and no verification library is involved.
+key the issuer publishes, and the signature is checked against that key with `node:crypto`. The whole
+check runs in process, with no network fetch and no verification library.
 
 ### What a refused request gets back
 
 A token that is missing, unreadable, signed with an unsupported algorithm, signed by an unknown key,
-or carrying a claim that does not hold is answered with a 401, `{"message":"Unauthorized"}` and a
-`www-authenticate: Bearer` header. The integration is never invoked. The client is told nothing about
-which check failed, which is what real API Gateway does, except for an audience that does not match:
-that one carries `error_description="the token does not have a valid audience"`, the one description
-AWS publishes.
+or carrying a claim that fails is answered with a 401, `{"message":"Unauthorized"}` and a
+`www-authenticate: Bearer` header. The integration is never invoked. Which check failed stays
+undisclosed, here and on real API Gateway. A mismatched audience is the exception. That one carries
+`error_description="the token does not have a valid audience"`, the one description AWS publishes.
 
 The claims are checked in the order AWS documents: the issuer, then the audience, then `exp`, `nbf`
 and `iat`. There is no allowance for clock skew, and every timestamp comes from the simulation's
-clock, so `simAws.clock().advanceBy(...)` expires a token that was accepted a moment before.
+clock. `simAws.clock().advanceBy(...)` expires a token that was accepted a moment before.
 
 ### Identity source
 
 `IdentitySource` takes one entry, either `$request.header.<name>` or `$request.querystring.<name>`. A
-`Bearer` prefix on the value, followed by whitespace, is stripped case-insensitively and is not
-required. Anything else is
-refused by `CreateAuthorizer`, because an authorizer looking for the token in a place nothing puts it
-refuses every request for a reason that reads like a signing problem.
+`Bearer` prefix on the value, followed by whitespace, is stripped case-insensitively and is optional.
+Anything else is refused by `CreateAuthorizer`. An authorizer looking for the token where no client
+puts it refuses every request, for a reason that reads like a signing problem.
 
 ### Route scopes, and access tokens versus ID tokens
 
 `AuthorizationScopes` on a route is checked against the token's `scope` claim, split on whitespace.
-The check is any-of: one matching scope is enough. A verified token that matches none of them is
+The check is any-of, so one matching scope is enough. A verified token matching none of them is
 answered with a 403 and `{"message":"Forbidden"}`.
 
 ```typescript
@@ -604,14 +601,14 @@ await apiGateway.createRoute(
 );
 ```
 
-An ID token passes an authorizer that configures only an audience. Nothing checks `token_use`, which
-is what real API Gateway does, and an ID token's `aud` is the app client id, so it matches. AWS
-documents this and recommends route scopes as the way to tell the two apart. A Cognito ID token has no
-`scope` claim at all, so any route scope refuses it.
+An ID token passes an authorizer that configures only an audience. `token_use` goes unchecked here, as
+it does on real API Gateway. An ID token's `aud` is the app client id, and matches. AWS documents this
+and recommends route scopes as the way to tell the two apart. A Cognito ID token has no `scope` claim
+at all, so any route scope refuses it.
 
 Sign-in through the user pool API issues one scope, `aws.cognito.signin.user.admin`, and that is the
 only scope a simulated flow can put in a token. Resource servers, custom scopes and the client
-credentials grant are not simulated, so no other route scope is satisfiable.
+credentials grant are outside the simulation. No other route scope is satisfiable.
 
 ### The claims the handler receives
 
@@ -634,9 +631,9 @@ An accepted token arrives as `event.requestContext.authorizer.jwt`:
 ```
 
 Every claim value is a string, whatever type it was signed as. A list claim such as `cognito:groups`
-is rendered the way Go prints a slice, so two groups arrive as `[Admins Readers]` rather than as JSON
-or as a comma-separated list. `scopes` is `null`, not an empty list, when the token carries no `scope`
-claim. None of that is published by AWS; all of it is what the real endpoint was observed to send.
+is rendered the way Go prints a slice, so two groups arrive as `[Admins Readers]`, and not as JSON or
+a comma-separated list. `scopes` is `null`, not an empty list, when the token carries no `scope` claim.
+AWS publishes none of that. All of it is what the real endpoint was observed to send.
 
 A route with `AuthorizationType: "NONE"` has no caller to describe, so `requestContext.authorizer` is
 left out of its events entirely.
@@ -644,11 +641,11 @@ left out of its events entirely.
 ## Protecting a route with IAM
 
 A route declared `AuthorizationType: "AWS_IAM"` reaches its integration only when the caller is
-allowed `execute-api:Invoke` on the ARN of the route being called. The route takes no authorizer, and
-naming one is refused: IAM itself is what decides.
+allowed `execute-api:Invoke` on the ARN of the route being called. IAM itself decides. The route takes
+no authorizer, and naming one is refused.
 
 The caller comes from the request, through either a SigV4 signature or an `x-sim-aws-caller` header
-naming a principal directly. A request that offers neither is anonymous, owns no policies, and is
+naming a principal directly. A request offering neither is anonymous, owns no policies, and is
 refused. See [callers of HTTP requests](../iam/#callers-of-http-requests) in the IAM docs for how that
 resolution works and how to sign a served request.
 
@@ -660,12 +657,12 @@ arn:aws:execute-api:<region>:<account>:<apiId>/<stage>/<METHOD>/<path>
 
 - The Account and Region are the API's own, not the caller's.
 - The stage is the one that served the request, so `$default` for the default stage.
-- The method is the one the client sent, upper case, so a `GET` reaching a route keyed `ANY /orders`
+- The method is the one the client sent, upper case. A `GET` reaching a route keyed `ANY /orders`
   gives `GET`.
-- The path is the request path with the stage segment and the leading slash taken off, so `/dev/orders/42`
-  served from stage `dev` gives `orders/42`. It is the path asked for rather than the route key, because
-  this is the resource a policy is written against by hand. A request to the API root gives an ARN
-  ending `/GET/`.
+- The path is the request path with the stage segment and the leading slash taken off, so
+  `/dev/orders/42` served from stage `dev` gives `orders/42`. This is the path asked for, not the route
+  key, because a policy is written against it by hand. A request to the API root gives an ARN ending
+  `/GET/`.
 
 An identity policy may wildcard any part of that. `<apiId>/*`, `<apiId>/$default/*` and
 `<apiId>/*/GET/orders/*` all allow a `GET` of `/orders/42` on the default stage.
@@ -802,13 +799,13 @@ await srv.close();
 
 ### What a refused request gets back
 
-A caller IAM does not allow is answered with a 403 and `{"message":"Forbidden"}`, and the integration
-is never invoked. That is the answer for an unsigned request too: the serving boundary resolves it to
-an anonymous caller, and nothing allows an anonymous caller anything. An explicit `Deny` beats an
-`Allow`, as it does in any IAM evaluation.
+A caller IAM refuses is answered with a 403 and `{"message":"Forbidden"}`, and the integration is
+never invoked. An unsigned request gets the same answer. The serving boundary resolves it to an
+anonymous caller, and an anonymous caller is allowed nothing. An explicit `Deny` beats an `Allow`, as
+it does in any IAM evaluation.
 
-A request whose signature is malformed, or is scoped to another service, does not reach the route at
-all. The serving boundary refuses it first, with `{"Message":"Forbidden"}` and a capital `M`.
+A request whose signature is malformed, or is scoped to another service, never reaches the route. The
+serving boundary refuses it first, with `{"Message":"Forbidden"}` and a capital `M`.
 
 ### The caller the handler receives
 
@@ -826,15 +823,15 @@ An admitted request carries its caller into the event as `requestContext.authori
 }
 ```
 
-`accountId` and `userArn` come from the resolved principal's ARN. `requestContext.accountId` is that
-Account too, rather than `anonymous`. The block is the same one a Lambda Function URL produces, so
+`accountId` and `userArn` come from the resolved principal's ARN. `requestContext.accountId` carries
+that Account too, in place of `anonymous`. The block is the same one a Lambda Function URL produces, so
 handler code reading it behaves the same behind either.
 
 ### Callers from another Account
 
 A principal of another Account is refused, whatever its own Account allows it. A cross-Account request
-needs an Allow from the resource side as well, and an HTTP API has nowhere to put one: unlike a REST
-API, it has no resource policy at all. Real AWS behaves the same way.
+needs an Allow from the resource side as well, and an HTTP API has nowhere to put one. An HTTP API has
+no resource policy at all, where a REST API does. Real AWS behaves the same way.
 
 The way through, here and on AWS, is for that principal to assume a Role in the API's Account through
 STS and sign with the session credentials. The request is then made by a principal of the API's own
@@ -986,9 +983,9 @@ console.log(await admitted.text()); // '{"tenant":"acme"}'
 await srv.close();
 ```
 
-The authorizer function is invoked once per request reaching the route. Nothing is cached between
-requests until the authorizer is given an `AuthorizerResultTtlInSeconds`, which is what AWS defaults
-to as well. See [Caching the authorizer's decision](#caching-the-authorizers-decision).
+The authorizer function is invoked once per request reaching the route. Caching starts once the
+authorizer is given an `AuthorizerResultTtlInSeconds`, and AWS defaults it off the same way. See
+[Caching the authorizer's decision](#caching-the-authorizers-decision).
 
 ### The event the authorizer receives
 
@@ -1010,20 +1007,20 @@ exported as `SimHttpApiAuthorizerEvent`:
 ```
 
 `identitySource` carries the values found at the authorizer's identity sources, in the order they were
-configured, rather than the expressions that found them. `routeArn` names the route the request
-matched, with the route key's path template rather than the path asked for, so `GET /orders/{orderId}`
-is `<apiId>/<stage>/GET/orders/{orderId}` whichever order was asked for.
+configured. The expressions that found them stay out of the event. `routeArn` names the route the
+request matched, carrying the route key's path template. `GET /orders/{orderId}` is
+`<apiId>/<stage>/GET/orders/{orderId}` whichever order was asked for.
 
-There is no `body` and no `isBase64Encoded`. AWS's published example of this event carries neither, so
-an authorizer cannot read the request body here, as it cannot on AWS.
+There is no `body` and no `isBase64Encoded`. AWS's published example of this event carries neither, and
+an authorizer cannot read the request body here or on AWS.
 
 ### Answering with a policy
 
 With `EnableSimpleResponses` left off, the function answers a `principalId` and an IAM policy
 document, and simulated IAM evaluates it for `execute-api:Invoke` against the route ARN. That is the
-same evaluation an [`AWS_IAM` route](#protecting-a-route-with-iam) goes through, with one difference:
-the returned document is the whole decision, since there is no IAM principal behind it. `principalId`
-is a name the function chose for the caller and grants nothing.
+same evaluation an [`AWS_IAM` route](#protecting-a-route-with-iam) goes through, with one difference.
+The request has no IAM principal behind it, and the returned document is the whole decision.
+`principalId` is a name the function chose for the caller, and grants no access.
 
 ```typescript
 makeLambdaZipFileInput((event: SimHttpApiAuthorizerEvent) => ({
@@ -1042,38 +1039,38 @@ makeLambdaZipFileInput((event: SimHttpApiAuthorizerEvent) => ({
 }));
 ```
 
-An explicit `Deny` beats an `Allow`, and a document allowing nothing relevant refuses the request.
+An explicit `Deny` beats an `Allow`, and a document with no relevant `Allow` refuses the request.
 
 ### What a refused request gets back
 
 - A request missing any configured identity source is a 401 and `{"message":"Unauthorized"}`, and the
   authorizer function is never invoked.
-- `isAuthorized: false`, or a policy that does not allow `execute-api:Invoke` on the route ARN, is a
-  403 and `{"message":"Forbidden"}`.
+- `isAuthorized: false`, or a policy that refuses `execute-api:Invoke` on the route ARN, is a 403 and
+  `{"message":"Forbidden"}`.
 - Returning `{ "errorMessage": "Unauthorized" }` is a 401. That is the only way an authorizer produces
   one, and it is read whichever response format the authorizer is configured for.
-- A function that throws, returns a shape neither response format matches, returns a policy document
+- A function that throws, returns a shape matching no response format, returns a policy document
   IAM cannot read, or has no invoke permission, is a 500 and `{"message":"Internal Server Error"}`.
-  The caller is told nothing further, as it is told nothing about a failed integration.
+  The caller hears no more, the way it hears no detail about a failed integration.
 
 The integration is never invoked in any of these cases.
 
 ### The authorizer's invoke permission
 
 The authorizer's function is invoked under
-`arn:aws:execute-api:<region>:<account>:<apiId>/authorizers/<authorizerId>`, which is the `SourceArn`
-AWS documents for granting API Gateway permission to invoke one. That ARN names no stage and no
-route, so it is a different grant from the integration's, and a function used for both needs both.
+`arn:aws:execute-api:<region>:<account>:<apiId>/authorizers/<authorizerId>`. That is the `SourceArn`
+AWS documents for granting API Gateway permission to invoke one. It names no stage and no route. That
+is a different grant from the integration's, and a function used for both needs both.
 
 ### Caching the authorizer's decision
 
 `AuthorizerResultTtlInSeconds` holds a decision for that many seconds, and a request presenting the
 same identity source values within it is served from that decision without the function running
-again. AWS accepts up to 3600, and 0, which is the default, holds nothing.
+again. AWS accepts up to 3600. The default, 0, holds no decision at all.
 
 The key is the identity source values and nothing else, so one decision covers every route of the API
-that uses the authorizer. Adding `$context.routeKey` as an identity source puts the route in the key,
-which is what AWS documents for caching per route.
+that uses the authorizer. Adding `$context.routeKey` as an identity source puts the route in the key.
+AWS documents that for caching per route.
 
 ```typescript sim-apigatewayv2-lambda-authorizer-cache
 /**
@@ -1212,17 +1209,18 @@ await srv.close();
 ```
 
 A refusal is held the same way an admission is, so a session the authorizer rejected stays rejected
-until the TTL expires. What is not held is an authorizer that could not answer at all: a function that
+until the TTL expires. An authorizer that could not answer at all is the exception. A function that
 threw, or replied in neither format, is asked again on the next request.
 
-Expiry is checked against the simulation's clock, so `simAws.clock().advanceBy(...)` expires a
-decision that was being reused a moment before, and no test has to wait.
+Expiry is checked against the simulation's clock. `simAws.clock().advanceBy(...)` expires a decision
+that was being reused a moment before, and no test has to wait.
 
 ### The context the handler receives
 
 The `context` the authorizer returned arrives as `event.requestContext.authorizer.lambda`, with its
-values as the function returned them rather than stringified. An authorizer that allowed the request
-and returned no context leaves `null` there, so the block still says which kind of authorizer ran.
+values as the function returned them and no stringifying on the way. An authorizer that allowed the
+request and returned no context leaves `null` there, and the block still says which kind of authorizer
+ran.
 
 ## The event the handler receives
 
@@ -1260,17 +1258,17 @@ The handler is invoked with the API Gateway HTTP API payload format 2.0 event, e
 }
 ```
 
-A field with nothing in it is left out rather than set to null, which is what real API Gateway does:
-`cookies`, `queryStringParameters`, `body`, `pathParameters` and `stageVariables` are absent when the
-request has nothing for them. `rawQueryString` is the exception and is always present, as an empty
-string when there was no query.
+An empty field is left out of the event, as real API Gateway leaves it out. `cookies`,
+`queryStringParameters`, `body`, `pathParameters` and `stageVariables` are absent when the request has
+nothing for them. `rawQueryString` is the exception and is always present, as an empty string when
+there was no query.
 
-Repeated query parameters are joined with commas, cookies travel in `cookies` rather than in a
-`cookie` header, and a body is passed through as text for a text content type and base64-encoded
-otherwise, with `isBase64Encoded` saying which happened.
+Repeated query parameters are joined with commas. Cookies travel in `cookies`, with no `cookie`
+header. A body is passed through as text for a text content type and base64-encoded otherwise, with
+`isBase64Encoded` saying which happened.
 
-The headers API Gateway sets itself replace whatever the client sent under those names: `host` is the
-API's own hostname rather than the localhost one the request arrived at, `x-forwarded-proto` is
+The headers API Gateway sets itself replace whatever the client sent under those names. `host` is the
+API's own hostname, in place of the localhost one the request arrived at. `x-forwarded-proto` is
 `https`, `x-forwarded-port` is `443`, `x-forwarded-for` and `requestContext.http.sourceIp` are
 `127.0.0.1`, and `x-amzn-trace-id` carries an X-Ray-shaped id that no trace exists for.
 
@@ -1322,8 +1320,8 @@ console.log(ordersHandler(order));
 The defaults describe an unauthorized `GET /` reaching the API's default stage, down to the headers
 API Gateway sets itself. The route key and the request agree whichever a test gives: an event for
 `rawPath: "/orders"` is one for the `GET /orders` route, and an event for `routeKey: "POST /orders"`
-is a POST to `/orders`. A route key whose path is a template captures nothing on its own, so an
-event for a parameterised route says the concrete path and its `pathParameters` itself, as above.
+is a POST to `/orders`. A route key whose path is a template captures nothing on its own. An event for
+a parameterised route says the concrete path and its `pathParameters` itself, as above.
 
 `requestContext.authorizer` is absent, as it is for a route with no authorizer. Adding it is how a
 test describes a request that has been through one: `{ jwt: { claims, scopes } }` for a
@@ -1333,25 +1331,24 @@ test describes a request that has been through one: `{ jwt: { claims, scopes } }
 is a different shape, `SimHttpApiAuthorizerEvent`, and has no factory.
 
 The [event factories page](../../factories/ "Test factories for AWS event shapes usage docs")
-covers what the factories have in common; a Function URL invocation, which is the same event from a
-different endpoint, has
+covers what the factories have in common. A Function URL invocation is the same event from a different
+endpoint, and has
 [its own factory](../lambda/#making-an-invocation-event-without-a-request "Simulated Lambda usage docs").
 
 ## The response the handler returns
 
 A handler returning an object with a `statusCode` produces that HTTP response. Its `headers` are
-sent as headers, its `cookies` become `set-cookie` headers, and an empty body is sent as no body, so
-a 204 stays a valid response.
+sent as headers, its `cookies` become `set-cookie` headers, and an empty body is sent as no body,
+leaving a 204 a valid response.
 
 A handler returning anything else produces a 200 whose body is that value as JSON. That includes an
-object with no `statusCode` in it, so a handler returning `{ body: "hi" }` produces a 200 whose body
-is the JSON `{"body":"hi"}` with `content-type: application/json`, which is what real API Gateway
-does with it.
+object with no `statusCode` in it. A handler returning `{ body: "hi" }` produces a 200 whose body is
+the JSON `{"body":"hi"}` with `content-type: application/json`. Real API Gateway does the same.
 
 ## Reading an API back
 
 `GetApisCommand`, `GetIntegrationsCommand`, `GetRoutesCommand` and `GetStagesCommand` list what an
-API has. Each answers in full, since paging is not simulated.
+API has. Each answers in full, as paging is outside the simulation.
 
 ```typescript sim-apigatewayv2-list-resources
 /**
@@ -1395,13 +1392,13 @@ console.log(stages.Items[0]?.StageVariables);
 ## Deleting what an API has
 
 `DeleteRouteCommand`, `DeleteIntegrationCommand` and `DeleteStageCommand` each take one resource off
-an API and leave the rest of it in place. A deleted route stops matching, so a request that used to
-reach it is answered the way any unmatched request is. A deleted stage stops resolving, so a request
-addressed to it finds nothing, while the routes it served are still served by the API's other stages.
+an API and leave the rest of it in place. A deleted route stops matching, and a request that used to
+reach it is answered the way any unmatched request is. A deleted stage stops resolving. A request
+addressed to it finds no stage, while the routes it served are still served by the API's other stages.
 
 An integration a route still points at cannot be deleted. That is a `BadRequestException` naming the
-routes in the way, as it is on real AWS, so an API comes apart routes first and then the integrations
-behind them. Deleting a route does not delete its integration, since an integration outlives the
+routes in the way, as it is on real AWS, and an API comes apart routes first and then the integrations
+behind them. Deleting a route leaves its integration in place, since an integration outlives the
 routes pointing at it.
 
 ```typescript sim-apigatewayv2-delete-resources
@@ -1476,16 +1473,16 @@ these.
 
 ## Turning the generated endpoint off
 
-`DisableExecuteApiEndpoint: true` stops the generated endpoint serving, which is how an API reachable
+`DisableExecuteApiEndpoint: true` stops the generated endpoint serving. That is how an API reachable
 only through a custom domain is configured. A request to it is answered with a 403 and
 `{"message":"Forbidden"}`. AWS publishes neither the status nor the body for that case, so both are
-what a disabled endpoint was observed to answer rather than something documented.
+what a disabled endpoint was observed to answer.
 
 ## Importing an OpenAPI definition
 
 `ImportApiCommand` takes a serialised OpenAPI 3.0 document and creates the API, one route and one
 integration per operation, and one authorizer per security scheme an operation names. The route
-key is the operation key uppercased and the path taken verbatim, since OpenAPI path templating is
+key is the operation key uppercased and the path taken unchanged, since OpenAPI path templating is
 already API Gateway's path parameter syntax.
 
 An import creates no stage. `CreateStageCommand` or an `AWS::ApiGatewayV2::Stage` is still declared
@@ -1589,7 +1586,7 @@ or as the bare function ARN.
 ### Members that are ignored
 
 AWS sorts what an import finds into three categories, and the third is valid OpenAPI that HTTP APIs
-do not support. It is ignored silently, and so is it here: `requestBody`, the content schemas under
+leave unsupported. AWS ignores it silently, and so does this: `requestBody`, the content schemas under
 `responses`, `components.schemas`, and an operation's `parameters`, `summary`, `description` and
 `tags`. HTTP APIs perform no request validation, so a request whose body contradicts a declared
 schema still reaches the handler.
@@ -1681,7 +1678,7 @@ and a value carrying more is refused, as more than one `IdentitySource` is on `C
 
 [Simulated CloudFormation](../cloudformation/ "Simulated CloudFormation docs") deploys
 `AWS::ApiGatewayV2::Api`, `AWS::ApiGatewayV2::Authorizer`, `AWS::ApiGatewayV2::Integration`,
-`AWS::ApiGatewayV2::Route` and `AWS::ApiGatewayV2::Stage`, so a synthesized or hand-written template
+`AWS::ApiGatewayV2::Route` and `AWS::ApiGatewayV2::Stage`. A synthesized or hand-written template
 produces an API that serves requests.
 
 `Ref` and `Fn::GetAtt` return what real CloudFormation returns for each type:
@@ -1821,8 +1818,8 @@ await srv.close();
 Every property outside the simulated set is left out of what is created and recorded in
 [`stack.ignoredProperties`](../cloudformation/README.md#properties-a-resource-was-created-without),
 naming the Resource type, the logical id and the ones this can act on instead. The API, authorizer,
-integration, route or stage is created either way, so the stack deploys and the record says which of
-its parts behaves differently to the template. The simulated properties are:
+integration, route or stage is created either way. The stack deploys, and the record says which of its
+parts behaves differently to the template. The simulated properties are:
 
 - `Api`: `Name`, `ProtocolType`, `Description`, `DisableExecuteApiEndpoint`, `Body`,
   `FailOnWarnings`
@@ -1839,18 +1836,18 @@ requires IAM authorization when it is served.
 
 CDK's `HttpJwtAuthorizer` and `HttpUserPoolAuthorizer` both deploy. `HttpUserPoolAuthorizer` builds
 its issuer from `Fn::GetAtt <UserPool>.ProviderURL`, which resolves to the same string the pool's
-tokens name as their issuer, so a CDK-declared authorizer and a CDK-deployed pool agree with nothing
-to configure. Pass the app client explicitly through `userPoolClients`, because otherwise the
+tokens name as their issuer. A CDK-declared authorizer and a CDK-deployed pool agree, with no
+configuration to write. Pass the app client explicitly through `userPoolClients`, because otherwise the
 authorizer adds a client of its own with CDK's defaults, and those emit the OAuth properties
 [simulated Cognito refuses](../cognito/#limitations).
 
 An `Authorizer` with `AuthorizerType: "REQUEST"` deploys as a Lambda authorizer, and a `Route` with
 `AuthorizationType: "CUSTOM"` and a `Ref` to it is decided by that authorizer's function.
-`AuthorizerUri` is read the same way an integration's URI is, so the bare function ARN and the
+`AuthorizerUri` is read the same way an integration's URI is. The bare function ARN and the
 `arn:aws:apigateway:<region>:lambda:path/2015-03-31/functions/<function-arn>/invocations` form both
 work. The `AWS::Lambda::Permission` alongside it needs a `SourceArn` of
-`arn:aws:execute-api:<region>:<account>:<api-id>/authorizers/<authorizer-id>`, which is what CDK
-writes and what the authorizer is invoked under. A function used both as an integration and as an
+`arn:aws:execute-api:<region>:<account>:<api-id>/authorizers/<authorizer-id>`. That is what CDK
+writes, and what the authorizer is invoked under. A function used both as an integration and as an
 authorizer needs two permissions, as it does on AWS.
 
 CDK's `HttpLambdaAuthorizer` deploys when it is given `responseTypes: [HttpLambdaResponseType.SIMPLE]`.
@@ -1871,13 +1868,13 @@ httpApi.addRoutes({
 });
 ```
 
-A `Route` with `AuthorizationType: "JWT"` or `"CUSTOM"` whose `AuthorizerId` does not resolve to an
-authorizer of that API, or resolves to one of the other kind, fails the stack, naming both. That
-covers a `Ref` to a Resource this simulation skipped: a skipped Resource resolves to its own logical
+A `Route` with `AuthorizationType: "JWT"` or `"CUSTOM"` whose `AuthorizerId` resolves to something
+other than an authorizer of that API, or to one of the other kind, fails the stack, naming both. That
+covers a `Ref` to a Resource this simulation skipped. A skipped Resource resolves to its own logical
 ID, and no authorizer has that id.
 
-`Api.Body` carries an OpenAPI document as an inline JSON object, which CloudFormation resolves
-`Ref` and `Fn::GetAtt` inside as it does anywhere else, so an operation's integration URI can be an
+`Api.Body` carries an OpenAPI document as an inline JSON object. CloudFormation resolves `Ref` and
+`Fn::GetAtt` inside it as it does anywhere else, and an operation's integration URI can be an
 `Fn::GetAtt` on a function the same stack deploys. The document goes through the same `ImportApi`
 translator an SDK caller reaches, so the two produce the same API.
 
@@ -1898,35 +1895,35 @@ Api:
               payloadFormatVersion: "2.0"
 ```
 
-`Name` and `ProtocolType` are both optional alongside a `Body`, which is what AWS documents. A
-`ProtocolType` that is present has to be `HTTP`, and a `Name` that is present names the API instead
-of the document's `info.title`. `Description` and `DisableExecuteApiEndpoint` are refused alongside a
-`Body`, because `ImportApi` does not take them and nothing here changes an API after it is created.
-Each is recorded rather than applied, so the API is created from the document without them.
+`Name` and `ProtocolType` are both optional alongside a `Body`, as AWS documents. A `ProtocolType`
+that is present has to be `HTTP`, and a `Name` that is present names the API in place of the
+document's `info.title`. `Description` and `DisableExecuteApiEndpoint` are refused alongside a
+`Body`, because `ImportApi` takes neither, and no command here changes an API after it is created.
+Each is recorded rather than applied, and the API is created from the document without them.
 
 A template combining an `Api` with a `Body` and a separate `Route`, `Integration` or `Authorizer`
 Resource for that same API fails the stack, naming both logical IDs. The document already declares
-the API's parts, and which of the two AWS would keep is not established.
+the API's parts, and which of the two AWS would keep is unestablished.
 
-An `Api` carrying a `Policy` property is refused with its own message rather than the generic one. AWS
-has no such property on this Resource type, because an HTTP API has no resource policy, so a template
+An `Api` carrying a `Policy` property is refused with its own message, in place of the generic one.
+AWS has no such property on this Resource type, because an HTTP API has no resource policy. A template
 carrying one was written for a REST API.
 
 `AWS::ApiGatewayV2::Deployment`, `DomainName`, `ApiMapping`, `VpcLink` and the WebSocket-only
-`Model`, `RouteResponse` and `IntegrationResponse` create nothing, so a template carrying one has
-that resource skipped rather than deployed.
+`Model`, `RouteResponse` and `IntegrationResponse` create no resource. A template carrying one has
+that resource skipped.
 
 ## Authorization
 
-Every command is authorized by simulated IAM. API Gateway is unusual in what it asks for: the action
-is the HTTP method of the underlying REST call rather than a name matching the SDK operation, and the
-resource is the request path rather than an ARN naming a resource type. Creating a route on API
+Every command is authorized by simulated IAM. API Gateway is unusual in what it asks for. The action
+is the HTTP method of the underlying REST call, not a name matching the SDK operation, and the
+resource is the request path, where other services name an ARN. Creating a route on API
 `a1b2c3d4e5` asks whether the caller may `apigateway:POST` on
 `arn:aws:apigateway:<region>::/apis/a1b2c3d4e5/routes`. Those ARNs carry no Account id, as API Gateway
 control-plane ARNs leave the Account segment empty.
 
-A policy written the way policies for other services are written matches nothing here, as it matches
-nothing on real AWS.
+A policy written the way policies for other services are written matches no request here, as it
+matches none on real AWS.
 
 ## SDK interception
 
@@ -1939,7 +1936,7 @@ the simulation without being given one. See the
 - `CreateApi`, `GetApi`, `GetApis` and `DeleteApi`, with the API id, the generated endpoint, and the
   Account and Region scoping a real API has
 - `CreateIntegration`, `GetIntegrations` and `DeleteIntegration` for an `AWS_PROXY` integration
-  naming a Lambda function, with an integration a route still targets refused rather than deleted
+  naming a Lambda function, with an integration a route still targets refused, never deleted
 - `CreateRoute`, `GetRoutes` and `DeleteRoute`, with route keys parsed and validated at creation,
   requests matched to a route by method, literal segment, `{name}` parameter, `{proxy+}` parameter
   and `$default`, and a deleted route no longer matching anything
@@ -1983,33 +1980,34 @@ Current documented limitations:
 - Two of the route selection rules, and the place of the method comparison in the order, are observed
   rather than published by AWS. See [Which route serves a request](#which-route-serves-a-request).
 - A route path naming the same parameter twice, such as `GET /pets/{id}/toys/{id}`, is refused. This
-  is stricter than AWS is known to be: it was refused because only one of the two captures could
-  reach the handler, not because real API Gateway was seen to refuse it.
-- Deployments are not simulated, so `CreateStage` requires `AutoDeploy: true`. A stage without it
-  serves whichever Deployment it was given, which on real AWS is nothing until one is created.
+  is stricter than AWS is known to be. It was refused because only one of the two captures could
+  reach the handler, and not because real API Gateway was seen to refuse it.
+- Deployments are outside the simulation, so `CreateStage` requires `AutoDeploy: true`. A stage
+  without it serves whichever Deployment it was given, which on real AWS is nothing until one is
+  created.
 - `RouteSettings`, `DefaultRouteSettings` and `AccessLogSettings` on a stage are refused, as is any
-  other option `CreateStage` takes and this one does not.
+  other option `CreateStage` takes and this one lacks.
 - `AWS_PROXY` is the only integration type, and its URI must name an unqualified Lambda function
   ARN, written either as that ARN or as the
   `arn:aws:apigateway:<region>:lambda:path/2015-03-31/functions/<function-arn>/invocations` form.
   Both reach the same function, and `GetIntegrations` answers with the function ARN whichever was
   written. A version or alias qualifier is refused, since simulated Lambda has no versions. HTTP
-  proxy integrations and AWS service integrations are not simulated.
-- Payload format 1.0 is refused. A handler written for 1.0 reads event fields a 2.0 event does not
-  have, so treating one as the other would pass here and fail on AWS.
+  proxy integrations and AWS service integrations are outside the simulation.
+- Payload format 1.0 is refused. A handler written for 1.0 reads event fields absent from a 2.0
+  event, so treating one as the other would pass here and fail on AWS.
 - `AuthorizationScopes` on an `AWS_IAM` or `CUSTOM` route is refused. This is stricter than AWS, which
   documents route scopes as meaningful only for `JWT` and ignores them here. Accepting one would let a
-  test assert on a scope restriction that nothing applies.
+  test assert on a scope restriction no code applies.
 - The method and path segments of the ARN an `AWS_IAM` route is authorized against are inferred
-  rather than documented, and the two callers of that ARN builder fill them differently: this one
+  rather than documented, and the two callers of that ARN builder fill them differently. This one
   names the request's own method and path, while the integration's invoke permission names the route
   key template. AWS documents one format for both. See
   [Protecting a route with IAM](#protecting-a-route-with-iam).
 - A `*` in a policy resource is uniformly greedy here, so it crosses `/` boundaries. AWS distinguishes
-  `*` from `*/*` in some ARN path positions, which makes the simulator more permissive than AWS for a
-  policy relying on that distinction.
-- Only `execute-api:Invoke` is evaluated. Nothing constrains the action string a policy may name, so
-  a policy can be written with `execute-api:ManageConnections` or `execute-api:InvalidateCache` and
+  `*` from `*/*` in some ARN path positions. That makes the simulator more permissive than AWS for a
+  policy relying on the distinction.
+- Only `execute-api:Invoke` is evaluated. The action string a policy names goes unconstrained, so a
+  policy can be written with `execute-api:ManageConnections` or `execute-api:InvalidateCache` and
   nothing will ever ask about it.
 - `accessKey` in the `iam` block is empty, `callerId` and `userId` carry the caller ARN rather than
   the `AIDA`/`AROA` unique id real AWS puts there, and `cognitoIdentity` and `principalOrgId` are
@@ -2020,11 +2018,11 @@ Current documented limitations:
 - An unsigned request to an `AWS_IAM` route is a 403 rather than the 403 with an
   `x-amzn-ErrorType` of `IncompleteSignatureException` real API Gateway was observed to send. The
   simulator resolves such a request to an anonymous caller and refuses it by ordinary IAM evaluation.
-- HTTP API resource policies are not simulated, because AWS does not have them. A caller from another
+- HTTP API resource policies are outside the simulation, because AWS has none. A caller from another
   Account is therefore always refused, since a cross-Account request needs an Allow from the resource
-  side. Assume a Role in the API's Account instead, which is the route through on AWS as well.
-- `AuthorizerPayloadFormatVersion: "2.0"` is required on a `REQUEST` authorizer, and stating nothing
-  is refused too. AWS defaults it to `1.0`, which builds a different event and answers a policy
+  side. Assume a Role in the API's Account instead. That is the route through on AWS as well.
+- `AuthorizerPayloadFormatVersion: "2.0"` is required on a `REQUEST` authorizer, and omitting it is
+  refused too. AWS defaults it to `1.0`, which builds a different event and answers a policy
   against a method ARN, and none of that is built here. CDK defaults `HttpLambdaAuthorizer` to
   `responseTypes: [HttpLambdaResponseType.IAM]`, which sets the format to `1.0`, so a default
   `new HttpLambdaAuthorizer(...)` fails the stack. Pass
@@ -2038,84 +2036,84 @@ Current documented limitations:
   imported document. On an `AWS::ApiGatewayV2::Authorizer` it is recorded instead, and the authorizer
   is created without it. It names a Role API Gateway assumes to invoke the authorizer, and the
   function's own resource policy is the whole decision here.
-- `AuthorizerResultTtlInSeconds` is accepted between 0 and 3600, which is the range AWS accepts, and
-  is refused on an authorizer with no `IdentitySource`, since there would be nothing to key the held
-  decision on.
-- A held decision is the whole answer, so a policy response is not re-evaluated per route on a cache
-  hit. That is what AWS's own warning about caching describes, and `$context.routeKey` as an identity
+- `AuthorizerResultTtlInSeconds` is accepted between 0 and 3600, the range AWS accepts, and is refused
+  on an authorizer with no `IdentitySource`, since the held decision would have no key.
+- A held decision is the whole answer. A policy response is re-evaluated per route only on a cache
+  miss. That is what AWS's own warning about caching describes, and `$context.routeKey` as an identity
   source is the documented way to separate routes.
-- An authorizer that could not answer at all, by throwing or by replying in neither format, is not
+- An authorizer that could not answer at all, by throwing or by replying in neither format, is never
   held. There is no answer to hold, and the next request asks the function again.
 - A `REQUEST` authorizer requires at least one `IdentitySource`. An authorizer with none is invoked
-  for every request on AWS, including one carrying nothing, and that is not simulated.
+  for every request on AWS, including one carrying nothing, and that is outside the simulation.
 - A `REQUEST` authorizer's identity source is `$request.header.<name>`,
   `$request.querystring.<name>` or `$context.routeKey`. The rest of `$context` and all of
-  `$stageVariables`, which a `REQUEST` authorizer may also name on AWS, are refused rather than read
-  from nowhere. A JWT authorizer takes one identity source naming something the client sent, so
-  `$context.routeKey` is refused for it, and a second source is refused rather than partly read.
-- An identity source naming nothing after its prefix is refused, and so is one naming a header that
-  is not an HTTP field name. Either would find nothing on every request, and an invalid header name
-  would fail at request time rather than at the command that configured it.
-- `JwtConfiguration.Audience` is required. What real API Gateway does with an authorizer that has an
-  empty audience list is not documented, so this is stricter than AWS may be, in the direction that
-  cannot quietly admit an app client.
-- A token with no `exp` claim is refused. Real Cognito always sets one, and admitting a token that
-  nothing can expire is the divergence worth failing on.
-- `token_use` is not checked, which is what real API Gateway does, so an ID token passes an
-  authorizer that configures only an audience. See
+  `$stageVariables`, which a `REQUEST` authorizer may also name on AWS, are refused, with nowhere to
+  read them from. A JWT authorizer takes one identity source naming something the client sent, so
+  `$context.routeKey` is refused for it, and a second source is refused outright.
+- An identity source with an empty name after its prefix is refused, and so is one whose header name is
+  invalid as an HTTP field name. Each would find no value on any request, and an invalid header name
+  would fail at request time, far from the command that configured it.
+- `JwtConfiguration.Audience` is required. AWS documents no behaviour for an authorizer with an empty
+  audience list. This may be stricter than AWS, in the direction that cannot quietly admit an app
+  client.
+- A token with no `exp` claim is refused. Real Cognito always sets one, and admitting a token with no
+  expiry is the divergence worth failing on.
+- `token_use` goes unchecked, as it does on real API Gateway. An ID token passes an authorizer that
+  configures only an audience. See
   [Route scopes, and access tokens versus ID tokens](#route-scopes-and-access-tokens-versus-id-tokens).
-- `aws.cognito.signin.user.admin` is the only scope any simulated Cognito flow issues, so it is the
-  only satisfiable route scope. Resource servers, custom scopes and the client credentials grant are
-  not simulated.
+- `aws.cognito.signin.user.admin` is the only scope any simulated Cognito flow issues, and the only
+  satisfiable route scope. Resource servers, custom scopes and the client credentials grant are
+  outside the simulation.
 - A token invalidated by `GlobalSignOut` still passes. Real API Gateway knows nothing about the pool's
   issued tokens, so consulting them here would refuse a token AWS would accept.
 - The pool's JWKS is read in process rather than fetched. A pool's published OpenID configuration
-  names the localhost origin it is served from while its tokens name the real AWS URL, so a discovery
+  names the localhost origin it is served from while its tokens name the real AWS URL. A discovery
   client would reject its own issuer's tokens.
 - One signing key per issuer, no key rotation and no JWKS caching. Real Cognito publishes two keys
   and rotates between them, so code assuming a single entry passes here and is still wrong on AWS.
 - The 403 body for an unmet route scope, the string rendering of claim values, and `scopes` being
-  `null` rather than `[]` are all what the real endpoint was observed to send rather than anything
-  AWS publishes. Only the one `error_description` AWS documents is ever sent; every other refusal
-  names the scheme and nothing else. How AWS lays out the `www-authenticate` parameters around that
-  description is not published either, so they are comma-separated as RFC 6750 writes them.
+  `null` rather than `[]` are all what the real endpoint was observed to send. AWS publishes none of
+  them. Only the one `error_description` AWS documents is ever sent, and every other refusal names the
+  scheme and nothing else. AWS publishes no layout for the `www-authenticate` parameters around that
+  description either, so they are comma-separated as RFC 6750 writes them.
 - Deleting an authorizer a route still points at leaves that route refusing every request. What real
-  API Gateway does with such a route is not established, so it stays closed rather than falling open.
+  API Gateway does with such a route is unestablished. It stays closed here.
 - The method and path segments of the source ARN are inferred rather than documented. See
   [Granting the API permission to invoke the function](#granting-the-api-permission-to-invoke-the-function).
 - An integration `CredentialsArn`, the IAM Role alternative to a resource policy grant, is refused
   by `CreateIntegration`. A permission on the function is the only way to admit the invocation.
 - No `Update*` commands. A route, integration or stage is changed by deleting it and creating it
   again. `DeleteApi` deletes everything under the API, as it does on AWS.
-- Custom domain names and API mappings are not simulated. They change what `rawPath` holds, so an API
-  reached through one behaves differently on AWS from what is served here.
-- No paging. `MaxResults` and `NextToken` are refused rather than ignored, and every list command
-  answers in full.
+- Custom domain names and API mappings are outside the simulation. They change what `rawPath` holds,
+  so an API reached through one behaves differently on AWS from what is served here.
+- No paging. `MaxResults` and `NextToken` are refused, never ignored, and every list command answers
+  in full.
 - `CorsConfiguration` and `Tags` are refused, as is the `RouteKey`/`Target` quick-create shorthand on
-  `CreateApi`. Anything else the real commands accept and this one does not is refused by name rather
+  `CreateApi`. Anything else the real commands accept and this one lacks is refused by name rather
   than dropped.
 - `AWS::ApiGatewayV2::Api` records `CorsConfiguration` rather than applying it. CORS request handling
-  is not simulated, so a CDK stack using `corsPreflight` deploys and its API answers preflight
+  is outside the simulation, so a CDK stack using `corsPreflight` deploys and its API answers preflight
   requests here differently from AWS. The record is where a test checks that.
 - Only OpenAPI 3.0.x is imported. A `swagger: "2.0"` document and an `openapi: "3.1.0"` one are both
   refused by version, and only JSON is parsed, not YAML.
 - `FailOnWarnings` is honoured only in its strict sense. Everything an import cannot apply is refused
-  rather than warned about, so `true` is accepted and has no further effect and `false` is refused by
-  name. What AWS defaults the property to is not established, so nothing here relies on a default.
+  outright, with no warning, so `true` is accepted and has no further effect and `false` is refused by
+  name. What AWS defaults the property to is unestablished, and no code here relies on a default.
 - `Basepath` on `ImportApi`, `BasePath` on `AWS::ApiGatewayV2::Api` and `servers` in the document are
   all refused. A base path changes the path every route matches on, which belongs with custom domain
   names.
-- `ReimportApi` is not simulated, as no `Update*` command is. Delete the API and import again.
-- An imported `operationId` is dropped rather than stored. AWS maps it to the route's
+- `ReimportApi` is outside the simulation, as every `Update*` command is. Delete the API and import
+  again.
+- An imported `operationId` is dropped. AWS maps it to the route's
   `OperationName`, and no command here takes one.
 - A `trace` operation, a path item `$ref`, `x-amazon-apigateway-any-method` and a document-level
   `security` are each refused by name. None of the four is established for HTTP APIs by the research
-  behind this, so each is refused rather than turned into a route the API may not have on AWS.
+  behind this, so each is refused, and never turned into a route the API may lack on AWS.
 - An operation carrying more than one security requirement is refused, as is a requirement naming
   more than one scheme. A route has one authorizer.
-- A security scheme that is not `oauth2` with an explicit `jwtConfiguration.issuer` is refused. That
+- Anything other than an `oauth2` scheme with an explicit `jwtConfiguration.issuer` is refused. That
   includes `openIdConnect`, where AWS reads the issuer out of the discovery document at
-  `openIdConnectUrl`: nothing here is fetched over HTTP, and taking the URL as the issuer would
+  `openIdConnectUrl`. Nothing here is fetched over HTTP, and taking the URL as the issuer would
   mismatch every token's `iss` and answer a silent 401.
 - `http_proxy` integrations, `integrationMethod`, `integrationSubtype`, `requestParameters`,
   `credentials`, `tlsConfig`, `responseTransferMode`, `connectionId` and `connectionType` in an
@@ -2124,21 +2122,21 @@ Current documented limitations:
 - `x-amazon-apigateway-cors` is refused, alongside the `CorsConfiguration` refusal above.
 - A referenced `x-amazon-apigateway-integrations` definition becomes one shared integration, so two
   operations naming it produce one entry in `GetIntegrations`. Whether AWS shares one or creates one
-  per use is not established; this is what a reusable definition reads as.
+  per use is unestablished. This is what a reusable definition reads as.
 - A `Name` on an `AWS::ApiGatewayV2::Api` with a `Body` names the API rather than the document's
-  `info.title`. Which of the two AWS takes when both are present is not established, and it affects
-  only the name `GetApi` reports.
+  `info.title`. Which of the two AWS takes when both are present is unestablished, and it affects only
+  the name `GetApi` reports.
 - A terminal `{proxy+}` in an imported path reaches `CreateRoute` unchanged. Greedy segments are
-  established for route keys rather than for OpenAPI path templating.
-- `AWS::ApiGatewayV2::Api` records `BodyS3Location` rather than reading it, so the API is created
-  with no routes at all. Reading a document out of a simulated S3 bucket adds a fetch path and
-  nothing about OpenAPI.
+  established for route keys, and not for OpenAPI path templating.
+- `AWS::ApiGatewayV2::Api` records `BodyS3Location` rather than reading it. The API is created with no
+  routes at all. Reading a document out of a simulated S3 bucket adds a fetch path and nothing about
+  OpenAPI.
 - `AWS::ApiGatewayV2::Api` refuses `Policy` with a message of its own saying an HTTP API has no
-  resource policy. There is no such property on the real Resource type, so a template carrying one
-  was written for a REST API rather than hitting a gap here.
+  resource policy. The real Resource type has no such property. A template carrying one was written
+  for a REST API, not against a gap here.
 - A stack update replaces a changed resource of these types rather than updating it in place, as it
   does for any other type. See the [CloudFormation limitations](../cloudformation/#limitations).
-- Access logging, throttling, usage plans and API keys are not simulated.
+- Access logging, throttling, usage plans and API keys are outside the simulation.
 - The response an API Gateway endpoint returns itself uses a lower-case `message` field, as a real
-  HTTP API does. A Lambda Function URL uses `Message` for the same thing, so the two are not
-  interchangeable.
+  HTTP API does. A Lambda Function URL uses `Message` for the same thing, so the two cannot be
+  swapped.

--- a/docs/services/apigatewayv2/README.md
+++ b/docs/services/apigatewayv2/README.md
@@ -1047,8 +1047,8 @@ An explicit `Deny` beats an `Allow`, and a document with no relevant `Allow` ref
   authorizer function is never invoked.
 - `isAuthorized: false`, or a policy that refuses `execute-api:Invoke` on the route ARN, is a 403 and
   `{"message":"Forbidden"}`.
-- Returning `{ "errorMessage": "Unauthorized" }` is a 401. That is the only way an authorizer produces
-  one, and it is read whichever response format the authorizer is configured for.
+- Returning `{ "errorMessage": "Unauthorized" }` is a 401. That is the only way the authorizer
+  function produces one, and it is read whichever response format the authorizer is configured for.
 - A function that throws, returns a shape matching no response format, returns a policy document
   IAM cannot read, or has no invoke permission, is a 500 and `{"message":"Internal Server Error"}`.
   The caller hears no more, the way it hears no detail about a failed integration.
@@ -1897,9 +1897,9 @@ Api:
 
 `Name` and `ProtocolType` are both optional alongside a `Body`, as AWS documents. A `ProtocolType`
 that is present has to be `HTTP`, and a `Name` that is present names the API in place of the
-document's `info.title`. `Description` and `DisableExecuteApiEndpoint` are refused alongside a
-`Body`, because `ImportApi` takes neither, and no command here changes an API after it is created.
-Each is recorded rather than applied, and the API is created from the document without them.
+document's `info.title`. `Description` and `DisableExecuteApiEndpoint` are recorded rather than
+applied alongside a `Body`, because `ImportApi` takes neither, and no command here changes an API
+after it is created. The API is created from the document without them, and the stack deploys.
 
 A template combining an `Api` with a `Body` and a separate `Route`, `Integration` or `Authorizer`
 Resource for that same API fails the stack, naming both logical IDs. The document already declares

--- a/docs/services/cloudformation/README.md
+++ b/docs/services/cloudformation/README.md
@@ -1,9 +1,8 @@
 # Simulated CloudFormation
 
-Yulin includes a simulated CloudFormation service for tests and local development.
-
-Sim CloudFormation creates simulated AWS resources from CloudFormation templates. It can be used with
-hand-written templates, AWS SDK-style `CreateStackCommand` calls, or synthesized CDK template files.
+Yulin includes a simulated CloudFormation service for tests and local development. It creates
+simulated AWS resources from CloudFormation templates, and works with hand-written templates, AWS
+SDK-style `CreateStackCommand` calls, or synthesized CDK template files.
 
 ## Basic usage
 
@@ -287,34 +286,34 @@ stack has moved to `UPDATE_IN_PROGRESS`, and `waitForStackUpdateComplete(...)` w
 resources to change. `DescribeStacksCommand` reports `UPDATE_IN_PROGRESS` in between and
 `UPDATE_COMPLETE` after, along with the outputs resolved again against the new template.
 
-Updating a stack name that is not there is refused with the same `ValidationError` that
-`DescribeStacksCommand` refuses it with, because there is nothing else an update of a stack that is
-not there could mean.
+Updating a stack name that was never deployed is refused with the same `ValidationError`
+`DescribeStacksCommand` refuses it with. An update of a stack that was never there could mean nothing
+else.
 
 ### What counts as a change
 
-Resources are compared as they resolve rather than as they are written, so a changed parameter value
-shows up as a changed resource even when the template body is identical, and a template reordered
-without being changed does not. Outputs are compared the same way. The rest of the template body is
-compared as written, so a change to a section the simulator does not act on, such as `Description`,
-is still an update.
+Resources are compared as they resolve, not as they are written. A changed parameter value shows up
+as a changed resource even when the template body is identical, and a template reordered without
+being changed shows up as no change at all. Outputs are compared the same way. The rest of the
+template body is compared as written. A change to a section the simulator ignores, such as
+`Description`, is still an update.
 
 A template that changes nothing at all is refused with a `ValidationError` reading
-`No updates are to be performed.`, which is what CloudFormation answers. So is an update asked for
+`No updates are to be performed.`, the same answer CloudFormation gives. So is an update asked for
 while another is still running.
 
 ### Changed resources are replaced
 
 A resource whose template entry changed is deleted and created again from the new template. Real
-CloudFormation updates most properties in place and keeps what the resource holds, so this is a
-divergence worth knowing about: a bucket that gains a property loses its objects here, where in AWS
-it would keep them. In-place update is the obvious next step and is not implemented yet.
+CloudFormation updates most properties in place and keeps what the resource holds. That makes this a
+divergence worth knowing about. A bucket that gains a property loses its objects here, where in AWS
+it would keep them. In-place update is the obvious next step, still to be built.
 
 Two things follow from replacement:
 
-- A resource naming a replaced resource is replaced too, all the way up the dependency chain, so
+- A resource naming a replaced resource is replaced too, all the way up the dependency chain, and
   nothing is left pointing at a resource that has gone. Real CloudFormation hands the dependent the
-  new physical name instead of recreating it.
+  new physical name and leaves it standing.
 - `UpdateReplacePolicy` is not read. Honouring `Retain` would leave the old resource holding the
   name the replacement needs, and CDK marks buckets and tables with it as a matter of course, so
   every such update would fail. The old resource is deleted whatever the policy says.
@@ -385,15 +384,15 @@ await simCfn.waitForStackDeployComplete("deletable-stack");
 Deletion runs in the background, as deployment does. `deleteStack(...)` returns once the stack has
 moved to `DELETE_IN_PROGRESS`, and `waitForStackDeleteComplete(...)` waits for the resources to go.
 `DescribeStacksCommand` reports `DELETE_IN_PROGRESS` in between, and then refuses the stack name with
-a `ValidationError` once the deletion has finished, which is how CloudFormation answers a name it no
+a `ValidationError` once the deletion has finished. That is how CloudFormation answers a name it no
 longer holds.
 
-Deleting a stack name that is not there succeeds rather than failing, as it does in CloudFormation.
+Deleting a stack name that was never deployed succeeds, as it does in CloudFormation.
 
 ### When a resource cannot be deleted
 
 Some resources refuse to go, the same way they do in AWS. An S3 bucket that still holds objects is
-the common one: CloudFormation fails there rather than emptying the bucket first, which is why CDK
+the common one. CloudFormation fails there and never empties the bucket for you. That is why CDK
 ships an `autoDeleteObjects` custom resource.
 
 A refusal leaves the stack in `DELETE_FAILED` with the reason on it, and keeps the stack name in use.
@@ -403,10 +402,10 @@ A refusal leaves the stack in `DELETE_FAILED` with the reason on it, and keeps t
 ### `DeletionPolicy`
 
 A resource declared with `DeletionPolicy: Retain` is left in simulated AWS and reported as
-`DELETE_SKIPPED`, which is what CloudFormation does with it. The rest of the stack still deletes
-around it, and the stack name is still released. `RetainExceptOnCreate` is treated the same way,
-because the two differ only in what a rolled back creation does, and sim CloudFormation does not roll
-a deployment back.
+`DELETE_SKIPPED`, the same as CloudFormation reports it. The rest of the stack still deletes around
+it, and the stack name is still released. `RetainExceptOnCreate` is treated the same way, because the
+two differ only in what a rolled back creation does, and sim CloudFormation never rolls a deployment
+back.
 
 Retained resources are readable from the stack:
 
@@ -459,7 +458,7 @@ console.log(
 );
 ```
 
-When a parameter value is not supplied, the template default is used if present.
+A parameter with no supplied value takes the template default, when the template has one.
 
 ## Intrinsic functions
 
@@ -568,8 +567,8 @@ simulated CloudFront hostname, such as `e123example.cloudfront.net`.
 
 #### Values from a skipped Resource
 
-A Resource that was skipped, because its type is not simulated or because there is no simulated
-Resource to create at all, still answers both intrinsics. `Ref` returns the logical ID, and
+A Resource that was skipped, because its type is outside the simulation or because there is no
+simulated Resource to create at all, still answers both intrinsics. `Ref` returns the logical ID, and
 `Fn::GetAtt` returns the string `<logical ID>.<attribute name>`.
 
 ```typescript sim-cloudformation-skipped-resource-values
@@ -615,18 +614,18 @@ every Resource holding a `Ref` or `Fn::GetAtt` to a skipped Resource would fail 
 every Resource depending on those, until one EventBridge rule took the whole stack down with it. The skip
 stays where it happened.
 
-A stand-in is deliberately not ARN-shaped, so it fails closed wherever the simulator reads it.
+A stand-in is deliberately shaped unlike an ARN. It fails closed wherever the simulator reads it.
 
 - In an IAM policy `Resource` it matches no ARN, so a caller relying on that statement is denied.
 - In a property that is parsed as an ARN it is refused as malformed, and that Resource fails.
   Handing `Fn::GetAtt: ["Orders", "StreamArn"]` from a skipped DynamoDB table to an
   `AWS::Lambda::EventSourceMapping` fails with
   `EventSourceArn Orders.StreamArn names no simulated Lambda event source`.
-- Handed to a Lambda function through its environment, it names something that is not there, so the
-  function's own SDK call fails as a call for a missing resource does. A `PutItem` naming the
-  skipped table gets `ResourceNotFoundException: No DynamoDB Table named Orders`.
+- Handed to a Lambda function through its environment, it names something absent. The function's own
+  SDK call fails the way a call for a missing resource does. A `PutItem` naming the skipped table
+  gets `ResourceNotFoundException: No DynamoDB Table named Orders`.
 
-A stand-in stands in for something absent, so it is not a value to rely on. A test asserting against
+A stand-in stands in for something absent, and is never a value to rely on. A test asserting against
 one is asserting on a Resource that was never created. `stack.skippedResources` is where to find out
 which Resources those are and why, under
 [Inspecting stacks and resources](#inspecting-stacks-and-resources).
@@ -755,15 +754,15 @@ await stack.waitForDeployComplete();
 console.log(simAws.s3().getSimBucketByName("staging-site-bucket")?.bucketName);
 ```
 
-Each of the three arguments can be a nested expression rather than a literal string, as long as it
+Each of the three arguments can be a nested expression as well as a literal string, as long as it
 resolves to a string. The example above uses a `Ref` to a parameter for the top-level key. A `Ref` to
 the `AWS::Region` pseudo parameter works the same way, for the per-region maps that `Fn::FindInMap`
 is most often used for, and a nested `Fn::FindInMap` can supply any of the three arguments.
 
-The value a lookup returns does not have to be a string. A list value is returned as a list.
+The value a lookup returns can be any type. A list value is returned as a list.
 
-`Fn::FindInMap` is resolved when the template is read, before any resource is created, so it can be
-used in resource properties and in `Outputs`. A map name or key that is not in `Mappings` fails the
+`Fn::FindInMap` is resolved when the template is read, before any resource is created, and can be
+used in resource properties and in `Outputs`. A map name or key missing from `Mappings` fails the
 deployment with an error naming the path that could not be found.
 
 ### `Fn::Split` and `Fn::Select`
@@ -824,9 +823,9 @@ console.log(simAws.s3().getSimBucketByName("site-bucket-logs")?.bucketName);
 ```
 
 The delimiter is a literal string. The string being split can be any expression that resolves to a
-string, including a `Ref`, an `Fn::GetAtt` or another function. A delimiter the string does not
-contain gives a one-element list, and a delimiter at the start or end of the string gives an empty
-element there, as CloudFormation does.
+string, including a `Ref`, an `Fn::GetAtt` or another function. A delimiter absent from the string
+gives a one-element list, and a delimiter at the start or end of the string gives an empty element
+there, as CloudFormation does.
 
 `Fn::Select` takes its list from a literal list, from `Fn::Split`, or from anything else that
 resolves to a list, such as an `Fn::FindInMap` of a list value. The index is a number or a string of
@@ -849,9 +848,9 @@ at a Lambda function URL:
 `https://abc123.lambda-url.eu-west-2.on.aws/` splits into
 `["https:", "", "abc123.lambda-url.eu-west-2.on.aws", ""]`, so index 2 is the host.
 
-An index past the end of the list, a negative or fractional index, and a second argument that is not
-a list all fail the deployment, as they are all templates AWS rejects. The error names the resource
-and the property path the value sat at, for example
+An index past the end of the list, a negative or fractional index, and a second argument of any type
+but a list all fail the deployment, as they are all templates AWS rejects. The error names the
+resource and the property path the value sat at, for example
 `Sim CloudFormation Resource LogsBucket value at Properties.BucketName`.
 
 ## Conditions
@@ -924,11 +923,11 @@ name one written below it in the section.
 }
 ```
 
-`Fn::Equals` compares its two values as strings, as CloudFormation does, so a JSON number in the
+`Fn::Equals` compares its two values as strings, as CloudFormation does. A JSON number in the
 template matches the string a parameter carries.
 
-The whole section is evaluated once per deployment, before any resource is created, so a condition
-can read parameters and pseudo parameters and nothing else. A comparison that would need a created
+The whole section is evaluated once per deployment, before any resource is created. A condition can
+read parameters and pseudo parameters and nothing else. A comparison that would need a created
 resource, such as an `Fn::GetAtt`, fails the deployment rather than reading as false.
 
 ### `Fn::If`
@@ -936,22 +935,22 @@ resource, such as an `Fn::GetAtt`, fails the deployment rather than reading as f
 `Fn::If` takes a condition name, a value to use when it is true, and a value to use when it is
 false. It works anywhere a resource property or an output value is read.
 
-Only the branch the condition selects is resolved. The other branch is left alone, so it can name a
-resource this deployment does not create.
+Only the branch the condition selects is resolved. The other branch is left alone, and may name a
+resource this deployment never creates.
 
 ### The resource `Condition` attribute
 
-A resource carrying a `Condition` attribute whose condition is false is not created at all. It is
-absent from `stack.resources`, which is different from a resource sim CloudFormation skips: a
-skipped resource stays in the stack and answers `Ref` and `Fn::GetAtt` with
+A resource carrying a `Condition` attribute whose condition is false is never created. It is absent
+from `stack.resources`. A resource sim CloudFormation skips behaves differently. A skipped resource
+stays in the stack and answers `Ref` and `Fn::GetAtt` with
 [stand-in values](#values-from-a-skipped-resource).
 
-Because the resource does not exist, another resource naming it fails the deployment, with an error
-naming both resources and the condition. That covers a `Ref` or `Fn::GetAtt` that is actually
-reached, and a `DependsOn`. A name carried only by the branch of an `Fn::If` the condition did not
-select is not reached, so it does not fail.
+With the resource absent, another resource naming it fails the deployment, with an error naming both
+resources and the condition. That covers a `Ref` or `Fn::GetAtt` that is actually reached, and a
+`DependsOn`. A name carried only by the unselected branch of an `Fn::If` is never reached, and never
+fails.
 
-A `Condition` attribute naming a condition the template does not define fails the same way.
+A `Condition` attribute naming a condition the template leaves undefined fails the same way.
 
 ## Resource dependencies
 
@@ -1041,7 +1040,7 @@ create the simulated resources from that synthesized output template.
 ## Editing a synthesized template before deploying it
 
 Sometimes a synthesized template needs a change before Yulin will deploy it, such as dropping a
-resource or property that this simulator does not accept. Read the file, edit the parsed object,
+resource or property that this simulator refuses. Read the file, edit the parsed object,
 then deploy it with `deployTemplate(...)`, naming the file it came from:
 
 ```typescript sim-cloudformation-cdk-edited-template
@@ -1081,8 +1080,8 @@ const stack = await simAws.cloudFormation().deployTemplate({
 await stack.waitForDeployComplete();
 ```
 
-The template file is not read as the template: the `template` object is what gets deployed.
-`templatePath` only tells Yulin which cloud assembly the template came from, so it can find the
+The `template` object is what gets deployed, and the template file itself goes unread.
+`templatePath` only tells Yulin which cloud assembly the template came from, letting it find the
 sibling `TestStack.assets.json` manifest and the staged asset directories beside it. Without it,
 anything that needs a CDK asset, such as a `Custom::CDKBucketDeployment` or a Lambda function
 bundled with `Code.fromAsset`, fails with `No CDK assets manifest is available.`
@@ -1091,8 +1090,8 @@ bundled with `Code.fromAsset`, fails with `No CDK assets manifest is available.`
 
 Editing the parsed object works for a template you deploy once. A template you keep reading, because
 it is [watched](#watching-a-template-file) or applied again as an update, needs the same change made
-every time it is read. `transform` is that: it is given the parsed template and answers with the one
-to deploy, on the deployment and again on every change:
+every time it is read. `transform` is that hook. It is given the parsed template and answers with the
+one to deploy, on the deployment and again on every change:
 
 ```typescript sim-cloudformation-transform-template-file
 /**
@@ -1129,20 +1128,20 @@ await simAws.cloudFormation().deployTemplateFile({
 ```
 
 This is for what a simulation cannot resolve at all, such as an ARN carrying a real account or a
-hosted zone ID that came from `HostedZone.fromLookup`. A property Yulin does not model is usually not
-one you need this for: S3, DynamoDB, Cognito, API Gateway v2, SQS and KMS
+hosted zone ID that came from `HostedZone.fromLookup`. A property Yulin leaves unmodelled rarely
+needs it. S3, DynamoDB, Cognito, API Gateway v2, SQS and KMS
 [record it and carry on](#properties-a-resource-was-created-without).
 
-The template file is still the real one, so there is no derived `.local.template.json` in `cdk.out`
-to keep in step with it. Staged assets resolve as they always did, from the assets manifest beside
-`templatePath`, since the cloud assembly is found by path rather than read out of the template.
+The template file is still the real one. There is no derived `.local.template.json` in `cdk.out` to
+keep in step with it. Staged assets resolve as they always did, from the assets manifest beside
+`templatePath`, since the cloud assembly is found by path and never read out of the template.
 
 `updateTemplateFile(...)` takes it too, for a consumer driving updates itself. Give it the same
-deployment object, so the difference applied is the difference in the file.
+deployment object, and the difference applied is the difference in the file.
 
 A transform that throws fails the deployment, with what it threw as the cause. On a watched change it
-is reported the way a failed update is: the stack keeps the resources it had, and the watch carries
-on to the next save.
+is reported the way a failed update is. The stack keeps the resources it had, and the watch carries on
+to the next save.
 
 ## Applying a changed template file
 
@@ -1174,12 +1173,12 @@ await simAws.cloudFormation().deployTemplateFile({ templatePath });
 await simAws.cloudFormation().updateTemplateFile({ templatePath });
 ```
 
-The sibling assets manifest is read again with the template, so a resource the update replaces reads
-the assets that synthesis staged rather than the ones the stack was deployed with.
+The sibling assets manifest is read again with the template. A resource the update replaces reads the
+assets that synthesis staged, not the ones the stack was deployed with.
 
 A file written without being changed is refused with `No updates are to be performed.`, and a failed
 update leaves the stack in `UPDATE_FAILED` holding whatever the update reached. There is no rollback
-to the template it was deployed from, so a failure part way through has already deleted, replaced or
+to the template it was deployed from. A failure part way through has already deleted, replaced or
 created some of the resources the change asked for.
 
 ## Watching a template file
@@ -1212,42 +1211,40 @@ await simAws.cloudFormation().deployTemplateFile({
 `watch: true` watches with nothing to do afterwards.
 
 `reload` is the local server, and reloads the browsers connected to it once the update is complete.
-It reloads when the resources have changed rather than when the write lands, so a browser reloads
-onto the resources the new template asked for. A write that changed nothing is a no-op, so nothing
-reloads for it, and neither does an update that failed: a browser should not be sent to a stack the
-update did not reach. Anything with a `reload()` method will do, so a test can watch a template
+It reloads when the resources have changed, not when the write lands. A browser therefore arrives on
+the resources the new template asked for. A write that changed nothing is a no-op, and reloads
+nothing. A failed update reloads nothing either, since a browser has no business on a stack the
+update never reached. Anything with a `reload()` method will do, and a test can watch a template
 without serving anything.
 
-A server serving without live reload can never reload anything, and says so as the deployment asks
-it to rather than on the first change, which is a long way from the mistake. Serve with
+A server serving without live reload can never reload anything, and says so as the deployment asks it
+to. Saying it on the first change instead would be a long way from the mistake. Serve with
 [`{ liveReload: true }`](../../serve/README.md#live-reload).
 
 `onUpdated` runs once the update is complete too, for whatever else a change is worth doing, with or
-without a `reload` alongside it. Given both, the callback runs first and the reload follows it, so a
+without a `reload` alongside it. Given both, the callback runs first and the reload follows it, and a
 browser arriving on the new resources finds whatever the callback left ready for it.
 
-`onFailed` is given an update the changed template did not survive. It reports the failure and
-nothing else: the stack is left holding whatever the update reached, as an update through the
-command is. What a failure does keep is the process, and the resources it never got to, so a
-template that no longer deploys leaves a working environment where a restart on it would leave
-none.
+`onFailed` is given an update the changed template failed. It reports the failure and nothing else.
+The stack is left holding whatever the update reached, as it is after an update through the command.
+What a failure does keep is the process, and the resources it never got to. A template that no longer
+deploys leaves a working environment where a restart on it would leave none.
 
 A burst of writes is one update. Saving a file is several filesystem events, so changes are held
 until they stop arriving. `settleMs` is how long that wait is, and it defaults to the 250ms
 [`yulin watch` settles at](../../serve/README.md#one-restart-for-a-burst-of-writes). A synth that
-keeps writing is updated from after five seconds of it, rather than being held off until it stops.
+keeps writing is updated from after five seconds of it, without waiting for it to stop.
 
-[`transform`](#adapting-a-synthesized-template-on-the-way-in) runs again on every change, so a
-template that needs adapting before Yulin will take it can still be watched as the file synthesis
-writes.
+[`transform`](#adapting-a-synthesized-template-on-the-way-in) runs again on every change. A template
+that needs adapting before Yulin will take it can still be watched as the file synthesis writes.
 
-Watching holds a filesystem handle open, so the process does not exit on its own. That is what a dev
+Watching holds a filesystem handle open, so the process stays alive on its own. That is what a dev
 process wants. Anything with an end, such as a test, calls `stopWatchingTemplateFiles()` when it is
-done. `watchedTemplateFiles()` names what is being watched. Both are per Account and Region, so a
+done. `watchedTemplateFiles()` names what is being watched. Both are per Account and Region, and a
 simulation deploying into more than one has one call each.
-[`simAws.close()`](../../serve/README.md#stopping-and-restarting) is the one that is not: it lets go
-of the template watches in every scope, along with everything else the environment is holding, and a
-served environment gets that from `srv.close()`.
+[`simAws.close()`](../../serve/README.md#stopping-and-restarting) is the exception. It lets go of the
+template watches in every scope, along with everything else the environment is holding, and a served
+environment gets that from `srv.close()`.
 
 Yulin never synthesizes anything. It reads the output template, so run your own `cdk synth` and let
 the watch pick up what it writes.
@@ -1255,9 +1252,9 @@ the watch pick up what it writes.
 ### Under `yulin watch`
 
 [`yulin watch`](../../serve/README.md#restarting-on-a-file-change) restarts the process when a
-deployed template changes. A watched template is left to the process that is watching it instead, so
-the stack updates in place and everything held in simulated S3, DynamoDB and SQS stays where it is.
-Nothing needs configuring for that: the process names the file it is holding.
+deployed template changes. A watched template is left to the process that is watching it instead. The
+stack updates in place, and everything held in simulated S3, DynamoDB and SQS stays where it is. That
+needs no configuring, because the process names the file it is holding.
 
 ## CDK S3 BucketDeployment
 
@@ -1295,35 +1292,35 @@ The files in the staged asset directory become Objects in the destination Bucket
 relative to the asset root. When the Bucket is configured for website hosting, or sits behind a
 CloudFront Distribution, those Objects are what gets served.
 
-This is the `aws s3 sync` the real provider function shells out to, so the properties CDK synthesizes
+This is the `aws s3 sync` the real provider function shells out to. The properties CDK synthesizes
 around it are read the same way:
 
 - `DestinationBucketKeyPrefix` puts the Objects under a key prefix.
 - `Exclude` and `Include` choose which files are copied. Every `Exclude` pattern is applied first and
-  then every `Include` one, and the last pattern to match a path decides, which is what makes
+  then every `Include` one, and the last pattern to match a path decides. That is what makes
   `exclude: ["*"], include: ["*.txt"]` mean "only the text files". A file no pattern matches is
   copied. `*` matches across `/`, so `data/*` covers everything under a `data` directory.
 - `SystemMetadata` sets content headers on every Object the deployment copies, such as
   `content-encoding` or `cache-control`. Without it, the content type is guessed from the file
   extension. See [Object system metadata](../s3/README.md#object-system-metadata) for what comes back
-  on a read. The deployment also tells the destination Bucket what it publishes, so a directory
+  on a read. The deployment also tells the destination Bucket what it publishes. A directory
   [mounted over that Bucket](../s3/README.md#inheriting-what-the-deployment-set) for local
-  development is served with the same headers without restating them.
+  development is then served with the same headers without restating them.
 - `Prune` removes the Objects the deployment covers and its source no longer holds. It is on unless
   the deployment turns it off, as the construct is. Pruning only considers what the filters and the
-  key prefix select, so a deployment does not delete Objects it would never have copied.
+  key prefix select, and leaves alone any Object the deployment would never have copied.
 
-Several deployments can share one Bucket, which is the usual arrangement when the headers differ by
-file type: a `BucketDeployment` sets them for all of its files at once, so a second deployment is how
-the rest of the site gets different ones. Give the second one `prune: false`, or filters that do not
-overlap the first, the same as you would in AWS.
+Several deployments can share one Bucket. That is the usual arrangement when the headers differ by
+file type, since a `BucketDeployment` sets them for all of its files at once. A second deployment is
+how the rest of the site gets different ones. Give the second one `prune: false`, or filters that miss
+what the first one covers, the same as you would in AWS.
 
 A deployment with more than one entry in `SourceObjectKeys` copies each source in turn, and a path
 two of them share ends up with the later one's content.
 
 Filter patterns take `*` and `?`. The CLI also takes character classes such as `[abc]`, and a pattern
-using one is refused by name rather than matched as written, since a pattern that quietly means
-something else would copy the wrong files.
+using one is refused by name. Matching it as written risks copying the wrong files, since the pattern
+quietly means something else.
 
 ### The provider CDK synthesizes
 
@@ -1333,34 +1330,34 @@ in AWS: an AWS CLI Lambda Layer, a Python Lambda function, and that function's l
 deployment adds another Layer and another custom resource, and shares the one function, because CDK
 builds it as a singleton.
 
-None of those three do anything here. Yulin makes the copy itself, so the function is never invoked,
-the Layer it would have loaded the CLI from is never read, and nothing is ever written to the log
+None of those three do anything here. Yulin makes the copy itself. The function is never invoked, the
+Layer it would have loaded the CLI from is never read, and nothing is ever written to the log
 group. The function and the Layer are reported in
-[`stack.inertResources`](#resources-deliberately-left-out) rather than as skipped resources, so a
-stack whose deployments all worked reports no gaps at all. The log group is created like any other,
-and stays empty, which is what an account is left with too.
+[`stack.inertResources`](#resources-deliberately-left-out) rather than as skipped resources, and a
+stack whose deployments all worked reports no gaps at all. The log group is created like any other and
+stays empty, as an account's would.
 
 That matters beyond tidiness. Sim Lambda declines the provider on its Python runtime with a message
-saying to [bind a real in-process handler](#lambda-function-bindings) to the function, which is sound
-advice for a Python function of your own and exactly the wrong thing to do here: it would replace a
+saying to [bind a real in-process handler](#lambda-function-bindings) to the function. That is sound
+advice for a Python function of your own, and exactly the wrong thing to do here. It would replace a
 working simulation with a hand-written one.
 
 The provider is found through the `ServiceToken` its custom resource names it by, not by the logical
-ID CDK generated for it, which is a hash of the construct path and not something to match on.
+ID CDK generated for it. That ID is a hash of the construct path, and no kind of thing to match on.
 
 ## S3 Bucket notifications
 
 The `NotificationConfiguration` property of `AWS::S3::Bucket` deploys through the ordinary
-`PutBucketNotificationConfiguration` path, so an Object put into the deployed Bucket reaches the
-deployed function. CloudFormation spells the configuration differently from the SDK in four places,
-and Yulin reads the CloudFormation spelling and refuses the others rather than deploying a
-configuration that quietly lost its filter.
+`PutBucketNotificationConfiguration` path. An Object put into the deployed Bucket reaches the deployed
+function. CloudFormation spells the configuration differently from the SDK in four places, and Yulin
+reads the CloudFormation spelling and refuses the others. Accepting them would deploy a configuration
+that quietly lost its filter.
 
 Real CloudFormation has a circular dependency here. The Bucket needs the function's ARN and the
-function's permission needs the Bucket's ARN, so a template hardcodes `BucketName`, names the Bucket
-by ARN literal on the permission, and adds a `DependsOn` so the permission is in place before S3
-validates the destination. Simulated CloudFormation needs the same, and surfaces the alternative as a
-dependency resolution failure.
+function's permission needs the Bucket's ARN. A template therefore hardcodes `BucketName`, names the
+Bucket by ARN literal on the permission, and adds a `DependsOn` so the permission is in place before
+S3 validates the destination. Simulated CloudFormation needs the same, and surfaces the alternative as
+a dependency resolution failure.
 
 Note that every other `AWS::S3::Bucket` property the simulator has no behaviour for fails the stack
 by name. See [Buckets from CloudFormation](../s3/README.md#buckets-from-cloudformation).
@@ -1369,13 +1366,12 @@ by name. See [Buckets from CloudFormation](../s3/README.md#buckets-from-cloudfor
 
 `bucket.addEventNotification(...)` synthesizes a `Custom::S3BucketNotifications` resource rather than
 a Bucket property. Sim CloudFormation applies the configuration it carries through the ordinary
-`PutBucketNotificationConfiguration` path, so an Object put into the deployed Bucket reaches the
+`PutBucketNotificationConfiguration` path, and an Object put into the deployed Bucket reaches the
 deployed function.
 
 Deploy into an Account and Region matching the ones the CDK app synthesized for. The `SourceAccount`
-on the `AWS::Lambda::Permission` CDK writes beside the notification is a synth-time literal, so a
-stack deployed into another Account leaves S3 unable to validate the destination, and the stack
-fails.
+on the `AWS::Lambda::Permission` CDK writes beside the notification is a synth-time literal. A stack
+deployed into another Account leaves S3 unable to validate the destination, and the stack fails.
 
 See [Event notifications](../s3/README.md#event-notifications) in the S3 docs for the configuration
 itself and what it refuses.
@@ -1516,9 +1512,9 @@ to provide an executable local function directly.
 ## Lambda function bindings
 
 `AWS::Lambda::Function` resources support the same bindings. The deployed function is backed by your
-real in-process handler, so tests can close over test state and step through the handler in a
-debugger, while the stack still wires roles, grants and references as the template declares. A bound
-function may omit template `Code` and `Handler` entirely.
+real in-process handler. Tests can close over test state and step through the handler in a debugger,
+while the stack still wires roles, grants and references as the template declares. A bound function
+may omit template `Code` and `Handler` entirely.
 
 ```typescript sim-cloudformation-lambda-binding
 /**
@@ -1719,8 +1715,8 @@ created through that same simulated account/region scope unless the underlying s
 different AWS-like scoping behaviour.
 
 An Account ID can always be written as a plain string, as above. Code that wants to name the type
-can get a `SimAwsAccountId` from `simAwsAccountId("111111111111")`, which refuses anything that is
-not a 12-digit AWS Account ID.
+can get a `SimAwsAccountId` from `simAwsAccountId("111111111111")`, which refuses anything other than
+a 12-digit AWS Account ID.
 
 ## Inspecting stacks and resources
 
@@ -1760,8 +1756,8 @@ This is useful in tests when you want to assert that a specific template resourc
 expected simulated service resource.
 
 `stack.skippedResources` lists the Resources the deployment did not create. Each one carries a
-`skippedReason` naming the type that is not simulated, so a test that expected a resource to exist
-can find out why it does not.
+`skippedReason` naming the type outside the simulation. A test that expected a resource to exist can
+find out what happened to it.
 
 ```typescript sim-cloudformation-inspect-skipped
 /**
@@ -1801,23 +1797,24 @@ console.log(stack.getResource("AlarmRule")?.skippedReason);
 A skipped Resource is still in `stack.resources`, and still answers `Ref` and `Fn::GetAtt` with
 [stand-in values](#values-from-a-skipped-resource).
 
-A skip is not always a whole Resource type nothing simulates. A service can decline one Resource of a
+A skip is more than a whole Resource type nothing simulates. A service can decline one Resource of a
 type it does create, when that Resource asks for something the service cannot model, and the
 `skippedReason` says which part it was. An `AWS::Route53::RecordSet` declaring a record type sim
-Route53 does not store is skipped with the record type named, so a DNS stack carrying a record the
-test is not about still deploys. See [record types](../route53/README.md#record-types).
+Route53 has no room for is skipped with the record type named. A DNS stack carrying a record beside
+the point of the test still deploys. See [record types](../route53/README.md#record-types).
 
-A Resource that was skipped on create is stepped over by a teardown rather than deleted, because
-nothing reached simulated AWS to delete. It reaches `DELETE_COMPLETE` and stays out of
-`stack.skippedResourceDeletions`, which is for Resources that were created and could not be removed.
+A Resource that was skipped on create is stepped over by a teardown, never deleted, because nothing
+reached simulated AWS to delete. It reaches `DELETE_COMPLETE` and stays out of
+`stack.skippedResourceDeletions`. That list is for Resources that were created and could not be
+removed.
 
 ### Resources deliberately left out
 
 `stack.skippedResources` is for gaps. A Resource it names is one a test written against would find
-missing, so some Resources are deliberately kept out of it: the ones the simulator left uncreated on
-purpose, because nothing it models could tell them apart from Resources it had created. Those are in
-`stack.inertResources` instead, each with an `inertReason` for what it would take for the difference
-to start mattering.
+missing, so some Resources are deliberately kept out of it. Those are the ones the simulator left
+uncreated on purpose, because nothing it models could tell them apart from Resources it had created.
+They are in `stack.inertResources` instead, each with an `inertReason` for what it would take for the
+difference to start mattering.
 
 ```typescript sim-cloudformation-inert-resources
 /**
@@ -1870,16 +1867,16 @@ Two things make a Resource inert. Its type can be one no simulated service reads
   function's module path.
 - `AWS::CDK::Metadata`, the construct-library analytics CDK adds to every synthesized stack.
 
-Or the stack around it can: the provider Lambda function for a CDK custom resource the simulator
-carries out itself is inert. Its log group is not, because log groups are created: an empty one is
-what an account is left with when nothing invokes the provider either. See
+Or the stack around it can. The provider Lambda function for a CDK custom resource the simulator
+carries out itself is inert. Its log group stays ordinary, because log groups are created, and an
+empty one is what an account is left with when nothing invokes the provider either. See
 [the provider CDK synthesizes](#the-provider-cdk-synthesizes).
 
 ## Properties a Resource was created without
 
-Deployment is best effort. A Resource type that is not simulated is skipped and the rest of the
-stack still deploys, and the same goes one level down: a property the Resource's own service cannot
-act on does not stop the Resource being created. It is left out, and the omission is recorded in
+Deployment is best effort. A Resource type outside the simulation is skipped and the rest of the
+stack still deploys. The same goes one level down. A property the Resource's own service cannot act
+on still leaves the Resource created. It is left out, and the omission is recorded in
 `stack.ignoredProperties`.
 
 ```typescript sim-cloudformation-ignored-properties
@@ -1921,34 +1918,33 @@ for (const ignored of stack.ignoredProperties) {
 ```
 
 Each entry names the `logicalId` and `resourceType` of the Resource, the `path` to the property, and
-a `reason`. The path is the whole way down, so a setting on one entry of a list says which entry it
+a `reason`. The path is the whole way down, and a setting on one entry of a list says which entry it
 was on, such as `GlobalSecondaryIndexes.1.WarmThroughput`. The same list is on each Resource as
 `resource.ignoredProperties`.
 
 **An ignored property means the simulated Resource behaves differently to the one the template
-describes.** That is the trade this makes: a template deploys as far as it can, and the record is
+describes.** That is the trade this makes. A template deploys as far as it can, and the record is
 where to check whether what it could not do matters to the test you are writing. A test asserting on
 object versions, on a dead-letter queue, or on a rotated key needs to look here before trusting the
 result.
 
-A property name that is not one AWS has is recorded the same way rather than failing the stack. A
-typo and a property AWS added after this simulator read the docs look identical from here, and a
-Resource that deploys with the unread name reported is more useful than a stack that fails over
-either.
+A property name AWS has never had is recorded the same way, and never fails the stack. A typo and a
+property AWS added after this simulator read the docs look identical from here, and a Resource that
+deploys with the unread name reported is more useful than a stack that fails over either.
 
 Two things are still refused outright, and fail the Resource:
 
 - A property that leaves nothing coherent to create, such as an `AWS::S3::Bucket` whose `BucketName`
-  is not a string, or an `AWS::DynamoDB::GlobalTable` whose replica list does not include the region
-  the stack is deploying into. Real CloudFormation refuses these templates too.
-- A value the simulated service itself refuses, which is refused in the same words an SDK caller
-  gets. An `AWS::SQS::Queue` with `FifoQueue: true` is one: a FIFO queue is named `<name>.fifo`,
-  which simulated SQS refuses, so there is no queue to create under the name the template gave it.
+  is some type other than a string, or an `AWS::DynamoDB::GlobalTable` whose replica list omits the
+  region the stack is deploying into. Real CloudFormation refuses these templates too.
+- A value the simulated service itself refuses, in the same words an SDK caller gets. An
+  `AWS::SQS::Queue` with `FifoQueue: true` is one. A FIFO queue is named `<name>.fifo`, which
+  simulated SQS refuses, leaving no queue to create under the name the template gave it.
 
-Properties nothing simulated could tell apart are not listed. There is no simulated KMS and Object
-bytes are stored as they arrive, so an `AWS::S3::Bucket` carrying `BucketEncryption` and `Tags`, as
-almost every Bucket CDK synthesizes does, records nothing: a report of differences that make no
-difference is one nobody can read.
+Properties nothing simulated could tell apart are left off the list. There is no simulated KMS and
+Object bytes are stored as they arrive. An `AWS::S3::Bucket` carrying `BucketEncryption` and `Tags`,
+as almost every Bucket CDK synthesizes does, therefore records nothing. A report of differences that
+make no difference is one nobody can read.
 
 ## Handling deployment failures
 
@@ -2070,7 +2066,7 @@ Each service's own docs describe what its resource types support.
 ## Limitations
 
 - `TemplateBody` must be JSON when using `CreateStackCommand` or `UpdateStackCommand`. YAML parsing
-  is not currently provided by the CloudFormation service.
+  is outside the CloudFormation service for now.
 - Only supported resource types create simulated service resources. An unsupported resource may be
   skipped or may fail the stack, depending on how safely the simulator can model it. A skipped
   resource answers `Ref` and `Fn::GetAtt` with
@@ -2081,24 +2077,23 @@ Each service's own docs describe what its resource types support.
   `stack.inertResources` instead, and are listed under
   [resources deliberately left out](#resources-deliberately-left-out). Read both when accounting for
   every resource in a template.
-- `AWS::Logs::LogGroup` is created, including the one CDK writes for a custom resource provider,
-  which is left empty because that provider is never invoked. A log group a stack declares for a
+- `AWS::Logs::LogGroup` is created, including the one CDK writes for a custom resource provider. That
+  one is left empty, because the provider is never invoked. A log group a stack declares for a
   Lambda function is the same group that function writes to, and a group already there is taken over
   rather than failing the deploy the way real CloudFormation does. See the
   [simulated CloudWatch Logs docs](../logs/ "Simulated CloudWatch Logs usage docs").
-- A resource property that is not simulated is left out and recorded in `stack.ignoredProperties`
-  rather than failing the stack, so the resource is created behaving differently to the one the
+- A resource property outside the simulation is left out and recorded in `stack.ignoredProperties`
+  rather than failing the stack. The resource is created behaving differently to the one the
   template describes. See
   [properties a Resource was created without](#properties-a-resource-was-created-without) for what
   is still refused outright.
 - A stack update replaces a changed resource rather than updating it in place, so what the resource
   held is lost. See [changed resources are replaced](#changed-resources-are-replaced).
-- A watched template file updates its stack in place, which does not make the update itself any
-  gentler: a changed resource is still replaced and loses what it holds, the same as any other
-  update.
-- Yulin never synthesizes a CDK app. It watches the synthesized output template, so a change to the
-  app itself only reaches the stack once something has run `cdk synth` over it.
-- A stack update applies a whole template directly. Change sets are not supported, so
+- A watched template file updates its stack in place. That makes the update itself no gentler. A
+  changed resource is still replaced and loses what it holds, the same as any other update.
+- Yulin never synthesizes a CDK app. It watches the synthesized output template. A change to the app
+  itself reaches the stack once something has run `cdk synth` over it.
+- A stack update applies a whole template directly. Change sets are outside the simulation, so
   `CreateChangeSetCommand` and `ExecuteChangeSetCommand` have nothing behind them, and neither does
   drift detection.
 - A failed stack update is not rolled back to the template the stack was deployed from. The stack is
@@ -2109,7 +2104,7 @@ Each service's own docs describe what its resource types support.
   is no queue behind it.
 - A stack deletion deletes only the resource types the simulator can delete. A resource type it
   creates but cannot delete is recorded in `stack.skippedResourceDeletions` and stepped over, the
-  same way an unsupported resource type is on create, so the stack still deletes with that resource
+  same way an unsupported resource type is on create, and the stack still deletes with that resource
   left behind.
 - `DeletionPolicy` is read for `Retain` and `RetainExceptOnCreate` only. `Snapshot` is treated as
   `Delete`, because no simulated service takes snapshots.
@@ -2124,15 +2119,15 @@ Each service's own docs describe what its resource types support.
   argument is `{ "DefaultValue": ... }`, is rejected.
 - `Fn::FindInMap` arguments are resolved from literals, `Parameters` and pseudo parameters. An
   argument that depends on a created resource, such as a `Ref` to a resource logical ID, fails the
-  resource with a "could not find map" error rather than being resolved. Real CloudFormation allows
-  only `Ref` and a nested `Fn::FindInMap` inside `Fn::FindInMap`, so this only affects templates real
-  CloudFormation would reject as well, but the simulator does not reject them up front.
-- `Fn::If` is not supported inside the `Conditions` section itself. It is rejected there rather than
+  resource with a "could not find map" error. Real CloudFormation allows only `Ref` and a nested
+  `Fn::FindInMap` inside `Fn::FindInMap`. The templates affected here are ones real CloudFormation
+  would reject as well. The simulator just rejects them later rather than up front.
+- `Fn::If` is unsupported inside the `Conditions` section itself. It is rejected there rather than
   read against a half-evaluated section.
 - `Fn::Split` and `Fn::Select` accept any argument that resolves to the type they need. Real
-  CloudFormation allows only a named set of functions inside each of them, so a template the
-  simulator resolves may still be one CloudFormation rejects.
+  CloudFormation allows only a named set of functions inside each of them. A template the simulator
+  resolves may still be one CloudFormation rejects.
 - The `Condition` attribute is read on resources but not on outputs. An output carrying one is
   resolved and present in `stack.outputs` whichever way its condition falls, where real
   CloudFormation would leave it out.
-- Many advanced CloudFormation features are not supported.
+- Many advanced CloudFormation features are outside the simulation.

--- a/docs/services/cloudformation/README.md
+++ b/docs/services/cloudformation/README.md
@@ -286,9 +286,9 @@ stack has moved to `UPDATE_IN_PROGRESS`, and `waitForStackUpdateComplete(...)` w
 resources to change. `DescribeStacksCommand` reports `UPDATE_IN_PROGRESS` in between and
 `UPDATE_COMPLETE` after, along with the outputs resolved again against the new template.
 
-Updating a stack name that was never deployed is refused with the same `ValidationError`
-`DescribeStacksCommand` refuses it with. An update of a stack that was never there could mean nothing
-else.
+`UpdateStackCommand` refuses a stack name that was never deployed, with the same `ValidationError`
+that `DescribeStacksCommand` answers such a name with. An update of a stack that was never there
+could mean nothing else.
 
 ### What counts as a change
 
@@ -1225,7 +1225,8 @@ to. Saying it on the first change instead would be a long way from the mistake. 
 without a `reload` alongside it. Given both, the callback runs first and the reload follows it, and a
 browser arriving on the new resources finds whatever the callback left ready for it.
 
-`onFailed` is given an update the changed template failed. It reports the failure and nothing else.
+`onFailed` is given the update the changed template failed to survive. It reports the failure and
+nothing else.
 The stack is left holding whatever the update reached, as it is after an update through the command.
 What a failure does keep is the process, and the resources it never got to. A template that no longer
 deploys leaves a working environment where a restart on it would leave none.
@@ -1756,8 +1757,8 @@ This is useful in tests when you want to assert that a specific template resourc
 expected simulated service resource.
 
 `stack.skippedResources` lists the Resources the deployment did not create. Each one carries a
-`skippedReason` naming the type outside the simulation. A test that expected a resource to exist can
-find out what happened to it.
+`skippedReason` saying why that Resource was skipped. A test that expected a resource to exist can
+find out why it is missing.
 
 ```typescript sim-cloudformation-inspect-skipped
 /**

--- a/docs/services/cloudwatch/README.md
+++ b/docs/services/cloudwatch/README.md
@@ -5,12 +5,12 @@ metrics: the datapoints `PutMetricData` publishes, and the statistics `GetMetric
 `GetMetricData` read back from them, without an AWS account. It also holds alarms over those
 metrics, which evaluate on the simulation's clock and notify an SNS topic when they change state.
 
-That is what this service is for. Code that publishes a business metric is code teams already have,
-and until now the only way to test it was to assert that the SDK client had been called, which
-proves the call was made and nothing about what it measured.
+Code that publishes a business metric is code teams already have, and until now the only way to test
+it was to assert that the SDK client had been called. That proves the call was made. What it
+measured goes untested.
 
-Only custom metrics live here. Nothing in this simulation publishes into the `AWS/` namespaces, so a
-query for `AWS/Lambda` `Invocations` finds nothing rather than a number that was never measured.
+Only custom metrics live here. This simulation publishes into no `AWS/` namespace. A query for
+`AWS/Lambda` `Invocations` comes back empty, in place of a number that was never measured.
 
 CloudWatch specific types are imported from the `@kensio/yulin/cloudwatch` subpath.
 
@@ -66,28 +66,27 @@ console.log(read.Datapoints?.at(0)?.Sum);
 ```
 
 A datum may state its values as a plain `Value`, as a `StatisticValues` summary, or as `Values` with
-matching `Counts`. All three answer the same statistics, so a metric published one way reads back
+matching `Counts`. All three answer the same statistics, and a metric published one way reads back
 like a metric published another.
 
 Values are checked the way real CloudWatch checks them: within -2^360 to 2^360, never `NaN` or an
-infinity, at most 150 unique values in one datum, and `Counts` only alongside the `Values` it counts.
-`Unit` is the closed `StandardUnit` set rather than free text, on the way in and on the way out, so a
-query naming a unit CloudWatch does not have fails here as it would in an account rather than
-quietly matching nothing.
+infinity, at most 150 unique values in one datum, and `Counts` only alongside the `Values` it
+counts. `Unit` is the closed `StandardUnit` set, not free text, on the way in and on the way out. A
+query naming a unit CloudWatch lacks fails here as it would in an account.
 
 ## Metrics are identified by their dimensions
 
-Real CloudWatch does not roll a custom metric up across its dimensions, and neither does this. The
-same metric name published under two channels is two metrics, and a read naming no dimensions
-reaches the metric that was published with none rather than the total of all of them.
+Real CloudWatch leaves a custom metric unrolled across its dimensions, and so does this. The same
+metric name published under two channels is two metrics, and a read naming no dimensions reaches the
+metric that was published with none, not the total of all of them.
 
-That is the behaviour teams most often get wrong, so it is worth a test of its own: a dashboard
+That is the behaviour teams most often get wrong, and it is worth a test of its own. A dashboard
 query written against a metric name alone finds nothing at all if every publish carried a dimension.
 
 ## Metrics and simulated time
 
-A datum carrying no `Timestamp` is stamped from the simulation's clock, not the host's. A test with a
-frozen clock therefore gets timestamps it can assert on exactly, and one that moves time on gets
+A datum carrying no `Timestamp` is stamped from the simulation's clock, not the host's. A test with
+a frozen clock therefore gets timestamps it can assert on exactly, and one that moves time on gets
 datapoints in the period it moved to:
 
 ```typescript sim-cloudwatch-simulated-time
@@ -146,9 +145,9 @@ window drops a metric out of the listing without anything having to expire it.
 
 ## Alarms
 
-An alarm watches one metric and changes state on the simulation's clock. Nothing here uses a real
-timer: each evaluation is scheduled at the next period boundary, so a frozen clock evaluates nothing
-and advancing time by twenty minutes walks twenty one-minute evaluations and settles before the next
+An alarm watches one metric and changes state on the simulation's clock, with no real timer behind
+it. Each evaluation is scheduled at the next period boundary. A frozen clock evaluates nothing, and
+advancing time by twenty minutes walks twenty one-minute evaluations and settles before the next
 line of the test runs.
 
 ```typescript sim-cloudwatch-alarm
@@ -209,22 +208,22 @@ console.log(described.MetricAlarms?.at(0)?.StateValue);
 ```
 
 A new alarm is in `INSUFFICIENT_DATA` until it has evaluated a period, as on real CloudWatch. The
-window it looks back over reaches behind the moment the alarm was created, so an alarm over a metric
-nothing publishes into, with `TreatMissingData: "breaching"`, fires on its first evaluation rather
-than waiting for the periods to accumulate. That is what an account does too.
+window it looks back over reaches behind the moment the alarm was created. An alarm over a metric
+nothing publishes into, with `TreatMissingData: "breaching"`, therefore fires on its first
+evaluation, without waiting for the periods to accumulate. That is what an account does too.
 
 ### Reaching a subscriber
 
-An alarm notifies through the ordinary `Publish` path, so a notification fans out to the topic's
+An alarm notifies through the ordinary `Publish` path. A notification fans out to the topic's
 subscriptions exactly as an SDK caller's message would, with the JSON body real CloudWatch sends:
 `AlarmName`, `NewStateValue`, `OldStateValue`, `NewStateReason`, `StateChangeTime` and `Trigger`.
-Only a change fires anything, so an alarm that stays in `ALARM` across ten periods notifies once.
+Only a change fires anything, and an alarm that stays in `ALARM` across ten periods notifies once.
 
-`SetAlarmState` forces a transition and fires its actions, which is how a test exercises a
-subscriber without arranging for a metric to breach at all.
+`SetAlarmState` forces a transition and fires its actions. That is how a test exercises a subscriber
+without arranging for a metric to breach at all.
 
 The topic has to be in the same account and region as the alarm, as real CloudWatch requires. An
-action that reaches nothing is recorded rather than passing quietly:
+action that lands nowhere is recorded, never passed over quietly:
 
 ```typescript sim-cloudwatch-alarm-failures
 /**
@@ -241,25 +240,26 @@ for (const failure of simAws.cloudWatch().alarmActionFailures) {
 }
 ```
 
-Real CloudWatch tells nobody when an alarm action fails, and neither does this: the alarm changes
-state either way. Keeping the failure is what stops a subscriber's queue being mysteriously empty.
+Real CloudWatch tells nobody when an alarm action fails, and this tells nobody either. The alarm
+changes state regardless. Keeping the failure is what stops a subscriber's queue being mysteriously
+empty.
 
 ### What an alarm can watch and do
 
 - The four threshold comparison operators, `DatapointsToAlarm` for M-of-N evaluation, and all four
   `TreatMissingData` treatments including `ignore`, which leaves the alarm where it is.
-- `ActionsEnabled: false` still evaluates and records state; it just publishes nothing.
+- `ActionsEnabled: false` still evaluates and records state. It just publishes no notification.
 - `DescribeAlarmHistory` reports the state changes with the simulated time each happened at.
 - An SNS topic ARN is the only action target. Auto Scaling, EC2, Systems Manager and Lambda actions
-  are refused rather than stored and ignored, because an alarm that fired and did nothing would let
-  a test pass while the thing the alarm exists to do never happened.
+  are refused, never stored and ignored, because an alarm that fired into nowhere would let a test
+  pass while the thing the alarm exists to do never happened.
 - Composite alarms, anomaly detection and metric math alarms are all refused.
 
 ## Declaring an alarm in a template
 
 Alarms are nearly always declared in infrastructure rather than created through the SDK, so
 `AWS::CloudWatch::Alarm` is deployed by simulated CloudFormation. The alarm a stack creates is the
-same thing `PutMetricAlarm` creates: it evaluates on the clock, fires on a transition, and refuses
+same thing `PutMetricAlarm` creates. It evaluates on the clock, fires on a transition, and refuses
 what the command refuses.
 
 ```yaml
@@ -280,37 +280,38 @@ OrdersFailing:
 ```
 
 `Ref` resolves to the alarm name and `Fn::GetAtt Arn` to the alarm ARN. An `AlarmActions` entry
-holding a `Ref` to an `AWS::SNS::Topic` in the same stack resolves to that topic's ARN, so a test can
+holding a `Ref` to an `AWS::SNS::Topic` in the same stack resolves to that topic's ARN. A test can
 deploy the stack, publish a breaching datapoint, advance the clock and read the notification off
 whatever is subscribed. Deleting the stack deletes the alarm and takes its scheduled evaluation back
 off the clock with it.
 
-`AlarmName` may be left out, and the alarm is then named after the stack and the logical ID, so a
-test still has a name to pass to `DescribeAlarms`. Real CloudFormation generates a physical ID of the
-same shape with a random tail on the end, which is left off here so the name is one a test can
+`AlarmName` may be left out, and the alarm is then named after the stack and the logical ID. A test
+still has a name to pass to `DescribeAlarms`. Real CloudFormation generates a physical ID of the
+same shape with a random tail on the end. The tail is left off here, so the name is one a test can
 predict.
 
-These are the properties acted on: `AlarmName`, `AlarmDescription`, `ActionsEnabled`, `AlarmActions`,
-`OKActions`, `InsufficientDataActions`, `Namespace`, `MetricName`, `Dimensions`, `Statistic`, `Unit`,
-`Period`, `EvaluationPeriods`, `DatapointsToAlarm`, `Threshold`, `ComparisonOperator` and
-`TreatMissingData`.
+These are the properties acted on: `AlarmName`, `AlarmDescription`, `ActionsEnabled`,
+`AlarmActions`, `OKActions`, `InsufficientDataActions`, `Namespace`, `MetricName`, `Dimensions`,
+`Statistic`, `Unit`, `Period`, `EvaluationPeriods`, `DatapointsToAlarm`, `Threshold`,
+`ComparisonOperator` and `TreatMissingData`.
 
 `Metrics`, `ThresholdMetricId`, `ExtendedStatistic` and `EvaluateLowSampleCountPercentile` are
-refused, in the same words `PutMetricAlarm` refuses them with: each of them changes what the alarm
-watches or how it decides, so an alarm deployed with one ignored would sit in a test looking
-configured and evaluating something else.
+refused, in the same words `PutMetricAlarm` refuses them with. Each of them changes what the alarm
+watches or how it decides. An alarm deployed with one ignored would sit in a test looking configured
+and evaluating something else.
 
-`Tags` is the one difference from the command, which refuses it. Real CloudFormation does tag the
-alarm it creates, and nothing here does: a template's tags are usually the whole stack's rather than
-the alarm's, so they are recorded as an ignored property instead of taking the deploy down. Nothing
-reads them back, so an alarm deployed with tags behaves as though the template had never named them.
+`Tags` is the one difference from the command, which refuses it outright. Real CloudFormation tags
+the alarm it creates, and this leaves the alarm untagged. A template's tags are usually the whole
+stack's rather than the alarm's, and they are recorded as an ignored property, leaving the deploy
+standing. Nothing reads them back either. An alarm deployed with tags behaves as though the template
+had never named them.
 
 `AWS::CloudWatch::CompositeAlarm`, `AWS::CloudWatch::Dashboard` and
-`AWS::CloudWatch::AnomalyDetector` are not deployed, and are recorded as gaps in the stack.
+`AWS::CloudWatch::AnomalyDetector` are left undeployed, and recorded as gaps in the stack.
 
 ## Permissions
 
-CloudWatch metrics have no ARN, so there is nothing for a policy to name: every metric action here is
+CloudWatch metrics have no ARN, leaving a policy nothing to name. Every metric action here is
 granted on `*`. A policy written against something like
 `arn:aws:cloudwatch:eu-west-2:111111111111:metric/Orders/Failed` reaches nothing, here and in an
 account.
@@ -392,28 +393,28 @@ await simAws.cloudWatch().putMetricData(
 - `AWS::CloudWatch::Alarm` in simulated CloudFormation, deployed through `PutMetricAlarm` and taken
   down with the stack.
 
-## What is not, and how it says so
+## What is refused, and how it says so
 
-Anything real CloudWatch would accept and this does not carry out is refused with a message saying
-so, rather than accepted and ignored. A silently dropped filter is worse than a failure, because the
+Anything real CloudWatch would accept and this leaves undone is refused with a message saying so,
+rather than accepted and ignored. A silently dropped filter is worse than a failure, because the
 test still passes and no longer means what it says.
 
 - **Composite and anomaly detection alarms.** `Metrics` and `ThresholdMetricId` on `PutMetricAlarm`
-  are refused; there is no trained model here for an anomaly band to come from.
+  are refused. There is no trained model here for an anomaly band to come from.
 - **Metric math.** A `GetMetricData` query carrying an `Expression` is refused.
 - **Percentiles and other extended statistics.** They need the individual values behind a period,
   which a `StatisticValues` datum never carries, so CloudWatch itself cannot report one for a metric
   published that way.
-- **High-resolution metrics.** `StorageResolution: 1` is refused; every period here is a whole
+- **High-resolution metrics.** `StorageResolution: 1` is refused. Every period here is a whole
   number of minutes.
-- **`MaxDatapoints`.** Real CloudWatch answers it by widening the period, and every result here comes
-  back at the period its query asked for.
-- **Cross-account metrics.** `IncludeLinkedAccounts` and `OwningAccount` are refused; there is no
+- **`MaxDatapoints`.** Real CloudWatch answers it by widening the period, and every result here
+  comes back at the period its query asked for.
+- **Cross-account metrics.** `IncludeLinkedAccounts` and `OwningAccount` are refused. There is no
   monitoring account.
 - **Metrics AWS publishes.** No simulated service writes its own `AWS/` metrics.
 
-Two divergences are deliberate rather than refusals. Real CloudWatch rejects a datapoint more than
-two weeks old or more than two hours in the future, and this accepts any timestamp, so that a test
-can seed a window without arranging the clock around it. And datapoints come back earliest first,
-which real CloudWatch's contract permits but does not promise, because a test reading the third
-period of five needs an order it can rely on.
+Two divergences are deliberate, and not refusals. Real CloudWatch rejects a datapoint more than two
+weeks old or more than two hours in the future, and this accepts any timestamp, letting a test seed
+a window without arranging the clock around it. And datapoints come back earliest first, which real
+CloudWatch's contract permits without promising, because a test reading the third period of five
+needs an order it can rely on.

--- a/docs/services/cognito/README.md
+++ b/docs/services/cognito/README.md
@@ -4,7 +4,7 @@ Yulin includes a simulated Cognito user pool directory for tests and local devel
 their app clients are held in memory, and every operation is authorized by simulated IAM.
 
 Only user pools are simulated. Cognito identity pools, which exchange a token for AWS credentials,
-are a different service and are not simulated.
+are a different service and are outside the simulation.
 
 Cognito-specific types are imported from the `@kensio/yulin/cognito` subpath.
 
@@ -86,10 +86,10 @@ with `InvalidPasswordException`, saying which rule it broke.
 
 ## Users
 
-`AdminCreateUser` creates a user in `FORCE_CHANGE_PASSWORD`, which is where real Cognito leaves a
-user an admin made: it has a temporary password and cannot sign in with it. Setting a permanent
-password moves the user to `CONFIRMED`. The status is what the sign-in flows read: a user in
-`FORCE_CHANGE_PASSWORD` gets the `NEW_PASSWORD_REQUIRED` challenge rather than tokens.
+`AdminCreateUser` creates a user in `FORCE_CHANGE_PASSWORD`, where real Cognito leaves a user an
+admin made. It has a temporary password and cannot sign in with it. Setting a permanent password
+moves the user to `CONFIRMED`. The sign-in flows read that status. A user in
+`FORCE_CHANGE_PASSWORD` gets the `NEW_PASSWORD_REQUIRED` challenge, not tokens.
 
 ```typescript sim-cognito-create-user
 /**
@@ -146,13 +146,13 @@ A password set without `Permanent: true` is temporary, and leaves the user in
 `FORCE_CHANGE_PASSWORD` again.
 
 A user's `sub` is a UUID Cognito allocates, reported among its attributes. It is not the username,
-and code treating the two as interchangeable fails here rather than in a deployment. Admin
+and code treating the two as interchangeable fails here, and not in a deployment. Admin
 operations here name a user by its username only. Real Cognito also accepts a `sub` where an
-operation asks for a username, so that is one thing that works there and not here. The refusal says
-so when the username given is some user's `sub`.
+operation asks for a username. That is one thing that works there and not here. The refusal says so
+when the username given is some user's `sub`.
 
 Attributes come back under `Attributes` from `AdminCreateUser` and `ListUsers`, and under
-`UserAttributes` from `AdminGetUser`, which is how the real API names them.
+`UserAttributes` from `AdminGetUser`, as the real API names them.
 
 `AdminUpdateUserAttributes` changes the attributes it names and leaves the rest alone.
 `AdminDisableUser` sets `Enabled` to `false` without changing the user's status, and
@@ -160,14 +160,14 @@ Attributes come back under `Attributes` from `AdminCreateUser` and `ListUsers`, 
 
 ## Signing in by email or phone number
 
-A pool created with `UsernameAttributes` signs its users in by that attribute rather than by a
-username they chose. Cognito generates a UUID as the username for such a user, and the value the
+A pool created with `UsernameAttributes` signs its users in by that attribute, not by a username
+they chose. Cognito generates a UUID as the username for such a user, and the value the
 request called the username goes into the attribute the pool signs in by. That generated username
-is what `AdminGetUser` reports and what the `cognito:username` claim carries, so an application
-reading "the username" off such a pool reads a UUID.
+is what `AdminGetUser` reports and what the `cognito:username` claim carries. An application reading
+"the username" off such a pool reads a UUID.
 
-A CDK `UserPool` with `signInAliases: { email: true }` emits `UsernameAttributes: ["email"]`, which
-is the usual way to build an email sign-in pool.
+A CDK `UserPool` with `signInAliases: { email: true }` emits `UsernameAttributes: ["email"]`, the
+usual way to build an email sign-in pool.
 
 ```typescript sim-cognito-sign-in-by-email
 /**
@@ -253,29 +253,28 @@ user holding it, as real Cognito resolves it, so `AdminGetUser`, `ConfirmSignUp`
 
 A `SECRET_HASH` covers the value the request itself carries. A sign-up or a sign-in naming the
 address computes it over the address. `REFRESH_TOKEN_AUTH` names no user, so its hash is computed
-over the username the token was issued to, which is the generated one.
+over the username the token was issued to, the generated one.
 
 Two users cannot sign in by the same address. A second sign-up with one is refused with
 `UsernameExistsException`, and an `AdminUpdateUserAttributes` request setting one another user
-already holds is refused with `AliasExistsException`. A username that is not written the way the
-attribute's values are, such
-as a plain name on a pool signing in by email, is refused too, because a user created that way
-could never sign in. A request naming one address as the username and a different one as the
-attribute is refused rather than resolved in favour of either.
+already holds is refused with `AliasExistsException`. A username written some other way than the
+attribute's values are, such as a plain name on a pool signing in by email, is refused too, because
+a user created that way could never sign in. A request naming one address as the username and a
+different one as the attribute is refused, and never resolved in favour of either.
 
 `UsernameAttributes` takes `email` and `phone_number`, and a pool can name both. It is settled when
-the pool is created: real `UpdateUserPool` has no such input, and a request carrying one here is
+the pool is created. Real `UpdateUserPool` has no such input, and a request carrying one here is
 refused.
 
 ## Custom attributes
 
 A pool holds the standard OpenID Connect attributes, and the ones its `Schema` declares beside them.
-A custom attribute is the ordinary way to hold an application's own identifier for a user: a `sub`
+A custom attribute is the ordinary way to hold an application's own identifier for a user. A `sub`
 belongs to the pool that issued it, so keying application data on one welds that data to a pool that
 cannot be moved.
 
-Cognito prefixes an attribute a pool declares with `custom:`, so a `Schema` naming `userId` is
-written and read as `custom:userId`.
+Cognito prefixes an attribute a pool declares with `custom:`. A `Schema` naming `userId` is written
+and read as `custom:userId`.
 
 ```typescript sim-cognito-custom-attributes
 /**
@@ -361,41 +360,40 @@ console.log(
 // [ "sub", "address", ..., "custom:userId", "custom:seats" ]
 ```
 
-The declaration is held to what real Cognito accepts, so a pool that could not have been created on
-AWS is not created here. A `Required` custom attribute, a `DeveloperOnlyAttribute`, a name longer
-than 20 characters, a name carrying a character Cognito does not take or its own `custom:` prefix,
-an attribute type Cognito does not have, the same attribute declared twice, and a `Schema` with
-nothing in it or with more than the 50 attributes one request may carry are each refused, saying
-why.
+The declaration is held to what real Cognito accepts. A pool AWS would have refused is refused here.
+A `Required` custom attribute, a `DeveloperOnlyAttribute`, a name longer than 20 characters, a name
+carrying a character Cognito rejects or its own `custom:` prefix, an attribute type Cognito lacks,
+the same attribute declared twice, and an empty `Schema` or one with more than the 50
+attributes one request may carry are each refused, saying why.
 
-What an attribute may hold is held to the schema too. A `Number` attribute refuses a value that is
-not a number and one outside its `NumberAttributeConstraints`, a `String` attribute refuses a value
-outside its `StringAttributeConstraints`, and an attribute the schema declares `Mutable: false`
-refuses every write once the user exists, so an immutable attribute is one a user is created with or
-does without. An attribute no schema declares is refused, saying which ones the pool does hold.
+What an attribute may hold is held to the schema too. A `Number` attribute refuses a non-numeric
+value and one outside its `NumberAttributeConstraints`, a `String` attribute refuses a value outside
+its `StringAttributeConstraints`, and an attribute the schema declares `Mutable: false` refuses
+every write once the user exists. An immutable attribute is one a user is created with or does
+without. An attribute no schema declares is refused, saying which ones the pool does hold.
 
-A `Schema` can also redeclare a standard attribute, which is what a CDK `UserPool` emits for its
+A `Schema` can also redeclare a standard attribute, which a CDK `UserPool` emits for its
 `standardAttributes`. That is how a pool makes `email` required, and a user created without a
-required attribute is refused. Cognito defaults `Mutable` to `false` in a declaration, so a
+required attribute is refused. Cognito defaults `Mutable` to `false` in a declaration, and a
 redeclared standard attribute is fixed unless the declaration says otherwise.
 
 A pool's schema is settled when the pool is created. `UpdateUserPool` has no `Schema` input on real
-Cognito, so a request carrying one here is refused rather than replacing the attributes of a pool
-that already has users written against them. Real Cognito adds one with `AddCustomAttributes`, which
-is not simulated.
+Cognito, and a request carrying one here is refused, leaving the attributes of a pool that already
+has users written against them alone. Real Cognito adds one with `AddCustomAttributes`. That is
+outside the simulation.
 
 ## Signing up
 
 `SignUp` is the other way a user gets into a pool. It names an app client rather than a pool, is
 authorized by no IAM policy, and leaves the user in `UNCONFIRMED` with the password it chose.
 
-Real Cognito emails or texts a confirmation code at that point. Nothing here delivers a message, so
+Real Cognito emails or texts a confirmation code at that point. Nothing here delivers a message, and
 the code is readable from the pool instead, through `confirmationCode` on the pool object. That is a
-deliberate divergence: real Cognito never reports a code back to anyone, and reading one is what
+deliberate divergence. Real Cognito never reports a code back to anyone, and reading one is what
 makes a registration flow testable at all.
 
-The pool also records the message it would have sent, which is where the wording and the code a user
-would have read are. That is in [Messages a pool would have sent](#messages-a-pool-would-have-sent)
+The pool also records the message it would have sent, holding the wording and the code a user
+would have read. That is in [Messages a pool would have sent](#messages-a-pool-would-have-sent)
 below.
 
 ```typescript sim-cognito-sign-up
@@ -470,9 +468,9 @@ console.log(signedIn.AuthenticationResult?.AccessToken !== undefined); // true
 ```
 
 Signing in before confirming is refused with `UserNotConfirmedException`, which real Cognito answers
-with even when the password was right, so an application can tell the two apart and send the user to
-`ConfirmSignUp`. A wrong password is still refused as any wrong password is, and says nothing about
-the account being unconfirmed.
+with even when the password was right. An application can tell the two apart and send the user to
+`ConfirmSignUp`. A wrong password is still refused as any wrong password is, and gives no hint that
+the account is unconfirmed.
 
 A wrong code is refused with `CodeMismatchException`, and leaves the user unconfirmed holding the
 code it was issued, so a second attempt with the right one works. A code is single use, and
@@ -491,15 +489,14 @@ A pool with a `PreSignUp` trigger can confirm a user at sign-up instead, and one
 
 The pool's `AutoVerifiedAttributes` decide what confirming verifies. A pool created with
 `["email"]` has `email_verified` set to `true` on the user when it confirms, because answering with
-the code shows the address is the user's. `AdminConfirmSignUp` sets nothing, as it sets nothing on
-real Cognito: an admin confirming a user says nothing about whose address it is. Only `email` and
-`phone_number` can be verified, and an attribute the user does not have is left alone.
+the code shows the address is the user's. `AdminConfirmSignUp` verifies no attribute, as on
+real Cognito. An admin confirming a user says nothing about whose address it is. Only `email` and
+`phone_number` can be verified, and an attribute the user lacks is left alone.
 
 A pool created with `AdminCreateUserConfig: { AllowAdminCreateUserOnly: true }` refuses `SignUp`
 with `NotAuthorizedException`, as a real one does. That value is what a CDK `UserPool` without
-`selfSignUpEnabled` emits, so a project testing its registration flow gets the same answer here that
-the deployed pool would give. A pool created without the setting allows sign-up, which is the AWS
-default.
+`selfSignUpEnabled` emits. A project testing its registration flow gets the same answer here that
+the deployed pool would give. A pool created without the setting allows sign-up, the AWS default.
 
 ## Messages a pool would have sent
 
@@ -510,7 +507,7 @@ medium, the subject, the body and the occasion it was sent on.
 A message is recorded on three occasions: a `SignUp`, a `ResendConfirmationCode`, and an
 `AdminCreateUser` that did not ask for `MessageAction: SUPPRESS`. The verification wording is the
 pool's own, and `{####}` is replaced with the code the user was issued. A sign-up a `PreSignUp`
-handler auto-confirmed records none: that user has no code to answer with, and real Cognito sends it
+handler auto-confirmed records none. That user has no code to answer with, and real Cognito sends it
 nothing.
 
 ```typescript sim-cognito-sent-messages
@@ -569,11 +566,11 @@ console.log(message?.body === `Your Acme code is ${code}`); // true
 ```
 
 Where the message goes comes from the user's own attributes, as it does on real Cognito. A
-verification message goes to an attribute the pool verifies automatically, so a pool created with
-`AutoVerifiedAttributes: ["email"]` writes to the user's `email` and a pool that verifies nothing
-records no verification message at all. An invitation goes to the user's `email`, or to its
-`phone_number` where it has no email address. An email is recorded with a subject and a text message
-without one, and a user the pool has no address for is sent nothing.
+verification message goes to an attribute the pool verifies automatically. A pool created with
+`AutoVerifiedAttributes: ["email"]` writes to the user's `email`, and a pool that verifies no
+attribute records no verification message at all. An invitation goes to the user's `email`, or to
+its `phone_number` where it has no email address. An email is recorded with a subject and a text
+message without one, and a user the pool has no address for is sent nothing.
 
 `AdminCreateUser` records the invitation, carrying the username and the temporary password the
 request named, unless the request asked for `MessageAction: SUPPRESS`.
@@ -586,9 +583,9 @@ password` and `Your username is {username} and temporary password is {####}.` fo
 rules real Cognito holds them to: a message carries `{####}`, and runs to 20,000 characters for an
 email and the 140 an SMS carries.
 
-This is Cognito's own delivery record rather than a simulated SES. Real Cognito with the default
+This is Cognito's own delivery record, not a simulated SES. Real Cognito with the default
 `EmailSendingAccount` of `COGNITO_DEFAULT` sends through no other service, and `EmailConfiguration`
-and `SmsConfiguration` are refused here, so no pool is configured for a delivery this record would
+and `SmsConfiguration` are refused here. No pool is configured for a delivery this record would
 misrepresent.
 
 ### The CustomMessage trigger
@@ -599,8 +596,7 @@ replaces the pool's own wording. The handler writes `request.codeParameter` into
 the code belongs, as it does on real Cognito, and the code goes in afterwards.
 
 `triggerSource` names the occasion: `CustomMessage_SignUp`, `CustomMessage_ResendCode` or
-`CustomMessage_AdminCreateUser`. The invitation is the one that carries `request.usernameParameter`
-as well.
+`CustomMessage_AdminCreateUser`. The invitation carries `request.usernameParameter` as well.
 
 ```typescript sim-cognito-custom-message
 /**
@@ -703,19 +699,19 @@ const code = cognito.userPool(userPoolId).confirmationCode("alice")!;
 console.log(message?.body.startsWith(`Your code is ${code}.`)); // true
 ```
 
-A handler that writes nothing leaves the pool's own wording, which is what a handler that only cares
-about one occasion does for the others. A handler that throws fails the request with
+A handler that writes nothing leaves the pool's own wording, which a handler that only cares about
+one occasion does for the others. A handler that throws fails the request with
 `UserLambdaValidationException` and leaves the pool with no message, because the trigger runs before
-the message is recorded. A `response` that is not an object, or a message in it that is not a
-string, fails with `InvalidLambdaResponseException`.
+the message is recorded. A `response` of any other type than an object, or a message in it of any
+other type than a string, fails with `InvalidLambdaResponseException`.
 
 `ClientMetadata` on `SignUp`, `ResendConfirmationCode` and `AdminCreateUser` reaches the handler as
 `request.clientMetadata`.
 
 ### Reading the messages over HTTP
 
-`serveSimAws` lists a pool's recorded messages at `GET /<userPoolId>/messages`, so they can be read
-during local development. Real Cognito serves nothing at that path: it is the serving side of
+`serveSimAws` lists a pool's recorded messages at `GET /<userPoolId>/messages`, readable during
+local development. Real Cognito serves nothing at that path. This is the serving side of
 `sentMessages`, and a divergence for the same reason that accessor is one.
 
 The response is `{ "messages": [ ... ] }`, each message carrying `username`, `recipient`, `medium`,
@@ -723,7 +719,7 @@ The response is `{ "messages": [ ... ] }`, each message carrying `username`, `re
 
 ## Listing users
 
-`ListUsers` pages by `Limit` and `PaginationToken`, which is what the real operation calls them.
+`ListUsers` pages by `Limit` and `PaginationToken`, as the real operation calls them.
 
 ```typescript sim-cognito-list-users
 /**
@@ -761,8 +757,8 @@ console.log(listed.Users?.map((user) => user.Username)); // [ "alice", "bob" ]
 ```
 
 `Filter` is refused rather than ignored. A filter that was quietly dropped would answer with the
-wrong users rather than with an error, which is the kind of pass that turns into a failure in a
-deployment. List the users and filter them in the test instead.
+wrong users and no error, and that is the kind of pass that turns into a failure in a deployment.
+List the users and filter them in the test instead.
 
 ## Groups
 
@@ -841,27 +837,27 @@ console.log(groups.Groups?.map((group) => group.GroupName));
 ```
 
 Zero is the strongest precedence, not the weakest, and a group created without one is weaker than
-any group that has one. `AdminListGroupsForUser` sorts by it, lowest value first, which is the order
-the `cognito:groups` claim will use once tokens are simulated. `ListGroups` does not sort: it lists
-a pool's groups in creation order.
+any group that has one. `AdminListGroupsForUser` sorts by it, lowest value first, the order the
+`cognito:groups` claim will use once tokens are simulated. `ListGroups` leaves its answer unsorted,
+listing a pool's groups in creation order.
 
 Adding a user to a group they are already in succeeds and changes nothing, as it does on real
-Cognito, so nothing has to check first. Removing a user who was never in the group succeeds too.
+Cognito, and nothing has to check first. Removing a user who was never in the group succeeds too.
 
 Deleting a group takes the membership with it and leaves the users alone. Deleting a user takes them
-out of every group, so a group never holds a member the pool cannot describe.
+out of every group, and a group never holds a member the pool cannot describe.
 
 `ListUsersInGroup` reads the membership the other way round, and answers with the same user shape
 `ListUsers` does.
 
 `UpdateGroup` replaces the description, the precedence and the role together, so a property the
-request leaves out is cleared. Real Cognito does not document whether it replaces or merges here,
-and naming every property is the one thing that behaves the same either way.
+request leaves out is cleared. Real Cognito documents neither replacing nor merging here, and naming
+every property is the one thing that behaves the same either way.
 
 ## App clients
 
 An app client is how an application reaches a pool. What it holds decides what that application can
-do, so the settings later work depends on are stored and reported rather than dropped.
+do, and the settings later work depends on are stored and reported, never dropped.
 
 ```typescript sim-cognito-app-client
 /**
@@ -908,15 +904,15 @@ console.log(described.UserPoolClient?.RefreshTokenValidity); // 30, the default
 ```
 
 A client created without `GenerateSecret` has no `ClientSecret` at all, rather than an empty one. A
-client created without `ExplicitAuthFlows` supports `ALLOW_REFRESH_TOKEN_AUTH`, `ALLOW_USER_SRP_AUTH`
-and `ALLOW_CUSTOM_AUTH`, which is what real Cognito gives it. Sign-in with a username and password is
-not among them, which is why `USER_PASSWORD_AUTH` fails on a client nobody configured for it, here
-and on real AWS.
+client created without `ExplicitAuthFlows` supports `ALLOW_REFRESH_TOKEN_AUTH`,
+`ALLOW_USER_SRP_AUTH` and `ALLOW_CUSTOM_AUTH`, which real Cognito gives it. Sign-in with a username
+and password is absent from that set, and that is why `USER_PASSWORD_AUTH` fails on a client nobody
+configured for it, here and on real AWS.
 
-`PreventUserExistenceErrors` decides what a sign-in naming a user the pool does not hold answers
-with. On `ENABLED` it is the `NotAuthorizedException` a wrong password gets, and on `LEGACY` it is
-`UserNotFoundException`. The API default is `LEGACY`, which is what a client created here without
-the setting gets, and the Cognito console sets `ENABLED` on a client made through it.
+`PreventUserExistenceErrors` decides what a sign-in naming a user the pool lacks answers with. On
+`ENABLED` it is the `NotAuthorizedException` a wrong password gets, and on `LEGACY` it is
+`UserNotFoundException`. The API default is `LEGACY`, what a client created here without the setting
+gets, and the Cognito console sets `ENABLED` on a client made through it.
 
 Token lifetimes default to an hour for access and ID tokens and thirty days for refresh tokens. The
 units are separate inputs, so `AccessTokenValidity: 1` means an hour and `RefreshTokenValidity: 1`
@@ -925,14 +921,14 @@ means a day unless `TokenValidityUnits` says otherwise.
 The legacy authentication flows (`ADMIN_NO_SRP_AUTH`, `CUSTOM_AUTH_FLOW_ONLY` and
 `USER_PASSWORD_AUTH`) work on their own, and a request mixing them with the `ALLOW_` prefixed values
 is refused, as real Cognito refuses it. A client holding `ADMIN_NO_SRP_AUTH` can run
-`ADMIN_USER_PASSWORD_AUTH` and one holding `USER_PASSWORD_AUTH` can run `USER_PASSWORD_AUTH`, which
-is what those settings meant before the `ALLOW_` prefixed ones replaced them.
+`ADMIN_USER_PASSWORD_AUTH` and one holding `USER_PASSWORD_AUTH` can run `USER_PASSWORD_AUTH`, what
+those settings meant before the `ALLOW_` prefixed ones replaced them.
 
 ## Updating an app client
 
 `UpdateUserPoolClient` changes a client's settings, and `DescribeUserPoolClient` reports them along
-with a `LastModifiedDate` from when the update happened. A client nothing has updated reports its
-creation date there.
+with a `LastModifiedDate` from when the update happened. A client never updated reports its creation
+date there.
 
 ```typescript sim-cognito-update-app-client
 /**
@@ -979,42 +975,42 @@ console.log(updated.UserPoolClient?.AccessTokenValidity); // 5
 console.log(updated.UserPoolClient?.LastModifiedDate); // when the update ran
 ```
 
-An update replaces the client's configuration rather than merging into it, which is what real
-Cognito does. A setting the request leaves out goes back to the default `CreateUserPoolClient` would
-have given it, so the example above repeats `ExplicitAuthFlows` to keep them. A request carrying
-only `ClientName` sends the authentication flows back to `ALLOW_REFRESH_TOKEN_AUTH`,
+An update replaces the client's configuration rather than merging into it, as real Cognito does. A
+setting the request leaves out goes back to the default `CreateUserPoolClient` would have given it,
+and that is why the example above repeats `ExplicitAuthFlows` to keep them. A request carrying only
+`ClientName` sends the authentication flows back to `ALLOW_REFRESH_TOKEN_AUTH`,
 `ALLOW_USER_SRP_AUTH` and `ALLOW_CUSTOM_AUTH`, the token validities back to an hour and thirty days,
 and `PreventUserExistenceErrors` back to `LEGACY`.
 
 `ClientName` is the one setting an omitted request keeps rather than resets. A client has to have a
-name, and `CreateUserPoolClient` requires one, so there is no default to go back to.
+name, and `CreateUserPoolClient` requires one, leaving no default to go back to.
 
 The client's secret is untouched by an update. `UpdateUserPoolClient` has no `GenerateSecret` input
-on real Cognito, so a client created without a secret never gains one and a client with one keeps the
-same value.
+on real Cognito, and a client created without a secret never gains one while a client with one keeps
+the same value.
 
 A token already issued keeps the expiry it was issued with, because that expiry was stamped when the
-token was handed out. Shortening `AccessTokenValidity` therefore applies to the next sign-in rather
-than to a token a test is already holding, as it does on real Cognito. A changed `ExplicitAuthFlows`
-takes effect for the next `InitiateAuth`, so removing `ALLOW_USER_PASSWORD_AUTH` starts refusing that
-flow.
+token was handed out. Shortening `AccessTokenValidity` therefore applies to the next sign-in, and
+not to a token a test is already holding, as it does on real Cognito. A changed `ExplicitAuthFlows`
+takes effect for the next `InitiateAuth`, and removing `ALLOW_USER_PASSWORD_AUTH` starts refusing
+that flow.
 
 The inputs `CreateUserPoolClient` refuses are refused here too, in the same words, saying
 `UpdateUserPoolClient`.
 
 ## Signing in and verifying tokens
 
-`AdminInitiateAuth` runs the `ADMIN_USER_PASSWORD_AUTH` flow and answers with real signed tokens. The
-app client has to be created with `ALLOW_ADMIN_USER_PASSWORD_AUTH` among its `ExplicitAuthFlows`, as
-it does on real Cognito, and a request against a client without it is refused whatever the password
-was.
+`AdminInitiateAuth` runs the `ADMIN_USER_PASSWORD_AUTH` flow and answers with real signed tokens.
+The app client has to be created with `ALLOW_ADMIN_USER_PASSWORD_AUTH` among its
+`ExplicitAuthFlows`, as it does on real Cognito, and a request against a client without it is
+refused whatever the password was.
 
 This is the server-side flow, which needs AWS credentials and the
 `cognito-idp:AdminInitiateAuth` permission. The client-side flow a browser or mobile app uses is
 `InitiateAuth`, below.
 
 The tokens are RS256 JWTs signed by a key the pool publishes. Hand that JWKS to a verifier and it
-verifies them with nothing stubbed and nothing on the network.
+verifies them with nothing stubbed and no network involved.
 
 ```typescript sim-cognito-sign-in
 /**
@@ -1086,9 +1082,9 @@ console.log(payload.username); // "alice"
 console.log(payload.sub); // a UUID, and not "alice"
 ```
 
-An `AuthenticationResult` carries an `AccessToken`, an `IdToken`, a `RefreshToken`, an `ExpiresIn` of
-3600 and a `TokenType` of `Bearer`. The refresh token is an opaque string rather than a JWT, as it is
-on real Cognito, and the pool that issued it is what knows whose it is.
+An `AuthenticationResult` carries an `AccessToken`, an `IdToken`, a `RefreshToken`, an `ExpiresIn`
+of 3600 and a `TokenType` of `Bearer`. The refresh token is an opaque string, not a JWT, as it is on
+real Cognito, and the pool that issued it is what knows whose it is.
 
 The claim split is the real one. The id token carries `aud`, `token_use: "id"`, `cognito:username`
 and the user's attributes. The access token carries `client_id` and no `aud`, `token_use: "access"`,
@@ -1102,7 +1098,7 @@ names `RS256` and a `kid` the pool's JWKS holds. That is everything a verifier c
 ## The new password challenge
 
 A user an admin created is in `FORCE_CHANGE_PASSWORD` and cannot sign in. Signing in with its
-temporary password answers with the `NEW_PASSWORD_REQUIRED` challenge and a session rather than
+temporary password answers with the `NEW_PASSWORD_REQUIRED` challenge and a session, not
 tokens, and `AdminRespondToAuthChallenge` completes it.
 
 ```typescript sim-cognito-new-password-challenge
@@ -1169,17 +1165,17 @@ const signedIn = await cognito.adminRespondToAuthChallenge(
 console.log(signedIn.AuthenticationResult?.IdToken?.split(".").length); // 3
 ```
 
-Name a `TemporaryPassword` on `AdminCreateUser` when the test means to sign the user in. Real Cognito
-generates one and emails it, and nothing here delivers a message, so a user created without one has
-no password that works.
+Name a `TemporaryPassword` on `AdminCreateUser` when the test means to sign the user in. Real
+Cognito generates one and emails it, and nothing here delivers a message. A user created without one
+has no password that works.
 
 The new password is checked against the pool's policy and confirms the user, which signs in normally
 from then on. A session is single use and lasts three minutes of simulated time, so a replayed one
 and one left too long both fail with `NotAuthorizedException`.
 
-A wrong password and a disabled user fail with `NotAuthorizedException` too, saying no more than real
-Cognito says. An app client created with `GenerateSecret: true` needs a correct `SECRET_HASH` in
-`AuthParameters`, which is the HMAC-SHA256 of the username and client id keyed by the client secret.
+A wrong password and a disabled user fail with `NotAuthorizedException` too, saying no more than
+real Cognito says. An app client created with `GenerateSecret: true` needs a correct `SECRET_HASH`
+in `AuthParameters`, the HMAC-SHA256 of the username and client id keyed by the client secret.
 
 ## Signing in from a client
 
@@ -1264,16 +1260,16 @@ console.log(refreshed.AuthenticationResult!.RefreshToken); // undefined
 ## Refreshing tokens
 
 `REFRESH_TOKEN_AUTH` exchanges a refresh token for a new access token and a new id token. No new
-refresh token comes back, as none does on real Cognito with refresh token rotation off, so the
-client keeps the one it has until that expires. `REFRESH_TOKEN` is the same flow under its other
+refresh token comes back, as none does on real Cognito with refresh token rotation off. The client
+keeps the one it has until that expires. `REFRESH_TOKEN` is the same flow under its other
 name, and both `InitiateAuth` and `AdminInitiateAuth` run it.
 
-The app client has to have `ALLOW_REFRESH_TOKEN_AUTH`, which is one of the flows a client created
-without `ExplicitAuthFlows` gets.
+The app client has to have `ALLOW_REFRESH_TOKEN_AUTH`, one of the flows a client created without
+`ExplicitAuthFlows` gets.
 
 A refresh token lasts the app client's `RefreshTokenValidity`, thirty days by default, counted on
 the simulated clock. Advancing time past that is what makes a refresh fail with
-`NotAuthorizedException`, so a test can exercise the sign-in-again path without waiting a month.
+`NotAuthorizedException`, and a test can exercise the sign-in-again path without waiting a month.
 
 A refresh token belongs to the app client that got it, so presenting one to another client in the
 same pool is refused. A refresh for a user that has been disabled or deleted is refused too.
@@ -1284,9 +1280,9 @@ same pool is refused. A refresh for a user that has been disabled or deleted is 
 rather than by IAM. `AdminUserGlobalSignOut` does the same thing for a user an administrator names,
 and does need the `cognito-idp:AdminUserGlobalSignOut` permission on the pool.
 
-After either, the user's refresh tokens are gone, so a `REFRESH_TOKEN_AUTH` request fails and the
-user has to sign in again. Signing out does not stop the user signing in: it ends the sessions it
-had.
+After either, the user's refresh tokens are gone, and a `REFRESH_TOKEN_AUTH` request fails while the
+user has to sign in again. Signing out leaves the user free to sign in again. It ends the sessions
+it had.
 
 ```typescript sim-cognito-sign-out
 /**
@@ -1368,8 +1364,8 @@ try {
 
 A pool with a domain serves the OAuth endpoints an authorization code grant runs through, on the
 domain's own hostname. That is the only way a user signs in with Google or another external
-provider: there is no Cognito API operation that does it, so an application redirects the browser to
-the authorize endpoint and exchanges the code it comes back with.
+provider. No Cognito API operation does it, so an application redirects the browser to the authorize
+endpoint and exchanges the code it comes back with.
 
 Three things have to be in place. The pool needs a domain, the app client needs the OAuth settings
 that say what it may ask for and where the user may be sent back to, and the provider itself has to
@@ -1441,10 +1437,9 @@ const domain = await cognito.describeUserPoolDomain(
 console.log(domain.DomainDescription!.Status); // "ACTIVE"
 ```
 
-A prefix domain is served at `<prefix>.auth.<region>.amazoncognito.com`, and a custom domain, which
-is one created with a `CustomDomainConfig`, at the hostname it names. A pool has one domain, and a
-domain string is unique across every simulated account and region, as it is across the whole of real
-AWS.
+A prefix domain is served at `<prefix>.auth.<region>.amazoncognito.com`, and a custom domain, one
+created with a `CustomDomainConfig`, at the hostname it names. A pool has one domain, and a domain
+string is unique across every simulated account and region, as it is across the whole of real AWS.
 
 ### Who is signed in at the provider
 
@@ -1473,10 +1468,10 @@ cognito
   });
 ```
 
-`signInAs` stands in for everything that happens at the provider, which is where a real user types a
-password this simulation never sees. An authorize request that reaches a provider nobody is signed
-in at is refused, saying so, rather than signing in a user nothing put there. `signOut()` on the
-provider puts it back that way.
+`signInAs` stands in for everything that happens at the provider, where a real user types a password
+this simulation never sees. An authorize request that reaches a provider nobody is signed in at is
+refused, saying so, rather than signing in a user nothing put there. `signOut()` on the provider
+puts it back that way.
 
 ### Driving the code flow
 
@@ -1484,7 +1479,7 @@ The browser goes to `/oauth2/authorize`, comes back to the app client's callback
 and the application's own server exchanges that code at `/oauth2/token`. Both endpoints are on the
 domain's hostname, and `SimAwsHttp` sends a request into the simulation without a server listening.
 A domain answers on the real AWS hostname as well as on the localhost one `serveSimAws` rewrites it
-to, so the URL an application already builds needs no changing:
+to. The URL an application already builds needs no changing:
 
 ```typescript sim-cognito-hosted-sign-in
 /**
@@ -1563,7 +1558,7 @@ console.log(claims["email"]); // "someone@example.com"
 ```
 
 The pool creates a user of its own for each external subject the first time it signs in, exactly as
-real Cognito does: the username is the provider name and the subject with an underscore between
+real Cognito does. The username is the provider name and the subject with an underscore between
 them, the status is `EXTERNAL_PROVIDER`, and the provider's claims reach the user through the
 provider's attribute mapping. The same subject signing in again reaches the same user, with its
 mapped attributes brought up to date. `AdminGetUser` reports where it came from in an `identities`
@@ -1577,7 +1572,7 @@ out.
 
 `GET /logout?client_id=...&logout_uri=...` redirects to the sign-out URL, once it has checked it is
 one of the app client's `LogoutURLs`. It ends no session, because there is no managed login cookie
-here: every authorize request signs in afresh at the identity provider. `GlobalSignOut` and
+here. Every authorize request signs in afresh at the identity provider. `GlobalSignOut` and
 `AdminUserGlobalSignOut` are what revoke a user's tokens.
 
 ### PKCE
@@ -1608,15 +1603,15 @@ a message. Each one is given the real event and has to return it, changed or not
 [The CustomMessage trigger](#the-custommessage-trigger) above. The rest are here.
 
 The function is a simulated Lambda function anywhere in the simulation, and it has to admit
-`cognito-idp.amazonaws.com` for the pool, which is what `AddPermission` grants and what CDK's
-`addTrigger` emits an `AWS::Lambda::Permission` for.
+`cognito-idp.amazonaws.com` for the pool. `AddPermission` grants that, and CDK's `addTrigger` emits
+an `AWS::Lambda::Permission` for it.
 
 ### Sign-up triggers
 
-`PreSignUp` runs before the pool takes the new user, so a handler that throws refuses the sign-up
-with `UserLambdaValidationException` and leaves no user behind. `PostConfirmation` runs once the
-user has reached `CONFIRMED`, and is given its attributes with the `sub` the pool allocated among
-them, which is what a handler keys an external record on.
+`PreSignUp` runs before the pool takes the new user. A handler that throws refuses the sign-up with
+`UserLambdaValidationException` and leaves no user behind. `PostConfirmation` runs once the user has
+reached `CONFIRMED`, and is given its attributes with the `sub` the pool allocated among them, which
+a handler keys an external record on.
 
 The handler runs as its function's execution role, so a call it makes to another simulated service
 is authorized by simulated IAM the way the deployed function's would be.
@@ -1804,15 +1799,15 @@ A `PreSignUp` handler answers in the `response` it is given, which arrives with 
 `autoVerifyEmail` and `autoVerifyPhone` all set to `false`. Setting `autoConfirmUser` takes the new
 user straight to `CONFIRMED`, and `SignUp` reports `UserConfirmed: true`. The two verify flags set
 `email_verified` and `phone_number_verified` without a code being answered, and work whether or not
-the user was confirmed. Asking to verify an attribute the sign-up did not carry refuses the sign-up,
-as it does on real Cognito, rather than creating a user with the flag quietly unset.
+the user was confirmed. Asking to verify an attribute the sign-up left out refuses the sign-up, as
+it does on real Cognito, rather than creating a user with the flag quietly unset.
 
-A user confirmed that way still reaches `PostConfirmation`, at sign-up rather than at a
+A user confirmed that way still reaches `PostConfirmation`, at sign-up and not at a
 `ConfirmSignUp` that never comes. A project whose users never confirm is covered by that, here as on
 real Cognito.
 
 `AdminCreateUser` reaches `PreSignUp` and never reaches `PostConfirmation`. That matters more than
-it looks: `AdminCreateUser` is the obvious place to hang the trigger and the wrong one, and a
+it looks. `AdminCreateUser` is the obvious place to hang the trigger and the wrong one, and a
 project relying on it would pass here and write nothing in production. What the handler wrote into
 the response is ignored on that occasion too, because an admin-created user is already past
 confirmation. Real Cognito ignores all three flags there.
@@ -1820,16 +1815,16 @@ confirmation. Real Cognito ignores all three flags there.
 The `ValidationData` and `ClientMetadata` a request carries reach the handler. `SignUp` and
 `AdminCreateUser` pass both to `PreSignUp`, as `request.validationData` and
 `request.clientMetadata`. `ConfirmSignUp` and `AdminConfirmSignUp` pass their `ClientMetadata` to
-`PostConfirmation`. Neither is stored on the user, as neither is on real Cognito.
+`PostConfirmation`. Neither is stored on the user, as on real Cognito.
 
-The admin operations have no app client to name, so a handler fired by `AdminCreateUser` or
-`AdminConfirmSignUp` reads `callerContext.clientId` as `CLIENT_ID_NOT_APPLICABLE`, which is what
-real Cognito sends.
+The admin operations have no app client to name. A handler fired by `AdminCreateUser` or
+`AdminConfirmSignUp` reads `callerContext.clientId` as `CLIENT_ID_NOT_APPLICABLE`, which real
+Cognito sends.
 
 ### Sign-in triggers
 
 `PreAuthentication` runs once the user is known and before its password is checked, so a wrong
-password reaches it too: the trigger is given the user to decide about, and deciding is what it is
+password reaches it too. The trigger is given the user to decide about, and deciding is what it is
 for. `PostAuthentication` runs once the tokens have been issued.
 
 ```typescript sim-cognito-lambda-triggers
@@ -1961,10 +1956,10 @@ Cognito. Neither fires for `REFRESH_TOKEN_AUTH`, as neither does on real Cognito
 
 Every event carries `version`, `region`, `userPoolId`, `userName`, the `triggerSource` naming the
 occasion, a `callerContext` naming the app client, and the `request` and `response` pair. The
-`request` holds `userAttributes` as a plain object of strings rather than the `Name`/`Value` pairs
-the API answers with.
+`request` holds `userAttributes` as a plain object of strings, not the `Name`/`Value` pairs the
+API answers with.
 
-`sub` is among those attributes everywhere except `PreSignUp`, where the user does not exist yet: on
+`sub` is among those attributes everywhere except `PreSignUp`, where the user is yet to exist. On
 real Cognito the sub is allocated once the sign-up has got past that handler. A handler keying an
 external record on `sub` has to be a `PostConfirmation` one, here as there.
 
@@ -1972,13 +1967,13 @@ Three failures are reported the way real Cognito reports them:
 
 - A handler that throws fails the request with `UserLambdaValidationException`, carrying the message
   it threw. For `PreSignUp` and `PreAuthentication` that is how the trigger turns the request down.
-- A trigger naming a function that is not there, or one whose resource policy does not admit
+- A trigger naming a function the simulation lacks, or one whose resource policy withholds
   `cognito-idp.amazonaws.com` for the pool, fails with `UnexpectedLambdaException`.
 - A handler that returns something other than the event it was given fails with
   `InvalidLambdaResponseException`.
 
 Only the triggers in the table above run. Every other `LambdaConfig` key is refused when the pool is
-created or updated, naming the trigger, so a pool never quietly drops one.
+created or updated, naming the trigger. A pool never quietly drops one.
 
 ## Custom claims from a token trigger
 
@@ -1986,7 +1981,7 @@ created or updated, naming the trigger, so a pool never quietly drops one.
 `response.claimsOverrideDetails`, and the id token is signed with what it asked for.
 `claimsToAddOrOverride` adds or replaces a claim, `claimsToSuppress` removes one, and
 `groupOverrideDetails.groupsToOverride` replaces the `cognito:groups` claim. The group override
-reaches the access token too, which is the one change a `V1_0` trigger makes to one.
+reaches the access token too, the one change a `V1_0` trigger makes to one.
 
 ```typescript sim-cognito-pre-token-generation
 /**
@@ -2122,8 +2117,8 @@ console.log(payload["cognito:groups"]); // ["tenant-admin"]
 The trigger runs wherever the pool issues tokens, and names the occasion in `triggerSource`:
 `TokenGeneration_Authentication` for a sign-in, `TokenGeneration_NewPasswordChallenge` for the
 sign-in that finishes by answering the new password challenge, and `TokenGeneration_RefreshTokens`
-for `REFRESH_TOKEN_AUTH`. A refresh runs the handler again, so a claim that changed since the
-sign-in is on the reissued token rather than being stale for the life of the session.
+for `REFRESH_TOKEN_AUTH`. A refresh runs the handler again. A claim that changed since the
+sign-in is on the reissued token, never stale for the life of the session.
 
 The request the handler is given carries `userAttributes`, a `groupConfiguration.groupsToOverride`
 holding the groups the user is in, and, from a challenge response, `clientMetadata`. Real Cognito
@@ -2134,18 +2129,18 @@ A response naming something this simulation would have to drop is refused with
 `InvalidLambdaResponseException` rather than applied in part:
 
 - A reserved claim in `claimsToAddOrOverride` or `claimsToSuppress`, such as `sub`, `aud`, `iss`,
-  `token_use`, `exp`, `iat` or `auth_time`. Real Cognito ignores an override of one, so a handler
-  that appeared to work here would do nothing deployed.
+  `token_use`, `exp`, `iat` or `auth_time`. Real Cognito ignores an override of one. A handler that
+  appeared to work here would have no effect deployed.
 - Any `cognito:` claim in `claimsToAddOrOverride`. `cognito:groups` is changed through
   `groupOverrideDetails` instead, and the refusal says so.
 - `groupOverrideDetails.iamRolesToOverride` or `preferredRole`, because the `cognito:roles` and
-  `cognito:preferred_role` claims they feed are not issued here at all.
-- A claim value that is not a string. Complex claim values arrived with the `V2_0` event, which is
-  not simulated.
+  `cognito:preferred_role` claims they feed go unissued here.
+- A claim value of any other type than a string. Complex claim values arrived with the `V2_0`
+  event, which is outside the simulation.
 
 ## Token timestamps and expiry
 
-`iat`, `exp` and `auth_time` come from the simulation's clock rather than the host's, and the tokens
+`iat`, `exp` and `auth_time` come from the simulation's clock, not the host's, and the tokens
 last the hour a pool's tokens last unless the app client says otherwise.
 
 That makes an expired token something a test can produce: sign the user in with the simulated clock
@@ -2210,19 +2205,19 @@ const signedIn = await cognito.adminInitiateAuth(
 console.log(signedIn.AuthenticationResult?.ExpiresIn); // 3600
 ```
 
-Advancing the clock after a sign-in is a different thing. It moves what the simulation calls now, and
-the timestamps on tokens issued after it, but a verifier reading the host clock still judges a token
-it already holds by host time. Signing in in the past is what produces a token such a verifier
+Advancing the clock after a sign-in is a different thing. It moves what the simulation calls now,
+and the timestamps on tokens issued after it, but a verifier reading the host clock still judges a
+token it already holds by host time. Signing in in the past is what produces a token such a verifier
 refuses.
 
 ## Pool ARNs and IAM policies
 
-A pool ARN is the pool id after `userpool/`, so the region appears twice:
+A pool ARN is the pool id after `userpool/`, and the region appears twice:
 `arn:aws:cognito-idp:eu-west-2:111111111111:userpool/eu-west-2_aBcDeFgHi`.
 
 App clients have no ARN of their own. Every app client operation authorizes against the ARN of the
-pool the client belongs to, so a policy granting `cognito-idp:DescribeUserPoolClient` on a pool
-reaches every client in it. There is no way to narrow it to one client, here or on real AWS.
+pool the client belongs to. A policy granting `cognito-idp:DescribeUserPoolClient` on a pool reaches
+every client in it. There is no way to narrow it to one client, here or on real AWS.
 
 ```typescript sim-cognito-iam-policy
 /**
@@ -2297,13 +2292,13 @@ console.log(described.UserPoolClient?.ClientName); // "web"
 ```
 
 `CreateUserPool` and `ListUserPools` are the exception. Real Cognito gives those two actions no
-resource-level permissions, so they authorize against `*` here, and a policy naming individual pool
+resource-level permissions. They authorize against `*` here, and a policy naming individual pool
 ARNs grants nothing.
 
 The client-side operations are the other exception. `InitiateAuth`, `RespondToAuthChallenge` and
-`GlobalSignOut` authorize nothing at all, because real Cognito evaluates no IAM policy for them:
-they are what an application calls on behalf of a user, holding no AWS credentials. A `caller` is
-not read on those three, and the tokens or the app client id are what authorizes them.
+`GlobalSignOut` authorize against no resource at all, because real Cognito evaluates no IAM policy
+for them: they are what an application calls on behalf of a user, holding no AWS credentials. A
+`caller` goes unread on those three, and the tokens or the app client id are what authorizes them.
 
 That is the difference the two sign-in paths make to a policy. Code calling `AdminInitiateAuth`
 needs `cognito-idp:AdminInitiateAuth` on the pool, and code calling `InitiateAuth` needs no policy
@@ -2312,8 +2307,8 @@ and for `AdminUserGlobalSignOut` against `GlobalSignOut`.
 
 ## Listing pools and clients
 
-`ListUserPools` requires `MaxResults`, as the real API does. A request without it is refused rather
-than answered with a default.
+`ListUserPools` requires `MaxResults`, as the real API does. A request without it is refused, never
+answered with a default.
 
 ```typescript sim-cognito-list-user-pools
 /**
@@ -2350,8 +2345,8 @@ those out of a listing.
 ## Deploying a pool from CloudFormation
 
 `AWS::Cognito::UserPool`, `AWS::Cognito::UserPoolClient` and
-`AWS::Cognito::UserPoolGroup` deploy into simulated Cognito, so a stack that already declares a pool
-does not have to be duplicated in SDK calls to be tested.
+`AWS::Cognito::UserPoolGroup` deploy into simulated Cognito. A stack that already declares a pool
+needs no duplicating in SDK calls to be tested.
 
 ```typescript sim-cognito-cloudformation
 /**
@@ -2457,30 +2452,30 @@ console.log(AuthenticationResult?.AccessToken !== undefined); // true
 | `AWS::Cognito::UserPoolGroup`  | group name | none                                               |
 
 `ProviderName` is `cognito-idp.<region>.amazonaws.com/<userPoolId>` and `ProviderURL` is the same
-with an `https://` prefix, which is also the `iss` claim of the tokens the pool issues.
+with an `https://` prefix, also the `iss` claim of the tokens the pool issues.
 
-An app client publishes no `ClientSecret` attribute, because real CloudFormation publishes none. Read
-the secret with `DescribeUserPoolClient`, which reports it here as it does on real Cognito.
+An app client publishes no `ClientSecret` attribute, because real CloudFormation publishes none.
+Read the secret with `DescribeUserPoolClient`, which reports it here as it does on real Cognito.
 
 The properties each type reads are the ones this simulation models:
 
 - `AWS::Cognito::UserPool`: `UserPoolName`, `Policies`, `DeletionProtection`, `LambdaConfig`,
   `AdminCreateUserConfig`, `AutoVerifiedAttributes`, `UsernameAttributes`, `Schema`,
-  `MfaConfiguration`, `EnabledMfas`,
-  `UserPoolTier`, `AccountRecoverySetting`, `EmailVerificationMessage`, `EmailVerificationSubject`,
-  `SmsVerificationMessage` and `VerificationMessageTemplate`. `LambdaConfig` is read a trigger at a
-  time, so a template naming a trigger this simulation runs deploys and one naming a trigger it
-  does not fails the stack. `UsernameAttributes` is what a CDK `UserPool` emits for its
-  `signInAliases`, so a stack building an email sign-in pool deploys one that
-  [identifies its users](#signing-in-by-email-or-phone-number) the way a deployed one would.
-  `Schema` is what a CDK `UserPool` emits for its `customAttributes` and
-  its `standardAttributes`, so a stack keying its own data on a `custom:` attribute deploys and the
-  sign-up it was built for works. `MfaConfiguration` and `EnabledMfas` are deployed in a
-  `SetUserPoolMfaConfig` call once the pool exists, which is how real CloudFormation deploys them
-  and why a stack declaring MFA needs `cognito-idp:SetUserPoolMfaConfig` on its execution role. A
-  template asking for neither makes no such call. `AccountRecoverySetting` is recorded as the
-  template declared it, and a setting outside the shape Cognito states fails the stack. The last
-  four are the wording of the messages the pool records.
+  `MfaConfiguration`, `EnabledMfas`, `UserPoolTier`, `AccountRecoverySetting`,
+  `EmailVerificationMessage`, `EmailVerificationSubject`, `SmsVerificationMessage` and
+  `VerificationMessageTemplate`. `LambdaConfig` is read a trigger at a time. A template naming a
+  trigger this simulation runs deploys, and one naming a trigger it lacks fails the stack.
+  `UsernameAttributes` is what a CDK `UserPool` emits for its `signInAliases`, and a stack building
+  an email sign-in pool deploys one that [identifies its
+  users](#signing-in-by-email-or-phone-number) the way a deployed one would. `Schema` is what a CDK
+  `UserPool` emits for its `customAttributes` and its `standardAttributes`, and a stack keying its
+  own data on a `custom:` attribute deploys with the sign-up it was built for working.
+  `MfaConfiguration` and `EnabledMfas` are deployed in a `SetUserPoolMfaConfig` call once the pool
+  exists, the way real CloudFormation deploys them and why a stack declaring MFA needs
+  `cognito-idp:SetUserPoolMfaConfig` on its execution role. A template asking for neither makes no
+  such call. `AccountRecoverySetting` is recorded as the template declared it, and a setting outside
+  the shape Cognito states fails the stack. The last four are the wording of the messages the pool
+  records.
 - `AWS::Cognito::UserPoolClient`: `UserPoolId`, `ClientName`, `GenerateSecret`, `ExplicitAuthFlows`,
   `PreventUserExistenceErrors`, `AccessTokenValidity`, `IdTokenValidity`, `RefreshTokenValidity`,
   `TokenValidityUnits`, `AllowedOAuthFlowsUserPoolClient`, `AllowedOAuthFlows`,
@@ -2497,15 +2492,15 @@ The properties each type reads are the ones this simulation models:
 Any other property is left out of what is created and recorded in
 [`stack.ignoredProperties`](../cloudformation/README.md#properties-a-resource-was-created-without),
 naming the logical id, the property and the ones this can act on instead. The pool or client is
-created either way, so a stack full of Cognito resources deploys and the record says which of them
+created either way. A stack full of Cognito resources deploys, and the record says which of them
 behaves differently to the template. A stack that forgets `ALLOW_ADMIN_USER_PASSWORD_AUTH` still
-fails at the sign-in here as it would in a deployment, which is the point of deploying the template
-rather than restating it.
+fails at the sign-in here as it would in a deployment, the point of deploying the template at
+all.
 
 `UserPoolName` and `ClientName` are optional. A template that sets neither gets
 `<stack name>-<logical id>`, as real CloudFormation generates a name, trimmed to the 128 characters
 Cognito allows if the two are longer than that together. Real CloudFormation adds random characters
-on the end and this does not, so the name is the same on every deployment of the same template and a
+on the end and this adds none. The name is the same on every deployment of the same template, and a
 test can assert it.
 
 ## Properties accepted without being simulated
@@ -2515,8 +2510,8 @@ for anything, and a client created with `disableOAuth` emits two on `AWS::Cognit
 Most of them are simulated: `AdminCreateUserConfig` decides whether `SignUp` works against the pool,
 and the four verification wording properties are what a recorded message says.
 
-`AccountRecoverySetting` is the one that is not. There is no `ForgotPassword` here, so no recovery
-is ever started and no mechanism is ever chosen. The pool records the mechanisms it was asked for
+`AccountRecoverySetting` is the exception. There is no `ForgotPassword` here, so no recovery is ever
+started and no mechanism is ever chosen. The pool records the mechanisms it was asked for
 and `DescribeUserPool` reports them back, so what a template declared stays visible. The two app
 client properties are accepted at one value each instead.
 
@@ -2597,7 +2592,7 @@ console.log(described.UserPool?.EmailVerificationSubject);
 ```
 
 The accepted value of each app client property is below. A pool or a client created without one of
-these reports it not at all, rather than reporting the value it would have had to use.
+these reports it not at all, and never reports the value it would have had to use.
 
 | Property                          | Accepted value |
 | --------------------------------- | -------------- |
@@ -2648,10 +2643,10 @@ shape would exist here and fail to be created on real AWS. A list of mechanisms 
 of them, each naming a mechanism Cognito has at a priority of 1 or 2. The refusal says which of
 those it was.
 
-`VerificationMessageTemplate` is read rather than compared, and the one thing refused in it is
+`VerificationMessageTemplate` is read and never compared, and the one thing refused in it is
 `DefaultEmailOption: CONFIRM_WITH_LINK`, along with `EmailMessageByLink` and `EmailSubjectByLink`.
-Nothing here serves a link, and `ConfirmSignUp` with the code is the only way a user is confirmed, so
-a pool that asked for a link would be tested against a flow it does not have in a deployment.
+Nothing here serves a link, and `ConfirmSignUp` with the code is the only way a user is confirmed. A
+pool that asked for a link would be tested against a flow it lacks in a deployment.
 
 ## Serving a pool's JWKS on localhost
 
@@ -2660,13 +2655,13 @@ a pool that asked for a link would be tested against a flow it does not have in 
 - `GET /<userPoolId>/.well-known/jwks.json`
 - `GET /<userPoolId>/.well-known/openid-configuration`
 
-It also lists the messages a pool would have sent, at `GET /<userPoolId>/messages`, which real
-Cognito serves nothing at. That one is anonymous too, and it hands out confirmation codes and
+It also lists the messages a pool would have sent, at `GET /<userPoolId>/messages`, an endpoint
+real Cognito lacks. That one is anonymous too, and it hands out confirmation codes and
 temporary passwords to anyone who asks, so serve a simulation on a port other people can reach only
 if you mean to.
 
-The two real endpoints are anonymous as they are on real Cognito, so no SigV4 signature is needed to
-fetch them. The real hostname `cognito-idp.<region>.amazonaws.com` maps to
+The two real endpoints are anonymous as they are on real Cognito, and no SigV4 signature is needed
+to fetch them. The real hostname `cognito-idp.<region>.amazonaws.com` maps to
 `cognito-idp.<region>.sim-aws.localhost`, and `srv.localUrl(...)` does that rewriting for you. An
 unknown pool id gets a 404, as does a pool reached through another region's hostname.
 
@@ -2755,16 +2750,16 @@ try {
 ```
 
 `aws-jwt-verify` fetches over HTTPS only, and `CognitoJwtVerifier` builds its own JWKS URI from the
-pool id rather than taking one, so it cannot be pointed at the local URL. Fetching the document and
-calling `cacheJwks` with it is one way round that. The other is to hand the verifier a
+pool id rather than taking one, leaving it impossible to point at the local URL. Fetching the
+document and calling `cacheJwks` with it is one way round that. The other is to hand the verifier a
 `SimpleJwksCache` from `aws-jwt-verify/jwk` whose fetcher passes the URI through `srv.localUrl`,
 which leaves the verifier setup in the application untouched. A verifier that takes a `jwksUri` and
 accepts plain HTTP can be pointed at the local URL as it is.
 
-The OpenID configuration names the origin the request arrived on in `issuer` and `jwks_uri`, so a
+The OpenID configuration names the origin the request arrived on in `issuer` and `jwks_uri`. A
 client that discovers the document can go on to fetch the keys it points at. The tokens keep the
-real `https://cognito-idp.<region>.amazonaws.com/<userPoolId>` in `iss`, which is what a verifier
-built from a pool id checks against, so the two disagree here where they agree on real Cognito.
+real `https://cognito-idp.<region>.amazonaws.com/<userPoolId>` in `iss`, what a verifier built from
+a pool id checks against. The two disagree here where they agree on real Cognito.
 
 ## Intercepting the SDK client
 
@@ -2803,7 +2798,7 @@ simSdk.restoreAll();
 ```
 
 The same applies inside a simulated Lambda handler. A client the handler builds is intercepted and
-dispatched with the function's execution role as the caller, so the role's policy decides whether the
+dispatched with the function's execution role as the caller. The role's policy decides whether the
 call succeeds.
 
 ## Account and region scoping
@@ -2839,19 +2834,20 @@ console.log(pool.UserPool?.Arn);
 Lambda triggers and `AdminCreateUserConfig.AllowAdminCreateUserOnly`.
 
 It replaces those settings rather than merging into them, as real Cognito does. A setting the
-request leaves out goes back to the default `CreateUserPool` would have given it, so a request that
+request leaves out goes back to the default `CreateUserPool` would have given it. A request that
 names only the one setting it wants to change resets the others. Name every setting the pool should
 keep. That is the sharp edge on real Cognito too, and a request written that way behaves the same
 here and in a deployment.
 
-A pool's `LambdaConfig` is replaced the same way, so an update that says nothing about it stops the
+A pool's `LambdaConfig` is replaced the same way. An update that says nothing about it stops the
 pool running the triggers it was created with, as real Cognito would.
 
-The pool's name is not among the settings an update carries. Real `UpdateUserPool` renames a pool
-with `PoolName`, and a rename is not simulated, so a request carrying one is refused. Every other
-input `CreateUserPool` refuses is refused here too, in the same words, saying `UpdateUserPool`.
+The pool's name falls outside the settings an update carries. Real `UpdateUserPool` renames a pool
+with `PoolName`, and a rename is outside the simulation. A request carrying one is refused. Every
+other input `CreateUserPool` refuses is refused here too, in the same words, saying
+`UpdateUserPool`.
 
-`UpdateUserPool` answers with nothing but the response metadata, as the real operation does, so
+`UpdateUserPool` answers with the response metadata alone, as the real operation does, so
 `DescribeUserPool` is what reads the change back.
 
 ```typescript sim-cognito-update-user-pool
@@ -2904,8 +2900,8 @@ A pool reports the time of its last update as its `LastModifiedDate`, in `Descri
 
 ## Deletion protection
 
-A pool created through the API is unprotected unless the request asks for protection, which is the
-opposite of what the console does. A pool created with `DeletionProtection: "ACTIVE"` refuses
+A pool created through the API is unprotected unless the request asks for protection, the opposite
+of what the console does. A pool created with `DeletionProtection: "ACTIVE"` refuses
 `DeleteUserPool` with `InvalidParameterException`.
 
 Real Cognito wants an `UpdateUserPool` request deactivating the protection before the pool can go,
@@ -2919,7 +2915,7 @@ it was asked for. `SetUserPoolMfaConfig` sets which factors are behind that sett
 `GetUserPoolMfaConfig` reads both back, as they do on real Cognito. `SOFTWARE_TOKEN_MFA` and
 `SMS_MFA` are the factors a pool can offer. A code sent by email is refused, because no pool here
 has the `EmailConfiguration` real Cognito wants before it will send one, and so is the
-`SmsConfiguration` inside an `SmsMfaConfiguration`: no message is delivered here, so the IAM role
+`SmsConfiguration` inside an `SmsMfaConfiguration`. No message is delivered here, and the IAM role
 that would send one is never assumed.
 
 A pool configured `OPTIONAL` challenges the users that have registered a factor, and one configured
@@ -3032,24 +3028,24 @@ administrator names, and `AdminGetUser` and `GetUser` report the result as `User
 Each of those, and `GetUser`, is authorized by the user's own access token rather than by any IAM
 policy, and the token has to carry the `aws.cognito.signin.user.admin` scope. A sign-in through the
 API always carries it. A sign-in at the hosted domain carries it only where the app client asked for
-it among its `AllowedOAuthScopes`, so a browser sign-in granted `openid email` alone is refused with
+it among its `AllowedOAuthScopes`. A browser sign-in granted `openid email` alone is refused with
 `NotAuthorizedException`, as real Cognito refuses one. `GlobalSignOut` is held to the same rule.
 
-The `SecretCode` is a real RFC 6238 shared secret, so an authenticator app or any TOTP library given
+The `SecretCode` is a real RFC 6238 shared secret. An authenticator app or any TOTP library given
 it produces the codes `VerifySoftwareToken` accepts, and a code from another secret is refused with
 `EnableSoftwareTokenMFAException`. A test that would rather not compute one reads the code the
 user's app would be showing off the pool, through `SimCognitoUserPool.softwareTokenCode`, in the way
 it reads a sign-up confirmation code: real Cognito reports neither to anyone, and nothing here is
 holding the user's phone.
 
-Verifying a token registers it and enables nothing. `SetUserMFAPreference` is what turns a factor on,
-which is the step the Cognito documentation gives for activating one; whether real Cognito also
-activates a TOTP factor on verification alone was not checked against a live account. Enabling
-`SMS_MFA` for a user with no `phone_number` attribute is refused, because there would be nowhere to
-send the code, and so is enabling `SOFTWARE_TOKEN_MFA` for a user that has verified no token. A
-factor a request says nothing about is left as it was, so an application turning on an authenticator
-app does not have to restate what it wants for SMS. One factor at most is preferred, and preferring
-one means enabling it in the same request.
+Verifying a token registers it and leaves it disabled. `SetUserMFAPreference` is what turns a factor
+on, the step the Cognito documentation gives for activating one. Whether real Cognito also activates
+a TOTP factor on verification alone was not checked against a live account. Enabling `SMS_MFA` for a
+user with no `phone_number` attribute is refused, because there would be nowhere to send the code,
+and so is enabling `SOFTWARE_TOKEN_MFA` for a user that has verified no token. A factor a request
+says nothing about is left as it was, and an application turning on an authenticator app can leave
+what it wants for SMS unstated. One factor at most is preferred, and preferring one means enabling
+it in the same request.
 
 ```typescript sim-cognito-user-mfa
 /**
@@ -3154,7 +3150,7 @@ console.log(user.PreferredMfaSetting); // "SOFTWARE_TOKEN_MFA"
 ### Signing in with a second factor
 
 A sign-in by a user that has registered a factor is answered with `SMS_MFA` or `SOFTWARE_TOKEN_MFA`
-and a `Session` rather than with tokens, on `InitiateAuth` and `AdminInitiateAuth` alike, and after
+and a `Session` in place of tokens, on `InitiateAuth` and `AdminInitiateAuth` alike, and after
 a `NEW_PASSWORD_REQUIRED` response as well: one challenge follows the other. The code goes back
 through `RespondToAuthChallenge` or `AdminRespondToAuthChallenge` as `SMS_MFA_CODE` or
 `SOFTWARE_TOKEN_MFA_CODE`, and that request is what hands out the tokens.
@@ -3163,27 +3159,27 @@ An `SMS_MFA` challenge carries `CODE_DELIVERY_DELIVERY_MEDIUM` and a masked
 `CODE_DELIVERY_DESTINATION` in its `ChallengeParameters`, as real Cognito does, and the pool records
 the message it would have texted, on an occasion of `Authentication`. That is where a test reads the
 code from, the way it reads a sign-up confirmation code. A `SOFTWARE_TOKEN_MFA` challenge sends
-nothing anywhere: the code is whatever the user's authenticator app is showing, so a test computes
+nothing anywhere. The code is whatever the user's authenticator app is showing, and a test computes
 it from the `SecretCode` or reads it off the pool.
 
 The code goes to the user's `phone_number` whatever the pool's `AutoVerifiedAttributes` say, and to
-the phone number rather than the email address of a user that has both, because the phone is the
+the phone number, not the email address, of a user that has both, because the phone is the
 factor.
 
-A wrong code is refused with `CodeMismatchException` and leaves the challenge standing, so the user
-can be asked to type it again. Every session lasts three minutes, which is what real Cognito gives
+A wrong code is refused with `CodeMismatchException` and leaves the challenge standing. The user can
+be asked to type it again. Every session lasts three minutes, what real Cognito gives
 an app client that names no `AuthSessionValidity` of its own, and that input is refused here. A
 session that has run out, one already spent, and one issued for a different challenge are each
 refused with `NotAuthorizedException`.
 
-`PostAuthentication` runs where the tokens are issued, which is the response rather than the sign-in
-that was challenged. `PreTokenGeneration` runs there too, reporting
+`PostAuthentication` runs where the tokens are issued, the response rather than the sign-in that
+was challenged. `PreTokenGeneration` runs there too, reporting
 `TokenGeneration_Authentication`, including for a sign-in that answered the new password challenge
-before this one; which source real Cognito reports for that pair of challenges was not checked
+before this one. Which source real Cognito reports for that pair of challenges was not checked
 against a live account.
 
 A user with both factors enabled and neither preferred is refused: real Cognito answers that
-sign-in with `SELECT_MFA_TYPE`, which is a challenge of its own. `SetUserMFAPreference` naming one
+sign-in with `SELECT_MFA_TYPE`, a challenge of its own. `SetUserMFAPreference` naming one
 of them as `PreferredMfa` is what settles it.
 
 ```typescript sim-cognito-mfa-sign-in
@@ -3293,8 +3289,8 @@ Sim Cognito currently supports:
   `DeleteUserPoolClientCommand` and `ListUserPoolClientsCommand`
 - `AdminCreateUserCommand`, `AdminGetUserCommand`, `AdminDeleteUserCommand`,
   `AdminSetUserPasswordCommand`, `AdminUpdateUserAttributesCommand`, `AdminDisableUserCommand`,
-  `AdminEnableUserCommand` and `ListUsersCommand`, and `GetUserCommand`, which is the signed-in
-  user reading itself
+  `AdminEnableUserCommand` and `ListUsersCommand`, and `GetUserCommand`, the signed-in user reading
+  itself
 - `AssociateSoftwareTokenCommand`, `VerifySoftwareTokenCommand` and `SetUserMFAPreferenceCommand`,
   which register an authenticator app for the signed-in user, and
   `AdminSetUserMFAPreferenceCommand`, which sets a named user's factors
@@ -3302,15 +3298,15 @@ Sim Cognito currently supports:
   factor and answered through `RespondToAuthChallengeCommand` or
   `AdminRespondToAuthChallengeCommand`, with the texted code recorded as a message on the pool
 - `SignUpCommand`, `ConfirmSignUpCommand` and `ResendConfirmationCodeCommand`, authorized by no IAM
-  policy as they are on real Cognito, and `AdminConfirmSignUpCommand`, which is authorized like the
-  other admin operations
+  policy as they are on real Cognito, and `AdminConfirmSignUpCommand`, authorized like the other
+  admin operations
 - The `PreSignUp` and `PostConfirmation` Lambda triggers, with `autoConfirmUser`, `autoVerifyEmail`
   and `autoVerifyPhone` applied, and with the `ValidationData` and `ClientMetadata` a request
   carries reaching the handler
 - `AutoVerifiedAttributes`, so confirming a sign-up sets `email_verified` or
   `phone_number_verified`, and `AdminCreateUserConfig.AllowAdminCreateUserOnly`, which refuses
   `SignUp` against a pool created with it
-- A pool's `Schema`, so a `custom:` attribute is set and read on its users, held to the type, the
+- A pool's `Schema`, with a `custom:` attribute set and read on its users, held to the type, the
   bounds and the mutability it was declared with, and reported as `SchemaAttributes` alongside the
   standard attributes
 - A pool's `AccountRecoverySetting`, recorded as the request set it and reported back by
@@ -3336,10 +3332,10 @@ Sim Cognito currently supports:
 - The `CustomMessage` Lambda trigger, invoked before a message is recorded, with the occasion in its
   `triggerSource` and the wording it writes replacing the pool's
 - The recorded messages listed over HTTP by `serveSimAws`, at `/<userPoolId>/messages`
-- Real RS256 JWTs, signed by a key the pool publishes as a JWKS, so a verifier configured for the
-  pool verifies them unchanged
+- Real RS256 JWTs, signed by a key the pool publishes as a JWKS, verified unchanged by a verifier
+  configured for the pool
 - A pool's `.well-known/jwks.json` and `.well-known/openid-configuration` served over HTTP by
-  `serveSimAws`, anonymously, so a verifier fetches the keys rather than being handed them
+  `serveSimAws`, anonymously, letting a verifier fetch the keys instead of taking them by hand
 - `CreateUserPoolDomainCommand`, `DescribeUserPoolDomainCommand` and
   `DeleteUserPoolDomainCommand`, for a Cognito prefix domain and for a custom domain
 - `CreateIdentityProviderCommand`, `DescribeIdentityProviderCommand`,
@@ -3359,8 +3355,8 @@ Sim Cognito currently supports:
   CloudFormation template, with the `Ref` and `Fn::GetAtt` values real CloudFormation returns
 - Pool ids in the real `<region>_<nine characters>` form, and pool ARNs built from them
 - The real default password policy, applied to the passwords users are given
-- The real user status lifecycle, so an admin-created user stays in `FORCE_CHANGE_PASSWORD` until it
-  has a permanent password, and a signed-up user stays in `UNCONFIRMED` until it confirms
+- The real user status lifecycle, in which an admin-created user stays in `FORCE_CHANGE_PASSWORD`
+  until it has a permanent password, and a signed-up user stays in `UNCONFIRMED` until it confirms
 - Group membership, and the precedence order the `cognito:groups` claim uses
 - App client authentication flows, token lifetimes, generated client secrets and
   `PreventUserExistenceErrors`
@@ -3375,32 +3371,32 @@ Sim Cognito currently supports:
 Current documented limitations:
 
 - Four authentication flows run: `ADMIN_USER_PASSWORD_AUTH` and `REFRESH_TOKEN_AUTH` through
-  `AdminInitiateAuth`, and `USER_PASSWORD_AUTH` and `REFRESH_TOKEN_AUTH` through `InitiateAuth`. SRP,
-  `USER_AUTH` choice-based sign-in, custom authentication and device tracking are not simulated, and
-  an `AuthFlow` naming one of them is refused rather than run as a flow that is.
+  `AdminInitiateAuth`, and `USER_PASSWORD_AUTH` and `REFRESH_TOKEN_AUTH` through `InitiateAuth`.
+  SRP, `USER_AUTH` choice-based sign-in, custom authentication and device tracking are outside the
+  simulation, and an `AuthFlow` naming one of them is refused, never run as a flow that is.
 - `NEW_PASSWORD_REQUIRED`, `SMS_MFA` and `SOFTWARE_TOKEN_MFA` are the challenges issued, so
   `MFA_SETUP`, `SELECT_MFA_TYPE` and the custom authentication challenges cannot be reached. A
-  `ChallengeName` this simulation does not issue is refused rather than answered as one it does.
-- `GetTokensFromRefreshToken` and `RevokeToken` are not implemented, and `RefreshTokenRotation` is
+  `ChallengeName` this simulation never issues is refused, never answered as one it does.
+- `GetTokensFromRefreshToken` and `RevokeToken` are unimplemented, and `RefreshTokenRotation` is
   refused on an app client. Refreshing goes through `REFRESH_TOKEN_AUTH`, which issues no new
   refresh token.
 - Signing out revokes the user's tokens inside the simulation, and a token already handed to a
   verifier goes on verifying against the pool's JWKS until it expires. Verification happens in the
-  caller's own verifier, which asks this simulation nothing, so nothing here can tell it the token
-  was revoked. Real Cognito is the same for a verifier reading only the JWKS.
-- The `cognito:preferred_role` and `cognito:roles` claims are not on the tokens. A group's `RoleArn`
-  is stored and reported, and nothing assumes that role. A `PreTokenGeneration` handler naming
-  either claim is refused rather than half-applied.
+  caller's own verifier, which asks this simulation nothing and cannot be told the token was
+  revoked. Real Cognito is the same for a verifier reading only the JWKS.
+- The `cognito:preferred_role` and `cognito:roles` claims are absent from the tokens. A group's
+  `RoleArn` is stored and reported, and nothing assumes that role. A `PreTokenGeneration` handler
+  naming either claim is refused, never half-applied.
 - A pool publishes one signing key where real Cognito publishes two and rotates between them, so
   code assuming a single JWKS entry passes here and is still wrong against real AWS. The key is
   generated with `node:crypto` the first time the pool signs or publishes one, and kept in memory
   for the life of the simulation.
-- A password is kept so a user can sign in with it, and nothing reads one back.
+- A password is kept so a user can sign in with it, and no operation reads one back.
 - Users are resolved by username only. Real Cognito also accepts a user's `sub` where an admin
   operation asks for a username, and that fails here with `UserNotFoundException`.
 - A pool reports the confirmation code a signed-up user is waiting to answer with, through
   `confirmationCode` on the pool object. Real Cognito sends the code and never reports it to anyone.
-  Nothing here delivers a message, so this is what makes a registration flow testable, and it is a
+  Nothing here delivers a message, and this is what makes a registration flow testable. It is a
   deliberate divergence rather than an operation to write application code against.
 - A confirmation code never expires, where a real one lasts 24 hours. `ResendConfirmationCode` is
   what replaces one.
@@ -3410,91 +3406,91 @@ Current documented limitations:
   trigger sets them by asking for `autoVerifyEmail` or `autoVerifyPhone`.
 - `AutoVerifiedAttributes` is accepted at `email` and `phone_number`, and anything else is refused.
   Those are the two Cognito can send a code to.
-- `ConfirmSignUp` and `ResendConfirmationCode` report a user the pool does not hold whatever the app
+- `ConfirmSignUp` and `ResendConfirmationCode` report a user the pool lacks whatever the app
   client's `PreventUserExistenceErrors` says. That setting is honoured for sign-in only.
-- Password reset is not simulated. `ForgotPassword`, `ConfirmForgotPassword` and `ChangePassword`
-  are not implemented, so the `RESET_REQUIRED` status cannot be reached.
+- Password reset is outside the simulation. `ForgotPassword`, `ConfirmForgotPassword` and
+  `ChangePassword` are unimplemented, leaving the `RESET_REQUIRED` status unreachable.
 - Unsimulated sign-up inputs are refused rather than ignored: `AnalyticsMetadata` and
   `UserContextData` on the three client-side operations, and `ForceAliasCreation` and `Session` on
-  `ConfirmSignUp`. `ClientMetadata` is not among them on any of them: each reaches a trigger that
+  `ConfirmSignUp`. `ClientMetadata` is absent from that list, because each reaches a trigger that
   runs here.
 - No message is ever delivered. A pool records what it would have sent and `sentMessages` reads it
   back, which real Cognito reports to nobody. Nothing leaves the simulation, and no
   `CodeDeliveryDetails` is reported by `SignUp` or `ResendConfirmationCode`.
 - A message is recorded on three occasions: `SignUp`, `ResendConfirmationCode` and
   `AdminCreateUser`. Password reset, MFA and the account-taken-over notices are occasions real
-  Cognito sends on and this simulation does not reach.
-- A verification message is recorded only for an attribute the pool verifies automatically, so a
-  pool with no `AutoVerifiedAttributes` records none, and only for a user that has to confirm: one a
-  `PreSignUp` handler auto-confirmed is sent nothing, as it is sent nothing on real Cognito. An invitation is recorded whatever the pool
-  verifies, and both are recorded only where the user has an `email` or a `phone_number` to be
-  reached at.
+  Cognito sends on and this simulation never reaches.
+- A verification message is recorded only for an attribute the pool verifies automatically. A pool
+  with no `AutoVerifiedAttributes` records none, and only for a user that has to confirm: one a
+  `PreSignUp` handler auto-confirmed is sent nothing, as on real Cognito. An invitation is recorded
+  whatever the pool verifies, and both are recorded only where the user has an `email` or a
+  `phone_number` to be reached at.
 - `DesiredDeliveryMediums` is refused. The medium comes from the attribute the message is written
-  to, so a request naming `SMS` for a user with an email address would be recorded as an email.
-  Real Cognito defaults `AdminCreateUser` to `SMS`, and this records an email where the user has an
+  to. A request naming `SMS` for a user with an email address would be recorded as an email. Real
+  Cognito defaults `AdminCreateUser` to `SMS`, and this records an email where the user has an
   address.
 - An invitation for a user created with no `TemporaryPassword` keeps the `{####}` placeholder,
   because real Cognito generates a password there and this simulation leaves the user with none at
   all.
 - `EmailConfiguration` and `SmsConfiguration` stay refused. A pool configured to send through SES or
   an SNS SMS role would still only record here, and accepting the configuration would say the
-  messages went that way. The record is Cognito's own, which is what the default
-  `EmailSendingAccount` of `COGNITO_DEFAULT` sends by, and there is no simulated SES.
-- Confirming a sign-up by following a link is not simulated. A `VerificationMessageTemplate` with
-  `DefaultEmailOption: CONFIRM_WITH_LINK`, an `EmailMessageByLink` or an `EmailSubjectByLink` is
-  refused, and a `CustomMessage` event carries no `linkParameter`.
+  messages went that way. The record is Cognito's own, what the default `EmailSendingAccount` of
+  `COGNITO_DEFAULT` sends by, and there is no simulated SES.
+- Confirming a sign-up by following a link is outside the simulation. A
+  `VerificationMessageTemplate` with `DefaultEmailOption: CONFIRM_WITH_LINK`, an
+  `EmailMessageByLink` or an `EmailSubjectByLink` is refused, and a `CustomMessage` event carries no
+  `linkParameter`.
 - `VerificationMessageTemplate` wins over `EmailVerificationMessage`, `EmailVerificationSubject` and
   `SmsVerificationMessage` where a request sets both, and each of those fills in what the template
   left out. What real Cognito does when the two disagree was not checked against a live account.
 - Verification wording with no `{####}` in it is refused, as it is on real Cognito, because the
-  message would reach a user with no code in it. So is wording outside the lengths Cognito takes:
-  6 to 20,000 characters for an email, and 6 to 140 for a text message. The subject is not checked
+  message would reach a user with no code in it. So is wording outside the lengths Cognito takes: 6
+  to 20,000 characters for an email, and 6 to 140 for a text message. The subject goes unchecked
   against its own length.
 - The default wording, for a pool that set none, is taken from the Cognito API documentation rather
   than read back from a live account.
-- The recorded messages are listed over HTTP at `GET /<userPoolId>/messages`, which is an endpoint
-  real Cognito does not have. It is the serving side of `sentMessages` and a divergence for the same
-  reason.
+- The recorded messages are listed over HTTP at `GET /<userPoolId>/messages`, an endpoint real
+  Cognito lacks. It is the serving side of `sentMessages` and a divergence for the same reason.
 - The `CustomEmailSender` and `CustomSMSSender` triggers are refused. Real Cognito hands those the
-  code as an AWS Encryption SDK ciphertext to decrypt through KMS, that envelope is not simulated
-  anywhere here, and a version handing over a plain code would give a handler that cannot decrypt
-  anything on real AWS.
+  code as an AWS Encryption SDK ciphertext to decrypt through KMS, that envelope is outside the
+  simulation anywhere here, and a version handing over a plain code would give a handler that cannot
+  decrypt anything on real AWS.
 - A temporary password never expires. `TemporaryPasswordValidityDays` is stored on the pool and
-  nothing acts on it.
-- Unsimulated `AdminCreateUser` inputs are refused rather than ignored: `DesiredDeliveryMediums`,
+  acted on nowhere.
+- Unsimulated `AdminCreateUser` inputs are refused, never ignored: `DesiredDeliveryMediums`,
   `ForceAliasCreation`, and a `MessageAction` of `RESEND`, which invites a user that already exists.
   Its `ValidationData` and `ClientMetadata` are read, and reach the `PreSignUp` and `CustomMessage`
   triggers. `AdminUpdateUserAttributes` refuses `ClientMetadata`, because the message an attribute
-  update would have sent is not one this simulation sends.
-- `ListUsers` refuses `Filter` and `AttributesToGet` rather than ignoring them, and lists users in
-  creation order. Real Cognito chooses its own order and does not promise one.
+  update would have sent is one this simulation never sends.
+- `ListUsers` refuses `Filter` and `AttributesToGet` outright, and lists users in creation order.
+  Real Cognito chooses its own order and promises none.
 - `ListUsers`, `ListGroups`, `AdminListGroupsForUser` and `ListUsersInGroup` refuse a `Limit` of
   zero, which the real operations accept without saying what they return. Refusing it is better than
   guessing between an empty page and a full one.
-- Real Cognito does not document the order `AdminListGroupsForUser` returns groups in. Here it is by
-  precedence, because that is the order the `cognito:groups` claim uses, and it is what a test
+- Real Cognito leaves the order `AdminListGroupsForUser` returns groups in undocumented. Here it is
+  by precedence, because that is the order the `cognito:groups` claim uses, and it is what a test
   reading the first group is usually after.
-- `UpdateGroup` replaces all three group properties rather than merging, so an omitted one is
-  cleared. Real Cognito does not say which it does.
-- A group's `RoleArn` is stored and reported, and nothing assumes that role. It reaches the
-  `cognito:roles` and `cognito:preferred_role` claims, which are not simulated yet, and identity
-  pools, which are not simulated at all.
-- Group to IAM role mapping is an identity pool feature and is not simulated.
+- `UpdateGroup` replaces all three group properties rather than merging, and an omitted one is
+  cleared. Real Cognito says which it does nowhere.
+- A group's `RoleArn` is stored and reported, and no code assumes that role. It reaches the
+  `cognito:roles` and `cognito:preferred_role` claims, which are outside the simulation yet, and
+  identity pools, which are outside the simulation at all.
+- Group to IAM role mapping is an identity pool feature and is outside the simulation.
 - A pool holds the standard user attributes and the ones its `Schema` declared, and an attribute no
   schema declares is refused, as is a request setting `sub`. A `DeveloperOnlyAttribute` is refused,
   because a `dev:` attribute needs the developer credentials that read and write it.
-  `AdminDeleteUserAttributes` is not implemented, so an attribute can be changed but not removed.
-  An app client's `ReadAttributes` and `WriteAttributes` are refused, so every client of a pool sees
+  `AdminDeleteUserAttributes` is unimplemented, so an attribute can be changed and never removed. An
+  app client's `ReadAttributes` and `WriteAttributes` are refused, so every client of a pool sees
   and sets every attribute the pool holds.
 - `EstimatedNumberOfUsers` is how many users the pool holds now. Real Cognito refreshes that number
-  periodically rather than on each write, so it can lag there in a way it never does here.
+  periodically rather than on each write, and it can lag there in a way it never does here.
 - A sign-in by a user of an `ON` pool that has registered no factor is refused, because real Cognito
-  answers that one with the `MFA_SETUP` challenge, which registers a factor mid-sign-in and is not
-  simulated. A user with both factors enabled and neither preferred is refused for the same kind of
-  reason: real Cognito answers that with `SELECT_MFA_TYPE`.
+  answers that one with the `MFA_SETUP` challenge, which registers a factor mid-sign-in and is
+  outside the simulation. A user with both factors enabled and neither preferred is refused for the
+  same kind of reason: real Cognito answers that with `SELECT_MFA_TYPE`.
 - An MFA code is texted to the user's `phone_number` whatever the pool's `AutoVerifiedAttributes`
-  say, and the pool records it as a message with an occasion of `Authentication`, which is where a
-  test reads it from. Real Cognito delivers it and reports it to nobody.
+  say, and the pool records it as a message with an occasion of `Authentication`, where a test reads
+  it from. Real Cognito delivers it and reports it to nobody.
 - A `SOFTWARE_TOKEN_MFA` challenge carries no `FRIENDLY_DEVICE_NAME` in its `ChallengeParameters`,
   because no device is remembered here.
 - A user's software token secret is a real RFC 6238 shared secret, and the pool reports the code the
@@ -3505,102 +3501,101 @@ Current documented limitations:
   turns a factor on. Whether real Cognito also activates a TOTP factor on verification alone was not
   checked against a live account.
 - A `SetUserMFAPreference` request leaves a factor it says nothing about as it was. Real Cognito
-  does not document whether it replaces or merges there, and a request naming both factors behaves
-  the same either way.
+  documents neither replacing nor merging there, and a request naming both factors behaves the same
+  either way.
 - `AdminGetUser` reports no `MFAOptions`. That field is the deprecated way of reporting an SMS
   factor, and `UserMFASettingList` and `PreferredMfaSetting` are what report one here.
 - `SetUserPoolMfaConfig` accepts `SoftwareTokenMfaConfiguration` and `SmsMfaConfiguration`. The
   `SmsConfiguration` inside the latter is refused, in the same words `CreateUserPool` refuses the
-  pool's own: no message is delivered here, so the IAM role Cognito would assume to send one is
+  pool's own. No message is delivered here, and the IAM role Cognito would assume to send one is
   never assumed. `EmailMfaConfiguration` is refused because a pool here has no `EmailConfiguration`
   to send that message with, and `WebAuthnConfiguration` because a passkey is presented through the
-  `USER_AUTH` flow, which is refused as a flow of its own.
+  `USER_AUTH` flow, itself refused as a flow of its own.
 - `AssociateSoftwareToken` and `VerifySoftwareToken` take an `AccessToken` and refuse a `Session`,
-  because the `MFA_SETUP` challenge that would issue one is not simulated. A `FriendlyDeviceName` is
-  refused for the same kind of reason: device tracking is not simulated.
-- `UpdateUserPool` replaces a pool's settings rather than merging into them, as real Cognito does, so
-  a setting the request leaves out goes back to the default `CreateUserPool` would have given it. It
+  because the `MFA_SETUP` challenge that would issue one is outside the simulation. A
+  `FriendlyDeviceName` is refused for the same kind of reason: device tracking is outside the
+  simulation.
+- `UpdateUserPool` replaces a pool's settings rather than merging into them, as real Cognito does. A
+  setting the request leaves out goes back to the default `CreateUserPool` would have given it. It
   covers the settings this simulation models: `Policies.PasswordPolicy`, `DeletionProtection`,
   `AdminCreateUserConfig.AllowAdminCreateUserOnly`, `AutoVerifiedAttributes`, `LambdaConfig`,
-  `MfaConfiguration` and the verification wording. An update carries no factor configuration, so the
-  factors a `SetUserPoolMfaConfig` request set are left alone, as real Cognito leaves them.
-  `PoolName` is refused, so a pool cannot be renamed, a `Schema` is refused because real
+  `MfaConfiguration` and the verification wording. An update carries no factor configuration, and
+  the factors a `SetUserPoolMfaConfig` request set are left alone, as real Cognito leaves them.
+  `PoolName` is refused, leaving a pool unrenameable, a `Schema` is refused because real
   `UpdateUserPool` has no such input, and every input `CreateUserPool` refuses is refused here too,
   in the same words.
-- `UpdateUserPoolClient` replaces an app client's settings the same way, so a setting the request
+- `UpdateUserPoolClient` replaces an app client's settings the same way. A setting the request
   leaves out goes back to the default `CreateUserPoolClient` would have given it. `ClientName` is
-  the exception: a client has to have a name and there is no default to reset to, so an update that
+  the exception: a client has to have a name and there is no default to reset to, and an update that
   names none keeps the one the client has.
 - An update leaves the client's secret alone. `UpdateUserPoolClient` has no `GenerateSecret` input
-  on real Cognito, so a client created without a secret never gains one.
+  on real Cognito, and a client created without a secret never gains one.
 - A redeployed template reaches neither update. Sim CloudFormation replaces a resource whose
   resolved template entry changed rather than updating it in place, whatever the resource type.
 - `PreSignUp`, `PostConfirmation`, `PreAuthentication`, `PostAuthentication`, `PreTokenGeneration`
   and `CustomMessage` are the only Lambda triggers that run. Every other `LambdaConfig` key is
   refused when the pool is created or updated, naming the trigger, because a pool that accepted one
   would never call the function the template named. The custom challenge triggers would need a
-  challenge loop this simulation does not have, and the migration and federation triggers have no
-  external directory to reach: a simulated identity provider answers with the user `signInAs` put
-  there rather than with anything a trigger could change.
-- `AdminCreateUser` does not fire `PostConfirmation`, here or on real Cognito. It is the tempting
-  place to hang the trigger and the wrong one: a project relying on it would pass here and write
-  nothing in production.
-- `PostConfirmation_ConfirmForgotPassword` is not reached, because password reset is not simulated.
-  `PostConfirmation_ConfirmSignUp` is the only source the trigger reports.
+  challenge loop this simulation lacks, and the migration and federation triggers have no external
+  directory to reach: a simulated identity provider answers with the user `signInAs` put there,
+  beyond the reach of a trigger.
+- `AdminCreateUser` leaves `PostConfirmation` unfired, here and on real Cognito. It is the tempting
+  place to hang the trigger and the wrong one. A project relying on it would pass here and write no
+  record in production.
+- `PostConfirmation_ConfirmForgotPassword` goes unreached, because password reset is outside the
+  simulation. `PostConfirmation_ConfirmSignUp` is the only source the trigger reports.
 - A `PreSignUp` handler asking to verify an attribute the sign-up did not carry refuses the sign-up
   with `InvalidParameterException`. Real Cognito refuses it too, and what it names the error has not
   been checked against a live account.
-- `PreSignUp_ExternalProvider` is not reached either. A federated sign-in creates the pool's user
+- `PreSignUp_ExternalProvider` goes unreached too. A federated sign-in creates the pool's user
   directly rather than through the sign-up path a trigger hangs off.
 - A `PostConfirmation` or `PostAuthentication` handler that throws fails the request, and what it
-  ran after is not undone: a confirmed user stays confirmed and the tokens a pool issued stay
-  issued, as they do on real Cognito.
+  ran after stands. A confirmed user stays confirmed and the tokens a pool issued stay issued, as
+  they do on real Cognito.
 - Neither sign-in trigger fires for `REFRESH_TOKEN_AUTH`, as neither does on real Cognito.
   `PreTokenGeneration` does fire there, because the pool is issuing tokens.
-- `PreTokenGenerationConfig` is refused, so the trigger runs at `V1_0` and nothing else. The `V2_0`
-  and `V3_0` events customise access token claims and carry `scopesToAdd` and `scopesToSuppress`,
-  none of which is simulated. The one change a `V1_0` event makes to an access token, replacing its
+- `PreTokenGenerationConfig` is refused, and the trigger runs at `V1_0` alone. The `V2_0` and `V3_0`
+  events customise access token claims and carry `scopesToAdd` and `scopesToSuppress`, none of which
+  is simulated. The one change a `V1_0` event makes to an access token, replacing its
   `cognito:groups`, is applied.
 - A `V1_0` claim value is a string, and a handler returning anything else is refused. The complex
   claim values arrived with the `V2_0` event.
 - `claimsToAddOrOverride` and `claimsToSuppress` reach the id token alone, because a `V1_0` event
   customises that token. `cognito:groups` on an access token is changed through
-  `groupOverrideDetails`, which is what real Cognito calls the only change a `V1_0` event makes to
-  an access token. `claimsToSuppress` naming a `cognito:` claim other than `cognito:groups` is
-  refused, since real Cognito suppresses none of the others.
-- A `PreTokenGeneration` response naming a claim real Cognito reserves is refused rather than
-  ignored, which is what real Cognito does with one. That is a deliberate divergence: a claim that
-  silently does not arrive in production is the failure a test with a trigger in it is there to
-  catch.
+  `groupOverrideDetails`, what real Cognito calls the only change a `V1_0` event makes to an access
+  token. `claimsToSuppress` naming a `cognito:` claim other than `cognito:groups` is refused, since
+  real Cognito suppresses none of the others.
+- A `PreTokenGeneration` response naming a claim real Cognito reserves is refused, where real
+  Cognito ignores one. That is a deliberate divergence. A claim that silently goes missing in
+  production is the failure a test with a trigger in it is there to catch.
 - `groupOverrideDetails.iamRolesToOverride` and `preferredRole` are refused, and the request's
   `groupConfiguration` carries neither, because the `cognito:roles` and `cognito:preferred_role`
-  claims they feed are not issued here. A handler copying the request's `groupConfiguration` back
-  into its response, which is how real Cognito says to leave the groups alone, works unchanged.
+  claims they feed go unissued here. A handler copying the request's `groupConfiguration` back into
+  its response, the way real Cognito says to leave the groups alone, works unchanged.
 - `ClientMetadata` reaches `PreTokenGeneration` from `RespondToAuthChallenge` and
   `AdminRespondToAuthChallenge` alone, as it does on real Cognito. A refresh accepts one and it
   reaches nothing.
 - A `CustomMessage` event reports `CLIENT_ID_NOT_APPLICABLE` as its `callerContext.clientId` for an
   `AdminCreateUser`, as real Cognito does for an admin operation, and names the app client for the
   two occasions that come through one.
-- Unsimulated `CreateUserPool` inputs are refused rather than ignored: `AliasAttributes`,
-  `UsernameConfiguration`,
-  `UserAttributeUpdateSettings`, `DeviceConfiguration`, `UserPoolAddOns`, `KeyConfiguration`,
-  `IssuerConfiguration`, `UserPoolTags`, the email and SMS configurations, an
+- Unsimulated `CreateUserPool` inputs are refused, never ignored: `AliasAttributes`,
+  `UsernameConfiguration`, `UserAttributeUpdateSettings`, `DeviceConfiguration`, `UserPoolAddOns`,
+  `KeyConfiguration`, `IssuerConfiguration`, `UserPoolTags`, the email and SMS configurations, an
   `SmsAuthenticationMessage`, a `UserPoolTier` other than `ESSENTIALS`, a `SignInPolicy`, and a
   `PasswordHistorySize`.
-- `AccountRecoverySetting` is recorded and reported back by `DescribeUserPool`, and nothing reads
+- `AccountRecoverySetting` is recorded and reported back by `DescribeUserPool`, and no code reads
   it, because there is no `ForgotPassword`. Any mechanisms Cognito has are accepted, in any order,
   and a setting outside the shape Cognito states is refused. A pool that recovers by email alone
   therefore behaves here exactly as one that recovers by phone number would, which only shows in a
   recovery neither of them can start.
 - `AdminCreateUserConfig.AllowAdminCreateUserOnly` is acted on, and the two keys beside it are
   refused. `InviteMessageTemplate` is the wording of the invitation, and a pool cannot set its own
-  yet, so an invitation is recorded at Cognito's default wording. `UnusedAccountValidityDays`
-  expires a temporary password, and nothing here expires one.
-- `UsernameAttributes` is simulated, and `AliasAttributes` is not. The two differ in what the
-  username is: a `UsernameAttributes` pool generates one, which is what this stores, and an
+  yet, leaving an invitation recorded at Cognito's default wording. `UnusedAccountValidityDays`
+  expires a temporary password, and no code here expires one.
+- `UsernameAttributes` is simulated, and `AliasAttributes` is outside it. The two differ in what the
+  username is. A `UsernameAttributes` pool generates one, and that is what this stores. An
   `AliasAttributes` pool keeps the username the request chose and takes the attribute as a second
-  way of naming the user, which is not modelled.
+  way of naming the user, and that is unmodelled.
 - A `UsernameAttributes` pool resolves the address for its admin operations and its sign-ins, and
   refuses a second user holding an address another user already signs in by.
 - Unsimulated `CreateUserPoolClient` inputs are refused the same way: a `ClientSecret` of your own,
@@ -3615,14 +3610,15 @@ Current documented limitations:
 - Unsimulated authentication inputs are refused the same way: `AnalyticsMetadata` on all four
   operations, `ContextData` on the admin ones, `UserContextData` on the client ones, and a `Session`
   on `InitiateAuth` or `AdminInitiateAuth`, which continues a flow neither of them starts.
-- A pool's schema is settled when the pool is created. `AddCustomAttributes` is not implemented, and
+- A pool's schema is settled when the pool is created. `AddCustomAttributes` is unimplemented, and
   an `UpdateUserPool` request carrying a `Schema` is refused, because real `UpdateUserPool` has no
   such input.
-- Managed login and the classic hosted UI are pages a person fills in, and are not simulated. An
-  authorize request naming no `identity_provider`, or naming `COGNITO`, would reach one of those
-  pages on real Cognito and is refused here with a message saying so. The pool's own users sign in
-  through `InitiateAuth` and `AdminInitiateAuth`, which are simulated. `/login`, `/signup`,
-  `/oauth2/userInfo`, `/oauth2/revoke`, `/oauth2/idpresponse` and the SAML endpoints are not served.
+- Managed login and the classic hosted UI are pages a person fills in, and are outside the
+  simulation. An authorize request naming no `identity_provider`, or naming `COGNITO`, would reach
+  one of those pages on real Cognito and is refused here with a message saying so. The pool's own
+  users sign in through `InitiateAuth` and `AdminInitiateAuth`, which are simulated. `/login`,
+  `/signup`, `/oauth2/userInfo`, `/oauth2/revoke`, `/oauth2/idpresponse` and the SAML endpoints go
+  unserved.
 - The implicit grant is refused, and so is the client credentials grant, which needs resource
   servers.
 - The served OpenID configuration names its `authorization_endpoint`, `token_endpoint` and
@@ -3633,41 +3629,41 @@ Current documented limitations:
   `signInAs` put there. That accessor is a divergence for the same reason `confirmationCode` is one.
 - A custom domain answers on its own hostname with no Route53 record of its own, where real AWS
   needs an alias record to the CloudFront distribution Cognito creates. The distribution name a
-  domain reports is a name nothing here serves.
+  domain reports is a name unserved here.
 - `/logout` redirects and ends no session. There is no managed login session cookie here, because
-  every authorize request signs in afresh at the identity provider, so there is nothing for it to
-  end. It signs nobody out at the provider either, which real Cognito also does not do.
-- A pool does not create a group for each identity provider, where real Cognito creates one named
+  every authorize request signs in afresh at the identity provider, leaving it nothing to end. It
+  signs nobody out at the provider either, which real Cognito also leaves undone.
+- A pool creates no group for each identity provider, where real Cognito creates one named
   `<userPoolId>_<ProviderName>` and puts each federated user in it. A `cognito:groups` claim here
   therefore names only the groups something added the user to.
 - A federated sign-in is refused with `UsernameExistsException` where the username it would take is
   already a user of the pool's own. A username may hold an underscore, so `Google_1234` can be a
   local user, and signing in as it would hand the application someone else's account.
-- `AdminLinkProviderForUser` is not implemented, so a federated user is never linked to a user that
+- `AdminLinkProviderForUser` is unimplemented, and a federated user is never linked to a user that
   was already in the pool, and the `identities` it carries always names one provider.
 - The `PreAuthentication`, `PostAuthentication` and migrate user triggers do not fire on a federated
   sign-in.
 - A domain reports no `S3Bucket` or `Version`, both of which name parts of the machinery real
   Cognito builds a domain out of. Its `Status` is `ACTIVE` as soon as it exists, where a real prefix
   domain takes a minute and a custom domain up to an hour.
-- A custom domain's `CertificateArn` is required and recorded, and is not resolved against simulated
+- A custom domain's `CertificateArn` is required and recorded, and goes unresolved against simulated
   ACM. Nothing here terminates TLS.
-- A `SupportedIdentityProviders` naming a provider the pool does not have is accepted, and the
-  authorize request naming that provider is what refuses. Real Cognito checks the provider exists
-  when the app client is written.
-- The served `issuer` and `jwks_uri` name the localhost origin the request arrived on, so a client
-  can fetch the keys they point at. A token's `iss` claim still names the real
-  `https://cognito-idp.<region>.amazonaws.com/<userPoolId>`, so the two disagree here and agree on
-  real Cognito.
-- Resource servers and risk configuration are not simulated.
-- Tags are not simulated. `UserPoolTags` is refused, and `TagResource`, `UntagResource` and
-  `ListTagsForResource` are not implemented.
+- A `SupportedIdentityProviders` naming a provider the pool lacks is accepted, and the authorize
+  request naming that provider is what refuses. Real Cognito checks the provider exists when the app
+  client is written.
+- The served `issuer` and `jwks_uri` name the localhost origin the request arrived on, letting a
+  client fetch the keys they point at. A token's `iss` claim still names the real
+  `https://cognito-idp.<region>.amazonaws.com/<userPoolId>`. The two disagree here and agree on real
+  Cognito.
+- Resource servers and risk configuration are outside the simulation.
+- Tags are outside the simulation. `UserPoolTags` is refused, and `TagResource`, `UntagResource` and
+  `ListTagsForResource` are unimplemented.
 - Listings carry no filtering, and are in creation order rather than any order real Cognito chooses.
 - Of the CloudFormation resource types, `AWS::Cognito::UserPool`, `AWS::Cognito::UserPoolClient`,
   `AWS::Cognito::UserPoolGroup`, `AWS::Cognito::UserPoolDomain` and
   `AWS::Cognito::UserPoolIdentityProvider` deploy. The others, including
   `AWS::Cognito::UserPoolResourceServer`, `AWS::Cognito::UserPoolUser` and everything under
-  `AWS::Cognito::IdentityPool`, are reported as unsupported and skipped rather than deployed.
+  `AWS::Cognito::IdentityPool`, are reported as unsupported and skipped, never deployed.
 - The Cognito API itself is not served as HTTP by `serveSimAws`, only the two public pool endpoints.
   A `CognitoIdentityProviderClient` reaches the simulator through `SimSdk` rather than through an
   endpoint override.


### PR DESCRIPTION
Rewrites the prose in the API Gateway v2, CloudFormation, CloudWatch and Cognito READMEs. Every code
example is byte-identical. All four failed the prose checker on the five measured sentence shapes, and
three carried banned semicolons. All four now score below the warn threshold on every pattern.

Worth a look from a reviewer:

- A few edits restate a fact rather than only reshaping a sentence. A held authorizer decision is now
  described as re-evaluated per route only on a cache miss, in-place CloudFormation update is "still
  to be built", and `AdminDeleteUserAttributes` leaves an attribute changeable "and never removed".
- CloudWatch's "What is not, and how it says so" heading is now "What is refused, and how it says
  so". The section only covers refusals, and nothing links to the old anchor.
- The `- **Label.**` list convention is untouched. It runs to 62 uses across six doc files with no
  colon-form instances, so it is house style.

The template change is a separate commit: the "one paragraph of prose" rule was producing walls of
text, so it now asks only for a brief, concise description.

- [x] Conventional commit message, used as the title

- [x] Conventional branch name, like `feat/concise-description`
- [x] Full check with `pnpm run check` passed
- [x] Rebased off latest main
- [x] User-facing behaviour is documented in `docs/`
